### PR TITLE
Attempt a new data poll message in case of tx failure of an earlier one

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -82,6 +82,7 @@ MeshForwarder::MeshForwarder(ThreadNetif &aThreadNetif):
     mRestorePanId(Mac::kPanIdBroadcast),
     mScanning(false),
     mBacktoBackPollTimeoutCounter(0),
+    mBackToBackPollTxFailures(0),
     mNetif(aThreadNetif),
     mSrcMatchEnabled(false)
 {
@@ -1769,6 +1770,24 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, ThreadError aError)
         {
             mPollTimer.Stop();
             mNetif.GetMle().BecomeDetached();
+        }
+        else
+        {
+            switch (aError)
+            {
+            case kThreadError_None:
+                mBackToBackPollTxFailures = 0;
+                break;
+
+            default:
+                if (mBackToBackPollTxFailures < kMaxPollRetxAttempts)
+                {
+                    mBackToBackPollTxFailures++;
+                    SendMacDataRequest();
+                }
+
+                break;
+            }
         }
     }
 

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -264,6 +264,7 @@ private:
         kStateUpdatePeriod     = 1000,  ///< State update period in milliseconds.
         kDataRequestRetryDelay = 200,   ///< Retry delay in milliseconds (for sending data request if no buffer).
         kQuickPollsAfterTimout = 5,     ///< Maximum number of quick data poll tx in case of back-to-back poll timeouts.
+        kMaxPollRetxAttempts   = 5,     ///< Maximum number of retransmit attempts of data poll (mac data request).
     };
 
     enum
@@ -370,6 +371,7 @@ private:
     bool mScanning;
 
     uint8_t mBacktoBackPollTimeoutCounter;
+    uint8_t mBackToBackPollTxFailures;
 
     ThreadNetif &mNetif;
 


### PR DESCRIPTION
This commit adds a new logic in `MeshForwarder` so that if the
transmission of a MAC data request (data poll) message fails
(e.g., no ack received from parent), a new data poll message is
sent, up to a fixed number of attempts (`kMaxPollRetxAttempts`).

This change helps a sleepy child to detect (more quickly) if its
parent is unresponsive (e.g, turned off or no longer available) and
try to attach to a new parent.