### PR TITLE
Adding new OT api to get/set the active/pending datasets as tlv byte sequence

### DIFF
--- a/doc/spinel-protocol-src/spinel-tech-thread.md
+++ b/doc/spinel-protocol-src/spinel-tech-thread.md
@@ -209,3 +209,23 @@ Data per item is:
 * `b`: `true` if neighbor is a child, `false` otherwise.
 * `L`: Link Frame Counter
 * `L`: MLE Frame Counter
+
+### PROP 5388: SPINEL_PROP_THREAD_CHILD_COUNT_MAX
+* Type: Read-Write
+* Packed-encoding `C`
+
+### PROP 5389: SPINEL_PROP_THREAD_ACTIVE_DATASET
+* Type: Read-Write
+* Packed-encoding `D`
+
+Provides access to active operational dataset as a byte sequence.
+The byte sequence is encoded using TLV format defined by the Thread
+specification.
+
+### PROP 5390: SPINEL_PROP_THREAD_PENDING_DATASET
+* Type: Read-Write
+* Packed-encoding `D`
+
+Provides access to pending operational dataset as a byte sequence.
+The byte sequence is encoded using TLV format defined by the Thread
+specification.

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -956,6 +956,56 @@ OTAPI ThreadError OTCALL otGetPendingDataset(otInstance *aInstance, otOperationa
 OTAPI ThreadError OTCALL otSetPendingDataset(otInstance *aInstance, const otOperationalDataset *aDataset);
 
 /**
+ * This function gets the Active Operational Dataset bytes (TLVs).
+ *
+ * @param[in]   aInstance A pointer to an OpenThread instance.
+ * @param[out]  aLength   A pointer to return the dataset length (number of bytes).
+ *
+ * @returns  Pointer to the first byte of active data set
+ *
+ */
+const uint8_t *otGetActiveDatasetBytes(otInstance *aInstance, uint16_t *aLength);
+
+/**
+ * This function sets the Active Operational Dataset.
+ *
+ * @param[in]  aInstance      A pointer to an OpenThread instance.
+ * @param[in]  aDatasetBytes  A pointer to buffer with the dataset bytes.
+ * @param[in]  aLength        Length of dataset (number of bytes).
+ *
+ * @retval kThreadError_None         Successfully set the Active Operational Dataset.
+ * @retval kThreadError_NoBufs       Insufficient buffer space to set the Active Operational Datset.
+ * @retval kThreadError_InvalidArgs  @p aDatasetBytes was NULL.
+ *
+ */
+ThreadError otSetActiveDatasetBytes(otInstance *aInstance, const uint8_t *aDatasetBytes, uint16_t aLength);
+
+/**
+ * This function gets the Pending Operational Dataset bytes (TLVs).
+ *
+ * @param[in]   aInstance A pointer to an OpenThread instance.
+ * @param[out]  aLength   A pointer to return the dataset length (number of bytes).
+ *
+ * @returns  Pointer to the first byte of pending data set.
+ *
+ */
+const uint8_t *otGetPendingDatasetBytes(otInstance *aInstance, uint16_t *aLength);
+
+/**
+ * This function sets the Pending Operational Dataset.
+ *
+ * @param[in]  aInstance      A pointer to an OpenThread instance.
+ * @param[in]  aDatasetBytes  A pointer to buffer with the dataset bytes.
+ * @param[in]  aLength        Length of dataset (number of bytes).
+ *
+ * @retval kThreadError_None         Successfully set the Pending Operational Dataset.
+ * @retval kThreadError_NoBufs       Insufficient buffer space to set the Active Operational Datset.
+ * @retval kThreadError_InvalidArgs  @p aDatasetBytes was NULL.
+ *
+ */
+ThreadError otSetPendingDatasetBytes(otInstance *aInstance, const uint8_t *aDatasetBytes, uint16_t aLength);
+
+/**
  * This function sends MGMT_ACTIVE_GET.
  *
  * @param[in]  aInstance  A pointer to an OpenThread instance.

--- a/include/openthread.h
+++ b/include/openthread.h
@@ -956,29 +956,32 @@ OTAPI ThreadError OTCALL otGetPendingDataset(otInstance *aInstance, otOperationa
 OTAPI ThreadError OTCALL otSetPendingDataset(otInstance *aInstance, const otOperationalDataset *aDataset);
 
 /**
- * This function gets the Active Operational Dataset bytes (TLVs).
+ * This function gets the Active Operational Dataset TLVs.
  *
  * @param[in]   aInstance A pointer to an OpenThread instance.
  * @param[out]  aLength   A pointer to return the dataset length (number of bytes).
  *
- * @returns  Pointer to the first byte of active data set
+ * @returns  Pointer to the first byte of active data set.
  *
  */
-const uint8_t *otGetActiveDatasetBytes(otInstance *aInstance, uint16_t *aLength);
+const uint8_t *otGetActiveDatasetTlvs(otInstance *aInstance, uint16_t *aLength);
 
 /**
- * This function sets the Active Operational Dataset.
+ * This function updates a set of TLVs in the Active Operational Dataset.
+ *
+ * If the Active Operation Dataset does not contain a passed in TLV, the new TLV is added/inserted into the Active
+ * Dataset, otherwise for an existing TLV, the value gets updated.
  *
  * @param[in]  aInstance      A pointer to an OpenThread instance.
- * @param[in]  aDatasetBytes  A pointer to buffer with the dataset bytes.
- * @param[in]  aLength        Length of dataset (number of bytes).
+ * @param[in]  aTlvs          A pointer to buffer with the new set of TLVs.
+ * @param[in]  aTlvsLength    Length of @p aTlvs sequence (number of bytes).
  *
- * @retval kThreadError_None         Successfully set the Active Operational Dataset.
- * @retval kThreadError_NoBufs       Insufficient buffer space to set the Active Operational Datset.
- * @retval kThreadError_InvalidArgs  @p aDatasetBytes was NULL.
+ * @retval kThreadError_None         Successfully updated the Active Operational Dataset.
+ * @retval kThreadError_NoBufs       Insufficient buffer space to update the Active Operational Dataset.
+ * @retval kThreadError_InvalidArgs  @p aTlvs was NULL or contained unknown/invalid or improperly formatted TLVs.
  *
  */
-ThreadError otSetActiveDatasetBytes(otInstance *aInstance, const uint8_t *aDatasetBytes, uint16_t aLength);
+ThreadError otUpdateActiveDatasetTlvs(otInstance *aInstance, const uint8_t *aTlvs, uint16_t aTlvsLength);
 
 /**
  * This function gets the Pending Operational Dataset bytes (TLVs).
@@ -989,21 +992,25 @@ ThreadError otSetActiveDatasetBytes(otInstance *aInstance, const uint8_t *aDatas
  * @returns  Pointer to the first byte of pending data set.
  *
  */
-const uint8_t *otGetPendingDatasetBytes(otInstance *aInstance, uint16_t *aLength);
+const uint8_t *otGetPendingDatasetTlvs(otInstance *aInstance, uint16_t *aLength);
 
 /**
- * This function sets the Pending Operational Dataset.
+ * This function updates a set of TLVs in Pending Operational Dataset.
+ *
+ * If the Pending Operation Dataset does not contain a passed in TLV, the new TLV is added/inserted into the Active
+ * Dataset, otherwise for an existing TLV, the value gets updated.
+ *
  *
  * @param[in]  aInstance      A pointer to an OpenThread instance.
- * @param[in]  aDatasetBytes  A pointer to buffer with the dataset bytes.
- * @param[in]  aLength        Length of dataset (number of bytes).
+ * @param[in]  aTlvs          A pointer to buffer with new set of TLVs.
+ * @param[in]  aTlvsLength    Length of @p aTlvs sequence (number of bytes).
  *
  * @retval kThreadError_None         Successfully set the Pending Operational Dataset.
- * @retval kThreadError_NoBufs       Insufficient buffer space to set the Active Operational Datset.
- * @retval kThreadError_InvalidArgs  @p aDatasetBytes was NULL.
+ * @retval kThreadError_NoBufs       Insufficient buffer space to set the Pending Operational Dataset.
+ * @retval kThreadError_InvalidArgs  @p aTlvs was NULL or contained unknown/invalid or improperly formatted TLVs.
  *
  */
-ThreadError otSetPendingDatasetBytes(otInstance *aInstance, const uint8_t *aDatasetBytes, uint16_t aLength);
+ThreadError otUpdatePendingDatasetTlvs(otInstance *aInstance, const uint8_t *aTlvs, uint16_t aTlvsLength);
 
 /**
  * This function sends MGMT_ACTIVE_GET.

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -361,6 +361,19 @@ exit:
     return error;
 }
 
+ThreadError Dataset::Set(const uint8_t *aBytes, uint16_t aLength)
+{
+    ThreadError error = kThreadError_None;
+
+    VerifyOrExit(aBytes != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aLength <= sizeof(mTlvs), error = kThreadError_NoBufs);
+    memcpy(mTlvs, aBytes, aLength);
+    mLength = aLength;
+
+exit:
+    return error;
+}
+
 const Timestamp *Dataset::GetTimestamp(void) const
 {
     const Timestamp *timestamp = NULL;

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -361,14 +361,14 @@ exit:
     return error;
 }
 
-ThreadError Dataset::Set(const uint8_t *aBytes, uint16_t aLength)
+ThreadError Dataset::Update(const uint8_t *aTlvs, uint16_t aTlvsLength)
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(aBytes != NULL, error = kThreadError_InvalidArgs);
-    VerifyOrExit(aLength <= sizeof(mTlvs), error = kThreadError_NoBufs);
-    memcpy(mTlvs, aBytes, aLength);
-    mLength = aLength;
+    VerifyOrExit(aTlvs != NULL, error = kThreadError_InvalidArgs);
+
+
+
 
 exit:
     return error;

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -166,7 +166,21 @@ public:
 
     ThreadError Set(const otOperationalDataset &aDataset);
 
-    ThreadError Set(const uint8_t *aBytes, uint16_t aLength);
+    /**
+     * This methods updates the TLVs in the Dataset.
+     *
+     * If the Dataset does not contain a passed in TLV, the new TLV is added/inserted into the
+     * Dataset, otherwise for an existing TLV, the value gets updated.
+     *
+     * @param[in]  aTlvs          A pointer to buffer with new set of TLVs.
+     * @param[in]  aTlvsLength    Length of @p aTlvs sequence (number of bytes).
+     *
+     * @retval kThreadError_None         Successfully set the Pending Operational Dataset.
+     * @retval kThreadError_NoBufs       Insufficient buffer space to set the Pending Operational Dataset.
+     * @retval kThreadError_InvalidArgs  @p aTlvs was NULL or contained unknown/invalid or improperly formatted TLVs.
+     *
+     */
+    ThreadError Update(const uint8_t *aTlvs, uint16_t aTlvsLength);
 
     /**
      * This method removes a TLV from the Dataset.

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -166,6 +166,8 @@ public:
 
     ThreadError Set(const otOperationalDataset &aDataset);
 
+    ThreadError Set(const uint8_t *aBytes, uint16_t aLength);
+
     /**
      * This method removes a TLV from the Dataset.
      *

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -1654,6 +1654,36 @@ exit:
     return error;
 }
 
+const uint8_t *otGetActiveDatasetBytes(otInstance *aInstance, uint16_t *aLength)
+{
+    if (aLength != NULL)
+    {
+        *aLength = aInstance->mThreadNetif.GetActiveDataset().GetLocal().GetSize();
+    }
+
+    return aInstance->mThreadNetif.GetActiveDataset().GetLocal().GetBytes();
+}
+
+ThreadError otSetActiveDatasetBytes(otInstance *aInstance, const uint8_t *aDatasetBytes, uint16_t aLength)
+{
+    return aInstance->mThreadNetif.GetActiveDataset().GetLocal().Set(aDatasetBytes, aLength);
+}
+
+const uint8_t *otGetPendingDatasetBytes(otInstance *aInstance, uint16_t *aLength)
+{
+    if (aLength != NULL)
+    {
+        *aLength = aInstance->mThreadNetif.GetPendingDataset().GetLocal().GetSize();
+    }
+
+    return aInstance->mThreadNetif.GetPendingDataset().GetLocal().GetBytes();
+}
+
+ThreadError otSetPendingDatasetBytes(otInstance *aInstance, const uint8_t *aDatasetBytes, uint16_t aLength)
+{
+    return aInstance->mThreadNetif.GetPendingDataset().GetLocal().Set(aDatasetBytes, aLength);
+}
+
 ThreadError otSendActiveGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength,
                             const otIp6Address *aAddress)
 {

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -1654,7 +1654,7 @@ exit:
     return error;
 }
 
-const uint8_t *otGetActiveDatasetBytes(otInstance *aInstance, uint16_t *aLength)
+const uint8_t *otGetActiveDatasetTlvs(otInstance *aInstance, uint16_t *aLength)
 {
     if (aLength != NULL)
     {
@@ -1664,12 +1664,12 @@ const uint8_t *otGetActiveDatasetBytes(otInstance *aInstance, uint16_t *aLength)
     return aInstance->mThreadNetif.GetActiveDataset().GetLocal().GetBytes();
 }
 
-ThreadError otSetActiveDatasetBytes(otInstance *aInstance, const uint8_t *aDatasetBytes, uint16_t aLength)
+ThreadError otUpdateActiveDatasetTlvs(otInstance *aInstance, const uint8_t *aTlvs, uint16_t aTlvsLength)
 {
-    return aInstance->mThreadNetif.GetActiveDataset().GetLocal().Set(aDatasetBytes, aLength);
+    return aInstance->mThreadNetif.GetActiveDataset().GetLocal().UpdateTlvs(aTlvs, aTlvsLength);
 }
 
-const uint8_t *otGetPendingDatasetBytes(otInstance *aInstance, uint16_t *aLength)
+const uint8_t *otGetPendingDatasetTlvs(otInstance *aInstance, uint16_t *aLength)
 {
     if (aLength != NULL)
     {
@@ -1679,9 +1679,9 @@ const uint8_t *otGetPendingDatasetBytes(otInstance *aInstance, uint16_t *aLength
     return aInstance->mThreadNetif.GetPendingDataset().GetLocal().GetBytes();
 }
 
-ThreadError otSetPendingDatasetBytes(otInstance *aInstance, const uint8_t *aDatasetBytes, uint16_t aLength)
+ThreadError otSetPendingDatasetTlvs(otInstance *aInstance, const uint8_t *aTlvs, uint16_t aTlvsLength)
 {
-    return aInstance->mThreadNetif.GetPendingDataset().GetLocal().Set(aDatasetBytes, aLength);
+    return aInstance->mThreadNetif.GetPendingDataset().GetLocal().UpdateTlvs(aTlvs, aTlvsLength);
 }
 
 ThreadError otSendActiveGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength,

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -155,6 +155,8 @@ const NcpBase::GetPropertyHandlerEntry NcpBase::mGetPropertyHandlerTable[] =
     { SPINEL_PROP_THREAD_ON_MESH_NETS, &NcpBase::NcpBase::GetPropertyHandler_THREAD_ON_MESH_NETS },
     { SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING, &NcpBase::GetPropertyHandler_NET_REQUIRE_JOIN_EXISTING },
     { SPINEL_PROP_THREAD_ROUTER_SELECTION_JITTER, &NcpBase::GetPropertyHandler_THREAD_ROUTER_SELECTION_JITTER },
+    { SPINEL_PROP_THREAD_ACTIVE_DATASET, &NcpBase::GetPropertyHandler_THREAD_ACTIVE_DATASET },
+    { SPINEL_PROP_THREAD_PENDING_DATASET, &NcpBase::GetPropertyHandler_THREAD_PENDING_DATASET },
 
     { SPINEL_PROP_IPV6_ML_PREFIX, &NcpBase::GetPropertyHandler_IPV6_ML_PREFIX },
     { SPINEL_PROP_IPV6_ML_ADDR, &NcpBase::GetPropertyHandler_IPV6_ML_ADDR },
@@ -271,6 +273,8 @@ const NcpBase::SetPropertyHandlerEntry NcpBase::mSetPropertyHandlerTable[] =
     { SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING, &NcpBase::SetPropertyHandler_NET_REQUIRE_JOIN_EXISTING },
     { SPINEL_PROP_THREAD_ROUTER_SELECTION_JITTER, &NcpBase::SetPropertyHandler_THREAD_ROUTER_SELECTION_JITTER },
     { SPINEL_PROP_THREAD_PREFERRED_ROUTER_ID, &NcpBase::SetPropertyHandler_THREAD_PREFERRED_ROUTER_ID },
+    { SPINEL_PROP_THREAD_ACTIVE_DATASET, &NcpBase::SetPropertyHandler_THREAD_ACTIVE_DATASET },
+    { SPINEL_PROP_THREAD_PENDING_DATASET, &NcpBase::SetPropertyHandler_THREAD_PENDING_DATASET },
 
 #if OPENTHREAD_ENABLE_JAM_DETECTION
     { SPINEL_PROP_JAM_DETECT_ENABLE, &NcpBase::SetPropertyHandler_JAM_DETECT_ENABLE },
@@ -2957,6 +2961,40 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header
            );
 }
 
+ThreadError NcpBase::GetPropertyHandler_THREAD_ACTIVE_DATASET(uint8_t header, spinel_prop_key_t key)
+{
+    uint16_t length = 0;
+    const uint8_t *dataset_bytes;
+
+    dataset_bytes = otGetActiveDatasetBytes(mInstance, &length);
+
+    return SendPropertyUpdate(
+               header,
+               SPINEL_CMD_PROP_VALUE_IS,
+               key,
+               SPINEL_DATATYPE_DATA_S,
+               dataset_bytes,
+               length
+           );
+}
+
+ThreadError NcpBase::GetPropertyHandler_THREAD_PENDING_DATASET(uint8_t header, spinel_prop_key_t key)
+{
+    uint16_t length = 0;
+    const uint8_t *dataset_bytes;
+
+    dataset_bytes = otGetPendingDatasetBytes(mInstance, &length);
+
+    return SendPropertyUpdate(
+               header,
+               SPINEL_CMD_PROP_VALUE_IS,
+               key,
+               SPINEL_DATATYPE_DATA_S,
+               dataset_bytes,
+               length
+           );
+}
+
 ThreadError NcpBase::GetPropertyHandler_NET_REQUIRE_JOIN_EXISTING(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
@@ -4502,6 +4540,78 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header
         otSetNetworkIdTimeout(mInstance, i);
 
         errorCode = HandleCommandPropertyGet(header, key);
+    }
+    else
+    {
+        errorCode = SendLastStatus(header, SPINEL_STATUS_PARSE_ERROR);
+    }
+
+    return errorCode;
+}
+
+ThreadError NcpBase::SetPropertyHandler_THREAD_ACTIVE_DATASET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len)
+{
+    const uint8_t *dataset_ptr = NULL;
+    unsigned int dataset_len = 0;
+    spinel_ssize_t parsedLength;
+    ThreadError errorCode = kThreadError_None;
+
+    parsedLength = spinel_datatype_unpack(
+                       value_ptr,
+                       value_len,
+                       SPINEL_DATATYPE_UINT8_S,
+                       &dataset_ptr,
+                       &dataset_len
+                   );
+
+    if (parsedLength > 0)
+    {
+        errorCode = otSetActiveDatasetBytes(mInstance, dataset_ptr, static_cast<uint16_t>(dataset_len));
+
+        if (errorCode == kThreadError_None)
+        {
+            errorCode = HandleCommandPropertyGet(header, key);
+        }
+        else
+        {
+            errorCode = SendLastStatus(header, ThreadErrorToSpinelStatus(errorCode));
+        }
+    }
+    else
+    {
+        errorCode = SendLastStatus(header, SPINEL_STATUS_PARSE_ERROR);
+    }
+
+    return errorCode;
+}
+
+ThreadError NcpBase::SetPropertyHandler_THREAD_PENDING_DATASET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len)
+{
+    const uint8_t *dataset_ptr = NULL;
+    unsigned int dataset_len = 0;
+    spinel_ssize_t parsedLength;
+    ThreadError errorCode = kThreadError_None;
+
+    parsedLength = spinel_datatype_unpack(
+                       value_ptr,
+                       value_len,
+                       SPINEL_DATATYPE_UINT8_S,
+                       &dataset_ptr,
+                       &dataset_len
+                   );
+
+    if (parsedLength > 0)
+    {
+        errorCode = otSetPendingDatasetBytes(mInstance, dataset_ptr, static_cast<uint16_t>(dataset_len));
+
+        if (errorCode == kThreadError_None)
+        {
+            errorCode = HandleCommandPropertyGet(header, key);
+        }
+        else
+        {
+            errorCode = SendLastStatus(header, ThreadErrorToSpinelStatus(errorCode));
+        }
     }
     else
     {

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -354,6 +354,8 @@ private:
     ThreadError GetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_ACTIVE_DATASET(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_PENDING_DATASET(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_NET_REQUIRE_JOIN_EXISTING(uint8_t header, spinel_prop_key_t key);
 
 #if OPENTHREAD_ENABLE_JAM_DETECTION
@@ -429,6 +431,8 @@ private:
     ThreadError SetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
     ThreadError SetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
     ThreadError SetPropertyHandler_THREAD_PREFERRED_ROUTER_ID(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
+    ThreadError SetPropertyHandler_THREAD_ACTIVE_DATASET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
+    ThreadError SetPropertyHandler_THREAD_PENDING_DATASET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr, uint16_t value_len);
 
     ThreadError SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
                                                     const uint8_t *value_ptr, uint16_t value_len);

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -762,6 +762,16 @@ typedef enum
      */
     SPINEL_PROP_THREAD_CHILD_COUNT_MAX = SPINEL_PROP_THREAD_EXT__BEGIN + 12,
 
+    /// Active Dataset
+    /** Format: 'D'
+    */
+    SPINEL_PROP_THREAD_ACTIVE_DATASET  = SPINEL_PROP_THREAD_EXT__BEGIN + 13,
+
+    /// Pending Dataset
+    /** Format: 'D'
+    */
+    SPINEL_PROP_THREAD_PENDING_DATASET = SPINEL_PROP_THREAD_EXT__BEGIN + 14,
+
     SPINEL_PROP_THREAD_EXT__END        = 0x1600,
 
     SPINEL_PROP_IPV6__BEGIN          = 0x60,


### PR DESCRIPTION
- Adds new OT apis to get or set the active or pending dataset as
  a byte sequence (tlv encoding).

- Adds new spinel properties corresponding to active and pending
  dataset along with their set and get handlers in `NcpBase`.