### PR TITLE
spi-hdlc-adapter: Add support for raw mode.

### DIFF
--- a/tools/spi-hdlc-adapter/README.md
+++ b/tools/spi-hdlc-adapter/README.md
@@ -19,6 +19,12 @@ protocol document.
 *   `--pty`: Create a pseudo terminal for HDLC input/output. The path
     of the newly-created PTY will be written to `stdout`, followed by
     a newline.
+*   `--raw`: Do not encode/decode packets using HDLC. Instead, write
+    whole, raw frames to the specified input and output FDs. This is
+    useful for emulating a serial port, or when datagram-based sockets
+    are supplied for `stdin` and `stdout` (when used with `--stdio`).
+*   `--mtu=[MTU]`: Specify the MTU. Currently only used in raw mode.
+    Default and maximum value is 2043. Must be greater than zero.
 *   `--gpio-int[=gpio-path]`: Specify a path to the Linux
     sysfs-exported GPIO directory for the `I̅N̅T̅` pin. If not
     specified, `spi-hdlc-adapter` will fall back to polling, which is
@@ -27,8 +33,14 @@ protocol document.
     sysfs-exported GPIO directory for the `R̅E̅S̅` pin.
 *   `--spi-mode[=mode]`: Specify the SPI mode to use (0-3).
 *   `--spi-speed[=hertz]`: Specify the SPI speed in hertz.
-*   `--spi-cs-delay[=usec]`: Specify the delay after C̅S̅ assertion, in
-    microseconds.
+*   `--spi-cs-delay[=usec]`: Specify the delay after C̅S̅ assertion,
+    in microseconds.
+*   `--spi-align-allowance[=n]`: Specify the the maximum number of 0xFF
+    bytes to clip from start of MISO frame. This makes this tool usable
+    with SPI slaves which have buggy SPI blocks that prepend up to
+    three 0xFF bytes to the start of MISO frame. Default value is `0`.
+    Maximum value is `3`. *This must be set to `2` for chips in the
+    SiLabs EM35x family.*
 *   `--verbose`: Increase debug verbosity.
 *   `--help`: Print out usage information to `stdout` and exit.
 


### PR DESCRIPTION
This commit adds support for two new arguments:

*   `--raw`: Do not encode/decode packets using HDLC. Instead, write whole, raw frames to the specified input and output FDs. This is useful for emulating a serial port, or when datagram-based sockets are supplied for `stdin` and `stdout` (when used with `--stdio`).
*   `--mtu=[MTU]`: Specify the MTU. Currently only used in raw mode.    Default and maximum value is 2043. Must be greater than zero.

The `--raw` argument will allow `wpantund` to use `spi-hdlc-adapter` without HDLC escaping by supplying datagram sockets for stdin and stdout. This should improve performance and reduce latency.

The `--mtu` argument is supplied to benefit the use case where we are emulating an asynchronous serial port over SPI. In such a case, you would likely want to lower the MTU significantly to match the internal buffer size of the MCU.

The code path for when these arguments are not used is unaffected.

Additional minor changes include:

* Version is bumped to 0.04.
* `--spi-align-allowance` is now documented in `README.md`.