### PR TITLE
Trigger attach if device fails to start Router Synchronization process

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -224,7 +224,10 @@ ThreadError Mle::Start(bool aEnableReattach)
     }
     else if (IsActiveRouter(GetRloc16()))
     {
-        mMleRouter.BecomeRouter(ThreadStatusTlv::kTooFewRouters);
+        if (mMleRouter.BecomeRouter(ThreadStatusTlv::kTooFewRouters) != kThreadError_None)
+        {
+            BecomeChild(kMleAttachAnyPartition);
+        }
     }
     else
     {


### PR DESCRIPTION
It is to fix the attach failure case with following steps:
1. Device join network as a router, the network information will be stored locally;
2. Reset device, and it will restore the network information;
3. Execute `routerrole disable` command to disable router capacity;
4. Execute `thread start` command to start attach;
5. Device will try to start Router Synchronization process in `BecomeRouter()`, but it will fail due to `VerifyOrExit(IsRouterRoleEnabled(), error = kThreadError_NotCapable);`.
