### PR TITLE
Spinel Protocol Documentation Updates

### DIFF
--- a/doc/draft-spinel-protocol.html
+++ b/doc/draft-spinel-protocol.html
@@ -375,84 +375,92 @@
 
   <link href="#rfc.toc" rel="Contents"/>
 <link href="#rfc.section.1" rel="Chapter" title="1 Introduction"/>
-<link href="#rfc.section.2" rel="Chapter" title="2 Definitions"/>
-<link href="#rfc.section.3" rel="Chapter" title="3 Frame Format"/>
-<link href="#rfc.section.3.1" rel="Chapter" title="3.1 Header Format"/>
-<link href="#rfc.section.3.1.1" rel="Chapter" title="3.1.1 FLG: Flag"/>
-<link href="#rfc.section.3.1.2" rel="Chapter" title="3.1.2 IID: Interface Identifier"/>
-<link href="#rfc.section.3.1.3" rel="Chapter" title="3.1.3 TID: Transaction Identifier"/>
-<link href="#rfc.section.3.1.4" rel="Chapter" title="3.1.4 Command Identifier (CMD)"/>
-<link href="#rfc.section.3.1.5" rel="Chapter" title="3.1.5 Command Payload (Optional)"/>
-<link href="#rfc.section.4" rel="Chapter" title="4 Data Packing"/>
-<link href="#rfc.section.4.1" rel="Chapter" title="4.1 Primitive Types"/>
-<link href="#rfc.section.4.2" rel="Chapter" title="4.2 Packed Unsigned Integer"/>
-<link href="#rfc.section.4.3" rel="Chapter" title="4.3 Data Blobs"/>
-<link href="#rfc.section.4.4" rel="Chapter" title="4.4 Structured Data"/>
-<link href="#rfc.section.4.5" rel="Chapter" title="4.5 Arrays"/>
-<link href="#rfc.section.5" rel="Chapter" title="5 Commands"/>
-<link href="#rfc.section.5.1" rel="Chapter" title="5.1 CMD 0: (Host-&gt;NCP) CMD_NOOP"/>
-<link href="#rfc.section.5.2" rel="Chapter" title="5.2 CMD 1: (Host-&gt;NCP) CMD_RESET"/>
-<link href="#rfc.section.5.3" rel="Chapter" title="5.3 CMD 2: (Host-&gt;NCP) CMD_PROP_VALUE_GET"/>
-<link href="#rfc.section.5.4" rel="Chapter" title="5.4 CMD 3: (Host-&gt;NCP) CMD_PROP_VALUE_SET"/>
-<link href="#rfc.section.5.5" rel="Chapter" title="5.5 CMD 4: (Host-&gt;NCP) CMD_PROP_VALUE_INSERT"/>
-<link href="#rfc.section.5.6" rel="Chapter" title="5.6 CMD 5: (Host-&gt;NCP) CMD_PROP_VALUE_REMOVE"/>
-<link href="#rfc.section.5.7" rel="Chapter" title="5.7 CMD 6: (NCP-&gt;Host) CMD_PROP_VALUE_IS"/>
-<link href="#rfc.section.5.8" rel="Chapter" title="5.8 CMD 7: (NCP-&gt;Host) CMD_PROP_VALUE_INSERTED"/>
-<link href="#rfc.section.5.9" rel="Chapter" title="5.9 CMD 8: (NCP-&gt;Host) CMD_PROP_VALUE_REMOVED"/>
-<link href="#rfc.section.6" rel="Chapter" title="6 Properties"/>
-<link href="#rfc.section.6.1" rel="Chapter" title="6.1 Property Sections"/>
-<link href="#rfc.section.6.2" rel="Chapter" title="6.2 Core Properties"/>
-<link href="#rfc.section.6.2.1" rel="Chapter" title="6.2.1 PROP 0: PROP_LAST_STATUS"/>
-<link href="#rfc.section.6.2.2" rel="Chapter" title="6.2.2 PROP 1: PROP_PROTOCOL_VERSION"/>
-<link href="#rfc.section.6.2.3" rel="Chapter" title="6.2.3 PROP 2: PROP_NCP_VERSION"/>
-<link href="#rfc.section.6.2.4" rel="Chapter" title="6.2.4 PROP 3: PROP_INTERFACE_TYPE"/>
-<link href="#rfc.section.6.2.5" rel="Chapter" title="6.2.5 PROP 4: PROP_INTERFACE_VENDOR_ID"/>
-<link href="#rfc.section.6.2.6" rel="Chapter" title="6.2.6 PROP 5: PROP_CAPS"/>
-<link href="#rfc.section.6.2.7" rel="Chapter" title="6.2.7 PROP 6: PROP_INTERFACE_COUNT"/>
-<link href="#rfc.section.6.2.8" rel="Chapter" title="6.2.8 PROP 7: PROP_POWER_STATE"/>
-<link href="#rfc.section.6.2.9" rel="Chapter" title="6.2.9 PROP 8: PROP_HWADDR"/>
-<link href="#rfc.section.6.2.10" rel="Chapter" title="6.2.10 PROP 9: PROP_LOCK"/>
-<link href="#rfc.section.6.2.11" rel="Chapter" title="6.2.11 PROP 112: PROP_STREAM_DEBUG"/>
-<link href="#rfc.section.6.2.12" rel="Chapter" title="6.2.12 PROP 113: PROP_STREAM_RAW"/>
-<link href="#rfc.section.6.2.13" rel="Chapter" title="6.2.13 PROP 114: PROP_STREAM_NET"/>
-<link href="#rfc.section.6.2.14" rel="Chapter" title="6.2.14 PROP 114: PROP_STREAM_NET_INSECURE"/>
-<link href="#rfc.section.6.3" rel="Chapter" title="6.3 PHY Properties"/>
-<link href="#rfc.section.6.3.1" rel="Chapter" title="6.3.1 PROP 32: PROP_PHY_ENABLED"/>
-<link href="#rfc.section.6.3.2" rel="Chapter" title="6.3.2 PROP 33: PROP_PHY_CHAN"/>
-<link href="#rfc.section.6.3.3" rel="Chapter" title="6.3.3 PROP 34: PROP_PHY_CHAN_SUPPORTED"/>
-<link href="#rfc.section.6.3.4" rel="Chapter" title="6.3.4 PROP 35: PROP_PHY_FREQ"/>
-<link href="#rfc.section.6.3.5" rel="Chapter" title="6.3.5 PROP 36: PROP_PHY_CCA_THRESHOLD"/>
-<link href="#rfc.section.6.3.6" rel="Chapter" title="6.3.6 PROP 37: PROP_PHY_TX_POWER"/>
-<link href="#rfc.section.6.3.7" rel="Chapter" title="6.3.7 PROP 38: PROP_PHY_RSSI"/>
-<link href="#rfc.section.6.4" rel="Chapter" title="6.4 MAC Properties"/>
-<link href="#rfc.section.6.4.1" rel="Chapter" title="6.4.1 PROP 48: PROP_MAC_SCAN_STATE"/>
-<link href="#rfc.section.6.4.2" rel="Chapter" title="6.4.2 PROP 49: PROP_MAC_SCAN_MASK"/>
-<link href="#rfc.section.6.4.3" rel="Chapter" title="6.4.3 PROP 50: PROP_MAC_SCAN_PERIOD"/>
-<link href="#rfc.section.6.4.4" rel="Chapter" title="6.4.4 PROP 51: PROP_MAC_SCAN_BEACON"/>
-<link href="#rfc.section.6.4.5" rel="Chapter" title="6.4.5 PROP 52: PROP_MAC_15_4_LADDR"/>
-<link href="#rfc.section.6.4.6" rel="Chapter" title="6.4.6 PROP 53: PROP_MAC_15_4_SADDR"/>
-<link href="#rfc.section.6.4.7" rel="Chapter" title="6.4.7 PROP 54: PROP_MAC_15_4_PANID"/>
-<link href="#rfc.section.6.4.8" rel="Chapter" title="6.4.8 PROP 55: PROP_MAC_RAW_STREAM_ENABLED"/>
-<link href="#rfc.section.6.4.9" rel="Chapter" title="6.4.9 PROP 56: PROP_MAC_FILTER_MODE"/>
-<link href="#rfc.section.6.4.10" rel="Chapter" title="6.4.10 PROP 4864: PROP_MAC_WHITELIST"/>
-<link href="#rfc.section.6.4.11" rel="Chapter" title="6.4.11 PROP 4865: PROP_MAC_WHITELIST_ENABLED"/>
-<link href="#rfc.section.6.5" rel="Chapter" title="6.5 NET Properties"/>
-<link href="#rfc.section.6.5.1" rel="Chapter" title="6.5.1 PROP 64: PROP_NET_SAVED"/>
-<link href="#rfc.section.6.5.2" rel="Chapter" title="6.5.2 PROP 65: PROP_NET_IF_UP"/>
-<link href="#rfc.section.6.5.3" rel="Chapter" title="6.5.3 PROP 66: PROP_NET_STACK_UP"/>
-<link href="#rfc.section.6.5.4" rel="Chapter" title="6.5.4 PROP 67: PROP_NET_ROLE"/>
-<link href="#rfc.section.6.5.5" rel="Chapter" title="6.5.5 PROP 68: PROP_NET_NETWORK_NAME"/>
-<link href="#rfc.section.6.5.6" rel="Chapter" title="6.5.6 PROP 69: PROP_NET_XPANID"/>
-<link href="#rfc.section.6.5.7" rel="Chapter" title="6.5.7 PROP 70: PROP_NET_MASTER_KEY"/>
-<link href="#rfc.section.6.5.8" rel="Chapter" title="6.5.8 PROP 71: PROP_NET_KEY_SEQUENCE"/>
-<link href="#rfc.section.6.5.9" rel="Chapter" title="6.5.9 PROP 72: PROP_NET_PARTITION_ID"/>
-<link href="#rfc.section.6.6" rel="Chapter" title="6.6 IPv6 Properties"/>
-<link href="#rfc.section.6.6.1" rel="Chapter" title="6.6.1 PROP 96: PROP_IPV6_LL_ADDR"/>
-<link href="#rfc.section.6.6.2" rel="Chapter" title="6.6.2 PROP 97: PROP_IPV6_ML_ADDR"/>
-<link href="#rfc.section.6.6.3" rel="Chapter" title="6.6.3 PROP 98: PROP_IPV6_ML_PREFIX"/>
-<link href="#rfc.section.6.6.4" rel="Chapter" title="6.6.4 PROP 99: PROP_IPV6_ADDRESS_TABLE"/>
-<link href="#rfc.section.6.6.5" rel="Chapter" title="6.6.5 PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD"/>
-<link href="#rfc.section.7" rel="Chapter" title="7 Status Codes"/>
+<link href="#rfc.section.1.1" rel="Chapter" title="1.1 About this Draft"/>
+<link href="#rfc.section.1.1.1" rel="Chapter" title="1.1.1 Renumbering"/>
+<link href="#rfc.section.1.1.2" rel="Chapter" title="1.1.2 Spinel as Application API"/>
+<link href="#rfc.section.1.1.3" rel="Chapter" title="1.1.3 Privileged Commands and Properties"/>
+<link href="#rfc.section.1.2" rel="Chapter" title="1.2 Property Overview"/>
+<link href="#rfc.section.1.2.1" rel="Chapter" title="1.2.1 Property Methods"/>
+<link href="#rfc.section.1.2.2" rel="Chapter" title="1.2.2 Property Types"/>
+<link href="#rfc.section.2" rel="Chapter" title="2 Frame Format"/>
+<link href="#rfc.section.2.1" rel="Chapter" title="2.1 Header Format"/>
+<link href="#rfc.section.2.1.1" rel="Chapter" title="2.1.1 FLG: Flag"/>
+<link href="#rfc.section.2.1.2" rel="Chapter" title="2.1.2 IID: Interface Identifier"/>
+<link href="#rfc.section.2.1.3" rel="Chapter" title="2.1.3 TID: Transaction Identifier"/>
+<link href="#rfc.section.2.1.4" rel="Chapter" title="2.1.4 Command Identifier (CMD)"/>
+<link href="#rfc.section.2.1.5" rel="Chapter" title="2.1.5 Command Payload (Optional)"/>
+<link href="#rfc.section.3" rel="Chapter" title="3 Data Packing"/>
+<link href="#rfc.section.3.1" rel="Chapter" title="3.1 Primitive Types"/>
+<link href="#rfc.section.3.2" rel="Chapter" title="3.2 Packed Unsigned Integer"/>
+<link href="#rfc.section.3.3" rel="Chapter" title="3.3 Data Blobs"/>
+<link href="#rfc.section.3.4" rel="Chapter" title="3.4 Structured Data"/>
+<link href="#rfc.section.3.5" rel="Chapter" title="3.5 Arrays"/>
+<link href="#rfc.section.4" rel="Chapter" title="4 Commands"/>
+<link href="#rfc.section.4.1" rel="Chapter" title="4.1 CMD 0: (Host-&gt;NCP) CMD_NOOP"/>
+<link href="#rfc.section.4.2" rel="Chapter" title="4.2 CMD 1: (Host-&gt;NCP) CMD_RESET"/>
+<link href="#rfc.section.4.3" rel="Chapter" title="4.3 CMD 2: (Host-&gt;NCP) CMD_PROP_VALUE_GET"/>
+<link href="#rfc.section.4.4" rel="Chapter" title="4.4 CMD 3: (Host-&gt;NCP) CMD_PROP_VALUE_SET"/>
+<link href="#rfc.section.4.5" rel="Chapter" title="4.5 CMD 4: (Host-&gt;NCP) CMD_PROP_VALUE_INSERT"/>
+<link href="#rfc.section.4.6" rel="Chapter" title="4.6 CMD 5: (Host-&gt;NCP) CMD_PROP_VALUE_REMOVE"/>
+<link href="#rfc.section.4.7" rel="Chapter" title="4.7 CMD 6: (NCP-&gt;Host) CMD_PROP_VALUE_IS"/>
+<link href="#rfc.section.4.8" rel="Chapter" title="4.8 CMD 7: (NCP-&gt;Host) CMD_PROP_VALUE_INSERTED"/>
+<link href="#rfc.section.4.9" rel="Chapter" title="4.9 CMD 8: (NCP-&gt;Host) CMD_PROP_VALUE_REMOVED"/>
+<link href="#rfc.section.5" rel="Chapter" title="5 Properties"/>
+<link href="#rfc.section.5.1" rel="Chapter" title="5.1 Property Sections"/>
+<link href="#rfc.section.5.2" rel="Chapter" title="5.2 Core Properties"/>
+<link href="#rfc.section.5.2.1" rel="Chapter" title="5.2.1 PROP 0: PROP_LAST_STATUS"/>
+<link href="#rfc.section.5.2.2" rel="Chapter" title="5.2.2 PROP 1: PROP_PROTOCOL_VERSION"/>
+<link href="#rfc.section.5.2.3" rel="Chapter" title="5.2.3 PROP 2: PROP_NCP_VERSION"/>
+<link href="#rfc.section.5.2.4" rel="Chapter" title="5.2.4 PROP 3: PROP_INTERFACE_TYPE"/>
+<link href="#rfc.section.5.2.5" rel="Chapter" title="5.2.5 PROP 4: PROP_INTERFACE_VENDOR_ID"/>
+<link href="#rfc.section.5.2.6" rel="Chapter" title="5.2.6 PROP 5: PROP_CAPS"/>
+<link href="#rfc.section.5.2.7" rel="Chapter" title="5.2.7 PROP 6: PROP_INTERFACE_COUNT"/>
+<link href="#rfc.section.5.2.8" rel="Chapter" title="5.2.8 PROP 7: PROP_POWER_STATE"/>
+<link href="#rfc.section.5.2.9" rel="Chapter" title="5.2.9 PROP 8: PROP_HWADDR"/>
+<link href="#rfc.section.5.2.10" rel="Chapter" title="5.2.10 PROP 9: PROP_LOCK"/>
+<link href="#rfc.section.5.2.11" rel="Chapter" title="5.2.11 PROP 112: PROP_STREAM_DEBUG"/>
+<link href="#rfc.section.5.2.12" rel="Chapter" title="5.2.12 PROP 113: PROP_STREAM_RAW"/>
+<link href="#rfc.section.5.2.13" rel="Chapter" title="5.2.13 PROP 114: PROP_STREAM_NET"/>
+<link href="#rfc.section.5.2.14" rel="Chapter" title="5.2.14 PROP 114: PROP_STREAM_NET_INSECURE"/>
+<link href="#rfc.section.5.3" rel="Chapter" title="5.3 PHY Properties"/>
+<link href="#rfc.section.5.3.1" rel="Chapter" title="5.3.1 PROP 32: PROP_PHY_ENABLED"/>
+<link href="#rfc.section.5.3.2" rel="Chapter" title="5.3.2 PROP 33: PROP_PHY_CHAN"/>
+<link href="#rfc.section.5.3.3" rel="Chapter" title="5.3.3 PROP 34: PROP_PHY_CHAN_SUPPORTED"/>
+<link href="#rfc.section.5.3.4" rel="Chapter" title="5.3.4 PROP 35: PROP_PHY_FREQ"/>
+<link href="#rfc.section.5.3.5" rel="Chapter" title="5.3.5 PROP 36: PROP_PHY_CCA_THRESHOLD"/>
+<link href="#rfc.section.5.3.6" rel="Chapter" title="5.3.6 PROP 37: PROP_PHY_TX_POWER"/>
+<link href="#rfc.section.5.3.7" rel="Chapter" title="5.3.7 PROP 38: PROP_PHY_RSSI"/>
+<link href="#rfc.section.5.4" rel="Chapter" title="5.4 MAC Properties"/>
+<link href="#rfc.section.5.4.1" rel="Chapter" title="5.4.1 PROP 48: PROP_MAC_SCAN_STATE"/>
+<link href="#rfc.section.5.4.2" rel="Chapter" title="5.4.2 PROP 49: PROP_MAC_SCAN_MASK"/>
+<link href="#rfc.section.5.4.3" rel="Chapter" title="5.4.3 PROP 50: PROP_MAC_SCAN_PERIOD"/>
+<link href="#rfc.section.5.4.4" rel="Chapter" title="5.4.4 PROP 51: PROP_MAC_SCAN_BEACON"/>
+<link href="#rfc.section.5.4.5" rel="Chapter" title="5.4.5 PROP 52: PROP_MAC_15_4_LADDR"/>
+<link href="#rfc.section.5.4.6" rel="Chapter" title="5.4.6 PROP 53: PROP_MAC_15_4_SADDR"/>
+<link href="#rfc.section.5.4.7" rel="Chapter" title="5.4.7 PROP 54: PROP_MAC_15_4_PANID"/>
+<link href="#rfc.section.5.4.8" rel="Chapter" title="5.4.8 PROP 55: PROP_MAC_RAW_STREAM_ENABLED"/>
+<link href="#rfc.section.5.4.9" rel="Chapter" title="5.4.9 PROP 56: PROP_MAC_FILTER_MODE"/>
+<link href="#rfc.section.5.4.10" rel="Chapter" title="5.4.10 PROP 4864: PROP_MAC_WHITELIST"/>
+<link href="#rfc.section.5.4.11" rel="Chapter" title="5.4.11 PROP 4865: PROP_MAC_WHITELIST_ENABLED"/>
+<link href="#rfc.section.5.5" rel="Chapter" title="5.5 NET Properties"/>
+<link href="#rfc.section.5.5.1" rel="Chapter" title="5.5.1 PROP 64: PROP_NET_SAVED"/>
+<link href="#rfc.section.5.5.2" rel="Chapter" title="5.5.2 PROP 65: PROP_NET_IF_UP"/>
+<link href="#rfc.section.5.5.3" rel="Chapter" title="5.5.3 PROP 66: PROP_NET_STACK_UP"/>
+<link href="#rfc.section.5.5.4" rel="Chapter" title="5.5.4 PROP 67: PROP_NET_ROLE"/>
+<link href="#rfc.section.5.5.5" rel="Chapter" title="5.5.5 PROP 68: PROP_NET_NETWORK_NAME"/>
+<link href="#rfc.section.5.5.6" rel="Chapter" title="5.5.6 PROP 69: PROP_NET_XPANID"/>
+<link href="#rfc.section.5.5.7" rel="Chapter" title="5.5.7 PROP 70: PROP_NET_MASTER_KEY"/>
+<link href="#rfc.section.5.5.8" rel="Chapter" title="5.5.8 PROP 71: PROP_NET_KEY_SEQUENCE"/>
+<link href="#rfc.section.5.5.9" rel="Chapter" title="5.5.9 PROP 72: PROP_NET_PARTITION_ID"/>
+<link href="#rfc.section.5.6" rel="Chapter" title="5.6 IPv6 Properties"/>
+<link href="#rfc.section.5.6.1" rel="Chapter" title="5.6.1 PROP 96: PROP_IPV6_LL_ADDR"/>
+<link href="#rfc.section.5.6.2" rel="Chapter" title="5.6.2 PROP 97: PROP_IPV6_ML_ADDR"/>
+<link href="#rfc.section.5.6.3" rel="Chapter" title="5.6.3 PROP 98: PROP_IPV6_ML_PREFIX"/>
+<link href="#rfc.section.5.6.4" rel="Chapter" title="5.6.4 PROP 99: PROP_IPV6_ADDRESS_TABLE"/>
+<link href="#rfc.section.5.6.5" rel="Chapter" title="5.6.5 PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD"/>
+<link href="#rfc.section.6" rel="Chapter" title="6 Status Codes"/>
+<link href="#rfc.section.7" rel="Chapter" title="7 Security Considerations"/>
+<link href="#rfc.section.8" rel="Chapter" title="8 Acknowledgments"/>
 <link href="#rfc.appendix.A" rel="Chapter" title="A Framing Protocol"/>
 <link href="#rfc.appendix.A.1" rel="Chapter" title="A.1 UART Recommendations"/>
 <link href="#rfc.appendix.A.1.1" rel="Chapter" title="A.1.1 HDLC-Lite"/>
@@ -526,6 +534,7 @@
 <link href="#rfc.appendix.F.8" rel="Chapter" title="F.8 Adding an on-mesh prefix"/>
 <link href="#rfc.appendix.F.9" rel="Chapter" title="F.9 Entering low-power modes"/>
 <link href="#rfc.appendix.F.10" rel="Chapter" title="F.10 Sniffing raw packets"/>
+<link href="#rfc.appendix.G" rel="Chapter" title="G Glossary"/>
 <link href="#rfc.authors" rel="Chapter"/>
 
 
@@ -533,8 +542,8 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Quattlebaum, R." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-spinel-protocol-94724cf" />
-  <meta name="dct.issued" scheme="ISO8601" content="2016-9-9" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-spinel-protocol-4d55c14" />
+  <meta name="dct.issued" scheme="ISO8601" content="2016-9-10" />
   <meta name="dct.abstract" content="This document describes a general management protocol for enabling a host device to communicate with and manage a Network Control Processor (NCP).  " />
   <meta name="description" content="This document describes a general management protocol for enabling a host device to communicate with and manage a Network Control Processor (NCP).  " />
 
@@ -555,7 +564,7 @@
 </tr>
 <tr>
   <td class="left"></td>
-  <td class="right">September 9, 2016</td>
+  <td class="right">September 10, 2016</td>
 </tr>
 
     	
@@ -563,7 +572,7 @@
   </table>
 
   <p class="title">Spinel Host-Controller Protocol<br />
-  <span class="filename">draft-spinel-protocol-94724cf</span></p>
+  <span class="filename">draft-spinel-protocol-4d55c14</span></p>
   
   <h1 id="rfc.abstract">
   <a href="#rfc.abstract">Abstract</a>
@@ -599,84 +608,92 @@
   <ul class="toc">
 
   	<li>1.   <a href="#rfc.section.1">Introduction</a></li>
-<li>2.   <a href="#rfc.section.2">Definitions</a></li>
-<li>3.   <a href="#rfc.section.3">Frame Format</a></li>
-<ul><li>3.1.   <a href="#rfc.section.3.1">Header Format</a></li>
-<ul><li>3.1.1.   <a href="#rfc.section.3.1.1">FLG: Flag</a></li>
-<li>3.1.2.   <a href="#rfc.section.3.1.2">IID: Interface Identifier</a></li>
-<li>3.1.3.   <a href="#rfc.section.3.1.3">TID: Transaction Identifier</a></li>
-<li>3.1.4.   <a href="#rfc.section.3.1.4">Command Identifier (CMD)</a></li>
-<li>3.1.5.   <a href="#rfc.section.3.1.5">Command Payload (Optional)</a></li>
-</ul></ul><li>4.   <a href="#rfc.section.4">Data Packing</a></li>
-<ul><li>4.1.   <a href="#rfc.section.4.1">Primitive Types</a></li>
-<li>4.2.   <a href="#rfc.section.4.2">Packed Unsigned Integer</a></li>
-<li>4.3.   <a href="#rfc.section.4.3">Data Blobs</a></li>
-<li>4.4.   <a href="#rfc.section.4.4">Structured Data</a></li>
-<li>4.5.   <a href="#rfc.section.4.5">Arrays</a></li>
-</ul><li>5.   <a href="#rfc.section.5">Commands</a></li>
-<ul><li>5.1.   <a href="#rfc.section.5.1">CMD 0: (Host-&gt;NCP) CMD_NOOP</a></li>
-<li>5.2.   <a href="#rfc.section.5.2">CMD 1: (Host-&gt;NCP) CMD_RESET</a></li>
-<li>5.3.   <a href="#rfc.section.5.3">CMD 2: (Host-&gt;NCP) CMD_PROP_VALUE_GET</a></li>
-<li>5.4.   <a href="#rfc.section.5.4">CMD 3: (Host-&gt;NCP) CMD_PROP_VALUE_SET</a></li>
-<li>5.5.   <a href="#rfc.section.5.5">CMD 4: (Host-&gt;NCP) CMD_PROP_VALUE_INSERT</a></li>
-<li>5.6.   <a href="#rfc.section.5.6">CMD 5: (Host-&gt;NCP) CMD_PROP_VALUE_REMOVE</a></li>
-<li>5.7.   <a href="#rfc.section.5.7">CMD 6: (NCP-&gt;Host) CMD_PROP_VALUE_IS</a></li>
-<li>5.8.   <a href="#rfc.section.5.8">CMD 7: (NCP-&gt;Host) CMD_PROP_VALUE_INSERTED</a></li>
-<li>5.9.   <a href="#rfc.section.5.9">CMD 8: (NCP-&gt;Host) CMD_PROP_VALUE_REMOVED</a></li>
-</ul><li>6.   <a href="#rfc.section.6">Properties</a></li>
-<ul><li>6.1.   <a href="#rfc.section.6.1">Property Sections</a></li>
-<li>6.2.   <a href="#rfc.section.6.2">Core Properties</a></li>
-<ul><li>6.2.1.   <a href="#rfc.section.6.2.1">PROP 0: PROP_LAST_STATUS</a></li>
-<li>6.2.2.   <a href="#rfc.section.6.2.2">PROP 1: PROP_PROTOCOL_VERSION</a></li>
-<li>6.2.3.   <a href="#rfc.section.6.2.3">PROP 2: PROP_NCP_VERSION</a></li>
-<li>6.2.4.   <a href="#rfc.section.6.2.4">PROP 3: PROP_INTERFACE_TYPE</a></li>
-<li>6.2.5.   <a href="#rfc.section.6.2.5">PROP 4: PROP_INTERFACE_VENDOR_ID</a></li>
-<li>6.2.6.   <a href="#rfc.section.6.2.6">PROP 5: PROP_CAPS</a></li>
-<li>6.2.7.   <a href="#rfc.section.6.2.7">PROP 6: PROP_INTERFACE_COUNT</a></li>
-<li>6.2.8.   <a href="#rfc.section.6.2.8">PROP 7: PROP_POWER_STATE</a></li>
-<li>6.2.9.   <a href="#rfc.section.6.2.9">PROP 8: PROP_HWADDR</a></li>
-<li>6.2.10.   <a href="#rfc.section.6.2.10">PROP 9: PROP_LOCK</a></li>
-<li>6.2.11.   <a href="#rfc.section.6.2.11">PROP 112: PROP_STREAM_DEBUG</a></li>
-<li>6.2.12.   <a href="#rfc.section.6.2.12">PROP 113: PROP_STREAM_RAW</a></li>
-<li>6.2.13.   <a href="#rfc.section.6.2.13">PROP 114: PROP_STREAM_NET</a></li>
-<li>6.2.14.   <a href="#rfc.section.6.2.14">PROP 114: PROP_STREAM_NET_INSECURE</a></li>
-</ul><li>6.3.   <a href="#rfc.section.6.3">PHY Properties</a></li>
-<ul><li>6.3.1.   <a href="#rfc.section.6.3.1">PROP 32: PROP_PHY_ENABLED</a></li>
-<li>6.3.2.   <a href="#rfc.section.6.3.2">PROP 33: PROP_PHY_CHAN</a></li>
-<li>6.3.3.   <a href="#rfc.section.6.3.3">PROP 34: PROP_PHY_CHAN_SUPPORTED</a></li>
-<li>6.3.4.   <a href="#rfc.section.6.3.4">PROP 35: PROP_PHY_FREQ</a></li>
-<li>6.3.5.   <a href="#rfc.section.6.3.5">PROP 36: PROP_PHY_CCA_THRESHOLD</a></li>
-<li>6.3.6.   <a href="#rfc.section.6.3.6">PROP 37: PROP_PHY_TX_POWER</a></li>
-<li>6.3.7.   <a href="#rfc.section.6.3.7">PROP 38: PROP_PHY_RSSI</a></li>
-</ul><li>6.4.   <a href="#rfc.section.6.4">MAC Properties</a></li>
-<ul><li>6.4.1.   <a href="#rfc.section.6.4.1">PROP 48: PROP_MAC_SCAN_STATE</a></li>
-<li>6.4.2.   <a href="#rfc.section.6.4.2">PROP 49: PROP_MAC_SCAN_MASK</a></li>
-<li>6.4.3.   <a href="#rfc.section.6.4.3">PROP 50: PROP_MAC_SCAN_PERIOD</a></li>
-<li>6.4.4.   <a href="#rfc.section.6.4.4">PROP 51: PROP_MAC_SCAN_BEACON</a></li>
-<li>6.4.5.   <a href="#rfc.section.6.4.5">PROP 52: PROP_MAC_15_4_LADDR</a></li>
-<li>6.4.6.   <a href="#rfc.section.6.4.6">PROP 53: PROP_MAC_15_4_SADDR</a></li>
-<li>6.4.7.   <a href="#rfc.section.6.4.7">PROP 54: PROP_MAC_15_4_PANID</a></li>
-<li>6.4.8.   <a href="#rfc.section.6.4.8">PROP 55: PROP_MAC_RAW_STREAM_ENABLED</a></li>
-<li>6.4.9.   <a href="#rfc.section.6.4.9">PROP 56: PROP_MAC_FILTER_MODE</a></li>
-<li>6.4.10.   <a href="#rfc.section.6.4.10">PROP 4864: PROP_MAC_WHITELIST</a></li>
-<li>6.4.11.   <a href="#rfc.section.6.4.11">PROP 4865: PROP_MAC_WHITELIST_ENABLED</a></li>
-</ul><li>6.5.   <a href="#rfc.section.6.5">NET Properties</a></li>
-<ul><li>6.5.1.   <a href="#rfc.section.6.5.1">PROP 64: PROP_NET_SAVED</a></li>
-<li>6.5.2.   <a href="#rfc.section.6.5.2">PROP 65: PROP_NET_IF_UP</a></li>
-<li>6.5.3.   <a href="#rfc.section.6.5.3">PROP 66: PROP_NET_STACK_UP</a></li>
-<li>6.5.4.   <a href="#rfc.section.6.5.4">PROP 67: PROP_NET_ROLE</a></li>
-<li>6.5.5.   <a href="#rfc.section.6.5.5">PROP 68: PROP_NET_NETWORK_NAME</a></li>
-<li>6.5.6.   <a href="#rfc.section.6.5.6">PROP 69: PROP_NET_XPANID</a></li>
-<li>6.5.7.   <a href="#rfc.section.6.5.7">PROP 70: PROP_NET_MASTER_KEY</a></li>
-<li>6.5.8.   <a href="#rfc.section.6.5.8">PROP 71: PROP_NET_KEY_SEQUENCE</a></li>
-<li>6.5.9.   <a href="#rfc.section.6.5.9">PROP 72: PROP_NET_PARTITION_ID</a></li>
-</ul><li>6.6.   <a href="#rfc.section.6.6">IPv6 Properties</a></li>
-<ul><li>6.6.1.   <a href="#rfc.section.6.6.1">PROP 96: PROP_IPV6_LL_ADDR</a></li>
-<li>6.6.2.   <a href="#rfc.section.6.6.2">PROP 97: PROP_IPV6_ML_ADDR</a></li>
-<li>6.6.3.   <a href="#rfc.section.6.6.3">PROP 98: PROP_IPV6_ML_PREFIX</a></li>
-<li>6.6.4.   <a href="#rfc.section.6.6.4">PROP 99: PROP_IPV6_ADDRESS_TABLE</a></li>
-<li>6.6.5.   <a href="#rfc.section.6.6.5">PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD</a></li>
-</ul></ul><li>7.   <a href="#rfc.section.7">Status Codes</a></li>
+<ul><li>1.1.   <a href="#rfc.section.1.1">About this Draft</a></li>
+<ul><li>1.1.1.   <a href="#rfc.section.1.1.1">Renumbering</a></li>
+<li>1.1.2.   <a href="#rfc.section.1.1.2">Spinel as Application API</a></li>
+<li>1.1.3.   <a href="#rfc.section.1.1.3">Privileged Commands and Properties</a></li>
+</ul><li>1.2.   <a href="#rfc.section.1.2">Property Overview</a></li>
+<ul><li>1.2.1.   <a href="#rfc.section.1.2.1">Property Methods</a></li>
+<li>1.2.2.   <a href="#rfc.section.1.2.2">Property Types</a></li>
+</ul></ul><li>2.   <a href="#rfc.section.2">Frame Format</a></li>
+<ul><li>2.1.   <a href="#rfc.section.2.1">Header Format</a></li>
+<ul><li>2.1.1.   <a href="#rfc.section.2.1.1">FLG: Flag</a></li>
+<li>2.1.2.   <a href="#rfc.section.2.1.2">IID: Interface Identifier</a></li>
+<li>2.1.3.   <a href="#rfc.section.2.1.3">TID: Transaction Identifier</a></li>
+<li>2.1.4.   <a href="#rfc.section.2.1.4">Command Identifier (CMD)</a></li>
+<li>2.1.5.   <a href="#rfc.section.2.1.5">Command Payload (Optional)</a></li>
+</ul></ul><li>3.   <a href="#rfc.section.3">Data Packing</a></li>
+<ul><li>3.1.   <a href="#rfc.section.3.1">Primitive Types</a></li>
+<li>3.2.   <a href="#rfc.section.3.2">Packed Unsigned Integer</a></li>
+<li>3.3.   <a href="#rfc.section.3.3">Data Blobs</a></li>
+<li>3.4.   <a href="#rfc.section.3.4">Structured Data</a></li>
+<li>3.5.   <a href="#rfc.section.3.5">Arrays</a></li>
+</ul><li>4.   <a href="#rfc.section.4">Commands</a></li>
+<ul><li>4.1.   <a href="#rfc.section.4.1">CMD 0: (Host-&gt;NCP) CMD_NOOP</a></li>
+<li>4.2.   <a href="#rfc.section.4.2">CMD 1: (Host-&gt;NCP) CMD_RESET</a></li>
+<li>4.3.   <a href="#rfc.section.4.3">CMD 2: (Host-&gt;NCP) CMD_PROP_VALUE_GET</a></li>
+<li>4.4.   <a href="#rfc.section.4.4">CMD 3: (Host-&gt;NCP) CMD_PROP_VALUE_SET</a></li>
+<li>4.5.   <a href="#rfc.section.4.5">CMD 4: (Host-&gt;NCP) CMD_PROP_VALUE_INSERT</a></li>
+<li>4.6.   <a href="#rfc.section.4.6">CMD 5: (Host-&gt;NCP) CMD_PROP_VALUE_REMOVE</a></li>
+<li>4.7.   <a href="#rfc.section.4.7">CMD 6: (NCP-&gt;Host) CMD_PROP_VALUE_IS</a></li>
+<li>4.8.   <a href="#rfc.section.4.8">CMD 7: (NCP-&gt;Host) CMD_PROP_VALUE_INSERTED</a></li>
+<li>4.9.   <a href="#rfc.section.4.9">CMD 8: (NCP-&gt;Host) CMD_PROP_VALUE_REMOVED</a></li>
+</ul><li>5.   <a href="#rfc.section.5">Properties</a></li>
+<ul><li>5.1.   <a href="#rfc.section.5.1">Property Sections</a></li>
+<li>5.2.   <a href="#rfc.section.5.2">Core Properties</a></li>
+<ul><li>5.2.1.   <a href="#rfc.section.5.2.1">PROP 0: PROP_LAST_STATUS</a></li>
+<li>5.2.2.   <a href="#rfc.section.5.2.2">PROP 1: PROP_PROTOCOL_VERSION</a></li>
+<li>5.2.3.   <a href="#rfc.section.5.2.3">PROP 2: PROP_NCP_VERSION</a></li>
+<li>5.2.4.   <a href="#rfc.section.5.2.4">PROP 3: PROP_INTERFACE_TYPE</a></li>
+<li>5.2.5.   <a href="#rfc.section.5.2.5">PROP 4: PROP_INTERFACE_VENDOR_ID</a></li>
+<li>5.2.6.   <a href="#rfc.section.5.2.6">PROP 5: PROP_CAPS</a></li>
+<li>5.2.7.   <a href="#rfc.section.5.2.7">PROP 6: PROP_INTERFACE_COUNT</a></li>
+<li>5.2.8.   <a href="#rfc.section.5.2.8">PROP 7: PROP_POWER_STATE</a></li>
+<li>5.2.9.   <a href="#rfc.section.5.2.9">PROP 8: PROP_HWADDR</a></li>
+<li>5.2.10.   <a href="#rfc.section.5.2.10">PROP 9: PROP_LOCK</a></li>
+<li>5.2.11.   <a href="#rfc.section.5.2.11">PROP 112: PROP_STREAM_DEBUG</a></li>
+<li>5.2.12.   <a href="#rfc.section.5.2.12">PROP 113: PROP_STREAM_RAW</a></li>
+<li>5.2.13.   <a href="#rfc.section.5.2.13">PROP 114: PROP_STREAM_NET</a></li>
+<li>5.2.14.   <a href="#rfc.section.5.2.14">PROP 114: PROP_STREAM_NET_INSECURE</a></li>
+</ul><li>5.3.   <a href="#rfc.section.5.3">PHY Properties</a></li>
+<ul><li>5.3.1.   <a href="#rfc.section.5.3.1">PROP 32: PROP_PHY_ENABLED</a></li>
+<li>5.3.2.   <a href="#rfc.section.5.3.2">PROP 33: PROP_PHY_CHAN</a></li>
+<li>5.3.3.   <a href="#rfc.section.5.3.3">PROP 34: PROP_PHY_CHAN_SUPPORTED</a></li>
+<li>5.3.4.   <a href="#rfc.section.5.3.4">PROP 35: PROP_PHY_FREQ</a></li>
+<li>5.3.5.   <a href="#rfc.section.5.3.5">PROP 36: PROP_PHY_CCA_THRESHOLD</a></li>
+<li>5.3.6.   <a href="#rfc.section.5.3.6">PROP 37: PROP_PHY_TX_POWER</a></li>
+<li>5.3.7.   <a href="#rfc.section.5.3.7">PROP 38: PROP_PHY_RSSI</a></li>
+</ul><li>5.4.   <a href="#rfc.section.5.4">MAC Properties</a></li>
+<ul><li>5.4.1.   <a href="#rfc.section.5.4.1">PROP 48: PROP_MAC_SCAN_STATE</a></li>
+<li>5.4.2.   <a href="#rfc.section.5.4.2">PROP 49: PROP_MAC_SCAN_MASK</a></li>
+<li>5.4.3.   <a href="#rfc.section.5.4.3">PROP 50: PROP_MAC_SCAN_PERIOD</a></li>
+<li>5.4.4.   <a href="#rfc.section.5.4.4">PROP 51: PROP_MAC_SCAN_BEACON</a></li>
+<li>5.4.5.   <a href="#rfc.section.5.4.5">PROP 52: PROP_MAC_15_4_LADDR</a></li>
+<li>5.4.6.   <a href="#rfc.section.5.4.6">PROP 53: PROP_MAC_15_4_SADDR</a></li>
+<li>5.4.7.   <a href="#rfc.section.5.4.7">PROP 54: PROP_MAC_15_4_PANID</a></li>
+<li>5.4.8.   <a href="#rfc.section.5.4.8">PROP 55: PROP_MAC_RAW_STREAM_ENABLED</a></li>
+<li>5.4.9.   <a href="#rfc.section.5.4.9">PROP 56: PROP_MAC_FILTER_MODE</a></li>
+<li>5.4.10.   <a href="#rfc.section.5.4.10">PROP 4864: PROP_MAC_WHITELIST</a></li>
+<li>5.4.11.   <a href="#rfc.section.5.4.11">PROP 4865: PROP_MAC_WHITELIST_ENABLED</a></li>
+</ul><li>5.5.   <a href="#rfc.section.5.5">NET Properties</a></li>
+<ul><li>5.5.1.   <a href="#rfc.section.5.5.1">PROP 64: PROP_NET_SAVED</a></li>
+<li>5.5.2.   <a href="#rfc.section.5.5.2">PROP 65: PROP_NET_IF_UP</a></li>
+<li>5.5.3.   <a href="#rfc.section.5.5.3">PROP 66: PROP_NET_STACK_UP</a></li>
+<li>5.5.4.   <a href="#rfc.section.5.5.4">PROP 67: PROP_NET_ROLE</a></li>
+<li>5.5.5.   <a href="#rfc.section.5.5.5">PROP 68: PROP_NET_NETWORK_NAME</a></li>
+<li>5.5.6.   <a href="#rfc.section.5.5.6">PROP 69: PROP_NET_XPANID</a></li>
+<li>5.5.7.   <a href="#rfc.section.5.5.7">PROP 70: PROP_NET_MASTER_KEY</a></li>
+<li>5.5.8.   <a href="#rfc.section.5.5.8">PROP 71: PROP_NET_KEY_SEQUENCE</a></li>
+<li>5.5.9.   <a href="#rfc.section.5.5.9">PROP 72: PROP_NET_PARTITION_ID</a></li>
+</ul><li>5.6.   <a href="#rfc.section.5.6">IPv6 Properties</a></li>
+<ul><li>5.6.1.   <a href="#rfc.section.5.6.1">PROP 96: PROP_IPV6_LL_ADDR</a></li>
+<li>5.6.2.   <a href="#rfc.section.5.6.2">PROP 97: PROP_IPV6_ML_ADDR</a></li>
+<li>5.6.3.   <a href="#rfc.section.5.6.3">PROP 98: PROP_IPV6_ML_PREFIX</a></li>
+<li>5.6.4.   <a href="#rfc.section.5.6.4">PROP 99: PROP_IPV6_ADDRESS_TABLE</a></li>
+<li>5.6.5.   <a href="#rfc.section.5.6.5">PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD</a></li>
+</ul></ul><li>6.   <a href="#rfc.section.6">Status Codes</a></li>
+<li>7.   <a href="#rfc.section.7">Security Considerations</a></li>
+<li>8.   <a href="#rfc.section.8">Acknowledgments</a></li>
 <li>Appendix A.   <a href="#rfc.appendix.A">Framing Protocol</a></li>
 <ul><li>A.1.   <a href="#rfc.appendix.A.1">UART Recommendations</a></li>
 <ul><li>A.1.1.   <a href="#rfc.appendix.A.1.1">HDLC-Lite</a></li>
