### PR TITLE
IP: Add API to subscribe/unsubscribe to multicast addresses.

### DIFF
--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -841,17 +841,27 @@ typedef struct otMacCounters
  */
 
 /**
- * This structure represents an IPv6 network interface address.
+ * This structure represents an IPv6 network interface unicast address.
  *
  */
 typedef struct otNetifAddress
 {
-    otIp6Address           mAddress;            ///< The IPv6 address.
+    otIp6Address           mAddress;            ///< The IPv6 unicast address.
     uint32_t               mPreferredLifetime;  ///< The Preferred Lifetime.
     uint32_t               mValidLifetime;      ///< The Valid lifetime.
     uint8_t                mPrefixLength;       ///< The Prefix length.
     struct otNetifAddress *mNext;               ///< A pointer to the next network interface address.
 } otNetifAddress;
+
+/**
+ * This structure represents an IPv6 network interface multicast address.
+ *
+ */
+typedef struct otNetifMulticastAddress
+{
+    otIp6Address                    mAddress;   ///< The IPv6 multicast address.
+    struct otNetifMulticastAddress *mNext;      ///< A pointer to the next network interface multicast address.
+} otNetifMulticastAddress;
 
 /**
  * This enumeration represents the list of allowable values for an InterfaceId.

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -791,6 +791,72 @@ ThreadError otAddUnicastAddress(otInstance *aInstance, const otNetifAddress *aAd
 ThreadError otRemoveUnicastAddress(otInstance *aInstance, const otIp6Address *aAddress);
 
 /**
+ * Get the list of IPv6 multicast addresses subscribed to the Thread interface.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ *
+ * @returns A pointer to the first Network Interface Multicast Address.
+ */
+const otNetifMulticastAddress *otGetMulticastAddresses(otInstance *aInstance);
+
+/**
+ * Subscribe the Thread interface to a Network Interface Multicast Address.
+ *
+ * The passed in instance @p aAddress will be copied by the Thread interface. The Thread interface only
+ * supports a fixed number of externally added multicast addresses. See OPENTHREAD_CONFIG_MAX_EXT_MULTICAST_IP_ADDRS.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ * @param[in]  aAddress  A pointer to an IP Address.
+ *
+ * @retval kThreadErrorNone          Successfully subscribed to the Network Interface Multicast Address.
+ * @retval kThreadError_InvalidArgs  The IP Address indicated by @p aAddress is invalid address.
+ * @retval kThreadError_NoBufs       The Network Interface is already storing the maximum allowed external multicast addresses.
+ */
+ThreadError otSubscribeMulticastAddress(otInstance *aInstance, const otIp6Address *aAddress);
+
+/**
+ * Unsubscribe the Thread interface to a Network Interface Multicast Address.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ * @param[in]  aAddress  A pointer to an IP Address.
+ *
+ * @retval kThreadErrorNone          Successfully unsubscribed to the Network Interface Multicast Address.
+ * @retval kThreadError_InvalidArgs  The IP Address indicated by @p aAddress is an internal address.
+ * @retval kThreadError_NotFound     The IP Address indicated by @p aAddress was not found.
+ */
+ThreadError otUnsubscribeMulticastAddress(otInstance *aInstance, const otIp6Address *aAddress);
+
+/**
+ * Check if multicast promiscuous mode is enabled on the Thread interface.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ *
+ * @sa otEnableMulticastPromiscuousMode
+ * @sa otDisableMulticastPromiscuousMode
+ */
+bool otIsMulticastPromiscuousModeEnabled(otInstance *aInstance);
+
+/**
+ * Enable multicast promiscuous mode on the Thread interface.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ *
+ * @sa otIsMulticastPromiscuousModeEnabled
+ * @sa otDisableMulticastPromiscuousMode
+ */
+void otEnableMulticastPromiscuousMode(otInstance *aInstance);
+
+/**
+ * Disable multicast promiscuous mode on the Thread interface.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ *
+ * @sa otIsMulticastPromiscuousModeEnabled
+ * @sa otEnableMulticastPromiscuousMode
+ */
+void otDisableMulticastPromiscuousMode(otInstance *aInstance);
+
+/**
  * This function pointer is called to create IPv6 IID during SLAAC procedure.
  *
  * @param[in]     aInstance  A pointer to an OpenThread instance.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -25,6 +25,7 @@ OpenThread test scripts use the CLI to execute test cases.
 * [hashmacaddr](#hashmacaddr)
 * [ifconfig](#ifconfig)
 * [ipaddr](#ipaddr)
+* [ipmaddr](#ipmaddr)
 * [joiner](#joiner)
 * [keysequence](#keysequence)
 * [leaderpartitionid](#leaderpartitionid)
@@ -786,6 +787,64 @@ Delete an IPv6 address from the Thread interface.
 
 ```bash
 > ipaddr del 2001::dead:beef:cafe
+Done
+```
+
+### ipmaddr
+
+List all IPv6 multicast addresses subscribed to the Thread interface.
+
+```bash
+> ipmaddr
+ff05:0:0:0:0:0:0:1
+ff33:40:fdde:ad00:beef:0:0:1
+ff32:40:fdde:ad00:beef:0:0:1
+Done
+```
+
+### ipmaddr add \<ipaddr\>
+
+Subscribe the Thread interface to the IPv6 multicast address.
+
+```bash
+> ipmaddr add ff05::1
+Done
+```
+
+### ipmaddr del \<ipaddr\>
+
+Unsubscribe the Thread interface to the IPv6 multicast address.
+
+```bash
+> ipmaddr del ff05::1
+Done
+```
+
+### ipmaddr promiscuous
+
+Get multicast promiscuous mode.
+
+```bash
+> ipmaddr promiscuous
+Disabled
+Done
+```
+
+### ipmaddr promiscuous enable
+
+Enable multicast promiscuous mode.
+
+```bash
+> ipmaddr promiscuous enable
+Done
+```
+
+### ipmaddr promiscuous disable
+
+Disable multicast promiscuous mode.
+
+```bash
+> ipmaddr promiscuous disable
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -92,6 +92,7 @@ const struct Command Interpreter::sCommands[] =
     { "hashmacaddr", &Interpreter::ProcessHashMacAddress },
     { "ifconfig", &Interpreter::ProcessIfconfig },
     { "ipaddr", &Interpreter::ProcessIpAddr },
+    { "ipmaddr", &Interpreter::ProcessIpMulticastAddr },
 #if OPENTHREAD_ENABLE_JOINER
     { "joiner", &Interpreter::ProcessJoiner },
 #endif
@@ -763,6 +764,108 @@ void Interpreter::ProcessIpAddr(int argc, char *argv[])
         else if (strcmp(argv[0], "del") == 0)
         {
             SuccessOrExit(error = ProcessIpAddrDel(argc - 1, argv + 1));
+        }
+    }
+
+exit:
+    AppendResult(error);
+}
+
+ThreadError Interpreter::ProcessIpMulticastAddrAdd(int argc, char *argv[])
+{
+    ThreadError error;
+    struct otIp6Address address;
+
+    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+
+    SuccessOrExit(error = otIp6AddressFromString(argv[0], &address));
+    error = otSubscribeMulticastAddress(mInstance, &address);
+
+exit:
+    return error;
+}
+
+ThreadError Interpreter::ProcessIpMulticastAddrDel(int argc, char *argv[])
+{
+    ThreadError error;
+    struct otIp6Address address;
+
+    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+
+    SuccessOrExit(error = otIp6AddressFromString(argv[0], &address));
+    error = otUnsubscribeMulticastAddress(mInstance, &address);
+
+exit:
+    return error;
+}
+
+ThreadError Interpreter::ProcessMulticastPromiscuous(int argc, char *argv[])
+{
+    ThreadError error = kThreadError_None;
+
+    if (argc == 0)
+    {
+        if (otIsMulticastPromiscuousModeEnabled(mInstance))
+        {
+            sServer->OutputFormat("Enabled\r\n");
+        }
+        else
+        {
+            sServer->OutputFormat("Disabled\r\n");
+        }
+    }
+    else
+    {
+        if (strcmp(argv[0], "enable") == 0)
+        {
+            otEnableMulticastPromiscuousMode(mInstance);
+        }
+        else if (strcmp(argv[0], "disable") == 0)
+        {
+            otDisableMulticastPromiscuousMode(mInstance);
+        }
+        else
+        {
+            ExitNow(error = kThreadError_Parse);
+        }
+    }
+
+exit:
+    return error;
+}
+
+void Interpreter::ProcessIpMulticastAddr(int argc, char *argv[])
+{
+    ThreadError error = kThreadError_None;
+
+    if (argc == 0)
+    {
+        for (const otNetifMulticastAddress *addr = otGetMulticastAddresses(mInstance); addr; addr = addr->mNext)
+        {
+            sServer->OutputFormat("%x:%x:%x:%x:%x:%x:%x:%x\r\n",
+                                  HostSwap16(addr->mAddress.mFields.m16[0]),
+                                  HostSwap16(addr->mAddress.mFields.m16[1]),
+                                  HostSwap16(addr->mAddress.mFields.m16[2]),
+                                  HostSwap16(addr->mAddress.mFields.m16[3]),
+                                  HostSwap16(addr->mAddress.mFields.m16[4]),
+                                  HostSwap16(addr->mAddress.mFields.m16[5]),
+                                  HostSwap16(addr->mAddress.mFields.m16[6]),
+                                  HostSwap16(addr->mAddress.mFields.m16[7]));
+        }
+    }
+    else
+    {
+        if (strcmp(argv[0], "add") == 0)
+        {
+            SuccessOrExit(error = ProcessIpMulticastAddrAdd(argc - 1, argv + 1));
+        }
+        else if (strcmp(argv[0], "del") == 0)
+        {
+            SuccessOrExit(error = ProcessIpMulticastAddrDel(argc - 1, argv + 1));
+        }
+        else if (strcmp(argv[0], "promiscuous") == 0)
+        {
+            SuccessOrExit(error = ProcessMulticastPromiscuous(argc - 1, argv + 1));
         }
     }
 

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -167,6 +167,10 @@ private:
     void ProcessIpAddr(int argc, char *argv[]);
     ThreadError ProcessIpAddrAdd(int argc, char *argv[]);
     ThreadError ProcessIpAddrDel(int argc, char *argv[]);
+    void ProcessIpMulticastAddr(int argc, char *argv[]);
+    ThreadError ProcessIpMulticastAddrAdd(int argc, char *argv[]);
+    ThreadError ProcessIpMulticastAddrDel(int argc, char *argv[]);
+    ThreadError ProcessMulticastPromiscuous(int argc, char *argv[]);
 #if OPENTHREAD_ENABLE_JOINER
     void ProcessJoiner(int argc, char *argv[]);
 #endif  // OPENTHREAD_ENABLE_JOINER

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -645,6 +645,7 @@ ThreadError Ip6::HandleDatagram(Message &message, Netif *netif, int8_t interface
     bool receive = false;
     bool forward = false;
     bool tunnel = false;
+    bool multicastPromiscuous = false;
     uint8_t nextHeader;
     uint8_t hopLimit;
 
@@ -677,9 +678,16 @@ ThreadError Ip6::HandleDatagram(Message &message, Netif *netif, int8_t interface
     // determine destination of packet
     if (header.GetDestination().IsMulticast())
     {
-        if (netif != NULL && netif->IsMulticastSubscribed(header.GetDestination()))
+        if (netif != NULL)
         {
-            receive = true;
+            if (netif->IsMulticastSubscribed(header.GetDestination()))
+            {
+                receive = true;
+            }
+            else if (netif->IsMulticastPromiscuousModeEnabled())
+            {
+                multicastPromiscuous = true;
+            }
         }
 
         if (netif == NULL)
@@ -738,6 +746,10 @@ ThreadError Ip6::HandleDatagram(Message &message, Netif *netif, int8_t interface
         }
 
         SuccessOrExit(error = HandlePayload(message, messageInfo, nextHeader));
+    }
+    else if (multicastPromiscuous)
+    {
+        ProcessReceiveCallback(message, messageInfo, nextHeader);
     }
 
     if (forward)

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -42,17 +42,18 @@ namespace Ip6 {
 
 Netif::Netif(Ip6 &aIp6, int8_t aInterfaceId):
     mIp6(aIp6),
-    mStateChangedTask(aIp6.mTaskletScheduler, &Netif::HandleStateChangedTask, this)
+    mCallbacks(NULL),
+    mUnicastAddresses(NULL),
+    mMulticastAddresses(NULL),
+    mInterfaceId(aInterfaceId),
+    mAllRoutersSubscribed(false),
+    mMulticastPromiscuousMode(false),
+    mStateChangedTask(aIp6.mTaskletScheduler, &Netif::HandleStateChangedTask, this),
+    mNext(NULL),
+    mStateChangedFlags(0),
+    mMaskExtUnicastAddresses(0),
+    mMaskExtMulticastAddresses(0)
 {
-    mCallbacks = NULL;
-    mUnicastAddresses = NULL;
-    mMulticastAddresses = NULL;
-    mInterfaceId = aInterfaceId;
-    mAllRoutersSubscribed = false;
-    mNext = NULL;
-    mMaskExtUnicastAddresses = 0;
-
-    mStateChangedFlags = 0;
 }
 
 ThreadError Netif::RegisterCallback(NetifCallback &aCallback)
@@ -132,7 +133,7 @@ bool Netif::IsMulticastSubscribed(const Address &aAddress) const
         ExitNow(rval = mAllRoutersSubscribed);
     }
 
-    for (NetifMulticastAddress *cur = mMulticastAddresses; cur; cur = cur->mNext)
+    for (NetifMulticastAddress *cur = mMulticastAddresses; cur; cur = cur->GetNext())
     {
         if (memcmp(&cur->mAddress, &aAddress, sizeof(cur->mAddress)) == 0)
         {
@@ -154,11 +155,16 @@ void Netif::UnsubscribeAllRoutersMulticast()
     mAllRoutersSubscribed = false;
 }
 
+const NetifMulticastAddress *Netif::GetMulticastAddresses() const
+{
+    return mMulticastAddresses;
+}
+
 ThreadError Netif::SubscribeMulticast(NetifMulticastAddress &aAddress)
 {
     ThreadError error = kThreadError_None;
 
-    for (NetifMulticastAddress *cur = mMulticastAddresses; cur; cur = cur->mNext)
+    for (NetifMulticastAddress *cur = mMulticastAddresses; cur; cur = cur->GetNext())
     {
         if (cur == &aAddress)
         {
@@ -179,12 +185,12 @@ ThreadError Netif::UnsubscribeMulticast(const NetifMulticastAddress &aAddress)
 
     if (mMulticastAddresses == &aAddress)
     {
-        mMulticastAddresses = mMulticastAddresses->mNext;
+        mMulticastAddresses = mMulticastAddresses->GetNext();
         ExitNow();
     }
     else if (mMulticastAddresses != NULL)
     {
-        for (NetifMulticastAddress *cur = mMulticastAddresses; cur->mNext; cur = cur->mNext)
+        for (NetifMulticastAddress *cur = mMulticastAddresses; cur->GetNext(); cur = cur->GetNext())
         {
             if (cur->mNext == &aAddress)
             {
@@ -198,6 +204,102 @@ ThreadError Netif::UnsubscribeMulticast(const NetifMulticastAddress &aAddress)
 
 exit:
     return error;
+}
+
+ThreadError Netif::SubscribeExternalMulticast(const Address &aAddress)
+{
+    ThreadError error = kThreadError_None;
+    int8_t index = 0;
+
+    for (NetifMulticastAddress *cur = mMulticastAddresses; cur; cur = cur->GetNext())
+    {
+        if (memcmp(&cur->mAddress, &aAddress, sizeof(otIp6Address)) == 0)
+        {
+            VerifyOrExit(GetExtMulticastAddressIndex(cur) != -1, error = kThreadError_InvalidArgs);
+            ExitNow(error = kThreadError_Already);
+        }
+    }
+
+    // Make sure we haven't set all the bits in the mask already
+    VerifyOrExit(mMaskExtMulticastAddresses != ((1 << OPENTHREAD_CONFIG_MAX_EXT_MULTICAST_IP_ADDRS) - 1),
+                 error = kThreadError_NoBufs);
+
+    // Get next available entry index
+    while ((mMaskExtMulticastAddresses & (1 << index)) != 0)
+    {
+        index++;
+    }
+
+    assert(index < OPENTHREAD_CONFIG_MAX_EXT_MULTICAST_IP_ADDRS);
+
+    // Increase the count and mask the index
+    mMaskExtMulticastAddresses |= 1 << index;
+
+    // Copy the address to the next available dynamic address
+    mExtMulticastAddresses[index].mAddress = aAddress;
+    mExtMulticastAddresses[index].mNext = mMulticastAddresses;
+
+    mMulticastAddresses = &mExtMulticastAddresses[index];
+
+exit:
+    return error;
+}
+
+ThreadError Netif::UnsubscribeExternalMulticast(const Address &aAddress)
+{
+    ThreadError error = kThreadError_None;
+    NetifMulticastAddress *last = NULL;
+    int8_t aAddressIndexToRemove = -1;
+
+    for (NetifMulticastAddress *cur = mMulticastAddresses; cur; cur = cur->GetNext())
+    {
+        if (memcmp(&cur->mAddress, &aAddress, sizeof(otIp6Address)) == 0)
+        {
+            aAddressIndexToRemove = GetExtMulticastAddressIndex(cur);
+            VerifyOrExit(aAddressIndexToRemove != -1, error = kThreadError_InvalidArgs);
+
+            if (last)
+            {
+                last->mNext = cur->GetNext();
+            }
+            else
+            {
+                mMulticastAddresses = cur->GetNext();
+            }
+
+            break;
+        }
+
+        last = cur;
+    }
+
+    if (aAddressIndexToRemove != -1)
+    {
+        mMaskExtMulticastAddresses &= ~(1 << aAddressIndexToRemove);
+    }
+    else
+    {
+        error = kThreadError_NotFound;
+    }
+
+exit:
+
+    return error;
+}
+
+bool Netif::IsMulticastPromiscuousModeEnabled(void)
+{
+    return mMulticastPromiscuousMode;
+}
+
+void Netif::EnableMulticastPromiscuousMode(void)
+{
+    mMulticastPromiscuousMode = true;
+}
+
+void Netif::DisableMulticastPromiscuousMode(void)
+{
+    mMulticastPromiscuousMode = false;
 }
 
 const NetifUnicastAddress *Netif::GetUnicastAddresses() const

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -126,6 +126,16 @@
 #endif  // OPENTHREAD_CONFIG_MAX_EXT_IP_ADDRS
 
 /**
+ * @def OPENTHREAD_CONFIG_MAX_EXT_MULTICAST_IP_ADDRS
+ *
+ * The maximum number of supported IPv6 multicast addresses allows to be externally added.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MAX_EXT_MULTICAST_IP_ADDRS
+#define OPENTHREAD_CONFIG_MAX_EXT_MULTICAST_IP_ADDRS            2
+#endif  // OPENTHREAD_CONFIG_MAX_EXT_MULTICAST_IP_ADDRS
+
+/**
  * @def OPENTHREAD_CONFIG_6LOWPAN_REASSEMBLY_TIMEOUT
  *
  * The 6LoWPAN fragment reassembly timeout in seconds.

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -929,6 +929,36 @@ void otDhcp6ClientUpdate(otInstance *aInstance, otNetifAddress *aAddresses, uint
 }
 #endif  // OPENTHREAD_ENABLE_DHCP6_CLIENT
 
+const otNetifMulticastAddress *otGetMulticastAddresses(otInstance *aInstance)
+{
+    return aInstance->mThreadNetif.GetMulticastAddresses();
+}
+
+ThreadError otSubscribeMulticastAddress(otInstance *aInstance, const otIp6Address *aAddress)
+{
+    return aInstance->mThreadNetif.SubscribeExternalMulticast(*static_cast<const Ip6::Address *>(aAddress));
+}
+
+ThreadError otUnsubscribeMulticastAddress(otInstance *aInstance, const otIp6Address *aAddress)
+{
+    return aInstance->mThreadNetif.UnsubscribeExternalMulticast(*static_cast<const Ip6::Address *>(aAddress));
+}
+
+bool otIsMulticastPromiscuousModeEnabled(otInstance *aInstance)
+{
+    return aInstance->mThreadNetif.IsMulticastPromiscuousModeEnabled();
+}
+
+void otEnableMulticastPromiscuousMode(otInstance *aInstance)
+{
+    aInstance->mThreadNetif.EnableMulticastPromiscuousMode();
+}
+
+void otDisableMulticastPromiscuousMode(otInstance *aInstance)
+{
+    aInstance->mThreadNetif.DisableMulticastPromiscuousMode();
+}
+
 void otSlaacUpdate(otInstance *aInstance, otNetifAddress *aAddresses, uint32_t aNumAddresses,
                    otSlaacIidCreate aIidCreate, void *aContext)
 {


### PR DESCRIPTION
This PR fixes #891 issue by adding external API to subscribe and unsubscribe multicast addresses.
Also i have added possibility of setting the multicast promiscuous mode suggested by @nibanks to accept all, where for example we act as an NCP.

There were no external registration for multicast addresses, so i mostly reused same code as it is for unicast addresses.

I follow numenclature of Linux and `ip maddr` command, so the CLI command is called `ipmaddr`.

The only problematic case is with command that list multicast addresses. Currently none of the default "ff02::1, ff03::1 etc." are printed, since they are not in the list of multicast addresses. Those addresses are just checked in `Netif::IsMulticastSubscribed()` method which saves a lot of RAM. So i would vote for leaving it as it is.
