### PR TITLE
api: Implement known missing OpenThread APIs needed for NCP support.

### DIFF
--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -75,6 +75,11 @@ typedef enum ThreadError
      */
     kThreadError_ChannelAccessFailure = 17,
 
+    /**
+     * Not currently attached to a Thread Partition.
+     */
+    kThreadError_Detached = 18,
+
     kThreadError_Error = 255,
 } ThreadError;
 

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -56,6 +56,7 @@ extern "C" {
  * @defgroup config Configuration
  * @defgroup diags Diagnostics
  * @defgroup messages Message Buffers
+ * @defgroup ip6 IPv6
  * @defgroup udp UDP
  *
  * @}
@@ -278,6 +279,18 @@ const uint8_t *otGetExtendedPanId(void);
 void otSetExtendedPanId(const uint8_t *aExtendedPanId);
 
 /**
+ * This function returns a pointer to the Leader's RLOC.
+ *
+ * @param[out]  aLeaderRloc  A pointer to where the Leader's RLOC will be written.
+ *
+ * @retval kThreadError_None         The Leader's RLOC was successfully written to @p aLeaderRloc.
+ * @retval kThreadError_InvalidArgs  @p aLeaderRloc was NULL.
+ * @retval kThreadError_Detached     Not currently attached to a Thread Partition.
+ *
+ */
+ThreadError otGetLeaderRloc(otIp6Address *aLeaderRloc);
+
+/**
  * Get the MLE Link Mode configuration.
  *
  * @returns The MLE Link Mode configuration.
@@ -323,6 +336,52 @@ const uint8_t *otGetMasterKey(uint8_t *aKeyLength);
 ThreadError otSetMasterKey(const uint8_t *aKey, uint8_t aKeyLength);
 
 /**
+ * This function returns a pointer to the Mesh Local EID.
+ *
+ * @returns A pointer to the Mesh Local EID.
+ *
+ */
+const otIp6Address *otGetMeshLocalEid(void);
+
+/**
+ * This function returns a pointer to the Mesh Local Prefix.
+ *
+ * @returns A pointer to the Mesh Local Prefix.
+ *
+ */
+const uint8_t *otGetMeshLocalPrefix(void);
+
+/**
+ * This function sets the Mesh Local Prefix.
+ *
+ * @param[in]  aMeshLocalPrefix  A pointer to the Mesh Local Prefix.
+ *
+ * @retval kThreadError_None  Successfully set the Mesh Local Prefix.
+ *
+ */
+ThreadError otSetMeshLocalPrefix(const uint8_t *aMeshLocalPrefix);
+
+/**
+ * This method provides a full or stable copy of the Leader's Thread Network Data.
+ *
+ * @param[in]     aStable      TRUE when copying the stable version, FALSE when copying the full version.
+ * @param[out]    aData        A pointer to the data buffer.
+ * @param[inout]  aDataLength  On entry, size of the data buffer pointed to by @p aData.
+ *                             On exit, number of copied bytes.
+ */
+ThreadError otGetNetworkDataLeader(bool aStable, uint8_t *aData, uint8_t *aDataLength);
+
+/**
+ * This method provides a full or stable copy of the local Thread Network Data.
+ *
+ * @param[in]     aStable      TRUE when copying the stable version, FALSE when copying the full version.
+ * @param[out]    aData        A pointer to the data buffer.
+ * @param[inout]  aDataLength  On entry, size of the data buffer pointed to by @p aData.
+ *                             On exit, number of copied bytes.
+ */
+ThreadError otGetNetworkDataLocal(bool aStable, uint8_t *aData, uint8_t *aDataLength);
+
+/**
  * Get the Thread Network Name.
  *
  * @returns A pointer to the Thread Network Name.
@@ -362,6 +421,13 @@ otPanId otGetPanId(void);
  * @sa otGetPanId
  */
 ThreadError otSetPanId(otPanId aPanId);
+
+/**
+ * Get the IEEE 802.15.4 Short Address.
+ *
+ * @returns A pointer to the IEEE 802.15.4 Short Address.
+ */
+otShortAddress otGetShortAddress(void);
 
 /**
  * Get the list of IPv6 addresses assigned to the Thread interface.
@@ -988,6 +1054,46 @@ int otReadMessage(otMessage aMessage, uint16_t aOffset, void *aBuf, uint16_t aLe
  * @sa otReadMessage
  */
 int otWriteMessage(otMessage aMessage, uint16_t aOffset, const void *aBuf, uint16_t aLength);
+
+/**
+ * @}
+ *
+ */
+
+/**
+ * @addtogroup ip6  IPv6
+ *
+ * @brief
+ *   This module includes functions that control IPv6 communication.
+ *
+ * @{
+ *
+ */
+
+/**
+ * This function pointer is called when an IPv6 datagram is received.
+ *
+ * @param[in]  aMessage  A pointer to the message buffer containing the received IPv6 datagram.
+ *
+ */
+typedef void (*otReceiveIp6DatagramCallback)(otMessage aMessage);
+
+/**
+ * This function registers a callback to provide received IPv6 datagrams.
+ *
+ * @param[in]  aCallback  A pointer to a function that is called when an IPv6 datagram is received or NULL to disable
+ *                        the callback.
+ *
+ */
+void otSetReceiveIp6DatagramCallback(otReceiveIp6DatagramCallback aCallback);
+
+/**
+ * This function sends an IPv6 datagram via the Thread interface.
+ *
+ * @param[in]  aMessage  A pointer to the message buffer containing the IPv6 datagram.
+ *
+ */
+ThreadError otSendIp6Datagram(otMessage aMessage);
 
 /**
  * @}

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -563,22 +563,13 @@ public:
                                                 uint16_t aLength, IpProto aProto);
 
     /**
-     * This function pointer is called when an IPv6 message is received.
+     * This function registers a callback to provide receivd raw IPv6 datagrams.
      *
-     * @param[in]  aContext  A pointer to arbitrary context information.
-     * @param[in]  aMessage  A reference to the IPv6 message.
-     *
-     */
-    typedef void (*NcpReceivedDatagramHandler)(void *aContext, Message &aMessage);
-
-    /**
-     * This method sets the NCP receive handler.
-     *
-     * @param[in]  aHandler  A pointer to a function that is called when IPv6 messages are received.
-     * @param[in]  aContext  A pointer to arbitrary context information.
+     * @param[in]  aCallback  A pointer to a function that is called when an IPv6 datagram is received or NULL to disable
+     *                        the callback.
      *
      */
