### PR TITLE
Refactor Python Node ping function

### DIFF
--- a/tests/scripts/thread-cert/Cert_5_1_02_ChildAddressTimeout.py
+++ b/tests/scripts/thread-cert/Cert_5_1_02_ChildAddressTimeout.py
@@ -96,13 +96,13 @@ class Cert_5_1_02_ChildAddressTimeout(unittest.TestCase):
         time.sleep(5)
         for addr in ed_addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[LEADER].ping(addr), False)
+                self.assertFalse(self.nodes[LEADER].ping(addr))
 
         self.nodes[SED].stop()
         time.sleep(5)
         for addr in sed_addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[LEADER].ping(addr), False)
+                self.assertFalse(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_1_02_ChildAddressTimeout.py
+++ b/tests/scripts/thread-cert/Cert_5_1_02_ChildAddressTimeout.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -97,21 +96,13 @@ class Cert_5_1_02_ChildAddressTimeout(unittest.TestCase):
         time.sleep(5)
         for addr in ed_addrs:
             if addr[0:4] != 'fe80':
-                try:
-                    self.nodes[LEADER].ping(addr)
-                    self.fail()
-                except pexpect.TIMEOUT:
-                    pass
+                self.assertEqual(self.nodes[LEADER].ping(addr), False)
 
         self.nodes[SED].stop()
         time.sleep(5)
         for addr in sed_addrs:
             if addr[0:4] != 'fe80':
-                try:
-                    self.nodes[LEADER].ping(addr)
-                    self.fail()
-                except pexpect.TIMEOUT:
-                    pass
+                self.assertEqual(self.nodes[LEADER].ping(addr), False)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_1_03_RouterAddressReallocation.py
+++ b/tests/scripts/thread-cert/Cert_5_1_03_RouterAddressReallocation.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_5_1_04_RouterAddressReallocation.py
+++ b/tests/scripts/thread-cert/Cert_5_1_04_RouterAddressReallocation.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_5_1_05_RouterAddressTimeout.py
+++ b/tests/scripts/thread-cert/Cert_5_1_05_RouterAddressTimeout.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_5_1_06_RemoveRouterId.py
+++ b/tests/scripts/thread-cert/Cert_5_1_06_RemoveRouterId.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -68,14 +67,14 @@ class Cert_5_1_06_RemoveRouterId(unittest.TestCase):
         rloc16 = self.nodes[ROUTER1].get_addr16()
 
         for addr in self.nodes[ROUTER1].get_addrs():
-            self.nodes[LEADER].ping(addr)
+            self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         self.nodes[LEADER].release_router_id(rloc16 >> 10)
         time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         for addr in self.nodes[ROUTER1].get_addrs():
-            self.nodes[LEADER].ping(addr)
+            self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_1_06_RemoveRouterId.py
+++ b/tests/scripts/thread-cert/Cert_5_1_06_RemoveRouterId.py
@@ -67,14 +67,14 @@ class Cert_5_1_06_RemoveRouterId(unittest.TestCase):
         rloc16 = self.nodes[ROUTER1].get_addr16()
 
         for addr in self.nodes[ROUTER1].get_addrs():
-            self.assertEqual(self.nodes[LEADER].ping(addr), True)
+            self.assertTrue(self.nodes[LEADER].ping(addr))
 
         self.nodes[LEADER].release_router_id(rloc16 >> 10)
         time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         for addr in self.nodes[ROUTER1].get_addrs():
-            self.assertEqual(self.nodes[LEADER].ping(addr), True)
+            self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
+++ b/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
@@ -98,7 +98,7 @@ class Cert_5_1_07_MaxChildCount(unittest.TestCase):
                         meshLocalEID = line
                         break
 
-                self.assertEqual(self.nodes[LEADER].ping(meshLocalEID, size=106), True)
+                self.assertTrue(self.nodes[LEADER].ping(meshLocalEID, size=106))
                 time.sleep(1)
 
         self.nodes[ED].start()

--- a/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
+++ b/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
@@ -98,7 +98,7 @@ class Cert_5_1_07_MaxChildCount(unittest.TestCase):
                         meshLocalEID = line
                         break
 
-                self.nodes[LEADER].ping(meshLocalEID, size=106)
+                self.assertEqual(self.nodes[LEADER].ping(meshLocalEID, size=106), True)
                 time.sleep(1)
 
         self.nodes[ED].start()

--- a/tests/scripts/thread-cert/Cert_5_1_08_RouterAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_5_1_08_RouterAttachConnectivity.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_5_1_09_REEDAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_5_1_09_REEDAttachConnectivity.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_5_1_10_RouterAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_5_1_10_RouterAttachLinkQuality.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_5_1_11_REEDAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_5_1_11_REEDAttachLinkQuality.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_5_1_12_NewRouterNeighborSync.py
+++ b/tests/scripts/thread-cert/Cert_5_1_12_NewRouterNeighborSync.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_5_2_01_BecomeActiveRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_2_01_BecomeActiveRouter.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_5_2_02_LeaderReject1Hop.py
+++ b/tests/scripts/thread-cert/Cert_5_2_02_LeaderReject1Hop.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_5_2_03_LeaderReject2Hops.py
+++ b/tests/scripts/thread-cert/Cert_5_2_03_LeaderReject2Hops.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_5_2_04_REEDUpgrade.py
+++ b/tests/scripts/thread-cert/Cert_5_2_04_REEDUpgrade.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -131,7 +130,7 @@ class Cert_5_2_5_AddressQuery(unittest.TestCase):
         addrs = self.nodes[REED].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[ED2].ping(addr)
+                self.assertEqual(self.nodes[ED2].ping(addr), True)
                 time.sleep(1)
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
@@ -130,7 +130,7 @@ class Cert_5_2_5_AddressQuery(unittest.TestCase):
         addrs = self.nodes[REED].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[ED2].ping(addr), True)
+                self.assertTrue(self.nodes[ED2].ping(addr))
                 time.sleep(1)
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_5_2_07_REEDSynchronization.py
+++ b/tests/scripts/thread-cert/Cert_5_2_07_REEDSynchronization.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_5_3_01_LinkLocal.py
+++ b/tests/scripts/thread-cert/Cert_5_3_01_LinkLocal.py
@@ -68,14 +68,14 @@ class Cert_5_3_1_LinkLocal(unittest.TestCase):
         addrs = self.nodes[ROUTER1].get_addrs()
         for addr in addrs:
             if addr[0:4] == 'fe80':
-                self.assertEqual(self.nodes[LEADER].ping(addr, size=256), True)
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr, size=256))
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
-        self.assertEqual(self.nodes[LEADER].ping('ff02::1', size=256), True)
-        self.assertEqual(self.nodes[LEADER].ping('ff02::1'), True)
+        self.assertTrue(self.nodes[LEADER].ping('ff02::1', size=256))
+        self.assertTrue(self.nodes[LEADER].ping('ff02::1'))
 
-        self.assertEqual(self.nodes[LEADER].ping('ff02::2', size=256), True)
-        self.assertEqual(self.nodes[LEADER].ping('ff02::2'), True)
+        self.assertTrue(self.nodes[LEADER].ping('ff02::2', size=256))
+        self.assertTrue(self.nodes[LEADER].ping('ff02::2'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_3_01_LinkLocal.py
+++ b/tests/scripts/thread-cert/Cert_5_3_01_LinkLocal.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -69,14 +68,14 @@ class Cert_5_3_1_LinkLocal(unittest.TestCase):
         addrs = self.nodes[ROUTER1].get_addrs()
         for addr in addrs:
             if addr[0:4] == 'fe80':
-                self.nodes[LEADER].ping(addr, size=256)
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr, size=256), True)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
-        self.nodes[LEADER].ping('ff02::1', size=256)
-        self.nodes[LEADER].ping('ff02::1')
+        self.assertEqual(self.nodes[LEADER].ping('ff02::1', size=256), True)
+        self.assertEqual(self.nodes[LEADER].ping('ff02::1'), True)
 
