### PR TITLE
on OSX I had an issue running the sniffer after following the readme

### DIFF
--- a/tools/spinel-cli/SNIFFER.md
+++ b/tools/spinel-cli/SNIFFER.md
@@ -96,6 +96,7 @@ open up wireshark, and start streaming packets into wireshark.
 
 ## Troubleshooting
 Q: sniffer.py throws ```ImportError: No module named dnet``` on OSX
+
 A: install the libdnet package for OSX -
 ```
 brew install --with-python libdnet
@@ -104,5 +105,6 @@ touch /Users/YourUsernameHere/Library/Python/2.7/lib/python/site-packages/homebr
 echo 'import site; site.addsitedir("/usr/local/lib/python2.7/site-packages")' >> /Users/YourUsernameHere/Library/Python/2.7/lib/python/site-packages/homebrew.pth
 ```
 you may need to reinstall the scapy pip dependency listed above
+
 you can read more about this issue here: http://stackoverflow.com/questions/26229057/scapy-installation-fails-on-osx-with-dnet-import-error
 

--- a/tools/spinel-cli/SNIFFER.md
+++ b/tools/spinel-cli/SNIFFER.md
@@ -94,3 +94,15 @@ This will connect to stock openthread ncp firmware over the given UART,
 make the node into a promiscuous mode sniffer on the given channel, 
 open up wireshark, and start streaming packets into wireshark. 
 
+## Troubleshooting
+Q: sniffer.py throws ```ImportError: No module named dnet``` on OSX
+A: install the libdnet package for OSX -
+```
+brew install --with-python libdnet
+mkdir -p /Users/YourUsernameHere/Library/Python/2.7/lib/python/site-packages
+touch /Users/YourUsernameHere/Library/Python/2.7/lib/python/site-packages/homebrew.pth
+echo 'import site; site.addsitedir("/usr/local/lib/python2.7/site-packages")' >> /Users/YourUsernameHere/Library/Python/2.7/lib/python/site-packages/homebrew.pth
+```
+you may need to reinstall the scapy pip dependency listed above
+you can read more about this issue here: http://stackoverflow.com/questions/26229057/scapy-installation-fails-on-osx-with-dnet-import-error
+


### PR DESCRIPTION
on OSX I had an issue running sniffer.py due to dnet not being installed. This may be listed elsewhere in the repo, but it's nice to have all installation dependencies for a tool listed in
the readme for the tool.