### PR TITLE
otLwf Spinel and Logging Fixes

### DIFF
--- a/examples/drivers/windows/otLwf/command.c
+++ b/examples/drivers/windows/otLwf/command.c
@@ -130,7 +130,7 @@ otLwfCmdInitialize(
             break;
         }
         if (MajorVersion != SPINEL_PROTOCOL_VERSION_THREAD_MAJOR ||
-            MinorVersion != SPINEL_PROTOCOL_VERSION_THREAD_MINOR)
+            MinorVersion < 3) // TODO - Remove this minor version check with the next major version update
         {
             Status = NDIS_STATUS_NOT_SUPPORTED;
             LogError(DRIVER_DEFAULT, "Protocol Version Mismatch! OsVer: %d.%d DeviceVer: %d.%d",

--- a/examples/drivers/windows/otLwf/eventprocessing.c
+++ b/examples/drivers/windows/otLwf/eventprocessing.c
@@ -1009,13 +1009,22 @@ otLwfEventWorkerThread(
                     if (try_spinel_datatype_unpack(
                             Event->Buffer + offset,
                             length,
-                            "ccSiCC",
+                            SPINEL_DATATYPE_INT8_S
+                            SPINEL_DATATYPE_INT8_S
+                            SPINEL_DATATYPE_UINT16_S
+                            SPINEL_DATATYPE_STRUCT_S( // PHY-data
+                                SPINEL_DATATYPE_UINT8_S // 802.15.4 channel
+                                SPINEL_DATATYPE_UINT8_S // 802.15.4 LQI
+                            )
+                            SPINEL_DATATYPE_STRUCT_S( // Vendor-data
+                                SPINEL_DATATYPE_UINT_PACKED_S
+                            ),
                             &pFilter->otReceiveFrame.mPower,
                             &noiseFloor,
                             &flags,
-                            &errorCode,
                             &pFilter->otReceiveFrame.mChannel,
-                            &pFilter->otReceiveFrame.mLqi))
+                            &pFilter->otReceiveFrame.mLqi,
+                            &errorCode))
                     {
                         otLwfRadioReceiveFrame(pFilter, errorCode);
                     }

--- a/examples/drivers/windows/otLwf/radio.c
+++ b/examples/drivers/windows/otLwf/radio.c
@@ -192,17 +192,20 @@ void otPlatRadioSetPanId(_In_ otInstance *otCtx, uint16_t panid)
 
     pFilter->otPanID = panid;
 
-    // Indicate to the miniport
-    status =
-        otLwfCmdSetProp(
-            pFilter,
-            SPINEL_PROP_MAC_15_4_PANID,
-            SPINEL_DATATYPE_UINT16_S,
-            panid
-        );
-    if (!NT_SUCCESS(status))
+    if (pFilter->otPhyState != kStateDisabled)
     {
-        LogError(DRIVER_DEFAULT, "Set SPINEL_PROP_MAC_15_4_PANID failed, %!STATUS!", status);
+        // Indicate to the miniport
+        status =
+            otLwfCmdSetProp(
+                pFilter,
+                SPINEL_PROP_MAC_15_4_PANID,
+                SPINEL_DATATYPE_UINT16_S,
+                panid
+            );
+        if (!NT_SUCCESS(status))
+        {
+            LogError(DRIVER_DEFAULT, "Set SPINEL_PROP_MAC_15_4_PANID failed, %!STATUS!", status);
+        }
     }
 }
 
@@ -246,17 +249,20 @@ void otPlatRadioSetShortAddress(_In_ otInstance *otCtx, uint16_t address)
 
     pFilter->otShortAddress = address;
 
-    // Indicate to the miniport
-    status =
-        otLwfCmdSetProp(
-            pFilter,
-            SPINEL_PROP_MAC_15_4_SADDR,
-            SPINEL_DATATYPE_UINT16_S,
-            address
-        );
-    if (!NT_SUCCESS(status))
+    if (pFilter->otPhyState != kStateDisabled)
     {
-        LogError(DRIVER_DEFAULT, "Set SPINEL_PROP_MAC_15_4_SADDR failed, %!STATUS!", status);
+        // Indicate to the miniport
+        status =
+            otLwfCmdSetProp(
+                pFilter,
+                SPINEL_PROP_MAC_15_4_SADDR,
+                SPINEL_DATATYPE_UINT16_S,
+                address
+            );
+        if (!NT_SUCCESS(status))
+        {
+            LogError(DRIVER_DEFAULT, "Set SPINEL_PROP_MAC_15_4_SADDR failed, %!STATUS!", status);
+        }
     }
 }
 
@@ -314,6 +320,32 @@ ThreadError otPlatRadioEnable(_In_ otInstance *otCtx)
     }
 
     LogInfo(DRIVER_DEFAULT, "Filter %p PhyState = kStateSleep.", pFilter);
+
+    // Indicate PANID to the miniport
+    status =
+        otLwfCmdSetProp(
+            pFilter,
+            SPINEL_PROP_MAC_15_4_PANID,
+            SPINEL_DATATYPE_UINT16_S,
+            pFilter->otPanID
+        );
+    if (!NT_SUCCESS(status))
+    {
+        LogError(DRIVER_DEFAULT, "Set SPINEL_PROP_MAC_15_4_PANID failed, %!STATUS!", status);
+    }
+
+    // Indicate Short address to the miniport
+    status =
+        otLwfCmdSetProp(
+            pFilter,
+            SPINEL_PROP_MAC_15_4_SADDR,
+            SPINEL_DATATYPE_UINT16_S,
+            pFilter->otShortAddress
+        );
+    if (!NT_SUCCESS(status))
+    {
+        LogError(DRIVER_DEFAULT, "Set SPINEL_PROP_MAC_15_4_SADDR failed, %!STATUS!", status);
+    }
 
     return NT_SUCCESS(status) ? kThreadError_None : kThreadError_Failed;
 }

