### PR TITLE
Remove extra white space at end of line and typo fixes

### DIFF
--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -93,7 +93,7 @@ void TrickleTimer::IndicateConsistent(void)
 
 void TrickleTimer::IndicateInconsistent(void)
 {
-    // Only relavent if we aren't already at 'I' == 'Imin'
+    // Only relevant if we aren't already at 'I' == 'Imin'
     if (IsRunning() && I != Imin)
     {
         // Reset I to Imin
@@ -161,7 +161,7 @@ void TrickleTimer::HandleTimerFired(void)
     // We have just reached time 't'
     case kPhaseTransmit:
     {
-        // Are we not using reduncancy or is the counter still less than it?
+        // Are we not using redundancy or is the counter still less than it?
 #ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
         if (k == 0 || c < k)
 #endif

--- a/src/core/common/trickle_timer.hpp
+++ b/src/core/common/trickle_timer.hpp
@@ -79,7 +79,7 @@ public:
     /**
      * This constructor creates a trickle timer instance.
      *
-     * @param[in]  aScheduler               A refrence to the timer scheduler.
+     * @param[in]  aScheduler               A reference to the timer scheduler.
      * @param[in]  aRedundancyConstant      The redundancy constant for the timer, k.
      * @param[in]  aTransmitHandler         A pointer to a function that is called when transmission should occur.
      * @param[in]  aIntervalExpiredHandler  An optional pointer to a function that is called when the interval expires.

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -80,7 +80,7 @@ public:
     /**
      * This method returns the Commissioner Session ID.
      *
-     * @retuns The Commissioner Session ID.
+     * @returns The Commissioner Session ID.
      *
      */
     uint16_t GetSessionId(void) const;

--- a/tools/harness-thci/ARM.py
+++ b/tools/harness-thci/ARM.py
@@ -47,16 +47,16 @@ from Queue import Queue
 class ARM(IThci):
     firmware = 'Sep 9 2016 14:57:36'# keep the consistency with ARM firmware style
     UIStatusMsg = ''
-    networkDataRequirement = ''     # indicate Thread devicde requests full or stable network data
+    networkDataRequirement = ''     # indicate Thread device requests full or stable network data
     isPowerDown = False             # indicate if Thread device experiences a power down event
     isWhiteListEnabled = False      # indicate if Thread device enables white list filter
     isBlackListEnabled = False      # indicate if Thread device enables black list filter
 
     #def __init__(self, SerialPort=COMPortName, EUI=MAC_Address):
     def __init__(self, **kwargs):
-        """initialize the serial port and default netowrk parameters
+        """initialize the serial port and default network parameters
         Args:
-            **kwargs: Arbitrary keyword aruments
+            **kwargs: Arbitrary keyword arguments
                       Includes 'EUI' and 'SerialPort'
         """
         try:
@@ -126,7 +126,7 @@ class ARM(IThci):
             addressType: the specific type of IPv6 address
 
             link local: link local unicast IPv6 address that's within one-hop scope
-            gloal: global unitcast IPv6 address
+            global: global unicast IPv6 address
             rloc: mesh local unicast IPv6 address for routing in thread network
             mesh EID: mesh Endpoint Identifier
 
@@ -628,7 +628,7 @@ class ARM(IThci):
 
     def getGlobal(self):
         """get global unicast IPv6 address set
-           if configuring mutliple entries
+           if configuring multiple entries
         """
         print '%s call getGlobal' % self.port
         return self.__getIp6Address('global')
@@ -679,7 +679,7 @@ class ARM(IThci):
 
         Returns:
             True: successful to add a given extended address to the black list entry
-            False: fail to addd a given extended address to the black list entry
+            False: fail to add a given extended address to the black list entry
         """
         print '%s call addBlockedMAC' % self.port
         print xEUI
@@ -745,7 +745,7 @@ class ARM(IThci):
         """clear all entries in white list table
 
         Returns:
-            True: successful to clearthe white list
+            True: successful to clear the white list
             False: fail to clear the white list
         """
         print '%s call clearAllowList' % self.port
@@ -1118,7 +1118,7 @@ class ARM(IThci):
 
         Returns:
             True: successful to remove the prefix entry from border router
-            False: fail to remove the prfix entry from border router
+            False: fail to remove the prefix entry from border router
         """
         print '%s call removeRouterPrefix' % self.port
         print prefixEntry
@@ -1165,13 +1165,13 @@ class ARM(IThci):
             ModuleHelper.WriteIntoDebugLogger("resetAndRejoin() Error: " + str(e))
 
     def configBorderRouter(self, P_Prefix, P_stable=1, P_default=1, P_slaac_preferred=0, P_Dhcp=0, P_preference=0, P_on_mesh=1, P_nd_dns=0):
-        """configure the border router with a given preifx entry parameters
+        """configure the border router with a given prefix entry parameters
 
         Args:
             P_Prefix: IPv6 prefix that is available on the Thread Network
             P_stable: is true if the default router is expected to be stable network data
             P_default: is true if border router offers the default route for P_Prefix
-            P_slaac_preferred: is true if Thread device is allowed autoconfigure address using P_Prefix
+            P_slaac_preferred: is true if Thread device is allowed auto-configure address using P_Prefix
             P_Dhcp: is true if border router is a DHCPv6 Agent
             P_preference: is two-bit signed integer indicating router preference
             P_on_mesh: is true if P_Prefix is considered to be on-mesh
@@ -1217,7 +1217,7 @@ class ARM(IThci):
             print cmd
             if self.__sendCommand(cmd)[0] == 'Done':
                 # if prefix configured before starting OpenThread stack
-                # do not send out server data ntf proactively
+                # do not send out server data ntf pro-actively
                 if not self.__isOpenThreadRunning():
                     return True
                 else:
@@ -1348,7 +1348,7 @@ class ARM(IThci):
 
         Returns:
             True: successful to configure the border router with a given external route prefix
-            False: fail to configure the border router with a given exteranl route prefix
+            False: fail to configure the border router with a given external route prefix
         """
         print '%s call configExternalRouter' % self.port
         print P_Prefix
@@ -1380,10 +1380,10 @@ class ARM(IThci):
             ModuleHelper.WriteIntoDebugLogger("configExternalRouter() Error: " + str(e))
 
     def getNeighbouringRouters(self):
-        """get neihbouring routers information
+        """get neighboring routers information
 
         Returns:
-            neihbouring routers' extended address
+            neighboring routers' extended address
         """
         print '%s call getNeighbouringRouters' % self.port
         try:
@@ -1501,11 +1501,11 @@ class ARM(IThci):
             ModuleHelper.WriteIntoDebugLogger("setXpanId() Error: " + str(e))
 
     def getNeighbouringDevices(self):
-        """gets the neighbouring devices' extended address to compute the DUT
-           extended addresss automatically
+        """gets the neighboring devices' extended address to compute the DUT
+           extended address automatically
 
         Returns:
-            A list including extended address of neighbouring routers, parent
+            A list including extended address of neighboring routers, parent
             as well as children
         """
         print '%s call getNeighbouringDevices' % self.port
@@ -1522,7 +1522,7 @@ class ARM(IThci):
             for entry in childNeighbours:
                 neighbourList.append(entry)
 
-        # get neighbouring routers info
+        # get neighboring routers info
         routerNeighbours = self.getNeighbouringRouters()
         if routerNeighbours != None and len(routerNeighbours) > 0:
             for entry in routerNeighbours:
@@ -1750,7 +1750,7 @@ class ARM(IThci):
             EncryptedPacket = PlatformDiagnosticPacket()
             infoList = rawLogEach.split('[THCI]')[1].split(']')[0].split('|')
             for eachInfo in infoList:
-                print eachInfo 
+                print eachInfo
                 info = eachInfo.split("=")
                 infoType = info[0].strip()
                 infoValue = info[1].strip()
@@ -1825,7 +1825,7 @@ class ARM(IThci):
     def setActiveTimestamp(self, xActiveTimestamp):
         pass
 
-    def setUdpJoinerPort(self, portNumber): 
+    def setUdpJoinerPort(self, portNumber):
         """set Joiner UDP Port
 
         Args:

--- a/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
+++ b/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
@@ -186,7 +186,7 @@ static void signal_SIGTERM(int sig)
     IGNORE_RETURN_VALUE(write(STDERR_FILENO, message, sizeof(message)-1));
 
     // Restore the previous handler so that if we end up getting
-    // this signal again we peform the system default action.
+    // this signal again we perform the system default action.
     signal(SIGTERM, sPreviousHandlerForSIGTERM);
     sPreviousHandlerForSIGTERM = NULL;
     (void) sig;

--- a/tools/spinel-cli/spinel-cli.py
+++ b/tools/spinel-cli/spinel-cli.py
@@ -26,25 +26,25 @@
 #  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
 #
-""" 
+"""
 spinel-cli.py
 
-vailable commands (type help <name> for more information):
+available commands (type help <name> for more information):
 ============================================================
-channel            diag-sleep  keysequence       q                     
-child              diag-start  leaderdata        quit                  
-childtimeout       diag-stats  leaderweight      releaserouterid       
-clear              diag-stop   masterkey         rloc16                
-commissioner       discover    mode              route                 
-contextreusedelay  eidcache    ncp-ll64          router                
+channel            diag-sleep  keysequence       q
+child              diag-start  leaderdata        quit
+childtimeout       diag-stats  leaderweight      releaserouterid
+clear              diag-stop   masterkey         rloc16
+commissioner       discover    mode              route
+contextreusedelay  eidcache    ncp-ll64          router
 counter            exit        ncp-ml64          routerupgradethreshold
-debug              extaddr     ncp-tun           scan                  
-debug-mem          extpanid    netdataregister   state                 
-diag               h           networkidtimeout  thread                
-diag-channel       help        networkname       tun                   
-diag-power         history     panid             v                     
-diag-repeat        ifconfig    ping              version               
-diag-send          ipaddr      prefix            whitelist  
+debug              extaddr     ncp-tun           scan
+debug-mem          extpanid    netdataregister   state
+diag               h           networkidtimeout  thread
+diag-channel       help        networkname       tun
+diag-power         history     panid             v
+diag-repeat        ifconfig    ping              version
+diag-send          ipaddr      prefix            whitelist
 """
 
 __copyright__   = "Copyright (c) 2016 The OpenThread Authors."
@@ -116,11 +116,11 @@ from scapy.layers.inet6 import ICMPv6EchoReply
 
 MASTER_PROMPT  = "spinel-cli"
 
-DEFAULT_NODE_TYPE = 2    
+DEFAULT_NODE_TYPE = 2
 
 logging.config.dictConfig({
-    'version': 1,              
-    'disable_existing_loggers': False, 
+    'version': 1,
+    'disable_existing_loggers': False,
 
     'formatters': {
         'minimal': {
@@ -132,21 +132,21 @@ logging.config.dictConfig({
     },
     'handlers': {
         'console': {
-            #'level':'INFO',    
-            'level':'DEBUG',    
+            #'level':'INFO',
+            'level':'DEBUG',
             'class':'logging.StreamHandler',
-        },  
+        },
         #'syslog': {
-        #    'level':'DEBUG',    
+        #    'level':'DEBUG',
         #    'class':'logging.handlers.SysLogHandler',
         #    'address': '/dev/log'
-        #},  
+        #},
     },
     'loggers': {
-        '': {                  
-            'handlers': ['console'], #,'syslog'],        
-            'level': 'DEBUG',  
-            'propagate': True  
+        '': {
+            'handlers': ['console'], #,'syslog'],
+            'level': 'DEBUG',
+            'propagate': True
         }
     }
 })
@@ -242,7 +242,7 @@ SPINEL_PROP_MAC_EXT__BEGIN         = 0x1300
 SPINEL_PROP_MAC_WHITELIST          = SPINEL_PROP_MAC_EXT__BEGIN + 0
 SPINEL_PROP_MAC_WHITELIST_ENABLED  = SPINEL_PROP_MAC_EXT__BEGIN + 1  #< [b]
 SPINEL_PROP_MAC_EXT__END           = 0x1400
-    
+
 SPINEL_PROP_NET__BEGIN           = 0x40
 SPINEL_PROP_NET_SAVED            = SPINEL_PROP_NET__BEGIN + 0 #< [b]
 SPINEL_PROP_NET_IF_UP            = SPINEL_PROP_NET__BEGIN + 1 #< [b]
@@ -415,7 +415,7 @@ SPINEL_PROP_CNTR_RX_ERR_SECURITY   = SPINEL_PROP_CNTR__BEGIN + 111
 # The number of received packets with a checksum error.
 # Format: `L` (Read-only) */
 SPINEL_PROP_CNTR_RX_ERR_BAD_FCS    = SPINEL_PROP_CNTR__BEGIN + 112
-    
+
 # The number of received packets with other errors.
 # Format: `L` (Read-only) */
 SPINEL_PROP_CNTR_RX_ERR_OTHER      = SPINEL_PROP_CNTR__BEGIN + 113
@@ -508,11 +508,11 @@ SPINEL_LAST_STATUS_MAP = {
 }
 
 #=========================================
-    
+
 def hexify_chr(s): return "%02X" % ord(s)
 def hexify_int(i): return "%02X" % i
 def hexify_bytes(data): return str(map(hexify_chr,data))
-def hexify_str(s,delim=':'): 
+def hexify_str(s,delim=':'):
     return delim.join(x.encode('hex') for x in s)
 
 def asciify_int(i): return "%c" % (i)
@@ -545,7 +545,7 @@ class StreamSerial(IStream):
     def read(self, size=1):
         b = self.sock.recv(size)
         if DEBUG_LOG_RX:
-            logger.debug("RX Raw: "+hexify_bytes(b))        
+            logger.debug("RX Raw: "+hexify_bytes(b))
         return b
 
 class StreamSocket(IStream):
@@ -560,11 +560,11 @@ class StreamSocket(IStream):
     def read(self, size=1):
         b = self.sock.recv(size)
         if DEBUG_LOG_RX_BYTES:
-            logger.debug("RX Raw: "+str(map(hexify_chr,b)))        
+            logger.debug("RX Raw: "+str(map(hexify_chr,b)))
         return b
 
 class StreamPipe(IStream):
-    def __init__(self, filename):        
+    def __init__(self, filename):
         """ Create a stream object from a piped system call """
         self.pipe = subprocess.Popen(filename, shell = True,
                                      stdin = subprocess.PIPE,
@@ -580,7 +580,7 @@ class StreamPipe(IStream):
         """ Blocking read on stream object """
         for b in iter(lambda: self.pipe.stdout.read(size), ''):
             if DEBUG_LOG_RX:
-                logger.debug("RX Raw: "+hexify_bytes(b))        
+                logger.debug("RX Raw: "+hexify_bytes(b))
             return ord(b)
 
     def close(self):
@@ -589,7 +589,7 @@ class StreamPipe(IStream):
             self.pipe = None
 
 def StreamOpen(type, descriptor):
-    """ 
+    """
     Factory function that creates and opens a stream connection.
 
     type:
@@ -603,7 +603,7 @@ def StreamOpen(type, descriptor):
         pipe - filename of command to execute and bind via stdin/stdout
     """
 
-    if (type == 'p'): 
+    if (type == 'p'):
         print "Opening pipe to "+str(descriptor)
         return StreamPipe(descriptor)
 
@@ -613,12 +613,12 @@ def StreamOpen(type, descriptor):
         print "Opening socket to "+hostname+":"+str(port)
         return StreamSocket(hostname, port)
 
-    elif (type == 'u'):        
+    elif (type == 'u'):
         dev = str(descriptor)
         baudrate = 115200
         print "Opening serial to "+dev+" @ "+str(baudrate)
         return StreamSerial(dev, baudrate)
-    
+
     else:
         return None
 
@@ -657,7 +657,7 @@ class Hdlc(IStream):
     def fcs16(self, byte, fcs):
         fcs = (fcs >> 8) ^ self.fcstab[(fcs ^ byte) & 0xff]
         return fcs
-                    
+
     def collect(self):
         fcs = HDLC_FCS_INIT
         packet = []
@@ -701,7 +701,7 @@ class Hdlc(IStream):
         fcs = HDLC_FCS_INIT
         packet = []
         packet.append(HDLC_FLAG)
-        for b in payload:  
+        for b in payload:
             b = ord(b)
             fcs = self.fcs16(b, fcs)
             packet = self.encode_b(b, packet)
@@ -758,7 +758,7 @@ class SpinelCodec():
         op = 0
         op_len = 0
         op_mul = 1
-        
+
         while op_len < 4:
             b = ord(payload[op_len])
             op += (b & 0x7F) * op_mul
@@ -767,7 +767,7 @@ class SpinelCodec():
             op_len += 1
 
         return (op, op_len+1)
-            
+
     def parse_field(self, payload, format):
         dispath_map = {
             'b': self.parse_b,
@@ -863,10 +863,10 @@ class SpinelPropertyHandler(SpinelCodec):
 
     def THREAD_LEADER_RID(self, payload):     return self.parse_C(payload)
     def THREAD_LEADER_WEIGHT(self, payload):  return self.parse_C(payload)
-    def THREAD_LOCAL_LEADER_WEIGHT(self, payload): 
+    def THREAD_LOCAL_LEADER_WEIGHT(self, payload):
         return self.parse_C(payload)
 
-    def THREAD_NETWORK_DATA(self, payload):          
+    def THREAD_NETWORK_DATA(self, payload):
         return self.parse_D(payload)
 
     def THREAD_NETWORK_DATA_VERSION(self, payload):  pass
@@ -880,7 +880,7 @@ class SpinelPropertyHandler(SpinelCodec):
         self.prefix_thread = threading.Thread(target=self.__run_prefix_handler)
         self.prefix_thread.setDaemon(True)
         self.prefix_thread.start()
-        
+
     def handle_ipaddr_remove(self, ipaddr):
         valid = 1
         preferred = 1
@@ -888,12 +888,12 @@ class SpinelPropertyHandler(SpinelCodec):
         prefix_len = 64  # always use /64
 
         arr = ipaddr.ip.packed
-        arr += pack('B', prefix_len) 
+        arr += pack('B', prefix_len)
         arr += pack('<L', valid)
         arr += pack('<L', preferred)
         arr += pack('B', flags)
-        gWpanApi.prop_remove_async(SPINEL_PROP_IPV6_ADDRESS_TABLE, 
-                                   arr, str(len(arr))+'s', 
+        gWpanApi.prop_remove_async(SPINEL_PROP_IPV6_ADDRESS_TABLE,
+                                   arr, str(len(arr))+'s',
                                    SPINEL_HEADER_EVENT_HANDLER)
 
     def handle_ipaddr_insert(self, prefix, prefixlen, stable, flags, isLocal):
@@ -912,13 +912,13 @@ class SpinelPropertyHandler(SpinelCodec):
         self.autoAddresses.add(ipaddr)
 
         arr = ipaddr.ip.packed
-        arr += pack('B', prefixlen) 
+        arr += pack('B', prefixlen)
         arr += pack('<L', valid)
         arr += pack('<L', preferred)
         arr += pack('B', flags)
 
-        gWpanApi.prop_insert_async(SPINEL_PROP_IPV6_ADDRESS_TABLE, 
-                                   arr, str(len(arr))+'s', 
+        gWpanApi.prop_insert_async(SPINEL_PROP_IPV6_ADDRESS_TABLE,
+                                   arr, str(len(arr))+'s',
                                    SPINEL_HEADER_EVENT_HANDLER)
 
 
@@ -956,11 +956,11 @@ class SpinelPropertyHandler(SpinelCodec):
         # for ipaddr in ipaddrs:
         #     if lifetime > 0 and not in slaac prefixes
         #             ==> remove
-        for ipaddr in self.autoAddresses:            
+        for ipaddr in self.autoAddresses:
             if not any(ipaddr in prefix for prefix in slaacPrefixSet):
                 self.handle_ipaddr_remove(ipaddr)
 
-        # for slaac prefix in prefixes: 
+        # for slaac prefix in prefixes:
         #     if no ipaddr with lifetime > 0 in prefix:
         #          ==> add
 
@@ -981,7 +981,7 @@ class SpinelPropertyHandler(SpinelCodec):
 
     def THREAD_LOCAL_ROUTES(self, payload):          pass
     def THREAD_ASSISTING_PORTS(self, payload):       pass
-    def THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(self, payload): 
+    def THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(self, payload):
         return self.parse_b(payload)
 
     def THREAD_MODE(self, payload):            return self.parse_C(payload)
@@ -989,17 +989,17 @@ class SpinelPropertyHandler(SpinelCodec):
     def THREAD_CHILD_TIMEOUT(self, payload):   return self.parse_L(payload)
     def THREAD_RLOC16(self, payload):          return self.parse_S(payload)
 
-    def THREAD_ROUTER_UPGRADE_THRESHOLD(self, payload): 
+    def THREAD_ROUTER_UPGRADE_THRESHOLD(self, payload):
         return self.parse_C(payload)
 
-    def THREAD_CONTEXT_REUSE_DELAY(self, payload):   
+    def THREAD_CONTEXT_REUSE_DELAY(self, payload):
         return self.parse_L(payload)
 
     def THREAD_NETWORK_ID_TIMEOUT(self, payload): return self.parse_C(payload)
     def THREAD_ACTIVE_ROUTER_IDS(self, payload): return self.parse_D(payload)
-    def THREAD_RLOC16_DEBUG_PASSTHRU(self, payload):   
+    def THREAD_RLOC16_DEBUG_PASSTHRU(self, payload):
         return self.parse_b(payload)
-    
+
     def IPV6_LL_ADDR(self, payload):          return self.parse_6(payload)
     def IPV6_ML_ADDR(self, payload):          return self.parse_6(payload)
     def IPV6_ML_PREFIX(self, payload):        return self.parse_E(payload)
@@ -1018,16 +1018,16 @@ class SpinelPropertyHandler(SpinelCodec):
 
 class SpinelCommandHandler(SpinelCodec):
 
-    def handle_prop(self, name, payload, tid): 
+    def handle_prop(self, name, payload, tid):
         (prop_op, prop_len) = self.parse_i(payload)
 
         try:
             handler = SPINEL_PROP_DISPATCH[prop_op]
             prop_name = handler.__name__
             prop_value = handler(payload[prop_len:])
-                
+
             if DEBUG_LOG_PROP:
-                    
+
                 # Generic output
                 if isinstance(prop_value, basestring):
                     prop_str = hexify_str(prop_value)
@@ -1035,7 +1035,7 @@ class SpinelCommandHandler(SpinelCodec):
                                  (name, (tid & 0xF), prop_name, prop_str))
                 else:
                     prop_str = str(prop_value)
-                    
+
                     logger.debug("PROP_VALUE_%s [tid=%d]: %s = %s" %
                                  (name, (tid & 0xF), prop_name, prop_str))
 
@@ -1044,7 +1044,7 @@ class SpinelCommandHandler(SpinelCodec):
                     logger.debug(SPINEL_LAST_STATUS_MAP[prop_value])
 
             if DEBUG_LOG_PKT:
-                if ((prop_op == SPINEL_PROP_STREAM_NET) or 
+                if ((prop_op == SPINEL_PROP_STREAM_NET) or
                       (prop_op == SPINEL_PROP_STREAM_NET_INSECURE)):
                     logger.debug("PROP_VALUE_"+name+": "+prop_name)
                     pkt = IPv6(prop_value[2:])
@@ -1054,7 +1054,7 @@ class SpinelCommandHandler(SpinelCodec):
                     logger.debug("DEBUG: "+prop_value)
 
             global gWpanApi
-            if gWpanApi: 
+            if gWpanApi:
                 gWpanApi.queue_add(prop_op, prop_value, tid)
             else:
                 print "no wpanApi"
@@ -1062,10 +1062,10 @@ class SpinelCommandHandler(SpinelCodec):
         except:
             prop_name = "Property Unknown"
             logger.info ("\n%s (%i): " % (prop_name, prop_op))
-            print traceback.format_exc()            
+            print traceback.format_exc()
 
 
-    def PROP_VALUE_IS(self, payload, tid): 
+    def PROP_VALUE_IS(self, payload, tid):
         self.handle_prop("IS", payload, tid)
 
     def PROP_VALUE_INSERTED(self, payload, tid):
@@ -1094,7 +1094,7 @@ SPINEL_PROP_DISPATCH = {
     SPINEL_PROP_CAPS:                  wpanPropHandler.CAPS,
     SPINEL_PROP_INTERFACE_COUNT:       wpanPropHandler.INTERFACE_COUNT,
     SPINEL_PROP_POWER_STATE:           wpanPropHandler.POWER_STATE,
-    SPINEL_PROP_HWADDR:                wpanPropHandler.HWADDR, 
+    SPINEL_PROP_HWADDR:                wpanPropHandler.HWADDR,
     SPINEL_PROP_LOCK:                  wpanPropHandler.LOCK,
     SPINEL_PROP_HBO_MEM_MAX:           wpanPropHandler.HBO_MEM_MAX,
     SPINEL_PROP_HBO_BLOCK_MAX:         wpanPropHandler.HBO_BLOCK_MAX,
@@ -1133,7 +1133,7 @@ SPINEL_PROP_DISPATCH = {
     SPINEL_PROP_THREAD_LEADER_ADDR: wpanPropHandler.THREAD_LEADER_ADDR,
     SPINEL_PROP_THREAD_PARENT: wpanPropHandler.THREAD_PARENT,
     SPINEL_PROP_THREAD_CHILD_TABLE:  wpanPropHandler.THREAD_CHILD_TABLE,
-    SPINEL_PROP_THREAD_LEADER_RID: wpanPropHandler.THREAD_LEADER_RID,      
+    SPINEL_PROP_THREAD_LEADER_RID: wpanPropHandler.THREAD_LEADER_RID,
     SPINEL_PROP_THREAD_LEADER_WEIGHT: wpanPropHandler.THREAD_LEADER_WEIGHT,
     SPINEL_PROP_THREAD_LOCAL_LEADER_WEIGHT: wpanPropHandler.THREAD_LOCAL_LEADER_WEIGHT,
     SPINEL_PROP_THREAD_NETWORK_DATA: wpanPropHandler.THREAD_NETWORK_DATA,
@@ -1165,7 +1165,7 @@ SPINEL_PROP_DISPATCH = {
     SPINEL_PROP_STREAM_NET:            wpanPropHandler.STREAM_NET,
     SPINEL_PROP_STREAM_NET_INSECURE:   wpanPropHandler.STREAM_NET_INSECURE,
 }
-       
+
 
 class TunInterface():
     def __init__(self, id):
@@ -1181,7 +1181,7 @@ class TunInterface():
         self.ifconfig("up")
         #self.ifconfig("inet6 add fd00::1/64")
         self.__start_tun_thread()
-        
+
     def __init_osx(self):
         logger.info("TUN: Starting osx "+self.ifname)
         filename = "/dev/"+self.ifname
@@ -1207,7 +1207,7 @@ class TunInterface():
         fcntl.ioctl(self.tun, IFF_TUNSETOWNER, 1000)   # Allow non-sudo access
 
     def close(self):
-        if self.tun: 
+        if self.tun:
             os.close(self.fd)
             self.fd = None
             self.tun = None
@@ -1253,7 +1253,7 @@ class TunInterface():
                                   hexify_str(packet))
                     self.write(packet)
             except:
-                print traceback.format_exc()            
+                print traceback.format_exc()
                 break
 
         logger.info("TUN: exiting")
@@ -1269,7 +1269,7 @@ class TunInterface():
         self.receiver_thread.setDaemon(True)
         self.receiver_thread.start()
 
- 
+
 class WpanApi(SpinelCodec):
     """ Helper class to format wpan command packets """
 
@@ -1333,17 +1333,17 @@ class WpanApi(SpinelCodec):
             handler = SPINEL_COMMAND_DISPATCH[cmd_op]
             cmd_name = handler.__name__
             handler(payload, tid)
-            
+
         except:
-            print traceback.format_exc()            
+            print traceback.format_exc()
             cmd_name = "CB_Unknown"
             logger.info ("\n%s (%i): " % (cmd_name, cmd_op))
 
         if DEBUG_CMD_RESPONSE:
             logger.info ("\n%s (%i): " % (cmd_name, cmd_op))
             logger.info ("===> %s" % hexify_str(payload))
-        
-         
+
+
     def serial_tx(self, pkt):
         # Encapsulate lagging and Framer support in self.serial class.
         self.serial.write(pkt)
@@ -1386,7 +1386,7 @@ class WpanApi(SpinelCodec):
         if (tid not in self.tid_filter): return
         item = self.PropertyItem(prop, value, tid)
         self.__queue_prop[tid].put_nowait(item)
-        
+
     def queue_clear(self, tid):
         with self.__queue_prop[tid].mutex:
             self.__queue_prop[tid].queue.clear()
@@ -1429,24 +1429,24 @@ class WpanApi(SpinelCodec):
 
         self.transact(SPINEL_CMD_PROP_VALUE_SET, pay)
 
-    def prop_change_async(self, cmd, prop_id, value, format='B', 
+    def prop_change_async(self, cmd, prop_id, value, format='B',
                           tid=SPINEL_HEADER_DEFAULT):
         pay = self.encode_i(prop_id)
         if format != None:
             pay += pack(format, value)
         self.transact(cmd, pay, tid)
 
-    def prop_insert_async(self, prop_id, value, format='B', 
+    def prop_insert_async(self, prop_id, value, format='B',
                           tid=SPINEL_HEADER_DEFAULT):
-        self.prop_change_async(SPINEL_CMD_PROP_VALUE_INSERT, prop_id, 
+        self.prop_change_async(SPINEL_CMD_PROP_VALUE_INSERT, prop_id,
                                value, format, tid)
 
-    def prop_remove_async(self, prop_id, value, format='B', 
+    def prop_remove_async(self, prop_id, value, format='B',
                           tid=SPINEL_HEADER_DEFAULT):
-        self.prop_change_async(SPINEL_CMD_PROP_VALUE_REMOVE, prop_id, 
+        self.prop_change_async(SPINEL_CMD_PROP_VALUE_REMOVE, prop_id,
                                value, format, tid)
 
-    def __prop_change_value(self, cmd, prop_id, value, format='B', 
+    def __prop_change_value(self, cmd, prop_id, value, format='B',
                             tid=SPINEL_HEADER_DEFAULT):
         """ Utility routine to change a property value over Spinel. """
         self.queue_wait_prepare(prop_id, tid)
@@ -1461,44 +1461,44 @@ class WpanApi(SpinelCodec):
             return result.value
         else:
             return None
-    
+
     def prop_get_value(self, prop_id, tid=SPINEL_HEADER_DEFAULT):
         """ Blocking routine to get a property value over Spinel. """
-        if DEBUG_LOG_PROP: 
+        if DEBUG_LOG_PROP:
             handler = SPINEL_PROP_DISPATCH[prop_id]
             prop_name = handler.__name__
             print "PROP_VALUE_GET [tid=%d]: %s" % (tid&0xF, prop_name)
-        return self.__prop_change_value(SPINEL_CMD_PROP_VALUE_GET, prop_id, 
+        return self.__prop_change_value(SPINEL_CMD_PROP_VALUE_GET, prop_id,
                                         None, None, tid)
 
-    def prop_set_value(self, prop_id, value, format='B', 
+    def prop_set_value(self, prop_id, value, format='B',
                        tid=SPINEL_HEADER_DEFAULT):
         """ Blocking routine to set a property value over Spinel. """
-        if DEBUG_LOG_PROP: 
+        if DEBUG_LOG_PROP:
             handler = SPINEL_PROP_DISPATCH[prop_id]
             prop_name = handler.__name__
             print "PROP_VALUE_SET [tid=%d]: %s" % (tid&0xF, prop_name)
-        return self.__prop_change_value(SPINEL_CMD_PROP_VALUE_SET, prop_id, 
+        return self.__prop_change_value(SPINEL_CMD_PROP_VALUE_SET, prop_id,
                                         value, format, tid)
 
-    def prop_insert_value(self, prop_id, value, format='B', 
+    def prop_insert_value(self, prop_id, value, format='B',
                           tid=SPINEL_HEADER_DEFAULT):
         """ Blocking routine to insert a property value over Spinel. """
-        if DEBUG_LOG_PROP: 
+        if DEBUG_LOG_PROP:
             handler = SPINEL_PROP_DISPATCH[prop_id]
             prop_name = handler.__name__
             print "PROP_VALUE_INSERT [tid=%d]: %s" % (tid&0xF, prop_name)
-        return self.__prop_change_value(SPINEL_CMD_PROP_VALUE_INSERT, prop_id, 
+        return self.__prop_change_value(SPINEL_CMD_PROP_VALUE_INSERT, prop_id,
                                         value, format, tid)
-        
-    def prop_remove_value(self, prop_id, value, format='B', 
+
+    def prop_remove_value(self, prop_id, value, format='B',
                           tid=SPINEL_HEADER_DEFAULT):
         """ Blocking routine to remove a property value over Spinel. """
-        if DEBUG_LOG_PROP: 
+        if DEBUG_LOG_PROP:
             handler = SPINEL_PROP_DISPATCH[prop_id]
             prop_name = handler.__name__
             print "PROP_VALUE_REMOVE [tid=%d]: %s" % (tid&0xF, prop_name)
-        return self.__prop_change_value(SPINEL_CMD_PROP_VALUE_REMOVE, prop_id, 
+        return self.__prop_change_value(SPINEL_CMD_PROP_VALUE_REMOVE, prop_id,
                                         value, format, tid)
 
     def get_ipaddrs(self, tid=SPINEL_HEADER_DEFAULT):
@@ -1517,7 +1517,7 @@ class WpanApi(SpinelCodec):
 
 
 class SpinelCliCmd(Cmd, SpinelCodec):
-    
+
     def __init__(self, device, nodeid, *a, **kw):
 
         self.wpanApi = WpanApi(device, nodeid)
@@ -1533,9 +1533,9 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         else:
             self.use_rawinput = 0
             self.prompt = ""
-        
+
         SpinelCliCmd.command_names.sort()
-            
+
         self.historyFileName = os.path.expanduser("~/.spinel-cli-history")
 
         try:
@@ -1556,7 +1556,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         self.prop_set_value(SPINEL_PROP_IPv6_ICMP_PING_OFFLOAD, 1)
         self.prop_set_value(SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU, 1)
 
- 
+
     command_names = [
         # Shell commands
         'exit',
@@ -1569,59 +1569,59 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         'v',
         'h',
         'q',
-        
+
         # OpenThread CLI commands
-        'help', 
-        'channel', 
-        'child', 
-        'childtimeout', 
-        'commissioner', 
-        'contextreusedelay', 
-        'counter', 
-        'discover', 
-        'eidcache', 
-        'extaddr', 
-        'extpanid', 
-        'ifconfig', 
-        'ipaddr', 
-        'keysequence', 
-        'leaderdata', 
-        'leaderweight', 
-        'masterkey', 
-        'mode', 
-        'netdataregister', 
-        'networkidtimeout', 
-        'networkname', 
-        'panid', 
-        'ping', 
-        'prefix', 
-        'releaserouterid', 
-        'rloc16', 
-        'route', 
-        'router', 
-        'routerupgradethreshold', 
-        'scan', 
-        'state', 
-        'thread', 
-        'tun', 
-        'version', 
-        'whitelist', 
+        'help',
+        'channel',
+        'child',
+        'childtimeout',
+        'commissioner',
+        'contextreusedelay',
+        'counter',
+        'discover',
+        'eidcache',
+        'extaddr',
+        'extpanid',
+        'ifconfig',
+        'ipaddr',
+        'keysequence',
+        'leaderdata',
+        'leaderweight',
+        'masterkey',
+        'mode',
+        'netdataregister',
+        'networkidtimeout',
+        'networkname',
+        'panid',
+        'ping',
+        'prefix',
+        'releaserouterid',
+        'rloc16',
+        'route',
+        'router',
+        'routerupgradethreshold',
+        'scan',
+        'state',
+        'thread',
+        'tun',
+        'version',
+        'whitelist',
 
         # OpenThread Diagnostics Module CLI
-        'diag', 
-        'diag-start', 
-        'diag-channel', 
-        'diag-power', 
-        'diag-send', 
-        'diag-repeat', 
-        'diag-sleep', 
-        'diag-stats', 
-        'diag-stop', 
+        'diag',
+        'diag-start',
+        'diag-channel',
+        'diag-power',
+        'diag-send',
+        'diag-repeat',
+        'diag-sleep',
+        'diag-stats',
+        'diag-stop',
 
         # OpenThread Spinel-specific commands
-        'ncp-ml64', 
-        'ncp-ll64', 
-        'ncp-tun', 
+        'ncp-ml64',
+        'ncp-ll64',
+        'ncp-tun',
 
     ]
 
@@ -1635,7 +1635,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             cmd = self.shortCommandName(cmd)
             line = cmd + ' ' + arg
         return cmd, arg, line
-        
+
     def completenames(self, text, *ignored):
         return [ name + ' ' for name in SpinelCliCmd.command_names \
                  if name.startswith(text) \
@@ -1643,7 +1643,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
 
     def shortCommandName(self, cmd):
         return cmd.replace('-', '')
-    
+
     def postloop(self):
         try:
             import readline
@@ -1654,7 +1654,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         except ImportError:
             pass
 
-    def prop_get_value(self, prop_id): 
+    def prop_get_value(self, prop_id):
         return self.wpanApi.prop_get_value(prop_id)
 
     def prop_set_value(self, prop_id, value, format='B'):
@@ -1662,7 +1662,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
 
     def prop_insert_value(self, prop_id, value, format='B'):
         return self.wpanApi.prop_insert_value(prop_id, value, format)
-        
+
     def prop_remove_value(self, prop_id, value, format='B'):
         return self.wpanApi.prop_remove_value(prop_id, value, format)
 
@@ -1670,13 +1670,13 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         """ Helper to get or set a property value based on line arguments. """
         if line:
             value = self.prop_set_value(prop_id, self.prep_line(line), format)
-        else:    
+        else:
             value = self.prop_get_value(prop_id)
         return value
 
     def prep_line(self, line):
         """ Convert a line argument to proper type """
-        if line != None: 
+        if line != None:
             line = int(line)
         return line
 
@@ -1686,7 +1686,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         if value == None:
             print("Error")
             return None
-            
+
         if (format == 'D') or (format == 'E'):
             print hexify_str(value,'')
         else:
@@ -1695,7 +1695,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
 
         return value
 
-    def prop_set(self, prop_id, line, format='B'):        
+    def prop_set(self, prop_id, line, format='B'):
         """ Helper to set a propery and output Done or Error. """
         arg = self.prep_line(line)
         value = self.prop_set_value(prop_id, arg, format)
@@ -1740,8 +1740,8 @@ class SpinelCliCmd(Cmd, SpinelCodec):
                 self.log("No help on %s\n" % (line))
         else:
             self.print_topics("\nAvailable commands (type help <name> for more information):", SpinelCliCmd.command_names, 15, 80)
-            
-        
+
+
     def do_v(self, line):
         """
         version
@@ -1759,7 +1759,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
     def do_history(self, line):
         """
         history
-          
+
           Show previously executed commands.
         """
 
@@ -1780,7 +1780,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         logger.info("exit")
         return True
 
-    
+
     def do_quit(self, line):
         logger.info("quit")
         return True
@@ -1819,7 +1819,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         if line != None and line != "":
             level = int(line)
 
-            if level: 
+            if level:
                 DEBUG_ENABLE = level
                 if level >= 1: DEBUG_LOG_PROP = 1
                 if level >= 2: DEBUG_LOG_PKT = 1
@@ -1854,7 +1854,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         \033[0m
         \033[1mchannel <channel>\033[0m
 
-            Set the IEEE 802.15.4 Channel value.        
+            Set the IEEE 802.15.4 Channel value.
         \033[2m
             > channel 11
             Done
@@ -1862,7 +1862,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         """
         self.handle_property(line, SPINEL_PROP_PHY_CHAN)
 
-    def do_child(self, line): 
+    def do_child(self, line):
         """\033[1m
         child list
         \033[0m
@@ -1874,7 +1874,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         \033[0m\033[1m
         child <id>
         \033[0m
-            Print diagnostic information for an attached Thread Child. 
+            Print diagnostic information for an attached Thread Child.
             The id may be a Child ID or an RLOC16.
         \033[2m
             > child 1
@@ -1887,12 +1887,12 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             Age: 0
             LQI: 3
             RSSI: -20
-            Done        
+            Done
         \033[0m
         """
         pass
 
-    def do_childtimeout(self, line): 
+    def do_childtimeout(self, line):
         """\033[1m
         childtimeout
         \033[0m
@@ -1912,7 +1912,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         """
         self.handle_property(line, SPINEL_PROP_THREAD_CHILD_TIMEOUT, 'L')
 
-    def do_commissioner(self, line): 
+    def do_commissioner(self, line):
         """
         These commands are enabled when configuring with --enable-commissioner.
 
@@ -1944,7 +1944,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             Perform energy scan.
         \033[2m
             > commissioner energy 327680 2 32 1000 fdde:ad00:beef:0:0:ff:fe00:c00
-            Energy: 00050000 0 0 0 0 
+            Energy: 00050000 0 0 0 0
             Done
         \033[0m
         """
@@ -1969,7 +1969,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         """
         self.handle_property(line, SPINEL_PROP_THREAD_CONTEXT_REUSE_DELAY, 'L')
 
-    def do_counter(self, line): 
+    def do_counter(self, line):
         """
         counter
 
@@ -1980,7 +1980,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             Done
 
         counter <countername>
-        
+
             Get the counter value.
 
             >counter mac
@@ -2010,7 +2010,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             RxErrFcs: 0
             RxErrOther: 0
         """
-        pass 
+        pass
 
     def do_discover(self, line):
         """
@@ -2025,9 +2025,9 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         | 0 | OpenThread       | dead00beef00cafe | ffff | f1d92a82c8d8fe43 | 11 | -20 |   0 |
         Done
         """
-        pass 
+        pass
 
-    def do_eidcache(self, line): 
+    def do_eidcache(self, line):
         """
         eidcache
 
@@ -2038,7 +2038,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             fdde:ad00:beef:0:110a:e041:8399:17cd 6000
             Done
         """
-        pass 
+        pass
 
     def do_extaddr(self, line):
         """
@@ -2071,11 +2071,11 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             Done
 
         extpanid <extpanid>
-        
+
             Set the Thread Extended PAN ID value.
-        
+
             > extpanid dead00beef00cafe
-            Done        
+            Done
         """
         self.handle_property(line, SPINEL_PROP_NET_XPANID, 'D')
 
@@ -2083,26 +2083,26 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         _SUB_COMMANDS = ('up', 'down')
         return [i for i in _SUB_COMMANDS if i.startswith(text)]
 
-    def do_ifconfig(self, line): 
+    def do_ifconfig(self, line):
         """
         ifconfig up
-        
+
             Bring up the IPv6 interface.
-        
+
             > ifconfig up
             Done
 
         ifconfig down
-        
+
             Bring down the IPv6 interface.
-        
+
             > ifconfig down
             Done
 
         ifconfig
-        
+
             Show the status of the IPv6 interface.
-        
+
             > ifconfig
             down
             Done
@@ -2133,7 +2133,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         _SUB_COMMANDS = ('add', 'remove')
         return [i for i in _SUB_COMMANDS if i.startswith(text)]
 
-    def do_ipaddr(self, line): 
+    def do_ipaddr(self, line):
         """
         ipaddr
 
@@ -2147,16 +2147,16 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             Done
 
         ipaddr add <ipaddr>
-        
+
             Add an IPv6 address to the Thread interface.
 
             > ipaddr add 2001::dead:beef:cafe
             Done
 
         ipaddr del <ipaddr>
-        
+
             Delete an IPv6 address from the Thread interface.
-        
+
             > ipaddr del 2001::dead:beef:cafe
             Done
         """
@@ -2178,28 +2178,28 @@ class SpinelCliCmd(Cmd, SpinelCodec):
                 print str(addr)
 
         elif args[0] == "add":
-            arr += pack('B', prefix_len) 
+            arr += pack('B', prefix_len)
             arr += pack('<L', valid)
             arr += pack('<L', preferred)
             arr += pack('B', flags)
-            value = self.prop_insert_value(SPINEL_PROP_IPV6_ADDRESS_TABLE, 
+            value = self.prop_insert_value(SPINEL_PROP_IPV6_ADDRESS_TABLE,
                                            arr, str(len(arr))+'s')
             if self.wpanApi.tun_if:
                 self.wpanApi.tun_if.addr_add(ipaddr)
 
         elif args[0] == "remove":
-            arr += pack('B', prefix_len) 
+            arr += pack('B', prefix_len)
             arr += pack('<L', valid)
             arr += pack('<L', preferred)
             arr += pack('B', flags)
-            value = self.prop_remove_value(SPINEL_PROP_IPV6_ADDRESS_TABLE, 
+            value = self.prop_remove_value(SPINEL_PROP_IPV6_ADDRESS_TABLE,
                                            arr, str(len(arr))+'s')
             if self.wpanApi.tun_if:
                 self.wpanApi.tun_if.addr_del(ipaddr)
 
         print("Done")
 
-    def do_keysequence(self, line): 
+    def do_keysequence(self, line):
         """
         keysequence
 
@@ -2218,8 +2218,8 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         """
         self.handle_property(line, SPINEL_PROP_NET_KEY_SEQUENCE, 'L')
 
-    def do_leaderdata(self, line): 
-        pass 
+    def do_leaderdata(self, line):
+        pass
 
     def do_leaderweight(self, line):
         """
@@ -2232,39 +2232,39 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             Done
 
         leaderweight <weight>
-        
+
             Set the Thread Leader Weight.
-        
+
             > leaderweight 128
             Done
         """
         self.handle_property(line, SPINEL_PROP_THREAD_LOCAL_LEADER_WEIGHT)
 
-    def do_masterkey(self, line): 
+    def do_masterkey(self, line):
         """
         masterkey
-        
+
             Get the Thread Master Key value.
-        
+
             > masterkey
             00112233445566778899aabbccddeeff
             Done
 
         masterkey <key>
-        
+
             Set the Thread Master Key value.
-        
+
             > masterkey 00112233445566778899aabbccddeeff
             Done
         """
-        pass 
+        pass
 
-    def do_mode(self, line): 
+    def do_mode(self, line):
         """
         mode
-        
+
             Get the Thread Device Mode value.
-        
+
               r: rx-on-when-idle
               s: Secure IEEE 802.15.4 data requests
               d: Full Function Device
@@ -2341,7 +2341,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             print("Error")
 
 
-    def do_netdataregister(self, line): 
+    def do_netdataregister(self, line):
         """
         netdataregister
 
@@ -2352,9 +2352,9 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         """
         self.prop_set_value(SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE, 1)
         self.handle_property("0", SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE)
-        pass 
+        pass
 
-    def do_networkidtimeout(self, line): 
+    def do_networkidtimeout(self, line):
         """
         networkidtimeout
 
@@ -2365,15 +2365,15 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             Done
 
         networkidtimeout <timeout>
-        
+
             Set the NETWORK_ID_TIMEOUT parameter used in the Router role.
-        
+
             > networkidtimeout 120
             Done
         """
         self.handle_property(line, SPINEL_PROP_THREAD_NETWORK_ID_TIMEOUT)
 
-    def do_networkname(self, line): 
+    def do_networkname(self, line):
         """
         networkname
 
@@ -2384,13 +2384,13 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             Done
 
         networkname <name>
-        
+
             Set the Thread Network Name.
-        
+
             > networkname OpenThread
             Done
         """
-        pass 
+        pass
 
     def do_panid(self, line):
         """
@@ -2401,17 +2401,17 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             > panid
             0xdead
             Done
-        
+
         panid <panid>
-        
+
             Set the IEEE 802.15.4 PAN ID value.
-        
+
             > panid 0xdead
             Done
         """
         self.handle_property(line, SPINEL_PROP_MAC_15_4_PANID, 'H')
 
-    def do_ping(self, line): 
+    def do_ping(self, line):
         """
         ping <ipaddr> [size] [count] [interval]
 
@@ -2429,7 +2429,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         if (len(args) > 1): size = args[1]
         if (len(args) > 2): count = args[2]
         if (len(args) > 3): interval = args[3]
-        
+
         try:
             # Generate local ping packet and send directly via spinel.
             ML64 = self.prop_get_value(SPINEL_PROP_IPV6_ML_ADDR)
@@ -2447,12 +2447,12 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         _SUB_COMMANDS = ('add', 'remove')
         return [i for i in _SUB_COMMANDS if i.startswith(text)]
 
-    def do_prefix(self, line): 
+    def do_prefix(self, line):
         """
         prefix add <prefix> [pvdcsr] [prf]
-        
+
             Add a valid prefix to the Network Data.
-        
+
               p: Preferred flag
               a: Stateless IPv6 Address Autoconfiguration flag
               d: DHCPv6 IPv6 Address Configuration flag
@@ -2465,7 +2465,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             Done
 
         prefix remove <prefix>
-        
+
             Invalidate a prefix in the Network Data.
 
             > prefix remove 2001:dead:beef:cafe::/64
@@ -2506,7 +2506,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             arr += pack('B', flags)
 
             self.prop_set_value(SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE,1)
-            value = self.prop_insert_value(SPINEL_PROP_THREAD_ON_MESH_NETS, 
+            value = self.prop_insert_value(SPINEL_PROP_THREAD_ON_MESH_NETS,
                                            arr, str(len(arr))+'s')
 
         elif args[0] == "remove":
@@ -2514,17 +2514,17 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             arr += pack('B', stable)
             arr += pack('B', flags)
             self.prop_set_value(SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE,1)
-            value = self.prop_remove_value(SPINEL_PROP_THREAD_ON_MESH_NETS, 
+            value = self.prop_remove_value(SPINEL_PROP_THREAD_ON_MESH_NETS,
                                            arr, str(len(arr))+'s')
 
         print("Done")
 
-    def do_releaserouterid(self, line): 
+    def do_releaserouterid(self, line):
         """
         releaserouterid <routerid>
 
             Release a Router ID that has been allocated by the device in the Leader role.
-        
+
             > releaserouterid 16
             Done
         """
@@ -2563,7 +2563,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             Done
 
         route remove <prefix>
-        
+
             Invalidate a prefix in the Network Data.
 
             > route remove 2001:dead:beef:cafe::/64
@@ -2587,28 +2587,28 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             arr += pack('B', prf)
 
             self.prop_set_value(SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE,1)
-            value = self.prop_insert_value(SPINEL_PROP_THREAD_LOCAL_ROUTES, 
+            value = self.prop_insert_value(SPINEL_PROP_THREAD_LOCAL_ROUTES,
                                            arr, str(len(arr))+'s')
 
         elif args[0] == "remove":
             self.prop_set_value(SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE,1)
-            value = self.prop_remove_value(SPINEL_PROP_THREAD_LOCAL_ROUTES, 
+            value = self.prop_remove_value(SPINEL_PROP_THREAD_LOCAL_ROUTES,
                                            arr, str(len(arr))+'s')
 
         print("Done")
 
-    def do_router(self, line): 
+    def do_router(self, line):
         """
         router list
 
             List allocated Router IDs
-        
+
             > router list
             8 24 50
             Done
 
         router <id>
-        
+
             Print diagnostic information for a Thread Router. The id may be a Router ID or an RLOC16.
 
             > router 50
@@ -2637,7 +2637,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             Age: 7
             Done
         """
-        pass 
+        pass
 
     def do_routerupgradethreshold(self, line):
         """
@@ -2650,20 +2650,20 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             Done
 
         routerupgradethreshold <threshold>
-        
+
             Set the ROUTER_UPGRADE_THRESHOLD value.
-        
+
             > routerupgradethreshold 16
-            Done        
+            Done
         """
         self.handle_property(line, SPINEL_PROP_THREAD_ROUTER_UPGRADE_THRESHOLD)
 
     def do_scan(self, line):
         """
         scan [channel]
-        
+
             Perform an IEEE 802.15.4 Active Scan.
-        
+
               channel: The channel to scan on. If no channel is provided, the active scan will cover all valid channels.
 
             > scan
@@ -2677,9 +2677,9 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         self.handle_property("4", SPINEL_PROP_MAC_SCAN_PERIOD, 'H')
         self.handle_property("1", SPINEL_PROP_MAC_SCAN_STATE)
         import time
-        time.sleep(5) 
+        time.sleep(5)
         self.handle_property("", SPINEL_PROP_MAC_SCAN_BEACON, 'U')
-        
+
 
     def complete_thread(self, text, line, begidx, endidx):
         _SUB_COMMANDS = ('start', 'stop')
@@ -2695,9 +2695,9 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             Done
 
         thread stop
-        
+
             Disable Thread protocol operation and detach from a Thread network.
-        
+
             > thread stop
             Done
         """
@@ -2729,7 +2729,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         else:
             print("Error")
 
-    def do_state(self, line): 
+    def do_state(self, line):
         ROLE_MAP_VALUE = {
             0: "detached",
             1: "child",
@@ -2756,8 +2756,8 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         result = self.prop_get_or_set_value(SPINEL_PROP_NET_ROLE, line)
         if result != None:
             if not line:
-                state = ROLE_MAP_VALUE[result] 
-                # TODO: if state="disabled": get NET_STATE to determine 
+                state = ROLE_MAP_VALUE[result]
+                # TODO: if state="disabled": get NET_STATE to determine
                 #       whether "disabled" or "detached"
                 print state
             print("Done")
@@ -2769,7 +2769,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         version
 
             Print the build version information.
-        
+
             > version
             OPENTHREAD/gf4f2f04; Jul  1 2016 17:00:09
             Done
@@ -2794,37 +2794,37 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             Done
 
         whitelist add <extaddr> [rssi]
-        
+
             Add an IEEE 802.15.4 Extended Address to the whitelist.
-        
+
             > whitelist add dead00beef00cafe
             Done
 
         whitelist clear
-        
+
             Clear all entries from the whitelist.
-        
+
             > whitelist clear
             Done
 
         whitelist disable
-        
+
             Disable MAC whitelist filtering.
-        
+
             > whitelist disable
             Done
 
         whitelist enable
-        
+
             Enable MAC whitelist filtering.
-        
+
             > whitelist enable
             Done
 
         whitelist remove <extaddr>
-        
+
             Remove an IEEE 802.15.4 Extended Address from the whitelist.
-        
+
             > whitelist remove dead00beef00cafe
             Done
         """
@@ -2853,13 +2853,13 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             value = self.prop_set_value(SPINEL_PROP_MAC_WHITELIST, None, None)
 
         elif args[0] == "add":
-            arr = hex_to_bytes(args[1])            
+            arr = hex_to_bytes(args[1])
             try:
                 rssi = int(args[2])
             except:
                 rssi = SPINEL_RSSI_OVERRIDE
             arr += pack('b', rssi)
-            value = self.prop_insert_value(SPINEL_PROP_MAC_WHITELIST, arr, 
+            value = self.prop_insert_value(SPINEL_PROP_MAC_WHITELIST, arr,
                                            str(len(arr))+'s')
 
         elif args[0] == "remove":
@@ -2867,7 +2867,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             arr += pack('b', SPINEL_RSSI_OVERRIDE)
             value = self.prop_remove_value(SPINEL_PROP_MAC_WHITELIST, arr,
                                            str(len(arr))+'s')
-        
+
         print("Done")
 
     def do_ncpll64(self, line):
@@ -2889,30 +2889,30 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             Control sideband tunnel interface.
 
         ncp-tun up
-        
+
             Bring up Thread TUN interface.
-        
+
             > ncp-tun up
             Done
 
         ncp-tun down
-        
+
             Bring down Thread TUN interface.
-        
+
             > ncp-tun down
             Done
 
         ncp-tun add <ipaddr>
-        
+
             Add an IPv6 address to the Thread TUN interface.
 
             > ncp-tun add 2001::dead:beef:cafe
             Done
 
         ncp-tun del <ipaddr>
-        
+
             Delete an IPv6 address from the Thread TUN interface.
-        
+
             > ncp-tun del 2001::dead:beef:cafe
             Done
 
@@ -2985,20 +2985,20 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             status 0x00
         """
         pass
-        
+
     def do_diagchannel(self, line):
         """
         diag-channel
 
             Get the IEEE 802.15.4 Channel value for diagnostics module.
-        
+
             > diag-channel
             channel: 11
 
         diag-channel <channel>
-        
+
             Set the IEEE 802.15.4 Channel value for diagnostics module.
-        
+
             > diag-channel 11
             set channel to 11
             status 0x00
@@ -3015,9 +3015,9 @@ class SpinelCliCmd(Cmd, SpinelCodec):
             tx power: -10 dBm
 
         diag-power <power>
-        
+
             Set the tx power value(dBm) for diagnostics module.
-        
+
             > diag-power -10
             set tx power to -10 dBm
             status 0x00
@@ -3029,7 +3029,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         diag-send <packets> <length>
 
             Transmit a fixed number of packets with fixed length.
-        
+
             > diag-send 20 100
             sending 0x14 packet(s), length 0x64
             status 0x00
@@ -3049,7 +3049,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         diag-repeat stop
 
             Stop repeated packet transmission.
-        
+
             > diag-repeat stop
             repeated packet transmission is stopped
             status 0x00
@@ -3061,7 +3061,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         diag-sleep
 
             Enter radio sleep mode.
-        
+
             > diag-sleep
             sleeping now...
         """
@@ -3072,7 +3072,7 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         diag-stats
 
             Print statistics during diagnostics mode.
-        
+
             > diag-stats
             received packets: 10
             sent packets: 10
@@ -3085,12 +3085,12 @@ class SpinelCliCmd(Cmd, SpinelCodec):
         diag stop
 
             Stop diagnostics mode and print statistics.
-        
+
             > diag-stop
             received packets: 10
             sent packets: 10
             first received packet: rssi=-65, lqi=101
-        
+
             stop diagnostics mode
             status 0x00
         """
@@ -3107,32 +3107,32 @@ if __name__ == "__main__":
     signal.signal(signal.SIGTRAP, goodbye)
     signal.signal(signal.SIGPIPE, goodbye)
 
-    args = sys.argv[1:] 
+    args = sys.argv[1:]
 
     optParser = optparse.OptionParser()
 
     optParser = optparse.OptionParser(usage=optparse.SUPPRESS_USAGE)
-    optParser.add_option("-u", "--uart", action="store", 
+    optParser.add_option("-u", "--uart", action="store",
                          dest="uart", type="string")
-    optParser.add_option("-p", "--pipe", action="store", 
+    optParser.add_option("-p", "--pipe", action="store",
                          dest="pipe", type="string")
-    optParser.add_option("-s", "--socket", action="store", 
+    optParser.add_option("-s", "--socket", action="store",
                          dest="socket", type="string")
-    optParser.add_option("-n", "--nodeid", action="store", 
+    optParser.add_option("-n", "--nodeid", action="store",
                          dest="nodeid", type="string", default="1")
     optParser.add_option("-q", "--quiet", action="store_true", dest="quiet")
     optParser.add_option("-v", "--verbose", action="store_false",dest="verbose")
-    optParser.add_option("-d", "--debug", action="store", 
+    optParser.add_option("-d", "--debug", action="store",
                          dest="debug", type="string")
 
     (options, remainingArgs) = optParser.parse_args(args)
-        
+
 
     # Set default stream to pipe
     streamType = 'p'
     streamDescriptor = "../../examples/apps/ncp/ot-ncp "+options.nodeid
 
-    if options.uart: 
+    if options.uart:
         streamType = 'u'
         streamDescriptor = options.uart
     elif options.socket:
@@ -3143,7 +3143,7 @@ if __name__ == "__main__":
         streamDescriptor = options.pipe
         if options.nodeid: streamDescriptor += " "+str(options.nodeid)
     else:
-        if len(remainingArgs) > 0: 
+        if len(remainingArgs) > 0:
             streamDescriptor = " ".join(remainingArgs)
 
     stream = StreamOpen(streamType, streamDescriptor)


### PR DESCRIPTION
This commit contains  only style change (there is no logic change)...
 It removes extra white space chars at the end of lines, and fixes typos in the comments.