### PR TITLE
Skip extended tlv when searching for Base TLV

### DIFF
--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -67,13 +67,24 @@ ThreadError Tlv::GetOffset(const Message &aMessage, uint8_t aType, uint16_t &aOf
     {
         aMessage.Read(offset, sizeof(Tlv), &tlv);
 
-        if (tlv.GetType() == aType && (offset + sizeof(tlv) + tlv.GetLength()) <= end)
+        // skip extended TLV
+        if (tlv.GetLength() == kExtendedLength)
+        {
+            uint16_t length = 0;
+
+            offset += sizeof(tlv);
+            aMessage.Read(offset, sizeof(length), &length);
+            offset += sizeof(length) + HostSwap16(length);
+        }
+        else if (tlv.GetType() == aType && (offset + sizeof(tlv) + tlv.GetLength()) <= end)
         {
             aOffset = offset;
             ExitNow(error = kThreadError_None);
         }
-
-        offset += sizeof(tlv) + tlv.GetLength();
+        else
+        {
+            offset += sizeof(tlv) + tlv.GetLength();
+        }
     }
 
 exit:


### PR DESCRIPTION
It handles the case that Joiner DTLS Encapsulation TLV is not the last TLV in RLY_RX.ntf and RLY_TX.ntf, and helps to pass six 8.2.x Certification tests with other vendors.