### PR TITLE
`spinel.h`: Adjust spacing and alignments

### DIFF
--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -37,9 +37,9 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 # if defined(__GNUC__)
-#  define SPINEL_API_EXTERN              extern __attribute__ ((visibility ("default")))
-#  define SPINEL_API_NONNULL_ALL         __attribute__((nonnull))
-#  define SPINEL_API_WARN_UNUSED_RESULT  __attribute__((warn_unused_result))
+#  define SPINEL_API_EXTERN             extern __attribute__ ((visibility ("default")))
+#  define SPINEL_API_NONNULL_ALL        __attribute__((nonnull))
+#  define SPINEL_API_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 # endif // ifdef __GNUC__
 
 # if !defined(__BEGIN_DECLS) || !defined(__END_DECLS)
@@ -55,7 +55,7 @@
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #ifndef SPINEL_API_EXTERN
-# define SPINEL_API_EXTERN               extern
+# define SPINEL_API_EXTERN              extern
 #endif
 
 #ifndef SPINEL_API_NONNULL_ALL
@@ -71,11 +71,11 @@
 #define SPINEL_PROTOCOL_VERSION_THREAD_MAJOR    4
 #define SPINEL_PROTOCOL_VERSION_THREAD_MINOR    3
 
-#define SPINEL_FRAME_MAX_SIZE                   1300
+#define SPINEL_FRAME_MAX_SIZE           1300
 
 /// Macro for generating bit masks using bit index from the spec
-#define SPINEL_BIT_MASK(bit_index,field_bit_count) \
-    ( (1 << ((field_bit_count) - 1)) >> (bit_index))
+#define SPINEL_BIT_MASK(bit_index,field_bit_count)                                                      \
+                                        ( (1 << ((field_bit_count) - 1)) >> (bit_index) )
 
 // ----------------------------------------------------------------------------
 
@@ -83,31 +83,32 @@ __BEGIN_DECLS
 
 typedef enum
 {
-    SPINEL_STATUS_OK                = 0, ///< Operation has completed successfully.
-    SPINEL_STATUS_FAILURE           = 1, ///< Operation has failed for some undefined reason.
+    SPINEL_STATUS_OK                    = 0, ///< Operation has completed successfully.
+    SPINEL_STATUS_FAILURE               = 1, ///< Operation has failed for some undefined reason.
 
-    SPINEL_STATUS_UNIMPLEMENTED     = 2, ///< Given operation has not been implemented.
-    SPINEL_STATUS_INVALID_ARGUMENT  = 3, ///< An argument to the operation is invalid.
-    SPINEL_STATUS_INVALID_STATE     = 4, ///< This operation is invalid for the current device state.
-    SPINEL_STATUS_INVALID_COMMAND   = 5, ///< This command is not recognized.
-    SPINEL_STATUS_INVALID_INTERFACE = 6, ///< This interface is not supported.
-    SPINEL_STATUS_INTERNAL_ERROR    = 7, ///< An internal runtime error has occured.
-    SPINEL_STATUS_SECURITY_ERROR    = 8, ///< A security/authentication error has occured.
-    SPINEL_STATUS_PARSE_ERROR       = 9, ///< A error has occured while parsing the command.
-    SPINEL_STATUS_IN_PROGRESS       = 10, ///< This operation is in progress.
-    SPINEL_STATUS_NOMEM             = 11, ///< Operation prevented due to memory pressure.
-    SPINEL_STATUS_BUSY              = 12, ///< The device is currently performing a mutually exclusive operation
-    SPINEL_STATUS_PROP_NOT_FOUND    = 13, ///< The given property is not recognized.
-    SPINEL_STATUS_DROPPED           = 14, ///< A/The packet was dropped.
-    SPINEL_STATUS_EMPTY             = 15, ///< The result of the operation is empty.
-    SPINEL_STATUS_CMD_TOO_BIG       = 16, ///< The command was too large to fit in the internal buffer.
-    SPINEL_STATUS_NO_ACK            = 17, ///< The packet was not acknowledged.
-    SPINEL_STATUS_CCA_FAILURE       = 18, ///< The packet was not sent due to a CCA failure.
-    SPINEL_STATUS_ALREADY           = 19, ///< The operation is already in progress.
-    SPINEL_STATUS_ITEM_NOT_FOUND    = 20, ///< The given item could not be found.
-    SPINEL_STATUS_INVALID_COMMAND_FOR_PROP = 21, ///< The given command cannot be performed on this property.
+    SPINEL_STATUS_UNIMPLEMENTED         = 2, ///< Given operation has not been implemented.
+    SPINEL_STATUS_INVALID_ARGUMENT      = 3, ///< An argument to the operation is invalid.
+    SPINEL_STATUS_INVALID_STATE         = 4, ///< This operation is invalid for the current device state.
+    SPINEL_STATUS_INVALID_COMMAND       = 5, ///< This command is not recognized.
+    SPINEL_STATUS_INVALID_INTERFACE     = 6, ///< This interface is not supported.
+    SPINEL_STATUS_INTERNAL_ERROR        = 7, ///< An internal runtime error has occured.
+    SPINEL_STATUS_SECURITY_ERROR        = 8, ///< A security/authentication error has occured.
+    SPINEL_STATUS_PARSE_ERROR           = 9, ///< A error has occured while parsing the command.
+    SPINEL_STATUS_IN_PROGRESS           = 10, ///< This operation is in progress.
+    SPINEL_STATUS_NOMEM                 = 11, ///< Operation prevented due to memory pressure.
+    SPINEL_STATUS_BUSY                  = 12, ///< The device is currently performing a mutually exclusive operation
+    SPINEL_STATUS_PROP_NOT_FOUND        = 13, ///< The given property is not recognized.
+    SPINEL_STATUS_DROPPED               = 14, ///< A/The packet was dropped.
+    SPINEL_STATUS_EMPTY                 = 15, ///< The result of the operation is empty.
+    SPINEL_STATUS_CMD_TOO_BIG           = 16, ///< The command was too large to fit in the internal buffer.
+    SPINEL_STATUS_NO_ACK                = 17, ///< The packet was not acknowledged.
+    SPINEL_STATUS_CCA_FAILURE           = 18, ///< The packet was not sent due to a CCA failure.
+    SPINEL_STATUS_ALREADY               = 19, ///< The operation is already in progress.
+    SPINEL_STATUS_ITEM_NOT_FOUND        = 20, ///< The given item could not be found.
+    SPINEL_STATUS_INVALID_COMMAND_FOR_PROP
+                                        = 21, ///< The given command cannot be performed on this property.
 
-    SPINEL_STATUS_JOIN__BEGIN       = 104,
+    SPINEL_STATUS_JOIN__BEGIN           = 104,
 
     /// Generic failure to associate with other peers.
     /**
@@ -117,7 +118,7 @@ typedef enum
      *
      *  \sa SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
      */
-    SPINEL_STATUS_JOIN_FAILURE      = SPINEL_STATUS_JOIN__BEGIN + 0,
+    SPINEL_STATUS_JOIN_FAILURE          = SPINEL_STATUS_JOIN__BEGIN + 0,
 
     /// The node found other peers but was unable to decode their packets.
     /**
@@ -126,117 +127,118 @@ typedef enum
      *
      *  \sa SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
      */
-    SPINEL_STATUS_JOIN_SECURITY     = SPINEL_STATUS_JOIN__BEGIN + 1,
+    SPINEL_STATUS_JOIN_SECURITY         = SPINEL_STATUS_JOIN__BEGIN + 1,
 
     /// The node was unable to find any other peers on the network.
     /**
      *  \sa SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
      */
-    SPINEL_STATUS_JOIN_NO_PEERS     = SPINEL_STATUS_JOIN__BEGIN + 2,
+    SPINEL_STATUS_JOIN_NO_PEERS         = SPINEL_STATUS_JOIN__BEGIN + 2,
 
     /// The only potential peer nodes found are incompatible.
     /**
      *  \sa SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
      */
-    SPINEL_STATUS_JOIN_INCOMPATIBLE = SPINEL_STATUS_JOIN__BEGIN + 3,
+    SPINEL_STATUS_JOIN_INCOMPATIBLE     = SPINEL_STATUS_JOIN__BEGIN + 3,
 
-    SPINEL_STATUS_JOIN__END         = 112,
+    SPINEL_STATUS_JOIN__END             = 112,
 
-    SPINEL_STATUS_RESET__BEGIN      = 112,
-    SPINEL_STATUS_RESET_POWER_ON    = SPINEL_STATUS_RESET__BEGIN + 0,
-    SPINEL_STATUS_RESET_EXTERNAL    = SPINEL_STATUS_RESET__BEGIN + 1,
-    SPINEL_STATUS_RESET_SOFTWARE    = SPINEL_STATUS_RESET__BEGIN + 2,
-    SPINEL_STATUS_RESET_FAULT       = SPINEL_STATUS_RESET__BEGIN + 3,
-    SPINEL_STATUS_RESET_CRASH       = SPINEL_STATUS_RESET__BEGIN + 4,
-    SPINEL_STATUS_RESET_ASSERT      = SPINEL_STATUS_RESET__BEGIN + 5,
-    SPINEL_STATUS_RESET_OTHER       = SPINEL_STATUS_RESET__BEGIN + 6,
-    SPINEL_STATUS_RESET_UNKNOWN     = SPINEL_STATUS_RESET__BEGIN + 7,
-    SPINEL_STATUS_RESET_WATCHDOG    = SPINEL_STATUS_RESET__BEGIN + 8,
-    SPINEL_STATUS_RESET__END        = 128,
+    SPINEL_STATUS_RESET__BEGIN          = 112,
+    SPINEL_STATUS_RESET_POWER_ON        = SPINEL_STATUS_RESET__BEGIN + 0,
+    SPINEL_STATUS_RESET_EXTERNAL        = SPINEL_STATUS_RESET__BEGIN + 1,
+    SPINEL_STATUS_RESET_SOFTWARE        = SPINEL_STATUS_RESET__BEGIN + 2,
+    SPINEL_STATUS_RESET_FAULT           = SPINEL_STATUS_RESET__BEGIN + 3,
+    SPINEL_STATUS_RESET_CRASH           = SPINEL_STATUS_RESET__BEGIN + 4,
+    SPINEL_STATUS_RESET_ASSERT          = SPINEL_STATUS_RESET__BEGIN + 5,
+    SPINEL_STATUS_RESET_OTHER           = SPINEL_STATUS_RESET__BEGIN + 6,
+    SPINEL_STATUS_RESET_UNKNOWN         = SPINEL_STATUS_RESET__BEGIN + 7,
+    SPINEL_STATUS_RESET_WATCHDOG        = SPINEL_STATUS_RESET__BEGIN + 8,
+    SPINEL_STATUS_RESET__END            = 128,
 
-    SPINEL_STATUS_VENDOR__BEGIN     = 15360,
-    SPINEL_STATUS_VENDOR__END       = 16384,
+    SPINEL_STATUS_VENDOR__BEGIN         = 15360,
+    SPINEL_STATUS_VENDOR__END           = 16384,
 
-    SPINEL_STATUS_STACK_NATIVE__BEGIN = 16384,
-    SPINEL_STATUS_STACK_NATIVE__END   = 81920,
+    SPINEL_STATUS_STACK_NATIVE__BEGIN   = 16384,
+    SPINEL_STATUS_STACK_NATIVE__END     = 81920,
 
-    SPINEL_STATUS_EXPERIMENTAL__BEGIN = 2000000,
-    SPINEL_STATUS_EXPERIMENTAL__END   = 2097152,
+    SPINEL_STATUS_EXPERIMENTAL__BEGIN   = 2000000,
+    SPINEL_STATUS_EXPERIMENTAL__END     = 2097152,
 } spinel_status_t;
 
 typedef enum
 {
-    SPINEL_NET_ROLE_DETACHED   = 0,
-    SPINEL_NET_ROLE_CHILD      = 1,
-    SPINEL_NET_ROLE_ROUTER     = 2,
-    SPINEL_NET_ROLE_LEADER     = 3,
+    SPINEL_NET_ROLE_DETACHED            = 0,
+    SPINEL_NET_ROLE_CHILD               = 1,
+    SPINEL_NET_ROLE_ROUTER              = 2,
+    SPINEL_NET_ROLE_LEADER              = 3,
 } spinel_net_role_t;
 
 typedef enum
 {
-    SPINEL_SCAN_STATE_IDLE     = 0,
-    SPINEL_SCAN_STATE_BEACON   = 1,
-    SPINEL_SCAN_STATE_ENERGY   = 2,
+    SPINEL_SCAN_STATE_IDLE              = 0,
+    SPINEL_SCAN_STATE_BEACON            = 1,
+    SPINEL_SCAN_STATE_ENERGY            = 2,
 } spinel_scan_state_t;
 
 typedef enum
 {
-    SPINEL_POWER_STATE_OFFLINE    = 0,
-    SPINEL_POWER_STATE_DEEP_SLEEP = 1,
-    SPINEL_POWER_STATE_STANDBY    = 2,
-    SPINEL_POWER_STATE_LOW_POWER  = 3,
-    SPINEL_POWER_STATE_ONLINE     = 4,
+    SPINEL_POWER_STATE_OFFLINE          = 0,
+    SPINEL_POWER_STATE_DEEP_SLEEP       = 1,
+    SPINEL_POWER_STATE_STANDBY          = 2,
+    SPINEL_POWER_STATE_LOW_POWER        = 3,
+    SPINEL_POWER_STATE_ONLINE           = 4,
 } spinel_power_state_t;
 
