### PR TITLE
Ncp: Add new spinel property `THREAD_ROUTER_ROLE_ENABLED`

### DIFF
--- a/doc/draft-spinel-protocol.html
+++ b/doc/draft-spinel-protocol.html
@@ -501,6 +501,7 @@
 <link href="#rfc.appendix.D.2.20" rel="Chapter" title="D.2.20 PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT"/>
 <link href="#rfc.appendix.D.2.21" rel="Chapter" title="D.2.21 PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS"/>
 <link href="#rfc.appendix.D.2.22" rel="Chapter" title="D.2.22 PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU"/>
+<link href="#rfc.appendix.D.2.23" rel="Chapter" title="D.2.23 PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED"/>
 <link href="#rfc.appendix.E" rel="Chapter" title="E Test Vectors"/>
 <link href="#rfc.appendix.E.1" rel="Chapter" title="E.1 Test Vector: Packed Unsigned Integer"/>
 <link href="#rfc.appendix.E.2" rel="Chapter" title="E.2 Test Vector: Reset Command"/>
@@ -532,8 +533,8 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Quattlebaum, R." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-spinel-protocol-f5ea928" />
-  <meta name="dct.issued" scheme="ISO8601" content="2016-9-7" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-spinel-protocol-94724cf" />
+  <meta name="dct.issued" scheme="ISO8601" content="2016-9-9" />
   <meta name="dct.abstract" content="This document describes a general management protocol for enabling a host device to communicate with and manage a Network Control Processor (NCP).  " />
   <meta name="description" content="This document describes a general management protocol for enabling a host device to communicate with and manage a Network Control Processor (NCP).  " />
 
@@ -554,7 +555,7 @@
 </tr>
 <tr>
   <td class="left"></td>
-  <td class="right">September 7, 2016</td>
+  <td class="right">September 9, 2016</td>
 </tr>
 
     	
@@ -562,7 +563,7 @@
   </table>
 
   <p class="title">Spinel Host-Controller Protocol<br />
-  <span class="filename">draft-spinel-protocol-f5ea928</span></p>
+  <span class="filename">draft-spinel-protocol-94724cf</span></p>
   
   <h1 id="rfc.abstract">
   <a href="#rfc.abstract">Abstract</a>
@@ -724,6 +725,7 @@
 <li>D.2.20.   <a href="#rfc.appendix.D.2.20">PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT</a></li>
 <li>D.2.21.   <a href="#rfc.appendix.D.2.21">PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS</a></li>
 <li>D.2.22.   <a href="#rfc.appendix.D.2.22">PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU</a></li>
+<li>D.2.23.   <a href="#rfc.appendix.D.2.23">PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED</a></li>
 </ul></ul><li>Appendix E.   <a href="#rfc.appendix.E">Test Vectors</a></li>
 <ul><li>E.1.   <a href="#rfc.appendix.E.1">Test Vector: Packed Unsigned Integer</a></li>
 <li>E.2.   <a href="#rfc.appendix.E.2">Test Vector: Reset Command</a></li>
@@ -2910,6 +2912,16 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 <p> </p>
 <p id="rfc.section.D.2.22.p.2">Allow the HOST to directly observe all IPv6 packets received by the NCP, including ones sent to the RLOC16 address.  </p>
 <p id="rfc.section.D.2.22.p.3">Default value is <samp>false</samp>.  </p>
+<h1 id="rfc.appendix.D.2.23"><a href="#rfc.appendix.D.2.23">D.2.23.</a> <a href="#prop-5383-spinelpropthreadrouterroleenabled" id="prop-5383-spinelpropthreadrouterroleenabled">PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>b</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.D.2.23.p.2">Allow the HOST to indicate whether or not the router role is enabled.  If current role is a router, setting this property to <samp>false</samp> starts a re-attach process as an end-device.  </p>
 <h1 id="rfc.appendix.E"><a href="#rfc.appendix.E">Appendix E.</a> <a href="#test-vectors" id="test-vectors">Test Vectors</a></h1>
 <h1 id="rfc.appendix.E.1"><a href="#rfc.appendix.E.1">E.1.</a> <a href="#test-vector-packed-unsigned-integer" id="test-vector-packed-unsigned-integer">Test Vector: Packed Unsigned Integer</a></h1>
 <table cellpadding="3" cellspacing="0" class="tt full center">

