### PR TITLE
Dataset storage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -79,6 +79,10 @@ PRETTY_SUBDIRS                      = \
     tools                             \
     $(NULL)
 
+# Ignore the pseudo flash files on Posix platform during diskcheck
+distcleancheck_listfiles            = \
+    $(AM_V_at)find . -type f -name "*flash"
+
 #
 # Package version files:
 #

--- a/etc/visual-studio/libopenthread-windows.vcxproj
+++ b/etc/visual-studio/libopenthread-windows.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\examples\platforms\posix\alarm.c" />
+    <ClCompile Include="..\..\examples\platforms\posix\flash-windows-stubs.c" />
     <ClCompile Include="..\..\examples\platforms\posix\logging.c" />
     <ClCompile Include="..\..\examples\platforms\posix\misc.c" />
     <ClCompile Include="..\..\examples\platforms\posix\platform.c" />

--- a/etc/visual-studio/libopenthread-windows.vcxproj.filters
+++ b/etc/visual-studio/libopenthread-windows.vcxproj.filters
@@ -13,6 +13,9 @@
     <ClCompile Include="..\..\examples\platforms\posix\alarm.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\examples\platforms\posix\flash-windows-stubs.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\examples\platforms\posix\logging.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/examples/platforms/posix/flash-windows-stubs.c
+++ b/examples/platforms/posix/flash-windows-stubs.c
@@ -26,37 +26,34 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-/**
- * @file
- * @brief
- *   This file includes the platform-specific initializers.
- */
+#include "platform-posix.h"
 
-#include <platform/uart.h>
-#include <platform/flash.h>
-#include "platform-cc2538.h"
-
-otInstance *sInstance;
-
-void PlatformInit(int argc, char *argv[])
+ThreadError otPlatFlashInit(void)
 {
-    cc2538AlarmInit();
-    cc2538RandomInit();
-    cc2538RadioInit();
-    otPlatUartEnable();
-    otPlatFlashInit();
-
-    (void)argc;
-    (void)argv;
+    return kThreadError_NotImplemented;
 }
 
-void PlatformProcessDrivers(otInstance *aInstance)
+uint32_t otPlatFlashGetSize(void)
 {
-    sInstance = aInstance;
+    return 0;
+}
 
-    // should sleep and wait for interrupts here
+ThreadError otPlatFlashErasePage(uint32_t aAddress)
+{
+    return kThreadError_NotImplemented;
+}
 
-    cc2538UartProcess();
-    cc2538RadioProcess(aInstance);
-    cc2538AlarmProcess(aInstance);
+ThreadError otPlatFlashStatusWait(uint32_t aTimeout)
+{
+    return kThreadError_None;
+}
+
+uint32_t otPlatFlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
+{
+    return 0;
+}
+
+uint32_t otPlatFlashRead(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
+{
+    return 0;
 }

--- a/examples/platforms/posix/flash.c
+++ b/examples/platforms/posix/flash.c
@@ -53,9 +53,12 @@ enum
 ThreadError otPlatFlashInit(void)
 {
     ThreadError error = kThreadError_None;
-    char fileName[16];
+    char fileName[20];
     struct stat st;
     bool create = false;
+    struct timeval tv;
+
+    gettimeofday(&tv, NULL);
 
     memset(&st, 0, sizeof(st));
 
@@ -64,7 +67,7 @@ ThreadError otPlatFlashInit(void)
         mkdir("tmp", 0777);
     }
 
-    snprintf(fileName, sizeof(fileName), "tmp/%d.flash", NODE_ID);
+    snprintf(fileName, sizeof(fileName), "tmp/%d_%d.flash", NODE_ID, (uint32_t)tv.tv_usec);
 
     if (access(fileName, 0))
     {

--- a/examples/platforms/posix/platform.c
+++ b/examples/platforms/posix/platform.c
@@ -43,6 +43,7 @@
 
 #include <openthread.h>
 #include <platform/alarm.h>
+#include <platform/flash.h>
 #include <platform/uart.h>
 
 uint32_t NODE_ID = 1;
@@ -68,6 +69,7 @@ void PlatformInit(int argc, char *argv[])
     platformAlarmInit();
     platformRadioInit();
     platformRandomInit();
+    otPlatFlashInit();
 }
 
 bool UartInitialized = false;

--- a/include/platform/settings.h
+++ b/include/platform/settings.h
@@ -36,6 +36,7 @@
 #define OT_PLATFORM_SETTINGS_H 1
 
 #include <stdint.h>
+#include <openthread-instance.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -125,6 +125,7 @@ noinst_HEADERS                      = \
     common/logging.hpp                \
     common/message.hpp                \
     common/new.hpp                    \
+    common/settings.hpp               \
     common/tasklet.hpp                \
     common/timer.hpp                  \
     common/trickle_timer.hpp          \

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -28,35 +28,28 @@
 
 /**
  * @file
- * @brief
- *   This file includes the platform-specific initializers.
+ *   This file includes functions for debugging.
  */
 
-#include <platform/uart.h>
-#include <platform/flash.h>
-#include "platform-cc2538.h"
+#ifndef SETTINGS_HPP_
+#define SETTINGS_HPP_
 
-otInstance *sInstance;
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-void PlatformInit(int argc, char *argv[])
+/**
+ * This enumeration defines the keys of settings
+ *
+ */
+enum
 {
-    cc2538AlarmInit();
-    cc2538RandomInit();
-    cc2538RadioInit();
-    otPlatUartEnable();
-    otPlatFlashInit();
+    kKeyActiveDataset  = 0x0001,
+    kKeyPendingDataset = 0x0002,
+};
 
-    (void)argc;
-    (void)argv;
-}
+#ifdef __cplusplus
+};
+#endif
 
