### PR TITLE
Ncp: Simplify Tx Buffer Management

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -476,6 +476,7 @@ static uint8_t BorderRouterConfigToFlagByte(const otBorderRouterConfig &config)
 
 NcpBase::NcpBase(otInstance *aInstance):
     mInstance(aInstance),
+    mTxFrameBuffer(mTxBuffer, sizeof(mTxBuffer)),
     mLastStatus(SPINEL_STATUS_OK),
     mSupportedChannelMask(kPhySupportedChannelMask),
     mChannelMask(kPhySupportedChannelMask),
@@ -527,6 +528,30 @@ NcpBase::NcpBase(otInstance *aInstance):
     mLegacyHandlers = NULL;
     memset(mLegacyUlaPrefix, 0, sizeof(mLegacyUlaPrefix));
 #endif
+}
+
+// ----------------------------------------------------------------------------
+// MARK: Outbound Frame methods
+// ----------------------------------------------------------------------------
+
+ThreadError NcpBase::OutboundFrameBegin(void)
+{
+    return mTxFrameBuffer.InFrameBegin();
+}
+
+ThreadError NcpBase::OutboundFrameFeedData(const uint8_t *aDataBuffer, uint16_t aDataBufferLength)
+{
+    return mTxFrameBuffer.InFrameFeedData(aDataBuffer, aDataBufferLength);
+}
+
+ThreadError NcpBase::OutboundFrameFeedMessage(otMessage aMessage)
+{
+    return mTxFrameBuffer.InFrameFeedMessage(aMessage);
+}
+
+ThreadError NcpBase::OutboundFrameEnd(void)
+{
+    return mTxFrameBuffer.InFrameEnd();
 }
 
 // ----------------------------------------------------------------------------

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -44,6 +44,7 @@
 #include <openthread-ip6.h>
 #include <common/tasklet.hpp>
 #include <ncp/ncp.h>
+#include <ncp/ncp_buffer.hpp>
 
 #include "spinel.h"
 
@@ -75,7 +76,7 @@ protected:
      * @retval kThreadError_NoBufs    Insufficient buffer space available to start a new frame.
      *
      */
-    virtual ThreadError OutboundFrameBegin(void) = 0;
+    ThreadError OutboundFrameBegin(void);
 
     /**
      * This method adds data to the current outbound frame being written.
@@ -89,7 +90,7 @@ protected:
      * @retval kThreadError_NoBufs    Insufficient buffer space available to add data.
      *
      */
-    virtual ThreadError OutboundFrameFeedData(const uint8_t *aDataBuffer, uint16_t aDataBufferLength) = 0;
+    ThreadError OutboundFrameFeedData(const uint8_t *aDataBuffer, uint16_t aDataBufferLength);
 
     /**
      * This method adds a message to the current outbound frame being written.
@@ -104,7 +105,7 @@ protected:
      * @retval kThreadError_NoBufs  Insufficient buffer space available to add message.
      *
      */
-    virtual ThreadError OutboundFrameFeedMessage(otMessage aMessage) = 0;
+    ThreadError OutboundFrameFeedMessage(otMessage aMessage);
 
     /**
      * This method finalizes and sends the current outbound frame
@@ -115,7 +116,7 @@ protected:
      * @retval kThreadError_NoBufs  Insufficient buffer space available to add message.
      *
      */
