### PR TITLE
Move example apps to C-only API.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -425,7 +425,9 @@ NL_RESTORE_WERROR
 AC_CONFIG_FILES([
 Makefile
 include/Makefile
+include/cli/Makefile
 include/crypto/Makefile
+include/ncp/Makefile
 include/platform/Makefile
 src/Makefile
 src/cli/Makefile

--- a/examples/posix/app/cli/Makefile.am
+++ b/examples/posix/app/cli/Makefile.am
@@ -43,10 +43,11 @@ soc_LDADD                                                      =  \
     $(top_builddir)/src/cli/libopenthread-cli.a                   \
     $(top_builddir)/examples/posix/platform/libopenthread-posix.a \
     $(top_builddir)/third_party/mbedtls/libmbedcrypto.a           \
+    -lstdc++                                                         \
     $(NULL)
 
 soc_SOURCES                                                    = \
-    main.cpp                                                     \
+    main.c                                                       \
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/posix/app/cli/main.c
+++ b/examples/posix/app/cli/main.c
@@ -26,77 +26,34 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-/**
- * @file
- *   This file contains definitions for a CLI server on the serial service.
- */
+#include <stdlib.h>
 
-#ifndef CLI_SERIAL_HPP_
-#define CLI_SERIAL_HPP_
+#include <openthread.h>
+#include <cli/cli-serial.h>
+#include <posix-platform.h>
 
-#include <openthread-types.h>
-#include <cli/cli_server.hpp>
-#include <common/tasklet.hpp>
-
-namespace Thread {
-namespace Cli {
-
-/**
- * This class implements the CLI server on top of the serial platform abstraction.
- *
- */
-class Serial: public Server
+void otSignalTaskletPending(void)
 {
-public:
-    Serial(void);
+}
 
-    /**
-     * This method delivers raw characters to the client.
-     *
-     * @param[in]  aBuf        A pointer to a buffer.
-     * @param[in]  aBufLength  Number of bytes in the buffer.
-     *
-     * @returns The number of bytes placed in the output queue.
-     *
-     */
-    int Output(const char *aBuf, uint16_t aBufLength);
-
-    /**
-     * This method delivers formatted output to the client.
-     *
-     * @param[in]  aFmt  A pointer to the format string.
-     * @param[in]  ...   A variable list of arguments to format.
-     *
-     * @returns The number of bytes placed in the output queue.
-     *
-     */
-    int OutputFormat(const char *fmt, ...);
-
-    void ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength);
-    void SendDoneTask(void);
-
-private:
-    enum
+int main(int argc, char *argv[])
+{
+    if (argc != 2)
     {
-        kRxBufferSize = 128,
-        kTxBufferSize = 512,
-        kMaxLineLength = 128,
-    };
+        exit(1);
+    }
 
-    ThreadError ProcessCommand(void);
-    void Send(void);
+    NODE_ID = atoi(argv[1]);
 
-    char mRxBuffer[kRxBufferSize];
-    uint16_t mRxLength;
+    posixPlatformInit();
+    otInit();
+    otCliSerialInit();
 
-    char mTxBuffer[kTxBufferSize];
-    uint16_t mTxHead;
-    uint16_t mTxLength;
+    while (1)
+    {
+        otProcessNextTasklet();
+        posixPlatformProcessDrivers();
+    }
 
-    uint16_t mSendLength;
-};
-
-}  // namespace Cli
-}  // namespace Thread
-
-#endif  // CLI_SERIAL_HPP_
+    return 0;
+}

--- a/examples/posix/app/ncp/Makefile.am
+++ b/examples/posix/app/ncp/Makefile.am
@@ -44,8 +44,11 @@ ncp_LDADD                                                       = \
     $(top_builddir)/src/core/libopenthread.a                      \
     $(top_builddir)/examples/posix/platform/libopenthread-posix.a \
     $(top_builddir)/third_party/mbedtls/libmbedcrypto.a           \
+    -lstdc++                                                      \
     $(NULL)
 
