### PR TITLE
Fix handle Pad1 option in IPv6 header issue.

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1309,7 +1309,7 @@ void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
         break;
     }
 
-    // Increment coutners
+    // Increment counters
     if (dstaddr.mShortAddress == kShortAddrBroadcast)
     {
         // Broadcast packet

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -472,6 +472,13 @@ ThreadError Ip6::HandleOptions(Message &message, Header &header, bool &forward)
     {
         VerifyOrExit(message.Read(message.GetOffset(), sizeof(optionHeader), &optionHeader) == sizeof(optionHeader),
                      error = kThreadError_Drop);
+
+        if (optionHeader.GetType() == OptionPad1::kType)
+        {
+            message.MoveOffset(sizeof(OptionPad1));
+            continue;
+        }
+
         VerifyOrExit(message.GetOffset() + sizeof(optionHeader) + optionHeader.GetLength() <= endOffset,
                      error = kThreadError_Drop);
 
@@ -503,15 +510,7 @@ ThreadError Ip6::HandleOptions(Message &message, Header &header, bool &forward)
             break;
         }
 
-        if (optionHeader.GetType() == OptionPad1::kType)
-        {
-            message.MoveOffset(sizeof(OptionPad1));
-        }
-        else
-        {
-            message.MoveOffset(sizeof(optionHeader) + optionHeader.GetLength());
-        }
-
+        message.MoveOffset(sizeof(optionHeader) + optionHeader.GetLength());
     }
 
 exit:


### PR DESCRIPTION
IPv6 packet with Pad1 option in its header was dropped due to the length check:

`VerifyOrExit(message.GetOffset() + sizeof(optionHeader) + optionHeader.GetLength() <= endOffset, error = kThreadError_Drop);`.

This PR fixes the issue, and helps to pass several certification interop tests with SiLabs.