### PR TITLE
`MleRouter`: Update how `CHILD_ADDED`/`CHILD_REMOVED` are signaled.

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2413,11 +2413,11 @@ ThreadError MleRouter::HandleChildUpdateResponse(const Message &aMessage, const 
         }
     }
 
+    SetChildStateToValid(child);
     child->mLastHeard = Timer::GetNow();
     child->mKeySequence = aKeySequence;
     child->mLinkInfo.AddRss(mNetif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
     child->mAddSrcMatchEntryShort = true;
-    child->mState = Neighbor::kStateValid;
 
 exit:
     return error;
@@ -2740,9 +2740,7 @@ ThreadError MleRouter::SendChildIdResponse(Child *aChild)
         SuccessOrExit(error = AppendChildAddresses(*message, *aChild));
     }
 
-    aChild->mState = Neighbor::kStateValid;
-    mNetif.SetStateChangedFlags(OT_THREAD_CHILD_ADDED);
-    StoreChild(aChild->mValid.mRloc16);
+    SetChildStateToValid(aChild);
 
     memset(&destination, 0, sizeof(destination));
     destination.mFields.m16[0] = HostSwap16(0xfe80);
@@ -4425,6 +4423,18 @@ exit:
     return rval;
 }
 
+void MleRouter::SetChildStateToValid(Child *aChild)
+{
+    VerifyOrExit(aChild->mState != Neighbor::kStateValid, ;);
+
+    aChild->mState = Neighbor::kStateValid;
+    mNetif.SetStateChangedFlags(OT_THREAD_CHILD_ADDED);
+    StoreChild(aChild->mValid.mRloc16);
+
+exit:
+    return;
+}
+
 bool MleRouter::HasChildren(void)
 {
     bool hasChildren = false;
@@ -4445,11 +4455,20 @@ void MleRouter::RemoveChildren(void)
 {
     for (uint8_t i = 0; i < mMaxChildrenAllowed; i++)
     {
-        if (mChildren[i].mState == Neighbor::kStateRestored ||
-            mChildren[i].mState == Neighbor::kStateChildUpdateRequest ||
-            mChildren[i].mState == Neighbor::kStateValid)
+        switch (mChildren[i].mState)
         {
+        case Neighbor::kStateValid:
+            mNetif.SetStateChangedFlags(OT_THREAD_CHILD_REMOVED);
+
+        // Fall-through to next case
+
+        case Neighbor::kStateChildUpdateRequest:
+        case Neighbor::kStateRestored:
             RemoveStoredChild(mChildren[i].mValid.mRloc16);
+            break;
+
+        default:
+            break;
         }
 
         mChildren[i].mState = Neighbor::kStateInvalid;

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -787,6 +787,7 @@ private:
     Child *FindChild(uint16_t aChildId);
     Child *FindChild(const Mac::ExtAddress &aMacAddr);
 
+    void SetChildStateToValid(Child *aChild);
     bool HasChildren(void);
     void RemoveChildren(void);
     bool HasMinDowngradeNeighborRouters(void);


### PR DESCRIPTION
- This commit adds a new method `MleRouter::SetChildStateToValid()`
  which updates the child state to `kStateValid` and ensures to
  signal `CHILD_ADDED` and store the child info (only if child was
  not in valid state before).

- It also updates the `RemoveChildren()` to signal `CHILD_REMOVED`
  if any child is removed.