--- a/doc/draft-spinel-protocol.txt
+++ b/doc/draft-spinel-protocol.txt
@@ -4,11 +4,11 @@
 
                                                           R. Quattlebaum
                                                                Nest Labs
-                                                       September 7, 2016
+                                                       September 9, 2016
 
 
                     Spinel Host-Controller Protocol
-                     draft-spinel-protocol-f5ea928
+                     draft-spinel-protocol-94724cf
 
 Abstract
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Quattlebaum              Expires March 11, 2017                 [Page 1]
+Quattlebaum              Expires March 13, 2017                 [Page 1]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Quattlebaum              Expires March 11, 2017                 [Page 2]
+Quattlebaum              Expires March 13, 2017                 [Page 2]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
        6.2.12. PROP 113: PROP_STREAM_RAW . . . . . . . . . . . . . .  23
@@ -165,9 +165,9 @@ Quattlebaum              Expires March 11, 2017                 [Page 2]
 
 
 
-Quattlebaum              Expires March 11, 2017                 [Page 3]
+Quattlebaum              Expires March 13, 2017                 [Page 3]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    Appendix B.  Feature: Network Save  . . . . . . . . . . . . . . .  37
@@ -211,29 +211,30 @@ Quattlebaum              Expires March 11, 2017                 [Page 3]
        D.2.20. PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT . . . . . .  44
        D.2.21. PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS  . . . . . .  44
        D.2.22. PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU  . . . .  44
-   Appendix E.  Test Vectors . . . . . . . . . . . . . . . . . . . .  44
+       D.2.23. PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED . .  44
+   Appendix E.  Test Vectors . . . . . . . . . . . . . . . . . . . .  45
      E.1.  Test Vector: Packed Unsigned Integer  . . . . . . . . . .  45
      E.2.  Test Vector: Reset Command  . . . . . . . . . . . . . . .  45
      E.3.  Test Vector: Reset Notification . . . . . . . . . . . . .  45
-     E.4.  Test Vector: Scan Beacon  . . . . . . . . . . . . . . . .  45
+     E.4.  Test Vector: Scan Beacon  . . . . . . . . . . . . . . . .  46
      E.5.  Test Vector: Inbound IPv6 Packet  . . . . . . . . . . . .  46
-     E.6.  Test Vector: Outbound IPv6 Packet . . . . . . . . . . . .  46
 
 
 
-Quattlebaum              Expires March 11, 2017                 [Page 4]
+Quattlebaum              Expires March 13, 2017                 [Page 4]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
+     E.6.  Test Vector: Outbound IPv6 Packet . . . . . . . . . . . .  46
      E.7.  Test Vector: Fetch list of on-mesh networks . . . . . . .  46
      E.8.  Test Vector: Returned list of on-mesh networks  . . . . .  47
      E.9.  Test Vector: Adding an on-mesh network  . . . . . . . . .  47
-     E.10. Test Vector: Insertion notification of an on-mesh network  47
+     E.10. Test Vector: Insertion notification of an on-mesh network  48
      E.11. Test Vector: Removing a local on-mesh network . . . . . .  48
      E.12. Test Vector: Removal notification of an on-mesh network .  48
-   Appendix F.  Example Sessions . . . . . . . . . . . . . . . . . .  48
-     F.1.  NCP Initialization  . . . . . . . . . . . . . . . . . . .  48
+   Appendix F.  Example Sessions . . . . . . . . . . . . . . . . . .  49
+     F.1.  NCP Initialization  . . . . . . . . . . . . . . . . . . .  49
      F.2.  Attaching to a network  . . . . . . . . . . . . . . . . .  49
      F.3.  Successfully joining a pre-existing network . . . . . . .  50
      F.4.  Unsuccessfully joining a pre-existing network . . . . . .  51
@@ -243,7 +244,7 @@ Quattlebaum              Expires March 11, 2017                 [Page 4]
      F.8.  Adding an on-mesh prefix  . . . . . . . . . . . . . . . .  52
      F.9.  Entering low-power modes  . . . . . . . . . . . . . . . .  52
      F.10. Sniffing raw packets  . . . . . . . . . . . . . . . . . .  52
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  53
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  54
 
 1.  Introduction
 