@@ -750,7 +767,8 @@
 <li>F.8.   <a href="#rfc.appendix.F.8">Adding an on-mesh prefix</a></li>
 <li>F.9.   <a href="#rfc.appendix.F.9">Entering low-power modes</a></li>
 <li>F.10.   <a href="#rfc.appendix.F.10">Sniffing raw packets</a></li>
-</ul><li><a href="#rfc.authors">Author's Address</a></li>
+</ul><li>Appendix G.   <a href="#rfc.appendix.G">Glossary</a></li>
+<li><a href="#rfc.authors">Author's Address</a></li>
 
 
   </ul>
@@ -769,30 +787,133 @@
 
 <p> </p>
 <p id="rfc.section.1.p.3">On top of this core framework, we define the properties and commands to enable various features and network protocols.  </p>
-<h1 id="rfc.section.2"><a href="#rfc.section.2">2.</a> <a href="#definitions" id="definitions">Definitions</a></h1>
+<h1 id="rfc.section.1.1"><a href="#rfc.section.1.1">1.1.</a> <a href="#about-this-draft" id="about-this-draft">About this Draft</a></h1>
+<p id="rfc.section.1.1.p.1">This document is currently in a draft status and is changing often.  This section discusses some ideas for changes to the protocol that haven't yet been fully specified, as well as some of the impetus for the current design.  </p>
+<h1 id="rfc.section.1.1.1"><a href="#rfc.section.1.1.1">1.1.1.</a> <a href="#renumbering" id="renumbering">Renumbering</a></h1>
+<p id="rfc.section.1.1.1.p.1">Efforts are currently maintained to try to prevent overtly backward-incompatible changes to the existing protocol, but if you are implementing Spinel in your own products you should expect there to be at least one large renumbering event and major version number change before the standard is considered "baked". All changes will be clearly marked and documented to make such a transition as easy as possible.  </p>
+<p id="rfc.section.1.1.1.p.2">To allow conclusive detection of protocol (in)compatibility between the host and the NCP, the following commands and properties are already considered to be "baked" and will not change: </p>
 <p/>
 
-<dl>
-  <dt>NCP</dt>
-  <dd style="margin-left: 8"><br/> Acryonym for Network Control Processor.</dd>
-  <dt>Host</dt>
-  <dd style="margin-left: 8"><br/> Computer or Micro-controller which controls the NCP.</dd>
-  <dt>TID</dt>
-  <dd style="margin-left: 8"><br/> Transaction Identifier. May be a value between zero and fifteen.  See <a href="#tid-transaction-identifier">Section 3.1.3</a> for more information.</dd>
-  <dt>IID</dt>
-  <dd style="margin-left: 8"><br/> Interface Identifier. May be a value between zero and three.  See <a href="#iid-interface-identifier">Section 3.1.2</a> for more information.</dd>
-  <dt>PUI</dt>
-  <dd style="margin-left: 8"><br/> Packed Unsigned Integer. A way to serialize an unsigned integer using one, two, or three bytes. Used throughout the Spinel protocol.  See <a href="#packed-unsigned-integer">Section 4.2</a> for more information.</dd>
-</dl>
+<ul>
+  <li>Command IDs zero through eight. (Reset, No-op, and Property-Value Commands)</li>
+  <li>Property IDs zero through two. (Last status, Protocol Version, and NCP Version)</li>
+</ul>
 
 <p> </p>
-<h1 id="rfc.section.3"><a href="#rfc.section.3">3.</a> <a href="#frame-format" id="frame-format">Frame Format</a></h1>
-<p id="rfc.section.3.p.1">A frame is defined simply as the concatenation of </p>
+<p id="rfc.section.1.1.1.p.4">Renumbering would be undertaken in order to better organize the allocation of property IDs and capability IDs. One of the initial goals of this protocol was for it to be possible for a host or NCP to only implement properties with values less than 127 and for the NCP to still be usable---relegating all larger property values for extra features or other capabilities that aren't strictly necessary. This would allow simple implementations to avoid the need to implement support for PUIs (<a href="#packed-unsigned-integer">Section 3.2</a>).  </p>
+<p id="rfc.section.1.1.1.p.5">As time has gone by and the protocol has become more fleshed out, it has become clear that some of the initial allocations were inadequate and should be revisited if we want to try to achieve the original goal.  </p>
+<h1 id="rfc.section.1.1.2"><a href="#rfc.section.1.1.2">1.1.2.</a> <a href="#spinel-as-application-api" id="spinel-as-application-api">Spinel as Application API</a></h1>
+<p id="rfc.section.1.1.2.p.1">The current primary host driver implementation is <a href="http://wpantund.org/">wpantund</a>. wpantund manages the NCP using the Spinel protocol and provides a management API for the application using <a href="https://www.freedesktop.org/wiki/Software/dbus/">D-Bus</a> IPC.  </p>
+<p id="rfc.section.1.1.2.p.2">However, some thought has been given to the idea of having a host driver daemon which uses Spinel directly as the management API. You would have user-space daemon similar to wpantund which would communicate directly with the NCP. Using Unix Domain Sockets, applications could connect to the daemon by opening a special socket file. The protocol for that socket might be (for example) HDLC-Lite-encoded (<a href="#hdlc-lite">Appendix A.1.1</a>) spinel frames, as if the application were talking directly to the NCP.  </p>
+<p id="rfc.section.1.1.2.p.3">Applications aren't necessarily interested in everything that an NCP would normally send out unsolicited, so a mechanism for specifying which properties should be listened to would need to be defined. This mechanism would not be implemented by the NCP but would instead be implemented by the daemon to control which notification packets need to be directed where.  </p>
+<p id="rfc.section.1.1.2.p.4">In the event of transaction ID collisions, the daemon would transparently renumber spinel frames so as to not cause TID collisions.  </p>
+<p id="rfc.section.1.1.2.p.5">Since there can be more than one application that is using the API at a time, the <samp>PROP_LOCK</samp> property (<a href="#prop-lock">Section 5.2.10</a>) would be used to ensure exclusive access to the NCP by an application. Only one process would be allowed to enable the lock at a time.  </p>
+<p id="rfc.section.1.1.2.p.6">Such a IPC mechanism would be desirable because it is, from a spinel perspective, future proof. New features can be added and new properties assigned and the IPC protocol would not need to be extended to support them. It is also simple and has no external dependencies other than unix domain sockets.  </p>
+<p id="rfc.section.1.1.2.p.7">Security is obviously paramount in a system like this, so a great deal of care should be taken to make sure that certain commands and properties cannot be executed or changed without the appropriate privileges.  </p>
+<h1 id="rfc.section.1.1.3"><a href="#rfc.section.1.1.3">1.1.3.</a> <a href="#privileged-commands-and-properties" id="privileged-commands-and-properties">Privileged Commands and Properties</a></h1>
+<p id="rfc.section.1.1.3.p.1">The idea here is that some commands should be considered "privileged", and actively prevented from letting normal applications access them.  This is important if the IPC protocol between the application and the NCP is Spinel.  </p>
+<p id="rfc.section.1.1.3.p.2">Examples of such privileged commands would be debugging commands like "peek" or "poke", properties which control bootloader behavior, or changing factory-specified constants. These commands should have some attribute about them that can be easily filtered to prevent applications from using issuing them directly to the NCP.  </p>
+<p id="rfc.section.1.1.3.p.3">This would likely be implemented as a part of the renumbering effort (<a href="#renumbering">Section 1.1.1</a>).  </p>
+<h1 id="rfc.section.1.2"><a href="#rfc.section.1.2">1.2.</a> <a href="#property-overview" id="property-overview">Property Overview</a></h1>
+<p id="rfc.section.1.2.p.1">Spinel is largely a property-based protocol, with a property defined for every attribute that needs to be set, changed, or known by the host. The inspiration of this approach was memory-mapped hardware registers for peripherals. The goal is to avoid, as much as possible, the use of large complicated structures and/or method argument lists.  The reason for avoiding these is because they have a tendency to change, especially early in development. Adding or removing a property from a structure can render the entire protocol incompatible. By using properties, you simply change an additional property.  </p>
+<p id="rfc.section.1.2.p.2">Almost all features and capabilities are implemented using properties.  Most new features that are initially proposed as commands can be adapted to be property-based instead. Notable exceptions include "Host Buffer Offload" (<a href="#feature-host-buffer-offload">Appendix C</a>) and "Network Save" (<a href="#feature-network-save">Appendix B</a>).  </p>
+<p id="rfc.section.1.2.p.3">In Spinel, properties are keyed by an unsigned integer between 0 and 2,097,151 (See <a href="#packed-unsigned-integer">Section 3.2</a>).  </p>
+<h1 id="rfc.section.1.2.1"><a href="#rfc.section.1.2.1">1.2.1.</a> <a href="#property-methods" id="property-methods">Property Methods</a></h1>
+<p id="rfc.section.1.2.1.p.1">Properties may support one or more of the following methods: </p>
+<p/>
+
+<ul>
+  <li>
+    <samp>VALUE_GET</samp>
+  </li>
+  <li>
+    <samp>VALUE_SET</samp>
+  </li>
+  <li>
+    <samp>VALUE_INSERT</samp>
+  </li>
+  <li>
+    <samp>VALUE_REMOVE</samp>
+  </li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.1.2.1.p.3">Additionally, the NCP can send updates to the host (either synchronously or asynchronously) that inform the host about changes to specific properties: </p>
+<p/>
+
+<ul>
+  <li>
+    <samp>VALUE_IS</samp>
+  </li>
+  <li>
+    <samp>VALUE_INSERTED</samp>
+  </li>
+  <li>
+    <samp>VALUE_REMOVED</samp>
+  </li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.1.2.2"><a href="#rfc.section.1.2.2">1.2.2.</a> <a href="#property-types" id="property-types">Property Types</a></h1>
+<p id="rfc.section.1.2.2.p.1">Conceptually, there are three different types of properties: </p>
+<p/>
+
+<ul>
+  <li>Single-value properties</li>
+  <li>Multiple-value (Array) properties</li>
+  <li>Stream properties</li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.1.2.2.1"><a href="#rfc.section.1.2.2.1">1.2.2.1.</a> <a href="#singlevalue-properties" id="singlevalue-properties">Single-Value Properties</a></h1>
+<p id="rfc.section.1.2.2.1.p.1">Single-value properties are properties that have a simple representation of a single value. Examples would be: </p>
+<p/>
+
+<ul>
+  <li>Current radio channel (Represented as a unsigned 8-bit integer)</li>
+  <li>Network name (Represented as a UTF-8 encoded string)</li>
+  <li>802.15.4 PAN ID (Represented as a unsigned 16-bit integer)</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.1.2.2.1.p.3">The valid operations on these sorts of properties are <samp>GET</samp> and <samp>SET</samp>.  </p>
+<h1 id="rfc.section.1.2.2.2"><a href="#rfc.section.1.2.2.2">1.2.2.2.</a> <a href="#multiplevalue-properties" id="multiplevalue-properties">Multiple-Value Properties</a></h1>
+<p id="rfc.section.1.2.2.2.p.1">Multiple-Value Properties have more than one value associated with them. Examples would be: </p>
+<p/>
+
+<ul>
+  <li>List of channels supported by the radio hardware.</li>
+  <li>List of IPv6 addresses assigned to the interface.</li>
+  <li>List of capabilities supported by the NCP.</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.1.2.2.2.p.3">The valid operations on these sorts of properties are <samp>VALUE_GET</samp>, <samp>VALUE_SET</samp>, <samp>VALUE_INSERT</samp>, and <samp>VALUE_REMOVE</samp>.  </p>
+<p id="rfc.section.1.2.2.2.p.4">When the value is fetched using <samp>VALUE_GET</samp>, the returned value is the concatenation of all of the individual values in the list. If the length of the value for an individual item in the list is not defined by the type then each item returned in the list is prepended with a length (See <a href="#arrays">Section 3.5</a>). The order of the returned items, unless explicitly defined for that specific property, is undefined.  </p>
+<p><samp>VALUE_SET</samp> provides a way to completely replace all previous values.  Calling <samp>VALUE_SET</samp> with an empty value effectively instructs the NCP to clear the value of that property.  </p>
+<p><samp>VALUE_INSERT</samp> and <samp>VALUE_REMOVE</samp> provide mechanisms for the insertion or removal of individual items <em>by value</em>. The payload for these commands is a plain single value.  </p>
+<h1 id="rfc.section.1.2.2.3"><a href="#rfc.section.1.2.2.3">1.2.2.3.</a> <a href="#stream-properties" id="stream-properties">Stream Properties</a></h1>
+<p id="rfc.section.1.2.2.3.p.1">Stream properties are special properties representing streams of data.  Examples would be: </p>
+<p/>
+
+<ul>
+  <li>Network packet stream (<a href="#prop-stream-net">Section 5.2.13</a>)</li>
+  <li>Raw packet stream (<a href="#prop-stream-raw">Section 5.2.12</a>)</li>
+  <li>Debug message stream (<a href="#prop-stream-debug">Section 5.2.11</a>)</li>
+  <li>Network Beacon stream (<a href="#prop-mac-scan-beacon">Section 5.4.4</a>)</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.1.2.2.3.p.3">All such properties emit changes asynchronously using the <samp>VALUE_IS</samp> command, sent from the NCP to the host. For example, as IPv6 traffic is received by the NCP, the IPv6 packets are sent to the host by way of asynchronous <samp>VALUE_IS</samp> notifications.  </p>
+<p id="rfc.section.1.2.2.3.p.4">Some of these properties also support the host send data back to the NCP. For example, this is how the host sends IPv6 traffic to the NCP.  </p>
+<p id="rfc.section.1.2.2.3.p.5">These types of properties generally do not support <samp>VALUE_GET</samp>, as it is meaningless.  </p>
+<h1 id="rfc.section.2"><a href="#rfc.section.2">2.</a> <a href="#frame-format" id="frame-format">Frame Format</a></h1>
+<p id="rfc.section.2.p.1">A frame is defined simply as the concatenation of </p>
 <p/>
 
 <ul>
   <li>A header byte</li>
-  <li>A command (up to three bytes, see <a href="#packed-unsigned-integer">Section 4.2</a> for format)</li>
+  <li>A command (up to three bytes, see <a href="#packed-unsigned-integer">Section 3.2</a> for format)</li>
   <li>An optional command payload</li>
 </ul>
 
@@ -815,8 +936,8 @@
     </tr>
   </tbody>
 </table>
-<h1 id="rfc.section.3.1"><a href="#rfc.section.3.1">3.1.</a> <a href="#header-format" id="header-format">Header Format</a></h1>
-<p id="rfc.section.3.1.p.1">The header byte is broken down as follows: </p>
+<h1 id="rfc.section.2.1"><a href="#rfc.section.2.1">2.1.</a> <a href="#header-format" id="header-format">Header Format</a></h1>
+<p id="rfc.section.2.1.p.1">The header byte is broken down as follows: </p>
 <pre>
   0   1   2   3   4   5   6   7
 +---+---+---+---+---+---+---+---+
@@ -826,17 +947,17 @@
 <p>
   <a id="CREF2" class="info">[CREF2]<span class="info">RQ: Eventually, when https://github.com/miekg/mmark/issues/95 is addressed, the above table should be swapped out with this: | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | |---|---|---|---|---|---|---|---| |  FLG ||  IID ||      TID   ||||</span></a>
 </p>
-<h1 id="rfc.section.3.1.1"><a href="#rfc.section.3.1.1">3.1.1.</a> <a href="#flg-flag" id="flg-flag">FLG: Flag</a></h1>
-<p id="rfc.section.3.1.1.p.1">The flag field of the header byte (<samp>FLG</samp>) is always set to the value two (or <samp>10</samp> in binary). Any frame received with these bits set to any other value else MUST NOT be considered a Spinel frame.  </p>
-<p id="rfc.section.3.1.1.p.2">This convention allows Spinel to be line compatible with BTLE HCI. By defining the first two bit in this way we can disambiguate between Spinel frames and HCI frames (which always start with either <samp>0x01</samp> or <samp>0x04</samp>) without any additional framing overhead.  </p>
-<h1 id="rfc.section.3.1.2"><a href="#rfc.section.3.1.2">3.1.2.</a> <a href="#iid-interface-identifier" id="iid-interface-identifier">IID: Interface Identifier</a></h1>
-<p id="rfc.section.3.1.2.p.1">The Interface Identifier (IID) is a number between 0 and 3 which identifies which subinterface the frame is intended for. This allows the protocol to support connecting to more than one network at once.  The first subinterface (0) is considered the primary subinterface and MUST be supported. Support for all other subinterfaces is OPTIONAL.  </p>
-<h1 id="rfc.section.3.1.3"><a href="#rfc.section.3.1.3">3.1.3.</a> <a href="#tid-transaction-identifier" id="tid-transaction-identifier">TID: Transaction Identifier</a></h1>
-<p id="rfc.section.3.1.3.p.1">The least significant bits of the header represent the Transaction Identifier(TID). The TID is used for correlating responses to the commands which generated them.  </p>
-<p id="rfc.section.3.1.3.p.2">When a command is sent from the host, any reply to that command sent by the NCP will use the same value for the TID. When the host receives a frame that matches the TID of the command it sent, it can easily recognize that frame as the actual response to that command.  </p>
-<p id="rfc.section.3.1.3.p.3">The TID value of zero (0) is used for commands to which a correlated response is not expected or needed, such as for unsolicited update commands sent to the host from the NCP.  </p>
-<h1 id="rfc.section.3.1.4"><a href="#rfc.section.3.1.4">3.1.4.</a> <a href="#command-identifier-cmd" id="command-identifier-cmd">Command Identifier (CMD)</a></h1>
-<p id="rfc.section.3.1.4.p.1">The command identifier is a 21-bit unsigned integer encoded in up to three bytes using the packed unsigned integer format described in <a href="#packed-unsigned-integer">Section 4.2</a>. This encoding allows for up to 2,097,152 individual commands, with the first 127 commands represented as a single byte.  Command identifiers larger than 2,097,151 are explicitly forbidden.  </p>
+<h1 id="rfc.section.2.1.1"><a href="#rfc.section.2.1.1">2.1.1.</a> <a href="#flg-flag" id="flg-flag">FLG: Flag</a></h1>
+<p id="rfc.section.2.1.1.p.1">The flag field of the header byte (<samp>FLG</samp>) is always set to the value two (or <samp>10</samp> in binary). Any frame received with these bits set to any other value else MUST NOT be considered a Spinel frame.  </p>
+<p id="rfc.section.2.1.1.p.2">This convention allows Spinel to be line compatible with BTLE HCI. By defining the first two bit in this way we can disambiguate between Spinel frames and HCI frames (which always start with either <samp>0x01</samp> or <samp>0x04</samp>) without any additional framing overhead.  </p>
+<h1 id="rfc.section.2.1.2"><a href="#rfc.section.2.1.2">2.1.2.</a> <a href="#iid-interface-identifier" id="iid-interface-identifier">IID: Interface Identifier</a></h1>
+<p id="rfc.section.2.1.2.p.1">The Interface Identifier (IID) is a number between 0 and 3 which identifies which subinterface the frame is intended for. This allows the protocol to support connecting to more than one network at once.  The first subinterface (0) is considered the primary subinterface and MUST be supported. Support for all other subinterfaces is OPTIONAL.  </p>
+<h1 id="rfc.section.2.1.3"><a href="#rfc.section.2.1.3">2.1.3.</a> <a href="#tid-transaction-identifier" id="tid-transaction-identifier">TID: Transaction Identifier</a></h1>
+<p id="rfc.section.2.1.3.p.1">The least significant bits of the header represent the Transaction Identifier(TID). The TID is used for correlating responses to the commands which generated them.  </p>
+<p id="rfc.section.2.1.3.p.2">When a command is sent from the host, any reply to that command sent by the NCP will use the same value for the TID. When the host receives a frame that matches the TID of the command it sent, it can easily recognize that frame as the actual response to that command.  </p>
+<p id="rfc.section.2.1.3.p.3">The TID value of zero (0) is used for commands to which a correlated response is not expected or needed, such as for unsolicited update commands sent to the host from the NCP.  </p>
+<h1 id="rfc.section.2.1.4"><a href="#rfc.section.2.1.4">2.1.4.</a> <a href="#command-identifier-cmd" id="command-identifier-cmd">Command Identifier (CMD)</a></h1>
+<p id="rfc.section.2.1.4.p.1">The command identifier is a 21-bit unsigned integer encoded in up to three bytes using the packed unsigned integer format described in <a href="#packed-unsigned-integer">Section 3.2</a>. This encoding allows for up to 2,097,152 individual commands, with the first 127 commands represented as a single byte.  Command identifiers larger than 2,097,151 are explicitly forbidden.  </p>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <thead>
     <tr>
@@ -871,11 +992,11 @@
     </tr>
   </tbody>
 </table>
-<h1 id="rfc.section.3.1.5"><a href="#rfc.section.3.1.5">3.1.5.</a> <a href="#command-payload-optional" id="command-payload-optional">Command Payload (Optional)</a></h1>
-<p id="rfc.section.3.1.5.p.1">Depending on the semantics of the command in question, a payload MAY be included in the frame. The exact composition and length of the payload is defined by the command identifier.  </p>
-<h1 id="rfc.section.4"><a href="#rfc.section.4">4.</a> <a href="#data-packing" id="data-packing">Data Packing</a></h1>
-<p id="rfc.section.4.p.1">Data serialization for properties is performed using a light-weight data packing format which was loosely inspired by D-Bus. The format of a serialization is defined by a specially formatted string.  </p>
-<p id="rfc.section.4.p.2">Goals: </p>
+<h1 id="rfc.section.2.1.5"><a href="#rfc.section.2.1.5">2.1.5.</a> <a href="#command-payload-optional" id="command-payload-optional">Command Payload (Optional)</a></h1>
+<p id="rfc.section.2.1.5.p.1">Depending on the semantics of the command in question, a payload MAY be included in the frame. The exact composition and length of the payload is defined by the command identifier.  </p>
+<h1 id="rfc.section.3"><a href="#rfc.section.3">3.</a> <a href="#data-packing" id="data-packing">Data Packing</a></h1>
+<p id="rfc.section.3.p.1">Data serialization for properties is performed using a light-weight data packing format which was loosely inspired by D-Bus. The format of a serialization is defined by a specially formatted string.  </p>
+<p id="rfc.section.3.p.2">Goals: </p>
 <p/>
 
 <ul>
@@ -886,7 +1007,7 @@
 </ul>
 
 <p> </p>
-<p id="rfc.section.4.p.4">Each primitive datatype has an ASCII character associated with it.  Structures can be represented as strings of these characters. For example: </p>
+<p id="rfc.section.3.p.4">Each primitive datatype has an ASCII character associated with it.  Structures can be represented as strings of these characters. For example: </p>
 <p/>
 
 <ul>
@@ -896,8 +1017,8 @@
 </ul>
 
 <p> </p>
-<p id="rfc.section.4.p.6">In each case, the data is represented exactly as described. For example, an array of 10 IPv6 address is stored as 160 bytes.  </p>
-<h1 id="rfc.section.4.1"><a href="#rfc.section.4.1">4.1.</a> <a href="#primitive-types" id="primitive-types">Primitive Types</a></h1>
+<p id="rfc.section.3.p.6">In each case, the data is represented exactly as described. For example, an array of 10 IPv6 address is stored as 160 bytes.  </p>
+<h1 id="rfc.section.3.1"><a href="#rfc.section.3.1">3.1.</a> <a href="#primitive-types" id="primitive-types">Primitive Types</a></h1>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <thead>
     <tr>
@@ -968,7 +1089,7 @@
         <samp>i</samp>
       </td>
       <td class="left">DATATYPE_UINT_PACKED</td>
-      <td class="left">Packed Unsigned Integer. See <a href="#packed-unsigned-integer">Section 4.2</a>.</td>
+      <td class="left">Packed Unsigned Integer. See <a href="#packed-unsigned-integer">Section 3.2</a>.</td>
     </tr>
     <tr>
       <td class="center">
@@ -996,7 +1117,7 @@
         <samp>D</samp>
       </td>
       <td class="left">DATATYPE_DATA</td>
-      <td class="left">Arbitrary Data. See <a href="#data-blobs">Section 4.3</a>.</td>
+      <td class="left">Arbitrary Data. See <a href="#data-blobs">Section 3.3</a>.</td>
     </tr>
     <tr>
       <td class="center">
@@ -1010,22 +1131,22 @@
         <samp>T</samp>
       </td>
       <td class="left">DATATYPE_STRUCT</td>
-      <td class="left">Structured datatype. Compound type. See <a href="#structured-data">Section 4.4</a>.</td>
+      <td class="left">Structured datatype. Compound type. See <a href="#structured-data">Section 3.4</a>.</td>
     </tr>
     <tr>
       <td class="center">
         <samp>A</samp>
       </td>
       <td class="left">DATATYPE_ARRAY</td>
-      <td class="left">Array of datatypes. Compound type. See <a href="#arrays">Section 4.5</a>.</td>
+      <td class="left">Array of datatypes. Compound type. See <a href="#arrays">Section 3.5</a>.</td>
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.4.1.p.1">All multi-byte values are little-endian unless explicitly stated otherwise.  </p>
-<h1 id="rfc.section.4.2"><a href="#rfc.section.4.2">4.2.</a> <a href="#packed-unsigned-integer" id="packed-unsigned-integer">Packed Unsigned Integer</a></h1>
-<p id="rfc.section.4.2.p.1">For certain types of integers, such command or property identifiers, usually have a value on the wire that is less than 127. However, in order to not preclude the use of values larger than 255, we would need to add an extra byte. Doing this would add an extra byte to the vast majority of instances, which can add up in terms of bandwidth.  </p>
-<p id="rfc.section.4.2.p.2">The packed unsigned integer format is based on the <a href="https://www.w3.org/TR/exi/#encodingUnsignedInteger">unsigned integer format in EXI</a>, except that we limit the maximum value to the largest value that can be encoded into three bytes(2,097,151).  </p>
-<p id="rfc.section.4.2.p.3">For all values less than 127, the packed form of the number is simply a single byte which directly represents the number. For values larger than 127, the following process is used to encode the value: </p>
+<p id="rfc.section.3.1.p.1">All multi-byte values are little-endian unless explicitly stated otherwise.  </p>
+<h1 id="rfc.section.3.2"><a href="#rfc.section.3.2">3.2.</a> <a href="#packed-unsigned-integer" id="packed-unsigned-integer">Packed Unsigned Integer</a></h1>
+<p id="rfc.section.3.2.p.1">For certain types of integers, such command or property identifiers, usually have a value on the wire that is less than 127. However, in order to not preclude the use of values larger than 255, we would need to add an extra byte. Doing this would add an extra byte to the vast majority of instances, which can add up in terms of bandwidth.  </p>
+<p id="rfc.section.3.2.p.2">The packed unsigned integer format is based on the <a href="https://www.w3.org/TR/exi/#encodingUnsignedInteger">unsigned integer format in EXI</a>, except that we limit the maximum value to the largest value that can be encoded into three bytes(2,097,151).  </p>
+<p id="rfc.section.3.2.p.3">For all values less than 127, the packed form of the number is simply a single byte which directly represents the number. For values larger than 127, the following process is used to encode the value: </p>
 <p/>
 
 <ol>
@@ -1035,39 +1156,39 @@
 </ol>
 
 <p> </p>
-<p id="rfc.section.4.2.p.5">Where <em>n</em> is the smallest number of 7-bit chunks you can use to represent the given value.  </p>
-<p id="rfc.section.4.2.p.6">Take the value 1337, for example: </p>
+<p id="rfc.section.3.2.p.5">Where <em>n</em> is the smallest number of 7-bit chunks you can use to represent the given value.  </p>
+<p id="rfc.section.3.2.p.6">Take the value 1337, for example: </p>
 <pre>
 1337 =&gt; 0x0539
      =&gt; [39 0A]
      =&gt; [B9 0A]
 </pre>
-<p id="rfc.section.4.2.p.7">To decode the value, you collect the 7-bit chunks until you find an octet with the most significant bit clear.  </p>
-<h1 id="rfc.section.4.3"><a href="#rfc.section.4.3">4.3.</a> <a href="#data-blobs" id="data-blobs">Data Blobs</a></h1>
-<p id="rfc.section.4.3.p.1">Data blobs are special datatypes in that the data that they contain does not inherently define the size of the data. This means that if the length of the data blob isn't <em>implied</em>, then the length of the blob must be prepended as a packed unsigned integer.  </p>
-<p id="rfc.section.4.3.p.2">The length of a data blob is <em>implied</em> only when it is the last datatype in a given buffer. This works because we already know the size of the buffer, and the length of the data is simply the rest of the size of the buffer.  </p>
-<p id="rfc.section.4.3.p.3">For example, let's say we have a buffer that is encoded with the datatype signature of <samp>CLLD</samp>. In this case, it is pretty easy to tell where the start and end of the data blob is: the start is 9 bytes from the start of the buffer, and its length is the length of the buffer minus 9. (9 is the number of bytes taken up by a byte and two longs) </p>
-<p id="rfc.section.4.3.p.4">However, things are a little different with <samp>CLDL</samp>. Since our data blob is no longer the last item in the signature, the length must be prepended.  </p>
-<p id="rfc.section.4.3.p.5">If you are a little confused, keep reading. This theme comes up in a a few different ways in the following sections.  </p>
-<p id="rfc.section.4.3.p.6">When a length is prepended, the length is encoded as a little-endian unsigned 16-bit integer.  </p>
+<p id="rfc.section.3.2.p.7">To decode the value, you collect the 7-bit chunks until you find an octet with the most significant bit clear.  </p>
+<h1 id="rfc.section.3.3"><a href="#rfc.section.3.3">3.3.</a> <a href="#data-blobs" id="data-blobs">Data Blobs</a></h1>
+<p id="rfc.section.3.3.p.1">Data blobs are special datatypes in that the data that they contain does not inherently define the size of the data. This means that if the length of the data blob isn't <em>implied</em>, then the length of the blob must be prepended as a packed unsigned integer.  </p>
+<p id="rfc.section.3.3.p.2">The length of a data blob is <em>implied</em> only when it is the last datatype in a given buffer. This works because we already know the size of the buffer, and the length of the data is simply the rest of the size of the buffer.  </p>
+<p id="rfc.section.3.3.p.3">For example, let's say we have a buffer that is encoded with the datatype signature of <samp>CLLD</samp>. In this case, it is pretty easy to tell where the start and end of the data blob is: the start is 9 bytes from the start of the buffer, and its length is the length of the buffer minus 9. (9 is the number of bytes taken up by a byte and two longs) </p>
+<p id="rfc.section.3.3.p.4">However, things are a little different with <samp>CLDL</samp>. Since our data blob is no longer the last item in the signature, the length must be prepended.  </p>
+<p id="rfc.section.3.3.p.5">If you are a little confused, keep reading. This theme comes up in a a few different ways in the following sections.  </p>
+<p id="rfc.section.3.3.p.6">When a length is prepended, the length is encoded as a little-endian unsigned 16-bit integer.  </p>
 <p/>
 
 <ul class="empty">
