### PR TITLE
Update otNewUdpMessage() to allow user to enable/disable layer 2 security

### DIFF
--- a/include/openthread.h
+++ b/include/openthread.h
@@ -2244,13 +2244,14 @@ uint8_t otIp6PrefixMatch(const otIp6Address *aFirst, const otIp6Address *aSecond
 /**
  * Allocate a new message buffer for sending a UDP message.
  *
- * @param[in]  aInstance A pointer to an OpenThread instance.
+ * @param[in]  aInstance             A pointer to an OpenThread instance.
+ * @param[in]  aLinkSecurityEnabled  TRUE if the message should be secured at Layer 2.
  *
  * @returns A pointer to the message buffer or NULL if no message buffers are available.
  *
  * @sa otFreeMessage
  */
-otMessage otNewUdpMessage(otInstance *aInstance);
+otMessage otNewUdpMessage(otInstance *aInstance, bool aLinkSecurityEnabled);
 
 /**
  * Open a UDP/IPv6 socket.

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -99,7 +99,7 @@ int Udp::Output(const char *aBuf, uint16_t aBufLength)
     ThreadError error = kThreadError_None;
     otMessage message;
 
-    VerifyOrExit((message = otNewUdpMessage(mInstance)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = otNewUdpMessage(mInstance, true)) != NULL, error = kThreadError_NoBufs);
     SuccessOrExit(error = otSetMessageLength(message, aBufLength));
     otWriteMessage(message, 0, aBuf, aBufLength);
     SuccessOrExit(error = otSendUdp(&mSocket, message, &mPeer));

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -1224,9 +1224,16 @@ ThreadError otSendIp6Datagram(otInstance *aInstance, otMessage aMessage)
                                           NULL, true);
 }
 
-otMessage otNewUdpMessage(otInstance *aInstance)
+otMessage otNewUdpMessage(otInstance *aInstance, bool aLinkSecurityEnabled)
 {
-    return aInstance->mIp6.mUdp.NewMessage(0);
+    Message *message = aInstance->mIp6.mUdp.NewMessage(0);
+
+    if (message)
+    {
+        message->SetLinkSecurityEnabled(aLinkSecurityEnabled);
+    }
+
+    return message;
 }
 
 otMessage otNewIp6Message(otInstance *aInstance, bool aLinkSecurityEnabled)


### PR DESCRIPTION
In `otNewIp6Message()` we have `aLinkSecurityEnabled` as an input argument to enable/disable layer 2 security for a message. This commit adds the same option for `otNewUdpMessage()`.