### PR TITLE
Ncp: Update the ncp implementation to use new buffering model

### DIFF
--- a/examples/platforms/posix/Makefile.am
+++ b/examples/platforms/posix/Makefile.am
@@ -46,6 +46,12 @@ libopenthread_posix_a_SOURCES             = \
     uart.c                                  \
     $(NULL)
 
+if OPENTHREAD_ENABLE_NCP_SPI
+libopenthread_posix_a_SOURCES           += \
+    spi-stubs.c                            \
+    $(NULL)
+endif
+
 noinst_HEADERS                            = \
     platform-posix.h                        \
     $(NULL)

--- a/examples/platforms/posix/spi-stubs.c
+++ b/examples/platforms/posix/spi-stubs.c
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2016, Nest Labs, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <platform/uart.h>
+#include <platform/spi-slave.h>
+
+// Spi-slave stubs
+
+ThreadError otPlatSpiSlaveEnable(
+    otPlatSpiSlaveTransactionCompleteCallback aCallback,
+    void *aContext
+)
+{
+    fprintf(stderr, "\nNo SPI support for posix platform.");
+    exit(0);
+
+    return kThreadError_NotImplemented;
+}
+
+void otPlatSpiSlaveDisable(void)
+{
+}
+
+ThreadError otPlatSpiSlavePrepareTransaction(
+    uint8_t *anOutputBuf,
+    uint16_t anOutputBufLen,
+    uint8_t *anInputBuf,
+    uint16_t anInputBufLen,
+    bool aRequestTransactionFlag
+)
+{
+    return kThreadError_NotImplemented;
+}
+
+// Uart
+
+void otPlatUartSendDone(void)
+{
+}
+
+void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength)
+{
+    (void)aBuf;
+    (void)aBufLength;
+}

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -45,40 +45,83 @@ class NcpBase
 {
 public:
 
-    NcpBase();
+    /**
+     * This constructor creates and initializes an NcpBase instance.
+     *
+     */
+    NcpBase(void);
 
 protected:
 
+    /**
+     * This method is called to start a new outbound frame.
+     *
+     * @retval kThreadError_None      Successfully started a new frame.
+     * @retval kThreadError_NoBufs    Insufficient buffer space available to start a new frame.
+     *
+     */
     virtual ThreadError OutboundFrameBegin(void) = 0;
 
-    virtual uint16_t OutboundFrameGetRemaining(void) = 0;
+    /**
+     * This method adds data to the current outbound frame being written.
+     *
+     * If no buffer space is available, this method should discard and clear the frame before returning an error status.
+     *
+     * @param[in]  aDataBuffer        A pointer to data buffer.
+     * @param[in]  aDataBufferLength  The length of the data buffer.
+     *
+     * @retval kThreadError_None      Successfully added new data to the frame.
+     * @retval kThreadError_NoBufs    Insufficient buffer space available to add data.
+     *
+     */
+    virtual ThreadError OutboundFrameFeedData(const uint8_t *aDataBuffer, uint16_t aDataBufferLength) = 0;
 
-    virtual ThreadError OutboundFrameFeedData(const uint8_t *frame, uint16_t frameLength) = 0;
+    /**
+     * This method adds a message to the current outbound frame being written.
+     *
+     * If no buffer space is available, this method should discard and clear the frame before returning an error status.
+     * In case of success, the passed-in message @aMessage should be owned by outbound buffer and should be freed
+     * when either the the frame is successfully sent and removed or if the frame is discarded.
+     *
+     * @param[in]  aMessage         A reference to the message to be added to current frame.
+     *
+     * @retval kThreadError_None    Successfully added the message to the frame.
+     * @retval kThreadError_NoBufs  Insufficient buffer space available to add message.
+     *
+     */
+    virtual ThreadError OutboundFrameFeedMessage(Message &aMessage) = 0;
 
-    virtual ThreadError OutboundFrameFeedMessage(Message &message) = 0;
-
+    /**
+     * This method finalizes and sends the current outbound frame
+     *
+     * If no buffer space is available, this method should discard and clear the frame before returning an error status.
+     *
+     * @retval kThreadError_None    Successfully added the message to the frame.
+     * @retval kThreadError_NoBufs  Insufficient buffer space available to add message.
+     *
+     */
     virtual ThreadError OutboundFrameSend(void) = 0;
 
 protected:
 
     /**
-     * Called by the superclass to indicate when a frame has been received.
+     * Called by the subclass to indicate when a frame has been received.
      */
     void HandleReceive(const uint8_t *buf, uint16_t bufLength);
 
     /**
-     * Called by the superclass to indicate when a send has been completed.
+     * Called by the subclass to indicate when a frame was removed and some space in tx buffer is available.
      */
-    void HandleSendDone(void);
+    void HandleSpaceAvailableInTxBuffer(void);
 
 private:
 
     /**
      * Trampoline for HandleDatagramFromStack().
      */
-    static void HandleDatagramFromStack(otMessage message);
+    static void HandleDatagramFromStack(otMessage aMessage);
 
-    void HandleDatagramFromStack(Message &message);
+    void HandleDatagramFromStack(Message &aMessage);
 
     /**
      * Trampoline for HandleActiveScanResult().
@@ -111,17 +154,20 @@ private:
 
 private:
 
-    void HandleCommand(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
+    ThreadError HandleCommand(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
 
-    void HandleCommandPropertyGet(uint8_t header, spinel_prop_key_t key);
+    ThreadError HandleCommandPropertyGet(uint8_t header, spinel_prop_key_t key);
 
-    void HandleCommandPropertySet(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
+    ThreadError HandleCommandPropertySet(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                         uint16_t value_len);
 
-    void HandleCommandPropertyInsert(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
+    ThreadError HandleCommandPropertyInsert(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                            uint16_t value_len);
 
-    void HandleCommandPropertyRemove(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
+    ThreadError HandleCommandPropertyRemove(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                            uint16_t value_len);
 
-    void SendLastStatus(uint8_t header, spinel_status_t lastStatus);
+    ThreadError SendLastStatus(uint8_t header, spinel_status_t lastStatus);
 
 public:
 
@@ -134,13 +180,13 @@ public:
 
 private:
 
-    typedef void (NcpBase::*CommandHandlerType)(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
-                                                uint16_t arg_len);
+    typedef ThreadError(NcpBase::*CommandHandlerType)(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+                                                      uint16_t arg_len);
 
-    typedef void (NcpBase::*GetPropertyHandlerType)(uint8_t header, spinel_prop_key_t key);
+    typedef ThreadError(NcpBase::*GetPropertyHandlerType)(uint8_t header, spinel_prop_key_t key);
 
-    typedef void (NcpBase::*SetPropertyHandlerType)(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                                    uint16_t value_len);
+    typedef ThreadError(NcpBase::*SetPropertyHandlerType)(uint8_t header, spinel_prop_key_t key,
+                                                          const uint8_t *value_ptr, uint16_t value_len);
 
     struct CommandHandlerEntry
     {
@@ -178,125 +224,137 @@ private:
     static const InsertPropertyHandlerEntry mInsertPropertyHandlerTable[];
     static const RemovePropertyHandlerEntry mRemovePropertyHandlerTable[];
 
-    void CommandHandler_NOOP(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
-    void CommandHandler_RESET(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
-    void CommandHandler_PROP_VALUE_GET(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
-    void CommandHandler_PROP_VALUE_SET(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
-    void CommandHandler_PROP_VALUE_INSERT(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
-    void CommandHandler_PROP_VALUE_REMOVE(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
+    ThreadError CommandHandler_NOOP(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
+    ThreadError CommandHandler_RESET(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
+    ThreadError CommandHandler_PROP_VALUE_GET(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+                                              uint16_t arg_len);
+    ThreadError CommandHandler_PROP_VALUE_SET(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+                                              uint16_t arg_len);
+    ThreadError CommandHandler_PROP_VALUE_INSERT(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+                                                 uint16_t arg_len);
+    ThreadError CommandHandler_PROP_VALUE_REMOVE(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+                                                 uint16_t arg_len);
 
-    void GetPropertyHandler_ChannelMaskHelper(uint8_t header, spinel_prop_key_t key, uint32_t channel_mask);
+    ThreadError GetPropertyHandler_ChannelMaskHelper(uint8_t header, spinel_prop_key_t key, uint32_t channel_mask);
 
-    void GetPropertyHandler_LAST_STATUS(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_PROTOCOL_VERSION(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_INTERFACE_TYPE(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_VENDOR_ID(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_CAPS(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_NCP_VERSION(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_INTERFACE_COUNT(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_HWADDR(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_LOCK(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_PHY_FREQ(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_PHY_CHAN_SUPPORTED(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_PHY_CHAN(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_PHY_RSSI(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_MAC_15_4_LADDR(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_MAC_15_4_SADDR(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_NET_ENABLED(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_NET_STATE(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_NET_NETWORK_NAME(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_NET_XPANID(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_NET_MASTER_KEY(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_NET_KEY_SEQUENCE(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_NET_PARTITION_ID(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_THREAD_LEADER(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_IPV6_ML_PREFIX(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_IPV6_ML_ADDR(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_IPV6_LL_ADDR(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_IPV6_ROUTE_TABLE(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_MAC_SCAN_MASK(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_MAC_SCAN_PERIOD(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_THREAD_LEADER_ADDR(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_THREAD_LEADER_RID(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_THREAD_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_THREAD_NETWORK_DATA(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_THREAD_NETWORK_DATA_VERSION(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_THREAD_STABLE_NETWORK_DATA(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_THREAD_STABLE_NETWORK_DATA_VERSION(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_MAC_FILTER_MODE(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key);
-    void GetPropertyHandler_CNTR(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_LAST_STATUS(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_PROTOCOL_VERSION(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_INTERFACE_TYPE(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_VENDOR_ID(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_CAPS(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_NCP_VERSION(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_INTERFACE_COUNT(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_HWADDR(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_LOCK(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_PHY_FREQ(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_PHY_CHAN_SUPPORTED(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_PHY_CHAN(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_PHY_RSSI(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_MAC_15_4_LADDR(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_MAC_15_4_SADDR(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_NET_ENABLED(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_NET_STATE(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_NET_NETWORK_NAME(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_NET_XPANID(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_NET_MASTER_KEY(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_NET_KEY_SEQUENCE(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_NET_PARTITION_ID(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_LEADER(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_IPV6_ML_PREFIX(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_IPV6_ML_ADDR(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_IPV6_LL_ADDR(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_IPV6_ROUTE_TABLE(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_MAC_SCAN_MASK(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_MAC_SCAN_PERIOD(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_LEADER_ADDR(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_LEADER_RID(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_NETWORK_DATA(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_NETWORK_DATA_VERSION(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_STABLE_NETWORK_DATA(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_STABLE_NETWORK_DATA_VERSION(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_MAC_FILTER_MODE(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_CNTR(uint8_t header, spinel_prop_key_t key);
 
-    void SetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                        uint16_t value_len);
-    void SetPropertyHandler_PHY_TX_POWER(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                         uint16_t value_len);
-    void SetPropertyHandler_PHY_CHAN(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
-    void SetPropertyHandler_MAC_SCAN_MASK(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                          uint16_t value_len);
-    void SetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                           uint16_t value_len);
-    void SetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                           uint16_t value_len);
-    void SetPropertyHandler_NET_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                        uint16_t value_len);
-    void SetPropertyHandler_NET_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
-    void SetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
-    void SetPropertyHandler_NET_NETWORK_NAME(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                             uint16_t value_len);
-    void SetPropertyHandler_NET_XPANID(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
-    void SetPropertyHandler_NET_MASTER_KEY(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                           uint16_t value_len);
-    void SetPropertyHandler_NET_KEY_SEQUENCE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                             uint16_t value_len);
-    void SetPropertyHandler_STREAM_NET_INSECURE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    ThreadError SetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                               uint16_t value_len);
+    ThreadError SetPropertyHandler_PHY_TX_POWER(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                 uint16_t value_len);
-    void SetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
-    void SetPropertyHandler_IPV6_ML_PREFIX(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                           uint16_t value_len);
-    void SetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                        uint16_t value_len);
-    void SetPropertyHandler_MAC_FILTER_MODE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                     uint16_t value_len);
-    void SetPropertyHandler_MAC_SCAN_PERIOD(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    ThreadError SetPropertyHandler_PHY_CHAN(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                             uint16_t value_len);
-    void SetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    ThreadError SetPropertyHandler_MAC_SCAN_MASK(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                 uint16_t value_len);
+    ThreadError SetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                  uint16_t value_len);
+    ThreadError SetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                  uint16_t value_len);
+    ThreadError SetPropertyHandler_NET_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                               uint16_t value_len);
+    ThreadError SetPropertyHandler_NET_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                             uint16_t value_len);
+    ThreadError SetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                            uint16_t value_len);
+    ThreadError SetPropertyHandler_NET_NETWORK_NAME(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                    uint16_t value_len);
+    ThreadError SetPropertyHandler_NET_XPANID(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                              uint16_t value_len);
+    ThreadError SetPropertyHandler_NET_MASTER_KEY(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                  uint16_t value_len);
+    ThreadError SetPropertyHandler_NET_KEY_SEQUENCE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                    uint16_t value_len);
+    ThreadError SetPropertyHandler_STREAM_NET_INSECURE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                        uint16_t value_len);
-
-    void SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    ThreadError SetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                              uint16_t value_len);
+    ThreadError SetPropertyHandler_IPV6_ML_PREFIX(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                  uint16_t value_len);
+    ThreadError SetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                               uint16_t value_len);
+    ThreadError SetPropertyHandler_MAC_FILTER_MODE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                    uint16_t value_len);
-    void SetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key,
+    ThreadError SetPropertyHandler_MAC_SCAN_PERIOD(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                   uint16_t value_len);
+    ThreadError SetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key,
+                                                              const uint8_t *value_ptr,
+                                                              uint16_t value_len);
+
+    ThreadError SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
+                                                    const uint8_t *value_ptr, uint16_t value_len);
+    ThreadError SetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key,
                                                    const uint8_t *value_ptr, uint16_t value_len);
-    void SetPropertyHandler_CNTR_RESET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                       uint16_t value_len);
+    ThreadError SetPropertyHandler_CNTR_RESET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                              uint16_t value_len);
 
-    void InsertPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                                  uint16_t value_len);
-    void InsertPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                                   uint16_t value_len);
-    void InsertPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                                   uint16_t value_len);
-    void InsertPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                                      uint16_t value_len);
+    ThreadError InsertPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                         uint16_t value_len);
+    ThreadError InsertPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                          uint16_t value_len);
+    ThreadError InsertPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                          uint16_t value_len);
+    ThreadError InsertPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
+                                                             const uint8_t *value_ptr,
+                                                             uint16_t value_len);
 
-    void RemovePropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                                  uint16_t value_len);
-    void RemovePropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                                   uint16_t value_len);
-    void RemovePropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                                   uint16_t value_len);
-    void RemovePropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                                      uint16_t value_len);
+    ThreadError RemovePropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                         uint16_t value_len);
+    ThreadError RemovePropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                          uint16_t value_len);
+    ThreadError RemovePropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                          uint16_t value_len);
+    ThreadError RemovePropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
+                                                             const uint8_t *value_ptr,
+                                                             uint16_t value_len);
 
 private:
     enum
@@ -311,32 +369,19 @@ private:
 
     uint32_t mChannelMask;
 
-    uint8_t mQueuedGetHeader;
-
     uint16_t mScanPeriod;
-
-    spinel_prop_key_t mQueuedGetKey;
-
-    Tasklet mSendDoneTask;
 
     Tasklet mUpdateChangedPropsTask;
 
-    MessageQueue mSendQueue;
-
     uint32_t mChangedFlags;
+
+    spinel_tid_t mDroppedReplyTid;
+
+    uint16_t mDroppedReplyTidBitSet;
 
     otNetifAddress mNetifAddresses[kNetifAddressListSize];
 
     bool mAllowLocalNetworkDataChange;
-
-protected:
-    /**
-     * Set to true when there is a send in progress. Set and cleared
-     * by the superclass. Should be considered read-only by everyone
-     * except the superclass!
-     */
-    bool mSending;
-
 };
 
 }  // namespace Thread