-  <li>Originally the length was a <a href="#packed-unsigned-integer">Section 4.2</a>, but it was changed to an unsigned 16-bit integer in order to help reduce protocol requirements.  </li>
+  <li>Originally the length was a <a href="#packed-unsigned-integer">Section 3.2</a>, but it was changed to an unsigned 16-bit integer in order to help reduce protocol requirements.  </li>
 </ul>
-<h1 id="rfc.section.4.4"><a href="#rfc.section.4.4">4.4.</a> <a href="#structured-data" id="structured-data">Structured Data</a></h1>
-<p id="rfc.section.4.4.p.1">The structured data type is a way of bundling together a bunch of data into a single data structure. This may at first seem useless. What is the difference between <samp>T(Cii)</samp> and just <samp>Cii</samp>? The answer is, in that particular case, nothing: they are stored in exactly the same way.  </p>
-<p id="rfc.section.4.4.p.2">However, one case where the structure datatype makes a difference is when you compare <samp>T(Cii)L</samp> to <samp>CiiL</samp>: they end up being represented entirely differently. This is because the structured data type follows the exact same semantics as the data blob type: if it isn't the last datatype in a signature, <em>it must be prepended with a length</em>. This is useful because it allows for new datatypes to be appended to the structure's signature while remaining <em>backward parsing compatibility</em>.  </p>
-<p id="rfc.section.4.4.p.3">More explicitly, if you take data that was encoded with <samp>T(Cii6)L</samp>, you can still decode it as <samp>T(Cii)L</samp>.  </p>
-<p id="rfc.section.4.4.p.4">Let's take, for example, the property <samp>PROP_IPv6_ADDR_TABLE</samp>.  Conceptually it is just a list of IPv6 addresses, so we can encode it as <samp>A(6c)</samp>. However, if we ever want to associate more data with the type (like flags), we break our backward compatibility if we add another member and use <samp>A(6cC)</samp>. To allow for data to be added without breaking backward compatibility, we use the structured data type from the start: <samp>A(T(6c))</samp>. Then when we add a new member to the structure (<samp>A(T(6cC))</samp>), we don't break backward compatibility.  </p>
-<p id="rfc.section.4.4.p.5">It's also worth noting that <samp>T(Cii)L</samp> also parses as <samp>DL</samp>. You could then take the resultant data blob and parse it as <samp>Cii</samp>.  </p>
-<p id="rfc.section.4.4.p.6">When a length is prepended, the length is encoded as a little-endian unsigned 16-bit integer.  </p>
-<h1 id="rfc.section.4.5"><a href="#rfc.section.4.5">4.5.</a> <a href="#arrays" id="arrays">Arrays</a></h1>
-<p id="rfc.section.4.5.p.1">An array is simply a concatenated set of <em>n</em> data encodings. For example, the type <samp>A(6)</samp> is simply a list of IPv6 addresses---one after the other.  </p>
-<p id="rfc.section.4.5.p.2">Just like the data blob type and the structured data type, the length of the entire array must be prepended <em>unless</em> the array is the last type in a given signature. Thus, <samp>A(C)</samp> (An array of unsigned bytes) encodes identically to <samp>D</samp>.  </p>
-<p id="rfc.section.4.5.p.3">When a length is prepended, the length is encoded as a little-endian unsigned 16-bit integer.  </p>
-<h1 id="rfc.section.5"><a href="#rfc.section.5">5.</a> <a href="#commands" id="commands">Commands</a></h1>
-<h1 id="rfc.section.5.1"><a href="#rfc.section.5.1">5.1.</a> <a href="#cmd-noop" id="cmd-noop">CMD 0: (Host-&gt;NCP) CMD_NOOP</a></h1>
+<h1 id="rfc.section.3.4"><a href="#rfc.section.3.4">3.4.</a> <a href="#structured-data" id="structured-data">Structured Data</a></h1>
+<p id="rfc.section.3.4.p.1">The structured data type is a way of bundling together a bunch of data into a single data structure. This may at first seem useless. What is the difference between <samp>T(Cii)</samp> and just <samp>Cii</samp>? The answer is, in that particular case, nothing: they are stored in exactly the same way.  </p>
+<p id="rfc.section.3.4.p.2">However, one case where the structure datatype makes a difference is when you compare <samp>T(Cii)L</samp> to <samp>CiiL</samp>: they end up being represented entirely differently. This is because the structured data type follows the exact same semantics as the data blob type: if it isn't the last datatype in a signature, <em>it must be prepended with a length</em>. This is useful because it allows for new datatypes to be appended to the structure's signature while remaining <em>backward parsing compatibility</em>.  </p>
+<p id="rfc.section.3.4.p.3">More explicitly, if you take data that was encoded with <samp>T(Cii6)L</samp>, you can still decode it as <samp>T(Cii)L</samp>.  </p>
+<p id="rfc.section.3.4.p.4">Let's take, for example, the property <samp>PROP_IPv6_ADDR_TABLE</samp>.  Conceptually it is just a list of IPv6 addresses, so we can encode it as <samp>A(6c)</samp>. However, if we ever want to associate more data with the type (like flags), we break our backward compatibility if we add another member and use <samp>A(6cC)</samp>. To allow for data to be added without breaking backward compatibility, we use the structured data type from the start: <samp>A(T(6c))</samp>. Then when we add a new member to the structure (<samp>A(T(6cC))</samp>), we don't break backward compatibility.  </p>
+<p id="rfc.section.3.4.p.5">It's also worth noting that <samp>T(Cii)L</samp> also parses as <samp>DL</samp>. You could then take the resultant data blob and parse it as <samp>Cii</samp>.  </p>
+<p id="rfc.section.3.4.p.6">When a length is prepended, the length is encoded as a little-endian unsigned 16-bit integer.  </p>
+<h1 id="rfc.section.3.5"><a href="#rfc.section.3.5">3.5.</a> <a href="#arrays" id="arrays">Arrays</a></h1>
+<p id="rfc.section.3.5.p.1">An array is simply a concatenated set of <em>n</em> data encodings. For example, the type <samp>A(6)</samp> is simply a list of IPv6 addresses---one after the other.  </p>
+<p id="rfc.section.3.5.p.2">Just like the data blob type and the structured data type, the length of the entire array must be prepended <em>unless</em> the array is the last type in a given signature. Thus, <samp>A(C)</samp> (An array of unsigned bytes) encodes identically to <samp>D</samp>.  </p>
+<p id="rfc.section.3.5.p.3">When a length is prepended, the length is encoded as a little-endian unsigned 16-bit integer.  </p>
+<h1 id="rfc.section.4"><a href="#rfc.section.4">4.</a> <a href="#commands" id="commands">Commands</a></h1>
+<h1 id="rfc.section.4.1"><a href="#rfc.section.4.1">4.1.</a> <a href="#cmd-noop" id="cmd-noop">CMD 0: (Host-&gt;NCP) CMD_NOOP</a></h1>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <thead>
     <tr>
@@ -1084,10 +1205,10 @@
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.5.1.p.1">No-Operation command. Induces the NCP to send a success status back to the host. This is primarily used for liveliness checks.  </p>
-<p id="rfc.section.5.1.p.2">The command payload for this command SHOULD be empty. The receiver MUST ignore any non-empty command payload.  </p>
-<p id="rfc.section.5.1.p.3">There is no error condition for this command.  </p>
-<h1 id="rfc.section.5.2"><a href="#rfc.section.5.2">5.2.</a> <a href="#cmd-reset" id="cmd-reset">CMD 1: (Host-&gt;NCP) CMD_RESET</a></h1>
+<p id="rfc.section.4.1.p.1">No-Operation command. Induces the NCP to send a success status back to the host. This is primarily used for liveliness checks.  </p>
+<p id="rfc.section.4.1.p.2">The command payload for this command SHOULD be empty. The receiver MUST ignore any non-empty command payload.  </p>
+<p id="rfc.section.4.1.p.3">There is no error condition for this command.  </p>
+<h1 id="rfc.section.4.2"><a href="#rfc.section.4.2">4.2.</a> <a href="#cmd-reset" id="cmd-reset">CMD 1: (Host-&gt;NCP) CMD_RESET</a></h1>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <thead>
     <tr>
@@ -1104,10 +1225,10 @@
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.5.2.p.1">Reset NCP command. Causes the NCP to perform a software reset. Due to the nature of this command, the TID is ignored. The host should instead wait for a <samp>CMD_PROP_VALUE_IS</samp> command from the NCP indicating <samp>PROP_LAST_STATUS</samp> has been set to <samp>STATUS_RESET_SOFTWARE</samp>.  </p>
-<p id="rfc.section.5.2.p.2">The command payload for this command SHOULD be empty. The receiver MUST ignore any non-empty command payload.  </p>
-<p id="rfc.section.5.2.p.3">If an error occurs, the value of <samp>PROP_LAST_STATUS</samp> will be emitted instead with the value set to the generated status code for the error.  </p>
-<h1 id="rfc.section.5.3"><a href="#rfc.section.5.3">5.3.</a> <a href="#prop-value-get" id="prop-value-get">CMD 2: (Host-&gt;NCP) CMD_PROP_VALUE_GET</a></h1>
+<p id="rfc.section.4.2.p.1">Reset NCP command. Causes the NCP to perform a software reset. Due to the nature of this command, the TID is ignored. The host should instead wait for a <samp>CMD_PROP_VALUE_IS</samp> command from the NCP indicating <samp>PROP_LAST_STATUS</samp> has been set to <samp>STATUS_RESET_SOFTWARE</samp>.  </p>
+<p id="rfc.section.4.2.p.2">The command payload for this command SHOULD be empty. The receiver MUST ignore any non-empty command payload.  </p>
+<p id="rfc.section.4.2.p.3">If an error occurs, the value of <samp>PROP_LAST_STATUS</samp> will be emitted instead with the value set to the generated status code for the error.  </p>
+<h1 id="rfc.section.4.3"><a href="#rfc.section.4.3">4.3.</a> <a href="#prop-value-get" id="prop-value-get">CMD 2: (Host-&gt;NCP) CMD_PROP_VALUE_GET</a></h1>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <thead>
     <tr>
@@ -1126,10 +1247,10 @@
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.5.3.p.1">Get property value command. Causes the NCP to emit a <samp>CMD_PROP_VALUE_IS</samp> command for the given property identifier.  </p>
-<p id="rfc.section.5.3.p.2">The payload for this command is the property identifier encoded in the packed unsigned integer format described in <a href="#packed-unsigned-integer">Section 4.2</a>.  </p>
-<p id="rfc.section.5.3.p.3">If an error occurs, the value of <samp>PROP_LAST_STATUS</samp> will be emitted instead with the value set to the generated status code for the error.  </p>
-<h1 id="rfc.section.5.4"><a href="#rfc.section.5.4">5.4.</a> <a href="#prop-value-set" id="prop-value-set">CMD 3: (Host-&gt;NCP) CMD_PROP_VALUE_SET</a></h1>
+<p id="rfc.section.4.3.p.1">Get property value command. Causes the NCP to emit a <samp>CMD_PROP_VALUE_IS</samp> command for the given property identifier.  </p>
+<p id="rfc.section.4.3.p.2">The payload for this command is the property identifier encoded in the packed unsigned integer format described in <a href="#packed-unsigned-integer">Section 3.2</a>.  </p>
+<p id="rfc.section.4.3.p.3">If an error occurs, the value of <samp>PROP_LAST_STATUS</samp> will be emitted instead with the value set to the generated status code for the error.  </p>
+<h1 id="rfc.section.4.4"><a href="#rfc.section.4.4">4.4.</a> <a href="#prop-value-set" id="prop-value-set">CMD 3: (Host-&gt;NCP) CMD_PROP_VALUE_SET</a></h1>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <thead>
     <tr>
@@ -1150,10 +1271,10 @@
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.5.4.p.1">Set property value command. Instructs the NCP to set the given property to the specific given value, replacing any previous value.  </p>
-<p id="rfc.section.5.4.p.2">The payload for this command is the property identifier encoded in the packed unsigned integer format described in <a href="#packed-unsigned-integer">Section 4.2</a>, followed by the property value. The exact format of the property value is defined by the property.  </p>
-<p id="rfc.section.5.4.p.3">If an error occurs, the value of <samp>PROP_LAST_STATUS</samp> will be emitted with the value set to the generated status code for the error.  </p>
-<h1 id="rfc.section.5.5"><a href="#rfc.section.5.5">5.5.</a> <a href="#prop-value-insert" id="prop-value-insert">CMD 4: (Host-&gt;NCP) CMD_PROP_VALUE_INSERT</a></h1>
+<p id="rfc.section.4.4.p.1">Set property value command. Instructs the NCP to set the given property to the specific given value, replacing any previous value.  </p>
+<p id="rfc.section.4.4.p.2">The payload for this command is the property identifier encoded in the packed unsigned integer format described in <a href="#packed-unsigned-integer">Section 3.2</a>, followed by the property value. The exact format of the property value is defined by the property.  </p>
+<p id="rfc.section.4.4.p.3">If an error occurs, the value of <samp>PROP_LAST_STATUS</samp> will be emitted with the value set to the generated status code for the error.  </p>
+<h1 id="rfc.section.4.5"><a href="#rfc.section.4.5">4.5.</a> <a href="#prop-value-insert" id="prop-value-insert">CMD 4: (Host-&gt;NCP) CMD_PROP_VALUE_INSERT</a></h1>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <thead>
     <tr>
@@ -1174,10 +1295,10 @@
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.5.5.p.1">Insert value into property command. Instructs the NCP to insert the given value into a list-oriented property, without removing other items in the list. The resulting order of items in the list is defined by the individual property being operated on.  </p>
-<p id="rfc.section.5.5.p.2">The payload for this command is the property identifier encoded in the packed unsigned integer format described in <a href="#packed-unsigned-integer">Section 4.2</a>, followed by the value to be inserted. The exact format of the value is defined by the property.  </p>
-<p id="rfc.section.5.5.p.3">If an error occurs, the value of <samp>PROP_LAST_STATUS</samp> will be emitted with the value set to the generated status code for the error.  </p>
-<h1 id="rfc.section.5.6"><a href="#rfc.section.5.6">5.6.</a> <a href="#prop-value-remove" id="prop-value-remove">CMD 5: (Host-&gt;NCP) CMD_PROP_VALUE_REMOVE</a></h1>
+<p id="rfc.section.4.5.p.1">Insert value into property command. Instructs the NCP to insert the given value into a list-oriented property, without removing other items in the list. The resulting order of items in the list is defined by the individual property being operated on.  </p>
+<p id="rfc.section.4.5.p.2">The payload for this command is the property identifier encoded in the packed unsigned integer format described in <a href="#packed-unsigned-integer">Section 3.2</a>, followed by the value to be inserted. The exact format of the value is defined by the property.  </p>
+<p id="rfc.section.4.5.p.3">If an error occurs, the value of <samp>PROP_LAST_STATUS</samp> will be emitted with the value set to the generated status code for the error.  </p>
+<h1 id="rfc.section.4.6"><a href="#rfc.section.4.6">4.6.</a> <a href="#prop-value-remove" id="prop-value-remove">CMD 5: (Host-&gt;NCP) CMD_PROP_VALUE_REMOVE</a></h1>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <thead>
     <tr>
@@ -1198,11 +1319,11 @@
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.5.6.p.1">Remove value from property command. Instructs the NCP to remove the given value from a list-oriented property, without affecting other items in the list. The resulting order of items in the list is defined by the individual property being operated on.  </p>
-<p id="rfc.section.5.6.p.2">Note that this command operates <em>by value</em>, not by index! </p>
-<p id="rfc.section.5.6.p.3">The payload for this command is the property identifier encoded in the packed unsigned integer format described in <a href="#packed-unsigned-integer">Section 4.2</a>, followed by the value to be removed. The exact format of the value is defined by the property.  </p>
-<p id="rfc.section.5.6.p.4">If an error occurs, the value of <samp>PROP_LAST_STATUS</samp> will be emitted with the value set to the generated status code for the error.  </p>
-<h1 id="rfc.section.5.7"><a href="#rfc.section.5.7">5.7.</a> <a href="#prop-value-is" id="prop-value-is">CMD 6: (NCP-&gt;Host) CMD_PROP_VALUE_IS</a></h1>
+<p id="rfc.section.4.6.p.1">Remove value from property command. Instructs the NCP to remove the given value from a list-oriented property, without affecting other items in the list. The resulting order of items in the list is defined by the individual property being operated on.  </p>
+<p id="rfc.section.4.6.p.2">Note that this command operates <em>by value</em>, not by index! </p>
+<p id="rfc.section.4.6.p.3">The payload for this command is the property identifier encoded in the packed unsigned integer format described in <a href="#packed-unsigned-integer">Section 3.2</a>, followed by the value to be removed. The exact format of the value is defined by the property.  </p>
+<p id="rfc.section.4.6.p.4">If an error occurs, the value of <samp>PROP_LAST_STATUS</samp> will be emitted with the value set to the generated status code for the error.  </p>
+<h1 id="rfc.section.4.7"><a href="#rfc.section.4.7">4.7.</a> <a href="#prop-value-is" id="prop-value-is">CMD 6: (NCP-&gt;Host) CMD_PROP_VALUE_IS</a></h1>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <thead>
     <tr>
@@ -1223,9 +1344,9 @@
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.5.7.p.1">Property value notification command. This command can be sent by the NCP in response to a previous command from the host, or it can be sent by the NCP in an unsolicited fashion to notify the host of various state changes asynchronously.  </p>
-<p id="rfc.section.5.7.p.2">The payload for this command is the property identifier encoded in the packed unsigned integer format described in <a href="#packed-unsigned-integer">Section 4.2</a>, followed by the current value of the given property.  </p>
-<h1 id="rfc.section.5.8"><a href="#rfc.section.5.8">5.8.</a> <a href="#prop-value-inserted" id="prop-value-inserted">CMD 7: (NCP-&gt;Host) CMD_PROP_VALUE_INSERTED</a></h1>
+<p id="rfc.section.4.7.p.1">Property value notification command. This command can be sent by the NCP in response to a previous command from the host, or it can be sent by the NCP in an unsolicited fashion to notify the host of various state changes asynchronously.  </p>
+<p id="rfc.section.4.7.p.2">The payload for this command is the property identifier encoded in the packed unsigned integer format described in <a href="#packed-unsigned-integer">Section 3.2</a>, followed by the current value of the given property.  </p>
+<h1 id="rfc.section.4.8"><a href="#rfc.section.4.8">4.8.</a> <a href="#prop-value-inserted" id="prop-value-inserted">CMD 7: (NCP-&gt;Host) CMD_PROP_VALUE_INSERTED</a></h1>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <thead>
     <tr>
@@ -1246,10 +1367,10 @@
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.5.8.p.1">Property value insertion notification command. This command can be sent by the NCP in response to the <samp>CMD_PROP_VALUE_INSERT</samp> command, or it can be sent by the NCP in an unsolicited fashion to notify the host of various state changes asynchronously.  </p>
-<p id="rfc.section.5.8.p.2">The payload for this command is the property identifier encoded in the packed unsigned integer format described in <a href="#packed-unsigned-integer">Section 4.2</a>, followed by the value that was inserted into the given property.  </p>
-<p id="rfc.section.5.8.p.3">The resulting order of items in the list is defined by the given property.  </p>
-<h1 id="rfc.section.5.9"><a href="#rfc.section.5.9">5.9.</a> <a href="#prop-value-removed" id="prop-value-removed">CMD 8: (NCP-&gt;Host) CMD_PROP_VALUE_REMOVED</a></h1>
+<p id="rfc.section.4.8.p.1">Property value insertion notification command. This command can be sent by the NCP in response to the <samp>CMD_PROP_VALUE_INSERT</samp> command, or it can be sent by the NCP in an unsolicited fashion to notify the host of various state changes asynchronously.  </p>
+<p id="rfc.section.4.8.p.2">The payload for this command is the property identifier encoded in the packed unsigned integer format described in <a href="#packed-unsigned-integer">Section 3.2</a>, followed by the value that was inserted into the given property.  </p>
+<p id="rfc.section.4.8.p.3">The resulting order of items in the list is defined by the given property.  </p>
+<h1 id="rfc.section.4.9"><a href="#rfc.section.4.9">4.9.</a> <a href="#prop-value-removed" id="prop-value-removed">CMD 8: (NCP-&gt;Host) CMD_PROP_VALUE_REMOVED</a></h1>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <thead>
     <tr>
@@ -1270,13 +1391,13 @@
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.5.9.p.1">Property value removal notification command. This command can be sent by the NCP in response to the <samp>CMD_PROP_VALUE_REMOVE</samp> command, or it can be sent by the NCP in an unsolicited fashion to notify the host of various state changes asynchronously.  </p>
-<p id="rfc.section.5.9.p.2">Note that this command operates <em>by value</em>, not by index! </p>
-<p id="rfc.section.5.9.p.3">The payload for this command is the property identifier encoded in the packed unsigned integer format described in <a href="#packed-unsigned-integer">Section 4.2</a>, followed by the value that was removed from the given property.  </p>
-<p id="rfc.section.5.9.p.4">The resulting order of items in the list is defined by the given property.  </p>
-<h1 id="rfc.section.6"><a href="#rfc.section.6">6.</a> <a href="#properties" id="properties">Properties</a></h1>
-<p id="rfc.section.6.p.1">While the majority of the properties that allow the configuration of network connectivity are network protocol specific, there are several properties that are required in all implementations.  </p>
-<p id="rfc.section.6.p.2">Future property allocations SHALL be made from the following allocation plan: </p>
+<p id="rfc.section.4.9.p.1">Property value removal notification command. This command can be sent by the NCP in response to the <samp>CMD_PROP_VALUE_REMOVE</samp> command, or it can be sent by the NCP in an unsolicited fashion to notify the host of various state changes asynchronously.  </p>
+<p id="rfc.section.4.9.p.2">Note that this command operates <em>by value</em>, not by index! </p>
+<p id="rfc.section.4.9.p.3">The payload for this command is the property identifier encoded in the packed unsigned integer format described in <a href="#packed-unsigned-integer">Section 3.2</a>, followed by the value that was removed from the given property.  </p>
+<p id="rfc.section.4.9.p.4">The resulting order of items in the list is defined by the given property.  </p>
+<h1 id="rfc.section.5"><a href="#rfc.section.5">5.</a> <a href="#properties" id="properties">Properties</a></h1>
+<p id="rfc.section.5.p.1">While the majority of the properties that allow the configuration of network connectivity are network protocol specific, there are several properties that are required in all implementations.  </p>
+<p id="rfc.section.5.p.2">Future property allocations SHALL be made from the following allocation plan: </p>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <thead>
     <tr>
@@ -1307,9 +1428,9 @@
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.p.3">For an explanation of the data format encoding shorthand used throughout this document, see <a href="#data-packing">Section 4</a>.  </p>
-<h1 id="rfc.section.6.1"><a href="#rfc.section.6.1">6.1.</a> <a href="#property-sections" id="property-sections">Property Sections</a></h1>
-<p id="rfc.section.6.1.p.1">The currently assigned properties are broken up into several sections, each with reserved ranges of property identifiers.  These ranges are: </p>
+<p id="rfc.section.5.p.3">For an explanation of the data format encoding shorthand used throughout this document, see <a href="#data-packing">Section 3</a>.  </p>
+<h1 id="rfc.section.5.1"><a href="#rfc.section.5.1">5.1.</a> <a href="#property-sections" id="property-sections">Property Sections</a></h1>
+<p id="rfc.section.5.1.p.1">The currently assigned properties are broken up into several sections, each with reserved ranges of property identifiers.  These ranges are: </p>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <thead>
     <tr>
@@ -1323,28 +1444,28 @@
       <td class="center">Core</td>
       <td class="center">0x00 - 0x1F, 0x1000 - 0x11FF</td>
       <td class="center">
-        <a href="#prop-core">Section 6.2</a>
+        <a href="#prop-core">Section 5.2</a>
       </td>
     </tr>
     <tr>
       <td class="center">PHY</td>
       <td class="center">0x20 - 0x2F, 0x1200 - 0x12FF</td>
       <td class="center">
-        <a href="#prop-phy">Section 6.3</a>
+        <a href="#prop-phy">Section 5.3</a>
       </td>
     </tr>
     <tr>
       <td class="center">MAC</td>
       <td class="center">0x30 - 0x3F, 0x1300 - 0x13FF</td>
       <td class="center">
-        <a href="#prop-mac">Section 6.4</a>
+        <a href="#prop-mac">Section 5.4</a>
       </td>
     </tr>
     <tr>
       <td class="center">NET</td>
       <td class="center">0x40 - 0x4F, 0x1400 - 0x14FF</td>
       <td class="center">
-        <a href="#prop-net">Section 6.5</a>
+        <a href="#prop-net">Section 5.5</a>
       </td>
     </tr>
     <tr>
@@ -1356,21 +1477,21 @@
       <td class="center">IPv6</td>
       <td class="center">0x60 - 0x6F, 0x1600 - 0x16FF</td>
       <td class="center">
-        <a href="#prop-ipv6">Section 6.6</a>
+        <a href="#prop-ipv6">Section 5.6</a>
       </td>
     </tr>
     <tr>
       <td class="center">Stream</td>
       <td class="center">0x70 - 0x7F, 0x1700 - 0x17FF</td>
       <td class="center">
-        <a href="#prop-core">Section 6.2</a>
+        <a href="#prop-core">Section 5.2</a>
       </td>
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.1.p.2">Note that each property section has two reserved ranges: a primary range (which is encoded as a single byte) and an extended range (which is encoded as two bytes). properties which are used more frequently are generally allocated from the former range.  </p>
-<h1 id="rfc.section.6.2"><a href="#rfc.section.6.2">6.2.</a> <a href="#prop-core" id="prop-core">Core Properties</a></h1>
-<h1 id="rfc.section.6.2.1"><a href="#rfc.section.6.2.1">6.2.1.</a> <a href="#prop-last-status" id="prop-last-status">PROP 0: PROP_LAST_STATUS</a></h1>
+<p id="rfc.section.5.1.p.2">Note that each property section has two reserved ranges: a primary range (which is encoded as a single byte) and an extended range (which is encoded as two bytes). properties which are used more frequently are generally allocated from the former range.  </p>
+<h1 id="rfc.section.5.2"><a href="#rfc.section.5.2">5.2.</a> <a href="#prop-core" id="prop-core">Core Properties</a></h1>
+<h1 id="rfc.section.5.2.1"><a href="#rfc.section.5.2.1">5.2.1.</a> <a href="#prop-last-status" id="prop-last-status">PROP 0: PROP_LAST_STATUS</a></h1>
 <p/>
 
 <ul>
@@ -1393,11 +1514,11 @@
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.2.1.p.2">Describes the status of the last operation. Encoded as a packed unsigned integer.  </p>
-<p id="rfc.section.6.2.1.p.3">This property is emitted often to indicate the result status of pretty much any Host-to-NCP operation.  </p>
-<p id="rfc.section.6.2.1.p.4">It is emitted automatically at NCP startup with a value indicating the reset reason.  </p>
-<p id="rfc.section.6.2.1.p.5">See <a href="#status-codes">Section 7</a> for the complete list of status codes.  </p>
-<h1 id="rfc.section.6.2.2"><a href="#rfc.section.6.2.2">6.2.2.</a> <a href="#prop-protocol-version" id="prop-protocol-version">PROP 1: PROP_PROTOCOL_VERSION</a></h1>
+<p id="rfc.section.5.2.1.p.2">Describes the status of the last operation. Encoded as a packed unsigned integer.  </p>
+<p id="rfc.section.5.2.1.p.3">This property is emitted often to indicate the result status of pretty much any Host-to-NCP operation.  </p>
+<p id="rfc.section.5.2.1.p.4">It is emitted automatically at NCP startup with a value indicating the reset reason.  </p>
+<p id="rfc.section.5.2.1.p.5">See <a href="#status-codes">Section 6</a> for the complete list of status codes.  </p>
+<h1 id="rfc.section.5.2.2"><a href="#rfc.section.5.2.2">5.2.2.</a> <a href="#prop-protocol-version" id="prop-protocol-version">PROP 1: PROP_PROTOCOL_VERSION</a></h1>
 <p/>
 
 <ul>
@@ -1422,7 +1543,7 @@
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.2.2.p.2">Describes the protocol version information. This property contains four fields, each encoded as a packed unsigned integer: </p>
+<p id="rfc.section.5.2.2.p.2">Describes the protocol version information. This property contains four fields, each encoded as a packed unsigned integer: </p>
 <p/>
 
 <ul>
@@ -1431,13 +1552,13 @@
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.2.2.p.4">This document describes major version 4, minor version 1 of this protocol.  </p>
-<h1 id="rfc.section.6.2.2.1"><a href="#rfc.section.6.2.2.1">6.2.2.1.</a> <a href="#major-version-number" id="major-version-number">Major Version Number</a></h1>
-<p id="rfc.section.6.2.2.1.p.1">The major version number is used to identify large and incompatible differences between protocol versions.  </p>
-<p id="rfc.section.6.2.2.1.p.2">The host MUST enter a FAULT state if it does not explicitly support the given major version number.  </p>
-<h1 id="rfc.section.6.2.2.2"><a href="#rfc.section.6.2.2.2">6.2.2.2.</a> <a href="#minor-version-number" id="minor-version-number">Minor Version Number</a></h1>
-<p id="rfc.section.6.2.2.2.p.1">The minor version number is used to identify small but otherwise compatible differences between protocol versions. A mismatch between the advertised minor version number and the minor version that is supported by the host SHOULD NOT be fatal to the operation of the host.  </p>
-<h1 id="rfc.section.6.2.3"><a href="#rfc.section.6.2.3">6.2.3.</a> <a href="#prop-ncp-version" id="prop-ncp-version">PROP 2: PROP_NCP_VERSION</a></h1>
+<p id="rfc.section.5.2.2.p.4">This document describes major version 4, minor version 1 of this protocol.  </p>
+<h1 id="rfc.section.5.2.2.1"><a href="#rfc.section.5.2.2.1">5.2.2.1.</a> <a href="#major-version-number" id="major-version-number">Major Version Number</a></h1>
+<p id="rfc.section.5.2.2.1.p.1">The major version number is used to identify large and incompatible differences between protocol versions.  </p>
+<p id="rfc.section.5.2.2.1.p.2">The host MUST enter a FAULT state if it does not explicitly support the given major version number.  </p>
+<h1 id="rfc.section.5.2.2.2"><a href="#rfc.section.5.2.2.2">5.2.2.2.</a> <a href="#minor-version-number" id="minor-version-number">Minor Version Number</a></h1>
+<p id="rfc.section.5.2.2.2.p.1">The minor version number is used to identify small but otherwise compatible differences between protocol versions. A mismatch between the advertised minor version number and the minor version that is supported by the host SHOULD NOT be fatal to the operation of the host.  </p>
+<h1 id="rfc.section.5.2.3"><a href="#rfc.section.5.2.3">5.2.3.</a> <a href="#prop-ncp-version" id="prop-ncp-version">PROP 2: PROP_NCP_VERSION</a></h1>
 <p/>
 
 <ul>
@@ -1460,12 +1581,12 @@
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.2.3.p.2">Contains a string which describes the firmware currently running on the NCP. Encoded as a zero-terminated UTF-8 string.  </p>
-<p id="rfc.section.6.2.3.p.3">The format of the string is not strictly defined, but it is intended to present similarly to the "User-Agent" string from HTTP. The RECOMMENDED format of the string is as follows: </p>
+<p id="rfc.section.5.2.3.p.2">Contains a string which describes the firmware currently running on the NCP. Encoded as a zero-terminated UTF-8 string.  </p>
+<p id="rfc.section.5.2.3.p.3">The format of the string is not strictly defined, but it is intended to present similarly to the "User-Agent" string from HTTP. The RECOMMENDED format of the string is as follows: </p>
 <pre>
 STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </pre>
-<p id="rfc.section.6.2.3.p.4">Examples: </p>
+<p id="rfc.section.5.2.3.p.4">Examples: </p>
 <p/>
 
 <ul>
@@ -1478,7 +1599,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.6.2.4"><a href="#rfc.section.6.2.4">6.2.4.</a> <a href="#prop-interface-type" id="prop-interface-type">PROP 3: PROP_INTERFACE_TYPE</a></h1>
+<h1 id="rfc.section.5.2.4"><a href="#rfc.section.5.2.4">5.2.4.</a> <a href="#prop-interface-type" id="prop-interface-type">PROP 3: PROP_INTERFACE_TYPE</a></h1>
 <p/>
 
 <ul>
@@ -1501,7 +1622,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.2.4.p.2">This integer identifies what the network protocol for this NCP.  Currently defined values are: </p>
+<p id="rfc.section.5.2.4.p.2">This integer identifies what the network protocol for this NCP.  Currently defined values are: </p>
 <p/>
 
 <ul>
@@ -1511,8 +1632,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.2.4.p.4">The host MUST enter a FAULT state if it does not recognize the protocol given by the NCP.  </p>
-<h1 id="rfc.section.6.2.5"><a href="#rfc.section.6.2.5">6.2.5.</a> <a href="#prop-interface-vendor-id" id="prop-interface-vendor-id">PROP 4: PROP_INTERFACE_VENDOR_ID</a></h1>
+<p id="rfc.section.5.2.4.p.4">The host MUST enter a FAULT state if it does not recognize the protocol given by the NCP.  </p>
+<h1 id="rfc.section.5.2.5"><a href="#rfc.section.5.2.5">5.2.5.</a> <a href="#prop-interface-vendor-id" id="prop-interface-vendor-id">PROP 4: PROP_INTERFACE_VENDOR_ID</a></h1>
 <p/>
 
 <ul>
@@ -1535,8 +1656,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.2.5.p.2">Vendor identifier.  </p>
-<h1 id="rfc.section.6.2.6"><a href="#rfc.section.6.2.6">6.2.6.</a> <a href="#prop-caps" id="prop-caps">PROP 5: PROP_CAPS</a></h1>
+<p id="rfc.section.5.2.5.p.2">Vendor identifier.  </p>
+<h1 id="rfc.section.5.2.6"><a href="#rfc.section.5.2.6">5.2.6.</a> <a href="#prop-caps" id="prop-caps">PROP 5: PROP_CAPS</a></h1>
 <p/>
 
 <ul>
@@ -1563,9 +1684,9 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.2.6.p.2">Describes the supported capabilities of this NCP. Encoded as a list of packed unsigned integers.  </p>
-<p id="rfc.section.6.2.6.p.3">A capability is defined as a 21-bit integer that describes a subset of functionality which is supported by the NCP.  </p>
-<p id="rfc.section.6.2.6.p.4">Currently defined values are: </p>
+<p id="rfc.section.5.2.6.p.2">Describes the supported capabilities of this NCP. Encoded as a list of packed unsigned integers.  </p>
+<p id="rfc.section.5.2.6.p.3">A capability is defined as a 21-bit integer that describes a subset of functionality which is supported by the NCP.  </p>
+<p id="rfc.section.5.2.6.p.4">Currently defined values are: </p>
 <p/>
 
 <ul>
@@ -1591,7 +1712,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.2.6.p.6">Additionally, future capability allocations SHALL be made from the following allocation plan: </p>
+<p id="rfc.section.5.2.6.p.6">Additionally, future capability allocations SHALL be made from the following allocation plan: </p>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <thead>
     <tr>
@@ -1626,7 +1747,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
     </tr>
   </tbody>
 </table>
-<h1 id="rfc.section.6.2.7"><a href="#rfc.section.6.2.7">6.2.7.</a> <a href="#prop-interface-count" id="prop-interface-count">PROP 6: PROP_INTERFACE_COUNT</a></h1>
+<h1 id="rfc.section.5.2.7"><a href="#rfc.section.5.2.7">5.2.7.</a> <a href="#prop-interface-count" id="prop-interface-count">PROP 6: PROP_INTERFACE_COUNT</a></h1>
 <p/>
 
 <ul>
