### PR TITLE
cli: route fix

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1336,8 +1336,7 @@ ThreadError Interpreter::ProcessRouteAdd(int argc, char *argv[])
         {
             config.mStable = true;
         }
-
-        if (strcmp(argv[argcur], "high") == 0)
+        else if (strcmp(argv[argcur], "high") == 0)
         {
             config.mPreference = 1;
         }


### PR DESCRIPTION
external route could not be successfully added if there is 's' - will exit with error = kThreadError_Parse

@jwhui please have a review