### PR TITLE
correct va_list usage

### DIFF
--- a/include/cli/cli-uart.h
+++ b/include/cli/cli-uart.h
@@ -35,6 +35,7 @@
 #ifndef CLI_UART_H_
 #define CLI_UART_H_
 
+#include <stdarg.h>
 #include <openthread-types.h>
 #include <platform/logging.h>
 
@@ -57,10 +58,10 @@ void otCliUartInit(otInstance *aInstance);
  * @param[in]  aLogLevel   The log level.
  * @param[in]  aLogRegion  The log region.
  * @param[in]  aFormat     A pointer to the format string.
- * @param[in]  ...         Arguments for the format specification.
+ * @param[in]  aAp         Arguments pointer for the format specification.
  *
  */
-void otCliLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...);
+void otCliLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, va_list aAp);
 #endif
 
 #ifdef __cplusplus

--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -179,6 +179,15 @@ int Uart::OutputFormat(const char *fmt, ...)
     return Output(buf, static_cast<uint16_t>(strlen(buf)));
 }
 
+int Uart::OutputFormatV(const char *aFmt, va_list aAp)
+{
+    char buf[kMaxLineLength];
+
+    vsnprintf(buf, sizeof(buf), aFmt, aAp);
+
+    return Output(buf, static_cast<uint16_t>(strlen(buf)));
+}
+
 void Uart::Send(void)
 {
     VerifyOrExit(mSendLength == 0, ;);
@@ -219,7 +228,7 @@ void Uart::SendDoneTask(void)
 #ifdef __cplusplus
 extern "C" {
 #endif
-void otCliLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
+void otCliLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, va_list aAp)
 {
     if (NULL == Uart::sUartServer)
     {
@@ -298,10 +307,7 @@ void otCliLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat,
         return;
     }
 
-    va_list args;
-    va_start(args, aFormat);
-    Uart::sUartServer->OutputFormat(aFormat, args);
-    va_end(args);
+    Uart::sUartServer->OutputFormatV(aFormat, aAp);
 }
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/cli/cli_uart.hpp
+++ b/src/cli/cli_uart.hpp
@@ -78,6 +78,17 @@ public:
      */
     int OutputFormat(const char *fmt, ...);
 
+    /**
+     * This method delivers formatted output to the client.
+     *
+     * @param[in]  aFmt  A pointer to the format string.
+     * @param[in]  aAp   A variable list of arguments for format.
+     *
+     * @returns The number of bytes placed in the output queue.
+     *
+     */
+    int OutputFormatV(const char *aFmt, va_list aAp);
+
     void ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength);
     void SendDoneTask(void);
 

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -263,11 +263,12 @@ void NcpUart::HandleError(ThreadError aError, uint8_t *aBuf, uint16_t aBufLength
 #ifdef __cplusplus
 extern "C" {
 #endif
-void otCliLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
+void otCliLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, va_list aAp)
 {
     (void)aLogLevel;
     (void)aLogRegion;
     (void)aFormat;
+    (void)aAp;
 }
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
This fixes the incorrect va_list usage, which will cause the logging feature cannot handle logging arguments except the format string itself.