-void PlatformProcessDrivers(otInstance *aInstance)
-{
-    sInstance = aInstance;
-
-    // should sleep and wait for interrupts here
-
-    cc2538UartProcess();
-    cc2538RadioProcess(aInstance);
-    cc2538AlarmProcess(aInstance);
-}
+#endif  // SETTINGS_HPP_

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -50,6 +50,7 @@
 #include <crypto/mbedtls.hpp>
 #include <net/icmp6.hpp>
 #include <net/ip6.hpp>
+#include <platform/settings.h>
 #include <platform/radio.h>
 #include <platform/random.h>
 #include <platform/misc.h>
@@ -1019,6 +1020,13 @@ otInstance *otInstanceInit(void *aInstanceBuffer, size_t *aInstanceBufferSize)
     // Construct the context
     aInstance = new(aInstanceBuffer)otInstance();
 
+    // restore datasets
+    otPlatSettingsInit(aInstance);
+
+    aInstance->mThreadNetif.GetActiveDataset().Restore();
+
+    aInstance->mThreadNetif.GetPendingDataset().Restore();
+
 exit:
 
     otLogFuncExit();
@@ -1037,6 +1045,13 @@ otInstance *otInstanceInit()
 
     // Construct the context
     sInstance = new(&sInstanceRaw)otInstance();
+
+    // restore datasets
+    otPlatSettingsInit(sInstance);
+
+    sInstance->mThreadNetif.GetActiveDataset().Restore();
+
+    sInstance->mThreadNetif.GetPendingDataset().Restore();
 
 exit:
 

--- a/src/core/thread/meshcop_dataset.cpp
+++ b/src/core/thread/meshcop_dataset.cpp
@@ -35,21 +35,29 @@
 #include <stdio.h>
 
 #include <common/code_utils.hpp>
+#include <common/settings.hpp>
+#include <platform/settings.h>
 #include <thread/meshcop_tlvs.hpp>
 #include <thread/meshcop_dataset.hpp>
 
 namespace Thread {
 namespace MeshCoP {
 
-Dataset::Dataset(const Tlv::Type aType) :
+Dataset::Dataset(otInstance *aInstance, const Tlv::Type aType) :
     mType(aType),
-    mLength(0)
+    mLength(0),
+    mInstance(aInstance)
 {
 }
 
-void Dataset::Clear(void)
+void Dataset::Clear(bool isLocal)
 {
     mLength = 0;
+
+    if (isLocal)
+    {
+        otPlatSettingsDelete(mInstance, mType == Tlv::kActiveTimestamp ? kKeyActiveDataset : kKeyPendingDataset, -1);
+    }
 }
 
 Tlv *Dataset::Get(Tlv::Type aType)
@@ -109,8 +117,6 @@ void Dataset::Get(otOperationalDataset &aDataset) const
             const ActiveTimestampTlv *tlv = static_cast<const ActiveTimestampTlv *>(cur);
             aDataset.mActiveTimestamp = tlv->GetSeconds();
             aDataset.mIsActiveTimestampSet = true;
-
-            GetTimestamp();
             break;
         }
 
@@ -430,6 +436,18 @@ int Dataset::Compare(const Dataset &aCompare) const
     }
 
     return rval;
