### PR TITLE
Ensure messages are sent to/received from a child being restored

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -220,7 +220,7 @@ void MeshForwarder::UpdateIndirectMessages(void)
     {
         Child *child = &children[i];
 
-        if (child->mState == Child::kStateValid || child->mQueuedIndirectMessageCnt == 0)
+        if (child->IsStateValidOrRestoring() || child->mQueuedIndirectMessageCnt == 0)
         {
             continue;
         }
@@ -245,7 +245,7 @@ void MeshForwarder::ScheduleTransmissionTask()
     {
         Child &child = children[i];
 
-        if (child.mState != Child::kStateValid || !child.mDataRequest)
+        if (!child.IsStateValidOrRestoring() || !child.mDataRequest)
         {
             continue;
         }
@@ -311,7 +311,7 @@ ThreadError MeshForwarder::AddPendingSrcMatchEntries(void)
     // Add pending short address first
     for (uint8_t i = 0; i < numChildren; i++)
     {
-        if (children[i].mState == Child::kStateValid &&
+        if (children[i].IsStateValidOrRestoring() &&
             children[i].mAddSrcMatchEntryPending &&
             children[i].mAddSrcMatchEntryShort)
         {
@@ -322,7 +322,7 @@ ThreadError MeshForwarder::AddPendingSrcMatchEntries(void)
     // Add pending extended address
     for (uint8_t i = 0; i < numChildren; i++)
     {
-        if (children[i].mState == Child::kStateValid &&
+        if (children[i].IsStateValidOrRestoring() &&
             children[i].mAddSrcMatchEntryPending &&
             !children[i].mAddSrcMatchEntryShort)
         {
@@ -447,7 +447,7 @@ ThreadError MeshForwarder::SendMessage(Message &aMessage)
 
                 for (uint8_t i = 0; i < numChildren; i++)
                 {
-                    if (children[i].mState == Neighbor::kStateValid && (children[i].mMode & Mle::ModeTlv::kModeRxOnWhenIdle) == 0)
+                    if (children[i].IsStateValidOrRestoring() && (children[i].mMode & Mle::ModeTlv::kModeRxOnWhenIdle) == 0)
                     {
                         children[i].mQueuedIndirectMessageCnt++;
                         AddSrcMatchEntry(children[i]);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2954,7 +2954,7 @@ Child *MleRouter::GetChild(uint16_t aAddress)
 {
     for (int i = 0; i < mMaxChildrenAllowed; i++)
     {
-        if (mChildren[i].mState == Neighbor::kStateValid && mChildren[i].mValid.mRloc16 == aAddress)
+        if (mChildren[i].IsStateValidOrRestoring() && mChildren[i].mValid.mRloc16 == aAddress)
         {
             return &mChildren[i];
         }
@@ -2967,7 +2967,7 @@ Child *MleRouter::GetChild(const Mac::ExtAddress &aAddress)
 {
     for (int i = 0; i < mMaxChildrenAllowed; i++)
     {
-        if (mChildren[i].mState == Neighbor::kStateValid &&
+        if (mChildren[i].IsStateValidOrRestoring() &&
             memcmp(&mChildren[i].mMacAddr, &aAddress, sizeof(mChildren[i].mMacAddr)) == 0)
         {
             return &mChildren[i];
@@ -3023,26 +3023,6 @@ exit:
     return error;
 }
 
-bool MleRouter::IsValidOrRestoringChild(const Neighbor &aNeighbor)
-{
-    bool result;
-
-    switch (aNeighbor.mState)
-    {
-    case Neighbor::kStateValid:
-    case Neighbor::kStateRestored:
-    case Neighbor::kStateChildUpdateRequest:
-        result = !IsActiveRouter(aNeighbor.mValid.mRloc16);
-        break;
-
-    default:
-        result = false;
-        break;
-    }
-
-    return result;
-}
-
 ThreadError MleRouter::RemoveNeighbor(const Mac::Address &aAddress)
 {
     ThreadError error = kThreadError_None;
@@ -3073,7 +3053,7 @@ ThreadError MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
 
     case kDeviceStateRouter:
     case kDeviceStateLeader:
-        if (IsValidOrRestoringChild(aNeighbor))
+        if (aNeighbor.IsStateValidOrRestoring() && !IsActiveRouter(aNeighbor.mValid.mRloc16))
         {
             aNeighbor.mState = Neighbor::kStateInvalid;
             mNetif.GetMeshForwarder().UpdateIndirectMessages();
@@ -3113,7 +3093,7 @@ Neighbor *MleRouter::GetNeighbor(uint16_t aAddress)
     case kDeviceStateLeader:
         for (int i = 0; i < mMaxChildrenAllowed; i++)
         {
-            if (IsValidOrRestoringChild(mChildren[i]) && mChildren[i].mValid.mRloc16 == aAddress)
+            if (mChildren[i].IsStateValidOrRestoring() && mChildren[i].mValid.mRloc16 == aAddress)
             {
                 ExitNow(rval = &mChildren[i]);
             }
@@ -3152,7 +3132,7 @@ Neighbor *MleRouter::GetNeighbor(const Mac::ExtAddress &aAddress)
     case kDeviceStateLeader:
         for (int i = 0; i < mMaxChildrenAllowed; i++)
         {
-            if (IsValidOrRestoringChild(mChildren[i]) &&
+            if (mChildren[i].IsStateValidOrRestoring() &&
                 memcmp(&mChildren[i].mMacAddr, &aAddress, sizeof(mChildren[i].mMacAddr)) == 0)
             {
                 ExitNow(rval = &mChildren[i]);
@@ -3236,7 +3216,7 @@ Neighbor *MleRouter::GetNeighbor(const Ip6::Address &aAddress)
     {
         child = &mChildren[i];
 
-        if (child->mState != Neighbor::kStateValid)
+        if (!child->IsStateValidOrRestoring())
         {
             continue;
         }

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -790,7 +790,6 @@ private:
     Child *FindChild(uint16_t aChildId);
     Child *FindChild(const Mac::ExtAddress &aMacAddr);
 
-    bool IsValidOrRestoringChild(const Neighbor &aNeighbor);
     void SetChildStateToValid(Child *aChild);
     bool HasChildren(void);
     void RemoveChildren(void);

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -92,6 +92,27 @@ public:
     bool            mDataRequest : 1;    ///< Indicates whether or not a Data Poll was received
     uint8_t         mLinkFailures;       ///< Consecutive link failure count
     LinkQualityInfo mLinkInfo;           ///< Link quality info (contains average RSS, link margin and link quality)
+
+public:
+    /*
+     * Check if the neighbor/child is in valid state or if it is being restored.
+     * When in these states messages can be sent to and/or received from the neighbor/child.
+     *
+     * @returns `true` if the neighbor is in valid, restored, or being restored states, `false` otherwise.
+     *
+     */
+    bool IsStateValidOrRestoring(void) const {
+        switch (mState) {
+        case kStateValid:
+        case kStateRestored:
+        case kStateChildUpdateRequest:
+            return true;
+
+        default:
+            return false;
+        }
+    }
+
 };
 
 /**


### PR DESCRIPTION
- Adds `Neighbor::IsStateValidOrRestoring()` to check the state.
- Update usage in `MeshForwarder` and `MleRouter`.