### PR TITLE
fix routing table issue

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -168,6 +168,16 @@ ThreadError MleRouter::ReleaseRouterId(uint8_t aRouterId)
     mRouters[aRouterId].mReclaimDelay = true;
     mRouters[aRouterId].mState = Neighbor::kStateInvalid;
     mRouters[aRouterId].mNextHop = kInvalidRouterId;
+
+    for (uint8_t i = 0; i <= kMaxRouterId; i++)
+    {
+        if (mRouters[i].mNextHop == aRouterId)
+        {
+            mRouters[i].mNextHop = kInvalidRouterId;
+            mRouters[i].mCost = 0;
+        }
+    }
+
     mRouterIdSequence++;
     mRouterIdSequenceLastUpdated = Timer::GetNow();
     mAddressResolver.Remove(aRouterId);


### PR DESCRIPTION
Fix an issue caused by the incomplete [PR#685](https://github.com/openthread/openthread/pull/685):
the non-direct neighbors which have asymmetrical links with Leader might have no chance to be released.
@jwhui , please have a review.
