### PR TITLE
ncp: Add support for fetching MAC counters.

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -113,37 +113,63 @@ const NcpBase::GetPropertyHandlerEntry NcpBase::mGetPropertyHandlerTable[] =
     { SPINEL_PROP_IPV6_ROUTE_TABLE, &NcpBase::GetPropertyHandler_IPV6_ROUTE_TABLE },
 
     { SPINEL_PROP_STREAM_NET, &NcpBase::GetPropertyHandler_STREAM_NET },
+
+    { SPINEL_PROP_CNTR_TX_PKT_TOTAL, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_TX_PKT_ACK_REQ, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_TX_PKT_ACKED, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_TX_PKT_NO_ACK_REQ, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_TX_PKT_DATA, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_TX_PKT_DATA_POLL, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_TX_PKT_BEACON, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_TX_PKT_BEACON_REQ, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_TX_PKT_OTHER, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_TX_PKT_RETRY, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_TX_ERR_CCA, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_RX_PKT_TOTAL, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_RX_PKT_DATA, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_RX_PKT_DATA_POLL, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_RX_PKT_BEACON, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_RX_PKT_BEACON_REQ, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_RX_PKT_OTHER, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_RX_PKT_FILT_WL, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_RX_PKT_FILT_DA, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_RX_ERR_EMPTY, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_RX_ERR_UKWN_NBR, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_RX_ERR_NVLD_SADDR, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_RX_ERR_SECURITY, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_RX_ERR_BAD_FCS, &NcpBase::GetPropertyHandler_CNTR },
+    { SPINEL_PROP_CNTR_RX_ERR_OTHER, &NcpBase::GetPropertyHandler_CNTR },
 };
 
 const NcpBase::SetPropertyHandlerEntry NcpBase::mSetPropertyHandlerTable[] =
 {
-    { SPINEL_PROP_POWER_STATE, &NcpBase::NcpBase::SetPropertyHandler_POWER_STATE },
+    { SPINEL_PROP_POWER_STATE, &NcpBase::SetPropertyHandler_POWER_STATE },
 
     { SPINEL_PROP_PHY_ENABLED, &NcpBase::SetPropertyHandler_PHY_ENABLED },
-    { SPINEL_PROP_PHY_TX_POWER, &NcpBase::NcpBase::SetPropertyHandler_PHY_TX_POWER },
-    { SPINEL_PROP_PHY_CHAN, &NcpBase::NcpBase::SetPropertyHandler_PHY_CHAN },
+    { SPINEL_PROP_PHY_TX_POWER, &NcpBase::SetPropertyHandler_PHY_TX_POWER },
+    { SPINEL_PROP_PHY_CHAN, &NcpBase::SetPropertyHandler_PHY_CHAN },
     { SPINEL_PROP_MAC_FILTER_MODE, &NcpBase::SetPropertyHandler_MAC_FILTER_MODE },
 
-    { SPINEL_PROP_MAC_SCAN_MASK, &NcpBase::NcpBase::SetPropertyHandler_MAC_SCAN_MASK },
-    { SPINEL_PROP_MAC_SCAN_STATE, &NcpBase::NcpBase::SetPropertyHandler_MAC_SCAN_STATE },
+    { SPINEL_PROP_MAC_SCAN_MASK, &NcpBase::SetPropertyHandler_MAC_SCAN_MASK },
+    { SPINEL_PROP_MAC_SCAN_STATE, &NcpBase::SetPropertyHandler_MAC_SCAN_STATE },
     { SPINEL_PROP_MAC_SCAN_PERIOD, &NcpBase::SetPropertyHandler_MAC_SCAN_PERIOD },
-    { SPINEL_PROP_MAC_15_4_PANID, &NcpBase::NcpBase::SetPropertyHandler_MAC_15_4_PANID },
+    { SPINEL_PROP_MAC_15_4_PANID, &NcpBase::SetPropertyHandler_MAC_15_4_PANID },
 
-    { SPINEL_PROP_NET_ENABLED, &NcpBase::NcpBase::SetPropertyHandler_NET_ENABLED },
-    { SPINEL_PROP_NET_STATE, &NcpBase::NcpBase::SetPropertyHandler_NET_STATE },
-    { SPINEL_PROP_NET_ROLE, &NcpBase::NcpBase::SetPropertyHandler_NET_ROLE },
-    { SPINEL_PROP_NET_NETWORK_NAME, &NcpBase::NcpBase::SetPropertyHandler_NET_NETWORK_NAME },
-    { SPINEL_PROP_NET_XPANID, &NcpBase::NcpBase::SetPropertyHandler_NET_XPANID },
-    { SPINEL_PROP_NET_MASTER_KEY, &NcpBase::NcpBase::SetPropertyHandler_NET_MASTER_KEY },
-    { SPINEL_PROP_NET_KEY_SEQUENCE, &NcpBase::NcpBase::SetPropertyHandler_NET_KEY_SEQUENCE },
+    { SPINEL_PROP_NET_ENABLED, &NcpBase::SetPropertyHandler_NET_ENABLED },
+    { SPINEL_PROP_NET_STATE, &NcpBase::SetPropertyHandler_NET_STATE },
+    { SPINEL_PROP_NET_ROLE, &NcpBase::SetPropertyHandler_NET_ROLE },
+    { SPINEL_PROP_NET_NETWORK_NAME, &NcpBase::SetPropertyHandler_NET_NETWORK_NAME },
+    { SPINEL_PROP_NET_XPANID, &NcpBase::SetPropertyHandler_NET_XPANID },
+    { SPINEL_PROP_NET_MASTER_KEY, &NcpBase::SetPropertyHandler_NET_MASTER_KEY },
+    { SPINEL_PROP_NET_KEY_SEQUENCE, &NcpBase::SetPropertyHandler_NET_KEY_SEQUENCE },
 
     { SPINEL_PROP_THREAD_LOCAL_LEADER_WEIGHT, &NcpBase::SetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT },
-    { SPINEL_PROP_THREAD_ASSISTING_PORTS, &NcpBase::NcpBase::SetPropertyHandler_THREAD_ASSISTING_PORTS },
+    { SPINEL_PROP_THREAD_ASSISTING_PORTS, &NcpBase::SetPropertyHandler_THREAD_ASSISTING_PORTS },
 
-    { SPINEL_PROP_STREAM_NET_INSECURE, &NcpBase::NcpBase::SetPropertyHandler_STREAM_NET_INSECURE },
-    { SPINEL_PROP_STREAM_NET, &NcpBase::NcpBase::SetPropertyHandler_STREAM_NET },
+    { SPINEL_PROP_STREAM_NET_INSECURE, &NcpBase::SetPropertyHandler_STREAM_NET_INSECURE },
+    { SPINEL_PROP_STREAM_NET, &NcpBase::SetPropertyHandler_STREAM_NET },
 
-    { SPINEL_PROP_IPV6_ML_PREFIX, &NcpBase::NcpBase::SetPropertyHandler_IPV6_ML_PREFIX },
+    { SPINEL_PROP_IPV6_ML_PREFIX, &NcpBase::SetPropertyHandler_IPV6_ML_PREFIX },
 };
 
 const NcpBase::InsertPropertyHandlerEntry NcpBase::mInsertPropertyHandlerTable[] =
