### PR TITLE
Fix default route issue

### DIFF
--- a/src/core/net/ip6_routes.cpp
+++ b/src/core/net/ip6_routes.cpp
@@ -82,7 +82,7 @@ ThreadError Routes::Remove(Route &aRoute)
 
 int8_t Routes::Lookup(const Address &aSource, const Address &aDestination)
 {
-    uint8_t maxPrefixMatch = 0;
+    int8_t maxPrefixMatch = -1;
     uint8_t prefixMatch;
     int8_t rval = -1;
 
@@ -100,21 +100,21 @@ int8_t Routes::Lookup(const Address &aSource, const Address &aDestination)
             prefixMatch = cur->mPrefixLength;
         }
 
-        if (maxPrefixMatch > prefixMatch)
+        if (maxPrefixMatch > static_cast<int8_t>(prefixMatch))
         {
             continue;
         }
 
-        maxPrefixMatch = prefixMatch;
+        maxPrefixMatch = static_cast<int8_t>(prefixMatch);
         rval = cur->mInterfaceId;
     }
 
     for (Netif *netif = Netif::GetNetifList(); netif; netif = netif->GetNext())
     {
         if (netif->RouteLookup(aSource, aDestination, &prefixMatch) == kThreadError_None &&
-            prefixMatch > maxPrefixMatch)
+            static_cast<int8_t>(prefixMatch) > maxPrefixMatch)
         {
-            maxPrefixMatch = prefixMatch;
+            maxPrefixMatch = static_cast<int8_t>(prefixMatch);
             rval = netif->GetInterfaceId();
         }
     }


### PR DESCRIPTION
prefix with p_default True should offer a default route for messages whose IP source uses P_prefix

It is for test 5.6.9, when ping destination is 2007::0 which is either an on-mesh prefix 2001::/ or match an external route 2002::/,  2001::/ with p_default set should not be given up due to prefixMatch is 0.