-    virtual ThreadError OutboundFrameEnd(void) = 0;
+    ThreadError OutboundFrameEnd(void);
 
     /**
      * This method is called by the framer whenever a framing error
@@ -551,7 +552,14 @@ public:
     void RegisterLegacyHandlers(const otNcpLegacyHandlers *aHandlers);
 #endif
 
+protected:
+    NcpFrameBuffer  mTxFrameBuffer;
+
 private:
+    enum
+    {
+        kTxBufferSize = OPENTHREAD_CONFIG_NCP_TX_BUFFER_SIZE,  // Tx Buffer size (used by mTxFrameBuffer).
+    };
 
     spinel_status_t mLastStatus;
 
@@ -576,6 +584,8 @@ private:
     uint16_t mDroppedReplyTidBitSet;
 
     spinel_tid_t mNextExpectedTid;
+
+    uint8_t mTxBuffer[kTxBufferSize];
 
     bool mAllowLocalNetworkDataChange;
     bool mRequireJoinExistingNetwork;

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -89,8 +89,7 @@ static uint16_t spi_header_get_data_len(const uint8_t *header)
 NcpSpi::NcpSpi(otInstance *aInstance):
     NcpBase(aInstance),
     mHandleRxFrameTask(aInstance->mIp6.mTaskletScheduler, &NcpSpi::HandleRxFrame, this),
-    mPrepareTxFrameTask(aInstance->mIp6.mTaskletScheduler, &NcpSpi::PrepareTxFrame, this),
-    mTxFrameBuffer(mTxBuffer, sizeof(mTxBuffer))
+    mPrepareTxFrameTask(aInstance->mIp6.mTaskletScheduler, &NcpSpi::PrepareTxFrame, this)
 {
     memset(mEmptySendFrame, 0, kSpiHeaderLength);
     memset(mSendFrame, 0, kSpiHeaderLength);
@@ -230,26 +229,6 @@ NcpSpi::SpiTransactionComplete(
         aMOSIBufLen,
         (mTxState == kTxStateSending)
     );
-}
-
-ThreadError NcpSpi::OutboundFrameBegin(void)
-{
-    return mTxFrameBuffer.InFrameBegin();
-}
-
-ThreadError NcpSpi::OutboundFrameFeedData(const uint8_t *aDataBuffer, uint16_t aDataBufferLength)
-{
-    return mTxFrameBuffer.InFrameFeedData(aDataBuffer, aDataBufferLength);
-}
-
-ThreadError NcpSpi::OutboundFrameFeedMessage(otMessage aMessage)
-{
-    return mTxFrameBuffer.InFrameFeedMessage(aMessage);
-}
-
-ThreadError NcpSpi::OutboundFrameEnd(void)
-{
-    return mTxFrameBuffer.InFrameEnd();
 }
 
 void NcpSpi::TxFrameBufferHasData(void *aContext, NcpFrameBuffer *aNcpFrameBuffer)

--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -40,7 +40,6 @@
 #endif
 
 #include <ncp/ncp_base.hpp>
-#include <ncp/ncp_buffer.hpp>
 
 namespace Thread {
 
@@ -57,11 +56,6 @@ public:
      */
     NcpSpi(otInstance *aInstance);
 
-    virtual ThreadError OutboundFrameBegin(void);
-    virtual ThreadError OutboundFrameFeedData(const uint8_t *frame, uint16_t frameLength);
-    virtual ThreadError OutboundFrameFeedMessage(otMessage message);
-    virtual ThreadError OutboundFrameEnd(void);
-
     void ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength);
 
 private:
@@ -69,7 +63,6 @@ private:
     {
         kSpiBufferSize   = OPENTHREAD_CONFIG_NCP_SPI_BUFFER_SIZE, // Spi buffer size (should be large enough to fit a
                                                                   // max length frame + spi header).
-        kTxBufferSize    = OPENTHREAD_CONFIG_NCP_TX_BUFFER_SIZE,  // Tx Buffer size (used by mTxFrameBuffer).
         kSpiHeaderLength = 5,                                     // Size of spi header.
     };
 
@@ -122,8 +115,6 @@ private:
     uint8_t mEmptySendFrame[kSpiHeaderLength];
     uint8_t mEmptyReceiveFrame[kSpiHeaderLength];
 
-    uint8_t mTxBuffer[kTxBufferSize];
-    NcpFrameBuffer  mTxFrameBuffer;
 };
 
 }  // namespace Thread

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -89,7 +89,6 @@ NcpUart::NcpUart(otInstance *aInstance):
     NcpBase(aInstance),
     mFrameDecoder(mRxBuffer, sizeof(mRxBuffer), &NcpUart::HandleFrame, &NcpUart::HandleError, this),
     mUartBuffer(),
-    mTxFrameBuffer(mTxBuffer, sizeof(mTxBuffer)),
     mState(kStartingFrame),
     mByte(0),
     mUartSendTask(aInstance->mIp6.mTaskletScheduler, EncodeAndSendToUart, this)
@@ -97,26 +96,6 @@ NcpUart::NcpUart(otInstance *aInstance):
     mTxFrameBuffer.SetCallbacks(NULL, TxFrameBufferHasData, this);
 
     otPlatUartEnable();
