### PR TITLE
Ncp: Change the encoding of child info in prop THREAD_CHILD_TABLE getter

### DIFF
--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -425,8 +425,7 @@ typedef enum
     SPINEL_PROP_THREAD__BEGIN          = 0x50,
     SPINEL_PROP_THREAD_LEADER_ADDR     = SPINEL_PROP_THREAD__BEGIN + 0, ///< [6]
     SPINEL_PROP_THREAD_PARENT          = SPINEL_PROP_THREAD__BEGIN + 1, ///< LADDR, SADDR [ES]
-    SPINEL_PROP_THREAD_CHILD_TABLE     = SPINEL_PROP_THREAD__BEGIN + 2, ///< [A(T(ESSLLCCcbbbb))]
-        /// array(EUI64,chId,rloc16,timeout,age,netDataVer,inLqi,aveRSS,rxOnInIdle,secureDataReq,fullFunc,fullNetData)
+    SPINEL_PROP_THREAD_CHILD_TABLE     = SPINEL_PROP_THREAD__BEGIN + 2, ///< array(EUI64,rloc16,timeout,age,netDataVer,inLqi,aveRSS,mode) [A(T(ESLLCCcC))]
     SPINEL_PROP_THREAD_LEADER_RID      = SPINEL_PROP_THREAD__BEGIN + 3, ///< [C]
     SPINEL_PROP_THREAD_LEADER_WEIGHT   = SPINEL_PROP_THREAD__BEGIN + 4, ///< [C]
     SPINEL_PROP_THREAD_LOCAL_LEADER_WEIGHT


### PR DESCRIPTION
This commit makes two changes in how the child info is encoded in the getter of property `THREAD_CHILD_TABLE`. First, the child mode flags (e.g., `RxOnWhenIdle`) are sent as a single uint8_t bitmask. Second, the child id is no longer included in the response (as it
can be derived from Rloc16).