### PR TITLE
ensure first advertisement of REED include the correct Leader Data TLV

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2588,13 +2588,13 @@ ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::Messa
     }
 
     mParent.mValid.mRloc16 = sourceAddress.GetRloc16();
-    SuccessOrExit(error = SetStateChild(shortAddress.GetRloc16()));
 
     mNetworkData.SetNetworkData(leaderData.GetDataVersion(), leaderData.GetStableDataVersion(),
                                 (mDeviceMode & ModeTlv::kModeFullNetworkData) == 0,
                                 networkData.GetNetworkData(), networkData.GetLength());
 
     mNetif.GetActiveDataset().ApplyConfiguration();
+    SuccessOrExit(error = SetStateChild(shortAddress.GetRloc16()));
 
 exit:
 


### PR DESCRIPTION
The incorrect LeaderData TLV in the first advertisement from REED would cause NXP Leader start a new partition

Fixed Leader5.2.3 on OT-NXP(DUT) testbed