@@ -272,16 +273,17 @@ Quattlebaum              Expires March 11, 2017                 [Page 4]
    Host
       Computer or Micro-controller which controls the NCP.
    TID
+
+
+
+
+Quattlebaum              Expires March 13, 2017                 [Page 5]
+
+                        Spinel Protocol (94724cf)         September 2016
+
+
       Transaction Identifier.  May be a value between zero and fifteen.
       See Section 3.1.3 for more information.
-
-
-
-Quattlebaum              Expires March 11, 2017                 [Page 5]
-
-                        Spinel Protocol (f5ea928)         September 2016
-
-
    IID
       Interface Identifier.  May be a value between zero and three.  See
       Section 3.1.2 for more information.
@@ -331,11 +333,9 @@ Quattlebaum              Expires March 11, 2017                 [Page 5]
 
 
 
-
-
-Quattlebaum              Expires March 11, 2017                 [Page 6]
+Quattlebaum              Expires March 13, 2017                 [Page 6]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 3.1.2.  IID: Interface Identifier
@@ -389,9 +389,9 @@ Quattlebaum              Expires March 11, 2017                 [Page 6]
 
 
 
-Quattlebaum              Expires March 11, 2017                 [Page 7]
+Quattlebaum              Expires March 13, 2017                 [Page 7]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 4.  Data Packing
@@ -445,9 +445,9 @@ Quattlebaum              Expires March 11, 2017                 [Page 7]
 
 
 
-Quattlebaum              Expires March 11, 2017                 [Page 8]
+Quattlebaum              Expires March 13, 2017                 [Page 8]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    +------+----------------------+-------------------------------------+
@@ -501,9 +501,9 @@ Quattlebaum              Expires March 11, 2017                 [Page 8]
 
 
 
-Quattlebaum              Expires March 11, 2017                 [Page 9]
+Quattlebaum              Expires March 13, 2017                 [Page 9]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    1.  The unsigned integer is broken up into _n_ 7-bit chunks and
@@ -557,9 +557,9 @@ Quattlebaum              Expires March 11, 2017                 [Page 9]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 10]
+Quattlebaum              Expires March 13, 2017                [Page 10]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
       Originally the length was a Section 4.2, but it was changed to an
@@ -613,9 +613,9 @@ Quattlebaum              Expires March 11, 2017                [Page 10]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 11]
+Quattlebaum              Expires March 13, 2017                [Page 11]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    type in a given signature.  Thus, "A(C)" (An array of unsigned bytes)
@@ -669,9 +669,9 @@ Quattlebaum              Expires March 11, 2017                [Page 11]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 12]
+Quattlebaum              Expires March 13, 2017                [Page 12]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 5.3.  CMD 2: (Host->NCP) CMD_PROP_VALUE_GET
@@ -725,9 +725,9 @@ Quattlebaum              Expires March 11, 2017                [Page 12]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 13]
+Quattlebaum              Expires March 13, 2017                [Page 13]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    items in the list.  The resulting order of items in the list is
@@ -781,9 +781,9 @@ Quattlebaum              Expires March 11, 2017                [Page 13]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 14]
+Quattlebaum              Expires March 13, 2017                [Page 14]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    The payload for this command is the property identifier encoded in
@@ -837,9 +837,9 @@ Quattlebaum              Expires March 11, 2017                [Page 14]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 15]
+Quattlebaum              Expires March 13, 2017                [Page 15]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 6.  Properties
@@ -893,9 +893,9 @@ Quattlebaum              Expires March 11, 2017                [Page 15]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 16]
+Quattlebaum              Expires March 13, 2017                [Page 16]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 6.2.  Core Properties
@@ -949,9 +949,9 @@ Quattlebaum              Expires March 11, 2017                [Page 16]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 17]
+Quattlebaum              Expires March 13, 2017                [Page 17]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 6.2.2.1.  Major Version Number
@@ -1005,9 +1005,9 @@ Quattlebaum              Expires March 11, 2017                [Page 17]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 18]
+Quattlebaum              Expires March 13, 2017                [Page 18]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
                        +---------+----------------+
