### PR TITLE
Enable data poll triggered indirect retransmissions to a sleepy child

### DIFF
--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -105,8 +105,10 @@ typedef struct RadioPacket
     uint8_t  mChannel;         ///< Channel used to transmit/receive the frame.
     int8_t   mPower;           ///< Transmit/receive power in dBm.
     uint8_t  mLqi;             ///< Link Quality Indicator for received frames.
+    uint8_t  mMaxTxAttempts;   ///< Max number of transmit attempts for an outbound frame.
     bool     mSecurityValid: 1; ///< Security Enabled flag is set and frame passes security checks.
     bool     mDidTX: 1;        ///< Set to true if this packet sent from the radio. Ignored by radio driver.
+    bool     mIsARetx: 1;      ///< Set to true if this packet is a retransmission. Should be ignored by radio driver.
 } RadioPacket;
 
 /**

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -407,7 +407,7 @@ void LinkRaw::InvokeTransmitDone(RadioPacket *aPacket, bool aFramePending, Threa
 
     if (aError == kThreadError_NoAck)
     {
-        if (mTransmitAttempts < Mac::kMaxFrameAttempts)
+        if (mTransmitAttempts < aPacket->mMaxTxAttempts)
         {
             mTransmitAttempts++;
             StartCsmaBackoff();

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -72,11 +72,9 @@ enum
     kMinBE                = 3,                     ///< macMinBE (IEEE 802.15.4-2006)
     kMaxBE                = 5,                     ///< macMaxBE (IEEE 802.15.4-2006)
     kMaxCSMABackoffs      = 4,                     ///< macMaxCSMABackoffs (IEEE 802.15.4-2006)
-    kMaxFrameRetries      = 3,                     ///< macMaxFrameRetries (IEEE 802.15.4-2006)
     kUnitBackoffPeriod    = 20,                    ///< Number of symbols (IEEE 802.15.4-2006)
 
     kMinBackoff           = 1,                     ///< Minimum backoff (milliseconds).
-    kMaxFrameAttempts     = kMaxFrameRetries + 1,  ///< Number of transmission attempts.
 
     kAckTimeout           = 16,                    ///< Timeout for waiting on an ACK (milliseconds).
     kDataPollTimeout      = 100,                   ///< Timeout for receiving Data Frame (milliseconds).

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -633,6 +633,23 @@ public:
     void SetLqi(uint8_t aLqi) { mLqi = aLqi; }
 
     /**
+     * This method returns the maximum number of transmit attempts for the frame.
+     *
+     * @returns The maximum number of transmit attempts.
+     *
+     */
+    uint8_t GetMaxTxAttempts(void) const { return mMaxTxAttempts; }
+
+
+    /**
+     * This method set the maximum number of transmit attempts for frame.
+     *
+     * @returns The maximum number of transmit attempts.
+     *
+     */
+    void SetMaxTxAttempts(uint8_t aMaxTxAttempts) { mMaxTxAttempts = aMaxTxAttempts; }
+
+    /**
      * This method indicates whether or not frame security was enabled and passed security validation.
      *
      * @retval TRUE   Frame security was enabled and passed security validation.
@@ -648,6 +665,23 @@ public:
      *
      */
     void SetSecurityValid(bool aSecurityValid) { mSecurityValid = aSecurityValid; }
+
+    /**
+     * This method indicates whether or not the frame is a retransmission.
+     *
+     * @retval TRUE   Frame is a retransmission
+     * @retval FALSE  This is a new frame and not a retransmission of an earlier frame.
+     *
+     */
+    bool IsARetransmission(void) const { return mIsARetx; }
+
+    /**
+     * This method sets the retransmission flag attribute.
+     *
+     * @param[in]  aIsARetx  TRUE if frame is a retransmission of an earlier frame, FALSE otherwise.
+     *
+     */
+    void SetIsARetransmission(bool aIsARetx) { mIsARetx = aIsARetx; }
 
     /**
      * This method returns the IEEE 802.15.4 PSDU length.

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -116,6 +116,40 @@
 #endif  // OPENTHREAD_CONFIG_DEFAULT_MAX_TRANSMIT_POWER
 
 /**
+ * @def OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_DIRECT
+ *
+ * Maximum number of MAC layer transmit attempts for an outbound direct frame.
+ * Per IEEE 802.15.4-2006, default value is set to (macMaxFrameRetries + 1) with macMaxFrameRetries = 3.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_DIRECT
+#define OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_DIRECT                4
+#endif // OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_DIRECT
+
+/**
+ * @def OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_PER_POLL
+ *
+ * Maximum number of MAC layer transmit attempts for an outbound indirect frame (to a sleepy child) after receiving
+ * a data request command (data poll) from the child.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_PER_POLL
+#define OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_PER_POLL     1
+#endif // OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_PER_POLL
+
+/**
+ * @def OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_POLLS
+ *
+ * Maximum number of transmit attempts for an outbound indirect frame (for a sleepy child) each triggered by the
+ * reception of a new data request command (a new data poll) from the sleepy child. Each data poll triggered attempt is
+ * retried by the MAC layer up to `OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_PER_POLL` times.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_POLLS
+#define OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_POLLS        4
+#endif // OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_POLLS
+
+/**
  * @def OPENTHREAD_CONFIG_ATTACH_DATA_POLL_PERIOD
  *
  * The Data Poll period during attach in milliseconds.
@@ -536,7 +570,7 @@
  *
  */
 #ifndef OPENTHREAD_CONFIG_NCP_UART_RX_BUFFER_SIZE
