### PR TITLE
Add Channel Mask TLV CLI support

### DIFF
--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -215,6 +215,25 @@ enum
     OT_SECURITY_POLICY_BEACONS                = 1 << 3,  ///< Beacons enabled
 };
 
+#define OT_CHANNEL_MASK_ENTRIES_MAX_NUM    2   ///< Maximum number of Channel Mask Entries
+#define OT_CHANNEL_MASK_MAX_SIZE           4   ///< Maximum size of Channel Mask
+
+/**
+  * This structure represents Channel Mask Entry.
+  *
+  */
+typedef struct otChannelMaskEntry
+{
+    uint8_t mChannelPage;
+    uint8_t mMaskLength;
+    uint8_t m8[OT_CHANNEL_MASK_MAX_SIZE];
+} otChannelMaskEntry;
+
+typedef struct otChannelMask
+{
+    otChannelMaskEntry entries[OT_CHANNEL_MASK_ENTRIES_MAX_NUM];
+} otChannelMask;
+
 /**
  * This type represents the IEEE 802.15.4 PAN ID.
  *
@@ -349,8 +368,12 @@ typedef struct otOperationalDataset
     uint32_t          mDelay;                      ///< Delay Timer
     otPanId           mPanId;                      ///< PAN ID
     uint16_t          mChannel;                    ///< Channel
+<<<<<<< 8d465e5429f2c623bb46676dfab39a6e0ed01c83
     otPSKc            mPSKc;                       ///< PSKc
     otSecurityPolicy  mSecurityPolicy;             ///< Security Policy
+=======
+    otChannelMask     mChannelMask;                ///< Channel Mask
+>>>>>>> - Add a new Dataset::Set method to support variable TLV data payload. This is mainly for Channel Mask TLV
 
     bool              mIsActiveTimestampSet : 1;   ///< TRUE if Active Timestamp is set, FALSE otherwise.
     bool              mIsPendingTimestampSet : 1;  ///< TRUE if Pending Timestamp is set, FALSE otherwise.
@@ -361,8 +384,12 @@ typedef struct otOperationalDataset
     bool              mIsDelaySet : 1;             ///< TRUE if Delay Timer is set, FALSE otherwise.
     bool              mIsPanIdSet : 1;             ///< TRUE if PAN ID is set, FALSE otherwise.
     bool              mIsChannelSet : 1;           ///< TRUE if Channel is set, FALSE otherwise.
+<<<<<<< 8d465e5429f2c623bb46676dfab39a6e0ed01c83
     bool              mIsPSKcSet : 1;              ///< TRUE if PSKc is set, FALSE otherwise.
     bool              mIsSecurityPolicySet : 1;    ///< TRUE if Security Policy is set, FALSE otherwise.
+=======
+    bool              mIsChannelMaskSet : 1;       ///< TRUE if Channel Mask is set, FALSE otherwise.
+>>>>>>> - Add a new Dataset::Set method to support variable TLV data payload. This is mainly for Channel Mask TLV
 } otOperationalDataset;
 
 /**

--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -216,7 +216,7 @@ enum
 };
 
 /**
-  * This structure represents Channel Mask Page 0.
+  * This type represents Channel Mask Page 0.
   *
   */
 typedef uint32_t otChannelMaskPage0;

--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -218,15 +218,10 @@ enum
 #define OT_CHANNEL_MASK_MAX_SIZE           4   ///< Maximum size of Channel Mask
 
 /**
-  * This structure represents Channel Mask.
+  * This structure represents Channel Mask Page 0.
   *
   */
