### PR TITLE
spinel-protocol: Section reorganization, added GPIO cmds

### DIFF
--- a/doc/draft-spinel-protocol.html
+++ b/doc/draft-spinel-protocol.html
@@ -464,9 +464,68 @@
 <link href="#rfc.section.5.7.4" rel="Chapter" title="5.7.4 PROP 99: PROP_IPV6_ADDRESS_TABLE"/>
 <link href="#rfc.section.5.7.5" rel="Chapter" title="5.7.5 PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD"/>
 <link href="#rfc.section.6" rel="Chapter" title="6 Status Codes"/>
-<link href="#rfc.section.7" rel="Chapter" title="7 Security Considerations"/>
-<link href="#rfc.section.7.1" rel="Chapter" title="7.1 Raw Application Access"/>
-<link href="#rfc.section.8" rel="Chapter" title="8 Acknowledgments"/>
+<link href="#rfc.section.7" rel="Chapter" title="7 Technology: Thread"/>
+<link href="#rfc.section.7.1" rel="Chapter" title="7.1 Thread Capabilities"/>
+<link href="#rfc.section.7.2" rel="Chapter" title="7.2 Thread Properties"/>
+<link href="#rfc.section.7.2.1" rel="Chapter" title="7.2.1 PROP 80: PROP_THREAD_LEADER_ADDR"/>
+<link href="#rfc.section.7.2.2" rel="Chapter" title="7.2.2 PROP 81: PROP_THREAD_PARENT"/>
+<link href="#rfc.section.7.2.3" rel="Chapter" title="7.2.3 PROP 82: PROP_THREAD_CHILD_TABLE"/>
+<link href="#rfc.section.7.2.4" rel="Chapter" title="7.2.4 PROP 83: PROP_THREAD_LEADER_RID"/>
+<link href="#rfc.section.7.2.5" rel="Chapter" title="7.2.5 PROP 84: PROP_THREAD_LEADER_WEIGHT"/>
+<link href="#rfc.section.7.2.6" rel="Chapter" title="7.2.6 PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT"/>
+<link href="#rfc.section.7.2.7" rel="Chapter" title="7.2.7 PROP 86: PROP_THREAD_NETWORK_DATA"/>
+<link href="#rfc.section.7.2.8" rel="Chapter" title="7.2.8 PROP 87: PROP_THREAD_NETWORK_DATA_VERSION"/>
+<link href="#rfc.section.7.2.9" rel="Chapter" title="7.2.9 PROP 88: PROP_THREAD_STABLE_NETWORK_DATA"/>
+<link href="#rfc.section.7.2.10" rel="Chapter" title="7.2.10 PROP 89: PROP_THREAD_STABLE_NETWORK_DATA_VERSION"/>
+<link href="#rfc.section.7.2.11" rel="Chapter" title="7.2.11 PROP 90: PROP_THREAD_ON_MESH_NETS"/>
+<link href="#rfc.section.7.2.12" rel="Chapter" title="7.2.12 PROP 91: PROP_THREAD_LOCAL_ROUTES"/>
+<link href="#rfc.section.7.2.13" rel="Chapter" title="7.2.13 PROP 92: PROP_THREAD_ASSISTING_PORTS"/>
+<link href="#rfc.section.7.2.14" rel="Chapter" title="7.2.14 PROP 93: PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE"/>
+<link href="#rfc.section.7.2.15" rel="Chapter" title="7.2.15 PROP 94: PROP_THREAD_MODE"/>
+<link href="#rfc.section.7.2.16" rel="Chapter" title="7.2.16 PROP 5376: PROP_THREAD_CHILD_TIMEOUT"/>
+<link href="#rfc.section.7.2.17" rel="Chapter" title="7.2.17 PROP 5377: PROP_THREAD_RLOC16"/>
+<link href="#rfc.section.7.2.18" rel="Chapter" title="7.2.18 PROP 5378: PROP_THREAD_ROUTER_UPGRADE_THRESHOLD"/>
+<link href="#rfc.section.7.2.19" rel="Chapter" title="7.2.19 PROP 5379: PROP_THREAD_CONTEXT_REUSE_DELAY"/>
+<link href="#rfc.section.7.2.20" rel="Chapter" title="7.2.20 PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT"/>
+<link href="#rfc.section.7.2.21" rel="Chapter" title="7.2.21 PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS"/>
+<link href="#rfc.section.7.2.22" rel="Chapter" title="7.2.22 PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU"/>
+<link href="#rfc.section.7.2.23" rel="Chapter" title="7.2.23 PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED"/>
+<link href="#rfc.section.7.2.24" rel="Chapter" title="7.2.24 PROP 5384: PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD"/>
+<link href="#rfc.section.7.2.25" rel="Chapter" title="7.2.25 PROP 5385: PROP_THREAD_ROUTER_SELECTION_JITTER"/>
+<link href="#rfc.section.7.2.26" rel="Chapter" title="7.2.26 PROP 5386: PROP_THREAD_PREFERRED_ROUTER_ID"/>
+<link href="#rfc.section.7.2.27" rel="Chapter" title="7.2.27 PROP 5387: SPINEL_PROP_THREAD_NEIGHBOR_TABLE"/>
+<link href="#rfc.section.8" rel="Chapter" title="8 Feature: Network Save"/>
+<link href="#rfc.section.8.1" rel="Chapter" title="8.1 Commands"/>
+<link href="#rfc.section.8.1.1" rel="Chapter" title="8.1.1 CMD 9: (Host-&gt;NCP) CMD_NET_SAVE"/>
+<link href="#rfc.section.8.1.2" rel="Chapter" title="8.1.2 CMD 10: (Host-&gt;NCP) CMD_NET_CLEAR"/>
+<link href="#rfc.section.8.1.3" rel="Chapter" title="8.1.3 CMD 11: (Host-&gt;NCP) CMD_NET_RECALL"/>
+<link href="#rfc.section.9" rel="Chapter" title="9 Feature: Host Buffer Offload"/>
+<link href="#rfc.section.9.1" rel="Chapter" title="9.1 Commands"/>
+<link href="#rfc.section.9.1.1" rel="Chapter" title="9.1.1 CMD 12: (NCP-&gt;Host) CMD_HBO_OFFLOAD"/>
+<link href="#rfc.section.9.1.2" rel="Chapter" title="9.1.2 CMD 13: (NCP-&gt;Host) CMD_HBO_RECLAIM"/>
+<link href="#rfc.section.9.1.3" rel="Chapter" title="9.1.3 CMD 14: (NCP-&gt;Host) CMD_HBO_DROP"/>
+<link href="#rfc.section.9.1.4" rel="Chapter" title="9.1.4 CMD 15: (Host-&gt;NCP) CMD_HBO_OFFLOADED"/>
+<link href="#rfc.section.9.1.5" rel="Chapter" title="9.1.5 CMD 16: (Host-&gt;NCP) CMD_HBO_RECLAIMED"/>
+<link href="#rfc.section.9.1.6" rel="Chapter" title="9.1.6 CMD 17: (Host-&gt;NCP) CMD_HBO_DROPPED"/>
+<link href="#rfc.section.9.2" rel="Chapter" title="9.2 Properties"/>
+<link href="#rfc.section.9.2.1" rel="Chapter" title="9.2.1 PROP 10: PROP_HBO_MEM_MAX"/>
+<link href="#rfc.section.9.2.2" rel="Chapter" title="9.2.2 PROP 11: PROP_HBO_BLOCK_MAX"/>
+<link href="#rfc.section.10" rel="Chapter" title="10 Feature: Jam Detection"/>
+<link href="#rfc.section.10.1" rel="Chapter" title="10.1 Properties"/>
+<link href="#rfc.section.10.1.1" rel="Chapter" title="10.1.1 PROP 4608: PROP_JAM_DETECT_ENABLE"/>
+<link href="#rfc.section.10.1.2" rel="Chapter" title="10.1.2 PROP 4609: PROP_JAM_DETECTED"/>
+<link href="#rfc.section.10.1.3" rel="Chapter" title="10.1.3 PROP 4610: PROP_JAM_DETECT_RSSI_THRESHOLD"/>
+<link href="#rfc.section.10.1.4" rel="Chapter" title="10.1.4 PROP 4611: PROP_JAM_DETECT_WINDOW"/>
+<link href="#rfc.section.10.1.5" rel="Chapter" title="10.1.5 PROP 4612: PROP_JAM_DETECT_BUSY"/>
+<link href="#rfc.section.11" rel="Chapter" title="11 Feature: Basic GPIO Access"/>
+<link href="#rfc.section.11.1" rel="Chapter" title="11.1 Properties"/>
+<link href="#rfc.section.11.1.1" rel="Chapter" title="11.1.1 PROP 4096: PROP_GPIO_AVAILABLE"/>
+<link href="#rfc.section.11.1.2" rel="Chapter" title="11.1.2 PROP 4097: PROP_GPIO_DIRECTION"/>
+<link href="#rfc.section.11.1.3" rel="Chapter" title="11.1.3 PROP 4098: PROP_GPIO_STATE"/>
+<link href="#rfc.section.11.1.4" rel="Chapter" title="11.1.4 PROP 4099: PROP_GPIO_STATE_SET"/>
+<link href="#rfc.section.11.1.5" rel="Chapter" title="11.1.5 PROP 4100: PROP_GPIO_STATE_CLEAR"/>
+<link href="#rfc.section.12" rel="Chapter" title="12 Security Considerations"/>
+<link href="#rfc.section.12.1" rel="Chapter" title="12.1 Raw Application Access"/>
 <link href="#rfc.appendix.A" rel="Chapter" title="A Framing Protocol"/>
 <link href="#rfc.appendix.A.1" rel="Chapter" title="A.1 UART Recommendations"/>
 <link href="#rfc.appendix.A.1.1" rel="Chapter" title="A.1.1 UART Bit Rate Detection"/>
@@ -475,84 +534,32 @@
 <link href="#rfc.appendix.A.2.1" rel="Chapter" title="A.2.1 SPI Framing Protocol"/>
 <link href="#rfc.appendix.A.3" rel="Chapter" title="A.3 I&#xB2;C Recommendations"/>
 <link href="#rfc.appendix.A.4" rel="Chapter" title="A.4 Native USB Recommendations"/>
-<link href="#rfc.appendix.B" rel="Chapter" title="B Feature: Network Save"/>
-<link href="#rfc.appendix.B.1" rel="Chapter" title="B.1 Commands"/>
-<link href="#rfc.appendix.B.1.1" rel="Chapter" title="B.1.1 CMD 9: (Host-&gt;NCP) CMD_NET_SAVE"/>
-<link href="#rfc.appendix.B.1.2" rel="Chapter" title="B.1.2 CMD 10: (Host-&gt;NCP) CMD_NET_CLEAR"/>
-<link href="#rfc.appendix.B.1.3" rel="Chapter" title="B.1.3 CMD 11: (Host-&gt;NCP) CMD_NET_RECALL"/>
-<link href="#rfc.appendix.C" rel="Chapter" title="C Feature: Host Buffer Offload"/>
-<link href="#rfc.appendix.C.1" rel="Chapter" title="C.1 Commands"/>
-<link href="#rfc.appendix.C.1.1" rel="Chapter" title="C.1.1 CMD 12: (NCP-&gt;Host) CMD_HBO_OFFLOAD"/>
-<link href="#rfc.appendix.C.1.2" rel="Chapter" title="C.1.2 CMD 13: (NCP-&gt;Host) CMD_HBO_RECLAIM"/>
-<link href="#rfc.appendix.C.1.3" rel="Chapter" title="C.1.3 CMD 14: (NCP-&gt;Host) CMD_HBO_DROP"/>
-<link href="#rfc.appendix.C.1.4" rel="Chapter" title="C.1.4 CMD 15: (Host-&gt;NCP) CMD_HBO_OFFLOADED"/>
-<link href="#rfc.appendix.C.1.5" rel="Chapter" title="C.1.5 CMD 16: (Host-&gt;NCP) CMD_HBO_RECLAIMED"/>
-<link href="#rfc.appendix.C.1.6" rel="Chapter" title="C.1.6 CMD 17: (Host-&gt;NCP) CMD_HBO_DROPPED"/>
-<link href="#rfc.appendix.C.2" rel="Chapter" title="C.2 Properties"/>
-<link href="#rfc.appendix.C.2.1" rel="Chapter" title="C.2.1 PROP 10: PROP_HBO_MEM_MAX"/>
-<link href="#rfc.appendix.C.2.2" rel="Chapter" title="C.2.2 PROP 11: PROP_HBO_BLOCK_MAX"/>
-<link href="#rfc.appendix.D" rel="Chapter" title="D Feature: Jam Detection"/>
-<link href="#rfc.appendix.D.1" rel="Chapter" title="D.1 Properties"/>
-<link href="#rfc.appendix.D.1.1" rel="Chapter" title="D.1.1 PROP 4608: PROP_JAM_DETECT_ENABLE"/>
-<link href="#rfc.appendix.D.1.2" rel="Chapter" title="D.1.2 PROP 4609: PROP_JAM_DETECTED"/>
-<link href="#rfc.appendix.D.1.3" rel="Chapter" title="D.1.3 PROP 4610: PROP_JAM_DETECT_RSSI_THRESHOLD"/>
-<link href="#rfc.appendix.D.1.4" rel="Chapter" title="D.1.4 PROP 4611: PROP_JAM_DETECT_WINDOW"/>
-<link href="#rfc.appendix.D.1.5" rel="Chapter" title="D.1.5 PROP 4612: PROP_JAM_DETECT_BUSY"/>
-<link href="#rfc.appendix.E" rel="Chapter" title="E Technology: Thread"/>
-<link href="#rfc.appendix.E.1" rel="Chapter" title="E.1 Thread Capabilities"/>
-<link href="#rfc.appendix.E.2" rel="Chapter" title="E.2 Thread Properties"/>
-<link href="#rfc.appendix.E.2.1" rel="Chapter" title="E.2.1 PROP 80: PROP_THREAD_LEADER_ADDR"/>
-<link href="#rfc.appendix.E.2.2" rel="Chapter" title="E.2.2 PROP 81: PROP_THREAD_PARENT"/>
-<link href="#rfc.appendix.E.2.3" rel="Chapter" title="E.2.3 PROP 82: PROP_THREAD_CHILD_TABLE"/>
-<link href="#rfc.appendix.E.2.4" rel="Chapter" title="E.2.4 PROP 83: PROP_THREAD_LEADER_RID"/>
-<link href="#rfc.appendix.E.2.5" rel="Chapter" title="E.2.5 PROP 84: PROP_THREAD_LEADER_WEIGHT"/>
-<link href="#rfc.appendix.E.2.6" rel="Chapter" title="E.2.6 PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT"/>
-<link href="#rfc.appendix.E.2.7" rel="Chapter" title="E.2.7 PROP 86: PROP_THREAD_NETWORK_DATA"/>
-<link href="#rfc.appendix.E.2.8" rel="Chapter" title="E.2.8 PROP 87: PROP_THREAD_NETWORK_DATA_VERSION"/>
-<link href="#rfc.appendix.E.2.9" rel="Chapter" title="E.2.9 PROP 88: PROP_THREAD_STABLE_NETWORK_DATA"/>
-<link href="#rfc.appendix.E.2.10" rel="Chapter" title="E.2.10 PROP 89: PROP_THREAD_STABLE_NETWORK_DATA_VERSION"/>
-<link href="#rfc.appendix.E.2.11" rel="Chapter" title="E.2.11 PROP 90: PROP_THREAD_ON_MESH_NETS"/>
-<link href="#rfc.appendix.E.2.12" rel="Chapter" title="E.2.12 PROP 91: PROP_THREAD_LOCAL_ROUTES"/>
-<link href="#rfc.appendix.E.2.13" rel="Chapter" title="E.2.13 PROP 92: PROP_THREAD_ASSISTING_PORTS"/>
-<link href="#rfc.appendix.E.2.14" rel="Chapter" title="E.2.14 PROP 93: PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE"/>
-<link href="#rfc.appendix.E.2.15" rel="Chapter" title="E.2.15 PROP 94: PROP_THREAD_MODE"/>
-<link href="#rfc.appendix.E.2.16" rel="Chapter" title="E.2.16 PROP 5376: PROP_THREAD_CHILD_TIMEOUT"/>
-<link href="#rfc.appendix.E.2.17" rel="Chapter" title="E.2.17 PROP 5377: PROP_THREAD_RLOC16"/>
-<link href="#rfc.appendix.E.2.18" rel="Chapter" title="E.2.18 PROP 5378: PROP_THREAD_ROUTER_UPGRADE_THRESHOLD"/>
-<link href="#rfc.appendix.E.2.19" rel="Chapter" title="E.2.19 PROP 5379: PROP_THREAD_CONTEXT_REUSE_DELAY"/>
-<link href="#rfc.appendix.E.2.20" rel="Chapter" title="E.2.20 PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT"/>
-<link href="#rfc.appendix.E.2.21" rel="Chapter" title="E.2.21 PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS"/>
-<link href="#rfc.appendix.E.2.22" rel="Chapter" title="E.2.22 PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU"/>
-<link href="#rfc.appendix.E.2.23" rel="Chapter" title="E.2.23 PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED"/>
-<link href="#rfc.appendix.E.2.24" rel="Chapter" title="E.2.24 PROP 5384: PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD"/>
-<link href="#rfc.appendix.E.2.25" rel="Chapter" title="E.2.25 PROP 5385: PROP_THREAD_ROUTER_SELECTION_JITTER"/>
-<link href="#rfc.appendix.E.2.26" rel="Chapter" title="E.2.26 PROP 5386: PROP_THREAD_PREFERRED_ROUTER_ID"/>
-<link href="#rfc.appendix.E.2.27" rel="Chapter" title="E.2.27 PROP 5387: SPINEL_PROP_THREAD_NEIGHBOR_TABLE"/>
-<link href="#rfc.appendix.F" rel="Chapter" title="F Test Vectors"/>
-<link href="#rfc.appendix.F.1" rel="Chapter" title="F.1 Test Vector: Packed Unsigned Integer"/>
-<link href="#rfc.appendix.F.2" rel="Chapter" title="F.2 Test Vector: Reset Command"/>
-<link href="#rfc.appendix.F.3" rel="Chapter" title="F.3 Test Vector: Reset Notification"/>
-<link href="#rfc.appendix.F.4" rel="Chapter" title="F.4 Test Vector: Scan Beacon"/>
-<link href="#rfc.appendix.F.5" rel="Chapter" title="F.5 Test Vector: Inbound IPv6 Packet"/>
-<link href="#rfc.appendix.F.6" rel="Chapter" title="F.6 Test Vector: Outbound IPv6 Packet"/>
-<link href="#rfc.appendix.F.7" rel="Chapter" title="F.7 Test Vector: Fetch list of on-mesh networks"/>
-<link href="#rfc.appendix.F.8" rel="Chapter" title="F.8 Test Vector: Returned list of on-mesh networks"/>
-<link href="#rfc.appendix.F.9" rel="Chapter" title="F.9 Test Vector: Adding an on-mesh network"/>
-<link href="#rfc.appendix.F.10" rel="Chapter" title="F.10 Test Vector: Insertion notification of an on-mesh network"/>
-<link href="#rfc.appendix.F.11" rel="Chapter" title="F.11 Test Vector: Removing a local on-mesh network"/>
-<link href="#rfc.appendix.F.12" rel="Chapter" title="F.12 Test Vector: Removal notification of an on-mesh network"/>
-<link href="#rfc.appendix.G" rel="Chapter" title="G Example Sessions"/>
-<link href="#rfc.appendix.G.1" rel="Chapter" title="G.1 NCP Initialization"/>
-<link href="#rfc.appendix.G.2" rel="Chapter" title="G.2 Attaching to a network"/>
-<link href="#rfc.appendix.G.3" rel="Chapter" title="G.3 Successfully joining a pre-existing network"/>
-<link href="#rfc.appendix.G.4" rel="Chapter" title="G.4 Unsuccessfully joining a pre-existing network"/>
-<link href="#rfc.appendix.G.5" rel="Chapter" title="G.5 Detaching from a network"/>
-<link href="#rfc.appendix.G.6" rel="Chapter" title="G.6 Attaching to a saved network"/>
-<link href="#rfc.appendix.G.7" rel="Chapter" title="G.7 NCP Software Reset"/>
-<link href="#rfc.appendix.G.8" rel="Chapter" title="G.8 Adding an on-mesh prefix"/>
-<link href="#rfc.appendix.G.9" rel="Chapter" title="G.9 Entering low-power modes"/>
-<link href="#rfc.appendix.G.10" rel="Chapter" title="G.10 Sniffing raw packets"/>
-<link href="#rfc.appendix.H" rel="Chapter" title="H Glossary"/>
+<link href="#rfc.appendix.B" rel="Chapter" title="B Test Vectors"/>
+<link href="#rfc.appendix.B.1" rel="Chapter" title="B.1 Test Vector: Packed Unsigned Integer"/>
+<link href="#rfc.appendix.B.2" rel="Chapter" title="B.2 Test Vector: Reset Command"/>
+<link href="#rfc.appendix.B.3" rel="Chapter" title="B.3 Test Vector: Reset Notification"/>
+<link href="#rfc.appendix.B.4" rel="Chapter" title="B.4 Test Vector: Scan Beacon"/>
+<link href="#rfc.appendix.B.5" rel="Chapter" title="B.5 Test Vector: Inbound IPv6 Packet"/>
+<link href="#rfc.appendix.B.6" rel="Chapter" title="B.6 Test Vector: Outbound IPv6 Packet"/>
+<link href="#rfc.appendix.B.7" rel="Chapter" title="B.7 Test Vector: Fetch list of on-mesh networks"/>
+<link href="#rfc.appendix.B.8" rel="Chapter" title="B.8 Test Vector: Returned list of on-mesh networks"/>
+<link href="#rfc.appendix.B.9" rel="Chapter" title="B.9 Test Vector: Adding an on-mesh network"/>
+<link href="#rfc.appendix.B.10" rel="Chapter" title="B.10 Test Vector: Insertion notification of an on-mesh network"/>
+<link href="#rfc.appendix.B.11" rel="Chapter" title="B.11 Test Vector: Removing a local on-mesh network"/>
+<link href="#rfc.appendix.B.12" rel="Chapter" title="B.12 Test Vector: Removal notification of an on-mesh network"/>
+<link href="#rfc.appendix.C" rel="Chapter" title="C Example Sessions"/>
+<link href="#rfc.appendix.C.1" rel="Chapter" title="C.1 NCP Initialization"/>
+<link href="#rfc.appendix.C.2" rel="Chapter" title="C.2 Attaching to a network"/>
+<link href="#rfc.appendix.C.3" rel="Chapter" title="C.3 Successfully joining a pre-existing network"/>
+<link href="#rfc.appendix.C.4" rel="Chapter" title="C.4 Unsuccessfully joining a pre-existing network"/>
+<link href="#rfc.appendix.C.5" rel="Chapter" title="C.5 Detaching from a network"/>
+<link href="#rfc.appendix.C.6" rel="Chapter" title="C.6 Attaching to a saved network"/>
+<link href="#rfc.appendix.C.7" rel="Chapter" title="C.7 NCP Software Reset"/>
+<link href="#rfc.appendix.C.8" rel="Chapter" title="C.8 Adding an on-mesh prefix"/>
+<link href="#rfc.appendix.C.9" rel="Chapter" title="C.9 Entering low-power modes"/>
+<link href="#rfc.appendix.C.10" rel="Chapter" title="C.10 Sniffing raw packets"/>
+<link href="#rfc.appendix.D" rel="Chapter" title="D Acknowledgments"/>
+<link href="#rfc.appendix.E" rel="Chapter" title="E Glossary"/>
 <link href="#rfc.authors" rel="Chapter"/>
 
 
@@ -560,8 +567,8 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Quattlebaum, R." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-spinel-protocol-f9bf43254" />
-  <meta name="dct.issued" scheme="ISO8601" content="2016-11-4" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-spinel-protocol-05367497d" />
+  <meta name="dct.issued" scheme="ISO8601" content="2016-11-28" />
   <meta name="dct.abstract" content="This document describes a general management protocol for enabling a host device to communicate with and manage a Network Control Processor (NCP).  " />
   <meta name="description" content="This document describes a general management protocol for enabling a host device to communicate with and manage a Network Control Processor (NCP).  " />
 
@@ -582,7 +589,7 @@
 </tr>
 <tr>
   <td class="left"></td>
-  <td class="right">November 4, 2016</td>
+  <td class="right">November 28, 2016</td>
 </tr>
 
     	
@@ -590,7 +597,7 @@
   </table>
 
   <p class="title">Spinel Host-Controller Protocol<br />
-  <span class="filename">draft-spinel-protocol-f9bf43254</span></p>
+  <span class="filename">draft-spinel-protocol-05367497d</span></p>
   
   <h1 id="rfc.abstract">
   <a href="#rfc.abstract">Abstract</a>
@@ -715,10 +722,69 @@
 <li>5.7.4.   <a href="#rfc.section.5.7.4">PROP 99: PROP_IPV6_ADDRESS_TABLE</a></li>
 <li>5.7.5.   <a href="#rfc.section.5.7.5">PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD</a></li>
 </ul></ul><li>6.   <a href="#rfc.section.6">Status Codes</a></li>
-<li>7.   <a href="#rfc.section.7">Security Considerations</a></li>
-<ul><li>7.1.   <a href="#rfc.section.7.1">Raw Application Access</a></li>
-</ul><li>8.   <a href="#rfc.section.8">Acknowledgments</a></li>
-<li>Appendix A.   <a href="#rfc.appendix.A">Framing Protocol</a></li>
+<li>7.   <a href="#rfc.section.7">Technology: Thread</a></li>
+<ul><li>7.1.   <a href="#rfc.section.7.1">Thread Capabilities</a></li>
+<li>7.2.   <a href="#rfc.section.7.2">Thread Properties</a></li>
+<ul><li>7.2.1.   <a href="#rfc.section.7.2.1">PROP 80: PROP_THREAD_LEADER_ADDR</a></li>
+<li>7.2.2.   <a href="#rfc.section.7.2.2">PROP 81: PROP_THREAD_PARENT</a></li>
+<li>7.2.3.   <a href="#rfc.section.7.2.3">PROP 82: PROP_THREAD_CHILD_TABLE</a></li>
+<li>7.2.4.   <a href="#rfc.section.7.2.4">PROP 83: PROP_THREAD_LEADER_RID</a></li>
+<li>7.2.5.   <a href="#rfc.section.7.2.5">PROP 84: PROP_THREAD_LEADER_WEIGHT</a></li>
+<li>7.2.6.   <a href="#rfc.section.7.2.6">PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT</a></li>
+<li>7.2.7.   <a href="#rfc.section.7.2.7">PROP 86: PROP_THREAD_NETWORK_DATA</a></li>
+<li>7.2.8.   <a href="#rfc.section.7.2.8">PROP 87: PROP_THREAD_NETWORK_DATA_VERSION</a></li>
+<li>7.2.9.   <a href="#rfc.section.7.2.9">PROP 88: PROP_THREAD_STABLE_NETWORK_DATA</a></li>
+<li>7.2.10.   <a href="#rfc.section.7.2.10">PROP 89: PROP_THREAD_STABLE_NETWORK_DATA_VERSION</a></li>
+<li>7.2.11.   <a href="#rfc.section.7.2.11">PROP 90: PROP_THREAD_ON_MESH_NETS</a></li>
+<li>7.2.12.   <a href="#rfc.section.7.2.12">PROP 91: PROP_THREAD_LOCAL_ROUTES</a></li>
+<li>7.2.13.   <a href="#rfc.section.7.2.13">PROP 92: PROP_THREAD_ASSISTING_PORTS</a></li>
+<li>7.2.14.   <a href="#rfc.section.7.2.14">PROP 93: PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE</a></li>
+<li>7.2.15.   <a href="#rfc.section.7.2.15">PROP 94: PROP_THREAD_MODE</a></li>
+<li>7.2.16.   <a href="#rfc.section.7.2.16">PROP 5376: PROP_THREAD_CHILD_TIMEOUT</a></li>
+<li>7.2.17.   <a href="#rfc.section.7.2.17">PROP 5377: PROP_THREAD_RLOC16</a></li>
+<li>7.2.18.   <a href="#rfc.section.7.2.18">PROP 5378: PROP_THREAD_ROUTER_UPGRADE_THRESHOLD</a></li>
+<li>7.2.19.   <a href="#rfc.section.7.2.19">PROP 5379: PROP_THREAD_CONTEXT_REUSE_DELAY</a></li>
+<li>7.2.20.   <a href="#rfc.section.7.2.20">PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT</a></li>
+<li>7.2.21.   <a href="#rfc.section.7.2.21">PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS</a></li>
+<li>7.2.22.   <a href="#rfc.section.7.2.22">PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU</a></li>
+<li>7.2.23.   <a href="#rfc.section.7.2.23">PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED</a></li>
+<li>7.2.24.   <a href="#rfc.section.7.2.24">PROP 5384: PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD</a></li>
+<li>7.2.25.   <a href="#rfc.section.7.2.25">PROP 5385: PROP_THREAD_ROUTER_SELECTION_JITTER</a></li>
+<li>7.2.26.   <a href="#rfc.section.7.2.26">PROP 5386: PROP_THREAD_PREFERRED_ROUTER_ID</a></li>
+<li>7.2.27.   <a href="#rfc.section.7.2.27">PROP 5387: SPINEL_PROP_THREAD_NEIGHBOR_TABLE</a></li>
+</ul></ul><li>8.   <a href="#rfc.section.8">Feature: Network Save</a></li>
+<ul><li>8.1.   <a href="#rfc.section.8.1">Commands</a></li>
+<ul><li>8.1.1.   <a href="#rfc.section.8.1.1">CMD 9: (Host-&gt;NCP) CMD_NET_SAVE</a></li>
+<li>8.1.2.   <a href="#rfc.section.8.1.2">CMD 10: (Host-&gt;NCP) CMD_NET_CLEAR</a></li>
+<li>8.1.3.   <a href="#rfc.section.8.1.3">CMD 11: (Host-&gt;NCP) CMD_NET_RECALL</a></li>
+</ul></ul><li>9.   <a href="#rfc.section.9">Feature: Host Buffer Offload</a></li>
+<ul><li>9.1.   <a href="#rfc.section.9.1">Commands</a></li>
+<ul><li>9.1.1.   <a href="#rfc.section.9.1.1">CMD 12: (NCP-&gt;Host) CMD_HBO_OFFLOAD</a></li>
+<li>9.1.2.   <a href="#rfc.section.9.1.2">CMD 13: (NCP-&gt;Host) CMD_HBO_RECLAIM</a></li>
+<li>9.1.3.   <a href="#rfc.section.9.1.3">CMD 14: (NCP-&gt;Host) CMD_HBO_DROP</a></li>
+<li>9.1.4.   <a href="#rfc.section.9.1.4">CMD 15: (Host-&gt;NCP) CMD_HBO_OFFLOADED</a></li>
+<li>9.1.5.   <a href="#rfc.section.9.1.5">CMD 16: (Host-&gt;NCP) CMD_HBO_RECLAIMED</a></li>
+<li>9.1.6.   <a href="#rfc.section.9.1.6">CMD 17: (Host-&gt;NCP) CMD_HBO_DROPPED</a></li>
+</ul><li>9.2.   <a href="#rfc.section.9.2">Properties</a></li>
+<ul><li>9.2.1.   <a href="#rfc.section.9.2.1">PROP 10: PROP_HBO_MEM_MAX</a></li>
+<li>9.2.2.   <a href="#rfc.section.9.2.2">PROP 11: PROP_HBO_BLOCK_MAX</a></li>
+</ul></ul><li>10.   <a href="#rfc.section.10">Feature: Jam Detection</a></li>
+<ul><li>10.1.   <a href="#rfc.section.10.1">Properties</a></li>
+<ul><li>10.1.1.   <a href="#rfc.section.10.1.1">PROP 4608: PROP_JAM_DETECT_ENABLE</a></li>
+<li>10.1.2.   <a href="#rfc.section.10.1.2">PROP 4609: PROP_JAM_DETECTED</a></li>
+<li>10.1.3.   <a href="#rfc.section.10.1.3">PROP 4610: PROP_JAM_DETECT_RSSI_THRESHOLD</a></li>
+<li>10.1.4.   <a href="#rfc.section.10.1.4">PROP 4611: PROP_JAM_DETECT_WINDOW</a></li>
+<li>10.1.5.   <a href="#rfc.section.10.1.5">PROP 4612: PROP_JAM_DETECT_BUSY</a></li>
+</ul></ul><li>11.   <a href="#rfc.section.11">Feature: Basic GPIO Access</a></li>
+<ul><li>11.1.   <a href="#rfc.section.11.1">Properties</a></li>
+<ul><li>11.1.1.   <a href="#rfc.section.11.1.1">PROP 4096: PROP_GPIO_AVAILABLE</a></li>
+<li>11.1.2.   <a href="#rfc.section.11.1.2">PROP 4097: PROP_GPIO_DIRECTION</a></li>
+<li>11.1.3.   <a href="#rfc.section.11.1.3">PROP 4098: PROP_GPIO_STATE</a></li>
+<li>11.1.4.   <a href="#rfc.section.11.1.4">PROP 4099: PROP_GPIO_STATE_SET</a></li>
+<li>11.1.5.   <a href="#rfc.section.11.1.5">PROP 4100: PROP_GPIO_STATE_CLEAR</a></li>
+</ul></ul><li>12.   <a href="#rfc.section.12">Security Considerations</a></li>
+<ul><li>12.1.   <a href="#rfc.section.12.1">Raw Application Access</a></li>
+</ul><li>Appendix A.   <a href="#rfc.appendix.A">Framing Protocol</a></li>
 <ul><li>A.1.   <a href="#rfc.appendix.A.1">UART Recommendations</a></li>
 <ul><li>A.1.1.   <a href="#rfc.appendix.A.1.1">UART Bit Rate Detection</a></li>
 <li>A.1.2.   <a href="#rfc.appendix.A.1.2">HDLC-Lite</a></li>
