### PR TITLE
Only reset valid neighbor router if not heard for kMaxNeighborAge

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1704,7 +1704,7 @@ void MleRouter::HandleStateUpdateTimer(void)
     // update router state
     for (uint8_t i = 0; i <= kMaxRouterId; i++)
     {
-        if (mRouters[i].mState != Neighbor::kStateInvalid)
+        if (mRouters[i].mState == Neighbor::kStateValid)
         {
             if ((Timer::GetNow() - mRouters[i].mLastHeard) >= Timer::SecToMsec(kMaxNeighborAge))
             {


### PR DESCRIPTION
For the neighbor one device could not finish link synchronization (asymmetrical links, `mState` might be `Neighbor::kStateLinkRequest`),  it might be still routable via other interim routers, the router information (especially mNextHop) should be kept.

@jwhui , please have a review.