### PR TITLE
enable mac security for fragmented mle message

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -372,6 +372,21 @@ void Message::SetSubType(uint8_t aSubType)
     mInfo.mSubType = aSubType;
 }
 
+bool Message::IsSubTypeMle(void) const
+{
+    bool rval = false;
+
+    if (mInfo.mSubType == kSubTypeMleAnnounce ||
+        mInfo.mSubType == kSubTypeMleDiscoverRequest ||
+        mInfo.mSubType == kSubTypeMleDiscoverResponse ||
+        mInfo.mSubType == kSubTypeMleGeneral)
+    {
+        rval = true;
+    }
+
+    return rval;
+}
+
 uint8_t Message::GetPriority(void) const
 {
     return mInfo.mPriority;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -215,6 +215,7 @@ public:
         kSubTypeMleDiscoverResponse = 3,  ///< MLE Discover Response
         kSubTypeJoinerEntrust       = 4,  ///< Joiner Entrust
         kSubTypeMplRetransmission   = 5,  ///< MPL next retranmission message
+        kSubTypeMleGeneral          = 6,  ///< General MLE
     };
 
     enum
@@ -319,6 +320,15 @@ public:
      *
      */
     void SetSubType(uint8_t aSubType);
+
+    /**
+     * This method returns whether or not the message is of MLE subtype.
+     *
+     * @retval TRUE   If message is of MLE subtype.
+     * @retval FLASE  If message is not of MLE subtype.
+     *
+     */
+    bool IsSubTypeMle(void) const;
 
     /**
      * This method returns the message priority level.

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1259,7 +1259,7 @@ ThreadError MeshForwarder::SendFragment(Message &aMessage, Mac::Frame &aFrame)
 
         if (payloadLength > fragmentLength)
         {
-            if (!aMessage.IsLinkSecurityEnabled())
+            if ((!aMessage.IsLinkSecurityEnabled()) && aMessage.IsSubTypeMle())
             {
                 aMessage.SetLinkSecurityEnabled(true);
                 aMessage.SetOffset(0);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -882,6 +882,7 @@ Message *Mle::NewMleMessage(void)
     message = mSocket.NewMessage(0);
     VerifyOrExit(message != NULL, ;);
 
+    message->SetSubType(Message::kSubTypeMleGeneral);
     message->SetLinkSecurityEnabled(false);
     message->SetPriority(kMleMessagePriority);
 


### PR DESCRIPTION
To fix [DEV-1275](https://threadgroup.atlassian.net/browse/DEV-1275)

According to Thread spec 1.1.0, chapter 4.9: 
MLE messages that fit within a single 802.15.4 frame MUST NOT use 802.15.4 security. MLE messages that require fragmentation by 6LoWPAN MUST use 802.15.4 security. 