### PR TITLE
ncp functional tests

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -49,7 +49,6 @@ cd /tmp || die
     pip install scapy || die
     pip install pyserial || die
     pip install ipaddress || die
-    pip install blessed || die
 
     [ $BUILD_TARGET != pretty-check ] || {
         wget http://jaist.dl.sourceforge.net/project/astyle/astyle/astyle%202.05.1/astyle_2.05.1_linux.tar.gz || die

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -45,6 +45,12 @@ cd /tmp || die
     sudo -H pip install pexpect || die
     pip install pexpect || die
 
+    # posix-ncp tests
+    pip install scapy || die
+    pip install pyserial || die
+    pip install ipaddress || die
+    pip install blessed || die
+
     [ $BUILD_TARGET != pretty-check ] || {
         wget http://jaist.dl.sourceforge.net/project/astyle/astyle/astyle%202.05.1/astyle_2.05.1_linux.tar.gz || die
         tar xzvf astyle_2.05.1_linux.tar.gz || die
@@ -69,13 +75,6 @@ cd /tmp || die
 
     [ $BUILD_TARGET != posix-32-bit ] || {
         sudo apt-get install g++-multilib || die
-    }
-
-    [ $BUILD_TARGET != posix-ncp ] || {
-        pip install blessed || die
-        pip install ipaddress || die
-        pip install scapy || die
-        pip install pyserial || die
     }
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -732,6 +732,8 @@ tools/spi-hdlc-adapter/Makefile
 tools/spinel-cli/Makefile
 tests/Makefile
 tests/scripts/Makefile
+tests/scripts/thread-cert/Makefile
+tests/scripts/ncp/Makefile
 tests/unit/Makefile
 doc/Makefile
 ])

--- a/tests/scripts/Makefile.am
+++ b/tests/scripts/Makefile.am
@@ -51,33 +51,4 @@ endif
 PRETTY_SUBDIRS                          = \
     $(NULL)
 
-if OPENTHREAD_BUILD_TESTS
-if OPENTHREAD_BUILD_COVERAGE
-CLEANFILES                             = $(wildcard *.gcda *.gcno)
-
-if OPENTHREAD_BUILD_COVERAGE_REPORTS
-# The bundle should positively be qualified with the absolute build
-# path. Otherwise, VPATH will get auto-prefixed to it if there is
-# already such a directory in the non-colocated source tree.
-
-OPENTHREAD_COVERAGE_BUNDLE             = ${abs_builddir}/${PACKAGE}${NL_COVERAGE_BUNDLE_SUFFIX}
-OPENTHREAD_COVERAGE_INFO               = ${OPENTHREAD_COVERAGE_BUNDLE}/${PACKAGE}${NL_COVERAGE_INFO_SUFFIX}
-
-$(OPENTHREAD_COVERAGE_BUNDLE):
-	$(call create-directory)
-
-$(OPENTHREAD_COVERAGE_INFO): check | $(dir $(OPENTHREAD_COVERAGE_INFO))
-	$(call generate-coverage-report,${top_builddir})
-
-coverage-local: $(OPENTHREAD_COVERAGE_INFO)
-
-clean-local: clean-local-coverage
-
-.PHONY: clean-local-coverage
-clean-local-coverage:
-	-$(AM_V_at)rm -rf $(OPENTHREAD_COVERAGE_BUNDLE)
-endif # OPENTHREAD_BUILD_COVERAGE_REPORTS
-endif # OPENTHREAD_BUILD_COVERAGE
-endif # OPENTHREAD_BUILD_TESTS
-
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/tests/scripts/ncp/Makefile.am
+++ b/tests/scripts/ncp/Makefile.am
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2016, The OpenThread Authors.
+#  Copyright (c) 2016, Nest Labs, Inc.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -28,56 +28,47 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-# Always package (e.g. for 'make dist') these subdirectories.
+LOG_DRIVER=$(abs_top_srcdir)/third_party/openthread-test-driver/test-driver
 
-DIST_SUBDIRS                            = \
-    thread-cert                           \
-    ncp                                   \
-    $(NULL)
-
-# Always build (e.g. for 'make all') these subdirectories.
-
-if OPENTHREAD_EXAMPLES_POSIX
-if OPENTHREAD_ENABLE_CLI
-SUBDIRS                                 = \
-    thread-cert                           \
-    ncp                                   \
-    $(NULL)
-endif
-endif
-
-# Always pretty (e.g. for 'make pretty') these subdirectories.
-
-PRETTY_SUBDIRS                          = \
+EXTRA_DIST                                                         = \
+    test_ncp_basics.py                                               \
+    test_ncp_phy.py                                                  \
+    test_ncp_mac.py                                                  \
+    test_ncp_net.py                                                  \
+    node.py                                                          \
     $(NULL)
 
 if OPENTHREAD_BUILD_TESTS
-if OPENTHREAD_BUILD_COVERAGE
-CLEANFILES                             = $(wildcard *.gcda *.gcno)
 
-if OPENTHREAD_BUILD_COVERAGE_REPORTS
-# The bundle should positively be qualified with the absolute build
-# path. Otherwise, VPATH will get auto-prefixed to it if there is
-# already such a directory in the non-colocated source tree.
+# First, list all essential program and script tests that MUST be run.
 
-OPENTHREAD_COVERAGE_BUNDLE             = ${abs_builddir}/${PACKAGE}${NL_COVERAGE_BUNDLE_SUFFIX}
-OPENTHREAD_COVERAGE_INFO               = ${OPENTHREAD_COVERAGE_BUNDLE}/${PACKAGE}${NL_COVERAGE_INFO_SUFFIX}
+check_PROGRAMS =
 
-$(OPENTHREAD_COVERAGE_BUNDLE):
-	$(call create-directory)
+check_SCRIPTS =
 
-$(OPENTHREAD_COVERAGE_INFO): check | $(dir $(OPENTHREAD_COVERAGE_INFO))
-	$(call generate-coverage-report,${top_builddir})
+if OPENTHREAD_ENABLE_NCP
 
-coverage-local: $(OPENTHREAD_COVERAGE_INFO)
+check_SCRIPTS                                                     += \
+    test_ncp_basics.py                                               \
+    test_ncp_phy.py                                                  \
+    test_ncp_mac.py                                                  \
+    test_ncp_net.py                                                  \
+    $(NULL)
 
