### PR TITLE
Dataset Mgmt Certificate test clean up

### DIFF
--- a/src/core/thread/meshcop_dataset_manager.cpp
+++ b/src/core/thread/meshcop_dataset_manager.cpp
@@ -297,10 +297,11 @@ void DatasetManager::HandleSet(Coap::Header &aHeader, Message &aMessage, const I
                 if (data->GetType() == Tlv::kCommissionerSessionId)
                 {
                     uint16_t sessionId;
+                    uint16_t rxSessionId;
 
                     sessionId = static_cast<CommissionerSessionIdTlv *>(data)->GetCommissionerSessionId();
-                    VerifyOrExit(sessionId == static_cast<CommissionerSessionIdTlv *>(&tlv)->GetCommissionerSessionId(),
-                                 state = StateTlv::kReject);
+                    aMessage.Read(offset + sizeof(tlv), sizeof(rxSessionId), &rxSessionId);
+                    VerifyOrExit(sessionId == rxSessionId, state = StateTlv::kReject);
                     break;
                 }
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -487,7 +487,7 @@ ThreadError Mle::SetMeshLocalPrefix(const uint8_t *aMeshLocalPrefix)
     // Add the address back into the table.
     mNetif.AddUnicastAddress(mMeshLocal64);
 
-    if (mDeviceState != kDeviceStateDetached)
+    if (mDeviceState >= kDeviceStateChild)
     {
         mNetif.AddUnicastAddress(mMeshLocal16);
     }

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -487,6 +487,11 @@ ThreadError Mle::SetMeshLocalPrefix(const uint8_t *aMeshLocalPrefix)
     // Add the address back into the table.
     mNetif.AddUnicastAddress(mMeshLocal64);
 
+    if (mDeviceState != kDeviceStateDetached)
+    {
+        mNetif.AddUnicastAddress(mMeshLocal16);
+    }
+
     // Changing the prefix also causes the mesh local address to be different.
     mNetif.SetStateChangedFlags(OT_IP6_ML_ADDR_CHANGED);
 

--- a/tools/harness-thci/ARM.py
+++ b/tools/harness-thci/ARM.py
@@ -1925,7 +1925,7 @@ class ARM(IThci):
 
             if xPanId != None:
                 cmd += ' panid '
-                cmd + str(xPanId)
+                cmd += str(xPanId)
 
             if xDelayTimer != None:
                 cmd += ' delay '


### PR DESCRIPTION
- Fix bug of reading commissioner session id after rx MGMT_ACTIVE_SET/MGMT_PENDING_SET
- Restore ML16 address after modifying meshlocal prefix if the node keeps attaching
- Fix bug of THCI