### PR TITLE
fix that FFD device could not succeed to act as REED

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1684,9 +1684,11 @@ ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::Messa
     SuccessOrExit(error = SetStateChild(shortAddress.GetRloc16()));
 
     // Route
-    if (Tlv::GetTlv(aMessage, Tlv::kRoute, sizeof(route), route) == kThreadError_None)
+    if ((Tlv::GetTlv(aMessage, Tlv::kRoute, sizeof(route), route) == kThreadError_None) &&
+        (mDeviceMode & ModeTlv::kModeFFD))
     {
         numRouters = 0;
+        SuccessOrExit(error = mMleRouter.ProcessRouteTlv(route));
 
         for (int i = 0; i < kMaxRouterId; i++)
         {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1112,9 +1112,7 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kRoute, sizeof(route), route));
     VerifyOrExit(route.IsValid(), error = kThreadError_Parse);
 
-    if ((GetDeviceState() == kDeviceStateChild &&
-         memcmp(&mParent.mMacAddr, &macAddr, sizeof(mParent.mMacAddr)) == 0) ||
-        GetDeviceState() == kDeviceStateRouter || GetDeviceState() == kDeviceStateLeader)
+    if (mDeviceMode & ModeTlv::kModeFFD)
     {
         SuccessOrExit(error = ProcessRouteTlv(route));
     }


### PR DESCRIPTION
FFD should ProcessRouteTLV when HandleChildIdResponse() and only FFD need to consider whether to BecomeRouter() or not;
REED should also ProcessRouteTLV when HandleAdvertisement() from neighbors.

@jwhui , would you please help to have a review?