### PR TITLE
Unify settings block length with type 'uint16_t'

### DIFF
--- a/include/platform/settings.h
+++ b/include/platform/settings.h
@@ -163,7 +163,8 @@ ThreadError otPlatSettingsAbandonChange(otInstance *aInstance);
  *  @retval kThreadError_NotImplemented
  *          This function is not implemented on this platform.
  */
-ThreadError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue, int *aValueLength);
+ThreadError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue,
+                              uint16_t *aValueLength);
 
 /// Sets or replaces the value of a setting
 /** This function sets or replaces the value of a setting
@@ -191,7 +192,7 @@ ThreadError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, 
  *  @retval kThreadError_NotImplemented
  *          This function is not implemented on this platform.
  */
-ThreadError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, int aValueLength);
+ThreadError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
 
 /// Adds a value to a setting
 /** This function adds the value to a setting
@@ -224,7 +225,7 @@ ThreadError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_
  * @retval kThreadError_NotImplemented
  *         This function is not implemented on this platform.
  */
-ThreadError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, int aValueLength);
+ThreadError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
 
 /// Removes a setting from the setting store
 /** This function deletes a specific value from the

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -180,7 +180,7 @@ exit:
 }
 
 static ThreadError addSetting(otInstance *aInstance, uint16_t aKey, bool aIndex0, const uint8_t *aValue,
-                              int aValueLength)
+                              uint16_t aValueLength)
 {
     ThreadError error = kThreadError_None;
     OT_TOOL_PACKED_BEGIN
@@ -202,7 +202,7 @@ static ThreadError addSetting(otInstance *aInstance, uint16_t aKey, bool aIndex0
     }
 
     addBlock.block.flag &= (~kBlockAddBeginFlag);
-    addBlock.block.length = static_cast<uint16_t>(aValueLength);
+    addBlock.block.length = aValueLength;
 
     if ((aInstance->mSettingsUsedSize + getAlignLength(addBlock.block.length) + sizeof(struct settingsBlock)) >=
         settingsSize)
@@ -296,7 +296,7 @@ ThreadError otPlatSettingsAbandonChange(otInstance *aInstance)
     return kThreadError_None;
 }
 
-ThreadError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue, int *aValueLength)
+ThreadError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength)
 {
     ThreadError error = kThreadError_NotFound;
     uint32_t address = aInstance->mSettingsBaseAddress + kSettingsFlagSize;
@@ -344,14 +344,14 @@ exit:
     return error;
 }
 
-ThreadError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, int aValueLength)
+ThreadError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
 {
     return addSetting(aInstance, aKey, true, aValue, aValueLength);
 }
 
-ThreadError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, int aValueLength)
+ThreadError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
 {
-    int length;
+    uint16_t length;
     bool index0;
 
     index0 = (otPlatSettingsGet(aInstance, aKey, 0, NULL, &length) == kThreadError_NotFound ? true : false);

--- a/src/core/thread/meshcop_dataset.cpp
+++ b/src/core/thread/meshcop_dataset.cpp
@@ -441,7 +441,7 @@ int Dataset::Compare(const Dataset &aCompare) const
 ThreadError Dataset::Restore(void)
 {
     return otPlatSettingsGet(mInstance, mType == Tlv::kActiveTimestamp ? kKeyActiveDataset : kKeyPendingDataset, 0, mTlvs,
-                             reinterpret_cast<int *>(&mLength));
+                             &mLength);
 }
 
 ThreadError Dataset::Store(void)

--- a/src/core/thread/meshcop_dataset.hpp
+++ b/src/core/thread/meshcop_dataset.hpp
@@ -53,7 +53,8 @@ public:
     /**
      * This constructor initializes the object.
      *
-     * @param[in]  aType      The type of the dataset, active or pending.
+     * @param[in]  aInstance  A pointer to an OpenThread instance.
+     * @param[in]  aType       The type of the dataset, active or pending.
      *
      */
     Dataset(otInstance *aInstance, const Tlv::Type aType);
