### PR TITLE
THCI: Commit with new assigned Activetimestamp if any instead of default value.

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -2353,8 +2353,6 @@ class OpenThread(IThci):
 
             if xCommissionerSessionId != None:
                 cmd += ' binary '
-
-            if xCommissionerSessionId != None:
                 cmd += '0b02'
                 sessionid = str(hex(xCommissionerSessionId))[2:]
 
@@ -2454,6 +2452,7 @@ class OpenThread(IThci):
     def setActiveTimestamp(self, xActiveTimestamp):
         print '%s call setActiveTimestamp' % self.port
         try:
+            self.activetimestamp = xActiveTimestamp
             cmd = 'dataset activetimestamp %s' % str(xActiveTimestamp)
             self.hasActiveDatasetToCommit = True
             return self.__sendCommand(cmd)[0] == 'Done'


### PR DESCRIPTION
This PR help pass Router-9.2.11 detected this morning. In this case, harness assigns a new timestamp before call `setDefaultValue`, the final timestamp will be overwrote by the default value. Harness will check the new value. Please have a check.