### PR TITLE
THCI: provide updateRouterStatus() support

### DIFF
--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -614,7 +614,7 @@ ThreadError otBecomeChild(otInstance *aInstance, otMleAttachFilter aFilter)
 
 ThreadError otBecomeRouter(otInstance *aInstance)
 {
-    return aInstance->mThreadNetif.GetMle().BecomeRouter(ThreadStatusTlv::kTooFewRouters);
+    return aInstance->mThreadNetif.GetMle().BecomeRouter(ThreadStatusTlv::kHaveChildIdRequest);
 }
 
 ThreadError otBecomeLeader(otInstance *aInstance)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -209,7 +209,7 @@ ThreadError MleRouter::BecomeRouter(ThreadStatusTlv::Status aStatus)
 
     VerifyOrExit(mDeviceState != kDeviceStateDisabled, error = kThreadError_InvalidState);
     VerifyOrExit(mDeviceState != kDeviceStateRouter, error = kThreadError_None);
-    VerifyOrExit(mRouterRoleEnabled && (mDeviceMode & ModeTlv::kModeFFD), error = kThreadError_NotCapable);
+    VerifyOrExit(IsRouterRoleEnabled(), error = kThreadError_NotCapable);
 
     for (int i = 0; i <= kMaxRouterId; i++)
     {
@@ -250,7 +250,7 @@ ThreadError MleRouter::BecomeLeader(void)
 
     VerifyOrExit(mDeviceState != kDeviceStateDisabled, error = kThreadError_InvalidState);
     VerifyOrExit(mDeviceState != kDeviceStateLeader, error = kThreadError_None);
-    VerifyOrExit(mRouterRoleEnabled && (mDeviceMode & ModeTlv::kModeFFD), error = kThreadError_NotCapable);
+    VerifyOrExit(IsRouterRoleEnabled(), error = kThreadError_NotCapable);
 
     for (int i = 0; i <= kMaxRouterId; i++)
     {
@@ -1303,7 +1303,12 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
             break;
 
         case kDeviceStateChild:
-            processRouteTlv = (sourceAddress.GetRloc16() == mParent.mValid.mRloc16);
+            if ((sourceAddress.GetRloc16() == mParent.mValid.mRloc16) ||
+                (router->mState == Neighbor::kStateValid))
+            {
+                processRouteTlv = true;
+            }
+
             break;
 
         case kDeviceStateRouter:
@@ -1325,8 +1330,9 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
         ExitNow();
 
     case kDeviceStateChild:
-        if (mRouterSelectionJitterTimeout == 0 &&
+        if ((sourceAddress.GetRloc16() == mParent.mValid.mRloc16 || router->mState == Neighbor::kStateValid) &&
             (mDeviceMode & ModeTlv::kModeFFD) &&
+            (mRouterSelectionJitterTimeout == 0) &&
             (GetActiveRouterCount() < mRouterUpgradeThreshold))
         {
             mRouterSelectionJitterTimeout = (otPlatRandomGet() % mRouterSelectionJitter) + 1;
@@ -1371,7 +1377,7 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
                 }
             }
         }
-        else if (router->mState != Neighbor::kStateValid)
+        else if ((mDeviceMode & ModeTlv::kModeFFD) && (router->mState != Neighbor::kStateValid))
         {
             memcpy(&router->mMacAddr, &macAddr, sizeof(router->mMacAddr));
             router->mLinkInfo.Clear();

--- a/tools/harness-thci/ARM.py
+++ b/tools/harness-thci/ARM.py
@@ -992,16 +992,12 @@ class ARM(IThci):
                 print 'join as leader'
                 mode = 'rsdn'
                 if self.AutoDUTEnable is False:
-                    # set ROUTER_UPGRADE_THRESHOLD
-                    self.__setRouterUpgradeThreshold(32)
                     # set ROUTER_DOWNGRADE_THRESHOLD
                     self.__setRouterDowngradeThreshold(33)
             elif eRoleId == Thread_Device_Role.Router:
                 print 'join as router'
                 mode = 'rsdn'
                 if self.AutoDUTEnable is False:
-                    # set ROUTER_UPGRADE_THRESHOLD
-                    self.__setRouterUpgradeThreshold(33)
                     # set ROUTER_DOWNGRADE_THRESHOLD
                     self.__setRouterDowngradeThreshold(33)
             elif eRoleId == Thread_Device_Role.SED:
@@ -2486,7 +2482,19 @@ class ARM(IThci):
         return True
 
     def updateRouterStatus(self):
+        """force update to router as if there is child id request"""
         print '%s call updateRouterStatus' % self.port
+        cmd = 'state'
+        while state = self.__sendCommand(cmd)[0]:
+            if state == 'detached':
+                continue
+            elif state == 'child':
+                break
+            else:
+                return False
+
+        cmd = 'state router'
+        return self.__sendCommand(cmd)[0] == 'Done'
 
     def setRouterThresholdValues(self, upgradeThreshold, downgradeThreshold):
         print '%s call setRouterThresholdValues' % self.port


### PR DESCRIPTION
As required in[ DEV-845](https://threadgroup.atlassian.net/browse/DEV-845) for Leader 5.2.3 

> Harness will need to instruct the testbed routers to attach and become an active router with the reason 'HAVE_CHILD_ID_REQUEST' even though they are not bringing children.
> In 1.1, now when becoming an active router the device needs to specify a reason. If the devices specify TOO_FEW_ROUTERS the Leader will reject it.

Here update relative code to support updateRouterStatus() THCI API.

Below is the harness output with this PR.
[Leader_5_2_3.zip](https://github.com/openthread/openthread/files/610629/Leader_5_2_3.zip)

@xiaom-GitHub , @jwhui , please help to have a review.