### PR TITLE
Fix #838: Freeze version of scapy package.

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -47,10 +47,10 @@ cd /tmp || die
 
     # Packages used by ncp tools.
     sudo -H pip install ipaddress || die
-    sudo -H pip install scapy || die
+    sudo -H pip install scapy==2.3.2 || die
     sudo -H pip install pyserial || die
     pip install ipaddress || die
-    pip install scapy || die
+    pip install scapy==2.3.2 || die
     pip install pyserial || die
 
     [ $BUILD_TARGET != pretty-check ] || {


### PR DESCRIPTION
Quick turn fix for travis failures in ncp-sim build due to IP address parsing regression in scapy.
Fixes #838.  Freeze version of scapy package.