### PR TITLE
Make REED should know if its parent is connected to leader

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1345,6 +1345,7 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
                     {
                         mRouters[GetLeaderId()].mNextHop = kMaxRouterId;
                     }
+
                     break;
                 }
             }

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1321,6 +1321,33 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
                 SetStateDetached();
                 ExitNow(error = kThreadError_NoRoute);
             }
+
+            if ((mDeviceMode & ModeTlv::kModeFFD))
+            {
+                for (uint8_t i = 0, routeCount = 0; i < kMaxRouterId; i++)
+                {
+                    if (route.IsRouterIdSet(i) == false)
+                    {
+                        continue;
+                    }
+
+                    if (i != GetLeaderId())
+                    {
+                        routeCount++;
+                        continue;
+                    }
+
+                    if (route.GetRouteCost(routeCount) > 0)
+                    {
+                        mRouters[GetLeaderId()].mNextHop = routerId;
+                    }
+                    else
+                    {
+                        mRouters[GetLeaderId()].mNextHop = kMaxRouterId;
+                    }
+                    break;
+                }
+            }
         }
         else
         {


### PR DESCRIPTION
When receiving Parent Request, whether connected to Leader is checked in the handler. Currently REED don't update routes, so the check always fails, which results in REED failing to respond Parent Request.

Certification Test: REED_5_5_5