### PR TITLE
Enhance MeshCoP::DataManager::HandleSet

### DIFF
--- a/src/core/thread/meshcop_dataset.hpp
+++ b/src/core/thread/meshcop_dataset.hpp
@@ -46,7 +46,8 @@ class Dataset
 public:
     enum
     {
-        kMaxSize = 256,  ///< Maximum size of MeshCoP Dataset (bytes)
+        kMaxSize = 256,      ///< Maximum size of MeshCoP Dataset (bytes)
+        kMaxValueSize = 16,  /// < Maximum size of each Dataset TLV value (bytes)
     };
 
     /**

--- a/src/core/thread/meshcop_dataset_manager.cpp
+++ b/src/core/thread/meshcop_dataset_manager.cpp
@@ -247,7 +247,6 @@ void DatasetManager::HandleSet(Coap::Header &aHeader, Message &aMessage, const I
     uint16_t offset = aMessage.GetOffset();
     Tlv::Type type;
     StateTlv::State state = StateTlv::kAccept;
-    Dataset local = mLocal;
 
     VerifyOrExit(mMle.GetDeviceState() == Mle::kDeviceStateLeader, state = StateTlv::kReject);
 
@@ -265,9 +264,12 @@ void DatasetManager::HandleSet(Coap::Header &aHeader, Message &aMessage, const I
             aMessage.Read(offset + sizeof(Tlv), sizeof(timestamp), &timestamp);
         }
 
-        // verify the request does not include fields that affect connectivity
-        if (tlvType == Tlv::kChannel || tlvType == Tlv::kMeshLocalPrefix ||
-            tlvType == Tlv::kPanId || tlvType == Tlv::kNetworkMasterKey)
+        // verify the request only includes dataset tlvs that do not affect connectivity
+        if (tlvType != Tlv::kActiveTimestamp && tlvType != Tlv::kPendingTimestamp &&
+            tlvType != Tlv::kChannelMask && tlvType != Tlv::kExtendedPanId &&
+            tlvType != Tlv::kNetworkName && tlvType != Tlv::kPSKc &&
+            tlvType != Tlv::kSecurityPolicy && tlvType != Tlv::kDelayTimer &&
+            tlvType != Tlv::kCommissionerSessionId)
         {
             ExitNow(state = StateTlv::kReject);
         }
@@ -300,68 +302,6 @@ void DatasetManager::HandleSet(Coap::Header &aHeader, Message &aMessage, const I
             }
         }
 
-        if (tlvType == Tlv::kActiveTimestamp || tlvType == Tlv::kPendingTimestamp)
-        {
-            OT_TOOL_PACKED_BEGIN
-            struct
-            {
-                Tlv tlv;
-                Timestamp timestamp;
-            } OT_TOOL_PACKED_END timestampTlv;
-
-            timestampTlv.tlv.SetType(tlvType);
-            timestampTlv.tlv.SetLength(sizeof(Timestamp));
-            aMessage.Read(offset + sizeof(Tlv), sizeof(timestampTlv.timestamp), &timestampTlv.timestamp);
-            local.Set(timestampTlv.tlv);
-        }
-        else if (tlvType == Tlv::kChannelMask)
-        {
-            OT_TOOL_PACKED_BEGIN
-            struct
-            {
-                MeshCoP::ChannelMaskTlv tlv;
-                MeshCoP::ChannelMaskEntry entry;
-                uint8_t mask[sizeof(otChannelMaskPage0)];
-            } OT_TOOL_PACKED_END channelMaskTlv;
-
-            channelMaskTlv.tlv.Init();
-            channelMaskTlv.tlv.SetLength(sizeof(MeshCoP::ChannelMaskEntry) + sizeof(otChannelMaskPage0));
-            aMessage.Read(offset + sizeof(Tlv), sizeof(MeshCoP::ChannelMaskEntry) + sizeof(otChannelMaskPage0),
-                          &channelMaskTlv.entry);
-            local.Set(channelMaskTlv.tlv);
-        }
-        else if (tlvType == Tlv::kExtendedPanId)
-        {
-            MeshCoP::ExtendedPanIdTlv extPanIdTlv;
-            aMessage.Read(offset, sizeof(extPanIdTlv), &extPanIdTlv);
-            local.Set(extPanIdTlv);
-        }
-        else if (tlvType == Tlv::kNetworkName)
-        {
-            MeshCoP::NetworkNameTlv networkNameTlv;
-            aMessage.Read(offset, sizeof(Tlv), &networkNameTlv);
-            aMessage.Read(offset + sizeof(Tlv), networkNameTlv.GetLength(), networkNameTlv.GetValue());
-            local.Set(networkNameTlv);
-        }
-        else if (tlvType == Tlv::kPSKc)
-        {
-            MeshCoP::PSKcTlv pskcTlv;
-            aMessage.Read(offset, sizeof(pskcTlv), &pskcTlv);
-            local.Set(pskcTlv);
-        }
-        else if (tlvType == Tlv::kSecurityPolicy)
-        {
-            MeshCoP::SecurityPolicyTlv securityPolicyTlv;
-            aMessage.Read(offset, sizeof(securityPolicyTlv), &securityPolicyTlv);
-            local.Set(securityPolicyTlv);
-        }
-        else if (tlvType == Tlv::kDelayTimer)
-        {
-            MeshCoP::DelayTimerTlv delayTimerTlv;
-            aMessage.Read(offset, sizeof(delayTimerTlv), &delayTimerTlv);
-            local.Set(delayTimerTlv);
-        }
-
         offset += sizeof(tlv) + tlv.GetLength();
     }
 
@@ -369,7 +309,24 @@ void DatasetManager::HandleSet(Coap::Header &aHeader, Message &aMessage, const I
     VerifyOrExit(offset == aMessage.GetLength() && (mLocal.GetTimestamp() == NULL ||
                                                     mLocal.GetTimestamp()->Compare(timestamp) > 0), state = StateTlv::kReject);
 
-    mLocal = local;
+    // update dataset
+    offset = aMessage.GetOffset();
+
+    while (offset < aMessage.GetLength())
+    {
+        OT_TOOL_PACKED_BEGIN
+        struct
+        {
+            Tlv tlv;
+            uint8_t value[16];
+        } OT_TOOL_PACKED_END data;
+
+        aMessage.Read(offset, sizeof(Tlv), &data.tlv);
+        aMessage.Read(offset + sizeof(Tlv), data.tlv.GetLength(), data.value);
+        mLocal.Set(data.tlv);
+        offset += sizeof(Tlv) + data.tlv.GetLength();
+    }
+
     mNetwork = mLocal;
     mNetworkDataLeader.IncrementVersion();
     mNetworkDataLeader.IncrementStableVersion();

--- a/src/core/thread/meshcop_dataset_manager.cpp
+++ b/src/core/thread/meshcop_dataset_manager.cpp
@@ -264,12 +264,9 @@ void DatasetManager::HandleSet(Coap::Header &aHeader, Message &aMessage, const I
             aMessage.Read(offset + sizeof(Tlv), sizeof(timestamp), &timestamp);
         }
 
-        // verify the request only includes dataset tlvs that do not affect connectivity
-        if (tlvType != Tlv::kActiveTimestamp && tlvType != Tlv::kPendingTimestamp &&
-            tlvType != Tlv::kChannelMask && tlvType != Tlv::kExtendedPanId &&
-            tlvType != Tlv::kNetworkName && tlvType != Tlv::kPSKc &&
-            tlvType != Tlv::kSecurityPolicy && tlvType != Tlv::kDelayTimer &&
-            tlvType != Tlv::kCommissionerSessionId)
+        // verify not include tlvs that affect connectivity
+        if (tlvType == Tlv::kChannel || tlvType == Tlv::kMeshLocalPrefix ||
+            tlvType == Tlv::kPanId || tlvType == Tlv::kNetworkMasterKey)
         {
             ExitNow(state = StateTlv::kReject);
         }

--- a/src/core/thread/meshcop_dataset_manager.cpp
+++ b/src/core/thread/meshcop_dataset_manager.cpp
@@ -264,7 +264,7 @@ void DatasetManager::HandleSet(Coap::Header &aHeader, Message &aMessage, const I
             aMessage.Read(offset + sizeof(Tlv), sizeof(timestamp), &timestamp);
         }
 
-        // verify not include tlvs that affect connectivity
+        // verify the request does not include fields that affect connectivity
         if (tlvType == Tlv::kChannel || tlvType == Tlv::kMeshLocalPrefix ||
             tlvType == Tlv::kPanId || tlvType == Tlv::kNetworkMasterKey)
         {


### PR DESCRIPTION
MGMT_ACTIVE_SET.req and MGMT_PENDING_SET.req always includes parts of Operational Dataset. MGMT_ACTIVE_SET.req can not affect connectivity.
Then we can not simply copy message data to operational dataset buffer. Some useful fields would be erased.

This is need by passing 9.2.4.