### PR TITLE
Use correct destination address in CoAP responses.

### DIFF
--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -109,7 +109,6 @@ ThreadError Leader::SendPetitionResponse(const Coap::Header &aRequestHeader, con
     StateTlv state;
     CommissionerSessionIdTlv sessionId;
     Message *message;
-    Ip6::MessageInfo responseInfo(aMessageInfo);
 
     VerifyOrExit((message = mNetif.GetCoapServer().NewMeshCoPMessage(0)) != NULL, error = kThreadError_NoBufs);
 
@@ -135,8 +134,7 @@ ThreadError Leader::SendPetitionResponse(const Coap::Header &aRequestHeader, con
         SuccessOrExit(error = message->Append(&sessionId, sizeof(sessionId)));
     }
 
-    memset(&responseInfo.mSockAddr, 0, sizeof(responseInfo.mSockAddr));
-    SuccessOrExit(error = mNetif.GetCoapServer().SendMessage(*message, responseInfo));
+    SuccessOrExit(error = mNetif.GetCoapServer().SendMessage(*message, aMessageInfo));
 
     otLogInfoMeshCoP("sent petition response");
 
@@ -201,7 +199,6 @@ ThreadError Leader::SendKeepAliveResponse(const Coap::Header &aRequestHeader, co
     Coap::Header responseHeader;
     StateTlv state;
     Message *message;
-    Ip6::MessageInfo responseInfo(aMessageInfo);
 
     VerifyOrExit((message = mNetif.GetCoapServer().NewMeshCoPMessage(0)) != NULL, error = kThreadError_NoBufs);
 
@@ -214,7 +211,6 @@ ThreadError Leader::SendKeepAliveResponse(const Coap::Header &aRequestHeader, co
     state.SetState(aState);
     SuccessOrExit(error = message->Append(&state, sizeof(state)));
 
-    memset(&responseInfo.mSockAddr, 0, sizeof(responseInfo.mSockAddr));
     SuccessOrExit(error = mNetif.GetCoapServer().SendMessage(*message, aMessageInfo));
 
     otLogInfoMeshCoP("sent keep alive response");

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -219,7 +219,6 @@ void AddressResolver::HandleAddressNotification(Coap::Header &aHeader, Message &
     ThreadRloc16Tlv rloc16Tlv;
     ThreadLastTransactionTimeTlv lastTransactionTimeTlv;
     uint32_t lastTransactionTime;
-    Ip6::MessageInfo responseInfo(aMessageInfo);
 
     VerifyOrExit(aHeader.GetType() == kCoapTypeConfirmable &&
                  aHeader.GetCode() == kCoapRequestPost, ;);
@@ -278,8 +277,6 @@ void AddressResolver::HandleAddressNotification(Coap::Header &aHeader, Message &
             mCache[i].mTimeout = 0;
             mCache[i].mFailures = 0;
             mCache[i].mState = Cache::kStateCached;
-
-            memset(&responseInfo.mSockAddr, 0, sizeof(responseInfo.mSockAddr));
 
             if (mNetif.GetCoapServer().SendEmptyAck(aHeader, aMessageInfo) == kThreadError_None)
             {
@@ -359,7 +356,6 @@ void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessag
     uint8_t numChildren;
     Mac::ExtAddress macAddr;
     Ip6::Address destination;
-    Ip6::MessageInfo responseInfo(aMessageInfo);
 
     VerifyOrExit(aHeader.GetType() == kCoapTypeConfirmable &&
                  aHeader.GetCode() == kCoapRequestPost, error = kThreadError_Drop);
@@ -368,9 +364,7 @@ void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessag
 
     if (!aMessageInfo.GetSockAddr().IsMulticast())
     {
-        memset(&responseInfo.mSockAddr, 0, sizeof(responseInfo.mSockAddr));
-
-        if (mNetif.GetCoapServer().SendEmptyAck(aHeader, responseInfo) == kThreadError_None)
+        if (mNetif.GetCoapServer().SendEmptyAck(aHeader, aMessageInfo) == kThreadError_None)
         {
             otLogInfoArp("Sent address error notification acknowledgment");
         }

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -367,7 +367,6 @@ void Leader::SendCommissioningSetResponse(const Coap::Header &aRequestHeader, co
     Coap::Header responseHeader;
     Message *message;
     MeshCoP::StateTlv state;
-    Ip6::MessageInfo responseInfo(aMessageInfo);
 
     VerifyOrExit((message = mNetif.GetCoapServer().NewMeshCoPMessage(0)) != NULL, error = kThreadError_NoBufs);
 
@@ -380,8 +379,7 @@ void Leader::SendCommissioningSetResponse(const Coap::Header &aRequestHeader, co
     state.SetState(aState);
     SuccessOrExit(error = message->Append(&state, sizeof(state)));
 
-    memset(&responseInfo.mSockAddr, 0, sizeof(responseInfo.mSockAddr));
-    SuccessOrExit(error = mNetif.GetCoapServer().SendMessage(*message, responseInfo));
+    SuccessOrExit(error = mNetif.GetCoapServer().SendMessage(*message, aMessageInfo));
 
     otLogInfoMeshCoP("sent commissioning dataset set response");
 


### PR DESCRIPTION
This PR fixes #1222 .
CoAP uses copy of request destination address as response source address. In case it is a multicast or anycast address (not allowed as source address) source selection algorithm is used.