### PR TITLE
NcpBase: Add check for invalid value in setter of `MAC_PROMISCUOUS_MODE`

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -3109,6 +3109,10 @@ ThreadError NcpBase::SetPropertyHandler_MAC_PROMISCUOUS_MODE(uint8_t header, spi
             otPlatRadioSetPromiscuous(mInstance, true);
             errorCode = kThreadError_None;
             break;
+
+        default:
+            errorCode = kThreadError_InvalidArgs;
+            break;
         }
 
         if (errorCode == kThreadError_None)


### PR DESCRIPTION
This commit adds a check for invalid argument value in setter of the spinel property `MAC_PROMISCUOUS_MODE`.
