### PR TITLE
Reattach when parent fails to respond to child update request

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1419,6 +1419,7 @@ private:
     uint8_t mParentLinkQuality3;
     uint8_t mParentLinkQuality2;
     uint8_t mParentLinkQuality1;
+    uint8_t mKeepAliveAttemptsSent;
     LeaderDataTlv mParentLeaderData;
     bool mParentIsSingleton;
 


### PR DESCRIPTION
If the old parent becomes REED or child, it can still ACK the child's keep-alive ChildUpdateRequest, causing child cannot reattach.

This PR fixes this issue by counting keep-alive requests and responses and if more than `kMaxChildKeepAliveAttempts` requests has not been responded, start reattaching.