### PR TITLE
Implement settings API, add flash API and implement posix and CC2538 flash driver

### DIFF
--- a/examples/platforms/cc2538/Makefile.am
+++ b/examples/platforms/cc2538/Makefile.am
@@ -43,6 +43,7 @@ libopenthread_cc2538_a_SOURCES            = \
     radio.c                                 \
     random.c                                \
     uart.c                                  \
+    flash.c                                 \
     startup-gcc.c                           \
     $(NULL)
 
@@ -55,6 +56,7 @@ endif
 noinst_HEADERS                            = \
     cc2538-reg.h                            \
     platform-cc2538.h                       \
+    rom-utility.h                           \
     $(NULL)
 
 if OPENTHREAD_BUILD_COVERAGE

--- a/examples/platforms/cc2538/cc2538-reg.h
+++ b/examples/platforms/cc2538/cc2538-reg.h
@@ -167,4 +167,8 @@
 #define UART_IM_RXIM                          0x00000010  // UART receive interrupt mask
 #define UART_IM_RTIM                          0x00000040  // UART receive time-out interrupt 
 
+#define FLASH_BASE                            0x00200000
+#define FLASH_CTRL_FCTL                       0x400D3008  // Flash control
+#define FLASH_CTRL_DIECFG0                    0x400D3014  // Flash information
+
 #endif

--- a/examples/platforms/cc2538/flash.c
+++ b/examples/platforms/cc2538/flash.c
@@ -1,0 +1,205 @@
+/*
+ *  Copyright (c) 2016, Nest Labs, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <openthread-config.h>
+#include <platform/flash.h>
+
+#include <common/code_utils.hpp>
+#include "platform-cc2538.h"
+#include "rom-utility.h"
+
+#define FLASH_CTRL_FCTL_BUSY   0x00000080
+
+enum
+{
+    FLASH_PAGE_SIZE = 0x800,
+};
+
+static ThreadError romStatusToThread(int32_t aStatus)
+{
+    ThreadError error = kThreadError_None;
+
+    switch (aStatus)
+    {
+    case 0:
+        error = kThreadError_None;
+        break;
+
+    case -1:
+        error = kThreadError_Failed;
+        break;
+
+    case -2:
+        error = kThreadError_InvalidArgs;
+        break;
+
+    default:
+        error = kThreadError_Abort;
+    }
+
+    return error;
+}
+
+static ThreadError erasePage(uint32_t aAddress)
+{
+    ThreadError error = kThreadError_None;
+    int32_t status;
+    uint32_t busy = 1;
+
+    status = ROM_PageErase(aAddress, FLASH_PAGE_SIZE);
+    error = romStatusToThread(status);
+
+    while (busy)
+    {
+        busy = HWREG(FLASH_CTRL_FCTL) & FLASH_CTRL_FCTL_BUSY;
+    }
+
+    return error;
+}
+
+ThreadError otPlatFlashInit(void)
+{
+    return kThreadError_None;
+}
+
+ThreadError otPlatFlashDisable(void)
+{
+    return kThreadError_None;
+}
+
+uint32_t otPlatFlashGetBaseAddress(void)
+{
+    return FLASH_BASE;
+}
+
+uint32_t otPlatFlashGetSize(void)
+{
+    uint32_t reg;
+    uint32_t size;
+
+    reg = (HWREG(FLASH_CTRL_DIECFG0) & 0x00000070) >> 4;
+    size = reg ? (128 * reg) : 64;
+
+    return size;
+}
+
+uint32_t otPlatFlashGetPageSize(void)
+{
+    return FLASH_PAGE_SIZE;
+}
+
+ThreadError otPlatFlashErasePage(uint32_t aAddress, uint32_t aSize)
+{
+    ThreadError error = kThreadError_None;
+    uint16_t pageNum;
+    uint16_t index;
+
+    VerifyOrExit(aAddress >= FLASH_BASE, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aAddress < (FLASH_BASE + otPlatFlashGetSize() * 1024), error = kThreadError_InvalidArgs);
+    VerifyOrExit(!(aAddress & (FLASH_PAGE_SIZE - 1)), error = kThreadError_InvalidArgs);
+
+    pageNum = (uint16_t)(aSize / FLASH_PAGE_SIZE);
+
+    if (pageNum > (otPlatFlashGetSize() * 1024 / FLASH_PAGE_SIZE))
+    {
+        pageNum = otPlatFlashGetSize() * 1024 / FLASH_PAGE_SIZE;
+    }
+
+    for (index = 0; index < pageNum; index++)
+    {
+        SuccessOrExit(error = erasePage(aAddress + FLASH_PAGE_SIZE * index));
+    }
+
+exit:
+    return error;
+}
+
+uint32_t otPlatFlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
+{
+    ThreadError error = kThreadError_None;
+    int32_t status;
+    uint32_t busy = 1;
+    uint32_t * data;
+    uint32_t size = 0;
+
+    VerifyOrExit(aAddress >= FLASH_BASE, error = kThreadError_InvalidArgs);
+    VerifyOrExit((aAddress + aSize) < (FLASH_BASE + otPlatFlashGetSize() * 1024), error = kThreadError_InvalidArgs);
+    VerifyOrExit(!(aAddress & 3), error = kThreadError_InvalidArgs);
+    VerifyOrExit(!(aSize & 3), error = kThreadError_InvalidArgs);
+
+    data = (uint32_t *)(aData);
+
+    while (size < aSize)
+    {
+        status = ROM_ProgramFlash(data, aAddress, 4);
+
+        while (busy)
+        {
+            busy = HWREG(FLASH_CTRL_FCTL) & FLASH_CTRL_FCTL_BUSY;
+        }
+
+        SuccessOrExit(error = romStatusToThread(status));
+        size += 4;
+        data++;
+        aAddress += 4;
+    }
+
+exit:
+    return size;
+}
+
+uint32_t otPlatFlashRead(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
+{
+    uint32_t size = 0;
+    uint32_t reg = 0;
+    uint8_t index;
+    uint8_t *byte;
+
+    while (size < (aSize / 4))
+    {
+        reg = HWREG(aAddress);
+        byte = (uint8_t *)&reg;
+
+        for (index = 0; index < 4; index++, byte++, aData++)
+        {
+            *aData = *byte;
+        }
+
+        size += 1;
+        aAddress += 4;
+    }
+
+    size *= 4;
+
+    return size;
+}

--- a/examples/platforms/cc2538/flash.c
+++ b/examples/platforms/cc2538/flash.c
@@ -149,7 +149,7 @@ uint32_t otPlatFlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
     ThreadError error = kThreadError_None;
     int32_t status;
     uint32_t busy = 1;
-    uint32_t * data;
+    uint32_t *data;
     uint32_t size = 0;
 
     VerifyOrExit(aAddress >= FLASH_BASE, error = kThreadError_InvalidArgs);

--- a/examples/platforms/cc2538/rom-utility.h
+++ b/examples/platforms/cc2538/rom-utility.h
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2016, Nest Labs, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ROM_UTILITY_H_
+#define ROM_UTILITY_H_
+
+#define ROM_API_TABLE_ADDR 0x00000048
+
+typedef uint32_t (* volatile FPTR_CRC32_T)(uint8_t * /*pData*/, uint32_t /*byteCount*/);
+typedef uint32_t (* volatile FPTR_GETFLSIZE_T)(void);
+typedef uint32_t (* volatile FPTR_GETCHIPID_T)(void);
+typedef int32_t (* volatile FPTR_PAGEERASE_T)(uint32_t /*FlashAddr*/, uint32_t /*Size*/);
+typedef int32_t (* volatile FPTR_PROGFLASH_T)(uint32_t * /*pRamData*/, uint32_t /*FlashAdr*/, uint32_t /*ByteCount*/);
+typedef void (* volatile FPTR_RESETDEV_T)(void);
+typedef void *(* volatile FPTR_MEMSET_T)(void * /*s*/, int32_t /*c*/, uint32_t /*n*/);
+typedef void *(* volatile FPTR_MEMCPY_T)(void * /*s1*/, const void * /*s2*/, uint32_t /*n*/);
+typedef int32_t (* volatile FPTR_MEMCMP_T)(const void * /*s1*/, const void * /*s2*/, uint32_t /*n*/);
+typedef void *(* volatile FPTR_MEMMOVE_T)(void * /*s1*/, const void * /*s2*/, uint32_t /*n*/);
+
+typedef struct
+{
+    FPTR_CRC32_T        Crc32;
+    FPTR_GETFLSIZE_T    GetFlashSize;
+    FPTR_GETCHIPID_T    GetChipId;
+    FPTR_PAGEERASE_T    PageErase;
+    FPTR_PROGFLASH_T    ProgramFlash;
+    FPTR_RESETDEV_T     ResetDevice;
+    FPTR_MEMSET_T       memset;
+    FPTR_MEMCPY_T       memcpy;
+    FPTR_MEMCMP_T       memcmp;
+    FPTR_MEMMOVE_T      memmove;
+} ROM_API_T;
+
+#define P_ROM_API              ((ROM_API_T*) ROM_API_TABLE_ADDR)
+
+#define ROM_Crc32(a,b)          P_ROM_API->Crc32(a,b)
+#define ROM_GetFlashSize()      P_ROM_API->GetFlashSize()
+#define ROM_GetChipId()         P_ROM_API->GetChipId()
+#define ROM_PageErase(a,b)      P_ROM_API->PageErase(a,b)
+#define ROM_ProgramFlash(a,b,c) P_ROM_API->ProgramFlash(a,b,c)
+#define ROM_ResetDevice()       P_ROM_API->ResetDevice()
+#define ROM_Memset(a,b,c)       P_ROM_API->memset(a,b,c)
+#define ROM_Memcpy(a,b,c)       P_ROM_API->memcpy(a,b,c)
+#define ROM_Memcmp(a,b,c)       P_ROM_API->memcmp(a,b,c)
+#define ROM_Memmove(a,b,c)      P_ROM_API->memmove(a,b,c)
+
+#endif  // ROM_UTILITY_H_

