### PR TITLE
Send MLE Advertisement message first when REED becomes a child.

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -311,6 +311,8 @@ ThreadError MleRouter::HandleChildStart(otMleAttachFilter aFilter)
 
     if (mDeviceMode & ModeTlv::kModeFFD)
     {
+        SendAdvertisement();
+
         advertiseDelay = Timer::SecToMsec(kReedAdvertiseInterval +
                                           (otPlatRandomGet() % kReedAdvertiseJitter));
         mAdvertiseTimer.Start(advertiseDelay);


### PR DESCRIPTION
For REED 5.2.3-Router Upgrade Threshold case, Harness looks for two MLE Advertisement messages without Route64 TLV from REED. The first one is sent when REED becomes a child and the second one is sent after REED_ADVERTISEMENT_INTERVAL + a random jitter between 0 and 60s.

Another problem observed is that Harness checks the same MLE advertisement twice, this problem has been filed in [DEV-898](https://threadgroup.atlassian.net/browse/DEV-898). Below is our test result(pass now, but only one advertisement, packet index:1377)
[REED_5_2_3.zip](https://github.com/openthread/openthread/files/458822/REED_5_2_3.zip)


