### PR TITLE
Fix KEK attachment on Joiner Finalize Response retransmission

### DIFF
--- a/src/core/coap/secure_coap_client.cpp
+++ b/src/core/coap/secure_coap_client.cpp
@@ -180,12 +180,12 @@ exit:
     otLogFuncExit();
 }
 
-ThreadError SecureClient::HandleDtlsSend(void *aContext, const uint8_t *aBuf, uint16_t aLength)
+ThreadError SecureClient::HandleDtlsSend(void *aContext, const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType)
 {
-    return static_cast<SecureClient *>(aContext)->HandleDtlsSend(aBuf, aLength);
+    return static_cast<SecureClient *>(aContext)->HandleDtlsSend(aBuf, aLength, aMessageSubType);
 }
 
-ThreadError SecureClient::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength)
+ThreadError SecureClient::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType)
 {
     ThreadError error = kThreadError_None;
 
@@ -194,6 +194,7 @@ ThreadError SecureClient::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength)
     if (mTransmitMessage == NULL)
     {
         VerifyOrExit((mTransmitMessage = mSocket.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
+        mTransmitMessage->SetSubType(aMessageSubType);
         mTransmitMessage->SetLinkSecurityEnabled(false);
     }
 

--- a/src/core/coap/secure_coap_client.hpp
+++ b/src/core/coap/secure_coap_client.hpp
@@ -147,8 +147,8 @@ private:
     static void HandleDtlsReceive(void *aContext, uint8_t *aBuf, uint16_t aLength);
     void HandleDtlsReceive(uint8_t *aBuf, uint16_t aLength);
 
-    static ThreadError HandleDtlsSend(void *aContext, const uint8_t *aBuf, uint16_t aLength);
-    ThreadError HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength);
+    static ThreadError HandleDtlsSend(void *aContext, const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
+    ThreadError HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
 
     static void HandleUdpTransmit(void *aContext);
     void HandleUdpTransmit(void);

--- a/src/core/coap/secure_coap_server.cpp
+++ b/src/core/coap/secure_coap_server.cpp
@@ -176,12 +176,12 @@ exit:
     otLogFuncExit();
 }
 
-ThreadError SecureServer::HandleDtlsSend(void *aContext, const uint8_t *aBuf, uint16_t aLength)
+ThreadError SecureServer::HandleDtlsSend(void *aContext, const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType)
 {
-    return static_cast<SecureServer *>(aContext)->HandleDtlsSend(aBuf, aLength);
+    return static_cast<SecureServer *>(aContext)->HandleDtlsSend(aBuf, aLength, aMessageSubType);
 }
 
-ThreadError SecureServer::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength)
+ThreadError SecureServer::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType)
 {
     ThreadError error = kThreadError_None;
 
@@ -190,6 +190,7 @@ ThreadError SecureServer::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength)
     if (mTransmitMessage == NULL)
     {
         VerifyOrExit((mTransmitMessage = mSocket.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
+        mTransmitMessage->SetSubType(aMessageSubType);
         mTransmitMessage->SetLinkSecurityEnabled(false);
     }
 

--- a/src/core/coap/secure_coap_server.hpp
+++ b/src/core/coap/secure_coap_server.hpp
@@ -126,8 +126,8 @@ private:
     static void HandleDtlsReceive(void *aContext, uint8_t *aBuf, uint16_t aLength);
     void HandleDtlsReceive(uint8_t *aBuf, uint16_t aLength);
 
-    static ThreadError HandleDtlsSend(void *aContext, const uint8_t *aBuf, uint16_t aLength);
-    ThreadError HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength);
+    static ThreadError HandleDtlsSend(void *aContext, const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
+    ThreadError HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
 
     static void HandleUdpTransmit(void *aContext);
     void HandleUdpTransmit(void);

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -210,13 +210,14 @@ public:
 
     enum
     {
-        kSubTypeNone                = 0,  ///< None
-        kSubTypeMleAnnounce         = 1,  ///< MLE Announce
-        kSubTypeMleDiscoverRequest  = 2,  ///< MLE Discover Request
-        kSubTypeMleDiscoverResponse = 3,  ///< MLE Discover Response
-        kSubTypeJoinerEntrust       = 4,  ///< Joiner Entrust
-        kSubTypeMplRetransmission   = 5,  ///< MPL next retranmission message
-        kSubTypeMleGeneral          = 6,  ///< General MLE
+        kSubTypeNone                   = 0,  ///< None
+        kSubTypeMleAnnounce            = 1,  ///< MLE Announce
+        kSubTypeMleDiscoverRequest     = 2,  ///< MLE Discover Request
+        kSubTypeMleDiscoverResponse    = 3,  ///< MLE Discover Response
+        kSubTypeJoinerEntrust          = 4,  ///< Joiner Entrust
+        kSubTypeMplRetransmission      = 5,  ///< MPL next retranmission message
+        kSubTypeMleGeneral             = 6,  ///< General MLE
+        kSubTypeJoinerFinalizeResponse = 7,  ///< Joiner Finalize Response
     };
 
     enum

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -72,7 +72,6 @@ Commissioner::Commissioner(ThreadNetif &aThreadNetif):
     mTimer(aThreadNetif.GetIp6().mTimerScheduler, HandleTimer, this),
     mSessionId(0),
     mTransmitAttempts(0),
-    mSendKek(false),
     mRelayReceive(OPENTHREAD_URI_RELAY_RX, &Commissioner::HandleRelayReceive, this),
     mDatasetChanged(OPENTHREAD_URI_DATASET_CHANGED, &Commissioner::HandleDatasetChanged, this),
     mJoinerFinalize(OPENTHREAD_URI_JOINER_FINALIZE, &Commissioner::HandleJoinerFinalize, this),
@@ -100,7 +99,6 @@ ThreadError Commissioner::Start(void)
 
     mState = kStatePetition;
     mTransmitAttempts = 0;
-    mSendKek = false;
 
     SendPetition();
 
@@ -120,7 +118,6 @@ ThreadError Commissioner::Stop(void)
 
     mState = kStateDisabled;
     mTransmitAttempts = 0;
-    mSendKek = false;
 
     mTimer.Stop();
 
@@ -904,6 +901,8 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Header &aRequestHeader, 
     VerifyOrExit((message = mNetif.GetSecureCoapServer().NewMeshCoPMessage(responseHeader)) != NULL,
                  error = kThreadError_NoBufs);
 
+    message->SetSubType(Message::kSubTypeJoinerFinalizeResponse);
+
     stateTlv.Init();
     stateTlv.SetState(aState);
     SuccessOrExit(error = message->Append(&stateTlv, sizeof(stateTlv)));
@@ -912,7 +911,6 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Header &aRequestHeader, 
     joinerMessageInfo.GetPeerAddr().SetIid(mJoinerIid);
     joinerMessageInfo.SetPeerPort(mJoinerPort);
 
-    mSendKek = true;
 #if OPENTHREAD_ENABLE_CERT_LOG
     uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
     VerifyOrExit(message->GetLength() <= sizeof(buf), ;);
@@ -933,7 +931,6 @@ exit:
 
     if (error != kThreadError_None && message != NULL)
     {
-        mSendKek = false;
         message->Free();
     }
 
@@ -978,13 +975,12 @@ ThreadError Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::Messag
     rloc.SetJoinerRouterLocator(mJoinerRloc);
     SuccessOrExit(error = message->Append(&rloc, sizeof(rloc)));
 
-    if (mSendKek)
+    if (aMessage.GetSubType() == Message::kSubTypeJoinerFinalizeResponse)
     {
         JoinerRouterKekTlv kek;
         kek.Init();
         kek.SetKek(mNetif.GetKeyManager().GetKek());
         SuccessOrExit(error = message->Append(&kek, sizeof(kek)));
-        mSendKek = false;
     }
 
     tlv.SetType(Tlv::kJoinerDtlsEncapsulation);

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -284,7 +284,6 @@ private:
     Timer mTimer;
     uint16_t mSessionId;
     uint8_t mTransmitAttempts;
-    bool mSendKek;
 
     Coap::Resource mRelayReceive;
     Coap::Resource mDatasetChanged;

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -101,12 +101,13 @@ public:
     /**
      * This function pointer is called when data is ready to transmit for the DTLS session.
      *
-     * @param[in]  aContext  A pointer to application-specific context.
-     * @param[in]  aBuf      A pointer to the transmit data buffer.
-     * @param[in]  aLength   Number of bytes in the transmit data buffer.
+     * @param[in]  aContext         A pointer to application-specific context.
+     * @param[in]  aBuf             A pointer to the transmit data buffer.
+     * @param[in]  aLength          Number of bytes in the transmit data buffer.
+     * @param[in]  aMessageSubtype  A message sub type information for the sender.
      *
      */
-    typedef ThreadError(*SendHandler)(void *aContext, const uint8_t *aBuf, uint16_t aLength);
+    typedef ThreadError(*SendHandler)(void *aContext, const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
 
     /**
      * This method starts the DTLS service.
@@ -252,6 +253,8 @@ private:
     SendHandler mSendHandler;
     void *mContext;
     bool mClient;
+
+    uint8_t mMessageSubType;
 
     ThreadNetif &mNetif;
 };


### PR DESCRIPTION
#1500 introduced a problem with retransmision of Joiner Finalize Response. After the CoAP improvement, when a Commissioner receives a duplicated Joiner Finalize message from a Joiner, it does not call the the respective handler, but retransmits the original response. This is perfectly fine, though calling the handler resulted in setting the mSendKek flag, and in result attaching the KEK TLV to the response. When KEK TLV is not present in the response, sending of Joiner Entrust is not triggered on the Joiner Routers side, therefore the commissioning process does not end properly.

This PR adds a new message sub type - Joiner Finalize Response, and transfers this property over DTLS handlers, so the retransmission of this message on CoAP layer is handled properly.
