### PR TITLE
Fix commissioning problem due to retransmissions

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -50,6 +50,7 @@ set -x
 [ $BUILD_TARGET != arm-gcc49 ] || {
     export PATH=/tmp/gcc-arm-none-eabi-4_9-2015q3/bin:$PATH || die
 
+    git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
     COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 make -f examples/Makefile-cc2538 || die
@@ -57,6 +58,7 @@ set -x
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-mtd || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp || die
 
+    git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
     COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 make -f examples/Makefile-da15000 || die
@@ -64,6 +66,7 @@ set -x
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-mtd || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp || die
 
+    git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
     COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 make -f examples/Makefile-nrf52840 || die
@@ -75,6 +78,7 @@ set -x
 [ $BUILD_TARGET != arm-gcc54 ] || {
     export PATH=/tmp/gcc-arm-none-eabi-5_4-2016q3/bin:$PATH || die
 
+    git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
     COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 make -f examples/Makefile-cc2538 || die
@@ -82,6 +86,7 @@ set -x
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-mtd || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp || die
 
+    git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
     COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 make -f examples/Makefile-da15000 || die
@@ -89,6 +94,7 @@ set -x
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-mtd || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp || die
 
+    git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
     COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 make -f examples/Makefile-nrf52840 || die

--- a/third_party/mbedtls/Makefile.am
+++ b/third_party/mbedtls/Makefile.am
@@ -71,6 +71,26 @@ libmbedcrypto_a_SOURCES                      += \
     repo/library/ssl_ticket.c                   \
     repo/library/ssl_tls.c                      \
     $(NULL)
+
+EXTRA_DIST                                                         += \
+    patch/0001-Fix-commissioning-problem-with-retransmissions.patch   \
+    $(NULL)
+    
+BUILT_SOURCES                                 = \
+    $(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched \
+    $(NULL)
+
+$(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched: $(abs_top_srcdir)/third_party/mbedtls/patch/0001-Fix-commissioning-problem-with-retransmissions.patch
+	chmod u+w $(abs_top_srcdir)/third_party/mbedtls/repo/library/
+	chmod u+w $(abs_top_srcdir)/third_party/mbedtls/repo/library/ssl_tls.c
+	if [ -e $@ ]; then patch -R $(abs_top_srcdir)/third_party/mbedtls/repo/library/ssl_tls.c $@; fi
+	patch $(abs_top_srcdir)/third_party/mbedtls/repo/library/ssl_tls.c $<
+	cp $(abs_top_srcdir)/third_party/mbedtls/patch/0001-Fix-commissioning-problem-with-retransmissions.patch $@
+
+all-local: libmbedcrypto.a
+	patch -R $(abs_top_srcdir)/third_party/mbedtls/repo/library/ssl_tls.c $(abs_top_srcdir)/third_party/mbedtls/patch/0001-Fix-commissioning-problem-with-retransmissions.patch
+	rm -f $(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched
+
 endif  # OPENTHREAD_ENABLE_DTLS
 
 if OPENTHREAD_BUILD_COVERAGE

--- a/third_party/mbedtls/patch/0001-Fix-commissioning-problem-with-retransmissions.patch
+++ b/third_party/mbedtls/patch/0001-Fix-commissioning-problem-with-retransmissions.patch
@@ -1,0 +1,39 @@
+diff --git a/third_party/mbedtls/repo/library/ssl_tls.c b/third_party/mbedtls/repo/library/ssl_tls.c
+index 84a04ae..2153c80 100644
+--- a/third_party/mbedtls/repo/library/ssl_tls.c
++++ b/third_party/mbedtls/repo/library/ssl_tls.c
+@@ -3608,6 +3608,24 @@ static int ssl_parse_record_header( mbedtls_ssl_context *ssl )
+                                         "expected %d, received %d",
+                                         ssl->in_epoch, rec_epoch ) );
+ 
++#if defined(MBEDTLS_SSL_SRV_C)
++            /*
++             * Check for an epoch 0 Change Cipher Spec retransmission.
++             */
++            if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER &&
++                ssl->state == MBEDTLS_SSL_HANDSHAKE_OVER &&
++                rec_epoch == 0 &&
++                ssl->in_epoch == 1 &&
++                ssl->in_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE &&
++                ssl->in_left > 13 &&
++                ssl->in_buf[13] == MBEDTLS_SSL_HS_CLIENT_KEY_EXCHANGE )
++            {
++                MBEDTLS_SSL_DEBUG_MSG( 1, ( "possible Client Key Exchange "
++                                            "retransmission" ) );
++                return( mbedtls_ssl_resend( ssl ) );
++            }
++#endif
++
+ #if defined(MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE) && defined(MBEDTLS_SSL_SRV_C)
+             /*
+              * Check for an epoch 0 ClientHello. We can't use in_msg here to
+@@ -3737,7 +3755,8 @@ int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl )
+ 
+         ret = mbedtls_ssl_handle_message_type( ssl );
+ 
+-    } while( MBEDTLS_ERR_SSL_NON_FATAL == ret );
++    } while( MBEDTLS_ERR_SSL_NON_FATAL == ret ||
++             ( MBEDTLS_ERR_SSL_WANT_READ == ret && ssl->in_msglen ) );
+ 
+     if( 0 != ret )
+     {


### PR DESCRIPTION
We had a commissioning problem on a nrf52 chip.

nrf52 802.15.4 driver is running from IRQ context and it uses the rx queue. That's why it queues all retransmitted messages during commissioning procedure. Probably you didn't notice this problem using TI, because it's driver does not have rx queues and it drops DTLS retransmissions during commissioning procedure.

We didn't implement crypto hardware acceleration in nrf52 driver yet and some procedures take more than 8 seconds.

Because of that typical commissioning procedure looks like following diagram:
```
    Joiner                        Commissioner
(1) |      Client Hello           |
    |---------------------------->|
    |                             |
(2) |      Hello Verify Request   |
    |<----------------------------|
    |                             |
(3) |      Client Hello           |
    |---------------------------->|
8 s |                             |
(4) |      Client Hello           |  retransmission
    |---------------------------->|
    |                             |
(5) |      Server Hello           |
    |      Server Key Exchange    |
    |      Server Hello Done      |
    |<----------------------------|
    |                             |
(6) |      Server Hello           |  response to retransmission
    |      Server Key Exchange    |
    |      Server Hello Done      |
    |<----------------------------|
8 s |                             |
(7) |      Server Hello           |  retransmission
    |      Server Key Exchange    |
    |      Server Hello Done      |
    |<----------------------------|
    |                             |
(8) |      Client Key Exchange    |
    |      Change Cipher Spec     |
    | Encrypted Handshake Message |
    |---------------------------->|
    |                             |
(9) |      Change Cipher Spec     |
    | Encrypted Handshake Message |
    |      Application Data       |
    |<----------------------------|
    |                             |
(10)|      Client Key Exchange    |  retransmission
    |      Change Cipher Spec     |
    | Encrypted Handshake Message |
    |---------------------------->|
```

We found 2 problems:
1. Joiner queues retransmissions (6) and (7) during reply (8) preparation. After message flight (8) is sent Joiner receives queued retransmissions, but it removes only 1 record from it's queue (instead of all 6 records: (6) - Server Hello, (6) - Server Key Exchange, (6) - Server Hello Done, (7) - Server Hello, (7) - Server Key Exchange, (7) - Server Hello Done). When Joiner receives (9) it cannot parse it due to old records in the queue.
2. Commissioner does not retransmit message flight (9) when it receives retransmission (10). According to RFC 6347: 4.2.4 it should retransmit to avoid dead lock.

This PR solves both problems. And it makes commissioning procedure robust.