### PR TITLE
ncp: Add support for allowing leader to remove an active router id.

### DIFF
--- a/src/ncp/PROTOCOL.md
+++ b/src/ncp/PROTOCOL.md
@@ -1616,6 +1616,14 @@ Used when operating in the Child role.
 Allows you to get or set the Thread `NETWORK_ID_TIMEOUT` constant, as
 defined by the Thread specification.
 
+#### D.4.21. PROP 5381: `PROP_THREAD_ACTIVE_ROUTER_IDS`
+* Type: Read-Write/Write-Only
+* Packed-Encoding: `A(C)` (List of active thread router ids)
+
+Note that some implementations may not support `CMD_GET_VALUE`
+routerids, but may support `CMD_REMOVE_VALUE` when the node is
+a leader.
+
 ### D.5. IPv6 Properties
 
 #### D.5.1. PROP 96: `PROP_IPV6_LL_ADDR`

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -388,6 +388,8 @@ private:
                                                              const uint8_t *value_ptr,
                                                              uint16_t value_len);
     ThreadError RemovePropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
+    ThreadError RemovePropertyHandler_THREAD_ACTIVE_ROUTER_IDS(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                              uint16_t value_len);
 
 private:
     enum

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -423,6 +423,16 @@ typedef enum
     SPINEL_PROP_THREAD_NETWORK_ID_TIMEOUT
                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 4,
 
+    /// List of active thread router ids
+    /** Format: `A(C)`
+     *
+     * Note that some implementations may not support CMD_GET_VALUE
+     * routerids, but may support CMD_REMOVE_VALUE when the node is
+     * a leader.
+     */
+    SPINEL_PROP_THREAD_ACTIVE_ROUTER_IDS
+                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 5,
+
     SPINEL_PROP_THREAD_EXT__END        = 0x1600,
 
     SPINEL_PROP_IPV6__BEGIN          = 0x60,


### PR DESCRIPTION
This commit defines a new property, `PROP_THREAD_ACTIVE_ROUTER_IDS`.
While this property is theoretically a list of router-ids,
`CMD_VALUE_GET` is not currently implemented for this property.
`CMD_VALUE_REMOVE`, however, is implemented by this commit and maps
directly to `otReleaseRouterId()`.