--- a/src/ncp/ncp_buffer.cpp
+++ b/src/ncp/ncp_buffer.cpp
@@ -108,7 +108,7 @@ void NcpFrameBuffer::SetCallbacks(BufferCallback aEmptyBufferCallback, BufferCal
 uint8_t *NcpFrameBuffer::Next(uint8_t *aBufPtr) const
 {
     aBufPtr++;
-    return (aBufPtr == mBufferEnd)? mBuffer : aBufPtr;
+    return (aBufPtr == mBufferEnd) ? mBuffer : aBufPtr;
 }
 
 // Returns an advanced (moved forward) version of the given buffer pointer by the given offset.
@@ -383,6 +383,7 @@ exit:
     {
         mReadState = kReadStateDone;
     }
+
     return error;
 }
 
@@ -487,7 +488,7 @@ uint8_t NcpFrameBuffer::OutFrameReadByte(void)
         // Check if at end of current segment.
         if (mReadPointer == mReadSegmentTail)
         {
-             // Prepare any associated message with this segment.
+            // Prepare any message associated with this segment.
             error = OutFramePrepareMessage();
 
             // If there is no message, move to next segment (if any).
@@ -508,7 +509,7 @@ uint8_t NcpFrameBuffer::OutFrameReadByte(void)
         // Check if at the end of content in message buffer.
         if (mReadPointer == mReadMessageTail)
         {
-           // Fill more bytes from current message into message buffer.
+            // Fill more bytes from current message into message buffer.
             error = OutFrameFillMessageBuffer();
 
             // If no more bytes in the message, move to next segment (if any).

--- a/src/ncp/ncp_buffer.hpp
+++ b/src/ncp/ncp_buffer.hpp
@@ -116,7 +116,8 @@ public:
      * This method adds a message to the current input frame being written to the buffer.
      *
      * If no buffer space is available, this method will discard and clear the frame before returning an error status.
-     * The passed-in message @aMessage will be freed by the frame buffer when the frame is removed or discarded.
+     * In case of success, the passed-in message @p aMessage will be owned by the frame buffer instance and will be
+     * freed when either the the frame is removed or discarded.
      *
      * @param[in]  aMessage         A reference to the message to be added to current frame.
      *

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -89,6 +89,8 @@ NcpSpi::NcpSpi():
     memset(mEmptySendFrame, 0, sizeof(SPI_HEADER_LENGTH));
     memset(mSendFrame, 0, sizeof(SPI_HEADER_LENGTH));
 
+    mSending = false;
+
     spi_header_set_flag_byte(mSendFrame, SPI_RESET_FLAG);
     spi_header_set_flag_byte(mEmptySendFrame, SPI_RESET_FLAG);
     spi_header_set_accept_len(mSendFrame, sizeof(mReceiveFrame) - SPI_HEADER_LENGTH);
@@ -327,7 +329,7 @@ void NcpSpi::HandleSendDone(void)
     mSending = false;
     mHandlingSendDone = false;
 
-    super_t::HandleSendDone();
+    super_t::HandleSpaceAvailableInTxBuffer();
 }
 
 void NcpSpi::HandleRxFrame(void *context)

--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -79,12 +79,13 @@ private:
     static void HandleSendDone(void *context);
     void HandleSendDone(void);
 
+    bool mSending;
+
     bool mHandlingRxFrame;
     Tasklet mHandleRxFrame;
 
     bool mHandlingSendDone;
     Tasklet mHandleSendDone;
-
 
     uint8_t mEmptySendFrame[SPI_HEADER_LENGTH];
     uint8_t mEmptyReceiveFrame[SPI_HEADER_LENGTH];

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -27,7 +27,7 @@
 
 /**
  * @file
- *   This file implements an HDLC interface to the Thread stack.
+ *   This file contains definitions for a UART based NCP interface to the OpenThread stack.
  */
 
 #include <common/code_utils.hpp>
@@ -47,138 +47,158 @@ extern "C" void otNcpInit(void)
     sNcpUart = new(&sNcpRaw) NcpUart;
 }
 
