### PR TITLE
mle: Remove initialization of ML prefix from the MAC layer.

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -300,7 +300,6 @@ const uint8_t *Mac::GetExtendedPanId(void) const
 ThreadError Mac::SetExtendedPanId(const uint8_t *aExtPanId)
 {
     mBeacon.SetExtendedPanId(aExtPanId);
-    mMle.SetMeshLocalPrefix(aExtPanId);
     return kThreadError_None;
 }
 

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -112,6 +112,7 @@ const uint8_t *otGetExtendedPanId(void)
 void otSetExtendedPanId(const uint8_t *aExtendedPanId)
 {
     sThreadNetif->GetMac().SetExtendedPanId(aExtendedPanId);
+    sThreadNetif->GetMle().SetMeshLocalPrefix(aExtendedPanId);
 }
 
 otLinkModeConfig otGetLinkMode(void)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -128,6 +128,8 @@ Mle::Mle(ThreadNetif &aThreadNetif) :
     mRealmLocalAllThreadNodes.GetAddress().m16[7] = HostSwap16(0x0001);
     mNetif.SubscribeMulticast(mRealmLocalAllThreadNodes);
 
+    SetMeshLocalPrefix(mMac.GetExtendedPanId());
+
     mNetif.RegisterHandler(mNetifHandler);
 }
 


### PR DESCRIPTION
Moves the initialization of the ML prefix up to the MLE layer.