### PR TITLE
Fix otNetifAddress declaration to work between C & C++

### DIFF
--- a/etc/visual-studio/UnitTests.vcxproj
+++ b/etc/visual-studio/UnitTests.vcxproj
@@ -72,6 +72,7 @@
     <ClCompile Include="..\..\tests\unit\test_ncp_buffer.cpp" />
     <ClCompile Include="..\..\tests\unit\test_platform.cpp" />
     <ClCompile Include="..\..\tests\unit\test_timer.cpp" />
+    <ClCompile Include="..\..\tests\unit\test_toolchain_c.c" />
     <ClCompile Include="..\..\tests\unit\test_toolchain.cpp" />
     <ClCompile Include="..\..\tests\unit\test_util.cpp" />
     <ClCompile Include="..\..\tests\unit\test_windows.cpp" />

--- a/examples/drivers/windows/otLwf/radio.c
+++ b/examples/drivers/windows/otLwf/radio.c
@@ -245,7 +245,7 @@ void otPlatRadioSetShortAddress(_In_ otInstance *otCtx, uint16_t address)
     }
 }
 
-void otPlatRadioSetPromiscuous(_In_ otInstance *otCtx, int aEnable)
+void otPlatRadioSetPromiscuous(_In_ otInstance *otCtx, bool aEnable)
 {
     NT_ASSERT(otCtx);
     PMS_FILTER pFilter = otCtxToFilter(otCtx);
@@ -444,7 +444,7 @@ otRadioCaps otPlatRadioGetCaps(_In_ otInstance *otCtx)
     return otCtxToFilter(otCtx)->otRadioCapabilities;
 }
 
-int otPlatRadioGetPromiscuous(_In_ otInstance *otCtx)
+bool otPlatRadioGetPromiscuous(_In_ otInstance *otCtx)
 {
     NT_ASSERT(otCtx);
     PMS_FILTER pFilter = otCtxToFilter(otCtx);

--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -895,19 +895,16 @@ typedef struct otBufferInfo
  * This structure represents an IPv6 network interface unicast address.
  *
  */
-OT_TOOL_PACKED_BEGIN
-struct otNetifAddress
+typedef struct otNetifAddress
 {
     otIp6Address           mAddress;                 ///< The IPv6 unicast address.
     uint32_t               mPreferredLifetime;       ///< The Preferred Lifetime.
     uint32_t               mValidLifetime;           ///< The Valid lifetime.
     uint8_t                mPrefixLength;            ///< The Prefix length.
-    uint32_t               mScopeOverride : 4;       ///< The IPv6 scope of this address.
-    uint32_t               mScopeOverrideValid : 1;  ///< TRUE if the mScopeOverride value is valid, FALSE othewrise.
+    unsigned int           mScopeOverride : 4;       ///< The IPv6 scope of this address.
+    bool                   mScopeOverrideValid : 1;  ///< TRUE if the mScopeOverride value is valid, FALSE othewrise.
     struct otNetifAddress *mNext;                    ///< A pointer to the next network interface address.
-} OT_TOOL_PACKED_END;
-
-typedef struct otNetifAddress otNetifAddress;
+} otNetifAddress;
 
 /**
  * This structure represents an IPv6 network interface multicast address.

--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -48,6 +48,7 @@ extern "C" {
 #endif
 
 #ifdef _WIN32
+#pragma warning(disable:4214)  // nonstandard extension used: bit field types other than int
 #ifdef _KERNEL_MODE
 #include <ntdef.h>
 #else

--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -895,16 +895,19 @@ typedef struct otBufferInfo
  * This structure represents an IPv6 network interface unicast address.
  *
  */
