### PR TITLE
Add --enable-builtin-mbedtls flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -428,10 +428,34 @@ AM_CONDITIONAL([OPENTHREAD_ENABLE_NCP],      [test "${enable_ncp}" != "no"])
 AM_CONDITIONAL([OPENTHREAD_ENABLE_NCP_SPI],  [test "${enable_ncp}"  = "spi"])
 AM_CONDITIONAL([OPENTHREAD_ENABLE_NCP_UART], [test "${enable_ncp}"  = "uart"])
 
-MBEDTLS_CPPFLAGS="-I\${abs_top_srcdir}/third_party/mbedtls"
-MBEDTLS_CPPFLAGS="${MBEDTLS_CPPFLAGS} -I\${abs_top_srcdir}/third_party/mbedtls/repo/include"
-MBEDTLS_CPPFLAGS="${MBEDTLS_CPPFLAGS} -I\${abs_top_srcdir}/third_party/mbedtls/repo/include/mbedtls"
-MBEDTLS_CPPFLAGS="${MBEDTLS_CPPFLAGS} -DMBEDTLS_CONFIG_FILE=\\\"mbedtls-config.h\\\""
+#
+# Builtin mbedtls
+#
+
+AC_ARG_ENABLE(builtin-mbedtls,
+    [AS_HELP_STRING([--enable-builtin-mbedtls],[Enable builtin mbedtls @<:@default=yes@:>@.])],
+    [
+        case "${enableval}" in
+
+        no|yes)
+            enable_builtin_mbedtls=${enableval}
+            ;;
+
+        *)
+            AC_MSG_ERROR([Invalid value ${enable_builtin_mbedtls} for --enable-builtin-mbedtls])
+            ;;
+        esac
+    ],
+    [enable_builtin_mbedtls=yes])
+
+if test "$enable_builtin_mbedtls" = "yes"; then
+    MBEDTLS_CPPFLAGS="-I\${abs_top_srcdir}/third_party/mbedtls"
+    MBEDTLS_CPPFLAGS="${MBEDTLS_CPPFLAGS} -I\${abs_top_srcdir}/third_party/mbedtls/repo/include"
+    MBEDTLS_CPPFLAGS="${MBEDTLS_CPPFLAGS} -I\${abs_top_srcdir}/third_party/mbedtls/repo/include/mbedtls"
+    MBEDTLS_CPPFLAGS="${MBEDTLS_CPPFLAGS} -DMBEDTLS_CONFIG_FILE=\\\"mbedtls-config.h\\\""
+fi
+AC_MSG_RESULT(${enable_builtin_mbedtls})
+AM_CONDITIONAL([OPENTHREAD_ENABLE_BUILTIN_MBEDTLS], [test "${enable_builtin_mbedtls}" = "yes"])
 
 #
 # Thread Commissioner
