### PR TITLE
Automatic Joiners removal in Commissioner

### DIFF
--- a/examples/drivers/windows/include/otLwfIoctl.h
+++ b/examples/drivers/windows/include/otLwfIoctl.h
@@ -602,6 +602,7 @@ typedef struct otCommissionConfig
     // uint8_t - aExtAddressValid
     // otExtAddress - aExtAddress (optional)
     // char[OPENTHREAD_PSK_MAX_LENGTH + 1] - aPSKd
+    // uint32_t - aTimeout
 
 #define IOCTL_OTLWF_OT_COMMISIONER_REMOVE_JOINER \
     OTLWF_CTL_CODE(181, METHOD_BUFFERED, FILE_WRITE_DATA)

--- a/examples/drivers/windows/otApi/otApi.cpp
+++ b/examples/drivers/windows/otApi/otApi.cpp
@@ -3513,7 +3513,8 @@ OTCALL
 otCommissionerAddJoiner(
     _In_ otInstance *aInstance, 
     const otExtAddress *aExtAddress, 
-    const char *aPSKd
+    const char *aPSKd,
+    uint32_t aTimeout
     )
 {
     if (aInstance == nullptr || aPSKd == nullptr) return kThreadError_InvalidArgs;
@@ -3526,13 +3527,14 @@ otCommissionerAddJoiner(
 
     uint8_t aExtAddressValid = aExtAddress ? 1 : 0;
     
-    const ULONG BufferLength = sizeof(GUID) + sizeof(uint8_t) + sizeof(otExtAddress) + (ULONG)aPSKdLength + 1;
-    BYTE Buffer[sizeof(GUID) + sizeof(uint8_t) + sizeof(otExtAddress) + OPENTHREAD_PSK_MAX_LENGTH + 1] = {0};
+    const ULONG BufferLength = sizeof(GUID) + sizeof(uint8_t) + sizeof(otExtAddress) + (ULONG)aPSKdLength + 1 + sizeof(aTimeout);
+    BYTE Buffer[sizeof(GUID) + sizeof(uint8_t) + sizeof(otExtAddress) + OPENTHREAD_PSK_MAX_LENGTH + 1 + sizeof(aTimeout)] = {0};
     memcpy_s(Buffer, sizeof(Buffer), &aInstance->InterfaceGuid, sizeof(GUID));
     memcpy_s(Buffer + sizeof(GUID), sizeof(Buffer) - sizeof(GUID), &aExtAddressValid, sizeof(aExtAddressValid));
     if (aExtAddressValid)
         memcpy_s(Buffer + sizeof(GUID) + sizeof(uint8_t), sizeof(Buffer) - sizeof(GUID) - sizeof(uint8_t), aExtAddress, sizeof(otExtAddress));
     memcpy_s(Buffer + sizeof(GUID) + sizeof(uint8_t) + sizeof(otExtAddress), sizeof(Buffer) - sizeof(GUID) - sizeof(uint8_t) - sizeof(otExtAddress), aPSKd, aPSKdLength);
+    memcpy_s(Buffer + sizeof(GUID) + sizeof(uint8_t) + sizeof(otExtAddress) + aPSKdLength + 1, sizeof(Buffer) - sizeof(GUID) - sizeof(uint8_t) - sizeof(otExtAddress) - aPSKdLength - 1, &aTimeout, sizeof(aTimeout));
     
     return DwordToThreadError(SendIOCTL(aInstance->ApiHandle, IOCTL_OTLWF_OT_COMMISIONER_ADD_JOINER, Buffer, BufferLength, nullptr, 0));
 }

--- a/examples/drivers/windows/otLwf/iocontrol.c
+++ b/examples/drivers/windows/otLwf/iocontrol.c
@@ -5596,19 +5596,20 @@ otLwfIoCtl_otCommissionerAddJoiner(
     
     if (InBufferLength >= sizeof(uint8_t) + sizeof(otExtAddress))
     {
-        const ULONG aPSKdBufferLength = InBufferLength - sizeof(uint8_t) - sizeof(otExtAddress);
+        const ULONG aPSKdBufferLength = InBufferLength - sizeof(uint8_t) - sizeof(otExtAddress) - sizeof(uint32_t);
 
         if (aPSKdBufferLength <= OPENTHREAD_PSK_MAX_LENGTH + 1)
         {
             uint8_t aExtAddressValid = *(uint8_t*)InBuffer;
             const otExtAddress *aExtAddress = aExtAddressValid == 0 ? NULL : (otExtAddress*)(InBuffer + sizeof(uint8_t));
             char *aPSKd = (char*)(InBuffer + sizeof(uint8_t) + sizeof(otExtAddress));
+            uint32_t aTimeout = *(uint32_t*)(InBuffer + sizeof(uint8_t) + sizeof(otExtAddress) + aPSKdBufferLength);
 
             // Ensure aPSKd is NULL terminated in the buffer
             if (strnlen(aPSKd, aPSKdBufferLength) < aPSKdBufferLength)
             {
                 status = ThreadErrorToNtstatus(otCommissionerAddJoiner(
-                    pFilter->otCtx, aExtAddress, aPSKd));
+                    pFilter->otCtx, aExtAddress, aPSKd, aTimeout));
             }
         }
     }

