### PR TITLE
Add 'factoryreset' cli

### DIFF
--- a/include/openthread.h
+++ b/include/openthread.h
@@ -1658,6 +1658,13 @@ void otSetAssignLinkQuality(otInstance *aInstance, const uint8_t *aExtAddr, uint
 void otPlatformReset(otInstance *aInstance);
 
 /**
+ * This method deletes all the settings stored on non-volatile memory, and then triggers platform reset.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ */
+void otFactoryReset(otInstance *aInstance);
+
+/**
  * Get the ROUTER_DOWNGRADE_THRESHOLD parameter used in the Router role.
  *
  * @param[in]  aInstance  A pointer to an OpenThread instance.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -21,6 +21,7 @@ OpenThread test scripts use the CLI to execute test cases.
 * [eui64](#eui64)
 * [extaddr](#extaddr)
 * [extpanid](#extpanid)
+* [factoryreset](#factoryreset)
 * [hashmacaddr](#hashmacaddr)
 * [ifconfig](#ifconfig)
 * [ipaddr](#ipaddr)
@@ -709,6 +710,13 @@ Set the Thread Extended PAN ID value.
 ```bash
 > extpanid dead00beef00cafe
 Done
+```
+
+### factoryreset
+Delete all stored settings, and signal a platform reset.
+
+```bash
+> factoryreset
 ```
 
 ### hashmacaddr

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -87,6 +87,7 @@ const struct Command Interpreter::sCommands[] =
 #endif
     { "extaddr", &Interpreter::ProcessExtAddress },
     { "extpanid", &Interpreter::ProcessExtPanId },
+    { "factoryreset", &Interpreter::ProcessFactoryReset },
     { "hashmacaddr", &Interpreter::ProcessHashMacAddress },
     { "ifconfig", &Interpreter::ProcessIfconfig },
     { "ipaddr", &Interpreter::ProcessIpAddr },
@@ -648,6 +649,13 @@ void Interpreter::ProcessExtPanId(int argc, char *argv[])
 
 exit:
     AppendResult(error);
+}
+
+void Interpreter::ProcessFactoryReset(int argc, char *argv[])
+{
+    otFactoryReset(mInstance);
+    (void)argc;
+    (void)argv;
 }
 
 void Interpreter::ProcessHashMacAddress(int argc, char *argv[])

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -160,6 +160,7 @@ private:
 #endif
     void ProcessExtAddress(int argc, char *argv[]);
     void ProcessExtPanId(int argc, char *argv[]);
+    void ProcessFactoryReset(int argc, char *argv[]);
     void ProcessHashMacAddress(int argc, char *argv[]);
     void ProcessIfconfig(int argc, char *argv[]);
     void ProcessIpAddr(int argc, char *argv[]);

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -691,6 +691,12 @@ void otPlatformReset(otInstance *aInstance)
     otPlatReset(aInstance);
 }
 
+void otFactoryReset(otInstance *aInstance)
+{
+    otPlatSettingsWipe(aInstance);
+    otPlatReset(aInstance);
+}
+
 uint8_t otGetRouterDowngradeThreshold(otInstance *aInstance)
 {
     return aInstance->mThreadNetif.GetMle().GetRouterDowngradeThreshold();

--- a/tools/harness-thci/ARM.py
+++ b/tools/harness-thci/ARM.py
@@ -1103,7 +1103,9 @@ class ARM(IThci):
         """power down the Thread device"""
         print '%s call powerDown' % self.port
         self.isPowerDown = True
-        self.reset()
+        self._sendline('reset')
+        time.sleep(3)
+        self.setMAC(self.mac)
 
     def powerUp(self):
         """power up the Thread device"""
@@ -1225,7 +1227,7 @@ class ARM(IThci):
         """factory reset"""
         print '%s call reset' % self.port
         try:
-            self._sendline('reset')
+            self._sendline('factoryreset')
             self._read()
         except Exception, e:
             ModuleHelper.WriteIntoDebugLogger("reset() Error: " + str(e))
@@ -2210,10 +2212,6 @@ class ARM(IThci):
             if xPanId != None:
                 cmd += ' panid '
                 cmd += str(xPanId)
-
-            if xDelayTimer != None:
-                cmd += ' delay '
-                cmd += str(xDelayTimer)
 
             if listChannelMask != None:
                 cmd += ' channelmask '


### PR DESCRIPTION
* add 'factoryreset' cli to delete all stored settings and then reset

* use 'factoryreset' in THCI reset API to ensure that there is no pre-settings in DUT before running any test