### PR TITLE
Clean up mac/radio interaction.

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -192,6 +192,7 @@ bool Mac::GetRxOnWhenIdle(void) const
 void Mac::SetRxOnWhenIdle(bool aRxOnWhenIdle)
 {
     mRxOnWhenIdle = aRxOnWhenIdle;
+    NextOperation();
 }
 
 const ExtAddress *Mac::GetExtAddress(void) const
@@ -1019,8 +1020,6 @@ exit:
             break;
         }
     }
-
-    NextOperation();
 }
 
 ThreadError Mac::HandleMacCommand(Frame &aFrame)


### PR DESCRIPTION
- Remove unnecessary calls to otPlatRadioReceive().
- Allow calls to otPlatRadioReceiveDone() whenever the radio is active.