### PR TITLE
Radio Off By Default

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -117,6 +117,7 @@ Mac::Mac(ThreadNetif &aThreadNetif):
     mState = kStateIdle;
 
     mRadioOn = false;
+    mDisableRadioOnIdle = false;
     mRxOnWhenIdle = false;
     mCsmaAttempts = 0;
     mTransmitAttempts = 0;
@@ -218,6 +219,13 @@ ThreadError Mac::Scan(ScanType aScanType, uint32_t aScanChannels, uint16_t aScan
     {
         mScanChannels >>= 1;
         mScanChannel++;
+    }
+
+    // If the radio isn't enabled, enable it now
+    if (!mRadioOn)
+    {
+        mDisableRadioOnIdle = true;
+        EnableRadio();
     }
 
     if (mState == kStateIdle)
@@ -588,6 +596,12 @@ void Mac::ScheduleNextTransmission(void)
     else
     {
         mState = kStateIdle;
+
+        if (mDisableRadioOnIdle)
+        {
+            mDisableRadioOnIdle = false;
+            DisableRadio();
+        }
     }
 
     NextOperation();

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -201,6 +201,18 @@ public:
     typedef void (*ActiveScanHandler)(void *aContext, Frame *aBeaconFrame);
 
     /**
+    * This method ensures the radio is in the proper state for use.
+    *
+    */
+    void EnableRadio();
+
+    /**
+    * This method disables the radio, indicating it's no longer needed.
+    *
+    */
+    void DisableRadio();
+
+    /**
      * This method starts an IEEE 802.15.4 Active Scan.
      *
      * @param[in]  aScanChannels  A bit vector indicating which channels to scan.
@@ -637,6 +649,7 @@ private:
 
     uint8_t mBeaconSequence;
     uint8_t mDataSequence;
+    bool mRadioOn;
     bool mRxOnWhenIdle;
     uint8_t mCsmaAttempts;
     uint8_t mTransmitAttempts;

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -650,6 +650,7 @@ private:
     uint8_t mBeaconSequence;
     uint8_t mDataSequence;
     bool mRadioOn;
+    bool mDisableRadioOnIdle;
     bool mRxOnWhenIdle;
     uint8_t mCsmaAttempts;
     uint8_t mTransmitAttempts;

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1413,6 +1413,7 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, ThreadError aError)
 
             break;
 
+        case kThreadError_Abort:
         case kThreadError_ChannelAccessFailure:
             break;
 

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -74,6 +74,7 @@ ThreadNetif::ThreadNetif(Ip6::Ip6 &aIp6):
     mNetworkDataLocal(*this),
     mNetworkDataLeader(*this),
     mNetworkDiagnostic(*this),
+    mIsUp(false),
 #if OPENTHREAD_ENABLE_COMMISSIONER
     mSecureCoapServer(*this, OPENTHREAD_CONFIG_JOINER_UDP_PORT),
     mCommissioner(*this),
@@ -93,7 +94,6 @@ ThreadNetif::ThreadNetif(Ip6::Ip6 &aIp6):
     mAnnounceBegin(*this),
     mPanIdQuery(*this),
     mEnergyScan(*this)
-
 {
     mKeyManager.SetMasterKey(kThreadMasterKey, sizeof(kThreadMasterKey));
 }
@@ -102,6 +102,7 @@ ThreadError ThreadNetif::Up(void)
 {
     if (!mIsUp)
     {
+        mMac.EnableRadio();
         mIp6.AddNetif(*this);
         mMeshForwarder.Start();
         mCoapServer.Start();
@@ -131,6 +132,8 @@ ThreadError ThreadNetif::Down(void)
 #if OPENTHREAD_ENABLE_DTLS
     mDtls.Stop();
 #endif
+
+    mMac.DisableRadio();
 
     return kThreadError_None;
 }


### PR DESCRIPTION
This changes the behavior of OpenThread to only enable the Radio layer in response to the `otInterfaceUp` function and correspondingly turns the radio off in response to `otInterfaceDown`.