--- a/examples/drivers/windows/otNodeApi/otNodeApi.cpp
+++ b/examples/drivers/windows/otNodeApi/otNodeApi.cpp
@@ -1010,11 +1010,13 @@ OTNODEAPI int32_t OTCALL otNodeCommissionerJoinerAdd(otNode* aNode, const char *
     otLogFuncEntryMsg("[%d] %s %s", aNode->mId, aExtAddr, aPSKd);
     printf("%d: commissioner joiner add %s %s\r\n", aNode->mId, aExtAddr, aPSKd);
 
+    const uint32_t kDefaultJoinerTimeout = 120;
+
     ThreadError error;
     
     if (strcmp(aExtAddr, "*") == 0)
     {
-        error = otCommissionerAddJoiner(aNode->mInstance, nullptr, aPSKd);
+        error = otCommissionerAddJoiner(aNode->mInstance, nullptr, aPSKd, kDefaultJoinerTimeout);
     }
     else
     {
@@ -1022,7 +1024,7 @@ OTNODEAPI int32_t OTCALL otNodeCommissionerJoinerAdd(otNode* aNode, const char *
         if (Hex2Bin(aExtAddr, extAddr.m8, sizeof(extAddr)) != sizeof(extAddr))
             return kThreadError_Parse;
 
-        error = otCommissionerAddJoiner(aNode->mInstance, &extAddr, aPSKd);
+        error = otCommissionerAddJoiner(aNode->mInstance, &extAddr, aPSKd, kDefaultJoinerTimeout);
     }
     
     otLogFuncExit();

--- a/include/openthread/commissioner.h
+++ b/include/openthread/commissioner.h
@@ -75,6 +75,7 @@ OTAPI ThreadError OTCALL otCommissionerStop(otInstance *aInstance);
  * @param[in]  aInstance             A pointer to an OpenThread instance.
  * @param[in]  aExtAddress           A pointer to the Joiner's extended address or NULL for any Joiner.
  * @param[in]  aPSKd                 A pointer to the PSKd.
+ * @param[in]  aTimeout              A time after which a Joiner is automatically removed, in seconds.
  *
  * @retval kThreadError_None         Successfully added the Joiner.
  * @retval kThreadError_NoBufs       No buffers available to add the Joiner.
@@ -82,7 +83,7 @@ OTAPI ThreadError OTCALL otCommissionerStop(otInstance *aInstance);
  *
  */
 OTAPI ThreadError OTCALL otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *aExtAddress,
-                                                 const char *aPSKd);
+                                                 const char *aPSKd, uint32_t aTimeout);
 
 /**
  * This function removes a Joiner entry.
@@ -241,25 +242,6 @@ OTAPI uint16_t OTCALL otCommissionerGetSessionId(otInstance *);
 OTAPI ThreadError OTCALL otCommissionerGeneratePSKc(otInstance *aInstance, const char *aPassPhrase,
                                                     const char *aNetworkName, const uint8_t *aExtPanId,
                                                     uint8_t *aPSKc);
-
-/**
- * This method sets Joiner timeout.
- *
- * @param[in]  aInstance  A pointer to an OpenThread instance.
- * @param[in]  aTimeout   A time after which Joiners are automatically removed, in seconds.
- *
- */
-OTAPI void OTCALL otCommissionerSetJoinerTimeout(otInstance *aInstance, uint32_t aTimeout);
-
-/**
- * This method gets current Joiner timeout.
- *
- * @param[in]  aInstance  A pointer to an OpenThread instance.
- *
- * @returns  A time after which Joiners are automatically removed, in seconds.
- *
- */
-OTAPI uint32_t OTCALL otCommissionerGetJoinerTimeout(otInstance *aInstance);
 
 /**
  * @}

--- a/include/openthread/commissioner.h
+++ b/include/openthread/commissioner.h
@@ -243,6 +243,25 @@ OTAPI ThreadError OTCALL otCommissionerGeneratePSKc(otInstance *aInstance, const
                                                     uint8_t *aPSKc);
 
 /**
+ * This method sets Joiner timeout.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ * @param[in]  aTimeout   A time after which Joiners are automatically removed, in seconds.
+ *
+ */
+OTAPI void OTCALL otCommissionerSetJoinerTimeout(otInstance *aInstance, uint32_t aTimeout);
+
+/**
+ * This method gets current Joiner timeout.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ *
+ * @returns  A time after which Joiners are automatically removed, in seconds.
+ *
+ */
+OTAPI uint32_t OTCALL otCommissionerGetJoinerTimeout(otInstance *aInstance);
+
+/**
  * @}
  *
  */

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2327,7 +2327,15 @@ void Interpreter::ProcessCommissioner(int argc, char *argv[])
         if (strcmp(argv[1], "add") == 0)
         {
             VerifyOrExit(argc > 3, error = kThreadError_Parse);
-            SuccessOrExit(error = otCommissionerAddJoiner(mInstance, addrPtr, argv[3]));
+            // Timeout parameter is optional - if not specified, use default value.
+            unsigned long timeout = kDefaultJoinerTimeout;
+
+            if (argc > 4)
+            {
+                SuccessOrExit(error = ParseUnsignedLong(argv[4], timeout));
+            }
+
+            SuccessOrExit(error = otCommissionerAddJoiner(mInstance, addrPtr, argv[3], static_cast<uint32_t>(timeout)));
         }
         else if (strcmp(argv[1], "remove") == 0)
         {

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -147,6 +147,7 @@ private:
     {
         kMaxArgs = 32,
         kMaxAutoAddresses = 8,
+        kDefaultJoinerTimeout = 120,    ///< Default timeout for Joiners, in seconds.
     };
 
     void AppendResult(ThreadError error);

--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -114,6 +114,16 @@ ThreadError otCommissionerGeneratePSKc(otInstance *aInstance, const char *aPassP
     return aInstance->mThreadNetif.GetCommissioner().GeneratePSKc(aPassPhrase, aNetworkName, aExtPanId, aPSKc);
 }
 
+void otCommissionerSetJoinerTimeout(otInstance *aInstance, uint32_t aTimeout)
+{
+    aInstance->mThreadNetif.GetCommissioner().SetJoinerTimeout(aTimeout);
+}
+
+uint32_t otCommissionerGetJoinerTimeout(otInstance *aInstance)
+{
+    return aInstance->mThreadNetif.GetCommissioner().GetJoinerTimeout();
+}
+
 #endif  // OPENTHREAD_ENABLE_COMMISSIONER
 
 #ifdef __cplusplus

--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -53,9 +53,11 @@ ThreadError otCommissionerStop(otInstance *aInstance)
     return aInstance->mThreadNetif.GetCommissioner().Stop();
 }
 
