### PR TITLE
Add PSKc generation feature support

### DIFF
--- a/etc/visual-studio/libopenthread.vcxproj
+++ b/etc/visual-studio/libopenthread.vcxproj
@@ -72,6 +72,7 @@
     <ClCompile Include="..\..\src\core\crypto\aes_ecb.cpp" />
     <ClCompile Include="..\..\src\core\crypto\hmac_sha256.cpp" />
     <ClCompile Include="..\..\src\core\crypto\mbedtls.cpp" />
+    <ClCompile Include="..\..\src\core\crypto\pbkdf2_cmac.cpp" />
     <ClCompile Include="..\..\src\core\crypto\sha256.cpp" />
     <ClCompile Include="..\..\src\core\mac\mac.cpp" />
     <ClCompile Include="..\..\src\core\mac\mac_blacklist.cpp" />
@@ -145,6 +146,7 @@
     <ClInclude Include="..\..\src\core\crypto\aes_ecb.hpp" />
     <ClInclude Include="..\..\src\core\crypto\hmac_sha256.hpp" />
     <ClInclude Include="..\..\src\core\crypto\mbedtls.hpp" />
+    <ClInclude Include="..\..\src\core\crypto\pbkdf2_cmac.h" />
     <ClInclude Include="..\..\src\core\crypto\sha256.hpp" />
     <ClInclude Include="..\..\src\core\mac\mac.hpp" />
     <ClInclude Include="..\..\src\core\mac\mac_blacklist.hpp" />

--- a/etc/visual-studio/libopenthread.vcxproj.filters
+++ b/etc/visual-studio/libopenthread.vcxproj.filters
@@ -234,6 +234,9 @@
     <ClCompile Include="..\..\src\core\crypto\mbedtls.cpp">
       <Filter>Source Files\crypto</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\core\crypto\pbkdf2_cmac.cpp">
+      <Filter>Source Files\crypto</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\core\crypto\sha256.cpp">
       <Filter>Source Files\crypto</Filter>
     </ClCompile>
@@ -480,6 +483,9 @@
       <Filter>Header Files\crypto</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\core\crypto\mbedtls.hpp">
+      <Filter>Header Files\crypto</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\crypto\pbkdf2_cmac.h">
       <Filter>Header Files\crypto</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\core\crypto\sha256.hpp">

--- a/etc/visual-studio/libopenthread_k.vcxproj
+++ b/etc/visual-studio/libopenthread_k.vcxproj
@@ -80,6 +80,7 @@
     <ClCompile Include="..\..\src\core\crypto\aes_ccm.cpp" />
     <ClCompile Include="..\..\src\core\crypto\aes_ecb.cpp" />
     <ClCompile Include="..\..\src\core\crypto\hmac_sha256.cpp" />
+    <ClCompile Include="..\..\src\core\crypto\pbkdf2_cmac.cpp" />
     <ClCompile Include="..\..\src\core\crypto\sha256.cpp" />
     <ClCompile Include="..\..\src\core\mac\mac.cpp" />
     <ClCompile Include="..\..\src\core\mac\mac_blacklist.cpp" />
@@ -153,6 +154,7 @@
     <ClInclude Include="..\..\src\core\crypto\aes_ecb.hpp" />
     <ClInclude Include="..\..\src\core\crypto\hmac_sha256.hpp" />
     <ClInclude Include="..\..\src\core\crypto\mbedtls.hpp" />
+    <ClInclude Include="..\..\src\core\crypto\pbkdf2_cmac.h" />
     <ClInclude Include="..\..\src\core\crypto\sha256.hpp" />
     <ClInclude Include="..\..\src\core\mac\mac.hpp" />
     <ClInclude Include="..\..\src\core\mac\mac_blacklist.hpp" />

--- a/etc/visual-studio/libopenthread_k.vcxproj.filters
+++ b/etc/visual-studio/libopenthread_k.vcxproj.filters
@@ -231,6 +231,9 @@
     <ClCompile Include="..\..\src\core\crypto\hmac_sha256.cpp">
       <Filter>Source Files\crypto</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\core\crypto\pbkdf2_cmac.cpp">
