### PR TITLE
Enable mbedTLS dynamic memory allocation in user mode on Windows

### DIFF
--- a/etc/visual-studio/UnitTests.vcxproj
+++ b/etc/visual-studio/UnitTests.vcxproj
@@ -49,6 +49,7 @@
         %(PreprocessorDefinitions)
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
+        OPENTHREAD_MULTIPLE_INSTANCE;
       </PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>
       <UseFullPaths>true</UseFullPaths>

--- a/etc/visual-studio/libopenthread-cli.vcxproj
+++ b/etc/visual-studio/libopenthread-cli.vcxproj
@@ -40,6 +40,7 @@
         %(PreprocessorDefinitions);
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
+        OPENTHREAD_MULTIPLE_INSTANCE;
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);

--- a/etc/visual-studio/libopenthread-ncp-spi.vcxproj
+++ b/etc/visual-studio/libopenthread-ncp-spi.vcxproj
@@ -40,6 +40,7 @@
         %(PreprocessorDefinitions);
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
+        OPENTHREAD_MULTIPLE_INSTANCE;
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);

--- a/etc/visual-studio/libopenthread-ncp-uart.vcxproj
+++ b/etc/visual-studio/libopenthread-ncp-uart.vcxproj
@@ -40,6 +40,7 @@
         %(PreprocessorDefinitions);
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
+        OPENTHREAD_MULTIPLE_INSTANCE;
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);

--- a/etc/visual-studio/libopenthread.vcxproj
+++ b/etc/visual-studio/libopenthread.vcxproj
@@ -40,7 +40,7 @@
         %(PreprocessorDefinitions);
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
-        OPENTHREAD_MULTIPLE_INSTANCE
+        OPENTHREAD_MULTIPLE_INSTANCE;
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);

--- a/etc/visual-studio/libopenthread.vcxproj
+++ b/etc/visual-studio/libopenthread.vcxproj
@@ -40,6 +40,7 @@
         %(PreprocessorDefinitions);
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
+        OPENTHREAD_MULTIPLE_INSTANCE
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);

--- a/etc/visual-studio/libopenthread.vcxproj.filters
+++ b/etc/visual-studio/libopenthread.vcxproj.filters
@@ -174,9 +174,6 @@
     <ClCompile Include="..\..\src\core\thread\network_data_local.cpp">
       <Filter>Source Files\thread</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\core\thread\network_diag.cpp">
-      <Filter>Source Files\thread</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\core\thread\panid_query_server.cpp">
       <Filter>Source Files\thread</Filter>
     </ClCompile>

--- a/etc/visual-studio/mbedtls.vcxproj
+++ b/etc/visual-studio/mbedtls.vcxproj
@@ -39,7 +39,7 @@
       <PreprocessorDefinitions>
         ;%(PreprocessorDefinitions);
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
-        OPENTHREAD_MULTIPLE_INSTANCE
+        OPENTHREAD_MULTIPLE_INSTANCE;
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         ..\..\include;
@@ -71,7 +71,6 @@
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\md.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\md_wrap.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\memory_buffer_alloc.c" />
-    <ClCompile Include="..\..\third_party\mbedtls\repo\library\pkcs5.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\platform.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\sha256.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\ssl_ciphersuites.c" />

--- a/etc/visual-studio/mbedtls.vcxproj
+++ b/etc/visual-studio/mbedtls.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="openthread.configuration.props" /> 
+  <Import Project="openthread.configuration.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4111C8BB-D354-4348-AD3C-EB6832E84831}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -38,7 +38,8 @@
     <ClCompile>
       <PreprocessorDefinitions>
         ;%(PreprocessorDefinitions);
-        MBEDTLS_CONFIG_FILE="mbedtls-config.h"
+        MBEDTLS_CONFIG_FILE="mbedtls-config.h";
+        OPENTHREAD_MULTIPLE_INSTANCE
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         ..\..\include;
@@ -70,6 +71,7 @@
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\md.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\md_wrap.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\memory_buffer_alloc.c" />
+    <ClCompile Include="..\..\third_party\mbedtls\repo\library\pkcs5.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\platform.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\sha256.c" />
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\ssl_ciphersuites.c" />

