### PR TITLE
Dynamic Max Children

### DIFF
--- a/include/openthread.h
+++ b/include/openthread.h
@@ -385,9 +385,9 @@ uint8_t otGetMaxAllowedChildren(void);
  *
  * @retval  kThreadErrorNone           Successfully set the max.
  * @retval  kThreadError_InvalidArgs   If @p aMaxChildren is not in the range [1, OPENTHREAD_CONFIG_MAX_CHILDREN].
- * @retval  kThreadError_InvalidState  If OpenThread has already been started.
+ * @retval  kThreadError_InvalidState  If Thread has already been started.
  *
- * @sa otSetChildTimeout
+ * @sa otGetMaxAllowedChildren
  */
 ThreadError otSetMaxAllowedChildren(uint8_t aMaxChildren);
 

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -372,6 +372,26 @@ uint8_t otGetChannel(void);
 ThreadError otSetChannel(uint8_t aChannel);
 
 /**
+ * Get the maximum number of children currently allowed.
+ *
+ * @returns The maximum number of children currently allowed.
+ *
+ * @sa otSetMaxAllowedChildren
+ */
+uint8_t otGetMaxAllowedChildren(void);
+
+/**
+ * Set the maximum number of children currently allowed.
+ *
+ * @retval  kThreadErrorNone           Successfully set the max.
+ * @retval  kThreadError_InvalidArgs   If @p aMaxChildren is not in the range [1, OPENTHREAD_CONFIG_MAX_CHILDREN].
+ * @retval  kThreadError_InvalidState  If OpenThread has already been started.
+ *
+ * @sa otSetChildTimeout
+ */
+ThreadError otSetMaxAllowedChildren(uint8_t aMaxChildren);
+
+/**
  * Get the Thread Child Timeout used when operating in the Child role.
  *
  * @returns The Thread Child Timeout value.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -10,6 +10,7 @@ OpenThread test scripts use the CLI to execute test cases.
 * [channel](#channel)
 * [blacklist](#blacklist)
 * [child](#child)
+* [childmax](#childmax)
 * [childtimeout](#childtimeout)
 * [contextreusedelay](#contextreusedelay)
 * [counter](#counter)
@@ -151,6 +152,25 @@ Timeout: 100
 Age: 0
 LQI: 3
 RSSI: -20
+Done
+```
+
+### childmax
+
+Get the Thread maximum number of allowed children.
+
+```bash
+> childmax
+5
+Done
+```
+
+### childmax \<count\>
+
+Set the Thread maximum number of allowed children.
+
+```bash
+> childmax 2
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -393,7 +393,7 @@ void Interpreter::ProcessChildMax(int argc, char *argv[])
     else
     {
         SuccessOrExit(error = ParseLong(argv[0], value));
-        otSetMaxAllowedChildren(static_cast<uint8_t>(value));
+        SuccessOrExit(error = otSetMaxAllowedChildren(static_cast<uint8_t>(value)));
     }
 
 exit:

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -57,6 +57,7 @@ const struct Command Interpreter::sCommands[] =
     { "blacklist", &ProcessBlacklist },
     { "channel", &ProcessChannel },
     { "child", &ProcessChild },
+    { "childmax", &ProcessChildMax },
     { "childtimeout", &ProcessChildTimeout },
     { "contextreusedelay", &ProcessContextIdReuseDelay },
     { "counter", &ProcessCounters },
@@ -375,6 +376,25 @@ void Interpreter::ProcessChild(int argc, char *argv[])
     sServer->OutputFormat("Age: %d\r\n", childInfo.mAge);
     sServer->OutputFormat("LQI: %d\r\n", childInfo.mLinkQualityIn);
     sServer->OutputFormat("RSSI: %d\r\n", childInfo.mAverageRssi);
+
+exit:
+    AppendResult(error);
+}
+
+void Interpreter::ProcessChildMax(int argc, char *argv[])
+{
+    ThreadError error = kThreadError_None;
+    long value;
+
+    if (argc == 0)
+    {
+        sServer->OutputFormat("%d\r\n", otGetMaxAllowedChildren());
+    }
+    else
+    {
+        SuccessOrExit(error = ParseLong(argv[0], value));
+        otSetMaxAllowedChildren(static_cast<uint8_t>(value));
+    }
 
 exit:
     AppendResult(error);

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -134,6 +134,7 @@ private:
     static void ProcessChannel(int argc, char *argv[]);
     static void ProcessChild(int argc, char *argv[]);
     static void ProcessChildTimeout(int argc, char *argv[]);
+    static void ProcessChildMax(int argc, char *argv[]);
     static void ProcessContextIdReuseDelay(int argc, char *argv[]);
     static void ProcessCounters(int argc, char *argv[]);
     static void ProcessDataset(int argc, char *argv[]);

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -108,7 +108,7 @@ ThreadError otSetMaxAllowedChildren(uint8_t aMaxChildren)
     ThreadError error = kThreadError_None;
 
     // Do not allow setting max children if Thread is running
-    VerifyOrExit(sThreadNetif->GetMle().GetDeviceState() != Mle::kDeviceStateDisabled,
+    VerifyOrExit(sThreadNetif->GetMle().GetDeviceState() == Mle::kDeviceStateDisabled,
                  error = kThreadError_InvalidState);
 
     error = sThreadNetif->GetMle().SetMaxAllowedChildren(aMaxChildren);

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -105,16 +105,7 @@ uint8_t otGetMaxAllowedChildren(void)
 
 ThreadError otSetMaxAllowedChildren(uint8_t aMaxChildren)
 {
-    ThreadError error = kThreadError_None;
-
-    // Do not allow setting max children if Thread is running
-    VerifyOrExit(sThreadNetif->GetMle().GetDeviceState() == Mle::kDeviceStateDisabled,
-                 error = kThreadError_InvalidState);
-
-    error = sThreadNetif->GetMle().SetMaxAllowedChildren(aMaxChildren);
-
-exit:
-    return error;
+    return sThreadNetif->GetMle().SetMaxAllowedChildren(aMaxChildren);
 }
 
 uint32_t otGetChildTimeout(void)

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -94,6 +94,29 @@ ThreadError otSetChannel(uint8_t aChannel)
     return sThreadNetif->GetMac().SetChannel(aChannel);
 }
 
+uint8_t otGetMaxAllowedChildren(void)
+{
+    uint8_t aNumChildren;
+
+    (void)sThreadNetif->GetMle().GetChildren(&aNumChildren);
+
+    return aNumChildren;
+}
+
+ThreadError otSetMaxAllowedChildren(uint8_t aMaxChildren)
+{
+    ThreadError error = kThreadError_None;
+
+    // Do not allow setting max children if Thread is running
+    VerifyOrExit(sThreadNetif->GetMle().GetDeviceState() != Mle::kDeviceStateDisabled,
+                 error = kThreadError_InvalidState);
+
+    error = sThreadNetif->GetMle().SetMaxAllowedChildren(aMaxChildren);
+
+exit:
+    return error;
+}
+
 uint32_t otGetChildTimeout(void)
 {
     return sThreadNetif->GetMle().GetTimeout();

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -481,7 +481,7 @@ void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessag
     memcpy(&macAddr, mlIidTlv.GetIid(), sizeof(macAddr));
     macAddr.m8[0] ^= 0x2;
 
-    for (int i = 0; i < Mle::kMaxChildren; i++)
+    for (int i = 0; i < numChildren; i++)
     {
         if (children[i].mState != Neighbor::kStateValid || (children[i].mMode & Mle::ModeTlv::kModeFFD) != 0)
         {
@@ -547,7 +547,7 @@ void AddressResolver::HandleAddressQuery(Coap::Header &aHeader, Message &aMessag
 
     children = mMle.GetChildren(&numChildren);
 
-    for (int i = 0; i < Mle::kMaxChildren; i++)
+    for (int i = 0; i < numChildren; i++)
     {
         if (children[i].mState != Neighbor::kStateValid || (children[i].mMode & Mle::ModeTlv::kModeFFD) != 0)
         {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -65,6 +65,7 @@ MleRouter::MleRouter(ThreadNetif &aThreadNetif):
     mRouterUpgradeThreshold = kRouterUpgradeThreshold;
     mLeaderWeight = kLeaderWeight;
     mFixedLeaderPartitionId = 0;
+    mMaxChildrenAllowed = kMaxChildren;
     mRouterId = kMaxRouterId;
     mPreviousRouterId = kMaxRouterId;
     mAdvertiseInterval = kAdvertiseIntervalMin;
@@ -986,7 +987,7 @@ ThreadError MleRouter::HandleLinkReject(const Message &aMessage, const Ip6::Mess
 
 Child *MleRouter::NewChild(void)
 {
-    for (int i = 0; i < kMaxChildren; i++)
+    for (int i = 0; i < mMaxChildrenAllowed; i++)
     {
         if (mChildren[i].mState == Neighbor::kStateInvalid)
         {
@@ -1001,7 +1002,7 @@ Child *MleRouter::FindChild(uint16_t aChildId)
 {
     Child *rval = NULL;
 
-    for (int i = 0; i < kMaxChildren; i++)
+    for (int i = 0; i < mMaxChildrenAllowed; i++)
     {
         if (mChildren[i].mState != Neighbor::kStateInvalid &&
             GetChildId(mChildren[i].mValid.mRloc16) == aChildId)
@@ -1018,7 +1019,7 @@ Child *MleRouter::FindChild(const Mac::ExtAddress &aAddress)
 {
     Child *rval = NULL;
 
-    for (int i = 0; i < kMaxChildren; i++)
+    for (int i = 0; i < mMaxChildrenAllowed; i++)
     {
         if (mChildren[i].mState != Neighbor::kStateInvalid &&
             memcmp(&mChildren[i].mMacAddr, &aAddress, sizeof(mChildren[i].mMacAddr)) == 0)
@@ -1140,7 +1141,7 @@ bool MleRouter::IsSingleton(void)
         }
 
         // not a singleton if any children are REEDs
-        for (int i = 0; i < kMaxChildren; i++)
+        for (int i = 0; i < mMaxChildrenAllowed; i++)
         {
             if (mChildren[i].mState == Neighbor::kStateValid && (mChildren[i].mMode & ModeTlv::kModeFFD))
             {
@@ -1599,7 +1600,7 @@ void MleRouter::HandleStateUpdateTimer(void)
     }
 
     // update children state
-    for (int i = 0; i < kMaxChildren; i++)
+    for (int i = 0; i < mMaxChildrenAllowed; i++)
     {
         if (mChildren[i].mState == Neighbor::kStateInvalid)
         {
@@ -2227,7 +2228,7 @@ exit:
 
 Child *MleRouter::GetChild(uint16_t aAddress)
 {
-    for (int i = 0; i < kMaxChildren; i++)
+    for (int i = 0; i < mMaxChildrenAllowed; i++)
     {
         if (mChildren[i].mState == Neighbor::kStateValid && mChildren[i].mValid.mRloc16 == aAddress)
         {
@@ -2240,7 +2241,7 @@ Child *MleRouter::GetChild(uint16_t aAddress)
 
 Child *MleRouter::GetChild(const Mac::ExtAddress &aAddress)
 {
-    for (int i = 0; i < kMaxChildren; i++)
+    for (int i = 0; i < mMaxChildrenAllowed; i++)
     {
         if (mChildren[i].mState == Neighbor::kStateValid &&
             memcmp(&mChildren[i].mMacAddr, &aAddress, sizeof(mChildren[i].mMacAddr)) == 0)
@@ -2275,10 +2276,24 @@ Child *MleRouter::GetChildren(uint8_t *numChildren)
 {
     if (numChildren != NULL)
     {
-        *numChildren = kMaxChildren;
+        *numChildren = mMaxChildrenAllowed;
     }
 
     return mChildren;
+}
+
+ThreadError MleRouter::SetMaxAllowedChildren(uint8_t aMaxChildren)
+{
+    ThreadError error = kThreadError_None;
+
+    // Ensure the value is between 1 and kMaxChildren
+    VerifyOrExit(aMaxChildren > 0 && aMaxChildren <= kMaxChildren, error = kThreadError_InvalidArgs);
+
+    // Save the value
+    mMaxChildrenAllowed = aMaxChildren;
+
+exit:
+    return error;
 }
 
 ThreadError MleRouter::RemoveNeighbor(const Mac::Address &aAddress)
@@ -2345,7 +2360,7 @@ Neighbor *MleRouter::GetNeighbor(uint16_t aAddress)
 
     case kDeviceStateRouter:
     case kDeviceStateLeader:
-        for (int i = 0; i < kMaxChildren; i++)
+        for (int i = 0; i < mMaxChildrenAllowed; i++)
         {
             if (mChildren[i].mState == Neighbor::kStateValid && mChildren[i].mValid.mRloc16 == aAddress)
             {
@@ -2384,7 +2399,7 @@ Neighbor *MleRouter::GetNeighbor(const Mac::ExtAddress &aAddress)
 
     case kDeviceStateRouter:
     case kDeviceStateLeader:
-        for (int i = 0; i < kMaxChildren; i++)
+        for (int i = 0; i < mMaxChildrenAllowed; i++)
         {
             if (mChildren[i].mState == Neighbor::kStateValid &&
                 memcmp(&mChildren[i].mMacAddr, &aAddress, sizeof(mChildren[i].mMacAddr)) == 0)
@@ -2461,7 +2476,7 @@ Neighbor *MleRouter::GetNeighbor(const Ip6::Address &aAddress)
         context.mContextId = 0xff;
     }
 
-    for (int i = 0; i < kMaxChildren; i++)
+    for (int i = 0; i < mMaxChildrenAllowed; i++)
     {
         child = &mChildren[i];
 
@@ -2635,7 +2650,7 @@ ThreadError MleRouter::GetChildInfoByIndex(uint8_t aChildIndex, otChildInfo &aCh
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(aChildIndex < kMaxChildren, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aChildIndex < mMaxChildrenAllowed, error = kThreadError_InvalidArgs);
     GetChildInfo(mChildren[aChildIndex], aChildInfo);
 
 exit:
@@ -2908,7 +2923,7 @@ void MleRouter::HandleAddressSolicitResponse(Message &aMessage)
     ResetAdvertiseInterval();
 
     // send child id responses
-    for (int i = 0; i < kMaxChildren; i++)
+    for (int i = 0; i < mMaxChildrenAllowed; i++)
     {
         switch (mChildren[i].mState)
         {
@@ -3180,7 +3195,7 @@ ThreadError MleRouter::AppendConnectivity(Message &aMessage)
 
     tlv.Init();
 
-    for (int i = 0; i < kMaxChildren; i++)
+    for (int i = 0; i < mMaxChildrenAllowed; i++)
     {
         if (mChildren[i].mState == Neighbor::kStateValid)
         {
@@ -3188,7 +3203,7 @@ ThreadError MleRouter::AppendConnectivity(Message &aMessage)
         }
     }
 
-    if ((kMaxChildren - numChildren) < (kMaxChildren / 3))
+    if ((mMaxChildrenAllowed - numChildren) < (mMaxChildrenAllowed / 3))
     {
         tlv.SetParentPriority(-1);
     }

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2289,6 +2289,9 @@ ThreadError MleRouter::SetMaxAllowedChildren(uint8_t aMaxChildren)
     // Ensure the value is between 1 and kMaxChildren
     VerifyOrExit(aMaxChildren > 0 && aMaxChildren <= kMaxChildren, error = kThreadError_InvalidArgs);
 
+    // Do not allow setting max children if Thread is running
+    VerifyOrExit(GetDeviceState() == Mle::kDeviceStateDisabled, error = kThreadError_InvalidState);
+
     // Save the value
     mMaxChildrenAllowed = aMaxChildren;
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2289,8 +2289,8 @@ ThreadError MleRouter::SetMaxAllowedChildren(uint8_t aMaxChildren)
     // Ensure the value is between 1 and kMaxChildren
     VerifyOrExit(aMaxChildren > 0 && aMaxChildren <= kMaxChildren, error = kThreadError_InvalidArgs);
 
-    // Do not allow setting max children if Thread is running
-    VerifyOrExit(GetDeviceState() == Mle::kDeviceStateDisabled, error = kThreadError_InvalidState);
+    // Do not allow setting max children if MLE is running
+    VerifyOrExit(GetDeviceState() == kDeviceStateDisabled, error = kThreadError_InvalidState);
 
     // Save the value
     mMaxChildrenAllowed = aMaxChildren;

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -323,6 +323,7 @@ public:
      *
      * @retval  kThreadErrorNone           Successfully set the max.
      * @retval  kThreadError_InvalidArgs   If @p aMaxChildren is not in the range [1, kMaxChildren].
+     * @retval  kThreadError_InvalidState  If OpenThread has already been started.
      *
      */
     ThreadError SetMaxAllowedChildren(uint8_t aMaxChildren);

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -317,6 +317,17 @@ public:
     Child *GetChildren(uint8_t *aNumChildren);
 
     /**
+     * This method sets the max children allowed value for this Thread interface.
+     *
+     * @param[in]  aMaxChildren  The max children allowed value.
+     *
+     * @retval  kThreadErrorNone           Successfully set the max.
+     * @retval  kThreadError_InvalidArgs   If @p aMaxChildren is not in the range [1, kMaxChildren].
+     *
+     */
+    ThreadError SetMaxAllowedChildren(uint8_t aMaxChildren);
+
+    /**
      * This method returns a pointer to a Neighbor object.
      *
      * @param[in]  aAddress  The address of the Neighbor.
@@ -528,6 +539,7 @@ private:
     uint8_t mRouterIdSequence;
     uint32_t mRouterIdSequenceLastUpdated;
     Router mRouters[kMaxRouterId];
+    uint8_t mMaxChildrenAllowed;
     Child mChildren[kMaxChildren];
 
     uint8_t mChallenge[8];

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -323,7 +323,7 @@ public:
      *
      * @retval  kThreadErrorNone           Successfully set the max.
      * @retval  kThreadError_InvalidArgs   If @p aMaxChildren is not in the range [1, kMaxChildren].
-     * @retval  kThreadError_InvalidState  If OpenThread has already been started.
+     * @retval  kThreadError_InvalidState  If MLE has already been started.
      *
      */
     ThreadError SetMaxAllowedChildren(uint8_t aMaxChildren);


### PR DESCRIPTION
Add support for dynamically adjusting the maximum number of allowed children. This is needed for more easily testing some scenarios on Windows around configuring multiple hop networks.