@@ -1651,9 +1772,9 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.2.7.p.2">Describes the number of concurrent interfaces supported by this NCP.  Since the concurrent interface mechanism is still TBD, this value MUST always be one.  </p>
-<p id="rfc.section.6.2.7.p.3">This value is encoded as an unsigned 8-bit integer.  </p>
-<h1 id="rfc.section.6.2.8"><a href="#rfc.section.6.2.8">6.2.8.</a> <a href="#prop-power-state" id="prop-power-state">PROP 7: PROP_POWER_STATE</a></h1>
+<p id="rfc.section.5.2.7.p.2">Describes the number of concurrent interfaces supported by this NCP.  Since the concurrent interface mechanism is still TBD, this value MUST always be one.  </p>
+<p id="rfc.section.5.2.7.p.3">This value is encoded as an unsigned 8-bit integer.  </p>
+<h1 id="rfc.section.5.2.8"><a href="#rfc.section.5.2.8">5.2.8.</a> <a href="#prop-power-state" id="prop-power-state">PROP 7: PROP_POWER_STATE</a></h1>
 <p/>
 
 <ul>
@@ -1676,8 +1797,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.2.8.p.2">Describes the current power state of the NCP. By writing to this property you can manage the lower state of the NCP. Enumeration is encoded as a single unsigned byte.  </p>
-<p id="rfc.section.6.2.8.p.3">Defined values are: </p>
+<p id="rfc.section.5.2.8.p.2">Describes the current power state of the NCP. By writing to this property you can manage the lower state of the NCP. Enumeration is encoded as a single unsigned byte.  </p>
+<p id="rfc.section.5.2.8.p.3">Defined values are: </p>
 <p/>
 
 <ul>
@@ -1689,7 +1810,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.6.2.9"><a href="#rfc.section.6.2.9">6.2.9.</a> <a href="#prop-hwaddr" id="prop-hwaddr">PROP 8: PROP_HWADDR</a></h1>
+<h1 id="rfc.section.5.2.9"><a href="#rfc.section.5.2.9">5.2.9.</a> <a href="#prop-hwaddr" id="prop-hwaddr">PROP 8: PROP_HWADDR</a></h1>
 <p/>
 
 <ul>
@@ -1712,8 +1833,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.2.9.p.2">The static EUI64 address of the device. This value is read-only, but may be writable under certain vendor-defined circumstances.  </p>
-<h1 id="rfc.section.6.2.10"><a href="#rfc.section.6.2.10">6.2.10.</a> <a href="#prop-lock" id="prop-lock">PROP 9: PROP_LOCK</a></h1>
+<p id="rfc.section.5.2.9.p.2">The static EUI64 address of the device. This value is read-only, but may be writable under certain vendor-defined circumstances.  </p>
+<h1 id="rfc.section.5.2.10"><a href="#rfc.section.5.2.10">5.2.10.</a> <a href="#prop-lock" id="prop-lock">PROP 9: PROP_LOCK</a></h1>
 <p/>
 
 <ul>
@@ -1736,10 +1857,10 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.2.10.p.2">Property lock. Used for grouping changes to several properties to take effect at once, or to temporarily prevent the automatic updating of property values. When this property is set, the execution of the NCP is effectively frozen until it is cleared.  </p>
-<p id="rfc.section.6.2.10.p.3">This property is only supported if the <samp>CAP_LOCK</samp> capability is present.  </p>
-<p id="rfc.section.6.2.10.p.4">Unlike most other properties, setting this property to true when the value of the property is already true MUST fail with a last status of <samp>STATUS_ALREADY</samp>.  </p>
-<h1 id="rfc.section.6.2.11"><a href="#rfc.section.6.2.11">6.2.11.</a> <a href="#prop-stream-debug" id="prop-stream-debug">PROP 112: PROP_STREAM_DEBUG</a></h1>
+<p id="rfc.section.5.2.10.p.2">Property lock. Used for grouping changes to several properties to take effect at once, or to temporarily prevent the automatic updating of property values. When this property is set, the execution of the NCP is effectively frozen until it is cleared.  </p>
+<p id="rfc.section.5.2.10.p.3">This property is only supported if the <samp>CAP_LOCK</samp> capability is present.  </p>
+<p id="rfc.section.5.2.10.p.4">Unlike most other properties, setting this property to true when the value of the property is already true MUST fail with a last status of <samp>STATUS_ALREADY</samp>.  </p>
+<h1 id="rfc.section.5.2.11"><a href="#rfc.section.5.2.11">5.2.11.</a> <a href="#prop-stream-debug" id="prop-stream-debug">PROP 112: PROP_STREAM_DEBUG</a></h1>
 <p/>
 
 <ul>
@@ -1762,10 +1883,10 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.2.11.p.2">This property is a streaming property, meaning that you cannot explicitly fetch the value of this property. The stream provides human-readable debugging output which may be displayed in the host logs.  </p>
-<p id="rfc.section.6.2.11.p.3">The location of newline characters is not assumed by the host: it is the NCP's responsibility to insert newline characters where needed, just like with any other text stream.  </p>
-<p id="rfc.section.6.2.11.p.4">To receive the debugging stream, you wait for <samp>CMD_PROP_VALUE_IS</samp> commands for this property from the NCP.  </p>
-<h1 id="rfc.section.6.2.12"><a href="#rfc.section.6.2.12">6.2.12.</a> <a href="#prop-stream-raw" id="prop-stream-raw">PROP 113: PROP_STREAM_RAW</a></h1>
+<p id="rfc.section.5.2.11.p.2">This property is a streaming property, meaning that you cannot explicitly fetch the value of this property. The stream provides human-readable debugging output which may be displayed in the host logs.  </p>
+<p id="rfc.section.5.2.11.p.3">The location of newline characters is not assumed by the host: it is the NCP's responsibility to insert newline characters where needed, just like with any other text stream.  </p>
+<p id="rfc.section.5.2.11.p.4">To receive the debugging stream, you wait for <samp>CMD_PROP_VALUE_IS</samp> commands for this property from the NCP.  </p>
+<h1 id="rfc.section.5.2.12"><a href="#rfc.section.5.2.12">5.2.12.</a> <a href="#prop-stream-raw" id="prop-stream-raw">PROP 113: PROP_STREAM_RAW</a></h1>
 <p/>
 
 <ul>
@@ -1792,11 +1913,11 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.2.12.p.2">This stream provides the capability of sending and receiving raw packets to and from the radio. The exact format of the frame metadata and data is dependent on the MAC and PHY being used.  </p>
-<p id="rfc.section.6.2.12.p.3">This property is a streaming property, meaning that you cannot explicitly fetch the value of this property. To receive traffic, you wait for <samp>CMD_PROP_VALUE_IS</samp> commands with this property id from the NCP.  </p>
-<p id="rfc.section.6.2.12.p.4">Implementations may optionally support the ability to transmit arbitrary raw packets. If this capability is supported, you may call <samp>CMD_PROP_VALUE_SET</samp> on this property with the value of the raw packet.  </p>
-<p id="rfc.section.6.2.12.p.5">Any data past the end of <samp>FRAME_DATA_LEN</samp> is considered metadata. The format of the metadata is defined by the associated MAC and PHY being used, and typically includes RSSI/TX-Power, LQI, etc.  </p>
-<h1 id="rfc.section.6.2.13"><a href="#rfc.section.6.2.13">6.2.13.</a> <a href="#prop-stream-net" id="prop-stream-net">PROP 114: PROP_STREAM_NET</a></h1>
+<p id="rfc.section.5.2.12.p.2">This stream provides the capability of sending and receiving raw packets to and from the radio. The exact format of the frame metadata and data is dependent on the MAC and PHY being used.  </p>
+<p id="rfc.section.5.2.12.p.3">This property is a streaming property, meaning that you cannot explicitly fetch the value of this property. To receive traffic, you wait for <samp>CMD_PROP_VALUE_IS</samp> commands with this property id from the NCP.  </p>
+<p id="rfc.section.5.2.12.p.4">Implementations may optionally support the ability to transmit arbitrary raw packets. If this capability is supported, you may call <samp>CMD_PROP_VALUE_SET</samp> on this property with the value of the raw packet.  </p>
+<p id="rfc.section.5.2.12.p.5">Any data past the end of <samp>FRAME_DATA_LEN</samp> is considered metadata. The format of the metadata is defined by the associated MAC and PHY being used, and typically includes RSSI/TX-Power, LQI, etc.  </p>
+<h1 id="rfc.section.5.2.13"><a href="#rfc.section.5.2.13">5.2.13.</a> <a href="#prop-stream-net" id="prop-stream-net">PROP 114: PROP_STREAM_NET</a></h1>
 <p/>
 
 <ul>
@@ -1823,11 +1944,11 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.2.13.p.2">This stream provides the capability of sending and receiving data packets to and from the currently attached network. The exact format of the frame metadata and data is dependent on the network protocol being used.  </p>
-<p id="rfc.section.6.2.13.p.3">This property is a streaming property, meaning that you cannot explicitly fetch the value of this property. To receive traffic, you wait for <samp>CMD_PROP_VALUE_IS</samp> commands with this property id from the NCP.  </p>
-<p id="rfc.section.6.2.13.p.4">To send network packets, you call <samp>CMD_PROP_VALUE_SET</samp> on this property with the value of the packet.  </p>
-<p id="rfc.section.6.2.13.p.5">Any data past the end of <samp>FRAME_DATA_LEN</samp> is considered metadata. The format of the metadata is defined by the associated network protocol and typically includes RSSI/TX-Power, LQI, etc.  </p>
-<h1 id="rfc.section.6.2.14"><a href="#rfc.section.6.2.14">6.2.14.</a> <a href="#prop-stream-net-insecure" id="prop-stream-net-insecure">PROP 114: PROP_STREAM_NET_INSECURE</a></h1>
+<p id="rfc.section.5.2.13.p.2">This stream provides the capability of sending and receiving data packets to and from the currently attached network. The exact format of the frame metadata and data is dependent on the network protocol being used.  </p>
+<p id="rfc.section.5.2.13.p.3">This property is a streaming property, meaning that you cannot explicitly fetch the value of this property. To receive traffic, you wait for <samp>CMD_PROP_VALUE_IS</samp> commands with this property id from the NCP.  </p>
+<p id="rfc.section.5.2.13.p.4">To send network packets, you call <samp>CMD_PROP_VALUE_SET</samp> on this property with the value of the packet.  </p>
+<p id="rfc.section.5.2.13.p.5">Any data past the end of <samp>FRAME_DATA_LEN</samp> is considered metadata. The format of the metadata is defined by the associated network protocol and typically includes RSSI/TX-Power, LQI, etc.  </p>
+<h1 id="rfc.section.5.2.14"><a href="#rfc.section.5.2.14">5.2.14.</a> <a href="#prop-stream-net-insecure" id="prop-stream-net-insecure">PROP 114: PROP_STREAM_NET_INSECURE</a></h1>
 <p/>
 
 <ul>
@@ -1854,12 +1975,12 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.2.14.p.2">This stream provides the capability of sending and receiving unencrypted and unauthenticated data packets to and from nearby devices for the purposes of device commissioning. The exact format of the frame metadata and data is dependent on the network protocol being used.  </p>
-<p id="rfc.section.6.2.14.p.3">This property is a streaming property, meaning that you cannot explicitly fetch the value of this property. To receive traffic, you wait for <samp>CMD_PROP_VALUE_IS</samp> commands with this property id from the NCP.  </p>
-<p id="rfc.section.6.2.14.p.4">To send network packets, you call <samp>CMD_PROP_VALUE_SET</samp> on this property with the value of the packet.  </p>
-<p id="rfc.section.6.2.14.p.5">Any data past the end of <samp>FRAME_DATA_LEN</samp> is considered metadata. The format of the metadata is defined by the associated network protocol, and typically includes RSSI/TX-Power, LQI, etc.  </p>
-<h1 id="rfc.section.6.3"><a href="#rfc.section.6.3">6.3.</a> <a href="#prop-phy" id="prop-phy">PHY Properties</a></h1>
-<h1 id="rfc.section.6.3.1"><a href="#rfc.section.6.3.1">6.3.1.</a> <a href="#prop-phy-enabled" id="prop-phy-enabled">PROP 32: PROP_PHY_ENABLED</a></h1>
+<p id="rfc.section.5.2.14.p.2">This stream provides the capability of sending and receiving unencrypted and unauthenticated data packets to and from nearby devices for the purposes of device commissioning. The exact format of the frame metadata and data is dependent on the network protocol being used.  </p>
+<p id="rfc.section.5.2.14.p.3">This property is a streaming property, meaning that you cannot explicitly fetch the value of this property. To receive traffic, you wait for <samp>CMD_PROP_VALUE_IS</samp> commands with this property id from the NCP.  </p>
+<p id="rfc.section.5.2.14.p.4">To send network packets, you call <samp>CMD_PROP_VALUE_SET</samp> on this property with the value of the packet.  </p>
+<p id="rfc.section.5.2.14.p.5">Any data past the end of <samp>FRAME_DATA_LEN</samp> is considered metadata. The format of the metadata is defined by the associated network protocol, and typically includes RSSI/TX-Power, LQI, etc.  </p>
+<h1 id="rfc.section.5.3"><a href="#rfc.section.5.3">5.3.</a> <a href="#prop-phy" id="prop-phy">PHY Properties</a></h1>
+<h1 id="rfc.section.5.3.1"><a href="#rfc.section.5.3.1">5.3.1.</a> <a href="#prop-phy-enabled" id="prop-phy-enabled">PROP 32: PROP_PHY_ENABLED</a></h1>
 <p/>
 
 <ul>
@@ -1868,8 +1989,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.3.1.p.2">Set to 1 if the PHY is enabled, set to 0 otherwise.  May be directly enabled to bypass higher-level packet processing in order to implement things like packet sniffers.  </p>
-<h1 id="rfc.section.6.3.2"><a href="#rfc.section.6.3.2">6.3.2.</a> <a href="#prop-phy-chan" id="prop-phy-chan">PROP 33: PROP_PHY_CHAN</a></h1>
+<p id="rfc.section.5.3.1.p.2">Set to 1 if the PHY is enabled, set to 0 otherwise.  May be directly enabled to bypass higher-level packet processing in order to implement things like packet sniffers.  </p>
+<h1 id="rfc.section.5.3.2"><a href="#rfc.section.5.3.2">5.3.2.</a> <a href="#prop-phy-chan" id="prop-phy-chan">PROP 33: PROP_PHY_CHAN</a></h1>
 <p/>
 
 <ul>
@@ -1878,8 +1999,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.3.2.p.2">Value is the current channel. Must be set to one of the values contained in <samp>PROP_PHY_CHAN_SUPPORTED</samp>.  </p>
-<h1 id="rfc.section.6.3.3"><a href="#rfc.section.6.3.3">6.3.3.</a> <a href="#prop-phy-chan-supported" id="prop-phy-chan-supported">PROP 34: PROP_PHY_CHAN_SUPPORTED</a></h1>
+<p id="rfc.section.5.3.2.p.2">Value is the current channel. Must be set to one of the values contained in <samp>PROP_PHY_CHAN_SUPPORTED</samp>.  </p>
+<h1 id="rfc.section.5.3.3"><a href="#rfc.section.5.3.3">5.3.3.</a> <a href="#prop-phy-chan-supported" id="prop-phy-chan-supported">PROP 34: PROP_PHY_CHAN_SUPPORTED</a></h1>
 <p/>
 
 <ul>
@@ -1889,8 +2010,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.3.3.p.2">Value is a list of channel values that are supported by the hardware.  </p>
-<h1 id="rfc.section.6.3.4"><a href="#rfc.section.6.3.4">6.3.4.</a> <a href="#prop-phy-freq" id="prop-phy-freq">PROP 35: PROP_PHY_FREQ</a></h1>
+<p id="rfc.section.5.3.3.p.2">Value is a list of channel values that are supported by the hardware.  </p>
+<h1 id="rfc.section.5.3.4"><a href="#rfc.section.5.3.4">5.3.4.</a> <a href="#prop-phy-freq" id="prop-phy-freq">PROP 35: PROP_PHY_FREQ</a></h1>
 <p/>
 
 <ul>
@@ -1900,8 +2021,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.3.4.p.2">Value is the radio frequency (in kilohertz) of the current channel.  </p>
-<h1 id="rfc.section.6.3.5"><a href="#rfc.section.6.3.5">6.3.5.</a> <a href="#prop-phy-cca-threshold" id="prop-phy-cca-threshold">PROP 36: PROP_PHY_CCA_THRESHOLD</a></h1>
+<p id="rfc.section.5.3.4.p.2">Value is the radio frequency (in kilohertz) of the current channel.  </p>
+<h1 id="rfc.section.5.3.5"><a href="#rfc.section.5.3.5">5.3.5.</a> <a href="#prop-phy-cca-threshold" id="prop-phy-cca-threshold">PROP 36: PROP_PHY_CCA_THRESHOLD</a></h1>
 <p/>
 
 <ul>
@@ -1911,9 +2032,9 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.3.5.p.2">Value is the CCA (clear-channel assessment) threshold. Set to -128 to disable.  </p>
-<p id="rfc.section.6.3.5.p.3">When setting, the value will be rounded down to a value that is supported by the underlying radio hardware.  </p>
-<h1 id="rfc.section.6.3.6"><a href="#rfc.section.6.3.6">6.3.6.</a> <a href="#prop-phy-tx-power" id="prop-phy-tx-power">PROP 37: PROP_PHY_TX_POWER</a></h1>
+<p id="rfc.section.5.3.5.p.2">Value is the CCA (clear-channel assessment) threshold. Set to -128 to disable.  </p>
+<p id="rfc.section.5.3.5.p.3">When setting, the value will be rounded down to a value that is supported by the underlying radio hardware.  </p>
+<h1 id="rfc.section.5.3.6"><a href="#rfc.section.5.3.6">5.3.6.</a> <a href="#prop-phy-tx-power" id="prop-phy-tx-power">PROP 37: PROP_PHY_TX_POWER</a></h1>
 <p/>
 
 <ul>
@@ -1923,9 +2044,9 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.3.6.p.2">Value is the transmit power of the radio.  </p>
-<p id="rfc.section.6.3.6.p.3">When setting, the value will be rounded down to a value that is supported by the underlying radio hardware.  </p>
-<h1 id="rfc.section.6.3.7"><a href="#rfc.section.6.3.7">6.3.7.</a> <a href="#prop-phy-rssi" id="prop-phy-rssi">PROP 38: PROP_PHY_RSSI</a></h1>
+<p id="rfc.section.5.3.6.p.2">Value is the transmit power of the radio.  </p>
+<p id="rfc.section.5.3.6.p.3">When setting, the value will be rounded down to a value that is supported by the underlying radio hardware.  </p>
+<h1 id="rfc.section.5.3.7"><a href="#rfc.section.5.3.7">5.3.7.</a> <a href="#prop-phy-rssi" id="prop-phy-rssi">PROP 38: PROP_PHY_RSSI</a></h1>
 <p/>
 
 <ul>
@@ -1935,9 +2056,9 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.3.7.p.2">Value is the current RSSI (Received signal strength indication) from the radio. This value can be used in energy scans and for determining the ambient noise floor for the operating environment.  </p>
-<h1 id="rfc.section.6.4"><a href="#rfc.section.6.4">6.4.</a> <a href="#prop-mac" id="prop-mac">MAC Properties</a></h1>
-<h1 id="rfc.section.6.4.1"><a href="#rfc.section.6.4.1">6.4.1.</a> <a href="#prop-mac-scan-state" id="prop-mac-scan-state">PROP 48: PROP_MAC_SCAN_STATE</a></h1>
+<p id="rfc.section.5.3.7.p.2">Value is the current RSSI (Received signal strength indication) from the radio. This value can be used in energy scans and for determining the ambient noise floor for the operating environment.  </p>
+<h1 id="rfc.section.5.4"><a href="#rfc.section.5.4">5.4.</a> <a href="#prop-mac" id="prop-mac">MAC Properties</a></h1>
+<h1 id="rfc.section.5.4.1"><a href="#rfc.section.5.4.1">5.4.1.</a> <a href="#prop-mac-scan-state" id="prop-mac-scan-state">PROP 48: PROP_MAC_SCAN_STATE</a></h1>
 <p/>
 
 <ul>
@@ -1947,7 +2068,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.4.1.p.2">Possible Values: </p>
+<p id="rfc.section.5.4.1.p.2">Possible Values: </p>
 <p/>
 
 <ul>
@@ -1957,10 +2078,10 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.4.1.p.4">Set to <samp>SCAN_STATE_BEACON</samp> to start an active scan.  Beacons will be emitted from <samp>PROP_MAC_SCAN_BEACON</samp>.  </p>
-<p id="rfc.section.6.4.1.p.5">Set to <samp>SCAN_STATE_ENERGY</samp> to start an energy scan.  Channel energy will be reported by alternating emissions of <samp>PROP_PHY_CHAN</samp> and <samp>PROP_PHY_RSSI</samp>.  </p>
-<p id="rfc.section.6.4.1.p.6">Values switches to <samp>SCAN_STATE_IDLE</samp> when scan is complete.  </p>
-<h1 id="rfc.section.6.4.2"><a href="#rfc.section.6.4.2">6.4.2.</a> <a href="#prop-mac-scan-mask" id="prop-mac-scan-mask">PROP 49: PROP_MAC_SCAN_MASK</a></h1>
+<p id="rfc.section.5.4.1.p.4">Set to <samp>SCAN_STATE_BEACON</samp> to start an active scan.  Beacons will be emitted from <samp>PROP_MAC_SCAN_BEACON</samp>.  </p>
+<p id="rfc.section.5.4.1.p.5">Set to <samp>SCAN_STATE_ENERGY</samp> to start an energy scan.  Channel energy will be reported by alternating emissions of <samp>PROP_PHY_CHAN</samp> and <samp>PROP_PHY_RSSI</samp>.  </p>
+<p id="rfc.section.5.4.1.p.6">Values switches to <samp>SCAN_STATE_IDLE</samp> when scan is complete.  </p>
+<h1 id="rfc.section.5.4.2"><a href="#rfc.section.5.4.2">5.4.2.</a> <a href="#prop-mac-scan-mask" id="prop-mac-scan-mask">PROP 49: PROP_MAC_SCAN_MASK</a></h1>
 <p/>
 
 <ul>
@@ -1970,7 +2091,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.6.4.3"><a href="#rfc.section.6.4.3">6.4.3.</a> <a href="#prop-mac-scan-period" id="prop-mac-scan-period">PROP 50: PROP_MAC_SCAN_PERIOD</a></h1>
+<h1 id="rfc.section.5.4.3"><a href="#rfc.section.5.4.3">5.4.3.</a> <a href="#prop-mac-scan-period" id="prop-mac-scan-period">PROP 50: PROP_MAC_SCAN_PERIOD</a></h1>
 <p/>
 
 <ul>
@@ -1980,7 +2101,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.6.4.4"><a href="#rfc.section.6.4.4">6.4.4.</a> <a href="#prop-mac-scan-beacon" id="prop-mac-scan-beacon">PROP 51: PROP_MAC_SCAN_BEACON</a></h1>
+<h1 id="rfc.section.5.4.4"><a href="#rfc.section.5.4.4">5.4.4.</a> <a href="#prop-mac-scan-beacon" id="prop-mac-scan-beacon">PROP 51: PROP_MAC_SCAN_BEACON</a></h1>
 <p/>
 
 <ul>
@@ -2013,7 +2134,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.4.4.p.2">Scan beacons have two embedded structures which contain information about the MAC layer and the NET layer. Their format depends on the MAC and NET layer currently in use.  The format below is for an 802.15.4 MAC with Thread: </p>
+<p id="rfc.section.5.4.4.p.2">Scan beacons have two embedded structures which contain information about the MAC layer and the NET layer. Their format depends on the MAC and NET layer currently in use.  The format below is for an 802.15.4 MAC with Thread: </p>
 <p/>
 
 <ul>
@@ -2024,8 +2145,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.4.4.p.4">Extra parameters may be added to each of the structures in the future, so care should be taken to read the length that prepends each structure.  </p>
-<h1 id="rfc.section.6.4.5"><a href="#rfc.section.6.4.5">6.4.5.</a> <a href="#prop-mac-15-4-laddr" id="prop-mac-15-4-laddr">PROP 52: PROP_MAC_15_4_LADDR</a></h1>
+<p id="rfc.section.5.4.4.p.4">Extra parameters may be added to each of the structures in the future, so care should be taken to read the length that prepends each structure.  </p>
+<h1 id="rfc.section.5.4.5"><a href="#rfc.section.5.4.5">5.4.5.</a> <a href="#prop-mac-15-4-laddr" id="prop-mac-15-4-laddr">PROP 52: PROP_MAC_15_4_LADDR</a></h1>
 <p/>
 
 <ul>
@@ -2034,9 +2155,9 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.4.5.p.2">The 802.15.4 long address of this node.  </p>
-<p id="rfc.section.6.4.5.p.3">This property is only present on NCPs which implement 802.15.4 </p>
-<h1 id="rfc.section.6.4.6"><a href="#rfc.section.6.4.6">6.4.6.</a> <a href="#prop-mac-15-4-saddr" id="prop-mac-15-4-saddr">PROP 53: PROP_MAC_15_4_SADDR</a></h1>
+<p id="rfc.section.5.4.5.p.2">The 802.15.4 long address of this node.  </p>
+<p id="rfc.section.5.4.5.p.3">This property is only present on NCPs which implement 802.15.4 </p>
+<h1 id="rfc.section.5.4.6"><a href="#rfc.section.5.4.6">5.4.6.</a> <a href="#prop-mac-15-4-saddr" id="prop-mac-15-4-saddr">PROP 53: PROP_MAC_15_4_SADDR</a></h1>
 <p/>
 
 <ul>
@@ -2045,9 +2166,9 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.4.6.p.2">The 802.15.4 short address of this node.  </p>
-<p id="rfc.section.6.4.6.p.3">This property is only present on NCPs which implement 802.15.4 </p>
-<h1 id="rfc.section.6.4.7"><a href="#rfc.section.6.4.7">6.4.7.</a> <a href="#prop-mac-15-4-panid" id="prop-mac-15-4-panid">PROP 54: PROP_MAC_15_4_PANID</a></h1>
+<p id="rfc.section.5.4.6.p.2">The 802.15.4 short address of this node.  </p>
+<p id="rfc.section.5.4.6.p.3">This property is only present on NCPs which implement 802.15.4 </p>
+<h1 id="rfc.section.5.4.7"><a href="#rfc.section.5.4.7">5.4.7.</a> <a href="#prop-mac-15-4-panid" id="prop-mac-15-4-panid">PROP 54: PROP_MAC_15_4_PANID</a></h1>
 <p/>
 
 <ul>
@@ -2056,9 +2177,9 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.4.7.p.2">The 802.15.4 PANID this node is associated with.  </p>
-<p id="rfc.section.6.4.7.p.3">This property is only present on NCPs which implement 802.15.4 </p>
-<h1 id="rfc.section.6.4.8"><a href="#rfc.section.6.4.8">6.4.8.</a> <a href="#prop-mac-raw-stream-enabled" id="prop-mac-raw-stream-enabled">PROP 55: PROP_MAC_RAW_STREAM_ENABLED</a></h1>
+<p id="rfc.section.5.4.7.p.2">The 802.15.4 PANID this node is associated with.  </p>
+<p id="rfc.section.5.4.7.p.3">This property is only present on NCPs which implement 802.15.4 </p>
+<h1 id="rfc.section.5.4.8"><a href="#rfc.section.5.4.8">5.4.8.</a> <a href="#prop-mac-raw-stream-enabled" id="prop-mac-raw-stream-enabled">PROP 55: PROP_MAC_RAW_STREAM_ENABLED</a></h1>
 <p/>
 
 <ul>
@@ -2067,8 +2188,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.4.8.p.2">Set to true to enable raw MAC frames to be emitted from <samp>PROP_STREAM_RAW</samp>.  See <a href="#prop-stream-raw">Section 6.2.12</a>.  </p>
-<h1 id="rfc.section.6.4.9"><a href="#rfc.section.6.4.9">6.4.9.</a> <a href="#prop-mac-filter-mode" id="prop-mac-filter-mode">PROP 56: PROP_MAC_FILTER_MODE</a></h1>
+<p id="rfc.section.5.4.8.p.2">Set to true to enable raw MAC frames to be emitted from <samp>PROP_STREAM_RAW</samp>.  See <a href="#prop-stream-raw">Section 5.2.12</a>.  </p>
+<h1 id="rfc.section.5.4.9"><a href="#rfc.section.5.4.9">5.4.9.</a> <a href="#prop-mac-filter-mode" id="prop-mac-filter-mode">PROP 56: PROP_MAC_FILTER_MODE</a></h1>
 <p/>
 
 <ul>
@@ -2077,7 +2198,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.4.9.p.2">Possible Values: </p>
+<p id="rfc.section.5.4.9.p.2">Possible Values: </p>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <thead>
     <tr>
@@ -2110,8 +2231,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.6.4.9.p.3">See <a href="#prop-stream-raw">Section 6.2.12</a>.  </p>
-<h1 id="rfc.section.6.4.10"><a href="#rfc.section.6.4.10">6.4.10.</a> <a href="#prop-mac-whitelist" id="prop-mac-whitelist">PROP 4864: PROP_MAC_WHITELIST</a></h1>
+<p id="rfc.section.5.4.9.p.3">See <a href="#prop-stream-raw">Section 5.2.12</a>.  </p>
+<h1 id="rfc.section.5.4.10"><a href="#rfc.section.5.4.10">5.4.10.</a> <a href="#prop-mac-whitelist" id="prop-mac-whitelist">PROP 4864: PROP_MAC_WHITELIST</a></h1>
 <p/>
 
 <ul>
@@ -2121,16 +2242,16 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.4.10.p.2">Structure Parameters: </p>
+<p id="rfc.section.5.4.10.p.2">Structure Parameters: </p>
 <p/>
 
 <ul>
   <li><samp>E</samp>: EUI64 address of node</li>
-  <li><samp>c</samp>: Optional RSSI-override value. The value 127 indicates that the RSSI-override feature is not enabled for this address. If this value is ommitted when setting or inserting, it is assumed to be 127. This parameter is ignored when removing.</li>
+  <li><samp>c</samp>: Optional RSSI-override value. The value 127 indicates that the RSSI-override feature is not enabled for this address. If this value is omitted when setting or inserting, it is assumed to be 127. This parameter is ignored when removing.</li>
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.6.4.11"><a href="#rfc.section.6.4.11">6.4.11.</a> <a href="#prop-mac-whitelist-enabled" id="prop-mac-whitelist-enabled">PROP 4865: PROP_MAC_WHITELIST_ENABLED</a></h1>
+<h1 id="rfc.section.5.4.11"><a href="#rfc.section.5.4.11">5.4.11.</a> <a href="#prop-mac-whitelist-enabled" id="prop-mac-whitelist-enabled">PROP 4865: PROP_MAC_WHITELIST_ENABLED</a></h1>
 <p/>
 
 <ul>
@@ -2139,8 +2260,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.6.5"><a href="#rfc.section.6.5">6.5.</a> <a href="#prop-net" id="prop-net">NET Properties</a></h1>
-<h1 id="rfc.section.6.5.1"><a href="#rfc.section.6.5.1">6.5.1.</a> <a href="#prop-net-saved" id="prop-net-saved">PROP 64: PROP_NET_SAVED</a></h1>
+<h1 id="rfc.section.5.5"><a href="#rfc.section.5.5">5.5.</a> <a href="#prop-net" id="prop-net">NET Properties</a></h1>
+<h1 id="rfc.section.5.5.1"><a href="#rfc.section.5.5.1">5.5.1.</a> <a href="#prop-net-saved" id="prop-net-saved">PROP 64: PROP_NET_SAVED</a></h1>
 <p/>
 
 <ul>
@@ -2149,8 +2270,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.5.1.p.2">Returns true if there is a network state stored that can be restored with a call to <samp>CMD_NET_RECALL</samp>.  </p>
-<h1 id="rfc.section.6.5.2"><a href="#rfc.section.6.5.2">6.5.2.</a> <a href="#prop-net-if-up" id="prop-net-if-up">PROP 65: PROP_NET_IF_UP</a></h1>
+<p id="rfc.section.5.5.1.p.2">Returns true if there is a network state stored that can be restored with a call to <samp>CMD_NET_RECALL</samp>.  </p>
+<h1 id="rfc.section.5.5.2"><a href="#rfc.section.5.5.2">5.5.2.</a> <a href="#prop-net-if-up" id="prop-net-if-up">PROP 65: PROP_NET_IF_UP</a></h1>
 <p/>
 
 <ul>
@@ -2159,8 +2280,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.5.2.p.2">Network interface up/down status. Non-zero (set to 1) indicates up, zero indicates down.  </p>
-<h1 id="rfc.section.6.5.3"><a href="#rfc.section.6.5.3">6.5.3.</a> <a href="#prop-net-stack-up" id="prop-net-stack-up">PROP 66: PROP_NET_STACK_UP</a></h1>
+<p id="rfc.section.5.5.2.p.2">Network interface up/down status. Non-zero (set to 1) indicates up, zero indicates down.  </p>
+<h1 id="rfc.section.5.5.3"><a href="#rfc.section.5.5.3">5.5.3.</a> <a href="#prop-net-stack-up" id="prop-net-stack-up">PROP 66: PROP_NET_STACK_UP</a></h1>
 <p/>
 
 <ul>
@@ -2170,8 +2291,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.5.3.p.2">Thread stack operational status. Non-zero (set to 1) indicates up, zero indicates down.  </p>
-<h1 id="rfc.section.6.5.4"><a href="#rfc.section.6.5.4">6.5.4.</a> <a href="#prop-net-role" id="prop-net-role">PROP 67: PROP_NET_ROLE</a></h1>
+<p id="rfc.section.5.5.3.p.2">Thread stack operational status. Non-zero (set to 1) indicates up, zero indicates down.  </p>
+<h1 id="rfc.section.5.5.4"><a href="#rfc.section.5.5.4">5.5.4.</a> <a href="#prop-net-role" id="prop-net-role">PROP 67: PROP_NET_ROLE</a></h1>
 <p/>
 
 <ul>
@@ -2181,7 +2302,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.5.4.p.2">Values: </p>
+<p id="rfc.section.5.5.4.p.2">Values: </p>
 <p/>
 
 <ul>
@@ -2192,7 +2313,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.6.5.5"><a href="#rfc.section.6.5.5">6.5.5.</a> <a href="#prop-net-network-name" id="prop-net-network-name">PROP 68: PROP_NET_NETWORK_NAME</a></h1>
+<h1 id="rfc.section.5.5.5"><a href="#rfc.section.5.5.5">5.5.5.</a> <a href="#prop-net-network-name" id="prop-net-network-name">PROP 68: PROP_NET_NETWORK_NAME</a></h1>
 <p/>
 
 <ul>
@@ -2201,7 +2322,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.6.5.6"><a href="#rfc.section.6.5.6">6.5.6.</a> <a href="#prop-net-xpanid" id="prop-net-xpanid">PROP 69: PROP_NET_XPANID</a></h1>
+<h1 id="rfc.section.5.5.6"><a href="#rfc.section.5.5.6">5.5.6.</a> <a href="#prop-net-xpanid" id="prop-net-xpanid">PROP 69: PROP_NET_XPANID</a></h1>
 <p/>
 
 <ul>
@@ -2210,7 +2331,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.6.5.7"><a href="#rfc.section.6.5.7">6.5.7.</a> <a href="#prop-net-master-key" id="prop-net-master-key">PROP 70: PROP_NET_MASTER_KEY</a></h1>
+<h1 id="rfc.section.5.5.7"><a href="#rfc.section.5.5.7">5.5.7.</a> <a href="#prop-net-master-key" id="prop-net-master-key">PROP 70: PROP_NET_MASTER_KEY</a></h1>
 <p/>
 
 <ul>
@@ -2219,7 +2340,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.6.5.8"><a href="#rfc.section.6.5.8">6.5.8.</a> <a href="#prop-net-key-sequence" id="prop-net-key-sequence">PROP 71: PROP_NET_KEY_SEQUENCE</a></h1>
+<h1 id="rfc.section.5.5.8"><a href="#rfc.section.5.5.8">5.5.8.</a> <a href="#prop-net-key-sequence" id="prop-net-key-sequence">PROP 71: PROP_NET_KEY_SEQUENCE</a></h1>
 <p/>
 
 <ul>
@@ -2228,7 +2349,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.6.5.9"><a href="#rfc.section.6.5.9">6.5.9.</a> <a href="#prop-net-partition-id" id="prop-net-partition-id">PROP 72: PROP_NET_PARTITION_ID</a></h1>
+<h1 id="rfc.section.5.5.9"><a href="#rfc.section.5.5.9">5.5.9.</a> <a href="#prop-net-partition-id" id="prop-net-partition-id">PROP 72: PROP_NET_PARTITION_ID</a></h1>
 <p/>
 
 <ul>
