### PR TITLE
ncp: Add support for additional Spinel properties

### DIFF
--- a/src/ncp/PROTOCOL.md
+++ b/src/ncp/PROTOCOL.md
@@ -1,7 +1,7 @@
 Spinel Host Controller Interface
 ================================
 
-Updated: 2016-08-05
+Updated: 2016-08-10
 
 Written by: Robert Quattlebaum <rquattle@nestlabs.com>
 
@@ -1418,8 +1418,20 @@ Possible Values:
 
 #### D.2.10. PROP 4864: `PROP_MAC_WHITELIST`
 * Type: Read-Write
-* Packed-Encoding: `A(T(E))`
+* Packed-Encoding: `A(T(Ec))`
 
+Structure Parameters:
+
+* `E`: EUI64 address of node
+* `c`: Optional RSSI-override value. The value 127 indicates
+       that the RSSI-override feature is not enabled for this
+       address. If this value is ommitted when setting or
+       inserting, it is assumed to be 127. This parameter is
+       ignored when removing.
+
+#### D.2.11. PROP 4865: `PROP_MAC_WHITELIST_ENABLED`
+* Type: Read-Write
+* Packed-Encoding: `b`
 
 ### D.3. NET Properties
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -41,13 +41,24 @@
 #include <platform/radio.h>
 #include <platform/misc.h>
 
-namespace Thread {
+namespace Thread
+{
 
 extern ThreadNetif *sThreadNetif;
 
 static NcpBase *sNcpContext = NULL;
 
 #define NCP_PLAT_RESET_REASON        (1<<31)
+
+enum
+{
+    kThreadModeTLV_Receiver    = (1 << 3),
+    kThreadModeTLV_Secure      = (1 << 2),
+    kThreadModeTLV_DeviceType  = (1 << 1),
+    kThreadModeTLV_NetworkData = (1 << 0),
+};
+
+#define RSSI_OVERRIDE_DISABLED        127 // Used for PROP_MAC_WHITELIST
 
 // ----------------------------------------------------------------------------
 // MARK: Command/Property Jump Tables
@@ -110,6 +121,14 @@ const NcpBase::GetPropertyHandlerEntry NcpBase::mGetPropertyHandlerTable[] =
     { SPINEL_PROP_THREAD_LOCAL_ROUTES, &NcpBase::NcpBase::GetPropertyHandler_THREAD_LOCAL_ROUTES },
     { SPINEL_PROP_THREAD_ASSISTING_PORTS, &NcpBase::NcpBase::GetPropertyHandler_THREAD_ASSISTING_PORTS },
     { SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE, &NcpBase::GetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE},
+
+    { SPINEL_PROP_MAC_WHITELIST, &NcpBase::GetPropertyHandler_MAC_WHITELIST },
+    { SPINEL_PROP_MAC_WHITELIST_ENABLED, &NcpBase::GetPropertyHandler_MAC_WHITELIST_ENABLED },
+    { SPINEL_PROP_THREAD_MODE, &NcpBase::GetPropertyHandler_THREAD_MODE },
+    { SPINEL_PROP_THREAD_CHILD_TIMEOUT, &NcpBase::GetPropertyHandler_THREAD_CHILD_TIMEOUT },
+    { SPINEL_PROP_THREAD_RLOC16, &NcpBase::GetPropertyHandler_THREAD_RLOC16 },
+    { SPINEL_PROP_THREAD_ROUTER_UPGRADE_THRESHOLD, &NcpBase::GetPropertyHandler_THREAD_ROUTER_UPGRADE_THRESHOLD },
+    { SPINEL_PROP_THREAD_CONTEXT_REUSE_DELAY, &NcpBase::GetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY },
 
     { SPINEL_PROP_IPV6_ML_PREFIX, &NcpBase::GetPropertyHandler_IPV6_ML_PREFIX },
     { SPINEL_PROP_IPV6_ML_ADDR, &NcpBase::GetPropertyHandler_IPV6_ML_ADDR },
@@ -176,6 +195,14 @@ const NcpBase::SetPropertyHandlerEntry NcpBase::mSetPropertyHandlerTable[] =
     { SPINEL_PROP_STREAM_NET, &NcpBase::SetPropertyHandler_STREAM_NET },
 
     { SPINEL_PROP_IPV6_ML_PREFIX, &NcpBase::SetPropertyHandler_IPV6_ML_PREFIX },
+
+    { SPINEL_PROP_MAC_WHITELIST, &NcpBase::SetPropertyHandler_MAC_WHITELIST },
+    { SPINEL_PROP_MAC_WHITELIST_ENABLED, &NcpBase::SetPropertyHandler_MAC_WHITELIST_ENABLED },
+    { SPINEL_PROP_THREAD_MODE, &NcpBase::SetPropertyHandler_THREAD_MODE },
+    { SPINEL_PROP_THREAD_CHILD_TIMEOUT, &NcpBase::SetPropertyHandler_THREAD_CHILD_TIMEOUT },
+    { SPINEL_PROP_THREAD_ROUTER_UPGRADE_THRESHOLD, &NcpBase::SetPropertyHandler_THREAD_ROUTER_UPGRADE_THRESHOLD },
+    { SPINEL_PROP_THREAD_CONTEXT_REUSE_DELAY, &NcpBase::SetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY },
+
 };
 
 const NcpBase::InsertPropertyHandlerEntry NcpBase::mInsertPropertyHandlerTable[] =
@@ -186,6 +213,8 @@ const NcpBase::InsertPropertyHandlerEntry NcpBase::mInsertPropertyHandlerTable[]
     { SPINEL_PROP_THREAD_ASSISTING_PORTS, &NcpBase::NcpBase::InsertPropertyHandler_THREAD_ASSISTING_PORTS },
 
     { SPINEL_PROP_CNTR_RESET, &NcpBase::SetPropertyHandler_CNTR_RESET },
+
+    { SPINEL_PROP_MAC_WHITELIST, &NcpBase::InsertPropertyHandler_MAC_WHITELIST },
 };
 
 const NcpBase::RemovePropertyHandlerEntry NcpBase::mRemovePropertyHandlerTable[] =
