### PR TITLE
Fix spelling typos in comments.

### DIFF
--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -415,7 +415,7 @@ typedef struct otIp6Prefix
     uint8_t       mLength;  ///< The IPv6 prefix length.
 } otIp6Prefix;
 
-#define OT_NETWORK_DATA_ITERATOR_INIT  0  ///< Initializeer for otNetworkDataIterator.
+#define OT_NETWORK_DATA_ITERATOR_INIT  0  ///< Initializer for otNetworkDataIterator.
 
 typedef uint8_t otNetworkDataIterator;  ///< Used to iterate through Network Data information.
 
@@ -524,7 +524,7 @@ typedef struct otMacWhitelistEntry
 {
     otExtAddress mExtAddress;       ///< IEEE 802.15.4 Extended Address
     int8_t       mRssi;             ///< RSSI value
-    bool         mValid : 1;        ///< Indicates whether or not the whitelist entry is vaild
+    bool         mValid : 1;        ///< Indicates whether or not the whitelist entry is valid
     bool         mFixedRssi : 1;    ///< Indicates whether or not the RSSI value is fixed.
 } otMacWhitelistEntry;
 
@@ -535,7 +535,7 @@ typedef struct otMacWhitelistEntry
 typedef struct otMacBlacklistEntry
 {
     otExtAddress mExtAddress;       ///< IEEE 802.15.4 Extended Address
-    bool         mValid;            ///< Indicates whether or not the blacklist entry is vaild
+    bool         mValid;            ///< Indicates whether or not the blacklist entry is valid
 } otMacBlacklistEntry;
 
 /**

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -788,7 +788,7 @@ ThreadError otSendPendingGet(const uint8_t *aTlvTypes, uint8_t aLength);
 ThreadError otSendPendingSet(const otOperationalDataset *aDataset, const uint8_t *aTlvs, uint8_t aLength);
 
 /**
- * Get the data poll period of sleepy end deivce.
+ * Get the data poll period of sleepy end device.
  *
  * @returns  The data poll period of sleepy end device.
  *
@@ -797,7 +797,7 @@ ThreadError otSendPendingSet(const otOperationalDataset *aDataset, const uint8_t
 uint32_t otGetPollPeriod(void);
 
 /**
- * Set the data poll period for sleepy end deivce.
+ * Set the data poll period for sleepy end device.
  *
  * param[in]  aPollPeriod  data poll period.
  *
@@ -1382,7 +1382,7 @@ otDeviceRole otGetDeviceRole(void);
  * @param[in]   aIndex  An index into the EID cache table.
  * @param[out]  aEntry  A pointer to where the EID information is placed.
  *
- * @retval kThreadError_None         Successfully retreieved the EID cache entry.
+ * @retval kThreadError_None         Successfully retrieved the EID cache entry.
  * @retval kThreadError_InvalidArgs  @p aIndex was out of bounds or @p aEntry was NULL.
  *
  */

--- a/include/platform/misc.h
+++ b/include/platform/misc.h
@@ -29,7 +29,7 @@
 /**
  * @file
  * @brief
- *   This file includes platform abstractions for miscelaneous behaviors.
+ *   This file includes platform abstractions for miscellaneous behaviors.
  */
 
 #ifndef OT_PLATFORM_MISC_H

--- a/include/platform/radio.h
+++ b/include/platform/radio.h
@@ -120,7 +120,7 @@ typedef enum PhyState
  * The following are valid radio state transitions:
  *
  *                                    (Radio ON)
- *  +----------+  Enable()  +-------+  Receive() +---------+   Trasnmit()  +----------+
+ *  +----------+  Enable()  +-------+  Receive() +---------+   Transmit()  +----------+
  *  |          |----------->|       |----------->|         |-------------->|          |
  *  | Disabled |            | Sleep |            | Receive |               | Transmit |
  *  |          |<-----------|       |<-----------|         |<--------------|          |
@@ -240,7 +240,7 @@ ThreadError otPlatRadioReceive(uint8_t aChannel);
 extern void otPlatRadioReceiveDone(RadioPacket *aPacket, ThreadError aError);
 
 /**
- * The radio tranitions from Transmit to Receive.
+ * The radio transitions from Transmit to Receive.
  * This method returns a pointer to the transmit buffer.
  *
  * The caller forms the IEEE 802.15.4 frame in this buffer then calls otPlatRadioTransmit() to request transmission.

--- a/include/platform/settings.h
+++ b/include/platform/settings.h
@@ -113,7 +113,7 @@ ThreadError otPlatSettingsAbandonChange(void);
  *  aValueLength. The initial value of aValueLength is the
  *  maximum number of bytes to be written to aValue.
  *
- *  This function can be used to check for the existance of
+ *  This function can be used to check for the existence of
  *  a key without fetching the value by setting aValue and
  *  aValueLength to NULL. You can also check the length of
  *  the setting without fetching it by setting only aValue
@@ -214,7 +214,7 @@ ThreadError otPlatSettingsAdd(uint16_t aKey, const uint8_t *aValue, int aValueLe
  *  that is required to maintain the relative order of the
  *  values associated with aKey. For example, if you have three
  *  items ordered (A, B, C) and you delete B, the resulting order
- *  is guarateed to be (A, C).
+ *  is guaranteed to be (A, C).
  *
  *  @param[in] aKey
  *             The key associated with the requested setting.

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -84,7 +84,7 @@ public:
      * @param[in]   aIndex  An index into the EID cache table.
      * @param[out]  aEntry  A pointer to where the EID information is placed.
      *
-     * @retval kThreadError_None         Successfully retreieved the EID cache entry.
+     * @retval kThreadError_None         Successfully retrieved the EID cache entry.
      * @retval kThreadError_InvalidArgs  @p aIndex was out of bounds or @p aEntry was NULL.
      *
      */

