### PR TITLE
Remove AppVeyor Debug Builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,6 @@ version: 0.1.{build}
 image: Visual Studio 2015
 configuration:
 - Release
-- Debug
 platform:
 - x64
 - x86


### PR DESCRIPTION
Halves the AppVeyor build time. No real benefit from building debug and the debug release/app packages shouldn't be used anyways.