### PR TITLE
Fix REED behavior on migration

### DIFF
--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -183,6 +183,14 @@ public:
     void SetDiscoverParameters(uint32_t aScanChannels, uint16_t aScanDuration);
 
     /**
+     * This method frees any indirect messages queued for a specific child.
+     *
+     * @param[in]  aChild  A reference to a child whom messages shall be removed.
+     *
+     */
+    void ClearChildIndirectMessages(Child &aChild);
+
+    /**
      * This method frees any indirect messages queued for children that are no longer attached.
      *
      */

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -219,7 +219,6 @@ ThreadError Mle::Start(bool aEnableReattach)
     {
         BecomeChild(kMleAttachAnyPartition);
     }
-
     else if (IsActiveRouter(GetRloc16()))
     {
         if (mNetif.GetMle().BecomeRouter(ThreadStatusTlv::kTooFewRouters) != kThreadError_None)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -101,6 +101,7 @@ Mle::Mle(ThreadNetif &aThreadNetif) :
     memset(&mLinkLocalAllThreadNodes, 0, sizeof(mLinkLocalAllThreadNodes));
     memset(&mRealmLocalAllThreadNodes, 0, sizeof(mRealmLocalAllThreadNodes));
     memset(&mLeaderAloc, 0, sizeof(mLeaderAloc));
+    memset(&mParentCandidate, 0, sizeof(mParentCandidate));
 
     // link-local 64
     mLinkLocal64.GetAddress().mFields.m16[0] = HostSwap16(0xfe80);
@@ -218,6 +219,7 @@ ThreadError Mle::Start(bool aEnableReattach)
     {
         BecomeChild(kMleAttachAnyPartition);
     }
+
     else if (IsActiveRouter(GetRloc16()))
     {
         if (mNetif.GetMle().BecomeRouter(ThreadStatusTlv::kTooFewRouters) != kThreadError_None)
@@ -449,9 +451,14 @@ ThreadError Mle::BecomeChild(otMleAttachFilter aFilter)
         }
     }
 
+    ResetParentCandidate();
     mParentRequestState = kParentRequestStart;
     mParentRequestMode = aFilter;
