### PR TITLE
Allow SED to reattach to it's parent if the link was lost before timeout.

### DIFF
--- a/include/openthread.h
+++ b/include/openthread.h
@@ -1028,6 +1028,9 @@ OTAPI ThreadError OTCALL otSendPendingSet(otInstance *aInstance, const otOperati
 /**
  * Get the data poll period of sleepy end device.
  *
+ * @note This function updates only poll period of sleepy end device. To update child timeout the function
+ *       otGetChildTimeout() shall be called.
+ *
  * @param[in]  aInstance A pointer to an OpenThread instance.
  *
  * @returns  The data poll period of sleepy end device.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1670,7 +1670,16 @@ ThreadError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::M
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kChallenge, sizeof(challenge), challenge));
     VerifyOrExit(challenge.IsValid(), error = kThreadError_Parse);
 
-    if ((child = FindChild(macAddr)) == NULL)
+    child = FindChild(macAddr);
+
+    if (child != NULL && !(child->mMode & ModeTlv::kModeFFD))
+    {
+        // Parent Request from a MTD child means that the child had detached. It can be safely removed.
+        RemoveNeighbor(*child);
+        child = NULL;
+    }
+
+    if (child == NULL)
     {
         VerifyOrExit((child = NewChild()) != NULL, ;);
 


### PR DESCRIPTION
SED could not reattach to it's parent, because parent queued Parent Response message in the indirect queue. With this PR Parent Response is sent directly and Child Id Response is sent correctly using indirect queue.