### PR TITLE
New radio capability to indicate CSMA backoff support by radio layer

### DIFF
--- a/include/platform/radio.h
+++ b/include/platform/radio.h
@@ -91,7 +91,8 @@ typedef enum otRadioCaps
     kRadioCapsNone              = 0,  ///< None
     kRadioCapsAckTimeout        = 1,  ///< Radio supports AckTime event
     kRadioCapsEnergyScan        = 2,  ///< Radio supports Energy Scans
-    kRadioCapsTransmitRetries   = 4,  ///< Radio supports transmission retry logic with collision avoidance
+    kRadioCapsTransmitRetries   = 4,  ///< Radio supports transmission retry logic with collision avoidance (CSMA).
+    kRadioCapsCsmaBackOff       = 8,  ///< Radio supports CSMA backoff for frame transmission (but no retry).
 } otRadioCaps;
 
 /**

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -560,13 +560,22 @@ public:
     void ClearSrcMatchEntries(void);
 
     /**
-     * This method indicates whether or not transmit retries and CSMA backoff logic is supported by the radio layer.
+     * This method indicates whether or not CSMA backoff is supported by the radio layer.
      *
-     * @retval true   Retries and CSMA are supported by the radio.
-     * @retval false  Retries and CSMA are not supported by the radio.
+     * @retval true   CSMA backoff is supported by the radio.
+     * @retval false  CSMA backoff is not supported by the radio.
      *
      */
-    bool RadioSupportsRetriesAndCsmaBackoff(void);
+    bool RadioSupportsCsmaBackoff(void);
+
+    /**
+     * This method indicates whether or not transmit retries is supported by the radio layer.
+     *
+     * @retval true   Retries (and CSMA) are supported by the radio.
+     * @retval false  Retries (and CSMA) are not supported by the radio.
+     *
+     */
+    bool RadioSupportsRetries(void);
 
 private:
     enum ScanType


### PR DESCRIPTION
- This commit adds a new radio capability `kRadioCapsCsmaBackOff` to
  indicate that the radio supports CSMA backoff logic for frame
  transmission (but no frame retry).

- The existing capability `kRadioCapsTransmitRetries` is not changed
  and still indicates that the radio supports transmission retry logic
  along with collision avoidance (CSMA).

- `Mac` implementation is updated accordingly.