### PR TITLE
Allow message pool management by platform code.

### DIFF
--- a/include/platform/Makefile.am
+++ b/include/platform/Makefile.am
@@ -41,6 +41,7 @@ ot_platform_headers                      =\
     spi-slave.h                           \
     flash.h                               \
     settings.h                            \
+    messagepool.h                         \
     toolchain.h                           \
     $(NULL)
 

--- a/include/platform/messagepool.h
+++ b/include/platform/messagepool.h
@@ -66,10 +66,11 @@ extern "C" {
  * Initialize the platform implemented message pool with the provided buffer list.
  *
  * @param[in] aFreeBufferList   A linked list of free buffers.
- * @param[in] aNumFreeBuffers   A pointer to an int containing the number of free buffers in aFreeBufferList
+ * @param[in] aNumFreeBuffers   A pointer to an int containing the number of free buffers in aFreeBufferList.
+ * @param[in] aBufferSize       The size in bytes of a Buffer object.
  *
  */
-void otPlatMessagePoolInit(struct BufferHeader *aFreeBufferList, int *aNumFreeBuffers);
+void otPlatMessagePoolInit(struct BufferHeader *aFreeBufferList, int *aNumFreeBuffers, size_t aBufferSize);
 
 /**
  * Allocate a buffer from the platform managed buffer pool

--- a/include/platform/messagepool.h
+++ b/include/platform/messagepool.h
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2016, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * @brief
+ *   This file includes the platform abstraction for the message pool.
+ */
+
+#ifndef MESSAGEPOOL_H_
+#define MESSAGEPOOL_H_
+
+#include <stdint.h>
+#include <openthread-types.h>
+
+/**
+ * @defgroup messagepool MessagePool
+ * @ingroup platform
+ *
+ * @brief
+ *   This module includes the platform abstraction for the message pool.
+ *
+ * @{
+ *
+ */
+
+/**
+ * This structure contains a pointer to the next Message buffer.
+ *
+ */
+struct BufferHeader
+{
+    struct BufferHeader *mNext;  ///< A pointer to the next Message buffer.
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initialize the platform implemented message pool with the provided buffer list.
+ *
+ * @param[in] aFreeBufferList   A linked list of free buffers.
+ * @param[in] aNumFreeBuffers   A pointer to an int containing the number of free buffers in aFreeBufferList
+ *
+ */
+void otPlatMessagePoolInit(struct BufferHeader *aFreeBufferList, int *aNumFreeBuffers);
+
+/**
+ * Allocate a buffer from the platform managed buffer pool
+ *
+ * @returns A pointer to the Buffer or NULL if no Buffers are available.
+ *
+ */
+struct BufferHeader *otPlatMessagePoolNew(void);
+
+/**
+ * This function is used to free a Buffer to the free Buffer pool.
+ *
+ * @param[in]  aBuffer  The Buffer to free.
+ *
+ */
+void otPlatMessagePoolFree(struct BufferHeader *aBuffer);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+/**
+ * @}
+ *
+ */
+
+
+#endif  // MESSAGEPOOL_H_

--- a/include/platform/messagepool.h
+++ b/include/platform/messagepool.h
@@ -73,7 +73,7 @@ extern "C" {
 void otPlatMessagePoolInit(struct BufferHeader *aFreeBufferList, int *aNumFreeBuffers, size_t aBufferSize);
 
 /**
- * Allocate a buffer from the platform managed buffer pool
+ * Allocate a buffer from the platform managed buffer pool.
  *
  * @returns A pointer to the Buffer or NULL if no Buffers are available.
  *
@@ -81,7 +81,7 @@ void otPlatMessagePoolInit(struct BufferHeader *aFreeBufferList, int *aNumFreeBu
 struct BufferHeader *otPlatMessagePoolNew(void);
 
 /**
- * This function is used to free a Buffer to the free Buffer pool.
+ * This function is used to free a Buffer back to the platform managed buffer pool.
  *
  * @param[in]  aBuffer  The Buffer to free.
  *

--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -117,8 +117,12 @@ void Uart::ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength)
             break;
 
         default:
-            Output(reinterpret_cast<const char *>(aBuf), 1);
-            mRxBuffer[mRxLength++] = static_cast<char>(*aBuf);
+            if (mRxLength < kRxBufferSize)
+            {
+                Output(reinterpret_cast<const char *>(aBuf), 1);
+                mRxBuffer[mRxLength++] = static_cast<char>(*aBuf);
+            }
+
             break;
         }
     }

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -57,7 +57,7 @@ MessagePool::MessagePool(void)
 #if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
     // Pass the list of free buffers and a pointer to the count of free buffers
     // to the platform for management.
-    otPlatMessagePoolInit(static_cast<BufferHeader *>(mFreeBuffers), &mNumFreeBuffers);
+    otPlatMessagePoolInit(static_cast<BufferHeader *>(mFreeBuffers), &mNumFreeBuffers, sizeof(Buffer));
 #endif
 }
 

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -101,7 +101,9 @@ Buffer *MessagePool::NewBuffer(void)
     {
         otLogInfoMac("No available message buffer\n");
     }
+
 #else // OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
+
     if (mFreeBuffers == NULL)
     {
         otLogInfoMac("No available message buffer\n");

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -43,10 +43,11 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <openthread-types.h>
 #include <openthread-core-config.h>
+#include <openthread-types.h>
 #include <common/code_utils.hpp>
 #include <mac/mac_frame.hpp>
+#include <platform/messagepool.h>
 
 namespace Thread {
 
@@ -90,14 +91,7 @@ struct MessageListEntry
     Message            *mPrev;  ///< A pointer to the previous Message in the list.
 };
 
-/**
- * This structure contains a pointer to the next Message buffer.
- *
- */
-struct BufferHeader
-{
-    class Buffer *mNext;  ///< A pointer to the next Message buffer.
-};
+
 
 /**
  * This structure contains metdata about a Message.
@@ -136,7 +130,7 @@ struct MessageInfo
  * This class represents a Message buffer.
  *
  */
-class Buffer
+class Buffer : public ::BufferHeader
 {
     friend class Message;
 
@@ -147,13 +141,13 @@ public:
      * @returns A pointer to the next message buffer.
      *
      */
-    class Buffer *GetNextBuffer(void) const { return mHeader.mNext; }
+    class Buffer *GetNextBuffer(void) const { return static_cast<Buffer *>(mNext); }
 
     /**
      * This method sets the pointer to the next message buffer.
      *
      */
-    void SetNextBuffer(class Buffer *buf) { mHeader.mNext = buf; }
+    void SetNextBuffer(class Buffer *buf) { mNext = static_cast<BufferHeader *>(buf); }
 
 private:
     /**
@@ -194,7 +188,6 @@ private:
         kHeadBufferDataSize = kBufferDataSize - sizeof(struct MessageInfo),
     };
 
-    struct BufferHeader mHeader;
     union
     {
         struct

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -248,6 +248,19 @@
 #endif  // OPENTHREAD_CONFIG_JOIN_BEACON_VERSION
 
 /**
+ * @def OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
+ *
+ * The message pool is managed by platform defined logic when this flag is set.
+ * This feature would typically be used when operating in a multi-threaded system
+ * and multiple threads need to access the message pool.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
+#define OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT           0
+#endif  // OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
+
+
+/**
  * @def OPENTHREAD_CONFIG_LOG_LEVEL
  *
  * The log level.


### PR DESCRIPTION
This change allows for an configurable option to allow platform code to manage the free message pool.  This can be useful in a multi-threaded system where it is desired for a separate thread of execution to allocate messages for outgoing packets. Platform code can be written to allow multiple threads of execution to allocate and free messages.  The default implementation in OpenThread is only suitable for single threaded execution.