-    memset(&mParent, 0, sizeof(mParent));
+
+    if (aFilter != kMleAttachBetterPartition)
+    {
+        memset(&mParent, 0, sizeof(mParent));
+    }
 
     if (aFilter == kMleAttachAnyPartition)
     {
@@ -1253,7 +1260,7 @@ void Mle::HandleParentRequestTimer(void)
 
     case kParentRequestStart:
         mParentRequestState = kParentRequestRouter;
-        mParent.mState = Neighbor::kStateInvalid;
+        mParentCandidate.mState = Neighbor::kStateInvalid;
         SendParentRequest();
         mParentRequestTimer.Start(kParentRequestRouterTimeout);
         break;
@@ -1261,7 +1268,7 @@ void Mle::HandleParentRequestTimer(void)
     case kParentRequestRouter:
         mParentRequestState = kParentRequestChild;
 
-        if (mParent.mState == Neighbor::kStateValid)
+        if (mParentCandidate.mState == Neighbor::kStateValid)
         {
             SendChildIdRequest();
             mParentRequestState = kChildIdRequest;
@@ -1277,7 +1284,7 @@ void Mle::HandleParentRequestTimer(void)
     case kParentRequestChild:
         mParentRequestState = kParentRequestChild;
 
-        if (mParent.mState == Neighbor::kStateValid)
+        if (mParentCandidate.mState == Neighbor::kStateValid)
         {
             SendChildIdRequest();
             mParentRequestState = kChildIdRequest;
@@ -1285,6 +1292,8 @@ void Mle::HandleParentRequestTimer(void)
         }
         else
         {
+            ResetParentCandidate();
+
             if (mReattachState == kReattachActive)
             {
                 if (mNetif.GetPendingDataset().Restore() == kThreadError_None)
@@ -1338,6 +1347,13 @@ void Mle::HandleParentRequestTimer(void)
 
                 case kMleAttachBetterPartition:
                     mParentRequestState = kParentIdle;
+
+                    if (mDeviceState == kDeviceStateChild)
+                    {
+                        // Restart keep-alive timer as it was disturbed by attachment procedure.
+                        mParentRequestTimer.Start(0);
+                    }
+
                     break;
                 }
             }
@@ -1347,8 +1363,18 @@ void Mle::HandleParentRequestTimer(void)
 
     case kChildIdRequest:
         mParentRequestState = kParentIdle;
+        ResetParentCandidate();
 
-        if (mDeviceState != kDeviceStateRouter && mDeviceState != kDeviceStateLeader)
+        if ((mParentRequestMode == kMleAttachBetterPartition) || (mDeviceState == kDeviceStateRouter) ||
+            (mDeviceState == kDeviceStateLeader))
+        {
+            if (mDeviceState == kDeviceStateChild)
+            {
+                // Restart keep-alive timer as it was disturbed by attachment procedure.
+                mParentRequestTimer.Start(0);
+            }
+        }
+        else
         {
             BecomeDetached();
         }
@@ -1458,7 +1484,7 @@ ThreadError Mle::SendChildIdRequest(void)
 
     memset(&destination, 0, sizeof(destination));
     destination.mFields.m16[0] = HostSwap16(0xfe80);
-    destination.SetIid(mParent.mMacAddr);
+    destination.SetIid(mParentCandidate.mMacAddr);
     SuccessOrExit(error = SendMessage(*message, destination));
     otLogInfoMle("Sent Child ID Request");
 
@@ -2298,7 +2324,7 @@ bool Mle::IsBetterParent(uint16_t aRloc16, uint8_t aLinkQuality, ConnectivityTlv
         ExitNow(rval = (aLinkQuality > mParentLinkQuality));
     }
 
-    if (IsActiveRouter(aRloc16) != IsActiveRouter(mParent.mValid.mRloc16))
+    if (IsActiveRouter(aRloc16) != IsActiveRouter(mParentCandidate.mValid.mRloc16))
     {
         ExitNow(rval = IsActiveRouter(aRloc16));
     }
@@ -2325,6 +2351,12 @@ bool Mle::IsBetterParent(uint16_t aRloc16, uint8_t aLinkQuality, ConnectivityTlv
 
 exit:
     return rval;
+}
+
+void Mle::ResetParentCandidate(void)
+{
+    memset(&mParentCandidate, 0, sizeof(mParentCandidate));
+    mParentCandidate.mState = Neighbor::kStateInvalid;
 }
 
 ThreadError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
@@ -2404,7 +2436,7 @@ ThreadError Mle::HandleParentResponse(const Message &aMessage, const Ip6::Messag
     }
 
     // if already have a candidate parent, only seek a better parent
-    if (mParent.mState == Neighbor::kStateValid)
+    if (mParentCandidate.mState == Neighbor::kStateValid)
     {
         int compare = 0;
 
@@ -2441,16 +2473,16 @@ ThreadError Mle::HandleParentResponse(const Message &aMessage, const Ip6::Messag
     memcpy(mChildIdRequest.mChallenge, challenge.GetChallenge(), challenge.GetLength());
     mChildIdRequest.mChallengeLength = challenge.GetLength();
 
-    mParent.mMacAddr.Set(aMessageInfo.GetPeerAddr());
-    mParent.mValid.mRloc16 = sourceAddress.GetRloc16();
-    mParent.mValid.mLinkFrameCounter = linkFrameCounter.GetFrameCounter();
-    mParent.mValid.mMleFrameCounter = mleFrameCounter.GetFrameCounter();
-    mParent.mMode = ModeTlv::kModeFFD | ModeTlv::kModeRxOnWhenIdle | ModeTlv::kModeFullNetworkData;
-    mParent.mLinkInfo.Clear();
-    mParent.mLinkInfo.AddRss(mNetif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
-    mParent.mLinkFailures = 0;
-    mParent.mState = Neighbor::kStateValid;
-    mParent.mKeySequence = aKeySequence;
+    mParentCandidate.mMacAddr.Set(aMessageInfo.GetPeerAddr());
+    mParentCandidate.mValid.mRloc16 = sourceAddress.GetRloc16();
+    mParentCandidate.mValid.mLinkFrameCounter = linkFrameCounter.GetFrameCounter();
+    mParentCandidate.mValid.mMleFrameCounter = mleFrameCounter.GetFrameCounter();
+    mParentCandidate.mMode = ModeTlv::kModeFFD | ModeTlv::kModeRxOnWhenIdle | ModeTlv::kModeFullNetworkData;
+    mParentCandidate.mLinkInfo.Clear();
+    mParentCandidate.mLinkInfo.AddRss(mNetif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
+    mParentCandidate.mLinkFailures = 0;
+    mParentCandidate.mState = Neighbor::kStateValid;
+    mParentCandidate.mKeySequence = aKeySequence;
 
     mParentLinkQuality = linkQuality;
     mParentPriority = connectivity.GetParentPriority();
@@ -2586,6 +2618,9 @@ ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::Messa
             mRouterSelectionJitterTimeout = (otPlatRandomGet() % mRouterSelectionJitter) + 1;
         }
     }
+
+    mParent = mParentCandidate;
+    ResetParentCandidate();
 
     mParent.mValid.mRloc16 = sourceAddress.GetRloc16();
 
@@ -2953,13 +2988,34 @@ exit:
 
 Neighbor *Mle::GetNeighbor(uint16_t aAddress)
 {
-    return (mParent.mState == Neighbor::kStateValid && mParent.mValid.mRloc16 == aAddress) ? &mParent : NULL;
+    if ((mParent.mState == Neighbor::kStateValid) && (mParent.mValid.mRloc16 == aAddress))
+    {
+        return &mParent;
+    }
+
+    if ((mParentCandidate.mState == Neighbor::kStateValid) && (mParentCandidate.mValid.mRloc16 == aAddress))
+    {
+        return &mParentCandidate;
+    }
+
+    return NULL;
 }
 
 Neighbor *Mle::GetNeighbor(const Mac::ExtAddress &aAddress)
 {
-    return (mParent.mState == Neighbor::kStateValid &&
-            memcmp(&mParent.mMacAddr, &aAddress, sizeof(mParent.mMacAddr)) == 0) ? &mParent : NULL;
+    if ((mParent.mState == Neighbor::kStateValid) &&
+        (memcmp(&mParent.mMacAddr, &aAddress, sizeof(mParent.mMacAddr)) == 0))
+    {
+        return &mParent;
+    }
+
+    if ((mParentCandidate.mState == Neighbor::kStateValid) &&
+        (memcmp(&mParentCandidate.mMacAddr, &aAddress, sizeof(mParentCandidate.mMacAddr)) == 0))
+    {
+        return &mParentCandidate;
+    }
+
+    return NULL;
 }
 
 Neighbor *Mle::GetNeighbor(const Mac::Address &aAddress)
@@ -3005,6 +3061,11 @@ bool Mle::IsAnycastLocator(const Ip6::Address &aAddress) const
 
 Router *Mle::GetParent()
 {
+    if ((mParent.mState != Neighbor::kStateValid) && (mParentCandidate.mState == Neighbor::kStateValid))
+    {
+        return &mParentCandidate;
+    }
+
     return &mParent;
 }
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1246,6 +1246,7 @@ private:
     void SendOrphanAnnounce(void);
 
     bool IsBetterParent(uint16_t aRloc16, uint8_t aLinkQuality, ConnectivityTlv &aConnectivityTlv) const;
+    void ResetParentCandidate(void);
 
     /**
      * This struct represents the device's own network information for persistent storage.
@@ -1283,6 +1284,8 @@ private:
     uint8_t mParentLinkQuality1;
     LeaderDataTlv mParentLeaderData;
     bool mParentIsSingleton;
+
+    Router mParentCandidate;
 
     Ip6::UdpSocket mSocket;
     uint32_t mTimeout;

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1665,31 +1665,28 @@ ThreadError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::M
         break;
     }
 
-    if ((child = FindChild(macAddr)) != NULL)
-    {
-        RemoveNeighbor(*child);
-    }
-    else
-    {
-        VerifyOrExit((child = NewChild()) != NULL, ;);
-    }
-
-    memset(child, 0, sizeof(*child));
-
     // Challenge
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kChallenge, sizeof(challenge), challenge));
     VerifyOrExit(challenge.IsValid(), error = kThreadError_Parse);
 
-    // MAC Address
-    memcpy(&child->mMacAddr, &macAddr, sizeof(child->mMacAddr));
-    child->mLinkInfo.Clear();
-    child->mLinkInfo.AddRss(mNetif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
-    child->mLinkFailures = 0;
-    child->mState = Neighbor::kStateParentRequest;
-    child->mDataRequest = false;
+    if ((child = FindChild(macAddr)) == NULL)
+    {
+        VerifyOrExit((child = NewChild()) != NULL, ;);
 
-    child->mLastHeard = Timer::GetNow();
-    child->mTimeout = Timer::MsecToSec(kMaxChildIdRequestTimeout);
+        memset(child, 0, sizeof(*child));
+
+        // MAC Address
+        memcpy(&child->mMacAddr, &macAddr, sizeof(child->mMacAddr));
+        child->mLinkInfo.Clear();
+        child->mLinkInfo.AddRss(mNetif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
+        child->mLinkFailures = 0;
+        child->mState = Neighbor::kStateParentRequest;
+        child->mDataRequest = false;
+
+        child->mLastHeard = Timer::GetNow();
+        child->mTimeout = Timer::MsecToSec(kMaxChildIdRequestTimeout);
+    }
+
     SuccessOrExit(error = SendParentResponse(child, challenge, !scanMask.IsEndDeviceFlagSet()));
 
 exit:
@@ -1970,12 +1967,12 @@ ThreadError MleRouter::SendParentResponse(Child *aChild, const ChallengeTlv &cha
     SuccessOrExit(error = AppendMleFrameCounter(*message));
     SuccessOrExit(error = AppendResponse(*message, challenge.GetChallenge(), challenge.GetLength()));
 
-    for (uint8_t i = 0; i < sizeof(aChild->mPending.mChallenge); i++)
+    for (uint8_t i = 0; i < sizeof(aChild->mAttachChallenge); i++)
     {
-        aChild->mPending.mChallenge[i] = static_cast<uint8_t>(otPlatRandomGet());
+        aChild->mAttachChallenge[i] = static_cast<uint8_t>(otPlatRandomGet());
     }
 
-    SuccessOrExit(error = AppendChallenge(*message, aChild->mPending.mChallenge, sizeof(aChild->mPending.mChallenge)));
+    SuccessOrExit(error = AppendChallenge(*message, aChild->mAttachChallenge, sizeof(aChild->mAttachChallenge)));
 
     if (isAssignLinkQuality &&
         (memcmp(mAddr64.m8, aChild->mMacAddr.m8, OT_EXT_ADDRESS_SIZE) == 0))
@@ -2077,7 +2074,7 @@ ThreadError MleRouter::HandleChildIdRequest(const Message &aMessage, const Ip6::
     // Response
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kResponse, sizeof(response), response));
     VerifyOrExit(response.IsValid() &&
-                 memcmp(response.GetResponse(), child->mPending.mChallenge, sizeof(child->mPending.mChallenge)) == 0, ;);
+                 memcmp(response.GetResponse(), child->mAttachChallenge, sizeof(child->mAttachChallenge)) == 0, ;);
 
     // Link-Layer Frame Counter
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLinkFrameCounter, sizeof(linkFrameCounter),
@@ -2148,6 +2145,16 @@ ThreadError MleRouter::HandleChildIdRequest(const Message &aMessage, const Ip6::
     {
         child->mState = Neighbor::kStateChildIdRequest;
     }
+    else
+    {
+        RemoveStoredChild(child->mValid.mRloc16);
+
+        if (!(child->mMode & ModeTlv::kModeRxOnWhenIdle))
+        {
+            mNetif.GetMeshForwarder().ClearChildIndirectMessages(*child);
+        }
+    }
+
 
     child->mLastHeard = Timer::GetNow();
     child->mValid.mLinkFrameCounter = linkFrameCounter.GetFrameCounter();

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -103,15 +103,20 @@ public:
     enum
     {
         kMaxIp6AddressPerChild = OPENTHREAD_CONFIG_IP_ADDRS_PER_CHILD,
+        kMaxRequestTlvs        = 5,
     };
     Ip6::Address mIp6Address[kMaxIp6AddressPerChild];  ///< Registered IPv6 addresses
     uint32_t     mTimeout;                             ///< Child timeout
     uint16_t     mFragmentOffset;                      ///< 6LoWPAN fragment offset
-    uint8_t      mRequestTlvs[5];                      ///< Requested MLE TLVs
+    union
+    {
+        uint8_t mRequestTlvs[kMaxRequestTlvs];                 ///< Requested MLE TLVs
+        uint8_t mAttachChallenge[Mle::ChallengeTlv::kMaxSize]; ///< The challenge value
+    };
     uint8_t      mNetworkDataVersion;                  ///< Current Network Data version
     uint16_t     mQueuedIndirectMessageCnt;            ///< Count of queued messages
-    bool         mAddSrcMatchEntryShort;               ///< Indicates whether or not to force add short address
-    bool         mAddSrcMatchEntryPending;             ///< Indicates whether or not pending to add
+    bool         mAddSrcMatchEntryShort : 1;           ///< Indicates whether or not to force add short address
+    bool         mAddSrcMatchEntryPending : 1;         ///< Indicates whether or not pending to add
 };
 
 /**


### PR DESCRIPTION
This PR resolves #1166.

On the REED (Child) side, Parent data is no longer overwritten before attachment succeeds, hence need for additional Router object in Mle class for attachment purposes.

To prevent REED from being dropped by parent before migration succeeds, Children are no longer dropped on Parent Request, instead Child Id Request handler takes care of cleaning up on re-attachment.  Therefore addidtional storage was needed for outgoing Challenge value, so the existing child data would not be destroyed.

Unfortunately, I've encountered a problem with RAM shortages on cc2538 (32 bytes overflow). Any ideas on what could be trimmed?