### PR TITLE
`Mle_Router`: Check the child's state to be valid when receiving a  "…Child Update Request"

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2252,7 +2252,7 @@ ThreadError MleRouter::HandleChildUpdateRequest(const Message &aMessage, const I
 
     child = FindChild(macAddr);
 
-    if (child == NULL)
+    if ((child == NULL) || (child->mState != Neighbor::kStateValid))
     {
         tlvs[tlvslength++] = Tlv::kStatus;
         SendChildUpdateResponse(NULL, aMessageInfo, tlvs, tlvslength, NULL);
@@ -2326,7 +2326,6 @@ ThreadError MleRouter::HandleChildUpdateRequest(const Message &aMessage, const I
 
     child->mLastHeard = Timer::GetNow();
     child->mAddSrcMatchEntryShort = true;
-    child->mState = Neighbor::kStateValid;
 
     SendChildUpdateResponse(child, aMessageInfo, tlvs, tlvslength, &challenge);
 


### PR DESCRIPTION
- In `HandleChildUpdateRequest()` check that the child is already
  in state `kStateValid` before sending the full reply. This
  addresses an issue during re-attach process (where the child
  could switch to valid state before counters were synced on the
  parent).