### PR TITLE
Update the NCP code to use `otMessage` and `otMessageQueue` APIs

### DIFF
--- a/include/openthread-message.h
+++ b/include/openthread-message.h
@@ -167,6 +167,17 @@ uint16_t otGetMessageOffset(otMessage aMessage);
 ThreadError otSetMessageOffset(otMessage aMessage, uint16_t aOffset);
 
 /**
+ * This function indicates whether or not link security is enabled for the message.
+ *
+ * @param[in]  aMessage  A pointer to a message buffer.
+ *
+ * @retval TRUE   If link security is enabled.
+ * @retval FALSE  If link security is not enabled.
+ *
+ */
+bool otIsMessageLinkSecurityEnabled(otMessage aMessage);
+
+/**
  * Append bytes to a message.
  *
  * @param[in]  aMessage  A pointer to a message buffer.

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -1482,6 +1482,12 @@ ThreadError otSetMessageOffset(otMessage aMessage, uint16_t aOffset)
     return message->SetOffset(aOffset);
 }
 
+bool otIsMessageLinkSecurityEnabled(otMessage aMessage)
+{
+    Message *message = static_cast<Message *>(aMessage);
+    return message->IsLinkSecurityEnabled();
+}
+
 ThreadError otAppendMessage(otMessage aMessage, const void *aBuf, uint16_t aLength)
 {
     Message *message = static_cast<Message *>(aMessage);

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -513,14 +513,13 @@ NcpBase::NcpBase(otInstance *aInstance):
 
 void NcpBase::HandleDatagramFromStack(otMessage aMessage, void *aContext)
 {
-    static_cast<NcpBase *>(aContext)->HandleDatagramFromStack(*static_cast<Message *>(aMessage));
+    static_cast<NcpBase *>(aContext)->HandleDatagramFromStack(aMessage);
 }
 
-void NcpBase::HandleDatagramFromStack(Message &aMessage)
+void NcpBase::HandleDatagramFromStack(otMessage aMessage)
 {
     ThreadError errorCode = kThreadError_None;
-    Message *message = &aMessage;
-    bool isSecure = message->IsLinkSecurityEnabled();
+    bool isSecure = otIsMessageLinkSecurityEnabled(aMessage);
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
 
@@ -532,15 +531,15 @@ void NcpBase::HandleDatagramFromStack(Message &aMessage)
             isSecure
             ? SPINEL_PROP_STREAM_NET
             : SPINEL_PROP_STREAM_NET_INSECURE,
-            message->GetLength()
+            otGetMessageLength(aMessage)
     ));
 
-    SuccessOrExit(errorCode = OutboundFrameFeedMessage(*message));
+    SuccessOrExit(errorCode = OutboundFrameFeedMessage(aMessage));
 
-    // Set the message pointer to NULL, to indicate that it does not need to be freed at the exit.
-    // The message is now owned by the OutboundFrame and will be freed when the frame is either successfully sent and
+    // Set the aMessage pointer to NULL, to indicate that it does not need to be freed at the exit.
+    // The aMessage is now owned by the OutboundFrame and will be freed when the frame is either successfully sent and
     // then removed, or if the frame gets discarded.
-    message = NULL;
+    aMessage = NULL;
 
     // Append any metadata (rssi, lqi, channel, etc) here!
 
@@ -548,9 +547,9 @@ void NcpBase::HandleDatagramFromStack(Message &aMessage)
 
 exit:
 
-    if (message != NULL)
+    if (aMessage != NULL)
     {
-        message->Free();
+        otFreeMessage(aMessage);
     }
 
     if (errorCode != kThreadError_None)
@@ -1225,27 +1224,26 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key, Message &aMessage)
+ThreadError NcpBase::SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key, otMessage aMessage)
 {
     ThreadError errorCode = kThreadError_None;
-    Message    *message = &aMessage;
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
     SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, command, key));
-    SuccessOrExit(errorCode = OutboundFrameFeedMessage(*message));
+    SuccessOrExit(errorCode = OutboundFrameFeedMessage(aMessage));
 
-    // Set the message pointer to NULL, to indicate that it does not need to be freed at the exit.
+    // Set the aMessage pointer to NULL, to indicate that it does not need to be freed at the exit.
     // The message is now owned by the OutboundFrame and will be freed when the frame is either successfully sent and
     // then removed, or if the frame gets discarded.
-    message = NULL;
+    aMessage = NULL;
 
     SuccessOrExit(errorCode = OutboundFrameSend());
 
 exit:
 
-    if (message != NULL)
+    if (aMessage != NULL)
     {
-        message->Free();
+        otFreeMessage(aMessage);
     }
 
     return errorCode;

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -40,7 +40,8 @@
 #endif
 
 #include <openthread-types.h>
-#include <common/message.hpp>
+#include <openthread-message.h>
+#include <openthread-ip6.h>
 #include <common/tasklet.hpp>
 #include <ncp/ncp.h>
 
@@ -103,7 +104,7 @@ protected:
      * @retval kThreadError_NoBufs  Insufficient buffer space available to add message.
      *
      */
