### PR TITLE
Dequeue sender from the sender's queue

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -669,6 +669,8 @@ void Mac::SentFrame(bool aAcked)
             mSendTail = NULL;
         }
 
+        sender->mNext = NULL;
+
         mDataSequence++;
         sender->HandleSentFrame(sendFrame);
 


### PR DESCRIPTION
Though we only have mesh_forwarder as the MAC's sender, it needs to dequeue it from the queue.