@@ -194,6 +223,7 @@ const NcpBase::RemovePropertyHandlerEntry NcpBase::mRemovePropertyHandlerTable[]
     { SPINEL_PROP_THREAD_LOCAL_ROUTES, &NcpBase::NcpBase::RemovePropertyHandler_THREAD_LOCAL_ROUTES },
     { SPINEL_PROP_THREAD_ON_MESH_NETS, &NcpBase::NcpBase::RemovePropertyHandler_THREAD_ON_MESH_NETS },
     { SPINEL_PROP_THREAD_ASSISTING_PORTS, &NcpBase::NcpBase::RemovePropertyHandler_THREAD_ASSISTING_PORTS },
+    { SPINEL_PROP_MAC_WHITELIST, &NcpBase::RemovePropertyHandler_MAC_WHITELIST },
 };
 
 // ----------------------------------------------------------------------------
@@ -250,8 +280,18 @@ static spinel_status_t ThreadErrorToSpinelStatus(ThreadError error)
         ret = SPINEL_STATUS_CCA_FAILURE;
         break;
 
+    case kThreadError_Already:
+        ret = SPINEL_STATUS_ALREADY;
+        break;
+
+    case kThreadError_NotFound:
+        ret = SPINEL_STATUS_ITEM_NOT_FOUND;
+        break;
+
+
     default:
-        ret = SPINEL_STATUS_FAILURE;
+        // Unknown error code. Wrap it as a Spinel status and return that.
+        ret = static_cast<spinel_status_t>(SPINEL_STATUS_STACK_NATIVE__BEGIN + error);
         break;
     }
 
@@ -1065,6 +1105,8 @@ ThreadError NcpBase::GetPropertyHandler_CAPS(uint8_t header, spinel_prop_key_t k
 
     SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_UINT_PACKED_S, SPINEL_CAP_COUNTERS));
 
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_UINT_PACKED_S, SPINEL_CAP_MAC_WHITELIST));
+
     // TODO: Somehow get the following capability from the radio.
     SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_UINT_PACKED_S,
                                                       SPINEL_CAP_802_15_4_2450MHZ_OQPSK));
@@ -1857,6 +1899,123 @@ ThreadError NcpBase::GetPropertyHandler_CNTR(uint8_t header, spinel_prop_key_t k
 bail:
     return errorCode;
 }