--- a/examples/platforms/posix/Makefile.am
+++ b/examples/platforms/posix/Makefile.am
@@ -44,6 +44,7 @@ libopenthread_posix_a_SOURCES             = \
     radio.c                                 \
     random.c                                \
     uart.c                                  \
+    flash.c                                 \
     $(NULL)
 
 if OPENTHREAD_ENABLE_DIAG

--- a/examples/platforms/posix/flash.c
+++ b/examples/platforms/posix/flash.c
@@ -71,7 +71,7 @@ ThreadError otPlatFlashInit(void)
     ThreadError error = kThreadError_None;
 
     sFlashFd = open("OT_Flash", O_RDWR | O_CREAT, 0666);
-    ftruncate(sFlashFd, 0);
+    VerifyOrExit(ftruncate(sFlashFd, 0) == 0, error = kThreadError_Failed);
     lseek(sFlashFd, 0, SEEK_SET);
 
     VerifyOrExit(sFlashFd >= 0, error = kThreadError_Failed);

--- a/examples/platforms/posix/flash.c
+++ b/examples/platforms/posix/flash.c
@@ -1,0 +1,154 @@
+/*
+ *  Copyright (c) 2016, Nest Labs, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <openthread-config.h>
+#include <platform/flash.h>
+
+#include <common/code_utils.hpp>
+#include "platform-posix.h"
+
+static int sFlashFd;
+
+enum
+{
+    FLASH_SIZE = 0x100000,
+    FLASH_BASE_ADDRESS = 0x200000,
+    FLASH_PAGE_SIZE = 0x800,
+    FLASH_PAGE_NUM = 512,
+};
+
+static ThreadError erasePage(uint32_t aOffset)
+{
+    ThreadError error = kThreadError_Failed;
+    uint8_t buf = 0xff;
+    uint16_t size;
+
+    VerifyOrExit(sFlashFd >= 0, ;);
+
+    for (size = 0; size < FLASH_PAGE_SIZE; size++)
+    {
+        VerifyOrExit(pwrite(sFlashFd, &buf, 1, aOffset + size) == 1, ;);
+    }
+
+    error = kThreadError_None;
+
+exit:
+    return error;
+}
+
+ThreadError otPlatFlashInit(void)
+{
+    ThreadError error = kThreadError_None;
+
+    sFlashFd = open("OT_Flash", O_RDWR | O_CREAT, 0666);
+    ftruncate(sFlashFd, 0);
+    lseek(sFlashFd, 0, SEEK_SET);
+
+    VerifyOrExit(sFlashFd >= 0, error = kThreadError_Failed);
+
+    SuccessOrExit(error = otPlatFlashErasePage(FLASH_BASE_ADDRESS, FLASH_SIZE));
+
+exit:
+    return error;
+}
+
+ThreadError otPlatFlashDisable(void)
+{
+    close(sFlashFd);
+
+    return kThreadError_None;
+}
+
+uint32_t otPlatFlashGetBaseAddress(void)
+{
+    return FLASH_BASE_ADDRESS;
+}
+
+uint32_t otPlatFlashGetSize(void)
+{
+    return FLASH_SIZE;
+}
+
+uint32_t otPlatFlashGetPageSize(void)
+{
+    return FLASH_PAGE_SIZE;
+}
+
+ThreadError otPlatFlashErasePage(uint32_t aAddress, uint32_t aSize)
+{
+    ThreadError error = kThreadError_None;
+    uint32_t offset = aAddress - FLASH_BASE_ADDRESS;
+    uint16_t pageNum;
+    uint16_t index;
+
+    VerifyOrExit(aAddress >= FLASH_BASE_ADDRESS, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aAddress < (FLASH_BASE_ADDRESS + FLASH_SIZE), error = kThreadError_InvalidArgs);
+    VerifyOrExit(!(aAddress & (FLASH_PAGE_SIZE - 1)), error = kThreadError_InvalidArgs);
+
+    pageNum = (uint16_t)(aSize / FLASH_PAGE_SIZE);
+    pageNum = (pageNum > FLASH_PAGE_NUM) ? FLASH_PAGE_NUM : pageNum;
+
+    for (index = 0; index < pageNum; index++)
+    {
+        SuccessOrExit(error = erasePage(offset + FLASH_PAGE_SIZE * index));
+    }
+
+exit:
+    return error;
+}
+
+uint32_t otPlatFlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
+{
+    uint32_t offset = aAddress - FLASH_BASE_ADDRESS;
+    uint32_t ret;
+
+    VerifyOrExit(sFlashFd >= 0, ret = 0);
+
+    ret = (uint32_t)pwrite(sFlashFd, aData, aSize, offset);
+
+exit:
+    return ret;
+}
+
+uint32_t otPlatFlashRead(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
+{
+    uint32_t offset = aAddress - FLASH_BASE_ADDRESS;
+    uint32_t ret;
+
+    VerifyOrExit(sFlashFd >= 0, ret = 0);
+
+    ret = (uint32_t)pread(sFlashFd, aData, aSize, offset);
+
+exit:
+    return ret;
+}

--- a/include/platform/Makefile.am
+++ b/include/platform/Makefile.am
@@ -38,6 +38,7 @@ ot_platform_headers                      =\
     random.h                              \
     uart.h                                \
     spi-slave.h                           \
+    flash.h                               \
     settings.h                            \
     toolchain.h                           \
     $(NULL)

--- a/include/platform/flash.h
+++ b/include/platform/flash.h
@@ -1,0 +1,121 @@
+/*
+ *  Copyright (c) 2016, Nest Labs, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * @brief
+ *   This file defines flash interface.
+ */
+
+#ifndef OT_PLATFORM_FLASH_H
+#define OT_PLATFORM_FLASH_H
+
+#include <stdint.h>
+
+#include <openthread-types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Init flash driver.
+ *
+ * @retval ::kThreadError_None    Init flash driver success.
+ * @retval ::kThreadError_Failed  Init flash driver fail.
+ */
+ThreadError otPlatFlashInit(void);
+
+/**
+ * Disable flash driver.
+ *
+ * @retval ::kThreadError_None    Disable flash driver success.
+ * @retval ::kThreadError_Failed  Disable flash driver fail.
+ */
+ThreadError otPlatFlashDisable(void);
+
+/**
+ * Get the base address of flash.
+ *
+ * @returns The base address of the flash.
+ */
+uint32_t otPlatFlashGetBaseAddress(void);
+
+/**
+ * Get the size of flash.
+ *
+ * @returns The size of the flash.
+ */
+uint32_t otPlatFlashGetSize(void);
+
+/**
+ * Get the page size of flash.
+ *
+ * @returns The page size of the flash.
+ */
+uint32_t otPlatFlashGetPageSize(void);
+
+/**
+ * Erase flash pages.
+ *
+ * @param[in]  aAddress  The start address of the flash to erase.
+ * @param[in]  aSize     The size of the flash to erase.
+ *
+ * @retval ::kThreadError_None           Erase flash success.
+ * @retval ::kThreadError_InvalidArgs    Arguments invalid.
+ * @retval ::kThreadError_Failed         Erase flash fail.
+ */
+ThreadError otPlatFlashErasePage(uint32_t aAddress, uint32_t aSize);
+
+/**
+ * Write flash.
+ *
+ * @param[in]  aAddress  The start address of the flash to write.
+ * @param[in]  aData     The pointer of the data to write.
+ * @param[in]  aSize     The size of the data to write.
+ *
+ * @returns The actual size of octets write to flash.
+ */
+uint32_t otPlatFlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize);
+
+/**
+ * Read flash.
+ *
+ * @param[in]  aAddress  The start address of the flash to read.
+ * @param[in]  aData     The pointer of buffer to store the data.
+ * @param[in]  aSize     The size of the data to read.
+ *
+ * @returns The actual size of octets read to buffer.
+ */
+uint32_t otPlatFlashRead(uint32_t aAddress, uint8_t *aData, uint32_t aSize);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // OT_PLATFORM_FLASH_H

