### PR TITLE
spinel: Add mechanism to avoid using `errno` variable.

### DIFF
--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -48,11 +48,21 @@
 #include <assert.h>
 #include <string.h>
 #include <stdarg.h>
-#include <errno.h>
 #include <stdlib.h>
+#include <errno.h>
 
 // ----------------------------------------------------------------------------
 // MARK: -
+
+#if defined(errno) && SPINEL_PLATFORM_DOESNT_IMPLEMENT_ERRNO_VAR
+#error SPINEL_PLATFORM_DOESNT_IMPLEMENT_ERRNO_VAR is set but errno is already defined.
+#endif
+
+// Work-around for platforms that don't implement the `errno` variable.
+#if !defined(errno) && SPINEL_PLATFORM_DOESNT_IMPLEMENT_ERRNO_VAR
+static int spinel_errno_workaround_;
+#define errno spinel_errno_workaround_
+#endif // SPINEL_PLATFORM_DOESNT_IMPLEMENT_ERRNO_VAR
 
 #ifndef assert_printf
 #define assert_printf(fmt, ...) \


### PR DESCRIPTION
Some platforms do not implement the `errno` variable. This change
allows Spinel to work properly on those platforms.

To allow Spinel to build on those platforms, build Spinel with
the following command line argument:

    -DSPINEL_PLATFORM_DOESNT_IMPLEMENT_ERRNO_VAR=1