### PR TITLE
NcpSpi: Fix a race situation and simply the tx state model

### DIFF
--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -73,6 +73,13 @@ private:
         kSpiHeaderLength = 5,                                     // Size of spi header.
     };
 
+    enum TxState
+    {
+        kTxStateIdle,                      // No frame to send
+        kTxStateSending,                   // A frame is ready to be sent
+        kTxStateHandlingSendDone           // The frame was sent successfully, waiting to prepare the next one (if any)
+    };
+
     uint16_t OutboundFrameSize(void);
 
     static void SpiTransactionComplete(
@@ -102,9 +109,8 @@ private:
 
     ThreadError PrepareNextSpiSendFrame(void);
 
-    bool mSending;
+    TxState mTxState;
     bool mHandlingRxFrame;
-    bool mHandlingSendDone;
 
     Tasklet mHandleRxFrameTask;
     Tasklet mPrepareTxFrameTask;


### PR DESCRIPTION
This commit fixes a race issue in tx path of `NcpSpi`: If the SPI transaction is completed while in middle of `PrepareTxFrame()`task handler before clearing the `mHandlingSendDone` flag, we can have a situation where `PrepareTxFrame` task is not posted again and then the next queued tx frames are not handled immediately.

It also simplifies the tx state model by adding a single `mTxState` variable to track the current state as an `enum`.