### PR TITLE
`MeshForwader`: Check error cases from `SendPoll` and `SendMesh`

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1096,18 +1096,19 @@ ThreadError MeshForwarder::HandleFrameRequest(Mac::Frame &aFrame)
             error = SendFragment(*mSendMessage, aFrame);
         }
 
-        assert(error == kThreadError_None);
         assert(aFrame.GetLength() != 7);
         break;
 
     case Message::kType6lowpan:
-        SendMesh(*mSendMessage, aFrame);
+        error = SendMesh(*mSendMessage, aFrame);
         break;
 
     case Message::kTypeMacDataPoll:
-        SendPoll(*mSendMessage, aFrame);
+        error = SendPoll(*mSendMessage, aFrame);
         break;
     }
+
+    assert(error == kThreadError_None);
 
     // set FramePending if there are more queued messages for the child
     aFrame.GetDstAddr(macDest);
@@ -1125,13 +1126,9 @@ exit:
 
 ThreadError MeshForwarder::SendPoll(Message &aMessage, Mac::Frame &aFrame)
 {
-    ThreadError error = kThreadError_None;
     Mac::Address macSource;
     uint16_t fcf;
     Neighbor *neighbor;
-
-    // only send MAC Data Requests in rx-off-when-idle mode
-    VerifyOrExit(!mNetif.GetMac().GetRxOnWhenIdle(), error = kThreadError_InvalidState);
 
     macSource.mShortAddress = mNetif.GetMac().GetShortAddress();
 
@@ -1180,8 +1177,7 @@ ThreadError MeshForwarder::SendPoll(Message &aMessage, Mac::Frame &aFrame)
 
     mMessageNextOffset = aMessage.GetLength();
 
-exit:
-    return error;
+    return kThreadError_None;
 }
 
 ThreadError MeshForwarder::SendMesh(Message &aMessage, Mac::Frame &aFrame)


### PR DESCRIPTION

This commit makes the following changes:

- Change `SendPoll()` to allow scheduled data polls to be sent
  even when `RxOnWhenIOdle` is `true`.

- Add checks for error cases from `SendPoll()` and `SendMesh()`
  in `MeshForwarder::HandleFrameRequest()` which all should
  be successful and asserts in case of failure.

  These changes addresses a (rare) assert issue: A call to `SendPoll()`
  could fail due to mode change to "detached" and `RxOnWhenIdle`
  becoming `true` and in turn `mNextOffset` would not be updated which
  caused an assert when the incorrect offset was set on data poll
  message from `HandleSentFrame()`.