### PR TITLE
Include timestamp TLV

### DIFF
--- a/src/core/thread/meshcop_dataset.cpp
+++ b/src/core/thread/meshcop_dataset.cpp
@@ -109,6 +109,8 @@ void Dataset::Get(otOperationalDataset &aDataset)
             const ActiveTimestampTlv *tlv = static_cast<const ActiveTimestampTlv *>(cur);
             aDataset.mActiveTimestamp = tlv->GetSeconds();
             aDataset.mIsActiveTimestampSet = true;
+
+            GetTimestamp();
             break;
         }
 
@@ -361,13 +363,13 @@ const Timestamp *Dataset::GetTimestamp(void) const
     {
         const ActiveTimestampTlv *tlv = static_cast<const ActiveTimestampTlv *>(Get(mType));
         VerifyOrExit(tlv != NULL, ;);
-        timestamp = reinterpret_cast<const Timestamp *>(tlv->GetValue());
+        timestamp = static_cast<const Timestamp *>(tlv);
     }
     else
     {
         const PendingTimestampTlv *tlv = static_cast<const PendingTimestampTlv *>(Get(mType));
         VerifyOrExit(tlv != NULL, ;);
-        timestamp = reinterpret_cast<const Timestamp *>(tlv->GetValue());
+        timestamp = static_cast<const Timestamp *>(tlv);
     }
 
 exit:

--- a/src/core/thread/meshcop_dataset.cpp
+++ b/src/core/thread/meshcop_dataset.cpp
@@ -359,13 +359,13 @@ const Timestamp *Dataset::GetTimestamp(void) const
 
     if (mType == Tlv::kActiveTimestamp)
     {
-        const ActiveTimestampTlv *tlv = reinterpret_cast<const ActiveTimestampTlv *>(Get(mType));
+        const ActiveTimestampTlv *tlv = static_cast<const ActiveTimestampTlv *>(Get(mType));
         VerifyOrExit(tlv != NULL, ;);
         timestamp = reinterpret_cast<const Timestamp *>(tlv->GetValue());
     }
     else
     {
-        const PendingTimestampTlv *tlv = reinterpret_cast<const PendingTimestampTlv *>(Get(mType));
+        const PendingTimestampTlv *tlv = static_cast<const PendingTimestampTlv *>(Get(mType));
         VerifyOrExit(tlv != NULL, ;);
         timestamp = reinterpret_cast<const Timestamp *>(tlv->GetValue());
     }

--- a/src/core/thread/meshcop_dataset.cpp
+++ b/src/core/thread/meshcop_dataset.cpp
@@ -228,7 +228,7 @@ void Dataset::Get(otOperationalDataset &aDataset)
     }
 }
 