-clean-local: clean-local-coverage
+endif
 
-.PHONY: clean-local-coverage
-clean-local-coverage:
-	-$(AM_V_at)rm -rf $(OPENTHREAD_COVERAGE_BUNDLE)
-endif # OPENTHREAD_BUILD_COVERAGE_REPORTS
-endif # OPENTHREAD_BUILD_COVERAGE
+TESTS_ENVIRONMENT                                                  = \
+    export                                                           \
+    top_builddir='$(top_builddir)'                                   \
+    VERBOSE=1;                                                       \
+    $(NULL)
+
+TESTS                                                              = \
+    $(check_PROGRAMS)                                                \
+    $(check_SCRIPTS)                                                 \
+    $(NULL)
+
+
 endif # OPENTHREAD_BUILD_TESTS
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/tests/scripts/ncp/Makefile.am
+++ b/tests/scripts/ncp/Makefile.am
@@ -36,6 +36,7 @@ EXTRA_DIST                                                         = \
     test_ncp_mac.py                                                  \
     test_ncp_net.py                                                  \
     test_ncp_ipv6.py                                                 \
+    test_ncp_thread.py                                               \
     node.py                                                          \
     $(NULL)
 
@@ -55,6 +56,7 @@ check_SCRIPTS                                                     += \
     test_ncp_mac.py                                                  \
     test_ncp_net.py                                                  \
     test_ncp_ipv6.py                                                 \
+    test_ncp_thread.py                                               \
     $(NULL)
 
 endif

--- a/tests/scripts/ncp/Makefile.am
+++ b/tests/scripts/ncp/Makefile.am
@@ -35,6 +35,7 @@ EXTRA_DIST                                                         = \
     test_ncp_phy.py                                                  \
     test_ncp_mac.py                                                  \
     test_ncp_net.py                                                  \
+    test_ncp_ipv6.py                                                 \
     node.py                                                          \
     $(NULL)
 
@@ -53,6 +54,7 @@ check_SCRIPTS                                                     += \
     test_ncp_phy.py                                                  \
     test_ncp_mac.py                                                  \
     test_ncp_net.py                                                  \
+    test_ncp_ipv6.py                                                 \
     $(NULL)
 
 endif

--- a/tests/scripts/ncp/Makefile.am
+++ b/tests/scripts/ncp/Makefile.am
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2016, Nest Labs, Inc.
+#  Copyright (c) 2016, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without

--- a/tests/scripts/ncp/node.py
+++ b/tests/scripts/ncp/node.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-#  Copyright (c) 2016, Nest Labs, Inc.
+#  Copyright (c) 2016, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without

--- a/tests/scripts/ncp/node.py
+++ b/tests/scripts/ncp/node.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python
+#
+#  Copyright (c) 2016, Nest Labs, Inc.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import os
+import sys
+import time
+import pexpect
+import unittest
+
+class Node():
+    def __init__(self, nodeid=1):
+        """ Initialize an NCP simulation node. """
+        self.nodeid = nodeid
+        self.verbose = int(float(os.getenv('VERBOSE', 0)))
+
+        if "top_builddir" in os.environ.keys():
+            builddir = os.environ['top_builddir']
+            if "top_srcdir" in os.environ.keys():
+                srcdir = os.environ['top_srcdir']
+            else:
+                srcdir = os.path.dirname(os.path.realpath(__file__))
+                srcdir += "/../../.."
+            cmd = 'python %s/tools/spinel-cli/spinel-cli.py -p %s/examples/apps/ncp/ot-ncp -n' % (srcdir, builddir)
+        else:
+            cmd = '../../../examples/apps/ncp/ot-ncp'
+        cmd += ' %d' % nodeid
+        print ("%s" % cmd)
+
+        self.pexpect = pexpect.spawn(cmd, timeout=2)
+        time.sleep(0.1)
+        self.pexpect.expect('spinel-cli >')
+
+        if self.verbose:
+            self.pexpect.logfile_read = sys.stdout
+
+
+    def __del__(self):
+        if self.pexpect.isalive():
+            self.send_command('exit')
+            self.pexpect.expect(pexpect.EOF)
+            self.pexpect.terminate()
+            self.pexpect.close(force=True)
+
+    def send_command(self, cmd):
+        print ("%d: %s" % (self.nodeid, cmd))
+        self.pexpect.sendline(cmd)

--- a/tests/scripts/ncp/test_ncp_basics.py
+++ b/tests/scripts/ncp/test_ncp_basics.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-#  Copyright (c) 2016, Nest Labs, Inc.
+#  Copyright (c) 2016, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -42,10 +42,6 @@ class test_ncp(unittest.TestCase):
     def test_version(self):
         self.node.send_command('version')
         self.node.pexpect.expect('OPENTHREAD/')
-
-    def test_scan(self):
-        self.node.send_command('scan')
-        self.node.pexpect.expect('Done')
 
     #def test_noop(self): pass
     #def test_reset(self): pass

--- a/tests/scripts/ncp/test_ncp_basics.py
+++ b/tests/scripts/ncp/test_ncp_basics.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+#
+#  Copyright (c) 2016, Nest Labs, Inc.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import os
+import sys
+import time
+import pexpect
+import unittest
+
+import node
+
+class test_ncp(unittest.TestCase):
+    def setUp(self):
+        self.node = node.Node(1)
+
+    def test_version(self):
+        self.node.send_command('version')
+        self.node.pexpect.expect('OPENTHREAD/')
+
+    def test_scan(self):
+        self.node.send_command('scan')
+        self.node.pexpect.expect('Done')
+
+    #def test_noop(self): pass
+    #def test_reset(self): pass
+
+    def test_status(self): 
+        self.node.send_command('ncp-status')
+        self.node.pexpect.expect('Done')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/scripts/ncp/test_ncp_ipv6.py
+++ b/tests/scripts/ncp/test_ncp_ipv6.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-#  Copyright (c) 2016, Nest Labs, Inc.
+#  Copyright (c) 2016, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without

--- a/tests/scripts/ncp/test_ncp_ipv6.py
+++ b/tests/scripts/ncp/test_ncp_ipv6.py
@@ -50,5 +50,19 @@ class test_ncp_ipv6(unittest.TestCase):
         self.node.send_command('ncp-ml64')
         self.node.pexpect.expect('Done')
 
