### PR TITLE
Add implementations for strlcpy/strlcat when missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.gcno
 *.log
 *.o
+*.lo
+*.la
 *.opendb
 *.orig
 *.pyc
@@ -15,6 +17,7 @@
 .dirstamp
 .DS_Store
 .local-version
+.libs
 aclocal.m4
 autom4te.cache
 build

--- a/configure.ac
+++ b/configure.ac
@@ -253,6 +253,11 @@ AX_CHECK_COMPILER_OPTIONS([C++], ${PROSPECTIVE_CXXFLAGS})
 # Check for and initialize libtool
 
 LT_INIT
+AC_PROG_LIBTOOL
+
+# Disable building shared libraries by default (can be enabled with --enable-shared)
+
+AC_DISABLE_SHARED
 
 #
 # Debug instances
@@ -985,8 +990,27 @@ AC_MSG_NOTICE([checking required package dependencies])
 # NL_WITH_PACKAGE(...)
 
 #
+# Checks for missing functions
+#
+
+AC_DEFUN([CHECK_MISSING_FUNC], [
+    AC_CHECK_FUNC($1, [], [
+        nl_cv_missing_$1=yes
+        MISSING_CPPFLAGS="${MISSING_CPPFLAGS} "'-include $(top_srcdir)/src/missing/$1/$1.h'
+        MISSING_LIBADD="${MISSING_LIBADD} "'$(top_builddir)/src/missing/$1/lib$1.la'
+    ])
+    AM_CONDITIONAL(m4_toupper(MISSING_$1), [test "${nl_cv_missing_$1}" = "yes"])
+])
+AC_SUBST(MISSING_CPPFLAGS)
+AC_SUBST(MISSING_LIBADD)
+
+CHECK_MISSING_FUNC([strlcpy])
+CHECK_MISSING_FUNC([strlcat])
+
+#
 # Check for headers
 #
+
 AC_HEADER_STDBOOL
 AC_HEADER_STDC
 
@@ -1041,6 +1065,11 @@ src/cli/Makefile
 src/ncp/Makefile
 src/core/Makefile
 src/diag/Makefile
+src/missing/Makefile
+src/missing/stdbool/Makefile
+src/missing/stdint/Makefile
+src/missing/strlcat/Makefile
+src/missing/strlcpy/Makefile
 third_party/Makefile
 third_party/mbedtls/Makefile
 examples/Makefile

--- a/etc/visual-studio/libopenthread-cli-windows.vcxproj
+++ b/etc/visual-studio/libopenthread-cli-windows.vcxproj
@@ -41,12 +41,14 @@
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
         OTDLL;
+        OTBUILD;
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);
         ..\..\include;
         ..\..\src;
         ..\..\src\core;
+        ..\..\src\missing;
       </AdditionalIncludeDirectories>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>

--- a/etc/visual-studio/libopenthread-cli.vcxproj
+++ b/etc/visual-studio/libopenthread-cli.vcxproj
@@ -41,12 +41,14 @@
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
         OPENTHREAD_MULTIPLE_INSTANCE;
+        OTBUILD;
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);
         ..\..\include;
         ..\..\src;
         ..\..\src\core;
+        ..\..\src\missing;
         ..\..\third_party\mbedtls;
         ..\..\third_party\mbedtls\repo\include;
       </AdditionalIncludeDirectories>

--- a/etc/visual-studio/libopenthread-ncp-spi.vcxproj
+++ b/etc/visual-studio/libopenthread-ncp-spi.vcxproj
@@ -41,12 +41,14 @@
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
         OPENTHREAD_MULTIPLE_INSTANCE;
+        OTBUILD;
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);
         ..\..\include;
         ..\..\src;
         ..\..\src\core;
+        ..\..\src\missing;
         ..\..\third_party\mbedtls;
         ..\..\third_party\mbedtls\repo\include;
       </AdditionalIncludeDirectories>

--- a/etc/visual-studio/libopenthread-ncp-uart.vcxproj
+++ b/etc/visual-studio/libopenthread-ncp-uart.vcxproj
@@ -41,12 +41,14 @@
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
         OPENTHREAD_MULTIPLE_INSTANCE;
+        OTBUILD;
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);
         ..\..\include;
         ..\..\src;
         ..\..\src\core;
+        ..\..\src\missing;
         ..\..\third_party\mbedtls;
         ..\..\third_party\mbedtls\repo\include;
       </AdditionalIncludeDirectories>

