### PR TITLE
THCI: set AutoDUT SED's poll period to 15s

### DIFF
--- a/tools/harness-thci/ARM.py
+++ b/tools/harness-thci/ARM.py
@@ -1025,9 +1025,8 @@ class ARM(IThci):
             elif eRoleId == Thread_Device_Role.SED:
                 print 'join as sleepy end device'
                 role = 's'
-                if self.AutoDUTEnable is False:
-                    # set data polling rate to 15s for SED
-                    self.setPollingRate(15)
+                # set data polling rate to 15s for SED
+                self.setPollingRate(15)
             elif eRoleId == Thread_Device_Role.EndDevice:
                 print 'join as end device'
                 role = 'rsn'


### PR DESCRIPTION
It helps to pass Certification test SED_9_2_8:
[SED_9_2_8.zip](https://github.com/openthread/openthread/files/563698/SED_9_2_8.zip)

I also have a question:
In current implementation, if parent has a new version network data, it will not send Data Response to its child in the first Poll but will send it in the second Poll. This is because that the Data Response to child is triggered in the `HandlerDataRequest()` after receiving the first Poll Request, but at that point, parent has already acked with no pending frame, so then the Data Response will be sent in the second Poll. Not sure it is as expected or an issue needs to be fixed?