### PR TITLE
Enable local Pending Dataset when device detaches from the network

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -236,11 +236,6 @@ ThreadError Mle::Stop(bool aClearNetworkDatasets)
     SetStateDetached();
     mNetif.RemoveUnicastAddress(mMeshLocal16);
 
-    if (mDeviceState == kDeviceStateLeader)
-    {
-        mNetif.RemoveUnicastAddress(mLeaderAloc);
-    }
-
     if (aClearNetworkDatasets)
     {
         mNetif.GetActiveDataset().Clear(true);
@@ -325,6 +320,12 @@ ThreadError Mle::BecomeDetached(void)
     otLogFuncEntry();
 
     VerifyOrExit(mDeviceState != kDeviceStateDisabled, error = kThreadError_InvalidState);
+
+    if (mReattachState == kReattachStop)
+    {
+        mNetif.GetPendingDataset().UpdateDelayTimer();
+        mNetif.GetPendingDataset().Set(mNetif.GetPendingDataset().GetLocal());
+    }
 
     SetStateDetached();
     SetRloc16(Mac::kShortAddrInvalid);


### PR DESCRIPTION
Resolves #904.

I think it is the simplest way to achieve this without considering whether there is a running Delay Timer, or whether the Network Pending Dataset is the same with Local Pending Dataset. It just cover Network Pending Dataset with Local Pending Dataset, and restart the Delay Timer, nothing will actually happen if there is no Local Pending Dataset.

Also remove a dead code in `Mle::Stop()`.