### PR TITLE
Add API function to check if MAC layer is during transmission procedure.

### DIFF
--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -137,6 +137,20 @@ OTAPI bool OTCALL otLinkIsEnergyScanInProgress(otInstance *aInstance);
 OTAPI ThreadError OTCALL otLinkSendDataRequest(otInstance *aInstance);
 
 /**
+ * This function indicates whether or not an IEEE 802.15.4 MAC is in the transmit state.
+ *
+ * MAC module is in the transmit state during CSMA/CA procedure, CCA, Data, Beacon or Data Request frame transmission
+ * and receiving an ACK of a transmitted frame. MAC module is not in the transmit state during transmission of an ACK
+ * frame or a Beacon Request frame.
+ *
+ * @param[in] aInstance A pointer to an OpenThread instance.
+ *
+ * @returns true if an IEEE 802.15.4 MAC is in the transmit state, false otherwise.
+ *
+ */
+OTAPI bool OTCALL otLinkIsInTransmitState(otInstance *aInstance);
+
+/**
  * Get the IEEE 802.15.4 channel.
  *
  * @param[in] aInstance A pointer to an OpenThread instance.

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -352,6 +352,10 @@ bool otLinkIsEnergyScanInProgress(otInstance *aInstance)
     return aInstance->mThreadNetif.GetMac().IsEnergyScanInProgress();
 }
 
+bool otLinkIsInTransmitState(otInstance *aInstance)
+{
+    return aInstance->mThreadNetif.GetMac().IsInTransmitState();
+}
 
 
 #ifdef __cplusplus

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -257,6 +257,11 @@ bool Mac::IsEnergyScanInProgress(void)
     return (mState == kStateEnergyScan) || (mPendingScanRequest == kScanTypeEnergy);
 }
 
+bool Mac::IsInTransmitState(void)
+{
+    return (mState == kStateTransmitData) || (mState == kStateTransmitBeacon);
+}
+
 void Mac::StartEnergyScan(void)
 {
     mState = kStateEnergyScan;

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -490,6 +490,16 @@ public:
     bool IsEnergyScanInProgress(void);
 
     /**
+     * This method returns if the MAC layer is in transmit state.
+     *
+     * The MAC layer is in transmit state during CSMA/CA, CCA, transmission of Data, Beacon or Data Request frames and
+     * receiving of ACK frames. The MAC layer is not in transmit state during transmission of ACK frames or Beacon
+     * Requests.
+     *
+     */
+    bool IsInTransmitState(void);
+
+    /**
      * This method registers a callback to provide received raw IEEE 802.15.4 frames.
      *
      * @param[in]  aPcapCallback     A pointer to a function that is called when receiving an IEEE 802.15.4 link frame or


### PR DESCRIPTION
I've created a function to check in MAC layer is in transmission state.
It looks like good idea to combine checking Active Scan, Energy Scan and Transmission states to single function like `otLinkGetState()`. Should I change the API to make it simpler or leave it as it is?