### PR TITLE
Implement reattach process using stored dataset

### DIFF
--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -1139,7 +1139,7 @@ ThreadError otThreadStart(otInstance *aInstance)
 
     VerifyOrExit(aInstance->mThreadNetif.GetMac().GetPanId() != Mac::kPanIdBroadcast, error = kThreadError_InvalidState);
 
-    error = aInstance->mThreadNetif.GetMle().Start();
+    error = aInstance->mThreadNetif.GetMle().Start(true);
 
 exit:
     otLogFuncExitErr(error);
@@ -1152,7 +1152,7 @@ ThreadError otThreadStop(otInstance *aInstance)
 
     otLogFuncEntry();
 
-    error = aInstance->mThreadNetif.GetMle().Stop();
+    error = aInstance->mThreadNetif.GetMle().Stop(true);
 
     otLogFuncExitErr(error);
     return error;

--- a/src/core/thread/meshcop_dataset_manager.cpp
+++ b/src/core/thread/meshcop_dataset_manager.cpp
@@ -70,6 +70,79 @@ DatasetManager::DatasetManager(ThreadNetif &aThreadNetif, const Tlv::Type aType,
 {
 }
 
+ThreadError DatasetManager::ApplyConfiguration(void)
+{
+    ThreadError error = kThreadError_None;
+    Dataset *dataset;
+    const Tlv *cur;
+    const Tlv *end;
+
+    dataset = mMle.IsAttached() ? &mNetwork : &mLocal;
+
+    cur = reinterpret_cast<const Tlv *>(dataset->GetBytes());
+    end = reinterpret_cast<const Tlv *>(dataset->GetBytes() + dataset->GetSize());
+
+    while (cur < end)
+    {
+        switch (cur->GetType())
+        {
+        case Tlv::kChannel:
+        {
+            const ChannelTlv *channel = static_cast<const ChannelTlv *>(cur);
+            mNetif.GetMac().SetChannel(static_cast<uint8_t>(channel->GetChannel()));
+            break;
+        }
+
+        case Tlv::kPanId:
+        {
+            const PanIdTlv *panid = static_cast<const PanIdTlv *>(cur);
+            mNetif.GetMac().SetPanId(panid->GetPanId());
+            break;
+        }
+
+        case Tlv::kExtendedPanId:
+        {
+            const ExtendedPanIdTlv *extpanid = static_cast<const ExtendedPanIdTlv *>(cur);
+            mNetif.GetMac().SetExtendedPanId(extpanid->GetExtendedPanId());
+            break;
+        }
+
+        case Tlv::kNetworkName:
+        {
+            const NetworkNameTlv *name = static_cast<const NetworkNameTlv *>(cur);
+            otNetworkName networkName;
+            memset(networkName.m8, 0, sizeof(networkName));
+            memcpy(networkName.m8, name->GetNetworkName(), name->GetLength());
+            mNetif.GetMac().SetNetworkName(networkName.m8);
+            break;
+        }
+
+        case Tlv::kNetworkMasterKey:
+        {
+            const NetworkMasterKeyTlv *key = static_cast<const NetworkMasterKeyTlv *>(cur);
+            mNetif.GetKeyManager().SetMasterKey(key->GetNetworkMasterKey(), key->GetLength());
+            break;
+        }
+
+        case Tlv::kMeshLocalPrefix:
+        {
+            const MeshLocalPrefixTlv *prefix = static_cast<const MeshLocalPrefixTlv *>(cur);
+            mMle.SetMeshLocalPrefix(prefix->GetMeshLocalPrefix());
+            break;
+        }
+
+        default:
+        {
+            break;
+        }
+        }
+
+        cur = cur->GetNext();
+    }
+
+    return error;
+}
+
 ThreadError DatasetManager::Set(const otOperationalDataset &aDataset, uint8_t &aFlags)
 {
     ThreadError error = kThreadError_None;
@@ -100,9 +173,9 @@ exit:
     return error;
 }
 
-ThreadError DatasetManager::Clear(uint8_t &aFlags)
+ThreadError DatasetManager::Clear(uint8_t &aFlags, bool aOnlyClearNetwork)
 {
-    if (mLocal.Compare(mNetwork) == 0)
+    if (!aOnlyClearNetwork && mLocal.Compare(mNetwork) == 0)
     {
         mLocal.Clear(true);
     }
@@ -651,10 +724,15 @@ ActiveDataset::ActiveDataset(ThreadNetif &aThreadNetif):
 {
 }
 
-void ActiveDataset::Restore(void)
+ThreadError ActiveDataset::Restore(void)
 {
-    mLocal.Restore();
-    ApplyConfiguration();
+    ThreadError error = kThreadError_None;
+
+    SuccessOrExit(error = mLocal.Restore());
+    SuccessOrExit(error = DatasetManager::ApplyConfiguration());
+
+exit:
+    return error;
 }
 
 void ActiveDataset::StartLeader(void)
@@ -715,12 +793,12 @@ void ActiveDataset::StopLeader(void)
     mCoapServer.RemoveResource(mResourceSet);
 }
 
-ThreadError ActiveDataset::Clear(void)
+ThreadError ActiveDataset::Clear(bool aOnlyClearNetwork)
 {
     ThreadError error = kThreadError_None;
     uint8_t flags;
 
-    SuccessOrExit(error = DatasetManager::Clear(flags));
+    SuccessOrExit(error = DatasetManager::Clear(flags, aOnlyClearNetwork));
 
 exit:
     return error;
@@ -732,7 +810,7 @@ ThreadError ActiveDataset::Set(const otOperationalDataset &aDataset)
     uint8_t flags;
 
     SuccessOrExit(error = DatasetManager::Set(aDataset, flags));
-    ApplyConfiguration();
+    DatasetManager::ApplyConfiguration();
 
 exit:
     return error;
@@ -743,7 +821,7 @@ ThreadError ActiveDataset::Set(const Dataset &aDataset)
     ThreadError error = kThreadError_None;
 
     SuccessOrExit(error = DatasetManager::Set(aDataset));
-    ApplyConfiguration();
+    DatasetManager::ApplyConfiguration();
 
 exit:
     return error;
@@ -756,7 +834,7 @@ ThreadError ActiveDataset::Set(const Timestamp &aTimestamp, const Message &aMess
     uint8_t flags;
 
     SuccessOrExit(error = DatasetManager::Set(aTimestamp, aMessage, aOffset, aLength, flags));
-    ApplyConfiguration();
+    DatasetManager::ApplyConfiguration();
 
 exit:
     return error;
@@ -788,79 +866,6 @@ exit:
     return;
 }
 
-ThreadError ActiveDataset::ApplyConfiguration(void)
-{
-    ThreadError error = kThreadError_None;
-    Dataset *dataset;
-    const Tlv *cur;
-    const Tlv *end;
-
-    dataset = mMle.IsAttached() ? &mNetwork : &mLocal;
-
-    cur = reinterpret_cast<const Tlv *>(dataset->GetBytes());
-    end = reinterpret_cast<const Tlv *>(dataset->GetBytes() + dataset->GetSize());
-
-    while (cur < end)
-    {
-        switch (cur->GetType())
-        {
-        case Tlv::kChannel:
-        {
-            const ChannelTlv *channel = static_cast<const ChannelTlv *>(cur);
-            mNetif.GetMac().SetChannel(static_cast<uint8_t>(channel->GetChannel()));
-            break;
-        }
-
-        case Tlv::kPanId:
-        {
-            const PanIdTlv *panid = static_cast<const PanIdTlv *>(cur);
-            mNetif.GetMac().SetPanId(panid->GetPanId());
-            break;
-        }
-
-        case Tlv::kExtendedPanId:
-        {
-            const ExtendedPanIdTlv *extpanid = static_cast<const ExtendedPanIdTlv *>(cur);
-            mNetif.GetMac().SetExtendedPanId(extpanid->GetExtendedPanId());
-            break;
-        }
-
-        case Tlv::kNetworkName:
-        {
-            const NetworkNameTlv *name = static_cast<const NetworkNameTlv *>(cur);
-            otNetworkName networkName;
-            memset(networkName.m8, 0, sizeof(networkName));
-            memcpy(networkName.m8, name->GetNetworkName(), name->GetLength());
-            mNetif.GetMac().SetNetworkName(networkName.m8);
-            break;
-        }
-
-        case Tlv::kNetworkMasterKey:
-        {
-            const NetworkMasterKeyTlv *key = static_cast<const NetworkMasterKeyTlv *>(cur);
-            mNetif.GetKeyManager().SetMasterKey(key->GetNetworkMasterKey(), key->GetLength());
-            break;
-        }
-
-        case Tlv::kMeshLocalPrefix:
-        {
-            const MeshLocalPrefixTlv *prefix = static_cast<const MeshLocalPrefixTlv *>(cur);
-            mMle.SetMeshLocalPrefix(prefix->GetMeshLocalPrefix());
-            break;
-        }
-
-        default:
-        {
-            break;
-        }
-        }
-
-        cur = cur->GetNext();
-    }
-
-    return error;
-}
-
 PendingDataset::PendingDataset(ThreadNetif &aThreadNetif):
     DatasetManager(aThreadNetif, Tlv::kPendingTimestamp, OPENTHREAD_URI_PENDING_SET, OPENTHREAD_URI_PENDING_GET),
     mResourceGet(OPENTHREAD_URI_PENDING_GET, &PendingDataset::HandleGet, this),
@@ -869,10 +874,16 @@ PendingDataset::PendingDataset(ThreadNetif &aThreadNetif):
 {
 }
 
-void PendingDataset::Restore(void)
+ThreadError PendingDataset::Restore(void)
 {
-    mLocal.Restore();
+    ThreadError error = kThreadError_None;
+
+    SuccessOrExit(error = mLocal.Restore());
+
     ResetDelayTimer(kFlagLocalUpdated);
+
+exit:
+    return error;
 }
 
 void PendingDataset::StartLeader(void)
@@ -892,12 +903,12 @@ void PendingDataset::StopLeader(void)
     mCoapServer.RemoveResource(mResourceSet);
 }
 
-ThreadError PendingDataset::Clear(void)
+ThreadError PendingDataset::Clear(bool aOnlyClearNetwork)
 {
     ThreadError error = kThreadError_None;
     uint8_t flags;
 
-    SuccessOrExit(error = DatasetManager::Clear(flags));
+    SuccessOrExit(error = DatasetManager::Clear(flags, aOnlyClearNetwork));
     ResetDelayTimer(flags);
 
 exit:
@@ -911,6 +922,17 @@ ThreadError PendingDataset::Set(const otOperationalDataset &aDataset)
 
     SuccessOrExit(error = DatasetManager::Set(aDataset, flags));
     ResetDelayTimer(flags);
+
+exit:
+    return error;
+}
+
+ThreadError PendingDataset::Set(const Dataset &aDataset)
+{
+    ThreadError error = kThreadError_None;
+
+    SuccessOrExit(error = DatasetManager::Set(aDataset));
+    ResetDelayTimer(kFlagLocalUpdated | kFlagNetworkUpdated);
 
 exit:
     return error;
@@ -1037,7 +1059,7 @@ void PendingDataset::HandleTimer(void)
 
     mNetif.GetActiveDataset().Set(mNetwork);
 
-    Clear();
+    Clear(false);
 }
 
 }  // namespace MeshCoP