@@ -2237,9 +2358,9 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.5.9.p.2">The partition ID of the partition that this node is a member of.  </p>
-<h1 id="rfc.section.6.6"><a href="#rfc.section.6.6">6.6.</a> <a href="#prop-ipv6" id="prop-ipv6">IPv6 Properties</a></h1>
-<h1 id="rfc.section.6.6.1"><a href="#rfc.section.6.6.1">6.6.1.</a> <a href="#prop-ipv6-ll-addr" id="prop-ipv6-ll-addr">PROP 96: PROP_IPV6_LL_ADDR</a></h1>
+<p id="rfc.section.5.5.9.p.2">The partition ID of the partition that this node is a member of.  </p>
+<h1 id="rfc.section.5.6"><a href="#rfc.section.5.6">5.6.</a> <a href="#prop-ipv6" id="prop-ipv6">IPv6 Properties</a></h1>
+<h1 id="rfc.section.5.6.1"><a href="#rfc.section.5.6.1">5.6.1.</a> <a href="#prop-ipv6-ll-addr" id="prop-ipv6-ll-addr">PROP 96: PROP_IPV6_LL_ADDR</a></h1>
 <p/>
 
 <ul>
@@ -2248,8 +2369,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.6.1.p.2">IPv6 Address </p>
-<h1 id="rfc.section.6.6.2"><a href="#rfc.section.6.6.2">6.6.2.</a> <a href="#prop-ipv6-ml-addr" id="prop-ipv6-ml-addr">PROP 97: PROP_IPV6_ML_ADDR</a></h1>
+<p id="rfc.section.5.6.1.p.2">IPv6 Address </p>
+<h1 id="rfc.section.5.6.2"><a href="#rfc.section.5.6.2">5.6.2.</a> <a href="#prop-ipv6-ml-addr" id="prop-ipv6-ml-addr">PROP 97: PROP_IPV6_ML_ADDR</a></h1>
 <p/>
 
 <ul>
@@ -2258,8 +2379,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.6.2.p.2">IPv6 Address + Prefix Length </p>
-<h1 id="rfc.section.6.6.3"><a href="#rfc.section.6.6.3">6.6.3.</a> <a href="#prop-ipv6-ml-prefix" id="prop-ipv6-ml-prefix">PROP 98: PROP_IPV6_ML_PREFIX</a></h1>
+<p id="rfc.section.5.6.2.p.2">IPv6 Address + Prefix Length </p>
+<h1 id="rfc.section.5.6.3"><a href="#rfc.section.5.6.3">5.6.3.</a> <a href="#prop-ipv6-ml-prefix" id="prop-ipv6-ml-prefix">PROP 98: PROP_IPV6_ML_PREFIX</a></h1>
 <p/>
 
 <ul>
@@ -2268,8 +2389,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.6.3.p.2">IPv6 Prefix + Prefix Length </p>
-<h1 id="rfc.section.6.6.4"><a href="#rfc.section.6.6.4">6.6.4.</a> <a href="#prop-ipv6-address-table" id="prop-ipv6-address-table">PROP 99: PROP_IPV6_ADDRESS_TABLE</a></h1>
+<p id="rfc.section.5.6.3.p.2">IPv6 Prefix + Prefix Length </p>
+<h1 id="rfc.section.5.6.4"><a href="#rfc.section.5.6.4">5.6.4.</a> <a href="#prop-ipv6-address-table" id="prop-ipv6-address-table">PROP 99: PROP_IPV6_ADDRESS_TABLE</a></h1>
 <p/>
 
 <ul>
@@ -2278,7 +2399,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.6.4.p.2">Array of structures containing: </p>
+<p id="rfc.section.5.6.4.p.2">Array of structures containing: </p>
 <p/>
 
 <ul>
@@ -2290,7 +2411,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.6.6.5"><a href="#rfc.section.6.6.5">6.6.5.</a> <a href="#prop-101-propipv6icmppingoffload" id="prop-101-propipv6icmppingoffload">PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD</a></h1>
+<h1 id="rfc.section.5.6.5"><a href="#rfc.section.5.6.5">5.6.5.</a> <a href="#prop-101-propipv6icmppingoffload" id="prop-101-propipv6icmppingoffload">PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD</a></h1>
 <p/>
 
 <ul>
@@ -2299,12 +2420,12 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.6.6.5.p.2">Allow the NCP to directly respond to ICMP ping requests. If this is turned on, ping request ICMP packets will not be passed to the host.  </p>
-<p id="rfc.section.6.6.5.p.3">Default value is <samp>false</samp>.  </p>
-<h1 id="rfc.section.7"><a href="#rfc.section.7">7.</a> <a href="#status-codes" id="status-codes">Status Codes</a></h1>
-<p id="rfc.section.7.p.1">Status codes are sent from the NCP to the host via <samp>PROP_LAST_STATUS</samp> using the <samp>CMD_VALUE_IS</samp> command to indicate the return status of a previous command. As with any response, the TID field of the FLAG byte is used to correlate the response with the request.  </p>
-<p id="rfc.section.7.p.2">Note that most successfully executed commands do not indicate a last status of <samp>STATUS_OK</samp>. The usual way the NCP indicates a successful command is to mirror the property change back to the host. For example, if you do a <samp>CMD_VALUE_SET</samp> on <samp>PROP_PHY_ENABLED</samp>, the NCP would indicate success by responding with a <samp>CMD_VALUE_IS</samp> for <samp>PROP_PHY_ENABLED</samp>. If the command failed, <samp>PROP_LAST_STATUS</samp> would be emitted instead.  </p>
-<p id="rfc.section.7.p.3">See <a href="#prop-last-status">Section 6.2.1</a> for more information on <samp>PROP_LAST_STATUS</samp>.  </p>
+<p id="rfc.section.5.6.5.p.2">Allow the NCP to directly respond to ICMP ping requests. If this is turned on, ping request ICMP packets will not be passed to the host.  </p>
+<p id="rfc.section.5.6.5.p.3">Default value is <samp>false</samp>.  </p>
+<h1 id="rfc.section.6"><a href="#rfc.section.6">6.</a> <a href="#status-codes" id="status-codes">Status Codes</a></h1>
+<p id="rfc.section.6.p.1">Status codes are sent from the NCP to the host via <samp>PROP_LAST_STATUS</samp> using the <samp>CMD_VALUE_IS</samp> command to indicate the return status of a previous command. As with any response, the TID field of the FLAG byte is used to correlate the response with the request.  </p>
+<p id="rfc.section.6.p.2">Note that most successfully executed commands do not indicate a last status of <samp>STATUS_OK</samp>. The usual way the NCP indicates a successful command is to mirror the property change back to the host. For example, if you do a <samp>CMD_VALUE_SET</samp> on <samp>PROP_PHY_ENABLED</samp>, the NCP would indicate success by responding with a <samp>CMD_VALUE_IS</samp> for <samp>PROP_PHY_ENABLED</samp>. If the command failed, <samp>PROP_LAST_STATUS</samp> would be emitted instead.  </p>
+<p id="rfc.section.6.p.3">See <a href="#prop-last-status">Section 5.2.1</a> for more information on <samp>PROP_LAST_STATUS</samp>.  </p>
 <p/>
 
 <ul>
@@ -2315,9 +2436,9 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
   <li>4: <samp>STATUS_INVALID_STATE</samp> : The given operation is invalid for the current state of the device.</li>
   <li>5: <samp>STATUS_INVALID_COMMAND</samp>: The given command is not recognized.</li>
   <li>6: <samp>STATUS_INVALID_INTERFACE</samp>: The given Spinel interface is not supported.</li>
-  <li>7: <samp>STATUS_INTERNAL_ERROR</samp>: An internal runtime error has occured.</li>
-  <li>8: <samp>STATUS_SECURITY_ERROR</samp>: A security or authentication error has occured.</li>
-  <li>9: <samp>STATUS_PARSE_ERROR</samp>: An error has occured while parsing the command.</li>
+  <li>7: <samp>STATUS_INTERNAL_ERROR</samp>: An internal runtime error has occurred.</li>
+  <li>8: <samp>STATUS_SECURITY_ERROR</samp>: A security or authentication error has occurred.</li>
+  <li>9: <samp>STATUS_PARSE_ERROR</samp>: An error has occurred while parsing the command.</li>
   <li>10: <samp>STATUS_IN_PROGRESS</samp>: The operation is in progress and will be completed asynchronously.</li>
   <li>11: <samp>STATUS_NOMEM</samp>: The operation has been prevented due to memory pressure.</li>
   <li>12: <samp>STATUS_BUSY</samp>: The device is currently performing a mutually exclusive operation.</li>
@@ -2338,6 +2459,14 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
+<h1 id="rfc.section.7"><a href="#rfc.section.7">7.</a> <a href="#security-considerations" id="security-considerations">Security Considerations</a></h1>
+<p id="rfc.section.7.p.1">TBD </p>
+<h1 id="rfc.section.8"><a href="#rfc.section.8">8.</a> <a href="#acknowledgments" id="acknowledgments">Acknowledgments</a></h1>
+<p id="rfc.section.8.p.1">Special thanks to Abtin Keshavarzian, Martin Turon, Arjuna Sivasithambaresan and Jonathan Hui for their substantial contributions and feedback related to this document.  </p>
+<p>
+  <a id="CREF3" class="info">[CREF3]<span class="info">RQ: If I have missed anyone who has contributed to this document, please let me know ASAP.</span></a>
+</p>
+<p id="rfc.section.8.p.3">This document was prepared using <a href="https://github.com/miekg/mmark">mmark</a> by (Miek Gieben) and <a href="http://xml2rfc.ietf.org/">xml2rfc (version 2)</a>.  </p>
 <h1 id="rfc.appendix.A"><a href="#rfc.appendix.A">Appendix A.</a> <a href="#framing-protocol" id="framing-protocol">Framing Protocol</a></h1>
 <p id="rfc.section.A.p.1">Since this NCP protocol is defined independently of the physical transport or framing, any number of transports and framing protocols could be used successfully. However, in the interests of compatibility, this document provides some recommendations.  </p>
 <h1 id="rfc.appendix.A.1"><a href="#rfc.appendix.A.1">A.1.</a> <a href="#uart-recommendations" id="uart-recommendations">UART Recommendations</a></h1>
@@ -2355,8 +2484,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 
 <p> </p>
 <p id="rfc.section.A.1.p.3">These values may be adjusted depending on the individual needs of the application or product, but some sort of flow control MUST be used.  Hardware flow control is preferred over software flow control. In the absence of hardware flow control, software flow control (XON/XOFF) MUST be used instead.  </p>
-<p id="rfc.section.A.1.p.4">We also <strong>RECOMMEND</strong> an arduino-style hardware reset, where the DTR signal is coupled to the <samp>R&#773;E&#773;S&#773;</samp> pin through a 0.01&#181;F capacitor. This causes the NCP to automatically reset whenever the serial port is opened. At the very least we <strong>RECOMMEND</strong> dedicating one of your host pins to controlling the <samp>R&#773;E&#773;S&#773;</samp> pin on the NCP, so that you can easily perform a hardware reset if necessary.  </p>
-<h1 id="rfc.appendix.A.1.1"><a href="#rfc.appendix.A.1.1">A.1.1.</a> <a href="#hdlclite" id="hdlclite">HDLC-Lite</a></h1>
+<p id="rfc.section.A.1.p.4">We also <strong>RECOMMEND</strong> an Arduino-style hardware reset, where the DTR signal is coupled to the <samp>R&#773;E&#773;S&#773;</samp> pin through a 0.01&#181;F capacitor. This causes the NCP to automatically reset whenever the serial port is opened. At the very least we <strong>RECOMMEND</strong> dedicating one of your host pins to controlling the <samp>R&#773;E&#773;S&#773;</samp> pin on the NCP, so that you can easily perform a hardware reset if necessary.  </p>
+<h1 id="rfc.appendix.A.1.1"><a href="#rfc.appendix.A.1.1">A.1.1.</a> <a href="#hdlc-lite" id="hdlc-lite">HDLC-Lite</a></h1>
 <p><em>HDLC-Lite</em> is the recommended framing protocol for transmitting Spinel frames over a UART. HDLC-Lite consists of only the framing, escaping, and CRC parts of the larger HDLC protocol---all other parts of HDLC are omitted. This protocol was chosen because it works well with software flow control and is widely implemented.  </p>
 <p id="rfc.section.A.1.1.p.2">To transmit a frame with HDLC-lite, the 16-bit CRC must first be appended to the frame. The CRC function is defined to be CRC-16/CCITT, otherwise known as the <a href="http://reveng.sourceforge.net/crc-catalogue/16.htm#crc.cat.kermit">KERMIT CRC</a>.  </p>
 <p id="rfc.section.A.1.1.p.3">Individual frames are terminated with a frame delimiter octet called the 'flag' octet (<samp>0x7E</samp>).  </p>
@@ -2666,7 +2795,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 <p> </p>
 <p id="rfc.section.D.p.4">All serious implementations of an NCP SHOULD also support the network save feature (See <a href="#feature-network-save">Appendix B</a>).  </p>
 <h1 id="rfc.appendix.D.1"><a href="#rfc.appendix.D.1">D.1.</a> <a href="#thread-capabilities" id="thread-capabilities">Thread Capabilities</a></h1>
-<p id="rfc.section.D.1.p.1">The Thread techology defines the following capabilities: </p>
+<p id="rfc.section.D.1.p.1">The Thread technology defines the following capabilities: </p>
 <p/>
 
 <ul>
@@ -2676,7 +2805,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 
 <p> </p>
 <h1 id="rfc.appendix.D.2"><a href="#rfc.appendix.D.2">D.2.</a> <a href="#thread-properties" id="thread-properties">Thread Properties</a></h1>
-<p id="rfc.section.D.2.p.1">Properties for Thread are allocated out of the <samp>Tech</samp> property section (see <a href="#property-sections">Section 6.1</a>).  </p>
+<p id="rfc.section.D.2.p.1">Properties for Thread are allocated out of the <samp>Tech</samp> property section (see <a href="#property-sections">Section 5.1</a>).  </p>
 <h1 id="rfc.appendix.D.2.1"><a href="#rfc.appendix.D.2.1">D.2.1.</a> <a href="#prop-80-propthreadleaderaddr" id="prop-80-propthreadleaderaddr">PROP 80: PROP_THREAD_LEADER_ADDR</a></h1>
 <p/>
 
@@ -2900,7 +3029,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.D.2.21.p.2">Note that some implementations may not support <samp>CMD_GET_VALUE</samp> routerids, but may support <samp>CMD_REMOVE_VALUE</samp> when the node is a leader.  </p>
+<p id="rfc.section.D.2.21.p.2">Note that some implementations may not support <samp>CMD_GET_VALUE</samp> router ids, but may support <samp>CMD_REMOVE_VALUE</samp> when the node is a leader.  </p>
 <h1 id="rfc.appendix.D.2.22"><a href="#rfc.appendix.D.2.22">D.2.22.</a> <a href="#prop-5382-propthreadrloc16debugpassthru" id="prop-5382-propthreadrloc16debugpassthru">PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU</a></h1>
 <p/>
 
@@ -2995,7 +3124,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
   </tbody>
 </table>
 <p>
-  <a id="CREF3" class="info">[CREF3]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
+  <a id="CREF4" class="info">[CREF4]<span class="info">RQ: The PUI test-vector encodings need to be verified.</span></a>
 </p>
 <h1 id="rfc.appendix.E.2"><a href="#rfc.appendix.E.2">E.2.</a> <a href="#test-vector-reset-command" id="test-vector-reset-command">Test Vector: Reset Command</a></h1>
 <p/>
@@ -3048,12 +3177,12 @@ FE
 <h1 id="rfc.appendix.E.5"><a href="#rfc.appendix.E.5">E.5.</a> <a href="#test-vector-inbound-ipv6-packet" id="test-vector-inbound-ipv6-packet">Test Vector: Inbound IPv6 Packet</a></h1>
 <p id="rfc.section.E.5.p.1">CMD_VALUE_IS(PROP_STREAM_NET) </p>
 <p>
-  <a id="CREF4" class="info">[CREF4]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
+  <a id="CREF5" class="info">[CREF5]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
 </p>
 <h1 id="rfc.appendix.E.6"><a href="#rfc.appendix.E.6">E.6.</a> <a href="#test-vector-outbound-ipv6-packet" id="test-vector-outbound-ipv6-packet">Test Vector: Outbound IPv6 Packet</a></h1>
 <p id="rfc.section.E.6.p.1">CMD_VALUE_SET(PROP_STREAM_NET) </p>
 <p>
-  <a id="CREF5" class="info">[CREF5]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
+  <a id="CREF6" class="info">[CREF6]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
 </p>
 <h1 id="rfc.appendix.E.7"><a href="#rfc.appendix.E.7">E.7.</a> <a href="#test-vector-fetch-list-of-onmesh-networks" id="test-vector-fetch-list-of-onmesh-networks">Test Vector: Fetch list of on-mesh networks</a></h1>
 <p/>
@@ -3120,7 +3249,7 @@ FE
   <li>TID: 5</li>
   <li>CMD: 4 (<samp>CMD_VALUE_INSERT</samp>)</li>
   <li>PROP: 90 (<samp>PROP_THREAD_ON_MESH_NETS</samp>)</li>
-  <li>VALUE: Structure, encoded as <samp>6CbC</samp></li>
+  <li>VALUE: Structure, encoded as <samp>6CbCb</samp></li>
 </ul>
 
 <p> </p>
@@ -3145,10 +3274,10 @@ FE
 <p id="rfc.section.E.9.p.2">Frame: </p>
 <pre>
 85 03 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00 40
-01 ??
+01 ?? 01
 </pre>
 <p>
-  <a id="CREF6" class="info">[CREF6]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
+  <a id="CREF7" class="info">[CREF7]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
 </p>
 <h1 id="rfc.appendix.E.10"><a href="#rfc.appendix.E.10">E.10.</a> <a href="#test-vector-insertion-notification-of-an-onmesh-network" id="test-vector-insertion-notification-of-an-onmesh-network">Test Vector: Insertion notification of an on-mesh network</a></h1>
 <p/>
@@ -3158,7 +3287,7 @@ FE
   <li>TID: 5</li>
   <li>CMD: 7 (<samp>CMD_VALUE_INSERTED</samp>)</li>
   <li>PROP: 90 (<samp>PROP_THREAD_ON_MESH_NETS</samp>)</li>
-  <li>VALUE: Structure, encoded as <samp>6CbC</samp></li>
+  <li>VALUE: Structure, encoded as <samp>6CbCb</samp></li>
 </ul>
 
 <p> </p>
@@ -3183,10 +3312,10 @@ FE
 <p id="rfc.section.E.10.p.2">Frame: </p>
 <pre>
 85 07 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00 40
-01 ??
+01 ?? 01
 </pre>
 <p>
-  <a id="CREF7" class="info">[CREF7]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
+  <a id="CREF8" class="info">[CREF8]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
 </p>
 <h1 id="rfc.appendix.E.11"><a href="#rfc.appendix.E.11">E.11.</a> <a href="#test-vector-removing-a-local-onmesh-network" id="test-vector-removing-a-local-onmesh-network">Test Vector: Removing a local on-mesh network</a></h1>
 <p/>
@@ -3223,7 +3352,7 @@ FE
 <h1 id="rfc.appendix.F"><a href="#rfc.appendix.F">Appendix F.</a> <a href="#example-sessions" id="example-sessions">Example Sessions</a></h1>
 <h1 id="rfc.appendix.F.1"><a href="#rfc.appendix.F.1">F.1.</a> <a href="#ncp-initialization" id="ncp-initialization">NCP Initialization</a></h1>
 <p>
-  <a id="CREF8" class="info">[CREF8]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF9" class="info">[CREF9]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p id="rfc.section.F.1.p.2">Check the protocol version to see if it is supported: </p>
 <p/>
@@ -3280,7 +3409,7 @@ FE
 <p> </p>
 <h1 id="rfc.appendix.F.2"><a href="#rfc.appendix.F.2">F.2.</a> <a href="#attaching-to-a-network" id="attaching-to-a-network">Attaching to a network</a></h1>
 <p>
-  <a id="CREF9" class="info">[CREF9]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF10" class="info">[CREF10]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p id="rfc.section.F.2.p.2">We make the assumption that the NCP is not currently associated with a network.  </p>
 <p id="rfc.section.F.2.p.3">Set the network properties, if they were not already set: </p>
@@ -3332,7 +3461,7 @@ FE
 <p> </p>
 <h1 id="rfc.appendix.F.3"><a href="#rfc.appendix.F.3">F.3.</a> <a href="#successfully-joining-a-preexisting-network" id="successfully-joining-a-preexisting-network">Successfully joining a pre-existing network</a></h1>
 <p>
-  <a id="CREF10" class="info">[CREF10]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF11" class="info">[CREF11]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p id="rfc.section.F.3.p.2">This example session is identical to the above session up to the point where we set PROP_NET_IF_UP to true. From there, the behavior changes.  </p>
 <p/>
@@ -3402,7 +3531,7 @@ FE
 <p id="rfc.section.F.5.p.1">TBD </p>
 <h1 id="rfc.appendix.F.6"><a href="#rfc.appendix.F.6">F.6.</a> <a href="#attaching-to-a-saved-network" id="attaching-to-a-saved-network">Attaching to a saved network</a></h1>
 <p>
-  <a id="CREF11" class="info">[CREF11]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF12" class="info">[CREF12]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p id="rfc.section.F.6.p.2">Recall the saved network if you haven't already done so: </p>
 <p/>
@@ -3442,7 +3571,7 @@ FE
 <p> </p>
 <h1 id="rfc.appendix.F.7"><a href="#rfc.appendix.F.7">F.7.</a> <a href="#ncp-software-reset" id="ncp-software-reset">NCP Software Reset</a></h1>
 <p>
-  <a id="CREF12" class="info">[CREF12]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF13" class="info">[CREF13]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p/>
 
@@ -3459,9 +3588,9 @@ FE
 <p id="rfc.section.F.9.p.1">TBD </p>
 <h1 id="rfc.appendix.F.10"><a href="#rfc.appendix.F.10">F.10.</a> <a href="#sniffing-raw-packets" id="sniffing-raw-packets">Sniffing raw packets</a></h1>
 <p>
-  <a id="CREF13" class="info">[CREF13]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF14" class="info">[CREF14]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
-<p id="rfc.section.F.10.p.2">This assuems that the NCP has been initialized.  </p>
+<p id="rfc.section.F.10.p.2">This assumes that the NCP has been initialized.  </p>
 <p id="rfc.section.F.10.p.3">Optionally set the channel: </p>
 <p/>
 
@@ -3509,6 +3638,23 @@ FE
 
 <p> </p>
 <p id="rfc.section.F.10.p.13">This mode may be entered even when associated with a network.  In that case, you should set <samp>PROP_MAC_FILTER_MODE</samp> to <samp>MAC_FILTER_MODE_PROMISCUOUS</samp> or <samp>MAC_FILTER_MODE_NORMAL</samp>, so that you can avoid receiving packets from other networks or that are destined for other nodes.  </p>
+<h1 id="rfc.appendix.G"><a href="#rfc.appendix.G">Appendix G.</a> <a href="#glossary" id="glossary">Glossary</a></h1>
+<p/>
+
+<dl>
+  <dt>NCP</dt>
+  <dd style="margin-left: 8"><br/> Acronym for Network Control Processor.</dd>
+  <dt>Host</dt>
+  <dd style="margin-left: 8"><br/> Computer or Micro-controller which controls the NCP.</dd>
+  <dt>TID</dt>
+  <dd style="margin-left: 8"><br/> Transaction Identifier. May be a value between zero and fifteen.  See <a href="#tid-transaction-identifier">Section 2.1.3</a> for more information.</dd>
+  <dt>IID</dt>
+  <dd style="margin-left: 8"><br/> Interface Identifier. May be a value between zero and three.  See <a href="#iid-interface-identifier">Section 2.1.2</a> for more information.</dd>
+  <dt>PUI</dt>
+  <dd style="margin-left: 8"><br/> Packed Unsigned Integer. A way to serialize an unsigned integer using one, two, or three bytes. Used throughout the Spinel protocol.  See <a href="#packed-unsigned-integer">Section 3.2</a> for more information.</dd>
+</dl>
+
+<p> </p>
 <h1 id="rfc.authors">
   <a href="#rfc.authors">Author's Address</a>
 </h1>

--- a/doc/draft-spinel-protocol.txt
+++ b/doc/draft-spinel-protocol.txt
@@ -4,11 +4,11 @@
 
                                                           R. Quattlebaum
                                                                Nest Labs
-                                                       September 9, 2016
+                                                      September 10, 2016
 
 
                     Spinel Host-Controller Protocol
-                     draft-spinel-protocol-94724cf
+                     draft-spinel-protocol-4d55c14
 
 Abstract
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Quattlebaum              Expires March 13, 2017                 [Page 1]
+Quattlebaum              Expires March 14, 2017                 [Page 1]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
@@ -68,183 +68,192 @@ Quattlebaum              Expires March 13, 2017                 [Page 1]
 Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   5
-   2.  Definitions . . . . . . . . . . . . . . . . . . . . . . . . .   5
-   3.  Frame Format  . . . . . . . . . . . . . . . . . . . . . . . .   6
-     3.1.  Header Format . . . . . . . . . . . . . . . . . . . . . .   6
-       3.1.1.  FLG: Flag . . . . . . . . . . . . . . . . . . . . . .   6
-       3.1.2.  IID: Interface Identifier . . . . . . . . . . . . . .   7
-       3.1.3.  TID: Transaction Identifier . . . . . . . . . . . . .   7
-       3.1.4.  Command Identifier (CMD)  . . . . . . . . . . . . . .   7
-       3.1.5.  Command Payload (Optional)  . . . . . . . . . . . . .   7
-   4.  Data Packing  . . . . . . . . . . . . . . . . . . . . . . . .   8
-     4.1.  Primitive Types . . . . . . . . . . . . . . . . . . . . .   8
-     4.2.  Packed Unsigned Integer . . . . . . . . . . . . . . . . .   9
-     4.3.  Data Blobs  . . . . . . . . . . . . . . . . . . . . . . .  10
-     4.4.  Structured Data . . . . . . . . . . . . . . . . . . . . .  11
-     4.5.  Arrays  . . . . . . . . . . . . . . . . . . . . . . . . .  11
-   5.  Commands  . . . . . . . . . . . . . . . . . . . . . . . . . .  12
-     5.1.  CMD 0: (Host->NCP) CMD_NOOP . . . . . . . . . . . . . . .  12
-     5.2.  CMD 1: (Host->NCP) CMD_RESET  . . . . . . . . . . . . . .  12
-     5.3.  CMD 2: (Host->NCP) CMD_PROP_VALUE_GET . . . . . . . . . .  13
-     5.4.  CMD 3: (Host->NCP) CMD_PROP_VALUE_SET . . . . . . . . . .  13
-     5.5.  CMD 4: (Host->NCP) CMD_PROP_VALUE_INSERT  . . . . . . . .  13
-     5.6.  CMD 5: (Host->NCP) CMD_PROP_VALUE_REMOVE  . . . . . . . .  14
-     5.7.  CMD 6: (NCP->Host) CMD_PROP_VALUE_IS  . . . . . . . . . .  14
-     5.8.  CMD 7: (NCP->Host) CMD_PROP_VALUE_INSERTED  . . . . . . .  15
-     5.9.  CMD 8: (NCP->Host) CMD_PROP_VALUE_REMOVED . . . . . . . .  15
-   6.  Properties  . . . . . . . . . . . . . . . . . . . . . . . . .  16
-     6.1.  Property Sections . . . . . . . . . . . . . . . . . . . .  16
-     6.2.  Core Properties . . . . . . . . . . . . . . . . . . . . .  17
-       6.2.1.  PROP 0: PROP_LAST_STATUS  . . . . . . . . . . . . . .  17
-       6.2.2.  PROP 1: PROP_PROTOCOL_VERSION . . . . . . . . . . . .  17
-       6.2.3.  PROP 2: PROP_NCP_VERSION  . . . . . . . . . . . . . .  18
-       6.2.4.  PROP 3: PROP_INTERFACE_TYPE . . . . . . . . . . . . .  18
-       6.2.5.  PROP 4: PROP_INTERFACE_VENDOR_ID  . . . . . . . . . .  19
-       6.2.6.  PROP 5: PROP_CAPS . . . . . . . . . . . . . . . . . .  19
-       6.2.7.  PROP 6: PROP_INTERFACE_COUNT  . . . . . . . . . . . .  20
-       6.2.8.  PROP 7: PROP_POWER_STATE  . . . . . . . . . . . . . .  21
-       6.2.9.  PROP 8: PROP_HWADDR . . . . . . . . . . . . . . . . .  21
-       6.2.10. PROP 9: PROP_LOCK . . . . . . . . . . . . . . . . . .  22
-       6.2.11. PROP 112: PROP_STREAM_DEBUG . . . . . . . . . . . . .  22
+     1.1.  About this Draft  . . . . . . . . . . . . . . . . . . . .   6
+       1.1.1.  Renumbering . . . . . . . . . . . . . . . . . . . . .   6
+       1.1.2.  Spinel as Application API . . . . . . . . . . . . . .   6
+       1.1.3.  Privileged Commands and Properties  . . . . . . . . .   7
+     1.2.  Property Overview . . . . . . . . . . . . . . . . . . . .   8
+       1.2.1.  Property Methods  . . . . . . . . . . . . . . . . . .   8
+       1.2.2.  Property Types  . . . . . . . . . . . . . . . . . . .   8
+   2.  Frame Format  . . . . . . . . . . . . . . . . . . . . . . . .  10
+     2.1.  Header Format . . . . . . . . . . . . . . . . . . . . . .  10
+       2.1.1.  FLG: Flag . . . . . . . . . . . . . . . . . . . . . .  10
+       2.1.2.  IID: Interface Identifier . . . . . . . . . . . . . .  11
+       2.1.3.  TID: Transaction Identifier . . . . . . . . . . . . .  11
+       2.1.4.  Command Identifier (CMD)  . . . . . . . . . . . . . .  11
+       2.1.5.  Command Payload (Optional)  . . . . . . . . . . . . .  12
+   3.  Data Packing  . . . . . . . . . . . . . . . . . . . . . . . .  12
+     3.1.  Primitive Types . . . . . . . . . . . . . . . . . . . . .  12
+     3.2.  Packed Unsigned Integer . . . . . . . . . . . . . . . . .  13
+     3.3.  Data Blobs  . . . . . . . . . . . . . . . . . . . . . . .  14
+     3.4.  Structured Data . . . . . . . . . . . . . . . . . . . . .  15
+     3.5.  Arrays  . . . . . . . . . . . . . . . . . . . . . . . . .  15
+   4.  Commands  . . . . . . . . . . . . . . . . . . . . . . . . . .  16
+     4.1.  CMD 0: (Host->NCP) CMD_NOOP . . . . . . . . . . . . . . .  16
+     4.2.  CMD 1: (Host->NCP) CMD_RESET  . . . . . . . . . . . . . .  16
+     4.3.  CMD 2: (Host->NCP) CMD_PROP_VALUE_GET . . . . . . . . . .  17
+     4.4.  CMD 3: (Host->NCP) CMD_PROP_VALUE_SET . . . . . . . . . .  17
+     4.5.  CMD 4: (Host->NCP) CMD_PROP_VALUE_INSERT  . . . . . . . .  17
+     4.6.  CMD 5: (Host->NCP) CMD_PROP_VALUE_REMOVE  . . . . . . . .  18
+     4.7.  CMD 6: (NCP->Host) CMD_PROP_VALUE_IS  . . . . . . . . . .  18
+     4.8.  CMD 7: (NCP->Host) CMD_PROP_VALUE_INSERTED  . . . . . . .  19
+     4.9.  CMD 8: (NCP->Host) CMD_PROP_VALUE_REMOVED . . . . . . . .  19
+   5.  Properties  . . . . . . . . . . . . . . . . . . . . . . . . .  20
+     5.1.  Property Sections . . . . . . . . . . . . . . . . . . . .  20
+     5.2.  Core Properties . . . . . . . . . . . . . . . . . . . . .  21
+       5.2.1.  PROP 0: PROP_LAST_STATUS  . . . . . . . . . . . . . .  21
+       5.2.2.  PROP 1: PROP_PROTOCOL_VERSION . . . . . . . . . . . .  21
+       5.2.3.  PROP 2: PROP_NCP_VERSION  . . . . . . . . . . . . . .  22
+       5.2.4.  PROP 3: PROP_INTERFACE_TYPE . . . . . . . . . . . . .  22
+       5.2.5.  PROP 4: PROP_INTERFACE_VENDOR_ID  . . . . . . . . . .  23
 
 
 