+    def test_ipaddr(self):
+        self.node.send_command('ipaddr')
+        self.node.pexpect.expect('Done')
+
+        self.node.send_command('ipaddr add fd00::1')
+        self.node.pexpect.expect('Done')
+        self.node.send_command('ipaddr')
+        self.node.pexpect.expect('fd00::1')
+        self.node.pexpect.expect('Done')
+
+        self.node.send_command('ipaddr remove fd00::1')
+        self.node.pexpect.expect('Done')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/ncp/test_ncp_ipv6.py
+++ b/tests/scripts/ncp/test_ncp_ipv6.py
@@ -35,34 +35,13 @@ import unittest
 
 import node
 
-class test_ncp_phy(unittest.TestCase):
+class test_ncp_ipv6(unittest.TestCase):
     def setUp(self):
         self.node = node.Node(1)
 
-    def test_phy_freq(self):
-        self.node.send_command('phy-freq')
+    def test_ipv6_ml_prefix(self):
+        self.node.send_command('ncp-mlprefix')
         self.node.pexpect.expect('Done')
-
-    def test_phy_rssi(self):
-        self.node.send_command('phy-rssi')
-        self.node.pexpect.expect('Done')
-
-    def test_phy_channel(self):
-        self.node.send_command('channel')
-        self.node.pexpect.expect('Done')
-        self.node.send_command('channel 12')
-        self.node.pexpect.expect('Done')
-        self.node.send_command('channel')
-        self.node.pexpect.expect('12')
-        self.node.pexpect.expect('Done')
-
-    #def test_phy_cca_threshold(self):
-    #    self.node.send_command('phy-cca-threshold')
-    #    self.node.pexpect.expect('Done')
-    
-    #def test_phy_tx_power(self):
-    #    self.node.send_command('phy-tx-power')
-    #    self.node.pexpect.expect('Done')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/ncp/test_ncp_ipv6.py
+++ b/tests/scripts/ncp/test_ncp_ipv6.py
@@ -43,5 +43,12 @@ class test_ncp_ipv6(unittest.TestCase):
         self.node.send_command('ncp-mlprefix')
         self.node.pexpect.expect('Done')
 
+    def test_ipv6_ll64(self):
+        self.node.send_command('ncp-ll64')
+
+    def test_ipv6_ml64(self):
+        self.node.send_command('ncp-ml64')
+        self.node.pexpect.expect('Done')
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/ncp/test_ncp_mac.py
+++ b/tests/scripts/ncp/test_ncp_mac.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-#  Copyright (c) 2016, Nest Labs, Inc.
+#  Copyright (c) 2016, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without

--- a/tests/scripts/ncp/test_ncp_mac.py
+++ b/tests/scripts/ncp/test_ncp_mac.py
@@ -51,5 +51,23 @@ class test_ncp_mac(unittest.TestCase):
         self.node.send_command('mac-filter-mode')
         self.node.pexpect.expect('Done')
 
+    def test_whitelist(self):
+        self.node.send_command('whitelist')
+        self.node.pexpect.expect('Disabled')
+        self.node.pexpect.expect('Done')
+
+        self.node.send_command('whitelist enable')
+        self.node.pexpect.expect('Done')
+
+        self.node.send_command('whitelist')
+        self.node.pexpect.expect('Enabled')
+        self.node.pexpect.expect('Done')
+
+        self.node.send_command('whitelist add deadbeeff00dbabe')
+        self.node.pexpect.expect('Done')
+
+        self.node.send_command('whitelist remove deadbeeff00dbabe')
+        self.node.pexpect.expect('Done')
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/ncp/test_ncp_mac.py
+++ b/tests/scripts/ncp/test_ncp_mac.py
@@ -89,5 +89,9 @@ class test_ncp_mac(unittest.TestCase):
         self.node.send_command('whitelist remove deadbeeff00dbabe')
         self.node.pexpect.expect('Done')
 
+        # Test set with RSSI_OVERRIDE_DISABLED branch
+        self.node.send_command('whitelist add deadbeeff00dcafe 127')
+        self.node.pexpect.expect('Done')
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/ncp/test_ncp_mac.py
+++ b/tests/scripts/ncp/test_ncp_mac.py
@@ -51,6 +51,26 @@ class test_ncp_mac(unittest.TestCase):
         self.node.send_command('mac-filter-mode')
         self.node.pexpect.expect('Done')
 
+        self.node.send_command('mac-filter-mode 1')
+        self.node.pexpect.expect('Done')
+
+        self.node.send_command('mac-filter-mode 2')
+        self.node.pexpect.expect('Done')
+
+        self.node.send_command('mac-filter-mode 0')
+        self.node.pexpect.expect('Done')
+        self.node.send_command('mac-filter-mode')
+        self.node.pexpect.expect('0')
+        self.node.pexpect.expect('Done')
+
+    def test_hwaddr(self):
+        self.node.send_command('ncp-eui64')
+        self.node.pexpect.expect('Done')
+
+    def test_scan(self):
+        self.node.send_command('scan')
+        self.node.pexpect.expect('Done')
+
     def test_whitelist(self):
         self.node.send_command('whitelist')
         self.node.pexpect.expect('Disabled')

--- a/tests/scripts/ncp/test_ncp_mac.py
+++ b/tests/scripts/ncp/test_ncp_mac.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python
+#
+#  Copyright (c) 2016, Nest Labs, Inc.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import os
+import sys
+import time
+import pexpect
+import unittest
+
+import node
+
+class test_ncp_mac(unittest.TestCase):
+    def setUp(self):
+        self.node = node.Node(1)
+
+    def test_mac_saddr(self):
+        self.node.send_command('ncp-mac16')
+        self.node.pexpect.expect('Done')
+
+    def test_mac_laddr(self):
+        self.node.send_command('ncp-mac64')
+        self.node.pexpect.expect('Done')
+
+    def test_mac_filter_mode(self):
+        self.node.send_command('mac-filter-mode')
+        self.node.pexpect.expect('Done')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/scripts/ncp/test_ncp_net.py
+++ b/tests/scripts/ncp/test_ncp_net.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+#
+#  Copyright (c) 2016, Nest Labs, Inc.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import os
+import sys
+import time
+import pexpect
+import unittest
+
+import node
+
+class test_ncp_net(unittest.TestCase):
+    def setUp(self):
+        self.node = node.Node(1)
+        self.node.send_command('panid 1')
+        self.node.pexpect.expect('Done')
+
+    def test_net_name(self):
+        self.node.send_command('networkname')
+        self.node.pexpect.expect('Done')
+
+    def test_net_xpanid(self):
+        self.node.send_command('extpanid')
+        self.node.pexpect.expect('Done')
+        #self.node.send_command('extpanid 1234')
+        #self.node.pexpect.expect('Done')
+        #self.node.send_command('extpanid')
+        #self.node.pexpect.expect('1234')
+        #self.node.pexpect.expect('Done')
+
+    def test_net_masterkey(self):
+        self.node.send_command('masterkey')
+        self.node.pexpect.expect('Done')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/scripts/ncp/test_ncp_net.py
+++ b/tests/scripts/ncp/test_ncp_net.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-#  Copyright (c) 2016, Nest Labs, Inc.
+#  Copyright (c) 2016, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without

