### PR TITLE
Set commissioner id tlv length with actual string length.

### DIFF
--- a/src/core/meshcop/tlvs.hpp
+++ b/src/core/meshcop/tlvs.hpp
@@ -696,6 +696,7 @@ public:
     void SetCommissionerId(const char *aCommissionerId) {
         size_t length = strnlen(aCommissionerId, sizeof(mCommissionerId));
         memcpy(mCommissionerId, aCommissionerId, length);
+        SetLength(static_cast<uint8_t>(length));
     }
 
 private:


### PR DESCRIPTION
Notice that current commissioner id tlv length is 64 in Leader Petition message, that is the maximum value. Set tlv length with the actual string length instead.
![commissioner_id_tlv_len](https://cloud.githubusercontent.com/assets/19245360/22818900/866a04ec-efaa-11e6-9691-37857467f440.jpg)
