### PR TITLE
Enable logging feature for certification test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -574,6 +574,36 @@ AM_CONDITIONAL([OPENTHREAD_ENABLE_CLI_LOGGING], [test "${enable_cli_logging}" = 
 AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_CLI_LOGGING],[${OPENTHREAD_ENABLE_CLI_LOGGING}],[Define to 1 if you want to enable cli logging])
 
 #
+# Log for certification test
+#
+
+AC_ARG_ENABLE(cert_log,
+    [AS_HELP_STRING([--enable-cert-log],[Enable certification log support @<:@default=no@:>@.])],
+    [
+        case "${enableval}" in
+
+        no|yes)
+            enable_cert_log=${enableval}
+            ;;
+
+        *)
+            AC_MSG_ERROR([Invalid value ${enable_cert_log} for --enable-cert-log])
+            ;;
+        esac
+    ],
+    [enable_cert_log=no])
+
+if test "$enable_cert_log" = "yes"; then
+    OPENTHREAD_ENABLE_CERT_LOG=1
+else
+    OPENTHREAD_ENABLE_CERT_LOG=0
+fi
+
+AC_SUBST(OPENTHREAD_ENABLE_CERT_LOG)
+AM_CONDITIONAL([OPENTHREAD_ENABLE_CERT_LOG], [test "${enable_cert_log}" = "yes"])
+AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_CERT_LOG],[${OPENTHREAD_ENABLE_CERT_LOG}],[Define to 1 if you want to enable log for certification test])
+
+#
 # Examples
 #
 
@@ -827,6 +857,7 @@ AC_MSG_NOTICE([
   OpenThread DTLS support                   : ${enable_dtls}
   OpenThread Diagnostics support            : ${enable_diag}
   OpenThread Cli logging support            : ${enable_cli_logging}
+  OpenThread Certification log support      : ${enable_cert_log}
   OpenThread examples                       : ${OPENTHREAD_EXAMPLES}
   OpenThread platform information           : ${PLATFORM_INFO}
 

--- a/examples/Makefile-cc2538
+++ b/examples/Makefile-cc2538
@@ -53,6 +53,10 @@ ifeq ($(CLI_LOGGING),1)
 configure_OPTIONS              += --enable-cli-logging
 endif
 
+ifeq ($(CERT_LOG),1)
+configure_OPTIONS              += --enable-cert-log
+endif
+
 ifeq ($(COMMISSIONER),1)
 configure_OPTIONS              += --enable-commissioner
 endif

--- a/src/core/common/logging.cpp
+++ b/src/core/common/logging.cpp
@@ -103,7 +103,7 @@ static void DumpLine(otLogLevel aLogLevel, otLogRegion aLogRegion, const void *a
         }
     }
 
-    otPlatLog(aLogLevel, aLogRegion, "%s\n", buf);
+    otPlatLog(aLogLevel, aLogRegion, "%s\r\n", buf);
 }
 
 void otDump(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aId, const void *aBuf, const size_t aLength)
@@ -113,7 +113,7 @@ void otDump(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aId, const
     char buf[80];
     char *cur = buf;
 
-    otPlatLog(aLogLevel, aLogRegion, "\n");
+    otPlatLog(aLogLevel, aLogRegion, "\r\n");
 
     for (size_t i = 0; i < (width - idlen) / 2 - 5; i++)
     {
@@ -121,7 +121,7 @@ void otDump(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aId, const
         cur += strlen(cur);
     }
 
-    snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), "[%s len=%03zu]", aId, aLength);
+    snprintf(cur, sizeof(buf) - static_cast<size_t>(cur - buf), "[%s len=%03u]", aId, static_cast<uint16_t>(aLength));
     cur += strlen(cur);
 
     for (size_t i = 0; i < (width - idlen) / 2 - 4; i++)
@@ -130,7 +130,7 @@ void otDump(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aId, const
         cur += strlen(cur);
     }
 
-    otPlatLog(aLogLevel, aLogRegion, "%s\n", buf);
+    otPlatLog(aLogLevel, aLogRegion, "%s\r\n", buf);
 
     for (size_t i = 0; i < aLength; i += 16)
     {
@@ -145,7 +145,7 @@ void otDump(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aId, const
         cur += strlen(cur);
     }
 
-    otPlatLog(aLogLevel, aLogRegion, "%s\n", buf);
+    otPlatLog(aLogLevel, aLogRegion, "%s\r\n", buf);
 }
 
 #ifdef __cplusplus

