### PR TITLE
ncp-spinel: Update raw stream to support new metadata format

### DIFF
--- a/include/platform/radio.h
+++ b/include/platform/radio.h
@@ -96,13 +96,14 @@ typedef enum otRadioCaps
  */
 typedef struct RadioPacket
 {
-    uint8_t *mPsdu;          ///< The PSDU.
-    uint8_t mLength;         ///< Length of the PSDU.
-    uint8_t mChannel;        ///< Channel used to transmit/receive the frame.
-    int8_t  mPower;          ///< Transmit/receive power in dBm.
-    uint8_t mLqi;            ///< Link Quality Indicator for received frames.
-    bool    mSecurityValid;  ///< Security Enabled flag is set and frame passes security checks.
-    uint16_t mFcs;           ///< Final checksum (optional)
+    uint8_t  *mPsdu;           ///< The PSDU.
+    uint8_t  mLength;          ///< Length of the PSDU.
+    uint8_t  mChannel;         ///< Channel used to transmit/receive the frame.
+    int8_t   mPower;           ///< Transmit/receive power in dBm.
+    uint8_t  mLqi;             ///< Link Quality Indicator for received frames.
+    bool     mSecurityValid: 1; ///< Security Enabled flag is set and frame passes security checks.
+    bool     mDidTX: 1;        ///< Set to true if this packet sent from the radio. Ignored by radio driver.
+    uint16_t mFcs;             ///< Final checksum (optional)
 } RadioPacket;
 
 /**

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -657,6 +657,7 @@ void Mac::HandleBeginTransmit(void)
 
     if (mPcapCallback)
     {
+        sendFrame.mDidTX = true;
         mPcapCallback(&sendFrame, mPcapCallbackContext);
     }
 
@@ -1040,6 +1041,7 @@ void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
 
     if (mPcapCallback)
     {
+        aFrame->mDidTX = false;
         mPcapCallback(aFrame, mPcapCallbackContext);
     }
 

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -246,6 +246,15 @@ typedef unsigned int spinel_cid_t;
 
 enum
 {
+    SPINEL_MD_FLAG_TX               = 0x0001,
+    SPINEL_MD_FLAG_HAS_FCS          = 0x0002,
+    SPINEL_MD_FLAG_BAD_FCS          = 0x0004,
+    SPINEL_MD_FLAG_DUPE             = 0x0008,
+    SPINEL_MD_FLAG_RESERVED         = 0xFFF0,
+};
+
+enum
+{
     SPINEL_CMD_NOOP                 = 0,
     SPINEL_CMD_RESET                = 1,
     SPINEL_CMD_PROP_VALUE_GET       = 2,


### PR DESCRIPTION
This commit updates the raw packet reporting mechanism to use the [new Spinel metadata format][1] with `PROP_STREAM_RAW`.

To do this, a new boolean was needed for the `RadioPacket` structure to allow us to differentiate packets that we received over the air versus packets we have transmitted.

Since the format of the 802.15.4-PHY-specific metadata hasn't yet been defined, that field (Along with the vendor data field) is left unspecified.

[1]: https://cdn.rawgit.com/darconeous/openthread/5b887f3a4e7df5c0c806ca1ba80fb1d9619cf8f2/doc/draft-spinel-protocol.html#frame-metadata-format