### PR TITLE
update keySequence when incoming MAC frame has key index matches next key index

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -766,6 +766,11 @@ ThreadError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, 
 
     aFrame.SetSecurityValid(true);
 
+    if (keySequence > mKeyManager.GetCurrentKeySequence())
+    {
+        mKeyManager.SetCurrentKeySequence(keySequence);
+    }
+
 exit:
 
     if (error != kThreadError_None)

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -104,13 +104,16 @@ uint32_t KeyManager::GetCurrentKeySequence() const
 
 void KeyManager::SetCurrentKeySequence(uint32_t aKeySequence)
 {
-    mKeySequence = aKeySequence;
-    ComputeKey(mKeySequence, mKey);
+    if (aKeySequence != mKeySequence)
+    {
+        mKeySequence = aKeySequence;
+        ComputeKey(mKeySequence, mKey);
 
-    mMacFrameCounter = 0;
-    mMleFrameCounter = 0;
+        mMacFrameCounter = 0;
+        mMleFrameCounter = 0;
 
-    mNetif.SetStateChangedFlags(OT_NET_KEY_SEQUENCE);
+        mNetif.SetStateChangedFlags(OT_NET_KEY_SEQUENCE);
+    }
 }
 
 const uint8_t *KeyManager::GetCurrentMacKey() const


### PR DESCRIPTION
1) when incoming MAC frame has key index matches next key index, keySequence should also be updated.
FYI, Chapter 7.1.7 in spec says 'thrKeySwitchGuardTimer is 0 and the node receives and successfully processes a MAC frame or MLE message whose incoming key index matches the next key index.'

2) SetCurrentKeySequence() operation would reset FrameCounters,  if aKeySequence is the same as CurrentKey, should such FrameCounters reset be avoided?

@jwhui , please help to have a review