### PR TITLE
`MeshForwarder`: Handle the error case `kThreadError_Abort`

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1511,6 +1511,7 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, ThreadError aError)
             break;
 
         case kThreadError_ChannelAccessFailure:
+        case kThreadError_Abort:
             break;
 
         case kThreadError_NoAck:


### PR DESCRIPTION
- Change the `HandleSentFrame()` to include and handle the error
  case of `kThreadError_Abort`.