### PR TITLE
README: Improve markdown formatting for plaintext readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,118 @@
-<a href="https://github.com/openthread/openthread">![Logo](doc/images/openthread_logo.png)</a>
+[![OpenThread][ot-logo]][ot-repo]  
+[![Build Status][ot-travis-svg]][ot-travis]
 
-[![Build Status](https://travis-ci.org/openthread/openthread.svg?branch=master)](https://travis-ci.org/openthread/openthread)
+---
 
-OpenThread is an open-source implementation of the [Thread](http://threadgroup.org/technology/ourtechnology) networking protocol. With OpenThread, Nest is making the technology used in Nest products more broadly available to accelerate the development of products for the connected home.
+OpenThread is an open-source implementation of the [Thread][thread]
+networking protocol. With OpenThread, Nest is making the technology
+used in Nest products more broadly available to accelerate the
+development of products for the connected home.
 
-The Thread specification defines an IPv6-based reliable, secure and low-power wireless device-to-device communication protocol for home applications. More information about Thread can be found on [threadgroup.org](http://www.threadgroup.org/).
+The Thread specification defines an IPv6-based reliable, secure and
+low-power wireless device-to-device communication protocol for home
+applications. More information about Thread can be found on
+[threadgroup.org](http://threadgroup.org/).
 
-## Features
-- Highly portable: OS and platform agnostic, with a radio abstraction layer
-- Implements the End Device, Router, Leader & Border Router roles
-- Small memory footprint
-
-OpenThread implements all Thread networking layers, including IPv6, 6LoWPAN, IEEE 802.15.4 with MAC security, Mesh Link Establishment, and Mesh Routing.
-
-
-# Who is behind OpenThread
-
-![Logo](doc/images/openthread_contrib.png)
-
-Nest, along with ARM, Atmel, a subsidiary of Microchip Technology, Dialog Semiconductor,  Qualcomm Technologies, Inc., a subsidiary of Qualcomm Incorporated and Texas Instruments Incorporated are contributing to the ongoing development of OpenThread.
-
-
-# Getting Started
-
-The easiest way to get started is to run the CLI example in `/examples/cli`. See the [CLI example README](examples/cli/README.md) for more details.
+[thread]: http://threadgroup.org/technology/ourtechnology
+[ot-repo]: https://github.com/openthread/openthread
+[ot-logo]: doc/images/openthread_logo.png
+[ot-travis]: https://travis-ci.org/openthread/openthread
+[ot-travis-svg]: https://travis-ci.org/openthread/openthread.svg?branch=master
 
 
-## What's included
+## Features ##
 
-In the repo you'll find the following directories and files
+ *  Highly portable: OS and platform agnostic, with a radio
+    abstraction layer
+ *  Implements the End Device, Router, Leader & Border Router roles
+ *  Small memory footprint
 
-File/Folder	 | Provides
--------|--------
-doc | Doxygen docs
-examples | Sample applications demonstrating various parts of OpenThread
-include | Includes header files for OpenThread API
-src | The core implementation of the Thread standard
-tests | Unit and Thread conformance tests
-third_party | Third-party code used by OpenThread
+OpenThread implements all Thread networking layers, including IPv6,
+6LoWPAN, IEEE 802.15.4 with MAC security, Mesh Link Establishment, and
+Mesh Routing.
 
 
-## Docs
-The Doxygen reference docs are [hosted online](http://openthread.github.io/openthread/) and generated as part of the build.
+# Who is behind OpenThread #
+
+![OpenThread Contributor Logos](doc/images/openthread_contrib.png)
+
+Nest, along with ARM, Atmel, a subsidiary of Microchip Technology,
+Dialog Semiconductor, Qualcomm Technologies, Inc., a subsidiary of
+Qualcomm Incorporated and Texas Instruments Incorporated are
+contributing to the ongoing development of OpenThread.
 
 
-# Getting Help
+# Getting Started #
 
-Submit bugs and feature requests to [issue tracker](https://github.com/openthread/openthread/issues). Usage questions? Post questions to [Stack Overflow](http://stackoverflow.com/) using the [[openthread] tag](http://stackoverflow.com/questions/tagged/openthread). We also use Google Groups for discussion and announcements:
-
-* [openthread-announce](https://groups.google.com/forum/#!forum/openthread-announce) - subscribe for release notes and new updates on OpenThread
-* [openthread-users](https://groups.google.com/forum/#!forum/openthread-users) - the best place for users to discuss OpenThread and interact with the OpenThread team
-* [openthread-devel](https://groups.google.com/forum/#!forum/openthread-devel) - team members discuss the on-going development of OpenThread
+The easiest way to get started is to run the CLI example in
+`/examples/cli`. See the [CLI example README](examples/cli/README.md)
+for more details.
 
 
-# Versioning
+## What's included ##
 
-OpenThread follows [the Semantic Versioning guidelines](http://semver.org/) for release cycle transparency and to maintain backwards compatibility. OpenThread's versioning is independent of the Thread protocol specification version but will clearly indicate which version of the specification it currently supports.
+In the repo you'll find the following directories and files:
+
+File/Folder   | Provides
+--------------|----------------------------------------------------------------
+`doc`         | Doxygen docs
+`examples`    | Sample applications demonstrating various parts of OpenThread
+`include`     | Includes header files for OpenThread API
+`src`         | The core implementation of the Thread standard
+`tests`       | Unit and Thread conformance tests
+`third_party` | Third-party code used by OpenThread
 
 
-# Contributing
+## Documentation ##
 
-See the [CONTRIBUTING.md](CONTRIBUTING.md) file for more information.
+The Doxygen reference docs are [hosted online][ot-docs] and generated
+as part of the build.
+
+[ot-docs]: http://openthread.github.io/openthread/
 
 
-# License
+# Getting Help #
 
-OpenThread is released under the [BSD 3-Clause license](LICENSE).
-See the [LICENSE](LICENSE) file for more information.
+Submit bugs and feature requests to [issue tracker][ot-issues]. Usage
+questions? Post questions to [Stack Overflow][stackoverflow] using the
+[`openthread` tag][ot-tag]. We also use Google Groups for discussion
+and announcements:
 
-Please only use the OpenThread name and marks when accurately referencing this software distribution, and do not use these marks in a way that suggests you are endorsed by or otherwise affiliated with Nest, Google, or The Thread Group.
+ *  [openthread-announce](https://groups.google.com/forum/#!forum/openthread-announce)
+    \- subscribe for release notes and new updates on OpenThread
+ *  [openthread-users](https://groups.google.com/forum/#!forum/openthread-users)
+    \- the best place for users to discuss OpenThread and interact with
+    the OpenThread team
+ *  [openthread-devel](https://groups.google.com/forum/#!forum/openthread-devel)
+    \- team members discuss the on-going development of OpenThread
+
+[ot-issues]: https://github.com/openthread/openthread/issues
+[stackoverflow]: http://stackoverflow.com/
+[ot-tag]: http://stackoverflow.com/questions/tagged/openthread
+
+
+# Versioning #
+
+OpenThread follows [the Semantic Versioning guidelines][semver] for
+release cycle transparency and to maintain backwards compatibility.
+OpenThread's versioning is independent of the Thread protocol
+specification version but will clearly indicate which version of the
+specification it currently supports.
+
+[semver]: http://semver.org/
+
+
+# Contributing #
+
+See the [`CONTRIBUTING.md`](CONTRIBUTING.md) file for more information.
+
+
+# License #
+
+OpenThread is released under the [BSD 3-Clause license](LICENSE). See
+the [`LICENSE`](LICENSE) file for more information.
+
+Please only use the OpenThread name and marks when accurately
+referencing this software distribution, and do not use these marks in
+a way that suggests you are endorsed by or otherwise affiliated with
+Nest, Google, or The Thread Group.


### PR DESCRIPTION
This change doesn't affect how the README looks when viewed rendered into HTML. It simply reformats the markdown in such a way that improves readability when reading the document using a plaintext editor.

One of the ways to improve the visual appeal of the README text was to use reference-style links whenever an inline-link would cause the paragraph to line-wrap in a visually unappealing way.

For example, this is before:

    Submit bugs and feature requests to [issue
    tracker](https://github.com/openthread/openthread/issues). Usage
    questions? Post questions to [Stack
    Overflow](http://stackoverflow.com/) using the [`[openthread]`
    tag](http://stackoverflow.com/questions/tagged/openthread). We also
    use Google Groups for discussion and announcements:

And this is after:

    Submit bugs and feature requests to [issue tracker][ot-issues]. Usage
    questions? Post questions to [Stack Overflow][stackoverflow] using the
    [`[openthread]` tag][ot-tag]. We also use Google Groups for discussion
    and announcements:

    [ot-issues]: https://github.com/openthread/openthread/issues
    [stackoverflow]: http://stackoverflow.com/
    [ot-tag]: http://stackoverflow.com/questions/tagged/openthread

Both of these render to exactly the same HTML:

> Submit bugs and feature requests to [issue tracker][ot-issues]. Usage questions? Post questions to [Stack Overflow][stackoverflow] using the [`[openthread]` tag][ot-tag]. We also use Google Groups for discussion and announcements:

Click [here](https://raw.githubusercontent.com/darconeous/openthread/pr/readme-format/README.md) to see the README in plaintext. Click [here](https://github.com/darconeous/openthread/tree/pr/readme-format#readme) to see the HTML-rendered version.

[ot-issues]: https://github.com/openthread/openthread/issues
[stackoverflow]: http://stackoverflow.com/
[ot-tag]: http://stackoverflow.com/questions/tagged/openthread
