### PR TITLE
ncp-spinel: Remove include <sys/types.h>

### DIFF
--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -32,7 +32,6 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <sys/types.h>
 
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
This commit addresses issue #191.

This file was being included for `size_t`, but this header is not available
on IAR platforms. We can generally get `size_t` from including stdio.h.