### PR TITLE
Spi-hdlc-adapter: Check for invalid `fd` errors

### DIFF
--- a/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
+++ b/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
@@ -1537,6 +1537,12 @@ int main(int argc, char *argv[])
         goto bail;
     }
 
+    if ((sHdlcInputFd < 0) || (sHdlcOutputFd < 0))
+    {
+        sRet = EXIT_FAILURE;
+        goto bail;
+    }
+
     // Set up sHdlcInputFd for non-blocking I/O
     if (-1 == (i = fcntl(sHdlcInputFd, F_GETFL, 0)))
     {


### PR DESCRIPTION
This commit makes a change to `spi-hdlc-adapter` to check for any possible error case where either `sHdlcInputFd` or `sHdlcOutputFd`are invalid (e.g., `dup()` failures) before starting the main loop.