### PR TITLE
key_manager: Don't set changed flag in key sequence getter

### DIFF
--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -72,6 +72,8 @@ ThreadError KeyManager::SetMasterKey(const void *aKey, uint8_t aKeyLength)
     mCurrentKeySequence = 0;
     ComputeKey(mCurrentKeySequence, mCurrentKey);
 
+    mNetif.SetStateChangedFlags(OT_NET_KEY_SEQUENCE);
+
 exit:
     return error;
 }
@@ -96,7 +98,6 @@ ThreadError KeyManager::ComputeKey(uint32_t aKeySequence, uint8_t *aKey)
 
 uint32_t KeyManager::GetCurrentKeySequence() const
 {
-    mNetif.SetStateChangedFlags(OT_NET_KEY_SEQUENCE);
     return mCurrentKeySequence;
 }
 
@@ -137,6 +138,8 @@ void KeyManager::SetCurrentKeySequence(uint32_t aKeySequence)
     mMleFrameCounter = 0;
 
     UpdateNeighbors();
+
+    mNetif.SetStateChangedFlags(OT_NET_KEY_SEQUENCE);
 }
 
 const uint8_t *KeyManager::GetCurrentMacKey() const


### PR DESCRIPTION
The previous code was in error because the key sequence changed
flag tends to induce the key sequence to be read again, which
causes the flag to be set again, and so on.

This change moves the key sequence changed flag to be set
only in places where the key sequence is actually being changed.