### PR TITLE
Eliminate unncessary MLE Child Update Request transmissions.

### DIFF
--- a/examples/drivers/windows/otLwf/address.c
+++ b/examples/drivers/windows/otLwf/address.c
@@ -442,7 +442,7 @@ otLwfTunAddressesUpdated(
 
         {
             PIN6_ADDR pAddr = NULL;
-            otNetifAddress addr = { { 0 }, 0, 1, 1, 0, 0, NULL };
+            otNetifAddress addr = { { 0 }, 0, 1, 1, 0, 0, 0, NULL };
             uint32_t preferredLifetime = 0xFFFFFFFF;
             uint32_t validLifetime = 0xFFFFFFFF;
 

--- a/examples/drivers/windows/otLwf/thread.c
+++ b/examples/drivers/windows/otLwf/thread.c
@@ -348,6 +348,18 @@ void otLwfStateChangedCallback(uint32_t aFlags, _In_ void *aContext)
         otLwfRadioAddressesUpdated(pFilter);
     }
 
+    if ((aFlags & OT_IP6_RLOC_ADDED) != 0)
+    {
+        LogVerbose(DRIVER_DEFAULT, "Filter %p received OT_IP6_RLOC_ADDED", pFilter);
+        otLwfRadioAddressesUpdated(pFilter);
+    }
+
+    if ((aFlags & OT_IP6_RLOC_REMOVED) != 0)
+    {
+        LogVerbose(DRIVER_DEFAULT, "Filter %p received OT_IP6_RLOC_REMOVED", pFilter);
+        otLwfRadioAddressesUpdated(pFilter);
+    }
+
     if ((aFlags & OT_NET_ROLE) != 0)
     {
         LogVerbose(DRIVER_DEFAULT, "Filter %p received OT_NET_ROLE", pFilter);

--- a/examples/drivers/windows/otNodeApi/otNodeApi.cpp
+++ b/examples/drivers/windows/otNodeApi/otNodeApi.cpp
@@ -657,7 +657,8 @@ void OTCALL otNodeStateChangedCallback(uint32_t aFlags, void *aContext)
         printf("%d: new role: %s\r\n", aNode->mId, otDeviceRoleToString(Role));
     }
 
-    if ((aFlags & OT_IP6_ADDRESS_ADDED) != 0 || (aFlags & OT_IP6_ADDRESS_REMOVED) != 0)
+    if ((aFlags & OT_IP6_ADDRESS_ADDED) != 0 || (aFlags & OT_IP6_ADDRESS_REMOVED) != 0 ||
+        (aFlags & OT_IP6_RLOC_ADDED) != 0 || (aFlags & OT_IP6_RLOC_REMOVED) != 0)
     {
         HandleAddressChanges(aNode);
     }

--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -542,19 +542,22 @@ typedef struct otLinkModeConfig
  */
 enum
 {
-    OT_IP6_ADDRESS_ADDED      = 1 << 0,  ///< IPv6 address was added
-    OT_IP6_ADDRESS_REMOVED    = 1 << 1,  ///< IPv6 address was removed
+    OT_IP6_ADDRESS_ADDED         = 1 << 0,  ///< IPv6 address was added
+    OT_IP6_ADDRESS_REMOVED       = 1 << 1,  ///< IPv6 address was removed
 
-    OT_NET_ROLE               = 1 << 3,  ///< Device role (disabled, detached, child, router, leader) changed
-    OT_NET_PARTITION_ID       = 1 << 4,  ///< Partition ID changed
-    OT_NET_KEY_SEQUENCE_COUNTER = 1 << 5,  ///< Thread Key Sequence changed
+    OT_NET_ROLE                  = 1 << 3,  ///< Device role (disabled, detached, child, router, leader) changed
+    OT_NET_PARTITION_ID          = 1 << 4,  ///< Partition ID changed
+    OT_NET_KEY_SEQUENCE_COUNTER  = 1 << 5,  ///< Thread Key Sequence changed
 
-    OT_THREAD_CHILD_ADDED     = 1 << 6,  ///< Child was added
-    OT_THREAD_CHILD_REMOVED   = 1 << 7,  ///< Child was removed
-    OT_THREAD_NETDATA_UPDATED = 1 << 8,  ///< Thread Network Data updated
+    OT_THREAD_CHILD_ADDED        = 1 << 6,  ///< Child was added
+    OT_THREAD_CHILD_REMOVED      = 1 << 7,  ///< Child was removed
+    OT_THREAD_NETDATA_UPDATED    = 1 << 8,  ///< Thread Network Data updated
 
-    OT_IP6_LL_ADDR_CHANGED    = 1 << 9,  ///< The link-local address has changed
-    OT_IP6_ML_ADDR_CHANGED    = 1 << 10, ///< The mesh-local address has changed
+    OT_IP6_LL_ADDR_CHANGED       = 1 << 9,  ///< The link-local address has changed
+    OT_IP6_ML_ADDR_CHANGED       = 1 << 10, ///< The mesh-local address has changed
+
+    OT_IP6_RLOC_ADDED            = 1 << 11, ///< RLOC was added
+    OT_IP6_RLOC_REMOVED          = 1 << 12, ///< RLOC was removed
 };
 
 /**
@@ -905,6 +908,7 @@ typedef struct otNetifAddress
     bool                   mValid : 1;               ///< TRUE if the address is valid, FALSE otherwise.
     bool                   mScopeOverrideValid : 1;  ///< TRUE if the mScopeOverride value is valid, FALSE othewrise.
     unsigned int           mScopeOverride : 4;       ///< The IPv6 scope of this address.
+    bool                   mRloc : 1;                ///< TRUE if the address is an RLOC, FALSE otherwise.
     struct otNetifAddress *mNext;                    ///< A pointer to the next network interface address.
 } otNetifAddress;
 

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -322,7 +322,7 @@ ThreadError Netif::AddUnicastAddress(NetifUnicastAddress &aAddress)
     aAddress.mNext = mUnicastAddresses;
     mUnicastAddresses = &aAddress;
 
-    SetStateChangedFlags(OT_IP6_ADDRESS_ADDED);
+    SetStateChangedFlags(aAddress.mRloc ? OT_IP6_RLOC_ADDED : OT_IP6_ADDRESS_ADDED);
 
 exit:
     return error;
@@ -355,7 +355,7 @@ exit:
 
     if (error != kThreadError_NotFound)
     {
-        SetStateChangedFlags(OT_IP6_ADDRESS_REMOVED);
+        SetStateChangedFlags(aAddress.mRloc ? OT_IP6_RLOC_REMOVED : OT_IP6_ADDRESS_REMOVED);
     }
 
     return error;

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -885,6 +885,10 @@ void NcpBase::UpdateChangedProps(void)
 
             mChangedFlags &= ~static_cast<uint32_t>(OT_THREAD_NETDATA_UPDATED);
         }
+        else if ((mChangedFlags & (OT_IP6_RLOC_ADDED | OT_IP6_RLOC_REMOVED)) != 0)
+        {
+            mChangedFlags &= ~static_cast<uint32_t>(OT_IP6_RLOC_ADDED | OT_IP6_RLOC_REMOVED);
+        }
     }
 
 exit:


### PR DESCRIPTION
- Separate IPv6 RLOC changed event from IPv6 added/removed.
- Avoid unnecessary side effects when Mle::SetMeshLocalPrefix().

This change is to avoid transmitting MLE Child Update Request messages whenever the RLOC is updated.
