### PR TITLE
mle.cpp: Ensure to init the `mLeaderAloc` and set it with correct prefix length 

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -109,6 +109,12 @@ Mle::Mle(ThreadNetif &aThreadNetif) :
     mLinkLocal16.mPreferredLifetime = 0xffffffff;
     mLinkLocal16.mValidLifetime = 0xffffffff;
 
+    // Leader Aloc
+    memset(&mLeaderAloc, 0, sizeof(mLeaderAloc));
+    mLeaderAloc.mPrefixLength = 128;
+    mLeaderAloc.mPreferredLifetime = 0xffffffff;
+    mLeaderAloc.mValidLifetime = 0xffffffff;
+
     // initialize Mesh Local Prefix
     mMeshLocal64.GetAddress().mFields.m8[0] = 0xfd;
     memcpy(mMeshLocal64.GetAddress().mFields.m8 + 1, mMac.GetExtendedPanId(), 5);


### PR DESCRIPTION
This commit fixes an issue with the unicast address `mLeaderAloc` to ensure that it is initialized properly and its prefix length is correctly configured.

This resolves an issue where IP messages (which are destined for outside thread network) were not being forwarded to host. In commit "Add Leader ALOC feature support (#797)" a new unicast IP address `mLeaderAloc` is added to netif with uninitialized (or zero) prefix length. This in turn causes the `Ip6::GetOnLinkNetif()` to consider any address as "on-link" as any external address will match the new `mLeaderAloc` address with prefix length of zero. `Ip6::ForwardMessage()` will then keep the message inside thread network (not passed up to host).