-}
-
-ThreadError NcpUart::OutboundFrameBegin(void)
-{
-    return mTxFrameBuffer.InFrameBegin();
-}
-
-ThreadError NcpUart::OutboundFrameFeedData(const uint8_t *aDataBuffer, uint16_t aDataBufferLength)
-{
-    return mTxFrameBuffer.InFrameFeedData(aDataBuffer, aDataBufferLength);
-}
-
-ThreadError NcpUart::OutboundFrameFeedMessage(otMessage aMessage)
-{
-    return mTxFrameBuffer.InFrameFeedMessage(aMessage);
-}
-
-ThreadError NcpUart::OutboundFrameEnd(void)
-{
-    return mTxFrameBuffer.InFrameEnd();
 }
 
 void NcpUart::TxFrameBufferHasData(void *aContext, NcpFrameBuffer *aNcpFrameBuffer)

--- a/src/ncp/ncp_uart.hpp
+++ b/src/ncp/ncp_uart.hpp
@@ -41,7 +41,6 @@
 
 #include <ncp/ncp_base.hpp>
 #include <ncp/hdlc.hpp>
-#include <ncp/ncp_buffer.hpp>
 
 namespace Thread {
 
@@ -57,55 +56,6 @@ public:
      *
      */
     NcpUart(otInstance *aInstance);
-
-    /**
-     * This method is called to start a new outbound frame.
-     *
-     * @retval kThreadError_None      Successfully started a new frame.
-     * @retval kThreadError_NoBufs    Insufficient buffer space available to start a new frame.
-     *
-     */
-    virtual ThreadError OutboundFrameBegin(void);
-
-    /**
-     * This method adds data to the current outbound frame being written.
-     *
-     * If no buffer space is available, this method will discard and clear the frame before returning an error status.
-     *
-     * @param[in]  aDataBuffer        A pointer to data buffer.
-     * @param[in]  aDataBufferLength  The length of the data buffer.
-     *
-     * @retval kThreadError_None      Successfully added new data to the frame.
-     * @retval kThreadError_NoBufs    Insufficient buffer space available to add data.
-     *
-     */
-    virtual ThreadError OutboundFrameFeedData(const uint8_t *aDataBuffer, uint16_t aDataBufferLength);
-
-    /**
-     * This method adds a message to the current outbound frame being written.
-     *
-     * If no buffer space is available, this method will discard and clear the frame before returning an error status.
-     * In case of success, the passed-in message @aMessage will be owned by outbound buffer and will be freed
-     * when either the the frame is successfully sent and removed or if the frame is discarded.
-     *
-     * @param[in]  aMessage         A message instance to be added to current frame.
-     *
-     * @retval kThreadError_None    Successfully added the message to the frame.
-     * @retval kThreadError_NoBufs  Insufficient buffer space available to add message.
-     *
-     */
-    virtual ThreadError OutboundFrameFeedMessage(otMessage aMessage);
-
-    /**
-     * This method finalizes and sends the current outbound frame.
-     *
-     * If no buffer space is available, this method will discard and clear the frame before returning an error status.
-     *
-     * @retval kThreadError_None    Successfully added the message to the frame.
-     * @retval kThreadError_NoBufs  Insufficient buffer space available to add message.
-     *
-     */
-    virtual ThreadError OutboundFrameEnd(void);
 
     /**
      * This method is called when uart tx is finished. It prepares and sends the next data chunk (if any) to uart.
@@ -124,7 +74,6 @@ private:
     enum
     {
         kUartTxBufferSize = OPENTHREAD_CONFIG_NCP_UART_TX_CHUNK_SIZE,  // Uart tx buffer size.
-        kTxBufferSize = OPENTHREAD_CONFIG_NCP_TX_BUFFER_SIZE,          // Tx Buffer size (used by mTxFrameBuffer).
         kRxBufferSize = OPENTHREAD_CONFIG_NCP_UART_RX_BUFFER_SIZE,     // Rx buffer size (should be large enough to fit
                                                                        // one whole (decoded) received frame).
     };
@@ -163,10 +112,8 @@ private:
     Hdlc::Encoder   mFrameEncoder;
     Hdlc::Decoder   mFrameDecoder;
     UartTxBuffer    mUartBuffer;
-    NcpFrameBuffer  mTxFrameBuffer;
     UartTxState     mState;
     uint8_t         mByte;
-    uint8_t         mTxBuffer[kTxBufferSize];
     uint8_t         mRxBuffer[kRxBufferSize];
     Tasklet         mUartSendTask;
 };


### PR DESCRIPTION
This commit changes the `NcpBase` class so that it defines and
controls the NCP Tx buffer used for outbound spinel message (instead
of delegating this to the sub-classes `NcpUart` and `NcpSpi`).

This removes the need to use abstract `virtual` methods in the base
class. It also simplifies the code by removing the common/duplicate
implementation in each sub-class.