@@ -726,84 +792,32 @@
 <ul><li>A.2.1.   <a href="#rfc.appendix.A.2.1">SPI Framing Protocol</a></li>
 </ul><li>A.3.   <a href="#rfc.appendix.A.3">I&#178;C Recommendations</a></li>
 <li>A.4.   <a href="#rfc.appendix.A.4">Native USB Recommendations</a></li>
-</ul><li>Appendix B.   <a href="#rfc.appendix.B">Feature: Network Save</a></li>
-<ul><li>B.1.   <a href="#rfc.appendix.B.1">Commands</a></li>
-<ul><li>B.1.1.   <a href="#rfc.appendix.B.1.1">CMD 9: (Host-&gt;NCP) CMD_NET_SAVE</a></li>
-<li>B.1.2.   <a href="#rfc.appendix.B.1.2">CMD 10: (Host-&gt;NCP) CMD_NET_CLEAR</a></li>
-<li>B.1.3.   <a href="#rfc.appendix.B.1.3">CMD 11: (Host-&gt;NCP) CMD_NET_RECALL</a></li>
-</ul></ul><li>Appendix C.   <a href="#rfc.appendix.C">Feature: Host Buffer Offload</a></li>
-<ul><li>C.1.   <a href="#rfc.appendix.C.1">Commands</a></li>
-<ul><li>C.1.1.   <a href="#rfc.appendix.C.1.1">CMD 12: (NCP-&gt;Host) CMD_HBO_OFFLOAD</a></li>
-<li>C.1.2.   <a href="#rfc.appendix.C.1.2">CMD 13: (NCP-&gt;Host) CMD_HBO_RECLAIM</a></li>
-<li>C.1.3.   <a href="#rfc.appendix.C.1.3">CMD 14: (NCP-&gt;Host) CMD_HBO_DROP</a></li>
-<li>C.1.4.   <a href="#rfc.appendix.C.1.4">CMD 15: (Host-&gt;NCP) CMD_HBO_OFFLOADED</a></li>
-<li>C.1.5.   <a href="#rfc.appendix.C.1.5">CMD 16: (Host-&gt;NCP) CMD_HBO_RECLAIMED</a></li>
-<li>C.1.6.   <a href="#rfc.appendix.C.1.6">CMD 17: (Host-&gt;NCP) CMD_HBO_DROPPED</a></li>
-</ul><li>C.2.   <a href="#rfc.appendix.C.2">Properties</a></li>
-<ul><li>C.2.1.   <a href="#rfc.appendix.C.2.1">PROP 10: PROP_HBO_MEM_MAX</a></li>
-<li>C.2.2.   <a href="#rfc.appendix.C.2.2">PROP 11: PROP_HBO_BLOCK_MAX</a></li>
-</ul></ul><li>Appendix D.   <a href="#rfc.appendix.D">Feature: Jam Detection</a></li>
-<ul><li>D.1.   <a href="#rfc.appendix.D.1">Properties</a></li>
-<ul><li>D.1.1.   <a href="#rfc.appendix.D.1.1">PROP 4608: PROP_JAM_DETECT_ENABLE</a></li>
-<li>D.1.2.   <a href="#rfc.appendix.D.1.2">PROP 4609: PROP_JAM_DETECTED</a></li>
-<li>D.1.3.   <a href="#rfc.appendix.D.1.3">PROP 4610: PROP_JAM_DETECT_RSSI_THRESHOLD</a></li>
-<li>D.1.4.   <a href="#rfc.appendix.D.1.4">PROP 4611: PROP_JAM_DETECT_WINDOW</a></li>
-<li>D.1.5.   <a href="#rfc.appendix.D.1.5">PROP 4612: PROP_JAM_DETECT_BUSY</a></li>
-</ul></ul><li>Appendix E.   <a href="#rfc.appendix.E">Technology: Thread</a></li>
-<ul><li>E.1.   <a href="#rfc.appendix.E.1">Thread Capabilities</a></li>
-<li>E.2.   <a href="#rfc.appendix.E.2">Thread Properties</a></li>
-<ul><li>E.2.1.   <a href="#rfc.appendix.E.2.1">PROP 80: PROP_THREAD_LEADER_ADDR</a></li>
-<li>E.2.2.   <a href="#rfc.appendix.E.2.2">PROP 81: PROP_THREAD_PARENT</a></li>
-<li>E.2.3.   <a href="#rfc.appendix.E.2.3">PROP 82: PROP_THREAD_CHILD_TABLE</a></li>
-<li>E.2.4.   <a href="#rfc.appendix.E.2.4">PROP 83: PROP_THREAD_LEADER_RID</a></li>
-<li>E.2.5.   <a href="#rfc.appendix.E.2.5">PROP 84: PROP_THREAD_LEADER_WEIGHT</a></li>
-<li>E.2.6.   <a href="#rfc.appendix.E.2.6">PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT</a></li>
-<li>E.2.7.   <a href="#rfc.appendix.E.2.7">PROP 86: PROP_THREAD_NETWORK_DATA</a></li>
-<li>E.2.8.   <a href="#rfc.appendix.E.2.8">PROP 87: PROP_THREAD_NETWORK_DATA_VERSION</a></li>
-<li>E.2.9.   <a href="#rfc.appendix.E.2.9">PROP 88: PROP_THREAD_STABLE_NETWORK_DATA</a></li>
-<li>E.2.10.   <a href="#rfc.appendix.E.2.10">PROP 89: PROP_THREAD_STABLE_NETWORK_DATA_VERSION</a></li>
-<li>E.2.11.   <a href="#rfc.appendix.E.2.11">PROP 90: PROP_THREAD_ON_MESH_NETS</a></li>
-<li>E.2.12.   <a href="#rfc.appendix.E.2.12">PROP 91: PROP_THREAD_LOCAL_ROUTES</a></li>
-<li>E.2.13.   <a href="#rfc.appendix.E.2.13">PROP 92: PROP_THREAD_ASSISTING_PORTS</a></li>
-<li>E.2.14.   <a href="#rfc.appendix.E.2.14">PROP 93: PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE</a></li>
-<li>E.2.15.   <a href="#rfc.appendix.E.2.15">PROP 94: PROP_THREAD_MODE</a></li>
-<li>E.2.16.   <a href="#rfc.appendix.E.2.16">PROP 5376: PROP_THREAD_CHILD_TIMEOUT</a></li>
-<li>E.2.17.   <a href="#rfc.appendix.E.2.17">PROP 5377: PROP_THREAD_RLOC16</a></li>
-<li>E.2.18.   <a href="#rfc.appendix.E.2.18">PROP 5378: PROP_THREAD_ROUTER_UPGRADE_THRESHOLD</a></li>
-<li>E.2.19.   <a href="#rfc.appendix.E.2.19">PROP 5379: PROP_THREAD_CONTEXT_REUSE_DELAY</a></li>
-<li>E.2.20.   <a href="#rfc.appendix.E.2.20">PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT</a></li>
-<li>E.2.21.   <a href="#rfc.appendix.E.2.21">PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS</a></li>
-<li>E.2.22.   <a href="#rfc.appendix.E.2.22">PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU</a></li>
-<li>E.2.23.   <a href="#rfc.appendix.E.2.23">PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED</a></li>
-<li>E.2.24.   <a href="#rfc.appendix.E.2.24">PROP 5384: PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD</a></li>
-<li>E.2.25.   <a href="#rfc.appendix.E.2.25">PROP 5385: PROP_THREAD_ROUTER_SELECTION_JITTER</a></li>
-<li>E.2.26.   <a href="#rfc.appendix.E.2.26">PROP 5386: PROP_THREAD_PREFERRED_ROUTER_ID</a></li>
-<li>E.2.27.   <a href="#rfc.appendix.E.2.27">PROP 5387: SPINEL_PROP_THREAD_NEIGHBOR_TABLE</a></li>
-</ul></ul><li>Appendix F.   <a href="#rfc.appendix.F">Test Vectors</a></li>
-<ul><li>F.1.   <a href="#rfc.appendix.F.1">Test Vector: Packed Unsigned Integer</a></li>
-<li>F.2.   <a href="#rfc.appendix.F.2">Test Vector: Reset Command</a></li>
-<li>F.3.   <a href="#rfc.appendix.F.3">Test Vector: Reset Notification</a></li>
-<li>F.4.   <a href="#rfc.appendix.F.4">Test Vector: Scan Beacon</a></li>
-<li>F.5.   <a href="#rfc.appendix.F.5">Test Vector: Inbound IPv6 Packet</a></li>
-<li>F.6.   <a href="#rfc.appendix.F.6">Test Vector: Outbound IPv6 Packet</a></li>
-<li>F.7.   <a href="#rfc.appendix.F.7">Test Vector: Fetch list of on-mesh networks</a></li>
-<li>F.8.   <a href="#rfc.appendix.F.8">Test Vector: Returned list of on-mesh networks</a></li>
-<li>F.9.   <a href="#rfc.appendix.F.9">Test Vector: Adding an on-mesh network</a></li>
-<li>F.10.   <a href="#rfc.appendix.F.10">Test Vector: Insertion notification of an on-mesh network</a></li>
-<li>F.11.   <a href="#rfc.appendix.F.11">Test Vector: Removing a local on-mesh network</a></li>
-<li>F.12.   <a href="#rfc.appendix.F.12">Test Vector: Removal notification of an on-mesh network</a></li>
-</ul><li>Appendix G.   <a href="#rfc.appendix.G">Example Sessions</a></li>
-<ul><li>G.1.   <a href="#rfc.appendix.G.1">NCP Initialization</a></li>
-<li>G.2.   <a href="#rfc.appendix.G.2">Attaching to a network</a></li>
-<li>G.3.   <a href="#rfc.appendix.G.3">Successfully joining a pre-existing network</a></li>
-<li>G.4.   <a href="#rfc.appendix.G.4">Unsuccessfully joining a pre-existing network</a></li>
-<li>G.5.   <a href="#rfc.appendix.G.5">Detaching from a network</a></li>
-<li>G.6.   <a href="#rfc.appendix.G.6">Attaching to a saved network</a></li>
-<li>G.7.   <a href="#rfc.appendix.G.7">NCP Software Reset</a></li>
-<li>G.8.   <a href="#rfc.appendix.G.8">Adding an on-mesh prefix</a></li>
-<li>G.9.   <a href="#rfc.appendix.G.9">Entering low-power modes</a></li>
-<li>G.10.   <a href="#rfc.appendix.G.10">Sniffing raw packets</a></li>
-</ul><li>Appendix H.   <a href="#rfc.appendix.H">Glossary</a></li>
+</ul><li>Appendix B.   <a href="#rfc.appendix.B">Test Vectors</a></li>
+<ul><li>B.1.   <a href="#rfc.appendix.B.1">Test Vector: Packed Unsigned Integer</a></li>
+<li>B.2.   <a href="#rfc.appendix.B.2">Test Vector: Reset Command</a></li>
+<li>B.3.   <a href="#rfc.appendix.B.3">Test Vector: Reset Notification</a></li>
+<li>B.4.   <a href="#rfc.appendix.B.4">Test Vector: Scan Beacon</a></li>
+<li>B.5.   <a href="#rfc.appendix.B.5">Test Vector: Inbound IPv6 Packet</a></li>
+<li>B.6.   <a href="#rfc.appendix.B.6">Test Vector: Outbound IPv6 Packet</a></li>
+<li>B.7.   <a href="#rfc.appendix.B.7">Test Vector: Fetch list of on-mesh networks</a></li>
+<li>B.8.   <a href="#rfc.appendix.B.8">Test Vector: Returned list of on-mesh networks</a></li>
+<li>B.9.   <a href="#rfc.appendix.B.9">Test Vector: Adding an on-mesh network</a></li>
+<li>B.10.   <a href="#rfc.appendix.B.10">Test Vector: Insertion notification of an on-mesh network</a></li>
+<li>B.11.   <a href="#rfc.appendix.B.11">Test Vector: Removing a local on-mesh network</a></li>
+<li>B.12.   <a href="#rfc.appendix.B.12">Test Vector: Removal notification of an on-mesh network</a></li>
+</ul><li>Appendix C.   <a href="#rfc.appendix.C">Example Sessions</a></li>
+<ul><li>C.1.   <a href="#rfc.appendix.C.1">NCP Initialization</a></li>
+<li>C.2.   <a href="#rfc.appendix.C.2">Attaching to a network</a></li>
+<li>C.3.   <a href="#rfc.appendix.C.3">Successfully joining a pre-existing network</a></li>
+<li>C.4.   <a href="#rfc.appendix.C.4">Unsuccessfully joining a pre-existing network</a></li>
+<li>C.5.   <a href="#rfc.appendix.C.5">Detaching from a network</a></li>
+<li>C.6.   <a href="#rfc.appendix.C.6">Attaching to a saved network</a></li>
+<li>C.7.   <a href="#rfc.appendix.C.7">NCP Software Reset</a></li>
+<li>C.8.   <a href="#rfc.appendix.C.8">Adding an on-mesh prefix</a></li>
+<li>C.9.   <a href="#rfc.appendix.C.9">Entering low-power modes</a></li>
+<li>C.10.   <a href="#rfc.appendix.C.10">Sniffing raw packets</a></li>
+</ul><li>Appendix D.   <a href="#rfc.appendix.D">Acknowledgments</a></li>
+<li>Appendix E.   <a href="#rfc.appendix.E">Glossary</a></li>
 <li><a href="#rfc.authors">Author's Address</a></li>
 
 
@@ -852,7 +866,7 @@
 <p id="rfc.section.1.1.3.p.3">This would likely be implemented as a part of the renumbering effort (<a href="#renumbering">Section 1.1.1</a>).  </p>
 <h1 id="rfc.section.1.2"><a href="#rfc.section.1.2">1.2.</a> <a href="#property-overview" id="property-overview">Property Overview</a></h1>
 <p id="rfc.section.1.2.p.1">Spinel is largely a property-based protocol, with a property defined for every attribute that needs to be set, changed, or known by the host. The inspiration of this approach was memory-mapped hardware registers for peripherals. The goal is to avoid, as much as possible, the use of large complicated structures and/or method argument lists.  The reason for avoiding these is because they have a tendency to change, especially early in development. Adding or removing a property from a structure can render the entire protocol incompatible. By using properties, you simply change an additional property.  </p>
-<p id="rfc.section.1.2.p.2">Almost all features and capabilities are implemented using properties.  Most new features that are initially proposed as commands can be adapted to be property-based instead. Notable exceptions include "Host Buffer Offload" (<a href="#feature-host-buffer-offload">Appendix C</a>) and "Network Save" (<a href="#feature-network-save">Appendix B</a>).  </p>
+<p id="rfc.section.1.2.p.2">Almost all features and capabilities are implemented using properties.  Most new features that are initially proposed as commands can be adapted to be property-based instead. Notable exceptions include "Host Buffer Offload" (<a href="#feature-host-buffer-offload">Section 9</a>) and "Network Save" (<a href="#feature-network-save">Section 8</a>).  </p>
 <p id="rfc.section.1.2.p.3">In Spinel, properties are keyed by an unsigned integer between 0 and 2,097,151 (See <a href="#packed-unsigned-integer">Section 3.2</a>).  </p>
 <h1 id="rfc.section.1.2.1"><a href="#rfc.section.1.2.1">1.2.1.</a> <a href="#property-methods" id="property-methods">Property Methods</a></h1>
 <p id="rfc.section.1.2.1.p.1">Properties may support one or more of the following methods: </p>
@@ -1455,7 +1469,7 @@
 <p id="rfc.section.4.10.p.1">This command allows the NCP to fetch values from the RAM of the NCP for debugging purposes. Upon success, <samp>CMD_PEEK_RET</samp> is sent from the NCP to the host. Upon failure, <samp>PROP_LAST_STATUS</samp> is emitted with the appropriate error indication.  </p>
 <p id="rfc.section.4.10.p.2">Due to the low-level nature of this command, certain error conditions may induce the NCP to reset.  </p>
 <p id="rfc.section.4.10.p.3">The NCP MAY prevent certain regions of memory from being accessed.  </p>
-<p id="rfc.section.4.10.p.4">The implementation of this command has security implications.  See <a href="#security-considerations">Section 7</a> for more information.  </p>
+<p id="rfc.section.4.10.p.4">The implementation of this command has security implications.  See <a href="#security-considerations">Section 12</a> for more information.  </p>
 <p id="rfc.section.4.10.p.5">This command requires the capability <samp>CAP_PEEK_POKE</samp> to be present.  </p>
 <h1 id="rfc.section.4.11"><a href="#rfc.section.4.11">4.11.</a> <a href="#cmd-peek-ret" id="cmd-peek-ret">CMD 19: (NCP-&gt;Host) CMD_PEEK_RET</a></h1>
 <table cellpadding="3" cellspacing="0" class="tt full center">
@@ -1507,7 +1521,7 @@
 </table>
 <p id="rfc.section.4.12.p.1">This command writes the bytes to the specified memory address for debugging purposes.  </p>
 <p id="rfc.section.4.12.p.2">Due to the low-level nature of this command, certain error conditions may induce the NCP to reset.  </p>
-<p id="rfc.section.4.12.p.3">The implementation of this command has security implications.  See <a href="#security-considerations">Section 7</a> for more information.  </p>
+<p id="rfc.section.4.12.p.3">The implementation of this command has security implications.  See <a href="#security-considerations">Section 12</a> for more information.  </p>
 <p id="rfc.section.4.12.p.4">This command requires the capability <samp>CAP_PEEK_POKE</samp> to be present.  </p>
 <h1 id="rfc.section.5"><a href="#rfc.section.5">5.</a> <a href="#properties" id="properties">Properties</a></h1>
 <p id="rfc.section.5.p.1">While the majority of the properties that allow the configuration of network connectivity are network protocol specific, there are several properties that are required in all implementations.  </p>
@@ -1806,11 +1820,12 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 <ul>
   <li>1: <samp>CAP_LOCK</samp></li>
   <li>2: <samp>CAP_NET_SAVE</samp></li>
-  <li>3: <samp>CAP_HBO</samp>: Host Buffer Offload. See <a href="#feature-host-buffer-offload">Appendix C</a>.</li>
+  <li>3: <samp>CAP_HBO</samp>: Host Buffer Offload. See <a href="#feature-host-buffer-offload">Section 9</a>.</li>
   <li>4: <samp>CAP_POWER_SAVE</samp></li>
   <li>5: <samp>CAP_COUNTERS</samp></li>
-  <li>6: <samp>CAP_JAM_DETECT</samp>: Jamming detection. See <a href="#feature-jam-detect">Appendix D</a></li>
+  <li>6: <samp>CAP_JAM_DETECT</samp>: Jamming detection. See <a href="#feature-jam-detect">Section 10</a></li>
   <li>7: <samp>CAP_PEEK_POKE</samp>: PEEK/POKE debugging commands.</li>
+  <li>8: <samp>CAP_WRITABLE_RAW_STREAM</samp>: <samp>PROP_STREAM_RAW</samp> is writable.</li>
   <li>16: <samp>CAP_802_15_4_2003</samp></li>
   <li>17: <samp>CAP_802_15_4_2006</samp></li>
   <li>18: <samp>CAP_802_15_4_2011</samp></li>
@@ -2033,7 +2048,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </table>
 <p id="rfc.section.5.3.2.p.2">This stream provides the capability of sending and receiving raw packets to and from the radio. The exact format of the frame metadata and data is dependent on the MAC and PHY being used.  </p>
 <p id="rfc.section.5.3.2.p.3">This property is a streaming property, meaning that you cannot explicitly fetch the value of this property. To receive traffic, you wait for <samp>CMD_PROP_VALUE_IS</samp> commands with this property id from the NCP.  </p>
-<p id="rfc.section.5.3.2.p.4">Implementations may OPTIONALLY support the ability to transmit arbitrary raw packets. If this capability is supported, you may call <samp>CMD_PROP_VALUE_SET</samp> on this property with the value of the raw packet.  </p>
+<p id="rfc.section.5.3.2.p.4">Implementations may OPTIONALLY support the ability to transmit arbitrary raw packets. Support for this feature is indicated by the presence of the <samp>CAP_WRITABLE_RAW_STREAM</samp> capability.  </p>
+<p id="rfc.section.5.3.2.p.5">If the capability <samp>CAP_WRITABLE_RAW_STREAM</samp> is set, then packets written to this stream with <samp>CMD_PROP_VALUE_SET</samp> will be sent out over the radio.  This allows the caller to use the radio directly, with the stack being implemented on the host instead of the NCP.  </p>
 <h1 id="rfc.section.5.3.2.1"><a href="#rfc.section.5.3.2.1">5.3.2.1.</a> <a href="#frame-metadata-format" id="frame-metadata-format">Frame Metadata Format</a></h1>
 <p id="rfc.section.5.3.2.1.p.1">Any data past the end of <samp>FRAME_DATA_LEN</samp> is considered metadata and is OPTIONAL. Frame metadata MAY be empty or partially specified. Partially specified metadata MUST be accepted. Default values are used for all unspecified fields.  </p>
 <p id="rfc.section.5.3.2.1.p.2">The same general format is used for <samp>PROP_STREAM_RAW</samp>, <samp>PROP_STREAM_NET</samp>, and <samp>PROP_STREAM_NET_INSECURE</samp>. It can be used for frames sent from the NCP to the host as well as frames sent from the host to the NCP.  </p>
