### PR TITLE
Fix an incorrect Tlv append operation and Dump output JOIN_FIN.req

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -37,7 +37,6 @@
 #include <common/debug.hpp>
 #include <common/logging.hpp>
 #include <common/message.hpp>
-#include <common/logging.hpp>
 #include <net/ip6.hpp>
 
 namespace Thread {

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -799,7 +799,14 @@ void Commissioner::HandleJoinerFinalize(Coap::Header &aHeader, Message &aMessage
         }
     }
 
-    otLogCertMeshCoP("[THCI] direction=recv | type=JOIN_FIN.req");
+#if OPENTHREAD_ENABLE_CERT_LOG
+    uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
+    VerifyOrExit(aMessage.GetLength() <= sizeof(buf), ;);
+    aMessage.Read(aHeader.GetLength(), aMessage.GetLength() - aHeader.GetLength(), buf);
+    otDumpCertMeshCoP("[THCI] direction=recv | type=JOIN_FIN.req |", buf, aMessage.GetLength() - aHeader.GetLength());
+
+exit:
+#endif
 
     SendJoinFinalizeResponse(aHeader, state);
 

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -207,13 +207,20 @@ void Joiner::SendJoinerFinalize(void)
 
     if (length > 0)
     {
-        SuccessOrExit(error = message->Append(&stateTlv, length + sizeof(Tlv)));
+        SuccessOrExit(error = message->Append(&mSecureCoapClient.GetDtls().mProvisioningUrl, length + sizeof(Tlv)));
     }
+
+#if OPENTHREAD_ENABLE_CERT_LOG
+    uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
+    VerifyOrExit(message->GetLength() <= sizeof(buf), ;);
+    message->Read(header.GetLength(), message->GetLength() - header.GetLength(), buf);
+    otDumpCertMeshCoP("[THCI] direction=send | type=JOIN_FIN.req |", buf, message->GetLength() - header.GetLength());
+#endif
 
     mSecureCoapClient.SendMessage(*message, Joiner::HandleJoinerFinalizeResponse, this);
 
     otLogInfoMeshCoP("Sent joiner finalize");
-    otLogCertMeshCoP("[THCI] direction=send | type=JOIN_FIN.req");
+
 exit:
 
     if (error != kThreadError_None && message != NULL)

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -419,7 +419,7 @@ ThreadError JoinerRouter::SendJoinerEntrust(const Ip6::MessageInfo &aMessageInfo
     SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
 
     otLogInfoMeshCoP("Sent joiner entrust length = %d", message->GetLength());
-    otLogCertMeshCoP("[THCI] direction=send | msg_type=JOIN_ENT.ntf");
+    otLogCertMeshCoP("[THCI] direction=send | type=JOIN_ENT.ntf");
 
 exit:
 


### PR DESCRIPTION
It fixes two issues introduced by #949, which broken Certification test 8.x:

* Fix an incorrect Tlv append operation in Joiner::SendJoinerFinalize()

* Dump output JOIN_FIN.req for certification test