### PR TITLE
Update local dataset copy when rolling back the old Active Timestamp.

### DIFF
--- a/src/core/thread/meshcop_dataset_manager.cpp
+++ b/src/core/thread/meshcop_dataset_manager.cpp
@@ -112,10 +112,11 @@ ThreadError DatasetManager::Clear(uint8_t &aFlags)
     return kThreadError_None;
 }
 
-ThreadError DatasetManager::Set(const Dataset &aDataset, uint8_t &aFlags)
+ThreadError DatasetManager::Set(const Dataset &aDataset)
 {
     mNetwork.Set(aDataset);
-    HandleNetworkUpdate(aFlags);
+    mLocal.Set(aDataset);
+    mLocal.Store();
     return kThreadError_None;
 }
 
@@ -496,6 +497,7 @@ ThreadError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset,
     {
         ChannelTlv channel;
         channel.Init();
+        channel.SetChannelPage(0);
         channel.SetChannel(aDataset.mChannel);
         SuccessOrExit(error = message->Append(&channel, sizeof(channel)));
     }
@@ -739,9 +741,8 @@ exit:
 ThreadError ActiveDataset::Set(const Dataset &aDataset)
 {
     ThreadError error = kThreadError_None;
-    uint8_t flags;
 
-    SuccessOrExit(error = DatasetManager::Set(aDataset, flags));
+    SuccessOrExit(error = DatasetManager::Set(aDataset));
     ApplyConfiguration();
 
 exit:

--- a/src/core/thread/meshcop_dataset_manager.hpp
+++ b/src/core/thread/meshcop_dataset_manager.hpp
@@ -72,7 +72,7 @@ protected:
 
     ThreadError Set(const otOperationalDataset &aDataset, uint8_t &aFlags);
 
-    ThreadError Set(const Dataset &aDataset, uint8_t &aFlags);
+    ThreadError Set(const Dataset &aDataset);
 
     ThreadError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength,
                     uint8_t &aFlags);


### PR DESCRIPTION
Test case 9.2.11 and 9.2.18 verify rolling back the old active timestamp with different master key. If fail to update the local active operational dataset with pending operational dataset when delay timer expires, thread device will keep sending MGMT_ACTIVE_SET command to Leader.