### PR TITLE
Security Policy feature enhancement.

### DIFF
--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -57,6 +57,8 @@ KeyManager::KeyManager(ThreadNetif &aThreadNetif):
     mKeyRotationTime = kDefaultKeyRotationTime;
     mKeySwitchGuardTime = kDefaultKeySwitchGuardTime;
     mKeySwitchGuardEnabled = false;
+
+    mSecurityPolicyFlags = 0xff;
 }
 
 void KeyManager::Start(void)

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -251,6 +251,28 @@ public:
      */
     void SetKeySwitchGuardTime(uint32_t aKeySwitchGuardTime) { mKeySwitchGuardTime = aKeySwitchGuardTime; }
 
+    /**
+     * This method returns the Security Policy Flags.
+     *
+     * The Security Policy Flags specifies network administrator preferences for which
+     * security-related operations are allowed or disallowed.
+     *
+     * @returns The SecurityPolicy Flags.
+     *
+     */
+    uint8_t GetSecurityPolicyFlags(void) const { return mSecurityPolicyFlags; }
+
+    /**
+     * This method sets the Security Policy Flags.
+     *
+     * The Security Policy Flags specifies network administrator preferences for which
+     * security-related operations are allowed or disallowed.
+     *
+     * @param[in]  aSecurityPolicyFlags  The Security Policy Flags.
+     *
+     */
+    void SetSecurityPolicyFlags(uint8_t aSecurityPolicyFlags) { mSecurityPolicyFlags = aSecurityPolicyFlags; }
+
 private:
     enum
     {
@@ -286,6 +308,8 @@ private:
 
     uint8_t mKek[kMaxKeyLength];
     uint32_t mKekFrameCounter;
+
+    uint8_t mSecurityPolicyFlags;
 };
 
 /**

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2651,6 +2651,16 @@ ThreadError Mle::SendDiscoveryResponse(const Ip6::Address &aDestination, uint16_
     // Discovery Response TLV
     discoveryResponse.Init();
     discoveryResponse.SetVersion(kVersion);
+
+    if (mNetif.GetKeyManager().GetSecurityPolicyFlags() & OT_SECURITY_POLICY_NATIVE_COMMISSIONING)
+    {
+        discoveryResponse.SetNativeCommissioner(true);
+    }
+    else
+    {
+        discoveryResponse.SetNativeCommissioner(false);
+    }
+
     SuccessOrExit(error = message->Append(&discoveryResponse, sizeof(discoveryResponse)));
 
     // Extended PAN ID TLV

--- a/tools/harness-thci/ARM.py
+++ b/tools/harness-thci/ARM.py
@@ -1104,7 +1104,7 @@ class ARM(IThci):
         print '%s call powerDown' % self.port
         self.isPowerDown = True
         self._sendline('reset')
-        time.sleep(3)
+        time.sleep(5)
         self.setMAC(self.mac)
 
     def powerUp(self):
@@ -1271,7 +1271,7 @@ class ARM(IThci):
             self.setNetworkKey(self.networkKey)
             self.setMLPrefix(self.localprefix)
             self.setPSKc(self.pskc)
-            self.__setSecurityPolicy(self.securityPolicySecs)
+            self.__setSecurityPolicy("672 onrcb")
             self.__setChannelMask("0xffff")
             self.isWhiteListEnabled = False
             self.isBlackListEnabled = False
@@ -1913,7 +1913,16 @@ class ARM(IThci):
         return self.__sendCommand(cmd)
 
     def startNativeCommissioner(self, strPSKc='GRLpassWord'):
-        pass
+        #TODO: Support the whole Native Commissioner functionality
+        #      Currently it only aims to trigger a Discovery Request message to pass Certification test 5.8.4
+        print '%s call startNativeCommissioner' % self.port
+        self.__sendCommand('ifconfig up')
+        cmd = 'joiner start %s' %(strPSKc)
+        print cmd
+        if self.__sendCommand(cmd)[0] == "Done":
+            return True
+        else:
+            return False
 
     def startCollapsedCommissioner(self):
         """start Collapsed Commissioner
@@ -2493,6 +2502,8 @@ class ARM(IThci):
 
     def sendBeacons(self, sAddr, xCommissionerSessionId, listChannelMask, xPanId):
         print '%s call sendBeacons' % self.port
+        self._sendline('scan')
+        return True
 
     def updateRouterStatus(self):
         print '%s call updateRouterStatus' % self.port


### PR DESCRIPTION
* Initialize the Security Policy Tlv in Active Dataset

* Apply Security Policy configuration from Active Dataset

* Do not include NetworkMasterKey Tlv in MGMT_GET.rsp if Security Policy 'O' bit is disabled

* THCI: add startNativeCommissioner() and sendBeacons() support

It helps to pass Certification test Leader_5_8_4:
[Leader_5_8_4.zip](https://github.com/openthread/openthread/files/577798/Leader_5_8_4.zip)
