### PR TITLE
Ignore Exceptions While Parsing Frames

### DIFF
--- a/tests/scripts/thread-cert/sniffer.py
+++ b/tests/scripts/thread-cert/sniffer.py
@@ -80,11 +80,18 @@ class Sniffer:
         while self._thread_alive.is_set():
             data, nodeid = self._transport.recv(self.RECV_BUFFER_SIZE)
 
-            msg = self._message_factory.create(io.BytesIO(data))
+            # Ignore any exceptions
+            try:
+                msg = self._message_factory.create(io.BytesIO(data))
 
-            if msg is not None:
-                self.logger.debug("Received message: {}".format(msg))
-                self._buckets[nodeid].put(msg)
+                if msg is not None:
+                    self.logger.debug("Received message: {}".format(msg))
+                    self._buckets[nodeid].put(msg)
+
+            except Exception as e:
+                # Just print the exception to the console
+                print("EXCEPTION: %s" % e)
+                pass
 
         self.logger.debug("Sniffer stopped.")
 


### PR DESCRIPTION
This change is related to #1146. This updates `sniffer.py` to not crash if it encounters a packet that it can't parse. It just prints the exception string to the console. I get the following output currently when running the first Cert test:

```
Could not find specialized factory to parse ICMP body. Take the default one: <class 'ipv6.BytesPayloadFactory'>
EXCEPTION: Could not find HopByHopOption value factory for type=5.
EXCEPTION: Could not find HopByHopOption value factory for type=5.
ActiveOperationalDataset is not implemented yet.
Could not find specialized factory to parse ICMP body. Take the default one: <class 'ipv6.BytesPayloadFactory'>
EXCEPTION: Could not find HopByHopOption value factory for type=5.
EXCEPTION: Could not find HopByHopOption value factory for type=5.
EXCEPTION: Could not find HopByHopOption value factory for type=5.
EXCEPTION: Could not find HopByHopOption value factory for type=5.
EXCEPTION: Could not find HopByHopOption value factory for type=5.
Could not find specialized factory to parse ICMP body. Take the default one: <class 'ipv6.BytesPayloadFactory'>
Could not find specialized factory to parse ICMP body. Take the default one: <class 'ipv6.BytesPayloadFactory'>
MleMessage doesn't contain optional TLV: <class 'mle.MleFrameCounter'>
MleMessage doesn't contain optional TLV: <class 'mle.MleFrameCounter'>
MleMessage doesn't contain optional TLV: <class 'mle.NetworkData'>
MleMessage doesn't contain optional TLV: <class 'mle.Route64'>
MleMessage doesn't contain optional TLV: <class 'mle.AddressRegistration'>
CoapMessage doesn't contain optional TLV: <class 'network_layer.RouterMask'>
MleMessage doesn't contain optional TLV: <class 'mle.MleFrameCounter'>
MleMessage doesn't contain optional TLV: <class 'mle.Challenge'>
EXCEPTION: Could not find factory to build UDP payload.
EXCEPTION: Could not find factory to build UDP payload.
```

I believe these exceptions should still be fixed and somehow correctly handled, but this is the best way to unblock the Windows testing right now. #1146 still tracks fixing the actual exceptions.