+      <Filter>Source Files\crypto</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\core\crypto\sha256.cpp">
       <Filter>Source Files\crypto</Filter>
     </ClCompile>
@@ -468,6 +471,9 @@
       <Filter>Header Files\crypto</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\core\crypto\mbedtls.hpp">
+      <Filter>Header Files\crypto</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\crypto\pbkdf2_cmac.h">
       <Filter>Header Files\crypto</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\core\crypto\sha256.hpp">

--- a/etc/visual-studio/mbedtls.vcxproj
+++ b/etc/visual-studio/mbedtls.vcxproj
@@ -59,6 +59,7 @@
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\ccm.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\cipher.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\cipher_wrap.c" />
+    <ClCompile Include="..\..\third_party\mbedtls\repo\library\cmac.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\ctr_drbg.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\debug.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\ecjpake.c" />

--- a/etc/visual-studio/mbedtls.vcxproj.filters
+++ b/etc/visual-studio/mbedtls.vcxproj.filters
@@ -31,6 +31,9 @@
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\cipher_wrap.c">
       <Filter>Source Files\repo\library</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\third_party\mbedtls\repo\library\cmac.c">
+      <Filter>Source Files\repo\library</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\ctr_drbg.c">
       <Filter>Source Files\repo\library</Filter>
     </ClCompile>

--- a/etc/visual-studio/mbedtls_k.vcxproj
+++ b/etc/visual-studio/mbedtls_k.vcxproj
@@ -62,6 +62,7 @@
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\ccm.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\cipher.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\cipher_wrap.c" />
+    <ClCompile Include="..\..\third_party\mbedtls\repo\library\cmac.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\ctr_drbg.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\debug.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\ecjpake.c" />

--- a/etc/visual-studio/mbedtls_k.vcxproj.filters
+++ b/etc/visual-studio/mbedtls_k.vcxproj.filters
@@ -31,6 +31,9 @@
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\cipher_wrap.c">
       <Filter>Source Files\repo\library</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\third_party\mbedtls\repo\library\cmac.c">
+      <Filter>Source Files\repo\library</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\ctr_drbg.c">
       <Filter>Source Files\repo\library</Filter>
     </ClCompile>

--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -245,7 +245,11 @@ typedef struct otMeshLocalPrefix
     uint8_t m8[OT_MESH_LOCAL_PREFIX_SIZE];
 } otMeshLocalPrefix;
 
