### PR TITLE
Convert `MeshHeader` constructors to fail-able initializers

### DIFF
--- a/src/core/common/code_utils.hpp
+++ b/src/core/common/code_utils.hpp
@@ -44,6 +44,7 @@
 #define otDEFINE_ALIGNED_VAR(name, size, align_type)            \
     align_type name[(((size) + (sizeof (align_type) - 1)) / sizeof (align_type))]
 
+/* Check the input `ERR` against zero and go to `exit` label if it is non-zero. */
 #define SuccessOrExit(ERR)                      \
   do {                                          \
     if ((ERR) != 0) {                           \
@@ -51,18 +52,33 @@
     }                                           \
   } while (false)
 
-#define VerifyOrExit(COND, ACTION) \
-  do {                             \
-    if (!(COND)) {                 \
-      ACTION;                      \
-      goto exit;                   \
-    }                              \
+/* Verify that the `COND` is true, otherwise go to `exit` label. */
+#define VerifyOrExit(COND, ACTION)              \
+  do {                                          \
+    if (!(COND)) {                              \
+      ACTION;                                   \
+      goto exit;                                \
+    }                                           \
   } while (false)
 
+/* Run the passed in statement(s) and go to `exit` label. */
 #define ExitNow(...)                            \
   do {                                          \
     __VA_ARGS__;                                \
     goto exit;                                  \
   } while (false)
+
+/*
+ * Run the `statement` and ignore the return value.
+ *
+ * This is primarily used to indicate the intention of developer that the return value of function/method can be
+ * safely ignored.
+ *
+ */
+#define IgnoreReturnValue(statement)           \
+  do {                                         \
+    if (statement) {}                          \
+  } while (false)
+
 
 #endif  // CODE_UTILS_HPP_

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -233,39 +233,33 @@ public:
     MeshHeader(void) { memset(this, 0, sizeof(*this)); }
 
     /**
-     * Mesh Header constructor that takes frame @p aFrame as a parameter.
-     *
-     * @param[in]  aFrame  The pointer to the frame.
-     *
-     */
-    MeshHeader(const uint8_t *aFrame) {
-        mDispatchHopsLeft = *aFrame++;
-        mDeepHopsLeft = IsDeepHopsLeftField() ? *aFrame++ : 0;
-        memcpy(&mAddress, aFrame, sizeof(mAddress));
-    }
-
-    /**
-     * Mesh Header constructor that takes message object @p aMessage as a parameter.
-     *
-     * @param[in]  aMessage  The message object.
-     *
-     */
-    MeshHeader(const Message &aMessage) {
-        aMessage.Read(0, sizeof(mDispatchHopsLeft), &mDispatchHopsLeft);
-
-        if (IsDeepHopsLeftField()) {
-            aMessage.Read(1, sizeof(mDeepHopsLeft) + sizeof(mAddress), &mDeepHopsLeft);
-        }
-        else {
-            aMessage.Read(1, sizeof(mAddress), &mAddress);
-        }
-    }
-
-    /**
      * This method initializes the header.
      *
      */
     void Init(void) { mDispatchHopsLeft = kDispatch | kSourceShort | kDestinationShort; }
+
+    /**
+     * This method initializes the mesh header from a frame @p aFrame.
+     *
+     * @param[in]  aFrame        The pointer to the frame.
+     * @param[in]  aFrameLength  The length of the frame.
+     *
+     * @retval kThreadError_None     Mesh Header initialized successfully.
+     * @retval kThreadError_Failed   Mesh header could not be initialized from @p aFrame (e.g., frame not long enough).
+     *
+     */
+    ThreadError Init(const uint8_t *aFrame, uint8_t aFrameLength);
+
+    /**
+     * This method initializes the mesh header from a message object @p aMessage.
+     *
+     * @param[in]  aMessage  The message object.
+     *
+     * @retval kThreadError_None     Mesh Header initialized successfully.
+     * @retval kThreadError_Failed   Mesh header could not be initialized from @ aMessage(e.g., not long enough).
+     *
+     */
+    ThreadError Init(const Message &aMessage);
 
     /**
      * This method indicates whether or not the header is a Mesh Header.


### PR DESCRIPTION
This commit makes the following changes:

- It converts two of lowpan `MeshHeader` constructors to a
  fail-able initializers to handle error case where the passed-in
  argument frame or message is too short. It also updates
  `MeshForwarder` to use the new initializers instead.

- It adds new macro `IgnoreReturnValue()`. This macro is primarily
  used to indicate the intention of developer that the return value
  of the function/method can be safely ignored.