### PR TITLE
Remove timestamp from Active/Pending Operational Dataset Tlv.

### DIFF
--- a/src/core/thread/meshcop_dataset.hpp
+++ b/src/core/thread/meshcop_dataset.hpp
@@ -166,7 +166,22 @@ public:
 
     ThreadError Set(const otOperationalDataset &aDataset);
 
+    /**
+     * This method removes a TLV from the Dataset.
+     *
+     * @param[in] aType The type of a specific TLV.
+     *
+     */
     void Remove(Tlv::Type aType);
+
+    /**
+     * This method appends the MLE Dataset TLV but excluding MeshCoP Sub Timestamp TLV.
+     *
+     * @retval kThreadError_None    Successfully append MLE Dataset TLV without MeshCoP Sub Timestamp TLV.
+     * @retval kThreadError_NoBufs  Insufficient available buffers to append the message with MLE Dataset TLV.
+     *
+     */
+    ThreadError AppendMleDatasetTlv(Message &aMessage);
 
 private:
     void Remove(uint8_t *aStart, uint8_t aLength);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3729,12 +3729,10 @@ exit:
 ThreadError MleRouter::AppendActiveDataset(Message &aMessage)
 {
     ThreadError error = kThreadError_None;
-    Tlv tlv;
 
-    tlv.SetType(Tlv::kActiveDataset);
-    tlv.SetLength(static_cast<uint8_t>(mNetif.GetActiveDataset().GetNetwork().GetSize()));
-    SuccessOrExit(error = aMessage.Append(&tlv, sizeof(tlv)));
-    SuccessOrExit(error = aMessage.Append(mNetif.GetActiveDataset().GetNetwork().GetBytes(), tlv.GetLength()));
+    VerifyOrExit(mNetif.GetActiveDataset().GetNetwork().GetSize() > 0,);
+
+    SuccessOrExit(error = mNetif.GetActiveDataset().GetNetwork().AppendMleDatasetTlv(aMessage));
 
 exit:
     return error;
@@ -3743,13 +3741,11 @@ exit:
 ThreadError MleRouter::AppendPendingDataset(Message &aMessage)
 {
     ThreadError error = kThreadError_None;
-    Tlv tlv;
 
-    tlv.SetType(Tlv::kPendingDataset);
-    tlv.SetLength(static_cast<uint8_t>(mNetif.GetPendingDataset().GetNetwork().GetSize()));
-    SuccessOrExit(error = aMessage.Append(&tlv, sizeof(tlv)));
+    VerifyOrExit(mNetif.GetPendingDataset().GetNetwork().GetSize() > 0,);
+
     mNetif.GetPendingDataset().UpdateDelayTimer();
-    SuccessOrExit(error = aMessage.Append(mNetif.GetPendingDataset().GetNetwork().GetBytes(), tlv.GetLength()));
+    SuccessOrExit(error = mNetif.GetPendingDataset().GetNetwork().AppendMleDatasetTlv(aMessage));
 
 exit:
     return error;


### PR DESCRIPTION
Timestamp Tlv should be encoded with MLE Tlv type along with dissemination of Datasets, and Dataset Tlv should only include appropriate MeshCOP sub-TLVs.