### PR TITLE
spinel-cli: Add timestamp to ping.

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -72,7 +72,6 @@ cd /tmp || die
     }
 
     [ $BUILD_TARGET != posix-ncp ] || {
-        pip install blessed || die
         pip install ipaddress || die
         pip install scapy || die
         pip install pyserial || die

--- a/tests/scripts/Makefile.am
+++ b/tests/scripts/Makefile.am
@@ -236,7 +236,6 @@ TESTS                                                              = \
     $(NULL)
 
 XFAIL_NCP_TESTS                                                        = \
-        thread-cert/Cert_5_3_10_AddressQuery.py                          \
         thread-cert/Cert_5_6_06_NetworkDataExpiration.py                 \
         thread-cert/Cert_5_6_08_ContextManagement.py                     \
         thread-cert/Cert_9_2_13_EnergyScan.py                            \

--- a/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
@@ -38,7 +38,7 @@ ROUTER2 = 3
 ROUTER3 = 4
 SED2 = 5
 
-class Cert_5_3_9_AddressQuery(unittest.TestCase):
+class Cert_5_3_10_AddressQuery(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,6):

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -86,9 +86,10 @@ class Node:
         cmd += ' %d' % nodeid
         print ("%s" % cmd)
 
-        self.pexpect = pexpect.spawn(cmd, timeout=2)
+        self.pexpect = pexpect.spawn(cmd, timeout=4)
         time.sleep(0.1)
         self.pexpect.expect('spinel-cli >')
+        self.debug(int(os.getenv('DEBUG', '0')))
  
     def __init_soc(self, nodeid):
         """ Initialize a System-on-a-chip node connected via UART. """


### PR DESCRIPTION
Now calculates real round-trip times for ping6 reply:

```
    12 bytes from fdde:ad00:beef::3388:cc1e:5e44:6150: icmp_seq=0 hlim=63 time=891ms
```

Increased pexpect timeout for ncp-sim to 4 sec to handle ping responses >2 sec.
Makes Cert_5_3_10_AddressQuery pass reliably, even on low memory Travis VMs.
Added initial stub for commissioner command.
Add env variable control of ncp-sim DEBUG output.