@@ -2685,15 +2701,658 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<h1 id="rfc.section.7"><a href="#rfc.section.7">7.</a> <a href="#security-considerations" id="security-considerations">Security Considerations</a></h1>
-<h1 id="rfc.section.7.1"><a href="#rfc.section.7.1">7.1.</a> <a href="#raw-application-access" id="raw-application-access">Raw Application Access</a></h1>
-<p id="rfc.section.7.1.p.1">Spinel MAY be used as an API boundary for allowing processes to configure the NCP. However, such a system MUST NOT give unprivileged processess the ability to send or receive arbitrary command frames to the NCP. Only the specific commands and properties that are required should be allowed to be passed, and then only after being checked for proper format.  </p>
-<h1 id="rfc.section.8"><a href="#rfc.section.8">8.</a> <a href="#acknowledgments" id="acknowledgments">Acknowledgments</a></h1>
-<p id="rfc.section.8.p.1">Special thanks to Abtin Keshavarzian, Martin Turon, Arjuna Sivasithambaresan and Jonathan Hui for their substantial contributions and feedback related to this document.  </p>
-<p>
-  <a id="CREF3" class="info">[CREF3]<span class="info">RQ: If I have missed anyone who has contributed to this document, please let me know ASAP.</span></a>
-</p>
-<p id="rfc.section.8.p.3">This document was prepared using <a href="https://github.com/miekg/mmark">mmark</a> by (Miek Gieben) and <a href="http://xml2rfc.ietf.org/">xml2rfc (version 2)</a>.  </p>
+<h1 id="rfc.section.7"><a href="#rfc.section.7">7.</a> <a href="#technology-thread" id="technology-thread">Technology: Thread</a></h1>
+<p id="rfc.section.7.p.1">This section describes all of the properties and semantics required for managing a Thread NCP.  </p>
+<p id="rfc.section.7.p.2">Thread NCPs have the following requirements: </p>
+<p/>
+
+<ul>
+  <li>The property <samp>PROP_INTERFACE_TYPE</samp> must be 3.</li>
+  <li>The non-optional properties in the following sections MUST be implemented: CORE, PHY, MAC, NET, and IPV6.</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.p.4">All serious implementations of an NCP SHOULD also support the network save feature (See <a href="#feature-network-save">Section 8</a>).  </p>
+<h1 id="rfc.section.7.1"><a href="#rfc.section.7.1">7.1.</a> <a href="#thread-capabilities" id="thread-capabilities">Thread Capabilities</a></h1>
+<p id="rfc.section.7.1.p.1">The Thread technology defines the following capabilities: </p>
+<p/>
+
+<ul>
+  <li><samp>CAP_NET_THREAD_1_0</samp> - Indicates that the NCP implements v1.0 of the Thread standard.</li>
+  <li><samp>CAP_NET_THREAD_1_1</samp> - Indicates that the NCP implements v1.1 of the Thread standard.</li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.7.2"><a href="#rfc.section.7.2">7.2.</a> <a href="#thread-properties" id="thread-properties">Thread Properties</a></h1>
+<p id="rfc.section.7.2.p.1">Properties for Thread are allocated out of the <samp>Tech</samp> property section (see <a href="#property-sections">Section 5.1</a>).  </p>
+<h1 id="rfc.section.7.2.1"><a href="#rfc.section.7.2.1">7.2.1.</a> <a href="#prop-80-propthreadleaderaddr" id="prop-80-propthreadleaderaddr">PROP 80: PROP_THREAD_LEADER_ADDR</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Only</li>
+  <li>Packed-Encoding: <samp>6</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.1.p.2">The IPv6 address of the leader. (Note: May change to long and short address of leader) </p>
+<h1 id="rfc.section.7.2.2"><a href="#rfc.section.7.2.2">7.2.2.</a> <a href="#prop-81-propthreadparent" id="prop-81-propthreadparent">PROP 81: PROP_THREAD_PARENT</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Only</li>
+  <li>Packed-Encoding: <samp>ES</samp></li>
+  <li>LADDR, SADDR</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.2.p.2">The long address and short address of the parent of this node.  </p>
+<h1 id="rfc.section.7.2.3"><a href="#rfc.section.7.2.3">7.2.3.</a> <a href="#prop-82-propthreadchildtable" id="prop-82-propthreadchildtable">PROP 82: PROP_THREAD_CHILD_TABLE</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Only</li>
+  <li>Packed-Encoding: <samp>A(T(ES))</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.3.p.2">Table containing the long and short addresses of all the children of this node.  </p>
+<h1 id="rfc.section.7.2.4"><a href="#rfc.section.7.2.4">7.2.4.</a> <a href="#prop-83-propthreadleaderrid" id="prop-83-propthreadleaderrid">PROP 83: PROP_THREAD_LEADER_RID</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Only</li>
+  <li>Packed-Encoding: <samp>C</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.4.p.2">The router-id of the current leader.  </p>
+<h1 id="rfc.section.7.2.5"><a href="#rfc.section.7.2.5">7.2.5.</a> <a href="#prop-84-propthreadleaderweight" id="prop-84-propthreadleaderweight">PROP 84: PROP_THREAD_LEADER_WEIGHT</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Only</li>
+  <li>Packed-Encoding: <samp>C</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.5.p.2">The leader weight of the current leader.  </p>
+<h1 id="rfc.section.7.2.6"><a href="#rfc.section.7.2.6">7.2.6.</a> <a href="#prop-85-propthreadlocalleaderweight" id="prop-85-propthreadlocalleaderweight">PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>C</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.6.p.2">The leader weight for this node.  </p>
+<h1 id="rfc.section.7.2.7"><a href="#rfc.section.7.2.7">7.2.7.</a> <a href="#prop-86-propthreadnetworkdata" id="prop-86-propthreadnetworkdata">PROP 86: PROP_THREAD_NETWORK_DATA</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Only</li>
+  <li>Packed-Encoding: <samp>D</samp></li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.7.2.8"><a href="#rfc.section.7.2.8">7.2.8.</a> <a href="#prop-87-propthreadnetworkdataversion" id="prop-87-propthreadnetworkdataversion">PROP 87: PROP_THREAD_NETWORK_DATA_VERSION</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Only</li>
+  <li>Packed-Encoding: <samp>S</samp></li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.7.2.9"><a href="#rfc.section.7.2.9">7.2.9.</a> <a href="#prop-88-propthreadstablenetworkdata" id="prop-88-propthreadstablenetworkdata">PROP 88: PROP_THREAD_STABLE_NETWORK_DATA</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Only</li>
+  <li>Packed-Encoding: <samp>D</samp></li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.7.2.10"><a href="#rfc.section.7.2.10">7.2.10.</a> <a href="#prop-89-propthreadstablenetworkdataversion" id="prop-89-propthreadstablenetworkdataversion">PROP 89: PROP_THREAD_STABLE_NETWORK_DATA_VERSION</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Only</li>
+  <li>Packed-Encoding: <samp>S</samp></li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.7.2.11"><a href="#rfc.section.7.2.11">7.2.11.</a> <a href="#prop-90-propthreadonmeshnets" id="prop-90-propthreadonmeshnets">PROP 90: PROP_THREAD_ON_MESH_NETS</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>A(T(6CbCb))</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.11.p.2">Data per item is: </p>
+<p/>
+
+<ul>
+  <li><samp>6</samp>: IPv6 Prefix</li>
+  <li><samp>C</samp>: Prefix length, in bits</li>
+  <li><samp>b</samp>: Stable flag</li>
+  <li><samp>C</samp>: Thread flags</li>
+  <li><samp>b</samp>: "Is defined locally" flag. Set if this network was locally defined. Assumed to be true for set, insert and replace. Clear if the on mesh network was defined by another node.</li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.7.2.12"><a href="#rfc.section.7.2.12">7.2.12.</a> <a href="#prop-91-propthreadlocalroutes" id="prop-91-propthreadlocalroutes">PROP 91: PROP_THREAD_LOCAL_ROUTES</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>A(T(6CbC))</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.12.p.2">Data per item is: </p>
+<p/>
+
+<ul>
+  <li><samp>6</samp>: IPv6 Prefix</li>
+  <li><samp>C</samp>: Prefix length, in bits</li>
+  <li><samp>b</samp>: Stable flag</li>
+  <li><samp>C</samp>: Other flags</li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.7.2.13"><a href="#rfc.section.7.2.13">7.2.13.</a> <a href="#prop-92-propthreadassistingports" id="prop-92-propthreadassistingports">PROP 92: PROP_THREAD_ASSISTING_PORTS</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>A(S)</samp></li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.7.2.14"><a href="#rfc.section.7.2.14">7.2.14.</a> <a href="#prop-93-propthreadallowlocalnetdatachange" id="prop-93-propthreadallowlocalnetdatachange">PROP 93: PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>b</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.14.p.2">Set to true before changing local net data. Set to false when finished.  This allows changes to be aggregated into single events.  </p>
+<h1 id="rfc.section.7.2.15"><a href="#rfc.section.7.2.15">7.2.15.</a> <a href="#prop-94-propthreadmode" id="prop-94-propthreadmode">PROP 94: PROP_THREAD_MODE</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>C</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.15.p.2">This property contains the value of the mode TLV for this node. The meaning of the bits in this bitfield are defined by section 4.5.2 of the Thread specification.  </p>
+<h1 id="rfc.section.7.2.16"><a href="#rfc.section.7.2.16">7.2.16.</a> <a href="#prop-5376-propthreadchildtimeout" id="prop-5376-propthreadchildtimeout">PROP 5376: PROP_THREAD_CHILD_TIMEOUT</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>L</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.16.p.2">Used when operating in the Child role.  </p>
+<h1 id="rfc.section.7.2.17"><a href="#rfc.section.7.2.17">7.2.17.</a> <a href="#prop-5377-propthreadrloc16" id="prop-5377-propthreadrloc16">PROP 5377: PROP_THREAD_RLOC16</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>S</samp></li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.7.2.18"><a href="#rfc.section.7.2.18">7.2.18.</a> <a href="#prop-5378-propthreadrouterupgradethreshold" id="prop-5378-propthreadrouterupgradethreshold">PROP 5378: PROP_THREAD_ROUTER_UPGRADE_THRESHOLD</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>C</samp></li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.7.2.19"><a href="#rfc.section.7.2.19">7.2.19.</a> <a href="#prop-5379-propthreadcontextreusedelay" id="prop-5379-propthreadcontextreusedelay">PROP 5379: PROP_THREAD_CONTEXT_REUSE_DELAY</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>L</samp></li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.7.2.20"><a href="#rfc.section.7.2.20">7.2.20.</a> <a href="#prop-5380-propthreadnetworkidtimeout" id="prop-5380-propthreadnetworkidtimeout">PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>C</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.20.p.2">Allows you to get or set the Thread <samp>NETWORK_ID_TIMEOUT</samp> constant, as defined by the Thread specification.  </p>
+<h1 id="rfc.section.7.2.21"><a href="#rfc.section.7.2.21">7.2.21.</a> <a href="#prop-5381-propthreadactiverouterids" id="prop-5381-propthreadactiverouterids">PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write/Write-Only</li>
+  <li>Packed-Encoding: <samp>A(C)</samp> (List of active thread router ids)</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.21.p.2">Note that some implementations may not support <samp>CMD_GET_VALUE</samp> router ids, but may support <samp>CMD_REMOVE_VALUE</samp> when the node is a leader.  </p>
+<h1 id="rfc.section.7.2.22"><a href="#rfc.section.7.2.22">7.2.22.</a> <a href="#prop-5382-propthreadrloc16debugpassthru" id="prop-5382-propthreadrloc16debugpassthru">PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>b</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.22.p.2">Allow the HOST to directly observe all IPv6 packets received by the NCP, including ones sent to the RLOC16 address.  </p>
+<p id="rfc.section.7.2.22.p.3">Default value is <samp>false</samp>.  </p>
+<h1 id="rfc.section.7.2.23"><a href="#rfc.section.7.2.23">7.2.23.</a> <a href="#prop-5383-spinelpropthreadrouterroleenabled" id="prop-5383-spinelpropthreadrouterroleenabled">PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>b</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.23.p.2">Allow the HOST to indicate whether or not the router role is enabled.  If current role is a router, setting this property to <samp>false</samp> starts a re-attach process as an end-device.  </p>
+<h1 id="rfc.section.7.2.24"><a href="#rfc.section.7.2.24">7.2.24.</a> <a href="#prop-5384-propthreadrouterdowngradethreshold" id="prop-5384-propthreadrouterdowngradethreshold">PROP 5384: PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>C</samp></li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.7.2.25"><a href="#rfc.section.7.2.25">7.2.25.</a> <a href="#prop-5385-propthreadrouterselectionjitter" id="prop-5385-propthreadrouterselectionjitter">PROP 5385: PROP_THREAD_ROUTER_SELECTION_JITTER</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>C</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.25.p.2">Specifies the self imposed random delay in seconds a REED waits before registering to become an Active Router.  </p>
+<h1 id="rfc.section.7.2.26"><a href="#rfc.section.7.2.26">7.2.26.</a> <a href="#prop-5386-propthreadpreferredrouterid" id="prop-5386-propthreadpreferredrouterid">PROP 5386: PROP_THREAD_PREFERRED_ROUTER_ID</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Write-Only</li>
+  <li>Packed-Encoding: <samp>C</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.26.p.2">Specifies the preferred Router Id. Upon becoming a router/leader the node attempts to use this Router Id. If the preferred Router Id is not set or if it can not be used, a randomly generated router id is picked. This property can be set only when the device role is either detached or disabled.  </p>
+<h1 id="rfc.section.7.2.27"><a href="#rfc.section.7.2.27">7.2.27.</a> <a href="#prop-5387-spinelpropthreadneighbortable" id="prop-5387-spinelpropthreadneighbortable">PROP 5387: SPINEL_PROP_THREAD_NEIGHBOR_TABLE</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Only</li>
+  <li>Packed-Encoding: <samp>A(T(ESLCcCbLL))</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.27.p.2">Data per item is: </p>
+<p/>
+
+<ul>
+  <li><samp>E</samp>: Extended/long address</li>
+  <li><samp>S</samp>: RLOC16</li>
+  <li><samp>L</samp>: Age</li>
+  <li><samp>C</samp>: Link Quality In</li>
+  <li><samp>c</samp>: Average RSS</li>
+  <li><samp>C</samp>: Mode (bit-flags)</li>
+  <li><samp>b</samp>: <samp>true</samp> if neighbor is a child, <samp>false</samp> otherwise.</li>
+  <li><samp>L</samp>: Link Frame Counter</li>
+  <li><samp>L</samp>: MLE Frame Counter</li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.8"><a href="#rfc.section.8">8.</a> <a href="#feature-network-save" id="feature-network-save">Feature: Network Save</a></h1>
+<p id="rfc.section.8.p.1">The network save feature is an optional NCP capability that, when present, allows the host to save and recall network credentials and state to and from nonvolatile storage.  </p>
+<p id="rfc.section.8.p.2">The presence of this feature can be detected by checking for the presence of the <samp>CAP_NET_SAVE</samp> capability in <samp>PROP_CAPS</samp>.  </p>
+<h1 id="rfc.section.8.1"><a href="#rfc.section.8.1">8.1.</a> <a href="#commands-1" id="commands-1">Commands</a></h1>
+<h1 id="rfc.section.8.1.1"><a href="#rfc.section.8.1.1">8.1.1.</a> <a href="#cmd-9-hostncp-cmdnetsave" id="cmd-9-hostncp-cmdnetsave">CMD 9: (Host-&gt;NCP) CMD_NET_SAVE</a></h1>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+  <thead>
+    <tr>
+      <th class="center">Octets:</th>
+      <th class="center">1</th>
+      <th class="center">1</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="center">Fields:</td>
+      <td class="center">HEADER</td>
+      <td class="center">CMD_NET_SAVE</td>
+    </tr>
+  </tbody>
+</table>
+<p id="rfc.section.8.1.1.p.1">Save network state command. Saves any current network credentials and state necessary to reconnect to the current network to non-volatile memory.  </p>
+<p id="rfc.section.8.1.1.p.2">This operation affects non-volatile memory only. The current network information stored in volatile memory is unaffected.  </p>
+<p id="rfc.section.8.1.1.p.3">The response to this command is always a <samp>CMD_PROP_VALUE_IS</samp> for <samp>PROP_LAST_STATUS</samp>, indicating the result of the operation.  </p>
+<p id="rfc.section.8.1.1.p.4">This command is only available if the <samp>CAP_NET_SAVE</samp> capability is set.  </p>
+<h1 id="rfc.section.8.1.2"><a href="#rfc.section.8.1.2">8.1.2.</a> <a href="#cmd-10-hostncp-cmdnetclear" id="cmd-10-hostncp-cmdnetclear">CMD 10: (Host-&gt;NCP) CMD_NET_CLEAR</a></h1>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+  <thead>
+    <tr>
+      <th class="center">Octets:</th>
+      <th class="center">1</th>
+      <th class="center">1</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="center">Fields:</td>
+      <td class="center">HEADER</td>
+      <td class="center">CMD_NET_CLEAR</td>
+    </tr>
+  </tbody>
+</table>
+<p id="rfc.section.8.1.2.p.1">Clear saved network state command. Clears any previously saved network credentials and state previously stored by <samp>CMD_NET_SAVE</samp> from non-volatile memory.  </p>
+<p id="rfc.section.8.1.2.p.2">This operation affects non-volatile memory only. The current network information stored in volatile memory is unaffected.  </p>
+<p id="rfc.section.8.1.2.p.3">The response to this command is always a <samp>CMD_PROP_VALUE_IS</samp> for <samp>PROP_LAST_STATUS</samp>, indicating the result of the operation.  </p>
+<p id="rfc.section.8.1.2.p.4">This command is only available if the <samp>CAP_NET_SAVE</samp> capability is set.  </p>
+<h1 id="rfc.section.8.1.3"><a href="#rfc.section.8.1.3">8.1.3.</a> <a href="#cmd-11-hostncp-cmdnetrecall" id="cmd-11-hostncp-cmdnetrecall">CMD 11: (Host-&gt;NCP) CMD_NET_RECALL</a></h1>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+  <thead>
+    <tr>
+      <th class="center">Octets:</th>
+      <th class="center">1</th>
+      <th class="center">1</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="center">Fields:</td>
+      <td class="center">HEADER</td>
+      <td class="center">CMD_NET_RECALL</td>
+    </tr>
+  </tbody>
+</table>
+<p id="rfc.section.8.1.3.p.1">Recall saved network state command. Recalls any previously saved network credentials and state previously stored by <samp>CMD_NET_SAVE</samp> from non-volatile memory.  </p>
+<p id="rfc.section.8.1.3.p.2">This command will typically generated several unsolicited property updates as the network state is loaded. At the conclusion of loading, the authoritative response to this command is always a <samp>CMD_PROP_VALUE_IS</samp> for <samp>PROP_LAST_STATUS</samp>, indicating the result of the operation.  </p>
+<p id="rfc.section.8.1.3.p.3">This command is only available if the <samp>CAP_NET_SAVE</samp> capability is set.  </p>
+<h1 id="rfc.section.9"><a href="#rfc.section.9">9.</a> <a href="#feature-host-buffer-offload" id="feature-host-buffer-offload">Feature: Host Buffer Offload</a></h1>
+<p id="rfc.section.9.p.1">The memory on an NCP may be much more limited than the memory on the host processor. In such situations, it is sometimes useful for the NCP to offload buffers to the host processor temporarily so that it can perform other operations.  </p>
+<p id="rfc.section.9.p.2">Host buffer offload is an optional NCP capability that, when present, allows the NCP to store data buffers on the host processor that can be recalled at a later time.  </p>
+<p id="rfc.section.9.p.3">The presence of this feature can be detected by the host by checking for the presence of the <samp>CAP_HBO</samp> capability in <samp>PROP_CAPS</samp>.  </p>
+<h1 id="rfc.section.9.1"><a href="#rfc.section.9.1">9.1.</a> <a href="#commands-2" id="commands-2">Commands</a></h1>
+<h1 id="rfc.section.9.1.1"><a href="#rfc.section.9.1.1">9.1.1.</a> <a href="#cmd-12-ncphost-cmdhbooffload" id="cmd-12-ncphost-cmdhbooffload">CMD 12: (NCP-&gt;Host) CMD_HBO_OFFLOAD</a></h1>
+<p/>
+
+<ul>
+  <li>Argument-Encoding: <samp>LscD</samp> <ul><li><samp>OffloadId</samp>: 32-bit unique block identifier</li><li><samp>Expiration</samp>: In seconds-from-now</li><li><samp>Priority</samp>: Critical, High, Medium, Low</li><li><samp>Data</samp>: Data to offload</li></ul></li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.9.1.2"><a href="#rfc.section.9.1.2">9.1.2.</a> <a href="#cmd-13-ncphost-cmdhboreclaim" id="cmd-13-ncphost-cmdhboreclaim">CMD 13: (NCP-&gt;Host) CMD_HBO_RECLAIM</a></h1>
+<p/>
+
+<ul>
+  <li>Argument-Encoding: <samp>Lb</samp> <ul><li><samp>OffloadId</samp>: 32-bit unique block identifier</li><li><samp>KeepAfterReclaim</samp>: If not set to true, the block will be dropped by the host after it is sent to the NCP.</li></ul></li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.9.1.3"><a href="#rfc.section.9.1.3">9.1.3.</a> <a href="#cmd-14-ncphost-cmdhbodrop" id="cmd-14-ncphost-cmdhbodrop">CMD 14: (NCP-&gt;Host) CMD_HBO_DROP</a></h1>
+<p/>
+
+<ul>
+  <li>Argument-Encoding: <samp>L</samp> <ul><li><samp>OffloadId</samp>: 32-bit unique block identifier</li></ul></li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.9.1.4"><a href="#rfc.section.9.1.4">9.1.4.</a> <a href="#cmd-15-hostncp-cmdhbooffloaded" id="cmd-15-hostncp-cmdhbooffloaded">CMD 15: (Host-&gt;NCP) CMD_HBO_OFFLOADED</a></h1>
+<p/>
+
+<ul>
+  <li>Argument-Encoding: <samp>Li</samp> <ul><li><samp>OffloadId</samp>: 32-bit unique block identifier</li><li><samp>Status</samp>: Status code for the result of the operation.</li></ul></li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.9.1.5"><a href="#rfc.section.9.1.5">9.1.5.</a> <a href="#cmd-16-hostncp-cmdhboreclaimed" id="cmd-16-hostncp-cmdhboreclaimed">CMD 16: (Host-&gt;NCP) CMD_HBO_RECLAIMED</a></h1>
+<p/>
+
+<ul>
+  <li>Argument-Encoding: <samp>LiD</samp> <ul><li><samp>OffloadId</samp>: 32-bit unique block identifier</li><li><samp>Status</samp>: Status code for the result of the operation.</li><li><samp>Data</samp>: Data that was previously offloaded (if any)</li></ul></li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.9.1.6"><a href="#rfc.section.9.1.6">9.1.6.</a> <a href="#cmd-17-hostncp-cmdhbodropped" id="cmd-17-hostncp-cmdhbodropped">CMD 17: (Host-&gt;NCP) CMD_HBO_DROPPED</a></h1>
+<p/>
+
+<ul>
+  <li>Argument-Encoding: <samp>Li</samp> <ul><li><samp>OffloadId</samp>: 32-bit unique block identifier</li><li><samp>Status</samp>: Status code for the result of the operation.</li></ul></li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.9.2"><a href="#rfc.section.9.2">9.2.</a> <a href="#properties-1" id="properties-1">Properties</a></h1>
+<h1 id="rfc.section.9.2.1"><a href="#rfc.section.9.2.1">9.2.1.</a> <a href="#prop-hbo-mem-max" id="prop-hbo-mem-max">PROP 10: PROP_HBO_MEM_MAX</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>L</samp></li>
+</ul>
+
+<p> </p>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+  <thead>
+    <tr>
+      <th class="center">Octets:</th>
+      <th class="center">4</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="center">Fields:</td>
+      <td class="center">
+        <samp>PROP_HBO_MEM_MAX</samp>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<p id="rfc.section.9.2.1.p.2">Describes the number of bytes that may be offloaded from the NCP to the host. Default value is zero, so this property must be set by the host to a non-zero value before the NCP will begin offloading blocks.  </p>
+<p id="rfc.section.9.2.1.p.3">This value is encoded as an unsigned 32-bit integer.  </p>
+<p id="rfc.section.9.2.1.p.4">This property is only available if the <samp>CAP_HBO</samp> capability is present in <samp>PROP_CAPS</samp>.  </p>
+<h1 id="rfc.section.9.2.2"><a href="#rfc.section.9.2.2">9.2.2.</a> <a href="#prop-hbo-block-max" id="prop-hbo-block-max">PROP 11: PROP_HBO_BLOCK_MAX</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>S</samp></li>
+</ul>
+
+<p> </p>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+  <thead>
+    <tr>
+      <th class="center">Octets:</th>
+      <th class="center">2</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="center">Fields:</td>
+      <td class="center">
+        <samp>PROP_HBO_BLOCK_MAX</samp>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<p id="rfc.section.9.2.2.p.2">Describes the number of blocks that may be offloaded from the NCP to the host. Default value is 32. Setting this value to zero will cause host block offload to be effectively disabled.  </p>
+<p id="rfc.section.9.2.2.p.3">This value is encoded as an unsigned 16-bit integer.  </p>
+<p id="rfc.section.9.2.2.p.4">This property is only available if the <samp>CAP_HBO</samp> capability is present in <samp>PROP_CAPS</samp>.  </p>
+<h1 id="rfc.section.10"><a href="#rfc.section.10">10.</a> <a href="#feature-jam-detect" id="feature-jam-detect">Feature: Jam Detection</a></h1>
+<p id="rfc.section.10.p.1">Jamming detection is a feature that allows the NCP to report when it detects high levels of interference that are characteristic of intentional signal jamming.  </p>
+<p id="rfc.section.10.p.2">The presence of this feature can be detected by checking for the presence of the <samp>CAP_JAM_DETECT</samp> (value 6) capability in <samp>PROP_CAPS</samp>.  </p>
+<h1 id="rfc.section.10.1"><a href="#rfc.section.10.1">10.1.</a> <a href="#properties-2" id="properties-2">Properties</a></h1>
+<h1 id="rfc.section.10.1.1"><a href="#rfc.section.10.1.1">10.1.1.</a> <a href="#prop-jam-detect-enable" id="prop-jam-detect-enable">PROP 4608: PROP_JAM_DETECT_ENABLE</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>b</samp></li>
+  <li>Default Value: false</li>
+  <li>REQUIRED for <samp>CAP_JAM_DETECT</samp></li>
+</ul>
+
+<p> </p>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+  <thead>
+    <tr>
+      <th class="center">Octets:</th>
+      <th class="center">1</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="center">Fields:</td>
+      <td class="center">
+        <samp>PROP_JAM_DETECT_ENABLE</samp>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<p id="rfc.section.10.1.1.p.2">Indicates if jamming detection is enabled or disabled. Set to true to enable jamming detection.  </p>
+<p id="rfc.section.10.1.1.p.3">This property is only available if the <samp>CAP_JAM_DETECT</samp> capability is present in <samp>PROP_CAPS</samp>.  </p>
+<h1 id="rfc.section.10.1.2"><a href="#rfc.section.10.1.2">10.1.2.</a> <a href="#prop-jam-detected" id="prop-jam-detected">PROP 4609: PROP_JAM_DETECTED</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Only</li>
+  <li>Packed-Encoding: <samp>b</samp></li>
+  <li>REQUIRED for <samp>CAP_JAM_DETECT</samp></li>
+</ul>
+
+<p> </p>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+  <thead>
+    <tr>
+      <th class="center">Octets:</th>
+      <th class="center">1</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="center">Fields:</td>
+      <td class="center">
+        <samp>PROP_JAM_DETECTED</samp>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<p id="rfc.section.10.1.2.p.2">Set to true if radio jamming is detected. Set to false otherwise.  </p>
+<p id="rfc.section.10.1.2.p.3">When jamming detection is enabled, changes to the value of this property are emitted asynchronously via <samp>CMD_PROP_VALUE_IS</samp>.  </p>
+<p id="rfc.section.10.1.2.p.4">This property is only available if the <samp>CAP_JAM_DETECT</samp> capability is present in <samp>PROP_CAPS</samp>.  </p>
+<h1 id="rfc.section.10.1.3"><a href="#rfc.section.10.1.3">10.1.3.</a> <a href="#prop-4610-propjamdetectrssithreshold" id="prop-4610-propjamdetectrssithreshold">PROP 4610: PROP_JAM_DETECT_RSSI_THRESHOLD</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>c</samp></li>
+  <li>Units: dBm</li>
+  <li>Default Value: Implementation-specific</li>
+  <li>RECOMMENDED for <samp>CAP_JAM_DETECT</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.10.1.3.p.2">This parameter describes the threshold RSSI level (measured in dBm) above which the jamming detection will consider the channel blocked.  </p>
+<h1 id="rfc.section.10.1.4"><a href="#rfc.section.10.1.4">10.1.4.</a> <a href="#prop-4611-propjamdetectwindow" id="prop-4611-propjamdetectwindow">PROP 4611: PROP_JAM_DETECT_WINDOW</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>c</samp></li>
+  <li>Units: Seconds (1-64)</li>
+  <li>Default Value: Implementation-specific</li>
+  <li>RECOMMENDED for <samp>CAP_JAM_DETECT</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.10.1.4.p.2">This parameter describes the window period for signal jamming detection.  </p>
+<h1 id="rfc.section.10.1.5"><a href="#rfc.section.10.1.5">10.1.5.</a> <a href="#prop-4612-propjamdetectbusy" id="prop-4612-propjamdetectbusy">PROP 4612: PROP_JAM_DETECT_BUSY</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>i</samp></li>
+  <li>Units: Seconds (1-64)</li>
+  <li>Default Value: Implementation-specific</li>
+  <li>RECOMMENDED for <samp>CAP_JAM_DETECT</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.10.1.5.p.2">This parameter describes the number of aggregate seconds within the detection window where the RSSI must be above <samp>PROP_JAM_DETECT_RSSI_THRESHOLD</samp> to trigger detection.  </p>
+<p id="rfc.section.10.1.5.p.3">The behavior of the jamming detection feature when <samp>PROP_JAM_DETECT_BUSY</samp> is larger than <samp>PROP_JAM_DETECT_WINDOW</samp> is undefined.  </p>
+<h1 id="rfc.section.11"><a href="#rfc.section.11">11.</a> <a href="#feature-basic-gpio-access" id="feature-basic-gpio-access">Feature: Basic GPIO Access</a></h1>
+<p id="rfc.section.11.p.1">The length of the data associated with these properties depends on the number of GPIOs. If you have 10 GPIOs, you'd have two bytes. You determine the number of GPIOs available by examining PROP_GPIO_AVAILABLE, described below. This API isn't intended to support every possible GPIO state, it is intended for basic reading and writing.  </p>
+<h1 id="rfc.section.11.1"><a href="#rfc.section.11.1">11.1.</a> <a href="#properties-3" id="properties-3">Properties</a></h1>
+<h1 id="rfc.section.11.1.1"><a href="#rfc.section.11.1.1">11.1.1.</a> <a href="#prop-4096-propgpioavailable" id="prop-4096-propgpioavailable">PROP 4096: PROP_GPIO_AVAILABLE</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-only</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.11.1.1.p.2">Contains a bit field identifying which GPIOs are supported. Cleared bits are not supported. Set bits are supported.  </p>
+<h1 id="rfc.section.11.1.2"><a href="#rfc.section.11.1.2">11.1.2.</a> <a href="#prop-4097-propgpiodirection" id="prop-4097-propgpiodirection">PROP 4097: PROP_GPIO_DIRECTION</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-only (Optionally read/write)</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.11.1.2.p.2">Contains a bit field identifying which GPIOs are configured as outputs.  Cleared bits are inputs. Set bits are outputs.  </p>
+<h1 id="rfc.section.11.1.3"><a href="#rfc.section.11.1.3">11.1.3.</a> <a href="#prop-4098-propgpiostate" id="prop-4098-propgpiostate">PROP 4098: PROP_GPIO_STATE</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.11.1.3.p.2">Contains a bit field identifying the state of the GPIOs. For GPIOs configured as inputs, this is the read logic level. For GPIOs configured as outputs, this is the logic level of the output.  </p>
+<h1 id="rfc.section.11.1.4"><a href="#rfc.section.11.1.4">11.1.4.</a> <a href="#prop-4099-propgpiostateset" id="prop-4099-propgpiostateset">PROP 4099: PROP_GPIO_STATE_SET</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Write-only</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.11.1.4.p.2">Allows for the state of various output GPIOs to be set without affecting other GPIO states. Contains a bit field identifying the output GPIOs that should have their state set to 1.  </p>
+<h1 id="rfc.section.11.1.5"><a href="#rfc.section.11.1.5">11.1.5.</a> <a href="#prop-4100-propgpiostateclear" id="prop-4100-propgpiostateclear">PROP 4100: PROP_GPIO_STATE_CLEAR</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Write-only</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.11.1.5.p.2">Allows for the state of various output GPIOs to be cleared without affecting other GPIO states. Contains a bit field identifying the output GPIOs that should have their state cleared to 0.  </p>
+<h1 id="rfc.section.12"><a href="#rfc.section.12">12.</a> <a href="#security-considerations" id="security-considerations">Security Considerations</a></h1>
+<h1 id="rfc.section.12.1"><a href="#rfc.section.12.1">12.1.</a> <a href="#raw-application-access" id="raw-application-access">Raw Application Access</a></h1>
+<p id="rfc.section.12.1.p.1">Spinel MAY be used as an API boundary for allowing processes to configure the NCP. However, such a system MUST NOT give unprivileged processess the ability to send or receive arbitrary command frames to the NCP. Only the specific commands and properties that are required should be allowed to be passed, and then only after being checked for proper format.  </p>
 <h1 id="rfc.appendix.A"><a href="#rfc.appendix.A">Appendix A.</a> <a href="#framing-protocol" id="framing-protocol">Framing Protocol</a></h1>
 <p id="rfc.section.A.p.1">Since this NCP protocol is defined independently of the physical transport or framing, any number of transports and framing protocols could be used successfully. However, in the interests of compatibility, this document provides some recommendations.  </p>
 <h1 id="rfc.appendix.A.1"><a href="#rfc.appendix.A.1">A.1.</a> <a href="#uart-recommendations" id="uart-recommendations">UART Recommendations</a></h1>
