### PR TITLE
ncp: Adds new property, PROP_NET_REQUIRE_JOIN_EXISTING

### DIFF
--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -79,7 +79,7 @@ ThreadError ThreadNetif::Up(void)
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(!mIsUp, error = kThreadError_InvalidState);
+    VerifyOrExit(!mIsUp, error = kThreadError_Already);
 
     Netif::AddNetif();
     mMeshForwarder.Start();

--- a/src/ncp/PROTOCOL.md
+++ b/src/ncp/PROTOCOL.md
@@ -738,7 +738,13 @@ of the metadata is defined by the associated network protocol.
     buffer.
  *  17: `STATUS_NO_ACK`: The packet was not acknowledged.
  *  18: `STATUS_CCA_FAILURE`: The packet was not sent due to a CCA failure.
- *  19-111: *RESERVED*
+ *  19-103: *RESERVED*
+ *  104-111: Join Failure Causes (See `PROP_NET_REQUIRE_JOIN_EXISTING`)
+     *  104: `SPINEL_STATUS_JOIN_FAILURE`
+     *  105: `SPINEL_STATUS_JOIN_SECURITY`
+     *  106: `SPINEL_STATUS_JOIN_NO_PEERS`
+     *  107: `SPINEL_STATUS_JOIN_INCOMPATIBLE`
+     *  108-111: *RESERVED-JOIN-FAILURE-CODES*
  *  112-127: Reset Causes
      *  112: `STATUS_RESET_POWER_ON`
      *  113: `STATUS_RESET_EXTERNAL`
@@ -1491,6 +1497,24 @@ Values:
 
 The partition ID of the partition that this node is a member of.
 
+#### D.4.23. PROP 73: `PROP_NET_REQUIRE_JOIN_EXISTING`
+* Type: Read-Write
+* Format: `b`
+* Default Value: `false`
+
+This flag is typically used for nodes that are associating with an
+existing network for the first time. If this is set to `true` before
+`PROP_NET_STACK_UP` is set to `true`, the creation of a new partition
+at association is prevented. If the node cannot associate with an
+existing partition, `PROP_LAST_STATUS` will emit a status that
+indicates why the association failed and `PROP_NET_STACK_UP` will
+automatically revert to `false`.
+
+Once associated with an existing partition, this flag automatically
+reverts to `false`.
+
+The behavior of this property being set to `true` when
+`PROP_NET_STACK_UP` is already set to `true` is undefined.
 
 
 ### D.4. THREAD Properties
@@ -1632,6 +1656,7 @@ Allow the HOST to directly observe all IPv6 packets received by the NCP,
 including ones sent to the RLOC16 address.
 
 Default value is `false`.
+
 
 ### D.5. IPv6 Properties
 

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -314,7 +314,7 @@ private:
     ThreadError GetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key);
-
+    ThreadError GetPropertyHandler_NET_REQUIRE_JOIN_EXISTING(uint8_t header, spinel_prop_key_t key);
 
     ThreadError SetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                uint16_t value_len);
@@ -373,6 +373,8 @@ private:
     ThreadError SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
                                                     const uint8_t *value_ptr, uint16_t value_len);
     ThreadError SetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key,
+                                                   const uint8_t *value_ptr, uint16_t value_len);
+    ThreadError SetPropertyHandler_NET_REQUIRE_JOIN_EXISTING(uint8_t header, spinel_prop_key_t key,
                                                    const uint8_t *value_ptr, uint16_t value_len);
     ThreadError SetPropertyHandler_CNTR_RESET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                               uint16_t value_len);
@@ -434,6 +436,7 @@ private:
     otNetifAddress mNetifAddresses[kNetifAddressListSize];
 
     bool mAllowLocalNetworkDataChange;
+    bool mRequireJoinExistingNetwork;
 
     uint32_t mFramingErrorCounter;             // Number of inproperly formed received spinel frames.
     uint32_t mRxSpinelFrameCounter;            // Number of received (inbound) spinel frames.

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1138,6 +1138,11 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_THREAD_CONTEXT_REUSE_DELAY";
         break;
 
+    case SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING:
+        ret = "PROP_NET_REQUIRE_JOIN_EXISTING";
+        break;
+
+
     case SPINEL_PROP_NEST_STREAM_MFG:
         ret = "SPINEL_PROP_NEST_STREAM_MFG";
         break;
@@ -1237,6 +1242,22 @@ const char *spinel_status_to_cstr(spinel_status_t status)
 
     case SPINEL_STATUS_ITEM_NOT_FOUND:
         ret = "STATUS_ITEM_NOT_FOUND";
