### PR TITLE
Add code style formatting (pretty) and checker (pretty-check) targets.

### DIFF
--- a/.astyle-opts
+++ b/.astyle-opts
@@ -1,0 +1,16 @@
+--style="allman"
+--max-code-length=120
+--max-instatement-indent=100
+--attach-namespaces --attach-inlines
+--attach-extern-c
+--min-conditional-indent=0
+--break-blocks
+--pad-oper
+--pad-header
+--unpad-paren
+--align-pointer=name
+--add-brackets
+--keep-one-line-blocks
+--convert-tabs
+--break-after-logical
+--formatted

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,16 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install python-pexpect; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo easy_install pexpect; fi
 
+install:
+  - pushd ~
+  - wget https://sourceforge.net/projects/astyle/files/astyle/astyle%202.05.1/astyle_2.05.1_linux.tar.gz/download -O astyle.tar.gz
+  - tar -xzvf astyle.tar.gz
+  - pushd astyle/build/gcc && LDFLAGS=" " make
+  - export PATH=$PWD/bin:$PATH
+  - popd
+  - popd
+
 script:
   - ./bootstrap-configure --enable-minimum-set-of-tests
+  - make pretty-check
   - make distcheck

--- a/Makefile.am
+++ b/Makefile.am
@@ -42,6 +42,7 @@ SUBDIRS                             = \
     $(NULL)
 
 EXTRA_DIST                          = \
+    .astyle-opts                      \
     .default-version                  \
     bootstrap                         \
     bootstrap-configure               \
@@ -57,6 +58,13 @@ dist_doc_DATA                       = \
 
 DISTCLEANFILES                      = \
     .local-version                    \
+    $(NULL)
+
+PRETTY_SUBDIRS                      = \
+    examples                          \
+    include                           \
+    src                               \
+    tests                             \
     $(NULL)
 
 #

--- a/configure.ac
+++ b/configure.ac
@@ -265,6 +265,14 @@ NL_ENABLE_OPTIMIZATION([yes])
 AM_CONDITIONAL([OPENTHREAD_BUILD_OPTIMIZED], [test "${nl_cv_build_optimized}" = "yes"])
 
 #
+# Code style
+#
+
+AC_CHECK_TOOL(ASTYLE, astyle)
+AC_SUBST(ASTYLE_PRETTY_ARGS, ["--options=\${abs_top_builddir}/.astyle-opts"])
+AC_SUBST(ASTYLE_PRETTY_CHECK_ARGS, ["--options=\${abs_top_builddir}/.astyle-opts --dry-run"])
+
+#
 # Tests
 #
 AC_MSG_NOTICE([checking whether to build tests])
@@ -484,6 +492,9 @@ AC_MSG_NOTICE([
   C++ Compile flags                         : ${CXXFLAGS:--}
   Link flags                                : ${LDFLAGS:--}
   Link libraries                            : ${LIBS}
+  Astyle                                    : ${ASTYLE}
+  Astyle pretty args                        : ${ASTYLE_PRETTY_ARGS}
+  Astyle pretty check args                  : ${ASTYLE_PRETTY_CHECK_ARGS}
 
 ])
 

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -42,6 +42,11 @@ SUBDIRS                                 = \
     cli                                   \
     $(NULL)
 
-all:
+# Always pretty (e.g. for 'make pretty') these subdirectories.
+
+PRETTY_SUBDIRS                          = \
+    platform                              \
+    cli                                   \
+    $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platform/Makefile.am
+++ b/examples/platform/Makefile.am
@@ -40,4 +40,10 @@ SUBDIRS                                 = \
     posix                                 \
     $(NULL)
 
+# Always pretty (e.g. for 'make pretty') these subdirectories.
+
+PRETTY_SUBDIRS                          = \
+    posix                                 \
+    $(NULL)
+
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -42,6 +42,13 @@ SUBDIRS                                 = \
     platform                              \
     $(NULL)
 
+# Always pretty (e.g. for 'make pretty') these subdirectories.
+
+PRETTY_SUBDIRS                          = \
+    crypto                                \
+    platform                              \
+    $(NULL)
+
 include_HEADERS                         = \
     openthread.h                          \
     openthread-types.h                    \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -42,4 +42,11 @@ SUBDIRS                                 = \
     core                                  \
     $(NULL)
 
+# Always pretty (e.g. for 'make pretty') these subdirectories.
+
+PRETTY_SUBDIRS                          = \
+    cli                                   \
+    core                                  \
+    $(NULL)
+
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -42,6 +42,12 @@ SUBDIRS                                 = \
     unit                                  \
     $(NULL)
 
+# Always pretty (e.g. for 'make pretty') these subdirectories.
+
+PRETTY_SUBDIRS                          = \
+    unit                                  \
+    $(NULL)
+
 if OPENTHREAD_BUILD_TESTS
 if OPENTHREAD_BUILD_COVERAGE
 CLEANFILES                             = $(wildcard *.gcda *.gcno)

--- a/third_party/nlbuild-autotools/repo/automake/post/rules.am
+++ b/third_party/nlbuild-autotools/repo/automake/post/rules.am
@@ -21,4 +21,5 @@
 #
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post/rules/coverage.am
+include $(abs_top_nlbuild_autotools_dir)/automake/post/rules/pretty.am
 include $(abs_top_nlbuild_autotools_dir)/automake/post/rules/headers.am

--- a/third_party/nlbuild-autotools/repo/automake/post/rules/pretty.am
+++ b/third_party/nlbuild-autotools/repo/automake/post/rules/pretty.am
@@ -1,0 +1,55 @@
+#
+#    Copyright 2015-2016 Nest Labs Inc. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file is the automake footer for code style checking and
+#      reformatting related targets and rules.
+#
+
+pretty: pretty-recursive
+
+#
+# 'pretty' target calls astyle on each file in SOURCES and HEADERS.
+# This iteratively calls astyle on each file.  astyle seems to retain
+# state from processing a previous file, which sometimes causes
+# formatting of a subsequent file to fail.
+#
+pretty:
+ifneq ($(SOURCES) $(HEADERS),)
+	$(AM_V_at) for file in $(SOURCES) $(HEADERS); do $(ASTYLE) $(ASTYLE_PRETTY_ARGS) $$file; done
+endif
+
+pretty-check: pretty-recursive
+
+#
+# 'pretty-check' target calls astyle on each file in SOURCES and HEADERS.
+# This iteratively calls astyle on each file.  astyle seems to retain
+# state from processing a previous file, which sometimes causes
+# formatting of a subsequent file to fail.
+#
+pretty-check:
+ifneq ($(SOURCES) $(HEADERS),)
+	$(AM_V_at)for file in $(SOURCES) $(HEADERS); do \
+		if [[ -n `$(ASTYLE) $(ASTYLE_PRETTY_CHECK_ARGS) $$file` ]]; then \
+			echo "Code style error.  Run 'make pretty' to reformat."; \
+			exit 1; \
+		fi \
+	done
+endif
+
+pretty-recursive:
+	$(call nl-make-subdirs-with-dirs,$(PRETTY_SUBDIRS))


### PR DESCRIPTION
* Add 'pretty' target to reformat sources to be compliant with code style.
* Add 'pretty-check' target to check if sources are compliant with code style.
* Update travis-ci script to use 'pretty-check' and enforce code style.
* The 'pretty' and 'pretty-check' targets rely on the 'astyle' tool.