-NcpUart::SendHdlcBuffer::SendHdlcBuffer(void)
-    : BufferWriteIterator()
+NcpUart::UartTxBuffer::UartTxBuffer(void)
+    : Hdlc::Encoder::BufferWriteIterator()
 {
-    Reset();
+    Clear();
 }
 
-void
-NcpUart::SendHdlcBuffer::Reset(void)
+void NcpUart::UartTxBuffer::Clear(void)
 {
     mWritePointer = mBuffer;
     mRemainingLength = sizeof(mBuffer);
 }
 
-uint16_t
-NcpUart::SendHdlcBuffer::GetLength(void) const
+bool NcpUart::UartTxBuffer::IsEmpty(void) const
+{
+    return mWritePointer == mBuffer;
+}
+
+uint16_t NcpUart::UartTxBuffer::GetLength(void) const
 {
     return static_cast<uint16_t>(mWritePointer - mBuffer);
 }
 
-const uint8_t *
-NcpUart::SendHdlcBuffer::GetBuffer(void) const
+const uint8_t *NcpUart::UartTxBuffer::GetBuffer(void) const
 {
     return mBuffer;
 }
 
-uint16_t
-NcpUart::SendHdlcBuffer::GetRemainingLength(void) const
-{
-    return mRemainingLength;
-}
-
 NcpUart::NcpUart():
     NcpBase(),
