### PR TITLE
[spinel-py] Configure logger only for spinel package

### DIFF
--- a/tools/spinel-cli/spinel/config.py
+++ b/tools/spinel-cli/spinel/config.py
@@ -71,7 +71,7 @@ logging.config.dictConfig({
         #},
     },
     'loggers': {
-        '': {
+        'spinel': {
             'handlers': ['console'],  # ,'syslog'],
             'level': 'DEBUG',
             'propagate': True


### PR DESCRIPTION
This PR changes logging configuration, so that other python modules are not affected by the configuration.