-ThreadError otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *aExtAddress, const char *aPSKd)
+ThreadError otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *aExtAddress, const char *aPSKd,
+                                    uint32_t aTimeout)
 {
-    return aInstance->mThreadNetif.GetCommissioner().AddJoiner(static_cast<const Mac::ExtAddress *>(aExtAddress), aPSKd);
+    return aInstance->mThreadNetif.GetCommissioner().AddJoiner(static_cast<const Mac::ExtAddress *>(aExtAddress), aPSKd,
+                                                               aTimeout);
 }
 
 ThreadError otCommissionerRemoveJoiner(otInstance *aInstance, const otExtAddress *aExtAddress)
@@ -112,16 +114,6 @@ ThreadError otCommissionerGeneratePSKc(otInstance *aInstance, const char *aPassP
                                        const uint8_t *aExtPanId, uint8_t *aPSKc)
 {
     return aInstance->mThreadNetif.GetCommissioner().GeneratePSKc(aPassPhrase, aNetworkName, aExtPanId, aPSKc);
-}
-
-void otCommissionerSetJoinerTimeout(otInstance *aInstance, uint32_t aTimeout)
-{
-    aInstance->mThreadNetif.GetCommissioner().SetJoinerTimeout(aTimeout);
-}
-
-uint32_t otCommissionerGetJoinerTimeout(otInstance *aInstance)
-{
-    return aInstance->mThreadNetif.GetCommissioner().GetJoinerTimeout();
 }
 
 #endif  // OPENTHREAD_ENABLE_COMMISSIONER

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -92,13 +92,14 @@ public:
      * This method adds a Joiner entry.
      *
      * @param[in]  aExtAddress      A pointer to the Joiner's extended address or NULL for any Joiner.
