### PR TITLE
Cover all python test scripts by partitioning across different build instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,19 +44,19 @@ matrix:
     - env: BUILD_TARGET="scan-build"
       compiler: clang
       os: linux
-    - env: BUILD_TARGET="posix"
+    - env: BUILD_TARGET="posix" DISTCHECK_CONFIGURE_FLAGS="--with-examples=posix --enable-cli --enable-ncp --with-tests=subset1"
       compiler: clang
       os: linux
-    - env: BUILD_TARGET="posix"
+    - env: BUILD_TARGET="posix" DISTCHECK_CONFIGURE_FLAGS="--with-examples=posix --enable-cli --enable-ncp --with-tests=subset2"
       compiler: clang
       os: osx
-    - env: BUILD_TARGET="posix"
+    - env: BUILD_TARGET="posix" DISTCHECK_CONFIGURE_FLAGS="--with-examples=posix --enable-cli --enable-ncp --with-tests=subset3"
       compiler: gcc
       os: linux
-    - env: BUILD_TARGET="posix"
+    - env: BUILD_TARGET="posix" DISTCHECK_CONFIGURE_FLAGS="--with-examples=posix --enable-cli --enable-ncp --with-tests=subset4"
       compiler: gcc
       os: osx
-    - env: BUILD_TARGET="posix-32-bit"
+    - env: BUILD_TARGET="posix-32-bit" DISTCHECK_CONFIGURE_FLAGS="--with-examples=posix --enable-cli --enable-ncp --with-tests=subset5"
       compiler: gcc
       os: linux
     - env: BUILD_TARGET="cc2538"

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,6 @@ AM_DISTCHECK_CONFIGURE_FLAGS        = \
     --enable-cli                      \
     --enable-ncp                      \
     --with-examples=posix             \
-    --enable-minimum-set-of-tests     \
     $(NULL)
 
 SUBDIRS                             = \

--- a/configure.ac
+++ b/configure.ac
@@ -286,32 +286,59 @@ AM_CONDITIONAL([OPENTHREAD_BUILD_TESTS], [test "${nl_cv_build_tests}" = "yes"])
 
 # Check whether to run only the minimum set of tests.
 
-AC_MSG_CHECKING([whether to run only the minimum set of tests.])
-AC_ARG_ENABLE(minimum-set-of-tests,
-    [AS_HELP_STRING([--enable-minimum-set-of-tests],[Run only the most essential tests. @<:@default=no@:>@.])],
+AC_ARG_WITH(tests,
+    [AS_HELP_STRING([--with-tests=TESTS],
+        [Specify the tests from one of: all, subset1, subset2, subset3, subset4, subset5 @<:@default=all@:>@.])],
     [
-        case "${enableval}" in
+        case "${with_tests}" in
 
-        no|yes)
-            enable_minimum_set_of_tests=${enableval}
+        all|subset1|subset2|subset3|subset4|subset5)
             ;;
-
         *)
-            AC_MSG_ERROR([Invalid value ${enableval} for --enable-minimum-set-of-tests])
+            AC_MSG_ERROR([Invalid value ${with_tests} for --with-tests])
             ;;
-
         esac
     ],
-    [enable_minimum_set_of_tests=no])
-AC_MSG_RESULT(${enable_minimum_set_of_tests})
+    [with_tests=all])
 
-AM_CONDITIONAL([OPENTHREAD_WITH_MINIMUM_SET_OF_TESTS], [test "${enable_minimum_set_of_tests}" = "yes"])
+case ${with_tests} in
 
-if test "${enable_minimum_set_of_tests}" = "yes"; then
-    if test "${nl_cv_build_coverage}" = "yes"; then
-        AC_MSG_ERROR(["Do not run code coverage only with the minimum set of tests."])
-    fi
-fi
+    all)
+        OPENTHREAD_TESTS_SUBSET1=yes
+        OPENTHREAD_TESTS_SUBSET2=yes
+        OPENTHREAD_TESTS_SUBSET3=yes
+        OPENTHREAD_TESTS_SUBSET4=yes
+        OPENTHREAD_TESTS_SUBSET5=yes
+        ;;
+
+    subset1)
+        OPENTHREAD_TESTS_SUBSET1=yes
+        ;;
+
+    subset2)
+        OPENTHREAD_TESTS_SUBSET2=yes
+        ;;
+
+    subset3)
+        OPENTHREAD_TESTS_SUBSET3=yes
+        ;;
+
+    subset4)
+        OPENTHREAD_TESTS_SUBSET4=yes
+        ;;
+
+    subset5)
+        OPENTHREAD_TESTS_SUBSET5=yes
+        ;;
+
+esac
+
+AC_SUBST(OPENTHREAD_TESTS_SUBSET1)
+AM_CONDITIONAL([OPENTHREAD_TESTS_SUBSET1], [test "${OPENTHREAD_TESTS_SUBSET1}" = "yes"])
+AM_CONDITIONAL([OPENTHREAD_TESTS_SUBSET2], [test "${OPENTHREAD_TESTS_SUBSET2}" = "yes"])
+AM_CONDITIONAL([OPENTHREAD_TESTS_SUBSET3], [test "${OPENTHREAD_TESTS_SUBSET3}" = "yes"])
+AM_CONDITIONAL([OPENTHREAD_TESTS_SUBSET4], [test "${OPENTHREAD_TESTS_SUBSET4}" = "yes"])
+AM_CONDITIONAL([OPENTHREAD_TESTS_SUBSET5], [test "${OPENTHREAD_TESTS_SUBSET5}" = "yes"])
 
 # Check for Python and Python libraries used in the tests
 if test "${nl_cv_build_tests}" = "yes"; then