@@ -102,7 +103,7 @@ public:
      * @returns The Dataset size in bytes.
      *
      */
-    uint8_t GetSize(void) const { return mLength; }
+    uint16_t GetSize(void) const { return mLength; }
 
     /**
      * This method returns a reference to the Timestamp.
@@ -172,7 +173,7 @@ private:
 
     Tlv::Type  mType;            ///< Active or Pending
     uint8_t    mTlvs[kMaxSize];  ///< The Dataset buffer
-    uint8_t    mLength;          ///< The number of valid bytes in @var mTlvs
+    uint16_t   mLength;          ///< The number of valid bytes in @var mTlvs
     otInstance *mInstance;       ///< The pointer to an OpenThread instance
 };
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3751,7 +3751,7 @@ ThreadError MleRouter::AppendActiveDataset(Message &aMessage)
     Tlv tlv;
 
     tlv.SetType(Tlv::kActiveDataset);
-    tlv.SetLength(mNetif.GetActiveDataset().GetNetwork().GetSize());
+    tlv.SetLength(static_cast<uint8_t>(mNetif.GetActiveDataset().GetNetwork().GetSize()));
     SuccessOrExit(error = aMessage.Append(&tlv, sizeof(tlv)));
     SuccessOrExit(error = aMessage.Append(mNetif.GetActiveDataset().GetNetwork().GetBytes(), tlv.GetLength()));
 
@@ -3765,7 +3765,7 @@ ThreadError MleRouter::AppendPendingDataset(Message &aMessage)
     Tlv tlv;
 
     tlv.SetType(Tlv::kPendingDataset);
-    tlv.SetLength(mNetif.GetPendingDataset().GetNetwork().GetSize());
+    tlv.SetLength(static_cast<uint8_t>(mNetif.GetPendingDataset().GetNetwork().GetSize()));
     SuccessOrExit(error = aMessage.Append(&tlv, sizeof(tlv)));
     mNetif.GetPendingDataset().UpdateDelayTimer();
     SuccessOrExit(error = aMessage.Append(mNetif.GetPendingDataset().GetNetwork().GetBytes(), tlv.GetLength()));

--- a/tests/unit/test_settings.cpp
+++ b/tests/unit/test_settings.cpp
@@ -63,7 +63,7 @@ void TestSettingsAdd(void)
 {
     uint8_t key = 7;
     uint8_t readBuffer[kMaxStageDataLen];
-    int readBufferLength;
+    uint16_t readBufferLength;
 
     VerifyOrQuit(otPlatSettingsAdd(&sInstance, key, sWriteBuffer, sWriteBufferLength) == kThreadError_None,
                  "Settings::Add::Add Fail\n");
@@ -77,7 +77,7 @@ void TestSettingsDelete(void)
 {
     uint8_t key = 8;
     uint8_t readBuffer[kMaxStageDataLen];
-    int readBufferLength;
+    uint16_t readBufferLength;
 
     VerifyOrQuit(otPlatSettingsAdd(&sInstance, key, sWriteBuffer, sWriteBufferLength) == kThreadError_None,
                  "Settings::Delete::Add Fail\n");
@@ -94,7 +94,7 @@ void TestSettingsSet(void)
 {
     uint8_t key = 9;
     uint8_t readBuffer[kMaxStageDataLen];
-    int readBufferLength;
+    uint16_t readBufferLength;
 
     for (uint8_t index = 0; index < 2; index++)
     {
@@ -116,7 +116,7 @@ void TestSettingsSwap(void)
     uint8_t key = 11;
     uint16_t index = 0;
     uint8_t readBuffer[kMaxStageDataLen];
-    int readBufferLength = kMaxStageDataLen;
+    uint16_t readBufferLength = kMaxStageDataLen;
 
     while (true)
     {


### PR DESCRIPTION
It fixes the potential overflow issue when calling `otPlatSettingsGet()` in `Dataset::Restore()`.