### PR TITLE
cli: update instance data names to follow convention

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -187,15 +187,15 @@ typedef otPtr<const uint8_t> otBufferPtr;
 typedef otPtr<const char> otStringPtr;
 
 Interpreter::Interpreter(otInstance *aInstance):
-    sServer(NULL),
+    mServer(NULL),
 #ifdef OTDLL
     mApiInstance(otApiInit()),
     mInstanceIndex(0),
 #else
-    sLength(8),
-    sCount(1),
-    sInterval(1000),
-    sPingTimer(aInstance->mIp6.mTimerScheduler, &Interpreter::s_HandlePingTimer, this),
+    mLength(8),
+    mCount(1),
+    mInterval(1000),
+    mPingTimer(aInstance->mIp6.mTimerScheduler, &Interpreter::s_HandlePingTimer, this),
 #if OPENTHREAD_ENABLE_DNS_CLIENT
     mResolvingInProgress(0),
 #endif
@@ -279,11 +279,11 @@ void Interpreter::AppendResult(ThreadError error)
 {
     if (error == kThreadError_None)
     {
-        sServer->OutputFormat("Done\r\n");
+        mServer->OutputFormat("Done\r\n");
     }
     else
     {
-        sServer->OutputFormat("Error %d\r\n", error);
+        mServer->OutputFormat("Error %d\r\n", error);
     }
 }
 
@@ -291,7 +291,7 @@ void Interpreter::OutputBytes(const uint8_t *aBytes, uint8_t aLength)
 {
     for (int i = 0; i < aLength; i++)
     {
-        sServer->OutputFormat("%02x", aBytes[i]);
+        mServer->OutputFormat("%02x", aBytes[i]);
     }
 }
 
@@ -313,7 +313,7 @@ void Interpreter::ProcessHelp(int argc, char *argv[])
 {
     for (unsigned int i = 0; i < sizeof(sCommands) / sizeof(sCommands[0]); i++)
     {
-        sServer->OutputFormat("%s\r\n", sCommands[i].mName);
+        mServer->OutputFormat("%s\r\n", sCommands[i].mName);
     }
 
     (void)argc;
@@ -328,11 +328,11 @@ void Interpreter::ProcessAutoStart(int argc, char *argv[])
     {
         if (otThreadGetAutoStart(mInstance))
         {
-            sServer->OutputFormat("true\r\n");
+            mServer->OutputFormat("true\r\n");
         }
         else
         {
-            sServer->OutputFormat("false\r\n");
+            mServer->OutputFormat("false\r\n");
         }
     }
     else if (strcmp(argv[0], "true") == 0)
@@ -362,11 +362,11 @@ void Interpreter::ProcessBlacklist(int argc, char *argv[])
     {
         if (otLinkIsBlacklistEnabled(mInstance))
         {
-            sServer->OutputFormat("Enabled\r\n");
+            mServer->OutputFormat("Enabled\r\n");
         }
         else
         {
-            sServer->OutputFormat("Disabled\r\n");
+            mServer->OutputFormat("Disabled\r\n");
         }
 
         for (uint8_t i = 0; ; i++)
@@ -383,7 +383,7 @@ void Interpreter::ProcessBlacklist(int argc, char *argv[])
 
             OutputBytes(entry.mExtAddress.m8, OT_EXT_ADDRESS_SIZE);
 
-            sServer->OutputFormat("\r\n");
+            mServer->OutputFormat("\r\n");
         }
     }
     else if (strcmp(argv[argcur], "add") == 0)
@@ -425,15 +425,15 @@ void Interpreter::ProcessBufferInfo(int argc, char *argv[])
 
     otMessageGetBufferInfo(mInstance, &bufferInfo);
 
-    sServer->OutputFormat("total: %d\r\n", bufferInfo.mTotalBuffers);
-    sServer->OutputFormat("free: %d\r\n", bufferInfo.mFreeBuffers);
-    sServer->OutputFormat("6lo send: %d %d\r\n", bufferInfo.m6loSendMessages, bufferInfo.m6loSendBuffers);
-    sServer->OutputFormat("6lo reas: %d %d\r\n", bufferInfo.m6loReassemblyMessages, bufferInfo.m6loReassemblyBuffers);
-    sServer->OutputFormat("ip6: %d %d\r\n", bufferInfo.mIp6Messages, bufferInfo.mIp6Buffers);
-    sServer->OutputFormat("mpl: %d %d\r\n", bufferInfo.mMplMessages, bufferInfo.mMplBuffers);
-    sServer->OutputFormat("mle: %d %d\r\n", bufferInfo.mMleMessages, bufferInfo.mMleBuffers);
-    sServer->OutputFormat("arp: %d %d\r\n", bufferInfo.mArpMessages, bufferInfo.mArpBuffers);
-    sServer->OutputFormat("coap: %d %d\r\n", bufferInfo.mCoapClientMessages, bufferInfo.mCoapClientBuffers);
+    mServer->OutputFormat("total: %d\r\n", bufferInfo.mTotalBuffers);
+    mServer->OutputFormat("free: %d\r\n", bufferInfo.mFreeBuffers);
+    mServer->OutputFormat("6lo send: %d %d\r\n", bufferInfo.m6loSendMessages, bufferInfo.m6loSendBuffers);
+    mServer->OutputFormat("6lo reas: %d %d\r\n", bufferInfo.m6loReassemblyMessages, bufferInfo.m6loReassemblyBuffers);
+    mServer->OutputFormat("ip6: %d %d\r\n", bufferInfo.mIp6Messages, bufferInfo.mIp6Buffers);
+    mServer->OutputFormat("mpl: %d %d\r\n", bufferInfo.mMplMessages, bufferInfo.mMplBuffers);
+    mServer->OutputFormat("mle: %d %d\r\n", bufferInfo.mMleMessages, bufferInfo.mMleBuffers);
+    mServer->OutputFormat("arp: %d %d\r\n", bufferInfo.mArpMessages, bufferInfo.mArpBuffers);
+    mServer->OutputFormat("coap: %d %d\r\n", bufferInfo.mCoapClientMessages, bufferInfo.mCoapClientBuffers);
 
     AppendResult(kThreadError_None);
 }
