### PR TITLE
Reduce mbedtls memory pool for build configs that do not include DTLS.

### DIFF
--- a/src/core/crypto/mbedtls.hpp
+++ b/src/core/crypto/mbedtls.hpp
@@ -64,7 +64,7 @@ public:
 #if OPENTHREAD_ENABLE_DTLS
         kMemorySize = 2048 * sizeof(void *), ///< Size of memory buffer (bytes).
 #else
-        kMemorySize = 512,                   ///< Size of memory buffer (bytes).
+        kMemorySize = 384,                   ///< Size of memory buffer (bytes).
 #endif
     };
 


### PR DESCRIPTION
Reduce memory usage by 128 bytes for build configs that do not include DTLS.