### PR TITLE
Implement TrickleTimer class

### DIFF
--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -43,6 +43,7 @@ libopenthread_a_SOURCES             = \
     common/message.cpp                \
     common/tasklet.cpp                \
     common/timer.cpp                  \
+    common/trickle_timer.cpp          \
     crypto/aes_ccm.cpp                \
     crypto/aes_ecb.cpp                \
     crypto/hmac_sha256.cpp            \
@@ -113,6 +114,7 @@ noinst_HEADERS                      = \
     common/new.hpp                    \
     common/tasklet.hpp                \
     common/timer.hpp                  \
+    common/trickle_timer.hpp          \
     crypto/aes_ccm.hpp                \
     crypto/aes_ecb.hpp                \
     crypto/hmac_sha256.hpp            \

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -146,6 +146,9 @@ void TrickleTimer::HandleTimerFired(void *aContext)
 void TrickleTimer::HandleTimerFired(void)
 {
     bool shouldContinue = true;
+    
+    // Default the current state to Dormant
+    mPhase = kPhaseDormant;
 
     switch (mPhase)
     {
@@ -198,12 +201,6 @@ void TrickleTimer::HandleTimerFired(void)
 
     default:
         assert(false);
-    }
-
-    // If we aren't still running, we go dormant
-    if (!shouldContinue)
-    {
-        mPhase = kPhaseDormant;
     }
 }
 

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -139,7 +139,7 @@ void TrickleTimer::StartNewInterval(void)
 
 void TrickleTimer::HandleTimerFired(void *aContext)
 {
-    TrickleTimer *obj = reinterpret_cast<TrickleTimer *>(aContext);
+    TrickleTimer *obj = static_cast<TrickleTimer *>(aContext);
     obj->HandleTimerFired();
 }
 
@@ -151,7 +151,7 @@ void TrickleTimer::HandleTimerFired(void)
     {
     // We have just reached time 't'
     case kTricklePhaseTransmit:
-
+    {
         // Are we not using reduncancy or is the counter still less than it?
 #ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
         if (k == 0 || c < k)
@@ -172,10 +172,11 @@ void TrickleTimer::HandleTimerFired(void)
         }
 
         break;
+    }
 
     // We have just reached time 'I'
     case kTricklePhaseInterval:
-
+    {
         // Double 'I' to get the new interval length
         uint32_t newI = I == 0 ? 1 : I << 1;
 
@@ -193,6 +194,7 @@ void TrickleTimer::HandleTimerFired(void)
         }
 
         break;
