### PR TITLE
DIAG: Fixes Child Table TLV representation.

### DIFF
--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -246,8 +246,9 @@ ThreadError NetworkDiagnostic::AppendChildTable(Message &aMessage)
 
             while (static_cast<uint32_t>(1 << timeout) < children[i].mTimeout) { timeout++; }
 
+            entry.SetReserved(0);
             entry.SetTimeout(timeout + 4);
-            entry.SetChildId(children[i].mValid.mRloc16);
+            entry.SetChildId(mMle.GetChildId(children[i].mValid.mRloc16));
             entry.SetMode(children[i].mMode);
 
             SuccessOrExit(error = aMessage.Append(&entry, sizeof(ChildTableEntry)));

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -1168,49 +1168,55 @@ class ChildTableEntry
 {
 public:
     /**
-     * This method returns the Version value.
+     * This method returns the Timeout value.
      *
-     * @returns The Version value.
-     *
-     */
-    uint8_t GetTimeout(void) const { return mTimeout; }
-
-    /**
-     * This method sets the Version value.
-     *
-     * @param[in]  aVersion  The Version value.
+     * @returns The Timeout value.
      *
      */
-    void SetTimeout(uint8_t aTimeout) { mTimeout = aTimeout; }
+    uint8_t GetTimeout(void) const { return (HostSwap16(mTimeoutRsvChildId) & kTimeoutMask) >> kTimeoutOffset; }
 
     /**
-     * This method returns the Version value.
+     * This method sets the Timeout value.
      *
-     * @returns The Version value.
+     * @param[in]  aTimeout  The Timeout value.
      *
      */
-    uint16_t GetChildId(void) const { return mChildId; }
+    void SetTimeout(uint8_t aTimeout) {
+        mTimeoutRsvChildId = HostSwap16((HostSwap16(mTimeoutRsvChildId) & ~kTimeoutMask) |
+                                        ((aTimeout << kTimeoutOffset) & kTimeoutMask));
+    }
 
     /**
-     * This method sets the Version value.
+     * This method returns the Child ID value.
      *
-     * @param[in]  aVersion  The Version value.
+     * @returns The Child ID value.
      *
      */
-    void SetChildId(uint16_t aChildId) { mChildId = aChildId; }
+    uint16_t GetChildId(void) const { return HostSwap16(mTimeoutRsvChildId) & kChildIdMask; }
 
     /**
-     * This method returns the Version value.
+     * This method sets the Child ID value.
      *
-     * @returns The Version value.
+     * @param[in]  aChildId  The Child ID value.
+     *
+     */
+    void SetChildId(uint16_t aChildId) {
+        mTimeoutRsvChildId = HostSwap16((HostSwap16(mTimeoutRsvChildId) & ~kChildIdMask) |
+                                        (aChildId & kChildIdMask));
+    }
+
+    /**
+     * This method returns the Mode value.
+     *
+     * @returns The Mode value.
      *
      */
     uint8_t GetMode(void) const { return mMode; }
 
     /**
-     * This method sets the Version value.
+     * This method sets the Mode value.
      *
-     * @param[in]  aVersion  The Version value.
+     * @param[in]  aMode  The Mode value.
      *
      */
     void SetMode(uint8_t aMode) { mMode = aMode; }
@@ -1221,7 +1227,7 @@ public:
      * @returns The Reserved value.
      *
      */
-    uint8_t GetReserved(void) const { return mReserved; }
+    uint8_t GetReserved(void) const { return (HostSwap16(mTimeoutRsvChildId) & kReservedMask) >> kReservedOffset; }
 
     /**
      * This method sets the Reserved value.
@@ -1229,13 +1235,22 @@ public:
      * @param[in]  aReserved  The Reserved value.
      *
      */
-    void SetReserved(uint8_t aReserved) { mReserved = aReserved; }
-
+    void SetReserved(uint8_t aReserved) {
+        mTimeoutRsvChildId = HostSwap16((HostSwap16(mTimeoutRsvChildId) & ~kReservedMask) |
+                                        ((aReserved << kReservedOffset) & kReservedMask));
+    }
 
 private:
-    uint16_t mTimeout: 5;
-    uint16_t mReserved: 2;
-    uint16_t mChildId: 9;
+    enum
+    {
+        kTimeoutMask = 0xF800,
+        kTimeoutOffset = 11,
+        kReservedMask = 0x0600,
+        kReservedOffset = 9,
+        kChildIdMask = 0x1ff
+    };
+
+    uint16_t mTimeoutRsvChildId;
     uint8_t mMode;
 } OT_TOOL_PACKED_END;
 


### PR DESCRIPTION
I've found that Child Table TLV which is sent on DIAG_GET.rsp has incorrect values both on Posix and ARM. This PR fixes a way of how this TLV is serialized. Also as a side effect i have fixed erronous comments.