### PR TITLE
Drop duplicated packet directly

### DIFF
--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -167,6 +167,10 @@ typedef enum ThreadError
      */
     kThreadError_ResponseTimeout = 30,
 
+    /**
+     * Received a duplicated frame.
+     */
+    kThreadError_Duplicated = 31,
     kThreadError_Error = 255,
 } ThreadError;
 
@@ -822,6 +826,7 @@ typedef struct otMacCounters
     uint32_t mRxOther;                ///< The number of received other types of frames.
     uint32_t mRxWhitelistFiltered;    ///< The number of received packets filtered by whitelist.
     uint32_t mRxDestAddrFiltered;     ///< The number of received packets filtered by destination check.
+    uint32_t mRxDuplicated;           ///< The number of received duplicated packets.
     uint32_t mRxErrNoFrame;           ///< The number of received packets that do not contain contents.
     uint32_t mRxErrUnknownNeighbor;   ///< The number of received packets from unknown neighbor.
     uint32_t mRxErrInvalidSrcAddr;    ///< The number of received packets whose source address is invalid.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -360,6 +360,7 @@ RxTotal: 11
     RxOther: 0
     RxWhitelistFiltered: 0
     RxDestAddrFiltered: 0
+    RxDuplicated: 0
     RxErrNoFrame: 0
     RxErrNoUnknownNeighbor: 0
     RxErrInvalidSrcAddr: 0

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -512,6 +512,7 @@ void Interpreter::ProcessCounters(int argc, char *argv[])
             sServer->OutputFormat("    RxOther: %d\r\n", counters->mRxOther);
             sServer->OutputFormat("    RxWhitelistFiltered: %d\r\n", counters->mRxWhitelistFiltered);
             sServer->OutputFormat("    RxDestAddrFiltered: %d\r\n", counters->mRxDestAddrFiltered);
+            sServer->OutputFormat("    RxDuplicated: %d\r\n", counters->mRxDuplicated);
             sServer->OutputFormat("    RxErrNoFrame: %d\r\n", counters->mRxErrNoFrame);
             sServer->OutputFormat("    RxErrNoUnknownNeighbor: %d\r\n", counters->mRxErrUnknownNeighbor);
             sServer->OutputFormat("    RxErrInvalidSrcAddr: %d\r\n", counters->mRxErrInvalidSrcAddr);

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -179,6 +179,7 @@ const NcpBase::GetPropertyHandlerEntry NcpBase::mGetPropertyHandlerTable[] =
     { SPINEL_PROP_CNTR_RX_ERR_SECURITY, &NcpBase::GetPropertyHandler_MAC_CNTR },
     { SPINEL_PROP_CNTR_RX_ERR_BAD_FCS, &NcpBase::GetPropertyHandler_MAC_CNTR },
     { SPINEL_PROP_CNTR_RX_ERR_OTHER, &NcpBase::GetPropertyHandler_MAC_CNTR },
+    { SPINEL_PROP_CNTR_RX_PKT_DUP, &NcpBase::GetPropertyHandler_MAC_CNTR },
 
     { SPINEL_PROP_CNTR_TX_IP_SEC_TOTAL, &NcpBase::GetPropertyHandler_NCP_CNTR },
     { SPINEL_PROP_CNTR_TX_IP_INSEC_TOTAL, &NcpBase::GetPropertyHandler_NCP_CNTR },
@@ -2436,6 +2437,10 @@ ThreadError NcpBase::GetPropertyHandler_MAC_CNTR(uint8_t header, spinel_prop_key
 
     case SPINEL_PROP_CNTR_RX_PKT_FILT_DA:
         value = macCounters->mRxDestAddrFiltered;
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_DUP:
+        value = macCounters->mRxDuplicated;
         break;
 
     case SPINEL_PROP_CNTR_RX_ERR_EMPTY:

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -728,6 +728,10 @@ typedef enum
     /** Format: `L` (Read-only) */
     SPINEL_PROP_CNTR_RX_ERR_OTHER      = SPINEL_PROP_CNTR__BEGIN + 113,
 
+    /// The number of received duplicated.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_PKT_DUP        = SPINEL_PROP_CNTR__BEGIN + 114,
+
     /// The total number of secure transmitted IP messages.
     /** Format: `L` (Read-only) */
     SPINEL_PROP_CNTR_TX_IP_SEC_TOTAL   = SPINEL_PROP_CNTR__BEGIN + 200,


### PR DESCRIPTION
`LinkReject` would be sent out when receiving duplicated packets. This PR would drop duplicated packets directly instead of taking them as `kThreadError_Security`

@jwhui, would you please have a review?