### PR TITLE
fix AppendRoute() bug: LinkQualityOut is always 0

### DIFF
--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -591,7 +591,7 @@ public:
     void SetLinkQualityOut(uint8_t aRouterId, uint8_t aLinkQuality) {
         mRouteData[aRouterId] =
             (mRouteData[aRouterId] & ~kLinkQualityOutMask) |
-            ((aLinkQuality << kLinkQualityOutOffset) & kLinkQualityInMask);
+            ((aLinkQuality << kLinkQualityOutOffset) & kLinkQualityOutMask);
     }
 
 private:


### PR DESCRIPTION
one typo introduced in #358 