### PR TITLE
Fix CoAP not handling certain types of ACKs

### DIFF
--- a/include/openthread-coap.h
+++ b/include/openthread-coap.h
@@ -78,7 +78,7 @@ typedef enum otCoapCode
     kCoapRequestPost     = 0x02,  ///< Post
     kCoapRequestPut      = 0x03,  ///< Put
     kCoapRequestDelete   = 0x04,  ///< Delete
-    kCoapResponse200     = 0x40,  ///< 2.00
+    kCoapResponseCodeMin = 0x40,  ///< 2.00
     kCoapResponseCreated = 0x41,  ///< Created
     kCoapResponseDeleted = 0x42,  ///< Deleted
     kCoapResponseValid   = 0x43,  ///< Valid

--- a/include/openthread-coap.h
+++ b/include/openthread-coap.h
@@ -78,6 +78,10 @@ typedef enum otCoapCode
     kCoapRequestPost     = 0x02,  ///< Post
     kCoapRequestPut      = 0x03,  ///< Put
     kCoapRequestDelete   = 0x04,  ///< Delete
+    kCoapResponse200     = 0x40,  ///< 2.00
+    kCoapResponseCreated = 0x41,  ///< Created
+    kCoapResponseDeleted = 0x42,  ///< Deleted
+    kCoapResponseValid   = 0x43,  ///< Valid
     kCoapResponseChanged = 0x44,  ///< Changed
     kCoapResponseContent = 0x45,  ///< Content
 } otCoapCode;

--- a/src/core/coap/coap_header.hpp
+++ b/src/core/coap/coap_header.hpp
@@ -380,7 +380,7 @@ public:
      * @retval FALSE  Header is not a response header.
      *
      */
-    bool IsResponse(void) const { return (GetCode() >= kCoapResponseChanged); };
+    bool IsResponse(void) const { return (GetCode() >= kCoapResponse200); };
 
     /**
      * This method checks if a header is a CON message header.

--- a/src/core/coap/coap_header.hpp
+++ b/src/core/coap/coap_header.hpp
@@ -380,7 +380,7 @@ public:
      * @retval FALSE  Header is not a response header.
      *
      */
-    bool IsResponse(void) const { return (GetCode() >= kCoapResponse200); };
+    bool IsResponse(void) const { return (GetCode() >= kCoapResponseCodeMin); };
 
     /**
      * This method checks if a header is a CON message header.


### PR DESCRIPTION
ACK's with piggyback data and 2.00-2.03 response codes were ignored.