### PR TITLE
Make all devices could receive and response to MGMT_ACTIVE_GET.req and MGMT_PENDING_GET.req

### DIFF
--- a/examples/drivers/windows/otLwf/iocontrol.c
+++ b/examples/drivers/windows/otLwf/iocontrol.c
@@ -3319,7 +3319,8 @@ otLwfIoCtl_otSendActiveGet(
                 otSendActiveGet(
                     pFilter->otCtx,
                     aTlvTypes,
-                    aLength)
+                    aLength,
+                    NULL)
                 );
         }
     }
@@ -3393,7 +3394,8 @@ otLwfIoCtl_otSendPendingGet(
                 otSendPendingGet(
                     pFilter->otCtx,
                     aTlvTypes,
-                    aLength)
+                    aLength,
+                    NULL)
                 );
         }
     }

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -941,12 +941,14 @@ ThreadError otSetPendingDataset(otInstance *aInstance, const otOperationalDatase
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  * @param[in]  aTlvTypes  A pointer to the TLV Types.
  * @param[in]  aLength    The length of TLV Types.
+ * @param[in]  aAddress   A pointer to the IPv6 destination, if it is NULL, will use Leader ALOC as default.
  *
  * @retval kThreadError_None         Successfully send the meshcop dataset command.
  * @retval kThreadError_NoBufs       Insufficient buffer space to send.
  *
  */
-ThreadError otSendActiveGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength);
+ThreadError otSendActiveGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength,
+                            const otIp6Address *aAddress);
 
 /**
  * This function sends MGMT_ACTIVE_SET.
@@ -969,12 +971,14 @@ ThreadError otSendActiveSet(otInstance *aInstance, const otOperationalDataset *a
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  * @param[in]  aTlvTypes  A pointer to the TLV Types.
  * @param[in]  aLength    The length of TLV Types.
+ * @param[in]  aAddress   A pointer to the IPv6 destination, if it is NULL, will use Leader ALOC as default.
  *
  * @retval kThreadError_None         Successfully send the meshcop dataset command.
  * @retval kThreadError_NoBufs       Insufficient buffer space to send.
  *
  */
