### PR TITLE
Windows: Reset new test Nodes

### DIFF
--- a/examples/drivers/windows/otLwf/command.c
+++ b/examples/drivers/windows/otLwf/command.c
@@ -242,7 +242,6 @@ otLwfCmdProcess(
                 KeSetEvent(&pFilter->cmdResetCompleteEvent, IO_NO_INCREMENT, FALSE);
 
                 // TODO - Should this be passed on to Thread or Tunnel logic?
-                NT_ASSERT(pFilter->DeviceStatus == OTLWF_DEVICE_STATUS_UNINTIALIZED);
             }
         }
         else if (ExAcquireRundownProtection(&pFilter->ExternalRefs))

--- a/examples/drivers/windows/otLwf/eventprocessing.c
+++ b/examples/drivers/windows/otLwf/eventprocessing.c
@@ -712,7 +712,6 @@ otLwfEventWorkerThread(
     )
 {
     PMS_FILTER pFilter = (PMS_FILTER)Context;
-    size_t otInstanceSize = 0;
     NT_ASSERT(pFilter);
 
     LogFuncEntry(DRIVER_DEFAULT);
@@ -753,32 +752,33 @@ otLwfEventWorkerThread(
     otLwfRadioInit(pFilter);
 
     // Calculate the size of the otInstance and allocate it
-    (VOID)otInstanceInit(NULL, &otInstanceSize);
-    NT_ASSERT(otInstanceSize != 0);
+    pFilter->otInstanceSize = 0;
+    (VOID)otInstanceInit(NULL, &pFilter->otInstanceSize);
+    NT_ASSERT(pFilter->otInstanceSize != 0);
 
     // Add space for a pointer back to the filter
-    otInstanceSize += sizeof(PMS_FILTER);
+    pFilter->otInstanceSize += sizeof(PMS_FILTER);
 
     // Allocate the buffer
-    pFilter->otInstanceBuffer = (PUCHAR)FILTER_ALLOC_MEM(pFilter->FilterHandle, (ULONG)otInstanceSize);
+    pFilter->otInstanceBuffer = (PUCHAR)FILTER_ALLOC_MEM(pFilter->FilterHandle, (ULONG)pFilter->otInstanceSize);
     if (pFilter == NULL)
     {
-        LogWarning(DRIVER_DEFAULT, "Failed to allocate otInstance buffer, 0x%x bytes", (ULONG)otInstanceSize);
+        LogWarning(DRIVER_DEFAULT, "Failed to allocate otInstance buffer, 0x%x bytes", (ULONG)pFilter->otInstanceSize);
         goto exit;
     }
-    RtlZeroMemory(pFilter->otInstanceBuffer, otInstanceSize);
+    RtlZeroMemory(pFilter->otInstanceBuffer, pFilter->otInstanceSize);
 
     // Store the pointer and decrement the size
     memcpy(pFilter->otInstanceBuffer, &pFilter, sizeof(PMS_FILTER));
-    otInstanceSize -= sizeof(PMS_FILTER);
+    pFilter->otInstanceSize -= sizeof(PMS_FILTER);
 
     // Initialize the OpenThread library
     pFilter->otCachedRole = kDeviceRoleDisabled;
-    pFilter->otCtx = otInstanceInit(pFilter->otInstanceBuffer + sizeof(PMS_FILTER), &otInstanceSize);
+    pFilter->otCtx = otInstanceInit(pFilter->otInstanceBuffer + sizeof(PMS_FILTER), &pFilter->otInstanceSize);
     NT_ASSERT(pFilter->otCtx);
     if (pFilter->otCtx == NULL)
     {
-        LogError(DRIVER_DEFAULT, "otInstanceInit failed, otInstanceSize = %u bytes", (ULONG)otInstanceSize);
+        LogError(DRIVER_DEFAULT, "otInstanceInit failed, otInstanceSize = %u bytes", (ULONG)pFilter->otInstanceSize);
         goto exit;
     }
 

--- a/examples/drivers/windows/otLwf/filter.h
+++ b/examples/drivers/windows/otLwf/filter.h
@@ -271,6 +271,7 @@ typedef struct _MS_FILTER
         // OpenThread context buffer
         //
         otInstance*                 otCtx;
+        size_t                      otInstanceSize;
         PUCHAR                      otInstanceBuffer;
     };
     struct // Tunnel Mode Variables

--- a/examples/drivers/windows/otLwf/radio.c
+++ b/examples/drivers/windows/otLwf/radio.c
@@ -57,6 +57,8 @@ otPlatReset(
     NT_ASSERT(otCtx);
     PMS_FILTER pFilter = otCtxToFilter(otCtx);
 
+    LogFuncEntry(DRIVER_DEFAULT);
+
     LogInfo(DRIVER_DEFAULT, "Interface %!GUID! resetting...", &pFilter->InterfaceGuid);
 
     // Indicate to the miniport
@@ -70,6 +72,9 @@ otPlatReset(
     pFilter->otPhyState = kStateDisabled;
     pFilter->otCurrentListenChannel = 0xFF;
     pFilter->otPromiscuous = false;
+    pFilter->otPendingMacOffloadEnabled = FALSE;
+    pFilter->otPendingShortAddressCount = 0;
+    pFilter->otPendingExtendedAddressCount = 0;
 
     // Reinitialize the OpenThread library
     pFilter->otCachedRole = kDeviceRoleDisabled;
@@ -91,6 +96,8 @@ otPlatReset(
 
     // Initialze media connect state to disconnected
     otLwfIndicateLinkState(pFilter, MediaConnectStateDisconnected);
+
+    LogFuncExit(DRIVER_DEFAULT);
 }
 
 otPlatResetReason 

--- a/examples/drivers/windows/otLwf/radio.c
+++ b/examples/drivers/windows/otLwf/radio.c
@@ -61,6 +61,27 @@ otPlatReset(
 
     // Indicate to the miniport
     (void)otLwfCmdResetDevice(pFilter, TRUE);
+
+    // Reinitialize the OpenThread library
+    pFilter->otCachedRole = kDeviceRoleDisabled;
+    pFilter->otCtx = otInstanceInit(pFilter->otInstanceBuffer + sizeof(PMS_FILTER), &pFilter->otInstanceSize);
+    ASSERT(pFilter->otCtx);
+
+    // Make sure our helper function returns the right pointer for the filter, given the openthread instance
+    NT_ASSERT(otCtxToFilter(pFilter->otCtx) == pFilter);
+
+    // Disable Icmp (ping) handling
+    otSetIcmpEchoEnabled(pFilter->otCtx, FALSE);
+
+    // Register callbacks with OpenThread
+    otSetStateChangedCallback(pFilter->otCtx, otLwfStateChangedCallback, pFilter);
+    otSetReceiveIp6DatagramCallback(pFilter->otCtx, otLwfReceiveIp6DatagramCallback, pFilter);
+
+    // Query the current addresses from TCPIP and cache them
+    (void)otLwfInitializeAddresses(pFilter);
+
+    // Initialze media connect state to disconnected
+    otLwfIndicateLinkState(pFilter, MediaConnectStateDisconnected);
 }
 
 otPlatResetReason 

--- a/examples/drivers/windows/otLwf/radio.c
+++ b/examples/drivers/windows/otLwf/radio.c
@@ -62,6 +62,10 @@ otPlatReset(
     // Indicate to the miniport
     (void)otLwfCmdResetDevice(pFilter, TRUE);
 
+    // Finalize previous OpenThread instance
+    otInstanceFinalize(pFilter->otCtx);
+    pFilter->otCtx = NULL;
+
     // Reinitialize the OpenThread library
     pFilter->otCachedRole = kDeviceRoleDisabled;
     pFilter->otCtx = otInstanceInit(pFilter->otInstanceBuffer + sizeof(PMS_FILTER), &pFilter->otInstanceSize);

--- a/examples/drivers/windows/otLwf/radio.c
+++ b/examples/drivers/windows/otLwf/radio.c
@@ -66,6 +66,11 @@ otPlatReset(
     otInstanceFinalize(pFilter->otCtx);
     pFilter->otCtx = NULL;
 
+    // Reset radio layer
+    pFilter->otPhyState = kStateDisabled;
+    pFilter->otCurrentListenChannel = 0xFF;
+    pFilter->otPromiscuous = false;
+
     // Reinitialize the OpenThread library
     pFilter->otCachedRole = kDeviceRoleDisabled;
     pFilter->otCtx = otInstanceInit(pFilter->otInstanceBuffer + sizeof(PMS_FILTER), &pFilter->otInstanceSize);

--- a/examples/drivers/windows/otNodeApi/otNodeApi.cpp
+++ b/examples/drivers/windows/otNodeApi/otNodeApi.cpp
@@ -843,6 +843,9 @@ OTNODEAPI otNode* OTCALL otNodeInit(uint32_t id)
 
     InitializeCriticalSection(&node->mCS);
 
+    // Reset any previously saved settings
+    otFactoryReset(instance);
+
     otSetStateChangedCallback(instance, otNodeStateChangedCallback, node);
 
     HandleAddressChanges(node);


### PR DESCRIPTION
Each run of a Python cert test on Windows will grab or create a random new virtual Thread interface. With the support for persisted settings added, occasionally the interface already has saved settings. This causes the tests to fail. This change updates the test code (otNodeApi.dll) to reset the interface before using it.

This change also updates the driver side logic for `otPlatReset` to make sure the deleted settings are applied by completely reinitializing the OpenThread instance.