### PR TITLE
ncp: First pass at NCP support for a SPI slave interface

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -386,12 +386,16 @@ AM_CONDITIONAL([OPENTHREAD_ENABLE_CLI], [test "${enable_cli}" = "yes"])
 #
 
 AC_ARG_ENABLE(ncp,
-    [AS_HELP_STRING([--enable-ncp],[Enable NCP suport @<:@default=no@:>@.])],
+    [AS_HELP_STRING([--enable-ncp[[=spi|uart]]],[Enable NCP suport @<:@default=no@:>@.])],
     [
         case "${enableval}" in
 
-        no|yes)
+        no|spi|uart)
             enable_ncp=${enableval}
+            ;;
+
+        yes)
+            enable_ncp=uart
             ;;
 
         *)
@@ -401,7 +405,9 @@ AC_ARG_ENABLE(ncp,
     ],
     [enable_ncp=no])
 AC_MSG_RESULT(${enable_ncp})
-AM_CONDITIONAL([OPENTHREAD_ENABLE_NCP], [test "${enable_ncp}" = "yes"])
+AM_CONDITIONAL([OPENTHREAD_ENABLE_NCP],      [test "${enable_ncp}" != "no"])
+AM_CONDITIONAL([OPENTHREAD_ENABLE_NCP_SPI],  [test "${enable_ncp}"  = "spi"])
+AM_CONDITIONAL([OPENTHREAD_ENABLE_NCP_UART], [test "${enable_ncp}"  = "uart"])
 
 #
 # Examples