--- a/etc/visual-studio/libopenthread-windows.vcxproj
+++ b/etc/visual-studio/libopenthread-windows.vcxproj
@@ -40,12 +40,14 @@
       <PreprocessorDefinitions>
         %(PreprocessorDefinitions);
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
+        OTBUILD;
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);
         ..\..\include;
         ..\..\examples\platforms;
         ..\..\src\core;
+        ..\..\src\missing;
       </AdditionalIncludeDirectories>
       <SDLCheck>true</SDLCheck>
     </ClCompile>

--- a/etc/visual-studio/libopenthread.vcxproj
+++ b/etc/visual-studio/libopenthread.vcxproj
@@ -41,11 +41,15 @@
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
         OPENTHREAD_MULTIPLE_INSTANCE;
+        OTBUILD;
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);
         ..\..\include;
         ..\..\src\core;
+        ..\..\src\missing;
+        ..\..\src\missing\stdint;
+        ..\..\src\missing\stdbool;
         ..\..\third_party\mbedtls;
         ..\..\third_party\mbedtls\repo\include;
       </AdditionalIncludeDirectories>
@@ -131,6 +135,8 @@
     <ClCompile Include="..\..\src\core\thread\thread_netif.cpp" />
     <ClCompile Include="..\..\src\core\utils\slaac_address.cpp" />
     <ClCompile Include="..\..\src\core\utils\jam_detector.cpp" />
+    <ClCompile Include="..\..\src\missing\strlcpy\strlcpy.c" />
+    <ClCompile Include="..\..\src\missing\strlcat\strlcat.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\openthread\link_raw.h" />
@@ -213,6 +219,8 @@
     <ClInclude Include="..\..\src\core\thread\topology.hpp" />
     <ClInclude Include="..\..\src\core\utils\slaac_address.hpp" />
     <ClInclude Include="..\..\src\core\utils\jam_detector.hpp" />
+    <ClInclude Include="..\..\src\missing\strlcpy\strlcpy.h" />
+    <ClInclude Include="..\..\src\missing\strlcat\strlcat.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/etc/visual-studio/libopenthread.vcxproj.filters
+++ b/etc/visual-studio/libopenthread.vcxproj.filters
@@ -31,6 +31,9 @@
     <Filter Include="Source Files\utils">
       <UniqueIdentifier>{A0D2E990-DC5E-4B56-A552-888F97214A17}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\missing">
+      <UniqueIdentifier>{F0DDA90-D13F-4B56-A552-328F97124A81}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Header Files">
       <UniqueIdentifier>{b4905c15-9702-4ff0-8d57-e7926337d50f}</UniqueIdentifier>
     </Filter>
@@ -60,6 +63,9 @@
     </Filter>
     <Filter Include="Header Files\api">
       <UniqueIdentifier>{25a5662d-0709-4698-8fd9-3abfde8f0fc6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\missing">
+      <UniqueIdentifier>{971969f2-f6ec-50b4-806a-97965c934cef}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -290,6 +296,12 @@
     </ClCompile>
     <ClCompile Include="..\..\src\core\thread\network_diagnostic.cpp">
       <Filter>Source Files\thread</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\missing\strlcpy\strlcpy.c">
+      <Filter>Source Files\missing</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\missing\strlcat\strlcat.c">
+      <Filter>Source Files\missing</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -532,6 +544,12 @@
     </ClInclude>
     <ClInclude Include="..\..\src\core\thread\network_diagnostic_tlvs.hpp">
       <Filter>Header Files\thread</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\missing\strlcpy\strlcpy.h">
+      <Filter>Header Files\missing</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\missing\strlcat\strlcat.h">
+      <Filter>Header Files\missing</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/etc/visual-studio/libopenthread_k.vcxproj
+++ b/etc/visual-studio/libopenthread_k.vcxproj
@@ -43,12 +43,14 @@
         OPENTHREAD_PROJECT_CORE_CONFIG_FILE="openthread-core-windows-config.h";
         WINDOWS_LOGGING;
         OPENTHREAD_MULTIPLE_INSTANCE;
+        OTBUILD;
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);
         ..\..\include;
         ..\..\examples\drivers\windows\include;
         ..\..\src\core;
+        ..\..\src\missing;
         ..\..\src\missing\stdint;
         ..\..\src\missing\stdbool;
         ..\..\third_party\mbedtls;
