### PR TITLE
Utilize CoAP client in OpenThread

### DIFF
--- a/include/openthread-coap.h
+++ b/include/openthread-coap.h
@@ -71,6 +71,7 @@ typedef enum otCoapType
  */
 typedef enum otCoapCode
 {
+    kCoapCodeEmpty       = 0x00,  ///< Empty message code
     kCoapRequestGet      = 0x01,  ///< Get
     kCoapRequestPost     = 0x02,  ///< Post
     kCoapRequestPut      = 0x03,  ///< Put

--- a/src/core/coap/coap_client.cpp
+++ b/src/core/coap/coap_client.cpp
@@ -228,8 +228,7 @@ void Client::SendEmptyMessage(const Ip6::Address &aAddress, uint16_t aPort, uint
     Message *message;
     ThreadError error = kThreadError_None;
 
-    header.Init();
-    header.SetType(aType);
+    header.Init(aType, kCoapCodeEmpty);
     header.SetMessageId(aMessageId);
 
     VerifyOrExit((message = NewMessage(header)) != NULL, ;);
@@ -331,8 +330,8 @@ Message *Client::FindRelatedRequest(const Header &aResponseHeader, const Ip6::Me
 
             switch (aResponseHeader.GetType())
             {
-            case Header::kTypeReset:
-            case Header::kTypeAcknowledgment:
+            case kCoapTypeReset:
+            case kCoapTypeAcknowledgment:
                 if (aResponseHeader.GetMessageId() == aRequestHeader.GetMessageId())
                 {
                     ExitNow();
@@ -340,8 +339,8 @@ Message *Client::FindRelatedRequest(const Header &aResponseHeader, const Ip6::Me
 
                 break;
 
-            case Header::kTypeConfirmable:
-            case Header::kTypeNonConfirmable:
+            case kCoapTypeConfirmable:
+            case kCoapTypeNonConfirmable:
                 if (aResponseHeader.IsTokenEqual(aRequestHeader))
                 {
                     ExitNow();
@@ -396,7 +395,7 @@ void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
 
     switch (responseHeader.GetType())
     {
-    case Header::kTypeReset:
+    case kCoapTypeReset:
         if (responseHeader.IsEmpty())
         {
             FinalizeCoapTransaction(*message, requestMetadata, NULL, NULL, kThreadError_Abort);
@@ -405,7 +404,7 @@ void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
         // Silently ignore non-empty reset messages (RFC 7252, p. 4.2).
         break;
 
-    case Header::kTypeAcknowledgment:
+    case kCoapTypeAcknowledgment:
         if (responseHeader.IsEmpty())
         {
             // Empty acknowledgment.
@@ -431,8 +430,8 @@ void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
         // or with no token match (RFC 7252, p. 5.3.2)
         break;
 
-    case Header::kTypeConfirmable:
-    case Header::kTypeNonConfirmable:
+    case kCoapTypeConfirmable:
+    case kCoapTypeNonConfirmable:
         if (responseHeader.IsConfirmable())
         {
             // Send empty ACK if it is a CON message.

--- a/src/core/coap/coap_client.hpp
+++ b/src/core/coap/coap_client.hpp
@@ -253,10 +253,10 @@ private:
     ThreadError SendCopy(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     void SendEmptyMessage(const Ip6::Address &aAddress, uint16_t aPort, uint16_t aMessageId, Header::Type aType);
     void SendReset(const Ip6::Address &aAddress, uint16_t aPort, uint16_t aMessageId) {
-        SendEmptyMessage(aAddress, aPort, aMessageId, Header::kTypeReset);
+        SendEmptyMessage(aAddress, aPort, aMessageId, kCoapTypeReset);
     };
     void SendEmptyAck(const Ip6::Address &aAddress, uint16_t aPort, uint16_t aMessageId) {
-        SendEmptyMessage(aAddress, aPort, aMessageId, Header::kTypeAcknowledgment);
+        SendEmptyMessage(aAddress, aPort, aMessageId, kCoapTypeAcknowledgment);
     };
 
     static void HandleRetransmissionTimer(void *aContext);

--- a/src/core/coap/coap_header.hpp
+++ b/src/core/coap/coap_header.hpp
@@ -79,10 +79,31 @@ public:
     };
 
     /**
+     * CoAP Type values.
+     *
+     */
+    typedef otCoapType Type;
+
+    /**
+     * CoAP Code values.
+     *
+     */
+    typedef otCoapCode Code;
+
+    /**
      * This method initializes the CoAP header.
      *
      */
     void Init(void);
+
+    /**
+     * This method initializes the CoAP header with specific Type and Code.
+     *
+     * @param[in]  aType  The Type value.
+     * @param[in]  aCode  The Code value.
+     *
+     */
+    void Init(Type aType, Code aCode);
 
     /**
      * This method parses the CoAP header from a message.
@@ -115,18 +136,6 @@ public:
     }
 
     /**
-     * CoAP Type values.
-     *
-     */
-    enum Type
-    {
-        kTypeConfirmable    = 0x00,  ///< Confirmable
-        kTypeNonConfirmable = 0x10,  ///< Non-confirmable
-        kTypeAcknowledgment = 0x20,  ///< Acknowledgment
-        kTypeReset          = 0x30,  ///< Reset
-    };
-
-    /**
      * This method returns the Type value.
      *
      * @returns The Type value.
@@ -144,21 +153,6 @@ public:
         mHeader.mFields.mVersionTypeToken &= ~kTypeMask;
         mHeader.mFields.mVersionTypeToken |= aType;
     }
-
-
-    /**
-     * CoAP Code values.
-     *
-     */
-    enum Code
-    {
-        kCodeGet     = 0x01,  ///< Get
-        kCodePost    = 0x02,  ///< Post
-        kCodePut     = 0x03,  ///< Put
-        kCodeDelete  = 0x04,  ///< Delete
-        kCodeChanged = 0x44,  ///< Changed
-        kCodeContent = 0x45,  ///< Content
-    };
 
     /**
      * This method returns the Code value.
@@ -263,11 +257,7 @@ public:
         /**
          * Option Numbers
          */
-        enum Type
-        {
-            kOptionUriPath       = 11,   ///< Uri-Path
-            kOptionContentFormat = 12,   ///< Content-Format
-        };
+        typedef otCoapOptionType Type;
     };
 
     /**
@@ -332,13 +322,13 @@ public:
     const Option *GetNextOption(void);
 
     /**
-     * This method terminates the CoAP header.
+     * This method adds Payload Marker indicating beginning of the payload to the CoAP header.
      *
-     * @retval kThreadError_None    Header successfully terminated.
+     * @retval kThreadError_None    Payload Marker successfully added.
      * @retval kThreadError_NoBufs  Header Payload Marker exceeds the buffer size.
      *
      */
-    ThreadError Finalize(void);
+    ThreadError SetPayloadMarker(void);
 
     /**
      * This method returns a pointer to the first byte of the header.
@@ -380,7 +370,7 @@ public:
      * @retval FALSE  Header is not a request header.
      *
      */
-    bool IsRequest(void) const { return (GetCode() >= kCodeGet && GetCode() <= kCodeDelete); };
+    bool IsRequest(void) const { return (GetCode() >= kCoapRequestGet && GetCode() <= kCoapRequestDelete); };
 
     /**
      * This method checks if a header is a response header.
@@ -389,7 +379,7 @@ public:
      * @retval FALSE  Header is not a response header.
      *
      */
-    bool IsResponse(void) const { return (GetCode() >= kCodeChanged); };
+    bool IsResponse(void) const { return (GetCode() >= kCoapResponseChanged); };
 
     /**
      * This method checks if a header is a CON message header.
@@ -398,7 +388,7 @@ public:
      * @retval FALSE  Header is not is a CON message header.
      *
      */
-    bool IsConfirmable(void) const { return (GetType() == kTypeConfirmable); };
+    bool IsConfirmable(void) const { return (GetType() == kCoapTypeConfirmable); };
 
     /**
      * This method checks if a header is a NON message header.
@@ -407,7 +397,7 @@ public:
      * @retval FALSE  Header is not is a NON message header.
      *
      */
-    bool IsNonConfirmable(void) const { return (GetType() == kTypeNonConfirmable); };
+    bool IsNonConfirmable(void) const { return (GetType() == kCoapTypeNonConfirmable); };
 
     /**
      * This method checks if a header is a ACK message header.
@@ -416,7 +406,7 @@ public:
      * @retval FALSE  Header is not is a ACK message header.
      *
      */
-    bool IsAck(void) const { return (GetType() == kTypeAcknowledgment); };
+    bool IsAck(void) const { return (GetType() == kCoapTypeAcknowledgment); };
 
     /**
      * This method checks if a header is a RST message header.
@@ -425,7 +415,7 @@ public:
      * @retval FALSE  Header is not is a RST message header.
      *
      */
-    bool IsReset(void) const { return (GetType() == kTypeReset);  };
+    bool IsReset(void) const { return (GetType() == kCoapTypeReset);  };
 
 private:
     /**

--- a/src/core/coap/coap_server.cpp
+++ b/src/core/coap/coap_server.cpp
@@ -122,14 +122,14 @@ void Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
     {
         switch (coapOption->mNumber)
         {
-        case Header::Option::kOptionUriPath:
+        case kCoapOptionUriPath:
             VerifyOrExit(coapOption->mLength < sizeof(uriPath) - static_cast<size_t>(curUriPath - uriPath), ;);
             memcpy(curUriPath, coapOption->mValue, coapOption->mLength);
             curUriPath[coapOption->mLength] = '/';
             curUriPath += coapOption->mLength + 1;
             break;
 
-        case Header::Option::kOptionContentFormat:
+        case kCoapOptionContentFormat:
             break;
 
         default:

--- a/src/core/meshcop/announce_begin_client.cpp
+++ b/src/core/meshcop/announce_begin_client.cpp
@@ -52,11 +52,9 @@
 namespace Thread {
 
 AnnounceBeginClient::AnnounceBeginClient(ThreadNetif &aThreadNetif) :
-    mSocket(aThreadNetif.GetIp6().mUdp),
-    mNetif(aThreadNetif)
+    mNetif(aThreadNetif),
+    mCoapClient(aThreadNetif.GetCoapClient())
 {
-    mSocket.Open(HandleUdpReceive, this);
-    mCoapMessageId = static_cast<uint8_t>(otPlatRandomGet());
 }
 
 ThreadError AnnounceBeginClient::SendRequest(uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod,
@@ -80,21 +78,13 @@ ThreadError AnnounceBeginClient::SendRequest(uint32_t aChannelMask, uint8_t aCou
     Ip6::MessageInfo messageInfo;
     Message *message;
 
-    for (size_t i = 0; i < sizeof(mCoapToken); i++)
-    {
-        mCoapToken[i] = static_cast<uint8_t>(otPlatRandomGet());
-    }
-
-    header.Init();
-    header.SetType(aAddress.IsMulticast() ? Coap::Header::kTypeNonConfirmable : Coap::Header::kTypeConfirmable);
-    header.SetCode(Coap::Header::kCodePost);
-    header.SetMessageId(++mCoapMessageId);
-    header.SetToken(mCoapToken, sizeof(mCoapToken));
+    header.Init(aAddress.IsMulticast() ? kCoapTypeNonConfirmable : kCoapTypeConfirmable,
+                kCoapRequestPost);
+    header.SetToken(Coap::Header::kDefaultTokenLength);
     header.AppendUriPathOptions(OPENTHREAD_URI_ANNOUNCE_BEGIN);
-    header.Finalize();
+    header.SetPayloadMarker();
 
-    VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
-    SuccessOrExit(error = message->Append(header.GetBytes(), header.GetLength()));
+    VerifyOrExit((message = mCoapClient.NewMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     sessionId.Init();
     sessionId.SetCommissionerSessionId(mNetif.GetCommissioner().GetSessionId());
@@ -119,9 +109,10 @@ ThreadError AnnounceBeginClient::SendRequest(uint32_t aChannelMask, uint8_t aCou
     messageInfo.GetPeerAddr() = aAddress;
     messageInfo.mPeerPort = kCoapUdpPort;
     messageInfo.mInterfaceId = mNetif.GetInterfaceId();
-    SuccessOrExit(error = mSocket.SendTo(*message, messageInfo));
 
-    otLogInfoMeshCoP("sent announce begin query\n");
+    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
+
+    otLogInfoMeshCoP("sent announce begin query");
 
 exit:
 
@@ -131,14 +122,6 @@ exit:
     }
 
     return error;
-}
-
-void AnnounceBeginClient::HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo)
-{
-    otLogInfoMeshCoP("received announce begin response\n");
-    (void)aContext;
-    (void)aMessage;
-    (void)aMessageInfo;
 }
 
 }  // namespace Thread

--- a/src/core/meshcop/announce_begin_client.hpp
+++ b/src/core/meshcop/announce_begin_client.hpp
@@ -37,7 +37,7 @@
 #include <openthread-core-config.h>
 #include <openthread-types.h>
 #include <commissioning/commissioner.h>
-#include <coap/coap_server.hpp>
+#include <coap/coap_client.hpp>
 #include <net/ip6_address.hpp>
 #include <net/udp6.hpp>
 
@@ -72,12 +72,8 @@ public:
     ThreadError SendRequest(uint32_t aChannelMask, uint8_t aCount, uint16_t mPeriod, const Ip6::Address &aAddress);
 
 private:
-    static void HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo);
-
-    Ip6::UdpSocket mSocket;
-    uint8_t mCoapToken[2];
-    uint16_t mCoapMessageId;
     ThreadNetif &mNetif;
+    Coap::Client &mCoapClient;
 };
 
 /**

--- a/src/core/meshcop/energy_scan_client.hpp
+++ b/src/core/meshcop/energy_scan_client.hpp
@@ -37,6 +37,7 @@
 #include <openthread-core-config.h>
 #include <openthread-types.h>
 #include <commissioning/commissioner.h>
+#include <coap/coap_client.hpp>
 #include <coap/coap_server.hpp>
 #include <net/ip6_address.hpp>
 #include <net/udp6.hpp>
@@ -81,19 +82,15 @@ private:
                              const Ip6::MessageInfo &aMessageInfo);
     void HandleReport(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo);
-
     ThreadError SendResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aRequestMessageInfo);
 
     otCommissionerEnergyReportCallback mCallback;
     void *mContext;
 
     Coap::Resource mEnergyScan;
-    Ip6::UdpSocket mSocket;
-
     Coap::Server &mCoapServer;
-    uint8_t mCoapToken[2];
-    uint16_t mCoapMessageId;
+    Coap::Client &mCoapClient;
+
     ThreadNetif &mNetif;
 };
 

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -275,14 +275,11 @@ void Joiner::SendJoinerFinalize(void)
     uint8_t *cur = buf;
 
     otLogFuncEntry();
-
-    header.Init();
-    header.SetType(Coap::Header::kTypeConfirmable);
-    header.SetCode(Coap::Header::kCodePost);
+    header.Init(kCoapTypeConfirmable, kCoapRequestPost);
     header.SetMessageId(0);
     header.SetToken(NULL, 0);
     header.AppendUriPathOptions(OPENTHREAD_URI_JOINER_FINALIZE);
-    header.Finalize();
+    header.SetPayloadMarker();
     memcpy(cur, header.GetBytes(), header.GetLength());
     cur += header.GetLength();
 
@@ -321,8 +318,8 @@ void Joiner::ReceiveJoinerFinalizeResponse(uint8_t *buf, uint16_t length)
     SuccessOrExit(header.FromMessage(*message));
     SuccessOrExit(message->SetOffset(header.GetLength()));
 
-    VerifyOrExit(header.GetType() == Coap::Header::kTypeAcknowledgment &&
-                 header.GetCode() == Coap::Header::kCodeChanged &&
+    VerifyOrExit(header.GetType() == kCoapTypeAcknowledgment &&
+                 header.GetCode() == kCoapResponseChanged &&
                  header.GetMessageId() == 0 &&
                  header.GetTokenLength() == 0, ;);
 
@@ -362,8 +359,8 @@ void Joiner::HandleJoinerEntrust(Coap::Header &aHeader, Message &aMessage, const
 
     otLogFuncEntry();
 
-    VerifyOrExit(aHeader.GetType() == Coap::Header::kTypeConfirmable &&
-                 aHeader.GetCode() == Coap::Header::kCodePost, error = kThreadError_Drop);
+    VerifyOrExit(aHeader.GetType() == kCoapTypeConfirmable &&
+                 aHeader.GetCode() == kCoapRequestPost, error = kThreadError_Drop);
 
     otLogInfoMeshCoP("Received joiner entrust");
     otLogCertMeshCoP("[THCI] direction=recv | type=JOIN_ENT.ntf");

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -194,13 +194,11 @@ void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &a
 
     VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
 
-    header.Init();
-    header.SetType(Coap::Header::kTypeNonConfirmable);
-    header.SetCode(Coap::Header::kCodePost);
+    header.Init(kCoapTypeNonConfirmable, kCoapRequestPost);
     header.SetMessageId(0);
     header.SetToken(NULL, 0);
     header.AppendUriPathOptions(OPENTHREAD_URI_RELAY_RX);
-    header.Finalize();
+    header.SetPayloadMarker();
     SuccessOrExit(error = message->Append(header.GetBytes(), header.GetLength()));
 
     udpPort.Init();
@@ -274,8 +272,8 @@ void JoinerRouter::HandleRelayTransmit(Coap::Header &aHeader, Message &aMessage,
     Ip6::MessageInfo messageInfo;
 
     otLogFuncEntry();
-    VerifyOrExit(aHeader.GetType() == Coap::Header::kTypeNonConfirmable &&
-                 aHeader.GetCode() == Coap::Header::kCodePost, error = kThreadError_Drop);
+    VerifyOrExit(aHeader.GetType() == kCoapTypeNonConfirmable &&
+                 aHeader.GetCode() == kCoapRequestPost, error = kThreadError_Drop);
 
     otLogInfoMeshCoP("Received relay transmit");
 
@@ -352,13 +350,11 @@ ThreadError JoinerRouter::SendJoinerEntrust(const Ip6::MessageInfo &aMessageInfo
     VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
     message->SetSubType(Message::kSubTypeJoinerEntrust);
 
-    header.Init();
-    header.SetType(Coap::Header::kTypeConfirmable);
-    header.SetCode(Coap::Header::kCodePost);
+    header.Init(kCoapTypeConfirmable, kCoapRequestPost);
     header.SetMessageId(0);
     header.SetToken(NULL, 0);
     header.AppendUriPathOptions(OPENTHREAD_URI_JOINER_ENTRUST);
-    header.Finalize();
+    header.SetPayloadMarker();
     SuccessOrExit(error = message->Append(header.GetBytes(), header.GetLength()));
 
     masterKey.Init();

--- a/src/core/meshcop/leader.hpp
+++ b/src/core/meshcop/leader.hpp
@@ -34,6 +34,7 @@
 #ifndef MESHCOP_LEADER_HPP_
 #define MESHCOP_LEADER_HPP_
 
+#include <coap/coap_client.hpp>
 #include <coap/coap_server.hpp>
 #include <common/timer.hpp>
 #include <net/udp6.hpp>
@@ -106,12 +107,10 @@ private:
     Coap::Resource mPetition;
     Coap::Resource mKeepAlive;
     Coap::Server &mCoapServer;
-    uint8_t mCoapToken[2];
-    uint16_t mCoapMessageId;
+    Coap::Client &mCoapClient;
     NetworkData::Leader &mNetworkData;
 
     Timer mTimer;
-    Ip6::UdpSocket mSocket;
 
     CommissionerIdTlv mCommissionerId;
     uint16_t mSessionId;

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -47,14 +47,11 @@ namespace Thread {
 
 PanIdQueryClient::PanIdQueryClient(ThreadNetif &aThreadNetif) :
     mPanIdQuery(OPENTHREAD_URI_PANID_CONFLICT, &PanIdQueryClient::HandleConflict, this),
-    mSocket(aThreadNetif.GetIp6().mUdp),
     mCoapServer(aThreadNetif.GetCoapServer()),
+    mCoapClient(aThreadNetif.GetCoapClient()),
     mNetif(aThreadNetif)
 {
     mCoapServer.AddResource(mPanIdQuery);
-    mSocket.Open(HandleUdpReceive, this);
-
-    mCoapMessageId = static_cast<uint8_t>(otPlatRandomGet());
 }
 
 ThreadError PanIdQueryClient::SendQuery(uint16_t aPanId, uint32_t aChannelMask, const Ip6::Address &aAddress,
@@ -73,21 +70,13 @@ ThreadError PanIdQueryClient::SendQuery(uint16_t aPanId, uint32_t aChannelMask, 
     Ip6::MessageInfo messageInfo;
     Message *message;
 
-    for (size_t i = 0; i < sizeof(mCoapToken); i++)
-    {
-        mCoapToken[i] = static_cast<uint8_t>(otPlatRandomGet());
-    }
-
-    header.Init();
-    header.SetType(aAddress.IsMulticast() ? Coap::Header::kTypeNonConfirmable : Coap::Header::kTypeConfirmable);
-    header.SetCode(Coap::Header::kCodePost);
-    header.SetMessageId(++mCoapMessageId);
-    header.SetToken(mCoapToken, sizeof(mCoapToken));
+    header.Init(aAddress.IsMulticast() ? kCoapTypeNonConfirmable : kCoapTypeConfirmable,
+                kCoapRequestPost);
+    header.SetToken(Coap::Header::kDefaultTokenLength);
     header.AppendUriPathOptions(OPENTHREAD_URI_PANID_QUERY);
-    header.Finalize();
+    header.SetPayloadMarker();
 
-    VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
-    SuccessOrExit(error = message->Append(header.GetBytes(), header.GetLength()));
+    VerifyOrExit((message = mCoapClient.NewMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     sessionId.Init();
     sessionId.SetCommissionerSessionId(mNetif.GetCommissioner().GetSessionId());
@@ -115,7 +104,7 @@ ThreadError PanIdQueryClient::SendQuery(uint16_t aPanId, uint32_t aChannelMask, 
     messageInfo.GetPeerAddr() = aAddress;
     messageInfo.mPeerPort = kCoapUdpPort;
     messageInfo.mInterfaceId = mNetif.GetInterfaceId();
-    SuccessOrExit(error = mSocket.SendTo(*message, messageInfo));
+    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
 
     otLogInfoMeshCoP("sent panid query");
 
@@ -150,8 +139,8 @@ void PanIdQueryClient::HandleConflict(Coap::Header &aHeader, Message &aMessage, 
     uint16_t offset;
     uint16_t length;
 
-    VerifyOrExit(aHeader.GetType() == Coap::Header::kTypeConfirmable &&
-                 aHeader.GetCode() == Coap::Header::kCodePost, ;);
+    VerifyOrExit(aHeader.GetType() == kCoapTypeConfirmable &&
+                 aHeader.GetCode() == kCoapRequestPost, ;);
 
     otLogInfoMeshCoP("received panid conflict");
 
@@ -190,12 +179,8 @@ ThreadError PanIdQueryClient::SendConflictResponse(const Coap::Header &aRequestH
 
     VerifyOrExit((message = mCoapServer.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
 
-    responseHeader.Init();
-    responseHeader.SetType(Coap::Header::kTypeAcknowledgment);
-    responseHeader.SetCode(Coap::Header::kCodeChanged);
-    responseHeader.SetMessageId(aRequestHeader.GetMessageId());
-    responseHeader.SetToken(aRequestHeader.GetToken(), aRequestHeader.GetTokenLength());
-    responseHeader.Finalize();
+    responseHeader.SetDefaultResponseHeader(aRequestHeader);
+
     SuccessOrExit(error = message->Append(responseHeader.GetBytes(), responseHeader.GetLength()));
 
     memcpy(&responseInfo, &aRequestInfo, sizeof(responseInfo));
@@ -210,14 +195,6 @@ exit:
     }
 
     return error;
-}
-
-void PanIdQueryClient::HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo)
-{
-    otLogInfoMeshCoP("received panid query response");
-    (void)aContext;
-    (void)aMessage;
-    (void)aMessageInfo;
 }
 
 }  // namespace Thread

--- a/src/core/meshcop/panid_query_client.hpp
+++ b/src/core/meshcop/panid_query_client.hpp
@@ -37,6 +37,7 @@
 #include <openthread-core-config.h>
 #include <openthread-types.h>
 #include <commissioning/commissioner.h>
+#include <coap/coap_client.hpp>
 #include <coap/coap_server.hpp>
 #include <net/ip6_address.hpp>
 #include <net/udp6.hpp>
@@ -79,19 +80,15 @@ private:
                                const Ip6::MessageInfo &aMessageInfo);
     void HandleConflict(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo);
-
     ThreadError SendConflictResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aRequestMessageInfo);
 
     otCommissionerPanIdConflictCallback mCallback;
     void *mContext;
 
     Coap::Resource mPanIdQuery;
-    Ip6::UdpSocket mSocket;
-
     Coap::Server &mCoapServer;
-    uint8_t mCoapToken[2];
-    uint16_t mCoapMessageId;
+    Coap::Client &mCoapClient;
+
     ThreadNetif &mNetif;
 };
 

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -1553,9 +1553,7 @@ ThreadError otJoinerStop(otInstance *aInstance)
 void otCoapHeaderInit(otCoapHeader *aHeader, otCoapType aType, otCoapCode aCode)
 {
     Coap::Header *header = static_cast<Coap::Header *>(aHeader);
-    header->Init();
-    header->SetType(static_cast<Coap::Header::Type>(aType));
-    header->SetCode(static_cast<Coap::Header::Code>(aCode));
+    header->Init(aType, aCode);
 }
 
 void otCoapHeaderSetToken(otCoapHeader *aHeader, const uint8_t *aToken, uint8_t aTokenLength)
@@ -1570,7 +1568,7 @@ ThreadError otCoapHeaderAppendOption(otCoapHeader *aHeader, const otCoapOption *
 
 void otCoapHeaderSetPayloadMarker(otCoapHeader *aHeader)
 {
-    static_cast<Coap::Header *>(aHeader)->Finalize();
+    static_cast<Coap::Header *>(aHeader)->SetPayloadMarker();
 }
 
 const otCoapOption *otCoapGetCurrentOption(const otCoapHeader *aHeader)

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -172,11 +172,9 @@ ThreadError AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
     ThreadTargetTlv targetTlv;
     Ip6::MessageInfo messageInfo;
 
-    header.Init();
-    header.SetType(Coap::Header::kTypeNonConfirmable);
-    header.SetCode(Coap::Header::kCodePost);
+    header.Init(kCoapTypeNonConfirmable, kCoapRequestPost);
     header.AppendUriPathOptions(OPENTHREAD_URI_ADDRESS_QUERY);
-    header.Finalize();
+    header.SetPayloadMarker();
 
     VerifyOrExit((message = mCoapClient.NewMessage(header)) != NULL, error = kThreadError_NoBufs);
 
@@ -191,7 +189,7 @@ ThreadError AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
     messageInfo.mPeerPort = kCoapUdpPort;
     messageInfo.mInterfaceId = mNetif.GetInterfaceId();
 
-    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo, NULL, NULL));
+    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
 
     otLogInfoArp("Sent address query");
 
@@ -225,8 +223,8 @@ void AddressResolver::HandleAddressNotification(Coap::Header &aHeader, Message &
     ThreadLastTransactionTimeTlv lastTransactionTimeTlv;
     uint32_t lastTransactionTime;
 
-    VerifyOrExit(aHeader.GetType() == Coap::Header::kTypeConfirmable &&
-                 aHeader.GetCode() == Coap::Header::kCodePost, ;);
+    VerifyOrExit(aHeader.GetType() == kCoapTypeConfirmable &&
+                 aHeader.GetCode() == kCoapRequestPost, ;);
 
     otLogInfoArp("Received address notification from %04x", HostSwap16(aMessageInfo.GetPeerAddr().mFields.m16[7]));
 
@@ -303,6 +301,7 @@ void AddressResolver::SendAddressNotificationResponse(const Coap::Header &aReque
     VerifyOrExit((message = mCoapServer.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
 
     responseHeader.SetDefaultResponseHeader(aRequestHeader);
+
     SuccessOrExit(error = message->Append(responseHeader.GetBytes(), responseHeader.GetLength()));
 
     memcpy(&responseInfo, &aRequestInfo, sizeof(responseInfo));
@@ -327,11 +326,10 @@ ThreadError AddressResolver::SendAddressError(const ThreadTargetTlv &aTarget, co
     Coap::Header header;
     Ip6::MessageInfo messageInfo;
 
-    header.Init();
-    header.SetType(aDestination == NULL ? Coap::Header::kTypeNonConfirmable : Coap::Header::kTypeConfirmable);
-    header.SetCode(Coap::Header::kCodePost);
+    header.Init(aDestination == NULL ? kCoapTypeNonConfirmable : kCoapTypeConfirmable,
+                kCoapRequestPost);
     header.AppendUriPathOptions(OPENTHREAD_URI_ADDRESS_ERROR);
-    header.Finalize();
+    header.SetPayloadMarker();
 
     VerifyOrExit((message = mCoapClient.NewMessage(header)) != NULL, error = kThreadError_NoBufs);
 
@@ -353,7 +351,7 @@ ThreadError AddressResolver::SendAddressError(const ThreadTargetTlv &aTarget, co
     messageInfo.mPeerPort = kCoapUdpPort;
     messageInfo.mInterfaceId = mNetif.GetInterfaceId();
 
-    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo, NULL, NULL));
+    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
 
     otLogInfoArp("Sent address error");
 
@@ -412,8 +410,8 @@ void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessag
     Mac::ExtAddress macAddr;
     Ip6::Address destination;
 
-    VerifyOrExit(aHeader.GetType() == Coap::Header::kTypeConfirmable &&
-                 aHeader.GetCode() == Coap::Header::kCodePost, error = kThreadError_Drop);
+    VerifyOrExit(aHeader.GetType() == kCoapTypeConfirmable &&
+                 aHeader.GetCode() == kCoapRequestPost, error = kThreadError_Drop);
 
     otLogInfoArp("Received address error notification");
 
@@ -488,8 +486,8 @@ void AddressResolver::HandleAddressQuery(Coap::Header &aHeader, Message &aMessag
     Child *children;
     uint8_t numChildren;
 
-    VerifyOrExit(aHeader.GetType() == Coap::Header::kTypeNonConfirmable &&
-                 aHeader.GetCode() == Coap::Header::kCodePost, ;);
+    VerifyOrExit(aHeader.GetType() == kCoapTypeNonConfirmable &&
+                 aHeader.GetCode() == kCoapRequestPost, ;);
 
     otLogInfoArp("Received address query from %04x", HostSwap16(aMessageInfo.GetPeerAddr().mFields.m16[7]));
 
@@ -549,11 +547,9 @@ void AddressResolver::SendAddressQueryResponse(const ThreadTargetTlv &aTargetTlv
     ThreadRloc16Tlv rloc16Tlv;
     Ip6::MessageInfo messageInfo;
 
-    header.Init();
-    header.SetType(Coap::Header::kTypeConfirmable);
-    header.SetCode(Coap::Header::kCodePost);
+    header.Init(kCoapTypeConfirmable, kCoapRequestPost);
     header.AppendUriPathOptions(OPENTHREAD_URI_ADDRESS_NOTIFY);
-    header.Finalize();
+    header.SetPayloadMarker();
 
     VerifyOrExit((message = mCoapClient.NewMessage(header)) != NULL, error = kThreadError_NoBufs);
 
@@ -574,7 +570,7 @@ void AddressResolver::SendAddressQueryResponse(const ThreadTargetTlv &aTargetTlv
     messageInfo.GetSockAddr() = *mMle.GetMeshLocal16();
     messageInfo.mPeerPort = kCoapUdpPort;
 
-    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo, NULL, NULL));
+    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
 
     otLogInfoArp("Sent address notification");
 

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -107,7 +107,7 @@ void AnnounceBeginServer::HandleRequest(Coap::Header &aHeader, Message &aMessage
     MeshCoP::CountTlv count;
     MeshCoP::PeriodTlv period;
 
-    VerifyOrExit(aHeader.GetCode() == Coap::Header::kCodePost, ;);
+    VerifyOrExit(aHeader.GetCode() == kCoapRequestPost, ;);
 
     SuccessOrExit(MeshCoP::Tlv::GetTlv(aMessage, MeshCoP::Tlv::kChannelMask, sizeof(channelMask), channelMask.tlv));
     VerifyOrExit(channelMask.tlv.IsValid() &&
@@ -135,16 +135,12 @@ ThreadError AnnounceBeginServer::SendResponse(const Coap::Header &aRequestHeader
     Coap::Header responseHeader;
     Ip6::MessageInfo responseInfo;
 
-    VerifyOrExit(aRequestHeader.GetType() == Coap::Header::kTypeConfirmable, ;);
+    VerifyOrExit(aRequestHeader.GetType() == kCoapTypeConfirmable, ;);
 
     VerifyOrExit((message = mCoapServer.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
 
-    responseHeader.Init();
-    responseHeader.SetType(Coap::Header::kTypeAcknowledgment);
-    responseHeader.SetCode(Coap::Header::kCodeChanged);
-    responseHeader.SetMessageId(aRequestHeader.GetMessageId());
-    responseHeader.SetToken(aRequestHeader.GetToken(), aRequestHeader.GetTokenLength());
-    responseHeader.Finalize();
+    responseHeader.SetDefaultResponseHeader(aRequestHeader);
+
     SuccessOrExit(error = message->Append(responseHeader.GetBytes(), responseHeader.GetLength()));
 
     memcpy(&responseInfo, &aRequestInfo, sizeof(responseInfo));

--- a/src/core/thread/announce_begin_server.hpp
+++ b/src/core/thread/announce_begin_server.hpp
@@ -36,6 +36,7 @@
 
 #include <openthread-core-config.h>
 #include <openthread-types.h>
+#include <coap/coap_client.hpp>
 #include <coap/coap_server.hpp>
 #include <common/timer.hpp>
 #include <net/ip6_address.hpp>

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -47,19 +47,16 @@ namespace Thread {
 
 EnergyScanServer::EnergyScanServer(ThreadNetif &aThreadNetif) :
     mActive(false),
-    mEnergyScan(OPENTHREAD_URI_ENERGY_SCAN, &EnergyScanServer::HandleRequest, this),
-    mSocket(aThreadNetif.GetIp6().mUdp),
     mTimer(aThreadNetif.GetIp6().mTimerScheduler, &EnergyScanServer::HandleTimer, this),
+    mEnergyScan(OPENTHREAD_URI_ENERGY_SCAN, &EnergyScanServer::HandleRequest, this),
     mCoapServer(aThreadNetif.GetCoapServer()),
+    mCoapClient(aThreadNetif.GetCoapClient()),
     mNetif(aThreadNetif)
 {
     mNetifCallback.Set(&EnergyScanServer::HandleNetifStateChanged, this);
     mNetif.RegisterCallback(mNetifCallback);
 
     mCoapServer.AddResource(mEnergyScan);
-    mSocket.Open(HandleUdpReceive, this);
-
-    mCoapMessageId = static_cast<uint8_t>(otPlatRandomGet());
 }
 
 void EnergyScanServer::HandleRequest(void *aContext, Coap::Header &aHeader, Message &aMessage,
@@ -81,7 +78,7 @@ void EnergyScanServer::HandleRequest(Coap::Header &aHeader, Message &aMessage, c
     uint16_t offset;
     uint16_t length;
 
-    VerifyOrExit(aHeader.GetCode() == Coap::Header::kCodePost, ;);
+    VerifyOrExit(aHeader.GetCode() == kCoapRequestPost, ;);
 
     SuccessOrExit(MeshCoP::Tlv::GetTlv(aMessage, MeshCoP::Tlv::kCount, sizeof(count), count));
     VerifyOrExit(count.IsValid(), ;);
@@ -125,16 +122,12 @@ ThreadError EnergyScanServer::SendResponse(const Coap::Header &aRequestHeader, c
     Coap::Header responseHeader;
     Ip6::MessageInfo responseInfo;
 
-    VerifyOrExit(aRequestHeader.GetType() == Coap::Header::kTypeConfirmable, ;);
+    VerifyOrExit(aRequestHeader.GetType() == kCoapTypeConfirmable, ;);
 
     VerifyOrExit((message = mCoapServer.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
 
-    responseHeader.Init();
-    responseHeader.SetType(Coap::Header::kTypeAcknowledgment);
-    responseHeader.SetCode(Coap::Header::kCodeChanged);
-    responseHeader.SetMessageId(aRequestHeader.GetMessageId());
-    responseHeader.SetToken(aRequestHeader.GetToken(), aRequestHeader.GetTokenLength());
-    responseHeader.Finalize();
+    responseHeader.SetDefaultResponseHeader(aRequestHeader);
+
     SuccessOrExit(error = message->Append(responseHeader.GetBytes(), responseHeader.GetLength()));
 
     memcpy(&responseInfo, &aRequestInfo, sizeof(responseInfo));
@@ -232,16 +225,12 @@ ThreadError EnergyScanServer::SendReport(void)
     Ip6::MessageInfo messageInfo;
     Message *message;
 
-    header.Init();
-    header.SetType(Coap::Header::kTypeConfirmable);
-    header.SetCode(Coap::Header::kCodePost);
-    header.SetMessageId(++mCoapMessageId);
-    header.SetToken(mCoapToken, sizeof(mCoapToken));
+    header.Init(kCoapTypeConfirmable, kCoapRequestPost);
+    header.SetToken(Coap::Header::kDefaultTokenLength);
     header.AppendUriPathOptions(OPENTHREAD_URI_ENERGY_REPORT);
-    header.Finalize();
+    header.SetPayloadMarker();
 
-    VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
-    SuccessOrExit(error = message->Append(header.GetBytes(), header.GetLength()));
+    VerifyOrExit((message = mCoapClient.NewMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     channelMask.tlv.Init();
     channelMask.tlv.SetLength(sizeof(channelMask) - sizeof(channelMask.tlv));
@@ -258,7 +247,7 @@ ThreadError EnergyScanServer::SendReport(void)
     memset(&messageInfo, 0, sizeof(messageInfo));
     messageInfo.GetPeerAddr() = mCommissioner;
     messageInfo.mPeerPort = kCoapUdpPort;
-    SuccessOrExit(error = mSocket.SendTo(*message, messageInfo));
+    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
 
     otLogInfoMeshCoP("sent scan results");
 
@@ -272,14 +261,6 @@ exit:
     mActive = false;
 
     return error;
-}
-
-void EnergyScanServer::HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo)
-{
-    otLogInfoMeshCoP("received scan report response");
-    (void)aContext;
-    (void)aMessage;
-    (void)aMessageInfo;
 }
 
 void EnergyScanServer::HandleNetifStateChanged(uint32_t aFlags, void *aContext)

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -36,6 +36,7 @@
 
 #include <openthread-core-config.h>
 #include <openthread-types.h>
+#include <coap/coap_client.hpp>
 #include <coap/coap_server.hpp>
 #include <common/timer.hpp>
 #include <net/ip6_address.hpp>
@@ -79,8 +80,6 @@ private:
     static void HandleTimer(void *aContext);
     void HandleTimer(void);
 
-    static void HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo);
-
     static void HandleNetifStateChanged(uint32_t aFlags, void *aContext);
     void HandleNetifStateChanged(uint32_t aFlags);
 
@@ -98,15 +97,14 @@ private:
     int8_t mScanResults[OPENTHREAD_CONFIG_MAX_ENERGY_RESULTS];
     uint8_t mScanResultsLength;
 
-    Coap::Resource mEnergyScan;
-    Ip6::UdpSocket mSocket;
     Timer mTimer;
 
     Ip6::NetifCallback mNetifCallback;
 
+    Coap::Resource mEnergyScan;
     Coap::Server &mCoapServer;
-    uint8_t mCoapToken[2];
-    uint16_t mCoapMessageId;
+    Coap::Client &mCoapClient;
+
     ThreadNetif &mNetif;
 };
 

--- a/src/core/thread/meshcop_dataset_manager.cpp
+++ b/src/core/thread/meshcop_dataset_manager.cpp
@@ -64,7 +64,7 @@ DatasetManager::DatasetManager(ThreadNetif &aThreadNetif, const Tlv::Type aType,
     mNetif(aThreadNetif),
     mNetworkDataLeader(aThreadNetif.GetNetworkDataLeader()),
     mTimer(aThreadNetif.GetIp6().mTimerScheduler, &DatasetManager::HandleTimer, this),
-    mSocket(aThreadNetif.GetIp6().mUdp),
+    mCoapClient(aThreadNetif.GetCoapClient()),
     mUriSet(aUriSet),
     mUriGet(aUriGet)
 {
@@ -169,20 +169,10 @@ ThreadError DatasetManager::Register(void)
     Ip6::Address leader;
     Ip6::MessageInfo messageInfo;
 
-    mSocket.Open(&DatasetManager::HandleUdpReceive, this);
-
-    for (size_t i = 0; i < sizeof(mCoapToken); i++)
-    {
-        mCoapToken[i] = static_cast<uint8_t>(otPlatRandomGet());
-    }
-
-    header.Init();
-    header.SetType(Coap::Header::kTypeConfirmable);
-    header.SetCode(Coap::Header::kCodePost);
-    header.SetMessageId(++mCoapMessageId);
-    header.SetToken(mCoapToken, sizeof(mCoapToken));
+    header.Init(kCoapTypeConfirmable, kCoapRequestPost);
+    header.SetToken(Coap::Header::kDefaultTokenLength);
     header.AppendUriPathOptions(mUriSet);
-    header.Finalize();
+    header.SetPayloadMarker();
 
     if (strcmp(mUriSet, OPENTHREAD_URI_PENDING_SET) == 0)
     {
@@ -190,8 +180,8 @@ ThreadError DatasetManager::Register(void)
         pending->UpdateDelayTimer();
     }
 
-    VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
-    SuccessOrExit(error = message->Append(header.GetBytes(), header.GetLength()));
+    VerifyOrExit((message = mCoapClient.NewMessage(header)) != NULL, error = kThreadError_NoBufs);
+
     SuccessOrExit(error = message->Append(mLocal.GetBytes(), mLocal.GetSize()));
 
     mMle.GetLeaderAloc(leader);
@@ -199,7 +189,7 @@ ThreadError DatasetManager::Register(void)
     memset(&messageInfo, 0, sizeof(messageInfo));
     memcpy(&messageInfo.mPeerAddr, &leader, sizeof(messageInfo.mPeerAddr));
     messageInfo.mPeerPort = kCoapUdpPort;
-    SuccessOrExit(error = mSocket.SendTo(*message, messageInfo));
+    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
 
     otLogInfoMeshCoP("sent dataset to leader");
 
@@ -211,30 +201,6 @@ exit:
     }
 
     return error;
-}
-
-void DatasetManager::HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo)
-{
-    DatasetManager *obj = static_cast<DatasetManager *>(aContext);
-    obj->HandleUdpReceive(*static_cast<Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
-}
-
-void DatasetManager::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
-{
-    Coap::Header header;
-    (void)aMessageInfo;
-
-    SuccessOrExit(header.FromMessage(aMessage));
-    VerifyOrExit(header.GetType() == Coap::Header::kTypeAcknowledgment &&
-                 header.GetCode() == Coap::Header::kCodeChanged &&
-                 header.GetMessageId() == mCoapMessageId &&
-                 header.GetTokenLength() == sizeof(mCoapToken) &&
-                 memcmp(mCoapToken, header.GetToken(), sizeof(mCoapToken)) == 0, ;);
-
-    otLogInfoMeshCoP("received response from leader");
-
-exit:
-    return;
 }
 
 void DatasetManager::Get(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -446,23 +412,12 @@ ThreadError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset,
     Message *message;
     Ip6::MessageInfo messageInfo;
 
-    mSocket.Open(&DatasetManager::HandleUdpReceive, this);
-
-    for (size_t i = 0; i < sizeof(mCoapToken); i++)
-    {
-        mCoapToken[i] = static_cast<uint8_t>(otPlatRandomGet());
-    }
-
-    header.Init();
-    header.SetType(Coap::Header::kTypeConfirmable);
-    header.SetCode(Coap::Header::kCodePost);
-    header.SetMessageId(++mCoapMessageId);
-    header.SetToken(mCoapToken, sizeof(mCoapToken));
+    header.Init(kCoapTypeConfirmable, kCoapRequestPost);
+    header.SetToken(Coap::Header::kDefaultTokenLength);
     header.AppendUriPathOptions(mUriSet);
-    header.Finalize();
+    header.SetPayloadMarker();
 
-    VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
-    SuccessOrExit(error = message->Append(header.GetBytes(), header.GetLength()));
+    VerifyOrExit((message = mCoapClient.NewMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     if (aDataset.mIsActiveTimestampSet)
     {
@@ -554,7 +509,7 @@ ThreadError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset,
     memset(&messageInfo, 0, sizeof(messageInfo));
     mMle.GetLeaderAloc(messageInfo.GetPeerAddr());
     messageInfo.mPeerPort = kCoapUdpPort;
-    SuccessOrExit(error = mSocket.SendTo(*message, messageInfo));
+    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
 
     otLogInfoMeshCoP("sent dataset set request to leader");
 
@@ -576,23 +531,12 @@ ThreadError DatasetManager::SendGetRequest(const uint8_t *aTlvTypes, const uint8
     Ip6::MessageInfo messageInfo;
     Tlv tlv;
 
-    mSocket.Open(&DatasetManager::HandleUdpReceive, this);
-
-    for (size_t i = 0; i < sizeof(mCoapToken); i++)
-    {
-        mCoapToken[i] = static_cast<uint8_t>(otPlatRandomGet());
-    }
-
-    header.Init();
-    header.SetType(Coap::Header::kTypeConfirmable);
-    header.SetCode(Coap::Header::kCodePost);
-    header.SetMessageId(++mCoapMessageId);
-    header.SetToken(mCoapToken, sizeof(mCoapToken));
+    header.Init(kCoapTypeConfirmable, kCoapRequestPost);
+    header.SetToken(Coap::Header::kDefaultTokenLength);
     header.AppendUriPathOptions(mUriGet);
-    header.Finalize();
+    header.SetPayloadMarker();
 
-    VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
-    SuccessOrExit(error = message->Append(header.GetBytes(), header.GetLength()));
+    VerifyOrExit((message = mCoapClient.NewMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     if (aLength > 0)
     {
@@ -605,7 +549,7 @@ ThreadError DatasetManager::SendGetRequest(const uint8_t *aTlvTypes, const uint8
     memset(&messageInfo, 0, sizeof(messageInfo));
     mMle.GetLeaderAloc(messageInfo.GetPeerAddr());
     messageInfo.mPeerPort = kCoapUdpPort;
-    SuccessOrExit(error = mSocket.SendTo(*message, messageInfo));
+    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
 
     otLogInfoMeshCoP("sent dataset get request to leader");
 
@@ -628,12 +572,10 @@ void DatasetManager::SendSetResponse(const Coap::Header &aRequestHeader, const I
     StateTlv state;
 
     VerifyOrExit((message = mCoapServer.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
-    responseHeader.Init();
-    responseHeader.SetType(Coap::Header::kTypeAcknowledgment);
-    responseHeader.SetCode(Coap::Header::kCodeChanged);
-    responseHeader.SetMessageId(aRequestHeader.GetMessageId());
-    responseHeader.SetToken(aRequestHeader.GetToken(), aRequestHeader.GetTokenLength());
-    responseHeader.Finalize();
+
+    responseHeader.SetDefaultResponseHeader(aRequestHeader);
+    responseHeader.SetPayloadMarker();
+
     SuccessOrExit(error = message->Append(responseHeader.GetBytes(), responseHeader.GetLength()));
 
     state.Init();
@@ -662,12 +604,10 @@ void DatasetManager::SendGetResponse(const Coap::Header &aRequestHeader, const I
     uint8_t index;
 
     VerifyOrExit((message = mCoapServer.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
-    responseHeader.Init();
-    responseHeader.SetType(Coap::Header::kTypeAcknowledgment);
-    responseHeader.SetCode(Coap::Header::kCodeChanged);
-    responseHeader.SetMessageId(aRequestHeader.GetMessageId());
-    responseHeader.SetToken(aRequestHeader.GetToken(), aRequestHeader.GetTokenLength());
-    responseHeader.Finalize();
+
+    responseHeader.SetDefaultResponseHeader(aRequestHeader);
+    responseHeader.SetPayloadMarker();
+
     SuccessOrExit(error = message->Append(responseHeader.GetBytes(), responseHeader.GetLength()));
 
     if (aLength == 0)

--- a/src/core/thread/meshcop_dataset_manager.hpp
+++ b/src/core/thread/meshcop_dataset_manager.hpp
@@ -104,10 +104,7 @@ private:
                          uint8_t *aTlvs, uint8_t aLength);
 
     Timer mTimer;
-
-    Ip6::UdpSocket mSocket;
-    uint8_t        mCoapToken[2];
-    uint16_t       mCoapMessageId;
+    Coap::Client &mCoapClient;
 
     const char *mUriSet;
     const char *mUriGet;

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -52,10 +52,9 @@ NetworkData::NetworkData(ThreadNetif &aThreadNetif, bool aLocal):
     mLocal(aLocal),
     mLastAttemptWait(false),
     mLastAttempt(0),
-    mSocket(aThreadNetif.GetIp6().mUdp)
+    mCoapClient(aThreadNetif.GetCoapClient())
 {
     mLength = 0;
-    mCoapMessageId = 0;
 }
 
 void NetworkData::GetNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLength)
@@ -600,23 +599,12 @@ ThreadError NetworkData::SendServerDataNotification(uint16_t aRloc16)
     VerifyOrExit(!mLastAttemptWait || static_cast<int32_t>(Timer::GetNow() - mLastAttempt) < kDataResubmitDelay,
                  error = kThreadError_Already);
 
-    mSocket.Open(&NetworkData::HandleUdpReceive, this);
-
-    for (size_t i = 0; i < sizeof(mCoapToken); i++)
-    {
-        mCoapToken[i] = static_cast<uint8_t>(otPlatRandomGet());
-    }
-
-    header.Init();
-    header.SetType(Coap::Header::kTypeConfirmable);
-    header.SetCode(Coap::Header::kCodePost);
-    header.SetMessageId(++mCoapMessageId);
-    header.SetToken(mCoapToken, sizeof(mCoapToken));
+    header.Init(kCoapTypeConfirmable, kCoapRequestPost);
+    header.SetToken(Coap::Header::kDefaultTokenLength);
     header.AppendUriPathOptions(OPENTHREAD_URI_SERVER_DATA);
-    header.Finalize();
+    header.SetPayloadMarker();
 
-    VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
-    SuccessOrExit(error = message->Append(header.GetBytes(), header.GetLength()));
+    VerifyOrExit((message = mCoapClient.NewMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     if (mLocal)
     {
@@ -639,7 +627,7 @@ ThreadError NetworkData::SendServerDataNotification(uint16_t aRloc16)
     mMle.GetLeaderAloc(messageInfo.GetPeerAddr());
     messageInfo.mSockAddr = *mMle.GetMeshLocal16();
     messageInfo.mPeerPort = kCoapUdpPort;
-    SuccessOrExit(error = mSocket.SendTo(*message, messageInfo));
+    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
 
     if (mLocal)
     {
@@ -662,29 +650,6 @@ exit:
 void NetworkData::ClearResubmitDelayTimer(void)
 {
     mLastAttemptWait = false;
-}
-
-void NetworkData::HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo)
-{
-    Local *obj = static_cast<Local *>(aContext);
-    obj->HandleUdpReceive(*static_cast<Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
-}
-
-void NetworkData::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
-{
-    Coap::Header header;
-
-    SuccessOrExit(header.FromMessage(aMessage));
-    VerifyOrExit(header.GetType() == Coap::Header::kTypeAcknowledgment &&
-                 header.GetCode() == Coap::Header::kCodeChanged &&
-                 header.GetMessageId() == mCoapMessageId &&
-                 header.GetTokenLength() == sizeof(mCoapToken) &&
-                 memcmp(mCoapToken, header.GetToken(), sizeof(mCoapToken)) == 0, ;);
-
-    otLogInfoNetData("Server data notification acknowledged");
-
-exit:
-    (void)aMessageInfo;
 }
 
 }  // namespace NetworkData

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -35,6 +35,7 @@
 #define NETWORK_DATA_HPP_
 
 #include <openthread-types.h>
+#include <coap/coap_client.hpp>
 #include <net/udp6.hpp>
 #include <thread/lowpan.hpp>
 #include <thread/mle_router.hpp>
@@ -346,16 +347,11 @@ private:
         kDataResubmitDelay = 300,  ///< DATA_RESUBMIT_DELAY (seconds)
     };
 
-    static void HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo);
-    void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-
     const bool      mLocal;
     bool            mLastAttemptWait;
     uint32_t        mLastAttempt;
 
-    Ip6::UdpSocket  mSocket;
-    uint8_t         mCoapToken[2];
-    uint16_t        mCoapMessageId;
+    Coap::Client &mCoapClient;
 };
 
 }  // namespace NetworkData

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -672,12 +672,14 @@ void Leader::SendServerDataResponse(const Coap::Header &aRequestHeader, const Ip
     Message *message;
 
     VerifyOrExit((message = mCoapServer.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
-    responseHeader.Init();
-    responseHeader.SetType(Coap::Header::kTypeAcknowledgment);
-    responseHeader.SetCode(Coap::Header::kCodeChanged);
-    responseHeader.SetMessageId(aRequestHeader.GetMessageId());
-    responseHeader.SetToken(aRequestHeader.GetToken(), aRequestHeader.GetTokenLength());
-    responseHeader.Finalize();
+
+    responseHeader.SetDefaultResponseHeader(aRequestHeader);
+
+    if (aTlvsLength > 0)
+    {
+        responseHeader.SetPayloadMarker();
+    }
+
     SuccessOrExit(error = message->Append(responseHeader.GetBytes(), responseHeader.GetLength()));
     SuccessOrExit(error = message->Append(aTlvs, aTlvsLength));
 
@@ -704,12 +706,10 @@ void Leader::SendCommissioningGetResponse(const Coap::Header &aRequestHeader, co
     uint8_t length = 0;
 
     VerifyOrExit((message = mCoapServer.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
-    responseHeader.Init();
-    responseHeader.SetType(Coap::Header::kTypeAcknowledgment);
-    responseHeader.SetCode(Coap::Header::kCodeChanged);
-    responseHeader.SetMessageId(aRequestHeader.GetMessageId());
-    responseHeader.SetToken(aRequestHeader.GetToken(), aRequestHeader.GetTokenLength());
-    responseHeader.Finalize();
+
+    responseHeader.SetDefaultResponseHeader(aRequestHeader);
+    responseHeader.SetPayloadMarker();
+
     SuccessOrExit(error = message->Append(responseHeader.GetBytes(), responseHeader.GetLength()));
 
     for (NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs);
@@ -768,12 +768,10 @@ void Leader::SendCommissioningSetResponse(const Coap::Header &aRequestHeader, co
     MeshCoP::StateTlv state;
 
     VerifyOrExit((message = mCoapServer.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
-    responseHeader.Init();
-    responseHeader.SetType(Coap::Header::kTypeAcknowledgment);
-    responseHeader.SetCode(Coap::Header::kCodeChanged);
-    responseHeader.SetMessageId(aRequestHeader.GetMessageId());
-    responseHeader.SetToken(aRequestHeader.GetToken(), aRequestHeader.GetTokenLength());
-    responseHeader.Finalize();
+
+    responseHeader.SetDefaultResponseHeader(aRequestHeader);
+    responseHeader.SetPayloadMarker();
+
     SuccessOrExit(error = message->Append(responseHeader.GetBytes(), responseHeader.GetLength()));
 
     state.Init();

--- a/src/core/thread/network_diag.hpp
+++ b/src/core/thread/network_diag.hpp
@@ -36,6 +36,7 @@
 
 #include <openthread-core-config.h>
 #include <openthread-types.h>
+#include <coap/coap_client.hpp>
 #include <coap/coap_server.hpp>
 #include <net/udp6.hpp>
 
@@ -108,8 +109,9 @@ public:
     ThreadError AppendChildTable(Message &aMessage);
 
 private:
-    static void HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo);
-    void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    static void HandleDiagnosticGetResponse(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                            ThreadError result);
+    void HandleDiagnosticGetResponse(Coap::Header *aHeader, Message *aMessage, ThreadError result);
 
     static void HandleDiagnosticGet(void *aContext, Coap::Header &aHeader,
                                     Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
@@ -123,11 +125,9 @@ private:
 
     Coap::Resource mDiagnosticGet;
     Coap::Resource mDiagnosticReset;
-    Ip6::UdpSocket mSocket;
-
-    uint8_t mCoapToken[2];
-    uint16_t mCoapMessageId;
     Coap::Server &mCoapServer;
+    Coap::Client &mCoapClient;
+
     Mle::MleRouter &mMle;
     ThreadNetif &mNetif;
 };

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -46,16 +46,13 @@
 namespace Thread {
 
 PanIdQueryServer::PanIdQueryServer(ThreadNetif &aThreadNetif) :
-    mPanIdQuery(OPENTHREAD_URI_PANID_QUERY, &PanIdQueryServer::HandleQuery, this),
-    mSocket(aThreadNetif.GetIp6().mUdp),
     mTimer(aThreadNetif.GetIp6().mTimerScheduler, &PanIdQueryServer::HandleTimer, this),
+    mPanIdQuery(OPENTHREAD_URI_PANID_QUERY, &PanIdQueryServer::HandleQuery, this),
     mCoapServer(aThreadNetif.GetCoapServer()),
+    mCoapClient(aThreadNetif.GetCoapClient()),
     mNetif(aThreadNetif)
 {
     mCoapServer.AddResource(mPanIdQuery);
-    mSocket.Open(HandleUdpReceive, this);
-
-    mCoapMessageId = static_cast<uint8_t>(otPlatRandomGet());
 }
 
 void PanIdQueryServer::HandleQuery(void *aContext, Coap::Header &aHeader, Message &aMessage,
@@ -75,7 +72,7 @@ void PanIdQueryServer::HandleQuery(Coap::Header &aHeader, Message &aMessage, con
     uint16_t offset;
     uint16_t length;
 
-    VerifyOrExit(aHeader.GetCode() == Coap::Header::kCodePost, ;);
+    VerifyOrExit(aHeader.GetCode() == kCoapRequestPost, ;);
 
     SuccessOrExit(MeshCoP::Tlv::GetValueOffset(aMessage, MeshCoP::Tlv::kChannelMask, offset, length));
     aMessage.Read(offset, sizeof(channelMaskBuf), channelMaskBuf);
@@ -109,16 +106,12 @@ ThreadError PanIdQueryServer::SendQueryResponse(const Coap::Header &aRequestHead
     Coap::Header responseHeader;
     Ip6::MessageInfo responseInfo;
 
-    VerifyOrExit(aRequestHeader.GetType() == Coap::Header::kTypeConfirmable, ;);
+    VerifyOrExit(aRequestHeader.GetType() == kCoapTypeConfirmable, ;);
 
     VerifyOrExit((message = mCoapServer.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
 
-    responseHeader.Init();
-    responseHeader.SetType(Coap::Header::kTypeAcknowledgment);
-    responseHeader.SetCode(Coap::Header::kCodeChanged);
-    responseHeader.SetMessageId(aRequestHeader.GetMessageId());
-    responseHeader.SetToken(aRequestHeader.GetToken(), aRequestHeader.GetTokenLength());
-    responseHeader.Finalize();
+    responseHeader.SetDefaultResponseHeader(aRequestHeader);
+
     SuccessOrExit(error = message->Append(responseHeader.GetBytes(), responseHeader.GetLength()));
 
     memcpy(&responseInfo, &aRequestInfo, sizeof(responseInfo));
@@ -175,21 +168,12 @@ ThreadError PanIdQueryServer::SendConflict(void)
     Ip6::MessageInfo messageInfo;
     Message *message;
 
-    for (size_t i = 0; i < sizeof(mCoapToken); i++)
-    {
-        mCoapToken[i] = static_cast<uint8_t>(otPlatRandomGet());
-    }
-
-    header.Init();
-    header.SetType(Coap::Header::kTypeConfirmable);
-    header.SetCode(Coap::Header::kCodePost);
-    header.SetMessageId(++mCoapMessageId);
-    header.SetToken(mCoapToken, sizeof(mCoapToken));
+    header.Init(kCoapTypeConfirmable, kCoapRequestPost);
+    header.SetToken(Coap::Header::kDefaultTokenLength);
     header.AppendUriPathOptions(OPENTHREAD_URI_PANID_CONFLICT);
-    header.Finalize();
+    header.SetPayloadMarker();
 
-    VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
-    SuccessOrExit(error = message->Append(header.GetBytes(), header.GetLength()));
+    VerifyOrExit((message = mCoapClient.NewMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     channelMask.Init();
     channelMask.SetLength(sizeof(channelMaskBuf));
@@ -212,7 +196,7 @@ ThreadError PanIdQueryServer::SendConflict(void)
     memset(&messageInfo, 0, sizeof(messageInfo));
     messageInfo.GetPeerAddr() = mCommissioner;
     messageInfo.mPeerPort = kCoapUdpPort;
-    SuccessOrExit(error = mSocket.SendTo(*message, messageInfo));
+    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
 
     otLogInfoMeshCoP("sent panid conflict");
 
@@ -235,14 +219,6 @@ void PanIdQueryServer::HandleTimer(void)
 {
     mNetif.GetMac().ActiveScan(mChannelMask, 0, HandleScanResult, this);
     mChannelMask = 0;
-}
-
-void PanIdQueryServer::HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo)
-{
-    otLogInfoMeshCoP("received panid conflict response");
-    (void)aContext;
-    (void)aMessage;
-    (void)aMessageInfo;
 }
 
 }  // namespace Thread

--- a/src/core/thread/panid_query_server.hpp
+++ b/src/core/thread/panid_query_server.hpp
@@ -36,6 +36,7 @@
 
 #include <openthread-core-config.h>
 #include <openthread-types.h>
+#include <coap/coap_client.hpp>
 #include <coap/coap_server.hpp>
 #include <common/timer.hpp>
 #include <net/ip6_address.hpp>
@@ -87,13 +88,12 @@ private:
     uint32_t mChannelMask;
     uint16_t mPanId;
 
-    Coap::Resource mPanIdQuery;
-    Ip6::UdpSocket mSocket;
     Timer mTimer;
 
+    Coap::Resource mPanIdQuery;
     Coap::Server &mCoapServer;
-    uint8_t mCoapToken[2];
-    uint16_t mCoapMessageId;
+    Coap::Client &mCoapClient;
+
     ThreadNetif &mNetif;
 };
 


### PR DESCRIPTION
This PR utilizes recently introduces CoAP client in OpenThread.

Dummy responses sent for Thread Ntf/Qry/Ans_CON requests do not include Payload Marker now (previously added by Finalize function) as they do not carry any payload. Additionaly I've fixed a bug in CoAP Header parser, that returned error when message did not carry payload (no Payload Marker).

Three troublesome classes were not refactored - Joiner, JoinerRouter and Commissioner (CoAP over DTLS and CoAP encrypted with KEK). Please refer to #731 for discussion.