@@ -152,6 +178,8 @@ const NcpBase::InsertPropertyHandlerEntry NcpBase::mInsertPropertyHandlerTable[]
     { SPINEL_PROP_THREAD_LOCAL_ROUTES, &NcpBase::NcpBase::InsertPropertyHandler_THREAD_LOCAL_ROUTES },
     { SPINEL_PROP_THREAD_ON_MESH_NETS, &NcpBase::NcpBase::InsertPropertyHandler_THREAD_ON_MESH_NETS },
     { SPINEL_PROP_THREAD_ASSISTING_PORTS, &NcpBase::NcpBase::InsertPropertyHandler_THREAD_ASSISTING_PORTS },
+
+    { SPINEL_PROP_CNTR_RESET, &NcpBase::SetPropertyHandler_CNTR_RESET },
 };
 
 const NcpBase::RemovePropertyHandlerEntry NcpBase::mRemovePropertyHandlerTable[] =
@@ -383,7 +411,8 @@ void NcpBase::HandleNetifStateChanged(uint32_t flags, void *context)
 
     obj->mChangedFlags |= flags;
 
-    if (!obj->mSending) {
+    if (!obj->mSending)
+    {
         obj->mUpdateChangedPropsTask.Post();
     }
 }
@@ -396,7 +425,8 @@ void NcpBase::UpdateChangedProps(void *context)
 
 void NcpBase::UpdateChangedProps()
 {
-    if (!mSending) {
+    if (!mSending)
+    {
         if ((mChangedFlags & OT_IP6_ML_ADDR_CHANGED) != 0)
         {
             mChangedFlags &= ~OT_IP6_ML_ADDR_CHANGED;
@@ -496,7 +526,8 @@ void NcpBase::HandleSendDone()
         mQueuedGetHeader = 0;
     }
 
-    if (!mSending) {
+    if (!mSending)
+    {
         UpdateChangedProps();
     }
 }
@@ -974,6 +1005,8 @@ void NcpBase::GetPropertyHandler_CAPS(uint8_t header, spinel_prop_key_t key)
     // Begin adding capabilities //////////////////////////////////////////////
 
     OutboundFrameFeedPacked(SPINEL_DATATYPE_UINT_PACKED_S, SPINEL_CAP_NET_THREAD_1_0);
+
+    OutboundFrameFeedPacked(SPINEL_DATATYPE_UINT_PACKED_S, SPINEL_CAP_COUNTERS);
 
     // TODO: Somehow get the following capability from the radio.
     OutboundFrameFeedPacked(SPINEL_DATATYPE_UINT_PACKED_S, SPINEL_CAP_802_15_4_2450MHZ_OQPSK);
@@ -1655,6 +1688,135 @@ void NcpBase::GetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_key_t ke
     SendLastStatus(header, SPINEL_STATUS_UNIMPLEMENTED);
 }
 
+void NcpBase::GetPropertyHandler_CNTR(uint8_t header, spinel_prop_key_t key)
+{
+    uint32_t value;
+    const otMacCounters *macCounters;
+
+    macCounters = otGetMacCounters();
+
+    assert(macCounters != NULL);
+
+    switch (key)
+    {
+    case SPINEL_PROP_CNTR_TX_PKT_TOTAL:
+        value = macCounters->mTxTotal;
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_ACK_REQ:
+        value = macCounters->mTxAckRequested;
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_ACKED:
+        value = macCounters->mTxAcked;
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_NO_ACK_REQ:
+        value = macCounters->mTxNoAckRequested;
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_DATA:
+        value = macCounters->mTxData;
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_DATA_POLL:
+        value = macCounters->mTxDataPoll;
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_BEACON:
+        value = macCounters->mTxBeacon;
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_BEACON_REQ:
+        value = macCounters->mTxBeaconRequest;
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_OTHER:
+        value = macCounters->mTxOther;
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_RETRY:
+        value = macCounters->mTxRetry;
+        break;
+
+    case SPINEL_PROP_CNTR_TX_ERR_CCA:
+        value = macCounters->mTxErrCca;
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_TOTAL:
+        value = macCounters->mRxTotal;
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_DATA:
+        value = macCounters->mRxData;
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_DATA_POLL:
+        value = macCounters->mRxDataPoll;
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_BEACON:
+        value = macCounters->mRxBeacon;
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_BEACON_REQ:
+        value = macCounters->mRxBeaconRequest;
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_OTHER:
+        value = macCounters->mRxOther;
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_FILT_WL:
+        value = macCounters->mRxWhitelistFiltered;
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_FILT_DA:
+        value = macCounters->mRxDestAddrFiltered;
+        break;
+
+    case SPINEL_PROP_CNTR_RX_ERR_EMPTY:
+        value = macCounters->mRxErrNoFrame;
+        break;
+
+    case SPINEL_PROP_CNTR_RX_ERR_UKWN_NBR:
+        value = macCounters->mRxErrUnknownNeighbor;
+        break;
+
+    case SPINEL_PROP_CNTR_RX_ERR_NVLD_SADDR:
+        value = macCounters->mRxErrInvalidSrcAddr;
+        break;
+
+    case SPINEL_PROP_CNTR_RX_ERR_SECURITY:
+        value = macCounters->mRxErrSec;
+        break;
+
+    case SPINEL_PROP_CNTR_RX_ERR_BAD_FCS:
+        value = macCounters->mRxErrFcs;
+        break;
+
+    case SPINEL_PROP_CNTR_RX_ERR_OTHER:
+        value = macCounters->mRxErrOther;
+        break;
+
+    default:
+        SendLastStatus(header, SPINEL_STATUS_INTERNAL_ERROR);
+        goto bail;
+        break;
+    }
+
+    SendPropteryUpdate(
+        header,
+        SPINEL_CMD_PROP_VALUE_IS,
+        key,
+        SPINEL_DATATYPE_UINT32_S,
+        value
+    );
+
+bail:
+    return;
+}
+
 
 
 // ----------------------------------------------------------------------------
@@ -1764,7 +1926,8 @@ void NcpBase::SetPropertyHandler_MAC_FILTER_MODE(uint8_t header, spinel_prop_key
 
     if (parsedLength > 0)
     {
-        switch (i) {
+        switch (i)
+        {
         case SPINEL_MAC_FILTER_MODE_NORMAL:
             otPlatRadioSetPromiscuous(false);
             errorCode = kThreadError_None;
@@ -2450,9 +2613,12 @@ NcpBase::SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_k
                            &port
                        );
 
-        if (parsedLength > 0) {
+        if (parsedLength > 0)
+        {
             errorCode = otAddUnsecurePort(port);
-        } else {
+        }
+        else
+        {
             errorCode = kThreadError_Parse;
         }
 
@@ -2472,7 +2638,8 @@ NcpBase::SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_k
     {
         SendLastStatus(header, ThreadErrorToSpinelStatus(errorCode));
 
-        if (ports_changed) {
+        if (ports_changed)
+        {
             // We had an error, but we've actually changed
             // the state of these ports---so we need to report
             // those incomplete changes via an asynchronous
@@ -2480,6 +2647,42 @@ NcpBase::SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_k
             HandleCommandPropertyGet(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, key);
         }
     }
+}
+
+void NcpBase::SetPropertyHandler_CNTR_RESET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                uint16_t value_len)
+{
+    ThreadError errorCode = kThreadError_None;
+    uint8_t value = 0;
+    spinel_ssize_t parsedLength;
+
+    parsedLength = spinel_datatype_unpack(
+                       value_ptr,
+                       value_len,
+                       SPINEL_DATATYPE_UINT8_S,
+                       &value
+                   );
+
+    if (parsedLength > 0)
+    {
+        if (value == 1)
+        {
+            // TODO: Implement counter reset!
+            errorCode = kThreadError_NotImplemented;
+        }
+        else
+        {
+            errorCode = kThreadError_InvalidArgs;
+        }
+    }
+    else
+    {
+        errorCode = kThreadError_Parse;
+    }
+
+    // There is currently no getter for PROP_CNTR_RESET, so we just
+    // return SPINEL_STATUS_OK for success when the counters are reset.
+    SendLastStatus(header, ThreadErrorToSpinelStatus(errorCode));
 }
 
 // ----------------------------------------------------------------------------

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -226,6 +226,7 @@ private:
     void GetPropertyHandler_THREAD_STABLE_NETWORK_DATA_VERSION(uint8_t header, spinel_prop_key_t key);
     void GetPropertyHandler_MAC_FILTER_MODE(uint8_t header, spinel_prop_key_t key);
     void GetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key);
+    void GetPropertyHandler_CNTR(uint8_t header, spinel_prop_key_t key);
 
     void SetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                         uint16_t value_len);
@@ -265,6 +266,8 @@ private:
 
     void SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                    uint16_t value_len);
+    void SetPropertyHandler_CNTR_RESET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                       uint16_t value_len);
 
     void InsertPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                   uint16_t value_len);

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -239,6 +239,8 @@ enum
     SPINEL_CAP_HBO                   = 3,
     SPINEL_CAP_POWER_SAVE            = 4,
 
