### PR TITLE
ncp-uart: Keep track of and report framing errors.

### DIFF
--- a/src/ncp/hdlc.hpp
+++ b/src/ncp/hdlc.hpp
@@ -166,6 +166,17 @@ public:
     typedef void (*FrameHandler)(void *aContext, uint8_t *aFrame, uint16_t aFrameLength);
 
     /**
+     * This function pointer is called when an error has occured.
+     *
+     * @param[in]  aContext      A pointer to arbitrary context information.
+     * @param[in]  aError        An error code describing the error.
+     * @param[in]  aFrame        A pointer to the frame.
+     * @param[in]  aFrameLength  The frame length in bytes.
+     *
+     */
+    typedef void (*ErrorHandler)(void *aContext, ThreadError aError, uint8_t *aFrame, uint16_t aFrameLength);
+
+    /**
      * This constructor initializes the decoder.
      *
      * @param[in]  aOutBuf        A pointer to the output buffer.
@@ -174,7 +185,7 @@ public:
      * @param[in]  aContext       A pointer to arbitrary context information.
      *
      */
-    Decoder(uint8_t *aOutBuf, uint16_t aOutLength, FrameHandler aFrameHandler, void *aContext);
+    Decoder(uint8_t *aOutBuf, uint16_t aOutLength, FrameHandler aFrameHandler, ErrorHandler aErrorHandler, void *aContext);
 
     /**
      * This method streams bytes into the decoder.
@@ -195,6 +206,7 @@ private:
     State mState;
 
     FrameHandler mFrameHandler;
+    ErrorHandler mErrorHandler;
     void *mContext;
 
     uint8_t *mOutBuf;

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -347,6 +347,7 @@ NcpBase::NcpBase():
     sNcpContext = this;
     mChangedFlags = NCP_PLAT_RESET_REASON;
     mAllowLocalNetworkDataChange = false;
+    mFramingErrorCounter = 0;
 
     for (unsigned i = 0; i < sizeof(mNetifAddresses) / sizeof(mNetifAddresses[0]); i++)
     {
@@ -660,6 +661,11 @@ void NcpBase::HandleSpaceAvailableInTxBuffer(void)
 
 exit:
     return;
+}
+
+void NcpBase::IncrementFrameErrorCounter(void)
+{
+    mFramingErrorCounter++;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -102,6 +102,12 @@ protected:
      */
     virtual ThreadError OutboundFrameSend(void) = 0;
 
+    /**
+     * This method is called by the framer whenever a framing error
+     * is detected.
+     */
+    void IncrementFrameErrorCounter(void);
+
 protected:
 
     /**
@@ -398,6 +404,8 @@ private:
     otNetifAddress mNetifAddresses[kNetifAddressListSize];
 
     bool mAllowLocalNetworkDataChange;
+
+    uint32_t mFramingErrorCounter;
 };
 
 }  // namespace Thread

--- a/src/ncp/ncp_uart.hpp
+++ b/src/ncp/ncp_uart.hpp
@@ -140,10 +140,12 @@ private:
 
     void            EncodeAndSendToUart(void);
     void            HandleFrame(uint8_t *aBuf, uint16_t aBufLength);
+    void            HandleError(ThreadError aError, uint8_t *aBuf, uint16_t aBufLength);
     void            TxFrameBufferHasData(void);
 
     static void     EncodeAndSendToUart(void *aContext);
     static void     HandleFrame(void *context, uint8_t *aBuf, uint16_t aBufLength);
+    static void     HandleError(void *context, ThreadError aError, uint8_t *aBuf, uint16_t aBufLength);
     static void     TxFrameBufferHasData(void *aContext, NcpFrameBuffer *aNcpFrameBuffer);
 
     Hdlc::Encoder   mFrameEncoder;


### PR DESCRIPTION
Previously we were simply ignoring frames that contained errors. This
change causes framing errors to be logged to the `PROP_STREAM_DEBUG`
stream property, so that the event can be logged by the host. The log
message looks like this:

    Framing error E: [XX XX XX XX...]

Where `E` is the `ThreadError` code, and `XX XX...` is a hex dump of
no more than the first 42 bytes of the erroneous frame.

A frame error counter is also included, but is not yet being exposed.