### PR TITLE
Remove private `code_utils.hpp` include from examples.

### DIFF
--- a/examples/platforms/cc2538/flash.c
+++ b/examples/platforms/cc2538/flash.c
@@ -35,7 +35,7 @@
 #include "openthread/platform/alarm.h"
 #include <utils/flash.h>
 
-#include <common/code_utils.hpp>
+#include <utils/code_utils.h>
 #include "platform-cc2538.h"
 #include "rom-utility.h"
 
@@ -89,7 +89,7 @@ ThreadError utilsFlashErasePage(uint32_t aAddress)
     int32_t status;
     uint32_t address;
 
-    VerifyOrExit(aAddress < utilsFlashGetSize(), error = kThreadError_InvalidArgs);
+    otEXPECT_ACTION(aAddress < utilsFlashGetSize(), error = kThreadError_InvalidArgs);
 
     address = FLASH_BASE + aAddress - (aAddress & (FLASH_PAGE_SIZE - 1));
     status = ROM_PageErase(address, FLASH_PAGE_SIZE);
@@ -110,7 +110,7 @@ ThreadError utilsFlashStatusWait(uint32_t aTimeout)
         busy = HWREG(FLASH_CTRL_FCTL) & FLASH_CTRL_FCTL_BUSY;
     }
 
-    VerifyOrExit(!busy, error = kThreadError_Busy);
+    otEXPECT_ACTION(!busy, error = kThreadError_Busy);
 
 exit:
     return error;
@@ -123,8 +123,8 @@ uint32_t utilsFlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
     uint32_t *data;
     uint32_t size = 0;
 
-    VerifyOrExit(((aAddress + aSize) < utilsFlashGetSize()) &&
-                 (!(aAddress & 3)) && (!(aSize & 3)), aSize = 0);
+    otEXPECT_ACTION(((aAddress + aSize) < utilsFlashGetSize()) &&
+                    (!(aAddress & 3)) && (!(aSize & 3)), aSize = 0);
 
     data = (uint32_t *)(aData);
 
@@ -137,7 +137,7 @@ uint32_t utilsFlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
             busy = HWREG(FLASH_CTRL_FCTL) & FLASH_CTRL_FCTL_BUSY;
         }
 
-        VerifyOrExit(romStatusToThread(status) == kThreadError_None, ;);
+        otEXPECT(romStatusToThread(status) == kThreadError_None);
         size += 4;
         data++;
         aAddress += 4;
@@ -151,7 +151,7 @@ uint32_t utilsFlashRead(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
 {
     uint32_t size = 0;
 
-    VerifyOrExit((aAddress + aSize) < utilsFlashGetSize(), ;);
+    otEXPECT((aAddress + aSize) < utilsFlashGetSize());
 
     while (size < aSize)
     {

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -39,7 +39,7 @@
 #include "openthread/platform/radio.h"
 #include "openthread/platform/diag.h"
 
-#include <common/code_utils.hpp>
+#include <utils/code_utils.h>
 #include <common/logging.hpp>
 #include "platform-cc2538.h"
 
@@ -306,9 +306,9 @@ ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
         // wait for valid rssi
         while ((HWREG(RFCORE_XREG_RSSISTAT) & RFCORE_XREG_RSSISTAT_RSSI_VALID) == 0);
 
-        VerifyOrExit(((HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_CCA) &&
-                      !((HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_SFD))),
-                     sTransmitError = kThreadError_ChannelAccessFailure);
+        otEXPECT_ACTION(((HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_CCA) &&
+                         !((HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_SFD))),
+                        sTransmitError = kThreadError_ChannelAccessFailure);
 
         // begin transmit
         HWREG(RFCORE_SFR_RFST) = RFCORE_SFR_RFST_INSTR_TXON;
@@ -368,12 +368,12 @@ void readFrame(void)
     uint8_t crcCorr;
     int i;
 
-    VerifyOrExit(sState == kStateReceive || sState == kStateTransmit, ;);
-    VerifyOrExit((HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_FIFOP) != 0, ;);
+    otEXPECT(sState == kStateReceive || sState == kStateTransmit);
+    otEXPECT((HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_FIFOP) != 0);
 
     // read length
     length = HWREG(RFCORE_SFR_RFDATA);
-    VerifyOrExit(IEEE802154_MIN_LENGTH <= length && length <= IEEE802154_MAX_LENGTH, ;);
+    otEXPECT(IEEE802154_MIN_LENGTH <= length && length <= IEEE802154_MAX_LENGTH);
 
     // read psdu
     for (i = 0; i < length - 2; i++)
@@ -532,11 +532,11 @@ int8_t findSrcMatchShortEntry(const uint16_t aShortAddress)
 
         if ((shortAddr == aShortAddress))
         {
-            ExitNow(entry = i);
+            entry = i;
+            break;
         }
     }
 
-exit:
     return entry;
 }
 
@@ -569,11 +569,11 @@ int8_t findSrcMatchExtEntry(const uint8_t *aExtAddress)
 
         if (j == sizeof(otExtAddress))
         {
-            ExitNow(entry = i);
+            entry = i;
+            break;
         }
     }
 
-exit:
     return entry;
 }
 
@@ -617,7 +617,8 @@ int8_t findSrcMatchAvailEntry(bool aShort)
             {
                 if ((shortEnableStatus & bitMask) == 0)
                 {
-                    ExitNow(entry = i);
+                    entry = i;
+                    break;
                 }
             }
 
@@ -637,7 +638,8 @@ int8_t findSrcMatchAvailEntry(bool aShort)
         {
             if (((extEnableStatus | shortEnableStatus) & bitMask) == 0)
             {
-                ExitNow(entry = i);
+                entry = i;
+                break;
             }
 
             extEnableStatus = extEnableStatus >> 2;
@@ -645,7 +647,6 @@ int8_t findSrcMatchAvailEntry(bool aShort)
         }
     }
 
