### PR TITLE
Fix scanning behavior. Change logic around otPlatRadioGetTransmitBuffer.

### DIFF
--- a/examples/drivers/windows/otLwf/radio.c
+++ b/examples/drivers/windows/otLwf/radio.c
@@ -476,7 +476,7 @@ otLwfRadioReceiveFrame(
     LogFuncExit(DRIVER_DATA_PATH);
 }
 
-ThreadError otPlatRadioTransmit(_In_ otInstance *otCtx)
+ThreadError otPlatRadioTransmit(_In_ otInstance *otCtx, _In_ RadioPacket *aPacket)
 {
     NT_ASSERT(otCtx);
     PMS_FILTER pFilter = otCtxToFilter(otCtx);
@@ -576,19 +576,19 @@ otLwfRadioTransmitFrameDone(
         POT_NBL_CONTEXT SendNblContext = GetNBLContext(pFilter->SendNetBufferList);
         BOOLEAN FramePending = (SendNblContext->Flags & OT_NBL_FLAG_ACK_FRAME_PENDING) != 0 || pFilter->CountPendingRecvNBLs != 0;
 
-        otPlatRadioTransmitDone(pFilter->otCtx, FramePending, kThreadError_None);
+        otPlatRadioTransmitDone(pFilter->otCtx, pFilter->otTransmitFrame, FramePending, kThreadError_None);
     }
     else if (STATUS_DEVICE_BUSY == pFilter->SendNetBufferList->Status)
     {
-        otPlatRadioTransmitDone(pFilter->otCtx, false, kThreadError_ChannelAccessFailure);
+        otPlatRadioTransmitDone(pFilter->otCtx, pFilter->otTransmitFrame, false, kThreadError_ChannelAccessFailure);
     }
     else if (STATUS_TIMEOUT == pFilter->SendNetBufferList->Status)
     {
-        otPlatRadioTransmitDone(pFilter->otCtx, false, kThreadError_NoAck);
+        otPlatRadioTransmitDone(pFilter->otCtx, pFilter->otTransmitFrame, false, kThreadError_NoAck);
     }
     else
     {
-        otPlatRadioTransmitDone(pFilter->otCtx, false, kThreadError_Abort);
+        otPlatRadioTransmitDone(pFilter->otCtx, pFilter->otTransmitFrame, false, kThreadError_Abort);
     }
 
     LogFuncExit(DRIVER_DATA_PATH);

--- a/examples/drivers/windows/otLwf/radio.c
+++ b/examples/drivers/windows/otLwf/radio.c
@@ -481,7 +481,9 @@ ThreadError otPlatRadioTransmit(_In_ otInstance *otCtx, _In_ RadioPacket *aPacke
     NT_ASSERT(otCtx);
     PMS_FILTER pFilter = otCtxToFilter(otCtx);
     ThreadError error = kThreadError_Busy;
-    
+
+    UNREFERENCED_PARAMETER(aPacket);
+
     LogFuncEntryMsg(DRIVER_DATA_PATH, "Filter: %p", pFilter);
 
     NT_ASSERT(pFilter->otPhyState == kStateReceive);

--- a/examples/drivers/windows/otLwf/radio.c
+++ b/examples/drivers/windows/otLwf/radio.c
@@ -578,19 +578,19 @@ otLwfRadioTransmitFrameDone(
         POT_NBL_CONTEXT SendNblContext = GetNBLContext(pFilter->SendNetBufferList);
         BOOLEAN FramePending = (SendNblContext->Flags & OT_NBL_FLAG_ACK_FRAME_PENDING) != 0 || pFilter->CountPendingRecvNBLs != 0;
 
-        otPlatRadioTransmitDone(pFilter->otCtx, pFilter->otTransmitFrame, FramePending, kThreadError_None);
+        otPlatRadioTransmitDone(pFilter->otCtx, &pFilter->otTransmitFrame, FramePending, kThreadError_None);
     }
     else if (STATUS_DEVICE_BUSY == pFilter->SendNetBufferList->Status)
     {
-        otPlatRadioTransmitDone(pFilter->otCtx, pFilter->otTransmitFrame, false, kThreadError_ChannelAccessFailure);
+        otPlatRadioTransmitDone(pFilter->otCtx, &pFilter->otTransmitFrame, false, kThreadError_ChannelAccessFailure);
     }
     else if (STATUS_TIMEOUT == pFilter->SendNetBufferList->Status)
     {
-        otPlatRadioTransmitDone(pFilter->otCtx, pFilter->otTransmitFrame, false, kThreadError_NoAck);
+        otPlatRadioTransmitDone(pFilter->otCtx, &pFilter->otTransmitFrame, false, kThreadError_NoAck);
     }
     else
     {
-        otPlatRadioTransmitDone(pFilter->otCtx, pFilter->otTransmitFrame, false, kThreadError_Abort);
+        otPlatRadioTransmitDone(pFilter->otCtx, &pFilter->otTransmitFrame, false, kThreadError_Abort);
     }
 
     LogFuncExit(DRIVER_DATA_PATH);

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -427,10 +427,11 @@ ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
     return error;
 }
 
-ThreadError otPlatRadioTransmit(otInstance *aInstance)
+ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
 {
     ThreadError error = kThreadError_InvalidState;
     (void)aInstance;
+    (void)aPacket;
 
     if (sState == kStateReceive)
     {
@@ -489,12 +490,12 @@ void radioReceive(otInstance *aInstance)
 
         if (otPlatDiagModeGet())
         {
-            otPlatDiagRadioTransmitDone(aInstance, isFramePending(sReceiveFrame.mPsdu), kThreadError_None);
+            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, isFramePending(sReceiveFrame.mPsdu), kThreadError_None);
         }
         else
 #endif
         {
-            otPlatRadioTransmitDone(aInstance, isFramePending(sReceiveFrame.mPsdu), kThreadError_None);
+            otPlatRadioTransmitDone(aInstance, &sTransmitFrame, isFramePending(sReceiveFrame.mPsdu), kThreadError_None);
         }
     }
     else if ((sState == kStateReceive || sState == kStateTransmit) &&
@@ -520,12 +521,12 @@ void radioSendMessage(otInstance *aInstance)
 
         if (otPlatDiagModeGet())
         {
-            otPlatDiagRadioTransmitDone(aInstance, false, kThreadError_None);
+            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, false, kThreadError_None);
         }
         else
 #endif
         {
-            otPlatRadioTransmitDone(aInstance, false, kThreadError_None);
+            otPlatRadioTransmitDone(aInstance, &sTransmitFrame, false, kThreadError_None);
         }
     }
 }

