### PR TITLE
fix bug in filter driver

### DIFF
--- a/examples/drivers/windows/otLwf/iocontrol.c
+++ b/examples/drivers/windows/otLwf/iocontrol.c
@@ -5281,7 +5281,7 @@ otLwfIoCtl_otJoinerStart(
                     aConfig->ProvisioningUrl,
                     pFilter->otVendorName,
                     pFilter->otVendorModel,
-                    pFilter->otVendorSwVersion,
+                    pFilter->otVendorData[0] == '\0' ? NULL : pFilter->otVendorData,
                     pFilter->otVendorData,
                     otLwfJoinerCallback,
                     pFilter)

--- a/examples/drivers/windows/otLwf/iocontrol.c
+++ b/examples/drivers/windows/otLwf/iocontrol.c
@@ -5281,8 +5281,8 @@ otLwfIoCtl_otJoinerStart(
                     aConfig->ProvisioningUrl,
                     pFilter->otVendorName,
                     pFilter->otVendorModel,
+                    pFilter->otVendorSwVersion,
                     pFilter->otVendorData[0] == '\0' ? NULL : pFilter->otVendorData,
-                    pFilter->otVendorData,
                     otLwfJoinerCallback,
                     pFilter)
                 );


### PR DESCRIPTION
pass null vendor data to otJoinerStart if it is not provided to filter driver