### PR TITLE
ncp: Revisions to the Spinel protocol to mesh with recent API changes.

### DIFF
--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -346,7 +346,6 @@ enum
     OT_IP6_ADDRESS_ADDED    = 1 << 0,  ///< IPv6 address was added
     OT_IP6_ADDRESS_REMOVED  = 1 << 1,  ///< IPv6 address was removed
 
-    OT_NET_STATE            = 1 << 2,  ///< Device state (offline, detached, attached) changed
     OT_NET_ROLE             = 1 << 3,  ///< Device role (disabled, detached, child, router, leader) changed
     OT_NET_PARTITION_ID     = 1 << 4,  ///< Partition ID changed
     OT_NET_KEY_SEQUENCE     = 1 << 5,  ///< Thread Key Sequence changed

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -322,7 +322,7 @@ ThreadError Mle::SetStateDetached(void)
 {
     if (mDeviceState != kDeviceStateDetached)
     {
-        mNetif.SetStateChangedFlags(OT_NET_STATE | OT_NET_ROLE);
+        mNetif.SetStateChangedFlags(OT_NET_ROLE);
     }
 
     mAddressResolver.Clear();
@@ -337,11 +337,6 @@ ThreadError Mle::SetStateDetached(void)
 
 ThreadError Mle::SetStateChild(uint16_t aRloc16)
 {
-    if (mDeviceState == kDeviceStateDetached)
-    {
-        mNetif.SetStateChangedFlags(OT_NET_STATE);
-    }
-
     if (mDeviceState != kDeviceStateChild)
     {
         mNetif.SetStateChangedFlags(OT_NET_ROLE);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -324,11 +324,6 @@ ThreadError MleRouter::HandleChildStart(otMleAttachFilter aFilter)
 
 ThreadError MleRouter::SetStateRouter(uint16_t aRloc16)
 {
-    if (mDeviceState == kDeviceStateDetached)
-    {
-        mNetif.SetStateChangedFlags(OT_NET_STATE);
-    }
-
     if (mDeviceState != kDeviceStateRouter)
     {
         mNetif.SetStateChangedFlags(OT_NET_ROLE);
@@ -350,11 +345,6 @@ ThreadError MleRouter::SetStateRouter(uint16_t aRloc16)
 
 ThreadError MleRouter::SetStateLeader(uint16_t aRloc16)
 {
-    if (mDeviceState == kDeviceStateDetached)
-    {
-        mNetif.SetStateChangedFlags(OT_NET_STATE);
-    }
-
     if (mDeviceState != kDeviceStateLeader)
     {
         mNetif.SetStateChangedFlags(OT_NET_ROLE);

--- a/src/ncp/PROTOCOL.md
+++ b/src/ncp/PROTOCOL.md
@@ -1442,21 +1442,20 @@ Structure Parameters:
 Returns true if there is a network state stored that can be
 restored with a call to `CMD_NET_RECALL`.
 
-#### D.3.2. PROP 65: `PROP_NET_ENABLED`
-* Type: Read-Only
+#### D.3.2. PROP 65: `PROP_NET_IF_UP`
+* Type: Read-Write
 * Packed-Encoding: `b`
 
-#### D.3.3. PROP 66: `PROP_NET_STATE`
+Network interface up/down status. Non-zero (set to 1) indicates up,
+zero indicates down.
+
+#### D.3.3. PROP 66: `PROP_NET_STACK_UP`
 * Type: Read-Write
-* Packed-Encoding: `C`
+* Packed-Encoding: `b`
 * Unit: Enumeration
 
-Values:
-
-* 0: `NET_STATE_OFFLINE`
-* 1: `NET_STATE_DETACHED`
-* 2: `NET_STATE_ATTACHING`
-* 3: `NET_STATE_ATTACHED`
+Thread stack operational status. Non-zero (set to 1) indicates up,
+zero indicates down.
 
 #### D.3.4. PROP 67: `PROP_NET_ROLE`
 * Type: Read-Write
@@ -1465,7 +1464,7 @@ Values:
 
 Values:
 
-* 0: `NET_ROLE_NONE`
+* 0: `NET_ROLE_DETACHED`
 * 1: `NET_ROLE_CHILD`
 * 2: `NET_ROLE_ROUTER`
 * 3: `NET_ROLE_LEADER`

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -262,8 +262,8 @@ private:
     ThreadError GetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_MAC_15_4_LADDR(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_MAC_15_4_SADDR(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_NET_ENABLED(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_NET_STATE(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_NET_IF_UP(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_NET_STACK_UP(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_NET_NETWORK_NAME(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_NET_XPANID(uint8_t header, spinel_prop_key_t key);
@@ -312,9 +312,9 @@ private:
                                                   uint16_t value_len);
     ThreadError SetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                   uint16_t value_len);
-    ThreadError SetPropertyHandler_NET_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    ThreadError SetPropertyHandler_NET_IF_UP(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                uint16_t value_len);
-    ThreadError SetPropertyHandler_NET_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    ThreadError SetPropertyHandler_NET_STACK_UP(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                              uint16_t value_len);
     ThreadError SetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                             uint16_t value_len);

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -998,12 +998,12 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_NET_SAVED";
         break;
 
-    case SPINEL_PROP_NET_ENABLED:
-        ret = "PROP_NET_ENABLED";
+    case SPINEL_PROP_NET_IF_UP:
+        ret = "PROP_NET_IF_UP";
         break;
 
-    case SPINEL_PROP_NET_STATE:
-        ret = "PROP_NET_STATE";
+    case SPINEL_PROP_NET_STACK_UP:
+        ret = "PROP_NET_STACK_UP";
         break;
 
     case SPINEL_PROP_NET_ROLE:

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -69,7 +69,7 @@
 // ----------------------------------------------------------------------------
 
 #define SPINEL_PROTOCOL_VERSION_THREAD_MAJOR    4
-#define SPINEL_PROTOCOL_VERSION_THREAD_MINOR    0
+#define SPINEL_PROTOCOL_VERSION_THREAD_MINOR    1
 
 #define SPINEL_FRAME_MAX_SIZE                   1300
 
@@ -126,15 +126,7 @@ typedef enum
 
 typedef enum
 {
-    SPINEL_NET_STATE_OFFLINE   = 0,
-    SPINEL_NET_STATE_DETACHED  = 1,
-    SPINEL_NET_STATE_ATTACHING = 2,
-    SPINEL_NET_STATE_ATTACHED  = 3,
-} spinel_net_state_t;
-
-typedef enum
-{
-    SPINEL_NET_ROLE_NONE       = 0,
+    SPINEL_NET_ROLE_DETACHED   = 0,
     SPINEL_NET_ROLE_CHILD      = 1,
     SPINEL_NET_ROLE_ROUTER     = 2,
     SPINEL_NET_ROLE_LEADER     = 3,
@@ -343,8 +335,8 @@ typedef enum
 
     SPINEL_PROP_NET__BEGIN           = 0x40,
     SPINEL_PROP_NET_SAVED            = SPINEL_PROP_NET__BEGIN + 0, ///< [b]
-    SPINEL_PROP_NET_ENABLED          = SPINEL_PROP_NET__BEGIN + 1, ///< [b]
-    SPINEL_PROP_NET_STATE            = SPINEL_PROP_NET__BEGIN + 2, ///< [C]
+    SPINEL_PROP_NET_IF_UP            = SPINEL_PROP_NET__BEGIN + 1, ///< [b]
+    SPINEL_PROP_NET_STACK_UP         = SPINEL_PROP_NET__BEGIN + 2, ///< [C]
     SPINEL_PROP_NET_ROLE             = SPINEL_PROP_NET__BEGIN + 3, ///< [C]
     SPINEL_PROP_NET_NETWORK_NAME     = SPINEL_PROP_NET__BEGIN + 4, ///< [U]
     SPINEL_PROP_NET_XPANID           = SPINEL_PROP_NET__BEGIN + 5, ///< [D]
@@ -686,6 +678,8 @@ SPINEL_API_EXTERN const char *spinel_next_packed_datatype(const char *pack_forma
 // ----------------------------------------------------------------------------
 
 SPINEL_API_EXTERN const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key);
+
+SPINEL_API_EXTERN const char *spinel_status_to_cstr(spinel_status_t status);
 
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
With the introduction of the `otThreadStart()`/`otThreadStop()` and
`otInterfaceUp()`/`otInterfaceDown()` APIs, the existing spinel
command mapping was not adequate.

This commit makes the following changes:

*   `PROP_NET_ENABLED` is now `PROP_NET_IF_UP`, and maps directly to
    the `otInterfaceUp()`/`otInterfaceDown()` functions.
*   `PROP_NET_STATE` is now `PROP_NET_STACK_UP`, and is now a boolean
    that maps directly to `otThreadStart()`/`otThreadStop()`.

Also, `SPINEL_NET_ROLE_NONE` has now been renamed to
`SPINEL_NET_ROLE_DETACHED`.