### PR TITLE
Added non-sized delete opertor to fix compilation on gcc 6.

### DIFF
--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -64,6 +64,7 @@ otInstance *sInstance = NULL;
 #endif
 
 void OT_CDECL operator delete(void *, size_t) throw() { }
+void OT_CDECL operator delete(void *) throw() {}
 
 otInstance::otInstance(void) :
     mReceiveIp6DatagramCallback(NULL),


### PR DESCRIPTION
This PR fixes -Werror=sized-deallocation on gcc 6.2.1

```
  openthread.cpp:66:15: error: the program should also define ‘void operator delete(void*)’ [-Werror=sized-deallocation]
   void OT_CDECL operator delete(void *, size_t) throw() { }
```
