### PR TITLE
Add new spinel property `THREAD_PREFERRED_ROUTER_ID` and its set handler

### DIFF
--- a/doc/spinel-protocol-src/spinel-tech-thread.md
+++ b/doc/spinel-protocol-src/spinel-tech-thread.md
@@ -181,5 +181,15 @@ a re-attach process as an end-device.
 * Type: Read-Write
 * Packed-Encoding: `C`
 
-Specifies the self imposed random delay in seconds a REED waits before 
+Specifies the self imposed random delay in seconds a REED waits before
 registering to become an Active Router.
+
+### PROP 5386: PROP_THREAD_PREFERRED_ROUTER_ID
+* Type: Write
+* Packed-Encoding: `C`
+
+Specifies the preferred Router Id. Upon becoming a router/leader the node
+attempts to use this Router Id. If the preferred Router Id is not set or
+if it can not be used, a randomly generated router id is picked. This
+property can be set only when the device role is either detached or
+disabled.

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -233,6 +233,7 @@ const NcpBase::SetPropertyHandlerEntry NcpBase::mSetPropertyHandlerTable[] =
     { SPINEL_PROP_THREAD_CONTEXT_REUSE_DELAY, &NcpBase::SetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY },
     { SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING, &NcpBase::SetPropertyHandler_NET_REQUIRE_JOIN_EXISTING },
     { SPINEL_PROP_THREAD_ROUTER_SELECTION_JITTER, &NcpBase::SetPropertyHandler_THREAD_ROUTER_SELECTION_JITTER },
+    { SPINEL_PROP_THREAD_PREFERRED_ROUTER_ID, &NcpBase::SetPropertyHandler_THREAD_PREFERRED_ROUTER_ID },
 
 #if OPENTHREAD_ENABLE_DIAG
     { SPINEL_PROP_NEST_STREAM_MFG, &NcpBase::SetPropertyHandler_NEST_STREAM_MFG },
@@ -3964,6 +3965,47 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_ROUTER_SELECTION_JITTER(uint8_t h
         otSetRouterSelectionJitter(mInstance, i);
 
         errorCode = HandleCommandPropertyGet(header, key);
+    }
+    else
+    {
+        errorCode = SendLastStatus(header, SPINEL_STATUS_PARSE_ERROR);
+    }
+
+    return errorCode;
+}
+
+ThreadError NcpBase::SetPropertyHandler_THREAD_PREFERRED_ROUTER_ID(uint8_t header, spinel_prop_key_t key,
+                                                                   const uint8_t *value_ptr, uint16_t value_len)
+{
+    uint8_t router_id = 0;
+    spinel_ssize_t parsedLength;
+    ThreadError errorCode = kThreadError_None;
+
+    parsedLength = spinel_datatype_unpack(
+                       value_ptr,
+                       value_len,
+                       SPINEL_DATATYPE_UINT8_S,
+                       &router_id
+                   );
+
+    if (parsedLength > 0)
+    {
+        errorCode = otSetPreferredRouterId(mInstance, router_id);
+
+        if (errorCode == kThreadError_None)
+        {
+            errorCode = SendPropertyUpdate(
+               header,
+               SPINEL_CMD_PROP_VALUE_IS,
+               key,
+               SPINEL_DATATYPE_UINT8_S,
+               router_id
+           );
+        }
+        else
+        {
+            errorCode = SendLastStatus(header, ThreadErrorToSpinelStatus(errorCode));
+        }
     }
     else
     {

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -50,7 +50,7 @@ namespace Thread {
 class NcpBase
 {
 public:
-    
+
     /**
      * This constructor creates and initializes an NcpBase instance.
      *
@@ -60,7 +60,7 @@ public:
     NcpBase(otInstance *aInstance);
 
 protected:
-    
+
     // The pointer to the OpenThread instance
     otInstance* mInstance;
 
@@ -397,7 +397,7 @@ private:
     ThreadError SetPropertyHandler_THREAD_ROUTER_SELECTION_JITTER(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
     ThreadError SetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
     ThreadError SetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
-
+    ThreadError SetPropertyHandler_THREAD_PREFERRED_ROUTER_ID(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
 
     ThreadError SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
                                                     const uint8_t *value_ptr, uint16_t value_len);

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -520,6 +520,12 @@ typedef enum
     SPINEL_PROP_THREAD_ROUTER_SELECTION_JITTER
                                         = SPINEL_PROP_THREAD_EXT__BEGIN + 9,
 
+    /// Thread Preferred Router Id
+    /** Format: `C` - Write only
+     */
+    SPINEL_PROP_THREAD_PREFERRED_ROUTER_ID
+                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 10,
+
     SPINEL_PROP_THREAD_EXT__END        = 0x1600,
 
     SPINEL_PROP_IPV6__BEGIN          = 0x60,


### PR DESCRIPTION
This commit adds a new spinel property `THREAD_PREFERRED_ROUTER_ID` (write-only) along with its set property handler function.