### PR TITLE
fix zero-length payload with payload marker

### DIFF
--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -511,15 +511,17 @@ void NetworkDiagnostic::HandleDiagnosticGetRequest(Coap::Header &aHeader, Messag
     VerifyOrExit((message = mNetif.GetCoapServer().NewMessage(0)) != NULL, error = kThreadError_NoBufs);
 
     header.SetDefaultResponseHeader(aHeader);
-
-    if (networkDiagnosticTlv.GetLength() > 0)
-    {
-        header.SetPayloadMarker();
-    }
+    header.SetPayloadMarker();
 
     SuccessOrExit(error = message->Append(header.GetBytes(), header.GetLength()));
 
     SuccessOrExit(error = FillRequestedTlvs(aMessage, *message, networkDiagnosticTlv));
+
+    if (message->GetLength() == header.GetLength())
+    {
+        // Remove Payload Marker if payload is actually empty.
+        message->SetLength(header.GetLength() - 1);
+    }
 
     SuccessOrExit(error = mNetif.GetCoapServer().SendMessage(*message, messageInfo));
 


### PR DESCRIPTION
According to RFC7252:
> The presence of a marker followed by a zero-length payload MUST be processed as a message format error.

Since *Timeout* may be omitted, the payload can be actually empty even though requested TLV is not empty. This issue causes Router_5_7_1 pass by chance, for ARM will not process CoAP message with zero-length payload and a Payload Marker.

This PR fix this issue in this case only.