### PR TITLE
otAddUnicastAddress Doesn't Hold onto External Pointers

### DIFF
--- a/include/openthread.h
+++ b/include/openthread.h
@@ -650,26 +650,28 @@ const otNetifAddress *otGetUnicastAddresses(void);
 /**
  * Add a Network Interface Address to the Thread interface.
  *
- * The passed in instance @p aAddress will be added and stored by the Thread interface, so the caller should ensure
- * that the address instance remains valid (not de-alloacted) and is not modified after a successful call to this
- * method.
+ * The passed in instance @p aAddress will be copied by the Thread interface. The Thread interface only
+ * supports a fixed number of externally added unicast addresses. See OPENTHREAD_CONFIG_MAX_EXT_IP_ADDRS.
  *
  * @param[in]  aAddress  A pointer to a Network Interface Address.
  *
- * @retval kThreadErrorNone  Successfully added the Network Interface Address.
- * @retval kThreadErrorBusy  The Network Interface Address pointed to by @p aAddress is already added.
+ * @retval kThreadErrorNone          Successfully added the Network Interface Address.
+ * @retval kThreadError_InvalidArgs  The IP Address indicated by @p aAddress is an internal address.
+ * @retval kThreadError_NoBufs       The Network Interface is already storing the maximum allowed external addresses.
+ * @retval kThreadErrorBusy          The Network Interface Address indicated by @p aAddress is already added.
  */
-ThreadError otAddUnicastAddress(otNetifAddress *aAddress);
+ThreadError otAddUnicastAddress(const otNetifAddress *aAddress);
 
 /**
  * Remove a Network Interface Address from the Thread interface.
  *
- * @param[in]  aAddress  A pointer to a Network Interface Address.
+ * @param[in]  aAddress  A pointer to an IP Address.
  *
- * @retval kThreadErrorNone      Successfully removed the Network Interface Address.
- * @retval kThreadErrorNotFound  The Network Interface Address point to by @p aAddress was not added.
+ * @retval kThreadErrorNone          Successfully removed the Network Interface Address.
+ * @retval kThreadError_InvalidArgs  The IP Address indicated by @p aAddress is an internal address.
+ * @retval kThreadErrorBusy          The IP Address indicated by @p aAddress was not found.
  */
-ThreadError otRemoveUnicastAddress(otNetifAddress *aAddress);
+ThreadError otRemoveUnicastAddress(const otIp6Address *aAddress);
 
 /**
  * This function pointer is called to notify certain configuration or state changes within OpenThread.

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -655,10 +655,9 @@ const otNetifAddress *otGetUnicastAddresses(void);
  *
  * @param[in]  aAddress  A pointer to a Network Interface Address.
  *
- * @retval kThreadErrorNone          Successfully added the Network Interface Address.
+ * @retval kThreadErrorNone          Successfully added (or updated) the Network Interface Address.
  * @retval kThreadError_InvalidArgs  The IP Address indicated by @p aAddress is an internal address.
  * @retval kThreadError_NoBufs       The Network Interface is already storing the maximum allowed external addresses.
- * @retval kThreadErrorBusy          The Network Interface Address indicated by @p aAddress is already added.
  */
 ThreadError otAddUnicastAddress(const otNetifAddress *aAddress);
 
@@ -669,7 +668,7 @@ ThreadError otAddUnicastAddress(const otNetifAddress *aAddress);
  *
  * @retval kThreadErrorNone          Successfully removed the Network Interface Address.
  * @retval kThreadError_InvalidArgs  The IP Address indicated by @p aAddress is an internal address.
- * @retval kThreadErrorBusy          The IP Address indicated by @p aAddress was not found.
+ * @retval kThreadError_NotFound     The IP Address indicated by @p aAddress was not found.
  */
 ThreadError otRemoveUnicastAddress(const otIp6Address *aAddress);
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -102,8 +102,6 @@ const struct Command Interpreter::sCommands[] =
 #endif
 };
 
-otNetifAddress Interpreter::sAddress;
-
 static otDEFINE_ALIGNED_VAR(sPingTimerBuf, sizeof(Timer), uint64_t);
 Timer *Interpreter::sPingTimer;
 
