### PR TITLE
Enable -Wconversion on clang and fix all warnings.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -226,6 +226,25 @@ AC_PROG_LN_S
 PROSPECTIVE_CFLAGS="-Wall -std=c99 -pedantic-errors"
 PROSPECTIVE_CXXFLAGS="-Wall"
 
+AC_CACHE_CHECK([whether $CC is Clang],
+    [nl_cv_clang],
+    [nl_cv_clang=no
+    if test "x${GCC}" = "xyes"; then
+        AC_EGREP_CPP([NL_CC_IS_CLANG],
+            [/* Note: Clang 2.7 lacks __clang_[a-z]+__ */
+#            if defined(__clang__) && defined(__llvm__)
+             NL_CC_IS_CLANG
+#            endif
+            ],
+            [nl_cv_clang=yes])
+    fi
+    ])
+
+if test "${nl_cv_clang}" = "yes"; then
+    PROSPECTIVE_CFLAGS="${PROSPECTIVE_CFLAGS} -Wconversion"
+    PROSPECTIVE_CXXFLAGS="${PROSPECTIVE_CXXFLAGS} -Wconversion"
+fi
+
 AX_CHECK_COMPILER_OPTIONS([C],   ${PROSPECTIVE_CFLAGS})
 AX_CHECK_COMPILER_OPTIONS([C++], ${PROSPECTIVE_CXXFLAGS})
 

--- a/examples/platforms/posix/alarm.c
+++ b/examples/platforms/posix/alarm.c
@@ -50,7 +50,7 @@ uint32_t otPlatAlarmGetNow(void)
     gettimeofday(&tv, NULL);
     timersub(&tv, &s_start, &tv);
 
-    return (tv.tv_sec * 1000) + (tv.tv_usec / 1000);
+    return (uint32_t)((tv.tv_sec * 1000) + (tv.tv_usec / 1000));
 }
 
 void otPlatAlarmStartAt(uint32_t t0, uint32_t dt)
@@ -75,7 +75,7 @@ void posixAlarmUpdateTimeout(struct timeval *aTimeout)
 
     if (s_is_running)
     {
-        remaining = s_alarm - otPlatAlarmGetNow();
+        remaining = (int32_t)(s_alarm - otPlatAlarmGetNow());
 
         if (remaining > 0)
         {
@@ -101,7 +101,7 @@ void posixAlarmProcess(void)
 
     if (s_is_running)
     {
-        remaining = s_alarm - otPlatAlarmGetNow();
+        remaining = (int32_t)(s_alarm - otPlatAlarmGetNow());
 
         if (remaining <= 0)
         {

--- a/examples/platforms/posix/logging.c
+++ b/examples/platforms/posix/logging.c
@@ -43,7 +43,7 @@
 #define LOG_PRINTF(...)                                                                     \
     charsWritten = snprintf(&logString[index], sizeof(logString) - index , __VA_ARGS__);    \
     VerifyOrExit(charsWritten >= 0, logString[index] = 0);                                  \
-    index += charsWritten;                                                                  \
+    index += (unsigned int)charsWritten;                                    \
     VerifyOrExit(index < sizeof(logString), logString[sizeof(logString) -1 ] = 0)
 
 void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)

--- a/examples/platforms/posix/platform.c
+++ b/examples/platforms/posix/platform.c
@@ -57,7 +57,7 @@ void PlatformInit(int argc, char *argv[])
         exit(1);
     }
 
-    NODE_ID = strtol(argv[1], &endptr, 0);
+    NODE_ID = (uint32_t)strtol(argv[1], &endptr, 0);
 
     if (*endptr != '\0')
     {

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -238,12 +238,12 @@ static inline uint8_t getDsn(const uint8_t *frame)
 
 static inline otPanId getDstPan(const uint8_t *frame)
 {
-    return (((otPanId)frame[IEEE802154_DSTPAN_OFFSET + 1]) << 8) | frame[IEEE802154_DSTPAN_OFFSET];
+    return (otPanId)((frame[IEEE802154_DSTPAN_OFFSET + 1] << 8) | frame[IEEE802154_DSTPAN_OFFSET]);
 }
 
 static inline otShortAddress getShortAddress(const uint8_t *frame)
 {
-    return (((otShortAddress)frame[IEEE802154_DSTADDR_OFFSET + 1]) << 8) | frame[IEEE802154_DSTADDR_OFFSET];
+    return (otShortAddress)((frame[IEEE802154_DSTADDR_OFFSET + 1] << 8) | frame[IEEE802154_DSTADDR_OFFSET]);
 }
 
 static inline void getExtAddress(const uint8_t *frame, otExtAddress *address)
@@ -319,7 +319,7 @@ void posixRadioInit(void)
     {
         char *endptr;
 
-        sPortOffset = strtol(offset, &endptr, 0);
+        sPortOffset = (uint16_t)strtol(offset, &endptr, 0);
 
         if (*endptr != '\0')
         {
@@ -440,10 +440,10 @@ void radioReceive(void)
 {
     if (sState != kStateTransmit || sAckWait)
     {
-        int rval = recvfrom(sSockFd, &sReceiveMessage, sizeof(sReceiveMessage), 0, NULL, NULL);
+        ssize_t rval = recvfrom(sSockFd, &sReceiveMessage, sizeof(sReceiveMessage), 0, NULL, NULL);
         assert(rval >= 0);
 
-        sReceiveFrame.mLength = rval - 1;
+        sReceiveFrame.mLength = (uint8_t)(rval - 1);
 
         if (sAckWait &&
             sTransmitFrame.mChannel == sReceiveMessage.mChannel &&
@@ -532,7 +532,7 @@ void radioTransmit(const struct RadioMessage *msg, const struct RadioPacket *pkt
 
     for (i = 1; i <= WELLKNOWN_NODE_ID; i++)
     {
-        int rval;
+        ssize_t rval;
 
         if (NODE_ID == i)
         {

--- a/examples/platforms/posix/uart.c
+++ b/examples/platforms/posix/uart.c
@@ -91,13 +91,13 @@ ThreadError otPlatUartEnable(void)
         VerifyOrExit(tcgetattr(s_in_fd, &termios) == 0, perror("tcgetattr"); error = kThreadError_Error);
 
         // turn off input processing
-        termios.c_iflag &= ~(IGNBRK | BRKINT | ICRNL | INLCR | PARMRK | INPCK | ISTRIP | IXON);
+        termios.c_iflag &= ~(unsigned long)(IGNBRK | BRKINT | ICRNL | INLCR | PARMRK | INPCK | ISTRIP | IXON);
 
         // turn off line processing
-        termios.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN);
+        termios.c_lflag &= ~(unsigned long)(ECHO | ECHONL | ICANON | IEXTEN);
 
         // turn off character processing
-        termios.c_cflag &= ~(CSIZE | PARENB);
+        termios.c_cflag &= ~(unsigned long)(CSIZE | PARENB);
         termios.c_cflag |= CS8 | HUPCL | CREAD | CLOCAL;
 
         // return 1 byte at a time
@@ -122,7 +122,7 @@ ThreadError otPlatUartEnable(void)
         termios.c_oflag = 0;
 
         // turn off character processing
-        termios.c_cflag &= ~(CSIZE | PARENB);
+        termios.c_cflag &= ~(unsigned long)(CSIZE | PARENB);
         termios.c_cflag |= CS8 | HUPCL | CREAD | CLOCAL;
 
         // configure baud rate
@@ -190,13 +190,13 @@ void posixUartProcess(void)
 {
     const int flags = POLLRDNORM | POLLERR | POLLNVAL | POLLHUP;
     struct pollfd pollfd = { s_in_fd, flags, 0 };
-    int rval;
+    ssize_t rval;
 
     if (poll(&pollfd, 1, 0) > 0 && (pollfd.revents & flags) != 0)
     {
         rval = read(s_in_fd, s_receive_buffer, sizeof(s_receive_buffer));
         assert(rval >= 0);
-        otPlatUartReceived(s_receive_buffer, rval);
+        otPlatUartReceived(s_receive_buffer, (uint16_t)rval);
     }
 
     if (s_write_length > 0)

--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -294,7 +294,7 @@ typedef struct otOperationalDataset
     otMeshLocalPrefix mMeshLocalPrefix;            ///< Mesh Local Prefix
     uint32_t          mDelay;                      ///< Delay Timer
     otPanId           mPanId;                      ///< PAN ID
-    uint8_t           mChannel;                    ///< Channel
+    uint16_t          mChannel;                    ///< Channel
 
     bool              mIsActiveTimestampSet : 1;   ///< TRUE if Active Timestamp is set, FALSE otherwise.
     bool              mIsPendingTimestampSet : 1;  ///< TRUE if Pending Timestamp is set, FALSE otherwise.
@@ -526,10 +526,10 @@ typedef struct
 {
     otExtAddress   mExtAddress;            ///< IEEE 802.15.4 Extended Address
     uint32_t       mTimeout;               ///< Timeout
+    uint32_t       mAge;                   ///< Time last heard
     uint16_t       mRloc16;                ///< RLOC16
-    uint8_t        mChildId;               ///< Router ID
+    uint16_t       mChildId;               ///< Child ID
     uint8_t        mNetworkDataVersion;    ///< Network Data Version
-    uint8_t        mAge;                   ///< Time last heard
     uint8_t        mLinkQualityIn;         ///< Link Quality In
     int8_t         mAverageRssi;           ///< Average RSSI
     bool           mRxOnWhenIdle : 1;      ///< rx-on-when-idle
@@ -667,7 +667,7 @@ typedef struct otSockAddr
 {
     otIp6Address mAddress;  ///< An IPv6 address.
     uint16_t     mPort;     ///< A transport-layer port.
-    uint8_t      mScopeId;  ///< An IPv6 scope identifier.
+    int8_t       mScopeId;  ///< An IPv6 scope identifier.
 } otSockAddr;
 
 /**
@@ -679,7 +679,7 @@ typedef struct otMessageInfo
     otIp6Address mPeerAddr;     ///< The peer IPv6 address.
     uint16_t     mSockPort;     ///< The local transport-layer port.
     uint16_t     mPeerPort;     ///< The peer transport-layer port.
-    uint8_t      mInterfaceId;  ///< An IPv6 interface identifier.
+    int8_t       mInterfaceId;  ///< An IPv6 interface identifier.
     uint8_t      mHopLimit;     ///< The IPv6 Hop Limit.
     const void  *mLinkInfo;     ///< A pointer to link-specific information.
 } otMessageInfo;

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -842,7 +842,7 @@ uint32_t otGetNetworkIdTimeout(void);
  *
  * @sa otGetNetworkIdTimeout
  */
-void otSetNetworkIdTimeout(uint32_t aTimeout);
+void otSetNetworkIdTimeout(uint8_t aTimeout);
 
 /**
  * Get the ROUTER_UPGRADE_THRESHOLD parameter used in the REED role.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -114,7 +114,7 @@ void Interpreter::Init(void)
 
 int Interpreter::Hex2Bin(const char *aHex, uint8_t *aBin, uint16_t aBinLength)
 {
-    uint16_t hexLength = strlen(aHex);
+    size_t hexLength = strlen(aHex);
     const char *hexEnd = aHex + hexLength;
     uint8_t *cur = aBin;
     uint8_t numChars = hexLength & 1;
@@ -159,7 +159,7 @@ int Interpreter::Hex2Bin(const char *aHex, uint8_t *aBin, uint16_t aBinLength)
         }
     }
 
-    return cur - aBin;
+    return static_cast<int>(cur - aBin);
 }
 
 void Interpreter::AppendResult(ThreadError error)
@@ -212,7 +212,7 @@ void Interpreter::ProcessChannel(int argc, char *argv[])
     else
     {
         SuccessOrExit(error = ParseLong(argv[0], value));
-        otSetChannel(value);
+        otSetChannel(static_cast<uint8_t>(value));
     }
 
 exit:
@@ -229,7 +229,7 @@ void Interpreter::ProcessChild(int argc, char *argv[])
 
     if (strcmp(argv[0], "list") == 0)
     {
-        for (int i = 0; ; i++)
+        for (uint8_t i = 0; ; i++)
         {
             if (otGetChildInfoByIndex(i, &childInfo) != kThreadError_None)
             {
@@ -245,7 +245,7 @@ void Interpreter::ProcessChild(int argc, char *argv[])
     }
 
     SuccessOrExit(error = ParseLong(argv[0], value));
-    SuccessOrExit(error = otGetChildInfoById(value, &childInfo));
+    SuccessOrExit(error = otGetChildInfoById(static_cast<uint8_t>(value), &childInfo));
 
     sServer->OutputFormat("Child ID: %d\r\n", childInfo.mChildId);
     sServer->OutputFormat("Rloc: %04x\r\n", childInfo.mRloc16);
@@ -303,7 +303,7 @@ void Interpreter::ProcessChildTimeout(int argc, char *argv[])
     else
     {
         SuccessOrExit(error = ParseLong(argv[0], value));
-        otSetChildTimeout(value);
+        otSetChildTimeout(static_cast<uint32_t>(value));
     }
 
 exit:
@@ -322,7 +322,7 @@ void Interpreter::ProcessContextIdReuseDelay(int argc, char *argv[])
     else
     {
         SuccessOrExit(ParseLong(argv[0], value));
-        otSetContextIdReuseDelay(value);
+        otSetContextIdReuseDelay(static_cast<uint32_t>(value));
     }
 
 exit:
@@ -403,7 +403,7 @@ void Interpreter::ProcessEidCache(int argc, char *argv[])
 {
     otEidCacheEntry entry;
 
-    for (int i = 0; ; i++)
+    for (uint8_t i = 0; ; i++)
     {
         SuccessOrExit(otGetEidCacheEntry(i, &entry));
 
@@ -580,7 +580,7 @@ void Interpreter::ProcessKeySequence(int argc, char *argv[])
     else
     {
         SuccessOrExit(error = ParseLong(argv[0], value));
-        otSetKeySequenceCounter(value);
+        otSetKeySequenceCounter(static_cast<uint32_t>(value));
     }
 
 exit:
@@ -618,7 +618,7 @@ void Interpreter::ProcessLeaderWeight(int argc, char *argv[])
     else
     {
         SuccessOrExit(error = ParseLong(argv[0], value));
-        otSetLocalLeaderWeight(value);
+        otSetLocalLeaderWeight(static_cast<uint8_t>(value));
     }
 
 exit:
@@ -643,11 +643,11 @@ void Interpreter::ProcessMasterKey(int argc, char *argv[])
     }
     else
     {
-        int8_t keyLength;
+        int keyLength;
         uint8_t key[16];
 
         VerifyOrExit((keyLength = Hex2Bin(argv[0], key, sizeof(key))) >= 0, error = kThreadError_Parse);
-        SuccessOrExit(error = otSetMasterKey(key, keyLength));
+        SuccessOrExit(error = otSetMasterKey(key, static_cast<uint8_t>(keyLength)));
     }
 
 exit:
@@ -744,7 +744,7 @@ void Interpreter::ProcessNetworkIdTimeout(int argc, char *argv[])
     else
     {
         SuccessOrExit(error = ParseLong(argv[0], value));
-        otSetNetworkIdTimeout(value);
+        otSetNetworkIdTimeout(static_cast<uint8_t>(value));
     }
 
 exit:
@@ -780,7 +780,7 @@ void Interpreter::ProcessPanId(int argc, char *argv[])
     else
     {
         SuccessOrExit(error = ParseLong(argv[0], value));
-        otSetPanId(value);
+        otSetPanId(static_cast<otPanId>(value));
     }
 
 exit:
@@ -904,7 +904,7 @@ ThreadError Interpreter::ProcessPrefixAdd(int argc, char *argv[])
 
     SuccessOrExit(error = otIp6AddressFromString(argv[argcur], &config.mPrefix.mPrefix));
 
-    config.mPrefix.mLength = strtol(prefixLengthStr, &endptr, 0);
+    config.mPrefix.mLength = static_cast<uint8_t>(strtol(prefixLengthStr, &endptr, 0));
 
     if (*endptr != '\0')
     {
@@ -994,7 +994,7 @@ ThreadError Interpreter::ProcessPrefixRemove(int argc, char *argv[])
 
     SuccessOrExit(error = otIp6AddressFromString(argv[argcur], &prefix.mPrefix));
 
-    prefix.mLength = strtol(prefixLengthStr, &endptr, 0);
+    prefix.mLength = static_cast<uint8_t>(strtol(prefixLengthStr, &endptr, 0));
 
     if (*endptr != '\0')
     {
@@ -1039,7 +1039,7 @@ void Interpreter::ProcessReleaseRouterId(int argc, char *argv[])
     VerifyOrExit(argc > 0, error = kThreadError_Parse);
 
     SuccessOrExit(error = ParseLong(argv[0], value));
-    SuccessOrExit(error = otReleaseRouterId(value));
+    SuccessOrExit(error = otReleaseRouterId(static_cast<uint8_t>(value)));
 
 exit:
     AppendResult(error);
@@ -1075,7 +1075,7 @@ ThreadError Interpreter::ProcessRouteAdd(int argc, char *argv[])
 
     SuccessOrExit(error = otIp6AddressFromString(argv[argcur], &config.mPrefix.mPrefix));
 
-    config.mPrefix.mLength = strtol(prefixLengthStr, &endptr, 0);
+    config.mPrefix.mLength = static_cast<uint8_t>(strtol(prefixLengthStr, &endptr, 0));
 
     if (*endptr != '\0')
     {
@@ -1136,7 +1136,7 @@ ThreadError Interpreter::ProcessRouteRemove(int argc, char *argv[])
 
     SuccessOrExit(error = otIp6AddressFromString(argv[argcur], &prefix.mPrefix));
 
-    prefix.mLength = strtol(prefixLengthStr, &endptr, 0);
+    prefix.mLength = static_cast<uint8_t>(strtol(prefixLengthStr, &endptr, 0));
 
     if (*endptr != '\0')
     {
@@ -1182,7 +1182,7 @@ void Interpreter::ProcessRouter(int argc, char *argv[])
 
     if (strcmp(argv[0], "list") == 0)
     {
-        for (int i = 0; ; i++)
+        for (uint8_t i = 0; ; i++)
         {
             if (otGetRouterInfo(i, &routerInfo) != kThreadError_None)
             {
@@ -1198,7 +1198,7 @@ void Interpreter::ProcessRouter(int argc, char *argv[])
     }
 
     SuccessOrExit(error = ParseLong(argv[0], value));
-    SuccessOrExit(error = otGetRouterInfo(value, &routerInfo));
+    SuccessOrExit(error = otGetRouterInfo(static_cast<uint8_t>(value), &routerInfo));
 
     sServer->OutputFormat("Alloc: %d\r\n", routerInfo.mAllocated);
 
@@ -1242,7 +1242,7 @@ void Interpreter::ProcessRouterUpgradeThreshold(int argc, char *argv[])
     else
     {
         SuccessOrExit(error = ParseLong(argv[0], value));
-        otSetRouterUpgradeThreshold(value);
+        otSetRouterUpgradeThreshold(static_cast<uint8_t>(value));
     }
 
 exit:
@@ -1416,7 +1416,7 @@ void Interpreter::ProcessWhitelist(int argc, char *argv[])
             sServer->OutputFormat("Disabled\r\n");
         }
 
-        for (int i = 0; ; i++)
+        for (uint8_t i = 0; ; i++)
         {
             if (otGetMacWhitelistEntry(i, &entry) != kThreadError_None)
             {
@@ -1445,7 +1445,7 @@ void Interpreter::ProcessWhitelist(int argc, char *argv[])
 
         if (++argcur < argc)
         {
-            rssi = strtol(argv[argcur], NULL, 0);
+            rssi = static_cast<int8_t>(strtol(argv[argcur], NULL, 0));
             VerifyOrExit(otAddMacWhitelistRssi(extAddr, rssi) == kThreadError_None, error = kThreadError_Parse);
         }
         else

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -187,7 +187,7 @@ ThreadError Dataset::ProcessActiveTimestamp(int argc, char *argv[])
     VerifyOrExit(argc > 0, ;);
 
     SuccessOrExit(error = Interpreter::ParseLong(argv[0], value));
-    sDataset.mActiveTimestamp = value;
+    sDataset.mActiveTimestamp = static_cast<uint64_t>(value);
     sDataset.mIsActiveTimestampSet = true;
 
 exit:
@@ -201,7 +201,7 @@ ThreadError Dataset::ProcessChannel(int argc, char *argv[])
 
     VerifyOrExit(argc > 0, error = kThreadError_Parse);
     SuccessOrExit(error = Interpreter::ParseLong(argv[0], value));
-    sDataset.mChannel = value;
+    sDataset.mChannel = static_cast<uint16_t>(value);
     sDataset.mIsChannelSet = true;
 
 exit:
@@ -246,7 +246,7 @@ ThreadError Dataset::ProcessDelay(int argc, char *argv[])
 
     VerifyOrExit(argc > 0, error = kThreadError_Parse);
     SuccessOrExit(error = Interpreter::ParseLong(argv[0], value));
-    sDataset.mDelay = value;
+    sDataset.mDelay = static_cast<uint32_t>(value);
     sDataset.mIsDelaySet = true;
 
 exit:
@@ -271,7 +271,7 @@ exit:
 ThreadError Dataset::ProcessMasterKey(int argc, char *argv[])
 {
     ThreadError error = kThreadError_None;
-    int8_t keyLength;
+    int keyLength;
     uint8_t key[OT_MASTER_KEY_SIZE];
 
     VerifyOrExit(argc > 0, error = kThreadError_Parse);
@@ -303,7 +303,7 @@ exit:
 ThreadError Dataset::ProcessNetworkName(int argc, char *argv[])
 {
     ThreadError error = kThreadError_None;
-    int length;
+    size_t length;
 
     VerifyOrExit(argc > 0, error = kThreadError_Parse);
     VerifyOrExit((length = strlen(argv[0])) <= OT_NETWORK_NAME_SIZE, error = kThreadError_Parse);
@@ -323,7 +323,7 @@ ThreadError Dataset::ProcessPanId(int argc, char *argv[])
 
     VerifyOrExit(argc > 0, error = kThreadError_Parse);
     SuccessOrExit(error = Interpreter::ParseLong(argv[0], value));
-    sDataset.mPanId = value;
+    sDataset.mPanId = static_cast<otPanId>(value);
     sDataset.mIsPanIdSet = true;
 
 exit:
@@ -348,7 +348,7 @@ ThreadError Dataset::ProcessPendingTimestamp(int argc, char *argv[])
     VerifyOrExit(argc > 0, error = kThreadError_Parse);
 
     SuccessOrExit(error = Interpreter::ParseLong(argv[0], value));
-    sDataset.mPendingTimestamp = value;
+    sDataset.mPendingTimestamp = static_cast<uint64_t>(value);
     sDataset.mIsPendingTimestampSet = true;
 
 exit:

--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -110,7 +110,7 @@ void Uart::ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength)
 
         default:
             Output(reinterpret_cast<const char *>(aBuf), 1);
-            mRxBuffer[mRxLength++] = *aBuf;
+            mRxBuffer[mRxLength++] = static_cast<char>(*aBuf);
             break;
         }
     }
@@ -168,7 +168,7 @@ int Uart::OutputFormat(const char *fmt, ...)
     vsnprintf(buf, sizeof(buf), fmt, ap);
     va_end(ap);
 
-    return Output(buf, strlen(buf));
+    return Output(buf, static_cast<uint16_t>(strlen(buf)));
 }
 
 void Uart::Send(void)

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -119,7 +119,7 @@ int Udp::OutputFormat(const char *fmt, ...)
     vsnprintf(buf, sizeof(buf), fmt, ap);
     va_end(ap);
 
-    return Output(buf, strlen(buf));
+    return Output(buf, static_cast<uint16_t>(strlen(buf)));
 }
 
 }  // namespace Cli

--- a/src/core/coap/coap_header.cpp
+++ b/src/core/coap/coap_header.cpp
@@ -101,8 +101,8 @@ ThreadError Header::FromMessage(const Message &aMessage)
         }
         else if (optionDelta == kOption2ByteExtension)
         {
-            optionDelta = kOption2ByteExtensionOffset + ((static_cast<uint16_t>(mHeader[mHeaderLength]) << 8) |
-                                                         mHeader[mHeaderLength + 1]);
+            optionDelta = kOption2ByteExtensionOffset +
+                          static_cast<uint16_t>((mHeader[mHeaderLength] << 8) | mHeader[mHeaderLength + 1]);
             mHeaderLength += sizeof(uint16_t);
             offset += sizeof(uint16_t);
             length -= sizeof(uint16_t);
@@ -125,8 +125,8 @@ ThreadError Header::FromMessage(const Message &aMessage)
         }
         else if (optionLength == kOption2ByteExtension)
         {
-            optionLength = kOption2ByteExtensionOffset + ((static_cast<uint16_t>(mHeader[mHeaderLength]) << 8) |
-                                                          mHeader[mHeaderLength + 1]);
+            optionLength = kOption2ByteExtensionOffset +
+                           static_cast<uint16_t>((mHeader[mHeaderLength] << 8) | mHeader[mHeaderLength + 1]);
             mHeaderLength += sizeof(uint16_t);
             offset += sizeof(uint16_t);
             length -= sizeof(uint16_t);
@@ -165,19 +165,19 @@ ThreadError Header::AppendOption(const Option &aOption)
 
     if (optionDelta < kOption1ByteExtensionOffset)
     {
-        *buf = optionDelta << Option::kOptionDeltaOffset;
+        *buf = (optionDelta << Option::kOptionDeltaOffset) & Option::kOptionDeltaMask;
     }
     else if (optionDelta < kOption2ByteExtensionOffset)
     {
         *buf |= kOption1ByteExtension << Option::kOptionDeltaOffset;
-        *cur++ = optionDelta - kOption1ByteExtensionOffset;
+        *cur++ = (optionDelta - kOption1ByteExtensionOffset) & 0xff;
     }
     else
     {
         *buf |= kOption2ByteExtension << Option::kOptionDeltaOffset;
         optionDelta -= kOption2ByteExtensionOffset;
         *cur++ = optionDelta >> 8;
-        *cur++ = optionDelta;
+        *cur++ = optionDelta & 0xff;
     }
 
     if (aOption.mLength < kOption1ByteExtensionOffset)
@@ -187,14 +187,14 @@ ThreadError Header::AppendOption(const Option &aOption)
     else if (aOption.mLength < kOption2ByteExtensionOffset)
     {
         *buf |= kOption1ByteExtension;
-        *cur++ = aOption.mLength - kOption1ByteExtensionOffset;
+        *cur++ = (aOption.mLength - kOption1ByteExtensionOffset) & 0xff;
     }
     else
     {
         *buf |= kOption2ByteExtension;
         optionLength = aOption.mLength - kOption2ByteExtensionOffset;
         *cur++ = optionLength >> 8;
-        *cur++ = optionLength;
+        *cur++ = optionLength & 0xff;
     }
 
     memcpy(cur, aOption.mValue, aOption.mLength);
@@ -216,13 +216,13 @@ ThreadError Header::AppendUriPathOptions(const char *aUriPath)
 
     while ((end = strchr(cur, '/')) != NULL)
     {
-        coapOption.mLength = end - cur;
+        coapOption.mLength = static_cast<uint16_t>(end - cur);
         coapOption.mValue = reinterpret_cast<const uint8_t *>(cur);
         AppendOption(coapOption);
         cur = end + 1;
     }
 
-    coapOption.mLength = strlen(cur);
+    coapOption.mLength = static_cast<uint16_t>(strlen(cur));
     coapOption.mValue = reinterpret_cast<const uint8_t *>(cur);
     AppendOption(coapOption);
 
@@ -270,8 +270,8 @@ const Header::Option *Header::GetNextOption(void)
     }
     else if (optionDelta == kOption2ByteExtension)
     {
-        optionDelta = kOption2ByteExtensionOffset + ((static_cast<uint16_t>(mHeader[mNextOptionOffset]) << 8) |
-                                                     mHeader[mNextOptionOffset + 1]);
+        optionDelta = kOption2ByteExtensionOffset +
+                      static_cast<uint16_t>((mHeader[mNextOptionOffset] << 8) | mHeader[mNextOptionOffset + 1]);
         mNextOptionOffset += sizeof(uint16_t);
     }
     else
@@ -290,8 +290,8 @@ const Header::Option *Header::GetNextOption(void)
     }
     else if (optionLength == kOption2ByteExtension)
     {
-        optionLength = kOption2ByteExtensionOffset + ((static_cast<uint16_t>(mHeader[mNextOptionOffset]) << 8) |
-                                                      mHeader[mNextOptionOffset + 1]);
+        optionLength = kOption2ByteExtensionOffset +
+                       static_cast<uint16_t>((mHeader[mNextOptionOffset] << 8) | mHeader[mNextOptionOffset + 1]);
         mNextOptionOffset += sizeof(uint16_t);
     }
     else

--- a/src/core/coap/coap_server.cpp
+++ b/src/core/coap/coap_server.cpp
@@ -100,7 +100,7 @@ void Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
         switch (coapOption->mNumber)
         {
         case Header::Option::kOptionUriPath:
-            VerifyOrExit(coapOption->mLength < sizeof(uriPath) - (curUriPath - uriPath), ;);
+            VerifyOrExit(coapOption->mLength < sizeof(uriPath) - static_cast<size_t>(curUriPath - uriPath), ;);
             memcpy(curUriPath, coapOption->mValue, coapOption->mLength);
             curUriPath[coapOption->mLength] = '/';
             curUriPath += coapOption->mLength + 1;

--- a/src/core/common/encoding.hpp
+++ b/src/core/common/encoding.hpp
@@ -43,8 +43,8 @@ namespace Encoding {
 inline uint16_t Swap16(uint16_t v)
 {
     return
-        ((v & static_cast<uint16_t>(0x00ffU)) << 8) |
-        ((v & static_cast<uint16_t>(0xff00U)) >> 8);
+        (((v & 0x00ffU) << 8) & 0xff00) |
+        (((v & 0xff00U) >> 8) & 0x00ff);
 }
 
 inline uint32_t Swap32(uint32_t v)

--- a/src/core/common/logging.cpp
+++ b/src/core/common/logging.cpp
@@ -50,49 +50,49 @@ extern "C" {
  * @param[in]  aLength     Number of bytes in the buffer.
  *
  */
-static void DumpLine(otLogLevel aLogLevel, otLogRegion aLogRegion, const void *aBuf, const int aLength)
+static void DumpLine(otLogLevel aLogLevel, otLogRegion aLogRegion, const void *aBuf, const size_t aLength)
 {
     char buf[80];
     char *cur = buf;
 
-    snprintf(cur, sizeof(buf) - (cur - buf), "|");
+    snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), "|");
     cur += strlen(cur);
 
-    for (int i = 0; i < 16; i++)
+    for (size_t i = 0; i < 16; i++)
     {
         if (i < aLength)
         {
-            snprintf(cur, sizeof(buf) - (cur - buf), " %02X", ((uint8_t *)(aBuf))[i]);
+            snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), " %02X", ((uint8_t *)(aBuf))[i]);
             cur += strlen(cur);
         }
         else
         {
-            snprintf(cur, sizeof(buf) - (cur - buf), " ..");
+            snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), " ..");
             cur += strlen(cur);
         }
 
         if (!((i + 1) % 8))
         {
-            snprintf(cur, sizeof(buf) - (cur - buf), " |");
+            snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), " |");
             cur += strlen(cur);
         }
     }
 
-    snprintf(cur, sizeof(buf) - (cur - buf), " ");
+    snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), " ");
     cur += strlen(cur);
 
-    for (int i = 0; i < 16; i++)
+    for (size_t i = 0; i < 16; i++)
     {
         char c = 0x7f & ((char *)(aBuf))[i];
 
         if (i < aLength && isprint(c))
         {
-            snprintf(cur, sizeof(buf) - (cur - buf), "%c", c);
+            snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), "%c", c);
             cur += strlen(cur);
         }
         else
         {
-            snprintf(cur, sizeof(buf) - (cur - buf), ".");
+            snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), ".");
             cur += strlen(cur);
         }
     }
