### PR TITLE
Mpl Static Global was uninitialzed.

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -35,6 +35,7 @@
 #include <common/debug.hpp>
 #include <common/logging.hpp>
 #include <common/message.hpp>
+#include <common/new.hpp>
 #include <net/icmp6.hpp>
 #include <net/ip6.hpp>
 #include <net/ip6_address.hpp>
@@ -46,7 +47,9 @@
 namespace Thread {
 namespace Ip6 {
 
-static Mpl sMpl;
+static otDEFINE_ALIGNED_VAR(sMplBuf, sizeof(Mpl), uint64_t);
+static Mpl *sMpl;
+
 static otReceiveIp6DatagramCallback sReceiveIp6DatagramCallback = NULL;
 
 static ThreadError ForwardMessage(Message &message, MessageInfo &messageInfo);
@@ -55,6 +58,11 @@ Message *Ip6::NewMessage(uint16_t reserved)
 {
     return Message::New(Message::kTypeIp6,
                         sizeof(Header) + sizeof(HopByHopHeader) + sizeof(OptionMpl) + reserved);
+}
+
+void Ip6::Init(void)
+{
+    sMpl = new(&sMplBuf) Mpl;
 }
 
 uint16_t Ip6::UpdateChecksum(uint16_t checksum, uint16_t val)
@@ -105,7 +113,7 @@ ThreadError AddMplOption(Message &message, Header &header, IpProto nextHeader, u
 
     hbhHeader.SetNextHeader(nextHeader);
     hbhHeader.SetLength(0);
-    sMpl.InitOption(mplOption, HostSwap16(header.GetSource().mFields.m16[7]));
+    sMpl->InitOption(mplOption, HostSwap16(header.GetSource().mFields.m16[7]));
     SuccessOrExit(error = message.Prepend(&mplOption, sizeof(mplOption)));
     SuccessOrExit(error = message.Prepend(&hbhHeader, sizeof(hbhHeader)));
     header.SetPayloadLength(sizeof(hbhHeader) + sizeof(mplOption) + payloadLength);
@@ -198,7 +206,7 @@ ThreadError HandleOptions(Message &message)
         switch (optionHeader.GetType())
         {
         case OptionMpl::kType:
-            SuccessOrExit(error = sMpl.ProcessOption(message));
+            SuccessOrExit(error = sMpl->ProcessOption(message));
             break;
 
         default:

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -491,6 +491,11 @@ public:
     static Message *NewMessage(uint16_t aReserved);
 
     /**
+     * This static method for initialization.
+     */
+    static void Init(void);
+
+    /**
      * This static method sends an IPv6 datagram.
      *
      * @param[in]  aMessage      A reference to the message.

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -40,6 +40,7 @@
 #include <common/tasklet.hpp>
 #include <common/timer.hpp>
 #include <net/icmp6.hpp>
+#include <net/ip6.hpp>
 #include <platform/random.h>
 #include <thread/thread_netif.hpp>
 
@@ -687,6 +688,7 @@ ThreadError otEnable(void)
     otLogInfoApi("otEnable\n");
     Message::Init();
     sThreadNetif = new(&sThreadNetifRaw) ThreadNetif;
+    Ip6::Ip6::Init();
     mEnabled = true;
 
 exit:


### PR DESCRIPTION
This resulted in a crash when pinging the mesh local address.