-typedef struct otChannelMask
-{
-    uint8_t mChannelPage;
-    uint8_t mMaskLength;
-    uint8_t m8[OT_CHANNEL_MASK_MAX_SIZE];
-} otChannelMask;
+typedef uint32_t otChannelMaskPage0;
 
 /**
  * This type represents the IEEE 802.15.4 PAN ID.
@@ -353,31 +348,31 @@ typedef struct otEnergyScanResult
  */
 typedef struct otOperationalDataset
 {
-    uint64_t          mActiveTimestamp;            ///< Active Timestamp
-    uint64_t          mPendingTimestamp;           ///< Pending Timestamp
-    otMasterKey       mMasterKey;                  ///< Network Master Key
-    otNetworkName     mNetworkName;                ///< Network Name
-    otExtendedPanId   mExtendedPanId;              ///< Extended PAN ID
-    otMeshLocalPrefix mMeshLocalPrefix;            ///< Mesh Local Prefix
-    uint32_t          mDelay;                      ///< Delay Timer
-    otPanId           mPanId;                      ///< PAN ID
-    uint16_t          mChannel;                    ///< Channel
-    otPSKc            mPSKc;                       ///< PSKc
-    otSecurityPolicy  mSecurityPolicy;             ///< Security Policy
-    otChannelMask     mChannelMask;                ///< Channel Mask
+    uint64_t             mActiveTimestamp;            ///< Active Timestamp
+    uint64_t             mPendingTimestamp;           ///< Pending Timestamp
+    otMasterKey          mMasterKey;                  ///< Network Master Key
+    otNetworkName        mNetworkName;                ///< Network Name
+    otExtendedPanId      mExtendedPanId;              ///< Extended PAN ID
+    otMeshLocalPrefix    mMeshLocalPrefix;            ///< Mesh Local Prefix
+    uint32_t             mDelay;                      ///< Delay Timer
+    otPanId              mPanId;                      ///< PAN ID
+    uint16_t             mChannel;                    ///< Channel
+    otPSKc               mPSKc;                       ///< PSKc
+    otSecurityPolicy     mSecurityPolicy;             ///< Security Policy
+    otChannelMaskPage0   mChannelMaskPage0;           ///< Channel Mask Page 0
 
-    bool              mIsActiveTimestampSet : 1;   ///< TRUE if Active Timestamp is set, FALSE otherwise.
-    bool              mIsPendingTimestampSet : 1;  ///< TRUE if Pending Timestamp is set, FALSE otherwise.
-    bool              mIsMasterKeySet : 1;         ///< TRUE if Network Master Key is set, FALSE otherwise.
-    bool              mIsNetworkNameSet : 1;       ///< TRUE if Network Name is set, FALSE otherwise.
-    bool              mIsExtendedPanIdSet : 1;     ///< TRUE if Extended PAN ID is set, FALSE otherwise.
-    bool              mIsMeshLocalPrefixSet : 1;   ///< TRUE if Mesh Local Prefix is set, FALSE otherwise.
-    bool              mIsDelaySet : 1;             ///< TRUE if Delay Timer is set, FALSE otherwise.
-    bool              mIsPanIdSet : 1;             ///< TRUE if PAN ID is set, FALSE otherwise.
-    bool              mIsChannelSet : 1;           ///< TRUE if Channel is set, FALSE otherwise.
-    bool              mIsPSKcSet : 1;              ///< TRUE if PSKc is set, FALSE otherwise.
-    bool              mIsSecurityPolicySet : 1;    ///< TRUE if Security Policy is set, FALSE otherwise.
-    bool              mIsChannelMaskSet : 1;       ///< TRUE if Channel Mask is set, FALSE otherwise.
+    bool                 mIsActiveTimestampSet : 1;   ///< TRUE if Active Timestamp is set, FALSE otherwise.
+    bool                 mIsPendingTimestampSet : 1;  ///< TRUE if Pending Timestamp is set, FALSE otherwise.
+    bool                 mIsMasterKeySet : 1;         ///< TRUE if Network Master Key is set, FALSE otherwise.
+    bool                 mIsNetworkNameSet : 1;       ///< TRUE if Network Name is set, FALSE otherwise.
+    bool                 mIsExtendedPanIdSet : 1;     ///< TRUE if Extended PAN ID is set, FALSE otherwise.
+    bool                 mIsMeshLocalPrefixSet : 1;   ///< TRUE if Mesh Local Prefix is set, FALSE otherwise.
+    bool                 mIsDelaySet : 1;             ///< TRUE if Delay Timer is set, FALSE otherwise.
+    bool                 mIsPanIdSet : 1;             ///< TRUE if PAN ID is set, FALSE otherwise.
+    bool                 mIsChannelSet : 1;           ///< TRUE if Channel is set, FALSE otherwise.
+    bool                 mIsPSKcSet : 1;              ///< TRUE if PSKc is set, FALSE otherwise.
+    bool                 mIsSecurityPolicySet : 1;    ///< TRUE if Security Policy is set, FALSE otherwise.
+    bool                 mIsChannelMaskPage0Set : 1;  ///< TRUE if Channel Mask Page 0 is set, FALSE otherwise.
 } otOperationalDataset;
 
 /**

--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -215,23 +215,17 @@ enum
     OT_SECURITY_POLICY_BEACONS                = 1 << 3,  ///< Beacons enabled
 };
 
-#define OT_CHANNEL_MASK_ENTRIES_MAX_NUM    2   ///< Maximum number of Channel Mask Entries
 #define OT_CHANNEL_MASK_MAX_SIZE           4   ///< Maximum size of Channel Mask
 
 /**
-  * This structure represents Channel Mask Entry.
+  * This structure represents Channel Mask.
   *
   */
