### PR TITLE
Update the `MessageQueue` and add unit test for it.

### DIFF
--- a/etc/visual-studio/UnitTests.vcxproj
+++ b/etc/visual-studio/UnitTests.vcxproj
@@ -69,6 +69,7 @@
     <ClCompile Include="..\..\tests\unit\test_lowpan.cpp" />
     <ClCompile Include="..\..\tests\unit\test_mac_frame.cpp" />
     <ClCompile Include="..\..\tests\unit\test_message.cpp" />
+    <ClCompile Include="..\..\tests\unit\test_message_queue.cpp" />
     <ClCompile Include="..\..\tests\unit\test_ncp_buffer.cpp" />
     <ClCompile Include="..\..\tests\unit\test_platform.cpp" />
     <ClCompile Include="..\..\tests\unit\test_timer.cpp" />

--- a/etc/visual-studio/UnitTests.vcxproj.filters
+++ b/etc/visual-studio/UnitTests.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClCompile Include="..\..\tests\unit\test_message.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\tests\unit\test_message_queue.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\tests\unit\test_timer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1059,7 +1059,7 @@ exit:
     return rval;
 }
 
-otInstance *Ip6::GetInstance()
+otInstance *Ip6::GetInstance(void)
 {
     return otInstanceFromIp6(this);
 }

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -80,6 +80,7 @@ check_PROGRAMS                                                      = \
     test-link-quality                                                 \
     test-mac-frame                                                    \
     test-message                                                      \
+    test-message-queue                                                \
     test-timer                                                        \
     test-toolchain                                                    \
     $(NULL)
@@ -137,6 +138,9 @@ test_mac_frame_SOURCES       = test_platform.cpp test_mac_frame.cpp
 
 test_message_LDADD           = $(COMMON_LDADD)
 test_message_SOURCES         = test_platform.cpp test_message.cpp
+
+test_message_queue_LDADD     = $(COMMON_LDADD)
+test_message_queue_SOURCES   = test_platform.cpp test_message_queue.cpp
 
 test_ncp_buffer_LDADD        = $(COMMON_LDADD)
 test_ncp_buffer_SOURCES      = test_platform.cpp test_ncp_buffer.cpp

