### PR TITLE
Reset message offset at the beginning of new scheduled transmission.

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -296,6 +296,9 @@ void MeshForwarder::ScheduleTransmissionTask()
         ExitNow();
     }
 
+    // Reset offset for this message
+    mMessageNextOffset = 0;
+
 exit:
     (void) error;
 }


### PR DESCRIPTION
If a sleepy end device loses its parent while in the middle of
transmitting a large fragmented packet, it gets into a state
where it tries to send out a scheduled data poll by applies the
offset of a previous message. This causes an assert at SetOffset.