### PR TITLE
fix reset mle advertise timer

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -423,17 +423,14 @@ ThreadError MleRouter::ResetAdvertiseInterval(void)
 {
     uint32_t advertiseDelay;
 
-    VerifyOrExit(mAdvertiseInterval != kAdvertiseIntervalMin || !mAdvertiseTimer.IsRunning(), ;);
-
+    mAdvertiseTimer.Stop();
     mAdvertiseInterval = kAdvertiseIntervalMin;
-
     advertiseDelay = Timer::SecToMsec(mAdvertiseInterval) / 2;
     advertiseDelay += otPlatRandomGet() % advertiseDelay;
     mAdvertiseTimer.Start(advertiseDelay);
 
     otLogInfoMle("reset advertise interval\n");
 
-exit:
     return kThreadError_None;
 }
 


### PR DESCRIPTION
MLE Advertisement Trickle Timer would not be reset, if it were running.