### PR TITLE
Add NCP as a log region option in logging.h

### DIFF
--- a/examples/platforms/posix/logging.c
+++ b/examples/platforms/posix/logging.c
@@ -103,6 +103,10 @@ void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat
     case kLogRegionMem:
         fprintf(stderr, "MEM  ");
         break;
+
+    case kLogRegionNcp:
+        fprintf(stderr, "NCP  ");
+        break;
     }
 
     va_start(args, aFormat);

--- a/include/platform/logging.h
+++ b/include/platform/logging.h
@@ -85,6 +85,7 @@ typedef enum otLogRegion
     kLogRegionIp6      = 6,  ///< IPv6
     kLogRegionMac      = 7,  ///< IEEE 802.15.4 MAC
     kLogRegionMem      = 8,  ///< Memory
+    kLogRegionNcp      = 9,  ///< NCP
 } otLogRegion;
 
 /**


### PR DESCRIPTION
This commit adds new log region for NCP (`kLogRegionNcp`). It also adds the support for posix platform logging implementation.