@@ -100,42 +100,42 @@ static void DumpLine(otLogLevel aLogLevel, otLogRegion aLogRegion, const void *a
     otPlatLog(aLogLevel, aLogRegion, "%s\n", buf);
 }
 
-void otDump(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aId, const void *aBuf, const int aLength)
+void otDump(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aId, const void *aBuf, const size_t aLength)
 {
-    int idlen = strlen(aId);
-    const int width = 72;
+    size_t idlen = strlen(aId);
+    const size_t width = 72;
     char buf[80];
     char *cur = buf;
 
     otPlatLog(aLogLevel, aLogRegion, "\n");
 
-    for (int i = 0; i < (width - idlen) / 2 - 5; i++)
+    for (size_t i = 0; i < (width - idlen) / 2 - 5; i++)
     {
-        snprintf(cur, sizeof(buf) - (cur - buf), "=");
+        snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), "=");
         cur += strlen(cur);
     }
 
-    snprintf(cur, sizeof(buf) - (cur - buf), "[%s len=%03d]", aId, aLength);
+    snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), "[%s len=%03zu]", aId, aLength);
     cur += strlen(cur);
 
-    for (int i = 0; i < (width - idlen) / 2 - 4; i++)
+    for (size_t i = 0; i < (width - idlen) / 2 - 4; i++)
     {
-        snprintf(cur, sizeof(buf) - (cur - buf), "=");
+        snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), "=");
         cur += strlen(cur);
     }
 
     otPlatLog(aLogLevel, aLogRegion, "%s\n", buf);
 
-    for (int i = 0; i < aLength; i += 16)
+    for (size_t i = 0; i < aLength; i += 16)
     {
         DumpLine(aLogLevel, aLogRegion, (uint8_t *)(aBuf) + i, (aLength - i) < 16 ? (aLength - i) : 16);
     }
 
     cur = buf;
 
-    for (int i = 0; i < width; i++)
+    for (size_t i = 0; i < width; i++)
     {
-        snprintf(cur, sizeof(buf) - (cur - buf), "-");
+        snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), "-");
         cur += strlen(cur);
     }
 

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -256,7 +256,7 @@ exit:
     return error;
 }
 
