### PR TITLE
Make building cli, ncp, and examples optional.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,7 +30,12 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 AM_MAKEFLAGS                        = --no-print-directory
 
-AM_DISTCHECK_CONFIGURE_FLAGS        = --enable-minimum-set-of-tests
+AM_DISTCHECK_CONFIGURE_FLAGS        = \
+    --enable-cli                      \
+    --enable-ncp                      \
+    --with-examples=posix             \
+    --enable-minimum-set-of-tests     \
+    $(NULL)
 
 SUBDIRS                             = \
     include                           \

--- a/configure.ac
+++ b/configure.ac
@@ -332,6 +332,88 @@ if test "${nl_cv_build_tests}" = "yes"; then
 fi
 
 #
+# CLI Library
+#
+
+AC_ARG_ENABLE(cli,
+    [AS_HELP_STRING([--enable-cli],[Enable CLI suport @<:@default=no@:>@.])],
+    [
+        case "${enableval}" in
+
+        no|yes)
+            enable_cli=${enableval}
+            ;;
+
+        *)
+            AC_MSG_ERROR([Invalid value ${with_cli} for --enable-cli])
+            ;;
+        esac
+    ],
+    [enable_cli=no])
+AC_MSG_RESULT(${enable_cli})
+AM_CONDITIONAL([OPENTHREAD_ENABLE_CLI], [test "${enable_cli}" = "yes"])
+
+#
+# NCP Library
+#
+
+AC_ARG_ENABLE(ncp,
+    [AS_HELP_STRING([--enable-ncp],[Enable NCP suport @<:@default=no@:>@.])],
+    [
+        case "${enableval}" in
+
+        no|yes)
+            enable_ncp=${enableval}
+            ;;
+
+        *)
+            AC_MSG_ERROR([Invalid value ${with_ncp} for --enable-ncp])
+            ;;
+        esac
+    ],
+    [enable_ncp=no])
+AC_MSG_RESULT(${enable_ncp})
+AM_CONDITIONAL([OPENTHREAD_ENABLE_NCP], [test "${enable_ncp}" = "yes"])
+
+#
+# Examples
+#
+
+AC_ARG_WITH(examples,
+    [AS_HELP_STRING([--with-examples=TARGET],
+        [Specify the examples from one of: none, posix @<:@default=none@:>@.])],
+    [
+        case "${with_examples}" in
+
+        none|posix)
+            ;;
+        *)
+            AC_MSG_ERROR([Invalid value ${with_examples} for --with-examples])
+            ;;
+        esac
+    ],
+    [with_examples=none])
+
+OPENTHREAD_EXAMPLES=${with_examples}
+
+case ${with_examples} in
+
+    posix)
+        OPENTHREAD_EXAMPLES_POSIX=1
+        ;;
+
+esac
+
+AC_MSG_RESULT(${OPENTHREAD_EXAMPLES})
+
+AC_SUBST(OPENTHREAD_EXAMPLES)
+AC_DEFINE_UNQUOTED([OPENTHREAD_EXAMPLES],[${OPENTHREAD_EXAMPLES}],[OpenThread examples])
+
+AC_SUBST(OPENTHREAD_EXAMPLES_POSIX)
+AM_CONDITIONAL([OPENTHREAD_EXAMPLES_POSIX], [test "${OPENTHREAD_EXAMPLES}" = "posix"])
+AC_DEFINE_UNQUOTED([OPENTHREAD_EXAMPLES_POSIX],[${OPENTHREAD_EXAMPLES_POSIX}],[Define to 1 if you want to use posix examples])
+
+#
 # Tools
 #
 
@@ -500,8 +582,8 @@ AC_MSG_NOTICE([
   Astyle                                    : ${ASTYLE}
   Astyle pretty args                        : ${ASTYLE_PRETTY_ARGS}
   Astyle pretty check args                  : ${ASTYLE_PRETTY_CHECK_ARGS}
+  OpenThread CLI support                    : ${enable_cli}
+  OpenThread NCP support                    : ${enable_ncp}
+  OpenThread examples                       : ${OPENTHREAD_EXAMPLES}
 
 ])
-
-
-

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -36,9 +36,9 @@ DIST_SUBDIRS                            = \
 
 # Always build (e.g. for 'make all') these subdirectories.
 
-SUBDIRS                                 = \
-    posix                                 \
-    $(NULL)
+if OPENTHREAD_EXAMPLES_POSIX
+SUBDIRS                                 = posix
+endif
 
 # Always pretty (e.g. for 'make pretty') these subdirectories.
 

--- a/examples/posix/app/Makefile.am
+++ b/examples/posix/app/Makefile.am
@@ -38,9 +38,15 @@ DIST_SUBDIRS                            = \
 # Always build (e.g. for 'make all') these subdirectories.
 
 SUBDIRS                                 = \
-    cli                                   \
-    ncp                                   \
     $(NULL)
+
+if OPENTHREAD_ENABLE_CLI
+SUBDIRS                                += cli
+endif
+
+if OPENTHREAD_ENABLE_NCP
+SUBDIRS                                += ncp
+endif
 
 # Always pretty (e.g. for 'make pretty') these subdirectories.
 

--- a/examples/posix/app/cli/README.md
+++ b/examples/posix/app/cli/README.md
@@ -10,7 +10,8 @@ another emulated Thread device.
 
 ```bash
 $ cd openthread
-$ ./bootstrap-configure
+$ ./bootstrap
+$ ./configure --enable-cli --with-examples=posix
 $ make
 ```
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,10 +39,16 @@ DIST_SUBDIRS                            = \
 # Always build (e.g. for 'make all') these subdirectories.
 
 SUBDIRS                                 = \
-    cli                                   \
     core                                  \
-    ncp                                   \
     $(NULL)
+
+if OPENTHREAD_ENABLE_CLI
+SUBDIRS                                += cli
+endif
+
+if OPENTHREAD_ENABLE_NCP
+SUBDIRS                                += ncp
+endif
 
 # Always pretty (e.g. for 'make pretty') these subdirectories.
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -37,10 +37,14 @@ DIST_SUBDIRS                            = \
 
 # Always build (e.g. for 'make all') these subdirectories.
 
+if OPENTHREAD_EXAMPLES_POSIX
+if OPENTHREAD_ENABLE_CLI
 SUBDIRS                                 = \
     unit                                  \
     scripts                               \
     $(NULL)
+endif
+endif
 
 # Always pretty (e.g. for 'make pretty') these subdirectories.
 


### PR DESCRIPTION
This is a fix for #131.

By default, only core is built.  Added the following configure options:
--enable-cli
--enable-ncp
--with-examples=TARGET