### PR TITLE
Additional updates to `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,19 +1,44 @@
-# Treat everything that seems like a text file as a text file, with
-# whatever line endings are specified for this repository.
-* text=auto
+# Auto normalize all files which appear to be text files.
+*        text=auto
 
-# Treat files which are obviously binary as binary.
-*.gz -text
+# Auto normalize files which are explicitly text
+*.[ch]   text
+*.[ch]pp text
+*.txt    text
+*.md     text
+*.yml    text
+*.html   text
+*.py     text
 
-# Files that need to keep unix file endings
-bootstrap text eol=lf
-*.sh text eol=lf
-*.m4 text eol=lf
-configure.ac text eol=lf
-Makefile.am text eol=lf
-Makefile.in text eol=lf
+# Files which are explicitly binary
+*.gz     binary !eol
+*.xz     binary !eol
+*.bz2    binary !eol
+*.tar    binary !eol
+*.png    binary !eol
+*.jpg    binary !eol
+*.gif    binary !eol
 
-# Files that need to keep Windows file endings
-*.vcxproj text eol=crlf
-*.vcxproj.filters text eol=crlf
-*.sln text eol=crlf
+# Files normalized to always keep Unix line endings
+.default-version  eol=lf
+bootstrap*        eol=lf
+config.guess      eol=lf
+config.status     eol=lf
+configure         eol=lf
+libtool           eol=lf
+libtoolize        eol=lf
+autoreconf        eol=lf
+mkversion         eol=lf
+*.sh              eol=lf
+*-sh              eol=lf
+*.m4              eol=lf
+configure.ac      eol=lf
+Makefile.am       eol=lf
+Makefile.in       eol=lf
+Makefile          eol=lf
+
+# Files normalized to always keep Windows line endings
+*.vcxproj         eol=crlf
+*.vcxproj.filters eol=crlf
+*.sln             eol=crlf
+

--- a/third_party/.gitattributes
+++ b/third_party/.gitattributes
@@ -1,0 +1,4 @@
+# Disable automatic text file line-ending
+# normalization for third-party code.
+* !text
+


### PR DESCRIPTION
These new changes incorporate some fixes for troubles faced with building on Windows with the changes from #593. This commit should allow for seamless and transparent text file line ending normalization on both Unix and Windows platforms.