### PR TITLE
Fix Route TLV handling during reattach.

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2553,6 +2553,7 @@ ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::Messa
     // Parent Attach Success
     mParentRequestTimer.Stop();
     mReattachState = kReattachStop;
+    SetStateDetached();
 
     SetLeaderData(leaderData.GetPartitionId(), leaderData.GetWeighting(), leaderData.GetLeaderRouterId());
 


### PR DESCRIPTION
- When operating as a Router and attempting to reattach as a child,
  reset to the Detached state before calling ProcessRouteTlv.  Otherwise,
  ProcessRouteTlv will trigger another reattach since the previous
  Router ID cannot be found in the Router Mask.

Fixes #1167.