### PR TITLE
Remove mNextHop value if it is set to link being removed.

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1818,6 +1818,20 @@ void MleRouter::HandleStateUpdateTimer(void)
                 mRouters[i].mLinkQualityOut = 0;
                 mRouters[i].mLastHeard = Timer::GetNow();
 
+                for (uint8_t j = 0; j <= kMaxRouterId; j++)
+                {
+                    if (mRouters[j].mNextHop == i)
+                    {
+                        mRouters[j].mNextHop = kInvalidRouterId;
+                        mRouters[j].mCost = 0;
+
+                        if (GetLinkCost(j) >= kMaxRouteCost)
+                        {
+                            ResetAdvertiseInterval();
+                        }
+                    }
+                }
+
                 if (mRouters[i].mNextHop == kInvalidRouterId)
                 {
                     ResetAdvertiseInterval();


### PR DESCRIPTION
This fix should allow passing test 5.3.6 for Router with new harness (beta 3).