### PR TITLE
ncp-uart: Fix for platforms which call `otPlatUartSendDone()` reentrantly

### DIFF
--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -94,6 +94,12 @@ private:
 
     void UpdateChangedProps(void);
 
+    /**
+     * Trampoline for SendDoneTask().
+     */
+    static void SendDoneTask(void *context);
+
+    void SendDoneTask(void);
 
     static void HandleNetifStateChanged(uint32_t flags, void *context);
 
@@ -308,6 +314,8 @@ private:
     uint16_t mScanPeriod;
 
     spinel_prop_key_t mQueuedGetKey;
+
+    Tasklet mSendDoneTask;
 
     Tasklet mUpdateChangedPropsTask;
 

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -145,12 +145,17 @@ NcpUart::OutboundFrameSend(void)
 
     if (errorCode == kThreadError_None)
     {
+        // We go ahead and set this to `true` here in case
+        // `otPlatUartSend()` ends up directly calling
+        // `otPlatUartSendDone()`.
+        mSending = true;
+
         errorCode = otPlatUartSend(mSendFrame.GetBuffer(), mSendFrame.GetLength());
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode != kThreadError_None)
     {
-        mSending = true;
+        mSending = false;
     }
 
     return errorCode;


### PR DESCRIPTION
This change makes the `NcpUart` class behave more robustly against
various sorts of `otPlatUart` API implementations; specifically those
that might call `otPlatUartSendDone()` directly from
`otPlatUartSend()`.

Without this change, all NCP frames after the first few at startup
will be squelched.