### PR TITLE
ncp: Give InterfaceType and VendorID their own properties.

### DIFF
--- a/src/ncp/PROTOCOL.md
+++ b/src/ncp/PROTOCOL.md
@@ -331,21 +331,31 @@ several properties that are required in all implementations.
 
 * 0: `PROP_LAST_STATUS`
 * 1: `PROP_PROTOCOL_VERSION`
-* 2: `PROP_CAPS`
-* 3: `PROP_NCP_VERSION`
-* 4: `PROP_INTERFACE_COUNT`
-* 5: `PROP_POWER_STATE`
-* 6: `PROP_HWADDR`
-* 7: `PROP_LOCK`
-* 8: `PROP_HBO_MEM_MAX` (See section C.2.1.)
-* 9: `PROP_HBO_BLOCK_MAX` (See section C.2.2.)
+* 2: `PROP_NCP_VERSION`
+* 3: `PROP_INTERFACE_TYPE`
+* 4: `PROP_VENDOR_ID`
+* 5: `PROP_CAPS`
+* 6: `PROP_INTERFACE_COUNT`
+* 7: `PROP_POWER_STATE`
+* 8: `PROP_HWADDR`
+* 9: `PROP_LOCK`
+* 10: `PROP_HBO_MEM_MAX` (See section C.2.1.)
+* 11: `PROP_HBO_BLOCK_MAX` (See section C.2.2.)
 * 112: `PROP_STREAM_DEBUG`
 * 113: `PROP_STREAM_RAW`
 * 114: `PROP_STREAM_NET`
 * 115: `PROP_STREAM_NET_INSECURE`
 
+Additionally, future property allocations SHALL be made from the
+following allocation plan:
 
-
+Property ID Range     | Description
+----------------------|------------------
+0 - 127               | Reserved for frequently-used core properties
+128 - 15,359          | *UNALLOCATED*
+15,360 - 16,383       | Vendor-specific
+16,384 - 1,999,999    | *UNALLOCATED*
+2,000,000 - 2,097,151 | Experimental use only
 
 ### 5.1. PROP 0: `PROP_LAST_STATUS`
 
@@ -370,21 +380,66 @@ See section 6 for the complete list of status codes.
 ### 5.2. PROP 1: `PROP_PROTOCOL_VERSION`
 
 * Type: Read-Only
-* Encoding: `iiii`
+* Encoding: `ii`
 
-Octets: |       1-3      |      1-3      |      1-3      |        1-3
---------|----------------|---------------|---------------|-------------------
-Fields: | INTERFACE_TYPE | MAJOR_VERSION | MINOR_VERSION | VENDOR_IDENTIFIER
+Octets: |       1-3      |      1-3
+--------|----------------|---------------
+Fields: |  MAJOR_VERSION | MINOR_VERSION
 
 Describes the protocol version information. This property contains
 four fields, each encoded as a packed unsigned integer:
 
- *  Interface Type
  *  Major Version Number
  *  Minor Version Number
- *  Vendor Identifier
 
