### PR TITLE
spinel-doc: Updates and additions to spinel documentation.

### DIFF
--- a/doc/draft-spinel-protocol.html
+++ b/doc/draft-spinel-protocol.html
@@ -405,6 +405,9 @@
 <link href="#rfc.section.4.7" rel="Chapter" title="4.7 CMD 6: (NCP-&gt;Host) CMD_PROP_VALUE_IS"/>
 <link href="#rfc.section.4.8" rel="Chapter" title="4.8 CMD 7: (NCP-&gt;Host) CMD_PROP_VALUE_INSERTED"/>
 <link href="#rfc.section.4.9" rel="Chapter" title="4.9 CMD 8: (NCP-&gt;Host) CMD_PROP_VALUE_REMOVED"/>
+<link href="#rfc.section.4.10" rel="Chapter" title="4.10 CMD 18: (Host-&gt;NCP) CMD_PEEK"/>
+<link href="#rfc.section.4.11" rel="Chapter" title="4.11 CMD 19: (NCP-&gt;Host) CMD_PEEK_RET"/>
+<link href="#rfc.section.4.12" rel="Chapter" title="4.12 CMD 20: (Host-&gt;NCP) CMD_POKE"/>
 <link href="#rfc.section.5" rel="Chapter" title="5 Properties"/>
 <link href="#rfc.section.5.1" rel="Chapter" title="5.1 Property Sections"/>
 <link href="#rfc.section.5.2" rel="Chapter" title="5.2 Core Properties"/>
@@ -462,10 +465,12 @@
 <link href="#rfc.section.5.7.5" rel="Chapter" title="5.7.5 PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD"/>
 <link href="#rfc.section.6" rel="Chapter" title="6 Status Codes"/>
 <link href="#rfc.section.7" rel="Chapter" title="7 Security Considerations"/>
+<link href="#rfc.section.7.1" rel="Chapter" title="7.1 Raw Application Access"/>
 <link href="#rfc.section.8" rel="Chapter" title="8 Acknowledgments"/>
 <link href="#rfc.appendix.A" rel="Chapter" title="A Framing Protocol"/>
 <link href="#rfc.appendix.A.1" rel="Chapter" title="A.1 UART Recommendations"/>
-<link href="#rfc.appendix.A.1.1" rel="Chapter" title="A.1.1 HDLC-Lite"/>
+<link href="#rfc.appendix.A.1.1" rel="Chapter" title="A.1.1 UART Bit Rate Detection"/>
+<link href="#rfc.appendix.A.1.2" rel="Chapter" title="A.1.2 HDLC-Lite"/>
 <link href="#rfc.appendix.A.2" rel="Chapter" title="A.2 SPI Recommendations"/>
 <link href="#rfc.appendix.A.2.1" rel="Chapter" title="A.2.1 SPI Framing Protocol"/>
 <link href="#rfc.appendix.A.3" rel="Chapter" title="A.3 I&#xB2;C Recommendations"/>
@@ -555,7 +560,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Quattlebaum, R." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-spinel-protocol-4fce7582b" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-spinel-protocol-f9bf43254" />
   <meta name="dct.issued" scheme="ISO8601" content="2016-11-4" />
   <meta name="dct.abstract" content="This document describes a general management protocol for enabling a host device to communicate with and manage a Network Control Processor (NCP).  " />
   <meta name="description" content="This document describes a general management protocol for enabling a host device to communicate with and manage a Network Control Processor (NCP).  " />
@@ -585,7 +590,7 @@
   </table>
 
   <p class="title">Spinel Host-Controller Protocol<br />
-  <span class="filename">draft-spinel-protocol-4fce7582b</span></p>
+  <span class="filename">draft-spinel-protocol-f9bf43254</span></p>
   
   <h1 id="rfc.abstract">
   <a href="#rfc.abstract">Abstract</a>
@@ -651,6 +656,9 @@
 <li>4.7.   <a href="#rfc.section.4.7">CMD 6: (NCP-&gt;Host) CMD_PROP_VALUE_IS</a></li>
 <li>4.8.   <a href="#rfc.section.4.8">CMD 7: (NCP-&gt;Host) CMD_PROP_VALUE_INSERTED</a></li>
 <li>4.9.   <a href="#rfc.section.4.9">CMD 8: (NCP-&gt;Host) CMD_PROP_VALUE_REMOVED</a></li>
+<li>4.10.   <a href="#rfc.section.4.10">CMD 18: (Host-&gt;NCP) CMD_PEEK</a></li>
+<li>4.11.   <a href="#rfc.section.4.11">CMD 19: (NCP-&gt;Host) CMD_PEEK_RET</a></li>
+<li>4.12.   <a href="#rfc.section.4.12">CMD 20: (Host-&gt;NCP) CMD_POKE</a></li>
 </ul><li>5.   <a href="#rfc.section.5">Properties</a></li>
 <ul><li>5.1.   <a href="#rfc.section.5.1">Property Sections</a></li>
 <li>5.2.   <a href="#rfc.section.5.2">Core Properties</a></li>
@@ -708,10 +716,12 @@
 <li>5.7.5.   <a href="#rfc.section.5.7.5">PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD</a></li>
 </ul></ul><li>6.   <a href="#rfc.section.6">Status Codes</a></li>
 <li>7.   <a href="#rfc.section.7">Security Considerations</a></li>
-<li>8.   <a href="#rfc.section.8">Acknowledgments</a></li>
+<ul><li>7.1.   <a href="#rfc.section.7.1">Raw Application Access</a></li>
+</ul><li>8.   <a href="#rfc.section.8">Acknowledgments</a></li>
 <li>Appendix A.   <a href="#rfc.appendix.A">Framing Protocol</a></li>
 <ul><li>A.1.   <a href="#rfc.appendix.A.1">UART Recommendations</a></li>
-<ul><li>A.1.1.   <a href="#rfc.appendix.A.1.1">HDLC-Lite</a></li>
+<ul><li>A.1.1.   <a href="#rfc.appendix.A.1.1">UART Bit Rate Detection</a></li>
+<li>A.1.2.   <a href="#rfc.appendix.A.1.2">HDLC-Lite</a></li>
 </ul><li>A.2.   <a href="#rfc.appendix.A.2">SPI Recommendations</a></li>
 <ul><li>A.2.1.   <a href="#rfc.appendix.A.2.1">SPI Framing Protocol</a></li>
 </ul><li>A.3.   <a href="#rfc.appendix.A.3">I&#178;C Recommendations</a></li>
@@ -830,7 +840,7 @@
 <p id="rfc.section.1.1.1.p.5">As time has gone by and the protocol has become more fleshed out, it has become clear that some of the initial allocations were inadequate and should be revisited if we want to try to achieve the original goal.  </p>
 <h1 id="rfc.section.1.1.2"><a href="#rfc.section.1.1.2">1.1.2.</a> <a href="#spinel-as-application-api" id="spinel-as-application-api">Spinel as Application API</a></h1>
 <p id="rfc.section.1.1.2.p.1">The current primary host driver implementation is <a href="http://wpantund.org/">wpantund</a>. wpantund manages the NCP using the Spinel protocol and provides a management API for the application using <a href="https://www.freedesktop.org/wiki/Software/dbus/">D-Bus</a> IPC.  </p>
-<p id="rfc.section.1.1.2.p.2">However, some thought has been given to the idea of having a host driver daemon which uses Spinel directly as the management API. You would have user-space daemon similar to wpantund which would communicate directly with the NCP. Using Unix Domain Sockets, applications could connect to the daemon by opening a special socket file. The protocol for that socket might be (for example) HDLC-Lite-encoded (<a href="#hdlc-lite">Appendix A.1.1</a>) spinel frames, as if the application were talking directly to the NCP.  </p>
+<p id="rfc.section.1.1.2.p.2">However, some thought has been given to the idea of having a host driver daemon which uses Spinel directly as the management API. You would have user-space daemon similar to wpantund which would communicate directly with the NCP. Using Unix Domain Sockets, applications could connect to the daemon by opening a special socket file. The protocol for that socket might be (for example) HDLC-Lite-encoded (<a href="#hdlc-lite">Appendix A.1.2</a>) spinel frames, as if the application were talking directly to the NCP.  </p>
 <p id="rfc.section.1.1.2.p.3">Applications aren't necessarily interested in everything that an NCP would normally send out unsolicited, so a mechanism for specifying which properties should be listened to would need to be defined. This mechanism would not be implemented by the NCP but would instead be implemented by the daemon to control which notification packets need to be directed where.  </p>
 <p id="rfc.section.1.1.2.p.4">In the event of transaction ID collisions, the daemon would transparently renumber spinel frames so as to not cause TID collisions.  </p>
 <p id="rfc.section.1.1.2.p.5">Since there can be more than one application that is using the API at a time, the <samp>PROP_LOCK</samp> property (<a href="#prop-lock">Section 5.2.10</a>) would be used to ensure exclusive access to the NCP by an application. Only one process would be allowed to enable the lock at a time.  </p>
@@ -1421,6 +1431,84 @@
 <p id="rfc.section.4.9.p.2">Note that this command operates <em>by value</em>, not by index! </p>
 <p id="rfc.section.4.9.p.3">The payload for this command is the property identifier encoded in the packed unsigned integer format described in <a href="#packed-unsigned-integer">Section 3.2</a>, followed by the value that was removed from the given property.  </p>
 <p id="rfc.section.4.9.p.4">The resulting order of items in the list is defined by the given property.  </p>
+<h1 id="rfc.section.4.10"><a href="#rfc.section.4.10">4.10.</a> <a href="#cmd-peek" id="cmd-peek">CMD 18: (Host-&gt;NCP) CMD_PEEK</a></h1>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+  <thead>
+    <tr>
+      <th class="center">Octets:</th>
+      <th class="center">1</th>
+      <th class="center">1</th>
+      <th class="center">4</th>
+      <th class="center">2</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="center">Fields:</td>
+      <td class="center">HEADER</td>
+      <td class="center">CMD_PEEK</td>
+      <td class="center">ADDRESS</td>
+      <td class="center">COUNT</td>
+    </tr>
+  </tbody>
+</table>
+<p id="rfc.section.4.10.p.1">This command allows the NCP to fetch values from the RAM of the NCP for debugging purposes. Upon success, <samp>CMD_PEEK_RET</samp> is sent from the NCP to the host. Upon failure, <samp>PROP_LAST_STATUS</samp> is emitted with the appropriate error indication.  </p>
+<p id="rfc.section.4.10.p.2">Due to the low-level nature of this command, certain error conditions may induce the NCP to reset.  </p>
+<p id="rfc.section.4.10.p.3">The NCP MAY prevent certain regions of memory from being accessed.  </p>
+<p id="rfc.section.4.10.p.4">The implementation of this command has security implications.  See <a href="#security-considerations">Section 7</a> for more information.  </p>
+<p id="rfc.section.4.10.p.5">This command requires the capability <samp>CAP_PEEK_POKE</samp> to be present.  </p>
+<h1 id="rfc.section.4.11"><a href="#rfc.section.4.11">4.11.</a> <a href="#cmd-peek-ret" id="cmd-peek-ret">CMD 19: (NCP-&gt;Host) CMD_PEEK_RET</a></h1>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+  <thead>
+    <tr>
+      <th class="center">Octets:</th>
+      <th class="center">1</th>
+      <th class="center">1</th>
+      <th class="center">4</th>
+      <th class="center">2</th>
+      <th class="center">n</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="center">Fields:</td>
+      <td class="center">HEADER</td>
+      <td class="center">CMD_PEEK_RET</td>
+      <td class="center">ADDRESS</td>
+      <td class="center">COUNT</td>
+      <td class="center">BYTES</td>
+    </tr>
+  </tbody>
+</table>
+<p id="rfc.section.4.11.p.1">This command contains the contents of memory that was requested by a previous call to <samp>CMD_PEEK</samp>.  </p>
+<p id="rfc.section.4.11.p.2">This command requires the capability <samp>CAP_PEEK_POKE</samp> to be present.  </p>
+<h1 id="rfc.section.4.12"><a href="#rfc.section.4.12">4.12.</a> <a href="#cmd-poke" id="cmd-poke">CMD 20: (Host-&gt;NCP) CMD_POKE</a></h1>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+  <thead>
+    <tr>
+      <th class="center">Octets:</th>
+      <th class="center">1</th>
+      <th class="center">1</th>
+      <th class="center">4</th>
+      <th class="center">2</th>
+      <th class="center">n</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="center">Fields:</td>
+      <td class="center">HEADER</td>
+      <td class="center">CMD_POKE</td>
+      <td class="center">ADDRESS</td>
+      <td class="center">COUNT</td>
+      <td class="center">BYTES</td>
+    </tr>
+  </tbody>
+</table>
+<p id="rfc.section.4.12.p.1">This command writes the bytes to the specified memory address for debugging purposes.  </p>
+<p id="rfc.section.4.12.p.2">Due to the low-level nature of this command, certain error conditions may induce the NCP to reset.  </p>
+<p id="rfc.section.4.12.p.3">The implementation of this command has security implications.  See <a href="#security-considerations">Section 7</a> for more information.  </p>
+<p id="rfc.section.4.12.p.4">This command requires the capability <samp>CAP_PEEK_POKE</samp> to be present.  </p>
 <h1 id="rfc.section.5"><a href="#rfc.section.5">5.</a> <a href="#properties" id="properties">Properties</a></h1>
 <p id="rfc.section.5.p.1">While the majority of the properties that allow the configuration of network connectivity are network protocol specific, there are several properties that are required in all implementations.  </p>
 <p id="rfc.section.5.p.2">Future property allocations SHALL be made from the following allocation plan: </p>
@@ -1652,7 +1740,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 <p/>
 
 <ul>
-  <li>1: ZigBee</li>
+  <li>0: Bootloader</li>
   <li>2: ZigBeeIP</li>
   <li>3: Thread</li>
 </ul>
@@ -1722,6 +1810,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
   <li>4: <samp>CAP_POWER_SAVE</samp></li>
   <li>5: <samp>CAP_COUNTERS</samp></li>
   <li>6: <samp>CAP_JAM_DETECT</samp>: Jamming detection. See <a href="#feature-jam-detect">Appendix D</a></li>
+  <li>7: <samp>CAP_PEEK_POKE</samp>: PEEK/POKE debugging commands.</li>
   <li>16: <samp>CAP_802_15_4_2003</samp></li>
   <li>17: <samp>CAP_802_15_4_2006</samp></li>
   <li>18: <samp>CAP_802_15_4_2011</samp></li>
