### PR TITLE
Add precise timer to make CSMA/CA delays correct.

### DIFF
--- a/examples/drivers/windows/otLwf/alarm.c
+++ b/examples/drivers/windows/otLwf/alarm.c
@@ -45,6 +45,12 @@ otPlatAlarmGetNow()
     return (uint32_t)(PerformanceCounter.QuadPart * 1000 / FilterPerformanceFrequency.QuadPart);
 }
 
+void otPlatAlarmGetPreciseNow(otPlatAlarmTime *aNow)
+{
+    aNow->mMs = otPlatAlarmGetNow();
+    aNow->mUs = 0;
+}
+
 void 
 otPlatAlarmStop(
     _In_ otInstance *otCtx
@@ -57,11 +63,19 @@ otPlatAlarmStop(
 void 
 otPlatAlarmStartAt(
     _In_ otInstance *otCtx, 
-    uint32_t now, 
-    uint32_t waitTime
+    const otPlatAlarmTime *now,
+    const otPlatAlarmTime *waitTime
     )
 {
     UNREFERENCED_PARAMETER(now);
-    LogVerbose(DRIVER_DEFAULT, "otPlatAlarmStartAt %u ms", waitTime);
-    otLwfEventProcessingIndicateNewWaitTime(otCtxToFilter(otCtx), waitTime);
+
+    uint32_t waitMs = waitTime->mMs;
+
+    if (waitTime->mUs)
+    {
+        waitMs++;
+    }
+
+    LogVerbose(DRIVER_DEFAULT, "otPlatAlarmStartAt %u ms", waitMs);
+    otLwfEventProcessingIndicateNewWaitTime(otCtxToFilter(otCtx), waitMs);
 }

--- a/examples/platforms/cc2538/alarm.c
+++ b/examples/platforms/cc2538/alarm.c
@@ -65,11 +65,23 @@ uint32_t otPlatAlarmGetNow(void)
     return sCounter;
 }
 
-void otPlatAlarmStartAt(otInstance *aInstance, uint32_t t0, uint32_t dt)
+void otPlatAlarmGetPreciseNow(otPlatAlarmTime *aNow)
+{
+    aNow->mMs = otPlatAlarmGetNow();
+    aNow->mUs = 0;
+}
+
+void otPlatAlarmStartAt(otInstance *aInstance, const otPlatAlarmTime *aT0, const otPlatAlarmTime *aDt)
 {
     (void)aInstance;
-    sAlarmT0 = t0;
-    sAlarmDt = dt;
+    sAlarmT0 = aT0->mMs;
+    sAlarmDt = aDt->mMs;
+
+    if (aDt->mUs)
+    {
+        sAlarmDt++;
+    }
+
     sIsRunning = true;
 }
 

--- a/examples/platforms/cc2650/alarm.c
+++ b/examples/platforms/cc2650/alarm.c
@@ -72,11 +72,26 @@ uint32_t otPlatAlarmGetNow(void)
 /**
  * Function documented in platform/alarm.h
  */
-void otPlatAlarmStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
+void otPlatAlarmGetPreciseNow(otPlatAlarmTime *aNow)
+{
+    aNow->mMs = otPlatAlarmGetNow();
+    aNow->mUs = 0;
+}
+
+/**
+ * Function documented in platform/alarm.h
+ */
+void otPlatAlarmStartAt(otInstance *aInstance, const otPlatAlarmTime *aT0, const otPlatAlarmTime *aDt)
 {
     (void)aInstance;
-    sTime0 = aT0;
-    sAlarmTime = aDt;
+    sTime0 = aT0->mMs;
+    sAlarmTime = aDt->mMs;
+
+    if (aDt->mUs)
+    {
+        sAlarmTime++;
+    }
+
     sIsRunning = true;
 }
 

--- a/examples/platforms/da15000/alarm.c
+++ b/examples/platforms/da15000/alarm.c
@@ -73,10 +73,22 @@ uint32_t otPlatAlarmGetNow(void)
     return sCounter;
 }
 
