### PR TITLE
Make client responsible for configuring IPv6 addresses.

### DIFF
--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -343,18 +343,19 @@ typedef struct otLinkModeConfig
  */
 enum
 {
-    OT_IP6_ADDRESS_ADDED    = 1 << 0,  ///< IPv6 address was added
-    OT_IP6_ADDRESS_REMOVED  = 1 << 1,  ///< IPv6 address was removed
+    OT_IP6_ADDRESS_ADDED      = 1 << 0,  ///< IPv6 address was added
+    OT_IP6_ADDRESS_REMOVED    = 1 << 1,  ///< IPv6 address was removed
 
-    OT_NET_ROLE             = 1 << 3,  ///< Device role (disabled, detached, child, router, leader) changed
-    OT_NET_PARTITION_ID     = 1 << 4,  ///< Partition ID changed
-    OT_NET_KEY_SEQUENCE     = 1 << 5,  ///< Thread Key Sequence changed
+    OT_NET_ROLE               = 1 << 3,  ///< Device role (disabled, detached, child, router, leader) changed
+    OT_NET_PARTITION_ID       = 1 << 4,  ///< Partition ID changed
+    OT_NET_KEY_SEQUENCE       = 1 << 5,  ///< Thread Key Sequence changed
 
-    OT_THREAD_CHILD_ADDED   = 1 << 6,  ///< Child was added
-    OT_THREAD_CHILD_REMOVED = 1 << 7,  ///< Child was removed
+    OT_THREAD_CHILD_ADDED     = 1 << 6,  ///< Child was added
+    OT_THREAD_CHILD_REMOVED   = 1 << 7,  ///< Child was removed
+    OT_THREAD_NETDATA_UPDATED = 1 << 8,  ///< Thread Network Data updated
 
-    OT_IP6_LL_ADDR_CHANGED  = 1 << 8,  ///< The link-local address has changed
-    OT_IP6_ML_ADDR_CHANGED  = 1 << 9,  ///< The mesh-local address has changed
+    OT_IP6_LL_ADDR_CHANGED    = 1 << 9,  ///< The link-local address has changed
+    OT_IP6_ML_ADDR_CHANGED    = 1 << 10, ///< The mesh-local address has changed
 };
 
 /**

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -1642,6 +1642,17 @@ bool otIsIcmpEchoEnabled(void);
 void otSetIcmpEchoEnabled(bool aEnabled);
 
 /**
+ * This function returns the prefix match length (bits) for two IPv6 addresses.
+ *
+ * @param[in]  aFirst   A pointer to the first IPv6 address.
+ * @param[in]  aSecond  A pointer to the second IPv6 address.
+ *
+ * @returns  The prefix match length in bits.
+ *
+ */
+uint8_t otIp6PrefixMatch(const otIp6Address *aFirst, const otIp6Address *aSecond);
+
+/**
  * @}
  *
  */

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -185,6 +185,7 @@ private:
     static void HandleEchoResponse(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     static void HandlePingTimer(void *aContext);
     static void HandleActiveScanResult(otActiveScanResult *aResult);
+    static void HandleNetifStateChanged(uint32_t aFlags, void *aContext);
 
     static const struct Command sCommands[];
     static otNetifAddress sAddress;

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -1073,6 +1073,18 @@ void otSetIcmpEchoEnabled(bool aEnabled)
     Ip6::Icmp::SetEchoEnabled(aEnabled);
 }
 