@@ -2848,616 +3507,15 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 <h1 id="rfc.appendix.A.3"><a href="#rfc.appendix.A.3">A.3.</a> <a href="#i2c-recommendations" id="i2c-recommendations">I&#178;C Recommendations</a></h1>
 <p id="rfc.section.A.3.p.1">TBD </p>
 <p>
-  <a id="CREF4" class="info">[CREF4]<span class="info">RQ: It may make sense to have a look at what Bluetooth HCI is doing for native I&#178;C framing and go with that.</span></a>
+  <a id="CREF3" class="info">[CREF3]<span class="info">RQ: It may make sense to have a look at what Bluetooth HCI is doing for native I&#178;C framing and go with that.</span></a>
 </p>
 <h1 id="rfc.appendix.A.4"><a href="#rfc.appendix.A.4">A.4.</a> <a href="#native-usb-recommendations" id="native-usb-recommendations">Native USB Recommendations</a></h1>
 <p id="rfc.section.A.4.p.1">TBD </p>
 <p>
-  <a id="CREF5" class="info">[CREF5]<span class="info">RQ: It may make sense to have a look at what Bluetooth HCI is doing for native USB framing and go with that.</span></a>
+  <a id="CREF4" class="info">[CREF4]<span class="info">RQ: It may make sense to have a look at what Bluetooth HCI is doing for native USB framing and go with that.</span></a>
 </p>
-<h1 id="rfc.appendix.B"><a href="#rfc.appendix.B">Appendix B.</a> <a href="#feature-network-save" id="feature-network-save">Feature: Network Save</a></h1>
-<p id="rfc.section.B.p.1">The network save feature is an optional NCP capability that, when present, allows the host to save and recall network credentials and state to and from nonvolatile storage.  </p>
-<p id="rfc.section.B.p.2">The presence of this feature can be detected by checking for the presence of the <samp>CAP_NET_SAVE</samp> capability in <samp>PROP_CAPS</samp>.  </p>
-<h1 id="rfc.appendix.B.1"><a href="#rfc.appendix.B.1">B.1.</a> <a href="#commands-1" id="commands-1">Commands</a></h1>
-<h1 id="rfc.appendix.B.1.1"><a href="#rfc.appendix.B.1.1">B.1.1.</a> <a href="#cmd-9-hostncp-cmdnetsave" id="cmd-9-hostncp-cmdnetsave">CMD 9: (Host-&gt;NCP) CMD_NET_SAVE</a></h1>
-<table cellpadding="3" cellspacing="0" class="tt full center">
-  <thead>
-    <tr>
-      <th class="center">Octets:</th>
-      <th class="center">1</th>
-      <th class="center">1</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="center">Fields:</td>
-      <td class="center">HEADER</td>
-      <td class="center">CMD_NET_SAVE</td>
-    </tr>
-  </tbody>
-</table>
-<p id="rfc.section.B.1.1.p.1">Save network state command. Saves any current network credentials and state necessary to reconnect to the current network to non-volatile memory.  </p>
-<p id="rfc.section.B.1.1.p.2">This operation affects non-volatile memory only. The current network information stored in volatile memory is unaffected.  </p>
-<p id="rfc.section.B.1.1.p.3">The response to this command is always a <samp>CMD_PROP_VALUE_IS</samp> for <samp>PROP_LAST_STATUS</samp>, indicating the result of the operation.  </p>
-<p id="rfc.section.B.1.1.p.4">This command is only available if the <samp>CAP_NET_SAVE</samp> capability is set.  </p>
-<h1 id="rfc.appendix.B.1.2"><a href="#rfc.appendix.B.1.2">B.1.2.</a> <a href="#cmd-10-hostncp-cmdnetclear" id="cmd-10-hostncp-cmdnetclear">CMD 10: (Host-&gt;NCP) CMD_NET_CLEAR</a></h1>
-<table cellpadding="3" cellspacing="0" class="tt full center">
-  <thead>
-    <tr>
-      <th class="center">Octets:</th>
-      <th class="center">1</th>
-      <th class="center">1</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="center">Fields:</td>
-      <td class="center">HEADER</td>
-      <td class="center">CMD_NET_CLEAR</td>
-    </tr>
-  </tbody>
-</table>
-<p id="rfc.section.B.1.2.p.1">Clear saved network state command. Clears any previously saved network credentials and state previously stored by <samp>CMD_NET_SAVE</samp> from non-volatile memory.  </p>
-<p id="rfc.section.B.1.2.p.2">This operation affects non-volatile memory only. The current network information stored in volatile memory is unaffected.  </p>
-<p id="rfc.section.B.1.2.p.3">The response to this command is always a <samp>CMD_PROP_VALUE_IS</samp> for <samp>PROP_LAST_STATUS</samp>, indicating the result of the operation.  </p>
-<p id="rfc.section.B.1.2.p.4">This command is only available if the <samp>CAP_NET_SAVE</samp> capability is set.  </p>
-<h1 id="rfc.appendix.B.1.3"><a href="#rfc.appendix.B.1.3">B.1.3.</a> <a href="#cmd-11-hostncp-cmdnetrecall" id="cmd-11-hostncp-cmdnetrecall">CMD 11: (Host-&gt;NCP) CMD_NET_RECALL</a></h1>
-<table cellpadding="3" cellspacing="0" class="tt full center">
-  <thead>
-    <tr>
-      <th class="center">Octets:</th>
-      <th class="center">1</th>
-      <th class="center">1</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="center">Fields:</td>
-      <td class="center">HEADER</td>
-      <td class="center">CMD_NET_RECALL</td>
-    </tr>
-  </tbody>
-</table>
-<p id="rfc.section.B.1.3.p.1">Recall saved network state command. Recalls any previously saved network credentials and state previously stored by <samp>CMD_NET_SAVE</samp> from non-volatile memory.  </p>
-<p id="rfc.section.B.1.3.p.2">This command will typically generated several unsolicited property updates as the network state is loaded. At the conclusion of loading, the authoritative response to this command is always a <samp>CMD_PROP_VALUE_IS</samp> for <samp>PROP_LAST_STATUS</samp>, indicating the result of the operation.  </p>
-<p id="rfc.section.B.1.3.p.3">This command is only available if the <samp>CAP_NET_SAVE</samp> capability is set.  </p>
-<h1 id="rfc.appendix.C"><a href="#rfc.appendix.C">Appendix C.</a> <a href="#feature-host-buffer-offload" id="feature-host-buffer-offload">Feature: Host Buffer Offload</a></h1>
-<p id="rfc.section.C.p.1">The memory on an NCP may be much more limited than the memory on the host processor. In such situations, it is sometimes useful for the NCP to offload buffers to the host processor temporarily so that it can perform other operations.  </p>
-<p id="rfc.section.C.p.2">Host buffer offload is an optional NCP capability that, when present, allows the NCP to store data buffers on the host processor that can be recalled at a later time.  </p>
-<p id="rfc.section.C.p.3">The presence of this feature can be detected by the host by checking for the presence of the <samp>CAP_HBO</samp> capability in <samp>PROP_CAPS</samp>.  </p>
-<h1 id="rfc.appendix.C.1"><a href="#rfc.appendix.C.1">C.1.</a> <a href="#commands-2" id="commands-2">Commands</a></h1>
-<h1 id="rfc.appendix.C.1.1"><a href="#rfc.appendix.C.1.1">C.1.1.</a> <a href="#cmd-12-ncphost-cmdhbooffload" id="cmd-12-ncphost-cmdhbooffload">CMD 12: (NCP-&gt;Host) CMD_HBO_OFFLOAD</a></h1>
-<p/>
-
-<ul>
-  <li>Argument-Encoding: <samp>LscD</samp> <ul><li><samp>OffloadId</samp>: 32-bit unique block identifier</li><li><samp>Expiration</samp>: In seconds-from-now</li><li><samp>Priority</samp>: Critical, High, Medium, Low</li><li><samp>Data</samp>: Data to offload</li></ul></li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.C.1.2"><a href="#rfc.appendix.C.1.2">C.1.2.</a> <a href="#cmd-13-ncphost-cmdhboreclaim" id="cmd-13-ncphost-cmdhboreclaim">CMD 13: (NCP-&gt;Host) CMD_HBO_RECLAIM</a></h1>
-<p/>
-
-<ul>
-  <li>Argument-Encoding: <samp>Lb</samp> <ul><li><samp>OffloadId</samp>: 32-bit unique block identifier</li><li><samp>KeepAfterReclaim</samp>: If not set to true, the block will be dropped by the host after it is sent to the NCP.</li></ul></li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.C.1.3"><a href="#rfc.appendix.C.1.3">C.1.3.</a> <a href="#cmd-14-ncphost-cmdhbodrop" id="cmd-14-ncphost-cmdhbodrop">CMD 14: (NCP-&gt;Host) CMD_HBO_DROP</a></h1>
-<p/>
-
-<ul>
-  <li>Argument-Encoding: <samp>L</samp> <ul><li><samp>OffloadId</samp>: 32-bit unique block identifier</li></ul></li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.C.1.4"><a href="#rfc.appendix.C.1.4">C.1.4.</a> <a href="#cmd-15-hostncp-cmdhbooffloaded" id="cmd-15-hostncp-cmdhbooffloaded">CMD 15: (Host-&gt;NCP) CMD_HBO_OFFLOADED</a></h1>
-<p/>
-
-<ul>
-  <li>Argument-Encoding: <samp>Li</samp> <ul><li><samp>OffloadId</samp>: 32-bit unique block identifier</li><li><samp>Status</samp>: Status code for the result of the operation.</li></ul></li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.C.1.5"><a href="#rfc.appendix.C.1.5">C.1.5.</a> <a href="#cmd-16-hostncp-cmdhboreclaimed" id="cmd-16-hostncp-cmdhboreclaimed">CMD 16: (Host-&gt;NCP) CMD_HBO_RECLAIMED</a></h1>
-<p/>
-
-<ul>
-  <li>Argument-Encoding: <samp>LiD</samp> <ul><li><samp>OffloadId</samp>: 32-bit unique block identifier</li><li><samp>Status</samp>: Status code for the result of the operation.</li><li><samp>Data</samp>: Data that was previously offloaded (if any)</li></ul></li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.C.1.6"><a href="#rfc.appendix.C.1.6">C.1.6.</a> <a href="#cmd-17-hostncp-cmdhbodropped" id="cmd-17-hostncp-cmdhbodropped">CMD 17: (Host-&gt;NCP) CMD_HBO_DROPPED</a></h1>
-<p/>
-
-<ul>
-  <li>Argument-Encoding: <samp>Li</samp> <ul><li><samp>OffloadId</samp>: 32-bit unique block identifier</li><li><samp>Status</samp>: Status code for the result of the operation.</li></ul></li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.C.2"><a href="#rfc.appendix.C.2">C.2.</a> <a href="#properties-1" id="properties-1">Properties</a></h1>
-<h1 id="rfc.appendix.C.2.1"><a href="#rfc.appendix.C.2.1">C.2.1.</a> <a href="#prop-hbo-mem-max" id="prop-hbo-mem-max">PROP 10: PROP_HBO_MEM_MAX</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>L</samp></li>
-</ul>
-
-<p> </p>
-<table cellpadding="3" cellspacing="0" class="tt full center">
-  <thead>
-    <tr>
-      <th class="center">Octets:</th>
-      <th class="center">4</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="center">Fields:</td>
-      <td class="center">
-        <samp>PROP_HBO_MEM_MAX</samp>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<p id="rfc.section.C.2.1.p.2">Describes the number of bytes that may be offloaded from the NCP to the host. Default value is zero, so this property must be set by the host to a non-zero value before the NCP will begin offloading blocks.  </p>
-<p id="rfc.section.C.2.1.p.3">This value is encoded as an unsigned 32-bit integer.  </p>
-<p id="rfc.section.C.2.1.p.4">This property is only available if the <samp>CAP_HBO</samp> capability is present in <samp>PROP_CAPS</samp>.  </p>
-<h1 id="rfc.appendix.C.2.2"><a href="#rfc.appendix.C.2.2">C.2.2.</a> <a href="#prop-hbo-block-max" id="prop-hbo-block-max">PROP 11: PROP_HBO_BLOCK_MAX</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>S</samp></li>
-</ul>
-
-<p> </p>
-<table cellpadding="3" cellspacing="0" class="tt full center">
-  <thead>
-    <tr>
-      <th class="center">Octets:</th>
-      <th class="center">2</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="center">Fields:</td>
-      <td class="center">
-        <samp>PROP_HBO_BLOCK_MAX</samp>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<p id="rfc.section.C.2.2.p.2">Describes the number of blocks that may be offloaded from the NCP to the host. Default value is 32. Setting this value to zero will cause host block offload to be effectively disabled.  </p>
-<p id="rfc.section.C.2.2.p.3">This value is encoded as an unsigned 16-bit integer.  </p>
-<p id="rfc.section.C.2.2.p.4">This property is only available if the <samp>CAP_HBO</samp> capability is present in <samp>PROP_CAPS</samp>.  </p>
-<h1 id="rfc.appendix.D"><a href="#rfc.appendix.D">Appendix D.</a> <a href="#feature-jam-detect" id="feature-jam-detect">Feature: Jam Detection</a></h1>
-<p id="rfc.section.D.p.1">Jamming detection is a feature that allows the NCP to report when it detects high levels of interference that are characteristic of intentional signal jamming.  </p>
-<p id="rfc.section.D.p.2">The presence of this feature can be detected by checking for the presence of the <samp>CAP_JAM_DETECT</samp> (value 6) capability in <samp>PROP_CAPS</samp>.  </p>
-<h1 id="rfc.appendix.D.1"><a href="#rfc.appendix.D.1">D.1.</a> <a href="#properties-2" id="properties-2">Properties</a></h1>
-<h1 id="rfc.appendix.D.1.1"><a href="#rfc.appendix.D.1.1">D.1.1.</a> <a href="#prop-jam-detect-enable" id="prop-jam-detect-enable">PROP 4608: PROP_JAM_DETECT_ENABLE</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>b</samp></li>
-  <li>Default Value: false</li>
-  <li>REQUIRED for <samp>CAP_JAM_DETECT</samp></li>
-</ul>
-
-<p> </p>
-<table cellpadding="3" cellspacing="0" class="tt full center">
-  <thead>
-    <tr>
-      <th class="center">Octets:</th>
-      <th class="center">1</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="center">Fields:</td>
-      <td class="center">
-        <samp>PROP_JAM_DETECT_ENABLE</samp>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<p id="rfc.section.D.1.1.p.2">Indicates if jamming detection is enabled or disabled. Set to true to enable jamming detection.  </p>
-<p id="rfc.section.D.1.1.p.3">This property is only available if the <samp>CAP_JAM_DETECT</samp> capability is present in <samp>PROP_CAPS</samp>.  </p>
-<h1 id="rfc.appendix.D.1.2"><a href="#rfc.appendix.D.1.2">D.1.2.</a> <a href="#prop-jam-detected" id="prop-jam-detected">PROP 4609: PROP_JAM_DETECTED</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Only</li>
-  <li>Packed-Encoding: <samp>b</samp></li>
-  <li>REQUIRED for <samp>CAP_JAM_DETECT</samp></li>
-</ul>
-
-<p> </p>
-<table cellpadding="3" cellspacing="0" class="tt full center">
-  <thead>
-    <tr>
-      <th class="center">Octets:</th>
-      <th class="center">1</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="center">Fields:</td>
-      <td class="center">
-        <samp>PROP_JAM_DETECTED</samp>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<p id="rfc.section.D.1.2.p.2">Set to true if radio jamming is detected. Set to false otherwise.  </p>
-<p id="rfc.section.D.1.2.p.3">When jamming detection is enabled, changes to the value of this property are emitted asynchronously via <samp>CMD_PROP_VALUE_IS</samp>.  </p>
-<p id="rfc.section.D.1.2.p.4">This property is only available if the <samp>CAP_JAM_DETECT</samp> capability is present in <samp>PROP_CAPS</samp>.  </p>
-<h1 id="rfc.appendix.D.1.3"><a href="#rfc.appendix.D.1.3">D.1.3.</a> <a href="#prop-4610-propjamdetectrssithreshold" id="prop-4610-propjamdetectrssithreshold">PROP 4610: PROP_JAM_DETECT_RSSI_THRESHOLD</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>c</samp></li>
-  <li>Units: dBm</li>
-  <li>Default Value: Implementation-specific</li>
-  <li>RECOMMENDED for <samp>CAP_JAM_DETECT</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.D.1.3.p.2">This parameter describes the threshold RSSI level (measured in dBm) above which the jamming detection will consider the channel blocked.  </p>
-<h1 id="rfc.appendix.D.1.4"><a href="#rfc.appendix.D.1.4">D.1.4.</a> <a href="#prop-4611-propjamdetectwindow" id="prop-4611-propjamdetectwindow">PROP 4611: PROP_JAM_DETECT_WINDOW</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>c</samp></li>
-  <li>Units: Seconds (1-64)</li>
-  <li>Default Value: Implementation-specific</li>
-  <li>RECOMMENDED for <samp>CAP_JAM_DETECT</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.D.1.4.p.2">This parameter describes the window period for signal jamming detection.  </p>
-<h1 id="rfc.appendix.D.1.5"><a href="#rfc.appendix.D.1.5">D.1.5.</a> <a href="#prop-4612-propjamdetectbusy" id="prop-4612-propjamdetectbusy">PROP 4612: PROP_JAM_DETECT_BUSY</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>i</samp></li>
-  <li>Units: Seconds (1-64)</li>
-  <li>Default Value: Implementation-specific</li>
-  <li>RECOMMENDED for <samp>CAP_JAM_DETECT</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.D.1.5.p.2">This parameter describes the number of aggregate seconds within the detection window where the RSSI must be above <samp>PROP_JAM_DETECT_RSSI_THRESHOLD</samp> to trigger detection.  </p>
-<p id="rfc.section.D.1.5.p.3">The behavior of the jamming detection feature when <samp>PROP_JAM_DETECT_BUSY</samp> is larger than <samp>PROP_JAM_DETECT_WINDOW</samp> is undefined.  </p>
-<h1 id="rfc.appendix.E"><a href="#rfc.appendix.E">Appendix E.</a> <a href="#technology-thread" id="technology-thread">Technology: Thread</a></h1>
-<p id="rfc.section.E.p.1">This section describes all of the properties and semantics required for managing a Thread NCP.  </p>
-<p id="rfc.section.E.p.2">Thread NCPs have the following requirements: </p>
-<p/>
-
-<ul>
-  <li>The property <samp>PROP_INTERFACE_TYPE</samp> must be 3.</li>
-  <li>The non-optional properties in the following sections MUST be implemented: CORE, PHY, MAC, NET, and IPV6.</li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.p.4">All serious implementations of an NCP SHOULD also support the network save feature (See <a href="#feature-network-save">Appendix B</a>).  </p>
-<h1 id="rfc.appendix.E.1"><a href="#rfc.appendix.E.1">E.1.</a> <a href="#thread-capabilities" id="thread-capabilities">Thread Capabilities</a></h1>
-<p id="rfc.section.E.1.p.1">The Thread technology defines the following capabilities: </p>
-<p/>
-
-<ul>
-  <li><samp>CAP_NET_THREAD_1_0</samp> - Indicates that the NCP implements v1.0 of the Thread standard.</li>
-  <li><samp>CAP_NET_THREAD_1_1</samp> - Indicates that the NCP implements v1.1 of the Thread standard.</li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.E.2"><a href="#rfc.appendix.E.2">E.2.</a> <a href="#thread-properties" id="thread-properties">Thread Properties</a></h1>
-<p id="rfc.section.E.2.p.1">Properties for Thread are allocated out of the <samp>Tech</samp> property section (see <a href="#property-sections">Section 5.1</a>).  </p>
-<h1 id="rfc.appendix.E.2.1"><a href="#rfc.appendix.E.2.1">E.2.1.</a> <a href="#prop-80-propthreadleaderaddr" id="prop-80-propthreadleaderaddr">PROP 80: PROP_THREAD_LEADER_ADDR</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Only</li>
-  <li>Packed-Encoding: <samp>6</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.1.p.2">The IPv6 address of the leader. (Note: May change to long and short address of leader) </p>
-<h1 id="rfc.appendix.E.2.2"><a href="#rfc.appendix.E.2.2">E.2.2.</a> <a href="#prop-81-propthreadparent" id="prop-81-propthreadparent">PROP 81: PROP_THREAD_PARENT</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Only</li>
-  <li>Packed-Encoding: <samp>ES</samp></li>
-  <li>LADDR, SADDR</li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.2.p.2">The long address and short address of the parent of this node.  </p>
-<h1 id="rfc.appendix.E.2.3"><a href="#rfc.appendix.E.2.3">E.2.3.</a> <a href="#prop-82-propthreadchildtable" id="prop-82-propthreadchildtable">PROP 82: PROP_THREAD_CHILD_TABLE</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Only</li>
-  <li>Packed-Encoding: <samp>A(T(ES))</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.3.p.2">Table containing the long and short addresses of all the children of this node.  </p>
-<h1 id="rfc.appendix.E.2.4"><a href="#rfc.appendix.E.2.4">E.2.4.</a> <a href="#prop-83-propthreadleaderrid" id="prop-83-propthreadleaderrid">PROP 83: PROP_THREAD_LEADER_RID</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Only</li>
-  <li>Packed-Encoding: <samp>C</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.4.p.2">The router-id of the current leader.  </p>
-<h1 id="rfc.appendix.E.2.5"><a href="#rfc.appendix.E.2.5">E.2.5.</a> <a href="#prop-84-propthreadleaderweight" id="prop-84-propthreadleaderweight">PROP 84: PROP_THREAD_LEADER_WEIGHT</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Only</li>
-  <li>Packed-Encoding: <samp>C</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.5.p.2">The leader weight of the current leader.  </p>
-<h1 id="rfc.appendix.E.2.6"><a href="#rfc.appendix.E.2.6">E.2.6.</a> <a href="#prop-85-propthreadlocalleaderweight" id="prop-85-propthreadlocalleaderweight">PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>C</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.6.p.2">The leader weight for this node.  </p>
-<h1 id="rfc.appendix.E.2.7"><a href="#rfc.appendix.E.2.7">E.2.7.</a> <a href="#prop-86-propthreadnetworkdata" id="prop-86-propthreadnetworkdata">PROP 86: PROP_THREAD_NETWORK_DATA</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Only</li>
-  <li>Packed-Encoding: <samp>D</samp></li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.E.2.8"><a href="#rfc.appendix.E.2.8">E.2.8.</a> <a href="#prop-87-propthreadnetworkdataversion" id="prop-87-propthreadnetworkdataversion">PROP 87: PROP_THREAD_NETWORK_DATA_VERSION</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Only</li>
-  <li>Packed-Encoding: <samp>S</samp></li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.E.2.9"><a href="#rfc.appendix.E.2.9">E.2.9.</a> <a href="#prop-88-propthreadstablenetworkdata" id="prop-88-propthreadstablenetworkdata">PROP 88: PROP_THREAD_STABLE_NETWORK_DATA</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Only</li>
-  <li>Packed-Encoding: <samp>D</samp></li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.E.2.10"><a href="#rfc.appendix.E.2.10">E.2.10.</a> <a href="#prop-89-propthreadstablenetworkdataversion" id="prop-89-propthreadstablenetworkdataversion">PROP 89: PROP_THREAD_STABLE_NETWORK_DATA_VERSION</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Only</li>
-  <li>Packed-Encoding: <samp>S</samp></li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.E.2.11"><a href="#rfc.appendix.E.2.11">E.2.11.</a> <a href="#prop-90-propthreadonmeshnets" id="prop-90-propthreadonmeshnets">PROP 90: PROP_THREAD_ON_MESH_NETS</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>A(T(6CbCb))</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.11.p.2">Data per item is: </p>
-<p/>
-
-<ul>
-  <li><samp>6</samp>: IPv6 Prefix</li>
-  <li><samp>C</samp>: Prefix length, in bits</li>
-  <li><samp>b</samp>: Stable flag</li>
-  <li><samp>C</samp>: Thread flags</li>
-  <li><samp>b</samp>: "Is defined locally" flag. Set if this network was locally defined. Assumed to be true for set, insert and replace. Clear if the on mesh network was defined by another node.</li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.E.2.12"><a href="#rfc.appendix.E.2.12">E.2.12.</a> <a href="#prop-91-propthreadlocalroutes" id="prop-91-propthreadlocalroutes">PROP 91: PROP_THREAD_LOCAL_ROUTES</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>A(T(6CbC))</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.12.p.2">Data per item is: </p>
-<p/>
-
-<ul>
-  <li><samp>6</samp>: IPv6 Prefix</li>
-  <li><samp>C</samp>: Prefix length, in bits</li>
-  <li><samp>b</samp>: Stable flag</li>
-  <li><samp>C</samp>: Other flags</li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.E.2.13"><a href="#rfc.appendix.E.2.13">E.2.13.</a> <a href="#prop-92-propthreadassistingports" id="prop-92-propthreadassistingports">PROP 92: PROP_THREAD_ASSISTING_PORTS</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>A(S)</samp></li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.E.2.14"><a href="#rfc.appendix.E.2.14">E.2.14.</a> <a href="#prop-93-propthreadallowlocalnetdatachange" id="prop-93-propthreadallowlocalnetdatachange">PROP 93: PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>b</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.14.p.2">Set to true before changing local net data. Set to false when finished.  This allows changes to be aggregated into single events.  </p>
-<h1 id="rfc.appendix.E.2.15"><a href="#rfc.appendix.E.2.15">E.2.15.</a> <a href="#prop-94-propthreadmode" id="prop-94-propthreadmode">PROP 94: PROP_THREAD_MODE</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>C</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.15.p.2">This property contains the value of the mode TLV for this node. The meaning of the bits in this bitfield are defined by section 4.5.2 of the Thread specification.  </p>
-<h1 id="rfc.appendix.E.2.16"><a href="#rfc.appendix.E.2.16">E.2.16.</a> <a href="#prop-5376-propthreadchildtimeout" id="prop-5376-propthreadchildtimeout">PROP 5376: PROP_THREAD_CHILD_TIMEOUT</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>L</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.16.p.2">Used when operating in the Child role.  </p>
-<h1 id="rfc.appendix.E.2.17"><a href="#rfc.appendix.E.2.17">E.2.17.</a> <a href="#prop-5377-propthreadrloc16" id="prop-5377-propthreadrloc16">PROP 5377: PROP_THREAD_RLOC16</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>S</samp></li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.E.2.18"><a href="#rfc.appendix.E.2.18">E.2.18.</a> <a href="#prop-5378-propthreadrouterupgradethreshold" id="prop-5378-propthreadrouterupgradethreshold">PROP 5378: PROP_THREAD_ROUTER_UPGRADE_THRESHOLD</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>C</samp></li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.E.2.19"><a href="#rfc.appendix.E.2.19">E.2.19.</a> <a href="#prop-5379-propthreadcontextreusedelay" id="prop-5379-propthreadcontextreusedelay">PROP 5379: PROP_THREAD_CONTEXT_REUSE_DELAY</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>L</samp></li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.E.2.20"><a href="#rfc.appendix.E.2.20">E.2.20.</a> <a href="#prop-5380-propthreadnetworkidtimeout" id="prop-5380-propthreadnetworkidtimeout">PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>C</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.20.p.2">Allows you to get or set the Thread <samp>NETWORK_ID_TIMEOUT</samp> constant, as defined by the Thread specification.  </p>
-<h1 id="rfc.appendix.E.2.21"><a href="#rfc.appendix.E.2.21">E.2.21.</a> <a href="#prop-5381-propthreadactiverouterids" id="prop-5381-propthreadactiverouterids">PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write/Write-Only</li>
-  <li>Packed-Encoding: <samp>A(C)</samp> (List of active thread router ids)</li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.21.p.2">Note that some implementations may not support <samp>CMD_GET_VALUE</samp> router ids, but may support <samp>CMD_REMOVE_VALUE</samp> when the node is a leader.  </p>
-<h1 id="rfc.appendix.E.2.22"><a href="#rfc.appendix.E.2.22">E.2.22.</a> <a href="#prop-5382-propthreadrloc16debugpassthru" id="prop-5382-propthreadrloc16debugpassthru">PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>b</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.22.p.2">Allow the HOST to directly observe all IPv6 packets received by the NCP, including ones sent to the RLOC16 address.  </p>
-<p id="rfc.section.E.2.22.p.3">Default value is <samp>false</samp>.  </p>
-<h1 id="rfc.appendix.E.2.23"><a href="#rfc.appendix.E.2.23">E.2.23.</a> <a href="#prop-5383-spinelpropthreadrouterroleenabled" id="prop-5383-spinelpropthreadrouterroleenabled">PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>b</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.23.p.2">Allow the HOST to indicate whether or not the router role is enabled.  If current role is a router, setting this property to <samp>false</samp> starts a re-attach process as an end-device.  </p>
-<h1 id="rfc.appendix.E.2.24"><a href="#rfc.appendix.E.2.24">E.2.24.</a> <a href="#prop-5384-propthreadrouterdowngradethreshold" id="prop-5384-propthreadrouterdowngradethreshold">PROP 5384: PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>C</samp></li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.E.2.25"><a href="#rfc.appendix.E.2.25">E.2.25.</a> <a href="#prop-5385-propthreadrouterselectionjitter" id="prop-5385-propthreadrouterselectionjitter">PROP 5385: PROP_THREAD_ROUTER_SELECTION_JITTER</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Write</li>
-  <li>Packed-Encoding: <samp>C</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.25.p.2">Specifies the self imposed random delay in seconds a REED waits before registering to become an Active Router.  </p>
-<h1 id="rfc.appendix.E.2.26"><a href="#rfc.appendix.E.2.26">E.2.26.</a> <a href="#prop-5386-propthreadpreferredrouterid" id="prop-5386-propthreadpreferredrouterid">PROP 5386: PROP_THREAD_PREFERRED_ROUTER_ID</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Write-Only</li>
-  <li>Packed-Encoding: <samp>C</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.26.p.2">Specifies the preferred Router Id. Upon becoming a router/leader the node attempts to use this Router Id. If the preferred Router Id is not set or if it can not be used, a randomly generated router id is picked. This property can be set only when the device role is either detached or disabled.  </p>
-<h1 id="rfc.appendix.E.2.27"><a href="#rfc.appendix.E.2.27">E.2.27.</a> <a href="#prop-5387-spinelpropthreadneighbortable" id="prop-5387-spinelpropthreadneighbortable">PROP 5387: SPINEL_PROP_THREAD_NEIGHBOR_TABLE</a></h1>
-<p/>
-
-<ul>
-  <li>Type: Read-Only</li>
-  <li>Packed-Encoding: <samp>A(T(ESLCcCbLL))</samp></li>
-</ul>
-
-<p> </p>
-<p id="rfc.section.E.2.27.p.2">Data per item is: </p>
-<p/>
-
-<ul>
-  <li><samp>E</samp>: Extended/long address</li>
-  <li><samp>S</samp>: RLOC16</li>
-  <li><samp>L</samp>: Age</li>
-  <li><samp>C</samp>: Link Quality In</li>
-  <li><samp>c</samp>: Average RSS</li>
-  <li><samp>C</samp>: Mode (bit-flags)</li>
-  <li><samp>b</samp>: <samp>true</samp> if neighbor is a child, <samp>false</samp> otherwise.</li>
-  <li><samp>L</samp>: Link Frame Counter</li>
-  <li><samp>L</samp>: MLE Frame Counter</li>
-</ul>
-
-<p> </p>
-<h1 id="rfc.appendix.F"><a href="#rfc.appendix.F">Appendix F.</a> <a href="#test-vectors" id="test-vectors">Test Vectors</a></h1>
-<h1 id="rfc.appendix.F.1"><a href="#rfc.appendix.F.1">F.1.</a> <a href="#test-vector-packed-unsigned-integer" id="test-vector-packed-unsigned-integer">Test Vector: Packed Unsigned Integer</a></h1>
+<h1 id="rfc.appendix.B"><a href="#rfc.appendix.B">Appendix B.</a> <a href="#test-vectors" id="test-vectors">Test Vectors</a></h1>
+<h1 id="rfc.appendix.B.1"><a href="#rfc.appendix.B.1">B.1.</a> <a href="#test-vector-packed-unsigned-integer" id="test-vector-packed-unsigned-integer">Test Vector: Packed Unsigned Integer</a></h1>
 <table cellpadding="3" cellspacing="0" class="tt full center">
   <thead>
     <tr>
