### PR TITLE
Delay a random jitter period prior to request a Router ID for REED.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,3 +66,5 @@ matrix:
     - env: BUILD_TARGET="posix-ncp" VERBOSE=1
       compiler: gcc
       os: linux
+  allow_failures:
+    - env: BUILD_TARGET="posix-ncp" VERBOSE=1

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -1532,6 +1532,24 @@ uint8_t otGetRouterDowngradeThreshold(void);
 void otSetRouterDowngradeThreshold(uint8_t aThreshold);
 
 /**
+ * Get the ROUTER_SELECTION_JITTER parameter used in the REED/Router role.
+ *
+ * @returns The ROUTER_SELECTION_JITTER value.
+ *
+ * @sa otSetRouterSelectionJitter
+ */
+uint8_t otGetRouterSelectionJitter(void);
+
+/**
+ * Set the ROUTER_SELECTION_JITTER parameter used in the REED/Router role.
+ *
+ * @param[in]  aRouterJitter  The ROUTER_SELECTION_JITTER value.
+ *
+ * @sa otGetRouterSelectionJitter
+ */
+void otSetRouterSelectionJitter(uint8_t aRouterJitter);
+
+/**
  * @}
  *
  */

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -47,6 +47,7 @@ OpenThread test scripts use the CLI to execute test cases.
 * [router](#router)
 * [routerdowngradethreshold](#routerdowngradethreshold)
 * [routerrole](#routerrole)
+* [routerselectionjitter](#routerselectionjitter)
 * [routerupgradethreshold](#routerupgradethreshold)
 * [scan](#scan)
 * [singleton](#singleton)
@@ -1203,6 +1204,25 @@ Disable the router role.
 
 ```bash
 > routerrole disable
+Done
+```
+
+### routerselectionjitter
+
+Get the ROUTER_SELECTION_JITTER value.
+
+```bash
+> routerselectionjitter
+120
+Done
+```
+
+### routerselectionjitter \<jitter\>
+
+Set the ROUTER_SELECTION_JITTER value.
+
+```bash
+> routerselectionjitter 120
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -119,6 +119,7 @@ const struct Command Interpreter::sCommands[] =
     { "router", &Interpreter::ProcessRouter },
     { "routerdowngradethreshold", &Interpreter::ProcessRouterDowngradeThreshold },
     { "routerrole", &Interpreter::ProcessRouterRole },
+    { "routerselectionjitter", &Interpreter::ProcessRouterSelectionJitter },
     { "routerupgradethreshold", &Interpreter::ProcessRouterUpgradeThreshold },
     { "scan", &Interpreter::ProcessScan },
     { "singleton", &Interpreter::ProcessSingleton },
@@ -1779,6 +1780,25 @@ void Interpreter::ProcessRouterRole(int argc, char *argv[])
     else
     {
         ExitNow(error = kThreadError_Parse);
+    }
+
+exit:
+    AppendResult(error);
+}
+
+void Interpreter::ProcessRouterSelectionJitter(int argc, char *argv[])
+{
+    ThreadError error = kThreadError_None;
+    long value;
+
+    if (argc == 0)
+    {
+        sServer->OutputFormat("%d\r\n", otGetRouterSelectionJitter());
+    }
+    else
+    {
+        SuccessOrExit(error = ParseLong(argv[0], value));
+        otSetRouterSelectionJitter(static_cast<uint8_t>(value));
     }
 
 exit:

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -193,6 +193,7 @@ private:
     void ProcessRouter(int argc, char *argv[]);
     void ProcessRouterDowngradeThreshold(int argc, char *argv[]);
     void ProcessRouterRole(int argc, char *argv[]);
+    void ProcessRouterSelectionJitter(int argc, char *argv[]);
     ThreadError ProcessRouteAdd(int argc, char *argv[]);
     ThreadError ProcessRouteRemove(int argc, char *argv[]);
     void ProcessRouterUpgradeThreshold(int argc, char *argv[]);

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -684,6 +684,16 @@ void otSetRouterDowngradeThreshold(uint8_t aThreshold)
     sThreadNetif->GetMle().SetRouterDowngradeThreshold(aThreshold);
 }
 
+uint8_t otGetRouterSelectionJitter(void)
+{
+    return sThreadNetif->GetMle().GetRouterSelectionJitter();
+}
+
+void otSetRouterSelectionJitter(uint8_t aRouterJitter)
+{
+    sThreadNetif->GetMle().SetRouterSelectionJitter(aRouterJitter);
+}
+
 ThreadError otGetChildInfoById(otInstance *, uint16_t aChildId, otChildInfo *aChildInfo)
 {
     ThreadError error = kThreadError_None;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -622,6 +622,22 @@ public:
     void SetAssignLinkQuality(const Mac::ExtAddress aMacAddr, uint8_t aLinkQuality);
 
     /**
+     * This method returns the ROUTER_SELECTION_JITTER value.
+     *
+     * @returns The ROUTER_SELECTION_JITTER value.
+     *
+     */
+    uint8_t GetRouterSelectionJitter(void) const;
+
+    /**
+     * This method sets the ROUTER_SELECTION_JITTER value.
+     *
+     * @returns The ROUTER_SELECTION_JITTER value.
+     *
+     */
+    void SetRouterSelectionJitter(uint8_t aRouterJitter);
+
+    /**
      * This method returns the Child ID portion of an RLOC16.
      *
      * @param[in]  aRloc16  The RLOC16 value.
@@ -1075,6 +1091,9 @@ protected:
     ParentRequestState mParentRequestState;  ///< The parent request state.
 
     Timer mParentRequestTimer;  ///< The timer for driving the Parent Request process.
+
+    uint8_t mRouterSelectionJitter;         ///< The variable to save the assigned jitter value.
+    uint8_t mRouterSelectionJitterTimeout;  ///< The Timeout prior to request/release Router ID.
 
 private:
     enum

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -73,7 +73,6 @@ MleRouter::MleRouter(ThreadNetif &aThreadNetif):
     mPreviousRouterId = kInvalidRouterId;
     mRouterIdSequenceLastUpdated = 0;
     mRouterRoleEnabled = true;
-    mRouterSelectionJitterTimeout = 0;
 
     mCoapMessageId = static_cast<uint8_t>(otPlatRandomGet());
 }
@@ -1311,9 +1310,11 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
         ExitNow();
 
     case kDeviceStateChild:
-        if ((mDeviceMode & ModeTlv::kModeFFD) && (GetActiveRouterCount() < mRouterUpgradeThreshold))
+        if (mRouterSelectionJitterTimeout == 0 &&
+            (mDeviceMode & ModeTlv::kModeFFD) &&
+            (GetActiveRouterCount() < mRouterUpgradeThreshold))
         {
-            mRouterSelectionJitterTimer.Start(Timer::SecToMsec(otPlatRandomGet() % kRouterSelectionJitter));
+            mRouterSelectionJitterTimeout = otPlatRandomGet() % mRouterSelectionJitter;
             ExitNow();
         }
 
@@ -1392,7 +1393,7 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
             HasSmallNumberOfChildren() &&
             HasOneNeighborwithComparableConnectivity(route, routerId))
         {
-            mRouterSelectionJitterTimeout = otPlatRandomGet() % kRouterSelectionJitter;
+            mRouterSelectionJitterTimeout = otPlatRandomGet() % mRouterSelectionJitter;
         }
 
     // fall through
@@ -1640,6 +1641,11 @@ void MleRouter::HandleStateUpdateTimer(void)
         mChallengeTimeout--;
     }
 
+    if (mRouterSelectionJitterTimeout > 0)
+    {
+        mRouterSelectionJitterTimeout--;
+    }
+
     switch (GetDeviceState())
     {
     case kDeviceStateDisabled:
@@ -1652,6 +1658,13 @@ void MleRouter::HandleStateUpdateTimer(void)
         ExitNow();
 
     case kDeviceStateChild:
+        if (mRouterSelectionJitterTimeout == 0 &&
+            GetActiveRouterCount() < mRouterUpgradeThreshold)
+        {
+            // upgrade to Router
+            BecomeRouter(ThreadStatusTlv::kTooFewRouters);
+        }
+
     case kDeviceStateRouter:
         // verify path to leader
         otLogDebgMle("network id timeout = %d\n", GetLeaderAge());
@@ -1661,16 +1674,11 @@ void MleRouter::HandleStateUpdateTimer(void)
             BecomeChild(kMleAttachSamePartition);
         }
 
-        if (mRouterSelectionJitterTimeout > 0)
+        if (mRouterSelectionJitterTimeout == 0 &&
+            GetActiveRouterCount() > mRouterDowngradeThreshold)
         {
-            mRouterSelectionJitterTimeout--;
-
-            if (mRouterSelectionJitterTimeout == 0 &&
-                GetActiveRouterCount() > mRouterDowngradeThreshold)
-            {
-                // downgrade to REED
-                BecomeChild(kMleAttachSamePartition);
-            }
+            // downgrade to REED
+            BecomeChild(kMleAttachSamePartition);
         }
 
         break;
@@ -1738,25 +1746,6 @@ void MleRouter::HandleStateUpdateTimer(void)
     }
 
     mStateUpdateTimer.Start(kStateUpdatePeriod);
-
-exit:
-    {}
-}
-
-void MleRouter::HandleRouterSelectionJitterTimer(void *aContext)
-{
-    MleRouter *obj = reinterpret_cast<MleRouter *>(aContext);
-    obj->HandleRouterSelectionJitterTimer();
-}
-
-void MleRouter::HandleRouterSelectionJitterTimer(void)
-{
-    VerifyOrExit(mDeviceState == kDeviceStateChild, ;);
-
-    if (GetActiveRouterCount() < mRouterUpgradeThreshold)
-    {
-        BecomeRouter(ThreadStatusTlv::kTooFewRouters);
-    }
 
 exit:
     {}

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -579,9 +579,12 @@ private:
     bool HandleAdvertiseTimer(void);
     static void HandleStateUpdateTimer(void *aContext);
     void HandleStateUpdateTimer(void);
+    static void HandleRouterSelectionJitterTimer(void *aContext);
+    void HandleRouterSelectionJitterTimer(void);
 
     TrickleTimer mAdvertiseTimer;
     Timer mStateUpdateTimer;
+    Timer mRouterSelectionJitterTimer;
 
     Ip6::UdpSocket mSocket;
     Coap::Resource mAddressSolicit;

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -579,12 +579,9 @@ private:
     bool HandleAdvertiseTimer(void);
     static void HandleStateUpdateTimer(void *aContext);
     void HandleStateUpdateTimer(void);
-    static void HandleRouterSelectionJitterTimer(void *aContext);
-    void HandleRouterSelectionJitterTimer(void);
 
     TrickleTimer mAdvertiseTimer;
     Timer mStateUpdateTimer;
-    Timer mRouterSelectionJitterTimer;
 
     Ip6::UdpSocket mSocket;
     Coap::Resource mAddressSolicit;
@@ -605,7 +602,6 @@ private:
     uint8_t mLeaderWeight;
     uint32_t mFixedLeaderPartitionId;  ///< only for certification testing
     bool mRouterRoleEnabled;
-    uint8_t mRouterSelectionJitterTimeout;
 
     uint8_t mRouterId;
     uint8_t mPreviousRouterId;

--- a/tests/scripts/thread-cert/Cert_5_1_01_RouterAttach.py
+++ b/tests/scripts/thread-cert/Cert_5_1_01_RouterAttach.py
@@ -50,6 +50,7 @@ class Cert_5_1_01_RouterAttach(unittest.TestCase):
         self.nodes[ROUTER].set_mode('rsdn')
         self.nodes[ROUTER].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_5_1_02_ChildAddressTimeout.py
+++ b/tests/scripts/thread-cert/Cert_5_1_02_ChildAddressTimeout.py
@@ -54,6 +54,7 @@ class Cert_5_1_02_ChildAddressTimeout(unittest.TestCase):
         self.nodes[ROUTER].add_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ROUTER].add_whitelist(self.nodes[SED].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[ED].set_panid(0xface)
         self.nodes[ED].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_5_1_03_RouterAddressReallocation.py
+++ b/tests/scripts/thread-cert/Cert_5_1_03_RouterAddressReallocation.py
@@ -53,12 +53,14 @@ class Cert_5_1_03_RouterAddressReallocation(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_5_1_04_RouterAddressReallocation.py
+++ b/tests/scripts/thread-cert/Cert_5_1_04_RouterAddressReallocation.py
@@ -53,12 +53,14 @@ class Cert_5_1_04_RouterAddressReallocation(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_5_1_05_RouterAddressTimeout.py
+++ b/tests/scripts/thread-cert/Cert_5_1_05_RouterAddressTimeout.py
@@ -50,6 +50,7 @@ class Cert_5_1_05_RouterAddressTimeout(unittest.TestCase):
         self.nodes[ROUTER1].set_mode('rsdn')
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_5_1_06_RemoveRouterId.py
+++ b/tests/scripts/thread-cert/Cert_5_1_06_RemoveRouterId.py
@@ -50,6 +50,7 @@ class Cert_5_1_06_RemoveRouterId(unittest.TestCase):
         self.nodes[ROUTER1].set_mode('rsdn')
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
+++ b/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
@@ -51,6 +51,7 @@ class Cert_5_1_07_MaxChildCount(unittest.TestCase):
         self.nodes[ROUTER].set_mode('rsdn')
         self.nodes[ROUTER].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[ED].set_panid(0xface)
         self.nodes[ED].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_5_1_08_RouterAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_5_1_08_RouterAttachConnectivity.py
@@ -56,12 +56,14 @@ class Cert_5_1_08_RouterAttachConnectivity(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER3].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER4].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ROUTER3].set_panid(0xface)
         self.nodes[ROUTER3].set_mode('rsdn')
@@ -69,12 +71,14 @@ class Cert_5_1_08_RouterAttachConnectivity(unittest.TestCase):
         self.nodes[ROUTER3].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER3].add_whitelist(self.nodes[ROUTER4].get_addr64())
         self.nodes[ROUTER3].enable_whitelist()
+        self.nodes[ROUTER3].set_router_selection_jitter(1)
 
         self.nodes[ROUTER4].set_panid(0xface)
         self.nodes[ROUTER4].set_mode('rsdn')
         self.nodes[ROUTER4].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[ROUTER4].add_whitelist(self.nodes[ROUTER3].get_addr64())
         self.nodes[ROUTER4].enable_whitelist()
+        self.nodes[ROUTER4].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):
@@ -88,7 +92,7 @@ class Cert_5_1_08_RouterAttachConnectivity(unittest.TestCase):
 
         for i in range(2, 6):
             self.nodes[i].start()
-            time.sleep(3)
+            time.sleep(5)
             self.assertEqual(self.nodes[i].get_state(), 'router')
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_5_1_09_REEDAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_5_1_09_REEDAttachConnectivity.py
@@ -56,6 +56,7 @@ class Cert_5_1_09_REEDAttachConnectivity(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[REED1].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[REED0].set_panid(0xface)
         self.nodes[REED0].set_mode('rsdn')
@@ -77,6 +78,7 @@ class Cert_5_1_09_REEDAttachConnectivity(unittest.TestCase):
         self.nodes[ROUTER2].add_whitelist(self.nodes[REED0].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[REED1].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):
@@ -103,7 +105,7 @@ class Cert_5_1_09_REEDAttachConnectivity(unittest.TestCase):
         time.sleep(10)
 
         self.nodes[ROUTER2].start()
-        time.sleep(120)
+        time.sleep(10)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
         self.assertEqual(self.nodes[REED1].get_state(), 'router')
 

--- a/tests/scripts/thread-cert/Cert_5_1_09_REEDAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_5_1_09_REEDAttachConnectivity.py
@@ -103,7 +103,7 @@ class Cert_5_1_09_REEDAttachConnectivity(unittest.TestCase):
         time.sleep(10)
 
         self.nodes[ROUTER2].start()
-        time.sleep(10)
+        time.sleep(120)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
         self.assertEqual(self.nodes[REED1].get_state(), 'router')
 

--- a/tests/scripts/thread-cert/Cert_5_1_10_RouterAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_5_1_10_RouterAttachLinkQuality.py
@@ -54,18 +54,21 @@ class Cert_5_1_10_RouterAttachLinkQuality(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER3].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER3].get_addr64(), rssi=-85)
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ROUTER3].set_panid(0xface)
         self.nodes[ROUTER3].set_mode('rsdn')
         self.nodes[ROUTER3].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER3].add_whitelist(self.nodes[ROUTER2].get_addr64(), rssi=-85)
         self.nodes[ROUTER3].enable_whitelist()
+        self.nodes[ROUTER3].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):
@@ -78,15 +81,15 @@ class Cert_5_1_10_RouterAttachLinkQuality(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER3].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER3].get_state(), 'router')
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_5_1_11_REEDAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_5_1_11_REEDAttachLinkQuality.py
@@ -61,12 +61,14 @@ class Cert_5_1_11_REEDAttachLinkQuality(unittest.TestCase):
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER1].get_addr64(), rssi=-85)
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ROUTER1].set_panid(0xface)
         self.nodes[ROUTER1].set_mode('rsdn')
         self.nodes[ROUTER1].add_whitelist(self.nodes[REED].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER2].get_addr64(), rssi=-85)
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_5_1_12_NewRouterNeighborSync.py
+++ b/tests/scripts/thread-cert/Cert_5_1_12_NewRouterNeighborSync.py
@@ -52,11 +52,13 @@ class Cert_5_1_12_NewRouterSync(unittest.TestCase):
         self.nodes[ROUTER1].set_mode('rsdn')
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_5_1_13_RouterReset.py
+++ b/tests/scripts/thread-cert/Cert_5_1_13_RouterReset.py
@@ -50,6 +50,7 @@ class Cert_5_1_13_RouterReset(unittest.TestCase):
         self.nodes[ROUTER].set_mode('rsdn')
         self.nodes[ROUTER].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_5_2_01_BecomeActiveRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_2_01_BecomeActiveRouter.py
@@ -52,11 +52,13 @@ class Cert_5_2_1_BecomeActiveRouter(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[REED].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[REED].set_panid(0xface)
         self.nodes[REED].set_mode('rsdn')
         self.nodes[REED].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[REED].enable_whitelist()
+        self.nodes[REED].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):
@@ -69,11 +71,11 @@ class Cert_5_2_1_BecomeActiveRouter(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[REED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[REED].get_state(), 'router')
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_5_2_02_LeaderReject1Hop.py
+++ b/tests/scripts/thread-cert/Cert_5_2_02_LeaderReject1Hop.py
@@ -44,6 +44,7 @@ class Cert_5_2_2_LeaderReject1Hop(unittest.TestCase):
         self.nodes[LEADER].set_mode('rsdn')
         self.nodes[LEADER].enable_whitelist()
         self.nodes[LEADER].set_router_upgrade_threshold(32)
+        self.nodes[LEADER].set_router_downgrade_threshold(33)
 
         for i in range(2,34):
             self.nodes[i] = node.Node(i)
@@ -53,6 +54,8 @@ class Cert_5_2_2_LeaderReject1Hop(unittest.TestCase):
             self.nodes[LEADER].add_whitelist(self.nodes[i].get_addr64())
             self.nodes[i].enable_whitelist()
             self.nodes[i].set_router_upgrade_threshold(33)
+            self.nodes[i].set_router_downgrade_threshold(33)
+            self.nodes[i].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_5_2_03_LeaderReject2Hops.py
+++ b/tests/scripts/thread-cert/Cert_5_2_03_LeaderReject2Hops.py
@@ -45,6 +45,7 @@ class Cert_5_2_3_LeaderReject2Hops(unittest.TestCase):
         self.nodes[LEADER].set_mode('rsdn')
         self.nodes[LEADER].enable_whitelist()
         self.nodes[LEADER].set_router_upgrade_threshold(32)
+        self.nodes[LEADER].set_router_downgrade_threshold(33)
 
         for i in range(2,33):
             self.nodes[i] = node.Node(i)
@@ -54,6 +55,8 @@ class Cert_5_2_3_LeaderReject2Hops(unittest.TestCase):
             self.nodes[LEADER].add_whitelist(self.nodes[i].get_addr64())
             self.nodes[i].enable_whitelist()
             self.nodes[i].set_router_upgrade_threshold(33)
+            self.nodes[i].set_router_downgrade_threshold(33)
+            self.nodes[i].set_router_selection_jitter(1)
 
         self.nodes[DUT] = node.Node(DUT)
         self.nodes[DUT].set_panid(0xface)
@@ -62,6 +65,8 @@ class Cert_5_2_3_LeaderReject2Hops(unittest.TestCase):
         self.nodes[ROUTER].add_whitelist(self.nodes[DUT].get_addr64())
         self.nodes[DUT].enable_whitelist()
         self.nodes[DUT].set_router_upgrade_threshold(33)
+        self.nodes[DUT].set_router_downgrade_threshold(33)
+        self.nodes[DUT].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_5_2_04_REEDUpgrade.py
+++ b/tests/scripts/thread-cert/Cert_5_2_04_REEDUpgrade.py
@@ -54,6 +54,7 @@ class Cert_5_2_4_REEDUpgrade(unittest.TestCase):
             self.nodes[i].add_whitelist(self.nodes[LEADER].get_addr64())
             self.nodes[LEADER].add_whitelist(self.nodes[i].get_addr64())
             self.nodes[i].enable_whitelist()
+            self.nodes[i].set_router_selection_jitter(1)
 
         self.nodes[REED].set_panid(0xface)
         self.nodes[REED].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
@@ -58,6 +58,7 @@ class Cert_5_2_5_AddressQuery(unittest.TestCase):
         self.nodes[BR1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[BR1].add_whitelist(self.nodes[ED1].get_addr64())
         self.nodes[BR1].enable_whitelist()
+        self.nodes[BR1].set_router_selection_jitter(1)
 
         self.nodes[ED1].set_panid(0xface)
         self.nodes[ED1].set_mode('rsn')
@@ -78,6 +79,7 @@ class Cert_5_2_5_AddressQuery(unittest.TestCase):
         self.nodes[ROUTER2].add_whitelist(self.nodes[ED2].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[ED3].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ED2].set_panid(0xface)
         self.nodes[ED2].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_5_2_07_REEDSynchronization.py
+++ b/tests/scripts/thread-cert/Cert_5_2_07_REEDSynchronization.py
@@ -57,6 +57,7 @@ class Cert_5_2_7_REEDSynchronization(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[REED].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER3].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[REED].set_panid(0xface)
         self.nodes[REED].set_mode('rsdn')
@@ -73,6 +74,7 @@ class Cert_5_2_7_REEDSynchronization(unittest.TestCase):
         self.nodes[ROUTER2].add_whitelist(self.nodes[REED].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER3].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ROUTER3].set_panid(0xface)
         self.nodes[ROUTER3].set_mode('rsdn')
@@ -80,6 +82,7 @@ class Cert_5_2_7_REEDSynchronization(unittest.TestCase):
         self.nodes[ROUTER3].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER3].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[ROUTER3].enable_whitelist()
+        self.nodes[ROUTER3].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):
@@ -92,19 +95,19 @@ class Cert_5_2_7_REEDSynchronization(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[REED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[REED].get_state(), 'child')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER3].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER3].get_state(), 'router')
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_5_3_01_LinkLocal.py
+++ b/tests/scripts/thread-cert/Cert_5_3_01_LinkLocal.py
@@ -50,6 +50,7 @@ class Cert_5_3_1_LinkLocal(unittest.TestCase):
         self.nodes[ROUTER1].set_mode('rsdn')
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_5_3_02_RealmLocal.py
+++ b/tests/scripts/thread-cert/Cert_5_3_02_RealmLocal.py
@@ -53,12 +53,14 @@ class Cert_5_3_2_RealmLocal(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[SED1].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[SED1].set_panid(0xface)
         self.nodes[SED1].set_mode('sn')
@@ -77,15 +79,15 @@ class Cert_5_3_2_RealmLocal(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[SED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         addrs = self.nodes[ROUTER2].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_3_03_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_03_AddressQuery.py
@@ -55,6 +55,7 @@ class Cert_5_3_3_AddressQuery(unittest.TestCase):
         self.nodes[BR].set_mode('rsdn')
         self.nodes[BR].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[BR].enable_whitelist()
+        self.nodes[BR].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
@@ -62,12 +63,14 @@ class Cert_5_3_3_AddressQuery(unittest.TestCase):
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER3].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[ED2].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ROUTER3].set_panid(0xface)
         self.nodes[ROUTER3].set_mode('rsdn')
         self.nodes[ROUTER3].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER3].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[ROUTER3].enable_whitelist()
+        self.nodes[ROUTER3].set_router_selection_jitter(1)
 
         self.nodes[ED2].set_panid(0xface)
         self.nodes[ED2].set_mode('rsn')
@@ -94,15 +97,15 @@ class Cert_5_3_3_AddressQuery(unittest.TestCase):
         self.nodes[BR].register_netdata()
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER3].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER3].get_state(), 'router')
 
         self.nodes[ED2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED2].get_state(), 'child')
 
         addrs = self.nodes[ROUTER3].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_3_04_AddressMapCache.py
+++ b/tests/scripts/thread-cert/Cert_5_3_04_AddressMapCache.py
@@ -60,6 +60,7 @@ class Cert_5_3_4_AddressMapCache(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[SED1].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[SED1].set_panid(0xface)
         self.nodes[SED1].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_5_3_05_RoutingLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_5_3_05_RoutingLinkQuality.py
@@ -55,17 +55,20 @@ class Cert_5_3_5_RoutingLinkQuality(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER3].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ROUTER3].set_panid(0xface)
         self.nodes[ROUTER3].set_mode('rsdn')
         self.nodes[ROUTER3].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER3].enable_whitelist()
+        self.nodes[ROUTER3].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):
@@ -78,15 +81,15 @@ class Cert_5_3_5_RoutingLinkQuality(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER3].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER3].get_state(), 'router')
 
         time.sleep(10)

--- a/tests/scripts/thread-cert/Cert_5_3_06_RouterIdMask.py
+++ b/tests/scripts/thread-cert/Cert_5_3_06_RouterIdMask.py
@@ -52,11 +52,13 @@ class Cert_5_3_6_RouterIdMask(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):
@@ -69,11 +71,11 @@ class Cert_5_3_6_RouterIdMask(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER2].stop()

--- a/tests/scripts/thread-cert/Cert_5_3_06b_RouterIdMask.py
+++ b/tests/scripts/thread-cert/Cert_5_3_06b_RouterIdMask.py
@@ -52,11 +52,13 @@ class Cert_5_3_6_RouterIdMask(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):
@@ -69,11 +71,11 @@ class Cert_5_3_6_RouterIdMask(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER1].stop()

--- a/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
+++ b/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
@@ -57,12 +57,14 @@ class Cert_5_3_7_DuplicateAddress(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ED1].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[ED2].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ED1].set_panid(0xface)
         self.nodes[ED1].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
@@ -55,18 +55,21 @@ class Cert_5_3_10_AddressQuery(unittest.TestCase):
         self.nodes[BR].set_mode('rsdn')
         self.nodes[BR].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[BR].enable_whitelist()
+        self.nodes[BR].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[SED2].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ROUTER3].set_panid(0xface)
         self.nodes[ROUTER3].set_mode('rsdn')
         self.nodes[ROUTER3].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER3].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[ROUTER3].enable_whitelist()
+        self.nodes[ROUTER3].set_router_selection_jitter(1)
 
         self.nodes[SED2].set_panid(0xface)
         self.nodes[SED2].set_mode('sn')

--- a/tests/scripts/thread-cert/Cert_5_5_01_LeaderReset.py
+++ b/tests/scripts/thread-cert/Cert_5_5_01_LeaderReset.py
@@ -50,6 +50,7 @@ class Cert_5_5_1_LeaderReset(unittest.TestCase):
         self.nodes[ROUTER].set_mode('rsdn')
         self.nodes[ROUTER].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_5_5_02_LeaderReboot.py
+++ b/tests/scripts/thread-cert/Cert_5_5_02_LeaderReboot.py
@@ -46,12 +46,14 @@ class Cert_5_5_2_LeaderReboot(unittest.TestCase):
         self.nodes[LEADER].set_mode('rsdn')
         self.nodes[LEADER].add_whitelist(self.nodes[ROUTER].get_addr64())
         self.nodes[LEADER].enable_whitelist()
+        self.nodes[LEADER].set_router_selection_jitter(1)
 
         self.nodes[ROUTER].set_panid(0xface)
         self.nodes[ROUTER].set_mode('rsdn')
         self.nodes[ROUTER].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER].add_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[ED].set_panid(0xface)
         self.nodes[ED].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_5_5_03_SplitMergeChildren.py
+++ b/tests/scripts/thread-cert/Cert_5_5_03_SplitMergeChildren.py
@@ -51,6 +51,7 @@ class Cert_5_5_3_SplitMergeChildren(unittest.TestCase):
         self.nodes[LEADER].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[LEADER].add_whitelist(self.nodes[ED1].get_addr64())
         self.nodes[LEADER].enable_whitelist()
+        self.nodes[LEADER].set_router_selection_jitter(1)
 
         self.nodes[ROUTER1].set_panid(0xface)
         self.nodes[ROUTER1].set_mode('rsdn')
@@ -58,11 +59,13 @@ class Cert_5_5_3_SplitMergeChildren(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[ED2].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ED3].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ED1].set_panid(0xface)
         self.nodes[ED1].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_5_5_04_SplitMergeRouters.py
+++ b/tests/scripts/thread-cert/Cert_5_5_04_SplitMergeRouters.py
@@ -51,29 +51,34 @@ class Cert_5_5_4_SplitMergeRouters(unittest.TestCase):
         self.nodes[LEADER1].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[LEADER1].add_whitelist(self.nodes[ED1].get_addr64())
         self.nodes[LEADER1].enable_whitelist()
+        self.nodes[LEADER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER1].set_panid(0xface)
         self.nodes[ROUTER1].set_mode('rsdn')
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER1].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER3].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER1].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER4].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ROUTER3].set_panid(0xface)
         self.nodes[ROUTER3].set_mode('rsdn')
         self.nodes[ROUTER3].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER3].enable_whitelist()
         self.nodes[ROUTER3].set_network_id_timeout(110)
+        self.nodes[ROUTER3].set_router_selection_jitter(1)
 
         self.nodes[ROUTER4].set_panid(0xface)
         self.nodes[ROUTER4].set_mode('rsdn')
         self.nodes[ROUTER4].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[ROUTER4].enable_whitelist()
+        self.nodes[ROUTER4].set_router_selection_jitter(1)
 
         self.nodes[ED1].set_panid(0xface)
         self.nodes[ED1].set_mode('rsn')
@@ -91,23 +96,23 @@ class Cert_5_5_4_SplitMergeRouters(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER1].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER3].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER3].get_state(), 'router')
 
         self.nodes[ROUTER4].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER4].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[LEADER1].stop()

--- a/tests/scripts/thread-cert/Cert_5_5_05_SplitMergeREED.py
+++ b/tests/scripts/thread-cert/Cert_5_5_05_SplitMergeREED.py
@@ -55,18 +55,21 @@ class Cert_5_5_5_SplitMergeREED(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER3].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[REED2].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER1].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[REED2].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ROUTER3].set_panid(0xface)
         self.nodes[ROUTER3].set_mode('rsdn')
         self.nodes[ROUTER3].add_whitelist(self.nodes[LEADER1].get_addr64())
         self.nodes[ROUTER3].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER3].enable_whitelist()
+        self.nodes[ROUTER3].set_router_selection_jitter(1)
 
         self.nodes[REED2].set_panid(0xface)
         self.nodes[REED2].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_5_06_SplitWeight.py
+++ b/tests/scripts/thread-cert/Cert_5_5_06_SplitWeight.py
@@ -54,12 +54,14 @@ class Cert_5_5_6_SplitWeight(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER1].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
         self.nodes[ROUTER1].set_weight(1)
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER1].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
         self.nodes[ROUTER2].set_weight(0)
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_5_5_07_SplitMergeThreeWay.py
+++ b/tests/scripts/thread-cert/Cert_5_5_07_SplitMergeThreeWay.py
@@ -49,21 +49,25 @@ class Cert_5_5_7_SplitMergeThreeWay(unittest.TestCase):
         self.nodes[LEADER1].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[LEADER1].add_whitelist(self.nodes[ROUTER3].get_addr64())
         self.nodes[LEADER1].enable_whitelist()
+        self.nodes[LEADER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER1].set_panid(0xface)
         self.nodes[ROUTER1].set_mode('rsdn')
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER1].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER1].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ROUTER3].set_panid(0xface)
         self.nodes[ROUTER3].set_mode('rsdn')
         self.nodes[ROUTER3].add_whitelist(self.nodes[LEADER1].get_addr64())
         self.nodes[ROUTER3].enable_whitelist()
+        self.nodes[ROUTER3].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_5_5_08_SplitRoutersLostLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_5_08_SplitRoutersLostLeader.py
@@ -55,12 +55,14 @@ class Cert_5_5_8_SplitRoutersLostLeader(unittest.TestCase):
         self.nodes[ROUTER3].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[ROUTER3].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER3].enable_whitelist()
+        self.nodes[ROUTER3].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER3].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ROUTER1].set_panid(0xface)
         self.nodes[ROUTER1].set_mode('rsdn')
@@ -68,6 +70,7 @@ class Cert_5_5_8_SplitRoutersLostLeader(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ED1].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ED1].set_panid(0xface)
         self.nodes[ED1].set_mode('rsn')
@@ -85,19 +88,19 @@ class Cert_5_5_8_SplitRoutersLostLeader(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER1].get_state(), 'leader')
 
         self.nodes[ROUTER3].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER3].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         addrs = self.nodes[ED1].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py
@@ -54,6 +54,7 @@ class Cert_5_6_1_NetworkDataLeaderAsBr(unittest.TestCase):
         self.nodes[ROUTER].add_whitelist(self.nodes[ED1].get_addr64())
         self.nodes[ROUTER].add_whitelist(self.nodes[SED1].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[ED1].set_panid(0xface)
         self.nodes[ED1].set_mode('rsn')
@@ -81,27 +82,27 @@ class Cert_5_6_1_NetworkDataLeaderAsBr(unittest.TestCase):
         self.nodes[LEADER].register_netdata()
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[SED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         addrs = self.nodes[ED1].get_addrs()
-        self.assertTrue(any('2001' in word for word in addrs))
-        self.assertTrue(any('2002' in word for word in addrs))
+        self.assertTrue(any('2001' in word[0:4] for word in addrs))
+        self.assertTrue(any('2002' in word[0:4] for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
                 self.assertTrue(self.nodes[LEADER].ping(addr))
 
         addrs = self.nodes[SED1].get_addrs()
-        self.assertTrue(any('2001' in word for word in addrs))
-        self.assertFalse(any('2002' in word for word in addrs))
+        self.assertTrue(any('2001' in word[0:4] for word in addrs))
+        self.assertFalse(any('2002' in word[0:4] for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
                 self.assertTrue(self.nodes[LEADER].ping(addr))

--- a/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
@@ -54,6 +54,7 @@ class Cert_5_6_2_NetworkDataRouterAsBr(unittest.TestCase):
         self.nodes[ROUTER].set_mode('rsdn')
         self.nodes[ROUTER].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[ED1].set_panid(0xface)
         self.nodes[ED1].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py
@@ -54,6 +54,7 @@ class Cert_5_6_3_NetworkDataRegisterAfterAttachLeader(unittest.TestCase):
         self.nodes[ROUTER].add_whitelist(self.nodes[ED1].get_addr64())
         self.nodes[ROUTER].add_whitelist(self.nodes[SED1].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[ED1].set_panid(0xface)
         self.nodes[ED1].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
@@ -54,6 +54,7 @@ class Cert_5_6_4_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
         self.nodes[ROUTER].add_whitelist(self.nodes[ED1].get_addr64())
         self.nodes[ROUTER].add_whitelist(self.nodes[SED1].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[ED1].set_panid(0xface)
         self.nodes[ED1].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
@@ -54,6 +54,7 @@ class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
         self.nodes[ROUTER].add_whitelist(self.nodes[ED1].get_addr64())
         self.nodes[ROUTER].add_whitelist(self.nodes[SED1].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[ED1].set_panid(0xface)
         self.nodes[ED1].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
+++ b/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
@@ -54,6 +54,7 @@ class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
         self.nodes[ROUTER].add_whitelist(self.nodes[ED1].get_addr64())
         self.nodes[ROUTER].add_whitelist(self.nodes[SED1].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[ED1].set_panid(0xface)
         self.nodes[ED1].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_5_6_07_NetworkDataRequestREED.py
+++ b/tests/scripts/thread-cert/Cert_5_6_07_NetworkDataRequestREED.py
@@ -52,6 +52,7 @@ class Cert_5_6_7_NetworkDataRequestREED(unittest.TestCase):
         self.nodes[ROUTER].set_mode('rsdn')
         self.nodes[ROUTER].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[REED].set_panid(0xface)
         self.nodes[REED].set_mode('rsdn')
@@ -93,7 +94,7 @@ class Cert_5_6_7_NetworkDataRequestREED(unittest.TestCase):
         addrs = self.nodes[REED].get_addrs()
         self.assertTrue(any('2003' in word for word in addrs))
         for addr in addrs:
-            if addr[0:3] == '200':
+            if addr[0:4] == '2003':
                 self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_5_6_08_ContextManagement.py
+++ b/tests/scripts/thread-cert/Cert_5_6_08_ContextManagement.py
@@ -53,6 +53,7 @@ class Cert_5_6_8_ContextManagement(unittest.TestCase):
         self.nodes[ROUTER].set_mode('rsdn')
         self.nodes[ROUTER].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[ED].set_panid(0xface)
         self.nodes[ED].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
+++ b/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
@@ -56,11 +56,13 @@ class Cert_5_6_9_NetworkDataForwarding(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[SED].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ED].set_panid(0xface)
         self.nodes[ED].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_5_8_02_KeyIncrement.py
+++ b/tests/scripts/thread-cert/Cert_5_8_02_KeyIncrement.py
@@ -50,6 +50,7 @@ class Cert_5_8_2_KeyIncrement(unittest.TestCase):
         self.nodes[ROUTER].set_mode('rsdn')
         self.nodes[ROUTER].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_5_8_03_KeyIncrementRollOver.py
+++ b/tests/scripts/thread-cert/Cert_5_8_03_KeyIncrementRollOver.py
@@ -51,6 +51,7 @@ class Cert_5_8_3_KeyIncrementRollOver(unittest.TestCase):
         self.nodes[ROUTER].set_mode('rsdn')
         self.nodes[ROUTER].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
@@ -56,12 +56,14 @@ class Cert_6_1_3_RouterAttachConnectivity(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER3].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ROUTER3].set_panid(0xface)
         self.nodes[ROUTER3].set_mode('rsdn')
@@ -69,6 +71,7 @@ class Cert_6_1_3_RouterAttachConnectivity(unittest.TestCase):
         self.nodes[ROUTER3].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER3].add_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ROUTER3].enable_whitelist()
+        self.nodes[ROUTER3].set_router_selection_jitter(1)
 
         self.nodes[ED].set_panid(0xface)
         self.nodes[ED].set_mode('rsdn')
@@ -86,11 +89,13 @@ class Cert_6_1_3_RouterAttachConnectivity(unittest.TestCase):
         self.nodes[LEADER].set_state('leader')
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
-        for i in range(2, 6):
+        for i in range(2, 5):
             self.nodes[i].start()
             time.sleep(3)
             self.assertEqual(self.nodes[i].get_state(), 'router')
 
+        self.nodes[ED].start()
+        time.sleep(3)
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
             self.assertTrue(self.nodes[ROUTER3].ping(addr))

--- a/tests/scripts/thread-cert/Cert_6_1_04_REEDAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_6_1_04_REEDAttachConnectivity.py
@@ -56,6 +56,7 @@ class Cert_6_1_4_REEDAttachConnectivity(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[REED1].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[REED0].set_panid(0xface)
         self.nodes[REED0].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_1_05_RouterAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_6_1_05_RouterAttachLinkQuality.py
@@ -54,12 +54,14 @@ class Cert_6_1_5_RouterAttachLinkQuality(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[ED].get_addr64(), rssi=-85)
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ED].set_panid(0xface)
         self.nodes[ED].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_6_1_06_REEDAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_6_1_06_REEDAttachLinkQuality.py
@@ -61,6 +61,7 @@ class Cert_6_1_6_REEDAttachLinkQuality(unittest.TestCase):
         self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[ED].get_addr64(), rssi=-85)
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ED].set_panid(0xface)
         self.nodes[ED].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_6_1_07_EDSynchronization.py
+++ b/tests/scripts/thread-cert/Cert_6_1_07_EDSynchronization.py
@@ -57,6 +57,7 @@ class Cert_6_1_7_EDSynchronization(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER3].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ED].set_panid(0xface)
         self.nodes[ED].set_mode('rsn')
@@ -72,6 +73,7 @@ class Cert_6_1_7_EDSynchronization(unittest.TestCase):
         self.nodes[ROUTER2].add_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER3].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ROUTER3].set_panid(0xface)
         self.nodes[ROUTER3].set_mode('rsdn')
@@ -79,6 +81,7 @@ class Cert_6_1_7_EDSynchronization(unittest.TestCase):
         self.nodes[ROUTER3].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER3].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[ROUTER3].enable_whitelist()
+        self.nodes[ROUTER3].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):
@@ -91,19 +94,19 @@ class Cert_6_1_7_EDSynchronization(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER3].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER3].get_state(), 'router')
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_6_2_01_NewPartition.py
+++ b/tests/scripts/thread-cert/Cert_6_2_01_NewPartition.py
@@ -52,6 +52,7 @@ class Cert_6_2_1_NewPartition(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ED].set_panid(0xface)
         self.nodes[ED].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_6_2_02_NewPartition.py
+++ b/tests/scripts/thread-cert/Cert_6_2_02_NewPartition.py
@@ -55,6 +55,7 @@ class Cert_6_2_2_NewPartition(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
@@ -62,6 +63,7 @@ class Cert_6_2_2_NewPartition(unittest.TestCase):
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
         self.nodes[ROUTER2].set_network_id_timeout(110)
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
 
         self.nodes[ED].set_panid(0xface)
         self.nodes[ED].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_6_3_01_OrphanReattach.py
+++ b/tests/scripts/thread-cert/Cert_6_3_01_OrphanReattach.py
@@ -52,6 +52,7 @@ class Cert_6_3_1_OrphanReattach(unittest.TestCase):
         self.nodes[ROUTER].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER].add_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[ED].set_panid(0xface)
         self.nodes[ED].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_6_4_02_RealmLocal.py
+++ b/tests/scripts/thread-cert/Cert_6_4_02_RealmLocal.py
@@ -52,6 +52,7 @@ class Cert_5_3_2_RealmLocal(unittest.TestCase):
         self.nodes[ROUTER].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER].add_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[ED].set_panid(0xface)
         self.nodes[ED].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
@@ -54,6 +54,7 @@ class Cert_7_1_1_BorderRouterAsLeader(unittest.TestCase):
         self.nodes[ROUTER].set_mode('rsdn')
         self.nodes[ROUTER].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[SED1].set_panid(0xface)
         self.nodes[SED1].set_mode('s')

--- a/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
@@ -54,6 +54,7 @@ class Cert_7_1_2_BorderRouterAsRouter(unittest.TestCase):
         self.nodes[ROUTER].add_whitelist(self.nodes[ED2].get_addr64())
         self.nodes[ROUTER].add_whitelist(self.nodes[SED2].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[ED2].set_panid(0xface)
         self.nodes[ED2].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
@@ -54,6 +54,7 @@ class Cert_7_1_3_BorderRouterAsLeader(unittest.TestCase):
         self.nodes[ROUTER].set_mode('rsdn')
         self.nodes[ROUTER].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[SED1].set_panid(0xface)
         self.nodes[SED1].set_mode('s')

--- a/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
@@ -54,6 +54,7 @@ class Cert_7_1_4_BorderRouterAsRouter(unittest.TestCase):
         self.nodes[ROUTER].add_whitelist(self.nodes[ED2].get_addr64())
         self.nodes[ROUTER].add_whitelist(self.nodes[SED2].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[ED2].set_panid(0xface)
         self.nodes[ED2].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
@@ -54,6 +54,7 @@ class Cert_7_1_5_BorderRouterAsRouter(unittest.TestCase):
         self.nodes[ROUTER].add_whitelist(self.nodes[ED2].get_addr64())
         self.nodes[ROUTER].add_whitelist(self.nodes[SED2].get_addr64())
         self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
 
         self.nodes[ED2].set_panid(0xface)
         self.nodes[ED2].set_mode('rsn')

--- a/tests/scripts/thread-cert/Cert_8_1_01_Commissioning.py
+++ b/tests/scripts/thread-cert/Cert_8_1_01_Commissioning.py
@@ -47,6 +47,7 @@ class Cert_8_1_01_Commissioning(unittest.TestCase):
 
         self.nodes[JOINER].set_mode('rsdn')
         self.nodes[JOINER].set_masterkey('00112233445566778899aabbccddeeff')
+        self.nodes[JOINER].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_8_1_02_Commissioning.py
+++ b/tests/scripts/thread-cert/Cert_8_1_02_Commissioning.py
@@ -47,6 +47,7 @@ class Cert_8_1_02_Commissioning(unittest.TestCase):
 
         self.nodes[JOINER].set_mode('rsdn')
         self.nodes[JOINER].set_masterkey('00112233445566778899aabbccddeeff')
+        self.nodes[JOINER].set_router_selection_jitter(1)
 
     def tearDown(self):
         for node in list(self.nodes.values()):

--- a/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
+++ b/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
@@ -47,6 +47,7 @@ class Cert_9_2_13_EnergyScan(unittest.TestCase):
         self.nodes[COMMISSIONER].set_mode('rsdn')
         self.nodes[COMMISSIONER].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[COMMISSIONER].enable_whitelist()
+        self.nodes[COMMISSIONER].set_router_selection_jitter(1)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -59,6 +60,7 @@ class Cert_9_2_13_EnergyScan(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ED1].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ED1].set_panid(0xface)
         self.nodes[ED1].set_mode('rs')

--- a/tests/scripts/thread-cert/Cert_9_2_14_PanIdQuery.py
+++ b/tests/scripts/thread-cert/Cert_9_2_14_PanIdQuery.py
@@ -47,6 +47,7 @@ class Cert_9_2_14_PanIdQuery(unittest.TestCase):
         self.nodes[COMMISSIONER].set_mode('rsdn')
         self.nodes[COMMISSIONER].add_whitelist(self.nodes[LEADER1].get_addr64())
         self.nodes[COMMISSIONER].enable_whitelist()
+        self.nodes[COMMISSIONER].set_router_selection_jitter(1)
 
         self.nodes[LEADER1].set_panid(0xface)
         self.nodes[LEADER1].set_mode('rsdn')
@@ -59,6 +60,7 @@ class Cert_9_2_14_PanIdQuery(unittest.TestCase):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER1].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER2].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[LEADER2].set_panid(0xdead)
         self.nodes[LEADER2].set_mode('rsdn')

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -260,6 +260,11 @@ class Node:
         self.send_command(cmd)
         self.pexpect.expect('Done')
 
+    def set_router_downgrade_threshold(self, threshold):
+        cmd = 'routerdowngradethreshold %d' % threshold
+        self.send_command(cmd)
+        self.pexpect.expect('Done')
+
     def release_router_id(self, router_id):
         cmd = 'releaserouterid %d' % router_id
         self.send_command(cmd)
@@ -401,6 +406,11 @@ class Node:
             result = False
 
         return result
+
+    def set_router_selection_jitter(self, jitter):
+        cmd = 'routerselectionjitter %d' % jitter
+        self.send_command(cmd)
+        self.pexpect.expect('Done')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Wait a random jitter period prior to send address solicit when REED detects that current active router number is less than ROUTER_UPGRADE_THRESHOLD, @jwhui , Please have a review. Thanks.