### PR TITLE
Support OPENTHREAD_CONFIG_FILE define

### DIFF
--- a/examples/apps/cli/main.c
+++ b/examples/apps/cli/main.c
@@ -26,9 +26,14 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <openthread-core-config.h>
 #include <openthread.h>
-#include <openthread-config.h>
 #include <openthread-diag.h>
 #include <cli/cli-uart.h>
 #include <platform/platform.h>

--- a/examples/apps/ncp/main.c
+++ b/examples/apps/ncp/main.c
@@ -26,9 +26,14 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <openthread-core-config.h>
 #include <openthread.h>
-#include <openthread-config.h>
 #include <openthread-diag.h>
 #include <common/debug.hpp>
 #include <ncp/ncp.h>

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -31,12 +31,17 @@
  *   This file implements the CLI interpreter.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <openthread.h>
-#include <openthread-config.h>
 #include <openthread-diag.h>
 #include <commissioning/commissioner.h>
 #include <commissioning/joiner.h>

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -34,9 +34,13 @@
 #ifndef CLI_HPP_
 #define CLI_HPP_
 
-#include <stdarg.h>
-
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
 #include <openthread-config.h>
+#endif
+
+#include <stdarg.h>
 
 #include <cli/cli_server.hpp>
 #include <net/icmp6.hpp>

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -31,12 +31,17 @@
  *   This file implements the CLI interpreter.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <openthread.h>
-#include <openthread-config.h>
 
 #include "cli.hpp"
 #include "cli_dataset.hpp"

--- a/src/core/crypto/mbedtls.hpp
+++ b/src/core/crypto/mbedtls.hpp
@@ -34,7 +34,12 @@
 #ifndef OT_MBEDTLS_HPP_
 #define OT_MBEDTLS_HPP_
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
 #include <openthread-config.h>
+#endif
+
 #include <mbedtls/memory_buffer_alloc.h>
 
 namespace Thread {

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -31,9 +31,13 @@
  *   This file implements the subset of IEEE 802.15.4 primitives required for Thread.
  */
 
-#include <string.h>
-
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
 #include <openthread-config.h>
+#endif
+
+#include <string.h>
 
 #include <common/code_utils.hpp>
 #include <common/debug.hpp>

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -31,9 +31,13 @@
  *   This file implements a Commissioner role.
  */
 
-#include <stdio.h>
-
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
 #include <openthread-config.h>
+#endif
+
+#include <stdio.h>
 
 #include <coap/coap_header.hpp>
 #include <common/logging.hpp>

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -31,10 +31,14 @@
  *   This file implements the Joiner role.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <assert.h>
 #include <stdio.h>
-
-#include <openthread-config.h>
 
 #include <common/code_utils.hpp>
 #include <common/encoding.hpp>

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -31,8 +31,13 @@
  *   This file implements the top-level interface to the OpenThread stack.
  */
 
-#include <openthread.h>
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
 #include <openthread-config.h>
+#endif
+
+#include <openthread.h>
 #include <common/code_utils.hpp>
 #include <common/debug.hpp>
 #include <common/logging.hpp>

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -34,7 +34,12 @@
 #ifndef THREAD_NETIF_HPP_
 #define THREAD_NETIF_HPP_
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
 #include <openthread-config.h>
+#endif
+
 #include <openthread-types.h>
 
 #include <mac/mac.hpp>

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -33,8 +33,13 @@
 #ifndef NCP_BASE_HPP_
 #define NCP_BASE_HPP_
 
-#include <openthread-types.h>
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
 #include <openthread-config.h>
+#endif
+
+#include <openthread-types.h>
 #include <common/message.hpp>
 #include <common/tasklet.hpp>
 


### PR DESCRIPTION
Support #define to overwrite what openthread-config file to use, since Windows does support autoconf. This is required to get openthread building on Windows.