--- a/tests/scripts/ncp/test_ncp_net.py
+++ b/tests/scripts/ncp/test_ncp_net.py
@@ -44,6 +44,11 @@ class test_ncp_net(unittest.TestCase):
     def test_net_name(self):
         self.node.send_command('networkname')
         self.node.pexpect.expect('Done')
+        self.node.send_command('networkname test_ncp_net')
+        self.node.pexpect.expect('Done')
+        self.node.send_command('networkname')
+        self.node.pexpect.expect('test_ncp_net')
+        self.node.pexpect.expect('Done')
 
     def test_net_xpanid(self):
         self.node.send_command('extpanid')

--- a/tests/scripts/ncp/test_ncp_phy.py
+++ b/tests/scripts/ncp/test_ncp_phy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-#  Copyright (c) 2016, Nest Labs, Inc.
+#  Copyright (c) 2016, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without

--- a/tests/scripts/ncp/test_ncp_phy.py
+++ b/tests/scripts/ncp/test_ncp_phy.py
@@ -39,6 +39,12 @@ class test_ncp_phy(unittest.TestCase):
     def setUp(self):
         self.node = node.Node(1)
 
+    def test_phy_enabled(self):
+        self.node.send_command('phy-enabled')
+        # Get not implemented yet, so don't expect Done
+        self.node.send_command('phy-enabled 1')
+        self.node.send_command('phy-enabled 0')
+
     def test_phy_freq(self):
         self.node.send_command('phy-freq')
         self.node.pexpect.expect('Done')

--- a/tests/scripts/ncp/test_ncp_phy.py
+++ b/tests/scripts/ncp/test_ncp_phy.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+#
+#  Copyright (c) 2016, Nest Labs, Inc.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import os
+import sys
+import time
+import pexpect
+import unittest
+
+import node
+
+class test_ncp_phy(unittest.TestCase):
+    def setUp(self):
+        self.node = node.Node(1)
+
+    def test_phy_freq(self):
+        self.node.send_command('phy-freq')
+        self.node.pexpect.expect('Done')
+
+    def test_phy_rssi(self):
+        self.node.send_command('phy-rssi')
+        self.node.pexpect.expect('Done')
+
+    #def test_phy_cca_threshold(self):
+    #    self.node.send_command('phy-cca-threshold')
+    #    self.node.pexpect.expect('Done')
+    
+    #def test_phy_tx_power(self):
+    #    self.node.send_command('phy-tx-power')
+    #    self.node.pexpect.expect('Done')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/scripts/ncp/test_ncp_thread.py
+++ b/tests/scripts/ncp/test_ncp_thread.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+#
+#  Copyright (c) 2016, Nest Labs, Inc.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import os
+import sys
+import time
+import pexpect
+import unittest
+
+import node
+
+class test_ncp_thread(unittest.TestCase):
+    def setUp(self):
+        self.node = node.Node(1)
+
+    def test_assisting_ports(self):
+        self.node.send_command('ncp-assisting-ports 1234')
+        self.node.pexpect.expect('Done')
+
+        self.node.send_command('ncp-assisting-ports')
+        self.node.pexpect.expect('1234')
+        self.node.pexpect.expect('Done')
+
+        self.node.send_command('ncp-assisting-ports remove 1234')
+        self.node.pexpect.expect('Done')
+
+        self.node.send_command('ncp-assisting-ports add 5432')
+        self.node.pexpect.expect('Done')
+
+        self.node.send_command('ncp-assisting-ports')
+        self.node.pexpect.expect('5432')
+        self.node.pexpect.expect('Done')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/scripts/ncp/test_ncp_thread.py
+++ b/tests/scripts/ncp/test_ncp_thread.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-#  Copyright (c) 2016, Nest Labs, Inc.
+#  Copyright (c) 2016, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without

--- a/tests/scripts/ncp/test_ncp_thread.py
+++ b/tests/scripts/ncp/test_ncp_thread.py
@@ -38,6 +38,13 @@ import node
 class test_ncp_thread(unittest.TestCase):
     def setUp(self):
         self.node = node.Node(1)
+        self.node.send_command('panid 1')
+        self.node.pexpect.expect('Done')
+        self.node.send_command('ifconfig up')
+        self.node.pexpect.expect('Done')
+        self.node.send_command('thread start')
+        self.node.pexpect.expect('Done')
+
 
     def test_assisting_ports(self):
         self.node.send_command('ncp-assisting-ports 1234')
@@ -56,6 +63,24 @@ class test_ncp_thread(unittest.TestCase):
         self.node.send_command('ncp-assisting-ports')
         self.node.pexpect.expect('5432')
         self.node.pexpect.expect('Done')
+
+    def test_ipaddr(self):
+        self.node.send_command('ipaddr')
+        self.node.pexpect.expect('Done')
+
+        self.node.send_command('ipaddr add fd00::1')
+        self.node.pexpect.expect('Done')
+        self.node.send_command('ipaddr')
+        self.node.pexpect.expect('fd00::1')
+        self.node.pexpect.expect('Done')
+
+        #self.node.send_command('ipaddr remove fd00::1')
+        #self.node.pexpect.expect('Done')
+
+    def test_route(self):
+        self.node.send_command('route add fd00::1/64')
+        self.node.pexpect.expect('Done')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/ncp/test_ncp_thread.py
+++ b/tests/scripts/ncp/test_ncp_thread.py
@@ -81,6 +81,16 @@ class test_ncp_thread(unittest.TestCase):
         self.node.send_command('route add fd00::1/64')
         self.node.pexpect.expect('Done')
 
