### PR TITLE
mac: expose LQI from radio up through Thread stack (#69)

### DIFF
--- a/examples/platform/posix/radio.cpp
+++ b/examples/platform/posix/radio.cpp
@@ -463,6 +463,7 @@ ThreadError otPlatRadioHandleReceiveDone()
     }
 
     s_receive_frame->mPower = -20;
+    s_receive_frame->mLqi = kPhyNoLqi;
 
     // generate acknowledgment
     if (reinterpret_cast<Mac::Frame *>(s_receive_frame)->GetAckRequest())

--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -116,6 +116,7 @@ typedef struct otActiveScanResult
     uint16_t       mPanId;           ///< IEEE 802.15.4 PAN ID
     uint8_t        mChannel;         ///< IEEE 802.15.4 Channel
     int8_t         mRssi;            ///< RSSI (dBm)
+    uint8_t        mLqi;             ///< LQI
     uint8_t        mVersion : 4;     ///< Version
     bool           mIsNative : 1;    ///< Native Commissioner flag
     bool           mIsJoinable : 1;  ///< Joining Permitted flag

--- a/include/platform/radio.h
+++ b/include/platform/radio.h
@@ -75,6 +75,8 @@ enum
 
     kPhyBitsPerOctet    = 8,
     kPhyUsPerSymbol     = ((kPhyBitsPerOctet / kPhySymbolsPerOctet) * 1000000) / kPhyBitRate,
+
+    kPhyNoLqi           = 0,       ///< LQI measurement not supported
 };
 
 /**
@@ -97,6 +99,7 @@ typedef struct RadioPacket
     uint8_t mPsdu[kMaxPHYPacketSize];  ///< The PSDU.
     uint8_t mChannel;                  ///< Channel used to transmit/receive the frame.
     int8_t  mPower;                    ///< Transmit/receive power in dBm.
+    uint8_t mLqi;                      ///< Link Quality Indicator for received frames.
     bool    mSecurityValid;            ///< Security Enabled flag is set and frame passes security checks.
 } RadioPacket;
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -852,8 +852,8 @@ void Interpreter::ProcessScan(int argc, char *argv[])
     }
 
     SuccessOrExit(error = otActiveScan(scanChannels, 0, &HandleActiveScanResult));
-    sServer->OutputFormat("| J | Network Name     | Extended PAN     | PAN  | MAC Address      | Ch | dBm |\r\n");
-    sServer->OutputFormat("+---+------------------+------------------+------+------------------+----+-----+\r\n");
+    sServer->OutputFormat("| J | Network Name     | Extended PAN     | PAN  | MAC Address      | Ch | dBm | LQI |\r\n");
+    sServer->OutputFormat("+---+------------------+------------------+------+------------------+----+-----+-----+\r\n");
 
     return;
 
@@ -898,8 +898,9 @@ void Interpreter::HandleActiveScanResult(otActiveScanResult *aResult)
     bytes = aResult->mExtAddress.m8;
     sServer->OutputFormat("| %02x%02x%02x%02x%02x%02x%02x%02x ",
                           bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]);
-    sServer->OutputFormat("| %02d ", aResult->mChannel);
-    sServer->OutputFormat("| %03d |\r\n", aResult->mRssi);
+    sServer->OutputFormat("| %2d ", aResult->mChannel);
+    sServer->OutputFormat("| %3d ", aResult->mRssi);
+    sServer->OutputFormat("| %3d |\r\n", aResult->mLqi);
 
 exit:
     return;

--- a/src/cli/cli_serial.hpp
+++ b/src/cli/cli_serial.hpp
@@ -88,7 +88,7 @@ private:
     {
         kRxBufferSize = 128,
         kTxBufferSize = 512,
-        kMaxLineLength = 80,
+        kMaxLineLength = 128,
     };
 
     static void ReceiveTask(void *aContext);

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -516,6 +516,22 @@ public:
     void SetPower(int8_t aPower) { mPower = aPower; }
 
     /**
+     * This method returns the receive Link Quality Indicator.
+     *
+     * @returns The receive Link Quality Indicator.
+     *
+     */
+    int8_t GetLqi(void) const { return mLqi; }
+
+    /**
+     * This method sets the receive Link Quality Indicator.
+     *
+     * @param[in]  aLqi  The receive Link Quality Indicator.
+     *
+     */
+    void SetLqi(int8_t aLqi) { mLqi = aLqi; }
+
+    /**
      * This method indicates whether or not frame security was enabled and passed security validation.
      *
      * @retval TRUE   Frame security was enabled and passed security validation.

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -508,6 +508,7 @@ void HandleActiveScanResult(void *aContext, Mac::Frame *aFrame)
     aFrame->GetSrcPanId(result.mPanId);
     result.mChannel = aFrame->GetChannel();
     result.mRssi = aFrame->GetPower();
+    result.mLqi = aFrame->GetLqi();
 
     payloadLength = aFrame->GetPayloadLength();
     beacon = reinterpret_cast<Mac::Beacon *>(aFrame->GetPayload());

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1015,6 +1015,7 @@ void MeshForwarder::HandleReceivedFrame(Mac::Frame &aFrame, ThreadError aError)
 
     SuccessOrExit(aFrame.GetDstAddr(macDest));
     messageInfo.mLinkMargin = aFrame.GetPower() - -100;
+    messageInfo.mLqi = aFrame.GetLqi();
     messageInfo.mSecurityValid = aFrame.GetSecurityValid();
 
     payload = aFrame.GetPayload();

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -216,6 +216,7 @@ private:
 struct ThreadMessageInfo
 {
     uint8_t mLinkMargin;     ///< The Link Margin for a received message in dBm.
+    uint8_t mLqi;            ///< The Link Quality Indicator for a received message.
     bool    mSecurityValid;  ///< Link security on all received frames was enabled and passed validation.
 };
 


### PR DESCRIPTION
This is an enhancement for #69.

> Expose LQI from radio up through Thread stack
> * Add an LQI field to the radio packet structure.
> * Add an LQI field to the ThreadMessageInfo.
> * Add an LQI field to the scan result.
> * Print LQI value in CLI scan result.