### PR TITLE
Windows: otlwf.sys Driver Fixes

### DIFF
--- a/examples/drivers/windows/include/openthread-core-windows-config.h
+++ b/examples/drivers/windows/include/openthread-core-windows-config.h
@@ -75,5 +75,13 @@
  */
 #define OPENTHREAD_CONFIG_LOG_LEVEL                         OPENTHREAD_LOG_LEVEL_DEBG
 
+ /**
+ * @def OPENTHREAD_CONFIG_LOG_PKT_DUMP
+ *
+ * Define to enable log content of packets.
+ *
+ */
+#define OPENTHREAD_CONFIG_LOG_PKT_DUMP                      0
+
 #endif  // OPENTHREAD_CORE_WINDOWS_CONFIG_H_
 


### PR DESCRIPTION
Fixes a bug where the wrong variable was being checked for processing Windows address change notifications. Also adds some logging fixes.