### PR TITLE
rx-on-when-idle End Devices should be capable of sending Link Request

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1419,7 +1419,7 @@ ThreadError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::Message
 
     otLogInfoMle("Received advertisement from %04x\n", sourceAddress.GetRloc16());
 
-    if ((mDeviceState != kDeviceStateDetached) && (mDeviceMode & ModeTlv::kModeFFD))
+    if (mDeviceState != kDeviceStateDetached)
     {
         SuccessOrExit(error = mMleRouter.HandleAdvertisement(aMessage, aMessageInfo));
     }
@@ -1440,19 +1440,12 @@ ThreadError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::Message
             break;
         }
 
-        if (mParent.mValid.mRloc16 != sourceAddress.GetRloc16())
+        if ((mParent.mValid.mRloc16 == sourceAddress.GetRloc16()) &&
+            (leaderData.GetPartitionId() != mLeaderData.GetPartitionId() ||
+             leaderData.GetLeaderRouterId() != GetLeaderId()))
         {
-            SetStateDetached();
-            ExitNow(error = kThreadError_NoRoute);
-        }
-        else
-        {
-            if (leaderData.GetPartitionId() != mLeaderData.GetPartitionId() ||
-                leaderData.GetLeaderRouterId() != GetLeaderId())
-            {
-                SetLeaderData(leaderData.GetPartitionId(), leaderData.GetWeighting(), leaderData.GetLeaderRouterId());
-                mRetrieveNewNetworkData = true;
-            }
+            SetLeaderData(leaderData.GetPartitionId(), leaderData.GetWeighting(), leaderData.GetLeaderRouterId());
+            mRetrieveNewNetworkData = true;
         }
 
         isNeighbor = true;


### PR DESCRIPTION
REEDs or rx-on-when-idle End Devices should attempt to maintain one-way synchronization with neighboring routers from which incoming MLE advertisements are from as described in spec 4.7.7.4.

Hi @jwhui , sorry for not noticing this part when fixing child's stay attach issue in PR#161 and please help to review this patch.
