### PR TITLE
spinel-cli: Add ipaddr removal to prefix change handler.

### DIFF
--- a/tests/scripts/Makefile.am
+++ b/tests/scripts/Makefile.am
@@ -236,8 +236,6 @@ TESTS                                                              = \
     $(NULL)
 
 XFAIL_NCP_TESTS                                                        = \
-        thread-cert/Cert_5_6_06_NetworkDataExpiration.py                 \
-        thread-cert/Cert_5_6_08_ContextManagement.py                     \
         thread-cert/Cert_9_2_13_EnergyScan.py                            \
         thread-cert/Cert_9_2_14_PanIdQuery.py                            \
         $(NULL)


### PR DESCRIPTION
Fixes Cert_5_6_06 and Cert_5_6_08.  Fixes #517.
Collapse fcs16 into Hdlc class.
Add and correct subcommand completion handlers.
Move prefix handler to separate worker thread and task queue.
Channelize blocking spinel property change handlers to allow parallel
reuse across multiple threads.