### PR TITLE
Append CoAP Token and Message ID field for ED/PANID query/report/conflict message.

### DIFF
--- a/src/core/meshcop/energy_scan_client.hpp
+++ b/src/core/meshcop/energy_scan_client.hpp
@@ -38,7 +38,6 @@
 #include <openthread-types.h>
 #include <commissioning/commissioner.h>
 #include <coap/coap_server.hpp>
-#include <common/timer.hpp>
 #include <net/ip6_address.hpp>
 #include <net/udp6.hpp>
 
@@ -82,9 +81,6 @@ private:
                              const Ip6::MessageInfo &aMessageInfo);
     void HandleReport(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleTimer(void *aContext);
-    void HandleTimer(void);
-
     static void HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo);
 
     ThreadError SendResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aRequestMessageInfo);
@@ -94,9 +90,10 @@ private:
 
     Coap::Resource mEnergyScan;
     Ip6::UdpSocket mSocket;
-    Timer mTimer;
 
     Coap::Server &mCoapServer;
+    uint8_t mCoapToken[2];
+    uint16_t mCoapMessageId;
     ThreadNetif &mNetif;
 };
 

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -35,6 +35,7 @@
 #include <common/code_utils.hpp>
 #include <common/debug.hpp>
 #include <common/logging.hpp>
+#include <platform/random.h>
 #include <meshcop/panid_query_client.hpp>
 #include <thread/meshcop_tlvs.hpp>
 #include <thread/thread_netif.hpp>
@@ -45,12 +46,13 @@ namespace Thread {
 PanIdQueryClient::PanIdQueryClient(ThreadNetif &aThreadNetif) :
     mPanIdQuery(OPENTHREAD_URI_PANID_CONFLICT, &PanIdQueryClient::HandleConflict, this),
     mSocket(aThreadNetif.GetIp6().mUdp),
-    mTimer(aThreadNetif.GetIp6().mTimerScheduler, &PanIdQueryClient::HandleTimer, this),
     mCoapServer(aThreadNetif.GetCoapServer()),
     mNetif(aThreadNetif)
 {
     mCoapServer.AddResource(mPanIdQuery);
     mSocket.Open(HandleUdpReceive, this);
+
+    mCoapMessageId = static_cast<uint8_t>(otPlatRandomGet());
 }
 
 ThreadError PanIdQueryClient::SendQuery(uint16_t aPanId, uint32_t aChannelMask, const Ip6::Address &aAddress,
@@ -69,11 +71,16 @@ ThreadError PanIdQueryClient::SendQuery(uint16_t aPanId, uint32_t aChannelMask, 
     Ip6::MessageInfo messageInfo;
     Message *message;
 
+    for (size_t i = 0; i < sizeof(mCoapToken); i++)
+    {
+        mCoapToken[i] = static_cast<uint8_t>(otPlatRandomGet());
+    }
+
     header.Init();
     header.SetType(aAddress.IsMulticast() ? Coap::Header::kTypeNonConfirmable : Coap::Header::kTypeConfirmable);
     header.SetCode(Coap::Header::kCodePost);
-    header.SetMessageId(0);
-    header.SetToken(NULL, 0);
+    header.SetMessageId(++mCoapMessageId);
+    header.SetToken(mCoapToken, sizeof(mCoapToken));
     header.AppendUriPathOptions(OPENTHREAD_URI_PANID_QUERY);
     header.Finalize();
 
@@ -201,15 +208,6 @@ exit:
     }
 
     return error;
-}
-
-void PanIdQueryClient::HandleTimer(void *aContext)
-{
-    static_cast<PanIdQueryClient *>(aContext)->HandleTimer();
-}
-
-void PanIdQueryClient::HandleTimer(void)
-{
 }
 
 void PanIdQueryClient::HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo)

--- a/src/core/meshcop/panid_query_client.hpp
+++ b/src/core/meshcop/panid_query_client.hpp
@@ -38,7 +38,6 @@
 #include <openthread-types.h>
 #include <commissioning/commissioner.h>
 #include <coap/coap_server.hpp>
-#include <common/timer.hpp>
 #include <net/ip6_address.hpp>
 #include <net/udp6.hpp>
 