+    SPINEL_CAP_COUNTERS              = 5,
+
     SPINEL_CAP_802_15_4__BEGIN        = 16,
     SPINEL_CAP_802_15_4_2003          = (SPINEL_CAP_802_15_4__BEGIN + 0),
     SPINEL_CAP_802_15_4_2006          = (SPINEL_CAP_802_15_4__BEGIN + 1),
@@ -360,20 +362,41 @@ typedef enum
     SPINEL_PROP_STREAM__END         = 0x80,
 
     /// UART Bitrate
-    /** If the NCP is using a UART to communicate with the host,
+    /** Format: `L`
+     *
+     *  If the NCP is using a UART to communicate with the host,
      *  this property allows the host to change the bitrate
      *  of the serial connection. The value encoding is `L`,
      *  which is a little-endian 32-bit unsigned integer.
-     *  The host should not assume that all possible values are
-     *  supported.
+     *  The host should not assume that all possible numeric values
+     *  are supported.
      *
      *  If implemented by the NCP, this property should be persistent
      *  across software resets and forgotten upon hardware resets.
      *
      *  This property is only implemented when a UART is being
-     *  used for Spinel.
+     *  used for Spinel. This property is optional.
+     *
+     *  When changing the bitrate, all frames will be received
+     *  at the previous bitrate until the response frame to this command
+     *  is received. Once a successful response frame is received by
+     *  the host, all further frames will be transmitted at the new
+     *  bitrate.
      */
     SPINEL_PROP_UART_BITRATE    = 0x100,
