### PR TITLE
Fixes for setting unsecure/assisting ports

### DIFF
--- a/src/core/net/ip6_filter.cpp
+++ b/src/core/net/ip6_filter.cpp
@@ -127,6 +127,14 @@ ThreadError Filter::RemoveUnsecurePort(uint16_t aPort)
     {
         if (mUnsecurePorts[i] == aPort)
         {
+            // Shift all of the ports higher than this
+            // port down.
+            for (; i < kMaxUnsecurePorts - 1; i++)
+            {
+                mUnsecurePorts[i] = mUnsecurePorts[i + 1];
+            }
+
+            // Clear the last port entry.
             mUnsecurePorts[i] = 0;
             ExitNow();
         }
@@ -140,7 +148,15 @@ exit:
 
 const uint16_t *Filter::GetUnsecurePorts(uint8_t &aNumEntries) const
 {
-    aNumEntries = kMaxUnsecurePorts;
+    // Count the number of unsecure ports.
+    for (aNumEntries = 0; aNumEntries < kMaxUnsecurePorts; aNumEntries++)
+    {
+        if (mUnsecurePorts[aNumEntries] == 0)
+        {
+            break;
+        }
+    }
+
     return mUnsecurePorts;
 }
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1583,7 +1583,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, s
 
     for (; num_entries != 0; ports++, num_entries--)
     {
-        SuccessOrExit(errorCode = OutboundFrameFeedPacked("S", ports));
+        SuccessOrExit(errorCode = OutboundFrameFeedPacked("S", *ports));
     }
 
     SuccessOrExit(errorCode = OutboundFrameSend());
@@ -2688,7 +2688,7 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, s
     ThreadError errorCode = kThreadError_None;
     uint8_t num_entries = 0;
     const uint16_t *ports = otGetUnsecurePorts(&num_entries);
-    spinel_ssize_t parsedLength = 0;
+    spinel_ssize_t parsedLength = 1;
     int ports_changed = 0;
 
     // First, we need to remove all of the current assisting ports.
@@ -2731,6 +2731,9 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, s
         {
             break;
         }
+
+        value_ptr += parsedLength;
+        value_len -= parsedLength;
 
         ports_changed++;
     }


### PR DESCRIPTION
This change addresses two problems:

* `otGetUnsecurePorts()` was not indicating the proper number of entries (it was indicating the maximum number of entries).
* The NCP getter/setter for `PROP_THREAD_ASSISTING_PORTS` was not implemented properly.