### PR TITLE
Include the operational dataset tlv in Data Response unicast to SED.

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2399,7 +2399,7 @@ exit:
 
 ThreadError MleRouter::HandleNetworkDataUpdateRouter(void)
 {
-    static const uint8_t tlvs[] = {Tlv::kLeaderData, Tlv::kNetworkData};
+    static const uint8_t tlvs[] = {Tlv::kNetworkData};
     Ip6::Address destination;
 
     VerifyOrExit(mDeviceState == kDeviceStateRouter || mDeviceState == kDeviceStateLeader, ;);
@@ -2434,7 +2434,9 @@ ThreadError MleRouter::HandleNetworkDataUpdateRouter(void)
         {
             if (child->mNetworkDataVersion != mNetworkData.GetStableVersion())
             {
-                SendDataResponse(destination, tlvs, sizeof(tlvs));
+                static const uint8_t responseTlvs[] = {Tlv::kNetworkData, Tlv::kActiveDataset, Tlv::kPendingDataset};
+
+                SendDataResponse(destination, responseTlvs, sizeof(responseTlvs));
             }
         }
     }

--- a/tools/harness-thci/ARM.py
+++ b/tools/harness-thci/ARM.py
@@ -1961,7 +1961,7 @@ class ARM(IThci):
             else:
                 return False
         except Exception, e:
-            modulehelper.writeintodebuglogger("allowcommission() error: " + str(e))
+            Modulehelper.writeintodebuglogger("allowcommission() error: " + str(e))
 
     def joinCommissioned(self, strPSKd='threadjpaketest', waitTime=20):
         """start joiner
@@ -2061,7 +2061,7 @@ class ARM(IThci):
             print cmd
             return self.__sendCommand(cmd) == 'Done'
         except Exception, e:
-            modulehelper.writeintodebuglogger("MGMT_ED_SCAN() error: " + str(e))
+            Modulehelper.writeintodebuglogger("MGMT_ED_SCAN() error: " + str(e))
 
     def MGMT_PANID_QUERY(self, sAddr, xCommissionerSessionId, listChannelMask, xPanId):
         """send MGMT_PANID_QUERY message to a given destination
@@ -2086,7 +2086,7 @@ class ARM(IThci):
             print cmd
             return self.__sendCommand(cmd) == 'Done'
         except Exception, e:
-            modulehelper.writeintodebuglogger("MGMT_PANID_QUERY() error: " + str(e))
+            Modulehelper.writeintodebuglogger("MGMT_PANID_QUERY() error: " + str(e))
 
     def MGMT_ANNOUNCE_BEGIN(self, sAddr, xCommissionerSessionId, listChannelMask, xCount, xPeriod):
         """send MGMT_ANNOUNCE_BEGIN message to a given destination
@@ -2103,7 +2103,7 @@ class ARM(IThci):
             print cmd
             return self.__sendCommand(cmd) == 'Done'
         except Exception, e:
-            modulehelper.writeintodebuglogger("MGMT_ANNOUNCE_BEGIN() error: " + str(e))
+            Modulehelper.writeintodebuglogger("MGMT_ANNOUNCE_BEGIN() error: " + str(e))
 
     def MGMT_ACTIVE_GET(self, Addr='', TLVs=[]):
         """send MGMT_ACTIVE_GET command


### PR DESCRIPTION
According to [TESTPLAN-272](https://threadgroup.atlassian.net/browse/TESTPLAN-272) discussion, TestPlan adds the check for Active Operational Dataset TLV in step 13 and check for Pending Operational Data TLV in step 22 (Router unicast the Data Response to SED including valid operational dataset tlv as well as timestamp tlv). This PR helps pass 9.2.6 scenario of DUT as Router.
[Router_9_2_6.zip](https://github.com/openthread/openthread/files/611638/Router_9_2_6.zip)

However, if we add operational dataset tlv in Data Response unicast to SED, SED will not send Data Request to its parent, that will cause some test cases fail (e.g. 9.2.8-SED, harness checks if SED sends the Data Request to its parent). Seems that another Data Request is redundancy if the first Data Response has included dataset TLV.