@@ -1061,9 +1061,9 @@ Quattlebaum              Expires March 11, 2017                [Page 18]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 19]
+Quattlebaum              Expires March 13, 2017                [Page 19]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    o  1: "CAP_LOCK"
@@ -1117,9 +1117,9 @@ Quattlebaum              Expires March 11, 2017                [Page 19]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 20]
+Quattlebaum              Expires March 13, 2017                [Page 20]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    This value is encoded as an unsigned 8-bit integer.
@@ -1173,9 +1173,9 @@ Quattlebaum              Expires March 11, 2017                [Page 20]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 21]
+Quattlebaum              Expires March 13, 2017                [Page 21]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 6.2.10.  PROP 9: PROP_LOCK
@@ -1229,9 +1229,9 @@ Quattlebaum              Expires March 11, 2017                [Page 21]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 22]
+Quattlebaum              Expires March 13, 2017                [Page 22]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 6.2.12.  PROP 113: PROP_STREAM_RAW
@@ -1285,9 +1285,9 @@ Quattlebaum              Expires March 11, 2017                [Page 22]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 23]
+Quattlebaum              Expires March 13, 2017                [Page 23]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    wait for "CMD_PROP_VALUE_IS" commands with this property id from the
@@ -1341,9 +1341,9 @@ Quattlebaum              Expires March 11, 2017                [Page 23]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 24]
+Quattlebaum              Expires March 13, 2017                [Page 24]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    Set to 1 if the PHY is enabled, set to 0 otherwise.  May be directly
@@ -1397,9 +1397,9 @@ Quattlebaum              Expires March 11, 2017                [Page 24]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 25]
+Quattlebaum              Expires March 13, 2017                [Page 25]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    When setting, the value will be rounded down to a value that is
@@ -1453,9 +1453,9 @@ Quattlebaum              Expires March 11, 2017                [Page 25]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 26]
+Quattlebaum              Expires March 13, 2017                [Page 26]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 6.4.4.  PROP 51: PROP_MAC_SCAN_BEACON
@@ -1509,9 +1509,9 @@ Quattlebaum              Expires March 11, 2017                [Page 26]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 27]
+Quattlebaum              Expires March 13, 2017                [Page 27]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 6.4.6.  PROP 53: PROP_MAC_15_4_SADDR
@@ -1565,9 +1565,9 @@ Quattlebaum              Expires March 11, 2017                [Page 27]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 28]
+Quattlebaum              Expires March 13, 2017                [Page 28]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 6.4.10.  PROP 4864: PROP_MAC_WHITELIST
@@ -1621,9 +1621,9 @@ Quattlebaum              Expires March 11, 2017                [Page 28]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 29]
+Quattlebaum              Expires March 13, 2017                [Page 29]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 6.5.4.  PROP 67: PROP_NET_ROLE
@@ -1677,9 +1677,9 @@ Quattlebaum              Expires March 11, 2017                [Page 29]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 30]
+Quattlebaum              Expires March 13, 2017                [Page 30]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 6.6.2.  PROP 97: PROP_IPV6_ML_ADDR
@@ -1733,9 +1733,9 @@ Quattlebaum              Expires March 11, 2017                [Page 30]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 31]
+Quattlebaum              Expires March 13, 2017                [Page 31]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    would indicate success by responding with a "CMD_VALUE_IS" for
@@ -1789,9 +1789,9 @@ Quattlebaum              Expires March 11, 2017                [Page 31]
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 32]
+Quattlebaum              Expires March 13, 2017                [Page 32]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
       *  116: "STATUS_RESET_CRASH"
@@ -1845,9 +1845,9 @@ A.1.  UART Recommendations
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 33]
+Quattlebaum              Expires March 13, 2017                [Page 33]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    dedicating one of your host pins to controlling the
@@ -1901,9 +1901,9 @@ A.1.1.  HDLC-Lite
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 34]
+Quattlebaum              Expires March 13, 2017                [Page 34]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    When first establishing a connection to the NCP, it is customary to
@@ -1957,9 +1957,9 @@ A.2.1.  SPI Framing Protocol
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 35]
+Quattlebaum              Expires March 13, 2017                [Page 35]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
       is equal-to or less-than the number of bytes that the other device
