### PR TITLE
Add constructors and destructors to crypto objects

### DIFF
--- a/src/core/crypto/aes_ecb.cpp
+++ b/src/core/crypto/aes_ecb.cpp
@@ -36,15 +36,24 @@
 namespace Thread {
 namespace Crypto {
 
-void AesEcb::SetKey(const uint8_t *aKey, uint16_t aKeyLength)
+AesEcb::AesEcb()
 {
     mbedtls_aes_init(&mContext);
+}
+
+void AesEcb::SetKey(const uint8_t *aKey, uint16_t aKeyLength)
+{
     mbedtls_aes_setkey_enc(&mContext, aKey, aKeyLength);
 }
 
 void AesEcb::Encrypt(const uint8_t aInput[kBlockSize], uint8_t aOutput[kBlockSize])
 {
     mbedtls_aes_crypt_ecb(&mContext, MBEDTLS_AES_ENCRYPT, aInput, aOutput);
+}
+
+AesEcb::~AesEcb()
+{
+    mbedtls_aes_free(&mContext);
 }
 
 }  // namespace Crypto

--- a/src/core/crypto/aes_ecb.hpp
+++ b/src/core/crypto/aes_ecb.hpp
@@ -59,6 +59,18 @@ public:
     };
 
     /**
+     * Constructor to initialize the mbedtls_aes_context.
+     *
+     */
+    AesEcb();
+
+    /**
+     * Destructor to free the mbedtls_aes_context.
+     *
+     */
+    ~AesEcb();
+
+    /**
      * This method sets the key.
      *
      * @param[in]  aKey        A pointer to the key.

--- a/src/core/crypto/hmac_sha256.cpp
+++ b/src/core/crypto/hmac_sha256.cpp
@@ -36,12 +36,21 @@
 namespace Thread {
 namespace Crypto {
 
-void HmacSha256::Start(const uint8_t *aKey, uint16_t aKeyLength)
+HmacSha256::HmacSha256()
 {
     const mbedtls_md_info_t *mdInfo = NULL;
     mbedtls_md_init(&mContext);
     mdInfo = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
     mbedtls_md_setup(&mContext, mdInfo, 1);
+}
+
+HmacSha256::~HmacSha256()
+{
+    mbedtls_md_free(&mContext);
+}
+
+void HmacSha256::Start(const uint8_t *aKey, uint16_t aKeyLength)
+{
     mbedtls_md_hmac_starts(&mContext, aKey, aKeyLength);
 }
 
@@ -53,7 +62,6 @@ void HmacSha256::Update(const uint8_t *aBuf, uint16_t aBufLength)
 void HmacSha256::Finish(uint8_t aHash[kHashSize])
 {
     mbedtls_md_hmac_finish(&mContext, aHash);
-    mbedtls_md_free(&mContext);
 }
 
 }  // namespace Crypto

--- a/src/core/crypto/hmac_sha256.hpp
+++ b/src/core/crypto/hmac_sha256.hpp
@@ -61,6 +61,18 @@ public:
     };
 
     /**
+     * Constructor for initialization of mbedtls_md_context_t.
+     *
+     */
+    HmacSha256();
+
+    /**
+     * Destructor for freeing of mbedtls_md_context_t.
+     * 
+     */
+    ~HmacSha256();
+
+    /**
      * This method sets the key.
      *
      * @param[in]  aKey        A pointer to the key.

--- a/src/core/crypto/hmac_sha256.hpp
+++ b/src/core/crypto/hmac_sha256.hpp
@@ -68,7 +68,7 @@ public:
 
     /**
      * Destructor for freeing of mbedtls_md_context_t.
-     * 
+     *
      */
     ~HmacSha256();
 

--- a/src/core/crypto/sha256.cpp
+++ b/src/core/crypto/sha256.cpp
@@ -36,9 +36,18 @@
 namespace Thread {
 namespace Crypto {
 
-void Sha256::Start(void)
+Sha256::Sha256()
 {
     mbedtls_sha256_init(&mContext);
+}
+
+Sha256::~Sha256()
+{
+    mbedtls_sha256_free(&mContext);
+}
+
+void Sha256::Start(void)
+{
     mbedtls_sha256_starts(&mContext, 0);
 }
 
@@ -50,7 +59,6 @@ void Sha256::Update(const uint8_t *aBuf, uint16_t aBufLength)
 void Sha256::Finish(uint8_t aHash[kHashSize])
 {
     mbedtls_sha256_finish(&mContext, aHash);
-    mbedtls_sha256_free(&mContext);
 }
 
 }  // namespace Crypto

--- a/src/core/crypto/sha256.hpp
+++ b/src/core/crypto/sha256.hpp
@@ -61,6 +61,18 @@ public:
     };
 
     /**
+     * Constructor for initializing mbedtls_sha256_context.
+     *
+     */
+    Sha256();
+
+    /**
+     * Destructor for freeing mbedtls_sha256_context.
+     *
+     */
+    ~Sha256();
+
+    /**
      * This method starts the SHA-256 computation.
      *
      */


### PR DESCRIPTION
Ensures mbedtls init and free functions are called when crypto objects
enter and fall out of scope.