### PR TITLE
ncp: Allow underspecification of remove command for IPV6_ADDRESS_TABLE.

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -4575,11 +4575,8 @@ ThreadError NcpBase::RemovePropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, sp
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
                        value_len,
-                       "6CLL",
-                       &addr_ptr,
-                       NULL,
-                       NULL,
-                       NULL
+                       "6",
+                       &addr_ptr
                    );
 
     if (parsedLength > 0)


### PR DESCRIPTION
For removal operations, Spinel allows you to underspecify the entry in question by omitting any fields after the "key" field, since they would be ignored anyway. Without this change, underspecified IPV6 address removals will fail.