### PR TITLE
Do not remove child from table due to ack failures

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1197,13 +1197,6 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, ThreadError aError)
                     mMle.RemoveNeighbor(*neighbor);
                 }
             }
-            else
-            {
-                if (neighbor->mLinkFailures >= Mle::kFailedChildTransmissions)
-                {
-                    mMle.RemoveNeighbor(*neighbor);
-                }
-            }
 
             break;
 

--- a/src/core/thread/mle_constants.hpp
+++ b/src/core/thread/mle_constants.hpp
@@ -46,7 +46,6 @@ enum
 {
     kMaxChildren                = OPENTHREAD_CONFIG_MAX_CHILDREN,
     kMaxChildKeepAliveAttempts  = 4,    ///< Maximum keep alive attempts before attempting to reattach to a new Parent
-    kFailedChildTransmissions   = 4,    ///< FAILED_CHILD_TRANSMISSIONS
 };
 
 /**


### PR DESCRIPTION
This commit makes a change in `MeshForwarder` class so that a child is not removed from neighbor table if we see ack failures. The time out process will ensure that the child is removed if it's not responsive.