### PR TITLE
New spinel properties to get the "leader" network data

### DIFF
--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -336,6 +336,8 @@ private:
     ThreadError GetPropertyHandler_THREAD_NETWORK_DATA_VERSION(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_THREAD_STABLE_NETWORK_DATA(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_THREAD_STABLE_NETWORK_DATA_VERSION(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_LEADER_NETWORK_DATA(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_THREAD_STABLE_LEADER_NETWORK_DATA(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_MAC_PROMISCUOUS_MODE(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key);

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1119,6 +1119,14 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "SPINEL_PROP_THREAD_STABLE_NETWORK_DATA";
         break;
 
+    case SPINEL_PROP_THREAD_LEADER_NETWORK_DATA:
+        ret = "SPINEL_PROP_THREAD_LEADER_NETWORK_DATA";
+        break;
+
+    case SPINEL_PROP_THREAD_STABLE_LEADER_NETWORK_DATA:
+        ret = "SPINEL_PROP_THREAD_STABLE_LEADER_NETWORK_DATA";
+        break;
+
     case SPINEL_PROP_THREAD_ON_MESH_NETS:
         ret = "SPINEL_PROP_THREAD_ON_MESH_NETS";
         break;

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -762,6 +762,18 @@ typedef enum
      */
     SPINEL_PROP_THREAD_CHILD_COUNT_MAX = SPINEL_PROP_THREAD_EXT__BEGIN + 12,
 
+    /// Leader network data
+    /** Format: `D` - Read only
+     */
+    SPINEL_PROP_THREAD_LEADER_NETWORK_DATA
+                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 13,
+
+    /// Stable leader network data
+    /** Format: `D` - Read only
+     */
+    SPINEL_PROP_THREAD_STABLE_LEADER_NETWORK_DATA
+                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 14,
+
     SPINEL_PROP_THREAD_EXT__END        = 0x1600,
 
     SPINEL_PROP_IPV6__BEGIN          = 0x60,


### PR DESCRIPTION
- Adding two new spinel properties: `THREAD_LEADER_NETWORK_DATA`
  and `THREAD_STABLE_LEADER_NETWORK_DATA` (read-only)

- Add the corresponding `GetHandler` for the two new properties
  in `NcpBase`.

- When a `OT_THREAD_NETDATA_UPDATED` event is received in `NcpBase`
  in addition  to sending `HREAD_ON_MESH_NETS` we also send the
  full leader network data (this is mainly intended for debugging).