-Quattlebaum              Expires March 13, 2017                 [Page 2]
+Quattlebaum              Expires March 14, 2017                 [Page 2]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
-       6.2.12. PROP 113: PROP_STREAM_RAW . . . . . . . . . . . . . .  23
-       6.2.13. PROP 114: PROP_STREAM_NET . . . . . . . . . . . . . .  23
-       6.2.14. PROP 114: PROP_STREAM_NET_INSECURE  . . . . . . . . .  24
-     6.3.  PHY Properties  . . . . . . . . . . . . . . . . . . . . .  24
-       6.3.1.  PROP 32: PROP_PHY_ENABLED . . . . . . . . . . . . . .  24
-       6.3.2.  PROP 33: PROP_PHY_CHAN  . . . . . . . . . . . . . . .  25
-       6.3.3.  PROP 34: PROP_PHY_CHAN_SUPPORTED  . . . . . . . . . .  25
-       6.3.4.  PROP 35: PROP_PHY_FREQ  . . . . . . . . . . . . . . .  25
-       6.3.5.  PROP 36: PROP_PHY_CCA_THRESHOLD . . . . . . . . . . .  25
-       6.3.6.  PROP 37: PROP_PHY_TX_POWER  . . . . . . . . . . . . .  25
-       6.3.7.  PROP 38: PROP_PHY_RSSI  . . . . . . . . . . . . . . .  26
-     6.4.  MAC Properties  . . . . . . . . . . . . . . . . . . . . .  26
-       6.4.1.  PROP 48: PROP_MAC_SCAN_STATE  . . . . . . . . . . . .  26
-       6.4.2.  PROP 49: PROP_MAC_SCAN_MASK . . . . . . . . . . . . .  26
-       6.4.3.  PROP 50: PROP_MAC_SCAN_PERIOD . . . . . . . . . . . .  26
-       6.4.4.  PROP 51: PROP_MAC_SCAN_BEACON . . . . . . . . . . . .  27
-       6.4.5.  PROP 52: PROP_MAC_15_4_LADDR  . . . . . . . . . . . .  27
-       6.4.6.  PROP 53: PROP_MAC_15_4_SADDR  . . . . . . . . . . . .  28
-       6.4.7.  PROP 54: PROP_MAC_15_4_PANID  . . . . . . . . . . . .  28
-       6.4.8.  PROP 55: PROP_MAC_RAW_STREAM_ENABLED  . . . . . . . .  28
-       6.4.9.  PROP 56: PROP_MAC_FILTER_MODE . . . . . . . . . . . .  28
-       6.4.10. PROP 4864: PROP_MAC_WHITELIST . . . . . . . . . . . .  29
-       6.4.11. PROP 4865: PROP_MAC_WHITELIST_ENABLED . . . . . . . .  29
-     6.5.  NET Properties  . . . . . . . . . . . . . . . . . . . . .  29
-       6.5.1.  PROP 64: PROP_NET_SAVED . . . . . . . . . . . . . . .  29
-       6.5.2.  PROP 65: PROP_NET_IF_UP . . . . . . . . . . . . . . .  29
-       6.5.3.  PROP 66: PROP_NET_STACK_UP  . . . . . . . . . . . . .  29
-       6.5.4.  PROP 67: PROP_NET_ROLE  . . . . . . . . . . . . . . .  30
-       6.5.5.  PROP 68: PROP_NET_NETWORK_NAME  . . . . . . . . . . .  30
-       6.5.6.  PROP 69: PROP_NET_XPANID  . . . . . . . . . . . . . .  30
-       6.5.7.  PROP 70: PROP_NET_MASTER_KEY  . . . . . . . . . . . .  30
-       6.5.8.  PROP 71: PROP_NET_KEY_SEQUENCE  . . . . . . . . . . .  30
-       6.5.9.  PROP 72: PROP_NET_PARTITION_ID  . . . . . . . . . . .  30
-     6.6.  IPv6 Properties . . . . . . . . . . . . . . . . . . . . .  30
-       6.6.1.  PROP 96: PROP_IPV6_LL_ADDR  . . . . . . . . . . . . .  30
-       6.6.2.  PROP 97: PROP_IPV6_ML_ADDR  . . . . . . . . . . . . .  31
-       6.6.3.  PROP 98: PROP_IPV6_ML_PREFIX  . . . . . . . . . . . .  31
-       6.6.4.  PROP 99: PROP_IPV6_ADDRESS_TABLE  . . . . . . . . . .  31
-       6.6.5.  PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD . . . . . . . .  31
-   7.  Status Codes  . . . . . . . . . . . . . . . . . . . . . . . .  31
-     8.1.  URIs  . . . . . . . . . . . . . . . . . . . . . . . . . .  33
-   Appendix A.  Framing Protocol . . . . . . . . . . . . . . . . . .  33
-     A.1.  UART Recommendations  . . . . . . . . . . . . . . . . . .  33
-       A.1.1.  HDLC-Lite . . . . . . . . . . . . . . . . . . . . . .  34
-     A.2.  SPI Recommendations . . . . . . . . . . . . . . . . . . .  35
-       A.2.1.  SPI Framing Protocol  . . . . . . . . . . . . . . . .  35
-     A.3.  I^2C Recommendations  . . . . . . . . . . . . . . . . . .  36
-     A.4.  Native USB Recommendations  . . . . . . . . . . . . . . .  37
+       5.2.6.  PROP 5: PROP_CAPS . . . . . . . . . . . . . . . . . .  23
+       5.2.7.  PROP 6: PROP_INTERFACE_COUNT  . . . . . . . . . . . .  24
+       5.2.8.  PROP 7: PROP_POWER_STATE  . . . . . . . . . . . . . .  25
+       5.2.9.  PROP 8: PROP_HWADDR . . . . . . . . . . . . . . . . .  25
+       5.2.10. PROP 9: PROP_LOCK . . . . . . . . . . . . . . . . . .  26
+       5.2.11. PROP 112: PROP_STREAM_DEBUG . . . . . . . . . . . . .  26
+       5.2.12. PROP 113: PROP_STREAM_RAW . . . . . . . . . . . . . .  27
+       5.2.13. PROP 114: PROP_STREAM_NET . . . . . . . . . . . . . .  27
+       5.2.14. PROP 114: PROP_STREAM_NET_INSECURE  . . . . . . . . .  28
+     5.3.  PHY Properties  . . . . . . . . . . . . . . . . . . . . .  28
+       5.3.1.  PROP 32: PROP_PHY_ENABLED . . . . . . . . . . . . . .  28
+       5.3.2.  PROP 33: PROP_PHY_CHAN  . . . . . . . . . . . . . . .  29
+       5.3.3.  PROP 34: PROP_PHY_CHAN_SUPPORTED  . . . . . . . . . .  29
+       5.3.4.  PROP 35: PROP_PHY_FREQ  . . . . . . . . . . . . . . .  29
+       5.3.5.  PROP 36: PROP_PHY_CCA_THRESHOLD . . . . . . . . . . .  29
+       5.3.6.  PROP 37: PROP_PHY_TX_POWER  . . . . . . . . . . . . .  29
+       5.3.7.  PROP 38: PROP_PHY_RSSI  . . . . . . . . . . . . . . .  30
+     5.4.  MAC Properties  . . . . . . . . . . . . . . . . . . . . .  30
+       5.4.1.  PROP 48: PROP_MAC_SCAN_STATE  . . . . . . . . . . . .  30
+       5.4.2.  PROP 49: PROP_MAC_SCAN_MASK . . . . . . . . . . . . .  30
+       5.4.3.  PROP 50: PROP_MAC_SCAN_PERIOD . . . . . . . . . . . .  30
+       5.4.4.  PROP 51: PROP_MAC_SCAN_BEACON . . . . . . . . . . . .  31
+       5.4.5.  PROP 52: PROP_MAC_15_4_LADDR  . . . . . . . . . . . .  31
+       5.4.6.  PROP 53: PROP_MAC_15_4_SADDR  . . . . . . . . . . . .  32
+       5.4.7.  PROP 54: PROP_MAC_15_4_PANID  . . . . . . . . . . . .  32
+       5.4.8.  PROP 55: PROP_MAC_RAW_STREAM_ENABLED  . . . . . . . .  32
+       5.4.9.  PROP 56: PROP_MAC_FILTER_MODE . . . . . . . . . . . .  32
+       5.4.10. PROP 4864: PROP_MAC_WHITELIST . . . . . . . . . . . .  33
+       5.4.11. PROP 4865: PROP_MAC_WHITELIST_ENABLED . . . . . . . .  33
+     5.5.  NET Properties  . . . . . . . . . . . . . . . . . . . . .  33
+       5.5.1.  PROP 64: PROP_NET_SAVED . . . . . . . . . . . . . . .  33
+       5.5.2.  PROP 65: PROP_NET_IF_UP . . . . . . . . . . . . . . .  33
+       5.5.3.  PROP 66: PROP_NET_STACK_UP  . . . . . . . . . . . . .  33
+       5.5.4.  PROP 67: PROP_NET_ROLE  . . . . . . . . . . . . . . .  34
+       5.5.5.  PROP 68: PROP_NET_NETWORK_NAME  . . . . . . . . . . .  34
+       5.5.6.  PROP 69: PROP_NET_XPANID  . . . . . . . . . . . . . .  34
+       5.5.7.  PROP 70: PROP_NET_MASTER_KEY  . . . . . . . . . . . .  34
+       5.5.8.  PROP 71: PROP_NET_KEY_SEQUENCE  . . . . . . . . . . .  34
+       5.5.9.  PROP 72: PROP_NET_PARTITION_ID  . . . . . . . . . . .  34
+     5.6.  IPv6 Properties . . . . . . . . . . . . . . . . . . . . .  34
+       5.6.1.  PROP 96: PROP_IPV6_LL_ADDR  . . . . . . . . . . . . .  34
+       5.6.2.  PROP 97: PROP_IPV6_ML_ADDR  . . . . . . . . . . . . .  35
+       5.6.3.  PROP 98: PROP_IPV6_ML_PREFIX  . . . . . . . . . . . .  35
+       5.6.4.  PROP 99: PROP_IPV6_ADDRESS_TABLE  . . . . . . . . . .  35
+       5.6.5.  PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD . . . . . . . .  35
+   6.  Status Codes  . . . . . . . . . . . . . . . . . . . . . . . .  35
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  37
+   8.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  37
 
 
 
-Quattlebaum              Expires March 13, 2017                 [Page 3]
+Quattlebaum              Expires March 14, 2017                 [Page 3]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
-   Appendix B.  Feature: Network Save  . . . . . . . . . . . . . . .  37
-     B.1.  Commands  . . . . . . . . . . . . . . . . . . . . . . . .  37
-       B.1.1.  CMD 9: (Host->NCP) CMD_NET_SAVE . . . . . . . . . . .  37
-       B.1.2.  CMD 10: (Host->NCP) CMD_NET_CLEAR . . . . . . . . . .  37
-       B.1.3.  CMD 11: (Host->NCP) CMD_NET_RECALL  . . . . . . . . .  38
-   Appendix C.  Feature: Host Buffer Offload . . . . . . . . . . . .  38
-     C.1.  Commands  . . . . . . . . . . . . . . . . . . . . . . . .  39
-       C.1.1.  CMD 12: (NCP->Host) CMD_HBO_OFFLOAD . . . . . . . . .  39
-       C.1.2.  CMD 13: (NCP->Host) CMD_HBO_RECLAIM . . . . . . . . .  39
-       C.1.3.  CMD 14: (NCP->Host) CMD_HBO_DROP  . . . . . . . . . .  39
-       C.1.4.  CMD 15: (Host->NCP) CMD_HBO_OFFLOADED . . . . . . . .  39
-       C.1.5.  CMD 16: (Host->NCP) CMD_HBO_RECLAIMED . . . . . . . .  39
-       C.1.6.  CMD 17: (Host->NCP) CMD_HBO_DROPPED . . . . . . . . .  39
-     C.2.  Properties  . . . . . . . . . . . . . . . . . . . . . . .  40
-       C.2.1.  PROP 10: PROP_HBO_MEM_MAX . . . . . . . . . . . . . .  40
-       C.2.2.  PROP 11: PROP_HBO_BLOCK_MAX . . . . . . . . . . . . .  40
-   Appendix D.  Technology: Thread . . . . . . . . . . . . . . . . .  40
-     D.1.  Thread Capabilities . . . . . . . . . . . . . . . . . . .  41
-     D.2.  Thread Properties . . . . . . . . . . . . . . . . . . . .  41
-       D.2.1.  PROP 80: PROP_THREAD_LEADER_ADDR  . . . . . . . . . .  41
-       D.2.2.  PROP 81: PROP_THREAD_PARENT . . . . . . . . . . . . .  41
-       D.2.3.  PROP 82: PROP_THREAD_CHILD_TABLE  . . . . . . . . . .  41
-       D.2.4.  PROP 83: PROP_THREAD_LEADER_RID . . . . . . . . . . .  42
-       D.2.5.  PROP 84: PROP_THREAD_LEADER_WEIGHT  . . . . . . . . .  42
-       D.2.6.  PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT  . . . . . .  42
-       D.2.7.  PROP 86: PROP_THREAD_NETWORK_DATA . . . . . . . . . .  42
-       D.2.8.  PROP 87: PROP_THREAD_NETWORK_DATA_VERSION . . . . . .  42
-       D.2.9.  PROP 88: PROP_THREAD_STABLE_NETWORK_DATA  . . . . . .  42
-       D.2.10. PROP 89: PROP_THREAD_STABLE_NETWORK_DATA_VERSION  . .  42
-       D.2.11. PROP 90: PROP_THREAD_ON_MESH_NETS . . . . . . . . . .  42
-       D.2.12. PROP 91: PROP_THREAD_LOCAL_ROUTES . . . . . . . . . .  43
-       D.2.13. PROP 92: PROP_THREAD_ASSISTING_PORTS  . . . . . . . .  43
-       D.2.14. PROP 93: PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE  . .  43
-       D.2.15. PROP 94: PROP_THREAD_MODE . . . . . . . . . . . . . .  43
-       D.2.16. PROP 5376: PROP_THREAD_CHILD_TIMEOUT  . . . . . . . .  43
-       D.2.17. PROP 5377: PROP_THREAD_RLOC16 . . . . . . . . . . . .  44
-       D.2.18. PROP 5378: PROP_THREAD_ROUTER_UPGRADE_THRESHOLD . . .  44
-       D.2.19. PROP 5379: PROP_THREAD_CONTEXT_REUSE_DELAY  . . . . .  44
-       D.2.20. PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT . . . . . .  44
-       D.2.21. PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS  . . . . . .  44
-       D.2.22. PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU  . . . .  44
-       D.2.23. PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED . .  44
-   Appendix E.  Test Vectors . . . . . . . . . . . . . . . . . . . .  45
-     E.1.  Test Vector: Packed Unsigned Integer  . . . . . . . . . .  45
-     E.2.  Test Vector: Reset Command  . . . . . . . . . . . . . . .  45
-     E.3.  Test Vector: Reset Notification . . . . . . . . . . . . .  45
-     E.4.  Test Vector: Scan Beacon  . . . . . . . . . . . . . . . .  46
-     E.5.  Test Vector: Inbound IPv6 Packet  . . . . . . . . . . . .  46
+     9.1.  URIs  . . . . . . . . . . . . . . . . . . . . . . . . . .  37
+   Appendix A.  Framing Protocol . . . . . . . . . . . . . . . . . .  38
+     A.1.  UART Recommendations  . . . . . . . . . . . . . . . . . .  38
+       A.1.1.  HDLC-Lite . . . . . . . . . . . . . . . . . . . . . .  38
+     A.2.  SPI Recommendations . . . . . . . . . . . . . . . . . . .  39
+       A.2.1.  SPI Framing Protocol  . . . . . . . . . . . . . . . .  40
+     A.3.  I^2C Recommendations  . . . . . . . . . . . . . . . . . .  41
+     A.4.  Native USB Recommendations  . . . . . . . . . . . . . . .  41
+   Appendix B.  Feature: Network Save  . . . . . . . . . . . . . . .  41
+     B.1.  Commands  . . . . . . . . . . . . . . . . . . . . . . . .  41
+       B.1.1.  CMD 9: (Host->NCP) CMD_NET_SAVE . . . . . . . . . . .  41
+       B.1.2.  CMD 10: (Host->NCP) CMD_NET_CLEAR . . . . . . . . . .  42
+       B.1.3.  CMD 11: (Host->NCP) CMD_NET_RECALL  . . . . . . . . .  42
+   Appendix C.  Feature: Host Buffer Offload . . . . . . . . . . . .  43
+     C.1.  Commands  . . . . . . . . . . . . . . . . . . . . . . . .  43
+       C.1.1.  CMD 12: (NCP->Host) CMD_HBO_OFFLOAD . . . . . . . . .  43
+       C.1.2.  CMD 13: (NCP->Host) CMD_HBO_RECLAIM . . . . . . . . .  43
+       C.1.3.  CMD 14: (NCP->Host) CMD_HBO_DROP  . . . . . . . . . .  43
+       C.1.4.  CMD 15: (Host->NCP) CMD_HBO_OFFLOADED . . . . . . . .  43
+       C.1.5.  CMD 16: (Host->NCP) CMD_HBO_RECLAIMED . . . . . . . .  44
+       C.1.6.  CMD 17: (Host->NCP) CMD_HBO_DROPPED . . . . . . . . .  44
+     C.2.  Properties  . . . . . . . . . . . . . . . . . . . . . . .  44
+       C.2.1.  PROP 10: PROP_HBO_MEM_MAX . . . . . . . . . . . . . .  44
+       C.2.2.  PROP 11: PROP_HBO_BLOCK_MAX . . . . . . . . . . . . .  44
+   Appendix D.  Technology: Thread . . . . . . . . . . . . . . . . .  45
+     D.1.  Thread Capabilities . . . . . . . . . . . . . . . . . . .  45
+     D.2.  Thread Properties . . . . . . . . . . . . . . . . . . . .  45
+       D.2.1.  PROP 80: PROP_THREAD_LEADER_ADDR  . . . . . . . . . .  45
+       D.2.2.  PROP 81: PROP_THREAD_PARENT . . . . . . . . . . . . .  46
+       D.2.3.  PROP 82: PROP_THREAD_CHILD_TABLE  . . . . . . . . . .  46
+       D.2.4.  PROP 83: PROP_THREAD_LEADER_RID . . . . . . . . . . .  46
+       D.2.5.  PROP 84: PROP_THREAD_LEADER_WEIGHT  . . . . . . . . .  46
+       D.2.6.  PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT  . . . . . .  46
+       D.2.7.  PROP 86: PROP_THREAD_NETWORK_DATA . . . . . . . . . .  46
+       D.2.8.  PROP 87: PROP_THREAD_NETWORK_DATA_VERSION . . . . . .  46
+       D.2.9.  PROP 88: PROP_THREAD_STABLE_NETWORK_DATA  . . . . . .  47
+       D.2.10. PROP 89: PROP_THREAD_STABLE_NETWORK_DATA_VERSION  . .  47
+       D.2.11. PROP 90: PROP_THREAD_ON_MESH_NETS . . . . . . . . . .  47
+       D.2.12. PROP 91: PROP_THREAD_LOCAL_ROUTES . . . . . . . . . .  47
+       D.2.13. PROP 92: PROP_THREAD_ASSISTING_PORTS  . . . . . . . .  47
+       D.2.14. PROP 93: PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE  . .  47
+       D.2.15. PROP 94: PROP_THREAD_MODE . . . . . . . . . . . . . .  48
+       D.2.16. PROP 5376: PROP_THREAD_CHILD_TIMEOUT  . . . . . . . .  48
+       D.2.17. PROP 5377: PROP_THREAD_RLOC16 . . . . . . . . . . . .  48
+       D.2.18. PROP 5378: PROP_THREAD_ROUTER_UPGRADE_THRESHOLD . . .  48
+       D.2.19. PROP 5379: PROP_THREAD_CONTEXT_REUSE_DELAY  . . . . .  48
+       D.2.20. PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT . . . . . .  48
+       D.2.21. PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS  . . . . . .  48
 
 
 
-Quattlebaum              Expires March 13, 2017                 [Page 4]
+Quattlebaum              Expires March 14, 2017                 [Page 4]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
-     E.6.  Test Vector: Outbound IPv6 Packet . . . . . . . . . . . .  46
-     E.7.  Test Vector: Fetch list of on-mesh networks . . . . . . .  46
-     E.8.  Test Vector: Returned list of on-mesh networks  . . . . .  47
-     E.9.  Test Vector: Adding an on-mesh network  . . . . . . . . .  47
-     E.10. Test Vector: Insertion notification of an on-mesh network  48
-     E.11. Test Vector: Removing a local on-mesh network . . . . . .  48
-     E.12. Test Vector: Removal notification of an on-mesh network .  48
-   Appendix F.  Example Sessions . . . . . . . . . . . . . . . . . .  49
-     F.1.  NCP Initialization  . . . . . . . . . . . . . . . . . . .  49
-     F.2.  Attaching to a network  . . . . . . . . . . . . . . . . .  49
-     F.3.  Successfully joining a pre-existing network . . . . . . .  50
-     F.4.  Unsuccessfully joining a pre-existing network . . . . . .  51
-     F.5.  Detaching from a network  . . . . . . . . . . . . . . . .  51
-     F.6.  Attaching to a saved network  . . . . . . . . . . . . . .  51
-     F.7.  NCP Software Reset  . . . . . . . . . . . . . . . . . . .  52
-     F.8.  Adding an on-mesh prefix  . . . . . . . . . . . . . . . .  52
-     F.9.  Entering low-power modes  . . . . . . . . . . . . . . . .  52
-     F.10. Sniffing raw packets  . . . . . . . . . . . . . . . . . .  52
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  54
+       D.2.22. PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU  . . . .  49
+       D.2.23. PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED . .  49
+   Appendix E.  Test Vectors . . . . . . . . . . . . . . . . . . . .  49
+     E.1.  Test Vector: Packed Unsigned Integer  . . . . . . . . . .  49
+     E.2.  Test Vector: Reset Command  . . . . . . . . . . . . . . .  49
+     E.3.  Test Vector: Reset Notification . . . . . . . . . . . . .  50
+     E.4.  Test Vector: Scan Beacon  . . . . . . . . . . . . . . . .  50
+     E.5.  Test Vector: Inbound IPv6 Packet  . . . . . . . . . . . .  51
+     E.6.  Test Vector: Outbound IPv6 Packet . . . . . . . . . . . .  51
+     E.7.  Test Vector: Fetch list of on-mesh networks . . . . . . .  51
+     E.8.  Test Vector: Returned list of on-mesh networks  . . . . .  51
+     E.9.  Test Vector: Adding an on-mesh network  . . . . . . . . .  52
+     E.10. Test Vector: Insertion notification of an on-mesh network  52
+     E.11. Test Vector: Removing a local on-mesh network . . . . . .  52
+     E.12. Test Vector: Removal notification of an on-mesh network .  53
+   Appendix F.  Example Sessions . . . . . . . . . . . . . . . . . .  53
+     F.1.  NCP Initialization  . . . . . . . . . . . . . . . . . . .  53
+     F.2.  Attaching to a network  . . . . . . . . . . . . . . . . .  54
+     F.3.  Successfully joining a pre-existing network . . . . . . .  55
+     F.4.  Unsuccessfully joining a pre-existing network . . . . . .  55
+     F.5.  Detaching from a network  . . . . . . . . . . . . . . . .  56
+     F.6.  Attaching to a saved network  . . . . . . . . . . . . . .  56
+     F.7.  NCP Software Reset  . . . . . . . . . . . . . . . . . . .  56
+     F.8.  Adding an on-mesh prefix  . . . . . . . . . . . . . . . .  56
+     F.9.  Entering low-power modes  . . . . . . . . . . . . . . . .  56
+     F.10. Sniffing raw packets  . . . . . . . . . . . . . . . . . .  57
+   Appendix G.  Glossary . . . . . . . . . . . . . . . . . . . . . .  57
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  58
 
 1.  Introduction
 
@@ -266,38 +275,258 @@ Quattlebaum              Expires March 13, 2017                 [Page 4]
    On top of this core framework, we define the properties and commands
    to enable various features and network protocols.
 
-2.  Definitions
-
-   NCP
-      Acryonym for Network Control Processor.
-   Host
-      Computer or Micro-controller which controls the NCP.
-   TID
 
 
-
-
-Quattlebaum              Expires March 13, 2017                 [Page 5]
+Quattlebaum              Expires March 14, 2017                 [Page 5]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
-      Transaction Identifier.  May be a value between zero and fifteen.
-      See Section 3.1.3 for more information.
-   IID
-      Interface Identifier.  May be a value between zero and three.  See
-      Section 3.1.2 for more information.
-   PUI
-      Packed Unsigned Integer.  A way to serialize an unsigned integer
-      using one, two, or three bytes.  Used throughout the Spinel
-      protocol.  See Section 4.2 for more information.
+1.1.  About this Draft
 
-3.  Frame Format
+   This document is currently in a draft status and is changing often.
+   This section discusses some ideas for changes to the protocol that
+   haven't yet been fully specified, as well as some of the impetus for
+   the current design.
+
+1.1.1.  Renumbering
+
+   Efforts are currently maintained to try to prevent overtly backward-
+   incompatible changes to the existing protocol, but if you are
+   implementing Spinel in your own products you should expect there to
+   be at least one large renumbering event and major version number
+   change before the standard is considered "baked".  All changes will
+   be clearly marked and documented to make such a transition as easy as
+   possible.
+
+   To allow conclusive detection of protocol (in)compatibility between
+   the host and the NCP, the following commands and properties are
+   already considered to be "baked" and will not change:
+
+   o  Command IDs zero through eight.  (Reset, No-op, and Property-Value
+      Commands)
+   o  Property IDs zero through two.  (Last status, Protocol Version,
+      and NCP Version)
+
+   Renumbering would be undertaken in order to better organize the
+   allocation of property IDs and capability IDs.  One of the initial
+   goals of this protocol was for it to be possible for a host or NCP to
+   only implement properties with values less than 127 and for the NCP
+   to still be usable---relegating all larger property values for extra
+   features or other capabilities that aren't strictly necessary.  This
+   would allow simple implementations to avoid the need to implement
+   support for PUIs (Section 3.2).
+
+   As time has gone by and the protocol has become more fleshed out, it
+   has become clear that some of the initial allocations were inadequate
+   and should be revisited if we want to try to achieve the original
+   goal.
+
+1.1.2.  Spinel as Application API
+
+   The current primary host driver implementation is wpantund [1].
+   wpantund manages the NCP using the Spinel protocol and provides a
+   management API for the application using D-Bus [2] IPC.
+
+   However, some thought has been given to the idea of having a host
+   driver daemon which uses Spinel directly as the management API.  You
+
+
+
+Quattlebaum              Expires March 14, 2017                 [Page 6]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
+   would have user-space daemon similar to wpantund which would
+   communicate directly with the NCP.  Using Unix Domain Sockets,
+   applications could connect to the daemon by opening a special socket
+   file.  The protocol for that socket might be (for example) HDLC-Lite-
+   encoded (Appendix A.1.1) spinel frames, as if the application were
+   talking directly to the NCP.
+
+   Applications aren't necessarily interested in everything that an NCP
+   would normally send out unsolicited, so a mechanism for specifying
+   which properties should be listened to would need to be defined.
+   This mechanism would not be implemented by the NCP but would instead
+   be implemented by the daemon to control which notification packets
+   need to be directed where.
+
+   In the event of transaction ID collisions, the daemon would
+   transparently renumber spinel frames so as to not cause TID
+   collisions.
+
+   Since there can be more than one application that is using the API at
+   a time, the "PROP_LOCK" property (Section 5.2.10) would be used to
+   ensure exclusive access to the NCP by an application.  Only one
+   process would be allowed to enable the lock at a time.
+
+   Such a IPC mechanism would be desirable because it is, from a spinel
+   perspective, future proof.  New features can be added and new
+   properties assigned and the IPC protocol would not need to be
+   extended to support them.  It is also simple and has no external
+   dependencies other than unix domain sockets.
+
+   Security is obviously paramount in a system like this, so a great
+   deal of care should be taken to make sure that certain commands and
+   properties cannot be executed or changed without the appropriate
+   privileges.
+
+1.1.3.  Privileged Commands and Properties
+
+   The idea here is that some commands should be considered
+   "privileged", and actively prevented from letting normal applications
+   access them.  This is important if the IPC protocol between the
+   application and the NCP is Spinel.
+
+   Examples of such privileged commands would be debugging commands like
+   "peek" or "poke", properties which control bootloader behavior, or
+   changing factory-specified constants.  These commands should have
+   some attribute about them that can be easily filtered to prevent
+   applications from using issuing them directly to the NCP.
+
+
+
+
+
+Quattlebaum              Expires March 14, 2017                 [Page 7]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
+   This would likely be implemented as a part of the renumbering effort
+   (Section 1.1.1).
+
+1.2.  Property Overview
+
+   Spinel is largely a property-based protocol, with a property defined
+   for every attribute that needs to be set, changed, or known by the
+   host.  The inspiration of this approach was memory-mapped hardware
+   registers for peripherals.  The goal is to avoid, as much as
+   possible, the use of large complicated structures and/or method
+   argument lists.  The reason for avoiding these is because they have a
+   tendency to change, especially early in development.  Adding or
+   removing a property from a structure can render the entire protocol
+   incompatible.  By using properties, you simply change an additional
+   property.
+
+   Almost all features and capabilities are implemented using
+   properties.  Most new features that are initially proposed as
+   commands can be adapted to be property-based instead.  Notable
+   exceptions include "Host Buffer Offload" (Appendix C) and "Network
+   Save" (Appendix B).
+
+   In Spinel, properties are keyed by an unsigned integer between 0 and
+   2,097,151 (See Section 3.2).
+
+1.2.1.  Property Methods
+
+   Properties may support one or more of the following methods:
+
+   o  "VALUE_GET"
+   o  "VALUE_SET"
+   o  "VALUE_INSERT"
+   o  "VALUE_REMOVE"
+
+   Additionally, the NCP can send updates to the host (either
+   synchronously or asynchronously) that inform the host about changes
+   to specific properties:
+
+   o  "VALUE_IS"
+   o  "VALUE_INSERTED"
+   o  "VALUE_REMOVED"
+
+1.2.2.  Property Types
+
+   Conceptually, there are three different types of properties:
+
+   o  Single-value properties
+   o  Multiple-value (Array) properties
+
+
+
+Quattlebaum              Expires March 14, 2017                 [Page 8]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
+   o  Stream properties
+
+1.2.2.1.  Single-Value Properties
+
+   Single-value properties are properties that have a simple
+   representation of a single value.  Examples would be:
+
+   o  Current radio channel (Represented as a unsigned 8-bit integer)
+   o  Network name (Represented as a UTF-8 encoded string)
+   o  802.15.4 PAN ID (Represented as a unsigned 16-bit integer)
+
+   The valid operations on these sorts of properties are "GET" and
+   "SET".
+
+1.2.2.2.  Multiple-Value Properties
+
+   Multiple-Value Properties have more than one value associated with
+   them.  Examples would be:
+
+   o  List of channels supported by the radio hardware.
+   o  List of IPv6 addresses assigned to the interface.
+   o  List of capabilities supported by the NCP.
+
+   The valid operations on these sorts of properties are "VALUE_GET",
+   "VALUE_SET", "VALUE_INSERT", and "VALUE_REMOVE".
+
+   When the value is fetched using "VALUE_GET", the returned value is
+   the concatenation of all of the individual values in the list.  If
+   the length of the value for an individual item in the list is not
+   defined by the type then each item returned in the list is prepended
+   with a length (See Section 3.5).  The order of the returned items,
+   unless explicitly defined for that specific property, is undefined.
+
+   "VALUE_SET" provides a way to completely replace all previous values.
+   Calling "VALUE_SET" with an empty value effectively instructs the NCP
+   to clear the value of that property.
+
+   "VALUE_INSERT" and "VALUE_REMOVE" provide mechanisms for the
+   insertion or removal of individual items _by value_. The payload for
+   these commands is a plain single value.
+
+1.2.2.3.  Stream Properties
+
+   Stream properties are special properties representing streams of
+   data.  Examples would be:
+
+   o  Network packet stream (Section 5.2.13)
+   o  Raw packet stream (Section 5.2.12)
+
+
+
+Quattlebaum              Expires March 14, 2017                 [Page 9]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
+   o  Debug message stream (Section 5.2.11)
+   o  Network Beacon stream (Section 5.4.4)
+
+   All such properties emit changes asynchronously using the "VALUE_IS"
+   command, sent from the NCP to the host.  For example, as IPv6 traffic
+   is received by the NCP, the IPv6 packets are sent to the host by way
+   of asynchronous "VALUE_IS" notifications.
+
+   Some of these properties also support the host send data back to the
+   NCP.  For example, this is how the host sends IPv6 traffic to the
+   NCP.
+
+   These types of properties generally do not support "VALUE_GET", as it
+   is meaningless.
+
+2.  Frame Format
 
    A frame is defined simply as the concatenation of
 
    o  A header byte
-   o  A command (up to three bytes, see Section 4.2 for format)
+   o  A command (up to three bytes, see Section 3.2 for format)
    o  An optional command payload
 
                  +---------+--------+-----+-------------+
@@ -306,7 +535,7 @@ Quattlebaum              Expires March 13, 2017                 [Page 5]
                  | Fields: | HEADER | CMD | CMD_PAYLOAD |
                  +---------+--------+-----+-------------+
 
-3.1.  Header Format
+2.1.  Header Format
 
    The header byte is broken down as follows:
 
@@ -317,7 +546,7 @@ Quattlebaum              Expires March 13, 2017                 [Page 5]
 
    [CREF1]
 
-3.1.1.  FLG: Flag
+2.1.1.  FLG: Flag
 
    The flag field of the header byte ("FLG") is always set to the value
    two (or "10" in binary).  Any frame received with these bits set to
@@ -325,20 +554,18 @@ Quattlebaum              Expires March 13, 2017                 [Page 5]
 
    This convention allows Spinel to be line compatible with BTLE HCI.
    By defining the first two bit in this way we can disambiguate between
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 10]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
    Spinel frames and HCI frames (which always start with either "0x01"
    or "0x04") without any additional framing overhead.
 
-
-
-
-
-
-Quattlebaum              Expires March 13, 2017                 [Page 6]
-
-                        Spinel Protocol (94724cf)         September 2016
-
-
-3.1.2.  IID: Interface Identifier
+2.1.2.  IID: Interface Identifier
 
    The Interface Identifier (IID) is a number between 0 and 3 which
    identifies which subinterface the frame is intended for.  This allows
@@ -346,7 +573,7 @@ Quattlebaum              Expires March 13, 2017                 [Page 6]
    The first subinterface (0) is considered the primary subinterface and
    MUST be supported.  Support for all other subinterfaces is OPTIONAL.
 
-3.1.3.  TID: Transaction Identifier
+2.1.3.  TID: Transaction Identifier
 
    The least significant bits of the header represent the Transaction
    Identifier(TID).  The TID is used for correlating responses to the
@@ -361,11 +588,11 @@ Quattlebaum              Expires March 13, 2017                 [Page 6]
    response is not expected or needed, such as for unsolicited update
    commands sent to the host from the NCP.
 
-3.1.4.  Command Identifier (CMD)
+2.1.4.  Command Identifier (CMD)
 
    The command identifier is a 21-bit unsigned integer encoded in up to
    three bytes using the packed unsigned integer format described in
-   Section 4.2.  This encoding allows for up to 2,097,152 individual
+   Section 3.2.  This encoding allows for up to 2,097,152 individual
    commands, with the first 127 commands represented as a single byte.
    Command identifiers larger than 2,097,151 are explicitly forbidden.
 
@@ -379,22 +606,25 @@ Quattlebaum              Expires March 13, 2017                 [Page 6]
           | 2,000,000 - 2,097,151 |   Experimental use only    |
           +-----------------------+----------------------------+
 
-3.1.5.  Command Payload (Optional)
+
+
+
+
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 11]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
+2.1.5.  Command Payload (Optional)
 
    Depending on the semantics of the command in question, a payload MAY
    be included in the frame.  The exact composition and length of the
    payload is defined by the command identifier.
 
-
-
-
-
-Quattlebaum              Expires March 13, 2017                 [Page 7]
-
-                        Spinel Protocol (94724cf)         September 2016
-
-
-4.  Data Packing
+3.  Data Packing
 
    Data serialization for properties is performed using a light-weight
    data packing format which was loosely inspired by D-Bus.  The format
@@ -420,7 +650,7 @@ Quattlebaum              Expires March 13, 2017                 [Page 7]
    In each case, the data is represented exactly as described.  For
    example, an array of 10 IPv6 address is stored as 160 bytes.
 
-4.1.  Primitive Types
+3.1.  Primitive Types
 
 
 
@@ -439,15 +669,9 @@ Quattlebaum              Expires March 13, 2017                 [Page 7]
 
 
 
-
-
-
-
-
-
-Quattlebaum              Expires March 13, 2017                 [Page 8]
+Quattlebaum              Expires March 14, 2017                [Page 12]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
    +------+----------------------+-------------------------------------+
@@ -464,23 +688,23 @@ Quattlebaum              Expires March 13, 2017                 [Page 8]
    | "L"  | DATATYPE_UINT32      | Unsigned 32-bit integer.            |
    | "l"  | DATATYPE_INT32       | Signed 32-bit integer.              |
    | "i"  | DATATYPE_UINT_PACKED | Packed Unsigned Integer. See        |
-   |      |                      | Section 4.2.                        |
+   |      |                      | Section 3.2.                        |
    | "6"  | DATATYPE_IPv6ADDR    | IPv6 Address. (Big-endian)          |
    | "E"  | DATATYPE_EUI64       | EUI-64 Address. (Big-endian)        |
    | "e"  | DATATYPE_EUI48       | EUI-48 Address. (Big-endian)        |
-   | "D"  | DATATYPE_DATA        | Arbitrary Data. See Section 4.3.    |
+   | "D"  | DATATYPE_DATA        | Arbitrary Data. See Section 3.3.    |
    | "U"  | DATATYPE_UTF8        | Zero-terminated UTF8-encoded        |
    |      |                      | string.                             |
    | "T"  | DATATYPE_STRUCT      | Structured datatype. Compound type. |
-   |      |                      | See Section 4.4.                    |
+   |      |                      | See Section 3.4.                    |
    | "A"  | DATATYPE_ARRAY       | Array of datatypes. Compound type.  |
-   |      |                      | See Section 4.5.                    |
+   |      |                      | See Section 3.5.                    |
    +------+----------------------+-------------------------------------+
 
    All multi-byte values are little-endian unless explicitly stated
    otherwise.
 
-4.2.  Packed Unsigned Integer
+3.2.  Packed Unsigned Integer
 
    For certain types of integers, such command or property identifiers,
    usually have a value on the wire that is less than 127.  However, in
@@ -489,7 +713,7 @@ Quattlebaum              Expires March 13, 2017                 [Page 8]
    vast majority of instances, which can add up in terms of bandwidth.
 
    The packed unsigned integer format is based on the unsigned integer
-   format in EXI [1], except that we limit the maximum value to the
+   format in EXI [3], except that we limit the maximum value to the
    largest value that can be encoded into three bytes(2,097,151).
 
    For all values less than 127, the packed form of the number is simply
@@ -501,9 +725,9 @@ Quattlebaum              Expires March 13, 2017                 [Page 8]
 
 
 
-Quattlebaum              Expires March 13, 2017                 [Page 9]
+Quattlebaum              Expires March 14, 2017                [Page 13]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
    1.  The unsigned integer is broken up into _n_ 7-bit chunks and
@@ -526,7 +750,7 @@ Quattlebaum              Expires March 13, 2017                 [Page 9]
    To decode the value, you collect the 7-bit chunks until you find an
    octet with the most significant bit clear.
 
-4.3.  Data Blobs
+3.3.  Data Blobs
 
    Data blobs are special datatypes in that the data that they contain
    does not inherently define the size of the data.  This means that if
@@ -557,16 +781,16 @@ Quattlebaum              Expires March 13, 2017                 [Page 9]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 10]
+Quattlebaum              Expires March 14, 2017                [Page 14]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
-      Originally the length was a Section 4.2, but it was changed to an
+      Originally the length was a Section 3.2, but it was changed to an
       unsigned 16-bit integer in order to help reduce protocol
       requirements.
 
-4.4.  Structured Data
+3.4.  Structured Data
 
    The structured data type is a way of bundling together a bunch of
    data into a single data structure.  This may at first seem useless.
@@ -601,7 +825,7 @@ Quattlebaum              Expires March 13, 2017                [Page 10]
    When a length is prepended, the length is encoded as a little-endian
    unsigned 16-bit integer.
 
-4.5.  Arrays
+3.5.  Arrays
 
    An array is simply a concatenated set of _n_ data encodings.  For
    example, the type "A(6)" is simply a list of IPv6 addresses---one
@@ -613,9 +837,9 @@ Quattlebaum              Expires March 13, 2017                [Page 10]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 11]
+Quattlebaum              Expires March 14, 2017                [Page 15]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
    type in a given signature.  Thus, "A(C)" (An array of unsigned bytes)
@@ -624,9 +848,9 @@ Quattlebaum              Expires March 13, 2017                [Page 11]
    When a length is prepended, the length is encoded as a little-endian
    unsigned 16-bit integer.
 
-5.  Commands
+4.  Commands
 
