### PR TITLE
[spinel-py] Allow for waiting for a given property change

### DIFF
--- a/tools/spinel-cli/spinel/codec.py
+++ b/tools/spinel-cli/spinel/codec.py
@@ -883,6 +883,12 @@ class WpanApi(SpinelCodec):
 
         self.transact(SPINEL.CMD_PROP_VALUE_SET, pay)
 
+    def cmd_reset(self):
+        self.queue_wait_prepare(None, SPINEL.HEADER_ASYNC)
+        self.transact(SPINEL.CMD_RESET, "", SPINEL.HEADER_DEFAULT)
+        result = self.queue_wait_for_prop(SPINEL.PROP_LAST_STATUS, SPINEL.HEADER_ASYNC, 5)
+        return (result is not None and result.value == 114)
+
     def cmd_send(self, command_id, payload="", tid=SPINEL.HEADER_DEFAULT):
         self.queue_wait_prepare(None, tid)
         self.transact(command_id, payload, tid)


### PR DESCRIPTION
This PR adds a quick & dirty fix, so that waiting for a particular property Id is possible.

In addition a cmd_reset() is added to perform SW reset of the NCP. 