@@ -1861,7 +1950,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.5.2.9.p.2">The static EUI64 address of the device. This value is read-only, but may be writable under certain vendor-defined circumstances.  </p>
+<p id="rfc.section.5.2.9.p.2">The static EUI64 address of the device, used as a serial number.  This value is read-only, but may be writable under certain vendor-defined circumstances.  </p>
 <h1 id="rfc.section.5.2.10"><a href="#rfc.section.5.2.10">5.2.10.</a> <a href="#prop-lock" id="prop-lock">PROP 9: PROP_LOCK</a></h1>
 <p/>
 
@@ -2597,7 +2686,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 
 <p> </p>
 <h1 id="rfc.section.7"><a href="#rfc.section.7">7.</a> <a href="#security-considerations" id="security-considerations">Security Considerations</a></h1>
-<p id="rfc.section.7.p.1">TBD </p>
+<h1 id="rfc.section.7.1"><a href="#rfc.section.7.1">7.1.</a> <a href="#raw-application-access" id="raw-application-access">Raw Application Access</a></h1>
+<p id="rfc.section.7.1.p.1">Spinel MAY be used as an API boundary for allowing processes to configure the NCP. However, such a system MUST NOT give unprivileged processess the ability to send or receive arbitrary command frames to the NCP. Only the specific commands and properties that are required should be allowed to be passed, and then only after being checked for proper format.  </p>
 <h1 id="rfc.section.8"><a href="#rfc.section.8">8.</a> <a href="#acknowledgments" id="acknowledgments">Acknowledgments</a></h1>
 <p id="rfc.section.8.p.1">Special thanks to Abtin Keshavarzian, Martin Turon, Arjuna Sivasithambaresan and Jonathan Hui for their substantial contributions and feedback related to this document.  </p>
 <p>
@@ -2622,11 +2712,25 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 <p> </p>
 <p id="rfc.section.A.1.p.3">These values may be adjusted depending on the individual needs of the application or product, but some sort of flow control MUST be used.  Hardware flow control is preferred over software flow control. In the absence of hardware flow control, software flow control (XON/XOFF) MUST be used instead.  </p>
 <p id="rfc.section.A.1.p.4">We also <strong>RECOMMEND</strong> an Arduino-style hardware reset, where the DTR signal is coupled to the <samp>R&#773;E&#773;S&#773;</samp> pin through a 0.01&#181;F capacitor. This causes the NCP to automatically reset whenever the serial port is opened. At the very least we <strong>RECOMMEND</strong> dedicating one of your host pins to controlling the <samp>R&#773;E&#773;S&#773;</samp> pin on the NCP, so that you can easily perform a hardware reset if necessary.  </p>
-<h1 id="rfc.appendix.A.1.1"><a href="#rfc.appendix.A.1.1">A.1.1.</a> <a href="#hdlc-lite" id="hdlc-lite">HDLC-Lite</a></h1>
+<h1 id="rfc.appendix.A.1.1"><a href="#rfc.appendix.A.1.1">A.1.1.</a> <a href="#uart-bit-rate-detection" id="uart-bit-rate-detection">UART Bit Rate Detection</a></h1>
+<p id="rfc.section.A.1.1.p.1">When using a UART, the issue of an appropriate bit rate must be considered. A bitrate of 115200 bits per second has become a defacto standard baud rate for many serial peripherals. This rate, however, is slower than the theoretical maximum bitrate of the 802.15.4 2.4GHz PHY (250kbit). In most circumstances this mismatch is not significant because the overall bitrate will be much lower than either of these rates, but there are circumstances where a faster UART bitrate is desirable. Thus, this document proposes a simple bitrate detection scheme that can be employed by the host to detect when the attached NCP is initially running at a higher bitrate.  </p>
+<p id="rfc.section.A.1.1.p.2">The algorithm is to send successive NOOP commands to the NCP at increasing bitrates. When a valid <samp>CMD_LAST_STATUS</samp> response has been received, we have identified the correct bitrate.  </p>
+<p id="rfc.section.A.1.1.p.3">In order to limit the time spent hunting for the appropriate bitrate, we RECOMMEND that only the following bitrates be checked: </p>
+<p/>
+
+<ul>
+  <li>115200</li>
+  <li>230400</li>
+  <li>1000000 (1Mbit)</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.A.1.1.p.5">The bitrate MAY also be changed programmatically by adjusting <samp>PROP_UART_BITRATE</samp>, if implemented.  </p>
+<h1 id="rfc.appendix.A.1.2"><a href="#rfc.appendix.A.1.2">A.1.2.</a> <a href="#hdlc-lite" id="hdlc-lite">HDLC-Lite</a></h1>
 <p><em>HDLC-Lite</em> is the recommended framing protocol for transmitting Spinel frames over a UART. HDLC-Lite consists of only the framing, escaping, and CRC parts of the larger HDLC protocol---all other parts of HDLC are omitted. This protocol was chosen because it works well with software flow control and is widely implemented.  </p>
-<p id="rfc.section.A.1.1.p.2">To transmit a frame with HDLC-lite, the 16-bit CRC must first be appended to the frame. The CRC function is defined to be CRC-16/CCITT, otherwise known as the <a href="http://reveng.sourceforge.net/crc-catalogue/16.htm#crc.cat.kermit">KERMIT CRC</a>.  </p>
-<p id="rfc.section.A.1.1.p.3">Individual frames are terminated with a frame delimiter octet called the 'flag' octet (<samp>0x7E</samp>).  </p>
-<p id="rfc.section.A.1.1.p.4">The following octets values are considered <em>special</em> and should be escaped when present in data frames: </p>
+<p id="rfc.section.A.1.2.p.2">To transmit a frame with HDLC-lite, the 16-bit CRC must first be appended to the frame. The CRC function is defined to be CRC-16/CCITT, otherwise known as the <a href="http://reveng.sourceforge.net/crc-catalogue/16.htm#crc.cat.kermit">KERMIT CRC</a>.  </p>
+<p id="rfc.section.A.1.2.p.3">Individual frames are terminated with a frame delimiter octet called the 'flag' octet (<samp>0x7E</samp>).  </p>
+<p id="rfc.section.A.1.2.p.4">The following octets values are considered <em>special</em> and should be escaped when present in data frames: </p>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <thead>
     <tr>
@@ -2657,10 +2761,10 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.A.1.1.p.5">When present in a data frame, these octet values are escaped by prepending the escape octet (<samp>0x7D</samp>) and XORing the value with <samp>0x20</samp>.  </p>
-<p id="rfc.section.A.1.1.p.6">When receiving a frame, the CRC must be verified after the frame is unescaped. If the CRC value does not match what is calculated for the frame data, the frame MUST be discarded. The implementation MAY indicate the failure to higher levels to handle as they see fit, but MUST NOT attempt to process the deceived frame.  </p>
-<p id="rfc.section.A.1.1.p.7">Consecutive flag octets are entirely legal and MUST NOT be treated as a framing error. Consecutive flag octets MAY be used as a way to wake up a sleeping NCP.  </p>
-<p id="rfc.section.A.1.1.p.8">When first establishing a connection to the NCP, it is customary to send one or more flag octets to ensure that any previously received data is discarded.  </p>
+<p id="rfc.section.A.1.2.p.5">When present in a data frame, these octet values are escaped by prepending the escape octet (<samp>0x7D</samp>) and XORing the value with <samp>0x20</samp>.  </p>
+<p id="rfc.section.A.1.2.p.6">When receiving a frame, the CRC must be verified after the frame is unescaped. If the CRC value does not match what is calculated for the frame data, the frame MUST be discarded. The implementation MAY indicate the failure to higher levels to handle as they see fit, but MUST NOT attempt to process the deceived frame.  </p>
+<p id="rfc.section.A.1.2.p.7">Consecutive flag octets are entirely legal and MUST NOT be treated as a framing error. Consecutive flag octets MAY be used as a way to wake up a sleeping NCP.  </p>
+<p id="rfc.section.A.1.2.p.8">When first establishing a connection to the NCP, it is customary to send one or more flag octets to ensure that any previously received data is discarded.  </p>
 <h1 id="rfc.appendix.A.2"><a href="#rfc.appendix.A.2">A.2.</a> <a href="#spi-recommendations" id="spi-recommendations">SPI Recommendations</a></h1>
 <p id="rfc.section.A.2.p.1">We RECOMMEND the use of the following standard SPI signals: </p>
 <p/>
@@ -2723,26 +2827,34 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 <pre>
   0   1   2   3   4   5   6   7
 +---+---+---+---+---+---+---+---+
-|RST|CRC|    RESERVED   |PATTERN|
+|RST|CRC|CCF|  RESERVED |PATTERN|
 +---+---+---+---+---+---+---+---+
 </pre>
 <p/>
 
 <ul>
   <li><samp>RST</samp>: This bit is set when that device has been reset since the last time <samp>C&#773;S&#773;</samp> was asserted.</li>
-  <li><samp>CRC</samp>: This bit is set when that device supports writing a 16-bit CRC at the end of the data. This CRC is NOT included in DATA_LEN.</li>
+  <li><samp>CRC</samp>: This bit is set when that device supports writing a 16-bit CRC at the end of the data. The CRC length is NOT included in DATA_LEN.</li>
+  <li><samp>CCF</samp>: "CRC Check Failure". Set if the CRC check on the last received frame failed, cleared to zero otherwise. This bit is only used if both sides support CRC.</li>
   <li><samp>RESERVED</samp>: These bits are all reserved for future used. They MUST be cleared to zero and MUST be ignored if set.</li>
   <li><samp>PATTERN</samp>: These bits are set to a fixed value to help distinguish valid SPI frames from garbage (by explicitly making <samp>0xFF</samp> and <samp>0x00</samp> invalid values). Bit 6 MUST be set to be one and bit 7 MUST be cleared (0). A frame received that has any other values for these bits MUST be dropped.</li>
 </ul>
 
 <p> </p>
-<p id="rfc.section.A.2.1.p.5">Prior to a sending or receiving a frame, the master SHOULD send a 5-octet frame with zeros for both the max receive frame size and the the contained frame length. This will induce the slave device to indicate the length of the frame it wants to send (if any) and indicate the largest frame it is capable of receiving at the moment.  This allows the master to calculate the size of the next transaction.  </p>
+<p id="rfc.section.A.2.1.p.5">Prior to a sending or receiving a frame, the master MAY send a 5-octet frame with zeros for both the max receive frame size and the the contained frame length. This will induce the slave device to indicate the length of the frame it wants to send (if any) and indicate the largest frame it is capable of receiving at the moment.  This allows the master to calculate the size of the next transaction.  Alternatively, if the master has a frame to send it can just go ahead and send a frame of that length and determine if the frame was accepted by checking that the <samp>RECV_LEN</samp> from the slave frame is larger than the frame the master just tried to send. If the <samp>RECV_LEN</samp> is smaller then the frame wasn't accepted and will need to be transmitted again.  </p>
 <p id="rfc.section.A.2.1.p.6">This protocol can be used either unidirectionally or bidirectionally, determined by the behavior of the master and the slave.  </p>
 <p id="rfc.section.A.2.1.p.7">If the the master notices <samp>PATTERN</samp> is not set correctly, the master should consider the transaction to have failed and try again after 10 milliseconds, retrying up to 200 times. After unsuccessfully trying 200 times in a row, the master MAY take appropriate remedial action (like a NCP hardware reset, or indicating a communication failure to a user interface).  </p>
+<p id="rfc.section.A.2.1.p.8">At the end of the data of a frame is an optional 16-bit CRC, support for which is indicated by the <samp>CRC</samp> bit of the <samp>HDR</samp> byte being set. If these bits are set for both the master and slave frames, then CRC checking is enabled on both sides, effectively requiring that frame sizes be two bytes longer than would be otherwise required. The CRC is calculated using the same mechanism used for the CRC calculation in HDLC-Lite (See <a href="#hdlc-lite">Appendix A.1.2</a>).  When both of the <samp>CRC</samp> bits are set, both sides must verify that the <samp>CRC</samp> is valid before accepting the frame. If not enough bytes were clocked out for the CRC to be read, then the frame must be ignored. If enough bytes were clocked out to perform a CRC check, but the CRC check fails, then the frame must be rejected and the <samp>CRC_FAIL</samp> bit on the next frame (and ONLY the next frame) MUST be set.  </p>
 <h1 id="rfc.appendix.A.3"><a href="#rfc.appendix.A.3">A.3.</a> <a href="#i2c-recommendations" id="i2c-recommendations">I&#178;C Recommendations</a></h1>
 <p id="rfc.section.A.3.p.1">TBD </p>
+<p>
+  <a id="CREF4" class="info">[CREF4]<span class="info">RQ: It may make sense to have a look at what Bluetooth HCI is doing for native I&#178;C framing and go with that.</span></a>
+</p>
 <h1 id="rfc.appendix.A.4"><a href="#rfc.appendix.A.4">A.4.</a> <a href="#native-usb-recommendations" id="native-usb-recommendations">Native USB Recommendations</a></h1>
 <p id="rfc.section.A.4.p.1">TBD </p>
+<p>
+  <a id="CREF5" class="info">[CREF5]<span class="info">RQ: It may make sense to have a look at what Bluetooth HCI is doing for native USB framing and go with that.</span></a>
+</p>
 <h1 id="rfc.appendix.B"><a href="#rfc.appendix.B">Appendix B.</a> <a href="#feature-network-save" id="feature-network-save">Feature: Network Save</a></h1>
 <p id="rfc.section.B.p.1">The network save feature is an optional NCP capability that, when present, allows the host to save and recall network credentials and state to and from nonvolatile storage.  </p>
 <p id="rfc.section.B.p.2">The presence of this feature can be detected by checking for the presence of the <samp>CAP_NET_SAVE</samp> capability in <samp>PROP_CAPS</samp>.  </p>
@@ -3417,7 +3529,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
   </tbody>
 </table>
 <p>
-  <a id="CREF4" class="info">[CREF4]<span class="info">RQ: The PUI test-vector encodings need to be verified.</span></a>
+  <a id="CREF6" class="info">[CREF6]<span class="info">RQ: The PUI test-vector encodings need to be verified.</span></a>
 </p>
 <h1 id="rfc.appendix.F.2"><a href="#rfc.appendix.F.2">F.2.</a> <a href="#test-vector-reset-command" id="test-vector-reset-command">Test Vector: Reset Command</a></h1>
 <p/>
