### PR TITLE
ncp: add flag to pass RLOC16 IPv6 traffic to host.

### DIFF
--- a/src/ncp/PROTOCOL.md
+++ b/src/ncp/PROTOCOL.md
@@ -1624,6 +1624,15 @@ Note that some implementations may not support `CMD_GET_VALUE`
 routerids, but may support `CMD_REMOVE_VALUE` when the node is
 a leader.
 
+#### D.4.22. PROP 5382: `PROP_THREAD_RLOC16_DEBUG_PASSTHRU`
+* Type: Read-Write
+* Packed-Encoding: `b`
+
+Allow the HOST to directly observe all IPv6 packets received by the NCP,
+including ones sent to the RLOC16 address.
+
+Default value is `false`.
+
 ### D.5. IPv6 Properties
 
 #### D.5.1. PROP 96: `PROP_IPV6_LL_ADDR`
@@ -1675,3 +1684,4 @@ Allow the NCP to directly respond to ICMP ping requests. If this is
 turned on, ping request ICMP packets will not be passed to the host.
 
 Default value is `false`.
+

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -280,6 +280,7 @@ private:
     ThreadError GetPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_IPV6_ROUTE_TABLE(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_IPV6_ICMP_PING_OFFLOAD(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_RLOC16_DEBUG_PASSTHRU(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_MAC_SCAN_MASK(uint8_t header, spinel_prop_key_t key);
@@ -342,6 +343,8 @@ private:
                                                   uint16_t value_len);
     ThreadError SetPropertyHandler_IPV6_ICMP_PING_OFFLOAD(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                   uint16_t value_len);
+    ThreadError SetPropertyHandler_THREAD_RLOC16_DEBUG_PASSTHRU(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+						       uint16_t value_len);
     ThreadError SetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                uint16_t value_len);
     ThreadError SetPropertyHandler_MAC_FILTER_MODE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1110,6 +1110,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE";
         break;
 
+    case SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU:
+        ret = "SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU";
+        break;
+
     case SPINEL_PROP_MAC_WHITELIST:
         ret = "PROP_MAC_WHITELIST";
         break;

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -438,6 +438,12 @@ typedef enum
     SPINEL_PROP_THREAD_ACTIVE_ROUTER_IDS
                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 5,
 
+    /// Forward IPv6 packets that use RLOC16 addresses to HOST.
+    /** Format: `b`
+     */
+    SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU
+                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 6,
+
     SPINEL_PROP_THREAD_EXT__END        = 0x1600,
 
     SPINEL_PROP_IPV6__BEGIN          = 0x60,
@@ -456,7 +462,7 @@ typedef enum
      *
      * Default value is `false`.
      */
-    SPINEL_PROP_IPV6_ICMP_PING_OFFLOAD = SPINEL_PROP_IPV6__BEGIN + 5,
+    SPINEL_PROP_IPV6_ICMP_PING_OFFLOAD = SPINEL_PROP_IPV6__BEGIN + 5, ///< [b]
 
     SPINEL_PROP_IPV6__END            = 0x70,
 


### PR DESCRIPTION
Add SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU to allow forwarding of RLOC16 traffic to HOST, including receipt of ping responses to RLOC16.