### PR TITLE
NcpBase: Fix the model for adding/removing IPv6 addresses.

### DIFF
--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -285,6 +285,11 @@ private:
                                                       uint16_t value_len);
 
 private:
+    enum
+    {
+        kNetifAddressListSize = 8,           // Size of mNetifAddresses array.
+        kUnusedNetifAddressPrefixLen = 0xff, // Prefix len value to indicate an unused/available NetifAddress element.
+    };
 
     spinel_status_t mLastStatus;
 
@@ -303,6 +308,8 @@ private:
     MessageQueue mSendQueue;
 
     uint32_t mChangedFlags;
+
+    otNetifAddress mNetifAddresses[kNetifAddressListSize];
 
 protected:
     /**


### PR DESCRIPTION
This change addresses issue #204 by adding an array of elements of type `otNetifAddress` to `NcpBase` class. The array elements are then used for adding/removing of Ipv6 addresses.