-#define OT_PSKC_MAX_SIZE           16  ///< Maximum size of the PSKc (bytes)
+#define OT_PSKC_MAX_SIZE                             16  ///< Maximum size of the PSKc (bytes)
+
+#define OT_COMMISSIONING_PASSPHRASE_MIN_SIZE         6   ///< Minimum size of the Commissioning Passphrase
+#define OT_COMMISSIONING_PASSPHRASE_MAX_SIZE         255 ///< Maximum size of the Commissioning Passphrase
+#define OT_COMMISSIONING_PASSPHRASE_DEFAULT          "OpenThreadPassphrase"  ///< The default commissioning passphrase
 
 /**
   * This structure represents PSKc.

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -640,6 +640,24 @@ OTAPI const uint8_t *OTCALL otGetMasterKey(otInstance *aInstance, uint8_t *aKeyL
 OTAPI ThreadError OTCALL otSetMasterKey(otInstance *aInstance, const uint8_t *aKey, uint8_t aKeyLength);
 
 /**
+ * This method generates PSKc.
+ *
+ * PSKc is used to establish the Commissioner Session.
+ *
+ * @param[in]  aInstance     A pointer to an OpenThread instance.
+ * @param[in]  aPassPhrase   The commissioning passphrase.
+ * @param[in]  aNetworkName  The network name for PSKc computation.
+ * @param[in]  aExtPanId     The extended pan id for PSKc computation.
+ * @param[out] aPSKc         A pointer to where the generated PSKc will be placed.
+ *
+ * @retval kThreadErrorNone          Successfully generate PSKc.
+ * @retval kThreadError_InvalidArgs  If any of the input arguments is invalid.
+ *
+ */
+OTAPI ThreadError OTCALL otGeneratePSKc(otInstance *aInstance, const char *aPassPhrase, const char *aNetworkName,
+                                        const uint8_t *aExtPanId, uint8_t *aPSKc);
+
+/**
  * This function returns the maximum transmit power setting in dBm.
  *
  * @param[in]  aInstance   A pointer to an OpenThread instance.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -406,6 +406,7 @@ networkname
 panid
 pending
 pendingtimestamp
+pskc
 userdata
 Done
 ```
@@ -642,6 +643,24 @@ Set pending timestamp.
 
 ```bash
 > dataset pendingtimestamp 123456789
+Done
+```
+
+### dataset pskc \[pskc\]
+
+Set pskc with hex format.
+
+```bash
+> dataset pskc 67c0c203aa0b042bfb5381c47aef4d9e
+Done
+```
+
+### dataset pskc \[passphrase\] \[networkname\] \[extpanid\]
+
+Generate pskc from passphrase, network name and extended panid.
+
+```bash
+> dataset pskc OpenThreadPassphrase OpenThread dead00beef00cafe
 Done
 ```
 

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -666,17 +666,25 @@ exit:
 ThreadError Dataset::ProcessPSKc(otInstance *aInstance, int argc, char *argv[])
 {
     ThreadError error = kThreadError_None;
+    uint8_t extPanId[OT_EXT_PAN_ID_SIZE];
     uint16_t length;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit((argc == 1) || (argc == 3), error = kThreadError_Parse);
 
-    length = static_cast<uint16_t>((strlen(argv[0]) + 1) / 2);
-    VerifyOrExit(length <= OT_PSKC_MAX_SIZE, error = kThreadError_NoBufs);
-    VerifyOrExit(Interpreter::Hex2Bin(argv[0], sDataset.mPSKc.m8 + OT_PSKC_MAX_SIZE - length, length)
-                 == length, error = kThreadError_Parse);
+    if (argc == 1)
+    {
+        length = static_cast<uint16_t>((strlen(argv[0]) + 1) / 2);
+        VerifyOrExit(length <= OT_PSKC_MAX_SIZE, error = kThreadError_NoBufs);
+        VerifyOrExit(Interpreter::Hex2Bin(argv[0], sDataset.mPSKc.m8 + OT_PSKC_MAX_SIZE - length, length) == length,
+                     error = kThreadError_Parse);
+    }
+    else
+    {
+        VerifyOrExit(Interpreter::Hex2Bin(argv[2], extPanId, sizeof(extPanId)) >= 0, error = kThreadError_Parse);
+        SuccessOrExit(error = otGeneratePSKc(aInstance, argv[0], argv[1], extPanId, sDataset.mPSKc.m8));
+    }
 
     sDataset.mIsPSKcSet = true;
-    (void)aInstance;
 
 exit:
     return error;

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -145,6 +145,7 @@ libopenthread_ftd_a_CPPFLAGS        = \
 
 libopenthread_ftd_a_SOURCES         = \
     $(SOURCES_COMMON)                 \
+    crypto/pbkdf2_cmac.cpp            \
     meshcop/dataset_manager_ftd.cpp   \
     meshcop/joiner_router.cpp         \
     meshcop/leader.cpp                \
@@ -190,6 +191,7 @@ noinst_HEADERS                      = \
     crypto/aes_ecb.hpp                \
     crypto/hmac_sha256.hpp            \
     crypto/mbedtls.hpp                \
+    crypto/pbkdf2_cmac.h              \
     crypto/sha256.hpp                 \
     mac/mac.hpp                       \
     mac/mac_blacklist.hpp             \

--- a/src/core/crypto/pbkdf2_cmac.cpp
+++ b/src/core/crypto/pbkdf2_cmac.cpp
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2016, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements PBKDF2 using AES-CMAC-PRF-128
+ */
+
+#include <string.h>
+#include <crypto/pbkdf2_cmac.h>
+#include <mbedtls/cmac.h>
+
+namespace Thread {
+namespace Crypto {
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void otPbkdf2Cmac(
+    const uint8_t *aPassword, uint16_t aPasswordLen,
+    const uint8_t *aSalt, uint16_t aSaltLen,
+    uint32_t aIterationCounter , uint16_t aKeyLen,
+    uint8_t *aKey)
+{
+    uint32_t blockCounter = 0;
+    uint16_t useLen = 0;
+    uint16_t prfBlockLen = MBEDTLS_CIPHER_BLKSIZE_MAX;
+    uint8_t prfInput[OT_PBKDF2_SALT_MAX_LEN + 4]; // Salt || INT(), for U1 calculation
+    uint8_t prfOutput[MBEDTLS_CIPHER_BLKSIZE_MAX];
+    uint8_t keyBlock[MBEDTLS_CIPHER_BLKSIZE_MAX];
+    uint8_t *key = aKey;
+    uint16_t keyLen = aKeyLen;
+
+    while (keyLen)
+    {
+        memcpy(prfInput, aSalt, aSaltLen);
+
+        blockCounter++;
+        prfInput[aSaltLen + 0] = (uint8_t)(blockCounter >> 24);
+        prfInput[aSaltLen + 1] = (uint8_t)(blockCounter >> 16);
+        prfInput[aSaltLen + 2] = (uint8_t)(blockCounter >> 8);
+        prfInput[aSaltLen + 3] = (uint8_t)(blockCounter);
+
+        // Calculate U_1
+        mbedtls_aes_cmac_prf_128(aPassword, aPasswordLen, prfInput, aSaltLen + 4, prfOutput);
+        memcpy(keyBlock, prfOutput, prfBlockLen);
+
+        for (uint32_t i = 1; i < aIterationCounter; i++)
+        {
+            memcpy(prfInput, prfOutput, prfBlockLen);
+
+            // Calculate U_i
+            mbedtls_aes_cmac_prf_128(aPassword, aPasswordLen, prfInput, prfBlockLen, prfOutput);
+
+            // xor
+            for (uint32_t j = 0; j < prfBlockLen; j++)
+            {
+                keyBlock[j] ^= prfOutput[j];
+            }
+        }
+
+        useLen = (keyLen < prfBlockLen) ? keyLen : prfBlockLen;
+        memcpy(key, keyBlock, useLen);
+        key += useLen;
+        keyLen -= useLen;
+    }
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+}  // namespace Crypto
+}  // namespace Thread

--- a/src/core/crypto/pbkdf2_cmac.h
+++ b/src/core/crypto/pbkdf2_cmac.h
@@ -28,42 +28,42 @@
 
 /**
  * @file
- *   This file includes definitions for manipulating Thread Network Data managed by the Thread Leader.
+ * @brief
+ *  This file defines the PBKDF2 using CMAC C APIs.
  */
 
-#ifndef NETWORK_DATA_LEADER_MTD_HPP_
-#define NETWORK_DATA_LEADER_MTD_HPP_
+#ifndef PBKDF2_CMAC_H_
+#define PBKDF2_CMAC_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 
-namespace Thread {
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-class ThreadNetif;
+#define OT_PBKDF2_SALT_MAX_LEN 30  // salt prefix (6) + extended panid (8) + network name (16)
 
-namespace NetworkData {
+/**
+ * This method perform PKCS#5 PBKDF2 using CMAC (AES-CMAC-PRF-128).
+ *
+ * @param[in]     aPassword          Password to use when generating key.
+ * @param[in]     aPasswordLen       Length of password.
+ * @param[in]     aSalt              Salt to use when generating key.
+ * @param[in]     aSaltLen           Length of salt.
+ * @param[in]     aIterationCounter  Iteration count.
+ * @param[in]     aKeyLen            Length of generated key in bytes.
+ * @param[out]    aKey               A pointer to the generated key.
+ *
+ */
+void otPbkdf2Cmac(
+    const uint8_t *aPassword, uint16_t aPasswordLen,
+    const uint8_t *aSalt, uint16_t aSaltLen,
+    uint32_t aIterationCounter , uint16_t aKeyLen,
+    uint8_t *aKey);
 
-class Leader: public LeaderBase
-{
-public:
-    explicit Leader(ThreadNetif &aThreadNetif) : LeaderBase(aThreadNetif) { }
+#ifdef __cplusplus
+}  // extern "C"
+#endif
 
-    void Start(void) { }
-    void Stop(void) { }
-
-    void IncrementVersion(void) { }
-    void IncrementStableVersion(void) { }
-
-    uint32_t GetContextIdReuseDelay(void) const { return 0; }
-    ThreadError SetContextIdReuseDelay(uint32_t) { return kThreadError_NotImplemented; }
-
-    void RemoveBorderRouter(uint16_t) { }
-
-    ThreadError SendServerDataNotification(uint16_t) { return kThreadError_NotImplemented; }
-
-    ThreadError GeneratePSKc(const char *, const char *, const uint8_t *, uint8_t *) { return kThreadError_NotImplemented; }
-};
-
-}  // namespace NetworkData
-}  // namespace Thread
-
-#endif  // NETWORK_DATA_LEADER_MTD_HPP_
+#endif  // PBKDF2_CMAC_H_

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -156,10 +156,15 @@ ThreadError ActiveDataset::GenerateLocal(void)
     // PSKc
     if (!IsTlvInitialized(Tlv::kPSKc))
     {
-        const uint8_t PSKc[16] = {0};
         PSKcTlv tlv;
+        uint8_t pskc[OT_PSKC_MAX_SIZE] = {0};
+        const char password[OT_COMMISSIONING_PASSPHRASE_MAX_SIZE] = OT_COMMISSIONING_PASSPHRASE_DEFAULT;
+        const char *networkName = mNetif.GetMac().GetNetworkName();
+        const uint8_t *extPanId = mNetif.GetMac().GetExtendedPanId();
+
+        mNetif.GetNetworkDataLeader().GeneratePSKc(password, networkName, extPanId, pskc);
         tlv.Init();
-        tlv.SetPSKc(PSKc);
+        tlv.SetPSKc(pskc);
         mLocal.Set(tlv);
     }
 

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -270,6 +270,12 @@ ThreadError otSetMasterKey(otInstance *aInstance, const uint8_t *aKey, uint8_t a
     return aInstance->mThreadNetif.GetKeyManager().SetMasterKey(aKey, aKeyLength);
 }
 
