### PR TITLE
Ncp: Ensure to always send the "end of scan" indicator spinel message

### DIFF
--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -397,6 +397,8 @@ private:
 
     uint32_t mChangedFlags;
 
+    bool mShouldSignalEndOfScan;
+
     spinel_tid_t mDroppedReplyTid;
 
     uint16_t mDroppedReplyTidBitSet;


### PR DESCRIPTION
This commit changes the way we send out the "end of scan" indicator message to ensure that it is always sent out and not dropped. If there is no buffer space available when scan finishes, we remember and send it out when buffer space becomes available later.