### PR TITLE
Increase attach timeout to 5 seconds to account for random delays.

### DIFF
--- a/tests/scripts/thread-cert/Cert_5_1_02_ChildAddressTimeout.py
+++ b/tests/scripts/thread-cert/Cert_5_1_02_ChildAddressTimeout.py
@@ -79,15 +79,15 @@ class Cert_5_1_02_ChildAddressTimeout(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         self.nodes[SED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[SED].get_state(), 'child')
 
         ed_addrs = self.nodes[ED].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_1_03_RouterAddressReallocation.py
+++ b/tests/scripts/thread-cert/Cert_5_1_03_RouterAddressReallocation.py
@@ -73,11 +73,11 @@ class Cert_5_1_03_RouterAddressReallocation(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         rloc16 = self.nodes[ROUTER1].get_addr16()

--- a/tests/scripts/thread-cert/Cert_5_1_04_RouterAddressReallocation.py
+++ b/tests/scripts/thread-cert/Cert_5_1_04_RouterAddressReallocation.py
@@ -73,11 +73,11 @@ class Cert_5_1_04_RouterAddressReallocation(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         rloc16 = self.nodes[ROUTER1].get_addr16()

--- a/tests/scripts/thread-cert/Cert_5_1_05_RouterAddressTimeout.py
+++ b/tests/scripts/thread-cert/Cert_5_1_05_RouterAddressTimeout.py
@@ -63,7 +63,7 @@ class Cert_5_1_05_RouterAddressTimeout(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         rloc16 = self.nodes[ROUTER1].get_addr16()

--- a/tests/scripts/thread-cert/Cert_5_1_06_RemoveRouterId.py
+++ b/tests/scripts/thread-cert/Cert_5_1_06_RemoveRouterId.py
@@ -63,7 +63,7 @@ class Cert_5_1_06_RemoveRouterId(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
         rloc16 = self.nodes[ROUTER1].get_addr16()
 

--- a/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
+++ b/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
@@ -81,12 +81,12 @@ class Cert_5_1_07_MaxChildCount(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         for i in range(4, 14):
             self.nodes[i].start()
-            time.sleep(3)
+            time.sleep(5)
             self.assertEqual(self.nodes[i].get_state(), 'child')
 
             if i in range(4, 8):   
@@ -103,19 +103,19 @@ class Cert_5_1_07_MaxChildCount(unittest.TestCase):
                 time.sleep(1)
 
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'detached')
 
         self.nodes[ED].stop()
         for i in range(4, 14):
             self.nodes[i].stop()
-        time.sleep(3)
+        time.sleep(5)
         
         self.nodes[LEADER].stop()
         time.sleep(100)
         
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'detached')
         
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_5_1_09_REEDAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_5_1_09_REEDAttachConnectivity.py
@@ -91,15 +91,15 @@ class Cert_5_1_09_REEDAttachConnectivity(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[REED0].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[REED0].get_state(), 'child')
 
         self.nodes[REED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[REED1].get_state(), 'child')
 
         time.sleep(10)

--- a/tests/scripts/thread-cert/Cert_5_1_11_REEDAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_5_1_11_REEDAttachLinkQuality.py
@@ -81,11 +81,11 @@ class Cert_5_1_11_REEDAttachLinkQuality(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[REED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[REED].get_state(), 'child')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER1].start()

--- a/tests/scripts/thread-cert/Cert_5_1_12_NewRouterNeighborSync.py
+++ b/tests/scripts/thread-cert/Cert_5_1_12_NewRouterNeighborSync.py
@@ -71,11 +71,11 @@ class Cert_5_1_12_NewRouterSync(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         time.sleep(10)

--- a/tests/scripts/thread-cert/Cert_5_1_13_RouterReset.py
+++ b/tests/scripts/thread-cert/Cert_5_1_13_RouterReset.py
@@ -63,16 +63,16 @@ class Cert_5_1_13_RouterReset(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         rloc16 = self.nodes[ROUTER].get_addr16()
 
         self.nodes[ROUTER].stop();
-        time.sleep(3)
+        time.sleep(5)
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
         self.assertEqual(self.nodes[ROUTER].get_addr16(), rloc16)
 

--- a/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
@@ -102,7 +102,7 @@ class Cert_5_2_5_AddressQuery(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[BR1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[BR1].get_state(), 'router')
 
         self.nodes[BR1].add_prefix('2003::/64', 'paros')
@@ -110,23 +110,23 @@ class Cert_5_2_5_AddressQuery(unittest.TestCase):
         self.nodes[BR1].register_netdata()
 
         self.nodes[ED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[REED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[REED].get_state(), 'child')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ED2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED2].get_state(), 'child')
 
         self.nodes[ED3].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED3].get_state(), 'child')
 
         addrs = self.nodes[REED].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_3_01_LinkLocal.py
+++ b/tests/scripts/thread-cert/Cert_5_3_01_LinkLocal.py
@@ -63,7 +63,7 @@ class Cert_5_3_1_LinkLocal(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         addrs = self.nodes[ROUTER1].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_3_03_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_03_AddressQuery.py
@@ -89,7 +89,7 @@ class Cert_5_3_3_AddressQuery(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[BR].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[BR].get_state(), 'router')
 
         self.nodes[BR].add_prefix('2003::/64', 'paros')

--- a/tests/scripts/thread-cert/Cert_5_3_04_AddressMapCache.py
+++ b/tests/scripts/thread-cert/Cert_5_3_04_AddressMapCache.py
@@ -98,27 +98,27 @@ class Cert_5_3_4_AddressMapCache(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[SED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         self.nodes[ED2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED2].get_state(), 'child')
 
         self.nodes[ED3].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED3].get_state(), 'child')
 
         self.nodes[ED4].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED4].get_state(), 'child')
 
         self.nodes[ED5].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED5].get_state(), 'child')
 
         for i in range(4, 8):

