### PR TITLE
`MleRouter`: Remove stored child (if already exists) before storing/saving it.

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3489,6 +3489,8 @@ ThreadError MleRouter::StoreChild(uint16_t aChildRloc16)
 
     SuccessOrExit(error = GetChildInfoById(GetChildId(aChildRloc16), childInfo));
 
+    IgnoreReturnValue(RemoveStoredChild(aChildRloc16));
+
     error = otPlatSettingsAdd(mNetif.GetInstance(), kKeyChildInfo, reinterpret_cast<uint8_t *>(&childInfo),
                               sizeof(childInfo));
 


### PR DESCRIPTION
- This ensures that the same child is not saved/stored at multiple
  indexes in the non-volatile settings.