### PR TITLE
spinel-cli: Stability improvements to ping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,5 +63,3 @@ matrix:
     - env: BUILD_TARGET="posix-ncp" VERBOSE=1
       compiler: gcc
       os: linux
-  allow_failures:
-    - env: BUILD_TARGET="posix-ncp" VERBOSE=1

--- a/tests/scripts/Makefile.am
+++ b/tests/scripts/Makefile.am
@@ -232,7 +232,6 @@ TESTS                                                              = \
     $(NULL)
 
 XFAIL_NCP_TESTS                                                        = \
-        thread-cert/Cert_5_1_07_MaxChildCount.py                         \
         thread-cert/Cert_5_3_07_DuplicateAddress.py                      \
         thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py \
         thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py \


### PR DESCRIPTION
This fixes the spurious issues highlighted in #517 by making the ping command completely asynchronous, as implemented in ot-cli.  

This PR does not address creation of ip addresses upon receipt of prefix change indications (the original purpose of #517), nor remove the use of CTRL+C to terminate ncp-sim nodes.