+
+    /// UART Software Flow Control
+    /** Format: `b`
+     *
+     *  If the NCP is using a UART to communicate with the host,
+     *  this property allows the host to determine if software flow
+     *  control (XON/XOFF style) should be used and (optionally) to
+     *  turn it on or off.
+     *
+     *  This property is only implemented when a UART is being
+     *  used for Spinel. This property is optional.
+     */
+    SPINEL_PROP_UART_XON_XOFF   = 0x101,
 
     SPINEL_PROP_15_4_PIB__BEGIN     = 1024,
     // For direct access to the 802.15.4 PID.
@@ -388,6 +411,116 @@ typedef enum
     SPINEL_PROP_15_4_PIB_MAC_PROMISCUOUS_MODE   = SPINEL_PROP_15_4_PIB__BEGIN + 0x51, ///< [b]
     SPINEL_PROP_15_4_PIB_MAC_SECURITY_ENABLED   = SPINEL_PROP_15_4_PIB__BEGIN + 0x5d, ///< [b]
     SPINEL_PROP_15_4_PIB__END       = 1280,
+
+    SPINEL_PROP_CNTR__BEGIN        = 1280,
+
+    /// Counter reset behavior
+    /** Format: `C`
+     *  Writing a '1' to this property will reset
+     *  all of the counters to zero. */
+    SPINEL_PROP_CNTR_RESET             = SPINEL_PROP_CNTR__BEGIN + 0,
+
+    /// The total number of transmissions.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_TOTAL      = SPINEL_PROP_CNTR__BEGIN + 1,
+
+    /// The number of transmissions with ack request.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_ACK_REQ    = SPINEL_PROP_CNTR__BEGIN + 2,
+
+    /// The number of transmissions that were acked.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_ACKED      = SPINEL_PROP_CNTR__BEGIN + 3,
+
+    /// The number of transmissions without ack request.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_NO_ACK_REQ = SPINEL_PROP_CNTR__BEGIN + 4,
+
+    /// The number of transmitted data.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_DATA       = SPINEL_PROP_CNTR__BEGIN + 5,
+
+    /// The number of transmitted data poll.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_DATA_POLL  = SPINEL_PROP_CNTR__BEGIN + 6,
+
+    /// The number of transmitted beacon.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_BEACON     = SPINEL_PROP_CNTR__BEGIN + 7,
+
+    /// The number of transmitted beacon request.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_BEACON_REQ = SPINEL_PROP_CNTR__BEGIN + 8,
+
+    /// The number of transmitted other types of frames.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_OTHER      = SPINEL_PROP_CNTR__BEGIN + 9,
+
+    /// The number of retransmission times.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_RETRY      = SPINEL_PROP_CNTR__BEGIN + 10,
+
+    /// The number of CCA failure times.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_ERR_CCA        = SPINEL_PROP_CNTR__BEGIN + 11,
+
+    /// The total number of received packets.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_PKT_TOTAL      = SPINEL_PROP_CNTR__BEGIN + 100,
+
+    /// The number of received data.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_PKT_DATA       = SPINEL_PROP_CNTR__BEGIN + 101,
+
+    /// The number of received data poll.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_PKT_DATA_POLL  = SPINEL_PROP_CNTR__BEGIN + 102,
+
+    /// The number of received beacon.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_PKT_BEACON     = SPINEL_PROP_CNTR__BEGIN + 103,
+
+    /// The number of received beacon request.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_PKT_BEACON_REQ = SPINEL_PROP_CNTR__BEGIN + 104,
+
+    /// The number of received other types of frames.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_PKT_OTHER      = SPINEL_PROP_CNTR__BEGIN + 105,
+
+    /// The number of received packets filtered by whitelist.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_PKT_FILT_WL    = SPINEL_PROP_CNTR__BEGIN + 106,
+
+    /// The number of received packets filtered by destination check.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_PKT_FILT_DA    = SPINEL_PROP_CNTR__BEGIN + 107,
+
+    /// The number of received packets that are empty.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_ERR_EMPTY      = SPINEL_PROP_CNTR__BEGIN + 108,
+
+    /// The number of received packets from an unknown neighbor.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_ERR_UKWN_NBR   = SPINEL_PROP_CNTR__BEGIN + 109,
+
+    /// The number of received packets whose source address is invalid.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_ERR_NVLD_SADDR = SPINEL_PROP_CNTR__BEGIN + 110,
+
+    /// The number of received packets with a security error.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_ERR_SECURITY   = SPINEL_PROP_CNTR__BEGIN + 111,
+
+    /// The number of received packets with a checksum error.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_ERR_BAD_FCS    = SPINEL_PROP_CNTR__BEGIN + 112,
+
+    /// The number of received packets with other errors.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_ERR_OTHER      = SPINEL_PROP_CNTR__BEGIN + 113,
+
+    SPINEL_PROP_CNTR__END       = 2048,
 
     SPINEL_PROP_NEST__BEGIN         = 15296,
     SPINEL_PROP_NEST__END           = 15360,


### PR DESCRIPTION
This change adds several new Spinel counter properties and a new
`CAP_COUNTERS` capability. These can be used by the host to fetch
the counter values for debugging purposes.

This commit also addresses a few style issues.

This is OpenThread side of the work for issue #199
