### PR TITLE
`mle`: Set `mRetrieveNewNetworkData` to `true` when requesting network data

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2204,7 +2204,6 @@ ThreadError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInf
     PendingTimestampTlv pendingTimestamp;
     uint16_t activeDatasetOffset = 0;
     uint16_t pendingDatasetOffset = 0;
-    bool dataRequest = false;
     Tlv tlv;
 
     // Leader Data
@@ -2247,7 +2246,7 @@ ThreadError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInf
         if ((timestamp == NULL || timestamp->Compare(activeTimestamp) != 0) &&
             (Tlv::GetOffset(aMessage, Tlv::kActiveDataset, activeDatasetOffset) != kThreadError_None))
         {
-            ExitNow(dataRequest = true);
+            ExitNow(mRetrieveNewNetworkData = true);
         }
     }
     else
@@ -2268,7 +2267,7 @@ ThreadError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInf
         if ((timestamp == NULL || timestamp->Compare(pendingTimestamp) != 0) &&
             (Tlv::GetOffset(aMessage, Tlv::kPendingDataset, pendingDatasetOffset) != kThreadError_None))
         {
-            ExitNow(dataRequest = true);
+            ExitNow(mRetrieveNewNetworkData = true);
         }
     }
     else
@@ -2323,7 +2322,7 @@ exit:
 
     (void)aMessageInfo;
 
-    if (dataRequest)
+    if (mRetrieveNewNetworkData)
     {
         static const uint8_t tlvs[] = {Tlv::kNetworkData};
 


### PR DESCRIPTION
This change ensures that the flag `mRetrieveNewNetworkData` is set to
`true` when a "Data Request" message is sent.

This addresses an issue where after updating the `mLeaderData`
(e.g., from a "ChildUpdateResponse" message not containing the active
dataset), and requesting (from `SendDataRequest()`) and receiving the
network data, `mRetrieveNewNetworkData` could remain `false` and
cause the network data not to be updated locally.