@@ -3470,12 +3582,12 @@ FE
 <h1 id="rfc.appendix.F.5"><a href="#rfc.appendix.F.5">F.5.</a> <a href="#test-vector-inbound-ipv6-packet" id="test-vector-inbound-ipv6-packet">Test Vector: Inbound IPv6 Packet</a></h1>
 <p id="rfc.section.F.5.p.1">CMD_VALUE_IS(PROP_STREAM_NET) </p>
 <p>
-  <a id="CREF5" class="info">[CREF5]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
+  <a id="CREF7" class="info">[CREF7]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
 </p>
 <h1 id="rfc.appendix.F.6"><a href="#rfc.appendix.F.6">F.6.</a> <a href="#test-vector-outbound-ipv6-packet" id="test-vector-outbound-ipv6-packet">Test Vector: Outbound IPv6 Packet</a></h1>
 <p id="rfc.section.F.6.p.1">CMD_VALUE_SET(PROP_STREAM_NET) </p>
 <p>
-  <a id="CREF6" class="info">[CREF6]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
+  <a id="CREF8" class="info">[CREF8]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
 </p>
 <h1 id="rfc.appendix.F.7"><a href="#rfc.appendix.F.7">F.7.</a> <a href="#test-vector-fetch-list-of-onmesh-networks" id="test-vector-fetch-list-of-onmesh-networks">Test Vector: Fetch list of on-mesh networks</a></h1>
 <p/>
@@ -3570,7 +3682,7 @@ FE
 01 ?? 01
 </pre>
 <p>
-  <a id="CREF7" class="info">[CREF7]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
+  <a id="CREF9" class="info">[CREF9]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
 </p>
 <h1 id="rfc.appendix.F.10"><a href="#rfc.appendix.F.10">F.10.</a> <a href="#test-vector-insertion-notification-of-an-onmesh-network" id="test-vector-insertion-notification-of-an-onmesh-network">Test Vector: Insertion notification of an on-mesh network</a></h1>
 <p/>
@@ -3608,7 +3720,7 @@ FE
 01 ?? 01
 </pre>
 <p>
-  <a id="CREF8" class="info">[CREF8]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
+  <a id="CREF10" class="info">[CREF10]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
 </p>
 <h1 id="rfc.appendix.F.11"><a href="#rfc.appendix.F.11">F.11.</a> <a href="#test-vector-removing-a-local-onmesh-network" id="test-vector-removing-a-local-onmesh-network">Test Vector: Removing a local on-mesh network</a></h1>
 <p/>
@@ -3645,7 +3757,7 @@ FE
 <h1 id="rfc.appendix.G"><a href="#rfc.appendix.G">Appendix G.</a> <a href="#example-sessions" id="example-sessions">Example Sessions</a></h1>
 <h1 id="rfc.appendix.G.1"><a href="#rfc.appendix.G.1">G.1.</a> <a href="#ncp-initialization" id="ncp-initialization">NCP Initialization</a></h1>
 <p>
-  <a id="CREF9" class="info">[CREF9]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF11" class="info">[CREF11]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p id="rfc.section.G.1.p.2">Check the protocol version to see if it is supported: </p>
 <p/>
@@ -3702,7 +3814,7 @@ FE
 <p> </p>
 <h1 id="rfc.appendix.G.2"><a href="#rfc.appendix.G.2">G.2.</a> <a href="#attaching-to-a-network" id="attaching-to-a-network">Attaching to a network</a></h1>
 <p>
-  <a id="CREF10" class="info">[CREF10]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF12" class="info">[CREF12]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p id="rfc.section.G.2.p.2">We make the assumption that the NCP is not currently associated with a network.  </p>
 <p id="rfc.section.G.2.p.3">Set the network properties, if they were not already set: </p>
@@ -3756,7 +3868,7 @@ FE
 <p> </p>
 <h1 id="rfc.appendix.G.3"><a href="#rfc.appendix.G.3">G.3.</a> <a href="#successfully-joining-a-preexisting-network" id="successfully-joining-a-preexisting-network">Successfully joining a pre-existing network</a></h1>
 <p>
-  <a id="CREF11" class="info">[CREF11]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF13" class="info">[CREF13]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p id="rfc.section.G.3.p.2">This example session is identical to the above session up to the point where we set PROP_NET_IF_UP to true. From there, the behavior changes.  </p>
 <p/>
@@ -3826,7 +3938,7 @@ FE
 <p id="rfc.section.G.5.p.1">TBD </p>
 <h1 id="rfc.appendix.G.6"><a href="#rfc.appendix.G.6">G.6.</a> <a href="#attaching-to-a-saved-network" id="attaching-to-a-saved-network">Attaching to a saved network</a></h1>
 <p>
-  <a id="CREF12" class="info">[CREF12]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF14" class="info">[CREF14]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p id="rfc.section.G.6.p.2">Recall the saved network if you haven't already done so: </p>
 <p/>
@@ -3866,7 +3978,7 @@ FE
 <p> </p>
 <h1 id="rfc.appendix.G.7"><a href="#rfc.appendix.G.7">G.7.</a> <a href="#ncp-software-reset" id="ncp-software-reset">NCP Software Reset</a></h1>
 <p>
-  <a id="CREF13" class="info">[CREF13]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF15" class="info">[CREF15]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p/>
 
@@ -3883,7 +3995,7 @@ FE
 <p id="rfc.section.G.9.p.1">TBD </p>
 <h1 id="rfc.appendix.G.10"><a href="#rfc.appendix.G.10">G.10.</a> <a href="#sniffing-raw-packets" id="sniffing-raw-packets">Sniffing raw packets</a></h1>
 <p>
-  <a id="CREF14" class="info">[CREF14]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF16" class="info">[CREF16]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p id="rfc.section.G.10.p.2">This assumes that the NCP has been initialized.  </p>
 <p id="rfc.section.G.10.p.3">Optionally set the channel: </p>
@@ -3935,7 +4047,7 @@ FE
 <p id="rfc.section.G.10.p.13">This mode may be entered even when associated with a network.  In that case, you should set <samp>PROP_MAC_PROMISCUOUS_MODE</samp> to <samp>MAC_PROMISCUOUS_MODE_PROMISCUOUS</samp> or <samp>MAC_PROMISCUOUS_MODE_NORMAL</samp>, so that you can avoid receiving packets from other networks or that are destined for other nodes.  </p>
 <h1 id="rfc.appendix.H"><a href="#rfc.appendix.H">Appendix H.</a> <a href="#glossary" id="glossary">Glossary</a></h1>
 <p>
-  <a id="CREF15" class="info">[CREF15]<span class="info">RQ: Alphabetize before finalization.</span></a>
+  <a id="CREF17" class="info">[CREF17]<span class="info">RQ: Alphabetize before finalization.</span></a>
 </p>
 <p/>
 

--- a/doc/draft-spinel-protocol.txt
+++ b/doc/draft-spinel-protocol.txt
@@ -8,7 +8,7 @@
 
 
                     Spinel Host-Controller Protocol
-                    draft-spinel-protocol-4fce7582b
+                    draft-spinel-protocol-f9bf43254
 
 Abstract
 
@@ -55,7 +55,7 @@ Copyright Notice
 
 Quattlebaum                Expires May 8, 2017                  [Page 1]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
@@ -67,7 +67,7 @@ Quattlebaum                Expires May 8, 2017                  [Page 1]
 
 Table of Contents
 
-   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   5
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   6
      1.1.  About this Draft  . . . . . . . . . . . . . . . . . . . .   6
        1.1.1.  Renumbering . . . . . . . . . . . . . . . . . . . . .   6
        1.1.2.  Spinel as Application API . . . . . . . . . . . . . .   7
@@ -98,189 +98,195 @@ Table of Contents
      4.7.  CMD 6: (NCP->Host) CMD_PROP_VALUE_IS  . . . . . . . . . .  18
      4.8.  CMD 7: (NCP->Host) CMD_PROP_VALUE_INSERTED  . . . . . . .  19
      4.9.  CMD 8: (NCP->Host) CMD_PROP_VALUE_REMOVED . . . . . . . .  19
-   5.  Properties  . . . . . . . . . . . . . . . . . . . . . . . . .  20
-     5.1.  Property Sections . . . . . . . . . . . . . . . . . . . .  20
-     5.2.  Core Properties . . . . . . . . . . . . . . . . . . . . .  21
-       5.2.1.  PROP 0: PROP_LAST_STATUS  . . . . . . . . . . . . . .  21
-       5.2.2.  PROP 1: PROP_PROTOCOL_VERSION . . . . . . . . . . . .  21
-       5.2.3.  PROP 2: PROP_NCP_VERSION  . . . . . . . . . . . . . .  22
-       5.2.4.  PROP 3: PROP_INTERFACE_TYPE . . . . . . . . . . . . .  22
-       5.2.5.  PROP 4: PROP_INTERFACE_VENDOR_ID  . . . . . . . . . .  23
+     4.10. CMD 18: (Host->NCP) CMD_PEEK  . . . . . . . . . . . . . .  20
+     4.11. CMD 19: (NCP->Host) CMD_PEEK_RET  . . . . . . . . . . . .  20
+     4.12. CMD 20: (Host->NCP) CMD_POKE  . . . . . . . . . . . . . .  20
+   5.  Properties  . . . . . . . . . . . . . . . . . . . . . . . . .  21
+     5.1.  Property Sections . . . . . . . . . . . . . . . . . . . .  21
+     5.2.  Core Properties . . . . . . . . . . . . . . . . . . . . .  22
+       5.2.1.  PROP 0: PROP_LAST_STATUS  . . . . . . . . . . . . . .  22
+       5.2.2.  PROP 1: PROP_PROTOCOL_VERSION . . . . . . . . . . . .  22
 
 
 
 Quattlebaum                Expires May 8, 2017                  [Page 2]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