@@ -80,9 +79,6 @@ private:
                                const Ip6::MessageInfo &aMessageInfo);
     void HandleConflict(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleTimer(void *aContext);
-    void HandleTimer(void);
-
     static void HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo);
 
     ThreadError SendConflictResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aRequestMessageInfo);
@@ -92,9 +88,10 @@ private:
 
     Coap::Resource mPanIdQuery;
     Ip6::UdpSocket mSocket;
-    Timer mTimer;
 
     Coap::Server &mCoapServer;
+    uint8_t mCoapToken[2];
+    uint16_t mCoapMessageId;
     ThreadNetif &mNetif;
 };
 

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -35,6 +35,7 @@
 #include <common/code_utils.hpp>
 #include <common/debug.hpp>
 #include <common/logging.hpp>
+#include <platform/random.h>
 #include <thread/meshcop_tlvs.hpp>
 #include <thread/energy_scan_server.hpp>
 #include <thread/thread_netif.hpp>
@@ -55,6 +56,8 @@ EnergyScanServer::EnergyScanServer(ThreadNetif &aThreadNetif) :
 
     mCoapServer.AddResource(mEnergyScan);
     mSocket.Open(HandleUdpReceive, this);
+
+    mCoapMessageId = static_cast<uint8_t>(otPlatRandomGet());
 }
 
 void EnergyScanServer::HandleRequest(void *aContext, Coap::Header &aHeader, Message &aMessage,
@@ -231,8 +234,8 @@ ThreadError EnergyScanServer::SendReport(void)
     header.Init();
     header.SetType(Coap::Header::kTypeConfirmable);
     header.SetCode(Coap::Header::kCodePost);
-    header.SetMessageId(0);
-    header.SetToken(NULL, 0);
+    header.SetMessageId(++mCoapMessageId);
+    header.SetToken(mCoapToken, sizeof(mCoapToken));
     header.AppendUriPathOptions(OPENTHREAD_URI_ENERGY_REPORT);
     header.Finalize();
 
@@ -272,6 +275,7 @@ exit:
 
 void EnergyScanServer::HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo)
 {
+    otLogInfoMeshCoP("received scan report response\r\n");
     (void)aContext;
     (void)aMessage;
     (void)aMessageInfo;

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -105,6 +105,8 @@ private:
     Ip6::NetifCallback mNetifCallback;
 
     Coap::Server &mCoapServer;
+    uint8_t mCoapToken[2];
+    uint16_t mCoapMessageId;
     ThreadNetif &mNetif;
 };
 

--- a/src/core/thread/panid_query_server.hpp
+++ b/src/core/thread/panid_query_server.hpp
@@ -92,6 +92,8 @@ private:
     Timer mTimer;
 
     Coap::Server &mCoapServer;
+    uint8_t mCoapToken[2];
+    uint16_t mCoapMessageId;
     ThreadNetif &mNetif;
 };
 


### PR DESCRIPTION
Test case 9.2.14 Harness initiates MGMT_PANID_QUERY.qry unicast to DUT and multicast to All Thread Node Multicast Address respectively. It will search the corresponding MGMT_PANID_CONFLICT.ans from pcap and compare the CoAP Token field between the two MGMT_PANID_CONFLICT.ans to decide which packet responses for unicast and which packet for multicast. Currently the CoAP Token field is zero-length, hence, harness doesn't find the second MGMT_PANID_CONFLICT correctly. pcap as below:
[Router_9_2_14(fail).zip](https://github.com/openthread/openthread/files/498257/Router_9_2_14.fail.zip)

Spec states that a zero-length Token may be allowed for qry/ans_con/ans_non. Maybe here we can append this filed to distinguish different packets. 9.2.14 two scenarios(DUT as Router and Commissioner) pass with this PR.
[Router_9_2_14(pass).zip](https://github.com/openthread/openthread/files/498267/Router_9_2_14.pass.zip)
[Commissioner_9_2_14(pass).zip](https://github.com/openthread/openthread/files/498268/Commissioner_9_2_14.pass.zip)

Also remove the unused Timer and relevant callback functions in ED/PANID query client side. Please have a review.