### PR TITLE
Set CMP varible to the absolute name of `cmp` if found.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -219,6 +219,8 @@ AC_CHECK_TOOL(STRIP, strip)
 AC_PROG_INSTALL
 AC_PROG_LN_S
 
+AC_PATH_PROG(CMP, cmp)
+
 #
 # Checks for specific compiler characteristics
 #


### PR DESCRIPTION
Resolves #1512.