### PR TITLE
astyle: remove use of quotes in options

### DIFF
--- a/.astyle-opts
+++ b/.astyle-opts
@@ -1,4 +1,4 @@
---style="allman"
+--style=allman
 --max-code-length=120
 --max-instatement-indent=100
 --attach-namespaces --attach-inlines


### PR DESCRIPTION
This is a fix for #58.