### PR TITLE
filter out outdated MLE advertisement from old partition

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -461,6 +461,8 @@ ThreadError Mle::BecomeChild(otMleAttachFilter aFilter)
     if (aFilter == kMleAttachAnyPartition)
     {
         mParent.mState = Neighbor::kStateInvalid;
+        mLastPartitionId = mMleRouter.GetPreviousPartitionId();
+        mLastPartitionRouterIdSequence = mMleRouter.GetRouterIdSequence();
     }
 
     mParentRequestTimer.Start(kParentRequestRouterTimeout);

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1217,6 +1217,8 @@ protected:
     uint8_t mRouterSelectionJitter;         ///< The variable to save the assigned jitter value.
     uint8_t mRouterSelectionJitterTimeout;  ///< The Timeout prior to request/release Router ID.
 
+    uint8_t mLastPartitionRouterIdSequence;
+    uint32_t mLastPartitionId;
 private:
     enum
     {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1285,6 +1285,12 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
                      leaderData.GetWeighting(), partitionId,
                      mLeaderData.GetWeighting(), mLeaderData.GetPartitionId());
 
+        if (partitionId == mLastPartitionId && (mDeviceMode & ModeTlv::kModeFFD))
+        {
+            VerifyOrExit((static_cast<int8_t>(route.GetRouterIdSequence() - mLastPartitionRouterIdSequence) > 0),
+                         error = kThreadError_Drop);
+        }
+
         if (GetDeviceState() == kDeviceStateChild &&
             (memcmp(&mParent.mMacAddr, &macAddr, sizeof(mParent.mMacAddr)) == 0 || !(mDeviceMode & ModeTlv::kModeFFD)))
         {
@@ -3266,6 +3272,11 @@ exit:
 void MleRouter::SetPreviousPartitionId(uint32_t aPartitionId)
 {
     mPreviousPartitionId = aPartitionId;
+}
+
+uint32_t MleRouter::GetPreviousPartitionId(void) const
+{
+    return mPreviousPartitionId;
 }
 
 void MleRouter::SetRouterId(uint8_t aRouterId)

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -299,6 +299,12 @@ public:
     ThreadError SetPreferredRouterId(uint8_t aRouterId);
 
     /**
+     * This method gets the Partition Id which the device joined successfully once.
+     *
+     */
+    uint32_t GetPreviousPartitionId(void) const;
+
+    /**
      * This method sets the Partition Id which the device joins successfully.
      *
      * @param[in]  aPartitionId   The Partition Id.

--- a/src/core/thread/mle_router_mtd.hpp
+++ b/src/core/thread/mle_router_mtd.hpp
@@ -69,6 +69,7 @@ public:
     void SetLeaderPartitionId(uint32_t) { }
 
     ThreadError SetPreferredRouterId(uint8_t) { return kThreadError_NotImplemented; }
+    uint32_t GetPreviousPartitionId(void) const { return 0; }
     void SetPreviousPartitionId(uint32_t) { }
     void SetRouterId(uint8_t) { }
 


### PR DESCRIPTION
As discussed in [spec-660](https://threadgroup.atlassian.net/browse/SPEC-660), the outdated MLE advertisement from old partition should be filtered out when the recipient is in new partition. 
Resolved 5.1.4 failing when interop with NXP and unstable 9.2.9 found during R2([DEV-1194](https://threadgroup.atlassian.net/browse/DEV-1194))