### PR TITLE
Cleanup usage of error codes and avoid raising errors when value is unchanged

### DIFF
--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -175,43 +175,35 @@ void cc2538RadioInit(void)
     // SRCMATCH.PEND_DATAREQ_ONLY(1), RFCORE_XREG_FRMCTRL1_PENDING_OR(0)
 }
 
-ThreadError otPlatRadioEnable(otInstance *aInstance)
-{
-    ThreadError error = kThreadError_Busy;
-    (void)aInstance;
-
-    if (sState == kStateSleep || sState == kStateDisabled)
-    {
-        error = kThreadError_None;
-        sState = kStateSleep;
-    }
-
-    return error;
-}
-
-ThreadError otPlatRadioDisable(otInstance *aInstance)
-{
-    ThreadError error = kThreadError_Busy;
-    (void)aInstance;
-
-    if (sState == kStateDisabled || sState == kStateSleep)
-    {
-        error = kThreadError_None;
-        sState = kStateDisabled;
-    }
-
-    return error;
-}
-
 bool otPlatRadioIsEnabled(otInstance *aInstance)
 {
     (void)aInstance;
     return (sState != kStateDisabled) ? true : false;
 }
 
+ThreadError otPlatRadioEnable(otInstance *aInstance)
+{
+    if (!otPlatRadioIsEnabled(aInstance))
+    {
+        sState = kStateSleep;
+    }
+
+    return kThreadError_None;
+}
+
+ThreadError otPlatRadioDisable(otInstance *aInstance)
+{
+    if (otPlatRadioIsEnabled(aInstance))
+    {
+        sState = kStateDisabled;
+    }
+
+    return kThreadError_None;
+}
+
 ThreadError otPlatRadioSleep(otInstance *aInstance)
 {
-    ThreadError error = kThreadError_Busy;
+    ThreadError error = kThreadError_InvalidState;
     (void)aInstance;
 
     if (sState == kStateSleep || sState == kStateReceive)
@@ -226,7 +218,7 @@ ThreadError otPlatRadioSleep(otInstance *aInstance)
 
 ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 {
-    ThreadError error = kThreadError_Busy;
+    ThreadError error = kThreadError_InvalidState;
     (void)aInstance;
 
     if (sState != kStateDisabled)
@@ -243,7 +235,7 @@ ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 
 ThreadError otPlatRadioTransmit(otInstance *aInstance)
 {
-    ThreadError error = kThreadError_Busy;
+    ThreadError error = kThreadError_InvalidState;
     (void)aInstance;
 
     if (sState == kStateReceive)

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -371,43 +371,35 @@ void platformRadioInit(void)
     sAckFrame.mPsdu = sAckMessage.mPsdu;
 }
 
-ThreadError otPlatRadioEnable(otInstance *aInstance)
-{
-    ThreadError error = kThreadError_Busy;
-    (void)aInstance;
-
-    if (sState == kStateSleep || sState == kStateDisabled)
-    {
-        error = kThreadError_None;
-        sState = kStateSleep;
-    }
-
-    return error;
-}
-
-ThreadError otPlatRadioDisable(otInstance *aInstance)
-{
-    ThreadError error = kThreadError_Busy;
-    (void)aInstance;
-
-    if (sState == kStateDisabled || sState == kStateSleep)
-    {
-        error = kThreadError_None;
-        sState = kStateDisabled;
-    }
-
-    return error;
-}
-
 bool otPlatRadioIsEnabled(otInstance *aInstance)
 {
     (void)aInstance;
     return (sState != kStateDisabled) ? true : false;
 }
 
+ThreadError otPlatRadioEnable(otInstance *aInstance)
+{
+    if (!otPlatRadioIsEnabled(aInstance))
+    {
+        sState = kStateSleep;
+    }
+
+    return kThreadError_None;
+}
+
+ThreadError otPlatRadioDisable(otInstance *aInstance)
+{
+    if (otPlatRadioIsEnabled(aInstance))
+    {
+        sState = kStateDisabled;
+    }
+
+    return kThreadError_None;
+}
+
 ThreadError otPlatRadioSleep(otInstance *aInstance)
 {
-    ThreadError error = kThreadError_Busy;
+    ThreadError error = kThreadError_InvalidState;
     (void)aInstance;
 
     if (sState == kStateSleep || sState == kStateReceive)
@@ -421,7 +413,7 @@ ThreadError otPlatRadioSleep(otInstance *aInstance)
 
 ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 {
-    ThreadError error = kThreadError_Busy;
+    ThreadError error = kThreadError_InvalidState;
     (void)aInstance;
 
     if (sState != kStateDisabled)
@@ -437,7 +429,7 @@ ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 
 ThreadError otPlatRadioTransmit(otInstance *aInstance)
 {
-    ThreadError error = kThreadError_Busy;
+    ThreadError error = kThreadError_InvalidState;
     (void)aInstance;
 
     if (sState == kStateReceive)

--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -157,6 +157,11 @@ typedef enum ThreadError
      */
     kThreadError_Ipv6AddressCreationFailure = 28,
 
+    /**
+     * Operation prevented by mode flags
+     */
+    kThreadError_NotCapable = 29,
+
     kThreadError_Error = 255,
 } ThreadError;
 

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -206,8 +206,8 @@ void otInstanceFinalize(otInstance *aInstance);
  *
  * @param[in] aInstance A pointer to an OpenThread instance.
  *
- * @retval kThreadError_None          Successfully enabled the IPv6 interface.
- * @retval kThreadError_InvalidState  OpenThread is not enabled or the IPv6 interface is already up.
+ * @retval kThreadError_None          Successfully enabled the IPv6 interface,
+ *                                    or the interface was already enabled.
  *
  */
 ThreadError otInterfaceUp(otInstance *aInstance);
@@ -219,8 +219,8 @@ ThreadError otInterfaceUp(otInstance *aInstance);
  *
  * @param[in] aInstance A pointer to an OpenThread instance.
  *
- * @retval kThreadError_None          Successfully brought the interface down.
- * @retval kThreadError_InvalidState  The interface was not up.
+ * @retval kThreadError_None          Successfully brought the interface down,
+ *                                    or the interface was already down.
  *
  */
 ThreadError otInterfaceDown(otInstance *aInstance);
@@ -244,7 +244,7 @@ bool otIsInterfaceUp(otInstance *aInstance);
  * @param[in] aInstance A pointer to an OpenThread instance.
  *
  * @retval kThreadError_None          Successfully started Thread protocol operation.
- * @retval kThreadError_InvalidState  Thread protocol operation is already started or the interface is not up.
+ * @retval kThreadError_InvalidState  The network interface was not not up.
  *
  */
 ThreadError otThreadStart(otInstance *aInstance);
@@ -255,7 +255,6 @@ ThreadError otThreadStart(otInstance *aInstance);
  * @param[in] aInstance A pointer to an OpenThread instance.
  *
  * @retval kThreadError_None          Successfully stopped Thread protocol operation.
- * @retval kThreadError_InvalidState  The Thread protocol operation was not started.
  *
  */
 ThreadError otThreadStop(otInstance *aInstance);
@@ -430,14 +429,17 @@ uint8_t otGetMaxAllowedChildren(otInstance *aInstance);
 /**
  * Set the maximum number of children currently allowed.
  *
+ * This parameter can only be set when Thread protocol operation
+ * has been stopped.
+ *
  * @param[in]  aInstance     A pointer to an OpenThread instance.
  * @param[in]  aMaxChildren  The maximum allowed children.
  *
  * @retval  kThreadErrorNone           Successfully set the max.
  * @retval  kThreadError_InvalidArgs   If @p aMaxChildren is not in the range [1, OPENTHREAD_CONFIG_MAX_CHILDREN].
- * @retval  kThreadError_InvalidState  If Thread has already been started.
+ * @retval  kThreadError_InvalidState  If Thread isn't stopped.
  *
- * @sa otGetMaxAllowedChildren
+ * @sa otGetMaxAllowedChildren, otThreadStop
  */
 ThreadError otSetMaxAllowedChildren(otInstance *aInstance, uint8_t aMaxChildren);
 
@@ -1450,8 +1452,8 @@ bool otIsMacWhitelistEnabled(otInstance *aInstance);
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.
  *
- * @retval kThreadErrorNone    Successfully detached from the Thread network.
- * @retval kThreadErrorBusy    Thread is disabled.
+ * @retval kThreadErrorNone          Successfully detached from the Thread network.
+ * @retval kThreadErrorInvalidState  Thread is disabled.
  */
 ThreadError otBecomeDetached(otInstance *aInstance);
 
@@ -1461,8 +1463,8 @@ ThreadError otBecomeDetached(otInstance *aInstance);
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aFilter   Identifies whether to join any, same, or better partition.
  *
- * @retval kThreadErrorNone    Successfully begin attempt to become a child.
- * @retval kThreadErrorBusy    Thread is disabled or in the middle of an attach process.
+ * @retval kThreadErrorNone          Successfully begin attempt to become a child.
+ * @retval kThreadErrorInvalidState  Thread is disabled.
  */
 ThreadError otBecomeChild(otInstance *aInstance, otMleAttachFilter aFilter);
 
@@ -1471,8 +1473,8 @@ ThreadError otBecomeChild(otInstance *aInstance, otMleAttachFilter aFilter);
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.
  *
- * @retval kThreadErrorNone    Successfully begin attempt to become a router.
- * @retval kThreadErrorBusy    Thread is disabled or already operating in a router or leader role.
+ * @retval kThreadErrorNone         Successfully begin attempt to become a router.
+ * @retval kThreadErrorInvalidState Thread is disabled.
  */
 ThreadError otBecomeRouter(otInstance *aInstance);
 
@@ -1481,7 +1483,8 @@ ThreadError otBecomeRouter(otInstance *aInstance);
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.
  *
- * @retval kThreadErrorNone  Successfully became a leader and started a new partition.
+ * @retval kThreadErrorNone          Successfully became a leader and started a new partition.
+ * @retval kThreadErrorInvalidState  Thread is disabled.
  */
 ThreadError otBecomeLeader(otInstance *aInstance);
 
@@ -1878,8 +1881,9 @@ bool otIsLinkPromiscuous(otInstance *aInstance);
  * @param[in]  aInstance     A pointer to an OpenThread instance.
  * @param[in]  aPromiscuous  true to enable promiscuous mode, or false otherwise.
  *
- * @retval kThreadError_None  Successfully enabled promiscuous mode.
- * @retval kThreadError_Busy  Could not enable promiscuous mode because the Thread interface is enabled.
+ * @retval kThreadError_None          Successfully enabled promiscuous mode.
+ * @retval kThreadError_InvalidState  Could not enable promiscuous mode because
+ *                                    the Thread interface is enabled.
  *
  */
 ThreadError otSetLinkPromiscuous(otInstance *aInstance, bool aPromiscuous);
@@ -2243,8 +2247,8 @@ otMessage otNewUdpMessage(otInstance *aInstance);
  * @param[in]  aCallback  A pointer to the application callback function.
  * @param[in]  aContext   A pointer to application-specific context.
  *
- * @retval kThreadErrorNone  Successfully opened the socket.
- * @retval kThreadErrorBusy  Socket is already opened.
+ * @retval kThreadErrorNone         Successfully opened the socket.
+ * @retval kThreadErrorInvalidArgs  Given socket structure was already opened.
  *
  * @sa otNewUdpMessage
  * @sa otCloseUdpSocket

--- a/include/platform/radio.h
+++ b/include/platform/radio.h
@@ -203,8 +203,8 @@ void otPlatRadioSetShortAddress(otInstance *aInstance, uint16_t aShortAddress);
  *
  * @param[in] aInstance  The OpenThread instance structure.
  *
- * @retval ::kThreadError_None  Successfully transitioned to Sleep.
- * @retval ::kThreadError_Busy  The radio was already enabled.
+ * @retval ::kThreadError_None     Successfully enabled.
+ * @retval ::kThreadError_Failure  The radio could not be enabled.
  */
 ThreadError otPlatRadioEnable(otInstance *aInstance);
 
@@ -233,8 +233,9 @@ bool otPlatRadioIsEnabled(otInstance *aInstance);
  *
  * @param[in] aInstance  The OpenThread instance structure.
  *
- * @retval ::kThreadError_None  Successfully transitioned to Sleep.
- * @retval ::kThreadError_Busy  The radio was not in the Receive state.
+ * @retval ::kThreadError_None         Successfully transitioned to Sleep.
+ * @retval ::kThreadError_Busy         The radio was transmitting
+ * @retval ::kThreadError_InvalidState The radio was disabled
  */
 ThreadError otPlatRadioSleep(otInstance *aInstance);
 
@@ -245,8 +246,8 @@ ThreadError otPlatRadioSleep(otInstance *aInstance);
  * @param[in]  aInstance  The OpenThread instance structure.
  * @param[in]  aChannel   The channel to use for receiving.
  *
- * @retval ::kThreadError_None  Successfully transitioned to Receive.
- * @retval ::kThreadError_Busy  The radio was not in the Sleep state.
+ * @retval ::kThreadError_None         Successfully transitioned to Receive.
+ * @retval ::kThreadError_InvalidState The radio was disabled or transmitting.
  */
 ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel);
 
@@ -355,7 +356,7 @@ RadioPacket *otPlatRadioGetTransmitBuffer(otInstance *aInstance);
  * @param[in] aInstance  The OpenThread instance structure.
  *
  * @retval ::kThreadError_None         Successfully transitioned to Transmit.
- * @retval ::kThreadError_Busy         The radio was not in the Receive state.
+ * @retval ::kThreadError_InvalidState The radio was not in the Receive state.
  */
 ThreadError otPlatRadioTransmit(otInstance *aInstance);
 

--- a/src/core/coap/coap_server.cpp
+++ b/src/core/coap/coap_server.cpp
@@ -68,7 +68,7 @@ ThreadError Server::AddResource(Resource &aResource)
 
     for (Resource *cur = mResources; cur; cur = cur->mNext)
     {
-        VerifyOrExit(cur != &aResource, error = kThreadError_Busy);
+        VerifyOrExit(cur != &aResource, error = kThreadError_Already);
     }
 
     aResource.mNext = mResources;

--- a/src/core/coap/coap_server.hpp
+++ b/src/core/coap/coap_server.hpp
@@ -131,8 +131,8 @@ public:
      *
      * @param[in]  aResource  A reference to the resource.
      *
-     * @retval kThreadError_None  Successfully added @p aResource.
-     * @retval kThreadError_Busy  The @p aResource was already added.
+     * @retval kThreadError_None     Successfully added @p aResource.
+     * @retval kThreadError_Already  The @p aResource was already added.
      *
      */
     ThreadError AddResource(Resource &aResource);

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -645,8 +645,8 @@ public:
      *
      * @param[in]  aMessage  The message to add.
      *
-     * @retval kThreadError_None  Successfully added the message to the list.
-     * @retval kThreadError_Busy  The message is already enqueued in a list.
+     * @retval kThreadError_None     Successfully added the message to the list.
+     * @retval kThreadError_Already  The message is already enqueued in a list.
      *
      */
     ThreadError Enqueue(Message &aMessage);
@@ -656,8 +656,8 @@ public:
      *
      * @param[in]  aMessage  The message to remove.
      *
-     * @retval kThreadError_None  Successfully removed the message from the list.
-     * @retval kThreadError_Busy  The message is not enqueued in a list.
+     * @retval kThreadError_None      Successfully removed the message from the list.
+     * @retval kThreadError_NotFound  The message is not enqueued in a list.
      *
      */
     ThreadError Dequeue(Message &aMessage);
@@ -669,8 +669,8 @@ private:
      * @param[in]  aListId   The list to add @p aMessage to.
      * @param[in]  aMessage  The message to add to @p aListId.
      *
-     * @retval kThreadError_None  Successfully added the message to the list.
-     * @retval kThreadError_Busy  The message is already enqueued in a list.
+     * @retval kThreadError_None     Successfully added the message to the list.
+     * @retval kThreadError_Already  The message is already enqueued in a list.
      *
      */
     static ThreadError AddToList(uint8_t aListId, Message &aMessage);
@@ -681,8 +681,8 @@ private:
      * @param[in]  aListId   The list to add @p aMessage to.
      * @param[in]  aMessage  The message to add to @p aListId.
      *
-     * @retval kThreadError_None  Successfully added the message to the list.
-     * @retval kThreadError_Busy  The message is not enqueued in the list.
+     * @retval kThreadError_None      Successfully added the message to the list.
+     * @retval kThreadError_NotFound  The message is not enqueued in the list.
      *
      */
     static ThreadError RemoveFromList(uint8_t aListId, Message &aMessage);

--- a/src/core/common/tasklet.cpp
+++ b/src/core/common/tasklet.cpp
@@ -62,7 +62,7 @@ ThreadError TaskletScheduler::Post(Tasklet &aTasklet)
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(mTail != &aTasklet && aTasklet.mNext == NULL, error = kThreadError_Busy);
+    VerifyOrExit(mTail != &aTasklet && aTasklet.mNext == NULL, error = kThreadError_Already);
 
     if (mTail == NULL)
     {

--- a/src/core/common/tasklet.hpp
+++ b/src/core/common/tasklet.hpp
@@ -113,7 +113,7 @@ public:
      * @param[in]  aTasklet  A reference to the tasklet to enqueue.
      *
      * @retval kThreadError_None  Successfully enqueued the tasklet.
-     * @retval kThreadError_Busy  The tasklet was already enqueued.
+     * @retval kThreadError_Already  The tasklet was already enqueued.
      */
     ThreadError Post(Tasklet &aTasklet);
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -466,7 +466,7 @@ ThreadError Mac::SendFrameRequest(Sender &aSender)
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(mSendTail != &aSender && aSender.mNext == NULL, error = kThreadError_Busy);
+    VerifyOrExit(mSendTail != &aSender && aSender.mNext == NULL, error = kThreadError_Already);
 
     if (mSendHead == NULL)
     {

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -265,7 +265,7 @@ public:
      * @param[in]  aReceiver  A reference to the MAC receiver client.
      *
      * @retval kThreadError_None  Successfully registered the receiver.
-     * @retval kThreadError_Busy  The receiver was already registered.
+     * @retval kThreadError_Already  The receiver was already registered.
      *
      */
     ThreadError RegisterReceiver(Receiver &aReceiver);
@@ -276,7 +276,7 @@ public:
      * @param[in]  aSender  A reference to the MAC sender client.
      *
      * @retval kThreadError_None  Successfully registered the sender.
-     * @retval kThreadError_Busy  The sender was already registered.
+     * @retval kThreadError_Already  The sender was already registered.
      *
      */
     ThreadError SendFrameRequest(Sender &aSender);

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -70,7 +70,7 @@ ThreadError Icmp::RegisterCallbacks(IcmpHandler &aHandler)
     {
         if (cur == &aHandler)
         {
-            ExitNow(error = kThreadError_Busy);
+            ExitNow(error = kThreadError_Already);
         }
     }
 

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -282,7 +282,7 @@ public:
      * @param[in]  aHandler  A reference to the ICMPv6 handler.
      *
      * @retval kThreadError_None  Successfully registered the ICMPv6 handler.
-     * @retval kThreadError_Busy  The ICMPv6 handler is already registered.
+     * @retval kThreadError_Already  The ICMPv6 handler is already registered.
      *
      */
     ThreadError RegisterCallbacks(IcmpHandler &aHandler);

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -624,7 +624,7 @@ ThreadError Ip6::AddNetif(Netif &aNetif)
         {
             if (netif == &aNetif)
             {
-                ExitNow(error = kThreadError_Busy);
+                ExitNow(error = kThreadError_Already);
             }
         }
         while (netif->mNext);
@@ -645,9 +645,9 @@ exit:
 
 ThreadError Ip6::RemoveNetif(Netif &aNetif)
 {
-    ThreadError error = kThreadError_None;
+    ThreadError error = kThreadError_NotFound;
 
-    VerifyOrExit(mNetifListHead != NULL, error = kThreadError_Busy);
+    VerifyOrExit(mNetifListHead != NULL, error = kThreadError_NotFound);
 
     if (mNetifListHead == &aNetif)
     {
@@ -663,6 +663,7 @@ ThreadError Ip6::RemoveNetif(Netif &aNetif)
             }
 
             netif->mNext = aNetif.mNext;
+            error = kThreadError_None;
             break;
         }
     }

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -248,7 +248,7 @@ public:
      * @param  aNetif  A reference to the network interface.
      *
      * @retval kThreadError_None  Successfully enabled the network interface.
-     * @retval KThreadError_Busy  The network interface was already enabled.
+     * @retval KThreadError_Already  The network interface was already enabled.
      *
      */
     ThreadError AddNetif(Netif &aNetif);
@@ -259,7 +259,7 @@ public:
      * @param  aNetif  A reference to the network interface.
      *
      * @retval kThreadError_None  Successfully disabled the network interface.
-     * @retval KThreadError_Busy  The network interface was already disabled.
+     * @retval KThreadError_NotFound  The network interface was already disabled.
      *
      */
     ThreadError RemoveNetif(Netif &aNetif);

--- a/src/core/net/ip6_routes.cpp
+++ b/src/core/net/ip6_routes.cpp
@@ -52,7 +52,7 @@ ThreadError Routes::Add(Route &aRoute)
 
     for (Route *cur = mRoutes; cur; cur = cur->mNext)
     {
-        VerifyOrExit(cur != &aRoute, error = kThreadError_Busy);
+        VerifyOrExit(cur != &aRoute, error = kThreadError_Already);
     }
 
     aRoute.mNext = mRoutes;

--- a/src/core/net/ip6_routes.hpp
+++ b/src/core/net/ip6_routes.hpp
@@ -81,7 +81,7 @@ public:
      * @param[in]  aRoute  A reference to the IPv6 route.
      *
      * @retval kThreadError_None  Successfully added the route.
-     * @retval kThreadError_Busy  The route was already added.
+     * @retval kThreadError_Already  The route was already added.
      *
      */
     ThreadError Add(Route &aRoute);
@@ -92,7 +92,7 @@ public:
      * @param[in]  aRoute  A reference to the IPv6 route.
      *
      * @retval kThreadError_None         Successfully removed the route.
-     * @retval kThreadError_InvalidArgs  The route was not added.
+     * @retval kThreadError_NotFound  The route was not added.
      *
      */
     ThreadError Remove(Route &aRoute);

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -63,7 +63,7 @@ ThreadError Netif::RegisterCallback(NetifCallback &aCallback)
     {
         if (cur == &aCallback)
         {
-            ExitNow(error = kThreadError_Busy);
+            ExitNow(error = kThreadError_Already);
         }
     }
 
@@ -132,7 +132,7 @@ ThreadError Netif::SubscribeMulticast(NetifMulticastAddress &aAddress)
     {
         if (cur == &aAddress)
         {
-            ExitNow(error = kThreadError_Busy);
+            ExitNow(error = kThreadError_Already);
         }
     }
 
@@ -183,7 +183,7 @@ ThreadError Netif::AddUnicastAddress(NetifUnicastAddress &aAddress)
     {
         if (cur == &aAddress)
         {
-            ExitNow(error = kThreadError_Busy);
+            ExitNow(error = kThreadError_Already);
         }
     }
 

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -241,8 +241,8 @@ public:
      *
      * @param[in]  aAddress  A reference to the unicast address.
      *
-     * @retval kThreadError_None  Successfully added the unicast address.
-     * @retval kThreadError_Busy  The unicast address was already added.
+     * @retval kThreadError_None     Successfully added the unicast address.
+     * @retval kThreadError_Already  The unicast address was already added.
      *
      */
     ThreadError AddUnicastAddress(NetifUnicastAddress &aAddress);
@@ -320,8 +320,8 @@ public:
      *
      * @param[in]  aAddress  A reference to the multicast address.
      *
-     * @retval kThreadError_None   Successfully subscribed to @p aAddress.
-     * @retval kThreadError_Busy   The multicast address is already subscribed.
+     * @retval kThreadError_None     Successfully subscribed to @p aAddress.
+     * @retval kThreadError_Already  The multicast address is already subscribed.
      *
      */
     ThreadError SubscribeMulticast(NetifMulticastAddress &aAddress);
@@ -331,8 +331,8 @@ public:
      *
      * @param[in]  aAddress  A reference to the multicast address.
      *
-     * @retval kThreadError_None   Successfully unsubscribed to @p aAddress.
-     * @retval kThreadError_Busy   The multicast address is already unsubscribed.
+     * @retval kThreadError_None     Successfully unsubscribed to @p aAddress.
+     * @retval kThreadError_Already  The multicast address is already unsubscribed.
      *
      */
     ThreadError UnsubscribeMulticast(const NetifMulticastAddress &aAddress);
@@ -342,8 +342,8 @@ public:
      *
      * @param[in]  aCallback  A reference to the callback.
      *
-     * @retval kThreadError_None   Successfully registered the callback.
-     * @retval kThreadError_Busy   The callback was already registered.
+     * @retval kThreadError_None    Successfully registered the callback.
+     * @retval kThreadError_Already The callback was already registered.
      */
     ThreadError RegisterCallback(NetifCallback &aCallback);
 

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -85,8 +85,8 @@ public:
      * @param[in]  aHandler  A pointer to a function that is called when receiving UDP messages.
      * @param[in]  aContext  A pointer to arbitrary context information.
      *
-     * @retval kThreadError_None  Successfully opened the socket.
-     * @retval kThreadError_Busy  The socket is already open.
+     * @retval kThreadError_None     Successfully opened the socket.
+     * @retval kThreadError_Already  The socket is already open.
      *
      */
     ThreadError Open(otUdpReceive aHandler, void *aContext);

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -862,7 +862,7 @@ ThreadError otSetLinkPromiscuous(otInstance *aInstance, bool aPromiscuous)
     ThreadError error = kThreadError_None;
 
     // cannot enable IEEE 802.15.4 promiscuous mode if the Thread interface is enabled
-    VerifyOrExit(aInstance->mThreadNetif.IsUp() == false, error = kThreadError_Busy);
+    VerifyOrExit(aInstance->mThreadNetif.IsUp() == false, error = kThreadError_InvalidState);
 
     aInstance->mThreadNetif.GetMac().SetPromiscuous(aPromiscuous);
 
@@ -1263,7 +1263,7 @@ int otWriteMessage(otMessage aMessage, uint16_t aOffset, const void *aBuf, uint1
 
 ThreadError otOpenUdpSocket(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aCallbackContext)
 {
-    ThreadError error = kThreadError_Busy;
+    ThreadError error = kThreadError_InvalidArgs;
     Ip6::UdpSocket *socket = static_cast<Ip6::UdpSocket *>(aSocket);
 
     if (socket->mTransport == NULL)

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -90,11 +90,12 @@ ThreadError MeshForwarder::Start()
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(mEnabled == false, error = kThreadError_Busy);
-    mMac.SetRxOnWhenIdle(true);
-    mEnabled = true;
+    if (mEnabled == false)
+    {
+        mMac.SetRxOnWhenIdle(true);
+        mEnabled = true;
+    }
 
-exit:
     return error;
 }
 
@@ -103,7 +104,7 @@ ThreadError MeshForwarder::Stop()
     ThreadError error = kThreadError_None;
     Message *message;
 
-    VerifyOrExit(mEnabled == true, error = kThreadError_Busy);
+    VerifyOrExit(mEnabled == true,);
 
     mPollTimer.Stop();
     mReassemblyTimer.Stop();

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -82,7 +82,6 @@ public:
      * This method enables mesh forwarding and the IEEE 802.15.4 MAC layer.
      *
      * @retval kThreadError_None          Successfully enabled the mesh forwarder.
-     * @retval kThreadError_InvalidState  The mesh forwarder was already enabled.
      *
      */
     ThreadError Start(void);
@@ -91,7 +90,6 @@ public:
      * This method disables mesh forwarding and the IEEE 802.15.4 MAC layer.
      *
      * @retval kThreadError_None          Successfully disabled the mesh forwarder.
-     * @retval kThreadError_InvalidState  The mesh forwarder was already disabled.
      *
      */
     ThreadError Stop(void);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -195,7 +195,7 @@ ThreadError Mle::Start(void)
     ThreadError error = kThreadError_None;
 
     // cannot bring up the interface if IEEE 802.15.4 promiscuous mode is enabled
-    VerifyOrExit(otPlatRadioGetPromiscuous(mNetif.GetInstance()) == false, error = kThreadError_Busy);
+    VerifyOrExit(otPlatRadioGetPromiscuous(mNetif.GetInstance()) == false, error = kThreadError_InvalidState);
     VerifyOrExit(mNetif.IsUp(), error = kThreadError_InvalidState);
 
     mDeviceState = kDeviceStateDetached;
@@ -302,7 +302,7 @@ ThreadError Mle::BecomeDetached(void)
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(mDeviceState != kDeviceStateDisabled, error = kThreadError_Busy);
+    VerifyOrExit(mDeviceState != kDeviceStateDisabled, error = kThreadError_InvalidState);
 
     SetStateDetached();
     SetRloc16(Mac::kShortAddrInvalid);
@@ -316,8 +316,8 @@ ThreadError Mle::BecomeChild(otMleAttachFilter aFilter)
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(mDeviceState != kDeviceStateDisabled &&
-                 mParentRequestState == kParentIdle, error = kThreadError_Busy);
+    VerifyOrExit(mDeviceState != kDeviceStateDisabled, error = kThreadError_InvalidState);
+    VerifyOrExit(mParentRequestState == kParentIdle, error = kThreadError_Busy);
 
     mParentRequestState = kParentRequestStart;
     mParentRequestMode = aFilter;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -339,8 +339,8 @@ public:
     /**
      * This method enables MLE.
      *
-     * @retval kThreadError_None  Successfully enabled MLE.
-     * @retval kThreadError_Busy  MLE was already enabled.
+     * @retval kThreadError_None     Successfully enabled MLE.
+     * @retval kThreadError_Already  MLE was already enabled.
      *
      */
     ThreadError Enable(void);
@@ -348,8 +348,7 @@ public:
     /**
      * This method disables MLE.
      *
-     * @retval kThreadError_None  Successfully disabled MLE.
-     * @retval kThreadError_Busy  MLE was already disabled.
+     * @retval kThreadError_None     Successfully disabled MLE.
      *
      */
     ThreadError Disable(void);
@@ -357,8 +356,8 @@ public:
     /**
      * This method starts the MLE protocol operation.
      *
-     * @retval kThreadError_None  Successfully started the protocol operation.
-     * @retval kThreadError_Busy  The protocol operation was already started.
+     * @retval kThreadError_None     Successfully started the protocol operation.
+     * @retval kThreadError_Already  The protocol operation was already started.
      *
      */
     ThreadError Start(void);
@@ -367,7 +366,6 @@ public:
      * This method stops the MLE protocol operation.
      *
      * @retval kThreadError_None  Successfully stopped the protocol operation.
-     * @retval kThreadError_Busy  The protocol operation was already stopped.
      *
      */
     ThreadError Stop(void);
@@ -425,8 +423,8 @@ public:
     /**
      * This method causes the Thread interface to detach from the Thread network.
      *
-     * @retval kThreadError_None  Successfully detached from the Thread network.
-     * @retval kThreadError_Busy  The protocol operation was stopped.
+     * @retval kThreadError_None          Successfully detached from the Thread network.
+     * @retval kThreadError_InvalidState  MLE is Disabled.
      *
      */
     ThreadError BecomeDetached(void);
@@ -436,8 +434,9 @@ public:
      *
      * @param[in]  aFilter  Indicates what partitions to attach to.
      *
-     * @retval kThreadError_None  Successfully began the attach process.
-     * @retval kThreadError_Busy  An attach process is in progress or the protocol operation was stopped.
+     * @retval kThreadError_None          Successfully began the attach process.
+     * @retval kThreadError_InvalidState  MLE is Disabled.
+     * @retval kThreadError_Busy          An attach process is in progress.
      *
      */
     ThreadError BecomeChild(otMleAttachFilter aFilter);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -198,9 +198,9 @@ ThreadError MleRouter::BecomeRouter(ThreadStatusTlv::Status aStatus)
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(mDeviceState == kDeviceStateDetached || mDeviceState == kDeviceStateChild,
-                 error = kThreadError_Busy);
-    VerifyOrExit(mRouterRoleEnabled && (mDeviceMode & ModeTlv::kModeFFD), error = kThreadError_InvalidState);
+    VerifyOrExit(mDeviceState != kDeviceStateDisabled, error = kThreadError_InvalidState);
+    VerifyOrExit(mDeviceState != kDeviceStateRouter, error = kThreadError_None);
+    VerifyOrExit(mRouterRoleEnabled && (mDeviceMode & ModeTlv::kModeFFD), error = kThreadError_NotCapable);
 
     for (int i = 0; i <= kMaxRouterId; i++)
     {
@@ -239,9 +239,9 @@ ThreadError MleRouter::BecomeLeader(void)
     ThreadError error = kThreadError_None;
     uint8_t routerId;
 
-    VerifyOrExit(mDeviceState != kDeviceStateDisabled && mDeviceState != kDeviceStateLeader,
-                 error = kThreadError_Busy);
-    VerifyOrExit(mRouterRoleEnabled && (mDeviceMode & ModeTlv::kModeFFD), error = kThreadError_InvalidState);
+    VerifyOrExit(mDeviceState != kDeviceStateDisabled, error = kThreadError_InvalidState);
+    VerifyOrExit(mDeviceState != kDeviceStateLeader, error = kThreadError_None);
+    VerifyOrExit(mRouterRoleEnabled && (mDeviceMode & ModeTlv::kModeFFD), error = kThreadError_NotCapable);
 
     for (int i = 0; i <= kMaxRouterId; i++)
     {

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -219,7 +219,8 @@ public:
      * @param[in]  aStatus  The reason for requesting a Router ID.
      *
      * @retval kThreadError_None          Successfully generated an Address Solicit message.
-     * @retval kThreadError_InvalidState  Not currently an End Device.
+     * @retval kThreadError_NotCapable    Device is not capable of becoming a router
+     * @retval kThreadError_InvalidState  Thread is not enabled
      *
      */
     ThreadError BecomeRouter(ThreadStatusTlv::Status aStatus);
@@ -228,7 +229,8 @@ public:
      * This method causes the Thread interface to become a Leader and start a new partition.
      *
      * @retval kThreadError_None          Successfully become a Leader and started a new partition.
-     * @retval kThreadError_InvalidState  Either MLE is disabled or the interface is already a Leader.
+     * @retval kThreadError_NotCapable    Device is not capable of becoming a leader
+     * @retval kThreadError_InvalidState  Thread is not enabled
      *
      */
     ThreadError BecomeLeader(void);

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -94,18 +94,16 @@ const char *ThreadNetif::GetName(void) const
 
 ThreadError ThreadNetif::Up(void)
 {
-    ThreadError error = kThreadError_None;
+    if (!mIsUp)
+    {
+        mIp6.AddNetif(*this);
+        mMeshForwarder.Start();
+        mCoapServer.Start();
+        mMleRouter.Enable();
+        mIsUp = true;
+    }
 
-    VerifyOrExit(!mIsUp, error = kThreadError_Already);
-
-    mIp6.AddNetif(*this);
-    mMeshForwarder.Start();
-    mCoapServer.Start();
-    mMleRouter.Enable();
-    mIsUp = true;
-
-exit:
-    return error;
+    return kThreadError_None;
 }
 
 ThreadError ThreadNetif::Down(void)


### PR DESCRIPTION
This change is attempting to address two issues:

1.  Returning `kThreadError_Busy`, when `kThreadError_Already`, `kThreadError_InvalidState`, or even the lazy `kThreadError_Failed` would be more-appropriate/less-misleading.
2.  Setters returning an error when the value to be changed is already set to the requested value.

Number one hurts debuggability. Number two makes the code more fragile. The cases where both intersect can be maddening.

This change replaces cases inappropriately returning `kThreadError_Busy` with a better, more specific error code. It also makes some "setter" functions (Including `otInterfaceUp()` and `otThreadStart()`) return success if the value is already set.