### PR TITLE
Expect data polls from a sleepy child being restored

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1237,6 +1237,12 @@ void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
     aFrame->GetSrcAddr(srcaddr);
     neighbor = mNetif.GetMle().GetNeighbor(srcaddr);
 
+    // Ensure that the neighbor is in valid state.
+    if ((neighbor != NULL) && (neighbor->mState != Neighbor::kStateValid))
+    {
+        neighbor = NULL;
+    }
+
     switch (srcaddr.mLength)
     {
     case 0:

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -790,6 +790,7 @@ private:
     Child *FindChild(uint16_t aChildId);
     Child *FindChild(const Mac::ExtAddress &aMacAddr);
 
+    bool IsValidOrRestoringChild(const Neighbor &aNeighbor);
     void SetChildStateToValid(Child *aChild);
     bool HasChildren(void);
     void RemoveChildren(void);

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -83,7 +83,7 @@ public:
         kStateParentRequest,             ///< Received an MLE Parent Request message
         kStateChildIdRequest,            ///< Received an MLE Child ID Request message
         kStateLinkRequest,               ///< Sent an MLE Link Request message
-        kStateChildUpdateRequest,        ///< Sent an MLE Child Update Request message
+        kStateChildUpdateRequest,        ///< Sent an MLE Child Update Request message (trying to restore the child)
         kStateValid,                     ///< Link is valid
     };
 


### PR DESCRIPTION
This commit relaxes the check in `MleRouter` for `GetNeighbor()`
and `RemoveNeighbor()` methods to consider a child in restored
or restoring (`kStateChildUpdateRequest`) states in addition to
valid state.

This change ensures that an outbound message for a sleepy child being
restored in queued until a data poll is received from the child. To
ensure that a received message from such a child is not dropped (due
to security frame counter mismatch) this commit also updates the
`Mac::ReceiveDoneTask()` to ensure that the neighbor corresponding
to message source is indeed in `kStateValid` state.