### PR TITLE
Fix SED energy detection in nrf52840 platform.

### DIFF
--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -420,13 +420,14 @@ ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, u
     sEnergyDetectionTime    = (uint32_t) aScanDuration * 1000UL;
     sEnergyDetectionChannel = aScanChannel;
 
+    clearPendingEvents();
+
     if (nrf_drv_radio802154_energy_detection(aScanChannel, sEnergyDetectionTime))
     {
-        clearPendingEvents();
+        resetPendingEvent(kPendingEventEnergyDetectionStart);
     }
     else
     {
-        clearPendingEvents();
         setPendingEvent(kPendingEventEnergyDetectionStart);
     }
 


### PR DESCRIPTION
This PR allows energy detection in nrf52840 platform when the radio driver is in the SLEEP state.
Also it fixes setting child timeout value in SED devices.