### PR TITLE
Change the LDADD order in `cli` Makefile

### DIFF
--- a/examples/apps/cli/Makefile.am
+++ b/examples/apps/cli/Makefile.am
@@ -40,7 +40,6 @@ CPPFLAGS_COMMON                                                        = \
     $(NULL)
 
 LDADD_COMMON                                                           = \
-    $(top_builddir)/src/cli/libopenthread-cli.a                          \
     $(NULL)
 
 LDFLAGS_COMMON                                                         = \
@@ -120,6 +119,7 @@ ot_cli_ftd_CPPFLAGS                                                    = \
     $(NULL)
 
 ot_cli_ftd_LDADD                                                       = \
+    $(top_builddir)/src/cli/libopenthread-cli.a                          \
     $(top_builddir)/src/core/libopenthread-ftd.a                         \
     $(LDADD_COMMON)                                                      \
     $(NULL)
@@ -137,6 +137,7 @@ ot_cli_mtd_CPPFLAGS                                                    = \
     $(NULL)
 
 ot_cli_mtd_LDADD                                                       = \
+    $(top_builddir)/src/cli/libopenthread-cli.a                          \
     $(top_builddir)/src/core/libopenthread-mtd.a                         \
     $(LDADD_COMMON)                                                      \
     $(NULL)


### PR DESCRIPTION
This commit changes the order of libs in the cli makefile to address
the issue with older gcc tool-chain.