### PR TITLE
Spinel: Thread Border Agent Support

### DIFF
--- a/doc/spinel-protocol-src/spinel-tech-thread.md
+++ b/doc/spinel-protocol-src/spinel-tech-thread.md
@@ -236,8 +236,9 @@ The stable leader network data.
 
 ### PROP 5391: PROP_THREAD_JOINERS {#prop-thread-joiners}
 
-* Type: Read-Write
+* Type: Insert/Remove Only (optionally Read-Write)
 * Packed-Encoding: `A(t(ULE))`
+* Required capability: `CAP_THREAD_COMMISSIONER`
 
 Data per item is:
 
@@ -246,12 +247,14 @@ Data per item is:
 * `E`: Extended/long address (optional)
 
 Passess Pre-Shared Key for the Device to the NCP in the commissioning process.
-When the Extended address is ommited all Devices which provided a valid PSKd are allowed to join the Thread Network.
+When the Extended address is ommited all Devices which provided a valid PSKd
+are allowed to join the Thread Network.
 
 ### PROP 5392: PROP_THREAD_COMMISSIONER_ENABLED {#prop-thread-commissioner-enabled}
 
-* Type: Read-Write
+* Type: Write only (optionally Read-Write)
 * Packed-Encoding: `b`
+* Required capability: `CAP_THREAD_COMMISSIONER`
 
 Set to true to enable the native commissioner. It is mandatory before adding the joiner to the network.
 
@@ -259,6 +262,7 @@ Set to true to enable the native commissioner. It is mandatory before adding the
 
 * Type: Read-Write
 * Packed-Encoding: `b`
+* Required capability: `CAP_THREAD_BA_PROXY`
 
 Set to true to enable the border agent proxy.
 
@@ -266,7 +270,22 @@ Set to true to enable the border agent proxy.
 
 * Type: Read-Write-Stream
 * Packed-Encoding: `dSS`
+* Required capability: `CAP_THREAD_BA_PROXY`
 
-Octects: | *n*  |    2    |  2
----------|------|---------|------
-Fields:  | CoAP | locator | port
+Data per item is:
+
+* `d`: CoAP frame
+* `S`: source/destination RLOC/ALOC
+* `S`: source/destination port
+
+Octects: | 2      | *n*  |    2    |  2
+---------|--------|------|---------|-------
+Fields:  | Length | CoAP | locator | port
+
+This property allows the host to send and receive border-agent-related
+CoAP requests/responses from the NCP's RLOC address. This allows the
+host driver to implement a Thread border agent.
+
+
+
+


### PR DESCRIPTION
This pull request proposes updates the Spinel protocol to support a host-based border-agent.

At the moment it is incomplete, since it doesn't specify a way to register as a border-agent with the leader. Suggestions and discussion is welcome.