### PR TITLE
Pass Ip6::MessageInfo in CoAP response handler.

### DIFF
--- a/include/openthread-coap.h
+++ b/include/openthread-coap.h
@@ -129,10 +129,11 @@ typedef struct otCoapHeader
 /**
  * This function pointer is called when a CoAP response is received or on the request timeout.
  *
- * @param[in]  aContext  A pointer to application-specific context.
- * @param[in[  aHeader   A pointer to the received CoAP header. NULL if no response was received.
- * @param[in]  aMessage  A pointer to the message buffer containing the response. NULL if no response was received.
- * @param[in]  aResult   A result of the CoAP transaction.
+ * @param[in]  aContext      A pointer to application-specific context.
+ * @param[in[  aHeader       A pointer to the received CoAP header. NULL if no response was received.
+ * @param[in]  aMessage      A pointer to the message buffer containing the response. NULL if no response was received.
+ * @param[in]  aMessageInfo  A pointer to the message info for @p aMessage. NULL if no response was received.
+ * @param[in]  aResult       A result of the CoAP transaction.
  *
  * @retval  kThreadError_None             A response was received successfully.
  * @retval  kThreadError_Abort            A CoAP transaction was reseted by peer.
@@ -140,7 +141,7 @@ typedef struct otCoapHeader
  *
  */
 typedef void (*otCoapResponseHandler)(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
-                                      ThreadError aResult);
+                                      const otMessageInfo *aMessageInfo, ThreadError aResult);
 
 /**
  * This function pointer is called when a CoAP request with a given Uri-Path is received.

--- a/src/core/coap/coap_client.hpp
+++ b/src/core/coap/coap_client.hpp
@@ -250,8 +250,8 @@ private:
     void DequeueMessage(Message &aMessage);
     Message *FindRelatedRequest(const Header &aResponseHeader, const Ip6::MessageInfo &aMessageInfo,
                                 Header &aRequestHeader, RequestMetadata &aRequestMetadata);
-    void FinalizeCoapTransaction(Message &aRequest, const RequestMetadata &aRequestMetadata,
-                                 Header *aResponseHeader, Message *aResponse, ThreadError aResult);
+    void FinalizeCoapTransaction(Message &aRequest, const RequestMetadata &aRequestMetadata, Header *aResponseHeader,
+                                 Message *aResponse, const Ip6::MessageInfo *aMessageInfo, ThreadError aResult);
 
     ThreadError SendCopy(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     void SendEmptyMessage(const Ip6::Address &aAddress, uint16_t aPort, uint16_t aMessageId, Header::Type aType);

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -357,15 +357,18 @@ exit:
 }
 
 void Commissioner::HandleMgmtCommissionerGetResponse(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
-                                                     ThreadError aResult)
+                                                     const otMessageInfo *aMessageInfo, ThreadError aResult)
 {
     static_cast<Commissioner *>(aContext)->HandleMgmtCommissisonerGetResponse(
-        static_cast<Coap::Header *>(aHeader), static_cast<Message *>(aMessage), aResult);
+        static_cast<Coap::Header *>(aHeader), static_cast<Message *>(aMessage),
+        static_cast<const Ip6::MessageInfo *>(aMessageInfo), aResult);
 }
 
-void Commissioner::HandleMgmtCommissisonerGetResponse(Coap::Header *aHeader, Message *aMessage, ThreadError aResult)
+void Commissioner::HandleMgmtCommissisonerGetResponse(Coap::Header *aHeader, Message *aMessage,
+                                                      const Ip6::MessageInfo *aMessageInfo, ThreadError aResult)
 {
     (void) aMessage;
+    (void) aMessageInfo;
 
     otLogFuncEntry();
 
@@ -450,15 +453,18 @@ exit:
 }
 
 void Commissioner::HandleMgmtCommissionerSetResponse(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
-                                                     ThreadError aResult)
+                                                     const otMessageInfo *aMessageInfo, ThreadError aResult)
 {
     static_cast<Commissioner *>(aContext)->HandleMgmtCommissisonerSetResponse(
-        static_cast<Coap::Header *>(aHeader), static_cast<Message *>(aMessage), aResult);
+        static_cast<Coap::Header *>(aHeader), static_cast<Message *>(aMessage),
+        static_cast<const Ip6::MessageInfo *>(aMessageInfo), aResult);
 }
 
-void Commissioner::HandleMgmtCommissisonerSetResponse(Coap::Header *aHeader, Message *aMessage, ThreadError aResult)
+void Commissioner::HandleMgmtCommissisonerSetResponse(Coap::Header *aHeader, Message *aMessage,
+                                                      const Ip6::MessageInfo *aMessageInfo, ThreadError aResult)
 {
     (void) aMessage;
+    (void) aMessageInfo;
 
     otLogFuncEntry();
 
@@ -511,15 +517,19 @@ exit:
 }
 
 void Commissioner::HandleLeaderPetitionResponse(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
-                                                ThreadError aResult)
+                                                const otMessageInfo *aMessageInfo, ThreadError aResult)
 {
     static_cast<Commissioner *>(aContext)->HandleLeaderPetitionResponse(
-        static_cast<Coap::Header *>(aHeader), static_cast<Message *>(aMessage), aResult);
+        static_cast<Coap::Header *>(aHeader), static_cast<Message *>(aMessage),
+        static_cast<const Ip6::MessageInfo *>(aMessageInfo), aResult);
 
 }
 
-void Commissioner::HandleLeaderPetitionResponse(Coap::Header *aHeader, Message *aMessage, ThreadError aResult)
+void Commissioner::HandleLeaderPetitionResponse(Coap::Header *aHeader, Message *aMessage,
+                                                const Ip6::MessageInfo *aMessageInfo, ThreadError aResult)
 {
+    (void) aMessageInfo;
+
     StateTlv state;
     CommissionerSessionIdTlv sessionId;
     bool retransmit = false;
@@ -607,14 +617,18 @@ exit:
 }
 
 void Commissioner::HandleLeaderKeepAliveResponse(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
-                                                 ThreadError aResult)
+                                                 const otMessageInfo *aMessageInfo, ThreadError aResult)
 {
     static_cast<Commissioner *>(aContext)->HandleLeaderKeepAliveResponse(
-        static_cast<Coap::Header *>(aHeader), static_cast<Message *>(aMessage), aResult);
+        static_cast<Coap::Header *>(aHeader), static_cast<Message *>(aMessage),
+        static_cast<const Ip6::MessageInfo *>(aMessageInfo), aResult);
 }
 
-void Commissioner::HandleLeaderKeepAliveResponse(Coap::Header *aHeader, Message *aMessage, ThreadError aResult)
+void Commissioner::HandleLeaderKeepAliveResponse(Coap::Header *aHeader, Message *aMessage,
+                                                 const Ip6::MessageInfo *aMessageInfo, ThreadError aResult)
 {
+    (void) aMessageInfo;
+
     StateTlv state;
 
     otLogFuncEntry();

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -190,18 +190,22 @@ private:
     static void HandleTimer(void *aContext);
     void HandleTimer(void);
 
-    static void HandleMgmtCommissionerSetResponse(void *aContext, otCoapHeader *aHeader,
-                                                  otMessage aMessage, ThreadError aResult);
-    void HandleMgmtCommissisonerSetResponse(Coap::Header *aHeader, Message *aMessage, ThreadError aResult);
-    static void HandleMgmtCommissionerGetResponse(void *aContext, otCoapHeader *aHeader,
-                                                  otMessage aMessage, ThreadError aResult);
-    void HandleMgmtCommissisonerGetResponse(Coap::Header *aHeader, Message *aMessage, ThreadError aResult);
-    static void HandleLeaderPetitionResponse(void *aContext, otCoapHeader *aHeader,
-                                             otMessage aMessage, ThreadError aResult);
-    void HandleLeaderPetitionResponse(Coap::Header *aHeader, Message *aMessage, ThreadError aResult);
-    static void HandleLeaderKeepAliveResponse(void *aContext, otCoapHeader *aHeader,
-                                              otMessage aMessage, ThreadError aResult);
-    void HandleLeaderKeepAliveResponse(Coap::Header *aHeader, Message *aMessage, ThreadError aResult);
+    static void HandleMgmtCommissionerSetResponse(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                                  const otMessageInfo *aMessageInfo, ThreadError aResult);
+    void HandleMgmtCommissisonerSetResponse(Coap::Header *aHeader, Message *aMessage,
+                                            const Ip6::MessageInfo *aMessageInfo, ThreadError aResult);
+    static void HandleMgmtCommissionerGetResponse(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                                  const otMessageInfo *aMessageInfo, ThreadError aResult);
+    void HandleMgmtCommissisonerGetResponse(Coap::Header *aHeader, Message *aMessage,
+                                            const Ip6::MessageInfo *aMessageInfo, ThreadError aResult);
+    static void HandleLeaderPetitionResponse(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                             const otMessageInfo *aMessageInfo, ThreadError aResult);
+    void HandleLeaderPetitionResponse(Coap::Header *aHeader, Message *aMessage,
+                                      const Ip6::MessageInfo *aMessageInfo, ThreadError aResult);
+    static void HandleLeaderKeepAliveResponse(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                              const otMessageInfo *aMessageInfo, ThreadError aResult);
+    void HandleLeaderKeepAliveResponse(Coap::Header *aHeader, Message *aMessage,
+                                       const Ip6::MessageInfo *aMessageInfo, ThreadError aResult);
 
     static void HandleRelayReceive(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
                                    const otMessageInfo *aMessageInfo);

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -231,20 +231,23 @@ exit:
     otLogFuncExit();
 }
 
-void Joiner::HandleJoinerFinalizeResponse(void *aContext, otCoapHeader *aHeader,
-                                          otMessage aMessage, ThreadError result)
+void Joiner::HandleJoinerFinalizeResponse(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                          const otMessageInfo *aMessageInfo, ThreadError aResult)
 {
     static_cast<Joiner *>(aContext)->HandleJoinerFinalizeResponse(
-        static_cast<Coap::Header *>(aHeader), static_cast<Message *>(aMessage), result);
+        static_cast<Coap::Header *>(aHeader), static_cast<Message *>(aMessage),
+        static_cast<const Ip6::MessageInfo *>(aMessageInfo), aResult);
 }
 
-void Joiner::HandleJoinerFinalizeResponse(Coap::Header *aHeader, Message *aMessage, ThreadError result)
+void Joiner::HandleJoinerFinalizeResponse(Coap::Header *aHeader, Message *aMessage,
+                                          const Ip6::MessageInfo *aMessageInfo, ThreadError aResult)
 {
+    (void) aMessageInfo;
     StateTlv state;
 
     otLogFuncEntry();
 
-    VerifyOrExit(result == kThreadError_None &&
+    VerifyOrExit(aResult == kThreadError_None &&
                  aHeader->GetType() == kCoapTypeAcknowledgment &&
                  aHeader->GetCode() == kCoapResponseChanged, ;);
 

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -97,9 +97,10 @@ private:
     static void HandleSecureCoapClientConnect(void *aContext);
 
     void SendJoinerFinalize(void);
-    static void HandleJoinerFinalizeResponse(void *aContext, otCoapHeader *aHeader,
-                                             otMessage aMessage, ThreadError result);
-    void HandleJoinerFinalizeResponse(Coap::Header *aHeader, Message *aMessage, ThreadError result);
+    static void HandleJoinerFinalizeResponse(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
+                                             const otMessageInfo *aMessageInfo, ThreadError aResult);
+    void HandleJoinerFinalizeResponse(Coap::Header *aHeader, Message *aMessage,
+                                      const Ip6::MessageInfo *aMessageInfo, ThreadError aResult);
 
     static void HandleJoinerEntrust(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
                                     const otMessageInfo *aMessageInfo);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3679,15 +3679,19 @@ exit:
 }
 
 void MleRouter::HandleAddressSolicitResponse(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
-                                             ThreadError result)
+                                             const otMessageInfo *aMessageInfo, ThreadError aResult)
 {
     static_cast<MleRouter *>(aContext)->HandleAddressSolicitResponse(static_cast<Coap::Header *>(aHeader),
-                                                                     static_cast<Message *>(aMessage), result);
+                                                                     static_cast<Message *>(aMessage),
+                                                                     static_cast<const Ip6::MessageInfo *>(aMessageInfo),
+                                                                     aResult);
 }
 
-void MleRouter::HandleAddressSolicitResponse(Coap::Header *aHeader, Message *aMessage, ThreadError result)
+void MleRouter::HandleAddressSolicitResponse(Coap::Header *aHeader, Message *aMessage,
+                                             const Ip6::MessageInfo *aMessageInfo, ThreadError aResult)
 {
-    (void) result;
+    (void)aResult;
+    (void)aMessageInfo;
 
     ThreadStatusTlv statusTlv;
     ThreadRloc16Tlv rlocTlv;
@@ -3696,7 +3700,7 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Header *aHeader, Message *aMe
     Router *router;
     bool old;
 
-    VerifyOrExit(result == kThreadError_None && aHeader != NULL && aMessage != NULL, ;);
+    VerifyOrExit(aResult == kThreadError_None && aHeader != NULL && aMessage != NULL, ;);
 
     VerifyOrExit(aHeader->GetCode() == kCoapResponseChanged, ;);
 

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -757,8 +757,9 @@ private:
     void UpdateRoutes(const RouteTlv &aTlv, uint8_t aRouterId);
 
     static void HandleAddressSolicitResponse(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
-                                             ThreadError result);
-    void HandleAddressSolicitResponse(Coap::Header *aHeader, Message *aMessage, ThreadError result);
+                                             const otMessageInfo *aMessageInfo, ThreadError result);
+    void HandleAddressSolicitResponse(Coap::Header *aHeader, Message *aMessage,
+                                      const Ip6::MessageInfo *aMessageInfo, ThreadError result);
     static void HandleAddressRelease(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
                                      const otMessageInfo *aMessageInfo);
     void HandleAddressRelease(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -110,17 +110,21 @@ exit:
 }
 
 void NetworkDiagnostic::HandleDiagnosticGetResponse(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
-                                                    ThreadError result)
+                                                    const otMessageInfo *aMessageInfo, ThreadError aResult)
 {
     static_cast<NetworkDiagnostic *>(aContext)->HandleDiagnosticGetResponse(static_cast<Coap::Header *>(aHeader),
-                                                                            static_cast<Message *>(aMessage), result);
+                                                                            static_cast<Message *>(aMessage),
+                                                                            static_cast<const Ip6::MessageInfo *>(aMessageInfo),
+                                                                            aResult);
 }
 
-void NetworkDiagnostic::HandleDiagnosticGetResponse(Coap::Header *aHeader, Message *aMessage, ThreadError result)
+void NetworkDiagnostic::HandleDiagnosticGetResponse(Coap::Header *aHeader, Message *aMessage,
+                                                    const Ip6::MessageInfo *aMessageInfo, ThreadError aResult)
 {
     (void)aMessage;
+    (void)aMessageInfo;
 
-    VerifyOrExit(result == kThreadError_None, ;);
+    VerifyOrExit(aResult == kThreadError_None, ;);
     VerifyOrExit(aHeader->GetCode() == kCoapResponseChanged, ;);
 
     otLogInfoNetDiag("Network Diagnostic get response received");

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -110,8 +110,9 @@ public:
 
 private:
     static void HandleDiagnosticGetResponse(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
-                                            ThreadError result);
-    void HandleDiagnosticGetResponse(Coap::Header *aHeader, Message *aMessage, ThreadError result);
+                                            const otMessageInfo *aMessageInfo, ThreadError aResult);
+    void HandleDiagnosticGetResponse(Coap::Header *aHeader, Message *aMessage,
+                                     const Ip6::MessageInfo *aMessageInfo, ThreadError aResult);
 
     static void HandleDiagnosticGet(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
                                     const otMessageInfo *aMessageInfo);


### PR DESCRIPTION
This PR extends CoAP response handler with a pointer to MessageInfo, the same way as it is in request handler.

This feature might be handy for an applicaction (for example to identify responder for a multicast CoAP request), and as we expose the CoAP API, it seems to be worth to add it.