### PR TITLE
For a child being restored, use short address in `SrcMatchEntry`

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3395,6 +3395,7 @@ ThreadError MleRouter::RestoreChildren(void)
                        (childInfo.mFullFunction ? ModeTlv::kModeFFD : 0) |
                        (childInfo.mFullNetworkData ? ModeTlv::kModeFullNetworkData : 0);
         child->mState = Neighbor::kStateRestored;
+        child->mAddSrcMatchEntryShort = true;
         child->mLastHeard = Timer::GetNow();
     }
 


### PR DESCRIPTION
This commit changes the `MleRouter::RestoreChildren()` so that
`mAddSrcMatchEntryShort` is set to true for a child being restored.
This ensures that during child recovery, the radio correctly sets
the "frame pending" in the acks to data poll from the child.