--- a/tests/unit/test_message_queue.cpp
+++ b/tests/unit/test_message_queue.cpp
@@ -1,0 +1,141 @@
+/*
+ *  Copyright (c) 2016, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test_util.h"
+#include <openthread.h>
+#include <common/debug.hpp>
+#include <common/message.hpp>
+#include <string.h>
+#include <stdarg.h>
+
+#define kNumMessages      5
+
+// This function verifies the content of the message to matches the passed in messages
+void VerifyMessageQueueContent(Thread::MessageQueue &aMessageQueue, int aExpectedLength, ...)
+{
+    va_list args;
+    Thread::Message *message;
+    Thread::Message *msgArg;
+
+    va_start(args, aExpectedLength);
+
+    if (aExpectedLength == 0)
+    {
+        message = aMessageQueue.GetHead();
+        VerifyOrQuit(message == NULL, "MessageQueue is not empty when expected len is zero.");
+    }
+    else
+    {
+        for (message = aMessageQueue.GetHead(); message != NULL; message = message->GetNext())
+        {
+            VerifyOrQuit(aExpectedLength != 0, "MessageQueue contains more entries than expected");
+
+            msgArg = va_arg(args, Thread::Message *);
+            VerifyOrQuit(msgArg == message, "MessageQueue content does not match what is expected.");
+
+            aExpectedLength--;
+        }
+
+        VerifyOrQuit(aExpectedLength == 0, "MessageQueue contains less entries than expected");
+    }
+
+    va_end(args);
+}
+
+void TestMessageQueue(void)
+{
+    Thread::MessagePool messagePool;
+    Thread::MessageQueue messageQueue;
+    Thread::Message *msg[kNumMessages];
+
+    for (int i = 0; i < kNumMessages; i++)
+    {
+        msg[i] = messagePool.New(Thread::Message::kTypeIp6, 0);
+        VerifyOrQuit(msg[i] != NULL, "Message::New failed\n");
+    }
+
+    VerifyMessageQueueContent(messageQueue, 0);
+
+    //printf("\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
+    //printf("\nEnqueue/Dequeue one message");
+
+    // Enqueue 1 message and remove it
+    SuccessOrQuit(messageQueue.Enqueue(*msg[0]), "MessageQueue::Enqueue() failed.");
+    VerifyMessageQueueContent(messageQueue, 1, msg[0]);
+    SuccessOrQuit(messageQueue.Dequeue(*msg[0]), "MessageQueue::Dequeue() failed.");
+    VerifyMessageQueueContent(messageQueue, 0);
+
+    // Enqueue 5 messages
+    SuccessOrQuit(messageQueue.Enqueue(*msg[0]), "MessageQueue::Enqueue() failed.");
+    VerifyMessageQueueContent(messageQueue, 1, msg[0]);
+    SuccessOrQuit(messageQueue.Enqueue(*msg[1]), "MessageQueue::Enqueue() failed.");
+    VerifyMessageQueueContent(messageQueue, 2, msg[0], msg[1]);
+    SuccessOrQuit(messageQueue.Enqueue(*msg[2]), "MessageQueue::Enqueue() failed.");
+    VerifyMessageQueueContent(messageQueue, 3, msg[0], msg[1], msg[2]);
+    SuccessOrQuit(messageQueue.Enqueue(*msg[3]), "MessageQueue::Enqueue() failed.");
+    VerifyMessageQueueContent(messageQueue, 4, msg[0], msg[1], msg[2], msg[3]);
+    SuccessOrQuit(messageQueue.Enqueue(*msg[4]), "MessageQueue::Enqueue() failed.");
+    VerifyMessageQueueContent(messageQueue, 5, msg[0], msg[1], msg[2], msg[3], msg[4]);
+
+    // Remove from head
+    SuccessOrQuit(messageQueue.Dequeue(*msg[0]), "MessageQueue::Dequeue() failed.");
+    VerifyMessageQueueContent(messageQueue, 4, msg[1], msg[2], msg[3], msg[4]);
+
+    // Remove a message in middle
+    SuccessOrQuit(messageQueue.Dequeue(*msg[3]), "MessageQueue::Dequeue() failed.");
+    VerifyMessageQueueContent(messageQueue, 3, msg[1], msg[2], msg[4]);
+
+    // Remove from tail
+    SuccessOrQuit(messageQueue.Dequeue(*msg[4]), "MessageQueue::Dequeue() failed.");
+    VerifyMessageQueueContent(messageQueue, 2, msg[1], msg[2]);
+
+    // Add after removes
+    SuccessOrQuit(messageQueue.Enqueue(*msg[0]), "MessageQueue::Enqueue() failed.");
+    VerifyMessageQueueContent(messageQueue, 3, msg[1], msg[2], msg[0]);
+    SuccessOrQuit(messageQueue.Enqueue(*msg[3]), "MessageQueue::Enqueue() failed.");
+    VerifyMessageQueueContent(messageQueue, 4, msg[1], msg[2], msg[0], msg[3]);
+
+    // Remove all messages
+    SuccessOrQuit(messageQueue.Dequeue(*msg[2]), "MessageQueue::Dequeue() failed.");
+    VerifyMessageQueueContent(messageQueue, 3, msg[1], msg[0], msg[3]);
+    SuccessOrQuit(messageQueue.Dequeue(*msg[1]), "MessageQueue::Dequeue() failed.");
+    VerifyMessageQueueContent(messageQueue, 2, msg[0], msg[3]);
+    SuccessOrQuit(messageQueue.Dequeue(*msg[3]), "MessageQueue::Dequeue() failed.");
+    VerifyMessageQueueContent(messageQueue, 1, msg[0]);
+    SuccessOrQuit(messageQueue.Dequeue(*msg[0]), "MessageQueue::Dequeue() failed.");
+    VerifyMessageQueueContent(messageQueue, 0);
+}
+
+#ifdef ENABLE_TEST_MAIN
+int main(void)
+{
+    TestMessageQueue();
+    printf("All tests passed\n");
+    return 0;
+}
+#endif

--- a/tests/unit/test_windows.cpp
+++ b/tests/unit/test_windows.cpp
@@ -65,6 +65,9 @@ namespace Thread
 // test_message.cpp
 void TestMessage();
 
+// test_message_queue.cpp
+void TestMessageQueue();
+
 // test_ncp_buffer.cpp
 namespace Thread
 {
@@ -92,7 +95,7 @@ utAssertTrue s_AssertTrue;
 utLogMessage s_LogMessage;
 
 namespace Thread
-{        
+{
     TEST_CLASS(UnitTests)
     {
     public:
@@ -114,7 +117,7 @@ namespace Thread
             va_start(args, format);
             vsnprintf(message, sizeof(message), format, args);
             va_end(args);
-            
+
             Logger::WriteMessage(message);
         }
 
@@ -145,7 +148,10 @@ namespace Thread
         // test_message.cpp
         TEST_METHOD(TestMessage) { ::TestMessage(); }
 
-        // test_message.cpp
+        // test_message_queue.cpp
+        TEST_METHOD(TestMessageQueue) { ::TestMessageQueue(); }
+
+        // test_timer.cpp
         TEST_METHOD(TestOneTimer) { ::TestOneTimer(); }
         TEST_METHOD(TestTenTimers) { ::TestTenTimers(); }
 


### PR DESCRIPTION
This commit makes the following changes:

- It adds a unit test for testing different `MessageQueue` operations.

- It modifies how the `MessageQueue`/`Message` store/determine the lists (the `kListAll`  is maintained by the message pool and the `kListInterface` is accessed  from the `MessageQueue` associated with the `Message`).

- It modifies the underlying list implementation to use a _circular_ doubly  linked-list. 

These changes are indirectly related to Issue https://github.com/openthread/openthread/issues/1047 (preparing to add `Priority` level to `Message`s and a priority queue implementation compatible with current `MessageQueue`).
