### PR TITLE
ncp: Fix handling of FCS for PROP_STREAM_RAW

### DIFF
--- a/doc/spinel-protocol-src/spinel-prop-core.md
+++ b/doc/spinel-protocol-src/spinel-prop-core.md
@@ -306,13 +306,12 @@ an appropriate transmit power will be chosen by the NCP.
 
 The bit values in `MD_FLAG` are defined as follows:
 
- Bit | Mask   | Name             | Description if set
------|--------|:-----------------|:----------------
-15   | 0x0001 | MD_FLAG_TX       | Packet was transmitted, not received.
-14   | 0x0002 | MD_FLAG_HAS_FCS  | Packet includes received PHY FCS
-13   | 0x0004 | MD_FLAG_BAD_FCS  | Packet was received with bad FCS
-12   | 0x0008 | MD_FLAG_DUPE     | Packet seems to be a duplicate
-0-11 | 0xFFF0 | MD_FLAG_RESERVED | Flags reserved for future use.
+ Bit     | Mask   | Name              | Description if set
+---------|--------|:------------------|:----------------
+15       | 0x0001 | MD_FLAG_TX        | Packet was transmitted, not received.
+13       | 0x0004 | MD_FLAG_BAD_FCS   | Packet was received with bad FCS
+12       | 0x0008 | MD_FLAG_DUPE      | Packet seems to be a duplicate
+0-11, 14 | 0xFFF2 | MD_FLAG_RESERVED  | Flags reserved for future use.
 
 The format of `MD_PHY` is specified by the PHY layer currently in use,
 and may contain information such as the channel, LQI, antenna, or other

--- a/include/platform/radio.h
+++ b/include/platform/radio.h
@@ -104,7 +104,6 @@ typedef struct RadioPacket
     uint8_t  mLqi;             ///< Link Quality Indicator for received frames.
     bool     mSecurityValid: 1; ///< Security Enabled flag is set and frame passes security checks.
     bool     mDidTX: 1;        ///< Set to true if this packet sent from the radio. Ignored by radio driver.
-    uint16_t mFcs;             ///< Final checksum (optional)
 } RadioPacket;
 
 /**

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -534,10 +534,6 @@ void NcpBase::HandleRawFrame(const RadioPacket *aFrame)
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
 
-    if (aFrame->mFcs != 0x0000)
-    {
-        flags |= SPINEL_MD_FLAG_HAS_FCS;
-    }
 
     if (aFrame->mDidTX)
     {
@@ -551,11 +547,7 @@ void NcpBase::HandleRawFrame(const RadioPacket *aFrame)
             SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
             SPINEL_CMD_PROP_VALUE_IS,
             SPINEL_PROP_STREAM_RAW,
-            aFrame->mLength + (
-                ((flags & SPINEL_MD_FLAG_HAS_FCS) == SPINEL_MD_FLAG_HAS_FCS)
-                ? 2 // +2 if we are appending the FCS
-                : 0 // +0 if we aren't appending the FCS
-            )
+            aFrame->mLength
         )
     );
 
@@ -566,18 +558,6 @@ void NcpBase::HandleRawFrame(const RadioPacket *aFrame)
             aFrame->mLength
         )
     );
-
-    if ((flags & SPINEL_MD_FLAG_HAS_FCS) == SPINEL_MD_FLAG_HAS_FCS)
-    {
-        // Append the FCS
-        SuccessOrExit(
-            errorCode = OutboundFrameFeedPacked(
-                "CC",
-                (aFrame->mFcs >> 0) & 0xFF,
-                (aFrame->mFcs >> 8) & 0xFF
-            )
-        );
-    }
 
     // Append metadata (rssi, etc)
     SuccessOrExit(

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -69,7 +69,7 @@
 // ----------------------------------------------------------------------------
 
 #define SPINEL_PROTOCOL_VERSION_THREAD_MAJOR    4
-#define SPINEL_PROTOCOL_VERSION_THREAD_MINOR    1
+#define SPINEL_PROTOCOL_VERSION_THREAD_MINOR    2
 
 #define SPINEL_FRAME_MAX_SIZE                   1300
 
@@ -236,11 +236,10 @@ typedef unsigned int spinel_cid_t;
 
 enum
 {
-    SPINEL_MD_FLAG_TX               = 0x0001,
-    SPINEL_MD_FLAG_HAS_FCS          = 0x0002,
-    SPINEL_MD_FLAG_BAD_FCS          = 0x0004,
-    SPINEL_MD_FLAG_DUPE             = 0x0008,
-    SPINEL_MD_FLAG_RESERVED         = 0xFFF0,
+    SPINEL_MD_FLAG_TX               = 0x0001, //!< Packet was transmitted, not received.
+    SPINEL_MD_FLAG_BAD_FCS          = 0x0004, //!< Packet was received with bad FCS
+    SPINEL_MD_FLAG_DUPE             = 0x0008, //!< Packet seems to be a duplicate
+    SPINEL_MD_FLAG_RESERVED         = 0xFFF2, //!< Flags reserved for future use.
 };
 
 enum


### PR DESCRIPTION
The way the FCS was handled previously was based on assumptions (Like the `mLength` field of `RadioPacket` didn't include a CRC) that were incorrect. This change fixes that issue and also simplifies how the protocol handles the FCS bytes for `PROP_STREAM_RAW`.

This commit addresses #808.