### PR TITLE
cli: Don't give character value 3 (CTRL-C) any special treatment.

### DIFF
--- a/src/cli/cli_serial.cpp
+++ b/src/cli/cli_serial.cpp
@@ -102,10 +102,6 @@ void Serial::ReceiveTask(void)
 
             break;
 
-        case 3: // CTRL-C
-            exit(1);
-            break;
-
         case '\b':
         case 127:
             otPlatSerialSend(sEraseString, sizeof(sEraseString));


### PR DESCRIPTION
This was originally here because of some misconfigured TTY settings, and can cause problems when running on embedded devices.

Since the misconfigured TTY settings have been addressed, this check is no longer needed.

This change resolves issue #57.