### PR TITLE
spinel: Clarify data packing notation and fix implementation.

### DIFF
--- a/doc/spinel-protocol-src/spinel-commands.md
+++ b/doc/spinel-protocol-src/spinel-commands.md
@@ -87,6 +87,13 @@ packed unsigned integer format described in (#packed-unsigned-integer), followed
 the value to be inserted. The exact format of the value is defined by
 the property.
 
+If the type signature of the property specified by `PROP_ID` consists
+of a single structure enclosed by an array (`A(t(...))`), then the
+contents of `VALUE` MUST contain the contents of the structure (`...`)
+rather than the serialization of the whole item (`t(...)`).  Specifically,
+the length of the structure MUST NOT be prepended to `VALUE`. This
+helps to eliminate redundant data.
+
 If an error occurs, the value of `PROP_LAST_STATUS` will be emitted
 with the value set to the generated status code for the error.
 
@@ -109,6 +116,13 @@ The payload for this command is the property identifier encoded in the
 packed unsigned integer format described in (#packed-unsigned-integer), followed by
 the value to be removed. The exact format of the value is defined by
 the property.
+
+If the type signature of the property specified by `PROP_ID` consists
+of a single structure enclosed by an array (`A(t(...))`), then the
+contents of `VALUE` MUST contain the contents of the structure (`...`)
+rather than the serialization of the whole item (`t(...)`).  Specifically,
+the length of the structure MUST NOT be prepended to `VALUE`. This
+helps to eliminate redundant data.
 
 If an error occurs, the value of `PROP_LAST_STATUS` will be emitted
 with the value set to the generated status code for the error.
@@ -146,6 +160,13 @@ The payload for this command is the property identifier encoded in the
 packed unsigned integer format described in (#packed-unsigned-integer), followed by
 the value that was inserted into the given property.
 
+If the type signature of the property specified by `PROP_ID` consists
+of a single structure enclosed by an array (`A(t(...))`), then the
+contents of `VALUE` MUST contain the contents of the structure (`...`)
+rather than the serialization of the whole item (`t(...)`).  Specifically,
+the length of the structure MUST NOT be prepended to `VALUE`. This
+helps to eliminate redundant data.
+
 The resulting order of items in the list is defined by the given
 property.
 
@@ -165,6 +186,13 @@ Note that this command operates *by value*, not by index!
 The payload for this command is the property identifier encoded in the
 packed unsigned integer format described in (#packed-unsigned-integer), followed by
 the value that was removed from the given property.
+
+If the type signature of the property specified by `PROP_ID` consists
+of a single structure enclosed by an array (`A(t(...))`), then the
+contents of `VALUE` MUST contain the contents of the structure (`...`)
+rather than the serialization of the whole item (`t(...)`).  Specifically,
+the length of the structure MUST NOT be prepended to `VALUE`. This
+helps to eliminate redundant data.
 
 The resulting order of items in the list is defined by the given
 property.
@@ -240,7 +268,7 @@ individual property with `STATUS_INVALID_COMMAND_FOR_PROP`.
 
 ## CMD 22: (Host->NCP) CMD_PROP_VALUE_MULTI_SET {#prop-value-multi-set}
 
-*   Argument-Encoding: `A(T(iD))`
+*   Argument-Encoding: `A(iD)`
 *   Required Capability: `CAP_CMD_MULTI`
 
 Octets: |    1   |          1               |   *n*
@@ -273,7 +301,7 @@ individual property with `STATUS_INVALID_COMMAND_FOR_PROP`.
 
 ## CMD 23: (NCP->Host) CMD_PROP_VALUES_ARE {#prop-values-are}
 
-*   Argument-Encoding: `A(T(iD))`
+*   Argument-Encoding: `A(iD)`
 *   Required Capability: `CAP_CMD_MULTI`
 
 Octets: |    1   |          1          |   *n*

--- a/doc/spinel-protocol-src/spinel-feature-gpio.md
+++ b/doc/spinel-protocol-src/spinel-feature-gpio.md
@@ -11,7 +11,7 @@ Support for this feature can be determined by the presence of `CAP_GPIO`.
 
 ### PROP 4096: PROP\_GPIO\_CONFIG ###
 
-*   Argument-Encoding: `A(CCU)`
+*   Argument-Encoding: `A(t(CCU))`
 *   Type: Read-write (Writable only using `CMD_PROP_VALUE_INSERT`,
     (#prop-value-insert))
 

--- a/doc/spinel-protocol-src/spinel-prop-core.md
+++ b/doc/spinel-protocol-src/spinel-prop-core.md
@@ -262,7 +262,7 @@ commands for this property from the NCP.
 ### PROP 113: PROP_STREAM_RAW {#prop-stream-raw}
 
 * Type: Read-Write-Stream
-* Packed-Encoding: `DD`
+* Packed-Encoding: `dD`
 
 Octets: |        2       |     *n*    |       *n*
 --------|----------------|------------|----------------
@@ -303,8 +303,8 @@ The frame metadata field consists of the following fields:
 MD_POWER | (dBm) RSSI/TX-Power          | `c` int8   | 1     | -128
 MD_NOISE | (dBm) Noise floor            | `c` int8   | 1     | -128
 MD_FLAG  | Flags (defined below)        | `S` uint16 | 2     |
-MD_PHY   | PHY-specific data            | `D` data   | >=2   |
-MD_VEND  | Vendor-specific data         | `D` data   | >=2   |
+MD_PHY   | PHY-specific data            | `d` data   | >=2   |
+MD_VEND  | Vendor-specific data         | `d` data   | >=2   |
 
 The following fields are ignored by the NCP for packets sent to it from
 the host:
@@ -333,7 +333,7 @@ pertainent information.
 ### PROP 114: PROP_STREAM_NET {#prop-stream-net}
 
 * Type: Read-Write-Stream
-* Packed-Encoding: `DD`
+* Packed-Encoding: `dD`
 
 Octets: |        2       |     *n*    |       *n*
 --------|----------------|------------|----------------
@@ -356,7 +356,7 @@ format of which is described in (#frame-metadata-format).
 ### PROP 114: PROP_STREAM_NET_INSECURE {#prop-stream-net-insecure}
 
 * Type: Read-Write-Stream
-* Packed-Encoding: `DD`
+* Packed-Encoding: `dD`
 
 Octets: |        2       |     *n*    |       *n*
 --------|----------------|------------|----------------

--- a/doc/spinel-protocol-src/spinel-prop-ipv6.md
+++ b/doc/spinel-protocol-src/spinel-prop-ipv6.md
@@ -20,7 +20,7 @@ IPv6 Prefix + Prefix Length
 
 ### PROP 99: PROP_IPV6_ADDRESS_TABLE {#prop-ipv6-address-table}
 * Type: Read-Write
-* Packed-Encoding: `A(T(6CLLC))`
+* Packed-Encoding: `A(t(6CLLC))`
 
 Array of structures containing:
 

--- a/doc/spinel-protocol-src/spinel-prop-mac.md
+++ b/doc/spinel-protocol-src/spinel-prop-mac.md
@@ -33,7 +33,7 @@ Values switches to `SCAN_STATE_IDLE` when scan is complete.
 
 ### PROP 51: PROP_MAC_SCAN_BEACON {#prop-mac-scan-beacon}
 * Type: Read-Only-Stream
-* Packed-Encoding: `CcDD.` (or `CcT(ESSc.)T(iCUD.).`)
+* Packed-Encoding: `Ccdd` (or `Cct(ESSc)t(iCUd)`)
 
 Octets: | 1  |   1  |    2    |   *n*    |    2    |   *n*  
 --------|----|------|---------|----------|---------|----------  
@@ -46,16 +46,16 @@ The format below is for an 802.15.4 MAC with Thread:
 
 * `C`: Channel
 * `c`: RSSI of the beacon
-* `T`: MAC layer properties
+* `t`: MAC layer properties (802.15.4 layer shown below for convenience)
   * `E`: Long address
   * `S`: Short address
   * `S`: PAN-ID
   * `c`: LQI
-* `T`: NET layer properties
+* NET layer properties (Standard net layer shown below for convenience)
   * `i`: Protocol Number
   * `C`: Flags
   * `U`: Network Name
-  * `D`: XPANID
+  * `d`: XPANID
 
 Extra parameters may be added to each of the structures
 in the future, so care should be taken to read the length

--- a/doc/spinel-protocol-src/spinel-tech-thread.md
+++ b/doc/spinel-protocol-src/spinel-tech-thread.md
@@ -39,7 +39,7 @@ The long address and short address of the parent of this node.
 
 ### PROP 82: PROP_THREAD_CHILD_TABLE
 * Type: Read-Only
-* Packed-Encoding: `A(T(ES))`
+* Packed-Encoding: `A(t(ES))`
 
 Table containing the long and short addresses of all
 the children of this node.
@@ -84,7 +84,7 @@ The local stable network data.
 
 ### PROP 90: PROP_THREAD_ON_MESH_NETS
 * Type: Read-Write
-* Packed-Encoding: `A(T(6CbCb))`
+* Packed-Encoding: `A(t(6CbCb))`
 
 Data per item is:
 
@@ -98,7 +98,7 @@ Data per item is:
 
 ### PROP 91: PROP_THREAD_LOCAL_ROUTES
 * Type: Read-Write
-* Packed-Encoding: `A(T(6CbC))`
+* Packed-Encoding: `A(t(6CbC))`
 
 Data per item is:
 
@@ -200,7 +200,7 @@ disabled.
 
 ### PROP 5387: PROP_THREAD_NEIGHBOR_TABLE
 * Type: Read-Only
-* Packed-Encoding: `A(T(ESLCcCbLL))`
+* Packed-Encoding: `A(t(ESLCcCbLL))`
 
 Data per item is:
 

--- a/doc/spinel-protocol-src/spinel-test-vectors.md
+++ b/doc/spinel-protocol-src/spinel-test-vectors.md
@@ -45,7 +45,7 @@ Frame:
 * TID: 0
 * CMD: 7 (`CMD_VALUE_INSERTED`)
 * PROP: 51 (`PROP_MAC_SCAN_BEACON`)
-* VALUE: Structure, encoded as `CcT(ESSc.)T(iCUD.).`
+* VALUE: Structure, encoded as `Cct(ESSc)t(iCUd)`
     * CHAN: 15
     * RSSI: -60dBm
     * MAC_DATA: (0D 00 B6 40 D4 8C E9 38 F9 52 FF FF D2 04 00)
@@ -94,7 +94,7 @@ Frame:
 * TID: 4
 * CMD: 6 (`CMD_VALUE_IS`)
 * PROP: 90 (`PROP_THREAD_ON_MESH_NETS`)
-* VALUE: Array of structures, encoded as `A(T(6CbC))`
+* VALUE: Array of structures, encoded as `A(t(6CbC))`
 
 IPv6 Prefix  | Prefix Length | Stable Flag | Other Flags
 -------------|---------------|-------------|--------------

--- a/examples/drivers/windows/otLwf/address.c
+++ b/examples/drivers/windows/otLwf/address.c
@@ -451,7 +451,7 @@ otLwfTunAddressesUpdated(
         const uint8_t *entry_ptr = NULL;
         spinel_size_t entry_len = 0;
 
-        spinel_ssize_t len = spinel_datatype_unpack(value_data_ptr, value_data_len, "D.", &entry_ptr, &entry_len);
+        spinel_ssize_t len = spinel_datatype_unpack(value_data_ptr, value_data_len, "d", &entry_ptr, &entry_len);
         if (len < 1) break;
 
         {

--- a/examples/drivers/windows/otLwf/tunnel.c
+++ b/examples/drivers/windows/otLwf/tunnel.c
@@ -497,7 +497,7 @@ otLwfTunValueIs(
         ret = spinel_datatype_unpack(
             value_data_ptr,
             value_data_len,
-            SPINEL_DATATYPE_DATA_S SPINEL_DATATYPE_DATA_S,
+            SPINEL_DATATYPE_DATA_WLEN_S SPINEL_DATATYPE_DATA_S,
             &frame_ptr,
             &frame_len,
             NULL,
@@ -601,11 +601,13 @@ otLwfTunValueInserted(
             const char *aNetworkName = NULL;
             unsigned int xpanid_len = 0;
 
-            //chan,rssi,(laddr,saddr,panid,lqi),(proto,flags,networkid,xpanid) [CcT(ESSC)T(iCUD.).]
             if (try_spinel_datatype_unpack(
                 value_data_ptr,
                 value_data_len,
-                "CcT(ESSC.)T(iCUD.).",
+                SPINEL_DATATYPE_MAC_SCAN_RESULT_S(
+                    SPINEL_802_15_4_DATATYPE_MAC_SCAN_RESULT_V1_S,
+                    SPINEL_NET_DATATYPE_MAC_SCAN_RESULT_V1_S
+                ),
                 &NotifEntry->Notif.ActiveScanPayload.Results.mChannel,
                 &NotifEntry->Notif.ActiveScanPayload.Results.mRssi,
                 &aExtAddr,

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -592,7 +592,7 @@ void NcpBase::HandleDatagramFromStack(otMessage *aMessage)
 
     SuccessOrExit(
         errorCode = OutboundFrameFeedPacked(
-            "CiiS",
+            SPINEL_DATATYPE_COMMAND_PROP_S SPINEL_DATATYPE_UINT16_S,
             SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
             SPINEL_CMD_PROP_VALUE_IS,
             isSecure
@@ -666,7 +666,7 @@ void NcpBase::HandleRawFrame(const RadioPacket *aFrame)
     // Append frame header and frame length
     SuccessOrExit(
         errorCode = OutboundFrameFeedPacked(
-            "CiiS",
+            SPINEL_DATATYPE_COMMAND_PROP_S SPINEL_DATATYPE_UINT16_S,
             SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
             SPINEL_CMD_PROP_VALUE_IS,
             SPINEL_PROP_STREAM_RAW,
@@ -685,7 +685,15 @@ void NcpBase::HandleRawFrame(const RadioPacket *aFrame)
     // Append metadata (rssi, etc)
     SuccessOrExit(
         errorCode = OutboundFrameFeedPacked(
-            "ccS",
+            SPINEL_DATATYPE_INT8_S
+            SPINEL_DATATYPE_INT8_S
+            SPINEL_DATATYPE_UINT16_S
+            SPINEL_DATATYPE_STRUCT_S( // PHY-data
+                // Empty for now
+            )
+            SPINEL_DATATYPE_STRUCT_S( // Vendor-data
+                // Empty for now
+            ),
             aFrame->mPower,   // TX Power
             -128,             // Noise Floor (Currently unused)
             flags             // Flags
@@ -728,12 +736,14 @@ void NcpBase::HandleActiveScanResult(otActiveScanResult *result)
             flags |= SPINEL_BEACON_THREAD_FLAG_NATIVE;
         }
 
-        //chan,rssi,(laddr,saddr,panid,lqi),(proto,flags,networkid,xpanid) [icT(ESSC)T(iCUD.).]
         NcpBase::SendPropertyUpdate(
             SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
             SPINEL_CMD_PROP_VALUE_INSERTED,
             SPINEL_PROP_MAC_SCAN_BEACON,
-            "CcT(ESSC.)T(iCUD.).",
+            SPINEL_DATATYPE_MAC_SCAN_RESULT_S(
+                SPINEL_802_15_4_DATATYPE_MAC_SCAN_RESULT_V1_S,
+                SPINEL_NET_DATATYPE_MAC_SCAN_RESULT_V1_S
+            ),
             result->mChannel,
             result->mRssi,
             result->mExtAddress.m8, // laddr
@@ -836,7 +846,7 @@ void NcpBase::LinkRawReceiveDone(RadioPacket *aPacket, ThreadError aError)
     // Append frame header and frame length
     SuccessOrExit(
         errorCode = OutboundFrameFeedPacked(
-            "CiiS",
+            SPINEL_DATATYPE_COMMAND_PROP_S SPINEL_DATATYPE_UINT16_S,
             SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
             SPINEL_CMD_PROP_VALUE_IS,
             SPINEL_PROP_STREAM_RAW,
@@ -858,13 +868,22 @@ void NcpBase::LinkRawReceiveDone(RadioPacket *aPacket, ThreadError aError)
     // Append metadata (rssi, etc)
     SuccessOrExit(
         errorCode = OutboundFrameFeedPacked(
-            "ccSiCC",
+            SPINEL_DATATYPE_INT8_S
+            SPINEL_DATATYPE_INT8_S
+            SPINEL_DATATYPE_UINT16_S
+            SPINEL_DATATYPE_STRUCT_S( // PHY-data
+                SPINEL_DATATYPE_UINT8_S // 802.15.4 channel
+                SPINEL_DATATYPE_UINT8_S // 802.15.4 LQI
+            )
+            SPINEL_DATATYPE_STRUCT_S( // Vendor-data
+                SPINEL_DATATYPE_UINT_PACKED_S
+            ),
             aPacket->mPower,    // TX Power
             -128,               // Noise Floor (Currently unused)
             flags,              // Flags
-            aError,             // Receive error
             aPacket->mChannel,  // Receive channel
-            aPacket->mLqi       // Link quality indicator
+            aPacket->mLqi,      // Link quality indicator
+            aError              // Receive error
         )
     );
 
@@ -887,7 +906,7 @@ void NcpBase::LinkRawTransmitDone(RadioPacket *, bool aFramePending, ThreadError
             SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0 | mCurTransmitTID,
             SPINEL_CMD_PROP_VALUE_IS,
             SPINEL_PROP_LAST_STATUS,
-            "ib",
+            SPINEL_DATATYPE_UINT_PACKED_S SPINEL_DATATYPE_BOOL_S,
             aError,
             aFramePending
         );
@@ -912,7 +931,8 @@ void NcpBase::LinkRawEnergyScanDone(int8_t aEnergyScanMaxRssi)
         SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
         SPINEL_CMD_PROP_VALUE_IS,
         SPINEL_PROP_MAC_ENERGY_SCAN_RESULT,
-        "Cc",
+        SPINEL_DATATYPE_UINT8_S
+        SPINEL_DATATYPE_INT8_S,
         mCurScanChannel,
         aEnergyScanMaxRssi
     );
@@ -1128,7 +1148,7 @@ void NcpBase::HandleReceive(const uint8_t *buf, uint16_t bufLength)
     ThreadError errorCode = kThreadError_None;
     spinel_tid_t tid = 0;
 
-    parsedLength = spinel_datatype_unpack(buf, bufLength, "CiD", &header, &command, &arg_ptr, &arg_len);
+    parsedLength = spinel_datatype_unpack(buf, bufLength, SPINEL_DATATYPE_COMMAND_S SPINEL_DATATYPE_DATA_S, &header, &command, &arg_ptr, &arg_len);
     tid = SPINEL_HEADER_GET_TID(header);
 
     if (parsedLength == bufLength)
@@ -1416,7 +1436,7 @@ ThreadError NcpBase::SendPropertyUpdate(uint8_t header, uint8_t command, spinel_
 
     va_start(args, pack_format);
     SuccessOrExit(errorCode = OutboundFrameBegin());
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, command, key));
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, command, key));
     SuccessOrExit(errorCode = OutboundFrameFeedVPacked(pack_format, args));
     SuccessOrExit(errorCode = OutboundFrameSend());
 
@@ -1431,7 +1451,7 @@ ThreadError NcpBase::SendPropertyUpdate(uint8_t header, uint8_t command, spinel_
     ThreadError errorCode = kThreadError_None;
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, command, key));
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, command, key));
     SuccessOrExit(errorCode = OutboundFrameFeedData(value_ptr, value_len));
     SuccessOrExit(errorCode = OutboundFrameSend());
 
@@ -1444,7 +1464,7 @@ ThreadError NcpBase::SendPropertyUpdate(uint8_t header, uint8_t command, spinel_
     ThreadError errorCode = kThreadError_None;
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, command, key));
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, command, key));
     SuccessOrExit(errorCode = OutboundFrameFeedMessage(aMessage));
 
     // Set the aMessage pointer to NULL, to indicate that it does not need to be freed at the exit.
@@ -1545,7 +1565,7 @@ ThreadError NcpBase::CommandHandler_PROP_VALUE_GET(uint8_t header, unsigned int 
     spinel_ssize_t parsedLength;
     ThreadError errorCode = kThreadError_None;
 
-    parsedLength = spinel_datatype_unpack(arg_ptr, arg_len, "i", &propKey);
+    parsedLength = spinel_datatype_unpack(arg_ptr, arg_len, SPINEL_DATATYPE_UINT_PACKED_S, &propKey);
 
     if (parsedLength > 0)
     {
@@ -1570,7 +1590,7 @@ ThreadError NcpBase::CommandHandler_PROP_VALUE_SET(uint8_t header, unsigned int 
     unsigned int value_len;
     ThreadError errorCode = kThreadError_None;
 
-    parsedLength = spinel_datatype_unpack(arg_ptr, arg_len, "iD", &propKey, &value_ptr, &value_len);
+    parsedLength = spinel_datatype_unpack(arg_ptr, arg_len, SPINEL_DATATYPE_UINT_PACKED_S SPINEL_DATATYPE_DATA_S, &propKey, &value_ptr, &value_len);
 
     if (parsedLength == arg_len)
     {
@@ -1596,7 +1616,7 @@ ThreadError NcpBase::CommandHandler_PROP_VALUE_INSERT(uint8_t header, unsigned i
     unsigned int value_len;
     ThreadError errorCode = kThreadError_None;
 
-    parsedLength = spinel_datatype_unpack(arg_ptr, arg_len, "iD", &propKey, &value_ptr, &value_len);
+    parsedLength = spinel_datatype_unpack(arg_ptr, arg_len, SPINEL_DATATYPE_UINT_PACKED_S SPINEL_DATATYPE_DATA_S, &propKey, &value_ptr, &value_len);
 
     if (parsedLength == arg_len)
     {
@@ -1622,7 +1642,7 @@ ThreadError NcpBase::CommandHandler_PROP_VALUE_REMOVE(uint8_t header, unsigned i
     unsigned int value_len;
     ThreadError errorCode = kThreadError_None;
 
-    parsedLength = spinel_datatype_unpack(arg_ptr, arg_len, "iD", &propKey, &value_ptr, &value_len);
+    parsedLength = spinel_datatype_unpack(arg_ptr, arg_len, SPINEL_DATATYPE_UINT_PACKED_S SPINEL_DATATYPE_DATA_S, &propKey, &value_ptr, &value_len);
 
     if (parsedLength == arg_len)
     {
@@ -1718,7 +1738,7 @@ ThreadError NcpBase::GetPropertyHandler_CAPS(uint8_t header, spinel_prop_key_t k
     ThreadError errorCode = kThreadError_None;
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, SPINEL_CMD_PROP_VALUE_IS, key));
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS, key));
 
     // Begin adding capabilities //////////////////////////////////////////////
 
@@ -1959,7 +1979,7 @@ ThreadError NcpBase::GetPropertyHandler_ChannelMaskHelper(uint8_t header, spinel
     ThreadError errorCode = kThreadError_None;
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, SPINEL_CMD_PROP_VALUE_IS, key));
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS, key));
 
     for (int i = 0; i < 32; i++)
     {
@@ -2224,7 +2244,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_NETWORK_DATA(uint8_t header, spin
     );
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, SPINEL_CMD_PROP_VALUE_IS, key));
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS, key));
     SuccessOrExit(errorCode = OutboundFrameFeedData(network_data, network_data_len));
     SuccessOrExit(errorCode = OutboundFrameSend());
 
@@ -2246,7 +2266,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_STABLE_NETWORK_DATA(uint8_t heade
     );
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, SPINEL_CMD_PROP_VALUE_IS, key));
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS, key));
     SuccessOrExit(errorCode = OutboundFrameFeedData(network_data, network_data_len));
     SuccessOrExit(errorCode = OutboundFrameSend());
 
@@ -2268,7 +2288,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_LEADER_NETWORK_DATA(uint8_t heade
     );
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, SPINEL_CMD_PROP_VALUE_IS, key));
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS, key));
     SuccessOrExit(errorCode = OutboundFrameFeedData(network_data, network_data_len));
     SuccessOrExit(errorCode = OutboundFrameSend());
 
@@ -2290,7 +2310,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_STABLE_LEADER_NETWORK_DATA(uint8_
     );
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, SPINEL_CMD_PROP_VALUE_IS, key));
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS, key));
     SuccessOrExit(errorCode = OutboundFrameFeedData(network_data, network_data_len));
     SuccessOrExit(errorCode = OutboundFrameSend());
 
