### PR TITLE
mParent is also the neighbor during Router rettach

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3093,6 +3093,11 @@ Neighbor *MleRouter::GetNeighbor(const Mac::ExtAddress &aAddress)
             }
         }
 
+        if (mParentRequestState != kParentIdle)
+        {
+            rval = Mle::GetNeighbor(aAddress);
+        }
+
         break;
     }
 


### PR DESCRIPTION
To avoid incorrect packet drop in MAC layer when GetNeighbor()

Fixed 9.2.9Router (NXP-OT DUT testbed)
Fixed 9.2.7Leader(OT-NXP DUT testbed)
Fixed 9.2.9Leader (OT-NXP DUT testbed)