-       5.2.6.  PROP 5: PROP_CAPS . . . . . . . . . . . . . . . . . .  23
-       5.2.7.  PROP 6: PROP_INTERFACE_COUNT  . . . . . . . . . . . .  24
-       5.2.8.  PROP 7: PROP_POWER_STATE  . . . . . . . . . . . . . .  25
-       5.2.9.  PROP 8: PROP_HWADDR . . . . . . . . . . . . . . . . .  25
-       5.2.10. PROP 9: PROP_LOCK . . . . . . . . . . . . . . . . . .  26
-     5.3.  Stream Properties . . . . . . . . . . . . . . . . . . . .  26
-       5.3.1.  PROP 112: PROP_STREAM_DEBUG . . . . . . . . . . . . .  26
-       5.3.2.  PROP 113: PROP_STREAM_RAW . . . . . . . . . . . . . .  27
-       5.3.3.  PROP 114: PROP_STREAM_NET . . . . . . . . . . . . . .  28
-       5.3.4.  PROP 114: PROP_STREAM_NET_INSECURE  . . . . . . . . .  29
-     5.4.  PHY Properties  . . . . . . . . . . . . . . . . . . . . .  29
-       5.4.1.  PROP 32: PROP_PHY_ENABLED . . . . . . . . . . . . . .  29
-       5.4.2.  PROP 33: PROP_PHY_CHAN  . . . . . . . . . . . . . . .  30
-       5.4.3.  PROP 34: PROP_PHY_CHAN_SUPPORTED  . . . . . . . . . .  30
-       5.4.4.  PROP 35: PROP_PHY_FREQ  . . . . . . . . . . . . . . .  30
-       5.4.5.  PROP 36: PROP_PHY_CCA_THRESHOLD . . . . . . . . . . .  30
-       5.4.6.  PROP 37: PROP_PHY_TX_POWER  . . . . . . . . . . . . .  30
-       5.4.7.  PROP 38: PROP_PHY_RSSI  . . . . . . . . . . . . . . .  31
-     5.5.  MAC Properties  . . . . . . . . . . . . . . . . . . . . .  31
-       5.5.1.  PROP 48: PROP_MAC_SCAN_STATE  . . . . . . . . . . . .  31
-       5.5.2.  PROP 49: PROP_MAC_SCAN_MASK . . . . . . . . . . . . .  31
-       5.5.3.  PROP 50: PROP_MAC_SCAN_PERIOD . . . . . . . . . . . .  31
-       5.5.4.  PROP 51: PROP_MAC_SCAN_BEACON . . . . . . . . . . . .  32
-       5.5.5.  PROP 52: PROP_MAC_15_4_LADDR  . . . . . . . . . . . .  32
-       5.5.6.  PROP 53: PROP_MAC_15_4_SADDR  . . . . . . . . . . . .  33
-       5.5.7.  PROP 54: PROP_MAC_15_4_PANID  . . . . . . . . . . . .  33
-       5.5.8.  PROP 55: PROP_MAC_RAW_STREAM_ENABLED  . . . . . . . .  33
-       5.5.9.  PROP 56: PROP_MAC_PROMISCUOUS_MODE  . . . . . . . . .  33
-       5.5.10. PROP 4864: PROP_MAC_WHITELIST . . . . . . . . . . . .  34
-       5.5.11. PROP 4865: PROP_MAC_WHITELIST_ENABLED . . . . . . . .  34
-     5.6.  NET Properties  . . . . . . . . . . . . . . . . . . . . .  34
-       5.6.1.  PROP 64: PROP_NET_SAVED . . . . . . . . . . . . . . .  34
-       5.6.2.  PROP 65: PROP_NET_IF_UP . . . . . . . . . . . . . . .  34
-       5.6.3.  PROP 66: PROP_NET_STACK_UP  . . . . . . . . . . . . .  34
-       5.6.4.  PROP 67: PROP_NET_ROLE  . . . . . . . . . . . . . . .  35
-       5.6.5.  PROP 68: PROP_NET_NETWORK_NAME  . . . . . . . . . . .  35
-       5.6.6.  PROP 69: PROP_NET_XPANID  . . . . . . . . . . . . . .  35
-       5.6.7.  PROP 70: PROP_NET_MASTER_KEY  . . . . . . . . . . . .  35
-       5.6.8.  PROP 71: PROP_NET_KEY_SEQUENCE_COUNTER  . . . . . . .  35
-       5.6.9.  PROP 72: PROP_NET_PARTITION_ID  . . . . . . . . . . .  35
-       5.6.10. PROP 73: PROP_NET_KEY_SWITCH_GUARDTIME  . . . . . . .  35
-     5.7.  IPv6 Properties . . . . . . . . . . . . . . . . . . . . .  36
-       5.7.1.  PROP 96: PROP_IPV6_LL_ADDR  . . . . . . . . . . . . .  36
-       5.7.2.  PROP 97: PROP_IPV6_ML_ADDR  . . . . . . . . . . . . .  36
-       5.7.3.  PROP 98: PROP_IPV6_ML_PREFIX  . . . . . . . . . . . .  36
-       5.7.4.  PROP 99: PROP_IPV6_ADDRESS_TABLE  . . . . . . . . . .  36
-       5.7.5.  PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD . . . . . . . .  36
-   6.  Status Codes  . . . . . . . . . . . . . . . . . . . . . . . .  37
+       5.2.3.  PROP 2: PROP_NCP_VERSION  . . . . . . . . . . . . . .  23
+       5.2.4.  PROP 3: PROP_INTERFACE_TYPE . . . . . . . . . . . . .  23
+       5.2.5.  PROP 4: PROP_INTERFACE_VENDOR_ID  . . . . . . . . . .  24
+       5.2.6.  PROP 5: PROP_CAPS . . . . . . . . . . . . . . . . . .  24
+       5.2.7.  PROP 6: PROP_INTERFACE_COUNT  . . . . . . . . . . . .  25
+       5.2.8.  PROP 7: PROP_POWER_STATE  . . . . . . . . . . . . . .  26
+       5.2.9.  PROP 8: PROP_HWADDR . . . . . . . . . . . . . . . . .  26
+       5.2.10. PROP 9: PROP_LOCK . . . . . . . . . . . . . . . . . .  27
+     5.3.  Stream Properties . . . . . . . . . . . . . . . . . . . .  27
+       5.3.1.  PROP 112: PROP_STREAM_DEBUG . . . . . . . . . . . . .  27
+       5.3.2.  PROP 113: PROP_STREAM_RAW . . . . . . . . . . . . . .  28
+       5.3.3.  PROP 114: PROP_STREAM_NET . . . . . . . . . . . . . .  29
+       5.3.4.  PROP 114: PROP_STREAM_NET_INSECURE  . . . . . . . . .  30
+     5.4.  PHY Properties  . . . . . . . . . . . . . . . . . . . . .  31
+       5.4.1.  PROP 32: PROP_PHY_ENABLED . . . . . . . . . . . . . .  31
+       5.4.2.  PROP 33: PROP_PHY_CHAN  . . . . . . . . . . . . . . .  31
+       5.4.3.  PROP 34: PROP_PHY_CHAN_SUPPORTED  . . . . . . . . . .  31
+       5.4.4.  PROP 35: PROP_PHY_FREQ  . . . . . . . . . . . . . . .  31
+       5.4.5.  PROP 36: PROP_PHY_CCA_THRESHOLD . . . . . . . . . . .  31
+       5.4.6.  PROP 37: PROP_PHY_TX_POWER  . . . . . . . . . . . . .  32
+       5.4.7.  PROP 38: PROP_PHY_RSSI  . . . . . . . . . . . . . . .  32
+     5.5.  MAC Properties  . . . . . . . . . . . . . . . . . . . . .  32
+       5.5.1.  PROP 48: PROP_MAC_SCAN_STATE  . . . . . . . . . . . .  32
+       5.5.2.  PROP 49: PROP_MAC_SCAN_MASK . . . . . . . . . . . . .  33
+       5.5.3.  PROP 50: PROP_MAC_SCAN_PERIOD . . . . . . . . . . . .  33
+       5.5.4.  PROP 51: PROP_MAC_SCAN_BEACON . . . . . . . . . . . .  33
+       5.5.5.  PROP 52: PROP_MAC_15_4_LADDR  . . . . . . . . . . . .  34
+       5.5.6.  PROP 53: PROP_MAC_15_4_SADDR  . . . . . . . . . . . .  34
+       5.5.7.  PROP 54: PROP_MAC_15_4_PANID  . . . . . . . . . . . .  34
+       5.5.8.  PROP 55: PROP_MAC_RAW_STREAM_ENABLED  . . . . . . . .  34
+       5.5.9.  PROP 56: PROP_MAC_PROMISCUOUS_MODE  . . . . . . . . .  34
+       5.5.10. PROP 4864: PROP_MAC_WHITELIST . . . . . . . . . . . .  35
+       5.5.11. PROP 4865: PROP_MAC_WHITELIST_ENABLED . . . . . . . .  35
+     5.6.  NET Properties  . . . . . . . . . . . . . . . . . . . . .  35
+       5.6.1.  PROP 64: PROP_NET_SAVED . . . . . . . . . . . . . . .  35
+       5.6.2.  PROP 65: PROP_NET_IF_UP . . . . . . . . . . . . . . .  35
+       5.6.3.  PROP 66: PROP_NET_STACK_UP  . . . . . . . . . . . . .  36
+       5.6.4.  PROP 67: PROP_NET_ROLE  . . . . . . . . . . . . . . .  36
+       5.6.5.  PROP 68: PROP_NET_NETWORK_NAME  . . . . . . . . . . .  36
+       5.6.6.  PROP 69: PROP_NET_XPANID  . . . . . . . . . . . . . .  36
+       5.6.7.  PROP 70: PROP_NET_MASTER_KEY  . . . . . . . . . . . .  36
+       5.6.8.  PROP 71: PROP_NET_KEY_SEQUENCE_COUNTER  . . . . . . .  36
+       5.6.9.  PROP 72: PROP_NET_PARTITION_ID  . . . . . . . . . . .  37
+       5.6.10. PROP 73: PROP_NET_KEY_SWITCH_GUARDTIME  . . . . . . .  37
+     5.7.  IPv6 Properties . . . . . . . . . . . . . . . . . . . . .  37
+       5.7.1.  PROP 96: PROP_IPV6_LL_ADDR  . . . . . . . . . . . . .  37
+       5.7.2.  PROP 97: PROP_IPV6_ML_ADDR  . . . . . . . . . . . . .  37
+       5.7.3.  PROP 98: PROP_IPV6_ML_PREFIX  . . . . . . . . . . . .  37
 
 
 
 Quattlebaum                Expires May 8, 2017                  [Page 3]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  38
-   8.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  38
-     9.1.  URIs  . . . . . . . . . . . . . . . . . . . . . . . . . .  38
-   Appendix A.  Framing Protocol . . . . . . . . . . . . . . . . . .  39
-     A.1.  UART Recommendations  . . . . . . . . . . . . . . . . . .  39
-       A.1.1.  HDLC-Lite . . . . . . . . . . . . . . . . . . . . . .  39
-     A.2.  SPI Recommendations . . . . . . . . . . . . . . . . . . .  40
-       A.2.1.  SPI Framing Protocol  . . . . . . . . . . . . . . . .  41
-     A.3.  I^2C Recommendations  . . . . . . . . . . . . . . . . . .  42
-     A.4.  Native USB Recommendations  . . . . . . . . . . . . . . .  42
-   Appendix B.  Feature: Network Save  . . . . . . . . . . . . . . .  42
-     B.1.  Commands  . . . . . . . . . . . . . . . . . . . . . . . .  42
-       B.1.1.  CMD 9: (Host->NCP) CMD_NET_SAVE . . . . . . . . . . .  43
-       B.1.2.  CMD 10: (Host->NCP) CMD_NET_CLEAR . . . . . . . . . .  43
-       B.1.3.  CMD 11: (Host->NCP) CMD_NET_RECALL  . . . . . . . . .  43
-   Appendix C.  Feature: Host Buffer Offload . . . . . . . . . . . .  44
-     C.1.  Commands  . . . . . . . . . . . . . . . . . . . . . . . .  44
-       C.1.1.  CMD 12: (NCP->Host) CMD_HBO_OFFLOAD . . . . . . . . .  44
-       C.1.2.  CMD 13: (NCP->Host) CMD_HBO_RECLAIM . . . . . . . . .  45
-       C.1.3.  CMD 14: (NCP->Host) CMD_HBO_DROP  . . . . . . . . . .  45
-       C.1.4.  CMD 15: (Host->NCP) CMD_HBO_OFFLOADED . . . . . . . .  45
-       C.1.5.  CMD 16: (Host->NCP) CMD_HBO_RECLAIMED . . . . . . . .  45
-       C.1.6.  CMD 17: (Host->NCP) CMD_HBO_DROPPED . . . . . . . . .  45
-     C.2.  Properties  . . . . . . . . . . . . . . . . . . . . . . .  45
-       C.2.1.  PROP 10: PROP_HBO_MEM_MAX . . . . . . . . . . . . . .  45
-       C.2.2.  PROP 11: PROP_HBO_BLOCK_MAX . . . . . . . . . . . . .  46
-   Appendix D.  Feature: Jam Detection . . . . . . . . . . . . . . .  46
-     D.1.  Properties  . . . . . . . . . . . . . . . . . . . . . . .  46
-       D.1.1.  PROP 4608: PROP_JAM_DETECT_ENABLE . . . . . . . . . .  46
-       D.1.2.  PROP 4609: PROP_JAM_DETECTED  . . . . . . . . . . . .  47
-       D.1.3.  PROP 4610: PROP_JAM_DETECT_RSSI_THRESHOLD . . . . . .  47
-       D.1.4.  PROP 4611: PROP_JAM_DETECT_WINDOW . . . . . . . . . .  47
-       D.1.5.  PROP 4612: PROP_JAM_DETECT_BUSY . . . . . . . . . . .  48
-   Appendix E.  Technology: Thread . . . . . . . . . . . . . . . . .  48
-     E.1.  Thread Capabilities . . . . . . . . . . . . . . . . . . .  48
-     E.2.  Thread Properties . . . . . . . . . . . . . . . . . . . .  49
-       E.2.1.  PROP 80: PROP_THREAD_LEADER_ADDR  . . . . . . . . . .  49
-       E.2.2.  PROP 81: PROP_THREAD_PARENT . . . . . . . . . . . . .  49
-       E.2.3.  PROP 82: PROP_THREAD_CHILD_TABLE  . . . . . . . . . .  49
-       E.2.4.  PROP 83: PROP_THREAD_LEADER_RID . . . . . . . . . . .  49
-       E.2.5.  PROP 84: PROP_THREAD_LEADER_WEIGHT  . . . . . . . . .  49
-       E.2.6.  PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT  . . . . . .  49
-       E.2.7.  PROP 86: PROP_THREAD_NETWORK_DATA . . . . . . . . . .  50
-       E.2.8.  PROP 87: PROP_THREAD_NETWORK_DATA_VERSION . . . . . .  50
-       E.2.9.  PROP 88: PROP_THREAD_STABLE_NETWORK_DATA  . . . . . .  50
-       E.2.10. PROP 89: PROP_THREAD_STABLE_NETWORK_DATA_VERSION  . .  50
-       E.2.11. PROP 90: PROP_THREAD_ON_MESH_NETS . . . . . . . . . .  50
-       E.2.12. PROP 91: PROP_THREAD_LOCAL_ROUTES . . . . . . . . . .  50
+       5.7.4.  PROP 99: PROP_IPV6_ADDRESS_TABLE  . . . . . . . . . .  37
+       5.7.5.  PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD . . . . . . . .  38
+   6.  Status Codes  . . . . . . . . . . . . . . . . . . . . . . . .  38
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  39
+     7.1.  Raw Application Access  . . . . . . . . . . . . . . . . .  39
+   8.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  40
+     9.1.  URIs  . . . . . . . . . . . . . . . . . . . . . . . . . .  40
+   Appendix A.  Framing Protocol . . . . . . . . . . . . . . . . . .  40
+     A.1.  UART Recommendations  . . . . . . . . . . . . . . . . . .  40
+       A.1.1.  UART Bit Rate Detection . . . . . . . . . . . . . . .  41
+       A.1.2.  HDLC-Lite . . . . . . . . . . . . . . . . . . . . . .  41
+     A.2.  SPI Recommendations . . . . . . . . . . . . . . . . . . .  42
+       A.2.1.  SPI Framing Protocol  . . . . . . . . . . . . . . . .  43
+     A.3.  I^2C Recommendations  . . . . . . . . . . . . . . . . . .  45
+     A.4.  Native USB Recommendations  . . . . . . . . . . . . . . .  45
+   Appendix B.  Feature: Network Save  . . . . . . . . . . . . . . .  45
+     B.1.  Commands  . . . . . . . . . . . . . . . . . . . . . . . .  45
+       B.1.1.  CMD 9: (Host->NCP) CMD_NET_SAVE . . . . . . . . . . .  45
+       B.1.2.  CMD 10: (Host->NCP) CMD_NET_CLEAR . . . . . . . . . .  46
+       B.1.3.  CMD 11: (Host->NCP) CMD_NET_RECALL  . . . . . . . . .  46
+   Appendix C.  Feature: Host Buffer Offload . . . . . . . . . . . .  46
+     C.1.  Commands  . . . . . . . . . . . . . . . . . . . . . . . .  47
+       C.1.1.  CMD 12: (NCP->Host) CMD_HBO_OFFLOAD . . . . . . . . .  47
+       C.1.2.  CMD 13: (NCP->Host) CMD_HBO_RECLAIM . . . . . . . . .  47
+       C.1.3.  CMD 14: (NCP->Host) CMD_HBO_DROP  . . . . . . . . . .  47
+       C.1.4.  CMD 15: (Host->NCP) CMD_HBO_OFFLOADED . . . . . . . .  47
+       C.1.5.  CMD 16: (Host->NCP) CMD_HBO_RECLAIMED . . . . . . . .  47
+       C.1.6.  CMD 17: (Host->NCP) CMD_HBO_DROPPED . . . . . . . . .  48
+     C.2.  Properties  . . . . . . . . . . . . . . . . . . . . . . .  48
+       C.2.1.  PROP 10: PROP_HBO_MEM_MAX . . . . . . . . . . . . . .  48
+       C.2.2.  PROP 11: PROP_HBO_BLOCK_MAX . . . . . . . . . . . . .  48
+   Appendix D.  Feature: Jam Detection . . . . . . . . . . . . . . .  49
+     D.1.  Properties  . . . . . . . . . . . . . . . . . . . . . . .  49
+       D.1.1.  PROP 4608: PROP_JAM_DETECT_ENABLE . . . . . . . . . .  49
+       D.1.2.  PROP 4609: PROP_JAM_DETECTED  . . . . . . . . . . . .  49
+       D.1.3.  PROP 4610: PROP_JAM_DETECT_RSSI_THRESHOLD . . . . . .  50
+       D.1.4.  PROP 4611: PROP_JAM_DETECT_WINDOW . . . . . . . . . .  50
+       D.1.5.  PROP 4612: PROP_JAM_DETECT_BUSY . . . . . . . . . . .  50
+   Appendix E.  Technology: Thread . . . . . . . . . . . . . . . . .  50
+     E.1.  Thread Capabilities . . . . . . . . . . . . . . . . . . .  51
+     E.2.  Thread Properties . . . . . . . . . . . . . . . . . . . .  51
+       E.2.1.  PROP 80: PROP_THREAD_LEADER_ADDR  . . . . . . . . . .  51
+       E.2.2.  PROP 81: PROP_THREAD_PARENT . . . . . . . . . . . . .  51
+       E.2.3.  PROP 82: PROP_THREAD_CHILD_TABLE  . . . . . . . . . .  51
+       E.2.4.  PROP 83: PROP_THREAD_LEADER_RID . . . . . . . . . . .  52
+       E.2.5.  PROP 84: PROP_THREAD_LEADER_WEIGHT  . . . . . . . . .  52
+       E.2.6.  PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT  . . . . . .  52
+       E.2.7.  PROP 86: PROP_THREAD_NETWORK_DATA . . . . . . . . . .  52
 
 
 
 Quattlebaum                Expires May 8, 2017                  [Page 4]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