-ThreadError Dataset::Set(const otOperationalDataset &aDataset, bool aActive)
+ThreadError Dataset::Set(const otOperationalDataset &aDataset)
 {
     ThreadError error = kThreadError_None;
     MeshCoP::ActiveTimestampTlv activeTimestampTlv;
@@ -240,17 +240,11 @@ ThreadError Dataset::Set(const otOperationalDataset &aDataset, bool aActive)
     activeTimestampTlv.SetTicks(0);
     Set(activeTimestampTlv);
 
-    if (aActive)
-    {
-        mType = Tlv::kActiveTimestamp;
-    }
-    else
+    if (mType == Tlv::kPendingTimestamp)
     {
         MeshCoP::PendingTimestampTlv pendingTimestampTlv;
 
         VerifyOrExit(aDataset.mIsPendingTimestampSet, error = kThreadError_InvalidArgs);
-
-        mType = Tlv::kPendingTimestamp;
 
         pendingTimestampTlv.Init();
         pendingTimestampTlv.SetSeconds(aDataset.mPendingTimestamp);

--- a/src/core/thread/meshcop_dataset.hpp
+++ b/src/core/thread/meshcop_dataset.hpp
@@ -128,7 +128,7 @@ public:
 
     ThreadError Set(const Message &aMessage, uint16_t aOffset, uint8_t aLength);
 
-    ThreadError Set(const otOperationalDataset &aDataset, bool aActive);
+    ThreadError Set(const otOperationalDataset &aDataset);
 
     void Remove(Tlv::Type aType);
 

--- a/src/core/thread/meshcop_dataset.hpp
+++ b/src/core/thread/meshcop_dataset.hpp
@@ -55,7 +55,7 @@ public:
      * @param[in]  aType      The type of the dataset, active or pending.
      *
      */
-    Dataset(const uint8_t aType);
+    Dataset(const Tlv::Type aType);
 
     /**
      * This method clears the Dataset.
@@ -135,9 +135,9 @@ public:
 private:
     void Remove(uint8_t *aStart, uint8_t aLength);
 
-    uint8_t   mType;            ///< Active or Pending
-    uint8_t   mTlvs[kMaxSize];  ///< The Dataset buffer
-    uint8_t   mLength;          ///< The number of valid bytes in @var mTlvs
+    Tlv::Type  mType;            ///< Active or Pending
+    uint8_t    mTlvs[kMaxSize];  ///< The Dataset buffer
+    uint8_t    mLength;          ///< The number of valid bytes in @var mTlvs
 };
 
 }  // namespace MeshCoP

--- a/src/core/thread/meshcop_dataset.hpp
+++ b/src/core/thread/meshcop_dataset.hpp
@@ -52,8 +52,10 @@ public:
     /**
      * This constructor initializes the object.
      *
+     * @param[in]  aType      The type of the dataset, active or pending.
+     *
      */
-    Dataset(void);
+    Dataset(const uint8_t aType);
 
     /**
      * This method clears the Dataset.
@@ -102,10 +104,10 @@ public:
     /**
      * This method returns a reference to the Timestamp.
      *
-     * @returns A reference to the Timestamp.
+     * @returns A pointer to the Timestamp.
      *
      */
-    const Timestamp &GetTimestamp(void) const;
+    const Timestamp *GetTimestamp(void) const;
 
     /**
      * This method sets the Timestamp value.
@@ -133,7 +135,7 @@ public:
 private:
     void Remove(uint8_t *aStart, uint8_t aLength);
 
-    Timestamp mTimestamp;       ///< Active or Pending Timestamp
+    uint8_t   mType;            ///< Active or Pending
     uint8_t   mTlvs[kMaxSize];  ///< The Dataset buffer
     uint8_t   mLength;          ///< The number of valid bytes in @var mTlvs
 };

--- a/src/core/thread/meshcop_dataset_manager.cpp
+++ b/src/core/thread/meshcop_dataset_manager.cpp
@@ -598,7 +598,7 @@ ThreadError ActiveDataset::Set(const otOperationalDataset &aDataset)
     ThreadError error = kThreadError_None;
     Dataset dataset(Tlv::kActiveTimestamp);
 
-    SuccessOrExit(error = dataset.Set(aDataset, true));
+    SuccessOrExit(error = dataset.Set(aDataset));
     SuccessOrExit(error = Set(dataset));
 
 exit:
@@ -717,7 +717,7 @@ ThreadError PendingDataset::Set(const otOperationalDataset &aDataset)
     ThreadError error = kThreadError_None;
     Dataset dataset(Tlv::kPendingTimestamp);
 
-    SuccessOrExit(error = dataset.Set(aDataset, false));
+    SuccessOrExit(error = dataset.Set(aDataset));
     SuccessOrExit(error = Set(dataset));
 
 exit:

--- a/src/core/thread/meshcop_dataset_manager.cpp
+++ b/src/core/thread/meshcop_dataset_manager.cpp
@@ -49,7 +49,7 @@
 namespace Thread {
 namespace MeshCoP {
 
-DatasetManager::DatasetManager(ThreadNetif &aThreadNetif, const uint8_t aType, const char *aUriSet,
+DatasetManager::DatasetManager(ThreadNetif &aThreadNetif, const Tlv::Type aType, const char *aUriSet,
                                const char *aUriGet):
     mLocal(aType),
     mNetwork(aType),

--- a/src/core/thread/meshcop_dataset_manager.hpp
+++ b/src/core/thread/meshcop_dataset_manager.hpp
@@ -69,7 +69,7 @@ protected:
         kFlagNetworkUpdated = 1 << 1,
     };
 
-    DatasetManager(ThreadNetif &aThreadNetif, const char *aUriSet, const char *aUriGet);
+    DatasetManager(ThreadNetif &aThreadNetif, const uint8_t aType, const char *aUriSet, const char *aUriGet);
 
     ThreadError Set(const Dataset &aDataset, uint8_t &aFlags);
 

--- a/src/core/thread/meshcop_dataset_manager.hpp
+++ b/src/core/thread/meshcop_dataset_manager.hpp
@@ -69,7 +69,7 @@ protected:
         kFlagNetworkUpdated = 1 << 1,
     };
 
-    DatasetManager(ThreadNetif &aThreadNetif, const uint8_t aType, const char *aUriSet, const char *aUriGet);
+    DatasetManager(ThreadNetif &aThreadNetif, const Tlv::Type aType, const char *aUriSet, const char *aUriGet);
 
     ThreadError Set(const Dataset &aDataset, uint8_t &aFlags);
 

--- a/src/core/thread/meshcop_tlvs.hpp
+++ b/src/core/thread/meshcop_tlvs.hpp
@@ -135,6 +135,14 @@ public:
     uint8_t *GetValue() { return reinterpret_cast<uint8_t *>(this) + sizeof(Tlv); }
 
     /**
+     * This method returns a pointer to the Value.
+     *
+     * @returns A pointer to the value.
+     *
+     */
+    const uint8_t *GetValue() const { return reinterpret_cast<const uint8_t *>(this) + sizeof(Tlv); }
+
+    /**
      * This method returns a pointer to the next TLV.
      *
      * @returns A pointer to the next TLV.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -896,12 +896,12 @@ ThreadError Mle::AppendActiveTimestamp(Message &aMessage)
 {
     ThreadError error;
     ActiveTimestampTlv timestampTlv;
-    const MeshCoP::Timestamp &timestamp(mNetif.GetActiveDataset().GetNetwork().GetTimestamp());
+    const MeshCoP::Timestamp *timestamp(mNetif.GetActiveDataset().GetNetwork().GetTimestamp());
 
-    VerifyOrExit(timestamp.GetSeconds() != 0, error = kThreadError_None);
+    VerifyOrExit(timestamp && timestamp->GetSeconds() != 0, error = kThreadError_None);
 
     timestampTlv.Init();
-    *static_cast<MeshCoP::Timestamp *>(&timestampTlv) = timestamp;
+    *static_cast<MeshCoP::Timestamp *>(&timestampTlv) = *timestamp;
     error = aMessage.Append(&timestampTlv, sizeof(timestampTlv));
 
 exit:
@@ -912,12 +912,12 @@ ThreadError Mle::AppendPendingTimestamp(Message &aMessage)
 {
     ThreadError error;
     PendingTimestampTlv timestampTlv;
-    const MeshCoP::Timestamp &timestamp(mNetif.GetPendingDataset().GetNetwork().GetTimestamp());
+    const MeshCoP::Timestamp *timestamp(mNetif.GetPendingDataset().GetNetwork().GetTimestamp());
 
-    VerifyOrExit(timestamp.GetSeconds() != 0, error = kThreadError_None);
+    VerifyOrExit(timestamp && timestamp->GetSeconds() != 0, error = kThreadError_None);
 
     timestampTlv.Init();
-    *static_cast<MeshCoP::Timestamp *>(&timestampTlv) = timestamp;
+    *static_cast<MeshCoP::Timestamp *>(&timestampTlv) = *timestamp;
     error = aMessage.Append(&timestampTlv, sizeof(timestampTlv));
 
 exit:

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1904,13 +1904,15 @@ ThreadError MleRouter::HandleChildIdRequest(const Message &aMessage, const Ip6::
     numTlvs = tlvRequest.GetLength();
 
     if (activeTimestamp.GetLength() == 0 ||
-        mNetif.GetActiveDataset().GetNetwork().GetTimestamp().Compare(activeTimestamp) != 0)
+        mNetif.GetActiveDataset().GetNetwork().GetTimestamp() == NULL ||
+        mNetif.GetActiveDataset().GetNetwork().GetTimestamp()->Compare(activeTimestamp) != 0)
     {
         child->mRequestTlvs[numTlvs++] = Tlv::kActiveDataset;
     }
 
     if (pendingTimestamp.GetLength() == 0 ||
-        mNetif.GetPendingDataset().GetNetwork().GetTimestamp().Compare(pendingTimestamp) != 0)
+        mNetif.GetPendingDataset().GetNetwork().GetTimestamp() == NULL ||
+        mNetif.GetPendingDataset().GetNetwork().GetTimestamp()->Compare(pendingTimestamp) != 0)
     {
         child->mRequestTlvs[numTlvs++] = Tlv::kPendingDataset;
     }
@@ -2054,13 +2056,15 @@ ThreadError MleRouter::HandleDataRequest(const Message &aMessage, const Ip6::Mes
     numTlvs = tlvRequest.GetLength();
 
     if (activeTimestamp.GetLength() == 0 ||
-        mNetif.GetActiveDataset().GetNetwork().GetTimestamp().Compare(activeTimestamp) != 0)
+        mNetif.GetActiveDataset().GetNetwork().GetTimestamp() == NULL ||
+        mNetif.GetActiveDataset().GetNetwork().GetTimestamp()->Compare(activeTimestamp) != 0)
     {
         tlvs[numTlvs++] = Tlv::kActiveDataset;
     }
 
     if (pendingTimestamp.GetLength() == 0 ||
-        mNetif.GetPendingDataset().GetNetwork().GetTimestamp().Compare(pendingTimestamp) != 0)
+        mNetif.GetPendingDataset().GetNetwork().GetTimestamp() == NULL ||
+        mNetif.GetPendingDataset().GetNetwork().GetTimestamp()->Compare(pendingTimestamp) != 0)
     {
         tlvs[numTlvs++] = Tlv::kPendingDataset;
     }


### PR DESCRIPTION
@jwhui , this is a work-in-progress PR. 
After merging this PR, it helps us to pass 9.3.2, but I don't think this is the final one.

I have some questions for the managing timestamp.

Now we have a mTimestamp in dataset that is used to store active/pending timestamp.
But there are 2 problems with current implementation.
- Not timestamp TLV in response, if configuring via CLI. I would suppose that dataset of Leader would be set by the user via CLI or any other configuration method.
- There are 2 copies of timestamp (mTlvs and mTimestamp), and they may be different, if receiving MGMT_ACTIVE_SET/MGMT_PENDING_SET from other nodes.

I would prefer that we keep one copy of timestamp in mTlvs, and remove mTimestamp, and make other corresponding changes.
But the problem here is that we need to explicitly to tell whether  it is active or pending while doing DatasetManager.mLocal/mNetwork.SetTimestamp.
I am not quite sure about your thoughts on mTimestamp while in your initial implementation.
Could you let me know your comments for this?