### PR TITLE
Fix typos in header file comments.

### DIFF
--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -172,7 +172,7 @@ typedef struct otActiveScanResult
  * @defgroup config-general  General
  *
  * @brief
- *   This module includes functions that manage configuration parameters for the Thread Child, Router, and Leader rols.
+ *   This module includes functions that manage configuration parameters for the Thread Child, Router, and Leader roles.
  *
  * @{
  *
@@ -414,10 +414,10 @@ typedef struct otMacCounters
     uint32_t mRxWhitelistFiltered;    ///< The number of received packets filtered by whitelist.
     uint32_t mRxDestAddrFiltered;     ///< The number of received packets filtered by destination check.
     uint32_t mRxErrNoFrame;           ///< The number of received packets that do not contain contents.
-    uint32_t mRxErrUnknownNeighbor;   ///< The number of recevied packets from unknown neighbor.
+    uint32_t mRxErrUnknownNeighbor;   ///< The number of received packets from unknown neighbor.
     uint32_t mRxErrInvalidSrcAddr;    ///< The number of received packets whose source address is invalid.
-    uint32_t mRxErrSec;               ///< The number of recevied packets with security error.
-    uint32_t mRxErrFcs;               ///< The number of recevied packets with FCS error.
+    uint32_t mRxErrSec;               ///< The number of received packets with security error.
+    uint32_t mRxErrFcs;               ///< The number of received packets with FCS error.
     uint32_t mRxErrOther;             ///< The number of received packets with other error.
 } otMacCounters;
 

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -211,7 +211,7 @@ bool otActiveScanInProgress(void);
  * @defgroup config-general  General
  *
  * @brief
