### PR TITLE
Add new mac counter `mTxErrAbort` to track number of tx abort failures.

### DIFF
--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -855,6 +855,7 @@ typedef struct otMacCounters
     uint32_t mTxOther;                ///< The number of transmitted other types of frames.
     uint32_t mTxRetry;                ///< The number of retransmission times.
     uint32_t mTxErrCca;               ///< The number of CCA failure times.
+    uint32_t mTxErrAbort;             ///< The number of frame transmission failures due to abort error.
     uint32_t mRxTotal;                ///< The total number of received packets.
     uint32_t mRxUnicast;              ///< The total number of unicast packets received.
     uint32_t mRxBroadcast;            ///< The total number of broadcast packets received.

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -845,6 +845,10 @@ void Mac::TransmitDoneTask(RadioPacket *aPacket, bool aRxPending, ThreadError aE
         mCounters.mTxUnicast++;
     }
 
+    if (aError == kThreadError_Abort)
+    {
+        mCounters.mTxErrAbort++;
+    }
 
     if (!RadioSupportsRetriesAndCsmaBackoff() &&
         aError == kThreadError_ChannelAccessFailure &&

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -192,6 +192,7 @@ const NcpBase::GetPropertyHandlerEntry NcpBase::mGetPropertyHandlerTable[] =
     { SPINEL_PROP_CNTR_TX_PKT_UNICAST, &NcpBase::GetPropertyHandler_MAC_CNTR },
     { SPINEL_PROP_CNTR_TX_PKT_BROADCAST, &NcpBase::GetPropertyHandler_MAC_CNTR },
     { SPINEL_PROP_CNTR_TX_ERR_CCA, &NcpBase::GetPropertyHandler_MAC_CNTR },
+    { SPINEL_PROP_CNTR_TX_ERR_ABORT, &NcpBase::GetPropertyHandler_MAC_CNTR },
     { SPINEL_PROP_CNTR_RX_PKT_TOTAL, &NcpBase::GetPropertyHandler_MAC_CNTR },
     { SPINEL_PROP_CNTR_RX_PKT_DATA, &NcpBase::GetPropertyHandler_MAC_CNTR },
     { SPINEL_PROP_CNTR_RX_PKT_DATA_POLL, &NcpBase::GetPropertyHandler_MAC_CNTR },
@@ -2799,6 +2800,10 @@ ThreadError NcpBase::GetPropertyHandler_MAC_CNTR(uint8_t header, spinel_prop_key
 
     case SPINEL_PROP_CNTR_TX_PKT_BROADCAST:
         value = macCounters->mTxBroadcast;
+        break;
+
+    case SPINEL_PROP_CNTR_TX_ERR_ABORT:
+        value = macCounters->mTxErrAbort;
         break;
 
     case SPINEL_PROP_CNTR_RX_PKT_TOTAL:

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -916,6 +916,10 @@ typedef enum
     /** Format: `L` (Read-only) */
     SPINEL_PROP_CNTR_TX_PKT_BROADCAST  = SPINEL_PROP_CNTR__BEGIN + 13,
 
+    /// The number of frame transmission failures due to abort error.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_ERR_ABORT      = SPINEL_PROP_CNTR__BEGIN + 14,
+
     /// The total number of received packets.
     /** Format: `L` (Read-only) */
     SPINEL_PROP_CNTR_RX_PKT_TOTAL      = SPINEL_PROP_CNTR__BEGIN + 100,


### PR DESCRIPTION
- Defines a new mac counter to track number of frame transmission
  failures due to abort error `kThreadError_Abort`.

- Adds a corresponding spinel property `CNTR_TX_ERR_ABORT` and its
  get handler.