### PR TITLE
remove unnecessary ChildUpdateRequest()

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2382,16 +2382,6 @@ void Mle::HandleNetworkDataUpdate(void)
     {
         mMleRouter.HandleNetworkDataUpdateRouter();
     }
-
-    switch (mDeviceState)
-    {
-    case kDeviceStateChild:
-        SendChildUpdateRequest();
-        break;
-
-    default:
-        break;
-    }
 }
 
 }  // namespace Mle


### PR DESCRIPTION
If network data update would cause address changes, Child Update Request would be sent when HandleNetifStateChanged(OT_IP6_ADDRESS_ADDED | OT_IP6_ADDRESS_REMOVED); hereby, it might be not necessary to send Child Update Request when HandleNetworkDataUpdate().

@jwhui , please have a review.