--- a/include/platform/radio.h
+++ b/include/platform/radio.h
@@ -354,16 +354,18 @@ RadioPacket *otPlatRadioGetTransmitBuffer(otInstance *aInstance);
  * 2. Transmits the psdu on the given channel and at the given transmit power.
  *
  * @param[in] aInstance  The OpenThread instance structure.
+ * @param[in] aPacket    A pointer to the packet that will be transmitted.
  *
  * @retval ::kThreadError_None         Successfully transitioned to Transmit.
  * @retval ::kThreadError_InvalidState The radio was not in the Receive state.
  */
-ThreadError otPlatRadioTransmit(otInstance *aInstance);
+ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket);
 
 /**
  * The radio driver calls this method to notify OpenThread that the transmission has completed.
  *
  * @param[in]  aInstance      The OpenThread instance structure.
+ * @param[in]  aPacket        A pointer to the packet that was transmitted.
  * @param[in]  aFramePending  TRUE if an ACK frame was received and the Frame Pending bit was set.
  * @param[in]  aError  ::kThreadError_None when the frame was transmitted, ::kThreadError_NoAck when the frame was
  *                     transmitted but no ACK was received, ::kThreadError_ChannelAccessFailure when the transmission
@@ -371,7 +373,8 @@ ThreadError otPlatRadioTransmit(otInstance *aInstance);
  *                     aborted for other reasons.
  *
  */
-extern void otPlatRadioTransmitDone(otInstance *aInstance, bool aFramePending, ThreadError aError);
+extern void otPlatRadioTransmitDone(otInstance *aInstance, RadioPacket *aPacket, bool aFramePending,
+                                    ThreadError aError);
 
 /**
  * Get the most recent RSSI measurement.
@@ -413,6 +416,7 @@ void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable);
  * The radio driver calls this method to notify OpenThread diagnostics module that the transmission has completed.
  *
  * @param[in]  aInstance      The OpenThread instance structure.
+ * @param[in]  aPacket        A pointer to the packet that was transmitted.
  * @param[in]  aFramePending  TRUE if an ACK frame was received and the Frame Pending bit was set.
  * @param[in]  aError  ::kThreadError_None when the frame was transmitted, ::kThreadError_NoAck when the frame was
  *                     transmitted but no ACK was received, ::kThreadError_ChannelAccessFailure when the transmission
@@ -420,7 +424,8 @@ void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable);
  *                     aborted for other reasons.
  *
  */