+
+ThreadError NcpBase::GetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key)
+{
+    otMacWhitelistEntry entry;
+    ThreadError errorCode = kThreadError_None;
+
+    SuccessOrExit(errorCode = OutboundFrameBegin());
+
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, SPINEL_CMD_PROP_VALUE_IS, key));
+
+    for (uint8_t i = 0; (i != 255) && (errorCode == kThreadError_None); i++)
+    {
+        errorCode = otGetMacWhitelistEntry(i, &entry);
+
+        if (errorCode != kThreadError_None)
+        {
+            break;
+        }
+
+        SuccessOrExit(errorCode = OutboundFrameFeedPacked("T(Ecb).", &entry.mExtAddress, entry.mRssi, entry.mValid));
+    }
+
+    SuccessOrExit(errorCode = OutboundFrameSend());
+
+exit:
+    return errorCode;
+}
+
+ThreadError NcpBase::GetPropertyHandler_MAC_WHITELIST_ENABLED(uint8_t header, spinel_prop_key_t key)
+{
+    return SendPropertyUpdate(
+               header,
+               SPINEL_CMD_PROP_VALUE_IS,
+               key,
+               SPINEL_DATATYPE_BOOL_S,
+               otIsMacWhitelistEnabled()
+           );
+}
+
+ThreadError NcpBase::GetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_key_t key)
+{
+    uint8_t numeric_mode(0);
+    otLinkModeConfig mode_config(otGetLinkMode());
+
+    if (mode_config.mRxOnWhenIdle)
+    {
+        numeric_mode |= kThreadModeTLV_Receiver;
+    }
+
+    if (mode_config.mSecureDataRequests)
+    {
+        numeric_mode |= kThreadModeTLV_Secure;
+    }
+
+    if (mode_config.mDeviceType)
+    {
+        numeric_mode |= kThreadModeTLV_DeviceType;
+    }
+
+    if (mode_config.mNetworkData)
+    {
+        numeric_mode |= kThreadModeTLV_NetworkData;
+    }
+
+    return SendPropertyUpdate(
+               header,
+               SPINEL_CMD_PROP_VALUE_IS,
+               key,
+               SPINEL_DATATYPE_UINT8_S,
+               numeric_mode
+           );
+}
+
+ThreadError NcpBase::GetPropertyHandler_THREAD_CHILD_TIMEOUT(uint8_t header, spinel_prop_key_t key)
+{
+    return SendPropertyUpdate(
+               header,
+               SPINEL_CMD_PROP_VALUE_IS,
+               key,
+               SPINEL_DATATYPE_UINT32_S,
+               otGetChildTimeout()
+           );
+}
+
+ThreadError NcpBase::GetPropertyHandler_THREAD_RLOC16(uint8_t header, spinel_prop_key_t key)
+{
+    return SendPropertyUpdate(
+               header,
+               SPINEL_CMD_PROP_VALUE_IS,
+               key,
+               SPINEL_DATATYPE_UINT16_S,
+               otGetRloc16()
+           );
+}
+
+ThreadError NcpBase::GetPropertyHandler_THREAD_ROUTER_UPGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key)
+{
+    return SendPropertyUpdate(
+               header,
+               SPINEL_CMD_PROP_VALUE_IS,
+               key,
+               SPINEL_DATATYPE_UINT8_S,
+               otGetRouterUpgradeThreshold()
+           );
+}
+
+ThreadError NcpBase::GetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t header, spinel_prop_key_t key)
+{
+    return SendPropertyUpdate(
+               header,
+               SPINEL_CMD_PROP_VALUE_IS,
+               key,
+               SPINEL_DATATYPE_UINT32_S,
+               otGetContextIdReuseDelay()
+           );
+}
+
 
 // ----------------------------------------------------------------------------
 // MARK: Individual Property Setters
@@ -2842,6 +3001,234 @@ ThreadError NcpBase::SetPropertyHandler_CNTR_RESET(uint8_t header, spinel_prop_k
     return SendLastStatus(header, ThreadErrorToSpinelStatus(errorCode));
 }
 
