### PR TITLE
Message: Add Clone method.

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -463,8 +463,12 @@ Message *Message::Clone(void) const
     VerifyOrExit((messageCopy = GetMessagePool()->New(GetType(), GetReserved())) != NULL, error = kThreadError_NoBufs);
     SuccessOrExit(error = messageCopy->SetLength(GetLength()));
     CopyTo(0, 0, GetLength(), *messageCopy);
-    memcpy(&messageCopy->mInfo, &mInfo, sizeof(mInfo));
-    memset(&messageCopy->mInfo.mList, 0, sizeof(messageCopy->mInfo.mList));
+
+    // Copy selected message information.
+    messageCopy->SetOffset(GetOffset());
+    messageCopy->SetInterfaceId(GetInterfaceId());
+    messageCopy->SetSubType(GetSubType());
+    messageCopy->SetLinkSecurityEnabled(IsLinkSecurityEnabled());
 
 exit:
 

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -455,6 +455,28 @@ int Message::CopyTo(uint16_t aSourceOffset, uint16_t aDestinationOffset, uint16_
     return bytesCopied;
 }
 
+Message *Message::Clone(void) const
+{
+    ThreadError error = kThreadError_None;
+    Message *messageCopy;
+
+    VerifyOrExit((messageCopy = GetMessagePool()->New(GetType(), GetReserved())) != NULL, error = kThreadError_NoBufs);
+    SuccessOrExit(error = messageCopy->SetLength(GetLength()));
+    CopyTo(0, 0, GetLength(), *messageCopy);
+    memcpy(&messageCopy->mInfo, &mInfo, sizeof(mInfo));
+    memset(&messageCopy->mInfo.mList, 0, sizeof(messageCopy->mInfo.mList));
+
+exit:
+
+    if (error != kThreadError_None && messageCopy != NULL)
+    {
+        messageCopy->Free();
+        messageCopy = NULL;
+    }
+
+    return messageCopy;
+}
+
 uint16_t Message::GetDatagramTag(void) const
 {
     return mInfo.mDatagramTag;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -385,6 +385,14 @@ public:
     int CopyTo(uint16_t aSourceOffset, uint16_t aDestinationOffset, uint16_t aLength, Message &aMessage) const;
 
     /**
+     * This method creates an exact copy of the current Message. It allocates the new one
+     * from the same Message Poll as the original Message.
+     *
+     * @returns A pointer to the message or NULL if insufficient message buffers are available.
+     */
+    Message *Clone(void) const;
+
+    /**
      * This method returns the datagram tag used for 6LoWPAN fragmentation.
      *
      * @returns The 6LoWPAN datagram tag.
@@ -559,7 +567,7 @@ public:
     uint16_t UpdateChecksum(uint16_t aChecksum, uint16_t aOffset, uint16_t aLength) const;
 
 private:
-    MessagePool *GetMessagePool(void) { return mInfo.mMessagePool; }
+    MessagePool *GetMessagePool(void) const { return mInfo.mMessagePool; }
 
     void SetMessagePool(MessagePool *aMessagePool) { mInfo.mMessagePool = aMessagePool; }
 

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -385,7 +385,7 @@ public:
     int CopyTo(uint16_t aSourceOffset, uint16_t aDestinationOffset, uint16_t aLength, Message &aMessage) const;
 
     /**
-     * This method creates an exact copy of the current Message. It allocates the new one
+     * This method creates a copy of the current Message. It allocates the new one
      * from the same Message Poll as the original Message.
      *
      * @returns A pointer to the message or NULL if insufficient message buffers are available.

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -412,20 +412,10 @@ ThreadError Ip6::ProcessReceiveCallback(const Message &aMessage, const MessageIn
     }
 
     // make a copy of the datagram to pass to host
-    VerifyOrExit((messageCopy = NewMessage(0)) != NULL, error = kThreadError_NoBufs);
-    SuccessOrExit(error = messageCopy->SetLength(aMessage.GetLength()));
-    aMessage.CopyTo(0, 0, aMessage.GetLength(), *messageCopy);
-    messageCopy->SetLinkSecurityEnabled(aMessage.IsLinkSecurityEnabled());
-
+    VerifyOrExit((messageCopy = aMessage.Clone()) != NULL, error = kThreadError_NoBufs);
     mReceiveIp6DatagramCallback(messageCopy, mReceiveIp6DatagramCallbackContext);
 
 exit:
-
-    if (error != kThreadError_None && messageCopy != NULL)
-    {
-        messageCopy->Free();
-    }
-
     return error;
 }
 


### PR DESCRIPTION
Message cloning is done only inside ip6.cpp right now, but this method
might be useful for incoming MPL and CoAP retransmissions in order to not repeat the same
code.

Question: Right now proposition is to do memcpy of mInfo structure and clear only lists. The alternative would be to copy some parameters manually:
 - offset
 - subtype
 - link security
 - interface_id
 - something else?