### PR TITLE
Stub crypto HW initialization function for nRF52840 port

### DIFF
--- a/examples/platforms/nrf52840/misc.c
+++ b/examples/platforms/nrf52840/misc.c
@@ -33,6 +33,11 @@
 
 static uint32_t sResetReason;
 
+__WEAK void nrf5CryptoInit(void)
+{
+    // This function is defined as weak so it could be overridden with external implementation.
+}
+
 void nrf5MiscInit(void)
 {
     // Read the reason of last reset.

--- a/examples/platforms/nrf52840/platform-nrf5.h
+++ b/examples/platforms/nrf52840/platform-nrf5.h
@@ -78,7 +78,7 @@ void nrf5RandomInit(void);
 void nrf5LogInit(void);
 
 /**
- * Function for processing SPI Slave driver.
+ * Initialization of Misc module.
  *
  */
 void nrf5MiscInit(void);
@@ -94,5 +94,11 @@ void nrf5RadioInit(void);
  *
  */
 void nrf5RadioProcess(otInstance *aInstance);
+
+/**
+ * Initialization of hardware crypto engine.
+ *
+ */
+void nrf5CryptoInit(void);
 
 #endif  // PLATFORM_NRF5_H_

--- a/examples/platforms/nrf52840/platform.c
+++ b/examples/platforms/nrf52840/platform.c
@@ -53,6 +53,7 @@ void PlatformInit(int argc, char *argv[])
     nrf5RandomInit();
     nrf5UartInit();
     nrf5MiscInit();
+    nrf5CryptoInit();
     nrf5RadioInit();
 #if (OPENTHREAD_ENABLE_DEFAULT_LOGGING == 0)
     nrf5LogInit();


### PR DESCRIPTION
This PR adds an empty initializer for cryptographic hardware to nRF52840 port initialization procedure.

Current implementation for OpenThread is empty, but it enables to use an external implementation, in case  crypto drivers are available.