--- a/etc/visual-studio/mbedtls.vcxproj.filters
+++ b/etc/visual-studio/mbedtls.vcxproj.filters
@@ -88,8 +88,5 @@
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\ssl_tls.c">
       <Filter>Source Files\repo\library</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\third_party\mbedtls\repo\library\pkcs5.c">
-      <Filter>Source Files\repo\library</Filter>
-    </ClCompile>
   </ItemGroup>
 </Project>

--- a/etc/visual-studio/mbedtls.vcxproj.filters
+++ b/etc/visual-studio/mbedtls.vcxproj.filters
@@ -88,5 +88,8 @@
     <ClCompile Include="..\..\third_party\mbedtls\repo\library\ssl_tls.c">
       <Filter>Source Files\repo\library</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\third_party\mbedtls\repo\library\pkcs5.c">
+      <Filter>Source Files\repo\library</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/etc/visual-studio/ot-cli.vcxproj
+++ b/etc/visual-studio/ot-cli.vcxproj
@@ -39,6 +39,7 @@
       <PreprocessorDefinitions>
         %(PreprocessorDefinitions);
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
+        OPENTHREAD_MULTIPLE_INSTANCE;
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);

--- a/etc/visual-studio/ot-ncp-spi.vcxproj
+++ b/etc/visual-studio/ot-ncp-spi.vcxproj
@@ -39,6 +39,7 @@
       <PreprocessorDefinitions>
         %(PreprocessorDefinitions);
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
+        OPENTHREAD_MULTIPLE_INSTANCE;
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);

--- a/etc/visual-studio/ot-ncp-uart.vcxproj
+++ b/etc/visual-studio/ot-ncp-uart.vcxproj
@@ -39,6 +39,7 @@
       <PreprocessorDefinitions>
         %(PreprocessorDefinitions);
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
+        OPENTHREAD_MULTIPLE_INSTANCE;
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);

--- a/examples/apps/cli/main.c
+++ b/examples/apps/cli/main.c
@@ -40,6 +40,18 @@
 #include <platform/platform.h>
 #include <assert.h>
 
