### PR TITLE
FTD sends out first MLE advertisement when it decides to be REED

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -350,6 +350,11 @@ ThreadError MleRouter::HandleChildStart(otMleAttachFilter aFilter)
             Timer::SecToMsec(kReedAdvertiseInterval + kReedAdvertiseJitter),
             TrickleTimer::kModePlainTimer);
         mNetif.SubscribeAllRoutersMulticast();
+
+        if (GetActiveRouterCount() >= mRouterUpgradeThreshold)
+        {
+            SendAdvertisement();
+        }
     }
 
     return kThreadError_None;


### PR DESCRIPTION
Harness would verify two MLE advertisement messages from REED since attaching in (REED_ADVERTISEMENT_INTERVAL+REED_ADVERTISEMENT_MAX_JITTER)
[REED_5_2_4.zip](https://github.com/openthread/openthread/files/611530/REED_5_2_4.zip)


@jwhui, please have a review.
