### PR TITLE
reversed logic for enabling thread configurations

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -77,7 +77,7 @@ set -x
     git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
-    ONLY_MTD=1 make -f examples/Makefile-cc2650 || die
+    make -f examples/Makefile-cc2650 || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-mtd || die
 }
 
@@ -111,7 +111,7 @@ set -x
     git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
-    ONLY_MTD=1 make -f examples/Makefile-cc2650 || die
+    make -f examples/Makefile-cc2650 || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-mtd || die
 }
 

--- a/examples/Makefile-cc2650
+++ b/examples/Makefile-cc2650
@@ -53,14 +53,22 @@ configure_OPTIONS              += \
     $(NULL)
 endif
 
-ifeq ($(ONLY_MTD),1)
-configure_OPTIONS              += \
-    --enable-cli=mtd              \
-    $(NULL)
-else
+ifeq ($(ENABLE_FTD),1)
+
+ifeq ($(ENABLE_NCP),1)
 configure_OPTIONS              += \
     --enable-cli                  \
     --enable-ncp                  \
+    $(NULL)
+else # !ENABLE_NCP
+configure_OPTIONS              += \
+    --enable-cli                  \
+    $(NULL)
+endif
+
+else # !ENABLE_FTD
+configure_OPTIONS              += \
+    --enable-cli=mtd              \
     $(NULL)
 endif
 


### PR DESCRIPTION
Default build for cc2650 is now MTD only.

* fixes (#1375)