+ThreadError otGeneratePSKc(otInstance *aInstance, const char *aPassPhrase, const char *aNetworkName,
+                           const uint8_t *aExtPanId, uint8_t *aPSKc)
+{
+    return aInstance->mThreadNetif.GetNetworkDataLeader().GeneratePSKc(aPassPhrase, aNetworkName, aExtPanId, aPSKc);
+}
+
 int8_t otGetMaxTransmitPower(otInstance *aInstance)
 {
     return aInstance->mThreadNetif.GetMac().GetMaxTransmitPower();

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -48,6 +48,7 @@
 #include <thread/thread_tlvs.hpp>
 #include <thread/thread_uris.hpp>
 #include <thread/lowpan.hpp>
+#include <crypto/pbkdf2_cmac.h>
 
 using Thread::Encoding::BigEndian::HostSwap16;
 
@@ -1072,6 +1073,34 @@ void Leader::HandleTimer(void)
     {
         mTimer.Start(kStateUpdatePeriod);
     }
+}
+
+ThreadError Leader::GeneratePSKc(const char *aPassPhrase, const char *aNetworkName, const uint8_t *aExtPanId,
+                                 uint8_t *aPSKc)
+{
+    ThreadError error = kThreadError_None;
+    const char *saltPrefix = "Thread";
+    uint8_t salt[OT_PBKDF2_SALT_MAX_LEN];
+    uint16_t saltLen = 0;
+
+    VerifyOrExit((strlen(aPassPhrase) >= OT_COMMISSIONING_PASSPHRASE_MIN_SIZE) &&
+                 (strlen(aPassPhrase) <= OT_COMMISSIONING_PASSPHRASE_MAX_SIZE), error = kThreadError_InvalidArgs);
+
+    memset(salt, 0, sizeof(salt));
+    memcpy(salt, saltPrefix, strlen(saltPrefix));
+    saltLen += static_cast<uint16_t>(strlen(saltPrefix));
+
+    memcpy(salt + saltLen, aExtPanId, OT_EXT_PAN_ID_SIZE);
+    saltLen += OT_EXT_PAN_ID_SIZE;
+
+    memcpy(salt + saltLen, aNetworkName, strlen(aNetworkName));
+    saltLen += static_cast<uint16_t>(strlen(aNetworkName));
+
+    otPbkdf2Cmac(reinterpret_cast<const uint8_t *>(aPassPhrase), static_cast<uint16_t>(strlen(aPassPhrase)),
+                 reinterpret_cast<const uint8_t *>(salt), saltLen, 16384, OT_PSKC_MAX_SIZE, aPSKc);
+
+exit:
+    return error;
 }
 
 }  // namespace NetworkData

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -140,6 +140,22 @@ public:
      */
     ThreadError SendServerDataNotification(uint16_t aRloc16);
 
