### PR TITLE
Change executable names for examples to `ot-cli` and `ot-ncp`.

### DIFF
--- a/examples/cc2538/app/cli/Makefile.am
+++ b/examples/cc2538/app/cli/Makefile.am
@@ -28,27 +28,27 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-bin_PROGRAMS = soc
+bin_PROGRAMS                                                      = \
+    ot-cli                                                          \
+    $(NULL)
 
-soc_CPPFLAGS                                                      = \
+ot_cli_CPPFLAGS                                                   = \
     -I$(top_srcdir)/include                                         \
-    -I$(top_srcdir)/src                                             \
-    -I$(top_srcdir)/src/core                                        \
     -I$(top_srcdir)/examples/cc2538/platform                        \
     $(NULL)
 
-soc_LDADD                                                         = \
+ot_cli_LDADD                                                      = \
     $(top_builddir)/src/core/libopenthread.a                        \
     $(top_builddir)/src/cli/libopenthread-cli.a                     \
     $(top_builddir)/examples/cc2538/platform/libopenthread-cc2538.a \
     $(top_builddir)/third_party/mbedtls/libmbedcrypto.a             \
     $(NULL)
 
-soc_LDFLAGS                                                       = \
+ot_cli_LDFLAGS                                                    = \
     -T $(top_srcdir)/examples/cc2538/platform/cc2538.ld             \
     $(NULL)
 
-soc_SOURCES                                                       = \
+ot_cli_SOURCES                                                    = \
     main.c                                                          \
     $(NULL)
 

--- a/examples/cc2538/app/ncp/Makefile.am
+++ b/examples/cc2538/app/ncp/Makefile.am
@@ -28,27 +28,27 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-bin_PROGRAMS = ncp
+bin_PROGRAMS                                                      = \
+    ot-ncp                                                          \
+    $(NULL)
 
-ncp_CPPFLAGS                                                      = \
+ot_ncp_CPPFLAGS                                                   = \
     -I$(top_srcdir)/include                                         \
-    -I$(top_srcdir)/src                                             \
-    -I$(top_srcdir)/src/core                                        \
     -I$(top_srcdir)/examples/cc2538/platform                        \
     $(NULL)
 
-ncp_LDADD                                                         = \
+ot_ncp_LDADD                                                      = \
     $(top_builddir)/src/ncp/libopenthread-ncp.a                     \
     $(top_builddir)/src/core/libopenthread.a                        \
     $(top_builddir)/examples/cc2538/platform/libopenthread-cc2538.a \
     $(top_builddir)/third_party/mbedtls/libmbedcrypto.a             \
     $(NULL)
 
-ncp_LDFLAGS                                                       = \
+ot_ncp_LDFLAGS                                                    = \
     -T $(top_srcdir)/examples/cc2538/platform/cc2538.ld             \
     $(NULL)
 
-ncp_SOURCES                                                       = \
+ot_ncp_SOURCES                                                    = \
     main.c                                                          \
     $(NULL)
 

--- a/examples/posix/app/cli/Makefile.am
+++ b/examples/posix/app/cli/Makefile.am
@@ -28,26 +28,25 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-bin_PROGRAMS = soc
-
-soc_CPPFLAGS                                                   = \
-    -I$(top_srcdir)/include                                      \
-    -I$(top_srcdir)/src                                          \
-    -I$(top_srcdir)/src/core                                     \
-    -I$(top_srcdir)/examples/posix/platform                      \
-    $(OPENTHREAD_TARGET_DEFINES)                                 \
+bin_PROGRAMS                                                    = \
+    ot-cli                                                        \
     $(NULL)
 
-soc_LDADD                                                      =  \
+ot_cli_CPPFLAGS                                                 = \
+    -I$(top_srcdir)/include                                       \
+    -I$(top_srcdir)/examples/posix/platform                       \
+    $(NULL)
+
+ot_cli_LDADD                                                   =  \
     $(top_builddir)/src/core/libopenthread.a                      \
     $(top_builddir)/src/cli/libopenthread-cli.a                   \
     $(top_builddir)/examples/posix/platform/libopenthread-posix.a \
     $(top_builddir)/third_party/mbedtls/libmbedcrypto.a           \
-    -lstdc++                                                         \
+    -lstdc++                                                      \
     $(NULL)
 
-soc_SOURCES                                                    = \
-    main.c                                                       \
+ot_cli_SOURCES                                                  = \
+    main.c                                                        \
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/posix/app/cli/README.md
+++ b/examples/posix/app/cli/README.md
@@ -21,7 +21,7 @@ Spawn the process:
 
 ```bash
 $ cd openthread/examples/posix/app/cli
-$ ./soc 1
+$ ./ot-cli 1
 ```
 
 Start OpenThread:
@@ -56,7 +56,7 @@ Spawn the process:
 
 ```bash
 $ cd openthread/examples/posix/app/cli
-$ ./soc 2
+$ ./ot-cli 2
 ```
 
 Start OpenThread:

--- a/examples/posix/app/ncp/Makefile.am
+++ b/examples/posix/app/ncp/Makefile.am
@@ -28,18 +28,16 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-bin_PROGRAMS = ncp
-
-ncp_CPPFLAGS                                                   = \
-    -I$(top_srcdir)/include                                      \
-    -I$(top_srcdir)/src                                          \
-    -I$(top_srcdir)/src/core                                     \
-    -I$(top_srcdir)/examples/posix/platform                      \
-    -I$(top_srcdir)/third_party                                  \
-    $(OPENTHREAD_TARGET_DEFINES)                                 \
+bin_PROGRAMS                                                    = \
+    ot-ncp                                                        \
     $(NULL)
 
-ncp_LDADD                                                       = \
+ot_ncp_CPPFLAGS                                                 = \
+    -I$(top_srcdir)/include                                       \
+    -I$(top_srcdir)/examples/posix/platform                       \
+    $(NULL)
+
+ot_ncp_LDADD                                                    = \
     $(top_builddir)/src/ncp/libopenthread-ncp.a                   \
     $(top_builddir)/src/core/libopenthread.a                      \
     $(top_builddir)/examples/posix/platform/libopenthread-posix.a \
@@ -47,7 +45,7 @@ ncp_LDADD                                                       = \
     -lstdc++                                                      \
     $(NULL)
 
-ncp_SOURCES                                                     = \
+ot_ncp_SOURCES                                                  = \
     main.c                                                        \
     $(NULL)
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -102,11 +102,13 @@ Mle::Mle(ThreadNetif &aThreadNetif) :
     memcpy(mMeshLocal64.GetAddress().m8 + 1, mMac.GetExtendedPanId(), 5);
     mMeshLocal64.GetAddress().m8[6] = 0x00;
     mMeshLocal64.GetAddress().m8[7] = 0x00;
+
     // mesh-local 64
     for (int i = 8; i < 16; i++)
     {
         mMeshLocal64.GetAddress().m8[i] = otPlatRandomGet();
     }
+
     mMeshLocal64.mPrefixLength = 64;
     mMeshLocal64.mPreferredLifetime = 0xffffffff;
     mMeshLocal64.mValidLifetime = 0xffffffff;

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -54,9 +54,9 @@ class Node:
         """ Initialize a simulation node. """
         if "top_builddir" in os.environ.keys():
             srcdir = os.environ['top_builddir']
-            cmd = '%s/examples/posix/app/cli/soc' % srcdir
+            cmd = '%s/examples/posix/app/cli/ot-cli' % srcdir
         else:
-            cmd = './soc'
+            cmd = './ot-cli'
         cmd += ' %d' % nodeid
         print cmd
 


### PR DESCRIPTION
This is a fix for #158.