### PR TITLE
Implement the use of otPlatRadioDefaultTxPower API.

### DIFF
--- a/examples/drivers/windows/otLwf/radio.c
+++ b/examples/drivers/windows/otLwf/radio.c
@@ -759,6 +759,13 @@ error:
     return NT_SUCCESS(status) ? kThreadError_None : kThreadError_Failed;
 }
 
+void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+{
+    // TODO: Create a proper implementation for this driver.
+    (void)aInstance;
+    (void)aPower;
+}
+
 inline USHORT getDstShortAddress(const UCHAR *frame)
 {
     return (((USHORT)frame[IEEE802154_DSTADDR_OFFSET + 1]) << 8) | frame[IEEE802154_DSTADDR_OFFSET];

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -785,3 +785,10 @@ ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, u
     (void)aScanDuration;
     return kThreadError_NotImplemented;
 }
+
+void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+{
+    // TODO: Create a proper implementation for this driver.
+    (void)aInstance;
+    (void)aPower;
+}

--- a/examples/platforms/cc2650/radio.c
+++ b/examples/platforms/cc2650/radio.c
@@ -1214,6 +1214,13 @@ exit:
     return error;
 }
 
+void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+{
+    // TODO: Create a proper implementation for this driver.
+    (void)aInstance;
+    (void)aPower;
+}
+
 /**
  * Function documented in platform/radio.h
  */

--- a/examples/platforms/da15000/radio.c
+++ b/examples/platforms/da15000/radio.c
@@ -405,6 +405,13 @@ ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, u
     return kThreadError_NotImplemented;
 }
 
+void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+{
+    // TODO: Create a proper implementation for this driver.
+    (void)aInstance;
+    (void)aPower;
+}
+
 void da15000RadioProcess(otInstance *aInstance)
 {
     if (sSendFrameDone)

--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -434,6 +434,13 @@ ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, u
     return kThreadError_None;
 }
 
+void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+{
+    // TODO: Create a proper implementation for this driver.
+    (void)aInstance;
+    (void)aPower;
+}
+
 void nrf5RadioProcess(otInstance *aInstance)
 {
     for (uint32_t i = 0; i < RADIO_RX_BUFFERS; i++)

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -738,3 +738,9 @@ ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, u
     (void)aScanDuration;
     return kThreadError_NotImplemented;
 }
+
+void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+{
+    (void)aInstance;
+    (void)aPower;
+}

--- a/include/platform/radio.h
+++ b/include/platform/radio.h
@@ -397,6 +397,15 @@ int8_t otPlatRadioGetRssi(otInstance *aInstance);
 otRadioCaps otPlatRadioGetCaps(otInstance *aInstance);
 
 /**
+ * Set the radio Tx power used for auto-generated frames.
+ *
+ * @param[in] aInstance  The OpenThread instance structure.
+ * @param[in] aPower     The Tx power to use in dBm.
+ *
+ */
+void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower);
+
+/**
  * Get the status of promiscuous mode.
  *
  * @param[in] aInstance  The OpenThread instance structure.

--- a/src/core/openthread.cpp
+++ b/src/core/openthread.cpp
@@ -289,6 +289,7 @@ int8_t otGetMaxTransmitPower(otInstance *aInstance)
 void otSetMaxTransmitPower(otInstance *aInstance, int8_t aPower)
 {
     aInstance->mThreadNetif.GetMac().SetMaxTransmitPower(aPower);
+    otPlatRadioSetDefaultTxPower(aInstance, aPower);
 }
 
 const otIp6Address *otGetMeshLocalEid(otInstance *aInstance)


### PR DESCRIPTION
Provide a solution for issue #1407.  When a client sets the max Tx power via otSetMaxTransmitPower, OpenThread will immediately call down to the platform with otPlatRadioDefaultTxPower and pass the new value so that it can be used for auto-generated frames (ACK's).