+    /**
+     * This method generates PSKc.
+     *
+     * PSKc is used to establish the Commissioner Session.
+     *
+     * @param[in]  aPassPhrase   The commissioning passphrase.
+     * @param[in]  aNetworkName  The network name for PSKc computation.
+     * @param[in]  aExtPanId     The extended pan id for PSKc computation.
+     * @param[out] aPSKc         A pointer to where the generated PSKc will be placed.
+     *
+     * @retval kThreadErrorNone          Successfully generate PSKc.
+     * @retval kThreadError_InvalidArgs  If the length of passphrase is out of range.
+     *
+     */
+    ThreadError GeneratePSKc(const char *aPassPhrase, const char *aNetworkName, const uint8_t *aExtPanId, uint8_t *aPSKc);
+
 private:
     static void HandleServerData(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
                                  const otMessageInfo *aMessageInfo);

--- a/third_party/mbedtls/Makefile.am
+++ b/third_party/mbedtls/Makefile.am
@@ -43,6 +43,10 @@ libmbedcrypto_a_CPPFLAGS                      = \
 libmbedcrypto_a_SOURCES                       = \
     hardware_entropy.c                          \
     repo/library/aes.c                          \
+    repo/library/ccm.c                          \
+    repo/library/cipher.c                       \
+    repo/library/cipher_wrap.c                  \
+    repo/library/cmac.c                         \
     repo/library/md.c                           \
     repo/library/md_wrap.c                      \
     repo/library/memory_buffer_alloc.c          \
