### PR TITLE
MPL: Seed-id field handling

### DIFF
--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -326,6 +326,7 @@ public:
     Routes mRoutes;
     Icmp mIcmp;
     Udp mUdp;
+    Mpl mMpl;
 
     MessagePool mMessagePool;
     TaskletScheduler mTaskletScheduler;
@@ -336,14 +337,13 @@ private:
     void HandleSendQueue(void);
 
     ThreadError ProcessReceiveCallback(const Message &aMessage, const MessageInfo &aMessageInfo, uint8_t aIpProto);
-    ThreadError HandleExtensionHeaders(Message &message, uint8_t &nextHeader, bool receive);
+    ThreadError HandleExtensionHeaders(Message &message, Header &header, uint8_t &nextHeader, bool receive);
     ThreadError HandleFragment(Message &message);
     ThreadError AddMplOption(Message &message, Header &header, IpProto nextHeader, uint16_t payloadLength);
-    ThreadError HandleOptions(Message &message);
+    ThreadError HandleOptions(Message &message, Header &header);
     ThreadError HandlePayload(Message &message, MessageInfo &messageInfo, uint8_t ipproto);
     ThreadError ForwardMessage(Message &message, MessageInfo &messageInfo, uint8_t ipproto);
 
-    Mpl mMpl;
     bool mForwardingEnabled;
 
     MessageQueue mSendQueue;

--- a/src/core/net/ip6_headers.hpp
+++ b/src/core/net/ip6_headers.hpp
@@ -388,6 +388,72 @@ private:
 } OT_TOOL_PACKED_END;
 
 /**
+ * This class implements IPv6 PadN Option generation and parsing.
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+class OptionPadN : public OptionHeader
+{
+public:
+    enum
+    {
+        kType = 0x01,      ///< PadN type
+        kData = 0x00,      ///< PadN specific data
+        kMaxLength = 0x05  ///< Maximum length of PadN option data
+    };
+
+    /**
+     * This method initializes the PadN header.
+     *
+     * @param[in]  aPadLength  The length of needed padding. Allowed value from
+     *                         range 2-7.
+     *
+     */
+    void Init(uint8_t aPadLength) {
+        OptionHeader::SetType(kType);
+        OptionHeader::SetLength(aPadLength - sizeof(OptionHeader));
+        memset(mPad, kData, aPadLength - sizeof(OptionHeader));
+    }
+
+    /**
+     * This method returns the total IPv6 Option Length value including option
+     * header.
+     *
+     * @returns The total IPv6 Option Length.
+     *
+     */
+    uint8_t GetTotalLength() const { return OptionHeader::GetLength() + sizeof(OptionHeader); }
+
+private:
+    uint8_t mPad[kMaxLength];
+} OT_TOOL_PACKED_END;
+
+/**
+ * This class implements IPv6 Pad1 Option generation and parsing. Pad1 does not
+ * followdefault option header structure.
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+class OptionPad1
+{
+public:
+    enum
+    {
+        kType = 0x00
+    };
+
+    /**
+     * This method initializes the Pad1 header.
+     *
+     */
+    void Init() { mType = kType; }
+
+private:
+    uint8_t mType;
+} OT_TOOL_PACKED_END;
+
+
+/**
  * This class implements IPv6 Fragment Header generation and parsing.
  *
  */

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -63,6 +63,7 @@ public:
     enum
     {
         kType = 0x6d,    /* 01 1 01101 */
+        kMinLength = 2
     };
 
     /**
@@ -72,7 +73,17 @@ public:
     void Init() {
         OptionHeader::SetType(kType);
         OptionHeader::SetLength(sizeof(*this) - sizeof(OptionHeader));
+        mControl = 0;
     }
+
+    /**
+     * This method returns the total MPL Option length value including option
+     * header.
+     *
+     * @returns The total IPv6 Option Length.
+     *
+     */
+    uint8_t GetTotalLength() const { return OptionHeader::GetLength() + sizeof(OptionHeader); }
 
     /**
      * MPL Seed lengths.
@@ -156,7 +167,7 @@ private:
     enum
     {
         kSeedLengthMask = 3 << 6,
-        kMaxFlag = 1 << 5,
+        kMaxFlag = 1 << 5
     };
     uint8_t  mControl;
     uint8_t  mSequence;
@@ -181,22 +192,46 @@ public:
     /**
      * This method initializes the MPL option.
      *
-     * @param[in]  aOption  A reference to the MPL header to initialize.
-     * @param[in]  aSeed    The MPL Seed value to use.
+     * @param[in]  aOption   A reference to the MPL header to initialize.
+     * @param[in]  aAddress  A reference to the IPv6 Source Address.
      *
      */