-       E.2.13. PROP 92: PROP_THREAD_ASSISTING_PORTS  . . . . . . . .  51
-       E.2.14. PROP 93: PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE  . .  51
-       E.2.15. PROP 94: PROP_THREAD_MODE . . . . . . . . . . . . . .  51
-       E.2.16. PROP 5376: PROP_THREAD_CHILD_TIMEOUT  . . . . . . . .  51
-       E.2.17. PROP 5377: PROP_THREAD_RLOC16 . . . . . . . . . . . .  51
-       E.2.18. PROP 5378: PROP_THREAD_ROUTER_UPGRADE_THRESHOLD . . .  51
-       E.2.19. PROP 5379: PROP_THREAD_CONTEXT_REUSE_DELAY  . . . . .  51
-       E.2.20. PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT . . . . . .  52
-       E.2.21. PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS  . . . . . .  52
-       E.2.22. PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU  . . . .  52
-       E.2.23. PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED . .  52
-       E.2.24. PROP 5384: PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD . .  52
-       E.2.25. PROP 5385: PROP_THREAD_ROUTER_SELECTION_JITTER  . . .  52
-       E.2.26. PROP 5386: PROP_THREAD_PREFERRED_ROUTER_ID  . . . . .  53
-       E.2.27. PROP 5387: SPINEL_PROP_THREAD_NEIGHBOR_TABLE  . . . .  53
-   Appendix F.  Test Vectors . . . . . . . . . . . . . . . . . . . .  53
-     F.1.  Test Vector: Packed Unsigned Integer  . . . . . . . . . .  53
-     F.2.  Test Vector: Reset Command  . . . . . . . . . . . . . . .  54
-     F.3.  Test Vector: Reset Notification . . . . . . . . . . . . .  54
-     F.4.  Test Vector: Scan Beacon  . . . . . . . . . . . . . . . .  54
-     F.5.  Test Vector: Inbound IPv6 Packet  . . . . . . . . . . . .  55
-     F.6.  Test Vector: Outbound IPv6 Packet . . . . . . . . . . . .  55
-     F.7.  Test Vector: Fetch list of on-mesh networks . . . . . . .  55
-     F.8.  Test Vector: Returned list of on-mesh networks  . . . . .  55
-     F.9.  Test Vector: Adding an on-mesh network  . . . . . . . . .  56
-     F.10. Test Vector: Insertion notification of an on-mesh network  56
-     F.11. Test Vector: Removing a local on-mesh network . . . . . .  56
-     F.12. Test Vector: Removal notification of an on-mesh network .  57
-   Appendix G.  Example Sessions . . . . . . . . . . . . . . . . . .  57
-     G.1.  NCP Initialization  . . . . . . . . . . . . . . . . . . .  57
-     G.2.  Attaching to a network  . . . . . . . . . . . . . . . . .  58
-     G.3.  Successfully joining a pre-existing network . . . . . . .  59
-     G.4.  Unsuccessfully joining a pre-existing network . . . . . .  59
-     G.5.  Detaching from a network  . . . . . . . . . . . . . . . .  60
-     G.6.  Attaching to a saved network  . . . . . . . . . . . . . .  60
-     G.7.  NCP Software Reset  . . . . . . . . . . . . . . . . . . .  60
-     G.8.  Adding an on-mesh prefix  . . . . . . . . . . . . . . . .  60
-     G.9.  Entering low-power modes  . . . . . . . . . . . . . . . .  60
-     G.10. Sniffing raw packets  . . . . . . . . . . . . . . . . . .  61
-   Appendix H.  Glossary . . . . . . . . . . . . . . . . . . . . . .  61
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  63
+       E.2.8.  PROP 87: PROP_THREAD_NETWORK_DATA_VERSION . . . . . .  52
+       E.2.9.  PROP 88: PROP_THREAD_STABLE_NETWORK_DATA  . . . . . .  52
+       E.2.10. PROP 89: PROP_THREAD_STABLE_NETWORK_DATA_VERSION  . .  52
+       E.2.11. PROP 90: PROP_THREAD_ON_MESH_NETS . . . . . . . . . .  52
+       E.2.12. PROP 91: PROP_THREAD_LOCAL_ROUTES . . . . . . . . . .  53
+       E.2.13. PROP 92: PROP_THREAD_ASSISTING_PORTS  . . . . . . . .  53
+       E.2.14. PROP 93: PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE  . .  53
+       E.2.15. PROP 94: PROP_THREAD_MODE . . . . . . . . . . . . . .  53
+       E.2.16. PROP 5376: PROP_THREAD_CHILD_TIMEOUT  . . . . . . . .  53
+       E.2.17. PROP 5377: PROP_THREAD_RLOC16 . . . . . . . . . . . .  54
+       E.2.18. PROP 5378: PROP_THREAD_ROUTER_UPGRADE_THRESHOLD . . .  54
+       E.2.19. PROP 5379: PROP_THREAD_CONTEXT_REUSE_DELAY  . . . . .  54
+       E.2.20. PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT . . . . . .  54
+       E.2.21. PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS  . . . . . .  54
+       E.2.22. PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU  . . . .  54
+       E.2.23. PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED . .  54
+       E.2.24. PROP 5384: PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD . .  55
+       E.2.25. PROP 5385: PROP_THREAD_ROUTER_SELECTION_JITTER  . . .  55
+       E.2.26. PROP 5386: PROP_THREAD_PREFERRED_ROUTER_ID  . . . . .  55
+       E.2.27. PROP 5387: SPINEL_PROP_THREAD_NEIGHBOR_TABLE  . . . .  55
+   Appendix F.  Test Vectors . . . . . . . . . . . . . . . . . . . .  56
+     F.1.  Test Vector: Packed Unsigned Integer  . . . . . . . . . .  56
+     F.2.  Test Vector: Reset Command  . . . . . . . . . . . . . . .  56
+     F.3.  Test Vector: Reset Notification . . . . . . . . . . . . .  56
+     F.4.  Test Vector: Scan Beacon  . . . . . . . . . . . . . . . .  56
+     F.5.  Test Vector: Inbound IPv6 Packet  . . . . . . . . . . . .  57
+     F.6.  Test Vector: Outbound IPv6 Packet . . . . . . . . . . . .  57
+     F.7.  Test Vector: Fetch list of on-mesh networks . . . . . . .  57
+     F.8.  Test Vector: Returned list of on-mesh networks  . . . . .  58
+     F.9.  Test Vector: Adding an on-mesh network  . . . . . . . . .  58
+     F.10. Test Vector: Insertion notification of an on-mesh network  58
+     F.11. Test Vector: Removing a local on-mesh network . . . . . .  59
+     F.12. Test Vector: Removal notification of an on-mesh network .  59
+   Appendix G.  Example Sessions . . . . . . . . . . . . . . . . . .  59
+     G.1.  NCP Initialization  . . . . . . . . . . . . . . . . . . .  59
+     G.2.  Attaching to a network  . . . . . . . . . . . . . . . . .  60
+     G.3.  Successfully joining a pre-existing network . . . . . . .  61
+     G.4.  Unsuccessfully joining a pre-existing network . . . . . .  62
+     G.5.  Detaching from a network  . . . . . . . . . . . . . . . .  62
+     G.6.  Attaching to a saved network  . . . . . . . . . . . . . .  62
+     G.7.  NCP Software Reset  . . . . . . . . . . . . . . . . . . .  63
+     G.8.  Adding an on-mesh prefix  . . . . . . . . . . . . . . . .  63
+     G.9.  Entering low-power modes  . . . . . . . . . . . . . . . .  63
+     G.10. Sniffing raw packets  . . . . . . . . . . . . . . . . . .  63
+   Appendix H.  Glossary . . . . . . . . . . . . . . . . . . . . . .  64
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  65
 
-1.  Introduction
-
-   This Network Control Processor (NCP) protocol was designed to enable
-   a host device to communicate with and manage a NCP while also
-   achieving the following goals:
 
 
 
 
 Quattlebaum                Expires May 8, 2017                  [Page 5]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
+
+1.  Introduction
+
+   This Network Control Processor (NCP) protocol was designed to enable
+   a host device to communicate with and manage a NCP while also
+   achieving the following goals:
 
    o  Adopt a layered approach to the protocol design, allowing future
       support for other network protocols.
@@ -324,19 +330,20 @@ Quattlebaum                Expires May 8, 2017                  [Page 5]
 
    Renumbering would be undertaken in order to better organize the
    allocation of property IDs and capability IDs.  One of the initial
+
+
+
+Quattlebaum                Expires May 8, 2017                  [Page 6]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    goals of this protocol was for it to be possible for a host or NCP to
    only implement properties with values less than 127 and for the NCP
    to still be usable---relegating all larger property values for extra
    features or other capabilities that aren't strictly necessary.  This
    would allow simple implementations to avoid the need to implement
    support for PUIs (Section 3.2).
-
-
-
-Quattlebaum                Expires May 8, 2017                  [Page 6]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
    As time has gone by and the protocol has become more fleshed out, it
    has become clear that some of the initial allocations were inadequate
@@ -355,7 +362,7 @@ Quattlebaum                Expires May 8, 2017                  [Page 6]
    communicate directly with the NCP.  Using Unix Domain Sockets,
    applications could connect to the daemon by opening a special socket
    file.  The protocol for that socket might be (for example) HDLC-Lite-
-   encoded (Appendix A.1.1) spinel frames, as if the application were
+   encoded (Appendix A.1.2) spinel frames, as if the application were
    talking directly to the NCP.
 
    Applications aren't necessarily interested in everything that an NCP
@@ -380,19 +387,17 @@ Quattlebaum                Expires May 8, 2017                  [Page 6]
    extended to support them.  It is also simple and has no external
    dependencies other than unix domain sockets.
 
-   Security is obviously paramount in a system like this, so a great
-   deal of care should be taken to make sure that certain commands and
-   properties cannot be executed or changed without the appropriate
-   privileges.
-
-
-
 
 
 Quattlebaum                Expires May 8, 2017                  [Page 7]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
+
+   Security is obviously paramount in a system like this, so a great
+   deal of care should be taken to make sure that certain commands and
+   properties cannot be executed or changed without the appropriate
+   privileges.
 
 1.1.3.  Privileged Commands and Properties
 
@@ -437,18 +442,17 @@ Quattlebaum                Expires May 8, 2017                  [Page 7]
    Properties may support one or more of the following methods:
 
    o  "VALUE_GET"
-   o  "VALUE_SET"
-   o  "VALUE_INSERT"
-   o  "VALUE_REMOVE"
-
-
 
 
 
 Quattlebaum                Expires May 8, 2017                  [Page 8]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
+
+   o  "VALUE_SET"
+   o  "VALUE_INSERT"
+   o  "VALUE_REMOVE"
 
    Additionally, the NCP can send updates to the host (either
    synchronously or asynchronously) that inform the host about changes
@@ -494,17 +498,16 @@ Quattlebaum                Expires May 8, 2017                  [Page 8]
    the concatenation of all of the individual values in the list.  If
    the length of the value for an individual item in the list is not
    defined by the type then each item returned in the list is prepended
-   with a length (See Section 3.5).  The order of the returned items,
-   unless explicitly defined for that specific property, is undefined.
-
-
 
 
 
 Quattlebaum                Expires May 8, 2017                  [Page 9]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
+
+   with a length (See Section 3.5).  The order of the returned items,
+   unless explicitly defined for that specific property, is undefined.
 
    "VALUE_SET" provides a way to completely replace all previous values.
    Calling "VALUE_SET" with an empty value effectively instructs the NCP
@@ -554,12 +557,9 @@ Quattlebaum                Expires May 8, 2017                  [Page 9]
 
 
 
-
-
-
 Quattlebaum                Expires May 8, 2017                 [Page 10]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
 2.1.  Header Format
@@ -615,7 +615,7 @@ Quattlebaum                Expires May 8, 2017                 [Page 10]
 
 Quattlebaum                Expires May 8, 2017                 [Page 11]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
 2.1.4.  Command Identifier (CMD)
@@ -671,7 +671,7 @@ Quattlebaum                Expires May 8, 2017                 [Page 11]
 
 Quattlebaum                Expires May 8, 2017                 [Page 12]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
    In each case, the data is represented exactly as described.  For
@@ -727,7 +727,7 @@ Quattlebaum                Expires May 8, 2017                 [Page 12]
 
 Quattlebaum                Expires May 8, 2017                 [Page 13]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
    For all values less than 127, the packed form of the number is simply
@@ -783,7 +783,7 @@ Quattlebaum                Expires May 8, 2017                 [Page 13]
 
 Quattlebaum                Expires May 8, 2017                 [Page 14]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
    If you are a little confused, keep reading.  This theme comes up in a
@@ -839,7 +839,7 @@ Quattlebaum                Expires May 8, 2017                 [Page 14]
 
 Quattlebaum                Expires May 8, 2017                 [Page 15]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
 3.5.  Arrays
@@ -895,7 +895,7 @@ Quattlebaum                Expires May 8, 2017                 [Page 15]
 
 Quattlebaum                Expires May 8, 2017                 [Page 16]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
    If an error occurs, the value of "PROP_LAST_STATUS" will be emitted
@@ -951,7 +951,7 @@ Quattlebaum                Expires May 8, 2017                 [Page 16]
 
 Quattlebaum                Expires May 8, 2017                 [Page 17]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
    Insert value into property command.  Instructs the NCP to insert the
