### PR TITLE
Fix the networkname TLV type during initialization.

### DIFF
--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -136,7 +136,7 @@ ThreadError ActiveDataset::GenerateLocal(void)
     }
 
     // Network Name
-    if (!IsTlvInitialized(Tlv::kNetworkMasterKey))
+    if (!IsTlvInitialized(Tlv::kNetworkName))
     {
         NetworkNameTlv tlv;
         tlv.Init();


### PR DESCRIPTION
Auto-nightly Run detects that 9.2.3-Leader fails due to the lack of networkname sub-tlv included in the active dataset Tlv. Mistaken to put a duplicated maskterkey tlv type as networkname tlv type. Please have a review. Thanks.