-        self.nodes[LEADER].ping('ff02::2', size=256)
-        self.nodes[LEADER].ping('ff02::2')
+        self.assertEqual(self.nodes[LEADER].ping('ff02::2', size=256), True)
+        self.assertEqual(self.nodes[LEADER].ping('ff02::2'), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_3_02_RealmLocal.py
+++ b/tests/scripts/thread-cert/Cert_5_3_02_RealmLocal.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -92,17 +91,17 @@ class Cert_5_3_2_RealmLocal(unittest.TestCase):
         addrs = self.nodes[ROUTER2].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[LEADER].ping(addr, size=256)
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr, size=256), True)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
-        self.nodes[LEADER].ping('ff03::1', size=256)
-        self.nodes[LEADER].ping('ff03::1')
+        self.assertEqual(self.nodes[LEADER].ping('ff03::1', size=256), True)
+        self.assertEqual(self.nodes[LEADER].ping('ff03::1'), True)
 
-        self.nodes[LEADER].ping('ff03::2', size=256)
-        self.nodes[LEADER].ping('ff03::2')
+        self.assertEqual(self.nodes[LEADER].ping('ff03::2', size=256), True)
+        self.assertEqual(self.nodes[LEADER].ping('ff03::2'), True)
 
-        self.nodes[LEADER].ping('ff33:0040:fdde:ad00:beef:0:0:1', size=256)
-        self.nodes[LEADER].ping('ff33:0040:fdde:ad00:beef:0:0:1')
+        self.assertEqual(self.nodes[LEADER].ping('ff33:0040:fdde:ad00:beef:0:0:1', size=256), True)
+        self.assertEqual(self.nodes[LEADER].ping('ff33:0040:fdde:ad00:beef:0:0:1'), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_3_02_RealmLocal.py
+++ b/tests/scripts/thread-cert/Cert_5_3_02_RealmLocal.py
@@ -91,17 +91,17 @@ class Cert_5_3_2_RealmLocal(unittest.TestCase):
         addrs = self.nodes[ROUTER2].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[LEADER].ping(addr, size=256), True)
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr, size=256))
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
-        self.assertEqual(self.nodes[LEADER].ping('ff03::1', size=256), True)
-        self.assertEqual(self.nodes[LEADER].ping('ff03::1'), True)
+        self.assertTrue(self.nodes[LEADER].ping('ff03::1', size=256))
+        self.assertTrue(self.nodes[LEADER].ping('ff03::1'))
 
-        self.assertEqual(self.nodes[LEADER].ping('ff03::2', size=256), True)
-        self.assertEqual(self.nodes[LEADER].ping('ff03::2'), True)
+        self.assertTrue(self.nodes[LEADER].ping('ff03::2', size=256))
+        self.assertTrue(self.nodes[LEADER].ping('ff03::2'))
 
-        self.assertEqual(self.nodes[LEADER].ping('ff33:0040:fdde:ad00:beef:0:0:1', size=256), True)
-        self.assertEqual(self.nodes[LEADER].ping('ff33:0040:fdde:ad00:beef:0:0:1'), True)
+        self.assertTrue(self.nodes[LEADER].ping('ff33:0040:fdde:ad00:beef:0:0:1', size=256))
+        self.assertTrue(self.nodes[LEADER].ping('ff33:0040:fdde:ad00:beef:0:0:1'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_3_03_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_03_AddressQuery.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -109,25 +108,25 @@ class Cert_5_3_3_AddressQuery(unittest.TestCase):
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[ED2].ping(addr)
+                self.assertEqual(self.nodes[ED2].ping(addr), True)
                 time.sleep(1)
 
         addrs = self.nodes[ED2].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
                 time.sleep(1)
 
         addrs = self.nodes[BR].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[ED2].ping(addr)
+                self.assertEqual(self.nodes[ED2].ping(addr), True)
                 time.sleep(1)
 
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[ED2].ping(addr)
+                self.assertEqual(self.nodes[ED2].ping(addr), True)
                 time.sleep(1)
 
         addrs = self.nodes[ROUTER3].get_addrs()
@@ -136,22 +135,14 @@ class Cert_5_3_3_AddressQuery(unittest.TestCase):
 
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                try:
-                    self.nodes[ED2].ping(addr)
-                    self.fail()
-                except pexpect.TIMEOUT:
-                    pass
+                self.assertEqual(self.nodes[ED2].ping(addr), False)
 
         addrs = self.nodes[ED2].get_addrs()
         self.nodes[ED2].stop()
         time.sleep(10)
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                try:
-                    self.nodes[BR].ping(addr)        
-                    self.fail()
-                except pexpect.TIMEOUT:
-                    pass
+                self.assertEqual(self.nodes[BR].ping(addr), False)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_3_03_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_03_AddressQuery.py
@@ -108,25 +108,25 @@ class Cert_5_3_3_AddressQuery(unittest.TestCase):
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[ED2].ping(addr), True)
+                self.assertTrue(self.nodes[ED2].ping(addr))
                 time.sleep(1)
 
         addrs = self.nodes[ED2].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
                 time.sleep(1)
 
         addrs = self.nodes[BR].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[ED2].ping(addr), True)
+                self.assertTrue(self.nodes[ED2].ping(addr))
                 time.sleep(1)
 
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[ED2].ping(addr), True)
+                self.assertTrue(self.nodes[ED2].ping(addr))
                 time.sleep(1)
 
         addrs = self.nodes[ROUTER3].get_addrs()