@@ -1007,7 +1007,7 @@ Quattlebaum                Expires May 8, 2017                 [Page 17]
 
 Quattlebaum                Expires May 8, 2017                 [Page 18]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
    The payload for this command is the property identifier encoded in
@@ -1063,8 +1063,72 @@ Quattlebaum                Expires May 8, 2017                 [Page 18]
 
 Quattlebaum                Expires May 8, 2017                 [Page 19]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
+
+4.10.  CMD 18: (Host->NCP) CMD_PEEK
+
+             +---------+--------+----------+---------+-------+
+             | Octets: |   1    |    1     |    4    |   2   |
+             +---------+--------+----------+---------+-------+
+             | Fields: | HEADER | CMD_PEEK | ADDRESS | COUNT |
+             +---------+--------+----------+---------+-------+
+
+   This command allows the NCP to fetch values from the RAM of the NCP
+   for debugging purposes.  Upon success, "CMD_PEEK_RET" is sent from
+   the NCP to the host.  Upon failure, "PROP_LAST_STATUS" is emitted
+   with the appropriate error indication.
+
+   Due to the low-level nature of this command, certain error conditions
+   may induce the NCP to reset.
+
+   The NCP MAY prevent certain regions of memory from being accessed.
+
+   The implementation of this command has security implications.  See
+   Section 7 for more information.
+
+   This command requires the capability "CAP_PEEK_POKE" to be present.
+
+4.11.  CMD 19: (NCP->Host) CMD_PEEK_RET
+
+       +---------+--------+--------------+---------+-------+-------+
+       | Octets: |   1    |      1       |    4    |   2   |   n   |
+       +---------+--------+--------------+---------+-------+-------+
+       | Fields: | HEADER | CMD_PEEK_RET | ADDRESS | COUNT | BYTES |
+       +---------+--------+--------------+---------+-------+-------+
+
+   This command contains the contents of memory that was requested by a
+   previous call to "CMD_PEEK".
+
+   This command requires the capability "CAP_PEEK_POKE" to be present.
+
+4.12.  CMD 20: (Host->NCP) CMD_POKE
+
+         +---------+--------+----------+---------+-------+-------+
+         | Octets: |   1    |    1     |    4    |   2   |   n   |
+         +---------+--------+----------+---------+-------+-------+
+         | Fields: | HEADER | CMD_POKE | ADDRESS | COUNT | BYTES |
+         +---------+--------+----------+---------+-------+-------+
+
+   This command writes the bytes to the specified memory address for
+   debugging purposes.
+
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 20]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
+   Due to the low-level nature of this command, certain error conditions
+   may induce the NCP to reset.
+
+   The implementation of this command has security implications.  See
+   Section 7 for more information.
+
+   This command requires the capability "CAP_PEEK_POKE" to be present.
 
 5.  Properties
 
@@ -1106,21 +1170,18 @@ Quattlebaum                Expires May 8, 2017                 [Page 19]
       | Stream | 0x70 - 0x7F, 0x1700 - 0x17FF |     Section 5.2     |
       +--------+------------------------------+---------------------+
 
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 21]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    Note that each property section has two reserved ranges: a primary
    range (which is encoded as a single byte) and an extended range
    (which is encoded as two bytes). properties which are used more
    frequently are generally allocated from the former range.
-
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 20]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
 5.2.  Core Properties
 
@@ -1168,14 +1229,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 20]
 
 
 
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 21]
+Quattlebaum                Expires May 8, 2017                 [Page 22]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
 5.2.2.1.  Major Version Number
@@ -1229,9 +1285,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 21]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 22]
+Quattlebaum                Expires May 8, 2017                 [Page 23]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
                        +---------+----------------+
@@ -1243,7 +1299,7 @@ Quattlebaum                Expires May 8, 2017                 [Page 22]
    This integer identifies what the network protocol for this NCP.
    Currently defined values are:
 
-   o  1: ZigBee
+   o  0: Bootloader
    o  2: ZigBeeIP
    o  3: Thread
 
@@ -1285,9 +1341,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 22]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 23]
+Quattlebaum                Expires May 8, 2017                 [Page 24]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
    o  1: "CAP_LOCK"
@@ -1296,6 +1352,7 @@ Quattlebaum                Expires May 8, 2017                 [Page 23]
    o  4: "CAP_POWER_SAVE"
    o  5: "CAP_COUNTERS"
    o  6: "CAP_JAM_DETECT": Jamming detection.  See Appendix D
+   o  7: "CAP_PEEK_POKE": PEEK/POKE debugging commands.
    o  16: "CAP_802_15_4_2003"
    o  17: "CAP_802_15_4_2006"
    o  18: "CAP_802_15_4_2011"
@@ -1340,10 +1397,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 23]
 
 
 
-
-Quattlebaum                Expires May 8, 2017                 [Page 24]
+Quattlebaum                Expires May 8, 2017                 [Page 25]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
    Describes the number of concurrent interfaces supported by this NCP.
@@ -1392,15 +1448,19 @@ Quattlebaum                Expires May 8, 2017                 [Page 24]
                            | Fields: | HWADDR |
                            +---------+--------+
 
-   The static EUI64 address of the device.  This value is read-only, but
-   may be writable under certain vendor-defined circumstances.
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 25]
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 26]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
+
+   The static EUI64 address of the device, used as a serial number.
+   This value is read-only, but may be writable under certain vendor-
+   defined circumstances.
 
 5.2.10.  PROP 9: PROP_LOCK
 
@@ -1447,16 +1507,15 @@ Quattlebaum                Expires May 8, 2017                 [Page 25]
    the NCP's responsibility to insert newline characters where needed,
    just like with any other text stream.
 
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 27]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    To receive the debugging stream, you wait for "CMD_PROP_VALUE_IS"
    commands for this property from the NCP.
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 26]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
 5.3.2.  PROP 113: PROP_STREAM_RAW
 
@@ -1497,6 +1556,20 @@ Quattlebaum                Expires May 8, 2017                 [Page 26]
 
    The frame metadata field consists of the following fields:
 
+
+
+
+
+
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 28]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
      +----------+-----------------------+------------+-----+---------+
      | Field    | Description           | Type       | Len | Default |
      +----------+-----------------------+------------+-----+---------+
@@ -1506,13 +1579,6 @@ Quattlebaum                Expires May 8, 2017                 [Page 26]
      | MD_PHY   | PHY-specific data     | "D" data   | >=2 |         |
      | MD_VEND  | Vendor-specific data  | "D" data   | >=2 |         |
      +----------+-----------------------+------------+-----+---------+
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 27]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
    The following fields are ignored by the NCP for packets sent to it
    from the host:
@@ -1550,6 +1616,16 @@ Quattlebaum                Expires May 8, 2017                 [Page 27]
    o  Type: Read-Write-Stream
    o  Packed-Encoding: "DD"
 
+
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 29]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
         +---------+----------------+------------+----------------+
         | Octets: |       2        |     n      |       n        |
         +---------+----------------+------------+----------------+
@@ -1560,15 +1636,6 @@ Quattlebaum                Expires May 8, 2017                 [Page 27]
    packets to and from the currently attached network.  The exact format
    of the frame metadata and data is dependent on the network protocol
    being used.
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 28]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
    This property is a streaming property, meaning that you cannot
    explicitly fetch the value of this property.  To receive traffic, you
@@ -1606,6 +1673,15 @@ Quattlebaum                Expires May 8, 2017                 [Page 28]
    To send network packets, you call "CMD_PROP_VALUE_SET" on this
    property with the value of the packet.
 
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 30]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    Any data past the end of "FRAME_DATA_LEN" is considered metadata, the
    format of which is described in Section 5.3.2.1.
 
@@ -1615,16 +1691,6 @@ Quattlebaum                Expires May 8, 2017                 [Page 28]
 
    o  Type: Read-Write
    o  Packed-Encoding: "b" (bool8)
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 29]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
    Set to 1 if the PHY is enabled, set to 0 otherwise.  May be directly
    enabled to bypass higher-level packet processing in order to
@@ -1663,6 +1729,15 @@ Quattlebaum                Expires May 8, 2017                 [Page 29]
    Value is the CCA (clear-channel assessment) threshold.  Set to -128
    to disable.
 
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 31]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    When setting, the value will be rounded down to a value that is
    supported by the underlying radio hardware.
 
@@ -1673,14 +1748,6 @@ Quattlebaum                Expires May 8, 2017                 [Page 29]
    o  Unit: dBm
 
    Value is the transmit power of the radio.
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 30]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
    When setting, the value will be rounded down to a value that is
    supported by the underlying radio hardware.
@@ -1718,6 +1785,15 @@ Quattlebaum                Expires May 8, 2017                 [Page 30]
 
    Values switches to "SCAN_STATE_IDLE" when scan is complete.
 
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 32]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
 5.5.2.  PROP 49: PROP_MAC_SCAN_MASK
 
    o  Type: Read-Write
@@ -1729,14 +1805,6 @@ Quattlebaum                Expires May 8, 2017                 [Page 30]
    o  Type: Read-Write
    o  Packed-Encoding: "S" (uint16)
    o  Unit: milliseconds per channel
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 31]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
 5.5.4.  PROP 51: PROP_MAC_SCAN_BEACON
 
@@ -1773,6 +1841,15 @@ Quattlebaum                Expires May 8, 2017                 [Page 31]
    future, so care should be taken to read the length that prepends each
    structure.
 
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 33]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
 5.5.5.  PROP 52: PROP_MAC_15_4_LADDR
 
    o  Type: Read-Write
@@ -1781,18 +1858,6 @@ Quattlebaum                Expires May 8, 2017                 [Page 31]
    The 802.15.4 long address of this node.
 
    This property is only present on NCPs which implement 802.15.4
-
-
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 32]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
 5.5.6.  PROP 53: PROP_MAC_15_4_SADDR
 
@@ -1827,6 +1892,20 @@ Quattlebaum                Expires May 8, 2017                 [Page 32]
 
    Possible Values:
 
+
+
+
+
+
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 34]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    +----+--------------------------------+-----------------------------+
    | Id |              Name              |         Description         |
    +----+--------------------------------+-----------------------------+
@@ -1840,15 +1919,6 @@ Quattlebaum                Expires May 8, 2017                 [Page 32]
    +----+--------------------------------+-----------------------------+
 
    See Section 5.3.2.
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 33]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
 5.5.10.  PROP 4864: PROP_MAC_WHITELIST
 
@@ -1884,6 +1954,14 @@ Quattlebaum                Expires May 8, 2017                 [Page 33]
    o  Type: Read-Write
    o  Packed-Encoding: "b"
 
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 35]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    Network interface up/down status.  Non-zero (set to 1) indicates up,
    zero indicates down.
 
@@ -1895,16 +1973,6 @@ Quattlebaum                Expires May 8, 2017                 [Page 33]
 
    Thread stack operational status.  Non-zero (set to 1) indicates up,
    zero indicates down.
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 34]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
 5.6.4.  PROP 67: PROP_NET_ROLE
 
@@ -1939,6 +2007,17 @@ Quattlebaum                Expires May 8, 2017                 [Page 34]
    o  Type: Read-Write
    o  Packed-Encoding: "L"
 
+
+
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 36]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
 5.6.9.  PROP 72: PROP_NET_PARTITION_ID
 
    o  Type: Read-Write
@@ -1950,17 +2029,6 @@ Quattlebaum                Expires May 8, 2017                 [Page 34]
 
    o  Type: Read-Write
    o  Packed-Encoding: "L"
-
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 35]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
 5.7.  IPv6 Properties
 
@@ -1998,6 +2066,14 @@ Quattlebaum                Expires May 8, 2017                 [Page 35]
    o  "L": Preferred Lifetime
    o  "C": Flags
 
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 37]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
 5.7.5.  PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD
 
    o  Type: Read-Write
@@ -2007,16 +2083,6 @@ Quattlebaum                Expires May 8, 2017                 [Page 35]
    turned on, ping request ICMP packets will not be passed to the host.
 
    Default value is "false".
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 36]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
 6.  Status Codes
 
@@ -2055,6 +2121,15 @@ Quattlebaum                Expires May 8, 2017                 [Page 36]
       command.
    o  10: "STATUS_IN_PROGRESS": The operation is in progress and will be
       completed asynchronously.
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 38]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    o  11: "STATUS_NOMEM": The operation has been prevented due to memory
       pressure.
    o  12: "STATUS_BUSY": The device is currently performing a mutually
@@ -2065,15 +2140,6 @@ Quattlebaum                Expires May 8, 2017                 [Page 36]
    o  16: "STATUS_CMD_TOO_BIG": The command was too large to fit in the
       internal buffer.
    o  17: "STATUS_NO_ACK": The packet was not acknowledged.
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 37]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
-
    o  18: "STATUS_CCA_FAILURE": The packet was not sent due to a CCA
       failure.
    o  19: "STATUS_ALREADY": The operation is already in progress or the
@@ -2101,7 +2167,24 @@ Quattlebaum                Expires May 8, 2017                 [Page 37]
 
 7.  Security Considerations
 
-   TBD
+7.1.  Raw Application Access
+
+   Spinel MAY be used as an API boundary for allowing processes to
+   configure the NCP.  However, such a system MUST NOT give unprivileged
+   processess the ability to send or receive arbitrary command frames to
+   the NCP.  Only the specific commands and properties that are required
+   should be allowed to be passed, and then only after being checked for
+   proper format.
+
+
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 39]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
 
 8.  Acknowledgments
 
@@ -2121,14 +2204,6 @@ Quattlebaum                Expires May 8, 2017                 [Page 37]
    [1] http://wpantund.org/
 
    [2] https://www.freedesktop.org/wiki/Software/dbus/
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 38]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
    [3] https://www.w3.org/TR/exi/#encodingUnsignedInteger
 
@@ -2159,6 +2234,14 @@ A.1.  UART Recommendations
    These values may be adjusted depending on the individual needs of the
    application or product, but some sort of flow control MUST be used.
    Hardware flow control is preferred over software flow control.  In
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 40]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    the absence of hardware flow control, software flow control (XON/
    XOFF) MUST be used instead.
 
@@ -2170,7 +2253,34 @@ A.1.  UART Recommendations
    "R&#773;E&#773;S&#773;" pin on the NCP, so that you can easily
    perform a hardware reset if necessary.
 