+enum
+{
+    SPINEL_NET_FLAG_ON_MESH             = (1 << 0),
+    SPINEL_NET_FLAG_DEFAULT_ROUTE       = (1 << 1),
+    SPINEL_NET_FLAG_CONFIGURE           = (1 << 2),
+    SPINEL_NET_FLAG_DHCP                = (1 << 3),
+    SPINEL_NET_FLAG_SLAAC               = (1 << 4),
+    SPINEL_NET_FLAG_PREFERRED           = (1 << 5),
+
+    SPINEL_NET_FLAG_PREFERENCE_OFFSET   = 6,
+    SPINEL_NET_FLAG_PREFERENCE_MASK     = (3 << SPINEL_NET_FLAG_PREFERENCE_OFFSET),
+};
+
 enum {
-    SPINEL_NET_FLAG_ON_MESH           = (1 << 0),
-    SPINEL_NET_FLAG_DEFAULT_ROUTE     = (1 << 1),
-    SPINEL_NET_FLAG_CONFIGURE         = (1 << 2),
-    SPINEL_NET_FLAG_DHCP              = (1 << 3),
-    SPINEL_NET_FLAG_SLAAC             = (1 << 4),
-    SPINEL_NET_FLAG_PREFERRED         = (1 << 5),
-
-    SPINEL_NET_FLAG_PREFERENCE_OFFSET = 6,
-    SPINEL_NET_FLAG_PREFERENCE_MASK   = (3 << SPINEL_NET_FLAG_PREFERENCE_OFFSET),
-};
-
-enum {
-    SPINEL_GPIO_FLAG_DIR_INPUT        = 0,
-    SPINEL_GPIO_FLAG_DIR_OUTPUT       = SPINEL_BIT_MASK(0, 8),
-    SPINEL_GPIO_FLAG_PULL_UP          = SPINEL_BIT_MASK(1, 8),
-    SPINEL_GPIO_FLAG_PULL_DOWN        = SPINEL_BIT_MASK(2, 8),
-    SPINEL_GPIO_FLAG_OPEN_DRAIN       = SPINEL_BIT_MASK(2, 8),
-    SPINEL_GPIO_FLAG_TRIGGER_NONE     = 0,
-    SPINEL_GPIO_FLAG_TRIGGER_RISING   = SPINEL_BIT_MASK(3, 8),
-    SPINEL_GPIO_FLAG_TRIGGER_FALLING  = SPINEL_BIT_MASK(4, 8),
-    SPINEL_GPIO_FLAG_TRIGGER_ANY      = SPINEL_GPIO_FLAG_TRIGGER_RISING
-                                      | SPINEL_GPIO_FLAG_TRIGGER_FALLING,
+    SPINEL_GPIO_FLAG_DIR_INPUT          = 0,
+    SPINEL_GPIO_FLAG_DIR_OUTPUT         = SPINEL_BIT_MASK(0, 8),
+    SPINEL_GPIO_FLAG_PULL_UP            = SPINEL_BIT_MASK(1, 8),
+    SPINEL_GPIO_FLAG_PULL_DOWN          = SPINEL_BIT_MASK(2, 8),
+    SPINEL_GPIO_FLAG_OPEN_DRAIN         = SPINEL_BIT_MASK(2, 8),
+    SPINEL_GPIO_FLAG_TRIGGER_NONE       = 0,
+    SPINEL_GPIO_FLAG_TRIGGER_RISING     = SPINEL_BIT_MASK(3, 8),
+    SPINEL_GPIO_FLAG_TRIGGER_FALLING    = SPINEL_BIT_MASK(4, 8),
+    SPINEL_GPIO_FLAG_TRIGGER_ANY        = SPINEL_GPIO_FLAG_TRIGGER_RISING
+                                        | SPINEL_GPIO_FLAG_TRIGGER_FALLING,
 };
 
 enum
 {
-    SPINEL_PROTOCOL_TYPE_BOOTLOADER = 0,
-    SPINEL_PROTOCOL_TYPE_ZIGBEE_IP  = 2,
-    SPINEL_PROTOCOL_TYPE_THREAD     = 3,
+    SPINEL_PROTOCOL_TYPE_BOOTLOADER     = 0,
+    SPINEL_PROTOCOL_TYPE_ZIGBEE_IP      = 2,
+    SPINEL_PROTOCOL_TYPE_THREAD         = 3,
 };
 
 enum
 {
-    SPINEL_MAC_PROMISCUOUS_MODE_OFF      = 0, ///< Normal MAC filtering is in place.
-    SPINEL_MAC_PROMISCUOUS_MODE_NETWORK  = 1, ///< All MAC packets matching network are passed up the stack.
-    SPINEL_MAC_PROMISCUOUS_MODE_FULL     = 2, ///< All decoded MAC packets are passed up the stack.
+    SPINEL_MAC_PROMISCUOUS_MODE_OFF     = 0, ///< Normal MAC filtering is in place.
+    SPINEL_MAC_PROMISCUOUS_MODE_NETWORK = 1, ///< All MAC packets matching network are passed up the stack.
+    SPINEL_MAC_PROMISCUOUS_MODE_FULL    = 2, ///< All decoded MAC packets are passed up the stack.
 };
 
 enum
 {
-    SPINEL_NCP_LOG_LEVEL_EMERG  = 0,
-    SPINEL_NCP_LOG_LEVEL_ALERT  = 1,
-    SPINEL_NCP_LOG_LEVEL_CRIT   = 2,
-    SPINEL_NCP_LOG_LEVEL_ERR    = 3,
-    SPINEL_NCP_LOG_LEVEL_WARN   = 4,
-    SPINEL_NCP_LOG_LEVEL_NOTICE = 5,
-    SPINEL_NCP_LOG_LEVEL_INFO   = 6,
-    SPINEL_NCP_LOG_LEVEL_DEBUG  = 7,
+    SPINEL_NCP_LOG_LEVEL_EMERG          = 0,
+    SPINEL_NCP_LOG_LEVEL_ALERT          = 1,
+    SPINEL_NCP_LOG_LEVEL_CRIT           = 2,
+    SPINEL_NCP_LOG_LEVEL_ERR            = 3,
+    SPINEL_NCP_LOG_LEVEL_WARN           = 4,
+    SPINEL_NCP_LOG_LEVEL_NOTICE         = 5,
+    SPINEL_NCP_LOG_LEVEL_INFO           = 6,
+    SPINEL_NCP_LOG_LEVEL_DEBUG          = 7,
 };
 
 typedef struct