--- a/include/platform/spi-slave.h
+++ b/include/platform/spi-slave.h
@@ -66,11 +66,28 @@ extern "C" {
  *
  * Note that this function is always called at the end of a transaction,
  * even if otPlatSpiSlavePrepareTransaction() has not yet been called.
+ * In such cases, anOutputBufLen and anInputBufLen will be zero.
  *
- * @param[in] aContext Context pointer passed into otPlatSpiSlaveEnable()
- * @param[in] aLen     Length of the completed transaction, in bytes
+ * @param[in] aContext           Context pointer passed into
+ *                               otPlatSpiSlaveEnable()
+ * @param[in] anOutputBuf        Value of anOutputBuf from last call to
+ *                               otPlatSpiSlavePrepareTransaction()
+ * @param[in] anOutputBufLen     Value of anOutputBufLen from last call to
+ *                               otPlatSpiSlavePrepareTransaction()
+ * @param[in] anInputBuf         Value of anInputBuf from last call to
+ *                               otPlatSpiSlavePrepareTransaction()
+ * @param[in] anInputBufLen      Value of anInputBufLen from last call to
+ *                               otPlatSpiSlavePrepareTransaction()
+ * @param[in] aTransactionLength Length of the completed transaction, in bytes
  */
-typedef void (*otPlatSpiSlaveTransactionCompleteCallback)(void *aContext, uint16_t aLen);
+typedef void (*otPlatSpiSlaveTransactionCompleteCallback)(
+    void *aContext,
+    uint8_t *anOutputBuf,
+    uint16_t anOutputBufLen,
+    uint8_t *anInputBuf,
+    uint16_t anInputBufLen,
+    uint16_t aTransactionLength
+);
 
 /**
  * Initialize the SPI slave interface.
@@ -90,7 +107,10 @@ typedef void (*otPlatSpiSlaveTransactionCompleteCallback)(void *aContext, uint16
  * @retval ::kThreadError_Already SPI Slave interface is already enabled.
  * @retval ::kThreadError_Failed  Failed to enable the SPI Slave interface.
  */
-ThreadError otPlatSpiSlaveEnable(otPlatSpiSlaveTransactionCompleteCallback aCallback, void *aContext);
+ThreadError otPlatSpiSlaveEnable(
+    otPlatSpiSlaveTransactionCompleteCallback aCallback,
+    void *aContext
+);
 
 /**
  * Shutdown and disable the SPI slave interface.
@@ -144,20 +164,12 @@ void otPlatSpiSlaveDisable(void);
  * @retval ::kThreadError_InvalidState otPlatSpiSlaveEnable() hasn't been called.
  */
 ThreadError otPlatSpiSlavePrepareTransaction(
-    const uint8_t *anOutputBuf,
+    uint8_t *anOutputBuf,
     uint16_t anOutputBufLen,
     uint8_t *anInputBuf,
     uint16_t anInputBufLen,
     bool aRequestTransactionFlag
 );
-
-/**
- * Transaction-in-progress check function.
- *
- * @retval true  A SPI transaction is in progress.
- * @retval false A SPI transaction is NOT in progress.
- */
-bool otPlatSpiSlaveIsTransactionInProgress(void);
 
 /**
  * @}

--- a/src/ncp/Makefile.am
+++ b/src/ncp/Makefile.am
@@ -54,16 +54,29 @@ libopenthread_ncp_a_CXXFLAGS        = \
     $(NULL)
 
 libopenthread_ncp_a_SOURCES         = \
+    ncp_base.cpp                      \
+    ncp_base.hpp                      \
+    spinel.c                          \
+    spinel.h                          \
+    $(NULL)
+
+if OPENTHREAD_ENABLE_NCP_SPI
+libopenthread_ncp_a_SOURCES        += \
+    ncp_spi.cpp                       \
+    ncp_spi.hpp                       \
+    $(NULL)
+endif
+
+if OPENTHREAD_ENABLE_NCP_UART
+libopenthread_ncp_a_SOURCES        += \
     hdlc.cpp                          \
     hdlc.hpp                          \
     flen.cpp                          \
     flen.hpp                          \
-    ncp.cpp                           \
-    ncp.hpp                           \
-    ncp_base.cpp                      \
-    ncp_base.hpp                      \
-    spinel.c spinel.h                 \
+    ncp_uart.cpp                      \
+    ncp_uart.hpp                      \
     $(NULL)
+endif
 
 include_HEADERS                     = \
     $(NULL)

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -33,7 +33,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <common/code_utils.hpp>
-#include <ncp/ncp.hpp>
+#include <ncp/ncp_base.hpp>
 #include <openthread.h>
 #include <openthread-config.h>
 #include <stdarg.h>

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -1,0 +1,336 @@
+/*
+ *    Copyright (c) 2016, Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+ *    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements a SPI interface to the OpenThread stack.
+ */
+
+#include <common/code_utils.hpp>
+#include <common/new.hpp>
+#include <ncp/ncp.h>
+#include <ncp/ncp_spi.hpp>
+#include <platform/spi-slave.h>
+#include <core/openthread-core-config.h>
+
+#define SPI_RESET_FLAG          0x80
+
+namespace Thread {
+
+static otDEFINE_ALIGNED_VAR(sNcpRaw, sizeof(NcpSpi), uint64_t);
+static NcpSpi *sNcpSpi;
+
+extern "C" void otNcpInit(void)
+{
+    sNcpSpi = new(&sNcpRaw) NcpSpi;
+}
+
+static void spi_header_set_accept_len(uint8_t *header, uint16_t len)
+{
+    header[1] = ((len << 0) & 0xFF);
+    header[2] = ((len << 8) & 0xFF);
+}
+
+static void spi_header_set_data_len(uint8_t *header, uint16_t len)
+{
+    header[3] = ((len << 0) & 0xFF);
+    header[4] = ((len << 8) & 0xFF);
+}
+
+static uint16_t spi_header_get_accept_len(uint8_t *header)
+{
+    return ( header[1] + (header[2] << 8) );
+}
+
+static uint16_t spi_header_get_data_len(uint8_t *header)
+{
+    return ( header[3] + (header[4] << 8) );
+}
+
+NcpSpi::NcpSpi():
+    NcpBase(),
+    mHandleRxFrame(&HandleRxFrame, this),
+    mHandleSendDone(&HandleSendDone, this)
+{
+    memset(mEmptySendFrame, 0, sizeof(SPI_HEADER_LENGTH));
+    memset(mSendFrame, 0, sizeof(SPI_HEADER_LENGTH));
+
+    mEmptySendFrame[0] = mSendFrame[0] = SPI_RESET_FLAG;
+    spi_header_set_accept_len(mSendFrame, sizeof(mReceiveFrame) - SPI_HEADER_LENGTH);
+    otPlatSpiSlaveEnable(&SpiTransactionComplete, (void*)this);
+
+    // We signal an interrupt on this first transaction to
+    // make sure that the host processor knows that our
+    // reset flag was set.
+    otPlatSpiSlavePrepareTransaction(
+        mEmptySendFrame,
+        SPI_HEADER_LENGTH,
+        mEmptyReceiveFrame,
+        SPI_HEADER_LENGTH,
+        true
+    );
+}
+
+void
+NcpSpi::SpiTransactionComplete(
+    void *aContext,
+    uint8_t *anOutputBuf,
+    uint16_t anOutputBufLen,
+    uint8_t *anInputBuf,
+    uint16_t anInputBufLen,
+    uint16_t aTransactionLength
+)
+{
+    static_cast<NcpSpi*>(aContext)->SpiTransactionComplete(
+        anOutputBuf,
+        anOutputBufLen,
+        anInputBuf,
+        anInputBufLen,
+        aTransactionLength
+    );
+}
+
+void
+NcpSpi::SpiTransactionComplete(
+    uint8_t *aMISOBuf,
+    uint16_t aMISOBufLen,
+    uint8_t *aMOSIBuf,
+    uint16_t aMOSIBufLen,
+    uint16_t aTransactionLength
+) {
+    // This may be executed from an interrupt context.
+    // Must return as quickly as possible.
+
+    uint16_t rx_data_len(0);
+    uint16_t rx_accept_len(0);
+    uint16_t tx_data_len(0);
+    uint16_t tx_accept_len(0);
+
+    if (aTransactionLength >= SPI_HEADER_LENGTH)
+    {
+        if (aMISOBufLen >= SPI_HEADER_LENGTH)
+        {
+            rx_accept_len = spi_header_get_accept_len(aMISOBuf);
+            tx_data_len = spi_header_get_data_len(aMISOBuf);
+        }
+
+        if (aMOSIBufLen >= SPI_HEADER_LENGTH)
+        {
+            rx_data_len = spi_header_get_data_len(aMOSIBuf);
+            tx_accept_len = spi_header_get_accept_len(aMOSIBuf);
+        }
+
+        if ( !mHandlingRxFrame
+          && (rx_data_len > 0)
+          && (rx_data_len <= (aTransactionLength - SPI_HEADER_LENGTH))
+          && (rx_data_len <= rx_accept_len)
+        ) {
+            mHandlingRxFrame = true;
+            mHandleRxFrame.Post();
+        }
+
+        if ( mSending
+          && !mHandlingSendDone
+          && (tx_data_len > 0)
+          && (tx_data_len <= (aTransactionLength - SPI_HEADER_LENGTH))
+          && (tx_data_len <= tx_accept_len)
+        ) {
+            // Our transmission was successful.
+            mHandlingSendDone = true;
+            mHandleSendDone.Post();
+        }
+    }
+
+    if ( (aTransactionLength >= 1)
+      && (aMISOBufLen >= 1)
+    ) {
+        // Clear the reset flag
+        mSendFrame[0] &= ~SPI_RESET_FLAG;
+        mEmptySendFrame[0] &= ~SPI_RESET_FLAG;
+    }
+
+    if (mSending && !mHandlingSendDone)
+    {
+        aMISOBuf = mSendFrame;
+        aMISOBufLen = OutboundFrameSize() + SPI_HEADER_LENGTH;
+    }
+    else
+    {
+        aMISOBuf = mEmptySendFrame;
+        aMISOBufLen = SPI_HEADER_LENGTH;
+    }
+
+    if (mHandlingRxFrame)
+    {
+        aMOSIBuf = mEmptyReceiveFrame;
+        aMOSIBufLen = SPI_HEADER_LENGTH;
+        spi_header_set_accept_len(aMISOBuf, 0);
+    }
+    else
+    {
+        aMOSIBuf = mReceiveFrame;
+        aMOSIBufLen = sizeof(mReceiveFrame);
+        spi_header_set_accept_len(aMISOBuf, sizeof(mReceiveFrame) - SPI_HEADER_LENGTH);
+    }
+
+    otPlatSpiSlavePrepareTransaction(
+        aMISOBuf,
+        aMISOBufLen,
+        aMOSIBuf,
+        aMOSIBufLen,
+        mSending && !mHandlingSendDone
+    );
+}
+
+uint16_t
+NcpSpi::OutboundFrameSize(void)
+{
+    return static_cast<uint16_t>(mSendFrameIter - (mSendFrame + SPI_HEADER_LENGTH));
+}
+
+uint16_t
+NcpSpi::OutboundFrameGetRemaining(void)
+{
+    return static_cast<uint16_t>((sizeof(mSendFrame) - SPI_HEADER_LENGTH) - OutboundFrameSize());
+}
+
+ThreadError
+NcpSpi::OutboundFrameBegin(void)
+{
+    ThreadError errorCode( kThreadError_None );
+
+    if (mSending)
+    {
+        errorCode = kThreadError_Busy;
+    }
+    else
+    {
+        mSendFrameIter = (mSendFrame + SPI_HEADER_LENGTH);
+    }
+
+    return errorCode;
+}
+
+ThreadError
+NcpSpi::OutboundFrameFeedData(const uint8_t *frame, uint16_t frameLength)
+{
+    ThreadError errorCode( kThreadError_None );
+    uint16_t maxOutLength( OutboundFrameGetRemaining() );
+
+    if (frameLength > maxOutLength)
+    {
+        errorCode = kThreadError_Failed;
+    }
+    else
+    {
+        memcpy(mSendFrameIter, frame, frameLength);
+        mSendFrameIter += frameLength;
+    }
+
+    return errorCode;
+}
+
+ThreadError
+NcpSpi::OutboundFrameFeedMessage(Message &message)
+{
+    ThreadError errorCode( kThreadError_None );
+    uint16_t maxOutLength( OutboundFrameGetRemaining() );
+    uint16_t frameLength( message.GetLength() );
+
+    if (frameLength > maxOutLength)
+    {
+        errorCode = kThreadError_Failed;
+    }
+    else
+    {
+        message.Read(0, frameLength, mSendFrameIter);
+        mSendFrameIter += frameLength;
+    }
+
+    return errorCode;
+}
+
+ThreadError
+NcpSpi::OutboundFrameSend(void)
+{
+    ThreadError errorCode;
+    uint16_t frameLength( OutboundFrameSize() );
+
+    spi_header_set_data_len(mSendFrame, frameLength);
+
+    // Half-duplex to avoid race condition.
+    spi_header_set_accept_len(mSendFrame, 0);
+
+    mSending = true;
+
+    errorCode = otPlatSpiSlavePrepareTransaction(
+        mSendFrame,
+        frameLength + SPI_HEADER_LENGTH,
+        mEmptyReceiveFrame,
+        sizeof(mEmptyReceiveFrame),
+        true
+    );
+
+    if (errorCode == kThreadError_Busy)
+    {
+        // Being busy is OK. We will get the transaction
+        // set up properly when the current transaction
+        // is completed.
+        errorCode = kThreadError_None;
+    }
+
+    return errorCode;
+}
+
+void NcpSpi::HandleSendDone(void *context)
+{
+    static_cast<NcpSpi*>(context)->HandleSendDone();
+}
+
+void NcpSpi::HandleSendDone(void)
+{
+    mSending = false;
+    mHandlingSendDone = false;
+
+    super_t::HandleSendDone();
+}
+
+void NcpSpi::HandleRxFrame(void *context)
+{
+    static_cast<NcpSpi*>(context)->HandleRxFrame();
+}
+
+void NcpSpi::HandleRxFrame(void)
+{
+    uint16_t rx_data_len( spi_header_get_data_len(mReceiveFrame) );
+    super_t::HandleReceive(mReceiveFrame + SPI_HEADER_LENGTH, rx_data_len);
+    mHandlingRxFrame = false;
+}
+
+
+}  // namespace Thread
+

--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -1,0 +1,98 @@
+/*
+ *    Copyright (c) 2016, Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+ *    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file contains definitions for a SPI interface to the OpenThread stack.
+ */
+
+#ifndef NCP_SPI_HPP_
+#define NCP_SPI_HPP_
+
+#include <ncp/ncp_base.hpp>
+
+#define SPI_HEADER_LENGTH       5
+
+namespace Thread {
+
+class NcpSpi : public NcpBase
+{
+    typedef NcpBase super_t;
+
+public:
+    NcpSpi();
+
+    virtual ThreadError OutboundFrameBegin(void);
+    virtual uint16_t OutboundFrameGetRemaining(void);
+    virtual ThreadError OutboundFrameFeedData(const uint8_t *frame, uint16_t frameLength);
+    virtual ThreadError OutboundFrameFeedMessage(Message &message);
+    virtual ThreadError OutboundFrameSend(void);
+
+    void ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength);
+
+private:
+    uint16_t OutboundFrameSize(void);
+
+    static void SpiTransactionComplete(
+        void *context,
+        uint8_t *anOutputBuf,
+        uint16_t anOutputBufLen,
+        uint8_t *anInputBuf,
+        uint16_t anInputBufLen,
+        uint16_t aTransactionLength
+    );
+    void SpiTransactionComplete(
+        uint8_t *anOutputBuf,
+        uint16_t anOutputBufLen,
+        uint8_t *anInputBuf,
+        uint16_t anInputBufLen,
+        uint16_t aTransactionLength
+    );
+
+    static void HandleRxFrame(void *context);
+    void HandleRxFrame(void);
+
+    static void HandleSendDone(void *context);
+    void HandleSendDone(void);
+
+    bool mHandlingRxFrame;
+    Tasklet mHandleRxFrame;
+
+    bool mHandlingSendDone;
+    Tasklet mHandleSendDone;
+
+
+    uint8_t mEmptySendFrame[SPI_HEADER_LENGTH];
+    uint8_t mEmptyReceiveFrame[SPI_HEADER_LENGTH];
+    uint8_t mSendFrame[1500];
+    uint8_t mReceiveFrame[1500];
+    uint8_t *mSendFrameIter;
+};
+
+}  // namespace Thread
+
+#endif  // NCP_SPI_HPP_

