### PR TITLE
Enhancements for Interop.

### DIFF
--- a/src/core/common/encoding.hpp
+++ b/src/core/common/encoding.hpp
@@ -69,6 +69,17 @@ inline uint64_t Swap64(uint64_t v)
         ((v & static_cast<uint64_t>(0xff00000000000000ULL)) >> 56);
 }
 
+inline uint32_t Reverse32(uint32_t v)
+{
+    v = ((v & 0x55555555) << 1)  | ((v & 0xaaaaaaaa) >> 1);
+    v = ((v & 0x33333333) << 2)  | ((v & 0xcccccccc) >> 2);
+    v = ((v & 0x0f0f0f0f) << 4)  | ((v & 0xf0f0f0f0) >> 4);
+    v = ((v & 0x00ff00ff) << 8)  | ((v & 0xff00ff00) >> 8);
+    v = ((v & 0x0000ffff) << 16) | ((v & 0xffff0000) >> 16);
+
+    return v;
+}
+
 #define BitVectorBytes(x)           \
     (((x) + (CHAR_BIT-1)) / CHAR_BIT)
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -161,6 +161,8 @@ Mac::Mac(ThreadNetif &aThreadNetif):
 
     otPlatRadioEnable(mNetif.GetInstance());
     mTxFrame = static_cast<Frame *>(otPlatRadioGetTransmitBuffer(mNetif.GetInstance()));
+
+    mKeyIdMode2FrameCounter = 0;
 }
 
 ThreadError Mac::ActiveScan(uint32_t aScanChannels, uint16_t aScanDuration, ActiveScanHandler aHandler, void *aContext)
@@ -685,7 +687,7 @@ void Mac::ProcessTransmitSecurity(Frame &aFrame)
     {
         const uint8_t keySource[] = {0xff, 0xff, 0xff, 0xff};
         key = sMode2Key;
-        frameCounter = 0xffffffff;
+        frameCounter = mKeyIdMode2FrameCounter++;
         aFrame.SetKeySource(keySource);
         aFrame.SetKeyId(0xff);
         extAddress = static_cast<const ExtAddress *>(&sMode2ExtAddress);

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -664,6 +664,7 @@ private:
     Frame *mTxFrame;
 
     otMacCounters mCounters;
+    uint32_t mKeyIdMode2FrameCounter;
 };
 
 /**

--- a/src/core/meshcop/timestamp.hpp
+++ b/src/core/meshcop/timestamp.hpp
@@ -35,6 +35,10 @@
 #ifndef MESHCOP_TIMESTAMP_HPP_
 #define MESHCOP_TIMESTAMP_HPP_
 
+#include <common/encoding.hpp>
+
+using Thread::Encoding::BigEndian::HostSwap16;
+
 namespace Thread {
 namespace MeshCoP {
 
@@ -98,7 +102,7 @@ public:
      * @returns The Ticks value.
      *
      */
-    uint16_t GetTicks(void) const { return mTicks >> kTicksOffset; }
+    uint16_t GetTicks(void) const { return HostSwap16(mTicks) >> kTicksOffset; }
 
     /**
      * This method sets the Ticks value.
@@ -107,7 +111,7 @@ public:
      *
      */
     void SetTicks(uint16_t aTicks) {
-        mTicks = (mTicks & ~kTicksMask) | ((aTicks << kTicksOffset) & kTicksMask);
+        mTicks = HostSwap16((HostSwap16(mTicks) & ~kTicksMask) | ((aTicks << kTicksOffset) & kTicksMask));
     }
 
     /**
@@ -116,7 +120,7 @@ public:
      * @returns The Authoritative value.
      *
      */