@@ -53,9 +57,6 @@ libmbedcrypto_a_SOURCES                       = \
 if OPENTHREAD_ENABLE_DTLS
 libmbedcrypto_a_SOURCES                      += \
     repo/library/bignum.c                       \
-    repo/library/ccm.c                          \
-    repo/library/cipher.c                       \
-    repo/library/cipher_wrap.c                  \
     repo/library/ctr_drbg.c                     \
     repo/library/debug.c                        \
     repo/library/ecjpake.c                      \

--- a/third_party/mbedtls/mbedtls-config.h
+++ b/third_party/mbedtls/mbedtls-config.h
@@ -39,6 +39,7 @@
 // Temporary, until the warnings can get fixed in the mbed library
 #pragma warning(disable:4242)  // conversion from '*' to '*', possible loss of data
 #pragma warning(disable:4244)  // conversion from '*' to '*', possible loss of data
+#pragma warning(disable:4267)  // conversion from '*' to '*', possible loss of data
 #endif
 
 #if defined(_KERNEL_MODE)
@@ -1696,7 +1697,7 @@ __inline int windows_kernel_snprintf(char * s, size_t n, const char * format, ..
  * Requires: MBEDTLS_AES_C or MBEDTLS_DES_C
  *
  */
-//#define MBEDTLS_CMAC_C
+#define MBEDTLS_CMAC_C
 
 /**
  * \def MBEDTLS_CTR_DRBG_C


### PR DESCRIPTION
This is the pre-work for the Board Agent feature implementation.

I implemented PBKDF2 using AES-CMAC-PRF-128 function in OpenThread temporarily, since it is not supported by mbedtls-2.4.1 (it only support PBKDF2 using HMAC).