--- a/examples/platforms/cc2538/openthread-core-cc2538-config.h
+++ b/examples/platforms/cc2538/openthread-core-cc2538-config.h
@@ -34,28 +34,6 @@
 #ifndef OPENTHREAD_CORE_CC2538_CONFIG_H_
 #define OPENTHREAD_CORE_CC2538_CONFIG_H_
 
-#if 0
-/**
- * @def OPENTHREAD_CONFIG_LOG_LEVEL
- *
- * The log level (used at compile time).
- *
- */
-#ifndef OPENTHREAD_CONFIG_LOG_LEVEL
-#define OPENTHREAD_CONFIG_LOG_LEVEL                            OPENTHREAD_LOG_LEVEL_DEBG
-#endif  // OPENTHREAD_CONFIG_LOG_LEVEL
-
-/**
-* @def OPENTHREAD_CONFIG_LOG_PLATFORM
-*
-* Define to enable platform region logging.
-*
-*/
-#ifndef OPENTHREAD_CONFIG_LOG_PLATFORM
-#define OPENTHREAD_CONFIG_LOG_PLATFORM                         1
-#endif  // OPENTHREAD_CONFIG_LOG_PLATFORM
-#endif
-
  /**
   * @def OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ACK_TIMEOUT
   *

--- a/examples/platforms/cc2538/openthread-core-cc2538-config.h
+++ b/examples/platforms/cc2538/openthread-core-cc2538-config.h
@@ -34,6 +34,28 @@
 #ifndef OPENTHREAD_CORE_CC2538_CONFIG_H_
 #define OPENTHREAD_CORE_CC2538_CONFIG_H_
 
+#if 0
+/**
+ * @def OPENTHREAD_CONFIG_LOG_LEVEL
+ *
+ * The log level (used at compile time).
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_LOG_LEVEL
+#define OPENTHREAD_CONFIG_LOG_LEVEL                            OPENTHREAD_LOG_LEVEL_DEBG
+#endif  // OPENTHREAD_CONFIG_LOG_LEVEL
+
+/**
+* @def OPENTHREAD_CONFIG_LOG_PLATFORM
+*
+* Define to enable platform region logging.
+*
+*/
+#ifndef OPENTHREAD_CONFIG_LOG_PLATFORM
+#define OPENTHREAD_CONFIG_LOG_PLATFORM                         1
+#endif  // OPENTHREAD_CONFIG_LOG_PLATFORM
+#endif
+
  /**
   * @def OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ACK_TIMEOUT
   *

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -47,7 +47,7 @@ ThreadError otLinkRawSetEnable(otInstance *aInstance, bool aEnabled)
 
     VerifyOrExit(!aInstance->mThreadNetif.IsUp(), error = kThreadError_InvalidState);
 
-    otLogInfoPlat("LinkRaw Enabled=%d", aEnabled ? 1 : 0);
+    otLogInfoPlat(aInstance, "LinkRaw Enabled=%d", aEnabled ? 1 : 0);
 
     aInstance->mLinkRaw.SetEnabled(aEnabled);
 
@@ -113,7 +113,7 @@ ThreadError otLinkRawSetPromiscuous(otInstance *aInstance, bool aEnable)
 
     VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = kThreadError_InvalidState);
 
-    otLogInfoPlat("LinkRaw Promiscuous=%d", aEnable ? 1 : 0);
+    otLogInfoPlat(aInstance, "LinkRaw Promiscuous=%d", aEnable ? 1 : 0);
 
     otPlatRadioSetPromiscuous(aInstance, aEnable);
 
@@ -332,6 +332,7 @@ void LinkRaw::InvokeReceiveDone(RadioPacket *aPacket, ThreadError aError)
 {
     if (mReceiveDoneCallback)
     {
+        otLogDebgPlat(&mInstance, "LinkRaw Invoke Receive Done");
         mReceiveDoneCallback(&mInstance, aPacket, aError);
     }
 }

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -2286,8 +2286,7 @@ void MeshForwarder::LogIp6Message(MessageAction aAction, const Message &aMessage
     uint16_t checksum = 0;
     Ip6::Header ip6Header;
     Ip6::IpProto protocol;
-    char stringBuffer[(Ip6::Address::kIp6AddressStringSize > Mac::Address::kAddressStringSize) ?
-                      Ip6::Address::kIp6AddressStringSize : Mac::Address::kAddressStringSize];
+    char stringBuffer[Ip6::Address::kIp6AddressStringSize];
 
     VerifyOrExit(aMessage.GetType() == Message::kTypeIp6, ;);
 


### PR DESCRIPTION
otLwf was recently broken by the Spinel protocol changes around the _RAW_STREAM property. To help handle future issues around this, I added additional validation of the protocol version on start up.

Also, while debugging this, I found several build breaks related to logging when enabling platform logging and building for cc2538 and nrf52840.

Note, otLwf is still not completely fixed it seems, but I am having issues diagnosing the problem due to an issue getting logs (#1531).