### PR TITLE
Fix extPanId size in NCP scan result packet

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -342,7 +342,7 @@ void NcpBase::HandleActiveScanResult(otActiveScanResult *result)
             SPINEL_PROTOCOL_TYPE_THREAD,
             flags,
             result->mNetworkName,
-            result->mExtPanId, Thread::Mac::Beacon::kExtPanIdSize
+            result->mExtPanId, OT_EXT_PAN_ID_SIZE
         );
     }
     else

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -342,7 +342,7 @@ void NcpBase::HandleActiveScanResult(otActiveScanResult *result)
             SPINEL_PROTOCOL_TYPE_THREAD,
             flags,
             result->mNetworkName,
-            result->mExtPanId, sizeof(result->mExtPanId)
+            result->mExtPanId, Thread::Mac::Beacon::kExtPanIdSize
         );
     }
     else


### PR DESCRIPTION
wpantund scan result handler expects extPanId size to be 0 or 8. If not
- it stops scan result handling. Because mExtPanId is a pointer, it's
size is architecture dependent, and scanning (by chance) works only on
64bit machines. extPanId size should be (is) a constant.