@@ -3529,9 +3587,9 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
   </tbody>
 </table>
 <p>
-  <a id="CREF6" class="info">[CREF6]<span class="info">RQ: The PUI test-vector encodings need to be verified.</span></a>
+  <a id="CREF5" class="info">[CREF5]<span class="info">RQ: The PUI test-vector encodings need to be verified.</span></a>
 </p>
-<h1 id="rfc.appendix.F.2"><a href="#rfc.appendix.F.2">F.2.</a> <a href="#test-vector-reset-command" id="test-vector-reset-command">Test Vector: Reset Command</a></h1>
+<h1 id="rfc.appendix.B.2"><a href="#rfc.appendix.B.2">B.2.</a> <a href="#test-vector-reset-command" id="test-vector-reset-command">Test Vector: Reset Command</a></h1>
 <p/>
 
 <ul>
@@ -3541,11 +3599,11 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.F.2.p.2">Frame: </p>
+<p id="rfc.section.B.2.p.2">Frame: </p>
 <pre>
 80 01
 </pre>
-<h1 id="rfc.appendix.F.3"><a href="#rfc.appendix.F.3">F.3.</a> <a href="#test-vector-reset-notification" id="test-vector-reset-notification">Test Vector: Reset Notification</a></h1>
+<h1 id="rfc.appendix.B.3"><a href="#rfc.appendix.B.3">B.3.</a> <a href="#test-vector-reset-notification" id="test-vector-reset-notification">Test Vector: Reset Notification</a></h1>
 <p/>
 
 <ul>
@@ -3557,11 +3615,11 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.F.3.p.2">Frame: </p>
+<p id="rfc.section.B.3.p.2">Frame: </p>
 <pre>
 80 06 00 72
 </pre>
-<h1 id="rfc.appendix.F.4"><a href="#rfc.appendix.F.4">F.4.</a> <a href="#test-vector-scan-beacon" id="test-vector-scan-beacon">Test Vector: Scan Beacon</a></h1>
+<h1 id="rfc.appendix.B.4"><a href="#rfc.appendix.B.4">B.4.</a> <a href="#test-vector-scan-beacon" id="test-vector-scan-beacon">Test Vector: Scan Beacon</a></h1>
 <p/>
 
 <ul>
@@ -3573,23 +3631,23 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 </ul>
 
 <p> </p>
-<p id="rfc.section.F.4.p.2">Frame: </p>
+<p id="rfc.section.B.4.p.2">Frame: </p>
 <pre>
 80 07 33 0F C4 0D 00 B6 40 D4 8C E9 38 F9 52 FF FF D2 04 00
 13 00 03 20 73 70 69 6E 65 6C 00 08 00 DE AD 00 BE EF 00 CA
 FE
 </pre>
-<h1 id="rfc.appendix.F.5"><a href="#rfc.appendix.F.5">F.5.</a> <a href="#test-vector-inbound-ipv6-packet" id="test-vector-inbound-ipv6-packet">Test Vector: Inbound IPv6 Packet</a></h1>
-<p id="rfc.section.F.5.p.1">CMD_VALUE_IS(PROP_STREAM_NET) </p>
+<h1 id="rfc.appendix.B.5"><a href="#rfc.appendix.B.5">B.5.</a> <a href="#test-vector-inbound-ipv6-packet" id="test-vector-inbound-ipv6-packet">Test Vector: Inbound IPv6 Packet</a></h1>
+<p id="rfc.section.B.5.p.1">CMD_VALUE_IS(PROP_STREAM_NET) </p>
+<p>
+  <a id="CREF6" class="info">[CREF6]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
+</p>
+<h1 id="rfc.appendix.B.6"><a href="#rfc.appendix.B.6">B.6.</a> <a href="#test-vector-outbound-ipv6-packet" id="test-vector-outbound-ipv6-packet">Test Vector: Outbound IPv6 Packet</a></h1>
+<p id="rfc.section.B.6.p.1">CMD_VALUE_SET(PROP_STREAM_NET) </p>
 <p>
   <a id="CREF7" class="info">[CREF7]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
 </p>
-<h1 id="rfc.appendix.F.6"><a href="#rfc.appendix.F.6">F.6.</a> <a href="#test-vector-outbound-ipv6-packet" id="test-vector-outbound-ipv6-packet">Test Vector: Outbound IPv6 Packet</a></h1>
-<p id="rfc.section.F.6.p.1">CMD_VALUE_SET(PROP_STREAM_NET) </p>
-<p>
-  <a id="CREF8" class="info">[CREF8]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
-</p>
-<h1 id="rfc.appendix.F.7"><a href="#rfc.appendix.F.7">F.7.</a> <a href="#test-vector-fetch-list-of-onmesh-networks" id="test-vector-fetch-list-of-onmesh-networks">Test Vector: Fetch list of on-mesh networks</a></h1>
+<h1 id="rfc.appendix.B.7"><a href="#rfc.appendix.B.7">B.7.</a> <a href="#test-vector-fetch-list-of-onmesh-networks" id="test-vector-fetch-list-of-onmesh-networks">Test Vector: Fetch list of on-mesh networks</a></h1>
 <p/>
 
 <ul>
@@ -3600,11 +3658,11 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.F.7.p.2">Frame: </p>
+<p id="rfc.section.B.7.p.2">Frame: </p>
 <pre>
 84 02 5A
 </pre>
-<h1 id="rfc.appendix.F.8"><a href="#rfc.appendix.F.8">F.8.</a> <a href="#test-vector-returned-list-of-onmesh-networks" id="test-vector-returned-list-of-onmesh-networks">Test Vector: Returned list of on-mesh networks</a></h1>
+<h1 id="rfc.appendix.B.8"><a href="#rfc.appendix.B.8">B.8.</a> <a href="#test-vector-returned-list-of-onmesh-networks" id="test-vector-returned-list-of-onmesh-networks">Test Vector: Returned list of on-mesh networks</a></h1>
 <p/>
 
 <ul>
@@ -3640,13 +3698,13 @@ FE
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.F.8.p.2">Frame: </p>
+<p id="rfc.section.B.8.p.2">Frame: </p>
 <pre>
 84 06 5A 13 00 20 01 0D B8 00 01 00 00 00 00 00 00 00 00 00
 00 40 01 ?? 13 00 20 01 0D B8 00 02 00 00 00 00 00 00 00 00
 00 00 40 00 ??
 </pre>
-<h1 id="rfc.appendix.F.9"><a href="#rfc.appendix.F.9">F.9.</a> <a href="#test-vector-adding-an-onmesh-network" id="test-vector-adding-an-onmesh-network">Test Vector: Adding an on-mesh network</a></h1>
+<h1 id="rfc.appendix.B.9"><a href="#rfc.appendix.B.9">B.9.</a> <a href="#test-vector-adding-an-onmesh-network" id="test-vector-adding-an-onmesh-network">Test Vector: Adding an on-mesh network</a></h1>
 <p/>
 
 <ul>
@@ -3676,15 +3734,15 @@ FE
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.F.9.p.2">Frame: </p>
+<p id="rfc.section.B.9.p.2">Frame: </p>
 <pre>
 85 03 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00 40
 01 ?? 01
 </pre>
 <p>
-  <a id="CREF9" class="info">[CREF9]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
+  <a id="CREF8" class="info">[CREF8]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
 </p>
-<h1 id="rfc.appendix.F.10"><a href="#rfc.appendix.F.10">F.10.</a> <a href="#test-vector-insertion-notification-of-an-onmesh-network" id="test-vector-insertion-notification-of-an-onmesh-network">Test Vector: Insertion notification of an on-mesh network</a></h1>
+<h1 id="rfc.appendix.B.10"><a href="#rfc.appendix.B.10">B.10.</a> <a href="#test-vector-insertion-notification-of-an-onmesh-network" id="test-vector-insertion-notification-of-an-onmesh-network">Test Vector: Insertion notification of an on-mesh network</a></h1>
 <p/>
 
 <ul>
@@ -3714,15 +3772,15 @@ FE
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.F.10.p.2">Frame: </p>
+<p id="rfc.section.B.10.p.2">Frame: </p>
 <pre>
 85 07 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00 40
 01 ?? 01
 </pre>
 <p>
-  <a id="CREF10" class="info">[CREF10]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
+  <a id="CREF9" class="info">[CREF9]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
 </p>
-<h1 id="rfc.appendix.F.11"><a href="#rfc.appendix.F.11">F.11.</a> <a href="#test-vector-removing-a-local-onmesh-network" id="test-vector-removing-a-local-onmesh-network">Test Vector: Removing a local on-mesh network</a></h1>
+<h1 id="rfc.appendix.B.11"><a href="#rfc.appendix.B.11">B.11.</a> <a href="#test-vector-removing-a-local-onmesh-network" id="test-vector-removing-a-local-onmesh-network">Test Vector: Removing a local on-mesh network</a></h1>
 <p/>
 
 <ul>
@@ -3734,11 +3792,11 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.F.11.p.2">Frame: </p>
+<p id="rfc.section.B.11.p.2">Frame: </p>
 <pre>
 86 05 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00
 </pre>
-<h1 id="rfc.appendix.F.12"><a href="#rfc.appendix.F.12">F.12.</a> <a href="#test-vector-removal-notification-of-an-onmesh-network" id="test-vector-removal-notification-of-an-onmesh-network">Test Vector: Removal notification of an on-mesh network</a></h1>
+<h1 id="rfc.appendix.B.12"><a href="#rfc.appendix.B.12">B.12.</a> <a href="#test-vector-removal-notification-of-an-onmesh-network" id="test-vector-removal-notification-of-an-onmesh-network">Test Vector: Removal notification of an on-mesh network</a></h1>
 <p/>
 
 <ul>
@@ -3750,16 +3808,16 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.F.12.p.2">Frame: </p>
+<p id="rfc.section.B.12.p.2">Frame: </p>
 <pre>
 86 08 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00
 </pre>
-<h1 id="rfc.appendix.G"><a href="#rfc.appendix.G">Appendix G.</a> <a href="#example-sessions" id="example-sessions">Example Sessions</a></h1>
-<h1 id="rfc.appendix.G.1"><a href="#rfc.appendix.G.1">G.1.</a> <a href="#ncp-initialization" id="ncp-initialization">NCP Initialization</a></h1>
+<h1 id="rfc.appendix.C"><a href="#rfc.appendix.C">Appendix C.</a> <a href="#example-sessions" id="example-sessions">Example Sessions</a></h1>
+<h1 id="rfc.appendix.C.1"><a href="#rfc.appendix.C.1">C.1.</a> <a href="#ncp-initialization" id="ncp-initialization">NCP Initialization</a></h1>
 <p>
-  <a id="CREF11" class="info">[CREF11]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF10" class="info">[CREF10]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
-<p id="rfc.section.G.1.p.2">Check the protocol version to see if it is supported: </p>
+<p id="rfc.section.C.1.p.2">Check the protocol version to see if it is supported: </p>
 <p/>
 
 <ul>
@@ -3768,7 +3826,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.1.p.4">Check the NCP version to see if a firmware update may be necessary: </p>
+<p id="rfc.section.C.1.p.4">Check the NCP version to see if a firmware update may be necessary: </p>
 <p/>
 
 <ul>
@@ -3777,7 +3835,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.1.p.6">Check interface type to make sure that it is what we expect: </p>
+<p id="rfc.section.C.1.p.6">Check interface type to make sure that it is what we expect: </p>
 <p/>
 
 <ul>
@@ -3786,7 +3844,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.1.p.8">If the host supports using vendor-specific commands, the vendor should be verified before using them: </p>
+<p id="rfc.section.C.1.p.8">If the host supports using vendor-specific commands, the vendor should be verified before using them: </p>
 <p/>
 
 <ul>
@@ -3795,7 +3853,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.1.p.10">Fetch the capability list so that we know what features this NCP supports: </p>
+<p id="rfc.section.C.1.p.10">Fetch the capability list so that we know what features this NCP supports: </p>
 <p/>
 
 <ul>
@@ -3804,7 +3862,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.1.p.12">If the NCP supports CAP_NET_SAVE, then we go ahead and recall the network: </p>
+<p id="rfc.section.C.1.p.12">If the NCP supports CAP_NET_SAVE, then we go ahead and recall the network: </p>
 <p/>
 
 <ul>
@@ -3812,12 +3870,12 @@ FE
 </ul>
 
 <p> </p>
-<h1 id="rfc.appendix.G.2"><a href="#rfc.appendix.G.2">G.2.</a> <a href="#attaching-to-a-network" id="attaching-to-a-network">Attaching to a network</a></h1>
+<h1 id="rfc.appendix.C.2"><a href="#rfc.appendix.C.2">C.2.</a> <a href="#attaching-to-a-network" id="attaching-to-a-network">Attaching to a network</a></h1>
 <p>
-  <a id="CREF12" class="info">[CREF12]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF11" class="info">[CREF11]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
-<p id="rfc.section.G.2.p.2">We make the assumption that the NCP is not currently associated with a network.  </p>
-<p id="rfc.section.G.2.p.3">Set the network properties, if they were not already set: </p>
+<p id="rfc.section.C.2.p.2">We make the assumption that the NCP is not currently associated with a network.  </p>
+<p id="rfc.section.C.2.p.3">Set the network properties, if they were not already set: </p>
 <p/>
 
 <ul>
@@ -3838,7 +3896,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.2.p.5">Bring the network interface up: </p>
+<p id="rfc.section.C.2.p.5">Bring the network interface up: </p>
 <p/>
 
 <ul>
@@ -3847,7 +3905,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.2.p.7">Bring the routing stack up: </p>
+<p id="rfc.section.C.2.p.7">Bring the routing stack up: </p>
 <p/>
 
 <ul>
@@ -3856,7 +3914,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.2.p.9">Some asynchronous events from the NCP: </p>
+<p id="rfc.section.C.2.p.9">Some asynchronous events from the NCP: </p>
 <p/>
 
 <ul>
@@ -3866,11 +3924,11 @@ FE
 </ul>
 
 <p> </p>
-<h1 id="rfc.appendix.G.3"><a href="#rfc.appendix.G.3">G.3.</a> <a href="#successfully-joining-a-preexisting-network" id="successfully-joining-a-preexisting-network">Successfully joining a pre-existing network</a></h1>
+<h1 id="rfc.appendix.C.3"><a href="#rfc.appendix.C.3">C.3.</a> <a href="#successfully-joining-a-preexisting-network" id="successfully-joining-a-preexisting-network">Successfully joining a pre-existing network</a></h1>
 <p>
-  <a id="CREF13" class="info">[CREF13]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF12" class="info">[CREF12]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
-<p id="rfc.section.G.3.p.2">This example session is identical to the above session up to the point where we set PROP_NET_IF_UP to true. From there, the behavior changes.  </p>
+<p id="rfc.section.C.3.p.2">This example session is identical to the above session up to the point where we set PROP_NET_IF_UP to true. From there, the behavior changes.  </p>
 <p/>
 
 <ul>
@@ -3879,7 +3937,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.3.p.4">Bring the routing stack up: </p>
+<p id="rfc.section.C.3.p.4">Bring the routing stack up: </p>
 <p/>
 
 <ul>
@@ -3888,7 +3946,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.3.p.6">Some asynchronous events from the NCP: </p>
+<p id="rfc.section.C.3.p.6">Some asynchronous events from the NCP: </p>
 <p/>
 
 <ul>
@@ -3898,7 +3956,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.3.p.8">Now let's save the network settings to NVRAM: </p>
+<p id="rfc.section.C.3.p.8">Now let's save the network settings to NVRAM: </p>
 <p/>
 
 <ul>
@@ -3906,8 +3964,8 @@ FE
 </ul>
 
 <p> </p>
-<h1 id="rfc.appendix.G.4"><a href="#rfc.appendix.G.4">G.4.</a> <a href="#unsuccessfully-joining-a-preexisting-network" id="unsuccessfully-joining-a-preexisting-network">Unsuccessfully joining a pre-existing network</a></h1>
-<p id="rfc.section.G.4.p.1">This example session is identical to the above session up to the point where we set PROP_NET_IF_UP to true. From there, the behavior changes.  </p>
+<h1 id="rfc.appendix.C.4"><a href="#rfc.appendix.C.4">C.4.</a> <a href="#unsuccessfully-joining-a-preexisting-network" id="unsuccessfully-joining-a-preexisting-network">Unsuccessfully joining a pre-existing network</a></h1>
+<p id="rfc.section.C.4.p.1">This example session is identical to the above session up to the point where we set PROP_NET_IF_UP to true. From there, the behavior changes.  </p>
 <p/>
 
 <ul>
@@ -3916,7 +3974,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.4.p.3">Bring the routing stack up: </p>
+<p id="rfc.section.C.4.p.3">Bring the routing stack up: </p>
 <p/>
 
 <ul>
@@ -3925,7 +3983,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.4.p.5">Some asynchronous events from the NCP: </p>
+<p id="rfc.section.C.4.p.5">Some asynchronous events from the NCP: </p>
 <p/>
 
 <ul>
@@ -3934,13 +3992,13 @@ FE
 </ul>
 
 <p> </p>
-<h1 id="rfc.appendix.G.5"><a href="#rfc.appendix.G.5">G.5.</a> <a href="#detaching-from-a-network" id="detaching-from-a-network">Detaching from a network</a></h1>
-<p id="rfc.section.G.5.p.1">TBD </p>
-<h1 id="rfc.appendix.G.6"><a href="#rfc.appendix.G.6">G.6.</a> <a href="#attaching-to-a-saved-network" id="attaching-to-a-saved-network">Attaching to a saved network</a></h1>
+<h1 id="rfc.appendix.C.5"><a href="#rfc.appendix.C.5">C.5.</a> <a href="#detaching-from-a-network" id="detaching-from-a-network">Detaching from a network</a></h1>
+<p id="rfc.section.C.5.p.1">TBD </p>
+<h1 id="rfc.appendix.C.6"><a href="#rfc.appendix.C.6">C.6.</a> <a href="#attaching-to-a-saved-network" id="attaching-to-a-saved-network">Attaching to a saved network</a></h1>
 <p>
-  <a id="CREF14" class="info">[CREF14]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF13" class="info">[CREF13]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
-<p id="rfc.section.G.6.p.2">Recall the saved network if you haven't already done so: </p>
+<p id="rfc.section.C.6.p.2">Recall the saved network if you haven't already done so: </p>
 <p/>
 
 <ul>
@@ -3948,7 +4006,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.6.p.4">Bring the network interface up: </p>
+<p id="rfc.section.C.6.p.4">Bring the network interface up: </p>
 <p/>
 
 <ul>
@@ -3957,7 +4015,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.6.p.6">Bring the routing stack up: </p>
+<p id="rfc.section.C.6.p.6">Bring the routing stack up: </p>
 <p/>
 
 <ul>
@@ -3966,7 +4024,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.6.p.8">Some asynchronous events from the NCP: </p>
+<p id="rfc.section.C.6.p.8">Some asynchronous events from the NCP: </p>
 <p/>
 
 <ul>
@@ -3976,9 +4034,9 @@ FE
 </ul>
 
 <p> </p>
-<h1 id="rfc.appendix.G.7"><a href="#rfc.appendix.G.7">G.7.</a> <a href="#ncp-software-reset" id="ncp-software-reset">NCP Software Reset</a></h1>
+<h1 id="rfc.appendix.C.7"><a href="#rfc.appendix.C.7">C.7.</a> <a href="#ncp-software-reset" id="ncp-software-reset">NCP Software Reset</a></h1>
 <p>
-  <a id="CREF15" class="info">[CREF15]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF14" class="info">[CREF14]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p/>
 
@@ -3988,17 +4046,17 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.7.p.3">Then jump to <a href="#ncp-initialization">Appendix G.1</a>.  </p>
-<h1 id="rfc.appendix.G.8"><a href="#rfc.appendix.G.8">G.8.</a> <a href="#adding-an-onmesh-prefix" id="adding-an-onmesh-prefix">Adding an on-mesh prefix</a></h1>
-<p id="rfc.section.G.8.p.1">TBD </p>
-<h1 id="rfc.appendix.G.9"><a href="#rfc.appendix.G.9">G.9.</a> <a href="#entering-lowpower-modes" id="entering-lowpower-modes">Entering low-power modes</a></h1>
-<p id="rfc.section.G.9.p.1">TBD </p>
-<h1 id="rfc.appendix.G.10"><a href="#rfc.appendix.G.10">G.10.</a> <a href="#sniffing-raw-packets" id="sniffing-raw-packets">Sniffing raw packets</a></h1>
+<p id="rfc.section.C.7.p.3">Then jump to <a href="#ncp-initialization">Appendix C.1</a>.  </p>
+<h1 id="rfc.appendix.C.8"><a href="#rfc.appendix.C.8">C.8.</a> <a href="#adding-an-onmesh-prefix" id="adding-an-onmesh-prefix">Adding an on-mesh prefix</a></h1>
+<p id="rfc.section.C.8.p.1">TBD </p>
+<h1 id="rfc.appendix.C.9"><a href="#rfc.appendix.C.9">C.9.</a> <a href="#entering-lowpower-modes" id="entering-lowpower-modes">Entering low-power modes</a></h1>
+<p id="rfc.section.C.9.p.1">TBD </p>
+<h1 id="rfc.appendix.C.10"><a href="#rfc.appendix.C.10">C.10.</a> <a href="#sniffing-raw-packets" id="sniffing-raw-packets">Sniffing raw packets</a></h1>
 <p>
-  <a id="CREF16" class="info">[CREF16]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF15" class="info">[CREF15]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
-<p id="rfc.section.G.10.p.2">This assumes that the NCP has been initialized.  </p>
-<p id="rfc.section.G.10.p.3">Optionally set the channel: </p>
+<p id="rfc.section.C.10.p.2">This assumes that the NCP has been initialized.  </p>
+<p id="rfc.section.C.10.p.3">Optionally set the channel: </p>
 <p/>
 
 <ul>
@@ -4007,7 +4065,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.10.p.5">Set the filter mode: </p>
+<p id="rfc.section.C.10.p.5">Set the filter mode: </p>
 <p/>
 
 <ul>
@@ -4016,7 +4074,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.10.p.7">Enable the raw stream: </p>
+<p id="rfc.section.C.10.p.7">Enable the raw stream: </p>
 <p/>
 
 <ul>
@@ -4025,7 +4083,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.10.p.9">Enable the PHY directly: </p>
+<p id="rfc.section.C.10.p.9">Enable the PHY directly: </p>
 <p/>
 
 <ul>
@@ -4034,7 +4092,7 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.10.p.11">Now we will get raw 802.15.4 packets asynchronously on PROP_STREAM_RAW: </p>
+<p id="rfc.section.C.10.p.11">Now we will get raw 802.15.4 packets asynchronously on PROP_STREAM_RAW: </p>
 <p/>
 
 <ul>
@@ -4044,8 +4102,14 @@ FE
 </ul>
 
 <p> </p>
-<p id="rfc.section.G.10.p.13">This mode may be entered even when associated with a network.  In that case, you should set <samp>PROP_MAC_PROMISCUOUS_MODE</samp> to <samp>MAC_PROMISCUOUS_MODE_PROMISCUOUS</samp> or <samp>MAC_PROMISCUOUS_MODE_NORMAL</samp>, so that you can avoid receiving packets from other networks or that are destined for other nodes.  </p>
-<h1 id="rfc.appendix.H"><a href="#rfc.appendix.H">Appendix H.</a> <a href="#glossary" id="glossary">Glossary</a></h1>
+<p id="rfc.section.C.10.p.13">This mode may be entered even when associated with a network.  In that case, you should set <samp>PROP_MAC_PROMISCUOUS_MODE</samp> to <samp>MAC_PROMISCUOUS_MODE_PROMISCUOUS</samp> or <samp>MAC_PROMISCUOUS_MODE_NORMAL</samp>, so that you can avoid receiving packets from other networks or that are destined for other nodes.  </p>
+<h1 id="rfc.appendix.D"><a href="#rfc.appendix.D">Appendix D.</a> <a href="#acknowledgments" id="acknowledgments">Acknowledgments</a></h1>
+<p id="rfc.section.D.p.1">Special thanks to Abtin Keshavarzian, Martin Turon, Arjuna Sivasithambaresan and Jonathan Hui for their substantial contributions and feedback related to this document.  </p>
+<p>
+  <a id="CREF16" class="info">[CREF16]<span class="info">RQ: If I have missed anyone who has contributed to this document, please let me know ASAP.</span></a>
+</p>
+<p id="rfc.section.D.p.3">This document was prepared using <a href="https://github.com/miekg/mmark">mmark</a> by (Miek Gieben) and <a href="http://xml2rfc.ietf.org/">xml2rfc (version 2)</a>.  </p>
+<h1 id="rfc.appendix.E"><a href="#rfc.appendix.E">Appendix E.</a> <a href="#glossary" id="glossary">Glossary</a></h1>
 <p>
   <a id="CREF17" class="info">[CREF17]<span class="info">RQ: Alphabetize before finalization.</span></a>
 </p>

--- a/doc/draft-spinel-protocol.txt
+++ b/doc/draft-spinel-protocol.txt
@@ -4,11 +4,11 @@
 
                                                           R. Quattlebaum
                                                                Nest Labs
-                                                        November 4, 2016
+                                                       November 28, 2016
 
 
                     Spinel Host-Controller Protocol
-                    draft-spinel-protocol-f9bf43254
+                    draft-spinel-protocol-05367497d
 
 Abstract
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Quattlebaum                Expires May 8, 2017                  [Page 1]
+Quattlebaum               Expires June 1, 2017                  [Page 1]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
@@ -73,7 +73,7 @@ Table of Contents
        1.1.2.  Spinel as Application API . . . . . . . . . . . . . .   7
        1.1.3.  Privileged Commands and Properties  . . . . . . . . .   8
      1.2.  Property Overview . . . . . . . . . . . . . . . . . . . .   8
-       1.2.1.  Property Methods  . . . . . . . . . . . . . . . . . .   8
+       1.2.1.  Property Methods  . . . . . . . . . . . . . . . . . .   9
        1.2.2.  Property Types  . . . . . . . . . . . . . . . . . . .   9
    2.  Frame Format  . . . . . . . . . . . . . . . . . . . . . . . .  10
      2.1.  Header Format . . . . . . . . . . . . . . . . . . . . . .  11
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Quattlebaum                Expires May 8, 2017                  [Page 2]
+Quattlebaum               Expires June 1, 2017                  [Page 2]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
        5.2.3.  PROP 2: PROP_NCP_VERSION  . . . . . . . . . . . . . .  23
@@ -165,122 +165,128 @@ Quattlebaum                Expires May 8, 2017                  [Page 2]
 
 
 
