### PR TITLE
Do not include local Pending Timestamp TLV in Child ID request message.

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -999,13 +999,12 @@ protected:
      * This method appends a Pending Timestamp TLV to a message.
      *
      * @param[in]  aMessage  A reference to the message.
-     * @param[in]  aCouldUseLocal  True to use local Pending Timestamp when network Pending Timestamp is not available, False not.
      *
      * @retval kThreadError_None    Successfully appended the Pending Timestamp TLV.
      * @retval kThreadError_NoBufs  Insufficient buffers available to append the Pending Timestamp TLV.
      *
      */
-    ThreadError AppendPendingTimestamp(Message &aMessage, bool aCouldUseLocal);
+    ThreadError AppendPendingTimestamp(Message &aMessage);
 
     /**
      * This method appends a Thread Discovery TLV to a message.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2688,7 +2688,7 @@ ThreadError MleRouter::SendChildIdResponse(Child *aChild)
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
     SuccessOrExit(error = AppendActiveTimestamp(*message, false));
-    SuccessOrExit(error = AppendPendingTimestamp(*message, false));
+    SuccessOrExit(error = AppendPendingTimestamp(*message));
 
     if (aChild->mState != Neighbor::kStateValid)
     {
@@ -2774,7 +2774,7 @@ ThreadError MleRouter::SendChildUpdateRequest(Child *aChild)
     SuccessOrExit(error = AppendLeaderData(*message));
     SuccessOrExit(error = AppendNetworkData(*message, (aChild->mMode & ModeTlv::kModeFullNetworkData) == 0));
     SuccessOrExit(error = AppendActiveTimestamp(*message, false));
-    SuccessOrExit(error = AppendPendingTimestamp(*message, false));
+    SuccessOrExit(error = AppendPendingTimestamp(*message));
     SuccessOrExit(error = AppendTlvRequest(*message, tlvs, sizeof(tlvs)));
 
     for (uint8_t i = 0; i < sizeof(aChild->mPending.mChallenge); i++)
@@ -2835,7 +2835,7 @@ ThreadError MleRouter::SendChildUpdateResponse(Child *aChild, const Ip6::Message
         case Tlv::kNetworkData:
             SuccessOrExit(error = AppendNetworkData(*message, (aChild->mMode & ModeTlv::kModeFullNetworkData) == 0));
             SuccessOrExit(error = AppendActiveTimestamp(*message, false));
-            SuccessOrExit(error = AppendPendingTimestamp(*message, false));
+            SuccessOrExit(error = AppendPendingTimestamp(*message));
             break;
 
         case Tlv::kResponse:
@@ -2886,7 +2886,7 @@ ThreadError MleRouter::SendDataResponse(const Ip6::Address &aDestination, const 
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
     SuccessOrExit(error = AppendActiveTimestamp(*message, false));
-    SuccessOrExit(error = AppendPendingTimestamp(*message, false));
+    SuccessOrExit(error = AppendPendingTimestamp(*message));
 
     for (int i = 0; i < aTlvsLength; i++)
     {


### PR DESCRIPTION
In #918, we had a workaround to pass certification test 9.2.15 and 9.2.16, and proposed to not include local Pending Timestamp TLV in Child ID request message([TESTPLAN-293](https://threadgroup.atlassian.net/browse/TESTPLAN-293)), the proposal is accepted by Thread Group, Test Harness is updated by [DEV-1238](https://threadgroup.atlassian.net/browse/DEV-1238), spec will be updated by [SPEC-668](https://threadgroup.atlassian.net/browse/SPEC-668).

This PR reverts the workaround, and I have verified that it will not break the related certification tests.