@@ -2013,9 +2013,9 @@ A.3.  I^2C Recommendations
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 36]
+Quattlebaum              Expires March 13, 2017                [Page 36]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 A.4.  Native USB Recommendations
@@ -2069,9 +2069,9 @@ B.1.2.  CMD 10: (Host->NCP) CMD_NET_CLEAR
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 37]
+Quattlebaum              Expires March 13, 2017                [Page 37]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    This operation affects non-volatile memory only.  The current network
@@ -2125,9 +2125,9 @@ Appendix C.  Feature: Host Buffer Offload
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 38]
+Quattlebaum              Expires March 13, 2017                [Page 38]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 C.1.  Commands
@@ -2181,9 +2181,9 @@ C.1.6.  CMD 17: (Host->NCP) CMD_HBO_DROPPED
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 39]
+Quattlebaum              Expires March 13, 2017                [Page 39]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 C.2.  Properties
@@ -2237,9 +2237,9 @@ Appendix D.  Technology: Thread
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 40]
+Quattlebaum              Expires March 13, 2017                [Page 40]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    o  The property "PROP_INTERFACE_TYPE" must be 3.
@@ -2293,9 +2293,9 @@ D.2.3.  PROP 82: PROP_THREAD_CHILD_TABLE
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 41]
+Quattlebaum              Expires March 13, 2017                [Page 41]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 D.2.4.  PROP 83: PROP_THREAD_LEADER_RID
@@ -2349,9 +2349,9 @@ D.2.11.  PROP 90: PROP_THREAD_ON_MESH_NETS
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 42]
+Quattlebaum              Expires March 13, 2017                [Page 42]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
    o  "6": IPv6 Prefix
@@ -2405,9 +2405,9 @@ D.2.16.  PROP 5376: PROP_THREAD_CHILD_TIMEOUT
 
 
 
-Quattlebaum              Expires March 11, 2017                [Page 43]
+Quattlebaum              Expires March 13, 2017                [Page 43]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
 
 D.2.17.  PROP 5377: PROP_THREAD_RLOC16
@@ -2452,19 +2452,25 @@ D.2.22.  PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU
 
    Default value is "false".
 
-Appendix E.  Test Vectors
+D.2.23.  PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "b"
 
 
 
 
 
-
-
-
-Quattlebaum              Expires March 11, 2017                [Page 44]
+Quattlebaum              Expires March 13, 2017                [Page 44]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
+
+   Allow the HOST to indicate whether or not the router role is enabled.
+   If current role is a router, setting this property to "false" starts
+   a re-attach process as an end-device.
+
+Appendix E.  Test Vectors
 
 E.1.  Test Vector: Packed Unsigned Integer
 
@@ -2507,6 +2513,15 @@ E.3.  Test Vector: Reset Notification
 
                                 80 06 00 72
 
+
+
+
+
+Quattlebaum              Expires March 13, 2017                [Page 45]
+
+                        Spinel Protocol (94724cf)         September 2016
+
+
 E.4.  Test Vector: Scan Beacon
 
    o  IID: 0
@@ -2514,13 +2529,6 @@ E.4.  Test Vector: Scan Beacon
    o  CMD: 7 ("CMD_VALUE_INSERTED")
    o  PROP: 51 ("PROP_MAC_SCAN_BEACON")
    o  VALUE: Structure, encoded as "CcT(ESSc.)T(iCUD.)."
-
-
-
-Quattlebaum              Expires March 11, 2017                [Page 45]
-
-                        Spinel Protocol (f5ea928)         September 2016
-
 
       *  CHAN: 15
       *  RSSI: -60dBm
@@ -2563,20 +2571,16 @@ E.7.  Test Vector: Fetch list of on-mesh networks
    o  CMD: 2 ("CMD_VALUE_GET")
    o  PROP: 90 ("PROP_THREAD_ON_MESH_NETS")
 
+
+
+Quattlebaum              Expires March 13, 2017                [Page 46]
+
+                        Spinel Protocol (94724cf)         September 2016
+
+
    Frame:
 
                                  84 02 5A
-
-
-
-
-
-
-
-Quattlebaum              Expires March 11, 2017                [Page 46]
-
-                        Spinel Protocol (f5ea928)         September 2016
-
 
 E.8.  Test Vector: Returned list of on-mesh networks
 
@@ -2620,20 +2624,22 @@ E.9.  Test Vector: Adding an on-mesh network
 
    [CREF5]
 
