### PR TITLE
Fix logic governing DataRequest PollTimer.

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -927,7 +927,8 @@ ThreadError MeshForwarder::SendMacDataRequest(void)
     }
     else
     {
-        mNetif.GetIp6().mMessagePool.Free(message);
+        message->Free();
+        message = NULL;
     }
 
 exit:

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -866,9 +866,35 @@ void MeshForwarder::HandlePollTimer()
 
     error = SendMacDataRequest();
 
-    if (error == kThreadError_NoBufs)
+    switch (error)
     {
+    case kThreadError_None:
+        break;
+
+    case kThreadError_InvalidState:
+        // The poll timer should have been stopped. Hitting
+        // this might indicate a logic error.
+        otLogWarnMac("Poll timer fired while RxOnWhenIdle set!");
+        break;
+
+    case kThreadError_NoBufs:
+        // Failed to send DataRequest due to a lack of buffers.
+        // Try again following a brief pause to free buffers.
         mPollTimer.Start(kDataRequstRetryDelay);
+        break;
+
+    case kThreadError_Already:
+        // This is perhaps a sign of
+        // bad behavior, as it suggests that mPollPeriod was not long
+        // enough for the previously scheduled DataRequest to get out of
+        // the sendQueue.
+        otLogDebgMac("Poll timer fired with DataRequest in SendQueue.");
+
+    // Intentional fall-thru
+    default:
+        // Restart for any other error which might originate from SendMessage().
+        mPollTimer.Start(mPollPeriod);
+        break;
     }
 }
 
@@ -890,11 +916,19 @@ ThreadError MeshForwarder::SendMacDataRequest(void)
     message = mNetif.GetIp6().mMessagePool.New(Message::kTypeMacDataPoll, 0);
     VerifyOrExit(message != NULL, error = kThreadError_NoBufs);
 
-    SuccessOrExit(error = SendMessage(*message));
-    otLogInfoMac("Sent poll");
+    error = SendMessage(*message);
 
-    // restart the polling timer
-    mPollTimer.Start(mPollPeriod);
+    if (error == kThreadError_None)
+    {
+        otLogInfoMac("Sent poll");
+
+        // restart the polling timer
+        mPollTimer.Start(mPollPeriod);
+    }
+    else
+    {
+        mNetif.GetIp6().mMessagePool.Free(message);
+    }
 
 exit:
     return error;


### PR DESCRIPTION
There were some logic issues around the DataRequest Polltimer. 
1) It was possible for the message to be leaked (not freed) if SendMessage failed.
2) It was possible for certain error cases to not restart the PollTimer.

Both of these have been fixed by this PR.