@@ -2392,7 +2412,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_CHILD_TABLE(uint8_t header, spine
     mDisableStreamWrite = true;
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, SPINEL_CMD_PROP_VALUE_IS, key));
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS, key));
 
     maxChildren = otThreadGetMaxAllowedChildren(mInstance);
 
@@ -2429,7 +2449,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_CHILD_TABLE(uint8_t header, spine
 
         SuccessOrExit(
             errorCode = OutboundFrameFeedPacked(
-                "T("
+                SPINEL_DATATYPE_STRUCT_S(
                     SPINEL_DATATYPE_EUI64_S         // EUI64 Address
                     SPINEL_DATATYPE_UINT16_S        // Rloc16
                     SPINEL_DATATYPE_UINT32_S        // Timeout
@@ -2438,7 +2458,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_CHILD_TABLE(uint8_t header, spine
                     SPINEL_DATATYPE_UINT8_S         // Link Quality In
                     SPINEL_DATATYPE_INT8_S          // Average RSS
                     SPINEL_DATATYPE_UINT8_S         // Mode (flags)
-                ")",
+                ),
                 childInfo.mExtAddress.m8,
                 childInfo.mRloc16,
                 childInfo.mTimeout,
@@ -2467,7 +2487,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_NEIGHBOR_TABLE(uint8_t header, sp
     mDisableStreamWrite = true;
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, SPINEL_CMD_PROP_VALUE_IS, key));
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS, key));
 
     while (otThreadGetNextNeighborInfo(mInstance, &iter, &neighInfo) == kThreadError_None)
     {
@@ -2495,7 +2515,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_NEIGHBOR_TABLE(uint8_t header, sp
 
         SuccessOrExit(
             errorCode = OutboundFrameFeedPacked(
-                "T("
+                SPINEL_DATATYPE_STRUCT_S(
                     SPINEL_DATATYPE_EUI64_S         // EUI64 Address
                     SPINEL_DATATYPE_UINT16_S        // Rloc16
                     SPINEL_DATATYPE_UINT32_S        // Age
@@ -2505,7 +2525,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_NEIGHBOR_TABLE(uint8_t header, sp
                     SPINEL_DATATYPE_BOOL_S          // Is Child
                     SPINEL_DATATYPE_UINT32_S        // Link Frame Counter
                     SPINEL_DATATYPE_UINT32_S        // MLE Frame Counter
-                ")",
+                ),
                 neighInfo.mExtAddress.m8,
                 neighInfo.mRloc16,
                 neighInfo.mAge,
@@ -2532,7 +2552,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, s
     const uint16_t *ports = otIp6GetUnsecurePorts(mInstance, &num_entries);
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, SPINEL_CMD_PROP_VALUE_IS, key));
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS, key));
 
     for (; num_entries != 0; ports++, num_entries--)
     {
@@ -2576,7 +2596,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spin
     mDisableStreamWrite = true;
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, SPINEL_CMD_PROP_VALUE_IS, key));
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS, key));
 
     // Fill from non-local network data first
     for (otNetworkDataIterator iter = OT_NETWORK_DATA_ITERATOR_INIT ;;)
