### PR TITLE
link: do not blindly pass up unsecure frames from the link layer

### DIFF
--- a/include/platform/radio.h
+++ b/include/platform/radio.h
@@ -97,6 +97,7 @@ typedef struct RadioPacket
     uint8_t mPsdu[kMaxPHYPacketSize];  ///< The PSDU.
     uint8_t mChannel;                  ///< Channel used to transmit/receive the frame.
     int8_t  mPower;                    ///< Transmit/receive power in dBm.
+    bool    mSecurityValid;            ///< Security Enabled flag is set and frame passes security checks.
 } RadioPacket;
 
 /**

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -498,6 +498,16 @@ void Message::SetDirectTransmission(void)
     mInfo.mDirectTx = true;
 }
 
+bool Message::GetSecurityValid(void) const
+{
+    return mInfo.mSecurityValid;
+}
+
+void Message::SetSecurityValid(bool aSecurityValid)
+{
+    mInfo.mSecurityValid = aSecurityValid;
+}
+
 uint16_t Message::UpdateChecksum(uint16_t aChecksum, uint16_t aOffset, uint16_t aLength) const
 {
     Buffer *curBuffer;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -100,20 +100,21 @@ struct MessageInfo
 {
     enum
     {
-        kListAll = 0,                ///< Identifies the all messages list.
-        kListInterface = 1,          ///< Identifies the per-inteface message list.
+        kListAll = 0,                    ///< Identifies the all messages list.
+        kListInterface = 1,              ///< Identifies the per-inteface message list.
     };
-    MessageListEntry mList[2];       ///< Message lists.
-    uint16_t         mReserved;      ///< Number of header bytes reserved for the message.
-    uint16_t         mLength;        ///< Number of bytes within the message.
-    uint16_t         mOffset;        ///< A byte offset within the message.
-    uint16_t         mDatagramTag;   ///< The datagram tag used for 6LoWPAN fragmentation.
-    uint8_t          mTimeout;       ///< Seconds remaining before dropping the message.
+    MessageListEntry mList[2];           ///< Message lists.
+    uint16_t         mReserved;          ///< Number of header bytes reserved for the message.
+    uint16_t         mLength;            ///< Number of bytes within the message.
+    uint16_t         mOffset;            ///< A byte offset within the message.
+    uint16_t         mDatagramTag;       ///< The datagram tag used for 6LoWPAN fragmentation.
+    uint8_t          mTimeout;           ///< Seconds remaining before dropping the message.
 
-    uint8_t          mChildMask[8];  ///< A bit-vector to indicate which sleepy children need to receive this message.
+    uint8_t          mChildMask[8];      ///< A bit-vector to indicate which sleepy children need to receive this message.
 
-    uint8_t          mType : 2;      ///< Identifies the type of message.
-    bool             mDirectTx : 1;  ///< Used to indicate whether a direct transmission is required.
+    uint8_t          mType : 2;          ///< Identifies the type of message.
+    bool             mDirectTx : 1;      ///< Used to indicate whether a direct transmission is required.
+    bool             mSecurityValid : 1; ///< Indicates whether received frames were secure and passed validation.
 };
 
 /**
@@ -422,6 +423,23 @@ public:
      *
      */
     void SetDirectTransmission(void);
+
+    /**
+     * This method indicates whether or not the message was secure and passed validation at the link layer.
+     *
+     * @retval TRUE   If the message was secure and passed validation at the link layer.
+     * @retval FALSE  If the message was not secure or did not pass validation at the link layer.
+     *
+     */
+    bool GetSecurityValid(void) const;
+
+    /**
+     * This method sets whether or not the message was secure and passed validation at the link layer.
+     *
+     * @param[in]  aSecurityValid  TRUE if the message was secure and passed link layer validation, FALSE otherwise.
+     *
+     */
+    void SetSecurityValid(bool aSecurityValid);
 
     /**
      * This method is used to update a checksum value.

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -722,6 +722,8 @@ ThreadError Mac::ProcessReceiveSecurity(const Address &aSrcAddr, Neighbor *aNeig
     const uint8_t *macKey;
     Crypto::AesCcm aesCcm;
 
+    mReceiveFrame.SetSecurityValid(false);
+
     if (mReceiveFrame.GetSecurityEnabled() == false)
     {
         ExitNow();
@@ -793,6 +795,8 @@ ThreadError Mac::ProcessReceiveSecurity(const Address &aSrcAddr, Neighbor *aNeig
     }
 
     aNeighbor->mValid.mLinkFrameCounter = frameCounter + 1;
+
+    mReceiveFrame.SetSecurityValid(true);
 
 exit:
     return error;

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -516,6 +516,23 @@ public:
     void SetPower(int8_t aPower) { mPower = aPower; }
 
     /**
+     * This method indicates whether or not frame security was enabled and passed security validation.
+     *
+     * @retval TRUE   Frame security was enabled and passed security validation.
+     * @retval FALSE  Frame security was not enabled or did not pass security validation.
+     *
+     */
+    bool GetSecurityValid(void) const { return mSecurityValid; }
+
+    /**
+     * This method sets the security valid attribute.
+     *
+     * @param[in]  aSecurityValid  TRUE if frame security was enabled and passed security validation, FALSE otherwise.
+     *
+     */
+    void SetSecurityValid(bool aSecurityValid) { mSecurityValid = aSecurityValid; }
+
+    /**
      * This method returns the IEEE 802.15.4 PSDU length.
      *
      * @returns The IEEE 802.15.4 PSDU length.

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -160,7 +160,7 @@ private:
     void HandleLowpanHC(uint8_t *aFrame, uint8_t aPayloadLength,
                         const Mac::Address &aMacSource, const Mac::Address &aMacDest,
                         const ThreadMessageInfo &aMessageInfo);
-    void HandleDataRequest(const Mac::Address &aMacSource);
+    void HandleDataRequest(const Mac::Address &aMacSource, const ThreadMessageInfo &aMessageInfo);
     void MoveToResolving(const Ip6::Address &aDestination);
     ThreadError SendPoll(Message &aMessage, Mac::Frame &aFrame);
     ThreadError SendMesh(Message &aMessage, Mac::Frame &aFrame);
@@ -168,6 +168,7 @@ private:
     void UpdateFramePending(void);
     ThreadError UpdateIp6Route(Message &aMessage);
     ThreadError UpdateMeshRoute(Message &aMessage);
+    ThreadError HandleDatagram(Message &aMessage, const ThreadMessageInfo &aMessageInfo);
 
     static void HandleReceivedFrame(void *aContext, Mac::Frame &aFrame, ThreadError aError);
     void HandleReceivedFrame(Mac::Frame &aFrame, ThreadError aError);

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -215,7 +215,8 @@ private:
  */
 struct ThreadMessageInfo
 {
-    uint8_t mLinkMargin;  ///< The Link Margin for a received message in dBm.
+    uint8_t mLinkMargin;     ///< The Link Margin for a received message in dBm.
+    bool    mSecurityValid;  ///< Link security on all received frames was enabled and passed validation.
 };
 
 /**


### PR DESCRIPTION
This is a pull request for #44.

> The following checks were added:
> 1) Any unsecure 6LoWPAN Mesh frames are dropped.
> 2) Any unsecure 6LoWPAN Fragment frames are only added to unsecure reassembly buffers.
> 3) Any unsecure MAC Data Poll frames are dropped.
> 4) Any unsecure IPv6 datagrams must have:
>     a) Destination with link-local scope,
>     b) Next Header set to UDP,
>     c) UDP Destination Port set to MLE,
>     d) Length long enough to carry IPv6 and UDP headers.