-void otPlatAlarmStartAt(otInstance *aInstance, uint32_t t0, uint32_t dt)
+void otPlatAlarmGetPreciseNow(otPlatAlarmTime *aNow)
+{
+    aNow->mMs = otPlatAlarmGetNow();
+    aNow->mUs = 0;
+}
+
+void otPlatAlarmStartAt(otInstance *aInstance, const otPlatAlarmTime *aT0, const otPlatAlarmTime *aDt)
 {
     (void)aInstance;
-    sAlarm = t0 + dt;
+    sAlarm = aT0->mMs + aDt->mMs;
+
+    if (aDt->mUs)
+    {
+        sAlarm++;
+    }
+
     sIsRunning = true;
 
     if (sCounter == 0)

--- a/examples/platforms/nrf52840/diag.c
+++ b/examples/platforms/nrf52840/diag.c
@@ -157,8 +157,10 @@ static void processTransmit(otInstance *aInstance, int argc, char *argv[], char 
         otPlatAlarmStop(aInstance);
         sTransmitActive = true;
         sTxCount = sTxRequestedCount;
-        uint32_t now = otPlatAlarmGetNow();
-        otPlatAlarmStartAt(aInstance, now, sTxPeriod);
+        otPlatAlarmTime now;
+        otPlatAlarmGetPreciseNow(&now);
+        otPlatAlarmTime txPeriod = {.mMs = sTxPeriod };
+        otPlatAlarmStartAt(aInstance, &now, &txPeriod);
         snprintf(aOutput, aOutputMaxLen, "sending %" PRId32 " diagnostic messages with %" PRIu32
                  " ms interval\r\nstatus 0x%02x\r\n",
                  sTxRequestedCount, sTxPeriod, error);
@@ -296,8 +298,10 @@ void otPlatDiagAlarmCallback(otInstance *aInstance)
                 sTxCount--;
             }
 
-            uint32_t now = otPlatAlarmGetNow();
-            otPlatAlarmStartAt(aInstance, now, sTxPeriod);
+            otPlatAlarmTime now;
+            otPlatAlarmGetPreciseNow(&now);
+            otPlatAlarmTime txPeriod = {.mMs = sTxPeriod};
+            otPlatAlarmStartAt(aInstance, &now, &txPeriod);
         }
         else
         {

--- a/include/platform/alarm.h
+++ b/include/platform/alarm.h
@@ -54,14 +54,21 @@ extern "C" {
  *
  */
 
+typedef struct
+{
+    uint32_t mMs;
+    uint16_t mUs;
+} otPlatAlarmTime;
+
 /**
  * Set the alarm to fire at @p aDt milliseconds after @p aT0.
  *
  * @param[in] aInstance  The OpenThread instance structure.
  * @param[in] aT0        The reference time.
- * @param[in] aDt        The time delay in milliseconds from @p aT0.
+ * @param[in] aDt        The time delay in milliseconds and microseconds from @p aT0.
  */
-void otPlatAlarmStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt);
+void otPlatAlarmStartAt(otInstance *aInstance, const otPlatAlarmTime *aT0, const otPlatAlarmTime *aDt);
+
 
 /**
  * Stop the alarm.
@@ -76,6 +83,13 @@ void otPlatAlarmStop(otInstance *aInstance);
  * @returns The current time in milliseconds.
  */
 uint32_t otPlatAlarmGetNow(void);
+
+/**
+ * Get the current time.
+ *
+ * @param[out]  aNow  The current time in milliseconds and microseconds fraction.
+ */
+void otPlatAlarmGetPreciseNow(otPlatAlarmTime *aNow);
 
 /**
  * Signal that the alarm has fired.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1241,7 +1241,7 @@ void Interpreter::HandleEchoResponse(Message &aMessage, const Ip6::MessageInfo &
     if (aMessage.Read(aMessage.GetOffset() + sizeof(icmp6Header), sizeof(uint32_t), &timestamp) >=
         static_cast<int>(sizeof(uint32_t)))
     {
-        sServer->OutputFormat(" time=%dms", Timer::GetNow() - HostSwap32(timestamp));
+        sServer->OutputFormat(" time=%dms", Time::GetNow() - HostSwap32(timestamp));
     }
 
     sServer->OutputFormat("\r\n");
@@ -1306,7 +1306,7 @@ void Interpreter::s_HandlePingTimer(void *aContext)
 void Interpreter::HandlePingTimer()
 {
     ThreadError error = kThreadError_None;
-    uint32_t timestamp = HostSwap32(Timer::GetNow());
+    uint32_t timestamp = HostSwap32(Time::GetNow());
     Message *message;
 
     VerifyOrExit((message = mInstance->mIp6.mIcmp.NewMessage(0)) != NULL, error = kThreadError_NoBufs);

--- a/src/core/coap/coap_client.cpp
+++ b/src/core/coap/coap_client.cpp
@@ -142,7 +142,7 @@ Message *Client::CopyAndEnqueueMessage(const Message &aMessage, uint16_t aCopyLe
     if (mRetransmissionTimer.IsRunning())
     {
         // If timer is already running, check if it should be restarted with earlier fire time.
-        alarmFireTime = mRetransmissionTimer.Gett0() + mRetransmissionTimer.Getdt();
+        alarmFireTime = mRetransmissionTimer.GetT0() + mRetransmissionTimer.GetDt();
 
         if (aRequestMetadata.IsEarlier(alarmFireTime))
         {
@@ -239,7 +239,7 @@ void Client::HandleRetransmissionTimer(void *aContext)
 
 void Client::HandleRetransmissionTimer(void)
 {
-    uint32_t now = otPlatAlarmGetNow();
+    uint32_t now = Time::GetNow();
     uint32_t nextDelta = 0xffffffff;
     RequestMetadata requestMetadata;
     Message *message = mPendingRequests.GetHead();
@@ -454,12 +454,12 @@ RequestMetadata::RequestMetadata(bool aConfirmable, const Ip6::MessageInfo &aMes
     if (aConfirmable)
     {
         // Set next retransmission timeout.
-        mNextTimerShot = Timer::GetNow() + mRetransmissionTimeout;
+        mNextTimerShot = Time::GetNow() + mRetransmissionTimeout;
     }
     else
     {
         // Set overall response timeout.
-        mNextTimerShot = Timer::GetNow() + kMaxTransmitWait;
+        mNextTimerShot = Time::GetNow() + kMaxTransmitWait;
     }
 
     mAcknowledged = false;

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -43,26 +43,152 @@
 
 namespace Thread {
 
+Time Time::operator+(const Time &aOther) const
+{
+    Time result(*this);
+
+    result.mMs += aOther.mMs;
+    result.mUs += aOther.mUs;
+
+    if (result.mUs >= 1000)
+    {
+        result.mUs -= 1000;
+        result.mMs++;
+    }
+
+    return result;
+}
+
+Time Time::operator-(const Time &aOther) const
+{
+    Time result(*this);
+
+    result.mMs -= aOther.mMs;
+    result.mUs -= aOther.mUs;
+
+    if (result.mUs > this->mUs)
+    {
+        result.mUs += 1000;
+        result.mMs--;
+    }
+
+    return result;
+}
+
+bool Time::operator>(const Time &aOther) const
+{
+    if (mMs > aOther.mMs)
+    {
+        return true;
+    }
+
+    if ((mMs == aOther.mMs) && (mUs > aOther.mUs))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+bool Time::operator>=(const Time &aOther) const
+{
+    if (mMs > aOther.mMs)
+    {
+        return true;
+    }
+
+    if ((mMs == aOther.mMs) && (mUs >= aOther.mUs))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+bool Time::operator<(const Time &aOther) const
+{
+    if (mMs < aOther.mMs)
+    {
+        return true;
+    }
+
+    if ((mMs == aOther.mMs) && (mUs < aOther.mUs))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+bool Time::operator<=(const Time &aOther) const
+{
+    if (mMs < aOther.mMs)
+    {
+        return true;
+    }
+
+    if ((mMs == aOther.mMs) && (mUs <= aOther.mUs))
+    {
+        return true;
+    }
+
+    return false;
+}
+
 TimerScheduler::TimerScheduler(void):
-    mHead(NULL)
+    mHead(NULL),
+    mHeadUs(NULL),
+    mCurrentlySetUs(false)
 {
 }
 
 void TimerScheduler::Add(Timer &aTimer)
 {
+    TemplateAdd(aTimer);
+}
+
+void TimerScheduler::Add(TimerUs &aTimer)
+{
+    TemplateAdd(aTimer);
+}
+
+void TimerScheduler::Remove(Timer &aTimer)
+{
+    TemplateRemove(aTimer);
+}
+
+void TimerScheduler::Remove(TimerUs &aTimer)
+{
+    TemplateRemove(aTimer);
+}
+
+bool TimerScheduler::IsAdded(const Timer &aTimer)
+{
+    return TemplateIsAdded(aTimer);
+}
+
+bool TimerScheduler::IsAdded(const TimerUs &aTimer)
+{
+    return TemplateIsAdded(aTimer);
+}
+
+template <class T> void TimerScheduler::TemplateAdd(T &aTimer)
+{
+    T **head = GetHead(&aTimer);
+
     Remove(aTimer);
 
-    if (mHead == NULL)
+    if (*head == NULL)
     {
-        mHead = &aTimer;
+        *head = &aTimer;
         SetAlarm();
     }
     else
     {
-        Timer *prev = NULL;
-        Timer *cur;
+        T *prev = NULL;
+        T *cur;
 
-        for (cur = mHead; cur; cur = cur->mNext)
+        for (cur = *head; cur; cur = cur->mNext)
         {
             if (TimerCompare(aTimer, *cur))
             {
@@ -73,8 +199,8 @@ void TimerScheduler::Add(Timer &aTimer)
                 }
                 else
                 {
-                    aTimer.mNext = mHead;
-                    mHead = &aTimer;
+                    aTimer.mNext = *head;
+                    *head = &aTimer;
                     SetAlarm();
                 }
 
@@ -91,17 +217,19 @@ void TimerScheduler::Add(Timer &aTimer)
     }
 }
 
-void TimerScheduler::Remove(Timer &aTimer)
+template <class T> void TimerScheduler::TemplateRemove(T &aTimer)
 {
-    if (mHead == &aTimer)
+    T **head = GetHead(&aTimer);
+
+    if (*head == &aTimer)
     {
-        mHead = aTimer.mNext;
+        *head = aTimer.mNext;
         aTimer.mNext = NULL;
         SetAlarm();
     }
     else
     {
-        for (Timer *cur = mHead; cur; cur = cur->mNext)
+        for (T *cur = *head; cur; cur = cur->mNext)
         {
             if (cur->mNext == &aTimer)
             {
@@ -113,11 +241,13 @@ void TimerScheduler::Remove(Timer &aTimer)
     }
 }
 
-bool TimerScheduler::IsAdded(const Timer &aTimer)
+template <class T> bool TimerScheduler::TemplateIsAdded(const T &aTimer)
 {
+    T **head = GetHead(&aTimer);
+
     bool rval = false;
 
-    for (Timer *cur = mHead; cur; cur = cur->mNext)
+    for (T *cur = *head; cur; cur = cur->mNext)
     {
         if (cur == &aTimer)
         {
@@ -129,22 +259,88 @@ exit:
     return rval;
 }
 
+template <class Ttimer, class Ttime> bool TimerScheduler::TimerCompareTemplate(const Ttimer &aTimerA,
+                                                                               const Ttimer &aTimerB)
+{
+    Ttime now;
+    Time::GetNow(now);
+
+    Ttime elapsedA = now - aTimerA.GetT0();
+    Ttime elapsedB = now - aTimerB.GetT0();
+    bool retval = false;
+
+    if (aTimerA.GetDt() >= elapsedA && aTimerB.GetDt() >= elapsedB)
+    {
+        Ttime remainingA = aTimerA.GetDt() - elapsedA;
+        Ttime remainingB = aTimerB.GetDt() - elapsedB;
+
+        if (remainingA < remainingB)
+        {
+            retval = true;
+        }
+    }
+    else if (aTimerA.GetDt() < elapsedA && aTimerB.GetDt() >= elapsedB)
+    {
+        retval = true;
+    }
+    else if (aTimerA.GetDt() < elapsedA && aTimerB.GetDt() < elapsedB)
+    {
+        Ttime expiredByA = elapsedA - aTimerA.GetDt();
+        Ttime expiredByB = elapsedB - aTimerB.GetDt();
+
+        if (expiredByB < expiredByA)
+        {
+            retval = true;
+        }
+    }
+
+    return retval;
+}
+
+bool TimerScheduler::TimerCompare(const TimerUs &aTimerA, const TimerUs &aTimerB) { return TimerCompareTemplate<TimerUs, Time>(aTimerA, aTimerB); }
+bool TimerScheduler::TimerCompare(const Timer &aTimerA, const Timer &aTimerB) { return TimerCompareTemplate<Timer, uint32_t>(aTimerA, aTimerB); }
+
 void TimerScheduler::SetAlarm(void)
 {
-    uint32_t now = otPlatAlarmGetNow();
-    uint32_t elapsed;
-    uint32_t remaining;
+    Time now;
+    Time::GetNow(now);
 
-    if (mHead == NULL)
+    Time elapsed;
+    Time remaining;
+
+    if ((mHead == NULL) && (mHeadUs == NULL))
     {
         otPlatAlarmStop(GetIp6()->GetInstance());
     }
     else
     {
-        elapsed = now - mHead->mT0;
-        remaining = (mHead->mDt > elapsed) ? mHead->mDt - elapsed : 0;
+        if (mHeadUs == NULL)
+        {
+            mCurrentlySetUs = false;
+        }
+        else if (mHead == NULL)
+        {
+            mCurrentlySetUs = true;
+        }
+        else
+        {
+            mCurrentlySetUs = TimerCompare(*mHeadUs, static_cast<TimerUs>(*mHead));
+        }
 
-        otPlatAlarmStartAt(GetIp6()->GetInstance(), now, remaining);
+        if (mCurrentlySetUs)
+        {
+            elapsed = now - mHeadUs->GetT0();
+            remaining = (mHeadUs->GetDt() > elapsed) ? mHeadUs->GetDt() - elapsed : Time(0);
+
+            otPlatAlarmStartAt(GetIp6()->GetInstance(), &now, &remaining);
+        }
+        else
+        {
+            elapsed = now - Time(mHead->GetT0());
+            remaining = (Time(mHead->GetDt()) > elapsed) ? Time(mHead->GetDt()) - elapsed : Time(0);
+
+            otPlatAlarmStartAt(GetIp6()->GetInstance(), &now, &remaining);
+        }
     }
 }
 
@@ -157,68 +353,58 @@ extern "C" void otPlatAlarmFired(otInstance *aInstance)
 
 void TimerScheduler::FireTimers()
 {
-    uint32_t now = otPlatAlarmGetNow();
-    uint32_t elapsed;
     Timer *timer = mHead;
+    TimerUs *timerUs = mHeadUs;
 
-    if (timer)
+    if (mCurrentlySetUs)
     {
-        elapsed = now - timer->mT0;
-
-        if (elapsed >= timer->mDt)
+        if (timerUs)
         {
-            Remove(*timer);
-            timer->Fired();
+            Time now;
+            Time::GetNow(now);
+
+            Time elapsed = now - timerUs->GetT0();
+
+            if (elapsed >= timerUs->GetDt())
+            {
+                Remove(*timerUs);
+                timerUs->Fired();
+            }
+            else
+            {
+                SetAlarm();
+            }
+        }
+    }
+    else
+    {
+        if (timer)
+        {
+            uint32_t now;
+            Time::GetNow(now);
+
+            uint32_t elapsed = now - timer->GetT0();
+
+            if (elapsed >= timer->GetDt())
+            {
+                Remove(*timer);
+                timer->Fired();
+            }
+            else
+            {
+                SetAlarm();
+            }
         }
         else
         {
             SetAlarm();
         }
     }
-    else
-    {
-        SetAlarm();
-    }
 }
 
 Ip6::Ip6 *TimerScheduler::GetIp6()
 {
     return Ip6::Ip6FromTimerScheduler(this);
-}
-
-bool TimerScheduler::TimerCompare(const Timer &aTimerA, const Timer &aTimerB)
-{
-    uint32_t now = otPlatAlarmGetNow();
-    uint32_t elapsedA = now - aTimerA.mT0;
-    uint32_t elapsedB = now - aTimerB.mT0;
-    bool retval = false;
-
-    if (aTimerA.mDt >= elapsedA && aTimerB.mDt >= elapsedB)
-    {
-        uint32_t remainingA = aTimerA.mDt - elapsedA;
-        uint32_t remainingB = aTimerB.mDt - elapsedB;
-
-        if (remainingA < remainingB)
-        {
-            retval = true;
-        }
-    }
-    else if (aTimerA.mDt < elapsedA && aTimerB.mDt >= elapsedB)
-    {
-        retval = true;
-    }
-    else if (aTimerA.mDt < elapsedA && aTimerB.mDt < elapsedB)
-    {
-        uint32_t expiredByA = elapsedA - aTimerA.mDt;
-        uint32_t expiredByB = elapsedB - aTimerB.mDt;
-
-        if (expiredByB < expiredByA)
-        {
-            retval = true;
-        }
-    }
-
-    return retval;
 }
 
 }  // namespace Thread

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -84,7 +84,7 @@ void Mac::StartCsmaBackoff(void)
     {
         // If the radio supports the retry and back off logic, immediately schedule the send,
         // and the radio will take care of everything.
-        mBackoffTimer.Start(0);
+        mBackoffTimer.Start(Time(0));
     }
     else
     {
@@ -96,10 +96,12 @@ void Mac::StartCsmaBackoff(void)
             backoffExponent = kMaxBE;
         }
 
-        backoff = kMinBackoff + (kUnitBackoffPeriod * kPhyUsPerSymbol * (1 << backoffExponent)) / 1000;
-        backoff = (otPlatRandomGet() % backoff);
+        backoff = (otPlatRandomGet() % (1UL << backoffExponent));
+        backoff *= (kUnitBackoffPeriod * kPhyUsPerSymbol);
 
-        mBackoffTimer.Start(backoff);
+        Time backoffTime(backoff / 1000, backoff % 1000);
+
+        mBackoffTimer.Start(backoffTime);
     }
 }
 

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -606,7 +606,7 @@ private:
     ThreadError Scan(ScanType aType, uint32_t aScanChannels, uint16_t aScanDuration, void *aContext);
 
     Timer mMacTimer;
-    Timer mBackoffTimer;
+    TimerUs mBackoffTimer;
     Timer mReceiveTimer;
 
     ThreadNetif &mNetif;

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -1014,12 +1014,12 @@ void PendingDatasetBase::ResetDelayTimer(uint8_t aFlags)
 
     if (aFlags & kFlagLocalUpdated)
     {
-        mLocalTime = Timer::GetNow();
+        mLocalTime = Time::GetNow();
     }
 
     if (aFlags & kFlagNetworkUpdated)
     {
-        mNetworkTime = Timer::GetNow();
+        mNetworkTime = Time::GetNow();
         mTimer.Stop();
 
         if ((delayTimer = static_cast<DelayTimerTlv *>(mNetwork.Get(Tlv::kDelayTimer))) != NULL)
@@ -1046,7 +1046,7 @@ void PendingDatasetBase::UpdateDelayTimer(void)
 void PendingDatasetBase::UpdateDelayTimer(Dataset &aDataset, uint32_t &aStartTime)
 {
     DelayTimerTlv *delayTimer;
-    uint32_t now = Timer::GetNow();
+    uint32_t now = Time::GetNow();
     uint32_t elapsed;
     uint32_t delay;
 

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -297,7 +297,7 @@ int Dtls::HandleMbedtlsGetTimer(void)
     {
         rval = 2;
     }
-    else if (static_cast<int32_t>(mTimerIntermediate - Timer::GetNow()) <= 0)
+    else if (static_cast<int32_t>(mTimerIntermediate - Time::GetNow()) <= 0)
     {
         rval = 1;
     }
@@ -327,7 +327,7 @@ void Dtls::HandleMbedtlsSetTimer(uint32_t aIntermediate, uint32_t aFinish)
     {
         mTimerSet = true;
         mTimer.Start(aFinish);
-        mTimerIntermediate = Timer::GetNow() + aIntermediate;
+        mTimerIntermediate = Time::GetNow() + aIntermediate;
     }
 }
 

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -159,7 +159,7 @@ exit:
 
 void Mpl::AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSequence, bool aIsOutbound)
 {
-    uint32_t now = Timer::GetNow();
+    uint32_t now = Time::GetNow();
     ThreadError error = kThreadError_None;
     Message *messageCopy = NULL;
     MplBufferedMessageMetadata messageMetadata;
@@ -188,7 +188,7 @@ void Mpl::AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSeque
     if (mRetransmissionTimer.IsRunning())
     {
         // If timer is already running, check if it should be restarted with earlier fire time.
-        nextTransmissionTime = mRetransmissionTimer.Gett0() + mRetransmissionTimer.Getdt();
+        nextTransmissionTime = mRetransmissionTimer.GetT0() + mRetransmissionTimer.GetDt();
 
         if (messageMetadata.IsEarlier(nextTransmissionTime))
         {
@@ -255,7 +255,7 @@ void Mpl::HandleRetransmissionTimer(void *aContext)
 
 void Mpl::HandleRetransmissionTimer()
 {
-    uint32_t now = Timer::GetNow();
+    uint32_t now = Time::GetNow();
     uint32_t nextDelta = 0xffffffff;
     MplBufferedMessageMetadata messageMetadata;
 

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -478,7 +478,7 @@ void AddressResolver::HandleAddressQuery(Coap::Header &aHeader, Message &aMessag
             children[i].mMacAddr.m8[0] ^= 0x2;
             mlIidTlv.SetIid(children[i].mMacAddr.m8);
             children[i].mMacAddr.m8[0] ^= 0x2;
-            lastTransactionTimeTlv.SetTime(Timer::GetNow() - children[i].mLastHeard);
+            lastTransactionTimeTlv.SetTime(Time::GetNow() - children[i].mLastHeard);
             SendAddressQueryResponse(targetTlv, mlIidTlv, &lastTransactionTimeTlv, aMessageInfo.GetPeerAddr());
             ExitNow();
         }

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -167,12 +167,12 @@ void KeyManager::SetCurrentKeySequence(uint32_t aKeySequence)
         mKeyRotationTimer.IsRunning() &&
         mKeySwitchGuardEnabled)
     {
-        uint32_t now = Timer::GetNow();
-        uint32_t guardStartTimestamp = mKeyRotationTimer.Gett0();
+        uint32_t now = Time::GetNow();
+        uint32_t guardStartTimestamp = mKeyRotationTimer.GetT0();
         uint32_t guardEndTimestamp = guardStartTimestamp + Timer::HoursToMsec(mKeySwitchGuardTime);
 
         // Check for timer overflow
-        if (guardEndTimestamp < mKeyRotationTimer.Gett0())
+        if (guardEndTimestamp < mKeyRotationTimer.GetT0())
         {
             if ((now > guardStartTimestamp) || (now < guardEndTimestamp))
             {

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -2075,7 +2075,7 @@ void MeshForwarder::HandleDataRequest(const Mac::Address &aMacSource, const Thre
     VerifyOrExit(mNetif.GetMle().GetDeviceState() != Mle::kDeviceStateDetached, ;);
 
     VerifyOrExit((child = mNetif.GetMle().GetChild(aMacSource)) != NULL, ;);
-    child->mLastHeard = Timer::GetNow();
+    child->mLastHeard = Time::GetNow();
     child->mLinkFailures = 0;
 
     if (!mSrcMatchEnabled || child->mQueuedIndirectMessageCnt > 0)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1927,7 +1927,7 @@ ThreadError Mle::AddDelayedResponse(Message &aMessage, const Ip6::Address &aDest
     if (mDelayedResponseTimer.IsRunning())
     {
         // If timer is already running, check if it should be restarted with earlier fire time.
-        alarmFireTime = mDelayedResponseTimer.Gett0() + mDelayedResponseTimer.Getdt();
+        alarmFireTime = mDelayedResponseTimer.GetT0() + mDelayedResponseTimer.GetDt();
 
         if (delayedResponse.IsEarlier(alarmFireTime))
         {
@@ -2253,7 +2253,7 @@ ThreadError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::Message
         }
 
         isNeighbor = true;
-        mParent.mLastHeard = mParentRequestTimer.GetNow();
+        mParent.mLastHeard = Time::GetNow();
         break;
 
     case kDeviceStateRouter:

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -601,7 +601,7 @@ ThreadError NetworkData::SendServerDataNotification(uint16_t aRloc16)
     Message *message = NULL;
     Ip6::MessageInfo messageInfo;
 
-    VerifyOrExit(!mLastAttemptWait || static_cast<int32_t>(Timer::GetNow() - mLastAttempt) < kDataResubmitDelay,
+    VerifyOrExit(!mLastAttemptWait || static_cast<int32_t>(Time::GetNow() - mLastAttempt) < kDataResubmitDelay,
                  error = kThreadError_Already);
 
     header.Init(kCoapTypeConfirmable, kCoapRequestPost);
@@ -635,7 +635,7 @@ ThreadError NetworkData::SendServerDataNotification(uint16_t aRloc16)
 
     if (mLocal)
     {
-        mLastAttempt = Timer::GetNow();
+        mLastAttempt = Time::GetNow();
         mLastAttemptWait = true;
     }
 

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -877,7 +877,7 @@ ThreadError Leader::RemoveRloc(PrefixTlv &prefix, uint16_t aRloc16)
         if (prefix.GetSubTlvsLength() == sizeof(ContextTlv))
         {
             context->ClearCompress();
-            mContextLastUsed[context->GetContextId() - kMinContextId] = Timer::GetNow();
+            mContextLastUsed[context->GetContextId() - kMinContextId] = Time::GetNow();
 
             if (mContextLastUsed[context->GetContextId() - kMinContextId] == 0)
             {
@@ -1058,7 +1058,7 @@ void Leader::HandleTimer(void)
             continue;
         }
 
-        if ((Timer::GetNow() - mContextLastUsed[i]) >= Timer::SecToMsec(mContextIdReuseDelay))
+        if ((Time::GetNow() - mContextLastUsed[i]) >= Timer::SecToMsec(mContextIdReuseDelay))
         {
             FreeContext(kMinContextId + i);
         }

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -75,7 +75,7 @@ ThreadError JamDetector::Start(Handler aHandler, void *aContext)
 
     mEnabled = true;
 
-    mCurSecondStartTime = Timer::GetNow();
+    mCurSecondStartTime = Time::GetNow();
     mAlwaysAboveThreshold = true;
     mHistoryBitmap = 0;
     mJamState = false;
@@ -183,7 +183,7 @@ exit:
 
 void JamDetector::UpdateHistory(bool aDidExceedThreshold)
 {
-    uint32_t now = Timer::GetNow();
+    uint32_t now = Time::GetNow();
 
     // If the RSSI is ever below the threshold, update mAlwaysAboveThreshold
     // for current second interval.

--- a/src/diag/diag_process.cpp
+++ b/src/diag/diag_process.cpp
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <common/code_utils.hpp>
+#include <common/timer.hpp>
 
 #include "diag_process.hpp"
 
@@ -298,8 +299,11 @@ void Diag::ProcessRepeat(int argc, char *argv[], char *aOutput, size_t aOutputMa
         sTxLen = static_cast<uint8_t>(value);
 
         sRepeatActive = true;
-        uint32_t now = otPlatAlarmGetNow();
-        otPlatAlarmStartAt(sContext, now, sTxPeriod);
+        Time now;
+        Time::GetNow(now);
+        Time txPeriod(sTxPeriod);
+
+        otPlatAlarmStartAt(sContext, &now, &txPeriod);
         snprintf(aOutput, aOutputMaxLen, "sending packets of length %#x at the delay of %#x ms\r\nstatus 0x%02x\r\n", static_cast<int>(sTxLen), static_cast<int>(sTxPeriod), error);
     }
 
@@ -374,10 +378,12 @@ void Diag::AlarmFired(otInstance *aInstance)
 {
     if(sRepeatActive)
     {
-        uint32_t now = otPlatAlarmGetNow();
+        Time now;
+        Time::GetNow(now);
+        Time txPeriod(sTxPeriod);
 
         TxPacket();
-        otPlatAlarmStartAt(aInstance, now, sTxPeriod);
+        otPlatAlarmStartAt(aInstance, &now, &txPeriod);
     }
     else
     {

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -45,6 +45,7 @@ uint32_t                        g_testPlatAlarmNext = 0;
 testPlatAlarmStop               g_testPlatAlarmStop = NULL;
 testPlatAlarmStartAt            g_testPlatAlarmStartAt = NULL;
 testPlatAlarmGetNow             g_testPlatAlarmGetNow = NULL;
+testPlatAlarmGetPreciseNow      g_testPlatAlarmGetPreciseNow = NULL;
 
 otRadioCaps                     g_testPlatRadioCaps = kRadioCapsNone;
 testPlatRadioSetPanId           g_testPlatRadioSetPanId = NULL;
@@ -64,6 +65,7 @@ void testPlatResetToDefaults(void)
     g_testPlatAlarmStop = NULL;
     g_testPlatAlarmStartAt = NULL;
     g_testPlatAlarmGetNow = NULL;
+    g_testPlatAlarmGetPreciseNow = NULL;
 
     g_testPlatRadioCaps = kRadioCapsNone;
     g_testPlatRadioSetPanId = NULL;
@@ -101,7 +103,7 @@ extern "C" {
         }
     }
 
-    void otPlatAlarmStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
+    void otPlatAlarmStartAt(otInstance *aInstance, const otPlatAlarmTime *aT0, const otPlatAlarmTime *aDt)
     {
         if (g_testPlatAlarmStartAt)
         {
@@ -110,7 +112,7 @@ extern "C" {
         else
         {
             g_testPlatAlarmSet = true;
-            g_testPlatAlarmNext = aT0 + aDt;
+            g_testPlatAlarmNext = aT0->mMs + aDt->mMs;
         }
     }
 
@@ -125,6 +127,21 @@ extern "C" {
             struct timeval tv;
             gettimeofday(&tv, NULL);
             return (uint32_t)((tv.tv_sec * 1000) + (tv.tv_usec / 1000) + 123456);
+        }
+    }
+
+    void otPlatAlarmGetPreciseNow(otPlatAlarmTime *aNow)
+    {
+        if (g_testPlatAlarmGetPreciseNow)
+        {
+            g_testPlatAlarmGetPreciseNow(aNow);
+        }
+        else
+        {
+            struct timeval tv;
+            gettimeofday(&tv, NULL);
+            aNow->mMs = (uint32_t)((tv.tv_sec * 1000) + (tv.tv_usec / 1000) + 123456);
+            aNow->mUs = (uint16_t)(tv.tv_usec % 1000);
         }
     }
 

--- a/tests/unit/test_platform.h
+++ b/tests/unit/test_platform.h
@@ -54,14 +54,16 @@
 //
 
 typedef void (*testPlatAlarmStop)(otInstance *);
-typedef void (*testPlatAlarmStartAt)(otInstance *, uint32_t, uint32_t);
+typedef void (*testPlatAlarmStartAt)(otInstance *, const otPlatAlarmTime *, const otPlatAlarmTime *);
 typedef uint32_t (*testPlatAlarmGetNow)(void);
+typedef void (*testPlatAlarmGetPreciseNow)(otPlatAlarmTime *);
 
 extern bool                             g_testPlatAlarmSet;
 extern uint32_t                         g_testPlatAlarmNext;
 extern testPlatAlarmStop                g_testPlatAlarmStop;
 extern testPlatAlarmStartAt             g_testPlatAlarmStartAt;
 extern testPlatAlarmGetNow              g_testPlatAlarmGetNow;
+extern testPlatAlarmGetPreciseNow       g_testPlatAlarmGetPreciseNow;
 
 //
 // Radio Platform


### PR DESCRIPTION
802.15.4-2006 specifies that before CCA MAC sublayer shall delay for a random number of _complete_ backoff periods. Single backoff period (20 symbols) is 320 us. 
Current timer implementation supports 1ms accuracy that is not enough to meet 802.15.4 requirements. That's why I created this PR.

It provides following classes:
* `Time` that keeps time in milliseconds (`uint32_t`) and microsecond fraction (`uint16_t`),
* `TimerUs` for precise timer (1 us accuracy). 

Timer scheduler supports both old-style (lower memory) `Timer` objects and precise `TimerUs` objects.
I also modified platform alarm.h API a little to support microsecond accuracy.

Currently only MAC `mBackoffTimer` is a `TimerUs` object but other modules that require precise timer can use this functionality as well.