+    def test_leader_weight(self):
+        self.node.send_command('leaderweight')
+        self.node.pexpect.expect('Done')
+
+        self.node.send_command('leaderweight 4')
+        self.node.pexpect.expect('Done')
+        self.node.send_command('leaderweight')
+        self.node.pexpect.expect('4')
+        self.node.pexpect.expect('Done')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/ncp/test_ncp_thread.py
+++ b/tests/scripts/ncp/test_ncp_thread.py
@@ -47,35 +47,42 @@ class test_ncp_thread(unittest.TestCase):
 
 
     def test_assisting_ports(self):
+        # Set over empty
         self.node.send_command('ncp-assisting-ports 1234')
         self.node.pexpect.expect('Done')
-
+        # Get and verify
         self.node.send_command('ncp-assisting-ports')
         self.node.pexpect.expect('1234')
         self.node.pexpect.expect('Done')
-
+        
+        # Remove
         self.node.send_command('ncp-assisting-ports remove 1234')
         self.node.pexpect.expect('Done')
-
+        
+        # Insert and verify
         self.node.send_command('ncp-assisting-ports add 5432')
         self.node.pexpect.expect('Done')
-
         self.node.send_command('ncp-assisting-ports')
         self.node.pexpect.expect('5432')
         self.node.pexpect.expect('Done')
 
-    def test_ipaddr(self):
-        self.node.send_command('ipaddr')
+        # Insert second
+        self.node.send_command('ncp-assisting-ports add 5433')
+        self.node.pexpect.expect('Done')
+        # Remove first
+        self.node.send_command('ncp-assisting-ports remove 5432')
+        self.node.pexpect.expect('Done')
+        # Verify remaining
+        self.node.send_command('ncp-assisting-ports')
+        self.node.pexpect.expect('5433')
         self.node.pexpect.expect('Done')
 
-        self.node.send_command('ipaddr add fd00::1')
+        # Set over existing
+        self.node.send_command('ncp-assisting-ports 8080')
         self.node.pexpect.expect('Done')
-        self.node.send_command('ipaddr')
-        self.node.pexpect.expect('fd00::1')
+        self.node.send_command('ncp-assisting-ports')
+        self.node.pexpect.expect('8080')
         self.node.pexpect.expect('Done')
-
-        #self.node.send_command('ipaddr remove fd00::1')
-        #self.node.pexpect.expect('Done')
 
     def test_route(self):
         self.node.send_command('route add fd00::1/64')