+}
+
+ThreadError Dataset::Restore(void)
+{
+    return otPlatSettingsGet(mInstance, mType == Tlv::kActiveTimestamp ? kKeyActiveDataset : kKeyPendingDataset, 0, mTlvs,
+                             reinterpret_cast<int *>(&mLength));
+}
+
+ThreadError Dataset::Store(void)
+{
+    return otPlatSettingsSet(mInstance, mType == Tlv::kActiveTimestamp ? kKeyActiveDataset : kKeyPendingDataset, mTlvs,
+                             mLength);
 }
 
 ThreadError Dataset::Set(const Tlv &aTlv)

--- a/src/core/thread/meshcop_dataset.hpp
+++ b/src/core/thread/meshcop_dataset.hpp
@@ -56,13 +56,15 @@ public:
      * @param[in]  aType      The type of the dataset, active or pending.
      *
      */
-    Dataset(const Tlv::Type aType);
+    Dataset(otInstance *aInstance, const Tlv::Type aType);
 
     /**
      * This method clears the Dataset.
      *
+     * @param[in]  isLocal  TRUE to delete the local dataset from non-volatile memory, FALSE not.
+     *
      */
-    void Clear(void);
+    void Clear(bool isLocal);
 
     /**
      * This method returns a pointer to the TLV.
@@ -129,6 +131,24 @@ public:
     int Compare(const Dataset &aCompare) const;
 
     /**
+     * This method restores dataset from non-volatile memory.
+     *
+     * @retval kThreadError_None      Successfully restore the dataset.
+     * @retval kThreadError_NotFound  There is no corresponding dataset stored in non-volatile memory.
+     *
+     */
+    ThreadError Restore(void);
+
+    /**
+     * This method stores dataset into non-volatile memory.
+     *
+     * @retval kThreadError_None      Successfully store the dataset.
+     * @retval kThreadError_NoBufs    Could not store the dataset due to insufficient memory space.
+     *
+     */
+    ThreadError Store(void);
+
+    /**
      * This method sets a TLV in the Dataset.
      *
      * @param[in]  aTlv  A reference to the TLV.
@@ -153,6 +173,7 @@ private:
     Tlv::Type  mType;            ///< Active or Pending
     uint8_t    mTlvs[kMaxSize];  ///< The Dataset buffer
     uint8_t    mLength;          ///< The number of valid bytes in @var mTlvs
+    otInstance *mInstance;       ///< The pointer to an OpenThread instance
 };
 
 }  // namespace MeshCoP

--- a/src/core/thread/meshcop_dataset_manager.hpp
+++ b/src/core/thread/meshcop_dataset_manager.hpp
@@ -118,6 +118,8 @@ class ActiveDataset: public DatasetManager
 public:
     ActiveDataset(ThreadNetif &aThreadNetif);
 
+    void Restore(void);
+
     void StartLeader(void);
 
     void StopLeader(void);
@@ -149,6 +151,8 @@ class PendingDataset: public DatasetManager
 {
 public:
     PendingDataset(ThreadNetif &aThreadNetif);
+
+    void Restore(void);
 
     void StartLeader(void);
 


### PR DESCRIPTION
Resolves #837.

  * Store active dataset and pending dataset in non-volatile memory.

  * Retrieve active dataset and pending dataset from non-volatile memory after each reboot.

  * Leader will generate the active dataset if it is not initialized.

  * Clear pending dataset after it replaces active dataset.

  * Create different pseudo flash files for posix nodes.