### PR TITLE
NcpBase: Counter for out of order received spinel frames

### DIFF
--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -518,6 +518,8 @@ private:
 
     uint16_t mDroppedReplyTidBitSet;
 
+    spinel_tid_t mNextExpectedTid;
+
     bool mAllowLocalNetworkDataChange;
     bool mRequireJoinExistingNetwork;
     bool mIsRawStreamEnabled;
@@ -525,6 +527,7 @@ private:
 
     uint32_t mFramingErrorCounter;             // Number of improperly formed received spinel frames.
     uint32_t mRxSpinelFrameCounter;            // Number of received (inbound) spinel frames.
+    uint32_t mRxSpinelOutOfOrderTidCounter;    // Number of out of order received spinel frames (tid increase > 1).
     uint32_t mTxSpinelFrameCounter;            // Number of sent (outbound) spinel frames.
     uint32_t mInboundSecureIpFrameCounter;     // Number of secure inbound data/IP frames.
     uint32_t mInboundInsecureIpFrameCounter;   // Number of insecure inbound data/IP frames.

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -1019,7 +1019,10 @@ typedef enum
     /** Format: `L` (Read-only) */
     SPINEL_PROP_CNTR_RX_SPINEL_ERR     = SPINEL_PROP_CNTR__BEGIN + 302,
 
-
+    /// Number of out of order received spinel frames (tid increase by more than 1).
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_SPINEL_OUT_OF_ORDER_TID
+                                       = SPINEL_PROP_CNTR__BEGIN + 303,
 
     /// The message buffer counter info
     /** Format: `T(SSSSSSSSSSSSSSSS)` (Read-only)


### PR DESCRIPTION
- Adds a new NCP counter to indicate the number of times the
  received `tid` in spinel frames jumps by more than 1. This is
  intended to track dropped (inbound) spinel frames.