### PR TITLE
Do not remove commissiong data if not Leader after different partitions merge.

### DIFF
--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -53,7 +53,8 @@ Leader::Leader(ThreadNetif &aThreadNetif):
     mCoapServer(aThreadNetif.GetCoapServer()),
     mNetworkData(aThreadNetif.GetNetworkDataLeader()),
     mTimer(aThreadNetif.GetIp6().mTimerScheduler, HandleTimer, this),
-    mSessionId(0xffff)
+    mSessionId(0xffff),
+    mNetif(aThreadNetif)
 {
     mCoapServer.AddResource(mPetition);
     mCoapServer.AddResource(mKeepAlive);
@@ -229,8 +230,13 @@ void Leader::HandleTimer(void *aContext)
 
 void Leader::HandleTimer(void)
 {
+    VerifyOrExit(mNetif.GetMle().GetDeviceState() == Mle::kDeviceStateLeader, ;);
+
     otLogInfoMeshCoP("commissioner inactive\r\n");
     mNetworkData.SetCommissioningData(NULL, 0);
+
+exit:
+    return;
 }
 
 }  // namespace MeshCoP

--- a/src/core/meshcop/leader.hpp
+++ b/src/core/meshcop/leader.hpp
@@ -99,6 +99,7 @@ private:
 
     CommissionerIdTlv mCommissionerId;
     uint16_t mSessionId;
+    ThreadNetif &mNetif;
 };
 
 }  // namespace MeshCoP


### PR DESCRIPTION
Leader-9.2.7 configures Router1 to form a partition as leader as well as commissioner and configures its active timestamp and pending timestamp first. Then starting Leader with a larger partition id. Router1 will migrate to the new partition later. However, Router1 also acts as commissioner and the keep alive timer starts. After it migrates to the other partition as Router, the keep alive message will not be received till to the timer expires, Router1 clears the commissioning data TLV, then propagates it in the new partition, that causes harness fails to detect the commissioning data TLV.