-A.1.1.  HDLC-Lite
+A.1.1.  UART Bit Rate Detection
+
+   When using a UART, the issue of an appropriate bit rate must be
+   considered.  A bitrate of 115200 bits per second has become a defacto
+   standard baud rate for many serial peripherals.  This rate, however,
+   is slower than the theoretical maximum bitrate of the 802.15.4 2.4GHz
+   PHY (250kbit).  In most circumstances this mismatch is not
+   significant because the overall bitrate will be much lower than
+   either of these rates, but there are circumstances where a faster
+   UART bitrate is desirable.  Thus, this document proposes a simple
+   bitrate detection scheme that can be employed by the host to detect
+   when the attached NCP is initially running at a higher bitrate.
+
+   The algorithm is to send successive NOOP commands to the NCP at
+   increasing bitrates.  When a valid "CMD_LAST_STATUS" response has
+   been received, we have identified the correct bitrate.
+
+   In order to limit the time spent hunting for the appropriate bitrate,
+   we RECOMMEND that only the following bitrates be checked:
+
+   o  115200
+   o  230400
+   o  1000000 (1Mbit)
+
+   The bitrate MAY also be changed programmatically by adjusting
+   "PROP_UART_BITRATE", if implemented.
+
+A.1.2.  HDLC-Lite
 
    _HDLC-Lite_ is the recommended framing protocol for transmitting
    Spinel frames over a UART.  HDLC-Lite consists of only the framing,
@@ -2181,9 +2291,11 @@ A.1.1.  HDLC-Lite
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 39]
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 41]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
    To transmit a frame with HDLC-lite, the 16-bit CRC must first be
@@ -2237,9 +2349,9 @@ A.2.  SPI Recommendations
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 40]
+Quattlebaum                Expires May 8, 2017                 [Page 42]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
    The "I&#773;N&#773;T&#773;" signal is used by the NCP to indicate to
@@ -2283,21 +2395,27 @@ A.2.1.  SPI Framing Protocol
 
                        0   1   2   3   4   5   6   7
                      +---+---+---+---+---+---+---+---+
-                     |RST|CRC|    RESERVED   |PATTERN|
+                     |RST|CRC|CCF|  RESERVED |PATTERN|
                      +---+---+---+---+---+---+---+---+
 
    o  "RST": This bit is set when that device has been reset since the
       last time "C&#773;S&#773;" was asserted.
-   o  "CRC": This bit is set when that device supports writing a 16-bit
-      CRC at the end of the data.  This CRC is NOT included in DATA_LEN.
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 41]
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 43]
 
-                       Spinel Protocol (4fce7582b)         November 2016
+                       Spinel Protocol (f9bf43254)         November 2016
 
 
+   o  "CRC": This bit is set when that device supports writing a 16-bit
+      CRC at the end of the data.  The CRC length is NOT included in
+      DATA_LEN.
+   o  "CCF": "CRC Check Failure".  Set if the CRC check on the last
+      received frame failed, cleared to zero otherwise.  This bit is
+      only used if both sides support CRC.
    o  "RESERVED": These bits are all reserved for future used.  They
       MUST be cleared to zero and MUST be ignored if set.
    o  "PATTERN": These bits are set to a fixed value to help distinguish
@@ -2306,12 +2424,18 @@ Quattlebaum                Expires May 8, 2017                 [Page 41]
       MUST be cleared (0).  A frame received that has any other values
       for these bits MUST be dropped.
 
-   Prior to a sending or receiving a frame, the master SHOULD send a
+   Prior to a sending or receiving a frame, the master MAY send a
    5-octet frame with zeros for both the max receive frame size and the
    the contained frame length.  This will induce the slave device to
    indicate the length of the frame it wants to send (if any) and
    indicate the largest frame it is capable of receiving at the moment.
    This allows the master to calculate the size of the next transaction.
+   Alternatively, if the master has a frame to send it can just go ahead
+   and send a frame of that length and determine if the frame was
+   accepted by checking that the "RECV_LEN" from the slave frame is
+   larger than the frame the master just tried to send.  If the
+   "RECV_LEN" is smaller then the frame wasn't accepted and will need to
+   be transmitted again.
 
    This protocol can be used either unidirectionally or bidirectionally,
    determined by the behavior of the master and the slave.
@@ -2323,13 +2447,39 @@ Quattlebaum                Expires May 8, 2017                 [Page 41]
    (like a NCP hardware reset, or indicating a communication failure to
    a user interface).
 
+   At the end of the data of a frame is an optional 16-bit CRC, support
+   for which is indicated by the "CRC" bit of the "HDR" byte being set.
+   If these bits are set for both the master and slave frames, then CRC
+   checking is enabled on both sides, effectively requiring that frame
+   sizes be two bytes longer than would be otherwise required.  The CRC
+   is calculated using the same mechanism used for the CRC calculation
+   in HDLC-Lite (See Appendix A.1.2).  When both of the "CRC" bits are
+   set, both sides must verify that the "CRC" is valid before accepting
+   the frame.  If not enough bytes were clocked out for the CRC to be
+   read, then the frame must be ignored.  If enough bytes were clocked
+   out to perform a CRC check, but the CRC check fails, then the frame
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 44]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
+   must be rejected and the "CRC_FAIL" bit on the next frame (and ONLY
+   the next frame) MUST be set.
+
 A.3.  I^2C Recommendations
 
    TBD
 
+   [CREF3]
+
 A.4.  Native USB Recommendations
 
    TBD
+
+   [CREF4]
 
 Appendix B.  Feature: Network Save
 
@@ -2341,18 +2491,6 @@ Appendix B.  Feature: Network Save
    presence of the "CAP_NET_SAVE" capability in "PROP_CAPS".
 
 B.1.  Commands
-
-
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 42]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
 B.1.1.  CMD 9: (Host->NCP) CMD_NET_SAVE
 
@@ -2374,6 +2512,15 @@ B.1.1.  CMD 9: (Host->NCP) CMD_NET_SAVE
 
    This command is only available if the "CAP_NET_SAVE" capability is
    set.
+
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 45]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
 
 B.1.2.  CMD 10: (Host->NCP) CMD_NET_CLEAR
 
@@ -2397,18 +2544,6 @@ B.1.2.  CMD 10: (Host->NCP) CMD_NET_CLEAR
    set.
 
 B.1.3.  CMD 11: (Host->NCP) CMD_NET_RECALL
-
-
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 43]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
                    +---------+--------+----------------+
                    | Octets: |   1    |       1        |
@@ -2436,6 +2571,13 @@ Appendix C.  Feature: Host Buffer Offload
    NCP to offload buffers to the host processor temporarily so that it
    can perform other operations.
 
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 46]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    Host buffer offload is an optional NCP capability that, when present,
    allows the NCP to store data buffers on the host processor that can
    be recalled at a later time.
@@ -2453,18 +2595,6 @@ C.1.1.  CMD 12: (NCP->Host) CMD_HBO_OFFLOAD
       *  "Expiration": In seconds-from-now
       *  "Priority": Critical, High, Medium, Low
       *  "Data": Data to offload
-
-
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 44]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
 C.1.2.  CMD 13: (NCP->Host) CMD_HBO_RECLAIM
 
@@ -2495,6 +2625,15 @@ C.1.5.  CMD 16: (Host->NCP) CMD_HBO_RECLAIMED
       *  "Status": Status code for the result of the operation.
       *  "Data": Data that was previously offloaded (if any)
 
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 47]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
 C.1.6.  CMD 17: (Host->NCP) CMD_HBO_DROPPED
 
    o  Argument-Encoding: "Li"
@@ -2514,13 +2653,6 @@ C.2.1.  PROP 10: PROP_HBO_MEM_MAX
                      +---------+--------------------+
                      | Fields: | "PROP_HBO_MEM_MAX" |
                      +---------+--------------------+
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 45]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
    Describes the number of bytes that may be offloaded from the NCP to
    the host.  Default value is zero, so this property must be set by the
@@ -2551,6 +2683,13 @@ C.2.2.  PROP 11: PROP_HBO_BLOCK_MAX
    This property is only available if the "CAP_HBO" capability is
    present in "PROP_CAPS".
 
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 48]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
 Appendix D.  Feature: Jam Detection
 
    Jamming detection is a feature that allows the NCP to report when it
@@ -2568,15 +2707,6 @@ D.1.1.  PROP 4608: PROP_JAM_DETECT_ENABLE
    o  Packed-Encoding: "b"
    o  Default Value: false
    o  REQUIRED for "CAP_JAM_DETECT"
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 46]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
                   +---------+--------------------------+
                   | Octets: |            1             |
@@ -2607,6 +2737,15 @@ D.1.2.  PROP 4609: PROP_JAM_DETECTED
    When jamming detection is enabled, changes to the value of this
    property are emitted asynchronously via "CMD_PROP_VALUE_IS".
 
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 49]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    This property is only available if the "CAP_JAM_DETECT" capability is
    present in "PROP_CAPS".
 
@@ -2626,14 +2765,6 @@ D.1.4.  PROP 4611: PROP_JAM_DETECT_WINDOW
    o  Type: Read-Write
    o  Packed-Encoding: "c"
    o  Units: Seconds (1-64)
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 47]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
-
    o  Default Value: Implementation-specific
    o  RECOMMENDED for "CAP_JAM_DETECT"
 
@@ -2663,6 +2794,14 @@ Appendix E.  Technology: Thread
 
    Thread NCPs have the following requirements:
 
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 50]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    o  The property "PROP_INTERFACE_TYPE" must be 3.
    o  The non-optional properties in the following sections MUST be
       implemented: CORE, PHY, MAC, NET, and IPV6.
@@ -2678,17 +2817,6 @@ E.1.  Thread Capabilities
       the Thread standard.
    o  "CAP_NET_THREAD_1_1" - Indicates that the NCP implements v1.1 of
       the Thread standard.
-
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 48]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
 E.2.  Thread Properties
 
@@ -2719,6 +2847,17 @@ E.2.3.  PROP 82: PROP_THREAD_CHILD_TABLE
    Table containing the long and short addresses of all the children of
    this node.
 
+
+
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 51]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
 E.2.4.  PROP 83: PROP_THREAD_LEADER_RID
 
    o  Type: Read-Only
@@ -2737,14 +2876,6 @@ E.2.6.  PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT
 
    o  Type: Read-Write
    o  Packed-Encoding: "C"
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 49]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
    The leader weight for this node.
 
@@ -2775,6 +2906,14 @@ E.2.11.  PROP 90: PROP_THREAD_ON_MESH_NETS
 
    Data per item is:
 
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 52]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    o  "6": IPv6 Prefix
    o  "C": Prefix length, in bits
    o  "b": Stable flag
@@ -2794,13 +2933,6 @@ E.2.12.  PROP 91: PROP_THREAD_LOCAL_ROUTES
    o  "C": Prefix length, in bits
    o  "b": Stable flag
    o  "C": Other flags
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 50]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
 E.2.13.  PROP 92: PROP_THREAD_ASSISTING_PORTS
 
@@ -2831,6 +2963,13 @@ E.2.16.  PROP 5376: PROP_THREAD_CHILD_TIMEOUT
 
    Used when operating in the Child role.
 
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 53]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
 E.2.17.  PROP 5377: PROP_THREAD_RLOC16
 
    o  Type: Read-Write
@@ -2845,18 +2984,6 @@ E.2.19.  PROP 5379: PROP_THREAD_CONTEXT_REUSE_DELAY
 
    o  Type: Read-Write
    o  Packed-Encoding: "L"
-
-
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 51]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
 E.2.20.  PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT
 
@@ -2889,6 +3016,16 @@ E.2.23.  PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED
    o  Type: Read-Write
    o  Packed-Encoding: "b"
 
+
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 54]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    Allow the HOST to indicate whether or not the router role is enabled.
    If current role is a router, setting this property to "false" starts
    a re-attach process as an end-device.
@@ -2905,14 +3042,6 @@ E.2.25.  PROP 5385: PROP_THREAD_ROUTER_SELECTION_JITTER
 
    Specifies the self imposed random delay in seconds a REED waits
    before registering to become an Active Router.
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 52]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
 E.2.26.  PROP 5386: PROP_THREAD_PREFERRED_ROUTER_ID
 
@@ -2942,6 +3071,17 @@ E.2.27.  PROP 5387: SPINEL_PROP_THREAD_NEIGHBOR_TABLE
    o  "L": Link Frame Counter
    o  "L": MLE Frame Counter
 
+
+
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 55]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
 Appendix F.  Test Vectors
 
 F.1.  Test Vector: Packed Unsigned Integer
@@ -2961,14 +3101,7 @@ F.1.  Test Vector: Packed Unsigned Integer
                  |     2,097,151 | "FF FF 7F"            |
                  +---------------+-----------------------+
 
-   [CREF3]
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 53]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
+   [CREF5]
 
 F.2.  Test Vector: Reset Command
 
@@ -2997,6 +3130,14 @@ F.4.  Test Vector: Scan Beacon
    o  IID: 0
    o  TID: 0
    o  CMD: 7 ("CMD_VALUE_INSERTED")
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 56]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    o  PROP: 51 ("PROP_MAC_SCAN_BEACON")
    o  VALUE: Structure, encoded as "CcT(ESSc.)T(iCUD.)."
 
@@ -3018,14 +3159,6 @@ F.4.  Test Vector: Scan Beacon
 
    Frame:
 
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 54]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
-
         80 07 33 0F C4 0D 00 B6 40 D4 8C E9 38 F9 52 FF FF D2 04 00
         13 00 03 20 73 70 69 6E 65 6C 00 08 00 DE AD 00 BE EF 00 CA
         FE
@@ -3034,13 +3167,13 @@ F.5.  Test Vector: Inbound IPv6 Packet
 
    CMD_VALUE_IS(PROP_STREAM_NET)
 
-   [CREF4]
+   [CREF6]
 
 F.6.  Test Vector: Outbound IPv6 Packet
 
    CMD_VALUE_SET(PROP_STREAM_NET)
 
-   [CREF5]
+   [CREF7]
 
 F.7.  Test Vector: Fetch list of on-mesh networks
 
@@ -3052,6 +3185,14 @@ F.7.  Test Vector: Fetch list of on-mesh networks
    Frame:
 
                                  84 02 5A
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 57]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
 
 F.8.  Test Vector: Returned list of on-mesh networks
 
@@ -3074,14 +3215,6 @@ F.8.  Test Vector: Returned list of on-mesh networks
         00 40 01 ?? 13 00 20 01 0D B8 00 02 00 00 00 00 00 00 00 00
         00 00 40 00 ??
 
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 55]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
-
 F.9.  Test Vector: Adding an on-mesh network
 
    o  IID: 0
