### PR TITLE
Set hash mac address's local bit

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -313,6 +313,7 @@ void Mac::GetHashMacAddress(ExtAddress *aHashMacAddress)
     sha256.Finish(buf);
 
     memcpy(aHashMacAddress->m8, buf, OT_EXT_ADDRESS_SIZE);
+    aHashMacAddress->SetLocal(true);
 }
 
 ShortAddress Mac::GetShortAddress(void) const


### PR DESCRIPTION
Test Harness calculates DUT's hash mac address based on the EUI-64, and sets the local bit by default, then use it as a filter for packets verification. So the tests may fail if the DUT's hash address's local bit is not set.