--- a/tests/scripts/thread-cert/Makefile.am
+++ b/tests/scripts/thread-cert/Makefile.am
@@ -1,0 +1,259 @@
+#
+#  Copyright (c) 2016, Nest Labs, Inc.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
+
+LOG_DRIVER=$(abs_top_srcdir)/third_party/openthread-test-driver/test-driver
+
+EXTRA_DIST                                                         = \
+    Cert_5_1_01_RouterAttach.py                                      \
+    Cert_5_1_02_ChildAddressTimeout.py                               \
+    Cert_5_1_03_RouterAddressReallocation.py                         \
+    Cert_5_1_04_RouterAddressReallocation.py                         \
+    Cert_5_1_05_RouterAddressTimeout.py                              \
+    Cert_5_1_06_RemoveRouterId.py                                    \
+    Cert_5_1_07_MaxChildCount.py                                     \
+    Cert_5_1_08_RouterAttachConnectivity.py                          \
+    Cert_5_1_09_REEDAttachConnectivity.py                            \
+    Cert_5_1_10_RouterAttachLinkQuality.py                           \
+    Cert_5_1_11_REEDAttachLinkQuality.py                             \
+    Cert_5_1_12_NewRouterNeighborSync.py                             \
+    Cert_5_1_13_RouterReset.py                                       \
+    Cert_5_2_01_BecomeActiveRouter.py                                \
+    Cert_5_2_02_LeaderReject1Hop.py                                  \
+    Cert_5_2_03_LeaderReject2Hops.py                                 \
+    Cert_5_2_04_REEDUpgrade.py                                       \
+    Cert_5_2_05_AddressQuery.py                                      \
+    Cert_5_2_07_REEDSynchronization.py                               \
+    Cert_5_3_01_LinkLocal.py                                         \
+    Cert_5_3_02_RealmLocal.py                                        \
+    Cert_5_3_03_AddressQuery.py                                      \
+    Cert_5_3_04_AddressMapCache.py                                   \
+    Cert_5_3_05_RoutingLinkQuality.py                                \
+    Cert_5_3_06_RouterIdMask.py                                      \
+    Cert_5_3_06b_RouterIdMask.py                                     \
+    Cert_5_3_07_DuplicateAddress.py                                  \
+    Cert_5_3_08_ChildAddressSet.py                                   \
+    Cert_5_3_10_AddressQuery.py                                      \
+    Cert_5_5_01_LeaderReset.py                                       \
+    Cert_5_5_02_LeaderReboot.py                                      \
+    Cert_5_5_03_SplitMergeChildren.py                                \
+    Cert_5_5_04_SplitMergeRouters.py                                 \
+    Cert_5_5_05_SplitMergeREED.py                                    \
+    Cert_5_5_06_SplitWeight.py                                       \
+    Cert_5_5_07_SplitMergeThreeWay.py                                \
+    Cert_5_5_08_SplitRoutersLostLeader.py                            \
+    Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py             \
+    Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py             \
+    Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py              \
+    Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py              \
+    Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py              \
+    Cert_5_6_06_NetworkDataExpiration.py                             \
+    Cert_5_6_07_NetworkDataRequestREED.py                            \
+    Cert_5_6_08_ContextManagement.py                                 \
+    Cert_5_6_09_NetworkDataForwarding.py                             \
+    Cert_5_8_01_KeySynchronization.py                                \
+    Cert_5_8_02_KeyIncrement.py                                      \
+    Cert_5_8_03_KeyIncrementRollOver.py                              \
+    Cert_6_1_01_RouterAttach.py                                      \
+    Cert_6_1_02_REEDAttach.py                                        \
+    Cert_6_1_03_RouterAttachConnectivity.py                          \
+    Cert_6_1_04_REEDAttachConnectivity.py                            \
+    Cert_6_1_05_RouterAttachLinkQuality.py                           \
+    Cert_6_1_06_REEDAttachLinkQuality.py                             \
+    Cert_6_1_07_EDSynchronization.py                                 \
+    Cert_6_2_01_NewPartition.py                                      \
+    Cert_6_2_02_NewPartition.py                                      \
+    Cert_6_3_01_OrphanReattach.py                                    \
+    Cert_6_3_02_NetworkDataUpdate.py                                 \
+    Cert_6_4_01_LinkLocal.py                                         \
+    Cert_6_4_02_RealmLocal.py                                        \
+    Cert_6_5_01_ChildResetSynchronize.py                             \
+    Cert_6_5_02_ChildResetReattach.py                                \
+    Cert_6_6_01_KeyIncrement.py                                      \
+    Cert_6_6_02_KeyIncrementRollOver.py                              \
+    Cert_7_1_01_BorderRouterAsLeader.py                              \
+    Cert_7_1_02_BorderRouterAsRouter.py                              \
+    Cert_7_1_03_BorderRouterAsLeader.py                              \
+    Cert_7_1_04_BorderRouterAsRouter.py                              \
+    Cert_7_1_05_BorderRouterAsRouter.py                              \
+    Cert_9_2_14_PanIdQuery.py                                        \
+    node.py                                                          \
+    $(NULL)
+
+if OPENTHREAD_BUILD_TESTS
+
+# First, list all essential program and script tests that MUST be run.
+
+check_PROGRAMS =
+
+check_SCRIPTS                                                      = \
+    $(NULL)
+
+if OPENTHREAD_TESTS_SUBSET1
+
+check_SCRIPTS                                                     += \
+    Cert_5_1_01_RouterAttach.py                                      \
+    Cert_5_1_02_ChildAddressTimeout.py                               \
+    Cert_5_1_03_RouterAddressReallocation.py                         \
+    Cert_5_1_04_RouterAddressReallocation.py                         \
+    Cert_5_1_05_RouterAddressTimeout.py                              \
+    Cert_5_1_06_RemoveRouterId.py                                    \
+    Cert_5_1_07_MaxChildCount.py                                     \
+    Cert_5_1_08_RouterAttachConnectivity.py                          \
+    Cert_5_1_09_REEDAttachConnectivity.py                            \
+    $(NULL)
+
+endif # OPENTHREAD_TESTS_SUBSET1
+
+if OPENTHREAD_TESTS_SUBSET2
+
+check_SCRIPTS                                                     += \
+    Cert_5_1_10_RouterAttachLinkQuality.py                           \
+    Cert_5_1_11_REEDAttachLinkQuality.py                             \
+    Cert_5_1_12_NewRouterNeighborSync.py                             \
+    Cert_5_1_13_RouterReset.py                                       \
+    Cert_5_2_01_BecomeActiveRouter.py                                \
+    Cert_5_2_02_LeaderReject1Hop.py                                  \
+    Cert_5_2_03_LeaderReject2Hops.py                                 \
+    Cert_5_2_04_REEDUpgrade.py                                       \
+    Cert_5_2_05_AddressQuery.py                                      \
+    Cert_5_2_07_REEDSynchronization.py                               \
+    Cert_5_3_01_LinkLocal.py                                         \
+    Cert_5_3_02_RealmLocal.py                                        \
+    Cert_5_3_03_AddressQuery.py                                      \
+    Cert_5_3_04_AddressMapCache.py                                   \
+    Cert_5_3_05_RoutingLinkQuality.py                                \
+    $(NULL)
+
+endif # OPENTHREAD_TESTS_SUBSET2
+
+if OPENTHREAD_TESTS_SUBSET3
+
+check_SCRIPTS                                                     += \
+    Cert_5_3_06_RouterIdMask.py                                      \
+    Cert_5_3_06b_RouterIdMask.py                                     \
+    Cert_5_3_07_DuplicateAddress.py                                  \
+    Cert_5_3_08_ChildAddressSet.py                                   \
+    Cert_5_3_10_AddressQuery.py                                      \
+    Cert_5_5_01_LeaderReset.py                                       \
+    Cert_5_5_02_LeaderReboot.py                                      \
+    $(NULL)
+
+endif # OPENTHREAD_TESTS_SUBSET3
+
+if OPENTHREAD_TESTS_SUBSET4
+
+check_SCRIPTS                                                     += \
+    Cert_5_5_03_SplitMergeChildren.py                                \
+    Cert_5_5_04_SplitMergeRouters.py                                 \
+    Cert_5_5_05_SplitMergeREED.py                                    \
+    Cert_5_5_06_SplitWeight.py                                       \
+    Cert_5_5_07_SplitMergeThreeWay.py                                \
+    Cert_5_5_08_SplitRoutersLostLeader.py                            \
+    Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py             \
+    Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py             \
+    $(NULL)
+
+endif # OPENTHREAD_TESTS_SUBSET4
+
+if OPENTHREAD_TESTS_SUBSET5
+
+check_SCRIPTS                                                     += \
+    Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py              \
+    Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py              \
+    Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py              \
+    Cert_5_6_06_NetworkDataExpiration.py                             \
+    Cert_5_6_07_NetworkDataRequestREED.py                            \
+    Cert_5_6_08_ContextManagement.py                                 \
+    Cert_5_6_09_NetworkDataForwarding.py                             \
+    Cert_5_8_01_KeySynchronization.py                                \
+    Cert_5_8_02_KeyIncrement.py                                      \
+    Cert_5_8_03_KeyIncrementRollOver.py                              \
+    Cert_6_1_01_RouterAttach.py                                      \
+    Cert_6_1_02_REEDAttach.py                                        \
+    Cert_6_1_03_RouterAttachConnectivity.py                          \
+    Cert_6_1_04_REEDAttachConnectivity.py                            \
+    Cert_6_1_05_RouterAttachLinkQuality.py                           \
+    Cert_6_1_06_REEDAttachLinkQuality.py                             \
+    Cert_6_1_07_EDSynchronization.py                                 \
+    Cert_6_2_01_NewPartition.py                                      \
+    Cert_6_2_02_NewPartition.py                                      \
+    Cert_6_3_01_OrphanReattach.py                                    \
+    Cert_6_3_02_NetworkDataUpdate.py                                 \
+    Cert_6_4_01_LinkLocal.py                                         \
+    Cert_6_4_02_RealmLocal.py                                        \
+    Cert_6_5_01_ChildResetSynchronize.py                             \
+    Cert_6_5_02_ChildResetReattach.py                                \
+    Cert_6_6_01_KeyIncrement.py                                      \
+    Cert_6_6_02_KeyIncrementRollOver.py                              \
+    Cert_7_1_01_BorderRouterAsLeader.py                              \
+    Cert_7_1_02_BorderRouterAsRouter.py                              \
+    Cert_7_1_03_BorderRouterAsLeader.py                              \
+    Cert_7_1_04_BorderRouterAsRouter.py                              \
+    Cert_7_1_05_BorderRouterAsRouter.py                              \
+    Cert_9_2_14_PanIdQuery.py                                        \
+    $(NULL)
+
+endif # OPENTHREAD_TESTS_SUBSET5
+
+TESTS_ENVIRONMENT                                                  = \
+    export                                                           \
+    top_builddir='$(top_builddir)'                                   \
+    VERBOSE=1;                                                       \
+    $(NULL)
+
+TESTS                                                              = \
+    $(check_PROGRAMS)                                                \
+    $(check_SCRIPTS)                                                 \
+    $(NULL)
+
+XFAIL_NCP_TESTS                                                        = \
+        Cert_5_3_07_DuplicateAddress.py                                  \
+        Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py             \
+        Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py             \
+        Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py              \
+        Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py              \
+        Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py              \
+        Cert_5_6_06_NetworkDataExpiration.py                             \
+        Cert_5_6_07_NetworkDataRequestREED.py                            \
+        Cert_5_6_08_ContextManagement.py                                 \
+        Cert_6_3_02_NetworkDataUpdate.py                                 \
+        Cert_7_1_01_BorderRouterAsLeader.py                              \
+        Cert_7_1_02_BorderRouterAsRouter.py                              \
+        Cert_7_1_03_BorderRouterAsLeader.py                              \
+        Cert_7_1_04_BorderRouterAsRouter.py                              \
+        Cert_7_1_05_BorderRouterAsRouter.py                              \
+        Cert_9_2_14_PanIdQuery.py                                        \
+        $(NULL)
+
+XFAIL_TESTS = $(if $(filter $(NODE_TYPE),ncp-sim),$(XFAIL_NCP_TESTS))
+
+endif # OPENTHREAD_BUILD_TESTS
+
+include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/tests/scripts/thread-cert/Makefile.am
+++ b/tests/scripts/thread-cert/Makefile.am
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2016, Nest Labs, Inc.
+#  Copyright (c) 2016, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without

