### PR TITLE
Don't reset key sequence when setting the same master key

### DIFF
--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -68,6 +68,8 @@ ThreadError KeyManager::SetMasterKey(const void *aKey, uint8_t aKeyLength)
     ThreadError error = kThreadError_None;
 
     VerifyOrExit(aKeyLength <= sizeof(mMasterKey), error = kThreadError_InvalidArgs);
+    VerifyOrExit((mMasterKeyLength != aKeyLength) || (memcmp(mMasterKey, aKey, aKeyLength) != 0), ;);
+
     memcpy(mMasterKey, aKey, aKeyLength);
     mMasterKeyLength = aKeyLength;
     mKeySequence = 0;


### PR DESCRIPTION
Update 'SetMasterKey()' to reset key sequence only when setting a different master key.

Resolves #467.