### PR TITLE
diags: Add output buffer size limitation to avoid overflow issue

### DIFF
--- a/examples/platforms/cc2538/diag.c
+++ b/examples/platforms/cc2538/diag.c
@@ -40,11 +40,11 @@
  */
 static bool sDiagMode = false;
 
-void otPlatDiagProcess(int argc, char *argv[], char *aOutput)
+void otPlatDiagProcess(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
     // add more plarform specific diagnostics features here
 
-    sprintf(aOutput, "diag feature '%s' is not supported\r\n", argv[0]);
+    snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", argv[0]);
     (void)argc;
 }
 

--- a/examples/platforms/posix/diag.c
+++ b/examples/platforms/posix/diag.c
@@ -40,10 +40,10 @@
  */
 static bool sDiagMode = false;
 
-void otPlatDiagProcess(int argc, char *argv[], char *aOutput)
+void otPlatDiagProcess(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
     // no more diagnostics features for Posix platform
-    sprintf(aOutput, "diag feature '%s' is not supported\r\n", argv[0]);
+    snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", argv[0]);
     (void)argc;
 }
 

--- a/include/platform/diag.h
+++ b/include/platform/diag.h
@@ -37,6 +37,7 @@
 #define DIAG_H_
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -59,8 +60,9 @@ extern "C" {
  * @param[in] argc  The argument counter of diagnostics command line.
  * @param[in] argv  The argument vector of diagnostics command line.
  * @param[out] aOutput  The diagnostics execution result.
+ * @param[in] aOutputMaxLen  The output buffer size.
  */
-void otPlatDiagProcess(int argc, char *argv[], char *aOutput);
+void otPlatDiagProcess(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
 
 /**
  *  Set diagnostics mode.

--- a/src/diag/diag_process.hpp
+++ b/src/diag/diag_process.hpp
@@ -48,7 +48,7 @@ namespace Diagnostics {
 struct Command
 {
     const char *mName;                         ///< A pointer to the command string.
-    void (*mCommand)(int argc, char *argv[], char *aOutput);  ///< A function pointer to process the command.
+    void (*mCommand)(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);  ///< A function pointer to process the command.
 };
 
 struct DiagStats
@@ -71,15 +71,15 @@ public:
     static void AlarmFired();
 
 private:
-    static void AppendErrorResult(ThreadError error, char *aOutput);
-    static void ProcessSleep(int argc, char *argv[], char *aOutput);
-    static void ProcessStart(int argc, char *argv[], char *aOutput);
-    static void ProcessStop(int argc, char *argv[], char *aOutput);
-    static void ProcessSend(int argc, char *argv[], char *aOutput);
-    static void ProcessRepeat(int argc, char *argv[], char *aOutput);
-    static void ProcessStats(int argc, char *argv[], char *aOutput);
-    static void ProcessChannel(int argc, char *argv[], char *aOutput);
-    static void ProcessPower(int argc, char *argv[], char *aOutput);
+    static void AppendErrorResult(ThreadError error, char *aOutput, size_t aOutputMaxLen);
+    static void ProcessSleep(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
+    static void ProcessStart(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
+    static void ProcessStop(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
+    static void ProcessSend(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
+    static void ProcessRepeat(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
+    static void ProcessStats(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
+    static void ProcessChannel(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
+    static void ProcessPower(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
     static void TxPacket();
     static ThreadError ParseLong(char *aString, long &aLong);
 


### PR DESCRIPTION
  - add aOutputMaxLen parameter in each diagnostics feature process function
  - use snprintf() to limit the size of output string