### PR TITLE
Update routing data on child migration.

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2037,6 +2037,7 @@ ThreadError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::Message
     Neighbor *neighbor;
     SourceAddressTlv sourceAddress;
     LeaderDataTlv leaderData;
+    RouteTlv route;
     uint8_t tlvs[] = {Tlv::kNetworkData};
 
     // Source Address
@@ -2075,6 +2076,15 @@ ThreadError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::Message
              leaderData.GetLeaderRouterId() != GetLeaderId()))
         {
             SetLeaderData(leaderData.GetPartitionId(), leaderData.GetWeighting(), leaderData.GetLeaderRouterId());
+
+            if ((mDeviceMode & ModeTlv::kModeFFD) &&
+                (Tlv::GetTlv(aMessage, Tlv::kRoute, sizeof(route), route) == kThreadError_None) &&
+                route.IsValid())
+            {
+                // Overwrite Route Data
+                mMleRouter.ProcessRouteTlv(route);
+            }
+
             mRetrieveNewNetworkData = true;
         }
 


### PR DESCRIPTION
This PR fixes issue rasied in #1003. 

When a child decides to swap partition basing on MLE Advertisement from a parent, it updates also routing data, to prevent situation when we end up with higher Router ID Sequence number from previous partition.