### PR TITLE
Stop responding to Address Queries after consecutive tx failures to child.

### DIFF
--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -543,7 +543,9 @@ void AddressResolver::HandleAddressQuery(Coap::Header &aHeader, Message &aMessag
 
     for (int i = 0; i < numChildren; i++)
     {
-        if (children[i].mState != Neighbor::kStateValid || (children[i].mMode & Mle::ModeTlv::kModeFFD) != 0)
+        if (children[i].mState != Neighbor::kStateValid ||
+            (children[i].mMode & Mle::ModeTlv::kModeFFD) != 0 ||
+            children[i].mLinkFailures >= Mle::kFailedChildTransmissions)
         {
             continue;
         }

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1693,6 +1693,7 @@ void MeshForwarder::HandleDataRequest(const Mac::Address &aMacSource, const Thre
 
     VerifyOrExit((child = mMle.GetChild(aMacSource)) != NULL, ;);
     child->mLastHeard = Timer::GetNow();
+    child->mLinkFailures = 0;
 
     mMle.HandleMacDataRequest(*child);
 

--- a/src/core/thread/mle_constants.hpp
+++ b/src/core/thread/mle_constants.hpp
@@ -46,6 +46,7 @@ enum
 {
     kMaxChildren                = OPENTHREAD_CONFIG_MAX_CHILDREN,
     kMaxChildKeepAliveAttempts  = 4,    ///< Maximum keep alive attempts before attempting to reattach to a new Parent
+    kFailedChildTransmissions   = 4,    ///< FAILED_CHILD_TRANSMISSIONS
 };
 
 /**


### PR DESCRIPTION
- Reset consecutive failure count on receiving a 15.4 Data Request message.

As discussed in #672.