### PR TITLE
Add support to ncp for parsing/handling a generic alternate (legacy) network stack commands

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -564,6 +564,37 @@ AM_CONDITIONAL([OPENTHREAD_ENABLE_DIAG], [test "${enable_diag}" = "yes"])
 AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_DIAG],[${OPENTHREAD_ENABLE_DIAG}],[Define to 1 if you want to use diagnostics module])
 
 #
+# Legacy Network
+#
+
+AC_ARG_ENABLE(legacy,
+    [AS_HELP_STRING([--enable-legacy],[Enable legacy network support @<:@default=no@:>@.])],
+    [
+        case "${enableval}" in
+
+        no|yes)
+            enable_legacy=${enableval}
+            ;;
+
+        *)
+            AC_MSG_ERROR([Invalid value ${enable_legacy} for --enable-legacy])
+            ;;
+        esac
+    ],
+    [enable_legacy=no])
+
+if test "$enable_legacy" = "yes"; then
+    OPENTHREAD_ENABLE_LEGACY=1
+else
+    OPENTHREAD_ENABLE_LEGACY=0
+fi
+
+AC_MSG_RESULT(${enable_legacy})
+AC_SUBST(OPENTHREAD_ENABLE_LEGACY)
+AM_CONDITIONAL([OPENTHREAD_ENABLE_LEGACY], [test "${enable_legacy}" = "yes"])
+AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_LEGACY],[${OPENTHREAD_ENABLE_LEGACY}],[Define to 1 if you want to use legacy network support])
+
+#
 # Cli Logging
 #
 
@@ -939,6 +970,7 @@ AC_MSG_NOTICE([
   OpenThread Joiner support                 : ${enable_joiner}
   OpenThread DTLS support                   : ${enable_dtls}
   OpenThread Diagnostics support            : ${enable_diag}
+  OpenThread Legacy network support         : ${enable_legacy}
   OpenThread Cli logging support            : ${enable_cli_logging}
   OpenThread Certification log support      : ${enable_cert_log}
   OpenThread DHCPv6 Server support          : ${enable_dhcp6_server}

--- a/include/ncp/ncp.h
+++ b/include/ncp/ncp.h
@@ -73,6 +73,88 @@ void otNcpInit(otInstance *aInstance);
 */
 ThreadError otNcpStreamWrite(int aStreamId, const uint8_t *aDataPtr, int aDataLen);
 
+
+//-----------------------------------------------------------------------------------------
+// Legacy network APIs
+
+#define OT_NCP_LEGACY_ULA_PREFIX_LENGTH    8   ///< Legacy ULA size (in bytes)
+
+/**
+ * Defines handler (function pointer) type for starting legacy network
+ *
+ * Invoked to start the legacy network.
+ *
+ */
+typedef void (*otNcpHandlerStartLegacy)(void);
+
+/**
+ * Defines handler (function pointer) type for stopping legacy network
+ *
+ * Invoked to stop the legacy network.
+ *
+ */
+typedef void (*otNcpHandlerStopLegacy)(void);
+
+/**
+ * Defines handler (function pointer) type for initiating joining process.
+ *
+ * @param[in] aExtAddress   A pointer to the extended address for the node to join
+ *                          or NULL if desired to join any neighboring node.
+ *
+ * Invoked to initiate a legacy join procedure to any or a specific node.
+ *
+ */
+typedef void (*otNcpHandlerJoinLegacyNode)(const otExtAddress *aExtAddress);
+
+/**
+ * Defines handler (function pointer) type for setting the legacy ULA prefix.
+ *
+ * @param[in] aUlaPrefix   A pointer to buffer containing the legacy ULA prefix.
+ *
+ * Invoked to set the legacy ULA prefix.
+ *
+ */
+typedef void (*otNcpHandlerSetLegacyUlaPrefix)(const uint8_t *aUlaPrefix);
+
+/**
+ * Defines a struct containing all the legacy handlers (function pointers).
+ *
+ */
+typedef struct otNcpLegacyHandlers
+{
+    otNcpHandlerStartLegacy         mStartLegacy;
+    otNcpHandlerStopLegacy          mStopLegacy;
+    otNcpHandlerJoinLegacyNode      mJoinLegacyNode;
+    otNcpHandlerSetLegacyUlaPrefix  mSetLegacyUlaPrefix;
+
+} otNcpLegacyHandlers;
+
+/**
+ * This callback is invoked by the legacy stack to notify that a new
+ * legacy node did join the network.
+ */
+void otNcpHandleLegacyNodeDidJoin(const otExtAddress *aExtAddr);
+
+/**
+ * This callback is invoked by the legacy stack to notify that the
+ * legacy ULA prefix has changed.
+ */
+void otNcpHandleDidReceiveNewLegacyUlaPrefix(const uint8_t *aUlaPrefix);
+
+/**
+ * This method registers a set of legacy handlers with NCP.
+ *
+ * The set of handlers provided by the struct @p aHandlers are used by
+ * NCP code to start/stop legacy network.
+ * The @p aHandlers can be NULL to disable legacy support on NCP.
+ * Individual handlers in the given handlers struct can also be NULL.
+ *
+ * @param[in] aHandlers    A pointer to a handler struct.
+ *
+ */
+void otNcpRegisterLegacyHandlers(const otNcpLegacyHandlers *aHandlers);
+
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/include/openthread-windows-config.h
+++ b/include/openthread-windows-config.h
@@ -32,6 +32,9 @@
 /* Define to 1 if you want to use diagnostics module */
 #define OPENTHREAD_ENABLE_DIAG 0
 
+/* Define to 1 if you want to enable legacy network. */
+#define OPENTHREAD_ENABLE_LEGACY 0
+
 /* Define to 1 to enable dtls support. */
 #define OPENTHREAD_ENABLE_DTLS 1
 
@@ -85,5 +88,5 @@
 // Disable a few warnings that we don't care about
 #pragma warning(disable:4200)  // nonstandard extension used: zero-sized array in struct/union
 #pragma warning(disable:4201)  // nonstandard extension used : nameless struct/union
-#pragma warning(disable:4291)  // no matching operator delete found 
+#pragma warning(disable:4291)  // no matching operator delete found
 #pragma warning(disable:4815)  // zero-sized array in stack object will have no elements

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -42,6 +42,7 @@
 #include <openthread-types.h>
 #include <common/message.hpp>
 #include <common/tasklet.hpp>
+#include <ncp/ncp.h>
 
 #include "spinel.h"
 
@@ -344,6 +345,10 @@ private:
     ThreadError GetPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_NET_REQUIRE_JOIN_EXISTING(uint8_t header, spinel_prop_key_t key);
 
+#if OPENTHREAD_ENABLE_LEGACY
+    ThreadError GetPropertyHandler_NEST_LEGACY_ULA_PREFIX(uint8_t header, spinel_prop_key_t key);
+#endif
+
     ThreadError SetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                uint16_t value_len);
     ThreadError SetPropertyHandler_PHY_TX_POWER(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
@@ -421,6 +426,11 @@ private:
                                                    uint16_t value_len);
 #endif
 
+#if OPENTHREAD_ENABLE_LEGACY
+    ThreadError SetPropertyHandler_NEST_LEGACY_ULA_PREFIX(uint8_t header, spinel_prop_key_t key,
+                                                   const uint8_t *value_ptr, uint16_t value_len);
+#endif
+
     ThreadError InsertPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                          uint16_t value_len);
     ThreadError InsertPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
