### PR TITLE
`NcpSpi`: Improve the error handling on spinel SPI tx path

### DIFF
--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -289,6 +289,8 @@ ThreadError NcpSpi::PrepareNextSpiSendFrame(void)
     if (errorCode != kThreadError_None)
     {
         mTxState = kTxStateIdle;
+        mPrepareTxFrameTask.Post();
+        ExitNow();
     }
 
     // Remove the frame from tx buffer and inform the base

--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -114,7 +114,6 @@ private:
 
     uint8_t mEmptySendFrame[kSpiHeaderLength];
     uint8_t mEmptyReceiveFrame[kSpiHeaderLength];
-
 };
 
 }  // namespace Thread


### PR DESCRIPTION
In the unlikely case where `otPlatSpiSlavePrepareTransaction()` returns
a failure code it is ensured that the spinel frame is not removed from
the tx buffer and instead the task which prepares the next SPI send
frame is posted again.