### PR TITLE
Create and use an enum for Route Config mPreference.

### DIFF
--- a/examples/drivers/windows/otNodeApi/otNodeApi.cpp
+++ b/examples/drivers/windows/otNodeApi/otNodeApi.cpp
@@ -1562,15 +1562,15 @@ OTNODEAPI int32_t OTCALL otNodeAddPrefix(otNode* aNode, const char *aPrefix, con
     
     if (strcmp(aPreference, "high") == 0)
     {
-        config.mPreference = 1;
+        config.mPreference = kRoutePreferenceHigh;
     }
     else if (strcmp(aPreference, "med") == 0)
     {
-        config.mPreference = 1;
+        config.mPreference = kRoutePreferenceMedium;
     }
     else if (strcmp(aPreference, "low") == 0)
     {
-        config.mPreference = -1;
+        config.mPreference = kRoutePreferenceLow;
     }
     else
     {
@@ -1605,15 +1605,15 @@ OTNODEAPI int32_t OTCALL otNodeAddRoute(otNode* aNode, const char *aPrefix, cons
     
     if (strcmp(aPreference, "high") == 0)
     {
-        config.mPreference = 1;
+        config.mPreference = kRoutePreferenceHigh;
     }
     else if (strcmp(aPreference, "med") == 0)
     {
-        config.mPreference = 1;
+        config.mPreference = kRoutePreferenceMedium;
     }
     else if (strcmp(aPreference, "low") == 0)
     {
-        config.mPreference = -1;
+        config.mPreference = kRoutePreferenceLow;
     }
     else
     {

--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -698,6 +698,16 @@ typedef struct otExternalRouteConfig
 } otExternalRouteConfig;
 
 /**
+ * Defines valid values for member mPreference in otExternalRouteConfig and otBorderRouterConfig.
+ */
+typedef enum otRoutePreference
+{
+    kRoutePreferenceLow    = -1,  ///< Routes assigned this value are used as a last resort when no other more preferred route exists.
+    kRoutePreferenceMedium =  0,  ///< Routes assigned this value should be selected only in the absence of any kRoutePreferenceHigh routes.
+    kRoutePreferenceHigh   =  1   ///< The most preferred route. Routes assigned this value should be selected over any other route.
+} otRoutePreference;
+
+/**
  * @}
  *
  */

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1723,15 +1723,15 @@ ThreadError Interpreter::ProcessPrefixAdd(int argc, char *argv[])
     {
         if (strcmp(argv[argcur], "high") == 0)
         {
-            config.mPreference = 1;
+            config.mPreference = kRoutePreferenceHigh;
         }
         else if (strcmp(argv[argcur], "med") == 0)
         {
-            config.mPreference = 0;
+            config.mPreference = kRoutePreferenceMedium;
         }
         else if (strcmp(argv[argcur], "low") == 0)
         {
-            config.mPreference = -1;
+            config.mPreference = kRoutePreferenceLow;
         }
         else
         {
@@ -1865,15 +1865,15 @@ ThreadError Interpreter::ProcessPrefixList(void)
 
         switch (config.mPreference)
         {
-        case -1:
+        case kRoutePreferenceLow:
             sServer->OutputFormat(" low\r\n");
             break;
 
-        case 0:
+        case kRoutePreferenceMedium:
             sServer->OutputFormat(" med\r\n");
             break;
 
-        case 1:
+        case kRoutePreferenceHigh:
             sServer->OutputFormat(" high\r\n");
             break;
         }
@@ -1975,15 +1975,15 @@ ThreadError Interpreter::ProcessRouteAdd(int argc, char *argv[])
         }
         else if (strcmp(argv[argcur], "high") == 0)
         {
-            config.mPreference = 1;
+            config.mPreference = kRoutePreferenceHigh;
         }
         else if (strcmp(argv[argcur], "med") == 0)
         {
-            config.mPreference = 0;
+            config.mPreference = kRoutePreferenceMedium;
         }
         else if (strcmp(argv[argcur], "low") == 0)
         {
-            config.mPreference = -1;
+            config.mPreference = kRoutePreferenceLow;
         }
         else
         {


### PR DESCRIPTION
Solves for Issue #1487.

Adds an enum to define possible values for mPreference in data structures otExternalRouteConfig and otBorderRouterConfig.