### PR TITLE
[ICMPv6] Allow application to register ICMPv6 handler.

### DIFF
--- a/examples/drivers/windows/otLwf/eventprocessing.c
+++ b/examples/drivers/windows/otLwf/eventprocessing.c
@@ -786,7 +786,7 @@ otLwfEventWorkerThread(
     NT_ASSERT(otCtxToFilter(pFilter->otCtx) == pFilter);
 
     // Disable Icmp (ping) handling
-    otSetIcmpEchoEnabled(pFilter->otCtx, FALSE);
+    otIcmp6SetEchoEnabled(pFilter->otCtx, FALSE);
 
     // Register callbacks with OpenThread
     otSetStateChangedCallback(pFilter->otCtx, otLwfStateChangedCallback, pFilter);

--- a/examples/drivers/windows/otLwf/precomp.h
+++ b/examples/drivers/windows/otLwf/precomp.h
@@ -62,6 +62,7 @@ RtlCopyBufferToMdl(
 #include <openthread-windows-config.h>
 #include <openthread-core-config.h>
 #include <openthread.h>
+#include <openthread-icmp6.h>
 #include <openthread-ip6.h>
 #include <openthread-tasklet.h>
 #include <commissioning/commissioner.h>

--- a/examples/drivers/windows/otLwf/radio.c
+++ b/examples/drivers/windows/otLwf/radio.c
@@ -85,7 +85,7 @@ otPlatReset(
     NT_ASSERT(otCtxToFilter(pFilter->otCtx) == pFilter);
 
     // Disable Icmp (ping) handling
-    otSetIcmpEchoEnabled(pFilter->otCtx, FALSE);
+    otIcmp6SetEchoEnabled(pFilter->otCtx, FALSE);
 
     // Register callbacks with OpenThread
     otSetStateChangedCallback(pFilter->otCtx, otLwfStateChangedCallback, pFilter);

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -64,6 +64,7 @@ include_HEADERS                         = \
     openthread-coap.h                     \
     openthread-crypto.h                   \
     openthread-diag.h                     \
+    openthread-icmp6.h                    \
     openthread-ip6.h                      \
     openthread-jam-detection.h            \
     openthread-message.h                  \

--- a/include/openthread-icmp6.h
+++ b/include/openthread-icmp6.h
@@ -1,0 +1,111 @@
+/*
+ *  Copyright (c) 2016, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * @brief
+ *  This file defines the top-level icmp6 functions for the OpenThread library.
+ */
+
+#ifndef OPENTHREAD_ICMP6_H_
+#define OPENTHREAD_ICMP6_H_
+
+#include <openthread-types.h>
+#include <openthread-message.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * @addtogroup icmp6  ICMPv6
+ *
+ * @brief
+ *   This module includes functions that control ICMPv6 communication.
+ *
+ * @{
+ *
+ */
+
+/**
+ * This function indicates whether or not ICMPv6 Echo processing is enabled.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ *
+ * @retval TRUE   ICMPv6 Echo processing is enabled.
+ * @retval FALSE  ICMPv6 Echo processing is disabled.
+ *
+ */
+bool otIcmp6IsEchoEnabled(otInstance *aInstance);
+
+/**
+ * This function sets whether or not ICMPv6 Echo processing is enabled.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ * @param[in]  aEnabled  TRUE to enable ICMPv6 Echo processing, FALSE otherwise.
+ *
+ */
+void otIcmp6SetEchoEnabled(otInstance *aInstance, bool aEnabled);
+
+/**
+ * This function registers a handler to provide received ICMPv6 messages.
+ *
+ * @note A handler structure @p aHandler has to be stored in persistant (static) memory.
+ *       OpenThread does not make a copy of handler structure.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ * @param[in]  aHandler  A pointer to a handler conitaining callback that is called when
+ *                       an ICMPv6 message is received.
+ *
+ */
+ThreadError otIcmp6RegisterHandler(otInstance *aInstance, otIcmp6Handler *aHandler);
+
+/**
+ * This function sends an ICMPv6 Echo Request via the Thread interface.
+ *
+ * @param[in]  aInstance     A pointer to an OpenThread instance.
+ * @param[in]  aMessage      A pointer to the message buffer containing the ICMPv6 payload.
+ * @param[in]  aMessageInfo  A reference to message information associated with @p aMessage.
+ * @param[in]  aIdentifier   An identifier to aid in matching Echo Replies to this Echo Request.
+ *                           May be zero.
+ *
+ */
+ThreadError otIcmp6SendEchoRequest(otInstance *aInstance, otMessage aMessage,
+                                   const otMessageInfo *aMessageInfo, uint16_t aIdentifier);
+
+/**
+ * @}
+ *
+ */
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // OPENTHREAD_ICMP6_H_

--- a/include/openthread-ip6.h
+++ b/include/openthread-ip6.h
@@ -343,26 +343,6 @@ void otSetReceiveIp6DatagramFilterEnabled(otInstance *aInstance, bool aEnabled);
 ThreadError otSendIp6Datagram(otInstance *aInstance, otMessage aMessage);
 
 /**
- * This function indicates whether or not ICMPv6 Echo processing is enabled.
- *
- * @param[in]  aInstance A pointer to an OpenThread instance.
- *
- * @retval TRUE   ICMPv6 Echo processing is enabled.
- * @retval FALSE  ICMPv6 Echo processing is disabled.
- *
- */
-bool otIsIcmpEchoEnabled(otInstance *aInstance);
-
-/**
- * This function sets whether or not ICMPv6 Echo processing is enabled.
- *
- * @param[in]  aInstance A pointer to an OpenThread instance.
- * @param[in]  aEnabled  TRUE to enable ICMPv6 Echo processing, FALSE otherwise.
- *
- */
-void otSetIcmpEchoEnabled(otInstance *aInstance, bool aEnabled);
-
-/**
  * @}
  *
  */

--- a/include/openthread-types.h
+++ b/include/openthread-types.h
@@ -329,6 +329,21 @@ struct otIp6Address
 
 typedef struct otIp6Address otIp6Address;
 
+
+/**
+ * This structure represents the local and peer IPv6 socket addresses.
+ */
+typedef struct otMessageInfo
+{
+    otIp6Address mSockAddr;     ///< The local IPv6 address.
+    otIp6Address mPeerAddr;     ///< The peer IPv6 address.
+    uint16_t     mSockPort;     ///< The local transport-layer port.
+    uint16_t     mPeerPort;     ///< The peer transport-layer port.
+    int8_t       mInterfaceId;  ///< An IPv6 interface identifier.
+    uint8_t      mHopLimit;     ///< The IPv6 Hop Limit.
+    const void  *mLinkInfo;     ///< A pointer to link-specific information.
+} otMessageInfo;
+
 /**
  * @addtogroup commands  Commands
  *
@@ -988,6 +1003,86 @@ typedef struct
  */
 
 /**
+ * @addtogroup icmp6  ICMPv6
+ *
+ * @brief
+ *   This module includes functions that control ICMPv6 communication.
+ *
+ * @{
+ *
+ */
+
+/**
+ * ICMPv6 Message Types
+ *
+*/
+typedef enum otIcmp6Type
+{
+    kIcmp6TypeDstUnreach  = 1,     ///< Destination Unreachable
+    kIcmp6TypeEchoRequest = 128,   ///< Echo Request
+    kIcmp6TypeEchoReply   = 129,   ///< Echo Reply
+} otIcmp6Type;
+
+/**
+ * ICMPv6 Message Codes
+ *
+ */
+typedef enum otIcmp6Code
+{
+    kIcmp6CodeDstUnreachNoRoute = 0,  ///< Destination Unreachable No Route
+} otIcmp6Code;
+
+#define OT_ICMP6_HEADER_DATA_SIZE  4   ///< Size of an message specific data of ICMPv6 Header.
+
+/**
+ * This structure represents an ICMPv6 header.
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+struct otIcmp6Header
+{
+    uint8_t      mType;      ///< Type
+    uint8_t      mCode;      ///< Code
+    uint16_t     mChecksum;  ///< Checksum
+    union
+    {
+        uint8_t  m8[OT_ICMP6_HEADER_DATA_SIZE / sizeof(uint8_t)];
+        uint16_t m16[OT_ICMP6_HEADER_DATA_SIZE / sizeof(uint16_t)];
+        uint32_t m32[OT_ICMP6_HEADER_DATA_SIZE / sizeof(uint32_t)];
+    } mData;                 ///< Message-specific data
+} OT_TOOL_PACKED_END;
+
+typedef struct otIcmp6Header otIcmp6Header;
+
+/**
+ * This callback allows OpenThread to inform the application of a received ICMPv6 message.
+ *
+ * @param[in]  aContext      A pointer to arbitrary context information.
+ * @param[in]  aMessage      A pointer to the received message.
+ * @param[in]  aMessageInfo  A pointer to message information associated with @p aMessage.
+ * @param[in]  aIcmpHeader   A pointer to the received ICMPv6 header.
+ *
+ */
+typedef void (*otIcmp6ReceiveCallback)(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo,
+                                       const otIcmp6Header *aIcmpHeader);
+
+/**
+ * This structure implements ICMPv6 message handler.
+ *
+ */
+typedef struct otIcmp6Handler
+{
+    otIcmp6ReceiveCallback  mReceiveCallback;
+    void                   *mContext;
+    struct otIcmp6Handler  *mNext;
+} otIcmp6Handler;
+
+/**
+ * @}
+ *
+ */
+
+/**
  * @addtogroup udp  UDP
  *
  * @brief
@@ -1006,20 +1101,6 @@ typedef struct otSockAddr
     uint16_t     mPort;     ///< A transport-layer port.
     int8_t       mScopeId;  ///< An IPv6 scope identifier.
 } otSockAddr;
-
-/**
- * This structure represents the local and peer IPv6 socket addresses.
- */
-typedef struct otMessageInfo
-{
-    otIp6Address mSockAddr;     ///< The local IPv6 address.
-    otIp6Address mPeerAddr;     ///< The peer IPv6 address.
-    uint16_t     mSockPort;     ///< The local transport-layer port.
-    uint16_t     mPeerPort;     ///< The peer transport-layer port.
-    int8_t       mInterfaceId;  ///< An IPv6 interface identifier.
-    uint8_t      mHopLimit;     ///< The IPv6 Hop Limit.
-    const void  *mLinkInfo;     ///< A pointer to link-specific information.
-} otMessageInfo;
 
 /**
  * This callback allows OpenThread to inform the application of a received UDP message.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -44,6 +44,7 @@
 #include <openthread.h>
 #include <openthread-instance.h>
 #include <openthread-diag.h>
+#include <openthread-icmp6.h>
 #include <commissioning/commissioner.h>
 #include <commissioning/joiner.h>
 #include <dhcp6/dhcp6_server.h>
@@ -144,9 +145,12 @@ Interpreter::Interpreter(otInstance *aInstance):
     mInstance(aInstance)
 {
     memset(mSlaacAddresses, 0, sizeof(mSlaacAddresses));
-    mInstance->mIp6.mIcmp.SetEchoReplyHandler(&s_HandleEchoResponse, this);
     otSetStateChangedCallback(mInstance, &Interpreter::s_HandleNetifStateChanged, this);
     otSetReceiveDiagnosticGetCallback(mInstance, &Interpreter::s_HandleDiagnosticGetResponse, this);
+
+    mIcmpHandler.mReceiveCallback = Interpreter::s_HandleIcmpReceive;
+    mIcmpHandler.mContext         = this;
+    otIcmp6RegisterHandler(mInstance, &mIcmpHandler);
 
 #if OPENTHREAD_ENABLE_DHCP6_CLIENT
     memset(mDhcpAddresses, 0, sizeof(mDhcpAddresses));
@@ -1270,17 +1274,20 @@ exit:
     AppendResult(error);
 }
 
-void Interpreter::s_HandleEchoResponse(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Interpreter::s_HandleIcmpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo,
+                                      const otIcmp6Header *aIcmpHeader)
 {
-    static_cast<Interpreter *>(aContext)->HandleEchoResponse(aMessage, aMessageInfo);
+    static_cast<Interpreter *>(aContext)->HandleIcmpReceive(*static_cast<Message *>(aMessage),
+                                                            *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
+                                                            *static_cast<const Ip6::IcmpHeader *>(aIcmpHeader));
 }
 
-void Interpreter::HandleEchoResponse(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Interpreter::HandleIcmpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
+                                    const Ip6::IcmpHeader &aIcmpHeader)
 {
-    Ip6::IcmpHeader icmp6Header;
     uint32_t timestamp = 0;
 
-    aMessage.Read(aMessage.GetOffset(), sizeof(icmp6Header), &icmp6Header);
+    VerifyOrExit(aIcmpHeader.GetType() == kIcmp6TypeEchoReply, ;);
 
     sServer->OutputFormat("%d bytes from ", aMessage.GetLength() - aMessage.GetOffset());
     sServer->OutputFormat("%x:%x:%x:%x:%x:%x:%x:%x",
@@ -1292,15 +1299,18 @@ void Interpreter::HandleEchoResponse(Message &aMessage, const Ip6::MessageInfo &
                           HostSwap16(aMessageInfo.GetPeerAddr().mFields.m16[5]),
                           HostSwap16(aMessageInfo.GetPeerAddr().mFields.m16[6]),
                           HostSwap16(aMessageInfo.GetPeerAddr().mFields.m16[7]));
-    sServer->OutputFormat(": icmp_seq=%d hlim=%d", icmp6Header.GetSequence(), aMessageInfo.mHopLimit);
+    sServer->OutputFormat(": icmp_seq=%d hlim=%d", aIcmpHeader.GetSequence(), aMessageInfo.mHopLimit);
 
-    if (aMessage.Read(aMessage.GetOffset() + sizeof(icmp6Header), sizeof(uint32_t), &timestamp) >=
+    if (aMessage.Read(aMessage.GetOffset(), sizeof(uint32_t), &timestamp) >=
         static_cast<int>(sizeof(uint32_t)))
     {
         sServer->OutputFormat(" time=%dms", Timer::GetNow() - HostSwap32(timestamp));
     }
 
     sServer->OutputFormat("\r\n");
+
+exit:
+    return;
 }
 
 void Interpreter::ProcessPing(int argc, char *argv[])
@@ -1363,20 +1373,22 @@ void Interpreter::HandlePingTimer()
 {
     ThreadError error = kThreadError_None;
     uint32_t timestamp = HostSwap32(Timer::GetNow());
-    Message *message;
 
-    VerifyOrExit((message = mInstance->mIp6.mIcmp.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
-    SuccessOrExit(error = message->Append(&timestamp, sizeof(timestamp)));
-    SuccessOrExit(error = message->SetLength(sLength));
+    otMessage message;
+    const otMessageInfo *messageInfo = static_cast<const otMessageInfo *>(&sMessageInfo);
 
-    SuccessOrExit(error = mInstance->mIp6.mIcmp.SendEchoRequest(*message, sMessageInfo));
+    VerifyOrExit((message = otNewIp6Message(mInstance, true)) != NULL, error = kThreadError_NoBufs);
+    SuccessOrExit(error = otAppendMessage(message, &timestamp, sizeof(timestamp)));
+    SuccessOrExit(error = otSetMessageLength(message, sLength));
+    SuccessOrExit(error = otIcmp6SendEchoRequest(mInstance, message, messageInfo, 1));
+
     sCount--;
 
 exit:
 
     if (error != kThreadError_None && message != NULL)
     {
-        message->Free();
+        otFreeMessage(message);
     }
 
     if (sCount)

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -218,7 +218,8 @@ private:
     void ProcessVersion(int argc, char *argv[]);
     void ProcessWhitelist(int argc, char *argv[]);
 
-    static void s_HandleEchoResponse(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    static void s_HandleIcmpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo,
+                                    const otIcmp6Header *aIcmpHeader);
     static void s_HandlePingTimer(void *aContext);
     static void s_HandleActiveScanResult(otActiveScanResult *aResult, void *aContext);
     static void s_HandleNetifStateChanged(uint32_t aFlags, void *aContext);
@@ -229,7 +230,8 @@ private:
     static void s_HandleDiagnosticGetResponse(otMessage aMessage, const otMessageInfo *aMessageInfo, void *aContext);
     static void s_HandleJoinerCallback(ThreadError aError, void *aContext);
 
-    void HandleEchoResponse(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    void HandleIcmpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
+                           const Ip6::IcmpHeader &aIcmpHeader);
     void HandlePingTimer();
     void HandleActiveScanResult(otActiveScanResult *aResult);
     void HandleNetifStateChanged(uint32_t aFlags);
@@ -242,6 +244,7 @@ private:
     static const struct Command sCommands[];
 
     Ip6::MessageInfo sMessageInfo;
+
     Server *sServer;
     uint16_t sLength;
     uint16_t sCount;
@@ -253,6 +256,7 @@ private:
     otDhcpAddress  mDhcpAddresses[OPENTHREAD_CONFIG_NUM_DHCP_PREFIXES];
 #endif // OPENTHREAD_ENABLE_DHCP6_CLIENT
 
+    otIcmp6Handler mIcmpHandler;
     otInstance *mInstance;
 };
 

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -617,7 +617,7 @@ ThreadError Ip6::ProcessReceiveCallback(const Message &aMessage, const MessageIn
                 aMessage.Read(aMessage.GetOffset(), sizeof(icmp), &icmp);
 
                 // do not pass ICMP Echo Request messages
-                VerifyOrExit(icmp.GetType() != IcmpHeader::kTypeEchoRequest, error = kThreadError_NoRoute);
+                VerifyOrExit(icmp.GetType() != kIcmp6TypeEchoRequest, error = kThreadError_NoRoute);
             }
 
             break;

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -1727,14 +1727,27 @@ ThreadError otSendUdp(otUdpSocket *aSocket, otMessage aMessage, const otMessageI
                           *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
-bool otIsIcmpEchoEnabled(otInstance *aInstance)
+bool otIcmp6IsEchoEnabled(otInstance *aInstance)
 {
     return aInstance->mIp6.mIcmp.IsEchoEnabled();
 }
 
-void otSetIcmpEchoEnabled(otInstance *aInstance, bool aEnabled)
+void otIcmp6SetEchoEnabled(otInstance *aInstance, bool aEnabled)
 {
     aInstance->mIp6.mIcmp.SetEchoEnabled(aEnabled);
+}
+
+ThreadError otIcmp6RegisterHandler(otInstance *aInstance, otIcmp6Handler *aHandler)
+{
+    return aInstance->mIp6.mIcmp.RegisterHandler(*static_cast<Ip6::IcmpHandler *>(aHandler));
+}
+
+ThreadError otIcmp6SendEchoRequest(otInstance *aInstance, otMessage aMessage,
+                                   const otMessageInfo *aMessageInfo, uint16_t aIdentifier)
+{
+    return aInstance->mIp6.mIcmp.SendEchoRequest(*static_cast<Message *>(aMessage),
+                                                 *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
+                                                 aIdentifier);
 }
 
 uint8_t otIp6PrefixMatch(const otIp6Address *aFirst, const otIp6Address *aSecond)

--- a/src/core/thread/address_resolver_ftd.hpp
+++ b/src/core/thread/address_resolver_ftd.hpp
@@ -174,9 +174,9 @@ private:
                                           const otMessageInfo *aMessageInfo);
     void HandleAddressNotification(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleDstUnreach(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
-                                 const Ip6::IcmpHeader &aIcmpHeader);
-    void HandleDstUnreach(Message &aMessage, const Ip6::MessageInfo &aMessageInfo, const Ip6::IcmpHeader &aIcmpHeader);
+    static void HandleIcmpReceive(void *aContext, otMessage aMessage, const otMessageInfo *aMessageInfo,
+                                  const otIcmp6Header *aIcmpHeader);
+    void HandleIcmpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo, const Ip6::IcmpHeader &aIcmpHeader);
 
     static void HandleTimer(void *aContext);
     void HandleTimer(void);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3203,8 +3203,8 @@ ThreadError Mle::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, Ip6
     messageInfo.GetPeerAddr().mFields.m16[7] = HostSwap16(aMeshSource);
     messageInfo.SetInterfaceId(mNetif.GetInterfaceId());
 
-    mNetif.GetIp6().mIcmp.SendError(Ip6::IcmpHeader::kTypeDstUnreach,
-                                    Ip6::IcmpHeader::kCodeDstUnreachNoRoute,
+    mNetif.GetIp6().mIcmp.SendError(kIcmp6TypeDstUnreach,
+                                    kIcmp6CodeDstUnreachNoRoute,
                                     messageInfo, aIp6Header);
 
 exit:

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3619,8 +3619,8 @@ ThreadError MleRouter::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDes
     messageInfo.GetPeerAddr().mFields.m16[7] = HostSwap16(aMeshSource);
     messageInfo.SetInterfaceId(mNetif.GetInterfaceId());
 
-    mNetif.GetIp6().mIcmp.SendError(Ip6::IcmpHeader::kTypeDstUnreach,
-                                    Ip6::IcmpHeader::kCodeDstUnreachNoRoute,
+    mNetif.GetIp6().mIcmp.SendError(kIcmp6TypeDstUnreach,
+                                    kIcmp6CodeDstUnreachNoRoute,
                                     messageInfo, aIp6Header);
 
     return kThreadError_Drop;

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -44,6 +44,7 @@
 #include <net/ip6.hpp>
 #include <openthread.h>
 #include <openthread-diag.h>
+#include <openthread-icmp6.h>
 #if OPENTHREAD_ENABLE_JAM_DETECTION
 #include <openthread-jam-detection.h>
 #endif
@@ -515,7 +516,7 @@ NcpBase::NcpBase(otInstance *aInstance):
     otSetStateChangedCallback(mInstance, &NcpBase::HandleNetifStateChanged, this);
     otSetReceiveIp6DatagramCallback(mInstance, &NcpBase::HandleDatagramFromStack, this);
     otSetLinkPcapCallback(mInstance, &NcpBase::HandleRawFrame, static_cast<void*>(this));
-    otSetIcmpEchoEnabled(mInstance, false);
+    otIcmp6SetEchoEnabled(mInstance, false);
     otSetReceiveIp6DatagramFilterEnabled(mInstance, true);
 
     mUpdateChangedPropsTask.Post();
@@ -2711,7 +2712,7 @@ ThreadError NcpBase::GetPropertyHandler_IPV6_ICMP_PING_OFFLOAD(uint8_t header, s
                SPINEL_CMD_PROP_VALUE_IS,
                key,
                SPINEL_DATATYPE_BOOL_S,
-               otIsIcmpEchoEnabled(mInstance)
+               otIcmp6IsEchoEnabled(mInstance)
            );
 }
 
@@ -4379,7 +4380,7 @@ ThreadError NcpBase::SetPropertyHandler_IPV6_ICMP_PING_OFFLOAD(uint8_t header, s
 
     if (parsedLength > 0)
     {
-        otSetIcmpEchoEnabled(mInstance, isEnabled);
+        otIcmp6SetEchoEnabled(mInstance, isEnabled);
 
         errorCode = HandleCommandPropertyGet(header, key);
     }


### PR DESCRIPTION
This PR allows application to register ICMPv6 handler.

I modified ICMP Handler in order to receive all ICMPv6 instead of only Destination Unreachable. In that way  application or any other module can decide which type of messages it wants to process.

Currently otIcmp6RegisterHandler demands its handler to be statically allocated. In this way i avoid to have configurable maximum number of handlers (as it's with StateChange callback). Would that be okay?

Apart of above:
 - Add API to send ICMPv6 Echo Request with specific Identifier
 - Modify cli example to use OpenThread's C API when it comes to Echo Request/Reply
 - Adjust other modules: Address Resolver, NCP

Btw. I see you have API clean up PR pending, i hope this one will not break much.