+#ifdef OPENTHREAD_MULTIPLE_INSTANCE
+void *otPlatCAlloc(size_t aNum, size_t aSize)
+{
+    return calloc(aNum, aSize);
+}
+
+void otPlatFree(void *aPtr)
+{
+    free(aPtr);
+}
+#endif
+
 void otSignalTaskletPending(otInstance *aInstance)
 {
     (void)aInstance;

--- a/examples/apps/ncp/main.c
+++ b/examples/apps/ncp/main.c
@@ -40,6 +40,18 @@
 #include <ncp/ncp.h>
 #include <platform/platform.h>
 
+#ifdef OPENTHREAD_MULTIPLE_INSTANCE
+void *otPlatCAlloc(size_t aNum, size_t aSize)
+{
+    return calloc(aNum, aSize);
+}
+
+void otPlatFree(void *aPtr)
+{
+    free(aPtr);
+}
+#endif
+
 void otSignalTaskletPending(otInstance *aInstance)
 {
     (void)aInstance;

--- a/tests/unit/test_aes.cpp
+++ b/tests/unit/test_aes.cpp
@@ -33,7 +33,9 @@
 #include <crypto/mbedtls.hpp>
 #include <string.h>
 
+#ifndef OPENTHREAD_MULTIPLE_INSTANCE
 static Thread::Crypto::MbedTls mbedtls;
+#endif
 
 /**
  * Verifies test vectors from IEEE 802.15.4-2006 Annex C Section C.2.1

--- a/tests/unit/test_fuzz.cpp
+++ b/tests/unit/test_fuzz.cpp
@@ -119,7 +119,7 @@ void TestFuzz(uint32_t aSeconds)
     // Call to allocate the buffer
     otInstanceBuffer = (uint8_t *)malloc(otInstanceBufferLength);
     VerifyOrQuit(otInstanceBuffer != NULL, "Failed to allocate otInstance");
-    memset(&otInstanceBuffer, 0, otInstanceBufferLength);
+    memset(otInstanceBuffer, 0, otInstanceBufferLength);
 
     // Initialize Openthread with the buffer
     aInstance = otInstanceInit(otInstanceBuffer, &otInstanceBufferLength);

--- a/tests/unit/test_fuzz.cpp
+++ b/tests/unit/test_fuzz.cpp
@@ -110,7 +110,7 @@ void TestFuzz(uint32_t aSeconds)
 #endif
 
 #ifdef OPENTHREAD_MULTIPLE_INSTANCE
-    uint64_t otInstanceBufferLength = 0;
+    size_t otInstanceBufferLength = 0;
     uint8_t *otInstanceBuffer = NULL;
 
     // Call to query the buffer size

--- a/tests/unit/test_hmac_sha256.cpp
+++ b/tests/unit/test_hmac_sha256.cpp
@@ -34,7 +34,9 @@
 #include <crypto/hmac_sha256.hpp>
 #include <crypto/mbedtls.hpp>
 
-static Thread::Crypto::MbedTls mbedtls;
+#ifndef OPENTHREAD_MULTIPLE_INSTANCE
+static Thread::Crypto::MbedTls mMbedTls;
+#endif
 
 void TestHmacSha256(void)
 {

--- a/tests/unit/test_message_queue.cpp
+++ b/tests/unit/test_message_queue.cpp
@@ -193,7 +193,7 @@ void TestMessageQueueOtApis(void)
     otMessage message;
 
 #ifdef OPENTHREAD_MULTIPLE_INSTANCE
-    uint64_t otInstanceBufferLength = 0;
+    size_t otInstanceBufferLength = 0;
     uint8_t *otInstanceBuffer = NULL;
 
     // Call to query the buffer size

--- a/tests/unit/test_message_queue.cpp
+++ b/tests/unit/test_message_queue.cpp
@@ -192,7 +192,23 @@ void TestMessageQueueOtApis(void)
     ThreadError error;
     otMessage message;
 
+#ifdef OPENTHREAD_MULTIPLE_INSTANCE
+    uint64_t otInstanceBufferLength = 0;
+    uint8_t *otInstanceBuffer = NULL;
+
+    // Call to query the buffer size
+    (void)otInstanceInit(NULL, &otInstanceBufferLength);
+
+    // Call to allocate the buffer
+    otInstanceBuffer = (uint8_t *)malloc(otInstanceBufferLength);
+    assert(otInstanceBuffer);
+
+    // Initialize Openthread with the buffer
+    instance = otInstanceInit(otInstanceBuffer, &otInstanceBufferLength);
+#else
     instance = otInstanceInit();
+#endif
+
     VerifyOrQuit(instance != NULL, "Failed to get and init an otInstance.\n");
 
     for (int i = 0; i < kNumTestMessages; i++)
@@ -251,6 +267,11 @@ void TestMessageQueueOtApis(void)
     // Remove all element and make sure queue is empty
     SuccessOrQuit(otMessageQueueDequeue(&queue, msg[2]), "Failed to dequeue a message from otMessageQueue.\n");
     VerifyMessageQueueContentUsingOtApi(&queue, 0);
+
+     otInstanceFinalize(instance);
+#ifdef OPENTHREAD_MULTIPLE_INSTANCE
+     free(otInstanceBuffer);
+#endif
 }
 
 #ifdef ENABLE_TEST_MAIN

--- a/tests/unit/test_message_queue.cpp
+++ b/tests/unit/test_message_queue.cpp
@@ -268,9 +268,9 @@ void TestMessageQueueOtApis(void)
     SuccessOrQuit(otMessageQueueDequeue(&queue, msg[2]), "Failed to dequeue a message from otMessageQueue.\n");
     VerifyMessageQueueContentUsingOtApi(&queue, 0);
 
-     otInstanceFinalize(instance);
+    otInstanceFinalize(instance);
 #ifdef OPENTHREAD_MULTIPLE_INSTANCE
-     free(otInstanceBuffer);
+    free(otInstanceBuffer);
 #endif
 }
 

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -81,6 +81,18 @@ bool sDiagMode = false;
 
 extern "C" {
 
+#ifdef OPENTHREAD_MULTIPLE_INSTANCE
+    void *otPlatCAlloc(size_t aNum, size_t aSize)
+    {
+        return calloc(aNum, aSize);
+    }
+
+    void otPlatFree(void *aPtr)
+    {
+        free(aPtr);
+    }
+#endif
+
     void otSignalTaskletPending(otInstance *)
     {
     }


### PR DESCRIPTION
This allows other user mode components (such as the under development border router) to use mbedTLS and use dynamic allocation.