### PR TITLE
Evict least-recently-used address cache entry.

### DIFF
--- a/src/core/thread/address_resolver_ftd.hpp
+++ b/src/core/thread/address_resolver_ftd.hpp
@@ -138,6 +138,7 @@ private:
         uint16_t          mRetryTimeout;
         uint8_t           mTimeout;
         uint8_t           mFailures;
+        uint8_t           mAge;
 
         enum State
         {
@@ -147,6 +148,10 @@ private:
         };
         State             mState;
     };
+
+    Cache *NewCacheEntry(void);
+    void MarkCacheEntryAsUsed(Cache &aEntry);
+    void InvalidateCacheEntry(Cache &aEntry);
 
     ThreadError SendAddressQuery(const Ip6::Address &aEid);
     ThreadError SendAddressError(const ThreadTargetTlv &aTarget, const ThreadMeshLocalEidTlv &aEid,


### PR DESCRIPTION
- Maintain ordering of cache entries based on use.
- Evict least-recently-used cache entry when all are used.
- Fixes #1336.