### PR TITLE
cli: Print 'Error' when CLI command results in an error (#6)

### DIFF
--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -132,6 +132,8 @@ private:
         kMaxArgs = 8,
     };
 
+    static void AppendResult(ThreadError error);
+
     static void ProcessHelp(int argc, char *argv[]);
     static void ProcessChannel(int argc, char *argv[]);
     static void ProcessChildTimeout(int argc, char *argv[]);


### PR DESCRIPTION
This is a fix for #6.

> Print 'Error' when CLI command results in an error, rather than failing silently.