### PR TITLE
Feature/extra clis for thci support

### DIFF
--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -124,7 +124,7 @@ typedef enum ThreadError
     /**
      * Received a frame filtered by the blacklist.
      */
-	kThreadError_BlacklistFiltered = 27,
+    kThreadError_BlacklistFiltered = 27,
 
     kThreadError_Error = 255,
 } ThreadError;

--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -116,11 +116,15 @@ typedef enum ThreadError
      */
     kThreadError_NotFound = 25,
 
-
     /**
      * The operation is already in progress.
      */
     kThreadError_Already = 26,
+
+    /**
+     * Received a frame filtered by the blacklist.
+     */
+	kThreadError_BlacklistFiltered = 27,
 
     kThreadError_Error = 255,
 } ThreadError;
@@ -485,6 +489,16 @@ typedef struct otMacWhitelistEntry
     bool         mValid : 1;        ///< Indicates whether or not the whitelist entry is vaild
     bool         mFixedRssi : 1;    ///< Indicates whether or not the RSSI value is fixed.
 } otMacWhitelistEntry;
+
+/**
+ * This structure represents a blacklist entry.
+ *
+ */
+typedef struct otMacBlacklistEntry
+{
+    otExtAddress mExtAddress;       ///< IEEE 802.15.4 Extended Address
+    bool         mValid;            ///< Indicates whether or not the blacklist entry is vaild
+} otMacBlacklistEntry;
 
 /**
  * @}

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -639,6 +639,24 @@ ThreadError otGetPendingDataset(otOperationalDataset *aDataset);
 ThreadError otSetPendingDataset(otOperationalDataset *aDataset);
 
 /**
+ * Get the data poll period of sleepy end deivce.
+ *
+ * @returns  The data poll period of sleepy end device.
+ *
+ * @sa otSetPollPeriod
+ */
+uint32_t otGetPollPeriod(void);
+
+/**
+ * Set the data poll period for sleepy end deivce.
+ *
+ * param[in]  aPollPeriod  data poll period.
+ *
+ * @sa otGetPollPeriod
+ */
+void otSetPollPeriod(uint32_t aPollPeriod);
+
+/**
  * @}
  */
 

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -1174,6 +1174,11 @@ ThreadError otGetAssignLinkQuality(const uint8_t *aExtAddr, uint8_t *aLinkQualit
 void otSetAssignLinkQuality(const uint8_t *aExtAddr, uint8_t aLinkQuality);
 
 /**
+ * This method triggers platform reset.
+ */
+void otPlatformReset(void);
+
+/**
  * @}
  *
  */

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -1061,6 +1061,96 @@ ThreadError otBecomeRouter(void);
 ThreadError otBecomeLeader(void);
 
 /**
+ * Add an IEEE 802.15.4 Extended Address to the MAC blacklist.
+ *
+ * @param[in]  aExtAddr  A pointer to the IEEE 802.15.4 Extended Address.
+ *
+ * @retval kThreadErrorNone    Successfully added to the MAC blacklist.
+ * @retval kThreadErrorNoBufs  No buffers available for a new MAC blacklist entry.
+ *
+ * @sa otRemoveMacBlacklist
+ * @sa otClearMacBlacklist
+ * @sa otGetMacBlacklistEntry
+ * @sa otDisableMacBlacklist
+ * @sa otEnableMacBlacklist
+ */
+ThreadError otAddMacBlacklist(const uint8_t *aExtAddr);
+
+/**
+ * Remove an IEEE 802.15.4 Extended Address from the MAC blacklist.
+ *
+ * @param[in]  aExtAddr  A pointer to the IEEE 802.15.4 Extended Address.
+ *
+ * @sa otAddMacBlacklist
+ * @sa otClearMacBlacklist
+ * @sa otGetMacBlacklistEntry
+ * @sa otDisableMacBlacklist
+ * @sa otEnableMacBlacklist
+ */
+void otRemoveMacBlacklist(const uint8_t *aExtAddr);
+
+/**
+ * This function gets a MAC Blacklist entry.
+ *
+ * @param[in]   aIndex  An index into the MAC Blacklist table.
+ * @param[out]  aEntry  A pointer to where the information is placed.
+ *
+ * @retval kThreadError_None         Successfully retrieved the MAC Blacklist entry.
+ * @retval kThreadError_InvalidArgs  @p aIndex is out of bounds or @p aEntry is NULL.
+ *
+ */
+ThreadError otGetMacBlacklistEntry(uint8_t aIndex, otMacBlacklistEntry *aEntry);
+
+/**
+ *  Remove all entries from the MAC Blacklist.
+ *
+ * @sa otAddMacBlacklist
+ * @sa otRemoveMacBlacklist
+ * @sa otGetMacBlacklistEntry
+ * @sa otDisableMacBlacklist
+ * @sa otEnableMacBlacklist
+ */
+void otClearMacBlacklist(void);
+
+/**
+ * Disable MAC blacklist filtering.
+ *
+ *
+ * @sa otAddMacBlacklist
+ * @sa otRemoveMacBlacklist
+ * @sa otClearMacBlacklist
+ * @sa otGetMacBlacklistEntry
+ * @sa otEnableMacBlacklist
+ */
+void otDisableMacBlacklist(void);
+
+/**
+ * Enable MAC Blacklist filtering.
+ *
+ * @sa otAddMacBlacklist
+ * @sa otRemoveMacBlacklist
+ * @sa otClearMacBlacklist
+ * @sa otGetMacBlacklistEntry
+ * @sa otDisableMacBlacklist
+ */
+void otEnableMacBlacklist(void);
+
+/**
+ * This function indicates whether or not the MAC Blacklist is enabled.
+ *
+ * @returns TRUE if the MAC Blacklist is enabled, FALSE otherwise.
+ *
+ * @sa otAddMacBlacklist
+ * @sa otRemoveMacBlacklist
+ * @sa otClearMacBlacklist
+ * @sa otGetMacBlacklistEntry
+ * @sa otDisableMacBlacklist
+ * @sa otEnableMacBlacklist
+ *
+ */
+bool otIsMacBlacklistEnabled(void);
+
+/**
  * @}
  *
  */

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -1167,6 +1167,14 @@ uint8_t otGetRouterIdSequence(void);
 ThreadError otGetRouterInfo(uint16_t aRouterId, otRouterInfo *aRouterInfo);
 
 /**
+ * The function retains diagnostic information for a Thread Router as parent.
+ *
+ * @param[out]  aParentInfo  A pointer to where the parent router information is placed.
+ *
+ */
+ThreadError otGetParentInfo(otRouterInfo *aParentInfo);
+
+/**
  * Get the Stable Network Data Version.
  *
  * @returns The Stable Network Data Version.

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -655,7 +655,7 @@ ThreadError otSetPendingDataset(otOperationalDataset *aDataset);
 /**
  * Get the Thread Leader Weight used when operating in the Leader role.
  *
- * @returns The Thread Child Timeout value.
+ * @returns The Thread Leader Weight value.
  *
  * @sa otSetLeaderWeight
  */
@@ -669,6 +669,22 @@ uint8_t otGetLocalLeaderWeight(void);
  * @sa otGetLeaderWeight
  */
 void otSetLocalLeaderWeight(uint8_t aWeight);
+
+/**
+ * Get the Thread Leader Partition Id used when operating in the Leader role.
+ *
+ * @returns The Thread Leader Partition Id value.
+ *
+ */
+uint32_t otGetLocalLeaderPartitionId(void);
+
+/**
+ * Set the Thread Leader Partition Id used when operating in the Leader role.
+ *
+ * @param[in]  aPartitionId  The Thread Leader Partition Id value.
+ *
+ */
+void otSetLocalLeaderPartitionId(uint32_t aPartitionId);
 
 /**
  * @}

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -1151,6 +1151,29 @@ void otEnableMacBlacklist(void);
 bool otIsMacBlacklistEnabled(void);
 
 /**
+ * Get the assigned link quality which is on the link to a given extended address.
+ *
+ * @param[in]  aExtAddr  A pointer to the IEEE 802.15.4 Extended Address.
+ * @param[in]  aLinkQuality A pointer to the assigned link quality.
+ *
+ * @retval kThreadError_None  Successfully retrieved the link quality to aLinkQuality.
+ * @retval kThreadError_InvalidState  No attached child matches with a given extended address.
+ *
+ * @sa otSetAssignLinkQuality
+ */
+ThreadError otGetAssignLinkQuality(const uint8_t *aExtAddr, uint8_t *aLinkQuality);
+
+/**
+ * Set the link quality which is on the link to a given extended address.
+ *
+ * @param[in]  aExtAddr  A pointer to the IEEE 802.15.4 Extended Address.
+ * @param[in]  aLinkQuality  The link quality to be set on the link.
+ *
+ * @sa otGetAssignLinkQuality
+ */
+void otSetAssignLinkQuality(const uint8_t *aExtAddr, uint8_t aLinkQuality);
+
+/**
  * @}
  *
  */

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -27,6 +27,7 @@ OpenThread test scripts use the CLI to execute test cases.
 * [networkidtimeout](#networkidtimeout)
 * [networkname](#networkname)
 * [panid](#panid)
+* [parent](#parent)
 * [ping](#ping)
 * [prefix](#prefix)
 * [releaserouterid](#releaserouterid)
@@ -461,6 +462,17 @@ Set the IEEE 802.15.4 PAN ID value.
 
 ```bash
 > panid 0xdead
+Done
+```
+
+### parent
+
+Get the diagnostic information for a Thread Router as parent.
+
+```bash
+> parent
+Ext Addr: be1857c6c21dce55
+Rloc: 5c00
 Done
 ```
 

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -8,6 +8,7 @@ OpenThread test scripts use the CLI to execute test cases.
 ## OpenThread Command List
 
 * [channel](#channel)
+* [blacklist](#blacklist)
 * [child](#child)
 * [childtimeout](#childtimeout)
 * [contextreusedelay](#contextreusedelay)
@@ -44,6 +45,62 @@ OpenThread test scripts use the CLI to execute test cases.
 
 ## OpenThread Command Details
 
+### blacklist
+
+List the blacklist entries.
+
+```bash
+> blacklist
+Enabled
+166e0a0000000002
+166e0a0000000003
+Done
+```
+
+### blacklist add \<extaddr\>
+
+Add an IEEE 802.15.4 Extended Address to the blacklist.
+
+```bash
+> blacklist add 166e0a0000000002
+Done
+```
+
+### blacklist clear
+
+Clear all entries from the blacklist.
+
+```bash
+> blacklist clear
+Done
+```
+
+### blacklist disable
+
+Disable MAC blacklist filtering.
+
+```bash
+> blacklist disable
+Done
+```
+
+### blacklist enable
+
+Enable MAC blacklist filtering.
+
+```bash
+> blacklist enable
+Done
+```
+
+### blacklist remove \<extaddr\>
+
+Remove an IEEE 802.15.4 Extended Address from the blacklist.
+
+```bash
+> blacklist remove 166e0a0000000002
+Done
+```
 ### channel
 
 Get the IEEE 802.15.4 Channel value.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -20,6 +20,7 @@ OpenThread test scripts use the CLI to execute test cases.
 * [ipaddr](#ipaddr)
 * [keysequence](#keysequence)
 * [leaderweight](#leaderweight)
+* [leaderpartitionid](#leaderpartitionid)
 * [masterkey](#masterkey)
 * [mode](#mode)
 * [netdataregister](#netdataregister)
@@ -327,6 +328,25 @@ Set the Thread Leader Weight.
 
 ```bash
 > leaderweight 128
+Done
+```
+
+### leaderpartitionid
+
+Get the Thread Leader Partition ID.
+
+```bash
+> leaderpartitionid
+2147483647
+Done
+```
+
+### leaderpartitionid \<partitionid>\
+
+Set the Thread Leader Partition ID.
+
+```bash
+> leaderpartitionid 0xffffffff
 Done
 ```
 

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -20,8 +20,9 @@ OpenThread test scripts use the CLI to execute test cases.
 * [ifconfig](#ifconfig)
 * [ipaddr](#ipaddr)
 * [keysequence](#keysequence)
-* [leaderweight](#leaderweight)
 * [leaderpartitionid](#leaderpartitionid)
+* [leaderweight](#leaderweight)
+* [linkquality](#linkquality)
 * [masterkey](#masterkey)
 * [mode](#mode)
 * [netdataregister](#netdataregister)
@@ -371,6 +372,25 @@ Set the Thread Key Sequence.
 Done
 ```
 
+### leaderpartitionid
+
+Get the Thread Leader Partition ID.
+
+```bash
+> leaderpartitionid
+2147483647
+Done
+```
+
+### leaderpartitionid \<partitionid>\
+
+Set the Thread Leader Partition ID.
+
+```bash
+> leaderpartitionid 0xffffffff
+Done
+```
+
 ### leaderweight
 
 Get the Thread Leader Weight.
@@ -390,22 +410,22 @@ Set the Thread Leader Weight.
 Done
 ```
 
-### leaderpartitionid
+### linkquality \<extaddr>\
 
-Get the Thread Leader Partition ID.
+Get the link quality on the link to a given extended address.
 
 ```bash
-> leaderpartitionid
-2147483647
+> linkquality 36c1dd7a4f5201ff
+3
 Done
 ```
 
-### leaderpartitionid \<partitionid>\
+### linkquality \<extaddr>\ \<linkquality>\
 
-Set the Thread Leader Partition ID.
+Set the link quality on the link to a given extended address.
 
 ```bash
-> leaderpartitionid 0xffffffff
+> linkquality 36c1dd7a4f5201ff 3
 Done
 ```
 

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -379,7 +379,7 @@ Get the Thread Leader Partition ID.
 
 ```bash
 > leaderpartitionid
-2147483647
+4294967295
 Done
 ```
 

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -34,6 +34,7 @@ OpenThread test scripts use the CLI to execute test cases.
 * [pollperiod](#pollperiod)
 * [prefix](#prefix)
 * [releaserouterid](#releaserouterid)
+* [reset](#reset)
 * [rloc16](#rloc16)
 * [route](#route)
 * [router](#router)
@@ -611,9 +612,17 @@ Done
 
 ### releaserouterid \<routerid\>
 Release a Router ID that has been allocated by the device in the Leader role.
+
 ```bash
 > releaserouterid 16
 Done
+```
+
+### reset
+Signal a platform reset.
+
+```bash
+> reset
 ```
 
 ### rloc16

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -29,6 +29,7 @@ OpenThread test scripts use the CLI to execute test cases.
 * [panid](#panid)
 * [parent](#parent)
 * [ping](#ping)
+* [pollperiod](#pollperiod)
 * [prefix](#prefix)
 * [releaserouterid](#releaserouterid)
 * [rloc16](#rloc16)
@@ -483,6 +484,25 @@ Send an ICMPv6 Echo Request.
 ```bash
 > ping fdde:ad00:beef:0:558:f56b:d688:799
 16 bytes from fdde:ad00:beef:0:558:f56b:d688:799: icmp_seq=1 hlim=64 time=28ms
+```
+
+### pollperiod
+
+Get the data poll period of sleepy end device
+
+```bash
+> pollperiod
+240
+Done
+```
+
+### pollperiod \<pollperiod>\
+
+Set the data poll period for sleepy end device
+
+```bash
+> pollperiod 240
+Done
 ```
 
 ### prefix add \<prefix\> [pvdcsr] [prf]

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -231,7 +231,7 @@ void Interpreter::ProcessBlacklist(int argc, char *argv[])
             sServer->OutputFormat("Disabled\r\n");
         }
 
-        for (int i = 0; ; i++)
+        for (uint8_t i = 0; ; i++)
         {
             if (otGetMacBlacklistEntry(i, &entry) != kThreadError_None)
             {
@@ -697,7 +697,7 @@ void Interpreter::ProcessLeaderPartitionId(int argc, char *argv[])
     else
     {
         SuccessOrExit(error = ParseUnsignedLong(argv[0], value));
-        otSetLocalLeaderPartitionId(value);
+        otSetLocalLeaderPartitionId(static_cast<uint32_t>(value));
     }
 
 exit:
@@ -741,7 +741,7 @@ void Interpreter::ProcessLinkQuality(int argc, char *argv[])
     else
     {
         SuccessOrExit(error = ParseLong(argv[1], value));
-        otSetAssignLinkQuality(extAddress, value);
+        otSetAssignLinkQuality(extAddress, static_cast<uint8_t>(value));
     }
 
 exit:
@@ -1042,7 +1042,7 @@ void Interpreter::ProcessPollPeriod(int argc, char *argv[])
     else
     {
         SuccessOrExit(error = ParseLong(argv[0], value));
-        otSetPollPeriod(value);
+        otSetPollPeriod(static_cast<uint32_t>(value));
     }
 
 exit:

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -67,6 +67,7 @@ const struct Command Interpreter::sCommands[] =
     { "ipaddr", &ProcessIpAddr },
     { "keysequence", &ProcessKeySequence },
     { "leaderdata", &ProcessLeaderData },
+    { "leaderpartitionid", &ProcessLeaderPartitionId },
     { "leaderweight", &ProcessLeaderWeight },
     { "masterkey", &ProcessMasterKey },
     { "mode", &ProcessMode },
@@ -603,6 +604,25 @@ void Interpreter::ProcessLeaderData(int argc, char *argv[])
 exit:
     (void)argc;
     (void)argv;
+    AppendResult(error);
+}
+
+void Interpreter::ProcessLeaderPartitionId(int argc, char *argv[])
+{
+    ThreadError error = kThreadError_None;
+    long value;
+
+    if (argc == 0)
+    {
+        sServer->OutputFormat("%d\r\n", otGetLocalLeaderPartitionId());
+    }
+    else
+    {
+        SuccessOrExit(error = ParseLong(argv[0], value));
+        otSetLocalLeaderPartitionId(value);
+    }
+
+exit:
     AppendResult(error);
 }
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -77,6 +77,7 @@ const struct Command Interpreter::sCommands[] =
     { "panid", &ProcessPanId },
     { "parent", &ProcessParent },
     { "ping", &ProcessPing },
+    { "pollperiod", &ProcessPollPeriod },
     { "prefix", &ProcessPrefix },
     { "releaserouterid", &ProcessReleaseRouterId },
     { "rloc16", &ProcessRloc16 },
@@ -926,6 +927,25 @@ void Interpreter::HandlePingTimer(void *aContext)
     }
 
     (void)aContext;
+}
+
+void Interpreter::ProcessPollPeriod(int argc, char *argv[])
+{
+	ThreadError error = kThreadError_None;
+	long value;
+
+	if (argc == 0)
+	{
+		sServer->OutputFormat("%d\r\n", otGetPollPeriod());
+	}
+	else
+	{
+		SuccessOrExit(error = ParseLong(argv[0], value));
+		otSetPollPeriod(value);
+	}
+
+exit:
+	AppendResult(error);
 }
 
 ThreadError Interpreter::ProcessPrefixAdd(int argc, char *argv[])

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -75,6 +75,7 @@ const struct Command Interpreter::sCommands[] =
     { "networkidtimeout", &ProcessNetworkIdTimeout },
     { "networkname", &ProcessNetworkName },
     { "panid", &ProcessPanId },
+    { "parent", &ProcessParent },
     { "ping", &ProcessPing },
     { "prefix", &ProcessPrefix },
     { "releaserouterid", &ProcessReleaseRouterId },
@@ -805,6 +806,29 @@ void Interpreter::ProcessPanId(int argc, char *argv[])
 
 exit:
     AppendResult(error);
+}
+
+void Interpreter::ProcessParent(int argc, char *argv[])
+{
+	ThreadError error = kThreadError_None;
+	otRouterInfo parentInfo;
+
+	SuccessOrExit(error = otGetParentInfo(&parentInfo));
+	sServer->OutputFormat("Ext Addr: ");
+
+	for (size_t i = 0; i < sizeof(parentInfo.mExtAddress); i++)
+	{
+		sServer->OutputFormat("%02x", parentInfo.mExtAddress.m8[i]);
+	}
+
+	sServer->OutputFormat("\r\n");
+
+	sServer->OutputFormat("Rloc: %x\r\n", parentInfo.mRloc16);
+
+exit:
+	(void)argc;
+	(void)argv;
+	AppendResult(error);
 }
 
 void Interpreter::HandleEchoResponse(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -70,6 +70,7 @@ const struct Command Interpreter::sCommands[] =
     { "leaderdata", &ProcessLeaderData },
     { "leaderpartitionid", &ProcessLeaderPartitionId },
     { "leaderweight", &ProcessLeaderWeight },
+    { "linkquality", &ProcessLinkQuality },
     { "masterkey", &ProcessMasterKey },
     { "mode", &ProcessMode },
     { "netdataregister", &ProcessNetworkDataRegister },
@@ -712,6 +713,31 @@ void Interpreter::ProcessLeaderWeight(int argc, char *argv[])
 
 exit:
     AppendResult(error);
+}
+
+void Interpreter::ProcessLinkQuality(int argc, char *argv[])
+{
+	ThreadError error = kThreadError_None;
+	uint8_t extAddress[8];
+	uint8_t linkQuality;
+	long value;
+
+	VerifyOrExit(Hex2Bin(argv[0], extAddress, OT_EXT_ADDRESS_SIZE) >= 0, error = kThreadError_Parse);
+
+	if (argc == 1)
+	{
+		VerifyOrExit(otGetAssignLinkQuality(extAddress, &linkQuality) == kThreadError_None,
+                     error = kThreadError_InvalidState);
+		sServer->OutputFormat("%d\r\n", linkQuality);
+	}
+	else
+	{
+		SuccessOrExit(error = ParseLong(argv[1], value));
+		otSetAssignLinkQuality(extAddress, value);
+	}
+
+exit:
+	AppendResult(error);
 }
 
 void Interpreter::ProcessMasterKey(int argc, char *argv[])

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -82,6 +82,7 @@ const struct Command Interpreter::sCommands[] =
     { "pollperiod", &ProcessPollPeriod },
     { "prefix", &ProcessPrefix },
     { "releaserouterid", &ProcessReleaseRouterId },
+    { "reset", &ProcessReset },
     { "rloc16", &ProcessRloc16 },
     { "route", &ProcessRoute },
     { "router", &ProcessRouter },
@@ -1200,6 +1201,13 @@ void Interpreter::ProcessReleaseRouterId(int argc, char *argv[])
 
 exit:
     AppendResult(error);
+}
+
+void Interpreter::ProcessReset(int argc, char *argv[])
+{
+	otPlatformReset();
+	(void)argc;
+	(void)argv;
 }
 
 void Interpreter::ProcessRloc16(int argc, char *argv[])

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -150,6 +150,7 @@ private:
     static ThreadError ProcessPrefixAdd(int argc, char *argv[]);
     static ThreadError ProcessPrefixRemove(int argc, char *argv[]);
     static void ProcessReleaseRouterId(int argc, char *argv[]);
+    static void ProcessReset(int argc, char *argv[]);
     static void ProcessRoute(int argc, char *argv[]);
     static void ProcessRouter(int argc, char *argv[]);
     static ThreadError ProcessRouteAdd(int argc, char *argv[]);

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -117,6 +117,7 @@ private:
     static void OutputBytes(const uint8_t *aBytes, uint8_t aLength);
 
     static void ProcessHelp(int argc, char *argv[]);
+    static void ProcessBlacklist(int argc, char *argv[]);
     static void ProcessChannel(int argc, char *argv[]);
     static void ProcessChild(int argc, char *argv[]);
     static void ProcessChildTimeout(int argc, char *argv[]);

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -141,6 +141,7 @@ private:
     static void ProcessNetworkIdTimeout(int argc, char *argv[]);
     static void ProcessNetworkName(int argc, char *argv[]);
     static void ProcessPanId(int argc, char *argv[]);
+    static void ProcessParent(int argc, char *argv[]);
     static void ProcessPing(int argc, char *argv[]);
     static void ProcessPrefix(int argc, char *argv[]);
     static ThreadError ProcessPrefixAdd(int argc, char *argv[]);

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -97,6 +97,18 @@ public:
     static ThreadError ParseLong(char *aString, long &aLong);
 
     /**
+     * This method parses an ASCII string as an unsigned long.
+     *
+     * @param[in]   aString          A pointer to the ASCII string.
+     * @param[out]  aUnsignedLong    A reference to where the parsed unsigned long is placed.
+     *
+     * @retval kThreadError_None   Successfully parsed the ASCII string.
+     * @retval kThreadError_Parse  Could not parse the ASCII string.
+     *
+     */
+    static ThreadError ParseUnsignedLong(char *aString, unsigned long &aUnsignedLong);
+
+    /**
      * This method converts a hex string to binary.
      *
      * @param[in]   aHex        A pointer to the hex string.

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -133,6 +133,7 @@ private:
     static ThreadError ProcessIpAddrDel(int argc, char *argv[]);
     static void ProcessKeySequence(int argc, char *argv[]);
     static void ProcessLeaderData(int argc, char *argv[]);
+    static void ProcessLeaderPartitionId(int argc, char *argv[]);
     static void ProcessLeaderWeight(int argc, char *argv[]);
     static void ProcessMasterKey(int argc, char *argv[]);
     static void ProcessMode(int argc, char *argv[]);

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -143,6 +143,7 @@ private:
     static void ProcessPanId(int argc, char *argv[]);
     static void ProcessParent(int argc, char *argv[]);
     static void ProcessPing(int argc, char *argv[]);
+    static void ProcessPollPeriod(int argc, char *argv[]);
     static void ProcessPrefix(int argc, char *argv[]);
     static ThreadError ProcessPrefixAdd(int argc, char *argv[]);
     static ThreadError ProcessPrefixRemove(int argc, char *argv[]);

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -136,6 +136,7 @@ private:
     static void ProcessLeaderData(int argc, char *argv[]);
     static void ProcessLeaderPartitionId(int argc, char *argv[]);
     static void ProcessLeaderWeight(int argc, char *argv[]);
+    static void ProcessLinkQuality(int argc, char *argv[]);
     static void ProcessMasterKey(int argc, char *argv[]);
     static void ProcessMode(int argc, char *argv[]);
     static void ProcessNetworkDataRegister(int argc, char *argv[]);

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -47,7 +47,7 @@ libopenthread_a_SOURCES             = \
     mac/mac.cpp                       \
     mac/mac_frame.cpp                 \
     mac/mac_whitelist.cpp             \
-	mac/mac_blacklist.cpp			  \
+    mac/mac_blacklist.cpp             \
     net/icmp6.cpp                     \
     net/ip6.cpp                       \
     net/ip6_address.cpp               \
@@ -91,7 +91,7 @@ noinst_HEADERS                      = \
     mac/mac.hpp                       \
     mac/mac_frame.hpp                 \
     mac/mac_whitelist.hpp             \
-	mac/mac_blacklist.hpp			  \
+    mac/mac_blacklist.hpp             \
     net/icmp6.hpp                     \
     net/ip6.hpp                       \
     net/ip6_address.hpp               \

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -47,6 +47,7 @@ libopenthread_a_SOURCES             = \
     mac/mac.cpp                       \
     mac/mac_frame.cpp                 \
     mac/mac_whitelist.cpp             \
+	mac/mac_blacklist.cpp			  \
     net/icmp6.cpp                     \
     net/ip6.cpp                       \
     net/ip6_address.cpp               \
@@ -90,6 +91,7 @@ noinst_HEADERS                      = \
     mac/mac.hpp                       \
     mac/mac_frame.hpp                 \
     mac/mac_whitelist.hpp             \
+	mac/mac_blacklist.hpp			  \
     net/icmp6.hpp                     \
     net/ip6.hpp                       \
     net/ip6_address.hpp               \

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -75,7 +75,7 @@ Mac::Mac(ThreadNetif &aThreadNetif):
     mMle(aThreadNetif.GetMle()),
     mNetif(aThreadNetif),
     mWhitelist(),
-	mBlacklist()
+    mBlacklist()
 {
     sMac = this;
 
@@ -804,7 +804,7 @@ void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
     PanId panid;
     Neighbor *neighbor;
     otMacWhitelistEntry *whitelistEntry;
-	otMacBlacklistEntry *blacklistEntry;
+    otMacBlacklistEntry *blacklistEntry;
     int8_t rssi;
     ThreadError error = aError;
 
@@ -857,11 +857,11 @@ void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
         }
     }
 
-	// Source Blacklist Processing
-	if (srcaddr.mLength != 0 && mBlacklist.IsEnabled())
-	{
-		VerifyOrExit((blacklistEntry = mBlacklist.Find(srcaddr.mExtAddress)) == NULL, error = kThreadError_BlacklistFiltered);
-	}
+    // Source Blacklist Processing
+    if (srcaddr.mLength != 0 && mBlacklist.IsEnabled())
+    {
+        VerifyOrExit((blacklistEntry = mBlacklist.Find(srcaddr.mExtAddress)) == NULL, error = kThreadError_BlacklistFiltered);
+    }
 
     // Destination Address Filtering
     aFrame->GetDstAddr(dstaddr);
@@ -1054,7 +1054,7 @@ Whitelist &Mac::GetWhitelist(void)
 
 Blacklist &Mac::GetBlacklist(void)
 {
-	return mBlacklist;
+    return mBlacklist;
 }
 
 otMacCounters &Mac::GetCounters(void)

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -74,7 +74,8 @@ Mac::Mac(ThreadNetif &aThreadNetif):
     mKeyManager(aThreadNetif.GetKeyManager()),
     mMle(aThreadNetif.GetMle()),
     mNetif(aThreadNetif),
-    mWhitelist()
+    mWhitelist(),
+	mBlacklist()
 {
     sMac = this;
 
@@ -802,7 +803,8 @@ void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
     Address dstaddr;
     PanId panid;
     Neighbor *neighbor;
-    otMacWhitelistEntry *entry;
+    otMacWhitelistEntry *whitelistEntry;
+	otMacBlacklistEntry *blacklistEntry;
     int8_t rssi;
     ThreadError error = aError;
 
@@ -847,13 +849,19 @@ void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
     // Source Whitelist Processing
     if (srcaddr.mLength != 0 && mWhitelist.IsEnabled())
     {
-        VerifyOrExit((entry = mWhitelist.Find(srcaddr.mExtAddress)) != NULL, error = kThreadError_WhitelistFiltered);
+        VerifyOrExit((whitelistEntry = mWhitelist.Find(srcaddr.mExtAddress)) != NULL, error = kThreadError_WhitelistFiltered);
 
-        if (mWhitelist.GetFixedRssi(*entry, rssi) == kThreadError_None)
+        if (mWhitelist.GetFixedRssi(*whitelistEntry, rssi) == kThreadError_None)
         {
             aFrame->mPower = rssi;
         }
     }
+
+	// Source Blacklist Processing
+	if (srcaddr.mLength != 0 && mBlacklist.IsEnabled())
+	{
+		VerifyOrExit((blacklistEntry = mBlacklist.Find(srcaddr.mExtAddress)) == NULL, error = kThreadError_BlacklistFiltered);
+	}
 
     // Destination Address Filtering
     aFrame->GetDstAddr(dstaddr);
@@ -1042,6 +1050,11 @@ exit:
 Whitelist &Mac::GetWhitelist(void)
 {
     return mWhitelist;
+}
+
+Blacklist &Mac::GetBlacklist(void)
+{
+	return mBlacklist;
 }
 
 otMacCounters &Mac::GetCounters(void)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -502,7 +502,7 @@ private:
     otLinkPcapCallback mPcapCallback;
 
     Whitelist mWhitelist;
-	Blacklist mBlacklist;
+    Blacklist mBlacklist;
 
     otMacCounters mCounters;
 };

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -39,6 +39,7 @@
 #include <common/timer.hpp>
 #include <mac/mac_frame.hpp>
 #include <mac/mac_whitelist.hpp>
+#include <mac/mac_blacklist.hpp>
 #include <platform/radio.h>
 #include <thread/key_manager.hpp>
 #include <thread/topology.hpp>
@@ -364,6 +365,14 @@ public:
     Whitelist &GetWhitelist(void);
 
     /**
+     * This method returns the MAC blacklist filter.
+     *
+     * @returns A reference to the MAC blacklist filter.
+     *
+     */
+    Blacklist &GetBlacklist(void);
+
+    /**
      * This method is called to handle receive events.
      *
      * @param[in]  aFrame  A pointer to the received frame, or NULL if the receive operation aborted.
@@ -493,6 +502,7 @@ private:
     otLinkPcapCallback mPcapCallback;
 
     Whitelist mWhitelist;
+	Blacklist mBlacklist;
 
     otMacCounters mCounters;
 };

--- a/src/core/mac/mac_blacklist.cpp
+++ b/src/core/mac/mac_blacklist.cpp
@@ -1,0 +1,148 @@
+/*
+ *  Copyright (c) 2016, Nest Labs, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements whitelist IEEE 802.15.4 frame filtering based on MAC address.
+ */
+
+#include <string.h>
+
+#include <common/code_utils.hpp>
+#include <mac/mac_blacklist.hpp>
+
+namespace Thread {
+namespace Mac {
+
+Blacklist::Blacklist(void)
+{
+    mEnabled = false;
+
+    for (int i = 0; i < kMaxEntries; i++)
+    {
+        mBlacklist[i].mValid = false;
+    }
+}
+
+void Blacklist::Enable(void)
+{
+    mEnabled = true;
+}
+
+void Blacklist::Disable(void)
+{
+    mEnabled = false;
+}
+
+bool Blacklist::IsEnabled(void) const
+{
+    return mEnabled;
+}
+
+int Blacklist::GetMaxEntries(void) const
+{
+    return kMaxEntries;
+}
+
+ThreadError Blacklist::GetEntry(uint8_t aIndex, Entry &aEntry) const
+{
+    ThreadError error = kThreadError_None;
+
+    VerifyOrExit(aIndex < kMaxEntries, error = kThreadError_InvalidArgs);
+
+    memcpy(&aEntry.mExtAddress, &mBlacklist[aIndex].mExtAddress, sizeof(aEntry.mExtAddress));
+    aEntry.mValid = mBlacklist[aIndex].mValid;
+
+exit:
+    return error;
+}
+
+Blacklist::Entry *Blacklist::Add(const ExtAddress &address)
+{
+    Entry *rval;
+
+    VerifyOrExit((rval = Find(address)) == NULL, ;);
+
+    for (int i = 0; i < kMaxEntries; i++)
+    {
+        if (mBlacklist[i].mValid)
+        {
+            continue;
+        }
+
+        memcpy(&mBlacklist[i].mExtAddress, &address, sizeof(mBlacklist[i].mExtAddress));
+        mBlacklist[i].mValid = true;
+        ExitNow(rval = &mBlacklist[i]);
+    }
+
+exit:
+    return rval;
+}
+
+void Blacklist::Clear(void)
+{
+    for (int i = 0; i < kMaxEntries; i++)
+    {
+        mBlacklist[i].mValid = false;
+    }
+}
+
+void Blacklist::Remove(const ExtAddress &address)
+{
+    Entry *entry;
+
+    VerifyOrExit((entry = Find(address)) != NULL, ;);
+    memset(entry, 0, sizeof(*entry));
+
+exit:
+    {}
+}
+
+Blacklist::Entry *Blacklist::Find(const ExtAddress &address)
+{
+    Entry *rval = NULL;
+
+    for (int i = 0; i < kMaxEntries; i++)
+    {
+        if (!mBlacklist[i].mValid)
+        {
+            continue;
+        }
+
+        if (memcmp(&mBlacklist[i].mExtAddress, &address, sizeof(mBlacklist[i].mExtAddress)) == 0)
+        {
+            ExitNow(rval = &mBlacklist[i]);
+        }
+    }
+
+exit:
+    return rval;
+}
+
+}  // namespace Mac
+}  // namespace Thread

--- a/src/core/mac/mac_blacklist.cpp
+++ b/src/core/mac/mac_blacklist.cpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *   This file implements whitelist IEEE 802.15.4 frame filtering based on MAC address.
+ *   This file implements blacklist IEEE 802.15.4 frame filtering based on MAC address.
  */
 
 #include <string.h>

--- a/src/core/mac/mac_blacklist.hpp
+++ b/src/core/mac/mac_blacklist.hpp
@@ -1,0 +1,161 @@
+/*
+ *  Copyright (c) 2016, Nest Labs, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for IEEE 802.15.4 frame filtering based on MAC address.
+ */
+
+#ifndef MAC_BLACKLIST_HPP_
+#define MAC_BLACKLIST_HPP_
+
+#include <stdint.h>
+
+#include <openthread-types.h>
+#include <mac/mac_frame.hpp>
+
+namespace Thread {
+namespace Mac {
+
+/**
+ * @addtogroup core-mac
+ *
+ * @{
+ *
+ */
+
+/**
+ * This class implements blacklist filtering on IEEE 802.15.4 frames.
+ *
+ */
+class Blacklist
+{
+public:
+    typedef otMacBlacklistEntry Entry;
+
+    enum
+    {
+        kMaxEntries = 32,
+    };
+
+    /**
+     * This constructor initializes the blacklist filter.
+     *
+     */
+    Blacklist(void);
+
+    /**
+     * This method enables the blacklist filter.
+     *
+     */
+    void Enable(void);
+
+    /**
+     * This method disables the blacklist filter.
+     *
+     */
+    void Disable(void);
+
+    /**
+     * This method indicates whether or not the blacklist filter is enabled.
+     *
+     * @retval TRUE   If the blacklist filter is enabled.
+     * @retval FALSE  If the blacklist filter is disabled.
+     *
+     */
+    bool IsEnabled(void) const;
+
+    /**
+     * This method returns the maximum number of blacklist entries.
+     *
+     * @returns The maximum number of blacklist entries.
+     *
+     */
+    int GetMaxEntries(void) const;
+
+    /**
+     * This method gets a blacklist entry.
+     *
+     * @param[in]   aIndex  An index into the MAC blacklist table.
+     * @param[out]  aEntry  A reference to where the information is placed.
+     *
+     * @retval kThreadError_None         Successfully retrieved the MAC blacklist entry.
+     * @retval kThreadError_InvalidArgs  @p aIndex is out of bounds or @p aEntry is NULL.
+     *
+     */
+    ThreadError GetEntry(uint8_t aIndex, Entry &aEntry) const;
+
+    /**
+     * This method adds an Extended Address to the blacklist filter.
+     *
+     * @param[in]  aAddress  A reference to the Extended Address.
+     *
+     * @returns A pointer to the blacklist entry or NULL if there are no available entries.
+     *
+     */
+    Entry *Add(const ExtAddress &aAddress);
+
+    /**
+     * This method removes an Extended Address to the blacklist filter.
+     *
+     * @param[in]  aAddress  A reference to the Extended Address.
+     *
+     */
+    void Remove(const ExtAddress &aAddress);
+
+    /**
+     * This method removes all entries from the blacklist filter.
+     *
+     */
+    void Clear(void);
+
+    /**
+     * This method finds a blacklist entry.
+     *
+     * @param[in]  aAddress  A reference to the Extended Address.
+     *
+     * @returns A pointer to the blacklist entry or NULL if the entry could not be found.
+     *
+     */
+    Entry *Find(const ExtAddress &aAddress);
+
+private:
+    Entry mBlacklist[kMaxEntries];
+
+    bool mEnabled;
+};
+
+/**
+ * @}
+ *
+ */
+
+}  // namespace Mac
+}  // namespace Thread
+
+#endif  // MAC_BLACKLIST_HPP_

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -293,6 +293,16 @@ void otSetLocalLeaderWeight(uint8_t aWeight)
     sThreadNetif->GetMle().SetLeaderWeight(aWeight);
 }
 
+uint32_t otGetLocalLeaderPartitionId(void)
+{
+	return sThreadNetif->GetMle().GetLeaderPartitionId();
+}
+
+void otSetLocalLeaderPartitionId(uint32_t aPartitionId)
+{
+	return sThreadNetif->GetMle().SetLeaderPartitionId(aPartitionId);
+}
+
 ThreadError otAddBorderRouter(const otBorderRouterConfig *aConfig)
 {
     uint8_t flags = 0;

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -555,6 +555,26 @@ bool otIsMacBlacklistEnabled(void)
 	return sThreadNetif->GetMac().GetBlacklist().IsEnabled();
 }
 
+ThreadError otGetAssignLinkQuality(const uint8_t *aExtAddr, uint8_t *aLinkQuality)
+{
+	Mac::ExtAddress extAddress;
+
+	memset(&extAddress, 0, sizeof(extAddress));
+	memcpy(extAddress.m8, aExtAddr, OT_EXT_ADDRESS_SIZE);
+
+	return sThreadNetif->GetMle().GetAssignLinkQuality(extAddress, *aLinkQuality);
+}
+
+void otSetAssignLinkQuality(const uint8_t *aExtAddr, uint8_t aLinkQuality)
+{
+	Mac::ExtAddress extAddress;
+
+	memset(&extAddress, 0, sizeof(extAddress));
+	memcpy(extAddress.m8, aExtAddr, OT_EXT_ADDRESS_SIZE);
+
+	sThreadNetif->GetMle().SetAssignLinkQuality(extAddress, aLinkQuality);
+}
+
 ThreadError otGetChildInfoById(uint16_t aChildId, otChildInfo *aChildInfo)
 {
     ThreadError error = kThreadError_None;

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -715,6 +715,15 @@ const char *otGetVersionString(void)
         __DATE__ " " __TIME__;
 
     return sVersion;
+
+uint32_t otGetPollPeriod()
+{
+	return sThreadNetif->GetMeshForwarder().GetPollPeriod();
+}
+
+void otSetPollPeriod(uint32_t aPollPeriod)
+{
+	sThreadNetif->GetMeshForwarder().SetPollPeriod(aPollPeriod);
 }
 
 ThreadError otEnable(void)

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -296,12 +296,12 @@ void otSetLocalLeaderWeight(uint8_t aWeight)
 
 uint32_t otGetLocalLeaderPartitionId(void)
 {
-	return sThreadNetif->GetMle().GetLeaderPartitionId();
+    return sThreadNetif->GetMle().GetLeaderPartitionId();
 }
 
 void otSetLocalLeaderPartitionId(uint32_t aPartitionId)
 {
-	return sThreadNetif->GetMle().SetLeaderPartitionId(aPartitionId);
+    return sThreadNetif->GetMle().SetLeaderPartitionId(aPartitionId);
 }
 
 ThreadError otAddBorderRouter(const otBorderRouterConfig *aConfig)
@@ -510,75 +510,75 @@ ThreadError otBecomeLeader(void)
 
 ThreadError otAddMacBlacklist(const uint8_t *aExtAddr)
 {
-	ThreadError error = kThreadError_None;
+    ThreadError error = kThreadError_None;
 
-	if (sThreadNetif->GetMac().GetBlacklist().Add(*reinterpret_cast<const Mac::ExtAddress *>(aExtAddr)) == NULL)
-	{
-		error = kThreadError_NoBufs;
-	}
+    if (sThreadNetif->GetMac().GetBlacklist().Add(*reinterpret_cast<const Mac::ExtAddress *>(aExtAddr)) == NULL)
+    {
+        error = kThreadError_NoBufs;
+    }
 
-	return error;
+    return error;
 }
 
 void otRemoveMacBlacklist(const uint8_t *aExtAddr)
 {
-	sThreadNetif->GetMac().GetBlacklist().Remove(*reinterpret_cast<const Mac::ExtAddress *>(aExtAddr));
+    sThreadNetif->GetMac().GetBlacklist().Remove(*reinterpret_cast<const Mac::ExtAddress *>(aExtAddr));
 }
 
 void otClearMacBlacklist(void)
 {
-	sThreadNetif->GetMac().GetBlacklist().Clear();
+    sThreadNetif->GetMac().GetBlacklist().Clear();
 }
 
 ThreadError otGetMacBlacklistEntry(uint8_t aIndex, otMacBlacklistEntry *aEntry)
 {
-	ThreadError error = kThreadError_None;
+    ThreadError error = kThreadError_None;
 
-	VerifyOrExit(aEntry != NULL, error = kThreadError_InvalidArgs);
-	error = sThreadNetif->GetMac().GetBlacklist().GetEntry(aIndex, *aEntry);
+    VerifyOrExit(aEntry != NULL, error = kThreadError_InvalidArgs);
+    error = sThreadNetif->GetMac().GetBlacklist().GetEntry(aIndex, *aEntry);
 
 exit:
-	return error;
+    return error;
 }
 
 void otDisableMacBlacklist(void)
 {
-	sThreadNetif->GetMac().GetBlacklist().Disable();
+    sThreadNetif->GetMac().GetBlacklist().Disable();
 }
 
 void otEnableMacBlacklist(void)
 {
-	sThreadNetif->GetMac().GetBlacklist().Enable();
+    sThreadNetif->GetMac().GetBlacklist().Enable();
 }
 
 bool otIsMacBlacklistEnabled(void)
 {
-	return sThreadNetif->GetMac().GetBlacklist().IsEnabled();
+    return sThreadNetif->GetMac().GetBlacklist().IsEnabled();
 }
 
 ThreadError otGetAssignLinkQuality(const uint8_t *aExtAddr, uint8_t *aLinkQuality)
 {
-	Mac::ExtAddress extAddress;
+    Mac::ExtAddress extAddress;
 
-	memset(&extAddress, 0, sizeof(extAddress));
-	memcpy(extAddress.m8, aExtAddr, OT_EXT_ADDRESS_SIZE);
+    memset(&extAddress, 0, sizeof(extAddress));
+    memcpy(extAddress.m8, aExtAddr, OT_EXT_ADDRESS_SIZE);
 
-	return sThreadNetif->GetMle().GetAssignLinkQuality(extAddress, *aLinkQuality);
+    return sThreadNetif->GetMle().GetAssignLinkQuality(extAddress, *aLinkQuality);
 }
 
 void otSetAssignLinkQuality(const uint8_t *aExtAddr, uint8_t aLinkQuality)
 {
-	Mac::ExtAddress extAddress;
+    Mac::ExtAddress extAddress;
 
-	memset(&extAddress, 0, sizeof(extAddress));
-	memcpy(extAddress.m8, aExtAddr, OT_EXT_ADDRESS_SIZE);
+    memset(&extAddress, 0, sizeof(extAddress));
+    memcpy(extAddress.m8, aExtAddr, OT_EXT_ADDRESS_SIZE);
 
-	sThreadNetif->GetMle().SetAssignLinkQuality(extAddress, aLinkQuality);
+    sThreadNetif->GetMle().SetAssignLinkQuality(extAddress, aLinkQuality);
 }
 
 void otPlatformReset(void)
 {
-	otPlatReset();
+    otPlatReset();
 }
 
 ThreadError otGetChildInfoById(uint16_t aChildId, otChildInfo *aChildInfo)
@@ -702,17 +702,17 @@ exit:
 
 ThreadError otGetParentInfo(otRouterInfo *aParentInfo)
 {
-	ThreadError error = kThreadError_None;
-	Router *parent;
+    ThreadError error = kThreadError_None;
+    Router *parent;
 
-	VerifyOrExit(aParentInfo != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aParentInfo != NULL, error = kThreadError_InvalidArgs);
 
-	parent = sThreadNetif->GetMle().GetParent();
-	memcpy(aParentInfo->mExtAddress.m8, parent->mMacAddr.m8, OT_EXT_ADDRESS_SIZE);
-	aParentInfo->mRloc16 = parent->mValid.mRloc16;
+    parent = sThreadNetif->GetMle().GetParent();
+    memcpy(aParentInfo->mExtAddress.m8, parent->mMacAddr.m8, OT_EXT_ADDRESS_SIZE);
+    aParentInfo->mRloc16 = parent->mValid.mRloc16;
 
 exit:
-	return error;
+    return error;
 }
 
 uint8_t otGetStableNetworkDataVersion(void)
@@ -792,12 +792,12 @@ const char *otGetVersionString(void)
 
 uint32_t otGetPollPeriod()
 {
-	return sThreadNetif->GetMeshForwarder().GetPollPeriod();
+    return sThreadNetif->GetMeshForwarder().GetPollPeriod();
 }
 
 void otSetPollPeriod(uint32_t aPollPeriod)
 {
-	sThreadNetif->GetMeshForwarder().SetPollPeriod(aPollPeriod);
+    sThreadNetif->GetMeshForwarder().SetPollPeriod(aPollPeriod);
 }
 
 ThreadError otEnable(void)

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -463,7 +463,7 @@ void otClearMacWhitelist(void)
 
 ThreadError otGetMacWhitelistEntry(uint8_t aIndex, otMacWhitelistEntry *aEntry)
 {
-    ThreadError error;
+    ThreadError error = kThreadError_None;
 
     VerifyOrExit(aEntry != NULL, error = kThreadError_InvalidArgs);
     error = sThreadNetif->GetMac().GetWhitelist().GetEntry(aIndex, *aEntry);
@@ -505,6 +505,54 @@ ThreadError otBecomeRouter(void)
 ThreadError otBecomeLeader(void)
 {
     return sThreadNetif->GetMle().BecomeLeader();
+}
+
+ThreadError otAddMacBlacklist(const uint8_t *aExtAddr)
+{
+	ThreadError error = kThreadError_None;
+
+	if (sThreadNetif->GetMac().GetBlacklist().Add(*reinterpret_cast<const Mac::ExtAddress *>(aExtAddr)) == NULL)
+	{
+		error = kThreadError_NoBufs;
+	}
+
+	return error;
+}
+
+void otRemoveMacBlacklist(const uint8_t *aExtAddr)
+{
+	sThreadNetif->GetMac().GetBlacklist().Remove(*reinterpret_cast<const Mac::ExtAddress *>(aExtAddr));
+}
+
+void otClearMacBlacklist(void)
+{
+	sThreadNetif->GetMac().GetBlacklist().Clear();
+}
+
+ThreadError otGetMacBlacklistEntry(uint8_t aIndex, otMacBlacklistEntry *aEntry)
+{
+	ThreadError error = kThreadError_None;
+
+	VerifyOrExit(aEntry != NULL, error = kThreadError_InvalidArgs);
+	error = sThreadNetif->GetMac().GetBlacklist().GetEntry(aIndex, *aEntry);
+
+exit:
+	return error;
+}
+
+void otDisableMacBlacklist(void)
+{
+	sThreadNetif->GetMac().GetBlacklist().Disable();
+}
+
+void otEnableMacBlacklist(void)
+{
+	sThreadNetif->GetMac().GetBlacklist().Enable();
+}
+
+bool otIsMacBlacklistEnabled(void)
+{
+	return sThreadNetif->GetMac().GetBlacklist().IsEnabled();
 }
 
 ThreadError otGetChildInfoById(uint16_t aChildId, otChildInfo *aChildInfo)

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -789,6 +789,7 @@ const char *otGetVersionString(void)
         __DATE__ " " __TIME__;
 
     return sVersion;
+}
 
 uint32_t otGetPollPeriod()
 {

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -43,6 +43,7 @@
 #include <net/icmp6.hpp>
 #include <net/ip6.hpp>
 #include <platform/random.h>
+#include <platform/misc.h>
 #include <thread/thread_netif.hpp>
 
 namespace Thread {
@@ -573,6 +574,11 @@ void otSetAssignLinkQuality(const uint8_t *aExtAddr, uint8_t aLinkQuality)
 	memcpy(extAddress.m8, aExtAddr, OT_EXT_ADDRESS_SIZE);
 
 	sThreadNetif->GetMle().SetAssignLinkQuality(extAddress, aLinkQuality);
+}
+
+void otPlatformReset(void)
+{
+	otPlatReset();
 }
 
 ThreadError otGetChildInfoById(uint16_t aChildId, otChildInfo *aChildInfo)

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -626,6 +626,21 @@ exit:
     return error;
 }
 
+ThreadError otGetParentInfo(otRouterInfo *aParentInfo)
+{
+	ThreadError error = kThreadError_None;
+	Router *parent;
+
+	VerifyOrExit(aParentInfo != NULL, error = kThreadError_InvalidArgs);
+
+	parent = sThreadNetif->GetMle().GetParent();
+	memcpy(aParentInfo->mExtAddress.m8, parent->mMacAddr.m8, OT_EXT_ADDRESS_SIZE);
+	aParentInfo->mRloc16 = parent->mValid.mRloc16;
+
+exit:
+	return error;
+}
+
 uint8_t otGetStableNetworkDataVersion(void)
 {
     return sThreadNetif->GetMle().GetLeaderDataTlv().GetStableDataVersion();

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -581,6 +581,11 @@ void MeshForwarder::SetPollPeriod(uint32_t aPeriod)
     mPollPeriod = aPeriod;
 }
 
+uint32_t MeshForwarder::GetPollPeriod()
+{
+	return mPollPeriod;
+}
+
 void MeshForwarder::HandlePollTimer(void *aContext)
 {
     MeshForwarder *obj = reinterpret_cast<MeshForwarder *>(aContext);

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -146,7 +146,7 @@ public:
      * @returns  The Data Poll period in milliseconds.
      *
      */
-	uint32_t GetPollPeriod(void);
+    uint32_t GetPollPeriod(void);
 
     /**
      * This method sets the scan parameters for MLE Discovery Request messages.
@@ -217,6 +217,7 @@ private:
     uint16_t mFragTag;
     uint16_t mMessageNextOffset;
     uint32_t mPollPeriod;
+    bool mPollPeriodAssigned;
     Message *mSendMessage;
 
     Mac::Address mMacSource;

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -141,6 +141,14 @@ public:
     void SetPollPeriod(uint32_t aPeriod);
 
     /**
+     * This method gets the Data Poll period.
+     *
+     * @returns  The Data Poll period in milliseconds.
+     *
+     */
+	uint32_t GetPollPeriod(void);
+
+    /**
      * This method sets the scan parameters for MLE Discovery Request messages.
      *
      * @param[in]  aScanChannels  A bit vector indicating which channels to scan.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -144,10 +144,10 @@ Mle::Mle(ThreadNetif &aThreadNetif) :
     mNetifCallback.Set(&HandleNetifStateChanged, this);
     mNetif.RegisterCallback(mNetifCallback);
 
-	isAssignLinkQuality = false;
-	mAssignLinkQuality = 0;
-	mAssignLinkMargin = 0;
-	memset(&mAddr64, 0, sizeof(mAddr64));
+    isAssignLinkQuality = false;
+    mAssignLinkQuality = 0;
+    mAssignLinkMargin = 0;
+    memset(&mAddr64, 0, sizeof(mAddr64));
 }
 
 ThreadError Mle::Enable(void)
@@ -495,12 +495,12 @@ ThreadError Mle::SetRloc16(uint16_t aRloc16)
     if (aRloc16 != Mac::kShortAddrInvalid)
     {
         // link-local 16
-		// add link-local 16 only for sleepy end device
-		if ((mDeviceMode & ModeTlv::kModeRxOnWhenIdle) == 0)
-		{
-        	mLinkLocal16.GetAddress().mFields.m16[7] = HostSwap16(aRloc16);
-        	mNetif.AddUnicastAddress(mLinkLocal16);
-		}
+        // add link-local 16 only for sleepy end device
+        if ((mDeviceMode & ModeTlv::kModeRxOnWhenIdle) == 0)
+        {
+            mLinkLocal16.GetAddress().mFields.m16[7] = HostSwap16(aRloc16);
+            mNetif.AddUnicastAddress(mLinkLocal16);
+        }
 
         // mesh-local 16
         mMeshLocal16.GetAddress().mFields.m16[7] = HostSwap16(aRloc16);
@@ -582,49 +582,45 @@ exit:
 
 ThreadError Mle::GetAssignLinkQuality(const Mac::ExtAddress aMacAddr, uint8_t &aLinkQuality)
 {
-	ThreadError error;
-	uint8_t numChildren;
-	Child *children;
+    ThreadError error;
 
-	VerifyOrExit((children = mMleRouter.GetChildren(&numChildren)) != NULL, error = kThreadError_InvalidState);
-	for (int i = 0; i < numChildren; i++)
-	{
-		if (memcmp(aMacAddr.m8, children[i].mMacAddr.m8, OT_EXT_ADDRESS_SIZE) == 0)
-		{
-			aLinkQuality = mAssignLinkQuality;
-			return kThreadError_None;
-		}
-	}
+    VerifyOrExit((memcmp(aMacAddr.m8, mAddr64.m8, OT_EXT_ADDRESS_SIZE)) == 0, error = kThreadError_InvalidArgs);
 
-	// didn't find the extended address from child table
-	error = kThreadError_InvalidState;
+    aLinkQuality = mAssignLinkQuality;
+
+    return kThreadError_None;
 
 exit:
-	return error;
+    return error;
 }
 
 void Mle::SetAssignLinkQuality(const Mac::ExtAddress aMacAddr, uint8_t aLinkQuality)
 {
-	isAssignLinkQuality = true;
-	mAddr64 = aMacAddr;
+    isAssignLinkQuality = true;
+    mAddr64 = aMacAddr;
 
-	mAssignLinkQuality = aLinkQuality;
-	switch (aLinkQuality)
-	{
-	case 3:
-		mAssignLinkMargin = 0xff; // 21 - 255
-		break;
-	case 2:
-		mAssignLinkMargin = 0x14; // 11 - 20
-		break;
-	case 1:
-		mAssignLinkMargin = 0x09; // 3 - 9
-		break;
-	case 0:
-		mAssignLinkMargin = 0x0; // 0 - 2
-	default:
-		break;
-	}
+    mAssignLinkQuality = aLinkQuality;
+
+    switch (aLinkQuality)
+    {
+    case 3:
+        mAssignLinkMargin = 0xff; // 21 - 255
+        break;
+
+    case 2:
+        mAssignLinkMargin = 0x14; // 11 - 20
+        break;
+
+    case 1:
+        mAssignLinkMargin = 0x09; // 3 - 9
+        break;
+
+    case 0:
+        mAssignLinkMargin = 0x0; // 0 - 2
+
+    default:
+        break;
+    }
 }
 
 void Mle::GenerateNonce(const Mac::ExtAddress &aMacAddr, uint32_t aFrameCounter, uint8_t aSecurityLevel,
@@ -1819,14 +1815,14 @@ ThreadError Mle::HandleParentResponse(const Message &aMessage, const Ip6::Messag
         linkMargin = linkMarginTlv.GetLinkMargin();
     }
 
-	// add for Thread Certification testing
-	if (isAssignLinkQuality)
-	{
-		linkMargin = linkMarginTlv.GetLinkMargin();
+    // add for Thread Certification testing
+    if (isAssignLinkQuality)
+    {
+        linkMargin = linkMarginTlv.GetLinkMargin();
 
-		// clear flag for subsequent normal MLE message
-		isAssignLinkQuality = false;
-	}
+        // clear flag for subsequent normal MLE message
+        isAssignLinkQuality = false;
+    }
 
     linkQuality = LinkQualityInfo::ConvertLinkMarginToLinkQuality(linkMargin);
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -495,8 +495,12 @@ ThreadError Mle::SetRloc16(uint16_t aRloc16)
     if (aRloc16 != Mac::kShortAddrInvalid)
     {
         // link-local 16
-        mLinkLocal16.GetAddress().mFields.m16[7] = HostSwap16(aRloc16);
-        mNetif.AddUnicastAddress(mLinkLocal16);
+		// add link-local 16 only for sleepy end device
+		if ((mDeviceMode & ModeTlv::kModeRxOnWhenIdle) == 0)
+		{
+        	mLinkLocal16.GetAddress().mFields.m16[7] = HostSwap16(aRloc16);
+        	mNetif.AddUnicastAddress(mLinkLocal16);
+		}
 
         // mesh-local 16
         mMeshLocal16.GetAddress().mFields.m16[7] = HostSwap16(aRloc16);

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -629,20 +629,20 @@ public:
      * @param[in]  aMacAddr  The IEEE 802.15.4 Extended Mac Address.
      * @param[in]  aLinkQuality A reference to the assigned link quality.
      *
-     * @retval kThreadError_None          Successfully retrieved the link quality to aLinkQuality.
-     * @retval kThreadError_InvalidState  No attached child matches with a given extended address.
+     * @retval kThreadError_None         Successfully retrieve the link quality to aLinkQuality.
+     * @retval kThreadError_InvalidArgs  No match found with a given extended address.
      *
      */
-	ThreadError GetAssignLinkQuality(const Mac::ExtAddress aMacAddr, uint8_t &aLinkQuality);
+    ThreadError GetAssignLinkQuality(const Mac::ExtAddress aMacAddr, uint8_t &aLinkQuality);
 
     /**
      * This method sets the link quality on the link to a given extended address.
      *
      * @param[in]  aMacAddr  The IEEE 802.15.4 Extended Mac Address.
-	 * @param[in]  aLinkQaulity The link quality to be set on the link.
+     * @param[in]  aLinkQaulity The link quality to be set on the link.
      *
      */
-	void SetAssignLinkQuality(const Mac::ExtAddress aMacAddr, uint8_t aLinkQuality);
+    void SetAssignLinkQuality(const Mac::ExtAddress aMacAddr, uint8_t aLinkQuality);
 
     /**
      * This method returns the Child ID portion of an RLOC16.
@@ -1068,10 +1068,10 @@ protected:
     Router mParent;                         ///< Parent information.
     uint8_t mDeviceMode;                    ///< Device mode setting.
 
-	bool isAssignLinkQuality;    ///<Indicating an assigned link quality is used on the link 
-	uint8_t mAssignLinkQuality;  ///<The assigned link quality value
-	uint8_t mAssignLinkMargin;   ///<The maximum link margin corresponding to mAssignLink
-	Mac::ExtAddress mAddr64;     ///<A given IEEE 802.15.4 Extended Address
+    bool isAssignLinkQuality;    ///< Indicating an assigned link quality is used on the link
+    uint8_t mAssignLinkQuality;  ///< The assigned link quality value
+    uint8_t mAssignLinkMargin;   ///< The maximum link margin corresponding to mAssignLinkQuality
+    Mac::ExtAddress mAddr64;     ///< A given IEEE 802.15.4 Extended Address
 
     /**
      * States when searching for a parent.

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -624,6 +624,27 @@ public:
     ThreadError GetLeaderData(otLeaderData &aLeaderData);
 
     /**
+     * This method returns the link quality on the link to a given extended address.
+     *
+     * @param[in]  aMacAddr  The IEEE 802.15.4 Extended Mac Address.
+     * @param[in]  aLinkQuality A reference to the assigned link quality.
+     *
+     * @retval kThreadError_None          Successfully retrieved the link quality to aLinkQuality.
+     * @retval kThreadError_InvalidState  No attached child matches with a given extended address.
+     *
+     */
+	ThreadError GetAssignLinkQuality(const Mac::ExtAddress aMacAddr, uint8_t &aLinkQuality);
+
+    /**
+     * This method sets the link quality on the link to a given extended address.
+     *
+     * @param[in]  aMacAddr  The IEEE 802.15.4 Extended Mac Address.
+	 * @param[in]  aLinkQaulity The link quality to be set on the link.
+     *
+     */
+	void SetAssignLinkQuality(const Mac::ExtAddress aMacAddr, uint8_t aLinkQuality);
+
+    /**
      * This method returns the Child ID portion of an RLOC16.
      *
      * @param[in]  aRloc16  The RLOC16 value.
@@ -1046,6 +1067,11 @@ protected:
     DeviceState mDeviceState;               ///< Current Thread interface state.
     Router mParent;                         ///< Parent information.
     uint8_t mDeviceMode;                    ///< Device mode setting.
+
+	bool isAssignLinkQuality;    ///<Indicating an assigned link quality is used on the link 
+	uint8_t mAssignLinkQuality;  ///<The assigned link quality value
+	uint8_t mAssignLinkMargin;   ///<The maximum link margin corresponding to mAssignLink
+	Mac::ExtAddress mAddr64;     ///<A given IEEE 802.15.4 Extended Address
 
     /**
      * States when searching for a parent.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -64,7 +64,7 @@ MleRouter::MleRouter(ThreadNetif &aThreadNetif):
     mNetworkIdTimeout = kNetworkIdTimeout;
     mRouterUpgradeThreshold = kRouterUpgradeThreshold;
     mLeaderWeight = 0;
-    mLeaderPartitionId = 0;
+    mFixedLeaderPartitionId = 0;
     mRouterId = kMaxRouterId;
     mPreviousRouterId = kMaxRouterId;
     mAdvertiseInterval = kAdvertiseIntervalMin;
@@ -247,14 +247,15 @@ ThreadError MleRouter::BecomeLeader(void)
 
     memcpy(&mRouters[mRouterId].mMacAddr, mMac.GetExtAddress(), sizeof(mRouters[mRouterId].mMacAddr));
 
-	if (mLeaderPartitionId != 0)
-	{
-    	SetLeaderData(mLeaderPartitionId, mLeaderWeight, mRouterId);
-	}
-	else
-	{
-    	SetLeaderData(otPlatRandomGet(), mLeaderWeight, mRouterId);
-	}
+    if (mFixedLeaderPartitionId != 0)
+    {
+        SetLeaderData(mFixedLeaderPartitionId, mLeaderWeight, mRouterId);
+    }
+    else
+    {
+        SetLeaderData(otPlatRandomGet(), mLeaderWeight, mRouterId);
+    }
+
     mRouterIdSequence = static_cast<uint8_t>(otPlatRandomGet());
 
     mNetworkData.Reset();
@@ -2525,12 +2526,12 @@ void MleRouter::SetLeaderWeight(uint8_t aWeight)
 
 uint32_t MleRouter::GetLeaderPartitionId(void) const
 {
-    return mLeaderPartitionId;
+    return mFixedLeaderPartitionId;
 }
 
 void MleRouter::SetLeaderPartitionId(uint32_t aPartitionId)
 {
-    mLeaderPartitionId = aPartitionId;
+    mFixedLeaderPartitionId = aPartitionId;
 }
 
 void MleRouter::HandleMacDataRequest(const Child &aChild)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -64,6 +64,7 @@ MleRouter::MleRouter(ThreadNetif &aThreadNetif):
     mNetworkIdTimeout = kNetworkIdTimeout;
     mRouterUpgradeThreshold = kRouterUpgradeThreshold;
     mLeaderWeight = 0;
+    mLeaderPartitionId = 0;
     mRouterId = kMaxRouterId;
     mPreviousRouterId = kMaxRouterId;
     mAdvertiseInterval = kAdvertiseIntervalMin;
@@ -246,7 +247,14 @@ ThreadError MleRouter::BecomeLeader(void)
 
     memcpy(&mRouters[mRouterId].mMacAddr, mMac.GetExtAddress(), sizeof(mRouters[mRouterId].mMacAddr));
 
-    SetLeaderData(otPlatRandomGet(), mLeaderWeight, mRouterId);
+	if (mLeaderPartitionId != 0)
+	{
+    	SetLeaderData(mLeaderPartitionId, mLeaderWeight, mRouterId);
+	}
+	else
+	{
+    	SetLeaderData(otPlatRandomGet(), mLeaderWeight, mRouterId);
+	}
     mRouterIdSequence = static_cast<uint8_t>(otPlatRandomGet());
 
     mNetworkData.Reset();
@@ -2502,6 +2510,16 @@ uint8_t MleRouter::GetLeaderWeight(void) const
 void MleRouter::SetLeaderWeight(uint8_t aWeight)
 {
     mLeaderWeight = aWeight;
+}
+
+uint32_t MleRouter::GetLeaderPartitionId(void) const
+{
+	return mLeaderPartitionId;
+}
+
+void MleRouter::SetLeaderPartitionId(uint32_t aPartitionId)
+{
+	mLeaderPartitionId = aPartitionId;
 }
 
 void MleRouter::HandleMacDataRequest(const Child &aChild)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1683,16 +1683,16 @@ ThreadError MleRouter::SendParentResponse(Child *aChild, const ChallengeTlv &cha
 
     SuccessOrExit(error = AppendChallenge(*message, aChild->mPending.mChallenge, sizeof(aChild->mPending.mChallenge)));
 
-	if (isAssignLinkQuality &&
-	    (memcmp(mAddr64.m8, aChild->mMacAddr.m8, OT_EXT_ADDRESS_SIZE) == 0))
-	{
-		// use assigned one to ensure the link quality
-		SuccessOrExit(error = AppendLinkMargin(*message, mAssignLinkMargin));	
-	}
-	else
-	{
-		SuccessOrExit(error = AppendLinkMargin(*message, aChild->mLinkInfo.GetLinkMargin()));
-	}
+    if (isAssignLinkQuality &&
+        (memcmp(mAddr64.m8, aChild->mMacAddr.m8, OT_EXT_ADDRESS_SIZE) == 0))
+    {
+        // use assigned one to ensure the link quality
+        SuccessOrExit(error = AppendLinkMargin(*message, mAssignLinkMargin));
+    }
+    else
+    {
+        SuccessOrExit(error = AppendLinkMargin(*message, aChild->mLinkInfo.GetLinkMargin()));
+    }
 
     SuccessOrExit(error = AppendConnectivity(*message));
     SuccessOrExit(error = AppendVersion(*message));
@@ -2525,12 +2525,12 @@ void MleRouter::SetLeaderWeight(uint8_t aWeight)
 
 uint32_t MleRouter::GetLeaderPartitionId(void) const
 {
-	return mLeaderPartitionId;
+    return mLeaderPartitionId;
 }
 
 void MleRouter::SetLeaderPartitionId(uint32_t aPartitionId)
 {
-	mLeaderPartitionId = aPartitionId;
+    mLeaderPartitionId = aPartitionId;
 }
 
 void MleRouter::HandleMacDataRequest(const Child &aChild)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1682,7 +1682,18 @@ ThreadError MleRouter::SendParentResponse(Child *aChild, const ChallengeTlv &cha
     }
 
     SuccessOrExit(error = AppendChallenge(*message, aChild->mPending.mChallenge, sizeof(aChild->mPending.mChallenge)));
-    SuccessOrExit(error = AppendLinkMargin(*message, aChild->mLinkInfo.GetLinkMargin()));
+
+	if (isAssignLinkQuality &&
+	    (memcmp(mAddr64.m8, aChild->mMacAddr.m8, OT_EXT_ADDRESS_SIZE) == 0))
+	{
+		// use assigned one to ensure the link quality
+		SuccessOrExit(error = AppendLinkMargin(*message, mAssignLinkMargin));	
+	}
+	else
+	{
+		SuccessOrExit(error = AppendLinkMargin(*message, aChild->mLinkInfo.GetLinkMargin()));
+	}
+
     SuccessOrExit(error = AppendConnectivity(*message));
     SuccessOrExit(error = AppendVersion(*message));
 

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -155,7 +155,7 @@ public:
      * @returns The Partition Id for this Thread network partition.
      *
      */
-	uint32_t GetLeaderPartitionId(void) const;
+    uint32_t GetLeaderPartitionId(void) const;
 
     /**
      * This method sets the Partition Id for this Thread network partition.
@@ -163,7 +163,7 @@ public:
      * @param[in]  aPartitionId  The Leader Partition Id.
      *
      */
-	void SetLeaderPartitionId(uint32_t aPartitionId);
+    void SetLeaderPartitionId(uint32_t aPartitionId);
 
     /**
      * This method returns the next hop towards an RLOC16 destination.

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -150,7 +150,7 @@ public:
     void SetLeaderWeight(uint8_t aWeight);
 
     /**
-     * This method returns the Partition Id for this Thread network partition.
+     * This method returns the fixed Partition Id of Thread network partition for certification testing.
      *
      * @returns The Partition Id for this Thread network partition.
      *
@@ -158,7 +158,7 @@ public:
     uint32_t GetLeaderPartitionId(void) const;
 
     /**
-     * This method sets the Partition Id for this Thread network partition.
+     * This method sets the fixed Partition Id for Thread network partition for certification testing.
      *
      * @param[in]  aPartitionId  The Leader Partition Id.
      *
@@ -506,7 +506,7 @@ private:
     uint8_t mNetworkIdTimeout;
     uint8_t mRouterUpgradeThreshold;
     uint8_t mLeaderWeight;
-    uint32_t mLeaderPartitionId;
+    uint32_t mFixedLeaderPartitionId;  ///< only for certification testing
     bool mRouterRoleEnabled;
 
     uint8_t mRouterId;

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -150,6 +150,22 @@ public:
     void SetLeaderWeight(uint8_t aWeight);
 
     /**
+     * This method returns the Partition Id for this Thread network partition.
+     *
+     * @returns The Partition Id for this Thread network partition.
+     *
+     */
+	uint32_t GetLeaderPartitionId(void) const;
+
+    /**
+     * This method sets the Partition Id for this Thread network partition.
+     *
+     * @param[in]  aPartitionId  The Leader Partition Id.
+     *
+     */
+	void SetLeaderPartitionId(uint32_t aPartitionId);
+
+    /**
      * This method returns the next hop towards an RLOC16 destination.
      *
      * @param[in]  aDestination  The RLOC16 of the destination.
@@ -490,6 +506,7 @@ private:
     uint8_t mNetworkIdTimeout;
     uint8_t mRouterUpgradeThreshold;
     uint8_t mLeaderWeight;
+    uint32_t mLeaderPartitionId;
     bool mRouterRoleEnabled;
 
     uint8_t mRouterId;


### PR DESCRIPTION
Create this pull request for adding extra CLIs to fully support THCI that interact with Harness for Thread Certificate 1.1 testing. (includes multiple submits for each CLI implementation).
Added CLIs as below:
1. leaderpartitionid: set/get leader partition id before joining the thread network.
2. get information such as extended mac address and rloc16 of thread device's parent.
3. set/get data poll period for SED.
4. blacklist relative commads. For forming the designed network topology in Harness test case, only whitelist is not enough for processing DUT (Harness doesn't know DUT ext address before inputing in the dialog)
5. set/get the specific link quality on the link to a thread device with a given extended address. used when select a better parent during attaching.
6. add link-local 16 unicast address only for SED role. Unnecessary for other thread device role.
7. add reset to signal a platform reset.