### PR TITLE
Allow project to provide MBEDTLS_CPPFLAGS to customize mbed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -483,7 +483,7 @@ AC_ARG_ENABLE(builtin-mbedtls,
     ],
     [enable_builtin_mbedtls=yes])
 
-if test "$enable_builtin_mbedtls" = "yes"; then
+if test "$enable_builtin_mbedtls" = "yes" -a ! "${MBEDTLS_CPPFLAGS}"; then
     MBEDTLS_CPPFLAGS="-I\${abs_top_srcdir}/third_party/mbedtls"
     MBEDTLS_CPPFLAGS="${MBEDTLS_CPPFLAGS} -I\${abs_top_srcdir}/third_party/mbedtls/repo/include"
     MBEDTLS_CPPFLAGS="${MBEDTLS_CPPFLAGS} -I\${abs_top_srcdir}/third_party/mbedtls/repo/include/mbedtls"

--- a/third_party/mbedtls/Makefile.am
+++ b/third_party/mbedtls/Makefile.am
@@ -37,8 +37,7 @@ libmbedcrypto_a_CPPFLAGS                      = \
     -I$(top_srcdir)/include                     \
     -I$(top_srcdir)/src/core                    \
     -I$(MBEDTLS_SRCDIR)/include                 \
-    -I$(MBEDTLS_SRCDIR)/include/mbedtls         \
-    -DMBEDTLS_CONFIG_FILE=\"mbedtls-config.h\"  \
+    $(MBEDTLS_CPPFLAGS)                         \
     $(NULL)
 
 libmbedcrypto_a_SOURCES                       = \


### PR DESCRIPTION
Allow another project to provide alternative MBEDTLS_CPPFLAGS
to customize things like using an alternative mbedtls-config.h
file with different settings than the default ones.