### PR TITLE
Fixed typo that is crashing the build when MAC logging is enabled

### DIFF
--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -537,7 +537,7 @@ extern "C" {
 #define otLogWarnMac(aInstance, aFormat, ...) otLogWarn(kLogRegionMac, aFormat, ## __VA_ARGS__)
 #define otLogInfoMac(aInstance, aFormat, ...) otLogInfo(kLogRegionMac, aFormat, ## __VA_ARGS__)
 #define otLogDebgMac(aInstance, aFormat, ...) otLogDebg(kLogRegionMac, aFormat, ## __VA_ARGS__)
-#define otLogDebgMacErr(aError, aFormat, ...) otLogWarn(kLogRegionMac, "Error %s: " aFormat, otThreadErrorToString(aError), ## __VA_ARGS__)
+#define otLogDebgMacErr(aInstance, aError, aFormat, ...) otLogWarn(kLogRegionMac, "Error %s: " aFormat, otThreadErrorToString(aError), ## __VA_ARGS__)
 #else
 #define otLogCritMac(aInstance, aFormat, ...)
 #define otLogWarnMac(aInstance, aFormat, ...)


### PR DESCRIPTION
Receiving the following error when enabling MAC logging as CONFIG parameter:

> CXX      thread/libopenthread_ftd_a-announce_begin_server.o
> In file included from /home/gr3yh0und/Downloads/openthread/examples/../src/core/mac/mac.cpp:50:0:
> /home/gr3yh0und/Downloads/openthread/examples/../src/core/mac/mac.cpp: In member function 'void Thread::Mac::Mac::ReceiveDoneTask(Thread::Mac::Frame*, ThreadError)':
> /home/gr3yh0und/Downloads/openthread/examples/../src/core/mac/mac.cpp:1479:40: error: expected ')' before 'error'
>          otLogDebgMacErr(GetInstance(), error, "Dropping received frame");