### PR TITLE
cli: pollperiod fix

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -567,20 +567,20 @@ Send an ICMPv6 Echo Request.
 
 ### pollperiod
 
-Get the data poll period of sleepy end device
+Get the customized data poll period of sleepy end device (seconds). Only for certification test
 
 ```bash
 > pollperiod
-240
+0
 Done
 ```
 
 ### pollperiod \<pollperiod>\
 
-Set the data poll period for sleepy end device
+Set the customized data poll period for sleepy end device (seconds). Only for certification test
 
 ```bash
-> pollperiod 240
+> pollperiod 10
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1040,12 +1040,12 @@ void Interpreter::ProcessPollPeriod(int argc, char *argv[])
 
     if (argc == 0)
     {
-        sServer->OutputFormat("%d\r\n", otGetPollPeriod());
+        sServer->OutputFormat("%d\r\n", (otGetPollPeriod() / 1000));  // ms->s
     }
     else
     {
         SuccessOrExit(error = ParseLong(argv[0], value));
-        otSetPollPeriod(static_cast<uint32_t>(value));
+        otSetPollPeriod(static_cast<uint32_t>(value * 1000));  // s->ms
     }
 
 exit:

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -793,12 +793,12 @@ const char *otGetVersionString(void)
 
 uint32_t otGetPollPeriod()
 {
-    return sThreadNetif->GetMeshForwarder().GetPollPeriod();
+    return sThreadNetif->GetMeshForwarder().GetAssignPollPeriod();
 }
 
 void otSetPollPeriod(uint32_t aPollPeriod)
 {
-    sThreadNetif->GetMeshForwarder().SetPollPeriod(aPollPeriod);
+    sThreadNetif->GetMeshForwarder().SetAssignPollPeriod(aPollPeriod);
 }
 
 ThreadError otEnable(void)

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -66,7 +66,7 @@ MeshForwarder::MeshForwarder(ThreadNetif &aThreadNetif):
 {
     mFragTag = static_cast<uint16_t>(otPlatRandomGet());
     mPollPeriod = 0;
-    mPollPeriodAssigned = false;
+    mAssignPollPeriod = 0;
     mSendMessage = NULL;
     mSendBusy = false;
     mEnabled = false;
@@ -573,29 +573,29 @@ void MeshForwarder::SetRxOnWhenIdle(bool aRxOnWhenIdle)
     }
 }
 
+void MeshForwarder::SetAssignPollPeriod(uint32_t aPeriod)
+{
+    mAssignPollPeriod = aPeriod;
+}
+
+uint32_t MeshForwarder::GetAssignPollPeriod()
+{
+    return mAssignPollPeriod;
+}
+
 void MeshForwarder::SetPollPeriod(uint32_t aPeriod)
 {
-    if (!mNetif.IsUp())
+    if (mPollPeriod != aPeriod)
     {
-        mPollPeriodAssigned = true;
-        mPollPeriod = aPeriod;
-        ExitNow();
+        if (mAssignPollPeriod != 0 && aPeriod != (OPENTHREAD_CONFIG_ATTACH_DATA_POLL_PERIOD))
+        {
+            mPollPeriod = mAssignPollPeriod;
+        }
+        else
+        {
+            mPollPeriod = aPeriod;
+        }
     }
-
-    if (mPollPeriodAssigned && mMac.GetRxOnWhenIdle() == false)
-    {
-        mPollTimer.Start(mPollPeriod);
-        ExitNow();
-    }
-    else if (mMac.GetRxOnWhenIdle() == false && mPollPeriod != aPeriod)
-    {
-        mPollTimer.Start(aPeriod);
-    }
-
-    mPollPeriod = aPeriod;
-
-exit:
-    return;
 }
 
 uint32_t MeshForwarder::GetPollPeriod()

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -133,6 +133,22 @@ public:
     void SetRxOnWhenIdle(bool aRxOnWhenIdle);
 
     /**
+     * This method sets customized Data Poll period. Only for certification test
+     *
+     * @param[in]  aPeriod  The Data Poll period in milliseconds.
+     *
+     */
+    void SetAssignPollPeriod(uint32_t aPeriod);
+
+    /**
+     * This method gets the customized Data Poll period. Only for certification test
+     *
+     * @returns  The Data Poll period in milliseconds.
+     *
+     */
+    uint32_t GetAssignPollPeriod(void);
+
+    /**
      * This method sets the Data Poll period.
      *
      * @param[in]  aPeriod  The Data Poll period in milliseconds.
@@ -217,7 +233,7 @@ private:
     uint16_t mFragTag;
     uint16_t mMessageNextOffset;
     uint32_t mPollPeriod;
-    bool mPollPeriodAssigned;
+    uint32_t mAssignPollPeriod;  ///< only for certification test
     Message *mSendMessage;
 
     Mac::Address mMacSource;


### PR DESCRIPTION
1) pollperiod value (seconds) in cli layer should be converted to milliseconds which is what underlayer uses , vice versa.

2) After device succeed in joining as SED, when SetPollPeriod(kAttachDataPollPeriod) for poll data, kAttachDataPollPeriod would don't have a chance to take effect because following condition would always be satisfied
`  if (mPollPeriodAssigned && mMac.GetRxOnWhenIdle() == false)
    {
        mPollTimer.Start(mPollPeriod);
        ExitNow();
    }
`
3) each SetPollPeriod() have an accompanying SetRxOnWhenIdle(false) in which mPollTimer will be started. So here remove the start operation in SetPollPeriod()

@jwhui , please have a review.