### PR TITLE
CoAP Server API

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -746,6 +746,36 @@ AM_CONDITIONAL([OPENTHREAD_ENABLE_DHCP6_SERVER], [test "${enable_dhcp6_server}" 
 AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_DHCP6_SERVER],[${OPENTHREAD_ENABLE_DHCP6_SERVER}],[Define to 1 if you want to enable DHCPv6 Server])
 
 #
+# Application CoAP
+#
+
+AC_ARG_ENABLE(application_coap,
+    [AS_HELP_STRING([--enable-application-coap],[Enable CoAP to an application.@<:@default=no@:>@.])],
+    [
+        case "${enableval}" in
+
+        no|yes)
+            enable_application_coap=${enableval}
+            ;;
+
+        *)
+            AC_MSG_ERROR([Invalid value ${enable_application_coap} for --enable-application-coap])
+            ;;
+        esac
+    ],
+    [enable_application_coap=no])
+
+if test "$enable_application_coap" = "yes"; then
+    OPENTHREAD_ENABLE_APPLICATION_COAP=1
+else
+    OPENTHREAD_ENABLE_APPLICATION_COAP=0
+fi
+
+AC_SUBST(OPENTHREAD_ENABLE_APPLICATION_COAP)
+AM_CONDITIONAL([OPENTHREAD_ENABLE_APPLICATION_COAP], [test "${enable_application_coap}" = "yes"])
+AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_APPLICATION_COAP],[${OPENTHREAD_ENABLE_APPLICATION_COAP}],[Define to 1 if you want to enable CoAP to an application.])
+
+#
 # Examples
 #
 
