### PR TITLE
mac: Allow MAC scans while the rest of the Thread stack is disabled (#42)

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -80,7 +80,7 @@ Mac::Mac(ThreadNetif &aThreadNetif):
 {
     sMac = this;
 
-    mState = kStateDisabled;
+    mState = kStateIdle;
 
     mRxOnWhenIdle = true;
     mCsmaAttempts = 0;
@@ -109,78 +109,21 @@ Mac::Mac(ThreadNetif &aThreadNetif):
 
     SetExtendedPanId(sExtendedPanidInit);
     SetNetworkName(sNetworkNameInit);
+    SetPanId(kPanIdBroadcast);
+    SetExtAddress(mExtAddress);
+    SetShortAddress(kShortAddrInvalid);
 
     mBeaconSequence = otPlatRandomGet();
     mDataSequence = otPlatRandomGet();
-}
 
-ThreadError Mac::Start(void)
-{
-    ThreadError error = kThreadError_None;
-
-    VerifyOrExit(mState == kStateDisabled, ;);
-
-    SuccessOrExit(error = otPlatRadioEnable());
-
-    SetExtendedPanId(mBeacon.GetExtendedPanId());
-    otPlatRadioSetPanId(mPanId);
-    otPlatRadioSetShortAddress(mShortAddress);
-    {
-        uint8_t buf[8];
-
-        for (size_t i = 0; i < sizeof(buf); i++)
-        {
-            buf[i] = mExtAddress.m8[7 - i];
-        }
-
-        otPlatRadioSetExtendedAddress(buf);
-    }
-    mState = kStateIdle;
-    NextOperation();
-
-exit:
-    return error;
-}
-
-ThreadError Mac::Stop(void)
-{
-    ThreadError error = kThreadError_None;
-
-    SuccessOrExit(error = otPlatRadioDisable());
-    mAckTimer.Stop();
-    mBackoffTimer.Stop();
-    mState = kStateDisabled;
-
-    while (mSendHead != NULL)
-    {
-        Sender *cur;
-        cur = mSendHead;
-        mSendHead = mSendHead->mNext;
-        cur->mNext = NULL;
-    }
-
-    mSendTail = NULL;
-
-    while (mReceiveHead != NULL)
-    {
-        Receiver *cur;
-        cur = mReceiveHead;
-        mReceiveHead = mReceiveHead->mNext;
-        cur->mNext = NULL;
-    }
-
-    mReceiveTail = NULL;
-
-exit:
-    return error;
+    otPlatRadioEnable();
 }
 
 ThreadError Mac::ActiveScan(uint16_t aScanChannels, uint16_t aScanDuration, ActiveScanHandler aHandler, void *aContext)
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(mState != kStateDisabled && mState != kStateActiveScan && mActiveScanRequest == false,
-                 error = kThreadError_Busy);
+    VerifyOrExit(mState != kStateActiveScan && mActiveScanRequest == false, error = kThreadError_Busy);
 
     mActiveScanHandler = aHandler;
     mActiveScanContext = aContext;
@@ -248,6 +191,19 @@ const ExtAddress *Mac::GetExtAddress(void) const
     return &mExtAddress;
 }
 
+ThreadError Mac::SetExtAddress(const ExtAddress &aExtAddress)
+{
+    uint8_t buf[8];
+
+    for (size_t i = 0; i < sizeof(buf); i++)
+    {
+        buf[i] = mExtAddress.m8[7 - i];
+    }
+
+    mExtAddress = aExtAddress;
+    return otPlatRadioSetExtendedAddress(buf);
+}
+
 ShortAddress Mac::GetShortAddress(void) const
 {
     return mShortAddress;
@@ -307,9 +263,7 @@ ThreadError Mac::SendFrameRequest(Sender &aSender)
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(mState != kStateDisabled &&
-                 mSendTail != &aSender && aSender.mNext == NULL,
-                 error = kThreadError_Busy);
+    VerifyOrExit(mSendTail != &aSender && aSender.mNext == NULL, error = kThreadError_Busy);
 
     if (mSendHead == NULL)
     {
@@ -336,9 +290,6 @@ void Mac::NextOperation(void)
 {
     switch (mState)
     {
-    case kStateDisabled:
-        break;
-
     case kStateActiveScan:
         mReceiveFrame.SetChannel(mScanChannel);
         otPlatRadioReceive(&mReceiveFrame);
@@ -880,7 +831,11 @@ void Mac::ReceiveDoneTask(void)
     switch (mState)
     {
     case kStateActiveScan:
-        mActiveScanHandler(mActiveScanContext, &mReceiveFrame);
+        if (mReceiveFrame.GetType() == Frame::kFcfFrameBeacon)
+        {
+            mActiveScanHandler(mActiveScanContext, &mReceiveFrame);
+        }
+
         break;
 
     default:

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -188,24 +188,6 @@ public:
     explicit Mac(ThreadNetif &aThreadNetif);
 
     /**
-     * This method starts the MAC.
-     *
-     * @retval kThreadError_None  Successfully started the MAC.
-     * @retval kThreadError_Busy  The MAC could not be started.
-     *
-     */
-    ThreadError Start(void);
-
-    /**
-     * This method stops the MAC.
-     *
-     * @retval kThreadError_None  Successfully stopped the MAC.
-     * @retval kThreadError_Busy  The MAC could not be stopped.
-     *
-     */
-    ThreadError Stop(void);
-
-    /**
      * This function pointer is called on receiving an IEEE 802.15.4 Beacon during an Active Scan.
      *
      * @param[in]  aContext       A pointer to arbitrary context information.
@@ -270,6 +252,16 @@ public:
      *
      */
     const ExtAddress *GetExtAddress(void) const;
+
+    /**
+     * This method sets the IEEE 802.15.4 Extended Address
+     *
+     * @param[in]  aExtAddress  A reference to the IEEE 802.15.4 Extended Address.
+     *
+     * @retval kThreadError_None  Successfully set the IEEE 802.15.4 Extended Address.
+     *
+     */
+    ThreadError SetExtAddress(const ExtAddress &aExtAddress);
 
     /**
      * This method returns the IEEE 802.15.4 Short Address.
@@ -437,8 +429,7 @@ private:
 
     enum
     {
-        kStateDisabled = 0,
-        kStateIdle,
+        kStateIdle = 0,
         kStateActiveScan,
         kStateTransmitBeacon,
         kStateTransmitData,

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -66,6 +66,8 @@ MeshForwarder::MeshForwarder(ThreadNetif &aThreadNetif):
     mSendMessage = NULL;
     mSendBusy = false;
     mEnabled = false;
+
+    mMac.RegisterReceiver(mMacReceiver);
 }
 
 ThreadError MeshForwarder::Start()
@@ -73,10 +75,7 @@ ThreadError MeshForwarder::Start()
     ThreadError error = kThreadError_None;
 
     VerifyOrExit(mEnabled == false, error = kThreadError_Busy);
-
-    mMac.RegisterReceiver(mMacReceiver);
-    SuccessOrExit(error = mMac.Start());
-
+    mMac.SetRxOnWhenIdle(true);
     mEnabled = true;
 
 exit:
@@ -106,8 +105,7 @@ ThreadError MeshForwarder::Stop()
     }
 
     mEnabled = false;
-
-    SuccessOrExit(error = mMac.Stop());
+    mMac.SetRxOnWhenIdle(false);
 
 exit:
     return error;


### PR DESCRIPTION
This is a pull request for issue #42.

This change removes the enable/disable methods from the MAC interface and allows MAC actions to occur at any time, automatically disabling the radio when no other actions are required.