### PR TITLE
ncp(spinel/SPI): Various additions and documentation updates

### DIFF
--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -38,6 +38,9 @@
 #include <core/openthread-core-config.h>
 
 #define SPI_RESET_FLAG          0x80
+#define SPI_CRC_FLAG            0x40
+#define SPI_PATTERN_VALUE       0x02
+#define SPI_PATTERN_MASK        0x03
 
 namespace Thread {
 
@@ -91,8 +94,8 @@ NcpSpi::NcpSpi():
 
     mSending = false;
 
-    spi_header_set_flag_byte(mSendFrame, SPI_RESET_FLAG);
-    spi_header_set_flag_byte(mEmptySendFrame, SPI_RESET_FLAG);
+    spi_header_set_flag_byte(mSendFrame, SPI_RESET_FLAG|SPI_PATTERN_VALUE);
+    spi_header_set_flag_byte(mEmptySendFrame, SPI_RESET_FLAG|SPI_PATTERN_VALUE);
     spi_header_set_accept_len(mSendFrame, sizeof(mReceiveFrame) - SPI_HEADER_LENGTH);
     otPlatSpiSlaveEnable(&SpiTransactionComplete, (void*)this);
 
@@ -143,6 +146,10 @@ NcpSpi::SpiTransactionComplete(
     uint16_t tx_data_len(0);
     uint16_t tx_accept_len(0);
 
+    // TODO: Check `PATTERN` bits of `HDR` and ignore frame if not set.
+    //       Holding off on implementing this so as to not cause immediate
+    //       compatability problems, even though it is required by the spec.
+
     if (aTransactionLength >= SPI_HEADER_LENGTH)
     {
         if (aMISOBufLen >= SPI_HEADER_LENGTH)
@@ -181,9 +188,9 @@ NcpSpi::SpiTransactionComplete(
     if ( (aTransactionLength >= 1)
       && (aMISOBufLen >= 1)
     ) {
-        // Clear the reset flag
-        spi_header_set_flag_byte(mSendFrame, 0);
-        spi_header_set_flag_byte(mEmptySendFrame, 0);
+        // Clear the reset flag.
+        spi_header_set_flag_byte(mSendFrame, SPI_PATTERN_VALUE);
+        spi_header_set_flag_byte(mEmptySendFrame, SPI_PATTERN_VALUE);
     }
 
     if (mSending && !mHandlingSendDone)

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1113,6 +1113,131 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
     return ret;
 }
 
+const char *spinel_status_to_cstr(spinel_status_t status)
+{
+    const char *ret = "UNKNOWN";
+
+    switch (status)
+    {
+    case SPINEL_STATUS_OK:
+        ret = "STATUS_OK";
+        break;
+
+    case SPINEL_STATUS_FAILURE:
+        ret = "STATUS_FAILURE";
+        break;
+
+    case SPINEL_STATUS_UNIMPLEMENTED:
+        ret = "STATUS_UNIMPLEMENTED";
+        break;
+
+    case SPINEL_STATUS_INVALID_ARGUMENT:
+        ret = "STATUS_INVALID_ARGUMENT";
+        break;
+
+    case SPINEL_STATUS_INVALID_STATE:
+        ret = "STATUS_INVALID_STATE";
+        break;
+
+    case SPINEL_STATUS_INVALID_COMMAND:
+        ret = "STATUS_INVALID_COMMAND";
+        break;
+
+    case SPINEL_STATUS_INVALID_INTERFACE:
+        ret = "STATUS_INVALID_INTERFACE";
+        break;
+
+    case SPINEL_STATUS_INTERNAL_ERROR:
+        ret = "STATUS_INTERNAL_ERROR";
+        break;
+
+    case SPINEL_STATUS_SECURITY_ERROR:
+        ret = "STATUS_SECURITY_ERROR";
+        break;
+
+    case SPINEL_STATUS_PARSE_ERROR:
+        ret = "STATUS_PARSE_ERROR";
+        break;
+
+    case SPINEL_STATUS_IN_PROGRESS:
+        ret = "STATUS_IN_PROGRESS";
+        break;
+
+    case SPINEL_STATUS_NOMEM:
+        ret = "STATUS_NOMEM";
+        break;
+
+    case SPINEL_STATUS_BUSY:
+        ret = "STATUS_BUSY";
+        break;
+
+    case SPINEL_STATUS_PROP_NOT_FOUND:
+        ret = "STATUS_PROP_NOT_FOUND";
+        break;
+
+    case SPINEL_STATUS_DROPPED:
+        ret = "STATUS_DROPPED";
+        break;
+
+    case SPINEL_STATUS_EMPTY:
+        ret = "STATUS_EMPTY";
+        break;
+
+    case SPINEL_STATUS_CMD_TOO_BIG:
+        ret = "STATUS_CMD_TOO_BIG";
+        break;
+
+    case SPINEL_STATUS_NO_ACK:
+        ret = "STATUS_NO_ACK";
+        break;
+
+    case SPINEL_STATUS_CCA_FAILURE:
+        ret = "STATUS_CCA_FAILURE";
+        break;
+
+    case SPINEL_STATUS_RESET_POWER_ON:
+        ret = "STATUS_RESET_POWER_ON";
+        break;
+
+    case SPINEL_STATUS_RESET_EXTERNAL:
+        ret = "STATUS_RESET_EXTERNAL";
+        break;
+
+    case SPINEL_STATUS_RESET_SOFTWARE:
+        ret = "STATUS_RESET_SOFTWARE";
+        break;
+
+    case SPINEL_STATUS_RESET_FAULT:
+        ret = "STATUS_RESET_FAULT";
+        break;
+
+    case SPINEL_STATUS_RESET_CRASH:
+        ret = "STATUS_RESET_CRASH";
+        break;
+
+    case SPINEL_STATUS_RESET_ASSERT:
+        ret = "STATUS_RESET_ASSERT";
+        break;
+
+    case SPINEL_STATUS_RESET_OTHER:
+        ret = "STATUS_RESET_OTHER";
+        break;
+
+    case SPINEL_STATUS_RESET_UNKNOWN:
+        ret = "STATUS_RESET_UNKNOWN";
+        break;
+
+    case SPINEL_STATUS_RESET_WATCHDOG:
+        ret = "STATUS_RESET_WATCHDOG";
+        break;
+
+    default:
+        break;
+    }
+
+    return ret;
+}
+
 
 /* -------------------------------------------------------------------------- */
 

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -92,8 +92,8 @@ typedef enum
     SPINEL_STATUS_PARSE_ERROR       = 9, ///< A error has occured while parsing the command.
     SPINEL_STATUS_IN_PROGRESS       = 10, ///< This operation is in progress.
     SPINEL_STATUS_NOMEM             = 11, ///< Operation prevented due to memory pressure.
-    SPINEL_STATUS_BUSY              = 12, ///< The device is currently performing an mutually exclusive operation
-    SPINEL_STATUS_PROP_NOT_FOUND    = 12, ///< The given property is not recognized.
+    SPINEL_STATUS_BUSY              = 12, ///< The device is currently performing a mutually exclusive operation
+    SPINEL_STATUS_PROP_NOT_FOUND    = 13, ///< The given property is not recognized.
     SPINEL_STATUS_DROPPED           = 14, ///< A/The packet was dropped.
     SPINEL_STATUS_EMPTY             = 15, ///< The result of the operation is empty.
     SPINEL_STATUS_CMD_TOO_BIG       = 16, ///< The command was too large to fit in the internal buffer.
@@ -316,6 +316,13 @@ typedef enum
     SPINEL_PROP_MAC_FILTER_MODE        = SPINEL_PROP_MAC__BEGIN + 8, ///< [C]
     SPINEL_PROP_MAC__END               = 0x40,
 
+    SPINEL_PROP_MAC_EXT__BEGIN         = 0x1300,
+    /// MAC Whitelist
+    /** Format: `A(T(E))`
+     */
+    SPINEL_PROP_MAC_WHITELIST          = SPINEL_PROP_MAC_EXT__BEGIN + 0, ///< [A(T(E))]
+    SPINEL_PROP_MAC_EXT__END           = 0x1400,
+
     SPINEL_PROP_NET__BEGIN           = 0x40,
     SPINEL_PROP_NET_SAVED            = SPINEL_PROP_NET__BEGIN + 0, ///< [b]
     SPINEL_PROP_NET_ENABLED          = SPINEL_PROP_NET__BEGIN + 1, ///< [b]
@@ -348,7 +355,44 @@ typedef enum
     SPINEL_PROP_THREAD_ASSISTING_PORTS = SPINEL_PROP_THREAD__BEGIN + 12, ///< array(portn) [A(S)]
     SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE
                                        = SPINEL_PROP_THREAD__BEGIN + 13, ///< [b]
+
+    /// Thread Mode
+    /** Format: `C`
+     *
+     *  This property contains the value of the mode
+     *  TLV for this node. The meaning of the bits in this
+     *  bitfield are defined by section 4.5.2 of the Thread
+     *  specification.
+     */
+    SPINEL_PROP_THREAD_MODE            = SPINEL_PROP_THREAD__BEGIN + 14,
     SPINEL_PROP_THREAD__END            = 0x60,
+
+    SPINEL_PROP_THREAD_EXT__BEGIN      = 0x1500,
+
+    /// Thread Child Timeout
+    /** Format: `L`
+     *
+     *  Used when operating in the Child role.
+     */
+    SPINEL_PROP_THREAD_CHILD_TIMEOUT   = SPINEL_PROP_THREAD_EXT__BEGIN + 0,
+
+    /// Thread RLOC16
+    /** Format: `S`
+     */
+    SPINEL_PROP_THREAD_RLOC16          = SPINEL_PROP_THREAD_EXT__BEGIN + 1,
+
+    /// Thread Router Upgrade Threshold
+    /** Format: `C`
+     */
+    SPINEL_PROP_THREAD_ROUTER_UPGRADE_THRESHOLD
+                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 2,
+
+    /// Thread Context Reuse Delay
+    /** Format: `L`
+     */
+    SPINEL_PROP_THREAD_CONTEXT_REUSE_DELAY
+                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 3,
+    SPINEL_PROP_THREAD_EXT__END        = 0x1600,
 
     SPINEL_PROP_IPV6__BEGIN          = 0x60,
     SPINEL_PROP_IPV6_LL_ADDR         = SPINEL_PROP_IPV6__BEGIN + 0, ///< [6]
@@ -364,6 +408,7 @@ typedef enum
     SPINEL_PROP_STREAM_NET          = SPINEL_PROP_STREAM__BEGIN + 2, ///< [D]
     SPINEL_PROP_STREAM_NET_INSECURE = SPINEL_PROP_STREAM__BEGIN + 3, ///< [D]
     SPINEL_PROP_STREAM__END         = 0x80,
+
 
     /// UART Bitrate
     /** Format: `L`


### PR DESCRIPTION
This commit includes some revisions to the spinel protocol, including
the addition of several new properties. It also includes some minor
updates to the SPI protocol, which should reduce ambiguity.

The new properties haven't been implemented in `ncp_base.cpp` yet,
but that will be comming soon.