### PR TITLE
set neighbor state to invalid while the neighbor's router id has been released

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -102,11 +102,13 @@ Mle::Mle(ThreadNetif &aThreadNetif) :
     memcpy(mMeshLocal64.GetAddress().m8 + 1, mMac.GetExtendedPanId(), 5);
     mMeshLocal64.GetAddress().m8[6] = 0x00;
     mMeshLocal64.GetAddress().m8[7] = 0x00;
+
     // mesh-local 64
     for (int i = 8; i < 16; i++)
     {
         mMeshLocal64.GetAddress().m8[i] = otPlatRandomGet();
     }
+
     mMeshLocal64.mPrefixLength = 64;
     mMeshLocal64.mPreferredLifetime = 0xffffffff;
     mMeshLocal64.mValidLifetime = 0xffffffff;

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1042,6 +1042,12 @@ ThreadError MleRouter::ProcessRouteTlv(const RouteTlv &aRoute)
         mRouterIdSequence = aRoute.GetRouterIdSequence();
         mRouterIdSequenceLastUpdated = Timer::GetNow();
 
+        if (GetDeviceState() == kDeviceStateRouter && !mRouters[mRouterId].mAllocated)
+        {
+            BecomeDetached();
+            ExitNow(error = kThreadError_NoRoute);
+        }
+
         for (int i = 0; i < kMaxRouterId; i++)
         {
             old = mRouters[i].mAllocated;
@@ -1050,16 +1056,10 @@ ThreadError MleRouter::ProcessRouteTlv(const RouteTlv &aRoute)
             if (old && !mRouters[i].mAllocated)
             {
                 mRouters[i].mNextHop = kMaxRouterId;
+                mRouters[i].mState = Neighbor::kStateInvalid;
                 mAddressResolver.Remove(i);
             }
         }
-
-        if (GetDeviceState() == kDeviceStateRouter && !mRouters[mRouterId].mAllocated)
-        {
-            BecomeDetached();
-            ExitNow(error = kThreadError_NoRoute);
-        }
-
     }
 
 exit:


### PR DESCRIPTION
- To my understanding, we do not need to process each router states, if the router detaches. So I move the become detach logic to the front.
- If the router id has been released,  the corresponding router's routing table has been cleared. I think that this node's neighbor state needs to be updated including the link state, once the node reattaches. So I think that we also need to set the neighbor state to kStateInvalid, not only indicates that the router is unreachable.
@jwhui , please correct me, if my understanding is wrong.