### PR TITLE
Fix spurious failures in 5.1.x tests.

### DIFF
--- a/tests/scripts/thread-cert/Cert_5_1_01_RouterAttach.py
+++ b/tests/scripts/thread-cert/Cert_5_1_01_RouterAttach.py
@@ -73,6 +73,7 @@ class Cert_5_1_01_RouterAttach(unittest.TestCase):
         self.nodes[LEADER].start()
         self.nodes[LEADER].set_state('leader')
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+        time.sleep(4)
 
         self.nodes[ROUTER].start()
         time.sleep(7)

--- a/tests/scripts/thread-cert/Cert_5_1_02_ChildAddressTimeout.py
+++ b/tests/scripts/thread-cert/Cert_5_1_02_ChildAddressTimeout.py
@@ -88,6 +88,7 @@ class Cert_5_1_02_ChildAddressTimeout(unittest.TestCase):
         self.nodes[LEADER].start()
         self.nodes[LEADER].set_state('leader')
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+        time.sleep(4)
 
         self.nodes[ROUTER].start()
         time.sleep(5)

--- a/tests/scripts/thread-cert/Cert_5_1_03_RouterAddressReallocation.py
+++ b/tests/scripts/thread-cert/Cert_5_1_03_RouterAddressReallocation.py
@@ -83,6 +83,7 @@ class Cert_5_1_03_RouterAddressReallocation(unittest.TestCase):
         self.nodes[LEADER].start()
         self.nodes[LEADER].set_state('leader')
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+        time.sleep(4)
 
         self.nodes[ROUTER1].start()
         time.sleep(5)

--- a/tests/scripts/thread-cert/Cert_5_1_04_RouterAddressReallocation.py
+++ b/tests/scripts/thread-cert/Cert_5_1_04_RouterAddressReallocation.py
@@ -83,6 +83,7 @@ class Cert_5_1_04_RouterAddressReallocation(unittest.TestCase):
         self.nodes[LEADER].start()
         self.nodes[LEADER].set_state('leader')
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+        time.sleep(4)
 
         self.nodes[ROUTER1].start()
         time.sleep(5)

--- a/tests/scripts/thread-cert/Cert_5_1_05_RouterAddressTimeout.py
+++ b/tests/scripts/thread-cert/Cert_5_1_05_RouterAddressTimeout.py
@@ -73,6 +73,7 @@ class Cert_5_1_05_RouterAddressTimeout(unittest.TestCase):
         self.nodes[LEADER].start()
         self.nodes[LEADER].set_state('leader')
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+        time.sleep(4)
 
         self.nodes[ROUTER1].start()
         time.sleep(5)

--- a/tests/scripts/thread-cert/Cert_5_1_06_RemoveRouterId.py
+++ b/tests/scripts/thread-cert/Cert_5_1_06_RemoveRouterId.py
@@ -73,6 +73,7 @@ class Cert_5_1_06_RemoveRouterId(unittest.TestCase):
         self.nodes[LEADER].start()
         self.nodes[LEADER].set_state('leader')
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+        time.sleep(4)
 
         self.nodes[ROUTER1].start()
         time.sleep(5)

--- a/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
+++ b/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
@@ -74,6 +74,7 @@ class Cert_5_1_07_MaxChildCount(unittest.TestCase):
         self.nodes[LEADER].start()
         self.nodes[LEADER].set_state('leader')
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+        time.sleep(4)
 
         self.nodes[ROUTER].start()
         time.sleep(5)

--- a/tests/scripts/thread-cert/Cert_5_1_08_RouterAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_5_1_08_RouterAttachConnectivity.py
@@ -100,6 +100,7 @@ class Cert_5_1_08_RouterAttachConnectivity(unittest.TestCase):
         self.nodes[LEADER].start()
         self.nodes[LEADER].set_state('leader')
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+        time.sleep(4)
 
         for i in range(2, 6):
             self.nodes[i].start()

--- a/tests/scripts/thread-cert/Cert_5_1_09_REEDAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_5_1_09_REEDAttachConnectivity.py
@@ -100,6 +100,7 @@ class Cert_5_1_09_REEDAttachConnectivity(unittest.TestCase):
         self.nodes[LEADER].start()
         self.nodes[LEADER].set_state('leader')
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+        time.sleep(4)
 
         self.nodes[ROUTER1].start()
         time.sleep(5)

--- a/tests/scripts/thread-cert/Cert_5_1_10_RouterAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_5_1_10_RouterAttachLinkQuality.py
@@ -90,6 +90,7 @@ class Cert_5_1_10_RouterAttachLinkQuality(unittest.TestCase):
         self.nodes[LEADER].start()
         self.nodes[LEADER].set_state('leader')
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+        time.sleep(4)
 
         self.nodes[ROUTER1].start()
         time.sleep(5)

--- a/tests/scripts/thread-cert/Cert_5_1_11_REEDAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_5_1_11_REEDAttachLinkQuality.py
@@ -90,6 +90,7 @@ class Cert_5_1_11_REEDAttachLinkQuality(unittest.TestCase):
         self.nodes[LEADER].start()
         self.nodes[LEADER].set_state('leader')
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+        time.sleep(4)
 
         self.nodes[REED].start()
         time.sleep(5)

--- a/tests/scripts/thread-cert/Cert_5_1_12_NewRouterNeighborSync.py
+++ b/tests/scripts/thread-cert/Cert_5_1_12_NewRouterNeighborSync.py
@@ -115,6 +115,7 @@ class Cert_5_1_12_NewRouterSync(unittest.TestCase):
         self.nodes[LEADER].start()
         self.nodes[LEADER].set_state('leader')
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+        time.sleep(4)
 
         self.nodes[ROUTER1].start()
         time.sleep(5)

--- a/tests/scripts/thread-cert/Cert_5_1_13_RouterReset.py
+++ b/tests/scripts/thread-cert/Cert_5_1_13_RouterReset.py
@@ -72,6 +72,7 @@ class Cert_5_1_13_RouterReset(unittest.TestCase):
         self.nodes[LEADER].start()
         self.nodes[LEADER].set_state('leader')
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+        time.sleep(4)
 
         self.nodes[ROUTER].start()
         time.sleep(5)

--- a/tests/scripts/thread-cert/message.py
+++ b/tests/scripts/thread-cert/message.py
@@ -250,7 +250,7 @@ class Message(object):
         assert self.ipv6_packet.ipv6_header.hop_limit == hop_limit
 
     def __repr__(self):
-        return "Message(type={})".format(self.type)
+        return "Message(type={})".format(MessageType(self.type).name)
 
 
 class MessagesSet(object):


### PR DESCRIPTION
There were spurious failures in 5.1.x tests caused by missing MLE advertisements sent from leader. Adding sleep for 4 seconds right after the leader start causes that MLE advertisements are always sent to children and tests work properly.