### PR TITLE
Escape literal "{" in a regular expression pattern.

### DIFF
--- a/third_party/nlbuild-autotools/repo/tools/host/i686-pc-cygwin/bin/automake
+++ b/third_party/nlbuild-autotools/repo/tools/host/i686-pc-cygwin/bin/automake
@@ -3927,7 +3927,7 @@ sub substitute_ac_subst_variables_worker
 sub substitute_ac_subst_variables
 {
   my ($text) = @_;
-  $text =~ s/\${([^ \t=:+{}]+)}/substitute_ac_subst_variables_worker ($1)/ge;
+  $text =~ s/\$\{([^ \t=:+{}]+)}/substitute_ac_subst_variables_worker ($1)/ge;
   return $text;
 }
 

--- a/third_party/nlbuild-autotools/repo/tools/host/i686-pc-linux-gnu/bin/automake
+++ b/third_party/nlbuild-autotools/repo/tools/host/i686-pc-linux-gnu/bin/automake
@@ -3927,7 +3927,7 @@ sub substitute_ac_subst_variables_worker
 sub substitute_ac_subst_variables
 {
   my ($text) = @_;
-  $text =~ s/\${([^ \t=:+{}]+)}/substitute_ac_subst_variables_worker ($1)/ge;
+  $text =~ s/\$\{([^ \t=:+{}]+)}/substitute_ac_subst_variables_worker ($1)/ge;
   return $text;
 }
 

--- a/third_party/nlbuild-autotools/repo/tools/host/x86_64-apple-darwin/bin/automake
+++ b/third_party/nlbuild-autotools/repo/tools/host/x86_64-apple-darwin/bin/automake
@@ -3927,7 +3927,7 @@ sub substitute_ac_subst_variables_worker
 sub substitute_ac_subst_variables
 {
   my ($text) = @_;
-  $text =~ s/\${([^ \t=:+{}]+)}/substitute_ac_subst_variables_worker ($1)/ge;
+  $text =~ s/\$\{([^ \t=:+{}]+)}/substitute_ac_subst_variables_worker ($1)/ge;
   return $text;
 }
 

--- a/third_party/nlbuild-autotools/repo/tools/host/x86_64-unknown-linux-gnu/bin/automake
+++ b/third_party/nlbuild-autotools/repo/tools/host/x86_64-unknown-linux-gnu/bin/automake
@@ -3927,7 +3927,7 @@ sub substitute_ac_subst_variables_worker
 sub substitute_ac_subst_variables
 {
   my ($text) = @_;
-  $text =~ s/\${([^ \t=:+{}]+)}/substitute_ac_subst_variables_worker ($1)/ge;
+  $text =~ s/\$\{([^ \t=:+{}]+)}/substitute_ac_subst_variables_worker ($1)/ge;
   return $text;
 }
 


### PR DESCRIPTION
- To support [changes](https://metacpan.org/pod/release/PCM/perl-5.21.3/pod/perl5211delta.pod#A-literal-should-now-be-escaped-in-a-pattern) introduced with perl-5.21.3.

Fixes the `./bootstrap` issue raised in #1036.