### PR TITLE
Sleepy child to immediately enqueue next data poll when frame pending is set

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -922,7 +922,7 @@ void MeshForwarder::HandlePollTimer()
     case kThreadError_NoBufs:
         // Failed to send DataRequest due to a lack of buffers.
         // Try again following a brief pause to free buffers.
-        mPollTimer.Start(kDataRequstRetryDelay);
+        mPollTimer.Start(kDataRequestRetryDelay);
         break;
 
     case kThreadError_Already:
@@ -1735,8 +1735,7 @@ void MeshForwarder::HandleReceivedFrame(Mac::Frame &aFrame)
 
     if (mPollTimer.IsRunning() && aFrame.GetFramePending())
     {
-        // add delay to avoid packet loss due to possible switch senarios between transmit/receive status
-        mPollTimer.Start(OPENTHREAD_CONFIG_ATTACH_DATA_POLL_PERIOD);
+        HandlePollTimer();
     }
 
     switch (aFrame.GetType())

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -223,8 +223,8 @@ public:
 private:
     enum
     {
-        kStateUpdatePeriod    = 1000,  ///< State update period in milliseconds.
-        kDataRequstRetryDelay = 1000,  ///< Retry delay in milliseconds.
+        kStateUpdatePeriod     = 1000,  ///< State update period in milliseconds.
+        kDataRequestRetryDelay = 200,   ///< Retry delay in milliseconds (for sending data request if no buffer).
     };
 
     ThreadError CheckReachability(uint8_t *aFrame, uint8_t aFrameLength,


### PR DESCRIPTION
This commit contains the following changes:

- On a sleepy end-device, if a data frame is received with "frame
  pending" bit set, we immediately schedule/enqueue the next data
  poll. This reduces the delay of receiving large messages which
  require multiple fragments.

- Changed `kDataRequestRetryDelay` from 1 second to 100ms. The
  retry interval is used when we are out of buffers and data poll
  can not be queued.