### PR TITLE
THCI: getChildTimeoutValue() should return integer type

### DIFF
--- a/tools/harness-thci/ARM.py
+++ b/tools/harness-thci/ARM.py
@@ -1841,7 +1841,8 @@ class ARM(IThci):
     def getChildTimeoutValue(self):
         """get child timeout"""
         print '%s call getChildTimeoutValue' % self.port
-        return self.__sendCommand('childtimeout')[0]
+        childTimeout = self.__sendCommand('childtimeout')[0]
+        return int(childTimeout)
 
     def diagnosticGet(self, strDestinationAddr, listTLV_ids=[]):
         if not listTLV_ids:


### PR DESCRIPTION
Harness expects the return value of getChildTimeoutValue() is of integer type when used in Test 5.1.2 and 5.5.3.

@xiaom-GitHub @jwhui , please have a review.