-typedef struct otChannelMaskEntry
+typedef struct otChannelMask
 {
     uint8_t mChannelPage;
     uint8_t mMaskLength;
     uint8_t m8[OT_CHANNEL_MASK_MAX_SIZE];
-} otChannelMaskEntry;
-
-typedef struct otChannelMask
-{
-    otChannelMaskEntry entries[OT_CHANNEL_MASK_ENTRIES_MAX_NUM];
 } otChannelMask;
 
 /**
@@ -368,12 +362,9 @@ typedef struct otOperationalDataset
     uint32_t          mDelay;                      ///< Delay Timer
     otPanId           mPanId;                      ///< PAN ID
     uint16_t          mChannel;                    ///< Channel
-<<<<<<< 8d465e5429f2c623bb46676dfab39a6e0ed01c83
     otPSKc            mPSKc;                       ///< PSKc
     otSecurityPolicy  mSecurityPolicy;             ///< Security Policy
-=======
     otChannelMask     mChannelMask;                ///< Channel Mask
->>>>>>> - Add a new Dataset::Set method to support variable TLV data payload. This is mainly for Channel Mask TLV
 
     bool              mIsActiveTimestampSet : 1;   ///< TRUE if Active Timestamp is set, FALSE otherwise.
     bool              mIsPendingTimestampSet : 1;  ///< TRUE if Pending Timestamp is set, FALSE otherwise.
@@ -384,12 +375,9 @@ typedef struct otOperationalDataset
     bool              mIsDelaySet : 1;             ///< TRUE if Delay Timer is set, FALSE otherwise.
     bool              mIsPanIdSet : 1;             ///< TRUE if PAN ID is set, FALSE otherwise.
     bool              mIsChannelSet : 1;           ///< TRUE if Channel is set, FALSE otherwise.
-<<<<<<< 8d465e5429f2c623bb46676dfab39a6e0ed01c83
     bool              mIsPSKcSet : 1;              ///< TRUE if PSKc is set, FALSE otherwise.
     bool              mIsSecurityPolicySet : 1;    ///< TRUE if Security Policy is set, FALSE otherwise.
-=======
     bool              mIsChannelMaskSet : 1;       ///< TRUE if Channel Mask is set, FALSE otherwise.
->>>>>>> - Add a new Dataset::Set method to support variable TLV data payload. This is mainly for Channel Mask TLV
 } otOperationalDataset;
 
 /**

--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -215,8 +215,6 @@ enum
     OT_SECURITY_POLICY_BEACONS                = 1 << 3,  ///< Beacons enabled
 };
 
-#define OT_CHANNEL_MASK_MAX_SIZE           4   ///< Maximum size of Channel Mask
-
 /**
   * This structure represents Channel Mask Page 0.
   *

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -99,14 +99,10 @@ ThreadError Dataset::Print(otOperationalDataset &aDataset)
     {
         sServer->OutputFormat("Channel Mask: ");
 
-        for (uint8_t index = 0; index < OT_CHANNEL_MASK_ENTRIES_MAX_NUM; index++)
+        if (aDataset.mChannelMask.mMaskLength > 0)
         {
-            if (aDataset.mChannelMask.entries[index].mMaskLength > 0)
-            {
-                sServer->OutputFormat("Page %d, Mask ", aDataset.mChannelMask.entries[index].mChannelPage);
-                OutputBytes(aDataset.mChannelMask.entries[index].m8, aDataset.mChannelMask.entries[index].mMaskLength);
-                sServer->OutputFormat("; ");
-            }
+            sServer->OutputFormat("Page %d, Mask ", aDataset.mChannelMask.mChannelPage);
+            OutputBytes(aDataset.mChannelMask.m8, aDataset.mChannelMask.mMaskLength);
         }
 
         sServer->OutputFormat("\r\n");
@@ -280,21 +276,17 @@ ThreadError Dataset::ProcessChannelMask(otInstance *aInstance, int argc, char *a
     long value;
     uint16_t length;
 
-    VerifyOrExit(argc > 1 && argc <= 2 * OT_CHANNEL_MASK_ENTRIES_MAX_NUM, error = kThreadError_Parse);
+    VerifyOrExit(argc > 1, error = kThreadError_Parse);
 
     memset(reinterpret_cast<uint8_t *>(&sDataset.mChannelMask), 0, sizeof(sDataset.mChannelMask));
 
-    for (uint8_t index = 0; index < argc; index++)
-    {
-        SuccessOrExit(error = Interpreter::ParseLong(argv[index], value));
-        sDataset.mChannelMask.entries[index / 2].mChannelPage = static_cast<uint8_t>(value);
+    SuccessOrExit(error = Interpreter::ParseLong(argv[0], value));
+    sDataset.mChannelMask.mChannelPage = static_cast<uint8_t>(value);
 
-        length = static_cast<uint16_t>((strlen(argv[++index]) + 1) / 2);
-        VerifyOrExit(length <= OT_CHANNEL_MASK_MAX_SIZE, error = kThreadError_NoBufs);
-        sDataset.mChannelMask.entries[index / 2].mMaskLength = static_cast<uint8_t>(length);
-        VerifyOrExit(Interpreter::Hex2Bin(argv[index], sDataset.mChannelMask.entries[index / 2].m8, length)
-                     == length, error = kThreadError_Parse);
-    }
+    length = static_cast<uint16_t>((strlen(argv[1]) + 1) / 2);
+    VerifyOrExit(length <= OT_CHANNEL_MASK_MAX_SIZE, error = kThreadError_NoBufs);
+    sDataset.mChannelMask.mMaskLength = static_cast<uint8_t>(length);
+    VerifyOrExit(Interpreter::Hex2Bin(argv[1], sDataset.mChannelMask.m8, length) == length, error = kThreadError_Parse);
 
     sDataset.mIsChannelMaskSet = true;
 

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -269,7 +269,7 @@ ThreadError Dataset::ProcessChannelMask(otInstance *aInstance, int argc, char *a
 
     VerifyOrExit(argc > 0, error = kThreadError_Parse);
     SuccessOrExit(error = Interpreter::ParseLong(argv[0], value));
-    sDataset.mChannelMaskPage0 = value;
+    sDataset.mChannelMaskPage0 = static_cast<uint32_t>(value);
     sDataset.mIsChannelMaskPage0Set = true;
     (void)aInstance;
 

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -41,8 +41,6 @@
 #include "cli.hpp"
 #include "cli_dataset.hpp"
 
-using Thread::Encoding::BigEndian::HostSwap32;
-
 namespace Thread {
 namespace Cli {
 

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -97,9 +97,7 @@ ThreadError Dataset::Print(otOperationalDataset &aDataset)
 
     if (aDataset.mIsChannelMaskPage0Set)
     {
-        sServer->OutputFormat("Channel Mask Page 0: ");
-        OutputBytes(reinterpret_cast<uint8_t *>(&aDataset.mChannelMaskPage0), sizeof(aDataset.mChannelMaskPage0));
-        sServer->OutputFormat("\r\n");
+        sServer->OutputFormat("Channel Mask Page 0: %x\r\n", aDataset.mChannelMaskPage0);
     }
 
     if (aDataset.mIsDelaySet)
@@ -267,10 +265,11 @@ exit:
 ThreadError Dataset::ProcessChannelMask(otInstance *aInstance, int argc, char *argv[])
 {
     ThreadError error = kThreadError_None;
+    long value;
 
     VerifyOrExit(argc > 0, error = kThreadError_Parse);
-    VerifyOrExit(Interpreter::Hex2Bin(argv[0], reinterpret_cast<uint8_t *>(&sDataset.mChannelMaskPage0), sizeof(sDataset.mChannelMaskPage0))
-                 == sizeof(sDataset.mChannelMaskPage0), error = kThreadError_Parse);
+    SuccessOrExit(error = Interpreter::ParseLong(argv[0], value));
+    sDataset.mChannelMaskPage0 = value;
     sDataset.mIsChannelMaskPage0Set = true;
     (void)aInstance;
 

--- a/src/cli/cli_dataset.hpp
+++ b/src/cli/cli_dataset.hpp
@@ -77,6 +77,7 @@ private:
     static ThreadError ProcessActive(otInstance *aInstance, int argc, char *argv[]);
     static ThreadError ProcessActiveTimestamp(otInstance *aInstance, int argc, char *argv[]);
     static ThreadError ProcessChannel(otInstance *aInstance, int argc, char *argv[]);
+    static ThreadError ProcessChannelMask(otInstance *aInstance, int argc, char *argv[]);
     static ThreadError ProcessClear(otInstance *aInstance, int argc, char *argv[]);
     static ThreadError ProcessCommit(otInstance *aInstance, int argc, char *argv[]);
     static ThreadError ProcessDelay(otInstance *aInstance, int argc, char *argv[]);

--- a/src/core/thread/meshcop_dataset.cpp
+++ b/src/core/thread/meshcop_dataset.cpp
@@ -123,17 +123,9 @@ void Dataset::Get(otOperationalDataset &aDataset)
 
         case Tlv::kChannelMask:
         {
-            const ChannelMaskTlv *tlv = static_cast<const ChannelMaskTlv *>(cur);
             const uint8_t *entry = reinterpret_cast<const uint8_t *>(cur) + sizeof(Tlv);
-            const uint8_t *entryEnd = entry + tlv->GetLength();
-
-            for (uint8_t index = 0; index < OT_CHANNEL_MASK_ENTRIES_MAX_NUM && entry < entryEnd; index++)
-            {
-                uint8_t entryLength = reinterpret_cast<const ChannelMaskEntry *>(entry)->GetMaskLength() + sizeof(ChannelMaskEntry);
-                memcpy(&aDataset.mChannelMask.entries[index].mChannelPage, entry, entryLength);
-                entry += entryLength;
-            }
-
+            uint8_t entryLength = reinterpret_cast<const ChannelMaskEntry *>(entry)->GetMaskLength() + sizeof(ChannelMaskEntry);
+            memcpy(&aDataset.mChannelMask.mChannelPage, entry, entryLength);
             aDataset.mIsChannelMaskSet = true;
             break;
         }
@@ -259,23 +251,9 @@ ThreadError Dataset::Set(const otOperationalDataset &aDataset, bool aActive)
     if (aDataset.mIsChannelMaskSet)
     {
         MeshCoP::ChannelMaskTlv tlv;
-        uint8_t length = 0;
-        uint8_t data[12];
-
         tlv.Init();
-
-        for (uint8_t index = 0; index < OT_CHANNEL_MASK_ENTRIES_MAX_NUM; index++)
-        {
-            if (aDataset.mChannelMask.entries[index].mMaskLength > 0)
-            {
-                memcpy(data + length, &aDataset.mChannelMask.entries[index].mChannelPage,
-                       aDataset.mChannelMask.entries[index].mMaskLength + sizeof(MeshCoP::ChannelMaskEntry));
-                length += (aDataset.mChannelMask.entries[index].mMaskLength + sizeof(MeshCoP::ChannelMaskEntry));
-            }
-        }
-
-        tlv.SetLength(length);
-        Set(tlv, *data);
+        tlv.SetLength(aDataset.mChannelMask.mMaskLength + sizeof(MeshCoP::ChannelMaskEntry));
+        Set(tlv, aDataset.mChannelMask.mChannelPage);
     }
 
     if (aDataset.mIsDelaySet)

--- a/src/core/thread/meshcop_dataset.cpp
+++ b/src/core/thread/meshcop_dataset.cpp
@@ -124,7 +124,13 @@ void Dataset::Get(otOperationalDataset &aDataset)
         case Tlv::kChannelMask:
         {
             const uint8_t *entry = reinterpret_cast<const uint8_t *>(cur) + sizeof(Tlv) + sizeof(ChannelMaskEntry);
-            aDataset.mChannelMaskPage0 = *reinterpret_cast<const uint32_t *>(entry);
+
+            aDataset.mChannelMaskPage0 = 0;
+            aDataset.mChannelMaskPage0 |= (entry[0] << 24);
+            aDataset.mChannelMaskPage0 |= (entry[1] << 16);
+            aDataset.mChannelMaskPage0 |= (entry[2] << 8);
+            aDataset.mChannelMaskPage0 |= entry[3];
+
             aDataset.mIsChannelMaskPage0Set = true;
             break;
         }
@@ -254,10 +260,16 @@ ThreadError Dataset::Set(const otOperationalDataset &aDataset, bool aActive)
         uint8_t data[6];
         tlv.Init();
         tlv.SetLength(sizeof(MeshCoP::ChannelMaskEntry) + sizeof(aDataset.mChannelMaskPage0));
+
         entry = reinterpret_cast<MeshCoP::ChannelMaskEntry *>(data);
         entry->SetChannelPage(0);
         entry->SetMaskLength(sizeof(aDataset.mChannelMaskPage0));
-        *reinterpret_cast<uint32_t *>(data + sizeof(MeshCoP::ChannelMaskEntry)) = aDataset.mChannelMaskPage0;
+
+        data[2] = (aDataset.mChannelMaskPage0 >> 24) & 0xff;
+        data[3] = (aDataset.mChannelMaskPage0 >> 16) & 0xff;
+        data[4] = (aDataset.mChannelMaskPage0 >> 8) & 0xff;
+        data[5] = (aDataset.mChannelMaskPage0) & 0xff;
+
         Set(tlv, *data);
     }
 

--- a/src/core/thread/meshcop_dataset.cpp
+++ b/src/core/thread/meshcop_dataset.cpp
@@ -139,7 +139,7 @@ void Dataset::Get(otOperationalDataset &aDataset)
                 }
 
                 entry += (reinterpret_cast<const ChannelMaskEntry *>(entry)->GetMaskLength() +
-                                                                       sizeof(ChannelMaskEntry));
+                          sizeof(ChannelMaskEntry));
             }
 
             break;

--- a/src/core/thread/meshcop_dataset.cpp
+++ b/src/core/thread/meshcop_dataset.cpp
@@ -129,16 +129,13 @@ void Dataset::Get(otOperationalDataset &aDataset)
 
             while (entry < entryEnd)
             {
-                switch (reinterpret_cast<const ChannelMaskEntry *>(entry)->GetChannelPage())
-                {
-                case 0:
+                if (reinterpret_cast<const ChannelMaskEntry *>(entry)->GetChannelPage() == 0)
                 {
                     uint8_t i = sizeof(ChannelMaskEntry);
                     aDataset.mChannelMaskPage0 = static_cast<uint32_t>(entry[i] | (entry[i + 1] << 8) | (entry[i + 2] << 16) |
                                                                        (entry[i + 3] << 24));
                     aDataset.mIsChannelMaskPage0Set = true;
                     break;
-                }
                 }
 
                 entry += (reinterpret_cast<const ChannelMaskEntry *>(entry)->GetMaskLength() + sizeof(ChannelMaskEntry));

--- a/src/core/thread/meshcop_dataset.cpp
+++ b/src/core/thread/meshcop_dataset.cpp
@@ -126,10 +126,11 @@ void Dataset::Get(otOperationalDataset &aDataset)
             const uint8_t *entry = reinterpret_cast<const uint8_t *>(cur) + sizeof(Tlv) + sizeof(ChannelMaskEntry);
 
             aDataset.mChannelMaskPage0 = 0;
-            aDataset.mChannelMaskPage0 |= (entry[0] << 24);
-            aDataset.mChannelMaskPage0 |= (entry[1] << 16);
-            aDataset.mChannelMaskPage0 |= (entry[2] << 8);
-            aDataset.mChannelMaskPage0 |= entry[3];
+
+            for (uint8_t index = 0; index < sizeof(aDataset.mChannelMaskPage0); index++)
+            {
+                aDataset.mChannelMaskPage0 |= (entry[index] << (8 * index));
+            }
 
             aDataset.mIsChannelMaskPage0Set = true;
             break;
@@ -265,10 +266,10 @@ ThreadError Dataset::Set(const otOperationalDataset &aDataset, bool aActive)
         entry->SetChannelPage(0);
         entry->SetMaskLength(sizeof(aDataset.mChannelMaskPage0));
 
-        data[2] = (aDataset.mChannelMaskPage0 >> 24) & 0xff;
-        data[3] = (aDataset.mChannelMaskPage0 >> 16) & 0xff;
-        data[4] = (aDataset.mChannelMaskPage0 >> 8) & 0xff;
-        data[5] = (aDataset.mChannelMaskPage0) & 0xff;
+        for (uint8_t index = 0; index < sizeof(aDataset.mChannelMaskPage0); index++)
+        {
+            data[index + sizeof(MeshCoP::ChannelMaskEntry)] = (aDataset.mChannelMaskPage0 >> (8 * index)) & 0xff;
+        }
 
         Set(tlv, *data);
     }

--- a/src/core/thread/meshcop_dataset.cpp
+++ b/src/core/thread/meshcop_dataset.cpp
@@ -124,14 +124,7 @@ void Dataset::Get(otOperationalDataset &aDataset)
         case Tlv::kChannelMask:
         {
             const uint8_t *entry = reinterpret_cast<const uint8_t *>(cur) + sizeof(Tlv) + sizeof(ChannelMaskEntry);
-
-            aDataset.mChannelMaskPage0 = 0;
-
-            for (uint8_t index = 0; index < sizeof(aDataset.mChannelMaskPage0); index++)
-            {
-                aDataset.mChannelMaskPage0 |= (entry[index] << (8 * index));
-            }
-
+            aDataset.mChannelMaskPage0 = static_cast<uint32_t>(entry[0] | (entry[1] << 8) | (entry[2] << 16) | (entry[3] << 24));
             aDataset.mIsChannelMaskPage0Set = true;
             break;
         }

--- a/src/core/thread/meshcop_dataset.cpp
+++ b/src/core/thread/meshcop_dataset.cpp
@@ -132,13 +132,14 @@ void Dataset::Get(otOperationalDataset &aDataset)
                 if (reinterpret_cast<const ChannelMaskEntry *>(entry)->GetChannelPage() == 0)
                 {
                     uint8_t i = sizeof(ChannelMaskEntry);
-                    aDataset.mChannelMaskPage0 = static_cast<uint32_t>(entry[i] | (entry[i + 1] << 8) | (entry[i + 2] << 16) |
-                                                                       (entry[i + 3] << 24));
+                    aDataset.mChannelMaskPage0 = static_cast<uint32_t>(entry[i] | (entry[i + 1] << 8) |
+                                                                       (entry[i + 2] << 16) | (entry[i + 3] << 24));
                     aDataset.mIsChannelMaskPage0Set = true;
                     break;
                 }
 
-                entry += (reinterpret_cast<const ChannelMaskEntry *>(entry)->GetMaskLength() + sizeof(ChannelMaskEntry));
+                entry += (reinterpret_cast<const ChannelMaskEntry *>(entry)->GetMaskLength() +
+                                                                       sizeof(ChannelMaskEntry));
             }
 
             break;

--- a/src/core/thread/meshcop_dataset.hpp
+++ b/src/core/thread/meshcop_dataset.hpp
@@ -124,18 +124,6 @@ public:
      */
     ThreadError Set(const Tlv &aTlv);
 