+ThreadError NcpBase::SetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len)
+{
+    ThreadError errorCode = kThreadError_None;
+    spinel_ssize_t parsedLength = 1;
+
+    // First, clear the whitelist.
+    otClearMacWhitelist();
+
+    while ((errorCode == kThreadError_None)
+           && (parsedLength > 0)
+           && (value_len > 0)
+          )
+    {
+        otExtAddress ext_addr;
+        int8_t rssi = RSSI_OVERRIDE_DISABLED;
+
+        parsedLength = spinel_datatype_unpack(
+                           value_ptr,
+                           value_len,
+                           "T(E).",
+                           &ext_addr
+                       );
+
+        if (parsedLength <= 0)
+        {
+            errorCode = kThreadError_Parse;
+            break;
+        }
+
+        // Check for an RSSI
+        if (parsedLength > static_cast<spinel_ssize_t>(sizeof(ext_addr)))
+        {
+            spinel_datatype_unpack(
+                value_ptr,
+                value_len,
+                "T(Ec).",
+                NULL,
+                &rssi
+            );
+        }
+
+        if (rssi == RSSI_OVERRIDE_DISABLED)
+        {
+            errorCode = otAddMacWhitelist(ext_addr.m8);
+        }
+        else
+        {
+            errorCode = otAddMacWhitelistRssi(ext_addr.m8, rssi);
+        }
+
+        value_ptr += parsedLength;
+        value_len -= parsedLength;
+    }
+
+    if (errorCode == kThreadError_None)
+    {
+        errorCode = HandleCommandPropertyGet(header, key);
+    }
+    else
+    {
+        errorCode = SendLastStatus(header, ThreadErrorToSpinelStatus(errorCode));
+
+        // We had an error, but we may have actually changed
+        // the state of the whitelist---so we need to report
+        // those incomplete changes via an asynchronous
+        // change event.
+        HandleCommandPropertyGet(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, key);
+    }
+
+    return errorCode;
+}
+
+ThreadError NcpBase::SetPropertyHandler_MAC_WHITELIST_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len)
+{
+    bool isEnabled;
+    spinel_ssize_t parsedLength;
+    ThreadError errorCode = kThreadError_None;
+
+    parsedLength = spinel_datatype_unpack(
+                       value_ptr,
+                       value_len,
+                       SPINEL_DATATYPE_BOOL_S,
+                       &isEnabled
+                   );
+
+    if (parsedLength > 0)
+    {
+        if (isEnabled)
+        {
+            otEnableMacWhitelist();
+        }
+        else
+        {
+            otDisableMacWhitelist();
+        }
+
+        errorCode = HandleCommandPropertyGet(header, key);
+    }
+    else
+    {
+        errorCode = SendLastStatus(header, SPINEL_STATUS_PARSE_ERROR);
+    }
+
+    return errorCode;
+}
+
+ThreadError NcpBase::SetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len)
+{
+    uint8_t numeric_mode = 0;
+    otLinkModeConfig mode_config;
+    spinel_ssize_t parsedLength;
+    ThreadError errorCode = kThreadError_None;
+
+    parsedLength = spinel_datatype_unpack(
+                       value_ptr,
+                       value_len,
+                       SPINEL_DATATYPE_UINT8_S,
+                       &numeric_mode
+                   );
+
+    if (parsedLength > 0)
+    {
+        mode_config.mRxOnWhenIdle = ((numeric_mode & kThreadModeTLV_Receiver) == kThreadModeTLV_Receiver);
+        mode_config.mSecureDataRequests = ((numeric_mode & kThreadModeTLV_Secure) == kThreadModeTLV_Secure);
+        mode_config.mDeviceType = ((numeric_mode & kThreadModeTLV_DeviceType) == kThreadModeTLV_DeviceType);
+        mode_config.mNetworkData = ((numeric_mode & kThreadModeTLV_NetworkData) == kThreadModeTLV_NetworkData);
+
+        errorCode = otSetLinkMode(mode_config);
+
+        if (errorCode == kThreadError_None)
+        {
+            errorCode = HandleCommandPropertyGet(header, key);
+        }
+        else
+        {
+            errorCode = SendLastStatus(header, ThreadErrorToSpinelStatus(errorCode));
+        }
+    }
+    else
+    {
+        errorCode = SendLastStatus(header, SPINEL_STATUS_PARSE_ERROR);
+    }
+
+    return errorCode;
+}
+
+ThreadError NcpBase::SetPropertyHandler_THREAD_CHILD_TIMEOUT(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len)
+{
+    uint32_t i = 0;
+    spinel_ssize_t parsedLength;
+    ThreadError errorCode = kThreadError_None;
+
+    parsedLength = spinel_datatype_unpack(
+                       value_ptr,
+                       value_len,
+                       SPINEL_DATATYPE_UINT32_S,
+                       &i
+                   );
+
+    if (parsedLength > 0)
+    {
+        otSetChildTimeout(i);
+
+        errorCode = HandleCommandPropertyGet(header, key);
+    }
+    else
+    {
+        errorCode = SendLastStatus(header, SPINEL_STATUS_PARSE_ERROR);
+    }
+
+    return errorCode;
+}
+
+ThreadError NcpBase::SetPropertyHandler_THREAD_ROUTER_UPGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len)
+{
+    uint8_t i = 0;
+    spinel_ssize_t parsedLength;
+    ThreadError errorCode = kThreadError_None;
+
+    parsedLength = spinel_datatype_unpack(
+                       value_ptr,
+                       value_len,
+                       SPINEL_DATATYPE_UINT8_S,
+                       &i
+                   );
+
+    if (parsedLength > 0)
+    {
+        otSetRouterUpgradeThreshold(i);
+
+        errorCode = HandleCommandPropertyGet(header, key);
+    }
+    else
+    {
+        errorCode = SendLastStatus(header, SPINEL_STATUS_PARSE_ERROR);
+    }
+
+    return errorCode;
+}
+
+ThreadError NcpBase::SetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len)
+{
+    uint32_t i = 0;
+    spinel_ssize_t parsedLength;
+    ThreadError errorCode = kThreadError_None;
+
+    parsedLength = spinel_datatype_unpack(
+                       value_ptr,
+                       value_len,
+                       SPINEL_DATATYPE_UINT32_S,
+                       &i
+                   );
+
+    if (parsedLength > 0)
+    {
+        otSetContextIdReuseDelay(i);
+
+        errorCode = HandleCommandPropertyGet(header, key);
+    }
+    else
+    {
+        errorCode = SendLastStatus(header, SPINEL_STATUS_PARSE_ERROR);
+    }
+
+    return errorCode;
+}
+
+
 // ----------------------------------------------------------------------------
 // MARK: Individual Property Inserters
 // ----------------------------------------------------------------------------
