### PR TITLE
THCI: update default SED polling rate as 3s

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -80,7 +80,8 @@ class OpenThread(IThci):
             self.pskc = ModuleHelper.Default_PSKc
             self.securityPolicySecs = ModuleHelper.Default_SecurityPolicy
             self.activetimestamp = ModuleHelper.Default_ActiveTimestamp
-            self.sedPollingRate = ModuleHelper.Default_Harness_SED_Polling_Rate
+            #self.sedPollingRate = ModuleHelper.Default_Harness_SED_Polling_Rate
+            self.sedPollingRate = 3
             self.deviceRole = None
             self.provisioningUrl = ''
             self.logThread = Queue()


### PR DESCRIPTION
workaround for NXP's not responding ChildId Request during child's reattaching in Child Timeout period [DEV-1223](https://threadgroup.atlassian.net/browse/DEV-1223)