@@ -138,6 +140,8 @@
     <ClCompile Include="..\..\src\core\thread\thread_netif.cpp" />
     <ClCompile Include="..\..\src\core\utils\slaac_address.cpp" />
     <ClCompile Include="..\..\src\core\utils\jam_detector.cpp" />
+    <ClCompile Include="..\..\src\missing\strlcat\strlcat.c" />
+    <ClCompile Include="..\..\src\missing\strlcpy\strlcpy.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\examples\drivers\windows\include\openthread-core-windows-config.h" />
@@ -244,6 +248,8 @@
     <ClInclude Include="..\..\src\core\thread\topology.hpp" />
     <ClInclude Include="..\..\src\core\utils\slaac_address.hpp" />
     <ClInclude Include="..\..\src\core\utils\jam_detector.hpp" />
+    <ClInclude Include="..\..\src\missing\strlcpy\strlcpy.h" />
+    <ClInclude Include="..\..\src\missing\strlcat\strlcat.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />

--- a/etc/visual-studio/libopenthread_k.vcxproj.filters
+++ b/etc/visual-studio/libopenthread_k.vcxproj.filters
@@ -31,6 +31,9 @@
     <Filter Include="Source Files\utils">
       <UniqueIdentifier>{A0D2E990-DC5E-4B56-A552-888F97214A17}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\missing">
+      <UniqueIdentifier>{F0DDA90-D13F-4B56-A552-328F97124A81}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Header Files">
       <UniqueIdentifier>{b4905c15-9702-4ff0-8d57-e7926337d50f}</UniqueIdentifier>
     </Filter>
@@ -63,6 +66,9 @@
     </Filter>
     <Filter Include="Header Files\openthread">
       <UniqueIdentifier>{2b66635d-fb09-421b-9942-8c43df5c8c77}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\missing">
+      <UniqueIdentifier>{971969f2-f6ec-50b4-806a-97965c934cef}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -287,6 +293,12 @@
     </ClCompile>
     <ClCompile Include="..\..\src\core\common\crc16.cpp">
       <Filter>Source Files\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\missing\strlcpy\strlcpy.c">
+      <Filter>Source Files\missing</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\missing\strlcat\strlcat.c">
+      <Filter>Source Files\missing</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -601,6 +613,12 @@
     </ClInclude>
     <ClInclude Include="..\..\src\core\api\link_raw.hpp">
       <Filter>Header Files\api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\missing\strlcpy\strlcpy.h">
+      <Filter>Header Files\missing</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\missing\strlcat\strlcat.h">
+      <Filter>Header Files\missing</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/include/openthread-windows-config.h
+++ b/include/openthread-windows-config.h
@@ -101,6 +101,11 @@
 // Temporary !!! TODO - Remove this once we figure out the strncpy issue
 #define _CRT_SECURE_NO_WARNINGS
 
+#ifdef OTBUILD
+#include <strlcat/strlcat.h>
+#include <strlcpy/strlcpy.h>
+#endif
+
 // Disable a few warnings that we don't care about
 #pragma warning(disable:4200)  // nonstandard extension used: zero-sized array in struct/union
 #pragma warning(disable:4201)  // nonstandard extension used : nameless struct/union

--- a/src/cli/Makefile.am
+++ b/src/cli/Makefile.am
@@ -35,6 +35,7 @@ libopenthread_cli_a_CPPFLAGS =        \
     -I$(top_srcdir)/src               \
     -I$(top_srcdir)/src/core          \
     $(OPENTHREAD_TARGET_DEFINES)      \
+    $(MISSING_CPPFLAGS)               \
     $(NULL)
 
 libopenthread_cli_a_SOURCES         = \

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -35,6 +35,7 @@ CPPFLAGS_COMMON                     = \
     -I$(top_srcdir)/include           \
     -I${abs_top_srcdir}/third_party/mbedtls/repo/include \
     $(MBEDTLS_CPPFLAGS)               \
+    $(MISSING_CPPFLAGS)               \
     $(OPENTHREAD_TARGET_DEFINES)      \
     $(NULL)
 
@@ -93,6 +94,40 @@ SOURCES_COMMON                      = \
     thread/thread_netif.cpp           \
     utils/slaac_address.cpp           \
     $(NULL)
