### PR TITLE
Let platforms specify linker section for version string

### DIFF
--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -1145,16 +1145,39 @@ void otRemoveStateChangeCallback(otInstance *aInstance, otStateChangedCallback a
 
 const char *otGetVersionString(void)
 {
-    static const char sVersion[] =
+    /**
+     * PLATFORM_VERSION_ATTR_PREFIX and PLATFORM_VERSION_ATTR_SUFFIX are
+     * intended to be used to specify compiler directives to indicate
+     * what linker section the platform version string should be stored.
+     *
+     * This is useful for specifying an exact locaiton of where the version
+     * string will be located so that it can be easily retrieved from the
+     * raw firmware image.
+     *
+     * If PLATFORM_VERSION_ATTR_PREFIX is unspecified, the keyword `static`
+     * is used instead.
+     *
+     * If both are unspecified, the location of the string in the firmware
+     * image will be undefined and may change.
+     */
+
+#ifdef PLATFORM_VERSION_ATTR_PREFIX
+    PLATFORM_VERSION_ATTR_PREFIX
+#else
+    static
+#endif
+    const char sVersion[] =
         PACKAGE_NAME "/" PACKAGE_VERSION
 #ifdef  PLATFORM_INFO
         "; " PLATFORM_INFO
 #endif
 #if defined(__DATE__)
-        "; " __DATE__ " " __TIME__;
-#else
-        ;
+        "; " __DATE__ " " __TIME__
 #endif
+#ifdef PLATFORM_VERSION_ATTR_SUFFIX
+        PLATFORM_VERSION_ATTR_SUFFIX
+#endif
+        ; // Trailing semicolon to end statement.
 
     return sVersion;
 }


### PR DESCRIPTION
`PLATFORM_VERSION_ATTR_PREFIX` and `PLATFORM_VERSION_ATTR_SUFFIX` are intended to be used to specify compiler directives to indicate what linker section the platform version string should be stored.

This is useful for specifying an exact location of where the version string will be located so that it can be easily retrieved from the raw firmware image.

If `PLATFORM_VERSION_ATTR_PREFIX` is unspecified, the keyword `static` is used instead.

If both are unspecified, the location of the string in the firmware image will be undefined and may change.