### PR TITLE
Ncp: Fix join existing network feature

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -740,7 +740,16 @@ void NcpBase::UpdateChangedProps(void)
         {
             if (mRequireJoinExistingNetwork)
             {
-                mRequireJoinExistingNetwork = false;
+                switch (otGetDeviceRole(mInstance))
+                {
+                case kDeviceRoleDetached:
+                case kDeviceRoleDisabled:
+                    break;
+
+                default:
+                    mRequireJoinExistingNetwork = false;
+                    break;
+                }
 
                 if ( (otGetDeviceRole(mInstance) == kDeviceRoleLeader)
                   && otIsSingleton(mInstance)


### PR DESCRIPTION
This commit changes the `NcpBase` and join-existing-network feature by ensuring that the flag `mRequireJoinExistingNetwork` is not cleared when role changes to detached or disabled. This fixes the
issue where a "join" command could seemingly succeed with device forming its own partition (e.g, if a wrong network key is used).