### PR TITLE
fix scan mask issue when reattach to the same partition

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -850,6 +850,12 @@ ThreadError Mle::SendParentRequest(void)
     {
     case kParentRequestRouter:
         scanMask = ScanMaskTlv::kRouterFlag;
+
+        if (mParentRequestMode == kMleAttachSamePartition)
+        {
+            scanMask |= ScanMaskTlv::kEndDeviceFlag;
+        }
+
         break;
 
     case kParentRequestChild:


### PR DESCRIPTION
Scan Mask TLV in the initial MLE Parent Request has both E and R set when reattaching to the same partition
@jwhui , is this fix ok for you?