-ncp_SOURCES = main.cpp
+ncp_SOURCES                                                     = \
+    main.c                                                        \
+    $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/posix/app/ncp/main.c
+++ b/examples/posix/app/ncp/main.c
@@ -27,10 +27,9 @@
 
 #include <stdlib.h>
 
-#include <ncp/ncp.hpp>
+#include <openthread.h>
+#include <ncp/ncp.h>
 #include <posix-platform.h>
-
-Thread::Ncp sNcp;
 
 void otSignalTaskletPending(void)
 {
@@ -46,8 +45,7 @@ int main(int argc, char *argv[])
     NODE_ID = atoi(argv[1]);
     posixPlatformInit();
     otInit();
-
-    sNcp.Start();
+    otNcpInit();
 
     while (1)
     {

--- a/examples/posix/platform/platform.c
+++ b/examples/posix/platform/platform.c
@@ -40,6 +40,7 @@
 
 #include <openthread.h>
 #include <platform/alarm.h>
+#include <platform/serial.h>
 #include <posix-platform.h>
 
 uint32_t NODE_ID = 1;
@@ -50,6 +51,7 @@ void posixPlatformInit(void)
     posixPlatformAlarmInit();
     posixPlatformRadioInit();
     posixPlatformRandomInit();
+    otPlatSerialEnable();
 }
 
 void posixPlatformProcessDrivers(void)

--- a/examples/posix/platform/serial.c
+++ b/examples/posix/platform/serial.c
@@ -30,6 +30,7 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <termios.h>
 #include <unistd.h>
 

--- a/include/cli/Makefile.am
+++ b/include/cli/Makefile.am
@@ -28,36 +28,8 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-# Always package (e.g. for 'make dist') these subdirectories.
-
-DIST_SUBDIRS                            = \
-    cli                                   \
-    crypto                                \
-    ncp                                   \
-    platform                              \
-    $(NULL)
-
-# Always build (e.g. for 'make all') these subdirectories.
-
-SUBDIRS                                 = \
-    cli                                   \
-    crypto                                \
-    ncp                                   \
-    platform                              \
-    $(NULL)
-
-# Always pretty (e.g. for 'make pretty') these subdirectories.
-
-PRETTY_SUBDIRS                          = \
-    cli                                   \
-    crypto                                \
-    ncp                                   \
-    platform                              \
-    $(NULL)
-
 include_HEADERS                         = \
-    openthread.h                          \
-    openthread-types.h                    \
+    cli-serial.h                          \
     $(NULL)
 
 install-headers: install-includeHEADERS

--- a/include/cli/cli-serial.h
+++ b/include/cli/cli-serial.h
@@ -28,75 +28,25 @@
 
 /**
  * @file
- *   This file contains definitions for a CLI server on the serial service.
+ * @brief
+ *  This file defines the top-level functions for the OpenThread CLI server.
  */
 
-#ifndef CLI_SERIAL_HPP_
-#define CLI_SERIAL_HPP_
+#ifndef CLI_SERIAL_H_
+#define CLI_SERIAL_H_
 
-#include <openthread-types.h>
-#include <cli/cli_server.hpp>
-#include <common/tasklet.hpp>
-
-namespace Thread {
-namespace Cli {
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
- * This class implements the CLI server on top of the serial platform abstraction.
+ * Initialize the CLI serial server.
  *
  */
-class Serial: public Server
-{
-public:
-    Serial(void);
+void otCliSerialInit(void);
 
-    /**
-     * This method delivers raw characters to the client.
-     *
-     * @param[in]  aBuf        A pointer to a buffer.
-     * @param[in]  aBufLength  Number of bytes in the buffer.
-     *
-     * @returns The number of bytes placed in the output queue.
-     *
-     */
-    int Output(const char *aBuf, uint16_t aBufLength);
+#ifdef __cplusplus
+}  // extern "C"
+#endif
 
-    /**
-     * This method delivers formatted output to the client.
-     *
-     * @param[in]  aFmt  A pointer to the format string.
-     * @param[in]  ...   A variable list of arguments to format.
-     *
-     * @returns The number of bytes placed in the output queue.
-     *
-     */
-    int OutputFormat(const char *fmt, ...);
-
-    void ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength);
-    void SendDoneTask(void);
-
-private:
-    enum
-    {
-        kRxBufferSize = 128,
-        kTxBufferSize = 512,
-        kMaxLineLength = 128,
-    };
-
-    ThreadError ProcessCommand(void);
-    void Send(void);
-
-    char mRxBuffer[kRxBufferSize];
-    uint16_t mRxLength;
-
-    char mTxBuffer[kTxBufferSize];
-    uint16_t mTxHead;
-    uint16_t mTxLength;
-
-    uint16_t mSendLength;
-};
-
-}  // namespace Cli
-}  // namespace Thread
-
-#endif  // CLI_SERIAL_HPP_
+#endif