@@ -2591,13 +2611,13 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spin
         flags = BorderRouterConfigToFlagByte(border_router_config);
 
         SuccessOrExit(errorCode = OutboundFrameFeedPacked(
-            "T("
+            SPINEL_DATATYPE_STRUCT_S(
                 SPINEL_DATATYPE_IPv6ADDR_S      // IPv6 Prefix
                 SPINEL_DATATYPE_UINT8_S         // Prefix Length (in bits)
                 SPINEL_DATATYPE_BOOL_S          // isStable
                 SPINEL_DATATYPE_UINT8_S         // Flags
                 SPINEL_DATATYPE_BOOL_S          // isLocal
-            ").",
+            ),
             &border_router_config.mPrefix,
             64,
             border_router_config.mStable,
@@ -2619,13 +2639,13 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spin
         flags = BorderRouterConfigToFlagByte(border_router_config);
 
         SuccessOrExit(errorCode = OutboundFrameFeedPacked(
-            "T("
+            SPINEL_DATATYPE_STRUCT_S(
                 SPINEL_DATATYPE_IPv6ADDR_S      // IPv6 Prefix
                 SPINEL_DATATYPE_UINT8_S         // Prefix Length (in bits)
                 SPINEL_DATATYPE_BOOL_S          // isStable
                 SPINEL_DATATYPE_UINT8_S         // Flags
                 SPINEL_DATATYPE_BOOL_S          // isLocal
-            ").",
+            ),
             &border_router_config.mPrefix,
             64,
             border_router_config.mStable,
@@ -2721,13 +2741,13 @@ ThreadError NcpBase::GetPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spine
     mDisableStreamWrite = true;
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, SPINEL_CMD_PROP_VALUE_IS, key));
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS, key));
 
     for (const otNetifAddress *address = otIp6GetUnicastAddresses(mInstance); address; address = address->mNext)
     {
 
         SuccessOrExit(errorCode = OutboundFrameFeedPacked(
-                                      "T(6CLL).",
+                                      SPINEL_DATATYPE_STRUCT_S("6CLL"),
                                       &address->mAddress,
                                       address->mPrefixLength,
                                       address->mPreferred ? 0xffffffff : 0,
@@ -3089,8 +3109,8 @@ ThreadError NcpBase::GetPropertyHandler_MSG_BUFFER_COUNTERS(uint8_t header, spin
     otMessageGetBufferInfo(mInstance, &bufferInfo);
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, SPINEL_CMD_PROP_VALUE_IS, key));
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked("T(SSSSSSSSSSSSSSSS)",
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS, key));
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked("SSSSSSSSSSSSSSSS",
         bufferInfo.mTotalBuffers,
         bufferInfo.mFreeBuffers,
         bufferInfo.m6loSendMessages,
@@ -3140,7 +3160,7 @@ ThreadError NcpBase::GetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_pro
     mDisableStreamWrite = true;
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked("Cii", header, SPINEL_CMD_PROP_VALUE_IS, key));
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS, key));
 
     for (uint8_t i = 0; (i != 255) && (errorCode == kThreadError_None); i++)
     {
@@ -3158,7 +3178,7 @@ ThreadError NcpBase::GetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_pro
                 entry.mRssi = RSSI_OVERRIDE_DISABLED;
             }
 
