### PR TITLE
NcpSpi: Ensure spi tx frame preparation and callbacks happen from the same tasklet

### DIFF
--- a/examples/platforms/posix/spi-stubs.c
+++ b/examples/platforms/posix/spi-stubs.c
@@ -39,6 +39,9 @@ ThreadError otPlatSpiSlaveEnable(
     void *aContext
 )
 {
+    (void)aCallback;
+    (void)aContext;
+
     fprintf(stderr, "\nNo SPI support for posix platform.");
     exit(0);
 
@@ -57,6 +60,12 @@ ThreadError otPlatSpiSlavePrepareTransaction(
     bool aRequestTransactionFlag
 )
 {
+    (void)anOutputBuf;
+    (void)anOutputBufLen;
+    (void)anInputBuf;
+    (void)anInputBufLen;
+    (void)aRequestTransactionFlag;
+
     return kThreadError_NotImplemented;
 }
 

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -86,8 +86,8 @@ static uint16_t spi_header_get_data_len(const uint8_t *header)
 
 NcpSpi::NcpSpi():
     NcpBase(),
-    mHandleRxFrame(&HandleRxFrame, this),
-    mHandleSendDone(&HandleSendDone, this),
+    mHandleRxFrameTask(&HandleRxFrame, this),
+    mPrepareTxFrameTask(&PrepareTxFrame, this),
     mTxFrameBuffer(mTxBuffer, sizeof(mTxBuffer))
 {
     memset(mEmptySendFrame, 0, kSpiHeaderLength);
@@ -161,6 +161,7 @@ NcpSpi::SpiTransactionComplete(
         {
             rx_accept_len = spi_header_get_accept_len(aMISOBuf);
             tx_data_len = spi_header_get_data_len(aMISOBuf);
+            (void)spi_header_get_flag_byte(aMISOBuf);
         }
 
         if (aMOSIBufLen >= kSpiHeaderLength)
@@ -175,7 +176,7 @@ NcpSpi::SpiTransactionComplete(
           && (rx_data_len <= rx_accept_len)
         ) {
             mHandlingRxFrame = true;
-            mHandleRxFrame.Post();
+            mHandleRxFrameTask.Post();
         }
 
         if ( mSending
@@ -186,7 +187,7 @@ NcpSpi::SpiTransactionComplete(
         ) {
             // Our transmission was successful.
             mHandlingSendDone = true;
-            mHandleSendDone.Post();
+            mPrepareTxFrameTask.Post();
         }
     }
 
@@ -261,7 +262,7 @@ void NcpSpi::TxFrameBufferHasData(void *aContext, NcpFrameBuffer *aNcpFrameBuffe
 
 void NcpSpi::TxFrameBufferHasData(void)
 {
-    PrepareNextSpiSendFrame();
+    mPrepareTxFrameTask.Post();
 }
 
 ThreadError NcpSpi::PrepareNextSpiSendFrame(void)
@@ -269,8 +270,6 @@ ThreadError NcpSpi::PrepareNextSpiSendFrame(void)
     ThreadError errorCode = kThreadError_None;
     uint16_t frameLength;
     uint16_t readLength;
-
-    VerifyOrExit(!mSending, errorCode = kThreadError_Busy);
 
     VerifyOrExit(!mTxFrameBuffer.IsEmpty(), ;);
 
@@ -321,16 +320,23 @@ exit:
     return errorCode;
 }
 
-void NcpSpi::HandleSendDone(void *aContext)
+void NcpSpi::PrepareTxFrame(void *aContext)
 {
-    static_cast<NcpSpi*>(aContext)->HandleSendDone();
+    static_cast<NcpSpi*>(aContext)->PrepareTxFrame();
 }
 
-void NcpSpi::HandleSendDone(void)
+void NcpSpi::PrepareTxFrame(void)
 {
-    mSending = false;
-    PrepareNextSpiSendFrame();
-    mHandlingSendDone = false;
+    if (mHandlingSendDone)
+    {
+        mSending = false;
+        PrepareNextSpiSendFrame();
+        mHandlingSendDone = false;
+    }
+    else if (!mSending)
+    {
+        PrepareNextSpiSendFrame();
+    }
 }
 
 void NcpSpi::HandleRxFrame(void *aContext)

--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -81,8 +81,8 @@ private:
     static void HandleRxFrame(void *context);
     void HandleRxFrame(void);
 
-    static void HandleSendDone(void *context);
-    void HandleSendDone(void);
+    static void PrepareTxFrame(void *context);
+    void PrepareTxFrame(void);
 
     static void TxFrameBufferHasData(void *aContext, NcpFrameBuffer *aNcpFrameBuffer);
     void TxFrameBufferHasData(void);
@@ -90,12 +90,11 @@ private:
     ThreadError PrepareNextSpiSendFrame(void);
 
     bool mSending;
-
     bool mHandlingRxFrame;
-    Tasklet mHandleRxFrame;
-
     bool mHandlingSendDone;
-    Tasklet mHandleSendDone;
+
+    Tasklet mHandleRxFrameTask;
+    Tasklet mPrepareTxFrameTask;
 
     uint8_t mSendFrame[kSpiBufferSize];
     uint16_t mSendFrameLen;


### PR DESCRIPTION
This commit changes the `NcpSpi` class implementation such that SPI tx frame preparation always happens from the same task `mPrepareTxFrameTask` This ensures that the callbacks to base class `Ncp` are also invoked from the the same task (and not from the the task calling `OutboundFrameEnd()`).