-    mFrameDecoder(mReceiveFrame, sizeof(mReceiveFrame), &HandleFrame, this),
-    mSendFrame()
+    mFrameDecoder(mRxBuffer, sizeof(mRxBuffer), &HandleFrame, this),
+    mUartBuffer(),
+    mTxFrameBuffer(mTxBuffer, sizeof(mTxBuffer)),
+    mUartSendTask(EncodeAndSendToUart, this)
 {
+    mState = kStartingFrame;
+
+    mTxFrameBuffer.SetCallbacks(NULL, TxFrameBufferHasData, this);
 }
 
-uint16_t
-NcpUart::OutboundFrameGetRemaining(void)
+ThreadError NcpUart::OutboundFrameBegin(void)
 {
-    return mSendFrame.GetRemainingLength();
+    return mTxFrameBuffer.InFrameBegin();
 }
 
-ThreadError
-NcpUart::OutboundFrameBegin(void)
+ThreadError NcpUart::OutboundFrameFeedData(const uint8_t *aDataBuffer, uint16_t aDataBufferLength)
 {
-    ThreadError errorCode;
-
-    mSendFrame.Reset();
-
-    errorCode = mFrameEncoder.Init(mSendFrame);
-
-    return errorCode;
+    return mTxFrameBuffer.InFrameFeedData(aDataBuffer, aDataBufferLength);
 }
 
