### PR TITLE
fix multicast-forward-to-SED issue

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -368,7 +368,7 @@ Message *MeshForwarder::GetIndirectTransmission(const Child &aChild)
         mAddMeshHeader = false;
         GetMacSourceAddress(ip6Header.GetSource(), mMacSource);
 
-        if (ip6Header.GetDestination().IsLinkLocal() || ip6Header.GetDestination().IsMulticast())
+        if (ip6Header.GetDestination().IsLinkLocal())
         {
             GetMacDestinationAddress(ip6Header.GetDestination(), mMacDest);
         }
@@ -946,6 +946,7 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame)
         else
         {
             mSendMessage->ClearDirectTransmission();
+            mSendMessage->SetOffset(0);
         }
     }
 


### PR DESCRIPTION
Unicast prefix based multicast address should be excluded from the general multicast addresses in GetIndirectTransmission();
The offset of message should be reset to 0 in case that the message would be forwarded to SED later after broadcast if the destination is unicast prefix based multicast addresses.
@jwhui , would you please help to review it?