### PR TITLE
#include misc.h for otPlatAssertFail.

### DIFF
--- a/src/core/common/debug.hpp
+++ b/src/core/common/debug.hpp
@@ -58,6 +58,8 @@
 
 #elif OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT
 
+#include <platform/misc.h>
+
 #define assert(cond)                            \
   do {                                          \
     if (!(cond)) {                              \


### PR DESCRIPTION
Needed to add a #include to resolve the call to otPlatAssertFail.