### PR TITLE
FFD device not advertise when attempts to attach any/same partition

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -477,6 +477,11 @@ ThreadError Mle::BecomeChild(otMleAttachFilter aFilter)
     if (aFilter != kMleAttachBetterPartition)
     {
         memset(&mParent, 0, sizeof(mParent));
+
+        if (mDeviceMode & ModeTlv::kModeFFD)
+        {
+            mNetif.GetMle().StopAdvertiseTimer();
+        }
     }
 
     if (aFilter == kMleAttachAnyPartition)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -504,6 +504,11 @@ bool MleRouter::HandleAdvertiseTimer(void)
     return true;
 }
 
+void MleRouter::StopAdvertiseTimer(void)
+{
+    mAdvertiseTimer.Stop();
+}
+
 void MleRouter::ResetAdvertiseInterval(void)
 {
     VerifyOrExit(mDeviceState == kDeviceStateRouter || mDeviceState == kDeviceStateLeader,);

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -637,6 +637,7 @@ private:
     ThreadError HandleDiscoveryRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     ThreadError ProcessRouteTlv(const RouteTlv &aRoute);
+    void StopAdvertiseTimer(void);
     void ResetAdvertiseInterval(void);
     ThreadError SendAddressSolicit(ThreadStatusTlv::Status aStatus);
     ThreadError SendAddressRelease(void);

--- a/src/core/thread/mle_router_mtd.hpp
+++ b/src/core/thread/mle_router_mtd.hpp
@@ -163,6 +163,7 @@ private:
     ThreadError HandleNetworkDataUpdateRouter(void) { return kThreadError_None; }
     ThreadError HandleDiscoveryRequest(const Message &, const Ip6::MessageInfo &) { return kThreadError_Drop; }
 
+    void StopAdvertiseTimer(void) { }
     ThreadError ProcessRouteTlv(const RouteTlv &aRoute) { (void)aRoute; return kThreadError_None; }
 };
 


### PR DESCRIPTION
To fix some unstable cert scenarios in which Harness would verify MLE advertisement after reattach