-5.1.  CMD 0: (Host->NCP) CMD_NOOP
+4.1.  CMD 0: (Host->NCP) CMD_NOOP
 
                       +---------+--------+----------+
                       | Octets: |   1    |    1     |
@@ -642,7 +866,7 @@ Quattlebaum              Expires March 13, 2017                [Page 11]
 
    There is no error condition for this command.
 
-5.2.  CMD 1: (Host->NCP) CMD_RESET
+4.2.  CMD 1: (Host->NCP) CMD_RESET
 
                      +---------+--------+-----------+
                      | Octets: |   1    |     1     |
@@ -669,12 +893,12 @@ Quattlebaum              Expires March 13, 2017                [Page 11]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 12]
+Quattlebaum              Expires March 14, 2017                [Page 16]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
-5.3.  CMD 2: (Host->NCP) CMD_PROP_VALUE_GET
+4.3.  CMD 2: (Host->NCP) CMD_PROP_VALUE_GET
 
             +---------+--------+--------------------+---------+
             | Octets: |   1    |         1          |   1-3   |
@@ -686,13 +910,13 @@ Quattlebaum              Expires March 13, 2017                [Page 12]
    "CMD_PROP_VALUE_IS" command for the given property identifier.
 
    The payload for this command is the property identifier encoded in
-   the packed unsigned integer format described in Section 4.2.
+   the packed unsigned integer format described in Section 3.2.
 
    If an error occurs, the value of "PROP_LAST_STATUS" will be emitted
    instead with the value set to the generated status code for the
    error.
 
-5.4.  CMD 3: (Host->NCP) CMD_PROP_VALUE_SET
+4.4.  CMD 3: (Host->NCP) CMD_PROP_VALUE_SET
 
         +---------+--------+--------------------+---------+-------+
         | Octets: |   1    |         1          |   1-3   |   n   |
@@ -704,14 +928,14 @@ Quattlebaum              Expires March 13, 2017                [Page 12]
    property to the specific given value, replacing any previous value.
 
    The payload for this command is the property identifier encoded in
-   the packed unsigned integer format described in Section 4.2, followed
+   the packed unsigned integer format described in Section 3.2, followed
    by the property value.  The exact format of the property value is
    defined by the property.
 
    If an error occurs, the value of "PROP_LAST_STATUS" will be emitted
    with the value set to the generated status code for the error.
 
-5.5.  CMD 4: (Host->NCP) CMD_PROP_VALUE_INSERT
+4.5.  CMD 4: (Host->NCP) CMD_PROP_VALUE_INSERT
 
       +---------+--------+-----------------------+---------+-------+
       | Octets: |   1    |           1           |   1-3   |   n   |
@@ -725,23 +949,23 @@ Quattlebaum              Expires March 13, 2017                [Page 12]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 13]
+Quattlebaum              Expires March 14, 2017                [Page 17]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
    items in the list.  The resulting order of items in the list is
    defined by the individual property being operated on.
 
    The payload for this command is the property identifier encoded in
-   the packed unsigned integer format described in Section 4.2, followed
+   the packed unsigned integer format described in Section 3.2, followed
    by the value to be inserted.  The exact format of the value is
    defined by the property.
 
    If an error occurs, the value of "PROP_LAST_STATUS" will be emitted
    with the value set to the generated status code for the error.
 
-5.6.  CMD 5: (Host->NCP) CMD_PROP_VALUE_REMOVE
+4.6.  CMD 5: (Host->NCP) CMD_PROP_VALUE_REMOVE
 
       +---------+--------+-----------------------+---------+-------+
       | Octets: |   1    |           1           |   1-3   |   n   |
@@ -757,14 +981,14 @@ Quattlebaum              Expires March 13, 2017                [Page 13]
    Note that this command operates _by value_, not by index!
 
    The payload for this command is the property identifier encoded in
-   the packed unsigned integer format described in Section 4.2, followed
+   the packed unsigned integer format described in Section 3.2, followed
    by the value to be removed.  The exact format of the value is defined
    by the property.
 
    If an error occurs, the value of "PROP_LAST_STATUS" will be emitted
    with the value set to the generated status code for the error.
 
-5.7.  CMD 6: (NCP->Host) CMD_PROP_VALUE_IS
+4.7.  CMD 6: (NCP->Host) CMD_PROP_VALUE_IS
 
         +---------+--------+-------------------+---------+-------+
         | Octets: |   1    |         1         |   1-3   |   n   |
@@ -781,16 +1005,16 @@ Quattlebaum              Expires March 13, 2017                [Page 13]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 14]
+Quattlebaum              Expires March 14, 2017                [Page 18]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
    The payload for this command is the property identifier encoded in
-   the packed unsigned integer format described in Section 4.2, followed
+   the packed unsigned integer format described in Section 3.2, followed
    by the current value of the given property.
 
-5.8.  CMD 7: (NCP->Host) CMD_PROP_VALUE_INSERTED
+4.8.  CMD 7: (NCP->Host) CMD_PROP_VALUE_INSERTED
 
      +---------+--------+-------------------------+---------+-------+
      | Octets: |   1    |            1            |   1-3   |   n   |
@@ -804,13 +1028,13 @@ Quattlebaum              Expires March 13, 2017                [Page 14]
    host of various state changes asynchronously.
 
    The payload for this command is the property identifier encoded in
-   the packed unsigned integer format described in Section 4.2, followed
+   the packed unsigned integer format described in Section 3.2, followed
    by the value that was inserted into the given property.
 
    The resulting order of items in the list is defined by the given
    property.
 
-5.9.  CMD 8: (NCP->Host) CMD_PROP_VALUE_REMOVED
+4.9.  CMD 8: (NCP->Host) CMD_PROP_VALUE_REMOVED
 
       +---------+--------+------------------------+---------+-------+
       | Octets: |   1    |           1            |   1-3   |   n   |
@@ -826,7 +1050,7 @@ Quattlebaum              Expires March 13, 2017                [Page 14]
    Note that this command operates _by value_, not by index!
 
    The payload for this command is the property identifier encoded in
-   the packed unsigned integer format described in Section 4.2, followed
+   the packed unsigned integer format described in Section 3.2, followed
    by the value that was removed from the given property.
 
    The resulting order of items in the list is defined by the given
@@ -837,12 +1061,12 @@ Quattlebaum              Expires March 13, 2017                [Page 14]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 15]
+Quattlebaum              Expires March 14, 2017                [Page 19]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
-6.  Properties
+5.  Properties
 
    While the majority of the properties that allow the configuration of
    network connectivity are network protocol specific, there are several
@@ -862,9 +1086,9 @@ Quattlebaum              Expires March 13, 2017                [Page 15]
     +-----------------------+-----------------------------------------+
 
    For an explanation of the data format encoding shorthand used
-   throughout this document, see Section 4.
+   throughout this document, see Section 3.
 
-6.1.  Property Sections
+5.1.  Property Sections
 
    The currently assigned properties are broken up into several
    sections, each with reserved ranges of property identifiers.  These
@@ -873,13 +1097,13 @@ Quattlebaum              Expires March 13, 2017                [Page 15]
       +--------+------------------------------+---------------------+
       |  Name  |      Range (Inclusive)       |    Documentation    |
       +--------+------------------------------+---------------------+
-      |  Core  | 0x00 - 0x1F, 0x1000 - 0x11FF |     Section 6.2     |
-      |  PHY   | 0x20 - 0x2F, 0x1200 - 0x12FF |     Section 6.3     |
-      |  MAC   | 0x30 - 0x3F, 0x1300 - 0x13FF |     Section 6.4     |
-      |  NET   | 0x40 - 0x4F, 0x1400 - 0x14FF |     Section 6.5     |
+      |  Core  | 0x00 - 0x1F, 0x1000 - 0x11FF |     Section 5.2     |
+      |  PHY   | 0x20 - 0x2F, 0x1200 - 0x12FF |     Section 5.3     |
+      |  MAC   | 0x30 - 0x3F, 0x1300 - 0x13FF |     Section 5.4     |
+      |  NET   | 0x40 - 0x4F, 0x1400 - 0x14FF |     Section 5.5     |
       |  Tech  | 0x50 - 0x5F, 0x1500 - 0x15FF | Technology-specific |
-      |  IPv6  | 0x60 - 0x6F, 0x1600 - 0x16FF |     Section 6.6     |
-      | Stream | 0x70 - 0x7F, 0x1700 - 0x17FF |     Section 6.2     |
+      |  IPv6  | 0x60 - 0x6F, 0x1600 - 0x16FF |     Section 5.6     |
+      | Stream | 0x70 - 0x7F, 0x1700 - 0x17FF |     Section 5.2     |
       +--------+------------------------------+---------------------+
 
    Note that each property section has two reserved ranges: a primary
@@ -893,14 +1117,14 @@ Quattlebaum              Expires March 13, 2017                [Page 15]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 16]
+Quattlebaum              Expires March 14, 2017                [Page 20]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
-6.2.  Core Properties
+5.2.  Core Properties
 
-6.2.1.  PROP 0: PROP_LAST_STATUS
+5.2.1.  PROP 0: PROP_LAST_STATUS
 
    o  Type: Read-Only
    o  Encoding: "i"
@@ -920,9 +1144,9 @@ Quattlebaum              Expires March 13, 2017                [Page 16]
    It is emitted automatically at NCP startup with a value indicating
    the reset reason.
 
-   See Section 7 for the complete list of status codes.
+   See Section 6 for the complete list of status codes.
 
-6.2.2.  PROP 1: PROP_PROTOCOL_VERSION
+5.2.2.  PROP 1: PROP_PROTOCOL_VERSION
 
    o  Type: Read-Only
    o  Encoding: "ii"
@@ -949,12 +1173,12 @@ Quattlebaum              Expires March 13, 2017                [Page 16]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 17]
+Quattlebaum              Expires March 14, 2017                [Page 21]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
-6.2.2.1.  Major Version Number
+5.2.2.1.  Major Version Number
 
    The major version number is used to identify large and incompatible
    differences between protocol versions.
@@ -962,7 +1186,7 @@ Quattlebaum              Expires March 13, 2017                [Page 17]
    The host MUST enter a FAULT state if it does not explicitly support
    the given major version number.
 
-6.2.2.2.  Minor Version Number
+5.2.2.2.  Minor Version Number
 
    The minor version number is used to identify small but otherwise
    compatible differences between protocol versions.  A mismatch between
@@ -970,7 +1194,7 @@ Quattlebaum              Expires March 13, 2017                [Page 17]
    supported by the host SHOULD NOT be fatal to the operation of the
    host.
 
-6.2.3.  PROP 2: PROP_NCP_VERSION
+5.2.3.  PROP 2: PROP_NCP_VERSION
 
    o  Type: Read-Only
    o  Packed-Encoding: "U"
@@ -995,7 +1219,7 @@ Quattlebaum              Expires March 13, 2017                [Page 17]
    o  "OpenThread/1.0d26-25-gb684c7f; DEBUG; May 9 2016 18:22:04"
    o  "ConnectIP/2.0b125 s1 ALPHA; Sept 24 2015 20:49:19"
 
-6.2.4.  PROP 3: PROP_INTERFACE_TYPE
+5.2.4.  PROP 3: PROP_INTERFACE_TYPE
 
    o  Type: Read-Only
    o  Encoding: "i"
@@ -1005,9 +1229,9 @@ Quattlebaum              Expires March 13, 2017                [Page 17]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 18]
+Quattlebaum              Expires March 14, 2017                [Page 22]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
                        +---------+----------------+
@@ -1026,7 +1250,7 @@ Quattlebaum              Expires March 13, 2017                [Page 18]
    The host MUST enter a FAULT state if it does not recognize the
    protocol given by the NCP.
 
-6.2.5.  PROP 4: PROP_INTERFACE_VENDOR_ID
+5.2.5.  PROP 4: PROP_INTERFACE_VENDOR_ID
 
    o  Type: Read-Only
    o  Encoding: "i"
@@ -1039,7 +1263,7 @@ Quattlebaum              Expires March 13, 2017                [Page 18]
 
    Vendor identifier.
 
-6.2.6.  PROP 5: PROP_CAPS
+5.2.6.  PROP 5: PROP_CAPS
 
    o  Type: Read-Only
    o  Packed-Encoding: "A(i)"
@@ -1061,9 +1285,9 @@ Quattlebaum              Expires March 13, 2017                [Page 18]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 19]
+Quattlebaum              Expires March 14, 2017                [Page 23]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
    o  1: "CAP_LOCK"
@@ -1099,7 +1323,7 @@ Quattlebaum              Expires March 13, 2017                [Page 19]
         | 2,000,000 - 2,097,151 |     Experimental use only      |
         +-----------------------+--------------------------------+
 
-6.2.7.  PROP 6: PROP_INTERFACE_COUNT
+5.2.7.  PROP 6: PROP_INTERFACE_COUNT
 
    o  Type: Read-Only
    o  Packed-Encoding: "C"
@@ -1117,14 +1341,14 @@ Quattlebaum              Expires March 13, 2017                [Page 19]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 20]
+Quattlebaum              Expires March 14, 2017                [Page 24]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
    This value is encoded as an unsigned 8-bit integer.
 
-6.2.8.  PROP 7: PROP_POWER_STATE
+5.2.8.  PROP 7: PROP_POWER_STATE
 
    o  Type: Read-Write
    o  Packed-Encoding: "C"
@@ -1153,7 +1377,7 @@ Quattlebaum              Expires March 13, 2017                [Page 20]
    o  4: "POWER_STATE_ONLINE": NCP is fully powered. (e.g.  "Parent"
       node)
 
-6.2.9.  PROP 8: PROP_HWADDR
+5.2.9.  PROP 8: PROP_HWADDR
 
    o  Type: Read-Only*
    o  Packed-Encoding: "E"
@@ -1173,12 +1397,12 @@ Quattlebaum              Expires March 13, 2017                [Page 20]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 21]
+Quattlebaum              Expires March 14, 2017                [Page 25]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
-6.2.10.  PROP 9: PROP_LOCK
+5.2.10.  PROP 9: PROP_LOCK
 
    o  Type: Read-Write
    o  Packed-Encoding: "b"
@@ -1201,7 +1425,7 @@ Quattlebaum              Expires March 13, 2017                [Page 21]
    value of the property is already true MUST fail with a last status of
    "STATUS_ALREADY".
 
-6.2.11.  PROP 112: PROP_STREAM_DEBUG
+5.2.11.  PROP 112: PROP_STREAM_DEBUG
 
    o  Type: Read-Only-Stream
    o  Packed-Encoding: "U"
@@ -1229,12 +1453,12 @@ Quattlebaum              Expires March 13, 2017                [Page 21]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 22]
+Quattlebaum              Expires March 14, 2017                [Page 26]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
-6.2.12.  PROP 113: PROP_STREAM_RAW
+5.2.12.  PROP 113: PROP_STREAM_RAW
 
    o  Type: Read-Write-Stream
    o  Packed-Encoding: "DD"
@@ -1263,7 +1487,7 @@ Quattlebaum              Expires March 13, 2017                [Page 22]
    The format of the metadata is defined by the associated MAC and PHY
    being used, and typically includes RSSI/TX-Power, LQI, etc.
 
-6.2.13.  PROP 114: PROP_STREAM_NET
+5.2.13.  PROP 114: PROP_STREAM_NET
 
    o  Type: Read-Write-Stream
    o  Packed-Encoding: "DD"
@@ -1285,9 +1509,9 @@ Quattlebaum              Expires March 13, 2017                [Page 22]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 23]
+Quattlebaum              Expires March 14, 2017                [Page 27]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
    wait for "CMD_PROP_VALUE_IS" commands with this property id from the
@@ -1300,7 +1524,7 @@ Quattlebaum              Expires March 13, 2017                [Page 23]
    The format of the metadata is defined by the associated network
    protocol and typically includes RSSI/TX-Power, LQI, etc.
 
-6.2.14.  PROP 114: PROP_STREAM_NET_INSECURE
+5.2.14.  PROP 114: PROP_STREAM_NET_INSECURE
 
    o  Type: Read-Write-Stream
    o  Packed-Encoding: "DD"
@@ -1329,9 +1553,9 @@ Quattlebaum              Expires March 13, 2017                [Page 23]
    The format of the metadata is defined by the associated network
    protocol, and typically includes RSSI/TX-Power, LQI, etc.
 
-6.3.  PHY Properties
+5.3.  PHY Properties
 
-6.3.1.  PROP 32: PROP_PHY_ENABLED
+5.3.1.  PROP 32: PROP_PHY_ENABLED
 
    o  Type: Read-Write
    o  Packed-Encoding: "b" (bool8)
@@ -1341,16 +1565,16 @@ Quattlebaum              Expires March 13, 2017                [Page 23]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 24]
+Quattlebaum              Expires March 14, 2017                [Page 28]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
    Set to 1 if the PHY is enabled, set to 0 otherwise.  May be directly
    enabled to bypass higher-level packet processing in order to
    implement things like packet sniffers.
 
-6.3.2.  PROP 33: PROP_PHY_CHAN
+5.3.2.  PROP 33: PROP_PHY_CHAN
 
    o  Type: Read-Write
    o  Packed-Encoding: "C" (uint8)
@@ -1358,7 +1582,7 @@ Quattlebaum              Expires March 13, 2017                [Page 24]
    Value is the current channel.  Must be set to one of the values
    contained in "PROP_PHY_CHAN_SUPPORTED".
 
-6.3.3.  PROP 34: PROP_PHY_CHAN_SUPPORTED
+5.3.3.  PROP 34: PROP_PHY_CHAN_SUPPORTED
 
    o  Type: Read-Only
    o  Packed-Encoding: "A(C)" (array of uint8)
@@ -1366,7 +1590,7 @@ Quattlebaum              Expires March 13, 2017                [Page 24]
 
    Value is a list of channel values that are supported by the hardware.
 
-6.3.4.  PROP 35: PROP_PHY_FREQ
+5.3.4.  PROP 35: PROP_PHY_FREQ
 
    o  Type: Read-Only
    o  Packed-Encoding: "L" (uint32)
@@ -1374,7 +1598,7 @@ Quattlebaum              Expires March 13, 2017                [Page 24]
 
    Value is the radio frequency (in kilohertz) of the current channel.
 
-6.3.5.  PROP 36: PROP_PHY_CCA_THRESHOLD
+5.3.5.  PROP 36: PROP_PHY_CCA_THRESHOLD
 
    o  Type: Read-Write
    o  Packed-Encoding: "c" (int8)
@@ -1386,7 +1610,7 @@ Quattlebaum              Expires March 13, 2017                [Page 24]
    When setting, the value will be rounded down to a value that is
    supported by the underlying radio hardware.
 
-6.3.6.  PROP 37: PROP_PHY_TX_POWER
+5.3.6.  PROP 37: PROP_PHY_TX_POWER
 
    o  Type: Read-Write
    o  Packed-Encoding: "c" (int8)
@@ -1397,15 +1621,15 @@ Quattlebaum              Expires March 13, 2017                [Page 24]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 25]
+Quattlebaum              Expires March 14, 2017                [Page 29]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
    When setting, the value will be rounded down to a value that is
    supported by the underlying radio hardware.
 
-6.3.7.  PROP 38: PROP_PHY_RSSI
+5.3.7.  PROP 38: PROP_PHY_RSSI
 
    o  Type: Read-Only
    o  Packed-Encoding: "c" (int8)
@@ -1415,9 +1639,9 @@ Quattlebaum              Expires March 13, 2017                [Page 25]
    the radio.  This value can be used in energy scans and for
    determining the ambient noise floor for the operating environment.
 
-6.4.  MAC Properties
+5.4.  MAC Properties
 
-6.4.1.  PROP 48: PROP_MAC_SCAN_STATE
+5.4.1.  PROP 48: PROP_MAC_SCAN_STATE
 
    o  Type: Read-Write
    o  Packed-Encoding: "C"
@@ -1438,13 +1662,13 @@ Quattlebaum              Expires March 13, 2017                [Page 25]
 
    Values switches to "SCAN_STATE_IDLE" when scan is complete.
 
-6.4.2.  PROP 49: PROP_MAC_SCAN_MASK
+5.4.2.  PROP 49: PROP_MAC_SCAN_MASK
 
    o  Type: Read-Write
    o  Packed-Encoding: "A(C)"
    o  Unit: List of channels to scan
 
-6.4.3.  PROP 50: PROP_MAC_SCAN_PERIOD
+5.4.3.  PROP 50: PROP_MAC_SCAN_PERIOD
 
    o  Type: Read-Write
    o  Packed-Encoding: "S" (uint16)
@@ -1453,12 +1677,12 @@ Quattlebaum              Expires March 13, 2017                [Page 25]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 26]
+Quattlebaum              Expires March 14, 2017                [Page 30]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
-6.4.4.  PROP 51: PROP_MAC_SCAN_BEACON
+5.4.4.  PROP 51: PROP_MAC_SCAN_BEACON
 
    o  Type: Read-Only-Stream
    o  Packed-Encoding: "CcDD." (or "CcT(ESSc.)T(iCUD.).")
@@ -1493,7 +1717,7 @@ Quattlebaum              Expires March 13, 2017                [Page 26]
    future, so care should be taken to read the length that prepends each
    structure.
 
-6.4.5.  PROP 52: PROP_MAC_15_4_LADDR
+5.4.5.  PROP 52: PROP_MAC_15_4_LADDR
 
    o  Type: Read-Write
    o  Packed-Encoding: "E"
@@ -1509,12 +1733,12 @@ Quattlebaum              Expires March 13, 2017                [Page 26]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 27]
+Quattlebaum              Expires March 14, 2017                [Page 31]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
-6.4.6.  PROP 53: PROP_MAC_15_4_SADDR
+5.4.6.  PROP 53: PROP_MAC_15_4_SADDR
 
    o  Type: Read-Write
    o  Packed-Encoding: "S"
@@ -1523,7 +1747,7 @@ Quattlebaum              Expires March 13, 2017                [Page 27]
 
    This property is only present on NCPs which implement 802.15.4
 
-6.4.7.  PROP 54: PROP_MAC_15_4_PANID
+5.4.7.  PROP 54: PROP_MAC_15_4_PANID
 
    o  Type: Read-Write
    o  Packed-Encoding: "S"
@@ -1532,15 +1756,15 @@ Quattlebaum              Expires March 13, 2017                [Page 27]
 
    This property is only present on NCPs which implement 802.15.4
 
-6.4.8.  PROP 55: PROP_MAC_RAW_STREAM_ENABLED
+5.4.8.  PROP 55: PROP_MAC_RAW_STREAM_ENABLED
 
    o  Type: Read-Write
    o  Packed-Encoding: "b"
 
    Set to true to enable raw MAC frames to be emitted from
-   "PROP_STREAM_RAW".  See Section 6.2.12.
+   "PROP_STREAM_RAW".  See Section 5.2.12.
 
-6.4.9.  PROP 56: PROP_MAC_FILTER_MODE
+5.4.9.  PROP 56: PROP_MAC_FILTER_MODE
 
    o  Type: Read-Write
    o  Packed-Encoding: "C"
@@ -1559,18 +1783,18 @@ Quattlebaum              Expires March 13, 2017                [Page 27]
    |    |                               |     passed up the stack.     |
    +----+-------------------------------+------------------------------+
 
-   See Section 6.2.12.
+   See Section 5.2.12.
 
 
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 28]
+Quattlebaum              Expires March 14, 2017                [Page 32]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
-6.4.10.  PROP 4864: PROP_MAC_WHITELIST
+5.4.10.  PROP 4864: PROP_MAC_WHITELIST
 
    o  Type: Read-Write
    o  Packed-Encoding: "A(T(Ec))"
@@ -1581,17 +1805,17 @@ Quattlebaum              Expires March 13, 2017                [Page 28]
    o  "E": EUI64 address of node
    o  "c": Optional RSSI-override value.  The value 127 indicates that
       the RSSI-override feature is not enabled for this address.  If
-      this value is ommitted when setting or inserting, it is assumed to
+      this value is omitted when setting or inserting, it is assumed to
       be 127.  This parameter is ignored when removing.
 
-6.4.11.  PROP 4865: PROP_MAC_WHITELIST_ENABLED
+5.4.11.  PROP 4865: PROP_MAC_WHITELIST_ENABLED
 
    o  Type: Read-Write
    o  Packed-Encoding: "b"
 
-6.5.  NET Properties
+5.5.  NET Properties
 
-6.5.1.  PROP 64: PROP_NET_SAVED
+5.5.1.  PROP 64: PROP_NET_SAVED
 
    o  Type: Read-Only
    o  Packed-Encoding: "b"
@@ -1599,7 +1823,7 @@ Quattlebaum              Expires March 13, 2017                [Page 28]
    Returns true if there is a network state stored that can be restored
    with a call to "CMD_NET_RECALL".
 
-6.5.2.  PROP 65: PROP_NET_IF_UP
+5.5.2.  PROP 65: PROP_NET_IF_UP
 
    o  Type: Read-Write
    o  Packed-Encoding: "b"
@@ -1607,7 +1831,7 @@ Quattlebaum              Expires March 13, 2017                [Page 28]
    Network interface up/down status.  Non-zero (set to 1) indicates up,
    zero indicates down.
 
-6.5.3.  PROP 66: PROP_NET_STACK_UP
+5.5.3.  PROP 66: PROP_NET_STACK_UP
 
    o  Type: Read-Write
    o  Packed-Encoding: "b"
@@ -1621,12 +1845,12 @@ Quattlebaum              Expires March 13, 2017                [Page 28]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 29]
+Quattlebaum              Expires March 14, 2017                [Page 33]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
-6.5.4.  PROP 67: PROP_NET_ROLE
+5.5.4.  PROP 67: PROP_NET_ROLE
 
    o  Type: Read-Write
    o  Packed-Encoding: "C"
@@ -1639,36 +1863,36 @@ Quattlebaum              Expires March 13, 2017                [Page 29]
    o  2: "NET_ROLE_ROUTER"
    o  3: "NET_ROLE_LEADER"
 
-6.5.5.  PROP 68: PROP_NET_NETWORK_NAME
+5.5.5.  PROP 68: PROP_NET_NETWORK_NAME
 
    o  Type: Read-Write
    o  Packed-Encoding: "U"
 
-6.5.6.  PROP 69: PROP_NET_XPANID
+5.5.6.  PROP 69: PROP_NET_XPANID
 
    o  Type: Read-Write
    o  Packed-Encoding: "D"
 
-6.5.7.  PROP 70: PROP_NET_MASTER_KEY
+5.5.7.  PROP 70: PROP_NET_MASTER_KEY
 
    o  Type: Read-Write
    o  Packed-Encoding: "D"
 
-6.5.8.  PROP 71: PROP_NET_KEY_SEQUENCE
+5.5.8.  PROP 71: PROP_NET_KEY_SEQUENCE
 
    o  Type: Read-Write
    o  Packed-Encoding: "L"
 
-6.5.9.  PROP 72: PROP_NET_PARTITION_ID
+5.5.9.  PROP 72: PROP_NET_PARTITION_ID
 
    o  Type: Read-Write
    o  Packed-Encoding: "L"
 
    The partition ID of the partition that this node is a member of.
 
-6.6.  IPv6 Properties
+5.6.  IPv6 Properties
 
-6.6.1.  PROP 96: PROP_IPV6_LL_ADDR
+5.6.1.  PROP 96: PROP_IPV6_LL_ADDR
 
    o  Type: Read-Only
    o  Packed-Encoding: "6"
@@ -1677,26 +1901,26 @@ Quattlebaum              Expires March 13, 2017                [Page 29]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 30]
+Quattlebaum              Expires March 14, 2017                [Page 34]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
-6.6.2.  PROP 97: PROP_IPV6_ML_ADDR
+5.6.2.  PROP 97: PROP_IPV6_ML_ADDR
 
    o  Type: Read-Only
    o  Packed-Encoding: "6"
 
    IPv6 Address + Prefix Length
 
-6.6.3.  PROP 98: PROP_IPV6_ML_PREFIX
+5.6.3.  PROP 98: PROP_IPV6_ML_PREFIX
 
    o  Type: Read-Write
    o  Packed-Encoding: "6C"
 
    IPv6 Prefix + Prefix Length
 
-6.6.4.  PROP 99: PROP_IPV6_ADDRESS_TABLE
+5.6.4.  PROP 99: PROP_IPV6_ADDRESS_TABLE
 
    o  Type: Read-Write
    o  Packed-Encoding: "A(T(6CLLC))"
@@ -1709,7 +1933,7 @@ Quattlebaum              Expires March 13, 2017                [Page 30]
    o  "L": Preferred Lifetime
    o  "C": Flags
 
-6.6.5.  PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD
+5.6.5.  PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD
 
    o  Type: Read-Write
    o  Packed-Encoding: "b"
@@ -1719,7 +1943,7 @@ Quattlebaum              Expires March 13, 2017                [Page 30]
 
    Default value is "false".
 
-7.  Status Codes
+6.  Status Codes
 
    Status codes are sent from the NCP to the host via "PROP_LAST_STATUS"
    using the "CMD_VALUE_IS" command to indicate the return status of a
@@ -1733,16 +1957,16 @@ Quattlebaum              Expires March 13, 2017                [Page 30]
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 31]
+Quattlebaum              Expires March 14, 2017                [Page 35]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
    would indicate success by responding with a "CMD_VALUE_IS" for
    "PROP_PHY_ENABLED".  If the command failed, "PROP_LAST_STATUS" would
    be emitted instead.
 
-   See Section 6.2.1 for more information on "PROP_LAST_STATUS".
+   See Section 5.2.1 for more information on "PROP_LAST_STATUS".
 
    o  0: "STATUS_OK": Operation has completed successfully.
    o  1: "STATUS_FAILURE": Operation has failed for some undefined
@@ -1756,10 +1980,11 @@ Quattlebaum              Expires March 13, 2017                [Page 31]
    o  5: "STATUS_INVALID_COMMAND": The given command is not recognized.
    o  6: "STATUS_INVALID_INTERFACE": The given Spinel interface is not
       supported.
-   o  7: "STATUS_INTERNAL_ERROR": An internal runtime error has occured.
+   o  7: "STATUS_INTERNAL_ERROR": An internal runtime error has
+      occurred.
    o  8: "STATUS_SECURITY_ERROR": A security or authentication error has
-      occured.
-   o  9: "STATUS_PARSE_ERROR": An error has occured while parsing the
+      occurred.
+   o  9: "STATUS_PARSE_ERROR": An error has occurred while parsing the
       command.
    o  10: "STATUS_IN_PROGRESS": The operation is in progress and will be
       completed asynchronously.
@@ -1785,15 +2010,15 @@ Quattlebaum              Expires March 13, 2017                [Page 31]
       *  112: "STATUS_RESET_POWER_ON"
       *  113: "STATUS_RESET_EXTERNAL"
       *  114: "STATUS_RESET_SOFTWARE"
-      *  115: "STATUS_RESET_FAULT"
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 32]
+Quattlebaum              Expires March 14, 2017                [Page 36]
 
-                        Spinel Protocol (94724cf)         September 2016
+                        Spinel Protocol (4d55c14)         September 2016
 
 
+      *  115: "STATUS_RESET_FAULT"
       *  116: "STATUS_RESET_CRASH"
       *  117: "STATUS_RESET_ASSERT"
       *  118: "STATUS_RESET_OTHER"
@@ -1806,13 +2031,48 @@ Quattlebaum              Expires March 13, 2017                [Page 32]
    o  2,000,000 - 2,097,151: Experimental Use Only (MUST NEVER be used
       in production!)
 
-8.  References
+7.  Security Considerations
 
-8.1.  URIs
+   TBD
 
-   [1] https://www.w3.org/TR/exi/#encodingUnsignedInteger
+8.  Acknowledgments
 
-   [2] http://reveng.sourceforge.net/crc-catalogue/16.htm#crc.cat.kermit
+   Special thanks to Abtin Keshavarzian, Martin Turon, Arjuna
+   Sivasithambaresan and Jonathan Hui for their substantial
+   contributions and feedback related to this document.
+
+   [CREF2]
+
+   This document was prepared using mmark [4] by (Miek Gieben) and
+   xml2rfc (version 2) [5].
+
+9.  References
+
+9.1.  URIs
+
+   [1] http://wpantund.org/
+
+   [2] https://www.freedesktop.org/wiki/Software/dbus/
+
+   [3] https://www.w3.org/TR/exi/#encodingUnsignedInteger
+
+   [4] https://github.com/miekg/mmark
+
+   [5] http://xml2rfc.ietf.org/
+
+   [6] http://reveng.sourceforge.net/crc-catalogue/16.htm#crc.cat.kermit
+
+
+
+
+
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 37]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
 
 Appendix A.  Framing Protocol
 
@@ -1838,18 +2098,10 @@ A.1.  UART Recommendations
    the absence of hardware flow control, software flow control (XON/
    XOFF) MUST be used instead.
 
-   We also *RECOMMEND* an arduino-style hardware reset, where the DTR
+   We also *RECOMMEND* an Arduino-style hardware reset, where the DTR
    signal is coupled to the "R&#773;E&#773;S&#773;" pin through a
    0.01[micro]F capacitor.  This causes the NCP to automatically reset
    whenever the serial port is opened.  At the very least we *RECOMMEND*
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 33]
-
-                        Spinel Protocol (94724cf)         September 2016
-
-
    dedicating one of your host pins to controlling the
    "R&#773;E&#773;S&#773;" pin on the NCP, so that you can easily
    perform a hardware reset if necessary.
@@ -1864,10 +2116,19 @@ A.1.1.  HDLC-Lite
 
    To transmit a frame with HDLC-lite, the 16-bit CRC must first be
    appended to the frame.  The CRC function is defined to be CRC-16/
-   CCITT, otherwise known as the KERMIT CRC [2].
+   CCITT, otherwise known as the KERMIT CRC [6].
 
    Individual frames are terminated with a frame delimiter octet called
    the 'flag' octet ("0x7E").
+
+
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 38]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
 
    The following octets values are considered _special_ and should be
    escaped when present in data frames:
@@ -1896,16 +2157,6 @@ A.1.1.  HDLC-Lite
    a framing error.  Consecutive flag octets MAY be used as a way to
    wake up a sleeping NCP.
 
-
-
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 34]
-
-                        Spinel Protocol (94724cf)         September 2016
-
-
    When first establishing a connection to the NCP, it is customary to
    send one or more flag octets to ensure that any previously received
    data is discarded.
@@ -1927,6 +2178,13 @@ A.2.  SPI Recommendations
    manner.
 
    We RECOMMEND the following SPI properties:
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 39]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
 
    o  "C&#773;S&#773;" is active low.
    o  "CLK" is active high.
@@ -1954,14 +2212,6 @@ A.2.1.  SPI Framing Protocol
       other device must not send any data.  (Little endian)
    o  "DATA_LEN": The fourth and fifth bytes indicate the size of the
       pending data frame to be sent to the other device.  If this value
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 35]
-
-                        Spinel Protocol (94724cf)         September 2016
-
-
       is equal-to or less-than the number of bytes that the other device
       is willing to receive, then the data of the frame is immediately
       after the header.  (Little Endian)
@@ -1985,6 +2235,13 @@ Quattlebaum              Expires March 13, 2017                [Page 35]
       MUST be cleared (0).  A frame received that has any other values
       for these bits MUST be dropped.
 
+
+
+Quattlebaum              Expires March 14, 2017                [Page 40]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
    Prior to a sending or receiving a frame, the master SHOULD send a
    5-octet frame with zeros for both the max receive frame size and the
    the contained frame length.  This will induce the slave device to
@@ -2005,18 +2262,6 @@ Quattlebaum              Expires March 13, 2017                [Page 35]
 A.3.  I^2C Recommendations
 
    TBD
-
-
-
-
-
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 36]
-
-                        Spinel Protocol (94724cf)         September 2016
-
 
 A.4.  Native USB Recommendations
 
@@ -2045,6 +2290,14 @@ B.1.1.  CMD 9: (Host->NCP) CMD_NET_SAVE
    and state necessary to reconnect to the current network to non-
    volatile memory.
 
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 41]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
    This operation affects non-volatile memory only.  The current network
    information stored in volatile memory is unaffected.
 
@@ -2065,14 +2318,6 @@ B.1.2.  CMD 10: (Host->NCP) CMD_NET_CLEAR
    Clear saved network state command.  Clears any previously saved
    network credentials and state previously stored by "CMD_NET_SAVE"
    from non-volatile memory.
-
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 37]
-
-                        Spinel Protocol (94724cf)         September 2016
-
 
    This operation affects non-volatile memory only.  The current network
    information stored in volatile memory is unaffected.
@@ -2101,6 +2346,14 @@ B.1.3.  CMD 11: (Host->NCP) CMD_NET_RECALL
    "CMD_PROP_VALUE_IS" for "PROP_LAST_STATUS", indicating the result of
    the operation.
 
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 42]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
    This command is only available if the "CAP_NET_SAVE" capability is
    set.
 
@@ -2117,18 +2370,6 @@ Appendix C.  Feature: Host Buffer Offload
 
    The presence of this feature can be detected by the host by checking
    for the presence of the "CAP_HBO" capability in "PROP_CAPS".
