### PR TITLE
mle_tlvs: fix kModeSecureDataRequest

### DIFF
--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -232,8 +232,8 @@ public:
 
     enum
     {
+        kModeSecureDataRequest = 1 << 6,
         kModeRxOnWhenIdle      = 1 << 3,
-        kModeSecureDataRequest = 1 << 2,
         kModeFFD               = 1 << 1,
         kModeFullNetworkData   = 1 << 0,
     };


### PR DESCRIPTION
According 802.15.4-2006 (MLE refers to that version) the security
capbility information bit is 6 not 2. The 2 bit represents the Power
Source capbility.