-#### 5.2.1 Interface Type ####
+
+#### 5.2.1 Major Version Number ####
+
+The major version number is used to identify large and incompatible
+differences between protocol versions.
+
+The host MUST enter a FAULT state if it does not explicitly support
+the given major version number.
+
+#### 5.2.2 Minor Version Number ####
+
+The minor version number is used to identify small but otherwise
+compatible differences between protocol versions. A mismatch between
+the advertised minor version number and the minor version that is
+supported by the host SHOULD NOT be fatal to the operation of the
+host.
+
+### 5.3. PROP 2: `PROP_NCP_VERSION`
+
+* Type: Read-Only
+* Packed-Encoding: `U`
+
+Octets: |       *n*
+--------|-------------------
+Fields: | `NCP_VESION_STRING`
+
+Contains a string which describes the firmware currently running on
+the NCP. Encoded as a zero-terminated UTF-8 string.
+
+The format of the string is not strictly defined, but it is intended
+to present similarly to the "User-Agent" string from HTTP. The
+RECOMMENDED format of the string is as follows:
+
+    <STACK-NAME>/<STACK-VERSION>[<BUILD_INFO>][; <OTHER_INFO>]; <BUILD_DATE_AND_TIME>
+
+Examples:
+
+ *  `OpenThread/1.0d26-25-gb684c7f; DEBUG; May 9 2016 18:22:04`
+ *  `ConnectIP/2.0b125 s1 ALPHA; Sept 24 2015 20:49:19`
+
+### 5.4. PROP 3: `PROP_INTERFACE_TYPE`
+
+* Type: Read-Only
+* Encoding: `i`
+
+Octets: |       1-3
+--------|----------------
+Fields: | INTERFACE_TYPE
 
 This integer identifies what the network protocol for this NCP.
 Currently defined values are:
@@ -397,26 +452,18 @@ Currently defined values are:
 The host MUST enter a FAULT state if it does not recognize the
 protocol given by the NCP.
 
-#### 5.2.2 Major Version Number ####
+### 5.5. PROP 4: `PROP_INTERFACE_VENDOR_ID`
 
-The major version number is used to identify large and incompatible
-differences between protocol versions.
+* Type: Read-Only
+* Encoding: `i`
 
-The host MUST enter a FAULT state if it does not explicitly support
-the given major version number.
+Octets: |       1-3
+--------|----------------
+Fields: | VENDOR_ID
 
-#### 5.2.3 Minor Version Number ####
+Vendor identifier.
 
-The minor version number is used to identify small but otherwise
-compatible differences between protocol versions. A mismatch between
-the advertised minor version number and the minor version that is
-supported by the host SHOULD NOT be fatal to the operation of the
-host.
-
-#### 5.2.3 Vendor Identifier ####
-
-
-### 5.3. PROP 2: `PROP_CAPS`
+### 5.6. PROP 2: `PROP_CAPS`
 
 * Type: Read-Only
 * Packed-Encoding: `A(i)`
@@ -458,35 +505,13 @@ following allocation plan:
 Capability Range      | Description
 ----------------------|------------------
 0 - 127               | Reserved for core capabilities
-64 - 15,359           | *UNALLOCATED*
+128 - 15,359          | *UNALLOCATED*
 15,360 - 16,383       | Vendor-specific
 16,384 - 1,999,999    | *UNALLOCATED*
 2,000,000 - 2,097,151 | Experimental use only
 
-### 5.4. PROP 3: `PROP_NCP_VERSION`
 
-* Type: Read-Only
-* Packed-Encoding: `U`
-
-Octets: |       *n*
---------|-------------------
-Fields: | `NCP_VESION_STRING`
-
-Contains a string which describes the firmware currently running on
-the NCP. Encoded as a zero-terminated UTF-8 string.
-
-The format of the string is not strictly defined, but it is intended
-to present similarly to the "User-Agent" string from HTTP. The
-RECOMMENDED format of the string is as follows:
-
-    <STACK-NAME>/<STACK-VERSION>[<BUILD_INFO>][; <OTHER_INFO>]; <BUILD_DATE_AND_TIME>
-
-Examples:
-
- *  `OpenThread/1.0d26-25-gb684c7f; DEBUG; May 9 2016 18:22:04`
- *  `ConnectIP/2.0b125 s1 ALPHA; Sept 24 2015 20:49:19`
-
-### 5.5. PROP 4: `PROP_INTERFACE_COUNT`
+### 5.7. PROP 4: `PROP_INTERFACE_COUNT`
 
 * Type: Read-Only
 * Packed-Encoding: `C`
@@ -501,7 +526,7 @@ always be one.
 
 This value is encoded as an unsigned 8-bit integer.
 
