### PR TITLE
Do not allow enabling Thread protocols when PAN ID is set to broadcast.

### DIFF
--- a/examples/apps/cli/README.md
+++ b/examples/apps/cli/README.md
@@ -23,6 +23,12 @@ $ cd <path-to-openthread>/output/<platform>/bin
 $ ./ot-cli 1
 ```
 
+Set the PAN ID:
+
+```bash
+> panid 0x1234
+```
+
 Bring up the IPv6 interface:
 
 ```bash
@@ -63,6 +69,12 @@ Spawn the process:
 ```bash
 $ cd <path-to-openthread>/output/<platform>/bin
 $ ./ot-cli 2
+```
+
+Set the PAN ID:
+
+```bash
+> panid 0x1234
 ```
 
 Bring up the IPv6 interface:


### PR DESCRIPTION
This change simply disallows:

1. Starting Thread protocol operation via `otThreadStart()` when the PAN ID is set to broadcast.
2. Setting the PAN ID to broadcast via `otSetPanId()` when MLE is not in the disabled state.

Resolves #56.