### PR TITLE
Update sourceforge mirror to jaist for astyle.

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -69,7 +69,7 @@ cd /tmp || die
 }
 
 [ $BUILD_TARGET != pretty-check ] || {
-    wget http://ufpr.dl.sourceforge.net/project/astyle/astyle/astyle%202.05.1/astyle_2.05.1_linux.tar.gz || die
+    wget http://jaist.dl.sourceforge.net/project/astyle/astyle/astyle%202.05.1/astyle_2.05.1_linux.tar.gz || die
     tar xzvf astyle_2.05.1_linux.tar.gz || die
     cd astyle/build/gcc || die
     LDFLAGS=" " make || die


### PR DESCRIPTION
The existing mirror (ufpr) seems to be down and not listed as an official sourceforge mirror.