### PR TITLE
bugs and enhancements

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -942,14 +942,9 @@ void Mle::HandleNetifStateChanged(uint32_t aFlags)
         mNetif.SetStateChangedFlags(OT_IP6_ML_ADDR_CHANGED);
     }
 
-    switch (mDeviceState)
+    if (mDeviceState == kDeviceStateChild && (mDeviceMode & ModeTlv::kModeFFD) == 0)
     {
-    case kDeviceStateChild:
         SendChildUpdateRequest();
-        break;
-
-    default:
-        break;
     }
 
 exit:
@@ -2385,6 +2380,10 @@ void Mle::HandleNetworkDataUpdate(void)
     if (mDeviceMode & ModeTlv::kModeFFD)
     {
         mMleRouter.HandleNetworkDataUpdateRouter();
+    }
+    else
+    {
+        SendChildUpdateRequest();
     }
 }
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1987,8 +1987,12 @@ ThreadError MleRouter::HandleDataRequest(const Message &aMessage, const Ip6::Mes
     VerifyOrExit(tlvRequest.IsValid() && tlvRequest.GetLength() <= sizeof(tlvs), error = kThreadError_Parse);
 
     // Active Timestamp
-    SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp));
-    VerifyOrExit(activeTimestamp.IsValid(), error = kThreadError_Parse);
+    activeTimestamp.SetLength(0);
+
+    if (Tlv::GetTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp) == kThreadError_None)
+    {
+        VerifyOrExit(activeTimestamp.IsValid(), error = kThreadError_Parse);
+    }
 
     // Pending Timestamp
     pendingTimestamp.SetLength(0);
@@ -2002,7 +2006,8 @@ ThreadError MleRouter::HandleDataRequest(const Message &aMessage, const Ip6::Mes
     memcpy(tlvs, tlvRequest.GetTlvs(), tlvRequest.GetLength());
     numTlvs = tlvRequest.GetLength();
 
-    if (mNetif.GetActiveDataset().GetNetwork().GetTimestamp().Compare(activeTimestamp) != 0)
+    if (activeTimestamp.GetLength() == 0 ||
+        mNetif.GetActiveDataset().GetNetwork().GetTimestamp().Compare(activeTimestamp) != 0)
     {
         tlvs[numTlvs++] = Tlv::kActiveDataset;
     }


### PR DESCRIPTION
1) Only RFD should SendChildUpdateRequest due to address update
2) Restore SendChildUpdateRequest() when HandleNetworkDataUpdate() for RFD
   as a feedback that their network data has been synced (in case network data
   update wouldn't cause address update
3) ActiveTimestamp might be optional in Data Request

@jwhui , please help to review it.