### PR TITLE
Improve Platform MessagePool support.

### DIFF
--- a/include/platform/messagepool.h
+++ b/include/platform/messagepool.h
@@ -63,14 +63,13 @@ extern "C" {
 #endif
 
 /**
- * Initialize the platform implemented message pool with the provided buffer list.
+ * Initialize the platform implemented message pool.
  *
- * @param[in] aFreeBufferList   A linked list of free buffers.
- * @param[in] aNumFreeBuffers   A pointer to an int containing the number of free buffers in aFreeBufferList.
- * @param[in] aBufferSize       The size in bytes of a Buffer object.
+ * @param[in] aMinNumFreeBuffers   An int containing the minimum number of free buffers desired by OpenThread.
+ * @param[in] aBufferSize          The size in bytes of a Buffer object.
  *
  */
-void otPlatMessagePoolInit(struct BufferHeader *aFreeBufferList, int *aNumFreeBuffers, size_t aBufferSize);
+void otPlatMessagePoolInit(int aMinNumFreeBuffers, size_t aBufferSize);
 
 /**
  * Allocate a buffer from the platform managed buffer pool.
@@ -87,6 +86,14 @@ struct BufferHeader *otPlatMessagePoolNew(void);
  *
  */
 void otPlatMessagePoolFree(struct BufferHeader *aBuffer);
+
+/**
+ * Get the number of free buffers.
+ *
+ * @returns The number of buffers currently free and available to OpenThread.
+ *
+ */
+int otPlatMessagePoolNumFreeBuffers(void);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -107,7 +107,9 @@ Buffer *MessagePool::NewBuffer(void)
     {
         otLogInfoMac("No available message buffer\n");
     }
+
 #else
+
     if (mFreeBuffers == NULL)
     {
         otLogInfoMac("No available message buffer");

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -1091,7 +1091,11 @@ public:
      * @returns The number of free buffers.
      *
      */
+#if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
+    uint16_t GetFreeBufferCount(void) const { return static_cast<uint16_t>(otPlatMessagePoolNumFreeBuffers()); }
+#else
     uint16_t GetFreeBufferCount(void) const { return static_cast<uint16_t>(mNumFreeBuffers); }
+#endif
 
 private:
     enum
@@ -1104,9 +1108,11 @@ private:
     ThreadError ReclaimBuffers(int aNumBuffers);
     PriorityQueue *GetAllMessagesQueue(void) { return &mAllQueue; }
 
+#if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT == 0
     int mNumFreeBuffers;
     Buffer mBuffers[kNumBuffers];
     Buffer *mFreeBuffers;
+#endif
     PriorityQueue mAllQueue;
 };
 


### PR DESCRIPTION
Platform message pool support is designed to allow OpenThread the option of operating with a message pool that is owned and managed by the platform.  This can be useful when multi-threaded systems need to allocate messages or when the system desires to allocate messages dynamically (heap) rather than from a static pool.