### PR TITLE
Initialize `length` parameter before calling `otPlatSettingsGet()`.

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -428,8 +428,17 @@ int Dataset::Compare(const Dataset &aCompare) const
 
 ThreadError Dataset::Restore(void)
 {
-    return otPlatSettingsGet(mInstance, static_cast<uint16_t>(mType == Tlv::kActiveTimestamp ? kKeyActiveDataset :
-                                                              kKeyPendingDataset), 0, mTlvs, &mLength);
+    ThreadError error;
+    uint16_t length = sizeof(mTlvs);
+
+    error = otPlatSettingsGet(mInstance, static_cast<uint16_t>(mType == Tlv::kActiveTimestamp ? kKeyActiveDataset :
+                                                               kKeyPendingDataset), 0, mTlvs, &length);
+    SuccessOrExit(error);
+
+    mLength = length;
+
+exit:
+    return error;
 }
 
 ThreadError Dataset::Store(void)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -268,9 +268,9 @@ ThreadError Mle::Restore(void)
     mNetif.GetActiveDataset().Restore();
     mNetif.GetPendingDataset().Restore();
 
+    length = sizeof(networkInfo);
     SuccessOrExit(error = otPlatSettingsGet(mNetif.GetInstance(), kKeyNetworkInfo, 0,
                                             reinterpret_cast<uint8_t *>(&networkInfo), &length));
-
     VerifyOrExit(length == sizeof(networkInfo), error = kThreadError_NotFound);
     VerifyOrExit(networkInfo.mDeviceState >= kDeviceStateChild, error = kThreadError_NotFound);
 
@@ -284,8 +284,10 @@ ThreadError Mle::Restore(void)
 
     if (networkInfo.mDeviceState == kDeviceStateChild)
     {
+        length = sizeof(mParent);
         SuccessOrExit(error = otPlatSettingsGet(mNetif.GetInstance(), kKeyParentInfo, 0,
                                                 reinterpret_cast<uint8_t *>(&mParent), &length));
+        VerifyOrExit(length == sizeof(mParent), error = kThreadError_NotFound);
     }
     else if (networkInfo.mDeviceState == kDeviceStateRouter || networkInfo.mDeviceState == kDeviceStateLeader)
     {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3339,16 +3339,19 @@ exit:
 ThreadError MleRouter::RestoreChildren(void)
 {
     ThreadError error = kThreadError_None;
-    Child *child;
-    otChildInfo childInfo;
-    uint16_t length;
 
     for (uint8_t i = 0; i < kMaxChildren; i++)
     {
+        Child *child;
+        otChildInfo childInfo;
+        uint16_t length;
+
+        length = sizeof(childInfo);
         SuccessOrExit(otPlatSettingsGet(mNetif.GetInstance(), kKeyChildInfo, i,
                                         reinterpret_cast<uint8_t *>(&childInfo), &length));
-        VerifyOrExit((child = NewChild()) != NULL, error = kThreadError_NoBufs);
+        VerifyOrExit(length == sizeof(childInfo), ;);
 
+        VerifyOrExit((child = NewChild()) != NULL, error = kThreadError_NoBufs);
         memset(child, 0, sizeof(*child));
 
         memcpy(&child->mMacAddr, &childInfo.mExtAddress, sizeof(child->mMacAddr));
@@ -3369,13 +3372,15 @@ exit:
 ThreadError MleRouter::RemoveStoredChild(uint16_t aChildRloc16)
 {
     ThreadError error = kThreadError_NotFound;
-    otChildInfo childInfo;
-    uint16_t length;
 
     for (uint8_t i = 0; i < kMaxChildren; i++)
     {
+        otChildInfo childInfo;
+        uint16_t length = sizeof(childInfo);
+
         SuccessOrExit(otPlatSettingsGet(mNetif.GetInstance(), kKeyChildInfo, i,
                                         reinterpret_cast<uint8_t *>(&childInfo), &length));
+        VerifyOrExit(length == sizeof(childInfo), ;);
 
         if (childInfo.mRloc16 == aChildRloc16)
         {


### PR DESCRIPTION
- Handle input length in `otPlatSettingsGet()` example.