### PR TITLE
fix RFD child reattach issue when the parent is in new partition

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -907,6 +907,7 @@ protected:
     NetworkData::Leader &mNetworkData;      ///< The Network Data object.
 
     LeaderDataTlv mLeaderData;              ///< Last received Leader Data TLV.
+    bool mRetrieveNewNetworkData;           ///< Indicating new Network Data is needed if set.
 
     DeviceState mDeviceState;               ///< Current Thread interface state.
     Router mParent;                         ///< Parent information.


### PR DESCRIPTION
RFD child should keep attached to its parent when the parent forms/joins a new partition without changing routerid - new round of attach process should be avoided

Besides, choose a random initial mRouterIdSequence when forming a new partition as the spec says.

@jwhui would you please help to review it?