@@ -266,109 +268,109 @@ typedef unsigned int spinel_cid_t;
 
 enum
 {
-    SPINEL_MD_FLAG_TX               = 0x0001, //!< Packet was transmitted, not received.
-    SPINEL_MD_FLAG_BAD_FCS          = 0x0004, //!< Packet was received with bad FCS
-    SPINEL_MD_FLAG_DUPE             = 0x0008, //!< Packet seems to be a duplicate
-    SPINEL_MD_FLAG_RESERVED         = 0xFFF2, //!< Flags reserved for future use.
+    SPINEL_MD_FLAG_TX                   = 0x0001, //!< Packet was transmitted, not received.
+    SPINEL_MD_FLAG_BAD_FCS              = 0x0004, //!< Packet was received with bad FCS
+    SPINEL_MD_FLAG_DUPE                 = 0x0008, //!< Packet seems to be a duplicate
+    SPINEL_MD_FLAG_RESERVED             = 0xFFF2, //!< Flags reserved for future use.
 };
 
 enum
 {
-    SPINEL_CMD_NOOP                 = 0,
-    SPINEL_CMD_RESET                = 1,
-    SPINEL_CMD_PROP_VALUE_GET       = 2,
-    SPINEL_CMD_PROP_VALUE_SET       = 3,
-    SPINEL_CMD_PROP_VALUE_INSERT    = 4,
-    SPINEL_CMD_PROP_VALUE_REMOVE    = 5,
-    SPINEL_CMD_PROP_VALUE_IS        = 6,
-    SPINEL_CMD_PROP_VALUE_INSERTED  = 7,
-    SPINEL_CMD_PROP_VALUE_REMOVED   = 8,
+    SPINEL_CMD_NOOP                     = 0,
+    SPINEL_CMD_RESET                    = 1,
+    SPINEL_CMD_PROP_VALUE_GET           = 2,
+    SPINEL_CMD_PROP_VALUE_SET           = 3,
+    SPINEL_CMD_PROP_VALUE_INSERT        = 4,
+    SPINEL_CMD_PROP_VALUE_REMOVE        = 5,
+    SPINEL_CMD_PROP_VALUE_IS            = 6,
+    SPINEL_CMD_PROP_VALUE_INSERTED      = 7,
+    SPINEL_CMD_PROP_VALUE_REMOVED       = 8,
 
-    SPINEL_CMD_NET_SAVE             = 9,
-    SPINEL_CMD_NET_CLEAR            = 10,
-    SPINEL_CMD_NET_RECALL           = 11,
+    SPINEL_CMD_NET_SAVE                 = 9,
+    SPINEL_CMD_NET_CLEAR                = 10,
+    SPINEL_CMD_NET_RECALL               = 11,
 
-    SPINEL_CMD_HBO_OFFLOAD          = 12,
-    SPINEL_CMD_HBO_RECLAIM          = 13,
-    SPINEL_CMD_HBO_DROP             = 14,
-    SPINEL_CMD_HBO_OFFLOADED        = 15,
-    SPINEL_CMD_HBO_RECLAIMED        = 16,
-    SPINEL_CMD_HBO_DROPED           = 17,
+    SPINEL_CMD_HBO_OFFLOAD              = 12,
+    SPINEL_CMD_HBO_RECLAIM              = 13,
+    SPINEL_CMD_HBO_DROP                 = 14,
+    SPINEL_CMD_HBO_OFFLOADED            = 15,
+    SPINEL_CMD_HBO_RECLAIMED            = 16,
+    SPINEL_CMD_HBO_DROPED               = 17,
 
-    SPINEL_CMD_PEEK                 = 18,
-    SPINEL_CMD_PEEK_RET             = 19,
-    SPINEL_CMD_POKE                 = 20,
+    SPINEL_CMD_PEEK                     = 18,
+    SPINEL_CMD_PEEK_RET                 = 19,
+    SPINEL_CMD_POKE                     = 20,
 
-    SPINEL_CMD_PROP_VALUE_MULTI_GET = 21,
-    SPINEL_CMD_PROP_VALUE_MULTI_SET = 22,
-    SPINEL_CMD_PROP_VALUES_ARE      = 23,
+    SPINEL_CMD_PROP_VALUE_MULTI_GET     = 21,
+    SPINEL_CMD_PROP_VALUE_MULTI_SET     = 22,
+    SPINEL_CMD_PROP_VALUES_ARE          = 23,
 
-    SPINEL_CMD_NEST__BEGIN          = 15296,
-    SPINEL_CMD_NEST__END            = 15360,
+    SPINEL_CMD_NEST__BEGIN              = 15296,
+    SPINEL_CMD_NEST__END                = 15360,
 
-    SPINEL_CMD_VENDOR__BEGIN        = 15360,
-    SPINEL_CMD_VENDOR__END          = 16384,
+    SPINEL_CMD_VENDOR__BEGIN            = 15360,
+    SPINEL_CMD_VENDOR__END              = 16384,
 
-    SPINEL_CMD_EXPERIMENTAL__BEGIN  = 2000000,
-    SPINEL_CMD_EXPERIMENTAL__END    = 2097152,
+    SPINEL_CMD_EXPERIMENTAL__BEGIN      = 2000000,
+    SPINEL_CMD_EXPERIMENTAL__END        = 2097152,
 };
 
 enum
 {
-    SPINEL_CAP_LOCK                  = 1,
-    SPINEL_CAP_NET_SAVE              = 2,
-    SPINEL_CAP_HBO                   = 3,
-    SPINEL_CAP_POWER_SAVE            = 4,
+    SPINEL_CAP_LOCK                     = 1,
+    SPINEL_CAP_NET_SAVE                 = 2,
+    SPINEL_CAP_HBO                      = 3,
+    SPINEL_CAP_POWER_SAVE               = 4,
 
-    SPINEL_CAP_COUNTERS              = 5,
-    SPINEL_CAP_JAM_DETECT            = 6,
+    SPINEL_CAP_COUNTERS                 = 5,
+    SPINEL_CAP_JAM_DETECT               = 6,
 
-    SPINEL_CAP_PEEK_POKE             = 7,
+    SPINEL_CAP_PEEK_POKE                = 7,
 
-    SPINEL_CAP_WRITABLE_RAW_STREAM   = 8,
-    SPINEL_CAP_GPIO                  = 9,
-    SPINEL_CAP_TRNG                  = 10,
-    SPINEL_CAP_CMD_MULTI             = 11,
+    SPINEL_CAP_WRITABLE_RAW_STREAM      = 8,
+    SPINEL_CAP_GPIO                     = 9,
+    SPINEL_CAP_TRNG                     = 10,
+    SPINEL_CAP_CMD_MULTI                = 11,
 
-    SPINEL_CAP_802_15_4__BEGIN        = 16,
-    SPINEL_CAP_802_15_4_2003          = (SPINEL_CAP_802_15_4__BEGIN + 0),
-    SPINEL_CAP_802_15_4_2006          = (SPINEL_CAP_802_15_4__BEGIN + 1),
-    SPINEL_CAP_802_15_4_2011          = (SPINEL_CAP_802_15_4__BEGIN + 2),
-    SPINEL_CAP_802_15_4_PIB           = (SPINEL_CAP_802_15_4__BEGIN + 5),
-    SPINEL_CAP_802_15_4_2450MHZ_OQPSK = (SPINEL_CAP_802_15_4__BEGIN + 8),
-    SPINEL_CAP_802_15_4_915MHZ_OQPSK  = (SPINEL_CAP_802_15_4__BEGIN + 9),
-    SPINEL_CAP_802_15_4_868MHZ_OQPSK  = (SPINEL_CAP_802_15_4__BEGIN + 10),
-    SPINEL_CAP_802_15_4_915MHZ_BPSK   = (SPINEL_CAP_802_15_4__BEGIN + 11),
-    SPINEL_CAP_802_15_4_868MHZ_BPSK   = (SPINEL_CAP_802_15_4__BEGIN + 12),
-    SPINEL_CAP_802_15_4_915MHZ_ASK    = (SPINEL_CAP_802_15_4__BEGIN + 13),
-    SPINEL_CAP_802_15_4_868MHZ_ASK    = (SPINEL_CAP_802_15_4__BEGIN + 14),
-    SPINEL_CAP_802_15_4__END          = 32,
+    SPINEL_CAP_802_15_4__BEGIN          = 16,
+    SPINEL_CAP_802_15_4_2003            = (SPINEL_CAP_802_15_4__BEGIN + 0),
+    SPINEL_CAP_802_15_4_2006            = (SPINEL_CAP_802_15_4__BEGIN + 1),
+    SPINEL_CAP_802_15_4_2011            = (SPINEL_CAP_802_15_4__BEGIN + 2),
+    SPINEL_CAP_802_15_4_PIB             = (SPINEL_CAP_802_15_4__BEGIN + 5),
+    SPINEL_CAP_802_15_4_2450MHZ_OQPSK   = (SPINEL_CAP_802_15_4__BEGIN + 8),
+    SPINEL_CAP_802_15_4_915MHZ_OQPSK    = (SPINEL_CAP_802_15_4__BEGIN + 9),
+    SPINEL_CAP_802_15_4_868MHZ_OQPSK    = (SPINEL_CAP_802_15_4__BEGIN + 10),
+    SPINEL_CAP_802_15_4_915MHZ_BPSK     = (SPINEL_CAP_802_15_4__BEGIN + 11),
+    SPINEL_CAP_802_15_4_868MHZ_BPSK     = (SPINEL_CAP_802_15_4__BEGIN + 12),
+    SPINEL_CAP_802_15_4_915MHZ_ASK      = (SPINEL_CAP_802_15_4__BEGIN + 13),
+    SPINEL_CAP_802_15_4_868MHZ_ASK      = (SPINEL_CAP_802_15_4__BEGIN + 14),
+    SPINEL_CAP_802_15_4__END            = 32,
 
-    SPINEL_CAP_ROLE__BEGIN           = 48,
-    SPINEL_CAP_ROLE_ROUTER           = (SPINEL_CAP_ROLE__BEGIN + 0),
-    SPINEL_CAP_ROLE_SLEEPY           = (SPINEL_CAP_ROLE__BEGIN + 1),
-    SPINEL_CAP_ROLE__END             = 52,
+    SPINEL_CAP_ROLE__BEGIN              = 48,
+    SPINEL_CAP_ROLE_ROUTER              = (SPINEL_CAP_ROLE__BEGIN + 0),
+    SPINEL_CAP_ROLE_SLEEPY              = (SPINEL_CAP_ROLE__BEGIN + 1),
+    SPINEL_CAP_ROLE__END                = 52,
 
-    SPINEL_CAP_NET__BEGIN            = 52,
-    SPINEL_CAP_NET_THREAD_1_0        = (SPINEL_CAP_NET__BEGIN + 0),
-    SPINEL_CAP_NET__END              = 64,
+    SPINEL_CAP_NET__BEGIN               = 52,
+    SPINEL_CAP_NET_THREAD_1_0           = (SPINEL_CAP_NET__BEGIN + 0),
+    SPINEL_CAP_NET__END                 = 64,
 
-    SPINEL_CAP_OPENTHREAD__BEGIN     = 512,
-    SPINEL_CAP_MAC_WHITELIST         = (SPINEL_CAP_OPENTHREAD__BEGIN + 0),
-    SPINEL_CAP_MAC_RAW               = (SPINEL_CAP_OPENTHREAD__BEGIN + 1),
-    SPINEL_CAP_OPENTHREAD__END       = 640,
+    SPINEL_CAP_OPENTHREAD__BEGIN        = 512,
+    SPINEL_CAP_MAC_WHITELIST            = (SPINEL_CAP_OPENTHREAD__BEGIN + 0),
+    SPINEL_CAP_MAC_RAW                  = (SPINEL_CAP_OPENTHREAD__BEGIN + 1),
+    SPINEL_CAP_OPENTHREAD__END          = 640,
 
-    SPINEL_CAP_NEST__BEGIN           = 15296,
-    SPINEL_CAP_NEST_LEGACY_INTERFACE = (SPINEL_CAP_NEST__BEGIN + 0),
-    SPINEL_CAP_NEST_LEGACY_NET_WAKE  = (SPINEL_CAP_NEST__BEGIN + 1),
-    SPINEL_CAP_NEST_TRANSMIT_HOOK    = (SPINEL_CAP_NEST__BEGIN + 2),
-    SPINEL_CAP_NEST__END             = 15360,
+    SPINEL_CAP_NEST__BEGIN              = 15296,
+    SPINEL_CAP_NEST_LEGACY_INTERFACE    = (SPINEL_CAP_NEST__BEGIN + 0),
+    SPINEL_CAP_NEST_LEGACY_NET_WAKE     = (SPINEL_CAP_NEST__BEGIN + 1),
+    SPINEL_CAP_NEST_TRANSMIT_HOOK       = (SPINEL_CAP_NEST__BEGIN + 2),
+    SPINEL_CAP_NEST__END                = 15360,
 
-    SPINEL_CAP_VENDOR__BEGIN         = 15360,
-    SPINEL_CAP_VENDOR__END           = 16384,
+    SPINEL_CAP_VENDOR__BEGIN            = 15360,
+    SPINEL_CAP_VENDOR__END              = 16384,
 
-    SPINEL_CAP_EXPERIMENTAL__BEGIN   = 2000000,
-    SPINEL_CAP_EXPERIMENTAL__END     = 2097152,
+    SPINEL_CAP_EXPERIMENTAL__BEGIN      = 2000000,
+    SPINEL_CAP_EXPERIMENTAL__END        = 2097152,
 };
 
 typedef enum
