### PR TITLE
fix sed issue - unable to reattach when the parent is removed

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -923,6 +923,7 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame)
 {
     Mac::Address macDest;
     Child *child;
+    Neighbor *neighbor;
 
     mSendBusy = false;
 
@@ -960,6 +961,17 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame)
         {
             mSendMessage->ClearDirectTransmission();
             mSendMessage->SetOffset(0);
+        }
+    }
+
+    if (mSendMessage->GetType() == Message::kTypeMacDataPoll)
+    {
+        neighbor = mMle.GetParent();
+
+        if (neighbor->mState == Neighbor::kStateInvalid)
+        {
+            mPollTimer.Stop();
+            mMle.BecomeDetached();
         }
     }
 


### PR DESCRIPTION
Without this fix, SED would keep sending Data Request periodically without any ACK when the parent is removed.
Hi @jwhui , please help to review it.