### PR TITLE
Copy TLVs from Active Dataset to Pending Dataset which are not included in MGMT_PENDING_SET request message.

### DIFF
--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -63,6 +63,7 @@ Commissioner::Commissioner(ThreadNetif &aThreadNetif):
     mAnnounceBegin(aThreadNetif),
     mEnergyScan(aThreadNetif),
     mPanIdQuery(aThreadNetif),
+    mState(kStateDisabled),
     mTimer(aThreadNetif.GetIp6().mTimerScheduler, HandleTimer, this),
     mTransmitTask(aThreadNetif.GetIp6().mTaskletScheduler, &Commissioner::HandleUdpTransmit, this),
     mSendKek(false),

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2338,6 +2338,10 @@ ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::Messa
             mNetif.GetPendingDataset().Set(pendingTimestamp, aMessage, offset + sizeof(tlv), tlv.GetLength());
         }
     }
+    else
+    {
+        mNetif.GetPendingDataset().Clear(true);
+    }
 
     // Parent Attach Success
     mParentRequestTimer.Stop();

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2097,7 +2097,6 @@ ThreadError MleRouter::HandleChildIdRequest(const Message &aMessage, const Ip6::
         mNetif.GetActiveDataset().GetNetwork().GetTimestamp()->Compare(activeTimestamp) != 0)
     {
         child->mRequestTlvs[numTlvs++] = Tlv::kActiveDataset;
-        child->mRequestTlvs[numTlvs++] = Tlv::kActiveTimestamp;
     }
 
     if (pendingTimestamp.GetLength() == 0 ||
@@ -2105,7 +2104,6 @@ ThreadError MleRouter::HandleChildIdRequest(const Message &aMessage, const Ip6::
         mNetif.GetPendingDataset().GetNetwork().GetTimestamp()->Compare(pendingTimestamp) != 0)
     {
         child->mRequestTlvs[numTlvs++] = Tlv::kPendingDataset;
-        child->mRequestTlvs[numTlvs++] = Tlv::kPendingTimestamp;
     }
 
     switch (GetDeviceState())
@@ -2314,6 +2312,8 @@ ThreadError MleRouter::SendChildIdResponse(Child *aChild)
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandChildIdResponse));
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
+    SuccessOrExit(error = AppendActiveTimestamp(*message));
+    SuccessOrExit(error = AppendPendingTimestamp(*message));
 
     if (aChild->mState != Neighbor::kStateValid)
     {
@@ -2355,12 +2355,7 @@ ThreadError MleRouter::SendChildIdResponse(Child *aChild)
             SuccessOrExit(error = AppendPendingDataset(*message));
             break;
 
-        case Tlv::kActiveTimestamp:
-            SuccessOrExit(error = AppendActiveTimestamp(*message));
-            break;
-
-        case Tlv::kPendingTimestamp:
-            SuccessOrExit(error = AppendPendingTimestamp(*message));
+        default:
             break;
         }
     }

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -105,7 +105,7 @@ public:
     Ip6::Address mIp6Address[kMaxIp6AddressPerChild];  ///< Registered IPv6 addresses
     uint32_t     mTimeout;                             ///< Child timeout
     uint16_t     mFragmentOffset;                      ///< 6LoWPAN fragment offset
-    uint8_t      mRequestTlvs[7];                      ///< Requested MLE TLVs
+    uint8_t      mRequestTlvs[5];                      ///< Requested MLE TLVs
     uint8_t      mNetworkDataVersion;                  ///< Current Network Data version
     uint16_t     mQueuedIndirectMessageCnt;            ///< Count of queued messages
     bool         mAddSrcMatchEntryShort;               ///< Indicates whether or not to force add short address

--- a/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
+++ b/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
@@ -87,7 +87,7 @@ class Cert_5_1_07_MaxChildCount(unittest.TestCase):
 
         for i in range(4, 14):
             self.nodes[i].start()
-            time.sleep(5)
+            time.sleep(7)
             self.assertEqual(self.nodes[i].get_state(), 'child')
 
             if i in range(4, 8):   


### PR DESCRIPTION
To address #910 , use commissioner session id to distinguish different role (on-mesh commissioner or Router):
(i) on-mesh commissioner will bring commissioner session id when call `SendSetRequest` for MGMT_PENDING_SET/MGMT_ACTIVE_SET request message
(ii)Router will call `Register` to sync up latest Dataset without no commissioner session id and Leader sends MGMT_DATASET_CHANGED to on-mesh commissioner if it accepts a newer Dataset.

Below is result of 9.2.9 with this PR, we can see that all traffic is normal and pending dataset includes all TLVs in Active dataset. But seems not to find the MGMT_PENDING_SET.rsp, however, it's just there(index 326).
[Leader_9_2_9.zip](https://github.com/openthread/openthread/files/565641/Leader_9_2_9.zip)
