### PR TITLE
Include timestamp tlv in Child ID Response only when it is necessary

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2093,6 +2093,7 @@ ThreadError MleRouter::HandleChildIdRequest(const Message &aMessage, const Ip6::
         mNetif.GetActiveDataset().GetNetwork().GetTimestamp()->Compare(activeTimestamp) != 0)
     {
         child->mRequestTlvs[numTlvs++] = Tlv::kActiveDataset;
+        child->mRequestTlvs[numTlvs++] = Tlv::kActiveTimestamp;
     }
 
     if (pendingTimestamp.GetLength() == 0 ||
@@ -2100,6 +2101,7 @@ ThreadError MleRouter::HandleChildIdRequest(const Message &aMessage, const Ip6::
         mNetif.GetPendingDataset().GetNetwork().GetTimestamp()->Compare(pendingTimestamp) != 0)
     {
         child->mRequestTlvs[numTlvs++] = Tlv::kPendingDataset;
+        child->mRequestTlvs[numTlvs++] = Tlv::kPendingTimestamp;
     }
 
     switch (GetDeviceState())
@@ -2307,8 +2309,6 @@ ThreadError MleRouter::SendChildIdResponse(Child *aChild)
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandChildIdResponse));
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
-    SuccessOrExit(error = AppendActiveTimestamp(*message));
-    SuccessOrExit(error = AppendPendingTimestamp(*message));
 
     // pick next Child ID that is not being used
     do
@@ -2345,6 +2345,14 @@ ThreadError MleRouter::SendChildIdResponse(Child *aChild)
 
         case Tlv::kPendingDataset:
             SuccessOrExit(error = AppendPendingDataset(*message));
+            break;
+
+        case Tlv::kActiveTimestamp:
+            SuccessOrExit(error = AppendActiveTimestamp(*message));
+            break;
+
+        case Tlv::kPendingTimestamp:
+            SuccessOrExit(error = AppendPendingTimestamp(*message));
             break;
         }
     }

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -105,7 +105,7 @@ public:
     Ip6::Address mIp6Address[kMaxIp6AddressPerChild];  ///< Registered IPv6 addresses
     uint32_t     mTimeout;                             ///< Child timeout
     uint16_t     mFragmentOffset;                      ///< 6LoWPAN fragment offset
-    uint8_t      mRequestTlvs[5];                      ///< Requested MLE TLVs
+    uint8_t      mRequestTlvs[7];                      ///< Requested MLE TLVs
     uint8_t      mNetworkDataVersion;                  ///< Current Network Data version
     uint16_t     mQueuedIndirectMessageCnt;            ///< Count of queued messages
     bool         mAddSrcMatchEntryShort;               ///< Indicates whether or not to force add short address


### PR DESCRIPTION
This does not help to pass any certification test, just to make this part specification compliant.