-exit:
     return entry;
 }
 
@@ -677,7 +678,7 @@ ThreadError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16
 
     otLogDebgPlat(sInstance, "Add ShortAddr entry: %d", entry);
 
-    VerifyOrExit(entry >= 0, error = kThreadError_NoBufs);
+    otEXPECT_ACTION(entry >= 0, error = kThreadError_NoBufs);
 
     addr += (entry * RFCORE_XREG_SRCMATCH_SHORT_ENTRY_OFFSET);
 
@@ -701,7 +702,7 @@ ThreadError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t 
 
     otLogDebgPlat(sInstance, "Add ExtAddr entry: %d", entry);
 
-    VerifyOrExit(entry >= 0, error = kThreadError_NoBufs);
+    otEXPECT_ACTION(entry >= 0, error = kThreadError_NoBufs);
 
     addr += (entry * RFCORE_XREG_SRCMATCH_EXT_ENTRY_OFFSET);
 
@@ -724,7 +725,7 @@ ThreadError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint
 
     otLogDebgPlat(sInstance, "Clear ShortAddr entry: %d", entry);
 
-    VerifyOrExit(entry >= 0, error = kThreadError_NoAddress);
+    otEXPECT_ACTION(entry >= 0, error = kThreadError_NoAddress);
 
     setSrcMatchEntryEnableStatus(true, (uint8_t)(entry), false);
 
@@ -740,7 +741,7 @@ ThreadError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_
 
     otLogDebgPlat(sInstance, "Clear ExtAddr entry: %d", entry);
 
-    VerifyOrExit(entry >= 0, error = kThreadError_NoAddress);
+    otEXPECT_ACTION(entry >= 0, error = kThreadError_NoAddress);
 
     setSrcMatchEntryEnableStatus(false, (uint8_t)(entry), false);
 

--- a/examples/platforms/cc2538/random.c
+++ b/examples/platforms/cc2538/random.c
@@ -36,7 +36,7 @@
 #include "openthread/platform/radio.h"
 #include "openthread/platform/random.h"
 
-#include <common/code_utils.hpp>
+#include <utils/code_utils.h>
 #include "platform-cc2538.h"
 
 static void generateRandom(uint16_t aInputLength, uint8_t *aOutput, uint16_t *aOutputLength)
