### PR TITLE
support udp socket connect

### DIFF
--- a/include/openthread/udp.h
+++ b/include/openthread/udp.h
@@ -99,6 +99,7 @@ otMessage *otUdpNewMessage(otInstance *aInstance, bool aLinkSecurityEnabled);
  * @sa otUdpNewMessage
  * @sa otUdpClose
  * @sa otUdpBind
+ * @sa otUdpConnect
  * @sa otUdpSend
  *
  */
@@ -114,6 +115,7 @@ ThreadError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive 
  * @sa otUdpNewMessage
  * @sa otUdpOpen
  * @sa otUdpBind
+ * @sa otUdpConnect
  * @sa otUdpSend
  *
  */
@@ -129,11 +131,29 @@ ThreadError otUdpClose(otUdpSocket *aSocket);
  *
  * @sa otUdpNewMessage
  * @sa otUdpOpen
+ * @sa otUdpConnect
  * @sa otUdpClose
  * @sa otUdpSend
  *
  */
 ThreadError otUdpBind(otUdpSocket *aSocket, otSockAddr *aSockName);
+
+/**
+ * Connect a UDP/IPv6 socket.
+ *
+ * @param[in]  aSocket    A pointer to a UDP socket structure.
+ * @param[in]  aSockName  A pointer to an IPv6 socket address structure.
+ *
+ * @retval kThreadErrorNone  Connect operation was successful.
+ *
+ * @sa otUdpNewMessage
+ * @sa otUdpOpen
+ * @sa otUdpBind
+ * @sa otUdpClose
+ * @sa otUdpSend
+ *
+ */
+ThreadError otUdpConnect(otUdpSocket *aSocket, otSockAddr *aSockName);
 
 /**
  * Send a UDP/IPv6 message.
@@ -146,6 +166,7 @@ ThreadError otUdpBind(otUdpSocket *aSocket, otSockAddr *aSockName);
  * @sa otUdpOpen
  * @sa otUdpClose
  * @sa otUdpBind
+ * @sa otUdpConnect
  * @sa otUdpSend
  *
  */

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -91,6 +91,12 @@ ThreadError otUdpBind(otUdpSocket *aSocket, otSockAddr *aSockName)
     return socket->Bind(*static_cast<const Ip6::SockAddr *>(aSockName));
 }
 
+ThreadError otUdpConnect(otUdpSocket *aSocket, otSockAddr *aSockName)
+{
+    Ip6::UdpSocket *socket = static_cast<Ip6::UdpSocket *>(aSocket);
+    return socket->Connect(*static_cast<const Ip6::SockAddr *>(aSockName));
+}
+
 ThreadError otUdpSend(otUdpSocket *aSocket, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
     Ip6::UdpSocket *socket = static_cast<Ip6::UdpSocket *>(aSocket);

--- a/src/core/coap/secure_coap_server.cpp
+++ b/src/core/coap/secure_coap_server.cpp
@@ -115,6 +115,11 @@ void SecureServer::Receive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
 
     if (!mNetif.GetDtls().IsStarted())
     {
+        Ip6::SockAddr sockAddr;
+        sockAddr.mAddress = aMessageInfo.GetPeerAddr();
+        sockAddr.mPort = aMessageInfo.GetPeerPort();
+        mSocket.Connect(sockAddr);
+
         mPeerAddress.SetPeerAddr(aMessageInfo.GetPeerAddr());
         mPeerAddress.SetPeerPort(aMessageInfo.GetPeerPort());
 

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -69,6 +69,12 @@ ThreadError UdpSocket::Bind(const SockAddr &aSockAddr)
     return kThreadError_None;
 }
 
+ThreadError UdpSocket::Connect(const SockAddr &aSockAddr)
+{
+    mPeerName = aSockAddr;
+    return kThreadError_None;
+}
+
 ThreadError UdpSocket::Close(void)
 {
     ThreadError error = kThreadError_None;

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -103,6 +103,15 @@ public:
     ThreadError Bind(const SockAddr &aSockAddr);
 
     /**
+     * This method connects the UDP socket.
+     *
+     * @param[in]  aSockAddr  A reference to the socket address.
+     *
+     * @retval kThreadError_None  Successfully connected the socket.
+     */
+    ThreadError Connect(const SockAddr &aSockAddr);
+
+    /**
      * This method closes the UDP socket.
      *
      * @retval kThreadError_None  Successfully closed the UDP socket.


### PR DESCRIPTION
I noticed the `otUdpSocket` was designed to support UDP `connect()` feature, but not fully implemented. This PR adds missing APIs and use this feature in `Coap::SecureServer`.