@@ -444,6 +454,13 @@ private:
     ThreadError RemovePropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
     ThreadError RemovePropertyHandler_THREAD_ACTIVE_ROUTER_IDS(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                               uint16_t value_len);
+
+#if OPENTHREAD_ENABLE_LEGACY
+public:
+    void HandleLegacyNodeDidJoin(const otExtAddress *aExtAddr);
+    void HandleDidReceiveNewLegacyUlaPrefix(const uint8_t *aUlaPrefix);
+    void RegisterLegacyHandlers(const otNcpLegacyHandlers *aHandlers);
+#endif
 
 private:
 
@@ -478,6 +495,13 @@ private:
     uint32_t mOutboundInsecureIpFrameCounter;  // Number of insecure outbound data/IP frames.
     uint32_t mDroppedOutboundIpFrameCounter;   // Number of dropped outbound data/IP frames.
     uint32_t mDroppedInboundIpFrameCounter;    // Number of dropped inbound data/IP frames.
+
+#if OPENTHREAD_ENABLE_LEGACY
+    const otNcpLegacyHandlers *mLegacyHandlers;
+    uint8_t mLegacyUlaPrefix[OT_NCP_LEGACY_ULA_PREFIX_LENGTH];
+    bool mLegacyNodeDidJoin;
+#endif
+
 };
 
 }  // namespace Thread

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -772,6 +772,17 @@ typedef enum
 
     SPINEL_PROP_NEST__BEGIN         = 15296,
     SPINEL_PROP_NEST_STREAM_MFG     = SPINEL_PROP_NEST__BEGIN + 0,
+
+    /// The legacy network ULA prefix (8 bytes)
+    /** Format: 'D' */
+    SPINEL_PROP_NEST_LEGACY_ULA_PREFIX
+                                    = SPINEL_PROP_NEST__BEGIN + 1,
+
+    /// A (newly) joined legacy node (this is signaled from NCP)
+    /** Format: 'E' */
+    SPINEL_PROP_NEST_LEGACY_JOINED_NODE
+                                    = SPINEL_PROP_NEST__BEGIN + 2,
+
     SPINEL_PROP_NEST__END           = 15360,
 
     SPINEL_PROP_VENDOR__BEGIN       = 15360,


### PR DESCRIPTION
This commit contains the following:

- APIs/typedefs in `ncp.h` to define handlers and callbacks for a generic alternate (legacy) network stack
- Support in `NcpBase` for parsing and handling of legacy network related commands/signals
- New legacy network related spinel properties
- Build feature "enable-legacy" to enable/disable this feature

PR https://github.com/openthread/wpantund/pull/90 is the counter-part of this PR in wpantund. 