### PR TITLE
Ensure to retransmit a frame in case of abort or CCA failure errors

### DIFF
--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -82,6 +82,19 @@ enum
 
     kScanChannelsAll      = OT_CHANNEL_ALL,        ///< All channels.
     kScanDurationDefault  = 300,                   ///< Default interval between channels (milliseconds).
+
+    /**
+     * Maximum number of MAC layer tx attempts for an outbound direct frame.
+     *
+     */
+    kDirectFrameMacTxAttempts   = OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_DIRECT,
+
+    /**
+     * Maximum number of MAC layer tx attempts for an outbound indirect frame (for a sleepy child) after receiving
+     * a data request command (data poll) from the child.
+     *
+     */
+    kIndirectFrameMacTxAttempts = OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_PER_POLL,
 };
 
 /**

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -260,7 +260,7 @@ void MeshForwarder::ScheduleTransmissionTask(void)
         }
 
         mSendMessage = child.mIndirectSendInfo.mMessage;
-        mSendMessageMaxMacTxAttempts = kIndirectFrameMacTxAttempts;
+        mSendMessageMaxMacTxAttempts = Mac::kIndirectFrameMacTxAttempts;
 
         if (mSendMessage == NULL)
         {
@@ -300,7 +300,7 @@ void MeshForwarder::ScheduleTransmissionTask(void)
     if ((mSendMessage = GetDirectTransmission()) != NULL)
     {
         mNetif.GetMac().SendFrameRequest(mMacSender);
-        mSendMessageMaxMacTxAttempts = kDirectFrameMacTxAttempts;
+        mSendMessageMaxMacTxAttempts = Mac::kDirectFrameMacTxAttempts;
         ExitNow();
     }
 
@@ -1092,7 +1092,7 @@ ThreadError MeshForwarder::HandleFrameRequest(Mac::Frame &aFrame)
     {
         SendEmptyFrame(aFrame);
         aFrame.SetIsARetransmission(false);
-        aFrame.SetMaxTxAttempts(kDirectFrameMacTxAttempts);
+        aFrame.SetMaxTxAttempts(Mac::kDirectFrameMacTxAttempts);
         ExitNow();
     }
 

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -260,19 +260,6 @@ private:
     enum
     {
         /**
-         * Maximum number of MAC layer tx attempts for an outbound direct frame.
-         *
-         */
-        kDirectFrameMacTxAttempts   = OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_DIRECT,
-
-        /**
-         * Maximum number of MAC layer tx attempts for an outbound indirect frame (for a sleepy child) after receiving
-         * a data request command (data poll) from the child.
-         *
-         */
-        kIndirectFrameMacTxAttempts = OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_PER_POLL,
-
-        /**
          * Maximum number of tx attempts by `MeshForwarder` for an outbound indirect frame (for a sleepy child). The
          * `MeshForwader` attempts occur following the reception of a new data request command (a new data poll) from
          * the sleepy child.


### PR DESCRIPTION
This commit contains the following changes:

- We allow retransmission of a frame in case of abort or CCA failure
  tx errors (in addition to no-ack).

- We add new logs in `Mac:HandleSent() to indicate such errors.

- We set the `MaxTxAttemps` on "Beacon Request" and "Beacon" frames
  to ensure they are retransmitted (in case CCA/abort errors).