### PR TITLE
IP: Add support to IP-in-IP in IPv6 layer

### DIFF
--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -304,13 +304,12 @@ public:
     /**
      * This method perform default source address selection.
      *
-     * @param[in]  aDestination  A reference to the destination address.
      * @param[in]  aMessageInfo  A reference to the message information.
      *
      * @returns A pointer to the selected IPv6 source address or NULL if no source address was found.
      *
      */
-    const NetifUnicastAddress *SelectSourceAddress(const Address &aDestination, MessageInfo &aMessageInfo);
+    const NetifUnicastAddress *SelectSourceAddress(MessageInfo &aMessageInfo);
 
     /**
      * This method determines which network interface @p aAddress is on-link, if any.

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -304,12 +304,13 @@ public:
     /**
      * This method perform default source address selection.
      *
+     * @param[in]  aDestination  A reference to the destination address.
      * @param[in]  aMessageInfo  A reference to the message information.
      *
      * @returns A pointer to the selected IPv6 source address or NULL if no source address was found.
      *
      */
-    const NetifUnicastAddress *SelectSourceAddress(MessageInfo &aMessageInfo);
+    const NetifUnicastAddress *SelectSourceAddress(const Address &aDestination, MessageInfo &aMessageInfo);
 
     /**
      * This method determines which network interface @p aAddress is on-link, if any.
@@ -346,8 +347,9 @@ private:
     ThreadError HandleExtensionHeaders(Message &message, Header &header, uint8_t &nextHeader, bool forward,
                                        bool receive);
     ThreadError HandleFragment(Message &message);
-    ThreadError AddMplOption(Message &message, Header &header, IpProto nextHeader, uint16_t payloadLength);
-    ThreadError InsertMplOption(Message &message, Header &header);
+    ThreadError AddMplOption(Message &message, Header &header);
+    ThreadError AddTunneledMplOption(Message &message, Header &header, MessageInfo &messageInfo);
+    ThreadError InsertMplOption(Message &message, Header &header, MessageInfo &messageInfo);
     ThreadError RemoveMplOption(Message &aMessage);
     ThreadError HandleOptions(Message &message, Header &header, bool &forward);
     ThreadError HandlePayload(Message &message, MessageInfo &messageInfo, uint8_t ipproto);

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -105,6 +105,12 @@ bool Address::IsRealmLocalAllRoutersMulticast(void) const
             mFields.m32[2] == 0 && mFields.m32[3] == HostSwap32(0x02));
 }
 
+bool Address::IsRealmLocalAllMplForwarders(void) const
+{
+    return (mFields.m32[0] == HostSwap32(0xff030000) && mFields.m32[1] == 0 &&
+            mFields.m32[2] == 0 && mFields.m32[3] == HostSwap32(0xfc));
+}
+
 bool Address::IsRoutingLocator(void) const
 {
     return (mFields.m16[4] == HostSwap16(0x0000) && mFields.m16[5] == HostSwap16(0x00ff) &&

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -138,7 +138,7 @@ public:
      * This method indicates whether or not the IPv6 address is a link-local all nodes multicast address.
      *
      * @retval TRUE   If the IPv6 address is a link-local all nodes multicast address.
-     * @retval FALSE  If the IPv6 address scope is not a link-local all nodes multicast address.
+     * @retval FALSE  If the IPv6 address is not a link-local all nodes multicast address.
      *
      */
     bool IsLinkLocalAllNodesMulticast(void) const;
@@ -147,7 +147,7 @@ public:
      * This method indicates whether or not the IPv6 address is a link-local all routers multicast address.
      *
      * @retval TRUE   If the IPv6 address is a link-local all routers multicast address.
-     * @retval FALSE  If the IPv6 address scope is not a link-local all routers multicast address.
+     * @retval FALSE  If the IPv6 address is not a link-local all routers multicast address.
      *
      */
     bool IsLinkLocalAllRoutersMulticast(void) const;
@@ -165,7 +165,7 @@ public:
      * This method indicates whether or not the IPv6 address is a realm-local all nodes multicast address.
      *
      * @retval TRUE   If the IPv6 address is a realm-local all nodes multicast address.
-     * @retval FALSE  If the IPv6 address scope is not a realm-local all nodes multicast address.
+     * @retval FALSE  If the IPv6 address is not a realm-local all nodes multicast address.
      *
      */
     bool IsRealmLocalAllNodesMulticast(void) const;
@@ -174,10 +174,19 @@ public:
      * This method indicates whether or not the IPv6 address is a realm-local all routers multicast address.
      *
      * @retval TRUE   If the IPv6 address is a realm-local all routers multicast address.
-     * @retval FALSE  If the IPv6 address scope is not a realm-local all routers multicast address.
+     * @retval FALSE  If the IPv6 address is not a realm-local all routers multicast address.
      *
      */
     bool IsRealmLocalAllRoutersMulticast(void) const;
+
+    /**
+     * This method indicates whether or not the IPv6 address is a realm-local all MPL forwarders address.
+     *
+     * @retval TRUE   If the IPv6 address is a realm-local all MPL forwarders address.
+     * @retval FALSE  If the IPv6 address is not a realm-local all MPL forwarders address.
+     *
+     */
+    bool IsRealmLocalAllMplForwarders(void) const;
 
     /**
      * This method indicates whether or not the IPv6 address is a RLOC address.

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -122,7 +122,8 @@ bool Netif::IsMulticastSubscribed(const Address &aAddress) const
 {
     bool rval = false;
 
-    if (aAddress.IsLinkLocalAllNodesMulticast() || aAddress.IsRealmLocalAllNodesMulticast())
+    if (aAddress.IsLinkLocalAllNodesMulticast() || aAddress.IsRealmLocalAllNodesMulticast() ||
+        aAddress.IsRealmLocalAllMplForwarders())
     {
         ExitNow(rval = true);
     }


### PR DESCRIPTION
This pull request adds support for IP-in-IP in IP layer which is an addition to #887 

As a result - forwarding of MPL packets with multicast scope larger than realm-local is possible.
Right now i see that there is an open discussion `SPEC-659` about hop-limit field in the encapsulating header. I have choosen to use the default one (64), and not that from the encapsulated header. Also i believe following RFC2473 source address of the encapsulating header is selected using the default procedure taking ff03::fc as an input instead of for example ff05::1 (from inner header).

Below I have attached wireshark capture of MPL messages send to pre-subscribed (for test) address ff05::11 (which are encapsulated using ff03::fc ALL_MPL_FORWARDERS address).

![ipinip](https://cloud.githubusercontent.com/assets/5144764/19765689/f66438b2-9c49-11e6-9621-0de706e1d45c.png)

Also #713 probably should be closed after this is merged.