-extern void otPlatDiagRadioTransmitDone(otInstance *aInstance, bool aFramePending, ThreadError aError);
+extern void otPlatDiagRadioTransmitDone(otInstance *aInstance, RadioPacket *aPacket, bool aFramePending,
+                                        ThreadError aError);
 
 /**
  * The radio driver calls this method to notify OpenThread diagnostics module of a received packet.

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -648,6 +648,8 @@ private:
     Whitelist mWhitelist;
     Blacklist mBlacklist;
 
+    Frame *mTxFrame;
+
     otMacCounters mCounters;
 };
 

--- a/src/diag/diag_process.cpp
+++ b/src/diag/diag_process.cpp
@@ -378,6 +378,8 @@ extern "C" void otPlatDiagAlarmFired(otInstance *aInstance)
 
 extern "C" void otPlatDiagRadioTransmitDone(otInstance *aInstance, RadioPacket *aPacket, bool aRxPending, ThreadError aError)
 {
+    (void)aPacket;
+
     Diag::DiagTransmitDone(aInstance, aRxPending, aError);
 }
 

--- a/src/diag/diag_process.hpp
+++ b/src/diag/diag_process.hpp
@@ -92,6 +92,7 @@ private:
     static uint8_t sTxLen;
     static uint32_t sTxPeriod;
     static uint32_t sTxPackets;
+    static RadioPacket *sTxPacket;
     static otInstance *sContext;
 };
 

--- a/tests/unit/test_diag.cpp
+++ b/tests/unit/test_diag.cpp
@@ -55,8 +55,9 @@ extern "C" void otPlatAlarmFired(otInstance *)
 {
 }
 
-extern "C" void otPlatRadioTransmitDone(otInstance *, bool aRxPending, ThreadError aError)
+extern "C" void otPlatRadioTransmitDone(otInstance *, RadioPacket *aFrame, bool aRxPending, ThreadError aError)
 {
+    (void)aFrame;
     (void)aRxPending;
     (void)aError;
 }

--- a/tests/unit/test_fuzz.cpp
+++ b/tests/unit/test_fuzz.cpp
@@ -145,7 +145,7 @@ void TestFuzz(uint32_t aSeconds)
             if (g_fTransmit)
             {
                 g_fTransmit = false;
-                otPlatRadioTransmitDone(aInstance, true, kThreadError_None);
+                otPlatRadioTransmitDone(aInstance, &g_TransmitRadioPacket, true, kThreadError_None);
 #ifdef DBG_FUZZ
                 Log("<== transmit");
 #endif

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -203,8 +203,10 @@ extern "C" {
         }
     }
 
-    ThreadError otPlatRadioTransmit(otInstance *aInstance)
+    ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
     {
+        (void)aPacket;
+
         if (g_testPlatRadioTransmit)
         {
             return g_testPlatRadioTransmit(aInstance);
@@ -346,7 +348,7 @@ exit:
     {
     }
 
-    void otPlatDiagRadioTransmitDone(otInstance *, bool, ThreadError)
+    void otPlatDiagRadioTransmitDone(otInstance *, RadioPacket *, bool, ThreadError)
     {
     }
 


### PR DESCRIPTION
The scanning behavior was previously setting the radio to the default channel between every new scan channel transition.  This presented a window of opportunity where a scan result could be received on an unexpected channel.  It also increased the time of the scan operation.

Separately, the logic around the use of otPlatRadioGetTransmitBuffer has been modified such that OT will now request and own the transmit buffer one time during MAC construction.  Furthermore, OT will provide a pointer to this buffer when it calls otPlatRadioTransmit.  This will make it more symmetrical with otPlatRadioReceive.  Also, this change makes the notion of reusing the transmit buffer for retries more intuitive.  It was not previously obvious that calling otPlatRadioGetTransmitBuffer needed to return the same buffer with every call.