### PR TITLE
Added CC2538 basic GPIO driver and LEDs functions

### DIFF
--- a/examples/cc2538/platform/Makefile.am
+++ b/examples/cc2538/platform/Makefile.am
@@ -43,12 +43,15 @@ libopenthread_cc2538_a_SOURCES            = \
     radio.c                                 \
     random.c                                \
     serial.c                                \
+    gpio.c                                  \
     startup-gcc.c                           \
     $(NULL)
 
 noinst_HEADERS                            = \
     cc2538-reg.h                            \
     platform.h                              \
+    leds.h                                  \
+    gpio.h                                  \
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/cc2538/platform/cc2538-reg.h
+++ b/examples/cc2538/platform/cc2538-reg.h
@@ -37,7 +37,9 @@
 
 #include <stdint.h>
 
-#define HWREG(x)                              (*((volatile uint32_t *)(x)))
+typedef volatile uint32_t cc2538_reg_t;
+
+#define HWREG(x)                              (*((cc2538_reg_t*)(x)))
 
 #define NVIC_ST_CTRL                          0xE000E010  // SysTick Control and Status
 #define NVIC_ST_RELOAD                        0xE000E014  // SysTick Reload Value Register
@@ -98,6 +100,11 @@
 #define SYS_CTRL_SYSDIV_32MHZ                 0x00000000  // Sys_div for sysclk 32MHz  
 #define SYS_CTRL_CLOCK_CTRL_AMP_DET           0x00200000
 
+#define SYS_CTRL_RCGCI2C                      0x400D2038  // I2C clocks - active mode
+#define SYS_CTRL_SCGCI2C                      0x400D203C  // I2C clocks - sleep mode
+#define SYS_CTRL_DCGCI2C                      0x400D2040  // I2C clocks - PM0
+#define SYS_CTRL_SRI2C                        0x400D2044  // I2C clocks - reset control
+
 #define SYS_CTRL_RCGCUART                     0x400D2028
 #define SYS_CTRL_SCGCUART                     0x400D202C
 #define SYS_CTRL_DCGCUART                     0x400D2030
@@ -123,11 +130,16 @@
 
 #define IOC_PA0_OVER                          0x400D4080
 #define IOC_PA1_OVER                          0x400D4084
+#define IOC_I2CMSSDA                          0x400D412C  // I2C SDA
+#define IOC_I2CMSSCL                          0x400D4130  // I2C SCL
 
 #define IOC_MUX_OUT_SEL_UART0_TXD             0x00000000
 
-#define IOC_OVERRIDE_OE                       0x00000008  // PAD Config Override Output Enable
 #define IOC_OVERRIDE_DIS                      0x00000000  // PAD Config Override Disabled
+#define IOC_OVERRIDE_ANA                      0x00000001
+#define IOC_OVERRIDE_PDE                      0x00000002
+#define IOC_OVERRIDE_PUE                      0x00000004
+#define IOC_OVERRIDE_OE                       0x00000008  // PAD Config Override Output Enable
 
 #define UART0_BASE                            0x4000C000
 #define GPIO_A_BASE                           0x400D9000  // GPIO

--- a/examples/cc2538/platform/gpio.c
+++ b/examples/cc2538/platform/gpio.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2016, Nest Labs, Inc.
+ *  Copyright (c) 2016, Zolertia
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -28,47 +28,27 @@
 
 /**
  * @file
- * @brief
- *   This file includes the platform-specific initializers.
+ *   This file implements a basic GPIO driver
+ *
  */
 
-#include <platform/serial.h>
-#include "platform.h"
-#include "leds.h"
+#include <stdbool.h>
+#include <stdint.h>
 
-static void PlatformLedsInit(void)
+#include "cc2538-reg.h"
+#include "gpio.h"
+
+static uint32_t *ioc_over;
+static uint32_t *ioc_sel;
+
+void cc2538GpioIocOver(uint8_t port, uint8_t pin, uint8_t over)
 {
-    cc2538GpioSoftwareControl(GPIO_D_NUM, LED0_PIN);
-    cc2538GpioSoftwareControl(GPIO_D_NUM, LED1_PIN);
-    cc2538GpioSoftwareControl(GPIO_D_NUM, LED2_PIN);
-
-    cc2538GpioDirOutput(GPIO_D_NUM, LED0_PIN);
-    cc2538GpioDirOutput(GPIO_D_NUM, LED1_PIN);
-    cc2538GpioDirOutput(GPIO_D_NUM, LED2_PIN);
-
-    cc2538GpioIocOver(GPIO_D_NUM, LED0_PIN, IOC_OVERRIDE_DIS);
-    cc2538GpioIocOver(GPIO_D_NUM, LED1_PIN, IOC_OVERRIDE_DIS);
-    cc2538GpioIocOver(GPIO_D_NUM, LED2_PIN, IOC_OVERRIDE_DIS);
-
-    LED_RAINBOW();
+    ioc_over = (uint32_t *)IOC_PA0_OVER;
+    ioc_over[(port << 3) + pin] = over;
 }
 