--- a/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
+++ b/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
@@ -92,23 +92,23 @@ class Cert_5_3_7_DuplicateAddress(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[ED2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED2].get_state(), 'child')
 
         self.nodes[ED3].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED3].get_state(), 'child')
 
         self.nodes[ROUTER2].add_prefix('2001::/64', 'paros')
@@ -116,7 +116,7 @@ class Cert_5_3_7_DuplicateAddress(unittest.TestCase):
 
         self.nodes[ED1].add_ipaddr('2001::1')
         self.nodes[ED2].add_ipaddr('2001::1')
-        time.sleep(3)
+        time.sleep(5)
 
         self.assertTrue(self.nodes[ED3].ping('2001::1'))
 

--- a/tests/scripts/thread-cert/Cert_5_3_08_ChildAddressSet.py
+++ b/tests/scripts/thread-cert/Cert_5_3_08_ChildAddressSet.py
@@ -83,19 +83,19 @@ class Cert_5_3_8_ChildAddressSet(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[ED2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED2].get_state(), 'child')
 
         self.nodes[ED3].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED3].get_state(), 'child')
 
         self.nodes[ED4].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED4].get_state(), 'child')
 
         for i in range(2,6):

--- a/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
@@ -88,7 +88,7 @@ class Cert_5_3_10_AddressQuery(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[BR].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[BR].get_state(), 'router')
 
         self.nodes[BR].add_prefix('2003::/64', 'paros')
@@ -96,15 +96,15 @@ class Cert_5_3_10_AddressQuery(unittest.TestCase):
         self.nodes[BR].register_netdata()
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER3].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER3].get_state(), 'router')
 
         self.nodes[SED2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[SED2].get_state(), 'child')
 
         addrs = self.nodes[ROUTER3].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_5_01_LeaderReset.py
+++ b/tests/scripts/thread-cert/Cert_5_5_01_LeaderReset.py
@@ -63,13 +63,13 @@ class Cert_5_5_1_LeaderReset(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         rloc16 = self.nodes[LEADER].get_addr16()
 
         self.nodes[LEADER].stop();
-        time.sleep(3)
+        time.sleep(5)
 
         self.nodes[LEADER].start()
         time.sleep(5)

--- a/tests/scripts/thread-cert/Cert_5_5_02_LeaderReboot.py
+++ b/tests/scripts/thread-cert/Cert_5_5_02_LeaderReboot.py
@@ -71,11 +71,11 @@ class Cert_5_5_2_LeaderReboot(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         self.nodes[LEADER].stop()

--- a/tests/scripts/thread-cert/Cert_5_5_03_SplitMergeChildren.py
+++ b/tests/scripts/thread-cert/Cert_5_5_03_SplitMergeChildren.py
@@ -93,23 +93,23 @@ class Cert_5_5_3_SplitMergeChildren(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[ED2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED2].get_state(), 'child')
 
         self.nodes[ED3].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED3].get_state(), 'child')
 
         self.nodes[LEADER].stop()