-typedef struct otNetifAddress
+OT_TOOL_PACKED_BEGIN
+struct otNetifAddress
 {
     otIp6Address           mAddress;                 ///< The IPv6 unicast address.
     uint32_t               mPreferredLifetime;       ///< The Preferred Lifetime.
     uint32_t               mValidLifetime;           ///< The Valid lifetime.
     uint8_t                mPrefixLength;            ///< The Prefix length.
-    unsigned int           mScopeOverride : 4;       ///< The IPv6 scope of this address.
-    bool                   mScopeOverrideValid : 1;  ///< TRUE if the mScopeOverride value is valid, FALSE othewrise.
+    uint32_t               mScopeOverride : 4;       ///< The IPv6 scope of this address.
+    uint32_t               mScopeOverrideValid : 1;  ///< TRUE if the mScopeOverride value is valid, FALSE othewrise.
     struct otNetifAddress *mNext;                    ///< A pointer to the next network interface address.
-} otNetifAddress;
+} OT_TOOL_PACKED_END;
+
+typedef struct otNetifAddress otNetifAddress;
 
 /**
  * This structure represents an IPv6 network interface multicast address.

--- a/src/missing/stdbool/stdbool.h
+++ b/src/missing/stdbool/stdbool.h
@@ -31,7 +31,7 @@
 
 #ifndef __cplusplus
 
-typedef int bool;
+typedef _Bool bool;
 #define false 0
 #define true 1
 

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -145,7 +145,7 @@ test_timer_LDADD             = $(COMMON_LDADD)
 test_timer_SOURCES           = test_platform.cpp test_timer.cpp
 
 test_toolchain_LDADD         = $(COMMON_LDADD)
-test_toolchain_SOURCES       = test_platform.cpp test_toolchain.cpp
+test_toolchain_SOURCES       = test_platform.cpp test_toolchain.cpp test_toolchain_c.c
 
 if OPENTHREAD_ENABLE_DIAG
 test_diag_LDADD              = $(top_builddir)/src/diag/libopenthread-diag.a                  \

--- a/tests/unit/test_toolchain.cpp
+++ b/tests/unit/test_toolchain.cpp
@@ -33,7 +33,8 @@
 #include "test_util.h"
 
 extern "C" {
-    void test_addr_size_c();
+    uint32_t otNetifAddress_Size_c();
+    uint32_t otNetifAddress_offset_mNext_c();
     otNetifAddress CreateNetif_c();
 }
 
@@ -98,15 +99,11 @@ void test_packed_enum()
     VerifyOrQuit(neighbor.mState == Thread::Neighbor::kStateValid, "Toolchain::OT_TOOL_PACKED failed 4\n");
 }
 
-void test_addr_size_cpp()
+void test_addr_sizes()
 {
-#ifdef _WIN64
-    CompileTimeAssert(offsetof(otNetifAddress, mNext) == 40, "mNext should offset by 40 bytes from front");
-    CompileTimeAssert(sizeof(otNetifAddress) == 48, "otNetifAddress should be 48 (unpacked) bytes");
-#else
-    CompileTimeAssert(offsetof(otNetifAddress, mNext) == 36, "mNext should offset by 36 bytes from front");
-    CompileTimeAssert(sizeof(otNetifAddress) == 40, "otNetifAddress should be 40 (unpacked) bytes");
-#endif
+    VerifyOrQuit(offsetof(otNetifAddress, mNext) == otNetifAddress_offset_mNext_c(),
+                 "mNext should offset the same in C & C++");
+    VerifyOrQuit(sizeof(otNetifAddress) == otNetifAddress_Size_c(), "otNetifAddress should the same in C & C++");
 }
 
 void test_addr_bitfield()
@@ -120,8 +117,7 @@ void TestToolchain(void)
     test_packed2();
     test_packed_union();
     test_packed_enum();
-    test_addr_size_c();
-    test_addr_size_cpp();
+    test_addr_sizes();
     test_addr_bitfield();
 }
 

--- a/tests/unit/test_toolchain.cpp
+++ b/tests/unit/test_toolchain.cpp
@@ -33,7 +33,8 @@
 #include "test_util.h"
 
 extern "C" {
-void test_addr_size_c();
+    void test_addr_size_c();
+    otNetifAddress CreateNetif_c();
 }
 
 void test_packed1()
@@ -108,6 +109,11 @@ void test_addr_size_cpp()
 #endif
 }
 
+void test_addr_bitfield()
+{
+    VerifyOrQuit(CreateNetif_c().mScopeOverrideValid == true, "Toolchain::test_addr_size_cpp\n");
+}
+
 void TestToolchain(void)
 {
     test_packed1();
@@ -116,6 +122,7 @@ void TestToolchain(void)
     test_packed_enum();
     test_addr_size_c();
     test_addr_size_cpp();
+    test_addr_bitfield();
 }
 
 #ifdef ENABLE_TEST_MAIN

--- a/tests/unit/test_toolchain.cpp
+++ b/tests/unit/test_toolchain.cpp
@@ -100,7 +100,7 @@ void test_packed_enum()
 
 void test_addr_size_cpp()
 {
-#ifdef X64
+#ifdef _WIN64
     CompileTimeAssert(offsetof(otNetifAddress, mNext) == 40, "mNext should offset by 40 bytes from front");
     CompileTimeAssert(sizeof(otNetifAddress) == 48, "otNetifAddress should be 48 (unpacked) bytes");
 #else

--- a/tests/unit/test_toolchain_c.c
+++ b/tests/unit/test_toolchain_c.c
@@ -41,3 +41,11 @@ void test_addr_size_c()
     CompileTimeAssert(sizeof(otNetifAddress) == 40, "otNetifAddress should be 40 (unpacked) bytes");
 #endif
 }
+
+otNetifAddress CreateNetif_c()
+{
+    otNetifAddress addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.mScopeOverrideValid = true;
+    return addr;
+}

--- a/tests/unit/test_toolchain_c.c
+++ b/tests/unit/test_toolchain_c.c
@@ -31,15 +31,14 @@
 #include <platform/toolchain.h>
 #include "test_util.h"
 
-void test_addr_size_c()
+uint32_t otNetifAddress_Size_c()
 {
-#ifdef _WIN64
-    CompileTimeAssert(offsetof(otNetifAddress, mNext) == 40, "mNext should offset by 40 bytes from front");
-    CompileTimeAssert(sizeof(otNetifAddress) == 48, "otNetifAddress should be 48 (unpacked) bytes");
-#else
-    CompileTimeAssert(offsetof(otNetifAddress, mNext) == 36, "mNext should offset by 36 bytes from front");
-    CompileTimeAssert(sizeof(otNetifAddress) == 40, "otNetifAddress should be 40 (unpacked) bytes");
-#endif
+    return sizeof(otNetifAddress);
+}
+
+uint32_t otNetifAddress_offset_mNext_c()
+{
+    return offsetof(otNetifAddress, mNext);
 }
 
 otNetifAddress CreateNetif_c()

--- a/tests/unit/test_toolchain_c.c
+++ b/tests/unit/test_toolchain_c.c
@@ -29,75 +29,9 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <platform/toolchain.h>
-#include <thread/topology.hpp>
 #include "test_util.h"
 
-extern "C" {
-void test_addr_size_c();
-}
-
-void test_packed1()
-{
-    OT_TOOL_PACKED_BEGIN
-    struct packed_t
-    {
-        uint8_t  mByte;
-        uint32_t mWord;
-        uint16_t mShort;
-    } OT_TOOL_PACKED_END;
-
-    CompileTimeAssert(sizeof(packed_t) == 7, "packed_t should be packed to 7 bytes");
-
-    VerifyOrQuit(sizeof(packed_t) == 7, "Toolchain::OT_TOOL_PACKED failed 1\n");
-}
-
-void test_packed2()
-{
-    OT_TOOL_PACKED_BEGIN
-    struct packed_t
-    {
-        uint8_t mBytes[3];
-        uint8_t mByte;
-    } OT_TOOL_PACKED_END;
-
-    CompileTimeAssert(sizeof(packed_t) == 4, "packed_t should be packed to 4 bytes");
-
-    VerifyOrQuit(sizeof(packed_t) == 4, "Toolchain::OT_TOOL_PACKED failed 2\n");
-}
-
-void test_packed_union()
-{
-    typedef struct
-    {
-        uint16_t mField;
-    } nested_t;
-
-    OT_TOOL_PACKED_BEGIN
-    struct packed_t
-    {
-        uint8_t mBytes[3];
-        union
-        {
-            nested_t mNestedStruct;
-            uint8_t  mByte;
-        } OT_TOOL_PACKED_FIELD;
-    } OT_TOOL_PACKED_END;
-
-    CompileTimeAssert(sizeof(packed_t) == 5, "packed_t should be packed to 5 bytes");
-
-    VerifyOrQuit(sizeof(packed_t) == 5, "Toolchain::OT_TOOL_PACKED failed 3\n");
-}
-
-void test_packed_enum()
-{
-    Thread::Neighbor neighbor;
-    neighbor.mState = Thread::Neighbor::kStateValid;
-
-    // Make sure that when we read the 3 bit field it is read as unsigned, so it return '4'
-    VerifyOrQuit(neighbor.mState == Thread::Neighbor::kStateValid, "Toolchain::OT_TOOL_PACKED failed 4\n");
-}
-
-void test_addr_size_cpp()
+void test_addr_size_c()
 {
 #ifdef X64
     CompileTimeAssert(offsetof(otNetifAddress, mNext) == 40, "mNext should offset by 40 bytes from front");
@@ -107,22 +41,3 @@ void test_addr_size_cpp()
     CompileTimeAssert(sizeof(otNetifAddress) == 40, "otNetifAddress should be 40 (unpacked) bytes");
 #endif
 }
-
-void TestToolchain(void)
-{
-    test_packed1();
-    test_packed2();
-    test_packed_union();
-    test_packed_enum();
-    test_addr_size_c();
-    test_addr_size_cpp();
-}
-
-#ifdef ENABLE_TEST_MAIN
-int main(void)
-{
-    TestToolchain();
-    printf("All tests passed\n");
-    return 0;
-}
-#endif

--- a/tests/unit/test_toolchain_c.c
+++ b/tests/unit/test_toolchain_c.c
@@ -27,7 +27,9 @@
  */
 
 #include <stdio.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 #include <platform/toolchain.h>
 #include "test_util.h"
 

