### PR TITLE
Fix Commissioning dataset update

### DIFF
--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -507,6 +507,7 @@ ThreadError Commissioner::SendPetition(void)
 
     mNetif.GetMle().GetLeaderAloc(*static_cast<Ip6::Address *>(&messageInfo.mPeerAddr));
     messageInfo.SetPeerPort(kCoapUdpPort);
+    messageInfo.SetSockAddr(mNetif.GetMle().GetMeshLocal16());
     SuccessOrExit(error = mNetif.GetCoapClient().SendMessage(*message, messageInfo,
                                                              Commissioner::HandleLeaderPetitionResponse, this));
 


### PR DESCRIPTION
This PR fixes two issues that emerged when Border Router is present in the network:
1.  HandleCommissioningSet function wrongly assumed that Commissioner Dataset TLV is always present at the beginnig of Network Data.
2. HandlePetition sets Border Agent Locator basing on the originators source address, so set it explicitly to RLOC on the originator side.