### PR TITLE
Fix typo in README.md

### DIFF
--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -69,7 +69,7 @@ Wait a few seconds and verify that the device has become a Thread Router:
 
 ```bash
 $ state
-leader
+router
 Done
 ```
 


### PR DESCRIPTION
The returned 'state' value for Node 2 should be 'router' instead of 'leader'.