### PR TITLE
Do not setup neighbor state when responding to MLE Link Request from child.

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -712,11 +712,19 @@ ThreadError MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::Mes
                 VerifyOrExit(memcmp(&neighbor->mMacAddr, &macAddr, sizeof(neighbor->mMacAddr)) == 0, ;);
             }
         }
+        else
+        {
+            // source is not a router
+            neighbor = NULL;
+        }
     }
     else
     {
         // lack of source address indicates router coming out of reset
-        VerifyOrExit((neighbor = GetNeighbor(macAddr)) != NULL, error = kThreadError_Drop);
+        VerifyOrExit((neighbor = GetNeighbor(macAddr)) != NULL &&
+                     neighbor->mState == Neighbor::kStateValid &&
+                     IsActiveRouter(neighbor->mValid.mRloc16),
+                     error = kThreadError_Drop);
     }
 
     // TLV Request


### PR DESCRIPTION
- Fixes #1354.