--- a/tools/spinel-cli/spinel-cli.py
+++ b/tools/spinel-cli/spinel-cli.py
@@ -1473,6 +1473,7 @@ class WpanDiagsCmd(Cmd, SpinelCodec):
         'ncp-ll64', 
         'ncp-mac16',
         'ncp-mac64',
+        'ncp-eui64',
         'ncp-mlprefix',
 
         'ncp-tun', 
@@ -2698,6 +2699,9 @@ class WpanDiagsCmd(Cmd, SpinelCodec):
 
     def do_ncpmac64(self, line):
         self.handle_property(line, SPINEL_PROP_MAC_15_4_LADDR, 'E')
+
+    def do_ncpeui64(self, line):
+        self.handle_property(line, SPINEL_PROP_HWADDR, 'E')
 
     def do_ncpstatus(self, line):
         """ Display the last status. """

--- a/tools/spinel-cli/spinel-cli.py
+++ b/tools/spinel-cli/spinel-cli.py
@@ -60,7 +60,6 @@ DEBUG_LOG_HDLC = 0
 DEBUG_LOG_PKT = DEBUG_ENABLE
 DEBUG_LOG_PROP = DEBUG_ENABLE
 DEBUG_LOG_TUN = 0
-DEBUG_TERM = 0
 DEBUG_CMD_RESPONSE = 0
 
 TIMEOUT_PROP = 2
@@ -78,8 +77,6 @@ import sys
 import time
 import threading
 import traceback
-
-import blessed
 
 import optparse
 from optparse import OptionParser, Option, OptionValueError
