### PR TITLE
Add gcc5 and gcc6 to travis build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-language: cpp
+language: generic
 
 sudo: required
 dist: trusty
@@ -43,29 +43,51 @@ after_success:
 matrix:
   include:
     - env: BUILD_TARGET="pretty-check"
-      compiler: clang
       os: linux
-    - env: BUILD_TARGET="scan-build"
-      compiler: clang
+    - env: BUILD_TARGET="scan-build" CC="clang" CXX="clang++"
       os: linux
+      compiler: clang
     - env: BUILD_TARGET="arm-gcc49"
-      compiler: gcc
       os: linux
+      compiler: gcc
     - env: BUILD_TARGET="arm-gcc54"
-      compiler: gcc
       os: linux
-    - env: BUILD_TARGET="posix"
+      compiler: gcc
+    - env: BUILD_TARGET="posix" CC="clang" CXX="clang++"
+      os: linux
       compiler: clang
+    - env: BUILD_TARGET="posix" CC="gcc" CXX="g++"
       os: linux
+      compiler: gcc
+    - env: BUILD_TARGET="posix" CC="gcc-5" CXX="g++-5"
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+            - g++-5
+    - env: BUILD_TARGET="posix" CC="gcc-6" CXX="g++-6"
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-6
+            - g++-6
     - env: BUILD_TARGET="posix-distcheck" VERBOSE=1
-      compiler: gcc
       os: linux
+      compiler: gcc
     - env: BUILD_TARGET="posix-32-bit" VERBOSE=1
-      compiler: gcc
       os: linux
+      compiler: gcc
     - env: BUILD_TARGET="posix-ncp-spi" VERBOSE=1
-      compiler: gcc
       os: linux
+      compiler: gcc
     - env: BUILD_TARGET="posix-ncp" VERBOSE=1
-      compiler: gcc
       os: linux
+      compiler: gcc

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -62,6 +62,8 @@ set -x
 }
 
 [ $BUILD_TARGET != posix ] || {
+    sh -c '$CC --version' || die
+    sh -c '$CXX --version' || die
     make -f examples/Makefile-posix || die
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -224,7 +224,7 @@ AC_PROG_LN_S
 #
 
 PROSPECTIVE_CFLAGS="-Wall -Wextra -Wshadow -Werror -std=c99 -pedantic-errors"
-PROSPECTIVE_CXXFLAGS="-Wall -Wextra -Wshadow -Werror -Wno-c++14-compat"
+PROSPECTIVE_CXXFLAGS="-Wall -Wextra -Wshadow -Werror -std=gnu++98 -Wno-c++14-compat"
 
 AC_CACHE_CHECK([whether $CC is Clang],
     [nl_cv_clang],


### PR DESCRIPTION
- Explicitly set mode for C++ to `-std=gnu++98`.