--- a/include/ncp/Makefile.am
+++ b/include/ncp/Makefile.am
@@ -28,36 +28,8 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-# Always package (e.g. for 'make dist') these subdirectories.
-
-DIST_SUBDIRS                            = \
-    cli                                   \
-    crypto                                \
-    ncp                                   \
-    platform                              \
-    $(NULL)
-
-# Always build (e.g. for 'make all') these subdirectories.
-
-SUBDIRS                                 = \
-    cli                                   \
-    crypto                                \
-    ncp                                   \
-    platform                              \
-    $(NULL)
-
-# Always pretty (e.g. for 'make pretty') these subdirectories.
-
-PRETTY_SUBDIRS                          = \
-    cli                                   \
-    crypto                                \
-    ncp                                   \
-    platform                              \
-    $(NULL)
-
 include_HEADERS                         = \
-    openthread.h                          \
-    openthread-types.h                    \
+    ncp.h                                 \
     $(NULL)
 
 install-headers: install-includeHEADERS

--- a/include/ncp/ncp.h
+++ b/include/ncp/ncp.h
@@ -26,36 +26,27 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdlib.h>
+/**
+ * @file
+ * @brief
+ *  This file defines the top-level functions for the OpenThread CLI server.
+ */
 
-#include <openthread.h>
-#include <cli/cli_serial.hpp>
-#include <posix-platform.h>
+#ifndef NCP_H_
+#define NCP_H_
 
-Thread::Cli::Serial sCliServer;
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-void otSignalTaskletPending(void)
-{
-}
+/**
+ * Initialize the CLI serial server.
+ *
+ */
+void otNcpInit(void);
 
-int main(int argc, char *argv[])
-{
-    if (argc != 2)
-    {
-        exit(1);
-    }
+#ifdef __cplusplus
+}  // extern "C"
+#endif
 
-    NODE_ID = atoi(argv[1]);
-
-    posixPlatformInit();
-    otInit();
-    sCliServer.Start();
-
-    while (1)
-    {
-        otProcessNextTasklet();
-        posixPlatformProcessDrivers();
-    }
-
-    return 0;
-}
+#endif

--- a/src/cli/cli_serial.cpp
+++ b/src/cli/cli_serial.cpp
@@ -31,12 +31,15 @@
  *   This file implements the CLI server on the serial service.
  */
 
+#include <new>
+
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <cli/cli.hpp>
+#include <cli/cli-serial.h>
 #include <cli/cli_serial.hpp>
 #include <common/code_utils.hpp>
 #include <common/encoding.hpp>
@@ -50,19 +53,19 @@ static const char sEraseString[] = {'\b', ' ', '\b'};
 static const char CRNL[] = {'\r', '\n'};
 static Serial *sServer;
 
-Serial::Serial(void)
+static otDEFINE_ALIGNED_VAR(sCliSerialRaw, sizeof(Serial), uint64_t);
+
+extern "C" void otCliSerialInit(void)
 {
-    sServer = this;
+    sServer = new(&sCliSerialRaw) Serial;
 }
 
-ThreadError Serial::Start(void)
+Serial::Serial(void)
 {
     mRxLength = 0;
     mTxHead = 0;
     mTxLength = 0;
     mSendLength = 0;
-    otPlatSerialEnable();
-    return kThreadError_None;
 }
 
 extern "C" void otPlatSerialReceived(const uint8_t *aBuf, uint16_t aBufLength)

