### PR TITLE
Add timeout check to limit wait time for `TransmitDone` callback

### DIFF
--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -666,6 +666,34 @@ private:
     Frame *mTxFrame;
 
     otMacCounters mCounters;
+
+#if OPENTHREAD_CONFIG_ADD_RADIO_TX_DONE_TIMEOUT_CHECK
+
+    /**
+     * OpenThread expects an `otPlatRadioTransmitDone()` callback after every successful call to
+     * `otPlatRadioTransmit()`. If for some reason the underlying platform radio APIs misbehave
+     * OpenThread can remain stuck waiting for the callback.
+     *
+     * Config option `OPENTHREAD_CONFIG_ADD_RADIO_TX_DONE_TIMEOUT_CHECK` can be used to enable
+     * additional check where a timeout is used to limit the maximum wait time to get the callback.
+     *
+     * This mechanism helps detect issues with platform radio implementation (by logging the issue)
+     * and it also tries to recover (by switching back to receive state and issuing the callback).
+     *
+     */
+
+    enum
+    {
+        kTxDoneCallbackTimeout = 2000,   // in ms.
+    };
+
+    static void HandleTxDoneTimeoutTimer(void *aContext);
+    void HandleTxDoneTimeoutTimer(void);
+
+    Timer mTxDoneTimeoutTimer;
+
+#endif // OPENTHREAD_CONFIG_ADD_RADIO_TX_DONE_TIMEOUT_CHECK
+
 };
 
 /**

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -300,6 +300,17 @@
 #endif  // OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD
 
 /**
+ * @def OPENTHREAD_CONFIG_ADD_RADIO_TX_DONE_TIMEOUT_CHECK
+ *
+ * Set to 1 to add timeout for radio tx done callback to detect
+ * radio platform code failures.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ADD_RADIO_TX_DONE_TIMEOUT_CHECK
+#define OPENTHREAD_CONFIG_ADD_RADIO_TX_DONE_TIMEOUT_CHECK    1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_LOG_LEVEL
  *
  * The log level.


### PR DESCRIPTION
OpenThread expects an `otPlatRadioTransmitDone()` callback after every successful call to `otPlatRadioTransmit()`. If for some reason the underlying platform radio APIs misbehave OpenThread can remain stuck waiting for the callback.

This commit adds `OPENTHREAD_CONFIG_ADD_RADIO_TX_DONE_TIMEOUT_CHECK` as a config option to enable additional check where a timeout is used to limit the maximum wait time to get the callback. This mechanism helps detect issues with platform radio implementation (by logging the issue) and it also tries to recover (by trying to switch the radio to receive state).