### PR TITLE
Add OpenThread APIs for retrieving neighbor info from neighor table

### DIFF
--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -672,6 +672,30 @@ typedef enum
 } otDeviceRole;
 
 /**
+ * This structure holds diagnostic information for a neighboring Thread node
+ *
+ */
+typedef struct
+{
+    otExtAddress   mExtAddress;            ///< IEEE 802.15.4 Extended Address
+    uint32_t       mAge;                   ///< Time last heard
+    uint16_t       mRloc16;                ///< RLOC16
+    uint32_t       mLinkFrameCounter;      ///< Link Frame Counter
+    uint32_t       mMleFrameCounter;       ///< MLE Frame Counter
+    uint8_t        mLinkQualityIn;         ///< Link Quality In
+    int8_t         mAverageRssi;           ///< Average RSSI
+    bool           mRxOnWhenIdle : 1;      ///< rx-on-when-idle
+    bool           mSecureDataRequest : 1; ///< Secure Data Requests
+    bool           mFullFunction : 1;      ///< Full Function Device
+    bool           mFullNetworkData : 1;   ///< Full Network Data
+    bool           mIsChild : 1;           ///< Is the neighbor a child
+} otNeighborInfo;
+
+#define OT_NEIGHBOR_INFO_ITERATOR_INIT  0  ///< Initializer for otNeighborInfoIterator.
+
+typedef int16_t otNeighborInfoIterator;    ///< Used to iterate through neighbor table.
+
+/**
  * This structure holds diagnostic information for a Thread Child
  *
  */

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -686,7 +686,8 @@ ThreadError otSetNetworkName(otInstance *aInstance, const char *aNetworkName);
  *
  * @param[in]     aInstance  A pointer to an OpenThread instance.
  * @param[in]     aLocal     TRUE to retrieve from the local Network Data, FALSE for partition's Network Data
- * @param[inout]  aIterator  A pointer to the Network Data iterator context.
+ * @param[inout]  aIterator  A pointer to the Network Data iterator context. To get the first on-mesh entry
+                             it should be set to OT_NETWORK_DATA_ITERATOR_INIT.
  * @param[out]    aConfig    A pointer to where the On Mesh Prefix information will be placed.
  *
  * @retval kThreadError_None      Successfully found the next On Mesh prefix.
@@ -1611,6 +1612,21 @@ ThreadError otGetChildInfoById(otInstance *aInstance, uint16_t aChildId, otChild
  *
  */
 ThreadError otGetChildInfoByIndex(otInstance *aInstance, uint8_t aChildIndex, otChildInfo *aChildInfo);
+
+/**
+ * This function gets the next neighbor information. It is used to go through the entries of
+ * the neighbor table.
+ *
+ * @param[in]     aInstance  A pointer to an OpenThread instance.
+ * @param[inout]  aIterator  A pointer to the iterator context. To get the first neighbor entry
+                             it should be set to OT_NEIGHBOR_INFO_ITERATOR_INIT.
+ * @param[out]    aInfo      A pointer to where the neighbor information will be placed.
+ *
+ * @retval kThreadError_None      Successfully found the next neighbor entry in table.
+ * @retval kThreadError_NotFound  No subsequent neighbor entry exists in the table.
+ *
+ */
+ThreadError otGetNextNeighborInfo(otInstance *aInstance, otNeighborInfoIterator *aIterator, otNeighborInfo *aInfo);
 
 /**
  * Get the device role.

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -728,6 +728,16 @@ exit:
     return error;
 }
 
+ThreadError otGetNextNeighborInfo(otInstance *, otNeighborInfoIterator *aIterator, otNeighborInfo *aInfo)
+{
+    ThreadError error = kThreadError_NotImplemented;
+
+    (void)aIterator;
+    (void)aInfo;
+
+    return error;
+}
+
 otDeviceRole otGetDeviceRole(otInstance *)
 {
     otDeviceRole rval = kDeviceRoleDisabled;


### PR DESCRIPTION
This commit adds new API for getting neighbor info from neighbor table.
It uses an iterator context to get elements of the table (similar to API to get on-mesh prefixes). This commit does not implement the APIs in OT though.

 My intention for this PR is to have the API reviewed/approved (and hopefully merged in) and then add the implementation and support for it on NCP and wpantund.
