### PR TITLE
Schedule MLE Data Response messages to SEDs on network data change.

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1780,8 +1780,6 @@ void MeshForwarder::HandleDataRequest(const Mac::Address &aMacSource, const Thre
     child->mLastHeard = Timer::GetNow();
     child->mLinkFailures = 0;
 
-    mMle.HandleMacDataRequest(*child);
-
     if (child->mQueuedIndirectMessageCnt > 0)
     {
         child->mDataRequest = true;

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -560,14 +560,6 @@ public:
     ThreadError GetRouterInfo(uint16_t aRouterId, otRouterInfo &aRouterInfo);
 
     /**
-     * This method handles MAC Data Poll messages.
-     *
-     * @param[in]  aChild  The Child that sent the MAC Data Poll message.
-     *
-     */
-    void HandleMacDataRequest(const Child &aChild);
-
-    /**
      * This method indicates whether or not the given Thread partition attributes are preferred.
      *
      * @param[in]  aSingletonA   Whether or not the Thread Partition A has a single router.


### PR DESCRIPTION
This addresses the delivery delay raised in #912.

This also addresses some of the spurious Travis failures caused by delays in delivering the Data Response message to SEDs (e.g. 9.2.11).

Resolves #950.