### PR TITLE
leader should keep its router id recorded

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -224,6 +224,7 @@ ThreadError MleRouter::BecomeLeader(void)
 
     mRouterId = (mPreviousRouterId != kMaxRouterId) ? AllocateRouterId(mPreviousRouterId) : AllocateRouterId();
     VerifyOrExit(mRouterId >= 0, error = kThreadError_NoBufs);
+    mPreviousRouterId = mRouterId;
 
     memcpy(&mRouters[mRouterId].mMacAddr, mMac.GetExtAddress(), sizeof(mRouters[mRouterId].mMacAddr));
 


### PR DESCRIPTION
routerid of leader should be recorded so that it could retrieve same router id
when it come back after off longer than networkidtimeout
@jwhui , please have a review, thanks!