-ThreadError
-NcpUart::OutboundFrameFeedData(const uint8_t *frame, uint16_t frameLength)
+ThreadError NcpUart::OutboundFrameFeedMessage(Message &aMessage)
 {
-    ThreadError errorCode;
-
-    errorCode = mFrameEncoder.Encode(frame, frameLength, mSendFrame);
-
-    return errorCode;
+    return mTxFrameBuffer.InFrameFeedMessage(aMessage);
 }
 
-ThreadError
-NcpUart::OutboundFrameFeedMessage(Message &message)
+ThreadError NcpUart::OutboundFrameSend(void)
 {
-    ThreadError errorCode;
-    uint16_t inLength;
-    uint8_t inBuf[16];
+    return mTxFrameBuffer.InFrameEnd();
+}
 
-    for (int offset = 0; offset < message.GetLength(); offset += sizeof(inBuf))
+void NcpUart::TxFrameBufferHasData(void *aContext, NcpFrameBuffer *aNcpFrameBuffer)
+{
+    (void)aContext;
+    (void)aNcpFrameBuffer;
+
+    sNcpUart->TxFrameBufferHasData();
+}
+
+void NcpUart::TxFrameBufferHasData(void)
+{
+    if (mUartBuffer.IsEmpty())
     {
-        (void) OutboundFrameGetRemaining();
-        inLength = message.Read(offset, sizeof(inBuf), inBuf);
+        mUartSendTask.Post();
+    }
+}
 
