### PR TITLE
Fix a packet receive issue in CC2538 radio driver

### DIFF
--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -381,7 +381,9 @@ void cc2538RadioProcess(otInstance *aInstance)
 {
     readFrame();
 
-    if ((sState == kStateReceive) && (sReceiveFrame.mLength > 0))
+    if ((sState == kStateReceive && sReceiveFrame.mLength > 0) ||
+        (sState == kStateTransmit && sReceiveFrame.mLength > 0 &&
+         (sReceiveFrame.mPsdu[0] & IEEE802154_FRAME_TYPE_MASK) != IEEE802154_FRAME_TYPE_ACK))
     {
 #if OPENTHREAD_ENABLE_DIAG
 


### PR DESCRIPTION
If a device sends an ACK required packet, but receives a packet other than ACK,
it should trigger the ReceiveDone() method with the received packet.

It would be helpful to make some Certification tests more stable, and the issue is exposed in the following case:
After the Joiner Router relay the JOIN_FIN.rsp to Joiner, then Joiner Router wants to send JOIN_ENT.ntf to Joiner, and Joiner wants to send DTLS Alert to Joiner Router, so in this case the Joiner Router may receive the DTLS Alert message other than the ACK to JOIN_FIN.rsp, but the DTLS Alert message will not be triggered to upper layer in current implementation.
