### PR TITLE
Ncp: Change the constant flag names for thread mode in `ncp_base`.

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -52,10 +52,10 @@ static NcpBase *sNcpContext = NULL;
 
 enum
 {
-    kThreadModeTLV_Receiver    = (1 << 3),
-    kThreadModeTLV_Secure      = (1 << 2),
-    kThreadModeTLV_DeviceType  = (1 << 1),
-    kThreadModeTLV_NetworkData = (1 << 0),
+    kThreadMode_RxOnWhenIdle        = (1 << 3),
+    kThreadMode_SecureDataRequest   = (1 << 2),
+    kThreadMode_FullFunctionDevice  = (1 << 1),
+    kThreadMode_FullNetworkData     = (1 << 0),
 };
 
 #define RSSI_OVERRIDE_DISABLED        127 // Used for PROP_MAC_WHITELIST
@@ -2347,22 +2347,22 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_
 
     if (mode_config.mRxOnWhenIdle)
     {
-        numeric_mode |= kThreadModeTLV_Receiver;
+        numeric_mode |= kThreadMode_RxOnWhenIdle;
     }
 
     if (mode_config.mSecureDataRequests)
     {
-        numeric_mode |= kThreadModeTLV_Secure;
+        numeric_mode |= kThreadMode_SecureDataRequest;
     }
 
     if (mode_config.mDeviceType)
     {
-        numeric_mode |= kThreadModeTLV_DeviceType;
+        numeric_mode |= kThreadMode_FullFunctionDevice;
     }
 
     if (mode_config.mNetworkData)
     {
-        numeric_mode |= kThreadModeTLV_NetworkData;
+        numeric_mode |= kThreadMode_FullNetworkData;
     }
 
     return SendPropertyUpdate(
@@ -3600,10 +3600,10 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_
 
     if (parsedLength > 0)
     {
-        mode_config.mRxOnWhenIdle = ((numeric_mode & kThreadModeTLV_Receiver) == kThreadModeTLV_Receiver);
-        mode_config.mSecureDataRequests = ((numeric_mode & kThreadModeTLV_Secure) == kThreadModeTLV_Secure);
-        mode_config.mDeviceType = ((numeric_mode & kThreadModeTLV_DeviceType) == kThreadModeTLV_DeviceType);
-        mode_config.mNetworkData = ((numeric_mode & kThreadModeTLV_NetworkData) == kThreadModeTLV_NetworkData);
+        mode_config.mRxOnWhenIdle = ((numeric_mode & kThreadMode_RxOnWhenIdle) == kThreadMode_RxOnWhenIdle);
+        mode_config.mSecureDataRequests = ((numeric_mode & kThreadMode_SecureDataRequest) == kThreadMode_SecureDataRequest);
+        mode_config.mDeviceType = ((numeric_mode & kThreadMode_FullFunctionDevice) == kThreadMode_FullFunctionDevice);
+        mode_config.mNetworkData = ((numeric_mode & kThreadMode_FullNetworkData) == kThreadMode_FullNetworkData);
 
         errorCode = otSetLinkMode(mode_config);
 


### PR DESCRIPTION


This commit changes the constant names used for `ThreadMode` bit flags in `ncp_base` to match the thread spec (as suggested in https://github.com/openthread/openthread/pull/515)