+    }
 
     default:
         assert(false);

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -145,12 +145,13 @@ void TrickleTimer::HandleTimerFired(void *aContext)
 
 void TrickleTimer::HandleTimerFired(void)
 {
+    Phase curPhase = mPhase;
     bool shouldContinue = true;
 
     // Default the current state to Dormant
     mPhase = kPhaseDormant;
 
-    switch (mPhase)
+    switch (curPhase)
     {
     // We have just reached time 't'
     case kPhaseTransmit:

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -173,11 +173,23 @@ void TrickleTimer::HandleTimerFired(void)
         // Wait for the rest of the interval to elapse
         if (shouldContinue)
         {
-            // Start next phase of the timer
-            mPhase = kPhaseInterval;
+            // If we are in plain timer mode, just randomize I and restart the interval
+            if (mMode == kModePlainTimer)
+            {
+                // Initialize I to [Imin, Imax]
+                I = Imin + otPlatRandomGet() % (Imax - Imin);
 
-            // Start the time for 'I - t' milliseconds
-            mTimer.Start(I - t);
+                // Start a new interval
+                StartNewInterval();
+            }
+            else
+            {
+                // Start next phase of the timer
+                mPhase = kPhaseInterval;
+
+                // Start the time for 'I - t' milliseconds
+                mTimer.Start(I - t);
+            }
         }
 
         break;

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -32,6 +32,7 @@
  */
 
 #include <common/code_utils.hpp>
+#include <common/debug.hpp>
 #include <common/trickle_timer.hpp>
 #include <platform/random.h>
 

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -1,0 +1,183 @@
+/*
+ *  Copyright (c) 2016, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the trickle timer logic.
+ */
+
+#include <common/code_utils.hpp>
+#include <common/trickle_timer.hpp>
+
+namespace Thread {
+
+TrickleTimer::TrickleTimer(
+    TimerScheduler &aScheduler, uint32_t aIntervalMin, uint32_t aIntervalMax,
+    uint32_t aRedundancyConstant, TrickleTimerMode aMode, Handler aTransmitHandler,
+    Handler aIntervalExpiredHandler, void *aContext)
+    :
+    mTimer(aScheduler, HandleTimerFired, this),
+    Imin(aIntervalMin),
+    Imax(aIntervalMax),
+    k(aRedundancyConstant),
+    mMode(aMode),
+    mPhase(kTricklePhaseDormant),
+    mTransmitHandler(aTransmitHandler),
+    mIntervalExpiredHandler(aIntervalExpiredHandler),
+    mContext(aContext)
+{
+    // Initialize I to [Imin, Imax]
+    I = Imin + otPlatRandomGet() % (Imax - Imin);
+}
+
+bool TrickleTimer::IsRunning(void) const
+{
+    return mPhase != kTricklePhaseDormant;
+}
+
+void TrickleTimer::Start(void)
+{
+    // Reset the counter and timer phase
+    c = 0;
+    mPhase = kTricklePhaseTransmit;
+
+    // Initialize t
+    if (I == 0)
+    {
+        // Immediate interval, just set t to 0
+        t = 0;
+    }
+    else if (mMode == kTrickleTimerModeMPL)
+    {
+        // Initialize t to random value between (0, I]
+        t = otPlatRandomGet() % I;
+    }
+    else
+    {
+        // Initialize t to random value between (I/2, I]
+        t = (I / 2) + otPlatRandomGet() % (I / 2);
+    }
+
+    // Start the timer for 't' milliseconds from now
+    mTimer.Start(t);
+}
+
+void TrickleTimer::Stop(void)
+{
+    mPhase = kTricklePhaseDormant;
+    mTimer.Stop();
+}
+
+void TrickleTimer::Reset(void)
+{
+    // Reset I to Imin
+    I = Imin;
+
+    // Stop the existing timer
+    mTimer.Stop();
+
+    // Start a new interval
+    Start();
+}
+
+void TrickleTimer::IndicateConsistent(void)
+{
+    // Increment counter
+    c++;
+}
+
+void TrickleTimer::IndicateInconsistent(void)
+{
+    // Only relavent if we aren't already at I == Imin
+    if (I != Imin)
+    {
+        // Resets the current timer
+        Reset();
+    }
+}
+
+void TrickleTimer::HandleTimerFired(void *aContext)
+{
+    TrickleTimer *obj = reinterpret_cast<TrickleTimer *>(aContext);
+    obj->HandleTimerFired();
+}
+
+void TrickleTimer::HandleTimerFired(void)
+{
+    bool ShouldContinue = true;
+
+    // We have just reached time 't'
+    if (mPhase == kTricklePhaseTransmit)
+    {
+        bool ShouldContinue = true;
+
+        // Are we not using reduncancy or is the counter still less than it?
+        if (k == 0 || c < k)
+        {
+            // Invoke the transmission callback
+            ShouldContinue = TransmitFired();
+        }
+
+        // Wait for the rest of the interval to elapse
+        if (ShouldContinue)
+        {
+            // Start next phase of the timer
+            mPhase = kTricklePhaseInterval;
+
+            // Start the time for 'I - t' milliseconds
+            mTimer.Start(I - t);
+        }
+    }
+    // We have just reached time 'I'
+    else if (mPhase == kTricklePhaseInterval)
+    {
+        // Double 'I' to get the new interval length
+        uint32_t newI = I == 0 ? 1 : I << 1;
+
+        if (newI > Imax) { newI = Imax; }
+
+        I = newI;
+
+        // Invoke the interval expiration callback
+        bool ShouldContinue = IntervalExpiredFired();
+
+        if (ShouldContinue)
+        {
+            // Start a new interval
+            Start();
+        }
+    }
+
+    // If we aren't still running, we go dormant
+    if (!ShouldContinue)
+    {
+        mPhase = kTricklePhaseDormant;
+    }
+}
+
+}  // namespace Thread

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -146,7 +146,7 @@ void TrickleTimer::HandleTimerFired(void *aContext)
 void TrickleTimer::HandleTimerFired(void)
 {
     bool shouldContinue = true;
-    
+
     // Default the current state to Dormant
     mPhase = kPhaseDormant;
 

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -50,7 +50,7 @@ TrickleTimer::TrickleTimer(
     k(aRedundancyConstant),
 #endif
     mMode(aMode),
-    mPhase(kTricklePhaseDormant),
+    mPhase(kPhaseDormant),
     mTransmitHandler(aTransmitHandler),
     mIntervalExpiredHandler(aIntervalExpiredHandler),
     mContext(aContext)
@@ -59,7 +59,7 @@ TrickleTimer::TrickleTimer(
 
 bool TrickleTimer::IsRunning(void) const
 {
-    return mPhase != kTricklePhaseDormant;
+    return mPhase != kPhaseDormant;
 }
 
 void TrickleTimer::Start(uint32_t aIntervalMin, uint32_t aIntervalMax)
@@ -79,7 +79,7 @@ void TrickleTimer::Start(uint32_t aIntervalMin, uint32_t aIntervalMax)
 
 void TrickleTimer::Stop(void)
 {
-    mPhase = kTricklePhaseDormant;
+    mPhase = kPhaseDormant;
     mTimer.Stop();
 }
 
@@ -114,7 +114,7 @@ void TrickleTimer::StartNewInterval(void)
 #ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
     c = 0;
 #endif
-    mPhase = kTricklePhaseTransmit;
+    mPhase = kPhaseTransmit;
 
     // Initialize t
     if (I == 0)
@@ -122,7 +122,7 @@ void TrickleTimer::StartNewInterval(void)
         // Immediate interval, just set t to 0
         t = 0;
     }
-    else if (mMode == kTrickleTimerModeMPL)
+    else if (mMode == kModeMPL)
     {
         // Initialize t to random value between (0, I]
         t = otPlatRandomGet() % I;
@@ -150,7 +150,7 @@ void TrickleTimer::HandleTimerFired(void)
     switch (mPhase)
     {
     // We have just reached time 't'
-    case kTricklePhaseTransmit:
+    case kPhaseTransmit:
     {
         // Are we not using reduncancy or is the counter still less than it?
 #ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
@@ -165,7 +165,7 @@ void TrickleTimer::HandleTimerFired(void)
         if (shouldContinue)
         {
             // Start next phase of the timer
-            mPhase = kTricklePhaseInterval;
+            mPhase = kPhaseInterval;
 
             // Start the time for 'I - t' milliseconds
             mTimer.Start(I - t);
@@ -175,7 +175,7 @@ void TrickleTimer::HandleTimerFired(void)
     }
 
     // We have just reached time 'I'
-    case kTricklePhaseInterval:
+    case kPhaseInterval:
     {
         // Double 'I' to get the new interval length
         uint32_t newI = I == 0 ? 1 : I << 1;
@@ -203,7 +203,7 @@ void TrickleTimer::HandleTimerFired(void)
     // If we aren't still running, we go dormant
     if (!shouldContinue)
     {
-        mPhase = kTricklePhaseDormant;
+        mPhase = kPhaseDormant;
     }
 }
 

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -33,13 +33,13 @@
 
 #include <common/code_utils.hpp>
 #include <common/trickle_timer.hpp>
+#include <platform/random.h>
 
 namespace Thread {
 
 TrickleTimer::TrickleTimer(
-    TimerScheduler &aScheduler, uint32_t aIntervalMin, uint32_t aIntervalMax,
-    uint32_t aRedundancyConstant, TrickleTimerMode aMode, Handler aTransmitHandler,
-    Handler aIntervalExpiredHandler, void *aContext)
+    TimerScheduler &aScheduler, uint32_t aRedundancyConstant, TrickleTimerMode aMode,
+    Handler aTransmitHandler, Handler aIntervalExpiredHandler, void *aContext)
     :
     mTimer(aScheduler, HandleTimerFired, this),
     k(aRedundancyConstant),
@@ -139,8 +139,6 @@ void TrickleTimer::HandleTimerFired(void)
     // We have just reached time 't'
     if (mPhase == kTricklePhaseTransmit)
     {
-        bool ShouldContinue = true;
-
         // Are we not using reduncancy or is the counter still less than it?
         if (k == 0 || c < k)
         {
@@ -169,13 +167,17 @@ void TrickleTimer::HandleTimerFired(void)
         I = newI;
 
         // Invoke the interval expiration callback
-        bool ShouldContinue = IntervalExpiredFired();
+        ShouldContinue = IntervalExpiredFired();
 
         if (ShouldContinue)
         {
             // Start a new interval
             StartNewInterval();
         }
+    }
+    else
+    {
+        assert(false);
     }
 
     // If we aren't still running, we go dormant

--- a/src/core/common/trickle_timer.hpp
+++ b/src/core/common/trickle_timer.hpp
@@ -61,8 +61,8 @@ public:
      */
     typedef enum Mode
     {
-        kTrickleTimerModeNormal = 0,  ///< Runs the normal trickle logic.
-        kTrickleTimerModeMPL    = 1,  ///< Runs the trickle logic modified for MPL.
+        kModeNormal = 0,  ///< Runs the normal trickle logic.
+        kModeMPL    = 1,  ///< Runs the trickle logic modified for MPL.
     } Mode;
 
     /**
@@ -141,11 +141,11 @@ private:
     typedef enum Phase
     {
         ///< Indicates we are currently not running
-        kTricklePhaseDormant    = 1,
+        kPhaseDormant    = 1,
         ///< Indicates that when the timer expires, it should evaluate for transmit callbacks
-        kTricklePhaseTransmit   = 2,
+        kPhaseTransmit   = 2,
         ///< Indicates that when the timer expires, it should process interval expiration callbacks
-        kTricklePhaseInterval   = 3,
+        kPhaseInterval   = 3,
     } Phase;
 
     Timer mTimer;

--- a/src/core/common/trickle_timer.hpp
+++ b/src/core/common/trickle_timer.hpp
@@ -49,21 +49,22 @@ namespace Thread {
  */
 
 /**
- * Represents the modes of operation for the TrickleTimer
- */
-typedef enum TrickleTimerMode
-{
-    kTrickleTimerModeNormal = 0,  ///< Runs the normal trickle logic.
-    kTrickleTimerModeMPL    = 1,  ///< Runs the trickle logic modified for MPL.
-} TrickleTimerMode;
-
-/**
  * This class implements a trickle timer.
  *
  */
 class TrickleTimer
 {
 public:
+
+    /**
+     * Represents the modes of operation for the TrickleTimer
+     */
+    typedef enum Mode
+    {
+        kTrickleTimerModeNormal = 0,  ///< Runs the normal trickle logic.
+        kTrickleTimerModeMPL    = 1,  ///< Runs the trickle logic modified for MPL.
+    } Mode;
+
     /**
      * This function pointer is called when the timer expires.
      *
@@ -85,8 +86,11 @@ public:
      * @param[in]  aContext                 A pointer to arbitrary context information.
      *
      */
-    TrickleTimer(TimerScheduler &aScheduler, uint32_t aRedundancyConstant, TrickleTimerMode aMode,
-                 Handler aTransmitHandler, Handler aIntervalExpiredHandler, void *aContext);
+    TrickleTimer(TimerScheduler &aScheduler,
+#ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
+                 uint32_t aRedundancyConstant,
+#endif
+                 Mode aMode, Handler aTransmitHandler, Handler aIntervalExpiredHandler, void *aContext);
 
     /**
      * This method indicates whether or not the trickle timer instance is running.
@@ -111,11 +115,13 @@ public:
      */
     void Stop(void);
 
+#ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
     /**
      * This method indicates to the trickle timer a 'consistent' state.
      *
      */
     void IndicateConsistent(void);
+#endif
 
     /**
      * This method indicates to the trickle timer an 'inconsistent' state.
@@ -132,7 +138,7 @@ private:
     static void HandleTimerFired(void *aContext);
     void HandleTimerFired(void);
 
-    typedef enum TricklePhase
+    typedef enum Phase
     {
         ///< Indicates we are currently not running
         kTricklePhaseDormant    = 1,
@@ -140,15 +146,17 @@ private:
         kTricklePhaseTransmit   = 2,
         ///< Indicates that when the timer expires, it should process interval expiration callbacks
         kTricklePhaseInterval   = 3,
-    } TricklePhase;
+    } Phase;
 
     Timer mTimer;
 
+#ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
     // Redundancy constant
     const uint32_t k;
+#endif
 
     // The mode of operation
-    const TrickleTimerMode mMode;
+    const Mode mMode;
 
     // Minimum interval size
     uint32_t Imin;
@@ -159,10 +167,12 @@ private:
     uint32_t I;
     // The time (in milliseconds) into the interval at which we should transmit
     uint32_t t;
+#ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
     // A counter, keeping track of the number of "consistent" transmissions received
     uint32_t c;
+#endif
     // The current trickle phase for the timer
-    TricklePhase mPhase;
+    Phase mPhase;
 
     // Callback variables
     Handler mTransmitHandler;

--- a/src/core/common/trickle_timer.hpp
+++ b/src/core/common/trickle_timer.hpp
@@ -80,18 +80,15 @@ public:
      * This constructor creates a trickle timer instance.
      *
      * @param[in]  aScheduler               A refrence to the timer scheduler.
-     * @param[in]  aIntervalMin             The minimum interval for the timer, Imin.
-     * @param[in]  aIntervalMax             The maximum interval for the timer, Imax.
      * @param[in]  aRedundancyConstant      The redundancy constant for the timer, k.
      * @param[in]  aMode                    The operating mode for the timer.
      * @param[in]  aTransmitHandler         A pointer to a function that is called when transmission should occur.
-     * @param[in]  aIntervalExpiredHandler  A pointer to a function that is called when the interval expires.
+     * @param[in]  aIntervalExpiredHandler  An optional pointer to a function that is called when the interval expires.
      * @param[in]  aContext                 A pointer to arbitrary context information.
      *
      */
-    TrickleTimer(TimerScheduler &aScheduler, uint32_t aIntervalMin, uint32_t aIntervalMax,
-                 uint32_t aRedundancyConstant, TrickleTimerMode aMode, Handler aTransmitHandler,
-                 Handler aIntervalExpiredHandler, void *aContext);
+    TrickleTimer(TimerScheduler &aScheduler, uint32_t aRedundancyConstant, TrickleTimerMode aMode,
+                 Handler aTransmitHandler, Handler aIntervalExpiredHandler, void *aContext);
 
     /**
      * This method indicates whether or not the trickle timer instance is running.
@@ -104,20 +101,17 @@ public:
     /**
      * This method start the trickle timer.
      *
+     * @param[in]  aIntervalMin             The minimum interval for the timer, Imin.
+     * @param[in]  aIntervalMax             The maximum interval for the timer, Imax.
+     *
      */
-    void Start(void);
+    void Start(uint32_t aIntervalMin, uint32_t aIntervalMax);
 
     /**
      * This method stops the trickle timer.
      *
      */
     void Stop(void);
-
-    /**
-     * This method resets the trickle timer.
-     *
-     */
-    void Reset(void);
 
     /**
      * This method indicates to the trickle timer a 'consistent' state.
@@ -133,7 +127,9 @@ public:
 
 private:
     bool TransmitFired(void) { return mTransmitHandler(mContext); }
-    bool IntervalExpiredFired(void) { return mIntervalExpiredHandler(mContext); }
+    bool IntervalExpiredFired(void) { return mIntervalExpiredHandler ? mIntervalExpiredHandler(mContext) : true; }
+
+    void StartNewInterval(void)
 
     static void HandleTimerFired(void *aContext);
     void HandleTimerFired(void);
@@ -150,15 +146,16 @@ private:
 
     Timer           mTimer;
 
-    // Constants
-    const uint32_t  Imin;
-    const uint32_t  Imax;
+    // Redundancy constant
     const uint32_t  k;
 
     // The mode of operation
     const TrickleTimerMode mMode;
 
-    // State variables
+    // Minimum interval size
+    uint32_t Imin;
+    // Maximum interval size
+    uint32_t Imax;
 
     // The current interval size (in milliseconds)
     uint32_t I;

--- a/src/core/common/trickle_timer.hpp
+++ b/src/core/common/trickle_timer.hpp
@@ -61,8 +61,9 @@ public:
      */
     typedef enum Mode
     {
-        kModeNormal = 0,  ///< Runs the normal trickle logic.
-        kModeMPL    = 1,  ///< Runs the trickle logic modified for MPL.
+        kModeNormal     = 0,  ///< Runs the normal trickle logic.
+        kModePlainTimer = 1,  ///< Runs a normal timer between Imin and Imax.
+        kModeMPL        = 2,  ///< Runs the trickle logic modified for MPL.
     } Mode;
 
     /**
@@ -80,7 +81,6 @@ public:
      *
      * @param[in]  aScheduler               A refrence to the timer scheduler.
      * @param[in]  aRedundancyConstant      The redundancy constant for the timer, k.
-     * @param[in]  aMode                    The operating mode for the timer.
      * @param[in]  aTransmitHandler         A pointer to a function that is called when transmission should occur.
      * @param[in]  aIntervalExpiredHandler  An optional pointer to a function that is called when the interval expires.
      * @param[in]  aContext                 A pointer to arbitrary context information.
@@ -90,7 +90,7 @@ public:
 #ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
                  uint32_t aRedundancyConstant,
 #endif
-                 Mode aMode, Handler aTransmitHandler, Handler aIntervalExpiredHandler, void *aContext);
+                 Handler aTransmitHandler, Handler aIntervalExpiredHandler, void *aContext);
 
     /**
      * This method indicates whether or not the trickle timer instance is running.
@@ -105,9 +105,10 @@ public:
      *
      * @param[in]  aIntervalMin  The minimum interval for the timer, Imin.
      * @param[in]  aIntervalMax  The maximum interval for the timer, Imax.
+     * @param[in]  aMode         The operating mode for the timer.
      *
      */
-    void Start(uint32_t aIntervalMin, uint32_t aIntervalMax);
+    void Start(uint32_t aIntervalMin, uint32_t aIntervalMax, Mode aMode);
 
     /**
      * This method stops the trickle timer.
@@ -155,13 +156,12 @@ private:
     const uint32_t k;
 #endif
 
-    // The mode of operation
-    const Mode mMode;
-
     // Minimum interval size
     uint32_t Imin;
     // Maximum interval size
     uint32_t Imax;
+    // The mode of operation
+    Mode mMode;
 
     // The current interval size (in milliseconds)
     uint32_t I;

--- a/src/core/common/trickle_timer.hpp
+++ b/src/core/common/trickle_timer.hpp
@@ -1,0 +1,185 @@
+/*
+ *  Copyright (c) 2016, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for the trickle timer logic.
+ */
+
+#ifndef TRICKLE_TIMER_HPP_
+#define TRICKLE_TIMER_HPP_
+
+#include <common/timer.hpp>
+
+namespace Thread {
+
+class Timer;
+
+/**
+ * @addtogroup core-timer-trickle
+ *
+ * @brief
+ *   This module includes definitions for the trickle timer logic.
+ *
+ * @{
+ *
+ */
+
+/**
+ * Represents the modes of operation for the TrickleTimer
+ */
+typedef enum TrickleTimerMode
+{
+    kTrickleTimerModeNormal = 0,  ///< Runs the normal trickle logic.
+    kTrickleTimerModeMPL    = 1,  ///< Runs the trickle logic modified for MPL.
+} TrickleTimerMode;
+
+/**
+ * This class implements a trickle timer.
+ *
+ */
+class TrickleTimer
+{
+public:
+    /**
+     * This function pointer is called when the timer expires.
+     *
+     * @param[in]  aContext  A pointer to arbitrary context information.
+     *
+     * @retval TRUE   If the trickle timer should continue running.
+     * @retval FALSE  If the trickle timer should stop running.
+     */
+    typedef bool (*Handler)(void *aContext);
+
+    /**
+     * This constructor creates a trickle timer instance.
+     *
+     * @param[in]  aScheduler               A refrence to the timer scheduler.
+     * @param[in]  aIntervalMin             The minimum interval for the timer, Imin.
+     * @param[in]  aIntervalMax             The maximum interval for the timer, Imax.
+     * @param[in]  aRedundancyConstant      The redundancy constant for the timer, k.
+     * @param[in]  aMode                    The operating mode for the timer.
+     * @param[in]  aTransmitHandler         A pointer to a function that is called when transmission should occur.
+     * @param[in]  aIntervalExpiredHandler  A pointer to a function that is called when the interval expires.
+     * @param[in]  aContext                 A pointer to arbitrary context information.
+     *
+     */
+    TrickleTimer(TimerScheduler &aScheduler, uint32_t aIntervalMin, uint32_t aIntervalMax,
+                 uint32_t aRedundancyConstant, TrickleTimerMode aMode, Handler aTransmitHandler,
+                 Handler aIntervalExpiredHandler, void *aContext);
+
+    /**
+     * This method indicates whether or not the trickle timer instance is running.
+     *
+     * @retval TRUE   If the trickle timer is running.
+     * @retval FALSE  If the trickle timer is not running.
+     */
+    bool IsRunning(void) const;
+
+    /**
+     * This method start the trickle timer.
+     *
+     */
+    void Start(void);
+
+    /**
+     * This method stops the trickle timer.
+     *
+     */
+    void Stop(void);
+
+    /**
+     * This method resets the trickle timer.
+     *
+     */
+    void Reset(void);
+
+    /**
+     * This method indicates to the trickle timer a 'consistent' state.
+     *
+     */
+    void IndicateConsistent(void);
+
+    /**
+     * This method indicates to the trickle timer an 'inconsistent' state.
+     *
+     */
+    void IndicateInconsistent(void);
+
+private:
+    bool TransmitFired(void) { return mTransmitHandler(mContext); }
+    bool IntervalExpiredFired(void) { return mIntervalExpiredHandler(mContext); }
+
+    static void HandleTimerFired(void *aContext);
+    void HandleTimerFired(void);
+
+    typedef enum TricklePhase
+    {
+        ///< Indicates we are currently not running
+        kTricklePhaseDormant    = 1,
+        ///< Indicates that when the timer expires, it should evaluate for transmit callbacks
+        kTricklePhaseTransmit   = 2,
+        ///< Indicates that when the timer expires, it should process interval expiration callbacks
+        kTricklePhaseInterval   = 3,
+    } TricklePhase;
+
+    Timer           mTimer;
+
+    // Constants
+    const uint32_t  Imin;
+    const uint32_t  Imax;
+    const uint32_t  k;
+
+    // The mode of operation
+    const TrickleTimerMode mMode;
+
+    // State variables
+
+    // The current interval size (in milliseconds)
+    uint32_t I;
+    // The time (in milliseconds) into the interval at which we should transmit
+    uint32_t t;
+    // A counter, keeping track of the number of "consistent" transmissions received
+    uint32_t c;
+    // The current trickle phase for the timer
+    TricklePhase mPhase;
+
+    // Callback variables
+    Handler         mTransmitHandler;
+    Handler         mIntervalExpiredHandler;
+    void           *mContext;
+};
+
+/**
+ * @}
+ *
+ */
+
+}  // namespace Thread
+
+#endif  // TRICKLE_TIMER_HPP_

--- a/src/core/common/trickle_timer.hpp
+++ b/src/core/common/trickle_timer.hpp
@@ -38,8 +38,6 @@
 
 namespace Thread {
 
-class Timer;
-
 /**
  * @addtogroup core-timer-trickle
  *
@@ -101,8 +99,8 @@ public:
     /**
      * This method start the trickle timer.
      *
-     * @param[in]  aIntervalMin             The minimum interval for the timer, Imin.
-     * @param[in]  aIntervalMax             The maximum interval for the timer, Imax.
+     * @param[in]  aIntervalMin  The minimum interval for the timer, Imin.
+     * @param[in]  aIntervalMax  The maximum interval for the timer, Imax.
      *
      */
     void Start(uint32_t aIntervalMin, uint32_t aIntervalMax);
@@ -129,7 +127,7 @@ private:
     bool TransmitFired(void) { return mTransmitHandler(mContext); }
     bool IntervalExpiredFired(void) { return mIntervalExpiredHandler ? mIntervalExpiredHandler(mContext) : true; }
 
-    void StartNewInterval(void)
+    void StartNewInterval(void);
 
     static void HandleTimerFired(void *aContext);
     void HandleTimerFired(void);
@@ -144,10 +142,10 @@ private:
         kTricklePhaseInterval   = 3,
     } TricklePhase;
 
-    Timer           mTimer;
+    Timer mTimer;
 
     // Redundancy constant
-    const uint32_t  k;
+    const uint32_t k;
 
     // The mode of operation
     const TrickleTimerMode mMode;
@@ -167,9 +165,9 @@ private:
     TricklePhase mPhase;
 
     // Callback variables
-    Handler         mTransmitHandler;
-    Handler         mIntervalExpiredHandler;
-    void           *mContext;
+    Handler mTransmitHandler;
+    Handler mIntervalExpiredHandler;
+    void *mContext;
 };
 
 /**

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -414,6 +414,7 @@ bool MleRouter::HandleAdvertiseTimer(void *aContext)
     MleRouter *obj = static_cast<MleRouter *>(aContext);
 
     bool result = obj->HandleAdvertiseTimer();
+
     if (result && obj->GetDeviceState() == kDeviceStateChild)
     {
         // Don't let the trickle timer continue its state machine

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -321,7 +321,7 @@ ThreadError MleRouter::HandleChildStart(otMleAttachFilter aFilter)
 
     if (mDeviceMode & ModeTlv::kModeFFD)
     {
-        obj->mAdvertiseTimer.Start(
+        mAdvertiseTimer.Start(
             Timer::SecToMsec(kReedAdvertiseInterval),
             Timer::SecToMsec(kReedAdvertiseInterval + kReedAdvertiseJitter));
         mNetif.SubscribeAllRoutersMulticast();

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -444,18 +444,22 @@ bool MleRouter::HandleAdvertiseTimer(void)
 
 void MleRouter::ResetAdvertiseInterval(void)
 {
-    assert(GetDeviceState() == kDeviceStateRouter ||
-           GetDeviceState() == kDeviceStateLeader);
-
-    if (!mRouterAdvertiseTimer.IsRunning())
+    if (GetDeviceState() == kDeviceStateRouter || GetDeviceState() == kDeviceStateLeader)
     {
-        mRouterAdvertiseTimer.Start(
-            Timer::SecToMsec(kAdvertiseIntervalMin),
-            Timer::SecToMsec(kAdvertiseIntervalMax));
+        if (!mRouterAdvertiseTimer.IsRunning())
+        {
+            mRouterAdvertiseTimer.Start(
+                Timer::SecToMsec(kAdvertiseIntervalMin),
+                Timer::SecToMsec(kAdvertiseIntervalMax));
+        }
+        else
+        {
+            mRouterAdvertiseTimer.IndicateInconsistent();
+        }
     }
     else
     {
-        mRouterAdvertiseTimer.IndicateInconsistent();
+        // TODO ...
     }
 }
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -426,7 +426,7 @@ void MleRouter::HandleReedAdvertiseTimer(void *aContext)
     {
         uint32_t advertiseDelay = Timer::SecToMsec(kReedAdvertiseInterval +
                                                    (otPlatRandomGet() % kReedAdvertiseJitter));
-        mReedAdvertiseTimer.Start(advertiseDelay);
+        obj->mReedAdvertiseTimer.Start(advertiseDelay);
     }
 }
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -50,8 +50,8 @@ namespace Mle {
 
 MleRouter::MleRouter(ThreadNetif &aThreadNetif):
     Mle(aThreadNetif),
-    mAdvertiseTimer(aThreadNetif.GetIp6().mTimerScheduler, 0,
-                    kTrickleTimerModeNormal, HandleAdvertiseTimer, NULL, this),
+    mAdvertiseTimer(aThreadNetif.GetIp6().mTimerScheduler, 0, kTrickleTimerModeNormal,
+                    HandleAdvertiseTimer, NULL, this),
     mStateUpdateTimer(aThreadNetif.GetIp6().mTimerScheduler, &HandleStateUpdateTimer, this),
     mSocket(aThreadNetif.GetIp6().mUdp),
     mAddressSolicit(OPENTHREAD_URI_ADDRESS_SOLICIT, &HandleAddressSolicit, this),
@@ -426,7 +426,7 @@ bool MleRouter::HandleAdvertiseTimer(void)
     return true;
 }
 
-ThreadError MleRouter::ResetAdvertiseInterval(void)
+void MleRouter::ResetAdvertiseInterval(void)
 {
     if (!mAdvertiseTimer.IsRunning())
     {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -50,7 +50,7 @@ namespace Mle {
 
 MleRouter::MleRouter(ThreadNetif &aThreadNetif):
     Mle(aThreadNetif),
-    mRouterAdvertiseTimer(aThreadNetif.GetIp6().mTimerScheduler, kTrickleTimerModeNormal,
+    mRouterAdvertiseTimer(aThreadNetif.GetIp6().mTimerScheduler, TrickleTimer::kModeNormal,
                           HandleRouterAdvertiseTimer, NULL, this),
     mReedAdvertiseTimer(aThreadNetif.GetIp6().mTimerScheduler, &HandleReedAdvertiseTimer, this),
     mStateUpdateTimer(aThreadNetif.GetIp6().mTimerScheduler, &HandleStateUpdateTimer, this),

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -50,8 +50,7 @@ namespace Mle {
 
 MleRouter::MleRouter(ThreadNetif &aThreadNetif):
     Mle(aThreadNetif),
-    mAdvertiseTimer(aThreadNetif.GetIp6().mTimerScheduler, TrickleTimer::kModeNormal,
-                    HandleAdvertiseTimer, NULL, this),
+    mAdvertiseTimer(aThreadNetif.GetIp6().mTimerScheduler, HandleAdvertiseTimer, NULL, this),
     mStateUpdateTimer(aThreadNetif.GetIp6().mTimerScheduler, &HandleStateUpdateTimer, this),
     mSocket(aThreadNetif.GetIp6().mUdp),
     mAddressSolicit(OPENTHREAD_URI_ADDRESS_SOLICIT, &HandleAddressSolicit, this),
@@ -323,7 +322,8 @@ ThreadError MleRouter::HandleChildStart(otMleAttachFilter aFilter)
     {
         mAdvertiseTimer.Start(
             Timer::SecToMsec(kReedAdvertiseInterval),
-            Timer::SecToMsec(kReedAdvertiseInterval + kReedAdvertiseJitter));
+            Timer::SecToMsec(kReedAdvertiseInterval + kReedAdvertiseJitter),
+            TrickleTimer::kModePlainTimer);
         mNetif.SubscribeAllRoutersMulticast();
     }
 
@@ -423,7 +423,8 @@ bool MleRouter::HandleAdvertiseTimer(void *aContext)
         // Manually restart it
         obj->mAdvertiseTimer.Start(
             Timer::SecToMsec(kReedAdvertiseInterval),
-            Timer::SecToMsec(kReedAdvertiseInterval + kReedAdvertiseJitter));
+            Timer::SecToMsec(kReedAdvertiseInterval + kReedAdvertiseJitter),
+            TrickleTimer::kModePlainTimer);
     }
 
     return result;
@@ -450,7 +451,8 @@ void MleRouter::ResetAdvertiseInterval(void)
     {
         mAdvertiseTimer.Start(
             Timer::SecToMsec(kAdvertiseIntervalMin),
-            Timer::SecToMsec(kAdvertiseIntervalMax));
+            Timer::SecToMsec(kAdvertiseIntervalMax),
+            TrickleTimer::kModeNormal);
     }
     else
     {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -412,22 +412,7 @@ void MleRouter::SetRouterDowngradeThreshold(uint8_t aThreshold)
 bool MleRouter::HandleAdvertiseTimer(void *aContext)
 {
     MleRouter *obj = static_cast<MleRouter *>(aContext);
-
-    bool result = obj->HandleAdvertiseTimer();
-
-    if (result && obj->GetDeviceState() == kDeviceStateChild)
-    {
-        // Don't let the trickle timer continue its state machine
-        result = false;
-
-        // Manually restart it
-        obj->mAdvertiseTimer.Start(
-            Timer::SecToMsec(kReedAdvertiseInterval),
-            Timer::SecToMsec(kReedAdvertiseInterval + kReedAdvertiseJitter),
-            TrickleTimer::kModePlainTimer);
-    }
-
-    return result;
+    return obj->HandleAdvertiseTimer();
 }
 
 bool MleRouter::HandleAdvertiseTimer(void)
@@ -454,10 +439,8 @@ void MleRouter::ResetAdvertiseInterval(void)
             Timer::SecToMsec(kAdvertiseIntervalMax),
             TrickleTimer::kModeNormal);
     }
-    else
-    {
-        mAdvertiseTimer.IndicateInconsistent();
-    }
+
+    mAdvertiseTimer.IndicateInconsistent();
 }
 
 ThreadError MleRouter::SendAdvertisement(void)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -243,7 +243,6 @@ ThreadError MleRouter::BecomeLeader(void)
 
     mSocket.Open(&HandleUdpReceive, this);
     mReedAdvertiseTimer.Stop();
-    ResetAdvertiseInterval();
     mStateUpdateTimer.Start(kStateUpdatePeriod);
     mAddressResolver.Clear();
 
@@ -268,6 +267,8 @@ ThreadError MleRouter::BecomeLeader(void)
     mNetworkData.Reset();
 
     SuccessOrExit(error = SetStateLeader(GetRloc16(mRouterId)));
+    
+    ResetAdvertiseInterval();
 
 exit:
     return error;
@@ -444,22 +445,18 @@ bool MleRouter::HandleAdvertiseTimer(void)
 
 void MleRouter::ResetAdvertiseInterval(void)
 {
-    if (GetDeviceState() == kDeviceStateRouter || GetDeviceState() == kDeviceStateLeader)
+    assert(GetDeviceState() == kDeviceStateRouter || 
+           GetDeviceState() == kDeviceStateLeader);
+
+    if (!mRouterAdvertiseTimer.IsRunning())
     {
-        if (!mRouterAdvertiseTimer.IsRunning())
-        {
-            mRouterAdvertiseTimer.Start(
-                Timer::SecToMsec(kAdvertiseIntervalMin),
-                Timer::SecToMsec(kAdvertiseIntervalMax));
-        }
-        else
-        {
-            mRouterAdvertiseTimer.IndicateInconsistent();
-        }
+        mRouterAdvertiseTimer.Start(
+            Timer::SecToMsec(kAdvertiseIntervalMin),
+            Timer::SecToMsec(kAdvertiseIntervalMax));
     }
     else
     {
-        // TODO ...
+        mRouterAdvertiseTimer.IndicateInconsistent();
     }
 }
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -267,7 +267,7 @@ ThreadError MleRouter::BecomeLeader(void)
     mNetworkData.Reset();
 
     SuccessOrExit(error = SetStateLeader(GetRloc16(mRouterId)));
-    
+
     ResetAdvertiseInterval();
 
 exit:
@@ -445,7 +445,7 @@ bool MleRouter::HandleAdvertiseTimer(void)
 
 void MleRouter::ResetAdvertiseInterval(void)
 {
-    assert(GetDeviceState() == kDeviceStateRouter || 
+    assert(GetDeviceState() == kDeviceStateRouter ||
            GetDeviceState() == kDeviceStateLeader);
 
     if (!mRouterAdvertiseTimer.IsRunning())

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2988,9 +2988,7 @@ void MleRouter::HandleAddressSolicitResponse(Message &aMessage)
 
     // send link request
     SendLinkRequest(NULL);
-    mAdvertiseTimer.Start(
-        Timer::SecToMsec(kAdvertiseIntervalMin),
-        Timer::SecToMsec(kAdvertiseIntervalMax));
+    ResetAdvertiseInterval();
 
     // send child id responses
     for (int i = 0; i < mMaxChildrenAllowed; i++)

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -548,12 +548,14 @@ private:
     uint8_t AllocateRouterId(uint8_t aRouterId);
     bool InRouterIdMask(uint8_t aRouterId);
 
-    static bool HandleAdvertiseTimer(void *aContext);
+    static bool HandleRouterAdvertiseTimer(void *aContext);
+    static void HandleReedAdvertiseTimer(void *aContext);
     bool HandleAdvertiseTimer(void);
     static void HandleStateUpdateTimer(void *aContext);
     void HandleStateUpdateTimer(void);
 
-    TrickleTimer mAdvertiseTimer;
+    TrickleTimer mRouterAdvertiseTimer;
+    Timer mReedAdvertiseTimer;
     Timer mStateUpdateTimer;
 
     Ip6::UdpSocket mSocket;

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -548,14 +548,12 @@ private:
     uint8_t AllocateRouterId(uint8_t aRouterId);
     bool InRouterIdMask(uint8_t aRouterId);
 
-    static bool HandleRouterAdvertiseTimer(void *aContext);
-    static void HandleReedAdvertiseTimer(void *aContext);
+    static bool HandleAdvertiseTimer(void *aContext);
     bool HandleAdvertiseTimer(void);
     static void HandleStateUpdateTimer(void *aContext);
     void HandleStateUpdateTimer(void);
 
-    TrickleTimer mRouterAdvertiseTimer;
-    Timer mReedAdvertiseTimer;
+    TrickleTimer mAdvertiseTimer;
     Timer mStateUpdateTimer;
 
     Ip6::UdpSocket mSocket;

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -37,6 +37,7 @@
 #include <coap/coap_header.hpp>
 #include <coap/coap_server.hpp>
 #include <common/timer.hpp>
+#include <common/trickle_timer.hpp>
 #include <mac/mac_frame.hpp>
 #include <net/icmp6.hpp>
 #include <net/udp6.hpp>
@@ -500,7 +501,6 @@ private:
     ThreadError HandleNetworkDataUpdateRouter(void);
 
     ThreadError ProcessRouteTlv(const RouteTlv &aRoute);
-    ThreadError ResetAdvertiseInterval(void);
     ThreadError SendAddressSolicit(ThreadStatusTlv::Status aStatus);
     ThreadError SendAddressRelease(void);
     void SendAddressSolicitResponse(const Coap::Header &aRequest, uint8_t aRouterId,
@@ -547,12 +547,12 @@ private:
     uint8_t AllocateRouterId(uint8_t aRouterId);
     bool InRouterIdMask(uint8_t aRouterId);
 
-    static void HandleAdvertiseTimer(void *aContext);
-    void HandleAdvertiseTimer(void);
+    static bool HandleAdvertiseTimer(void *aContext);
+    bool HandleAdvertiseTimer(void);
     static void HandleStateUpdateTimer(void *aContext);
     void HandleStateUpdateTimer(void);
 
-    Timer mAdvertiseTimer;
+    TrickleTimer mAdvertiseTimer;
     Timer mStateUpdateTimer;
 
     Ip6::UdpSocket mSocket;
@@ -577,7 +577,6 @@ private:
 
     uint8_t mRouterId;
     uint8_t mPreviousRouterId;
-    uint32_t mAdvertiseInterval;
 
     Coap::Server &mCoapServer;
     uint8_t mCoapToken[2];

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -501,7 +501,7 @@ private:
     ThreadError HandleNetworkDataUpdateRouter(void);
 
     ThreadError ProcessRouteTlv(const RouteTlv &aRoute);
-    ThreadError ResetAdvertiseInterval(void);
+    void ResetAdvertiseInterval(void);
     ThreadError SendAddressSolicit(ThreadStatusTlv::Status aStatus);
     ThreadError SendAddressRelease(void);
     void SendAddressSolicitResponse(const Coap::Header &aRequest, uint8_t aRouterId,

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -501,6 +501,7 @@ private:
     ThreadError HandleNetworkDataUpdateRouter(void);
 
     ThreadError ProcessRouteTlv(const RouteTlv &aRoute);
+    ThreadError ResetAdvertiseInterval(void);
     ThreadError SendAddressSolicit(ThreadStatusTlv::Status aStatus);
     ThreadError SendAddressRelease(void);
     void SendAddressSolicitResponse(const Coap::Header &aRequest, uint8_t aRouterId,


### PR DESCRIPTION
This change implements a separate `TrickleTimer` class to be used by MleRouter for advertisements and for (future) MeshForwarding for MC packets.