-ThreadError otSendPendingGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength);
+ThreadError otSendPendingGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength,
+                             const otIp6Address *aAddress);
 
 /**
  * This function sends MGMT_PENDING_SET.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -531,12 +531,12 @@ Set mesh local prefix.
 Done
 ```
 
-### dataset mgmtgetcommand active \[TLVs list\] \[binary\]
+### dataset mgmtgetcommand active \[address \<destination\>\] \[TLVs list\] \[binary\]
 
 Send MGMT_ACTIVE_GET.
 
 ```bash
-> dataset mgmtgetcommand active activetimestamp 123 binary 0001
+> dataset mgmtgetcommand active address fdde:ad00:beef:0:558:f56b:d688:799 activetimestamp 123 binary 0001
 Done
 ```
 
@@ -549,12 +549,12 @@ Send MGMT_ACTIVE_SET.
 Done
 ```
 
-### dataset mgmtgetcommand pending \[TLVs list\] \[binary\]
+### dataset mgmtgetcommand pending \[address \<destination\>\] \[TLVs list\] \[binary\]
 
 Send MGMT_PENDING_GET.
 
 ```bash
-> dataset mgmtgetcommand pending activetimestamp binary 0001
+> dataset mgmtgetcommand pending address fdde:ad00:beef:0:558:f56b:d688:799 activetimestamp binary 0001
 Done
 ```
 

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -574,6 +574,8 @@ ThreadError Dataset::ProcessMgmtGetCommand(otInstance *aInstance, int argc, char
     uint8_t tlvs[32];
     long value;
     int length = 0;
+    bool destAddrSpecified = false;
+    otIp6Address address;
 
     VerifyOrExit(argc > 0, error = kThreadError_Parse);
 
@@ -628,6 +630,12 @@ ThreadError Dataset::ProcessMgmtGetCommand(otInstance *aInstance, int argc, char
                          error = kThreadError_Parse);
             length += value;
         }
+        else if (strcmp(argv[index], "address") == 0)
+        {
+            VerifyOrExit(index < argc, error = kThreadError_Parse);
+            SuccessOrExit(error = otIp6AddressFromString(argv[++index], &address));
+            destAddrSpecified = true;
+        }
         else
         {
             ExitNow(error = kThreadError_Parse);
@@ -636,11 +644,13 @@ ThreadError Dataset::ProcessMgmtGetCommand(otInstance *aInstance, int argc, char
 
     if (strcmp(argv[0], "active") == 0)
     {
-        SuccessOrExit(error = otSendActiveGet(aInstance, tlvs, static_cast<uint8_t>(length)));
+        SuccessOrExit(error = otSendActiveGet(aInstance, tlvs, static_cast<uint8_t>(length),
+                                              destAddrSpecified ? &address : NULL));
     }
     else if (strcmp(argv[0], "pending") == 0)
     {
-        SuccessOrExit(error = otSendPendingGet(aInstance, tlvs, static_cast<uint8_t>(length)));
+        SuccessOrExit(error = otSendPendingGet(aInstance, tlvs, static_cast<uint8_t>(length),
+                                               destAddrSpecified ? &address : NULL));
     }
     else
     {

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -1482,9 +1482,10 @@ exit:
     return error;
 }
 
-ThreadError otSendActiveGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength)
+ThreadError otSendActiveGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength,
+                            const otIp6Address *aAddress)
 {
-    return aInstance->mThreadNetif.GetActiveDataset().SendGetRequest(aTlvTypes, aLength);
+    return aInstance->mThreadNetif.GetActiveDataset().SendGetRequest(aTlvTypes, aLength, aAddress);
 }
 
 ThreadError otSendActiveSet(otInstance *aInstance, const otOperationalDataset *aDataset, const uint8_t *aTlvs,
@@ -1493,9 +1494,10 @@ ThreadError otSendActiveSet(otInstance *aInstance, const otOperationalDataset *a
     return aInstance->mThreadNetif.GetActiveDataset().SendSetRequest(*aDataset, aTlvs, aLength);
 }
 
-ThreadError otSendPendingGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength)
+ThreadError otSendPendingGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength,
+                             const otIp6Address *aAddress)
 {
-    return aInstance->mThreadNetif.GetPendingDataset().SendGetRequest(aTlvTypes, aLength);
+    return aInstance->mThreadNetif.GetPendingDataset().SendGetRequest(aTlvTypes, aLength, aAddress);
 }
 
 ThreadError otSendPendingSet(otInstance *aInstance, const otOperationalDataset *aDataset, const uint8_t *aTlvs,

--- a/src/core/thread/meshcop_dataset_manager.hpp
+++ b/src/core/thread/meshcop_dataset_manager.hpp
@@ -59,7 +59,7 @@ public:
     ThreadError ApplyConfiguration(void);
 
     ThreadError SendSetRequest(const otOperationalDataset &aDataset, const uint8_t *aTlvs, uint8_t aLength);
-    ThreadError SendGetRequest(const uint8_t *aTlvTypes, uint8_t aLength);
+    ThreadError SendGetRequest(const uint8_t *aTlvTypes, uint8_t aLength, const otIp6Address *aAddress);
 
 protected:
     enum

--- a/tools/harness-thci/ARM.py
+++ b/tools/harness-thci/ARM.py
@@ -2149,6 +2149,10 @@ class ARM(IThci):
         try:
             cmd = 'dataset mgmtgetcommand active'
 
+            if Addr != '':
+                cmd += ' address '
+                cmd += Addr
+
             if len(TLVs) != 0:
                 tlvs = "".join(hex(tlv).lstrip("0x").zfill(2) for tlv in TLVs)
                 cmd += ' binary '
@@ -2289,6 +2293,10 @@ class ARM(IThci):
         print '%s call MGMT_PENDING_GET' % self.port
         try:
             cmd = 'dataset mgmtgetcommand pending'
+
+            if Addr != '':
+                cmd += ' address '
+                cmd += Addr
 
             if len(TLVs) != 0:
                 tlvs = "".join(hex(tlv).lstrip("0x").zfill(2) for tlv in TLVs)


### PR DESCRIPTION
According to the specification, Leader and other Thread devices MUST response to receiving MGMT_ACTIVE_GET.req and MGMT_PENDING_GET.req message. And in Certification test 9.2.15 and 9.2.16, Harness will verify the MGMT_ACTIVE_GET.req sent from Leader to DUT(Router) and the MGMT_ACTIVE_GET.rsp sent from DUT(Router) to Leader.