### PR TITLE
Adding `otMessageQueue` OpenThread C APIs and their unit test

### DIFF
--- a/include/openthread-message.h
+++ b/include/openthread-message.h
@@ -29,7 +29,7 @@
 /**
  * @file
  * @brief
- *  This file defines the top-level ip6 functions for the OpenThread library.
+ *  This file defines the top-level OpenThread APIs related to message buffer and queues.
  */
 
 #ifndef OPENTHREAD_MESSAGE_H_
@@ -228,6 +228,65 @@ int otReadMessage(otMessage aMessage, uint16_t aOffset, void *aBuf, uint16_t aLe
  * @sa otReadMessage
  */
 int otWriteMessage(otMessage aMessage, uint16_t aOffset, const void *aBuf, uint16_t aLength);
+
+/**
+ *
+ * Initialize the message queue.
+ *
+ * This function MUST be called once and only once for a `otMessageQueue` instance before any other `otMessageQueue`
+ * functions. The behavior is undefined if other queue APIs are used with an `otMessageQueue` before it being
+ * initialized or if it is initialized more than once.
+ *
+ * @param[in]  aQueue     A pointer to a message queue.
+ *
+ */
+void otMessageQueueInit(otMessageQueue *aQueue);
+
+/**
+ * This function adds a message to the end of the given message queue.
+ *
+ * @param[in]  aQueue    A pointer to the message queue.
+ * @param[in]  aMessage  The message to add.
+ *
+ * @retval kThreadError_None     Successfully added the message to the queue.
+ * @retval kThreadError_Already  The message is already enqueued in a queue.
+ *
+ */
+ThreadError otMessageQueueEnqueue(otMessageQueue *aQueue, otMessage aMessage);
+
+/**
+ * This function removes a message from the given message queue.
+ *
+ * @param[in]  aQueue    A pointer to the message queue.
+ * @param[in]  aMessage  The message to remove.
+ *
+ * @retval kThreadError_None      Successfully removed the message from the queue.
+ * @retval kThreadError_NotFound  The message is not enqueued in this queue.
+ *
+ */
+ThreadError otMessageQueueDequeue(otMessageQueue *aQueue, otMessage aMessage);
+
+/**
+ * This function returns a pointer to the message at the head of the queue.
+ *
+ * @param[in]  aQueue    A pointer to a message queue.
+ *
+ * @returns  A pointer to the message at the head of queue or NULL if queue is empty.
+ *
+ */
+otMessage otMessageQueueGetHead(otMessageQueue *aQueue);
+
+/**
+ * This function returns a pointer to the next message in the queue by iterating forward (from head to tail).
+ *
+ * @param[in]  aQueue    A pointer to a message queue.
+ * @param[in]  aMessage  A pointer to current message buffer.
+ *
+ * @returns  A pointer to the next message in the queue after `aMessage` or NULL if `aMessage is the tail of queue.
+ *           NULL is returned if `aMessage` is not in the queue `aQueue`.
+ *
+ */
+otMessage otMessageQueueGetNext(otMessageQueue *aQueue, const otMessage aMessage);
 
 /**
  * @}

--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -960,6 +960,14 @@ typedef struct
 typedef void *otMessage;
 
 /**
+ * This structure represents an OpenThread message queue.
+ */
+typedef struct
+{
+    void *mData;            ///< Opaque data used by the implementation.
+} otMessageQueue;
+
+/**
  * @}
  *
  */

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -874,9 +874,9 @@ void Message::SetPriorityQueue(PriorityQueue *aPriorityQueue)
     mInfo.mInPriorityQ = true;
 }
 
-MessageQueue::MessageQueue(void) :
-    mTail(NULL)
+MessageQueue::MessageQueue(void)
 {
+    SetTail(NULL);
 }
 
 void MessageQueue::AddToList(uint8_t aList, Message &aMessage)
@@ -885,36 +885,36 @@ void MessageQueue::AddToList(uint8_t aList, Message &aMessage)
 
     assert((aMessage.Next(aList) == NULL) && (aMessage.Prev(aList) == NULL));
 
-    if (mTail == NULL)
+    if (GetTail() == NULL)
     {
         aMessage.Next(aList) = &aMessage;
         aMessage.Prev(aList) = &aMessage;
     }
     else
     {
-        head = mTail->Next(aList);
+        head = GetTail()->Next(aList);
 
         aMessage.Next(aList) = head;
-        aMessage.Prev(aList) = mTail;
+        aMessage.Prev(aList) = GetTail();
 
         head->Prev(aList) = &aMessage;
-        mTail->Next(aList) = &aMessage;
+        GetTail()->Next(aList) = &aMessage;
     }
 
