### PR TITLE
Do not include uninitialized Steering Data Tlv in Discovery Response.

### DIFF
--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -86,8 +86,7 @@ void Leader::HandlePetition(Coap::Header &aHeader, Message &aMessage, const Ip6:
     data.mCommissionerSessionId.SetCommissionerSessionId(++mSessionId);
 
     data.mSteeringData.Init();
-    data.mSteeringData.SetLength(1);
-    data.mSteeringData.Clear();
+    data.mSteeringData.SetLength(0);
 
     SuccessOrExit(mNetif.GetNetworkDataLeader().SetCommissioningData(reinterpret_cast<uint8_t *>(&data), data.GetLength()));
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2649,7 +2649,7 @@ ThreadError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, u
     // Steering Data TLV
     steeringData = mNetif.GetNetworkDataLeader().GetCommissioningDataSubTlv(MeshCoP::Tlv::kSteeringData);
 
-    if (steeringData != NULL)
+    if (steeringData != NULL && steeringData->GetLength() > 0)
     {
         SuccessOrExit(message->Append(steeringData, sizeof(*steeringData) + steeringData->GetLength()));
     }


### PR DESCRIPTION
Resolves [DEV-1385](https://threadgroup.atlassian.net/browse/DEV-1385), and helps to pass certification tests 9.2.15&9.2.16 (SiLabs DUT - OT TestBed).