--- a/src/cli/cli_server.hpp
+++ b/src/cli/cli_server.hpp
@@ -47,14 +47,6 @@ class Server
 {
 public:
     /**
-     * This method starts the CLI server.
-     *
-     * @retval kThreadError_None  Successfully started the server.
-     *
-     */
-    virtual ThreadError Start() = 0;
-
-    /**
      * This method delivers raw characters to the client.
      *
      * @param[in]  aBuf        A pointer to a buffer.

--- a/src/core/common/code_utils.hpp
+++ b/src/core/common/code_utils.hpp
@@ -36,6 +36,10 @@
 
 #include <stdbool.h>
 
+// Allocate the structure using "raw" storage.
+#define otDEFINE_ALIGNED_VAR(name, size, align_type)            \
+    align_type name[(((size) + (sizeof (align_type) - 1)) / sizeof (align_type))]
+
 #define SuccessOrExit(ERR)                      \
   do {                                          \
     if ((ERR) != 0) {                           \

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -54,10 +54,6 @@ ThreadNetif *sThreadNetif;
 extern "C" {
 #endif
 
-// Allocate the structure using "raw" storage.
-#define otDEFINE_ALIGNED_VAR(name, size, align_type)            \
-    align_type name[(((size) + (sizeof (align_type) - 1)) / sizeof (align_type))]
-
 static otDEFINE_ALIGNED_VAR(sThreadNetifRaw, sizeof(ThreadNetif), uint64_t);
 
 static void HandleActiveScanResult(void *aContext, Mac::Frame *aFrame);

--- a/src/ncp/ncp.cpp
+++ b/src/ncp/ncp.cpp
@@ -30,31 +30,27 @@
  *   This file implements an HDLC interface to the Thread stack.
  */
 
+#include <new>
+
 #include <common/code_utils.hpp>
+#include <ncp/ncp.h>
 #include <ncp/ncp.hpp>
 #include <platform/serial.h>
 
 namespace Thread {
 
+static otDEFINE_ALIGNED_VAR(sNcpRaw, sizeof(Ncp), uint64_t);
 static Ncp *sNcp;
+
+extern "C" void otNcpInit(void)
+{
+    sNcp = new(&sNcpRaw) Ncp;
+}
 
 Ncp::Ncp():
     NcpBase(),
     mFrameDecoder(mReceiveFrame, sizeof(mReceiveFrame), &HandleFrame, this)
 {
-    sNcp = this;
-}
-
-ThreadError Ncp::Start()
-{
-    otPlatSerialEnable();
-    return super_t::Start();
-}
-
-ThreadError Ncp::Stop()
-{
-    otPlatSerialDisable();
-    return super_t::Stop();
 }
 
 uint16_t

--- a/src/ncp/ncp.hpp
+++ b/src/ncp/ncp.hpp
@@ -46,10 +46,6 @@ class Ncp : public NcpBase
 public:
     Ncp();
 
-    ThreadError Start();
-    ThreadError Stop();
-
-
     virtual ThreadError OutboundFrameBegin(void);
     virtual uint16_t OutboundFrameGetRemaining(void);
     virtual ThreadError OutboundFrameFeedData(const uint8_t *frame, uint16_t frameLength);

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -228,19 +228,10 @@ NcpBase::NcpBase():
     mSupportedChannelMask = (0xFFFF << 11); // Default to 2.4GHz 802.15.4 channels.
     mChannelMask = mSupportedChannelMask;
     mScanPeriod = 200; // ms
-}
 
-ThreadError NcpBase::Start()
-{
     assert(sThreadNetif != NULL);
     sThreadNetif->RegisterHandler(mNetifHandler);
     Ip6::Ip6::SetNcpReceivedHandler(&HandleDatagramFromStack, this);
-    return kThreadError_None;
-}
-
-ThreadError NcpBase::Stop()
-{
-    return kThreadError_None;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -47,9 +47,6 @@ public:
 
     NcpBase();
 
-    ThreadError Start();
-    ThreadError Stop();
-
 protected:
 
     virtual ThreadError OutboundFrameBegin(void) = 0;


### PR DESCRIPTION
This change allows top-level example apps to use a C-only API rather than directly accessing C++ objects.