### PR TITLE
Add option for Radio layer to support retries and CSMA backoff logic.

### DIFF
--- a/examples/drivers/windows/otLwf/radio.c
+++ b/examples/drivers/windows/otLwf/radio.c
@@ -131,6 +131,8 @@ otLwfRadioInit(
     pFilter->otRadioCapabilities = kRadioCapsEnergyScan;
     if ((pFilter->MiniportCapabilities.RadioCapabilities & OT_RADIO_CAP_ACK_TIMEOUT) != 0)
         pFilter->otRadioCapabilities |= kRadioCapsAckTimeout;
+    if ((pFilter->MiniportCapabilities.RadioCapabilities & OT_RADIO_CAP_MAC_RETRY_AND_COLLISION_AVOIDANCE) != 0)
+        pFilter->otRadioCapabilities |= kRadioCapsTransmitRetries;
 
     pFilter->otPhyState = kStateDisabled;
     pFilter->otCurrentListenChannel = 0xFF;

--- a/include/platform/radio.h
+++ b/include/platform/radio.h
@@ -87,9 +87,10 @@ enum
 
 typedef enum otRadioCaps
 {
-    kRadioCapsNone          = 0,  ///< None
-    kRadioCapsAckTimeout    = 1,  ///< Radio supports AckTime event
-    kRadioCapsEnergyScan    = 2,  ///< Radio supports Enegery Scans
+    kRadioCapsNone              = 0,  ///< None
+    kRadioCapsAckTimeout        = 1,  ///< Radio supports AckTime event
+    kRadioCapsEnergyScan        = 2,  ///< Radio supports Enegery Scans
+    kRadioCapsTransmitRetries   = 4,  ///< Radio supports transmission retry logic with collission avoidance
 } otRadioCaps;
 
 /**

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -80,7 +80,7 @@ static_assert(kMinBackoffSum > 0, "The min backoff value should be greater than 
 
 void Mac::StartCsmaBackoff(void)
 {
-    if (RadioSupportsRetriesAndCsmaBackofff())
+    if (RadioSupportsRetriesAndCsmaBackoff())
     {
         // If the radio supports the retry and back off logic, immediately schedule the send,
         // and the radio will take care of everything.
@@ -797,7 +797,7 @@ void Mac::TransmitDoneTask(bool aRxPending, ThreadError aError)
 
     mCounters.mTxTotal++;
 
-    if (!RadioSupportsRetriesAndCsmaBackofff() &&
+    if (!RadioSupportsRetriesAndCsmaBackoff() &&
         aError == kThreadError_ChannelAccessFailure &&
         mCsmaAttempts < kMaxCSMABackoffs)
     {
@@ -914,7 +914,7 @@ void Mac::SentFrame(ThreadError aError)
     case kThreadError_NoAck:
         otDumpDebgMac("NO ACK", sendFrame.GetHeader(), 16);
 
-        if (!RadioSupportsRetriesAndCsmaBackofff() &&
+        if (!RadioSupportsRetriesAndCsmaBackoff() &&
             mTransmitAttempts < kMaxFrameAttempts)
         {
             mTransmitAttempts++;
@@ -1387,7 +1387,7 @@ void Mac::SetPromiscuous(bool aPromiscuous)
     }
 }
 
-bool Mac::RadioSupportsRetriesAndCsmaBackofff(void)
+bool Mac::RadioSupportsRetriesAndCsmaBackoff(void)
 {
     return (otPlatRadioGetCaps(mNetif.GetInstance()) & kRadioCapsTransmitRetries) != 0;
 }

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -80,18 +80,27 @@ static_assert(kMinBackoffSum > 0, "The min backoff value should be greater than 
 
 void Mac::StartCsmaBackoff(void)
 {
-    uint32_t backoffExponent = kMinBE + mTransmitAttempts + mCsmaAttempts;
-    uint32_t backoff;
-
-    if (backoffExponent > kMaxBE)
+    if (RadioSupportsRetriesAndCsmaBackofff())
     {
-        backoffExponent = kMaxBE;
+        // If the radio supports the retry and back off logic, immediately schedule the send,
+        // and the radio will take care of everything.
+        mBackoffTimer.Start(0);
     }
+    else
+    {
+        uint32_t backoffExponent = kMinBE + mTransmitAttempts + mCsmaAttempts;
+        uint32_t backoff;
 
-    backoff = kMinBackoff + (kUnitBackoffPeriod * kPhyUsPerSymbol * (1 << backoffExponent)) / 1000;
-    backoff = (otPlatRandomGet() % backoff);
+        if (backoffExponent > kMaxBE)
+        {
+            backoffExponent = kMaxBE;
+        }
 
-    mBackoffTimer.Start(backoff);
+        backoff = kMinBackoff + (kUnitBackoffPeriod * kPhyUsPerSymbol * (1 << backoffExponent)) / 1000;
+        backoff = (otPlatRandomGet() % backoff);
+
+        mBackoffTimer.Start(backoff);
+    }
 }
 
 Mac::Mac(ThreadNetif &aThreadNetif):
@@ -788,7 +797,8 @@ void Mac::TransmitDoneTask(bool aRxPending, ThreadError aError)
 
     mCounters.mTxTotal++;
 
-    if (aError == kThreadError_ChannelAccessFailure &&
+    if (!RadioSupportsRetriesAndCsmaBackofff() &&
+        aError == kThreadError_ChannelAccessFailure &&
         mCsmaAttempts < kMaxCSMABackoffs)
     {
         mCsmaAttempts++;
@@ -904,7 +914,8 @@ void Mac::SentFrame(ThreadError aError)
     case kThreadError_NoAck:
         otDumpDebgMac("NO ACK", sendFrame.GetHeader(), 16);
 
-        if (mTransmitAttempts < kMaxFrameAttempts)
+        if (!RadioSupportsRetriesAndCsmaBackofff() &&
+            mTransmitAttempts < kMaxFrameAttempts)
         {
             mTransmitAttempts++;
             StartCsmaBackoff();
@@ -1374,6 +1385,11 @@ void Mac::SetPromiscuous(bool aPromiscuous)
     {
         NextOperation();
     }
+}
+
+bool Mac::RadioSupportsRetriesAndCsmaBackofff(void)
+{
+    return (otPlatRadioGetCaps(mNetif.GetInstance()) & kRadioCapsTransmitRetries) != 0;
 }
 
 Whitelist &Mac::GetWhitelist(void)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -545,6 +545,15 @@ public:
      */
     void ClearSrcMatchEntries();
 
+    /**
+     * This function indicates whether or not transmit retries and CSMA backoff logic is supported by the radio layer.
+     *
+     * @retval true   Logic mode is supported.
+     * @retval false  Logic mode is not supported.
+     *
+     */
+    bool RadioSupportsRetriesAndCsmaBackofff(void);
+
 private:
     enum ScanType
     {

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -552,7 +552,7 @@ public:
      * @retval false  Retries and CSMA are not supported by the radio.
      *
      */
-    bool RadioSupportsRetriesAndCsmaBackofff(void);
+    bool RadioSupportsRetriesAndCsmaBackoff(void);
 
 private:
     enum ScanType

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -548,8 +548,8 @@ public:
     /**
      * This function indicates whether or not transmit retries and CSMA backoff logic is supported by the radio layer.
      *
-     * @retval true   Logic mode is supported.
-     * @retval false  Logic mode is not supported.
+     * @retval true   Retries and CSMA are supported by the radio.
+     * @retval false  Retries and CSMA are not supported by the radio.
      *
      */
     bool RadioSupportsRetriesAndCsmaBackofff(void);


### PR DESCRIPTION
Because Windows is not a real-time OS, it will not necessarily be able to meet the timing requirements around the MAC retry and CSMA back off logic, when running OpenThread on the host. Instead, this adds support for that logic to be offloaded to the radio layer.