### PR TITLE
Add support for setting preferred Router Id

### DIFF
--- a/include/openthread.h
+++ b/include/openthread.h
@@ -933,6 +933,23 @@ uint32_t otGetPollPeriod(otInstance *aInstance);
 void otSetPollPeriod(otInstance *aInstance, uint32_t aPollPeriod);
 
 /**
+ * Set the preferred Router Id.
+ *
+ * Upon becoming a router/leader the node attempts to use this Router Id. If the
+ * preferred Router Id is not set or if it can not be used, a randomly generated
+ * router id is picked. This property can be set only when the device role is
+ * either detached or disabled.
+ *
+ * @param[in]  aInstance    A pointer to an OpenThread instance.
+ * @param[in]  aRouterId    The preferred Router Id.
+ *
+ * @retval kThreadError_None         Successfully set the preferred Router Id.
+ * @retval kThreadError_InvalidState Could not set (role is not detached or disabled)
+ *
+ */
+ThreadError otSetPreferredRouterId(otInstance *aInstance, uint8_t aRouterId);
+
+/**
  * @}
  */
 

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -938,6 +938,11 @@ void otSetPollPeriod(otInstance *, uint32_t aPollPeriod)
     sThreadNetif->GetMeshForwarder().SetAssignPollPeriod(aPollPeriod);
 }
 
+ThreadError otSetPreferredRouterId(otInstance *, uint8_t aRouterId)
+{
+    return sThreadNetif->GetMle().SetPreferredRouterId(aRouterId);
+}
+
 #ifdef OPENTHREAD_MULTIPLE_INSTANCE
 
 otInstance *otInstanceInit(void *aInstanceBuffer, uint64_t *aInstanceBufferSize)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -245,7 +245,8 @@ ThreadError MleRouter::BecomeLeader(void)
 
     routerId = IsRouterIdValid(mPreviousRouterId) ? AllocateRouterId(mPreviousRouterId) : AllocateRouterId();
     VerifyOrExit(IsRouterIdValid(routerId), error = kThreadError_NoBufs);
-    mRouterId = static_cast<uint8_t>(routerId);
+
+    mRouterId = routerId;
     mPreviousRouterId = mRouterId;
 
     memcpy(&mRouters[mRouterId].mMacAddr, mMac.GetExtAddress(), sizeof(mRouters[mRouterId].mMacAddr));
@@ -2719,6 +2720,21 @@ uint32_t MleRouter::GetLeaderPartitionId(void) const
 void MleRouter::SetLeaderPartitionId(uint32_t aPartitionId)
 {
     mFixedLeaderPartitionId = aPartitionId;
+}
+
+ThreadError MleRouter::SetPreferredRouterId(uint8_t aRouterId)
+{
+    ThreadError error = kThreadError_None;
+
+    VerifyOrExit(
+        (mDeviceState == kDeviceStateDetached) || (mDeviceState == kDeviceStateDisabled),
+        error = kThreadError_InvalidState
+    );
+
+    mPreviousRouterId = aRouterId;
+
+exit:
+    return error;
 }
 
 void MleRouter::HandleMacDataRequest(const Child &aChild)

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -176,6 +176,20 @@ public:
     void SetLeaderPartitionId(uint32_t aPartitionId);
 
     /**
+     * This method sets the preferred Router Id. Upon becoming a router/leader the node
+     * attempts to use this Router Id. If the preferred Router Id is not set or if it
+     * can not be used, a randomly generated router Id is picked.
+     * This property can be set when he device role is detached or disabled.
+     *
+     * @param[in]  aRouterId             The preferred Router Id.
+     *
+     * @retval kThreadError_None         Successfully set the preferred Router Id.
+     * @retval kThreadError_InvalidState Could not set (role is other than detached and disabled)
+     *
+     */
+    ThreadError SetPreferredRouterId(uint8_t aRouterId);
+
+    /**
      * This method returns the next hop towards an RLOC16 destination.
      *
      * @param[in]  aDestination  The RLOC16 of the destination.


### PR DESCRIPTION
This commit adds a new OpenThread API `otSetPreferredRouterId` and its implementation to set preferred Router Id for the node. 

Upon becoming a router/leader the node attempts to use the preferred Router Id. If it is not set or if it can not be used, a randomly generated router Id is picked.