### PR TITLE
Add additional check for ALOC as destination address of CoAP request messages.

### DIFF
--- a/src/core/coap/coap_client.cpp
+++ b/src/core/coap/coap_client.cpp
@@ -309,7 +309,8 @@ Message *Client::FindRelatedRequest(const Header &aResponseHeader, const Ip6::Me
         aRequestMetadata.ReadFrom(*message);
 
         if (((aRequestMetadata.mDestinationAddress == aMessageInfo.GetPeerAddr()) ||
-             aRequestMetadata.mDestinationAddress.IsMulticast()) &&
+             aRequestMetadata.mDestinationAddress.IsMulticast() ||
+             aRequestMetadata.mDestinationAddress.IsAnycastRoutingLocator()) &&
             (aRequestMetadata.mDestinationPort == aMessageInfo.GetPeerPort()))
         {
             assert(aRequestHeader.FromMessage(*message, true) == kThreadError_None);

--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -112,6 +112,7 @@ ThreadError Leader::SendPetitionResponse(const Coap::Header &aRequestHeader, con
     StateTlv state;
     CommissionerSessionIdTlv sessionId;
     Message *message;
+    Ip6::MessageInfo responseInfo(aMessageInfo);
 
     VerifyOrExit((message = mCoapServer.NewMeshCoPMessage(0)) != NULL, error = kThreadError_NoBufs);
 
@@ -137,7 +138,8 @@ ThreadError Leader::SendPetitionResponse(const Coap::Header &aRequestHeader, con
         SuccessOrExit(error = message->Append(&sessionId, sizeof(sessionId)));
     }
 
-    SuccessOrExit(error = mCoapServer.SendMessage(*message, aMessageInfo));
+    memset(&responseInfo.mSockAddr, 0, sizeof(responseInfo.mSockAddr));
+    SuccessOrExit(error = mCoapServer.SendMessage(*message, responseInfo));
 
     otLogInfoMeshCoP("sent petition response");
 
@@ -202,6 +204,7 @@ ThreadError Leader::SendKeepAliveResponse(const Coap::Header &aRequestHeader, co
     Coap::Header responseHeader;
     StateTlv state;
     Message *message;
+    Ip6::MessageInfo responseInfo(aMessageInfo);
 
     VerifyOrExit((message = mCoapServer.NewMeshCoPMessage(0)) != NULL, error = kThreadError_NoBufs);
 
@@ -214,6 +217,7 @@ ThreadError Leader::SendKeepAliveResponse(const Coap::Header &aRequestHeader, co
     state.SetState(aState);
     SuccessOrExit(error = message->Append(&state, sizeof(state)));
 
+    memset(&responseInfo.mSockAddr, 0, sizeof(responseInfo.mSockAddr));
     SuccessOrExit(error = mCoapServer.SendMessage(*message, aMessageInfo));
 
     otLogInfoMeshCoP("sent keep alive response");

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -223,6 +223,7 @@ void AddressResolver::HandleAddressNotification(Coap::Header &aHeader, Message &
     ThreadRloc16Tlv rloc16Tlv;
     ThreadLastTransactionTimeTlv lastTransactionTimeTlv;
     uint32_t lastTransactionTime;
+    Ip6::MessageInfo responseInfo(aMessageInfo);
 
     VerifyOrExit(aHeader.GetType() == kCoapTypeConfirmable &&
                  aHeader.GetCode() == kCoapRequestPost, ;);
@@ -281,6 +282,8 @@ void AddressResolver::HandleAddressNotification(Coap::Header &aHeader, Message &
             mCache[i].mTimeout = 0;
             mCache[i].mFailures = 0;
             mCache[i].mState = Cache::kStateCached;
+
+            memset(&responseInfo.mSockAddr, 0, sizeof(responseInfo.mSockAddr));
 
             if (mCoapServer.SendEmptyAck(aHeader, aMessageInfo) == kThreadError_None)
             {
@@ -360,6 +363,7 @@ void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessag
     uint8_t numChildren;
     Mac::ExtAddress macAddr;
     Ip6::Address destination;
+    Ip6::MessageInfo responseInfo(aMessageInfo);
 
     VerifyOrExit(aHeader.GetType() == kCoapTypeConfirmable &&
                  aHeader.GetCode() == kCoapRequestPost, error = kThreadError_Drop);
@@ -368,7 +372,9 @@ void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessag
 
     if (!aMessageInfo.GetSockAddr().IsMulticast())
     {
-        if (mCoapServer.SendEmptyAck(aHeader, aMessageInfo) == kThreadError_None)
+        memset(&responseInfo.mSockAddr, 0, sizeof(responseInfo.mSockAddr));
+
+        if (mCoapServer.SendEmptyAck(aHeader, responseInfo) == kThreadError_None)
         {
             otLogInfoArp("Sent address error notification acknowledgment");
         }

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -362,6 +362,7 @@ void Leader::SendCommissioningSetResponse(const Coap::Header &aRequestHeader, co
     Coap::Header responseHeader;
     Message *message;
     MeshCoP::StateTlv state;
+    Ip6::MessageInfo responseInfo(aMessageInfo);
 
     VerifyOrExit((message = mCoapServer.NewMeshCoPMessage(0)) != NULL, error = kThreadError_NoBufs);
 
@@ -374,7 +375,8 @@ void Leader::SendCommissioningSetResponse(const Coap::Header &aRequestHeader, co
     state.SetState(aState);
     SuccessOrExit(error = message->Append(&state, sizeof(state)));
 
-    SuccessOrExit(error = mCoapServer.SendMessage(*message, aMessageInfo));
+    memset(&responseInfo.mSockAddr, 0, sizeof(responseInfo.mSockAddr));
+    SuccessOrExit(error = mCoapServer.SendMessage(*message, responseInfo));
 
     otLogInfoMeshCoP("sent commissioning dataset set response");
 

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -2413,7 +2413,7 @@ class OpenThread(IThci):
 
             if xBorderRouterLocator != None:
                 cmd += ' locator '
-                cmd += str(xBorderRouterLocator)
+                cmd += str(hex(xBorderRouterLocator))
 
             if xChannelTlv != None:
                 cmd += ' binary '


### PR DESCRIPTION
Interop with NXP, notice that when OT as commissioner and NXP as Leader, OT sends the MGMT_COMM_SET.req to Leader's ALOC address, NXP node will response CoAP message with its RLOC unicast address, this will cause CoAP message retransmission due to the src/dst address mismatches. (Depends on the port, message id and token, so remove the address comparison). Thus Harness cannot find the correct packets, influences 9.2.2-commissioner and 9.2.4-commissioner. Screenshot as below:
![coap_retransmit](https://cloud.githubusercontent.com/assets/19245360/22021188/c5fcacca-dcf6-11e6-8096-3f939d537add.png)

Another enhancement is to select Leader's RLOC unicast address instead of ALOC as source address to response messages.  Please have a check.