@@ -154,31 +151,9 @@ logging.config.dictConfig({
 logger = logging.getLogger(__name__)
 
 
-# Terminal macros
-
-class Color:
-    END          = '\033[0m'
-    BOLD         = '\033[1m'
-    DIM          = '\033[2m'
-    UNDERLINE    = '\033[4m'
-    BLINK        = '\033[5m'
-    REVERSE      = '\033[7m'
-
-    CYAN         = '\033[96m'
-    PURPLE       = '\033[95m'
-    BLUE         = '\033[94m'
-    YELLOW       = '\033[93m'
-    GREEN        = '\033[92m'
-    RED          = '\033[91m'
-
-    BLACK        = "\033[30m"
-    DARKRED      = "\033[31m"
-    DARKGREEN    = "\033[32m"
-    DARKYELLOW   = "\033[33m"
-    DARKBLUE     = "\033[34m"
-    DARKMAGENTA  = "\033[35m"
-    DARKCYAN     = "\033[36m"
-    WHITE        = "\033[37m"
+#=========================================
+#    SPINEL Constants
+#=========================================
 
 SPINEL_RSSI_OVERRIDE            = 127
 
@@ -527,21 +502,6 @@ SPINEL_LAST_STATUS_MAP = {
     0x400F: "kThreadError_NoTasklets",
 
 }
-
-#=========================================
-
-
-class DiagsTerminal(blessed.Terminal):
-    def print_title(self, strings=[]):
-        clr = term.green_reverse
-        title = term.white_reverse("  spinel-cli  ")
-        with term.location(x=0, y=0):
-            print (clr + term.center(title+clr))
-            for string in strings:
-                print (term.ljust(string))
-            print (term.ljust(" ") + term.normal)
-
-term = DiagsTerminal()
 
 #=========================================
     
@@ -1293,11 +1253,6 @@ class WpanApi(SpinelCodec):
 
             self.parse_rx(self.rx_pkt)
 
-            # Output RX status window
-            if DEBUG_TERM:
-                msg = str(map(hexify_int,self.rx_pkt))
-                term.print_title(["RX: "+msg])
-
     class PropertyItem(object):
         """ Queue item for NCP response to property commands. """
         def __init__(self, prop, value, tid):
@@ -1460,7 +1415,6 @@ class WpanDiagsCmd(Cmd, SpinelCodec):
         'clear',
         'history',
         'debug',
-        'debug-term',
 
         'v',
         'h',
@@ -1737,20 +1691,6 @@ class WpanDiagsCmd(Cmd, SpinelCodec):
                 DEBUG_LOG_HDLC = 0
 
         print "DEBUG_ENABLE = "+str(DEBUG_ENABLE)
-
-    def do_debugterm(self, line):
-        """
-        Enables a debug terminal display in the title bar for viewing 
-        raw NCP packets.
-        Usage: debug_term <1=enable | 0=disable>
-        """
-        global DEBUG_TERM
-        if line: line = int(line)
-        if line: 
-            DEBUG_TERM = 1
-        else:
-            DEBUG_TERM = 0
-
 
     def do_channel(self, line):
         """

--- a/tools/spinel-cli/spinel-cli.py
+++ b/tools/spinel-cli/spinel-cli.py
@@ -1516,8 +1516,20 @@ class WpanDiagsCmd(Cmd, SpinelCodec):
         # OpenThread Spinel-specific commands
         'ncp-ml64', 
         'ncp-ll64', 
+        'ncp-mac16',
+        'ncp-mac64',
+
         'ncp-tun', 
 
+        'ncp-status',
+        'ncp-vendorid',
+
+        'phy-freq',
+        'phy-cca-threshold',
+        'phy-tx-power',
+        'phy-rssi',
+
+        'mac-filter-mode',
     ]
 
 
@@ -2113,7 +2125,7 @@ class WpanDiagsCmd(Cmd, SpinelCodec):
             > masterkey 00112233445566778899aabbccddeeff
             Done
         """
-        pass 
+        self.handle_property(line, SPINEL_PROP_NET_MASTER_KEY, 'D')
 
     def do_mode(self, line): 
         """
@@ -2246,7 +2258,7 @@ class WpanDiagsCmd(Cmd, SpinelCodec):
             > networkname OpenThread
             Done
         """
-        pass 
+        self.handle_property(line, SPINEL_PROP_NET_NETWORK_NAME, 'U')
 
     def do_panid(self, line):
         """
@@ -2727,6 +2739,39 @@ class WpanDiagsCmd(Cmd, SpinelCodec):
     def do_ncpml64(self, line):
         """ Display the mesh local IPv6 address. """
         self.handle_property(line, SPINEL_PROP_IPV6_ML_ADDR, '6')
+
+    def do_ncpmac16(self, line):
+        self.handle_property(line, SPINEL_PROP_MAC_15_4_SADDR, 'H')
+
+    def do_ncpmac64(self, line):
+        self.handle_property(line, SPINEL_PROP_MAC_15_4_LADDR, 'E')
+
+    def do_ncpstatus(self, line):
+        """ Display the last status. """
+        self.handle_property(line, SPINEL_PROP_LAST_STATUS) # 'i'
+
+    def do_ncpvendorid(self, line):
+        """ Display the vendor id. """
+        self.handle_property(line, SPINEL_PROP_VENDOR_ID) # 'i'
+
+    def do_phyfreq(self, line):
+        """ Display the last status. """
+        self.handle_property(line, SPINEL_PROP_PHY_FREQ, 'L')
+
+    def do_phyccathreshold(self, line):
+        """ Display the cca threshold. """
+        self.handle_property(line, SPINEL_PROP_CCA_THRESHOLD)
+
+    def do_phytxpower(self, line):
+        """ Display the tx power level. """
+        self.handle_property(line, SPINEL_PROP_PHY_TX_POWER)
+
+    def do_phyrssi(self, line):
+        """ Display the last rssi. """
+        self.handle_property(line, SPINEL_PROP_PHY_RSSI)
+
+    def do_macfiltermode(self, line):
+        self.handle_property(line, SPINEL_PROP_MAC_FILTER_MODE)
 
     def complete_ncptun(self, text, line, begidx, endidx):
         _SUB_COMMANDS = ('up', 'down', 'add', 'del', 'ping')

--- a/tools/spinel-cli/spinel-cli.py
+++ b/tools/spinel-cli/spinel-cli.py
@@ -1326,7 +1326,7 @@ class WpanApi(SpinelCodec):
         pay = self.encode_i(prop_id)
         if format != None:
             pay += pack(format, value)
-        else:
+        elif value != None:
             pay += value
         self.transact(cmd, pay)
 

--- a/tools/spinel-cli/spinel-cli.py
+++ b/tools/spinel-cli/spinel-cli.py
@@ -1482,6 +1482,7 @@ class WpanDiagsCmd(Cmd, SpinelCodec):
         'ncp-vendorid',
         'ncp-assisting-ports',
 
+        'phy-enabled',
         'phy-freq',
         'phy-cca-threshold',
         'phy-tx-power',
@@ -2008,6 +2009,10 @@ class WpanDiagsCmd(Cmd, SpinelCodec):
                 self.wpanApi.tun_if.addr_add(ipaddr)
 
         elif args[0] == "remove":
+            arr += pack('B', prefix_len) 
+            arr += pack('<L', valid)
+            arr += pack('<L', preferred)
+            arr += pack('B', flags)
             value = self.prop_remove_value(SPINEL_PROP_IPV6_ADDRESS_TABLE, 
                                            arr, str(len(arr))+'s')
             if self.wpanApi.tun_if:
@@ -2733,6 +2738,9 @@ class WpanDiagsCmd(Cmd, SpinelCodec):
         else:
             self.handle_property(line, SPINEL_PROP_THREAD_ASSISTING_PORTS, 'H')
             
+    def do_phyenabled(self, line):
+        self.handle_property(line, SPINEL_PROP_PHY_ENABLED)
+
     def do_phyfreq(self, line):
         """ Display the last status. """
         self.handle_property(line, SPINEL_PROP_PHY_FREQ, 'L')


### PR DESCRIPTION
Added functional coverage tests for ncp firmware in tests/scripts/ncp.  These are targeting increased coverage of ncp_base and ultimately the underlying ot apis as triggered via spinel.  Over time this can be expanded to include diags and other commands not covered by thread-cert.