--- a/include/platform/settings.h
+++ b/include/platform/settings.h
@@ -229,7 +229,7 @@ ThreadError otPlatSettingsAdd(uint16_t aKey, const uint8_t *aValue, int aValueLe
  *  @retval kThreadError_NotImplemented
  *          This function is not implemented on this platform.
  */
-ThreadError otPlatSettingsDelete(uint16_t aKey, int index);
+ThreadError otPlatSettingsDelete(uint16_t aKey, int aIndex);
 
 /// Removes all settings from the setting store
 /** This function deletes all settings from the settings

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -45,6 +45,8 @@
 #include <platform/random.h>
 #include <platform/uart.h>
 
+#include <platform/settings.h>
+
 using Thread::Encoding::BigEndian::HostSwap16;
 using Thread::Encoding::BigEndian::HostSwap32;
 
@@ -459,9 +461,19 @@ void Interpreter::ProcessCounters(int argc, char *argv[])
 
 void Interpreter::ProcessDataset(int argc, char *argv[])
 {
+#if 0
     ThreadError error;
     error = Dataset::Process(argc, argv, *sServer);
     AppendResult(error);
+#endif
+
+    int error;
+
+    (void)argc;
+    (void)argv;
+
+    error = testSettingsApi();
+    sServer->OutputFormat("error %d\r\n", error);
 }
 
 void Interpreter::ProcessDiscover(int argc, char *argv[])

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -45,8 +45,6 @@
 #include <platform/random.h>
 #include <platform/uart.h>
 
-#include <platform/settings.h>
-
 using Thread::Encoding::BigEndian::HostSwap16;
 using Thread::Encoding::BigEndian::HostSwap32;
 
@@ -461,19 +459,9 @@ void Interpreter::ProcessCounters(int argc, char *argv[])
 
 void Interpreter::ProcessDataset(int argc, char *argv[])
 {
-#if 0
     ThreadError error;
     error = Dataset::Process(argc, argv, *sServer);
     AppendResult(error);
-#endif
-
-    int error;
-
-    (void)argc;
-    (void)argv;
-
-    error = testSettingsApi();
-    sServer->OutputFormat("error %d\r\n", error);
 }
 
 void Interpreter::ProcessDiscover(int argc, char *argv[])

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -43,6 +43,7 @@ libopenthread_a_SOURCES             = \
     common/message.cpp                \
     common/tasklet.cpp                \
     common/timer.cpp                  \
+    common/settings.cpp               \
     crypto/aes_ccm.cpp                \
     mac/mac.cpp                       \
     mac/mac_frame.cpp                 \

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -704,7 +704,6 @@ void otPlatSettingsWipe(void)
 }
 
 // test functions
-#define ENABLE_SETTINGS_API_TEST 2
 #if ENABLE_SETTINGS_API_TEST
 int testSettingsApi(void)
 {

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -336,8 +336,8 @@ ThreadError otPlatSettingsCommitChange(void)
                 otPlatFlashRead(address, (uint8_t *)&block, sizeof(block));
 
                 if (!(block.flag & BLOCK_ADD_FLAG) && (block.flag & BLOCK_DELETE_FLAG) &&
-                     (block.key == stageDeleteBlock->key) &&
-                     (block.index == static_cast<uint8_t>(stageDeleteBlock->index) || stageDeleteBlock->index == -1))
+                    (block.key == stageDeleteBlock->key) &&
+                    (block.index == static_cast<uint8_t>(stageDeleteBlock->index) || stageDeleteBlock->index == -1))
                 {
                     block.flag &= (~BLOCK_DELETE_FLAG);
                     otPlatFlashWrite(address, (uint8_t *)&block, sizeof(block));
@@ -431,7 +431,7 @@ ThreadError otPlatSettingsSet(uint16_t aKey, const uint8_t *aValue, int aValueLe
     uint32_t address = sBaseAddress + sizeof(sSettingsBlockFlag);
     uint32_t endAddress = sBaseAddress + OPENTHREAD_CONFIG_SETTINGS_SIZE - 1;
     struct settingsBlock block;
-    
+
     while (address < endAddress)
     {
         otPlatFlashRead(address, (uint8_t *)&block, sizeof(block));
@@ -553,7 +553,7 @@ ThreadError otPlatSettingsDelete(uint16_t aKey, int aIndex)
         if (sCommitLock == false)
         {
             if (!(block.flag & BLOCK_ADD_FLAG) && (block.flag & BLOCK_DELETE_FLAG) &&
-                 (block.key == aKey) && (block.index == aIndex || aIndex == -1))
+                (block.key == aKey) && (block.index == aIndex || aIndex == -1))
             {
                 error = kThreadError_None;
 
@@ -570,7 +570,7 @@ ThreadError otPlatSettingsDelete(uint16_t aKey, int aIndex)
             stageBlock = &sStageDeleteSettingsBlock[sStageDeleteSettingsNum];
             stageBlock->key = aKey;
             stageBlock->index = aIndex;
-            sStageActionSeq &= ~(1 <<(sStageAddSettingsNum + sStageDeleteSettingsNum));
+            sStageActionSeq &= ~(1 << (sStageAddSettingsNum + sStageDeleteSettingsNum));
             sStageDeleteSettingsNum++;
             break;
         }

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -1,0 +1,908 @@
+/*
+ *  Copyright (c) 2016, Nest Labs, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the OpenThread platform abstraction for non-volatile storage of settings.
+ *
+ */
+
+#include <stddef.h>
+#include <string.h>
+#include <assert.h>
+
+#include <openthread-types.h>
+#include <openthread-core-config.h>
+
+#include <common/code_utils.hpp>
+#include <platform/settings.h>
+#include <platform/flash.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum
+{
+    BLOCK_ADD_FLAG = 0x1,
+    BLOCK_DELETE_FLAG = 0x2,
+};
+
+enum
+{
+    MAX_KEY_VALUE = 128,
+    MAX_BLOCKS_NUM = 256,
+    MAX_STAGE_ADD_NUM = 16,
+    MAX_STAGE_DELETE_NUM = 16,
+    MAX_STAGE_DATA_LEN = 32,
+};
+
+struct settingsBlock
+{
+    uint16_t key;
+    uint8_t index;
+    uint8_t flag;
+    uint16_t length;
+    uint16_t reserved;
+};
+
+struct settingsBlockMgmt
+{
+    uint32_t cur;
+    struct settingsBlockMgmt *prev;
+    struct settingsBlockMgmt *next;
+};
+
+struct settingsList
+{
+    struct settingsBlockMgmt *head;
+    struct settingsBlockMgmt *tail;
+};
+
+struct stageAddSettingsBlock
+{
+    struct settingsBlock block;
+    uint8_t data[MAX_STAGE_DATA_LEN];
+};
+
+struct stageDeleteSettingsBlock
+{
+    bool deleteList;
+    struct settingsBlockMgmt *blockMgmt;
+};
+
+static uint32_t sBaseAddress;
+
+static uint32_t sSettingsBlockFlag = 0xbe5cc5ef;
+
+static struct settingsList sSettingsList[MAX_KEY_VALUE];
+static struct settingsBlockMgmt sSettingsBlockMgmt[MAX_BLOCKS_NUM];
+static uint16_t sSettingsBlockMgmtNum;
+
+static uint32_t sStageActionSeq;
+static struct stageAddSettingsBlock sStageAddSettingsBlock[MAX_STAGE_ADD_NUM];
+static uint8_t sStageAddSettingsNum;
+static uint16_t sStageAddSettingsBufLength;
+static struct stageDeleteSettingsBlock sStageDeleteSettingsBlock[MAX_STAGE_DELETE_NUM];
+static uint8_t sStageDeleteSettingsNum;
+
+static uint32_t sAddress;
+static bool sCommitLock = false;
+
+// settings block management structure in ram
+static void enqueueSettingsBlockMgmt(uint16_t aKey, uint32_t aBlock)
+{
+    uint16_t index;
+    uint32_t endAddress = sBaseAddress + OPENTHREAD_CONFIG_SETTINGS_SIZE - 1;
+    struct settingsList *list;
+    struct settingsBlockMgmt *blockMgmt;
+
+    assert((aBlock >= sBaseAddress) && (aBlock <= endAddress));
+
+    for (index = 0; index < MAX_BLOCKS_NUM; index++)
+    {
+        if (sSettingsBlockMgmt[index].cur == 0)
+        {
+            break;
+        }
+    }
+
+    assert(index < MAX_BLOCKS_NUM);
+
+    list = &sSettingsList[aKey];
+    blockMgmt = &sSettingsBlockMgmt[index];
+
+    blockMgmt->cur = aBlock;
+    blockMgmt->prev = list->tail;
+    blockMgmt->next = NULL;
+
+    if (list->head == NULL)
+    {
+        list->head = blockMgmt;
+        list->tail = blockMgmt;
+    }
+    else
+    {
+        list->tail->next = blockMgmt;
+        list->tail = blockMgmt;
+    }
+
+    sSettingsBlockMgmtNum++;
+}
+
+static struct settingsBlockMgmt *dequeueSettingsBlockMgmt(struct settingsBlockMgmt *aBlockMgmt)
+{
+    struct settingsList *list;
+    struct settingsBlockMgmt *rval;
+    struct settingsBlock block;
+
+    assert(aBlockMgmt && aBlockMgmt->cur);
+
+    otPlatFlashRead(aBlockMgmt->cur, (uint8_t *)&block, sizeof(block));
+    list = &sSettingsList[block.key];
+    aBlockMgmt->cur = 0;
+
+    if (aBlockMgmt->prev)
+    {
+        aBlockMgmt->prev->next = aBlockMgmt->next;
+    }
+    else
+    {
+        list->head = aBlockMgmt->next;
+    }
+
+    if (aBlockMgmt->next)
+    {
+        aBlockMgmt->next->prev = aBlockMgmt->prev;
+    }
+    else
+    {
+        list->tail = aBlockMgmt->prev;
+    }
+
+    rval = aBlockMgmt->next;
+    aBlockMgmt->prev = NULL;
+    aBlockMgmt->next = NULL;
+
+    sSettingsBlockMgmtNum--;
+
+    return rval;
+}
+
+void reorderSettingsBlock(void)
+{
+    uint8_t reorderBuffer[OPENTHREAD_CONFIG_SETTINGS_PAGE_SIZE];
+    uint8_t *ramBufferStart;
+    uint8_t *ramBuffer;
+    uint32_t ramBufferOffset = 0;
+
+    uint8_t readPageIndex = 0;
+    uint32_t readAddress;
+    uint32_t readPageOffset = 0;
+
+    uint8_t writePageIndex = 0;
+    uint32_t writeAddress;
+    uint32_t writePageOffset = 0;
+
+    uint8_t pageNum;
+    struct settingsBlock block;
+    uint32_t length;
+    uint32_t writeLength;
+    bool storeLeft = false;
+    bool endOfData = false;
+
+    ramBufferStart = reorderBuffer;
+    ramBuffer = ramBufferStart;
+    pageNum = static_cast<uint8_t>(OPENTHREAD_CONFIG_SETTINGS_SIZE / otPlatFlashGetPageSize());
+    length = 0;
+
+    while ((readPageIndex < pageNum) && !endOfData)
+    {
+        readAddress = sBaseAddress + otPlatFlashGetPageSize() * readPageIndex;
+        readPageOffset = (readPageIndex == 0) ? sizeof(sSettingsBlockFlag) : 0;
+        readAddress += readPageOffset;
+
+        readPageOffset += length;
+
+        // read the left bytes of one block sitting in 2 pages
+        if (storeLeft)
+        {
+            otPlatFlashRead(readAddress, ramBuffer, length);
+            ramBuffer += length;
+            ramBufferOffset += length;
+        }
+
+        readAddress += length;
+        length = 0;
+        storeLeft = false;
+
+        // read flash to ram
+        while (readPageOffset < otPlatFlashGetPageSize())
+        {
+            otPlatFlashRead(readAddress, (uint8_t *)&block, sizeof(block));
+
+            if (!(block.flag & BLOCK_ADD_FLAG))
+            {
+                writeLength = block.length + sizeof(struct settingsBlock);
+
+                if ((readPageOffset + writeLength) > otPlatFlashGetPageSize())
+                {
+                    writeLength -= (readPageOffset + writeLength - otPlatFlashGetPageSize());
+                }
+
+                readPageOffset += writeLength;
+                length = block.length + sizeof(struct settingsBlock) - writeLength;
+
+                if (block.flag & BLOCK_DELETE_FLAG)
+                {
+                    otPlatFlashRead(readAddress, ramBuffer, writeLength);
+                    ramBuffer += writeLength;
+                    ramBufferOffset += writeLength;
+                    readAddress += writeLength;
+                    writeLength = 0;
+
+                    if (length)
+                    {
+                        storeLeft = true;
+                        break;
+                    }
+                }
+                else
+                {
+                    readAddress += writeLength;
+                    writeLength = 0;
+                }
+            }
+            else if (block.flag == 0xff)
+            {
+                endOfData = true;
+                break;
+            }
+            else
+            {
+                assert(false);
+            }
+        }
+
+        otPlatFlashErasePage(sBaseAddress + otPlatFlashGetPageSize() * readPageIndex, otPlatFlashGetPageSize());
+
+        if (readPageIndex == 0)
+        {
+            otPlatFlashWrite(sBaseAddress, (uint8_t *)&sSettingsBlockFlag, sizeof(sSettingsBlockFlag));
+            writePageOffset = sizeof(sSettingsBlockFlag);
+        }
+
+        // write ram back to flash
+        writeAddress = sBaseAddress + writePageIndex * otPlatFlashGetPageSize() + writePageOffset;
+
+        writeLength = (otPlatFlashGetPageSize() - writePageOffset) > ramBufferOffset ? ramBufferOffset :
+                      (otPlatFlashGetPageSize() - writePageOffset);
+        otPlatFlashWrite(writeAddress, ramBufferStart, writeLength);
+        writePageOffset += writeLength;
+
+        if (ramBufferOffset > writeLength)
+        {
+            writePageIndex++;
+            writePageOffset = 0;
+            writeAddress = otPlatFlashGetBaseAddress() + OPENTHREAD_CONFIG_SETTINGS_BASE_ADDRESS
+                           + writePageIndex * otPlatFlashGetPageSize() + writePageOffset;
+            otPlatFlashWrite(writeAddress, ramBufferStart + writeLength, ramBufferOffset - writeLength);
+            writePageOffset += (ramBufferOffset - writeLength);
+        }
+
+        ramBuffer = ramBufferStart;
+        ramBufferOffset = 0;
+        readPageIndex++;
+    }
+
+    otPlatSettingsInit();
+}
+
+// settings API
+void otPlatSettingsInit(void)
+{
+    uint32_t endAddress;
+    struct settingsBlock block;
+    uint32_t blockFlag;
+
+    sBaseAddress = otPlatFlashGetBaseAddress() + OPENTHREAD_CONFIG_SETTINGS_BASE_ADDRESS;
+    sAddress = sBaseAddress;
+    endAddress = sAddress + OPENTHREAD_CONFIG_SETTINGS_SIZE - 1;
+
+    assert(!(sAddress & otPlatFlashGetPageSize()));
+
+    memset(sSettingsList, 0, sizeof(sSettingsList));
+    memset(sSettingsBlockMgmt, 0, sizeof(sSettingsBlockMgmt));
+    sSettingsBlockMgmtNum = 0;
+
+    memset(sStageAddSettingsBlock, 0xff, sizeof(sStageAddSettingsBlock));
+    sStageAddSettingsNum = 0;
+    sStageAddSettingsBufLength = 0;
+
+    memset(sStageDeleteSettingsBlock, 0, sizeof(sStageDeleteSettingsBlock));
+    sStageDeleteSettingsNum = 0;
+
+    sStageActionSeq = 0xffffffff;
+
+    sCommitLock = false;
+
+    // initialize settings mangement data structure
+    while (sAddress < endAddress)
+    {
+        if (sAddress == sBaseAddress)
+        {
+            otPlatFlashRead(sAddress, (uint8_t *)&blockFlag, sizeof(blockFlag));
+
+            if (blockFlag != sSettingsBlockFlag)
+            {
+                break;
+            }
+
+            sAddress += sizeof(sSettingsBlockFlag);
+        }
+
+        otPlatFlashRead(sAddress, (uint8_t *)&block, sizeof(block));
+
+        if (!(blockFlag & BLOCK_DELETE_FLAG))
+        {
+            sAddress += (block.length + sizeof(struct settingsBlock));
+        }
+        else if (!(block.flag & BLOCK_ADD_FLAG))
+        {
+            assert(block.key <= MAX_KEY_VALUE);
+            assert(sSettingsBlockMgmtNum <= MAX_BLOCKS_NUM);
+
+            enqueueSettingsBlockMgmt(block.key, sAddress);
+            sAddress += (block.length + sizeof(struct settingsBlock));
+        }
+        else
+        {
+            break;
+        }
+    }
+}
+
+ThreadError otPlatSettingsBeginChange(void)
+{
+    ThreadError error = kThreadError_None;
+
+    VerifyOrExit(sCommitLock == false, error = kThreadError_Already);
+
+    sCommitLock = true;
+
+exit:
+    return error;
+}
+
+ThreadError otPlatSettingsCommitChange(void)
+{
+    ThreadError error = kThreadError_None;
+    uint8_t stageAddIndex;
+    uint8_t stageDeleteIndex;
+    uint16_t length;
+    uint32_t endAddress;
+    bool deleteList;
+    struct stageAddSettingsBlock *stageAddBlock;
+    struct stageDeleteSettingsBlock *stageDeleteBlock;
+    struct settingsBlockMgmt *blockMgmt;
+    struct settingsBlock block;
+
+    VerifyOrExit(sCommitLock == true, error = kThreadError_InvalidState);
+
+    endAddress = sBaseAddress + OPENTHREAD_CONFIG_SETTINGS_SIZE - 1;
+
+    if ((sAddress + sStageAddSettingsBufLength) >= endAddress)
+    {
+        reorderSettingsBlock();
+    }
+
+    VerifyOrExit((sAddress + sStageAddSettingsBufLength) < endAddress, error = kThreadError_NoBufs);
+
+    stageAddIndex = 0;
+    stageDeleteIndex = 0;
+
+    while ((stageAddIndex + stageDeleteIndex) < (sStageAddSettingsNum + sStageDeleteSettingsNum))
+    {
+        if (sStageActionSeq & (1 << (stageAddIndex + stageDeleteIndex)))
+        {
+            stageAddBlock = &sStageAddSettingsBlock[stageAddIndex++];
+            length = sizeof(struct settingsBlock) + stageAddBlock->block.length;
+            otPlatFlashWrite(sAddress, (uint8_t *)&stageAddBlock->block, sizeof(struct settingsBlock));
+            otPlatFlashWrite(sAddress + sizeof(struct settingsBlock), (uint8_t *)stageAddBlock->data, stageAddBlock->block.length);
+            enqueueSettingsBlockMgmt(stageAddBlock->block.key, sAddress);
+            sAddress += length;
+        }
+        else
+        {
+            stageDeleteBlock = &sStageDeleteSettingsBlock[stageDeleteIndex++];
+            blockMgmt = stageDeleteBlock->blockMgmt;
+            deleteList = stageDeleteBlock->deleteList;
+
+            while (blockMgmt)
+            {
+                otPlatFlashRead(blockMgmt->cur, (uint8_t *)&block, sizeof(block));
+                block.flag &= (~BLOCK_DELETE_FLAG);
+                otPlatFlashWrite(blockMgmt->cur, (uint8_t *)&block, sizeof(block));
+                blockMgmt = dequeueSettingsBlockMgmt(blockMgmt);
+
+                if (!deleteList)
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+exit:
+    sCommitLock = false;
+
+    memset(sStageAddSettingsBlock, 0, sizeof(sStageAddSettingsBlock));
+    sStageAddSettingsNum = 0;
+    sStageAddSettingsBufLength = 0;
+
+    memset(sStageDeleteSettingsBlock, 0, sizeof(sStageDeleteSettingsBlock));
+    sStageDeleteSettingsNum = 0;
+
+    sStageActionSeq = 0xffffffff;
+
+    return error;
+}
+
+ThreadError otPlatSettingsAbandonChange(void)
+{
+    ThreadError error = kThreadError_None;
+
+    VerifyOrExit(sCommitLock == true, error = kThreadError_InvalidState);
+
+    sCommitLock = false;
+    memset(sStageAddSettingsBlock, 0, sizeof(sStageAddSettingsBlock));
+    sStageAddSettingsNum = 0;
+    sStageAddSettingsBufLength = 0;
+
+    memset(sStageDeleteSettingsBlock, 0, sizeof(sStageDeleteSettingsBlock));
+    sStageDeleteSettingsNum = 0;
+
+    sStageActionSeq = 0xffffffff;
+
+exit:
+    return error;
+}
+
+ThreadError otPlatSettingsGet(uint16_t aKey, int aIndex, uint8_t *aValue, int *aValueLength)
+{
+    ThreadError error = kThreadError_NotFound;
+    struct settingsList *list;
+    struct settingsBlockMgmt *blockMgmt;
+    uint32_t address;
+    struct settingsBlock block;
+
+    VerifyOrExit(sSettingsList[aKey].head, error = kThreadError_NotFound);
+
+    list = &sSettingsList[aKey];
+    blockMgmt = list->head;
+
+    while (blockMgmt)
+    {
+        otPlatFlashRead(blockMgmt->cur, (uint8_t *)&block, sizeof(block));
+
+        if (block.index == aIndex)
+        {
+            if (!(block.flag & BLOCK_ADD_FLAG) && (block.flag & BLOCK_DELETE_FLAG))
+            {
+                error = kThreadError_None;
+
+                if (aValueLength)
+                {
+                    *aValueLength = block.length;
+                }
+
+                if (aValue)
+                {
+                    VerifyOrExit(aValueLength, error = kThreadError_InvalidArgs);
+                    address = blockMgmt->cur + sizeof(struct settingsBlock);
+                    otPlatFlashRead(address, aValue, block.length);
+                }
+            }
+
+            break;
+        }
+
+        blockMgmt = blockMgmt->next;
+    }
+
+exit:
+    return error;
+}
+
+ThreadError otPlatSettingsSet(uint16_t aKey, const uint8_t *aValue, int aValueLength)
+{
+    ThreadError error = kThreadError_None;
+    struct settingsList *list;
+
+    list = &sSettingsList[aKey];
+
+    if (list->head == NULL)
+    {
+        error = otPlatSettingsAdd(aKey, aValue, aValueLength);
+    }
+    else
+    {
+        SuccessOrExit(error = otPlatSettingsDelete(aKey, -1));
+        error = otPlatSettingsAdd(aKey, aValue, aValueLength);
+    }
+
+exit:
+    return error;
+}
+
+ThreadError otPlatSettingsAdd(uint16_t aKey, const uint8_t *aValue, int aValueLength)
+{
+    ThreadError error = kThreadError_None;
+    struct settingsList *list;
+    struct stageAddSettingsBlock *stageBlock;
+    struct settingsBlock block;
+    uint8_t index;
+    uint32_t endAddress;
+
+    VerifyOrExit((!sCommitLock) || (sCommitLock &&
+                                    (sStageAddSettingsNum < MAX_STAGE_ADD_NUM)), error = kThreadError_NoBufs);
+
+    list = &sSettingsList[aKey];
+    stageBlock = &sStageAddSettingsBlock[sStageAddSettingsNum];
+    stageBlock->block.key = aKey;
+
+    if (list->tail)
+    {
+        otPlatFlashRead(list->tail->cur, (uint8_t *)&block, sizeof(block));
+        stageBlock->block.index = block.index + 1;
+    }
+    else
+    {
+        stageBlock->block.index = 0;
+    }
+
+    if (sCommitLock)
+    {
+        for (index = 0; index < sStageAddSettingsNum; index++)
+        {
+            if ((sStageAddSettingsBlock[index].block.key == aKey) &&
+                (sStageAddSettingsBlock[index].block.index >= stageBlock->block.index))
+            {
+                stageBlock->block.index = sStageAddSettingsBlock[index].block.index + 1;
+            }
+        }
+    }
+
+    stageBlock->block.flag &= (~BLOCK_ADD_FLAG);
+    stageBlock->block.length = static_cast<uint16_t>(aValueLength);
+    memcpy(stageBlock->data, aValue, stageBlock->block.length);
+
+    // padding
+    while (stageBlock->block.length & 3)
+    {
+        stageBlock->data[stageBlock->block.length++] = 0xff;
+    }
+
+    if (!sCommitLock)
+    {
+        endAddress = sBaseAddress + OPENTHREAD_CONFIG_SETTINGS_SIZE - 1;
+
+        if ((sAddress + stageBlock->block.length + sizeof(struct settingsBlock)) > endAddress)
+        {
+            reorderSettingsBlock();
+        }
+
+        otPlatFlashWrite(sAddress, (uint8_t *)&stageBlock->block, sizeof(struct settingsBlock));
+        otPlatFlashWrite(sAddress + sizeof(struct settingsBlock), (uint8_t *)stageBlock->data, stageBlock->block.length);
+        enqueueSettingsBlockMgmt(aKey, sAddress);
+        sAddress += (stageBlock->block.length + sizeof(struct settingsBlock));
+        stageBlock->block.flag = 0xff;
+    }
+    else
+    {
+        sStageAddSettingsBufLength += (stageBlock->block.length + sizeof(struct settingsBlock));
+        sStageAddSettingsNum++;
+    }
+
+exit:
+    return error;
+}
+
+ThreadError otPlatSettingsDelete(uint16_t aKey, int aIndex)
+{
+    ThreadError error = kThreadError_NotFound;
+    struct settingsBlockMgmt *blockMgmt;
+    struct stageDeleteSettingsBlock *stageBlock;
+    struct settingsBlock block;
+
+    VerifyOrExit(sSettingsList[aKey].head, error = kThreadError_NotFound);
+    VerifyOrExit((!sCommitLock) || (sCommitLock &&
+                                    (sStageDeleteSettingsNum < MAX_STAGE_DELETE_NUM)), error = kThreadError_NoBufs);
+
+    blockMgmt = sSettingsList[aKey].head;
+
+    while (blockMgmt)
+    {
+        otPlatFlashRead(blockMgmt->cur, (uint8_t *)&block, sizeof(block));
+
+        if (aIndex == -1 || block.index == aIndex)
+        {
+            if (!(block.flag & BLOCK_ADD_FLAG) && (block.flag & BLOCK_DELETE_FLAG))
+            {
+                error = kThreadError_None;
+
+                if (sCommitLock)
+                {
+                    stageBlock = &sStageDeleteSettingsBlock[sStageDeleteSettingsNum];
+                    stageBlock->blockMgmt = blockMgmt;
+                    stageBlock->deleteList = (aIndex == -1) ? true : false;
+                    sStageActionSeq &= ~(1 << (sStageAddSettingsNum + sStageDeleteSettingsNum));
+                    sStageDeleteSettingsNum++;
+                    break;
+                }
+                else
+                {
+                    block.flag &= (~BLOCK_DELETE_FLAG);
+                    otPlatFlashWrite(blockMgmt->cur, (uint8_t *)&block, sizeof(block));
+                    blockMgmt = dequeueSettingsBlockMgmt(blockMgmt);
+
+                    if (aIndex != -1)
+                    {
+                        break;
+                    }
+                }
+            }
+            else if (aIndex == -1)
+            {
+                blockMgmt = blockMgmt->next;
+            }
+            else
+            {
+                break;
+            }
+        }
+        else
+        {
+            blockMgmt = blockMgmt->next;
+        }
+    }
+
+exit:
+    return error;
+}
+
+void otPlatSettingsWipe(void)
+{
+    otPlatFlashErasePage(sBaseAddress, OPENTHREAD_CONFIG_SETTINGS_SIZE);
+    otPlatFlashWrite(sBaseAddress, (uint8_t *)&sSettingsBlockFlag, sizeof(sSettingsBlockFlag));
+    otPlatSettingsInit();
+}
+
+// test functions
+#define ENABLE_SETTINGS_API_TEST 2
+#if ENABLE_SETTINGS_API_TEST
+int testSettingsApi(void)
+{
+    int rval = 0;
+    ThreadError error = kThreadError_None;
+    uint16_t key;
+    uint8_t index;
+    uint8_t writeBuffer[MAX_STAGE_DATA_LEN];
+    int writeBufferLength;
+    uint8_t readBuffer[MAX_STAGE_DATA_LEN];
+    int readBufferLength = 32;
+
+    otPlatFlashInit();
+    otPlatSettingsInit();
+
+    // wipe settings block flash area
+    otPlatSettingsWipe();
+
+    // prepare for add setting blocks
+    for (index = 0; index < MAX_STAGE_DATA_LEN - 1; index++)
+    {
+        writeBuffer[index] = index;
+    }
+
+    writeBufferLength = index;
+
+    // add setting blocks
+    for (key = 7; key < 15; key++)
+    {
+        for (index = 0; index < 10; index++)
+        {
+            writeBuffer[0] = index;
+            error = otPlatSettingsAdd(key, writeBuffer, (int)writeBufferLength);
+            // -1: otPlatSettingsAdd error
+            VerifyOrExit(error == kThreadError_None, rval = -1);
+        }
+    }
+
+    for (key = 7; key < 15; key++)
+    {
+        for (index = 0; index < 10; index++)
+        {
+            error = otPlatSettingsGet(key, index, readBuffer, &readBufferLength);
+            // -2: otPlatSettingsGet error to get setting block
+            VerifyOrExit(error == kThreadError_None, rval = -2);
+            // -3: otPlatSettingsAdd and otPlatSettingsGet not match
+            VerifyOrExit(readBuffer[0] == index, rval = -3);
+            VerifyOrExit(!memcmp(readBuffer + 1, writeBuffer + 1, static_cast<uint16_t>(writeBufferLength - 1)), rval = -3);
+        }
+    }
+
+    // delete all setting blocks of one key
+    key = 8;
+    error = otPlatSettingsDelete(key, -1);
+    // -4: otPlatSettingDelete error to delete all setting blocks of one key
+    VerifyOrExit(error == kThreadError_None, rval = -4);
+
+    for (index = 0; index < 10; index++)
+    {
+        error = otPlatSettingsGet(key, index, readBuffer, &readBufferLength);
+        // -5: otPlatSettingsDelete error to delete all setting blocks of one key
+        VerifyOrExit(error == kThreadError_NotFound, rval = -5);
+    }
+
+    // set one setting block
+    key = 8;
+    error = otPlatSettingsSet(key, writeBuffer, (int)writeBufferLength);
+    // -6: otPlatSettingsSet error to set a new setting block
+    VerifyOrExit(error == kThreadError_None, rval = -6);
+    error = otPlatSettingsGet(key, 0, readBuffer, &readBufferLength);
+    // -7: otPlatSettingsGet error to get after otPlatSettingsSet
+    VerifyOrExit(error == kThreadError_None, rval = -7);
+    // -8: otPlatSettingsGet and otPlatSettingsSet not match
+    VerifyOrExit(!memcmp(readBuffer, writeBuffer, static_cast<uint16_t>(writeBufferLength)), rval = -8);
+
+    // set one setting block
+    key = 8;
+    error = otPlatSettingsSet(key, writeBuffer, (int)writeBufferLength);
+    // -9: otPlatSettingsSet error to set an existing setting block
+    VerifyOrExit(error == kThreadError_None, rval = -9);
+    error = otPlatSettingsGet(key, 0, readBuffer, &readBufferLength);
+    // -10: otPlatSettingsGet error to get after otPlatSettingsSet for an existing setting block
+    VerifyOrExit(error == kThreadError_None, rval = -10);
+    // -11: otPlatSettingsGet and otPlatSettingsSet not match for an existing setting block
+    VerifyOrExit(!memcmp(readBuffer, writeBuffer, static_cast<uint16_t>(writeBufferLength)), rval = -10);
+
+    // commit
+    otPlatSettingsBeginChange();
+    key = 15;
+
+    for (index = 0; index < 3; index++)
+    {
+        writeBuffer[0] = index;
+        error = otPlatSettingsAdd(key, writeBuffer, (int)writeBufferLength);
+
+        // -12: otPlatSettingsAdd error in commit
+        VerifyOrExit(error == kThreadError_None, rval = -12);
+    }
+
+    key = 13;
+    writeBuffer[0] = 10;
+    error = otPlatSettingsSet(key, writeBuffer, (int)writeBufferLength);
+    // -13: set one new setting block error in commit
+    VerifyOrExit(error == kThreadError_None, rval = -13);
+
+    key = 7;
+    error = otPlatSettingsDelete(key, 1);
+    // -14: otPlatSettingsDelete error in commit
+    VerifyOrExit(error == kThreadError_None, rval = -14);
+
+    error = otPlatSettingsCommitChange();
+    // -15: otPlatSettingsCommitChange error
+    VerifyOrExit(error == kThreadError_None, rval = -15);
+
+    key = 15;
+
+    for (index = 0; index < 3; index++)
+    {
+        error = otPlatSettingsGet(key, index, readBuffer, &readBufferLength);
+        // -16: otPlatSettingsGet error in commit
+        VerifyOrExit(error == kThreadError_None, rval = -16);
+        // -17: otPlatSettingsAdd and otPlatSettingsGet not match in commit
+        VerifyOrExit(readBuffer[0] == index, rval = -17);
+        VerifyOrExit(!memcmp(readBuffer + 1, writeBuffer + 1, static_cast<uint16_t>(writeBufferLength - 1)), rval = -17);
+    }
+
+    key = 13;
+    index = 10;
+    error = otPlatSettingsGet(key, index, readBuffer, &readBufferLength);
+    // -18: otPlatSettingsGet error in commit
+    VerifyOrExit(error == kThreadError_None, rval = -18);
+    // -19: otPlatSettingsSet and otPlatSettingsGet not match in commit
+    VerifyOrExit(readBuffer[0] == index, rval = -19);
+    VerifyOrExit(!memcmp(readBuffer + 1, writeBuffer + 1, static_cast<uint16_t>(writeBufferLength - 1)), rval = -19);
+
+    // reordering
+    reorderSettingsBlock();
+
+    key = 7;
+
+    for (index = 0; index < 10; index++)
+    {
+        error = otPlatSettingsGet(key, index, readBuffer, &readBufferLength);
+
+        // -16: otPlatSettingsGet error in commit
+        if (index == 1)
+        {
+            VerifyOrExit(error == kThreadError_NotFound, rval = -20);
+        }
+        else
+        {
+            VerifyOrExit(error == kThreadError_None, rval = -21);
+        }
+
+        // -22: otPlatSettingsGet not match after reordering
+        VerifyOrExit(!memcmp(readBuffer + 1, writeBuffer + 1, static_cast<uint16_t>(writeBufferLength - 1)), rval = -22);
+    }
+
+    key = 8;
+
+    for (index = 0; index < 10; index++)
+    {
+        error = otPlatSettingsGet(key, index, readBuffer, &readBufferLength);
+
+        // -16: otPlatSettingsGet error in commit
+        if (index == 0)
+        {
+            VerifyOrExit(error == kThreadError_None, rval = -23);
+        }
+        else
+        {
+            VerifyOrExit(error == kThreadError_NotFound, rval = -24);
+        }
+
+        // -22: otPlatSettingsGet not match after reordering
+        VerifyOrExit(!memcmp(readBuffer + 1, writeBuffer + 1, static_cast<uint16_t>(writeBufferLength - 1)), rval = -25);
+    }
+
+    for (key = 9; key < 13; key++)
+    {
+        for (index = 0; index < 10; index++)
+        {
+            error = otPlatSettingsGet(key, index, readBuffer, &readBufferLength);
+            // -26: otPlatSettingsGet error to get setting block after reordering
+            VerifyOrExit(error == kThreadError_None, rval = -26);
+            // -27: otPlatSettingsAdd and otPlatSettingsGet not match after reordering
+            VerifyOrExit(readBuffer[0] == index, rval = -27);
+            VerifyOrExit(!memcmp(readBuffer + 1, writeBuffer + 1, static_cast<uint16_t>(writeBufferLength - 1)), rval = -27);
+        }
+    }
+
+exit:
+    otPlatFlashDisable();
+
+    return rval;
+}
+#endif
+
+#ifdef __cplusplus
+};
+#endif

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -156,6 +156,36 @@
 #endif  // OPENTHREAD_CONFIG_LOG_LEVEL
 
 /**
+ * @def OPENTHREAD_CONFIG_SETTINGS_BASE_ADDRESS
+ *
+ * The base address of settings.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_SETTINGS_BASE_ADDRESS
+#define OPENTHREAD_CONFIG_SETTINGS_BASE_ADDRESS             0x19000
+#endif  // OPENTHREAD_CONFIG_SETTINGS_BASE_ADDRESS
+
+/**
+ * @def OPENTHREAD_CONFIG_SETTINGS_PAGE_SIZE
+ *
+ * The page size of settings.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_SETTINGS_PAGE_SIZE
+#define OPENTHREAD_CONFIG_SETTINGS_PAGE_SIZE                0x800
+#endif  // OPENTHREAD_CONFIG_SETTINGS_PAGE_SIZE
+
+/**
+ * @def OPENTHREAD_CONFIG_SETTINGS_SIZE
+ *
+ * The size of settings.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_SETTINGS_SIZE
+#define OPENTHREAD_CONFIG_SETTINGS_SIZE                     0x2800
+#endif  // OPENTHREAD_CONFIG_SETTINGS_SIZE
+
+/**
  * @def OPENTHREAD_CONFIG_LOG_API
  *
  * Define to enable OpenThread API logging.


### PR DESCRIPTION
Resolves #325 

- implement setting API
- add flash API interface
- implement posix flash driver that simulates 1 MB flash
- implement CC2538 flash driver

We can enable the settings test function and using posix implement for test purpose.

There are 2 ways to check the test result.
- the return value of the test function. No error code returns indicates success.
- check the file that simulates 1MB flash. The file is named as OT_Flash in the same folder that runs ot-cli.

We can also build CC2538 image for testing on CC2538 board.

object file size while building CC2538 image:
arm-none-eabi-size libopenthread_a-settings.o 
   text	       data	        bss	        dec	           hex	   filename
   3131	          4	        159	        3294	    cde	   libopenthread_a-settings.o
