### PR TITLE
examples: Fix bug in reading IEEE 802.15.4 Extended Address from a MAC header.

### DIFF
--- a/examples/posix/platform/radio.c
+++ b/examples/posix/platform/radio.c
@@ -259,9 +259,9 @@ static inline void getExtAddress(const uint8_t *frame, otExtAddress *address)
 {
     size_t i;
 
-    for (i = 0; i < sizeof(address); i++)
+    for (i = 0; i < sizeof(otExtAddress); i++)
     {
-        address->m8[i] = frame[IEEE802154_DSTADDR_OFFSET + (7 - i)];
+        address->m8[i] = frame[IEEE802154_DSTADDR_OFFSET + (sizeof(otExtAddress) - 1 - i)];
     }
 }
 


### PR DESCRIPTION
This is a fix for #200.