### PR TITLE
Include platform details in version information

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -457,6 +457,25 @@ AM_CONDITIONAL([OPENTHREAD_EXAMPLES_CC2538], [test "${OPENTHREAD_EXAMPLES}" = "c
 AC_DEFINE_UNQUOTED([OPENTHREAD_EXAMPLES_CC2538],[${OPENTHREAD_EXAMPLES_CC2538}],[Define to 1 if you want to use cc2538 examples])
 
 #
+# Platform Information
+#
+
+AC_ARG_WITH(platform-info,
+    [AS_HELP_STRING([--with-platform-info=PLATFORM],
+        [Specify the platform information @<:@default=none@:>@.])],
+    [],
+    [with_platform_info=none])
+
+PLATFORM_INFO=${with_platform_info}
+
+AC_MSG_RESULT(${PLATFORM_INFO})
+
+if test "$PLATFORM_INFO" != "none"; then
+    AC_SUBST(PLATFORM_INFO)
+    AC_DEFINE_UNQUOTED([PLATFORM_INFO],["${PLATFORM_INFO}"],[OpenThread platform information])
+fi
+
+#
 # Tools
 #
 
@@ -632,5 +651,6 @@ AC_MSG_NOTICE([
   OpenThread CLI support                    : ${enable_cli}
   OpenThread NCP support                    : ${enable_ncp}
   OpenThread examples                       : ${OPENTHREAD_EXAMPLES}
+  OpenThread platform information           : ${PLATFORM_INFO}
 
 ])

--- a/examples/Makefile-cc2538
+++ b/examples/Makefile-cc2538
@@ -45,6 +45,7 @@ configure_OPTIONS               = \
     --enable-cli                  \
     --enable-ncp                  \
     --with-examples=cc2538        \
+    --with-platform-info=CC2538   \
     $(NULL)
 
 COMMONCFLAGS                   := \

--- a/examples/Makefile-posix
+++ b/examples/Makefile-posix
@@ -86,7 +86,12 @@ TargetTuple                     = $(shell ${AbsTopSourceDir}/third_party/nlbuild
 # If the user has asserted COVERAGE, alter the configuration options
 # accordingly.
 
-configure_OPTIONS               = --with-examples=posix --enable-cli --enable-ncp
+configure_OPTIONS               = \
+    --enable-cli                  \
+    --enable-ncp                  \
+    --with-examples=posix         \
+    --with-platform-info=POSIX    \
+    $(NULL)
 
 ifeq ($(COVERAGE),1)
 configure_OPTIONS              += --enable-coverage

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -146,6 +146,14 @@ extern void otSignalTaskletPending(void);
  */
 
 /**
+ * Get the OpenThread version string.
+ *
+ * @returns A pointer to the OpenThread version.
+ *
+ */
+const char *otGetVersionString(void);
+
+/**
  * This function initializes the OpenThread library.
  *
  * This function initializes OpenThread and prepares it for subsequent OpenThread API calls.  This function must be

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1391,7 +1391,7 @@ exit:
 
 void Interpreter::ProcessVersion(int argc, char *argv[])
 {
-    sServer->OutputFormat("%s\r\n", PACKAGE_NAME "/" PACKAGE_VERSION "; " __DATE__ " " __TIME__);
+    sServer->OutputFormat("%s\r\n", otGetVersionString());
     AppendResult(kThreadError_None);
     (void)argc;
     (void)argv;

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -32,6 +32,7 @@
  */
 
 #include <openthread.h>
+#include <openthread-config.h>
 #include <common/code_utils.hpp>
 #include <common/debug.hpp>
 #include <common/logging.hpp>
@@ -676,6 +677,18 @@ void otSetStateChangedCallback(otStateChangedCallback aCallback, void *aContext)
 {
     sNetifCallback.Set(aCallback, aContext);
     sThreadNetif->RegisterCallback(sNetifCallback);
+}
+
+const char *otGetVersionString(void)
+{
+    static const char sVersion[] =
+        PACKAGE_NAME "/" PACKAGE_VERSION "; "
+#ifdef  PLATFORM_INFO
+        PLATFORM_INFO "; "
+#endif
+        __DATE__ " " __TIME__;
+
+    return sVersion;
 }
 
 ThreadError otEnable(void)

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1088,7 +1088,7 @@ ThreadError NcpBase::GetPropertyHandler_NCP_VERSION(uint8_t header, spinel_prop_
                SPINEL_CMD_PROP_VALUE_IS,
                key,
                SPINEL_DATATYPE_UTF8_S,
-               PACKAGE_NAME "/" PACKAGE_VERSION "; " __DATE__ " " __TIME__
+               otGetVersionString()
            );
 }
 


### PR DESCRIPTION
  - add --with-platform-info configuration option to specify platform information
  - add otGetVersionString() interface to get OpenThread version

Resolves #331.