### PR TITLE
Do not set link security for MLE Announce message.

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1421,11 +1421,11 @@ ThreadError Mle::SendAnnounce(uint8_t aChannel)
     PanIdTlv panid;
     Ip6::Address destination;
     Message *message;
-    (void)aChannel;
 
     VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, ;);
     message->SetSubType(Message::kSubTypeMleAnnounce);
     message->SetChannel(aChannel);
+    message->SetLinkSecurityEnabled(false);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandAnnounce));
 
     channel.Init();


### PR DESCRIPTION
Harness cannot parse MLE Announce message correctly that includes auxiliary security header in link layer.