@@ -445,7 +445,7 @@ void Interpreter::ProcessChannel(int argc, char *argv[])
 
     if (argc == 0)
     {
-        sServer->OutputFormat("%d\r\n", otLinkGetChannel(mInstance));
+        mServer->OutputFormat("%d\r\n", otLinkGetChannel(mInstance));
     }
     else
     {
@@ -471,8 +471,8 @@ void Interpreter::ProcessChild(int argc, char *argv[])
     {
         if (isTable)
         {
-            sServer->OutputFormat("| ID  | RLOC16 | Timeout    | Age        | LQI In | C_VN |R|S|D|N| Extended MAC     |\r\n");
-            sServer->OutputFormat("+-----+--------+------------+------------+--------+------+-+-+-+-+------------------+\r\n");
+            mServer->OutputFormat("| ID  | RLOC16 | Timeout    | Age        | LQI In | C_VN |R|S|D|N| Extended MAC     |\r\n");
+            mServer->OutputFormat("+-----+--------+------------+------------+--------+------+-+-+-+-+------------------+\r\n");
         }
 
         maxChildren = otThreadGetMaxAllowedChildren(mInstance);
@@ -481,7 +481,7 @@ void Interpreter::ProcessChild(int argc, char *argv[])
         {
             if (otThreadGetChildInfoByIndex(mInstance, i, &childInfo) != kThreadError_None)
             {
-                sServer->OutputFormat("\r\n");
+                mServer->OutputFormat("\r\n");
                 ExitNow();
             }
 
@@ -489,28 +489,28 @@ void Interpreter::ProcessChild(int argc, char *argv[])
             {
                 if (isTable)
                 {
-                    sServer->OutputFormat("| %3d ", childInfo.mChildId);
-                    sServer->OutputFormat("| 0x%04x ", childInfo.mRloc16);
-                    sServer->OutputFormat("| %10d ", childInfo.mTimeout);
-                    sServer->OutputFormat("| %10d ", childInfo.mAge);
-                    sServer->OutputFormat("| %6d ", childInfo.mLinkQualityIn);
-                    sServer->OutputFormat("| %4d ", childInfo.mNetworkDataVersion);
-                    sServer->OutputFormat("|%1d", childInfo.mRxOnWhenIdle);
-                    sServer->OutputFormat("|%1d", childInfo.mSecureDataRequest);
-                    sServer->OutputFormat("|%1d", childInfo.mFullFunction);
-                    sServer->OutputFormat("|%1d", childInfo.mFullNetworkData);
-                    sServer->OutputFormat("| ");
+                    mServer->OutputFormat("| %3d ", childInfo.mChildId);
+                    mServer->OutputFormat("| 0x%04x ", childInfo.mRloc16);
+                    mServer->OutputFormat("| %10d ", childInfo.mTimeout);
+                    mServer->OutputFormat("| %10d ", childInfo.mAge);
+                    mServer->OutputFormat("| %6d ", childInfo.mLinkQualityIn);
+                    mServer->OutputFormat("| %4d ", childInfo.mNetworkDataVersion);
+                    mServer->OutputFormat("|%1d", childInfo.mRxOnWhenIdle);
+                    mServer->OutputFormat("|%1d", childInfo.mSecureDataRequest);
+                    mServer->OutputFormat("|%1d", childInfo.mFullFunction);
+                    mServer->OutputFormat("|%1d", childInfo.mFullNetworkData);
+                    mServer->OutputFormat("| ");
 
                     for (size_t j = 0; j < sizeof(childInfo.mExtAddress); j++)
                     {
-                        sServer->OutputFormat("%02x", childInfo.mExtAddress.m8[j]);
+                        mServer->OutputFormat("%02x", childInfo.mExtAddress.m8[j]);
                     }
 
-                    sServer->OutputFormat(" |\r\n");
+                    mServer->OutputFormat(" |\r\n");
                 }
                 else
                 {
-                    sServer->OutputFormat("%d ", childInfo.mChildId);
+                    mServer->OutputFormat("%d ", childInfo.mChildId);
                 }
             }
         }
@@ -519,45 +519,45 @@ void Interpreter::ProcessChild(int argc, char *argv[])
     SuccessOrExit(error = ParseLong(argv[0], value));
     SuccessOrExit(error = otThreadGetChildInfoById(mInstance, static_cast<uint16_t>(value), &childInfo));
 
-    sServer->OutputFormat("Child ID: %d\r\n", childInfo.mChildId);
-    sServer->OutputFormat("Rloc: %04x\r\n", childInfo.mRloc16);
-    sServer->OutputFormat("Ext Addr: ");
+    mServer->OutputFormat("Child ID: %d\r\n", childInfo.mChildId);
+    mServer->OutputFormat("Rloc: %04x\r\n", childInfo.mRloc16);
+    mServer->OutputFormat("Ext Addr: ");
 
     for (size_t j = 0; j < sizeof(childInfo.mExtAddress); j++)
     {
-        sServer->OutputFormat("%02x", childInfo.mExtAddress.m8[j]);
+        mServer->OutputFormat("%02x", childInfo.mExtAddress.m8[j]);
     }
 
-    sServer->OutputFormat("\r\n");
-    sServer->OutputFormat("Mode: ");
+    mServer->OutputFormat("\r\n");
+    mServer->OutputFormat("Mode: ");
 
     if (childInfo.mRxOnWhenIdle)
     {
-        sServer->OutputFormat("r");
+        mServer->OutputFormat("r");
     }
 
     if (childInfo.mSecureDataRequest)
     {
-        sServer->OutputFormat("s");
+        mServer->OutputFormat("s");
     }
 
     if (childInfo.mFullFunction)
     {
-        sServer->OutputFormat("d");
+        mServer->OutputFormat("d");
     }
 
     if (childInfo.mFullNetworkData)
     {
-        sServer->OutputFormat("n");
+        mServer->OutputFormat("n");
     }
 
-    sServer->OutputFormat("\r\n");
+    mServer->OutputFormat("\r\n");
 
-    sServer->OutputFormat("Net Data: %d\r\n", childInfo.mNetworkDataVersion);
-    sServer->OutputFormat("Timeout: %d\r\n", childInfo.mTimeout);
-    sServer->OutputFormat("Age: %d\r\n", childInfo.mAge);
-    sServer->OutputFormat("LQI: %d\r\n", childInfo.mLinkQualityIn);
-    sServer->OutputFormat("RSSI: %d\r\n", childInfo.mAverageRssi);
+    mServer->OutputFormat("Net Data: %d\r\n", childInfo.mNetworkDataVersion);
+    mServer->OutputFormat("Timeout: %d\r\n", childInfo.mTimeout);
+    mServer->OutputFormat("Age: %d\r\n", childInfo.mAge);
+    mServer->OutputFormat("LQI: %d\r\n", childInfo.mLinkQualityIn);
+    mServer->OutputFormat("RSSI: %d\r\n", childInfo.mAverageRssi);
 
 exit:
     AppendResult(error);
@@ -570,7 +570,7 @@ void Interpreter::ProcessChildMax(int argc, char *argv[])
 
     if (argc == 0)
     {
-        sServer->OutputFormat("%d\r\n", otThreadGetMaxAllowedChildren(mInstance));
+        mServer->OutputFormat("%d\r\n", otThreadGetMaxAllowedChildren(mInstance));
     }
     else
     {
@@ -589,7 +589,7 @@ void Interpreter::ProcessChildTimeout(int argc, char *argv[])
 
     if (argc == 0)
     {
-        sServer->OutputFormat("%d\r\n", otThreadGetChildTimeout(mInstance));
+        mServer->OutputFormat("%d\r\n", otThreadGetChildTimeout(mInstance));
     }
     else
     {
@@ -608,7 +608,7 @@ void Interpreter::ProcessContextIdReuseDelay(int argc, char *argv[])
 
     if (argc == 0)
     {
-        sServer->OutputFormat("%d\r\n", otThreadGetContextIdReuseDelay(mInstance));
+        mServer->OutputFormat("%d\r\n", otThreadGetContextIdReuseDelay(mInstance));
     }
     else
     {
@@ -624,44 +624,44 @@ void Interpreter::ProcessCounters(int argc, char *argv[])
 {
     if (argc == 0)
     {
-        sServer->OutputFormat("mac\r\n");
-        sServer->OutputFormat("Done\r\n");
+        mServer->OutputFormat("mac\r\n");
+        mServer->OutputFormat("Done\r\n");
     }
     else
     {
         if (strcmp(argv[0], "mac") == 0)
         {
             otMacCountersPtr counters(otLinkGetCounters(mInstance));
-            sServer->OutputFormat("TxTotal: %d\r\n", counters->mTxTotal);
-            sServer->OutputFormat("    TxUnicast: %d\r\n", counters->mTxUnicast);
-            sServer->OutputFormat("    TxBroadcast: %d\r\n", counters->mTxBroadcast);
-            sServer->OutputFormat("    TxAckRequested: %d\r\n", counters->mTxAckRequested);
-            sServer->OutputFormat("    TxAcked: %d\r\n", counters->mTxAcked);
-            sServer->OutputFormat("    TxNoAckRequested: %d\r\n", counters->mTxNoAckRequested);
-            sServer->OutputFormat("    TxData: %d\r\n", counters->mTxData);
-            sServer->OutputFormat("    TxDataPoll: %d\r\n", counters->mTxDataPoll);
-            sServer->OutputFormat("    TxBeacon: %d\r\n", counters->mTxBeacon);
-            sServer->OutputFormat("    TxBeaconRequest: %d\r\n", counters->mTxBeaconRequest);
-            sServer->OutputFormat("    TxOther: %d\r\n", counters->mTxOther);
-            sServer->OutputFormat("    TxRetry: %d\r\n", counters->mTxRetry);
-            sServer->OutputFormat("    TxErrCca: %d\r\n", counters->mTxErrCca);
-            sServer->OutputFormat("RxTotal: %d\r\n", counters->mRxTotal);
-            sServer->OutputFormat("    RxUnicast: %d\r\n", counters->mRxUnicast);
-            sServer->OutputFormat("    RxBroadcast: %d\r\n", counters->mRxBroadcast);
-            sServer->OutputFormat("    RxData: %d\r\n", counters->mRxData);
-            sServer->OutputFormat("    RxDataPoll: %d\r\n", counters->mRxDataPoll);
-            sServer->OutputFormat("    RxBeacon: %d\r\n", counters->mRxBeacon);
-            sServer->OutputFormat("    RxBeaconRequest: %d\r\n", counters->mRxBeaconRequest);
-            sServer->OutputFormat("    RxOther: %d\r\n", counters->mRxOther);
-            sServer->OutputFormat("    RxWhitelistFiltered: %d\r\n", counters->mRxWhitelistFiltered);
-            sServer->OutputFormat("    RxDestAddrFiltered: %d\r\n", counters->mRxDestAddrFiltered);
-            sServer->OutputFormat("    RxDuplicated: %d\r\n", counters->mRxDuplicated);
-            sServer->OutputFormat("    RxErrNoFrame: %d\r\n", counters->mRxErrNoFrame);
-            sServer->OutputFormat("    RxErrNoUnknownNeighbor: %d\r\n", counters->mRxErrUnknownNeighbor);
-            sServer->OutputFormat("    RxErrInvalidSrcAddr: %d\r\n", counters->mRxErrInvalidSrcAddr);
-            sServer->OutputFormat("    RxErrSec: %d\r\n", counters->mRxErrSec);
-            sServer->OutputFormat("    RxErrFcs: %d\r\n", counters->mRxErrFcs);
-            sServer->OutputFormat("    RxErrOther: %d\r\n", counters->mRxErrOther);
+            mServer->OutputFormat("TxTotal: %d\r\n", counters->mTxTotal);
+            mServer->OutputFormat("    TxUnicast: %d\r\n", counters->mTxUnicast);
+            mServer->OutputFormat("    TxBroadcast: %d\r\n", counters->mTxBroadcast);
+            mServer->OutputFormat("    TxAckRequested: %d\r\n", counters->mTxAckRequested);
+            mServer->OutputFormat("    TxAcked: %d\r\n", counters->mTxAcked);
+            mServer->OutputFormat("    TxNoAckRequested: %d\r\n", counters->mTxNoAckRequested);
+            mServer->OutputFormat("    TxData: %d\r\n", counters->mTxData);
+            mServer->OutputFormat("    TxDataPoll: %d\r\n", counters->mTxDataPoll);
+            mServer->OutputFormat("    TxBeacon: %d\r\n", counters->mTxBeacon);
+            mServer->OutputFormat("    TxBeaconRequest: %d\r\n", counters->mTxBeaconRequest);
+            mServer->OutputFormat("    TxOther: %d\r\n", counters->mTxOther);
+            mServer->OutputFormat("    TxRetry: %d\r\n", counters->mTxRetry);
+            mServer->OutputFormat("    TxErrCca: %d\r\n", counters->mTxErrCca);
+            mServer->OutputFormat("RxTotal: %d\r\n", counters->mRxTotal);
+            mServer->OutputFormat("    RxUnicast: %d\r\n", counters->mRxUnicast);
+            mServer->OutputFormat("    RxBroadcast: %d\r\n", counters->mRxBroadcast);
+            mServer->OutputFormat("    RxData: %d\r\n", counters->mRxData);
+            mServer->OutputFormat("    RxDataPoll: %d\r\n", counters->mRxDataPoll);
+            mServer->OutputFormat("    RxBeacon: %d\r\n", counters->mRxBeacon);
+            mServer->OutputFormat("    RxBeaconRequest: %d\r\n", counters->mRxBeaconRequest);
+            mServer->OutputFormat("    RxOther: %d\r\n", counters->mRxOther);
+            mServer->OutputFormat("    RxWhitelistFiltered: %d\r\n", counters->mRxWhitelistFiltered);
+            mServer->OutputFormat("    RxDestAddrFiltered: %d\r\n", counters->mRxDestAddrFiltered);
+            mServer->OutputFormat("    RxDuplicated: %d\r\n", counters->mRxDuplicated);
+            mServer->OutputFormat("    RxErrNoFrame: %d\r\n", counters->mRxErrNoFrame);
+            mServer->OutputFormat("    RxErrNoUnknownNeighbor: %d\r\n", counters->mRxErrUnknownNeighbor);
+            mServer->OutputFormat("    RxErrInvalidSrcAddr: %d\r\n", counters->mRxErrInvalidSrcAddr);
+            mServer->OutputFormat("    RxErrSec: %d\r\n", counters->mRxErrSec);
+            mServer->OutputFormat("    RxErrFcs: %d\r\n", counters->mRxErrFcs);
+            mServer->OutputFormat("    RxErrOther: %d\r\n", counters->mRxErrOther);
         }
     }
 }
@@ -669,7 +669,7 @@ void Interpreter::ProcessCounters(int argc, char *argv[])
 void Interpreter::ProcessDataset(int argc, char *argv[])
 {
     ThreadError error;
-    error = Dataset::Process(mInstance, argc, argv, *sServer);
+    error = Dataset::Process(mInstance, argc, argv, *mServer);
     AppendResult(error);
 }
 
@@ -679,7 +679,7 @@ void Interpreter::ProcessDelayTimerMin(int argc, char *argv[])
 
     if (argc == 0)
     {
-        sServer->OutputFormat("%d\r\n", (otDatasetGetDelayTimerMinimal(mInstance) / 1000));
+        mServer->OutputFormat("%d\r\n", (otDatasetGetDelayTimerMinimal(mInstance) / 1000));
     }
     else if (argc == 1)
     {
@@ -710,8 +710,8 @@ void Interpreter::ProcessDiscover(int argc, char *argv[])
 
     SuccessOrExit(error = otThreadDiscover(mInstance, scanChannels, 0, OT_PANID_BROADCAST,
                                            &Interpreter::s_HandleActiveScanResult, this));
-    sServer->OutputFormat("| J | Network Name     | Extended PAN     | PAN  | MAC Address      | Ch | dBm | LQI |\r\n");
-    sServer->OutputFormat("+---+------------------+------------------+------+------------------+----+-----+-----+\r\n");
+    mServer->OutputFormat("| J | Network Name     | Extended PAN     | PAN  | MAC Address      | Ch | dBm | LQI |\r\n");
+    mServer->OutputFormat("+---+------------------+------------------+------+------------------+----+-----+-----+\r\n");
 
     return;
 
@@ -785,11 +785,11 @@ void Interpreter::s_HandleDnsResponse(void *aContext, const char *aHostname, otI
 
 void Interpreter::HandleDnsResponse(const char *aHostname, Ip6::Address &aAddress, uint32_t aTtl, ThreadError aResult)
 {
-    sServer->OutputFormat("DNS response for %s - ", aHostname);
+    mServer->OutputFormat("DNS response for %s - ", aHostname);
 
     if (aResult == kThreadError_None)
     {
-        sServer->OutputFormat("[%x:%x:%x:%x:%x:%x:%x:%x] TTL: %d\r\n",
+        mServer->OutputFormat("[%x:%x:%x:%x:%x:%x:%x:%x] TTL: %d\r\n",
                               HostSwap16(aAddress.mFields.m16[0]),
                               HostSwap16(aAddress.mFields.m16[1]),
                               HostSwap16(aAddress.mFields.m16[2]),
@@ -822,7 +822,7 @@ void Interpreter::ProcessEidCache(int argc, char *argv[])
             continue;
         }
 
-        sServer->OutputFormat("%x:%x:%x:%x:%x:%x:%x:%x %04x\r\n",
+        mServer->OutputFormat("%x:%x:%x:%x:%x:%x:%x:%x %04x\r\n",
                               HostSwap16(entry.mTarget.mFields.m16[0]),
                               HostSwap16(entry.mTarget.mFields.m16[1]),
                               HostSwap16(entry.mTarget.mFields.m16[2]),
@@ -849,7 +849,7 @@ void Interpreter::ProcessEui64(int argc, char *argv[])
 
     otLinkGetFactoryAssignedIeeeEui64(mInstance, &extAddress);
     OutputBytes(extAddress.m8, OT_EXT_ADDRESS_SIZE);
-    sServer->OutputFormat("\r\n");
+    mServer->OutputFormat("\r\n");
 
 exit:
     (void)argv;
@@ -864,7 +864,7 @@ void Interpreter::ProcessExtAddress(int argc, char *argv[])
     {
         otBufferPtr extAddress(otLinkGetExtendedAddress(mInstance));
         OutputBytes(extAddress, OT_EXT_ADDRESS_SIZE);
-        sServer->OutputFormat("\r\n");
+        mServer->OutputFormat("\r\n");
     }
     else
     {
@@ -896,7 +896,7 @@ void Interpreter::ProcessExtPanId(int argc, char *argv[])
     {
         otBufferPtr extPanId(otThreadGetExtendedPanId(mInstance));
         OutputBytes(extPanId, OT_EXT_PAN_ID_SIZE);
-        sServer->OutputFormat("\r\n");
+        mServer->OutputFormat("\r\n");
     }
     else
     {
@@ -927,7 +927,7 @@ void Interpreter::ProcessHashMacAddress(int argc, char *argv[])
 
     otLinkGetJoinerId(mInstance, &hashMacAddress);
     OutputBytes(hashMacAddress.m8, OT_EXT_ADDRESS_SIZE);
-    sServer->OutputFormat("\r\n");
+    mServer->OutputFormat("\r\n");
 
 exit:
     (void)argv;
@@ -942,11 +942,11 @@ void Interpreter::ProcessIfconfig(int argc, char *argv[])
     {
         if (otIp6IsEnabled(mInstance))
         {
-            sServer->OutputFormat("up\r\n");
+            mServer->OutputFormat("up\r\n");
         }
         else
         {
-            sServer->OutputFormat("down\r\n");
+            mServer->OutputFormat("down\r\n");
         }
     }
     else if (strcmp(argv[0], "up") == 0)
@@ -1003,7 +1003,7 @@ void Interpreter::ProcessIpAddr(int argc, char *argv[])
 
         for (const otNetifAddress *addr = unicastAddrs; addr; addr = addr->mNext)
         {
-            sServer->OutputFormat("%x:%x:%x:%x:%x:%x:%x:%x\r\n",
+            mServer->OutputFormat("%x:%x:%x:%x:%x:%x:%x:%x\r\n",
                                   HostSwap16(addr->mAddress.mFields.m16[0]),
                                   HostSwap16(addr->mAddress.mFields.m16[1]),
                                   HostSwap16(addr->mAddress.mFields.m16[2]),
@@ -1067,11 +1067,11 @@ ThreadError Interpreter::ProcessMulticastPromiscuous(int argc, char *argv[])
     {
         if (otIp6IsMulticastPromiscuousEnabled(mInstance))
         {
-            sServer->OutputFormat("Enabled\r\n");
+            mServer->OutputFormat("Enabled\r\n");
         }
         else
         {
-            sServer->OutputFormat("Disabled\r\n");
+            mServer->OutputFormat("Disabled\r\n");
         }
     }
     else
@@ -1102,7 +1102,7 @@ void Interpreter::ProcessIpMulticastAddr(int argc, char *argv[])
     {
         for (const otNetifMulticastAddress *addr = otIp6GetMulticastAddresses(mInstance); addr; addr = addr->mNext)
         {
-            sServer->OutputFormat("%x:%x:%x:%x:%x:%x:%x:%x\r\n",
+            mServer->OutputFormat("%x:%x:%x:%x:%x:%x:%x:%x\r\n",
                                   HostSwap16(addr->mAddress.mFields.m16[0]),
                                   HostSwap16(addr->mAddress.mFields.m16[1]),
                                   HostSwap16(addr->mAddress.mFields.m16[2]),
@@ -1145,7 +1145,7 @@ void Interpreter::ProcessKeySequence(int argc, char *argv[])
     {
         if (argc == 1)
         {
-            sServer->OutputFormat("%d\r\n", otThreadGetKeySequenceCounter(mInstance));
+            mServer->OutputFormat("%d\r\n", otThreadGetKeySequenceCounter(mInstance));
         }
         else
         {
@@ -1157,7 +1157,7 @@ void Interpreter::ProcessKeySequence(int argc, char *argv[])
     {
         if (argc == 1)
         {
-            sServer->OutputFormat("%d\r\n", otThreadGetKeySwitchGuardTime(mInstance));
+            mServer->OutputFormat("%d\r\n", otThreadGetKeySwitchGuardTime(mInstance));
         }
         else
         {
@@ -1177,11 +1177,11 @@ void Interpreter::ProcessLeaderData(int argc, char *argv[])
 
     SuccessOrExit(error = otThreadGetLeaderData(mInstance, &leaderData));
 
-    sServer->OutputFormat("Partition ID: %u\r\n", leaderData.mPartitionId);
-    sServer->OutputFormat("Weighting: %d\r\n", leaderData.mWeighting);
-    sServer->OutputFormat("Data Version: %d\r\n", leaderData.mDataVersion);
-    sServer->OutputFormat("Stable Data Version: %d\r\n", leaderData.mStableDataVersion);
-    sServer->OutputFormat("Leader Router ID: %d\r\n", leaderData.mLeaderRouterId);
+    mServer->OutputFormat("Partition ID: %u\r\n", leaderData.mPartitionId);
+    mServer->OutputFormat("Weighting: %d\r\n", leaderData.mWeighting);
+    mServer->OutputFormat("Data Version: %d\r\n", leaderData.mDataVersion);
+    mServer->OutputFormat("Stable Data Version: %d\r\n", leaderData.mStableDataVersion);
+    mServer->OutputFormat("Leader Router ID: %d\r\n", leaderData.mLeaderRouterId);
 
 exit:
     (void)argc;
@@ -1196,7 +1196,7 @@ void Interpreter::ProcessLeaderPartitionId(int argc, char *argv[])
 
     if (argc == 0)
     {
-        sServer->OutputFormat("%u\r\n", otThreadGetLocalLeaderPartitionId(mInstance));
+        mServer->OutputFormat("%u\r\n", otThreadGetLocalLeaderPartitionId(mInstance));
     }
     else
     {
@@ -1215,7 +1215,7 @@ void Interpreter::ProcessLeaderWeight(int argc, char *argv[])
 
     if (argc == 0)
     {
-        sServer->OutputFormat("%d\r\n", otThreadGetLocalLeaderWeight(mInstance));
+        mServer->OutputFormat("%d\r\n", otThreadGetLocalLeaderWeight(mInstance));
     }
     else
     {
@@ -1241,7 +1241,7 @@ void Interpreter::ProcessLinkQuality(int argc, char *argv[])
     {
         VerifyOrExit(otLinkGetAssignLinkQuality(mInstance, extAddress, &linkQuality) == kThreadError_None,
                      error = kThreadError_InvalidArgs);
-        sServer->OutputFormat("%d\r\n", linkQuality);
+        mServer->OutputFormat("%d\r\n", linkQuality);
     }
     else
     {
@@ -1264,10 +1264,10 @@ void Interpreter::ProcessMasterKey(int argc, char *argv[])
 
         for (int i = 0; i < keyLength; i++)
         {
-            sServer->OutputFormat("%02x", key[i]);
+            mServer->OutputFormat("%02x", key[i]);
         }
 
-        sServer->OutputFormat("\r\n");
+        mServer->OutputFormat("\r\n");
     }
     else
     {
@@ -1295,25 +1295,25 @@ void Interpreter::ProcessMode(int argc, char *argv[])
 
         if (linkMode.mRxOnWhenIdle)
         {
-            sServer->OutputFormat("r");
+            mServer->OutputFormat("r");
         }
 
         if (linkMode.mSecureDataRequests)
         {
-            sServer->OutputFormat("s");
+            mServer->OutputFormat("s");
         }
 
         if (linkMode.mDeviceType)
         {
-            sServer->OutputFormat("d");
+            mServer->OutputFormat("d");
         }
 
         if (linkMode.mNetworkData)
         {
-            sServer->OutputFormat("n");
+            mServer->OutputFormat("n");
         }
 
-        sServer->OutputFormat("\r\n");
+        mServer->OutputFormat("\r\n");
     }
     else
     {
@@ -1367,7 +1367,7 @@ void Interpreter::ProcessNetworkIdTimeout(int argc, char *argv[])
 
     if (argc == 0)
     {
-        sServer->OutputFormat("%d\r\n", otThreadGetNetworkIdTimeout(mInstance));
+        mServer->OutputFormat("%d\r\n", otThreadGetNetworkIdTimeout(mInstance));
     }
     else
     {
@@ -1386,7 +1386,7 @@ void Interpreter::ProcessNetworkName(int argc, char *argv[])
     if (argc == 0)
     {
         otStringPtr networkName(otThreadGetNetworkName(mInstance));
-        sServer->OutputFormat("%.*s\r\n", OT_NETWORK_NAME_MAX_SIZE, (const char *)networkName);
+        mServer->OutputFormat("%.*s\r\n", OT_NETWORK_NAME_MAX_SIZE, (const char *)networkName);
     }
     else
     {
@@ -1404,7 +1404,7 @@ void Interpreter::ProcessPanId(int argc, char *argv[])
 
     if (argc == 0)
     {
-        sServer->OutputFormat("%04x\r\n", otLinkGetPanId(mInstance));
+        mServer->OutputFormat("%04x\r\n", otLinkGetPanId(mInstance));
     }
     else
     {
@@ -1422,16 +1422,16 @@ void Interpreter::ProcessParent(int argc, char *argv[])
     otRouterInfo parentInfo;
 
     SuccessOrExit(error = otThreadGetParentInfo(mInstance, &parentInfo));
-    sServer->OutputFormat("Ext Addr: ");
+    mServer->OutputFormat("Ext Addr: ");
 
     for (size_t i = 0; i < sizeof(parentInfo.mExtAddress); i++)
     {
-        sServer->OutputFormat("%02x", parentInfo.mExtAddress.m8[i]);
+        mServer->OutputFormat("%02x", parentInfo.mExtAddress.m8[i]);
     }
 
-    sServer->OutputFormat("\r\n");
+    mServer->OutputFormat("\r\n");
 
-    sServer->OutputFormat("Rloc: %x\r\n", parentInfo.mRloc16);
+    mServer->OutputFormat("Rloc: %x\r\n", parentInfo.mRloc16);
 
 exit:
     (void)argc;
@@ -1455,8 +1455,8 @@ void Interpreter::HandleIcmpReceive(Message &aMessage, const Ip6::MessageInfo &a
 
     VerifyOrExit(aIcmpHeader.GetType() == kIcmp6TypeEchoReply, ;);
 
-    sServer->OutputFormat("%d bytes from ", aMessage.GetLength() - aMessage.GetOffset());
-    sServer->OutputFormat("%x:%x:%x:%x:%x:%x:%x:%x",
+    mServer->OutputFormat("%d bytes from ", aMessage.GetLength() - aMessage.GetOffset());
+    mServer->OutputFormat("%x:%x:%x:%x:%x:%x:%x:%x",
                           HostSwap16(aMessageInfo.GetPeerAddr().mFields.m16[0]),
                           HostSwap16(aMessageInfo.GetPeerAddr().mFields.m16[1]),
                           HostSwap16(aMessageInfo.GetPeerAddr().mFields.m16[2]),
@@ -1465,15 +1465,15 @@ void Interpreter::HandleIcmpReceive(Message &aMessage, const Ip6::MessageInfo &a
                           HostSwap16(aMessageInfo.GetPeerAddr().mFields.m16[5]),
                           HostSwap16(aMessageInfo.GetPeerAddr().mFields.m16[6]),
                           HostSwap16(aMessageInfo.GetPeerAddr().mFields.m16[7]));
-    sServer->OutputFormat(": icmp_seq=%d hlim=%d", aIcmpHeader.GetSequence(), aMessageInfo.mHopLimit);
+    mServer->OutputFormat(": icmp_seq=%d hlim=%d", aIcmpHeader.GetSequence(), aMessageInfo.mHopLimit);
 
     if (aMessage.Read(aMessage.GetOffset(), sizeof(uint32_t), &timestamp) >=
         static_cast<int>(sizeof(uint32_t)))
     {
-        sServer->OutputFormat(" time=%dms", Timer::GetNow() - HostSwap32(timestamp));
+        mServer->OutputFormat(" time=%dms", Timer::GetNow() - HostSwap32(timestamp));
     }
 
-    sServer->OutputFormat("\r\n");
+    mServer->OutputFormat("\r\n");
 
 exit:
     return;
@@ -1486,15 +1486,15 @@ void Interpreter::ProcessPing(int argc, char *argv[])
     long value;
 
     VerifyOrExit(argc > 0, error = kThreadError_Parse);
-    VerifyOrExit(!sPingTimer.IsRunning(), error = kThreadError_Busy);
+    VerifyOrExit(!mPingTimer.IsRunning(), error = kThreadError_Busy);
 
-    memset(&sMessageInfo, 0, sizeof(sMessageInfo));
-    SuccessOrExit(error = sMessageInfo.GetPeerAddr().FromString(argv[0]));
-    sMessageInfo.mInterfaceId = OT_NETIF_INTERFACE_ID_THREAD;
+    memset(&mMessageInfo, 0, sizeof(mMessageInfo));
+    SuccessOrExit(error = mMessageInfo.GetPeerAddr().FromString(argv[0]));
+    mMessageInfo.mInterfaceId = OT_NETIF_INTERFACE_ID_THREAD;
 
-    sLength = 8;
-    sCount = 1;
-    sInterval = 1000;
+    mLength = 8;
+    mCount = 1;
+    mInterval = 1000;
 
     while (index < argc)
     {
@@ -1503,16 +1503,16 @@ void Interpreter::ProcessPing(int argc, char *argv[])
         switch (index)
         {
         case 1:
-            sLength = (uint16_t)value;
+            mLength = (uint16_t)value;
             break;
 
         case 2:
-            sCount = (uint16_t)value;
+            mCount = (uint16_t)value;
             break;
 
         case 3:
-            sInterval = (uint32_t)value;
-            sInterval = sInterval * 1000;
+            mInterval = (uint32_t)value;
+            mInterval = mInterval * 1000;
             break;
 
         default:
@@ -1541,14 +1541,14 @@ void Interpreter::HandlePingTimer()
     uint32_t timestamp = HostSwap32(Timer::GetNow());
 
     otMessage *message;
-    const otMessageInfo *messageInfo = static_cast<const otMessageInfo *>(&sMessageInfo);
+    const otMessageInfo *messageInfo = static_cast<const otMessageInfo *>(&mMessageInfo);
 
     VerifyOrExit((message = otIp6NewMessage(mInstance, true)) != NULL, error = kThreadError_NoBufs);
     SuccessOrExit(error = otMessageAppend(message, &timestamp, sizeof(timestamp)));
-    SuccessOrExit(error = otMessageSetLength(message, sLength));
+    SuccessOrExit(error = otMessageSetLength(message, mLength));
     SuccessOrExit(error = otIcmp6SendEchoRequest(mInstance, message, messageInfo, 1));
 
-    sCount--;
+    mCount--;
 
 exit:
 
@@ -1557,9 +1557,9 @@ exit:
         otMessageFree(message);
     }
 
-    if (sCount)
+    if (mCount)
     {
-        sPingTimer.Start(sInterval);
+        mPingTimer.Start(mInterval);
     }
 }
 #endif
@@ -1571,7 +1571,7 @@ void Interpreter::ProcessPollPeriod(int argc, char *argv[])
 
     if (argc == 0)
     {
-        sServer->OutputFormat("%d\r\n", (otLinkGetPollPeriod(mInstance) / 1000));  // ms->s
+        mServer->OutputFormat("%d\r\n", (otLinkGetPollPeriod(mInstance) / 1000));  // ms->s
     }
     else
     {
@@ -1592,11 +1592,11 @@ void Interpreter::ProcessPromiscuous(int argc, char *argv[])
     {
         if (otLinkIsPromiscuous(mInstance) && otPlatRadioGetPromiscuous(mInstance))
         {
-            sServer->OutputFormat("Enabled\r\n");
+            mServer->OutputFormat("Enabled\r\n");
         }
         else
         {
-            sServer->OutputFormat("Disabled\r\n");
+            mServer->OutputFormat("Disabled\r\n");
         }
     }
     else
@@ -1624,39 +1624,39 @@ void Interpreter::s_HandleLinkPcapReceive(const RadioPacket *aFrame, void *aCont
 
 void Interpreter::HandleLinkPcapReceive(const RadioPacket *aFrame)
 {
-    sServer->OutputFormat("\r\n");
+    mServer->OutputFormat("\r\n");
 
     for (size_t i = 0; i < 44; i++)
     {
-        sServer->OutputFormat("=");
+        mServer->OutputFormat("=");
     }
 
-    sServer->OutputFormat("[len = %3u]", aFrame->mLength);
+    mServer->OutputFormat("[len = %3u]", aFrame->mLength);
 
     for (size_t i = 0; i < 28; i++)
     {
-        sServer->OutputFormat("=");
+        mServer->OutputFormat("=");
     }
 
-    sServer->OutputFormat("\r\n");
+    mServer->OutputFormat("\r\n");
 
     for (size_t i = 0; i < aFrame->mLength; i += 16)
     {
-        sServer->OutputFormat("|");
+        mServer->OutputFormat("|");
 
         for (size_t j = 0; j < 16; j++)
         {
             if (i + j < aFrame->mLength)
             {
-                sServer->OutputFormat(" %02X", aFrame->mPsdu[i + j]);
+                mServer->OutputFormat(" %02X", aFrame->mPsdu[i + j]);
             }
             else
             {
-                sServer->OutputFormat(" ..");
+                mServer->OutputFormat(" ..");
             }
         }
 
-        sServer->OutputFormat("|");
+        mServer->OutputFormat("|");
 
         for (size_t j = 0; j < 16; j++)
         {
@@ -1664,28 +1664,28 @@ void Interpreter::HandleLinkPcapReceive(const RadioPacket *aFrame)
             {
                 if (31 < aFrame->mPsdu[i + j] && aFrame->mPsdu[i + j] < 127)
                 {
-                    sServer->OutputFormat(" %c", aFrame->mPsdu[i + j]);
+                    mServer->OutputFormat(" %c", aFrame->mPsdu[i + j]);
                 }
                 else
                 {
-                    sServer->OutputFormat(" ?");
+                    mServer->OutputFormat(" ?");
                 }
             }
             else
             {
-                sServer->OutputFormat(" .");
+                mServer->OutputFormat(" .");
             }
         }
 
-        sServer->OutputFormat("|\r\n");
+        mServer->OutputFormat("|\r\n");
     }
 
     for (size_t i = 0; i < 83; i++)
     {
-        sServer->OutputFormat("-");
+        mServer->OutputFormat("-");
     }
 
-    sServer->OutputFormat("\r\n");
+    mServer->OutputFormat("\r\n");
 }
 #endif
 
@@ -1820,7 +1820,7 @@ ThreadError Interpreter::ProcessPrefixList(void)
 
     while (otNetDataGetNextPrefixInfo(mInstance, true, &iterator, &config) == kThreadError_None)
     {
-        sServer->OutputFormat("%x:%x:%x:%x::/%d ",
+        mServer->OutputFormat("%x:%x:%x:%x::/%d ",
                               HostSwap16(config.mPrefix.mPrefix.mFields.m16[0]),
                               HostSwap16(config.mPrefix.mPrefix.mFields.m16[1]),
                               HostSwap16(config.mPrefix.mPrefix.mFields.m16[2]),
@@ -1829,51 +1829,51 @@ ThreadError Interpreter::ProcessPrefixList(void)
 
         if (config.mPreferred)
         {
-            sServer->OutputFormat("p");
+            mServer->OutputFormat("p");
         }
 
         if (config.mSlaac)
         {
-            sServer->OutputFormat("a");
+            mServer->OutputFormat("a");
         }
 
         if (config.mDhcp)
         {
-            sServer->OutputFormat("d");
+            mServer->OutputFormat("d");
         }
 
         if (config.mConfigure)
         {
-            sServer->OutputFormat("c");
+            mServer->OutputFormat("c");
         }
 
         if (config.mDefaultRoute)
         {
-            sServer->OutputFormat("r");
+            mServer->OutputFormat("r");
         }
 
         if (config.mOnMesh)
         {
-            sServer->OutputFormat("o");
+            mServer->OutputFormat("o");
         }
 
         if (config.mStable)
         {
-            sServer->OutputFormat("s");
+            mServer->OutputFormat("s");
         }
 
         switch (config.mPreference)
         {
         case -1:
-            sServer->OutputFormat(" low\r\n");
+            mServer->OutputFormat(" low\r\n");
             break;
 
         case 0:
-            sServer->OutputFormat(" med\r\n");
+            mServer->OutputFormat(" med\r\n");
             break;
 
         case 1:
-            sServer->OutputFormat(" high\r\n");
+            mServer->OutputFormat(" high\r\n");
             break;
         }
     }
@@ -1929,8 +1929,8 @@ void Interpreter::ProcessReset(int argc, char *argv[])
 
 void Interpreter::ProcessRloc16(int argc, char *argv[])
 {
-    sServer->OutputFormat("%04x\r\n", otThreadGetRloc16(mInstance));
-    sServer->OutputFormat("Done\r\n");
+    mServer->OutputFormat("%04x\r\n", otThreadGetRloc16(mInstance));
+    mServer->OutputFormat("Done\r\n");
     (void)argc;
     (void)argv;
 }
@@ -2066,15 +2066,15 @@ void Interpreter::ProcessRouter(int argc, char *argv[])
     {
         if (isTable)
         {
-            sServer->OutputFormat("| ID | RLOC16 | Next Hop | Path Cost | LQI In | LQI Out | Age | Extended MAC     |\r\n");
-            sServer->OutputFormat("+----+--------+----------+-----------+--------+---------+-----+------------------+\r\n");
+            mServer->OutputFormat("| ID | RLOC16 | Next Hop | Path Cost | LQI In | LQI Out | Age | Extended MAC     |\r\n");
+            mServer->OutputFormat("+----+--------+----------+-----------+--------+---------+-----+------------------+\r\n");
         }
 
         for (uint8_t i = 0; ; i++)
         {
             if (otThreadGetRouterInfo(mInstance, i, &routerInfo) != kThreadError_None)
             {
-                sServer->OutputFormat("\r\n");
+                mServer->OutputFormat("\r\n");
                 ExitNow();
             }
 
@@ -2082,25 +2082,25 @@ void Interpreter::ProcessRouter(int argc, char *argv[])
             {
                 if (isTable)
                 {
-                    sServer->OutputFormat("| %2d ", routerInfo.mRouterId);
-                    sServer->OutputFormat("| 0x%04x ", routerInfo.mRloc16);
-                    sServer->OutputFormat("| %8d ", routerInfo.mNextHop);
-                    sServer->OutputFormat("| %9d ", routerInfo.mPathCost);
-                    sServer->OutputFormat("| %6d ", routerInfo.mLinkQualityIn);
-                    sServer->OutputFormat("| %7d ", routerInfo.mLinkQualityOut);
-                    sServer->OutputFormat("| %3d ", routerInfo.mAge);
-                    sServer->OutputFormat("| ");
+                    mServer->OutputFormat("| %2d ", routerInfo.mRouterId);
+                    mServer->OutputFormat("| 0x%04x ", routerInfo.mRloc16);
+                    mServer->OutputFormat("| %8d ", routerInfo.mNextHop);
+                    mServer->OutputFormat("| %9d ", routerInfo.mPathCost);
+                    mServer->OutputFormat("| %6d ", routerInfo.mLinkQualityIn);
+                    mServer->OutputFormat("| %7d ", routerInfo.mLinkQualityOut);
+                    mServer->OutputFormat("| %3d ", routerInfo.mAge);
+                    mServer->OutputFormat("| ");
 
                     for (size_t j = 0; j < sizeof(routerInfo.mExtAddress); j++)
                     {
-                        sServer->OutputFormat("%02x", routerInfo.mExtAddress.m8[j]);
+                        mServer->OutputFormat("%02x", routerInfo.mExtAddress.m8[j]);
                     }
 
-                    sServer->OutputFormat(" |\r\n");
+                    mServer->OutputFormat(" |\r\n");
                 }
                 else
                 {
-                    sServer->OutputFormat("%d ", i);
+                    mServer->OutputFormat("%d ", i);
                 }
             }
         }
@@ -2109,29 +2109,29 @@ void Interpreter::ProcessRouter(int argc, char *argv[])
     SuccessOrExit(error = ParseLong(argv[0], value));
     SuccessOrExit(error = otThreadGetRouterInfo(mInstance, static_cast<uint16_t>(value), &routerInfo));
 
-    sServer->OutputFormat("Alloc: %d\r\n", routerInfo.mAllocated);
+    mServer->OutputFormat("Alloc: %d\r\n", routerInfo.mAllocated);
 
     if (routerInfo.mAllocated)
     {
-        sServer->OutputFormat("Router ID: %d\r\n", routerInfo.mRouterId);
-        sServer->OutputFormat("Rloc: %04x\r\n", routerInfo.mRloc16);
-        sServer->OutputFormat("Next Hop: %04x\r\n", static_cast<uint16_t>(routerInfo.mNextHop) << 10);
-        sServer->OutputFormat("Link: %d\r\n", routerInfo.mLinkEstablished);
+        mServer->OutputFormat("Router ID: %d\r\n", routerInfo.mRouterId);
+        mServer->OutputFormat("Rloc: %04x\r\n", routerInfo.mRloc16);
+        mServer->OutputFormat("Next Hop: %04x\r\n", static_cast<uint16_t>(routerInfo.mNextHop) << 10);
+        mServer->OutputFormat("Link: %d\r\n", routerInfo.mLinkEstablished);
 
         if (routerInfo.mLinkEstablished)
         {
-            sServer->OutputFormat("Ext Addr: ");
+            mServer->OutputFormat("Ext Addr: ");
 
             for (size_t j = 0; j < sizeof(routerInfo.mExtAddress); j++)
             {
-                sServer->OutputFormat("%02x", routerInfo.mExtAddress.m8[j]);
+                mServer->OutputFormat("%02x", routerInfo.mExtAddress.m8[j]);
             }
 
-            sServer->OutputFormat("\r\n");
-            sServer->OutputFormat("Cost: %d\r\n", routerInfo.mPathCost);
-            sServer->OutputFormat("LQI In: %d\r\n", routerInfo.mLinkQualityIn);
-            sServer->OutputFormat("LQI Out: %d\r\n", routerInfo.mLinkQualityOut);
-            sServer->OutputFormat("Age: %d\r\n", routerInfo.mAge);
+            mServer->OutputFormat("\r\n");
+            mServer->OutputFormat("Cost: %d\r\n", routerInfo.mPathCost);
+            mServer->OutputFormat("LQI In: %d\r\n", routerInfo.mLinkQualityIn);
+            mServer->OutputFormat("LQI Out: %d\r\n", routerInfo.mLinkQualityOut);
+            mServer->OutputFormat("Age: %d\r\n", routerInfo.mAge);
         }
     }
 
@@ -2146,7 +2146,7 @@ void Interpreter::ProcessRouterDowngradeThreshold(int argc, char *argv[])
 
     if (argc == 0)
     {
-        sServer->OutputFormat("%d\r\n", otThreadGetRouterDowngradeThreshold(mInstance));
+        mServer->OutputFormat("%d\r\n", otThreadGetRouterDowngradeThreshold(mInstance));
     }
     else
     {
@@ -2166,11 +2166,11 @@ void Interpreter::ProcessRouterRole(int argc, char *argv[])
     {
         if (otThreadIsRouterRoleEnabled(mInstance))
         {
-            sServer->OutputFormat("Enabled\r\n");
+            mServer->OutputFormat("Enabled\r\n");
         }
         else
         {
-            sServer->OutputFormat("Disabled\r\n");
+            mServer->OutputFormat("Disabled\r\n");
         }
     }
     else if (strcmp(argv[0], "enable") == 0)
@@ -2197,7 +2197,7 @@ void Interpreter::ProcessRouterSelectionJitter(int argc, char *argv[])
 
     if (argc == 0)
     {
-        sServer->OutputFormat("%d\r\n", otThreadGetRouterSelectionJitter(mInstance));
+        mServer->OutputFormat("%d\r\n", otThreadGetRouterSelectionJitter(mInstance));
     }
     else
     {
@@ -2217,7 +2217,7 @@ void Interpreter::ProcessRouterUpgradeThreshold(int argc, char *argv[])
 
     if (argc == 0)
     {
-        sServer->OutputFormat("%d\r\n", otThreadGetRouterUpgradeThreshold(mInstance));
+        mServer->OutputFormat("%d\r\n", otThreadGetRouterUpgradeThreshold(mInstance));
     }
     else
     {
@@ -2241,8 +2241,8 @@ void Interpreter::ProcessScan(int argc, char *argv[])
         scanChannels = 1 << value;
     }
 
-    sServer->OutputFormat("| J | Network Name     | Extended PAN     | PAN  | MAC Address      | Ch | dBm | LQI |\r\n");
-    sServer->OutputFormat("+---+------------------+------------------+------+------------------+----+-----+-----+\r\n");
+    mServer->OutputFormat("| J | Network Name     | Extended PAN     | PAN  | MAC Address      | Ch | dBm | LQI |\r\n");
+    mServer->OutputFormat("+---+------------------+------------------+------+------------------+----+-----+-----+\r\n");
     SuccessOrExit(error = otLinkActiveScan(mInstance, scanChannels, 0, &Interpreter::s_HandleActiveScanResult, this));
 
     return;
@@ -2260,23 +2260,23 @@ void Interpreter::HandleActiveScanResult(otActiveScanResult *aResult)
 {
     if (aResult == NULL)
     {
-        sServer->OutputFormat("Done\r\n");
+        mServer->OutputFormat("Done\r\n");
         ExitNow();
     }
 
-    sServer->OutputFormat("| %d ", aResult->mIsJoinable);
+    mServer->OutputFormat("| %d ", aResult->mIsJoinable);
 
-    sServer->OutputFormat("| %-16s ", aResult->mNetworkName.m8);
+    mServer->OutputFormat("| %-16s ", aResult->mNetworkName.m8);
 
-    sServer->OutputFormat("| ");
+    mServer->OutputFormat("| ");
     OutputBytes(aResult->mExtendedPanId.m8, OT_EXT_PAN_ID_SIZE);
-    sServer->OutputFormat(" ");
+    mServer->OutputFormat(" ");
 
-    sServer->OutputFormat("| %04x | ", aResult->mPanId);
+    mServer->OutputFormat("| %04x | ", aResult->mPanId);
     OutputBytes(aResult->mExtAddress.m8, OT_EXT_ADDRESS_SIZE);
-    sServer->OutputFormat(" | %2d ", aResult->mChannel);
-    sServer->OutputFormat("| %3d ", aResult->mRssi);
-    sServer->OutputFormat("| %3d |\r\n", aResult->mLqi);
+    mServer->OutputFormat(" | %2d ", aResult->mChannel);
+    mServer->OutputFormat("| %3d ", aResult->mRssi);
+    mServer->OutputFormat("| %3d |\r\n", aResult->mLqi);
 
 exit:
     return;
@@ -2288,11 +2288,11 @@ void Interpreter::ProcessSingleton(int argc, char *argv[])
 
     if (otThreadIsSingleton(mInstance))
     {
-        sServer->OutputFormat("true\r\n");
+        mServer->OutputFormat("true\r\n");
     }
     else
     {
-        sServer->OutputFormat("false\r\n");
+        mServer->OutputFormat("false\r\n");
     }
 
     (void)argc;
@@ -2310,27 +2310,27 @@ void Interpreter::ProcessState(int argc, char *argv[])
         switch (otThreadGetDeviceRole(mInstance))
         {
         case kDeviceRoleOffline:
-            sServer->OutputFormat("offline\r\n");
+            mServer->OutputFormat("offline\r\n");
             break;
 
         case kDeviceRoleDisabled:
-            sServer->OutputFormat("disabled\r\n");
+            mServer->OutputFormat("disabled\r\n");
             break;
 
         case kDeviceRoleDetached:
-            sServer->OutputFormat("detached\r\n");
+            mServer->OutputFormat("detached\r\n");
             break;
 
         case kDeviceRoleChild:
-            sServer->OutputFormat("child\r\n");
+            mServer->OutputFormat("child\r\n");
             break;
 
         case kDeviceRoleRouter:
-            sServer->OutputFormat("router\r\n");
+            mServer->OutputFormat("router\r\n");
             break;
 
         case kDeviceRoleLeader:
-            sServer->OutputFormat("leader\r\n");
+            mServer->OutputFormat("leader\r\n");
             break;
         }
     }
@@ -2386,7 +2386,7 @@ exit:
 void Interpreter::ProcessVersion(int argc, char *argv[])
 {
     otStringPtr version(otGetVersionString());
-    sServer->OutputFormat("%s\r\n", (const char *)version);
+    mServer->OutputFormat("%s\r\n", (const char *)version);
     AppendResult(kThreadError_None);
     (void)argc;
     (void)argv;
@@ -2640,7 +2640,7 @@ void Interpreter::ProcessCommissioner(int argc, char *argv[])
     }
     else if (strcmp(argv[0], "sessionid") == 0)
     {
-        sServer->OutputFormat("%d\r\n", otCommissionerGetSessionId(mInstance));
+        mServer->OutputFormat("%d\r\n", otCommissionerGetSessionId(mInstance));
     }
 
 exit:
@@ -2656,14 +2656,14 @@ void OTCALL Interpreter::s_HandleEnergyReport(uint32_t aChannelMask, const uint8
 
 void Interpreter::HandleEnergyReport(uint32_t aChannelMask, const uint8_t *aEnergyList, uint8_t aEnergyListLength)
 {
-    sServer->OutputFormat("Energy: %08x ", aChannelMask);
+    mServer->OutputFormat("Energy: %08x ", aChannelMask);
 
     for (uint8_t i = 0; i < aEnergyListLength; i++)
     {
-        sServer->OutputFormat("%d ", aEnergyList[i]);
+        mServer->OutputFormat("%d ", aEnergyList[i]);
     }
 
-    sServer->OutputFormat("\r\n");
+    mServer->OutputFormat("\r\n");
 }
 
 void OTCALL Interpreter::s_HandlePanIdConflict(uint16_t aPanId, uint32_t aChannelMask, void *aContext)
@@ -2673,7 +2673,7 @@ void OTCALL Interpreter::s_HandlePanIdConflict(uint16_t aPanId, uint32_t aChanne
 
 void Interpreter::HandlePanIdConflict(uint16_t aPanId, uint32_t aChannelMask)
 {
-    sServer->OutputFormat("Conflict: %04x, %08x\r\n", aPanId, aChannelMask);
+    mServer->OutputFormat("Conflict: %04x, %08x\r\n", aPanId, aChannelMask);
 }
 
 #endif  // OPENTHREAD_ENABLE_COMMISSIONER
@@ -2716,11 +2716,11 @@ void Interpreter::HandleJoinerCallback(ThreadError aError)
     switch (aError)
     {
     case kThreadError_None:
-        sServer->OutputFormat("Join success\r\n");
+        mServer->OutputFormat("Join success\r\n");
         break;
 
     default:
-        sServer->OutputFormat("Join failed [%s]\r\n", otThreadErrorToString(aError));
+        mServer->OutputFormat("Join failed [%s]\r\n", otThreadErrorToString(aError));
         break;
     }
 }
@@ -2732,7 +2732,7 @@ void Interpreter::ProcessJoinerPort(int argc, char *argv[])
 
     if (argc == 0)
     {
-        sServer->OutputFormat("%d\r\n", otThreadGetJoinerUdpPort(mInstance));
+        mServer->OutputFormat("%d\r\n", otThreadGetJoinerUdpPort(mInstance));
     }
     else
     {
@@ -2756,11 +2756,11 @@ void Interpreter::ProcessWhitelist(int argc, char *argv[])
     {
         if (otLinkIsWhitelistEnabled(mInstance))
         {
-            sServer->OutputFormat("Enabled\r\n");
+            mServer->OutputFormat("Enabled\r\n");
         }
         else
         {
-            sServer->OutputFormat("Disabled\r\n");
+            mServer->OutputFormat("Disabled\r\n");
         }
 
         for (uint8_t i = 0; ; i++)
@@ -2779,10 +2779,10 @@ void Interpreter::ProcessWhitelist(int argc, char *argv[])
 
             if (entry.mFixedRssi)
             {
-                sServer->OutputFormat(" %d", entry.mRssi);
+                mServer->OutputFormat(" %d", entry.mRssi);
             }
 
-            sServer->OutputFormat("\r\n");
+            mServer->OutputFormat("\r\n");
         }
     }
     else if (strcmp(argv[argcur], "add") == 0)
@@ -2828,7 +2828,7 @@ exit:
 void Interpreter::ProcessDiag(int argc, char *argv[])
 {
     // all diagnostics related features are processed within diagnostics module
-    sServer->OutputFormat("%s\r\n", otDiagProcessCmd(argc, argv));
+    mServer->OutputFormat("%s\r\n", otDiagProcessCmd(argc, argv));
 }
 #endif
 
@@ -2838,7 +2838,7 @@ void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength, Server &aServer)
     char *cmd;
     uint8_t argc = 0, i = 0;
 
-    sServer = &aServer;
+    mServer = &aServer;
 
     VerifyOrExit(aBuf != NULL, ;);
 
@@ -2847,7 +2847,7 @@ void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength, Server &aServer)
     for (cmd = aBuf + 1; (cmd < aBuf + aBufLength) && (cmd != NULL); ++cmd)
     {
         VerifyOrExit(argc < kMaxArgs,
-                     sServer->OutputFormat("Error: too many args (max %d)\r\n", kMaxArgs));
+                     mServer->OutputFormat("Error: too many args (max %d)\r\n", kMaxArgs));
 
         if (*cmd == ' ' || *cmd == '\r' || *cmd == '\n')
         {
@@ -2864,7 +2864,7 @@ void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength, Server &aServer)
 
 #if OPENTHREAD_ENABLE_DIAG
     VerifyOrExit((!otDiagIsEnabled() || (strcmp(cmd, "diag") == 0)),
-                 sServer->OutputFormat("under diagnostics mode, execute 'diag stop' before running any other commands.\r\n"));
+                 mServer->OutputFormat("under diagnostics mode, execute 'diag stop' before running any other commands.\r\n"));
 #endif
 
     for (i = 0; i < sizeof(sCommands) / sizeof(sCommands[0]); i++)
@@ -2974,7 +2974,7 @@ void Interpreter::HandleDiagnosticGetResponse(Message &aMessage, const Ip6::Mess
     uint16_t bytesPrinted = 0;
     uint16_t length = aMessage.GetLength() - aMessage.GetOffset();
 
-    sServer->OutputFormat("DIAG_GET.rsp: ");
+    mServer->OutputFormat("DIAG_GET.rsp: ");
 
     while (length > 0)
     {
@@ -2987,7 +2987,7 @@ void Interpreter::HandleDiagnosticGetResponse(Message &aMessage, const Ip6::Mess
         bytesPrinted += bytesToPrint;
     }
 
-    sServer->OutputFormat("\r\n");
+    mServer->OutputFormat("\r\n");
 }
 #endif
 

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -293,7 +293,7 @@ private:
 
     static const struct Command sCommands[];
 
-    Server *sServer;
+    Server *mServer;
 
 #ifdef OTDLL
 
@@ -312,12 +312,12 @@ private:
 
 #else
 
-    Ip6::MessageInfo sMessageInfo;
+    Ip6::MessageInfo mMessageInfo;
 
-    uint16_t sLength;
-    uint16_t sCount;
-    uint32_t sInterval;
-    Timer sPingTimer;
+    uint16_t mLength;
+    uint16_t mCount;
+    uint32_t mInterval;
+    Timer mPingTimer;
 
     otNetifAddress  mSlaacAddresses[OPENTHREAD_CONFIG_NUM_SLAAC_ADDRESSES];
 #if OPENTHREAD_ENABLE_DHCP6_CLIENT


### PR DESCRIPTION
Thread::Cli::Interpreter originally used static variables with names of the form "sField".  
It was since updated such that many of those fields are now member instance data, but their names were not updated.  This PR updates the names of those fields to follow the coding convention, "mField". 