-Quattlebaum                Expires May 8, 2017                  [Page 3]
+Quattlebaum               Expires June 1, 2017                  [Page 3]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
        5.7.4.  PROP 99: PROP_IPV6_ADDRESS_TABLE  . . . . . . . . . .  37
        5.7.5.  PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD . . . . . . . .  38
    6.  Status Codes  . . . . . . . . . . . . . . . . . . . . . . . .  38
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  39
-     7.1.  Raw Application Access  . . . . . . . . . . . . . . . . .  39
-   8.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  40
-     9.1.  URIs  . . . . . . . . . . . . . . . . . . . . . . . . . .  40
-   Appendix A.  Framing Protocol . . . . . . . . . . . . . . . . . .  40
-     A.1.  UART Recommendations  . . . . . . . . . . . . . . . . . .  40
-       A.1.1.  UART Bit Rate Detection . . . . . . . . . . . . . . .  41
-       A.1.2.  HDLC-Lite . . . . . . . . . . . . . . . . . . . . . .  41
-     A.2.  SPI Recommendations . . . . . . . . . . . . . . . . . . .  42
-       A.2.1.  SPI Framing Protocol  . . . . . . . . . . . . . . . .  43
-     A.3.  I^2C Recommendations  . . . . . . . . . . . . . . . . . .  45
-     A.4.  Native USB Recommendations  . . . . . . . . . . . . . . .  45
-   Appendix B.  Feature: Network Save  . . . . . . . . . . . . . . .  45
-     B.1.  Commands  . . . . . . . . . . . . . . . . . . . . . . . .  45
-       B.1.1.  CMD 9: (Host->NCP) CMD_NET_SAVE . . . . . . . . . . .  45
-       B.1.2.  CMD 10: (Host->NCP) CMD_NET_CLEAR . . . . . . . . . .  46
-       B.1.3.  CMD 11: (Host->NCP) CMD_NET_RECALL  . . . . . . . . .  46
-   Appendix C.  Feature: Host Buffer Offload . . . . . . . . . . . .  46
-     C.1.  Commands  . . . . . . . . . . . . . . . . . . . . . . . .  47
-       C.1.1.  CMD 12: (NCP->Host) CMD_HBO_OFFLOAD . . . . . . . . .  47
-       C.1.2.  CMD 13: (NCP->Host) CMD_HBO_RECLAIM . . . . . . . . .  47
-       C.1.3.  CMD 14: (NCP->Host) CMD_HBO_DROP  . . . . . . . . . .  47
-       C.1.4.  CMD 15: (Host->NCP) CMD_HBO_OFFLOADED . . . . . . . .  47
-       C.1.5.  CMD 16: (Host->NCP) CMD_HBO_RECLAIMED . . . . . . . .  47
-       C.1.6.  CMD 17: (Host->NCP) CMD_HBO_DROPPED . . . . . . . . .  48
-     C.2.  Properties  . . . . . . . . . . . . . . . . . . . . . . .  48
-       C.2.1.  PROP 10: PROP_HBO_MEM_MAX . . . . . . . . . . . . . .  48
-       C.2.2.  PROP 11: PROP_HBO_BLOCK_MAX . . . . . . . . . . . . .  48
-   Appendix D.  Feature: Jam Detection . . . . . . . . . . . . . . .  49
-     D.1.  Properties  . . . . . . . . . . . . . . . . . . . . . . .  49
-       D.1.1.  PROP 4608: PROP_JAM_DETECT_ENABLE . . . . . . . . . .  49
-       D.1.2.  PROP 4609: PROP_JAM_DETECTED  . . . . . . . . . . . .  49
-       D.1.3.  PROP 4610: PROP_JAM_DETECT_RSSI_THRESHOLD . . . . . .  50
-       D.1.4.  PROP 4611: PROP_JAM_DETECT_WINDOW . . . . . . . . . .  50
-       D.1.5.  PROP 4612: PROP_JAM_DETECT_BUSY . . . . . . . . . . .  50
-   Appendix E.  Technology: Thread . . . . . . . . . . . . . . . . .  50
-     E.1.  Thread Capabilities . . . . . . . . . . . . . . . . . . .  51
-     E.2.  Thread Properties . . . . . . . . . . . . . . . . . . . .  51
-       E.2.1.  PROP 80: PROP_THREAD_LEADER_ADDR  . . . . . . . . . .  51
-       E.2.2.  PROP 81: PROP_THREAD_PARENT . . . . . . . . . . . . .  51
-       E.2.3.  PROP 82: PROP_THREAD_CHILD_TABLE  . . . . . . . . . .  51
-       E.2.4.  PROP 83: PROP_THREAD_LEADER_RID . . . . . . . . . . .  52
-       E.2.5.  PROP 84: PROP_THREAD_LEADER_WEIGHT  . . . . . . . . .  52
-       E.2.6.  PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT  . . . . . .  52
-       E.2.7.  PROP 86: PROP_THREAD_NETWORK_DATA . . . . . . . . . .  52
+   7.  Technology: Thread  . . . . . . . . . . . . . . . . . . . . .  39
+     7.1.  Thread Capabilities . . . . . . . . . . . . . . . . . . .  40
+     7.2.  Thread Properties . . . . . . . . . . . . . . . . . . . .  40
+       7.2.1.  PROP 80: PROP_THREAD_LEADER_ADDR  . . . . . . . . . .  40
+       7.2.2.  PROP 81: PROP_THREAD_PARENT . . . . . . . . . . . . .  40
+       7.2.3.  PROP 82: PROP_THREAD_CHILD_TABLE  . . . . . . . . . .  40
+       7.2.4.  PROP 83: PROP_THREAD_LEADER_RID . . . . . . . . . . .  40
+       7.2.5.  PROP 84: PROP_THREAD_LEADER_WEIGHT  . . . . . . . . .  41
+       7.2.6.  PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT  . . . . . .  41
+       7.2.7.  PROP 86: PROP_THREAD_NETWORK_DATA . . . . . . . . . .  41
+       7.2.8.  PROP 87: PROP_THREAD_NETWORK_DATA_VERSION . . . . . .  41
+       7.2.9.  PROP 88: PROP_THREAD_STABLE_NETWORK_DATA  . . . . . .  41
+       7.2.10. PROP 89: PROP_THREAD_STABLE_NETWORK_DATA_VERSION  . .  41
+       7.2.11. PROP 90: PROP_THREAD_ON_MESH_NETS . . . . . . . . . .  41
+       7.2.12. PROP 91: PROP_THREAD_LOCAL_ROUTES . . . . . . . . . .  42
+       7.2.13. PROP 92: PROP_THREAD_ASSISTING_PORTS  . . . . . . . .  42
+       7.2.14. PROP 93: PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE  . .  42
+       7.2.15. PROP 94: PROP_THREAD_MODE . . . . . . . . . . . . . .  42
+       7.2.16. PROP 5376: PROP_THREAD_CHILD_TIMEOUT  . . . . . . . .  42
+       7.2.17. PROP 5377: PROP_THREAD_RLOC16 . . . . . . . . . . . .  42
+       7.2.18. PROP 5378: PROP_THREAD_ROUTER_UPGRADE_THRESHOLD . . .  43
+       7.2.19. PROP 5379: PROP_THREAD_CONTEXT_REUSE_DELAY  . . . . .  43
+       7.2.20. PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT . . . . . .  43
+       7.2.21. PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS  . . . . . .  43
+       7.2.22. PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU  . . . .  43
+       7.2.23. PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED . .  43
+       7.2.24. PROP 5384: PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD . .  44
+       7.2.25. PROP 5385: PROP_THREAD_ROUTER_SELECTION_JITTER  . . .  44
+       7.2.26. PROP 5386: PROP_THREAD_PREFERRED_ROUTER_ID  . . . . .  44
+       7.2.27. PROP 5387: SPINEL_PROP_THREAD_NEIGHBOR_TABLE  . . . .  44
+   8.  Feature: Network Save . . . . . . . . . . . . . . . . . . . .  44
+     8.1.  Commands  . . . . . . . . . . . . . . . . . . . . . . . .  45
+       8.1.1.  CMD 9: (Host->NCP) CMD_NET_SAVE . . . . . . . . . . .  45
+       8.1.2.  CMD 10: (Host->NCP) CMD_NET_CLEAR . . . . . . . . . .  45
+       8.1.3.  CMD 11: (Host->NCP) CMD_NET_RECALL  . . . . . . . . .  46
+   9.  Feature: Host Buffer Offload  . . . . . . . . . . . . . . . .  46
+     9.1.  Commands  . . . . . . . . . . . . . . . . . . . . . . . .  46
+       9.1.1.  CMD 12: (NCP->Host) CMD_HBO_OFFLOAD . . . . . . . . .  46
+       9.1.2.  CMD 13: (NCP->Host) CMD_HBO_RECLAIM . . . . . . . . .  47
+       9.1.3.  CMD 14: (NCP->Host) CMD_HBO_DROP  . . . . . . . . . .  47
+       9.1.4.  CMD 15: (Host->NCP) CMD_HBO_OFFLOADED . . . . . . . .  47
+       9.1.5.  CMD 16: (Host->NCP) CMD_HBO_RECLAIMED . . . . . . . .  47
+       9.1.6.  CMD 17: (Host->NCP) CMD_HBO_DROPPED . . . . . . . . .  47
+     9.2.  Properties  . . . . . . . . . . . . . . . . . . . . . . .  47
+       9.2.1.  PROP 10: PROP_HBO_MEM_MAX . . . . . . . . . . . . . .  47
 
 
 
-Quattlebaum                Expires May 8, 2017                  [Page 4]
+Quattlebaum               Expires June 1, 2017                  [Page 4]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
-       E.2.8.  PROP 87: PROP_THREAD_NETWORK_DATA_VERSION . . . . . .  52
-       E.2.9.  PROP 88: PROP_THREAD_STABLE_NETWORK_DATA  . . . . . .  52
-       E.2.10. PROP 89: PROP_THREAD_STABLE_NETWORK_DATA_VERSION  . .  52
-       E.2.11. PROP 90: PROP_THREAD_ON_MESH_NETS . . . . . . . . . .  52
-       E.2.12. PROP 91: PROP_THREAD_LOCAL_ROUTES . . . . . . . . . .  53
-       E.2.13. PROP 92: PROP_THREAD_ASSISTING_PORTS  . . . . . . . .  53
-       E.2.14. PROP 93: PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE  . .  53
-       E.2.15. PROP 94: PROP_THREAD_MODE . . . . . . . . . . . . . .  53
-       E.2.16. PROP 5376: PROP_THREAD_CHILD_TIMEOUT  . . . . . . . .  53
-       E.2.17. PROP 5377: PROP_THREAD_RLOC16 . . . . . . . . . . . .  54
-       E.2.18. PROP 5378: PROP_THREAD_ROUTER_UPGRADE_THRESHOLD . . .  54
-       E.2.19. PROP 5379: PROP_THREAD_CONTEXT_REUSE_DELAY  . . . . .  54
-       E.2.20. PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT . . . . . .  54
-       E.2.21. PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS  . . . . . .  54
-       E.2.22. PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU  . . . .  54
-       E.2.23. PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED . .  54
-       E.2.24. PROP 5384: PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD . .  55
-       E.2.25. PROP 5385: PROP_THREAD_ROUTER_SELECTION_JITTER  . . .  55
-       E.2.26. PROP 5386: PROP_THREAD_PREFERRED_ROUTER_ID  . . . . .  55
-       E.2.27. PROP 5387: SPINEL_PROP_THREAD_NEIGHBOR_TABLE  . . . .  55
-   Appendix F.  Test Vectors . . . . . . . . . . . . . . . . . . . .  56
-     F.1.  Test Vector: Packed Unsigned Integer  . . . . . . . . . .  56
-     F.2.  Test Vector: Reset Command  . . . . . . . . . . . . . . .  56
-     F.3.  Test Vector: Reset Notification . . . . . . . . . . . . .  56
-     F.4.  Test Vector: Scan Beacon  . . . . . . . . . . . . . . . .  56
-     F.5.  Test Vector: Inbound IPv6 Packet  . . . . . . . . . . . .  57
-     F.6.  Test Vector: Outbound IPv6 Packet . . . . . . . . . . . .  57
-     F.7.  Test Vector: Fetch list of on-mesh networks . . . . . . .  57
-     F.8.  Test Vector: Returned list of on-mesh networks  . . . . .  58
-     F.9.  Test Vector: Adding an on-mesh network  . . . . . . . . .  58
-     F.10. Test Vector: Insertion notification of an on-mesh network  58
-     F.11. Test Vector: Removing a local on-mesh network . . . . . .  59
-     F.12. Test Vector: Removal notification of an on-mesh network .  59
-   Appendix G.  Example Sessions . . . . . . . . . . . . . . . . . .  59
-     G.1.  NCP Initialization  . . . . . . . . . . . . . . . . . . .  59
-     G.2.  Attaching to a network  . . . . . . . . . . . . . . . . .  60
-     G.3.  Successfully joining a pre-existing network . . . . . . .  61
-     G.4.  Unsuccessfully joining a pre-existing network . . . . . .  62
-     G.5.  Detaching from a network  . . . . . . . . . . . . . . . .  62
-     G.6.  Attaching to a saved network  . . . . . . . . . . . . . .  62
-     G.7.  NCP Software Reset  . . . . . . . . . . . . . . . . . . .  63
-     G.8.  Adding an on-mesh prefix  . . . . . . . . . . . . . . . .  63
-     G.9.  Entering low-power modes  . . . . . . . . . . . . . . . .  63
-     G.10. Sniffing raw packets  . . . . . . . . . . . . . . . . . .  63
-   Appendix H.  Glossary . . . . . . . . . . . . . . . . . . . . . .  64
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  65
+       9.2.2.  PROP 11: PROP_HBO_BLOCK_MAX . . . . . . . . . . . . .  48
+   10. Feature: Jam Detection  . . . . . . . . . . . . . . . . . . .  48
+     10.1.  Properties . . . . . . . . . . . . . . . . . . . . . . .  48
+       10.1.1.  PROP 4608: PROP_JAM_DETECT_ENABLE  . . . . . . . . .  48
+       10.1.2.  PROP 4609: PROP_JAM_DETECTED . . . . . . . . . . . .  49
+       10.1.3.  PROP 4610: PROP_JAM_DETECT_RSSI_THRESHOLD  . . . . .  49
+       10.1.4.  PROP 4611: PROP_JAM_DETECT_WINDOW  . . . . . . . . .  49
+       10.1.5.  PROP 4612: PROP_JAM_DETECT_BUSY  . . . . . . . . . .  50
+   11. Feature: Basic GPIO Access  . . . . . . . . . . . . . . . . .  50
+     11.1.  Properties . . . . . . . . . . . . . . . . . . . . . . .  50
+       11.1.1.  PROP 4096: PROP_GPIO_AVAILABLE . . . . . . . . . . .  50
+       11.1.2.  PROP 4097: PROP_GPIO_DIRECTION . . . . . . . . . . .  50
+       11.1.3.  PROP 4098: PROP_GPIO_STATE . . . . . . . . . . . . .  51
+       11.1.4.  PROP 4099: PROP_GPIO_STATE_SET . . . . . . . . . . .  51
+       11.1.5.  PROP 4100: PROP_GPIO_STATE_CLEAR . . . . . . . . . .  51
+   12. Security Considerations . . . . . . . . . . . . . . . . . . .  51
+     12.1.  Raw Application Access . . . . . . . . . . . . . . . . .  51
+     13.1.  URIs . . . . . . . . . . . . . . . . . . . . . . . . . .  51
+   Appendix A.  Framing Protocol . . . . . . . . . . . . . . . . . .  52
+     A.1.  UART Recommendations  . . . . . . . . . . . . . . . . . .  52
+       A.1.1.  UART Bit Rate Detection . . . . . . . . . . . . . . .  52
+       A.1.2.  HDLC-Lite . . . . . . . . . . . . . . . . . . . . . .  53
+     A.2.  SPI Recommendations . . . . . . . . . . . . . . . . . . .  54
+       A.2.1.  SPI Framing Protocol  . . . . . . . . . . . . . . . .  54
+     A.3.  I^2C Recommendations  . . . . . . . . . . . . . . . . . .  56
+     A.4.  Native USB Recommendations  . . . . . . . . . . . . . . .  56
+   Appendix B.  Test Vectors . . . . . . . . . . . . . . . . . . . .  56
+     B.1.  Test Vector: Packed Unsigned Integer  . . . . . . . . . .  56
+     B.2.  Test Vector: Reset Command  . . . . . . . . . . . . . . .  57
+     B.3.  Test Vector: Reset Notification . . . . . . . . . . . . .  57
+     B.4.  Test Vector: Scan Beacon  . . . . . . . . . . . . . . . .  57
+     B.5.  Test Vector: Inbound IPv6 Packet  . . . . . . . . . . . .  58
+     B.6.  Test Vector: Outbound IPv6 Packet . . . . . . . . . . . .  58
+     B.7.  Test Vector: Fetch list of on-mesh networks . . . . . . .  58
+     B.8.  Test Vector: Returned list of on-mesh networks  . . . . .  59
+     B.9.  Test Vector: Adding an on-mesh network  . . . . . . . . .  59
+     B.10. Test Vector: Insertion notification of an on-mesh network  59
+     B.11. Test Vector: Removing a local on-mesh network . . . . . .  60
+     B.12. Test Vector: Removal notification of an on-mesh network .  60
+   Appendix C.  Example Sessions . . . . . . . . . . . . . . . . . .  60
+     C.1.  NCP Initialization  . . . . . . . . . . . . . . . . . . .  60
+     C.2.  Attaching to a network  . . . . . . . . . . . . . . . . .  61
+     C.3.  Successfully joining a pre-existing network . . . . . . .  62
+     C.4.  Unsuccessfully joining a pre-existing network . . . . . .  63
+     C.5.  Detaching from a network  . . . . . . . . . . . . . . . .  63
+     C.6.  Attaching to a saved network  . . . . . . . . . . . . . .  63
+     C.7.  NCP Software Reset  . . . . . . . . . . . . . . . . . . .  64
+     C.8.  Adding an on-mesh prefix  . . . . . . . . . . . . . . . .  64
 
 
 
-
-
-Quattlebaum                Expires May 8, 2017                  [Page 5]
+Quattlebaum               Expires June 1, 2017                  [Page 5]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
+
+     C.9.  Entering low-power modes  . . . . . . . . . . . . . . . .  64
+     C.10. Sniffing raw packets  . . . . . . . . . . . . . . . . . .  64
+   Appendix D.  Acknowledgments  . . . . . . . . . . . . . . . . . .  65
+   Appendix E.  Glossary . . . . . . . . . . . . . . . . . . . . . .  65
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  66
 
 1.  Introduction
 
@@ -323,6 +329,15 @@ Quattlebaum                Expires May 8, 2017                  [Page 5]
    the host and the NCP, the following commands and properties are
    already considered to be "baked" and will not change:
 
+
+
+
+
+Quattlebaum               Expires June 1, 2017                  [Page 6]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
    o  Command IDs zero through eight.  (Reset, No-op, and Property-Value
       Commands)
    o  Property IDs zero through two.  (Last status, Protocol Version,
@@ -330,14 +345,6 @@ Quattlebaum                Expires May 8, 2017                  [Page 5]
 
    Renumbering would be undertaken in order to better organize the
    allocation of property IDs and capability IDs.  One of the initial
-
-
-
-Quattlebaum                Expires May 8, 2017                  [Page 6]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
    goals of this protocol was for it to be possible for a host or NCP to
    only implement properties with values less than 127 and for the NCP
    to still be usable---relegating all larger property values for extra
@@ -378,6 +385,15 @@ Quattlebaum                Expires May 8, 2017                  [Page 6]
 
    Since there can be more than one application that is using the API at
    a time, the "PROP_LOCK" property (Section 5.2.10) would be used to
+
+
+
+
+Quattlebaum               Expires June 1, 2017                  [Page 7]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
    ensure exclusive access to the NCP by an application.  Only one
    process would be allowed to enable the lock at a time.
 
@@ -386,13 +402,6 @@ Quattlebaum                Expires May 8, 2017                  [Page 6]
    properties assigned and the IPC protocol would not need to be
    extended to support them.  It is also simple and has no external
    dependencies other than unix domain sockets.
-
-
-
-Quattlebaum                Expires May 8, 2017                  [Page 7]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
 
    Security is obviously paramount in a system like this, so a great
    deal of care should be taken to make sure that certain commands and
@@ -431,8 +440,15 @@ Quattlebaum                Expires May 8, 2017                  [Page 7]
    Almost all features and capabilities are implemented using
    properties.  Most new features that are initially proposed as
    commands can be adapted to be property-based instead.  Notable
-   exceptions include "Host Buffer Offload" (Appendix C) and "Network
-   Save" (Appendix B).
+   exceptions include "Host Buffer Offload" (Section 9) and "Network
+   Save" (Section 8).
+
+
+
+Quattlebaum               Expires June 1, 2017                  [Page 8]
+
+                       Spinel Protocol (05367497d)         November 2016
+
 
    In Spinel, properties are keyed by an unsigned integer between 0 and
    2,097,151 (See Section 3.2).
@@ -442,14 +458,6 @@ Quattlebaum                Expires May 8, 2017                  [Page 7]
    Properties may support one or more of the following methods:
 
    o  "VALUE_GET"
-
-
-
-Quattlebaum                Expires May 8, 2017                  [Page 8]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
    o  "VALUE_SET"
    o  "VALUE_INSERT"
    o  "VALUE_REMOVE"
@@ -491,6 +499,13 @@ Quattlebaum                Expires May 8, 2017                  [Page 8]
    o  List of IPv6 addresses assigned to the interface.
    o  List of capabilities supported by the NCP.
 
+
+
+Quattlebaum               Expires June 1, 2017                  [Page 9]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
    The valid operations on these sorts of properties are "VALUE_GET",
    "VALUE_SET", "VALUE_INSERT", and "VALUE_REMOVE".
 
@@ -498,14 +513,6 @@ Quattlebaum                Expires May 8, 2017                  [Page 8]
    the concatenation of all of the individual values in the list.  If
    the length of the value for an individual item in the list is not
    defined by the type then each item returned in the list is prepended
-
-
-
-Quattlebaum                Expires May 8, 2017                  [Page 9]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
    with a length (See Section 3.5).  The order of the returned items,
    unless explicitly defined for that specific property, is undefined.
 
@@ -547,20 +554,19 @@ Quattlebaum                Expires May 8, 2017                  [Page 9]
    o  A command (up to three bytes, see Section 3.2 for format)
    o  An optional command payload
 
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 10]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
                  +---------+--------+-----+-------------+
                  | Octets: |   1    | 1-3 |      n      |
                  +---------+--------+-----+-------------+
                  | Fields: | HEADER | CMD | CMD_PAYLOAD |
                  +---------+--------+-----+-------------+
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 10]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
 
 2.1.  Header Format
 
@@ -603,20 +609,18 @@ Quattlebaum                Expires May 8, 2017                 [Page 10]
    receives a frame that matches the TID of the command it sent, it can
    easily recognize that frame as the actual response to that command.
 
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 11]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
    The TID value of zero (0) is used for commands to which a correlated
    response is not expected or needed, such as for unsolicited update
    commands sent to the host from the NCP.
-
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 11]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
 
 2.1.4.  Command Identifier (CMD)
 
@@ -661,18 +665,18 @@ Quattlebaum                Expires May 8, 2017                 [Page 11]
    example:
 
    o  "C": A single unsigned byte.
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 12]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
    o  "C6U": A single unsigned byte, followed by a 128-bit IPv6 address,
       followed by a zero-terminated UTF8 string.
    o  "A(6)": An array of IPv6 addresses
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 12]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
 
    In each case, the data is represented exactly as described.  For
    example, an array of 10 IPv6 address is stored as 160 bytes.
@@ -717,18 +721,18 @@ Quattlebaum                Expires May 8, 2017                 [Page 12]
    need to add an extra byte.  Doing this would add an extra byte to the
    vast majority of instances, which can add up in terms of bandwidth.
 
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 13]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
    The packed unsigned integer format is based on the unsigned integer
    format in EXI [3], except that we limit the maximum value to the
    largest value that can be encoded into three bytes(2,097,151).
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 13]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
 
    For all values less than 127, the packed form of the number is simply
    a single byte which directly represents the number.  For values
@@ -773,18 +777,18 @@ Quattlebaum                Expires May 8, 2017                 [Page 13]
    the buffer minus 9. (9 is the number of bytes taken up by a byte and
    two longs)
 
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 14]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
    However, things are a little different with "CLDL".  Since our data
    blob is no longer the last item in the signature, the length must be
    prepended.
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 14]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
 
    If you are a little confused, keep reading.  This theme comes up in a
    a few different ways in the following sections.
@@ -833,13 +837,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 14]
 
 
 
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 15]
+Quattlebaum               Expires June 1, 2017                 [Page 15]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
 3.5.  Arrays
@@ -893,9 +893,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 15]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 16]
+Quattlebaum               Expires June 1, 2017                 [Page 16]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    If an error occurs, the value of "PROP_LAST_STATUS" will be emitted
@@ -949,9 +949,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 16]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 17]
+Quattlebaum               Expires June 1, 2017                 [Page 17]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    Insert value into property command.  Instructs the NCP to insert the
@@ -1005,9 +1005,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 17]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 18]
+Quattlebaum               Expires June 1, 2017                 [Page 18]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    The payload for this command is the property identifier encoded in
@@ -1061,9 +1061,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 18]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 19]
+Quattlebaum               Expires June 1, 2017                 [Page 19]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
 4.10.  CMD 18: (Host->NCP) CMD_PEEK
@@ -1085,7 +1085,7 @@ Quattlebaum                Expires May 8, 2017                 [Page 19]
    The NCP MAY prevent certain regions of memory from being accessed.
 
    The implementation of this command has security implications.  See
-   Section 7 for more information.
+   Section 12 for more information.
 
    This command requires the capability "CAP_PEEK_POKE" to be present.
 
@@ -1117,16 +1117,16 @@ Quattlebaum                Expires May 8, 2017                 [Page 19]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 20]
+Quattlebaum               Expires June 1, 2017                 [Page 20]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    Due to the low-level nature of this command, certain error conditions
    may induce the NCP to reset.
 
    The implementation of this command has security implications.  See
-   Section 7 for more information.
+   Section 12 for more information.
 
    This command requires the capability "CAP_PEEK_POKE" to be present.
 
@@ -1173,9 +1173,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 20]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 21]
+Quattlebaum               Expires June 1, 2017                 [Page 21]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    Note that each property section has two reserved ranges: a primary
@@ -1229,9 +1229,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 21]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 22]
+Quattlebaum               Expires June 1, 2017                 [Page 22]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
 5.2.2.1.  Major Version Number
@@ -1285,9 +1285,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 22]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 23]
+Quattlebaum               Expires June 1, 2017                 [Page 23]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
                        +---------+----------------+
@@ -1341,18 +1341,19 @@ Quattlebaum                Expires May 8, 2017                 [Page 23]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 24]
+Quattlebaum               Expires June 1, 2017                 [Page 24]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    o  1: "CAP_LOCK"
    o  2: "CAP_NET_SAVE"
-   o  3: "CAP_HBO": Host Buffer Offload.  See Appendix C.
+   o  3: "CAP_HBO": Host Buffer Offload.  See Section 9.
    o  4: "CAP_POWER_SAVE"
    o  5: "CAP_COUNTERS"
-   o  6: "CAP_JAM_DETECT": Jamming detection.  See Appendix D
+   o  6: "CAP_JAM_DETECT": Jamming detection.  See Section 10
    o  7: "CAP_PEEK_POKE": PEEK/POKE debugging commands.
+   o  8: "CAP_WRITABLE_RAW_STREAM": "PROP_STREAM_RAW" is writable.
    o  16: "CAP_802_15_4_2003"
    o  17: "CAP_802_15_4_2006"
    o  18: "CAP_802_15_4_2011"
@@ -1396,10 +1397,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 24]
 
 
 
-
-Quattlebaum                Expires May 8, 2017                 [Page 25]
+Quattlebaum               Expires June 1, 2017                 [Page 25]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    Describes the number of concurrent interfaces supported by this NCP.
@@ -1453,9 +1453,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 25]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 26]
+Quattlebaum               Expires June 1, 2017                 [Page 26]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    The static EUI64 address of the device, used as a serial number.
@@ -1509,9 +1509,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 26]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 27]
+Quattlebaum               Expires June 1, 2017                 [Page 27]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    To receive the debugging stream, you wait for "CMD_PROP_VALUE_IS"
@@ -1538,9 +1538,13 @@ Quattlebaum                Expires May 8, 2017                 [Page 27]
    NCP.
 
    Implementations may OPTIONALLY support the ability to transmit
-   arbitrary raw packets.  If this capability is supported, you may call
-   "CMD_PROP_VALUE_SET" on this property with the value of the raw
-   packet.
+   arbitrary raw packets.  Support for this feature is indicated by the
+   presence of the "CAP_WRITABLE_RAW_STREAM" capability.
+
+   If the capability "CAP_WRITABLE_RAW_STREAM" is set, then packets
+   written to this stream with "CMD_PROP_VALUE_SET" will be sent out
+   over the radio.  This allows the caller to use the radio directly,
+   with the stack being implemented on the host instead of the NCP.
 
 5.3.2.1.  Frame Metadata Format
 
@@ -1561,13 +1565,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 27]
 
 
 
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 28]
+Quattlebaum               Expires June 1, 2017                 [Page 28]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
      +----------+-----------------------+------------+-----+---------+
@@ -1621,9 +1621,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 28]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 29]
+Quattlebaum               Expires June 1, 2017                 [Page 29]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
         +---------+----------------+------------+----------------+
@@ -1677,9 +1677,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 29]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 30]
+Quattlebaum               Expires June 1, 2017                 [Page 30]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    Any data past the end of "FRAME_DATA_LEN" is considered metadata, the
@@ -1733,9 +1733,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 30]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 31]
+Quattlebaum               Expires June 1, 2017                 [Page 31]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    When setting, the value will be rounded down to a value that is
@@ -1789,9 +1789,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 31]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 32]
+Quattlebaum               Expires June 1, 2017                 [Page 32]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
 5.5.2.  PROP 49: PROP_MAC_SCAN_MASK
@@ -1845,9 +1845,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 32]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 33]
+Quattlebaum               Expires June 1, 2017                 [Page 33]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
 5.5.5.  PROP 52: PROP_MAC_15_4_LADDR
@@ -1901,9 +1901,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 33]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 34]
+Quattlebaum               Expires June 1, 2017                 [Page 34]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    +----+--------------------------------+-----------------------------+
@@ -1957,9 +1957,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 34]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 35]
+Quattlebaum               Expires June 1, 2017                 [Page 35]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    Network interface up/down status.  Non-zero (set to 1) indicates up,
@@ -2013,9 +2013,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 35]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 36]
+Quattlebaum               Expires June 1, 2017                 [Page 36]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
 5.6.9.  PROP 72: PROP_NET_PARTITION_ID
