### PR TITLE
`NCP/Spinel` Add new spinel property to test assert

### DIFF
--- a/doc/spinel-protocol-src/Makefile
+++ b/doc/spinel-protocol-src/Makefile
@@ -80,6 +80,7 @@ draft-spinel-protocol-bis.xml: \
 	spinel-frame-format.md \
 	spinel-framing.md \
 	spinel-prop-core.md \
+	spinel-prop-debug.md \
 	spinel-prop-ipv6.md \
 	spinel-prop-mac.md \
 	spinel-prop-net.md \

--- a/doc/spinel-protocol-src/spinel-prop-debug.md
+++ b/doc/spinel-protocol-src/spinel-prop-debug.md
@@ -1,0 +1,11 @@
+## Debug Properties {#prop-debug}
+
+### PROP 16384: SPINEL_PROP_DEBUG_TEST_ASSERT {#prop-debug-test-assert}
+* Type: Read-Only
+* Packed-Encoding: `b`
+
+Reading this property will cause an assert on the NCP. This
+is intended for testing the assert functionality of
+underlying platform/NCP. Assert should ideally cause the
+NCP to reset, but if `assert` is not supported or disabled
+boolean value of `false` is returned in response.

--- a/doc/spinel-protocol-src/spinel-prop.md
+++ b/doc/spinel-protocol-src/spinel-prop.md
@@ -33,12 +33,13 @@ NET    | 0x40 - 0x4F, 0x1400 - 0x14FF | (#prop-net)
 Tech   | 0x50 - 0x5F, 0x1500 - 0x15FF | Technology-specific
 IPv6   | 0x60 - 0x6F, 0x1600 - 0x16FF | (#prop-ipv6)
 Stream | 0x70 - 0x7F, 0x1700 - 0x17FF | (#prop-core)
+Debug  |              0x4000 - 0x4400 | (#prop-debug)
 
-Note that each property section has two reserved ranges: a
-primary range (which is encoded as a single byte) and
-an extended range (which is encoded as two bytes). properties
-which are used more frequently are generally allocated
-from the former range.
+Note that some of the property sections have two reserved
+ranges: a primary range (which is encoded as a single byte)
+and an extended range (which is encoded as two bytes).
+properties which are used more frequently are generally
+allocated from the former range.
 
 {{spinel-prop-core.md}}
 
@@ -50,3 +51,4 @@ from the former range.
 
 {{spinel-prop-ipv6.md}}
 
+{{spinel-prop-debug.md}}

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -36,9 +36,9 @@
 #include <openthread-config.h>
 #endif
 
-#include <assert.h>
 #include <stdlib.h>
 #include <common/code_utils.hpp>
+ #include <common/debug.hpp>
 #include <ncp/ncp.h>
 #include <ncp/ncp_base.hpp>
 #include <net/ip6.hpp>
@@ -225,6 +225,7 @@ const NcpBase::GetPropertyHandlerEntry NcpBase::mGetPropertyHandlerTable[] =
     { SPINEL_PROP_CNTR_RX_SPINEL_ERR, &NcpBase::GetPropertyHandler_NCP_CNTR },
 
     { SPINEL_PROP_MSG_BUFFER_COUNTERS, &NcpBase::GetPropertyHandler_MSG_BUFFER_COUNTERS },
+    { SPINEL_PROP_DEBUG_TEST_ASSERT, &NcpBase::GetPropertyHandler_DEBUG_TEST_ASSERT },
 
 #if OPENTHREAD_ENABLE_LEGACY
     { SPINEL_PROP_NEST_LEGACY_ULA_PREFIX, &NcpBase::GetPropertyHandler_NEST_LEGACY_ULA_PREFIX },
@@ -3066,6 +3067,24 @@ ThreadError NcpBase::GetPropertyHandler_MSG_BUFFER_COUNTERS(uint8_t header, spin
 
 exit:
     return errorCode;
+}
+
+ThreadError NcpBase::GetPropertyHandler_DEBUG_TEST_ASSERT(uint8_t header, spinel_prop_key_t key)
+{
+    assert(false);
+
+    // We only get to this point if `assert(false)`
+    // does not cause an NCP reset on the platform.
+    // In such a case we return `false` as the
+    // property value to inidicate this.
+
+    return SendPropertyUpdate(
+               header,
+               SPINEL_CMD_PROP_VALUE_IS,
+               key,
+               SPINEL_DATATYPE_BOOL_S,
+               false
+            );
 }
 
 ThreadError NcpBase::GetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key)

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -389,6 +389,7 @@ private:
     ThreadError GetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_NET_REQUIRE_JOIN_EXISTING(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_DEBUG_TEST_ASSERT(uint8_t header, spinel_prop_key_t key);
 
 #if OPENTHREAD_ENABLE_JAM_DETECTION
     ThreadError GetPropertyHandler_JAM_DETECT_ENABLE(uint8_t header, spinel_prop_key_t key);
@@ -402,6 +403,7 @@ private:
 #if OPENTHREAD_ENABLE_LEGACY
     ThreadError GetPropertyHandler_NEST_LEGACY_ULA_PREFIX(uint8_t header, spinel_prop_key_t key);
 #endif
+
 
     ThreadError SetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                uint16_t value_len);

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1248,6 +1248,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_GPIO_STATE_CLEAR";
         break;
 
+    case SPINEL_PROP_DEBUG_TEST_ASSERT:
+        ret = "SPINEL_PROP_DEBUG_TEST_ASSERT";
+        break;
+
     default:
         break;
     }

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -1078,6 +1078,19 @@ typedef enum
     SPINEL_PROP_VENDOR__BEGIN       = 15360,
     SPINEL_PROP_VENDOR__END         = 16384,
 
+    SPINEL_PROP_DEBUG__BEGIN        = 16384,
+
+    /// Reading this property will cause an assert on the NCP.
+    /// This is intended for testing the assert functionality of
+    /// underlying platform/NCP. Assert should ideally cause the
+    /// NCP to reset, but if this is not supported a `false` boolean
+    /// is returned in response.
+    /** Format: 'b' (read-only) */
+    SPINEL_PROP_DEBUG_TEST_ASSERT
+                                    = SPINEL_PROP_DEBUG__BEGIN + 0,
+
+    SPINEL_PROP_DEBUG__END          = 17408,
+
     SPINEL_PROP_EXPERIMENTAL__BEGIN = 2000000,
     SPINEL_PROP_EXPERIMENTAL__END   = 2097152,
 } spinel_prop_key_t;


### PR DESCRIPTION
This commit adds `SPINEL_PROP_DEBUG_TEST_ASSERT` as a new read-only
spinel property and also adds its associated get handler.

Getting this property will cause an assert on the NCP. This is
intended as method for testing the the assert functionality of
underlying platform.