+uint8_t otIp6PrefixMatch(const otIp6Address *aFirst, const otIp6Address *aSecond)
+{
+    uint8_t rval;
+
+    VerifyOrExit(aFirst != NULL && aSecond != NULL, rval = 0);
+
+    rval = static_cast<const Ip6::Address *>(aFirst)->PrefixMatch(*static_cast<const Ip6::Address *>(aSecond));
+
+exit:
+    return rval;
+}
+
 ThreadError otGetActiveDataset(otOperationalDataset *aDataset)
 {
     ThreadError error = kThreadError_None;

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -63,7 +63,6 @@ Leader::Leader(ThreadNetif &aThreadNetif):
 
 void Leader::Reset(void)
 {
-    memset(mAddresses, 0, sizeof(mAddresses));
     memset(mContextLastUsed, 0, sizeof(mContextLastUsed));
     mVersion = static_cast<uint8_t>(otPlatRandomGet());
     mStableVersion = static_cast<uint8_t>(otPlatRandomGet());
@@ -210,97 +209,6 @@ ThreadError Leader::GetContext(uint8_t aContextId, Lowpan::Context &aContext)
 
 exit:
     return error;
-}
-
-ThreadError Leader::ConfigureAddresses(void)
-{
-    PrefixTlv *prefix;
-
-    // clear out addresses that are not on-mesh
-    for (size_t i = 0; i < sizeof(mAddresses) / sizeof(mAddresses[0]); i++)
-    {
-        if (mAddresses[i].mValidLifetime == 0 ||
-            IsOnMesh(mAddresses[i].GetAddress()))
-        {
-            continue;
-        }
-
-        mNetif.RemoveUnicastAddress(mAddresses[i]);
-        mAddresses[i].mValidLifetime = 0;
-    }
-
-    // configure on-mesh addresses
-    for (NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs);
-         cur < reinterpret_cast<NetworkDataTlv *>(mTlvs + mLength);
-         cur = cur->GetNext())
-    {
-        if (cur->GetType() != NetworkDataTlv::kTypePrefix)
-        {
-            continue;
-        }
-
-        prefix = reinterpret_cast<PrefixTlv *>(cur);
-        ConfigureAddress(*prefix);
-    }
-
-    return kThreadError_None;
-}
-
-ThreadError Leader::ConfigureAddress(PrefixTlv &aPrefix)
-{
-    BorderRouterTlv *borderRouter;
-    BorderRouterEntry *entry;
-
-    // look for Border Router TLV
-    if ((borderRouter = FindBorderRouter(aPrefix)) == NULL)
-    {
-        ExitNow();
-    }
-
-    // check if SLAAC flag is set
-    if ((entry = borderRouter->GetEntry(0)) == NULL ||
-        entry->IsSlaac() == false)
-    {
-        ExitNow();
-    }
-
-    // check if address is already added for this prefix
-    for (size_t i = 0; i < sizeof(mAddresses) / sizeof(mAddresses[0]); i++)
-    {
-        if (mAddresses[i].mValidLifetime != 0 &&
-            mAddresses[i].mPrefixLength == aPrefix.GetPrefixLength() &&
-            PrefixMatch(mAddresses[i].mAddress.mFields.m8, aPrefix.GetPrefix(), aPrefix.GetPrefixLength()) >= 0)
-        {
-            mAddresses[i].mPreferredLifetime = entry->IsPreferred() ? 0xffffffff : 0;
-            ExitNow();
-        }
-    }
-
-    // configure address for this prefix
-    for (size_t i = 0; i < sizeof(mAddresses) / sizeof(mAddresses[0]); i++)
-    {
-        if (mAddresses[i].mValidLifetime != 0)
-        {
-            continue;
-        }
-
-        memset(&mAddresses[i], 0, sizeof(mAddresses[i]));
-        memcpy(mAddresses[i].mAddress.mFields.m8, aPrefix.GetPrefix(), BitVectorBytes(aPrefix.GetPrefixLength()));
-
-        for (size_t j = 8; j < sizeof(mAddresses[i].mAddress); j++)
-        {
-            mAddresses[i].mAddress.mFields.m8[j] = static_cast<uint8_t>(otPlatRandomGet());
-        }
-
-        mAddresses[i].mPrefixLength = aPrefix.GetPrefixLength();
-        mAddresses[i].mPreferredLifetime = entry->IsPreferred() ? 0xffffffff : 0;
-        mAddresses[i].mValidLifetime = 0xffffffff;
-        mNetif.AddUnicastAddress(mAddresses[i]);
-        break;
-    }
-
-exit:
-    return kThreadError_None;
 }
 
 bool Leader::IsOnMesh(const Ip6::Address &aAddress)
@@ -527,8 +435,8 @@ void Leader::SetNetworkData(uint8_t aVersion, uint8_t aStableVersion, bool aStab
 
     otDumpDebgNetData("set network data", mTlvs, mLength);
 
-    ConfigureAddresses();
     mMle.HandleNetworkDataUpdate();
+    mNetif.SetStateChangedFlags(OT_THREAD_NETDATA_UPDATED);
 }
 
 void Leader::RemoveBorderRouter(uint16_t aRloc16)
@@ -546,11 +454,10 @@ void Leader::RemoveBorderRouter(uint16_t aRloc16)
         {
             mStableVersion++;
         }
-
-        ConfigureAddresses();
     }
 
     mMle.HandleNetworkDataUpdate();
+    mNetif.SetStateChangedFlags(OT_THREAD_NETDATA_UPDATED);
 }
 
 void Leader::HandleServerData(void *aContext, Coap::Header &aHeader, Message &aMessage,
@@ -785,8 +692,8 @@ ThreadError Leader::RegisterNetworkData(uint16_t aRloc16, uint8_t *aTlvs, uint8_
         }
     }
 
-    ConfigureAddresses();
     mMle.HandleNetworkDataUpdate();
+    mNetif.SetStateChangedFlags(OT_THREAD_NETDATA_UPDATED);
 
 exit:
     return error;

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -263,8 +263,6 @@ private:
     uint32_t mContextIdReuseDelay;
     Timer mTimer;
 
-    Ip6::NetifUnicastAddress mAddresses[4];
-
     Coap::Resource  mServerData;
     uint8_t         mStableVersion;
     uint8_t         mVersion;


### PR DESCRIPTION
* OpenThread no longer automatically configures IPv6 addresses based on network data.
* Added IPv6 address configuration to CLI to support certification tests.
* Added notification to indicate when the Thread Network Data is updated.
* Added otIp6PrefixMatch API to compute prefix match.

Resolves #381.