### PR TITLE
Trickle Timer: Allow other modules to set Imin and Imax on same value

### DIFF
--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -71,7 +71,14 @@ void TrickleTimer::Start(uint32_t aIntervalMin, uint32_t aIntervalMax, Mode aMod
     mMode = aMode;
 
     // Initialize I to [Imin, Imax]
-    I = Imin + otPlatRandomGet() % (Imax - Imin);
+    if (Imin == Imax)
+    {
+        I = Imin;
+    }
+    else
+    {
+        I = Imin + otPlatRandomGet() % (Imax - Imin);
+    }
 
     // Start a new interval
     StartNewInterval();


### PR DESCRIPTION
Currently, when TrickleTimer::Start method is called with same aIntervalMin
and aIntervalMax values, the remainder used to calculate I is 0, which causes an
Arithmetic Error and crash of the program.

MPL uses Imin and Imax equal to 64ms.