### PR TITLE
Some fixes to reattach process

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2486,6 +2486,12 @@ ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::Messa
         }
     }
 
+    // clear local Pending Dataset if device succeed to reattach using stored Pending Dataset
+    if (mReattachState == kReattachPending)
+    {
+        mNetif.GetPendingDataset().GetLocal().Clear(true);
+    }
+
     // Pending Timestamp
     if (Tlv::GetTlv(aMessage, Tlv::kPendingTimestamp, sizeof(pendingTimestamp), pendingTimestamp) == kThreadError_None)
     {
@@ -2506,7 +2512,7 @@ ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::Messa
     }
     else
     {
-        mNetif.GetPendingDataset().Clear(true);
+        mNetif.GetPendingDataset().Clear(false);
     }
 
     // Parent Attach Success

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1658,7 +1658,15 @@ ThreadError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::M
         break;
     }
 
-    VerifyOrExit((child = FindChild(macAddr)) != NULL || (child = NewChild()) != NULL, ;);
+    if ((child = FindChild(macAddr)) != NULL)
+    {
+        RemoveNeighbor(*child);
+    }
+    else
+    {
+        VerifyOrExit((child = NewChild()) != NULL, ;);
+    }
+
     memset(child, 0, sizeof(*child));
 
     // Challenge
@@ -2993,6 +3001,7 @@ ThreadError MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
     case kDeviceStateLeader:
         if (aNeighbor.mState == Neighbor::kStateValid && !IsActiveRouter(aNeighbor.mValid.mRloc16))
         {
+            aNeighbor.mState = Neighbor::kStateInvalid;
             mMesh.UpdateIndirectMessages();
             mNetif.SetStateChangedFlags(OT_THREAD_CHILD_REMOVED);
             mNetworkData.SendServerDataNotification(aNeighbor.mValid.mRloc16);


### PR DESCRIPTION
* Remove existing child if it tries to reattach.

* Ensure to dequeue the pending messages to the removed child.

* Clear local Pending Dataset if device succeed to reattach using stored Pending Dataset.