@@ -3101,7 +3234,7 @@ F.9.  Test Vector: Adding an on-mesh network
         85 03 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00 40
         01 ?? 01
 
-   [CREF6]
+   [CREF8]
 
 F.10.  Test Vector: Insertion notification of an on-mesh network
 
@@ -3109,6 +3242,14 @@ F.10.  Test Vector: Insertion notification of an on-mesh network
    o  TID: 5
    o  CMD: 7 ("CMD_VALUE_INSERTED")
    o  PROP: 90 ("PROP_THREAD_ON_MESH_NETS")
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 58]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    o  VALUE: Structure, encoded as "6CbCb"
 
        +--------------+---------------+-------------+-------------+
@@ -3122,7 +3263,7 @@ F.10.  Test Vector: Insertion notification of an on-mesh network
         85 07 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00 40
         01 ?? 01
 
-   [CREF7]
+   [CREF9]
 
 F.11.  Test Vector: Removing a local on-mesh network
 
@@ -3130,14 +3271,6 @@ F.11.  Test Vector: Removing a local on-mesh network
    o  TID: 6
    o  CMD: 5 ("CMD_VALUE_REMOVE")
    o  PROP: 90 ("PROP_THREAD_ON_MESH_NETS")
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 56]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
-
    o  VALUE: IPv6 Prefix "2001:DB8:3::"
 
    Frame:
@@ -3160,11 +3293,19 @@ Appendix G.  Example Sessions
 
 G.1.  NCP Initialization
 
-   [CREF8]
+   [CREF10]
 
    Check the protocol version to see if it is supported:
 
    o  CMD_VALUE_GET:PROP_PROTOCOL_VERSION
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 59]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    o  CMD_VALUE_IS:PROP_PROTOCOL_VERSION
 
    Check the NCP version to see if a firmware update may be necessary:
@@ -3186,14 +3327,6 @@ G.1.  NCP Initialization
    Fetch the capability list so that we know what features this NCP
    supports:
 
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 57]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
-
    o  CMD_VALUE_GET:PROP_CAPS
    o  CMD_VALUE_IS:PROP_CAPS
 
@@ -3204,7 +3337,7 @@ Quattlebaum                Expires May 8, 2017                 [Page 57]
 
 G.2.  Attaching to a network
 
-   [CREF9]
+   [CREF11]
 
    We make the assumption that the NCP is not currently associated with
    a network.
@@ -3221,6 +3354,14 @@ G.2.  Attaching to a network
    o  CMD_VALUE_IS:PROP_NET_NETWORK_NAME
    o  CMD_VALUE_SET:PROP_NET_MASTER_KEY
    o  CMD_VALUE_IS:PROP_NET_MASTER_KEY
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 60]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    o  CMD_VALUE_SET:PROP_NET_KEY_SEQUENCE_COUNTER
    o  CMD_VALUE_IS:PROP_NET_KEY_SEQUENCE_COUNTER
    o  CMD_VALUE_SET:PROP_NET_KEY_SWITCH_GUARDTIME
@@ -3242,17 +3383,9 @@ G.2.  Attaching to a network
    o  CMD_VALUE_IS:PROP_NET_PARTITION_ID
    o  CMD_VALUE_IS:PROP_THREAD_ON_MESH_NETS
 
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 58]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
-
 G.3.  Successfully joining a pre-existing network
 
-   [CREF10]
+   [CREF12]
 
    This example session is identical to the above session up to the
    point where we set PROP_NET_IF_UP to true.  From there, the behavior
@@ -3276,6 +3409,15 @@ G.3.  Successfully joining a pre-existing network
 
    o  CMD_NET_SAVE
 
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 61]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
 G.4.  Unsuccessfully joining a pre-existing network
 
    This example session is identical to the above session up to the
@@ -3295,24 +3437,13 @@ G.4.  Unsuccessfully joining a pre-existing network
    o  CMD_VALUE_IS:PROP_LAST_STATUS:STATUS_JOIN_NO_PEERS
    o  CMD_VALUE_IS:PROP_NET_STACK_UP:FALSE
 
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 59]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
-
 G.5.  Detaching from a network
 
    TBD
 
 G.6.  Attaching to a saved network
 
-   [CREF11]
+   [CREF13]
 
    Recall the saved network if you haven't already done so:
 
@@ -3334,9 +3465,18 @@ G.6.  Attaching to a saved network
    o  CMD_VALUE_IS:PROP_NET_PARTITION_ID
    o  CMD_VALUE_IS:PROP_THREAD_ON_MESH_NETS
 
+
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 62]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
 G.7.  NCP Software Reset
 
-   [CREF12]
+   [CREF14]
 
    o  CMD_RESET
    o  CMD_VALUE_IS:PROP_LAST_STATUS:STATUS_RESET_SOFTWARE
@@ -3351,20 +3491,9 @@ G.9.  Entering low-power modes
 
    TBD
 
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 60]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
-
 G.10.  Sniffing raw packets
 
-   [CREF13]
+   [CREF15]
 
    This assumes that the NCP has been initialized.
 
@@ -3393,6 +3522,14 @@ G.10.  Sniffing raw packets
    Now we will get raw 802.15.4 packets asynchronously on
    PROP_STREAM_RAW:
 
+
+
+
+Quattlebaum                Expires May 8, 2017                 [Page 63]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
    o  CMD_VALUE_IS:PROP_STREAM_RAW:...
    o  CMD_VALUE_IS:PROP_STREAM_RAW:...
    o  CMD_VALUE_IS:PROP_STREAM_RAW:...
@@ -3405,19 +3542,11 @@ G.10.  Sniffing raw packets
 
 Appendix H.  Glossary
 
-   [CREF14]
+   [CREF16]
 
    NCP
       Acronym for Network Control Processor.
    Host
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 61]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
-
       Computer or Micro-controller which controls the NCP.
    TID
       Transaction Identifier.  May be a value between zero and fifteen.
@@ -3450,29 +3579,30 @@ Editorial Comments
 [CREF2] RQ: If I have missed anyone who has contributed to this
         document, please let me know ASAP.
 
-[CREF3] RQ: The PUI test-vector encodings need to be verified.
 
-[CREF4] RQ: FIXME: This test vector is incomplete.
 
-[CREF5] RQ: FIXME: This test vector is incomplete.
+Quattlebaum                Expires May 8, 2017                 [Page 64]
+
+                       Spinel Protocol (f9bf43254)         November 2016
+
+
+[CREF3] RQ: It may make sense to have a look at what Bluetooth HCI is
+        doing for native I^2C framing and go with that.
+
+[CREF4] RQ: It may make sense to have a look at what Bluetooth HCI is
+        doing for native USB framing and go with that.
+
+[CREF5] RQ: The PUI test-vector encodings need to be verified.
 
 [CREF6] RQ: FIXME: This test vector is incomplete.
 
 [CREF7] RQ: FIXME: This test vector is incomplete.
 
-[CREF8] RQ: FIXME: This example session is incomplete.
+[CREF8] RQ: FIXME: This test vector is incomplete.
 
-[CREF9] RQ: FIXME: This example session is incomplete.
+[CREF9] RQ: FIXME: This test vector is incomplete.
 
 [CREF10] RQ: FIXME: This example session is incomplete.
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 62]
-
-                       Spinel Protocol (4fce7582b)         November 2016
-
 
 [CREF11] RQ: FIXME: This example session is incomplete.
 
@@ -3480,7 +3610,11 @@ Quattlebaum                Expires May 8, 2017                 [Page 62]
 
 [CREF13] RQ: FIXME: This example session is incomplete.
 
-[CREF14] RQ: Alphabetize before finalization.
+[CREF14] RQ: FIXME: This example session is incomplete.
+
+[CREF15] RQ: FIXME: This example session is incomplete.
+
+[CREF16] RQ: Alphabetize before finalization.
 
 Author's Address
 
@@ -3503,26 +3637,4 @@ Author's Address
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 63]
+Quattlebaum                Expires May 8, 2017                 [Page 65]

--- a/doc/spinel-protocol-src/spinel-commands.md
+++ b/doc/spinel-protocol-src/spinel-commands.md
@@ -170,4 +170,52 @@ The resulting order of items in the list is defined by the given
 property.
 
 
+## CMD 18: (Host->NCP) CMD_PEEK {#cmd-peek}
+
+Octets: |    1   |     1    |    4    | 2
+--------|--------|----------|---------|-------
+Fields: | HEADER | CMD_PEEK | ADDRESS | COUNT
+
+This command allows the NCP to fetch values from the RAM of the NCP
+for debugging purposes. Upon success, `CMD_PEEK_RET` is sent from the
+NCP to the host. Upon failure, `PROP_LAST_STATUS` is emitted with
+the appropriate error indication.
+
+Due to the low-level nature of this command, certain error conditions
+may induce the NCP to reset.
+
+The NCP MAY prevent certain regions of memory from being accessed.
+
+The implementation of this command has security implications.
+See (#security-considerations) for more information.
+
+This command requires the capability `CAP_PEEK_POKE` to be present.
+
+## CMD 19: (NCP->Host) CMD_PEEK_RET {#cmd-peek-ret}
+
+Octets: |    1   |     1        |    4    | 2     | *n*
+--------|--------|--------------|---------|-------|-------
+Fields: | HEADER | CMD_PEEK_RET | ADDRESS | COUNT | BYTES
+
+This command contains the contents of memory that was requested by
+a previous call to `CMD_PEEK`.
+
+This command requires the capability `CAP_PEEK_POKE` to be present.
+
+## CMD 20: (Host->NCP) CMD_POKE {#cmd-poke}
+
+Octets: |    1   |     1    |    4    | 2     | *n*
+--------|--------|----------|---------|-------|-------
+Fields: | HEADER | CMD_POKE | ADDRESS | COUNT | BYTES
+
+This command writes the bytes to the specified memory address
+for debugging purposes.
+
+Due to the low-level nature of this command, certain error conditions
+may induce the NCP to reset.
+
+The implementation of this command has security implications.
+See (#security-considerations) for more information.
+
+This command requires the capability `CAP_PEEK_POKE` to be present.
 

--- a/doc/spinel-protocol-src/spinel-prop-core.md
+++ b/doc/spinel-protocol-src/spinel-prop-core.md
@@ -88,7 +88,7 @@ Fields: | INTERFACE_TYPE
 This integer identifies what the network protocol for this NCP.
 Currently defined values are:
 
- *  1: ZigBee
+ *  0: Bootloader
  *  2: ZigBeeIP
  *  3: Thread
 
@@ -129,6 +129,7 @@ Currently defined values are:
  * 4: `CAP_POWER_SAVE`
  * 5: `CAP_COUNTERS`
  * 6: `CAP_JAM_DETECT`: Jamming detection. See (#feature-jam-detect)
+ * 7: `CAP_PEEK_POKE`: PEEK/POKE debugging commands.
  * 16: `CAP_802_15_4_2003`
  * 17: `CAP_802_15_4_2006`
  * 18: `CAP_802_15_4_2011`
@@ -208,8 +209,9 @@ Octets: |    8
 --------|------------
 Fields: | HWADDR
 
-The static EUI64 address of the device. This value is read-only, but
-may be writable under certain vendor-defined circumstances.
+The static EUI64 address of the device, used as a serial number.
+This value is read-only, but may be writable under certain
+vendor-defined circumstances.
 
 ### PROP 9: PROP_LOCK {#prop-lock}
 

--- a/doc/spinel-protocol-src/spinel-security-considerations.md
+++ b/doc/spinel-protocol-src/spinel-security-considerations.md
@@ -1,3 +1,9 @@
 # Security Considerations #
 
-TBD
+## Raw Application Access ##
+
+Spinel MAY be used as an API boundary for allowing processes to configure
+the NCP. However, such a system MUST NOT give unprivileged processess the
+ability to send or receive arbitrary command frames to the NCP. Only the
+specific commands and properties that are required should be allowed to be
+passed, and then only after being checked for proper format.

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -197,9 +197,9 @@ enum {
 
 enum
 {
-    SPINEL_PROTOCOL_TYPE_ZIGBEE    = 1,
-    SPINEL_PROTOCOL_TYPE_ZIGBEE_IP = 2,
-    SPINEL_PROTOCOL_TYPE_THREAD    = 3,
+    SPINEL_PROTOCOL_TYPE_BOOTLOADER = 0,
+    SPINEL_PROTOCOL_TYPE_ZIGBEE_IP  = 2,
+    SPINEL_PROTOCOL_TYPE_THREAD     = 3,
 };
 
 enum
@@ -265,6 +265,10 @@ enum
     SPINEL_CMD_HBO_RECLAIMED        = 16,
     SPINEL_CMD_HBO_DROPED           = 17,
 
+    SPINEL_CMD_PEEK                 = 18,
+    SPINEL_CMD_PEEK_RET             = 19,
+    SPINEL_CMD_POKE                 = 20,
+
     SPINEL_CMD_NEST__BEGIN          = 15296,
     SPINEL_CMD_NEST__END            = 15360,
 
@@ -284,6 +288,8 @@ enum
 
     SPINEL_CAP_COUNTERS              = 5,
     SPINEL_CAP_JAM_DETECT            = 6,
+
+    SPINEL_CAP_PEEK_POKE             = 7,
 
     SPINEL_CAP_802_15_4__BEGIN        = 16,
     SPINEL_CAP_802_15_4_2003          = (SPINEL_CAP_802_15_4__BEGIN + 0),
@@ -444,7 +450,7 @@ typedef enum
     SPINEL_PROP_NET__BEGIN           = 0x40,
     SPINEL_PROP_NET_SAVED            = SPINEL_PROP_NET__BEGIN + 0, ///< [b]
     SPINEL_PROP_NET_IF_UP            = SPINEL_PROP_NET__BEGIN + 1, ///< [b]
-    SPINEL_PROP_NET_STACK_UP         = SPINEL_PROP_NET__BEGIN + 2, ///< [C]
+    SPINEL_PROP_NET_STACK_UP         = SPINEL_PROP_NET__BEGIN + 2, ///< [b]
     SPINEL_PROP_NET_ROLE             = SPINEL_PROP_NET__BEGIN + 3, ///< [C]
     SPINEL_PROP_NET_NETWORK_NAME     = SPINEL_PROP_NET__BEGIN + 4, ///< [U]
     SPINEL_PROP_NET_XPANID           = SPINEL_PROP_NET__BEGIN + 5, ///< [D]


### PR DESCRIPTION
These changes add peek/poke commands, improvements to the SPI protocol, and a few other miscellaneous minor changes.