+        break;
+
+    case SPINEL_STATUS_JOIN_FAILURE:
+        ret = "STATUS_JOIN_FAILURE";
+        break;
+
+    case SPINEL_STATUS_JOIN_SECURITY:
+        ret = "STATUS_JOIN_SECURITY";
+        break;
+
+    case SPINEL_STATUS_JOIN_NO_PEERS:
+        ret = "STATUS_JOIN_NO_PEERS";
+        break;
+
+    case SPINEL_STATUS_JOIN_INCOMPATIBLE:
+        ret = "STATUS_JOIN_INCOMPATIBLE";
         break;
 
     case SPINEL_STATUS_RESET_POWER_ON:

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -102,6 +102,41 @@ typedef enum
     SPINEL_STATUS_ALREADY           = 19, ///< The operation is already in progress.
     SPINEL_STATUS_ITEM_NOT_FOUND    = 20, ///< The given item could not be found.
 
+    SPINEL_STATUS_JOIN__BEGIN       = 104,
+
+    /// Generic failure to associate with other peers.
+    /**
+     *  This status error should not be used by implementors if
+     *  enough information is available to determine that one of the
+     *  later join failure status codes would be more accurate.
+     *
+     *  \sa SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
+     */
+    SPINEL_STATUS_JOIN_FAILURE      = SPINEL_STATUS_JOIN__BEGIN + 0,
+
+    /// The node found other peers but was unable to decode their packets.
+    /**
+     *  Typically this error code indicates that the network
+     *  key has been set incorrectly.
+     *
+     *  \sa SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
+     */
+    SPINEL_STATUS_JOIN_SECURITY     = SPINEL_STATUS_JOIN__BEGIN + 1,
+
+    /// The node was unable to find any other peers on the network.
+    /**
+     *  \sa SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
+     */
+    SPINEL_STATUS_JOIN_NO_PEERS     = SPINEL_STATUS_JOIN__BEGIN + 2,
+
+    /// The only potential peer nodes found are incompatible.
+    /**
+     *  \sa SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
+     */
+    SPINEL_STATUS_JOIN_INCOMPATIBLE = SPINEL_STATUS_JOIN__BEGIN + 3,
+
+    SPINEL_STATUS_JOIN__END         = 112,
+
     SPINEL_STATUS_RESET__BEGIN      = 112,
     SPINEL_STATUS_RESET_POWER_ON    = SPINEL_STATUS_RESET__BEGIN + 0,
     SPINEL_STATUS_RESET_EXTERNAL    = SPINEL_STATUS_RESET__BEGIN + 1,
@@ -363,6 +398,28 @@ typedef enum
     SPINEL_PROP_NET_MASTER_KEY       = SPINEL_PROP_NET__BEGIN + 6, ///< [D]
     SPINEL_PROP_NET_KEY_SEQUENCE     = SPINEL_PROP_NET__BEGIN + 7, ///< [L]
     SPINEL_PROP_NET_PARTITION_ID     = SPINEL_PROP_NET__BEGIN + 8, ///< [L]
+
+    /// Require Join Existing
+    /** Format: `b`
+     *  Default Value: `false`
+     *
+     * This flag is typically used for nodes that are associating with an
+     * existing network for the first time. If this is set to `true` before
+     * `PROP_NET_STACK_UP` is set to `true`, the
+     * creation of a new partition at association is prevented. If the node
+     * cannot associate with an existing partition, `PROP_LAST_STATUS` will
+     * emit a status that indicates why the association failed and
+     * `PROP_NET_STACK_UP` will automatically revert to `false`.
+     *
+     * Once associated with an existing partition, this flag automatically
+     * reverts to `false`.
+     *
+     * The behavior of this property being set to `true` when
+     * `PROP_NET_STACK_UP` is already set to `true` is undefined.
+     */
+    SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
+                                     = SPINEL_PROP_NET__BEGIN + 9,
+
     SPINEL_PROP_NET__END             = 0x50,
 
     SPINEL_PROP_THREAD__BEGIN          = 0x50,


### PR DESCRIPTION
This new flag is typically used for nodes that are associating with an
existing network for the first time. If this is set to `true` before
`PROP_NET_STACK_UP` is set to `true`, the creation of a new partition
at association is prevented. If the node cannot associate with an
existing partition, `PROP_LAST_STATUS` will emit a status that
indicates why the association failed and `PROP_NET_STACK_UP` will
automatically revert to `false`.

Once associated with an existing partition, this flag automatically
reverts to `false`.