### PR TITLE
Change otPlatRadioSetDefaultTxPower return value type for parameter validation.

### DIFF
--- a/examples/drivers/windows/otLwf/radio.c
+++ b/examples/drivers/windows/otLwf/radio.c
@@ -758,7 +758,7 @@ error:
     return NT_SUCCESS(status) ? kThreadError_None : kThreadError_Failed;
 }
 
-void otPlatRadioSetDefaultTxPower(_In_ otInstance *otCtx, int8_t aPower)
+ThreadError otPlatRadioSetDefaultTxPower(_In_ otInstance *otCtx, int8_t aPower)
 {
     NT_ASSERT(otCtx);
     PMS_FILTER pFilter = otCtxToFilter(otCtx);
@@ -776,6 +776,8 @@ void otPlatRadioSetDefaultTxPower(_In_ otInstance *otCtx, int8_t aPower)
     {
         LogError(DRIVER_DEFAULT, "Set SPINEL_PROP_PHY_TX_POWER failed, %!STATUS!", status);
     }
+
+    return NT_SUCCESS(status) ? kThreadError_None : kThreadError_Failed;
 }
 
 inline USHORT getDstShortAddress(const UCHAR *frame)

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -786,9 +786,10 @@ ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, u
     return kThreadError_NotImplemented;
 }
 
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+ThreadError otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
 {
     // TODO: Create a proper implementation for this driver.
     (void)aInstance;
     (void)aPower;
+    return kThreadError_NotImplemented;
 }

--- a/examples/platforms/cc2650/radio.c
+++ b/examples/platforms/cc2650/radio.c
@@ -1214,11 +1214,12 @@ exit:
     return error;
 }
 
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+ThreadError otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
 {
     // TODO: Create a proper implementation for this driver.
     (void)aInstance;
     (void)aPower;
+    return kThreadError_NotImplemented;
 }
 
 /**

--- a/examples/platforms/da15000/radio.c
+++ b/examples/platforms/da15000/radio.c
@@ -410,11 +410,12 @@ ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, u
     return kThreadError_NotImplemented;
 }
 
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+ThreadError otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
 {
     // TODO: Create a proper implementation for this driver.
     (void)aInstance;
     (void)aPower;
+    return kThreadError_NotImplemented;
 }
 
 void da15000RadioProcess(otInstance *aInstance)

--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -462,11 +462,12 @@ ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, u
     return kThreadError_None;
 }
 
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+ThreadError otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
 {
     // TODO: Create a proper implementation for this driver.
     (void)aInstance;
     (void)aPower;
+    return kThreadError_NotImplemented;
 }
 
 void nrf5RadioProcess(otInstance *aInstance)

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -739,8 +739,9 @@ ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, u
     return kThreadError_NotImplemented;
 }
 
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+ThreadError otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
 {
     (void)aInstance;
     (void)aPower;
+    return kThreadError_NotImplemented;
 }

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -426,8 +426,10 @@ otRadioCaps otPlatRadioGetCaps(otInstance *aInstance);
  * @param[in] aInstance  The OpenThread instance structure.
  * @param[in] aPower     The Tx power to use in dBm.
  *
+ * @retval ::kThreadError_None         Successfully set default tx power.
+ * @retval ::kThreadError_InvalidArgs  aPower is not within the available range supported by hardware.
  */
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower);
+ThreadError otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower);
 
 /**
  * Get the status of promiscuous mode.

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -319,10 +319,11 @@ extern "C" {
         return kThreadError_NotImplemented;
     }
 
-    void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+    ThreadError otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
     {
         (void)aInstance;
         (void)aPower;
+        return kThreadError_NotImplemented;
     }
 
     //


### PR DESCRIPTION
Update the return value type of otPlatRadioSetDefaultTxPower to `ThreadError`, the purpose is to validate the parameter `aPower` range (in dBm). Different hardware supports different output power range. Does this make sense?