@@ -498,10 +522,6 @@ AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_JOINER],[${OPENTHREAD_ENABLE_JOINER}],[Def
 if test "${enable_commissioner}" = "yes" -o "${enable_joiner}" = "yes"; then
     enable_dtls="yes"
     OPENTHREAD_ENABLE_DTLS=1
-    MBEDTLS_CPPFLAGS="-I\${abs_top_srcdir}/third_party/mbedtls"
-    MBEDTLS_CPPFLAGS="${MBEDTLS_CPPFLAGS} -I\${abs_top_srcdir}/third_party/mbedtls/repo/include"
-    MBEDTLS_CPPFLAGS="${MBEDTLS_CPPFLAGS} -I\${abs_top_srcdir}/third_party/mbedtls/repo/include/mbedtls"
-    MBEDTLS_CPPFLAGS="${MBEDTLS_CPPFLAGS} -DMBEDTLS_CONFIG_FILE=\\\"mbedtls-config.h\\\""
 else
     enable_dtls="no"
     OPENTHREAD_ENABLE_DTLS=0
@@ -853,6 +873,7 @@ AC_MSG_NOTICE([
   Pretty check args                         : ${PRETTY_CHECK_ARGS:--}
   OpenThread CLI support                    : ${enable_cli}
   OpenThread NCP support                    : ${enable_ncp}
+  OpenThread builtin mbedtls support        : ${enable_builtin_mbedtls}
   OpenThread Commissioner support           : ${enable_commissioner}
   OpenThread Joiner support                 : ${enable_joiner}
   OpenThread DTLS support                   : ${enable_dtls}

--- a/examples/apps/cli/Makefile.am
+++ b/examples/apps/cli/Makefile.am
@@ -41,11 +41,16 @@ ot_cli_CPPFLAGS                                                        = \
 ot_cli_LDADD                                                           = \
     $(top_builddir)/src/cli/libopenthread-cli.a                          \
     $(top_builddir)/src/core/libopenthread.a                             \
-    $(top_builddir)/third_party/mbedtls/libmbedcrypto.a                  \
     $(NULL)
 
 ot_cli_LDFLAGS                                                         = \
     $(NULL)
+
+if OPENTHREAD_ENABLE_BUILTIN_MBEDTLS
+ot_cli_LDADD                                                          += \
+    $(top_builddir)/third_party/mbedtls/libmbedcrypto.a                  \
+    $(NULL)
+endif # OPENTHREAD_ENABLE_BUILTIN_MBEDTLS
 
 if OPENTHREAD_ENABLE_DIAG
 ot_cli_LDADD                                                          += \

--- a/examples/apps/ncp/Makefile.am
+++ b/examples/apps/ncp/Makefile.am
@@ -41,11 +41,16 @@ ot_ncp_CPPFLAGS                                                        = \
 ot_ncp_LDADD                                                           = \
     $(top_builddir)/src/core/libopenthread.a                             \
     $(top_builddir)/src/ncp/libopenthread-ncp.a                          \
-    $(top_builddir)/third_party/mbedtls/libmbedcrypto.a                  \
     $(NULL)
 
 ot_ncp_LDFLAGS                                                         = \
     $(NULL)
+
+if OPENTHREAD_ENABLE_BUILTIN_MBEDTLS
+ot_ncp_LDADD                                                          += \
+    $(top_builddir)/third_party/mbedtls/libmbedcrypto.a                  \
+    $(NULL)
+endif # OPENTHREAD_ENABLE_BUILTIN_MBEDTLS
 
 if OPENTHREAD_ENABLE_DIAG
 ot_ncp_LDADD                                                          += \

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -52,14 +52,22 @@ AM_CPPFLAGS                                                         = \
     -I$(top_srcdir)/include                                           \
     -I$(top_srcdir)/src                                               \
     -I$(top_srcdir)/src/core                                          \
-    -I$(top_srcdir)/third_party/mbedtls/repo/include                  \
     $(NULL)
 
 COMMON_LDADD                                                        = \
     $(top_builddir)/src/core/libopenthread.a                          \
-    $(top_builddir)/third_party/mbedtls/libmbedcrypto.a               \
     -lpthread                                                         \
     $(NULL)
+
+if OPENTHREAD_ENABLE_BUILTIN_MBEDTLS
+AM_CPPFLAGS                                                        += \
+    -I$(top_srcdir)/third_party/mbedtls/repo/include                  \
+    $(NULL)
+
+COMMON_LDADD                                                       += \
+    $(top_builddir)/third_party/mbedtls/libmbedcrypto.a               \
+    $(NULL)
+endif # OPENTHREAD_ENABLE_BUILTIN_MBEDTLS
 
 # Test applications that should be run when the 'check' target is run.
 

--- a/third_party/Makefile.am
+++ b/third_party/Makefile.am
@@ -39,10 +39,10 @@ DIST_SUBDIRS                            = \
     mbedtls                               \
     $(NULL)
 
-# Always build (e.g. for 'make all') these subdirectories.
-
+if OPENTHREAD_ENABLE_BUILTIN_MBEDTLS
 SUBDIRS                                 = \
     mbedtls                               \
     $(NULL)
+endif # OPENTHREAD_ENABLE_BUILTIN_MBEDTLS
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am


### PR DESCRIPTION
Currently mbedtls has been integrated into openthread. However, this
package could be already present in the system so add a flag to enable
or disable the builtin version of mbedtls. By default, the builtin
version is enabled to keep the current behaviour.

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>