### PR TITLE
Free buffer while no route

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -414,7 +414,7 @@ ThreadError Ip6::HandleDatagram(Message &message, Netif *netif, uint8_t interfac
 
 exit:
 
-    if (error == kThreadError_Drop)
+    if ((error == kThreadError_Drop) || (error == kThreadError_NoRoute))
     {
         Message::Free(message);
     }


### PR DESCRIPTION
ForwardMessage would not enqueue the message, if there is no route. We also need to free the buffer in this case.