### PR TITLE
CC2538: Add .ARM.exidx section

### DIFF
--- a/examples/platforms/cc2538/cc2538.ld
+++ b/examples/platforms/cc2538/cc2538.ld
@@ -60,6 +60,11 @@ SECTIONS
         _einit_array = .;
     } > FLASH
 
+    .ARM.exidx : ALIGN(4)
+    {
+        *(.ARM.exidx*)
+    } > FLASH
+
     .data : ALIGN(4)
     {
         _data = .;


### PR DESCRIPTION
mbedtls armv7-m/libgcc.a(_udivmoddi4.o) needs .ARM.exidx section.