### PR TITLE
Make mbedTLS heap size configurable.

### DIFF
--- a/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
+++ b/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
@@ -115,4 +115,12 @@
  */
 #define SETTINGS_CONFIG_PAGE_NUM                                4
 
+/**
+ * @def OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE
+ *
+ * The size of mbedTLS heap buffer when DTLS is enabled.
+ *
+ */
+#define OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE                     (4096 * sizeof(void *))
+
 #endif  // OPENTHREAD_CORE_NRF52840_CONFIG_H_

--- a/src/core/crypto/mbedtls.hpp
+++ b/src/core/crypto/mbedtls.hpp
@@ -40,6 +40,8 @@
 #include <openthread-config.h>
 #endif
 
+#include <openthread-core-config.h>
+
 #include <mbedtls/memory_buffer_alloc.h>
 
 namespace Thread {
@@ -62,9 +64,9 @@ public:
     enum
     {
 #if OPENTHREAD_ENABLE_DTLS
-        kMemorySize = 2048 * sizeof(void *), ///< Size of memory buffer (bytes).
+        kMemorySize = OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE, ///< Size of memory buffer (bytes).
 #else
-        kMemorySize = 384,                   ///< Size of memory buffer (bytes).
+        kMemorySize = 384,                                 ///< Size of memory buffer (bytes).
 #endif
     };
 

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -677,4 +677,14 @@
 #define OPENTHREAD_CONFIG_ENABLE_AUTO_START_SUPPORT             1
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE
+ *
+ * The size of mbedTLS heap buffer when DTLS is enabled.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE
+#define OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE                     (2048 * sizeof(void *))
+#endif
+
 #endif  // OPENTHREAD_CORE_DEFAULT_CONFIG_H_


### PR DESCRIPTION
This PR makes the mbedTLS heap size configurable, so it can be increased if needed, to handle larger context allocation. Current heap size seem to be perfectly tailored for default mbedTLS needs, so it is not possible to allocate any extra memory for Crypto engine needs.