### PR TITLE
Ensure that Network Name strings are NULL-termianted for client code.

### DIFF
--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -142,7 +142,7 @@ typedef struct otMasterKey
     uint8_t m8[OT_MASTER_KEY_SIZE];
 } otMasterKey;
 
-#define OT_NETWORK_NAME_SIZE       16  ///< Size of the Thread Network Name field (bytes)
+#define OT_NETWORK_NAME_MAX_SIZE   16  ///< Maximum size of the Thread Network Name field (bytes)
 
 /**
  * This structure represents a Network Name.
@@ -150,7 +150,7 @@ typedef struct otMasterKey
  */
 typedef struct otNetworkName
 {
-    char m8[OT_NETWORK_NAME_SIZE];
+    char m8[OT_NETWORK_NAME_MAX_SIZE + 1];
 } otNetworkName;
 
 #define OT_EXT_PAN_ID_SIZE         8   ///< Size of a Thread PAN ID (bytes)
@@ -247,16 +247,16 @@ typedef OT_TOOL_PACKED_BEGIN struct otIp6Address
  */
 typedef struct otActiveScanResult
 {
-    otExtAddress   mExtAddress;      ///< IEEE 802.15.4 Extended Address
-    const char    *mNetworkName;     ///< Thread Network Name
-    const uint8_t *mExtPanId;        ///< Thread Extended PAN ID
-    uint16_t       mPanId;           ///< IEEE 802.15.4 PAN ID
-    uint8_t        mChannel;         ///< IEEE 802.15.4 Channel
-    int8_t         mRssi;            ///< RSSI (dBm)
-    uint8_t        mLqi;             ///< LQI
-    unsigned int   mVersion : 4;     ///< Version
-    bool           mIsNative : 1;    ///< Native Commissioner flag
-    bool           mIsJoinable : 1;  ///< Joining Permitted flag
+    otExtAddress    mExtAddress;      ///< IEEE 802.15.4 Extended Address
+    otNetworkName   mNetworkName;     ///< Thread Network Name
+    otExtendedPanId mExtendedPanId;   ///< Thread Extended PAN ID
+    uint16_t        mPanId;           ///< IEEE 802.15.4 PAN ID
+    uint8_t         mChannel;         ///< IEEE 802.15.4 Channel
+    int8_t          mRssi;            ///< RSSI (dBm)
+    uint8_t         mLqi;             ///< LQI
+    unsigned int    mVersion : 4;     ///< Version
+    bool            mIsNative : 1;    ///< Native Commissioner flag
+    bool            mIsJoinable : 1;  ///< Joining Permitted flag
 } otActiveScanResult;
 
 /**

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -883,7 +883,7 @@ void Interpreter::ProcessNetworkName(int argc, char *argv[])
 
     if (argc == 0)
     {
-        sServer->OutputFormat("%.*s\r\n", OT_NETWORK_NAME_SIZE, otGetNetworkName());
+        sServer->OutputFormat("%.*s\r\n", OT_NETWORK_NAME_MAX_SIZE, otGetNetworkName());
     }
     else
     {
@@ -1456,25 +1456,11 @@ void Interpreter::HandleActiveScanResult(otActiveScanResult *aResult)
 
     sServer->OutputFormat("| %d ", aResult->mIsJoinable);
 
-    if (aResult->mNetworkName != NULL)
-    {
-        sServer->OutputFormat("| %-16s ", aResult->mNetworkName);
-    }
-    else
-    {
-        sServer->OutputFormat("| ---------------- ");
-    }
+    sServer->OutputFormat("| %-16s ", aResult->mNetworkName.m8);
 
-    if (aResult->mExtPanId != NULL)
-    {
-        sServer->OutputFormat("| ");
-        OutputBytes(aResult->mExtPanId, OT_EXT_PAN_ID_SIZE);
-        sServer->OutputFormat(" ");
-    }
-    else
-    {
-        sServer->OutputFormat("| ---------------- ");
-    }
+    sServer->OutputFormat("| ");
+    OutputBytes(aResult->mExtendedPanId.m8, OT_EXT_PAN_ID_SIZE);
+    sServer->OutputFormat(" ");
 
     sServer->OutputFormat("| %04x | ", aResult->mPanId);
     OutputBytes(aResult->mExtAddress.m8, OT_EXT_ADDRESS_SIZE);

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -306,7 +306,7 @@ ThreadError Dataset::ProcessNetworkName(int argc, char *argv[])
     size_t length;
 
     VerifyOrExit(argc > 0, error = kThreadError_Parse);
-    VerifyOrExit((length = strlen(argv[0])) <= OT_NETWORK_NAME_SIZE, error = kThreadError_Parse);
+    VerifyOrExit((length = strlen(argv[0])) <= OT_NETWORK_NAME_MAX_SIZE, error = kThreadError_Parse);
 
     memset(&sDataset.mNetworkName, 0, sizeof(sDataset.mNetworkName));
     memcpy(sDataset.mNetworkName.m8, argv[0], length);

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -471,7 +471,8 @@ private:
     PanId mPanId;
     uint8_t mChannel;
 
-    Beacon mBeacon;
+    otNetworkName mNetworkName;
+    otExtendedPanId mExtendedPanId;
 
     Sender *mSendHead, *mSendTail;
     Receiver *mReceiveHead, *mReceiveTail;

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -928,8 +928,8 @@ void HandleActiveScanResult(void *aContext, Mac::Frame *aFrame)
         result.mVersion = beacon->GetProtocolVersion();
         result.mIsJoinable = beacon->IsJoiningPermitted();
         result.mIsNative = beacon->IsNative();
-        result.mNetworkName = beacon->GetNetworkName();
-        result.mExtPanId = beacon->GetExtendedPanId();
+        memcpy(&result.mNetworkName, beacon->GetNetworkName(), sizeof(result.mNetworkName));
+        memcpy(&result.mExtendedPanId, beacon->GetExtendedPanId(), sizeof(result.mExtendedPanId));
     }
 
     handler(&result);

--- a/src/core/thread/meshcop_tlvs.hpp
+++ b/src/core/thread/meshcop_tlvs.hpp
@@ -321,10 +321,11 @@ public:
     void SetNetworkName(const char *aNetworkName) {
         size_t length = strnlen(aNetworkName, sizeof(mNetworkName));
         memcpy(mNetworkName, aNetworkName, length);
+        SetLength(static_cast<uint8_t>(length));
     }
 
 private:
-    char mNetworkName[OT_NETWORK_NAME_SIZE];
+    char mNetworkName[OT_NETWORK_NAME_MAX_SIZE];
 } OT_TOOL_PACKED_END;
 
 /**

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2235,7 +2235,6 @@ ThreadError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::Mes
     otActiveScanResult result;
     uint16_t offset;
     uint16_t end;
-    char networkNameBuf[OT_NETWORK_NAME_SIZE];
 
     otLogInfoMle("Handle discovery response\n");
 
@@ -2284,15 +2283,13 @@ ThreadError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::Mes
         case MeshCoP::Tlv::kExtendedPanId:
             aMessage.Read(offset, sizeof(extPanId), &extPanId);
             VerifyOrExit(extPanId.IsValid(), error = kThreadError_Parse);
-            result.mExtPanId = extPanId.GetExtendedPanId();
+            memcpy(&result.mExtendedPanId, extPanId.GetExtendedPanId(), sizeof(result.mExtendedPanId));
             break;
 
         case MeshCoP::Tlv::kNetworkName:
             aMessage.Read(offset, sizeof(networkName), &networkName);
             VerifyOrExit(networkName.IsValid(), error = kThreadError_Parse);
-            memcpy(networkNameBuf, networkName.GetNetworkName(), networkName.GetLength());
-            memset(networkNameBuf + networkName.GetLength(), 0, sizeof(networkNameBuf) - networkName.GetLength());
-            result.mNetworkName = networkNameBuf;
+            memcpy(&result.mNetworkName, networkName.GetNetworkName(), networkName.GetLength());
             break;
 
         default:

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -455,8 +455,8 @@ void NcpBase::HandleActiveScanResult(otActiveScanResult *result)
             result->mLqi,
             SPINEL_PROTOCOL_TYPE_THREAD,
             flags,
-            result->mNetworkName,
-            result->mExtPanId, OT_EXT_PAN_ID_SIZE
+            result->mNetworkName.m8,
+            result->mExtendedPanId.m8, OT_EXT_PAN_ID_SIZE
         );
     }
     else


### PR DESCRIPTION
* otGetNetworkName() no longer returns a pointer into a beacon message.
* Scan results no longer point into a beacon message.

Fixes #365.