-    virtual ThreadError OutboundFrameFeedMessage(Message &aMessage) = 0;
+    virtual ThreadError OutboundFrameFeedMessage(otMessage aMessage) = 0;
 
     /**
      * This method finalizes and sends the current outbound frame
@@ -143,7 +144,7 @@ private:
      */
     static void HandleDatagramFromStack(otMessage aMessage, void *aContext);
 
-    void HandleDatagramFromStack(Message &aMessage);
+    void HandleDatagramFromStack(otMessage aMessage);
 
     /**
      * Trampoline for HandleRawFrame().
@@ -217,7 +218,7 @@ public:
     ThreadError SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key, const uint8_t *value_ptr,
                             uint16_t value_len);
 
-    ThreadError SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key, Message &message);
+    ThreadError SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key, otMessage message);
 
     ThreadError SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key, const char *format, ...);
 

--- a/src/ncp/ncp_buffer.hpp
+++ b/src/ncp/ncp_buffer.hpp
@@ -34,7 +34,7 @@
 #define NCP_FRAME_BUFFER_HPP_
 
 #include <openthread-types.h>
-#include <common/message.hpp>
+#include <openthread-message.h>
 
 namespace Thread {
 
@@ -119,13 +119,13 @@ public:
      * In case of success, the passed-in message @p aMessage will be owned by the frame buffer instance and will be
      * freed when either the the frame is removed or discarded.
      *
-     * @param[in]  aMessage         A reference to the message to be added to current frame.
+     * @param[in]  aMessage         A  message to be added to current frame.
      *
      * @retval kThreadError_None    Successfully added the message to the frame.
      * @retval kThreadError_NoBufs  Insufficient buffer space available to add message.
      *
      */
