### PR TITLE
Store IID of ML-EID in NVM.

### DIFF
--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -311,6 +311,7 @@ typedef struct otExtAddress
     uint8_t m8[OT_EXT_ADDRESS_SIZE];  ///< IEEE 802.15.4 Extended Address bytes
 } otExtAddress;
 
+#define OT_IP6_PREFIX_SIZE         8   ///< Size of an IPv6 prefix (bytes)
 #define OT_IP6_ADDRESS_SIZE        16  ///< Size of an IPv6 address (bytes)
 
 /**

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -128,7 +128,7 @@ Mle::Mle(ThreadNetif &aThreadNetif) :
     meshLocalPrefix[7] = 0x00;
 
     // mesh-local 64
-    for (int i = 8; i < 16; i++)
+    for (int i = OT_IP6_PREFIX_SIZE; i < OT_IP6_ADDRESS_SIZE; i++)
     {
         mMeshLocal64.GetAddress().mFields.m8[i] = static_cast<uint8_t>(otPlatRandomGet());
     }
@@ -284,6 +284,10 @@ ThreadError Mle::Restore(void)
     mNetif.GetMac().SetExtAddress(networkInfo.mExtAddress);
     UpdateLinkLocalAddress();
 
+    memcpy(&mMeshLocal64.GetAddress().mFields.m8[OT_IP6_PREFIX_SIZE],
+           networkInfo.mMlIid,
+           OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE);
+
     if (networkInfo.mDeviceState == kDeviceStateChild)
     {
         length = sizeof(mParent);
@@ -327,6 +331,10 @@ ThreadError Mle::Store(void)
                                    OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD;
     networkInfo.mPreviousPartitionId = mLeaderData.GetPartitionId();
     memcpy(networkInfo.mExtAddress.m8, mNetif.GetMac().GetExtAddress(), sizeof(networkInfo.mExtAddress));
+    memcpy(networkInfo.mMlIid,
+           &mMeshLocal64.GetAddress().mFields.m8[OT_IP6_PREFIX_SIZE],
+           OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE);
+
 
     if (mDeviceState == kDeviceStateChild)
     {

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1392,15 +1392,16 @@ private:
      */
     typedef struct NetworkInfo
     {
-        DeviceState          mDeviceState;                ///< Current Thread interface state.
+        DeviceState          mDeviceState;                                      ///< Current Thread interface state.
 
-        uint8_t              mDeviceMode;                 ///< Device mode setting.
-        uint16_t             mRloc16;                     ///< RLOC16
-        uint32_t             mKeySequence;                ///< Key Sequence
-        uint32_t             mMleFrameCounter;            ///< MLE Frame Counter
-        uint32_t             mMacFrameCounter;            ///< MAC Frame Counter
-        uint32_t             mPreviousPartitionId;        ///< PartitionId
-        Mac::ExtAddress      mExtAddress;                 ///< Extended Address
+        uint8_t              mDeviceMode;                                       ///< Device mode setting.
+        uint16_t             mRloc16;                                           ///< RLOC16
+        uint32_t             mKeySequence;                                      ///< Key Sequence
+        uint32_t             mMleFrameCounter;                                  ///< MLE Frame Counter
+        uint32_t             mMacFrameCounter;                                  ///< MAC Frame Counter
+        uint32_t             mPreviousPartitionId;                              ///< PartitionId
+        Mac::ExtAddress      mExtAddress;                                       ///< Extended Address
+        uint8_t              mMlIid[OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE];  ///< IID from ML-EID
     } NetworkInfo;
 
     struct


### PR DESCRIPTION
IID in ML-EID is chosen at random, but should be persistent over reboots. This PR adds this feature.