@@ -591,20 +593,20 @@ typedef enum
 
     SPINEL_PROP_PHY_EXT__END            = 0x1300,
 
-    SPINEL_PROP_MAC__BEGIN             = 0x30,
-    SPINEL_PROP_MAC_SCAN_STATE         = SPINEL_PROP_MAC__BEGIN + 0, ///< [C]
-    SPINEL_PROP_MAC_SCAN_MASK          = SPINEL_PROP_MAC__BEGIN + 1, ///< [A(C)]
-    SPINEL_PROP_MAC_SCAN_PERIOD        = SPINEL_PROP_MAC__BEGIN + 2, ///< ms-per-channel [S]
-    SPINEL_PROP_MAC_SCAN_BEACON        = SPINEL_PROP_MAC__BEGIN + 3, ///< chan,rssi,mac_data,net_data [CcdD]
-    SPINEL_PROP_MAC_15_4_LADDR         = SPINEL_PROP_MAC__BEGIN + 4, ///< [E]
-    SPINEL_PROP_MAC_15_4_SADDR         = SPINEL_PROP_MAC__BEGIN + 5, ///< [S]
-    SPINEL_PROP_MAC_15_4_PANID         = SPINEL_PROP_MAC__BEGIN + 6, ///< [S]
-    SPINEL_PROP_MAC_RAW_STREAM_ENABLED = SPINEL_PROP_MAC__BEGIN + 7, ///< [C]
-    SPINEL_PROP_MAC_PROMISCUOUS_MODE   = SPINEL_PROP_MAC__BEGIN + 8, ///< [C]
-    SPINEL_PROP_MAC_ENERGY_SCAN_RESULT = SPINEL_PROP_MAC__BEGIN + 9, ///< chan,maxRssi [Cc]
-    SPINEL_PROP_MAC__END               = 0x40,
+    SPINEL_PROP_MAC__BEGIN              = 0x30,
+    SPINEL_PROP_MAC_SCAN_STATE          = SPINEL_PROP_MAC__BEGIN + 0, ///< [C]
+    SPINEL_PROP_MAC_SCAN_MASK           = SPINEL_PROP_MAC__BEGIN + 1, ///< [A(C)]
+    SPINEL_PROP_MAC_SCAN_PERIOD         = SPINEL_PROP_MAC__BEGIN + 2, ///< ms-per-channel [S]
+    SPINEL_PROP_MAC_SCAN_BEACON         = SPINEL_PROP_MAC__BEGIN + 3, ///< chan,rssi,mac_data,net_data [CcdD]
+    SPINEL_PROP_MAC_15_4_LADDR          = SPINEL_PROP_MAC__BEGIN + 4, ///< [E]
+    SPINEL_PROP_MAC_15_4_SADDR          = SPINEL_PROP_MAC__BEGIN + 5, ///< [S]
+    SPINEL_PROP_MAC_15_4_PANID          = SPINEL_PROP_MAC__BEGIN + 6, ///< [S]
+    SPINEL_PROP_MAC_RAW_STREAM_ENABLED  = SPINEL_PROP_MAC__BEGIN + 7, ///< [C]
+    SPINEL_PROP_MAC_PROMISCUOUS_MODE    = SPINEL_PROP_MAC__BEGIN + 8, ///< [C]
+    SPINEL_PROP_MAC_ENERGY_SCAN_RESULT  = SPINEL_PROP_MAC__BEGIN + 9, ///< chan,maxRssi [Cc]
+    SPINEL_PROP_MAC__END                = 0x40,
 
-    SPINEL_PROP_MAC_EXT__BEGIN         = 0x1300,
+    SPINEL_PROP_MAC_EXT__BEGIN          = 0x1300,
     /// MAC Whitelist
     /** Format: `A(t(Ec))`
      *
@@ -613,49 +615,49 @@ typedef enum
      * * `E`: EUI64 address of node
      * * `c`: Optional fixed RSSI. 127 means not set.
      */
-    SPINEL_PROP_MAC_WHITELIST          = SPINEL_PROP_MAC_EXT__BEGIN + 0,
+    SPINEL_PROP_MAC_WHITELIST           = SPINEL_PROP_MAC_EXT__BEGIN + 0,
 
     /// MAC Whitelist Enabled Flag
     /** Format: `b`
      */
-    SPINEL_PROP_MAC_WHITELIST_ENABLED  = SPINEL_PROP_MAC_EXT__BEGIN + 1,
+    SPINEL_PROP_MAC_WHITELIST_ENABLED   = SPINEL_PROP_MAC_EXT__BEGIN + 1,
 
     /// MAC Extended Address
     /** Format: `E`
      *
      *  Specified by Thread. Randomly-chosen, but non-volatile EUI-64.
      */
-    SPINEL_PROP_MAC_EXTENDED_ADDR      = SPINEL_PROP_MAC_EXT__BEGIN + 2,
+    SPINEL_PROP_MAC_EXTENDED_ADDR       = SPINEL_PROP_MAC_EXT__BEGIN + 2,
 
     /// MAC Source Match Enabled Flag
     /** Format: `b`
      */
-    SPINEL_PROP_MAC_SRC_MATCH_ENABLED  = SPINEL_PROP_MAC_EXT__BEGIN + 3,
+    SPINEL_PROP_MAC_SRC_MATCH_ENABLED   = SPINEL_PROP_MAC_EXT__BEGIN + 3,
 
     /// MAC Source Match Short Address List
     /** Format: `A(S)`
      */
     SPINEL_PROP_MAC_SRC_MATCH_SHORT_ADDRESSES
-                                       = SPINEL_PROP_MAC_EXT__BEGIN + 4,
+                                        = SPINEL_PROP_MAC_EXT__BEGIN + 4,
 
     /// MAC Source Match Extended Address List
     /** Format: `A(E)`
      */
     SPINEL_PROP_MAC_SRC_MATCH_EXTENDED_ADDRESSES
-                                       = SPINEL_PROP_MAC_EXT__BEGIN + 5,
-    SPINEL_PROP_MAC_EXT__END           = 0x1400,
+                                        = SPINEL_PROP_MAC_EXT__BEGIN + 5,
+    SPINEL_PROP_MAC_EXT__END            = 0x1400,
 
-    SPINEL_PROP_NET__BEGIN           = 0x40,
-    SPINEL_PROP_NET_SAVED            = SPINEL_PROP_NET__BEGIN + 0, ///< [b]
-    SPINEL_PROP_NET_IF_UP            = SPINEL_PROP_NET__BEGIN + 1, ///< [b]
-    SPINEL_PROP_NET_STACK_UP         = SPINEL_PROP_NET__BEGIN + 2, ///< [b]
-    SPINEL_PROP_NET_ROLE             = SPINEL_PROP_NET__BEGIN + 3, ///< [C]
-    SPINEL_PROP_NET_NETWORK_NAME     = SPINEL_PROP_NET__BEGIN + 4, ///< [U]
-    SPINEL_PROP_NET_XPANID           = SPINEL_PROP_NET__BEGIN + 5, ///< [D]
-    SPINEL_PROP_NET_MASTER_KEY       = SPINEL_PROP_NET__BEGIN + 6, ///< [D]
+    SPINEL_PROP_NET__BEGIN              = 0x40,
+    SPINEL_PROP_NET_SAVED               = SPINEL_PROP_NET__BEGIN + 0, ///< [b]
+    SPINEL_PROP_NET_IF_UP               = SPINEL_PROP_NET__BEGIN + 1, ///< [b]
+    SPINEL_PROP_NET_STACK_UP            = SPINEL_PROP_NET__BEGIN + 2, ///< [b]
+    SPINEL_PROP_NET_ROLE                = SPINEL_PROP_NET__BEGIN + 3, ///< [C]
+    SPINEL_PROP_NET_NETWORK_NAME        = SPINEL_PROP_NET__BEGIN + 4, ///< [U]
+    SPINEL_PROP_NET_XPANID              = SPINEL_PROP_NET__BEGIN + 5, ///< [D]
+    SPINEL_PROP_NET_MASTER_KEY          = SPINEL_PROP_NET__BEGIN + 6, ///< [D]
     SPINEL_PROP_NET_KEY_SEQUENCE_COUNTER
-                                     = SPINEL_PROP_NET__BEGIN + 7, ///< [L]
-    SPINEL_PROP_NET_PARTITION_ID     = SPINEL_PROP_NET__BEGIN + 8, ///< [L]
+                                        = SPINEL_PROP_NET__BEGIN + 7, ///< [L]
+    SPINEL_PROP_NET_PARTITION_ID        = SPINEL_PROP_NET__BEGIN + 8, ///< [L]
 
     /// Require Join Existing
     /** Format: `b`
@@ -676,33 +678,33 @@ typedef enum
      * `PROP_NET_STACK_UP` is already set to `true` is undefined.
      */
     SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
-                                     = SPINEL_PROP_NET__BEGIN + 9,
+                                        = SPINEL_PROP_NET__BEGIN + 9,
 
     SPINEL_PROP_NET_KEY_SWITCH_GUARDTIME
-                                     = SPINEL_PROP_NET__BEGIN + 10, ///< [L]
+                                        = SPINEL_PROP_NET__BEGIN + 10, ///< [L]
 
-    SPINEL_PROP_NET__END             = 0x50,
+    SPINEL_PROP_NET__END                = 0x50,
 