-    /**
-     * This method sets a TLV in the Dataset.
-     *
-     * @param[in]  aTlv   A reference to the TLV.
-     * @param[in]  aData  A reference to the TLV's data.
-     *
-     * @retval kThreadError_None    Successfully set the TLV.
-     * @retval kThreadError_NoBufs  Could not set the TLV due to insufficient buffer space.
-     *
-     */
-    ThreadError Set(const Tlv &aTlv, const uint8_t &aData);
-
     ThreadError Set(const Message &aMessage, uint16_t aOffset, uint8_t aLength);
 
     ThreadError Set(const otOperationalDataset &aDataset, bool aActive);

--- a/src/core/thread/meshcop_dataset.hpp
+++ b/src/core/thread/meshcop_dataset.hpp
@@ -124,6 +124,18 @@ public:
      */
     ThreadError Set(const Tlv &aTlv);
 
+    /**
+     * This method sets a TLV in the Dataset.
+     *
+     * @param[in]  aTlv   A reference to the TLV.
+     * @param[in]  aData  A reference to the TLV's data.
+     *
+     * @retval kThreadError_None    Successfully set the TLV.
+     * @retval kThreadError_NoBufs  Could not set the TLV due to insufficient buffer space.
+     *
+     */
+    ThreadError Set(const Tlv &aTlv, const uint8_t &aData);
+
     ThreadError Set(const Message &aMessage, uint16_t aOffset, uint8_t aLength);
 
     ThreadError Set(const otOperationalDataset &aDataset, bool aActive);


### PR DESCRIPTION
- Add a new Dataset::Set method to support variable TLV data payload. This is mainly for Channel Mask TLV

- Add CLI to support Channel Mask TLV

This is one of the 2 PRs for passing Certificate Test 9.2.3.