@@ -3087,7 +3474,7 @@ ThreadError NcpBase::InsertPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header
         {
             errorCode = SendPropertyUpdate(
                             header,
-                            SPINEL_CMD_PROP_VALUE_REMOVED,
+                            SPINEL_CMD_PROP_VALUE_INSERTED,
                             key,
                             value_ptr,
                             value_len
@@ -3106,6 +3493,65 @@ ThreadError NcpBase::InsertPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header
     return errorCode;
 }
 
+ThreadError NcpBase::InsertPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len)
+{
+    ThreadError errorCode = kThreadError_None;
+    spinel_ssize_t parsedLength;
+    otExtAddress ext_addr;
+    int8_t rssi = RSSI_OVERRIDE_DISABLED;
+
+    parsedLength = spinel_datatype_unpack(
+                       value_ptr,
+                       value_len,
+                       "E",
+                       &ext_addr
+                   );
+
+    // Check for an RSSI
+    if (parsedLength > static_cast<spinel_ssize_t>(sizeof(ext_addr)))
+    {
+        spinel_datatype_unpack(
+            value_ptr,
+            value_len,
+            "Ec",
+            NULL,
+            &rssi
+        );
+    }
+
+    if (parsedLength > 0)
+    {
+        if (rssi == RSSI_OVERRIDE_DISABLED)
+        {
+            errorCode = otAddMacWhitelist(ext_addr.m8);
+        }
+        else
+        {
+            errorCode = otAddMacWhitelistRssi(ext_addr.m8, rssi);
+        }
+
+        if (errorCode == kThreadError_None)
+        {
+            errorCode = SendPropertyUpdate(
+                            header,
+                            SPINEL_CMD_PROP_VALUE_INSERTED,
+                            key,
+                            value_ptr,
+                            value_len
+                        );
+        }
+        else
+        {
+            errorCode = SendLastStatus(header, ThreadErrorToSpinelStatus(errorCode));
+        }
+    }
+    else
+    {
+        errorCode = SendLastStatus(header, SPINEL_STATUS_PARSE_ERROR);
+    }
+
+    return errorCode;
+}
 
 // ----------------------------------------------------------------------------
 // MARK: Individual Property Removers
