### PR TITLE
[UART] Remove otPlatUartEnable from platform.c files

### DIFF
--- a/examples/platforms/cc2538/platform.c
+++ b/examples/platforms/cc2538/platform.c
@@ -32,7 +32,6 @@
  *   This file includes the platform-specific initializers.
  */
 
-#include <platform/uart.h>
 #include "platform-cc2538.h"
 
 otInstance *sInstance;
@@ -42,7 +41,6 @@ void PlatformInit(int argc, char *argv[])
     cc2538AlarmInit();
     cc2538RandomInit();
     cc2538RadioInit();
-    otPlatUartEnable();
 
     (void)argc;
     (void)argv;

--- a/examples/platforms/cc2650/platform.c
+++ b/examples/platforms/cc2650/platform.c
@@ -27,7 +27,6 @@
  */
 
 #include <openthread-types.h>
-#include <platform/uart.h>
 #include "platform-cc2650.h"
 
 otInstance *sInstance;
@@ -42,7 +41,6 @@ void PlatformInit(int argc, char *argv[])
     cc2650AlarmInit();
     cc2650RandomInit();
     cc2650RadioInit();
-    otPlatUartEnable();
 }
 
 /**

--- a/examples/platforms/da15000/platform.c
+++ b/examples/platforms/da15000/platform.c
@@ -43,7 +43,6 @@
 #include "hw_watchdog.h"
 #include "ftdf.h"
 #include "hw_gpio.h"
-#include "platform/uart.h"
 
 static bool sBlink = false;
 static int  sMsCounterInit;
@@ -144,8 +143,6 @@ void PlatformInit(int argc, char *argv[])
     da15000AlarmInit();
     // Initialize Radio
     da15000RadioInit();
-    // Initialize UART
-    otPlatUartEnable();
     // enable interrupts
     portENABLE_INTERRUPTS();
 

--- a/examples/platforms/nrf52840/platform.c
+++ b/examples/platforms/nrf52840/platform.c
@@ -33,7 +33,6 @@
  */
 
 #include <platform/logging.h>
-#include <platform/uart.h>
 
 #include "drivers/nrf_drv_clock.h"
 #include "platform-nrf5.h"
@@ -58,9 +57,6 @@ void PlatformInit(int argc, char *argv[])
 #if (OPENTHREAD_ENABLE_DEFAULT_LOGGING == 0)
     nrf5LogInit();
 #endif
-
-    // Enable UART since its not enabled by higher level layers.
-    otPlatUartEnable();
 }
 
 void PlatformProcessDrivers(otInstance *aInstance)

--- a/examples/platforms/posix/platform.c
+++ b/examples/platforms/posix/platform.c
@@ -49,7 +49,6 @@
 #include <openthread.h>
 #include <openthread-tasklet.h>
 #include <platform/alarm.h>
-#include <platform/uart.h>
 
 uint32_t NODE_ID = 1;
 uint32_t WELLKNOWN_NODE_ID = 34;
@@ -81,8 +80,6 @@ void PlatformInit(int argc, char *argv[])
     platformRandomInit();
 }
 
-bool UartInitialized = false;
-
 void PlatformProcessDrivers(otInstance *aInstance)
 {
     fd_set read_fds;
@@ -91,12 +88,6 @@ void PlatformProcessDrivers(otInstance *aInstance)
     int max_fd = -1;
     struct timeval timeout;
     int rval;
-
-    if (!UartInitialized)
-    {
-        UartInitialized = true;
-        otPlatUartEnable();
-    }
 
     FD_ZERO(&read_fds);
     FD_ZERO(&write_fds);
@@ -121,4 +112,3 @@ void PlatformProcessDrivers(otInstance *aInstance)
     platformRadioProcess(aInstance);
     platformAlarmProcess(aInstance);
 }
-

--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -68,6 +68,8 @@ Uart::Uart(otInstance *aInstance):
     mTxHead = 0;
     mTxLength = 0;
     mSendLength = 0;
+
+    otPlatUartEnable();
 }
 
 extern "C" void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength)

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -95,6 +95,8 @@ NcpUart::NcpUart(otInstance *aInstance):
     mUartSendTask(aInstance->mIp6.mTaskletScheduler, EncodeAndSendToUart, this)
 {
     mTxFrameBuffer.SetCallbacks(NULL, TxFrameBufferHasData, this);
+
+    otPlatUartEnable();
 }
 
 ThreadError NcpUart::OutboundFrameBegin(void)


### PR DESCRIPTION
This PR change place of `otPlatUartEnable` execution, from platform files to propriate transport of CLI and NCP.

If application doesn't want to use CLI/NCP it can simply skip calling e.g. `otCliUartInit` instead of calling `otPlatUartDisable `in order to disable UART (e.g. to reduce power consumption).