+
+if MISSING_STRLCPY
+###############################################################
+# You'll see something similar to the next four lines in all
+# of these `MISSING_*` blocks. These makefile gynmastics are
+# to work around some unfortunate bugs in automake which
+# prevent a more elegant solution. We can't just pull in the
+# convenience libraries in `$(MISSING_LIBADD)` because that
+# doesn't seem to work on some platforms. Also, we can't
+# just include `$(top_srcdir)/src/missing/X/X.c` directly
+# because a bug in automake causes the `clean` target to
+# break. The following code may look ugly, but it gets the
+# job done. It does this by copying the source file to the
+# local build directory as an intermediate target. We then
+# compile that file. We have to add the path in CPPFLAGS
+# because the file might include headers from that directory.
+# Because the copied source file is explicitly labeled as
+# an intermediate target, it will always get deleted (unless
+# it already existed in the first place). -- RQ 2017-03-22
+strlcpy.c: $(top_srcdir)/src/missing/strlcpy/strlcpy.c
+	$(AM_V_GEN)cp $< $@
+.INTERMEDIATE: strlcpy.c
+CPPFLAGS_COMMON += -I$(top_srcdir)/src/missing/strlcpy
+SOURCES_COMMON += strlcpy.c
+endif
+
+if MISSING_STRLCAT
+# See comment above for explanation.
+strlcat.c: $(top_srcdir)/src/missing/strlcat/strlcat.c
+	$(AM_V_GEN)cp $< $@
+.INTERMEDIATE: strlcat.c
+CPPFLAGS_COMMON += -I$(top_srcdir)/src/missing/strlcat
+SOURCES_COMMON += strlcat.c
+endif
 
 if OPENTHREAD_ENABLE_APPLICATION_COAP
 SOURCES_COMMON                     += \

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -494,7 +494,7 @@ ThreadError Mac::SetNetworkName(const char *aNetworkName)
 
     VerifyOrExit(strlen(aNetworkName) <= OT_NETWORK_NAME_MAX_SIZE, error = kThreadError_InvalidArgs);
 
-    strncpy(mNetworkName.m8, aNetworkName, sizeof(mNetworkName) - 1);
+    (void)strlcpy(mNetworkName.m8, aNetworkName, sizeof(mNetworkName));
 
 exit:
     otLogFuncExitErr(error);

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -230,7 +230,7 @@ ThreadError Commissioner::AddJoiner(const Mac::ExtAddress *aExtAddress, const ch
             mJoiners[i].mAny = true;
         }
 