-### 5.6. PROP 5: `PROP_POWER_STATE`
+### 5.8. PROP 5: `PROP_POWER_STATE`
 
 * Type: Read-Write
 * Packed-Encoding: `C`
@@ -528,7 +553,7 @@ Defined values are:
  *  4: `POWER_STATE_ONLINE`: NCP is fully powered. (e.g. "Parent"
     node)
 
-### 5.7. PROP 6: `PROP_HWADDR`
+### 5.9. PROP 6: `PROP_HWADDR`
 
 * Type: Read-Only*
 * Packed-Encoding: `E`
@@ -540,7 +565,7 @@ Fields: | PROP_HWADDR
 The static EUI64 address of the device. This value is read-only, but
 may be writable under certain vendor-defined circumstances.
 
-### 5.8. PROP 6: `PROP_LOCK`
+### 5.10. PROP 6: `PROP_LOCK`
 
 * Type: Read-Write
 * Packed-Encoding: `b`
@@ -556,7 +581,7 @@ NCP is effectively frozen until it is cleared.
 
 This property is only supported if the `CAP_LOCK` capability is present.
 
-### 5.9. PROP 112: `PROP_STREAM_DEBUG`
+### 5.11. PROP 112: `PROP_STREAM_DEBUG`
 
 * Type: Read-Only-Stream
 * Packed-Encoding: `U`
@@ -572,7 +597,7 @@ output which may be displayed in the host logs.
 To receive the debugging stream, you wait for `CMD_PROP_VALUE_IS` commands for
 this property from the NCP.
 
-### 5.10. PROP 113: `PROP_STREAM_RAW`
+### 5.12. PROP 113: `PROP_STREAM_RAW`
 
 * Type: Read-Write-Stream
 * Packed-Encoding: `DD`
@@ -596,7 +621,7 @@ on this property with the value of the raw packet.
 Any data past the end of `FRAME_DATA_LEN` is considered metadata. The format
 of the metadata is defined by the associated MAC and PHY being used.
 
-### 5.11. PROP 114: `PROP_STREAM_NET`
+### 5.13. PROP 114: `PROP_STREAM_NET`
 
 * Type: Read-Write-Stream
 * Packed-Encoding: `DD`
@@ -619,7 +644,7 @@ the value of the packet.
 Any data past the end of `FRAME_DATA_LEN` is considered metadata. The format
 of the metadata is defined by the associated network protocol.
 
