### PR TITLE
Add detailed logs for a received, transmitted, or dropped IPv6 message

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -31,6 +31,15 @@
  *   This file implements IEEE 802.15.4 header generation and processing.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
+#include <stdio.h>
+#include <string.h>
+
 #include <common/code_utils.hpp>
 #include <common/debug.hpp>
 #include <mac/mac_frame.hpp>
@@ -43,6 +52,28 @@ void ExtAddress::Set(const Ip6::Address &aIpAddress)
 {
     memcpy(m8, aIpAddress.GetIid(), sizeof(m8));
     m8[0] ^= 0x02;
+}
+
+const char *Address::ToString(char *aBuf, uint16_t aSize) const
+{
+    switch (mLength)
+    {
+    case sizeof(ShortAddress):
+        snprintf(aBuf, aSize, "0x%04x", mShortAddress);
+        break;
+
+    case sizeof(ExtAddress):
+        snprintf(aBuf, aSize, "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x",
+                 mExtAddress.m8[0], mExtAddress.m8[1], mExtAddress.m8[2], mExtAddress.m8[3],
+                 mExtAddress.m8[4], mExtAddress.m8[5], mExtAddress.m8[6], mExtAddress.m8[7]);
+        break;
+
+    default:
+        snprintf(aBuf, aSize, "Unknown");
+        break;
+    }
+
+    return aBuf;
 }
 
 ThreadError Frame::InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl)

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -154,12 +154,28 @@ private:
  */
 struct Address
 {
+    enum
+    {
+        kAddressStringSize =  24,    ///< Max chars needed for a string representation of address (@sa ToString()).
+    };
+
     uint8_t mLength;                 ///< Length of address in bytes.
     union
     {
         ShortAddress mShortAddress;  ///< The IEEE 802.15.4 Short Address.
         ExtAddress mExtAddress;      ///< The IEEE 802.15.4 Extended Address.
     };
+
+    /**
+     * This method converts an address object to a NULL-terminated string.
+     *
+     * @param[out]  aBuf   A pointer to the buffer.
+     * @param[in]   aSize  The maximum size of the buffer.
+     *
+     * @returns A pointer to the char string buffer.
+     *
+     */
+    const char *ToString(char *aBuf, uint16_t aSize) const;
 };
 
 /**

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1074,5 +1074,55 @@ otInstance *Ip6::GetInstance(void)
     return otInstanceFromIp6(this);
 }
 
+const char *Ip6::IpProtoToString(IpProto aIpProto)
+{
+    const char *retval;
+
+    switch (aIpProto)
+    {
+    case kProtoHopOpts:
+        retval = "HopOpts";
+        break;
+
+    case kProtoTcp:
+        retval = "TCP";
+        break;
+
+    case kProtoUdp:
+        retval = "UDP";
+        break;
+
+    case kProtoIp6:
+        retval = "IP6";
+        break;
+
+    case kProtoRouting:
+        retval = "Routing";
+        break;
+
+    case kProtoFragment:
+        retval = "Frag";
+        break;
+
+    case kProtoIcmp6:
+        retval = "ICMP6";
+        break;
+
+    case kProtoNone:
+        retval = "None";
+        break;
+
+    case kProtoDstOpts:
+        retval = "DstOpts";
+        break;
+
+    default:
+        retval = "Unknown";
+        break;
+    }
+
+    return retval;
+}
+
 }  // namespace Ip6
 }  // namespace Thread

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -347,6 +347,14 @@ public:
      */
     const PriorityQueue &GetSendQueue(void) const { return mSendQueue; }
 
+    /**
+     * This static method converts an `IpProto` enumeration to a string.
+     *
+     * @returns The string representation of an IP protocol enumeration.
+     *
+     */
+    static const char *IpProtoToString(IpProto aIpProto);
+
     Routes mRoutes;
     Icmp mIcmp;
     Udp mUdp;

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -297,6 +297,7 @@ const char *Address::ToString(char *aBuf, uint16_t aSize) const
              HostSwap16(mFields.m16[2]), HostSwap16(mFields.m16[3]),
              HostSwap16(mFields.m16[4]), HostSwap16(mFields.m16[5]),
              HostSwap16(mFields.m16[6]), HostSwap16(mFields.m16[7]));
+
     return aBuf;
 }
 

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -63,6 +63,7 @@ public:
     enum
     {
         kInterfaceIdentifierSize   = 8,  ///< Interface Identifier size in bytes.
+        kIp6AddressStringSize      = 40, ///< Max buffer size in bytes to store an IPv6 address in string format.
     };
 
     /**

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -277,6 +277,12 @@ private:
         kMaxPollTriggeredTxAttempts = OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_POLLS,
     };
 
+    enum MessageAction              ///< Defines the action parameter in `LogMessageInfo()` method.
+    {
+        kMessageReceive,            ///< Indicates that the message was received.
+        kMessageTransmit,           ///< Indicates that the message was sent.
+    };
+
     ThreadError CheckReachability(uint8_t *aFrame, uint8_t aFrameLength,
                                   const Mac::Address &aMeshSource, const Mac::Address &aMeshDest);
 
@@ -301,7 +307,8 @@ private:
     ThreadError SendEmptyFrame(Mac::Frame &aFrame);
     ThreadError UpdateIp6Route(Message &aMessage);
     ThreadError UpdateMeshRoute(Message &aMessage);
-    ThreadError HandleDatagram(Message &aMessage, const ThreadMessageInfo &aMessageInfo);
+    ThreadError HandleDatagram(Message &aMessage, const ThreadMessageInfo &aMessageInfo,
+                               const Mac::Address &aMacSource);
     void ClearReassemblyList(void);
 
     static void HandleReceivedFrame(void *aContext, Mac::Frame &aFrame);
@@ -329,6 +336,9 @@ private:
     ThreadError AddPendingSrcMatchEntries(void);
     ThreadError AddSrcMatchEntry(Child &aChild);
     void ClearSrcMatchEntry(Child &aChild);
+
+    void LogIp6Message(MessageAction aAction, const Message &aMessage, const Mac::Address &aMacAddress,
+                       ThreadError aError);
 
     Mac::Receiver mMacReceiver;
     Mac::Sender mMacSender;


### PR DESCRIPTION
This commit adds detailed logs (at `info` level) when an IPv6
message is received, transmitted or dropped (due to tx failures).
The log contains the following information about the IPv6 message:

- The message length (in bytes),
- The protocol (TCP/UDP/ICMP6, etc.),
- Checksum value for UDP or TCP,
- MAC address of source/dest (short or extended address),
- Message security (enabled/disabled),
- Message's source and destination IPv6 addresses,
- In case of tx failure, error causing the drop (CCA, No Ack, ...).