-    ThreadError InFrameFeedMessage(Message &aMessage);
+    ThreadError InFrameFeedMessage(otMessage aMessage);
 
     /**
      * This method finalizes/ends the current input frame being written to the buffer.
@@ -332,9 +332,9 @@ private:
     BufferCallback  mNonEmptyBufferCallback;    // Callback to signal when buffer becomes non-empty.
     void *          mCallbackContext;           // Context passed to callbacks.
 
-    MessageQueue    mMessageQueue;              // Main message queue.
+    otMessageQueue  mMessageQueue;              // Main message queue.
 
-    MessageQueue    mWriteFrameMessageQueue;    // Message queue for the current frame being written.
+    otMessageQueue  mWriteFrameMessageQueue;    // Message queue for the current frame being written.
     uint8_t *       mWriteFrameStart;           // Pointer to start of current frame being written.
     uint8_t *       mWriteSegmentHead;          // Pointer to start of current segment in the frame being written.
     uint8_t *       mWriteSegmentTail;          // Pointer to end of current segment in the frame being written.
@@ -347,7 +347,7 @@ private:
     uint8_t *       mReadSegmentTail;           // Pointer to end of current segment in the frame being read.
     uint8_t *       mReadPointer;               // Pointer to next byte to read (either in segment or in msg buffer).
 
-    Message *       mReadMessage;               // Current Message in the frame being read.
+    otMessage       mReadMessage;               // Current Message in the frame being read.
     uint16_t        mReadMessageOffset;         // Offset within current message being read.
 
     uint8_t         mMessageBuffer[kMessageReadBufferSize];   // Buffer to hold part of current message being read.

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -242,7 +242,7 @@ ThreadError NcpSpi::OutboundFrameFeedData(const uint8_t *aDataBuffer, uint16_t a
     return mTxFrameBuffer.InFrameFeedData(aDataBuffer, aDataBufferLength);
 }
 
-ThreadError NcpSpi::OutboundFrameFeedMessage(Message &aMessage)
+ThreadError NcpSpi::OutboundFrameFeedMessage(otMessage aMessage)
 {
     return mTxFrameBuffer.InFrameFeedMessage(aMessage);
 }

--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -59,7 +59,7 @@ public:
 
     virtual ThreadError OutboundFrameBegin(void);
     virtual ThreadError OutboundFrameFeedData(const uint8_t *frame, uint16_t frameLength);
-    virtual ThreadError OutboundFrameFeedMessage(Message &message);
+    virtual ThreadError OutboundFrameFeedMessage(otMessage message);
     virtual ThreadError OutboundFrameEnd(void);
 
     void ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength);

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -107,7 +107,7 @@ ThreadError NcpUart::OutboundFrameFeedData(const uint8_t *aDataBuffer, uint16_t 
     return mTxFrameBuffer.InFrameFeedData(aDataBuffer, aDataBufferLength);
 }
 
-ThreadError NcpUart::OutboundFrameFeedMessage(Message &aMessage)
+ThreadError NcpUart::OutboundFrameFeedMessage(otMessage aMessage)
 {
     return mTxFrameBuffer.InFrameFeedMessage(aMessage);
 }

--- a/src/ncp/ncp_uart.hpp
+++ b/src/ncp/ncp_uart.hpp
@@ -89,13 +89,13 @@ public:
      * In case of success, the passed-in message @aMessage will be owned by outbound buffer and will be freed
      * when either the the frame is successfully sent and removed or if the frame is discarded.
      *
-     * @param[in]  aMessage         A reference to the message to be added to current frame.
+     * @param[in]  aMessage         A message instance to be added to current frame.
      *
      * @retval kThreadError_None    Successfully added the message to the frame.
      * @retval kThreadError_NoBufs  Insufficient buffer space available to add message.
      *
      */
