### PR TITLE
Only enable `LogIp6Message` when `OPENTHREAD_CONFIG_LOG_MAC` is 1.

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -2278,7 +2278,7 @@ void MeshForwarder::HandleDataPollTimeout(void)
     }
 }
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OPENTHREAD_LOG_LEVEL_INFO
+#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OPENTHREAD_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MAC == 1)
 
 void MeshForwarder::LogIp6Message(MessageAction aAction, const Message &aMessage, const Mac::Address &aMacAddress,
                                   ThreadError aError)


### PR DESCRIPTION
Resolves #1535.