-            SuccessOrExit(errorCode = OutboundFrameFeedPacked("T(Ec).", entry.mExtAddress.m8, entry.mRssi));
+            SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_STRUCT_S("Ec"), entry.mExtAddress.m8, entry.mRssi));
         }
     }
 
@@ -3923,7 +3943,9 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_RAW(uint8_t header, spinel_prop_k
         parsedLength = spinel_datatype_unpack(
             value_ptr,
             value_len,
-            "DCc",
+            SPINEL_DATATYPE_DATA_WLEN_S
+            SPINEL_DATATYPE_UINT8_S
+            SPINEL_DATATYPE_INT8_S,
             &frame_buffer,
             &frame_len,
             &packet->mChannel,
@@ -4341,7 +4363,7 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_NET_INSECURE(uint8_t header, spin
         parsedLength = spinel_datatype_unpack(
                            value_ptr,
                            value_len,
-                           SPINEL_DATATYPE_DATA_S SPINEL_DATATYPE_DATA_S,
+                           SPINEL_DATATYPE_DATA_WLEN_S SPINEL_DATATYPE_DATA_S,
                            &frame_ptr,
                            &frame_len,
                            &meta_ptr,
@@ -4414,7 +4436,7 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_k
         parsedLength = spinel_datatype_unpack(
                            value_ptr,
                            value_len,
-                           SPINEL_DATATYPE_DATA_S SPINEL_DATATYPE_DATA_S,
+                           SPINEL_DATATYPE_DATA_WLEN_S SPINEL_DATATYPE_DATA_S,
                            &frame_ptr,
                            &frame_len,
                            &meta_ptr,
@@ -4755,7 +4777,10 @@ ThreadError NcpBase::SetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_pro
         parsedLength = spinel_datatype_unpack(
                            value_ptr,
                            value_len,
-                           "T(Ec).",
+                           SPINEL_DATATYPE_STRUCT_S(
+                               SPINEL_DATATYPE_EUI64_S
+                               SPINEL_DATATYPE_INT8_S
+                           ),
                            &ext_addr,
                            &rssi
                        );
@@ -4766,7 +4791,9 @@ ThreadError NcpBase::SetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_pro
             parsedLength = spinel_datatype_unpack(
                                value_ptr,
                                value_len,
-                               "T(E).",
+                               SPINEL_DATATYPE_STRUCT_S(
+                                   SPINEL_DATATYPE_EUI64_S
+                               ),
                                &ext_addr
                            );
         }
@@ -5806,7 +5833,7 @@ ThreadError NcpBase::InsertPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
                        value_len,
-                       "S",
+                       SPINEL_DATATYPE_UINT16_S,
                        &port
                    );
 
@@ -5851,7 +5878,7 @@ ThreadError NcpBase::InsertPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_
         parsedLength = spinel_datatype_unpack(
             value_ptr,
             value_len,
-            "Ec",
+            SPINEL_DATATYPE_EUI64_S SPINEL_DATATYPE_INT8_S,
             &ext_addr,
             &rssi
         );
@@ -5861,7 +5888,7 @@ ThreadError NcpBase::InsertPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_
         parsedLength = spinel_datatype_unpack(
             value_ptr,
             value_len,
-            "E",
+            SPINEL_DATATYPE_EUI64_S,
             &ext_addr
         );
     }
@@ -6145,7 +6172,7 @@ ThreadError NcpBase::RemovePropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
                        value_len,
-                       "S",
+                       SPINEL_DATATYPE_UINT16_S,
                        &port
                    );
 
@@ -6186,7 +6213,7 @@ ThreadError NcpBase::RemovePropertyHandler_THREAD_ACTIVE_ROUTER_IDS(uint8_t head
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
                        value_len,
-                       "C",
+                       SPINEL_DATATYPE_UINT8_S,
                        &router_id
                    );
 
@@ -6227,7 +6254,7 @@ ThreadError NcpBase::RemovePropertyHandler_MAC_WHITELIST(uint8_t header, spinel_
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
                        value_len,
-                       "E",
+                       SPINEL_DATATYPE_EUI64_S,
                        &ext_addr
                    );
 
@@ -6294,7 +6321,7 @@ void NcpBase::HandleDidReceiveNewLegacyUlaPrefix(const uint8_t *aUlaPrefix)
 
     SuccessOrExit(
         OutboundFrameFeedPacked(
-            "Cii" SPINEL_DATATYPE_DATA_S,
+            SPINEL_DATATYPE_COMMAND_PROP_S SPINEL_DATATYPE_DATA_S,
             SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
             SPINEL_CMD_PROP_VALUE_IS,
             SPINEL_PROP_NEST_LEGACY_ULA_PREFIX,
@@ -6315,7 +6342,7 @@ void NcpBase::HandleLegacyNodeDidJoin(const otExtAddress *aExtAddr)
 
     SuccessOrExit(
         OutboundFrameFeedPacked(
-            "Cii" SPINEL_DATATYPE_EUI64_S,
+            SPINEL_DATATYPE_COMMAND_PROP_S SPINEL_DATATYPE_EUI64_S,
             SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
             SPINEL_CMD_PROP_VALUE_IS,
             SPINEL_PROP_NEST_LEGACY_JOINED_NODE,

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -69,7 +69,7 @@
 // ----------------------------------------------------------------------------
 
 #define SPINEL_PROTOCOL_VERSION_THREAD_MAJOR    4
-#define SPINEL_PROTOCOL_VERSION_THREAD_MINOR    2
+#define SPINEL_PROTOCOL_VERSION_THREAD_MINOR    3
 
 #define SPINEL_FRAME_MAX_SIZE                   1300
 
@@ -583,7 +583,7 @@ typedef enum
     SPINEL_PROP_MAC_SCAN_STATE         = SPINEL_PROP_MAC__BEGIN + 0, ///< [C]
     SPINEL_PROP_MAC_SCAN_MASK          = SPINEL_PROP_MAC__BEGIN + 1, ///< [A(C)]
     SPINEL_PROP_MAC_SCAN_PERIOD        = SPINEL_PROP_MAC__BEGIN + 2, ///< ms-per-channel [S]
-    SPINEL_PROP_MAC_SCAN_BEACON        = SPINEL_PROP_MAC__BEGIN + 3, ///< chan,rssi,(laddr,saddr,panid,lqi),(proto,xtra) [CcT(ESSC.)T(i).]
+    SPINEL_PROP_MAC_SCAN_BEACON        = SPINEL_PROP_MAC__BEGIN + 3, ///< chan,rssi,mac_data,net_data [CcdD]
     SPINEL_PROP_MAC_15_4_LADDR         = SPINEL_PROP_MAC__BEGIN + 4, ///< [E]
     SPINEL_PROP_MAC_15_4_SADDR         = SPINEL_PROP_MAC__BEGIN + 5, ///< [S]
     SPINEL_PROP_MAC_15_4_PANID         = SPINEL_PROP_MAC__BEGIN + 6, ///< [S]
@@ -594,7 +594,7 @@ typedef enum
 
     SPINEL_PROP_MAC_EXT__BEGIN         = 0x1300,
     /// MAC Whitelist
-    /** Format: `A(T(Ec))`
+    /** Format: `A(t(Ec))`
      *
      * Structure Parameters:
      *
@@ -674,7 +674,7 @@ typedef enum
     SPINEL_PROP_THREAD__BEGIN          = 0x50,
     SPINEL_PROP_THREAD_LEADER_ADDR     = SPINEL_PROP_THREAD__BEGIN + 0, ///< [6]
     SPINEL_PROP_THREAD_PARENT          = SPINEL_PROP_THREAD__BEGIN + 1, ///< LADDR, SADDR [ES]
-    SPINEL_PROP_THREAD_CHILD_TABLE     = SPINEL_PROP_THREAD__BEGIN + 2, ///< array(EUI64,rloc16,timeout,age,netDataVer,inLqi,aveRSS,mode) [A(T(ESLLCCcC))]
+    SPINEL_PROP_THREAD_CHILD_TABLE     = SPINEL_PROP_THREAD__BEGIN + 2, ///< array(EUI64,rloc16,timeout,age,netDataVer,inLqi,aveRSS,mode) [A(t(ESLLCCcC))]
     SPINEL_PROP_THREAD_LEADER_RID      = SPINEL_PROP_THREAD__BEGIN + 3, ///< [C]
     SPINEL_PROP_THREAD_LEADER_WEIGHT   = SPINEL_PROP_THREAD__BEGIN + 4, ///< [C]
     SPINEL_PROP_THREAD_LOCAL_LEADER_WEIGHT
@@ -686,8 +686,8 @@ typedef enum
                                        = SPINEL_PROP_THREAD__BEGIN + 8, ///< [D]
     SPINEL_PROP_THREAD_STABLE_NETWORK_DATA_VERSION
                                        = SPINEL_PROP_THREAD__BEGIN + 9,  ///< [S]
-    SPINEL_PROP_THREAD_ON_MESH_NETS    = SPINEL_PROP_THREAD__BEGIN + 10, ///< array(ipv6prefix,prefixlen,stable,flags) [A(T(6CbC))]
-    SPINEL_PROP_THREAD_LOCAL_ROUTES    = SPINEL_PROP_THREAD__BEGIN + 11, ///< array(ipv6prefix,prefixlen,stable,flags) [A(T(6CbC))]
+    SPINEL_PROP_THREAD_ON_MESH_NETS    = SPINEL_PROP_THREAD__BEGIN + 10, ///< array(ipv6prefix,prefixlen,stable,flags) [A(t(6CbC))]
+    SPINEL_PROP_THREAD_LOCAL_ROUTES    = SPINEL_PROP_THREAD__BEGIN + 11, ///< array(ipv6prefix,prefixlen,stable,flags) [A(t(6CbC))]
     SPINEL_PROP_THREAD_ASSISTING_PORTS = SPINEL_PROP_THREAD__BEGIN + 12, ///< array(portn) [A(S)]
     SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE
                                        = SPINEL_PROP_THREAD__BEGIN + 13, ///< [b]
@@ -776,7 +776,7 @@ typedef enum
                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 10,
 
     /// Thread Neighbor Table
-    /** Format: `A(T(ESLCcCbLL))`
+    /** Format: `A(t(ESLCcCbLL))`
      *  eui64, rloc16, age, inLqi ,aveRSS, mode, isChild. linkFrameCounter, mleCounter
      */
     SPINEL_PROP_THREAD_NEIGHBOR_TABLE  = SPINEL_PROP_THREAD_EXT__BEGIN + 11,
@@ -804,8 +804,8 @@ typedef enum
     SPINEL_PROP_IPV6_LL_ADDR         = SPINEL_PROP_IPV6__BEGIN + 0, ///< [6]
     SPINEL_PROP_IPV6_ML_ADDR         = SPINEL_PROP_IPV6__BEGIN + 1, ///< [6C]
     SPINEL_PROP_IPV6_ML_PREFIX       = SPINEL_PROP_IPV6__BEGIN + 2, ///< [6C]
-    SPINEL_PROP_IPV6_ADDRESS_TABLE   = SPINEL_PROP_IPV6__BEGIN + 3, ///< array(ipv6addr,prefixlen,valid,preferred,flags) [A(T(6CLLC))]
-    SPINEL_PROP_IPV6_ROUTE_TABLE     = SPINEL_PROP_IPV6__BEGIN + 4, ///< array(ipv6prefix,prefixlen,iface,flags) [A(T(6CCC))]
+    SPINEL_PROP_IPV6_ADDRESS_TABLE   = SPINEL_PROP_IPV6__BEGIN + 3, ///< array(ipv6addr,prefixlen,valid,preferred,flags) [A(t(6CLLC))]
+    SPINEL_PROP_IPV6_ROUTE_TABLE     = SPINEL_PROP_IPV6__BEGIN + 4, ///< array(ipv6prefix,prefixlen,iface,flags) [A(t(6CCC))]
 
 
     /// IPv6 ICMP Ping Offload
@@ -822,9 +822,9 @@ typedef enum
 
     SPINEL_PROP_STREAM__BEGIN       = 0x70,
     SPINEL_PROP_STREAM_DEBUG        = SPINEL_PROP_STREAM__BEGIN + 0, ///< [U]
-    SPINEL_PROP_STREAM_RAW          = SPINEL_PROP_STREAM__BEGIN + 1, ///< [D]
-    SPINEL_PROP_STREAM_NET          = SPINEL_PROP_STREAM__BEGIN + 2, ///< [D]
-    SPINEL_PROP_STREAM_NET_INSECURE = SPINEL_PROP_STREAM__BEGIN + 3, ///< [D]
+    SPINEL_PROP_STREAM_RAW          = SPINEL_PROP_STREAM__BEGIN + 1, ///< [dD]
+    SPINEL_PROP_STREAM_NET          = SPINEL_PROP_STREAM__BEGIN + 2, ///< [dD]
+    SPINEL_PROP_STREAM_NET_INSECURE = SPINEL_PROP_STREAM__BEGIN + 3, ///< [dD]
     SPINEL_PROP_STREAM__END         = 0x80,
 
 
@@ -1053,8 +1053,7 @@ typedef enum
                                        = SPINEL_PROP_CNTR__BEGIN + 303,
 
     /// The message buffer counter info
-    /** Format: `T(SSSSSSSSSSSSSSSS)` (Read-only)
-     *  `T(`
+    /** Format: `SSSSSSSSSSSSSSSS` (Read-only)
      *      `S`, (TotalBuffers)           The number of buffers in the pool.
      *      `S`, (FreeBuffers)            The number of free message buffers.
      *      `S`, (6loSendMessages)        The number of messages in the 6lo send queue.
@@ -1071,7 +1070,6 @@ typedef enum
      *      `S`, (ArpBuffers)             The number of buffers in the ARP send queue.
      *      `S`, (CoapClientMessages)     The number of messages in the CoAP client send queue.
      *      `S`, (CoapClientBuffers)      The number of buffers in the CoAP client send queue.
-     *  `)`
      */
     SPINEL_PROP_MSG_BUFFER_COUNTERS    = SPINEL_PROP_CNTR__BEGIN + 400,
 
@@ -1154,9 +1152,10 @@ enum
     SPINEL_DATATYPE_IPv6ADDR_C    = '6',
     SPINEL_DATATYPE_EUI64_C       = 'E',
     SPINEL_DATATYPE_EUI48_C       = 'e',
+    SPINEL_DATATYPE_DATA_WLEN_C   = 'd',
     SPINEL_DATATYPE_DATA_C        = 'D',
     SPINEL_DATATYPE_UTF8_C        = 'U', //!< Zero-Terminated UTF8-Encoded String
-    SPINEL_DATATYPE_STRUCT_C      = 'T',
+    SPINEL_DATATYPE_STRUCT_C      = 't',
     SPINEL_DATATYPE_ARRAY_C       = 'A',
 };
 
@@ -1175,10 +1174,43 @@ typedef char spinel_datatype_t;
 #define SPINEL_DATATYPE_IPv6ADDR_S    "6"
 #define SPINEL_DATATYPE_EUI64_S       "E"
 #define SPINEL_DATATYPE_EUI48_S       "e"
+#define SPINEL_DATATYPE_DATA_WLEN_S   "d"
 #define SPINEL_DATATYPE_DATA_S        "D"
 #define SPINEL_DATATYPE_UTF8_S        "U" //!< Zero-Terminated UTF8-Encoded String
-#define SPINEL_DATATYPE_STRUCT_S      "T"
-#define SPINEL_DATATYPE_ARRAY_S       "A"
+
+#define SPINEL_DATATYPE_ARRAY_S(x)        "A(" x ")"
+#define SPINEL_DATATYPE_STRUCT_S(x)       "t(" x ")"
+
+#define SPINEL_DATATYPE_ARRAY_STRUCT_S(x)                                     \
+        SPINEL_DATATYPE_ARRAY_S(SPINEL_DATATYPE_STRUCT_WLEN_S(x))
+
+#define SPINEL_DATATYPE_COMMAND_S                                             \
+        SPINEL_DATATYPE_UINT8_S       /* header  */                           \
+        SPINEL_DATATYPE_UINT_PACKED_S /* command */
+
+#define SPINEL_DATATYPE_COMMAND_PROP_S                                        \
+        SPINEL_DATATYPE_COMMAND_S     /* prop command  */                     \
+        SPINEL_DATATYPE_UINT_PACKED_S /* property id */
+
+#define SPINEL_DATATYPE_MAC_SCAN_RESULT_S(mac_format_str, net_format_str)     \
+        SPINEL_DATATYPE_UINT8_S /* Channel */                                 \
+        SPINEL_DATATYPE_INT8_S  /* RSSI */                                    \
+        SPINEL_DATATYPE_STRUCT_S(mac_format_str) /* mac-layer data */         \
+        SPINEL_DATATYPE_STRUCT_S(net_format_str) /* net-layer data */
+
+#define SPINEL_802_15_4_DATATYPE_MAC_SCAN_RESULT_V1_S                         \
+        SPINEL_DATATYPE_EUI64_S  /* laddr */                                  \
+        SPINEL_DATATYPE_UINT16_S /* saddr */                                  \
+        SPINEL_DATATYPE_UINT16_S /* panid */                                  \
+        SPINEL_DATATYPE_UINT8_S  /* lqi   */
+
+#define SPINEL_NET_DATATYPE_MAC_SCAN_RESULT_V1_S                              \
+        SPINEL_DATATYPE_UINT_PACKED_S /* type */                              \
+        SPINEL_DATATYPE_UINT8_S /* flags */                                   \
+        SPINEL_DATATYPE_UTF8_S /* network name */                             \
+        SPINEL_DATATYPE_DATA_WLEN_S /* xpanid */
+
+#define SPINEL_MAX_UINT_PACKED        2097151
 
 SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_pack(uint8_t *data_out, spinel_size_t data_len,
                                                       const char *pack_format, ...);

--- a/tools/spinel-cli/spinel/const.py
+++ b/tools/spinel-cli/spinel/const.py
@@ -103,7 +103,7 @@ class SPINEL(object):
     PROP_MAC_SCAN_STATE = PROP_MAC__BEGIN + 0  # < [C]
     PROP_MAC_SCAN_MASK = PROP_MAC__BEGIN + 1  # < [A(C)]
     PROP_MAC_SCAN_PERIOD = PROP_MAC__BEGIN + 2  # < ms-per-channel [S]
-    # < chan,rssi,(laddr,saddr,panid,lqi),(proto,xtra) [CcT(ESSC.)T(i).]
+    # < chan,rssi,(laddr,saddr,panid,lqi),(proto,xtra) [Cct(ESSC)t(i)]
     PROP_MAC_SCAN_BEACON = PROP_MAC__BEGIN + 3
     PROP_MAC_15_4_LADDR = PROP_MAC__BEGIN + 4  # < [E]
     PROP_MAC_15_4_SADDR = PROP_MAC__BEGIN + 5  # < [S]
@@ -136,7 +136,7 @@ class SPINEL(object):
     PROP_THREAD__BEGIN = 0x50
     PROP_THREAD_LEADER_ADDR = PROP_THREAD__BEGIN + 0  # < [6]
     PROP_THREAD_PARENT = PROP_THREAD__BEGIN + 1  # < LADDR, SADDR [ES]
-    PROP_THREAD_CHILD_TABLE = PROP_THREAD__BEGIN + 2  # < [A(T(ES))]
+    PROP_THREAD_CHILD_TABLE = PROP_THREAD__BEGIN + 2  # < [A(t(ES))]
     PROP_THREAD_LEADER_RID = PROP_THREAD__BEGIN + 3  # < [C]
     PROP_THREAD_LEADER_WEIGHT = PROP_THREAD__BEGIN + 4  # < [C]
     PROP_THREAD_LOCAL_LEADER_WEIGHT = PROP_THREAD__BEGIN + 5  # < [C]
@@ -144,9 +144,9 @@ class SPINEL(object):
     PROP_THREAD_NETWORK_DATA_VERSION = PROP_THREAD__BEGIN + 7  # < [S]
     PROP_THREAD_STABLE_NETWORK_DATA = PROP_THREAD__BEGIN + 8  # < [D]
     PROP_THREAD_STABLE_NETWORK_DATA_VERSION = PROP_THREAD__BEGIN + 9  # < [S]
-    # < array(ipv6prefix,prefixlen,stable,flags) [A(T(6CbC))]
+    # < array(ipv6prefix,prefixlen,stable,flags) [A(t(6CbC))]
     PROP_THREAD_ON_MESH_NETS = PROP_THREAD__BEGIN + 10
-    # < array(ipv6prefix,prefixlen,stable,flags) [A(T(6CbC))]
+    # < array(ipv6prefix,prefixlen,stable,flags) [A(t(6CbC))]
     PROP_THREAD_LOCAL_ROUTES = PROP_THREAD__BEGIN + 11
     PROP_THREAD_ASSISTING_PORTS = PROP_THREAD__BEGIN + 12  # < array(portn) [A(S)]
     PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE = PROP_THREAD__BEGIN + 13  # < [b]
@@ -165,7 +165,7 @@ class SPINEL(object):
     PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD = PROP_THREAD_EXT__BEGIN + 8  # < [C]
     PROP_THREAD_ROUTER_SELECTION_JITTER = PROP_THREAD_EXT__BEGIN + 9  # < [C]
     PROP_THREAD_PREFERRED_ROUTER_ID = PROP_THREAD_EXT__BEGIN + 10  # < [C]
-    PROP_THREAD_NEIGHBOR_TABLE = PROP_THREAD_EXT__BEGIN + 11  # < [A(T(ESLCcCbLL))]
+    PROP_THREAD_NEIGHBOR_TABLE = PROP_THREAD_EXT__BEGIN + 11  # < [A(t(ESLCcCbLL))]
     PROP_THREAD_CHILD_COUNT_MAX = PROP_THREAD_EXT__BEGIN + 12  # < [C]
 
     PROP_THREAD_EXT__END = 0x1600
@@ -181,9 +181,9 @@ class SPINEL(object):
     PROP_IPV6_LL_ADDR = PROP_IPV6__BEGIN + 0  # < [6]
     PROP_IPV6_ML_ADDR = PROP_IPV6__BEGIN + 1  # < [6C]
     PROP_IPV6_ML_PREFIX = PROP_IPV6__BEGIN + 2  # < [6C]
-    # < array(ipv6addr,prefixlen,valid,preferred,flags) [A(T(6CLLC))]
+    # < array(ipv6addr,prefixlen,valid,preferred,flags) [A(t(6CLLC))]
     PROP_IPV6_ADDRESS_TABLE = PROP_IPV6__BEGIN + 3
-    # < array(ipv6prefix,prefixlen,iface,flags) [A(T(6CCC))]
+    # < array(ipv6prefix,prefixlen,iface,flags) [A(t(6CCC))]
     PROP_IPV6_ROUTE_TABLE = PROP_IPV6__BEGIN + 4
     PROP_IPv6_ICMP_PING_OFFLOAD = PROP_IPV6__BEGIN + 5  # < [b]
 
@@ -315,8 +315,7 @@ class SPINEL(object):
     PROP_CNTR_RX_ERR_OTHER = PROP_CNTR__BEGIN + 113
 
     # The message buffer counter info
-    # Format: `T(SSSSSSSSSSSSSSSS)` (Read-only)
-    # `T(`
+    # Format: `SSSSSSSSSSSSSSSS` (Read-only)
     #     `S`, (TotalBuffers)           The number of buffers in the pool.
     #     `S`, (FreeBuffers)            The number of free message buffers.
     #     `S`, (6loSendMessages)        The number of messages in the 6lo send queue.
@@ -332,8 +331,7 @@ class SPINEL(object):
     #     `S`, (ArpMessages)            The number of messages in the ARP send queue.
     #     `S`, (ArpBuffers)             The number of buffers in the ARP send queue.
     #     `S`, (CoapClientMessages)     The number of messages in the CoAP client send queue.
-    #     `S`, (CoapClientBuffers)      The number of buffers in the CoAP client send queue.
-    # `)`
+    #     `S`  (CoapClientBuffers)      The number of buffers in the CoAP client send queue.
     PROP_MSG_BUFFER_COUNTERS = PROP_CNTR__BEGIN + 400
 
     #=========================================


### PR DESCRIPTION
The data packing format that I designed for Spinel was a bit too clever for its own good. While elegant from a certain perspective, the behavior of the data blob (`D`), array (`A(...)`), and structure (`T(...)`) types was way too confusing. I thought that I was (as the guy who came up with it) immune from such confusion, but after taking the time to go through all the code and address all of the mishaps in the code it seems that the subtitles befuddled even its creator on a time or two.

The specific issue that made me realize I needed to prioritize making this fix was #1393.

As far as packing types go, this commit makes the following changes:

*   **New type `DATATYPE_DATA_WLEN` (`d`)**: Just like `DATATYPE_DATA`    except that it ALWAYS prepends the length, irrespective of the    type's location in the type string. Think of WLEN as being "With    LENgth". Unless you are adding a property that has a type which is    just a single data blob, you should use this type instead of    `DATATYPE_DATA` (`D`). `DATATYPE_DATA` is still useful, so it will    be sticking around, except that it is defined by the documentation to ONLY appear as the last type in a datatype string. Using it anywhere else is deprecated.
*   **Changed type `DATATYPE_STRUCT` (was `T`, now `t`)**: The new    struct type, ALWAYS prepends the length of the contents of the    struct, just like `DATATYPE_DATA_WLEN`. The old `T` style struct    still works and behaves the same way, but its use is now    deprecated.
*   **Changed type `DATATYPE_ARRAY` (`A`)**: This type has changed in    documentation only, as no one is currently using it in the way    that it was originally specified. The change is that this type    NEVER prepends the length of the entire array, and using it    alongside other types is now unspecified (it should only be used    alone).

I also added some convenient macros for building up datatype signature strings that include structs.

One of the goals of these changes was to make this commit a change in specification only, not to change what was currently on-the-wire. However, after updating the spec and then going through and updating all of the code to use the new nomenclature, I was horrified to find that, due to the confusing nature of the previous datatype signature string format, many properties that are arrays were not implemented correctly --- making them impossible to update or add fields to without breaking backward compatibility. To add insult to injury, some of these instances were written by me!

This change updates all of the array properties to reflect how they should have been implemented to begin with.

At the moment this change only bumps the minor version, but I need to take a closer look and see if a major version bump is actually going to be required. If that is the case then I'll likely roll back the parts of this change that make those certain properties incompatible for now and save the big changes for later. (Because if I'm going to rev the major version, there are other changes I'd like to make, like renumbering)

Thoughts?