### PR TITLE
fix SED issue

### DIFF
--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -99,6 +99,12 @@ bool Address::IsRealmLocalAllRoutersMulticast(void) const
             m32[2] == 0 && m32[3] == HostSwap32(0x02));
 }
 
+bool Address::IsRoutingLocator(void) const
+{
+    return (m16[4] == HostSwap16(0x0000) && m16[5] == HostSwap16(0x00ff) &&
+            m16[6] == HostSwap16(0xfe00));
+}
+
 const uint8_t *Address::GetIid(void) const
 {
     return m8 + kInterfaceIdentifierOffset;

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -179,6 +179,15 @@ public:
     bool IsRealmLocalAllRoutersMulticast(void) const;
 
     /**
+     * This method indicates whether or not the IPv6 address is a RLOC address.
+     *
+     * @retval TRUE   If the IPv6 address is a RLOC address.
+     * @retval FALSE  If the IPv6 address is not a RLOC address.
+     *
+     */
+    bool IsRoutingLocator(void) const;
+
+    /**
      * This method returns a pointer to the Interface Identifier.
      *
      * @returns A pointer to the Interface Identifier.

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -281,7 +281,10 @@ ThreadError Netif::AddUnicastAddress(NetifUnicastAddress &aAddress)
     aAddress.mNext = mUnicastAddresses;
     mUnicastAddresses = &aAddress;
 
-    mUnicastChangedTask.Post();
+    if (!aAddress.GetAddress().IsRoutingLocator())
+    {
+        mUnicastChangedTask.Post();
+    }
 
 exit:
     return error;
@@ -311,7 +314,12 @@ ThreadError Netif::RemoveUnicastAddress(const NetifUnicastAddress &aAddress)
     ExitNow(error = kThreadError_Error);
 
 exit:
-    mUnicastChangedTask.Post();
+
+    if (!aAddress.GetAddress().IsRoutingLocator())
+    {
+        mUnicastChangedTask.Post();
+    }
+
     return error;
 }
 


### PR DESCRIPTION
SED should not SendChildUpdateRequest() due to configure the RLOC addresses when it becomes a child;
Poll timer should be started in SendChildUpdateRequest() in case it is from SED after reset
SED should accept network information (eg leader etc) from Child Update Response after its reset
Timeout TLV might be optional in Child Update Response.

Hi @jwhui , would you please help to have a review?
