### PR TITLE
Handle router selection jitter timeout only once

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2165,7 +2165,7 @@ ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::Messa
             (mDeviceMode & ModeTlv::kModeFFD) &&
             (numRouters < mMleRouter.GetRouterUpgradeThreshold()))
         {
-            mRouterSelectionJitterTimeout = otPlatRandomGet() % mRouterSelectionJitter;
+            mRouterSelectionJitterTimeout = (otPlatRandomGet() % mRouterSelectionJitter) + 1;
         }
     }
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1362,7 +1362,7 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
             (mDeviceMode & ModeTlv::kModeFFD) &&
             (GetActiveRouterCount() < mRouterUpgradeThreshold))
         {
-            mRouterSelectionJitterTimeout = otPlatRandomGet() % mRouterSelectionJitter;
+            mRouterSelectionJitterTimeout = (otPlatRandomGet() % mRouterSelectionJitter) + 1;
             ExitNow();
         }
 
@@ -1688,6 +1688,8 @@ void MleRouter::HandleStateUpdateTimer(void *aContext)
 
 void MleRouter::HandleStateUpdateTimer(void)
 {
+    bool routerStateUpdate = false;
+
     if (mChallengeTimeout > 0)
     {
         mChallengeTimeout--;
@@ -1696,6 +1698,11 @@ void MleRouter::HandleStateUpdateTimer(void)
     if (mRouterSelectionJitterTimeout > 0)
     {
         mRouterSelectionJitterTimeout--;
+
+        if (mRouterSelectionJitterTimeout == 0)
+        {
+            routerStateUpdate = true;
+        }
     }
 
     switch (GetDeviceState())
@@ -1710,8 +1717,7 @@ void MleRouter::HandleStateUpdateTimer(void)
         ExitNow();
 
     case kDeviceStateChild:
-        if (mRouterSelectionJitterTimeout == 0 &&
-            GetActiveRouterCount() < mRouterUpgradeThreshold)
+        if (routerStateUpdate && GetActiveRouterCount() < mRouterUpgradeThreshold)
         {
             // upgrade to Router
             BecomeRouter(ThreadStatusTlv::kTooFewRouters);
@@ -1726,8 +1732,7 @@ void MleRouter::HandleStateUpdateTimer(void)
             BecomeChild(kMleAttachSamePartition);
         }
 
-        if (mRouterSelectionJitterTimeout == 0 &&
-            GetActiveRouterCount() > mRouterDowngradeThreshold)
+        if (routerStateUpdate && GetActiveRouterCount() > mRouterDowngradeThreshold)
         {
             // downgrade to REED
             BecomeChild(kMleAttachSamePartition);


### PR DESCRIPTION
While implementing CoAP retransmissions I've noticed that MLE layer retransmits Address Solicit on its own. The issue was, that once `mRouterSelectionJitterTimeout `hit 0, it kept calling BecomeRouter function every second until it received response and became a Router, which IMHO is incorrect behavior and result in high and unnecessary CoAP traffic.
This PR solves this issue, so the BecomeRouter/BecomeChild functions are called only once, when `mRouterSelectionJitterTimeout `hits 0.