### PR TITLE
6LOWPAN: Add support for compression and decompression of IP-in-IP.

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1567,8 +1567,7 @@ void MeshForwarder::HandleFragment(uint8_t *aFrame, uint8_t aFrameLength,
         aFrameLength -= static_cast<uint8_t>(headerLength);
 
         SuccessOrExit(error = message->SetLength(datagramLength));
-        datagramLength = HostSwap16(datagramLength - sizeof(Ip6::Header));
-        message->Write(Ip6::Header::GetPayloadLengthOffset(), sizeof(datagramLength), &datagramLength);
+
         message->SetDatagramTag(datagramTag);
         message->SetTimeout(kReassemblyTimeout);
 
@@ -1670,7 +1669,6 @@ void MeshForwarder::HandleLowpanHC(uint8_t *aFrame, uint8_t aFrameLength,
     ThreadError error = kThreadError_None;
     Message *message;
     int headerLength;
-    uint16_t ip6PayloadLength;
 
     VerifyOrExit((message = mNetif.GetIp6().mMessagePool.New(Message::kTypeIp6, 0)) != NULL,
                  error = kThreadError_NoBufs);
@@ -1684,10 +1682,6 @@ void MeshForwarder::HandleLowpanHC(uint8_t *aFrame, uint8_t aFrameLength,
     aFrameLength -= static_cast<uint8_t>(headerLength);
 
     SuccessOrExit(error = message->SetLength(message->GetLength() + aFrameLength));
-
-    ip6PayloadLength = HostSwap16(message->GetLength() - sizeof(Ip6::Header));
-    message->Write(Ip6::Header::GetPayloadLengthOffset(), sizeof(ip6PayloadLength), &ip6PayloadLength);
-
     message->Write(message->GetOffset(), aFrameLength, aFrame);
 
     // Security Check

--- a/tests/unit/test_lowpan.cpp
+++ b/tests/unit/test_lowpan.cpp
@@ -96,10 +96,6 @@ void TestLowpanIphc(void)
         SuccessOrQuit(message->Append(frame.GetPayload() + decompressedBytes,
                                       ip6PayloadLength),
                       "6lo: Message::Append failed");
-        ip6PayloadLength = HostSwap16(message->GetLength() -
-                                      sizeof(Ip6::Header));
-        message->Write(Ip6::Header::GetPayloadLengthOffset(),
-                       sizeof(ip6PayloadLength), &ip6PayloadLength);
 
         resultLength = message->GetLength();
         message->Read(0, resultLength, result);
@@ -109,6 +105,8 @@ void TestLowpanIphc(void)
 
         VerifyOrQuit(memcmp(ipVector.data(), result, resultLength) == 0,
                      "6lo: Lowpan::Decompress failed");
+
+        message->SetOffset(0);
 
         // ===> Test Lowpan::Compress
         int compressBytes = sMockLowpan.Compress(*message, macSource, macDest,


### PR DESCRIPTION
This pull request adds support for compression and decompression of IP-in-IP header in 6LoWPAN layer.

Additionally calculation of IPv6 length has been rewritten and moved to Lowpan::Decompress() method instead of having it in three separate places.

This is part of IP-in-IP support, since i wait for #874 to be merged (RemoveHeader function). I will send PR right after with IP-in-IP support in IP layer.

Below I have attached wireshark capture of MPL messages send to pre-subscribed (for test) address ff05::11 (which are encapsulated using ff03::fc ALL_MPL_FORWARDERS address). As you see outer and inner IPv6 headers are compressed and decompressed using IPHC on 6LoWPAN layer correctly.

![ipinip](https://cloud.githubusercontent.com/assets/5144764/19726956/aeda9340-9b8d-11e6-9a94-633da0ead72f.png)