@@ -1007,6 +1037,7 @@ AC_MSG_NOTICE([
   OpenThread Certification log support      : ${enable_cert_log}
   OpenThread DHCPv6 Server support          : ${enable_dhcp6_server}
   OpenThread DHCPv6 Client support          : ${enable_dhcp6_client}
+  Openthread Application CoAP support       : ${enable_application_coap}
   OpenThread examples                       : ${OPENTHREAD_EXAMPLES}
   OpenThread platform information           : ${PLATFORM_INFO}
 

--- a/include/openthread-coap.h
+++ b/include/openthread-coap.h
@@ -53,6 +53,8 @@ extern "C" {
  *
  */
 
+#define OT_DEFAULT_COAP_PORT  5683  ///< Default CoAP port, as specified in RFC 7252
+
 /**
  * CoAP Type values.
  *
@@ -141,7 +143,32 @@ typedef void (*otCoapResponseHandler)(void *aContext, otCoapHeader *aHeader, otM
                                       ThreadError aResult);
 
 /**
- * This method initializes the CoAP header.
+ * This function pointer is called when a CoAP request with a given Uri-Path is received.
+ *
+ * @param[in]  aContext      A pointer to arbitrary context information.
+ * @param[in]  aHeader       A pointer to the CoAP header.
+ * @param[in]  aMessage      A pointer to the message.
+ * @param[in]  aMessageInfo  A pointer to the message info for @p aMessage.
+ *
+ */
+typedef void (*otCoapRequestHandler)(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                     const otMessageInfo *aMessageInfo);
+
+/**
+ * This structure represents a CoAP resource.
+ *
+ */
+typedef struct otCoapResource
+{
+    const char *mUriPath;
+    otCoapRequestHandler mHandler;
+    void *mContext;
+    struct otCoapResource *mNext;
+} otCoapResource;
+
+#if OPENTHREAD_ENABLE_APPLICATION_COAP
+/**
+ * This function initializes the CoAP header.
  *
  * @param[inout] aHeader  A pointer to the CoAP header to initialize.
  * @param[in]    aType    CoAP message type.
@@ -151,7 +178,7 @@ typedef void (*otCoapResponseHandler)(void *aContext, otCoapHeader *aHeader, otM
 void otCoapHeaderInit(otCoapHeader *aHeader, otCoapType aType, otCoapCode aCode);
 
 /**
- * This method sets the Token value and length in a header.
+ * This function sets the Token value and length in a header.
  *
  * @param[inout]  aHeader       A pointer to the CoAP header.
  * @param[in]     aToken        A pointer to the Token value.
@@ -161,7 +188,16 @@ void otCoapHeaderInit(otCoapHeader *aHeader, otCoapType aType, otCoapCode aCode)
 void otCoapHeaderSetToken(otCoapHeader *aHeader, const uint8_t *aToken, uint8_t aTokenLength);
 
 /**
- * This method appends a CoAP option in a header.
+ * This function sets the Token length and randomizes its value.
+ *
+ * @param[inout]  aHeader       A pointer to the CoAP header.
+ * @param[in]     aTokenLength  The Length of a Token to set.
+ *
+ */
+void otCoapHeaderGenerateToken(otCoapHeader *aHeader, uint8_t aTokenLength);
+
+/**
+ * This function appends a CoAP option in a header.
  *
  * @param[inout]  aHeader  A pointer to the CoAP header.
  * @param[in]     aOption  A pointer to the CoAP option.
@@ -174,7 +210,20 @@ void otCoapHeaderSetToken(otCoapHeader *aHeader, const uint8_t *aToken, uint8_t 
 ThreadError otCoapHeaderAppendOption(otCoapHeader *aHeader, const otCoapOption *aOption);
 
 /**
- * This method adds Payload Marker indicating beginning of the payload to the CoAP header.
+ * This function appends an Uri-Path option.
+ *
+ * @param[inout]  aHeader   A pointer to the CoAP header.
+ * @param[in]     aUriPath  A pointer to a NULL-terminated string.
+ *
+ * @retval kThreadError_None         Successfully appended the option.
+ * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
+ * @retval kThreadError_NoBufs       The option length exceeds the buffer size.
+ *
+ */
+ThreadError otCoapHeaderAppendUriPathOptions(otCoapHeader *aHeader, const char *aUriPath);
+
+/**
+ * This function adds Payload Marker indicating beginning of the payload to the CoAP header.
  *
  * @param[inout]  aHeader  A pointer to the CoAP header.
  *
@@ -185,27 +234,86 @@ ThreadError otCoapHeaderAppendOption(otCoapHeader *aHeader, const otCoapOption *
 void otCoapHeaderSetPayloadMarker(otCoapHeader *aHeader);
 
 /**
- * This method returns a pointer to the current option.
+ * This function sets the Message ID value.
+ *
+ * @param[in]  aHeader     A pointer to the CoAP header.
+ * @param[in]  aMessageId  The Message ID value.
+ *
+ */
+void otCoapHeaderSetMessageId(otCoapHeader *aHeader, uint16_t aMessageId);
+
+/**
+ * This function returns the Type value.
+ *
+ * @param[in]  aHeader  A pointer to the CoAP header.
+ *
+ * @returns The Type value.
+ *
+ */
+otCoapType otCoapHeaderGetType(const otCoapHeader *aHeader);
+
+/**
+ * This function returns the Code value.
+ *
+ * @param[in]  aHeader  A pointer to the CoAP header.
+ *
+ * @returns The Code value.
+ *
+ */
+otCoapCode otCoapHeaderGetCode(const otCoapHeader *aHeader);
+
+/**
+* This function returns the Message ID value.
+*
+* @param[in]  aHeader  A pointer to the CoAP header.
+*
+* @returns The Message ID value.
+*
+*/
+uint16_t otCoapHeaderGetMessageId(const otCoapHeader *aHeader);
+
+/**
+ * This function returns the Token length.
+ *
+ * @param[in]  aHeader  A pointer to the CoAP header.
+ *
+ * @returns The Token length.
+ *
+ */
+uint8_t otCoapHeaderGetTokenLength(const otCoapHeader *aHeader);
+
+/**
+ * This function returns a pointer to the Token value.
+ *
+ * @param[in]  aHeader  A pointer to the CoAP header.
+ *
+ * @returns A pointer to the Token value.
+ *
+ */
+const uint8_t *otCoapHeaderGetToken(const otCoapHeader *aHeader);
+
+/**
+ * This function returns a pointer to the current option.
  *
  * @param[in]  aHeader  A pointer to the CoAP header.
  *
  * @returns A pointer to the current option. If no option is present NULL pointer is returned.
  *
  */
-const otCoapOption *otCoapGetCurrentOption(const otCoapHeader *aHeader);
+const otCoapOption *otCoapHeaderGetCurrentOption(const otCoapHeader *aHeader);
 
 /**
- * This method returns a pointer to the next option.
+ * This function returns a pointer to the next option.
  *
  * @param[in]  aHeader  A pointer to the CoAP header.
  *
  * @returns A pointer to the next option. If no more options are present NULL pointer is returned.
  *
  */
-const otCoapOption *otCoapGetNextOption(otCoapHeader *aHeader);
+const otCoapOption *otCoapHeaderGetNextOption(otCoapHeader *aHeader);
 
 /**
- * This method creates a new message with a CoAP header.
+ * This function creates a new message with a CoAP header.
  *
  * @param[in]  aInstance     A pointer to an OpenThread instance.
  * @param[in]  aHeader  A pointer to a CoAP header that is used to create the message.
@@ -213,10 +321,10 @@ const otCoapOption *otCoapGetNextOption(otCoapHeader *aHeader);
  * @returns A pointer to the message or NULL if failed to allocate message.
  *
  */
-otMessage otNewCoapMessage(otInstance *aInstance, const otCoapHeader *aHeader);
+otMessage otCoapNewMessage(otInstance *aInstance, const otCoapHeader *aHeader);
 
 /**
- * This method sends a CoAP message.
+ * This function sends a CoAP request.
  *
  * If a response for a request is expected, respective function and contex information should be provided.
  * If no response is expected, these arguments should be NULL pointers.
@@ -231,8 +339,74 @@ otMessage otNewCoapMessage(otInstance *aInstance, const otCoapHeader *aHeader);
  * @retval kThreadError_NoBufs Failed to allocate retransmission data.
  *
  */
-ThreadError otSendCoapMessage(otInstance *aInstance, otMessage aMessage, const otMessageInfo *aMessageInfo,
+ThreadError otCoapSendRequest(otInstance *aInstance, otMessage aMessage, const otMessageInfo *aMessageInfo,
                               otCoapResponseHandler aHandler, void *aContext);
+
+/**
+ * This function starts the CoAP server.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ *
+ * @retval kThreadError_None  Successfully started the CoAP server.
+ *
+ */
+ThreadError otCoapServerStart(otInstance *aInstance);
+
+/**
+ * This function stops the CoAP server.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ *
+ * @retval kThreadError_None  Successfully stopped the CoAP server.
+ *
+ */
+ThreadError otCoapServerStop(otInstance *aInstance);
+
+/**
+ * This function sets CoAP server's port number.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ * @param[in]  aPort  A port number to set.
+ *
+ * @retval kThreadError_None  Binding with a port succeeded.
+ *
+ */
+ThreadError otCoapServerSetPort(otInstance *aInstance, uint16_t aPort);
+
+/**
+ * This function adds a resource to the CoAP server.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ * @param[in]  aResource  A pointer to the resource.
+ *
+ * @retval kThreadError_None     Successfully added @p aResource.
+ * @retval kThreadError_Already  The @p aResource was already added.
+ *
+ */
+ThreadError otCoapServerAddResource(otInstance *aInstance, otCoapResource *aResource);
+
+/**
+ * This function removes a resource from the CoAP server.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ * @param[in]  aResource  A pointer to the resource.
+ *
+ */
+void otCoapServerRemoveResource(otInstance *aInstance, otCoapResource *aResource);
+
+/**
+ * This function sends a CoAP response from the server.
+ *
+ * @param[in]  aInstance     A pointer to an OpenThread instance.
+ * @param[in]  aMessage      A pointer to the CoAP response to send.
+ * @param[in]  aMessageInfo  A pointer to the message info associated with @p aMessage.
+ *
+ * @retval kThreadError_None    Successfully enqueued the CoAP response message.
+ * @retval kThreadError_NoBufs  Insufficient buffers available to send the CoAP response.
+ *
+ */
+ThreadError otCoapSendResponse(otInstance *aInstance, otMessage aMessage, const otMessageInfo *aMessageInfo);
+#endif // OPENTHREAD_ENABLE_APPLICATION_COAP
 
 /**
  * @}

--- a/src/core/coap/coap_client.cpp
+++ b/src/core/coap/coap_client.cpp
@@ -436,6 +436,7 @@ exit:
 RequestMetadata::RequestMetadata(bool aConfirmable, const Ip6::MessageInfo &aMessageInfo,
                                  otCoapResponseHandler aHandler, void *aContext)
 {
+    mPayloadMarker = kPayloadMarker;
     mDestinationPort = aMessageInfo.GetPeerPort();
     mDestinationAddress = aMessageInfo.GetPeerAddr();
     mResponseHandler = aHandler;

--- a/src/core/coap/coap_client.hpp
+++ b/src/core/coap/coap_client.hpp
@@ -71,7 +71,9 @@ enum
     kProcessingDelay            = kAckTimeout,
     kMaxRtt                     = 2 * kMaxLatency + kProcessingDelay,
     kExchangeLifetime           = kMaxTransmitSpan + 2 * (kMaxLatency) + kProcessingDelay,
-    kNonLifetime                = kMaxTransmitSpan + kMaxLatency
+    kNonLifetime                = kMaxTransmitSpan + kMaxLatency,
+
+    kPayloadMarker              = 0xff
 };
 
 /**
@@ -90,6 +92,7 @@ public:
      *
      */
     RequestMetadata(void):
+        mPayloadMarker(kPayloadMarker),
         mDestinationPort(0),
         mResponseHandler(NULL),
         mResponseContext(NULL),
@@ -169,7 +172,7 @@ public:
     bool IsLater(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mNextTimerShot) < 0); };
 
 private:
-
+    uint8_t               mPayloadMarker;         ///< A value indicating beginning of the metadata.
     Ip6::Address          mDestinationAddress;    ///< IPv6 address of the message destination.
     uint16_t              mDestinationPort;       ///< UDP port of the message destination.
     otCoapResponseHandler mResponseHandler;       ///< A function pointer that is called on response reception.

--- a/src/core/coap/coap_server.cpp
+++ b/src/core/coap/coap_server.cpp
@@ -61,7 +61,7 @@ ThreadError Server::AddResource(Resource &aResource)
 {
     ThreadError error = kThreadError_None;
 
-    for (Resource *cur = mResources; cur; cur = cur->mNext)
+    for (Resource *cur = mResources; cur; cur = cur->GetNext())
     {
         VerifyOrExit(cur != &aResource, error = kThreadError_Already);
     }
@@ -77,11 +77,11 @@ void Server::RemoveResource(Resource &aResource)
 {
     if (mResources == &aResource)
     {
-        mResources = aResource.mNext;
+        mResources = aResource.GetNext();
     }
     else
     {
-        for (Resource *cur = mResources; cur; cur = cur->mNext)
+        for (Resource *cur = mResources; cur; cur = cur->GetNext())
         {
             if (cur->mNext == &aResource)
             {
@@ -145,7 +145,7 @@ void Server::ProcessReceivedMessage(Message &aMessage, const Ip6::MessageInfo &a
 
     curUriPath[0] = '\0';
 
-    for (Resource *resource = mResources; resource; resource = resource->mNext)
+    for (Resource *resource = mResources; resource; resource = resource->GetNext())
     {
         if (strcmp(resource->mUriPath, uriPath) == 0)
         {
@@ -156,6 +156,16 @@ void Server::ProcessReceivedMessage(Message &aMessage, const Ip6::MessageInfo &a
 
 exit:
     {}
+}
+
+ThreadError Server::SetPort(uint16_t aPort)
+{
+    mPort = aPort;
+
+    Ip6::SockAddr sockaddr;
+    sockaddr.mPort = mPort;
+
+    return mSocket.Bind(sockaddr);
 }
 
 }  // namespace Coap

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -636,10 +636,12 @@ exit:
     otLogFuncExit();
 }
 
-void Commissioner::HandleRelayReceive(void *aContext, Coap::Header &aHeader,
-                                      Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Commissioner::HandleRelayReceive(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                      const otMessageInfo *aMessageInfo)
 {
-    static_cast<Commissioner *>(aContext)->HandleRelayReceive(aHeader, aMessage, aMessageInfo);
+    static_cast<Commissioner *>(aContext)->HandleRelayReceive(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void Commissioner::HandleRelayReceive(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -720,10 +722,12 @@ exit:
     otLogFuncExit();
 }
 
-void Commissioner::HandleDatasetChanged(void *aContext, Coap::Header &aHeader,
-                                        Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Commissioner::HandleDatasetChanged(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                        const otMessageInfo *aMessageInfo)
 {
-    static_cast<Commissioner *>(aContext)->HandleDatasetChanged(aHeader, aMessage, aMessageInfo);
+    static_cast<Commissioner *>(aContext)->HandleDatasetChanged(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void Commissioner::HandleDatasetChanged(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -768,10 +772,12 @@ exit:
     otLogFuncExit();
 }
 
-void Commissioner::HandleJoinerFinalize(void *aContext, Coap::Header &aHeader,
-                                        Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Commissioner::HandleJoinerFinalize(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                        const otMessageInfo *aMessageInfo)
 {
-    static_cast<Commissioner *>(aContext)->HandleJoinerFinalize(aHeader, aMessage, aMessageInfo);
+    static_cast<Commissioner *>(aContext)->HandleJoinerFinalize(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void Commissioner::HandleJoinerFinalize(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -203,16 +203,16 @@ private:
                                               otMessage aMessage, ThreadError aResult);
     void HandleLeaderKeepAliveResponse(Coap::Header *aHeader, Message *aMessage, ThreadError aResult);
 
-    static void HandleRelayReceive(void *aContext, Coap::Header &aHeader,
-                                   Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    static void HandleRelayReceive(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                   const otMessageInfo *aMessageInfo);
     void HandleRelayReceive(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleDatasetChanged(void *aContext, Coap::Header &aHeader,
-                                     Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    static void HandleDatasetChanged(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                     const otMessageInfo *aMessageInfo);
     void HandleDatasetChanged(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleJoinerFinalize(void *aContext, Coap::Header &aHeader,
-                                     Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    static void HandleJoinerFinalize(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                     const otMessageInfo *aMessageInfo);
     void HandleJoinerFinalize(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     void SendJoinFinalizeResponse(const Coap::Header &aRequestHeader, StateTlv::State aState);

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -122,10 +122,12 @@ exit:
     return error;
 }
 
-void EnergyScanClient::HandleReport(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                    const Ip6::MessageInfo &aMessageInfo)
+void EnergyScanClient::HandleReport(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                    const otMessageInfo *aMessageInfo)
 {
-    static_cast<EnergyScanClient *>(aContext)->HandleReport(aHeader, aMessage, aMessageInfo);
+    static_cast<EnergyScanClient *>(aContext)->HandleReport(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void EnergyScanClient::HandleReport(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/meshcop/energy_scan_client.hpp
+++ b/src/core/meshcop/energy_scan_client.hpp
@@ -78,8 +78,8 @@ public:
                           const Ip6::Address &aAddress, otCommissionerEnergyReportCallback aCallback, void *aContext);
 
 private:
-    static void HandleReport(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                             const Ip6::MessageInfo &aMessageInfo);
+    static void HandleReport(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                             const otMessageInfo *aMessageInfo);
     void HandleReport(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     ThreadError SendResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aRequestMessageInfo);

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -252,10 +252,12 @@ exit:
     otLogFuncExit();
 }
 
-void Joiner::HandleJoinerEntrust(void *aContext, Coap::Header &aHeader,
-                                 Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Joiner::HandleJoinerEntrust(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                 const otMessageInfo *aMessageInfo)
 {
-    static_cast<Joiner *>(aContext)->HandleJoinerEntrust(aHeader, aMessage, aMessageInfo);
+    static_cast<Joiner *>(aContext)->HandleJoinerEntrust(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void Joiner::HandleJoinerEntrust(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -101,8 +101,8 @@ private:
                                              otMessage aMessage, ThreadError result);
     void HandleJoinerFinalizeResponse(Coap::Header *aHeader, Message *aMessage, ThreadError result);
 
-    static void HandleJoinerEntrust(void *aContext, Coap::Header &aHeader,
-                                    Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    static void HandleJoinerEntrust(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                    const otMessageInfo *aMessageInfo);
     void HandleJoinerEntrust(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     void SendJoinerEntrustResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aRequestInfo);
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -252,10 +252,12 @@ exit:
     otLogFuncExitErr(error);
 }
 
-void JoinerRouter::HandleRelayTransmit(void *aContext, Coap::Header &aHeader,
-                                       Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void JoinerRouter::HandleRelayTransmit(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                       const otMessageInfo *aMessageInfo)
 {
-    static_cast<JoinerRouter *>(aContext)->HandleRelayTransmit(aHeader, aMessage, aMessageInfo);
+    static_cast<JoinerRouter *>(aContext)->HandleRelayTransmit(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void JoinerRouter::HandleRelayTransmit(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -85,8 +85,8 @@ private:
     static void HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo);
     void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleRelayTransmit(void *aContext, Coap::Header &aHeader,
-                                    Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    static void HandleRelayTransmit(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                    const otMessageInfo *aMessageInfo);
     void HandleRelayTransmit(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     ThreadError SendJoinerEntrust(const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -48,8 +48,8 @@ namespace Thread {
 namespace MeshCoP {
 
 Leader::Leader(ThreadNetif &aThreadNetif):
-    mPetition(OPENTHREAD_URI_LEADER_PETITION, HandlePetition, this),
-    mKeepAlive(OPENTHREAD_URI_LEADER_KEEP_ALIVE, HandleKeepAlive, this),
+    mPetition(OPENTHREAD_URI_LEADER_PETITION, Leader::HandlePetition, this),
+    mKeepAlive(OPENTHREAD_URI_LEADER_KEEP_ALIVE, Leader::HandleKeepAlive, this),
     mCoapServer(aThreadNetif.GetCoapServer()),
     mCoapClient(aThreadNetif.GetCoapClient()),
     mNetworkData(aThreadNetif.GetNetworkDataLeader()),
@@ -61,10 +61,12 @@ Leader::Leader(ThreadNetif &aThreadNetif):
     mCoapServer.AddResource(mKeepAlive);
 }
 
-void Leader::HandlePetition(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                            const Ip6::MessageInfo &aMessageInfo)
+void Leader::HandlePetition(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                            const otMessageInfo *aMessageInfo)
 {
-    static_cast<Leader *>(aContext)->HandlePetition(aHeader, aMessage, aMessageInfo);
+    static_cast<Leader *>(aContext)->HandlePetition(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void Leader::HandlePetition(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -149,10 +151,12 @@ exit:
     return error;
 }
 
-void Leader::HandleKeepAlive(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                             const Ip6::MessageInfo &aMessageInfo)
+void Leader::HandleKeepAlive(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                             const otMessageInfo *aMessageInfo)
 {
-    static_cast<Leader *>(aContext)->HandleKeepAlive(aHeader, aMessage, aMessageInfo);
+    static_cast<Leader *>(aContext)->HandleKeepAlive(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void Leader::HandleKeepAlive(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/meshcop/leader.hpp
+++ b/src/core/meshcop/leader.hpp
@@ -90,14 +90,14 @@ private:
     static void HandleTimer(void *aContext);
     void HandleTimer(void);
 
-    static void HandlePetition(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                               const Ip6::MessageInfo &aMessageInfo);
+    static void HandlePetition(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                               const otMessageInfo *aMessageInfo);
     void HandlePetition(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     ThreadError SendPetitionResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
                                      StateTlv::State aState);
 
-    static void HandleKeepAlive(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                const Ip6::MessageInfo &aMessageInfo);
+    static void HandleKeepAlive(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                const otMessageInfo *aMessageInfo);
     void HandleKeepAlive(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     ThreadError SendKeepAliveResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
                                       StateTlv::State aState);

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -105,10 +105,12 @@ exit:
     return error;
 }
 
-void PanIdQueryClient::HandleConflict(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                      const Ip6::MessageInfo &aMessageInfo)
+void PanIdQueryClient::HandleConflict(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                      const otMessageInfo *aMessageInfo)
 {
-    static_cast<PanIdQueryClient *>(aContext)->HandleConflict(aHeader, aMessage, aMessageInfo);
+    static_cast<PanIdQueryClient *>(aContext)->HandleConflict(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void PanIdQueryClient::HandleConflict(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/meshcop/panid_query_client.hpp
+++ b/src/core/meshcop/panid_query_client.hpp
@@ -76,8 +76,8 @@ public:
                           otCommissionerPanIdConflictCallback aCallback, void *aContext);
 
 private:
-    static void HandleConflict(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                               const Ip6::MessageInfo &aMessageInfo);
+    static void HandleConflict(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                               const otMessageInfo *aMessageInfo);
     void HandleConflict(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     ThreadError SendConflictResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aRequestMessageInfo);

--- a/src/core/openthread-instance.h
+++ b/src/core/openthread-instance.h
@@ -43,6 +43,7 @@
 #include <crypto/mbedtls.hpp>
 #include <net/ip6.hpp>
 #include <thread/thread_netif.hpp>
+#include <coap/coap_server.hpp>
 
 /**
  * This type represents all the static / global variables used by OpenThread allocated in one place.
@@ -73,6 +74,10 @@ typedef struct otInstance
 #endif
     Thread::Ip6::Ip6 mIp6;
     Thread::ThreadNetif mThreadNetif;
+
+#if OPENTHREAD_ENABLE_APPLICATION_COAP
+    Thread::Coap::Server mApplicationCoapServer;
+#endif // OPENTHREAD_ENABLE_APPLICATION_COAP
 
     // Constructor
     otInstance(void);

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -62,8 +62,10 @@
 #include <thread/thread_uris.hpp>
 #include <utils/slaac_address.hpp>
 #include <openthread-instance.h>
+#include <openthread-coap.h>
 #include <coap/coap_header.hpp>
 #include <coap/coap_client.hpp>
+#include <coap/coap_server.hpp>
 
 #ifndef OPENTHREAD_MULTIPLE_INSTANCE
 static otDEFINE_ALIGNED_VAR(sInstanceRaw, sizeof(otInstance), uint64_t);
@@ -76,6 +78,9 @@ otInstance::otInstance(void) :
     mActiveScanCallback(NULL),
     mActiveScanCallbackContext(NULL),
     mThreadNetif(mIp6)
+#if OPENTHREAD_ENABLE_APPLICATION_COAP
+    , mApplicationCoapServer(mIp6.mUdp, OT_DEFAULT_COAP_PORT)
+#endif // OPENTHREAD_ENABLE_APPLICATION_COAP
 {
 }
 
@@ -1678,6 +1683,7 @@ ThreadError otJoinerStop(otInstance *aInstance)
 }
 #endif  // OPENTHREAD_ENABLE_JOINER
 
+#if OPENTHREAD_ENABLE_APPLICATION_COAP
 void otCoapHeaderInit(otCoapHeader *aHeader, otCoapType aType, otCoapCode aCode)
 {
     Coap::Header *header = static_cast<Coap::Header *>(aHeader);
@@ -1689,14 +1695,54 @@ void otCoapHeaderSetToken(otCoapHeader *aHeader, const uint8_t *aToken, uint8_t 
     static_cast<Coap::Header *>(aHeader)->SetToken(aToken, aTokenLength);
 }
 
+void otCoapHeaderGenerateToken(otCoapHeader *aHeader, uint8_t aTokenLength)
+{
+    static_cast<Coap::Header *>(aHeader)->SetToken(aTokenLength);
+}
+
 ThreadError otCoapHeaderAppendOption(otCoapHeader *aHeader, const otCoapOption *aOption)
 {
     return static_cast<Coap::Header *>(aHeader)->AppendOption(*static_cast<const Coap::Header::Option *>(aOption));
 }
 
+ThreadError otCoapHeaderAppendUriPathOptions(otCoapHeader *aHeader, const char *aUriPath)
+{
+    return static_cast<Coap::Header *>(aHeader)->AppendUriPathOptions(aUriPath);
+}
+
 void otCoapHeaderSetPayloadMarker(otCoapHeader *aHeader)
 {
     static_cast<Coap::Header *>(aHeader)->SetPayloadMarker();
+}
+
+void otCoapHeaderSetMessageId(otCoapHeader *aHeader, uint16_t aMessageId)
+{
+    return static_cast<Coap::Header *>(aHeader)->SetMessageId(aMessageId);
+}
+
+otCoapType otCoapHeaderGetType(const otCoapHeader *aHeader)
+{
+    return static_cast<const Coap::Header *>(aHeader)->GetType();
+}
+
+otCoapCode otCoapHeaderGetCode(const otCoapHeader *aHeader)
+{
+    return static_cast<const Coap::Header *>(aHeader)->GetCode();
+}
+
+uint16_t otCoapHeaderGetMessageId(const otCoapHeader *aHeader)
+{
+    return static_cast<const Coap::Header *>(aHeader)->GetMessageId();
+}
+
+uint8_t otCoapHeaderGetTokenLength(const otCoapHeader *aHeader)
+{
+    return static_cast<const Coap::Header *>(aHeader)->GetTokenLength();
+}
+
+const uint8_t *otCoapHeaderGetToken(const otCoapHeader *aHeader)
+{
+    return static_cast<const Coap::Header *>(aHeader)->GetToken();
 }
 
 const otCoapOption *otCoapGetCurrentOption(const otCoapHeader *aHeader)
@@ -1709,12 +1755,12 @@ const otCoapOption *otCoapGetNextOption(otCoapHeader *aHeader)
     return static_cast<const otCoapOption *>(static_cast<Coap::Header *>(aHeader)->GetNextOption());
 }
 
-otMessage otNewCoapMessage(otInstance *aInstance, const otCoapHeader *aHeader)
+otMessage otCoapNewMessage(otInstance *aInstance, const otCoapHeader *aHeader)
 {
     return aInstance->mThreadNetif.GetCoapClient().NewMessage(*(static_cast<const Coap::Header *>(aHeader)));
 }
 
-ThreadError otSendCoapMessage(otInstance *aInstance, otMessage aMessage, const otMessageInfo *aMessageInfo,
+ThreadError otCoapSendRequest(otInstance *aInstance, otMessage aMessage, const otMessageInfo *aMessageInfo,
                               otCoapResponseHandler aHandler, void *aContext)
 {
     return aInstance->mThreadNetif.GetCoapClient().SendMessage(
@@ -1722,6 +1768,38 @@ ThreadError otSendCoapMessage(otInstance *aInstance, otMessage aMessage, const o
                *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
                aHandler, aContext);
 }
+
+ThreadError otCoapServerStart(otInstance *aInstance)
+{
+    return aInstance->mApplicationCoapServer.Start();
+}
+
+ThreadError otCoapServerStop(otInstance *aInstance)
+{
+    return aInstance->mApplicationCoapServer.Stop();
+}
+
+ThreadError otCoapServerSetPort(otInstance *aInstance, uint16_t aPort)
+{
+    return aInstance->mApplicationCoapServer.SetPort(aPort);
+}
+
+ThreadError otCoapServerAddResource(otInstance *aInstance, otCoapResource *aResource)
+{
+    return aInstance->mApplicationCoapServer.AddResource(*static_cast<Coap::Resource *>(aResource));
+}
+
+void otCoapServerRemoveResource(otInstance *aInstance, otCoapResource *aResource)
+{
+    aInstance->mApplicationCoapServer.RemoveResource(*static_cast<Coap::Resource *>(aResource));
+}
+
+ThreadError otCoapSendResponse(otInstance *aInstance, otMessage aMessage, const otMessageInfo *aMessageInfo)
+{
+    return aInstance->mApplicationCoapServer.SendMessage(
+               *static_cast<Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+}
+#endif // OPENTHREAD_ENABLE_APPLICATION_COAP
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -207,10 +207,12 @@ exit:
     return error;
 }
 
-void AddressResolver::HandleAddressNotification(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                                const Ip6::MessageInfo &aMessageInfo)
+void AddressResolver::HandleAddressNotification(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                                const otMessageInfo *aMessageInfo)
 {
-    static_cast<AddressResolver *>(aContext)->HandleAddressNotification(aHeader, aMessage, aMessageInfo);
+    static_cast<AddressResolver *>(aContext)->HandleAddressNotification(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void AddressResolver::HandleAddressNotification(Coap::Header &aHeader, Message &aMessage,
@@ -389,10 +391,12 @@ exit:
     }
 }
 
-void AddressResolver::HandleAddressError(void *aContext, Coap::Header &aHeader,
-                                         Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void AddressResolver::HandleAddressError(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                         const otMessageInfo *aMessageInfo)
 {
-    static_cast<AddressResolver *>(aContext)->HandleAddressError(aHeader, aMessage, aMessageInfo);
+    static_cast<AddressResolver *>(aContext)->HandleAddressError(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessage,
@@ -467,10 +471,12 @@ exit:
     {}
 }
 
-void AddressResolver::HandleAddressQuery(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                         const Ip6::MessageInfo &aMessageInfo)
+void AddressResolver::HandleAddressQuery(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                         const otMessageInfo *aMessageInfo)
 {
-    static_cast<AddressResolver *>(aContext)->HandleAddressQuery(aHeader, aMessage, aMessageInfo);
+    static_cast<AddressResolver *>(aContext)->HandleAddressQuery(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void AddressResolver::HandleAddressQuery(Coap::Header &aHeader, Message &aMessage,

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -159,16 +159,16 @@ private:
 
     static void HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo);
 
-    static void HandleAddressError(void *aContext, Coap::Header &aHeader,
-                                   Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    static void HandleAddressError(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                   const otMessageInfo *aMessageInfo);
     void HandleAddressError(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleAddressQuery(void *aContext, Coap::Header &aHeader,
-                                   Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    static void HandleAddressQuery(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                   const otMessageInfo *aMessageInfo);
     void HandleAddressQuery(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleAddressNotification(void *aContext, Coap::Header &aHeader,
-                                          Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    static void HandleAddressNotification(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                          const otMessageInfo *aMessageInfo);
     void HandleAddressNotification(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     static void HandleDstUnreach(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo,

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -88,12 +88,13 @@ exit:
     return error;
 }
 
-void AnnounceBeginServer::HandleRequest(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                        const Ip6::MessageInfo &aMessageInfo)
+void AnnounceBeginServer::HandleRequest(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                        const otMessageInfo *aMessageInfo)
 {
-    static_cast<AnnounceBeginServer *>(aContext)->HandleRequest(aHeader, aMessage, aMessageInfo);
+    static_cast<AnnounceBeginServer *>(aContext)->HandleRequest(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
-
 void AnnounceBeginServer::HandleRequest(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     MeshCoP::ChannelMask0Tlv channelMask;

--- a/src/core/thread/announce_begin_server.hpp
+++ b/src/core/thread/announce_begin_server.hpp
@@ -87,8 +87,8 @@ private:
         kDefaultPeriod = 1000,
     };
 
-    static void HandleRequest(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                              const Ip6::MessageInfo &aMessageInfo);
+    static void HandleRequest(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                              const otMessageInfo *aMessageInfo);
     void HandleRequest(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     ThreadError SendResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aRequestMessageInfo);

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -59,10 +59,12 @@ EnergyScanServer::EnergyScanServer(ThreadNetif &aThreadNetif) :
     mCoapServer.AddResource(mEnergyScan);
 }
 
-void EnergyScanServer::HandleRequest(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                     const Ip6::MessageInfo &aMessageInfo)
+void EnergyScanServer::HandleRequest(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                     const otMessageInfo *aMessageInfo)
 {
-    static_cast<EnergyScanServer *>(aContext)->HandleRequest(aHeader, aMessage, aMessageInfo);
+    static_cast<EnergyScanServer *>(aContext)->HandleRequest(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void EnergyScanServer::HandleRequest(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -70,8 +70,8 @@ private:
         kReportDelay = 500,   ///< Delay before sending a report (milliseconds)
     };
 
-    static void HandleRequest(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                              const Ip6::MessageInfo &aMessageInfo);
+    static void HandleRequest(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                              const otMessageInfo *aMessageInfo);
     void HandleRequest(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     static void HandleScanResult(void *aContext, otEnergyScanResult *aResult);

--- a/src/core/thread/meshcop_dataset_manager.cpp
+++ b/src/core/thread/meshcop_dataset_manager.cpp
@@ -935,10 +935,12 @@ exit:
     return error;
 }
 
-void ActiveDataset::HandleGet(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                              const Ip6::MessageInfo &aMessageInfo)
+void ActiveDataset::HandleGet(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                              const otMessageInfo *aMessageInfo)
 {
-    static_cast<ActiveDataset *>(aContext)->HandleGet(aHeader, aMessage, aMessageInfo);
+    static_cast<ActiveDataset *>(aContext)->HandleGet(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void ActiveDataset::HandleGet(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -946,10 +948,12 @@ void ActiveDataset::HandleGet(Coap::Header &aHeader, Message &aMessage, const Ip
     DatasetManager::Get(aHeader, aMessage, aMessageInfo);
 }
 
-void ActiveDataset::HandleSet(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                              const Ip6::MessageInfo &aMessageInfo)
+void ActiveDataset::HandleSet(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                              const otMessageInfo *aMessageInfo)
 {
-    static_cast<ActiveDataset *>(aContext)->HandleSet(aHeader, aMessage, aMessageInfo);
+    static_cast<ActiveDataset *>(aContext)->HandleSet(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void ActiveDataset::HandleSet(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -1045,10 +1049,12 @@ exit:
     return error;
 }
 
-void PendingDataset::HandleGet(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                               const Ip6::MessageInfo &aMessageInfo)
+void PendingDataset::HandleGet(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                               const otMessageInfo *aMessageInfo)
 {
-    static_cast<PendingDataset *>(aContext)->HandleGet(aHeader, aMessage, aMessageInfo);
+    static_cast<PendingDataset *>(aContext)->HandleGet(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void PendingDataset::HandleGet(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -1056,10 +1062,12 @@ void PendingDataset::HandleGet(Coap::Header &aHeader, Message &aMessage, const I
     DatasetManager::Get(aHeader, aMessage, aMessageInfo);
 }
 
-void PendingDataset::HandleSet(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                               const Ip6::MessageInfo &aMessageInfo)
+void PendingDataset::HandleSet(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                               const otMessageInfo *aMessageInfo)
 {
-    static_cast<PendingDataset *>(aContext)->HandleSet(aHeader, aMessage, aMessageInfo);
+    static_cast<PendingDataset *>(aContext)->HandleSet(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void PendingDataset::HandleSet(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/thread/meshcop_dataset_manager.hpp
+++ b/src/core/thread/meshcop_dataset_manager.hpp
@@ -132,12 +132,12 @@ public:
     ThreadError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
 
 private:
-    static void HandleGet(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                          const Ip6::MessageInfo &aMessageInfo);
+    static void HandleGet(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                          const otMessageInfo *aMessageInfo);
     void HandleGet(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleSet(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                          const Ip6::MessageInfo &aMessageInfo);
+    static void HandleSet(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                          const otMessageInfo *aMessageInfo);
     void HandleSet(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     Coap::Resource mResourceGet;
@@ -168,12 +168,12 @@ public:
     void ApplyActiveDataset(const Timestamp &aTimestamp, Message &aMessage);
 
 private:
-    static void HandleGet(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                          const Ip6::MessageInfo &aMessageInfo);
+    static void HandleGet(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                          const otMessageInfo *aMessageInfo);
     void HandleGet(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleSet(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                          const Ip6::MessageInfo &aMessageInfo);
+    static void HandleSet(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                          const otMessageInfo *aMessageInfo);
     void HandleSet(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     static void HandleTimer(void *aContext);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3268,10 +3268,12 @@ exit:
     {}
 }
 
-void MleRouter::HandleAddressSolicit(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                     const Ip6::MessageInfo &aMessageInfo)
+void MleRouter::HandleAddressSolicit(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                     const otMessageInfo *aMessageInfo)
 {
-    static_cast<MleRouter *>(aContext)->HandleAddressSolicit(aHeader, aMessage, aMessageInfo);
+    static_cast<MleRouter *>(aContext)->HandleAddressSolicit(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void MleRouter::HandleAddressSolicit(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -3428,10 +3430,12 @@ exit:
     }
 }
 
-void MleRouter::HandleAddressRelease(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                     const Ip6::MessageInfo &aMessageInfo)
+void MleRouter::HandleAddressRelease(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                     const otMessageInfo *aMessageInfo)
 {
-    static_cast<MleRouter *>(aContext)->HandleAddressRelease(aHeader, aMessage, aMessageInfo);
+    static_cast<MleRouter *>(aContext)->HandleAddressRelease(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void MleRouter::HandleAddressRelease(Coap::Header &aHeader, Message &aMessage,

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -678,11 +678,11 @@ private:
     static void HandleAddressSolicitResponse(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
                                              ThreadError result);
     void HandleAddressSolicitResponse(Coap::Header *aHeader, Message *aMessage, ThreadError result);
-    static void HandleAddressRelease(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                     const Ip6::MessageInfo &aMessageInfo);
+    static void HandleAddressRelease(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                     const otMessageInfo *aMessageInfo);
     void HandleAddressRelease(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    static void HandleAddressSolicit(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                     const Ip6::MessageInfo &aMessageInfo);
+    static void HandleAddressSolicit(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                     const otMessageInfo *aMessageInfo);
     void HandleAddressSolicit(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     static uint8_t LqiToCost(uint8_t aLqi);

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -563,10 +563,12 @@ exit:
     return error;
 }
 
-void Leader::HandleServerData(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                              const Ip6::MessageInfo &aMessageInfo)
+void Leader::HandleServerData(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                              const otMessageInfo *aMessageInfo)
 {
-    static_cast<Leader *>(aContext)->HandleServerData(aHeader, aMessage, aMessageInfo);
+    static_cast<Leader *>(aContext)->HandleServerData(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void Leader::HandleServerData(Coap::Header &aHeader, Message &aMessage,
@@ -596,11 +598,12 @@ exit:
     return;
 }
 
-void Leader::HandleCommissioningSet(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                    const Ip6::MessageInfo &aMessageInfo)
+void Leader::HandleCommissioningSet(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                    const otMessageInfo *aMessageInfo)
 {
-    Leader *obj = static_cast<Leader *>(aContext);
-    obj->HandleCommissioningSet(aHeader, aMessage, aMessageInfo);
+    static_cast<Leader *>(aContext)->HandleCommissioningSet(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void Leader::HandleCommissioningSet(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -665,11 +668,12 @@ exit:
     return;
 }
 
-void Leader::HandleCommissioningGet(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                    const Ip6::MessageInfo &aMessageInfo)
+void Leader::HandleCommissioningGet(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                    const otMessageInfo *aMessageInfo)
 {
-    Leader *obj = static_cast<Leader *>(aContext);
-    obj->HandleCommissioningGet(aHeader, aMessage, aMessageInfo);
+    static_cast<Leader *>(aContext)->HandleCommissioningGet(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void Leader::HandleCommissioningGet(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -256,8 +256,8 @@ public:
 #endif  // OPENTHREAD_ENABLE_DHCP6_SERVER || OPENTHREAD_ENABLE_DHCP6_CLIENT
 
 private:
-    static void HandleServerData(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                 const Ip6::MessageInfo &aMessageInfo);
+    static void HandleServerData(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                 const otMessageInfo *aMessageInfo);
     void HandleServerData(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     void SendServerDataResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
                                 const uint8_t *aTlvs, uint8_t aTlvsLength);
@@ -295,12 +295,12 @@ private:
     bool IsStableUpdated(uint16_t aRloc16, uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aTlvsBase,
                          uint8_t aTlvsBaseLength);
 
-    static void HandleCommissioningSet(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                       const Ip6::MessageInfo &aMessageInfo);
+    static void HandleCommissioningSet(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                       const otMessageInfo *aMessageInfo);
     void HandleCommissioningSet(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleCommissioningGet(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                       const Ip6::MessageInfo &aMessageInfo);
+    static void HandleCommissioningGet(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                       const otMessageInfo *aMessageInfo);
     void HandleCommissioningGet(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     void SendCommissioningGetResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,

--- a/src/core/thread/network_diag.cpp
+++ b/src/core/thread/network_diag.cpp
@@ -165,11 +165,12 @@ exit:
     return error;
 }
 
-void NetworkDiagnostic::HandleDiagnosticGet(void *aContext, Coap::Header &aHeader,
-                                            Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void NetworkDiagnostic::HandleDiagnosticGet(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                            const otMessageInfo *aMessageInfo)
 {
-    NetworkDiagnostic *obj = reinterpret_cast<NetworkDiagnostic *>(aContext);
-    obj->HandleDiagnosticGet(aHeader, aMessage, aMessageInfo);
+    static_cast<NetworkDiagnostic *>(aContext)->HandleDiagnosticGet(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 ThreadError NetworkDiagnostic::AppendIPv6AddressList(Message &aMessage)
@@ -430,11 +431,12 @@ exit:
     }
 }
 
-void NetworkDiagnostic::HandleDiagnosticReset(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                              const Ip6::MessageInfo &aMessageInfo)
+void NetworkDiagnostic::HandleDiagnosticReset(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                              const otMessageInfo *aMessageInfo)
 {
-    NetworkDiagnostic *obj = reinterpret_cast<NetworkDiagnostic *>(aContext);
-    obj->HandleDiagnosticReset(aHeader, aMessage, aMessageInfo);
+    static_cast<NetworkDiagnostic *>(aContext)->HandleDiagnosticReset(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void NetworkDiagnostic::HandleDiagnosticReset(Coap::Header &aHeader, Message &aMessage,

--- a/src/core/thread/network_diag.hpp
+++ b/src/core/thread/network_diag.hpp
@@ -113,13 +113,13 @@ private:
                                             ThreadError result);
     void HandleDiagnosticGetResponse(Coap::Header *aHeader, Message *aMessage, ThreadError result);
 
-    static void HandleDiagnosticGet(void *aContext, Coap::Header &aHeader,
-                                    Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    static void HandleDiagnosticGet(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                    const otMessageInfo *aMessageInfo);
     void HandleDiagnosticGet(Thread::Coap::Header &aHeader, Thread::Message &aMessage,
                              const Thread::Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleDiagnosticReset(void *aContext, Thread::Coap::Header &aHeader, Thread::Message &,
-                                      const Thread::Ip6::MessageInfo &aMessageInfo);
+    static void HandleDiagnosticReset(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                      const otMessageInfo *aMessageInfo);
     void HandleDiagnosticReset(Coap::Header &aHeader, Message &aMessage,
                                const Ip6::MessageInfo &aMessageInfo);
 

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -55,10 +55,12 @@ PanIdQueryServer::PanIdQueryServer(ThreadNetif &aThreadNetif) :
     mCoapServer.AddResource(mPanIdQuery);
 }
 
-void PanIdQueryServer::HandleQuery(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                                   const Ip6::MessageInfo &aMessageInfo)
+void PanIdQueryServer::HandleQuery(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                   const otMessageInfo *aMessageInfo)
 {
-    static_cast<PanIdQueryServer *>(aContext)->HandleQuery(aHeader, aMessage, aMessageInfo);
+    static_cast<PanIdQueryServer *>(aContext)->HandleQuery(
+        *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
+        *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void PanIdQueryServer::HandleQuery(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/thread/panid_query_server.hpp
+++ b/src/core/thread/panid_query_server.hpp
@@ -69,8 +69,7 @@ private:
         kScanDelay = 1000,  ///< SCAN_DELAY (milliseconds)
     };
 
-    static void HandleQuery(void *aContext, Coap::Header &aHeader, Message &aMessage,
-                            const Ip6::MessageInfo &aMessageInfo);
+    static void HandleQuery(void *aContext, otCoapHeader *aHeader, otMessage aMessage, const otMessageInfo *aMessageInfo);
     void HandleQuery(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     static void HandleScanResult(void *aContext, Mac::Frame *aFrame);


### PR DESCRIPTION
This PR introduces an API for CoAP Server that can be used by an application. Also, the existing API was extended with some useful functions. As this feature is not essential for Thead to operate and requires some extra resources (antoher server object), I disabled the CoAP API by default. It can be enabled by running configure with --enable-application-coap option.

As the resource handler has to be C-compatible, I updated all of the existing resources in Thread to support the new handler prototype.

Also this PR includes a fix for a bug that I've encountered in the CoAP Client. When an application wanted to send a request without any payload, and thus without payload marker, the header parser failed to parse messages with appended metadata (it started to parse metadata as options). My proposal is to include payload marker at the beginning of the metadata, so the parser knows when to stop when there is no payload. This change should be irrevelant when payload marker is already present.