### PR TITLE
CoAP: Add source address to the stored metadata.

### DIFF
--- a/src/core/coap/coap_client.cpp
+++ b/src/core/coap/coap_client.cpp
@@ -279,6 +279,7 @@ void Client::HandleRetransmissionTimer(void)
             {
                 messageInfo.SetPeerAddr(requestMetadata.mDestinationAddress);
                 messageInfo.SetPeerPort(requestMetadata.mDestinationPort);
+                messageInfo.SetSockAddr(requestMetadata.mSourceAddress);
 
                 SendCopy(*message, messageInfo);
             }
@@ -438,6 +439,7 @@ exit:
 RequestMetadata::RequestMetadata(bool aConfirmable, const Ip6::MessageInfo &aMessageInfo,
                                  otCoapResponseHandler aHandler, void *aContext)
 {
+    mSourceAddress = aMessageInfo.GetSockAddr();
     mDestinationPort = aMessageInfo.GetPeerPort();
     mDestinationAddress = aMessageInfo.GetPeerAddr();
     mResponseHandler = aHandler;

--- a/src/core/coap/coap_client.hpp
+++ b/src/core/coap/coap_client.hpp
@@ -169,6 +169,7 @@ public:
     bool IsLater(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mNextTimerShot) < 0); };
 
 private:
+    Ip6::Address          mSourceAddress;         ///< IPv6 address of the message source.
     Ip6::Address          mDestinationAddress;    ///< IPv6 address of the message destination.
     uint16_t              mDestinationPort;       ///< UDP port of the message destination.
     otCoapResponseHandler mResponseHandler;       ///< A function pointer that is called on response reception.


### PR DESCRIPTION
For some messages e.g. server data notification we need to preserve source address (RLOC), so the message would not be send using address from the best match algorithm.