### PR TITLE
Add OpenThread API to erase network settings

### DIFF
--- a/doc/spinel-protocol-src/spinel-feature-network-save.md
+++ b/doc/spinel-protocol-src/spinel-feature-network-save.md
@@ -1,11 +1,14 @@
 # Feature: Network Save
 
-The network save feature is an optional NCP capability that, when
+The network save/recall feature is an optional NCP capability that, when
 present, allows the host to save and recall network credentials and
 state to and from nonvolatile storage.
 
-The presence of this feature can be detected by checking for the
-presence of the `CAP_NET_SAVE` capability in `PROP_CAPS`.
+The presence of the save/recall feature can be detected by checking for
+the presence of the `CAP_NET_SAVE` capability in `PROP_CAPS`.
+
+Network clear feature allows host to erase all network credentials and
+state from non-volatile memory.
 
 ## Commands
 
@@ -28,17 +31,16 @@ The response to this command is always a `CMD_PROP_VALUE_IS` for
 This command is only available if the `CAP_NET_SAVE` capability is
 set.
 
-
-
 ### CMD 10: (Host->NCP) CMD_NET_CLEAR
 
 Octets: |    1   |      1
 --------|--------|---------------
 Fields: | HEADER | CMD_NET_CLEAR
 
-Clear saved network state command. Clears any previously saved network
-credentials and state previously stored by `CMD_NET_SAVE` from
-non-volatile memory.
+Clear saved network settings command. Erases all network credentials
+and state from non-volatile memory. The erased settings include any data
+saved automatically by the network stack firmware and/or data saved by
+`CMD_NET_SAVE` operation.
 
 This operation affects non-volatile memory only. The current network
 information stored in volatile memory is unaffected.
@@ -46,9 +48,8 @@ information stored in volatile memory is unaffected.
 The response to this command is always a `CMD_PROP_VALUE_IS` for
 `PROP_LAST_STATUS`, indicating the result of the operation.
 
-This command is only available if the `CAP_NET_SAVE` capability is
-set.
-
+This command is always available independent of the value of
+`CAP_NET_SAVE` capability.
 
 
 ### CMD 11: (Host->NCP) CMD_NET_RECALL

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -1689,6 +1689,17 @@ OTAPI void OTCALL otPlatformReset(otInstance *aInstance);
 OTAPI void OTCALL otFactoryReset(otInstance *aInstance);
 
 /**
+ * This method erases all the settings stored on non-volatile memory.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ *
+ * @retval kThreadError_None  All data was wiped successfully.
+ * @retval kThreadError_InvalidState  Device is not in `disabled` state/role.
+ *
+ */
+ThreadError otNetworkSettingsErase(otInstance *aInstance);
+
+/**
  * Get the ROUTER_DOWNGRADE_THRESHOLD parameter used in the Router role.
  *
  * @param[in]  aInstance  A pointer to an OpenThread instance.

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -703,6 +703,17 @@ void otFactoryReset(otInstance *aInstance)
     otPlatReset(aInstance);
 }
 
+ThreadError otNetworkSettingsErase(otInstance *aInstance)
+{
+    ThreadError error = kThreadError_None;
+
+    VerifyOrExit(otGetDeviceRole(aInstance) == kDeviceRoleDisabled, error = kThreadError_InvalidState);
+    otPlatSettingsWipe(aInstance);
+
+exit:
+    return error;
+}
+
 uint8_t otGetRouterDowngradeThreshold(otInstance *aInstance)
 {
     return aInstance->mThreadNetif.GetMle().GetRouterDowngradeThreshold();

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -83,6 +83,9 @@ const NcpBase::CommandHandlerEntry NcpBase::mCommandHandlerTable[] =
     { SPINEL_CMD_PROP_VALUE_SET, &NcpBase::CommandHandler_PROP_VALUE_SET },
     { SPINEL_CMD_PROP_VALUE_INSERT, &NcpBase::CommandHandler_PROP_VALUE_INSERT },
     { SPINEL_CMD_PROP_VALUE_REMOVE, &NcpBase::CommandHandler_PROP_VALUE_REMOVE },
+    { SPINEL_CMD_NET_SAVE, &NcpBase::CommandHandler_NET_SAVE },
+    { SPINEL_CMD_NET_CLEAR, &NcpBase::CommandHandler_NET_CLEAR },
+    { SPINEL_CMD_NET_RECALL, &NcpBase::CommandHandler_NET_RECALL },
 };
 
 const NcpBase::GetPropertyHandlerEntry NcpBase::mGetPropertyHandlerTable[] =
@@ -1298,7 +1301,7 @@ ThreadError NcpBase::CommandHandler_RESET(uint8_t header, unsigned int command, 
 
     // Signal a platform reset. If implemented, this function
     // shouldn't return.
-    otPlatReset(mInstance);
+    otPlatformReset(mInstance);
 
     // We only get to this point if the
     // platform doesn't support resetting.
@@ -1419,6 +1422,35 @@ ThreadError NcpBase::CommandHandler_PROP_VALUE_REMOVE(uint8_t header, unsigned i
     return errorCode;
 }
 
+ThreadError NcpBase::CommandHandler_NET_SAVE(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+                                             uint16_t arg_len)
+{
+    (void)command;
+    (void)arg_ptr;
+    (void)arg_len;
+
+    return SendLastStatus(header, SPINEL_STATUS_UNIMPLEMENTED);
+}
+
+ThreadError NcpBase::CommandHandler_NET_CLEAR(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+                                              uint16_t arg_len)
+{
+    (void)command;
+    (void)arg_ptr;
+    (void)arg_len;
+
+    return SendLastStatus(header, ThreadErrorToSpinelStatus(otNetworkSettingsErase(mInstance)));
+}
+
+ThreadError NcpBase::CommandHandler_NET_RECALL(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+                                               uint16_t arg_len)
+{
+    (void)command;
+    (void)arg_ptr;
+    (void)arg_len;
+
+    return SendLastStatus(header, SPINEL_STATUS_UNIMPLEMENTED);
+}
 
 // ----------------------------------------------------------------------------
 // MARK: Individual Property Getters

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -277,6 +277,9 @@ private:
                                                  uint16_t arg_len);
     ThreadError CommandHandler_PROP_VALUE_REMOVE(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
                                                  uint16_t arg_len);
+    ThreadError CommandHandler_NET_SAVE(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
+    ThreadError CommandHandler_NET_CLEAR(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
+    ThreadError CommandHandler_NET_RECALL(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
 
     ThreadError GetPropertyHandler_ChannelMaskHelper(uint8_t header, spinel_prop_key_t key, uint32_t channel_mask);
 


### PR DESCRIPTION
This commit makes the following changes:

- It adds a new OpenThread API named `otNetworkSettingsErase()` to  allow caller to erase all the settings stored on non-volatile  memory.

- It exposes the same functionality through `SPINEL_CMD_NET_CLEAR`  spinel command. It also makes `SPINEL_CMD_NET_CLEAR` implementation  non-optional (not tied to `CAP_NET_SAVE` capability).

https://github.com/openthread/wpantund/pull/118 is the counterpat of this change in wpantund.