@@ -135,14 +135,14 @@ class Cert_5_3_3_AddressQuery(unittest.TestCase):
 
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[ED2].ping(addr), False)
+                self.assertFalse(self.nodes[ED2].ping(addr))
 
         addrs = self.nodes[ED2].get_addrs()
         self.nodes[ED2].stop()
         time.sleep(10)
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[BR].ping(addr), False)
+                self.assertFalse(self.nodes[BR].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_3_04_AddressMapCache.py
+++ b/tests/scripts/thread-cert/Cert_5_3_04_AddressMapCache.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -125,13 +124,13 @@ class Cert_5_3_4_AddressMapCache(unittest.TestCase):
             addrs = self.nodes[i].get_addrs()
             for addr in addrs:
                 if addr[0:4] != 'fe80':
-                    self.nodes[SED1].ping(addr)
+                    self.assertEqual(self.nodes[SED1].ping(addr), True)
 
         for i in range(4, 8):
             addrs = self.nodes[i].get_addrs()
             for addr in addrs:
                 if addr[0:4] != 'fe80':
-                    self.nodes[SED1].ping(addr)
+                    self.assertEqual(self.nodes[SED1].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_3_04_AddressMapCache.py
+++ b/tests/scripts/thread-cert/Cert_5_3_04_AddressMapCache.py
@@ -124,13 +124,13 @@ class Cert_5_3_4_AddressMapCache(unittest.TestCase):
             addrs = self.nodes[i].get_addrs()
             for addr in addrs:
                 if addr[0:4] != 'fe80':
-                    self.assertEqual(self.nodes[SED1].ping(addr), True)
+                    self.assertTrue(self.nodes[SED1].ping(addr))
 
         for i in range(4, 8):
             addrs = self.nodes[i].get_addrs()
             for addr in addrs:
                 if addr[0:4] != 'fe80':
-                    self.assertEqual(self.nodes[SED1].ping(addr), True)
+                    self.assertTrue(self.nodes[SED1].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_3_05_RoutingLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_5_3_05_RoutingLinkQuality.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -95,7 +94,7 @@ class Cert_5_3_5_RoutingLinkQuality(unittest.TestCase):
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         self.nodes[LEADER].add_whitelist(self.nodes[ROUTER1].get_addr64(), rssi=-95)
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64(), rssi=-95)
@@ -105,7 +104,7 @@ class Cert_5_3_5_RoutingLinkQuality(unittest.TestCase):
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         self.nodes[LEADER].add_whitelist(self.nodes[ROUTER1].get_addr64(), rssi=-85)
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64(), rssi=-85)
@@ -115,7 +114,7 @@ class Cert_5_3_5_RoutingLinkQuality(unittest.TestCase):
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         self.nodes[LEADER].add_whitelist(self.nodes[ROUTER1].get_addr64(), rssi=-100)
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64(), rssi=-100)
@@ -125,7 +124,7 @@ class Cert_5_3_5_RoutingLinkQuality(unittest.TestCase):
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_5_3_05_RoutingLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_5_3_05_RoutingLinkQuality.py
@@ -94,7 +94,7 @@ class Cert_5_3_5_RoutingLinkQuality(unittest.TestCase):
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         self.nodes[LEADER].add_whitelist(self.nodes[ROUTER1].get_addr64(), rssi=-95)
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64(), rssi=-95)
@@ -104,7 +104,7 @@ class Cert_5_3_5_RoutingLinkQuality(unittest.TestCase):
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         self.nodes[LEADER].add_whitelist(self.nodes[ROUTER1].get_addr64(), rssi=-85)
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64(), rssi=-85)
@@ -114,7 +114,7 @@ class Cert_5_3_5_RoutingLinkQuality(unittest.TestCase):
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         self.nodes[LEADER].add_whitelist(self.nodes[ROUTER1].get_addr64(), rssi=-100)
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64(), rssi=-100)
@@ -124,7 +124,7 @@ class Cert_5_3_5_RoutingLinkQuality(unittest.TestCase):
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_5_3_06_RouterIdMask.py
+++ b/tests/scripts/thread-cert/Cert_5_3_06_RouterIdMask.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_5_3_06b_RouterIdMask.py
+++ b/tests/scripts/thread-cert/Cert_5_3_06b_RouterIdMask.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
+++ b/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -117,7 +116,7 @@ class Cert_5_3_7_DuplicateAddress(unittest.TestCase):
         self.nodes[ED2].add_ipaddr('2001::1')
         time.sleep(3)
 
-        self.nodes[ED3].ping('2001::1')
+        self.assertEqual(self.nodes[ED3].ping('2001::1'), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
+++ b/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
@@ -116,7 +116,7 @@ class Cert_5_3_7_DuplicateAddress(unittest.TestCase):
         self.nodes[ED2].add_ipaddr('2001::1')
         time.sleep(3)
 
-        self.assertEqual(self.nodes[ED3].ping('2001::1'), True)
+        self.assertTrue(self.nodes[ED3].ping('2001::1'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_3_08_ChildAddressSet.py
+++ b/tests/scripts/thread-cert/Cert_5_3_08_ChildAddressSet.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -103,7 +102,7 @@ class Cert_5_3_8_ChildAddressSet(unittest.TestCase):
             addrs = self.nodes[i].get_addrs()
             for addr in addrs:
                 if addr[0:4] != 'fe80':
-                    self.nodes[LEADER].ping(addr)
+                    self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_3_08_ChildAddressSet.py
+++ b/tests/scripts/thread-cert/Cert_5_3_08_ChildAddressSet.py
@@ -102,7 +102,7 @@ class Cert_5_3_8_ChildAddressSet(unittest.TestCase):
             addrs = self.nodes[i].get_addrs()
             for addr in addrs:
                 if addr[0:4] != 'fe80':
-                    self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                    self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -108,17 +107,17 @@ class Cert_5_3_9_AddressQuery(unittest.TestCase):
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[SED2].ping(addr)
+                self.assertEqual(self.nodes[SED2].ping(addr), True)
 
         addrs = self.nodes[SED2].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[BR].ping(addr)
+                self.assertEqual(self.nodes[BR].ping(addr), True)
 
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[SED2].ping(addr)
+                self.assertEqual(self.nodes[SED2].ping(addr), True)
 
         self.nodes[ROUTER3].stop()
         time.sleep(300)
@@ -126,11 +125,7 @@ class Cert_5_3_9_AddressQuery(unittest.TestCase):
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                try:
-                    self.nodes[SED2].ping(addr)
-                    self.fail()
-                except pexpect.TIMEOUT:
-                    pass
+                self.assertEqual(self.nodes[SED2].ping(addr), False)
 
         self.nodes[SED2].stop()
         time.sleep(10)
@@ -138,11 +133,7 @@ class Cert_5_3_9_AddressQuery(unittest.TestCase):
         addrs = self.nodes[SED2].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                try:
-                    self.nodes[BR].ping(addr)
-                    self.fail()
-                except pexpect.TIMEOUT:
-                    pass
+                self.assertEqual(self.nodes[BR].ping(addr), False)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
@@ -107,17 +107,17 @@ class Cert_5_3_9_AddressQuery(unittest.TestCase):
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[SED2].ping(addr), True)
+                self.assertTrue(self.nodes[SED2].ping(addr))
 
         addrs = self.nodes[SED2].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[BR].ping(addr), True)
+                self.assertTrue(self.nodes[BR].ping(addr))
 
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[SED2].ping(addr), True)
+                self.assertTrue(self.nodes[SED2].ping(addr))
 
         self.nodes[ROUTER3].stop()
         time.sleep(300)
@@ -125,7 +125,7 @@ class Cert_5_3_9_AddressQuery(unittest.TestCase):
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[SED2].ping(addr), False)
+                self.assertFalse(self.nodes[SED2].ping(addr))
 
         self.nodes[SED2].stop()
         time.sleep(10)
@@ -133,7 +133,7 @@ class Cert_5_3_9_AddressQuery(unittest.TestCase):
         addrs = self.nodes[SED2].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[BR].ping(addr), False)
