### PR TITLE
Separate out interface up/down from Thread start/stop.

### DIFF
--- a/examples/apps/cli/README.md
+++ b/examples/apps/cli/README.md
@@ -23,10 +23,17 @@ $ cd <path-to-openthread>/output/<platform>/bin
 $ ./ot-cli 1
 ```
 
-Start OpenThread:
+Bring up the IPv6 interface:
 
 ```bash
-> start
+> ifconfig up
+Done
+```
+
+Start Thread protocol operation:
+
+```bash
+> thread start
 Done
 ```
 
@@ -58,10 +65,17 @@ $ cd <path-to-openthread>/output/<platform>/bin
 $ ./ot-cli 2
 ```
 
-Start OpenThread:
+Bring up the IPv6 interface:
 
 ```bash
-> start
+> ifconfig up
+Done
+```
+
+Start Thread protocol operation:
+
+```bash
+> thread start
 Done
 ```
 

--- a/examples/apps/cli/main.c
+++ b/examples/apps/cli/main.c
@@ -37,7 +37,7 @@ void otSignalTaskletPending(void)
 int main(int argc, char *argv[])
 {
     PlatformInit(argc, argv);
-    otInit();
+    otEnable();
     otCliUartInit();
 
     while (1)

--- a/examples/apps/ncp/main.c
+++ b/examples/apps/ncp/main.c
@@ -37,7 +37,7 @@ void otSignalTaskletPending(void)
 int main(int argc, char *argv[])
 {
     PlatformInit(argc, argv);
-    otInit();
+    otEnable();
     otNcpInit();
 
     while (1)

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -112,11 +112,6 @@ extern "C" {
  */
 
 /**
- * Initialize the OpenThread library.
- */
-void otInit(void);
-
-/**
  * Run the next queued tasklet in OpenThread.
  */
 void otProcessNextTasklet(void);
@@ -151,18 +146,77 @@ extern void otSignalTaskletPending(void);
  */
 
 /**
- * Enable the Thread interface.
+ * This function initializes the OpenThread library.
  *
- * @retval kThreadErrorNone  Successfully enabled the Thread interface.
+ * This function initializes OpenThread and prepares it for subsequent OpenThread API calls.  This function must be
+ * called before any other calls to OpenThread.
+ *
+ * @retval kThreadError_None  Successfully enabled the Thread interface.
+ *
  */
 ThreadError otEnable(void);
 
 /**
- * Disable the Thread interface.
+ * This function disables the OpenThread library.
  *
- * @retval kThreadErrorNone  Successfully disabled the Thread interface.
+ * Call this function when OpenThread is no longer in use.  The client must call otEnable() to use OpenThread
+ * again.
+ *
+ * @retval kThreadError_None  Successfully disabled the Thread interface.
+ *
  */
 ThreadError otDisable(void);
+
+/**
+ * This function brings up the IPv6 interface.
+ *
+ * Call this function to bring up the IPv6 interface and enables IPv6 communication.
+ *
+ * @retval kThreadError_None          Successfully enabled the IPv6 interface.
+ * @retval kThreadError_InvalidState  OpenThread is not enabled or the IPv6 interface is already up.
+ *
+ */
+ThreadError otInterfaceUp(void);
+
+/**
+ * This function brings down the IPv6 interface.
+ *
+ * Call this function to bring down the IPv6 interface and disable all IPv6 communication.
+ *
+ * @retval kThreadError_None          Successfully brought the interface down.
+ * @retval kThreadError_InvalidState  The interface was not up.
+ *
+ */
+ThreadError otInterfaceDown(void);
+
+/**
+ * This function indicates whether or not the IPv6 interface is up.
+ *
+ * @retval TRUE   The IPv6 interface is up.
+ * @retval FALSE  The IPv6 interface is down.
+ *
+ */
+bool otIsInterfaceUp(void);
+
+/**
+ * This function starts Thread protocol operation.
+ *
+ * The interface must be up when calling this function.
+ *
+ * @retval kThreadError_None          Successfully started Thread protocol operation.
+ * @retval kThreadError_InvalidState  Thread protocol operation is already started or the interface is not up.
+ *
+ */
+ThreadError otThreadStart(void);
+
+/**
+ * This function stops Thread protocol operation.
+ *
+ * @retval kThreadError_None          Successfully stopped Thread protocol operation.
+ * @retval kThreadError_InvalidState  The Thread protocol operation was not started.
+ *
+ */
+ThreadError otThreadStop(void);
 
 /**
  * This function pointer is called during an IEEE 802.15.4 Active Scan when an IEEE 802.15.4 Beacon is received or

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -15,6 +15,7 @@ OpenThread test scripts use the CLI to execute test cases.
 * [eidcache](#eidcache)
 * [extaddr](#extaddr)
 * [extpanid](#extpanid)
+* [ifconfig](#ifconfig)
 * [ipaddr](#ipaddr)
 * [keysequence](#keysequence)
 * [leaderweight](#leaderweight)
@@ -32,9 +33,8 @@ OpenThread test scripts use the CLI to execute test cases.
 * [router](#router)
 * [routerupgradethreshold](#routerupgradethreshold)
 * [scan](#scan)
-* [start](#start)
 * [state](#state)
-* [stop](#stop)
+* [thread](#thread)
 * [version](#version)
 * [whitelist](#whitelist)
 
@@ -205,6 +205,24 @@ Set the Thread Extended PAN ID value.
 
 ```bash
 > extpanid dead00beef00cafe
+Done
+```
+
+### ifconfig up
+
+Bring up the IPv6 interface.
+
+```bash
+> ifconfig up
+Done
+```
+
+### ifconfig down
+
+Bring down the IPv6 interface.
+
+```bash
+> ifconfig down
 Done
 ```
 
@@ -541,21 +559,21 @@ Perform an IEEE 802.15.4 Active Scan.
 Done
 ```
 
-### start
+### thread start
 
-Enable OpenThread.
+Enable Thread protocol operation and attach to a Thread network.
 
 ```bash
-> start
+> thread start
 Done
 ```
 
-### stop
+### thread stop
 
-Disable OpenThread.
+Disable Thread protocol operation and detach from a Thread network.
 
 ```bash
-> stop
+> thread stop
 Done
 ```
 

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -96,6 +96,7 @@ private:
     static void ProcessEidCache(int argc, char *argv[]);
     static void ProcessExtAddress(int argc, char *argv[]);
     static void ProcessExtPanId(int argc, char *argv[]);
+    static void ProcessIfconfig(int argc, char *argv[]);
     static void ProcessIpAddr(int argc, char *argv[]);
     static ThreadError ProcessIpAddrAdd(int argc, char *argv[]);
     static ThreadError ProcessIpAddrDel(int argc, char *argv[]);
@@ -120,9 +121,8 @@ private:
     static void ProcessRouterUpgradeThreshold(int argc, char *argv[]);
     static void ProcessRloc16(int argc, char *argv[]);
     static void ProcessScan(int argc, char *argv[]);
-    static void ProcessStart(int argc, char *argv[]);
     static void ProcessState(int argc, char *argv[]);
-    static void ProcessStop(int argc, char *argv[]);
+    static void ProcessThread(int argc, char *argv[]);
     static void ProcessVersion(int argc, char *argv[]);
     static void ProcessWhitelist(int argc, char *argv[]);
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -40,6 +40,7 @@
 #include <mac/mac_frame.hpp>
 #include <net/netif.hpp>
 #include <net/udp6.hpp>
+#include <platform/radio.h>
 #include <platform/random.h>
 #include <thread/address_resolver.hpp>
 #include <thread/key_manager.hpp>
@@ -144,6 +145,10 @@ ThreadError Mle::Start(void)
     ThreadError error = kThreadError_None;
     Ip6::SockAddr sockaddr;
 
+    // cannot bring up the interface if IEEE 802.15.4 promiscuous mode is enabled
+    VerifyOrExit(otPlatRadioGetPromiscuous() == false, error = kThreadError_Busy);
+    VerifyOrExit(mNetif.IsUp(), error = kThreadError_InvalidState);
+
     // memcpy(&sockaddr.mAddr, &mLinkLocal64.GetAddress(), sizeof(sockaddr.mAddr));
     sockaddr.mPort = kUdpPort;
     SuccessOrExit(error = mSocket.Open(&HandleUdpReceive, this));
@@ -173,18 +178,12 @@ exit:
 
 ThreadError Mle::Stop(void)
 {
-    ThreadError error = kThreadError_None;
-
-    VerifyOrExit(mDeviceState != kDeviceStateDisabled, error = kThreadError_Busy);
-
     SetStateDetached();
     mSocket.Close();
     mNetif.RemoveUnicastAddress(mLinkLocal16);
     mNetif.RemoveUnicastAddress(mMeshLocal16);
     mDeviceState = kDeviceStateDisabled;
-
-exit:
-    return error;
+    return kThreadError_None;
 }
 
 ThreadError Mle::BecomeDetached(void)

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -74,12 +74,17 @@ const char *ThreadNetif::GetName(void) const
 
 ThreadError ThreadNetif::Up(void)
 {
+    ThreadError error = kThreadError_None;
+
+    VerifyOrExit(!mIsUp, error = kThreadError_InvalidState);
+
     Netif::AddNetif();
     mMeshForwarder.Start();
-    mMleRouter.Start();
     mCoapServer.Start();
     mIsUp = true;
-    return kThreadError_None;
+
+exit:
+    return error;
 }
 
 ThreadError ThreadNetif::Down(void)

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -94,11 +94,15 @@ class Node:
         self.pexpect.expect('Done')
 
     def start(self):
-        self.send_command('start')
+        self.send_command('ifconfig up')
+        self.pexpect.expect('Done')
+        self.send_command('thread start')
         self.pexpect.expect('Done')
 
     def stop(self):
-        self.send_command('stop')
+        self.send_command('thread stop')
+        self.pexpect.expect('Done')
+        self.send_command('ifconfig down')
         self.pexpect.expect('Done')
 
     def clear_whitelist(self):


### PR DESCRIPTION
- Redefine otEnable/otDisable to just initialize/uninitialize the OpenThread stack.
- Remove otInit API since it is replaced by otEnable.
- Add otInterfaceUp/otInterfaceDown APIs to bring up/down IPv6 interface.
- Add otThreadStart/otThreadStop APIs to start/stop Thread protocol operation.
- Updated NCP implementation to utilize new APIs.

- Resolves #276.