### PR TITLE
Clear multicast bit from randomly generated extended address

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -105,6 +105,7 @@ Mac::Mac(ThreadNetif &aThreadNetif):
     {
         mExtAddress.m8[i] = otPlatRandomGet();
     }
+    mExtAddress.m8[0] &= ~1; // always remove multicast bit
 
     memset(&mCounters, 0, sizeof(otMacCounters));
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -105,6 +105,7 @@ Mac::Mac(ThreadNetif &aThreadNetif):
     {
         mExtAddress.m8[i] = otPlatRandomGet();
     }
+
     mExtAddress.m8[0] &= ~1; // always remove multicast bit
 
     memset(&mCounters, 0, sizeof(otMacCounters));


### PR DESCRIPTION
Randomly generated extended addresses can sometimes cause the following warning message in NCP applicion (wpantund):
```
wpantund[30369]: [NCP->] CMD_PROP_VALUE_IS(PROP_HWADDR)                
wpantund[30369]: NCP Status: HardwareAddr:      0D:68:D0:B1:A6:1E:21:91
wpantund[30369]: HARDWARE ADDRESS IS INVALID, MULTICAST BIT IS SET!    
wpantund[30369]: [->NCP] CMD_PROP_VALUE_GET(PROP_NET_MASTER_KEY) len=3 
wpantund[30369]:        ↳ {8C0246}                                     
wpantund[30369]: "fe80::f68:d0b1:a61e:2191" was added to "wpan0"       
```