### PR TITLE
Run configure through scan-build and die on error.

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -43,8 +43,8 @@ set -x
 }
 
 [ $BUILD_TARGET != scan-build ] || {
-    ./configure --with-examples=posix --enable-cli
-    scan-build --status-bugs -v make
+    scan-build ./configure --with-examples=posix --enable-cli --enable-ncp || die
+    scan-build --status-bugs -analyze-headers -v make || die
 }
 
 [ $BUILD_TARGET != cc2538 ] || {

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -117,7 +117,7 @@ void TrickleTimer::StartNewInterval(void)
     mPhase = kPhaseTransmit;
 
     // Initialize t
-    if (I == 0)
+    if (I < 2)
     {
         // Immediate interval, just set t to 0
         t = 0;

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1362,7 +1362,7 @@ exit:
         if (message->GetOffset() >= message->GetLength())
         {
             mReassemblyList.Dequeue(*message);
-            error = HandleDatagram(*message, aMessageInfo);
+            HandleDatagram(*message, aMessageInfo);
         }
     }
     else if (message != NULL)
@@ -1438,7 +1438,7 @@ exit:
 
     if (error == kThreadError_None)
     {
-        error = HandleDatagram(*message, aMessageInfo);
+        HandleDatagram(*message, aMessageInfo);
     }
     else if (message != NULL)
     {

--- a/src/core/thread/meshcop_tlvs.hpp
+++ b/src/core/thread/meshcop_tlvs.hpp
@@ -1532,9 +1532,14 @@ public:
     ThreadError SetProvisioningUrl(const char *aProvisioningUrl) {
         ThreadError error = kThreadError_None;
         size_t len = aProvisioningUrl ? strnlen(aProvisioningUrl, kMaxLength + 1) : 0;
+
         SetLength(static_cast<uint8_t>(len));
         VerifyOrExit(len <= kMaxLength, error = kThreadError_InvalidArgs);
-        memcpy(mProvisioningUrl, aProvisioningUrl, len);
+
+        if (len > 0) {
+            memcpy(mProvisioningUrl, aProvisioningUrl, len);
+        }
+
 exit:
         return error;
     }

--- a/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
+++ b/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
@@ -1112,8 +1112,6 @@ static bool setup_int_gpio(const char* path)
         }
 
         close(setup_fd);
-
-        setup_fd = -1;
     }
 
     setup_fd = open(edge_path, O_WRONLY);
@@ -1523,7 +1521,7 @@ int main(int argc, char *argv[])
         timeout.tv_usec = (timeout_ms % MSEC_PER_SEC) * USEC_PER_MSEC;
 
         // Wait for something to happen.
-        i = select(max_fd + 1, &read_set, &write_set, &error_set, &timeout);
+        select(max_fd + 1, &read_set, &write_set, &error_set, &timeout);
 
         // Handle serial input.
         if (FD_ISSET(sHdlcInputFd, &read_set))


### PR DESCRIPTION
- Fix bugs reported by scan-build.
- Add --enable-ncp to configure.
- Add -analyze-headers to scan-build.