### PR TITLE
Locally define new operator to avoid dependence on stdinc++.

### DIFF
--- a/src/cli/cli_serial.cpp
+++ b/src/cli/cli_serial.cpp
@@ -31,8 +31,6 @@
  *   This file implements the CLI server on the serial service.
  */
 
-#include <new>
-
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -43,6 +41,7 @@
 #include <cli/cli_serial.hpp>
 #include <common/code_utils.hpp>
 #include <common/encoding.hpp>
+#include <common/new.hpp>
 #include <common/tasklet.hpp>
 #include <platform/serial.h>
 

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -77,6 +77,7 @@ noinst_HEADERS                      = \
     common/encoding.hpp               \
     common/logging.hpp                \
     common/message.hpp                \
+    common/new.hpp                    \
     common/tasklet.hpp                \
     common/timer.hpp                  \
     crypto/aes_ccm.hpp                \

--- a/src/core/common/new.hpp
+++ b/src/core/common/new.hpp
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2016, Nest Labs, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file defines the new operator used by OpenThread.
+ */
+
+#ifndef NEW_HPP_
+#define NEW_HPP_
+
+#include <stddef.h>
+
+inline void *operator new(size_t, void *p) throw() { return p; }
+
+#endif  // NEW_HPP_

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -31,13 +31,12 @@
  *   This file implements the top-level interface to the OpenThread stack.
  */
 
-#include <new>
-
 #include <openthread.h>
 #include <common/code_utils.hpp>
 #include <common/debug.hpp>
 #include <common/logging.hpp>
 #include <common/message.hpp>
+#include <common/new.hpp>
 #include <common/tasklet.hpp>
 #include <common/timer.hpp>
 #include <platform/random.h>

--- a/src/ncp/ncp.cpp
+++ b/src/ncp/ncp.cpp
@@ -30,9 +30,8 @@
  *   This file implements an HDLC interface to the Thread stack.
  */
 
-#include <new>
-
 #include <common/code_utils.hpp>
+#include <common/new.hpp>
 #include <ncp/ncp.h>
 #include <ncp/ncp.hpp>
 #include <platform/serial.h>


### PR DESCRIPTION
This is a fix for #115.