-    mTail = &aMessage;
+    SetTail(&aMessage);
 }
 
 void MessageQueue::RemoveFromList(uint8_t aList, Message &aMessage)
 {
     assert((aMessage.Next(aList) != NULL) && (aMessage.Prev(aList) != NULL));
 
-    if (&aMessage == mTail)
+    if (&aMessage == GetTail())
     {
-        mTail = mTail->Prev(aList);
+        SetTail(GetTail()->Prev(aList));
 
-        if (&aMessage == mTail)
+        if (&aMessage == GetTail())
         {
-            mTail = NULL;
+            SetTail(NULL);
         }
     }
 
@@ -927,7 +927,7 @@ void MessageQueue::RemoveFromList(uint8_t aList, Message &aMessage)
 
 Message *MessageQueue::GetHead(void) const
 {
-    return (mTail == NULL) ? NULL : mTail->Next(MessageInfo::kListInterface);
+    return (GetTail() == NULL) ? NULL : GetTail()->Next(MessageInfo::kListInterface);
 }
 
 ThreadError MessageQueue::Enqueue(Message &aMessage)

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -610,6 +610,14 @@ public:
      */
     uint16_t UpdateChecksum(uint16_t aChecksum, uint16_t aOffset, uint16_t aLength) const;
 
+    /**
+     * This method returns a pointer to the message queue (if any) where this message is queued.
+     *
+     * @returns A pointer to the message queue or NULL if not in any message queue.
+     *
+     */
+    MessageQueue *GetMessageQueue(void) const { return (!mInfo.mInPriorityQ) ? mInfo.mMessageQueue : NULL; }
+
 private:
 
     /**
@@ -635,14 +643,6 @@ private:
      *
      */
     bool IsInAQueue(void) const { return (mInfo.mMessageQueue != NULL); }
-
-    /**
-     * This method returns a pointer to the message queue (if any) where this message is queued.
-     *
-     * @returns A pointer to the message queue or NULL if not in any message queue.
-     *
-     */
-    MessageQueue *GetMessageQueue(void) const { return (!mInfo.mInPriorityQ) ? mInfo.mMessageQueue : NULL; }
 
     /**
      * This method sets the message queue information for the message.
@@ -738,7 +738,7 @@ private:
  * This class implements a message queue.
  *
  */
-class MessageQueue
+class MessageQueue : public otMessageQueue
 {
     friend class Message;
     friend class PriorityQueue;
@@ -797,7 +797,15 @@ private:
      * @returns A pointer to the tail of the list.
      *
      */
-    Message *GetTail(void) const { return mTail; }
+    Message *GetTail(void) const { return static_cast<Message *>(mData); }
+
+    /**
+     * This method set the tail of the list.
+     *
+     * @param[in]  aMessage  A pointer to the message to set as new tail.
+     *
+     */
+    void SetTail(Message *aMessage) { mData = aMessage; }
 
     /**
      * This method adds a message to a list.
@@ -816,8 +824,6 @@ private:
      *
      */
     void RemoveFromList(uint8_t aListId, Message &aMessage);
-
-    Message *mTail;   ///< A pointer to the last Message in the list.
 };
 
 /**

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -1489,6 +1489,45 @@ int otWriteMessage(otMessage aMessage, uint16_t aOffset, const void *aBuf, uint1
     return message->Write(aOffset, aLength, aBuf);
 }
 
+void otMessageQueueInit(otMessageQueue *aQueue)
+{
+    aQueue->mData = NULL;
+}
+
+ThreadError otMessageQueueEnqueue(otMessageQueue *aQueue, otMessage aMessage)
+{
+    Message *message = static_cast<Message *>(aMessage);
+    MessageQueue *queue = static_cast<MessageQueue *>(aQueue);
+    return queue->Enqueue(*message);
+}
+
+ThreadError otMessageQueueDequeue(otMessageQueue *aQueue, otMessage aMessage)
+{
+    Message *message = static_cast<Message *>(aMessage);
+    MessageQueue *queue = static_cast<MessageQueue *>(aQueue);
+    return queue->Dequeue(*message);
+}
+
+otMessage otMessageQueueGetHead(otMessageQueue *aQueue)
+{
+    MessageQueue *queue = static_cast<MessageQueue *>(aQueue);
+    return queue->GetHead();
+}
+
+otMessage otMessageQueueGetNext(otMessageQueue *aQueue, otMessage aMessage)
+{
+    Message *next;
+    Message *message = static_cast<Message *>(aMessage);
+    MessageQueue *queue = static_cast<MessageQueue *>(aQueue);
+
+    VerifyOrExit(message != NULL, next = NULL);
+    VerifyOrExit(message->GetMessageQueue() == queue, next = NULL);
+    next = message->GetNext();
+
+exit:
+    return next;
+}
+
 ThreadError otOpenUdpSocket(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aCallbackContext)
 {
     ThreadError error = kThreadError_InvalidArgs;


### PR DESCRIPTION
This PR adds public OpenThread `otMessageQueue` and a set of C APIs corresponding to this. Also adds unit test to check  them.

For naming the new APIs I followed the model from new proposal #1100 to make it easier to transition.  