@@ -101,7 +101,7 @@ ThreadError otPlatRandomSecureGet(uint16_t aInputLength, uint8_t *aOutput, uint1
     ThreadError error = kThreadError_None;
     uint8_t channel = 0;
 
-    VerifyOrExit(aOutput && aOutputLength, error = kThreadError_InvalidArgs);
+    otEXPECT_ACTION(aOutput && aOutputLength, error = kThreadError_InvalidArgs);
 
     if (otPlatRadioIsEnabled(sInstance))
     {

--- a/examples/platforms/cc2538/uart.c
+++ b/examples/platforms/cc2538/uart.c
@@ -37,7 +37,7 @@
 #include "openthread/types.h"
 #include "openthread/platform/uart.h"
 
-#include <common/code_utils.hpp>
+#include <utils/code_utils.h>
 #include "platform-cc2538.h"
 
 enum
@@ -120,7 +120,7 @@ ThreadError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(sTransmitBuffer == NULL, error = kThreadError_Busy);
+    otEXPECT_ACTION(sTransmitBuffer == NULL, error = kThreadError_Busy);
 
     sTransmitBuffer = aBuf;
     sTransmitLength = aBufLength;
@@ -155,7 +155,7 @@ void processReceive(void)
 
 void processTransmit(void)
 {
-    VerifyOrExit(sTransmitBuffer != NULL, ;);
+    otEXPECT(sTransmitBuffer != NULL);
 
     for (; sTransmitLength > 0; sTransmitLength--)
     {

--- a/examples/platforms/cc2650/crypto/aes_alt.c
+++ b/examples/platforms/cc2650/crypto/aes_alt.c
@@ -34,7 +34,7 @@
 #include <string.h>
 #include <driverlib/crypto.h>
 #include <driverlib/prcm.h>
-#include <common/code_utils.hpp>
+#include <utils/code_utils.h>
 
 #define CC2650_AES_KEY_UNUSED (-1)
 #define CC2650_AES_CTX_MAGIC  (0x7E)
@@ -76,7 +76,7 @@ void mbedtls_aes_init(mbedtls_aes_context *ctx)
 
 void mbedtls_aes_free(mbedtls_aes_context *ctx)
 {
-    VerifyOrExit(ctx->magic == CC2650_AES_CTX_MAGIC, ;);
+    otEXPECT(ctx->magic == CC2650_AES_CTX_MAGIC);
 
     if (ctx->key_idx != CC2650_AES_KEY_UNUSED)
     {
@@ -113,7 +113,7 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key, u
     unsigned char key_idx;
     int retval = 0;
 
-    VerifyOrExit(ctx->magic == CC2650_AES_CTX_MAGIC, retval = -1);
+    otEXPECT_ACTION(ctx->magic == CC2650_AES_CTX_MAGIC, retval = -1);
 
     if (ctx->key_idx != CC2650_AES_KEY_UNUSED)
     {
@@ -121,14 +121,15 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context *ctx, const unsigned char *key, u
     }
 
     /* our hardware only supports 128 bit keys */
-    VerifyOrExit(keybits == 128u, retval = MBEDTLS_ERR_AES_INVALID_KEY_LENGTH);
+    otEXPECT_ACTION(keybits == 128u, retval = MBEDTLS_ERR_AES_INVALID_KEY_LENGTH);
 
     for (key_idx = 0; ((sUsedKeys >> key_idx) & 0x01) != 0 && key_idx < 8; key_idx++);
 
     /* we have no more room for this key */
-    VerifyOrExit(key_idx < 8, retval = -2);
+    otEXPECT_ACTION(key_idx < 8, retval = -2);
 
-    VerifyOrExit(CRYPTOAesLoadKey((uint32_t *)key, key_idx) == AES_SUCCESS, retval = MBEDTLS_ERR_AES_INVALID_KEY_LENGTH);
+    otEXPECT_ACTION(CRYPTOAesLoadKey((uint32_t *)key, key_idx) == AES_SUCCESS,
+                    retval = MBEDTLS_ERR_AES_INVALID_KEY_LENGTH);
 
     sUsedKeys |= (1 << key_idx);
     ctx->key_idx = key_idx;
@@ -141,7 +142,7 @@ int mbedtls_aes_setkey_dec(mbedtls_aes_context *ctx, const unsigned char *key, u
     unsigned char key_idx;
     int retval = 0;
 
-    VerifyOrExit(ctx->magic == CC2650_AES_CTX_MAGIC, retval = -1);
+    otEXPECT_ACTION(ctx->magic == CC2650_AES_CTX_MAGIC, retval = -1);
 
     if (ctx->key_idx != CC2650_AES_KEY_UNUSED)
     {
@@ -149,14 +150,15 @@ int mbedtls_aes_setkey_dec(mbedtls_aes_context *ctx, const unsigned char *key, u
     }
 
     /* our hardware only supports 128 bit keys */
-    VerifyOrExit(keybits == 128u, retval = MBEDTLS_ERR_AES_INVALID_KEY_LENGTH);
+    otEXPECT_ACTION(keybits == 128u, retval = MBEDTLS_ERR_AES_INVALID_KEY_LENGTH);
 
     for (key_idx = 0; ((sUsedKeys >> key_idx) & 0x01) != 0 && key_idx < 8; key_idx++);
 
     /* we have no more room for this key */
-    VerifyOrExit(key_idx < 8, retval = -2);
+    otEXPECT_ACTION(key_idx < 8, retval = -2);
 
-    VerifyOrExit(CRYPTOAesLoadKey((uint32_t *)key, key_idx) == AES_SUCCESS, retval = MBEDTLS_ERR_AES_INVALID_KEY_LENGTH);
+    otEXPECT_ACTION(CRYPTOAesLoadKey((uint32_t *)key, key_idx) == AES_SUCCESS,
+                    retval = MBEDTLS_ERR_AES_INVALID_KEY_LENGTH);
 
     sUsedKeys |= (1 << key_idx);
     ctx->key_idx = key_idx;
@@ -179,7 +181,7 @@ int mbedtls_aes_crypt_ecb(mbedtls_aes_context *ctx, int mode, const unsigned cha
     int retval = -1;
 
     retval = CRYPTOAesEcb((uint32_t *)input, (uint32_t *)output, ctx->key_idx, mode == MBEDTLS_AES_ENCRYPT, false);
-    VerifyOrExit(retval == AES_SUCCESS, ;);
+    otEXPECT(retval == AES_SUCCESS);
 
     while ((retval = CRYPTOAesEcbStatus()) ==  AES_DMA_BSY);
 

--- a/examples/platforms/cc2650/random.c
+++ b/examples/platforms/cc2650/random.c
@@ -27,7 +27,7 @@
  */
 
 #include <openthread/types.h>
-#include <common/code_utils.hpp>
+#include <utils/code_utils.h>
 
 #include <driverlib/prcm.h>
 #include <driverlib/trng.h>
@@ -129,9 +129,9 @@ ThreadError otPlatRandomSecureGet(uint16_t aInputLength, uint8_t *aOutput, uint1
     size_t temp_size;
     size_t length = aInputLength;
 
-    VerifyOrExit(aOutput && aOutputLength, error = kThreadError_InvalidArgs);
+    otEXPECT_ACTION(aOutput && aOutputLength, error = kThreadError_InvalidArgs);
 
-    VerifyOrExit(TRNGPoll((unsigned char *)aOutput, length, &temp_size) != 0, error = kThreadError_Failed);
+    otEXPECT_ACTION(TRNGPoll((unsigned char *)aOutput, length, &temp_size) != 0, error = kThreadError_Failed);
 
 exit:
     *aOutputLength = temp_size;

--- a/examples/platforms/cc2650/uart.c
+++ b/examples/platforms/cc2650/uart.c
@@ -34,7 +34,7 @@
 #include <driverlib/sys_ctrl.h>
 
 #include <openthread/types.h>
-#include <common/code_utils.hpp>
+#include <utils/code_utils.h>
 #include <openthread/platform/uart.h>
 
 /**
@@ -113,7 +113,7 @@ ThreadError otPlatUartDisable(void)
 ThreadError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
     ThreadError error = kThreadError_None;
-    VerifyOrExit(sSendBuffer == NULL, error = kThreadError_Busy);
+    otEXPECT_ACTION(sSendBuffer == NULL, error = kThreadError_Busy);
 
     sSendBuffer = aBuf;
     sSendLen = aBufLength;
@@ -151,7 +151,7 @@ static void processReceive(void)
  */
 static void processTransmit(void)
 {
-    VerifyOrExit(sSendBuffer != NULL, ;);
+    otEXPECT(sSendBuffer != NULL);
 
     for (; sSendLen > 0; sSendLen--)
     {

--- a/examples/platforms/da15000/radio.c
+++ b/examples/platforms/da15000/radio.c
@@ -31,7 +31,7 @@
 * Platform abstraction for radio communication.
 */
 
-#include <common/code_utils.hpp>
+#include <utils/code_utils.h>
 #include "openthread/openthread.h"
 #include "openthread/platform/alarm.h"
 #include "openthread/platform/radio.h"
@@ -138,7 +138,7 @@ ThreadError otPlatRadioEnable(otInstance *aInstance)
     uint8_t maxRetries;
 
     ThreadError error = kThreadError_None;
-    VerifyOrExit(sRadioState == kStateDisabled, error = kThreadError_InvalidState);
+    otEXPECT_ACTION(sRadioState == kStateDisabled, error = kThreadError_InvalidState);
 
     sThreadInstance = aInstance;
     sTransmitFrame.mPsdu = sTransmitPsdu;
@@ -194,7 +194,8 @@ ThreadError otPlatRadioSleep(otInstance *aInstance)
     }
 
     ThreadError error = kThreadError_None;
-    VerifyOrExit(((sRadioState == kStateReceive) || (sRadioState == kStateSleep)), error = kThreadError_InvalidState);
+    otEXPECT_ACTION(((sRadioState == kStateReceive) || (sRadioState == kStateSleep)),
+                    error = kThreadError_InvalidState);
 
     sGoSleep = true;
     sRadioState = kStateSleep;
@@ -208,7 +209,7 @@ ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
     (void)aInstance;
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(sRadioState != kStateDisabled, error = kThreadError_InvalidState);
+    otEXPECT_ACTION(sRadioState != kStateDisabled, error = kThreadError_InvalidState);
 
     ad_ftdf_wake_up();
     sChannel = aChannel;
@@ -237,9 +238,9 @@ ThreadError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16
 
     // check if address already stored
     ThreadError error = kThreadError_None;
-    SuccessOrExit(FTDF_fpprLookupShortAddress(aShortAddress, &entry, &entryIdx));
+    otEXPECT(!FTDF_fpprLookupShortAddress(aShortAddress, &entry, &entryIdx));
 
-    VerifyOrExit(FTDF_fpprGetFreeShortAddress(&entry, &entryIdx), error = kThreadError_NoBufs);
+    otEXPECT_ACTION(FTDF_fpprGetFreeShortAddress(&entry, &entryIdx), error = kThreadError_NoBufs);
 
     FTDF_fpprSetShortAddress(entry, entryIdx, aShortAddress);
     FTDF_fpprSetShortAddressValid(entry, entryIdx, FTDF_TRUE);
@@ -264,9 +265,9 @@ ThreadError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t 
 
     // check if address already stored
     ThreadError error = kThreadError_None;
-    SuccessOrExit(FTDF_fpprLookupExtAddress(addr, &entry));
+    otEXPECT(!FTDF_fpprLookupExtAddress(addr, &entry));
 
-    VerifyOrExit(FTDF_fpprGetFreeExtAddress(&entry), error = kThreadError_NoBufs);
+    otEXPECT_ACTION(FTDF_fpprGetFreeExtAddress(&entry), error = kThreadError_NoBufs);
 
     FTDF_fpprSetExtAddress(entry, addr);
     FTDF_fpprSetExtAddressValid(entry, FTDF_TRUE);
@@ -283,7 +284,7 @@ ThreadError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint
     uint8_t entryIdx;
 
     ThreadError error = kThreadError_None;
-    VerifyOrExit(FTDF_fpprLookupShortAddress(aShortAddress, &entry, &entryIdx), error = kThreadError_NoAddress);
+    otEXPECT_ACTION(FTDF_fpprLookupShortAddress(aShortAddress, &entry, &entryIdx), error = kThreadError_NoAddress);
 
     FTDF_fpprSetShortAddress(entry, entryIdx, 0);
     FTDF_fpprSetShortAddressValid(entry, entryIdx, FTDF_FALSE);
@@ -306,7 +307,7 @@ ThreadError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_
     addr = addrL | (addrH << 32);
 
     ThreadError error = kThreadError_None;
-    VerifyOrExit(FTDF_fpprLookupExtAddress(addr, &entry), error = kThreadError_NoAddress);
+    otEXPECT_ACTION(FTDF_fpprLookupExtAddress(addr, &entry), error = kThreadError_NoAddress);
 
     FTDF_fpprSetExtAddress(entry, 0);
     FTDF_fpprSetExtAddressValid(entry, FTDF_FALSE);
@@ -362,7 +363,7 @@ ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
     uint8_t csmaSuppress;
 
     ThreadError error = kThreadError_None;
-    VerifyOrExit(sRadioState != kStateDisabled, error = kThreadError_InvalidState);
+    otEXPECT_ACTION(sRadioState != kStateDisabled, error = kThreadError_InvalidState);
 
     csmaSuppress = 0;
     ad_ftdf_send_frame_simple(aPacket->mLength, aPacket->mPsdu, aPacket->mChannel, 0, csmaSuppress); //Prio 0 for all.

--- a/examples/platforms/nrf52840/diag.c
+++ b/examples/platforms/nrf52840/diag.c
@@ -36,8 +36,8 @@
 #include <openthread/platform/alarm.h>
 #include <openthread/platform/radio.h>
 
-#include <common/code_utils.hpp>
 #include <common/logging.hpp>
+#include <utils/code_utils.h>
 
 struct PlatformDiagCommand
 {
@@ -88,7 +88,7 @@ static void processListen(otInstance *aInstance, int argc, char *argv[], char *a
     (void) aInstance;
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(otPlatDiagModeGet(), error = kThreadError_InvalidState);
+    otEXPECT_ACTION(otPlatDiagModeGet(), error = kThreadError_InvalidState);
 
     if (argc == 0)
     {
@@ -98,7 +98,8 @@ static void processListen(otInstance *aInstance, int argc, char *argv[], char *a
     {
         long value;
 
-        SuccessOrExit(error = parseLong(argv[0], &value));
+        error = parseLong(argv[0], &value);
+        otEXPECT(error == kThreadError_None);
         sListen = (bool)(value);
         snprintf(aOutput, aOutputMaxLen, "set listen to %s\r\nstatus 0x%02x\r\n", sListen == true ? "yes" : "no", error);
     }
@@ -113,7 +114,7 @@ static void processID(otInstance *aInstance, int argc, char *argv[], char *aOutp
 
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(otPlatDiagModeGet(), error = kThreadError_InvalidState);
+    otEXPECT_ACTION(otPlatDiagModeGet(), error = kThreadError_InvalidState);
 
     if (argc == 0)
     {
@@ -123,8 +124,9 @@ static void processID(otInstance *aInstance, int argc, char *argv[], char *aOutp
     {
         long value;
 
-        SuccessOrExit(error = parseLong(argv[0], &value));
-        VerifyOrExit(value >= 0, error = kThreadError_InvalidArgs);
+        error = parseLong(argv[0], &value);
+        otEXPECT(error == kThreadError_None);
+        otEXPECT_ACTION(value >= 0, error = kThreadError_InvalidArgs);
         sID = (int16_t)(value);
         snprintf(aOutput, aOutputMaxLen, "set ID to %" PRId16 "\r\nstatus 0x%02x\r\n", sID, error);
     }
@@ -138,7 +140,7 @@ static void processTransmit(otInstance *aInstance, int argc, char *argv[], char 
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(otPlatDiagModeGet(), error = kThreadError_InvalidState);
+    otEXPECT_ACTION(otPlatDiagModeGet(), error = kThreadError_InvalidState);
 
     if (argc == 0)
     {
@@ -167,10 +169,11 @@ static void processTransmit(otInstance *aInstance, int argc, char *argv[], char 
     {
         long value;
 
-        VerifyOrExit(argc == 2, error = kThreadError_InvalidArgs);
+        otEXPECT_ACTION(argc == 2, error = kThreadError_InvalidArgs);
 
-        SuccessOrExit(error = parseLong(argv[1], &value));
-        VerifyOrExit(value > 0, error = kThreadError_InvalidArgs);
+        error = parseLong(argv[1], &value);
+        otEXPECT(error == kThreadError_None);
+        otEXPECT_ACTION(value > 0, error = kThreadError_InvalidArgs);
         sTxPeriod = (uint32_t)(value);
         snprintf(aOutput, aOutputMaxLen, "set diagnostic messages interval to %" PRIu32 " ms\r\nstatus 0x%02x\r\n", sTxPeriod,
                  error);
@@ -179,10 +182,11 @@ static void processTransmit(otInstance *aInstance, int argc, char *argv[], char 
     {
         long value;
 
-        VerifyOrExit(argc == 2, error = kThreadError_InvalidArgs);
+        otEXPECT_ACTION(argc == 2, error = kThreadError_InvalidArgs);
 
-        SuccessOrExit(error = parseLong(argv[1], &value));
-        VerifyOrExit((value > 0) || (value == -1), error = kThreadError_InvalidArgs);
+        error = parseLong(argv[1], &value);
+        otEXPECT(error == kThreadError_None);
+        otEXPECT_ACTION((value > 0) || (value == -1), error = kThreadError_InvalidArgs);
         sTxRequestedCount = (uint32_t)(value);
         snprintf(aOutput, aOutputMaxLen, "set diagnostic messages count to %" PRId32 "\r\nstatus 0x%02x\r\n", sTxRequestedCount,
                  error);

--- a/examples/platforms/nrf52840/flash.c
+++ b/examples/platforms/nrf52840/flash.c
@@ -31,9 +31,9 @@
 #include <assert.h>
 
 #include <openthread/types.h>
-#include <common/code_utils.hpp>
 #include <openthread/platform/alarm.h>
 #include <utils/flash.h>
+#include <utils/code_utils.h>
 
 #include "hal/nrf_nvmc.h"
 #include "platform-nrf5.h"
@@ -68,7 +68,7 @@ uint32_t utilsFlashGetSize(void)
 ThreadError utilsFlashErasePage(uint32_t aAddress)
 {
     ThreadError error = kThreadError_None;
-    VerifyOrExit(aAddress < utilsFlashGetSize(), error = kThreadError_InvalidArgs);
+    otEXPECT_ACTION(aAddress < utilsFlashGetSize(), error = kThreadError_InvalidArgs);
 
     nrf_nvmc_page_erase(mapAddress(aAddress & FLASH_PAGE_ADDR_MASK));
 
@@ -108,8 +108,8 @@ ThreadError utilsFlashStatusWait(uint32_t aTimeout)
 uint32_t utilsFlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
 {
     uint32_t result = 0;
-    VerifyOrExit(aData, ;);
-    VerifyOrExit(aAddress < utilsFlashGetSize(), ;);
+    otEXPECT(aData);
+    otEXPECT(aAddress < utilsFlashGetSize());
 
     nrf_nvmc_write_bytes(mapAddress(aAddress), aData, aSize);
     result = aSize;
@@ -121,8 +121,8 @@ exit:
 uint32_t utilsFlashRead(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
 {
     uint32_t result = 0;
-    VerifyOrExit(aData, ;);
-    VerifyOrExit(aAddress < utilsFlashGetSize(), ;);
+    otEXPECT(aData);
+    otEXPECT(aAddress < utilsFlashGetSize());
 
     memcpy(aData, (uint8_t *)mapAddress(aAddress), aSize);
     result = aSize;

--- a/examples/platforms/nrf52840/logging.c
+++ b/examples/platforms/nrf52840/logging.c
@@ -37,7 +37,7 @@
 
 #include <openthread/platform/logging.h>
 #include <openthread/platform/alarm.h>
-#include <common/code_utils.hpp>
+#include <utils/code_utils.h>
 
 #include "platform-nrf5.h"
 
@@ -128,7 +128,7 @@ void nrf5LogInit()
                                         LOG_RTT_BUFFER_NAME, sLogBuffer,
                                         LOG_RTT_BUFFER_SIZE,
                                         SEGGER_RTT_MODE_NO_BLOCK_TRIM);
-    VerifyOrExit(res >= 0, ;);
+    otEXPECT(res >= 0);
 
     sLogInitialized = true;
 
@@ -146,7 +146,7 @@ void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion,
 {
     (void) aLogRegion;
 
-    VerifyOrExit(sLogInitialized == true, ;);
+    otEXPECT(sLogInitialized == true);
 
     char logString[LOG_PARSE_BUFFER_SIZE + 1];
     uint16_t length = 0;

--- a/examples/platforms/nrf52840/random.c
+++ b/examples/platforms/nrf52840/random.c
@@ -37,7 +37,7 @@
 #include <string.h>
 
 #include <openthread/platform/random.h>
-#include <common/code_utils.hpp>
+#include <utils/code_utils.h>
 
 #include "hal/nrf_rng.h"
 #include "platform-nrf5.h"
@@ -154,8 +154,8 @@ ThreadError otPlatRandomSecureGet(uint16_t aInputLength, uint8_t *aOutput, uint1
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(aOutput && aOutputLength, error = kThreadError_InvalidArgs);
-    VerifyOrExit(!bufferIsEmpty(), error = kThreadError_Failed);
+    otEXPECT_ACTION(aOutput && aOutputLength, error = kThreadError_InvalidArgs);
+    otEXPECT_ACTION(!bufferIsEmpty(), error = kThreadError_Failed);
 
     uint16_t copyLength = (uint16_t)bufferCount();
 

--- a/examples/platforms/nrf52840/uart.c
+++ b/examples/platforms/nrf52840/uart.c
@@ -37,7 +37,7 @@
 
 #include <openthread/types.h>
 #include <openthread/platform/uart.h>
-#include <common/code_utils.hpp>
+#include <utils/code_utils.h>
 
 #include "drivers/nrf_drv_clock.h"
 #include "hal/nrf_uart.h"
@@ -86,7 +86,7 @@ static __INLINE bool isRxBufferEmpty()
  */
 static void processReceive(void)
 {
-    VerifyOrExit(isRxBufferEmpty() == false, ;);
+    otEXPECT(isRxBufferEmpty() == false);
 
     // Set head position to not be changed during read procedure.
     uint16_t head = sReceiveHead;
@@ -117,7 +117,7 @@ exit:
  */
 static void processTransmit(void)
 {
-    VerifyOrExit(sTransmitBuffer != NULL, ;);
+    otEXPECT(sTransmitBuffer != NULL);
 
     if (sTransmitDone)
     {
@@ -220,7 +220,7 @@ ThreadError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(sTransmitBuffer == NULL, error = kThreadError_Busy);
+    otEXPECT_ACTION(sTransmitBuffer == NULL, error = kThreadError_Busy);
 
     // Set up transmit buffer and its size without counting first triggered byte.
     sTransmitBuffer = aBuf;

--- a/examples/platforms/posix/flash.c
+++ b/examples/platforms/posix/flash.c
@@ -37,8 +37,7 @@
 
 #include <openthread-config.h>
 #include <utils/flash.h>
-
-#include <common/code_utils.hpp>
+#include <utils/code_utils.h>
 
 static int sFlashFd;
 uint32_t sEraseAddress;
@@ -77,7 +76,7 @@ ThreadError utilsFlashInit(void)
     sFlashFd = open(fileName, O_RDWR | O_CREAT, 0666);
     lseek(sFlashFd, 0, SEEK_SET);
 
-    VerifyOrExit(sFlashFd >= 0, error = kThreadError_Failed);
+    otEXPECT_ACTION(sFlashFd >= 0, error = kThreadError_Failed);
 
     if (create)
     {
@@ -102,15 +101,15 @@ ThreadError utilsFlashErasePage(uint32_t aAddress)
     uint8_t buf = 0xff;
     uint32_t address;
 
-    VerifyOrExit(sFlashFd >= 0, error = kThreadError_Failed);
-    VerifyOrExit(aAddress < FLASH_SIZE, error = kThreadError_InvalidArgs);
+    otEXPECT_ACTION(sFlashFd >= 0, error = kThreadError_Failed);
+    otEXPECT_ACTION(aAddress < FLASH_SIZE, error = kThreadError_InvalidArgs);
 
     // Get start address of the flash page that includes aAddress
     address = aAddress & (~(uint32_t)(FLASH_PAGE_SIZE - 1));
 
     for (uint16_t offset = 0; offset < FLASH_PAGE_SIZE; offset++)
     {
-        VerifyOrExit(pwrite(sFlashFd, &buf, 1, address + offset) == 1, error = kThreadError_Failed);
+        otEXPECT_ACTION(pwrite(sFlashFd, &buf, 1, address + offset) == 1, error = kThreadError_Failed);
     }
 
 exit:
@@ -129,14 +128,14 @@ uint32_t utilsFlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
     uint32_t index = 0;
     uint8_t byte;
 
-    VerifyOrExit(sFlashFd >= 0 && aAddress < FLASH_SIZE, ;);
+    otEXPECT(sFlashFd >= 0 && aAddress < FLASH_SIZE);
 
     for (index = 0; index < aSize; index++)
     {
-        VerifyOrExit((ret = utilsFlashRead(aAddress + index, &byte, 1)) == 1, ;);
+        otEXPECT((ret = utilsFlashRead(aAddress + index, &byte, 1)) == 1);
         // Use bitwise AND to emulate the behavior of flash memory
         byte &= aData[index];
-        VerifyOrExit((ret = (uint32_t)pwrite(sFlashFd, &byte, 1, aAddress + index)) == 1, ;);
+        otEXPECT((ret = (uint32_t)pwrite(sFlashFd, &byte, 1, aAddress + index)) == 1);
     }
 
 exit:
@@ -147,7 +146,7 @@ uint32_t utilsFlashRead(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
 {
     uint32_t ret = 0;
 
-    VerifyOrExit(sFlashFd >= 0 && aAddress < FLASH_SIZE, ;);
+    otEXPECT(sFlashFd >= 0 && aAddress < FLASH_SIZE);
     ret = (uint32_t)pread(sFlashFd, aData, aSize, aAddress);
 
 exit:

--- a/examples/platforms/posix/logging.c
+++ b/examples/platforms/posix/logging.c
@@ -40,14 +40,15 @@
 #endif
 
 #include "openthread/platform/logging.h"
+#include "utils/code_utils.h"
 
 // Macro to append content to end of the log string.
 
 #define LOG_PRINTF(...)                                                                     \
-    charsWritten = snprintf(&logString[offset], sizeof(logString) - offset , __VA_ARGS__);    \
-    VerifyOrExit(charsWritten >= 0, logString[offset] = 0);                                  \
-    offset += (unsigned int)charsWritten;                                    \
-    VerifyOrExit(offset < sizeof(logString), logString[sizeof(logString) -1 ] = 0)
+    charsWritten = snprintf(&logString[offset], sizeof(logString) - offset , __VA_ARGS__);  \
+    otEXPECT_ACTION(charsWritten >= 0, logString[offset] = 0);                              \
+    offset += (unsigned int)charsWritten;                                                   \
+    otEXPECT_ACTION(offset < sizeof(logString), logString[sizeof(logString) -1 ] = 0)
 
 void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
 {
@@ -64,7 +65,7 @@ void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat
     charsWritten = vsnprintf(&logString[offset], sizeof(logString) - offset, aFormat, args);
     va_end(args);
 
-    VerifyOrExit(charsWritten >= 0, logString[offset] = 0);
+    otEXPECT_ACTION(charsWritten >= 0, logString[offset] = 0);
 
 exit:
 #ifndef _WIN32

--- a/examples/platforms/posix/random.c
+++ b/examples/platforms/posix/random.c
@@ -39,7 +39,7 @@
 #include "openthread/types.h"
 #include "openthread/platform/random.h"
 
-#include <common/code_utils.hpp>
+#include <utils/code_utils.h>
 
 static uint32_t s_state = 1;
 
@@ -75,7 +75,7 @@ ThreadError otPlatRandomSecureGet(uint16_t aInputLength, uint8_t *aOutput, uint1
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(aOutput && aOutputLength, error = kThreadError_InvalidArgs);
+    otEXPECT_ACTION(aOutput && aOutputLength, error = kThreadError_InvalidArgs);
 
     for (uint16_t length = 0; length < aInputLength; length++)
     {

--- a/examples/platforms/posix/uart-posix.c
+++ b/examples/platforms/posix/uart-posix.c
@@ -40,7 +40,7 @@
 
 #include "openthread/platform/uart.h"
 
-#include <common/code_utils.hpp>
+#include <utils/code_utils.h>
 
 #ifdef OPENTHREAD_TARGET_LINUX
 #include <sys/prctl.h>
@@ -103,7 +103,7 @@ ThreadError otPlatUartEnable(void)
     if (isatty(s_in_fd))
     {
         // get current configuration
-        VerifyOrExit(tcgetattr(s_in_fd, &termios) == 0, perror("tcgetattr"); error = kThreadError_Error);
+        otEXPECT_ACTION(tcgetattr(s_in_fd, &termios) == 0, perror("tcgetattr"); error = kThreadError_Error);
 
         // Set up the termios settings for raw mode. This turns
         // off input/output processing, line processing, and character processing.
@@ -119,16 +119,16 @@ ThreadError otPlatUartEnable(void)
         termios.c_cc[VTIME] = 0;
 
         // configure baud rate
-        VerifyOrExit(cfsetispeed(&termios, B115200) == 0, perror("cfsetispeed"); error = kThreadError_Error);
+        otEXPECT_ACTION(cfsetispeed(&termios, B115200) == 0, perror("cfsetispeed"); error = kThreadError_Error);
 
         // set configuration
-        VerifyOrExit(tcsetattr(s_in_fd, TCSANOW, &termios) == 0, perror("tcsetattr"); error = kThreadError_Error);
+        otEXPECT_ACTION(tcsetattr(s_in_fd, TCSANOW, &termios) == 0, perror("tcsetattr"); error = kThreadError_Error);
     }
 
     if (isatty(s_out_fd))
     {
         // get current configuration
-        VerifyOrExit(tcgetattr(s_out_fd, &termios) == 0, perror("tcgetattr"); error = kThreadError_Error);
+        otEXPECT_ACTION(tcgetattr(s_out_fd, &termios) == 0, perror("tcgetattr"); error = kThreadError_Error);
 
         // Set up the termios settings for raw mode. This turns
         // off input/output processing, line processing, and character processing.
@@ -141,10 +141,10 @@ ThreadError otPlatUartEnable(void)
         termios.c_cflag |= HUPCL | CREAD | CLOCAL;
 
         // configure baud rate
-        VerifyOrExit(cfsetospeed(&termios, B115200) == 0, perror("cfsetospeed"); error = kThreadError_Error);
+        otEXPECT_ACTION(cfsetospeed(&termios, B115200) == 0, perror("cfsetospeed"); error = kThreadError_Error);
 
         // set configuration
-        VerifyOrExit(tcsetattr(s_out_fd, TCSANOW, &termios) == 0, perror("tcsetattr"); error = kThreadError_Error);
+        otEXPECT_ACTION(tcsetattr(s_out_fd, TCSANOW, &termios) == 0, perror("tcsetattr"); error = kThreadError_Error);
     }
 
     return error;
@@ -169,7 +169,7 @@ ThreadError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(s_write_length == 0, error = kThreadError_Busy);
+    otEXPECT_ACTION(s_write_length == 0, error = kThreadError_Busy);
 
     s_write_buffer = aBuf;
     s_write_length = aBufLength;

--- a/examples/platforms/posix/uart-windows.c
+++ b/examples/platforms/posix/uart-windows.c
@@ -29,6 +29,7 @@
 #include "platform-posix.h"
 
 #include "openthread/platform/uart.h"
+#include "utils/code_utils.h"
 
 static HANDLE s_WorkerThread;
 static HANDLE s_StopWorkerEvent;
@@ -78,10 +79,11 @@ ThreadError otPlatUartEnable(void)
     ThreadError error = kThreadError_None;
 
     // Create the worker thread stop event
-    VerifyOrExit((s_StopWorkerEvent = CreateEvent(NULL, TRUE, FALSE, NULL)) != NULL, error = kThreadError_Error);
+    otEXPECT_ACTION((s_StopWorkerEvent = CreateEvent(NULL, TRUE, FALSE, NULL)) != NULL, error = kThreadError_Error);
 
     // Start the worker thread
-    VerifyOrExit((s_WorkerThread = CreateThread(NULL, 0, windowsUartWorkerThread, NULL, 0, NULL)) != NULL, error = kThreadError_Error);
+    otEXPECT_ACTION((s_WorkerThread = CreateThread(NULL, 0, windowsUartWorkerThread, NULL, 0, NULL)) != NULL,
+		    error = kThreadError_Error);
 
     return error;
 
@@ -115,7 +117,8 @@ ThreadError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
     ThreadError error = kThreadError_None;
 
     DWORD dwNumCharsWritten = 0;
-    VerifyOrExit(WriteConsoleA(GetStdHandle(STD_OUTPUT_HANDLE), aBuf, aBufLength, &dwNumCharsWritten, NULL), error = kThreadError_Error);
+    otEXPECT_ACTION(WriteConsoleA(GetStdHandle(STD_OUTPUT_HANDLE), aBuf, aBufLength, &dwNumCharsWritten, NULL),
+		    error = kThreadError_Error);
 
     otPlatUartSendDone();
 

--- a/examples/platforms/utils/Makefile.am
+++ b/examples/platforms/utils/Makefile.am
@@ -32,6 +32,7 @@ lib_LIBRARIES                           = libopenthread-platform-utils.a
 
 libopenthread_platform_utils_a_CPPFLAGS = \
     -I$(top_srcdir)/include               \
+    -I$(top_srcdir)/examples/platforms    \
     -I$(top_srcdir)/src/core              \
     $(NULL)
 
@@ -40,6 +41,7 @@ libopenthread_platform_utils_a_SOURCES  = \
     $(NULL)
 
 noinst_HEADERS                          = \
+    code_utils.h                          \
     flash.h                               \
     $(NULL)
 

--- a/examples/platforms/utils/code_utils.h
+++ b/examples/platforms/utils/code_utils.h
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2017, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes macros for validating runtime conditions.
+ */
+
+#ifndef CODE_UTILS_H
+#define CODE_UTILS_H
+
+/**
+ *  This checks for the specified condition, which is expected to
+ *  commonly be true, and branches to the local label 'exit' if the
+ *  condition is false.
+ *
+ *  @param[in]  aCondition  A Boolean expression to be evaluated.
+ *
+ */
+#define otEXPECT(aCondition)                    \
+    do                                          \
+    {                                           \
+        if (!(aCondition))                      \
+        {                                       \
+            goto exit;                          \
+        }                                       \
+    } while (0)
+
+/**
+ *  This checks for the specified condition, which is expected to
+ *  commonly be true, and both executes @p anAction and branches to
+ *  the local label 'exit' if the condition is false.
+ *
+ *  @param[in]  aCondition  A Boolean expression to be evaluated.
+ *  @param[in]  aAction     An expression or block to execute when the
+ *                          assertion fails.
+ *
+ */
+#define otEXPECT_ACTION(aCondition, aAction)    \
+    do                                          \
+    {                                           \
+        if (!(aCondition))                      \
+        {                                       \
+            aAction;                            \
+            goto exit;                          \
+        }                                       \
+    } while (0)
+
+#endif  // CODE_UTILS_H

--- a/examples/platforms/utils/settings.cpp
+++ b/examples/platforms/utils/settings.cpp
@@ -42,7 +42,7 @@
 #include "openthread/types.h"
 #include "openthread/platform/settings.h"
 
-#include <common/code_utils.hpp>
+#include <utils/code_utils.h>
 
 #include "flash.h"
 
@@ -149,7 +149,7 @@ static uint32_t swapSettingsBlock(otInstance *aInstance)
 
     (void)aInstance;
 
-    VerifyOrExit(pageNum > 1, ;);
+    otEXPECT(pageNum > 1);
 
     sSettingsBaseAddress = (swapAddress == SETTINGS_CONFIG_BASE_ADDRESS) ?
                            (swapAddress + settingsSize) :
@@ -244,8 +244,8 @@ static ThreadError addSetting(otInstance *aInstance, uint16_t aKey, bool aIndex0
     if ((sSettingsUsedSize + getAlignLength(addBlock.block.length) + sizeof(struct settingsBlock)) >=
         settingsSize)
     {
-        VerifyOrExit(swapSettingsBlock(aInstance) >= (getAlignLength(addBlock.block.length) + sizeof(struct settingsBlock)),
-                     error = kThreadError_NoBufs);
+        otEXPECT_ACTION(swapSettingsBlock(aInstance) >= (getAlignLength(addBlock.block.length) + sizeof(struct settingsBlock)),
+                        error = kThreadError_NoBufs);
     }
 
     utilsFlashWrite(sSettingsBaseAddress + sSettingsUsedSize,


### PR DESCRIPTION
`src/core/common/code_utils.hpp` is not a public include and should not be used by the example platform code.  This PR creates a new `examples/platforms/utils/code_utils.h` with macros that strictly adhere to the C99 standard and replaces the use of OpenThread's private `code_utils.hpp` in example platform-specific code.