### PR TITLE
Increase buffer for SHA256 context in nrf52840

### DIFF
--- a/examples/Makefile-nrf52840
+++ b/examples/Makefile-nrf52840
@@ -41,13 +41,14 @@ OBJCOPY                         = arm-none-eabi-objcopy
 
 BuildJobs                      ?= 10
 
-configure_OPTIONS               = \
-    --enable-ftd                  \
-    --enable-cli                  \
-    --enable-ncp                  \
-    --enable-diag                 \
-    --with-examples=nrf52840      \
-    --with-platform-info=NRF52840 \
+configure_OPTIONS                                 = \
+    --enable-ftd                                    \
+    --enable-cli                                    \
+    --enable-ncp                                    \
+    --enable-diag                                   \
+    --with-examples=nrf52840                        \
+    --with-platform-info=NRF52840                   \
+    MBEDTLS_CPPFLAGS="$(NRF52840_MBEDTLS_CPPFLAGS)" \
     $(NULL)
 
 ifeq ($(DEFAULT_LOGGING),1)
@@ -108,6 +109,13 @@ endif
 
 TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..
 AbsTopSourceDir                 := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))..
+
+NRF52840_MBEDTLS_CPPFLAGS  = -DMBEDTLS_CONFIG_FILE='\"mbedtls-config.h\"'
+NRF52840_MBEDTLS_CPPFLAGS += -DMBEDTLS_USER_CONFIG_FILE='\"nrf52840-mbedtls-config.h\"'
+NRF52840_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/examples/platforms/nrf52840/crypto
+NRF52840_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls
+NRF52840_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls/repo/include
+NRF52840_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls/repo/include/mbedtls
 
 CONFIG_FILE      = OPENTHREAD_PROJECT_CORE_CONFIG_FILE='\"openthread-core-nrf52840-config.h\"'
 CONFIG_FILE_PATH = $(AbsTopSourceDir)/examples/platforms/nrf52840/

--- a/examples/platforms/nrf52840/crypto/nrf52840-mbedtls-config.h
+++ b/examples/platforms/nrf52840/crypto/nrf52840-mbedtls-config.h
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2017, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+ #define MBEDTLS_SHA256_ALT

--- a/examples/platforms/nrf52840/crypto/sha256_alt.h
+++ b/examples/platforms/nrf52840/crypto/sha256_alt.h
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (c) 2017, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MBEDTLS_SHA256_ALT_H
+#define MBEDTLS_SHA256_ALT_H
+
+#ifdef MBEDTLS_SHA256_ALT
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief          SHA-256 context structure
+ */
+typedef union
+{
+    struct
+    {
+        uint32_t total[2];          /*!< number of bytes processed  */
+        uint32_t state[8];          /*!< intermediate digest state  */
+        unsigned char buffer[64];   /*!< data block being processed */
+        int is224;                  /*!< 0 => SHA-256, else SHA-224 */
+    };
+    uint8_t reserved[256];
+}
+mbedtls_sha256_context;
+
+/**
+ * @brief Initialize SHA-256 context
+ *
+ * @param [in,out] ctx SHA-256 context to be initialized
+ */
+void mbedtls_sha256_init(mbedtls_sha256_context *ctx);
+
+/**
+ * @brief Clear SHA-256 context
+ *
+ * @param [in,out] ctx SHA-256 context to be cleared
+ */
+void mbedtls_sha256_free(mbedtls_sha256_context *ctx);
+
+/**
+ * @brief Clone (the state of) a SHA-256 context
+ *
+ * @param [out] dst The destination context
+ * @param [in] src The context to be cloned
+ */
+void mbedtls_sha256_clone(mbedtls_sha256_context *dst,
+                          const mbedtls_sha256_context *src);
+
+/**
+ * @brief SHA-256 context setup
+ *
+ * @param [in,out] ctx context to be initialized
+ * @param [in] is224 0 = use SHA256, 1 = use SHA224
+ */
+void mbedtls_sha256_starts(mbedtls_sha256_context *ctx, int is224);
+
+/**
+ * @brief SHA-256 process buffer
+ *
+ * @param [in,out] ctx SHA-256 context
+ * @param [in] input buffer holding the  data
+ * @param [in] ilen length of the input data
+ */
+void mbedtls_sha256_update(mbedtls_sha256_context *ctx, const unsigned char *input, size_t ilen);
+
+/**
+ * @brief SHA-256 final digest
+ *
+ * @param [in,out] ctx SHA-256 context
+ * @param [out] output SHA-224/256 checksum result
+ */
+void mbedtls_sha256_finish(mbedtls_sha256_context *ctx, unsigned char output[32]);
+
+/* Internal use */
+void mbedtls_sha256_process(mbedtls_sha256_context *ctx, const unsigned char data[64]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_SHA256_ALT */
+
+/* MBEDTLS_SHA256_ALT was used to redifine context structure. Undefine it now to enable default mbedTLS implementation. */
+#undef MBEDTLS_SHA256_ALT
+
+#endif /* MBEDTLS_SHA256_ALT_H */


### PR DESCRIPTION
This PR increases the memory reserved for SHA256 context for Nordic's platform.

The context size required by SHA Crypto accelerator used by Nordic is larger than the default from mbedTLS, so we need a larger buffer. Unfortunately the Crypto engine license does not allow us to make it public, hence need for a change like this. 
Other possible solution is to create a patch that would be applied directly on mbedTLS header when building OT for nrf52840, but I find the patching solution a little bit more complex and trickier to maintain.