-void PlatformInit(void)
+void cc2538GpioIocSel(uint8_t port, uint8_t pin, uint8_t sel)
 {
-    PlatformAlarmInit();
-    PlatformRadioInit();
-    PlatformRandomInit();
-    otPlatSerialEnable();
-
-    // Specific platform initialization
-    PlatformLedsInit();
-}
-
-void PlatformProcessDrivers(void)
-{
-    // should sleep and wait for interrupts here
-
-    PlatformSerialProcess();
-    PlatformRadioProcess();
-    PlatformAlarmProcess();
+    ioc_sel = (uint32_t *)IOC_PA0_SEL;
+    ioc_sel[(port << 3) + pin] = sel;
 }

--- a/examples/cc2538/platform/gpio.h
+++ b/examples/cc2538/platform/gpio.h
@@ -1,0 +1,92 @@
+#ifndef GPIO_H
+#define GPIO_H
+
+#include <stdint.h>
+#include "cc2538-reg.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+enum {
+  GPIO_A_NUM = 0,
+  GPIO_B_NUM = 1,
+  GPIO_C_NUM = 2,
+  GPIO_D_NUM = 3,
+};
+
+// port dev
+#define GPIO_A_DEV              0x400d9000
+#define GPIO_B_DEV              0x400da000
+#define GPIO_C_DEV              0x400db000
+#define GPIO_D_DEV              0x400dc000
+
+// helper macros
+#define GPIO_PIN_MASK(n)        ( 1 << (n) )
+#define GPIO_PORT_TO_DEV(port)  (GPIO_A_DEV + ((port) << 12))
+
+// in/out control
+#define IOC_PXX_SEL             0x400d4000
+#define IOC_PXX_OVER            0x400d4080
+
+// peripheral select values
+#define IOC_SEL_UART0_TXD       (0)
+#define IOC_SEL_UART1_RTS       (1)
+#define IOC_SEL_UART1_TXD       (2)
+#define IOC_SEL_SSI0_TXD        (3)
+#define IOC_SEL_SSI0_CLKOUT     (4)
+#define IOC_SEL_SSI0_FSSOUT     (5)
+#define IOC_SEL_SSI0_STXSER_EN  (6)
+#define IOC_SEL_SSI1_TXD        (7)
+#define IOC_SEL_SSI1_CLKOUT     (8)
+#define IOC_SEL_SSI1_FSSOUT     (9)
+#define IOC_SEL_SSI1_STXSER_EN  (10)
+#define IOC_SEL_I2C_CMSSDA      (11)
+#define IOC_SEL_I2C_CMSSCL      (12)
+#define IOC_SEL_GPT0_ICP1       (13)
+#define IOC_SEL_GPT0_ICP2       (14)
+#define IOC_SEL_GPT1_ICP1       (15)
+#define IOC_SEL_GPT1_ICP2       (16)
+#define IOC_SEL_GPT2_ICP1       (17)
+#define IOC_SEL_GPT2_ICP2       (18)
+#define IOC_SEL_GPT3_ICP1       (19)
+#define IOC_SEL_GPT3_ICP2       (20)
+
+// GPIO offsets
+#define GPIO_DATA               0x00000000
+#define GPIO_DIR                0x00000400
+#define GPIO_IS                 0x00000404
+#define GPIO_IBE                0x00000408
+#define GPIO_IEV                0x0000040C
+#define GPIO_IE                 0x00000410
+#define GPIO_RIS                0x00000414
+#define GPIO_MIS                0x00000418
+#define GPIO_IC                 0x0000041C
+#define GPIO_AFSEL              0x00000420
+#define GPIO_GPIOLOCK           0x00000520
+#define GPIO_GPIOCR             0x00000524
+#define GPIO_PMUX               0x00000700
+#define GPIO_P_EDGE_CTRL        0x00000704
+#define GPIO_USB_CTRL           0x00000708
+#define GPIO_PI_IEN             0x00000710
+#define GPIO_IRQ_DETECT_ACK     0x00000718
+#define GPIO_USB_IRQ_ACK        0x0000071C
+#define GPIO_IRQ_DETECT_UNMASK  0x00000720
+
+// GPIO macros
+#define cc2538GpioHardwareControl(port_num, pin_num) ( HWREG(GPIO_PORT_TO_DEV(port_num) + GPIO_AFSEL) |= GPIO_PIN_MASK(pin_num) )
+#define cc2538GpioSoftwareControl(port_num, pin_num) ( HWREG(GPIO_PORT_TO_DEV(port_num) + GPIO_AFSEL) &= ~GPIO_PIN_MASK(pin_num) )
+#define cc2538GpioDirOutput(port_num, pin_num)       ( HWREG(GPIO_PORT_TO_DEV(port_num) + GPIO_DIR) |= GPIO_PIN_MASK(pin_num) )
+#define cc2538GpioDirInput(port_num, pin_num)        ( HWREG(GPIO_PORT_TO_DEV(port_num) + GPIO_DIR) &= ~GPIO_PIN_MASK(pin_num) )
+#define cc2538GpioReadPin(port_num, pin_num)         ( HWREG(GPIO_PORT_TO_DEV(port_num) + GPIO_DATA + (GPIO_PIN_MASK(pin_num) << 2)) )
+#define cc2538GpioSetPin(port_num, pin_num)          ( HWREG(GPIO_PORT_TO_DEV(port_num) + GPIO_DATA + (GPIO_PIN_MASK(pin_num) << 2)) = 0xFF )
+#define cc2538GpioClearPin(port_num, pin_num)        ( HWREG(GPIO_PORT_TO_DEV(port_num) + GPIO_DATA + (GPIO_PIN_MASK(pin_num) << 2)) = 0x00 )
+
+// IOC functions
+void cc2538GpioIocOver(uint8_t port, uint8_t pin, uint8_t over);
+void cc2538GpioIocSel(uint8_t port, uint8_t pin, uint8_t sel);
+
+#ifdef __cplusplus
+} // end extern "C"
+#endif
+#endif // GPIO_H_