@@ -3314,6 +3760,39 @@ ThreadError NcpBase::RemovePropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header
         {
             errorCode = SendLastStatus(header, ThreadErrorToSpinelStatus(errorCode));
         }
+    }
+    else
+    {
+        errorCode = SendLastStatus(header, SPINEL_STATUS_PARSE_ERROR);
+    }
+
+    return errorCode;
+}
+
+ThreadError NcpBase::RemovePropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len)
+{
+    ThreadError errorCode = kThreadError_None;
+    spinel_ssize_t parsedLength;
+    otExtAddress ext_addr;
+
+    parsedLength = spinel_datatype_unpack(
+                       value_ptr,
+                       value_len,
+                       "E",
+                       &ext_addr
+                   );
+
+    if (parsedLength > 0)
+    {
+        otRemoveMacWhitelist(ext_addr.m8);
+
+        errorCode = SendPropertyUpdate(
+                        header,
+                        SPINEL_CMD_PROP_VALUE_REMOVED,
+                        key,
+                        value_ptr,
+                        value_len
+                    );
     }
     else
     {

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -286,6 +286,13 @@ private:
     ThreadError GetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_CNTR(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_MAC_WHITELIST_ENABLED(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_CHILD_TIMEOUT(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_RLOC16(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_ROUTER_UPGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t header, spinel_prop_key_t key);
 
     ThreadError SetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                uint16_t value_len);
@@ -328,6 +335,13 @@ private:
     ThreadError SetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key,
                                                               const uint8_t *value_ptr,
                                                               uint16_t value_len);
+    ThreadError SetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
+    ThreadError SetPropertyHandler_MAC_WHITELIST_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
+    ThreadError SetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
+    ThreadError SetPropertyHandler_THREAD_CHILD_TIMEOUT(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
+    ThreadError SetPropertyHandler_THREAD_ROUTER_UPGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
+    ThreadError SetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
+
 
     ThreadError SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
                                                     const uint8_t *value_ptr, uint16_t value_len);
@@ -345,6 +359,7 @@ private:
     ThreadError InsertPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
                                                              const uint8_t *value_ptr,
                                                              uint16_t value_len);
+    ThreadError InsertPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
 
     ThreadError RemovePropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                          uint16_t value_len);
@@ -355,6 +370,7 @@ private:
     ThreadError RemovePropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
                                                              const uint8_t *value_ptr,
                                                              uint16_t value_len);
+    ThreadError RemovePropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
 
 private:
     enum

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1106,6 +1106,30 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE";
         break;
 
+    case SPINEL_PROP_MAC_WHITELIST:
+        ret = "PROP_MAC_WHITELIST";
+        break;
+
+    case SPINEL_PROP_MAC_WHITELIST_ENABLED:
+        ret = "PROP_MAC_WHITELIST_ENABLED";
+        break;
+
+    case SPINEL_PROP_THREAD_MODE:
+        ret = "PROP_THREAD_MODE";
+        break;
+
+    case SPINEL_PROP_THREAD_CHILD_TIMEOUT:
+        ret = "PROP_THREAD_CHILD_TIMEOUT";
+        break;
+
+    case SPINEL_PROP_THREAD_ROUTER_UPGRADE_THRESHOLD:
+        ret = "PROP_THREAD_ROUTER_UPGRADE_THRESHOLD";
+        break;
+
+    case SPINEL_PROP_THREAD_CONTEXT_REUSE_DELAY:
+        ret = "PROP_THREAD_CONTEXT_REUSE_DELAY";
+        break;
+
     default:
         break;
     }
@@ -1193,6 +1217,14 @@ const char *spinel_status_to_cstr(spinel_status_t status)
 
     case SPINEL_STATUS_CCA_FAILURE:
         ret = "STATUS_CCA_FAILURE";
