### PR TITLE
api: Add notifications on configuration and state changes from OpenThread.

### DIFF
--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -207,6 +207,24 @@ typedef struct otLinkModeConfig
 } otLinkModeConfig;
 
 /**
+ * This enumeration represents flags that indicate what configuration or state has changed within OpenThread.
+ *
+ */
+enum
+{
+    OT_IP6_ADDRESS_ADDED    = 1 << 0,  ///< IPv6 address was added
+    OT_IP6_ADDRESS_REMOVED  = 1 << 1,  ///< IPv6 address was removed
+
+    OT_NET_STATE            = 1 << 2,  ///< Device state (offline, detached, attached) changed
+    OT_NET_ROLE             = 1 << 3,  ///< Device role (disabled, detached, child, router, leader) changed
+    OT_NET_PARTITION_ID     = 1 << 4,  ///< Partition ID changed
+    OT_NET_KEY_SEQUENCE     = 1 << 5,  ///< Thread Key Sequence changed
+
+    OT_THREAD_CHILD_ADDED   = 1 << 6,  ///< Child was added
+    OT_THREAD_CHILD_REMOVED = 1 << 7   ///< Child was removed
+};
+
+/**
  * @}
  */
 

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -458,6 +458,24 @@ ThreadError otAddUnicastAddress(otNetifAddress *aAddress);
 ThreadError otRemoveUnicastAddress(otNetifAddress *aAddress);
 
 /**
+ * This function pointer is called to notify certain configuration or state changes within OpenThread.
+ *
+ * @param[in]  aFlags    A bit-field indicating specific state that has changed.
+ * @param[in]  aContext  A pointer to application-specific context.
+ *
+ */
+typedef void (*otStateChangedCallback)(uint32_t aFlags, void *aContext);
+
+/**
+ * This function registers a callback to indicate when certain configuration or state changes within OpenThread.
+ *
+ * @param[in]  aCallback  A pointer to a function that is called with certain configuration or state changes.
+ * @param[in]  aContext   A pointer to application-specific context.
+ *
+ */
+void otSetStateChangedCallback(otStateChangedCallback aCallback, void *aContext);
+
+/**
  * @}
  */
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -73,6 +73,7 @@ Mac::Mac(ThreadNetif &aThreadNetif):
     mReceiveTimer(&HandleReceiveTimer, this),
     mKeyManager(aThreadNetif.GetKeyManager()),
     mMle(aThreadNetif.GetMle()),
+    mNetif(aThreadNetif),
     mWhitelist()
 {
     sMac = this;
@@ -611,6 +612,11 @@ void Mac::SentFrame(bool aAcked)
 
         if ((neighbor = mMle.GetNeighbor(destination)) != NULL)
         {
+            if (neighbor->mState == Neighbor::kStateValid && mMle.GetChildId(neighbor->mValid.mRloc16) != 0)
+            {
+                mNetif.SetStateChangedFlags(OT_THREAD_CHILD_REMOVED);
+            }
+
             neighbor->mState = Neighbor::kStateInvalid;
         }
     }

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -455,6 +455,7 @@ private:
 
     KeyManager &mKeyManager;
     Mle::MleRouter &mMle;
+    ThreadNetif &mNetif;
 
     ExtAddress mExtAddress;
     ShortAddress mShortAddress;

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -49,6 +49,8 @@ namespace Thread {
 // of of the features in the NCP.
 ThreadNetif *sThreadNetif;
 
+static Ip6::NetifCallback sNetifCallback;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -543,6 +545,12 @@ ThreadError otAddUnicastAddress(otNetifAddress *address)
 ThreadError otRemoveUnicastAddress(otNetifAddress *address)
 {
     return sThreadNetif->RemoveUnicastAddress(*static_cast<Ip6::NetifUnicastAddress *>(address));
+}
+
+void otSetStateChangedCallback(otStateChangedCallback aCallback, void *aContext)
+{
+    sNetifCallback.Set(aCallback, aContext);
+    sThreadNetif->RegisterCallback(sNetifCallback);
 }
 
 ThreadError otEnable(void)

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -96,6 +96,7 @@ ThreadError KeyManager::ComputeKey(uint32_t aKeySequence, uint8_t *aKey)
 
 uint32_t KeyManager::GetCurrentKeySequence() const
 {
+    mNetif.SetStateChangedFlags(OT_NET_KEY_SEQUENCE);
     return mCurrentKeySequence;
 }
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -888,6 +888,16 @@ protected:
      */
     ThreadError SetStateChild(uint16_t aRloc16);
 
+    /**
+     * This method sets the Leader's Partition ID, Weighting, and Router ID values.
+     *
+     * @param[in]  aPartitionId     The Leader's Parititon ID value.
+     * @param[in]  aWeighting       The Leader's Weighting value.
+     * @param[in]  aLeaderRouterId  The Leader's Router ID value.
+     *
+     */
+    void SetLeaderData(uint32_t aPartitionId, uint8_t aWeighting, uint8_t aLeaderRouterId);
+
     ThreadNetif         &mNetif;            ///< The Thread Network Interface object.
     AddressResolver     &mAddressResolver;  ///< The Address Resolver object.
     KeyManager          &mKeyManager;       ///< The Key Manager object.
@@ -928,8 +938,8 @@ private:
     void GenerateNonce(const Mac::ExtAddress &aMacAddr, uint32_t aFrameCounter, uint8_t aSecurityLevel,
                        uint8_t *aNonce);
 
-    static void HandleUnicastAddressesChanged(void *aContext);
-    void HandleUnicastAddressesChanged(void);
+    static void HandleNetifStateChanged(uint32_t aFlags, void *aContext);
+    void HandleNetifStateChanged(uint32_t aFlags);
     static void HandleParentRequestTimer(void *aContext);
     void HandleParentRequestTimer(void);
     static void HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo);
@@ -970,7 +980,7 @@ private:
     Ip6::NetifMulticastAddress mLinkLocalAllThreadNodes;
     Ip6::NetifMulticastAddress mRealmLocalAllThreadNodes;
 
-    Ip6::NetifHandler mNetifHandler;
+    Ip6::NetifCallback mNetifCallback;
 };
 
 }  // namespace Mle

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -95,7 +95,7 @@ private:
     void RunUpdateAddressesTask(void);
 
 
-    static void HandleUnicastAddressesChanged(void *context);
+    static void HandleNetifStateChanged(uint32_t flags, void *context);
 
 private:
 
@@ -277,8 +277,6 @@ private:
                                                    uint16_t value_len);
 
 private:
-
-    Ip6::NetifHandler mNetifHandler;
 
     spinel_status_t mLastStatus;
 


### PR DESCRIPTION
This is an enhancement for #143.

Example state changes that will cause a notification:
- IPv6 address added/removed
- Device state (offline, detached, attached)
- Device role (disabled, detached, child, router, leader)
- Partition ID
- Key Sequence
- Child added/removed