### PR TITLE
spinel: Make assert logging opt-in.

### DIFF
--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -105,13 +105,21 @@ static size_t spinel_strnlen_(const char *s, size_t maxlen)
 #endif
 
 #ifndef require_action
+#if SPINEL_PLATFORM_SHOULD_LOG_ASSERTS
 #define require_action(c, l, a) \
     do { if (!(c)) { \
         assert_printf("Requirement Failed (%s)", # c); \
         a; \
         goto l; \
     } } while (0)
-#endif
+#else // if DEBUG
+#define require_action(c, l, a) \
+    do { if (!(c)) { \
+        a; \
+        goto l; \
+    } } while (0)
+#endif // else DEBUG
+#endif // ifndef require_action
 
 #ifndef require
 #define require(c, l)   require_action(c, l, {})


### PR DESCRIPTION
This change makes assert logging an opt-in proposition. By default, this means that spinel will not make any calls to `printf` or `fprintf` when it hits a non-fatal runtime assertion (like an input validation failure).

This was causing some problems on some platforms.