### PR TITLE
Add Cert_5_3_10_AddressQuery.py to XFAIL list.

### DIFF
--- a/tests/scripts/Makefile.am
+++ b/tests/scripts/Makefile.am
@@ -236,6 +236,7 @@ TESTS                                                              = \
     $(NULL)
 
 XFAIL_NCP_TESTS                                                        = \
+        thread-cert/Cert_5_3_10_AddressQuery.py                          \
         thread-cert/Cert_5_6_06_NetworkDataExpiration.py                 \
         thread-cert/Cert_5_6_08_ContextManagement.py                     \
         thread-cert/Cert_9_2_13_EnergyScan.py                            \


### PR DESCRIPTION
Expect failure introduced with #641.