### PR TITLE
Ncp: Clear the "prop changed flags" after successful message sent.

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -514,19 +514,19 @@ void NcpBase::UpdateChangedProps(void)
     {
         if ((mChangedFlags & NCP_PLAT_RESET_REASON) != 0)
         {
-            mChangedFlags &= ~static_cast<uint32_t>(NCP_PLAT_RESET_REASON);
-            SendLastStatus(
+            SuccessOrExit(SendLastStatus(
                 SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
                 ResetReasonToSpinelStatus(otPlatGetResetReason())
-            );
+            ));
+            mChangedFlags &= ~static_cast<uint32_t>(NCP_PLAT_RESET_REASON);
         }
         else if ((mChangedFlags & OT_IP6_LL_ADDR_CHANGED) != 0)
         {
-            mChangedFlags &= ~static_cast<uint32_t>(OT_IP6_LL_ADDR_CHANGED);
-            HandleCommandPropertyGet(
+            SuccessOrExit(HandleCommandPropertyGet(
                 SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
                 SPINEL_PROP_IPV6_LL_ADDR
-            );
+            ));
+            mChangedFlags &= ~static_cast<uint32_t>(OT_IP6_LL_ADDR_CHANGED);
         }
         else if ((mChangedFlags & OT_IP6_ML_ADDR_CHANGED) != 0)
         {


### PR DESCRIPTION
This commit updates how the `mChangedFlags` (which keeps track of properties which are changed) is cleared for `RESET_REASON` and `IP6_LL_ADDR` to ensure that the notification message is successfully queued/sent before clearing the flag.