### PR TITLE
Add "--enable-ftd" build option

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -37,13 +37,13 @@ set -x
 [ $BUILD_TARGET != pretty-check ] || {
     export PATH=/tmp/astyle/build/gcc/bin:$PATH || die
     ./bootstrap || die
-    ./configure --enable-cli --enable-diag --enable-dhcp6-client --enable-dhcp6-server --enable-commissioner --enable-joiner --with-examples=posix || die
+    ./configure --enable-ftd --enable-cli --enable-diag --enable-dhcp6-client --enable-dhcp6-server --enable-commissioner --enable-joiner --with-examples=posix || die
     make pretty-check || die
 }
 
 [ $BUILD_TARGET != scan-build ] || {
     ./bootstrap || die
-    scan-build ./configure --with-examples=posix --enable-cli --enable-ncp || die
+    scan-build ./configure --with-examples=posix --enable-ftd --enable-cli --enable-ncp || die
     scan-build --status-bugs -analyze-headers -v make || die
 }
 
@@ -56,7 +56,8 @@ set -x
     COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 make -f examples/Makefile-cc2538 || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-ftd || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-mtd || die
-    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp || die
+    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp-ftd || die
+    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp-mtd || die
 
     git checkout -- . || die
     git clean -xfd || die
@@ -64,7 +65,8 @@ set -x
     COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 make -f examples/Makefile-da15000 || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-ftd || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-mtd || die
-    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp || die
+    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp-ftd || die
+    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp-mtd || die
 
     git checkout -- . || die
     git clean -xfd || die
@@ -72,13 +74,15 @@ set -x
     COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 make -f examples/Makefile-nrf52840 || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-ftd || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-mtd || die
-    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp || die
+    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp-ftd || die
+    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp-mtd || die
 
     git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
     make -f examples/Makefile-cc2650 || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-mtd || die
+    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp-mtd || die
 }
 
 [ $BUILD_TARGET != arm-gcc54 ] || {
@@ -90,7 +94,8 @@ set -x
     COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 make -f examples/Makefile-cc2538 || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-ftd || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-mtd || die
-    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp || die
+    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp-ftd || die
+    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp-mtd || die
 
     git checkout -- . || die
     git clean -xfd || die
@@ -98,7 +103,8 @@ set -x
     COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 make -f examples/Makefile-da15000 || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-ftd || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-mtd || die
-    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp || die
+    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp-ftd || die
+    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp-mtd || die
 
     git checkout -- . || die
     git clean -xfd || die
@@ -106,13 +112,15 @@ set -x
     COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 make -f examples/Makefile-nrf52840 || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-ftd || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-mtd || die
-    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp || die
+    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp-ftd || die
+    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp-mtd || die
 
     git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
     make -f examples/Makefile-cc2650 || die
     arm-none-eabi-size  output/bin/arm-none-eabi-ot-cli-mtd || die
+    arm-none-eabi-size  output/bin/arm-none-eabi-ot-ncp-mtd || die
 }
 
 [ $BUILD_TARGET != posix ] || {
@@ -136,7 +144,7 @@ set -x
 
 [ $BUILD_TARGET != posix-ncp-spi ] || {
     ./bootstrap || die
-    BuildJobs=10 make -f examples/Makefile-posix check configure_OPTIONS="--enable-ncp=spi --with-examples=posix --with-platform-info=POSIX" || die
+    BuildJobs=10 make -f examples/Makefile-posix check configure_OPTIONS="--enable-ftd --enable-ncp=spi --with-examples=posix --with-platform-info=POSIX" || die
 }
 
 [ $BUILD_TARGET != posix-ncp ] || {

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,7 @@ AM_MAKEFLAGS                        = --no-print-directory
 
 AM_DISTCHECK_CONFIGURE_FLAGS        = \
     --enable-address-sanitizer        \
+    --enable-ftd                      \
     --enable-cli                      \
     --enable-ncp                      \
     --enable-diag                     \

--- a/configure.ac
+++ b/configure.ac
@@ -414,6 +414,28 @@ if test "${nl_cv_build_tests}" = "yes"; then
 fi
 
 #
+#  Full Thread Device
+#
+
+AC_ARG_ENABLE(ftd,
+    [AS_HELP_STRING([--enable-ftd],[Enable Full Thread Device features @<:@default=no@:>@.])],
+    [
+        case "${enableval}" in
+
+        no|yes)
+            enable_ftd=${enableval}
+            ;;
+
+        *)
+            AC_MSG_ERROR([Invalid value ${enable_ftd} for --enable-ftd])
+            ;;
+        esac
+    ],
+    [enable_ftd=no])
+AC_MSG_RESULT(${enable_ftd})
+AM_CONDITIONAL([OPENTHREAD_ENABLE_FTD], [test "${enable_ftd}" = "yes"])
+
+#
 # CLI Library
 #
 