-    SPINEL_PROP_THREAD__BEGIN          = 0x50,
-    SPINEL_PROP_THREAD_LEADER_ADDR     = SPINEL_PROP_THREAD__BEGIN + 0, ///< [6]
-    SPINEL_PROP_THREAD_PARENT          = SPINEL_PROP_THREAD__BEGIN + 1, ///< LADDR, SADDR [ES]
-    SPINEL_PROP_THREAD_CHILD_TABLE     = SPINEL_PROP_THREAD__BEGIN + 2, ///< array(EUI64,rloc16,timeout,age,netDataVer,inLqi,aveRSS,mode) [A(t(ESLLCCcC))]
-    SPINEL_PROP_THREAD_LEADER_RID      = SPINEL_PROP_THREAD__BEGIN + 3, ///< [C]
-    SPINEL_PROP_THREAD_LEADER_WEIGHT   = SPINEL_PROP_THREAD__BEGIN + 4, ///< [C]
+    SPINEL_PROP_THREAD__BEGIN           = 0x50,
+    SPINEL_PROP_THREAD_LEADER_ADDR      = SPINEL_PROP_THREAD__BEGIN + 0, ///< [6]
+    SPINEL_PROP_THREAD_PARENT           = SPINEL_PROP_THREAD__BEGIN + 1, ///< LADDR, SADDR [ES]
+    SPINEL_PROP_THREAD_CHILD_TABLE      = SPINEL_PROP_THREAD__BEGIN + 2, ///< array(EUI64,rloc16,timeout,age,netDataVer,inLqi,aveRSS,mode) [A(t(ESLLCCcC))]
+    SPINEL_PROP_THREAD_LEADER_RID       = SPINEL_PROP_THREAD__BEGIN + 3, ///< [C]
+    SPINEL_PROP_THREAD_LEADER_WEIGHT    = SPINEL_PROP_THREAD__BEGIN + 4, ///< [C]
     SPINEL_PROP_THREAD_LOCAL_LEADER_WEIGHT
-                                       = SPINEL_PROP_THREAD__BEGIN + 5, ///< [C]
-    SPINEL_PROP_THREAD_NETWORK_DATA    = SPINEL_PROP_THREAD__BEGIN + 6, ///< [D]
+                                        = SPINEL_PROP_THREAD__BEGIN + 5, ///< [C]
+    SPINEL_PROP_THREAD_NETWORK_DATA     = SPINEL_PROP_THREAD__BEGIN + 6, ///< [D]
     SPINEL_PROP_THREAD_NETWORK_DATA_VERSION
-                                       = SPINEL_PROP_THREAD__BEGIN + 7, ///< [S]
+                                        = SPINEL_PROP_THREAD__BEGIN + 7, ///< [S]
     SPINEL_PROP_THREAD_STABLE_NETWORK_DATA
-                                       = SPINEL_PROP_THREAD__BEGIN + 8, ///< [D]
+                                        = SPINEL_PROP_THREAD__BEGIN + 8, ///< [D]
     SPINEL_PROP_THREAD_STABLE_NETWORK_DATA_VERSION
-                                       = SPINEL_PROP_THREAD__BEGIN + 9,  ///< [S]
-    SPINEL_PROP_THREAD_ON_MESH_NETS    = SPINEL_PROP_THREAD__BEGIN + 10, ///< array(ipv6prefix,prefixlen,stable,flags) [A(t(6CbC))]
-    SPINEL_PROP_THREAD_LOCAL_ROUTES    = SPINEL_PROP_THREAD__BEGIN + 11, ///< array(ipv6prefix,prefixlen,stable,flags) [A(t(6CbC))]
-    SPINEL_PROP_THREAD_ASSISTING_PORTS = SPINEL_PROP_THREAD__BEGIN + 12, ///< array(portn) [A(S)]
+                                        = SPINEL_PROP_THREAD__BEGIN + 9,  ///< [S]
+    SPINEL_PROP_THREAD_ON_MESH_NETS     = SPINEL_PROP_THREAD__BEGIN + 10, ///< array(ipv6prefix,prefixlen,stable,flags) [A(t(6CbC))]
+    SPINEL_PROP_THREAD_LOCAL_ROUTES     = SPINEL_PROP_THREAD__BEGIN + 11, ///< array(ipv6prefix,prefixlen,stable,flags) [A(t(6CbC))]
+    SPINEL_PROP_THREAD_ASSISTING_PORTS  = SPINEL_PROP_THREAD__BEGIN + 12, ///< array(portn) [A(S)]
     SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE
-                                       = SPINEL_PROP_THREAD__BEGIN + 13, ///< [b]
+                                        = SPINEL_PROP_THREAD__BEGIN + 13, ///< [b]
 
     /// Thread Mode
     /** Format: `C`
@@ -712,40 +714,40 @@ typedef enum
      *  bitfield are defined by section 4.5.2 of the Thread
      *  specification.
      */
-    SPINEL_PROP_THREAD_MODE            = SPINEL_PROP_THREAD__BEGIN + 14,
-    SPINEL_PROP_THREAD__END            = 0x60,
+    SPINEL_PROP_THREAD_MODE             = SPINEL_PROP_THREAD__BEGIN + 14,
+    SPINEL_PROP_THREAD__END             = 0x60,
 
-    SPINEL_PROP_THREAD_EXT__BEGIN      = 0x1500,
+    SPINEL_PROP_THREAD_EXT__BEGIN       = 0x1500,
 
     /// Thread Child Timeout
     /** Format: `L`
      *
      *  Used when operating in the Child role.
      */
-    SPINEL_PROP_THREAD_CHILD_TIMEOUT   = SPINEL_PROP_THREAD_EXT__BEGIN + 0,
+    SPINEL_PROP_THREAD_CHILD_TIMEOUT    = SPINEL_PROP_THREAD_EXT__BEGIN + 0,
 
     /// Thread RLOC16
     /** Format: `S`
      */
-    SPINEL_PROP_THREAD_RLOC16          = SPINEL_PROP_THREAD_EXT__BEGIN + 1,
+    SPINEL_PROP_THREAD_RLOC16           = SPINEL_PROP_THREAD_EXT__BEGIN + 1,
 
     /// Thread Router Upgrade Threshold
     /** Format: `C`
      */
     SPINEL_PROP_THREAD_ROUTER_UPGRADE_THRESHOLD
-                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 2,
+                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 2,
 
     /// Thread Context Reuse Delay
     /** Format: `L`
      */
     SPINEL_PROP_THREAD_CONTEXT_REUSE_DELAY
-                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 3,
+                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 3,
 
     /// Thread Network ID Timeout
     /** Format: `C`
      */
     SPINEL_PROP_THREAD_NETWORK_ID_TIMEOUT
-                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 4,
+                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 4,
 
     /// List of active thread router ids
     /** Format: `A(C)`
@@ -755,70 +757,69 @@ typedef enum
      * a leader.
      */
     SPINEL_PROP_THREAD_ACTIVE_ROUTER_IDS
-                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 5,
+                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 5,
 
     /// Forward IPv6 packets that use RLOC16 addresses to HOST.
     /** Format: `b`
      */
     SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU
-                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 6,
+                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 6,
 
     /// This property indicates whether or not the `Router Role` is enabled.
     /** Format `b`
      */
     SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED
-                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 7,
+                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 7,
 
     /// Thread Router Downgrade Threshold
     /** Format: `C`
      */
     SPINEL_PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD
-                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 8,
+                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 8,
 
     /// Thread Router Selection Jitter
     /** Format: `C`
      */
     SPINEL_PROP_THREAD_ROUTER_SELECTION_JITTER
-                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 9,
+                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 9,
 
     /// Thread Preferred Router Id
     /** Format: `C` - Write only
      */
     SPINEL_PROP_THREAD_PREFERRED_ROUTER_ID
-                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 10,
+                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 10,
 
     /// Thread Neighbor Table
     /** Format: `A(t(ESLCcCbLL))`
      *  eui64, rloc16, age, inLqi ,aveRSS, mode, isChild. linkFrameCounter, mleCounter
      */
-    SPINEL_PROP_THREAD_NEIGHBOR_TABLE  = SPINEL_PROP_THREAD_EXT__BEGIN + 11,
+    SPINEL_PROP_THREAD_NEIGHBOR_TABLE   = SPINEL_PROP_THREAD_EXT__BEGIN + 11,
 
     /// Thread Max Child Count
     /** Format: `C`
      */
-    SPINEL_PROP_THREAD_CHILD_COUNT_MAX = SPINEL_PROP_THREAD_EXT__BEGIN + 12,
+    SPINEL_PROP_THREAD_CHILD_COUNT_MAX  = SPINEL_PROP_THREAD_EXT__BEGIN + 12,
 
     /// Leader network data
     /** Format: `D` - Read only
      */
     SPINEL_PROP_THREAD_LEADER_NETWORK_DATA
-                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 13,
+                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 13,
 
     /// Stable leader network data
     /** Format: `D` - Read only
      */
     SPINEL_PROP_THREAD_STABLE_LEADER_NETWORK_DATA
-                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 14,
+                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 14,
 
-    SPINEL_PROP_THREAD_EXT__END        = 0x1600,
+    SPINEL_PROP_THREAD_EXT__END         = 0x1600,
 
-    SPINEL_PROP_IPV6__BEGIN          = 0x60,
-    SPINEL_PROP_IPV6_LL_ADDR         = SPINEL_PROP_IPV6__BEGIN + 0, ///< [6]
-    SPINEL_PROP_IPV6_ML_ADDR         = SPINEL_PROP_IPV6__BEGIN + 1, ///< [6C]
-    SPINEL_PROP_IPV6_ML_PREFIX       = SPINEL_PROP_IPV6__BEGIN + 2, ///< [6C]
-    SPINEL_PROP_IPV6_ADDRESS_TABLE   = SPINEL_PROP_IPV6__BEGIN + 3, ///< array(ipv6addr,prefixlen,valid,preferred,flags) [A(t(6CLLC))]
-    SPINEL_PROP_IPV6_ROUTE_TABLE     = SPINEL_PROP_IPV6__BEGIN + 4, ///< array(ipv6prefix,prefixlen,iface,flags) [A(t(6CCC))]
-
+    SPINEL_PROP_IPV6__BEGIN             = 0x60,
+    SPINEL_PROP_IPV6_LL_ADDR            = SPINEL_PROP_IPV6__BEGIN + 0, ///< [6]
+    SPINEL_PROP_IPV6_ML_ADDR            = SPINEL_PROP_IPV6__BEGIN + 1, ///< [6C]
+    SPINEL_PROP_IPV6_ML_PREFIX          = SPINEL_PROP_IPV6__BEGIN + 2, ///< [6C]
+    SPINEL_PROP_IPV6_ADDRESS_TABLE      = SPINEL_PROP_IPV6__BEGIN + 3, ///< array(ipv6addr,prefixlen,valid,preferred,flags) [A(t(6CLLC))]
+    SPINEL_PROP_IPV6_ROUTE_TABLE        = SPINEL_PROP_IPV6__BEGIN + 4, ///< array(ipv6prefix,prefixlen,iface,flags) [A(t(6CCC))]
 
     /// IPv6 ICMP Ping Offload
     /** Format: `b`
@@ -828,17 +829,16 @@ typedef enum
      *
      * Default value is `false`.
      */
-    SPINEL_PROP_IPV6_ICMP_PING_OFFLOAD = SPINEL_PROP_IPV6__BEGIN + 5, ///< [b]
+    SPINEL_PROP_IPV6_ICMP_PING_OFFLOAD  = SPINEL_PROP_IPV6__BEGIN + 5, ///< [b]
 
-    SPINEL_PROP_IPV6__END            = 0x70,
+    SPINEL_PROP_IPV6__END               = 0x70,
 