-    virtual ThreadError OutboundFrameFeedMessage(Message &aMessage);
+    virtual ThreadError OutboundFrameFeedMessage(otMessage aMessage);
 
     /**
      * This method finalizes and sends the current outbound frame.

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -55,10 +55,22 @@ AM_CPPFLAGS                                                         = \
     -I$(top_srcdir)/src/core                                          \
     $(NULL)
 
+if OPENTHREAD_ENABLE_NCP
+
+COMMON_LDADD                                                        = \
+    $(top_builddir)/src/ncp/libopenthread-ncp.a                       \
+    $(top_builddir)/src/core/libopenthread-ftd.a                      \
+    -lpthread                                                         \
+    $(NULL)
+
+else
+
 COMMON_LDADD                                                        = \
     $(top_builddir)/src/core/libopenthread-ftd.a                      \
     -lpthread                                                         \
     $(NULL)
+
+endif # OPENTHREAD_ENABLE_NCP
 
 if OPENTHREAD_ENABLE_BUILTIN_MBEDTLS
 AM_CPPFLAGS                                                        += \
@@ -93,20 +105,14 @@ if OPENTHREAD_ENABLE_DIAG
 check_PROGRAMS                                                     += \
     test-diag                                                         \
     $(NULL)
-endif
+endif # OPENTHREAD_ENABLE_DIAG
 
 if OPENTHREAD_ENABLE_NCP
-
-COMMON_LDADD                                                       += \
-    $(top_builddir)/src/ncp/libopenthread-ncp.a                       \
-    $(NULL)
-
 check_PROGRAMS                                                     += \
     test-ncp-buffer                                                   \
     $(NULL)
-
-
 endif # OPENTHREAD_ENABLE_NCP
+
 if OPENTHREAD_WITH_ADDRESS_SANITIZER
 check_PROGRAMS                 += test-address-sanitizer
 XFAIL_TESTS                    += test-address-sanitizer

--- a/tests/unit/test_ncp_buffer.cpp
+++ b/tests/unit/test_ncp_buffer.cpp
@@ -30,6 +30,7 @@
 #include "test_util.h"
 #include <openthread.h>
 #include <common/code_utils.hpp>
+#include <common/message.hpp>
 #include <ncp/ncp_buffer.hpp>
 
 namespace Thread {
@@ -142,7 +143,7 @@ void WriteTestFrame1(NcpFrameBuffer &aNcpBuffer)
     SuccessOrQuit(aNcpBuffer.InFrameBegin(), "InFrameBegin() failed.");
     SuccessOrQuit(aNcpBuffer.InFrameFeedData(sMottoText, sizeof(sMottoText)), "InFrameFeedData() failed.");
     SuccessOrQuit(aNcpBuffer.InFrameFeedData(sMysteryText, sizeof(sMysteryText)), "InFrameFeedData() failed.");
-    SuccessOrQuit(aNcpBuffer.InFrameFeedMessage(*message), "InFrameFeedMessage() failed.");
+    SuccessOrQuit(aNcpBuffer.InFrameFeedMessage(message), "InFrameFeedMessage() failed.");
     SuccessOrQuit(aNcpBuffer.InFrameFeedData(sHelloText, sizeof(sHelloText)), "InFrameFeedData() failed.");
     SuccessOrQuit(aNcpBuffer.InFrameEnd(), "InFrameEnd() failed.");
 }
@@ -180,9 +181,9 @@ void WriteTestFrame2(NcpFrameBuffer &aNcpBuffer)
     message2->Write(0, sizeof(sHelloText), sHelloText);
 
     SuccessOrQuit(aNcpBuffer.InFrameBegin(), "InFrameFeedBegin() failed.");
-    SuccessOrQuit(aNcpBuffer.InFrameFeedMessage(*message1), "InFrameFeedMessage() failed.");
+    SuccessOrQuit(aNcpBuffer.InFrameFeedMessage(message1), "InFrameFeedMessage() failed.");
     SuccessOrQuit(aNcpBuffer.InFrameFeedData(sOpenThreadText, sizeof(sOpenThreadText)), "InFrameFeedData() failed.");
-    SuccessOrQuit(aNcpBuffer.InFrameFeedMessage(*message2), "InFrameFeedMessage() failed.");
+    SuccessOrQuit(aNcpBuffer.InFrameFeedMessage(message2), "InFrameFeedMessage() failed.");
     SuccessOrQuit(aNcpBuffer.InFrameEnd(), "InFrameEnd() failed.");
 }
 
@@ -213,7 +214,7 @@ void WriteTestFrame3(NcpFrameBuffer &aNcpBuffer)
     SuccessOrQuit(message1->SetLength(0), "Could not set the length of message.");
 
     SuccessOrQuit(aNcpBuffer.InFrameBegin(), "InFrameFeedBegin() failed.");
-    SuccessOrQuit(aNcpBuffer.InFrameFeedMessage(*message1), "InFrameFeedMessage() failed.");
+    SuccessOrQuit(aNcpBuffer.InFrameFeedMessage(message1), "InFrameFeedMessage() failed.");
     SuccessOrQuit(aNcpBuffer.InFrameFeedData(sMysteryText, sizeof(sMysteryText)), "InFrameFeedData() failed.");
     SuccessOrQuit(aNcpBuffer.InFrameEnd(), "InFrameEnd() failed.");
 }
@@ -336,7 +337,7 @@ void TestNcpFrameBuffer(void)
         SuccessOrQuit(message->SetLength(sizeof(sMysteryText)), "Could not set the length of message.");
         message->Write(0, sizeof(sMysteryText), sMysteryText);
 
-        ncpBuffer.InFrameFeedMessage(*message);
+        ncpBuffer.InFrameFeedMessage(message);
 
         // Now cause a restart the current frame and test if it's discarded ok.
         WriteTestFrame2(ncpBuffer);


### PR DESCRIPTION
This change updates the NCP related files to use `otMessage` and `otMessageQueue` APIs to replace the direct calls into OpenThread internal `Message` and `MessageQueue` classes.