### PR TITLE
Added configure option to limit builds to only mtd

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -73,6 +73,12 @@ set -x
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-ftd || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-mtd || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp || die
+
+    git checkout -- . || die
+    git clean -xfd || die
+    ./bootstrap || die
+    ONLY_MTD=1 make -f examples/Makefile-cc2650 || die
+    arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-mtd || die
 }
 
 [ $BUILD_TARGET != arm-gcc54 ] || {
@@ -105,10 +111,8 @@ set -x
     git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
-    make -f examples/Makefile-cc2650 || die
-    arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-ftd || die
+    ONLY_MTD=1 make -f examples/Makefile-cc2650 || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-mtd || die
-    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp || die
 }
 
 [ $BUILD_TARGET != posix ] || {

--- a/configure.ac
+++ b/configure.ac
@@ -422,7 +422,7 @@ AC_ARG_ENABLE(cli,
     [
         case "${enableval}" in
 
-        no|yes)
+        no|yes|mtd|ftd)
             enable_cli=${enableval}
             ;;
 
@@ -433,7 +433,9 @@ AC_ARG_ENABLE(cli,
     ],
     [enable_cli=no])
 AC_MSG_RESULT(${enable_cli})
-AM_CONDITIONAL([OPENTHREAD_ENABLE_CLI], [test "${enable_cli}" = "yes"])
+AM_CONDITIONAL([OPENTHREAD_ENABLE_CLI], [test "${enable_cli}" != "no"])
+AM_CONDITIONAL([OPENTHREAD_ENABLE_CLI_FTD], [test "${enable_cli}" = "yes" -o "${enable_cli}" = "ftd"])
+AM_CONDITIONAL([OPENTHREAD_ENABLE_CLI_MTD], [test "${enable_cli}" = "yes" -o "${enable_cli}" = "mtd"])
 
 #
 # NCP Library

--- a/examples/Makefile-cc2650
+++ b/examples/Makefile-cc2650
@@ -42,15 +42,26 @@ OBJCOPY                         = arm-none-eabi-objcopy
 BuildJobs                      ?= 99
 
 configure_OPTIONS               = \
-    --enable-cli                  \
-    --enable-ncp                  \
     --with-examples=cc2650        \
     --with-platform-info=cc2650   \
     MBEDTLS_CPPFLAGS="$(CC2650_MBEDTLS_CPPFLAGS)" \
     $(NULL)
 
 ifeq ($(DISABLE_DOC),1)
-configure_OPTIONS              += --disable-docs
+configure_OPTIONS              += \
+    --disable-docs                \
+    $(NULL)
+endif
+
+ifeq ($(ONLY_MTD),1)
+configure_OPTIONS              += \
+    --enable-cli=mtd              \
+    $(NULL)
+else
+configure_OPTIONS              += \
+    --enable-cli                  \
+    --enable-ncp                  \
+    $(NULL)
 endif
 
 CC2650_MBEDTLS_CPPFLAGS  = -DMBEDTLS_CONFIG_FILE='\"cc2650-mbedtls-config.h\"'

--- a/examples/apps/cli/Makefile.am
+++ b/examples/apps/cli/Makefile.am
@@ -29,8 +29,6 @@
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 bin_PROGRAMS                                                           = \
-    ot-cli-ftd                                                           \
-    ot-cli-mtd                                                           \
     $(NULL)
 
 CPPFLAGS_COMMON                                                        = \
@@ -115,6 +113,11 @@ LDFLAGS_COMMON                                                        += \
     $(NULL)
 endif
 
+if OPENTHREAD_ENABLE_CLI_FTD
+bin_PROGRAMS                                                          += \
+    ot-cli-ftd                                                           \
+    $(NULL)
+
 ot_cli_ftd_CPPFLAGS                                                    = \
     $(CPPFLAGS_COMMON)                                                   \
     $(NULL)
@@ -130,6 +133,12 @@ ot_cli_ftd_LDFLAGS                                                     = \
 
 ot_cli_ftd_SOURCES                                                     = \
     $(SOURCES_COMMON)                                                    \
+    $(NULL)
+endif # OPENTHREAD_ENABLE_CLI_FTD
+
+if OPENTHREAD_ENABLE_CLI_MTD
+bin_PROGRAMS                                                          += \
+    ot-cli-mtd                                                           \
     $(NULL)
 
 ot_cli_mtd_CPPFLAGS                                                    = \
@@ -148,6 +157,7 @@ ot_cli_mtd_LDFLAGS                                                     = \
 ot_cli_mtd_SOURCES                                                     = \
     $(SOURCES_COMMON)                                                    \
     $(NULL)
+endif # OPENTHREAD_ENABLE_CLI_MTD
 
 if OPENTHREAD_BUILD_COVERAGE
 CLEANFILES                                                             = $(wildcard *.gcda *.gcno)

--- a/examples/platforms/cc2650/README.md
+++ b/examples/platforms/cc2650/README.md
@@ -3,9 +3,11 @@
 This directory contains example platform drivers for the [Texas
 Instruments CC2650][cc2650].
 
-The example platform drivers are intended to present the minimal code
-necessary to support OpenThread.  As a result, the example platform
-drivers do not necessarily highlight the platform's full capabilities.
+The example platform drivers are intended to present the minimal code necessary
+to support OpenThread. As a result, the example platform drivers do not
+necessarily highlight the platform's full capabilities. The platform
+abstraction layer was build for the [CC2650 LAUNCHXL][cc2650-launchxl], usage
+on other boards with a CC2650 will require changes to the peripheral drivers.
 
 Due to flash size limitations, some features of OpenThread are not supported on
 the [Texas Instruments CC2650][cc2650]. This platform is intended for
@@ -14,7 +16,14 @@ environment. Texas Instruments recommends future TI SoCs for production.
 
 Building with gcc 5.4 is recommended due to generated code size concerns.
 
+All three configurations were tested with `arm-none-eabi-gcc 5.4.1 20160609
+(release)` on [this commit][tested-commit]. The automatic integration builds have since
+been limited to only the `cli-mtd` configuration to limit the impact on pull
+requests.
+
 [cc2650]: http://www.ti.com/product/CC2650
+[cc2650-launchxl]: http://www.ti.com/tool/Launchxl-cc2650
+[tested-commit]: https://github.com/openthread/openthread/commit/e8611291d65e8ad28d77a7645695c5352504c3dd
 
 ## Build Environment
 


### PR DESCRIPTION
This pull request limits integration builds for CC2650 to only MTD configurations. This is to avoid blocking pull requests due to code size.