--- a/tests/scripts/thread-cert/Cert_5_5_05_SplitMergeREED.py
+++ b/tests/scripts/thread-cert/Cert_5_5_05_SplitMergeREED.py
@@ -89,19 +89,19 @@ class Cert_5_5_5_SplitMergeREED(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER1].get_state(), 'leader')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[REED2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[REED2].get_state(), 'child')
 
         self.nodes[ROUTER3].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER3].get_state(), 'router')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER3].stop()

--- a/tests/scripts/thread-cert/Cert_5_5_06_SplitWeight.py
+++ b/tests/scripts/thread-cert/Cert_5_5_06_SplitWeight.py
@@ -74,11 +74,11 @@ class Cert_5_5_6_SplitWeight(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER1].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[LEADER1].stop()

--- a/tests/scripts/thread-cert/Cert_5_5_07_SplitMergeThreeWay.py
+++ b/tests/scripts/thread-cert/Cert_5_5_07_SplitMergeThreeWay.py
@@ -80,15 +80,15 @@ class Cert_5_5_7_SplitMergeThreeWay(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER1].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER3].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER3].get_state(), 'router')
 
         self.nodes[LEADER1].stop()

--- a/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
@@ -78,7 +78,7 @@ class Cert_5_6_2_NetworkDataRouterAsBr(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ROUTER].add_prefix('2001::/64', 'paros')
@@ -86,11 +86,11 @@ class Cert_5_6_2_NetworkDataRouterAsBr(unittest.TestCase):
         self.nodes[ROUTER].register_netdata()
 
         self.nodes[ED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[SED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         addrs = self.nodes[ED1].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
@@ -78,15 +78,15 @@ class Cert_5_6_4_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[SED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         self.nodes[ROUTER].add_prefix('2001::/64', 'paros')

--- a/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
@@ -78,15 +78,15 @@ class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[SED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         self.nodes[ROUTER].add_prefix('2001::/64', 'paros')

--- a/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
+++ b/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
@@ -78,15 +78,15 @@ class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[SED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         self.nodes[ROUTER].add_prefix('2001::/64', 'paros')

--- a/tests/scripts/thread-cert/Cert_5_6_07_NetworkDataRequestREED.py
+++ b/tests/scripts/thread-cert/Cert_5_6_07_NetworkDataRequestREED.py
@@ -71,11 +71,11 @@ class Cert_5_6_7_NetworkDataRequestREED(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[REED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[REED].get_state(), 'child')
 
         self.nodes[LEADER].remove_whitelist(self.nodes[REED].get_addr64())

--- a/tests/scripts/thread-cert/Cert_5_6_08_ContextManagement.py
+++ b/tests/scripts/thread-cert/Cert_5_6_08_ContextManagement.py
@@ -71,11 +71,11 @@ class Cert_5_6_8_ContextManagement(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         self.nodes[ROUTER].add_prefix('2001::/64', 'paros')

--- a/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
+++ b/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
@@ -86,19 +86,19 @@ class Cert_5_6_9_NetworkDataForwarding(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         self.nodes[SED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[SED].get_state(), 'child')
 
         self.nodes[LEADER].add_prefix('2001::/64', 'paros', 'med')

--- a/tests/scripts/thread-cert/Cert_5_8_01_KeySynchronization.py
+++ b/tests/scripts/thread-cert/Cert_5_8_01_KeySynchronization.py
@@ -62,7 +62,7 @@ class Cert_5_8_1_KeySynchronization(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         addrs = self.nodes[LEADER].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_8_02_KeyIncrement.py
+++ b/tests/scripts/thread-cert/Cert_5_8_02_KeyIncrement.py
@@ -62,7 +62,7 @@ class Cert_5_8_2_KeyIncrement(unittest.TestCase):
         self.nodes[LEADER].set_state('leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), "router")
 
         addrs = self.nodes[ROUTER].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_8_03_KeyIncrementRollOver.py
+++ b/tests/scripts/thread-cert/Cert_5_8_03_KeyIncrementRollOver.py
@@ -64,7 +64,7 @@ class Cert_5_8_3_KeyIncrementRollOver(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         addrs = self.nodes[ROUTER].get_addrs()

--- a/tests/scripts/thread-cert/Cert_6_1_01_RouterAttach.py
+++ b/tests/scripts/thread-cert/Cert_6_1_01_RouterAttach.py
@@ -62,7 +62,7 @@ class Cert_6_1_1_RouterAttach(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_6_1_02_REEDAttach.py
+++ b/tests/scripts/thread-cert/Cert_6_1_02_REEDAttach.py
@@ -70,7 +70,7 @@ class Cert_6_1_2_REEDAttach(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[REED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[REED].get_state(), 'child')
 
         self.nodes[ED].start()

--- a/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
@@ -91,11 +91,11 @@ class Cert_6_1_3_RouterAttachConnectivity(unittest.TestCase):
 
         for i in range(2, 5):
             self.nodes[i].start()
-            time.sleep(3)
+            time.sleep(5)
             self.assertEqual(self.nodes[i].get_state(), 'router')
 
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         addrs = self.nodes[ED].get_addrs()
         for addr in addrs:
             self.assertTrue(self.nodes[ROUTER3].ping(addr))

--- a/tests/scripts/thread-cert/Cert_6_1_04_REEDAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_6_1_04_REEDAttachConnectivity.py
@@ -90,15 +90,15 @@ class Cert_6_1_4_REEDAttachConnectivity(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[REED0].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[REED0].get_state(), 'child')
 
         self.nodes[REED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[REED1].get_state(), 'child')
 
         time.sleep(10)

--- a/tests/scripts/thread-cert/Cert_6_1_05_RouterAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_6_1_05_RouterAttachLinkQuality.py
@@ -80,15 +80,15 @@ class Cert_6_1_5_RouterAttachLinkQuality(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_6_1_06_REEDAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_6_1_06_REEDAttachLinkQuality.py
@@ -80,11 +80,11 @@ class Cert_6_1_6_REEDAttachLinkQuality(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[REED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[REED].get_state(), 'child')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ED].start()

--- a/tests/scripts/thread-cert/Cert_6_2_01_NewPartition.py
+++ b/tests/scripts/thread-cert/Cert_6_2_01_NewPartition.py
@@ -70,7 +70,7 @@ class Cert_6_2_1_NewPartition(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ED].start()

--- a/tests/scripts/thread-cert/Cert_6_2_02_NewPartition.py
+++ b/tests/scripts/thread-cert/Cert_6_2_02_NewPartition.py
@@ -81,11 +81,11 @@ class Cert_6_2_2_NewPartition(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ED].start()

--- a/tests/scripts/thread-cert/Cert_6_3_01_OrphanReattach.py
+++ b/tests/scripts/thread-cert/Cert_6_3_01_OrphanReattach.py
@@ -71,7 +71,7 @@ class Cert_6_3_1_OrphanReattach(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED].start()

--- a/tests/scripts/thread-cert/Cert_6_3_02_NetworkDataUpdate.py
+++ b/tests/scripts/thread-cert/Cert_6_3_02_NetworkDataUpdate.py
@@ -63,12 +63,12 @@ class Cert_5_6_2_NetworkDataUpdate(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         self.nodes[LEADER].add_prefix('2001::/64', 'paros')
         self.nodes[LEADER].register_netdata()
-        time.sleep(3)
+        time.sleep(5)
 
         addrs = self.nodes[ED].get_addrs()
         self.assertTrue(any('2001' in addr[0:4] for addr in addrs))
@@ -81,7 +81,7 @@ class Cert_5_6_2_NetworkDataUpdate(unittest.TestCase):
 
         self.nodes[LEADER].add_prefix('2002::/64', 'paros')
         self.nodes[LEADER].register_netdata()
-        time.sleep(3)
+        time.sleep(5)
 
         self.nodes[LEADER].add_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ED].add_whitelist(self.nodes[LEADER].get_addr64())

--- a/tests/scripts/thread-cert/Cert_6_4_01_LinkLocal.py
+++ b/tests/scripts/thread-cert/Cert_6_4_01_LinkLocal.py
@@ -62,7 +62,7 @@ class Cert_6_4_1_LinkLocal(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         addrs = self.nodes[ED].get_addrs()

--- a/tests/scripts/thread-cert/Cert_6_4_02_RealmLocal.py
+++ b/tests/scripts/thread-cert/Cert_6_4_02_RealmLocal.py
@@ -70,11 +70,11 @@ class Cert_5_3_2_RealmLocal(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         addrs = self.nodes[ED].get_addrs()

--- a/tests/scripts/thread-cert/Cert_6_5_01_ChildResetSynchronize.py
+++ b/tests/scripts/thread-cert/Cert_6_5_01_ChildResetSynchronize.py
@@ -63,7 +63,7 @@ class Cert_6_5_1_ChildResetSynchronize(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         self.nodes[ED].stop()
@@ -71,13 +71,13 @@ class Cert_6_5_1_ChildResetSynchronize(unittest.TestCase):
 
         self.nodes[ED].set_timeout(100)
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         self.nodes[ED].stop()
-        time.sleep(3)
+        time.sleep(5)
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         addrs = self.nodes[ED].get_addrs()

--- a/tests/scripts/thread-cert/Cert_6_5_02_ChildResetReattach.py
+++ b/tests/scripts/thread-cert/Cert_6_5_02_ChildResetReattach.py
@@ -62,17 +62,17 @@ class Cert_6_5_2_ChildResetReattach(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         self.nodes[LEADER].remove_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ED].remove_whitelist(self.nodes[LEADER].get_addr64())
 
         self.nodes[ED].stop()
-        time.sleep(3)
+        time.sleep(5)
         self.nodes[ED].start()
 
-        time.sleep(3)
+        time.sleep(5)
         self.nodes[LEADER].add_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ED].add_whitelist(self.nodes[LEADER].get_addr64())
         time.sleep(5)

--- a/tests/scripts/thread-cert/Cert_6_6_01_KeyIncrement.py
+++ b/tests/scripts/thread-cert/Cert_6_6_01_KeyIncrement.py
@@ -61,7 +61,7 @@ class Cert_6_6_1_KeyIncrement(unittest.TestCase):
         self.nodes[LEADER].set_state('leader')
 
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), "child")
 
         addrs = self.nodes[ED].get_addrs()

--- a/tests/scripts/thread-cert/Cert_6_6_02_KeyIncrementRollOver.py
+++ b/tests/scripts/thread-cert/Cert_6_6_02_KeyIncrementRollOver.py
@@ -63,7 +63,7 @@ class Cert_6_6_2_KeyIncrement1(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ED].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         addrs = self.nodes[ED].get_addrs()

--- a/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
@@ -82,15 +82,15 @@ class Cert_7_1_1_BorderRouterAsLeader(unittest.TestCase):
         self.nodes[LEADER].register_netdata()
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[SED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         self.nodes[ED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         addrs = self.nodes[SED1].get_addrs()

--- a/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
@@ -78,7 +78,7 @@ class Cert_7_1_2_BorderRouterAsRouter(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ROUTER].add_prefix('2001::/64', 'paros')
@@ -86,11 +86,11 @@ class Cert_7_1_2_BorderRouterAsRouter(unittest.TestCase):
         self.nodes[ROUTER].register_netdata()
 
         self.nodes[ED2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED2].get_state(), 'child')
 
         self.nodes[SED2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[SED2].get_state(), 'child')
 
         addrs = self.nodes[ED2].get_addrs()

--- a/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
@@ -78,21 +78,21 @@ class Cert_7_1_3_BorderRouterAsLeader(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[SED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         self.nodes[ED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[LEADER].add_prefix('2001::/64', 'paros')
         self.nodes[LEADER].add_prefix('2002::/64', 'paro')
         self.nodes[LEADER].register_netdata()
-        time.sleep(3)
+        time.sleep(5)
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001' in addr[0:4] for addr in addrs))

--- a/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
@@ -78,21 +78,21 @@ class Cert_7_1_4_BorderRouterAsRouter(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED2].get_state(), 'child')
 
         self.nodes[SED2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[SED2].get_state(), 'child')
 
         self.nodes[ROUTER].add_prefix('2001::/64', 'paros')
         self.nodes[ROUTER].add_prefix('2002::/64', 'paro')
         self.nodes[ROUTER].register_netdata()
-        time.sleep(3)
+        time.sleep(5)
 
         addrs = self.nodes[ED2].get_addrs()
         self.assertTrue(any('2001' in addr[0:4] for addr in addrs))

--- a/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
@@ -78,21 +78,21 @@ class Cert_7_1_5_BorderRouterAsRouter(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED2].get_state(), 'child')
 
         self.nodes[SED2].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[SED2].get_state(), 'child')
 
         self.nodes[ROUTER].add_prefix('2001::/64', 'paros')
         self.nodes[ROUTER].add_prefix('2002::/64', 'paro')
         self.nodes[ROUTER].register_netdata()
-        time.sleep(3)
+        time.sleep(5)
 
         addrs = self.nodes[ED2].get_addrs()
         self.assertTrue(any('2001' in addr[0:4] for addr in addrs))
@@ -110,7 +110,7 @@ class Cert_7_1_5_BorderRouterAsRouter(unittest.TestCase):
 
         self.nodes[ROUTER].add_prefix('2003::/64', 'paros')
         self.nodes[ROUTER].register_netdata()
-        time.sleep(3)
+        time.sleep(5)
 
         addrs = self.nodes[ED2].get_addrs()
         self.assertTrue(any('2001' in addr[0:4] for addr in addrs))

--- a/tests/scripts/thread-cert/Cert_8_1_01_Commissioning.py
+++ b/tests/scripts/thread-cert/Cert_8_1_01_Commissioning.py
@@ -57,7 +57,7 @@ class Cert_8_1_01_Commissioning(unittest.TestCase):
     def test(self):
         self.nodes[COMMISSIONER].interface_up()
         self.nodes[COMMISSIONER].thread_start()
-        time.sleep(4)
+        time.sleep(5)
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'leader')
         self.nodes[COMMISSIONER].commissioner_start('openthread')
 
@@ -67,7 +67,7 @@ class Cert_8_1_01_Commissioning(unittest.TestCase):
         self.assertEqual(self.nodes[JOINER].get_masterkey(), self.nodes[COMMISSIONER].get_masterkey())
 
         self.nodes[JOINER].thread_start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[JOINER].get_state(), 'router')
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_8_1_02_Commissioning.py
+++ b/tests/scripts/thread-cert/Cert_8_1_02_Commissioning.py
@@ -57,7 +57,7 @@ class Cert_8_1_02_Commissioning(unittest.TestCase):
     def test(self):
         self.nodes[COMMISSIONER].interface_up()
         self.nodes[COMMISSIONER].thread_start()
-        time.sleep(4)
+        time.sleep(5)
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'leader')
         self.nodes[COMMISSIONER].commissioner_start('openthread')
 

--- a/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
+++ b/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
@@ -78,15 +78,15 @@ class Cert_9_2_13_EnergyScan(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[COMMISSIONER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'router')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         ipaddrs = self.nodes[ROUTER1].get_addrs()

--- a/tests/scripts/thread-cert/Cert_9_2_14_PanIdQuery.py
+++ b/tests/scripts/thread-cert/Cert_9_2_14_PanIdQuery.py
@@ -78,11 +78,11 @@ class Cert_9_2_14_PanIdQuery(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER1].get_state(), 'leader')
 
         self.nodes[COMMISSIONER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'router')
 
         self.nodes[ROUTER1].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[LEADER2].start()

--- a/tests/scripts/thread-cert/Test_MacScan.py
+++ b/tests/scripts/thread-cert/Test_MacScan.py
@@ -66,7 +66,7 @@ class Test_MacScan(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(3)
+        time.sleep(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         results = self.nodes[LEADER].scan()


### PR DESCRIPTION
This PR addresses issues in the `thread-cert` tests caused by #554 as noted in #697.