### PR TITLE
Enable dynamic log level selection

### DIFF
--- a/doc/spinel-protocol-src/spinel-prop-debug.md
+++ b/doc/spinel-protocol-src/spinel-prop-debug.md
@@ -9,3 +9,25 @@ is intended for testing the assert functionality of
 underlying platform/NCP. Assert should ideally cause the
 NCP to reset, but if `assert` is not supported or disabled
 boolean value of `false` is returned in response.
+
+### PROP 16385: SPINEL_PROP_DEBUG_NCP_LOG_LEVEL {#prop-debug-ncp-log-level}
+* Type: Read-Write
+* Packed-Encoding: `C`
+
+Provides access to the NCP log level. Currently defined values are (which follows
+the RFC 5424):
+
+ *  0: Emergency (emerg).
+ *  1: Alert (alert).
+ *  2: Critical (crit).
+ *  3: Error (err).
+ *  4: Warning (warn).
+ *  5: Notice (notice).
+ *  6: Information (info).
+ *  7: Debug (debug).
+
+ If the NCP supports dynamic log level control, setting this property
+ changes the log level accordingly. Getting the value returns the current
+ log level.  If the dynamic log level control is not supported, setting this
+ property returns a LAST_STATUS with SPINEL_STATUS_INVALID_COMMAND_FOR_PROP
+ status.

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -78,7 +78,7 @@ void enableReceiver(void)
 {
     if (!sIsReceiverEnabled)
     {
-        otLogInfoPlat("Enabling receiver", NULL);
+        otLogInfoPlat(sInstance, "Enabling receiver", NULL);
 
         // flush rxfifo
         HWREG(RFCORE_SFR_RFST) = RFCORE_SFR_RFST_INSTR_FLUSHRX;
@@ -94,7 +94,7 @@ void disableReceiver(void)
 {
     if (sIsReceiverEnabled)
     {
-        otLogInfoPlat("Disabling receiver", NULL);
+        otLogInfoPlat(sInstance, "Disabling receiver", NULL);
 
         while (HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_TX_ACTIVE);
 
@@ -124,7 +124,7 @@ void setChannel(uint8_t channel)
             enabled = true;
         }
 
-        otLogInfoPlat("Channel=%d", channel);
+        otLogInfoPlat(sInstance, "Channel=%d", channel);
 
         HWREG(RFCORE_XREG_FREQCTRL) = 11 + (channel - 11) * 5;
         sChannel = channel;
@@ -151,7 +151,7 @@ void otPlatRadioSetPanId(otInstance *aInstance, uint16_t panid)
 {
     (void)aInstance;
 
-    otLogInfoPlat("PANID=%X", panid);
+    otLogInfoPlat(sInstance, "PANID=%X", panid);
 
     HWREG(RFCORE_FFSM_PAN_ID0) = panid & 0xFF;
     HWREG(RFCORE_FFSM_PAN_ID1) = panid >> 8;
@@ -161,7 +161,7 @@ void otPlatRadioSetExtendedAddress(otInstance *aInstance, uint8_t *address)
 {
     (void)aInstance;
 
-    otLogInfoPlat("ExtAddr=%X%X%X%X%X%X%X%X",
+    otLogInfoPlat(sInstance, "ExtAddr=%X%X%X%X%X%X%X%X",
                   address[7], address[6], address[5], address[4], address[3], address[2], address[1], address[0]);
 
     for (int i = 0; i < 8; i++)
@@ -174,7 +174,7 @@ void otPlatRadioSetShortAddress(otInstance *aInstance, uint16_t address)
 {
     (void)aInstance;
 
-    otLogInfoPlat("ShortAddr=%X", address);
+    otLogInfoPlat(sInstance, "ShortAddr=%X", address);
 
     HWREG(RFCORE_FFSM_SHORT_ADDR0) = address & 0xFF;
     HWREG(RFCORE_FFSM_SHORT_ADDR1) = address >> 8;
@@ -205,7 +205,7 @@ void cc2538RadioInit(void)
     // default: SRCMATCH.SRC_MATCH_EN(1), SRCMATCH.AUTOPEND(1),
     // SRCMATCH.PEND_DATAREQ_ONLY(1), RFCORE_XREG_FRMCTRL1_PENDING_OR(0)
 
-    otLogInfoPlat("Initialized", NULL);
+    otLogInfoPlat(sInstance, "Initialized", NULL);
 }
 
 bool otPlatRadioIsEnabled(otInstance *aInstance)
@@ -218,7 +218,7 @@ ThreadError otPlatRadioEnable(otInstance *aInstance)
 {
     if (!otPlatRadioIsEnabled(aInstance))
     {
-        otLogDebgPlat("State=kStateSleep", NULL);
+        otLogDebgPlat(sInstance, "State=kStateSleep", NULL);
         sState = kStateSleep;
     }
 
@@ -229,7 +229,7 @@ ThreadError otPlatRadioDisable(otInstance *aInstance)
 {
     if (otPlatRadioIsEnabled(aInstance))
     {
-        otLogDebgPlat("State=kStateDisabled", NULL);
+        otLogDebgPlat(sInstance, "State=kStateDisabled", NULL);
         sState = kStateDisabled;
     }
 
@@ -243,7 +243,7 @@ ThreadError otPlatRadioSleep(otInstance *aInstance)
 
     if (sState == kStateSleep || sState == kStateReceive)
     {
-        otLogDebgPlat("State=kStateSleep", NULL);
+        otLogDebgPlat(sInstance, "State=kStateSleep", NULL);
         error = kThreadError_None;
         sState = kStateSleep;
         disableReceiver();
@@ -259,7 +259,7 @@ ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 
     if (sState != kStateDisabled)
     {
-        otLogDebgPlat("State=kStateReceive", NULL);
+        otLogDebgPlat(sInstance, "State=kStateReceive", NULL);
 
         error = kThreadError_None;
         sState = kStateReceive;
@@ -315,7 +315,7 @@ ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
 
         while (HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_TX_ACTIVE);
 
-        otLogDebgPlat("Transmitted %d bytes", aPacket->mLength);
+        otLogDebgPlat(sInstance, "Transmitted %d bytes", aPacket->mLength);
     }
 
 exit:
@@ -350,7 +350,7 @@ void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable)
 {
     (void)aInstance;
 
-    otLogInfoPlat("PromiscuousMode=%d", aEnable ? 1 : 0);
+    otLogInfoPlat(sInstance, "PromiscuousMode=%d", aEnable ? 1 : 0);
 
     if (aEnable)
     {
@@ -395,7 +395,7 @@ void readFrame(void)
         HWREG(RFCORE_SFR_RFST) = RFCORE_SFR_RFST_INSTR_FLUSHRX;
         HWREG(RFCORE_SFR_RFST) = RFCORE_SFR_RFST_INSTR_FLUSHRX;
 
-        otLogDebgPlat("Dropping %d received bytes (Invalid CRC)", length);
+        otLogDebgPlat(sInstance, "Dropping %d received bytes (Invalid CRC)", length);
     }
 
     // check for rxfifo overflow
@@ -431,7 +431,7 @@ void cc2538RadioProcess(otInstance *aInstance)
             if (((HWREG(RFCORE_XREG_FRMFILT0) & RFCORE_XREG_FRMFILT0_FRAME_FILTER_EN) == 0) ||
                 (sReceiveFrame.mLength > IEEE802154_ACK_LENGTH))
             {
-                otLogDebgPlat("Received %d bytes", sReceiveFrame.mLength);
+                otLogDebgPlat(sInstance, "Received %d bytes", sReceiveFrame.mLength);
                 otPlatRadioReceiveDone(aInstance, &sReceiveFrame, sReceiveError);
             }
         }
@@ -443,7 +443,7 @@ void cc2538RadioProcess(otInstance *aInstance)
         {
             if (sTransmitError != kThreadError_None)
             {
-                otLogDebgPlat("Transmit failed ErrorCode=%d", sTransmitError);
+                otLogDebgPlat(sInstance, "Transmit failed ErrorCode=%d", sTransmitError);
             }
 
             sState = kStateReceive;
@@ -604,8 +604,8 @@ int8_t findSrcMatchAvailEntry(bool aShort)
     uint32_t shortEnableStatus = getSrcMatchEntriesEnableStatus(true);
     uint32_t extEnableStatus = getSrcMatchEntriesEnableStatus(false);
 
-    otLogDebgPlat("Short enable status: 0x%x", shortEnableStatus);
-    otLogDebgPlat("Ext enable status: 0x%x", extEnableStatus);
+    otLogDebgPlat(sInstance, "Short enable status: 0x%x", shortEnableStatus);
+    otLogDebgPlat(sInstance, "Ext enable status: 0x%x", extEnableStatus);
 
     if (aShort)
     {
@@ -653,7 +653,7 @@ void otPlatRadioEnableSrcMatch(otInstance *aInstance, bool aEnable)
 {
     (void)aInstance;
 
-    otLogInfoPlat("EnableSrcMatch=%d", aEnable ? 1 : 0);
+    otLogInfoPlat(sInstance, "EnableSrcMatch=%d", aEnable ? 1 : 0);
 
     if (aEnable)
     {
@@ -675,7 +675,7 @@ ThreadError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16
     uint32_t *addr = (uint32_t *)RFCORE_FFSM_SRCADDRESS_TABLE;
     (void)aInstance;
 
-    otLogDebgPlat("Add ShortAddr entry: %d", entry);
+    otLogDebgPlat(sInstance, "Add ShortAddr entry: %d", entry);
 
     VerifyOrExit(entry >= 0, error = kThreadError_NoBufs);
 
@@ -699,7 +699,7 @@ ThreadError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t 
     uint32_t *addr = (uint32_t *)RFCORE_FFSM_SRCADDRESS_TABLE;
     (void)aInstance;
 
-    otLogDebgPlat("Add ExtAddr entry: %d", entry);
+    otLogDebgPlat(sInstance, "Add ExtAddr entry: %d", entry);
 
     VerifyOrExit(entry >= 0, error = kThreadError_NoBufs);
 
@@ -722,7 +722,7 @@ ThreadError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint
     int8_t entry = findSrcMatchShortEntry(aShortAddress);
     (void)aInstance;
 
-    otLogDebgPlat("Clear ShortAddr entry: %d", entry);
+    otLogDebgPlat(sInstance, "Clear ShortAddr entry: %d", entry);
 
     VerifyOrExit(entry >= 0, error = kThreadError_NoAddress);
 
@@ -738,7 +738,7 @@ ThreadError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_
     int8_t entry = findSrcMatchExtEntry(aExtAddress);
     (void)aInstance;
 
-    otLogDebgPlat("Clear ExtAddr entry: %d", entry);
+    otLogDebgPlat(sInstance, "Clear ExtAddr entry: %d", entry);
 
     VerifyOrExit(entry >= 0, error = kThreadError_NoAddress);
 
@@ -754,7 +754,7 @@ void otPlatRadioClearSrcMatchShortEntries(otInstance *aInstance)
     uint32_t *addrAutoPendEn = (uint32_t *)RFCORE_FFSM_SRCSHORTPENDEN0;
     (void)aInstance;
 
-    otLogDebgPlat("Clear ShortAddr entries", NULL);
+    otLogDebgPlat(sInstance, "Clear ShortAddr entries", NULL);
 
     for (uint8_t i = 0; i < RFCORE_XREG_SRCMATCH_ENABLE_STATUS_SIZE; i++)
     {
@@ -769,7 +769,7 @@ void otPlatRadioClearSrcMatchExtEntries(otInstance *aInstance)
     uint32_t *addrAutoPendEn = (uint32_t *)RFCORE_FFSM_SRCEXTPENDEN0;
     (void)aInstance;
 
-    otLogDebgPlat("Clear ExtAddr entries", NULL);
+    otLogDebgPlat(sInstance, "Clear ExtAddr entries", NULL);
 
     for (uint8_t i = 0; i < RFCORE_XREG_SRCMATCH_ENABLE_STATUS_SIZE; i++)
     {

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -36,6 +36,7 @@
 #define OPENTHREAD_INSTANCE_H_
 
 #include "openthread/types.h"
+#include "openthread/platform/logging.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -154,7 +155,7 @@ OTAPI uint32_t OTCALL otGetDeviceIfIndex(otInstance *aInstance);
  */
 OTAPI uint32_t OTCALL otGetCompartmentId(otInstance *aInstance);
 
-#else
+#else // OTDLL
 
 #ifdef OPENTHREAD_MULTIPLE_INSTANCE
 /**
@@ -173,7 +174,7 @@ OTAPI uint32_t OTCALL otGetCompartmentId(otInstance *aInstance);
  *
  */
 otInstance *otInstanceInit(void *aInstanceBuffer, size_t *aInstanceBufferSize);
-#else
+#else // OPENTHREAD_MULTIPLE_INSTANCE
 /**
  * This function initializes the static instance of the OpenThread library.
  *
@@ -184,7 +185,7 @@ otInstance *otInstanceInit(void *aInstanceBuffer, size_t *aInstanceBufferSize);
  *
  */
 otInstance *otInstanceInit(void);
-#endif
+#endif // OPENTHREAD_MULTIPLE_INSTANCE
 
 /**
  * This function disables the OpenThread library.
@@ -196,7 +197,7 @@ otInstance *otInstanceInit(void);
  */
 void otInstanceFinalize(otInstance *aInstance);
 
-#endif
+#endif // OTDLL
 
 /**
  * This function pointer is called to notify certain configuration or state changes within OpenThread.
@@ -260,6 +261,28 @@ OTAPI void OTCALL otInstanceFactoryReset(otInstance *aInstance);
  *
  */
 ThreadError otInstanceErasePersistentInfo(otInstance *aInstance);
+
+/**
+ * This function returns the current dynamic log level.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ *
+ * @returns the currently set dynamic log level.
+ *
+ */
+otLogLevel otGetDynamicLogLevel(otInstance *aInstance);
+
+/**
+ * This function sets the dynamic log level.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ * @param[in]  aLogLevel The dynamic log level.
+ *
+ * @retval kThreadError_None         The log level was changed successfully.
+ * @retval kThreadError_NotCapable   The dynamic log level is not supported.
+ *
+ */
+ThreadError otSetDynamicLogLevel(otInstance *aInstance, otLogLevel aLogLevel);
 
 /**
  * @}

--- a/include/openthread/platform/logging-windows.h
+++ b/include/openthread/platform/logging-windows.h
@@ -112,7 +112,7 @@
 // USEPREFIX(LogFuncExitNDIS, "<--- %!FUNC!");
 // FUNC LogFuncExitNDIS{LEVEL=TRACE_LEVEL_VERBOSE}(FLAGS, EXP);
 // USESUFFIX(LogFuncExitNDIS, " %!NDIS_STATUS!", EXP);
-// end_wpp  
+// end_wpp
 
 // begin_wpp config
 // USEPREFIX(LogFuncExitWIN, "<--- %!FUNC!");
@@ -393,23 +393,23 @@
 // ==MEM==
 
 // begin_wpp config
-// USEPREFIX (otLogCritMem, "MEM%!SPACE!");
-// otLogCritMem{LEVEL=TRACE_LEVEL_ERROR,FLAGS=OT_MEM}(MSG, ...);
+// USEPREFIX (otLogCritMem, "[%p]MEM%!SPACE!", CTX);
+// otLogCritMem{LEVEL=TRACE_LEVEL_ERROR,FLAGS=OT_MEM}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogWarnMem, "MEM%!SPACE!");
-// otLogWarnMem{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_MEM}(MSG, ...);
+// USEPREFIX (otLogWarnMem, "[%p]MEM%!SPACE!", CTX);
+// otLogWarnMem{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_MEM}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogInfoMem, "MEM%!SPACE!");
-// otLogInfoMem{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_MEM}(MSG, ...);
+// USEPREFIX (otLogInfoMem, "[%p]MEM%!SPACE!", CTX);
+// otLogInfoMem{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_MEM}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogDebgMem, "MEM%!SPACE!");
-// otLogDebgMem{LEVEL=TRACE_LEVEL_VERBOSE,FLAGS=OT_MEM}(MSG, ...);
+// USEPREFIX (otLogDebgMem, "[%p]MEM%!SPACE!", CTX);
+// otLogDebgMem{LEVEL=TRACE_LEVEL_VERBOSE,FLAGS=OT_MEM}(CTX, MSG, ...);
 // end_wpp
 
 // ==DUMP==

--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -33,6 +33,12 @@
 
 #define WPP_NAME "instance_api.tmh"
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/instance.h"
 #include "openthread/platform/misc.h"
 #include "openthread/platform/settings.h"
@@ -61,6 +67,9 @@ otInstance::otInstance(void) :
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
     , mApplicationCoapServer(mIp6.mUdp, OT_DEFAULT_COAP_PORT)
 #endif // OPENTHREAD_ENABLE_APPLICATION_COAP
+#if OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
+    , mLogLevel(static_cast<otLogLevel>(OPENTHREAD_CONFIG_LOG_LEVEL))
+#endif // OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
 {
 }
 
@@ -211,6 +220,35 @@ ThreadError otInstanceErasePersistentInfo(otInstance *aInstance)
     otPlatSettingsWipe(aInstance);
 
 exit:
+    return error;
+}
+
+otLogLevel otGetDynamicLogLevel(otInstance *aInstance)
+{
+    otLogLevel logLevel;
+
+#if OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
+    logLevel =  aInstance->mLogLevel;
+#else
+    logLevel = static_cast<otLogLevel>(OPENTHREAD_CONFIG_LOG_LEVEL);
+    (void)aInstance;
+#endif
+
+    return logLevel;
+}
+
+ThreadError otSetDynamicLogLevel(otInstance *aInstance, otLogLevel aLogLevel)
+{
+    ThreadError error = kThreadError_None;
+
+#if OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
+    aInstance->mLogLevel = aLogLevel;
+#else
+    error = kThreadError_NotCapable;
+    (void)aInstance;
+    (void)aLogLevel;
+#endif
+
     return error;
 }
 

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -127,7 +127,7 @@ ThreadError otLinkRawSleep(otInstance *aInstance)
 
     VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = kThreadError_InvalidState);
 
-    otLogDebgPlat("LinkRaw Sleep");
+    otLogDebgPlat(aInstance, "LinkRaw Sleep");
 
     error = otPlatRadioSleep(aInstance);
 
@@ -137,7 +137,7 @@ exit:
 
 ThreadError otLinkRawReceive(otInstance *aInstance, uint8_t aChannel, otLinkRawReceiveDone aCallback)
 {
-    otLogDebgPlat("LinkRaw Recv (Channel %d)", aChannel);
+    otLogDebgPlat(aInstance, "LinkRaw Recv (Channel %d)", aChannel);
     return aInstance->mLinkRaw.Receive(aChannel, aCallback);
 }
 
@@ -155,7 +155,7 @@ exit:
 
 ThreadError otLinkRawTransmit(otInstance *aInstance, RadioPacket *aPacket, otLinkRawTransmitDone aCallback)
 {
-    otLogDebgPlat("LinkRaw Transmit (%d bytes)", aPacket->mLength);
+    otLogDebgPlat(aInstance, "LinkRaw Transmit (%d bytes)", aPacket->mLength);
     return aInstance->mLinkRaw.Transmit(aPacket, aCallback);
 }
 
@@ -371,7 +371,7 @@ ThreadError LinkRaw::DoTransmit(RadioPacket *aPacket)
     // to fire if we don't get a transmit done callback in time.
     if (static_cast<Mac::Frame *>(aPacket)->GetAckRequest())
     {
-        otLogDebgPlat("LinkRaw Starting AckTimeout Timer");
+        otLogDebgPlat(aInstance, "LinkRaw Starting AckTimeout Timer");
         mTimerReason = kTimerReasonAckTimeout;
         mTimer.Start(kAckTimeout);
     }
@@ -383,7 +383,7 @@ ThreadError LinkRaw::DoTransmit(RadioPacket *aPacket)
 
 void LinkRaw::InvokeTransmitDone(RadioPacket *aPacket, bool aFramePending, ThreadError aError)
 {
-    otLogDebgPlat("LinkRaw Transmit Done (err=0x%x)", aError);
+    otLogDebgPlat(aInstance, "LinkRaw Transmit Done (err=0x%x)", aError);
 
 #if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ACK_TIMEOUT
     mTimer.Stop();
@@ -419,7 +419,7 @@ void LinkRaw::InvokeTransmitDone(RadioPacket *aPacket, bool aFramePending, Threa
 
     if (mTransmitDoneCallback)
     {
-        otLogDebgPlat("LinkRaw Invoke Transmit Done");
+        otLogDebgPlat(aInstance, "LinkRaw Invoke Transmit Done");
         mTransmitDoneCallback(&mInstance, aPacket, aFramePending, aError);
         mTransmitDoneCallback = NULL;
     }
@@ -553,7 +553,7 @@ void LinkRaw::StartCsmaBackoff(void)
     delay.mMs = backoff / 1000UL;
     delay.mUs = backoff - (delay.mMs * 1000UL);
 
-    otLogDebgPlat("LinkRaw Starting RetransmitTimeout Timer (%d ms)", backoff);
+    otLogDebgPlat(aInstance, "LinkRaw Starting RetransmitTimeout Timer (%d ms)", backoff);
     mTimerReason = kTimerReasonRetransmitTimeout;
     otPlatUsecAlarmStartAt(&mInstance, &now, &delay, &HandleTimer, this);
 #else // OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_BACKOFF_TIMER

--- a/src/core/common/logging.cpp
+++ b/src/core/common/logging.cpp
@@ -44,7 +44,8 @@
 #include <common/logging.hpp>
 
 #ifndef WINDOWS_LOGGING
-#define otLogDump(aFormat, ...) otPlatLog(aLogLevel, aLogRegion, aFormat OPENTHREAD_CONFIG_LOG_SUFFIX, ## __VA_ARGS__)
+#define otLogDump(aFormat, ...)                                             \
+    _otPlatLog(aInstance, aLogLevel, aLogRegion, aFormat OPENTHREAD_CONFIG_LOG_SUFFIX, ## __VA_ARGS__)
 #endif
 
 #ifdef __cplusplus
@@ -61,7 +62,8 @@ extern "C" {
  * @param[in]  aLength     Number of bytes in the buffer.
  *
  */
-static void DumpLine(otLogLevel aLogLevel, otLogRegion aLogRegion, const void *aBuf, const size_t aLength)
+static void DumpLine(otInstance *aInstance, otLogLevel aLogLevel, otLogRegion aLogRegion, const void *aBuf,
+                     const size_t aLength)
 {
     char buf[80];
     char *cur = buf;
@@ -109,9 +111,12 @@ static void DumpLine(otLogLevel aLogLevel, otLogRegion aLogRegion, const void *a
     }
 
     otLogDump("%s", buf);
+
+    (void)aInstance;
 }
 
-void otDump(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aId, const void *aBuf, const size_t aLength)
+void otDump(otInstance *aInstance, otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aId, const void *aBuf,
+            const size_t aLength)
 {
     size_t idlen = strlen(aId);
     const size_t width = 72;
@@ -137,7 +142,7 @@ void otDump(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aId, const
 
     for (size_t i = 0; i < aLength; i += 16)
     {
-        DumpLine(aLogLevel, aLogRegion, (uint8_t *)(aBuf) + i, (aLength - i) < 16 ? (aLength - i) : 16);
+        DumpLine(aInstance, aLogLevel, aLogRegion, (uint8_t *)(aBuf) + i, (aLength - i) < 16 ? (aLength - i) : 16);
     }
 
     cur = buf;
@@ -150,9 +155,9 @@ void otDump(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aId, const
 
     otLogDump("%s", buf);
 }
-#else
-void otDump(otLogLevel, otLogRegion, const char *, const void *, const size_t) {}
-#endif
+#else // OPENTHREAD_CONFIG_LOG_PKT_DUMP
+void otDump(otInstance *, otLogLevel, otLogRegion, const char *, const void *, const size_t) {}
+#endif // OPENTHREAD_CONFIG_LOG_PKT_DUMP
 
 #ifdef OPENTHREAD_CONFIG_LOG_PREPEND_LEVEL
 const char *otLogLevelToString(otLogLevel aLevel)

--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -39,6 +39,8 @@
 #include <string.h>
 
 #include <openthread-core-config.h>
+#include "openthread/types.h"
+#include "openthread/instance.h"
 #include "openthread/platform/logging.h"
 
 #ifdef WINDOWS_LOGGING
@@ -74,9 +76,10 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OPENTHREAD_LOG_LEVEL_CRIT
-#define otLogCrit(aRegion, aFormat, ...)  _otLogFormatter(kLogLevelCrit, aRegion, aFormat, ## __VA_ARGS__)
+#define otLogCrit(aInstance, aRegion, aFormat, ...)                         \
+    _otLogFormatter(aInstane, kLogLevelCrit, aRegion, aFormat, ## __VA_ARGS__)
 #else
-#define otLogCrit(aRegion, aFormat, ...)
+#define otLogCrit(aInstance, aRegion, aFormat, ...)
 #endif
 
 /**
@@ -90,9 +93,10 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OPENTHREAD_LOG_LEVEL_WARN
-#define otLogWarn(aRegion, aFormat, ...)  _otLogFormatter(kLogLevelWarn, aRegion, aFormat, ## __VA_ARGS__)
+#define otLogWarn(aInstance, aRegion, aFormat, ...)                         \
+    _otLogFormatter(aInstance, kLogLevelWarn, aRegion, aFormat, ## __VA_ARGS__)
 #else
-#define otLogWarn(aRegion, aFormat, ...)
+#define otLogWarn(aInstance, aRegion, aFormat, ...)
 #endif
 
 /**
@@ -106,9 +110,10 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OPENTHREAD_LOG_LEVEL_INFO
-#define otLogInfo(aRegion, aFormat, ...)  _otLogFormatter(kLogLevelInfo, aRegion, aFormat, ## __VA_ARGS__)
+#define otLogInfo(aInstance, aRegion, aFormat, ...)                         \
+    _otLogFormatter(aInstance, kLogLevelInfo, aRegion, aFormat, ## __VA_ARGS__)
 #else
-#define otLogInfo(aRegion, aFormat, ...)
+#define otLogInfo(aInstance, aRegion, aFormat, ...)
 #endif
 
 /**
@@ -122,9 +127,10 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OPENTHREAD_LOG_LEVEL_DEBG
-#define otLogDebg(aRegion, aFormat, ...)  _otLogFormatter(kLogLevelDebg, aRegion, aFormat, ## __VA_ARGS__)
+#define otLogDebg(aInstance, aRegion, aFormat, ...)                         \
+    _otLogFormatter(aInstance, kLogLevelDebg, aRegion, aFormat, ## __VA_ARGS__)
 #else
-#define otLogDebg(aRegion, aFormat, ...)
+#define otLogDebg(aInstance, aRegion, aFormat, ...)
 #endif
 
 #ifndef WINDOWS_LOGGING
@@ -169,10 +175,10 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_API == 1
-#define otLogCritApi(aInstance, aFormat, ...) otLogCrit(kLogRegionApi, aFormat, ## __VA_ARGS__)
-#define otLogWarnApi(aInstance, aFormat, ...) otLogWarn(kLogRegionApi, aFormat, ## __VA_ARGS__)
-#define otLogInfoApi(aInstance, aFormat, ...) otLogInfo(kLogRegionApi, aFormat, ## __VA_ARGS__)
-#define otLogDebgApi(aInstance, aFormat, ...) otLogDebg(kLogRegionApi, aFormat, ## __VA_ARGS__)
+#define otLogCritApi(aInstance, aFormat, ...) otLogCrit(aInstance, kLogRegionApi, aFormat, ## __VA_ARGS__)
+#define otLogWarnApi(aInstance, aFormat, ...) otLogWarn(aInstance, kLogRegionApi, aFormat, ## __VA_ARGS__)
+#define otLogInfoApi(aInstance, aFormat, ...) otLogInfo(aInstance, kLogRegionApi, aFormat, ## __VA_ARGS__)
+#define otLogDebgApi(aInstance, aFormat, ...) otLogDebg(aInstance, kLogRegionApi, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCritApi(aInstance, aFormat, ...)
 #define otLogWarnApi(aInstance, aFormat, ...)
@@ -220,10 +226,10 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MLE == 1
-#define otLogCritMeshCoP(aInstance, aFormat, ...) otLogCrit(kLogRegionMeshCoP, aFormat, ## __VA_ARGS__)
-#define otLogWarnMeshCoP(aInstance, aFormat, ...) otLogWarn(kLogRegionMeshCoP, aFormat, ## __VA_ARGS__)
-#define otLogInfoMeshCoP(aInstance, aFormat, ...) otLogInfo(kLogRegionMeshCoP, aFormat, ## __VA_ARGS__)
-#define otLogDebgMeshCoP(aInstance, aFormat, ...) otLogDebg(kLogRegionMeshCoP, aFormat, ## __VA_ARGS__)
+#define otLogCritMeshCoP(aInstance, aFormat, ...) otLogCrit(aInstance, kLogRegionMeshCoP, aFormat, ## __VA_ARGS__)
+#define otLogWarnMeshCoP(aInstance, aFormat, ...) otLogWarn(aInstance, kLogRegionMeshCoP, aFormat, ## __VA_ARGS__)
+#define otLogInfoMeshCoP(aInstance, aFormat, ...) otLogInfo(aInstance, kLogRegionMeshCoP, aFormat, ## __VA_ARGS__)
+#define otLogDebgMeshCoP(aInstance, aFormat, ...) otLogDebg(aInstance, kLogRegionMeshCoP, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCritMeshCoP(aInstance, aFormat, ...)
 #define otLogWarnMeshCoP(aInstance, aFormat, ...)
@@ -276,11 +282,12 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MLE == 1
-#define otLogCritMle(aInstance, aFormat, ...) otLogCrit(kLogRegionMle, aFormat, ## __VA_ARGS__)
-#define otLogWarnMle(aInstance, aFormat, ...) otLogWarn(kLogRegionMle, aFormat, ## __VA_ARGS__)
-#define otLogWarnMleErr(aInstance, aError, aFormat, ...) otLogWarn(kLogRegionMac, "Error %s: " aFormat, otThreadErrorToString(aError), ## __VA_ARGS__)
-#define otLogInfoMle(aInstance, aFormat, ...) otLogInfo(kLogRegionMle, aFormat, ## __VA_ARGS__)
-#define otLogDebgMle(aInstance, aFormat, ...) otLogDebg(kLogRegionMle, aFormat, ## __VA_ARGS__)
+#define otLogCritMle(aInstance, aFormat, ...) otLogCrit(aInstance, kLogRegionMle, aFormat, ## __VA_ARGS__)
+#define otLogWarnMle(aInstance, aFormat, ...) otLogWarn(aInstance, kLogRegionMle, aFormat, ## __VA_ARGS__)
+#define otLogWarnMleErr(aInstance, aError, aFormat, ...)                    \
+    otLogWarn(aInstance, kLogRegionMac, "Error %s: " aFormat, otThreadErrorToString(aError), ## __VA_ARGS__)
+#define otLogInfoMle(aInstance, aFormat, ...) otLogInfo(aInstance, kLogRegionMle, aFormat, ## __VA_ARGS__)
+#define otLogDebgMle(aInstance, aFormat, ...) otLogDebg(aInstance, kLogRegionMle, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCritMle(aInstance, aFormat, ...)
 #define otLogWarnMle(aInstance, aFormat, ...)
@@ -329,10 +336,10 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_ARP == 1
-#define otLogCritArp(aInstance, aFormat, ...) otLogCrit(kLogRegionArp, aFormat, ## __VA_ARGS__)
-#define otLogWarnArp(aInstance, aFormat, ...) otLogWarn(kLogRegionArp, aFormat, ## __VA_ARGS__)
-#define otLogInfoArp(aInstance, aFormat, ...) otLogInfo(kLogRegionArp, aFormat, ## __VA_ARGS__)
-#define otLogDebgArp(aInstance, aFormat, ...) otLogDebg(kLogRegionArp, aFormat, ## __VA_ARGS__)
+#define otLogCritArp(aInstance, aFormat, ...) otLogCrit(aInstance, kLogRegionArp, aFormat, ## __VA_ARGS__)
+#define otLogWarnArp(aInstance, aFormat, ...) otLogWarn(aInstance, kLogRegionArp, aFormat, ## __VA_ARGS__)
+#define otLogInfoArp(aInstance, aFormat, ...) otLogInfo(aInstance, kLogRegionArp, aFormat, ## __VA_ARGS__)
+#define otLogDebgArp(aInstance, aFormat, ...) otLogDebg(aInstance, kLogRegionArp, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCritArp(aInstance, aFormat, ...)
 #define otLogWarnArp(aInstance, aFormat, ...)
@@ -380,10 +387,10 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_NETDATA == 1
-#define otLogCritNetData(aInstance, aFormat, ...) otLogCrit(kLogRegionNetData, aFormat, ## __VA_ARGS__)
-#define otLogWarnNetData(aInstance, aFormat, ...) otLogWarn(kLogRegionNetData, aFormat, ## __VA_ARGS__)
-#define otLogInfoNetData(aInstance, aFormat, ...) otLogInfo(kLogRegionNetData, aFormat, ## __VA_ARGS__)
-#define otLogDebgNetData(aInstance, aFormat, ...) otLogDebg(kLogRegionNetData, aFormat, ## __VA_ARGS__)
+#define otLogCritNetData(aInstance, aFormat, ...) otLogCrit(aInstance, kLogRegionNetData, aFormat, ## __VA_ARGS__)
+#define otLogWarnNetData(aInstance, aFormat, ...) otLogWarn(aInstance, kLogRegionNetData, aFormat, ## __VA_ARGS__)
+#define otLogInfoNetData(aInstance, aFormat, ...) otLogInfo(aInstance, kLogRegionNetData, aFormat, ## __VA_ARGS__)
+#define otLogDebgNetData(aInstance, aFormat, ...) otLogDebg(aInstance, kLogRegionNetData, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCritNetData(aInstance, aFormat, ...)
 #define otLogWarnNetData(aInstance, aFormat, ...)
@@ -431,10 +438,10 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_ICMP == 1
-#define otLogCritIcmp(aInstance, aFormat, ...) otLogCrit(kLogRegionIcmp, aFormat, ## __VA_ARGS__)
-#define otLogWarnIcmp(aInstance, aFormat, ...) otLogWarn(kLogRegionIcmp, aFormat, ## __VA_ARGS__)
-#define otLogInfoIcmp(aInstance, aFormat, ...) otLogInfo(kLogRegionIcmp, aFormat, ## __VA_ARGS__)
-#define otLogDebgIcmp(aInstance, aFormat, ...) otLogDebg(kLogRegionIcmp, aFormat, ## __VA_ARGS__)
+#define otLogCritIcmp(aInstance, aFormat, ...) otLogCrit(aInstance, kLogRegionIcmp, aFormat, ## __VA_ARGS__)
+#define otLogWarnIcmp(aInstance, aFormat, ...) otLogWarn(aInstance, kLogRegionIcmp, aFormat, ## __VA_ARGS__)
+#define otLogInfoIcmp(aInstance, aFormat, ...) otLogInfo(aInstance, kLogRegionIcmp, aFormat, ## __VA_ARGS__)
+#define otLogDebgIcmp(aInstance, aFormat, ...) otLogDebg(aInstance, kLogRegionIcmp, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCritIcmp(aInstance, aFormat, ...)
 #define otLogWarnIcmp(aInstance, aFormat, ...)
@@ -482,10 +489,10 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_IP6 == 1
-#define otLogCritIp6(aInstance, aFormat, ...) otLogCrit(kLogRegionIp6, aFormat, ## __VA_ARGS__)
-#define otLogWarnIp6(aInstance, aFormat, ...) otLogWarn(kLogRegionIp6, aFormat, ## __VA_ARGS__)
-#define otLogInfoIp6(aInstance, aFormat, ...) otLogInfo(kLogRegionIp6, aFormat, ## __VA_ARGS__)
-#define otLogDebgIp6(aInstance, aFormat, ...) otLogDebg(kLogRegionIp6, aFormat, ## __VA_ARGS__)
+#define otLogCritIp6(aInstance, aFormat, ...) otLogCrit(aInstance, kLogRegionIp6, aFormat, ## __VA_ARGS__)
+#define otLogWarnIp6(aInstance, aFormat, ...) otLogWarn(aInstance, kLogRegionIp6, aFormat, ## __VA_ARGS__)
+#define otLogInfoIp6(aInstance, aFormat, ...) otLogInfo(aInstance, kLogRegionIp6, aFormat, ## __VA_ARGS__)
+#define otLogDebgIp6(aInstance, aFormat, ...) otLogDebg(aInstance, kLogRegionIp6, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCritIp6(aInstance, aFormat, ...)
 #define otLogWarnIp6(aInstance, aFormat, ...)
@@ -533,11 +540,12 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MAC == 1
-#define otLogCritMac(aInstance, aFormat, ...) otLogCrit(kLogRegionMac, aFormat, ## __VA_ARGS__)
-#define otLogWarnMac(aInstance, aFormat, ...) otLogWarn(kLogRegionMac, aFormat, ## __VA_ARGS__)
-#define otLogInfoMac(aInstance, aFormat, ...) otLogInfo(kLogRegionMac, aFormat, ## __VA_ARGS__)
-#define otLogDebgMac(aInstance, aFormat, ...) otLogDebg(kLogRegionMac, aFormat, ## __VA_ARGS__)
-#define otLogDebgMacErr(aInstance, aError, aFormat, ...) otLogWarn(kLogRegionMac, "Error %s: " aFormat, otThreadErrorToString(aError), ## __VA_ARGS__)
+#define otLogCritMac(aInstance, aFormat, ...) otLogCrit(aInstance, kLogRegionMac, aFormat, ## __VA_ARGS__)
+#define otLogWarnMac(aInstance, aFormat, ...) otLogWarn(aInstance, kLogRegionMac, aFormat, ## __VA_ARGS__)
+#define otLogInfoMac(aInstance, aFormat, ...) otLogInfo(aInstance, kLogRegionMac, aFormat, ## __VA_ARGS__)
+#define otLogDebgMac(aInstance, aFormat, ...) otLogDebg(aInstance, kLogRegionMac, aFormat, ## __VA_ARGS__)
+#define otLogDebgMacErr(aInstance, aError, aFormat, ...)                    \
+    otLogWarn(aInstance, kLogRegionMac, "Error %s: " aFormat, otThreadErrorToString(aError), ## __VA_ARGS__)
 #else
 #define otLogCritMac(aInstance, aFormat, ...)
 #define otLogWarnMac(aInstance, aFormat, ...)
@@ -586,15 +594,15 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MEM == 1
-#define otLogCritMem(aFormat, ...) otLogCrit(kLogRegionMem, aFormat, ## __VA_ARGS__)
-#define otLogWarnMem(aFormat, ...) otLogWarn(kLogRegionMem, aFormat, ## __VA_ARGS__)
-#define otLogInfoMem(aFormat, ...) otLogInfo(kLogRegionMem, aFormat, ## __VA_ARGS__)
-#define otLogDebgMem(aFormat, ...) otLogDebg(kLogRegionMem, aFormat, ## __VA_ARGS__)
+#define otLogCritMem(aInstance, aFormat, ...) otLogCrit(aInstance, kLogRegionMem, aFormat, ## __VA_ARGS__)
+#define otLogWarnMem(aInstance, aFormat, ...) otLogWarn(aInstance, kLogRegionMem, aFormat, ## __VA_ARGS__)
+#define otLogInfoMem(aInstance, aFormat, ...) otLogInfo(aInstance, kLogRegionMem, aFormat, ## __VA_ARGS__)
+#define otLogDebgMem(aInstance, aFormat, ...) otLogDebg(aInstance, kLogRegionMem, aFormat, ## __VA_ARGS__)
 #else
-#define otLogCritMem(aFormat, ...)
-#define otLogWarnMem(aFormat, ...)
-#define otLogInfoMem(aFormat, ...)
-#define otLogDebgMem(aFormat, ...)
+#define otLogCritMem(aInstance, aFormat, ...)
+#define otLogWarnMem(aInstance, aFormat, ...)
+#define otLogInfoMem(aInstance, aFormat, ...)
+#define otLogDebgMem(aInstance, aFormat, ...)
 #endif
 
 /**
@@ -637,10 +645,10 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_NETDIAG == 1
-#define otLogCritNetDiag(aInstance, aFormat, ...) otLogCrit(kLogRegionNetDiag, aFormat, ## __VA_ARGS__)
-#define otLogWarnNetDiag(aInstance, aFormat, ...) otLogWarn(kLogRegionNetDiag, aFormat, ## __VA_ARGS__)
-#define otLogInfoNetDiag(aInstance, aFormat, ...) otLogInfo(kLogRegionNetDiag, aFormat, ## __VA_ARGS__)
-#define otLogDebgNetDiag(aInstance, aFormat, ...) otLogDebg(kLogRegionNetDiag, aFormat, ## __VA_ARGS__)
+#define otLogCritNetDiag(aInstance, aFormat, ...) otLogCrit(aInstance, kLogRegionNetDiag, aFormat, ## __VA_ARGS__)
+#define otLogWarnNetDiag(aInstance, aFormat, ...) otLogWarn(aInstance, kLogRegionNetDiag, aFormat, ## __VA_ARGS__)
+#define otLogInfoNetDiag(aInstance, aFormat, ...) otLogInfo(aInstance, kLogRegionNetDiag, aFormat, ## __VA_ARGS__)
+#define otLogDebgNetDiag(aInstance, aFormat, ...) otLogDebg(aInstance, kLogRegionNetDiag, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCritNetDiag(aInstance, aFormat, ...)
 #define otLogWarnNetDiag(aInstance, aFormat, ...)
@@ -658,7 +666,8 @@ extern "C" {
  *
  */
 #if OPENTHREAD_ENABLE_CERT_LOG
-#define otLogCertMeshCoP(aInstance, aFormat, ...) _otLogFormatter(kLogLevelNone, kLogRegionMeshCoP, aFormat, ## __VA_ARGS__)
+#define otLogCertMeshCoP(aInstance, aFormat, ...)                           \
+    _otLogFormatter(aInstance, kLogLevelNone, kLogRegionMeshCoP, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCertMeshCoP(aInstance, aFormat, ...)
 #endif
@@ -703,15 +712,15 @@ extern "C" {
 *
 */
 #if OPENTHREAD_CONFIG_LOG_PLATFORM == 1
-#define otLogCritPlat(aFormat, ...) otLogCrit(kLogRegionPlatform, aFormat, ## __VA_ARGS__)
-#define otLogWarnPlat(aFormat, ...) otLogWarn(kLogRegionPlatform, aFormat, ## __VA_ARGS__)
-#define otLogInfoPlat(aFormat, ...) otLogInfo(kLogRegionPlatform, aFormat, ## __VA_ARGS__)
-#define otLogDebgPlat(aFormat, ...) otLogDebg(kLogRegionPlatform, aFormat, ## __VA_ARGS__)
+#define otLogCritPlat(aInstance, aFormat, ...) otLogCrit(aInstance, kLogRegionPlatform, aFormat, ## __VA_ARGS__)
+#define otLogWarnPlat(aInstance, aFormat, ...) otLogWarn(aInstance, kLogRegionPlatform, aFormat, ## __VA_ARGS__)
+#define otLogInfoPlat(aInstance, aFormat, ...) otLogInfo(aInstance, kLogRegionPlatform, aFormat, ## __VA_ARGS__)
+#define otLogDebgPlat(aInstance, aFormat, ...) otLogDebg(aInstance, kLogRegionPlatform, aFormat, ## __VA_ARGS__)
 #else
-#define otLogCritPlat(aFormat, ...)
-#define otLogWarnPlat(aFormat, ...)
-#define otLogInfoPlat(aFormat, ...)
-#define otLogDebgPlat(aFormat, ...)
+#define otLogCritPlat(aInstance, aFormat, ...)
+#define otLogWarnPlat(aInstance, aFormat, ...)
+#define otLogInfoPlat(aInstance, aFormat, ...)
+#define otLogDebgPlat(aInstance, aFormat, ...)
 #endif
 
 #endif // WINDOWS_LOGGING
@@ -728,9 +737,10 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OPENTHREAD_LOG_LEVEL_CRIT
-#define otDumpCrit(aRegion, aId, aBuf, aLength)  otDump(kLogLevelCrit, aRegion, aId, aBuf, aLength)
+#define otDumpCrit(aInstance, aRegion, aId, aBuf, aLength)                  \
+    otDump(aInstance, kLogLevelCrit, aRegion, aId, aBuf, aLength)
 #else
-#define otDumpCrit(aRegion, aId, aBuf, aLength)
+#define otDumpCrit(aInstance, aRegion, aId, aBuf, aLength)
 #endif
 
 /**
@@ -745,9 +755,10 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OPENTHREAD_LOG_LEVEL_WARN
-#define otDumpWarn(aRegion, aId, aBuf, aLength)  otDump(kLogLevelWarn, aRegion, aId, aBuf, aLength)
+#define otDumpWarn(aInstance, aRegion, aId, aBuf, aLength)                  \
+    otDump(aInstance, kLogLevelWarn, aRegion, aId, aBuf, aLength)
 #else
-#define otDumpWarn(aRegion, aId, aBuf, aLength)
+#define otDumpWarn(aInstance, aRegion, aId, aBuf, aLength)
 #endif
 
 /**
@@ -762,9 +773,10 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OPENTHREAD_LOG_LEVEL_INFO
-#define otDumpInfo(aRegion, aId, aBuf, aLength)  otDump(kLogLevelInfo, aRegion, aId, aBuf, aLength)
+#define otDumpInfo(aInstance, aRegion, aId, aBuf, aLength)                  \
+    otDump(aInstance, kLogLevelInfo, aRegion, aId, aBuf, aLength)
 #else
-#define otDumpInfo(aRegion, aId, aBuf, aLength)
+#define otDumpInfo(aInstance, aRegion, aId, aBuf, aLength)
 #endif
 
 /**
@@ -779,9 +791,10 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OPENTHREAD_LOG_LEVEL_DEBG
-#define otDumpDebg(aRegion, aId, aBuf, aLength)  otDump(kLogLevelDebg, aRegion, aId, aBuf, aLength)
+#define otDumpDebg(aInstance, aRegion, aId, aBuf, aLength)                  \
+    otDump(aInstance, kLogLevelDebg, aRegion, aId, aBuf, aLength)
 #else
-#define otDumpDebg(aRegion, aId, aBuf, aLength)
+#define otDumpDebg(aInstance, aRegion, aId, aBuf, aLength)
 #endif
 
 /**
@@ -828,15 +841,15 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_NETDATA == 1
-#define otDumpCritNetData(aId, aBuf, aLength) otDumpCrit(kLogRegionNetData, aId, aBuf, aLength)
-#define otDumpWarnNetData(aId, aBuf, aLength) otDumpWarn(kLogRegionNetData, aId, aBuf, aLength)
-#define otDumpInfoNetData(aId, aBuf, aLength) otDumpInfo(kLogRegionNetData, aId, aBuf, aLength)
-#define otDumpDebgNetData(aId, aBuf, aLength) otDumpDebg(kLogRegionNetData, aId, aBuf, aLength)
+#define otDumpCritNetData(aInstance, aId, aBuf, aLength) otDumpCrit(aInstance, kLogRegionNetData, aId, aBuf, aLength)
+#define otDumpWarnNetData(aInstance, aId, aBuf, aLength) otDumpWarn(aInstance, kLogRegionNetData, aId, aBuf, aLength)
+#define otDumpInfoNetData(aInstance, aId, aBuf, aLength) otDumpInfo(aInstance, kLogRegionNetData, aId, aBuf, aLength)
+#define otDumpDebgNetData(aInstance, aId, aBuf, aLength) otDumpDebg(aInstance, kLogRegionNetData, aId, aBuf, aLength)
 #else
-#define otDumpCritNetData(aId, aBuf, aLength)
-#define otDumpWarnNetData(aId, aBuf, aLength)
-#define otDumpInfoNetData(aId, aBuf, aLength)
-#define otDumpDebgNetData(aId, aBuf, aLength)
+#define otDumpCritNetData(aInstance, aId, aBuf, aLength)
+#define otDumpWarnNetData(aInstance, aId, aBuf, aLength)
+#define otDumpInfoNetData(aInstance, aId, aBuf, aLength)
+#define otDumpDebgNetData(aInstance, aId, aBuf, aLength)
 #endif
 
 /**
@@ -883,15 +896,15 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MLE == 1
-#define otDumpCritMle(aId, aBuf, aLength) otDumpCrit(kLogRegionMle, aId, aBuf, aLength)
-#define otDumpWarnMle(aId, aBuf, aLength) otDumpWarn(kLogRegionMle, aId, aBuf, aLength)
-#define otDumpInfoMle(aId, aBuf, aLength) otDumpInfo(kLogRegionMle, aId, aBuf, aLength)
-#define otDumpDebgMle(aId, aBuf, aLength) otDumpDebg(kLogRegionMle, aId, aBuf, aLength)
+#define otDumpCritMle(aInstance, aId, aBuf, aLength) otDumpCrit(aInstance, kLogRegionMle, aId, aBuf, aLength)
+#define otDumpWarnMle(aInstance, aId, aBuf, aLength) otDumpWarn(aInstance, kLogRegionMle, aId, aBuf, aLength)
+#define otDumpInfoMle(aInstance, aId, aBuf, aLength) otDumpInfo(aInstance, kLogRegionMle, aId, aBuf, aLength)
+#define otDumpDebgMle(aInstance, aId, aBuf, aLength) otDumpDebg(aInstance, kLogRegionMle, aId, aBuf, aLength)
 #else
-#define otDumpCritMle(aId, aBuf, aLength)
-#define otDumpWarnMle(aId, aBuf, aLength)
-#define otDumpInfoMle(aId, aBuf, aLength)
-#define otDumpDebgMle(aId, aBuf, aLength)
+#define otDumpCritMle(aInstance, aId, aBuf, aLength)
+#define otDumpWarnMle(aInstance, aId, aBuf, aLength)
+#define otDumpInfoMle(aInstance, aId, aBuf, aLength)
+#define otDumpDebgMle(aInstance, aId, aBuf, aLength)
 #endif
 
 /**
@@ -938,15 +951,15 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_ARP == 1
-#define otDumpCritArp(aId, aBuf, aLength) otDumpCrit(kLogRegionArp, aId, aBuf, aLength)
-#define otDumpWarnArp(aId, aBuf, aLength) otDumpWarn(kLogRegionArp, aId, aBuf, aLength)
-#define otDumpInfoArp(aId, aBuf, aLength) otDumpInfo(kLogRegionArp, aId, aBuf, aLength)
-#define otDumpDebgArp(aId, aBuf, aLength) otDumpDebg(kLogRegionArp, aId, aBuf, aLength)
+#define otDumpCritArp(aInstance, aId, aBuf, aLength) otDumpCrit(aInstance, kLogRegionArp, aId, aBuf, aLength)
+#define otDumpWarnArp(aInstance, aId, aBuf, aLength) otDumpWarn(aInstance, kLogRegionArp, aId, aBuf, aLength)
+#define otDumpInfoArp(aInstance, aId, aBuf, aLength) otDumpInfo(aInstance, kLogRegionArp, aId, aBuf, aLength)
+#define otDumpDebgArp(aInstance, aId, aBuf, aLength) otDumpDebg(aInstance, kLogRegionArp, aId, aBuf, aLength)
 #else
-#define otDumpCritArp(aId, aBuf, aLength)
-#define otDumpWarnArp(aId, aBuf, aLength)
-#define otDumpInfoArp(aId, aBuf, aLength)
-#define otDumpDebgArp(aId, aBuf, aLength)
+#define otDumpCritArp(aInstance, aId, aBuf, aLength)
+#define otDumpWarnArp(aInstance, aId, aBuf, aLength)
+#define otDumpInfoArp(aInstance, aId, aBuf, aLength)
+#define otDumpDebgArp(aInstance, aId, aBuf, aLength)
 #endif
 
 /**
@@ -993,15 +1006,15 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_ICMP == 1
-#define otDumpCritIcmp(aId, aBuf, aLength) otDumpCrit(kLogRegionIcmp, aId, aBuf, aLength)
-#define otDumpWarnIcmp(aId, aBuf, aLength) otDumpWarn(kLogRegionIcmp, aId, aBuf, aLength)
-#define otDumpInfoIcmp(aId, aBuf, aLength) otDumpInfo(kLogRegionIcmp, aId, aBuf, aLength)
-#define otDumpDebgIcmp(aId, aBuf, aLength) otDumpDebg(kLogRegionIcmp, aId, aBuf, aLength)
+#define otDumpCritIcmp(aInstance, aId, aBuf, aLength) otDumpCrit(aInstance, kLogRegionIcmp, aId, aBuf, aLength)
+#define otDumpWarnIcmp(aInstance, aId, aBuf, aLength) otDumpWarn(aInstance, kLogRegionIcmp, aId, aBuf, aLength)
+#define otDumpInfoIcmp(aInstance, aId, aBuf, aLength) otDumpInfo(aInstance, kLogRegionIcmp, aId, aBuf, aLength)
+#define otDumpDebgIcmp(aInstance, aId, aBuf, aLength) otDumpDebg(aInstance, kLogRegionIcmp, aId, aBuf, aLength)
 #else
-#define otDumpCritIcmp(aId, aBuf, aLength)
-#define otDumpWarnIcmp(aId, aBuf, aLength)
-#define otDumpInfoIcmp(aId, aBuf, aLength)
-#define otDumpDebgIcmp(aId, aBuf, aLength)
+#define otDumpCritIcmp(aInstance, aId, aBuf, aLength)
+#define otDumpWarnIcmp(aInstance, aId, aBuf, aLength)
+#define otDumpInfoIcmp(aInstance, aId, aBuf, aLength)
+#define otDumpDebgIcmp(aInstance, aId, aBuf, aLength)
 #endif
 
 /**
@@ -1048,15 +1061,15 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_IP6 == 1
-#define otDumpCritIp6(aId, aBuf, aLength) otDumpCrit(kLogRegionIp6, aId, aBuf, aLength)
-#define otDumpWarnIp6(aId, aBuf, aLength) otDumpWarn(kLogRegionIp6, aId, aBuf, aLength)
-#define otDumpInfoIp6(aId, aBuf, aLength) otDumpInfo(kLogRegionIp6, aId, aBuf, aLength)
-#define otDumpDebgIp6(aId, aBuf, aLength) otDumpDebg(kLogRegionIp6, aId, aBuf, aLength)
+#define otDumpCritIp6(aInstance, aId, aBuf, aLength) otDumpCrit(aInstance, kLogRegionIp6, aId, aBuf, aLength)
+#define otDumpWarnIp6(aInstance, aId, aBuf, aLength) otDumpWarn(aInstance, kLogRegionIp6, aId, aBuf, aLength)
+#define otDumpInfoIp6(aInstance, aId, aBuf, aLength) otDumpInfo(aInstance, kLogRegionIp6, aId, aBuf, aLength)
+#define otDumpDebgIp6(aInstance, aId, aBuf, aLength) otDumpDebg(aInstance, kLogRegionIp6, aId, aBuf, aLength)
 #else
-#define otDumpCritIp6(aId, aBuf, aLength)
-#define otDumpWarnIp6(aId, aBuf, aLength)
-#define otDumpInfoIp6(aId, aBuf, aLength)
-#define otDumpDebgIp6(aId, aBuf, aLength)
+#define otDumpCritIp6(aInstance, aId, aBuf, aLength)
+#define otDumpWarnIp6(aInstance, aId, aBuf, aLength)
+#define otDumpInfoIp6(aInstance, aId, aBuf, aLength)
+#define otDumpDebgIp6(aInstance, aId, aBuf, aLength)
 #endif
 
 /**
@@ -1103,15 +1116,15 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MAC == 1
-#define otDumpCritMac(aId, aBuf, aLength) otDumpCrit(kLogRegionMac, aId, aBuf, aLength)
-#define otDumpWarnMac(aId, aBuf, aLength) otDumpWarn(kLogRegionMac, aId, aBuf, aLength)
-#define otDumpInfoMac(aId, aBuf, aLength) otDumpInfo(kLogRegionMac, aId, aBuf, aLength)
-#define otDumpDebgMac(aId, aBuf, aLength) otDumpDebg(kLogRegionMac, aId, aBuf, aLength)
+#define otDumpCritMac(aInstance, aId, aBuf, aLength) otDumpCrit(aInstance, kLogRegionMac, aId, aBuf, aLength)
+#define otDumpWarnMac(aInstance, aId, aBuf, aLength) otDumpWarn(aInstance, kLogRegionMac, aId, aBuf, aLength)
+#define otDumpInfoMac(aInstance, aId, aBuf, aLength) otDumpInfo(aInstance, kLogRegionMac, aId, aBuf, aLength)
+#define otDumpDebgMac(aInstance, aId, aBuf, aLength) otDumpDebg(aInstance, kLogRegionMac, aId, aBuf, aLength)
 #else
-#define otDumpCritMac(aId, aBuf, aLength)
-#define otDumpWarnMac(aId, aBuf, aLength)
-#define otDumpInfoMac(aId, aBuf, aLength)
-#define otDumpDebgMac(aId, aBuf, aLength)
+#define otDumpCritMac(aInstance, aId, aBuf, aLength)
+#define otDumpWarnMac(aInstance, aId, aBuf, aLength)
+#define otDumpInfoMac(aInstance, aId, aBuf, aLength)
+#define otDumpDebgMac(aInstance, aId, aBuf, aLength)
 #endif
 
 /**
@@ -1158,15 +1171,15 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MEM == 1
-#define otDumpCritMem(aId, aBuf, aLength) otDumpCrit(kLogRegionMem, aId, aBuf, aLength)
-#define otDumpWarnMem(aId, aBuf, aLength) otDumpWarn(kLogRegionMem, aId, aBuf, aLength)
-#define otDumpInfoMem(aId, aBuf, aLength) otDumpInfo(kLogRegionMem, aId, aBuf, aLength)
-#define otDumpDebgMem(aId, aBuf, aLength) otDumpDebg(kLogRegionMem, aId, aBuf, aLength)
+#define otDumpCritMem(aInstance, aId, aBuf, aLength) otDumpCrit(aInstance, kLogRegionMem, aId, aBuf, aLength)
+#define otDumpWarnMem(aInstance, aId, aBuf, aLength) otDumpWarn(aInstance, kLogRegionMem, aId, aBuf, aLength)
+#define otDumpInfoMem(aInstance, aId, aBuf, aLength) otDumpInfo(aInstance, kLogRegionMem, aId, aBuf, aLength)
+#define otDumpDebgMem(aInstance, aId, aBuf, aLength) otDumpDebg(aInstance, kLogRegionMem, aId, aBuf, aLength)
 #else
-#define otDumpCritMem(aId, aBuf, aLength)
-#define otDumpWarnMem(aId, aBuf, aLength)
-#define otDumpInfoMem(aId, aBuf, aLength)
-#define otDumpDebgMem(aId, aBuf, aLength)
+#define otDumpCritMem(aInstance, aId, aBuf, aLength)
+#define otDumpWarnMem(aInstance, aId, aBuf, aLength)
+#define otDumpInfoMem(aInstance, aId, aBuf, aLength)
+#define otDumpDebgMem(aInstance, aId, aBuf, aLength)
 #endif
 
 /**
@@ -1180,9 +1193,10 @@ extern "C" {
  *
  */
 #if OPENTHREAD_ENABLE_CERT_LOG
-#define otDumpCertMeshCoP(aId, aBuf, aLength) otDump(kLogLevelNone, kLogRegionMeshCoP, aId, aBuf, aLength)
+#define otDumpCertMeshCoP(aInstance, aId, aBuf, aLength)                    \
+    otDump(aInstance, kLogLevelNone, kLogRegionMeshCoP, aId, aBuf, aLength)
 #else
-#define otDumpCertMeshCoP(aId, aBuf, aLength)
+#define otDumpCertMeshCoP(aInstance, aId, aBuf, aLength)
 #endif
 
 /**
@@ -1195,7 +1209,8 @@ extern "C" {
  * @param[in]  aLength  Number of bytes to print.
  *
  */
-void otDump(otLogLevel aLevel, otLogRegion aRegion, const char *aId, const void *aBuf, const size_t aLength);
+void otDump(otInstance *aIntsance, otLogLevel aLevel, otLogRegion aRegion, const char *aId, const void *aBuf,
+            const size_t aLength);
 
 #if OPENTHREAD_CONFIG_LOG_PREPEND_LEVEL == 1
 /**
@@ -1228,8 +1243,9 @@ const char *otLogRegionToString(otLogRegion aRegion);
 /**
  * Local/private macro to format the log message
  */
-#define _otLogFormatter(aLogLevel, aRegion, aFormat, ...)                   \
-    otPlatLog(                                                              \
+#define _otLogFormatter(aInstance, aLogLevel, aRegion, aFormat, ...)        \
+    _otPlatLog(                                                             \
+        aInstance,                                                          \
         aLogLevel,                                                          \
         aRegion,                                                            \
         "[%s]%s: " aFormat OPENTHREAD_CONFIG_LOG_SUFFIX,                    \
@@ -1243,8 +1259,9 @@ const char *otLogRegionToString(otLogRegion aRegion);
 /**
 * Local/private macro to format the log message
 */
-#define _otLogFormatter(aLogLevel, aRegion, aFormat, ...)                   \
-    otPlatLog(                                                              \
+#define _otLogFormatter(aInstanc, aLogLevel, aRegion, aFormat, ...)         \
+    _otPlatLog(                                                             \
+        aInstance,                                                          \
         aLogLevel,                                                          \
         aRegion,                                                            \
         "[%s]: " aFormat OPENTHREAD_CONFIG_LOG_SUFFIX,                      \
@@ -1261,8 +1278,9 @@ const char *otLogRegionToString(otLogRegion aRegion);
 /**
 * Local/private macro to format the log message
 */
-#define _otLogFormatter(aLogLevel, aRegion, aFormat, ...)                   \
-    otPlatLog(                                                              \
+#define _otLogFormatter(aInstance, aLogLevel, aRegion, aFormat, ...)        \
+    _otPlatLog(                                                             \
+        aInstance,                                                          \
         aLogLevel,                                                          \
         aRegion,                                                            \
         "%s: " aFormat OPENTHREAD_CONFIG_LOG_SUFFIX,                        \
@@ -1275,8 +1293,9 @@ const char *otLogRegionToString(otLogRegion aRegion);
 /**
 * Local/private macro to format the log message
 */
-#define _otLogFormatter(aLogLevel, aRegion, aFormat, ...)                   \
-    otPlatLog(                                                              \
+#define _otLogFormatter(aInstace, aLogLevel, aRegion, aFormat, ...)         \
+    _otPlatLog(                                                             \
+        aInstance,                                                          \
         aLogLevel,                                                          \
         aRegion,                                                            \
         aFormat OPENTHREAD_CONFIG_LOG_SUFFIX,                               \
@@ -1286,6 +1305,24 @@ const char *otLogRegionToString(otLogRegion aRegion);
 #endif
 
 #endif // OPENTHREAD_CONFIG_LOG_PREPEND_REGION
+
+
+#if OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL == 1
+
+/**
+* Local/private macro to dynamically filter log level.
+*/
+#define _otPlatLog(aInstance, aLogLevel, aRegion, aFormat, ...)             \
+    do {                                                                    \
+        if (otGetDynamicLogLevel(aInstance) >= aLogLevel)                   \
+            otPlatLog(aLogLevel, aRegion, aFormat, ## __VA_ARGS__);         \
+    } while (false)
+
+#else // OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
+
+#define _otPlatLog(aInstance, aLogLevel, aRegion, aFormat, ...) otPlatLog(aLogLevel, aRegion, aFormat, ## __VA_ARGS__)
+
+#endif // OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
 
 #ifdef __cplusplus
 };

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -42,16 +42,13 @@
 namespace Thread {
 
 MessagePool::MessagePool(otInstance *aInstance) :
-#if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
     mInstance(aInstance),
-#endif
     mAllQueue()
 {
 #if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
     // Initialize Platform buffer pool management.
     otPlatMessagePoolInit(mInstance, kNumBuffers, sizeof(Buffer));
 #else
-    (void)aInstance;
     memset(mBuffers, 0, sizeof(mBuffers));
 
     mFreeBuffers = mBuffers;
@@ -64,6 +61,9 @@ MessagePool::MessagePool(otInstance *aInstance) :
     mBuffers[kNumBuffers - 1].SetNextBuffer(NULL);
     mNumFreeBuffers = kNumBuffers;
 #endif
+
+    // This is required to remove warning of "unused member variable".
+    (void)mInstance;
 }
 
 Message *MessagePool::New(uint8_t aType, uint16_t aReserved)
@@ -122,7 +122,7 @@ Buffer *MessagePool::NewBuffer(void)
 
     if (buffer == NULL)
     {
-        otLogInfoMem("No available message buffer");
+        otLogInfoMem(mInstance, "No available message buffer");
     }
 
     return buffer;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -1123,9 +1123,9 @@ private:
     uint16_t mNumFreeBuffers;
     Buffer   mBuffers[kNumBuffers];
     Buffer   *mFreeBuffers;
-#else
-    otInstance *mInstance;
 #endif
+
+    otInstance *mInstance;
     PriorityQueue mAllQueue;
 };
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -179,7 +179,7 @@ Mac::Mac(ThreadNetif &aThreadNetif):
     mKeyIdMode2FrameCounter = 0;
 }
 
-otInstance *Mac::GetInstance()
+otInstance *Mac::GetInstance(void)
 {
     return mNetif.GetInstance();
 }
@@ -1067,7 +1067,7 @@ void Mac::SentFrame(ThreadError aError)
             break;
         }
 
-        otDumpDebgMac("TX ERR", sendFrame.GetHeader(), 16);
+        otDumpDebgMac(GetInstance(), "TX ERR", sendFrame.GetHeader(), 16);
 
         if (!RadioSupportsRetries() &&
             mTransmitAttempts < sendFrame.GetMaxTxAttempts())
@@ -1141,7 +1141,7 @@ void Mac::SentFrame(ThreadError aError)
             mDataSequence++;
         }
 
-        otDumpDebgMac("TX", sendFrame.GetHeader(), sendFrame.GetLength());
+        otDumpDebgMac(GetInstance(), "TX", sendFrame.GetHeader(), sendFrame.GetLength());
         sender->HandleSentFrame(sendFrame, aError);
 
         ScheduleNextTransmission();
@@ -1508,7 +1508,7 @@ void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
 
         if (receive)
         {
-            otDumpDebgMac("RX", aFrame->GetHeader(), aFrame->GetLength());
+            otDumpDebgMac(GetInstance(), "RX", aFrame->GetHeader(), aFrame->GetLength());
 
             for (Receiver *receiver = mReceiveHead; receiver; receiver = receiver->mNext)
             {

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -227,7 +227,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
     /**
      * This function pointer is called on receiving an IEEE 802.15.4 Beacon during an Active Scan.

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -875,7 +875,8 @@ void Commissioner::HandleJoinerFinalize(Coap::Header &aHeader, Message &aMessage
     uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
     VerifyOrExit(aMessage.GetLength() <= sizeof(buf), ;);
     aMessage.Read(aHeader.GetLength(), aMessage.GetLength() - aHeader.GetLength(), buf);
-    otDumpCertMeshCoP("[THCI] direction=recv | type=JOIN_FIN.req |", buf, aMessage.GetLength() - aHeader.GetLength());
+    otDumpCertMeshCoP(GetInstance(), "[THCI] direction=recv | type=JOIN_FIN.req |", buf,
+                      aMessage.GetLength() - aHeader.GetLength());
 
 exit:
 #endif
@@ -916,7 +917,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Header &aRequestHeader, 
     uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
     VerifyOrExit(message->GetLength() <= sizeof(buf), ;);
     message->Read(responseHeader.GetLength(), message->GetLength() - responseHeader.GetLength(), buf);
-    otDumpCertMeshCoP("[THCI] direction=send | type=JOIN_FIN.rsp |", buf,
+    otDumpCertMeshCoP(GetInstance(), "[THCI] direction=send | type=JOIN_FIN.rsp |", buf,
                       message->GetLength() - responseHeader.GetLength());
 #endif
 

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -316,7 +316,8 @@ void Joiner::SendJoinerFinalize(void)
     uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
     VerifyOrExit(message->GetLength() <= sizeof(buf), ;);
     message->Read(header.GetLength(), message->GetLength() - header.GetLength(), buf);
-    otDumpCertMeshCoP("[THCI] direction=send | type=JOIN_FIN.req |", buf, message->GetLength() - header.GetLength());
+    otDumpCertMeshCoP(GetInstance(), "[THCI] direction=send | type=JOIN_FIN.req |", buf,
+                      message->GetLength() - header.GetLength());
 #endif
 
     mNetif.GetSecureCoapClient().SendMessage(*message, Joiner::HandleJoinerFinalizeResponse, this);
@@ -365,7 +366,8 @@ void Joiner::HandleJoinerFinalizeResponse(Coap::Header *aHeader, Message *aMessa
     uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
     VerifyOrExit(aMessage->GetLength() <= sizeof(buf), ;);
     aMessage->Read(aHeader->GetLength(), aMessage->GetLength() - aHeader->GetLength(), buf);
-    otDumpCertMeshCoP("[THCI] direction=recv | type=JOIN_FIN.rsp |", buf, aMessage->GetLength() - aHeader->GetLength());
+    otDumpCertMeshCoP(GetInstance(), "[THCI] direction=recv | type=JOIN_FIN.rsp |", buf,
+                      aMessage->GetLength() - aHeader->GetLength());
 #endif
 
 exit:

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -838,7 +838,7 @@ ThreadError Ip6::ForwardMessage(Message &message, MessageInfo &messageInfo, uint
             break;
 
         case kThreadError_NoRoute:
-            otDumpDebgIp6("no route", &messageInfo.GetSockAddr(), 16);
+            otDumpDebgIp6(GetInstance(), "no route", &messageInfo.GetSockAddr(), 16);
             break;
 
         default:

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -396,12 +396,26 @@
 /**
  * @def OPENTHREAD_CONFIG_LOG_LEVEL
  *
- * The log level.
+ * The log level (used at compile time).
  *
  */
 #ifndef OPENTHREAD_CONFIG_LOG_LEVEL
 #define OPENTHREAD_CONFIG_LOG_LEVEL                             OPENTHREAD_LOG_LEVEL_CRIT
 #endif  // OPENTHREAD_CONFIG_LOG_LEVEL
+
+/**
+ * @def OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
+ *
+ * Define as 1 to enable dynamic log level control.
+ *
+ * Note that the OPENTHREAD_CONFIG_LOG_LEVEL determines the log level at
+ * compile time. The dynamic log level control (if enabled) only allows
+ * decreasing the log level from the compile time value.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
+#define OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL              0
+#endif // OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
 
 /**
  * @def OPENTHREAD_CONFIG_LOG_API

--- a/src/core/openthread-instance.h
+++ b/src/core/openthread-instance.h
@@ -41,6 +41,7 @@
 #include <openthread-core-config.h>
 
 #include "openthread/types.h"
+#include "openthread/platform/logging.h"
 
 #include <crypto/mbedtls.hpp>
 #include <net/ip6.hpp>
@@ -87,6 +88,10 @@ typedef struct otInstance
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
     Thread::Coap::Server mApplicationCoapServer;
 #endif // OPENTHREAD_ENABLE_APPLICATION_COAP
+
+#if OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
+    otLogLevel mLogLevel;
+#endif // OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
 
     // Constructor
     otInstance(void);

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -300,7 +300,7 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength)
                 continue;
             }
 
-            otDumpDebgNetData("remove prefix done", mTlvs, mLength);
+            otDumpDebgNetData(GetInstance(), "remove prefix done", mTlvs, mLength);
             break;
         }
 
@@ -324,7 +324,7 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength)
         cur = cur->GetNext();
     }
 
-    otDumpDebgNetData("remove done", aData, aDataLength);
+    otDumpDebgNetData(GetInstance(), "remove done", aData, aDataLength);
 }
 
 void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, PrefixTlv &aPrefix)

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -423,7 +423,7 @@ void LeaderBase::SetNetworkData(uint8_t aVersion, uint8_t aStableVersion, bool a
         RemoveTemporaryData(mTlvs, mLength);
     }
 
-    otDumpDebgNetData("set network data", mTlvs, mLength);
+    otDumpDebgNetData(GetInstance(), "set network data", mTlvs, mLength);
 
     mNetif.SetStateChangedFlags(OT_THREAD_NETDATA_UPDATED);
 }

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -599,7 +599,7 @@ ThreadError Leader::AddNetworkData(uint8_t *aTlvs, uint8_t aTlvsLength)
         {
         case NetworkDataTlv::kTypePrefix:
             AddPrefix(*static_cast<PrefixTlv *>(cur));
-            otDumpDebgNetData("add prefix done", mTlvs, mLength);
+            otDumpDebgNetData(GetInstance(), "add prefix done", mTlvs, mLength);
             break;
 
         default:
@@ -609,7 +609,7 @@ ThreadError Leader::AddNetworkData(uint8_t *aTlvs, uint8_t aTlvsLength)
         cur = cur->GetNext();
     }
 
-    otDumpDebgNetData("add done", mTlvs, mLength);
+    otDumpDebgNetData(GetInstance(), "add done", mTlvs, mLength);
 
     return kThreadError_None;
 }
@@ -814,7 +814,7 @@ ThreadError Leader::RemoveRloc(uint16_t aRloc16)
                 continue;
             }
 
-            otDumpDebgNetData("remove prefix done", mTlvs, mLength);
+            otDumpDebgNetData(GetInstance(), "remove prefix done", mTlvs, mLength);
             break;
         }
 
@@ -825,7 +825,7 @@ ThreadError Leader::RemoveRloc(uint16_t aRloc16)
         cur = cur->GetNext();
     }
 
-    otDumpDebgNetData("remove done", mTlvs, mLength);
+    otDumpDebgNetData(GetInstance(), "remove done", mTlvs, mLength);
 
     return kThreadError_None;
 }
@@ -978,7 +978,7 @@ ThreadError Leader::RemoveContext(uint8_t aContextId)
                 continue;
             }
 
-            otDumpDebgNetData("remove prefix done", mTlvs, mLength);
+            otDumpDebgNetData(GetInstance(), "remove prefix done", mTlvs, mLength);
             break;
         }
 
@@ -989,7 +989,7 @@ ThreadError Leader::RemoveContext(uint8_t aContextId)
         cur = cur->GetNext();
     }
 
-    otDumpDebgNetData("remove done", mTlvs, mLength);
+    otDumpDebgNetData(GetInstance(), "remove done", mTlvs, mLength);
 
     return kThreadError_None;
 }

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -76,7 +76,7 @@ ThreadError Local::AddOnMeshPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength
 
     ClearResubmitDelayTimer();
 
-    otDumpDebgNetData("add prefix done", mTlvs, mLength);
+    otDumpDebgNetData(GetInstance(), "add prefix done", mTlvs, mLength);
     return kThreadError_None;
 }
 
@@ -91,7 +91,7 @@ ThreadError Local::RemoveOnMeshPrefix(const uint8_t *aPrefix, uint8_t aPrefixLen
     ClearResubmitDelayTimer();
 
 exit:
-    otDumpDebgNetData("remove done", mTlvs, mLength);
+    otDumpDebgNetData(GetInstance(), "remove done", mTlvs, mLength);
     return error;
 }
 
@@ -122,7 +122,7 @@ ThreadError Local::AddHasRoutePrefix(const uint8_t *aPrefix, uint8_t aPrefixLeng
 
     ClearResubmitDelayTimer();
 
-    otDumpDebgNetData("add route done", mTlvs, mLength);
+    otDumpDebgNetData(GetInstance(), "add route done", mTlvs, mLength);
     return kThreadError_None;
 }
 
@@ -137,7 +137,7 @@ ThreadError Local::RemoveHasRoutePrefix(const uint8_t *aPrefix, uint8_t aPrefixL
     ClearResubmitDelayTimer();
 
 exit:
-    otDumpDebgNetData("remove done", mTlvs, mLength);
+    otDumpDebgNetData(GetInstance(), "remove done", mTlvs, mLength);
     return error;
 }
 

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -392,6 +392,7 @@ private:
     ThreadError GetPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_NET_REQUIRE_JOIN_EXISTING(uint8_t header, spinel_prop_key_t key);
     ThreadError GetPropertyHandler_DEBUG_TEST_ASSERT(uint8_t header, spinel_prop_key_t key);
+    ThreadError GetPropertyHandler_DEBUG_NCP_LOG_LEVEL(uint8_t header, spinel_prop_key_t key);
 
 #if OPENTHREAD_ENABLE_JAM_DETECTION
     ThreadError GetPropertyHandler_JAM_DETECT_ENABLE(uint8_t header, spinel_prop_key_t key);
@@ -510,6 +511,8 @@ private:
                                                              const uint8_t *value_ptr, uint16_t value_len);
     ThreadError SetPropertyHandler_CNTR_RESET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                               uint16_t value_len);
+    ThreadError SetPropertyHandler_DEBUG_NCP_LOG_LEVEL(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                   uint16_t value_len);
 
 #if OPENTHREAD_ENABLE_JAM_DETECTION
     ThreadError SetPropertyHandler_JAM_DETECT_ENABLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1268,6 +1268,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "SPINEL_PROP_DEBUG_TEST_ASSERT";
         break;
 
+    case SPINEL_PROP_DEBUG_NCP_LOG_LEVEL:
+        ret = "SPINEL_PROP_DEBUG_NCP_LOG_LEVEL";
+        break;
+
     default:
         break;
     }

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -227,6 +227,18 @@ enum
     SPINEL_MAC_PROMISCUOUS_MODE_FULL     = 2, ///< All decoded MAC packets are passed up the stack.
 };
 
+enum
+{
+    SPINEL_NCP_LOG_LEVEL_EMERG  = 0,
+    SPINEL_NCP_LOG_LEVEL_ALERT  = 1,
+    SPINEL_NCP_LOG_LEVEL_CRIT   = 2,
+    SPINEL_NCP_LOG_LEVEL_ERR    = 3,
+    SPINEL_NCP_LOG_LEVEL_WARN   = 4,
+    SPINEL_NCP_LOG_LEVEL_NOTICE = 5,
+    SPINEL_NCP_LOG_LEVEL_INFO   = 6,
+    SPINEL_NCP_LOG_LEVEL_DEBUG  = 7,
+};
+
 typedef struct
 {
     uint8_t bytes[8];
@@ -1103,6 +1115,10 @@ typedef enum
     /** Format: 'b' (read-only) */
     SPINEL_PROP_DEBUG_TEST_ASSERT
                                     = SPINEL_PROP_DEBUG__BEGIN + 0,
+
+    /// The NCP log level.
+    /** Format: `C` */
+    SPINEL_PROP_DEBUG_NCP_LOG_LEVEL  = SPINEL_PROP_DEBUG__BEGIN + 1,
 
     SPINEL_PROP_DEBUG__END          = 17408,
 


### PR DESCRIPTION
This commit adds support for the dynamic log level selection. Config
option `OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL` can be used to
enable/disable this feature (default setting is disabled).

Note that the `OPENTHREAD_CONFIG_LOG_LEVEL` specifies the log level at
compile/build time. The dynamic log level feature (if enabled) only
allows decreasing log level from the compile time setting.

This commit also adds `SPINEL_PROP_DEBUG_NCP_LOG_LEVEL` as a new
spinel property to control the log level. The set/get handlers for
this property along with its documentation are also added.

This commit modifies some of the log related macros/methods so
to harmonize them all to require an `otInstance` as their first
argument.