--- a/src/core/thread/meshcop_dataset_manager.hpp
+++ b/src/core/thread/meshcop_dataset_manager.hpp
@@ -56,6 +56,8 @@ public:
     Dataset &GetLocal(void) { return mLocal; }
     Dataset &GetNetwork(void) { return mNetwork; }
 
+    ThreadError ApplyConfiguration(void);
+
     ThreadError SendSetRequest(const otOperationalDataset &aDataset, const uint8_t *aTlvs, uint8_t aLength);
     ThreadError SendGetRequest(const uint8_t *aTlvTypes, uint8_t aLength);
 
@@ -68,7 +70,7 @@ protected:
 
     DatasetManager(ThreadNetif &aThreadNetif, const Tlv::Type aType, const char *aUriSet, const char *aUriGet);
 
-    ThreadError Clear(uint8_t &aFlags);
+    ThreadError Clear(uint8_t &aFlags, bool aOnlyClearNetwork);
 
     ThreadError Set(const otOperationalDataset &aDataset, uint8_t &aFlags);
 
@@ -115,21 +117,19 @@ class ActiveDataset: public DatasetManager
 public:
     ActiveDataset(ThreadNetif &aThreadNetif);
 
-    void Restore(void);
+    ThreadError Restore(void);
 
     void StartLeader(void);
 
     void StopLeader(void);
 
