### PR TITLE
THCI: enhance commissioner session id.

### DIFF
--- a/include/commissioning/commissioner.h
+++ b/include/commissioning/commissioner.h
@@ -213,6 +213,16 @@ OTAPI ThreadError OTCALL otSendMgmtCommissionerSet(otInstance *, const otCommiss
                                                    const uint8_t *aTlvs, uint8_t aLength);
 
 /**
+ * This function returns the origian Commissioner Session ID.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ *
+ * @returns The current commissioner session id.
+ *
+ */
+OTAPI uint16_t OTCALL otCommissionerGetSessionId(otInstance *);
+
+/**
  * @}
  *
  */

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -307,6 +307,16 @@ Done
 Conflict: dead, 00000800
 ```
 
+### commissioner sessionid
+
+Get current commissioner session id.
+
+```bash
+> commissioner sessionid
+0
+Done
+```
+
 ### contextreusedelay
 
 Get the CONTEXT_ID_REUSE_DELAY value.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2375,6 +2375,10 @@ void Interpreter::ProcessCommissioner(int argc, char *argv[])
 
         SuccessOrExit(error = otSendMgmtCommissionerSet(mInstance, &dataset, tlvs, static_cast<uint8_t>(length)));
     }
+    else if (strcmp(argv[0], "sessionid") == 0)
+    {
+        sServer->OutputFormat("%d\r\n", otCommissionerGetSessionId(mInstance));
+    }
 
 exit:
     AppendResult(error);

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -1669,6 +1669,11 @@ ThreadError otSendMgmtCommissionerSet(otInstance *aInstance, const otCommissioni
 {
     return aInstance->mThreadNetif.GetCommissioner().SendMgmtCommissionerSetRequest(*aDataset, aTlvs, aLength);
 }
+
+uint16_t otCommissionerGetSessionId(otInstance *aInstance)
+{
+    return aInstance->mThreadNetif.GetCommissioner().GetSessionId();
+}
 #endif  // OPENTHREAD_ENABLE_COMMISSIONER
 
 #if OPENTHREAD_ENABLE_JOINER


### PR DESCRIPTION
To address issue #835 . Harness passes "None" as xCommissionerSessionId parameter to indicate using commissioner's original session id(allocated from Leader after success petition); passes a specific number for validating whether or not Leader is able to detect the invalid parameter and responds with "Reject" state TLV. This PR helps 9.2.2 scenario of DUT as commissioner pass.
[Commissioner_9_2_2.zip](https://github.com/openthread/openthread/files/596746/Commissioner_9_2_2.zip)