### PR TITLE
child should not forward packets

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -43,6 +43,7 @@
 #include <net/ip6_routes.hpp>
 #include <net/netif.hpp>
 #include <net/udp6.hpp>
+#include <openthread.h>
 
 namespace Thread {
 namespace Ip6 {
@@ -426,6 +427,11 @@ ThreadError Ip6::HandleDatagram(Message &message, Netif *netif, int8_t interface
     {
         if (netif != NULL)
         {
+            if (otGetDeviceRole() == kDeviceRoleChild)
+            {
+                ExitNow(error = kThreadError_Drop);
+            }
+
             header.SetHopLimit(header.GetHopLimit() - 1);
         }
 

--- a/src/core/thread/mle_constants.hpp
+++ b/src/core/thread/mle_constants.hpp
@@ -92,6 +92,7 @@ enum
     kReedAdvertiseInterval      = 570,  ///< REED_ADVERTISEMENT_INTERVAL (seconds)
     kReedAdvertiseJitter        = 60,   ///< REED_ADVERTISEMENT_JITTER (seconds)
     kMleEndDeviceTimeout        = 240,  ///< MLE_END_DEVICE_TIMEOUT (secondes)
+    kLeaderWeight               = 64,   ///< Default leaderweight for the Thread Network Partition
 };
 
 enum

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -63,7 +63,7 @@ MleRouter::MleRouter(ThreadNetif &aThreadNetif):
 
     mNetworkIdTimeout = kNetworkIdTimeout;
     mRouterUpgradeThreshold = kRouterUpgradeThreshold;
-    mLeaderWeight = 0;
+    mLeaderWeight = kLeaderWeight;
     mFixedLeaderPartitionId = 0;
     mRouterId = kMaxRouterId;
     mPreviousRouterId = kMaxRouterId;


### PR DESCRIPTION
child should not forward packets;
default leader weight should be 64.

@jwhui , please have a review.