### PR TITLE
Miscellaneous MAC cleanup.

### DIFF
--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -439,7 +439,7 @@ ThreadError otPlatRadioTransmit(otInstance *aInstance)
     ThreadError error = kThreadError_Busy;
     (void)aInstance;
 
-    if ((sState == kStateTransmit && !sAckWait) || sState == kStateReceive)
+    if (sState == kStateReceive)
     {
         error = kThreadError_None;
         sState = kStateTransmit;

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -74,7 +74,6 @@ void Mac::StartCsmaBackoff(void)
 }
 
 Mac::Mac(ThreadNetif &aThreadNetif):
-    mBeginTransmit(aThreadNetif.GetIp6().mTaskletScheduler, &Mac::HandleBeginTransmit, this),
     mMacTimer(aThreadNetif.GetIp6().mTimerScheduler, &Mac::HandleMacTimer, this),
     mBackoffTimer(aThreadNetif.GetIp6().mTimerScheduler, &Mac::HandleBeginTransmit, this),
     mReceiveTimer(aThreadNetif.GetIp6().mTimerScheduler, &Mac::HandleReceiveTimer, this),
@@ -221,8 +220,7 @@ void Mac::StartEnergyScan(void)
 
 void Mac::HandleEnergyScanSampleRssi(void *aContext)
 {
-    Mac *obj = static_cast<Mac *>(aContext);
-    obj->HandleEnergyScanSampleRssi();
+    static_cast<Mac *>(aContext)->HandleEnergyScanSampleRssi();
 }
 
 void Mac::HandleEnergyScanSampleRssi(void)
@@ -273,7 +271,11 @@ bool Mac::GetRxOnWhenIdle(void) const
 void Mac::SetRxOnWhenIdle(bool aRxOnWhenIdle)
 {
     mRxOnWhenIdle = aRxOnWhenIdle;
-    NextOperation();
+
+    if (mState == kStateIdle)
+    {
+        NextOperation();
+    }
 }
 
 const ExtAddress *Mac::GetExtAddress(void) const
@@ -332,6 +334,12 @@ uint8_t Mac::GetChannel(void) const
 ThreadError Mac::SetChannel(uint8_t aChannel)
 {
     mChannel = aChannel;
+
+    if (mState == kStateIdle)
+    {
+        NextOperation();
+    }
+
     return kThreadError_None;
 }
 
@@ -463,6 +471,8 @@ void Mac::ScheduleNextTransmission(void)
     {
         mState = kStateIdle;
     }
+
+    NextOperation();
 }
 
 void Mac::GenerateNonce(const ExtAddress &aAddress, uint32_t aFrameCounter, uint8_t aSecurityLevel, uint8_t *aNonce)
@@ -598,12 +608,6 @@ void Mac::HandleBeginTransmit(void)
     Frame &sendFrame(*static_cast<Frame *>(otPlatRadioGetTransmitBuffer(NULL)));
     ThreadError error = kThreadError_None;
 
-    if (otPlatRadioReceive(NULL, mChannel) != kThreadError_None)
-    {
-        mBeginTransmit.Post();
-        ExitNow();
-    }
-
     sendFrame.SetPower(mMaxTransmitPower);
 
     switch (mState)
@@ -640,7 +644,10 @@ void Mac::HandleBeginTransmit(void)
         sendFrame.SetPower(mMaxTransmitPower);
     }
 
-    SuccessOrExit(error = otPlatRadioTransmit(NULL));
+    error = otPlatRadioReceive(NULL, sendFrame.GetChannel());
+    assert(error == kThreadError_None);
+    error = otPlatRadioTransmit(NULL);
+    assert(error == kThreadError_None);
 
     if (sendFrame.GetAckRequest() && !(otPlatRadioGetCaps(NULL) & kRadioCapsAckTimeout))
     {
@@ -706,7 +713,7 @@ void Mac::TransmitDoneTask(bool aRxPending, ThreadError aError)
     }
 
 exit:
-    NextOperation();
+    return;
 }
 
 void Mac::HandleMacTimer(void *aContext)
@@ -779,7 +786,7 @@ void Mac::HandleMacTimer(void)
     }
 
 exit:
-    NextOperation();
+    return;
 }
 
 void Mac::HandleReceiveTimer(void *aContext)
@@ -790,7 +797,11 @@ void Mac::HandleReceiveTimer(void *aContext)
 void Mac::HandleReceiveTimer(void)
 {
     otLogInfoMac("data poll timeout!\n");
-    NextOperation();
+
+    if (mState == kStateIdle)
+    {
+        NextOperation();
+    }
 }
 
 void Mac::SentFrame(ThreadError aError)
@@ -1257,11 +1268,10 @@ void Mac::SetPromiscuous(bool aPromiscuous)
 {
     otPlatRadioSetPromiscuous(NULL, aPromiscuous);
 
-    SuccessOrExit(otPlatRadioReceive(NULL, mChannel));
-    NextOperation();
-
-exit:
-    return;
+    if (mState == kStateIdle)
+    {
+        NextOperation();
+    }
 }
 
 Whitelist &Mac::GetWhitelist(void)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -576,7 +576,6 @@ private:
     void StartCsmaBackoff(void);
     ThreadError Scan(ScanType aType, uint32_t aScanChannels, uint16_t aScanDuration, void *aContext);
 
-    Tasklet mBeginTransmit;
     Timer mMacTimer;
     Timer mBackoffTimer;
     Timer mReceiveTimer;


### PR DESCRIPTION
- Call otPlatRadioReceive() on SetChannel().
- Only call NextOperation() in the idle state.
- Call otPlatRadioReceive() with the proper channel in HandleBeginTransmit().
- Remove unnecessary mBeginTransmit tasklet.