@@ -611,14 +609,15 @@ exit:
 ThreadError Interpreter::ProcessIpAddrAdd(int argc, char *argv[])
 {
     ThreadError error;
+    otNetifAddress aAddress;
 
     VerifyOrExit(argc > 0, error = kThreadError_Parse);
 
-    SuccessOrExit(error = otIp6AddressFromString(argv[0], &sAddress.mAddress));
-    sAddress.mPrefixLength = 64;
-    sAddress.mPreferredLifetime = 0xffffffff;
-    sAddress.mValidLifetime = 0xffffffff;
-    error = otAddUnicastAddress(&sAddress);
+    SuccessOrExit(error = otIp6AddressFromString(argv[0], &aAddress.mAddress));
+    aAddress.mPrefixLength = 64;
+    aAddress.mPreferredLifetime = 0xffffffff;
+    aAddress.mValidLifetime = 0xffffffff;
+    error = otAddUnicastAddress(&aAddress);
 
 exit:
     return error;
@@ -632,8 +631,7 @@ ThreadError Interpreter::ProcessIpAddrDel(int argc, char *argv[])
     VerifyOrExit(argc > 0, error = kThreadError_Parse);
 
     SuccessOrExit(error = otIp6AddressFromString(argv[0], &address));
-    VerifyOrExit(otIsIp6AddressEqual(&address, &sAddress.mAddress), error = kThreadError_Parse);
-    error = otRemoveUnicastAddress(&sAddress);
+    error = otRemoveUnicastAddress(&address);
 
 exit:
     return error;
@@ -1989,7 +1987,7 @@ void Interpreter::HandleNetifStateChanged(uint32_t aFlags, void *aContext)
 
         if (!found)
         {
-            otRemoveUnicastAddress(address);
+            otRemoveUnicastAddress(&address->mAddress);
             address->mValidLifetime = 0;
         }
     }

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -192,7 +192,6 @@ private:
     static void HandleLinkPcapReceive(const RadioPacket *aFrame, void *aContext);
 
     static const struct Command sCommands[];
