### PR TITLE
add delay when removing successfully joined joiner

### DIFF
--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -62,7 +62,7 @@ ThreadError otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *a
 
 ThreadError otCommissionerRemoveJoiner(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
-    return aInstance->mThreadNetif.GetCommissioner().RemoveJoiner(static_cast<const Mac::ExtAddress *>(aExtAddress));
+    return aInstance->mThreadNetif.GetCommissioner().RemoveJoiner(static_cast<const Mac::ExtAddress *>(aExtAddress), 0);
 }
 
 ThreadError otCommissionerSetProvisioningUrl(otInstance *aInstance, const char *aProvisioningUrl)

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -113,12 +113,13 @@ public:
      * This method removes a Joiner entry.
      *
      * @param[in]  aExtAddress        A pointer to the Joiner's extended address or NULL for any Joiner.
+     * @param[in]  aDelay             The delay to remove Joiner (in seconds).
      *
      * @retval kThreadError_None      Successfully added the Joiner.
      * @retval kThreadError_NotFound  The Joiner specified by @p aExtAddress was not found.
      *
      */
-    ThreadError RemoveJoiner(const Mac::ExtAddress *aExtAddress);
+    ThreadError RemoveJoiner(const Mac::ExtAddress *aExtAddress, uint32_t aDelay);
 
     /**
      * This method sets the Provisioning URL.
@@ -205,6 +206,7 @@ private:
         kPetitionRetryCount   = 2,      ///< COMM_PET_RETRY_COUNT
         kPetitionRetryDelay   = 1,      ///< COMM_PET_RETRY_DELAY (seconds)
         kKeepAliveTimeout     = 50,     ///< TIMEOUT_COMM_PET (seconds)
+        kRemoveJoinerDelay    = 20,     ///< Delay to remove successfully joined joiner
     };
 
     static void HandleTimer(void *aContext);


### PR DESCRIPTION
If RemoveJoiner() immediately after JOIN_FIN.rsp, JR of other Thread stacks would not forward alert message after receiving DataResponse with all 0 steeringData. So here add some delay.

Help to pass 8.2.5 OT Commissioner on mixed testbed