### PR TITLE
fix AddressRegistration issues

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2768,6 +2768,11 @@ ThreadError MleRouter::AppendChildAddresses(Message &aMessage, Child &aChild)
 
     for (size_t i = 0; i < sizeof(aChild.mIp6Address) / sizeof(aChild.mIp6Address[0]); i++)
     {
+        if (aChild.mIp6Address[i].IsUnspecified())
+        {
+            break;
+        }
+
         if (mNetworkData.GetContext(aChild.mIp6Address[i], context) == kThreadError_None)
         {
             // compressed entry

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -1362,7 +1362,7 @@ public:
             aIndex--;
         }
 
-        return entry;
+        return (cur < end) ? entry : NULL;
     }
 
 private:


### PR DESCRIPTION
GetAddressEntry() should return NULL when trying to get an invalid entry;
AppendChlidAddress() should only append valid addresses.
Hi @jwhui , could you help to have a review?