--- a/src/core/thread/meshcop_tlvs.hpp
+++ b/src/core/thread/meshcop_tlvs.hpp
@@ -63,7 +63,7 @@ public:
         kChannel           = OT_MESHCOP_TLV_CHANNEL,           ///< Channel TLV
         kPanId             = OT_MESHCOP_TLV_PANID,             ///< PAN ID TLV
         kExtendedPanId     = OT_MESHCOP_TLV_EXTPANID,          ///< Extended PAN ID TLV
-        kNetworkName       = OT_MESHCOP_TLV_NETWORKNAME,       ///< Newtork Name TLV
+        kNetworkName       = OT_MESHCOP_TLV_NETWORKNAME,       ///< Network Name TLV
         kPSKc              = OT_MESHCOP_TLV_PSKC,              ///< PSKc TLV
         kNetworkMasterKey  = OT_MESHCOP_TLV_MASTERKEY,         ///< Network Master Key TLV
         kMeshLocalPrefix   = OT_MESHCOP_TLV_LOCALPREFIX,       ///< Mesh Local Prefix TLV

--- a/src/core/thread/mle_constants.hpp
+++ b/src/core/thread/mle_constants.hpp
@@ -91,8 +91,8 @@ enum
     kMaxLeaderToRouterTimeout   = 90,   ///< INFINITE_COST_TIMEOUT (seconds)
     kReedAdvertiseInterval      = 570,  ///< REED_ADVERTISEMENT_INTERVAL (seconds)
     kReedAdvertiseJitter        = 60,   ///< REED_ADVERTISEMENT_JITTER (seconds)
-    kMleEndDeviceTimeout        = 240,  ///< MLE_END_DEVICE_TIMEOUT (secondes)
-    kLeaderWeight               = 64,   ///< Default leaderweight for the Thread Network Partition
+    kMleEndDeviceTimeout        = 240,  ///< MLE_END_DEVICE_TIMEOUT (seconds)
+    kLeaderWeight               = 64,   ///< Default leader weight for the Thread Network Partition
 };
 
 enum

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -369,7 +369,7 @@ public:
     Neighbor *GetNeighbor(const Ip6::Address &aAddress);
 
     /**
-     * This method retains diagnotsic information for an attached child by Child ID or RLOC16.
+     * This method retains diagnostic information for an attached child by Child ID or RLOC16.
      *
      * @param[in]   aChildId    The Child ID or RLOC16 for an attached child.
      * @param[out]  aChildInfo  The child information.
@@ -378,7 +378,7 @@ public:
     ThreadError GetChildInfoById(uint16_t aChildId, otChildInfo &aChildInfo);
 
     /**
-     * This method retains diagnotsic information for an attached child by the internal table index.
+     * This method retains diagnostic information for an attached child by the internal table index.
      *
      * @param[in]   aChildIndex  The table index.
      * @param[out]  aChildInfo   The child information.
@@ -397,7 +397,7 @@ public:
     Router *GetRouters(uint8_t *aNumRouters);
 
     /**
-     * This method retains diagnotsic information for a given router.
+     * This method retains diagnostic information for a given router.
      *
      * @param[in]   aRouterId    The router ID or RLOC16 for a given router.
      * @param[out]  aRouterInfo  The router information.
@@ -416,9 +416,9 @@ public:
     /**
      * This method indicates whether or not the given Thread partition attributes are preferred.
      *
-     * @param[in]  aSingletonA   Whether or not the Thread Parititon A has a single router.
+     * @param[in]  aSingletonA   Whether or not the Thread Partition A has a single router.
      * @param[in]  aLeaderDataA  A reference to Thread Partition A's Leader Data.
-     * @param[in]  aSingletonB   Whether or not the Thread Parititon B has a single router.
+     * @param[in]  aSingletonB   Whether or not the Thread Partition B has a single router.
      * @param[in]  aLeaderDataB  A reference to Thread Partition B's Leader Data.
      *
      * @retval 1   If partition A is preferred.

--- a/src/ncp/hdlc.hpp
+++ b/src/ncp/hdlc.hpp
@@ -166,7 +166,7 @@ public:
     typedef void (*FrameHandler)(void *aContext, uint8_t *aFrame, uint16_t aFrameLength);
 
     /**
-     * This function pointer is called when an error has occured.
+     * This function pointer is called when an error has occurred.
      *
      * @param[in]  aContext      A pointer to arbitrary context information.
      * @param[in]  aError        An error code describing the error.

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -433,7 +433,7 @@ private:
     bool mAllowLocalNetworkDataChange;
     bool mRequireJoinExistingNetwork;
 
-    uint32_t mFramingErrorCounter;             // Number of inproperly formed received spinel frames.
+    uint32_t mFramingErrorCounter;             // Number of improperly formed received spinel frames.
     uint32_t mRxSpinelFrameCounter;            // Number of received (inbound) spinel frames.
     uint32_t mTxSpinelFrameCounter;            // Number of sent (outbound) spinel frames.
     uint32_t mInboundSecureIpFrameCounter;     // Number of secure inbound data/IP frames.


### PR DESCRIPTION
This PR/commit just fixes some of the spelling typos in  the comments. There is no code/logic change.
