### PR TITLE
prevent RxBuffer from overflowing

### DIFF
--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -117,8 +117,12 @@ void Uart::ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength)
             break;
 
         default:
-            Output(reinterpret_cast<const char *>(aBuf), 1);
-            mRxBuffer[mRxLength++] = static_cast<char>(*aBuf);
+            if (mRxLength < kRxBufferSize)
+            {
+                Output(reinterpret_cast<const char *>(aBuf), 1);
+                mRxBuffer[mRxLength++] = static_cast<char>(*aBuf);
+            }
+
             break;
         }
     }


### PR DESCRIPTION
RxBuffer overflow cause OpenThread crashes.