### PR TITLE
Remove Preferred and Valid Lifetimes from otNetifAddress.

### DIFF
--- a/examples/drivers/windows/otApi/otApi.cpp
+++ b/examples/drivers/windows/otApi/otApi.cpp
@@ -1915,8 +1915,8 @@ otGetUnicastAddresses(
 
                 // Copy the necessary parameters
                 memcpy(&addrs[AddrCount].mAddress, &pAddr->sin6_addr, sizeof(pAddr->sin6_addr));
-                addrs[AddrCount].mPreferredLifetime = pUnicastAddr->PreferredLifetime;
-                addrs[AddrCount].mValidLifetime = pUnicastAddr->ValidLifetime;
+                addrs[AddrCount].mPreferred = pUnicastAddr->PreferredLifetime != 0;
+                addrs[AddrCount].mValid = pUnicastAddr->ValidLifetime != 0;
                 addrs[AddrCount].mPrefixLength = pUnicastAddr->OnLinkPrefixLength;
 
                 AddrCount++;
@@ -1979,8 +1979,8 @@ otAddUnicastAddress(
 
     memcpy(&newRow.Address.Ipv6.sin6_addr, &aAddress->mAddress, sizeof(IN6_ADDR));
     newRow.OnLinkPrefixLength = aAddress->mPrefixLength;
-    newRow.PreferredLifetime = aAddress->mPreferredLifetime;
-    newRow.ValidLifetime = aAddress->mValidLifetime;
+    newRow.PreferredLifetime = aAddress->mPreferred ? 0xffffffff : 0;
+    newRow.ValidLifetime = aAddress->mValid ? 0xffffffff : 0;
     newRow.PrefixOrigin = IpPrefixOriginOther;  // Derived from network XPANID
     newRow.SkipAsSource = FALSE;                // Allow automatic binding to this address (default)
 

--- a/examples/drivers/windows/otLwf/filter.h
+++ b/examples/drivers/windows/otLwf/filter.h
@@ -144,7 +144,7 @@ typedef struct _MS_FILTER
     IN6_ADDR                    otLinkLocalAddr;
     otNetifAddress              otAutoAddresses[OPENTHREAD_CONFIG_NUM_SLAAC_ADDRESSES];
 #if OPENTHREAD_ENABLE_DHCP6_CLIENT
-    otNetifAddress              otDhcpAddresses[OPENTHREAD_CONFIG_NUM_DHCP_PREFIXES];
+    otDhcpAddress               otDhcpAddresses[OPENTHREAD_CONFIG_NUM_DHCP_PREFIXES];
 #endif // OPENTHREAD_ENABLE_DHCP6_CLIENT
 
     union

--- a/examples/drivers/windows/otNodeApi/otNodeApi.cpp
+++ b/examples/drivers/windows/otNodeApi/otNodeApi.cpp
@@ -1338,8 +1338,8 @@ OTNODEAPI int32_t OTCALL otNodeAddIpAddr(otNode* aNode, const char *aAddr)
     if (error != kThreadError_None) return error;
 
     aAddress.mPrefixLength = 64;
-    aAddress.mPreferredLifetime = 0xffffffff;
-    aAddress.mValidLifetime = 0xffffffff;
+    aAddress.mPreferred = true;
+    aAddress.mValid = true;
     auto result = otAddUnicastAddress(aNode->mInstance, &aAddress);
     otLogFuncExit();
     return result;

--- a/include/dhcp6/dhcp6_client.h
+++ b/include/dhcp6/dhcp6_client.h
@@ -35,6 +35,8 @@
 #ifndef OPENTHREAD_DHCP6_CLIENT_H_
 #define OPENTHREAD_DHCP6_CLIENT_H_
 
+#include <openthread-types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,6 +49,17 @@ extern "C" {
  */
 
 /**
+ * This structure represents a DHCPv6 address.
+ *
+ */
+typedef struct otDhcpAddress
+{
+    otNetifAddress mAddress;            ///< The network interface address.
+    uint32_t       mPreferredLifetime;  ///< The preferred lifetime.
+    uint32_t       mValidLifetime;      ///< The valid lifetime.
+} otDhcpAddress;
+
+/**
  * Update all automatically created IPv6 addresses for prefixes from current Network Data with DHCP procedure.
  *
  * @param[in]     aInstance      A pointer to an OpenThread instance.
@@ -55,7 +68,7 @@ extern "C" {
  * @param[in]     aContext       A pointer to data passed to aIidCreate function.
  *
  */
-void otDhcp6ClientUpdate(otInstance *aInstance, otNetifAddress *aAddresses, uint32_t aNumAddresses, void *aContext);
+void otDhcp6ClientUpdate(otInstance *aInstance, otDhcpAddress *aAddresses, uint32_t aNumAddresses, void *aContext);
 
 /**
  * @}

--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -900,11 +900,11 @@ typedef struct otBufferInfo
 typedef struct otNetifAddress
 {
     otIp6Address           mAddress;                 ///< The IPv6 unicast address.
-    uint32_t               mPreferredLifetime;       ///< The Preferred Lifetime.
-    uint32_t               mValidLifetime;           ///< The Valid lifetime.
     uint8_t                mPrefixLength;            ///< The Prefix length.
-    unsigned int           mScopeOverride : 4;       ///< The IPv6 scope of this address.
+    bool                   mPreferred : 1;           ///< TRUE if the address is preferred, FALSE otherwise.
+    bool                   mValid : 1;               ///< TRUE if the address is valid, FALSE otherwise.
     bool                   mScopeOverrideValid : 1;  ///< TRUE if the mScopeOverride value is valid, FALSE othewrise.
+    unsigned int           mScopeOverride : 4;       ///< The IPv6 scope of this address.
     struct otNetifAddress *mNext;                    ///< A pointer to the next network interface address.
 } otNetifAddress;
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -748,8 +748,8 @@ ThreadError Interpreter::ProcessIpAddrAdd(int argc, char *argv[])
 
     SuccessOrExit(error = otIp6AddressFromString(argv[0], &aAddress.mAddress));
     aAddress.mPrefixLength = 64;
-    aAddress.mPreferredLifetime = 0xffffffff;
-    aAddress.mValidLifetime = 0xffffffff;
+    aAddress.mPreferred = true;
+    aAddress.mValid = true;
     error = otAddUnicastAddress(mInstance, &aAddress);
 
 exit:

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -248,7 +248,7 @@ private:
 
     otNetifAddress  mSlaacAddresses[OPENTHREAD_CONFIG_NUM_SLAAC_ADDRESSES];
 #if OPENTHREAD_ENABLE_DHCP6_CLIENT
-    otNetifAddress  mDhcpAddresses[OPENTHREAD_CONFIG_NUM_DHCP_PREFIXES];
+    otDhcpAddress  mDhcpAddresses[OPENTHREAD_CONFIG_NUM_DHCP_PREFIXES];
 #endif // OPENTHREAD_ENABLE_DHCP6_CLIENT
 
     otInstance *mInstance;

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -34,6 +34,8 @@
 #ifndef DHCP6_CLIENT_HPP_
 #define DHCP6_CLIENT_HPP_
 
+#include <dhcp6/dhcp6_client.h>
+
 #include <common/message.hpp>
 #include <common/timer.hpp>
 #include <common/trickle_timer.hpp>
@@ -185,7 +187,7 @@ public:
      * @param[in]     aContext      A pointer to IID creator-specific context data.
      *
      */
-    void UpdateAddresses(otInstance *aInstance, otNetifAddress *aAddresses, uint32_t aNumAddresses, void *aContext);
+    void UpdateAddresses(otInstance *aInstance, otDhcpAddress *aAddresses, uint32_t aNumAddresses, void *aContext);
 
 private:
     ThreadError Start(void);
@@ -228,7 +230,7 @@ private:
 
     uint8_t mTransactionId[kTransactionIdSize];
     uint32_t mStartTime;
-    otNetifAddress *mAddresses;
+    otDhcpAddress *mAddresses;
     uint32_t mNumAddresses;
 
     IdentityAssociation mIdentityAssociations[OPENTHREAD_CONFIG_NUM_DHCP_PREFIXES];

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -80,7 +80,7 @@ ThreadError Dhcp6Server::UpdateService(void)
     {
         found = false;
 
-        if (mAgentsAloc[i].mValidLifetime == 0)
+        if (!mAgentsAloc[i].mValid)
         {
             continue;
         }
@@ -109,7 +109,7 @@ ThreadError Dhcp6Server::UpdateService(void)
         {
             mNetworkDataLeader.GetContext(address->mFields.m8[15], lowpanContext);
             mNetif.RemoveUnicastAddress(mAgentsAloc[i]);
-            mAgentsAloc[i].mValidLifetime = 0;
+            mAgentsAloc[i].mValid = false;
             RemovePrefixAgent(lowpanContext.mPrefix);
         }
     }
@@ -132,7 +132,7 @@ ThreadError Dhcp6Server::UpdateService(void)
         {
             address = &(mAgentsAloc[i].GetAddress());
 
-            if ((mAgentsAloc[i].mValidLifetime != 0) && (address->mFields.m8[15] == lowpanContext.mContextId))
+            if ((mAgentsAloc[i].mValid) && (address->mFields.m8[15] == lowpanContext.mContextId))
             {
                 found = true;
                 break;
@@ -147,7 +147,7 @@ ThreadError Dhcp6Server::UpdateService(void)
 
         for (i = 0; i < OPENTHREAD_CONFIG_NUM_DHCP_PREFIXES; i++)
         {
-            if (mAgentsAloc[i].mValidLifetime == 0)
+            if (!mAgentsAloc[i].mValid)
             {
                 address = &(mAgentsAloc[i].GetAddress());
                 memcpy(address, mMle.GetMeshLocalPrefix(), 8);
@@ -157,8 +157,8 @@ ThreadError Dhcp6Server::UpdateService(void)
                 address->mFields.m8[14] = Mle::kAloc16Mask;
                 address->mFields.m8[15] = lowpanContext.mContextId;
                 mAgentsAloc[i].mPrefixLength = 128;
-                mAgentsAloc[i].mPreferredLifetime = 0xffffffff;
-                mAgentsAloc[i].mValidLifetime = 0xffffffff;
+                mAgentsAloc[i].mPreferred = true;
+                mAgentsAloc[i].mValid = true;
                 mNetif.AddUnicastAddress(mAgentsAloc[i]);
                 AddPrefixAgent(config.mPrefix);
                 break;

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1010,7 +1010,7 @@ const NetifUnicastAddress *Ip6::SelectSourceAddress(MessageInfo &aMessageInfo)
                     rvalIface = candidateId;
                 }
             }
-            else if (addr->mPreferredLifetime != 0 && rvalAddr->mPreferredLifetime == 0)
+            else if (addr->mPreferred && !rvalAddr->mPreferred)
             {
                 // Rule 3: Avoid deprecated addresses
                 rvalAddr = addr;

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -372,9 +372,9 @@ ThreadError Netif::AddExternalUnicastAddress(const NetifUnicastAddress &aAddress
         {
             VerifyOrExit(GetExtUnicastAddressIndex(cur) != -1, error = kThreadError_InvalidArgs);
 
-            cur->mPreferredLifetime = aAddress.mPreferredLifetime;
-            cur->mValidLifetime = aAddress.mValidLifetime;
             cur->mPrefixLength = aAddress.mPrefixLength;
+            cur->mPreferred = aAddress.mPreferred;
+            cur->mValid = aAddress.mValid;
             ExitNow();
         }
     }

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -1020,7 +1020,7 @@ void otDhcp6ServerUpdate(otInstance *aInstance)
 #endif  // OPENTHREAD_ENABLE_DHCP6_SERVER
 
 #if OPENTHREAD_ENABLE_DHCP6_CLIENT
-void otDhcp6ClientUpdate(otInstance *aInstance, otNetifAddress *aAddresses, uint32_t aNumAddresses, void *aContext)
+void otDhcp6ClientUpdate(otInstance *aInstance, otDhcpAddress *aAddresses, uint32_t aNumAddresses, void *aContext)
 {
     aInstance->mThreadNetif.GetDhcp6Client().UpdateAddresses(aInstance, aAddresses, aNumAddresses, aContext);
 }

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -111,14 +111,14 @@ Mle::Mle(ThreadNetif &aThreadNetif) :
     mLinkLocal64.GetAddress().mFields.m16[0] = HostSwap16(0xfe80);
     mLinkLocal64.GetAddress().SetIid(*mMac.GetExtAddress());
     mLinkLocal64.mPrefixLength = 64;
-    mLinkLocal64.mPreferredLifetime = 0xffffffff;
-    mLinkLocal64.mValidLifetime = 0xffffffff;
+    mLinkLocal64.mPreferred = true;
+    mLinkLocal64.mValid = true;
     mNetif.AddUnicastAddress(mLinkLocal64);
 
     // Leader Aloc
     mLeaderAloc.mPrefixLength = 128;
-    mLeaderAloc.mPreferredLifetime = 0xffffffff;
-    mLeaderAloc.mValidLifetime = 0xffffffff;
+    mLeaderAloc.mPreferred = true;
+    mLeaderAloc.mValid = true;
     mLeaderAloc.mScopeOverride = Ip6::Address::kRealmLocalScope;
     mLeaderAloc.mScopeOverrideValid = true;
 
@@ -137,8 +137,8 @@ Mle::Mle(ThreadNetif &aThreadNetif) :
     }
 
     mMeshLocal64.mPrefixLength = 64;
-    mMeshLocal64.mPreferredLifetime = 0xffffffff;
-    mMeshLocal64.mValidLifetime = 0xffffffff;
+    mMeshLocal64.mPreferred = true;
+    mMeshLocal64.mValid = true;
     SetMeshLocalPrefix(mMeshLocal64.GetAddress().mFields.m8); // Also calls AddUnicastAddress
 
     // mesh-local 16
@@ -146,8 +146,8 @@ Mle::Mle(ThreadNetif &aThreadNetif) :
     mMeshLocal16.GetAddress().mFields.m16[5] = HostSwap16(0x00ff);
     mMeshLocal16.GetAddress().mFields.m16[6] = HostSwap16(0xfe00);
     mMeshLocal16.mPrefixLength = 64;
-    mMeshLocal16.mPreferredLifetime = 0xffffffff;
-    mMeshLocal16.mValidLifetime = 0xffffffff;
+    mMeshLocal16.mPreferred = true;
+    mMeshLocal16.mValid = true;
     mMeshLocal16.mScopeOverride = Ip6::Address::kRealmLocalScope;
     mMeshLocal16.mScopeOverrideValid = true;
 

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -63,7 +63,7 @@ void Slaac::UpdateAddresses(otInstance *aInstance, otNetifAddress *aAddresses, u
         otNetifAddress *address = &aAddresses[i];
         bool found = false;
 
-        if (address->mValidLifetime == 0)
+        if (!address->mValid)
         {
             continue;
         }
@@ -88,7 +88,7 @@ void Slaac::UpdateAddresses(otInstance *aInstance, otNetifAddress *aAddresses, u
         if (!found)
         {
             otRemoveUnicastAddress(aInstance, &address->mAddress);
-            address->mValidLifetime = 0;
+            address->mValid = false;
         }
     }
 
@@ -108,7 +108,7 @@ void Slaac::UpdateAddresses(otInstance *aInstance, otNetifAddress *aAddresses, u
         {
             otNetifAddress *address = &aAddresses[i];
 
-            if (address->mValidLifetime == 0)
+            if (!address->mValid)
             {
                 continue;
             }
@@ -127,7 +127,7 @@ void Slaac::UpdateAddresses(otInstance *aInstance, otNetifAddress *aAddresses, u
             {
                 otNetifAddress *address = &aAddresses[i];
 
-                if (address->mValidLifetime != 0)
+                if (address->mValid)
                 {
                     continue;
                 }
@@ -136,8 +136,8 @@ void Slaac::UpdateAddresses(otInstance *aInstance, otNetifAddress *aAddresses, u
                 memcpy(&address->mAddress, &config.mPrefix.mPrefix, 8);
 
                 address->mPrefixLength = config.mPrefix.mLength;
-                address->mPreferredLifetime = config.mPreferred ? 0xffffffff : 0;
-                address->mValidLifetime = 0xffffffff;
+                address->mPreferred = config.mPreferred;
+                address->mValid = true;
 
                 if (aIidCreator(aInstance, address, aContext) != kThreadError_None)
                 {

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -2374,8 +2374,8 @@ ThreadError NcpBase::GetPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spine
                                       "T(6CLL).",
                                       &address->mAddress,
                                       address->mPrefixLength,
-                                      address->mPreferredLifetime,
-                                      address->mValidLifetime
+                                      address->mPreferred ? 0xffffffff : 0,
+                                      address->mValid ? 0xffffffff : 0
                                   ));
     }
 
@@ -4750,8 +4750,8 @@ ThreadError NcpBase::InsertPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, sp
 
     netif_addr.mAddress = *addr_ptr;
     netif_addr.mPrefixLength = prefix_len;
-    netif_addr.mPreferredLifetime = preferred_lifetime;
-    netif_addr.mValidLifetime = valid_lifetime;
+    netif_addr.mPreferred = preferred_lifetime != 0;
+    netif_addr.mValid = valid_lifetime != 0;
 
     errorCode = otAddUnicastAddress(mInstance, &netif_addr);
 


### PR DESCRIPTION
- Replace Preferred and Valid Lifetimes with a flag.
- Introduce new `otDhcpAddress` type for maintaining Preferred and Valid Lifetimes.
- Reduces RAM usage by 128 bytes.
- Fixes RAM overflow [build failure](https://travis-ci.org/openthread/openthread/jobs/188937843) on CC2538 platform.