### PR TITLE
Increment the Commissioner Session ID when the Leader resigns an active Commissioner

### DIFF
--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -181,8 +181,7 @@ void Leader::HandleKeepAlive(Coap::Header &aHeader, Message &aMessage, const Ip6
     {
         responseState = StateTlv::kReject;
         mTimer.Stop();
-        mNetworkData.SetCommissioningData(NULL, 0);
-        otLogInfoMeshCoP("commissioner inactive");
+        ResignCommissioner();
     }
     else
     {
@@ -267,11 +266,23 @@ void Leader::HandleTimer(void)
 {
     VerifyOrExit(mNetif.GetMle().GetDeviceState() == Mle::kDeviceStateLeader, ;);
 
-    otLogInfoMeshCoP("commissioner inactive");
-    mNetworkData.SetCommissioningData(NULL, 0);
+    ResignCommissioner();
 
 exit:
     return;
+}
+
+void Leader::ResignCommissioner(void)
+{
+    CommissionerSessionIdTlv mCommissionerSessionId;
+
+    mCommissionerSessionId.Init();
+    mCommissionerSessionId.SetCommissionerSessionId(++mSessionId);
+
+    mNetworkData.SetCommissioningData(reinterpret_cast<uint8_t *>(&mCommissionerSessionId),
+                                      sizeof(Tlv) + mCommissionerSessionId.GetLength());
+
+    otLogInfoMeshCoP("commissioner inactive");
 }
 
 }  // namespace MeshCoP

--- a/src/core/meshcop/leader_ftd.hpp
+++ b/src/core/meshcop/leader_ftd.hpp
@@ -104,6 +104,8 @@ private:
 
     static void HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo);
 
+    void ResignCommissioner(void);
+
     Coap::Resource mPetition;
     Coap::Resource mKeepAlive;
     Coap::Server &mCoapServer;


### PR DESCRIPTION
According to the specification, when the Leader resigns an active Commissioner, the Leader must remove the Border Agent Locator and Steering Data from the Commissioner Dataset, and increment the Commissioner Session ID. So we need to keep the Commissioner Session ID in the Commissioning Dataset even if there is no active Commissioner.

Some Harness changes expose this issue, and fail Certification test Leader_8.3.1, this PR helps to repass it.