### PR TITLE
Move tunnel interface dependency from a codec to spinel-cli. Issue: #960

### DIFF
--- a/tools/spinel-cli/spinel/codec.py
+++ b/tools/spinel-cli/spinel/codec.py
@@ -57,7 +57,7 @@ from spinel.const import kThread
 from spinel.const import SPINEL
 from spinel.const import SPINEL_LAST_STATUS_MAP
 from spinel.hdlc import Hdlc
-from spinel.tun import TunInterface
+
 
 
 FEATURE_USE_HDLC = 1
@@ -724,8 +724,6 @@ class WpanApi(SpinelCodec):
     """ Helper class to format wpan command packets """
 
     def __init__(self, stream, nodeid, use_hdlc=FEATURE_USE_HDLC):
-
-        self.tun_if = None
         self.stream = stream
         self.nodeid = nodeid
 
@@ -858,17 +856,6 @@ class WpanApi(SpinelCodec):
             item = None
 
         return item
-
-    def if_up(self, nodeid='1'):
-        if os.geteuid() == 0:
-            self.tun_if = TunInterface(nodeid)
-        else:
-            print("Warning: superuser required to start tun interface.")
-
-    def if_down(self):
-        if self.tun_if:
-            self.tun_if.close()
-        self.tun_if = None
 
     def ip_send(self, pkt):
         pay = self.encode_i(SPINEL.PROP_STREAM_NET)

--- a/tools/spinel-cli/spinel/tun.py
+++ b/tools/spinel-cli/spinel/tun.py
@@ -31,12 +31,14 @@ from __future__ import print_function
 
 import os
 import sys
-import fcntl
 import struct
 import logging
 import threading
 import traceback
 import subprocess
+
+if sys.platform == "linux" or sys.platform == "linux2":
+    import fcntl
 
 from select import select
 
@@ -63,6 +65,8 @@ class TunInterface(object):
             self.__init_linux()
         elif platform == "darwin":
             self.__init_osx()
+        else:
+            raise RuntimeError("Platform \"{}\" is not supported.".format(platform))
 
         self.ifconfig("up")
         #self.ifconfig("inet6 add fd00::1/64")


### PR DESCRIPTION
There was problem with import codec.py on the Windows platform (issue #960). I've moved tunnel interface dependency from the codec.py to the spinel-cli.py. Currently it is possible to use spinel codec on a not Posix OS.