### PR TITLE
Remove external unicast/multicast addresses on `ThreadNetif::Down()`

### DIFF
--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -291,6 +291,20 @@ exit:
     return error;
 }
 
+void Netif::UnsubscribeAllExternalMulticastAddresses(void)
+{
+    size_t num = sizeof(mExtMulticastAddresses) / sizeof(mExtMulticastAddresses[0]);
+
+    for (NetifMulticastAddress *entry = &mExtMulticastAddresses[0]; num > 0; num--, entry++)
+    {
+        // In unused entries, the `mNext` points back to the entry itself.
+        if (entry->mNext != entry)
+        {
+            UnsubscribeExternalMulticast(*static_cast<Address *>(&entry->mAddress));
+        }
+    }
+}
+
 bool Netif::IsMulticastPromiscuousModeEnabled(void)
 {
     return mMulticastPromiscuousMode;
@@ -448,6 +462,20 @@ exit:
     return error;
 }
 
+void Netif::RemoveAllExternalUnicastAddresses(void)
+{
+    size_t num = sizeof(mExtUnicastAddresses) / sizeof(mExtUnicastAddresses[0]);
+
+    for (NetifUnicastAddress *entry = &mExtUnicastAddresses[0]; num > 0; num--, entry++)
+    {
+        // In unused entries, the `mNext` points back to the entry itself.
+        if (entry->mNext != entry)
+        {
+            RemoveExternalUnicastAddress(*static_cast<Address *>(&entry->mAddress));
+        }
+    }
+}
+
 bool Netif::IsUnicastAddress(const Address &aAddress) const
 {
     bool rval = false;
@@ -463,7 +491,6 @@ bool Netif::IsUnicastAddress(const Address &aAddress) const
 exit:
     return rval;
 }
-
 
 bool Netif::IsStateChangedCallbackPending(void)
 {

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -341,6 +341,13 @@ public:
     ThreadError RemoveExternalUnicastAddress(const Address &aAddress);
 
     /**
+     * This method removes all the previously added external (to OpenThread) unicast addresses from the
+     * network interface.
+     *
+     */
+    void RemoveAllExternalUnicastAddresses(void);
+
+    /**
      * This method indicates whether or not an address is assigned to this interface.
      *
      * @param[in]  aAddress  A reference to the unicast address.
@@ -417,7 +424,7 @@ public:
     ThreadError SubscribeExternalMulticast(const Address &aAddress);
 
     /**
-     * This method ussubscribes the network interface to the external (to OpenThread) multicast address.
+     * This method unsubscribes the network interface to the external (to OpenThread) multicast address.
      *
      * @param[in]  aAddress  A reference to the multicast address.
      *
@@ -427,6 +434,12 @@ public:
      *
      */
     ThreadError UnsubscribeExternalMulticast(const Address &aAddress);
+
+    /**
+     * This method unsubscribes the network interface from all previously added external (to OpenThread) multicast
+     * addresses.
+     */
+    void UnsubscribeAllExternalMulticastAddresses(void);
 
     /**
      * This method checks if multicast promiscuous mode is enabled on the network interface.

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -126,6 +126,8 @@ ThreadError ThreadNetif::Down(void)
     mMleRouter.Disable();
     mMeshForwarder.Stop();
     mIp6.RemoveNetif(*this);
+    RemoveAllExternalUnicastAddresses();
+    UnsubscribeAllExternalMulticastAddresses();
     mIsUp = false;
 
 #if OPENTHREAD_ENABLE_DTLS


### PR DESCRIPTION
- This commit adds new methods to `Netif` to remove all previously
  added external (to OpenThread) unicast or multicast addresses.

- The new methods are used to remove all such addresses when the
  thread interface is brought down.