### PR TITLE
Remove Netif name and rely on enumerated Interface Id's for netif.

### DIFF
--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -839,6 +839,14 @@ typedef struct otNetifAddress
 } otNetifAddress;
 
 /**
+ * This enumeration represents the list of allowable values for an InterfaceId.
+ */
+typedef enum otNetifInterfaceId
+{
+    OT_NETIF_INTERFACE_ID_THREAD = 1,  ///< The Thread Network interface ID.
+} otNetifInterfaceId;
+
+/**
  * This structure represents data used by Semantically Opaque IID Generator.
  *
  */

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1107,7 +1107,7 @@ void Interpreter::ProcessPing(int argc, char *argv[])
 
     memset(&sMessageInfo, 0, sizeof(sMessageInfo));
     SuccessOrExit(error = sMessageInfo.GetPeerAddr().FromString(argv[0]));
-    sMessageInfo.mInterfaceId = 1;
+    sMessageInfo.mInterfaceId = OT_NETIF_INTERFACE_ID_THREAD;
 
     sLength = 8;
     sCount = 1;

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -227,7 +227,7 @@ void Joiner::HandleUdpTransmit(void)
     messageInfo.GetPeerAddr().mFields.m16[0] = HostSwap16(0xfe80);
     messageInfo.GetPeerAddr().SetIid(mJoinerRouter);
     messageInfo.mPeerPort = mJoinerUdpPort;
-    messageInfo.mInterfaceId = 1;
+    messageInfo.mInterfaceId = OT_NETIF_INTERFACE_ID_THREAD;
 
     SuccessOrExit(error = mSocket.SendTo(*mTransmitMessage, messageInfo));
 

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -58,8 +58,7 @@ Ip6::Ip6(void):
     mReceiveIp6DatagramCallback(NULL),
     mReceiveIp6DatagramCallbackContext(NULL),
     mIsReceiveIp6FilterEnabled(false),
-    mNetifListHead(NULL),
-    mNextInterfaceId(1)
+    mNetifListHead(NULL)
 {
 }
 
@@ -609,7 +608,7 @@ ThreadError Ip6::AddNetif(Netif &aNetif)
 
         do
         {
-            if (netif == &aNetif)
+            if (netif == &aNetif || netif->mInterfaceId == aNetif.mInterfaceId)
             {
                 ExitNow(error = kThreadError_Already);
             }
@@ -620,11 +619,6 @@ ThreadError Ip6::AddNetif(Netif &aNetif)
     }
 
     aNetif.mNext = NULL;
-
-    if (aNetif.mInterfaceId < 0)
-    {
-        aNetif.mInterfaceId = mNextInterfaceId++;
-    }
 
 exit:
     return error;
