### PR TITLE
`Timer`: Update how we detect if a timer is running

### DIFF
--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -56,6 +56,7 @@ void TimerScheduler::Add(Timer &aTimer)
     if (mHead == NULL)
     {
         mHead = &aTimer;
+        aTimer.mNext = NULL;
         SetAlarm();
     }
     else
@@ -88,16 +89,18 @@ void TimerScheduler::Add(Timer &aTimer)
         if (cur == NULL)
         {
             prev->mNext = &aTimer;
+            aTimer.mNext = NULL;
         }
     }
 }
 
 void TimerScheduler::Remove(Timer &aTimer)
 {
+    VerifyOrExit(aTimer.mNext != &aTimer, ;);
+
     if (mHead == &aTimer)
     {
         mHead = aTimer.mNext;
-        aTimer.mNext = NULL;
         SetAlarm();
     }
     else
@@ -107,27 +110,15 @@ void TimerScheduler::Remove(Timer &aTimer)
             if (cur->mNext == &aTimer)
             {
                 cur->mNext = aTimer.mNext;
-                aTimer.mNext = NULL;
                 break;
             }
         }
     }
-}
 
-bool TimerScheduler::IsAdded(const Timer &aTimer)
-{
-    bool rval = false;
-
-    for (Timer *cur = mHead; cur; cur = cur->mNext)
-    {
-        if (cur == &aTimer)
-        {
-            ExitNow(rval = true);
-        }
-    }
+    aTimer.mNext = &aTimer;
 
 exit:
-    return rval;
+    return;
 }
 
 void TimerScheduler::SetAlarm(void)
@@ -156,7 +147,7 @@ extern "C" void otPlatAlarmFired(otInstance *aInstance)
     otLogFuncExit();
 }
 
-void TimerScheduler::FireTimers()
+void TimerScheduler::FireTimers(void)
 {
     uint32_t now = otPlatAlarmGetNow();
     uint32_t elapsed;

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -90,15 +90,6 @@ public:
     void Remove(Timer &aTimer);
 
     /**
-     * This method returns whether or not the timer instance is already added.
-     *
-     * @retval TRUE   If the timer instance is already added.
-     * @retval FALSE  If the timer instance is not added.
-     *
-     */
-    bool IsAdded(const Timer &aTimer);
-
-    /**
      * This method processes all running timers.
      *
      * @param[in]  aContext  A pointer to arbitrary context information.
@@ -162,7 +153,7 @@ public:
         mContext(aContext),
         mT0(0),
         mDt(0),
-        mNext(NULL) {
+        mNext(this) {
     }
 
     /**
@@ -187,7 +178,7 @@ public:
      * @retval TRUE   If the timer is running.
      * @retval FALSE  If the timer is not running.
      */
-    bool IsRunning(void) const { return mScheduler.IsAdded(*this); }
+    bool IsRunning(void) const { return (mNext != this); }
 
     /**
      * This method schedules the timer to fire a @p dt milliseconds from now.


### PR DESCRIPTION
This commit makes a change in the `Timer` implementation to simplify
how we detect if a timer is running.

On an un-scheduled timer, we ensure to set the `mNext` to point back
to the `Timer` instance itself. In a scheduled/running timer, the
timer is included in a linked-list where `mNext` is used to point
to next timer in the list (or `NULL` if at the end of list). The
`mNext` value is then used to quickly determine if a timer is
scheduled/running or not.

This commit also removes the now unused `TimerScheduler::IsAdded()`
method.