### PR TITLE
Do not call otPlatRadioEnableSrcMatch in constructor.

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -80,9 +80,7 @@ MeshForwarder::MeshForwarder(ThreadNetif &aThreadNetif):
     mMeshSource = Mac::kShortAddrInvalid;
     mMeshDest = Mac::kShortAddrInvalid;
     mAddMeshHeader = false;
-
-    mMac.EnableSrcMatch(true);
-    mSrcMatchEnabled = true;
+    mSrcMatchEnabled = false;
 
     mMac.RegisterReceiver(mMacReceiver);
 }
@@ -320,6 +318,12 @@ ThreadError MeshForwarder::AddSrcMatchEntry(Child &aChild)
     {
         // succeed in adding to source match table
         aChild.mAddSrcMatchEntryPending = false;
+
+        if (!mSrcMatchEnabled)
+        {
+            mMac.EnableSrcMatch(true);
+            mSrcMatchEnabled = true;
+        }
     }
     else
     {


### PR DESCRIPTION
- Removes an unnecessary call to `otPlatRadioEnableSrcMatch()` when the device is operating as an MTD.