### PR TITLE
spinel-cli: Clean exit

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -67,5 +67,5 @@ set -x
 }
 
 [ $BUILD_TARGET != posix-ncp ] || {
-    NODE_TYPE=ncp-sim BuildJobs=10 make -f examples/Makefile-posix check || die
+    COVERAGE=1 NODE_TYPE=ncp-sim BuildJobs=10 make -f examples/Makefile-posix check || die
 }

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -98,11 +98,8 @@ class Node:
 
     def __del__(self):
         if self.pexpect.isalive():
-            if self.node_type == 'sim':
-                self.send_command('exit')
-                self.pexpect.expect(pexpect.EOF)
-            elif self.node_type == 'ncp-sim':
-                self.pexpect.sendcontrol('c');
+            self.send_command('exit')
+            self.pexpect.expect(pexpect.EOF)
             self.pexpect.terminate()
             self.pexpect.close(force=True)
 


### PR DESCRIPTION
Use new clean eof termination of ot-ncp processes rather than CTRL+C.  
Node.py now terminates both cli and ncp processes the same way.
Solves the spurious issues with eof exceptions.