### PR TITLE
Fix bugs in Announce

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -589,7 +589,7 @@ ThreadError otThreadSetEnabled(otInstance *aInstance, bool aEnabled)
     {
         VerifyOrExit(aInstance->mThreadNetif.GetMac().GetPanId() != Mac::kPanIdBroadcast,
                      error = kThreadError_InvalidState);
-        error = aInstance->mThreadNetif.GetMle().Start(true);
+        error = aInstance->mThreadNetif.GetMle().Start(true, false);
     }
     else
     {

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -488,13 +488,15 @@ public:
     /**
      * This method starts the MLE protocol operation.
      *
-     * @param[in]  aEnableReattach  True to enable reattach process using stored dataset, False not.
+     * @param[in]  aEnableReattach True if reattach using stored dataset, or False if not.
+     * @param[in]  aAnnounceAttach True if attach on the announced thread network with newer active timestamp,
+     *                             or False if not.
      *
      * @retval kThreadError_None     Successfully started the protocol operation.
      * @retval kThreadError_Already  The protocol operation was already started.
      *
      */
-    ThreadError Start(bool aEnableReattach);
+    ThreadError Start(bool aEnableReattach, bool aAnnounceAttach);
 
     /**
      * This method stops the MLE protocol operation.


### PR DESCRIPTION
This PR is to 1) fix MED device not sending out announce message due to PR #1339 ; 2) conformance with specification - attach process other than re-synchronization process after receiving Announce message with newer activetimestamp.

Chapter 4.8.1 in specification
> If the received value is newer and the channel and/or PAN ID in the Announce message differ
> from those currently in use, the receiving device attempts to attach using the channel and
> PAN ID received from the Announce message.

Helps to pass 9.2.12