### PR TITLE
let REED successfully ProcessRouteTLV when HandleChildIdResponse

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -110,7 +110,7 @@ Mac::Mac(ThreadNetif &aThreadNetif):
 
     SetExtendedPanId(sExtendedPanidInit);
     SetNetworkName(sNetworkNameInit);
-    SetPanId(kPanIdBroadcast);
+    SetPanId(mPanId);
     SetExtAddress(mExtAddress);
     SetShortAddress(kShortAddrInvalid);
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1720,6 +1720,22 @@ ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::Messa
                                 (mDeviceMode & ModeTlv::kModeFullNetworkData) == 0,
                                 networkData.GetNetworkData(), networkData.GetLength());
 
+    // Route
+    if ((Tlv::GetTlv(aMessage, Tlv::kRoute, sizeof(route), route) == kThreadError_None) &&
+        (mDeviceMode & ModeTlv::kModeFFD))
+    {
+        numRouters = 0;
+        SuccessOrExit(error = mMleRouter.ProcessRouteTlv(route));
+
+        for (int i = 0; i < kMaxRouterId; i++)
+        {
+            if (route.IsRouterIdSet(i))
+            {
+                numRouters++;
+            }
+        }
+    }
+
     // Parent Attach Success
     mParentRequestTimer.Stop();
 
@@ -1738,25 +1754,9 @@ ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::Messa
     mParent.mValid.mRloc16 = sourceAddress.GetRloc16();
     SuccessOrExit(error = SetStateChild(shortAddress.GetRloc16()));
 
-    // Route
-    if ((Tlv::GetTlv(aMessage, Tlv::kRoute, sizeof(route), route) == kThreadError_None) &&
-        (mDeviceMode & ModeTlv::kModeFFD))
+    if ((mDeviceMode & ModeTlv::kModeFFD) && (numRouters < mMleRouter.GetRouterUpgradeThreshold()))
     {
-        numRouters = 0;
-        SuccessOrExit(error = mMleRouter.ProcessRouteTlv(route));
-
-        for (int i = 0; i < kMaxRouterId; i++)
-        {
-            if (route.IsRouterIdSet(i))
-            {
-                numRouters++;
-            }
-        }
-
-        if (numRouters < mMleRouter.GetRouterUpgradeThreshold())
-        {
-            mMleRouter.BecomeRouter();
-        }
+        mMleRouter.BecomeRouter();
     }
 
 exit:


### PR DESCRIPTION
For REED, mRouterIdSequence is default as 0, and if the RouterIdSequence in network is bigger than 128 when the REED joins the network, routeTLV information could not be accepted successfully (diff < 0); thus FFD device would always BecomeRouter() because it thinks there is no enough active routers (routerupgradethreshold) in network.
So here put SetStateChild() after FFD's processRouteTlv() so that it could have proper mRouterIdSequence when it joins to the network at the beginning.

Besides, use the defined variable mPanId instead of the constant to SetPanId when init mac.

@jwhui , please have a review.