-    SPINEL_PROP_STREAM__BEGIN       = 0x70,
-    SPINEL_PROP_STREAM_DEBUG        = SPINEL_PROP_STREAM__BEGIN + 0, ///< [U]
-    SPINEL_PROP_STREAM_RAW          = SPINEL_PROP_STREAM__BEGIN + 1, ///< [dD]
-    SPINEL_PROP_STREAM_NET          = SPINEL_PROP_STREAM__BEGIN + 2, ///< [dD]
-    SPINEL_PROP_STREAM_NET_INSECURE = SPINEL_PROP_STREAM__BEGIN + 3, ///< [dD]
-    SPINEL_PROP_STREAM__END         = 0x80,
-
+    SPINEL_PROP_STREAM__BEGIN           = 0x70,
+    SPINEL_PROP_STREAM_DEBUG            = SPINEL_PROP_STREAM__BEGIN + 0, ///< [U]
+    SPINEL_PROP_STREAM_RAW              = SPINEL_PROP_STREAM__BEGIN + 1, ///< [dD]
+    SPINEL_PROP_STREAM_NET              = SPINEL_PROP_STREAM__BEGIN + 2, ///< [dD]
+    SPINEL_PROP_STREAM_NET_INSECURE     = SPINEL_PROP_STREAM__BEGIN + 3, ///< [dD]
+    SPINEL_PROP_STREAM__END             = 0x80,
 
     /// UART Bitrate
     /** Format: `L`
@@ -862,7 +862,7 @@ typedef enum
      *  the host, all further frames will be transmitted at the new
      *  bitrate.
      */
-    SPINEL_PROP_UART_BITRATE    = 0x100,
+    SPINEL_PROP_UART_BITRATE            = 0x100,
 
     /// UART Software Flow Control
     /** Format: `b`
@@ -875,9 +875,9 @@ typedef enum
      *  This property is only implemented when a UART is being
      *  used for Spinel. This property is optional.
      */
-    SPINEL_PROP_UART_XON_XOFF   = 0x101,
+    SPINEL_PROP_UART_XON_XOFF           = 0x101,
 
-    SPINEL_PROP_15_4_PIB__BEGIN     = 1024,
+    SPINEL_PROP_15_4_PIB__BEGIN         = 1024,
     // For direct access to the 802.15.4 PID.
     // Individual registers are fetched using
     // `SPINEL_PROP_15_4_PIB__BEGIN+[PIB_IDENTIFIER]`
@@ -886,183 +886,186 @@ typedef enum
     // For brevity, the entire 802.15.4 PIB space is
     // not defined here, but a few choice attributes
     // are defined for illustration and convenience.
-    SPINEL_PROP_15_4_PIB_PHY_CHANNELS_SUPPORTED = SPINEL_PROP_15_4_PIB__BEGIN + 0x01, ///< [A(L)]
-    SPINEL_PROP_15_4_PIB_MAC_PROMISCUOUS_MODE   = SPINEL_PROP_15_4_PIB__BEGIN + 0x51, ///< [b]
-    SPINEL_PROP_15_4_PIB_MAC_SECURITY_ENABLED   = SPINEL_PROP_15_4_PIB__BEGIN + 0x5d, ///< [b]
-    SPINEL_PROP_15_4_PIB__END       = 1280,
+    SPINEL_PROP_15_4_PIB_PHY_CHANNELS_SUPPORTED
+                                        = SPINEL_PROP_15_4_PIB__BEGIN + 0x01, ///< [A(L)]
+    SPINEL_PROP_15_4_PIB_MAC_PROMISCUOUS_MODE
+                                        = SPINEL_PROP_15_4_PIB__BEGIN + 0x51, ///< [b]
+    SPINEL_PROP_15_4_PIB_MAC_SECURITY_ENABLED
+                                        = SPINEL_PROP_15_4_PIB__BEGIN + 0x5d, ///< [b]
+    SPINEL_PROP_15_4_PIB__END           = 1280,
 
-    SPINEL_PROP_CNTR__BEGIN        = 1280,
+    SPINEL_PROP_CNTR__BEGIN             = 1280,
 
     /// Counter reset behavior
     /** Format: `C`
      *  Writing a '1' to this property will reset
      *  all of the counters to zero. */
-    SPINEL_PROP_CNTR_RESET             = SPINEL_PROP_CNTR__BEGIN + 0,
+    SPINEL_PROP_CNTR_RESET              = SPINEL_PROP_CNTR__BEGIN + 0,
 
     /// The total number of transmissions.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_TOTAL      = SPINEL_PROP_CNTR__BEGIN + 1,
+    SPINEL_PROP_CNTR_TX_PKT_TOTAL       = SPINEL_PROP_CNTR__BEGIN + 1,
 
     /// The number of transmissions with ack request.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_ACK_REQ    = SPINEL_PROP_CNTR__BEGIN + 2,
+    SPINEL_PROP_CNTR_TX_PKT_ACK_REQ     = SPINEL_PROP_CNTR__BEGIN + 2,
 
     /// The number of transmissions that were acked.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_ACKED      = SPINEL_PROP_CNTR__BEGIN + 3,
+    SPINEL_PROP_CNTR_TX_PKT_ACKED       = SPINEL_PROP_CNTR__BEGIN + 3,
 
     /// The number of transmissions without ack request.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_NO_ACK_REQ = SPINEL_PROP_CNTR__BEGIN + 4,
+    SPINEL_PROP_CNTR_TX_PKT_NO_ACK_REQ  = SPINEL_PROP_CNTR__BEGIN + 4,
 
     /// The number of transmitted data.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_DATA       = SPINEL_PROP_CNTR__BEGIN + 5,
+    SPINEL_PROP_CNTR_TX_PKT_DATA        = SPINEL_PROP_CNTR__BEGIN + 5,
 
     /// The number of transmitted data poll.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_DATA_POLL  = SPINEL_PROP_CNTR__BEGIN + 6,
+    SPINEL_PROP_CNTR_TX_PKT_DATA_POLL   = SPINEL_PROP_CNTR__BEGIN + 6,
 
     /// The number of transmitted beacon.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_BEACON     = SPINEL_PROP_CNTR__BEGIN + 7,
+    SPINEL_PROP_CNTR_TX_PKT_BEACON      = SPINEL_PROP_CNTR__BEGIN + 7,
 
     /// The number of transmitted beacon request.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_BEACON_REQ = SPINEL_PROP_CNTR__BEGIN + 8,
+    SPINEL_PROP_CNTR_TX_PKT_BEACON_REQ  = SPINEL_PROP_CNTR__BEGIN + 8,
 
     /// The number of transmitted other types of frames.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_OTHER      = SPINEL_PROP_CNTR__BEGIN + 9,
+    SPINEL_PROP_CNTR_TX_PKT_OTHER       = SPINEL_PROP_CNTR__BEGIN + 9,
 
     /// The number of retransmission times.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_RETRY      = SPINEL_PROP_CNTR__BEGIN + 10,
+    SPINEL_PROP_CNTR_TX_PKT_RETRY       = SPINEL_PROP_CNTR__BEGIN + 10,
 
     /// The number of CCA failure times.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_ERR_CCA        = SPINEL_PROP_CNTR__BEGIN + 11,
+    SPINEL_PROP_CNTR_TX_ERR_CCA         = SPINEL_PROP_CNTR__BEGIN + 11,
 
     /// The number of unicast packets transmitted.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_UNICAST    = SPINEL_PROP_CNTR__BEGIN + 12,
+    SPINEL_PROP_CNTR_TX_PKT_UNICAST     = SPINEL_PROP_CNTR__BEGIN + 12,
 
     /// The number of broadcast packets transmitted.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_BROADCAST  = SPINEL_PROP_CNTR__BEGIN + 13,
+    SPINEL_PROP_CNTR_TX_PKT_BROADCAST   = SPINEL_PROP_CNTR__BEGIN + 13,
 
     /// The number of frame transmission failures due to abort error.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_ERR_ABORT      = SPINEL_PROP_CNTR__BEGIN + 14,
+    SPINEL_PROP_CNTR_TX_ERR_ABORT       = SPINEL_PROP_CNTR__BEGIN + 14,
 
     /// The total number of received packets.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_TOTAL      = SPINEL_PROP_CNTR__BEGIN + 100,
+    SPINEL_PROP_CNTR_RX_PKT_TOTAL       = SPINEL_PROP_CNTR__BEGIN + 100,
 
     /// The number of received data.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_DATA       = SPINEL_PROP_CNTR__BEGIN + 101,
+    SPINEL_PROP_CNTR_RX_PKT_DATA        = SPINEL_PROP_CNTR__BEGIN + 101,
 
     /// The number of received data poll.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_DATA_POLL  = SPINEL_PROP_CNTR__BEGIN + 102,
+    SPINEL_PROP_CNTR_RX_PKT_DATA_POLL   = SPINEL_PROP_CNTR__BEGIN + 102,
 
     /// The number of received beacon.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_BEACON     = SPINEL_PROP_CNTR__BEGIN + 103,
+    SPINEL_PROP_CNTR_RX_PKT_BEACON      = SPINEL_PROP_CNTR__BEGIN + 103,
 
     /// The number of received beacon request.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_BEACON_REQ = SPINEL_PROP_CNTR__BEGIN + 104,
+    SPINEL_PROP_CNTR_RX_PKT_BEACON_REQ  = SPINEL_PROP_CNTR__BEGIN + 104,
 
     /// The number of received other types of frames.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_OTHER      = SPINEL_PROP_CNTR__BEGIN + 105,
+    SPINEL_PROP_CNTR_RX_PKT_OTHER       = SPINEL_PROP_CNTR__BEGIN + 105,
 
     /// The number of received packets filtered by whitelist.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_FILT_WL    = SPINEL_PROP_CNTR__BEGIN + 106,
+    SPINEL_PROP_CNTR_RX_PKT_FILT_WL     = SPINEL_PROP_CNTR__BEGIN + 106,
 
     /// The number of received packets filtered by destination check.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_FILT_DA    = SPINEL_PROP_CNTR__BEGIN + 107,
+    SPINEL_PROP_CNTR_RX_PKT_FILT_DA     = SPINEL_PROP_CNTR__BEGIN + 107,
 
     /// The number of received packets that are empty.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_ERR_EMPTY      = SPINEL_PROP_CNTR__BEGIN + 108,
+    SPINEL_PROP_CNTR_RX_ERR_EMPTY       = SPINEL_PROP_CNTR__BEGIN + 108,
 
     /// The number of received packets from an unknown neighbor.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_ERR_UKWN_NBR   = SPINEL_PROP_CNTR__BEGIN + 109,
+    SPINEL_PROP_CNTR_RX_ERR_UKWN_NBR    = SPINEL_PROP_CNTR__BEGIN + 109,
 
     /// The number of received packets whose source address is invalid.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_ERR_NVLD_SADDR = SPINEL_PROP_CNTR__BEGIN + 110,
+    SPINEL_PROP_CNTR_RX_ERR_NVLD_SADDR  = SPINEL_PROP_CNTR__BEGIN + 110,
 
     /// The number of received packets with a security error.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_ERR_SECURITY   = SPINEL_PROP_CNTR__BEGIN + 111,