-#define OPENTHREAD_CONFIG_NCP_UART_RX_BUFFER_SIZE               1500
+#define OPENTHREAD_CONFIG_NCP_UART_RX_BUFFER_SIZE               1300
 #endif  // OPENTHREAD_CONFIG_NCP_UART_RX_BUFFER_SIZE
 
 /**
@@ -546,7 +580,7 @@
  *
  */
 #ifndef OPENTHREAD_CONFIG_NCP_SPI_BUFFER_SIZE
-#define OPENTHREAD_CONFIG_NCP_SPI_BUFFER_SIZE                   1500
+#define OPENTHREAD_CONFIG_NCP_SPI_BUFFER_SIZE                   1300
 #endif  // OPENTHREAD_CONFIG_NCP_SPI_BUFFER_SIZE
 
 /**

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -248,6 +248,30 @@ private:
         kDataRequestRetryDelay = 200,   ///< Retry delay in milliseconds (for sending data request if no buffer).
     };
 
+    enum
+    {
+        /**
+         * Maximum number of MAC layer tx attempts for an outbound direct frame.
+         *
+         */
+        kDirectFrameMacTxAttempts   = OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_DIRECT,
+
+        /**
+         * Maximum number of MAC layer tx attempts for an outbound indirect frame (for a sleepy child) after receiving
+         * a data request command (data poll) from the child.
+         *
+         */
+        kIndirectFrameMacTxAttempts = OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_PER_POLL,
+
+        /**
+         * Maximum number of tx attempts by `MeshForwarder` for an outbound indirect frame (for a sleepy child). The
+         * `MeshForwader` attempts occur following the reception of a new data request command (a new data poll) from
+         * the sleepy child.
+         *
+         */
+        kMaxPollTriggeredTxAttempts = OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_POLLS,
+    };
+
     ThreadError CheckReachability(uint8_t *aFrame, uint8_t aFrameLength,
                                   const Mac::Address &aMeshSource, const Mac::Address &aMeshDest);
 
@@ -255,8 +279,8 @@ private:
     ThreadError GetMacDestinationAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr);
     ThreadError GetMacSourceAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr);
     Message *GetDirectTransmission(void);
-    Message *GetIndirectTransmission(const Child &aChild);
-    void PrepareIndirectTransmission(const Message &aMessage, const Child &aChild);
+    Message *GetIndirectTransmission(Child &aChild);
+    void PrepareIndirectTransmission(Message &aMessage, const Child &aChild);
     void HandleMesh(uint8_t *aFrame, uint8_t aPayloadLength, const Mac::Address &aMacSource,
                     const ThreadMessageInfo &aMessageInfo);
     void HandleFragment(uint8_t *aFrame, uint8_t aPayloadLength,
@@ -311,7 +335,13 @@ private:
     uint16_t mMessageNextOffset;
     uint32_t mPollPeriod;
     uint32_t mAssignPollPeriod;  ///< only for certification test
+
+    uint32_t mSendMessageFrameCounter;
     Message *mSendMessage;
+    bool     mSendMessageIsARetransmission;
+    uint8_t  mSendMessageMaxMacTxAttempts;
+    uint8_t  mSendMessageKeyId;
+    uint8_t  mSendMessageDataSequenceNumber;
 
     Mac::Address mMacSource;
     Mac::Address mMacDest;

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -127,10 +127,18 @@ public:
         kMaxIp6AddressPerChild = OPENTHREAD_CONFIG_IP_ADDRS_PER_CHILD,
         kMaxRequestTlvs        = 5,
     };
+
     Ip6::Address mIp6Address[kMaxIp6AddressPerChild];  ///< Registered IPv6 addresses
     uint32_t     mTimeout;                             ///< Child timeout
-    uint16_t     mFragmentOffset;                      ///< 6LoWPAN fragment offset for the indirect message
-    Message     *mIndirectSendMessage;                 ///< Current indirect message being sent.
+    struct
+    {
+        uint32_t     mFrameCounter;                    ///< Frame counter for current indirect message (used fore retx).
+        Message     *mMessage;                         ///< Current indirect message.
+        uint16_t     mFragmentOffset;                  ///< 6LoWPAN fragment offset for the indirect message.
+        uint8_t      mKeyId;                           ///< Key Id for current indirect message (used for retx).
+        uint8_t      mTxAttemptCounter;                ///< Number of data poll triggered tx attempts.
+        uint8_t      mDataSequenceNumber;              ///< MAC level Data Sequence Number (DSN) for retx attempts.
+    } mIndirectSendInfo;                               ///< Info about current outbound indirect message.
     union
     {
         uint8_t mRequestTlvs[kMaxRequestTlvs];                 ///< Requested MLE TLVs

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -3939,6 +3939,9 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_RAW(uint8_t header, spinel_prop_k
             packet->mLength = static_cast<uint8_t>(frame_len);
             memcpy(packet->mPsdu, frame_buffer, packet->mLength);
 
+            // TODO: This should be later added in the STREAM_RAW argument to allow user to directly specify it.
+            packet->mMaxTxAttempts = OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_DIRECT;
+
             // Pass packet to the radio layer. Note, this fails if we
             // haven't enabled raw stream or are already transmitting.
             errorCode = otLinkRawTransmit(mInstance, packet, &NcpBase::LinkRawTransmitDone);


### PR DESCRIPTION
If transmission of an indirect frame (frame to a sleepy child)
fails, the sender retransmits the frame following the reception of
a new data request command (a new data poll) from the sleepy child.

It is ensured that the re-transmissions use the same security frame
counter and key id as the earlier attempts. To realize this, info
about the indirect transmissions (such as attempt counter, frame
counter, key id) is saved in the child table.

In `openthread-core-default-config.h` a set of new OpenThread options
are added to allow  the maximum number of attempts to be configured
for both direct and indirect transmissions.

This PR addresses Issue: https://github.com/openthread/openthread/issues/1424