### PR TITLE
Operational Dataset management cleanup.

### DIFF
--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -1310,7 +1310,7 @@ ThreadError otGetActiveDataset(otInstance *, otOperationalDataset *aDataset)
 
     VerifyOrExit(aDataset != NULL, error = kThreadError_InvalidArgs);
 
-    sThreadNetif->GetActiveDataset().Get(*aDataset);
+    sThreadNetif->GetActiveDataset().GetLocal().Get(*aDataset);
 
 exit:
     return error;
@@ -1334,7 +1334,7 @@ ThreadError otGetPendingDataset(otInstance *, otOperationalDataset *aDataset)
 
     VerifyOrExit(aDataset != NULL, error = kThreadError_InvalidArgs);
 
-    sThreadNetif->GetPendingDataset().Get(*aDataset);
+    sThreadNetif->GetPendingDataset().GetLocal().Get(*aDataset);
 
 exit:
     return error;

--- a/src/core/thread/meshcop_dataset.cpp
+++ b/src/core/thread/meshcop_dataset.cpp
@@ -92,7 +92,7 @@ exit:
     return rval;
 }
 
-void Dataset::Get(otOperationalDataset &aDataset)
+void Dataset::Get(otOperationalDataset &aDataset) const
 {
     const Tlv *cur = reinterpret_cast<const Tlv *>(mTlvs);
     const Tlv *end = reinterpret_cast<const Tlv *>(mTlvs + mLength);
@@ -227,6 +227,20 @@ void Dataset::Get(otOperationalDataset &aDataset)
 
         cur = cur->GetNext();
     }
+}
+
+ThreadError Dataset::Set(const Dataset &aDataset)
+{
+    memcpy(mTlvs, aDataset.mTlvs, aDataset.mLength);
+    mLength = aDataset.mLength;
+
+    if (mType == Tlv::kActiveTimestamp)
+    {
+        Remove(Tlv::kPendingTimestamp);
+        Remove(Tlv::kDelayTimer);
+    }
+
+    return kThreadError_None;
 }
 
 ThreadError Dataset::Set(const otOperationalDataset &aDataset)

--- a/src/core/thread/meshcop_dataset.hpp
+++ b/src/core/thread/meshcop_dataset.hpp
@@ -92,7 +92,7 @@ public:
      * This method converts the TLV representation to structure representation.
      *
      */
-    void Get(otOperationalDataset &aDataset);
+    void Get(otOperationalDataset &aDataset) const;
 
     /**
      * This method returns the Dataset size in bytes.
@@ -128,6 +128,8 @@ public:
     ThreadError Set(const Tlv &aTlv);
 
     ThreadError Set(const Message &aMessage, uint16_t aOffset, uint8_t aLength);
+
+    ThreadError Set(const Dataset &aDataset);
 
     ThreadError Set(const otOperationalDataset &aDataset);
 

--- a/src/core/thread/meshcop_dataset_manager.hpp
+++ b/src/core/thread/meshcop_dataset_manager.hpp
@@ -57,7 +57,6 @@ public:
     void StopLeader(void);
 
     Dataset &GetLocal(void) { return mLocal; }
-
     Dataset &GetNetwork(void) { return mNetwork; }
 
     ThreadError SendSetRequest(const otOperationalDataset &aDataset, const uint8_t *aTlvs, uint8_t aLength);
@@ -71,6 +70,8 @@ protected:
     };
 
     DatasetManager(ThreadNetif &aThreadNetif, const Tlv::Type aType, const char *aUriSet, const char *aUriGet);
+
+    ThreadError Set(const otOperationalDataset &aDataset, uint8_t &aFlags);
 
     ThreadError Set(const Dataset &aDataset, uint8_t &aFlags);
 
@@ -99,6 +100,8 @@ private:
     static void HandleTimer(void *aContext);
     void HandleTimer(void);
 
+    void HandleNetworkUpdate(uint8_t &aFlags);
+
     ThreadError Register(void);
     void SendSetResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo, StateTlv::State aState);
     void SendGetResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
@@ -123,11 +126,9 @@ class ActiveDataset: public DatasetManager
 public:
     ActiveDataset(ThreadNetif &aThreadNetif);
 
-    void Get(otOperationalDataset &aDataset);
+    ThreadError Set(const otOperationalDataset &aDataset);
 
     ThreadError Set(const Dataset &aDataset);
-
-    ThreadError Set(const otOperationalDataset &aDataset);
 
     ThreadError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
 
@@ -140,10 +141,6 @@ public:
     PendingDataset(ThreadNetif &aThreadNetif);
 
     void StartLeader(void);
-
-    void Get(otOperationalDataset &aDataset);
-
-    ThreadError Set(const Dataset &aDataset);
 
     ThreadError Set(const otOperationalDataset &aDataset);
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1748,7 +1748,7 @@ ThreadError Mle::HandleDataResponse(const Message &aMessage, const Ip6::MessageI
         if (Tlv::GetOffset(aMessage, Tlv::kPendingDataset, offset) == kThreadError_None)
         {
             aMessage.Read(offset, sizeof(tlv), &tlv);
-            mNetif.GetPendingDataset().Set(activeTimestamp, aMessage, offset + sizeof(tlv), tlv.GetLength());
+            mNetif.GetPendingDataset().Set(pendingTimestamp, aMessage, offset + sizeof(tlv), tlv.GetLength());
         }
         else
         {


### PR DESCRIPTION
- Reduce stack pressure when setting datasets via the API.
- Remove pending timestamp and delay timer from active dataset when updating.
- Always manage delay timer based on the network copy of the pending dataset.