-        errorCode = OutboundFrameFeedData(inBuf, inLength);
+void NcpUart::EncodeAndSendToUart(void *aContext)
+{
+    NcpUart *obj = reinterpret_cast<NcpUart *>(aContext);
 
-        if (errorCode != kThreadError_None)
+    obj->EncodeAndSendToUart();
+}
+
+// This method encodes a frame from the tx frame buffer (mTxFrameBuffer) into the uart buffer and sends it over uart.
+// If the uart buffer gets full, it sends the current encoded portion. This method remembers current state, so on
+// sub-sequent calls, it restarts encoding the bytes from where it left of in the frame .
+void NcpUart::EncodeAndSendToUart(void)
+{
+    uint16_t len;
+
+    while (!mTxFrameBuffer.IsEmpty())
+    {
+        switch (mState)
         {
-            break;
+        case kStartingFrame:
+
+            SuccessOrExit(mFrameEncoder.Init(mUartBuffer));
+
+            mTxFrameBuffer.OutFrameBegin();
+
+            mState = kEncodingFrame;
+
+            while (!mTxFrameBuffer.OutFrameHasEnded())
+            {
+                mByte = mTxFrameBuffer.OutFrameReadByte();
+
+            case kEncodingFrame:
+
+                SuccessOrExit(mFrameEncoder.Encode(mByte, mUartBuffer));
+            }
+
+            mTxFrameBuffer.OutFrameRemove();
+
+            // Notify the super/base class that there is space available in tx frame buffer for a new frame.
+            super_t::HandleSpaceAvailableInTxBuffer();
+
+            mState = kFinalizingFrame;
+
+        case kFinalizingFrame:
+
+            SuccessOrExit(mFrameEncoder.Finalize(mUartBuffer));
+
+            mState = kStartingFrame;
         }
     }
 
-    return errorCode;
-}
+exit:
+    len = mUartBuffer.GetLength();
 