-### 5.12. PROP 114: `PROP_STREAM_NET_INSECURE`
+### 5.14. PROP 114: `PROP_STREAM_NET_INSECURE`
 
 * Type: Read-Write-Stream
 * Packed-Encoding: `DD`

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -60,6 +60,8 @@ const NcpBase::GetPropertyHandlerEntry NcpBase::mGetPropertyHandlerTable[] =
 {
     { SPINEL_PROP_LAST_STATUS, &NcpBase::GetPropertyHandler_LAST_STATUS },
     { SPINEL_PROP_PROTOCOL_VERSION, &NcpBase::GetPropertyHandler_PROTOCOL_VERSION },
+    { SPINEL_PROP_INTERFACE_TYPE, &NcpBase::GetPropertyHandler_INTERFACE_TYPE },
+    { SPINEL_PROP_VENDOR_ID, &NcpBase::GetPropertyHandler_VENDOR_ID },
     { SPINEL_PROP_CAPS, &NcpBase::GetPropertyHandler_CAPS },
     { SPINEL_PROP_NCP_VERSION, &NcpBase::GetPropertyHandler_NCP_VERSION },
     { SPINEL_PROP_INTERFACE_COUNT, &NcpBase::GetPropertyHandler_INTERFACE_COUNT },
@@ -840,13 +842,30 @@ void NcpBase::GetPropertyHandler_PROTOCOL_VERSION(uint8_t header, spinel_prop_ke
         header,
         SPINEL_CMD_PROP_VALUE_IS,
         key,
-        SPINEL_DATATYPE_UINT_PACKED_S
-            SPINEL_DATATYPE_UINT_PACKED_S
-            SPINEL_DATATYPE_UINT_PACKED_S
-            SPINEL_DATATYPE_UINT_PACKED_S,
-        SPINEL_PROTOCOL_TYPE_THREAD,
+        SPINEL_DATATYPE_UINT_PACKED_S SPINEL_DATATYPE_UINT_PACKED_S,
         SPINEL_PROTOCOL_VERSION_THREAD_MAJOR,
-        SPINEL_PROTOCOL_VERSION_THREAD_MINOR,
+        SPINEL_PROTOCOL_VERSION_THREAD_MINOR
+    );
+}
+
+void NcpBase::GetPropertyHandler_INTERFACE_TYPE(uint8_t header, spinel_prop_key_t key)
+{
+    SendPropteryUpdate(
+        header,
+        SPINEL_CMD_PROP_VALUE_IS,
+        key,
+        SPINEL_DATATYPE_UINT_PACKED_S,
+        SPINEL_PROTOCOL_TYPE_THREAD
+    );
+}
+
+void NcpBase::GetPropertyHandler_VENDOR_ID(uint8_t header, spinel_prop_key_t key)
+{
+    SendPropteryUpdate(
+        header,
+        SPINEL_CMD_PROP_VALUE_IS,
+        key,
+        SPINEL_DATATYPE_UINT_PACKED_S,
         0 // Vendor ID. Zero for unknown.
     );
 }

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -174,6 +174,8 @@ private:
 
     void GetPropertyHandler_LAST_STATUS(uint8_t header, spinel_prop_key_t key);
     void GetPropertyHandler_PROTOCOL_VERSION(uint8_t header, spinel_prop_key_t key);
+    void GetPropertyHandler_INTERFACE_TYPE(uint8_t header, spinel_prop_key_t key);
+    void GetPropertyHandler_VENDOR_ID(uint8_t header, spinel_prop_key_t key);
     void GetPropertyHandler_CAPS(uint8_t header, spinel_prop_key_t key);
     void GetPropertyHandler_NCP_VERSION(uint8_t header, spinel_prop_key_t key);
     void GetPropertyHandler_INTERFACE_COUNT(uint8_t header, spinel_prop_key_t key);

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -798,6 +798,14 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_PROTOCOL_VERSION";
         break;
 
+    case SPINEL_PROP_INTERFACE_TYPE:
+        ret = "PROP_INTERFACE_TYPE";
+        break;
+
+    case SPINEL_PROP_VENDOR_ID:
+        ret = "PROP_VENDOR_ID";
+        break;
+
     case SPINEL_PROP_CAPS:
         ret = "PROP_CAPS";
         break;

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -60,7 +60,7 @@ __BEGIN_DECLS
 
 // ----------------------------------------------------------------------------
 
-#define SPINEL_PROTOCOL_VERSION_THREAD_MAJOR    0
+#define SPINEL_PROTOCOL_VERSION_THREAD_MAJOR    4
 #define SPINEL_PROTOCOL_VERSION_THREAD_MINOR    0
 
 #define SPINEL_FRAME_MAX_SIZE                   1300