-int Message::Read(uint16_t aOffset, uint16_t aLength, void *aBuf) const
+uint16_t Message::Read(uint16_t aOffset, uint16_t aLength, void *aBuf) const
 {
     Buffer *curBuffer;
     uint16_t bytesCopied = 0;
@@ -622,7 +622,7 @@ MessageQueue::MessageQueue(void)
     mInterface.mTail = NULL;
 }
 
-ThreadError MessageQueue::AddToList(int aList, Message &aMessage)
+ThreadError MessageQueue::AddToList(uint8_t aList, Message &aMessage)
 {
     MessageList *list;
 
@@ -647,7 +647,7 @@ ThreadError MessageQueue::AddToList(int aList, Message &aMessage)
     return kThreadError_None;
 }
 
-ThreadError MessageQueue::RemoveFromList(int aList, Message &aMessage)
+ThreadError MessageQueue::RemoveFromList(uint8_t aList, Message &aMessage)
 {
     MessageList *list;
 

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -313,7 +313,7 @@ public:
      * @returns The number of bytes read.
      *
      */
-    int Read(uint16_t aOffset, uint16_t aLength, void *aBuf) const;
+    uint16_t Read(uint16_t aOffset, uint16_t aLength, void *aBuf) const;
 
     /**
      * This method writes bytes to the message.
@@ -647,7 +647,7 @@ private:
      * @retval kThreadError_Busy  The message is already enqueued in a list.
      *
      */
-    static ThreadError AddToList(int aListId, Message &aMessage);
+    static ThreadError AddToList(uint8_t aListId, Message &aMessage);
 
     /**
      * This static method removes a message from a list.
@@ -659,7 +659,7 @@ private:
      * @retval kThreadError_Busy  The message is not enqueued in the list.
      *
      */
-    static ThreadError RemoveFromList(int aListId, Message &aMessage);
+    static ThreadError RemoveFromList(uint8_t aListId, Message &aMessage);
 
     MessageList mInterface;   ///< The instance-specific message list.
 };