-ThreadError
-NcpUart::OutboundFrameSend(void)
-{
-    ThreadError errorCode;
-
-    errorCode = mFrameEncoder.Finalize(mSendFrame);
-
-    if (errorCode == kThreadError_None)
+    if (len > 0)
     {
-        // We go ahead and set this to `true` here in case
-        // `otPlatUartSend()` ends up directly calling
-        // `otPlatUartSendDone()`.
-        mSending = true;
-
-        errorCode = otPlatUartSend(mSendFrame.GetBuffer(), mSendFrame.GetLength());
+        otPlatUartSend(mUartBuffer.GetBuffer(), len);
     }
-
-    if (errorCode != kThreadError_None)
-    {
-        mSending = false;
-    }
-
-    return errorCode;
 }
 
 extern "C" void otPlatUartSendDone(void)
 {
-    sNcpUart->SendDoneTask();
+    sNcpUart->HandleUartSendDone();
 }
 
-void NcpUart::SendDoneTask(void)
+void NcpUart::HandleUartSendDone(void)
 {
-    mSending = false;
+    mUartBuffer.Clear();
 
-    super_t::HandleSendDone();
+    mUartSendTask.Post();
 }
 
 extern "C" void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength)
 {
-    sNcpUart->ReceiveTask(aBuf, aBufLength);
+    sNcpUart->HandleUartReceiveDone(aBuf, aBufLength);
 }
 
-void NcpUart::ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength)
+void NcpUart::HandleUartReceiveDone(const uint8_t *aBuf, uint16_t aBufLength)
 {
     mFrameDecoder.Decode(aBuf, aBufLength);
 }
@@ -195,4 +215,3 @@ void NcpUart::HandleFrame(uint8_t *aBuf, uint16_t aBufLength)
 }
 
 }  // namespace Thread
-

--- a/src/ncp/ncp_uart.hpp
+++ b/src/ncp/ncp_uart.hpp
@@ -27,7 +27,7 @@
 
 /**
  * @file
- *   This file contains definitions for an FLEN/HDLC interface to the OpenThread stack.
+ *   This file contains definitions for a UART based NCP interface to the OpenThread stack.
  */
 
 #ifndef NCP_UART_HPP_
@@ -36,6 +36,7 @@
 #include <ncp/ncp_base.hpp>
 #include <ncp/flen.hpp>
 #include <ncp/hdlc.hpp>
+#include <ncp/ncp_buffer.hpp>
 
 namespace Thread {
 
@@ -46,38 +47,114 @@ class NcpUart : public NcpBase
 public:
     NcpUart();
 
+    /**
+     * This method is called to start a new outbound frame.
+     *
+     * @retval kThreadError_None      Successfully started a new frame.
+     * @retval kThreadError_NoBufs    Insufficient buffer space available to start a new frame.
+     *
+     */
     virtual ThreadError OutboundFrameBegin(void);
-    virtual uint16_t OutboundFrameGetRemaining(void);
-    virtual ThreadError OutboundFrameFeedData(const uint8_t *frame, uint16_t frameLength);
-    virtual ThreadError OutboundFrameFeedMessage(Message &message);
+
+    /**
+     * This method adds data to the current outbound frame being written.
+     *
+     * If no buffer space is available, this method will discard and clear the frame before returning an error status.
+     *
+     * @param[in]  aDataBuffer        A pointer to data buffer.
+     * @param[in]  aDataBufferLength  The length of the data buffer.
+     *
+     * @retval kThreadError_None      Successfully added new data to the frame.
+     * @retval kThreadError_NoBufs    Insufficient buffer space available to add data.
+     *
+     */
+    virtual ThreadError OutboundFrameFeedData(const uint8_t *aDataBuffer, uint16_t aDataBufferLength);
+
+    /**
+     * This method adds a message to the current outbound frame being written.
+     *
+     * If no buffer space is available, this method will discard and clear the frame before returning an error status.
+     * In case of success, the passed-in message @aMessage will be owned by outbound buffer and will be freed
+     * when either the the frame is successfully sent and removed or if the frame is discarded.
+     *
+     * @param[in]  aMessage         A reference to the message to be added to current frame.
+     *
+     * @retval kThreadError_None    Successfully added the message to the frame.
+     * @retval kThreadError_NoBufs  Insufficient buffer space available to add message.
+     *
+     */
+    virtual ThreadError OutboundFrameFeedMessage(Message &aMessage);
+
+    /**
+     * This method finalizes and sends the current outbound frame.
+     *
+     * If no buffer space is available, this method will discard and clear the frame before returning an error status.
+     *
+     * @retval kThreadError_None    Successfully added the message to the frame.
+     * @retval kThreadError_NoBufs  Insufficient buffer space available to add message.
+     *
+     */
     virtual ThreadError OutboundFrameSend(void);
 
-    void SendDoneTask(void);
-    void ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength);
+    /**
+     * This method is called when uart tx is finished. It prepares and sends the next data chunk (if any) to uart.
+     *
+     */
+    void HandleUartSendDone(void);
+
+    /**
+     * This method is called when uart received a data buffer.
+     *
+     */
+    void HandleUartReceiveDone(const uint8_t *aBuf, uint16_t aBufLength);
 
 private:
