### PR TITLE
Send specific DTLS alert for the failure caused by incorrect PSKd

### DIFF
--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -354,6 +354,15 @@ void Dtls::Process(void)
             case MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE:
                 break;
 
+            case MBEDTLS_ERR_SSL_INVALID_MAC:
+                if (mSsl.state != MBEDTLS_SSL_HANDSHAKE_OVER)
+                {
+                    mbedtls_ssl_send_alert_message(&mSsl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
+                                                   MBEDTLS_SSL_ALERT_MSG_BAD_RECORD_MAC);
+                }
+
+                break;
+
             default:
                 if (mSsl.state != MBEDTLS_SSL_HANDSHAKE_OVER)
                 {


### PR DESCRIPTION
To pass Certification test 8.1.2 and 8.2.2.