+                self.assertFalse(self.nodes[BR].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_5_02_LeaderReboot.py
+++ b/tests/scripts/thread-cert/Cert_5_5_02_LeaderReboot.py
@@ -86,7 +86,7 @@ class Cert_5_5_2_LeaderReboot(unittest.TestCase):
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.assertEqual(self.nodes[ROUTER].ping(addr), True)
+            self.assertTrue(self.nodes[ROUTER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_5_02_LeaderReboot.py
+++ b/tests/scripts/thread-cert/Cert_5_5_02_LeaderReboot.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -87,7 +86,7 @@ class Cert_5_5_2_LeaderReboot(unittest.TestCase):
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.nodes[ROUTER].ping(addr)
+            self.assertEqual(self.nodes[ROUTER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_5_03_SplitMergeChildren.py
+++ b/tests/scripts/thread-cert/Cert_5_5_03_SplitMergeChildren.py
@@ -127,7 +127,7 @@ class Cert_5_5_3_SplitMergeChildren(unittest.TestCase):
         addrs = self.nodes[ED1].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[ROUTER2].ping(addr), True)
+                self.assertTrue(self.nodes[ROUTER2].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_5_03_SplitMergeChildren.py
+++ b/tests/scripts/thread-cert/Cert_5_5_03_SplitMergeChildren.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -128,7 +127,7 @@ class Cert_5_5_3_SplitMergeChildren(unittest.TestCase):
         addrs = self.nodes[ED1].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[ROUTER2].ping(addr)
+                self.assertEqual(self.nodes[ROUTER2].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_5_04_SplitMergeRouters.py
+++ b/tests/scripts/thread-cert/Cert_5_5_04_SplitMergeRouters.py
@@ -128,7 +128,7 @@ class Cert_5_5_4_SplitMergeRouters(unittest.TestCase):
         addrs = self.nodes[ED1].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[ROUTER2].ping(addr), True)
+                self.assertTrue(self.nodes[ROUTER2].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_5_04_SplitMergeRouters.py
+++ b/tests/scripts/thread-cert/Cert_5_5_04_SplitMergeRouters.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -129,7 +128,7 @@ class Cert_5_5_4_SplitMergeRouters(unittest.TestCase):
         addrs = self.nodes[ED1].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[ROUTER2].ping(addr)
+                self.assertEqual(self.nodes[ROUTER2].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_5_05_SplitMergeREED.py
+++ b/tests/scripts/thread-cert/Cert_5_5_05_SplitMergeREED.py
@@ -110,7 +110,7 @@ class Cert_5_5_5_SplitMergeREED(unittest.TestCase):
         addrs = self.nodes[LEADER1].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[ROUTER1].ping(addr), True)
+                self.assertTrue(self.nodes[ROUTER1].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_5_05_SplitMergeREED.py
+++ b/tests/scripts/thread-cert/Cert_5_5_05_SplitMergeREED.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -111,7 +110,7 @@ class Cert_5_5_5_SplitMergeREED(unittest.TestCase):
         addrs = self.nodes[LEADER1].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[ROUTER1].ping(addr)
+                self.assertEqual(self.nodes[ROUTER1].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_5_06_SplitWeight.py
+++ b/tests/scripts/thread-cert/Cert_5_5_06_SplitWeight.py
@@ -89,7 +89,7 @@ class Cert_5_5_6_SplitWeight(unittest.TestCase):
 
         addrs = self.nodes[ROUTER2].get_addrs()
         for addr in addrs:
-            self.assertEqual(self.nodes[ROUTER1].ping(addr), True)
+            self.assertTrue(self.nodes[ROUTER1].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_5_06_SplitWeight.py
+++ b/tests/scripts/thread-cert/Cert_5_5_06_SplitWeight.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -90,7 +89,7 @@ class Cert_5_5_6_SplitWeight(unittest.TestCase):
 
         addrs = self.nodes[ROUTER2].get_addrs()
         for addr in addrs:
-            self.nodes[ROUTER1].ping(addr)
+            self.assertEqual(self.nodes[ROUTER1].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_5_07_SplitMergeThreeWay.py
+++ b/tests/scripts/thread-cert/Cert_5_5_07_SplitMergeThreeWay.py
@@ -96,17 +96,17 @@ class Cert_5_5_7_SplitMergeThreeWay(unittest.TestCase):
         addrs = self.nodes[LEADER1].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[ROUTER1].ping(addr), True)
+                self.assertTrue(self.nodes[ROUTER1].ping(addr))
 
         addrs = self.nodes[ROUTER2].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[ROUTER1].ping(addr), True)
+                self.assertTrue(self.nodes[ROUTER1].ping(addr))
 
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[ROUTER1].ping(addr), True)
+                self.assertTrue(self.nodes[ROUTER1].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_5_07_SplitMergeThreeWay.py
+++ b/tests/scripts/thread-cert/Cert_5_5_07_SplitMergeThreeWay.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -97,17 +96,17 @@ class Cert_5_5_7_SplitMergeThreeWay(unittest.TestCase):
         addrs = self.nodes[LEADER1].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[ROUTER1].ping(addr)
+                self.assertEqual(self.nodes[ROUTER1].ping(addr), True)
 
         addrs = self.nodes[ROUTER2].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[ROUTER1].ping(addr)
+                self.assertEqual(self.nodes[ROUTER1].ping(addr), True)
 
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[ROUTER1].ping(addr)
+                self.assertEqual(self.nodes[ROUTER1].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_5_08_SplitRoutersLostLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_5_08_SplitRoutersLostLeader.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -104,7 +103,7 @@ class Cert_5_5_8_SplitRoutersLostLeader(unittest.TestCase):
         addrs = self.nodes[ED1].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[LEADER1].ping(addr)
+                self.assertEqual(self.nodes[LEADER1].ping(addr), True)
 
         self.nodes[ROUTER3].stop()
         time.sleep(130)
@@ -115,7 +114,7 @@ class Cert_5_5_8_SplitRoutersLostLeader(unittest.TestCase):
         addrs = self.nodes[ED1].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[LEADER1].ping(addr)
+                self.assertEqual(self.nodes[LEADER1].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_5_08_SplitRoutersLostLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_5_08_SplitRoutersLostLeader.py
@@ -103,7 +103,7 @@ class Cert_5_5_8_SplitRoutersLostLeader(unittest.TestCase):
         addrs = self.nodes[ED1].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[LEADER1].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER1].ping(addr))
 
         self.nodes[ROUTER3].stop()
         time.sleep(130)
@@ -114,7 +114,7 @@ class Cert_5_5_8_SplitRoutersLostLeader(unittest.TestCase):
         addrs = self.nodes[ED1].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[LEADER1].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER1].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -98,14 +97,14 @@ class Cert_5_6_1_NetworkDataLeaderAsBr(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py
@@ -97,14 +97,14 @@ class Cert_5_6_1_NetworkDataLeaderAsBr(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -98,14 +97,14 @@ class Cert_5_6_2_NetworkDataRouterAsBr(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
@@ -97,14 +97,14 @@ class Cert_5_6_2_NetworkDataRouterAsBr(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py
@@ -99,14 +99,14 @@ class Cert_5_6_3_NetworkDataRegisterAfterAttachLeader(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -100,14 +99,14 @@ class Cert_5_6_3_NetworkDataRegisterAfterAttachLeader(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
@@ -99,14 +99,14 @@ class Cert_5_6_4_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -100,14 +99,14 @@ class Cert_5_6_4_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
@@ -99,14 +99,14 @@ class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         self.nodes[ROUTER].add_prefix('2003::/64', 'pacs')
         self.nodes[ROUTER].register_netdata()
@@ -119,7 +119,7 @@ class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
         self.assertTrue(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
@@ -127,7 +127,7 @@ class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
         self.assertTrue(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -100,14 +99,14 @@ class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         self.nodes[ROUTER].add_prefix('2003::/64', 'pacs')
         self.nodes[ROUTER].register_netdata()
@@ -120,7 +119,7 @@ class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
         self.assertTrue(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
@@ -128,7 +127,7 @@ class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
         self.assertTrue(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
+++ b/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
@@ -99,14 +99,14 @@ class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         self.nodes[ROUTER].add_prefix('2003::/64', 'pacs')
         self.nodes[ROUTER].register_netdata()
@@ -119,7 +119,7 @@ class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
         self.assertTrue(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
@@ -127,7 +127,7 @@ class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
         self.assertTrue(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         self.nodes[ROUTER].remove_prefix('2003::/64')
         self.nodes[ROUTER].register_netdata()
@@ -139,7 +139,7 @@ class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
         self.assertFalse(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
@@ -147,7 +147,7 @@ class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
         self.assertFalse(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         self.nodes[ROUTER].stop()
 

--- a/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
+++ b/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -100,14 +99,14 @@ class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         self.nodes[ROUTER].add_prefix('2003::/64', 'pacs')
         self.nodes[ROUTER].register_netdata()
@@ -120,7 +119,7 @@ class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
         self.assertTrue(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
@@ -128,7 +127,7 @@ class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
         self.assertTrue(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         self.nodes[ROUTER].remove_prefix('2003::/64')
         self.nodes[ROUTER].register_netdata()
@@ -140,7 +139,7 @@ class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
         self.assertFalse(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
@@ -148,7 +147,7 @@ class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
         self.assertFalse(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         self.nodes[ROUTER].stop()
 

--- a/tests/scripts/thread-cert/Cert_5_6_07_NetworkDataRequestREED.py
+++ b/tests/scripts/thread-cert/Cert_5_6_07_NetworkDataRequestREED.py
@@ -94,7 +94,7 @@ class Cert_5_6_7_NetworkDataRequestREED(unittest.TestCase):
         self.assertTrue(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_6_07_NetworkDataRequestREED.py
+++ b/tests/scripts/thread-cert/Cert_5_6_07_NetworkDataRequestREED.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -95,7 +94,7 @@ class Cert_5_6_7_NetworkDataRequestREED(unittest.TestCase):
         self.assertTrue(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_6_08_ContextManagement.py
+++ b/tests/scripts/thread-cert/Cert_5_6_08_ContextManagement.py
@@ -85,7 +85,7 @@ class Cert_5_6_8_ContextManagement(unittest.TestCase):
         self.assertTrue(any('2001' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.assertEqual(self.nodes[ED].ping(addr), True)
+                self.assertTrue(self.nodes[ED].ping(addr))
 
         self.nodes[ROUTER].remove_prefix('2001::/64')
         self.nodes[ROUTER].register_netdata()
@@ -95,7 +95,7 @@ class Cert_5_6_8_ContextManagement(unittest.TestCase):
         self.assertFalse(any('2001' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.assertEqual(self.nodes[ED].ping(addr), True)
+                self.assertTrue(self.nodes[ED].ping(addr))
 
         self.nodes[ROUTER].add_prefix('2002::/64', 'paros')
         self.nodes[ROUTER].register_netdata()
@@ -106,7 +106,7 @@ class Cert_5_6_8_ContextManagement(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.assertEqual(self.nodes[ED].ping(addr), True)
+                self.assertTrue(self.nodes[ED].ping(addr))
 
         time.sleep(5)
         self.nodes[ROUTER].add_prefix('2003::/64', 'paros')
@@ -119,7 +119,7 @@ class Cert_5_6_8_ContextManagement(unittest.TestCase):
         self.assertTrue(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.assertEqual(self.nodes[ED].ping(addr), True)
+                self.assertTrue(self.nodes[ED].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_6_08_ContextManagement.py
+++ b/tests/scripts/thread-cert/Cert_5_6_08_ContextManagement.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -86,7 +85,7 @@ class Cert_5_6_8_ContextManagement(unittest.TestCase):
         self.assertTrue(any('2001' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.nodes[ED].ping(addr)
+                self.assertEqual(self.nodes[ED].ping(addr), True)
 
         self.nodes[ROUTER].remove_prefix('2001::/64')
         self.nodes[ROUTER].register_netdata()
@@ -96,7 +95,7 @@ class Cert_5_6_8_ContextManagement(unittest.TestCase):
         self.assertFalse(any('2001' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.nodes[ED].ping(addr)
+                self.assertEqual(self.nodes[ED].ping(addr), True)
 
         self.nodes[ROUTER].add_prefix('2002::/64', 'paros')
         self.nodes[ROUTER].register_netdata()
@@ -107,7 +106,7 @@ class Cert_5_6_8_ContextManagement(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.nodes[ED].ping(addr)
+                self.assertEqual(self.nodes[ED].ping(addr), True)
 
         time.sleep(5)
         self.nodes[ROUTER].add_prefix('2003::/64', 'paros')
@@ -120,7 +119,7 @@ class Cert_5_6_8_ContextManagement(unittest.TestCase):
         self.assertTrue(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:3] == '200':
-                self.nodes[ED].ping(addr)
+                self.assertEqual(self.nodes[ED].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
+++ b/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
@@ -109,23 +109,23 @@ class Cert_5_6_9_NetworkDataForwarding(unittest.TestCase):
         self.nodes[ROUTER2].register_netdata()
         time.sleep(10)
 
-        self.assertEqual(self.nodes[SED].ping('2002::1'), False)
+        self.assertFalse(self.nodes[SED].ping('2002::1'))
 
-        self.assertEqual(self.nodes[SED].ping('2007::1'), False)
+        self.assertFalse(self.nodes[SED].ping('2007::1'))
 
         self.nodes[ROUTER2].remove_prefix('2001::/64')
         self.nodes[ROUTER2].add_prefix('2001::/64', 'paros', 'high')
         self.nodes[ROUTER2].register_netdata()
         time.sleep(10)
 
-        self.assertEqual(self.nodes[SED].ping('2007::1'), False)
+        self.assertFalse(self.nodes[SED].ping('2007::1'))
 
         self.nodes[ROUTER2].remove_prefix('2001::/64')
         self.nodes[ROUTER2].add_prefix('2001::/64', 'paros', 'med')
         self.nodes[ROUTER2].register_netdata()
         time.sleep(10)
 
-        self.assertEqual(self.nodes[SED].ping('2007::1'), False)
+        self.assertFalse(self.nodes[SED].ping('2007::1'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
+++ b/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -110,35 +109,23 @@ class Cert_5_6_9_NetworkDataForwarding(unittest.TestCase):
         self.nodes[ROUTER2].register_netdata()
         time.sleep(10)
 
-        try:
-            self.nodes[SED].ping('2002::1')
-        except pexpect.TIMEOUT:
-            pass
+        self.assertEqual(self.nodes[SED].ping('2002::1'), False)
 
-        try:
-            self.nodes[SED].ping('2007::1')
-        except pexpect.TIMEOUT:
-            pass
+        self.assertEqual(self.nodes[SED].ping('2007::1'), False)
 
         self.nodes[ROUTER2].remove_prefix('2001::/64')
         self.nodes[ROUTER2].add_prefix('2001::/64', 'paros', 'high')
         self.nodes[ROUTER2].register_netdata()
         time.sleep(10)
 
-        try:
-            self.nodes[SED].ping('2007::1')
-        except pexpect.TIMEOUT:
-            pass
+        self.assertEqual(self.nodes[SED].ping('2007::1'), False)
 
         self.nodes[ROUTER2].remove_prefix('2001::/64')
         self.nodes[ROUTER2].add_prefix('2001::/64', 'paros', 'med')
         self.nodes[ROUTER2].register_netdata()
         time.sleep(10)
 
-        try:
-            self.nodes[SED].ping('2007::1')
-        except pexpect.TIMEOUT:
-            pass
+        self.assertEqual(self.nodes[SED].ping('2007::1'), False)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_8_01_KeySynchronization.py
+++ b/tests/scripts/thread-cert/Cert_5_8_01_KeySynchronization.py
@@ -68,7 +68,7 @@ class Cert_5_8_1_KeySynchronization(unittest.TestCase):
         addrs = self.nodes[LEADER].get_addrs()
         for addr in addrs:
             if 'ff:fe00' not in addr:
-                self.assertEqual(self.nodes[ED].ping(addr), True)
+                self.assertTrue(self.nodes[ED].ping(addr))
 
         key_sequence = self.nodes[ED].get_key_sequence()
         self.nodes[ED].set_key_sequence(key_sequence + 10)
@@ -76,7 +76,7 @@ class Cert_5_8_1_KeySynchronization(unittest.TestCase):
         addrs = self.nodes[LEADER].get_addrs()
         for addr in addrs:
             if 'ff:fe00' not in addr:
-                self.assertEqual(self.nodes[ED].ping(addr), False)
+                self.assertFalse(self.nodes[ED].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_8_01_KeySynchronization.py
+++ b/tests/scripts/thread-cert/Cert_5_8_01_KeySynchronization.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -69,7 +68,7 @@ class Cert_5_8_1_KeySynchronization(unittest.TestCase):
         addrs = self.nodes[LEADER].get_addrs()
         for addr in addrs:
             if 'ff:fe00' not in addr:
-                self.nodes[ED].ping(addr)
+                self.assertEqual(self.nodes[ED].ping(addr), True)
 
         key_sequence = self.nodes[ED].get_key_sequence()
         self.nodes[ED].set_key_sequence(key_sequence + 10)
@@ -77,10 +76,7 @@ class Cert_5_8_1_KeySynchronization(unittest.TestCase):
         addrs = self.nodes[LEADER].get_addrs()
         for addr in addrs:
             if 'ff:fe00' not in addr:
-                try:
-                    self.nodes[ED].ping(addr)
-                except pexpect.TIMEOUT:
-                    pass
+                self.assertEqual(self.nodes[ED].ping(addr), False)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_8_02_KeyIncrement.py
+++ b/tests/scripts/thread-cert/Cert_5_8_02_KeyIncrement.py
@@ -66,14 +66,14 @@ class Cert_5_8_2_KeyIncrement(unittest.TestCase):
 
         addrs = self.nodes[ROUTER].get_addrs()
         for addr in addrs:
-            self.nodes[LEADER].ping(addr)
+            self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         key_sequence = self.nodes[LEADER].get_key_sequence()
         self.nodes[LEADER].set_key_sequence(key_sequence + 1)
 
         addrs = self.nodes[ROUTER].get_addrs()
         for addr in addrs:
-            self.nodes[LEADER].ping(addr)
+            self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_8_02_KeyIncrement.py
+++ b/tests/scripts/thread-cert/Cert_5_8_02_KeyIncrement.py
@@ -66,14 +66,14 @@ class Cert_5_8_2_KeyIncrement(unittest.TestCase):
 
         addrs = self.nodes[ROUTER].get_addrs()
         for addr in addrs:
-            self.assertEqual(self.nodes[LEADER].ping(addr), True)
+            self.assertTrue(self.nodes[LEADER].ping(addr))
 
         key_sequence = self.nodes[LEADER].get_key_sequence()
         self.nodes[LEADER].set_key_sequence(key_sequence + 1)
 
         addrs = self.nodes[ROUTER].get_addrs()
         for addr in addrs:
-            self.assertEqual(self.nodes[LEADER].ping(addr), True)
+            self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_8_03_KeyIncrementRollOver.py
+++ b/tests/scripts/thread-cert/Cert_5_8_03_KeyIncrementRollOver.py
@@ -68,14 +68,14 @@ class Cert_5_8_3_KeyIncrementRollOver(unittest.TestCase):
 
         addrs = self.nodes[ROUTER].get_addrs()
         for addr in addrs:
-            self.nodes[LEADER].ping(addr)
+            self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         key_sequence = self.nodes[LEADER].get_key_sequence()
         self.nodes[LEADER].set_key_sequence(key_sequence + 1)
 
         addrs = self.nodes[ROUTER].get_addrs()
         for addr in addrs:
-            self.nodes[LEADER].ping(addr)
+            self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_8_03_KeyIncrementRollOver.py
+++ b/tests/scripts/thread-cert/Cert_5_8_03_KeyIncrementRollOver.py
@@ -68,14 +68,14 @@ class Cert_5_8_3_KeyIncrementRollOver(unittest.TestCase):
 
         addrs = self.nodes[ROUTER].get_addrs()
         for addr in addrs:
-            self.assertEqual(self.nodes[LEADER].ping(addr), True)
+            self.assertTrue(self.nodes[LEADER].ping(addr))
 
         key_sequence = self.nodes[LEADER].get_key_sequence()
         self.nodes[LEADER].set_key_sequence(key_sequence + 1)
 
         addrs = self.nodes[ROUTER].get_addrs()
         for addr in addrs:
-            self.assertEqual(self.nodes[LEADER].ping(addr), True)
+            self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -94,7 +93,7 @@ class Cert_6_1_3_RouterAttachConnectivity(unittest.TestCase):
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.nodes[ROUTER3].ping(addr)
+            self.assertEqual(self.nodes[ROUTER3].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
@@ -93,7 +93,7 @@ class Cert_6_1_3_RouterAttachConnectivity(unittest.TestCase):
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.assertEqual(self.nodes[ROUTER3].ping(addr), True)
+            self.assertTrue(self.nodes[ROUTER3].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_1_04_REEDAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_6_1_04_REEDAttachConnectivity.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_6_1_05_RouterAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_6_1_05_RouterAttachLinkQuality.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_6_1_06_REEDAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_6_1_06_REEDAttachLinkQuality.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_6_1_07_EDSynchronization.py
+++ b/tests/scripts/thread-cert/Cert_6_1_07_EDSynchronization.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 

--- a/tests/scripts/thread-cert/Cert_6_2_01_NewPartition.py
+++ b/tests/scripts/thread-cert/Cert_6_2_01_NewPartition.py
@@ -83,7 +83,7 @@ class Cert_6_2_1_NewPartition(unittest.TestCase):
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.nodes[ROUTER1].ping(addr)
+            self.assertEqual(self.nodes[ROUTER1].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_2_01_NewPartition.py
+++ b/tests/scripts/thread-cert/Cert_6_2_01_NewPartition.py
@@ -83,7 +83,7 @@ class Cert_6_2_1_NewPartition(unittest.TestCase):
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.assertEqual(self.nodes[ROUTER1].ping(addr), True)
+            self.assertTrue(self.nodes[ROUTER1].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_2_02_NewPartition.py
+++ b/tests/scripts/thread-cert/Cert_6_2_02_NewPartition.py
@@ -98,7 +98,7 @@ class Cert_6_2_2_NewPartition(unittest.TestCase):
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.assertEqual(self.nodes[ROUTER1].ping(addr), True)
+            self.assertTrue(self.nodes[ROUTER1].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_2_02_NewPartition.py
+++ b/tests/scripts/thread-cert/Cert_6_2_02_NewPartition.py
@@ -98,7 +98,7 @@ class Cert_6_2_2_NewPartition(unittest.TestCase):
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.nodes[ROUTER1].ping(addr)
+            self.assertEqual(self.nodes[ROUTER1].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_3_01_OrphanReattach.py
+++ b/tests/scripts/thread-cert/Cert_6_3_01_OrphanReattach.py
@@ -86,7 +86,7 @@ class Cert_6_3_1_OrphanReattach(unittest.TestCase):
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.nodes[LEADER].ping(addr)
+            self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_3_01_OrphanReattach.py
+++ b/tests/scripts/thread-cert/Cert_6_3_01_OrphanReattach.py
@@ -86,7 +86,7 @@ class Cert_6_3_1_OrphanReattach(unittest.TestCase):
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.assertEqual(self.nodes[LEADER].ping(addr), True)
+            self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_3_02_NetworkDataUpdate.py
+++ b/tests/scripts/thread-cert/Cert_6_3_02_NetworkDataUpdate.py
@@ -74,7 +74,7 @@ class Cert_5_6_2_NetworkDataUpdate(unittest.TestCase):
         self.assertTrue(any('2001' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         self.nodes[LEADER].remove_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ED].remove_whitelist(self.nodes[LEADER].get_addr64())
@@ -92,7 +92,7 @@ class Cert_5_6_2_NetworkDataUpdate(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_3_02_NetworkDataUpdate.py
+++ b/tests/scripts/thread-cert/Cert_6_3_02_NetworkDataUpdate.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -75,7 +74,7 @@ class Cert_5_6_2_NetworkDataUpdate(unittest.TestCase):
         self.assertTrue(any('2001' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         self.nodes[LEADER].remove_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ED].remove_whitelist(self.nodes[LEADER].get_addr64())
@@ -93,7 +92,7 @@ class Cert_5_6_2_NetworkDataUpdate(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_4_01_LinkLocal.py
+++ b/tests/scripts/thread-cert/Cert_6_4_01_LinkLocal.py
@@ -68,11 +68,11 @@ class Cert_6_4_1_LinkLocal(unittest.TestCase):
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
             if addr[0:4] == 'fe80':
-                self.assertEqual(self.nodes[LEADER].ping(addr, size=256), True)
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr, size=256))
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
-        self.assertEqual(self.nodes[LEADER].ping('ff02::1', size=256), True)
-        self.assertEqual(self.nodes[LEADER].ping('ff02::1'), True)
+        self.assertTrue(self.nodes[LEADER].ping('ff02::1', size=256))
+        self.assertTrue(self.nodes[LEADER].ping('ff02::1'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_4_01_LinkLocal.py
+++ b/tests/scripts/thread-cert/Cert_6_4_01_LinkLocal.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -69,11 +68,11 @@ class Cert_6_4_1_LinkLocal(unittest.TestCase):
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
             if addr[0:4] == 'fe80':
-                self.nodes[LEADER].ping(addr, size=256)
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr, size=256), True)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
-        self.nodes[LEADER].ping('ff02::1', size=256)
-        self.nodes[LEADER].ping('ff02::1')
+        self.assertEqual(self.nodes[LEADER].ping('ff02::1', size=256), True)
+        self.assertEqual(self.nodes[LEADER].ping('ff02::1'), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_4_02_RealmLocal.py
+++ b/tests/scripts/thread-cert/Cert_6_4_02_RealmLocal.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -80,14 +79,14 @@ class Cert_5_3_2_RealmLocal(unittest.TestCase):
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.nodes[LEADER].ping(addr, size=256)
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr, size=256), True)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
-        self.nodes[LEADER].ping('ff03::1', size=256)
-        self.nodes[LEADER].ping('ff03::1')
+        self.assertEqual(self.nodes[LEADER].ping('ff03::1', size=256), True)
+        self.assertEqual(self.nodes[LEADER].ping('ff03::1'), True)
 
-        self.nodes[LEADER].ping('ff33:0040:fdde:ad00:beef:0:0:1', size=256)
-        self.nodes[LEADER].ping('ff33:0040:fdde:ad00:beef:0:0:1')
+        self.assertEqual(self.nodes[LEADER].ping('ff33:0040:fdde:ad00:beef:0:0:1', size=256), True)
+        self.assertEqual(self.nodes[LEADER].ping('ff33:0040:fdde:ad00:beef:0:0:1'), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_4_02_RealmLocal.py
+++ b/tests/scripts/thread-cert/Cert_6_4_02_RealmLocal.py
@@ -79,14 +79,14 @@ class Cert_5_3_2_RealmLocal(unittest.TestCase):
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertEqual(self.nodes[LEADER].ping(addr, size=256), True)
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr, size=256))
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
-        self.assertEqual(self.nodes[LEADER].ping('ff03::1', size=256), True)
-        self.assertEqual(self.nodes[LEADER].ping('ff03::1'), True)
+        self.assertTrue(self.nodes[LEADER].ping('ff03::1', size=256))
+        self.assertTrue(self.nodes[LEADER].ping('ff03::1'))
 
-        self.assertEqual(self.nodes[LEADER].ping('ff33:0040:fdde:ad00:beef:0:0:1', size=256), True)
-        self.assertEqual(self.nodes[LEADER].ping('ff33:0040:fdde:ad00:beef:0:0:1'), True)
+        self.assertTrue(self.nodes[LEADER].ping('ff33:0040:fdde:ad00:beef:0:0:1', size=256))
+        self.assertTrue(self.nodes[LEADER].ping('ff33:0040:fdde:ad00:beef:0:0:1'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_5_01_ChildResetSynchronize.py
+++ b/tests/scripts/thread-cert/Cert_6_5_01_ChildResetSynchronize.py
@@ -83,7 +83,7 @@ class Cert_6_5_1_ChildResetSynchronize(unittest.TestCase):
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
             if addr[0:4] == 'fe80':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_5_01_ChildResetSynchronize.py
+++ b/tests/scripts/thread-cert/Cert_6_5_01_ChildResetSynchronize.py
@@ -83,7 +83,7 @@ class Cert_6_5_1_ChildResetSynchronize(unittest.TestCase):
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
             if addr[0:4] == 'fe80':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_5_02_ChildResetReattach.py
+++ b/tests/scripts/thread-cert/Cert_6_5_02_ChildResetReattach.py
@@ -81,7 +81,7 @@ class Cert_6_5_2_ChildResetReattach(unittest.TestCase):
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
             if addr[0:4] == 'fe80':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_5_02_ChildResetReattach.py
+++ b/tests/scripts/thread-cert/Cert_6_5_02_ChildResetReattach.py
@@ -81,7 +81,7 @@ class Cert_6_5_2_ChildResetReattach(unittest.TestCase):
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
             if addr[0:4] == 'fe80':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_6_01_KeyIncrement.py
+++ b/tests/scripts/thread-cert/Cert_6_6_01_KeyIncrement.py
@@ -66,14 +66,14 @@ class Cert_6_6_1_KeyIncrement(unittest.TestCase):
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.nodes[LEADER].ping(addr)
+            self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         key_sequence = self.nodes[LEADER].get_key_sequence()
         self.nodes[LEADER].set_key_sequence(key_sequence + 1)
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.nodes[LEADER].ping(addr)
+            self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_6_01_KeyIncrement.py
+++ b/tests/scripts/thread-cert/Cert_6_6_01_KeyIncrement.py
@@ -66,14 +66,14 @@ class Cert_6_6_1_KeyIncrement(unittest.TestCase):
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.assertEqual(self.nodes[LEADER].ping(addr), True)
+            self.assertTrue(self.nodes[LEADER].ping(addr))
 
         key_sequence = self.nodes[LEADER].get_key_sequence()
         self.nodes[LEADER].set_key_sequence(key_sequence + 1)
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.assertEqual(self.nodes[LEADER].ping(addr), True)
+            self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_6_02_KeyIncrementRollOver.py
+++ b/tests/scripts/thread-cert/Cert_6_6_02_KeyIncrementRollOver.py
@@ -68,14 +68,14 @@ class Cert_6_6_2_KeyIncrement1(unittest.TestCase):
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.assertEqual(self.nodes[LEADER].ping(addr), True)
+            self.assertTrue(self.nodes[LEADER].ping(addr))
 
         key_sequence = self.nodes[LEADER].get_key_sequence()
         self.nodes[LEADER].set_key_sequence(key_sequence + 1)
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.assertEqual(self.nodes[LEADER].ping(addr), True)
+            self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_6_02_KeyIncrementRollOver.py
+++ b/tests/scripts/thread-cert/Cert_6_6_02_KeyIncrementRollOver.py
@@ -68,14 +68,14 @@ class Cert_6_6_2_KeyIncrement1(unittest.TestCase):
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.nodes[LEADER].ping(addr)
+            self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         key_sequence = self.nodes[LEADER].get_key_sequence()
         self.nodes[LEADER].set_key_sequence(key_sequence + 1)
 
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
-            self.nodes[LEADER].ping(addr)
+            self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
@@ -97,14 +97,14 @@ class Cert_7_1_1_BorderRouterAsLeader(unittest.TestCase):
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         addrs = self.nodes[ED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -98,14 +97,14 @@ class Cert_7_1_1_BorderRouterAsLeader(unittest.TestCase):
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         addrs = self.nodes[ED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -98,14 +97,14 @@ class Cert_7_1_2_BorderRouterAsRouter(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         addrs = self.nodes[SED2].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
@@ -97,14 +97,14 @@ class Cert_7_1_2_BorderRouterAsRouter(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         addrs = self.nodes[SED2].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
@@ -98,14 +98,14 @@ class Cert_7_1_3_BorderRouterAsLeader(unittest.TestCase):
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         addrs = self.nodes[ED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -99,14 +98,14 @@ class Cert_7_1_3_BorderRouterAsLeader(unittest.TestCase):
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         addrs = self.nodes[ED1].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -99,14 +98,14 @@ class Cert_7_1_4_BorderRouterAsRouter(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         addrs = self.nodes[SED2].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
@@ -98,14 +98,14 @@ class Cert_7_1_4_BorderRouterAsRouter(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         addrs = self.nodes[SED2].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import pexpect
 import time
 import unittest
 
@@ -99,14 +98,14 @@ class Cert_7_1_5_BorderRouterAsRouter(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         addrs = self.nodes[SED2].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         self.nodes[ROUTER].add_prefix('2003::/64', 'paros')
         self.nodes[ROUTER].register_netdata()
@@ -118,7 +117,7 @@ class Cert_7_1_5_BorderRouterAsRouter(unittest.TestCase):
         self.assertTrue(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002' or addr[0:4] == '2003':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
         addrs = self.nodes[SED2].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
@@ -126,7 +125,7 @@ class Cert_7_1_5_BorderRouterAsRouter(unittest.TestCase):
         self.assertTrue(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002' or addr[0:4] == '2003':
-                self.nodes[LEADER].ping(addr)
+                self.assertEqual(self.nodes[LEADER].ping(addr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
@@ -98,14 +98,14 @@ class Cert_7_1_5_BorderRouterAsRouter(unittest.TestCase):
         self.assertTrue(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         addrs = self.nodes[SED2].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
         self.assertFalse(any('2002' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         self.nodes[ROUTER].add_prefix('2003::/64', 'paros')
         self.nodes[ROUTER].register_netdata()
@@ -117,7 +117,7 @@ class Cert_7_1_5_BorderRouterAsRouter(unittest.TestCase):
         self.assertTrue(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002' or addr[0:4] == '2003':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
         addrs = self.nodes[SED2].get_addrs()
         self.assertTrue(any('2001' in word for word in addrs))
@@ -125,7 +125,7 @@ class Cert_7_1_5_BorderRouterAsRouter(unittest.TestCase):
         self.assertTrue(any('2003' in word for word in addrs))
         for addr in addrs:
             if addr[0:4] == '2001' or addr[0:4] == '2002' or addr[0:4] == '2003':
-                self.assertEqual(self.nodes[LEADER].ping(addr), True)
+                self.assertTrue(self.nodes[LEADER].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
+++ b/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
@@ -92,7 +92,7 @@ class Cert_9_2_13_EnergyScan(unittest.TestCase):
             if ipaddr[0:4] != 'fe80':
                 break
 
-        self.assertEqual(self.nodes[COMMISSIONER].ping(ipaddr), True)
+        self.assertTrue(self.nodes[COMMISSIONER].ping(ipaddr))
         self.nodes[COMMISSIONER].energy_scan(0x50000, 0x02, 0x20, 0x3e8, ipaddr)
 
         ipaddrs = self.nodes[ED1].get_addrs()
@@ -100,12 +100,12 @@ class Cert_9_2_13_EnergyScan(unittest.TestCase):
             if ipaddr[0:4] != 'fe80':
                 break
 
-        self.assertEqual(self.nodes[COMMISSIONER].ping(ipaddr), True)
+        self.assertTrue(self.nodes[COMMISSIONER].ping(ipaddr))
         self.nodes[COMMISSIONER].energy_scan(0x50000, 0x02, 0x20, 0x3e8, ipaddr)
 
         self.nodes[COMMISSIONER].energy_scan(0x50000, 0x02, 0x20, 0x3e8, 'ff33:0040:fdde:ad00:beef:0:0:1')
 
-        self.assertEqual(self.nodes[COMMISSIONER].ping(ipaddr), True)
+        self.assertTrue(self.nodes[COMMISSIONER].ping(ipaddr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
+++ b/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
@@ -92,7 +92,7 @@ class Cert_9_2_13_EnergyScan(unittest.TestCase):
             if ipaddr[0:4] != 'fe80':
                 break
 
-        self.nodes[COMMISSIONER].ping(ipaddr)
+        self.assertEqual(self.nodes[COMMISSIONER].ping(ipaddr), True)
         self.nodes[COMMISSIONER].energy_scan(0x50000, 0x02, 0x20, 0x3e8, ipaddr)
 
         ipaddrs = self.nodes[ED1].get_addrs()
@@ -100,12 +100,12 @@ class Cert_9_2_13_EnergyScan(unittest.TestCase):
             if ipaddr[0:4] != 'fe80':
                 break
 
-        self.nodes[COMMISSIONER].ping(ipaddr)
+        self.assertEqual(self.nodes[COMMISSIONER].ping(ipaddr), True)
         self.nodes[COMMISSIONER].energy_scan(0x50000, 0x02, 0x20, 0x3e8, ipaddr)
 
         self.nodes[COMMISSIONER].energy_scan(0x50000, 0x02, 0x20, 0x3e8, 'ff33:0040:fdde:ad00:beef:0:0:1')
 
-        self.nodes[COMMISSIONER].ping(ipaddr)
+        self.assertEqual(self.nodes[COMMISSIONER].ping(ipaddr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_9_2_14_PanIdQuery.py
+++ b/tests/scripts/thread-cert/Cert_9_2_14_PanIdQuery.py
@@ -96,7 +96,7 @@ class Cert_9_2_14_PanIdQuery(unittest.TestCase):
 
         self.nodes[COMMISSIONER].panid_query(0xdead, 0xffffffff, 'ff33:0040:fdde:ad00:beef:0:0:1')
 
-        self.nodes[COMMISSIONER].ping(ipaddr)
+        self.assertEqual(self.nodes[COMMISSIONER].ping(ipaddr), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_9_2_14_PanIdQuery.py
+++ b/tests/scripts/thread-cert/Cert_9_2_14_PanIdQuery.py
@@ -96,7 +96,7 @@ class Cert_9_2_14_PanIdQuery(unittest.TestCase):
 
         self.nodes[COMMISSIONER].panid_query(0xdead, 0xffffffff, 'ff33:0040:fdde:ad00:beef:0:0:1')
 
-        self.assertEqual(self.nodes[COMMISSIONER].ping(ipaddr), True)
+        self.assertTrue(self.nodes[COMMISSIONER].ping(ipaddr))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -352,13 +352,19 @@ class Node:
             cmd += ' ' + str(size)
 
         self.send_command(cmd)
-        responders = {}
-        while len(responders) < num_responses:
-            i = self.pexpect.expect(['from (\S+):'])
-            if i == 0:
-                responders[self.pexpect.match.groups()[0]] = 1
-        self.pexpect.expect('\n')
-        return responders
+        
+        result = True
+        try:
+            responders = {}
+            while len(responders) < num_responses:
+                i = self.pexpect.expect(['from (\S+):'])
+                if i == 0:
+                    responders[self.pexpect.match.groups()[0]] = 1
+            self.pexpect.expect('\n')
+        except pexpect.TIMEOUT:
+            result = False
+
+        return result
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Refactor ping command to remove `pexpect` dependency on each cert test. `pexpect` isn't fully supported on Windows, so I have to provide my own implementations for the `Node` functions that don't rely on `pexpect`. So, I want the `Node` class to completely abstract the `pexpect` dependency away.