@@ -2069,9 +2069,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 36]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 37]
+Quattlebaum               Expires June 1, 2017                 [Page 37]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
 5.7.5.  PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD
@@ -2125,9 +2125,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 37]
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 38]
+Quattlebaum               Expires June 1, 2017                 [Page 38]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    o  11: "STATUS_NOMEM": The operation has been prevented due to memory
@@ -2165,9 +2165,670 @@ Quattlebaum                Expires May 8, 2017                 [Page 38]
    o  2,000,000 - 2,097,151: Experimental Use Only (MUST NEVER be used
       in production!)
 
-7.  Security Considerations
+7.  Technology: Thread
 
-7.1.  Raw Application Access
+   This section describes all of the properties and semantics required
+   for managing a Thread NCP.
+
+   Thread NCPs have the following requirements:
+
+   o  The property "PROP_INTERFACE_TYPE" must be 3.
+   o  The non-optional properties in the following sections MUST be
+      implemented: CORE, PHY, MAC, NET, and IPV6.
+
+   All serious implementations of an NCP SHOULD also support the network
+   save feature (See Section 8).
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 39]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
+7.1.  Thread Capabilities
+
+   The Thread technology defines the following capabilities:
+
+   o  "CAP_NET_THREAD_1_0" - Indicates that the NCP implements v1.0 of
+      the Thread standard.
+   o  "CAP_NET_THREAD_1_1" - Indicates that the NCP implements v1.1 of
+      the Thread standard.
+
+7.2.  Thread Properties
+
+   Properties for Thread are allocated out of the "Tech" property
+   section (see Section 5.1).
+
+7.2.1.  PROP 80: PROP_THREAD_LEADER_ADDR
+
+   o  Type: Read-Only
+   o  Packed-Encoding: "6"
+
+   The IPv6 address of the leader.  (Note: May change to long and short
+   address of leader)
+
+7.2.2.  PROP 81: PROP_THREAD_PARENT
+
+   o  Type: Read-Only
+   o  Packed-Encoding: "ES"
+   o  LADDR, SADDR
+
+   The long address and short address of the parent of this node.
+
+7.2.3.  PROP 82: PROP_THREAD_CHILD_TABLE
+
+   o  Type: Read-Only
+   o  Packed-Encoding: "A(T(ES))"
+
+   Table containing the long and short addresses of all the children of
+   this node.
+
+7.2.4.  PROP 83: PROP_THREAD_LEADER_RID
+
+   o  Type: Read-Only
+   o  Packed-Encoding: "C"
+
+   The router-id of the current leader.
+
+
+
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 40]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
+7.2.5.  PROP 84: PROP_THREAD_LEADER_WEIGHT
+
+   o  Type: Read-Only
+   o  Packed-Encoding: "C"
+
+   The leader weight of the current leader.
+
+7.2.6.  PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "C"
+
+   The leader weight for this node.
+
+7.2.7.  PROP 86: PROP_THREAD_NETWORK_DATA
+
+   o  Type: Read-Only
+   o  Packed-Encoding: "D"
+
+7.2.8.  PROP 87: PROP_THREAD_NETWORK_DATA_VERSION
+
+   o  Type: Read-Only
+   o  Packed-Encoding: "S"
+
+7.2.9.  PROP 88: PROP_THREAD_STABLE_NETWORK_DATA
+
+   o  Type: Read-Only
+   o  Packed-Encoding: "D"
+
+7.2.10.  PROP 89: PROP_THREAD_STABLE_NETWORK_DATA_VERSION
+
+   o  Type: Read-Only
+   o  Packed-Encoding: "S"
+
+7.2.11.  PROP 90: PROP_THREAD_ON_MESH_NETS
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "A(T(6CbCb))"
+
+   Data per item is:
+
+   o  "6": IPv6 Prefix
+   o  "C": Prefix length, in bits
+   o  "b": Stable flag
+   o  "C": Thread flags
+   o  "b": "Is defined locally" flag.  Set if this network was locally
+      defined.  Assumed to be true for set, insert and replace.  Clear
+      if the on mesh network was defined by another node.
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 41]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
+7.2.12.  PROP 91: PROP_THREAD_LOCAL_ROUTES
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "A(T(6CbC))"
+
+   Data per item is:
+
+   o  "6": IPv6 Prefix
+   o  "C": Prefix length, in bits
+   o  "b": Stable flag
+   o  "C": Other flags
+
+7.2.13.  PROP 92: PROP_THREAD_ASSISTING_PORTS
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "A(S)"
+
+7.2.14.  PROP 93: PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "b"
+
+   Set to true before changing local net data.  Set to false when
+   finished.  This allows changes to be aggregated into single events.
+
+7.2.15.  PROP 94: PROP_THREAD_MODE
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "C"
+
+   This property contains the value of the mode TLV for this node.  The
+   meaning of the bits in this bitfield are defined by section 4.5.2 of
+   the Thread specification.
+
+7.2.16.  PROP 5376: PROP_THREAD_CHILD_TIMEOUT
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "L"
+
+   Used when operating in the Child role.
+
+7.2.17.  PROP 5377: PROP_THREAD_RLOC16
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "S"
+
+
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 42]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
+7.2.18.  PROP 5378: PROP_THREAD_ROUTER_UPGRADE_THRESHOLD
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "C"
+
+7.2.19.  PROP 5379: PROP_THREAD_CONTEXT_REUSE_DELAY
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "L"
+
+7.2.20.  PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "C"
+
+   Allows you to get or set the Thread "NETWORK_ID_TIMEOUT" constant, as
+   defined by the Thread specification.
+
+7.2.21.  PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS
+
+   o  Type: Read-Write/Write-Only
+   o  Packed-Encoding: "A(C)" (List of active thread router ids)
+
+   Note that some implementations may not support "CMD_GET_VALUE" router
+   ids, but may support "CMD_REMOVE_VALUE" when the node is a leader.
+
+7.2.22.  PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "b"
+
+   Allow the HOST to directly observe all IPv6 packets received by the
+   NCP, including ones sent to the RLOC16 address.
+
+   Default value is "false".
+
+7.2.23.  PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "b"
+
+   Allow the HOST to indicate whether or not the router role is enabled.
+   If current role is a router, setting this property to "false" starts
+   a re-attach process as an end-device.
+
+
+
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 43]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
+7.2.24.  PROP 5384: PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "C"
+
+7.2.25.  PROP 5385: PROP_THREAD_ROUTER_SELECTION_JITTER
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "C"
+
+   Specifies the self imposed random delay in seconds a REED waits
+   before registering to become an Active Router.
+
+7.2.26.  PROP 5386: PROP_THREAD_PREFERRED_ROUTER_ID
+
+   o  Type: Write-Only
+   o  Packed-Encoding: "C"
+
+   Specifies the preferred Router Id.  Upon becoming a router/leader the
+   node attempts to use this Router Id.  If the preferred Router Id is
+   not set or if it can not be used, a randomly generated router id is
+   picked.  This property can be set only when the device role is either
+   detached or disabled.
+
+7.2.27.  PROP 5387: SPINEL_PROP_THREAD_NEIGHBOR_TABLE
+
+   o  Type: Read-Only
+   o  Packed-Encoding: "A(T(ESLCcCbLL))"
+
+   Data per item is:
+
+   o  "E": Extended/long address
+   o  "S": RLOC16
+   o  "L": Age
+   o  "C": Link Quality In
+   o  "c": Average RSS
+   o  "C": Mode (bit-flags)
+   o  "b": "true" if neighbor is a child, "false" otherwise.
+   o  "L": Link Frame Counter
+   o  "L": MLE Frame Counter
+
+8.  Feature: Network Save
+
+   The network save feature is an optional NCP capability that, when
+   present, allows the host to save and recall network credentials and
+   state to and from nonvolatile storage.
+
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 44]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
+   The presence of this feature can be detected by checking for the
+   presence of the "CAP_NET_SAVE" capability in "PROP_CAPS".
+
+8.1.  Commands
+
+8.1.1.  CMD 9: (Host->NCP) CMD_NET_SAVE
+
+                    +---------+--------+--------------+
+                    | Octets: |   1    |      1       |
+                    +---------+--------+--------------+
+                    | Fields: | HEADER | CMD_NET_SAVE |
+                    +---------+--------+--------------+
+
+   Save network state command.  Saves any current network credentials
+   and state necessary to reconnect to the current network to non-
+   volatile memory.
+
+   This operation affects non-volatile memory only.  The current network
+   information stored in volatile memory is unaffected.
+
+   The response to this command is always a "CMD_PROP_VALUE_IS" for
+   "PROP_LAST_STATUS", indicating the result of the operation.
+
+   This command is only available if the "CAP_NET_SAVE" capability is
+   set.
+
+8.1.2.  CMD 10: (Host->NCP) CMD_NET_CLEAR
+
+                   +---------+--------+---------------+
+                   | Octets: |   1    |       1       |
+                   +---------+--------+---------------+
+                   | Fields: | HEADER | CMD_NET_CLEAR |
+                   +---------+--------+---------------+
+
+   Clear saved network state command.  Clears any previously saved
+   network credentials and state previously stored by "CMD_NET_SAVE"
+   from non-volatile memory.
+
+   This operation affects non-volatile memory only.  The current network
+   information stored in volatile memory is unaffected.
+
+   The response to this command is always a "CMD_PROP_VALUE_IS" for
+   "PROP_LAST_STATUS", indicating the result of the operation.
+
+   This command is only available if the "CAP_NET_SAVE" capability is
+   set.
+
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 45]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
+8.1.3.  CMD 11: (Host->NCP) CMD_NET_RECALL
+
+                   +---------+--------+----------------+
+                   | Octets: |   1    |       1        |
+                   +---------+--------+----------------+
+                   | Fields: | HEADER | CMD_NET_RECALL |
+                   +---------+--------+----------------+
+
+   Recall saved network state command.  Recalls any previously saved
+   network credentials and state previously stored by "CMD_NET_SAVE"
+   from non-volatile memory.
+
+   This command will typically generated several unsolicited property
+   updates as the network state is loaded.  At the conclusion of
+   loading, the authoritative response to this command is always a
+   "CMD_PROP_VALUE_IS" for "PROP_LAST_STATUS", indicating the result of
+   the operation.
+
+   This command is only available if the "CAP_NET_SAVE" capability is
+   set.
+
+9.  Feature: Host Buffer Offload
+
+   The memory on an NCP may be much more limited than the memory on the
+   host processor.  In such situations, it is sometimes useful for the
+   NCP to offload buffers to the host processor temporarily so that it
+   can perform other operations.
+
+   Host buffer offload is an optional NCP capability that, when present,
+   allows the NCP to store data buffers on the host processor that can
+   be recalled at a later time.
+
+   The presence of this feature can be detected by the host by checking
+   for the presence of the "CAP_HBO" capability in "PROP_CAPS".
+
+9.1.  Commands
+
+9.1.1.  CMD 12: (NCP->Host) CMD_HBO_OFFLOAD
+
+   o  Argument-Encoding: "LscD"
+
+      *  "OffloadId": 32-bit unique block identifier
+      *  "Expiration": In seconds-from-now
+      *  "Priority": Critical, High, Medium, Low
+      *  "Data": Data to offload
+
+
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 46]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
+9.1.2.  CMD 13: (NCP->Host) CMD_HBO_RECLAIM
+
+   o  Argument-Encoding: "Lb"
+
+      *  "OffloadId": 32-bit unique block identifier
+      *  "KeepAfterReclaim": If not set to true, the block will be
+         dropped by the host after it is sent to the NCP.
+
+9.1.3.  CMD 14: (NCP->Host) CMD_HBO_DROP
+
+   o  Argument-Encoding: "L"
+
+      *  "OffloadId": 32-bit unique block identifier
+
+9.1.4.  CMD 15: (Host->NCP) CMD_HBO_OFFLOADED
+
+   o  Argument-Encoding: "Li"
+
+      *  "OffloadId": 32-bit unique block identifier
+      *  "Status": Status code for the result of the operation.
+
+9.1.5.  CMD 16: (Host->NCP) CMD_HBO_RECLAIMED
+
+   o  Argument-Encoding: "LiD"
+
+      *  "OffloadId": 32-bit unique block identifier
+      *  "Status": Status code for the result of the operation.
+      *  "Data": Data that was previously offloaded (if any)
+
+9.1.6.  CMD 17: (Host->NCP) CMD_HBO_DROPPED
+
+   o  Argument-Encoding: "Li"
+
+      *  "OffloadId": 32-bit unique block identifier
+      *  "Status": Status code for the result of the operation.
+
+9.2.  Properties
+
+9.2.1.  PROP 10: PROP_HBO_MEM_MAX
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "L"
+
+                     +---------+--------------------+
+                     | Octets: |         4          |
+                     +---------+--------------------+
+                     | Fields: | "PROP_HBO_MEM_MAX" |
+                     +---------+--------------------+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 47]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
+   Describes the number of bytes that may be offloaded from the NCP to
+   the host.  Default value is zero, so this property must be set by the
+   host to a non-zero value before the NCP will begin offloading blocks.
+
+   This value is encoded as an unsigned 32-bit integer.
+
+   This property is only available if the "CAP_HBO" capability is
+   present in "PROP_CAPS".
+
+9.2.2.  PROP 11: PROP_HBO_BLOCK_MAX
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "S"
+
+                    +---------+----------------------+
+                    | Octets: |          2           |
+                    +---------+----------------------+
+                    | Fields: | "PROP_HBO_BLOCK_MAX" |
+                    +---------+----------------------+
+
+   Describes the number of blocks that may be offloaded from the NCP to
+   the host.  Default value is 32.  Setting this value to zero will
+   cause host block offload to be effectively disabled.
+
+   This value is encoded as an unsigned 16-bit integer.
+
+   This property is only available if the "CAP_HBO" capability is
+   present in "PROP_CAPS".
+
+10.  Feature: Jam Detection
+
+   Jamming detection is a feature that allows the NCP to report when it
+   detects high levels of interference that are characteristic of
+   intentional signal jamming.
+
+   The presence of this feature can be detected by checking for the
+   presence of the "CAP_JAM_DETECT" (value 6) capability in "PROP_CAPS".
+
+10.1.  Properties
+
+10.1.1.  PROP 4608: PROP_JAM_DETECT_ENABLE
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "b"
+   o  Default Value: false
+   o  REQUIRED for "CAP_JAM_DETECT"
+
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 48]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
+                  +---------+--------------------------+
+                  | Octets: |            1             |
+                  +---------+--------------------------+
+                  | Fields: | "PROP_JAM_DETECT_ENABLE" |
+                  +---------+--------------------------+
+
+   Indicates if jamming detection is enabled or disabled.  Set to true
+   to enable jamming detection.
+
+   This property is only available if the "CAP_JAM_DETECT" capability is
+   present in "PROP_CAPS".
+
+10.1.2.  PROP 4609: PROP_JAM_DETECTED
+
+   o  Type: Read-Only
+   o  Packed-Encoding: "b"
+   o  REQUIRED for "CAP_JAM_DETECT"
+
+                     +---------+---------------------+
+                     | Octets: |          1          |
+                     +---------+---------------------+
+                     | Fields: | "PROP_JAM_DETECTED" |
+                     +---------+---------------------+
+
+   Set to true if radio jamming is detected.  Set to false otherwise.
+
+   When jamming detection is enabled, changes to the value of this
+   property are emitted asynchronously via "CMD_PROP_VALUE_IS".
+
+   This property is only available if the "CAP_JAM_DETECT" capability is
+   present in "PROP_CAPS".
+
+10.1.3.  PROP 4610: PROP_JAM_DETECT_RSSI_THRESHOLD
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "c"
+   o  Units: dBm
+   o  Default Value: Implementation-specific
+   o  RECOMMENDED for "CAP_JAM_DETECT"
+
+   This parameter describes the threshold RSSI level (measured in dBm)
+   above which the jamming detection will consider the channel blocked.
+
+10.1.4.  PROP 4611: PROP_JAM_DETECT_WINDOW
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "c"
+   o  Units: Seconds (1-64)
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 49]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
+   o  Default Value: Implementation-specific
+   o  RECOMMENDED for "CAP_JAM_DETECT"
+
+   This parameter describes the window period for signal jamming
+   detection.
+
+10.1.5.  PROP 4612: PROP_JAM_DETECT_BUSY
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "i"
+   o  Units: Seconds (1-64)
+   o  Default Value: Implementation-specific
+   o  RECOMMENDED for "CAP_JAM_DETECT"
+
+   This parameter describes the number of aggregate seconds within the
+   detection window where the RSSI must be above
+   "PROP_JAM_DETECT_RSSI_THRESHOLD" to trigger detection.
+
+   The behavior of the jamming detection feature when
+   "PROP_JAM_DETECT_BUSY" is larger than "PROP_JAM_DETECT_WINDOW" is
+   undefined.
+
+11.  Feature: Basic GPIO Access
+
+   The length of the data associated with these properties depends on
+   the number of GPIOs.  If you have 10 GPIOs, you'd have two bytes.
+   You determine the number of GPIOs available by examining
+   PROP_GPIO_AVAILABLE, described below.  This API isn't intended to
+   support every possible GPIO state, it is intended for basic reading
+   and writing.
+
+11.1.  Properties
+
+11.1.1.  PROP 4096: PROP_GPIO_AVAILABLE
+
+   o  Type: Read-only
+
+   Contains a bit field identifying which GPIOs are supported.  Cleared
+   bits are not supported.  Set bits are supported.
+
+11.1.2.  PROP 4097: PROP_GPIO_DIRECTION
+
+   o  Type: Read-only (Optionally read/write)
+
+   Contains a bit field identifying which GPIOs are configured as
+   outputs.  Cleared bits are inputs.  Set bits are outputs.
+
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 50]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
+11.1.3.  PROP 4098: PROP_GPIO_STATE
+
+   o  Type: Read-Write
+
+   Contains a bit field identifying the state of the GPIOs.  For GPIOs
+   configured as inputs, this is the read logic level.  For GPIOs
+   configured as outputs, this is the logic level of the output.
+
+11.1.4.  PROP 4099: PROP_GPIO_STATE_SET
+
+   o  Type: Write-only
+
+   Allows for the state of various output GPIOs to be set without
+   affecting other GPIO states.  Contains a bit field identifying the
+   output GPIOs that should have their state set to 1.
+
+11.1.5.  PROP 4100: PROP_GPIO_STATE_CLEAR
+
+   o  Type: Write-only
+
+   Allows for the state of various output GPIOs to be cleared without
+   affecting other GPIO states.  Contains a bit field identifying the
+   output GPIOs that should have their state cleared to 0.
+
+12.  Security Considerations
+
+12.1.  Raw Application Access
 
    Spinel MAY be used as an API boundary for allowing processes to
    configure the NCP.  However, such a system MUST NOT give unprivileged
@@ -2176,30 +2837,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 38]
    should be allowed to be passed, and then only after being checked for
    proper format.
 
+13.  References
 
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 39]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
-8.  Acknowledgments
-
-   Special thanks to Abtin Keshavarzian, Martin Turon, Arjuna
-   Sivasithambaresan and Jonathan Hui for their substantial
-   contributions and feedback related to this document.
-
-   [CREF2]
-
-   This document was prepared using mmark [4] by (Miek Gieben) and
-   xml2rfc (version 2) [5].
-
-9.  References
-
-9.1.  URIs
+13.1.  URIs
 
    [1] http://wpantund.org/
 
@@ -2207,11 +2847,18 @@ Quattlebaum                Expires May 8, 2017                 [Page 39]
 
    [3] https://www.w3.org/TR/exi/#encodingUnsignedInteger
 
-   [4] https://github.com/miekg/mmark
+   [4] http://reveng.sourceforge.net/crc-catalogue/16.htm#crc.cat.kermit
 
-   [5] http://xml2rfc.ietf.org/
+   [5] https://github.com/miekg/mmark
 
-   [6] http://reveng.sourceforge.net/crc-catalogue/16.htm#crc.cat.kermit
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 51]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
+   [6] http://xml2rfc.ietf.org/
 
 Appendix A.  Framing Protocol
 
@@ -2234,14 +2881,6 @@ A.1.  UART Recommendations
    These values may be adjusted depending on the individual needs of the
    application or product, but some sort of flow control MUST be used.
    Hardware flow control is preferred over software flow control.  In
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 40]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
    the absence of hardware flow control, software flow control (XON/
    XOFF) MUST be used instead.
 
@@ -2266,6 +2905,15 @@ A.1.1.  UART Bit Rate Detection
    bitrate detection scheme that can be employed by the host to detect
    when the attached NCP is initially running at a higher bitrate.
 
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 52]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
    The algorithm is to send successive NOOP commands to the NCP at
    increasing bitrates.  When a valid "CMD_LAST_STATUS" response has
    been received, we have identified the correct bitrate.
@@ -2288,19 +2936,9 @@ A.1.2.  HDLC-Lite
    of HDLC are omitted.  This protocol was chosen because it works well
    with software flow control and is widely implemented.
 
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 41]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
    To transmit a frame with HDLC-lite, the 16-bit CRC must first be
    appended to the frame.  The CRC function is defined to be CRC-16/
-   CCITT, otherwise known as the KERMIT CRC [6].
+   CCITT, otherwise known as the KERMIT CRC [4].
 
    Individual frames are terminated with a frame delimiter octet called
    the 'flag' octet ("0x7E").
@@ -2324,6 +2962,14 @@ Quattlebaum                Expires May 8, 2017                 [Page 41]
 
    When receiving a frame, the CRC must be verified after the frame is
    unescaped.  If the CRC value does not match what is calculated for
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 53]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
    the frame data, the frame MUST be discarded.  The implementation MAY
    indicate the failure to higher levels to handle as they see fit, but
    MUST NOT attempt to process the deceived frame.
@@ -2347,13 +2993,6 @@ A.2.  SPI Recommendations
    o  "I&#773;N&#773;T&#773;": (NCP-to-Host) Host Interrupt
    o  "R&#773;E&#773;S&#773;": (Host-to-NCP) NCP Hardware Reset
 
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 42]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
    The "I&#773;N&#773;T&#773;" signal is used by the NCP to indicate to
    the host that the NCP has frames pending to send to it.  When
    asserted, the host SHOULD initiate a SPI transaction in a timely
@@ -2374,6 +3013,18 @@ Quattlebaum                Expires May 8, 2017                 [Page 42]
 A.2.1.  SPI Framing Protocol
 
    Each SPI frame starts with a 5-byte frame header:
+
+
+
+
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 54]
+
+                       Spinel Protocol (05367497d)         November 2016
+
 
                   +---------+-----+----------+----------+
                   | Octets: |  1  |    2     |    2     |
@@ -2400,16 +3051,6 @@ A.2.1.  SPI Framing Protocol
 
    o  "RST": This bit is set when that device has been reset since the
       last time "C&#773;S&#773;" was asserted.
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 43]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
    o  "CRC": This bit is set when that device supports writing a 16-bit
       CRC at the end of the data.  The CRC length is NOT included in
       DATA_LEN.
@@ -2433,6 +3074,14 @@ Quattlebaum                Expires May 8, 2017                 [Page 43]
    Alternatively, if the master has a frame to send it can just go ahead
    and send a frame of that length and determine if the frame was
    accepted by checking that the "RECV_LEN" from the slave frame is
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 55]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
    larger than the frame the master just tried to send.  If the
    "RECV_LEN" is smaller then the frame wasn't accepted and will need to
    be transmitted again.
@@ -2458,14 +3107,6 @@ Quattlebaum                Expires May 8, 2017                 [Page 43]
    the frame.  If not enough bytes were clocked out for the CRC to be
    read, then the frame must be ignored.  If enough bytes were clocked
    out to perform a CRC check, but the CRC check fails, then the frame
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 44]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
    must be rejected and the "CRC_FAIL" bit on the next frame (and ONLY
    the next frame) MUST be set.
 
@@ -2473,618 +3114,29 @@ A.3.  I^2C Recommendations
 
    TBD
 
-   [CREF3]
+   [CREF2]
 
 A.4.  Native USB Recommendations
 
    TBD
 
-   [CREF4]
+   [CREF3]
 
-Appendix B.  Feature: Network Save
+Appendix B.  Test Vectors
 