-    ThreadError Clear(void);
+    ThreadError Clear(bool aOnlyClearNetwork);
 
     ThreadError Set(const otOperationalDataset &aDataset);
 
     ThreadError Set(const Dataset &aDataset);
 
     ThreadError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
-
-    ThreadError ApplyConfiguration(void);
 
 private:
     static void HandleGet(void *aContext, Coap::Header &aHeader, Message &aMessage,
@@ -149,15 +149,17 @@ class PendingDataset: public DatasetManager
 public:
     PendingDataset(ThreadNetif &aThreadNetif);
 
-    void Restore(void);
+    ThreadError Restore(void);
 
     void StartLeader(void);
 
     void StopLeader(void);
 
-    ThreadError Clear(void);
+    ThreadError Clear(bool aOnlyClearNetwork);
 
     ThreadError Set(const otOperationalDataset &aDataset);
+
+    ThreadError Set(const Dataset &aDataset);
 
     ThreadError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -374,19 +374,23 @@ public:
     /**
      * This method starts the MLE protocol operation.
      *
+     * @param[in]  aEnableReattach  True to enable reattach process using stored dataset, False not.
+     *
      * @retval kThreadError_None     Successfully started the protocol operation.
      * @retval kThreadError_Already  The protocol operation was already started.
      *
      */
-    ThreadError Start(void);
+    ThreadError Start(bool aEnableReattach);
 
     /**
      * This method stops the MLE protocol operation.
      *
+     * @param[in]  aClearNetworkDatasets  True to clear network datasets, False not.
+     *
      * @retval kThreadError_None  Successfully stopped the protocol operation.
      *
      */
-    ThreadError Stop(void);
+    ThreadError Stop(bool aClearNetworkDatasets);
 
     /**
      * This function pointer is called on receiving an MLE Discovery Response message.
@@ -1159,6 +1163,19 @@ protected:
         kChildIdRequest,       ///< Sending a Child ID Request message.
     };
     ParentRequestState mParentRequestState;  ///< The parent request state.
+
+    /**
+     * States when reattaching network using stored dataset
+     *
+     */
+    enum ReattachState
+    {
+        kReattachStop       = 0,   ///< Reattach process is disabled or finished
+        kReattachStart      = 1,   ///< Start reattach process
+        kReattachActive     = 2,   ///< Reattach using stored Active Dataset
+        kReattachPending    = 3,   ///< Reattach using stored Pending Dataset
+    };
+    ReattachState mReattachState;
 
     Timer mParentRequestTimer;  ///< The timer for driving the Parent Request process.
 

--- a/tests/scripts/thread-cert/Cert_9_2_07_DelayTimer.py
+++ b/tests/scripts/thread-cert/Cert_9_2_07_DelayTimer.py
@@ -86,7 +86,7 @@ class Cert_9_2_7_DelayTimer(unittest.TestCase):
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'router')
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        time.sleep(10)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'leader')
 
         self.nodes[LEADER].add_whitelist(self.nodes[ROUTER].get_addr64())


### PR DESCRIPTION
Resolves #867.

This PR implements the reattach process using stored dataset:
1. Reattach process will only be enabled with command "thread start";
2. It will try to attach using stored active dataset firstly, if there is no active dataset, stop reattach process;
3. If it failed to attach using active dataset, it will apply pending dataset and try to attach again, if there is no pending dataset, stop reattach process;
4. If it failed to attach using pending dataset, it will revert back to using the active dataset, and enable local Pending dataset and start its delay timer.

It helps to pass certification test: ED_9_2_8 and Router_9_2_8:
[Router_9_2_8.zip](https://github.com/openthread/openthread/files/555820/Router_9_2_8.zip)
[ED_9_2_8.zip](https://github.com/openthread/openthread/files/555821/ED_9_2_8.zip)

While other three related tests still failed due to some other issues, I will go on to analyze and fix them:
[SED_9_2_8.zip](https://github.com/openthread/openthread/files/555972/SED_9_2_8.zip)
[Router_9_2_15.zip](https://github.com/openthread/openthread/files/555856/Router_9_2_15.zip)
[Router_9_2_16.zip](https://github.com/openthread/openthread/files/555857/Router_9_2_16.zip)
