### PR TITLE
Update Thread Certification 5.5.4,5 to current test plan.

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1977,8 +1977,7 @@ ThreadError Mle::HandleParentResponse(const Message &aMessage, const Ip6::Messag
         switch (mParentRequestMode)
         {
         case kMleAttachAnyPartition:
-            VerifyOrExit((mDeviceMode & ModeTlv::kModeFFD) == 0 ||
-                         leaderData.GetPartitionId() != mLeaderData.GetPartitionId() ||
+            VerifyOrExit(leaderData.GetPartitionId() != mLeaderData.GetPartitionId() ||
                          static_cast<int8_t>(connectivity.GetIdSequence() - mMleRouter.GetRouterIdSequence()) > 0,);
             break;
 

--- a/tests/scripts/thread-cert/Cert_5_5_04_SplitMergeRouters.py
+++ b/tests/scripts/thread-cert/Cert_5_5_04_SplitMergeRouters.py
@@ -32,37 +32,35 @@ import unittest
 
 import node
 
-LEADER1 = 1
+LEADER = 1
 ROUTER1 = 2
 ROUTER2 = 3
 ROUTER3 = 4
 ROUTER4 = 5
-ED1 = 6
 
 class Cert_5_5_4_SplitMergeRouters(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
-        for i in range(1,7):
+        for i in range(1,6):
             self.nodes[i] = node.Node(i)
 
-        self.nodes[LEADER1].set_panid(0xface)
-        self.nodes[LEADER1].set_mode('rsdn')
-        self.nodes[LEADER1].add_whitelist(self.nodes[ROUTER1].get_addr64())
-        self.nodes[LEADER1].add_whitelist(self.nodes[ROUTER2].get_addr64())
-        self.nodes[LEADER1].add_whitelist(self.nodes[ED1].get_addr64())
-        self.nodes[LEADER1].enable_whitelist()
-        self.nodes[LEADER1].set_router_selection_jitter(1)
+        self.nodes[LEADER].set_panid(0xface)
+        self.nodes[LEADER].set_mode('rsdn')
+        self.nodes[LEADER].add_whitelist(self.nodes[ROUTER1].get_addr64())
+        self.nodes[LEADER].add_whitelist(self.nodes[ROUTER2].get_addr64())
+        self.nodes[LEADER].enable_whitelist()
+        self.nodes[LEADER].set_router_selection_jitter(1)
 
         self.nodes[ROUTER1].set_panid(0xface)
         self.nodes[ROUTER1].set_mode('rsdn')
-        self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER1].get_addr64())
+        self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER3].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
         self.nodes[ROUTER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER2].set_panid(0xface)
         self.nodes[ROUTER2].set_mode('rsdn')
-        self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER1].get_addr64())
+        self.nodes[ROUTER2].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER4].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
         self.nodes[ROUTER2].set_router_selection_jitter(1)
@@ -71,7 +69,6 @@ class Cert_5_5_4_SplitMergeRouters(unittest.TestCase):
         self.nodes[ROUTER3].set_mode('rsdn')
         self.nodes[ROUTER3].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER3].enable_whitelist()
-        self.nodes[ROUTER3].set_network_id_timeout(110)
         self.nodes[ROUTER3].set_router_selection_jitter(1)
 
         self.nodes[ROUTER4].set_panid(0xface)
@@ -80,20 +77,15 @@ class Cert_5_5_4_SplitMergeRouters(unittest.TestCase):
         self.nodes[ROUTER4].enable_whitelist()
         self.nodes[ROUTER4].set_router_selection_jitter(1)
 
-        self.nodes[ED1].set_panid(0xface)
-        self.nodes[ED1].set_mode('rsn')
-        self.nodes[ED1].add_whitelist(self.nodes[LEADER1].get_addr64())
-        self.nodes[ED1].enable_whitelist()
-
     def tearDown(self):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
 
     def test(self):
-        self.nodes[LEADER1].start()
-        self.nodes[LEADER1].set_state('leader')
-        self.assertEqual(self.nodes[LEADER1].get_state(), 'leader')
+        self.nodes[LEADER].start()
+        self.nodes[LEADER].set_state('leader')
+        self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
         time.sleep(5)
@@ -111,29 +103,18 @@ class Cert_5_5_4_SplitMergeRouters(unittest.TestCase):
         time.sleep(5)
         self.assertEqual(self.nodes[ROUTER4].get_state(), 'router')
 
-        self.nodes[ED1].start()
-        time.sleep(5)
-        self.assertEqual(self.nodes[ED1].get_state(), 'child')
+        self.nodes[LEADER].stop()
+        time.sleep(150)
 
-        self.nodes[LEADER1].stop()
+        self.nodes[LEADER].start()
+        time.sleep(50)
 
-        self.nodes[ED1].add_whitelist(self.nodes[ROUTER1].get_addr64())
-        self.nodes[ROUTER1].add_whitelist(self.nodes[ED1].get_addr64())
+        self.assertEqual(self.nodes[LEADER].get_state(), 'router')
 
-        time.sleep(130)
-        #self.assertEqual(self.nodes[ROUTER3].get_state(), 'leader')
-        #self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
-
-        self.nodes[LEADER1].start()
-        time.sleep(5)
-        self.assertEqual(self.nodes[LEADER1].get_state(), 'router')
-
-        time.sleep(60)
-
-        addrs = self.nodes[ED1].get_addrs()
+        addrs = self.nodes[ROUTER4].get_addrs()
         for addr in addrs:
             if addr[0:4] != 'fe80':
-                self.assertTrue(self.nodes[ROUTER2].ping(addr))
+                self.assertTrue(self.nodes[ROUTER3].ping(addr))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Restrict child to only process Route TLV from parent.