### PR TITLE
Hdlc: Remove unused include file "message.h"

### DIFF
--- a/src/ncp/hdlc.cpp
+++ b/src/ncp/hdlc.cpp
@@ -30,6 +30,7 @@
  *   This file implements an HDLC-lite encoder and decoder.
  */
 
+#include <stdlib.h>
 #include <common/code_utils.hpp>
 #include <ncp/hdlc.hpp>
 

--- a/src/ncp/hdlc.hpp
+++ b/src/ncp/hdlc.hpp
@@ -34,7 +34,6 @@
 #define HDLC_HPP_
 
 #include <openthread-types.h>
-#include <common/message.hpp>
 
 namespace Thread {
 


### PR DESCRIPTION
(need to include <stdlib.h> to get the definition of `NULL`)