### PR TITLE
`mle`: Set `mRetrieveNewNetworkData` to `true` when LeaderData is updated

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2218,6 +2218,7 @@ ThreadError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInf
         if (mDeviceState == kDeviceStateChild)
         {
             SetLeaderData(leaderData.GetPartitionId(), leaderData.GetWeighting(), leaderData.GetLeaderRouterId());
+            mRetrieveNewNetworkData = true;
         }
         else
         {


### PR DESCRIPTION
This change ensures that the flag `mRetrieveNewNetworkData` is set to
`true` when the `LeaderData` is updated to accept the next received
network data without version check.

This addresses an issue where after updating the `mLeaderData`
(e.g., from a "ChildUpdateResponse" message not containing the active
dataset), and requesting (from `SendDataRequest()`) and receiving the
network data, `mRetrieveNewNetworkData` could remain `false` and
cause the network data not to be updated locally.