-    bool GetAuthoritative(void) const { return (mTicks & kAuthoritativeMask) != 0; }
+    bool GetAuthoritative(void) const { return (HostSwap16(mTicks) & kAuthoritativeMask) != 0; }
 
     /**
      * This method sets the Authoritative value.
@@ -125,7 +129,8 @@ public:
      *
      */
     void SetAuthoritative(bool aAuthoritative) {
-        mTicks = (mTicks & kTicksMask) | ((aAuthoritative << kAuthoritativeOffset) & kAuthoritativeMask);
+        mTicks = HostSwap16((HostSwap16(mTicks) & kTicksMask) | ((aAuthoritative << kAuthoritativeOffset) &
+                                                                 kAuthoritativeMask));
     }
 
 private:

--- a/src/core/meshcop/tlvs.hpp
+++ b/src/core/meshcop/tlvs.hpp
@@ -43,6 +43,7 @@
 #include <common/tlvs.hpp>
 #include <meshcop/timestamp.hpp>
 
+using Thread::Encoding::Reverse32;
 using Thread::Encoding::BigEndian::HostSwap16;
 using Thread::Encoding::BigEndian::HostSwap32;
 
@@ -1189,7 +1190,7 @@ public:
      */
     void ClearChannel(uint8_t aChannel) {
         uint8_t *mask = reinterpret_cast<uint8_t *>(this) + sizeof(*this);
-        mask[aChannel / 8] &= ~(1 << (aChannel % 8));
+        mask[aChannel / 8] &= ~(0x80 >> (aChannel % 8));
     }
 
     /**
@@ -1200,7 +1201,7 @@ public:
      */
     void SetChannel(uint8_t aChannel) {
         uint8_t *mask = reinterpret_cast<uint8_t *>(this) + sizeof(*this);
-        mask[aChannel / 8] |= 1 << (aChannel % 8);
+        mask[aChannel / 8] |= 0x80 >> (aChannel % 8);
     }
 
     /**
@@ -1211,7 +1212,7 @@ public:
      */
     bool IsChannelSet(uint8_t aChannel) const {
         const uint8_t *mask = reinterpret_cast<const uint8_t *>(this) + sizeof(*this);
-        return (aChannel < (mMaskLength * 8)) ? ((mask[aChannel / 8] & (1 << (aChannel % 8))) != 0) : false;
+        return (aChannel < (mMaskLength * 8)) ? ((mask[aChannel / 8] & (0x80 >> (aChannel % 8))) != 0) : false;
     }
 
 private:
@@ -1282,7 +1283,7 @@ public:
      * @returns The Channel Mask value.
      *
      */
-    uint32_t GetMask(void) const { return Thread::Encoding::LittleEndian::HostSwap32(mMask); }
+    uint32_t GetMask(void) const { return Reverse32(HostSwap32(mMask)); }
 
     /**
      * This method sets the Channel Mask value.
@@ -1290,7 +1291,7 @@ public:
      * @param[in]  aMask  The Channel Mask value.
      *
      */
-    void SetMask(uint32_t aMask) { mMask = Thread::Encoding::LittleEndian::HostSwap32(aMask); }
+    void SetMask(uint32_t aMask) { mMask = HostSwap32(Reverse32(aMask)); }
 
 private:
     uint32_t mMask;

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -2200,10 +2200,7 @@ class OpenThread(IThci):
 
             if listChannelMask != None:
                 cmd += ' channelmask '
-                if len(listChannelMask) > 2:
-                    cmd += '0x' + self.__convertLongToString(self.__convertChannelMask(listChannelMask))
-                elif len(listChannelMask) == 2:
-                    cmd += str(hex(1 << listChannelMask[1]))
+                cmd += '0x' + self.__convertLongToString(self.__convertChannelMask(listChannelMask))
 
             if sPSKc != None or listSecurityPolicy != None or \
                xCommissioningSessionId != None or xTmfPort != None or xSteeringData != None or xBorderRouterLocator != None or \


### PR DESCRIPTION
 - Processing received channel mask bits from left-side.
 - Host swap Ticks field of Timestamp in big-endian order.
 - Set transmit frame counter for Announce message to an incrementing value.

This PR help pass the interop test cases with NXP (including 9.2.12, 9.2.14, 9.2.17, bidirection). @jwhui Please have a check first. And thanks much for @chshu 's suggestion and help to locate the issues.