+        break;
+
+    case SPINEL_STATUS_ALREADY:
+        ret = "STATUS_ALREADY";
+        break;
+
+    case SPINEL_STATUS_ITEM_NOT_FOUND:
+        ret = "STATUS_ITEM_NOT_FOUND";
         break;
 
     case SPINEL_STATUS_RESET_POWER_ON:

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -99,6 +99,8 @@ typedef enum
     SPINEL_STATUS_CMD_TOO_BIG       = 16, ///< The command was too large to fit in the internal buffer.
     SPINEL_STATUS_NO_ACK            = 17, ///< The packet was not acknowledged.
     SPINEL_STATUS_CCA_FAILURE       = 18, ///< The packet was not sent due to a CCA failure.
+    SPINEL_STATUS_ALREADY           = 19, ///< The operation is already in progress.
+    SPINEL_STATUS_ITEM_NOT_FOUND    = 20, ///< The given item could not be found.
 
     SPINEL_STATUS_RESET__BEGIN      = 112,
     SPINEL_STATUS_RESET_POWER_ON    = SPINEL_STATUS_RESET__BEGIN + 0,
@@ -112,9 +114,11 @@ typedef enum
     SPINEL_STATUS_RESET_WATCHDOG    = SPINEL_STATUS_RESET__BEGIN + 8,
     SPINEL_STATUS_RESET__END        = 128,
 
-
     SPINEL_STATUS_VENDOR__BEGIN     = 15360,
     SPINEL_STATUS_VENDOR__END       = 16384,
+
+    SPINEL_STATUS_STACK_NATIVE__BEGIN = 16384,
+    SPINEL_STATUS_STACK_NATIVE__END   = 81920,
 
     SPINEL_STATUS_EXPERIMENTAL__BEGIN = 2000000,
     SPINEL_STATUS_EXPERIMENTAL__END   = 2097152,
@@ -266,6 +270,10 @@ enum
     SPINEL_CAP_NET_THREAD_1_0        = (SPINEL_CAP_NET__BEGIN + 0),
     SPINEL_CAP_NET__END              = 64,
 
+    SPINEL_CAP_OPENTHREAD__BEGIN     = 512,
+    SPINEL_CAP_MAC_WHITELIST         = (SPINEL_CAP_OPENTHREAD__BEGIN + 0),
+    SPINEL_CAP_OPENTHREAD__END       = 640,
+
     SPINEL_CAP_NEST__BEGIN           = 15296,
     SPINEL_CAP_NEST_LEGACY_INTERFACE = (SPINEL_CAP_NEST__BEGIN + 0),
     SPINEL_CAP_NEST_LEGACY_NET_WAKE  = (SPINEL_CAP_NEST__BEGIN + 1),
@@ -318,9 +326,19 @@ typedef enum
 
     SPINEL_PROP_MAC_EXT__BEGIN         = 0x1300,
     /// MAC Whitelist
-    /** Format: `A(T(E))`
+    /** Format: `A(T(Ec))`
+     *
+     * Structure Parameters:
+     *
+     * * `E`: EUI64 address of node
+     * * `c`: Optional fixed RSSI. -127 means not set.
      */
-    SPINEL_PROP_MAC_WHITELIST          = SPINEL_PROP_MAC_EXT__BEGIN + 0, ///< [A(T(E))]
+    SPINEL_PROP_MAC_WHITELIST          = SPINEL_PROP_MAC_EXT__BEGIN + 0,
+
+    /// MAC Whitelist Enabled Flag
+    /** Format: `b`
+     */
+    SPINEL_PROP_MAC_WHITELIST_ENABLED  = SPINEL_PROP_MAC_EXT__BEGIN + 1,
     SPINEL_PROP_MAC_EXT__END           = 0x1400,
 
     SPINEL_PROP_NET__BEGIN           = 0x40,


### PR DESCRIPTION
This commit adds support for the following properties:

* `PROP_MAC_WHITELIST`
* `PROP_MAC_WHITELIST_ENABLED`
* `PROP_THREAD_MODE`
* `PROP_THREAD_CHILD_TIMEOUT`
* `PROP_THREAD_ROUTER_UPGRADE_THRESHOLD`
* `PROP_THREAD_CONTEXT_REUSE_DELAY`

It also adds documentation for the property `PROP_MAC_WHITELIST_ENABLED`,
which was previously undocumented.

This commit also fixes a few style errors and some typos.