-     * @param[in]  aPSKd            A pointer to the PSKd
+     * @param[in]  aPSKd            A pointer to the PSKd.
+     * @param[in]  aTimeout         A time after which a Joiner is automatically removed, in seconds.
      *
      * @retval kThreadError_None    Successfully added the Joiner.
      * @retval kThreadError_NoBufs  No buffers available to add the Joiner.
      *
      */
-    ThreadError AddJoiner(const Mac::ExtAddress *aExtAddress, const char *aPSKd);
+    ThreadError AddJoiner(const Mac::ExtAddress *aExtAddress, const char *aPSKd, uint32_t aTimeout);
 
     /**
      * This method removes a Joiner entry.
@@ -148,22 +149,6 @@ public:
      *
      */
     uint8_t GetState(void) const;
-
-    /**
-     * This method sets Joiner timeout.
-     *
-     * @param[in]  aTimeout  A time after which Joiners are automatically removed, in seconds.
-     *
-     */
-    void SetJoinerTimeout(uint32_t aTimeout) { mJoinerTimeout = aTimeout; };
-
-    /**
-     * This method gets current Joiner timeout.
-     *
-     * @returns  A time after which Joiners are automatically removed, in seconds.
-     *
-     */
-    uint32_t GetJoinerTimeout(void) { return mJoinerTimeout; };
 
     /**
      * This method sends MGMT_COMMISSIONER_GET.
@@ -219,7 +204,6 @@ private:
         kPetitionRetryCount   = 2,      ///< COMM_PET_RETRY_COUNT
         kPetitionRetryDelay   = 1,      ///< COMM_PET_RETRY_DELAY (seconds)
         kKeepAliveTimeout     = 50,     ///< TIMEOUT_COMM_PET (seconds)
-        kDefaultJoinerTimeout = 120,    ///< Default time after which Joiner is removed (seconds)
     };
 
     static void HandleTimer(void *aContext);
@@ -227,6 +211,8 @@ private:
 
     static void HandleJoinerExpirationTimer(void *aContext);
     void HandleJoinerExpirationTimer(void);
+
+    void UpdateJoinerExpirationTimer(void);
 
     static void HandleMgmtCommissionerSetResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
                                                   const otMessageInfo *aMessageInfo, ThreadError aResult);
@@ -285,7 +271,6 @@ private:
     };
     uint16_t mJoinerPort;
     uint16_t mJoinerRloc;
-    uint32_t mJoinerTimeout;
     Timer mJoinerExpirationTimer;
 
     Timer mTimer;

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -150,6 +150,22 @@ public:
     uint8_t GetState(void) const;
 
     /**
+     * This method sets Joiner timeout.
+     *
+     * @param[in]  aTimeout  A time after which Joiners are automatically removed, in seconds.
+     *
+     */
+    void SetJoinerTimeout(uint32_t aTimeout) { mJoinerTimeout = aTimeout; };
+
+    /**
+     * This method gets current Joiner timeout.
+     *
+     * @returns  A time after which Joiners are automatically removed, in seconds.
+     *
+     */
+    uint32_t GetJoinerTimeout(void) { return mJoinerTimeout; };
+
+    /**
      * This method sends MGMT_COMMISSIONER_GET.
      *
      * @param[in]  aTlvs        A pointer to Commissioning Data TLVs.
@@ -199,14 +215,18 @@ public:
 private:
     enum
     {
-        kPetitionAttemptDelay = 5,   ///< COMM_PET_ATTEMPT_DELAY (seconds)
-        kPetitionRetryCount   = 2,   ///< COMM_PET_RETRY_COUNT
-        kPetitionRetryDelay   = 1,   ///< COMM_PET_RETRY_DELAY (seconds)
-        kKeepAliveTimeout     = 50,  ///< TIMEOUT_COMM_PET (seconds)
+        kPetitionAttemptDelay = 5,      ///< COMM_PET_ATTEMPT_DELAY (seconds)
+        kPetitionRetryCount   = 2,      ///< COMM_PET_RETRY_COUNT
+        kPetitionRetryDelay   = 1,      ///< COMM_PET_RETRY_DELAY (seconds)
+        kKeepAliveTimeout     = 50,     ///< TIMEOUT_COMM_PET (seconds)
+        kDefaultJoinerTimeout = 120,    ///< Default time after which Joiner is removed (seconds)
     };
 
     static void HandleTimer(void *aContext);
     void HandleTimer(void);
+
+    static void HandleJoinerExpirationTimer(void *aContext);
+    void HandleJoinerExpirationTimer(void);
 
     static void HandleMgmtCommissionerSetResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
                                                   const otMessageInfo *aMessageInfo, ThreadError aResult);
@@ -251,6 +271,7 @@ private:
     struct Joiner
     {
         Mac::ExtAddress mExtAddress;
+        uint32_t mExpirationTime;
         char mPsk[Dtls::kPskMaxLength + 1];
         bool mValid : 1;
         bool mAny : 1;
@@ -264,6 +285,8 @@ private:
     };
     uint16_t mJoinerPort;
     uint16_t mJoinerRloc;
+    uint32_t mJoinerTimeout;
+    Timer mJoinerExpirationTimer;
 
     Timer mTimer;
     uint16_t mSessionId;

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -60,9 +60,9 @@ JoinerRouter::JoinerRouter(ThreadNetif &aNetif):
     mSocket(aNetif.GetIp6().mUdp),
     mRelayTransmit(OPENTHREAD_URI_RELAY_TX, &JoinerRouter::HandleRelayTransmit, this),
     mNetif(aNetif),
+    mTimer(aNetif.GetIp6().mTimerScheduler, &JoinerRouter::HandleTimer, this),
     mJoinerUdpPort(0),
     mIsJoinerPortConfigured(false),
-    mTimer(aNetif.GetIp6().mTimerScheduler, &JoinerRouter::HandleTimer, this),
     mExpectJoinEntRsp(false)
 {
     mSocket.GetSockName().mPort = OPENTHREAD_CONFIG_JOINER_UDP_PORT;

--- a/src/core/meshcop/joiner_router_ftd.hpp
+++ b/src/core/meshcop/joiner_router_ftd.hpp
@@ -118,12 +118,13 @@ private:
     Coap::Resource mRelayTransmit;
     ThreadNetif &mNetif;
 
-    uint16_t mJoinerUdpPort;
-    bool mIsJoinerPortConfigured;
-
     Timer mTimer;
     MessageQueue mDelayedJoinEnts;
-    bool mExpectJoinEntRsp;
+
+    uint16_t mJoinerUdpPort;
+
+    bool mIsJoinerPortConfigured : 1;
+    bool mExpectJoinEntRsp : 1;
 };
 
 /**


### PR DESCRIPTION
This PR resolves #1377.

Commissioner will now remove Joiners after successfull commissioning or after a timeout period.

Again, I've hit the RAM shortage on CC2538, hence I did some memory savings in JoinerRouter class. 8 bytes only, but it was enough.