### PR TITLE
Check whether or not commissioner session id tlv is repeated and the validity of channel tlv.

### DIFF
--- a/tools/harness-thci/ARM.py
+++ b/tools/harness-thci/ARM.py
@@ -2193,7 +2193,10 @@ class ARM(IThci):
 
             if listChannelMask != None:
                 cmd += ' channelmask '
-                cmd += str(hex(1 << listChannelMask[1]))
+                if len(listChannelMask) > 2:
+                    cmd += '0x' + self.__convertLongToString(self.__convertChannelMask(listChannelMask))
+                elif len(listChannelMask) == 2:
+                    cmd += str(hex(1 << listChannelMask[1]))
 
             if sPSKc != None or listSecurityPolicy != None or \
                xCommissioningSessionId != None or xTmfPort != None or xSteeringData != None or xBorderRouterLocator != None or \
@@ -2250,6 +2253,14 @@ class ARM(IThci):
                     locator = locator.zfill(4)
 
                 cmd += locator
+
+            if xSteeringData != None:
+                steeringData = self.__convertLongToString(xSteeringData)
+                cmd += '08' + str(len(steeringData)/2).zfill(2)
+                cmd += steeringData
+
+            if BogusTLV != None:
+                cmd += "8202aa55"
 
             print cmd
 


### PR DESCRIPTION
This PR help pass 9.2.4 scenario of DUT as commissioner and 9.2.5-Leader.
[Commissioner_9_2_4.zip](https://github.com/openthread/openthread/files/605414/Commissioner_9_2_4.zip)
[Leader_9_2_5.zip](https://github.com/openthread/openthread/files/605415/Leader_9_2_5.zip)

- For MGMT_ACTIVE_SET.req message, if thread device is an active commissioner, request message includes commissioner session id tlv. Harness validates if Leader can recognize an invalid commissioner session id via bringing an invalid session id tlv. So if detecting session id tlv in binary format in MGMT_ACTIVE_SET.req, replace the original one with this value. Otherwise, there will be two commissioner session id tlv appeared.

- For MGMT_ACTIVE_SET.req, Harness checks if channel tlv is valid or not (e.g. channels supported by PHY). If not, Leader rejects the request message.