### PR TITLE
Remove reference usage to reduce RAM usage.

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -107,8 +107,6 @@ Mac::Mac(ThreadNetif &aThreadNetif):
     mMacTimer(aThreadNetif.GetIp6().mTimerScheduler, &Mac::HandleMacTimer, this),
     mBackoffTimer(aThreadNetif.GetIp6().mTimerScheduler, &Mac::HandleBeginTransmit, this),
     mReceiveTimer(aThreadNetif.GetIp6().mTimerScheduler, &Mac::HandleReceiveTimer, this),
-    mKeyManager(aThreadNetif.GetKeyManager()),
-    mMle(aThreadNetif.GetMle()),
     mNetif(aThreadNetif),
     mEnergyScanSampleRssiTask(aThreadNetif.GetIp6().mTaskletScheduler, &Mac::HandleEnergyScanSampleRssi, this),
     mWhitelist(),
@@ -669,17 +667,17 @@ void Mac::ProcessTransmitSecurity(Frame &aFrame)
     switch (keyIdMode)
     {
     case Frame::kKeyIdMode0:
-        key = mKeyManager.GetKek();
-        frameCounter = mKeyManager.GetKekFrameCounter();
-        mKeyManager.IncrementKekFrameCounter();
+        key = mNetif.GetKeyManager().GetKek();
+        frameCounter = mNetif.GetKeyManager().GetKekFrameCounter();
+        mNetif.GetKeyManager().IncrementKekFrameCounter();
         extAddress = &mExtAddress;
         break;
 
     case Frame::kKeyIdMode1:
-        key = mKeyManager.GetCurrentMacKey();
-        frameCounter = mKeyManager.GetMacFrameCounter();
-        mKeyManager.IncrementMacFrameCounter();
-        aFrame.SetKeyId((mKeyManager.GetCurrentKeySequence() & 0x7f) + 1);
+        key = mNetif.GetKeyManager().GetCurrentMacKey();
+        frameCounter = mNetif.GetKeyManager().GetMacFrameCounter();
+        mNetif.GetKeyManager().IncrementMacFrameCounter();
+        aFrame.SetKeyId((mNetif.GetKeyManager().GetCurrentKeySequence() & 0x7f) + 1);
         extAddress = &mExtAddress;
         break;
 
@@ -1064,7 +1062,7 @@ ThreadError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, 
     switch (keyIdMode)
     {
     case Frame::kKeyIdMode0:
-        VerifyOrExit((macKey = mKeyManager.GetKek()) != NULL, error = kThreadError_Security);
+        VerifyOrExit((macKey = mNetif.GetKeyManager().GetKek()) != NULL, error = kThreadError_Security);
         extAddress = &aSrcAddr.mExtAddress;
         break;
 
@@ -1074,23 +1072,23 @@ ThreadError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, 
         aFrame.GetKeyId(keyid);
         keyid--;
 
-        if (keyid == (mKeyManager.GetCurrentKeySequence() & 0x7f))
+        if (keyid == (mNetif.GetKeyManager().GetCurrentKeySequence() & 0x7f))
         {
             // same key index
-            keySequence = mKeyManager.GetCurrentKeySequence();
-            macKey = mKeyManager.GetCurrentMacKey();
+            keySequence = mNetif.GetKeyManager().GetCurrentKeySequence();
+            macKey = mNetif.GetKeyManager().GetCurrentMacKey();
         }
-        else if (keyid == ((mKeyManager.GetCurrentKeySequence() - 1) & 0x7f))
+        else if (keyid == ((mNetif.GetKeyManager().GetCurrentKeySequence() - 1) & 0x7f))
         {
             // previous key index
-            keySequence = mKeyManager.GetCurrentKeySequence() - 1;
-            macKey = mKeyManager.GetTemporaryMacKey(keySequence);
+            keySequence = mNetif.GetKeyManager().GetCurrentKeySequence() - 1;
+            macKey = mNetif.GetKeyManager().GetTemporaryMacKey(keySequence);
         }
-        else if (keyid == ((mKeyManager.GetCurrentKeySequence() + 1) & 0x7f))
+        else if (keyid == ((mNetif.GetKeyManager().GetCurrentKeySequence() + 1) & 0x7f))
         {
             // next key index
-            keySequence = mKeyManager.GetCurrentKeySequence() + 1;
-            macKey = mKeyManager.GetTemporaryMacKey(keySequence);
+            keySequence = mNetif.GetKeyManager().GetCurrentKeySequence() + 1;
+            macKey = mNetif.GetKeyManager().GetTemporaryMacKey(keySequence);
         }
         else
         {
@@ -1149,9 +1147,9 @@ ThreadError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, 
 
         aNeighbor->mValid.mLinkFrameCounter = frameCounter + 1;
 
-        if (keySequence > mKeyManager.GetCurrentKeySequence())
+        if (keySequence > mNetif.GetKeyManager().GetCurrentKeySequence())
         {
-            mKeyManager.SetCurrentKeySequence(keySequence);
+            mNetif.GetKeyManager().SetCurrentKeySequence(keySequence);
         }
     }
 
@@ -1198,7 +1196,7 @@ void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
     SuccessOrExit(error = aFrame->ValidatePsdu());
 
     aFrame->GetSrcAddr(srcaddr);
-    neighbor = mMle.GetNeighbor(srcaddr);
+    neighbor = mNetif.GetMle().GetNeighbor(srcaddr);
 
     switch (srcaddr.mLength)
     {

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -609,8 +609,6 @@ private:
     Timer mBackoffTimer;
     Timer mReceiveTimer;
 
-    KeyManager &mKeyManager;
-    Mle::MleRouter &mMle;
     ThreadNetif &mNetif;
 
     ExtAddress mExtAddress;

--- a/src/core/meshcop/announce_begin_client.cpp
+++ b/src/core/meshcop/announce_begin_client.cpp
@@ -52,8 +52,7 @@
 namespace Thread {
 
 AnnounceBeginClient::AnnounceBeginClient(ThreadNetif &aThreadNetif) :
-    mNetif(aThreadNetif),
-    mCoapClient(aThreadNetif.GetCoapClient())
+    mNetif(aThreadNetif)
 {
 }
 
@@ -76,7 +75,7 @@ ThreadError AnnounceBeginClient::SendRequest(uint32_t aChannelMask, uint8_t aCou
     header.AppendUriPathOptions(OPENTHREAD_URI_ANNOUNCE_BEGIN);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mCoapClient.NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoapClient().NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     sessionId.Init();
     sessionId.SetCommissionerSessionId(mNetif.GetCommissioner().GetSessionId());
@@ -98,7 +97,7 @@ ThreadError AnnounceBeginClient::SendRequest(uint32_t aChannelMask, uint8_t aCou
     messageInfo.SetPeerPort(kCoapUdpPort);
     messageInfo.SetInterfaceId(mNetif.GetInterfaceId());
 
-    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
+    SuccessOrExit(error = mNetif.GetCoapClient().SendMessage(*message, messageInfo));
 
     otLogInfoMeshCoP("sent announce begin query");
 

--- a/src/core/meshcop/announce_begin_client.hpp
+++ b/src/core/meshcop/announce_begin_client.hpp
@@ -73,7 +73,6 @@ public:
 
 private:
     ThreadNetif &mNetif;
-    Coap::Client &mCoapClient;
 };
 
 /**

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -73,15 +73,12 @@ Commissioner::Commissioner(ThreadNetif &aThreadNetif):
     mRelayReceive(OPENTHREAD_URI_RELAY_RX, &Commissioner::HandleRelayReceive, this),
     mDatasetChanged(OPENTHREAD_URI_DATASET_CHANGED, &Commissioner::HandleDatasetChanged, this),
     mJoinerFinalize(OPENTHREAD_URI_JOINER_FINALIZE, &Commissioner::HandleJoinerFinalize, this),
-    mCoapServer(aThreadNetif.GetCoapServer()),
-    mCoapClient(aThreadNetif.GetCoapClient()),
-    mSecureCoapServer(aThreadNetif.GetSecureCoapServer()),
     mNetif(aThreadNetif)
 {
     memset(mJoiners, 0, sizeof(mJoiners));
-    mCoapServer.AddResource(mRelayReceive);
-    mCoapServer.AddResource(mDatasetChanged);
-    mSecureCoapServer.AddResource(mJoinerFinalize);
+    mNetif.GetCoapServer().AddResource(mRelayReceive);
+    mNetif.GetCoapServer().AddResource(mDatasetChanged);
+    mNetif.GetSecureCoapServer().AddResource(mJoinerFinalize);
 }
 
 ThreadError Commissioner::Start(void)
@@ -91,7 +88,7 @@ ThreadError Commissioner::Start(void)
     otLogFuncEntry();
     VerifyOrExit(mState == kStateDisabled, error = kThreadError_InvalidState);
 
-    SuccessOrExit(error = mSecureCoapServer.Start(SendRelayTransmit, this));
+    SuccessOrExit(error = mNetif.GetSecureCoapServer().Start(SendRelayTransmit, this));
 
     mState = kStatePetition;
     mTransmitAttempts = 0;
@@ -111,7 +108,7 @@ ThreadError Commissioner::Stop(void)
     otLogFuncEntry();
     VerifyOrExit(mState != kStateDisabled, error = kThreadError_InvalidState);
 
-    mSecureCoapServer.Stop();
+    mNetif.GetSecureCoapServer().Stop();
 
     mState = kStateDisabled;
     mTransmitAttempts = 0;
@@ -332,7 +329,7 @@ ThreadError Commissioner::SendMgmtCommissionerGetRequest(const uint8_t *aTlvs,
         header.SetPayloadMarker();
     }
 
-    VerifyOrExit((message = mCoapClient.NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoapClient().NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     if (aLength > 0)
     {
@@ -344,8 +341,8 @@ ThreadError Commissioner::SendMgmtCommissionerGetRequest(const uint8_t *aTlvs,
 
     mNetif.GetMle().GetLeaderAloc(messageInfo.GetPeerAddr());
     messageInfo.SetPeerPort(kCoapUdpPort);
-    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo,
-                                                  Commissioner::HandleMgmtCommissionerGetResponse, this));
+    SuccessOrExit(error = mNetif.GetCoapClient().SendMessage(*message, messageInfo,
+                                                             Commissioner::HandleMgmtCommissionerGetResponse, this));
 
     otLogInfoMeshCoP("sent MGMT_COMMISSIONER_GET.req to leader");
 
@@ -398,7 +395,7 @@ ThreadError Commissioner::SendMgmtCommissionerSetRequest(const otCommissioningDa
     header.AppendUriPathOptions(OPENTHREAD_URI_COMMISSIONER_SET);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mCoapClient.NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoapClient().NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     if (aDataset.mIsLocatorSet)
     {
@@ -440,8 +437,8 @@ ThreadError Commissioner::SendMgmtCommissionerSetRequest(const otCommissioningDa
 
     mNetif.GetMle().GetLeaderAloc(messageInfo.GetPeerAddr());
     messageInfo.SetPeerPort(kCoapUdpPort);
-    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo,
-                                                  Commissioner::HandleMgmtCommissionerSetResponse, this));
+    SuccessOrExit(error = mNetif.GetCoapClient().SendMessage(*message, messageInfo,
+                                                             Commissioner::HandleMgmtCommissionerSetResponse, this));
 
     otLogInfoMeshCoP("sent MGMT_COMMISSIONER_SET.req to leader");
 
@@ -496,7 +493,7 @@ ThreadError Commissioner::SendPetition(void)
     header.AppendUriPathOptions(OPENTHREAD_URI_LEADER_PETITION);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mCoapClient.NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoapClient().NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
     commissionerId.Init();
     commissionerId.SetCommissionerId("OpenThread Commissioner");
 
@@ -504,8 +501,8 @@ ThreadError Commissioner::SendPetition(void)
 
     mNetif.GetMle().GetLeaderAloc(*static_cast<Ip6::Address *>(&messageInfo.mPeerAddr));
     messageInfo.SetPeerPort(kCoapUdpPort);
-    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo,
-                                                  Commissioner::HandleLeaderPetitionResponse, this));
+    SuccessOrExit(error = mNetif.GetCoapClient().SendMessage(*message, messageInfo,
+                                                             Commissioner::HandleLeaderPetitionResponse, this));
 
     otLogInfoMeshCoP("sent petition");
 
@@ -592,7 +589,7 @@ ThreadError Commissioner::SendKeepAlive(void)
     header.AppendUriPathOptions(OPENTHREAD_URI_LEADER_KEEP_ALIVE);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mCoapClient.NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoapClient().NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     state.Init();
     state.SetState(mState == kStateActive ? StateTlv::kAccept : StateTlv::kReject);
@@ -604,8 +601,8 @@ ThreadError Commissioner::SendKeepAlive(void)
 
     mNetif.GetMle().GetLeaderAloc(*static_cast<Ip6::Address *>(&messageInfo.mPeerAddr));
     messageInfo.SetPeerPort(kCoapUdpPort);
-    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo,
-                                                  Commissioner::HandleLeaderKeepAliveResponse, this));
+    SuccessOrExit(error = mNetif.GetCoapClient().SendMessage(*message, messageInfo,
+                                                             Commissioner::HandleLeaderKeepAliveResponse, this));
 
     otLogInfoMeshCoP("sent keep alive");
 
@@ -690,7 +687,7 @@ void Commissioner::HandleRelayReceive(Coap::Header &aHeader, Message &aMessage, 
     SuccessOrExit(error = Tlv::GetValueOffset(aMessage, Tlv::kJoinerDtlsEncapsulation, offset, length));
     VerifyOrExit(length <= aMessage.GetLength() - offset, error = kThreadError_Parse);
 
-    if (!mSecureCoapServer.IsConnectionActive())
+    if (!mNetif.GetSecureCoapServer().IsConnectionActive())
     {
         memcpy(mJoinerIid, joinerIid.GetIid(), sizeof(mJoinerIid));
         mJoinerPort = joinerPort.GetUdpPort();
@@ -710,8 +707,9 @@ void Commissioner::HandleRelayReceive(Coap::Header &aHeader, Message &aMessage, 
             if (mJoiners[i].mAny || !memcmp(&mJoiners[i].mExtAddress, mJoinerIid, sizeof(mJoiners[i].mExtAddress)))
             {
 
-                SuccessOrExit(error = mSecureCoapServer.SetPsk(reinterpret_cast<const uint8_t *>(mJoiners[i].mPsk),
-                                                               static_cast<uint8_t>(strlen(mJoiners[i].mPsk))));
+                error = mNetif.GetSecureCoapServer().SetPsk(reinterpret_cast<const uint8_t *>(mJoiners[i].mPsk),
+                                                            static_cast<uint8_t>(strlen(mJoiners[i].mPsk)));
+                SuccessOrExit(error);
                 otLogInfoMeshCoP("found joiner, starting new session");
                 enableJoiner = true;
                 break;
@@ -734,7 +732,7 @@ void Commissioner::HandleRelayReceive(Coap::Header &aHeader, Message &aMessage, 
     joinerMessageInfo.GetPeerAddr().SetIid(mJoinerIid);
     joinerMessageInfo.SetPeerPort(mJoinerPort);
 
-    mSecureCoapServer.Receive(aMessage, joinerMessageInfo);
+    mNetif.GetSecureCoapServer().Receive(aMessage, joinerMessageInfo);
 
 exit:
     (void)aMessageInfo;
@@ -758,7 +756,7 @@ void Commissioner::HandleDatasetChanged(Coap::Header &aHeader, Message &aMessage
     otLogInfoMeshCoP("received dataset changed");
     (void)aMessage;
 
-    SuccessOrExit(mCoapServer.SendEmptyAck(aHeader, aMessageInfo));
+    SuccessOrExit(mNetif.GetCoapServer().SendEmptyAck(aHeader, aMessageInfo));
 
     otLogInfoMeshCoP("sent dataset changed acknowledgment");
 
@@ -821,7 +819,8 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Header &aRequestHeader, 
     responseHeader.SetDefaultResponseHeader(aRequestHeader);
     responseHeader.SetPayloadMarker();
 
-    VerifyOrExit((message = mSecureCoapServer.NewMeshCoPMessage(responseHeader)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetSecureCoapServer().NewMeshCoPMessage(responseHeader)) != NULL,
+                 error = kThreadError_NoBufs);
 
     stateTlv.Init();
     stateTlv.SetState(aState);
@@ -832,7 +831,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Header &aRequestHeader, 
     joinerMessageInfo.SetPeerPort(mJoinerPort);
 
     mSendKek = true;
-    SuccessOrExit(error = mSecureCoapServer.SendMessage(*message, joinerMessageInfo));
+    SuccessOrExit(error = mNetif.GetSecureCoapServer().SendMessage(*message, joinerMessageInfo));
 
     otLogInfoMeshCoP("sent joiner finalize response");
     otLogCertMeshCoP("[THCI] direction=send | type=JOIN_FIN.rsp");
@@ -871,7 +870,7 @@ ThreadError Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::Messag
     header.AppendUriPathOptions(OPENTHREAD_URI_RELAY_TX);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mCoapClient.NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoapClient().NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     udpPort.Init();
     udpPort.SetUdpPort(mJoinerPort);
@@ -906,7 +905,7 @@ ThreadError Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::Messag
     messageInfo.SetPeerPort(kCoapUdpPort);
     messageInfo.SetInterfaceId(mNetif.GetInterfaceId());
 
-    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
+    SuccessOrExit(error = mNetif.GetCoapClient().SendMessage(*message, messageInfo));
 
     aMessage.Free();
 

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -255,9 +255,6 @@ private:
     Coap::Resource mRelayReceive;
     Coap::Resource mDatasetChanged;
     Coap::Resource mJoinerFinalize;
-    Coap::Server &mCoapServer;
-    Coap::Client &mCoapClient;
-    Coap::SecureServer &mSecureCoapServer;
 
     ThreadNetif &mNetif;
 };

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -88,10 +88,7 @@ protected:
     Dataset mLocal;
     Dataset mNetwork;
 
-    Coap::Server &mCoapServer;
-    Mle::Mle &mMle;
     ThreadNetif &mNetif;
-    NetworkData::Leader &mNetworkDataLeader;
 
 private:
     static void HandleUdpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo);
@@ -106,7 +103,6 @@ private:
                          uint8_t *aTlvs, uint8_t aLength);
 
     Timer mTimer;
-    Coap::Client &mCoapClient;
 
     const char *mUriSet;
     const char *mUriGet;

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -62,7 +62,7 @@ ActiveDataset::ActiveDataset(ThreadNetif &aThreadNetif):
     mResourceGet(OPENTHREAD_URI_ACTIVE_GET, &ActiveDataset::HandleGet, this),
     mResourceSet(OPENTHREAD_URI_ACTIVE_SET, &ActiveDataset::HandleSet, this)
 {
-    mCoapServer.AddResource(mResourceGet);
+    mNetif.GetCoapServer().AddResource(mResourceGet);
 }
 
 bool ActiveDataset::IsTlvInitialized(Tlv::Type aType)
@@ -183,12 +183,12 @@ void ActiveDataset::StartLeader(void)
 
     mLocal.Store();
     mNetwork = mLocal;
-    mCoapServer.AddResource(mResourceSet);
+    mNetif.GetCoapServer().AddResource(mResourceSet);
 }
 
 void ActiveDataset::StopLeader(void)
 {
-    mCoapServer.RemoveResource(mResourceSet);
+    mNetif.GetCoapServer().RemoveResource(mResourceSet);
 }
 
 void ActiveDataset::HandleGet(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
@@ -226,7 +226,7 @@ PendingDataset::PendingDataset(ThreadNetif &aThreadNetif):
     mResourceGet(OPENTHREAD_URI_PENDING_GET, &PendingDataset::HandleGet, this),
     mResourceSet(OPENTHREAD_URI_PENDING_SET, &PendingDataset::HandleSet, this)
 {
-    mCoapServer.AddResource(mResourceGet);
+    mNetif.GetCoapServer().AddResource(mResourceGet);
 }
 
 void PendingDataset::StartLeader(void)
@@ -236,12 +236,12 @@ void PendingDataset::StartLeader(void)
     mNetwork = mLocal;
     ResetDelayTimer(kFlagNetworkUpdated);
 
-    mCoapServer.AddResource(mResourceSet);
+    mNetif.GetCoapServer().AddResource(mResourceSet);
 }
 
 void PendingDataset::StopLeader(void)
 {
-    mCoapServer.RemoveResource(mResourceSet);
+    mNetif.GetCoapServer().RemoveResource(mResourceSet);
 }
 
 void PendingDataset::HandleGet(void *aContext, otCoapHeader *aHeader, otMessage aMessage,

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -51,13 +51,11 @@ namespace Thread {
 
 EnergyScanClient::EnergyScanClient(ThreadNetif &aThreadNetif) :
     mEnergyScan(OPENTHREAD_URI_ENERGY_REPORT, &EnergyScanClient::HandleReport, this),
-    mCoapServer(aThreadNetif.GetCoapServer()),
-    mCoapClient(aThreadNetif.GetCoapClient()),
     mNetif(aThreadNetif)
 {
     mContext = NULL;
     mCallback = NULL;
-    mCoapServer.AddResource(mEnergyScan);
+    mNetif.GetCoapServer().AddResource(mEnergyScan);
 }
 
 ThreadError EnergyScanClient::SendQuery(uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod,
@@ -80,7 +78,7 @@ ThreadError EnergyScanClient::SendQuery(uint32_t aChannelMask, uint8_t aCount, u
     header.AppendUriPathOptions(OPENTHREAD_URI_ENERGY_SCAN);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mCoapClient.NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoapClient().NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     sessionId.Init();
     sessionId.SetCommissionerSessionId(mNetif.GetCommissioner().GetSessionId());
@@ -105,7 +103,7 @@ ThreadError EnergyScanClient::SendQuery(uint32_t aChannelMask, uint8_t aCount, u
     messageInfo.SetPeerAddr(aAddress);
     messageInfo.SetPeerPort(kCoapUdpPort);
     messageInfo.SetInterfaceId(mNetif.GetInterfaceId());
-    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
+    SuccessOrExit(error = mNetif.GetCoapClient().SendMessage(*message, messageInfo));
 
     otLogInfoMeshCoP("sent energy scan query");
 
@@ -159,7 +157,7 @@ void EnergyScanClient::HandleReport(Coap::Header &aHeader, Message &aMessage, co
     }
 
     memset(&responseInfo.mSockAddr, 0, sizeof(responseInfo.mSockAddr));
-    SuccessOrExit(mCoapServer.SendEmptyAck(aHeader, responseInfo));
+    SuccessOrExit(mNetif.GetCoapServer().SendEmptyAck(aHeader, responseInfo));
 
     otLogInfoMeshCoP("sent energy scan report response");
 

--- a/src/core/meshcop/energy_scan_client.hpp
+++ b/src/core/meshcop/energy_scan_client.hpp
@@ -86,8 +86,6 @@ private:
     void *mContext;
 
     Coap::Resource mEnergyScan;
-    Coap::Server &mCoapServer;
-    Coap::Client &mCoapClient;
 
     ThreadNetif &mNetif;
 };

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -146,8 +146,6 @@ private:
 
     Timer mTimer;
     Coap::Resource mJoinerEntrust;
-    Coap::Server &mCoapServer;
-    Coap::SecureClient &mSecureCoapClient;
     ThreadNetif &mNetif;
 };
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -59,7 +59,6 @@ namespace MeshCoP {
 JoinerRouter::JoinerRouter(ThreadNetif &aNetif):
     mSocket(aNetif.GetIp6().mUdp),
     mRelayTransmit(OPENTHREAD_URI_RELAY_TX, &JoinerRouter::HandleRelayTransmit, this),
-    mCoapClient(aNetif.GetCoapClient()),
     mNetif(aNetif),
     mJoinerUdpPort(0),
     mIsJoinerPortConfigured(false)
@@ -329,7 +328,7 @@ ThreadError JoinerRouter::SendJoinerEntrust(const Ip6::MessageInfo &aMessageInfo
     header.AppendUriPathOptions(OPENTHREAD_URI_JOINER_ENTRUST);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mCoapClient.NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoapClient().NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
     message->SetSubType(Message::kSubTypeJoinerEntrust);
 
     masterKey.Init();
@@ -398,7 +397,7 @@ ThreadError JoinerRouter::SendJoinerEntrust(const Ip6::MessageInfo &aMessageInfo
 
     messageInfo = aMessageInfo;
     messageInfo.SetPeerPort(kCoapUdpPort);
-    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
+    SuccessOrExit(error = mNetif.GetCoapClient().SendMessage(*message, messageInfo));
 
     otLogInfoMeshCoP("Sent joiner entrust length = %d", message->GetLength());
     otLogCertMeshCoP("[THCI] direction=send | type=JOIN_ENT.ntf");

--- a/src/core/meshcop/joiner_router_ftd.hpp
+++ b/src/core/meshcop/joiner_router_ftd.hpp
@@ -98,7 +98,6 @@ private:
 
     Ip6::UdpSocket mSocket;
     Coap::Resource mRelayTransmit;
-    Coap::Client &mCoapClient;
     ThreadNetif &mNetif;
 
     uint16_t mJoinerUdpPort;

--- a/src/core/meshcop/leader_ftd.hpp
+++ b/src/core/meshcop/leader_ftd.hpp
@@ -108,10 +108,6 @@ private:
 
     Coap::Resource mPetition;
     Coap::Resource mKeepAlive;
-    Coap::Server &mCoapServer;
-    Coap::Client &mCoapClient;
-    NetworkData::Leader &mNetworkData;
-
     Timer mTimer;
 
     CommissionerIdTlv mCommissionerId;

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -49,11 +49,9 @@ PanIdQueryClient::PanIdQueryClient(ThreadNetif &aThreadNetif) :
     mCallback(NULL),
     mContext(NULL),
     mPanIdQuery(OPENTHREAD_URI_PANID_CONFLICT, &PanIdQueryClient::HandleConflict, this),
-    mCoapServer(aThreadNetif.GetCoapServer()),
-    mCoapClient(aThreadNetif.GetCoapClient()),
     mNetif(aThreadNetif)
 {
-    mCoapServer.AddResource(mPanIdQuery);
+    mNetif.GetCoapServer().AddResource(mPanIdQuery);
 }
 
 ThreadError PanIdQueryClient::SendQuery(uint16_t aPanId, uint32_t aChannelMask, const Ip6::Address &aAddress,
@@ -73,7 +71,7 @@ ThreadError PanIdQueryClient::SendQuery(uint16_t aPanId, uint32_t aChannelMask, 
     header.AppendUriPathOptions(OPENTHREAD_URI_PANID_QUERY);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mCoapClient.NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoapClient().NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     sessionId.Init();
     sessionId.SetCommissionerSessionId(mNetif.GetCommissioner().GetSessionId());
@@ -90,7 +88,7 @@ ThreadError PanIdQueryClient::SendQuery(uint16_t aPanId, uint32_t aChannelMask, 
     messageInfo.SetPeerAddr(aAddress);
     messageInfo.SetPeerPort(kCoapUdpPort);
     messageInfo.SetInterfaceId(mNetif.GetInterfaceId());
-    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
+    SuccessOrExit(error = mNetif.GetCoapClient().SendMessage(*message, messageInfo));
 
     otLogInfoMeshCoP("sent panid query");
 
@@ -138,7 +136,7 @@ void PanIdQueryClient::HandleConflict(Coap::Header &aHeader, Message &aMessage, 
     }
 
     memset(&responseInfo.mSockAddr, 0, sizeof(responseInfo.mSockAddr));
-    SuccessOrExit(mCoapServer.SendEmptyAck(aHeader, responseInfo));
+    SuccessOrExit(mNetif.GetCoapServer().SendEmptyAck(aHeader, responseInfo));
 
     otLogInfoMeshCoP("sent panid query conflict response");
 

--- a/src/core/meshcop/panid_query_client.hpp
+++ b/src/core/meshcop/panid_query_client.hpp
@@ -84,8 +84,6 @@ private:
     void *mContext;
 
     Coap::Resource mPanIdQuery;
-    Coap::Server &mCoapServer;
-    Coap::Client &mCoapClient;
 
     ThreadNetif &mNetif;
 };

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -224,8 +224,6 @@ private:
     TrickleTimer mTrickleTimer;
 
     Ip6::UdpSocket mSocket;
-    Mle::MleRouter &mMle;
-    Mac::Mac &mMac;
     ThreadNetif &mNetif;
 
     uint8_t mTransactionId[kTransactionIdSize];

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -148,9 +148,6 @@ private:
 
     Ip6::UdpSocket mSocket;
 
-    Mac::Mac &mMac;
-    Mle::MleRouter &mMle;
-    NetworkData::Leader &mNetworkDataLeader;
     ThreadNetif &mNetif;
 
     Ip6::NetifUnicastAddress mAgentsAloc[OPENTHREAD_CONFIG_NUM_DHCP_PREFIXES];

--- a/src/core/thread/address_resolver_ftd.hpp
+++ b/src/core/thread/address_resolver_ftd.hpp
@@ -183,11 +183,7 @@ private:
     Ip6::IcmpHandler mIcmpHandler;
     Timer mTimer;
 
-    MeshForwarder &mMeshForwarder;
-    Coap::Server &mCoapServer;
-    Coap::Client &mCoapClient;
-    Mle::MleRouter &mMle;
-    Ip6::Netif &mNetif;
+    ThreadNetif &mNetif;
 };
 
 /**

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -60,10 +60,9 @@ AnnounceBeginServer::AnnounceBeginServer(ThreadNetif &aThreadNetif) :
     mChannel(0),
     mTimer(aThreadNetif.GetIp6().mTimerScheduler, &AnnounceBeginServer::HandleTimer, this),
     mAnnounceBegin(OPENTHREAD_URI_ANNOUNCE_BEGIN, &AnnounceBeginServer::HandleRequest, this),
-    mCoapServer(aThreadNetif.GetCoapServer()),
     mNetif(aThreadNetif)
 {
-    mCoapServer.AddResource(mAnnounceBegin);
+    mNetif.GetCoapServer().AddResource(mAnnounceBegin);
 }
 
 ThreadError AnnounceBeginServer::SendAnnounce(uint32_t aChannelMask)
@@ -120,7 +119,7 @@ void AnnounceBeginServer::HandleRequest(Coap::Header &aHeader, Message &aMessage
     SendAnnounce(channelMask.GetMask(), count.GetCount(), period.GetPeriod());
 
     memset(&responseInfo.mSockAddr, 0, sizeof(responseInfo.mSockAddr));
-    SuccessOrExit(mCoapServer.SendEmptyAck(aHeader, responseInfo));
+    SuccessOrExit(mNetif.GetCoapServer().SendEmptyAck(aHeader, responseInfo));
 
     otLogInfoMeshCoP("sent announce begin response");
 

--- a/src/core/thread/announce_begin_server.hpp
+++ b/src/core/thread/announce_begin_server.hpp
@@ -102,7 +102,6 @@ private:
     Timer mTimer;
 
     Coap::Resource mAnnounceBegin;
-    Coap::Server &mCoapServer;
     ThreadNetif &mNetif;
 };
 

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -55,14 +55,12 @@ EnergyScanServer::EnergyScanServer(ThreadNetif &aThreadNetif) :
     mScanResultsLength(0),
     mTimer(aThreadNetif.GetIp6().mTimerScheduler, &EnergyScanServer::HandleTimer, this),
     mEnergyScan(OPENTHREAD_URI_ENERGY_SCAN, &EnergyScanServer::HandleRequest, this),
-    mCoapServer(aThreadNetif.GetCoapServer()),
-    mCoapClient(aThreadNetif.GetCoapClient()),
     mNetif(aThreadNetif)
 {
     mNetifCallback.Set(&EnergyScanServer::HandleNetifStateChanged, this);
     mNetif.RegisterCallback(mNetifCallback);
 
-    mCoapServer.AddResource(mEnergyScan);
+    mNetif.GetCoapServer().AddResource(mEnergyScan);
 }
 
 void EnergyScanServer::HandleRequest(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
@@ -107,7 +105,7 @@ void EnergyScanServer::HandleRequest(Coap::Header &aHeader, Message &aMessage, c
     mCommissioner = aMessageInfo.GetPeerAddr();
 
     memset(&responseInfo.mSockAddr, 0, sizeof(responseInfo.mSockAddr));
-    SuccessOrExit(mCoapServer.SendEmptyAck(aHeader, responseInfo));
+    SuccessOrExit(mNetif.GetCoapServer().SendEmptyAck(aHeader, responseInfo));
 
     otLogInfoMeshCoP("sent energy scan query response");
 
@@ -191,7 +189,7 @@ ThreadError EnergyScanServer::SendReport(void)
     header.AppendUriPathOptions(OPENTHREAD_URI_ENERGY_REPORT);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mCoapClient.NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoapClient().NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     channelMask.Init();
     channelMask.SetMask(mChannelMask);
@@ -204,7 +202,7 @@ ThreadError EnergyScanServer::SendReport(void)
 
     messageInfo.SetPeerAddr(mCommissioner);
     messageInfo.SetPeerPort(kCoapUdpPort);
-    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
+    SuccessOrExit(error = mNetif.GetCoapClient().SendMessage(*message, messageInfo));
 
     otLogInfoMeshCoP("sent scan results");
 

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -101,8 +101,6 @@ private:
     Ip6::NetifCallback mNetifCallback;
 
     Coap::Resource mEnergyScan;
-    Coap::Server &mCoapServer;
-    Coap::Client &mCoapClient;
 
     ThreadNetif &mNetif;
 };

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -75,15 +75,10 @@ MeshForwarder::MeshForwarder(ThreadNetif &aThreadNetif):
     mRestoreChannel(0),
     mScanning(false),
     mNetif(aThreadNetif),
-    mAddressResolver(aThreadNetif.GetAddressResolver()),
-    mLowpan(aThreadNetif.GetLowpan()),
-    mMac(aThreadNetif.GetMac()),
-    mMle(aThreadNetif.GetMle()),
-    mNetworkData(aThreadNetif.GetNetworkDataLeader()),
     mSrcMatchEnabled(false)
 {
     mFragTag = static_cast<uint16_t>(otPlatRandomGet());
-    mMac.RegisterReceiver(mMacReceiver);
+    mNetif.GetMac().RegisterReceiver(mMacReceiver);
     mMacSource.mLength = 0;
     mMacDest.mLength = 0;
 }
@@ -94,7 +89,7 @@ ThreadError MeshForwarder::Start(void)
 
     if (mEnabled == false)
     {
-        mMac.SetRxOnWhenIdle(true);
+        mNetif.GetMac().SetRxOnWhenIdle(true);
         mEnabled = true;
     }
 
@@ -113,9 +108,9 @@ ThreadError MeshForwarder::Stop(void)
 
     if (mScanning)
     {
-        mMac.SetChannel(mRestoreChannel);
+        mNetif.GetMac().SetChannel(mRestoreChannel);
         mScanning = false;
-        mMle.HandleDiscoverComplete();
+        mNetif.GetMle().HandleDiscoverComplete();
     }
 
     while ((message = mSendQueue.GetHead()) != NULL)
@@ -132,7 +127,7 @@ ThreadError MeshForwarder::Stop(void)
 
     mEnabled = false;
     mSendMessage = NULL;
-    mMac.SetRxOnWhenIdle(false);
+    mNetif.GetMac().SetRxOnWhenIdle(false);
 
 exit:
     return error;
@@ -187,7 +182,7 @@ void MeshForwarder::UpdateIndirectMessages(void)
     Child *children;
     uint8_t numChildren;
 
-    children = mMle.GetChildren(&numChildren);
+    children = mNetif.GetMle().GetChildren(&numChildren);
 
     for (uint8_t i = 0; i < numChildren; i++)
     {
@@ -232,7 +227,7 @@ void MeshForwarder::ScheduleTransmissionTask()
 
     UpdateIndirectMessages();
 
-    children = mMle.GetChildren(&numChildren);
+    children = mNetif.GetMle().GetChildren(&numChildren);
 
     for (int i = 0; i < numChildren; i++)
     {
@@ -259,14 +254,14 @@ void MeshForwarder::ScheduleTransmissionTask()
                 }
             }
 
-            mMac.SendFrameRequest(mMacSender);
+            mNetif.GetMac().SendFrameRequest(mMacSender);
             ExitNow();
         }
     }
 
     if ((mSendMessage = GetDirectTransmission()) != NULL)
     {
-        mMac.SendFrameRequest(mMacSender);
+        mNetif.GetMac().SendFrameRequest(mMacSender);
         ExitNow();
     }
 
@@ -280,7 +275,7 @@ ThreadError MeshForwarder::AddPendingSrcMatchEntries(void)
     Child *children = NULL;
     ThreadError error = kThreadError_NoBufs;
 
-    children = mMle.GetChildren(&numChildren);
+    children = mNetif.GetMle().GetChildren(&numChildren);
 
     // Add pending short address first
     for (uint8_t i = 0; i < numChildren; i++)
@@ -335,14 +330,14 @@ ThreadError MeshForwarder::AddSrcMatchEntry(Child &aChild)
         memcpy(macAddr.mExtAddress.m8, aChild.mMacAddr.m8, sizeof(macAddr.mExtAddress));
     }
 
-    if ((error = mMac.AddSrcMatchEntry(macAddr)) == kThreadError_None)
+    if ((error = mNetif.GetMac().AddSrcMatchEntry(macAddr)) == kThreadError_None)
     {
         // succeed in adding to source match table
         aChild.mAddSrcMatchEntryPending = false;
 
         if (!mSrcMatchEnabled)
         {
-            mMac.EnableSrcMatch(true);
+            mNetif.GetMac().EnableSrcMatch(true);
             mSrcMatchEnabled = true;
         }
     }
@@ -350,7 +345,7 @@ ThreadError MeshForwarder::AddSrcMatchEntry(Child &aChild)
     {
         if (mSrcMatchEnabled)
         {
-            mMac.EnableSrcMatch(false);
+            mNetif.GetMac().EnableSrcMatch(false);
             mSrcMatchEnabled = false;
         }
     }
@@ -375,11 +370,11 @@ void MeshForwarder::ClearSrcMatchEntry(Child &aChild)
         memcpy(macAddr.mExtAddress.m8, aChild.mMacAddr.m8, sizeof(macAddr.mExtAddress));
     }
 
-    if (mMac.ClearSrcMatchEntry(macAddr) == kThreadError_None)
+    if (mNetif.GetMac().ClearSrcMatchEntry(macAddr) == kThreadError_None)
     {
         if (!mSrcMatchEnabled && (AddPendingSrcMatchEntries() == kThreadError_None))
         {
-            mMac.EnableSrcMatch(true);
+            mNetif.GetMac().EnableSrcMatch(true);
             mSrcMatchEnabled = true;
         }
     }
@@ -406,9 +401,10 @@ ThreadError MeshForwarder::SendMessage(Message &aMessage)
 
         aMessage.Read(0, sizeof(ip6Header), &ip6Header);
 
-        if (!memcmp(&ip6Header.GetDestination(), mMle.GetLinkLocalAllThreadNodesAddress(),
+        if (!memcmp(&ip6Header.GetDestination(), mNetif.GetMle().GetLinkLocalAllThreadNodesAddress(),
                     sizeof(ip6Header.GetDestination())) ||
-            !memcmp(&ip6Header.GetDestination(), mMle.GetRealmLocalAllThreadNodesAddress(), sizeof(ip6Header.GetDestination())))
+            !memcmp(&ip6Header.GetDestination(), mNetif.GetMle().GetRealmLocalAllThreadNodesAddress(),
+                    sizeof(ip6Header.GetDestination())))
         {
             // schedule direct transmission
             aMessage.SetDirectTransmission();
@@ -416,7 +412,7 @@ ThreadError MeshForwarder::SendMessage(Message &aMessage)
             if (aMessage.GetSubType() != Message::kSubTypeMplRetransmission)
             {
                 // destined for all sleepy children
-                children = mMle.GetChildren(&numChildren);
+                children = mNetif.GetMle().GetChildren(&numChildren);
 
                 for (uint8_t i = 0; i < numChildren; i++)
                 {
@@ -429,7 +425,7 @@ ThreadError MeshForwarder::SendMessage(Message &aMessage)
                 }
             }
         }
-        else if ((neighbor = mMle.GetNeighbor(ip6Header.GetDestination())) != NULL &&
+        else if ((neighbor = mNetif.GetMle().GetNeighbor(ip6Header.GetDestination())) != NULL &&
                  (neighbor->mMode & Mle::ModeTlv::kModeRxOnWhenIdle) == 0)
         {
             // destined for a sleepy child
@@ -437,7 +433,7 @@ ThreadError MeshForwarder::SendMessage(Message &aMessage)
             children->mQueuedIndirectMessageCnt++;
 
             AddSrcMatchEntry(*children);
-            aMessage.SetChildMask(mMle.GetChildIndex(*children));
+            aMessage.SetChildMask(mNetif.GetMle().GetChildIndex(*children));
         }
         else
         {
@@ -454,7 +450,7 @@ ThreadError MeshForwarder::SendMessage(Message &aMessage)
 
         IgnoreReturnValue(meshHeader.Init(aMessage));
 
-        if ((neighbor = mMle.GetNeighbor(meshHeader.GetDestination())) != NULL &&
+        if ((neighbor = mNetif.GetMle().GetNeighbor(meshHeader.GetDestination())) != NULL &&
             (neighbor->mMode & Mle::ModeTlv::kModeRxOnWhenIdle) == 0)
         {
             // destined for a sleepy child
@@ -462,7 +458,7 @@ ThreadError MeshForwarder::SendMessage(Message &aMessage)
             children->mQueuedIndirectMessageCnt++;
 
             AddSrcMatchEntry(*children);
-            aMessage.SetChildMask(mMle.GetChildIndex(*children));
+            aMessage.SetChildMask(mNetif.GetMle().GetChildIndex(*children));
         }
         else
         {
@@ -544,7 +540,7 @@ exit:
 Message *MeshForwarder::GetIndirectTransmission(const Child &aChild)
 {
     Message *message = NULL;
-    uint8_t childIndex = mMle.GetChildIndex(aChild);
+    uint8_t childIndex = mNetif.GetMle().GetChildIndex(aChild);
     Ip6::Header ip6Header;
 
     for (message = mSendQueue.GetHead(); message; message = message->GetNext())
@@ -586,7 +582,7 @@ Message *MeshForwarder::GetIndirectTransmission(const Child &aChild)
         mMeshDest = meshHeader.GetDestination();
         mMeshSource = meshHeader.GetSource();
         mMacSource.mLength = sizeof(mMacSource.mShortAddress);
-        mMacSource.mShortAddress = mMac.GetShortAddress();
+        mMacSource.mShortAddress = mNetif.GetMac().GetShortAddress();
         mMacDest.mLength = sizeof(mMacDest.mShortAddress);
         mMacDest.mShortAddress = meshHeader.GetDestination();
         break;
@@ -611,15 +607,15 @@ ThreadError MeshForwarder::UpdateMeshRoute(Message &aMessage)
 
     IgnoreReturnValue(meshHeader.Init(aMessage));
 
-    nextHop = mMle.GetNextHop(meshHeader.GetDestination());
+    nextHop = mNetif.GetMle().GetNextHop(meshHeader.GetDestination());
 
     if (nextHop != Mac::kShortAddrInvalid)
     {
-        neighbor = mMle.GetNeighbor(nextHop);
+        neighbor = mNetif.GetMle().GetNeighbor(nextHop);
     }
     else
     {
-        neighbor = mMle.GetNeighbor(meshHeader.GetDestination());
+        neighbor = mNetif.GetMle().GetNeighbor(meshHeader.GetDestination());
     }
 
     if (neighbor == NULL)
@@ -630,7 +626,7 @@ ThreadError MeshForwarder::UpdateMeshRoute(Message &aMessage)
     mMacDest.mLength = sizeof(mMacDest.mShortAddress);
     mMacDest.mShortAddress = neighbor->mValid.mRloc16;
     mMacSource.mLength = sizeof(mMacSource.mShortAddress);
-    mMacSource.mShortAddress = mMac.GetShortAddress();
+    mMacSource.mShortAddress = mNetif.GetMac().GetShortAddress();
 
     mAddMeshHeader = true;
     mMeshDest = meshHeader.GetDestination();
@@ -652,7 +648,7 @@ ThreadError MeshForwarder::UpdateIp6Route(Message &aMessage)
 
     aMessage.Read(0, sizeof(ip6Header), &ip6Header);
 
-    switch (mMle.GetDeviceState())
+    switch (mNetif.GetMle().GetDeviceState())
     {
     case Mle::kDeviceStateDisabled:
     case Mle::kDeviceStateDetached:
@@ -679,7 +675,7 @@ ThreadError MeshForwarder::UpdateIp6Route(Message &aMessage)
             }
             else
             {
-                mMacDest.mShortAddress = mMle.GetNextHop(Mac::kShortAddrBroadcast);
+                mMacDest.mShortAddress = mNetif.GetMle().GetNextHop(Mac::kShortAddrBroadcast);
             }
 
             GetMacSourceAddress(ip6Header.GetSource(), mMacSource);
@@ -705,20 +701,21 @@ ThreadError MeshForwarder::UpdateIp6Route(Message &aMessage)
         }
         else
         {
-            if (mMle.IsRoutingLocator(ip6Header.GetDestination()))
+            if (mNetif.GetMle().IsRoutingLocator(ip6Header.GetDestination()))
             {
                 rloc16 = HostSwap16(ip6Header.GetDestination().mFields.m16[7]);
-                VerifyOrExit(mMle.IsRouterIdValid(mMle.GetRouterId(rloc16)), error = kThreadError_Drop);
+                VerifyOrExit(mNetif.GetMle().IsRouterIdValid(mNetif.GetMle().GetRouterId(rloc16)),
+                             error = kThreadError_Drop);
                 mMeshDest = rloc16;
             }
-            else if (mMle.IsAnycastLocator(ip6Header.GetDestination()))
+            else if (mNetif.GetMle().IsAnycastLocator(ip6Header.GetDestination()))
             {
                 // only support Leader ALOC for now
                 aloc16 = HostSwap16(ip6Header.GetDestination().mFields.m16[7]);
 
                 if (aloc16 == Mle::kAloc16Leader)
                 {
-                    mMeshDest = mMle.GetRloc16(mMle.GetLeaderId());
+                    mMeshDest = mNetif.GetMle().GetRloc16(mNetif.GetMle().GetLeaderId());
                 }
 
 #if OPENTHREAD_ENABLE_DHCP6_SERVER || OPENTHREAD_ENABLE_DHCP6_CLIENT
@@ -726,20 +723,23 @@ ThreadError MeshForwarder::UpdateIp6Route(Message &aMessage)
                 {
                     uint16_t agentRloc16;
                     uint8_t routerId;
-                    VerifyOrExit((mNetworkData.GetRlocByContextId(static_cast<uint8_t>(aloc16 & Mle::kAloc16DhcpAgentMask),
-                                                                  agentRloc16) == kThreadError_None), error = kThreadError_Drop);
+                    VerifyOrExit((mNetif.GetNetworkDataLeader().GetRlocByContextId(
+                                      static_cast<uint8_t>(aloc16 & Mle::kAloc16DhcpAgentMask),
+                                      agentRloc16) == kThreadError_None),
+                                 error = kThreadError_Drop);
 
-                    routerId = mMle.GetRouterId(agentRloc16);
+                    routerId = mNetif.GetMle().GetRouterId(agentRloc16);
 
                     // if agent is active router or the child of the device
-                    if ((mMle.IsActiveRouter(agentRloc16)) || (mMle.GetRloc16(routerId) == mMle.GetRloc16()))
+                    if ((mNetif.GetMle().IsActiveRouter(agentRloc16)) ||
+                        (mNetif.GetMle().GetRloc16(routerId) == mNetif.GetMle().GetRloc16()))
                     {
                         mMeshDest = agentRloc16;
                     }
                     else
                     {
                         // use the parent of the ED Agent as Dest
-                        mMeshDest = mMle.GetRloc16(routerId);
+                        mMeshDest = mNetif.GetMle().GetRloc16(routerId);
                     }
                 }
 
@@ -750,22 +750,27 @@ ThreadError MeshForwarder::UpdateIp6Route(Message &aMessage)
                     ExitNow(error = kThreadError_Drop);
                 }
             }
-            else if ((neighbor = mMle.GetNeighbor(ip6Header.GetDestination())) != NULL)
+            else if ((neighbor = mNetif.GetMle().GetNeighbor(ip6Header.GetDestination())) != NULL)
             {
                 mMeshDest = neighbor->mValid.mRloc16;
             }
-            else if (mNetworkData.IsOnMesh(ip6Header.GetDestination()))
+            else if (mNetif.GetNetworkDataLeader().IsOnMesh(ip6Header.GetDestination()))
             {
-                SuccessOrExit(error = mAddressResolver.Resolve(ip6Header.GetDestination(), mMeshDest));
+                SuccessOrExit(error = mNetif.GetAddressResolver().Resolve(ip6Header.GetDestination(), mMeshDest));
             }
             else
             {
-                mNetworkData.RouteLookup(ip6Header.GetSource(), ip6Header.GetDestination(), NULL, &mMeshDest);
+                mNetif.GetNetworkDataLeader().RouteLookup(
+                    ip6Header.GetSource(),
+                    ip6Header.GetDestination(),
+                    NULL,
+                    &mMeshDest
+                );
             }
 
             VerifyOrExit(mMeshDest != Mac::kShortAddrInvalid, error = kThreadError_Drop);
 
-            if (mMle.GetNeighbor(mMeshDest) != NULL)
+            if (mNetif.GetMle().GetNeighbor(mMeshDest) != NULL)
             {
                 // destination is neighbor
                 mMacDest.mLength = sizeof(mMacDest.mShortAddress);
@@ -775,12 +780,12 @@ ThreadError MeshForwarder::UpdateIp6Route(Message &aMessage)
             else
             {
                 // destination is not neighbor
-                mMeshSource = mMac.GetShortAddress();
+                mMeshSource = mNetif.GetMac().GetShortAddress();
 
-                SuccessOrExit(error = mMle.CheckReachability(mMeshSource, mMeshDest, ip6Header));
+                SuccessOrExit(error = mNetif.GetMle().CheckReachability(mMeshSource, mMeshDest, ip6Header));
 
                 mMacDest.mLength = sizeof(mMacDest.mShortAddress);
-                mMacDest.mShortAddress = mMle.GetNextHop(mMeshDest);
+                mMacDest.mShortAddress = mNetif.GetMle().GetNextHop(mMeshDest);
                 mMacSource.mLength = sizeof(mMacSource.mShortAddress);
                 mMacSource.mShortAddress = mMeshSource;
                 mAddMeshHeader = true;
@@ -796,12 +801,12 @@ exit:
 
 bool MeshForwarder::GetRxOnWhenIdle()
 {
-    return mMac.GetRxOnWhenIdle();
+    return mNetif.GetMac().GetRxOnWhenIdle();
 }
 
 void MeshForwarder::SetRxOnWhenIdle(bool aRxOnWhenIdle)
 {
-    mMac.SetRxOnWhenIdle(aRxOnWhenIdle);
+    mNetif.GetMac().SetRxOnWhenIdle(aRxOnWhenIdle);
 
     if (aRxOnWhenIdle)
     {
@@ -817,7 +822,7 @@ void MeshForwarder::SetAssignPollPeriod(uint32_t aPeriod)
 {
     mAssignPollPeriod = aPeriod;
 
-    if (mPollTimer.IsRunning() && ((mMle.GetDeviceMode() & Mle::ModeTlv::kModeFFD) == 0))
+    if (mPollTimer.IsRunning() && ((mNetif.GetMle().GetDeviceMode() & Mle::ModeTlv::kModeFFD) == 0))
     {
         SetPollPeriod(mAssignPollPeriod);
     }
@@ -873,7 +878,7 @@ ThreadError MeshForwarder::SendMacDataRequest(void)
     Message *message;
 
     // only send MAC Data Requests in rx-off-when-idle mode
-    VerifyOrExit(!mMac.GetRxOnWhenIdle(), error = kThreadError_InvalidState);
+    VerifyOrExit(!mNetif.GetMac().GetRxOnWhenIdle(), error = kThreadError_InvalidState);
 
     // only enqueue one MAC Data Request at a time
     for (message = mSendQueue.GetHead(); message; message = message->GetNext())
@@ -900,10 +905,10 @@ ThreadError MeshForwarder::GetMacSourceAddress(const Ip6::Address &aIp6Addr, Mac
     aMacAddr.mLength = sizeof(aMacAddr.mExtAddress);
     aMacAddr.mExtAddress.Set(aIp6Addr);
 
-    if (memcmp(&aMacAddr.mExtAddress, mMac.GetExtAddress(), sizeof(aMacAddr.mExtAddress)) != 0)
+    if (memcmp(&aMacAddr.mExtAddress, mNetif.GetMac().GetExtAddress(), sizeof(aMacAddr.mExtAddress)) != 0)
     {
         aMacAddr.mLength = sizeof(aMacAddr.mShortAddress);
-        aMacAddr.mShortAddress = mMac.GetShortAddress();
+        aMacAddr.mShortAddress = mNetif.GetMac().GetShortAddress();
     }
 
     return kThreadError_None;
@@ -927,7 +932,7 @@ ThreadError MeshForwarder::GetMacDestinationAddress(const Ip6::Address &aIp6Addr
         aMacAddr.mLength = sizeof(aMacAddr.mShortAddress);
         aMacAddr.mShortAddress = HostSwap16(aIp6Addr.mFields.m16[7]);
     }
-    else if (mMle.IsRoutingLocator(aIp6Addr))
+    else if (mNetif.GetMle().IsRoutingLocator(aIp6Addr))
     {
         aMacAddr.mLength = sizeof(aMacAddr.mShortAddress);
         aMacAddr.mShortAddress = HostSwap16(aIp6Addr.mFields.m16[7]);
@@ -970,7 +975,7 @@ ThreadError MeshForwarder::HandleFrameRequest(Mac::Frame &aFrame)
             if (!mScanning)
             {
                 mScanChannel = kPhyMinChannel;
-                mRestoreChannel = mMac.GetChannel();
+                mRestoreChannel = mNetif.GetMac().GetChannel();
                 mScanning = true;
             }
 
@@ -980,7 +985,7 @@ ThreadError MeshForwarder::HandleFrameRequest(Mac::Frame &aFrame)
                 mScanChannel++;
             }
 
-            mMac.SetChannel(mScanChannel);
+            mNetif.GetMac().SetChannel(mScanChannel);
             aFrame.SetChannel(mScanChannel);
         }
 
@@ -1000,7 +1005,7 @@ ThreadError MeshForwarder::HandleFrameRequest(Mac::Frame &aFrame)
     // set FramePending if there are more queued messages for the child
     aFrame.GetDstAddr(macDest);
 
-    if (((child = mMle.GetChild(macDest)) != NULL)
+    if (((child = mNetif.GetMle().GetChild(macDest)) != NULL)
         && ((child->mMode & Mle::ModeTlv::kModeRxOnWhenIdle) == 0)
         && (child->mQueuedIndirectMessageCnt > 1))
     {
@@ -1019,9 +1024,9 @@ ThreadError MeshForwarder::SendPoll(Message &aMessage, Mac::Frame &aFrame)
     Neighbor *neighbor;
 
     // only send MAC Data Requests in rx-off-when-idle mode
-    VerifyOrExit(!mMac.GetRxOnWhenIdle(), error = kThreadError_InvalidState);
+    VerifyOrExit(!mNetif.GetMac().GetRxOnWhenIdle(), error = kThreadError_InvalidState);
 
-    macSource.mShortAddress = mMac.GetShortAddress();
+    macSource.mShortAddress = mNetif.GetMac().GetShortAddress();
 
     if (macSource.mShortAddress != Mac::kShortAddrInvalid)
     {
@@ -1030,7 +1035,7 @@ ThreadError MeshForwarder::SendPoll(Message &aMessage, Mac::Frame &aFrame)
     else
     {
         macSource.mLength = sizeof(macSource.mExtAddress);
-        memcpy(&macSource.mExtAddress, mMac.GetExtAddress(), sizeof(macSource.mExtAddress));
+        memcpy(&macSource.mExtAddress, mNetif.GetMac().GetExtAddress(), sizeof(macSource.mExtAddress));
     }
 
     // initialize MAC header
@@ -1048,9 +1053,9 @@ ThreadError MeshForwarder::SendPoll(Message &aMessage, Mac::Frame &aFrame)
     fcf |= Mac::Frame::kFcfAckRequest | Mac::Frame::kFcfSecurityEnabled;
 
     aFrame.InitMacHeader(fcf, Mac::Frame::kKeyIdMode1 | Mac::Frame::kSecEncMic32);
-    aFrame.SetDstPanId(mMac.GetPanId());
+    aFrame.SetDstPanId(mNetif.GetMac().GetPanId());
 
-    neighbor = mMle.GetParent();
+    neighbor = mNetif.GetMle().GetParent();
     assert(neighbor != NULL);
 
     if (macSource.mLength == 2)
@@ -1082,7 +1087,7 @@ ThreadError MeshForwarder::SendMesh(Message &aMessage, Mac::Frame &aFrame)
           Mac::Frame::kFcfAckRequest | Mac::Frame::kFcfSecurityEnabled;
 
     aFrame.InitMacHeader(fcf, Mac::Frame::kKeyIdMode1 | Mac::Frame::kSecEncMic32);
-    aFrame.SetDstPanId(mMac.GetPanId());
+    aFrame.SetDstPanId(mNetif.GetMac().GetPanId());
     aFrame.SetDstAddr(mMacDest.mShortAddress);
     aFrame.SetSrcAddr(mMacSource.mShortAddress);
 
@@ -1157,7 +1162,7 @@ ThreadError MeshForwarder::SendFragment(Message &aMessage, Mac::Frame &aFrame)
         secCtl |= Mac::Frame::kSecEncMic32;
     }
 
-    dstpan = mMac.GetPanId();
+    dstpan = mNetif.GetMac().GetPanId();
 
     switch (aMessage.GetSubType())
     {
@@ -1175,14 +1180,14 @@ ThreadError MeshForwarder::SendFragment(Message &aMessage, Mac::Frame &aFrame)
         break;
     }
 
-    if (dstpan == mMac.GetPanId())
+    if (dstpan == mNetif.GetMac().GetPanId())
     {
         fcf |= Mac::Frame::kFcfPanidCompression;
     }
 
     aFrame.InitMacHeader(fcf, secCtl);
     aFrame.SetDstPanId(dstpan);
-    aFrame.SetSrcPanId(mMac.GetPanId());
+    aFrame.SetSrcPanId(mNetif.GetMac().GetPanId());
 
     if (mMacDest.mLength == 2)
     {
@@ -1210,19 +1215,19 @@ ThreadError MeshForwarder::SendFragment(Message &aMessage, Mac::Frame &aFrame)
     if (mAddMeshHeader)
     {
         // Calculate the number of predicted hops.
-        hopsLeft = mMle.GetRouteCost(mMeshDest);
-        hopsLeft += mMle.GetLinkCost(mMle.GetRouterId(mMle.GetNextHop(mMeshDest)));
+        hopsLeft = mNetif.GetMle().GetRouteCost(mMeshDest);
+        hopsLeft += mNetif.GetMle().GetLinkCost(mNetif.GetMle().GetRouterId(mNetif.GetMle().GetNextHop(mMeshDest)));
 
         // The hopsLft field MUST be incremented by one if the device is not
         // an active Router.
-        if (!mMle.IsActiveRouter(mMeshSource))
+        if (!mNetif.GetMle().IsActiveRouter(mMeshSource))
         {
             hopsLeft += 1;
         }
 
         // The hopsLft field MUST be incremented by one if the destination RLOC16
         // is not that of an active Router.
-        if (!mMle.IsActiveRouter(mMeshDest))
+        if (!mNetif.GetMle().IsActiveRouter(mMeshDest))
         {
             hopsLeft += 1;
         }
@@ -1239,7 +1244,7 @@ ThreadError MeshForwarder::SendFragment(Message &aMessage, Mac::Frame &aFrame)
     // copy IPv6 Header
     if (aMessage.GetOffset() == 0)
     {
-        hcLength = mLowpan.Compress(aMessage, meshSource, meshDest, payload);
+        hcLength = mNetif.GetLowpan().Compress(aMessage, meshSource, meshDest, payload);
         assert(hcLength > 0);
         headerLength += static_cast<uint8_t>(hcLength);
 
@@ -1326,7 +1331,7 @@ ThreadError MeshForwarder::SendEmptyFrame(Mac::Frame &aFrame)
     uint8_t secCtl;
     Mac::Address macSource;
 
-    macSource.mShortAddress = mMac.GetShortAddress();
+    macSource.mShortAddress = mNetif.GetMac().GetShortAddress();
 
     if (macSource.mShortAddress != Mac::kShortAddrInvalid)
     {
@@ -1335,7 +1340,7 @@ ThreadError MeshForwarder::SendEmptyFrame(Mac::Frame &aFrame)
     else
     {
         macSource.mLength = sizeof(macSource.mExtAddress);
-        memcpy(&macSource.mExtAddress, mMac.GetExtAddress(), sizeof(macSource.mExtAddress));
+        memcpy(&macSource.mExtAddress, mNetif.GetMac().GetExtAddress(), sizeof(macSource.mExtAddress));
     }
 
     fcf = Mac::Frame::kFcfFrameData | Mac::Frame::kFcfFrameVersion2006;
@@ -1352,8 +1357,8 @@ ThreadError MeshForwarder::SendEmptyFrame(Mac::Frame &aFrame)
 
     aFrame.InitMacHeader(fcf, secCtl);
 
-    aFrame.SetDstPanId(mMac.GetPanId());
-    aFrame.SetSrcPanId(mMac.GetPanId());
+    aFrame.SetDstPanId(mNetif.GetMac().GetPanId());
+    aFrame.SetSrcPanId(mNetif.GetMac().GetPanId());
 
     if (mMacDest.mLength == 2)
     {
@@ -1401,7 +1406,7 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, ThreadError aError)
 
     aFrame.GetDstAddr(macDest);
 
-    if ((neighbor = mMle.GetNeighbor(macDest)) != NULL)
+    if ((neighbor = mNetif.GetMle().GetNeighbor(macDest)) != NULL)
     {
         switch (aError)
         {
@@ -1419,11 +1424,11 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, ThreadError aError)
         case kThreadError_NoAck:
             neighbor->mLinkFailures++;
 
-            if (mMle.IsActiveRouter(neighbor->mValid.mRloc16))
+            if (mNetif.GetMle().IsActiveRouter(neighbor->mValid.mRloc16))
             {
                 if (neighbor->mLinkFailures >= Mle::kFailedRouterTransmissions)
                 {
-                    mMle.RemoveNeighbor(*neighbor);
+                    mNetif.GetMle().RemoveNeighbor(*neighbor);
                 }
             }
 
@@ -1435,7 +1440,7 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, ThreadError aError)
         }
     }
 
-    if ((child = mMle.GetChild(macDest)) != NULL)
+    if ((child = mNetif.GetMle().GetChild(macDest)) != NULL)
     {
         child->mDataRequest = false;
 
@@ -1448,7 +1453,7 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, ThreadError aError)
         else
         {
             child->mFragmentOffset = 0;
-            mSendMessage->ClearChildMask(mMle.GetChildIndex(*child));
+            mSendMessage->ClearChildMask(mNetif.GetMle().GetChildIndex(*child));
 
             if ((child->mMode & Mle::ModeTlv::kModeRxOnWhenIdle) == 0)
             {
@@ -1488,12 +1493,12 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, ThreadError aError)
 
     if (mSendMessage->GetType() == Message::kTypeMacDataPoll)
     {
-        neighbor = mMle.GetParent();
+        neighbor = mNetif.GetMle().GetParent();
 
         if (neighbor->mState == Neighbor::kStateInvalid)
         {
             mPollTimer.Stop();
-            mMle.BecomeDetached();
+            mNetif.GetMle().BecomeDetached();
         }
     }
 
@@ -1537,9 +1542,9 @@ void MeshForwarder::HandleDiscoverTimer(void)
             mSendQueue.Dequeue(*mSendMessage);
             mSendMessage->Free();
             mSendMessage = NULL;
-            mMac.SetChannel(mRestoreChannel);
+            mNetif.GetMac().SetChannel(mRestoreChannel);
             mScanning = false;
-            mMle.HandleDiscoverComplete();
+            mNetif.GetMle().HandleDiscoverComplete();
             ExitNow();
         }
     }
@@ -1576,7 +1581,7 @@ void MeshForwarder::HandleReceivedFrame(Mac::Frame &aFrame)
     SuccessOrExit(error = aFrame.GetSrcAddr(macSource));
     SuccessOrExit(aFrame.GetDstAddr(macDest));
 
-    if ((child = mMle.GetChild(macSource)) != NULL)
+    if ((child = mNetif.GetMle().GetChild(macSource)) != NULL)
     {
         if (((child->mMode & Mle::ModeTlv::kModeRxOnWhenIdle) == 0) &&
             macSource.mLength == sizeof(otShortAddress))
@@ -1660,7 +1665,7 @@ void MeshForwarder::HandleMesh(uint8_t *aFrame, uint8_t aFrameLength, const Mac:
     meshDest.mLength = sizeof(meshDest.mShortAddress);
     meshDest.mShortAddress = meshHeader.GetDestination();
 
-    if (meshDest.mShortAddress == mMac.GetShortAddress())
+    if (meshDest.mShortAddress == mNetif.GetMac().GetShortAddress())
     {
         aFrame += meshHeader.GetHeaderLength();
         aFrameLength -= meshHeader.GetHeaderLength();
@@ -1680,7 +1685,7 @@ void MeshForwarder::HandleMesh(uint8_t *aFrame, uint8_t aFrameLength, const Mac:
     }
     else if (meshHeader.GetHopsLeft() > 0)
     {
-        mMle.ResolveRoutingLoops(aMacSource.mShortAddress, meshDest.mShortAddress);
+        mNetif.GetMle().ResolveRoutingLoops(aMacSource.mShortAddress, meshDest.mShortAddress);
 
         SuccessOrExit(error = CheckReachability(aFrame, aFrameLength, meshSource, meshDest));
 
@@ -1737,10 +1742,10 @@ ThreadError MeshForwarder::CheckReachability(uint8_t *aFrame, uint8_t aFrameLeng
     // only process IPv6 packets
     VerifyOrExit(aFrameLength >= 1 && Lowpan::Lowpan::IsLowpanHc(aFrame),);
 
-    VerifyOrExit(mLowpan.DecompressBaseHeader(ip6Header, aMeshSource, aMeshDest, aFrame, aFrameLength) > 0,
+    VerifyOrExit(mNetif.GetLowpan().DecompressBaseHeader(ip6Header, aMeshSource, aMeshDest, aFrame, aFrameLength) > 0,
                  error = kThreadError_Drop);
 
-    error = mMle.CheckReachability(aMeshSource.mShortAddress, aMeshDest.mShortAddress, ip6Header);
+    error = mNetif.GetMle().CheckReachability(aMeshSource.mShortAddress, aMeshDest.mShortAddress, ip6Header);
 
 exit:
     return error;
@@ -1766,7 +1771,8 @@ void MeshForwarder::HandleFragment(uint8_t *aFrame, uint8_t aFrameLength,
                      error = kThreadError_NoBufs);
         message->SetLinkSecurityEnabled(aMessageInfo.mLinkSecurity);
         message->SetPanId(aMessageInfo.mPanId);
-        headerLength = mLowpan.Decompress(*message, aMacSource, aMacDest, aFrame, aFrameLength, datagramLength);
+        headerLength = mNetif.GetLowpan().Decompress(*message, aMacSource, aMacDest, aFrame, aFrameLength,
+                                                     datagramLength);
         VerifyOrExit(headerLength > 0, error = kThreadError_Parse);
 
         aFrame += headerLength;
@@ -1883,7 +1889,7 @@ void MeshForwarder::HandleLowpanHC(uint8_t *aFrame, uint8_t aFrameLength,
     message->SetLinkSecurityEnabled(aMessageInfo.mLinkSecurity);
     message->SetPanId(aMessageInfo.mPanId);
 
-    headerLength = mLowpan.Decompress(*message, aMacSource, aMacDest, aFrame, aFrameLength, 0);
+    headerLength = mNetif.GetLowpan().Decompress(*message, aMacSource, aMacDest, aFrame, aFrameLength, 0);
     VerifyOrExit(headerLength > 0, error = kThreadError_Parse);
 
     aFrame += headerLength;
@@ -1928,9 +1934,9 @@ void MeshForwarder::HandleDataRequest(const Mac::Address &aMacSource, const Thre
     // Security Check: only process secure Data Poll frames.
     VerifyOrExit(aMessageInfo.mLinkSecurity, ;);
 
-    VerifyOrExit(mMle.GetDeviceState() != Mle::kDeviceStateDetached, ;);
+    VerifyOrExit(mNetif.GetMle().GetDeviceState() != Mle::kDeviceStateDetached, ;);
 
-    VerifyOrExit((child = mMle.GetChild(aMacSource)) != NULL, ;);
+    VerifyOrExit((child = mNetif.GetMle().GetChild(aMacSource)) != NULL, ;);
     child->mLastHeard = Timer::GetNow();
     child->mLinkFailures = 0;
 

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -299,11 +299,6 @@ private:
     bool mScanning;
 
     ThreadNetif &mNetif;
-    AddressResolver &mAddressResolver;
-    Lowpan::Lowpan &mLowpan;
-    Mac::Mac &mMac;
-    Mle::MleRouter &mMle;
-    NetworkData::Leader &mNetworkData;
 
     bool mSrcMatchEnabled;
 };

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -59,13 +59,6 @@ namespace Mle {
 
 Mle::Mle(ThreadNetif &aThreadNetif) :
     mNetif(aThreadNetif),
-    mAddressResolver(aThreadNetif.GetAddressResolver()),
-    mKeyManager(aThreadNetif.GetKeyManager()),
-    mMac(aThreadNetif.GetMac()),
-    mMesh(aThreadNetif.GetMeshForwarder()),
-    mMleRouter(aThreadNetif.GetMle()),
-    mNetworkData(aThreadNetif.GetNetworkDataLeader()),
-    mJoinerRouter(aThreadNetif.GetJoinerRouter()),
     mRetrieveNewNetworkData(false),
     mDeviceState(kDeviceStateDisabled),
     mDeviceMode(ModeTlv::kModeRxOnWhenIdle | ModeTlv::kModeSecureDataRequest | ModeTlv::kModeFFD |
@@ -111,7 +104,7 @@ Mle::Mle(ThreadNetif &aThreadNetif) :
 
     // link-local 64
     mLinkLocal64.GetAddress().mFields.m16[0] = HostSwap16(0xfe80);
-    mLinkLocal64.GetAddress().SetIid(*mMac.GetExtAddress());
+    mLinkLocal64.GetAddress().SetIid(*mNetif.GetMac().GetExtAddress());
     mLinkLocal64.mPrefixLength = 64;
     mLinkLocal64.mPreferred = true;
     mLinkLocal64.mValid = true;
@@ -126,7 +119,7 @@ Mle::Mle(ThreadNetif &aThreadNetif) :
 
     // initialize Mesh Local Prefix
     meshLocalPrefix[0] = 0xfd;
-    memcpy(meshLocalPrefix + 1, mMac.GetExtendedPanId(), 5);
+    memcpy(meshLocalPrefix + 1, mNetif.GetMac().GetExtendedPanId(), 5);
     meshLocalPrefix[6] = 0x00;
     meshLocalPrefix[7] = 0x00;
 
@@ -214,7 +207,7 @@ ThreadError Mle::Start(bool aEnableReattach)
     mNetif.SetStateChangedFlags(OT_NET_ROLE);
     SetStateDetached();
 
-    mKeyManager.Start();
+    mNetif.GetKeyManager().Start();
 
     if (aEnableReattach)
     {
@@ -227,7 +220,7 @@ ThreadError Mle::Start(bool aEnableReattach)
     }
     else if (IsActiveRouter(GetRloc16()))
     {
-        if (mMleRouter.BecomeRouter(ThreadStatusTlv::kTooFewRouters) != kThreadError_None)
+        if (mNetif.GetMle().BecomeRouter(ThreadStatusTlv::kTooFewRouters) != kThreadError_None)
         {
             BecomeChild(kMleAttachAnyPartition);
         }
@@ -247,7 +240,7 @@ exit:
 ThreadError Mle::Stop(bool aClearNetworkDatasets)
 {
     otLogFuncEntry();
-    mKeyManager.Stop();
+    mNetif.GetKeyManager().Stop();
     SetStateDetached();
     mNetif.RemoveUnicastAddress(mMeshLocal16);
 
@@ -279,10 +272,10 @@ ThreadError Mle::Restore(void)
 
     mDeviceMode = networkInfo.mDeviceMode;
     SetRloc16(networkInfo.mRloc16);
-    mKeyManager.SetCurrentKeySequence(networkInfo.mKeySequence);
-    mKeyManager.SetMleFrameCounter(networkInfo.mMleFrameCounter);
-    mKeyManager.SetMacFrameCounter(networkInfo.mMacFrameCounter);
-    mMac.SetExtAddress(networkInfo.mExtAddress);
+    mNetif.GetKeyManager().SetCurrentKeySequence(networkInfo.mKeySequence);
+    mNetif.GetKeyManager().SetMleFrameCounter(networkInfo.mMleFrameCounter);
+    mNetif.GetKeyManager().SetMacFrameCounter(networkInfo.mMacFrameCounter);
+    mNetif.GetMac().SetExtAddress(networkInfo.mExtAddress);
     UpdateLinkLocalAddress();
 
     if (networkInfo.mDeviceState == kDeviceStateChild)
@@ -294,9 +287,9 @@ ThreadError Mle::Restore(void)
     }
     else if (networkInfo.mDeviceState == kDeviceStateRouter || networkInfo.mDeviceState == kDeviceStateLeader)
     {
-        mMleRouter.SetRouterId(GetRouterId(GetRloc16()));
-        mMleRouter.SetPreviousPartitionId(networkInfo.mPreviousPartitionId);
-        mMleRouter.RestoreChildren();
+        mNetif.GetMle().SetRouterId(GetRouterId(GetRloc16()));
+        mNetif.GetMle().SetPreviousPartitionId(networkInfo.mPreviousPartitionId);
+        mNetif.GetMle().RestoreChildren();
     }
 
 exit:
@@ -321,11 +314,13 @@ ThreadError Mle::Store(void)
     networkInfo.mDeviceMode = mDeviceMode;
     networkInfo.mDeviceState = mDeviceState;
     networkInfo.mRloc16 = GetRloc16();
-    networkInfo.mKeySequence = mKeyManager.GetCurrentKeySequence();
-    networkInfo.mMleFrameCounter = mKeyManager.GetMleFrameCounter() + OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD;
-    networkInfo.mMacFrameCounter = mKeyManager.GetMacFrameCounter() + OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD;
+    networkInfo.mKeySequence = mNetif.GetKeyManager().GetCurrentKeySequence();
+    networkInfo.mMleFrameCounter = mNetif.GetKeyManager().GetMleFrameCounter() +
+                                   OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD;
+    networkInfo.mMacFrameCounter = mNetif.GetKeyManager().GetMacFrameCounter() +
+                                   OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD;
     networkInfo.mPreviousPartitionId = mLeaderData.GetPartitionId();
-    memcpy(networkInfo.mExtAddress.m8, mMac.GetExtAddress(), sizeof(networkInfo.mExtAddress));
+    memcpy(networkInfo.mExtAddress.m8, mNetif.GetMac().GetExtAddress(), sizeof(networkInfo.mExtAddress));
 
     if (mDeviceState == kDeviceStateChild)
     {
@@ -336,8 +331,8 @@ ThreadError Mle::Store(void)
     SuccessOrExit(error = otPlatSettingsSet(mNetif.GetInstance(), kKeyNetworkInfo,
                                             reinterpret_cast<uint8_t *>(&networkInfo), sizeof(networkInfo)));
 
-    mKeyManager.SetStoredMleFrameCounter(networkInfo.mMleFrameCounter);
-    mKeyManager.SetStoredMacFrameCounter(networkInfo.mMacFrameCounter);
+    mNetif.GetKeyManager().SetStoredMleFrameCounter(networkInfo.mMleFrameCounter);
+    mNetif.GetKeyManager().SetStoredMacFrameCounter(networkInfo.mMacFrameCounter);
 
     otLogDebgMle("Store Network Information");
 
@@ -359,7 +354,7 @@ ThreadError Mle::Discover(uint32_t aScanChannels, uint16_t aScanDuration, uint16
 
     mDiscoverHandler = aCallback;
     mDiscoverContext = aContext;
-    mMesh.SetDiscoverParameters(aScanChannels, aScanDuration);
+    mNetif.GetMeshForwarder().SetDiscoverParameters(aScanChannels, aScanDuration);
 
     VerifyOrExit((message = NewMleMessage()) != NULL, ;);
     message->SetSubType(Message::kSubTypeMleDiscoverRequest);
@@ -461,8 +456,8 @@ ThreadError Mle::BecomeChild(otMleAttachFilter aFilter)
     if (aFilter == kMleAttachAnyPartition)
     {
         mParent.mState = Neighbor::kStateInvalid;
-        mLastPartitionId = mMleRouter.GetPreviousPartitionId();
-        mLastPartitionRouterIdSequence = mMleRouter.GetRouterIdSequence();
+        mLastPartitionId = mNetif.GetMle().GetPreviousPartitionId();
+        mLastPartitionRouterIdSequence = mNetif.GetMle().GetRouterIdSequence();
     }
 
     mParentRequestTimer.Start(kParentRequestRouterTimeout);
@@ -496,12 +491,12 @@ ThreadError Mle::SetStateDetached(void)
         mNetif.RemoveUnicastAddress(mLeaderAloc);
     }
 
-    mAddressResolver.Clear();
+    mNetif.GetAddressResolver().Clear();
     mDeviceState = kDeviceStateDetached;
     mParentRequestState = kParentIdle;
     mParentRequestTimer.Stop();
-    mMesh.SetRxOnWhenIdle(true);
-    mMleRouter.HandleDetachStart();
+    mNetif.GetMeshForwarder().SetRxOnWhenIdle(true);
+    mNetif.GetMle().HandleDetachStart();
     mNetif.GetIp6().SetForwardingEnabled(false);
     mNetif.GetIp6().mMpl.SetTimerExpirations(0);
 
@@ -532,7 +527,7 @@ ThreadError Mle::SetStateChild(uint16_t aRloc16)
 
     if ((mDeviceMode & ModeTlv::kModeFFD) != 0)
     {
-        mMleRouter.HandleChildStart(mParentRequestMode);
+        mNetif.GetMle().HandleChildStart(mParentRequestMode);
     }
 
     mNetif.GetNetworkDataLocal().ClearResubmitDelayTimer();
@@ -619,7 +614,7 @@ exit:
 ThreadError Mle::UpdateLinkLocalAddress(void)
 {
     mNetif.RemoveUnicastAddress(mLinkLocal64);
-    mLinkLocal64.GetAddress().SetIid(*mMac.GetExtAddress());
+    mLinkLocal64.GetAddress().SetIid(*mNetif.GetMac().GetExtAddress());
     mNetif.AddUnicastAddress(mLinkLocal64);
 
     mNetif.SetStateChangedFlags(OT_IP6_LL_ADDR_CHANGED);
@@ -686,7 +681,7 @@ const Ip6::Address *Mle::GetRealmLocalAllThreadNodesAddress(void) const
 
 uint16_t Mle::GetRloc16(void) const
 {
-    return mMac.GetShortAddress();
+    return mNetif.GetMac().GetShortAddress();
 }
 
 ThreadError Mle::SetRloc16(uint16_t aRloc16)
@@ -700,7 +695,7 @@ ThreadError Mle::SetRloc16(uint16_t aRloc16)
         mNetif.AddUnicastAddress(mMeshLocal16);
     }
 
-    mMac.SetShortAddress(aRloc16);
+    mNetif.GetMac().SetShortAddress(aRloc16);
     mNetif.GetIp6().mMpl.SetSeedId(aRloc16);
 
     return kThreadError_None;
@@ -781,8 +776,8 @@ exit:
 
 const LeaderDataTlv &Mle::GetLeaderDataTlv(void)
 {
-    mLeaderData.SetDataVersion(mNetworkData.GetVersion());
-    mLeaderData.SetStableDataVersion(mNetworkData.GetStableVersion());
+    mLeaderData.SetDataVersion(mNetif.GetNetworkDataLeader().GetVersion());
+    mLeaderData.SetStableDataVersion(mNetif.GetNetworkDataLeader().GetStableVersion());
     return mLeaderData;
 }
 
@@ -988,7 +983,7 @@ ThreadError Mle::AppendLinkFrameCounter(Message &aMessage)
     LinkFrameCounterTlv tlv;
 
     tlv.Init();
-    tlv.SetFrameCounter(mKeyManager.GetMacFrameCounter());
+    tlv.SetFrameCounter(mNetif.GetKeyManager().GetMacFrameCounter());
 
     return aMessage.Append(&tlv, sizeof(tlv));
 }
@@ -998,7 +993,7 @@ ThreadError Mle::AppendMleFrameCounter(Message &aMessage)
     MleFrameCounterTlv tlv;
 
     tlv.Init();
-    tlv.SetFrameCounter(mKeyManager.GetMleFrameCounter());
+    tlv.SetFrameCounter(mNetif.GetKeyManager().GetMleFrameCounter());
 
     return aMessage.Append(&tlv, sizeof(tlv));
 }
@@ -1016,8 +1011,8 @@ ThreadError Mle::AppendAddress16(Message &aMessage, uint16_t aRloc16)
 ThreadError Mle::AppendLeaderData(Message &aMessage)
 {
     mLeaderData.Init();
-    mLeaderData.SetDataVersion(mNetworkData.GetVersion());
-    mLeaderData.SetStableDataVersion(mNetworkData.GetStableVersion());
+    mLeaderData.SetDataVersion(mNetif.GetNetworkDataLeader().GetVersion());
+    mLeaderData.SetStableDataVersion(mNetif.GetNetworkDataLeader().GetStableVersion());
 
     return aMessage.Append(&mLeaderData, sizeof(mLeaderData));
 }
@@ -1025,7 +1020,7 @@ ThreadError Mle::AppendLeaderData(Message &aMessage)
 void Mle::FillNetworkDataTlv(NetworkDataTlv &aTlv, bool aStableOnly)
 {
     uint8_t length;
-    mNetworkData.GetNetworkData(aStableOnly, aTlv.GetNetworkData(), length);
+    mNetif.GetNetworkDataLeader().GetNetworkData(aStableOnly, aTlv.GetNetworkData(), length);
     aTlv.SetLength(length);
 }
 
@@ -1108,7 +1103,7 @@ ThreadError Mle::AppendAddressRegistration(Message &aMessage)
             continue;
         }
 
-        if (mNetworkData.GetContext(addr->GetAddress(), context) == kThreadError_None)
+        if (mNetif.GetNetworkDataLeader().GetContext(addr->GetAddress(), context) == kThreadError_None)
         {
             // compressed entry
             entry.SetContextId(context.mContextId);
@@ -1207,7 +1202,7 @@ void Mle::HandleNetifStateChanged(uint32_t aFlags)
     {
         if (mDeviceMode & ModeTlv::kModeFFD)
         {
-            mMleRouter.HandleNetworkDataUpdateRouter();
+            mNetif.GetMle().HandleNetworkDataUpdateRouter();
         }
         else if ((aFlags & OT_NET_ROLE) == 0)
         {
@@ -1318,8 +1313,8 @@ void Mle::HandleParentRequestTimer(void)
                 case kMleAttachAnyPartition:
                     if (mPreviousPanId != Mac::kPanIdBroadcast)
                     {
-                        mMac.SetChannel(mPreviousChannel);
-                        mMac.SetPanId(mPreviousPanId);
+                        mNetif.GetMac().SetChannel(mPreviousChannel);
+                        mNetif.GetMac().SetPanId(mPreviousPanId);
                         mPreviousPanId = Mac::kPanIdBroadcast;
                         BecomeDetached();
                     }
@@ -1328,7 +1323,7 @@ void Mle::HandleParentRequestTimer(void)
                         SendOrphanAnnounce();
                         BecomeDetached();
                     }
-                    else if (mMleRouter.BecomeLeader() != kThreadError_None)
+                    else if (mNetif.GetMle().BecomeLeader() != kThreadError_None)
                     {
                         mParentRequestState = kParentIdle;
                         BecomeDetached();
@@ -1469,8 +1464,8 @@ ThreadError Mle::SendChildIdRequest(void)
 
     if ((mDeviceMode & ModeTlv::kModeRxOnWhenIdle) == 0)
     {
-        mMesh.SetPollPeriod(kAttachDataPollPeriod);
-        mMesh.SetRxOnWhenIdle(false);
+        mNetif.GetMeshForwarder().SetPollPeriod(kAttachDataPollPeriod);
+        mNetif.GetMeshForwarder().SetRxOnWhenIdle(false);
     }
 
 exit:
@@ -1576,8 +1571,8 @@ ThreadError Mle::SendChildUpdateRequest(void)
 
     if ((mDeviceMode & ModeTlv::kModeRxOnWhenIdle) == 0)
     {
-        mMesh.SetPollPeriod(kAttachDataPollPeriod);
-        mMesh.SetRxOnWhenIdle(false);
+        mNetif.GetMeshForwarder().SetPollPeriod(kAttachDataPollPeriod);
+        mNetif.GetMeshForwarder().SetRxOnWhenIdle(false);
     }
 
 exit:
@@ -1665,7 +1660,7 @@ ThreadError Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce)
 
     channel.Init();
     channel.SetChannelPage(0);
-    channel.SetChannel(mMac.GetChannel());
+    channel.SetChannel(mNetif.GetMac().GetChannel());
     SuccessOrExit(error = message->Append(&channel, sizeof(channel)));
 
     if (aOrphanAnnounce)
@@ -1683,7 +1678,7 @@ ThreadError Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce)
     }
 
     panid.Init();
-    panid.SetPanId(mMac.GetPanId());
+    panid.SetPanId(mNetif.GetMac().GetPanId());
     SuccessOrExit(error = message->Append(&panid, sizeof(panid)));
 
     memset(&destination, 0, sizeof(destination));
@@ -1760,16 +1755,19 @@ ThreadError Mle::SendMessage(Message &aMessage, const Ip6::Address &aDestination
 
     if (header.GetSecuritySuite() == Header::k154Security)
     {
-        header.SetFrameCounter(mKeyManager.GetMleFrameCounter());
+        header.SetFrameCounter(mNetif.GetKeyManager().GetMleFrameCounter());
 
-        keySequence = mKeyManager.GetCurrentKeySequence();
+        keySequence = mNetif.GetKeyManager().GetCurrentKeySequence();
         header.SetKeyId(keySequence);
 
         aMessage.Write(0, header.GetLength(), &header);
 
-        GenerateNonce(*mMac.GetExtAddress(), mKeyManager.GetMleFrameCounter(), Mac::Frame::kSecEncMic32, nonce);
+        GenerateNonce(*mNetif.GetMac().GetExtAddress(),
+                      mNetif.GetKeyManager().GetMleFrameCounter(),
+                      Mac::Frame::kSecEncMic32,
+                      nonce);
 
-        aesCcm.SetKey(mKeyManager.GetCurrentMleKey(), 16);
+        aesCcm.SetKey(mNetif.GetKeyManager().GetCurrentMleKey(), 16);
         aesCcm.Init(16 + 16 + header.GetHeaderLength(), aMessage.GetLength() - (header.GetLength() - 1),
                     sizeof(tag), nonce, sizeof(nonce));
 
@@ -1791,7 +1789,7 @@ ThreadError Mle::SendMessage(Message &aMessage, const Ip6::Address &aDestination
         aesCcm.Finalize(tag, &tagLength);
         SuccessOrExit(error = aMessage.Append(tag, tagLength));
 
-        mKeyManager.IncrementMleFrameCounter();
+        mNetif.GetKeyManager().IncrementMleFrameCounter();
     }
 
     messageInfo.SetPeerAddr(aDestination);
@@ -1843,7 +1841,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
         switch (header.GetCommand())
         {
         case Header::kCommandDiscoveryRequest:
-            mMleRouter.HandleDiscoveryRequest(aMessage, aMessageInfo);
+            mNetif.GetMle().HandleDiscoveryRequest(aMessage, aMessageInfo);
             break;
 
         case Header::kCommandDiscoveryResponse:
@@ -1861,13 +1859,13 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
 
     keySequence = header.GetKeyId();
 
-    if (keySequence == mKeyManager.GetCurrentKeySequence())
+    if (keySequence == mNetif.GetKeyManager().GetCurrentKeySequence())
     {
-        mleKey = mKeyManager.GetCurrentMleKey();
+        mleKey = mNetif.GetKeyManager().GetCurrentMleKey();
     }
     else
     {
-        mleKey = mKeyManager.GetTemporaryMleKey(keySequence);
+        mleKey = mNetif.GetKeyManager().GetTemporaryMleKey(keySequence);
     }
 
     aMessage.MoveOffset(header.GetLength() - 1);
@@ -1902,9 +1900,9 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     aesCcm.Finalize(tag, &tagLength);
     VerifyOrExit(messageTagLength == tagLength && memcmp(messageTag, tag, tagLength) == 0, ;);
 
-    if (keySequence > mKeyManager.GetCurrentKeySequence())
+    if (keySequence > mNetif.GetKeyManager().GetCurrentKeySequence())
     {
-        mKeyManager.SetCurrentKeySequence(keySequence);
+        mNetif.GetKeyManager().SetCurrentKeySequence(keySequence);
     }
 
     aMessage.SetOffset(mleOffset);
@@ -1927,7 +1925,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
         }
         else
         {
-            neighbor = mMleRouter.GetNeighbor(macAddr);
+            neighbor = mNetif.GetMle().GetNeighbor(macAddr);
         }
 
         break;
@@ -1982,15 +1980,15 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     switch (command)
     {
     case Header::kCommandLinkRequest:
-        mMleRouter.HandleLinkRequest(aMessage, aMessageInfo);
+        mNetif.GetMle().HandleLinkRequest(aMessage, aMessageInfo);
         break;
 
     case Header::kCommandLinkAccept:
-        mMleRouter.HandleLinkAccept(aMessage, aMessageInfo, keySequence);
+        mNetif.GetMle().HandleLinkAccept(aMessage, aMessageInfo, keySequence);
         break;
 
     case Header::kCommandLinkAcceptAndRequest:
-        mMleRouter.HandleLinkAcceptAndRequest(aMessage, aMessageInfo, keySequence);
+        mNetif.GetMle().HandleLinkAcceptAndRequest(aMessage, aMessageInfo, keySequence);
         break;
 
     case Header::kCommandAdvertisement:
@@ -1998,7 +1996,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
         break;
 
     case Header::kCommandDataRequest:
-        mMleRouter.HandleDataRequest(aMessage, aMessageInfo);
+        mNetif.GetMle().HandleDataRequest(aMessage, aMessageInfo);
         break;
 
     case Header::kCommandDataResponse:
@@ -2006,7 +2004,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
         break;
 
     case Header::kCommandParentRequest:
-        mMleRouter.HandleParentRequest(aMessage, aMessageInfo);
+        mNetif.GetMle().HandleParentRequest(aMessage, aMessageInfo);
         break;
 
     case Header::kCommandParentResponse:
@@ -2014,7 +2012,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
         break;
 
     case Header::kCommandChildIdRequest:
-        mMleRouter.HandleChildIdRequest(aMessage, aMessageInfo, keySequence);
+        mNetif.GetMle().HandleChildIdRequest(aMessage, aMessageInfo, keySequence);
         break;
 
     case Header::kCommandChildIdResponse:
@@ -2024,7 +2022,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     case Header::kCommandChildUpdateRequest:
         if (mDeviceState == kDeviceStateLeader || mDeviceState == kDeviceStateRouter)
         {
-            mMleRouter.HandleChildUpdateRequest(aMessage, aMessageInfo);
+            mNetif.GetMle().HandleChildUpdateRequest(aMessage, aMessageInfo);
         }
         else
         {
@@ -2036,7 +2034,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     case Header::kCommandChildUpdateResponse:
         if (mDeviceState == kDeviceStateLeader || mDeviceState == kDeviceStateRouter)
         {
-            mMleRouter.HandleChildUpdateResponse(aMessage, aMessageInfo, keySequence);
+            mNetif.GetMle().HandleChildUpdateResponse(aMessage, aMessageInfo, keySequence);
         }
         else
         {
@@ -2077,7 +2075,7 @@ ThreadError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::Message
 
     if (mDeviceState != kDeviceStateDetached)
     {
-        SuccessOrExit(error = mMleRouter.HandleAdvertisement(aMessage, aMessageInfo));
+        SuccessOrExit(error = mNetif.GetMle().HandleAdvertisement(aMessage, aMessageInfo));
     }
 
     macAddr.Set(aMessageInfo.GetPeerAddr());
@@ -2107,7 +2105,7 @@ ThreadError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::Message
                 route.IsValid())
             {
                 // Overwrite Route Data
-                mMleRouter.ProcessRouteTlv(route);
+                mNetif.GetMle().ProcessRouteTlv(route);
             }
 
             mRetrieveNewNetworkData = true;
@@ -2119,7 +2117,7 @@ ThreadError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::Message
 
     case kDeviceStateRouter:
     case kDeviceStateLeader:
-        if ((neighbor = mMleRouter.GetNeighbor(macAddr)) != NULL &&
+        if ((neighbor = mNetif.GetMle().GetNeighbor(macAddr)) != NULL &&
             neighbor->mState == Neighbor::kStateValid)
         {
             isNeighbor = true;
@@ -2131,7 +2129,7 @@ ThreadError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::Message
     if (isNeighbor)
     {
         if (mRetrieveNewNetworkData ||
-            (static_cast<int8_t>(leaderData.GetDataVersion() - mNetworkData.GetVersion()) > 0))
+            (static_cast<int8_t>(leaderData.GetDataVersion() - mNetif.GetNetworkDataLeader().GetVersion()) > 0))
         {
             SendDataRequest(aMessageInfo.GetPeerAddr(), tlvs, sizeof(tlvs));
         }
@@ -2179,7 +2177,8 @@ ThreadError Mle::HandleDataResponse(const Message &aMessage, const Ip6::MessageI
     }
     else if (!mRetrieveNewNetworkData)
     {
-        VerifyOrExit(static_cast<int8_t>(leaderData.GetDataVersion() - mNetworkData.GetVersion()) > 0, ;);
+        int8_t diff = static_cast<int8_t>(leaderData.GetDataVersion() - mNetif.GetNetworkDataLeader().GetVersion());
+        VerifyOrExit(diff > 0, ;);
     }
 
     // Network Data
@@ -2229,9 +2228,9 @@ ThreadError Mle::HandleDataResponse(const Message &aMessage, const Ip6::MessageI
     }
 
     // Network Data
-    mNetworkData.SetNetworkData(leaderData.GetDataVersion(), leaderData.GetStableDataVersion(),
-                                (mDeviceMode & ModeTlv::kModeFullNetworkData) == 0,
-                                networkData.GetNetworkData(), networkData.GetLength());
+    mNetif.GetNetworkDataLeader().SetNetworkData(leaderData.GetDataVersion(), leaderData.GetStableDataVersion(),
+                                                 (mDeviceMode & ModeTlv::kModeFullNetworkData) == 0,
+                                                 networkData.GetNetworkData(), networkData.GetLength());
 
     // Active Dataset
     if (activeTimestamp.GetLength() > 0)
@@ -2365,7 +2364,7 @@ ThreadError Mle::HandleParentResponse(const Message &aMessage, const Ip6::Messag
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLinkMargin, sizeof(linkMarginTlv), linkMarginTlv));
     VerifyOrExit(linkMarginTlv.IsValid(), error = kThreadError_Parse);
 
-    linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(mMac.GetNoiseFloor(), threadMessageInfo->mRss);
+    linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(mNetif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
 
     if (linkMargin > linkMarginTlv.GetLinkMargin())
     {
@@ -2382,23 +2381,24 @@ ThreadError Mle::HandleParentResponse(const Message &aMessage, const Ip6::Messag
 
     if ((mDeviceMode & ModeTlv::kModeFFD) && (mDeviceState != kDeviceStateDetached))
     {
+        diff = static_cast<int8_t>(connectivity.GetIdSequence() - mNetif.GetMle().GetRouterIdSequence());
+
         switch (mParentRequestMode)
         {
         case kMleAttachAnyPartition:
-            VerifyOrExit(leaderData.GetPartitionId() != mLeaderData.GetPartitionId() ||
-                         static_cast<int8_t>(connectivity.GetIdSequence() - mMleRouter.GetRouterIdSequence()) > 0,);
+            VerifyOrExit(leaderData.GetPartitionId() != mLeaderData.GetPartitionId() || diff > 0,);
             break;
 
         case kMleAttachSamePartition:
             VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId(), ;);
-            diff = static_cast<int8_t>(connectivity.GetIdSequence() - mMleRouter.GetRouterIdSequence());
-            VerifyOrExit(diff > 0 || (diff == 0 && mMleRouter.GetLeaderAge() < mMleRouter.GetNetworkIdTimeout()), ;);
+            VerifyOrExit(diff > 0 ||
+                         (diff == 0 && mNetif.GetMle().GetLeaderAge() < mNetif.GetMle().GetNetworkIdTimeout()), ;);
             break;
 
         case kMleAttachBetterPartition:
             VerifyOrExit(leaderData.GetPartitionId() != mLeaderData.GetPartitionId(), ;);
-            VerifyOrExit(mMleRouter.ComparePartitions(connectivity.GetActiveRouters() <= 1, leaderData,
-                                                      mMleRouter.IsSingleton(), mLeaderData) > 0, ;);
+            VerifyOrExit(mNetif.GetMle().ComparePartitions(connectivity.GetActiveRouters() <= 1, leaderData,
+                                                           mNetif.GetMle().IsSingleton(), mLeaderData) > 0, ;);
             break;
         }
     }
@@ -2410,8 +2410,8 @@ ThreadError Mle::HandleParentResponse(const Message &aMessage, const Ip6::Messag
 
         if (mDeviceMode & ModeTlv::kModeFFD)
         {
-            compare = mMleRouter.ComparePartitions(connectivity.GetActiveRouters() <= 1, leaderData,
-                                                   mParentIsSingleton, mParentLeaderData);
+            compare = mNetif.GetMle().ComparePartitions(connectivity.GetActiveRouters() <= 1, leaderData,
+                                                        mParentIsSingleton, mParentLeaderData);
         }
 
         // only consider partitions that are the same or better
@@ -2447,7 +2447,7 @@ ThreadError Mle::HandleParentResponse(const Message &aMessage, const Ip6::Messag
     mParent.mValid.mMleFrameCounter = mleFrameCounter.GetFrameCounter();
     mParent.mMode = ModeTlv::kModeFFD | ModeTlv::kModeRxOnWhenIdle | ModeTlv::kModeFullNetworkData;
     mParent.mLinkInfo.Clear();
-    mParent.mLinkInfo.AddRss(mMac.GetNoiseFloor(), threadMessageInfo->mRss);
+    mParent.mLinkInfo.AddRss(mNetif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
     mParent.mLinkFailures = 0;
     mParent.mState = Neighbor::kStateValid;
     mParent.mKeySequence = aKeySequence;
@@ -2559,19 +2559,19 @@ ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::Messa
 
     if ((mDeviceMode & ModeTlv::kModeRxOnWhenIdle) == 0)
     {
-        mMesh.SetPollPeriod(Timer::SecToMsec(mTimeout / kMaxChildKeepAliveAttempts));
-        mMesh.SetRxOnWhenIdle(false);
+        mNetif.GetMeshForwarder().SetPollPeriod(Timer::SecToMsec(mTimeout / kMaxChildKeepAliveAttempts));
+        mNetif.GetMeshForwarder().SetRxOnWhenIdle(false);
     }
     else
     {
-        mMesh.SetRxOnWhenIdle(true);
+        mNetif.GetMeshForwarder().SetRxOnWhenIdle(true);
     }
 
     // Route
     if ((Tlv::GetTlv(aMessage, Tlv::kRoute, sizeof(route), route) == kThreadError_None) &&
         (mDeviceMode & ModeTlv::kModeFFD))
     {
-        SuccessOrExit(error = mMleRouter.ProcessRouteTlv(route));
+        SuccessOrExit(error = mNetif.GetMle().ProcessRouteTlv(route));
 
         for (uint8_t i = 0; i <= kMaxRouterId; i++)
         {
@@ -2581,7 +2581,7 @@ ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::Messa
             }
         }
 
-        if (mRouterSelectionJitterTimeout == 0 && numRouters < mMleRouter.GetRouterUpgradeThreshold())
+        if (mRouterSelectionJitterTimeout == 0 && numRouters < mNetif.GetMle().GetRouterUpgradeThreshold())
         {
             mRouterSelectionJitterTimeout = (otPlatRandomGet() % mRouterSelectionJitter) + 1;
         }
@@ -2590,9 +2590,9 @@ ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::Messa
     mParent.mValid.mRloc16 = sourceAddress.GetRloc16();
     SuccessOrExit(error = SetStateChild(shortAddress.GetRloc16()));
 
-    mNetworkData.SetNetworkData(leaderData.GetDataVersion(), leaderData.GetStableDataVersion(),
-                                (mDeviceMode & ModeTlv::kModeFullNetworkData) == 0,
-                                networkData.GetNetworkData(), networkData.GetLength());
+    mNetif.GetNetworkDataLeader().SetNetworkData(leaderData.GetDataVersion(), leaderData.GetStableDataVersion(),
+                                                 (mDeviceMode & ModeTlv::kModeFullNetworkData) == 0,
+                                                 networkData.GetNetworkData(), networkData.GetLength());
 
     mNetif.GetActiveDataset().ApplyConfiguration();
 
@@ -2634,9 +2634,10 @@ ThreadError Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::Me
         VerifyOrExit(leaderData.IsValid(), error = kThreadError_Parse);
         SetLeaderData(leaderData.GetPartitionId(), leaderData.GetWeighting(), leaderData.GetLeaderRouterId());
 
-        if ((mDeviceMode & ModeTlv::kModeFullNetworkData && leaderData.GetDataVersion() != mNetworkData.GetVersion()) ||
+        if ((mDeviceMode & ModeTlv::kModeFullNetworkData &&
+             leaderData.GetDataVersion() != mNetif.GetNetworkDataLeader().GetVersion()) ||
             ((mDeviceMode & ModeTlv::kModeFullNetworkData) == 0 &&
-             leaderData.GetStableDataVersion() != mNetworkData.GetStableVersion()))
+             leaderData.GetStableDataVersion() != mNetif.GetNetworkDataLeader().GetStableVersion()))
         {
             mRetrieveNewNetworkData = true;
         }
@@ -2645,9 +2646,11 @@ ThreadError Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::Me
         if (Tlv::GetTlv(aMessage, Tlv::kNetworkData, sizeof(networkData), networkData) == kThreadError_None)
         {
             VerifyOrExit(networkData.IsValid(), error = kThreadError_Parse);
-            mNetworkData.SetNetworkData(leaderData.GetDataVersion(), leaderData.GetStableDataVersion(),
-                                        (mDeviceMode & ModeTlv::kModeFullNetworkData) == 0,
-                                        networkData.GetNetworkData(), networkData.GetLength());
+            mNetif.GetNetworkDataLeader().SetNetworkData(leaderData.GetDataVersion(),
+                                                         leaderData.GetStableDataVersion(),
+                                                         (mDeviceMode & ModeTlv::kModeFullNetworkData) == 0,
+                                                         networkData.GetNetworkData(),
+                                                         networkData.GetLength());
         }
     }
 
@@ -2746,25 +2749,27 @@ ThreadError Mle::HandleChildUpdateResponse(const Message &aMessage, const Ip6::M
         if (Tlv::GetTlv(aMessage, Tlv::kNetworkData, sizeof(networkData), networkData) == kThreadError_None)
         {
             VerifyOrExit(networkData.IsValid(), error = kThreadError_Parse);
-            mNetworkData.SetNetworkData(leaderData.GetDataVersion(), leaderData.GetStableDataVersion(),
-                                        (mDeviceMode & ModeTlv::kModeFullNetworkData) == 0,
-                                        networkData.GetNetworkData(), networkData.GetLength());
+            mNetif.GetNetworkDataLeader().SetNetworkData(leaderData.GetDataVersion(),
+                                                         leaderData.GetStableDataVersion(),
+                                                         (mDeviceMode & ModeTlv::kModeFullNetworkData) == 0,
+                                                         networkData.GetNetworkData(),
+                                                         networkData.GetLength());
         }
 
         if ((mDeviceMode & ModeTlv::kModeRxOnWhenIdle) == 0)
         {
-            mMesh.SetPollPeriod(Timer::SecToMsec(mTimeout / kMaxChildKeepAliveAttempts));
-            mMesh.SetRxOnWhenIdle(false);
+            mNetif.GetMeshForwarder().SetPollPeriod(Timer::SecToMsec(mTimeout / kMaxChildKeepAliveAttempts));
+            mNetif.GetMeshForwarder().SetRxOnWhenIdle(false);
         }
         else
         {
-            mMesh.SetRxOnWhenIdle(true);
+            mNetif.GetMeshForwarder().SetRxOnWhenIdle(true);
         }
 
         if (mDeviceMode & ModeTlv::kModeFullNetworkData)
         {
             // full network data
-            if (leaderData.GetDataVersion() != mNetworkData.GetVersion())
+            if (leaderData.GetDataVersion() != mNetif.GetNetworkDataLeader().GetVersion())
             {
                 SendDataRequest(aMessageInfo.GetPeerAddr(), tlvs, sizeof(tlvs));
             }
@@ -2772,7 +2777,7 @@ ThreadError Mle::HandleChildUpdateResponse(const Message &aMessage, const Ip6::M
         else
         {
             // stable network data
-            if (leaderData.GetStableDataVersion() != mNetworkData.GetStableVersion())
+            if (leaderData.GetStableDataVersion() != mNetif.GetNetworkDataLeader().GetStableVersion())
             {
                 SendDataRequest(aMessageInfo.GetPeerAddr(), tlvs, sizeof(tlvs));
             }
@@ -2824,10 +2829,10 @@ ThreadError Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo 
         }
 
         Stop(false);
-        mPreviousChannel = mMac.GetChannel();
-        mPreviousPanId = mMac.GetPanId();
-        mMac.SetChannel(static_cast<uint8_t>(channel.GetChannel()));
-        mMac.SetPanId(panid.GetPanId());
+        mPreviousChannel = mNetif.GetMac().GetChannel();
+        mPreviousPanId = mNetif.GetMac().GetPanId();
+        mNetif.GetMac().SetChannel(static_cast<uint8_t>(channel.GetChannel()));
+        mNetif.GetMac().SetPanId(panid.GetPanId());
         Start(false);
     }
     else

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1164,13 +1164,6 @@ protected:
     void SetLeaderData(uint32_t aPartitionId, uint8_t aWeighting, uint8_t aLeaderRouterId);
 
     ThreadNetif           &mNetif;            ///< The Thread Network Interface object.
-    AddressResolver       &mAddressResolver;  ///< The Address Resolver object.
-    KeyManager            &mKeyManager;       ///< The Key Manager object.
-    Mac::Mac              &mMac;              ///< The MAC object.
-    MeshForwarder         &mMesh;             ///< The Mesh Forwarding object.
-    MleRouter             &mMleRouter;        ///< The MLE Router object.
-    NetworkData::Leader   &mNetworkData;      ///< The Network Data object.
-    MeshCoP::JoinerRouter &mJoinerRouter;     ///< The Joiner Router object.
 
     LeaderDataTlv mLeaderData;              ///< Last received Leader Data TLV.
     bool mRetrieveNewNetworkData;           ///< Indicating new Network Data is needed if set.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1,6 +1,5 @@
 /*
- *  Copyright (c) 2016, The OpenThread Authors.
- *  All rights reserved.
+ *  Copyright (c) 2016, The OpenThread Authors.  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are met:
@@ -59,9 +58,7 @@ MleRouter::MleRouter(ThreadNetif &aThreadNetif):
     mDelayedResponseTimer(aThreadNetif.GetIp6().mTimerScheduler, &MleRouter::HandleDelayedResponseTimer, this),
     mChildUpdateRequestTimer(aThreadNetif.GetIp6().mTimerScheduler, &MleRouter::HandleChildUpdateRequestTimer, this),
     mAddressSolicit(OPENTHREAD_URI_ADDRESS_SOLICIT, &MleRouter::HandleAddressSolicit, this),
-    mAddressRelease(OPENTHREAD_URI_ADDRESS_RELEASE, &MleRouter::HandleAddressRelease, this),
-    mCoapServer(aThreadNetif.GetCoapServer()),
-    mCoapClient(aThreadNetif.GetCoapClient())
+    mAddressRelease(OPENTHREAD_URI_ADDRESS_RELEASE, &MleRouter::HandleAddressRelease, this)
 {
     mChallengeTimeout = 0;
     mNextChildId = kMaxChildId;
@@ -195,8 +192,8 @@ ThreadError MleRouter::ReleaseRouterId(uint8_t aRouterId)
 
     mRouterIdSequence++;
     mRouterIdSequenceLastUpdated = Timer::GetNow();
-    mAddressResolver.Remove(aRouterId);
-    mNetworkData.RemoveBorderRouter(GetRloc16(aRouterId));
+    mNetif.GetAddressResolver().Remove(aRouterId);
+    mNetif.GetNetworkDataLeader().RemoveBorderRouter(GetRloc16(aRouterId));
     ResetAdvertiseInterval();
 
 exit:
@@ -225,7 +222,7 @@ ThreadError MleRouter::BecomeRouter(ThreadStatusTlv::Status aStatus)
     }
 
     mAdvertiseTimer.Stop();
-    mAddressResolver.Clear();
+    mNetif.GetAddressResolver().Clear();
     mRouterSelectionJitterTimeout = 0;
 
     switch (mDeviceState)
@@ -268,7 +265,7 @@ ThreadError MleRouter::BecomeLeader(void)
 
     mAdvertiseTimer.Stop();
     mStateUpdateTimer.Start(kStateUpdatePeriod);
-    mAddressResolver.Clear();
+    mNetif.GetAddressResolver().Clear();
 
     routerId = IsRouterIdValid(mPreviousRouterId) ? AllocateRouterId(mPreviousRouterId) : AllocateRouterId();
     router = GetRouter(routerId);
@@ -276,7 +273,7 @@ ThreadError MleRouter::BecomeLeader(void)
 
     SetRouterId(routerId);
 
-    memcpy(&router->mMacAddr, mMac.GetExtAddress(), sizeof(router->mMacAddr));
+    memcpy(&router->mMacAddr, mNetif.GetMac().GetExtAddress(), sizeof(router->mMacAddr));
 
     if (mFixedLeaderPartitionId != 0)
     {
@@ -289,7 +286,7 @@ ThreadError MleRouter::BecomeLeader(void)
 
     mRouterIdSequence = static_cast<uint8_t>(otPlatRandomGet());
 
-    mNetworkData.Reset();
+    mNetif.GetNetworkDataLeader().Reset();
 
     SuccessOrExit(error = SetStateLeader(GetRloc16(mRouterId)));
 
@@ -303,12 +300,12 @@ exit:
 
 void MleRouter::StopLeader(void)
 {
-    mCoapServer.RemoveResource(mAddressSolicit);
-    mCoapServer.RemoveResource(mAddressRelease);
+    mNetif.GetCoapServer().RemoveResource(mAddressSolicit);
+    mNetif.GetCoapServer().RemoveResource(mAddressRelease);
     mNetif.GetActiveDataset().StopLeader();
     mNetif.GetPendingDataset().StopLeader();
     mAdvertiseTimer.Stop();
-    mNetworkData.Stop();
+    mNetif.GetNetworkDataLeader().Stop();
     mNetif.UnsubscribeAllRoutersMulticast();
 }
 
@@ -405,7 +402,7 @@ ThreadError MleRouter::SetStateRouter(uint16_t aRloc16)
     mNetif.SubscribeAllRoutersMulticast();
     mRouters[mRouterId].mNextHop = mRouterId;
     mPreviousPartitionId = mLeaderData.GetPartitionId();
-    mNetworkData.Stop();
+    mNetif.GetNetworkDataLeader().Stop();
     mStateUpdateTimer.Start(kStateUpdatePeriod);
     mNetif.GetIp6().SetForwardingEnabled(true);
     mNetif.GetIp6().mMpl.SetTimerExpirations(kMplRouterDataMessageTimerExpirations);
@@ -440,11 +437,11 @@ ThreadError MleRouter::SetStateLeader(uint16_t aRloc16)
     mPreviousPartitionId = mLeaderData.GetPartitionId();
     mRouters[mRouterId].mLastHeard = Timer::GetNow();
 
-    mNetworkData.Start();
+    mNetif.GetNetworkDataLeader().Start();
     mNetif.GetActiveDataset().StartLeader();
     mNetif.GetPendingDataset().StartLeader();
-    mCoapServer.AddResource(mAddressSolicit);
-    mCoapServer.AddResource(mAddressRelease);
+    mNetif.GetCoapServer().AddResource(mAddressSolicit);
+    mNetif.GetCoapServer().AddResource(mAddressRelease);
     mNetif.GetIp6().SetForwardingEnabled(true);
     mNetif.GetIp6().mMpl.SetTimerExpirations(kMplRouterDataMessageTimerExpirations);
 
@@ -710,7 +707,7 @@ ThreadError MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::Mes
 
                 memcpy(&neighbor->mMacAddr, &macAddr, sizeof(neighbor->mMacAddr));
                 neighbor->mLinkInfo.Clear();
-                neighbor->mLinkInfo.AddRss(mMac.GetNoiseFloor(), threadMessageInfo->mRss);
+                neighbor->mLinkInfo.AddRss(mNetif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
                 neighbor->mLinkFailures = 0;
                 neighbor->mState = Neighbor::kStateLinkRequest;
             }
@@ -764,7 +761,7 @@ ThreadError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo, Neig
     SuccessOrExit(error = AppendMleFrameCounter(*message));
 
     // always append a link margin, regardless of whether or not it was requested
-    linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(mMac.GetNoiseFloor(), threadMessageInfo->mRss);
+    linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(mNetif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
 
     // add for certification testing
     if (isAssignLinkQuality &&
@@ -1006,7 +1003,7 @@ ThreadError MleRouter::HandleLinkAccept(const Message &aMessage, const Ip6::Mess
     router->mLastHeard = Timer::GetNow();
     router->mMode = ModeTlv::kModeFFD | ModeTlv::kModeRxOnWhenIdle | ModeTlv::kModeFullNetworkData;
     router->mLinkInfo.Clear();
-    router->mLinkInfo.AddRss(mMac.GetNoiseFloor(), threadMessageInfo->mRss);
+    router->mLinkInfo.AddRss(mNetif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
     router->mLinkFailures = 0;
     router->mState = Neighbor::kStateValid;
     router->mKeySequence = aKeySequence;
@@ -1109,7 +1106,7 @@ uint8_t MleRouter::GetLinkCost(uint8_t aRouterId)
     // NULL aRouterId indicates non-existing next hop, hence return kMaxRouteCost for it.
     VerifyOrExit(aRouterId != mRouterId && router != NULL && router->mState == Neighbor::kStateValid,);
 
-    rval = router->mLinkInfo.GetLinkQuality(mMac.GetNoiseFloor());
+    rval = router->mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
 
     if (rval > router->mLinkQualityOut)
     {
@@ -1143,7 +1140,7 @@ ThreadError MleRouter::ProcessRouteTlv(const RouteTlv &aRoute)
         if (old && !mRouters[i].mAllocated)
         {
             mRouters[i].mNextHop = kInvalidRouterId;
-            mAddressResolver.Remove(i);
+            mNetif.GetAddressResolver().Remove(i);
         }
     }
 
@@ -1421,7 +1418,7 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
         {
             memcpy(&router->mMacAddr, &macAddr, sizeof(router->mMacAddr));
             router->mLinkInfo.Clear();
-            router->mLinkInfo.AddRss(mMac.GetNoiseFloor(), threadMessageInfo->mRss);
+            router->mLinkInfo.AddRss(mNetif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
             router->mLinkFailures = 0;
             router->mState = Neighbor::kStateLinkRequest;
             SendLinkRequest(router);
@@ -1468,7 +1465,7 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
         {
             memcpy(&router->mMacAddr, &macAddr, sizeof(router->mMacAddr));
             router->mLinkInfo.Clear();
-            router->mLinkInfo.AddRss(mMac.GetNoiseFloor(), threadMessageInfo->mRss);
+            router->mLinkInfo.AddRss(mNetif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
             router->mLinkFailures = 0;
             router->mState = Neighbor::kStateLinkRequest;
             router->mDataRequest = false;
@@ -1605,8 +1602,11 @@ void MleRouter::UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId)
             continue;
         }
 
-        otLogDebgMle("%x: %x %d %d %d %d", GetRloc16(i), GetRloc16(mRouters[i].mNextHop),
-                     mRouters[i].mCost, GetLinkCost(i), mRouters[i].mLinkInfo.GetLinkQuality(mMac.GetNoiseFloor()),
+        otLogDebgMle("%x: %x %d %d %d %d",
+                     GetRloc16(i),
+                     GetRloc16(mRouters[i].mNextHop),
+                     mRouters[i].mCost,
+                     GetLinkCost(i), mRouters[i].mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor()),
                      mRouters[i].mLinkQualityOut);
     }
 
@@ -1683,7 +1683,7 @@ ThreadError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::M
     // MAC Address
     memcpy(&child->mMacAddr, &macAddr, sizeof(child->mMacAddr));
     child->mLinkInfo.Clear();
-    child->mLinkInfo.AddRss(mMac.GetNoiseFloor(), threadMessageInfo->mRss);
+    child->mLinkInfo.AddRss(mNetif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
     child->mLinkFailures = 0;
     child->mState = Neighbor::kStateParentRequest;
     child->mDataRequest = false;
@@ -1985,7 +1985,8 @@ ThreadError MleRouter::SendParentResponse(Child *aChild, const ChallengeTlv &cha
     }
     else
     {
-        SuccessOrExit(error = AppendLinkMargin(*message, aChild->mLinkInfo.GetLinkMargin(mMac.GetNoiseFloor())));
+        error = AppendLinkMargin(*message, aChild->mLinkInfo.GetLinkMargin(mNetif.GetMac().GetNoiseFloor()));
+        SuccessOrExit(error);
     }
 
     SuccessOrExit(error = AppendConnectivity(*message));
@@ -2035,7 +2036,7 @@ ThreadError MleRouter::UpdateChildAddresses(const AddressRegistrationTlv &aTlv, 
         if (entry->IsCompressed())
         {
             // xxx check if context id exists
-            mNetworkData.GetContext(entry->GetContextId(), context);
+            mNetif.GetNetworkDataLeader().GetContext(entry->GetContextId(), context);
             memcpy(&aChild.mIp6Address[count], context.mPrefix, BitVectorBytes(context.mPrefixLength));
             aChild.mIp6Address[count].SetIid(entry->GetIid());
         }
@@ -2153,7 +2154,7 @@ ThreadError MleRouter::HandleChildIdRequest(const Message &aMessage, const Ip6::
     child->mValid.mMleFrameCounter = mleFrameCounter.GetFrameCounter();
     child->mKeySequence = aKeySequence;
     child->mMode = mode.GetMode();
-    child->mLinkInfo.AddRss(mMac.GetNoiseFloor(), threadMessageInfo->mRss);
+    child->mLinkInfo.AddRss(mNetif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
     child->mTimeout = timeout.GetTimeout();
 
     if (mode.GetMode() & ModeTlv::kModeFullNetworkData)
@@ -2272,7 +2273,7 @@ ThreadError MleRouter::HandleChildUpdateRequest(const Message &aMessage, const I
             // full network data
             child->mNetworkDataVersion = leaderData.GetDataVersion();
 
-            if (leaderData.GetDataVersion() != mNetworkData.GetVersion())
+            if (leaderData.GetDataVersion() != mNetif.GetNetworkDataLeader().GetVersion())
             {
                 tlvs[tlvslength++] = Tlv::kNetworkData;
             }
@@ -2282,7 +2283,7 @@ ThreadError MleRouter::HandleChildUpdateRequest(const Message &aMessage, const I
             // stable network data
             child->mNetworkDataVersion = leaderData.GetStableDataVersion();
 
-            if (leaderData.GetStableDataVersion() != mNetworkData.GetStableVersion())
+            if (leaderData.GetStableDataVersion() != mNetif.GetNetworkDataLeader().GetStableVersion())
             {
                 tlvs[tlvslength++] = Tlv::kNetworkData;
             }
@@ -2392,7 +2393,7 @@ ThreadError MleRouter::HandleChildUpdateResponse(const Message &aMessage, const 
 
     child->mLastHeard = Timer::GetNow();
     child->mKeySequence = aKeySequence;
-    child->mLinkInfo.AddRss(mMac.GetNoiseFloor(), threadMessageInfo->mRss);
+    child->mLinkInfo.AddRss(mNetif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
     child->mAddSrcMatchEntryShort = true;
     child->mState = Neighbor::kStateValid;
 
@@ -2483,14 +2484,14 @@ ThreadError MleRouter::HandleNetworkDataUpdateRouter(void)
 
         if (child->mMode & ModeTlv::kModeFullNetworkData)
         {
-            if (child->mNetworkDataVersion != mNetworkData.GetVersion())
+            if (child->mNetworkDataVersion != mNetif.GetNetworkDataLeader().GetVersion())
             {
                 SendDataResponse(destination, tlvs, sizeof(tlvs));
             }
         }
         else
         {
-            if (child->mNetworkDataVersion != mNetworkData.GetStableVersion())
+            if (child->mNetworkDataVersion != mNetif.GetNetworkDataLeader().GetStableVersion())
             {
                 static const uint8_t responseTlvs[] = {Tlv::kNetworkData, Tlv::kActiveDataset, Tlv::kPendingDataset};
 
@@ -2553,7 +2554,7 @@ ThreadError MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6
         case MeshCoP::Tlv::kExtendedPanId:
             aMessage.Read(offset, sizeof(extPanId), &extPanId);
             VerifyOrExit(extPanId.IsValid(), error = kThreadError_Parse);
-            VerifyOrExit(memcmp(mMac.GetExtendedPanId(), extPanId.GetExtendedPanId(), OT_EXT_PAN_ID_SIZE),
+            VerifyOrExit(memcmp(mNetif.GetMac().GetExtendedPanId(), extPanId.GetExtendedPanId(), OT_EXT_PAN_ID_SIZE),
                          error = kThreadError_Drop);
             break;
 
@@ -2616,12 +2617,12 @@ ThreadError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, u
 
     // Extended PAN ID TLV
     extPanId.Init();
-    extPanId.SetExtendedPanId(mMac.GetExtendedPanId());
+    extPanId.SetExtendedPanId(mNetif.GetMac().GetExtendedPanId());
     SuccessOrExit(error = message->Append(&extPanId, sizeof(extPanId)));
 
     // Network Name TLV
     networkName.Init();
-    networkName.SetNetworkName(mMac.GetNetworkName());
+    networkName.SetNetworkName(mNetif.GetMac().GetNetworkName());
     SuccessOrExit(error = message->Append(&networkName, sizeof(tlv) + networkName.GetLength()));
 
     // Steering Data TLV
@@ -2634,7 +2635,7 @@ ThreadError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, u
 
     // Joiner UDP Port TLV
     joinerUdpPort.Init();
-    joinerUdpPort.SetUdpPort(mJoinerRouter.GetJoinerUdpPort());
+    joinerUdpPort.SetUdpPort(mNetif.GetJoinerRouter().GetJoinerUdpPort());
     SuccessOrExit(error = message->Append(&joinerUdpPort, sizeof(tlv) + joinerUdpPort.GetLength()));
 
     tlv.SetLength(static_cast<uint8_t>(message->GetLength() - startOffset));
@@ -2682,7 +2683,7 @@ ThreadError MleRouter::SendChildIdResponse(Child *aChild)
         while (FindChild(mNextChildId) != NULL);
 
         // allocate Child ID
-        aChild->mValid.mRloc16 = mMac.GetShortAddress() | mNextChildId;
+        aChild->mValid.mRloc16 = mNetif.GetMac().GetShortAddress() | mNextChildId;
     }
 
     SuccessOrExit(error = AppendAddress16(*message, aChild->mValid.mRloc16));
@@ -2866,7 +2867,7 @@ ThreadError MleRouter::SendDataResponse(const Ip6::Address &aDestination, const 
         switch (aTlvs[i])
         {
         case Tlv::kNetworkData:
-            neighbor = mMleRouter.GetNeighbor(aDestination);
+            neighbor = GetNeighbor(aDestination);
             stableOnly = neighbor != NULL ? (neighbor->mMode & ModeTlv::kModeFullNetworkData) == 0 : false;
             SuccessOrExit(error = AppendNetworkData(*message, stableOnly));
             break;
@@ -3001,9 +3002,9 @@ ThreadError MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
         if (aNeighbor.mState == Neighbor::kStateValid && !IsActiveRouter(aNeighbor.mValid.mRloc16))
         {
             aNeighbor.mState = Neighbor::kStateInvalid;
-            mMesh.UpdateIndirectMessages();
+            mNetif.GetMeshForwarder().UpdateIndirectMessages();
             mNetif.SetStateChangedFlags(OT_THREAD_CHILD_REMOVED);
-            mNetworkData.SendServerDataNotification(aNeighbor.mValid.mRloc16);
+            mNetif.GetNetworkDataLeader().SendServerDataNotification(aNeighbor.mValid.mRloc16);
             RemoveStoredChild(aNeighbor.mValid.mRloc16);
         }
 
@@ -3152,7 +3153,7 @@ Neighbor *MleRouter::GetNeighbor(const Ip6::Address &aAddress)
         ExitNow(rval = GetNeighbor(macaddr));
     }
 
-    if (mNetworkData.GetContext(aAddress, context) != kThreadError_None)
+    if (mNetif.GetNetworkDataLeader().GetContext(aAddress, context) != kThreadError_None)
     {
         context.mContextId = 0xff;
     }
@@ -3424,7 +3425,7 @@ ThreadError MleRouter::StoreChild(uint16_t aChildRloc16)
     ThreadError error = kThreadError_None;
     otChildInfo childInfo;
 
-    SuccessOrExit(error = mMleRouter.GetChildInfoById(GetChildId(aChildRloc16), childInfo));
+    SuccessOrExit(error = GetChildInfoById(GetChildId(aChildRloc16), childInfo));
 
     error = otPlatSettingsAdd(mNetif.GetInstance(), kKeyChildInfo, reinterpret_cast<uint8_t *>(&childInfo),
                               sizeof(childInfo));
@@ -3445,7 +3446,7 @@ void MleRouter::GetChildInfo(Child &aChild, otChildInfo &aChildInfo)
         aChildInfo.mChildId = GetChildId(aChild.mValid.mRloc16);
         aChildInfo.mNetworkDataVersion = aChild.mNetworkDataVersion;
         aChildInfo.mAge = Timer::MsecToSec(Timer::GetNow() - aChild.mLastHeard);
-        aChildInfo.mLinkQualityIn = aChild.mLinkInfo.GetLinkQuality(mMac.GetNoiseFloor());
+        aChildInfo.mLinkQualityIn = aChild.mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
         aChildInfo.mAverageRssi = aChild.mLinkInfo.GetAverageRss();
 
         aChildInfo.mRxOnWhenIdle = (aChild.mMode & ModeTlv::kModeRxOnWhenIdle) != 0;
@@ -3480,7 +3481,7 @@ ThreadError MleRouter::GetRouterInfo(uint16_t aRouterId, otRouterInfo &aRouterIn
     aRouterInfo.mNextHop = router->mNextHop;
     aRouterInfo.mLinkEstablished = router->mState == Neighbor::kStateValid;
     aRouterInfo.mPathCost = router->mCost;
-    aRouterInfo.mLinkQualityIn = router->mLinkInfo.GetLinkQuality(mMac.GetNoiseFloor());
+    aRouterInfo.mLinkQualityIn = router->mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
     aRouterInfo.mLinkQualityOut = router->mLinkQualityOut;
     aRouterInfo.mAge = static_cast<uint8_t>(Timer::MsecToSec(Timer::GetNow() - router->mLastHeard));
 
@@ -3541,7 +3542,7 @@ exit:
         aNeighInfo.mRloc16 = neighbor->mValid.mRloc16;
         aNeighInfo.mLinkFrameCounter = neighbor->mValid.mLinkFrameCounter;
         aNeighInfo.mMleFrameCounter = neighbor->mValid.mMleFrameCounter;
-        aNeighInfo.mLinkQualityIn = neighbor->mLinkInfo.GetLinkQuality(mMac.GetNoiseFloor());
+        aNeighInfo.mLinkQualityIn = neighbor->mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
         aNeighInfo.mAverageRssi = neighbor->mLinkInfo.GetAverageRss();
         aNeighInfo.mRxOnWhenIdle = (neighbor->mMode & ModeTlv::kModeRxOnWhenIdle) != 0;
         aNeighInfo.mSecureDataRequest = (neighbor->mMode & ModeTlv::kModeSecureDataRequest) != 0;
@@ -3575,7 +3576,7 @@ ThreadError MleRouter::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDes
         return Mle::CheckReachability(aMeshSource, aMeshDest, aIp6Header);
     }
 
-    if (aMeshDest == mMac.GetShortAddress())
+    if (aMeshDest == mNetif.GetMac().GetShortAddress())
     {
         // mesh destination is this device
         if (mNetif.IsUnicastAddress(aIp6Header.GetDestination()))
@@ -3629,10 +3630,10 @@ ThreadError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
     header.AppendUriPathOptions(OPENTHREAD_URI_ADDRESS_SOLICIT);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mCoapClient.NewMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoapClient().NewMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     macAddr64Tlv.Init();
-    macAddr64Tlv.SetMacAddr(*mMac.GetExtAddress());
+    macAddr64Tlv.SetMacAddr(*mNetif.GetMac().GetExtAddress());
     SuccessOrExit(error = message->Append(&macAddr64Tlv, sizeof(macAddr64Tlv)));
 
     if (IsRouterIdValid(mPreviousRouterId))
@@ -3650,8 +3651,8 @@ ThreadError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
     messageInfo.SetSockAddr(GetMeshLocal16());
     messageInfo.SetPeerPort(kCoapUdpPort);
 
-    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo,
-                                                  &MleRouter::HandleAddressSolicitResponse, this));
+    SuccessOrExit(error = mNetif.GetCoapClient().SendMessage(*message, messageInfo,
+                                                             &MleRouter::HandleAddressSolicitResponse, this));
 
     otLogInfoMle("Sent address solicit to %04x", HostSwap16(messageInfo.GetPeerAddr().mFields.m16[7]));
 
@@ -3679,19 +3680,19 @@ ThreadError MleRouter::SendAddressRelease(void)
     header.AppendUriPathOptions(OPENTHREAD_URI_ADDRESS_RELEASE);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mCoapClient.NewMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoapClient().NewMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     rlocTlv.Init();
     rlocTlv.SetRloc16(GetRloc16(mRouterId));
     SuccessOrExit(error = message->Append(&rlocTlv, sizeof(rlocTlv)));
 
     macAddr64Tlv.Init();
-    macAddr64Tlv.SetMacAddr(*mMac.GetExtAddress());
+    macAddr64Tlv.SetMacAddr(*mNetif.GetMac().GetExtAddress());
     SuccessOrExit(error = message->Append(&macAddr64Tlv, sizeof(macAddr64Tlv)));
 
     SuccessOrExit(error = GetLeaderAddress(messageInfo.GetPeerAddr()));
     messageInfo.SetPeerPort(kCoapUdpPort);
-    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
+    SuccessOrExit(error = mNetif.GetCoapClient().SendMessage(*message, messageInfo));
 
     otLogInfoMle("Sent address release");
 
@@ -3788,7 +3789,7 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Header *aHeader, Message *aMe
 
         if (old && !mRouters[i].mAllocated)
         {
-            mAddressResolver.Remove(i);
+            mNetif.GetAddressResolver().Remove(i);
         }
     }
 
@@ -3941,7 +3942,7 @@ void MleRouter::SendAddressSolicitResponse(const Coap::Header &aRequestHeader, u
     ThreadRloc16Tlv rlocTlv;
     Message *message;
 
-    VerifyOrExit((message = mCoapServer.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoapServer().NewMessage(0)) != NULL, error = kThreadError_NoBufs);
 
     responseHeader.SetDefaultResponseHeader(aRequestHeader);
     responseHeader.SetPayloadMarker();
@@ -3973,7 +3974,7 @@ void MleRouter::SendAddressSolicitResponse(const Coap::Header &aRequestHeader, u
         SuccessOrExit(error = message->Append(&routerMaskTlv, sizeof(routerMaskTlv)));
     }
 
-    SuccessOrExit(error = mCoapServer.SendMessage(*message, aMessageInfo));
+    SuccessOrExit(error = mNetif.GetCoapServer().SendMessage(*message, aMessageInfo));
 
     otLogInfoMle("Sent address reply");
 
@@ -4020,7 +4021,7 @@ void MleRouter::HandleAddressRelease(Coap::Header &aHeader, Message &aMessage,
 
     ReleaseRouterId(routerId);
 
-    SuccessOrExit(mCoapServer.SendEmptyAck(aHeader, aMessageInfo));
+    SuccessOrExit(mNetif.GetCoapServer().SendEmptyAck(aHeader, aMessageInfo));
 
     otLogInfoMle("Sent address release response");
 
@@ -4067,7 +4068,7 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
         break;
 
     case kDeviceStateChild:
-        switch (mParent.mLinkInfo.GetLinkQuality(mMac.GetNoiseFloor()))
+        switch (mParent.mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor()))
         {
         case 1:
             tlv.SetLinkQuality1(tlv.GetLinkQuality1() + 1);
@@ -4082,7 +4083,7 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
             break;
         }
 
-        cost += LqiToCost(mParent.mLinkInfo.GetLinkQuality(mMac.GetNoiseFloor()));
+        cost += LqiToCost(mParent.mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor()));
         break;
 
     case kDeviceStateRouter:
@@ -4108,7 +4109,7 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
             continue;
         }
 
-        lqi = mRouters[i].mLinkInfo.GetLinkQuality(mMac.GetNoiseFloor());
+        lqi = mRouters[i].mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
 
         if (lqi > mRouters[i].mLinkQualityOut)
         {
@@ -4170,7 +4171,7 @@ ThreadError MleRouter::AppendChildAddresses(Message &aMessage, Child &aChild)
             break;
         }
 
-        if (mNetworkData.GetContext(aChild.mIp6Address[i], context) == kThreadError_None)
+        if (mNetif.GetNetworkDataLeader().GetContext(aChild.mIp6Address[i], context) == kThreadError_None)
         {
             // compressed entry
             entry.SetContextId(context.mContextId);
@@ -4243,7 +4244,8 @@ void MleRouter::FillRouteTlv(RouteTlv &tlv)
             }
             else
             {
-                tlv.SetLinkQualityIn(routeCount, mRouters[i].mLinkInfo.GetLinkQuality(mMac.GetNoiseFloor()));
+                tlv.SetLinkQualityIn(routeCount,
+                                     mRouters[i].mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor()));
             }
         }
 
@@ -4320,7 +4322,7 @@ bool MleRouter::HasOneNeighborwithComparableConnectivity(const RouteTlv &aRoute,
                 continue;
             }
 
-            localLqi = mRouters[i].mLinkInfo.GetLinkQuality(mMac.GetNoiseFloor());
+            localLqi = mRouters[i].mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
 
             if (localLqi > mRouters[i].mLinkQualityOut)
             {
@@ -4427,7 +4429,7 @@ uint8_t MleRouter::GetMinDowngradeNeighborRouters(void)
             continue;
         }
 
-        lqi = mRouters[i].mLinkInfo.GetLinkQuality(mMac.GetNoiseFloor());
+        lqi = mRouters[i].mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
 
         if (lqi > mRouters[i].mLinkQualityOut)
         {

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -838,9 +838,6 @@ private:
     uint8_t mRouterId;
     uint8_t mPreviousRouterId;
     uint32_t mPreviousPartitionId;
-
-    Coap::Server &mCoapServer;
-    Coap::Client &mCoapClient;
 };
 
 }  // namespace Mle

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -48,11 +48,10 @@ namespace Thread {
 namespace NetworkData {
 
 NetworkData::NetworkData(ThreadNetif &aThreadNetif, bool aLocal):
-    mMle(aThreadNetif.GetMle()),
+    mNetif(aThreadNetif),
     mLocal(aLocal),
     mLastAttemptWait(false),
-    mLastAttempt(0),
-    mCoapClient(aThreadNetif.GetCoapClient())
+    mLastAttempt(0)
 {
     mLength = 0;
 }
@@ -605,7 +604,7 @@ ThreadError NetworkData::SendServerDataNotification(uint16_t aRloc16)
     header.AppendUriPathOptions(OPENTHREAD_URI_SERVER_DATA);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mCoapClient.NewMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoapClient().NewMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     if (mLocal)
     {
@@ -624,10 +623,10 @@ ThreadError NetworkData::SendServerDataNotification(uint16_t aRloc16)
         SuccessOrExit(error = message->Append(&rloc16Tlv, sizeof(rloc16Tlv)));
     }
 
-    mMle.GetLeaderAloc(messageInfo.GetPeerAddr());
-    messageInfo.SetSockAddr(mMle.GetMeshLocal16());
+    mNetif.GetMle().GetLeaderAloc(messageInfo.GetPeerAddr());
+    messageInfo.SetSockAddr(mNetif.GetMle().GetMeshLocal16());
     messageInfo.SetPeerPort(kCoapUdpPort);
-    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
+    SuccessOrExit(error = mNetif.GetCoapClient().SendMessage(*message, messageInfo));
 
     if (mLocal)
     {

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -339,7 +339,7 @@ protected:
     uint8_t mTlvs[kMaxSize];  ///< The Network Data buffer.
     uint8_t mLength;          ///< The number of valid bytes in @var mTlvs.
 
-    Mle::MleRouter &mMle;
+    ThreadNetif &mNetif;
 
 private:
     enum
@@ -350,8 +350,6 @@ private:
     const bool      mLocal;
     bool            mLastAttemptWait;
     uint32_t        mLastAttempt;
-
-    Coap::Client &mCoapClient;
 };
 
 }  // namespace NetworkData

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -55,8 +55,7 @@ namespace Thread {
 namespace NetworkData {
 
 LeaderBase::LeaderBase(ThreadNetif &aThreadNetif):
-    NetworkData(aThreadNetif, false),
-    mNetif(aThreadNetif)
+    NetworkData(aThreadNetif, false)
 {
     Reset();
 }
@@ -86,9 +85,9 @@ ThreadError LeaderBase::GetContext(const Ip6::Address &aAddress, Lowpan::Context
 
     aContext.mPrefixLength = 0;
 
-    if (PrefixMatch(mMle.GetMeshLocalPrefix(), aAddress.mFields.m8, 64) >= 0)
+    if (PrefixMatch(mNetif.GetMle().GetMeshLocalPrefix(), aAddress.mFields.m8, 64) >= 0)
     {
-        aContext.mPrefix = mMle.GetMeshLocalPrefix();
+        aContext.mPrefix = mNetif.GetMle().GetMeshLocalPrefix();
         aContext.mPrefixLength = 64;
         aContext.mContextId = 0;
         aContext.mCompressFlag = true;
@@ -137,7 +136,7 @@ ThreadError LeaderBase::GetContext(uint8_t aContextId, Lowpan::Context &aContext
 
     if (aContextId == 0)
     {
-        aContext.mPrefix = mMle.GetMeshLocalPrefix();
+        aContext.mPrefix = mNetif.GetMle().GetMeshLocalPrefix();
         aContext.mPrefixLength = 64;
         aContext.mContextId = 0;
         aContext.mCompressFlag = true;
@@ -209,7 +208,7 @@ bool LeaderBase::IsOnMesh(const Ip6::Address &aAddress)
     PrefixTlv *prefix;
     bool rval = false;
 
-    if (memcmp(aAddress.mFields.m8, mMle.GetMeshLocalPrefix(), 8) == 0)
+    if (memcmp(aAddress.mFields.m8, mNetif.GetMle().GetMeshLocalPrefix(), 8) == 0)
     {
         ExitNow(rval = true);
     }
@@ -332,7 +331,8 @@ ThreadError LeaderBase::ExternalRouteLookup(uint8_t aDomainId, const Ip6::Addres
                     if (rvalRoute == NULL ||
                         entry->GetPreference() > rvalRoute->GetPreference() ||
                         (entry->GetPreference() == rvalRoute->GetPreference() &&
-                         mMle.GetRouteCost(entry->GetRloc()) < mMle.GetRouteCost(rvalRoute->GetRloc())))
+                         mNetif.GetMle().GetRouteCost(entry->GetRloc()) <
+                         mNetif.GetMle().GetRouteCost(rvalRoute->GetRloc())))
                     {
                         rvalRoute = entry;
                         rval_plen = static_cast<uint8_t>(plen);
@@ -389,7 +389,7 @@ ThreadError LeaderBase::DefaultRouteLookup(PrefixTlv &aPrefix, uint16_t *aRloc16
             if (route == NULL ||
                 entry->GetPreference() > route->GetPreference() ||
                 (entry->GetPreference() == route->GetPreference() &&
-                 mMle.GetRouteCost(entry->GetRloc()) < mMle.GetRouteCost(route->GetRloc())))
+                 mNetif.GetMle().GetRouteCost(entry->GetRloc()) < mNetif.GetMle().GetRouteCost(route->GetRloc())))
             {
                 route = entry;
             }

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -216,7 +216,6 @@ public:
 protected:
     uint8_t         mStableVersion;
     uint8_t         mVersion;
-    ThreadNetif    &mNetif;
 
 private:
     ThreadError RemoveCommissioningData(void);

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -59,8 +59,7 @@ Leader::Leader(ThreadNetif &aThreadNetif):
     mTimer(aThreadNetif.GetIp6().mTimerScheduler, &Leader::HandleTimer, this),
     mServerData(OPENTHREAD_URI_SERVER_DATA, &Leader::HandleServerData, this),
     mCommissioningDataGet(OPENTHREAD_URI_COMMISSIONER_GET, &Leader::HandleCommissioningGet, this),
-    mCommissioningDataSet(OPENTHREAD_URI_COMMISSIONER_SET, &Leader::HandleCommissioningSet, this),
-    mCoapServer(aThreadNetif.GetCoapServer())
+    mCommissioningDataSet(OPENTHREAD_URI_COMMISSIONER_SET, &Leader::HandleCommissioningSet, this)
 {
     Reset();
 }
@@ -76,21 +75,21 @@ void Leader::Reset(void)
 
 void Leader::Start(void)
 {
-    mCoapServer.AddResource(mServerData);
-    mCoapServer.AddResource(mCommissioningDataGet);
-    mCoapServer.AddResource(mCommissioningDataSet);
+    mNetif.GetCoapServer().AddResource(mServerData);
+    mNetif.GetCoapServer().AddResource(mCommissioningDataGet);
+    mNetif.GetCoapServer().AddResource(mCommissioningDataSet);
 }
 
 void Leader::Stop(void)
 {
-    mCoapServer.RemoveResource(mServerData);
-    mCoapServer.RemoveResource(mCommissioningDataGet);
-    mCoapServer.RemoveResource(mCommissioningDataSet);
+    mNetif.GetCoapServer().RemoveResource(mServerData);
+    mNetif.GetCoapServer().RemoveResource(mCommissioningDataGet);
+    mNetif.GetCoapServer().RemoveResource(mCommissioningDataSet);
 }
 
 void Leader::IncrementVersion(void)
 {
-    if (mMle.GetDeviceState() == Mle::kDeviceStateLeader)
+    if (mNetif.GetMle().GetDeviceState() == Mle::kDeviceStateLeader)
     {
         mVersion++;
         mNetif.SetStateChangedFlags(OT_THREAD_NETDATA_UPDATED);
@@ -99,7 +98,7 @@ void Leader::IncrementVersion(void)
 
 void Leader::IncrementStableVersion(void)
 {
-    if (mMle.GetDeviceState() == Mle::kDeviceStateLeader)
+    if (mNetif.GetMle().GetDeviceState() == Mle::kDeviceStateLeader)
     {
         mStableVersion++;
     }
@@ -167,7 +166,7 @@ void Leader::HandleServerData(Coap::Header &aHeader, Message &aMessage,
                             networkData.GetTlvs(), networkData.GetLength());
     }
 
-    SuccessOrExit(mCoapServer.SendEmptyAck(aHeader, aMessageInfo));
+    SuccessOrExit(mNetif.GetCoapServer().SendEmptyAck(aHeader, aMessageInfo));
 
     otLogInfoNetData("Sent network data registration acknowledgment");
 
@@ -193,7 +192,7 @@ void Leader::HandleCommissioningSet(Coap::Header &aHeader, Message &aMessage, co
     bool hasValidTlv = false;
     uint16_t sessionId = 0;
 
-    VerifyOrExit(mMle.GetDeviceState() == Mle::kDeviceStateLeader, state = MeshCoP::StateTlv::kReject);
+    VerifyOrExit(mNetif.GetMle().GetDeviceState() == Mle::kDeviceStateLeader, state = MeshCoP::StateTlv::kReject);
 
     aMessage.Read(offset, length, tlvs);
 
@@ -251,7 +250,7 @@ void Leader::HandleCommissioningSet(Coap::Header &aHeader, Message &aMessage, co
 
 exit:
 
-    if (mMle.GetDeviceState() == Mle::kDeviceStateLeader)
+    if (mNetif.GetMle().GetDeviceState() == Mle::kDeviceStateLeader)
     {
         SendCommissioningSetResponse(aHeader, aMessageInfo, state);
     }
@@ -301,7 +300,7 @@ void Leader::SendCommissioningGetResponse(const Coap::Header &aRequestHeader, co
     uint8_t *data = NULL;
     uint8_t length = 0;
 
-    VerifyOrExit((message = mCoapServer.NewMeshCoPMessage(0)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoapServer().NewMeshCoPMessage(0)) != NULL, error = kThreadError_NoBufs);
 
     responseHeader.SetDefaultResponseHeader(aRequestHeader);
     responseHeader.SetPayloadMarker();
@@ -343,7 +342,7 @@ void Leader::SendCommissioningGetResponse(const Coap::Header &aRequestHeader, co
         }
     }
 
-    SuccessOrExit(error = mCoapServer.SendMessage(*message, aMessageInfo));
+    SuccessOrExit(error = mNetif.GetCoapServer().SendMessage(*message, aMessageInfo));
 
     otLogInfoMeshCoP("sent commissioning dataset get response");
 
@@ -364,7 +363,7 @@ void Leader::SendCommissioningSetResponse(const Coap::Header &aRequestHeader, co
     MeshCoP::StateTlv state;
     Ip6::MessageInfo responseInfo(aMessageInfo);
 
-    VerifyOrExit((message = mCoapServer.NewMeshCoPMessage(0)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoapServer().NewMeshCoPMessage(0)) != NULL, error = kThreadError_NoBufs);
 
     responseHeader.SetDefaultResponseHeader(aRequestHeader);
     responseHeader.SetPayloadMarker();
@@ -376,7 +375,7 @@ void Leader::SendCommissioningSetResponse(const Coap::Header &aRequestHeader, co
     SuccessOrExit(error = message->Append(&state, sizeof(state)));
 
     memset(&responseInfo.mSockAddr, 0, sizeof(responseInfo.mSockAddr));
-    SuccessOrExit(error = mCoapServer.SendMessage(*message, responseInfo));
+    SuccessOrExit(error = mNetif.GetCoapServer().SendMessage(*message, responseInfo));
 
     otLogInfoMeshCoP("sent commissioning dataset set response");
 

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -205,8 +205,6 @@ private:
 
     Coap::Resource mCommissioningDataGet;
     Coap::Resource mCommissioningDataSet;
-
-    Coap::Server   &mCoapServer;
 };
 
 /**

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -43,8 +43,7 @@ namespace NetworkData {
 
 Local::Local(ThreadNetif &aThreadNetif):
     NetworkData(aThreadNetif, true),
-    mOldRloc(Mac::kShortAddrInvalid),
-    mLeader(aThreadNetif.GetNetworkDataLeader())
+    mOldRloc(Mac::kShortAddrInvalid)
 {
 }
 
@@ -191,38 +190,38 @@ ThreadError Local::UpdateRloc(PrefixTlv &aPrefix)
 ThreadError Local::UpdateRloc(HasRouteTlv &aHasRoute)
 {
     HasRouteEntry *entry = aHasRoute.GetEntry(0);
-    entry->SetRloc(mMle.GetRloc16());
+    entry->SetRloc(mNetif.GetMle().GetRloc16());
     return kThreadError_None;
 }
 
 ThreadError Local::UpdateRloc(BorderRouterTlv &aBorderRouter)
 {
     BorderRouterEntry *entry = aBorderRouter.GetEntry(0);
-    entry->SetRloc(mMle.GetRloc16());
+    entry->SetRloc(mNetif.GetMle().GetRloc16());
     return kThreadError_None;
 }
 
 bool Local::IsOnMeshPrefixConsistent(void)
 {
-    return (mLeader.ContainsOnMeshPrefixes(*this, mMle.GetRloc16()) &&
-            ContainsOnMeshPrefixes(mLeader, mMle.GetRloc16()));
+    return (mNetif.GetNetworkDataLeader().ContainsOnMeshPrefixes(*this, mNetif.GetMle().GetRloc16()) &&
+            ContainsOnMeshPrefixes(mNetif.GetNetworkDataLeader(), mNetif.GetMle().GetRloc16()));
 }
 
 bool Local::IsExternalRouteConsistent(void)
 {
-    return (mLeader.ContainsExternalRoutes(*this, mMle.GetRloc16()) &&
-            ContainsExternalRoutes(mLeader, mMle.GetRloc16()));
+    return (mNetif.GetNetworkDataLeader().ContainsExternalRoutes(*this, mNetif.GetMle().GetRloc16()) &&
+            ContainsExternalRoutes(mNetif.GetNetworkDataLeader(), mNetif.GetMle().GetRloc16()));
 }
 
 ThreadError Local::SendServerDataNotification(void)
 {
     ThreadError error = kThreadError_None;
-    uint16_t rloc = mMle.GetRloc16();
+    uint16_t rloc = mNetif.GetMle().GetRloc16();
 
-    if ((mMle.GetDeviceMode() & Mle::ModeTlv::kModeFFD) != 0 &&
-        (mMle.IsRouterRoleEnabled()) &&
-        (mMle.GetDeviceState() < Mle::kDeviceStateRouter) &&
-        (mMle.GetActiveRouterCount() < mMle.GetRouterUpgradeThreshold()))
+    if ((mNetif.GetMle().GetDeviceMode() & Mle::ModeTlv::kModeFFD) != 0 &&
+        (mNetif.GetMle().IsRouterRoleEnabled()) &&
+        (mNetif.GetMle().GetDeviceState() < Mle::kDeviceStateRouter) &&
+        (mNetif.GetMle().GetActiveRouterCount() < mNetif.GetMle().GetRouterUpgradeThreshold()))
     {
         ExitNow(error = kThreadError_InvalidState);
     }

--- a/src/core/thread/network_data_local_ftd.hpp
+++ b/src/core/thread/network_data_local_ftd.hpp
@@ -139,8 +139,6 @@ private:
     bool IsExternalRouteConsistent(void);
 
     uint16_t mOldRloc;
-
-    Leader &mLeader;
 };
 
 }  // namespace NetworkData

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -135,11 +135,7 @@ private:
     Coap::Resource mDiagnosticGetQuery;
     Coap::Resource mDiagnosticGetAnswer;
     Coap::Resource mDiagnosticReset;
-    Coap::Server &mCoapServer;
-    Coap::Client &mCoapClient;
 
-    Mle::MleRouter &mMle;
-    Mac::Mac &mMac;
     ThreadNetif &mNetif;
 
     otReceiveDiagnosticGetCallback mReceiveDiagnosticGetCallback;

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -50,11 +50,9 @@ PanIdQueryServer::PanIdQueryServer(ThreadNetif &aThreadNetif) :
     mPanId(Mac::kPanIdBroadcast),
     mTimer(aThreadNetif.GetIp6().mTimerScheduler, &PanIdQueryServer::HandleTimer, this),
     mPanIdQuery(OPENTHREAD_URI_PANID_QUERY, &PanIdQueryServer::HandleQuery, this),
-    mCoapServer(aThreadNetif.GetCoapServer()),
-    mCoapClient(aThreadNetif.GetCoapClient()),
     mNetif(aThreadNetif)
 {
-    mCoapServer.AddResource(mPanIdQuery);
+    mNetif.GetCoapServer().AddResource(mPanIdQuery);
 }
 
 void PanIdQueryServer::HandleQuery(void *aContext, otCoapHeader *aHeader, otMessage aMessage,
@@ -85,7 +83,7 @@ void PanIdQueryServer::HandleQuery(Coap::Header &aHeader, Message &aMessage, con
     mTimer.Start(kScanDelay);
 
     memset(&responseInfo.mSockAddr, 0, sizeof(responseInfo.mSockAddr));
-    SuccessOrExit(mCoapServer.SendEmptyAck(aHeader, responseInfo));
+    SuccessOrExit(mNetif.GetCoapServer().SendEmptyAck(aHeader, responseInfo));
 
     otLogInfoMeshCoP("sent panid query response");
 
@@ -131,7 +129,7 @@ ThreadError PanIdQueryServer::SendConflict(void)
     header.AppendUriPathOptions(OPENTHREAD_URI_PANID_CONFLICT);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mCoapClient.NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoapClient().NewMeshCoPMessage(header)) != NULL, error = kThreadError_NoBufs);
 
     channelMask.Init();
     channelMask.SetMask(mChannelMask);
@@ -143,7 +141,7 @@ ThreadError PanIdQueryServer::SendConflict(void)
 
     messageInfo.SetPeerAddr(mCommissioner);
     messageInfo.SetPeerPort(kCoapUdpPort);
-    SuccessOrExit(error = mCoapClient.SendMessage(*message, messageInfo));
+    SuccessOrExit(error = mNetif.GetCoapClient().SendMessage(*message, messageInfo));
 
     otLogInfoMeshCoP("sent panid conflict");
 

--- a/src/core/thread/panid_query_server.hpp
+++ b/src/core/thread/panid_query_server.hpp
@@ -89,8 +89,6 @@ private:
     Timer mTimer;
 
     Coap::Resource mPanIdQuery;
-    Coap::Server &mCoapServer;
-    Coap::Client &mCoapClient;
 
     ThreadNetif &mNetif;
 };


### PR DESCRIPTION
- Rather than maintaining references to a number of commonly-used objects,
  only maintain a single reference to the primary `ThreadNetif` object.

- This trades RAM for code size, as additional code is required to acquire
  objects from the ThreadNetif object.

Reduces RAM by 240 bytes.  Increases text by 1,088 bytes.

Before:

```
   text	   data	    bss	    dec	    hex	filename
 207348	   4588	  27700	 239636	  3a814	output/bin/arm-none-eabi-ot-cli-ftd
```

After:

```
   text	   data	    bss	    dec	    hex	filename
 208436	   4588	  27460	 240484	  3ab64	output/bin/arm-none-eabi-ot-cli-ftd
```