--- a/src/ncp/ncp_uart.hpp
+++ b/src/ncp/ncp_uart.hpp
@@ -30,8 +30,8 @@
  *   This file contains definitions for an FLEN/HDLC interface to the OpenThread stack.
  */
 
-#ifndef NCP_HPP_
-#define NCP_HPP_
+#ifndef NCP_UART_HPP_
+#define NCP_UART_HPP_
 
 #include <ncp/ncp_base.hpp>
 #include <ncp/flen.hpp>
@@ -39,12 +39,12 @@
 
 namespace Thread {
 
-class Ncp : public NcpBase
+class NcpUart : public NcpBase
 {
     typedef NcpBase super_t;
 
 public:
-    Ncp();
+    NcpUart();
 
     virtual ThreadError OutboundFrameBegin(void);
     virtual uint16_t OutboundFrameGetRemaining(void);
@@ -52,11 +52,11 @@ public:
     virtual ThreadError OutboundFrameFeedMessage(Message &message);
     virtual ThreadError OutboundFrameSend(void);
 
-    static void HandleFrame(void *context, uint8_t *aBuf, uint16_t aBufLength);
     void SendDoneTask(void);
     void ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength);
 
 private:
+    static void HandleFrame(void *context, uint8_t *aBuf, uint16_t aBufLength);
     void HandleFrame(uint8_t *aBuf, uint16_t aBufLength);
 
     Hdlc::Encoder mFrameEncoder;
@@ -69,4 +69,4 @@ private:
 
 }  // namespace Thread
 
-#endif  // NCP_HPP_
+#endif  // NCP_UART_HPP_


### PR DESCRIPTION
In order to avoid some race conditions, this change necessitated
some minor changes to the SPI slave platform API. Specifically,
the callback function now includes most of the arguments passed
to `otPlatSpiSlavePrepareTransaction()`.

This has not been tested outside of doing a simple compile test.
Once we have a platform up and running we can iron out the
bugs.