### PR TITLE
Add return codes to Ip6::HandleDatagram.

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -181,7 +181,7 @@ exit:
 
     if (error == kThreadError_None)
     {
-        error = HandleDatagram(message, NULL, messageInfo.mInterfaceId, NULL, false);
+        HandleDatagram(message, NULL, messageInfo.mInterfaceId, NULL, false);
     }
 
     return error;
@@ -320,10 +320,9 @@ void Ip6::ProcessReceiveCallback(Message &aMessage)
     VerifyOrExit(sReceiveIp6DatagramCallback != NULL, ;);
 
     // make a copy of the datagram to pass to host
-    VerifyOrExit((messageCopy = NewMessage(0)) != NULL, ;);
+    VerifyOrExit((messageCopy = NewMessage(0)) != NULL, error = kThreadError_NoBufs);
     SuccessOrExit(error = messageCopy->SetLength(aMessage.GetLength()));
-    VerifyOrExit(aMessage.CopyTo(0, 0, aMessage.GetLength(), *messageCopy) == aMessage.GetLength(),
-                 error = kThreadError_Drop);
+    aMessage.CopyTo(0, 0, aMessage.GetLength(), *messageCopy);
 
     sReceiveIp6DatagramCallback(messageCopy);
 
@@ -338,7 +337,7 @@ exit:
 ThreadError Ip6::HandleDatagram(Message &message, Netif *netif, int8_t interfaceId, const void *linkMessageInfo,
                                 bool fromLocalHost)
 {
-    ThreadError error = kThreadError_Drop;
+    ThreadError error = kThreadError_None;
     MessageInfo messageInfo;
     Header header;
     uint16_t payloadLength;
@@ -354,16 +353,16 @@ ThreadError Ip6::HandleDatagram(Message &message, Netif *netif, int8_t interface
 #endif
 
     // check message length
-    VerifyOrExit(message.GetLength() >= sizeof(header), ;);
+    VerifyOrExit(message.GetLength() >= sizeof(header), error = kThreadError_Drop);
     message.Read(0, sizeof(header), &header);
     payloadLength = header.GetPayloadLength();
 
     // check Version
-    VerifyOrExit(header.IsVersion6(), ;);
+    VerifyOrExit(header.IsVersion6(), error = kThreadError_Drop);
 
     // check Payload Length
     VerifyOrExit(sizeof(header) + payloadLength == message.GetLength() &&
-                 sizeof(header) + payloadLength <= Ip6::kMaxDatagramLength, ;);
+                 sizeof(header) + payloadLength <= Ip6::kMaxDatagramLength, error = kThreadError_Drop);
 
     memset(&messageInfo, 0, sizeof(messageInfo));
     messageInfo.GetPeerAddr() = header.GetSource();
@@ -409,7 +408,7 @@ ThreadError Ip6::HandleDatagram(Message &message, Netif *netif, int8_t interface
 
     // process IPv6 Extension Headers
     nextHeader = header.GetNextHeader();
-    SuccessOrExit(HandleExtensionHeaders(message, nextHeader, receive));
+    SuccessOrExit(error = HandleExtensionHeaders(message, nextHeader, receive));
 
     // process IPv6 Payload
     if (receive)
@@ -419,7 +418,7 @@ ThreadError Ip6::HandleDatagram(Message &message, Netif *netif, int8_t interface
             ProcessReceiveCallback(message);
         }
 
-        SuccessOrExit(HandlePayload(message, messageInfo, nextHeader));
+        SuccessOrExit(error = HandlePayload(message, messageInfo, nextHeader));
     }
 
     if (forward)
@@ -432,24 +431,24 @@ ThreadError Ip6::HandleDatagram(Message &message, Netif *netif, int8_t interface
         if (header.GetHopLimit() == 0)
         {
             // send time exceeded
+            ExitNow(error = kThreadError_Drop);
         }
         else
         {
             hopLimit = header.GetHopLimit();
             message.Write(Header::GetHopLimitOffset(), Header::GetHopLimitSize(), &hopLimit);
-            SuccessOrExit(ForwardMessage(message, messageInfo));
-            ExitNow(error = kThreadError_None);
+            SuccessOrExit(error = ForwardMessage(message, messageInfo));
         }
     }
 
 exit:
 
-    if (error == kThreadError_Drop)
+    if (error != kThreadError_None || !forward)
     {
         Message::Free(message);
     }
 
-    return kThreadError_None;
+    return error;
 }
 
 ThreadError ForwardMessage(Message &message, MessageInfo &messageInfo)

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -514,7 +514,7 @@ void NcpBase::UpdateChangedProps(void)
                 SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
                 SPINEL_PROP_IPV6_LL_ADDR
             );
