### PR TITLE
Delay a little longer after starting sim node

### DIFF
--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -65,10 +65,10 @@ class Node:
         cmd += ' %d' % nodeid
         print ("%s" % cmd)
 
-        self.pexpect = pexpect.spawn(cmd, timeout=2)
+        self.pexpect = pexpect.spawn(cmd, timeout=4)
 
         # Add delay to ensure that the process is ready to receive commands.
-        time.sleep(0.1)
+        time.sleep(0.2)
 
 
     def __init_ncp_sim(self, nodeid):
@@ -87,7 +87,7 @@ class Node:
         print ("%s" % cmd)
 
         self.pexpect = pexpect.spawn(cmd, timeout=4)
-        time.sleep(0.1)
+        time.sleep(0.2)
         self.pexpect.expect('spinel-cli >')
         self.debug(int(os.getenv('DEBUG', '0')))
  


### PR DESCRIPTION
It helps to avoid some random failures in travis check.

Sim node needs to take a little longer time to create and initialize pseudo flash file before it is ready to receive commands, especially in parallel run (The bigger `BuildJobs` number, the longer delay it need).