### PR TITLE
Remove CRC space when calculating payload length

### DIFF
--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -307,7 +307,7 @@ int8_t otPlatRadioGetRssi(void)
 
 otRadioCaps otPlatRadioGetCaps(void)
 {
-    return kRadioCapsNone;
+    return kRadioCapsAutoCrc;
 }
 
 bool otPlatRadioGetPromiscuous(void)

--- a/include/platform/radio.h
+++ b/include/platform/radio.h
@@ -89,6 +89,7 @@ typedef enum otRadioCaps
 {
     kRadioCapsNone          = 0,  ///< None
     kRadioCapsAckTimeout    = 1,  ///< Radio supports AckTime event
+    kRadioCapsAutoCrc       = 2,  ///< Radio supports AutoCRC
 } otRadioCaps;
 
 /**

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -703,7 +703,7 @@ exit:
 
 uint8_t Frame::GetMaxPayloadLength(void)
 {
-    return kMTU - (GetHeaderLength() + GetFooterLength());
+    return kMTU - (GetHeaderLength() + GetFooterLength() + 2);
 }
 
 uint8_t Frame::GetPayloadLength(void)


### PR DESCRIPTION
If the Radio enables AUTOCRC, 2 bytes will be padded at the end of frame.
If we do not remove it when calculating payload length, 2 more bytes will be added.
It may be larger than the buffer size of radio.

CC2538 tx fifo buffer is 128 bytes. If we do not remove this 2 bytes, assemble fragments may encounter errors.

Add AutoCRC capability for the case that Radio may do not support this.
Need software implements CRC. This is in the TODO list.