-    void InitOption(OptionMpl &aOption, uint16_t aSeed);
+    void InitOption(OptionMpl &aOption, const Address &aAddress);
 
     /**
      * This method processes an MPL option.
      *
      * @param[in]  aMessage  A reference to the message.
+     * @param[in]  aAddress  A reference to the IPv6 Source Address.
      *
      * @retval kThreadError_None  Successfully processed the MPL option.
      * @retval kThreadError_Drop  The MPL message is a duplicate and should be dropped.
      *
      */
-    ThreadError ProcessOption(const Message &aMessage);
+    ThreadError ProcessOption(const Message &aMessage, const Address &aAddress);
+
+    /**
+     * This method returns the MPL Seed value.
+     *
+     * @returns The MPL Seed value.
+     *
+     */
+    uint16_t GetSeed() const { return mSeed; }
+
+    /**
+     * This method sets the MPL Seed value.
+     *
+     * @param[in]  aSeed  The MPL Seed value.
+     */
+    void SetSeed(uint16_t aSeed) { mSeed = aSeed; }
+
+    /**
+     * This method sets IPv6 matching address, that allows to elide seed-id.
+     *
+     * @param[in] aAddress The reference to IPv6 matching address.
+     */
+    void SetMatchingAddress(const Address &aAddress) { mMatchingAddress = &aAddress; }
+
 
 private:
     enum
@@ -210,6 +245,8 @@ private:
 
     Timer mTimer;
     uint8_t mSequence;
+    uint16_t mSeed;
+    const Address *mMatchingAddress;
 
     struct MplEntry
     {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -131,6 +131,9 @@ Mle::Mle(ThreadNetif &aThreadNetif) :
     mMeshLocal16.mPreferredLifetime = 0xffffffff;
     mMeshLocal16.mValidLifetime = 0xffffffff;
 
+    // Store RLOC address reference in MPL module.
+    mNetif.GetIp6().mMpl.SetMatchingAddress(mMeshLocal16.GetAddress());
+
     // link-local all thread nodes
     mLinkLocalAllThreadNodes.GetAddress().mFields.m16[0] = HostSwap16(0xff32);
     mLinkLocalAllThreadNodes.GetAddress().mFields.m16[6] = HostSwap16(0x0000);
@@ -522,6 +525,7 @@ ThreadError Mle::SetRloc16(uint16_t aRloc16)
     }
 
     mMac.SetShortAddress(aRloc16);
+    mNetif.GetIp6().mMpl.SetSeed(aRloc16);
 
     return kThreadError_None;
 }


### PR DESCRIPTION
This PR fixes issue #599.

As stated in the issue page, other stacks may be not compilant with this mandatory change. In this case some #define may be introduced for TX path.

Below example of MPL Echo Request and Response:
 - seed-id is being elided (MPL option has 4 and not 6 bytes)
 - extra PadN option is compressed by 6Lo - saving 2 extra bytes in the frame
 - 6Lo decompressor automatically adds PadN option and keeps proper alignment requirements.

![wireshark](https://cloud.githubusercontent.com/assets/5144764/18742025/71afc3aa-80b2-11e6-87d6-93c5ed49cc6c.png)

Additionally bug in ip6.cpp:278 has been detected and fixed, if option Pad1 is applied to the Extension Header. Pad1 option does not follow normal option header structure thus there is need to increment offset only by 1 byte.