### PR TITLE
Fix a python sniffer stop method (Remove deadlock).

### DIFF
--- a/tests/scripts/thread-cert/sniffer.py
+++ b/tests/scripts/thread-cert/sniffer.py
@@ -103,10 +103,11 @@ class Sniffer:
         """ Stop sniffing. """
 
         self._thread_alive.clear()
-        self._thread.join()
-        self._thread = None
 
         self._transport.close()
+        
+        self._thread.join()
+        self._thread = None
 
     def get_messages_sent_by(self, nodeid):
         """ Get sniffed messages.


### PR DESCRIPTION
A fix for the deadlock in the python sniffer.