### PR TITLE
support enabling features on cc2538 without modifying Makefile

### DIFF
--- a/examples/Makefile-cc2538
+++ b/examples/Makefile-cc2538
@@ -49,6 +49,18 @@ configure_OPTIONS               = \
     --with-platform-info=CC2538   \
     $(NULL)
 
+ifeq ($(CLI_LOGGING),1)
+configure_OPTIONS              += --enable-cli-logging
+endif
+
+ifeq ($(COMMISSIONER),1)
+configure_OPTIONS              += --enable-commissioner
+endif
+
+ifeq ($(JOINER),1)
+configure_OPTIONS              += --enable-joiner
+endif
+
 COMMONCFLAGS                   := \
     -fdata-sections               \
     -ffunction-sections           \

--- a/examples/Makefile-posix
+++ b/examples/Makefile-posix
@@ -103,7 +103,7 @@ endif
 ifeq ($(DEBUG),1)
 configure_OPTIONS              += --enable-debug --enable-optimization=no
 else
-configure_OPTIONS              += 
+configure_OPTIONS              +=
 endif
 
 ifndef BuildJobs


### PR DESCRIPTION
This eases the work to build firmwares automatically.