-	}
+        }
         else if ((mChangedFlags & OT_IP6_ML_ADDR_CHANGED) != 0)
         {
             SuccessOrExit(HandleCommandPropertyGet(
@@ -927,7 +927,7 @@ ThreadError NcpBase::CommandHandler_NOOP(uint8_t header, unsigned int command, c
 ThreadError NcpBase::CommandHandler_RESET(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
                                           uint16_t arg_len)
 {
-	// We aren't using any of the arguments to this function.
+    // We aren't using any of the arguments to this function.
     (void)header;
     (void)command;
     (void)arg_ptr;
@@ -985,7 +985,7 @@ ThreadError NcpBase::CommandHandler_PROP_VALUE_SET(uint8_t header, unsigned int 
     if (parsedLength == arg_len)
     {
         errorCode = HandleCommandPropertySet(header, static_cast<spinel_prop_key_t>(propKey), value_ptr,
-					     static_cast<uint16_t>(value_len));
+                                             static_cast<uint16_t>(value_len));
     }
     else
     {
@@ -1011,7 +1011,7 @@ ThreadError NcpBase::CommandHandler_PROP_VALUE_INSERT(uint8_t header, unsigned i
     if (parsedLength == arg_len)
     {
         errorCode = HandleCommandPropertyInsert(header, static_cast<spinel_prop_key_t>(propKey), value_ptr,
-						static_cast<uint16_t>(value_len));
+                                                static_cast<uint16_t>(value_len));
     }
     else
     {
@@ -1037,7 +1037,7 @@ ThreadError NcpBase::CommandHandler_PROP_VALUE_REMOVE(uint8_t header, unsigned i
     if (parsedLength == arg_len)
     {
         errorCode = HandleCommandPropertyRemove(header, static_cast<spinel_prop_key_t>(propKey), value_ptr,
-						static_cast<uint16_t>(value_len));
+                                                static_cast<uint16_t>(value_len));
     }
     else
     {
@@ -2656,6 +2656,10 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_NET_INSECURE(uint8_t header, spin
     {
         errorCode = otSendIp6Datagram(message);
     }
+    else if (message)
+    {
+        Message::Free(*message);
+    }
 
     if (errorCode == kThreadError_None)
     {
@@ -2668,11 +2672,6 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_NET_INSECURE(uint8_t header, spin
     }
     else
     {
-        if (message)
-        {
-            Message::Free(*message);
-        }
-
         errorCode = SendLastStatus(header, ThreadErrorToSpinelStatus(errorCode));
     }
 
@@ -2724,6 +2723,10 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_k
     {
         errorCode = otSendIp6Datagram(message);
     }
+    else if (message)
+    {
+        Message::Free(*message);
+    }
 
     if (errorCode == kThreadError_None)
     {
@@ -2736,11 +2739,6 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_k
     }
     else
     {
-        if (message)
-        {
-            Message::Free(*message);
-        }
-
         errorCode = SendLastStatus(header, ThreadErrorToSpinelStatus(errorCode));
     }
 


### PR DESCRIPTION
This change provides feedback to the client when something fails in `Ip6::HandleDatagram` and equivalently `otSendIp6Datagram`.  When operating in NCP mode, the error code will also be passed back via spinel.