### PR TITLE
Fix the CoAP message length during parsing CoAP header.

### DIFF
--- a/src/core/coap/coap_client.cpp
+++ b/src/core/coap/coap_client.cpp
@@ -86,7 +86,7 @@ ThreadError Client::SendMessage(Message &aMessage, const Ip6::MessageInfo &aMess
     Message *storedCopy = NULL;
     uint16_t copyLength = 0;
 
-    SuccessOrExit(error = header.FromMessage(aMessage));
+    SuccessOrExit(error = header.FromMessage(aMessage, false));
 
     // Set Message Id if it was not already set.
     if (header.GetMessageId() == 0)
@@ -310,7 +310,7 @@ Message *Client::FindRelatedRequest(const Header &aResponseHeader, const Ip6::Me
         if ((aRequestMetadata.mDestinationAddress == aMessageInfo.GetPeerAddr()) &&
             (aRequestMetadata.mDestinationPort == aMessageInfo.GetPeerPort()))
         {
-            assert(aRequestHeader.FromMessage(*message) == kThreadError_None);
+            assert(aRequestHeader.FromMessage(*message, true) == kThreadError_None);
 
             switch (aResponseHeader.GetType())
             {
@@ -361,7 +361,7 @@ void Client::ProcessReceivedMessage(Message &aMessage, const Ip6::MessageInfo &a
     Message *message = NULL;
     ThreadError error;
 
-    SuccessOrExit(error = responseHeader.FromMessage(aMessage));
+    SuccessOrExit(error = responseHeader.FromMessage(aMessage, false));
     aMessage.MoveOffset(responseHeader.GetLength());
 
     message = FindRelatedRequest(responseHeader, aMessageInfo, requestHeader, requestMetadata);
@@ -436,7 +436,6 @@ exit:
 RequestMetadata::RequestMetadata(bool aConfirmable, const Ip6::MessageInfo &aMessageInfo,
                                  otCoapResponseHandler aHandler, void *aContext)
 {
-    mPayloadMarker = kPayloadMarker;
     mDestinationPort = aMessageInfo.GetPeerPort();
     mDestinationAddress = aMessageInfo.GetPeerAddr();
     mResponseHandler = aHandler;

--- a/src/core/coap/coap_client.hpp
+++ b/src/core/coap/coap_client.hpp
@@ -71,9 +71,7 @@ enum
     kProcessingDelay            = kAckTimeout,
     kMaxRtt                     = 2 * kMaxLatency + kProcessingDelay,
     kExchangeLifetime           = kMaxTransmitSpan + 2 * (kMaxLatency) + kProcessingDelay,
-    kNonLifetime                = kMaxTransmitSpan + kMaxLatency,
-
-    kPayloadMarker              = 0xff
+    kNonLifetime                = kMaxTransmitSpan + kMaxLatency
 };
 
 /**
@@ -92,7 +90,6 @@ public:
      *
      */
     RequestMetadata(void):
-        mPayloadMarker(kPayloadMarker),
         mDestinationPort(0),
         mResponseHandler(NULL),
         mResponseContext(NULL),
@@ -172,7 +169,6 @@ public:
     bool IsLater(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mNextTimerShot) < 0); };
 
 private:
-    uint8_t               mPayloadMarker;         ///< A value indicating beginning of the metadata.
     Ip6::Address          mDestinationAddress;    ///< IPv6 address of the message destination.
     uint16_t              mDestinationPort;       ///< UDP port of the message destination.
     otCoapResponseHandler mResponseHandler;       ///< A function pointer that is called on response reception.

--- a/src/core/coap/coap_header.cpp
+++ b/src/core/coap/coap_header.cpp
@@ -32,6 +32,7 @@
  */
 
 #include <coap/coap_header.hpp>
+#include <coap/coap_client.hpp>
 #include <common/debug.hpp>
 #include <common/code_utils.hpp>
 #include <common/encoding.hpp>
@@ -57,7 +58,7 @@ void Header::Init(Type aType, Code aCode)
     SetCode(aCode);
 }
 
-ThreadError Header::FromMessage(const Message &aMessage)
+ThreadError Header::FromMessage(const Message &aMessage, bool aCopiedMessage)
 {
     ThreadError error = kThreadError_Parse;
     uint16_t offset = aMessage.GetOffset();
@@ -66,6 +67,11 @@ ThreadError Header::FromMessage(const Message &aMessage)
     bool firstOption = true;
     uint16_t optionDelta;
     uint16_t optionLength;
+
+    if (aCopiedMessage)
+    {
+        length -= sizeof(RequestMetadata);
+    }
 
     VerifyOrExit(length >= kTokenOffset, error = kThreadError_Parse);
     aMessage.Read(offset, kTokenOffset, mHeader.mBytes);

--- a/src/core/coap/coap_header.hpp
+++ b/src/core/coap/coap_header.hpp
@@ -108,13 +108,14 @@ public:
     /**
      * This method parses the CoAP header from a message.
      *
-     * @param[in]  aMessage  A reference to the message.
+     * @param[in]  aMessage       A reference to the message.
+     * @param[in]  aCopiedMessage To indicate if this message is a copied one or not
      *
      * @retval kThreadError_None   Successfully parsed the message.
      * @retval kThreadError_Parse  Failed to parse the message.
      *
      */
-    ThreadError FromMessage(const Message &aMessage);
+    ThreadError FromMessage(const Message &aMessage, bool aCopiedMessage);
 
     /**
      * This method returns the Version value.

--- a/src/core/coap/coap_server.cpp
+++ b/src/core/coap/coap_server.cpp
@@ -112,7 +112,7 @@ void Server::ProcessReceivedMessage(Message &aMessage, const Ip6::MessageInfo &a
     char *curUriPath = uriPath;
     const Header::Option *coapOption;
 
-    SuccessOrExit(header.FromMessage(aMessage));
+    SuccessOrExit(header.FromMessage(aMessage, false));
     aMessage.MoveOffset(header.GetLength());
 
     coapOption = header.GetCurrentOption();

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -755,8 +755,6 @@ void Commissioner::SendDatasetChangedResponse(const Coap::Header &aRequestHeader
     VerifyOrExit((message = mCoapServer.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
 
     responseHeader.SetDefaultResponseHeader(aRequestHeader);
-    responseHeader.SetPayloadMarker();
-
     SuccessOrExit(error = message->Append(responseHeader.GetBytes(), responseHeader.GetLength()));
     SuccessOrExit(error = mCoapServer.SendMessage(*message, aMessageInfo));
 

--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -239,7 +239,6 @@ ThreadError Leader::SendDatasetChanged(const Ip6::Address &aAddress)
     header.Init(kCoapTypeConfirmable, kCoapRequestPost);
     header.SetToken(Coap::Header::kDefaultTokenLength);
     header.AppendUriPathOptions(OPENTHREAD_URI_DATASET_CHANGED);
-    header.SetPayloadMarker();
 
     VerifyOrExit((message = mCoapClient.NewMessage(header)) != NULL, error = kThreadError_NoBufs);
 


### PR DESCRIPTION
Notice that currently when calling `FromMessage()` to parse the CoAP Header we get the whole message length including RequestMetaData class if this is a copied message. For example, for MGMT_COMM_GET.req. the CoAP message length should be 11, we can see the message length is 0x30 (including RequestMetaData). So it only depends on detecting the payload marker to exit the loop. Basically if the length reduces to zero, we can exit the loop directly and unnecessary to detect the payload marker, especial for cases that CoAP message does not contain payload.
![screen shot 2016-11-16 at 2 20 58 pm](https://cloud.githubusercontent.com/assets/19245360/20337465/48f920f2-ac0c-11e6-8895-7bd3b661b0fc.png)
For MGMT_DATASET_CHANGED.ntf, it has no CoAP payload, so remove the `SetPayloadMarker()`.