### PR TITLE
sniffer.py: remove scapy dependency.

### DIFF
--- a/tools/spinel-cli/README.md
+++ b/tools/spinel-cli/README.md
@@ -1,13 +1,13 @@
 # Spinel CLI Reference
 
-The Spinel CLI exposes the OpenThread configuration and management APIs 
+The Spinel CLI exposes the OpenThread configuration and management APIs
 running on an NCP build via a command line interface.  Spinel CLI is primarily
 targeted for driving the automated continuous integration tests, and is
 suitable for manual experimentation with controlling OpenThread NCP instances.
 For a production grade host driver, see [wpantund]: https://github.com/openthread/wpantund.
 
-Use the CLI to play with NCP builds of OpenThread on a Linux or Mac OS 
-platform, including starting a basic tunnel interface to allow IPv6 
+Use the CLI to play with NCP builds of OpenThread on a Linux or Mac OS
+platform, including starting a basic tunnel interface to allow IPv6
 applications to run on the HOST and use the Thread network.
 
 The power of this tool is three fold:
@@ -31,9 +31,9 @@ The power of this tool is three fold:
 
 ```
 sudo easy_install pip
-sudo pip install blessed
-sudo pip install ipaddress
-sudo pip install scapy
+sudo pip install --user pyserial
+sudo pip install --user ipaddress
+sudo pip install --user scapy==2.3.2
 ```
 
 ## Usage
@@ -56,7 +56,7 @@ sudo pip install scapy
 
     -p <PIPE>, --pipe=<PIPE>
         Open a piped process connection to the OpenThread NCP device
-        where <PIPE> is the command to start an emulator, such as 
+        where <PIPE> is the command to start an emulator, such as
         "ot-ncp".  Spinel-cli will communicate with the child process
         via stdin/stdout.
 
@@ -80,9 +80,9 @@ sudo pip install scapy
 ## Quick Start
 
 The spinel-cli tool provides an intuitive command line interface, including
-all the standard OpenThread CLI commands, plus full history accessible by 
+all the standard OpenThread CLI commands, plus full history accessible by
 pressing the up/down keys, or searchable via ^R.  There are a few commands
-that spinel-cli provides as well that aren't part of the standard set 
+that spinel-cli provides as well that aren't part of the standard set
 documented in the command reference section.
 
 ```
@@ -118,7 +118,7 @@ spinel-cli >
 
 ## Running the NCP Tests
 
-The OpenThread automated test suite can be run against any of the following 
+The OpenThread automated test suite can be run against any of the following
 node types by passing the NODE_TYPE environment variable:
 
 | NODE_TYPE     |    Description                                     |
@@ -152,7 +152,7 @@ NODE_TYPE=ncp-sim BUILD_TARGET=posix-distcheck DISTCHECK_CONFIGURE_FLAGS="--with
 ### OpenThread CLI Commands
 
 The primary intent of spinel-cli is to support the exact syntax and output
-of the OpenThread CLI command set in order to seamlessly reapply the 
+of the OpenThread CLI command set in order to seamlessly reapply the
 thread-cert automated test suite against NCP targets.
 
 See [cli module][1] for more information on these commands.
@@ -161,7 +161,7 @@ See [cli module][1] for more information on these commands.
 
 ### Diagnostics CLI Commands
 
-The Diagnostics module is enabled only when building OpenThread with 
+The Diagnostics module is enabled only when building OpenThread with
 the --enable-diag configure option.
 
 See [diag module][2] for more information on these commands.
@@ -171,7 +171,7 @@ See [diag module][2] for more information on these commands.
 
 ### NCP CLI Commands
 
-These commands extend beyond the core OpenThread CLI, and are specific to 
+These commands extend beyond the core OpenThread CLI, and are specific to
 the spinel-cli tool for the purposes of debugging, access to NCP-specific
 Spinel parameters, and support of advanced configurations.
 
@@ -287,8 +287,8 @@ DEBUG_ENABLE = 0
 spinel-cli > debug 1
 DEBUG_ENABLE = 1
 spinel-cli > version
-TX Pay: (3) ['81', '02', '02'] 
-RX Pay: (53) ['81', '06', '02', '4F', '50', '45', '4E', '54', '48', '52', '45', '41', '44', '2F', '67', '38', '62', '63', '34', '62', '31', '64', '2D', '64', '69', '72', '74', '79', '3B', '20', '41', '75', '67', '20', '33', '31', '20', '32', '30', '31', '36', '20', '31', '30', '3A', '34', '38', '3A', '35', '33', '00', '40', '33'] 
+TX Pay: (3) ['81', '02', '02']
+RX Pay: (53) ['81', '06', '02', '4F', '50', '45', '4E', '54', '48', '52', '45', '41', '44', '2F', '67', '38', '62', '63', '34', '62', '31', '64', '2D', '64', '69', '72', '74', '79', '3B', '20', '41', '75', '67', '20', '33', '31', '20', '32', '30', '31', '36', '20', '31', '30', '3A', '34', '38', '3A', '35', '33', '00', '40', '33']
 OPENTHREAD/g8bc4b1d-dirty; Aug 31 2016 10:48:53
 Done
 ```
