### PR TITLE
Implement the use of otPlatRadioDefaultTxPower API.

### DIFF
--- a/examples/drivers/windows/otLwf/radio.c
+++ b/examples/drivers/windows/otLwf/radio.c
@@ -759,6 +759,13 @@ error:
     return NT_SUCCESS(status) ? kThreadError_None : kThreadError_Failed;
 }
 
+void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+{
+    // TODO: Create a proper implementation for this driver.
+    (void)aInstance;
+    (void)aPower;
+}
+
 inline USHORT getDstShortAddress(const UCHAR *frame)
 {
     return (((USHORT)frame[IEEE802154_DSTADDR_OFFSET + 1]) << 8) | frame[IEEE802154_DSTADDR_OFFSET];

--- a/examples/drivers/windows/otLwf/radio.c
+++ b/examples/drivers/windows/otLwf/radio.c
@@ -759,11 +759,24 @@ error:
     return NT_SUCCESS(status) ? kThreadError_None : kThreadError_Failed;
 }
 
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+void otPlatRadioSetDefaultTxPower(_In_ otInstance *otCtx, int8_t aPower)
 {
-    // TODO: Create a proper implementation for this driver.
-    (void)aInstance;
-    (void)aPower;
+    NT_ASSERT(otCtx);
+    PMS_FILTER pFilter = otCtxToFilter(otCtx);
+    NTSTATUS status;
+
+    // Indicate to the miniport
+    status =
+        otLwfCmdSetProp(
+            pFilter,
+            SPINEL_PROP_PHY_TX_POWER,
+            SPINEL_DATATYPE_INT8_S,
+            aPower
+        );
+    if (!NT_SUCCESS(status))
+    {
+        LogError(DRIVER_DEFAULT, "Set SPINEL_PROP_PHY_TX_POWER failed, %!STATUS!", status);
+    }
 }
 
 inline USHORT getDstShortAddress(const UCHAR *frame)

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -785,3 +785,10 @@ ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, u
     (void)aScanDuration;
     return kThreadError_NotImplemented;
 }
+
+void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+{
+    // TODO: Create a proper implementation for this driver.
+    (void)aInstance;
+    (void)aPower;
+}

--- a/examples/platforms/cc2650/radio.c
+++ b/examples/platforms/cc2650/radio.c
@@ -1214,6 +1214,13 @@ exit:
     return error;
 }
 
+void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+{
+    // TODO: Create a proper implementation for this driver.
+    (void)aInstance;
+    (void)aPower;
+}
+
 /**
  * Function documented in platform/radio.h
  */

--- a/examples/platforms/da15000/radio.c
+++ b/examples/platforms/da15000/radio.c
@@ -406,6 +406,13 @@ ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, u
     return kThreadError_NotImplemented;
 }
 
+void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+{
+    // TODO: Create a proper implementation for this driver.
+    (void)aInstance;
+    (void)aPower;
+}
+
 void da15000RadioProcess(otInstance *aInstance)
 {
     if (sSendFrameDone)

--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -434,6 +434,13 @@ ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, u
     return kThreadError_None;
 }
 
+void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+{
+    // TODO: Create a proper implementation for this driver.
+    (void)aInstance;
+    (void)aPower;
+}
+
 void nrf5RadioProcess(otInstance *aInstance)
 {
     for (uint32_t i = 0; i < RADIO_RX_BUFFERS; i++)

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -738,3 +738,9 @@ ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, u
     (void)aScanDuration;
     return kThreadError_NotImplemented;
 }
+
+void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+{
+    (void)aInstance;
+    (void)aPower;
+}

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -397,6 +397,15 @@ int8_t otPlatRadioGetRssi(otInstance *aInstance);
 otRadioCaps otPlatRadioGetCaps(otInstance *aInstance);
 
 /**
+ * Set the radio Tx power used for auto-generated frames.
+ *
+ * @param[in] aInstance  The OpenThread instance structure.
+ * @param[in] aPower     The Tx power to use in dBm.
+ *
+ */
+void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower);
+
+/**
  * Get the status of promiscuous mode.
  *
  * @param[in] aInstance  The OpenThread instance structure.

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -91,6 +91,7 @@ int8_t otLinkGetMaxTransmitPower(otInstance *aInstance)
 void otLinkSetMaxTransmitPower(otInstance *aInstance, int8_t aPower)
 {
     aInstance->mThreadNetif.GetMac().SetMaxTransmitPower(aPower);
+    otPlatRadioSetDefaultTxPower(aInstance, aPower);
 }
 
 otPanId otLinkGetPanId(otInstance *aInstance)

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -319,6 +319,12 @@ extern "C" {
         return kThreadError_NotImplemented;
     }
 
+    void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+    {
+        (void)aInstance;
+        (void)aPower;
+    }
+
     //
     // Random
     //


### PR DESCRIPTION
This PR adds a call from otLinkSetMaxTransmitPower to otPlatRadioDefaultTxPower so that the platform can immediately apply a new power value to auto-generated frames (ACK's).  Many example implementations are currently just stubs that will need to be implemented by the respective example owners.

Addresses issue #1407.