### PR TITLE
Send DTLS-Alert(close_notify) after receiving it from peer

### DIFF
--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -342,6 +342,11 @@ void Dtls::Process(void)
         }
         else
         {
+            if (rval == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY)
+            {
+                mbedtls_ssl_close_notify(&mSsl);
+            }
+
             mbedtls_ssl_session_reset(&mSsl);
             mbedtls_ssl_set_hs_ecjpake_password(&mSsl, mPsk, mPskLength);
             break;


### PR DESCRIPTION
Make it specification compliant, which requires a round trip to close joiner session. Resolves #619 

Along with #611  and #613, we have made Test 8.1.1 (DUT as commissioner) passed:

[Commissioner_8_1_1.zip](https://github.com/openthread/openthread/files/479535/Commissioner_8_1_1.zip)

