### PR TITLE
`Mle`: Ensure to send/queue the "Child Update Response" before the "Data Request"

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2842,12 +2842,12 @@ ThreadError Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::Me
         tlvs[numTlvs++] = Tlv::kLinkFrameCounter;
     }
 
+    SuccessOrExit(error = SendChildUpdateResponse(tlvs, numTlvs, challenge));
+
     if (mRetrieveNewNetworkData)
     {
-        SendDataRequest(aMessageInfo.GetPeerAddr(), dataRequestTlvs, sizeof(tlvs), 0);
+        SendDataRequest(aMessageInfo.GetPeerAddr(), dataRequestTlvs, sizeof(dataRequestTlvs), 0);
     }
-
-    SuccessOrExit(error = SendChildUpdateResponse(tlvs, numTlvs, challenge));
 
 exit:
     return error;


### PR DESCRIPTION
This commit adds two fixes in `Mle::HandleChildUpdateRequest()`:

- "Child Update Response" is queued/sent before the "Data Request".
   This change addresses the issue during parent reset recovery where
   (without this change) the parent  would receive the "Data Request"
   before the "Child Update Response" and would ignore it (as the child
   is still being restored).

- The `tlv length` parameter in call to `SendDataRequest()` is fixed.
  This change addresses the issue where incorrect (number of) TLVs
  were being requested/appended to the "Data Request" message.