### PR TITLE
Cleanup to detach process.

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -472,10 +472,7 @@ ThreadError Mle::BecomeChild(otMleAttachFilter aFilter)
         mLastPartitionRouterIdSequence = mNetif.GetMle().GetRouterIdSequence();
     }
 
-    if ((mDeviceMode & ModeTlv::kModeRxOnWhenIdle) == 0)
-    {
-        mNetif.GetMeshForwarder().SetRxOnWhenIdle(true);
-    }
+    mNetif.GetMeshForwarder().SetRxOnWhenIdle(true);
 
     mParentRequestTimer.Start(kParentRequestRouterTimeout);
 
@@ -512,7 +509,7 @@ ThreadError Mle::SetStateDetached(void)
     mDeviceState = kDeviceStateDetached;
     mParentRequestState = kParentIdle;
     mParentRequestTimer.Stop();
-    mNetif.GetMeshForwarder().SetRxOnWhenIdle(true);
+    mNetif.GetMeshForwarder().SetRxOnWhenIdle(false);
     mNetif.GetMle().HandleDetachStart();
     mNetif.GetIp6().SetForwardingEnabled(false);
     mNetif.GetIp6().mMpl.SetTimerExpirations(0);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -222,6 +222,7 @@ ThreadError MleRouter::BecomeRouter(ThreadStatusTlv::Status aStatus)
 
     mAdvertiseTimer.Stop();
     mNetif.GetAddressResolver().Clear();
+    mNetif.GetMeshForwarder().SetRxOnWhenIdle(true);
     mRouterSelectionJitterTimeout = 0;
 
     switch (mDeviceState)
@@ -1385,7 +1386,7 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
 
             if (mParent.mValid.mRloc16 != sourceAddress.GetRloc16())
             {
-                SetStateDetached();
+                BecomeDetached();
                 ExitNow(error = kThreadError_NoRoute);
             }
 
@@ -1738,8 +1739,7 @@ void MleRouter::HandleStateUpdateTimer(void)
         break;
 
     case kDeviceStateDetached:
-        SetStateDetached();
-        BecomeChild(kMleAttachAnyPartition);
+        BecomeDetached();
         ExitNow();
 
     case kDeviceStateChild:


### PR DESCRIPTION
- Set radio to rx-off-when-idle when entering detached state.
- Set radio to rx-on-when-idle when entering router state.
- Prefer use of `BecomeDetached()` rather than `SetStateDetached()`.