### PR TITLE
spi-hdlc-adapter: Reliability and Performance Improvements

### DIFF
--- a/tools/spi-hdlc-adapter/README.md
+++ b/tools/spi-hdlc-adapter/README.md
@@ -31,16 +31,19 @@ protocol document.
     inefficient.
 *   `--gpio-reset[=gpio-path]`: Specify a path to the Linux
     sysfs-exported GPIO directory for the `R̅E̅S̅` pin.
-*   `--spi-mode[=mode]`: Specify the SPI mode to use (0-3).
-*   `--spi-speed[=hertz]`: Specify the SPI speed in hertz.
+*   `--spi-mode[=mode]`: Specify the SPI mode to use (0-3). Default
+    value is `0`.
+*   `--spi-speed[=hertz]`: Specify the SPI speed in hertz. Default
+    value is `1000000` (1MHz).
 *   `--spi-cs-delay[=usec]`: Specify the delay after C̅S̅ assertion,
-    in microseconds.
+    in microseconds. Default is 20µs. Note that this may need to be
+    set to zero for spi-hdlc-adapter to work with some SPI drivers.
 *   `--spi-align-allowance[=n]`: Specify the the maximum number of 0xFF
     bytes to clip from start of MISO frame. This makes this tool usable
     with SPI slaves which have buggy SPI blocks that prepend up to
     three 0xFF bytes to the start of MISO frame. Default value is `0`.
-    Maximum value is `3`. *This must be set to `2` for chips in the
-    SiLabs EM35x family.*
+    Maximum value is `3`. *This must be set to at least `2` for chips
+    in the SiLabs EM35x family.*
 *   `--verbose`: Increase debug verbosity.
 *   `--help`: Print out usage information to `stdout` and exit.
 
@@ -70,3 +73,18 @@ procedure:
 1.  Set `R̅E̅S̅/direction` to `low`.
 2.  Sleep for 30ms.
 3.  Set `R̅E̅S̅/direction` to `high`.
+
+## Statistics ##
+
+Some simple usage statistics are printed out to syslog at exit and
+whenever the `SIGUSR1` signal is received. The easiest way to send
+that signal to `spi-hdlc-adapter` is like this:
+
+    # killall -sigusr1 spi-hdlc-adapter
+
+At which point you will see something like this in the syslogs:
+
+    spi-hdlc-adapter[5215]: INFO: sSpiFrameCount=45660
+    spi-hdlc-adapter[5215]: INFO: sSpiValidFrameCount=45643
+    spi-hdlc-adapter[5215]: INFO: sSpiGarbageFrameCount=17
+    spi-hdlc-adapter[5215]: INFO: sSpiDuplexFrameCount=20931


### PR DESCRIPTION
This change includes many improvements which reduce latency, increase throughput, and improve reliability.

The most significant change from this commit is addressing a frame corruption bug which would occasionally corrupt frames received from the slave during periods of congestion. This was occurring because `push_pull_spi()` was allowed to be called when `sSpiTxIsReady` was set, even if `sSpiRxPayloadSize` was not equal to zero. Under such circumstances the previously received frame would be corrupted. This change makes sure that `push_pull_spi()` does not get called until `sSpiRxPayloadSize` is zero.

`push_pull_spi()` now only performs a single SPI transaction (instead of two), which eliminates a significant amount of duplicated code. The call to `usleep()` has been removed entirely, along with the associated static `sSpiTransactionDelay`.

Statistics are now gathered and reported at exit. You can also induce `spi-hdlc-adapter` to dump its statistics while it is running by sending it a `SIGUSR1` signal.

This change also includes miscellaneous smaller changes.
