### PR TITLE
Add ncp-sim to allow_failures group.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,3 +65,5 @@ matrix:
     - env: BUILD_TARGET="cc2538"
       compiler: gcc
       os: linux
+  allow_failures:
+    - env: NODE_TYPE=ncp-sim BUILD_TARGET="posix-distcheck" DISTCHECK_CONFIGURE_FLAGS="--with-examples=posix --enable-cli --enable-ncp=uart --with-tests=all" VERBOSE=1 BuildJobs=10


### PR DESCRIPTION
Moving ncp-sim travis check to `allow_failures` group until spurious failures are resolved [[1](https://travis-ci.org/openthread/openthread/jobs/157802084), [2](https://travis-ci.org/openthread/openthread/jobs/157889296)].

This issue is tracked in #517.