### PR TITLE
Enable rx-on-when-idle on MeshForwarder just after notifying parent that mode changed.

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1603,6 +1603,10 @@ ThreadError Mle::SendChildUpdateRequest(void)
         mNetif.GetMeshForwarder().SetPollPeriod(kAttachDataPollPeriod);
         mNetif.GetMeshForwarder().SetRxOnWhenIdle(false);
     }
+    else
+    {
+        mNetif.GetMeshForwarder().SetRxOnWhenIdle(true);
+    }
 
 exit:
 


### PR DESCRIPTION
There was an issue when SED changed mode to MED. It could not receive Child Update Response (sent directly by the parent) because MeshForwarder and MAC layers were still in
rx-off-when-idle mode.