+
+
+
+
+
+Quattlebaum              Expires March 13, 2017                [Page 47]
+
+                        Spinel Protocol (94724cf)         September 2016
+
+
 E.10.  Test Vector: Insertion notification of an on-mesh network
 
    o  IID: 0
    o  TID: 5
    o  CMD: 7 ("CMD_VALUE_INSERTED")
    o  PROP: 90 ("PROP_THREAD_ON_MESH_NETS")
-
-
-
-Quattlebaum              Expires March 11, 2017                [Page 47]
-
-                        Spinel Protocol (f5ea928)         September 2016
-
-
    o  VALUE: Structure, encoded as "6CbC"
 
        +--------------+---------------+-------------+-------------+
@@ -2673,6 +2679,17 @@ E.12.  Test Vector: Removal notification of an on-mesh network
 
          86 08 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00
 
+
+
+
+
+
+
+Quattlebaum              Expires March 13, 2017                [Page 48]
+
+                        Spinel Protocol (94724cf)         September 2016
+
+
 Appendix F.  Example Sessions
 
 F.1.  NCP Initialization
@@ -2682,14 +2699,6 @@ F.1.  NCP Initialization
    Check the protocol version to see if it is supported:
 
    o  CMD_VALUE_GET:PROP_PROTOCOL_VERSION
-
-
-
-Quattlebaum              Expires March 11, 2017                [Page 48]
-
-                        Spinel Protocol (f5ea928)         September 2016
-
-
    o  CMD_VALUE_IS:PROP_PROTOCOL_VERSION
 
    Check the NCP version to see if a firmware update may be necessary:
@@ -2729,6 +2738,14 @@ F.2.  Attaching to a network
    Set the network properties, if they were not already set:
 
    o  CMD_VALUE_SET:PROP_PHY_CHAN
+
+
+
+Quattlebaum              Expires March 13, 2017                [Page 49]
+
+                        Spinel Protocol (94724cf)         September 2016
+
+
    o  CMD_VALUE_IS:PROP_PHY_CHAN
    o  CMD_VALUE_SET:PROP_NET_XPANID
    o  CMD_VALUE_IS:PROP_NET_XPANID
@@ -2738,14 +2755,6 @@ F.2.  Attaching to a network
    o  CMD_VALUE_IS:PROP_NET_NETWORK_NAME
    o  CMD_VALUE_SET:PROP_NET_MASTER_KEY
    o  CMD_VALUE_IS:PROP_NET_MASTER_KEY
-
-
-
-Quattlebaum              Expires March 11, 2017                [Page 49]
-
-                        Spinel Protocol (f5ea928)         September 2016
-
-
    o  CMD_VALUE_SET:PROP_NET_KEY_SEQUENCE
    o  CMD_VALUE_IS:PROP_NET_KEY_SEQUENCE
 
@@ -2785,22 +2794,19 @@ F.3.  Successfully joining a pre-existing network
 
    o  CMD_VALUE_IS:PROP_NET_ROLE
    o  CMD_VALUE_IS:PROP_NET_PARTITION_ID
+
+
+
+Quattlebaum              Expires March 13, 2017                [Page 50]
+
+                        Spinel Protocol (94724cf)         September 2016
+
+
    o  CMD_VALUE_IS:PROP_THREAD_ON_MESH_NETS
 
    Now let's save the network settings to NVRAM:
 
    o  CMD_NET_SAVE
-
-
-
-
-
-
-
-Quattlebaum              Expires March 11, 2017                [Page 50]
-
-                        Spinel Protocol (f5ea928)         September 2016
-
 
 F.4.  Unsuccessfully joining a pre-existing network
 
@@ -2845,18 +2851,16 @@ F.6.  Attaching to a saved network
 
    Some asynchronous events from the NCP:
 
+
+
+Quattlebaum              Expires March 13, 2017                [Page 51]
+
+                        Spinel Protocol (94724cf)         September 2016
+
+
    o  CMD_VALUE_IS:PROP_NET_ROLE
    o  CMD_VALUE_IS:PROP_NET_PARTITION_ID
    o  CMD_VALUE_IS:PROP_THREAD_ON_MESH_NETS
-
-
-
-
-
-Quattlebaum              Expires March 11, 2017                [Page 51]
-
-                        Spinel Protocol (f5ea928)         September 2016
-
 
 F.7.  NCP Software Reset
 