--- a/tests/unit/test_toolchain_c.c
+++ b/tests/unit/test_toolchain_c.c
@@ -33,7 +33,7 @@
 
 void test_addr_size_c()
 {
-#ifdef X64
+#ifdef _WIN64
     CompileTimeAssert(offsetof(otNetifAddress, mNext) == 40, "mNext should offset by 40 bytes from front");
     CompileTimeAssert(sizeof(otNetifAddress) == 48, "otNetifAddress should be 48 (unpacked) bytes");
 #else

--- a/tests/unit/test_windows.cpp
+++ b/tests/unit/test_windows.cpp
@@ -80,6 +80,7 @@ void test_packed1();
 void test_packed2();
 void test_packed_union();
 void test_packed_enum();
+void test_addr_bitfield();
 
 // test_fuzz.cpp
 void TestFuzz(uint32_t aSeconds);
@@ -155,6 +156,7 @@ namespace Thread
         TEST_METHOD(test_packed2) { ::test_packed2(); }
         TEST_METHOD(test_packed_union) { ::test_packed_union(); }
         TEST_METHOD(test_packed_enum) { ::test_packed_enum(); }
+        TEST_METHOD(test_addr_bitfield) { ::test_addr_bitfield(); }
 
         // test_settings.cpp
         TEST_METHOD(RunTestFuzz) { ::TestFuzz(30); }

--- a/tests/unit/test_windows.cpp
+++ b/tests/unit/test_windows.cpp
@@ -80,6 +80,7 @@ void test_packed1();
 void test_packed2();
 void test_packed_union();
 void test_packed_enum();
+void test_addr_sizes();
 void test_addr_bitfield();
 
 // test_fuzz.cpp
@@ -156,6 +157,7 @@ namespace Thread
         TEST_METHOD(test_packed2) { ::test_packed2(); }
         TEST_METHOD(test_packed_union) { ::test_packed_union(); }
         TEST_METHOD(test_packed_enum) { ::test_packed_enum(); }
+        TEST_METHOD(test_addr_sizes) { ::test_addr_sizes(); }
         TEST_METHOD(test_addr_bitfield) { ::test_addr_bitfield(); }
 
         // test_settings.cpp


### PR DESCRIPTION
The padding and field sizes (for bool) were different between C & C++. This gets them lined up.