### PR TITLE
travis: Update travis to do a `make distcheck` instead of just `make check`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ before_install:
 
 script:
   - ./bootstrap-configure --enable-minimum-set-of-tests
-  - make check
+  - make distcheck

--- a/Makefile.am
+++ b/Makefile.am
@@ -30,6 +30,8 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 AM_MAKEFLAGS                        = --no-print-directory
 
+AM_DISTCHECK_CONFIGURE_FLAGS        = --enable-minimum-set-of-tests
+
 SUBDIRS                             = \
     include                           \
     src                               \
@@ -90,6 +92,14 @@ OPENTHREAD_VERSION                ?= $(shell cat $(VERSION_FILE) 2> /dev/null)
 
 PACKAGE_VERSION                    = $(OPENTHREAD_VERSION)
 VERSION                            = $(PACKAGE_VERSION)
+
+distdir = $(PACKAGE)-$(shell                                     \
+if [ "$(origin OPENTHREAD_VERSION)" != "file" ]; then            \
+    echo "$(OPENTHREAD_VERSION)" ;                               \
+else                                                             \
+    $(abs_top_nlbuild_autotools_dir)/scripts/mkversion           \
+        -b "$(OPENTHREAD_VERSION)" "$(top_srcdir)";              \
+fi )
 
 #
 # check-file-.local-version

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1116,7 +1116,7 @@ HTML_FILE_EXTENSION    = .html
 # of the possible markers and block names see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_HEADER            = header.html
+HTML_HEADER            = @abs_srcdir@/header.html
 
 # The HTML_FOOTER tag can be used to specify a user-defined HTML footer for each
 # generated HTML page. If the tag is left blank doxygen will generate a standard

--- a/examples/cli/Makefile.am
+++ b/examples/cli/Makefile.am
@@ -39,12 +39,12 @@ soc_CPPFLAGS                                                   = \
     $(OPENTHREAD_TARGET_DEFINES)                                 \
     $(NULL)
 
-soc_LDADD                                                      = \
-    $(top_srcdir)/src/core/libopenthread.a                       \
-    $(top_srcdir)/src/cli/libopenthread-cli.a                    \
-    $(top_srcdir)/examples/platform/posix/libopenthread-posix.a  \
-    $(top_srcdir)/third_party/mbedtls/libmbedcrypto.a            \
-    -lpthread                                                    \
+soc_LDADD                                                      =  \
+    $(top_builddir)/src/core/libopenthread.a                      \
+    $(top_builddir)/src/cli/libopenthread-cli.a                   \
+    $(top_builddir)/examples/platform/posix/libopenthread-posix.a \
+    $(top_builddir)/third_party/mbedtls/libmbedcrypto.a           \
+    -lpthread                                                     \
     $(NULL)
 
 soc_SOURCES                                                    = \

--- a/tests/scripts/Makefile.am
+++ b/tests/scripts/Makefile.am
@@ -192,7 +192,7 @@ endif # OPENTHREAD_WITH_ESSENTIAL_TESTS_ONLY
 
 TESTS_ENVIRONMENT                                                  = \
     export                                                           \
-    top_srcdir='$(top_srcdir)'                                       \
+    top_builddir='$(top_builddir)'                                   \
     VERBOSE=1;                                                       \
     $(NULL)
 

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -52,8 +52,8 @@ class Node:
 
     def __init_sim(self, nodeid):
         """ Initialize a simulation node. """
-        if "top_srcdir" in os.environ.keys():
-            srcdir = os.environ['top_srcdir']
+        if "top_builddir" in os.environ.keys():
+            srcdir = os.environ['top_builddir']
             cmd = '%s/examples/cli/soc' % srcdir
         else:
             cmd = './soc'

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -53,11 +53,11 @@ AM_CPPFLAGS                                                    = \
     -I$(top_srcdir)/third_party/mbedtls/repo/include             \
     $(NULL)
 
-COMMON_LDADD                                                   = \
-    $(top_srcdir)/src/core/libopenthread.a                       \
-    $(top_srcdir)/examples/platform/posix/libopenthread-posix.a  \
-    $(top_srcdir)/third_party/mbedtls/libmbedcrypto.a            \
-    -lpthread                                                    \
+COMMON_LDADD                                                   =  \
+    $(top_builddir)/src/core/libopenthread.a                      \
+    $(top_builddir)/examples/platform/posix/libopenthread-posix.a \
+    $(top_builddir)/third_party/mbedtls/libmbedcrypto.a           \
+    -lpthread                                                     \
     $(NULL)
 
 # Test applications that should be run when the 'check' target is run.


### PR DESCRIPTION
Doing a `make distcheck` instead of just a `make check` ensures that the build system is sane.

I fully expect this commit to break travis, so expect a few more commits to come in on top of this commit correcting any issues that crop up.

This issue is related to #40.