-
-
-
-
-
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 38]
-
-                        Spinel Protocol (94724cf)         September 2016
-
 
 C.1.  Commands
 
@@ -2162,6 +2403,13 @@ C.1.4.  CMD 15: (Host->NCP) CMD_HBO_OFFLOADED
       *  "OffloadId": 32-bit unique block identifier
       *  "Status": Status code for the result of the operation.
 
+
+
+Quattlebaum              Expires March 14, 2017                [Page 43]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
 C.1.5.  CMD 16: (Host->NCP) CMD_HBO_RECLAIMED
 
    o  Argument-Encoding: "LiD"
@@ -2176,15 +2424,6 @@ C.1.6.  CMD 17: (Host->NCP) CMD_HBO_DROPPED
 
       *  "OffloadId": 32-bit unique block identifier
       *  "Status": Status code for the result of the operation.
-
-
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 39]
-
-                        Spinel Protocol (94724cf)         September 2016
-
 
 C.2.  Properties
 
@@ -2219,6 +2458,14 @@ C.2.2.  PROP 11: PROP_HBO_BLOCK_MAX
                     | Fields: | "PROP_HBO_BLOCK_MAX" |
                     +---------+----------------------+
 
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 44]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
    Describes the number of blocks that may be offloaded from the NCP to
    the host.  Default value is 32.  Setting this value to zero will
    cause host block offload to be effectively disabled.
@@ -2235,13 +2482,6 @@ Appendix D.  Technology: Thread
 
    Thread NCPs have the following requirements:
 
-
-
-Quattlebaum              Expires March 13, 2017                [Page 40]
-
-                        Spinel Protocol (94724cf)         September 2016
-
-
    o  The property "PROP_INTERFACE_TYPE" must be 3.
    o  The non-optional properties in the following sections MUST be
       implemented: CORE, PHY, MAC, NET, and IPV6.
@@ -2251,7 +2491,7 @@ Quattlebaum              Expires March 13, 2017                [Page 40]
 
 D.1.  Thread Capabilities
 
-   The Thread techology defines the following capabilities:
+   The Thread technology defines the following capabilities:
 
    o  "CAP_NET_THREAD_1_0" - Indicates that the NCP implements v1.0 of
       the Thread standard.
@@ -2261,7 +2501,7 @@ D.1.  Thread Capabilities
 D.2.  Thread Properties
 
    Properties for Thread are allocated out of the "Tech" property
-   section (see Section 6.1).
+   section (see Section 5.1).
 
 D.2.1.  PROP 80: PROP_THREAD_LEADER_ADDR
 
@@ -2270,6 +2510,17 @@ D.2.1.  PROP 80: PROP_THREAD_LEADER_ADDR
 
    The IPv6 address of the leader.  (Note: May change to long and short
    address of leader)
+
+
+
+
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 45]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
 
 D.2.2.  PROP 81: PROP_THREAD_PARENT
 
@@ -2286,17 +2537,6 @@ D.2.3.  PROP 82: PROP_THREAD_CHILD_TABLE
 
    Table containing the long and short addresses of all the children of
    this node.
-
-
-
-
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 41]
-
-                        Spinel Protocol (94724cf)         September 2016
-
 
 D.2.4.  PROP 83: PROP_THREAD_LEADER_RID
 
@@ -2329,6 +2569,15 @@ D.2.8.  PROP 87: PROP_THREAD_NETWORK_DATA_VERSION
    o  Type: Read-Only
    o  Packed-Encoding: "S"
 
+
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 46]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
 D.2.9.  PROP 88: PROP_THREAD_STABLE_NETWORK_DATA
 
    o  Type: Read-Only
@@ -2345,14 +2594,6 @@ D.2.11.  PROP 90: PROP_THREAD_ON_MESH_NETS
    o  Packed-Encoding: "A(T(6CbCb))"
 
    Data per item is:
-
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 42]
-
-                        Spinel Protocol (94724cf)         September 2016
-
 
    o  "6": IPv6 Prefix
    o  "C": Prefix length, in bits
@@ -2384,6 +2625,15 @@ D.2.14.  PROP 93: PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE
    o  Type: Read-Write
    o  Packed-Encoding: "b"
 
+
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 47]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
    Set to true before changing local net data.  Set to false when
    finished.  This allows changes to be aggregated into single events.
 
@@ -2402,13 +2652,6 @@ D.2.16.  PROP 5376: PROP_THREAD_CHILD_TIMEOUT
    o  Packed-Encoding: "L"
 
    Used when operating in the Child role.
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 43]
-
-                        Spinel Protocol (94724cf)         September 2016
-
 
 D.2.17.  PROP 5377: PROP_THREAD_RLOC16
 
@@ -2438,9 +2681,17 @@ D.2.21.  PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS
    o  Type: Read-Write/Write-Only
    o  Packed-Encoding: "A(C)" (List of active thread router ids)
 
-   Note that some implementations may not support "CMD_GET_VALUE"
-   routerids, but may support "CMD_REMOVE_VALUE" when the node is a
-   leader.
+
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 48]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
+   Note that some implementations may not support "CMD_GET_VALUE" router
+   ids, but may support "CMD_REMOVE_VALUE" when the node is a leader.
 
 D.2.22.  PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU
 
@@ -2456,15 +2707,6 @@ D.2.23.  PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED
 
    o  Type: Read-Write
    o  Packed-Encoding: "b"
-
-
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 44]
-
-                        Spinel Protocol (94724cf)         September 2016
-
 
    Allow the HOST to indicate whether or not the router role is enabled.
    If current role is a router, setting this property to "false" starts
@@ -2489,13 +2731,20 @@ E.1.  Test Vector: Packed Unsigned Integer
                  |     2,097,151 | "FF FF 7F"            |
                  +---------------+-----------------------+
 
-   [CREF2]
+   [CREF3]
 
 E.2.  Test Vector: Reset Command
 
    o  IID: 0
    o  TID: 0
    o  CMD: 1 ("CMD_RESET")
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 49]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
 
    Frame:
 
@@ -2512,15 +2761,6 @@ E.3.  Test Vector: Reset Notification
    Frame:
 
                                 80 06 00 72
-
-
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 45]
-
-                        Spinel Protocol (94724cf)         September 2016
-
 
 E.4.  Test Vector: Scan Beacon
 
@@ -2552,17 +2792,27 @@ E.4.  Test Vector: Scan Beacon
         13 00 03 20 73 70 69 6E 65 6C 00 08 00 DE AD 00 BE EF 00 CA
         FE
 
+
+
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 50]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
 E.5.  Test Vector: Inbound IPv6 Packet
 
    CMD_VALUE_IS(PROP_STREAM_NET)
 
-   [CREF3]
+   [CREF4]
 
 E.6.  Test Vector: Outbound IPv6 Packet
 
    CMD_VALUE_SET(PROP_STREAM_NET)
 
-   [CREF4]
+   [CREF5]
 
 E.7.  Test Vector: Fetch list of on-mesh networks
 
@@ -2570,13 +2820,6 @@ E.7.  Test Vector: Fetch list of on-mesh networks
    o  TID: 4
    o  CMD: 2 ("CMD_VALUE_GET")
    o  PROP: 90 ("PROP_THREAD_ON_MESH_NETS")
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 46]
-
-                        Spinel Protocol (94724cf)         September 2016
-
 
    Frame:
 
@@ -2603,13 +2846,25 @@ E.8.  Test Vector: Returned list of on-mesh networks
         00 40 01 ?? 13 00 20 01 0D B8 00 02 00 00 00 00 00 00 00 00
         00 00 40 00 ??
 
+
+
+
+
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 51]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
 E.9.  Test Vector: Adding an on-mesh network
 
    o  IID: 0
    o  TID: 5
    o  CMD: 4 ("CMD_VALUE_INSERT")
    o  PROP: 90 ("PROP_THREAD_ON_MESH_NETS")
-   o  VALUE: Structure, encoded as "6CbC"
+   o  VALUE: Structure, encoded as "6CbCb"
 
        +--------------+---------------+-------------+-------------+
        | IPv6 Prefix  | Prefix Length | Stable Flag | Other Flags |
@@ -2620,19 +2875,9 @@ E.9.  Test Vector: Adding an on-mesh network
    Frame:
 
         85 03 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00 40
-        01 ??
+        01 ?? 01
 
-   [CREF5]
-
-
-
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 47]
-
-                        Spinel Protocol (94724cf)         September 2016
-
+   [CREF6]
 
 E.10.  Test Vector: Insertion notification of an on-mesh network
 
@@ -2640,7 +2885,7 @@ E.10.  Test Vector: Insertion notification of an on-mesh network
    o  TID: 5
    o  CMD: 7 ("CMD_VALUE_INSERTED")
    o  PROP: 90 ("PROP_THREAD_ON_MESH_NETS")
-   o  VALUE: Structure, encoded as "6CbC"
+   o  VALUE: Structure, encoded as "6CbCb"
 
        +--------------+---------------+-------------+-------------+
        | IPv6 Prefix  | Prefix Length | Stable Flag | Other Flags |
@@ -2651,9 +2896,9 @@ E.10.  Test Vector: Insertion notification of an on-mesh network
    Frame:
 
         85 07 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00 40
-        01 ??
+        01 ?? 01
 
-   [CREF6]
+   [CREF7]
 
 E.11.  Test Vector: Removing a local on-mesh network
 
@@ -2661,6 +2906,14 @@ E.11.  Test Vector: Removing a local on-mesh network
    o  TID: 6
    o  CMD: 5 ("CMD_VALUE_REMOVE")
    o  PROP: 90 ("PROP_THREAD_ON_MESH_NETS")
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 52]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
    o  VALUE: IPv6 Prefix "2001:DB8:3::"
 
    Frame:
@@ -2679,22 +2932,11 @@ E.12.  Test Vector: Removal notification of an on-mesh network
 
          86 08 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00
 
-
-
-
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 48]
-
-                        Spinel Protocol (94724cf)         September 2016
-
-
 Appendix F.  Example Sessions
 
 F.1.  NCP Initialization
 
-   [CREF7]
+   [CREF8]
 
    Check the protocol version to see if it is supported:
 
@@ -2720,6 +2962,14 @@ F.1.  NCP Initialization
    Fetch the capability list so that we know what features this NCP
    supports:
 
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 53]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
    o  CMD_VALUE_GET:PROP_CAPS
    o  CMD_VALUE_IS:PROP_CAPS
 
@@ -2730,7 +2980,7 @@ F.1.  NCP Initialization
 
 F.2.  Attaching to a network
 
-   [CREF8]
+   [CREF9]
 
    We make the assumption that the NCP is not currently associated with
    a network.
@@ -2738,14 +2988,6 @@ F.2.  Attaching to a network
    Set the network properties, if they were not already set:
 
    o  CMD_VALUE_SET:PROP_PHY_CHAN
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 49]
-
-                        Spinel Protocol (94724cf)         September 2016
-
-
    o  CMD_VALUE_IS:PROP_PHY_CHAN
    o  CMD_VALUE_SET:PROP_NET_XPANID
    o  CMD_VALUE_IS:PROP_NET_XPANID
@@ -2774,9 +3016,19 @@ Quattlebaum              Expires March 13, 2017                [Page 49]
    o  CMD_VALUE_IS:PROP_NET_PARTITION_ID
    o  CMD_VALUE_IS:PROP_THREAD_ON_MESH_NETS
 
+
+
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 54]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
 F.3.  Successfully joining a pre-existing network
 
-   [CREF9]
+   [CREF10]
 
    This example session is identical to the above session up to the
    point where we set PROP_NET_IF_UP to true.  From there, the behavior
@@ -2794,14 +3046,6 @@ F.3.  Successfully joining a pre-existing network
 
    o  CMD_VALUE_IS:PROP_NET_ROLE
    o  CMD_VALUE_IS:PROP_NET_PARTITION_ID
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 50]
-
-                        Spinel Protocol (94724cf)         September 2016
-
-
    o  CMD_VALUE_IS:PROP_THREAD_ON_MESH_NETS
 
    Now let's save the network settings to NVRAM:
@@ -2827,13 +3071,24 @@ F.4.  Unsuccessfully joining a pre-existing network
    o  CMD_VALUE_IS:PROP_LAST_STATUS:STATUS_JOIN_NO_PEERS
    o  CMD_VALUE_IS:PROP_NET_STACK_UP:FALSE
 
+
+
+
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 55]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
 F.5.  Detaching from a network
 
    TBD
 
 F.6.  Attaching to a saved network
 
-   [CREF10]
+   [CREF11]
 
    Recall the saved network if you haven't already done so:
 
@@ -2851,20 +3106,13 @@ F.6.  Attaching to a saved network
 
    Some asynchronous events from the NCP:
 
-
-
-Quattlebaum              Expires March 13, 2017                [Page 51]
-
-                        Spinel Protocol (94724cf)         September 2016
-
-
    o  CMD_VALUE_IS:PROP_NET_ROLE
    o  CMD_VALUE_IS:PROP_NET_PARTITION_ID
    o  CMD_VALUE_IS:PROP_THREAD_ON_MESH_NETS
 
 F.7.  NCP Software Reset
 
-   [CREF11]
+   [CREF12]
 
    o  CMD_RESET
    o  CMD_VALUE_IS:PROP_LAST_STATUS:STATUS_RESET_SOFTWARE
@@ -2879,11 +3127,22 @@ F.9.  Entering low-power modes
 
    TBD
 
+
+
+
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 56]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
 F.10.  Sniffing raw packets
 
-   [CREF12]
+   [CREF13]
 
-   This assuems that the NCP has been initialized.
+   This assumes that the NCP has been initialized.
 
    Optionally set the channel:
 
@@ -2905,15 +3164,6 @@ F.10.  Sniffing raw packets
    o  CMD_VALUE_SET:PROP_PHY_ENABLED:TRUE
    o  CMD_VALUE_IS:PROP_PHY_ENABLED:TRUE
 
-
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 52]
-
-                        Spinel Protocol (94724cf)         September 2016
-
-
    Now we will get raw 802.15.4 packets asynchronously on
    PROP_STREAM_RAW:
 
@@ -2927,6 +3177,31 @@ Quattlebaum              Expires March 13, 2017                [Page 52]
    you can avoid receiving packets from other networks or that are
    destined for other nodes.
 
+Appendix G.  Glossary
+
+   NCP
+      Acronym for Network Control Processor.
+   Host
+      Computer or Micro-controller which controls the NCP.
+   TID
+      Transaction Identifier.  May be a value between zero and fifteen.
+      See Section 2.1.3 for more information.
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 57]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
+
+   IID
+      Interface Identifier.  May be a value between zero and three.  See
+      Section 2.1.2 for more information.
+   PUI
+      Packed Unsigned Integer.  A way to serialize an unsigned integer
+      using one, two, or three bytes.  Used throughout the Spinel
+      protocol.  See Section 3.2 for more information.
+
 Editorial Comments
 
 [CREF1] RQ: We may want to consider a license more appropriate for
@@ -2937,9 +3212,10 @@ Editorial Comments
         0 | 1 | 2 | 3 | 4 | 5 | 6 |
         7 | |---|---|---|---|---|---|---|---| | FLG || IID || TID ||||
 
-[CREF2] RQ: FIXME: This test vector is incomplete.
+[CREF2] RQ: If I have missed anyone who has contributed to this
+        document, please let me know ASAP.
 
-[CREF3] RQ: FIXME: This test vector is incomplete.
+[CREF3] RQ: The PUI test-vector encodings need to be verified.
 
 [CREF4] RQ: FIXME: This test vector is incomplete.
 
@@ -2947,7 +3223,7 @@ Editorial Comments
 
 [CREF6] RQ: FIXME: This test vector is incomplete.
 
-[CREF7] RQ: FIXME: This example session is incomplete.
+[CREF7] RQ: FIXME: This test vector is incomplete.
 
 [CREF8] RQ: FIXME: This example session is incomplete.
 
@@ -2959,18 +3235,20 @@ Editorial Comments
 
 [CREF12] RQ: FIXME: This example session is incomplete.
 
-
-
-
-
-
-
-Quattlebaum              Expires March 13, 2017                [Page 53]
-
-                        Spinel Protocol (94724cf)         September 2016
-
+[CREF13] RQ: FIXME: This example session is incomplete.
 
 Author's Address
+
+
+
+
+
+
+
+Quattlebaum              Expires March 14, 2017                [Page 58]
+
+                        Spinel Protocol (4d55c14)         September 2016
+
 
    Robert S. Quattlebaum
    Nest Labs
@@ -3021,4 +3299,6 @@ Author's Address
 
 
 
-Quattlebaum              Expires March 13, 2017                [Page 54]
+
+
+Quattlebaum              Expires March 14, 2017                [Page 59]

--- a/doc/spinel-protocol-src/Makefile
+++ b/doc/spinel-protocol-src/Makefile
@@ -1,0 +1,92 @@
+#
+#  Copyright (c) 2016, Nest Labs, Inc.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+XML2RFC_CACHE_DIR ?= $(HOME)/.cache/xml2rfc
+
+TOOL_PREFIX        = $(DOCKER) run --rm --user=`id -u`:`id -g` -v `pwd`:/rfc -v $(XML2RFC_CACHE_DIR):/var/cache/xml2rfc paulej/rfctools
+
+DOCKER            ?= docker
+MD2RFC            ?= $(TOOL_PREFIX) md2rfc
+XML2RFC           ?= $(TOOL_PREFIX) xml2rfc
+MMARK             ?= $(TOOL_PREFIX) mmark
+SED               ?= sed
+RM_F		      ?= rm -f
+MKDIR_P		      ?= mkdir -p
+
+SOURCE_DATE       := $(shell (TZ=UTC git log -n 1 --date=iso-strict-local --pretty=format:%ad 2> /dev/null || date -u +"%Y-%m-%dT%H:%M:%SZ" ) | sed 's/+00:00$$/Z/')
+SOURCE_VERSION    := $(shell git describe --dirty --always --match "--PoIsOn--" 2> /dev/null)
+
+# -------------
+
+SRC   := $(wildcard draft-*.md) $(wildcard draft-*.md.in)
+XML   := $(patsubst %.md,%.xml,$(patsubst %.md.in,%.xml,$(SRC)))
+TXT   := $(patsubst %.md,%.txt,$(patsubst %.md.in,%.txt,$(SRC)))
+HTML  := $(patsubst %.md,%.html,$(patsubst %.md.in,%.html,$(SRC)))
+
+all: $(XML) $(TXT) $(HTML)
+
+clean:
+	$(RM_F) $(XML) $(TXT) $(HTML) $(patsubst %.md.in,%.md,$(wildcard draft-*.md.in))
+
+$(XML2RFC_CACHE_DIR):
+	$(MKDIR_P) "$(XML2RFC_CACHE_DIR)"
+
+%.md: %.md.in
+	$(SED) 's/@SOURCE_VERSION@/$(SOURCE_VERSION)/g;s/@SOURCE_DATE@/$(SOURCE_DATE)/g' < $< > $@
+
+%.xml: %.md
+	$(MMARK) -xml2 -page $< $@
+
+%.html: %.xml $(XML2RFC_CACHE_DIR)
+	$(XML2RFC) --html $<
+
+%.txt: %.xml $(XML2RFC_CACHE_DIR)
+	$(XML2RFC) --text $<
+
+# -------------
+
+draft-spinel-protocol-bis.xml: \
+	draft-spinel-protocol-bis.md \
+	spinel-commands.md \
+	spinel-data-packing.md \
+	spinel-example-sessions.md \
+	spinel-feature-host-buffer-offload.md \
+	spinel-feature-network-save.md \
+	spinel-frame-format.md \
+	spinel-framing.md \
+	spinel-prop-core.md \
+	spinel-prop-ipv6.md \
+	spinel-prop-mac.md \
+	spinel-prop-net.md \
+	spinel-prop-phy.md \
+	spinel-prop.md \
+	spinel-status-codes.md \
+	spinel-tech-thread.md \
+	spinel-test-vectors.md \
+	$(NULL)
+

--- a/doc/spinel-protocol-src/draft-spinel-protocol.md.in
+++ b/doc/spinel-protocol-src/draft-spinel-protocol.md.in
@@ -81,28 +81,271 @@ POSSIBILITY OF SUCH DAMAGE.
 
 # Introduction #
 
-This Network Control Processor (NCP) protocol was designed to enable a host
-device to communicate with and manage a NCP while also achieving the
-following goals:
+This Network Control Processor (NCP) protocol was designed to enable a
+host device to communicate with and manage a NCP while also achieving
+the following goals:
 
- *  Adopt a layered approach to the protocol design, allowing future
+*   Adopt a layered approach to the protocol design, allowing future
     support for other network protocols.
- *  Minimize the number of required commands/methods by providing a
+*   Minimize the number of required commands/methods by providing a
     rich, property-based API.
- *  Support NCPs capable of being connected to more than one network
+*   Support NCPs capable of being connected to more than one network
     at a time.
- *  Gracefully handle the addition of new features and capabilities
+*   Gracefully handle the addition of new features and capabilities
     without necessarily breaking backward compatibility.
- *  Be as minimal and light-weight as possible without unnecessarily
+*   Be as minimal and light-weight as possible without unnecessarily
     sacrificing flexibility.
 
 On top of this core framework, we define the properties and commands
 to enable various features and network protocols.
 
-# Definitions #
+## About this Draft ##
+
+This document is currently in a draft status and is changing often.
+This section discusses some ideas for changes to the protocol that
+haven't yet been fully specified, as well as some of the impetus for
+the current design.
+
+### Renumbering ###
+
+Efforts are currently maintained to try to prevent overtly
+backward-incompatible changes to the existing protocol, but if you are
+implementing Spinel in your own products you should expect there to be
+at least one large renumbering event and major version number change
+before the standard is considered "baked". All changes will be clearly
+marked and documented to make such a transition as easy as possible.
+
+To allow conclusive detection of protocol (in)compatibility between
+the host and the NCP, the following commands and properties are
+already considered to be "baked" and will not change:
+
+*   Command IDs zero through eight. (Reset, No-op, and Property-Value
+    Commands)
+*   Property IDs zero through two. (Last status, Protocol Version, and
+    NCP Version)
+
+Renumbering would be undertaken in order to better organize the
+allocation of property IDs and capability IDs. One of the initial
+goals of this protocol was for it to be possible for a host or NCP to
+only implement properties with values less than 127 and for the NCP to
+still be usable---relegating all larger property values for extra
+features or other capabilities that aren't strictly necessary. This
+would allow simple implementations to avoid the need to implement
+support for PUIs ((#packed-unsigned-integer)).
+
+As time has gone by and the protocol has become more fleshed out, it
+has become clear that some of the initial allocations were inadequate
+and should be revisited if we want to try to achieve the original
+goal.
+
+### Spinel as Application API ###
+
+The current primary host driver implementation is
+[wpantund](http://wpantund.org/). wpantund manages the NCP using the
+Spinel protocol and provides a management API for the application using
+[D-Bus](https://www.freedesktop.org/wiki/Software/dbus/) IPC.
+
+However, some thought has been given to the idea of having a host
+driver daemon which uses Spinel directly as the management API. You
+would have user-space daemon similar to wpantund which would
+communicate directly with the NCP. Using Unix Domain Sockets,
+applications could connect to the daemon by opening a special socket
+file. The protocol for that socket might be (for example)
+HDLC-Lite-encoded ((#hdlc-lite)) spinel frames, as if the application
+were talking directly to the NCP.
+
+Applications aren't necessarily interested in everything that an NCP
+would normally send out unsolicited, so a mechanism for specifying
+which properties should be listened to would need to be defined. This
+mechanism would not be implemented by the NCP but would instead be
+implemented by the daemon to control which notification packets need
+to be directed where.
+
+In the event of transaction ID collisions, the daemon would
+transparently renumber spinel frames so as to not cause TID
+collisions.
+
+Since there can be more than one application that is using the API at
+a time, the `PROP_LOCK` property ((#prop-lock)) would be used to
+ensure exclusive access to the NCP by an application. Only one process
+would be allowed to enable the lock at a time.
+
+Such a IPC mechanism would be desirable because it is, from a spinel
+perspective, future proof. New features can be added and new
+properties assigned and the IPC protocol would not need to be extended
+to support them. It is also simple and has no external dependencies
+other than unix domain sockets.
+
+Security is obviously paramount in a system like this, so a great deal
+of care should be taken to make sure that certain commands and
+properties cannot be executed or changed without the appropriate
+privileges.
+
+### Privileged Commands and Properties ###
+
+The idea here is that some commands should be considered "privileged",
+and actively prevented from letting normal applications access them.
+This is important if the IPC protocol between the application and the
+NCP is Spinel.
+
+Examples of such privileged commands would be debugging commands like
+"peek" or "poke", properties which control bootloader behavior, or
+changing factory-specified constants. These commands should have some
+attribute about them that can be easily filtered to prevent
+applications from using issuing them directly to the NCP.
+
+This would likely be implemented as a part of the renumbering effort
+((#renumbering)).
+
+## Property Overview ##
+
+Spinel is largely a property-based protocol, with a property defined
+for every attribute that needs to be set, changed, or known by the
+host. The inspiration of this approach was memory-mapped hardware
+registers for peripherals. The goal is to avoid, as much as possible,
+the use of large complicated structures and/or method argument lists.
+The reason for avoiding these is because they have a tendency to
+change, especially early in development. Adding or removing a property
+from a structure can render the entire protocol incompatible. By using
+properties, you simply change an additional property.
+
+Almost all features and capabilities are implemented using properties.
+Most new features that are initially proposed as commands can be
+adapted to be property-based instead. Notable exceptions include "Host
+Buffer Offload" ((#feature-host-buffer-offload)) and "Network Save"
+((#feature-network-save)).
+
+In Spinel, properties are keyed by an unsigned integer between 0 and
+2,097,151 (See (#packed-unsigned-integer)).
+
+### Property Methods ###
+
+Properties may support one or more of the following methods:
+
+*   `VALUE_GET`
+*   `VALUE_SET`
+*   `VALUE_INSERT`
+*   `VALUE_REMOVE`
+
+Additionally, the NCP can send updates to the host (either
+synchronously or asynchronously) that inform the host about changes to
+specific properties:
+
+*   `VALUE_IS`
+*   `VALUE_INSERTED`
+*   `VALUE_REMOVED`
+
+### Property Types ###
+
+Conceptually, there are three different types of properties:
+
+*   Single-value properties
+*   Multiple-value (Array) properties
+*   Stream properties
+
+#### Single-Value Properties ####
+
+Single-value properties are properties that have a simple
+representation of a single value. Examples would be:
+
+*   Current radio channel (Represented as a unsigned 8-bit integer)
+*   Network name (Represented as a UTF-8 encoded string)
+*   802\.15.4 PAN ID (Represented as a unsigned 16-bit integer)
+
+The valid operations on these sorts of properties are `GET` and `SET`.
+
+#### Multiple-Value Properties ####
+
+Multiple-Value Properties have more than one value associated with
+them. Examples would be:
+
+*   List of channels supported by the radio hardware.
+*   List of IPv6 addresses assigned to the interface.
+*   List of capabilities supported by the NCP.
+
+The valid operations on these sorts of properties are `VALUE_GET`,
+`VALUE_SET`, `VALUE_INSERT`, and `VALUE_REMOVE`.
+
+When the value is fetched using `VALUE_GET`, the returned value is the
+concatenation of all of the individual values in the list. If the
+length of the value for an individual item in the list is not defined
+by the type then each item returned in the list is prepended with a
+length (See (#arrays)). The order of the returned items, unless
+explicitly defined for that specific property, is undefined.
+
+`VALUE_SET` provides a way to completely replace all previous values.
+Calling `VALUE_SET` with an empty value effectively instructs the NCP
+to clear the value of that property.
+
+`VALUE_INSERT` and `VALUE_REMOVE` provide mechanisms for the insertion
+or removal of individual items *by value*. The payload for these
+commands is a plain single value.
+
+#### Stream Properties ####
+
+Stream properties are special properties representing streams of data.
+Examples would be:
+
+*   Network packet stream ((#prop-stream-net))
+*   Raw packet stream ((#prop-stream-raw))
+*   Debug message stream ((#prop-stream-debug))
+*   Network Beacon stream ((#prop-mac-scan-beacon))
+
+All such properties emit changes asynchronously using the `VALUE_IS`
+command, sent from the NCP to the host. For example, as IPv6 traffic
+is received by the NCP, the IPv6 packets are sent to the host by way
+of asynchronous `VALUE_IS` notifications.
+
+Some of these properties also support the host send data back to the
+NCP. For example, this is how the host sends IPv6 traffic to the NCP.
+
+These types of properties generally do not support `VALUE_GET`, as it
+is meaningless.
+
+{{spinel-frame-format.md}}
+
+{{spinel-data-packing.md}}
+
+{{spinel-commands.md}}
+
+{{spinel-prop.md}}
+
+{{spinel-status-codes.md}}
+
+{{spinel-security-considerations.md}}
+
+# Acknowledgments #
+
+Special thanks to Abtin Keshavarzian, Martin Turon, Arjuna Sivasithambaresan
+and Jonathan Hui for their substantial contributions and feedback related
+to this document.
+
+<!-- RQ
+  -- If I have missed anyone who has contributed to this document,
+     please let me know ASAP.
+  -->
+
+This document was prepared using [mmark](https://github.com/miekg/mmark)
+by (Miek Gieben) and [xml2rfc (version 2)](http://xml2rfc.ietf.org/).
+
+{backmatter}
+
+{{spinel-framing.md}}
+
+{{spinel-feature-network-save.md}}
+
+{{spinel-feature-host-buffer-offload.md}}
+
+{{spinel-tech-thread.md}}
+
+{{spinel-test-vectors.md}}
+
+{{spinel-example-sessions.md}}
+
+# Glossary #
 
 NCP
-: Acryonym for Network Control Processor.
+: Acronym for Network Control Processor.
 
 Host
 : Computer or Micro-controller which controls the NCP.
@@ -119,27 +362,3 @@ PUI
 : Packed Unsigned Integer. A way to serialize an unsigned integer
   using one, two, or three bytes. Used throughout the Spinel protocol.
   See (#packed-unsigned-integer) for more information.
-
-{{spinel-frame-format.md}}
-
-{{spinel-data-packing.md}}
-
-{{spinel-commands.md}}
-
-{{spinel-prop.md}}
-
-{{spinel-status-codes.md}}
-
-{backmatter}
-
-{{spinel-framing.md}}
-
-{{spinel-feature-network-save.md}}
-
-{{spinel-feature-host-buffer-offload.md}}
-
-{{spinel-tech-thread.md}}
-
-{{spinel-test-vectors.md}}
-
-{{spinel-example-sessions.md}}

--- a/doc/spinel-protocol-src/spinel-example-sessions.md
+++ b/doc/spinel-protocol-src/spinel-example-sessions.md
@@ -170,7 +170,7 @@ TBD
 
 <!-- RQ -- FIXME: This example session is incomplete. -->
 
-This assuems that the NCP has been initialized.
+This assumes that the NCP has been initialized.
 
 Optionally set the channel:
 

--- a/doc/spinel-protocol-src/spinel-framing.md
+++ b/doc/spinel-protocol-src/spinel-framing.md
@@ -23,14 +23,14 @@ Hardware flow control is preferred over software flow control. In the
 absence of hardware flow control, software flow control (XON/XOFF) **MUST**
 be used instead.
 
-We also **RECOMMEND** an arduino-style hardware reset, where the DTR
+We also **RECOMMEND** an Arduino-style hardware reset, where the DTR
 signal is coupled to the `R̅E̅S̅` pin through a 0.01µF capacitor. This
 causes the NCP to automatically reset whenever the serial port is
 opened. At the very least we **RECOMMEND** dedicating one of your host
 pins to controlling the `R̅E̅S̅` pin on the NCP, so that you can
 easily perform a hardware reset if necessary.
 
-### HDLC-Lite ####
+### HDLC-Lite {#hdlc-lite}
 
 *HDLC-Lite* is the recommended framing protocol for transmitting
 Spinel frames over a UART. HDLC-Lite consists of only the framing,

--- a/doc/spinel-protocol-src/spinel-prop-mac.md
+++ b/doc/spinel-protocol-src/spinel-prop-mac.md
@@ -116,7 +116,7 @@ Structure Parameters:
 * `E`: EUI64 address of node
 * `c`: Optional RSSI-override value. The value 127 indicates
        that the RSSI-override feature is not enabled for this
-       address. If this value is ommitted when setting or
+       address. If this value is omitted when setting or
        inserting, it is assumed to be 127. This parameter is
        ignored when removing.
 

--- a/doc/spinel-protocol-src/spinel-security-considerations.md
+++ b/doc/spinel-protocol-src/spinel-security-considerations.md
@@ -1,0 +1,3 @@
+# Security Considerations #
+
+TBD

--- a/doc/spinel-protocol-src/spinel-status-codes.md
+++ b/doc/spinel-protocol-src/spinel-status-codes.md
@@ -25,9 +25,9 @@ See (#prop-last-status) for more information on `PROP_LAST_STATUS`.
     state of the device.
  *  5: `STATUS_INVALID_COMMAND`: The given command is not recognized.
  *  6: `STATUS_INVALID_INTERFACE`: The given Spinel interface is not supported.
- *  7: `STATUS_INTERNAL_ERROR`: An internal runtime error has occured.
- *  8: `STATUS_SECURITY_ERROR`: A security or authentication error has occured.
- *  9: `STATUS_PARSE_ERROR`: An error has occured while parsing the command.
+ *  7: `STATUS_INTERNAL_ERROR`: An internal runtime error has occurred.
+ *  8: `STATUS_SECURITY_ERROR`: A security or authentication error has occurred.
+ *  9: `STATUS_PARSE_ERROR`: An error has occurred while parsing the command.
  *  10: `STATUS_IN_PROGRESS`: The operation is in progress and will be
     completed asynchronously.
  *  11: `STATUS_NOMEM`: The operation has been prevented due to memory

--- a/doc/spinel-protocol-src/spinel-tech-thread.md
+++ b/doc/spinel-protocol-src/spinel-tech-thread.md
@@ -14,7 +14,7 @@ save feature (See (#feature-network-save)).
 
 ## Thread Capabilities
 
-The Thread techology defines the following capabilities:
+The Thread technology defines the following capabilities:
 
 * `CAP_NET_THREAD_1_0` - Indicates that the NCP implements v1.0 of the Thread standard.
 * `CAP_NET_THREAD_1_1` - Indicates that the NCP implements v1.1 of the Thread standard.
@@ -153,7 +153,7 @@ defined by the Thread specification.
 * Packed-Encoding: `A(C)` (List of active thread router ids)
 
 Note that some implementations may not support `CMD_GET_VALUE`
-routerids, but may support `CMD_REMOVE_VALUE` when the node is
+router ids, but may support `CMD_REMOVE_VALUE` when the node is
 a leader.
 
 ### PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU

--- a/doc/spinel-protocol-src/spinel-test-vectors.md
+++ b/doc/spinel-protocol-src/spinel-test-vectors.md
@@ -15,7 +15,7 @@ Decimal Value | Packet Octet Encoding
        16,385 | `81 80 01`
     2,097,151 | `FF FF 7F`
 
-<!-- RQ -- FIXME: This test vector is incomplete. -->
+<!-- RQ -- The PUI test-vector encodings need to be verified. -->
 
 ## Test Vector: Reset Command
 
@@ -115,7 +115,7 @@ Frame:
 * TID: 5
 * CMD: 4 (`CMD_VALUE_INSERT`)
 * PROP: 90 (`PROP_THREAD_ON_MESH_NETS`)
-* VALUE: Structure, encoded as `6CbC`
+* VALUE: Structure, encoded as `6CbCb`
 
 IPv6 Prefix  | Prefix Length | Stable Flag | Other Flags
 -------------|---------------|-------------|--------------
@@ -124,7 +124,7 @@ IPv6 Prefix  | Prefix Length | Stable Flag | Other Flags
 Frame:
 
     85 03 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00 40
-    01 ??
+    01 ?? 01
 
 <!-- RQ -- FIXME: This test vector is incomplete. -->
 
@@ -134,7 +134,7 @@ Frame:
 * TID: 5
 * CMD: 7 (`CMD_VALUE_INSERTED`)
 * PROP: 90 (`PROP_THREAD_ON_MESH_NETS`)
-* VALUE: Structure, encoded as `6CbC`
+* VALUE: Structure, encoded as `6CbCb`
 
 IPv6 Prefix  | Prefix Length | Stable Flag | Other Flags
 -------------|---------------|-------------|--------------
@@ -143,7 +143,7 @@ IPv6 Prefix  | Prefix Length | Stable Flag | Other Flags
 Frame:
 
     85 07 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00 40
-    01 ??
+    01 ?? 01
 
 <!-- RQ -- FIXME: This test vector is incomplete. -->
 


### PR DESCRIPTION
Elaborated on introduction section. Added explanation of how properties are intended to work. Minor fixes to test vectors. Move glossary to the end of the document. Fixed several spelling errors.

This is a part of #492.