-    static void SetNcpReceivedHandler(NcpReceivedDatagramHandler aHandler, void *aContext);
+    static void SetReceiveDatagramCallback(otReceiveIp6DatagramCallback aCallback);
 
 };
 

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -110,6 +110,18 @@ void otSetExtendedPanId(const uint8_t *aExtendedPanId)
     sThreadNetif->GetMle().SetMeshLocalPrefix(aExtendedPanId);
 }
 
+ThreadError otGetLeaderRloc(otIp6Address *aAddress)
+{
+    ThreadError error;
+
+    VerifyOrExit(aAddress != NULL, error = kThreadError_InvalidArgs);
+
+    error = sThreadNetif->GetMle().GetLeaderAddress(*static_cast<Ip6::Address *>(aAddress));
+
+exit:
+    return error;
+}
+
 otLinkModeConfig otGetLinkMode(void)
 {
     otLinkModeConfig config = {};
@@ -175,6 +187,45 @@ ThreadError otSetMasterKey(const uint8_t *aKey, uint8_t aKeyLength)
     return sThreadNetif->GetKeyManager().SetMasterKey(aKey, aKeyLength);
 }
 
+const otIp6Address *otGetMeshLocalEid(void)
+{
+    return sThreadNetif->GetMle().GetMeshLocal64();
+}
+
+const uint8_t *otGetMeshLocalPrefix(void)
+{
+    return sThreadNetif->GetMle().GetMeshLocalPrefix();
+}
+
+ThreadError otSetMeshLocalPrefix(const uint8_t *aMeshLocalPrefix)
+{
+    return sThreadNetif->GetMle().SetMeshLocalPrefix(aMeshLocalPrefix);
+}
+
+ThreadError otGetNetworkDataLeader(bool aStable, uint8_t *aData, uint8_t *aDataLength)
+{
+    ThreadError error = kThreadError_None;
+
+    VerifyOrExit(aData != NULL && aDataLength != NULL, error = kThreadError_InvalidArgs);
+
+    sThreadNetif->GetNetworkDataLeader().GetNetworkData(aStable, aData, *aDataLength);
+
+exit:
+    return error;
+}
+
+ThreadError otGetNetworkDataLocal(bool aStable, uint8_t *aData, uint8_t *aDataLength)
+{
+    ThreadError error = kThreadError_None;
+
+    VerifyOrExit(aData != NULL && aDataLength != NULL, error = kThreadError_InvalidArgs);
+
+    sThreadNetif->GetNetworkDataLocal().GetNetworkData(aStable, aData, *aDataLength);
+
+exit:
+    return error;
+}
+
 const char *otGetNetworkName(void)
 {
     return sThreadNetif->GetMac().GetNetworkName();
@@ -193,6 +244,11 @@ otPanId otGetPanId(void)
 ThreadError otSetPanId(otPanId aPanId)
 {
     return sThreadNetif->GetMac().SetPanId(aPanId);
+}
+
+otShortAddress otGetShortAddress(void)
+{
+    return sThreadNetif->GetMac().GetShortAddress();
 }
 
 uint8_t otGetLocalLeaderWeight(void)
@@ -521,6 +577,17 @@ void HandleActiveScanResult(void *aContext, Mac::Frame *aFrame)
 
 exit:
     return;
+}
+
+void otSetReceiveIp6DatagramCallback(otReceiveIp6DatagramCallback aCallback)
+{
+    Ip6::Ip6::SetReceiveDatagramCallback(aCallback);
+}
+
+ThreadError otSendIp6Datagram(otMessage aMessage)
+{
+    return Ip6::Ip6::HandleDatagram(*static_cast<Message *>(aMessage), NULL, sThreadNetif->GetInterfaceId(),
+                                    NULL, true);
 }
 
 otMessage otNewUdpMessage(void)

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -76,7 +76,7 @@ private:
     /**
      * Trampoline for HandleDatagramFromStack().
      */
-    static void HandleDatagramFromStack(void *context, Message &message);
+    static void HandleDatagramFromStack(otMessage message);
 
     void HandleDatagramFromStack(Message &message);
 


### PR DESCRIPTION
This change adds the following APIs:
* otGetLeaderRloc
* otGetMeshLocalEid
* otGetMeshLocalPrefix
* otSetMeshLocalPrefix
* otGetNetworkDataLeader
* otGetNetworkDataLocal
* otGetShortAddress
* otSetRawIp6ReceivedCallback
* otSendRawIp6

Note that there is still a lingering reference to `sThreadNetif` for notifications.  The notifications will be cleaned up in a future PR.