### PR TITLE
Send commissioner set after petitioning

### DIFF
--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -636,6 +636,8 @@ void Commissioner::HandleLeaderPetitionResponse(Coap::Header *aHeader, Message *
     mTransmitAttempts = 0;
     mTimer.Start(Timer::SecToMsec(kKeepAliveTimeout) / 2);
 
+    SendCommissionerSet();
+
 exit:
 
     if (retransmit)


### PR DESCRIPTION
If AddJoiner (or other joiner list methods) are called before the
commissioner manages to finish the petitioning, then network steering
data is not properly updated and joiners don't join the network.