--- a/src/core/crypto/aes_ccm.cpp
+++ b/src/core/crypto/aes_ccm.cpp
@@ -108,7 +108,7 @@ void AesCcm::Init(uint32_t aHeaderLength, uint32_t aPlainTextLength, uint8_t aTa
 
     for (i = sizeof(mBlock) - 1; i > aNonceLength; i--)
     {
-        mBlock[i] = len;
+        mBlock[i] = len & 0xff;
         len >>= 8;
     }
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -103,7 +103,7 @@ Mac::Mac(ThreadNetif &aThreadNetif):
 
     for (size_t i = 0; i < sizeof(mExtAddress); i++)
     {
-        mExtAddress.m8[i] = otPlatRandomGet();
+        mExtAddress.m8[i] = static_cast<uint8_t>(otPlatRandomGet());
     }
 
     mExtAddress.SetGroup(false);
@@ -117,8 +117,8 @@ Mac::Mac(ThreadNetif &aThreadNetif):
     SetExtAddress(mExtAddress);
     SetShortAddress(kShortAddrInvalid);
 
-    mBeaconSequence = otPlatRandomGet();
-    mDataSequence = otPlatRandomGet();
+    mBeaconSequence = static_cast<uint8_t>(otPlatRandomGet());
+    mDataSequence = static_cast<uint8_t>(otPlatRandomGet());
 
     mPcapCallback = NULL;
 
@@ -356,10 +356,10 @@ void Mac::GenerateNonce(const ExtAddress &aAddress, uint32_t aFrameCounter, uint
     aNonce += 8;
 
     // frame counter
-    aNonce[0] = aFrameCounter >> 24;
-    aNonce[1] = aFrameCounter >> 16;
-    aNonce[2] = aFrameCounter >> 8;
-    aNonce[3] = aFrameCounter >> 0;
+    aNonce[0] = (aFrameCounter >> 24) & 0xff;
+    aNonce[1] = (aFrameCounter >> 16) & 0xff;
+    aNonce[2] = (aFrameCounter >> 8) & 0xff;
+    aNonce[3] = (aFrameCounter >> 0) & 0xff;
     aNonce += 4;
 
     // security level

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -51,7 +51,7 @@ ThreadError Frame::InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl)
     uint8_t length = 0;
 
     // Frame Control Field
-    bytes[0] = aFcf;
+    bytes[0] = aFcf & 0xff;
     bytes[1] = aFcf >> 8;
     length += kFcfSize;
 
@@ -214,7 +214,7 @@ void Frame::SetSequence(uint8_t aSequence)
 uint8_t *Frame::FindDstPanId(void)
 {
     uint8_t *cur = GetPsdu();
-    uint16_t fcf = (static_cast<uint16_t>(GetPsdu()[1]) << 8) | GetPsdu()[0];
+    uint16_t fcf = static_cast<uint16_t>((GetPsdu()[1] << 8) | GetPsdu()[0]);
 
     VerifyOrExit((fcf & Frame::kFcfDstAddrMask) != Frame::kFcfDstAddrNone, cur = NULL);
 
@@ -234,7 +234,7 @@ ThreadError Frame::GetDstPanId(PanId &aPanId)
 
     VerifyOrExit((buf = FindDstPanId()) != NULL, error = kThreadError_Parse);
 
-    aPanId = (static_cast<uint16_t>(buf[1]) << 8) | buf[0];
+    aPanId = static_cast<uint16_t>((buf[1] << 8) | buf[0]);
 
 exit:
     return error;
@@ -247,7 +247,7 @@ ThreadError Frame::SetDstPanId(PanId aPanId)
     buf = FindDstPanId();
     assert(buf != NULL);
 
-    buf[0] = aPanId;
+    buf[0] = aPanId & 0xff;
     buf[1] = aPanId >> 8;
 
     return kThreadError_None;
@@ -271,7 +271,7 @@ ThreadError Frame::GetDstAddr(Address &aAddress)
 {
     ThreadError error = kThreadError_None;
     uint8_t *buf;
-    uint16_t fcf = (static_cast<uint16_t>(GetPsdu()[1]) << 8) | GetPsdu()[0];
+    uint16_t fcf = static_cast<uint16_t>((GetPsdu()[1] << 8) | GetPsdu()[0]);
 
     VerifyOrExit(buf = FindDstAddr(), error = kThreadError_Parse);
 
@@ -279,7 +279,7 @@ ThreadError Frame::GetDstAddr(Address &aAddress)
     {
     case Frame::kFcfDstAddrShort:
         aAddress.mLength = sizeof(ShortAddress);
-        aAddress.mShortAddress = (static_cast<uint16_t>(buf[1]) << 8) | buf[0];
+        aAddress.mShortAddress = static_cast<uint16_t>((buf[1] << 8) | buf[0]);
         break;
 
     case Frame::kFcfDstAddrExt:
@@ -304,14 +304,14 @@ exit:
 ThreadError Frame::SetDstAddr(ShortAddress aShortAddress)
 {
     uint8_t *buf;
-    uint16_t fcf = (static_cast<uint16_t>(GetPsdu()[1]) << 8) | GetPsdu()[0];
+    uint16_t fcf = static_cast<uint16_t>((GetPsdu()[1] << 8) | GetPsdu()[0]);
 
     assert((fcf & Frame::kFcfDstAddrMask) == Frame::kFcfDstAddrShort);
 
     buf = FindDstAddr();
     assert(buf != NULL);
 
-    buf[0] = aShortAddress;
+    buf[0] = aShortAddress & 0xff;
     buf[1] = aShortAddress >> 8;
 
     return kThreadError_None;
@@ -320,7 +320,7 @@ ThreadError Frame::SetDstAddr(ShortAddress aShortAddress)
 ThreadError Frame::SetDstAddr(const ExtAddress &aExtAddress)
 {
     uint8_t *buf;
-    uint16_t fcf = (static_cast<uint16_t>(GetPsdu()[1]) << 8) | GetPsdu()[0];
+    uint16_t fcf = static_cast<uint16_t>((GetPsdu()[1] << 8) | GetPsdu()[0]);
 
     assert((fcf & Frame::kFcfDstAddrMask) == Frame::kFcfDstAddrExt);
 
@@ -338,7 +338,7 @@ ThreadError Frame::SetDstAddr(const ExtAddress &aExtAddress)
 uint8_t *Frame::FindSrcPanId(void)
 {
     uint8_t *cur = GetPsdu();
-    uint16_t fcf = (static_cast<uint16_t>(GetPsdu()[1]) << 8) | GetPsdu()[0];
+    uint16_t fcf = static_cast<uint16_t>((GetPsdu()[1] << 8) | GetPsdu()[0]);
 
     VerifyOrExit((fcf & Frame::kFcfDstAddrMask) != Frame::kFcfDstAddrNone ||
                  (fcf & Frame::kFcfSrcAddrMask) != Frame::kFcfSrcAddrNone, cur = NULL);
@@ -374,7 +374,7 @@ ThreadError Frame::GetSrcPanId(PanId &aPanId)
 
     VerifyOrExit((buf = FindSrcPanId()) != NULL, error = kThreadError_Parse);
 
-    aPanId = (static_cast<uint16_t>(buf[1]) << 8) | buf[0];
+    aPanId = static_cast<uint16_t>((buf[1] << 8) | buf[0]);
 
 exit:
     return error;
@@ -387,7 +387,7 @@ ThreadError Frame::SetSrcPanId(PanId aPanId)
 
     VerifyOrExit((buf = FindSrcPanId()) != NULL, error = kThreadError_Parse);
 
-    buf[0] = aPanId;
+    buf[0] = aPanId & 0xff;
     buf[1] = aPanId >> 8;
 
 exit:
@@ -397,7 +397,7 @@ exit:
 uint8_t *Frame::FindSrcAddr(void)
 {
     uint8_t *cur = GetPsdu();
-    uint16_t fcf = (static_cast<uint16_t>(GetPsdu()[1]) << 8) | GetPsdu()[0];
+    uint16_t fcf = static_cast<uint16_t>((GetPsdu()[1] << 8) | GetPsdu()[0]);
 
     // Frame Control Field
     cur += kFcfSize;
@@ -429,7 +429,7 @@ ThreadError Frame::GetSrcAddr(Address &address)
 {
     ThreadError error = kThreadError_None;
     uint8_t *buf;
-    uint16_t fcf = (static_cast<uint16_t>(GetPsdu()[1]) << 8) | GetPsdu()[0];
+    uint16_t fcf = static_cast<uint16_t>((GetPsdu()[1] << 8) | GetPsdu()[0]);
 
     VerifyOrExit((buf = FindSrcAddr()) != NULL, error = kThreadError_Parse);
 
@@ -437,7 +437,7 @@ ThreadError Frame::GetSrcAddr(Address &address)
     {
     case Frame::kFcfSrcAddrShort:
         address.mLength = sizeof(ShortAddress);
-        address.mShortAddress = (static_cast<uint16_t>(buf[1]) << 8) | buf[0];;
+        address.mShortAddress = static_cast<uint16_t>((buf[1] << 8) | buf[0]);
         break;
 
     case Frame::kFcfSrcAddrExt:
@@ -462,14 +462,14 @@ exit:
 ThreadError Frame::SetSrcAddr(ShortAddress aShortAddress)
 {
     uint8_t *buf;
-    uint16_t fcf = (static_cast<uint16_t>(GetPsdu()[1]) << 8) | GetPsdu()[0];
+    uint16_t fcf = static_cast<uint16_t>((GetPsdu()[1] << 8) | GetPsdu()[0]);
 
     assert((fcf & Frame::kFcfSrcAddrMask) == Frame::kFcfSrcAddrShort);
 
     buf = FindSrcAddr();
     assert(buf != NULL);
 
-    buf[0] = aShortAddress;
+    buf[0] = aShortAddress & 0xff;
     buf[1] = aShortAddress >> 8;
 
     return kThreadError_None;
@@ -478,7 +478,7 @@ ThreadError Frame::SetSrcAddr(ShortAddress aShortAddress)
 ThreadError Frame::SetSrcAddr(const ExtAddress &aExtAddress)
 {
     uint8_t *buf;
-    uint16_t fcf = (static_cast<uint16_t>(GetPsdu()[1]) << 8) | GetPsdu()[0];
+    uint16_t fcf = static_cast<uint16_t>((GetPsdu()[1] << 8) | GetPsdu()[0]);
 
     assert((fcf & Frame::kFcfSrcAddrMask) == Frame::kFcfSrcAddrExt);
 
@@ -496,7 +496,7 @@ ThreadError Frame::SetSrcAddr(const ExtAddress &aExtAddress)
 uint8_t *Frame::FindSecurityHeader(void)
 {
     uint8_t *cur = GetPsdu();
-    uint16_t fcf = (static_cast<uint16_t>(GetPsdu()[1]) << 8) | GetPsdu()[0];
+    uint16_t fcf = static_cast<uint16_t>((GetPsdu()[1] << 8) | GetPsdu()[0]);
 
     VerifyOrExit((fcf & Frame::kFcfSecurityEnabled) != 0, cur = NULL);
 
@@ -585,10 +585,10 @@ ThreadError Frame::SetFrameCounter(uint32_t aFrameCounter)
     // Security Control
     buf += kSecurityControlSize;
 
-    buf[0] = aFrameCounter;
-    buf[1] = aFrameCounter >> 8;
-    buf[2] = aFrameCounter >> 16;
-    buf[3] = aFrameCounter >> 24;
+    buf[0] = aFrameCounter & 0xff;
+    buf[1] = (aFrameCounter >> 8) & 0xff;
+    buf[2] = (aFrameCounter >> 16) & 0xff;
+    buf[3] = (aFrameCounter >> 24) & 0xff;
 
     return kThreadError_None;
 }
@@ -661,7 +661,7 @@ ThreadError Frame::SetLength(uint8_t aLength)
 
 uint8_t Frame::GetHeaderLength(void)
 {
-    return GetPayload() - GetPsdu();
+    return static_cast<uint8_t>(GetPayload() - GetPsdu());
 }
 
 uint8_t Frame::GetFooterLength(void)
@@ -725,7 +725,7 @@ uint8_t *Frame::GetHeader(void)
 uint8_t *Frame::GetPayload(void)
 {
     uint8_t *cur = GetPsdu();
-    uint16_t fcf = (static_cast<uint16_t>(GetPsdu()[1]) << 8) | GetPsdu()[0];
+    uint16_t fcf = static_cast<uint16_t>((GetPsdu()[1] << 8) | GetPsdu()[0]);
     uint8_t securityControl;
 
     // Frame Control

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -577,7 +577,7 @@ public:
      * @returns The receive Link Quality Indicator.
      *
      */
-    int8_t GetLqi(void) const { return mLqi; }
+    uint8_t GetLqi(void) const { return mLqi; }
 
     /**
      * This method sets the receive Link Quality Indicator.
@@ -585,7 +585,7 @@ public:
      * @param[in]  aLqi  The receive Link Quality Indicator.
      *
      */
-    void SetLqi(int8_t aLqi) { mLqi = aLqi; }
+    void SetLqi(uint8_t aLqi) { mLqi = aLqi; }
 
     /**
      * This method indicates whether or not frame security was enabled and passed security validation.
@@ -790,7 +790,7 @@ public:
      *
      */
     void SetNetworkName(const char *aNetworkName) {
-        int length = strnlen(aNetworkName, sizeof(mNetworkName));
+        size_t length = strnlen(aNetworkName, sizeof(mNetworkName));
         memset(mNetworkName, 0, sizeof(mNetworkName));
         memcpy(mNetworkName, aNetworkName, length);
     }

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -77,7 +77,7 @@ uint16_t Ip6::UpdateChecksum(uint16_t checksum, const void *buf, uint16_t len)
 
     for (int i = 0; i < len; i++)
     {
-        checksum = Ip6::UpdateChecksum(checksum, (i & 1) ? bytes[i] : (static_cast<uint16_t>(bytes[i])) << 8);
+        checksum = Ip6::UpdateChecksum(checksum, (i & 1) ? bytes[i] : static_cast<uint16_t>(bytes[i] << 8));
     }
 
     return checksum;
@@ -335,7 +335,7 @@ exit:
     }
 }
 
-ThreadError Ip6::HandleDatagram(Message &message, Netif *netif, uint8_t interfaceId, const void *linkMessageInfo,
+ThreadError Ip6::HandleDatagram(Message &message, Netif *netif, int8_t interfaceId, const void *linkMessageInfo,
                                 bool fromLocalHost)
 {
     ThreadError error = kThreadError_Drop;
@@ -455,7 +455,7 @@ exit:
 ThreadError ForwardMessage(Message &message, MessageInfo &messageInfo)
 {
     ThreadError error = kThreadError_None;
-    int interfaceId;
+    int8_t interfaceId;
     Netif *netif;
 
     if (messageInfo.GetSockAddr().IsMulticast())

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -296,7 +296,7 @@ public:
      * @returns The IPv6 Header Extension Length value.
      *
      */
-    uint16_t GetLength() const { return mLength; }
+    uint8_t GetLength() const { return mLength; }
 
     /**
      * This method sets the IPv6 Header Extension Length value.
@@ -304,7 +304,7 @@ public:
      * @param[in]  aLength  The IPv6 Header Extension Length value.
      *
      */
-    void SetLength(uint16_t aLength) { mLength = aLength; }
+    void SetLength(uint8_t aLength) { mLength = aLength; }
 
 private:
     uint8_t mNextHeader;
@@ -430,7 +430,9 @@ public:
      * @param[in]  aOffset  The Fragment Offset value.
      */
     void SetOffset(uint16_t aOffset) {
-        mOffsetMore = HostSwap16((HostSwap16(mOffsetMore) & kOffsetMask) | (aOffset << kOffsetOffset));
+        uint16_t tmp = HostSwap16(mOffsetMore);
+        tmp = (tmp & ~kOffsetMask) | ((aOffset << kOffsetOffset) & kOffsetMask);
+        mOffsetMore = HostSwap16(tmp);
     }
 
     /**
@@ -521,7 +523,7 @@ public:
      * @retval kThreadError_Drop   Message processing failed and the message should be dropped.
      *
      */
-    static ThreadError HandleDatagram(Message &aMessage, Netif *aNetif, uint8_t aInterfaceId,
+    static ThreadError HandleDatagram(Message &aMessage, Netif *aNetif, int8_t aInterfaceId,
                                       const void *aLinkMessageInfo, bool aFromNcpHost);
 
     /**

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -191,7 +191,7 @@ ThreadError Address::FromString(const char *aBuf)
     uint16_t val = 0;
     uint8_t count = 0;
     bool first = true;
-    uint8_t ch;
+    char ch;
     uint8_t d;
 
     memset(mFields.m8, 0, 16);
@@ -237,7 +237,7 @@ ThreadError Address::FromString(const char *aBuf)
         }
 
         first = false;
-        val = (val << 4) | d;
+        val = static_cast<uint16_t>((val << 4) | d);
         VerifyOrExit(++count <= 4, error = kThreadError_Parse);
     }
 

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -73,7 +73,7 @@ ThreadError Mpl::ProcessOption(const Message &aMessage)
         else if (mEntries[i].mSeed == option.GetSeed())
         {
             entry = &mEntries[i];
-            diff = option.GetSequence() - entry->mSequence;
+            diff = static_cast<int8_t>(option.GetSequence() - entry->mSequence);
 
             if (diff <= 0)
             {

--- a/src/core/net/ip6_routes.cpp
+++ b/src/core/net/ip6_routes.cpp
@@ -80,11 +80,11 @@ ThreadError Routes::Remove(Route &aRoute)
     return kThreadError_None;
 }
 
-int Routes::Lookup(const Address &aSource, const Address &aDestination)
+int8_t Routes::Lookup(const Address &aSource, const Address &aDestination)
 {
-    int maxPrefixMatch = -1;
+    uint8_t maxPrefixMatch = 0;
     uint8_t prefixMatch;
-    int rval = -1;
+    int8_t rval = -1;
 
     for (Route *cur = sRoutes; cur; cur = cur->mNext)
     {

--- a/src/core/net/ip6_routes.hpp
+++ b/src/core/net/ip6_routes.hpp
@@ -56,7 +56,7 @@ struct Route
 {
     Address       mPrefix;        ///< The IPv6 prefix.
     uint8_t       mPrefixLength;  ///< The IPv6 prefix length.
-    uint8_t       mInterfaceId;   ///< The interface identifier.
+    int8_t        mInterfaceId;   ///< The interface identifier.
     struct Route *mNext;          ///< A pointer to the next IPv6 route.
 };
 
@@ -98,7 +98,7 @@ public:
      * @returns The interface identifier for the best route or -1 if no route is available.
      *
      */
-    static int Lookup(const Address &aSource, const Address &aDestination);
+    static int8_t Lookup(const Address &aSource, const Address &aDestination);
 };
 
 /**

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -40,7 +40,7 @@ namespace Thread {
 namespace Ip6 {
 
 Netif *Netif::sNetifListHead = NULL;
-int Netif::sNextInterfaceId = 1;
+int8_t Netif::sNextInterfaceId = 1;
 
 Netif::Netif() :
     mStateChangedTask(&HandleStateChangedTask, this)
@@ -145,7 +145,7 @@ Netif *Netif::GetNext() const
     return mNext;
 }
 
-Netif *Netif::GetNetifById(uint8_t aInterfaceId)
+Netif *Netif::GetNetifById(int8_t aInterfaceId)
 {
     Netif *netif;
 
@@ -177,7 +177,7 @@ exit:
     return netif;
 }
 
-int Netif::GetInterfaceId() const
+int8_t Netif::GetInterfaceId() const
 {
     return mInterfaceId;
 }
@@ -355,8 +355,8 @@ const NetifUnicastAddress *Netif::SelectSourceAddress(MessageInfo &aMessageInfo)
     int interfaceId = aMessageInfo.mInterfaceId;
     const NetifUnicastAddress *rvalAddr = NULL;
     const Address *candidateAddr;
-    uint8_t candidateId;
-    uint8_t rvalIface = 0;
+    int8_t candidateId;
+    int8_t rvalIface = 0;
 
     for (Netif *netif = GetNetifList(); netif; netif = netif->mNext)
     {
@@ -434,9 +434,9 @@ exit:
     return rvalAddr;
 }
 
-int Netif::GetOnLinkNetif(const Address &aAddress)
+int8_t Netif::GetOnLinkNetif(const Address &aAddress)
 {
-    int rval = -1;
+    int8_t rval = -1;
 
     for (Netif *netif = sNetifListHead; netif; netif = netif->mNext)
     {

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -230,7 +230,7 @@ public:
      * @returns The network interface identifier.
      *
      */
-    int GetInterfaceId(void) const;
+    int8_t GetInterfaceId(void) const;
 
     /**
      * This method returns a pointer to the list of unicast addresses.
@@ -385,7 +385,7 @@ public:
      * @returns A pointer to the network interface or NULL if none is found.
      *
      */
-    static Netif *GetNetifById(uint8_t aInterfaceId);
+    static Netif *GetNetifById(int8_t aInterfaceId);
 
     /**
      * This static method returns the network interface identified by @p aName.
@@ -426,7 +426,7 @@ public:
      * @returns The network interface identifier for the on-link interface or -1 if none is found.
      *
      */
-    static int GetOnLinkNetif(const Address &aAddress);
+    static int8_t GetOnLinkNetif(const Address &aAddress);
 
 private:
     static void HandleStateChangedTask(void *aContext);
@@ -435,7 +435,7 @@ private:
     NetifCallback *mCallbacks;
     NetifUnicastAddress *mUnicastAddresses;
     NetifMulticastAddress *mMulticastAddresses;
-    int mInterfaceId;
+    int8_t mInterfaceId;
     bool mAllRoutersSubscribed;
     Tasklet mStateChangedTask;
     Netif *mNext;
@@ -443,7 +443,7 @@ private:
     uint32_t mStateChangedFlags;
 
     static Netif *sNetifListHead;
-    static int sNextInterfaceId;
+    static int8_t sNextInterfaceId;
 };
 
 /**

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -395,7 +395,7 @@ uint32_t otGetNetworkIdTimeout(void)
     return sThreadNetif->GetMle().GetNetworkIdTimeout();
 }
 
-void otSetNetworkIdTimeout(uint32_t aTimeout)
+void otSetNetworkIdTimeout(uint8_t aTimeout)
 {
     sThreadNetif->GetMle().SetNetworkIdTimeout(aTimeout);
 }

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -65,7 +65,7 @@ AddressResolver::AddressResolver(ThreadNetif &aThreadNetif) :
     mCoapServer.AddResource(mAddressError);
     mCoapServer.AddResource(mAddressQuery);
     mCoapServer.AddResource(mAddressNotification);
-    mCoapMessageId = otPlatRandomGet();
+    mCoapMessageId = static_cast<uint8_t>(otPlatRandomGet());
 
     Ip6::Icmp::RegisterCallbacks(mIcmpHandler);
 }
@@ -177,7 +177,7 @@ ThreadError AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
 
     for (size_t i = 0; i < sizeof(mCoapToken); i++)
     {
-        mCoapToken[i] = otPlatRandomGet();
+        mCoapToken[i] = static_cast<uint8_t>(otPlatRandomGet());
     }
 
     VerifyOrExit((message = Ip6::Udp::NewMessage(0)) != NULL, error = kThreadError_NoBufs);
@@ -361,7 +361,7 @@ ThreadError AddressResolver::SendAddressError(const ThreadTargetTlv &aTarget, co
 
     for (size_t i = 0; i < sizeof(mCoapToken); i++)
     {
-        mCoapToken[i] = otPlatRandomGet();
+        mCoapToken[i] = static_cast<uint8_t>(otPlatRandomGet());
     }
 
     VerifyOrExit((message = Ip6::Udp::NewMessage(0)) != NULL, error = kThreadError_NoBufs);
@@ -626,7 +626,8 @@ void AddressResolver::HandleTimer()
             if (mCache[i].mTimeout == 0)
             {
                 mCache[i].mFailures++;
-                mCache[i].mRetryTimeout = kAddressQueryInitialRetryDelay * (1 << mCache[i].mFailures);
+                mCache[i].mRetryTimeout =
+                    static_cast<uint16_t>(kAddressQueryInitialRetryDelay * (1 << mCache[i].mFailures));
 
                 if (mCache[i].mRetryTimeout > kAddressQueryMaxRetryDelay)
                 {

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -85,10 +85,10 @@ ThreadError KeyManager::ComputeKey(uint32_t aKeySequence, uint8_t *aKey)
 
     otCryptoHmacSha256Start(mMasterKey, mMasterKeyLength);
 
-    keySequenceBytes[0] = aKeySequence >> 24;
-    keySequenceBytes[1] = aKeySequence >> 16;
-    keySequenceBytes[2] = aKeySequence >> 8;
-    keySequenceBytes[3] = aKeySequence >> 0;
+    keySequenceBytes[0] = (aKeySequence >> 24) & 0xff;
+    keySequenceBytes[1] = (aKeySequence >> 16) & 0xff;
+    keySequenceBytes[2] = (aKeySequence >> 8) & 0xff;
+    keySequenceBytes[3] = aKeySequence & 0xff;
     otCryptoHmacSha256Update(keySequenceBytes, sizeof(keySequenceBytes));
     otCryptoHmacSha256Update(kThreadString, sizeof(kThreadString));
 

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -84,7 +84,7 @@ void LinkQualityInfo::AddRss(int8_t anRss)
 
     // Multiply the the RSS value by a precision multiple (currently -8).
 
-    newValue = -anRss;
+    newValue = static_cast<uint16_t>(-anRss);
     newValue <<= kRssAveragePrecisionMultipleBitShift;
 
     oldAverage = mRssAverage;
@@ -92,12 +92,12 @@ void LinkQualityInfo::AddRss(int8_t anRss)
     if (mCount >= kRssCountForWeightCoefficientOneEighth)
     {
         // New average = old average * 7/8 + new value * 1/8
-        mRssAverage = ((oldAverage << 3) - oldAverage + newValue) >> 3;
+        mRssAverage = static_cast<uint16_t>(((oldAverage << 3) - oldAverage + newValue) >> 3);
     }
     else if (mCount >= kRssCountForWeightCoefficientOneFourth)
     {
         // New average = old average * 3/4 + new value * 1/4
-        mRssAverage = ((oldAverage << 2) - oldAverage + newValue) >> 2;
+        mRssAverage = static_cast<uint16_t>(((oldAverage << 2) - oldAverage + newValue) >> 2);
     }
     else if (mCount >= kRssCountForWeightCoefficientOneHalf)
     {
@@ -123,7 +123,7 @@ int8_t LinkQualityInfo::GetAverageRss(void) const
 
     if (mCount != 0)
     {
-        average = -(static_cast<int16_t>(mRssAverage >> kRssAveragePrecisionMultipleBitShift));
+        average = -static_cast<int8_t>(mRssAverage >> kRssAveragePrecisionMultipleBitShift);
 
         // Check for round up (e.g. average of -71.5 --> -72)
 

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -406,7 +406,7 @@ public:
         }
         else {
             mDispatchOffsetSize |= kOffset;
-            mOffset = aOffset / 8;
+            mOffset = (aOffset >> 3) & kOffsetMask;
         }
     }
 
@@ -417,6 +417,7 @@ private:
         kDispatchMask = 3 << 6,
         kOffset       = 1 << 5,
         kSizeMask     = 0x7ff,
+        kOffsetMask   = 0xff,
     };
 
     union

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -64,7 +64,7 @@ MeshForwarder::MeshForwarder(ThreadNetif &aThreadNetif):
     mMle(aThreadNetif.GetMle()),
     mNetworkData(aThreadNetif.GetNetworkDataLeader())
 {
-    mFragTag = otPlatRandomGet();
+    mFragTag = static_cast<uint16_t>(otPlatRandomGet());
     mPollPeriod = 0;
     mSendMessage = NULL;
     mSendBusy = false;
@@ -221,7 +221,7 @@ ThreadError MeshForwarder::SendMessage(Message &aMessage)
             // destined for all sleepy children
             children = mMle.GetChildren(&numChildren);
 
-            for (int i = 0; i < numChildren; i++)
+            for (uint8_t i = 0; i < numChildren; i++)
             {
                 if (children[i].mState == Neighbor::kStateValid && (children[i].mMode & Mle::ModeTlv::kModeRxOnWhenIdle) == 0)
                 {
@@ -355,7 +355,7 @@ exit:
 Message *MeshForwarder::GetIndirectTransmission(const Child &aChild)
 {
     Message *message = NULL;
-    int childIndex = mMle.GetChildIndex(aChild);
+    uint8_t childIndex = mMle.GetChildIndex(aChild);
     Ip6::Header ip6Header;
     Lowpan::MeshHeader meshHeader;
 
@@ -772,7 +772,7 @@ ThreadError MeshForwarder::SendMesh(Message &aMessage, Mac::Frame &aFrame)
     // write payload
     assert(aMessage.GetLength() <= aFrame.GetMaxPayloadLength());
     aMessage.Read(0, aMessage.GetLength(), aFrame.GetPayload());
-    aFrame.SetPayloadLength(aMessage.GetLength());
+    aFrame.SetPayloadLength(static_cast<uint8_t>(aMessage.GetLength()));
 
     mMessageNextOffset = aMessage.GetLength();
 
@@ -786,8 +786,8 @@ ThreadError MeshForwarder::SendFragment(Message &aMessage, Mac::Frame &aFrame)
     Lowpan::FragmentHeader *fragmentHeader;
     Lowpan::MeshHeader *meshHeader;
     uint8_t *payload;
-    int headerLength;
-    int payloadLength;
+    uint8_t headerLength;
+    uint16_t payloadLength;
     int hcLength;
     uint16_t fragmentLength;
     uint16_t dstpan;
@@ -906,7 +906,7 @@ ThreadError MeshForwarder::SendFragment(Message &aMessage, Mac::Frame &aFrame)
 
         // copy IPv6 Payload
         aMessage.Read(aMessage.GetOffset(), payloadLength, payload);
-        aFrame.SetPayloadLength(headerLength + payloadLength);
+        aFrame.SetPayloadLength(static_cast<uint8_t>(headerLength + payloadLength));
 
         mMessageNextOffset = aMessage.GetOffset() + payloadLength;
         aMessage.SetOffset(0);
@@ -934,7 +934,7 @@ ThreadError MeshForwarder::SendFragment(Message &aMessage, Mac::Frame &aFrame)
 
         // copy IPv6 Payload
         aMessage.Read(aMessage.GetOffset(), payloadLength, payload);
-        aFrame.SetPayloadLength(headerLength + payloadLength);
+        aFrame.SetPayloadLength(static_cast<uint8_t>(headerLength + payloadLength));
 
         mMessageNextOffset = aMessage.GetOffset() + payloadLength;
     }
@@ -1415,7 +1415,7 @@ void MeshForwarder::UpdateFramePending()
 void MeshForwarder::HandleDataRequest(const Mac::Address &aMacSource, const ThreadMessageInfo &aMessageInfo)
 {
     Neighbor *neighbor;
-    int childIndex;
+    uint8_t childIndex;
 
     // Security Check: only process secure Data Poll frames.
     VerifyOrExit(aMessageInfo.mLinkSecurity, ;);

--- a/src/core/thread/meshcop_dataset.cpp
+++ b/src/core/thread/meshcop_dataset.cpp
@@ -311,16 +311,11 @@ exit:
     return error;
 }
 
-ThreadError Dataset::Set(const Message &aMessage, uint16_t aOffset, uint16_t aLength)
+ThreadError Dataset::Set(const Message &aMessage, uint16_t aOffset, uint8_t aLength)
 {
-    ThreadError error = kThreadError_None;
-
-    VerifyOrExit(aLength <= kMaxSize, error = kThreadError_InvalidArgs);
     aMessage.Read(aOffset, aLength, mTlvs);
     mLength = aLength;
-
-exit:
-    return error;
+    return kThreadError_None;
 }
 
 void Dataset::Remove(Tlv::Type aType)
@@ -336,7 +331,7 @@ exit:
 
 void Dataset::Remove(uint8_t *aStart, uint8_t aLength)
 {
-    memmove(aStart, aStart + aLength, mLength - ((aStart - mTlvs) + aLength));
+    memmove(aStart, aStart + aLength, mLength - (static_cast<uint8_t>(aStart - mTlvs) + aLength));
     mLength -= aLength;
 }
 

--- a/src/core/thread/meshcop_dataset.hpp
+++ b/src/core/thread/meshcop_dataset.hpp
@@ -97,7 +97,7 @@ public:
      * @returns The Dataset size in bytes.
      *
      */
-    uint16_t GetSize(void) const { return mLength; }
+    uint8_t GetSize(void) const { return mLength; }
 
     /**
      * This method returns a reference to the Timestamp.
@@ -124,7 +124,7 @@ public:
      */
     ThreadError Set(const Tlv &aTlv);
 
-    ThreadError Set(const Message &aMessage, uint16_t aOffset, uint16_t aLength);
+    ThreadError Set(const Message &aMessage, uint16_t aOffset, uint8_t aLength);
 
     ThreadError Set(const otOperationalDataset &aDataset, bool aActive);
 
@@ -135,7 +135,7 @@ private:
 
     Timestamp mTimestamp;       ///< Active or Pending Timestamp
     uint8_t   mTlvs[kMaxSize];  ///< The Dataset buffer
-    uint16_t  mLength;          ///< The number of valid bytes in @var mTlvs
+    uint8_t   mLength;          ///< The number of valid bytes in @var mTlvs
 };
 
 }  // namespace MeshCoP

--- a/src/core/thread/meshcop_dataset_manager.cpp
+++ b/src/core/thread/meshcop_dataset_manager.cpp
@@ -94,7 +94,7 @@ exit:
 }
 
 ThreadError DatasetManager::Set(const Timestamp &aTimestamp, const Message &aMessage,
-                                uint16_t aOffset, uint16_t aLength, uint8_t &aFlags)
+                                uint16_t aOffset, uint8_t aLength, uint8_t &aFlags)
 {
     ThreadError error = kThreadError_None;
     int compare;
@@ -159,7 +159,7 @@ ThreadError DatasetManager::Register(void)
 
     for (size_t i = 0; i < sizeof(mCoapToken); i++)
     {
-        mCoapToken[i] = otPlatRandomGet();
+        mCoapToken[i] = static_cast<uint8_t>(otPlatRandomGet());
     }
 
     header.Init();
@@ -257,7 +257,7 @@ void DatasetManager::HandleSet(Coap::Header &aHeader, Message &aMessage, const I
     // verify the request includes a timestamp that is ahead of the locally stored value
     VerifyOrExit(offset < aMessage.GetLength() && mLocal.GetTimestamp().Compare(timestamp) > 0, ;);
 
-    mLocal.Set(aMessage, aMessage.GetOffset(), aMessage.GetLength() - aMessage.GetOffset());
+    mLocal.Set(aMessage, aMessage.GetOffset(), static_cast<uint8_t>(aMessage.GetLength() - aMessage.GetOffset()));
     mNetwork = mLocal;
     mNetworkDataLeader.IncrementVersion();
     mNetworkDataLeader.IncrementStableVersion();
@@ -335,7 +335,7 @@ exit:
 }
 
 ThreadError ActiveDataset::Set(const Timestamp &aTimestamp, const Message &aMessage,
-                               uint16_t aOffset, uint16_t aLength)
+                               uint16_t aOffset, uint8_t aLength)
 {
     ThreadError error = kThreadError_None;
     uint8_t flags;
@@ -366,7 +366,7 @@ ThreadError ActiveDataset::ApplyConfiguration(void)
         case Tlv::kChannel:
         {
             const ChannelTlv *channel = static_cast<const ChannelTlv *>(cur);
-            mNetif.GetMac().SetChannel(channel->GetChannel());
+            mNetif.GetMac().SetChannel(static_cast<uint8_t>(channel->GetChannel()));
             break;
         }
 
@@ -456,7 +456,7 @@ exit:
 }
 
 ThreadError PendingDataset::Set(const Timestamp &aTimestamp, const Message &aMessage,
-                                uint16_t aOffset, uint16_t aLength)
+                                uint16_t aOffset, uint8_t aLength)
 {
     ThreadError error = kThreadError_None;
     uint8_t flags;

--- a/src/core/thread/meshcop_dataset_manager.hpp
+++ b/src/core/thread/meshcop_dataset_manager.hpp
@@ -70,7 +70,7 @@ protected:
 
     ThreadError Set(const Dataset &aDataset, uint8_t &aFlags);
 
-    ThreadError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint16_t aLength,
+    ThreadError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength,
                     uint8_t &aFlags);
 
     Dataset mLocal;
@@ -117,7 +117,7 @@ public:
 
     ThreadError Set(const otOperationalDataset &aDataset);
 
-    ThreadError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint16_t aLength);
+    ThreadError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
 
     ThreadError ApplyConfiguration(void);
 };
@@ -133,7 +133,7 @@ public:
 
     ThreadError Set(const otOperationalDataset &aDataset);
 
-    ThreadError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint16_t aLength);
+    ThreadError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
 
     void ApplyLocalToNetwork(void);
 

--- a/src/core/thread/meshcop_tlvs.hpp
+++ b/src/core/thread/meshcop_tlvs.hpp
@@ -319,7 +319,7 @@ public:
      *
      */
     void SetNetworkName(const char *aNetworkName) {
-        int length = strnlen(aNetworkName, sizeof(mNetworkName));
+        size_t length = strnlen(aNetworkName, sizeof(mNetworkName));
         memcpy(mNetworkName, aNetworkName, length);
     }
 
@@ -581,7 +581,7 @@ public:
      */
     void SetSeconds(uint64_t aSeconds) {
         for (size_t i = 0; i < sizeof(mSeconds); i++, aSeconds >>= 8) {
-            mSeconds[sizeof(mSeconds) - 1 - i] = aSeconds;
+            mSeconds[sizeof(mSeconds) - 1 - i] = aSeconds & 0xff;
         }
     }
 
@@ -599,7 +599,9 @@ public:
      * @param[in]  aTicks  The Ticks value.
      *
      */
-    void SetTicks(uint16_t aTicks) { mTicks = (mTicks & ~kTicksMask) | (aTicks << kTicksOffset); }
+    void SetTicks(uint16_t aTicks) {
+        mTicks = (mTicks & ~kTicksMask) | ((aTicks << kTicksOffset) & kTicksMask);
+    }
 
     /**
      * This method returns the Authoritative value.
@@ -616,7 +618,7 @@ public:
      *
      */
     void SetAuthoritative(bool aAuthoritative) {
-        mTicks = (mTicks & kTicksMask) | (aAuthoritative << kAuthoritativeOffset);
+        mTicks = (mTicks & kTicksMask) | ((aAuthoritative << kAuthoritativeOffset) & kAuthoritativeMask);
     }
 
 private:
@@ -709,7 +711,7 @@ public:
      * @returns The Delay Timer value.
      *
      */
-    uint16_t GetDelayTimer(void) const { return HostSwap32(mDelayTimer); }
+    uint32_t GetDelayTimer(void) const { return HostSwap32(mDelayTimer); }
 
     /**
      * This method sets the Delay Timer value.
@@ -862,7 +864,9 @@ public:
      * @param[in]  aVersion  The Version value.
      *
      */
-    void SetVersion(uint8_t aVersion) { mFlags = (mFlags & ~kVersionMask) | (aVersion << kVersionOffset); }
+    void SetVersion(uint8_t aVersion) {
+        mFlags = (mFlags & ~kVersionMask) | ((aVersion << kVersionOffset) & kVersionMask);
+    }
 
     /**
      * This method indicates whether or not the Joiner flag is set.
@@ -937,7 +941,9 @@ public:
      * @param[in]  aVersion  The Version value.
      *
      */
-    void SetVersion(uint8_t aVersion) { mFlags = (mFlags & ~kVersionMask) | (aVersion << kVersionOffset); }
+    void SetVersion(uint8_t aVersion) {
+        mFlags = (mFlags & ~kVersionMask) | ((aVersion << kVersionOffset) & kVersionMask);
+    }
 
     /**
      * This method indicates whether or not the Native Commissioner flag is set.

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -243,10 +243,10 @@ public:
         }
         else {
             mKeyIdentifier[4] = (aKeySequence & 0x7f) + 1;
-            mKeyIdentifier[3] = aKeySequence >> 0;
-            mKeyIdentifier[2] = aKeySequence >> 8;
-            mKeyIdentifier[1] = aKeySequence >> 16;
-            mKeyIdentifier[0] = aKeySequence >> 24;
+            mKeyIdentifier[3] = (aKeySequence >> 0) & 0xff;
+            mKeyIdentifier[2] = (aKeySequence >> 8) & 0xff;
+            mKeyIdentifier[1] = (aKeySequence >> 16) & 0xff;
+            mKeyIdentifier[0] = (aKeySequence >> 24) & 0xff;
         }
     }
 
@@ -631,7 +631,7 @@ public:
      * @returns The Child ID portion of an RLOC16.
      *
      */
-    static uint8_t GetChildId(uint16_t aRloc16) { return aRloc16 & kMaxChildId; }
+    static uint16_t GetChildId(uint16_t aRloc16) { return aRloc16 & kMaxChildId; }
 
     /**
      * This method returns the Router ID portion of an RLOC16.
@@ -651,7 +651,7 @@ public:
      * @returns The RLOC16 of the given Router ID.
      *
      */
-    static uint16_t GetRloc16(uint8_t aRouterId) { return static_cast<uint16_t>(aRouterId) << kRouterIdOffset; }
+    static uint16_t GetRloc16(uint8_t aRouterId) { return static_cast<uint16_t>(aRouterId << kRouterIdOffset); }
 
     /**
      * This method indicates whether or not @p aRloc16 refers to an active router.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -70,7 +70,7 @@ MleRouter::MleRouter(ThreadNetif &aThreadNetif):
     mRouterIdSequenceLastUpdated = 0;
     mRouterRoleEnabled = true;
 
-    mCoapMessageId = otPlatRandomGet();
+    mCoapMessageId = static_cast<uint8_t>(otPlatRandomGet());
 }
 
 bool MleRouter::IsRouterRoleEnabled(void) const
@@ -88,9 +88,9 @@ void MleRouter::SetRouterRoleEnabled(bool aEnabled)
     }
 }
 
-int MleRouter::AllocateRouterId(void)
+uint8_t MleRouter::AllocateRouterId(void)
 {
-    int rval = -1;
+    uint8_t rval = kMaxRouterId;
 
     // count available router ids
     uint8_t numAvailable = 0;
@@ -108,14 +108,14 @@ int MleRouter::AllocateRouterId(void)
         }
     }
 
-    VerifyOrExit(numAllocated < kMaxRouters && numAvailable > 0, rval = -1);
+    VerifyOrExit(numAllocated < kMaxRouters && numAvailable > 0, rval = kMaxRouterId);
 
     // choose available router id at random
     uint8_t freeBit;
     freeBit = otPlatRandomGet() % numAvailable;
 
     // allocate router id
-    for (int i = 0; i < kMaxRouterId; i++)
+    for (uint8_t i = 0; i < kMaxRouterId; i++)
     {
         if (mRouters[i].mAllocated || mRouters[i].mReclaimDelay)
         {
@@ -135,11 +135,11 @@ exit:
     return rval;
 }
 
-int MleRouter::AllocateRouterId(uint8_t aRouterId)
+uint8_t MleRouter::AllocateRouterId(uint8_t aRouterId)
 {
-    int rval = -1;
+    uint8_t rval = kMaxRouterId;
 
-    VerifyOrExit(!mRouters[aRouterId].mAllocated, rval = -1);
+    VerifyOrExit(!mRouters[aRouterId].mAllocated, rval = kMaxRouterId);
 
     // init router state
     mRouters[aRouterId].mAllocated = true;
@@ -220,6 +220,7 @@ exit:
 ThreadError MleRouter::BecomeLeader(void)
 {
     ThreadError error = kThreadError_None;
+    uint8_t routerId;
 
     VerifyOrExit(mDeviceState != kDeviceStateDisabled && mDeviceState != kDeviceStateLeader,
                  error = kThreadError_Busy);
@@ -238,18 +239,19 @@ ThreadError MleRouter::BecomeLeader(void)
     mStateUpdateTimer.Start(kStateUpdatePeriod);
     mAddressResolver.Clear();
 
-    mRouterId = (mPreviousRouterId != kMaxRouterId) ? AllocateRouterId(mPreviousRouterId) : AllocateRouterId();
-    VerifyOrExit(mRouterId >= 0, error = kThreadError_NoBufs);
+    routerId = (mPreviousRouterId != kMaxRouterId) ? AllocateRouterId(mPreviousRouterId) : AllocateRouterId();
+    VerifyOrExit(routerId < kMaxRouterId, error = kThreadError_NoBufs);
+    mRouterId = static_cast<uint8_t>(routerId);
     mPreviousRouterId = mRouterId;
 
     memcpy(&mRouters[mRouterId].mMacAddr, mMac.GetExtAddress(), sizeof(mRouters[mRouterId].mMacAddr));
 
     SetLeaderData(otPlatRandomGet(), mLeaderWeight, mRouterId);
-    mRouterIdSequence = otPlatRandomGet();
+    mRouterIdSequence = static_cast<uint8_t>(otPlatRandomGet());
 
     mNetworkData.Reset();
 
-    SuccessOrExit(error = SetStateLeader(mRouterId << 10));
+    SuccessOrExit(error = SetStateLeader(GetRloc16(mRouterId)));
 
 exit:
     return error;
@@ -539,7 +541,7 @@ ThreadError MleRouter::SendLinkRequest(Neighbor *aNeighbor)
     {
         for (uint8_t i = 0; i < sizeof(mChallenge); i++)
         {
-            mChallenge[i] = otPlatRandomGet();
+            mChallenge[i] = static_cast<uint8_t>(otPlatRandomGet());
         }
 
         SuccessOrExit(error = AppendChallenge(*message, mChallenge, sizeof(mChallenge)));
@@ -551,7 +553,7 @@ ThreadError MleRouter::SendLinkRequest(Neighbor *aNeighbor)
     {
         for (uint8_t i = 0; i < sizeof(aNeighbor->mPending.mChallenge); i++)
         {
-            aNeighbor->mPending.mChallenge[i] = otPlatRandomGet();
+            aNeighbor->mPending.mChallenge[i] = static_cast<uint8_t>(otPlatRandomGet());
         }
 
         SuccessOrExit(error = AppendChallenge(*message, mChallenge, sizeof(mChallenge)));
@@ -674,7 +676,7 @@ ThreadError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo, Neig
     static const uint8_t routerTlvs[] = {Tlv::kLinkMargin};
     Message *message;
     Header::Command command;
-    int8_t linkMargin;
+    uint8_t linkMargin;
 
     command = (aNeighbor == NULL || aNeighbor->mState == Neighbor::kStateValid) ?
               Header::kCommandLinkAccept : Header::kCommandLinkAcceptAndRequest;
@@ -727,7 +729,7 @@ ThreadError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo, Neig
     {
         for (uint8_t i = 0; i < sizeof(aNeighbor->mPending.mChallenge); i++)
         {
-            aNeighbor->mPending.mChallenge[i] = otPlatRandomGet();
+            aNeighbor->mPending.mChallenge[i] = static_cast<uint8_t>(otPlatRandomGet());
         }
 
         SuccessOrExit(error = AppendChallenge(*message, aNeighbor->mPending.mChallenge,
@@ -1072,7 +1074,7 @@ exit:
 ThreadError MleRouter::ProcessRouteTlv(const RouteTlv &aRoute)
 {
     ThreadError error = kThreadError_None;
-    int8_t diff = aRoute.GetRouterIdSequence() - mRouterIdSequence;
+    int8_t diff = static_cast<int8_t>(aRoute.GetRouterIdSequence() - mRouterIdSequence);
     bool old;
 
     // check for newer route data
@@ -1081,7 +1083,7 @@ ThreadError MleRouter::ProcessRouteTlv(const RouteTlv &aRoute)
         mRouterIdSequence = aRoute.GetRouterIdSequence();
         mRouterIdSequenceLastUpdated = Timer::GetNow();
 
-        for (int i = 0; i < kMaxRouterId; i++)
+        for (uint8_t i = 0; i < kMaxRouterId; i++)
         {
             old = mRouters[i].mAllocated;
             mRouters[i].mAllocated = aRoute.IsRouterIdSet(i);
@@ -1241,7 +1243,7 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
 
         routerCount = 0;
 
-        for (int i = 0; i < kMaxRouterId; i++)
+        for (uint8_t i = 0; i < kMaxRouterId; i++)
         {
             if (route.IsRouterIdSet(i))
             {
@@ -1367,7 +1369,7 @@ void MleRouter::UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId)
     {
         update = false;
 
-        for (int i = 0, routeCount = 0; i < kMaxRouterId; i++)
+        for (uint8_t i = 0, routeCount = 0; i < kMaxRouterId; i++)
         {
             if (aRoute.IsRouterIdSet(i) == false)
             {
@@ -1610,7 +1612,7 @@ void MleRouter::HandleStateUpdateTimer(void)
     }
 
     // update router state
-    for (int i = 0; i < kMaxRouterId; i++)
+    for (uint8_t i = 0; i < kMaxRouterId; i++)
     {
         if (mRouters[i].mState != Neighbor::kStateInvalid)
         {
@@ -1668,7 +1670,7 @@ ThreadError MleRouter::SendParentResponse(Child *aChild, const ChallengeTlv &cha
 
     for (uint8_t i = 0; i < sizeof(aChild->mPending.mChallenge); i++)
     {
-        aChild->mPending.mChallenge[i] = otPlatRandomGet();
+        aChild->mPending.mChallenge[i] = static_cast<uint8_t>(otPlatRandomGet());
     }
 
     SuccessOrExit(error = AppendChallenge(*message, aChild->mPending.mChallenge, sizeof(aChild->mPending.mChallenge)));
@@ -1700,7 +1702,7 @@ ThreadError MleRouter::UpdateChildAddresses(const AddressRegistrationTlv &aTlv, 
 
     memset(aChild.mIp6Address, 0, sizeof(aChild.mIp6Address));
 
-    for (size_t count = 0; count < sizeof(aChild.mIp6Address) / sizeof(aChild.mIp6Address[0]); count++)
+    for (uint8_t count = 0; count < sizeof(aChild.mIp6Address) / sizeof(aChild.mIp6Address[0]); count++)
     {
         if ((entry = aTlv.GetAddressEntry(count)) == NULL)
         {
@@ -2247,9 +2249,9 @@ Child *MleRouter::GetChild(const Mac::Address &aAddress)
     return NULL;
 }
 
-int MleRouter::GetChildIndex(const Child &child)
+uint8_t MleRouter::GetChildIndex(const Child &child)
 {
-    return &child - mChildren;
+    return static_cast<uint8_t>(&child - mChildren);
 }
 
 Child *MleRouter::GetChildren(uint8_t *numChildren)
@@ -2595,24 +2597,29 @@ void MleRouter::GetChildInfo(Child &aChild, otChildInfo &aChildInfo)
 ThreadError MleRouter::GetRouterInfo(uint16_t aRouterId, otRouterInfo &aRouterInfo)
 {
     ThreadError error = kThreadError_None;
+    uint8_t routerId;
 
     if (aRouterId > kMaxRouterId && IsActiveRouter(aRouterId))
     {
-        aRouterId = GetRouterId(aRouterId);
+        routerId = GetRouterId(aRouterId);
+    }
+    else
+    {
+        routerId = static_cast<uint8_t>(aRouterId);
     }
 
-    VerifyOrExit(aRouterId <= kMaxRouterId, error = kThreadError_InvalidArgs);
+    VerifyOrExit(routerId <= kMaxRouterId, error = kThreadError_InvalidArgs);
 
-    memcpy(&aRouterInfo.mExtAddress, &mRouters[aRouterId].mMacAddr, sizeof(aRouterInfo.mExtAddress));
-    aRouterInfo.mAllocated = mRouters[aRouterId].mAllocated;
-    aRouterInfo.mRouterId = aRouterId;
-    aRouterInfo.mRloc16 = GetRloc16(aRouterId);
-    aRouterInfo.mNextHop = mRouters[aRouterId].mNextHop;
-    aRouterInfo.mLinkEstablished = mRouters[aRouterId].mState == Neighbor::kStateValid;
-    aRouterInfo.mPathCost = mRouters[aRouterId].mCost;
-    aRouterInfo.mLinkQualityIn = mRouters[aRouterId].mLinkInfo.GetLinkQuality();
-    aRouterInfo.mLinkQualityOut = mRouters[aRouterId].mLinkQualityOut;
-    aRouterInfo.mAge = Timer::MsecToSec(Timer::GetNow() - mRouters[aRouterId].mLastHeard);
+    memcpy(&aRouterInfo.mExtAddress, &mRouters[routerId].mMacAddr, sizeof(aRouterInfo.mExtAddress));
+    aRouterInfo.mAllocated = mRouters[routerId].mAllocated;
+    aRouterInfo.mRouterId = routerId;
+    aRouterInfo.mRloc16 = GetRloc16(routerId);
+    aRouterInfo.mNextHop = mRouters[routerId].mNextHop;
+    aRouterInfo.mLinkEstablished = mRouters[routerId].mState == Neighbor::kStateValid;
+    aRouterInfo.mPathCost = mRouters[routerId].mCost;
+    aRouterInfo.mLinkQualityIn = mRouters[routerId].mLinkInfo.GetLinkQuality();
+    aRouterInfo.mLinkQualityOut = mRouters[routerId].mLinkQualityOut;
+    aRouterInfo.mAge = static_cast<uint8_t>(Timer::MsecToSec(Timer::GetNow() - mRouters[routerId].mLastHeard));
 
 exit:
     return error;
@@ -2675,7 +2682,7 @@ ThreadError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
 
     for (size_t i = 0; i < sizeof(mCoapToken); i++)
     {
-        mCoapToken[i] = otPlatRandomGet();
+        mCoapToken[i] = static_cast<uint8_t>(otPlatRandomGet());
     }
 
     header.Init();
@@ -2728,7 +2735,7 @@ ThreadError MleRouter::SendAddressRelease(void)
 
     for (size_t i = 0; i < sizeof(mCoapToken); i++)
     {
-        mCoapToken[i] = otPlatRandomGet();
+        mCoapToken[i] = static_cast<uint8_t>(otPlatRandomGet());
     }
 
     header.Init();
@@ -2815,7 +2822,7 @@ void MleRouter::HandleAddressSolicitResponse(Message &aMessage)
     mRouterIdSequence = routerMaskTlv.GetIdSequence();
     mRouterIdSequenceLastUpdated = Timer::GetNow();
 
-    for (int i = 0; i < kMaxRouterId; i++)
+    for (uint8_t i = 0; i < kMaxRouterId; i++)
     {
         old = mRouters[i].mAllocated;
         mRouters[i].mAllocated = routerMaskTlv.IsAssignedRouterIdSet(i);
@@ -2874,7 +2881,7 @@ void MleRouter::HandleAddressSolicit(Coap::Header &aHeader, Message &aMessage, c
     ThreadExtMacAddressTlv macAddr64Tlv;
     ThreadRloc16Tlv rlocTlv;
     ThreadStatusTlv statusTlv;
-    int routerId = -1;
+    uint8_t routerId = kMaxRouterId;
 
     VerifyOrExit(aHeader.GetType() == Coap::Header::kTypeConfirmable && aHeader.GetCode() == Coap::Header::kCodePost,
                  error = kThreadError_Parse);
@@ -2888,7 +2895,7 @@ void MleRouter::HandleAddressSolicit(Coap::Header &aHeader, Message &aMessage, c
     VerifyOrExit(statusTlv.IsValid(), error = kThreadError_Parse);
 
     // see if allocation already exists
-    for (int i = 0; i < kMaxRouterId; i++)
+    for (uint8_t i = 0; i < kMaxRouterId; i++)
     {
         if (mRouters[i].mAllocated &&
             memcmp(&mRouters[i].mMacAddr, macAddr64Tlv.GetMacAddr(), sizeof(mRouters[i].mMacAddr)) == 0)
@@ -2921,19 +2928,19 @@ void MleRouter::HandleAddressSolicit(Coap::Header &aHeader, Message &aMessage, c
         if (routerId >= kMaxRouterId)
         {
             // requested Router ID is out of range
-            routerId = -1;
+            routerId = kMaxRouterId;
         }
         else if (mRouters[routerId].mAllocated &&
                  memcmp(&mRouters[routerId].mMacAddr, macAddr64Tlv.GetMacAddr(),
                         sizeof(mRouters[routerId].mMacAddr)))
         {
             // requested Router ID is allocated to another device
-            routerId = -1;
+            routerId = kMaxRouterId;
         }
         else if (!mRouters[routerId].mAllocated && mRouters[routerId].mReclaimDelay)
         {
             // requested Router ID is deallocated but within ID_REUSE_DELAY period
-            routerId = -1;
+            routerId = kMaxRouterId;
         }
         else
         {
@@ -2942,7 +2949,7 @@ void MleRouter::HandleAddressSolicit(Coap::Header &aHeader, Message &aMessage, c
     }
 
     // allocate new router id
-    if (routerId < 0)
+    if (routerId >= kMaxRouterId)
     {
         routerId = AllocateRouterId();
     }
@@ -2951,7 +2958,7 @@ void MleRouter::HandleAddressSolicit(Coap::Header &aHeader, Message &aMessage, c
         otLogInfoMle("router id requested and provided!\n");
     }
 
-    if (routerId >= 0)
+    if (routerId < kMaxRouterId)
     {
         memcpy(&mRouters[routerId].mMacAddr, macAddr64Tlv.GetMacAddr(), sizeof(mRouters[routerId].mMacAddr));
     }
@@ -2968,7 +2975,7 @@ exit:
     }
 }
 
-void MleRouter::SendAddressSolicitResponse(const Coap::Header &aRequestHeader, int aRouterId,
+void MleRouter::SendAddressSolicitResponse(const Coap::Header &aRequestHeader, uint8_t aRouterId,
                                            const Ip6::MessageInfo &aMessageInfo)
 {
     ThreadError error = kThreadError_None;
@@ -2990,10 +2997,10 @@ void MleRouter::SendAddressSolicitResponse(const Coap::Header &aRequestHeader, i
     SuccessOrExit(error = message->Append(responseHeader.GetBytes(), responseHeader.GetLength()));
 
     statusTlv.Init();
-    statusTlv.SetStatus((aRouterId < 0) ? statusTlv.kNoAddressAvailable : statusTlv.kSuccess);
+    statusTlv.SetStatus((aRouterId >= kMaxRouterId) ? statusTlv.kNoAddressAvailable : statusTlv.kSuccess);
     SuccessOrExit(error = message->Append(&statusTlv, sizeof(statusTlv)));
 
-    if (aRouterId >= 0)
+    if (aRouterId < kMaxRouterId)
     {
         rlocTlv.Init();
         rlocTlv.SetRloc16(GetRloc16(aRouterId));
@@ -3003,7 +3010,7 @@ void MleRouter::SendAddressSolicitResponse(const Coap::Header &aRequestHeader, i
         routerMaskTlv.SetIdSequence(mRouterIdSequence);
         routerMaskTlv.ClearAssignedRouterIdMask();
 
-        for (int i = 0; i < kMaxRouterId; i++)
+        for (uint8_t i = 0; i < kMaxRouterId; i++)
         {
             if (mRouters[i].mAllocated)
             {
@@ -3217,7 +3224,7 @@ ThreadError MleRouter::AppendChildAddresses(Message &aMessage, Child &aChild)
     AddressRegistrationEntry entry;
     Lowpan::Context context;
     uint8_t length = 0;
-    uint8_t startOffset = aMessage.GetLength();
+    uint8_t startOffset = static_cast<uint8_t>(aMessage.GetLength());
 
     tlv.SetType(Tlv::kAddressRegistration);
     SuccessOrExit(error = aMessage.Append(&tlv, sizeof(tlv)));
@@ -3257,14 +3264,14 @@ ThreadError MleRouter::AppendRoute(Message &aMessage)
 {
     ThreadError error;
     RouteTlv tlv;
-    int routeCount = 0;
+    uint8_t routeCount = 0;
     uint8_t cost;
 
     tlv.Init();
     tlv.SetRouterIdSequence(mRouterIdSequence);
     tlv.ClearRouterIdMask();
 
-    for (int i = 0; i < kMaxRouterId; i++)
+    for (uint8_t i = 0; i < kMaxRouterId; i++)
     {
         if (mRouters[i].mAllocated == false)
         {

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -255,10 +255,10 @@ public:
      *
      * @param[in]  aChild  A reference to the Child object.
      *
-     * @returns A pointer to the Child corresponding to @p aAddress, NULL otherwise.
+     * @returns The index for the Child corresponding to @p aChild.
      *
      */
-    int GetChildIndex(const Child &aChild);
+    uint8_t GetChildIndex(const Child &aChild);
 
     /**
      * This method returns a pointer to a Child array.
@@ -430,7 +430,8 @@ private:
     ThreadError ResetAdvertiseInterval(void);
     ThreadError SendAddressSolicit(ThreadStatusTlv::Status aStatus);
     ThreadError SendAddressRelease(void);
-    void SendAddressSolicitResponse(const Coap::Header &aRequest, int aRouterId, const Ip6::MessageInfo &aMessageInfo);
+    void SendAddressSolicitResponse(const Coap::Header &aRequest, uint8_t aRouterId,
+                                    const Ip6::MessageInfo &aMessageInfo);
     void SendAddressReleaseResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo);
     ThreadError SendAdvertisement(void);
     ThreadError SendLinkRequest(Neighbor *aNeighbor);
@@ -463,8 +464,8 @@ private:
     Child *FindChild(uint16_t aChildId);
     Child *FindChild(const Mac::ExtAddress &aMacAddr);
 
-    int AllocateRouterId(void);
-    int AllocateRouterId(uint8_t aRouterId);
+    uint8_t AllocateRouterId(void);
+    uint8_t AllocateRouterId(uint8_t aRouterId);
     bool InRouterIdMask(uint8_t aRouterId);
 
     static void HandleAdvertiseTimer(void *aContext);
@@ -491,8 +492,8 @@ private:
     uint8_t mLeaderWeight;
     bool mRouterRoleEnabled;
 
-    int8_t mRouterId;
-    int8_t mPreviousRouterId;
+    uint8_t mRouterId;
+    uint8_t mPreviousRouterId;
     uint32_t mAdvertiseInterval;
 
     Coap::Server &mCoapServer;

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -122,7 +122,7 @@ public:
      * This method returns the Length value.
      *
      */
-    size_t GetLength(void) const { return mLength; }
+    uint8_t GetLength(void) const { return mLength; }
 
     /**
      * This method sets the Length value.
@@ -515,9 +515,7 @@ public:
      * @returns The Route Data Length value.
      *
      */
-    uint8_t GetRouteDataLength(void) const {
-        return GetLength() - sizeof(mRouterIdSequence) - sizeof(mRouterIdMask);
-    }
+    uint8_t GetRouteDataLength(void) const { return GetLength() - sizeof(mRouterIdSequence) - sizeof(mRouterIdMask); }
 
     /**
      * This method sets the Route Data Length value.
@@ -569,7 +567,8 @@ public:
      */
     void SetLinkQualityIn(uint8_t aRouterId, uint8_t aLinkQuality) {
         mRouteData[aRouterId] =
-            (mRouteData[aRouterId] & ~kLinkQualityInMask) | (aLinkQuality << kLinkQualityInOffset);
+            (mRouteData[aRouterId] & ~kLinkQualityInMask) |
+            ((aLinkQuality << kLinkQualityInOffset) & kLinkQualityInMask);
     }
 
     /**
@@ -591,7 +590,8 @@ public:
      */
     void SetLinkQualityOut(uint8_t aRouterId, uint8_t aLinkQuality) {
         mRouteData[aRouterId] =
-            (mRouteData[aRouterId] & ~kLinkQualityOutMask) | (aLinkQuality << kLinkQualityOutOffset);
+            (mRouteData[aRouterId] & ~kLinkQualityOutMask) |
+            ((aLinkQuality << kLinkQualityOutOffset) & kLinkQualityInMask);
     }
 
 private:
@@ -827,7 +827,7 @@ public:
      * @retval FALSE  If the TLV does not appear to be well-formed.
      *
      */
-    bool IsValid(void) const { return GetLength() <= sizeof(*this) - sizeof(Tlv); }
+    bool IsValid(void) const { return GetLength() < sizeof(*this) - sizeof(Tlv); }
 
     /**
      * This method returns a pointer to the Network Data.
@@ -1006,7 +1006,7 @@ public:
      * @returns The Parent Priority value.
      *
      */
-    int8_t GetParentPriority(void) const { return mParentPriority >> kParentPriorityOffset; }
+    int8_t GetParentPriority(void) const { return (mParentPriority & kParentPriorityOffset) >> kParentPriorityOffset; }
 
     /**
      * This method sets the Parent Priority value.
@@ -1014,7 +1014,9 @@ public:
      * @param[in] aParentPriority  The Parent Priority value.
      *
      */
-    void SetParentPriority(int8_t aParentPriority) { mParentPriority = aParentPriority << kParentPriorityOffset; }
+    void SetParentPriority(int8_t aParentPriority) {
+        mParentPriority = (aParentPriority << kParentPriorityOffset) & kParentPriorityMask;
+    }
 
     /**
      * This method returns the Link Quality 3 value.
@@ -1148,9 +1150,10 @@ private:
     enum
     {
         kParentPriorityOffset = 6,
+        kParentPriorityMask = 3 << kParentPriorityOffset,
     };
 
-    int8_t   mParentPriority;
+    uint8_t  mParentPriority;
     uint8_t  mLinkQuality3;
     uint8_t  mLinkQuality2;
     uint8_t  mLinkQuality1;

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -87,7 +87,7 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength)
                 length = sizeof(NetworkDataTlv) + cur->GetLength();
                 dst = reinterpret_cast<uint8_t *>(cur);
                 src = reinterpret_cast<uint8_t *>(cur->GetNext());
-                memmove(dst, src, aDataLength - (src - aData));
+                memmove(dst, src, aDataLength - static_cast<size_t>(src - aData));
                 aDataLength -= length;
                 continue;
             }
@@ -104,7 +104,7 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength)
                 length = sizeof(NetworkDataTlv) + cur->GetLength();
                 dst = reinterpret_cast<uint8_t *>(cur);
                 src = reinterpret_cast<uint8_t *>(cur->GetNext());
-                memmove(dst, src, aDataLength - (src - aData));
+                memmove(dst, src, aDataLength - static_cast<size_t>(src - aData));
                 aDataLength -= length;
                 continue;
             }
@@ -158,7 +158,7 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, Pref
                 contextId = context->GetContextId();
 
                 // replace p_border_router_16
-                for (int i = 0; i < borderRouter->GetNumEntries(); i++)
+                for (uint8_t i = 0; i < borderRouter->GetNumEntries(); i++)
                 {
                     borderRouterEntry = borderRouter->GetEntry(i);
 
@@ -180,7 +180,7 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, Pref
                 hasRoute = FindHasRoute(aPrefix);
 
                 // replace r_border_router_16
-                for (int j = 0; j < hasRoute->GetNumEntries(); j++)
+                for (uint8_t j = 0; j < hasRoute->GetNumEntries(); j++)
                 {
                     hasRouteEntry = hasRoute->GetEntry(j);
                     hasRouteEntry->SetRloc(0xfffe);
@@ -204,7 +204,7 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, Pref
             length = sizeof(NetworkDataTlv) + cur->GetLength();
             dst = reinterpret_cast<uint8_t *>(cur);
             src = reinterpret_cast<uint8_t *>(cur->GetNext());
-            memmove(dst, src, aDataLength - (src - aData));
+            memmove(dst, src, aDataLength - static_cast<size_t>(src - aData));
             aPrefix.SetSubTlvsLength(aPrefix.GetSubTlvsLength() - length);
             aDataLength -= length;
         }
@@ -345,7 +345,7 @@ PrefixTlv *NetworkData::FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength
 
 int8_t NetworkData::PrefixMatch(const uint8_t *a, const uint8_t *b, uint8_t aLength)
 {
-    uint8_t rval = 0;
+    int8_t rval = 0;
     uint8_t bytes = BitVectorBytes(aLength);
     uint8_t diff;
 
@@ -377,7 +377,7 @@ ThreadError NetworkData::Insert(uint8_t *aStart, uint8_t aLength)
     assert(aLength + mLength <= sizeof(mTlvs) &&
            mTlvs <= aStart &&
            aStart <= mTlvs + mLength);
-    memmove(aStart + aLength, aStart, mLength - (aStart - mTlvs));
+    memmove(aStart + aLength, aStart, mLength - static_cast<size_t>(aStart - mTlvs));
     mLength += aLength;
     return kThreadError_None;
 }
@@ -387,7 +387,7 @@ ThreadError NetworkData::Remove(uint8_t *aStart, uint8_t aLength)
     assert(aLength <= mLength &&
            mTlvs <= aStart &&
            (aStart - mTlvs) + aLength <= mLength);
-    memmove(aStart, aStart + aLength, mLength - ((aStart - mTlvs) + aLength));
+    memmove(aStart, aStart + aLength, mLength - (static_cast<size_t>(aStart - mTlvs) + aLength));
     mLength -= aLength;
     return kThreadError_None;
 }

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -65,8 +65,8 @@ void Leader::Reset(void)
 {
     memset(mAddresses, 0, sizeof(mAddresses));
     memset(mContextLastUsed, 0, sizeof(mContextLastUsed));
-    mVersion = otPlatRandomGet();
-    mStableVersion = otPlatRandomGet();
+    mVersion = static_cast<uint8_t>(otPlatRandomGet());
+    mStableVersion = static_cast<uint8_t>(otPlatRandomGet());
     mLength = 0;
     mContextUsed = 0;
     mContextIdReuseDelay = kContextIdReuseDelay;
@@ -289,7 +289,7 @@ ThreadError Leader::ConfigureAddress(PrefixTlv &aPrefix)
 
         for (size_t j = 8; j < sizeof(mAddresses[i].mAddress); j++)
         {
-            mAddresses[i].mAddress.mFields.m8[j] = otPlatRandomGet();
+            mAddresses[i].mAddress.mFields.m8[j] = static_cast<uint8_t>(otPlatRandomGet());
         }
 
         mAddresses[i].mPrefixLength = aPrefix.GetPrefixLength();
@@ -389,7 +389,7 @@ ThreadError Leader::ExternalRouteLookup(uint8_t aDomainId, const Ip6::Address &a
     HasRouteTlv *hasRoute;
     HasRouteEntry *entry;
     HasRouteEntry *rvalRoute = NULL;
-    int8_t rval_plen = 0;
+    uint8_t rval_plen = 0;
     int8_t plen;
     NetworkDataTlv *cur;
     NetworkDataTlv *subCur;
@@ -426,7 +426,7 @@ ThreadError Leader::ExternalRouteLookup(uint8_t aDomainId, const Ip6::Address &a
 
                 hasRoute = reinterpret_cast<HasRouteTlv *>(subCur);
 
-                for (int i = 0; i < hasRoute->GetNumEntries(); i++)
+                for (uint8_t i = 0; i < hasRoute->GetNumEntries(); i++)
                 {
                     entry = hasRoute->GetEntry(i);
 
@@ -436,7 +436,7 @@ ThreadError Leader::ExternalRouteLookup(uint8_t aDomainId, const Ip6::Address &a
                          mMle.GetRouteCost(entry->GetRloc()) < mMle.GetRouteCost(rvalRoute->GetRloc())))
                     {
                         rvalRoute = entry;
-                        rval_plen = plen;
+                        rval_plen = static_cast<uint8_t>(plen);
                     }
                 }
 
@@ -480,7 +480,7 @@ ThreadError Leader::DefaultRouteLookup(PrefixTlv &aPrefix, uint16_t *aRloc16)
 
         borderRouter = reinterpret_cast<BorderRouterTlv *>(cur);
 
-        for (int i = 0; i < borderRouter->GetNumEntries(); i++)
+        for (uint8_t i = 0; i < borderRouter->GetNumEntries(); i++)
         {
             entry = borderRouter->GetEntry(i);
 
@@ -638,7 +638,7 @@ void Leader::RlocLookup(uint16_t aRloc16, bool &aIn, bool &aStable, uint8_t *aTl
                 case NetworkDataTlv::kTypeBorderRouter:
                     borderRouter = FindBorderRouter(*prefix);
 
-                    for (int i = 0; i < borderRouter->GetNumEntries(); i++)
+                    for (uint8_t i = 0; i < borderRouter->GetNumEntries(); i++)
                     {
                         borderRouterEntry = borderRouter->GetEntry(i);
 
@@ -658,7 +658,7 @@ void Leader::RlocLookup(uint16_t aRloc16, bool &aIn, bool &aStable, uint8_t *aTl
                 case NetworkDataTlv::kTypeHasRoute:
                     hasRoute = FindHasRoute(*prefix);
 
-                    for (int i = 0; i < hasRoute->GetNumEntries(); i++)
+                    for (uint8_t i = 0; i < hasRoute->GetNumEntries(); i++)
                     {
                         hasRouteEntry = hasRoute->GetEntry(i);
 
@@ -918,7 +918,7 @@ ThreadError Leader::AddBorderRouter(PrefixTlv &aPrefix, BorderRouterTlv &aBorder
             dstContext->Init();
             dstContext->SetStable();
             dstContext->SetCompress();
-            dstContext->SetContextId(contextId);
+            dstContext->SetContextId(static_cast<uint8_t>(contextId));
             dstContext->SetContextLength(aPrefix.GetPrefixLength());
         }
         else
@@ -1112,7 +1112,7 @@ ThreadError Leader::RemoveRloc(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute, uint1
     HasRouteEntry *entry;
 
     // remove rloc from has route tlv
-    for (int i = 0; i < aHasRoute.GetNumEntries(); i++)
+    for (uint8_t i = 0; i < aHasRoute.GetNumEntries(); i++)
     {
         entry = aHasRoute.GetEntry(i);
 
@@ -1135,7 +1135,7 @@ ThreadError Leader::RemoveRloc(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRoute
     BorderRouterEntry *entry;
 
     // remove rloc from border router tlv
-    for (int i = 0; i < aBorderRouter.GetNumEntries(); i++)
+    for (uint8_t i = 0; i < aBorderRouter.GetNumEntries(); i++)
     {
         entry = aBorderRouter.GetEntry(i);
 
@@ -1262,7 +1262,7 @@ void Leader::HandleTimer(void)
 {
     bool contextsWaiting = false;
 
-    for (int i = 0; i < kNumContextIds; i++)
+    for (uint8_t i = 0; i < kNumContextIds; i++)
     {
         if (mContextLastUsed[i] == 0)
         {

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -212,7 +212,7 @@ ThreadError Local::Register(const Ip6::Address &aDestination)
 
     for (size_t i = 0; i < sizeof(mCoapToken); i++)
     {
-        mCoapToken[i] = otPlatRandomGet();
+        mCoapToken[i] = static_cast<uint8_t>(otPlatRandomGet());
     }
 
     header.Init();

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -95,7 +95,9 @@ public:
      * @param[in]  aType  The Type value.
      *
      */
-    void SetType(Type aType) { mType = (mType & ~kTypeMask) | (static_cast<uint8_t>(aType) << kTypeOffset); }
+    void SetType(Type aType) {
+        mType = (mType & ~kTypeMask) | ((aType << kTypeOffset) & kTypeMask);
+    }
 
     /**
      * This method returns the Length value.
@@ -206,7 +208,9 @@ public:
      * @param[in]  aPrf  The Preference value.
      *
      */
-    void SetPreference(int8_t aPrf) { mFlags = (mFlags & ~kPreferenceMask) | (aPrf << kPreferenceOffset); }
+    void SetPreference(int8_t aPrf) {
+        mFlags = (mFlags & ~kPreferenceMask) | ((aPrf << kPreferenceOffset) & kPreferenceMask);
+    }
 
 private:
     enum
@@ -249,7 +253,7 @@ public:
      * @returns A pointer to the i'th HasRoute entry.
      *
      */
-    HasRouteEntry *GetEntry(int i) {
+    HasRouteEntry *GetEntry(uint8_t i) {
         return reinterpret_cast<HasRouteEntry *>(GetValue() + (i * sizeof(HasRouteEntry)));
     }
 } OT_TOOL_PACKED_END;
@@ -327,7 +331,7 @@ public:
      * @param[in]  aLength  The Sub-TLVs length in bytes.
      *
      */
-    void SetSubTlvsLength(int aLength) {
+    void SetSubTlvsLength(uint8_t aLength) {
         SetLength(sizeof(*this) - sizeof(NetworkDataTlv) + BitVectorBytes(mPrefixLength) + aLength);
     }
 
@@ -407,7 +411,9 @@ public:
      * @param[in]  aPrf  The Preference value.
      *
      */
-    void SetPreference(int8_t aPrf) { mFlags = (mFlags & ~kPreferenceMask) | (aPrf << kPreferenceOffset); }
+    void SetPreference(int8_t aPrf) {
+        mFlags = (mFlags & ~kPreferenceMask) | ((aPrf << kPreferenceOffset) & kPreferenceMask);
+    }
 
     /**
      * This method indicates whether or not the Preferred flag is set.
@@ -571,7 +577,7 @@ public:
      * @returns A pointer to the i'th Border Router entry.
      *
      */
-    BorderRouterEntry *GetEntry(int i) {
+    BorderRouterEntry *GetEntry(uint8_t i) {
         return reinterpret_cast<BorderRouterEntry *>(GetValue() + (i * sizeof(BorderRouterEntry)));
     }
 } OT_TOOL_PACKED_END;
@@ -625,7 +631,9 @@ public:
      * @param[in]  aContextId  The Context ID value.
      *
      */
-    void SetContextId(uint8_t aContextId) { mFlags = (mFlags & ~kContextIdMask) | (aContextId << kContextIdOffset); }
+    void SetContextId(uint8_t aContextId) {
+        mFlags = (mFlags & ~kContextIdMask) | ((aContextId << kContextIdOffset) & kContextIdMask);
+    }
 
     /**
      * This method returns the Context Length value.

--- a/src/ncp/flen.cpp
+++ b/src/ncp/flen.cpp
@@ -132,7 +132,7 @@ void Decoder::Decode(const uint8_t *aInBuf, uint16_t aInLength)
             break;
 
         case kStateNeedLenH:
-            mReadLength = (byte << 8);
+            mReadLength = static_cast<uint16_t>(byte << 8);
             mState = kStateNeedLenL;
             break;
 

--- a/src/ncp/hdlc.cpp
+++ b/src/ncp/hdlc.cpp
@@ -187,7 +187,7 @@ ThreadError Encoder::Finalize(BufferWriteIterator &aIterator)
 
     fcs ^= 0xffff;
 
-    SuccessOrExit(error = Encode(fcs, aIterator));
+    SuccessOrExit(error = Encode(fcs & 0xff, aIterator));
     SuccessOrExit(error = Encode(fcs >> 8, aIterator));
 
     SuccessOrExit(error = aIterator.WriteByte(kFlagSequence));

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -47,7 +47,7 @@ extern ThreadNetif *sThreadNetif;
 
 static NcpBase *sNcpContext = NULL;
 
-#define NCP_PLAT_RESET_REASON        (1<<31)
+#define NCP_PLAT_RESET_REASON        (1U<<31)
 
 // ----------------------------------------------------------------------------
 // MARK: Command/Property Jump Tables
@@ -389,7 +389,7 @@ void NcpBase::HandleActiveScanResult(otActiveScanResult *result)
 {
     if (result)
     {
-        uint8_t flags = (result->mVersion << SPINEL_BEACON_THREAD_FLAG_VERSION_SHIFT);
+        uint8_t flags = static_cast<uint8_t>(result->mVersion << SPINEL_BEACON_THREAD_FLAG_VERSION_SHIFT);
 
         if (result->mIsJoinable)
         {
@@ -458,7 +458,7 @@ void NcpBase::UpdateChangedProps(void)
     {
         if ((mChangedFlags & NCP_PLAT_RESET_REASON) != 0)
         {
-            mChangedFlags &= ~NCP_PLAT_RESET_REASON;
+            mChangedFlags &= ~static_cast<uint32_t>(NCP_PLAT_RESET_REASON);
             SendLastStatus(
                 SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
                 ResetReasonToSpinelStatus(otPlatGetResetReason())
@@ -466,7 +466,7 @@ void NcpBase::UpdateChangedProps(void)
         }
         else if ((mChangedFlags & OT_IP6_LL_ADDR_CHANGED) != 0)
         {
-            mChangedFlags &= ~OT_IP6_LL_ADDR_CHANGED;
+            mChangedFlags &= ~static_cast<uint32_t>(OT_IP6_LL_ADDR_CHANGED);
             HandleCommandPropertyGet(
                 SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
                 SPINEL_PROP_IPV6_LL_ADDR
@@ -478,7 +478,7 @@ void NcpBase::UpdateChangedProps(void)
                               SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
                               SPINEL_PROP_IPV6_ML_ADDR
                           ));
-            mChangedFlags &= ~OT_IP6_ML_ADDR_CHANGED;
+            mChangedFlags &= ~static_cast<uint32_t>(OT_IP6_ML_ADDR_CHANGED);
         }
         else if ((mChangedFlags & OT_NET_STATE) != 0)
         {
@@ -486,7 +486,7 @@ void NcpBase::UpdateChangedProps(void)
                               SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
                               SPINEL_PROP_NET_STATE
                           ));
-            mChangedFlags &= ~OT_NET_STATE;
+            mChangedFlags &= ~static_cast<uint32_t>(OT_NET_STATE);
         }
         else if ((mChangedFlags & OT_NET_ROLE) != 0)
         {
@@ -494,7 +494,7 @@ void NcpBase::UpdateChangedProps(void)
                               SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
                               SPINEL_PROP_NET_ROLE
                           ));
-            mChangedFlags &= ~OT_NET_ROLE;
+            mChangedFlags &= ~static_cast<uint32_t>(OT_NET_ROLE);
 
         }
         else if ((mChangedFlags & OT_NET_PARTITION_ID) != 0)
@@ -503,7 +503,7 @@ void NcpBase::UpdateChangedProps(void)
                               SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
                               SPINEL_PROP_NET_PARTITION_ID
                           ));
-            mChangedFlags &= ~OT_NET_PARTITION_ID;
+            mChangedFlags &= ~static_cast<uint32_t>(OT_NET_PARTITION_ID);
         }
         else if ((mChangedFlags & OT_NET_KEY_SEQUENCE) != 0)
         {
@@ -511,7 +511,7 @@ void NcpBase::UpdateChangedProps(void)
                               SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
                               SPINEL_PROP_NET_KEY_SEQUENCE
                           ));
-            mChangedFlags &= ~OT_NET_KEY_SEQUENCE;
+            mChangedFlags &= ~static_cast<uint32_t>(OT_NET_KEY_SEQUENCE);
         }
         else if ((mChangedFlags & (OT_IP6_ADDRESS_ADDED | OT_IP6_ADDRESS_REMOVED)) != 0)
         {
@@ -519,7 +519,7 @@ void NcpBase::UpdateChangedProps(void)
                               SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
                               SPINEL_PROP_IPV6_ADDRESS_TABLE
                           ));
-            mChangedFlags &= ~(OT_IP6_ADDRESS_ADDED | OT_IP6_ADDRESS_REMOVED);
+            mChangedFlags &= ~static_cast<uint32_t>(OT_IP6_ADDRESS_ADDED | OT_IP6_ADDRESS_REMOVED);
         }
         else if ((mChangedFlags & (OT_THREAD_CHILD_ADDED | OT_THREAD_CHILD_REMOVED)) != 0)
         {
@@ -528,7 +528,7 @@ void NcpBase::UpdateChangedProps(void)
             //    SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
             //    SPINEL_PROP_THREAD_CHILD_TABLE
             //));
-            mChangedFlags &= ~(OT_THREAD_CHILD_ADDED | OT_THREAD_CHILD_REMOVED);
+            mChangedFlags &= ~static_cast<uint32_t>(OT_THREAD_CHILD_ADDED | OT_THREAD_CHILD_REMOVED);
         }
     }
 
@@ -853,7 +853,7 @@ ThreadError NcpBase::OutboundFrameFeedVPacked(const char *pack_format, va_list a
 
     if ((packed_len > 0) && (packed_len <= static_cast<spinel_ssize_t>(sizeof(buf))))
     {
-        errorCode = OutboundFrameFeedData(buf, packed_len);
+        errorCode = OutboundFrameFeedData(buf, static_cast<uint16_t>(packed_len));
     }
 
     return errorCode;
@@ -944,7 +944,8 @@ ThreadError NcpBase::CommandHandler_PROP_VALUE_SET(uint8_t header, unsigned int 
 
     if (parsedLength == arg_len)
     {
-        errorCode = HandleCommandPropertySet(header, static_cast<spinel_prop_key_t>(propKey), value_ptr, value_len);
+        errorCode = HandleCommandPropertySet(header, static_cast<spinel_prop_key_t>(propKey), value_ptr,
+					     static_cast<uint16_t>(value_len));
     }
     else
     {
@@ -969,7 +970,8 @@ ThreadError NcpBase::CommandHandler_PROP_VALUE_INSERT(uint8_t header, unsigned i
 
     if (parsedLength == arg_len)
     {
-        errorCode = HandleCommandPropertyInsert(header, static_cast<spinel_prop_key_t>(propKey), value_ptr, value_len);
+        errorCode = HandleCommandPropertyInsert(header, static_cast<spinel_prop_key_t>(propKey), value_ptr,
+						static_cast<uint16_t>(value_len));
     }
     else
     {
@@ -994,7 +996,8 @@ ThreadError NcpBase::CommandHandler_PROP_VALUE_REMOVE(uint8_t header, unsigned i
 
     if (parsedLength == arg_len)
     {
-        errorCode = HandleCommandPropertyRemove(header, static_cast<spinel_prop_key_t>(propKey), value_ptr, value_len);
+        errorCode = HandleCommandPropertyRemove(header, static_cast<spinel_prop_key_t>(propKey), value_ptr,
+						static_cast<uint16_t>(value_len));
     }
     else
     {
@@ -2555,7 +2558,7 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_NET_INSECURE(uint8_t header, spin
         (void)meta_len;
         (void)parsedLength;
 
-        errorCode = message->Append(frame_ptr, frame_len);
+        errorCode = message->Append(frame_ptr, static_cast<uint16_t>(frame_len));
     }
 
     if (errorCode == kThreadError_None)
@@ -2623,7 +2626,7 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_k
         (void)meta_len;
         (void)parsedLength;
 
-        errorCode = message->Append(frame_ptr, frame_len);
+        errorCode = message->Append(frame_ptr, static_cast<uint16_t>(frame_len));
     }
 
     if (errorCode == kThreadError_None)
@@ -3342,6 +3345,6 @@ ThreadError otNcpStreamWrite(int aStreamId, const uint8_t* aDataPtr, int aDataLe
         SPINEL_CMD_PROP_VALUE_IS,
         static_cast<spinel_prop_key_t>(aStreamId),
         aDataPtr,
-        aDataLen
+        static_cast<uint16_t>(aDataLen)
     );
 }

--- a/src/ncp/ncp_buffer.cpp
+++ b/src/ncp/ncp_buffer.cpp
@@ -131,12 +131,12 @@ uint16_t NcpFrameBuffer::GetDistance(uint8_t *aStartPtr, uint8_t *aEndPtr) const
 
     if (aEndPtr >= aStartPtr)
     {
-        distance =  aEndPtr - aStartPtr;
+        distance = static_cast<size_t>(aEndPtr - aStartPtr);
     }
     else
     {
-        distance  = mBufferEnd - aStartPtr;
-        distance +=  aEndPtr - mBuffer;
+        distance  = static_cast<size_t>(mBufferEnd - aStartPtr);
+        distance += static_cast<size_t>(aEndPtr - mBuffer);
     }
 
     return static_cast<uint16_t>(distance);
@@ -154,7 +154,7 @@ uint16_t NcpFrameBuffer::ReadUint16At(uint8_t *aBufPtr)
 {
     uint16_t value;
 
-    value = (*aBufPtr) << 8;
+    value = static_cast<uint16_t>((*aBufPtr) << 8);
     value += *Next(aBufPtr);
 
     return value;
@@ -355,7 +355,8 @@ ThreadError NcpFrameBuffer::OutFramePrepareSegment(void)
         }
 
         // Find tail/end of current segment.
-        mReadSegmentTail = Advance(mReadSegmentHead, kSegmentHeaderSize + (header & kSegmentHeaderLengthMask));
+        mReadSegmentTail = Advance(mReadSegmentHead,
+				   kSegmentHeaderSize + static_cast<uint8_t>(header & kSegmentHeaderLengthMask));
 
         // Update the current read pointer to skip the segment header.
         mReadPointer = Advance(mReadSegmentHead, kSegmentHeaderSize);
@@ -576,7 +577,7 @@ ThreadError NcpFrameBuffer::OutFrameRemove(void)
         }
 
         // Move the pointer to next segment.
-        bufPtr = Advance(bufPtr, kSegmentHeaderSize + (header & kSegmentHeaderLengthMask));
+        bufPtr = Advance(bufPtr, kSegmentHeaderSize + static_cast<uint8_t>(header & kSegmentHeaderLengthMask));
     }
 
     mReadFrameStart = bufPtr;
@@ -644,7 +645,7 @@ uint16_t NcpFrameBuffer::OutFrameGetLength(void)
         frameLength += (header & kSegmentHeaderLengthMask);
 
         // Move the pointer to next segment.
-        bufPtr = Advance(bufPtr, kSegmentHeaderSize + (header & kSegmentHeaderLengthMask));
+        bufPtr = Advance(bufPtr, kSegmentHeaderSize + static_cast<uint8_t>(header & kSegmentHeaderLengthMask));
     }
 
     // Remember the calculated frame length for current frame.

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -141,7 +141,7 @@ spinel_packed_uint_decode(const uint8_t *bytes, spinel_size_t len, unsigned int 
             break;
         }
 
-        value |= ((bytes[0] & 0x7F) << i);
+        value |= (unsigned int)((bytes[0] & 0x7F) << i);
         i += 7;
         ret += sizeof(uint8_t);
         bytes += sizeof(uint8_t);
@@ -160,7 +160,7 @@ spinel_packed_uint_decode(const uint8_t *bytes, spinel_size_t len, unsigned int 
 spinel_ssize_t
 spinel_packed_uint_size(unsigned int value)
 {
-    spinel_size_t ret;
+    spinel_ssize_t ret;
 
     if (value < (1 << 7))
     {
@@ -292,7 +292,7 @@ spinel_datatype_vunpack_(const uint8_t *data_ptr, spinel_size_t data_len, const 
 
             if (arg_ptr)
             {
-                *arg_ptr = ((data_ptr[1] << 8) | data_ptr[0]);
+                *arg_ptr = (uint16_t)((data_ptr[1] << 8) | data_ptr[0]);
             }
 
             ret += sizeof(uint16_t);
@@ -309,7 +309,7 @@ spinel_datatype_vunpack_(const uint8_t *data_ptr, spinel_size_t data_len, const 
 
             if (arg_ptr)
             {
-                *arg_ptr = ((data_ptr[3] << 24) | (data_ptr[2] << 16) | (data_ptr[1] << 8) | data_ptr[0]);
+                *arg_ptr = (uint32_t)((data_ptr[3] << 24) | (data_ptr[2] << 16) | (data_ptr[1] << 8) | data_ptr[0]);
             }
 
             ret += sizeof(uint32_t);
@@ -377,7 +377,7 @@ spinel_datatype_vunpack_(const uint8_t *data_ptr, spinel_size_t data_len, const 
 
             ret += pui_len;
             data_ptr += pui_len;
-            data_len -= pui_len;
+            data_len -= (spinel_size_t)pui_len;
             break;
         }
 
@@ -419,7 +419,7 @@ spinel_datatype_vunpack_(const uint8_t *data_ptr, spinel_size_t data_len, const 
             }
             else
             {
-                block_len = data_len;
+                block_len = (uint16_t)data_len;
                 pui_len = 0;
             }
 
@@ -446,7 +446,7 @@ spinel_datatype_vunpack_(const uint8_t *data_ptr, spinel_size_t data_len, const 
         {
             spinel_ssize_t pui_len = 0;
             uint16_t block_len = 0;
-            unsigned int actual_len = 0;
+            spinel_ssize_t actual_len = 0;
             const uint8_t *block_ptr = data_ptr;
             char nextformat = *spinel_next_packed_datatype(pack_format);
 
@@ -460,7 +460,7 @@ spinel_datatype_vunpack_(const uint8_t *data_ptr, spinel_size_t data_len, const 
             }
             else
             {
-                block_len = data_len;
+                block_len = (uint16_t)data_len;
                 pui_len = 0;
             }
 
@@ -468,7 +468,7 @@ spinel_datatype_vunpack_(const uint8_t *data_ptr, spinel_size_t data_len, const 
 
             actual_len = spinel_datatype_vunpack_(block_ptr, block_len, pack_format + 2, args);
 
-            require_action((int)actual_len > -1, bail, (ret = -1, errno = EOVERFLOW));
+            require_action(actual_len > -1, bail, (ret = -1, errno = EOVERFLOW));
 
             if (pui_len)
             {
@@ -476,7 +476,7 @@ spinel_datatype_vunpack_(const uint8_t *data_ptr, spinel_size_t data_len, const 
             }
             else
             {
-                block_len = actual_len;
+                block_len = (uint16_t)actual_len;
             }
 
             ret += block_len;
@@ -592,8 +592,8 @@ spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char
 
             if (data_len_max >= sizeof(uint16_t))
             {
-                data_ptr[1] = (arg >> 8);
-                data_ptr[0] = (arg >> 0);
+                data_ptr[1] = (arg >> 8) & 0xff;
+                data_ptr[0] = (arg >> 0) & 0xff;
                 data_ptr += sizeof(uint16_t);
                 data_len_max -= sizeof(uint16_t);
             }
@@ -613,10 +613,10 @@ spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char
 
             if (data_len_max >= sizeof(uint32_t))
             {
-                data_ptr[3] = (arg >> 24);
-                data_ptr[2] = (arg >> 16);
-                data_ptr[1] = (arg >> 8);
-                data_ptr[0] = (arg >> 0);
+                data_ptr[3] = (arg >> 24) & 0xff;
+                data_ptr[2] = (arg >> 16) & 0xff;
+                data_ptr[1] = (arg >> 8) & 0xff;
+                data_ptr[0] = (arg >> 0) & 0xff;
                 data_ptr += sizeof(uint32_t);
                 data_len_max -= sizeof(uint32_t);
             }
@@ -694,7 +694,7 @@ spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char
             if ((spinel_ssize_t)data_len_max >= encoded_size)
             {
                 data_ptr += encoded_size;
-                data_len_max -= encoded_size;
+                data_len_max -= (spinel_size_t)encoded_size;
             }
             else
             {
@@ -749,12 +749,12 @@ spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char
                 require_action(size_len > 0, bail, {ret = -1; errno = EINVAL;});
             }
 
-            ret += size_len + data_size_arg;
+            ret += (spinel_size_t)size_len + data_size_arg;
 
-            if (data_len_max >= size_len + data_size_arg)
+            if (data_len_max >= (spinel_size_t)size_len + data_size_arg)
             {
                 data_ptr += size_len;
-                data_len_max -= size_len;
+                data_len_max -= (spinel_size_t)size_len;
 
                 memcpy(data_ptr, arg, data_size_arg);
 
@@ -796,12 +796,12 @@ spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char
             if (struct_len + size_len <= (spinel_ssize_t)data_len_max)
             {
                 data_ptr += size_len;
-                data_len_max -= size_len;
+                data_len_max -= (spinel_size_t)size_len;
 
                 struct_len = spinel_datatype_vpack_(data_ptr, data_len_max, pack_format + 2, args);
 
                 data_ptr += struct_len;
-                data_len_max -= struct_len;
+                data_len_max -= (spinel_size_t)struct_len;
             }
             else
             {

--- a/third_party/mbedtls/Makefile.am
+++ b/third_party/mbedtls/Makefile.am
@@ -23,6 +23,10 @@ EXTRA_DIST                                    = \
 
 lib_LIBRARIES                                 = libmbedcrypto.a
 
+# Do not enable -Wconversion for mbedtls
+CPPFLAGS                                     := $(filter-out -Wconversion,$(CPPFLAGS))
+CFLAGS                                       := $(filter-out -Wconversion,$(CFLAGS))
+
 MBEDTLS_SRCDIR                                = $(top_srcdir)/third_party/mbedtls/repo
 
 libmbedcrypto_a_CPPFLAGS                      = \

--- a/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
+++ b/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
@@ -318,12 +318,12 @@ static uint8_t spi_header_get_flag_byte(const uint8_t *header)
 
 static uint16_t spi_header_get_accept_len(const uint8_t *header)
 {
-    return ( header[1] + (header[2] << 8) );
+    return ( header[1] + (uint16_t)(header[2] << 8) );
 }
 
 static uint16_t spi_header_get_data_len(const uint8_t *header)
 {
-    return ( header[3] + (header[4] << 8) );
+    return ( header[3] + (uint16_t)(header[4] << 8) );
 }
 
 static uint8_t* get_real_rx_frame_start(void)
@@ -355,17 +355,17 @@ static int do_spi_xfer(int len)
             .tx_buf = 0,
             .rx_buf = 0,
             .len = 0,
-            .delay_usecs = sSpiCsDelay,
-            .speed_hz = sSpiSpeed,
+            .delay_usecs = (uint16_t)sSpiCsDelay,
+            .speed_hz = (uint32_t)sSpiSpeed,
             .bits_per_word = 8,
             .cs_change = false,
         },
         {   // This part is the actual SPI transfer.
             .tx_buf = (unsigned long)sSpiTxFrameBuffer,
             .rx_buf = (unsigned long)sSpiRxFrameBuffer,
-            .len = len + HEADER_LEN + sSpiRxAlignAllowance,
+            .len = (uint32_t)(len + HEADER_LEN + sSpiRxAlignAllowance),
             .delay_usecs = 0,
-            .speed_hz = sSpiSpeed,
+            .speed_hz = (uint32_t)sSpiSpeed,
             .bits_per_word = 8,
             .cs_change = false,
         }
@@ -386,8 +386,8 @@ static int do_spi_xfer(int len)
 
     if (ret != -1)
     {
-        log_debug_buffer("SPI-TX", sSpiTxFrameBuffer, xfer[1].len);
-        log_debug_buffer("SPI-RX", sSpiRxFrameBuffer, xfer[1].len);
+        log_debug_buffer("SPI-TX", sSpiTxFrameBuffer, (int)xfer[1].len);
+        log_debug_buffer("SPI-RX", sSpiRxFrameBuffer, (int)xfer[1].len);
 
         if (spi_header_get_flag_byte(sSpiRxFrameBuffer) != 0xFF)
         {
@@ -522,7 +522,7 @@ static int push_pull_spi(void)
         }
     }
 
-    usleep(sSpiTransactionDelay);
+    usleep((unsigned int)sSpiTransactionDelay);
 
     spi_header_set_flag_byte(sSpiTxFrameBuffer, SPI_HEADER_PATTERN_VALUE);
 
@@ -591,7 +591,7 @@ bail:
 static bool check_and_clear_interrupt(void)
 {
     char value[5] = "";
-    int len;
+    ssize_t len;
 
     lseek(sIntGpioValueFd, 0, SEEK_SET);
 
@@ -763,7 +763,7 @@ static int push_hdlc(void)
         }
     }
 
-    ret = write(
+    ret = (int)write(
         sHdlcOutputFd,
         escaped_frame_buffer + escaped_frame_sent,
         escaped_frame_len    - escaped_frame_sent
@@ -806,7 +806,7 @@ static int pull_hdlc(void)
     if (!sSpiTxIsReady)
     {
         uint8_t byte;
-        while ((ret = read(sHdlcInputFd, &byte, 1)) == 1)
+        while ((ret = (int)read(sHdlcInputFd, &byte, 1)) == 1)
         {
             if (sSpiTxPayloadSize >= (MAX_FRAME_SIZE - HEADER_LEN))
             {
@@ -1069,7 +1069,7 @@ static bool setup_int_gpio(const char* path)
     char* edge_path = NULL;
     char* dir_path = NULL;
     char* value_path = NULL;
-    int len;
+    ssize_t len;
     int setup_fd = -1;
 
     sIntGpioValueFd = -1;


### PR DESCRIPTION
These conversion issues were raised by @nibanks as part of #344.  This PR separates those changes out and enables -Wconversion on clang.