### PR TITLE
Provide an API to retrieve the list of on-mesh prefixes.

### DIFF
--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -380,6 +380,10 @@ typedef struct otIp6Prefix
     uint8_t       mLength;  ///< The IPv6 prefix length.
 } otIp6Prefix;
 
+#define OT_NETWORK_DATA_ITERATOR_INIT  0  ///< Initializeer for otNetworkDataIterator.
+
+typedef uint8_t otNetworkDataIterator;  ///< Used to iterate through Network Data information.
+
 /**
  * This structure represents a Border Router configuration.
  */

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -499,6 +499,19 @@ const char *otGetNetworkName(void);
 ThreadError otSetNetworkName(const char *aNetworkName);
 
 /**
+ * This function gets the next On Mesh Prefix in the Network Data.
+ *
+ * @param[in]     aLocal     TRUE to retrieve from the local Network Data, FALSE for partition's Network Data
+ * @param[inout]  aIterator  A pointer to the Network Data iterator context.
+ * @param[out]    aConfig    A pointer to where the On Mesh Prefix information will be placed.
+ *
+ * @retval kThreadError_None      Successfully found the next On Mesh prefix.
+ * @retval kThreadError_NotFound  No subsequent On Mesh prefix exists in the Thread Network Data.
+ *
+ */
+ThreadError otGetNextOnMeshPrefix(bool aLocal, otNetworkDataIterator *aIterator, otBorderRouterConfig *aConfig);
+
+/**
  * Get the IEEE 802.15.4 PAN ID.
  *
  * @returns The IEEE 802.15.4 PAN ID.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1176,13 +1176,83 @@ exit:
     return error;
 }
 
+ThreadError Interpreter::ProcessPrefixList(void)
+{
+    otNetworkDataIterator iterator = OT_NETWORK_DATA_ITERATOR_INIT;
+    otBorderRouterConfig config;
+
+    while (otGetNextOnMeshPrefix(true, &iterator, &config) == kThreadError_None)
+    {
+        sServer->OutputFormat("%x:%x:%x:%x::/%d ",
+                              HostSwap16(config.mPrefix.mPrefix.mFields.m16[0]),
+                              HostSwap16(config.mPrefix.mPrefix.mFields.m16[1]),
+                              HostSwap16(config.mPrefix.mPrefix.mFields.m16[2]),
+                              HostSwap16(config.mPrefix.mPrefix.mFields.m16[3]),
+                              config.mPrefix.mLength);
+
+        if (config.mPreferred)
+        {
+            sServer->OutputFormat("p");
+        }
+
+        if (config.mSlaac)
+        {
+            sServer->OutputFormat("a");
+        }
+
+        if (config.mDhcp)
+        {
+            sServer->OutputFormat("d");
+        }
+
+        if (config.mConfigure)
+        {
+            sServer->OutputFormat("c");
+        }
+
+        if (config.mDefaultRoute)
+        {
+            sServer->OutputFormat("r");
+        }
+
+        if (config.mOnMesh)
+        {
+            sServer->OutputFormat("o");
+        }
+
+        if (config.mStable)
+        {
+            sServer->OutputFormat("s");
+        }
+
+        switch (config.mPreference)
+        {
+        case -1:
+            sServer->OutputFormat(" low\r\n");
+            break;
+
+        case 0:
+            sServer->OutputFormat(" med\r\n");
+            break;
+
+        case 1:
+            sServer->OutputFormat(" high\r\n");
+            break;
+        }
+    }
+
+    return kThreadError_None;
+}
+
 void Interpreter::ProcessPrefix(int argc, char *argv[])
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
-
-    if (strcmp(argv[0], "add") == 0)
+    if (argc == 0)
+    {
+        SuccessOrExit(error = ProcessPrefixList());
+    }
+    else if (strcmp(argv[0], "add") == 0)
     {
         SuccessOrExit(error = ProcessPrefixAdd(argc - 1, argv + 1));
     }

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -162,6 +162,7 @@ private:
     static void ProcessPrefix(int argc, char *argv[]);
     static ThreadError ProcessPrefixAdd(int argc, char *argv[]);
     static ThreadError ProcessPrefixRemove(int argc, char *argv[]);
+    static ThreadError ProcessPrefixList(void);
     static void ProcessReleaseRouterId(int argc, char *argv[]);
     static void ProcessReset(int argc, char *argv[]);
     static void ProcessRoute(int argc, char *argv[]);

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -348,6 +348,25 @@ ThreadError otRemoveBorderRouter(const otIp6Prefix *aPrefix)
     return sThreadNetif->GetNetworkDataLocal().RemoveOnMeshPrefix(aPrefix->mPrefix.mFields.m8, aPrefix->mLength);
 }
 
+ThreadError otGetNextOnMeshPrefix(bool aLocal, otNetworkDataIterator *aIterator, otBorderRouterConfig *aConfig)
+{
+    ThreadError error = kThreadError_None;
+
+    VerifyOrExit(aIterator && aConfig, error = kThreadError_InvalidArgs);
+
+    if (aLocal)
+    {
+        error = sThreadNetif->GetNetworkDataLocal().GetNextOnMeshPrefix(aIterator, aConfig);
+    }
+    else
+    {
+        error = sThreadNetif->GetNetworkDataLeader().GetNextOnMeshPrefix(aIterator, aConfig);
+    }
+
+exit:
+    return error;
+}
+
 ThreadError otAddExternalRoute(const otExternalRouteConfig *aConfig)
 {
     return sThreadNetif->GetNetworkDataLocal().AddHasRoutePrefix(aConfig->mPrefix.mPrefix.mFields.m8,

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -103,6 +103,18 @@ public:
      */
     void GetNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLength);
 
+    /**
+     * This method provides the next On Mesh prefix in the Thread Network Data.
+     *
+     * @param[out]  aIterator  A pointer to the Network Data iterator context.
+     * @param[out]  aConfig    A pointer to where the On Mesh Prefix information will be placed.
+     *
+     * @retval kThreadError_None      Successfully found the next On Mesh prefix.
+     * @retval kThreadError_NotFound  No subsequent On Mesh prefix exists in the Thread Network Data.
+     *
+     */
+    ThreadError GetNextOnMeshPrefix(otNetworkDataIterator *aIterator, otBorderRouterConfig *aConfig);
+
 protected:
     /**
      * This method returns a pointer to the Border Router TLV within a given Prefix TLV.


### PR DESCRIPTION
Resolves #388.

Will add the corresponding API for external routes in a separate PR.