### PR TITLE
Support CoAP option Uri-Port

### DIFF
--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -99,6 +99,7 @@ typedef enum otCoapCode
 typedef enum otCoapOptionType
 {
     kCoapOptionObserve       = 6,    ///< Observe
+    kCoapOptionUriPort       = 7,    ///< Uri-Port
     kCoapOptionUriPath       = 11,   ///< Uri-Path
     kCoapOptionContentFormat = 12,   ///< Content-Format
     kCoapOptionMaxAge        = 14,   ///< Max-Age

--- a/src/core/coap/coap_server.cpp
+++ b/src/core/coap/coap_server.cpp
@@ -191,6 +191,9 @@ void Server::ProcessReceivedMessage(Message &aMessage, const Ip6::MessageInfo &a
             curUriPath += coapOption->mLength;
             break;
 
+        case kCoapOptionUriPort:
+            break;
+
         case kCoapOptionContentFormat:
             break;
 


### PR DESCRIPTION
Some CoAP client may include a `Uri-Port` option, and OpenThread's CoAP doesn't handle packets' with this option. This PR fixes this issue by simply ignoring this option.