### PR TITLE
Most recent RSSI in child/neighbour tables

### DIFF
--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -791,6 +791,7 @@ typedef struct
     uint32_t       mMleFrameCounter;       ///< MLE Frame Counter
     uint8_t        mLinkQualityIn;         ///< Link Quality In
     int8_t         mAverageRssi;           ///< Average RSSI
+    int8_t         mLastRssi;              ///< Last observed RSSI
     bool           mRxOnWhenIdle : 1;      ///< rx-on-when-idle
     bool           mSecureDataRequest : 1; ///< Secure Data Requests
     bool           mFullFunction : 1;      ///< Full Function Device
@@ -816,6 +817,7 @@ typedef struct
     uint8_t        mNetworkDataVersion;    ///< Network Data Version
     uint8_t        mLinkQualityIn;         ///< Link Quality In
     int8_t         mAverageRssi;           ///< Average RSSI
+    int8_t         mLastRssi;              ///< Last observed RSSI
     bool           mRxOnWhenIdle : 1;      ///< rx-on-when-idle
     bool           mSecureDataRequest : 1; ///< Secure Data Requests
     bool           mFullFunction : 1;      ///< Full Function Device

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -70,15 +70,18 @@ LinkQualityInfo::LinkQualityInfo(void)
 
 void LinkQualityInfo::Clear(void)
 {
-    mRssAverage = 0;
-    mCount = 0;
+    mRssAverage  = 0;
+    mCount       = 0;
     mLinkQuality = 0;
+    mLastRss     = 0;
 }
 
 void LinkQualityInfo::AddRss(LinkQualityInfo &aNoiseFloor, int8_t anRss)
 {
     uint16_t    newValue;
     uint16_t    oldAverage;
+
+    mLastRss = anRss;
 
     // Restrict/Cap the RSS value to the closed range [0, -128] so the value can fit in 8 bits.
 
@@ -182,6 +185,11 @@ uint8_t LinkQualityInfo::GetLinkQuality(LinkQualityInfo &aNoiseFloor)
     UpdateLinkQuality(aNoiseFloor);
 
     return mLinkQuality;
+}
+
+int8_t LinkQualityInfo::GetLastRss(void) const
+{
+    return mLastRss;
 }
 
 void LinkQualityInfo::UpdateLinkQuality(LinkQualityInfo &aNoiseFloor)

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -141,6 +141,14 @@ public:
     uint8_t GetLinkQuality(LinkQualityInfo &aNoiseFloor);
 
     /**
+     * Returns the most recent RSS value.
+     *
+     * @returns The most recent RSS
+     *
+     */
+    int8_t GetLastRss(void) const;
+
+    /**
      * This method converts a received signal strength value to a link margin value.
      *
      * @param[in]  aNoiseFloor  A reference to the noise state.
@@ -216,6 +224,7 @@ private:
     uint16_t mRssAverage  : 11;  // The encoded average signal strength value (stored as rss times precision multiple).
     uint8_t  mCount       : 3;   // Number of RSS values added to average so far (limited to kRssCountMax).
     uint8_t  mLinkQuality : 2;   // Current link quality value (0-3).
+    int8_t   mLastRss;
 };
 
 /**

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3484,7 +3484,7 @@ ThreadError MleRouter::GetChildInfo(Child &aChild, otChildInfo &aChildInfo)
     aChildInfo.mAge                = Timer::MsecToSec(Timer::GetNow() - aChild.mLastHeard);
     aChildInfo.mLinkQualityIn      = aChild.mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
     aChildInfo.mAverageRssi        = aChild.mLinkInfo.GetAverageRss();
-    aChildInfo.mLastRssi           = neighbor->mLinkInfo.GetLastRss();
+    aChildInfo.mLastRssi           = aChild.mLinkInfo.GetLastRss();
 
     aChildInfo.mRxOnWhenIdle      = (aChild.mMode & ModeTlv::kModeRxOnWhenIdle) != 0;
     aChildInfo.mSecureDataRequest = (aChild.mMode & ModeTlv::kModeSecureDataRequest) != 0;

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3483,6 +3483,7 @@ ThreadError MleRouter::GetChildInfo(Child &aChild, otChildInfo &aChildInfo)
     aChildInfo.mAge = Timer::MsecToSec(Timer::GetNow() - aChild.mLastHeard);
     aChildInfo.mLinkQualityIn = aChild.mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
     aChildInfo.mAverageRssi = aChild.mLinkInfo.GetAverageRss();
+    aChildInfo.mLastRssi = neighbor->mLinkInfo.GetLastRss();
 
     aChildInfo.mRxOnWhenIdle = (aChild.mMode & ModeTlv::kModeRxOnWhenIdle) != 0;
     aChildInfo.mSecureDataRequest = (aChild.mMode & ModeTlv::kModeSecureDataRequest) != 0;
@@ -3581,6 +3582,7 @@ exit:
         aNeighInfo.mMleFrameCounter = neighbor->mValid.mMleFrameCounter;
         aNeighInfo.mLinkQualityIn = neighbor->mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
         aNeighInfo.mAverageRssi = neighbor->mLinkInfo.GetAverageRss();
+        aNeighInfo.mLastRssi = neighbor->mLinkInfo.GetLastRss();
         aNeighInfo.mRxOnWhenIdle = (neighbor->mMode & ModeTlv::kModeRxOnWhenIdle) != 0;
         aNeighInfo.mSecureDataRequest = (neighbor->mMode & ModeTlv::kModeSecureDataRequest) != 0;
         aNeighInfo.mFullFunction = (neighbor->mMode & ModeTlv::kModeFFD) != 0;

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3476,19 +3476,20 @@ ThreadError MleRouter::GetChildInfo(Child &aChild, otChildInfo &aChildInfo)
 
     memset(&aChildInfo, 0, sizeof(aChildInfo));
     memcpy(&aChildInfo.mExtAddress, &aChild.mMacAddr, sizeof(aChildInfo.mExtAddress));
-    aChildInfo.mTimeout = aChild.mTimeout;
-    aChildInfo.mRloc16 = aChild.mValid.mRloc16;
-    aChildInfo.mChildId = GetChildId(aChild.mValid.mRloc16);
-    aChildInfo.mNetworkDataVersion = aChild.mNetworkDataVersion;
-    aChildInfo.mAge = Timer::MsecToSec(Timer::GetNow() - aChild.mLastHeard);
-    aChildInfo.mLinkQualityIn = aChild.mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
-    aChildInfo.mAverageRssi = aChild.mLinkInfo.GetAverageRss();
-    aChildInfo.mLastRssi = neighbor->mLinkInfo.GetLastRss();
 
-    aChildInfo.mRxOnWhenIdle = (aChild.mMode & ModeTlv::kModeRxOnWhenIdle) != 0;
+    aChildInfo.mTimeout            = aChild.mTimeout;
+    aChildInfo.mRloc16             = aChild.mValid.mRloc16;
+    aChildInfo.mChildId            = GetChildId(aChild.mValid.mRloc16);
+    aChildInfo.mNetworkDataVersion = aChild.mNetworkDataVersion;
+    aChildInfo.mAge                = Timer::MsecToSec(Timer::GetNow() - aChild.mLastHeard);
+    aChildInfo.mLinkQualityIn      = aChild.mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
+    aChildInfo.mAverageRssi        = aChild.mLinkInfo.GetAverageRss();
+    aChildInfo.mLastRssi           = neighbor->mLinkInfo.GetLastRss();
+
+    aChildInfo.mRxOnWhenIdle      = (aChild.mMode & ModeTlv::kModeRxOnWhenIdle) != 0;
     aChildInfo.mSecureDataRequest = (aChild.mMode & ModeTlv::kModeSecureDataRequest) != 0;
-    aChildInfo.mFullFunction = (aChild.mMode & ModeTlv::kModeFFD) != 0;
-    aChildInfo.mFullNetworkData = (aChild.mMode & ModeTlv::kModeFullNetworkData) != 0;
+    aChildInfo.mFullFunction      = (aChild.mMode & ModeTlv::kModeFFD) != 0;
+    aChildInfo.mFullNetworkData   = (aChild.mMode & ModeTlv::kModeFullNetworkData) != 0;
 
 exit:
     return error;
@@ -3513,15 +3514,16 @@ ThreadError MleRouter::GetRouterInfo(uint16_t aRouterId, otRouterInfo &aRouterIn
     VerifyOrExit(router != NULL, error = kThreadError_InvalidArgs);
 
     memcpy(&aRouterInfo.mExtAddress, &router->mMacAddr, sizeof(aRouterInfo.mExtAddress));
-    aRouterInfo.mAllocated = router->mAllocated;
-    aRouterInfo.mRouterId = routerId;
-    aRouterInfo.mRloc16 = GetRloc16(routerId);
-    aRouterInfo.mNextHop = router->mNextHop;
+
+    aRouterInfo.mAllocated       = router->mAllocated;
+    aRouterInfo.mRouterId        = routerId;
+    aRouterInfo.mRloc16          = GetRloc16(routerId);
+    aRouterInfo.mNextHop         = router->mNextHop;
     aRouterInfo.mLinkEstablished = router->mState == Neighbor::kStateValid;
-    aRouterInfo.mPathCost = router->mCost;
-    aRouterInfo.mLinkQualityIn = router->mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
-    aRouterInfo.mLinkQualityOut = router->mLinkQualityOut;
-    aRouterInfo.mAge = static_cast<uint8_t>(Timer::MsecToSec(Timer::GetNow() - router->mLastHeard));
+    aRouterInfo.mPathCost        = router->mCost;
+    aRouterInfo.mLinkQualityIn   = router->mLinkInfo.GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
+    aRouterInfo.mLinkQualityOut  = router->mLinkQualityOut;
+    aRouterInfo.mAge             = static_cast<uint8_t>(Timer::MsecToSec(Timer::GetNow() - router->mLastHeard));
 
 exit:
     return error;

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -2540,7 +2540,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_NEIGHBOR_TABLE(uint8_t header, sp
                 neighInfo.mIsChild,
                 neighInfo.mLinkFrameCounter,
                 neighInfo.mMleFrameCounter,
-                neighInfo.mLastRssi,
+                neighInfo.mLastRssi
         ));
     }
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -2460,6 +2460,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_CHILD_TABLE(uint8_t header, spine
                     SPINEL_DATATYPE_UINT8_S         // Link Quality In
                     SPINEL_DATATYPE_INT8_S          // Average RSS
                     SPINEL_DATATYPE_UINT8_S         // Mode (flags)
+                    SPINEL_DATATYPE_INT8_S          // Most recent RSS
                 ),
                 childInfo.mExtAddress.m8,
                 childInfo.mRloc16,
@@ -2468,7 +2469,8 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_CHILD_TABLE(uint8_t header, spine
                 childInfo.mNetworkDataVersion,
                 childInfo.mLinkQualityIn,
                 childInfo.mAverageRssi,
-                modeFlags
+                modeFlags,
+                childInfo.mLastRssi
         ));
     }
 
@@ -2527,6 +2529,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_NEIGHBOR_TABLE(uint8_t header, sp
                     SPINEL_DATATYPE_BOOL_S          // Is Child
                     SPINEL_DATATYPE_UINT32_S        // Link Frame Counter
                     SPINEL_DATATYPE_UINT32_S        // MLE Frame Counter
+                    SPINEL_DATATYPE_INT8_S          // Most recent RSS
                 ),
                 neighInfo.mExtAddress.m8,
                 neighInfo.mRloc16,
@@ -2536,7 +2539,8 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_NEIGHBOR_TABLE(uint8_t header, sp
                 modeFlags,
                 neighInfo.mIsChild,
                 neighInfo.mLinkFrameCounter,
-                neighInfo.mMleFrameCounter
+                neighInfo.mMleFrameCounter,
+                neighInfo.mLastRssi,
         ));
     }
 


### PR DESCRIPTION
This adds an entry to the child and neighbour tables for the most recent RSSI observed. 
There is an accompanying  wpantund PR.