### PR TITLE
Change resubmit delay value from seconds to miliseconds.

### DIFF
--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -344,7 +344,7 @@ protected:
 private:
     enum
     {
-        kDataResubmitDelay = 300,  ///< DATA_RESUBMIT_DELAY (seconds)
+        kDataResubmitDelay = 300000,  ///< DATA_RESUBMIT_DELAY (miliseconds)
     };
 
     const bool      mLocal;


### PR DESCRIPTION
This PR fixes conditional check on network_data.cpp:600, where result of Timer::GetNow() (in miliseconds) is compared with kDataResubmitDelay (in seconds). It causes NCP to spam CoAP a/sd messages.