@@ -2901,19 +2905,20 @@ F.10.  Sniffing raw packets
    o  CMD_VALUE_SET:PROP_PHY_ENABLED:TRUE
    o  CMD_VALUE_IS:PROP_PHY_ENABLED:TRUE
 
+
+
+
+
+Quattlebaum              Expires March 13, 2017                [Page 52]
+
+                        Spinel Protocol (94724cf)         September 2016
+
+
    Now we will get raw 802.15.4 packets asynchronously on
    PROP_STREAM_RAW:
 
    o  CMD_VALUE_IS:PROP_STREAM_RAW:...
    o  CMD_VALUE_IS:PROP_STREAM_RAW:...
-
-
-
-Quattlebaum              Expires March 11, 2017                [Page 52]
-
-                        Spinel Protocol (f5ea928)         September 2016
-
-
    o  CMD_VALUE_IS:PROP_STREAM_RAW:...
 
    This mode may be entered even when associated with a network.  In
@@ -2954,21 +2959,18 @@ Editorial Comments
 
 [CREF12] RQ: FIXME: This example session is incomplete.
 
-Author's Address
 
 
 
 
 
 
-
-
-
-
-Quattlebaum              Expires March 11, 2017                [Page 53]
+Quattlebaum              Expires March 13, 2017                [Page 53]
 
-                        Spinel Protocol (f5ea928)         September 2016
+                        Spinel Protocol (94724cf)         September 2016
 
+
+Author's Address
 
    Robert S. Quattlebaum
    Nest Labs
@@ -3019,6 +3021,4 @@ Quattlebaum              Expires March 11, 2017                [Page 53]
 
 
 
-
-
-Quattlebaum              Expires March 11, 2017                [Page 54]
+Quattlebaum              Expires March 13, 2017                [Page 54]

--- a/doc/spinel-protocol-src/spinel-tech-thread.md
+++ b/doc/spinel-protocol-src/spinel-tech-thread.md
@@ -165,3 +165,10 @@ including ones sent to the RLOC16 address.
 
 Default value is `false`.
 
+### PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED
+* Type: Read-Write
+* Packed-Encoding: `b`
+
+Allow the HOST to indicate whether or not the router role is enabled.
+If current role is a router, setting this property to `false` starts
+a re-attach process as an end-device.

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -124,7 +124,8 @@ const NcpBase::GetPropertyHandlerEntry NcpBase::mGetPropertyHandlerTable[] =
     { SPINEL_PROP_THREAD_STABLE_NETWORK_DATA_VERSION, &NcpBase::GetPropertyHandler_THREAD_STABLE_NETWORK_DATA_VERSION },
     { SPINEL_PROP_THREAD_LOCAL_ROUTES, &NcpBase::NcpBase::GetPropertyHandler_THREAD_LOCAL_ROUTES },
     { SPINEL_PROP_THREAD_ASSISTING_PORTS, &NcpBase::NcpBase::GetPropertyHandler_THREAD_ASSISTING_PORTS },
-    { SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE, &NcpBase::GetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE},
+    { SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE, &NcpBase::GetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE },
+    { SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED, &NcpBase::GetPropertyHandler_THREAD_ROUTER_ROLE_ENABLED },
 
     { SPINEL_PROP_MAC_WHITELIST, &NcpBase::GetPropertyHandler_MAC_WHITELIST },
     { SPINEL_PROP_MAC_WHITELIST_ENABLED, &NcpBase::GetPropertyHandler_MAC_WHITELIST_ENABLED },
@@ -208,8 +209,9 @@ const NcpBase::SetPropertyHandlerEntry NcpBase::mSetPropertyHandlerTable[] =
 
     { SPINEL_PROP_THREAD_LOCAL_LEADER_WEIGHT, &NcpBase::SetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT },
     { SPINEL_PROP_THREAD_ASSISTING_PORTS, &NcpBase::SetPropertyHandler_THREAD_ASSISTING_PORTS },
-    { SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE, &NcpBase::SetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE},
+    { SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE, &NcpBase::SetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE },
     { SPINEL_PROP_THREAD_NETWORK_ID_TIMEOUT, &NcpBase::SetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT },
+    { SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED, &NcpBase::SetPropertyHandler_THREAD_ROUTER_ROLE_ENABLED },
 
     { SPINEL_PROP_STREAM_NET_INSECURE, &NcpBase::SetPropertyHandler_STREAM_NET_INSECURE },
     { SPINEL_PROP_STREAM_NET, &NcpBase::SetPropertyHandler_STREAM_NET },
