### PR TITLE
New ot API to set a message to always use direct tx

### DIFF
--- a/include/openthread-message.h
+++ b/include/openthread-message.h
@@ -178,6 +178,17 @@ ThreadError otSetMessageOffset(otMessage aMessage, uint16_t aOffset);
 bool otIsMessageLinkSecurityEnabled(otMessage aMessage);
 
 /**
+ * This function sets/forces the message to be forwarded using direct transmission.
+ * Default setting for a new message is `false`.
+ *
+ * @param[in]  aMessage  A pointer to a message buffer.
+ * @param[in]  aEnabled  If `true` message will be forced to use direct transmission. If `false` message will
+ *                       follow the normal procedure.
+ *
+ */
+void otMessageSetDirectTransmission(otMessage aMessage, bool aEnabled);
+
+/**
  * Append bytes to a message.
  *
  * @param[in]  aMessage  A pointer to a message buffer.

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -1509,6 +1509,20 @@ bool otIsMessageLinkSecurityEnabled(otMessage aMessage)
     return message->IsLinkSecurityEnabled();
 }
 
+void otMessageSetDirectTransmission(otMessage aMessage, bool aEnabled)
+{
+    Message *message = static_cast<Message *>(aMessage);
+
+    if (aEnabled)
+    {
+        message->SetDirectTransmission();
+    }
+    else
+    {
+        message->ClearDirectTransmission();
+    }
+}
+
 ThreadError otAppendMessage(otMessage aMessage, const void *aBuf, uint16_t aLength)
 {
     Message *message = static_cast<Message *>(aMessage);

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -438,7 +438,8 @@ ThreadError MeshForwarder::SendMessage(Message &aMessage)
             }
         }
         else if ((neighbor = mNetif.GetMle().GetNeighbor(ip6Header.GetDestination())) != NULL &&
-                 (neighbor->mMode & Mle::ModeTlv::kModeRxOnWhenIdle) == 0)
+                 (neighbor->mMode & Mle::ModeTlv::kModeRxOnWhenIdle) == 0 &&
+                 !aMessage.GetDirectTransmission())
         {
             // destined for a sleepy child
             children = static_cast<Child *>(neighbor);

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -4079,6 +4079,9 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_NET_INSECURE(uint8_t header, spin
 
     if (errorCode == kThreadError_None)
     {
+        // Ensure the insecure message is forwarded using direct transmission.
+        otMessageSetDirectTransmission(message, true);
+
         errorCode = otSendIp6Datagram(mInstance, message);
     }
     else if (message)


### PR DESCRIPTION
- New OpenThread API `otMessageForceDirectTransmission()` to force
  a message to forwarded using direct transmission even if the
  destination is an sleepy-node.

- The new API is used from `NcpBase` from set handler of insecure
  network stream spinel `STREAM_NET_INSECURE` property.