### PR TITLE
Increase cli rx buffer size

### DIFF
--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -449,7 +449,7 @@ ThreadError Dataset::ProcessMgmtSetCommand(otInstance *aInstance, int argc, char
 {
     ThreadError error = kThreadError_None;
     otOperationalDataset dataset;
-    uint8_t tlvs[32];
+    uint8_t tlvs[128];
     long value;
     int length = 0;
     otIp6Address prefix;
@@ -489,7 +489,7 @@ ThreadError Dataset::ProcessMgmtSetCommand(otInstance *aInstance, int argc, char
             VerifyOrExit((length = static_cast<int>(strlen(argv[++index]))) <= OT_NETWORK_NAME_MAX_SIZE,
                          error = kThreadError_Parse);
             memset(&dataset.mNetworkName, 0, sizeof(sDataset.mNetworkName));
-            memcpy(dataset.mNetworkName.m8, argv[0], static_cast<size_t>(length));
+            memcpy(dataset.mNetworkName.m8, argv[index], static_cast<size_t>(length));
             length = 0;
         }
         else if (strcmp(argv[index], "extpanid") == 0)

--- a/src/cli/cli_uart.hpp
+++ b/src/cli/cli_uart.hpp
@@ -97,7 +97,7 @@ public:
 private:
     enum
     {
-        kRxBufferSize = 128,
+        kRxBufferSize = 512,
         kTxBufferSize = 1024,
         kMaxLineLength = 128,
     };


### PR DESCRIPTION
- increase cli rx buffer size
   The rx buffer is not enough to store the command while doing MGMT_ACTIVE_SET certificate test.
   This is not a good solution to solve this, but can help to solve this problem quickly.
    I will update it, if we have better ways to solve this.
- fix networkname cli