### PR TITLE
NcpBase: Check for and clear `NETDATA_UPDATED` flag in the `UpdateChangedProps()

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -612,6 +612,12 @@ void NcpBase::UpdateChangedProps(void)
             //));
             mChangedFlags &= ~static_cast<uint32_t>(OT_THREAD_CHILD_ADDED | OT_THREAD_CHILD_REMOVED);
         }
+        else if ((mChangedFlags & OT_THREAD_NETDATA_UPDATED) != 0)
+        {
+            // TODO: Handle the netdata changed event.
+
+            mChangedFlags &= ~static_cast<uint32_t>(OT_THREAD_NETDATA_UPDATED);
+        }
     }
 
 exit:


### PR DESCRIPTION
This commit changes the `UpdateChangedProps()` in `NcpBase` to check for and clear the `OT_THREAD_NETDATA_UPDATED` flag.  