### PR TITLE
MPL: Fix Seed Set Entry update procedure

### DIFF
--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -76,10 +76,7 @@ ThreadError Mpl::ProcessOption(const Message &aMessage)
             entry = &mEntries[i];
             diff = static_cast<int8_t>(option.GetSequence() - entry->mSequence);
 
-            if (diff <= 0)
-            {
-                error = kThreadError_Drop;
-            }
+            VerifyOrExit(diff > 0, error = kThreadError_Drop);
 
             break;
         }


### PR DESCRIPTION
This pull request fixes issue #596, so that MPL module does not change seed's sequence number if MPL Data Message is discarded.