### PR TITLE
spinel-cli: Fixes for spinel documentation bugs.

### DIFF
--- a/doc/spinel-protocol-src/spinel-prop-core.md
+++ b/doc/spinel-protocol-src/spinel-prop-core.md
@@ -242,7 +242,7 @@ of `STATUS_ALREADY`.
 ### PROP 112: PROP_STREAM_DEBUG {#prop-stream-debug}
 
 * Type: Read-Only-Stream
-* Packed-Encoding: `U`
+* Packed-Encoding: `D`
 
 Octets: |    *n*
 --------|------------

--- a/tools/spinel-cli/README.md
+++ b/tools/spinel-cli/README.md
@@ -30,10 +30,9 @@ The power of this tool is three fold:
 ### Package Installation
 
 ```
-sudo easy_install pip
-sudo pip install --user pyserial
-sudo pip install --user ipaddress
-sudo pip install --user scapy==2.3.2
+# From openthread root
+cd tools/spinel-cli
+sudo python setup.py install
 ```
 
 ## Usage

--- a/tools/spinel-cli/spinel/codec.py
+++ b/tools/spinel-cli/spinel/codec.py
@@ -674,7 +674,7 @@ class SpinelPropertyHandler(SpinelCodec):
     def IPv6_ICMP_PING_OFFLOAD(self, _, payload):
         return self.parse_b(payload)
 
-    def STREAM_DEBUG(self, _, payload): return self.parse_U(payload)
+    def STREAM_DEBUG(self, _, payload): return self.parse_D(payload)
 
     def STREAM_RAW(self, _, payload): return self.parse_D(payload)
 


### PR DESCRIPTION
Updates the spinel documentation to properly reflect PROP_STREAM_DEBUG = 'D' rather than 'U'.
Updates spinel-cli.py to reflect this choice (@darconeous approved).

This also fixes a side effect where sniffer.py breaks due to the following exception output:

```
Traceback (most recent call last):
  File "/usr/local/automation/openthread/tools/spinel-cli/spinel/codec.py", line 925, in parse_rx
    handler = SPINEL_COMMAND_DISPATCH[cmd_id]
KeyError: 3
```