@@ -572,7 +599,7 @@ AC_MSG_NOTICE([
   Genhtml                                   : ${GENHTML:--}
   Build tests                               : ${nl_cv_build_tests}
   Build tools                               : ${build_tools}
-  Minimum set of tests                      : ${enable_minimum_set_of_tests}
+  OpenThread tests                          : ${with_tests}
   Prefix                                    : ${prefix}
   Documentation support                     : ${nl_cv_build_docs}
   Doxygen                                   : ${DOXYGEN:--}

--- a/tests/scripts/Makefile.am
+++ b/tests/scripts/Makefile.am
@@ -54,6 +54,7 @@ EXTRA_DIST                                                         = \
     thread-cert/Cert_5_3_04_AddressMapCache.py                       \
     thread-cert/Cert_5_3_05_RoutingLinkQuality.py                    \
     thread-cert/Cert_5_3_06_RouterIdMask.py                          \
+    thread-cert/Cert_5_3_06b_RouterIdMask.py                         \
     thread-cert/Cert_5_3_07_DuplicateAddress.py                      \
     thread-cert/Cert_5_3_08_ChildAddressSet.py                       \
     thread-cert/Cert_5_3_10_AddressQuery.py                          \
@@ -109,25 +110,78 @@ if OPENTHREAD_BUILD_TESTS
 check_PROGRAMS =
 
 check_SCRIPTS                                                      = \
+    $(NULL)
+
+if OPENTHREAD_TESTS_SUBSET1
+
+check_SCRIPTS                                                     += \
     thread-cert/Cert_5_1_01_RouterAttach.py                          \
     thread-cert/Cert_5_1_02_ChildAddressTimeout.py                   \
     thread-cert/Cert_5_1_03_RouterAddressReallocation.py             \
+    thread-cert/Cert_5_1_04_RouterAddressReallocation.py             \
+    thread-cert/Cert_5_1_05_RouterAddressTimeout.py                  \
     thread-cert/Cert_5_1_06_RemoveRouterId.py                        \
+    thread-cert/Cert_5_1_07_MaxChildCount.py                         \
     thread-cert/Cert_5_1_08_RouterAttachConnectivity.py              \
     thread-cert/Cert_5_1_09_REEDAttachConnectivity.py                \
+    $(NULL)
+
+endif # OPENTHREAD_TESTS_SUBSET1
+
+if OPENTHREAD_TESTS_SUBSET2
+
+check_SCRIPTS                                                     += \
     thread-cert/Cert_5_1_10_RouterAttachLinkQuality.py               \
     thread-cert/Cert_5_1_11_REEDAttachLinkQuality.py                 \
     thread-cert/Cert_5_1_12_NewRouterNeighborSync.py                 \
     thread-cert/Cert_5_1_13_RouterReset.py                           \
     thread-cert/Cert_5_2_01_BecomeActiveRouter.py                    \
+    thread-cert/Cert_5_2_02_LeaderReject1Hop.py                      \
+    thread-cert/Cert_5_2_03_LeaderReject2Hops.py                     \
+    thread-cert/Cert_5_2_04_REEDUpgrade.py                           \
     thread-cert/Cert_5_2_05_AddressQuery.py                          \
     thread-cert/Cert_5_2_07_REEDSynchronization.py                   \
     thread-cert/Cert_5_3_01_LinkLocal.py                             \
+    thread-cert/Cert_5_3_02_RealmLocal.py                            \
+    thread-cert/Cert_5_3_03_AddressQuery.py                          \
+    thread-cert/Cert_5_3_04_AddressMapCache.py                       \
+    thread-cert/Cert_5_3_05_RoutingLinkQuality.py                    \
+    $(NULL)
+
+endif # OPENTHREAD_TESTS_SUBSET2
+
+if OPENTHREAD_TESTS_SUBSET3
+
+check_SCRIPTS                                                     += \
+    thread-cert/Cert_5_3_06_RouterIdMask.py                          \
+    thread-cert/Cert_5_3_06b_RouterIdMask.py                         \
     thread-cert/Cert_5_3_07_DuplicateAddress.py                      \
     thread-cert/Cert_5_3_08_ChildAddressSet.py                       \
+    thread-cert/Cert_5_3_10_AddressQuery.py                          \
     thread-cert/Cert_5_5_01_LeaderReset.py                           \
+    thread-cert/Cert_5_5_02_LeaderReboot.py                          \
+    $(NULL)
+
+endif # OPENTHREAD_TESTS_SUBSET3
+
+if OPENTHREAD_TESTS_SUBSET4
+
+check_SCRIPTS                                                     += \
+    thread-cert/Cert_5_5_03_SplitMergeChildren.py                    \
+    thread-cert/Cert_5_5_04_SplitMergeRouters.py                     \
+    thread-cert/Cert_5_5_05_SplitMergeREED.py                        \
+    thread-cert/Cert_5_5_06_SplitWeight.py                           \
+    thread-cert/Cert_5_5_07_SplitMergeThreeWay.py                    \
+    thread-cert/Cert_5_5_08_SplitRoutersLostLeader.py                \
     thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py \
     thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py \
+    $(NULL)
+
+endif # OPENTHREAD_TESTS_SUBSET4
+
+if OPENTHREAD_TESTS_SUBSET5
+
+check_SCRIPTS                                                     += \
     thread-cert/Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py  \
     thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py  \
     thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py  \
@@ -145,6 +199,8 @@ check_SCRIPTS                                                      = \
     thread-cert/Cert_6_1_05_RouterAttachLinkQuality.py               \
     thread-cert/Cert_6_1_06_REEDAttachLinkQuality.py                 \
     thread-cert/Cert_6_1_07_EDSynchronization.py                     \
+    thread-cert/Cert_6_2_01_NewPartition.py                          \
+    thread-cert/Cert_6_2_02_NewPartition.py                          \
     thread-cert/Cert_6_3_01_OrphanReattach.py                        \
     thread-cert/Cert_6_3_02_NetworkDataUpdate.py                     \
     thread-cert/Cert_6_4_01_LinkLocal.py                             \
@@ -160,35 +216,7 @@ check_SCRIPTS                                                      = \
     thread-cert/Cert_7_1_05_BorderRouterAsRouter.py                  \
     $(NULL)
 
-# List all other non-essential program and script tests that MAY be run.
-
-if !OPENTHREAD_WITH_MINIMUM_SET_OF_TESTS
-
-check_SCRIPTS                                                     += \
-    thread-cert/Cert_5_1_04_RouterAddressReallocation.py             \
-    thread-cert/Cert_5_1_05_RouterAddressTimeout.py                  \
-    thread-cert/Cert_5_1_07_MaxChildCount.py                         \
-    thread-cert/Cert_5_2_02_LeaderReject1Hop.py                      \
-    thread-cert/Cert_5_2_03_LeaderReject2Hops.py                     \
-    thread-cert/Cert_5_2_04_REEDUpgrade.py                           \
-    thread-cert/Cert_5_3_02_RealmLocal.py                            \
-    thread-cert/Cert_5_3_03_AddressQuery.py                          \
-    thread-cert/Cert_5_3_04_AddressMapCache.py                       \
-    thread-cert/Cert_5_3_05_RoutingLinkQuality.py                    \
-    thread-cert/Cert_5_3_06_RouterIdMask.py                          \
-    thread-cert/Cert_5_3_10_AddressQuery.py                          \
-    thread-cert/Cert_5_5_02_LeaderReboot.py                          \
-    thread-cert/Cert_5_5_03_SplitMergeChildren.py                    \
-    thread-cert/Cert_5_5_04_SplitMergeRouters.py                     \
-    thread-cert/Cert_5_5_05_SplitMergeREED.py                        \
-    thread-cert/Cert_5_5_06_SplitWeight.py                           \
-    thread-cert/Cert_5_5_07_SplitMergeThreeWay.py                    \
-    thread-cert/Cert_5_5_08_SplitRoutersLostLeader.py                \
-    thread-cert/Cert_6_2_01_NewPartition.py                          \
-    thread-cert/Cert_6_2_02_NewPartition.py                          \
-    $(NULL)
-
-endif # OPENTHREAD_WITH_ESSENTIAL_TESTS_ONLY
+endif # OPENTHREAD_TESTS_SUBSET5
 
 TESTS_ENVIRONMENT                                                  = \
     export                                                           \

--- a/tests/scripts/thread-cert/Cert_5_3_06b_RouterIdMask.py
+++ b/tests/scripts/thread-cert/Cert_5_3_06b_RouterIdMask.py
@@ -77,13 +77,10 @@ class Cert_5_3_6_RouterIdMask(unittest.TestCase):
         time.sleep(3)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
+        self.nodes[ROUTER1].stop()
         self.nodes[ROUTER2].stop()
 
         time.sleep(300)
-
-        self.nodes[ROUTER2].start()
-        time.sleep(5)
-        self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Before this commit, only a subset of the python test scripts were being included as a part of `make check`.  At the same time, all travis instances were running the same subset.  This commit assigns a unique subset to each travis instance, allowing for full coverage without any additional time overhead.