-    static void HandleFrame(void *context, uint8_t *aBuf, uint16_t aBufLength);
-    void HandleFrame(uint8_t *aBuf, uint16_t aBufLength);
 
-    Hdlc::Encoder mFrameEncoder;
-    Hdlc::Decoder mFrameDecoder;
+    enum
+    {
+        kUartTxBufferSize = 128,  // Uart tx buffer size.
+        kTxBufferSize = 512,      // Tx Buffer size (used by mTxFrameBuffer).
+        kRxBufferSize = 1500,     // Rx buffer size (should be large enough to fit one whole (decoded) received frame).
+    };
 
-    class SendHdlcBuffer : public Hdlc::Encoder::BufferWriteIterator
+    enum UartTxState
+    {
+        kStartingFrame,          // Starting a new frame.
+        kEncodingFrame,          // In middle of encoding a frame.
+        kFinalizingFrame,        // Finalizing a frame.
+    };
+
+    class UartTxBuffer : public Hdlc::Encoder::BufferWriteIterator
     {
     public:
-        SendHdlcBuffer(void);
+        UartTxBuffer(void);
 
-        void           Reset(void);
+        void           Clear(void);
+        bool           IsEmpty(void) const;
         uint16_t       GetLength(void) const;
-        uint16_t       GetRemainingLength(void) const;
         const uint8_t *GetBuffer(void) const;
 
     private:
-        uint8_t     mBuffer[1500];
+        uint8_t        mBuffer[kUartTxBufferSize];
     };
 
-    SendHdlcBuffer mSendFrame;
-    uint8_t        mReceiveFrame[1500];
+    void            EncodeAndSendToUart(void);
+    void            HandleFrame(uint8_t *aBuf, uint16_t aBufLength);
+    void            TxFrameBufferHasData(void);
+
+    static void     EncodeAndSendToUart(void *aContext);
+    static void     HandleFrame(void *context, uint8_t *aBuf, uint16_t aBufLength);
+    static void     TxFrameBufferHasData(void *aContext, NcpFrameBuffer *aNcpFrameBuffer);
+
+    Hdlc::Encoder   mFrameEncoder;
+    Hdlc::Decoder   mFrameDecoder;
+    UartTxBuffer    mUartBuffer;
+    NcpFrameBuffer  mTxFrameBuffer;
+    UartTxState     mState;
+    uint8_t         mByte;
+    uint8_t         mTxBuffer[kTxBufferSize];
+    uint8_t         mRxBuffer[kRxBufferSize];
+    Tasklet         mUartSendTask;
 };
 
 }  // namespace Thread


### PR DESCRIPTION
This commit modifies the `NcpBase` and `NcpUart` classes to use new Ncp buffer model (defined `in NcpFrameBuffer` class).

Here are the main changes in this commit:

- It changes the `NcpUart` to adopt the `NcpFrameBuffer` for storing the  outbound frames. This allows multiple frames to be queued for tx.

- `NcpUart` is changed so that the outgoing frames are encoded and  sent over to Uart in smaller chunks. This helps reduce the required  buffer size for storing the encoded outbound uart data.

- The spinel command handler methods in `NcpBase` are modified to return  ThreadError status to indicate success or failure (e.g., when there is no  buffer space for a response frame).

- If the response to a spinel command cannot be sent (no buffer space) the `NcpBase` remembers the set of TIDs (transaction ids) of such commands so to reply later with error status `SPINEL_STATUS_NOMEM` when buffer  space becomes available. This ensures that spinel commands will get  a response even in case of full buffer.

- The `NcpSpi` class is modified to address the changes from `NcpBase` but  this commit does not change the buffer model for the `NcpSpi`. It adds  `spi-stubs.c` to enable building the ncp app with spi feature under  posix platform.

I have tested the changes using openthred (posix simulator) with wpantund. 