@@ -673,22 +667,6 @@ Netif *Ip6::GetNetifById(int8_t aInterfaceId)
     for (netif = mNetifListHead; netif; netif = netif->mNext)
     {
         if (netif->GetInterfaceId() == aInterfaceId)
-        {
-            ExitNow();
-        }
-    }
-
-exit:
-    return netif;
-}
-
-Netif *Ip6::GetNetifByName(char *aName)
-{
-    Netif *netif;
-
-    for (netif = mNetifListHead; netif; netif = netif->mNext)
-    {
-        if (strcmp(netif->GetName(), aName) == 0)
         {
             ExitNow();
         }

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -283,16 +283,6 @@ public:
     Netif *GetNetifById(int8_t aInterfaceId);
 
     /**
-     * This method returns the network interface identified by @p aName.
-     *
-     * @param[in]  aName  A pointer to a NULL-terminated string.
-     *
-     * @returns A pointer to the network interface or NULL if none is found.
-     *
-     */
-    Netif *GetNetifByName(char *aName);
-
-    /**
      * This method indicates whether or not @p aAddress is assigned to a network interface.
      *
      * @param[in]  aAddress  A reference to the IPv6 address.
@@ -363,7 +353,6 @@ private:
     bool mIsReceiveIp6FilterEnabled;
 
     Netif *mNetifListHead;
-    int8_t mNextInterfaceId;
 };
 
 static inline Ip6 *Ip6FromTaskletScheduler(TaskletScheduler *aTaskletScheduler)

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -40,14 +40,14 @@
 namespace Thread {
 namespace Ip6 {
 
-Netif::Netif(Ip6 &aIp6):
+Netif::Netif(Ip6 &aIp6, int8_t aInterfaceId):
     mIp6(aIp6),
     mStateChangedTask(aIp6.mTaskletScheduler, &Netif::HandleStateChangedTask, this)
 {
     mCallbacks = NULL;
     mUnicastAddresses = NULL;
     mMulticastAddresses = NULL;
-    mInterfaceId = -1;
+    mInterfaceId = aInterfaceId;
     mAllRoutersSubscribed = false;
     mNext = NULL;
     mMaskExtUnicastAddresses = 0;

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -233,10 +233,11 @@ public:
     /**
      * This constructor initializes the network interface.
      *
-     * @param[in]  aIp6  A reference to the IPv6 network object.
+     * @param[in]  aIp6             A reference to the IPv6 network object.
+     * @param[in]  aInterfaceId     The interface ID for this object.
      *
      */
-    Netif(Ip6 &aIp6);
+    Netif(Ip6 &aIp6, int8_t aInterfaceId);
 
     /**
      * This method returns a reference to the IPv6 network object.
@@ -417,14 +418,6 @@ public:
      *
      */
     virtual ThreadError SendMessage(Message &aMessage) = 0;
-
-    /**
-     * This virtual method returns a NULL-terminated string that names the network interface.
-     *
-     * @returns A NULL-terminated string that names the network interface.
-     *
-     */
-    virtual const char *GetName(void) const = 0;
 
     /**
      * This virtual method fills out @p aAddress with the link address.

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -53,10 +53,8 @@ static const uint8_t kThreadMasterKey[] =
     0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
 };
 
-static const char name[] = "thread";
-
 ThreadNetif::ThreadNetif(Ip6::Ip6 &aIp6):
-    Netif(aIp6),
+    Netif(aIp6, OT_NETIF_INTERFACE_ID_THREAD),
     mCoapServer(aIp6.mUdp, kCoapUdpPort),
     mAddressResolver(*this),
     mActiveDataset(*this),
@@ -85,11 +83,6 @@ ThreadNetif::ThreadNetif(Ip6::Ip6 &aIp6):
     mEnergyScan(*this)
 {
     mKeyManager.SetMasterKey(kThreadMasterKey, sizeof(kThreadMasterKey));
-}
-
-const char *ThreadNetif::GetName(void) const
-{
-    return name;
 }
 
 ThreadError ThreadNetif::Up(void)

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -115,14 +115,6 @@ public:
     bool IsUp(void) const;
 
     /**
-     * This method returns a pointer to a NULL-terminated string that names the interface.
-     *
-     * @returns A pointer to a NULL-terminated string that names the interface.
-     *
-     */
-    const char *GetName(void) const;
-
-    /**
      * This method retrieves the link address.
      *
      * @param[out]  aAddress  A reference to the link address.

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -74,7 +74,7 @@ public:
      */
     enum State
 #if _WIN32
-        : unsigned int
+    : unsigned int
 #endif
     {
         kStateInvalid,                   ///< Neighbor link is invalid

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -74,7 +74,7 @@ public:
      */
     enum State
 #if _WIN32
-    : unsigned int
+        : unsigned int
 #endif
     {
         kStateInvalid,                   ///< Neighbor link is invalid


### PR DESCRIPTION
A defined Netif Interface ID enumeration has been added to openthread-types.h, allowing code both inside and out of OpenThread to specify well known InterfaceId values, such as within a otMessageInfo struct.

The Name member and associated API's, has been removed from the netif. This feature was not used and is no longer necessary now that all allowable Interface ID's are exposed in openthread-types.h