### PR TITLE
Fix bug in starting a timer.

### DIFF
--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -42,7 +42,7 @@ static Timer   *sTail = NULL;
 
 void TimerScheduler::Add(Timer &aTimer)
 {
-    VerifyOrExit(aTimer.mNext == NULL && sTail != &aTimer, ;);
+    Remove(aTimer);
 
     if (sHead == NULL)
     {
@@ -83,9 +83,6 @@ void TimerScheduler::Add(Timer &aTimer)
             sTail = &aTimer;
         }
     }
-
-exit:
-    return;
 }
 
 void TimerScheduler::Remove(Timer &aTimer)


### PR DESCRIPTION
This fixes an issue where calling Start() on a running timer could
lead to out-of-order timers.  This fix always removes the timer from
the list then adds it back after the timer values have been updated.