### PR TITLE
let sed back to rxon when failed to recover previous partition after power off/on

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -460,6 +460,11 @@ ThreadError Mle::BecomeChild(otMleAttachFilter aFilter)
         mLastPartitionRouterIdSequence = mNetif.GetMle().GetRouterIdSequence();
     }
 
+    if ((mDeviceMode & ModeTlv::kModeRxOnWhenIdle) == 0)
+    {
+        mNetif.GetMeshForwarder().SetRxOnWhenIdle(true);
+    }
+
     mParentRequestTimer.Start(kParentRequestRouterTimeout);
 
 exit:


### PR DESCRIPTION
Fixed unstable 9.2.8SED on OT-OT testbed