@@ -1871,7 +1873,6 @@ exit:
     return errorCode;
 }
 
-
 ThreadError NcpBase::GetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
@@ -1880,6 +1881,17 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8
         key,
         SPINEL_DATATYPE_BOOL_S,
         mAllowLocalNetworkDataChange
+    );
+}
+
+ThreadError NcpBase::GetPropertyHandler_THREAD_ROUTER_ROLE_ENABLED(uint8_t header, spinel_prop_key_t key)
+{
+    return SendPropertyUpdate(
+        header,
+        SPINEL_CMD_PROP_VALUE_IS,
+        key,
+        SPINEL_DATATYPE_BOOL_S,
+        otIsRouterRoleEnabled()
     );
 }
 
@@ -3433,6 +3445,34 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8
     if (should_register_with_leader)
     {
         otSendServerData();
+    }
+
+    return errorCode;
+}
+
+ThreadError NcpBase::SetPropertyHandler_THREAD_ROUTER_ROLE_ENABLED(uint8_t header, spinel_prop_key_t key,
+                                                   const uint8_t *value_ptr, uint16_t value_len)
+{
+    bool isEnabled;
+    spinel_ssize_t parsedLength;
+    ThreadError errorCode = kThreadError_None;
+
+    parsedLength = spinel_datatype_unpack(
+                       value_ptr,
+                       value_len,
+                       SPINEL_DATATYPE_BOOL_S,
+                       &isEnabled
+                   );
+
+    if (parsedLength > 0)
+    {
+        otSetRouterRoleEnabled(isEnabled);
+
+        errorCode = HandleCommandPropertyGet(header, key);
+    }
+    else
+    {
+        errorCode = SendLastStatus(header, SPINEL_STATUS_PARSE_ERROR);
     }
 
     return errorCode;

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -305,6 +305,7 @@ private:
     ThreadError GetPropertyHandler_MAC_FILTER_MODE(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_ROUTER_ROLE_ENABLED(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_MAC_CNTR(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_NCP_CNTR(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key);
@@ -375,6 +376,8 @@ private:
     ThreadError SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
                                                     const uint8_t *value_ptr, uint16_t value_len);
     ThreadError SetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key,
+                                                   const uint8_t *value_ptr, uint16_t value_len);
+    ThreadError SetPropertyHandler_THREAD_ROUTER_ROLE_ENABLED(uint8_t header, spinel_prop_key_t key,
                                                    const uint8_t *value_ptr, uint16_t value_len);
     ThreadError SetPropertyHandler_NET_REQUIRE_JOIN_EXISTING(uint8_t header, spinel_prop_key_t key,
                                                    const uint8_t *value_ptr, uint16_t value_len);

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -859,6 +859,8 @@ spinel_datatype_vpack(uint8_t *data_ptr, spinel_size_t data_len_max, const char 
 // ----------------------------------------------------------------------------
 // MARK: -
 
+// **** LCOV_EXCL_START ****
+
 const char *
 spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
 {
@@ -1114,6 +1116,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU";
         break;
 
+    case SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED:
+        ret = "SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED";
+        break;
+
     case SPINEL_PROP_MAC_WHITELIST:
         ret = "PROP_MAC_WHITELIST";
         break;
@@ -1303,6 +1309,7 @@ const char *spinel_status_to_cstr(spinel_status_t status)
     return ret;
 }
 
+// **** LCOV_EXCL_STOP ****
 
 /* -------------------------------------------------------------------------- */
 

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -503,6 +503,12 @@ typedef enum
     SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU
                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 6,
 
+    /// This property indicates whether or not the `Router Role` is enabled.
+    /** Format `b`
+     */
+    SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED
+                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 7,
+
     SPINEL_PROP_THREAD_EXT__END        = 0x1600,
 
     SPINEL_PROP_IPV6__BEGIN          = 0x60,


### PR DESCRIPTION
This commit adds a new spinel property `THREAD_ROUTER_ROLE_ENABLED` (updates the `draft-spinel-protocol` files). It also adds get and set handlers in `NcpBase` class for this property.
This will be used from wpantun to enable joining as a end-device...