-        strncpy(mJoiners[i].mPsk, aPSKd, sizeof(mJoiners[i].mPsk) - 1);
+        (void)strlcpy(mJoiners[i].mPsk, aPSKd, sizeof(mJoiners[i].mPsk));
         mJoiners[i].mValid = true;
         mJoiners[i].mExpirationTime = Timer::GetNow() + Timer::SecToMsec(aTimeout);
 

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -153,20 +153,18 @@ ThreadError LinkQualityInfo::GetAverageRssAsString(char *aCharBuffer, size_t aBu
 
     if (mCount == 0)
     {
-        VerifyOrExit(aBufferLen >= sizeof(kUnknownRssString), error = kThreadError_NoBufs);
-
-        strncpy(aCharBuffer, kUnknownRssString, aBufferLen);
+        charsWritten = static_cast<int>(strlcpy(aCharBuffer, kUnknownRssString, aBufferLen));
     }
     else
     {
         charsWritten = snprintf(aCharBuffer, aBufferLen, "%d.%s dBm",
                                 -(mRssAverage >> kRssAveragePrecisionMultipleBitShift),
                                 kLinkQualityDecimalDigitsString[mRssAverage & kRssAveragePrecisionMultipleBitMask]);
-
-        VerifyOrExit(charsWritten >= 0, error = kThreadError_NoBufs);
-
-        VerifyOrExit(static_cast<size_t>(charsWritten) < aBufferLen, error = kThreadError_NoBufs);
     }
+
+    VerifyOrExit(charsWritten >= 0, error = kThreadError_NoBufs);
+
+    VerifyOrExit(charsWritten < static_cast<int>(aBufferLen), error = kThreadError_NoBufs);
 
 exit:
     return error;

--- a/src/diag/Makefile.am
+++ b/src/diag/Makefile.am
@@ -35,6 +35,7 @@ libopenthread_diag_a_CPPFLAGS =        \
     -I$(top_srcdir)/src                \
     -I$(top_srcdir)/src/core           \
     $(OPENTHREAD_TARGET_DEFINES)       \
+    $(MISSING_CPPFLAGS)                \
     $(NULL)
 
 libopenthread_diag_a_SOURCES         = \

--- a/src/missing/Makefile.am
+++ b/src/missing/Makefile.am
@@ -31,38 +31,26 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 # Always package (e.g. for 'make dist') these subdirectories.
 
 DIST_SUBDIRS                            = \
-    missing                               \
-    core                                  \
-    cli                                   \
-    ncp                                   \
-    diag                                  \
+    stdbool                               \
+    stdint                                \
+    strlcpy                               \
+    strlcat                               \
     $(NULL)
 
 # Always build (e.g. for 'make all') these subdirectories.
 
 SUBDIRS                                 = \
-    missing                               \
-    core                                  \
+    strlcpy                               \
+    strlcat                               \
     $(NULL)
-
-if OPENTHREAD_ENABLE_CLI
-SUBDIRS                                += cli
-endif
-
-if OPENTHREAD_ENABLE_NCP
-SUBDIRS                                += ncp
-endif
-
-if OPENTHREAD_ENABLE_DIAG
-SUBDIRS                                += diag
-endif
 
 # Always pretty (e.g. for 'make pretty') these subdirectories.
 
 PRETTY_SUBDIRS                          = \
-    cli                                   \
-    core                                  \
-    missing                               \
+    stdbool                               \
+    stdint                                \
+    strlcpy                               \
+    strlcat                               \
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/missing/stdbool/Makefile.am
+++ b/src/missing/stdbool/Makefile.am
@@ -28,41 +28,8 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-# Always package (e.g. for 'make dist') these subdirectories.
-
-DIST_SUBDIRS                            = \
-    missing                               \
-    core                                  \
-    cli                                   \
-    ncp                                   \
-    diag                                  \
-    $(NULL)
-
-# Always build (e.g. for 'make all') these subdirectories.
-
-SUBDIRS                                 = \
-    missing                               \
-    core                                  \
-    $(NULL)
-
-if OPENTHREAD_ENABLE_CLI
-SUBDIRS                                += cli
-endif
-
-if OPENTHREAD_ENABLE_NCP
-SUBDIRS                                += ncp
-endif
-
-if OPENTHREAD_ENABLE_DIAG
-SUBDIRS                                += diag
-endif
-
-# Always pretty (e.g. for 'make pretty') these subdirectories.
-
-PRETTY_SUBDIRS                          = \
-    cli                                   \
-    core                                  \
-    missing                               \
+EXTRA_DIST                              = \
+    stdbool.h                             \
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/missing/stdint/Makefile.am
+++ b/src/missing/stdint/Makefile.am
@@ -28,41 +28,8 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-# Always package (e.g. for 'make dist') these subdirectories.
-
-DIST_SUBDIRS                            = \
-    missing                               \
-    core                                  \
-    cli                                   \
-    ncp                                   \
-    diag                                  \
-    $(NULL)
-
-# Always build (e.g. for 'make all') these subdirectories.
-
-SUBDIRS                                 = \
-    missing                               \
-    core                                  \
-    $(NULL)
-
-if OPENTHREAD_ENABLE_CLI
-SUBDIRS                                += cli
-endif
-
-if OPENTHREAD_ENABLE_NCP
-SUBDIRS                                += ncp
-endif
-
-if OPENTHREAD_ENABLE_DIAG
-SUBDIRS                                += diag
-endif
-
-# Always pretty (e.g. for 'make pretty') these subdirectories.
-
-PRETTY_SUBDIRS                          = \
-    cli                                   \
-    core                                  \
-    missing                               \
+EXTRA_DIST                              = \
+    stdint.h                              \
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/missing/strlcat/Makefile.am
+++ b/src/missing/strlcat/Makefile.am
@@ -28,41 +28,31 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-# Always package (e.g. for 'make dist') these subdirectories.
-
-DIST_SUBDIRS                            = \
-    missing                               \
-    core                                  \
-    cli                                   \
-    ncp                                   \
-    diag                                  \
+check_PROGRAMS                      = strlcat_test
+strlcat_test_SOURCES                = strlcat_test.c
+strlcat_test_CPPFLAGS               = \
+    $(AM_CPPFLAGS)                    \
+    $(MISSING_CPPFLAGS)               \
     $(NULL)
+strlcat_test_LDADD                  = $(NULL)
 
-# Always build (e.g. for 'make all') these subdirectories.
+TESTS                               = strlcat_test
 
-SUBDIRS                                 = \
-    missing                               \
-    core                                  \
+if MISSING_STRLCAT
+noinst_LTLIBRARIES                  = libstrlcat.la
+libstrlcat_la_SOURCES               = \
+    strlcat.c                         \
+    strlcat.h                         \
     $(NULL)
-
-if OPENTHREAD_ENABLE_CLI
-SUBDIRS                                += cli
+libstrlcat_la_CPPFLAGS              = \
+    $(AM_CPPFLAGS)                    \
+    $(MISSING_CPPFLAGS)               \
+    $(NULL)
+strlcat_test_LDADD                 += libstrlcat.la
 endif
 
-if OPENTHREAD_ENABLE_NCP
-SUBDIRS                                += ncp
+if MISSING_STRLCAT
+strlcat_test_LDADD                 += ../strlcpy/libstrlcpy.la
 endif
-
-if OPENTHREAD_ENABLE_DIAG
-SUBDIRS                                += diag
-endif
-
-# Always pretty (e.g. for 'make pretty') these subdirectories.
-
-PRETTY_SUBDIRS                          = \
-    cli                                   \
-    core                                  \
-    missing                               \
-    $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/missing/strlcat/strlcat.c
+++ b/src/missing/strlcat/strlcat.c
@@ -1,0 +1,42 @@
+/*
+ *    Copyright (c) 2016, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+ *    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "strlcat.h"
+#include "../strlcpy/strlcpy.h"
+
+size_t strlcat(char *dest, const char *src, size_t size)
+{
+    size_t len = strlen(dest);
+
+    if (len < size - 1)
+    {
+        return (len + strlcpy(dest + len, src, size - len));
+    }
+
+    return len + strlen(src);
+}
+

--- a/src/missing/strlcat/strlcat.h
+++ b/src/missing/strlcat/strlcat.h
@@ -1,0 +1,49 @@
+/*
+ *    Copyright (c) 2016, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+ *    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MISSING_STRLCAT_HEADER_INCLUDED
+#define MISSING_STRLCAT_HEADER_INCLUDED 1
+
+#include <string.h>
+
+#ifdef strlcat
+#undef strlcat
+#endif
+
+#define strlcat ___missing_strlcat
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+size_t strlcat(char *dest, const char *src, size_t size);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif // MISSING_STRLCPY_HEADER_INCLUDED

--- a/src/missing/strlcat/strlcat_test.c
+++ b/src/missing/strlcat/strlcat_test.c
@@ -1,0 +1,61 @@
+/*
+ *    Copyright (c) 2016, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+ *    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "string.h"
+
+int main(void)
+{
+    char string_a[8] = "foo";
+    char string_b[8] = "barbar";
+    size_t ret = 0;
+    int errors = 0;
+
+    ret = strlcat(string_a, string_b, sizeof(string_a));
+
+    if (0 != strcmp(string_a, "foobarb"))
+    {
+        printf("strcmp failed\n");
+        errors++;
+    }
+
+    if (ret != 9)
+    {
+        printf("strlcat return value is wrong (%d)\n", (int)ret);
+        errors++;
+    }
+
+    if (errors != 0)
+    {
+        printf("FAIL\n");
+        return EXIT_FAILURE;
+    }
+
+    printf("OK\n");
+    return EXIT_SUCCESS;
+}

--- a/src/missing/strlcpy/Makefile.am
+++ b/src/missing/strlcpy/Makefile.am
@@ -28,41 +28,19 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-# Always package (e.g. for 'make dist') these subdirectories.
+check_PROGRAMS                      = strlcpy_test
+strlcpy_test_SOURCES                = strlcpy_test.c
+strlcpy_test_CPPFLAGS               = $(MISSING_CPPFLAGS)
 
-DIST_SUBDIRS                            = \
-    missing                               \
-    core                                  \
-    cli                                   \
-    ncp                                   \
-    diag                                  \
+TESTS                               = strlcpy_test
+
+if MISSING_STRLCPY
+noinst_LTLIBRARIES                  = libstrlcpy.la
+libstrlcpy_la_SOURCES               = \
+    strlcpy.c                         \
+    strlcpy.h                         \
     $(NULL)
-
-# Always build (e.g. for 'make all') these subdirectories.
-
-SUBDIRS                                 = \
-    missing                               \
-    core                                  \
-    $(NULL)
-
-if OPENTHREAD_ENABLE_CLI
-SUBDIRS                                += cli
+strlcpy_test_LDADD                  = libstrlcpy.la
 endif
-
-if OPENTHREAD_ENABLE_NCP
-SUBDIRS                                += ncp
-endif
-
-if OPENTHREAD_ENABLE_DIAG
-SUBDIRS                                += diag
-endif
-
-# Always pretty (e.g. for 'make pretty') these subdirectories.
-
-PRETTY_SUBDIRS                          = \
-    cli                                   \
-    core                                  \
-    missing                               \
-    $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/missing/strlcpy/strlcpy.c
+++ b/src/missing/strlcpy/strlcpy.c
@@ -1,0 +1,53 @@
+/*
+ *    Copyright (c) 2016, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+ *    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "strlcpy.h"
+
+size_t strlcpy(char *dest, const char *src, size_t size)
+{
+    const size_t slen = strlen(src);
+
+    if (size != 0)
+    {
+        size--;
+
+        if (slen < size)
+        {
+            size = slen;
+        }
+
+        if (size != 0)
+        {
+            memcpy(dest, src, size);
+        }
+
+        dest[size] = 0;
+    }
+
+    return slen;
+}
+

--- a/src/missing/strlcpy/strlcpy.h
+++ b/src/missing/strlcpy/strlcpy.h
@@ -1,0 +1,49 @@
+/*
+ *    Copyright (c) 2016, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+ *    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MISSING_STRLCPY_HEADER_INCLUDED
+#define MISSING_STRLCPY_HEADER_INCLUDED 1
+
+#include <string.h>
+
+#ifdef strlcpy
+#undef strlcpy
+#endif
+
+#define strlcpy ___missing_strlcpy
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern size_t strlcpy(char *dest, const char *src, size_t size);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif // MISSING_STRLCPY_HEADER_INCLUDED

--- a/src/missing/strlcpy/strlcpy_test.c
+++ b/src/missing/strlcpy/strlcpy_test.c
@@ -1,0 +1,61 @@
+/*
+ *    Copyright (c) 2016, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+ *    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "string.h"
+
+int main(void)
+{
+    char string_a[8] = "foo";
+    char string_b[] = "barbarbar";
+    size_t ret = 0;
+    int errors = 0;
+
+    ret = strlcpy(string_a, string_b, sizeof(string_a));
+
+    if (0 != strcmp(string_a, "barbarb"))
+    {
+        printf("strcmp failed\n");
+        errors++;
+    }
+
+    if (ret != 9)
+    {
+        printf("strlcpy return value is wrong (%d)\n", (int)ret);
+        errors++;
+    }
+
+    if (errors != 0)
+    {
+        printf("FAIL\n");
+        return EXIT_FAILURE;
+    }
+
+    printf("OK\n");
+    return EXIT_SUCCESS;
+}

--- a/src/ncp/Makefile.am
+++ b/src/ncp/Makefile.am
@@ -43,6 +43,7 @@ libopenthread_ncp_a_CPPFLAGS        = \
     -I$(top_srcdir)/third_party       \
     -D_GNU_SOURCE                     \
     $(OPENTHREAD_TARGET_DEFINES)      \
+    $(MISSING_CPPFLAGS)               \
     $(NULL)
 
 libopenthread_ncp_a_CXXFLAGS        = \


### PR DESCRIPTION
This commit shows how to add implementations of missing functions for platforms where those functions are not present. In this case we are adding the `strlcpy()` and `strlcat()`, which are "safe" replacements for `strncpy()` and `strncat()` that behave in a way more consistent with developer expectations.

~~This update required more changes than I had originally thought would be necessary, due to the fact that the `ar` tool [generally includes the files passed to it verbatim in the archive](http://stackoverflow.com/questions/3821916/how-to-merge-two-ar-static-libraries-into-one), which causes symbols to not be able to be looked up properly if they are in [convenience libraries](http://stackoverflow.com/questions/3821916/how-to-merge-two-ar-static-libraries-into-one) because `ar` is stupid and double nests them. Since I'm using convenience libraries for the replacements to the missing functions, I had to switch over the main OpenThread library to link with `libtool` instead of just a normal static link. This shouldn't be a big deal in practice (because it still ultimately produces a normal static `libopenthread.a` file), but it's worth noting the change.~~

After this commit, adding additional replacements for missing functions should be fairly straightforward.
