### PR TITLE
Do not prematurely detach when a router migrates to another partition.

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1073,7 +1073,7 @@ ThreadError MleRouter::ProcessRouteTlv(const RouteTlv &aRoute)
     bool old;
 
     // check for newer route data
-    if (diff > 0 || mDeviceState == kDeviceStateDetached)
+    if (diff > 0 || mDeviceState == kDeviceStateDetached || mDeviceState == kDeviceStateChild)
     {
         mRouterIdSequence = aRoute.GetRouterIdSequence();
         mRouterIdSequenceLastUpdated = Timer::GetNow();


### PR DESCRIPTION
Move processing the Route TLV from the new partition after successfully completing the attach.