### PR TITLE
ncp: Fix for fetching whitelist.

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -602,7 +602,7 @@ void NcpBase::HandleReceive(const uint8_t *buf, uint16_t bufLength)
         errorCode = SendLastStatus(header, SPINEL_STATUS_PARSE_ERROR);
     }
 
-   if (errorCode == kThreadError_NoBufs)
+    if (errorCode == kThreadError_NoBufs)
     {
         // If we cannot send a response due to buffer space not being
         // available, we remember the TID of command so to send an
@@ -1927,7 +1927,15 @@ ThreadError NcpBase::GetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_pro
             break;
         }
 
-        SuccessOrExit(errorCode = OutboundFrameFeedPacked("T(Ecb).", &entry.mExtAddress, entry.mRssi, entry.mValid));
+        if (entry.mValid)
+        {
+            if (!entry.mFixedRssi)
+            {
+                entry.mRssi = RSSI_OVERRIDE_DISABLED;
+            }
+
+            SuccessOrExit(errorCode = OutboundFrameFeedPacked("T(Ec).", entry.mExtAddress.m8, entry.mRssi));
+        }
     }
 
     SuccessOrExit(errorCode = OutboundFrameSend());
@@ -3023,15 +3031,27 @@ ThreadError NcpBase::SetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_pro
            && (value_len > 0)
           )
     {
-        otExtAddress ext_addr;
+        otExtAddress *ext_addr = NULL;
         int8_t rssi = RSSI_OVERRIDE_DISABLED;
 
         parsedLength = spinel_datatype_unpack(
                            value_ptr,
                            value_len,
-                           "T(E).",
-                           &ext_addr
+                           "T(Ec).",
+                           &ext_addr,
+                           &rssi
                        );
+
+        if (parsedLength <= 0)
+        {
+            rssi = RSSI_OVERRIDE_DISABLED;
+            parsedLength = spinel_datatype_unpack(
+                               value_ptr,
+                               value_len,
+                               "T(E).",
+                               &ext_addr
+                           );
+        }
 
         if (parsedLength <= 0)
         {
@@ -3039,25 +3059,13 @@ ThreadError NcpBase::SetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_pro
             break;
         }
 
-        // Check for an RSSI
-        if (parsedLength > static_cast<spinel_ssize_t>(sizeof(ext_addr)))
-        {
-            spinel_datatype_unpack(
-                value_ptr,
-                value_len,
-                "T(Ec).",
-                NULL,
-                &rssi
-            );
-        }
-
         if (rssi == RSSI_OVERRIDE_DISABLED)
         {
-            errorCode = otAddMacWhitelist(ext_addr.m8);
+            errorCode = otAddMacWhitelist(ext_addr->m8);
         }
         else
         {
-            errorCode = otAddMacWhitelistRssi(ext_addr.m8, rssi);
+            errorCode = otAddMacWhitelistRssi(ext_addr->m8, rssi);
         }
 
         value_ptr += parsedLength;
@@ -3506,25 +3514,27 @@ ThreadError NcpBase::InsertPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_
 {
     ThreadError errorCode = kThreadError_None;
     spinel_ssize_t parsedLength;
-    otExtAddress ext_addr;
+    otExtAddress *ext_addr = NULL;
     int8_t rssi = RSSI_OVERRIDE_DISABLED;
 
-    parsedLength = spinel_datatype_unpack(
-                       value_ptr,
-                       value_len,
-                       "E",
-                       &ext_addr
-                   );
 
-    // Check for an RSSI
-    if (parsedLength > static_cast<spinel_ssize_t>(sizeof(ext_addr)))
+    if (value_len > static_cast<spinel_ssize_t>(sizeof(ext_addr)))
     {
-        spinel_datatype_unpack(
+        parsedLength = spinel_datatype_unpack(
             value_ptr,
             value_len,
             "Ec",
-            NULL,
+            &ext_addr,
             &rssi
+        );
+    }
+    else
+    {
+        parsedLength = spinel_datatype_unpack(
+            value_ptr,
+            value_len,
+            "E",
+            &ext_addr
         );
     }
 
@@ -3532,11 +3542,11 @@ ThreadError NcpBase::InsertPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_
     {
         if (rssi == RSSI_OVERRIDE_DISABLED)
         {
-            errorCode = otAddMacWhitelist(ext_addr.m8);
+            errorCode = otAddMacWhitelist(ext_addr->m8);
         }
         else
         {
-            errorCode = otAddMacWhitelistRssi(ext_addr.m8, rssi);
+            errorCode = otAddMacWhitelistRssi(ext_addr->m8, rssi);
         }
 
         if (errorCode == kThreadError_None)

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -331,7 +331,7 @@ typedef enum
      * Structure Parameters:
      *
      * * `E`: EUI64 address of node
-     * * `c`: Optional fixed RSSI. -127 means not set.
+     * * `c`: Optional fixed RSSI. 127 means not set.
      */
     SPINEL_PROP_MAC_WHITELIST          = SPINEL_PROP_MAC_EXT__BEGIN + 0,
 


### PR DESCRIPTION
Fetching the whitelist previously returned unused whitelist slots
instead of omitting them. It also makes sure that we return
an RSSI value of `0x7F` (127) when the fixed-RSSI feature is
not being used.