### PR TITLE
Ensure thread device has synced with latest Dataset before sending MLE Announce.

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -406,7 +406,7 @@ ThreadError Mle::SetStateChild(uint16_t aRloc16)
     mNetif.GetNetworkDataLocal().ClearResubmitDelayTimer();
     mNetif.GetIp6().SetForwardingEnabled(false);
 
-    if (mPreviousPanId != Mac::kPanIdBroadcast)
+    if (mPreviousPanId != Mac::kPanIdBroadcast && (mDeviceMode & ModeTlv::kModeFFD))
     {
         mPreviousPanId = Mac::kPanIdBroadcast;
         mNetif.GetAnnounceBeginServer().SendAnnounce(1 << mPreviousChannel);
@@ -1495,8 +1495,6 @@ exit:
     return;
 }
 
-
-
 ThreadError Mle::SendMessage(Message &aMessage, const Ip6::Address &aDestination)
 {
     ThreadError error = kThreadError_None;
@@ -1989,6 +1987,12 @@ ThreadError Mle::HandleDataResponse(const Message &aMessage, const Ip6::MessageI
         mNetif.GetPendingDataset().Clear();
     }
 
+    if (mPreviousPanId != Mac::kPanIdBroadcast && ((mDeviceMode & ModeTlv::kModeFFD) == 0))
+    {
+        mPreviousPanId = Mac::kPanIdBroadcast;
+        mNetif.GetAnnounceBeginServer().SendAnnounce(1 << mPreviousChannel);
+    }
+
     mRetrieveNewNetworkData = false;
 
 exit:
@@ -2420,6 +2424,11 @@ ThreadError Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo 
 
     if (localTimestamp == NULL || localTimestamp->Compare(timestamp) > 0)
     {
+        if ((mDeviceMode & ModeTlv::kModeFFD) == 0)
+        {
+            mRetrieveNewNetworkData = true;
+        }
+
         Stop();
         mPreviousChannel = mMac.GetChannel();
         mPreviousPanId = mMac.GetPanId();


### PR DESCRIPTION
This PR is to ensure thread device(Router or Child) has synced with latest Dataset before sending MLE Announce on its previous channel.

Router will go through the whole attach process after it receives an Announce message with newer Active Timestamp, it gets the new Dataset from Child Id Response message. For Child, there are some cases to be considered:
1. Child has Parent before the different partitions merge and Parent migrates to the new partition first. (Child sends Child Update and receive response, then sends Data Request and receives Data Response.)
2. Child has Parent but receive a new Advertisement from another Router with different partition id.
(Child will become detached and migrates to new partition)
3. Child has no Parent, and go through the whole attach progress again.

Hence, use a timer to check whether or not child has synced with latest Dataset from network periodically. Below is the result of MED_9_2_12 with this PR.
[MED_9_2_12.zip](https://github.com/openthread/openthread/files/538212/MED_9_2_12.zip)