--- a/examples/cc2538/platform/leds.h
+++ b/examples/cc2538/platform/leds.h
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (c) 2016, Nest Labs, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements support for the Zolertia RE-Mote RGB LEDs
+ *
+ */
+
+#ifndef LEDS_H
+#define LEDS_H
+
+#include "gpio.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#define LED0_PIN        5
+#define LED1_PIN        4
+#define LED2_PIN        3
+
+#define LED0_ON         cc2538GpioSetPin(GPIO_D_NUM, LED0_PIN)
+#define LED0_OFF        cc2538GpioClearPin(GPIO_D_NUM, LED0_PIN)
+
+#define LED1_ON         cc2538GpioSetPin(GPIO_D_NUM, LED1_PIN)
+#define LED1_OFF        cc2538GpioClearPin(GPIO_D_NUM, LED1_PIN)
+
+#define LED2_ON         cc2538GpioSetPin(GPIO_D_NUM, LED2_PIN)
+#define LED2_OFF        cc2538GpioClearPin(GPIO_D_NUM, LED2_PIN)
+
+#define LED_ALL_OFF     LED0_OFF;   \
+                        LED1_OFF;   \
+                        LED2_OFF
+
+// White
+#define LED_ALL_ON      LED0_ON;    \
+                        LED1_ON;    \
+                        LED2_ON
+
+// Yellow
+#define LED3_ON         LED2_OFF;    \
+                        LED0_ON;     \
+                        LED1_ON
+#define LED3_OFF        LED1_OFF;    \
+                        LED0_OFF
+
+// Purple
+#define LED4_ON         LED1_OFF;     \
+                        LED2_ON;      \
+                        LED0_ON
+#define LED4_OFF        LED2_OFF;     \
+                        LED0_OFF
+
+// Take LED_COLOR as argument, i.e LED0
+#define LED_FADE(led)                         \
+  volatile int i;                             \
+  int k, j;                                   \
+  LED_FADE_EXPAND(led)
+
+#define LED_FADE_EXPAND(led)                  \
+  for(k = 0; k < 800; ++k) {                  \
+    j = k > 400 ? 800 - k : k;                \
+    led##_ON;                                 \
+    for(i = 0; i < j; ++i) {                  \
+      asm("nop");                             \
+    }                                         \
+    led##_OFF;                                \
+    for(i = 0; i < 400 - j; ++i) {            \
+      asm("nop");                             \
+    }                                         \
+  }
+
+#define LED_RAINBOW()                         \
+  volatile int i;                             \
+  int k,j;                                    \
+  LED_FADE_EXPAND(LED3);                      \
+  LED_FADE_EXPAND(LED0);                      \
+  LED_FADE_EXPAND(LED4);                      \
+  LED_FADE_EXPAND(LED2);                      \
+  LED_FADE_EXPAND(LED1);
+
+#ifdef __cplusplus
+} // end extern "C"
+#endif
+#endif // LEDS_H_
+

--- a/examples/cc2538/platform/startup-gcc.c
+++ b/examples/cc2538/platform/startup-gcc.c
@@ -66,8 +66,8 @@ void (*const vectors[])(void) =
 {
     (void (*)(void))((unsigned long)stack + sizeof(stack)),   // Initial Stack Pointer
     ResetHandler,                           // 1 The reset handler
-    ResetHandler,                       // 2 The NMI handler
-    IntDefaultHandler,                     // 3 The hard fault handler
+    ResetHandler,                           // 2 The NMI handler
+    IntDefaultHandler,                      // 3 The hard fault handler
     IntDefaultHandler,                      // 4 The MPU fault handler
     IntDefaultHandler,                      // 5 The bus fault handler
     IntDefaultHandler,                      // 6 The usage fault handler


### PR DESCRIPTION
This PR adds a basic GPIO driver and LEDs functions to the CC2538-based platforms.

This was tested on the [Zolertia RE-Mote](https://github.com/Zolertia/Resources/wiki/RE-Mote) platform, which features an on-board RGB LED.  The pin-out on the `leds.h` corresponds to the `RE-Mote`, but can be easily changed for the `cc2538dk`.

I will prepare a next PR to separate platform-specific from the cc2538-base implementation, in the meantime do you have any suggestion about the approach to follow?