@@ -243,80 +243,82 @@ enum
 
 typedef enum
 {
-    SPINEL_PROP_LAST_STATUS             = 0,        // status [i]
-    SPINEL_PROP_PROTOCOL_VERSION        = 1,        // interface type, major, minor, vendor [i,i,i,i]
-    SPINEL_PROP_CAPS                    = 2,        // capability list [A(i)]
-    SPINEL_PROP_NCP_VERSION             = 3,        // version string [U]
-    SPINEL_PROP_INTERFACE_COUNT         = 4,        // Interface count [C]
-    SPINEL_PROP_POWER_STATE             = 5,        // PowerState [C]
-    SPINEL_PROP_HWADDR                  = 6,        // PermEUI64 [E]
-    SPINEL_PROP_LOCK                    = 7,        // PropLock [b]
-    SPINEL_PROP_HBO_MEM_MAX             = 8,        // Max offload mem [S]
-    SPINEL_PROP_HBO_BLOCK_MAX           = 9,        // Max offload block [S]
+    SPINEL_PROP_LAST_STATUS             = 0,        ///< status [i]
+    SPINEL_PROP_PROTOCOL_VERSION        = 1,        ///< major, minor [i,i]
+    SPINEL_PROP_NCP_VERSION             = 2,        ///< version string [U]
+    SPINEL_PROP_INTERFACE_TYPE          = 3,        ///< [i]
+    SPINEL_PROP_VENDOR_ID               = 4,        ///< [i]
+    SPINEL_PROP_CAPS                    = 5,        ///< capability list [A(i)]
+    SPINEL_PROP_INTERFACE_COUNT         = 6,        ///< Interface count [C]
+    SPINEL_PROP_POWER_STATE             = 7,        ///< PowerState [C]
+    SPINEL_PROP_HWADDR                  = 8,        ///< PermEUI64 [E]
+    SPINEL_PROP_LOCK                    = 9,        ///< PropLock [b]
+    SPINEL_PROP_HBO_MEM_MAX             = 10,       ///< Max offload mem [S]
+    SPINEL_PROP_HBO_BLOCK_MAX           = 11,       ///< Max offload block [S]
 
     SPINEL_PROP_PHY__BEGIN              = 0x20,
-    SPINEL_PROP_PHY_ENABLED             = SPINEL_PROP_PHY__BEGIN + 0, // [b]
-    SPINEL_PROP_PHY_CHAN                = SPINEL_PROP_PHY__BEGIN + 1, // [C]
-    SPINEL_PROP_PHY_CHAN_SUPPORTED      = SPINEL_PROP_PHY__BEGIN + 2, // [A(C)]
-    SPINEL_PROP_PHY_FREQ                = SPINEL_PROP_PHY__BEGIN + 3, // kHz [L]
-    SPINEL_PROP_PHY_CCA_THRESHOLD       = SPINEL_PROP_PHY__BEGIN + 4, // dBm [c]
-    SPINEL_PROP_PHY_TX_POWER            = SPINEL_PROP_PHY__BEGIN + 5, // [c]
-    SPINEL_PROP_PHY_RSSI                = SPINEL_PROP_PHY__BEGIN + 6, // dBm [c]
-    SPINEL_PROP_PHY_RAW_STREAM_ENABLED  = SPINEL_PROP_PHY__BEGIN + 7, // [C]
-    SPINEL_PROP_PHY_PROMISCUOUS_MODE    = SPINEL_PROP_PHY__BEGIN + 8, // [C]
+    SPINEL_PROP_PHY_ENABLED             = SPINEL_PROP_PHY__BEGIN + 0, ///< [b]
+    SPINEL_PROP_PHY_CHAN                = SPINEL_PROP_PHY__BEGIN + 1, ///< [C]
+    SPINEL_PROP_PHY_CHAN_SUPPORTED      = SPINEL_PROP_PHY__BEGIN + 2, ///< [A(C)]
+    SPINEL_PROP_PHY_FREQ                = SPINEL_PROP_PHY__BEGIN + 3, ///< kHz [L]
+    SPINEL_PROP_PHY_CCA_THRESHOLD       = SPINEL_PROP_PHY__BEGIN + 4, ///< dBm [c]
+    SPINEL_PROP_PHY_TX_POWER            = SPINEL_PROP_PHY__BEGIN + 5, ///< [c]
+    SPINEL_PROP_PHY_RSSI                = SPINEL_PROP_PHY__BEGIN + 6, ///< dBm [c]
+    SPINEL_PROP_PHY_RAW_STREAM_ENABLED  = SPINEL_PROP_PHY__BEGIN + 7, ///< [C]
+    SPINEL_PROP_PHY_PROMISCUOUS_MODE    = SPINEL_PROP_PHY__BEGIN + 8, ///< [C]
     SPINEL_PROP_PHY__END                = 0x30,
 
     SPINEL_PROP_MAC__BEGIN           = 0x30,
-    SPINEL_PROP_MAC_SCAN_STATE       = SPINEL_PROP_MAC__BEGIN + 0, // [C]
-    SPINEL_PROP_MAC_SCAN_MASK        = SPINEL_PROP_MAC__BEGIN + 1, // [A(C)]
-    SPINEL_PROP_MAC_SCAN_PERIOD      = SPINEL_PROP_MAC__BEGIN + 2, // ms-per-channel [S]
-    SPINEL_PROP_MAC_SCAN_BEACON      = SPINEL_PROP_MAC__BEGIN + 3, // chan,rssi,(laddr,saddr,panid,lqi),(proto,xtra) [CcT(ESSC)T(i).]
-    SPINEL_PROP_MAC_15_4_LADDR       = SPINEL_PROP_MAC__BEGIN + 4, // [E]
-    SPINEL_PROP_MAC_15_4_SADDR       = SPINEL_PROP_MAC__BEGIN + 5, // [S]
-    SPINEL_PROP_MAC_15_4_PANID       = SPINEL_PROP_MAC__BEGIN + 6, // [S]
+    SPINEL_PROP_MAC_SCAN_STATE       = SPINEL_PROP_MAC__BEGIN + 0, ///< [C]
+    SPINEL_PROP_MAC_SCAN_MASK        = SPINEL_PROP_MAC__BEGIN + 1, ///< [A(C)]
+    SPINEL_PROP_MAC_SCAN_PERIOD      = SPINEL_PROP_MAC__BEGIN + 2, ///< ms-per-channel [S]
+    SPINEL_PROP_MAC_SCAN_BEACON      = SPINEL_PROP_MAC__BEGIN + 3, ///< chan,rssi,(laddr,saddr,panid,lqi),(proto,xtra) [CcT(ESSC)T(i).]
+    SPINEL_PROP_MAC_15_4_LADDR       = SPINEL_PROP_MAC__BEGIN + 4, ///< [E]
+    SPINEL_PROP_MAC_15_4_SADDR       = SPINEL_PROP_MAC__BEGIN + 5, ///< [S]
+    SPINEL_PROP_MAC_15_4_PANID       = SPINEL_PROP_MAC__BEGIN + 6, ///< [S]
     SPINEL_PROP_MAC__END             = 0x40,
 
     SPINEL_PROP_NET__BEGIN           = 0x40,
-    SPINEL_PROP_NET_SAVED            = SPINEL_PROP_NET__BEGIN + 0, // [b]
-    SPINEL_PROP_NET_ENABLED          = SPINEL_PROP_NET__BEGIN + 1, // [b]
-    SPINEL_PROP_NET_STATE            = SPINEL_PROP_NET__BEGIN + 2, // [C]
-    SPINEL_PROP_NET_ROLE             = SPINEL_PROP_NET__BEGIN + 3, // [C]
-    SPINEL_PROP_NET_NETWORK_NAME     = SPINEL_PROP_NET__BEGIN + 4, // [U]
-    SPINEL_PROP_NET_XPANID           = SPINEL_PROP_NET__BEGIN + 5, // [D]
-    SPINEL_PROP_NET_MASTER_KEY       = SPINEL_PROP_NET__BEGIN + 6, // [D]
-    SPINEL_PROP_NET_KEY_SEQUENCE     = SPINEL_PROP_NET__BEGIN + 7, // [L]
-    SPINEL_PROP_NET_PARTITION_ID     = SPINEL_PROP_NET__BEGIN + 8, // [L]
+    SPINEL_PROP_NET_SAVED            = SPINEL_PROP_NET__BEGIN + 0, ///< [b]
+    SPINEL_PROP_NET_ENABLED          = SPINEL_PROP_NET__BEGIN + 1, ///< [b]
+    SPINEL_PROP_NET_STATE            = SPINEL_PROP_NET__BEGIN + 2, ///< [C]
+    SPINEL_PROP_NET_ROLE             = SPINEL_PROP_NET__BEGIN + 3, ///< [C]
+    SPINEL_PROP_NET_NETWORK_NAME     = SPINEL_PROP_NET__BEGIN + 4, ///< [U]
+    SPINEL_PROP_NET_XPANID           = SPINEL_PROP_NET__BEGIN + 5, ///< [D]
+    SPINEL_PROP_NET_MASTER_KEY       = SPINEL_PROP_NET__BEGIN + 6, ///< [D]
+    SPINEL_PROP_NET_KEY_SEQUENCE     = SPINEL_PROP_NET__BEGIN + 7, ///< [L]
+    SPINEL_PROP_NET_PARTITION_ID     = SPINEL_PROP_NET__BEGIN + 8, ///< [L]
     SPINEL_PROP_NET__END             = 0x50,
 
     SPINEL_PROP_THREAD__BEGIN          = 0x50,
-    SPINEL_PROP_THREAD_LEADER_ADDR     = SPINEL_PROP_THREAD__BEGIN + 0, // [6]
-    SPINEL_PROP_THREAD_PARENT          = SPINEL_PROP_THREAD__BEGIN + 1, // LADDR, SADDR [ES]
-    SPINEL_PROP_THREAD_CHILD_TABLE     = SPINEL_PROP_THREAD__BEGIN + 2, // [A(T(ES))]
-    SPINEL_PROP_THREAD_LEADER_RID      = SPINEL_PROP_THREAD__BEGIN + 3, // [C]
-    SPINEL_PROP_THREAD_LEADER_WEIGHT   = SPINEL_PROP_THREAD__BEGIN + 4, // [6]
+    SPINEL_PROP_THREAD_LEADER_ADDR     = SPINEL_PROP_THREAD__BEGIN + 0, ///< [6]
+    SPINEL_PROP_THREAD_PARENT          = SPINEL_PROP_THREAD__BEGIN + 1, ///< LADDR, SADDR [ES]
+    SPINEL_PROP_THREAD_CHILD_TABLE     = SPINEL_PROP_THREAD__BEGIN + 2, ///< [A(T(ES))]
+    SPINEL_PROP_THREAD_LEADER_RID      = SPINEL_PROP_THREAD__BEGIN + 3, ///< [C]
+    SPINEL_PROP_THREAD_LEADER_WEIGHT   = SPINEL_PROP_THREAD__BEGIN + 4, ///< [6]
     SPINEL_PROP_THREAD_LOCAL_LEADER_WEIGHT
-                                       = SPINEL_PROP_THREAD__BEGIN + 5, // [6]
-    SPINEL_PROP_THREAD_NETWORK_DATA    = SPINEL_PROP_THREAD__BEGIN + 6, // [D]
+                                       = SPINEL_PROP_THREAD__BEGIN + 5, ///< [6]
+    SPINEL_PROP_THREAD_NETWORK_DATA    = SPINEL_PROP_THREAD__BEGIN + 6, ///< [D]
     SPINEL_PROP_THREAD_NETWORK_DATA_VERSION
-                                       = SPINEL_PROP_THREAD__BEGIN + 7, // [S]
+                                       = SPINEL_PROP_THREAD__BEGIN + 7, ///< [S]
     SPINEL_PROP_THREAD_STABLE_NETWORK_DATA_VERSION
-                                       = SPINEL_PROP_THREAD__BEGIN + 8, // [S]
+                                       = SPINEL_PROP_THREAD__BEGIN + 8, ///< [S]
     SPINEL_PROP_THREAD__END            = 0x60,
 
     SPINEL_PROP_IPV6__BEGIN          = 0x60,
-    SPINEL_PROP_IPV6_LL_ADDR         = SPINEL_PROP_IPV6__BEGIN + 0, // [6]
-    SPINEL_PROP_IPV6_ML_ADDR         = SPINEL_PROP_IPV6__BEGIN + 1, // [6C]
-    SPINEL_PROP_IPV6_ML_PREFIX       = SPINEL_PROP_IPV6__BEGIN + 2, // [6C]
-    SPINEL_PROP_IPV6_ADDRESS_TABLE   = SPINEL_PROP_IPV6__BEGIN + 3, // array(ipv6addr,prefixlen,flags) [A(6CL)]
-    SPINEL_PROP_IPV6_ROUTE_TABLE     = SPINEL_PROP_IPV6__BEGIN + 4, // array(ipv6prefix,prefixlen,iface,flags) [A(6CCL)]
-    SPINEL_PROP_IPV6_EXT_ROUTE_TABLE = SPINEL_PROP_IPV6__BEGIN + 5, // array(ipv6prefix,prefixlen,flags) [A(6CL)]
+    SPINEL_PROP_IPV6_LL_ADDR         = SPINEL_PROP_IPV6__BEGIN + 0, ///< [6]
+    SPINEL_PROP_IPV6_ML_ADDR         = SPINEL_PROP_IPV6__BEGIN + 1, ///< [6C]
+    SPINEL_PROP_IPV6_ML_PREFIX       = SPINEL_PROP_IPV6__BEGIN + 2, ///< [6C]
+    SPINEL_PROP_IPV6_ADDRESS_TABLE   = SPINEL_PROP_IPV6__BEGIN + 3, ///< array(ipv6addr,prefixlen,flags) [A(6CL)]
+    SPINEL_PROP_IPV6_ROUTE_TABLE     = SPINEL_PROP_IPV6__BEGIN + 4, ///< array(ipv6prefix,prefixlen,iface,flags) [A(6CCL)]
+    SPINEL_PROP_IPV6_EXT_ROUTE_TABLE = SPINEL_PROP_IPV6__BEGIN + 5, ///< array(ipv6prefix,prefixlen,flags) [A(6CL)]
     SPINEL_PROP_IPV6__END            = 0x70,
 
     SPINEL_PROP_STREAM__BEGIN       = 0x70,
-    SPINEL_PROP_STREAM_DEBUG        = SPINEL_PROP_STREAM__BEGIN + 0, // [U]
-    SPINEL_PROP_STREAM_RAW          = SPINEL_PROP_STREAM__BEGIN + 1, // [D]
-    SPINEL_PROP_STREAM_NET          = SPINEL_PROP_STREAM__BEGIN + 2, // [D]
-    SPINEL_PROP_STREAM_NET_INSECURE = SPINEL_PROP_STREAM__BEGIN + 3, // [D]
+    SPINEL_PROP_STREAM_DEBUG        = SPINEL_PROP_STREAM__BEGIN + 0, ///< [U]
+    SPINEL_PROP_STREAM_RAW          = SPINEL_PROP_STREAM__BEGIN + 1, ///< [D]
+    SPINEL_PROP_STREAM_NET          = SPINEL_PROP_STREAM__BEGIN + 2, ///< [D]
+    SPINEL_PROP_STREAM_NET_INSECURE = SPINEL_PROP_STREAM__BEGIN + 3, ///< [D]
     SPINEL_PROP_STREAM__END         = 0x80,
 
     SPINEL_PROP_15_4_PIB__BEGIN     = 1024,


### PR DESCRIPTION
Previously, the InterfaceType and VendorID were thrown together into `PROP_PROTOCOL_VERSION`. Since these are conceptually different properties than the protocol version, this change spits them out into their own properties.