### PR TITLE
Revert the introduction of ".gitattributes" from #473

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,0 @@
-* text=lf
-*.vcxproj eol=crlf
-*.vcxproj.filters eol=crlf
-*.sln eol=crlf


### PR DESCRIPTION
This will be reintroduced via pull request #593, which will be re-opened after this commit is merged.