### PR TITLE
move UpdateChecksum from ip6 to common message

### DIFF
--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -43,6 +43,7 @@ libopenthread_a_SOURCES             = \
     common/message.cpp                \
     common/tasklet.cpp                \
     common/timer.cpp                  \
+    common/checksum.cpp               \
     crypto/aes_ccm.cpp                \
     mac/mac.cpp                       \
     mac/mac_frame.cpp                 \
@@ -79,6 +80,7 @@ noinst_HEADERS                      = \
     common/message.hpp                \
     common/tasklet.hpp                \
     common/timer.hpp                  \
+    common/checksum.hpp               \
     crypto/aes_ccm.hpp                \
     mac/mac.hpp                       \
     mac/mac_frame.hpp                 \

--- a/src/core/common/checksum.cpp
+++ b/src/core/common/checksum.cpp
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2016, Nest Labs, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes implementations for checksum calculation.
+ */
+
+#include <common/checksum.hpp>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint16_t CalculateChecksum16(uint16_t aChecksum, uint16_t aVal)
+{
+    uint16_t result = aChecksum + aVal;
+    return result + (result < aChecksum);
+}
+
+uint16_t CalculateChecksum(uint16_t aChecksum, const void *aBuf, uint16_t aLength)
+{
+    const uint8_t *bytes = reinterpret_cast<const uint8_t *>(aBuf);
+
+    for (int i = 0; i < aLength; i++)
+    {
+        aChecksum = CalculateChecksum16(aChecksum, (i & 1) ? bytes[i] : (static_cast<uint16_t>(bytes[i])) << 8);
+    }
+
+    return aChecksum;
+}
+
+#ifdef __cplusplus
+};
+#endif

--- a/src/core/common/checksum.hpp
+++ b/src/core/common/checksum.hpp
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2016, Nest Labs, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for checksum calculation.
+ */
+
+#ifndef CHECKSUM_HPP_
+#define CHECKSUM_HPP_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @def CalculateChecksum16
+ *
+ * This method updates a checksum.
+ *
+ * @param[in]  aChecksum      The checksum value to update.
+ * @param[in]  aValue         The 16-bit value to update @p aChecksum with.
+ *
+ * @returns  The updated checksum.
+ *
+ */
+uint16_t CalculateChecksum16(uint16_t aChecksum, uint16_t aValue);
+
+/**
+ * @def CalculateChecksum
+ *
+ * This method updates a checksum.
+ *
+ * @param[in]  aChecksum      The checksum value to update.
+ * @param[in]  aBuf           A pointer to a buffer.
+ * @param[in]  aLength        The number of bytes in @p aBuf.
+ *
+ * @returns  The updated checksum.
+ *
+ */
+uint16_t CalculateChecksum(uint16_t aChecksum, const void *aBuf, uint16_t aLength);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif  // CHECKSUM_HPP_

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -528,7 +528,7 @@ uint16_t Message::UpdateChecksum(uint16_t aChecksum, uint16_t aOffset, uint16_t 
             bytesToCover = aLength;
         }
 
-        aChecksum = Ip6::Ip6::UpdateChecksum(aChecksum, GetFirstData() + aOffset, bytesToCover);
+        aChecksum = CalculateChecksum(aChecksum, GetFirstData() + aOffset, bytesToCover);
 
         aLength -= bytesToCover;
         bytesCovered += bytesToCover;
@@ -563,7 +563,7 @@ uint16_t Message::UpdateChecksum(uint16_t aChecksum, uint16_t aOffset, uint16_t 
             bytesToCover = aLength;
         }
 
-        aChecksum = Ip6::Ip6::UpdateChecksum(aChecksum, curBuffer->GetData() + aOffset, bytesToCover);
+        aChecksum = CalculateChecksum(aChecksum, curBuffer->GetData() + aOffset, bytesToCover);
 
         aLength -= bytesToCover;
         bytesCovered += bytesToCover;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -37,6 +37,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <common/checksum.hpp>
 #include <openthread-types.h>
 #include <openthread-core-config.h>
 #include <common/code_utils.hpp>

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -58,37 +58,14 @@ Message *Ip6::NewMessage(uint16_t reserved)
                         sizeof(Header) + sizeof(HopByHopHeader) + sizeof(OptionMpl) + reserved);
 }
 
-uint16_t Ip6::UpdateChecksum(uint16_t checksum, uint16_t val)
-{
-    uint16_t result = checksum + val;
-    return result + (result < checksum);
-}
-
-uint16_t Ip6::UpdateChecksum(uint16_t checksum, const void *buf, uint16_t len)
-{
-    const uint8_t *bytes = reinterpret_cast<const uint8_t *>(buf);
-
-    for (int i = 0; i < len; i++)
-    {
-        checksum = Ip6::UpdateChecksum(checksum, (i & 1) ? bytes[i] : (static_cast<uint16_t>(bytes[i])) << 8);
-    }
-
-    return checksum;
-}
-
-uint16_t Ip6::UpdateChecksum(uint16_t checksum, const Address &address)
-{
-    return Ip6::UpdateChecksum(checksum, address.m8, sizeof(address));
-}
-
 uint16_t Ip6::ComputePseudoheaderChecksum(const Address &src, const Address &dst, uint16_t length, IpProto proto)
 {
     uint16_t checksum;
 
-    checksum = Ip6::UpdateChecksum(0, length);
-    checksum = Ip6::UpdateChecksum(checksum, proto);
-    checksum = UpdateChecksum(checksum, src);
-    checksum = UpdateChecksum(checksum, dst);
+    checksum = CalculateChecksum16(0, length);
+    checksum = CalculateChecksum16(checksum, proto);
+    checksum = CalculateChecksum(checksum, src.m8, sizeof(src));
+    checksum = CalculateChecksum(checksum, dst.m8, sizeof(dst));
 
     return checksum;
 }

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -39,6 +39,7 @@
 #include <openthread-types.h>
 #include <common/encoding.hpp>
 #include <common/message.hpp>
+#include <common/checksum.hpp>
 #include <net/ip6_address.hpp>
 #include <net/netif.hpp>
 #include <net/socket.hpp>
@@ -512,41 +513,6 @@ public:
      */
     static ThreadError HandleDatagram(Message &aMessage, Netif *aNetif, uint8_t aInterfaceId,
                                       const void *aLinkMessageInfo, bool aFromNcpHost);
-
-    /**
-     * This static method updates a checksum.
-     *
-     * @param[in]  aChecksum  The checksum value to update.
-     * @param[in]  aValue     The 16-bit value to update @p aChecksum with.
-     *
-     * @returns The updated checksum.
-     *
-     */
-    static uint16_t UpdateChecksum(uint16_t aChecksum, uint16_t aValue);
-
-
-    /**
-     * This static method updates a checksum.
-     *
-     * @param[in]  aChecksum  The checksum value to update.
-     * @param[in]  aBuf       A pointer to a buffer.
-     * @param[in]  aLength    The number of bytes in @p aBuf.
-     *
-     * @returns The updated checksum.
-     *
-     */
-    static uint16_t UpdateChecksum(uint16_t aChecksum, const void *aBuf, uint16_t aLength);
-
-    /**
-     * This static method updates a checksum.
-     *
-     * @param[in]  aChecksum  The checksum value to update.
-     * @param[in]  aAddress   A reference to an IPv6 address.
-     *
-     * @returns The updated checksum.
-     *
-     */
-    static uint16_t UpdateChecksum(uint16_t aChecksum, const Address &aAddress);
 
     /**
      * This static method computes the pseudoheader checksum.


### PR DESCRIPTION
Keep the common functions independently that other apps can use them without linking to the used functions.