### PR TITLE
Fix mismatching source address of secured CoAP server

### DIFF
--- a/src/core/coap/secure_coap_server.cpp
+++ b/src/core/coap/secure_coap_server.cpp
@@ -117,7 +117,10 @@ void SecureServer::Receive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     {
         mPeerAddress.SetPeerAddr(aMessageInfo.GetPeerAddr());
         mPeerAddress.SetPeerPort(aMessageInfo.GetPeerPort());
-        mPeerAddress.SetSockAddr(aMessageInfo.GetSockAddr());
+        if (mNetif.IsUnicastAddress(aMessageInfo.GetSockAddr()))
+        {
+            mPeerAddress.SetSockAddr(aMessageInfo.GetSockAddr());
+        }
         mPeerAddress.SetSockPort(aMessageInfo.GetSockPort());
 
         mNetif.GetDtls().Start(false, HandleDtlsConnected, HandleDtlsReceive, HandleDtlsSend, this);

--- a/src/core/coap/secure_coap_server.cpp
+++ b/src/core/coap/secure_coap_server.cpp
@@ -117,10 +117,12 @@ void SecureServer::Receive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     {
         mPeerAddress.SetPeerAddr(aMessageInfo.GetPeerAddr());
         mPeerAddress.SetPeerPort(aMessageInfo.GetPeerPort());
+
         if (mNetif.IsUnicastAddress(aMessageInfo.GetSockAddr()))
         {
             mPeerAddress.SetSockAddr(aMessageInfo.GetSockAddr());
         }
+
         mPeerAddress.SetSockPort(aMessageInfo.GetSockPort());
 
         mNetif.GetDtls().Start(false, HandleDtlsConnected, HandleDtlsReceive, HandleDtlsSend, this);

--- a/src/core/coap/secure_coap_server.cpp
+++ b/src/core/coap/secure_coap_server.cpp
@@ -117,6 +117,8 @@ void SecureServer::Receive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     {
         mPeerAddress.SetPeerAddr(aMessageInfo.GetPeerAddr());
         mPeerAddress.SetPeerPort(aMessageInfo.GetPeerPort());
+        mPeerAddress.SetSockAddr(aMessageInfo.GetSockAddr());
+        mPeerAddress.SetSockPort(aMessageInfo.GetSockPort());
 
         mNetif.GetDtls().Start(false, HandleDtlsConnected, HandleDtlsReceive, HandleDtlsSend, this);
     }


### PR DESCRIPTION
This PR fixes the issue that secured CoAP Server responds with mismatching IP source address during DTLS handshake.