@@ -306,7 +306,7 @@ Set whether debug terminal title bar is enabled.
 Control sideband tunnel interface.
 
 #### ncp-tun up
-        
+
 Bring up Thread TUN interface.
 
 ```bash
@@ -315,7 +315,7 @@ Done
 ```
 
 #### ncp-tun down
-        
+
 Bring down Thread TUN interface.
 
 ```bash
@@ -335,7 +335,7 @@ Done
 #### ncp-tun del \<ipaddr\>
 
 Delete an IPv6 address from the Thread TUN interface.
-        
+
 ```bash
 spinel-cli > ncp-tun del 2001::dead:beef:cafe
 Done

--- a/tools/spinel-cli/SNIFFER.md
+++ b/tools/spinel-cli/SNIFFER.md
@@ -1,6 +1,6 @@
 # Spinel Sniffer Reference
 
-Any Spinel NCP node can be made into a promiscuous packet sniffer, and this 
+Any Spinel NCP node can be made into a promiscuous packet sniffer, and this
 tool both intializes a device into this mode and outputs a pcap stream that
 can be saved or piped directly into Wireshark.
 
@@ -21,9 +21,8 @@ The tool has been tested on the following platforms:
 
 ```
 sudo easy_install pip
-sudo pip install ipaddress
-sudo pip install scapy
-sudo pip install pyserial
+sudo pip install --user pyserial
+sudo pip install --user ipaddress
 ```
 
 ## Usage
@@ -46,7 +45,7 @@ sudo pip install pyserial
 
     -p <PIPE>, --pipe=<PIPE>
         Open a piped process connection to the OpenThread NCP device
-        where <PIPE> is the command to start an emulator, such as 
+        where <PIPE> is the command to start an emulator, such as
         "ot-ncp".  Spinel-cli will communicate with the child process
         via stdin/stdout.
 
