### PR TITLE
fill mChannel field of received mac frame for cc2538

### DIFF
--- a/examples/cc2538/platform/radio.c
+++ b/examples/cc2538/platform/radio.c
@@ -239,6 +239,7 @@ ThreadError otPlatRadioReceive(uint8_t aChannel)
     sState = kStateListen;
 
     setChannel(aChannel);
+    sReceiveFrame.mChannel = aChannel;
     enableReceiver();
 
 exit:


### PR DESCRIPTION
fix invalid channel in scan results
@jwhui , please have a review.