### PR TITLE
Delay the Tlv that affects connectivity by using Pending Operational Dataset.

### DIFF
--- a/src/core/thread/meshcop_dataset_manager.hpp
+++ b/src/core/thread/meshcop_dataset_manager.hpp
@@ -81,6 +81,8 @@ protected:
 
     void Get(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
+    void HandleNetworkUpdate(uint8_t &aFlags);
+
     ThreadError Set(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     Dataset mLocal;
@@ -97,8 +99,6 @@ private:
 
     static void HandleTimer(void *aContext);
     void HandleTimer(void);
-
-    void HandleNetworkUpdate(uint8_t &aFlags);
 
     ThreadError Register(void);
     void SendSetResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo, StateTlv::State aState);
@@ -165,6 +165,8 @@ public:
 
     void UpdateDelayTimer(void);
 
+    void ApplyActiveDataset(const Timestamp &aTimestamp, Message &aMessage);
+
 private:
     static void HandleGet(void *aContext, Coap::Header &aHeader, Message &aMessage,
                           const Ip6::MessageInfo &aMessageInfo);
@@ -179,6 +181,8 @@ private:
 
     void ResetDelayTimer(uint8_t aFlags);
     void UpdateDelayTimer(Dataset &aDataset, uint32_t &aStartTime);
+
+    void HandleNetworkUpdate(uint8_t &aFlags);
 
     Coap::Resource mResourceGet;
     Coap::Resource mResourceSet;

--- a/src/core/thread/meshcop_tlvs.hpp
+++ b/src/core/thread/meshcop_tlvs.hpp
@@ -1243,6 +1243,12 @@ public:
      */
     void SetDelayTimer(uint32_t aDelayTimer) { mDelayTimer = HostSwap32(aDelayTimer); }
 
+    enum
+    {
+        kMaxDelayTimer = 259200,  ///< maximum delay timer value for a Pending Dataset in seconds
+        kMinDelayTimer = 28800,   ///< minimum delay timer value for a Pending Dataset in seconds
+    };
+
 private:
     uint32_t mDelayTimer;
 } OT_TOOL_PACKED_END;

--- a/tests/scripts/thread-cert/Cert_9_2_07_DelayTimer.py
+++ b/tests/scripts/thread-cert/Cert_9_2_07_DelayTimer.py
@@ -52,22 +52,26 @@ class Cert_9_2_7_DelayTimer(unittest.TestCase):
         for i in range(1,4):
             self.nodes[i] = node.Node(i)
 
-        self.nodes[COMMISSIONER].set_active_dataset(LEADER_ACTIVE_TIMESTAMP, panid=PANID_INIT)
+        self.nodes[COMMISSIONER].set_active_dataset(LEADER_ACTIVE_TIMESTAMP)
         self.nodes[COMMISSIONER].set_mode('rsdn')
+        self.nodes[COMMISSIONER].set_panid(PANID_INIT)
         self.nodes[COMMISSIONER].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[COMMISSIONER].enable_whitelist()
         self.nodes[COMMISSIONER].set_router_selection_jitter(1)
 
-        self.nodes[LEADER].set_active_dataset(LEADER_ACTIVE_TIMESTAMP, panid=PANID_INIT)
+        self.nodes[LEADER].set_active_dataset(LEADER_ACTIVE_TIMESTAMP)
         self.nodes[LEADER].set_mode('rsdn')
+        self.nodes[LEADER].set_panid(PANID_INIT)
         self.nodes[LEADER].set_partition_id(0xffffffff)
         self.nodes[LEADER].add_whitelist(self.nodes[COMMISSIONER].get_addr64())
         self.nodes[LEADER].enable_whitelist()
         self.nodes[LEADER].set_router_selection_jitter(1)
 
-        self.nodes[ROUTER].set_active_dataset(ROUTER_ACTIVE_TIMESTAMP, panid=PANID_INIT)
+        self.nodes[ROUTER].set_active_dataset(ROUTER_ACTIVE_TIMESTAMP)
         self.nodes[ROUTER].set_pending_dataset(ROUTER_PENDING_TIMESTAMP, ROUTER_PENDING_ACTIVE_TIMESTAMP)
         self.nodes[ROUTER].set_mode('rsdn')
+        self.nodes[ROUTER].set_panid(PANID_INIT)
+        self.nodes[ROUTER].set_partition_id(0x1)
         self.nodes[ROUTER].enable_whitelist()
         self.nodes[ROUTER].set_router_selection_jitter(1)
 


### PR DESCRIPTION
This PR is part of #803, to delay the tlv that would affect network connectivity by using pending operational dataset. When receiving MGMT_ACTIVE_SET message including tlv that affects connectivity, will do:
1. replace the pending operational dataset with the whole of active operational dataset.
2. associate a pending active timestamp with pending operational dataset, it's received active timestamp tlv from MGMT_ACTIVE_SET.
3. add delay timer tlv with MIN_DELAY_TIMER (for delay timer value, it should be in milliseconds.)
4. when delay timer expires, apply pending operational dataset to active operational dataset. If device is Leader, increment network data version.