+    SPINEL_PROP_CNTR_RX_ERR_SECURITY    = SPINEL_PROP_CNTR__BEGIN + 111,
 
     /// The number of received packets with a checksum error.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_ERR_BAD_FCS    = SPINEL_PROP_CNTR__BEGIN + 112,
+    SPINEL_PROP_CNTR_RX_ERR_BAD_FCS     = SPINEL_PROP_CNTR__BEGIN + 112,
 
     /// The number of received packets with other errors.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_ERR_OTHER      = SPINEL_PROP_CNTR__BEGIN + 113,
+    SPINEL_PROP_CNTR_RX_ERR_OTHER       = SPINEL_PROP_CNTR__BEGIN + 113,
 
     /// The number of received duplicated.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_DUP        = SPINEL_PROP_CNTR__BEGIN + 114,
+    SPINEL_PROP_CNTR_RX_PKT_DUP         = SPINEL_PROP_CNTR__BEGIN + 114,
 
     /// The number of unicast packets recived.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_UNICAST    = SPINEL_PROP_CNTR__BEGIN + 115,
+    SPINEL_PROP_CNTR_RX_PKT_UNICAST     = SPINEL_PROP_CNTR__BEGIN + 115,
 
     /// The number of broadcast packets recived.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_BROADCAST  = SPINEL_PROP_CNTR__BEGIN + 116,
+    SPINEL_PROP_CNTR_RX_PKT_BROADCAST   = SPINEL_PROP_CNTR__BEGIN + 116,
 
     /// The total number of secure transmitted IP messages.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_IP_SEC_TOTAL   = SPINEL_PROP_CNTR__BEGIN + 200,
+    SPINEL_PROP_CNTR_TX_IP_SEC_TOTAL    = SPINEL_PROP_CNTR__BEGIN + 200,
 
     /// The total number of insecure transmitted IP messages.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_IP_INSEC_TOTAL = SPINEL_PROP_CNTR__BEGIN + 201,
+    SPINEL_PROP_CNTR_TX_IP_INSEC_TOTAL  = SPINEL_PROP_CNTR__BEGIN + 201,
 
     /// The number of dropped (not transmitted) IP messages.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_IP_DROPPED     = SPINEL_PROP_CNTR__BEGIN + 202,
+    SPINEL_PROP_CNTR_TX_IP_DROPPED      = SPINEL_PROP_CNTR__BEGIN + 202,
 
     /// The total number of secure received IP message.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_IP_SEC_TOTAL   = SPINEL_PROP_CNTR__BEGIN + 203,
+    SPINEL_PROP_CNTR_RX_IP_SEC_TOTAL    = SPINEL_PROP_CNTR__BEGIN + 203,
 
     /// The total number of insecure received IP message.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_IP_INSEC_TOTAL = SPINEL_PROP_CNTR__BEGIN + 204,
+    SPINEL_PROP_CNTR_RX_IP_INSEC_TOTAL  = SPINEL_PROP_CNTR__BEGIN + 204,
 
     /// The number of dropped received IP messages.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_IP_DROPPED     = SPINEL_PROP_CNTR__BEGIN + 205,
+    SPINEL_PROP_CNTR_RX_IP_DROPPED      = SPINEL_PROP_CNTR__BEGIN + 205,
 
     /// The number of transmitted spinel frames.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_SPINEL_TOTAL   = SPINEL_PROP_CNTR__BEGIN + 300,
+    SPINEL_PROP_CNTR_TX_SPINEL_TOTAL    = SPINEL_PROP_CNTR__BEGIN + 300,
 
     /// The number of received spinel frames.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_SPINEL_TOTAL   = SPINEL_PROP_CNTR__BEGIN + 301,
+    SPINEL_PROP_CNTR_RX_SPINEL_TOTAL    = SPINEL_PROP_CNTR__BEGIN + 301,
 
     /// The number of received spinel frames with error.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_SPINEL_ERR     = SPINEL_PROP_CNTR__BEGIN + 302,
+    SPINEL_PROP_CNTR_RX_SPINEL_ERR      = SPINEL_PROP_CNTR__BEGIN + 302,
 
     /// Number of out of order received spinel frames (tid increase by more than 1).
     /** Format: `L` (Read-only) */
     SPINEL_PROP_CNTR_RX_SPINEL_OUT_OF_ORDER_TID
-                                       = SPINEL_PROP_CNTR__BEGIN + 303,
+                                        = SPINEL_PROP_CNTR__BEGIN + 303,
 
     /// The message buffer counter info
     /** Format: `SSSSSSSSSSSSSSSS` (Read-only)
@@ -1083,29 +1086,27 @@ typedef enum
      *      `S`, (CoapClientMessages)     The number of messages in the CoAP client send queue.
      *      `S`, (CoapClientBuffers)      The number of buffers in the CoAP client send queue.
      */
-    SPINEL_PROP_MSG_BUFFER_COUNTERS    = SPINEL_PROP_CNTR__BEGIN + 400,
+    SPINEL_PROP_MSG_BUFFER_COUNTERS     = SPINEL_PROP_CNTR__BEGIN + 400,
 
-    SPINEL_PROP_CNTR__END       = 2048,
+    SPINEL_PROP_CNTR__END               = 2048,
 
-    SPINEL_PROP_NEST__BEGIN         = 15296,
-    SPINEL_PROP_NEST_STREAM_MFG     = SPINEL_PROP_NEST__BEGIN + 0,
+    SPINEL_PROP_NEST__BEGIN             = 15296,
+    SPINEL_PROP_NEST_STREAM_MFG         = SPINEL_PROP_NEST__BEGIN + 0,
 
     /// The legacy network ULA prefix (8 bytes)
     /** Format: 'D' */
-    SPINEL_PROP_NEST_LEGACY_ULA_PREFIX
-                                    = SPINEL_PROP_NEST__BEGIN + 1,
+    SPINEL_PROP_NEST_LEGACY_ULA_PREFIX  = SPINEL_PROP_NEST__BEGIN + 1,
 
     /// A (newly) joined legacy node (this is signaled from NCP)
     /** Format: 'E' */
-    SPINEL_PROP_NEST_LEGACY_JOINED_NODE
-                                    = SPINEL_PROP_NEST__BEGIN + 2,
+    SPINEL_PROP_NEST_LEGACY_JOINED_NODE = SPINEL_PROP_NEST__BEGIN + 2,
 
-    SPINEL_PROP_NEST__END           = 15360,
+    SPINEL_PROP_NEST__END               = 15360,
 
-    SPINEL_PROP_VENDOR__BEGIN       = 15360,
-    SPINEL_PROP_VENDOR__END         = 16384,
+    SPINEL_PROP_VENDOR__BEGIN           = 15360,
+    SPINEL_PROP_VENDOR__END             = 16384,
 
-    SPINEL_PROP_DEBUG__BEGIN        = 16384,
+    SPINEL_PROP_DEBUG__BEGIN            = 16384,
 
     /// Reading this property will cause an assert on the NCP.
     /// This is intended for testing the assert functionality of
@@ -1113,120 +1114,124 @@ typedef enum
     /// NCP to reset, but if this is not supported a `false` boolean
     /// is returned in response.
     /** Format: 'b' (read-only) */
-    SPINEL_PROP_DEBUG_TEST_ASSERT
-                                    = SPINEL_PROP_DEBUG__BEGIN + 0,
+    SPINEL_PROP_DEBUG_TEST_ASSERT       = SPINEL_PROP_DEBUG__BEGIN + 0,
 
     /// The NCP log level.
     /** Format: `C` */
-    SPINEL_PROP_DEBUG_NCP_LOG_LEVEL  = SPINEL_PROP_DEBUG__BEGIN + 1,
+    SPINEL_PROP_DEBUG_NCP_LOG_LEVEL     = SPINEL_PROP_DEBUG__BEGIN + 1,
 
-    SPINEL_PROP_DEBUG__END          = 17408,
+    SPINEL_PROP_DEBUG__END              = 17408,
 
-    SPINEL_PROP_EXPERIMENTAL__BEGIN = 2000000,
-    SPINEL_PROP_EXPERIMENTAL__END   = 2097152,
+    SPINEL_PROP_EXPERIMENTAL__BEGIN     = 2000000,
+    SPINEL_PROP_EXPERIMENTAL__END       = 2097152,
 } spinel_prop_key_t;
 
 // ----------------------------------------------------------------------------
 
-#define SPINEL_HEADER_FLAG               0x80
+#define SPINEL_HEADER_FLAG              0x80
 
-#define SPINEL_HEADER_TID_SHIFT          0
-#define SPINEL_HEADER_TID_MASK           (15 << SPINEL_HEADER_TID_SHIFT)
+#define SPINEL_HEADER_TID_SHIFT         0
+#define SPINEL_HEADER_TID_MASK          (15 << SPINEL_HEADER_TID_SHIFT)
 
-#define SPINEL_HEADER_IID_SHIFT          4
-#define SPINEL_HEADER_IID_MASK           (3 << SPINEL_HEADER_IID_SHIFT)
+#define SPINEL_HEADER_IID_SHIFT         4
+#define SPINEL_HEADER_IID_MASK          (3 << SPINEL_HEADER_IID_SHIFT)
 
-#define SPINEL_HEADER_IID_0              (0 << SPINEL_HEADER_IID_SHIFT)
-#define SPINEL_HEADER_IID_1              (1 << SPINEL_HEADER_IID_SHIFT)
-#define SPINEL_HEADER_IID_2              (2 << SPINEL_HEADER_IID_SHIFT)
-#define SPINEL_HEADER_IID_3              (3 << SPINEL_HEADER_IID_SHIFT)
+#define SPINEL_HEADER_IID_0             (0 << SPINEL_HEADER_IID_SHIFT)
+#define SPINEL_HEADER_IID_1             (1 << SPINEL_HEADER_IID_SHIFT)
+#define SPINEL_HEADER_IID_2             (2 << SPINEL_HEADER_IID_SHIFT)
+#define SPINEL_HEADER_IID_3             (3 << SPINEL_HEADER_IID_SHIFT)
 
-#define SPINEL_HEADER_GET_IID(x)            (((x) & SPINEL_HEADER_IID_MASK) >> SPINEL_HEADER_IID_SHIFT)
-#define SPINEL_HEADER_GET_TID(x)            (spinel_tid_t)(((x)&SPINEL_HEADER_TID_MASK)>>SPINEL_HEADER_TID_SHIFT)
+#define SPINEL_HEADER_GET_IID(x)        (((x) & SPINEL_HEADER_IID_MASK) >> SPINEL_HEADER_IID_SHIFT)
+#define SPINEL_HEADER_GET_TID(x)        (spinel_tid_t)(((x)&SPINEL_HEADER_TID_MASK)>>SPINEL_HEADER_TID_SHIFT)
 