-    static otNetifAddress sAddress;
 
     static Ip6::MessageInfo sMessageInfo;
     static Server *sServer;

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -366,6 +366,8 @@ ThreadError Netif::AddExternalUnicastAddress(const NetifUnicastAddress &aAddress
     mExtUnicastAddresses[index].mNext = mUnicastAddresses;
 
     mUnicastAddresses = &mExtUnicastAddresses[index];
+    
+    SetStateChangedFlags(OT_IP6_ADDRESS_ADDED);
 
 exit:
     return error;
@@ -403,6 +405,8 @@ ThreadError Netif::RemoveExternalUnicastAddress(const Address &aAddress)
     {
         mMaskExtUnicastAddresses &= ~(1 << aAddressIndexToRemove);
         mCountExtUnicastAddresses--;
+    
+        SetStateChangedFlags(OT_IP6_ADDRESS_REMOVED);
     }
     else
     {

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -366,7 +366,7 @@ ThreadError Netif::AddExternalUnicastAddress(const NetifUnicastAddress &aAddress
     mExtUnicastAddresses[index].mNext = mUnicastAddresses;
 
     mUnicastAddresses = &mExtUnicastAddresses[index];
-    
+
     SetStateChangedFlags(OT_IP6_ADDRESS_ADDED);
 
 exit:
@@ -405,7 +405,7 @@ ThreadError Netif::RemoveExternalUnicastAddress(const Address &aAddress)
     {
         mMaskExtUnicastAddresses &= ~(1 << aAddressIndexToRemove);
         mCountExtUnicastAddresses--;
-    
+
         SetStateChangedFlags(OT_IP6_ADDRESS_REMOVED);
     }
     else

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -256,8 +256,8 @@ public:
      *
      * @param[in]  aAddress  A reference to the unicast address.
      *
-     * @retval kThreadError_None  Successfully removed the unicast address.
-     * @retval kThreadError_Busy  The unicast address was already removed.
+     * @retval kThreadError_None      Successfully removed the unicast address.
+     * @retval kThreadError_NotFound  The unicast address wasn't found to be removed.
      *
      */
     ThreadError RemoveUnicastAddress(const NetifUnicastAddress &aAddress);
@@ -267,10 +267,9 @@ public:
      *
      * @param[in]  aAddress  A reference to the unicast address.
      *
-     * @retval kThreadError_None         Successfully added the unicast address.
+     * @retval kThreadError_None         Successfully added (or updated) the unicast address.
      * @retval kThreadError_InvalidArgs  The address indicated by @p aAddress is an internal address.
      * @retval kThreadError_NoBufs       The maximum number of allowed external addresses are already added.
-     * @retval kThreadError_Busy         The unicast address was already added.
      *
      */
     ThreadError AddExternalUnicastAddress(const NetifUnicastAddress &aAddress);
@@ -282,7 +281,7 @@ public:
      *
      * @retval kThreadError_None         Successfully removed the unicast address.
      * @retval kThreadError_InvalidArgs  The address indicated by @p aAddress is an internal address.
-     * @retval kThreadError_Busy         The unicast address was not found.
+     * @retval kThreadError_NotFound     The unicast address was not found.
      *
      */
     ThreadError RemoveExternalUnicastAddress(const Address &aAddress);
@@ -476,7 +475,6 @@ private:
     uint32_t mStateChangedFlags;
 
     NetifUnicastAddress mExtUnicastAddresses[OPENTHREAD_CONFIG_MAX_EXT_IP_ADDRS];
-    uint8_t mCountExtUnicastAddresses;
     uint8_t mMaskExtUnicastAddresses; // Must have enough bits to hold OPENTHREAD_CONFIG_MAX_EXT_IP_ADDRS
 
     static Netif *sNetifListHead;

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -263,6 +263,31 @@ public:
     ThreadError RemoveUnicastAddress(const NetifUnicastAddress &aAddress);
 
     /**
+     * This method adds an external (to OpenThread) unicast address to the network interface.
+     *
+     * @param[in]  aAddress  A reference to the unicast address.
+     *
+     * @retval kThreadError_None         Successfully added the unicast address.
+     * @retval kThreadError_InvalidArgs  The address indicated by @p aAddress is an internal address.
+     * @retval kThreadError_NoBufs       The maximum number of allowed external addresses are already added.
+     * @retval kThreadError_Busy         The unicast address was already added.
+     *
+     */
+    ThreadError AddExternalUnicastAddress(const NetifUnicastAddress &aAddress);
+
+    /**
+     * This method removes a external (to OpenThread) unicast address from the network interface.
+     *
+     * @param[in]  aAddress  A reference to the unicast address.
+     *
+     * @retval kThreadError_None         Successfully removed the unicast address.
+     * @retval kThreadError_InvalidArgs  The address indicated by @p aAddress is an internal address.
+     * @retval kThreadError_Busy         The unicast address was not found.
+     *
+     */
+    ThreadError RemoveExternalUnicastAddress(const Address &aAddress);
+
+    /**
      * This method indicates whether or not the network interface is subscribed to a multicast address.
      *
      * @param[in]  aAddress  The multicast address to check.
@@ -450,8 +475,30 @@ private:
 
     uint32_t mStateChangedFlags;
 
+    NetifUnicastAddress mExtUnicastAddresses[OPENTHREAD_CONFIG_MAX_EXT_IP_ADDRS];
+    uint8_t mCountExtUnicastAddresses;
+    uint8_t mMaskExtUnicastAddresses; // Must have enough bits to hold OPENTHREAD_CONFIG_MAX_EXT_IP_ADDRS
+
     static Netif *sNetifListHead;
     static int8_t sNextInterfaceId;
+
+    /**
+     * This method determines if an address is one of the external unicast addresses, and if so returns
+     * the index in the mExtUnicastAddresses array.
+     *
+     * @param[in]  aAddress  A pointer to the Network Interface address.
+     *
+     * @returns The index in the mExtUnicastAddresses array or -1 if not part of the array.
+     *
+     */
+    int8_t GetExtUnicastAddressIndex(const NetifUnicastAddress *address) {
+        if (address < &mExtUnicastAddresses[0] ||
+            address >= &mExtUnicastAddresses[0] + OPENTHREAD_CONFIG_MAX_EXT_IP_ADDRS) {
+            return -1;
+        }
+
+        return address - &mExtUnicastAddresses[0];
+    }
 };
 
 /**

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -497,7 +497,7 @@ private:
             return -1;
         }
 
-        return address - &mExtUnicastAddresses[0];
+        return static_cast<int8_t>(address - &mExtUnicastAddresses[0]);
     }
 };
 

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -116,6 +116,16 @@
 #endif  // OPENTHREAD_CONFIG_IP_ADDRS_PER_CHILD
 
 /**
+ * @def OPENTHREAD_CONFIG_MAX_EXT_IP_ADDRS
+ *
+ * The maximum number of supported IPv6 addresses allows to be externally added.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MAX_EXT_IP_ADDRS
+#define OPENTHREAD_CONFIG_MAX_EXT_IP_ADDRS                  4
+#endif  // OPENTHREAD_CONFIG_MAX_EXT_IP_ADDRS
+
+/**
  * @def OPENTHREAD_CONFIG_6LOWPAN_REASSEMBLY_TIMEOUT
  *
  * The 6LoWPAN fragment reassembly timeout in seconds.

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -824,14 +824,14 @@ const otNetifAddress *otGetUnicastAddresses(void)
     return sThreadNetif->GetUnicastAddresses();
 }
 
-ThreadError otAddUnicastAddress(otNetifAddress *address)
+ThreadError otAddUnicastAddress(const otNetifAddress *address)
 {
-    return sThreadNetif->AddUnicastAddress(*static_cast<Ip6::NetifUnicastAddress *>(address));
+    return sThreadNetif->AddExternalUnicastAddress(*static_cast<const Ip6::NetifUnicastAddress *>(address));
 }
 
-ThreadError otRemoveUnicastAddress(otNetifAddress *address)
+ThreadError otRemoveUnicastAddress(const otIp6Address *address)
 {
-    return sThreadNetif->RemoveUnicastAddress(*static_cast<Ip6::NetifUnicastAddress *>(address));
+    return sThreadNetif->RemoveExternalUnicastAddress(*static_cast<const Ip6::Address *>(address));
 }
 
 void otSetStateChangedCallback(otStateChangedCallback aCallback, void *aContext)

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -3622,10 +3622,7 @@ ThreadError NcpBase::InsertPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, sp
 
     errorCode = otAddUnicastAddress(&netif_addr);
 
-    // `kThreadError_Busy` indicates that the address was already on the list. In this case the lifetimes and prefix len
-    // are updated, and the add/insert operation is considered a success.
-
-    VerifyOrExit(errorCode == kThreadError_None || errorCode == kThreadError_Busy,
+    VerifyOrExit(errorCode == kThreadError_None,
                  errorStatus = ThreadErrorToSpinelStatus(errorCode));
 
     errorCode = SendPropertyUpdate(

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -421,11 +421,6 @@ NcpBase::NcpBase():
     mDroppedOutboundIpFrameCounter = 0;
     mDroppedInboundIpFrameCounter = 0;
 
-    for (unsigned i = 0; i < sizeof(mNetifAddresses) / sizeof(mNetifAddresses[0]); i++)
-    {
-        mNetifAddresses[i].mPrefixLength = kUnusedNetifAddressPrefixLen;
-    }
-
     assert(sThreadNetif != NULL);
     otSetStateChangedCallback(&HandleNetifStateChanged, this);
     otSetReceiveIp6DatagramCallback(&HandleDatagramFromStack, this);
@@ -3602,7 +3597,7 @@ ThreadError NcpBase::InsertPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, sp
     spinel_ssize_t parsedLength;
     ThreadError errorCode = kThreadError_None;
     spinel_status_t errorStatus = SPINEL_STATUS_OK;
-    otNetifAddress *netif_addr = NULL;
+    otNetifAddress netif_addr;
     otIp6Address *addr_ptr;
     uint32_t preferred_lifetime;
     uint32_t valid_lifetime;
@@ -3620,36 +3615,12 @@ ThreadError NcpBase::InsertPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, sp
 
     VerifyOrExit(parsedLength > 0, errorStatus = SPINEL_STATUS_PARSE_ERROR);
 
-    VerifyOrExit(prefix_len != kUnusedNetifAddressPrefixLen, errorStatus = SPINEL_STATUS_INVALID_ARGUMENT);
+    netif_addr.mAddress = *addr_ptr;
+    netif_addr.mPrefixLength = prefix_len;
+    netif_addr.mPreferredLifetime = preferred_lifetime;
+    netif_addr.mValidLifetime = valid_lifetime;
 
-    for (unsigned i = 0; i < sizeof(mNetifAddresses) / sizeof(mNetifAddresses[0]); i++)
-    {
-        if (mNetifAddresses[i].mPrefixLength != kUnusedNetifAddressPrefixLen)
-        {
-            // If the address matches an already added address.
-            if (memcmp(&mNetifAddresses[i].mAddress, addr_ptr, sizeof(otIp6Address)) == 0)
-            {
-                netif_addr = &mNetifAddresses[i];
-                break;
-            }
-        }
-        else
-        {
-            if (netif_addr == NULL)
-            {
-                netif_addr = &mNetifAddresses[i];
-            }
-        }
-    }
-
-    VerifyOrExit(netif_addr != NULL, errorStatus = SPINEL_STATUS_NOMEM);
-
-    netif_addr->mAddress = *addr_ptr;
-    netif_addr->mPrefixLength = prefix_len;
-    netif_addr->mPreferredLifetime = preferred_lifetime;
-    netif_addr->mValidLifetime = valid_lifetime;
-
-    errorCode = otAddUnicastAddress(netif_addr);
+    errorCode = otAddUnicastAddress(&netif_addr);
 
     // `kThreadError_Busy` indicates that the address was already on the list. In this case the lifetimes and prefix len
     // are updated, and the add/insert operation is considered a success.
@@ -3927,7 +3898,6 @@ ThreadError NcpBase::RemovePropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, sp
 {
     spinel_ssize_t parsedLength;
     ThreadError errorCode = kThreadError_None;
-    otNetifAddress *netif_addr = NULL;
     otIp6Address *addr_ptr;
 
     parsedLength = spinel_datatype_unpack(
@@ -3942,42 +3912,21 @@ ThreadError NcpBase::RemovePropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, sp
 
     if (parsedLength > 0)
     {
-        for (unsigned i = 0; i < sizeof(mNetifAddresses) / sizeof(mNetifAddresses[0]); i++)
+        errorCode = otRemoveUnicastAddress(addr_ptr);
+
+        if (errorCode == kThreadError_None)
         {
-            if (mNetifAddresses[i].mPrefixLength != kUnusedNetifAddressPrefixLen)
-            {
-                if (memcmp(&mNetifAddresses[i].mAddress, addr_ptr, sizeof(otIp6Address)) == 0)
-                {
-                    netif_addr = &mNetifAddresses[i];
-                    break;
-                }
-            }
-        }
-
-        if (netif_addr != NULL)
-        {
-            errorCode = otRemoveUnicastAddress(netif_addr);
-
-            if (errorCode == kThreadError_None)
-            {
-                netif_addr->mNext = NULL;
-
-                errorCode = SendPropertyUpdate(
-                                header,
-                                SPINEL_CMD_PROP_VALUE_REMOVED,
-                                key,
-                                value_ptr,
-                                value_len
-                            );
-            }
-            else
-            {
-                errorCode = SendLastStatus(header, ThreadErrorToSpinelStatus(errorCode));
-            }
+            errorCode = SendPropertyUpdate(
+                            header,
+                            SPINEL_CMD_PROP_VALUE_REMOVED,
+                            key,
+                            value_ptr,
+                            value_len
+                        );
         }
         else
         {
-            errorCode = SendLastStatus(header, ThreadErrorToSpinelStatus(kThreadError_NoAddress));
+            errorCode = SendLastStatus(header, ThreadErrorToSpinelStatus(errorCode));
         }
     }
     else

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -400,11 +400,6 @@ private:
                                               uint16_t value_len);
 
 private:
-    enum
-    {
-        kNetifAddressListSize = 8,           // Size of mNetifAddresses array.
-        kUnusedNetifAddressPrefixLen = 0xff, // Prefix len value to indicate an unused/available NetifAddress element.
-    };
 
     spinel_status_t mLastStatus;
 
@@ -423,8 +418,6 @@ private:
     spinel_tid_t mDroppedReplyTid;
 
     uint16_t mDroppedReplyTidBitSet;
-
-    otNetifAddress mNetifAddresses[kNetifAddressListSize];
 
     bool mAllowLocalNetworkDataChange;
 


### PR DESCRIPTION
This updates the `otAddUnicastAddress` and `otRemoveUnicastAddress` functions so that clients of OpenThread don't have to try to manage the lifetime of the memory for as long as OpenThread has a reference.

The `Netif` class now maintains a list of externally set unicast addresses, the size of which is defined by `OPENTHREAD_CONFIG_MAX_EXT_IP_ADDRS`.

Tested with the ot-cli tool.