### PR TITLE
Add config option and otPlat API to govern assert behavior.

### DIFF
--- a/include/platform/misc.h
+++ b/include/platform/misc.h
@@ -80,6 +80,15 @@ typedef enum
  */
 otPlatResetReason otPlatGetResetReason(otInstance *aInstance);
 
+/**
+ * This function provides a platform specific implementation for assert.
+ *
+ * @param[in] aFilename    The name of the file where the assert occurred.
+ * @param[in] aLineNumber  The line number in the file where the assert occurred.
+ *
+ */
+void otPlatAssertFail(const char *aFilename, int aLineNumber);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/src/core/common/debug.hpp
+++ b/src/core/common/debug.hpp
@@ -34,6 +34,7 @@
 #ifndef DEBUG_HPP_
 #define DEBUG_HPP_
 
+#include <openthread-core-config.h>
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
@@ -54,6 +55,16 @@
 #elif defined(_WIN32)
 
 #include <assert.h>
+
+#elif OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT
+
+#define assert(cond)                            \
+  do {                                          \
+    if (!(cond)) {                              \
+      otPlatAssertFail(__FILE__, __LINE__);     \
+      while (1) {}                              \
+    }                                           \
+  } while (0)
 
 #else
 

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -549,4 +549,14 @@
 #define OPENTHREAD_CONFIG_NCP_SPI_BUFFER_SIZE                   1500
 #endif  // OPENTHREAD_CONFIG_NCP_SPI_BUFFER_SIZE
 
+/**
+ * @def OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT
+ *
+ * The assert is managed by platform defined logic when this flag is set.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT
+#define OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT            0
+#endif
+
 #endif  // OPENTHREAD_CORE_DEFAULT_CONFIG_H_


### PR DESCRIPTION
This change allows a platform, that otherwise lacks assert support, to implement an assert API that OT will call when it asserts.