-#define SPINEL_GET_NEXT_TID(x)      (spinel_tid_t)((x)>=0xF?1:(x)+1)
+#define SPINEL_GET_NEXT_TID(x)          (spinel_tid_t)((x)>=0xF?1:(x)+1)
 
-#define SPINEL_BEACON_THREAD_FLAG_VERSION_SHIFT 4
-#define SPINEL_BEACON_THREAD_FLAG_VERSION_MASK  (0xf << SPINEL_BEACON_THREAD_FLAG_VERSION_SHIFT)
-#define SPINEL_BEACON_THREAD_FLAG_JOINABLE      (1 << 0)
-#define SPINEL_BEACON_THREAD_FLAG_NATIVE        (1 << 3)
+#define SPINEL_BEACON_THREAD_FLAG_VERSION_SHIFT                                                         \
+                                        4
+
+#define SPINEL_BEACON_THREAD_FLAG_VERSION_MASK                                                          \
+                                        (0xf << SPINEL_BEACON_THREAD_FLAG_VERSION_SHIFT)
+
+#define SPINEL_BEACON_THREAD_FLAG_JOINABLE                                                              \
+                                        (1 << 0)
+
+#define SPINEL_BEACON_THREAD_FLAG_NATIVE                                                                \
+                                       (1 << 3)
 
 // ----------------------------------------------------------------------------
 
 enum
 {
-    SPINEL_DATATYPE_NULL_C        = 0,
-    SPINEL_DATATYPE_VOID_C        = '.',
-    SPINEL_DATATYPE_BOOL_C        = 'b',
-    SPINEL_DATATYPE_UINT8_C       = 'C',
-    SPINEL_DATATYPE_INT8_C        = 'c',
-    SPINEL_DATATYPE_UINT16_C      = 'S',
-    SPINEL_DATATYPE_INT16_C       = 's',
-    SPINEL_DATATYPE_UINT32_C      = 'L',
-    SPINEL_DATATYPE_INT32_C       = 'l',
-    SPINEL_DATATYPE_UINT_PACKED_C = 'i',
-    SPINEL_DATATYPE_IPv6ADDR_C    = '6',
-    SPINEL_DATATYPE_EUI64_C       = 'E',
-    SPINEL_DATATYPE_EUI48_C       = 'e',
-    SPINEL_DATATYPE_DATA_WLEN_C   = 'd',
-    SPINEL_DATATYPE_DATA_C        = 'D',
-    SPINEL_DATATYPE_UTF8_C        = 'U', //!< Zero-Terminated UTF8-Encoded String
-    SPINEL_DATATYPE_STRUCT_C      = 't',
-    SPINEL_DATATYPE_ARRAY_C       = 'A',
+    SPINEL_DATATYPE_NULL_C              = 0,
+    SPINEL_DATATYPE_VOID_C              = '.',
+    SPINEL_DATATYPE_BOOL_C              = 'b',
+    SPINEL_DATATYPE_UINT8_C             = 'C',
+    SPINEL_DATATYPE_INT8_C              = 'c',
+    SPINEL_DATATYPE_UINT16_C            = 'S',
+    SPINEL_DATATYPE_INT16_C             = 's',
+    SPINEL_DATATYPE_UINT32_C            = 'L',
+    SPINEL_DATATYPE_INT32_C             = 'l',
+    SPINEL_DATATYPE_UINT_PACKED_C       = 'i',
+    SPINEL_DATATYPE_IPv6ADDR_C          = '6',
+    SPINEL_DATATYPE_EUI64_C             = 'E',
+    SPINEL_DATATYPE_EUI48_C             = 'e',
+    SPINEL_DATATYPE_DATA_WLEN_C         = 'd',
+    SPINEL_DATATYPE_DATA_C              = 'D',
+    SPINEL_DATATYPE_UTF8_C              = 'U', //!< Zero-Terminated UTF8-Encoded String
+    SPINEL_DATATYPE_STRUCT_C            = 't',
+    SPINEL_DATATYPE_ARRAY_C             = 'A',
 };
 
 typedef char spinel_datatype_t;
 
-#define SPINEL_DATATYPE_NULL_S        ""
-#define SPINEL_DATATYPE_VOID_S        "."
-#define SPINEL_DATATYPE_BOOL_S        "b"
-#define SPINEL_DATATYPE_UINT8_S       "C"
-#define SPINEL_DATATYPE_INT8_S        "c"
-#define SPINEL_DATATYPE_UINT16_S      "S"
-#define SPINEL_DATATYPE_INT16_S       "s"
-#define SPINEL_DATATYPE_UINT32_S      "L"
-#define SPINEL_DATATYPE_INT32_S       "l"
-#define SPINEL_DATATYPE_UINT_PACKED_S "i"
-#define SPINEL_DATATYPE_IPv6ADDR_S    "6"
-#define SPINEL_DATATYPE_EUI64_S       "E"
-#define SPINEL_DATATYPE_EUI48_S       "e"
-#define SPINEL_DATATYPE_DATA_WLEN_S   "d"
-#define SPINEL_DATATYPE_DATA_S        "D"
-#define SPINEL_DATATYPE_UTF8_S        "U" //!< Zero-Terminated UTF8-Encoded String
+#define SPINEL_DATATYPE_NULL_S          ""
+#define SPINEL_DATATYPE_VOID_S          "."
+#define SPINEL_DATATYPE_BOOL_S          "b"
+#define SPINEL_DATATYPE_UINT8_S         "C"
+#define SPINEL_DATATYPE_INT8_S          "c"
+#define SPINEL_DATATYPE_UINT16_S        "S"
+#define SPINEL_DATATYPE_INT16_S         "s"
+#define SPINEL_DATATYPE_UINT32_S        "L"
+#define SPINEL_DATATYPE_INT32_S         "l"
+#define SPINEL_DATATYPE_UINT_PACKED_S   "i"
+#define SPINEL_DATATYPE_IPv6ADDR_S      "6"
+#define SPINEL_DATATYPE_EUI64_S         "E"
+#define SPINEL_DATATYPE_EUI48_S         "e"
+#define SPINEL_DATATYPE_DATA_WLEN_S     "d"
+#define SPINEL_DATATYPE_DATA_S          "D"
+#define SPINEL_DATATYPE_UTF8_S          "U" //!< Zero-Terminated UTF8-Encoded String
 
-#define SPINEL_DATATYPE_ARRAY_S(x)        "A(" x ")"
-#define SPINEL_DATATYPE_STRUCT_S(x)       "t(" x ")"
+#define SPINEL_DATATYPE_ARRAY_S(x)      "A(" x ")"
+#define SPINEL_DATATYPE_STRUCT_S(x)     "t(" x ")"
 
-#define SPINEL_DATATYPE_ARRAY_STRUCT_S(x)                                     \
-        SPINEL_DATATYPE_ARRAY_S(SPINEL_DATATYPE_STRUCT_WLEN_S(x))
+#define SPINEL_DATATYPE_ARRAY_STRUCT_S(x)                                                               \
+                                        SPINEL_DATATYPE_ARRAY_S(SPINEL_DATATYPE_STRUCT_WLEN_S(x))
 
-#define SPINEL_DATATYPE_COMMAND_S                                             \
-        SPINEL_DATATYPE_UINT8_S       /* header  */                           \
-        SPINEL_DATATYPE_UINT_PACKED_S /* command */
+#define SPINEL_DATATYPE_COMMAND_S       SPINEL_DATATYPE_UINT8_S       /* header  */                     \
+                                        SPINEL_DATATYPE_UINT_PACKED_S /* command */
 
-#define SPINEL_DATATYPE_COMMAND_PROP_S                                        \
-        SPINEL_DATATYPE_COMMAND_S     /* prop command  */                     \
-        SPINEL_DATATYPE_UINT_PACKED_S /* property id */
+#define SPINEL_DATATYPE_COMMAND_PROP_S  SPINEL_DATATYPE_COMMAND_S     /* prop command  */               \
+                                        SPINEL_DATATYPE_UINT_PACKED_S /* property id */
 
-#define SPINEL_DATATYPE_MAC_SCAN_RESULT_S(mac_format_str, net_format_str)     \
-        SPINEL_DATATYPE_UINT8_S /* Channel */                                 \
-        SPINEL_DATATYPE_INT8_S  /* RSSI */                                    \
-        SPINEL_DATATYPE_STRUCT_S(mac_format_str) /* mac-layer data */         \
-        SPINEL_DATATYPE_STRUCT_S(net_format_str) /* net-layer data */
+#define SPINEL_DATATYPE_MAC_SCAN_RESULT_S(mac_format_str, net_format_str)                               \
+                                        SPINEL_DATATYPE_UINT8_S /* Channel */                           \
+                                        SPINEL_DATATYPE_INT8_S  /* RSSI */                              \
+                                        SPINEL_DATATYPE_STRUCT_S(mac_format_str) /* mac-layer data */   \
+                                        SPINEL_DATATYPE_STRUCT_S(net_format_str) /* net-layer data */
 
-#define SPINEL_802_15_4_DATATYPE_MAC_SCAN_RESULT_V1_S                         \
-        SPINEL_DATATYPE_EUI64_S  /* laddr */                                  \
-        SPINEL_DATATYPE_UINT16_S /* saddr */                                  \
-        SPINEL_DATATYPE_UINT16_S /* panid */                                  \
-        SPINEL_DATATYPE_UINT8_S  /* lqi   */
+#define SPINEL_802_15_4_DATATYPE_MAC_SCAN_RESULT_V1_S                                                   \
+                                        SPINEL_DATATYPE_EUI64_S  /* laddr */                            \
+                                        SPINEL_DATATYPE_UINT16_S /* saddr */                            \
+                                        SPINEL_DATATYPE_UINT16_S /* panid */                            \
+                                        SPINEL_DATATYPE_UINT8_S  /* lqi   */
 
-#define SPINEL_NET_DATATYPE_MAC_SCAN_RESULT_V1_S                              \
-        SPINEL_DATATYPE_UINT_PACKED_S /* type */                              \
-        SPINEL_DATATYPE_UINT8_S /* flags */                                   \
-        SPINEL_DATATYPE_UTF8_S /* network name */                             \
-        SPINEL_DATATYPE_DATA_WLEN_S /* xpanid */
+#define SPINEL_NET_DATATYPE_MAC_SCAN_RESULT_V1_S                                                        \
+                                        SPINEL_DATATYPE_UINT_PACKED_S /* type */                        \
+                                        SPINEL_DATATYPE_UINT8_S /* flags */                             \
+                                        SPINEL_DATATYPE_UTF8_S /* network name */                       \
+                                        SPINEL_DATATYPE_DATA_WLEN_S /* xpanid */
 
-#define SPINEL_MAX_UINT_PACKED        2097151
+#define SPINEL_MAX_UINT_PACKED          2097151
 
 SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_pack(uint8_t *data_out, spinel_size_t data_len,
                                                       const char *pack_format, ...);


### PR DESCRIPTION
No code change. Only spacing and alignment changes.
Aligning `= number` and `#define` values at column 41 across all the definitions.