--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -1073,6 +1073,37 @@ extern "C" {
 #endif
 
 /**
+ * @def otLogCert
+ *
+ * This method generates a log with level none for the certification test.
+ *
+ * @param[in]  aFormat  A pointer to the format string.
+ * @param[in]  ...      Arguments for the format specification.
+ *
+ */
+#if OPENTHREAD_ENABLE_CERT_LOG
+#define otLogCertMeshCoP(aFormat, ...) otPlatLog(kLogLevelNone, kLogRegionMeshCoP, aFormat, ## __VA_ARGS__)
+#else
+#define otLogCertMeshCoP(aFormat, ...)
+#endif
+
+/**
+ * @def otDumpCert
+ *
+ * This method generates a memory dump with log level none for the certification test.
+ *
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
+ *
+ */
+#if OPENTHREAD_ENABLE_CERT_LOG
+#define otDumpCertMeshCoP(aId, aBuf, aLength) otDump(kLogLevelNone, kLogRegionMeshCoP, aId, aBuf, aLength)
+#else
+#define otDumpCertMeshCoP(aId, aBuf, aLength)
+#endif
+
+/**
  * This method dumps bytes to the log in a human-readable fashion.
  *
  * @param[in]  aLevel   The log level.

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -631,6 +631,8 @@ void Commissioner::ReceiveJoinerFinalize(uint8_t *buf, uint16_t length)
         }
     }
 
+    otDumpCertMeshCoP("[THCI] direction=recv | type=JOIN_FIN.req |", buf + header.GetLength(), length - header.GetLength());
+
     SendJoinFinalizeResponse(header, state);
 
 exit:
@@ -667,6 +669,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Header &aRequestHeader, 
     mSendKek = false;
 
     otLogInfoMeshCoP("sent joiner finalize response\r\n");
+    otLogCertMeshCoP("[THCI] direction=send | type=JOIN_FIN.rsp\r\n");
 }
 
 }  // namespace MeshCoP

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -249,6 +249,8 @@ void Joiner::SendJoinerFinalize(void)
     mNetif.GetDtls().Send(buf, static_cast<uint16_t>(cur - buf));
 
     otLogInfoMeshCoP("Sent joiner finalize\r\n");
+    otDumpCertMeshCoP("[THCI] direction=send | type=JOIN_FIN.req |", buf + header.GetLength(),
+                      cur - buf - header.GetLength());
 }
 
 void Joiner::ReceiveJoinerFinalizeResponse(uint8_t *buf, uint16_t length)
@@ -271,6 +273,7 @@ void Joiner::ReceiveJoinerFinalizeResponse(uint8_t *buf, uint16_t length)
     VerifyOrExit(state.IsValid(), ;);
 
     otLogInfoMeshCoP("received joiner finalize response %d\r\n", static_cast<uint8_t>(state.GetState()));
+    otLogCertMeshCoP("[THCI] direction=recv | type=JOIN_FIN.rsp\r\n");
 
     Close();
 
@@ -303,6 +306,7 @@ void Joiner::HandleJoinerEntrust(Coap::Header &aHeader, Message &aMessage, const
                  aHeader.GetCode() == Coap::Header::kCodePost, error = kThreadError_Drop);
 
     otLogInfoMeshCoP("Received joiner entrust\r\n");
+    otLogCertMeshCoP("[THCI] direction=recv | type=JOIN_ENT.ntf\r\n");
 
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kNetworkMasterKey, sizeof(masterKey), masterKey));
     VerifyOrExit(masterKey.IsValid(), error = kThreadError_Parse);

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -31,6 +31,12 @@
  *   This file implements the Joiner Router role.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <assert.h>
 #include <stdio.h>
 
@@ -408,6 +414,7 @@ ThreadError JoinerRouter::SendJoinerEntrust(const Ip6::MessageInfo &aMessageInfo
     SuccessOrExit(error = mSocket.SendTo(*message, messageInfo));
 
     otLogInfoMeshCoP("Sent joiner entrust length = %d\r\n", message->GetLength());
+    otLogCertMeshCoP("[THCI] direction=send | msg_type=JOIN_ENT.ntf\r\n");
 
 exit:
 


### PR DESCRIPTION
Resolves #590.

This helps to pass certification test 8.1.6 Joiner, and truly pass 7 commissioning tests which passed based on the workaround.