### PR TITLE
ncp: Add support for `PROP_STREAM_RAW`

### DIFF
--- a/include/platform/radio.h
+++ b/include/platform/radio.h
@@ -102,6 +102,7 @@ typedef struct RadioPacket
     int8_t  mPower;          ///< Transmit/receive power in dBm.
     uint8_t mLqi;            ///< Link Quality Indicator for received frames.
     bool    mSecurityValid;  ///< Security Enabled flag is set and frame passes security checks.
+    uint16_t mFcs;           ///< Final checksum (optional)
 } RadioPacket;
 
 /**

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -649,6 +649,11 @@ void Mac::HandleBeginTransmit(void)
         otLogDebgMac("ack timer start\n");
     }
 
+    if (mPcapCallback)
+    {
+        mPcapCallback(&sendFrame, mPcapCallbackContext);
+    }
+
 exit:
 
     if (error != kThreadError_None)

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -535,7 +535,7 @@ void NcpBase::HandleRawFrame(const RadioPacket *aFrame)
             SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
             SPINEL_CMD_PROP_VALUE_IS,
             SPINEL_PROP_STREAM_RAW,
-            aFrame->mLength
+            aFrame->mLength + 2 // +2 for FCS
         )
     );
 
@@ -545,6 +545,15 @@ void NcpBase::HandleRawFrame(const RadioPacket *aFrame)
         errorCode = OutboundFrameFeedData(
             aFrame->mPsdu,
             aFrame->mLength
+        )
+    );
+
+    // Append the FCS
+    SuccessOrExit(
+        errorCode = OutboundFrameFeedPacked(
+            "CC",
+            (aFrame->mFcs >> 0) & 0xFF,
+            (aFrame->mFcs >> 8) & 0xFF
         )
     );
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -548,14 +548,12 @@ void NcpBase::HandleRawFrame(const RadioPacket *aFrame)
         )
     );
 
-    // Append metadata (rssi, lqi, channel, etc)
+    // Append metadata (rssi, etc)
 
     SuccessOrExit(
         errorCode = OutboundFrameFeedPacked(
-            "cCC",
-            aFrame->mPower,
-            aFrame->mLqi,
-            aFrame->mChannel
+            "c",
+            aFrame->mPower
         )
     );
 

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -145,6 +145,13 @@ private:
     void HandleDatagramFromStack(Message &aMessage);
 
     /**
+     * Trampoline for HandleRawFrame().
+     */
+    static void HandleRawFrame(const RadioPacket *aFrame, void *aContext);
+
+    void HandleRawFrame(const RadioPacket *aFrame);
+
+    /**
      * Trampoline for HandleActiveScanResult().
      */
     static void HandleActiveScanResult_Jump(otActiveScanResult *result, void *aContext);
@@ -284,6 +291,7 @@ private:
     ThreadError GetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_MAC_15_4_LADDR(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_MAC_15_4_SADDR(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_MAC_RAW_STREAM_ENABLED(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_NET_IF_UP(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_NET_STACK_UP(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key_t key);
@@ -343,6 +351,8 @@ private:
                                                   uint16_t value_len);
     ThreadError SetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                   uint16_t value_len);
+    ThreadError SetPropertyHandler_MAC_RAW_STREAM_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                          uint16_t value_len);
     ThreadError SetPropertyHandler_NET_IF_UP(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                uint16_t value_len);
     ThreadError SetPropertyHandler_NET_STACK_UP(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
@@ -447,6 +457,7 @@ private:
 
     bool mAllowLocalNetworkDataChange;
     bool mRequireJoinExistingNetwork;
+    bool mIsRawStreamEnabled;
 
     uint32_t mFramingErrorCounter;             // Number of improperly formed received spinel frames.
     uint32_t mRxSpinelFrameCounter;            // Number of received (inbound) spinel frames.


### PR DESCRIPTION
This change allows the NCP to be a packet sniffer when used with host software that supports this feature.

See the section of the Spinel protocol document titled ["Sniffing Raw Packets"][1] for an example of how this property is intended to be used.

[1]: https://cdn.rawgit.com/openthread/openthread/654f953fdaf34e457bee61eb674908141d0a5f8e/doc/draft-spinel-protocol.html#rfc.appendix.F.10