### PR TITLE
Fix mbedtls patch build on mac os.

### DIFF
--- a/third_party/mbedtls/Makefile.am
+++ b/third_party/mbedtls/Makefile.am
@@ -72,24 +72,30 @@ libmbedcrypto_a_SOURCES                      += \
     repo/library/ssl_tls.c                      \
     $(NULL)
 
+#
+# mbedtls patches
+#
+
+MBEDTLS_ABS_SRCDIR                           := $(abspath $(top_srcdir)/third_party/mbedtls)
+
 EXTRA_DIST                                                         += \
     patch/0001-Fix-commissioning-problem-with-retransmissions.patch   \
     $(NULL)
-    
+
 repo/library/libmbedcrypto_a-ssl_tls.$(OBJEXT): $(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched
 
-$(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched: $(abs_top_srcdir)/third_party/mbedtls/patch/0001-Fix-commissioning-problem-with-retransmissions.patch
-	chmod u+w $(abs_top_srcdir)/third_party/mbedtls/repo/library/
-	chmod u+w $(abs_top_srcdir)/third_party/mbedtls/repo/library/ssl_tls.c
-	if [ -e $@ ]; then patch -R $(abs_top_srcdir)/third_party/mbedtls/repo/library/ssl_tls.c $@; fi
-	patch $(abs_top_srcdir)/third_party/mbedtls/repo/library/ssl_tls.c $<
-	cp $(abs_top_srcdir)/third_party/mbedtls/patch/0001-Fix-commissioning-problem-with-retransmissions.patch $@
+$(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched: $(MBEDTLS_ABS_SRCDIR)/patch/0001-Fix-commissioning-problem-with-retransmissions.patch
+	chmod u+w $(MBEDTLS_ABS_SRCDIR)/repo/library/
+	chmod u+w $(MBEDTLS_ABS_SRCDIR)/repo/library/ssl_tls.c
+	if [ -e $@ ]; then patch -R $(MBEDTLS_ABS_SRCDIR)/repo/library/ssl_tls.c $@; fi
+	patch $(MBEDTLS_ABS_SRCDIR)/repo/library/ssl_tls.c $<
+	cp $(MBEDTLS_ABS_SRCDIR)/patch/0001-Fix-commissioning-problem-with-retransmissions.patch $@
 
 all-local: libmbedcrypto.a
-	if [ -e $(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched ]; then patch -R $(abs_top_srcdir)/third_party/mbedtls/repo/library/ssl_tls.c $(abs_top_srcdir)/third_party/mbedtls/patch/0001-Fix-commissioning-problem-with-retransmissions.patch; rm -f $(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched; fi
+	if [ -e $(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched ]; then patch -R $(MBEDTLS_ABS_SRCDIR)/repo/library/ssl_tls.c $(MBEDTLS_ABS_SRCDIR)/patch/0001-Fix-commissioning-problem-with-retransmissions.patch; rm -f $(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched; fi
 
 clean-local:
-	if [ -e $(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched ]; then patch -R $(abs_top_srcdir)/third_party/mbedtls/repo/library/ssl_tls.c $(abs_top_srcdir)/third_party/mbedtls/patch/0001-Fix-commissioning-problem-with-retransmissions.patch; rm -f $(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched; fi
+	if [ -e $(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched ]; then patch -R $(MBEDTLS_ABS_SRCDIR)/repo/library/ssl_tls.c $(MBEDTLS_ABS_SRCDIR)/patch/0001-Fix-commissioning-problem-with-retransmissions.patch; rm -f $(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched; fi
 
 endif  # OPENTHREAD_ENABLE_DTLS
 


### PR DESCRIPTION
- `patch` on Mac OS does not allow '..' components in the file path.