-   The network save feature is an optional NCP capability that, when
-   present, allows the host to save and recall network credentials and
-   state to and from nonvolatile storage.
-
-   The presence of this feature can be detected by checking for the
-   presence of the "CAP_NET_SAVE" capability in "PROP_CAPS".
-
-B.1.  Commands
-
-B.1.1.  CMD 9: (Host->NCP) CMD_NET_SAVE
-
-                    +---------+--------+--------------+
-                    | Octets: |   1    |      1       |
-                    +---------+--------+--------------+
-                    | Fields: | HEADER | CMD_NET_SAVE |
-                    +---------+--------+--------------+
-
-   Save network state command.  Saves any current network credentials
-   and state necessary to reconnect to the current network to non-
-   volatile memory.
-
-   This operation affects non-volatile memory only.  The current network
-   information stored in volatile memory is unaffected.
-
-   The response to this command is always a "CMD_PROP_VALUE_IS" for
-   "PROP_LAST_STATUS", indicating the result of the operation.
-
-   This command is only available if the "CAP_NET_SAVE" capability is
-   set.
+B.1.  Test Vector: Packed Unsigned Integer
 
 
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 45]
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 56]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
-
-B.1.2.  CMD 10: (Host->NCP) CMD_NET_CLEAR
-
-                   +---------+--------+---------------+
-                   | Octets: |   1    |       1       |
-                   +---------+--------+---------------+
-                   | Fields: | HEADER | CMD_NET_CLEAR |
-                   +---------+--------+---------------+
-
-   Clear saved network state command.  Clears any previously saved
-   network credentials and state previously stored by "CMD_NET_SAVE"
-   from non-volatile memory.
-
-   This operation affects non-volatile memory only.  The current network
-   information stored in volatile memory is unaffected.
-
-   The response to this command is always a "CMD_PROP_VALUE_IS" for
-   "PROP_LAST_STATUS", indicating the result of the operation.
-
-   This command is only available if the "CAP_NET_SAVE" capability is
-   set.
-
-B.1.3.  CMD 11: (Host->NCP) CMD_NET_RECALL
-
-                   +---------+--------+----------------+
-                   | Octets: |   1    |       1        |
-                   +---------+--------+----------------+
-                   | Fields: | HEADER | CMD_NET_RECALL |
-                   +---------+--------+----------------+
-
-   Recall saved network state command.  Recalls any previously saved
-   network credentials and state previously stored by "CMD_NET_SAVE"
-   from non-volatile memory.
-
-   This command will typically generated several unsolicited property
-   updates as the network state is loaded.  At the conclusion of
-   loading, the authoritative response to this command is always a
-   "CMD_PROP_VALUE_IS" for "PROP_LAST_STATUS", indicating the result of
-   the operation.
-
-   This command is only available if the "CAP_NET_SAVE" capability is
-   set.
-
-Appendix C.  Feature: Host Buffer Offload
-
-   The memory on an NCP may be much more limited than the memory on the
-   host processor.  In such situations, it is sometimes useful for the
-   NCP to offload buffers to the host processor temporarily so that it
-   can perform other operations.
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 46]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
-   Host buffer offload is an optional NCP capability that, when present,
-   allows the NCP to store data buffers on the host processor that can
-   be recalled at a later time.
-
-   The presence of this feature can be detected by the host by checking
-   for the presence of the "CAP_HBO" capability in "PROP_CAPS".
-
-C.1.  Commands
-
-C.1.1.  CMD 12: (NCP->Host) CMD_HBO_OFFLOAD
-
-   o  Argument-Encoding: "LscD"
-
-      *  "OffloadId": 32-bit unique block identifier
-      *  "Expiration": In seconds-from-now
-      *  "Priority": Critical, High, Medium, Low
-      *  "Data": Data to offload
-
-C.1.2.  CMD 13: (NCP->Host) CMD_HBO_RECLAIM
-
-   o  Argument-Encoding: "Lb"
-
-      *  "OffloadId": 32-bit unique block identifier
-      *  "KeepAfterReclaim": If not set to true, the block will be
-         dropped by the host after it is sent to the NCP.
-
-C.1.3.  CMD 14: (NCP->Host) CMD_HBO_DROP
-
-   o  Argument-Encoding: "L"
-
-      *  "OffloadId": 32-bit unique block identifier
-
-C.1.4.  CMD 15: (Host->NCP) CMD_HBO_OFFLOADED
-
-   o  Argument-Encoding: "Li"
-
-      *  "OffloadId": 32-bit unique block identifier
-      *  "Status": Status code for the result of the operation.
-
-C.1.5.  CMD 16: (Host->NCP) CMD_HBO_RECLAIMED
-
-   o  Argument-Encoding: "LiD"
-
-      *  "OffloadId": 32-bit unique block identifier
-      *  "Status": Status code for the result of the operation.
-      *  "Data": Data that was previously offloaded (if any)
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 47]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
-C.1.6.  CMD 17: (Host->NCP) CMD_HBO_DROPPED
-
-   o  Argument-Encoding: "Li"
-
-      *  "OffloadId": 32-bit unique block identifier
-      *  "Status": Status code for the result of the operation.
-
-C.2.  Properties
-
-C.2.1.  PROP 10: PROP_HBO_MEM_MAX
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "L"
-
-                     +---------+--------------------+
-                     | Octets: |         4          |
-                     +---------+--------------------+
-                     | Fields: | "PROP_HBO_MEM_MAX" |
-                     +---------+--------------------+
-
-   Describes the number of bytes that may be offloaded from the NCP to
-   the host.  Default value is zero, so this property must be set by the
-   host to a non-zero value before the NCP will begin offloading blocks.
-
-   This value is encoded as an unsigned 32-bit integer.
-
-   This property is only available if the "CAP_HBO" capability is
-   present in "PROP_CAPS".
-
-C.2.2.  PROP 11: PROP_HBO_BLOCK_MAX
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "S"
-
-                    +---------+----------------------+
-                    | Octets: |          2           |
-                    +---------+----------------------+
-                    | Fields: | "PROP_HBO_BLOCK_MAX" |
-                    +---------+----------------------+
-
-   Describes the number of blocks that may be offloaded from the NCP to
-   the host.  Default value is 32.  Setting this value to zero will
-   cause host block offload to be effectively disabled.
-
-   This value is encoded as an unsigned 16-bit integer.
-
-   This property is only available if the "CAP_HBO" capability is
-   present in "PROP_CAPS".
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 48]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
-Appendix D.  Feature: Jam Detection
-
-   Jamming detection is a feature that allows the NCP to report when it
-   detects high levels of interference that are characteristic of
-   intentional signal jamming.
-
-   The presence of this feature can be detected by checking for the
-   presence of the "CAP_JAM_DETECT" (value 6) capability in "PROP_CAPS".
-
-D.1.  Properties
-
-D.1.1.  PROP 4608: PROP_JAM_DETECT_ENABLE
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "b"
-   o  Default Value: false
-   o  REQUIRED for "CAP_JAM_DETECT"
-
-                  +---------+--------------------------+
-                  | Octets: |            1             |
-                  +---------+--------------------------+
-                  | Fields: | "PROP_JAM_DETECT_ENABLE" |
-                  +---------+--------------------------+
-
-   Indicates if jamming detection is enabled or disabled.  Set to true
-   to enable jamming detection.
-
-   This property is only available if the "CAP_JAM_DETECT" capability is
-   present in "PROP_CAPS".
-
-D.1.2.  PROP 4609: PROP_JAM_DETECTED
-
-   o  Type: Read-Only
-   o  Packed-Encoding: "b"
-   o  REQUIRED for "CAP_JAM_DETECT"
-
-                     +---------+---------------------+
-                     | Octets: |          1          |
-                     +---------+---------------------+
-                     | Fields: | "PROP_JAM_DETECTED" |
-                     +---------+---------------------+
-
-   Set to true if radio jamming is detected.  Set to false otherwise.
-
-   When jamming detection is enabled, changes to the value of this
-   property are emitted asynchronously via "CMD_PROP_VALUE_IS".
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 49]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
-   This property is only available if the "CAP_JAM_DETECT" capability is
-   present in "PROP_CAPS".
-
-D.1.3.  PROP 4610: PROP_JAM_DETECT_RSSI_THRESHOLD
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "c"
-   o  Units: dBm
-   o  Default Value: Implementation-specific
-   o  RECOMMENDED for "CAP_JAM_DETECT"
-
-   This parameter describes the threshold RSSI level (measured in dBm)
-   above which the jamming detection will consider the channel blocked.
-
-D.1.4.  PROP 4611: PROP_JAM_DETECT_WINDOW
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "c"
-   o  Units: Seconds (1-64)
-   o  Default Value: Implementation-specific
-   o  RECOMMENDED for "CAP_JAM_DETECT"
-
-   This parameter describes the window period for signal jamming
-   detection.
-
-D.1.5.  PROP 4612: PROP_JAM_DETECT_BUSY
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "i"
-   o  Units: Seconds (1-64)
-   o  Default Value: Implementation-specific
-   o  RECOMMENDED for "CAP_JAM_DETECT"
-
-   This parameter describes the number of aggregate seconds within the
-   detection window where the RSSI must be above
-   "PROP_JAM_DETECT_RSSI_THRESHOLD" to trigger detection.
-
-   The behavior of the jamming detection feature when
-   "PROP_JAM_DETECT_BUSY" is larger than "PROP_JAM_DETECT_WINDOW" is
-   undefined.
-
-Appendix E.  Technology: Thread
-
-   This section describes all of the properties and semantics required
-   for managing a Thread NCP.
-
-   Thread NCPs have the following requirements:
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 50]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
-   o  The property "PROP_INTERFACE_TYPE" must be 3.
-   o  The non-optional properties in the following sections MUST be
-      implemented: CORE, PHY, MAC, NET, and IPV6.
-
-   All serious implementations of an NCP SHOULD also support the network
-   save feature (See Appendix B).
-
-E.1.  Thread Capabilities
-
-   The Thread technology defines the following capabilities:
-
-   o  "CAP_NET_THREAD_1_0" - Indicates that the NCP implements v1.0 of
-      the Thread standard.
-   o  "CAP_NET_THREAD_1_1" - Indicates that the NCP implements v1.1 of
-      the Thread standard.
-
-E.2.  Thread Properties
-
-   Properties for Thread are allocated out of the "Tech" property
-   section (see Section 5.1).
-
-E.2.1.  PROP 80: PROP_THREAD_LEADER_ADDR
-
-   o  Type: Read-Only
-   o  Packed-Encoding: "6"
-
-   The IPv6 address of the leader.  (Note: May change to long and short
-   address of leader)
-
-E.2.2.  PROP 81: PROP_THREAD_PARENT
-
-   o  Type: Read-Only
-   o  Packed-Encoding: "ES"
-   o  LADDR, SADDR
-
-   The long address and short address of the parent of this node.
-
-E.2.3.  PROP 82: PROP_THREAD_CHILD_TABLE
-
-   o  Type: Read-Only
-   o  Packed-Encoding: "A(T(ES))"
-
-   Table containing the long and short addresses of all the children of
-   this node.
-
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 51]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
-E.2.4.  PROP 83: PROP_THREAD_LEADER_RID
-
-   o  Type: Read-Only
-   o  Packed-Encoding: "C"
-
-   The router-id of the current leader.
-
-E.2.5.  PROP 84: PROP_THREAD_LEADER_WEIGHT
-
-   o  Type: Read-Only
-   o  Packed-Encoding: "C"
-
-   The leader weight of the current leader.
-
-E.2.6.  PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "C"
-
-   The leader weight for this node.
-
-E.2.7.  PROP 86: PROP_THREAD_NETWORK_DATA
-
-   o  Type: Read-Only
-   o  Packed-Encoding: "D"
-
-E.2.8.  PROP 87: PROP_THREAD_NETWORK_DATA_VERSION
-
-   o  Type: Read-Only
-   o  Packed-Encoding: "S"
-
-E.2.9.  PROP 88: PROP_THREAD_STABLE_NETWORK_DATA
-
-   o  Type: Read-Only
-   o  Packed-Encoding: "D"
-
-E.2.10.  PROP 89: PROP_THREAD_STABLE_NETWORK_DATA_VERSION
-
-   o  Type: Read-Only
-   o  Packed-Encoding: "S"
-
-E.2.11.  PROP 90: PROP_THREAD_ON_MESH_NETS
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "A(T(6CbCb))"
-
-   Data per item is:
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 52]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
-   o  "6": IPv6 Prefix
-   o  "C": Prefix length, in bits
-   o  "b": Stable flag
-   o  "C": Thread flags
-   o  "b": "Is defined locally" flag.  Set if this network was locally
-      defined.  Assumed to be true for set, insert and replace.  Clear
-      if the on mesh network was defined by another node.
-
-E.2.12.  PROP 91: PROP_THREAD_LOCAL_ROUTES
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "A(T(6CbC))"
-
-   Data per item is:
-
-   o  "6": IPv6 Prefix
-   o  "C": Prefix length, in bits
-   o  "b": Stable flag
-   o  "C": Other flags
-
-E.2.13.  PROP 92: PROP_THREAD_ASSISTING_PORTS
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "A(S)"
-
-E.2.14.  PROP 93: PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "b"
-
-   Set to true before changing local net data.  Set to false when
-   finished.  This allows changes to be aggregated into single events.
-
-E.2.15.  PROP 94: PROP_THREAD_MODE
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "C"
-
-   This property contains the value of the mode TLV for this node.  The
-   meaning of the bits in this bitfield are defined by section 4.5.2 of
-   the Thread specification.
-
-E.2.16.  PROP 5376: PROP_THREAD_CHILD_TIMEOUT
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "L"
-
-   Used when operating in the Child role.
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 53]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
-E.2.17.  PROP 5377: PROP_THREAD_RLOC16
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "S"
-
-E.2.18.  PROP 5378: PROP_THREAD_ROUTER_UPGRADE_THRESHOLD
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "C"
-
-E.2.19.  PROP 5379: PROP_THREAD_CONTEXT_REUSE_DELAY
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "L"
-
-E.2.20.  PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "C"
-
-   Allows you to get or set the Thread "NETWORK_ID_TIMEOUT" constant, as
-   defined by the Thread specification.
-
-E.2.21.  PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS
-
-   o  Type: Read-Write/Write-Only
-   o  Packed-Encoding: "A(C)" (List of active thread router ids)
-
-   Note that some implementations may not support "CMD_GET_VALUE" router
-   ids, but may support "CMD_REMOVE_VALUE" when the node is a leader.
-
-E.2.22.  PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "b"
-
-   Allow the HOST to directly observe all IPv6 packets received by the
-   NCP, including ones sent to the RLOC16 address.
-
-   Default value is "false".
-
-E.2.23.  PROP 5383: SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "b"
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 54]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
-   Allow the HOST to indicate whether or not the router role is enabled.
-   If current role is a router, setting this property to "false" starts
-   a re-attach process as an end-device.
-
-E.2.24.  PROP 5384: PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "C"
-
-E.2.25.  PROP 5385: PROP_THREAD_ROUTER_SELECTION_JITTER
-
-   o  Type: Read-Write
-   o  Packed-Encoding: "C"
-
-   Specifies the self imposed random delay in seconds a REED waits
-   before registering to become an Active Router.
-
-E.2.26.  PROP 5386: PROP_THREAD_PREFERRED_ROUTER_ID
-
-   o  Type: Write-Only
-   o  Packed-Encoding: "C"
-
-   Specifies the preferred Router Id.  Upon becoming a router/leader the
-   node attempts to use this Router Id.  If the preferred Router Id is
-   not set or if it can not be used, a randomly generated router id is
-   picked.  This property can be set only when the device role is either
-   detached or disabled.
-
-E.2.27.  PROP 5387: SPINEL_PROP_THREAD_NEIGHBOR_TABLE
-
-   o  Type: Read-Only
-   o  Packed-Encoding: "A(T(ESLCcCbLL))"
-
-   Data per item is:
-
-   o  "E": Extended/long address
-   o  "S": RLOC16
-   o  "L": Age
-   o  "C": Link Quality In
-   o  "c": Average RSS
-   o  "C": Mode (bit-flags)
-   o  "b": "true" if neighbor is a child, "false" otherwise.
-   o  "L": Link Frame Counter
-   o  "L": MLE Frame Counter
-
-
-
-
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 55]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
-Appendix F.  Test Vectors
-
-F.1.  Test Vector: Packed Unsigned Integer
 
                  +---------------+-----------------------+
                  | Decimal Value | Packet Octet Encoding |
@@ -3101,9 +3153,9 @@ F.1.  Test Vector: Packed Unsigned Integer
                  |     2,097,151 | "FF FF 7F"            |
                  +---------------+-----------------------+
 
-   [CREF5]
+   [CREF4]
 
-F.2.  Test Vector: Reset Command
+B.2.  Test Vector: Reset Command
 
    o  IID: 0
    o  TID: 0
@@ -3113,7 +3165,7 @@ F.2.  Test Vector: Reset Command
 
                                    80 01
 
-F.3.  Test Vector: Reset Notification
+B.3.  Test Vector: Reset Notification
 
    o  IID: 0
    o  TID: 0
@@ -3125,23 +3177,23 @@ F.3.  Test Vector: Reset Notification
 
                                 80 06 00 72
 
-F.4.  Test Vector: Scan Beacon
+B.4.  Test Vector: Scan Beacon
 
    o  IID: 0
    o  TID: 0
    o  CMD: 7 ("CMD_VALUE_INSERTED")
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 56]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
    o  PROP: 51 ("PROP_MAC_SCAN_BEACON")
    o  VALUE: Structure, encoded as "CcT(ESSc.)T(iCUD.)."
 
       *  CHAN: 15
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 57]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
       *  RSSI: -60dBm
       *  MAC_DATA: (0D 00 B6 40 D4 8C E9 38 F9 52 FF FF D2 04 00)
 
@@ -3163,19 +3215,19 @@ Quattlebaum                Expires May 8, 2017                 [Page 56]
         13 00 03 20 73 70 69 6E 65 6C 00 08 00 DE AD 00 BE EF 00 CA
         FE
 
-F.5.  Test Vector: Inbound IPv6 Packet
+B.5.  Test Vector: Inbound IPv6 Packet
 
    CMD_VALUE_IS(PROP_STREAM_NET)
 
-   [CREF6]
+   [CREF5]
 
-F.6.  Test Vector: Outbound IPv6 Packet
+B.6.  Test Vector: Outbound IPv6 Packet
 
    CMD_VALUE_SET(PROP_STREAM_NET)
 
-   [CREF7]
+   [CREF6]
 
-F.7.  Test Vector: Fetch list of on-mesh networks
+B.7.  Test Vector: Fetch list of on-mesh networks
 
    o  IID: 0
    o  TID: 4
@@ -3189,12 +3241,16 @@ F.7.  Test Vector: Fetch list of on-mesh networks
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 57]
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 58]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
-F.8.  Test Vector: Returned list of on-mesh networks
+B.8.  Test Vector: Returned list of on-mesh networks
 
    o  IID: 0
    o  TID: 4
@@ -3215,7 +3271,7 @@ F.8.  Test Vector: Returned list of on-mesh networks
         00 40 01 ?? 13 00 20 01 0D B8 00 02 00 00 00 00 00 00 00 00
         00 00 40 00 ??
 
-F.9.  Test Vector: Adding an on-mesh network
+B.9.  Test Vector: Adding an on-mesh network
 
    o  IID: 0
    o  TID: 5
@@ -3234,9 +3290,9 @@ F.9.  Test Vector: Adding an on-mesh network
         85 03 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00 40
         01 ?? 01
 
-   [CREF8]
+   [CREF7]
 
-F.10.  Test Vector: Insertion notification of an on-mesh network
+B.10.  Test Vector: Insertion notification of an on-mesh network
 
    o  IID: 0
    o  TID: 5
@@ -3245,9 +3301,9 @@ F.10.  Test Vector: Insertion notification of an on-mesh network
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 58]
+Quattlebaum               Expires June 1, 2017                 [Page 59]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    o  VALUE: Structure, encoded as "6CbCb"
@@ -3263,9 +3319,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 58]
         85 07 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00 40
         01 ?? 01
 
-   [CREF9]
+   [CREF8]
 
-F.11.  Test Vector: Removing a local on-mesh network
+B.11.  Test Vector: Removing a local on-mesh network
 
    o  IID: 0
    o  TID: 6
@@ -3277,7 +3333,7 @@ F.11.  Test Vector: Removing a local on-mesh network
 
          86 05 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00
 
-F.12.  Test Vector: Removal notification of an on-mesh network
+B.12.  Test Vector: Removal notification of an on-mesh network
 
    o  IID: 0
    o  TID: 6
@@ -3289,11 +3345,11 @@ F.12.  Test Vector: Removal notification of an on-mesh network
 
          86 08 5A 20 01 0D B8 00 03 00 00 00 00 00 00 00 00 00 00
 
-Appendix G.  Example Sessions
+Appendix C.  Example Sessions
 
-G.1.  NCP Initialization
+C.1.  NCP Initialization
 
-   [CREF10]
+   [CREF9]
 
    Check the protocol version to see if it is supported:
 
@@ -3301,9 +3357,9 @@ G.1.  NCP Initialization
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 59]
+Quattlebaum               Expires June 1, 2017                 [Page 60]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    o  CMD_VALUE_IS:PROP_PROTOCOL_VERSION
@@ -3335,9 +3391,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 59]
 
    o  CMD_NET_RECALL
 
-G.2.  Attaching to a network
+C.2.  Attaching to a network
 
-   [CREF11]
+   [CREF10]
 
    We make the assumption that the NCP is not currently associated with
    a network.
@@ -3357,9 +3413,9 @@ G.2.  Attaching to a network
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 60]
+Quattlebaum               Expires June 1, 2017                 [Page 61]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    o  CMD_VALUE_SET:PROP_NET_KEY_SEQUENCE_COUNTER
@@ -3383,9 +3439,9 @@ Quattlebaum                Expires May 8, 2017                 [Page 60]
    o  CMD_VALUE_IS:PROP_NET_PARTITION_ID
    o  CMD_VALUE_IS:PROP_THREAD_ON_MESH_NETS
 
-G.3.  Successfully joining a pre-existing network
+C.3.  Successfully joining a pre-existing network
 
-   [CREF12]
+   [CREF11]
 
    This example session is identical to the above session up to the
    point where we set PROP_NET_IF_UP to true.  From there, the behavior
@@ -3413,12 +3469,12 @@ G.3.  Successfully joining a pre-existing network
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 61]
+Quattlebaum               Expires June 1, 2017                 [Page 62]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
-G.4.  Unsuccessfully joining a pre-existing network
+C.4.  Unsuccessfully joining a pre-existing network
 
    This example session is identical to the above session up to the
    point where we set PROP_NET_IF_UP to true.  From there, the behavior
@@ -3437,13 +3493,13 @@ G.4.  Unsuccessfully joining a pre-existing network
    o  CMD_VALUE_IS:PROP_LAST_STATUS:STATUS_JOIN_NO_PEERS
    o  CMD_VALUE_IS:PROP_NET_STACK_UP:FALSE
 
-G.5.  Detaching from a network
+C.5.  Detaching from a network
 
    TBD
 
-G.6.  Attaching to a saved network
+C.6.  Attaching to a saved network
 
-   [CREF13]
+   [CREF12]
 
    Recall the saved network if you haven't already done so:
 
@@ -3469,31 +3525,31 @@ G.6.  Attaching to a saved network
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 62]
+Quattlebaum               Expires June 1, 2017                 [Page 63]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
-G.7.  NCP Software Reset
+C.7.  NCP Software Reset
 
-   [CREF14]
+   [CREF13]
 
    o  CMD_RESET
    o  CMD_VALUE_IS:PROP_LAST_STATUS:STATUS_RESET_SOFTWARE
 
-   Then jump to Appendix G.1.
+   Then jump to Appendix C.1.
 
-G.8.  Adding an on-mesh prefix
-
-   TBD
-
-G.9.  Entering low-power modes
+C.8.  Adding an on-mesh prefix
 
    TBD
 
-G.10.  Sniffing raw packets
+C.9.  Entering low-power modes
 
-   [CREF15]
+   TBD
+
+C.10.  Sniffing raw packets
+
+   [CREF14]
 
    This assumes that the NCP has been initialized.
 
@@ -3525,9 +3581,9 @@ G.10.  Sniffing raw packets
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 63]
+Quattlebaum               Expires June 1, 2017                 [Page 64]
 
-                       Spinel Protocol (f9bf43254)         November 2016
+                       Spinel Protocol (05367497d)         November 2016
 
 
    o  CMD_VALUE_IS:PROP_STREAM_RAW:...
@@ -3540,7 +3596,18 @@ Quattlebaum                Expires May 8, 2017                 [Page 63]
    so that you can avoid receiving packets from other networks or that
    are destined for other nodes.
 
-Appendix H.  Glossary
+Appendix D.  Acknowledgments
+
+   Special thanks to Abtin Keshavarzian, Martin Turon, Arjuna
+   Sivasithambaresan and Jonathan Hui for their substantial
+   contributions and feedback related to this document.
+
+   [CREF15]
+
+   This document was prepared using mmark [5] by (Miek Gieben) and
+   xml2rfc (version 2) [6].
+
+Appendix E.  Glossary
 
    [CREF16]
 
@@ -3566,6 +3633,15 @@ Appendix H.  Glossary
       to the physical implementation and operation of a networking
       medium.
 
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 65]
+
+                       Spinel Protocol (05367497d)         November 2016
+
+
 Editorial Comments
 
 [CREF1] RQ: We may want to consider a license more appropriate for
@@ -3576,23 +3652,15 @@ Editorial Comments
         0 | 1 | 2 | 3 | 4 | 5 | 6 |
         7 | |---|---|---|---|---|---|---|---| | FLG || IID || TID ||||
 
-[CREF2] RQ: If I have missed anyone who has contributed to this
-        document, please let me know ASAP.
-
-
-
-Quattlebaum                Expires May 8, 2017                 [Page 64]
-
-                       Spinel Protocol (f9bf43254)         November 2016
-
-
-[CREF3] RQ: It may make sense to have a look at what Bluetooth HCI is
+[CREF2] RQ: It may make sense to have a look at what Bluetooth HCI is
         doing for native I^2C framing and go with that.
 
-[CREF4] RQ: It may make sense to have a look at what Bluetooth HCI is
+[CREF3] RQ: It may make sense to have a look at what Bluetooth HCI is
         doing for native USB framing and go with that.
 
-[CREF5] RQ: The PUI test-vector encodings need to be verified.
+[CREF4] RQ: The PUI test-vector encodings need to be verified.
+
+[CREF5] RQ: FIXME: This test vector is incomplete.
 
 [CREF6] RQ: FIXME: This test vector is incomplete.
 
@@ -3600,7 +3668,7 @@ Quattlebaum                Expires May 8, 2017                 [Page 64]
 
 [CREF8] RQ: FIXME: This test vector is incomplete.
 
-[CREF9] RQ: FIXME: This test vector is incomplete.
+[CREF9] RQ: FIXME: This example session is incomplete.
 
 [CREF10] RQ: FIXME: This example session is incomplete.
 
@@ -3612,11 +3680,23 @@ Quattlebaum                Expires May 8, 2017                 [Page 64]
 
 [CREF14] RQ: FIXME: This example session is incomplete.
 
-[CREF15] RQ: FIXME: This example session is incomplete.
+[CREF15] RQ: If I have missed anyone who has contributed to this
+         document, please let me know ASAP.
 
 [CREF16] RQ: Alphabetize before finalization.
 
 Author's Address
+
+
+
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 66]
+
+                       Spinel Protocol (05367497d)         November 2016
+
 
    Robert S. Quattlebaum
    Nest Labs
@@ -3637,4 +3717,36 @@ Author's Address
 
 
 
-Quattlebaum                Expires May 8, 2017                 [Page 65]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Quattlebaum               Expires June 1, 2017                 [Page 67]

--- a/doc/spinel-protocol-src/draft-spinel-protocol.md.in
+++ b/doc/spinel-protocol-src/draft-spinel-protocol.md.in
@@ -312,7 +312,25 @@ is meaningless.
 
 {{spinel-status-codes.md}}
 
+{{spinel-tech-thread.md}}
+
+{{spinel-feature-network-save.md}}
+
+{{spinel-feature-host-buffer-offload.md}}
+
+{{spinel-feature-jam-detect.md}}
+
+{{spinel-feature-gpio.md}}
+
 {{spinel-security-considerations.md}}
+
+{backmatter}
+
+{{spinel-framing.md}}
+
+{{spinel-test-vectors.md}}
+
+{{spinel-example-sessions.md}}
 
 # Acknowledgments #
 
@@ -327,22 +345,6 @@ to this document.
 
 This document was prepared using [mmark](https://github.com/miekg/mmark)
 by (Miek Gieben) and [xml2rfc (version 2)](http://xml2rfc.ietf.org/).
-
-{backmatter}
-
-{{spinel-framing.md}}
-
-{{spinel-feature-network-save.md}}
-
-{{spinel-feature-host-buffer-offload.md}}
-
-{{spinel-feature-jam-detect.md}}
-
-{{spinel-tech-thread.md}}
-
-{{spinel-test-vectors.md}}
-
-{{spinel-example-sessions.md}}
 
 # Glossary #
 

--- a/doc/spinel-protocol-src/spinel-feature-gpio.md
+++ b/doc/spinel-protocol-src/spinel-feature-gpio.md
@@ -1,0 +1,47 @@
+# Feature: Basic GPIO Access
+
+The length of the data associated with these properties depends on the
+number of GPIOs. If you have 10 GPIOs, you'd have two bytes. You determine
+the number of GPIOs available by examining PROP_GPIO_AVAILABLE, described
+below. This API isn't intended to support every possible GPIO state, it is
+intended for basic reading and writing.
+
+## Properties
+
+### PROP 4096: PROP_GPIO_AVAILABLE
+
+* Type: Read-only
+
+Contains a bit field identifying which GPIOs are supported. Cleared bits
+are not supported. Set bits are supported.
+
+### PROP 4097: PROP_GPIO_DIRECTION
+
+* Type: Read-only (Optionally read/write)
+
+Contains a bit field identifying which GPIOs are configured as outputs.
+Cleared bits are inputs. Set bits are outputs.
+
+### PROP 4098: PROP_GPIO_STATE
+
+* Type: Read-Write
+
+Contains a bit field identifying the state of the GPIOs. For GPIOs
+configured as inputs, this is the read logic level. For GPIOs configured
+as outputs, this is the logic level of the output.
+
+### PROP 4099: PROP_GPIO_STATE_SET
+
+* Type: Write-only
+
+Allows for the state of various output GPIOs to be set without affecting
+other GPIO states. Contains a bit field identifying the output GPIOs that
+should have their state set to 1.
+
+### PROP 4100: PROP_GPIO_STATE_CLEAR
+
+* Type: Write-only
+
+Allows for the state of various output GPIOs to be cleared without affecting
+other GPIO states. Contains a bit field identifying the output GPIOs that
+should have their state cleared to 0.

--- a/doc/spinel-protocol-src/spinel-prop-core.md
+++ b/doc/spinel-protocol-src/spinel-prop-core.md
@@ -130,6 +130,7 @@ Currently defined values are:
  * 5: `CAP_COUNTERS`
  * 6: `CAP_JAM_DETECT`: Jamming detection. See (#feature-jam-detect)
  * 7: `CAP_PEEK_POKE`: PEEK/POKE debugging commands.
+ * 8: `CAP_WRITABLE_RAW_STREAM`: `PROP_STREAM_RAW` is writable.
  * 16: `CAP_802_15_4_2003`
  * 17: `CAP_802_15_4_2006`
  * 18: `CAP_802_15_4_2011`
@@ -273,8 +274,13 @@ fetch the value of this property. To receive traffic, you wait for
 `CMD_PROP_VALUE_IS` commands with this property id from the NCP.
 
 Implementations may OPTIONALLY support the ability to transmit arbitrary
-raw packets. If this capability is supported, you may call `CMD_PROP_VALUE_SET`
-on this property with the value of the raw packet.
+raw packets. Support for this feature is indicated by the presence of the
+`CAP_WRITABLE_RAW_STREAM` capability.
+
+If the capability `CAP_WRITABLE_RAW_STREAM` is set, then packets written
+to this stream with `CMD_PROP_VALUE_SET` will be sent out over the radio.
+This allows the caller to use the radio directly, with the stack being
+implemented on the host instead of the NCP.
 
 #### Frame Metadata Format {#frame-metadata-format}
 

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -291,6 +291,8 @@ enum
 
     SPINEL_CAP_PEEK_POKE             = 7,
 
+    SPINEL_CAP_WRITABLE_RAW_STREAM   = 8,
+
     SPINEL_CAP_802_15_4__BEGIN        = 16,
     SPINEL_CAP_802_15_4_2003          = (SPINEL_CAP_802_15_4__BEGIN + 0),
     SPINEL_CAP_802_15_4_2006          = (SPINEL_CAP_802_15_4__BEGIN + 1),
@@ -345,6 +347,58 @@ typedef enum
     SPINEL_PROP_LOCK                    = 9,        ///< PropLock [b]
     SPINEL_PROP_HBO_MEM_MAX             = 10,       ///< Max offload mem [S]
     SPINEL_PROP_HBO_BLOCK_MAX           = 11,       ///< Max offload block [S]
+
+    SPINEL_PROP_BASE_EXT__BEGIN         = 0x1000,
+
+    /// Available GPIO Bitmask
+    /** Format: `D`
+     *  Type: Read-Only
+     *
+     * Contains a bit field identifying which GPIOs are supported. Cleared bits
+     * are not supported. Set bits are supported.
+     */
+    SPINEL_PROP_GPIO_AVAILABLE          = SPINEL_PROP_BASE_EXT__BEGIN + 0,
+
+    /// GPIO Direction Bitmask
+    /** Format: `D`
+     *  Type: Read-only (Optionally read/write)
+     *
+     * Contains a bit field identifying which GPIOs are configured as outputs.
+     * Cleared bits are inputs. Set bits are outputs.
+     */
+    SPINEL_PROP_GPIO_DIRECTION          = SPINEL_PROP_BASE_EXT__BEGIN + 1,
+
+    /// GPIO State Bitmask
+    /** Format: `D`
+     *  Type: Read-Write
+     *
+     * Contains a bit field identifying the state of the GPIOs. For GPIOs
+     * configured as inputs, this is the read logic level. For GPIOs configured
+     * as outputs, this is the logic level of the output.
+     */
+    SPINEL_PROP_GPIO_STATE              = SPINEL_PROP_BASE_EXT__BEGIN + 2,
+
+    /// GPIO State Set-Only Bitmask
+    /** Format: `D`
+     *  Type: Write-Only
+     *
+     * Allows for the state of various output GPIOs to be set without affecting
+     * other GPIO states. Contains a bit field identifying the output GPIOs that
+     * should have their state set to 1.
+     */
+    SPINEL_PROP_GPIO_STATE_SET          = SPINEL_PROP_BASE_EXT__BEGIN + 3,
+
+    /// GPIO State Clear-Only Bitmask
+    /** Format: `D`
+     *  Type: Write-Only
+     *
+     * Allows for the state of various output GPIOs to be cleared without affecting
+     * other GPIO states. Contains a bit field identifying the output GPIOs that
+     * should have their state cleared to 0.
+     */
+    SPINEL_PROP_GPIO_STATE_CLEAR        = SPINEL_PROP_BASE_EXT__BEGIN + 4,
+
+    SPINEL_PROP_BASE_EXT__END           = 0x1100,
 
     SPINEL_PROP_PHY__BEGIN              = 0x20,
     SPINEL_PROP_PHY_ENABLED             = SPINEL_PROP_PHY__BEGIN + 0, ///< [b]


### PR DESCRIPTION
Also added `CAP_WRITABLE_RAW_STREAM`, to indicate that the raw stream is writable.