### PR TITLE
Add POLLIN to the poll flags for the posix example.

### DIFF
--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -531,7 +531,7 @@ void posixRadioUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, int *aMaxFd)
 
 void posixRadioProcess(void)
 {
-    const int flags = POLLRDNORM | POLLERR | POLLNVAL | POLLHUP;
+    const int flags = POLLIN | POLLRDNORM | POLLERR | POLLNVAL | POLLHUP;
     struct pollfd pollfd = { sSockFd, flags, 0 };
 
     if (poll(&pollfd, 1, 0) > 0 && (pollfd.revents & flags) != 0)

--- a/examples/platforms/posix/uart.c
+++ b/examples/platforms/posix/uart.c
@@ -188,7 +188,7 @@ void posixUartUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, int *aMaxFd)
 
 void posixUartProcess(void)
 {
-    const int flags = POLLRDNORM | POLLERR | POLLNVAL | POLLHUP;
+    const int flags = POLLIN | POLLRDNORM | POLLERR | POLLNVAL | POLLHUP;
     struct pollfd pollfd = { s_in_fd, flags, 0 };
     ssize_t rval;
 


### PR DESCRIPTION
Without these flags, the posix example doesn't work on the Windows subsystem for Linux environment.