- *   This module includes functions that manage configuration parameters for the Thread Child, Router, and Leader rols.
+ *   This module includes functions that manage configuration parameters for the Thread Child, Router, and Leader roles.
  *
  * @{
  *
@@ -433,7 +433,7 @@ otShortAddress otGetShortAddress(void);
 /**
  * Get the list of IPv6 addresses assigned to the Thread interface.
  *
- * @returns A pointer to the first Network Inteface Address.
+ * @returns A pointer to the first Network Interface Address.
  */
 const otNetifAddress *otGetUnicastAddresses(void);
 
@@ -1191,8 +1191,8 @@ otMessage otNewUdpMessage(void);
  * @param[in]  aCallback  A pointer to the application callback function.
  * @param[in]  aContext   A pointer to application-specific context.
  *
- * @retval kThreadErrorNone  Successfully openned the socket.
- * @retval kThreadErrorBusy  Socket is already openned.
+ * @retval kThreadErrorNone  Successfully opened the socket.
+ * @retval kThreadErrorBusy  Socket is already opened.
  *
  * @sa otNewUdpMessage
  * @sa otCloseUdpSocket

--- a/include/platform/radio.h
+++ b/include/platform/radio.h
@@ -71,7 +71,7 @@ enum
     kPhyMinChannel      = 11,      ///< 2.4 GHz IEEE 802.15.4-2006
     kPhyMaxChannel      = 26,      ///< 2.4 GHz IEEE 802.15.4-2006
     kPhySymbolsPerOctet = 2,       ///< 2.4 GHz IEEE 802.15.4-2006
-    kPhyBitRate         = 250000,  ///< 2.4 GHz IEEE 802.15.4 (kilbits per second)
+    kPhyBitRate         = 250000,  ///< 2.4 GHz IEEE 802.15.4 (kilobits per second)
 
     kPhyBitsPerOctet    = 8,
     kPhyUsPerSymbol     = ((kPhyBitsPerOctet / kPhySymbolsPerOctet) * 1000000) / kPhyBitRate,

--- a/src/core/coap/coap_header.hpp
+++ b/src/core/coap/coap_header.hpp
@@ -236,7 +236,7 @@ public:
      * @param[in]  aOption  The CoAP Option.
      *
      * @retval kThreadError_None         Successfully appended the option.
-     * @retval kThreadError_InvalidArgs  The option type is not equal or gerater than the last option type.
+     * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
      *
      */
     ThreadError AppendOption(const Option &aOption);
@@ -247,7 +247,7 @@ public:
      * @param[in]  aUriPath  A pointer to a NULL-terminated string.
      *
      * @retval kThreadError_None         Successfully appended the option.
-     * @retval kThreadError_InvalidArgs  The option type is not equal or gerater than the last option type.
+     * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
      *
      */
     ThreadError AppendUriPathOptions(const char *aUriPath);
@@ -267,7 +267,7 @@ public:
      * @param[in]  aType  The Media Type value.
      *
      * @retval kThreadError_None         Successfully appended the option.
-     * @retval kThreadError_InvalidArgs  The option type is not equal or gerater than the last option type.
+     * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
      *
      */
     ThreadError AppendContentFormatOption(MediaType aType);

--- a/src/core/coap/coap_server.hpp
+++ b/src/core/coap/coap_server.hpp
@@ -128,7 +128,7 @@ public:
      * @param[in]  aResource  A reference to the resource.
      *
      * @retval kThreadError_None  Successfully added @p aResource.
-     * @retval kThreadError_Busy  The @p aResource was alerady added.
+     * @retval kThreadError_Busy  The @p aResource was already added.
      *
      */
     ThreadError AddResource(Resource &aResource);

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -80,7 +80,7 @@ struct MessageListEntry
 {
     struct MessageList *mList;  ///< A pointer to the MessageList structure for the list.
     Message            *mNext;  ///< A pointer to the next Message in the list.
-    Message            *mPrev;  ///< A pointer to the pprevious Message in the list.
+    Message            *mPrev;  ///< A pointer to the previous Message in the list.
 };
 
 /**
@@ -101,7 +101,7 @@ struct MessageInfo
     enum
     {
         kListAll = 0,                    ///< Identifies the all messages list.
-        kListInterface = 1,              ///< Identifies the per-inteface message list.
+        kListInterface = 1,              ///< Identifies the per-interface message list.
     };
     MessageListEntry mList[2];           ///< Message lists.
     uint16_t         mReserved;          ///< Number of header bytes reserved for the message.
@@ -259,7 +259,7 @@ public:
      * @param[in]  aOffset  The number of bytes to move the current offset, which may be positive or negative.
      *
      * @retval kThreadError_None         Successfully moved the byte offset.
-     * @retval kThreadError_InvalidArgs  The requestd byte offset is not within the existing message.
+     * @retval kThreadError_InvalidArgs  The requested byte offset is not within the existing message.
      *
      */
     ThreadError SetOffset(uint16_t aOffset);
@@ -487,7 +487,7 @@ private:
      *
      * @param[in]  aList  The message list.
      *
-     * @returns A reference to a message lis.
+     * @returns A reference to a message list.
      *
      */
     MessageListEntry &GetMessageList(uint8_t aList) { return mInfo.mList[aList]; }
@@ -497,7 +497,7 @@ private:
      *
      * @param[in]  aList  The message list.
      *
-     * @returns A reference to a message lis.
+     * @returns A reference to a message list.
      *
      */
     const MessageListEntry &GetMessageList(uint8_t aList) const { return mInfo.mList[aList]; }

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -192,7 +192,7 @@ public:
     static uint32_t GetNow(void) { return otPlatAlarmGetNow(); }
 
     /**
-     * This static method returns the number of milliseonds given seconds.
+     * This static method returns the number of milliseconds given seconds.
      *
      * @returns The number of milliseconds.
      *

--- a/src/core/crypto/aes_ccm.hpp
+++ b/src/core/crypto/aes_ccm.hpp
@@ -82,7 +82,7 @@ public:
      * This method processes the header.
      *
      * @param[in]  aHeader        A pointer to the header.
-     * @param[in]  aHeaderLength  Lenth of header in bytes.
+     * @param[in]  aHeaderLength  Length of header in bytes.
      *
      */
     void Header(const void *aHeader, uint32_t aHeaderLength);

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -75,7 +75,7 @@ enum
     kMaxFrameAttempts     = kMaxFrameRetries + 1,  ///< Number of transmission attempts.
 
     kAckTimeout           = 16,                    ///< Timeout for waiting on an ACK (milliseconds).
-    kDataPollTimeout      = 100,                   ///< Timeout for receivint Data Frame (milliseconds).
+    kDataPollTimeout      = 100,                   ///< Timeout for receiving Data Frame (milliseconds).
     kNonceSize            = 13,                    ///< Size of IEEE 802.15.4 Nonce (bytes).
 
     kScanChannelsAll      = 0xffff,                ///< All channels.
@@ -96,7 +96,7 @@ public:
      *
      * @param[in]  aContext  A pointer to arbitrary context information.
      * @param[in]  aFrame    A reference to the MAC frame.
-     * @param[in]  aError    Any errors that occured during reception.
+     * @param[in]  aError    Any errors that occurred during reception.
      *
      */
     typedef void (*ReceiveFrameHandler)(void *aContext, Frame &aFrame, ThreadError aError);

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -82,7 +82,7 @@ class ExtAddress: public otExtAddress
 {
 public:
     /**
-     * This method converts an IPv6 Interface Identifer to an IEEE 802.15.4 Extended Address.
+     * This method converts an IPv6 Interface Identifier to an IEEE 802.15.4 Extended Address.
      *
      * @param[in]  aIpAddress  A reference to the IPv6 address.
      *
@@ -663,7 +663,7 @@ public:
     }
 
     /**
-     * This method returns the Protocol ID value.xs
+     * This method returns the Protocol ID value.
      *
      * @returns the Protocol ID value.
      *

--- a/src/core/mac/mac_whitelist.hpp
+++ b/src/core/mac/mac_whitelist.hpp
@@ -165,7 +165,7 @@ public:
      * @param[out]  aRssi   A reference to the RSSI variable.
      *
      * @retval kThreadError_None        A constant RSSI is set and written to @p aRssi.
-     * @retval kThreadError_InvalidArg  A constnat RSSI was not set.
+     * @retval kThreadError_InvalidArg  A constant RSSI was not set.
      *
      */
     ThreadError GetConstantRssi(Entry &aEntry, int8_t &aRssi) const;

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -239,7 +239,7 @@ public:
      *
      * @param[in]  aDestination    The socket address of the destination.
      * @param[in]  aPayload        A pointer to the data payload to send.
-     * @param[in]  aPayloadLength  The number of data payoad bytes.
+     * @param[in]  aPayloadLength  The number of data payload bytes.
      *
      * @retval kThreadError_None    An ICMPv6 Echo Request message was enqueued.
      * @retval kThreadError_NoBufs  Insufficient buffers available to generate an ICMPv6 Echo Request message.
@@ -277,7 +277,7 @@ public:
      * @param[in]  aContext      A pointer to arbitrary context information.
      * @param[in]  aMessage      A reference to the received message.
      * @param[in]  aMessageInfo  A reference to message information associated with @p aMessage.
-     * @param[in]  aIcmpHeader   A reference to the receievd ICMPv6 header.
+     * @param[in]  aIcmpHeader   A reference to the received ICMPv6 header.
      *
      */
     typedef void (*DstUnreachHandler)(void *aContext, Message &aMesage, const MessageInfo &aMessageInfo,
@@ -344,7 +344,7 @@ public:
     /**
      * This static method handles an ICMPv6 message.
      *
-     * @param[in]  aMessage      A reference to the ICMPv6 mesasge.
+     * @param[in]  aMessage      A reference to the ICMPv6 message.
      * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
      *
      * @retval kThreadError_None    Successfully processed the ICMPv6 message.

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -508,9 +508,9 @@ public:
      *
      * @param[in]  aMessage          A reference to the message.
      * @param[in]  aNetif            A pointer to the network interface that received the message.
-     * @param[in]  aInterfaceId      The interface identier of the network interface that received the message.
+     * @param[in]  aInterfaceId      The interface identifier of the network interface that received the message.
      * @param[in]  aLinkMessageInfo  A pointer to link-specific message information.
-     * @param[in]  aFromNcpHost      TRUE if the message was submited by the NCP host, FALSE otherwise.
+     * @param[in]  aFromNcpHost      TRUE if the message was submitted by the NCP host, FALSE otherwise.
      *
      * @retval kThreadError_None   Successfully processed the message.
      * @retval kThreadError_Drop   Message processing failed and the message should be dropped.
@@ -562,14 +562,14 @@ public:
      * @param[in]  aLength       The IPv6 Payload Length value.
      * @param[in]  aProto        The IPv6 Next Header value.
      *
-     * @returns The psuedoheader checksum.
+     * @returns The pseudoheader checksum.
      *
      */
     static uint16_t ComputePseudoheaderChecksum(const Address &aSource, const Address &aDestination,
                                                 uint16_t aLength, IpProto aProto);
 
     /**
-     * This function registers a callback to provide receivd raw IPv6 datagrams.
+     * This function registers a callback to provide received raw IPv6 datagrams.
      *
      * @param[in]  aCallback  A pointer to a function that is called when an IPv6 datagram is received or NULL to disable
      *                        the callback.

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -99,7 +99,7 @@ public:
     bool IsLoopback(void) const;
 
     /**
-     * This method indicates whether or not the IPv6 address scope is Interafce-Local.
+     * This method indicates whether or not the IPv6 address scope is Interface-Local.
      *
      * @retval TRUE   If the IPv6 address scope is Interface-Local.
      * @retval FALSE  If the IPv6 address scope is not Interface-Local.

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -338,7 +338,7 @@ public:
     virtual ThreadError SendMessage(Message &aMessage) = 0;
 
     /**
-     * This virtual method returns a NULL-termianted string that names the network interface.
+     * This virtual method returns a NULL-terminated string that names the network interface.
      *
      * @returns A NULL-terminated string that names the network interface.
      *
@@ -359,7 +359,7 @@ public:
      * This virtual method performs a source-destination route lookup.
      *
      * @param[in]   aSource       A reference to the IPv6 source address.
-     * @param[in]   aDestination  A reference to the IPv6 destinationa ddress.
+     * @param[in]   aDestination  A reference to the IPv6 destination address.
      * @param[out]  aPrefixMatch  The longest prefix match result.
      *
      * @retval kThreadError_None     Successfully found a route.
@@ -398,7 +398,7 @@ public:
     static Netif *GetNetifByName(char *aName);
 
     /**
-     * This static method indicates whether or not @p aAddress is assigned to a network interfacfe.
+     * This static method indicates whether or not @p aAddress is assigned to a network interface.
      *
      * @param[in]  aAddress  A reference to the IPv6 address.
      *
@@ -423,7 +423,7 @@ public:
      *
      * @param[in]  aAddress  A reference to the IPv6 address.
      *
-     * @returns The network interafce identifier for the on-link interface or -1 if none is found.
+     * @returns The network interface identifier for the on-link interface or -1 if none is found.
      *
      */
     static int GetOnLinkNetif(const Address &aAddress);

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -96,7 +96,7 @@ public:
      * @param[in]  aMessage      The message to send.
      * @param[in]  aMessageInfo  The message info associated with @p aMessage.
      *
-     * @retval kThreadError_None    Successfully sent the UDP messag.
+     * @retval kThreadError_None    Successfully sent the UDP message.
      * @retval kThreadError_NoBufs  Insufficient available buffer to add the UDP and IPv6 headers.
      *
      */

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -120,7 +120,7 @@ public:
     /**
      * This method indicates whether the previous key is valid.
      *
-     * @retval TRUE   If the previous key is vaild.
+     * @retval TRUE   If the previous key is valid.
      * @retval FALSE  If the previous key is not valid.
      *
      */

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -508,7 +508,7 @@ public:
     const Ip6::Address *GetMeshLocal64(void) const;
 
     /**
-     * This method notifes MLE that the Network Data has changed.
+     * This method notifies MLE that the Network Data has changed.
      *
      */
     void HandleNetworkDataUpdate(void);
@@ -535,7 +535,7 @@ public:
     /**
      * This method returns the most recently received Leader Data TLV.
      *
-     * @returns  A reference to the most recently receievd Leader Data TLV.
+     * @returns  A reference to the most recently received Leader Data TLV.
      *
      */
     const LeaderDataTlv &GetLeaderDataTlv(void);
@@ -891,7 +891,7 @@ protected:
     /**
      * This method sets the Leader's Partition ID, Weighting, and Router ID values.
      *
-     * @param[in]  aPartitionId     The Leader's Parititon ID value.
+     * @param[in]  aPartitionId     The Leader's Partition ID value.
      * @param[in]  aWeighting       The Leader's Weighting value.
      * @param[in]  aLeaderRouterId  The Leader's Router ID value.
      *

--- a/src/core/thread/mle_constants.hpp
+++ b/src/core/thread/mle_constants.hpp
@@ -67,7 +67,7 @@ enum
 };
 
 /**
- * Routing Protocol Contstants
+ * Routing Protocol Constants
  *
  */
 enum

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -369,7 +369,7 @@ public:
     /**
      * This method sets the Response value.
      *
-     * @param[in]  aResponse  A pointer to the Respones value.
+     * @param[in]  aResponse  A pointer to the Response value.
      *
      */
     void SetResponse(const uint8_t *aResponse) { memcpy(mResponse, aResponse, GetLength()); }

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -229,7 +229,7 @@ protected:
      *
      * @param[in]  a        A pointer to the first IPv6 Prefix.
      * @param[in]  b        A pointer to the second IPv6 prefix.
-     * @param[in]  aLength  The aximum length in bits to compare.
+     * @param[in]  aLength  The maximum length in bits to compare.
      *
      * @returns The number of matching bits.
      *

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *   This file includes definitions for manipulating Thread Network Data maanged by the Thread Leader.
+ *   This file includes definitions for manipulating Thread Network Data managed by the Thread Leader.
  */
 
 #ifndef NETWORK_DATA_LEADER_HPP_
@@ -52,7 +52,7 @@ namespace NetworkData {
  * @addtogroup core-netdata-leader
  *
  * @brief
- *   This module includes definitions for manipulating Thread Network Data maanged by the Thread Leader.
+ *   This module includes definitions for manipulating Thread Network Data managed by the Thread Leader.
  *
  * @{
  *

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -124,7 +124,7 @@ public:
     /**
      * This method returns a pointer to the next Network Data TLV.
      *
-     * @returns A pointer to the next Newtork Data TLV.
+     * @returns A pointer to the next Network Data TLV.
      *
      */
     NetworkDataTlv *GetNext() {

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -71,7 +71,7 @@ public:
      */
     enum State
     {
-        kStateInvalid,                   ///< Neighbor link is invaild
+        kStateInvalid,                   ///< Neighbor link is invalid
         kStateParentRequest,             ///< Received an MLE Parent Request message
         kStateChildIdRequest,            ///< Received an MLE Child ID Request message
         kStateLinkRequest,               ///< Sent a MLE Link Request message
@@ -81,7 +81,7 @@ public:
     uint8_t mMode : 4;                   ///< The MLE device mode
     bool    mPreviousKey : 1;            ///< Indicates whether or not the neighbor is still using a previous key
     bool    mDataRequest : 1;            ///< Indicates whether or not a Data Poll was received
-    int8_t  mRssi;                       ///< Received Signal Strengh Indicator
+    int8_t  mRssi;                       ///< Received Signal Strength Indicator
 };
 
 /**


### PR DESCRIPTION
This commit fixes some typos in the header file comments. It contains no change in the code logic.
