### PR TITLE
Add check for CLI argument number

### DIFF
--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -126,11 +126,6 @@ typedef enum ThreadError
      */
     kThreadError_BlacklistFiltered = 27,
 
-    /**
-     * Too many arguments.
-     */
-    kThreadError_TooManyArgs = 28,
-
     kThreadError_Error = 255,
 } ThreadError;
 

--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -126,6 +126,11 @@ typedef enum ThreadError
      */
     kThreadError_BlacklistFiltered = 27,
 
+    /**
+     * Too many arguments.
+     */
+    kThreadError_TooManyArgs = 28,
+
     kThreadError_Error = 255,
 } ThreadError;
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1898,6 +1898,9 @@ void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength, Server &aServer)
         {
             argv[argc++] = cmd;
         }
+
+        VerifyOrExit(argc < kMaxArgs,
+                     sServer->OutputFormat("Error %d, Max %d\r\n", kThreadError_TooManyArgs, kMaxArgs));
     }
 
     cmd = aBuf;

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1899,7 +1899,7 @@ void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength, Server &aServer)
             argv[argc++] = cmd;
         }
 
-        VerifyOrExit(argc < kMaxArgs,
+        VerifyOrExit(argc <= kMaxArgs,
                      sServer->OutputFormat("Error: too many args (max %d)\r\n", kMaxArgs));
     }
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1900,7 +1900,7 @@ void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength, Server &aServer)
         }
 
         VerifyOrExit(argc < kMaxArgs,
-                     sServer->OutputFormat("Error %d, Max %d\r\n", kThreadError_TooManyArgs, kMaxArgs));
+                     sServer->OutputFormat("Error: too many args (max %d)\r\n", kMaxArgs));
     }
 
     cmd = aBuf;

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1889,6 +1889,9 @@ void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength, Server &aServer)
 
     for (cmd = aBuf + 1; (cmd < aBuf + aBufLength) && (cmd != NULL); ++cmd)
     {
+        VerifyOrExit(argc < kMaxArgs,
+                     sServer->OutputFormat("Error: too many args (max %d)\r\n", kMaxArgs));
+
         if (*cmd == ' ' || *cmd == '\r' || *cmd == '\n')
         {
             *cmd = '\0';
@@ -1898,9 +1901,6 @@ void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength, Server &aServer)
         {
             argv[argc++] = cmd;
         }
-
-        VerifyOrExit(argc <= kMaxArgs,
-                     sServer->OutputFormat("Error: too many args (max %d)\r\n", kMaxArgs));
     }
 
     cmd = aBuf;


### PR DESCRIPTION
CLI user may input too many arguments to crash the node.