@@ -90,9 +89,9 @@ From openthread root:
     sudo ./tools/spinel-cli/sniffer.py -c 11 -n 1 -u /dev/ttyUSB0 | wireshark -k -i -
 ```
 
-This will connect to stock openthread ncp firmware over the given UART, 
-make the node into a promiscuous mode sniffer on the given channel, 
-open up wireshark, and start streaming packets into wireshark. 
+This will connect to stock openthread ncp firmware over the given UART,
+make the node into a promiscuous mode sniffer on the given channel,
+open up wireshark, and start streaming packets into wireshark.
 
 ## Troubleshooting
 Q: sniffer.py throws ```ImportError: No module named dnet``` on OSX
@@ -107,4 +106,3 @@ echo 'import site; site.addsitedir("/usr/local/lib/python2.7/site-packages")' >>
 you may need to reinstall the scapy pip dependency listed above
 
 you can read more about this issue here: http://stackoverflow.com/questions/26229057/scapy-installation-fails-on-osx-with-dnet-import-error
-

--- a/tools/spinel-cli/spinel/config.py
+++ b/tools/spinel-cli/spinel/config.py
@@ -110,4 +110,4 @@ def debug_set_level(level):
             DEBUG_STREAM_RX = 1
             DEBUG_STREAM_TX = 1
 
-    print "DEBUG_ENABLE = " + str(DEBUG_ENABLE)
+    print("DEBUG_ENABLE = " + str(DEBUG_ENABLE))

--- a/tools/spinel-cli/spinel/stream.py
+++ b/tools/spinel-cli/spinel/stream.py
@@ -31,6 +31,8 @@ Module providing a generic stream interface.
 Also includes adapter implementations for serial, socket, and pipes.
 """
 
+from __future__ import print_function
+
 import sys
 import logging
 import traceback
@@ -67,7 +69,7 @@ class StreamSerial(IStream):
             self.serial = serial.Serial(dev, baudrate)
         except:
             logging.error("Couldn't open " + dev)
-            print traceback.format_exc()
+            traceback.print_exc()
 
     def write(self, data):
         self.serial.write(data)
@@ -113,7 +115,7 @@ class StreamPipe(IStream):
                                          stderr=sys.stdout.fileno())
         except:
             logging.error("Couldn't open " + filename)
-            print traceback.format_exc()
+            traceback.print_exc()
 
     def write(self, data):
         if CONFIG.DEBUG_STREAM_TX:
@@ -151,21 +153,21 @@ def StreamOpen(stream_type, descriptor, verbose=True):
 
     if stream_type == 'p':
         if verbose:
-            print "Opening pipe to " + str(descriptor)
+            print("Opening pipe to " + str(descriptor))
         return StreamPipe(descriptor)
 
     elif stream_type == 's':
         port = int(descriptor)
         hostname = "localhost"
         if verbose:
-            print "Opening socket to " + hostname + ":" + str(port)
+            print("Opening socket to " + hostname + ":" + str(port))
         return StreamSocket(hostname, port)
 
     elif stream_type == 'u':
         dev = str(descriptor)
         baudrate = 115200
         if verbose:
-            print "Opening serial to " + dev + " @ " + str(baudrate)
+            print("Opening serial to " + dev + " @ " + str(baudrate))
         return StreamSerial(dev, baudrate)
 
     else:

--- a/tools/spinel-cli/spinel/test_codec.py
+++ b/tools/spinel-cli/spinel/test_codec.py
@@ -27,6 +27,7 @@
 #
 """ Unittest for spinel.codec module. """
 
+import time
 import unittest
 
 from spinel.const import SPINEL
@@ -69,3 +70,27 @@ class TestCodec(unittest.TestCase):
             # print "value "+util.hexify_str(value)
             # print "truth "+util.hexify_str(truth_value)
             self.failUnless(value == truth_value)
+
+    def cb_test_callback(self, prop, value, tid):
+        self.test_callback_pass = True
+
+    def test_callback(self):
+        """ Unit test of WpanApi.callback_register. """
+
+        vector = [
+            "800672340060000000000c3a40fe80000000000000020d6f00055715d3fddead00beef0000cd9bb7814c5619ea8100b0ca00000000267fc789"  # PROP_STREAM_NET
+        ]
+
+        mock_stream = MockStream({})
+        nodeid = 1
+        use_hdlc = False
+        wpan_api = WpanApi(mock_stream, nodeid, use_hdlc)
+
+        self.test_callback_pass = False
+        wpan_api.callback_register(SPINEL.PROP_STREAM_NET, self.cb_test_callback)
+
+        for pkt in vector:
+            mock_stream.write_child_hex(pkt)
+            time.sleep(0.1)
+
+        self.failUnless(self.test_callback_pass)

--- a/tools/spinel-cli/spinel/tun.py
+++ b/tools/spinel-cli/spinel/tun.py
@@ -27,6 +27,8 @@
 #
 """ Utility class for creating TUN network interfaces on Linux and OSX. """
 
+from __future__ import print_function
+
 import os
 import sys
 import fcntl
@@ -103,7 +105,7 @@ class TunInterface(object):
     def ping6(self, args):
         """ Ping an address. """
         cmd = 'ping6 ' + args
-        print cmd
+        print(cmd)
         self.command(cmd)
 
     def addr_add(self, addr):
@@ -137,7 +139,7 @@ class TunInterface(object):
                                       util.hexify_str(packet))
                     self.write(packet)
             except:
-                print traceback.format_exc()
+                traceback.print_exc()
                 break
 
         logging.info("TUN: exiting")


### PR DESCRIPTION
Added to spinel.codec a method to register a callback for a given message type.
Pulled all IPv6 packet parsing from spinel.codec using the new callback mechanism.

Adjusted codebase toward allowing python3 support in addition to python2.
Note on python3 support: there are still open issues with differences in handling struct.pack() results.