@@ -422,7 +444,7 @@ AC_ARG_ENABLE(cli,
     [
         case "${enableval}" in
 
-        no|yes|mtd|ftd)
+        no|yes)
             enable_cli=${enableval}
             ;;
 
@@ -434,8 +456,6 @@ AC_ARG_ENABLE(cli,
     [enable_cli=no])
 AC_MSG_RESULT(${enable_cli})
 AM_CONDITIONAL([OPENTHREAD_ENABLE_CLI], [test "${enable_cli}" != "no"])
-AM_CONDITIONAL([OPENTHREAD_ENABLE_CLI_FTD], [test "${enable_cli}" = "yes" -o "${enable_cli}" = "ftd"])
-AM_CONDITIONAL([OPENTHREAD_ENABLE_CLI_MTD], [test "${enable_cli}" = "yes" -o "${enable_cli}" = "mtd"])
 
 #
 # NCP Library
@@ -1151,6 +1171,7 @@ AC_MSG_NOTICE([
   Pretty args                               : ${PRETTY_ARGS:--}
   Pretty check                              : ${PRETTY_CHECK:--}
   Pretty check args                         : ${PRETTY_CHECK_ARGS:--}
+  OpenThread Full Thread Device support     : ${enable_ftd}
   OpenThread CLI support                    : ${enable_cli}
   OpenThread NCP support                    : ${enable_ncp}
   OpenThread builtin mbedtls support        : ${enable_builtin_mbedtls}

--- a/examples/Makefile-cc2538
+++ b/examples/Makefile-cc2538
@@ -42,6 +42,7 @@ OBJCOPY                         = arm-none-eabi-objcopy
 BuildJobs                      ?= 99
 
 configure_OPTIONS               = \
+    --enable-ftd                  \
     --enable-cli                  \
     --enable-ncp                  \
     --enable-diag                 \

--- a/examples/Makefile-cc2650
+++ b/examples/Makefile-cc2650
@@ -42,6 +42,8 @@ OBJCOPY                         = arm-none-eabi-objcopy
 BuildJobs                      ?= 99
 
 configure_OPTIONS               = \
+    --enable-cli                  \
+    --enable-ncp                  \
     --with-examples=cc2650        \
     --with-platform-info=cc2650   \
     MBEDTLS_CPPFLAGS="$(CC2650_MBEDTLS_CPPFLAGS)" \
@@ -50,25 +52,6 @@ configure_OPTIONS               = \
 ifeq ($(DISABLE_DOC),1)
 configure_OPTIONS              += \
     --disable-docs                \
-    $(NULL)
-endif
-
-ifeq ($(ENABLE_FTD),1)
-
-ifeq ($(ENABLE_NCP),1)
-configure_OPTIONS              += \
-    --enable-cli                  \
-    --enable-ncp                  \
-    $(NULL)
-else # !ENABLE_NCP
-configure_OPTIONS              += \
-    --enable-cli                  \
-    $(NULL)
-endif
-
-else # !ENABLE_FTD
-configure_OPTIONS              += \
-    --enable-cli=mtd              \
     $(NULL)
 endif
 

--- a/examples/Makefile-da15000
+++ b/examples/Makefile-da15000
@@ -42,6 +42,7 @@ OBJCOPY                         = arm-none-eabi-objcopy
 BuildJobs                      ?= 99
 
 configure_OPTIONS               = \
+    --enable-ftd                  \
     --enable-cli                  \
     --enable-ncp                  \
     --enable-default-logging      \

--- a/examples/Makefile-nrf52840
+++ b/examples/Makefile-nrf52840
@@ -42,6 +42,7 @@ OBJCOPY                         = arm-none-eabi-objcopy
 BuildJobs                      ?= 99
 
 configure_OPTIONS               = \
+    --enable-ftd                  \
     --enable-cli                  \
     --enable-ncp                  \
     --enable-diag                 \

--- a/examples/Makefile-posix
+++ b/examples/Makefile-posix
@@ -82,9 +82,11 @@ TargetTuple                     = $(shell ${AbsTopSourceDir}/third_party/nlbuild
 # accordingly.
 
 configure_OPTIONS               = \
+    --enable-ftd                  \
     --enable-cli                  \
     --enable-ncp                  \
     --enable-diag                 \
+    --enable-default-logging      \
     --enable-raw-link-api=no      \
     --with-examples=posix         \
     --with-platform-info=POSIX    \

--- a/examples/apps/cli/Makefile.am
+++ b/examples/apps/cli/Makefile.am
@@ -112,7 +112,7 @@ LDFLAGS_COMMON                                                        += \
     $(NULL)
 endif
 
-if OPENTHREAD_ENABLE_CLI_FTD
+if OPENTHREAD_ENABLE_FTD
 bin_PROGRAMS                                                          += \
     ot-cli-ftd                                                           \
     $(NULL)
@@ -134,9 +134,8 @@ ot_cli_ftd_LDFLAGS                                                     = \
 ot_cli_ftd_SOURCES                                                     = \
     $(SOURCES_COMMON)                                                    \
     $(NULL)
-endif # OPENTHREAD_ENABLE_CLI_FTD
+endif # OPENTHREAD_ENABLE_FTD
 
-if OPENTHREAD_ENABLE_CLI_MTD
 bin_PROGRAMS                                                          += \
     ot-cli-mtd                                                           \
     $(NULL)
@@ -158,7 +157,6 @@ ot_cli_mtd_LDFLAGS                                                     = \
 ot_cli_mtd_SOURCES                                                     = \
     $(SOURCES_COMMON)                                                    \
     $(NULL)
-endif # OPENTHREAD_ENABLE_CLI_MTD
 
 if OPENTHREAD_BUILD_COVERAGE
 CLEANFILES                                                             = $(wildcard *.gcda *.gcno)

--- a/examples/apps/ncp/Makefile.am
+++ b/examples/apps/ncp/Makefile.am
@@ -29,91 +29,134 @@
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 bin_PROGRAMS                                                           = \
-    ot-ncp                                                               \
     $(NULL)
 
-ot_ncp_CPPFLAGS                                                        = \
+CPPFLAGS_COMMON                                                        = \
     -I$(top_srcdir)/include                                              \
     -I$(top_srcdir)/src/core                                             \
     -I$(top_srcdir)/examples/platforms                                   \
     $(NULL)
 
-ot_ncp_LDADD                                                           = \
-    $(top_builddir)/src/ncp/libopenthread-ncp.a                          \
-    $(top_builddir)/src/core/libopenthread-ftd.a                         \
+LDADD_COMMON                                                           = \
     $(NULL)
 
-ot_ncp_LDFLAGS                                                         = \
+LDFLAGS_COMMON                                                         = \
+    $(NULL)
+
+SOURCES_COMMON                                                         = \
+    main.c                                                               \
     $(NULL)
 
 if OPENTHREAD_ENABLE_BUILTIN_MBEDTLS
-ot_ncp_LDADD                                                          += \
+LDADD_COMMON                                                          += \
     $(top_builddir)/third_party/mbedtls/libmbedcrypto.a                  \
     $(NULL)
 endif # OPENTHREAD_ENABLE_BUILTIN_MBEDTLS
 
-ot_ncp_SOURCES                                                         = \
-    main.c                                                               \
-    $(NULL)
-
 if OPENTHREAD_ENABLE_DIAG
-ot_ncp_LDADD                                                          += \
+LDADD_COMMON                                                          += \
     $(top_builddir)/src/diag/libopenthread-diag.a                        \
     $(NULL)
 endif
 
 if OPENTHREAD_EXAMPLES_POSIX
-ot_ncp_LDADD                                                          += \
+LDADD_COMMON                                                          += \
     $(top_builddir)/examples/platforms/posix/libopenthread-posix.a       \
     -lstdc++                                                             \
     $(NULL)
 endif # OPENTHREAD_EXAMPLES_POSIX
 
 if OPENTHREAD_EXAMPLES_CC2538
-ot_ncp_LDADD                                                          += \
+LDADD_COMMON                                                          += \
     $(top_builddir)/examples/platforms/cc2538/libopenthread-cc2538.a     \
     $(NULL)
 
-ot_ncp_LDFLAGS                                                        += \
+LDFLAGS_COMMON                                                        += \
     -T $(top_srcdir)/examples/platforms/cc2538/cc2538.ld                 \
     $(NULL)
 endif # OPENTHREAD_EXAMPLES_CC2538
 
 if OPENTHREAD_EXAMPLES_CC2650
-ot_ncp_CPPFLAGS                                                       += \
+CPPFLAGS_COMMON                                                       += \
     -I$(top_srcdir)/third_party/ti/cc26xxware                            \
     $(NULL)
 
-ot_ncp_LDADD                                                          +=  \
+LDADD_COMMON                                                          +=  \
     $(top_builddir)/examples/platforms/cc2650/libopenthread-cc2650.a      \
     $(top_srcdir)/third_party/ti/cc26xxware/driverlib/bin/gcc/driverlib.a \
     $(NULL)
 
-ot_ncp_LDFLAGS                                                        +=   \
+LDFLAGS_COMMON                                                        +=   \
     -T $(top_srcdir)/third_party/ti/cc26xxware/linker_files/cc26x0f128.lds \
     $(NULL)
 
 endif # OPENTHREAD_EXAMPLES_CC2650
 
 if OPENTHREAD_EXAMPLES_DA15000
-ot_ncp_LDADD                                                          += \
+LDADD_COMMON                                                          += \
     $(top_builddir)/examples/platforms/da15000/libopenthread-da15000.a   \
     $(NULL)
 
-ot_ncp_LDFLAGS                                                        += \
+LDFLAGS_COMMON                                                        += \
     -T $(top_srcdir)/examples/platforms/da15000/da15000.ld               \
     $(NULL)
 endif # OPENTHREAD_EXAMPLES_DA15000
 
 if OPENTHREAD_EXAMPLES_NRF52840
-ot_ncp_LDADD                                                          += \
+LDADD_COMMON                                                          += \
     $(top_builddir)/examples/platforms/nrf52840/libopenthread-nrf52840.a \
     $(NULL)
 
-ot_ncp_LDFLAGS                                                        += \
+LDFLAGS_COMMON                                                        += \
     -T $(top_srcdir)/examples/platforms/nrf52840/nrf52840.ld             \
     $(NULL)
 endif
+
+if OPENTHREAD_ENABLE_FTD
+bin_PROGRAMS                                                          += \
+    ot-ncp-ftd                                                           \
+    $(NULL)
+
+ot_ncp_ftd_CPPFLAGS                                                    = \
+    $(CPPFLAGS_COMMON)                                                   \
+    $(NULL)
+
+ot_ncp_ftd_LDADD                                                       = \
+    $(top_builddir)/src/ncp/libopenthread-ncp.a                          \
+    $(top_builddir)/src/core/libopenthread-ftd.a                         \
+    $(LDADD_COMMON)                                                      \
+    $(NULL)
+
+ot_ncp_ftd_LDFLAGS                                                     = \
+    $(LDFLAGS_COMMON)                                                    \
+    $(NULL)
+
+ot_ncp_ftd_SOURCES                                                     = \
+    $(SOURCES_COMMON)                                                    \
+    $(NULL)
+endif # OPENTHREAD_ENABLE_FTD
+
+bin_PROGRAMS                                                          += \
+    ot-ncp-mtd                                                           \
+    $(NULL)
+
+ot_ncp_mtd_CPPFLAGS                                                    = \
+    $(CPPFLAGS_COMMON)                                                   \
+    $(NULL)
+
+ot_ncp_mtd_LDADD                                                       = \
+    $(top_builddir)/src/ncp/libopenthread-ncp.a                          \
+    $(top_builddir)/src/core/libopenthread-mtd.a                         \
+    $(LDADD_COMMON)                                                      \
+    $(NULL)
+
+ot_ncp_mtd_LDFLAGS                                                     = \
+    $(LDFLAGS_COMMON)                                                    \
+    $(NULL)
+
+ot_ncp_mtd_SOURCES                                                     = \
+    $(SOURCES_COMMON)                                                    \
+    $(NULL)
 
 if OPENTHREAD_BUILD_COVERAGE
 CLEANFILES                                                             = $(wildcard *.gcda *.gcno)

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -29,8 +29,6 @@
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 lib_LIBRARIES                       = \
-    libopenthread-ftd.a               \
-    libopenthread-mtd.a               \
     $(NULL)
 
 CPPFLAGS_COMMON                     = \
@@ -142,6 +140,11 @@ SOURCES_COMMON                     += \
     $(NULL)
 endif  # OPENTHREAD_ENABLE_RAW_LINK_API
 
+if OPENTHREAD_ENABLE_FTD
+lib_LIBRARIES                      += \
+    libopenthread-ftd.a               \
+    $(NULL)
+
 libopenthread_ftd_a_CPPFLAGS        = \
     $(CPPFLAGS_COMMON)                \
     $(NULL)
@@ -155,6 +158,11 @@ libopenthread_ftd_a_SOURCES         = \
     thread/mle_router.cpp             \
     thread/network_data_leader_ftd.cpp \
     thread/network_data_local.cpp     \
+    $(NULL)
+endif # OPENTHREAD_ENABLE_FTD
+
+lib_LIBRARIES                      += \
+    libopenthread-mtd.a               \
     $(NULL)
 
 libopenthread_mtd_a_CPPFLAGS        = \

--- a/tests/scripts/thread-cert/node_cli.py
+++ b/tests/scripts/thread-cert/node_cli.py
@@ -75,9 +75,9 @@ class otCli:
             else:
                 srcdir = os.path.dirname(os.path.realpath(__file__))
                 srcdir += "/../../.."
-            cmd = 'python %s/tools/spinel-cli/spinel-cli.py -p %s/examples/apps/ncp/ot-ncp -n' % (srcdir, builddir)
+            cmd = 'python %s/tools/spinel-cli/spinel-cli.py -p %s/examples/apps/ncp/ot-ncp-ftd -n' % (srcdir, builddir)
         else:
-            cmd = './ot-ncp'
+            cmd = './ot-ncp-ftd'
         cmd += ' %d' % nodeid
         print ("%s" % cmd)
 

--- a/tools/spinel-cli/README.md
+++ b/tools/spinel-cli/README.md
@@ -57,7 +57,7 @@ sudo pip install --user scapy==2.3.2
     -p <PIPE>, --pipe=<PIPE>
         Open a piped process connection to the OpenThread NCP device
         where <PIPE> is the command to start an emulator, such as
-        "ot-ncp".  Spinel-cli will communicate with the child process
+        "ot-ncp-ftd".  Spinel-cli will communicate with the child process
         via stdin/stdout.
 
     -s <SOCKET>, --socket=<SOCKET>
@@ -88,7 +88,7 @@ documented in the command reference section.
 ```
 openthread$ cd tools/spinel-cli/
 spinel-cli$ ./spinel-cli.py
-Opening pipe to ../../examples/apps/ncp/ot-ncp 1
+Opening pipe to ../../examples/apps/ncp/ot-ncp-ftd 1
 spinel-cli > help
 
 Available commands (type help <name> for more information):

--- a/tools/spinel-cli/SNIFFER.md
+++ b/tools/spinel-cli/SNIFFER.md
@@ -46,7 +46,7 @@ sudo pip install --user ipaddress
     -p <PIPE>, --pipe=<PIPE>
         Open a piped process connection to the OpenThread NCP device
         where <PIPE> is the command to start an emulator, such as
-        "ot-ncp".  Spinel-cli will communicate with the child process
+        "ot-ncp-ftd".  Spinel-cli will communicate with the child process
         via stdin/stdout.
 
     -s <SOCKET>, --socket=<SOCKET>

--- a/tools/spinel-cli/sniffer.py
+++ b/tools/spinel-cli/sniffer.py
@@ -47,7 +47,7 @@ from spinel.stream import StreamOpen
 from spinel.pcap import PcapCodec
 
 
-# Nodeid is required to execute ot-ncp for its sim radio socket port.
+# Nodeid is required to execute ot-ncp-ftd for its sim radio socket port.
 # This is maximum that works for MacOS.
 DEFAULT_NODEID = 34    # same as WELLKNOWN_NODE_ID
 DEFAULT_CHANNEL = 11
@@ -100,7 +100,7 @@ def main():
 
     # Set default stream to pipe
     stream_type = 'p'
-    stream_descriptor = "../../examples/apps/ncp/ot-ncp "+options.nodeid
+    stream_descriptor = "../../examples/apps/ncp/ot-ncp-ftd "+options.nodeid
 
     if options.uart:
         stream_type = 'u'

--- a/tools/spinel-cli/spinel-cli.py
+++ b/tools/spinel-cli/spinel-cli.py
@@ -2076,7 +2076,7 @@ def main():
 
     # Set default stream to pipe
     stream_type = 'p'
-    stream_descriptor = "../../examples/apps/ncp/ot-ncp " + options.nodeid
+    stream_descriptor = "../../examples/apps/ncp/ot-ncp-ftd " + options.nodeid
 
     if options.uart:
         stream_type = 'u'


### PR DESCRIPTION
* Add a new build target: ncp-mtd.
    
* Platform with "--enable-ftd" build option will build both MTD and FTD.
    
* Platform without "--enable-ftd" build option will only build MTD.

Also resolves #1375.