### PR TITLE
Inlining simple getter and setter methods

### DIFF
--- a/src/core/common/crc16.cpp
+++ b/src/core/common/crc16.cpp
@@ -41,11 +41,6 @@ Crc16::Crc16(Polynomial aPolynomial)
     Init();
 }
 
-void Crc16::Init(void)
-{
-    mCrc = 0;
-}
-
 void Crc16::Update(uint8_t aByte)
 {
     uint8_t i;
@@ -65,11 +60,6 @@ void Crc16::Update(uint8_t aByte)
         }
     }
     while (--i);
-}
-
-uint16_t Crc16::Get(void) const
-{
-    return mCrc;
 }
 
 }  // namespace Thread

--- a/src/core/common/crc16.hpp
+++ b/src/core/common/crc16.hpp
@@ -63,7 +63,7 @@ public:
      * This method initializes the CRC16 computation.
      *
      */
-    void Init(void);
+    void Init(void) { mCrc = 0; }
 
     /*c*
      * This method feeds a byte value into the CRC16 computation.
@@ -79,7 +79,7 @@ public:
      * @returns The current CRC16 value.
      *
      */
-    uint16_t Get(void) const;
+    uint16_t Get(void) const { return mCrc; }
 
 private:
     uint16_t mPolynomial;

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -289,11 +289,6 @@ exit:
     return next;
 }
 
-uint16_t Message::GetLength(void) const
-{
-    return mInfo.mLength;
-}
-
 ThreadError Message::SetLength(uint16_t aLength)
 {
     ThreadError error = kThreadError_None;
@@ -332,11 +327,6 @@ uint8_t Message::GetBufferCount(void) const
     return rval;
 }
 
-uint16_t Message::GetOffset(void) const
-{
-    return mInfo.mOffset;
-}
-
 ThreadError Message::MoveOffset(int aDelta)
 {
     ThreadError error = kThreadError_None;
@@ -364,26 +354,6 @@ exit:
     return error;
 }
 
-uint8_t Message::GetType(void) const
-{
-    return mInfo.mType;
-}
-
-void Message::SetType(uint8_t aType)
-{
-    mInfo.mType = aType;
-}
-
-uint8_t Message::GetSubType(void) const
-{
-    return mInfo.mSubType;
-}
-
-void Message::SetSubType(uint8_t aSubType)
-{
-    mInfo.mSubType = aSubType;
-}
-
 bool Message::IsSubTypeMle(void) const
 {
     bool rval = false;
@@ -397,11 +367,6 @@ bool Message::IsSubTypeMle(void) const
     }
 
     return rval;
-}
-
-uint8_t Message::GetPriority(void) const
-{
-    return mInfo.mPriority;
 }
 
 ThreadError Message::SetPriority(uint8_t aPriority)
@@ -710,16 +675,6 @@ exit:
     return messageCopy;
 }
 
-uint16_t Message::GetDatagramTag(void) const
-{
-    return mInfo.mDatagramTag;
-}
-
-void Message::SetDatagramTag(uint16_t aTag)
-{
-    mInfo.mDatagramTag = aTag;
-}
-
 bool Message::GetChildMask(uint8_t aChildIndex) const
 {
     assert(aChildIndex < sizeof(mInfo.mChildMask) * 8);
@@ -752,71 +707,6 @@ bool Message::IsChildPending(void) const
 
 exit:
     return rval;
-}
-
-uint16_t Message::GetPanId(void) const
-{
-    return mInfo.mPanId;
-}
-
-void Message::SetPanId(uint16_t aPanId)
-{
-    mInfo.mPanId = aPanId;
-}
-
-uint8_t Message::GetChannel(void) const
-{
-    return mInfo.mChannel;
-}
-
-void Message::SetChannel(uint8_t aChannel)
-{
-    mInfo.mChannel = aChannel;
-}
-
-uint8_t Message::GetTimeout(void) const
-{
-    return mInfo.mTimeout;
-}
-
-void Message::SetTimeout(uint8_t aTimeout)
-{
-    mInfo.mTimeout = aTimeout;
-}
-
-int8_t Message::GetInterfaceId(void) const
-{
-    return mInfo.mInterfaceId;
-}
-
-void Message::SetInterfaceId(int8_t aInterfaceId)
-{
-    mInfo.mInterfaceId = aInterfaceId;
-}
-
-bool Message::GetDirectTransmission(void) const
-{
-    return mInfo.mDirectTx;
-}
-
-void Message::ClearDirectTransmission(void)
-{
-    mInfo.mDirectTx = false;
-}
-
-void Message::SetDirectTransmission(void)
-{
-    mInfo.mDirectTx = true;
-}
-
-bool Message::IsLinkSecurityEnabled(void) const
-{
-    return mInfo.mLinkSecurity;
-}
-
-void Message::SetLinkSecurityEnabled(bool aLinkSecurityEnabled)
-{
-    mInfo.mLinkSecurity = aLinkSecurityEnabled;
 }
 
 uint16_t Message::UpdateChecksum(uint16_t aChecksum, uint16_t aOffset, uint16_t aLength) const
@@ -884,16 +774,6 @@ uint16_t Message::UpdateChecksum(uint16_t aChecksum, uint16_t aOffset, uint16_t 
     }
 
     return aChecksum;
-}
-
-uint16_t Message::GetReserved(void) const
-{
-    return mInfo.mReserved;
-}
-
-void Message::SetReserved(uint16_t aReserved)
-{
-    mInfo.mReserved = aReserved;
 }
 
 void Message::SetMessageQueue(MessageQueue *aMessageQueue)

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -249,7 +249,7 @@ public:
      *
      * @returns The number of bytes in the message.
      */
-    uint16_t GetLength(void) const;
+    uint16_t GetLength(void) const { return mInfo.mLength; }
 
     /**
      * This method sets the number of bytes in the message.
@@ -275,7 +275,7 @@ public:
      * @returns A byte offset within the message.
      *
      */
-    uint16_t GetOffset(void) const;
+    uint16_t GetOffset(void) const { return mInfo.mOffset; }
 
     /**
      * This method moves the byte offset within the message.
@@ -305,7 +305,15 @@ public:
      * @returns The type of the message.
      *
      */
-    uint8_t GetType(void) const;
+    uint8_t GetType(void) const { return mInfo.mType; }
+
+    /**
+     * This method sets the message type.
+     *
+     * @param[in]  aType  The message type.
+     *
+     */
+    void SetType(uint8_t aType) { mInfo.mType = aType; }
 
     /**
      * This method returns the sub type of the message.
@@ -313,7 +321,7 @@ public:
      * @returns The sub type of the message.
      *
      */
-    uint8_t GetSubType(void) const;
+    uint8_t GetSubType(void) const { return mInfo.mSubType; }
 
     /**
      * This method sets the message sub type.
@@ -321,7 +329,7 @@ public:
      * @param[in]  aSubType  The message sub type.
      *
      */
-    void SetSubType(uint8_t aSubType);
+    void SetSubType(uint8_t aSubType) { mInfo.mSubType = aSubType; }
 
     /**
      * This method returns whether or not the message is of MLE subtype.
@@ -338,7 +346,7 @@ public:
      * @returns The priority level associated with this message.
      *
      */
-    uint8_t GetPriority(void) const;
+    uint8_t GetPriority(void) const { return mInfo.mPriority; }
 
     /**
      * This method sets the messages priority.
@@ -455,7 +463,7 @@ public:
      * @returns The 6LoWPAN datagram tag.
      *
      */
-    uint16_t GetDatagramTag(void) const;
+    uint16_t GetDatagramTag(void) const { return mInfo.mDatagramTag; }
 
     /**
      * This method sets the datagram tag used for 6LoWPAN fragmentation.
@@ -463,7 +471,7 @@ public:
      * @param[in]  aTag  The 6LoWPAN datagram tag.
      *
      */
-    void SetDatagramTag(uint16_t aTag);
+    void SetDatagramTag(uint16_t aTag) { mInfo.mDatagramTag = aTag; }
 
     /**
      * This method returns whether or not the message forwarding is scheduled for the child.
@@ -509,7 +517,7 @@ public:
      * @returns The IEEE 802.15.4 Destination PAN ID.
      *
      */
-    uint16_t GetPanId(void) const;
+    uint16_t GetPanId(void) const { return mInfo.mPanId; }
 
     /**
      * This method sets the IEEE 802.15.4 Destination PAN ID.
@@ -519,7 +527,7 @@ public:
      * @param[in]  aPanId  The IEEE 802.15.4 Destination PAN ID.
      *
      */
-    void SetPanId(uint16_t aPanId);
+    void SetPanId(uint16_t aPanId) { mInfo.mPanId = aPanId; }
 
     /**
      * This method returns the IEEE 802.15.4 Channel to use for transmission.
@@ -529,7 +537,7 @@ public:
      * @returns The IEEE 802.15.4 Channel to use for transmission.
      *
      */
-    uint8_t GetChannel(void) const;
+    uint8_t GetChannel(void) const { return mInfo.mChannel; }
 
     /**
      * This method sets the IEEE 802.15.4 Channel to use for transmission.
@@ -539,7 +547,7 @@ public:
      * @param[in]  aChannel  The IEEE 802.15.4 Channel to use for transmission.
      *
      */
-    void SetChannel(uint8_t aChannel);
+    void SetChannel(uint8_t aChannel) { mInfo.mChannel = aChannel; }
 
     /**
      * This method returns the timeout used for 6LoWPAN reassembly.
@@ -547,7 +555,7 @@ public:
      * @returns The time remaining in seconds.
      *
      */
-    uint8_t GetTimeout(void) const;
+    uint8_t GetTimeout(void) const { return mInfo.mTimeout; }
 
     /**
      * This method sets the timeout used for 6LoWPAN reassembly.
@@ -555,7 +563,7 @@ public:
      * @param[in]  aTimeout  The timeout value.
      *
      */
-    void SetTimeout(uint8_t aTimeout);
+    void SetTimeout(uint8_t aTimeout) { mInfo.mTimeout = aTimeout; }
 
     /**
      * This method returns the interface ID.
@@ -563,7 +571,7 @@ public:
      * @returns The interface ID.
      *
      */
-    int8_t GetInterfaceId(void) const;
+    int8_t GetInterfaceId(void) const { return mInfo.mInterfaceId; }
 
     /**
      * This method sets the interface ID.
@@ -571,7 +579,7 @@ public:
      * @param[in]  aInterfaceId  The interface ID value.
      *
      */
-    void SetInterfaceId(int8_t aInterfaceId);
+    void SetInterfaceId(int8_t aInterfaceId) { mInfo.mInterfaceId = aInterfaceId; }
 
     /**
      * This method returns whether or not message forwarding is scheduled for direct transmission.
@@ -580,19 +588,19 @@ public:
      * @retval FALSE  If message forwarding is not scheduled for direct transmission.
      *
      */
-    bool GetDirectTransmission(void) const;
+    bool GetDirectTransmission(void) const { return mInfo.mDirectTx; }
 
     /**
      * This method unschedules forwarding using direct transmission.
      *
      */
-    void ClearDirectTransmission(void);
+    void ClearDirectTransmission(void) { mInfo.mDirectTx = false; }
 
     /**
      * This method schedules forwarding using direct transmission.
      *
      */
-    void SetDirectTransmission(void);
+    void SetDirectTransmission(void) { mInfo.mDirectTx = true; }
 
     /**
      * This method indicates whether or not link security is enabled for the message.
@@ -601,7 +609,7 @@ public:
      * @retval FALSE  If link security is not enabled.
      *
      */
-    bool IsLinkSecurityEnabled(void) const;
+    bool IsLinkSecurityEnabled(void) const { return mInfo.mLinkSecurity; }
 
     /**
      * This method sets whether or not link security is enabled for the message.
@@ -609,7 +617,7 @@ public:
      * @param[in]  aLinkSecurityEnabled  TRUE if link security is enabled, FALSE otherwise.
      *
      */
-    void SetLinkSecurityEnabled(bool aLinkSecurityEnabled);
+    void SetLinkSecurityEnabled(bool aLinkSecurityEnabled) { mInfo.mLinkSecurity = aLinkSecurityEnabled; }
 
     /**
      * This method is used to update a checksum value.
@@ -717,7 +725,7 @@ private:
      * @returns The number of reserved header bytes.
      *
      */
-    uint16_t GetReserved(void) const;
+    uint16_t GetReserved(void) const { return mInfo.mReserved; }
 
     /**
      * This method sets the number of reserved header bytes.
@@ -725,15 +733,7 @@ private:
      * @pram[in]  aReservedHeader  The number of header bytes to reserve.
      *
      */
-    void SetReserved(uint16_t aReservedHeader);
-
-    /**
-     * This method sets the message type.
-     *
-     * @param[in]  aType  The message type.
-     *
-     */
-    void SetType(uint8_t aType);
+    void SetReserved(uint16_t aReservedHeader) { mInfo.mReserved = aReservedHeader; }
 
     /**
      * This method adds or frees message buffers to meet the requested length.

--- a/src/core/common/tasklet.cpp
+++ b/src/core/common/tasklet.cpp
@@ -100,11 +100,6 @@ Tasklet *TaskletScheduler::PopTasklet(void)
     return task;
 }
 
-bool TaskletScheduler::AreTaskletsPending(void)
-{
-    return mHead != NULL;
-}
-
 void TaskletScheduler::ProcessQueuedTasklets(void)
 {
     Tasklet *tail = mTail;
@@ -127,7 +122,7 @@ void TaskletScheduler::ProcessQueuedTasklets(void)
     }
 }
 
-Ip6::Ip6 *TaskletScheduler::GetIp6()
+Ip6::Ip6 *TaskletScheduler::GetIp6(void)
 {
     return Ip6::Ip6FromTaskletScheduler(this);
 }

--- a/src/core/common/tasklet.hpp
+++ b/src/core/common/tasklet.hpp
@@ -124,7 +124,7 @@ public:
      * @retval FALSE  If there are no tasklets pending.
      *
      */
-    bool AreTaskletsPending(void);
+    bool AreTaskletsPending(void) { return mHead != NULL; }
 
     /**
      * This method processes all tasklets queued when this is called.
@@ -138,7 +138,7 @@ public:
      * @returns The pointer to the parent Ip6 structure.
      *
      */
-    Ip6::Ip6 *GetIp6();
+    Ip6::Ip6 *GetIp6(void);
 
 private:
     Tasklet *PopTasklet(void);

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -182,7 +182,7 @@ void TimerScheduler::FireTimers()
     }
 }
 
-Ip6::Ip6 *TimerScheduler::GetIp6()
+Ip6::Ip6 *TimerScheduler::GetIp6(void)
 {
     return Ip6::Ip6FromTimerScheduler(this);
 }

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -112,7 +112,7 @@ public:
      * @returns The pointer to the parent Ip6 structure.
      *
      */
-    Ip6::Ip6 *GetIp6();
+    Ip6::Ip6 *GetIp6(void);
 
 private:
     void SetAlarm(void);

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -383,11 +383,6 @@ ThreadError Mac::RegisterReceiver(Receiver &aReceiver)
     return kThreadError_None;
 }
 
-bool Mac::GetRxOnWhenIdle(void) const
-{
-    return mRxOnWhenIdle;
-}
-
 void Mac::SetRxOnWhenIdle(bool aRxOnWhenIdle)
 {
     mRxOnWhenIdle = aRxOnWhenIdle;
@@ -396,11 +391,6 @@ void Mac::SetRxOnWhenIdle(bool aRxOnWhenIdle)
     {
         NextOperation();
     }
-}
-
-const ExtAddress *Mac::GetExtAddress(void) const
-{
-    return &mExtAddress;
 }
 
 void Mac::SetExtAddress(const ExtAddress &aExtAddress)
@@ -438,11 +428,6 @@ void Mac::GetHashMacAddress(ExtAddress *aHashMacAddress)
     otLogFuncExitMsg("%llX", HostSwap64(*reinterpret_cast<uint64_t *>(aHashMacAddress)));
 }
 
-ShortAddress Mac::GetShortAddress(void) const
-{
-    return mShortAddress;
-}
-
 ThreadError Mac::SetShortAddress(ShortAddress aShortAddress)
 {
     otLogFuncEntryMsg("%d", aShortAddress);
@@ -450,11 +435,6 @@ ThreadError Mac::SetShortAddress(ShortAddress aShortAddress)
     otPlatRadioSetShortAddress(GetInstance(), aShortAddress);
     otLogFuncExit();
     return kThreadError_None;
-}
-
-uint8_t Mac::GetChannel(void) const
-{
-    return mChannel;
 }
 
 ThreadError Mac::SetChannel(uint8_t aChannel)
@@ -469,21 +449,6 @@ ThreadError Mac::SetChannel(uint8_t aChannel)
 
     otLogFuncExit();
     return kThreadError_None;
-}
-
-int8_t Mac::GetMaxTransmitPower(void) const
-{
-    return mMaxTransmitPower;
-}
-
-void Mac::SetMaxTransmitPower(int8_t aPower)
-{
-    mMaxTransmitPower = aPower;
-}
-
-const char *Mac::GetNetworkName(void) const
-{
-    return mNetworkName.m8;
 }
 
 ThreadError Mac::SetNetworkName(const char *aNetworkName)
@@ -501,11 +466,6 @@ exit:
     return error;
 }
 
-PanId Mac::GetPanId(void) const
-{
-    return mPanId;
-}
-
 ThreadError Mac::SetPanId(PanId aPanId)
 {
     otLogFuncEntryMsg("%d", aPanId);
@@ -513,11 +473,6 @@ ThreadError Mac::SetPanId(PanId aPanId)
     otPlatRadioSetPanId(GetInstance(), mPanId);
     otLogFuncExit();
     return kThreadError_None;
-}
-
-const uint8_t *Mac::GetExtendedPanId(void) const
-{
-    return mExtendedPanId.m8;
 }
 
 ThreadError Mac::SetExtendedPanId(const uint8_t *aExtPanId)
@@ -1637,16 +1592,6 @@ bool Mac::RadioSupportsRetries(void)
     return (otPlatRadioGetCaps(GetInstance()) & kRadioCapsTransmitRetries) != 0;
 }
 
-Whitelist &Mac::GetWhitelist(void)
-{
-    return mWhitelist;
-}
-
-Blacklist &Mac::GetBlacklist(void)
-{
-    return mBlacklist;
-}
-
 void Mac::FillMacCountersTlv(NetworkDiagnostic::MacCountersTlv &aMacCounters) const
 {
     aMacCounters.SetIfInUnknownProtos(mCounters.mRxOther);
@@ -1664,11 +1609,6 @@ void Mac::FillMacCountersTlv(NetworkDiagnostic::MacCountersTlv &aMacCounters) co
 void Mac::ResetCounters(void)
 {
     memset(&mCounters, 0, sizeof(mCounters));
-}
-
-otMacCounters &Mac::GetCounters(void)
-{
-    return mCounters;
 }
 
 void Mac::EnableSrcMatch(bool aEnable)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -287,7 +287,7 @@ public:
      * @retval TRUE   If rx-on-when-idle is enabled.
      * @retval FALSE  If rx-on-when-idle is not enabled.
      */
-    bool GetRxOnWhenIdle(void) const;
+    bool GetRxOnWhenIdle(void) const { return mRxOnWhenIdle; }
 
     /**
      * This method sets the rx-on-when-idle mode.
@@ -325,7 +325,7 @@ public:
      * @returns A pointer to the IEEE 802.15.4 Extended Address.
      *
      */
-    const ExtAddress *GetExtAddress(void) const;
+    const ExtAddress *GetExtAddress(void) const { return &mExtAddress; }
 
     /**
      * This method sets the IEEE 802.15.4 Extended Address
@@ -352,7 +352,7 @@ public:
      * @returns The IEEE 802.15.4 Short Address.
      *
      */
-    ShortAddress GetShortAddress(void) const;
+    ShortAddress GetShortAddress(void) const { return mShortAddress; }
 
     /**
      * This method sets the IEEE 802.15.4 Short Address.
@@ -370,7 +370,7 @@ public:
      * @returns The IEEE 802.15.4 Channel.
      *
      */
-    uint8_t GetChannel(void) const;
+    uint8_t GetChannel(void) const { return mChannel; }
 
     /**
      * This method sets the IEEE 802.15.4 Channel.
@@ -388,7 +388,7 @@ public:
      * @returns  The maximum transmit power in dBm.
      *
      */
-    int8_t GetMaxTransmitPower(void) const;
+    int8_t GetMaxTransmitPower(void) const { return mMaxTransmitPower; }
 
     /**
      * This method sets the maximum transmit power in dBm.
@@ -396,7 +396,7 @@ public:
      * @param[in]  aPower  The maximum transmit power in dBm.
      *
      */
-    void SetMaxTransmitPower(int8_t aPower);
+    void SetMaxTransmitPower(int8_t aPower) { mMaxTransmitPower = aPower; }
 
     /**
      * This method returns the IEEE 802.15.4 Network Name.
@@ -404,7 +404,7 @@ public:
      * @returns A pointer to the IEEE 802.15.4 Network Name.
      *
      */
-    const char *GetNetworkName(void) const;
+    const char *GetNetworkName(void) const { return mNetworkName.m8; }
 
     /**
      * This method sets the IEEE 802.15.4 Network Name.
@@ -422,7 +422,7 @@ public:
      * @returns The IEEE 802.15.4 PAN ID.
      *
      */
-    uint16_t GetPanId(void) const;
+    uint16_t GetPanId(void) const { return mPanId; }
 
     /**
      * This method sets the IEEE 802.15.4 PAN ID.
@@ -440,7 +440,7 @@ public:
      * @returns A pointer to the IEEE 802.15.4 Extended PAN ID.
      *
      */
-    const uint8_t *GetExtendedPanId(void) const;
+    const uint8_t *GetExtendedPanId(void) const { return mExtendedPanId.m8; }
 
     /**
      * This method sets the IEEE 802.15.4 Extended PAN ID.
@@ -458,7 +458,7 @@ public:
      * @returns A reference to the MAC whitelist filter.
      *
      */
-    Whitelist &GetWhitelist(void);
+    Whitelist &GetWhitelist(void) { return mWhitelist; }
 
     /**
      * This method returns the MAC blacklist filter.
@@ -466,7 +466,7 @@ public:
      * @returns A reference to the MAC blacklist filter.
      *
      */
-    Blacklist &GetBlacklist(void);
+    Blacklist &GetBlacklist(void) { return mBlacklist; }
 
     /**
      * This method is called to handle receive events.
@@ -561,7 +561,7 @@ public:
      * @returns A reference to the MAC counter.
      *
      */
-    otMacCounters &GetCounters(void);
+    otMacCounters &GetCounters(void) { return mCounters; }
 
     /**
      * This method returns the noise floor state.

--- a/src/core/mac/mac_blacklist.cpp
+++ b/src/core/mac/mac_blacklist.cpp
@@ -49,21 +49,6 @@ Blacklist::Blacklist(void)
     }
 }
 
-bool Blacklist::IsEnabled(void) const
-{
-    return mEnabled;
-}
-
-void Blacklist::SetEnabled(bool aEnabled)
-{
-    mEnabled = aEnabled;
-}
-
-int Blacklist::GetMaxEntries(void) const
-{
-    return kMaxEntries;
-}
-
 ThreadError Blacklist::GetEntry(uint8_t aIndex, Entry &aEntry) const
 {
     ThreadError error = kThreadError_None;

--- a/src/core/mac/mac_blacklist_impl.hpp
+++ b/src/core/mac/mac_blacklist_impl.hpp
@@ -77,7 +77,7 @@ public:
      * @retval FALSE  If the blacklist filter is disabled.
      *
      */
-    bool IsEnabled(void) const;
+    bool IsEnabled(void) const { return mEnabled; }
 
     /**
      * This method enables the blacklist filter.
@@ -85,7 +85,7 @@ public:
      * @param[in]  aEnabled  TRUE to enable the blacklist filter, FALSE otherwise.
      *
      */
-    void SetEnabled(bool aEnabled);
+    void SetEnabled(bool aEnabled) { mEnabled = aEnabled; }
 
     /**
      * This method returns the maximum number of blacklist entries.
@@ -93,7 +93,7 @@ public:
      * @returns The maximum number of blacklist entries.
      *
      */
-    int GetMaxEntries(void) const;
+    int GetMaxEntries(void) const { return kMaxEntries; }
 
     /**
      * This method gets a blacklist entry.

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -870,17 +870,6 @@ exit:
     return error;
 }
 
-uint8_t Frame::GetLength() const
-{
-    return GetPsduLength();
-}
-
-ThreadError Frame::SetLength(uint8_t aLength)
-{
-    SetPsduLength(aLength);
-    return kThreadError_None;
-}
-
 uint8_t Frame::GetHeaderLength(void)
 {
     return static_cast<uint8_t>(GetPayload() - GetPsdu());

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -546,7 +546,7 @@ public:
      * @returns The MAC Frame Length.
      *
      */
-    uint8_t GetLength(void) const;
+    uint8_t GetLength(void) const { return GetPsduLength(); }
 
     /**
      * This method sets the MAC Frame Length.
@@ -557,7 +557,7 @@ public:
      * @retval kThreadError_InvalidArgs  The @p aLength value was invalid.
      *
      */
-    ThreadError SetLength(uint8_t aLength);
+    ThreadError SetLength(uint8_t aLength) { SetPsduLength(aLength); return kThreadError_None; }
 
     /**
      * This method returns the MAC header size.

--- a/src/core/mac/mac_whitelist.cpp
+++ b/src/core/mac/mac_whitelist.cpp
@@ -49,21 +49,6 @@ Whitelist::Whitelist(void)
     }
 }
 
-bool Whitelist::IsEnabled(void) const
-{
-    return mEnabled;
-}
-
-void Whitelist::SetEnabled(bool aEnabled)
-{
-    mEnabled = aEnabled;
-}
-
-int Whitelist::GetMaxEntries(void) const
-{
-    return kMaxEntries;
-}
-
 ThreadError Whitelist::GetEntry(uint8_t aIndex, Entry &aEntry) const
 {
     ThreadError error = kThreadError_None;

--- a/src/core/mac/mac_whitelist_impl.hpp
+++ b/src/core/mac/mac_whitelist_impl.hpp
@@ -77,7 +77,7 @@ public:
      * @retval FALSE  If the whitelist filter is disabled.
      *
      */
-    bool IsEnabled(void) const;
+    bool IsEnabled(void) const { return mEnabled; }
 
     /**
      * This method enables the whitelist filter.
@@ -85,7 +85,7 @@ public:
      * @param[in]  aEnabled  TRUE to enable the whitelist filter, FALSE otherwise.
      *
      */
-    void SetEnabled(bool aEnabled);
+    void SetEnabled(bool aEnabled) { mEnabled = aEnabled; }
 
     /**
      * This method returns the maximum number of whitelist entries.
@@ -93,7 +93,7 @@ public:
      * @returns The maximum number of whitelist entries.
      *
      */
-    int GetMaxEntries(void) const;
+    int GetMaxEntries(void) const { return kMaxEntries; }
 
     /**
      * This method gets a whitelist entry.

--- a/src/core/meshcop/announce_begin_client.cpp
+++ b/src/core/meshcop/announce_begin_client.cpp
@@ -57,7 +57,7 @@ AnnounceBeginClient::AnnounceBeginClient(ThreadNetif &aThreadNetif) :
 {
 }
 
-otInstance *AnnounceBeginClient::GetInstance()
+otInstance *AnnounceBeginClient::GetInstance(void)
 {
     return mNetif.GetInstance();
 }

--- a/src/core/meshcop/announce_begin_client.hpp
+++ b/src/core/meshcop/announce_begin_client.hpp
@@ -65,7 +65,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
     /**
      * This method sends a Announce Begin message.

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -84,7 +84,7 @@ Commissioner::Commissioner(ThreadNetif &aThreadNetif):
     mNetif.GetSecureCoapServer().AddResource(mJoinerFinalize);
 }
 
-otInstance *Commissioner::GetInstance()
+otInstance *Commissioner::GetInstance(void)
 {
     return mNetif.GetInstance();
 }

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -72,7 +72,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
     /**
      * This method starts the Commissioner service.

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -69,7 +69,7 @@ DatasetManager::DatasetManager(ThreadNetif &aThreadNetif, const Tlv::Type aType,
 {
 }
 
-otInstance *DatasetManager::GetInstance()
+otInstance *DatasetManager::GetInstance(void)
 {
     return mNetif.GetInstance();
 }

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -60,7 +60,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
     Dataset &GetLocal(void) { return mLocal; }
     Dataset &GetNetwork(void) { return mNetwork; }

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -73,7 +73,7 @@ Dtls::Dtls(ThreadNetif &aNetif):
     mProvisioningUrl.Init();
 }
 
-otInstance *Dtls::GetInstance()
+otInstance *Dtls::GetInstance(void)
 {
     return mNetif.GetInstance();
 }

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -77,7 +77,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
     /**
      * This function pointer is called when a connection is established or torn down.

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -59,7 +59,7 @@ EnergyScanClient::EnergyScanClient(ThreadNetif &aThreadNetif) :
     mNetif.GetCoapServer().AddResource(mEnergyScan);
 }
 
-otInstance *EnergyScanClient::GetInstance()
+otInstance *EnergyScanClient::GetInstance(void)
 {
     return mNetif.GetInstance();
 }

--- a/src/core/meshcop/energy_scan_client.hpp
+++ b/src/core/meshcop/energy_scan_client.hpp
@@ -66,7 +66,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
     /**
      * This method sends an Energy Scan Query message.

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -80,7 +80,7 @@ Joiner::Joiner(ThreadNetif &aNetif):
     mNetif.GetCoapServer().AddResource(mJoinerEntrust);
 }
 
-otInstance *Joiner::GetInstance()
+otInstance *Joiner::GetInstance(void)
 {
     return mNetif.GetInstance();
 }

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -68,7 +68,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
     /**
      * This method starts the Joiner service.

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -71,7 +71,7 @@ JoinerRouter::JoinerRouter(ThreadNetif &aNetif):
     mNetif.RegisterCallback(mNetifCallback);
 }
 
-otInstance *JoinerRouter::GetInstance()
+otInstance *JoinerRouter::GetInstance(void)
 {
     return mNetif.GetInstance();
 }

--- a/src/core/meshcop/joiner_router_ftd.hpp
+++ b/src/core/meshcop/joiner_router_ftd.hpp
@@ -70,7 +70,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
     /**
      * This method returns the Joiner UDP Port.

--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -61,7 +61,7 @@ Leader::Leader(ThreadNetif &aThreadNetif):
     mNetif.GetCoapServer().AddResource(mKeepAlive);
 }
 
-otInstance *Leader::GetInstance()
+otInstance *Leader::GetInstance(void)
 {
     return mNetif.GetInstance();
 }

--- a/src/core/meshcop/leader_ftd.hpp
+++ b/src/core/meshcop/leader_ftd.hpp
@@ -76,7 +76,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
     /**
      * This method sends a MGMT_DATASET_CHANGED message to commissioner.

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -55,7 +55,7 @@ PanIdQueryClient::PanIdQueryClient(ThreadNetif &aThreadNetif) :
     mNetif.GetCoapServer().AddResource(mPanIdQuery);
 }
 
-otInstance *PanIdQueryClient::GetInstance()
+otInstance *PanIdQueryClient::GetInstance(void)
 {
     return mNetif.GetInstance();
 }

--- a/src/core/meshcop/panid_query_client.hpp
+++ b/src/core/meshcop/panid_query_client.hpp
@@ -66,7 +66,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
     /**
      * This method sends a PAN ID Query message.

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -70,7 +70,7 @@ Dhcp6Client::Dhcp6Client(ThreadNetif &aThreadNetif) :
     mIdentityAssociationAvail = &mIdentityAssociations[0];
 }
 
-otInstance *Dhcp6Client::GetInstance()
+otInstance *Dhcp6Client::GetInstance(void)
 {
     return mNetif.GetInstance();
 }

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -184,7 +184,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
     /**
      * This method update addresses that shall be automatically created using DHCP.

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -55,7 +55,7 @@ Icmp::Icmp(Ip6 &aIp6):
 {
 }
 
-otInstance *Icmp::GetInstance()
+otInstance *Icmp::GetInstance(void)
 {
     return mIp6.GetInstance();
 }
@@ -237,16 +237,6 @@ ThreadError Icmp::UpdateChecksum(Message &aMessage, uint16_t aChecksum)
     aChecksum = HostSwap16(aChecksum);
     aMessage.Write(aMessage.GetOffset() + IcmpHeader::GetChecksumOffset(), sizeof(aChecksum), &aChecksum);
     return kThreadError_None;
-}
-
-bool Icmp::IsEchoEnabled(void)
-{
-    return mIsEchoEnabled;
-}
-
-void Icmp::SetEchoEnabled(bool aEnabled)
-{
-    mIsEchoEnabled = aEnabled;
 }
 
 }  // namespace Ip6

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -227,7 +227,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
     /**
      * This method returns a new ICMP message with sufficient header space reserved.
@@ -311,7 +311,7 @@ public:
      * @retval FALSE  ICMPv6 Echo processing is disabled.
      *
      */
-    bool IsEchoEnabled(void);
+    bool IsEchoEnabled(void) { return mIsEchoEnabled; }
 
     /**
      * This method sets whether or not ICMPv6 Echo processing is enabled.
@@ -319,7 +319,7 @@ public:
      * @param[in]  aEnabled  TRUE to enable ICMPv6 Echo processing, FALSE otherwise.
      *
      */
-    void SetEchoEnabled(bool aEnabled);
+    void SetEchoEnabled(bool aEnabled) { mIsEchoEnabled = aEnabled; }
 
 private:
     ThreadError HandleEchoRequest(Message &aMessage, const MessageInfo &aMessageInfo);

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -69,16 +69,6 @@ Message *Ip6::NewMessage(uint16_t reserved)
     return mMessagePool.New(Message::kTypeIp6, sizeof(Header) + sizeof(HopByHopHeader) + sizeof(OptionMpl) + reserved);
 }
 
-bool Ip6::IsForwardingEnabled(void)
-{
-    return mForwardingEnabled;
-}
-
-void Ip6::SetForwardingEnabled(bool aEnable)
-{
-    mForwardingEnabled = aEnable;
-}
-
 uint16_t Ip6::UpdateChecksum(uint16_t checksum, uint16_t val)
 {
     uint16_t result = checksum + val;
@@ -118,16 +108,6 @@ void Ip6::SetReceiveDatagramCallback(otIp6ReceiveCallback aCallback, void *aCall
 {
     mReceiveIp6DatagramCallback = aCallback;
     mReceiveIp6DatagramCallbackContext = aCallbackContext;
-}
-
-bool Ip6::IsReceiveIp6FilterEnabled(void)
-{
-    return mIsReceiveIp6FilterEnabled;
-}
-
-void Ip6::SetReceiveIp6FilterEnabled(bool aEnabled)
-{
-    mIsReceiveIp6FilterEnabled = aEnabled;
 }
 
 ThreadError Ip6::AddMplOption(Message &message, Header &header)
@@ -918,11 +898,6 @@ ThreadError Ip6::RemoveNetif(Netif &aNetif)
 
 exit:
     return error;
-}
-
-Netif *Ip6::GetNetifList()
-{
-    return mNetifListHead;
 }
 
 Netif *Ip6::GetNetifById(int8_t aInterfaceId)

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -230,7 +230,7 @@ public:
      * @sa SetReceiveIp6FilterEnabled
      *
      */
-    bool IsReceiveIp6FilterEnabled(void);
+    bool IsReceiveIp6FilterEnabled(void) { return mIsReceiveIp6FilterEnabled; }
 
     /**
      * This method sets whether or not Thread control traffic is filtered out when delivering IPv6 datagrams
@@ -242,7 +242,7 @@ public:
      * @sa IsReceiveIp6FilterEnabled
      *
      */
-    void SetReceiveIp6FilterEnabled(bool aEnabled);
+    void SetReceiveIp6FilterEnabled(bool aEnabled) { mIsReceiveIp6FilterEnabled = aEnabled; }
 
     /**
      * This method indicates whether or not IPv6 forwarding is enabled.
@@ -250,7 +250,7 @@ public:
      * @returns TRUE if IPv6 forwarding is enabled, FALSE otherwise.
      *
      */
-    bool IsForwardingEnabled(void);
+    bool IsForwardingEnabled(void) { return mForwardingEnabled; }
 
     /**
      * This method enables/disables IPv6 forwarding.
@@ -258,7 +258,7 @@ public:
      * @param[in]  aEnable  TRUE to enable IPv6 forwarding, FALSE otherwise.
      *
      */
-    void SetForwardingEnabled(bool aEnable);
+    void SetForwardingEnabled(bool aEnable) { mForwardingEnabled = aEnable; }
 
     /**
      * This method enables the network interface.
@@ -288,7 +288,7 @@ public:
      * @returns A pointer to the network interface list.
      *
      */
-    Netif *GetNetifList(void);
+    Netif *GetNetifList(void) { return mNetifListHead; }
 
     /**
      * This method returns the network interface identified by @p aInterfaceId.

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -208,8 +208,6 @@ exit:
     {
         messageCopy->Free();
     }
-
-    return;
 }
 
 ThreadError Mpl::ProcessOption(Message &aMessage, const Address &aAddress, bool aIsOutbound)

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -113,21 +113,6 @@ ThreadError Netif::RemoveCallback(NetifCallback &aCallback)
     return error;
 }
 
-Netif *Netif::GetNext() const
-{
-    return mNext;
-}
-
-Ip6 &Netif::GetIp6(void)
-{
-    return mIp6;
-}
-
-int8_t Netif::GetInterfaceId() const
-{
-    return mInterfaceId;
-}
-
 bool Netif::IsMulticastSubscribed(const Address &aAddress) const
 {
     bool rval = false;
@@ -152,21 +137,6 @@ bool Netif::IsMulticastSubscribed(const Address &aAddress) const
 
 exit:
     return rval;
-}
-
-void Netif::SubscribeAllRoutersMulticast()
-{
-    mAllRoutersSubscribed = true;
-}
-
-void Netif::UnsubscribeAllRoutersMulticast()
-{
-    mAllRoutersSubscribed = false;
-}
-
-const NetifMulticastAddress *Netif::GetMulticastAddresses() const
-{
-    return mMulticastAddresses;
 }
 
 ThreadError Netif::SubscribeMulticast(NetifMulticastAddress &aAddress)
@@ -303,21 +273,6 @@ void Netif::UnsubscribeAllExternalMulticastAddresses(void)
             UnsubscribeExternalMulticast(*static_cast<Address *>(&entry->mAddress));
         }
     }
-}
-
-bool Netif::IsMulticastPromiscuousEnabled(void)
-{
-    return mMulticastPromiscuous;
-}
-
-void Netif::SetMulticastPromiscuous(bool aEnabled)
-{
-    mMulticastPromiscuous = aEnabled;
-}
-
-const NetifUnicastAddress *Netif::GetUnicastAddresses() const
-{
-    return mUnicastAddresses;
 }
 
 ThreadError Netif::AddUnicastAddress(NetifUnicastAddress &aAddress)
@@ -485,11 +440,6 @@ bool Netif::IsUnicastAddress(const Address &aAddress) const
 
 exit:
     return rval;
-}
-
-bool Netif::IsStateChangedCallbackPending(void)
-{
-    return mStateChangedFlags != 0;
 }
 
 void Netif::SetStateChangedFlags(uint32_t aFlags)

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -206,9 +206,7 @@ public:
      * @returns True if the object is free, false otherwise.
      *
      */
-    bool IsFree(void) {
-        return (mCallback == NULL);
-    }
+    bool IsFree(void) { return (mCallback == NULL); }
 
     /**
      * This method frees the object.
@@ -269,14 +267,14 @@ public:
      * @returns A reference to the IPv6 network object.
      *
      */
-    Ip6 &GetIp6(void);
+    Ip6 &GetIp6(void) { return mIp6; }
 
     /**
      * This method returns the next network interface in the list.
      *
      * @returns A pointer to the next network interface.
      */
-    Netif *GetNext(void) const;
+    Netif *GetNext(void) const { return mNext; }
 
     /**
      * This method returns the network interface identifier.
@@ -284,7 +282,7 @@ public:
      * @returns The network interface identifier.
      *
      */
-    int8_t GetInterfaceId(void) const;
+    int8_t GetInterfaceId(void) const { return mInterfaceId; }
 
     /**
      * This method returns a pointer to the list of unicast addresses.
@@ -292,7 +290,7 @@ public:
      * @returns A pointer to the list of unicast addresses.
      *
      */
-    const NetifUnicastAddress *GetUnicastAddresses(void) const;
+    const NetifUnicastAddress *GetUnicastAddresses(void) const { return mUnicastAddresses; }
 
     /**
      * This method adds a unicast address to the network interface.
@@ -372,13 +370,13 @@ public:
      * This method subscribes the network interface to the link-local and realm-local all routers address.
      *
      */
-    void SubscribeAllRoutersMulticast(void);
+    void SubscribeAllRoutersMulticast(void) { mAllRoutersSubscribed = true; }
 
     /**
      * This method unsubscribes the network interface to the link-local and realm-local all routers address.
      *
      */
-    void UnsubscribeAllRoutersMulticast(void);
+    void UnsubscribeAllRoutersMulticast(void) { mAllRoutersSubscribed = false; }
 
     /**
      * This method returns a pointer to the list of multicast addresses.
@@ -386,7 +384,7 @@ public:
      * @returns A pointer to the list of multicast addresses.
      *
      */
-    const NetifMulticastAddress *GetMulticastAddresses(void) const;
+    const NetifMulticastAddress *GetMulticastAddresses(void) const { return mMulticastAddresses; }
 
     /**
      * This method subscribes the network interface to a multicast address.
@@ -447,7 +445,7 @@ public:
      * @retval TRUE   If the multicast promiscuous mode is enabled.
      * @retval FALSE  If the multicast promiscuous mode is disabled.
      */
-    bool IsMulticastPromiscuousEnabled(void);
+    bool IsMulticastPromiscuousEnabled(void) { return mMulticastPromiscuous; }
 
     /**
      * This method enables multicast promiscuous mode on the network interface.
@@ -455,7 +453,7 @@ public:
      * @param[in]  aEnabled  TRUE if Multicast Promiscuous mode is enabled, FALSE otherwise.
      *
      */
-    void SetMulticastPromiscuous(bool aEnabled);
+    void SetMulticastPromiscuous(bool aEnabled) { mMulticastPromiscuous = aEnabled; }
 
     /**
      * This method registers a network interface callback.
@@ -483,7 +481,7 @@ public:
      * @retval TRUE if a state changed callback is pending, FALSE otherwise.
      *
      */
-    bool IsStateChangedCallbackPending(void);
+    bool IsStateChangedCallbackPending(void) { return mStateChangedFlags != 0; }
 
     /**
      * This method schedules notification of @p aFlags.

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -69,7 +69,7 @@ AddressResolver::AddressResolver(ThreadNetif &aThreadNetif) :
     mNetif.GetIp6().mIcmp.RegisterHandler(mIcmpHandler);
 }
 
-otInstance *AddressResolver::GetInstance()
+otInstance *AddressResolver::GetInstance(void)
 {
     return mNetif.GetInstance();
 }

--- a/src/core/thread/address_resolver_ftd.hpp
+++ b/src/core/thread/address_resolver_ftd.hpp
@@ -81,7 +81,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
     /**
      * This method clears the EID-to-RLOC cache.

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -66,7 +66,7 @@ AnnounceBeginServer::AnnounceBeginServer(ThreadNetif &aThreadNetif) :
     mNetif.GetCoapServer().AddResource(mAnnounceBegin);
 }
 
-otInstance *AnnounceBeginServer::GetInstance()
+otInstance *AnnounceBeginServer::GetInstance(void)
 {
     return mNetif.GetInstance();
 }

--- a/src/core/thread/announce_begin_server.hpp
+++ b/src/core/thread/announce_begin_server.hpp
@@ -66,7 +66,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
     /**
      * This method begins the MLE Announce transmission process using Count=3 and Period=1s.

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -64,7 +64,7 @@ EnergyScanServer::EnergyScanServer(ThreadNetif &aThreadNetif) :
     mNetif.GetCoapServer().AddResource(mEnergyScan);
 }
 
-otInstance *EnergyScanServer::GetInstance()
+otInstance *EnergyScanServer::GetInstance(void)
 {
     return mNetif.GetInstance();
 }

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -71,7 +71,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
 private:
     enum

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -149,11 +149,6 @@ ThreadError KeyManager::ComputeKey(uint32_t aKeySequence, uint8_t *aKey)
     return kThreadError_None;
 }
 
-uint32_t KeyManager::GetCurrentKeySequence(void) const
-{
-    return mKeySequence;
-}
-
 void KeyManager::SetCurrentKeySequence(uint32_t aKeySequence)
 {
     if (aKeySequence == mKeySequence)
@@ -206,41 +201,16 @@ exit:
     return;
 }
 
-const uint8_t *KeyManager::GetCurrentMacKey(void) const
-{
-    return mKey + 16;
-}
-
-const uint8_t *KeyManager::GetCurrentMleKey(void) const
-{
-    return mKey;
-}
-
 const uint8_t *KeyManager::GetTemporaryMacKey(uint32_t aKeySequence)
 {
     ComputeKey(aKeySequence, mTemporaryKey);
-    return mTemporaryKey + 16;
+    return mTemporaryKey + kMacKeyOffset;
 }
 
 const uint8_t *KeyManager::GetTemporaryMleKey(uint32_t aKeySequence)
 {
     ComputeKey(aKeySequence, mTemporaryKey);
     return mTemporaryKey;
-}
-
-uint32_t KeyManager::GetMacFrameCounter(void) const
-{
-    return mMacFrameCounter;
-}
-
-void KeyManager::SetMacFrameCounter(uint32_t aMacFrameCounter)
-{
-    mMacFrameCounter = aMacFrameCounter;
-}
-
-void KeyManager::SetStoredMacFrameCounter(uint32_t aStoredMacFrameCounter)
-{
-    mStoredMacFrameCounter = aStoredMacFrameCounter;
 }
 
 void KeyManager::IncrementMacFrameCounter(void)
@@ -253,21 +223,6 @@ void KeyManager::IncrementMacFrameCounter(void)
     }
 }
 
-uint32_t KeyManager::GetMleFrameCounter(void) const
-{
-    return mMleFrameCounter;
-}
-
-void KeyManager::SetMleFrameCounter(uint32_t aMleFrameCounter)
-{
-    mMleFrameCounter = aMleFrameCounter;
-}
-
-void KeyManager::SetStoredMleFrameCounter(uint32_t aStoredMleFrameCounter)
-{
-    mStoredMleFrameCounter = aStoredMleFrameCounter;
-}
-
 void KeyManager::IncrementMleFrameCounter(void)
 {
     mMleFrameCounter++;
@@ -278,25 +233,10 @@ void KeyManager::IncrementMleFrameCounter(void)
     }
 }
 
-const uint8_t *KeyManager::GetKek(void) const
-{
-    return mKek;
-}
-
 void KeyManager::SetKek(const uint8_t *aKek)
 {
     memcpy(mKek, aKek, sizeof(mKek));
     mKekFrameCounter = 0;
-}
-
-uint32_t KeyManager::GetKekFrameCounter(void) const
-{
-    return mKekFrameCounter;
-}
-
-void KeyManager::IncrementKekFrameCounter(void)
-{
-    mKekFrameCounter++;
 }
 
 ThreadError KeyManager::SetKeyRotation(uint32_t aKeyRotation)

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -110,7 +110,7 @@ public:
      * @returns The current key sequence value.
      *
      */
-    uint32_t GetCurrentKeySequence(void) const;
+    uint32_t GetCurrentKeySequence(void) const { return mKeySequence; }
 
     /**
      * This method sets the current key sequence value.
@@ -126,7 +126,7 @@ public:
      * @returns A pointer to the current MAC key.
      *
      */
-    const uint8_t *GetCurrentMacKey(void) const;
+    const uint8_t *GetCurrentMacKey(void) const { return mKey + kMacKeyOffset; }
 
     /**
      * This method returns a pointer to the current MLE key.
@@ -134,7 +134,7 @@ public:
      * @returns A pointer to the current MLE key.
      *
      */
-    const uint8_t *GetCurrentMleKey(void) const;
+    const uint8_t *GetCurrentMleKey(void) const { return mKey; }
 
     /**
      * This method returns a pointer to a temporary MAC key computed from the given key sequence.
@@ -162,7 +162,7 @@ public:
      * @returns The current MAC Frame Counter value.
      *
      */
-    uint32_t GetMacFrameCounter(void) const;
+    uint32_t GetMacFrameCounter(void) const { return mMacFrameCounter; }
 
     /**
      * This method sets the current MAC Frame Counter value.
@@ -170,7 +170,7 @@ public:
      * @param[in]  aMacFrameCounter  The MAC Frame Counter value.
      *
      */
-    void SetMacFrameCounter(uint32_t aMacFrameCounter);
+    void SetMacFrameCounter(uint32_t aMacFrameCounter) { mMacFrameCounter = aMacFrameCounter; }
 
     /**
      * This method sets the MAC Frame Counter value which is stored in non-volatile memory.
@@ -178,7 +178,7 @@ public:
      * @param[in]  aStoredMacFrameCounter  The stored MAC Frame Counter value.
      *
      */
-    void SetStoredMacFrameCounter(uint32_t aStoredMacFrameCounter);
+    void SetStoredMacFrameCounter(uint32_t aStoredMacFrameCounter) { mStoredMacFrameCounter = aStoredMacFrameCounter; }
 
     /**
      * This method increments the current MAC Frame Counter value.
@@ -192,7 +192,7 @@ public:
      * @returns The current MLE Frame Counter value.
      *
      */
-    uint32_t GetMleFrameCounter(void) const;
+    uint32_t GetMleFrameCounter(void) const { return mMleFrameCounter; }
 
     /**
      * This method sets the current MLE Frame Counter value.
@@ -200,7 +200,7 @@ public:
      * @param[in]  aMleFrameCounter  The MLE Frame Counter value.
      *
      */
-    void SetMleFrameCounter(uint32_t aMleFrameCounter);
+    void SetMleFrameCounter(uint32_t aMleFrameCounter) { mMleFrameCounter = aMleFrameCounter; }
 
     /**
      * This method sets the MLE Frame Counter value which is stored in non-volatile memory.
@@ -208,7 +208,7 @@ public:
      * @param[in]  aStoredMleFrameCounter  The stored MLE Frame Counter value.
      *
      */
-    void SetStoredMleFrameCounter(uint32_t aStoredMleFrameCounter);
+    void SetStoredMleFrameCounter(uint32_t aStoredMleFrameCounter) { mStoredMleFrameCounter = aStoredMleFrameCounter; }
 
     /**
      * This method increments the current MLE Frame Counter value.
@@ -222,7 +222,7 @@ public:
      * @returns A pointer to the KEK.
      *
      */
-    const uint8_t *GetKek(void) const;
+    const uint8_t *GetKek(void) const { return mKek; }
 
     /**
      * This method sets the KEK.
@@ -238,13 +238,13 @@ public:
      * @returns The current KEK Frame Counter value.
      *
      */
-    uint32_t GetKekFrameCounter(void) const;
+    uint32_t GetKekFrameCounter(void) const { return mKekFrameCounter; }
 
     /**
      * This method increments the current KEK Frame Counter value.
      *
      */
-    void IncrementKekFrameCounter(void);
+    void IncrementKekFrameCounter(void) { mKekFrameCounter++; }
 
     /**
      * This method returns the KeyRotation time.
@@ -318,6 +318,7 @@ private:
         kMaxKeyRotationTime = 0xffffffff / 3600u / 1000u,
         kDefaultKeyRotationTime = 672,
         kDefaultKeySwitchGuardTime = 624,
+        kMacKeyOffset = 16,
     };
 
     ThreadError ComputeKey(uint32_t aKeySequence, uint8_t *aKey);

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -86,7 +86,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
     /**
      * This method enables mesh forwarding and the IEEE 802.15.4 MAC layer.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -172,7 +172,7 @@ Mle::Mle(ThreadNetif &aThreadNetif) :
     memset(&mAddr64, 0, sizeof(mAddr64));
 }
 
-otInstance *Mle::GetInstance()
+otInstance *Mle::GetInstance(void)
 {
     return mNetif.GetInstance();
 }
@@ -522,11 +522,6 @@ bool Mle::IsAttached(void) const
             mDeviceState == kDeviceStateLeader);
 }
 
-DeviceState Mle::GetDeviceState(void) const
-{
-    return mDeviceState;
-}
-
 ThreadError Mle::SetStateDetached(void)
 {
     if (mDeviceState != kDeviceStateDetached)
@@ -595,11 +590,6 @@ ThreadError Mle::SetStateChild(uint16_t aRloc16)
     return kThreadError_None;
 }
 
-uint32_t Mle::GetTimeout(void) const
-{
-    return mTimeout;
-}
-
 ThreadError Mle::SetTimeout(uint32_t aTimeout)
 {
     VerifyOrExit(mTimeout != aTimeout, ;);
@@ -618,11 +608,6 @@ ThreadError Mle::SetTimeout(uint32_t aTimeout)
 
 exit:
     return kThreadError_None;
-}
-
-uint8_t Mle::GetDeviceMode(void) const
-{
-    return mDeviceMode;
 }
 
 ThreadError Mle::SetDeviceMode(uint8_t aDeviceMode)
@@ -890,11 +875,6 @@ void Mle::SetAssignLinkQuality(const Mac::ExtAddress aMacAddr, uint8_t aLinkQual
     default:
         break;
     }
-}
-
-uint8_t Mle::GetRouterSelectionJitter(void) const
-{
-    return mRouterSelectionJitter;
 }
 
 ThreadError Mle::SetRouterSelectionJitter(uint8_t aRouterJitter)
@@ -3181,12 +3161,6 @@ Neighbor *Mle::GetNeighbor(const Mac::Address &aAddress)
     }
 
     return neighbor;
-}
-
-Neighbor *Mle::GetNeighbor(const Ip6::Address &aAddress)
-{
-    (void)aAddress;
-    return NULL;
 }
 
 uint16_t Mle::GetNextHop(uint16_t aDestination) const

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -466,7 +466,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
     /**
      * This method enables MLE.
@@ -614,7 +614,7 @@ public:
      * @returns The current Thread interface state.
      *
      */
-    DeviceState GetDeviceState(void) const;
+    DeviceState GetDeviceState(void) const { return mDeviceState; }
 
     /**
      * This method returns the Device Mode as reported in the Mode TLV.
@@ -622,7 +622,7 @@ public:
      * @returns The Device Mode as reported in the Mode TLV.
      *
      */
-    uint8_t GetDeviceMode(void) const;
+    uint8_t GetDeviceMode(void) const { return mDeviceMode; }
 
     /**
      * This method sets the Device Mode as reported in the Mode TLV.
@@ -709,7 +709,7 @@ public:
      * @returns The MLE Timeout value.
      *
      */
-    uint32_t GetTimeout(void) const;
+    uint32_t GetTimeout(void) const { return mTimeout; }
 
     /**
      * This method sets the MLE Timeout value.
@@ -827,7 +827,7 @@ public:
      * @returns The ROUTER_SELECTION_JITTER value.
      *
      */
-    uint8_t GetRouterSelectionJitter(void) const;
+    uint8_t GetRouterSelectionJitter(void) const { return mRouterSelectionJitter; }
 
     /**
      * This method sets the ROUTER_SELECTION_JITTER value.
@@ -1195,7 +1195,7 @@ protected:
      * @returns A pointer to the neighbor object.
      *
      */
-    Neighbor *GetNeighbor(const Ip6::Address &aAddress);
+    Neighbor *GetNeighbor(const Ip6::Address &aAddress) { (void)aAddress; return NULL; }
 
     /**
      * This method returns the next hop towards an RLOC16 destination.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -456,36 +456,6 @@ ThreadError MleRouter::SetStateLeader(uint16_t aRloc16)
     return kThreadError_None;
 }
 
-uint8_t MleRouter::GetNetworkIdTimeout(void) const
-{
-    return mNetworkIdTimeout;
-}
-
-void MleRouter::SetNetworkIdTimeout(uint8_t aTimeout)
-{
-    mNetworkIdTimeout = aTimeout;
-}
-
-uint8_t MleRouter::GetRouterUpgradeThreshold(void) const
-{
-    return mRouterUpgradeThreshold;
-}
-
-void MleRouter::SetRouterUpgradeThreshold(uint8_t aThreshold)
-{
-    mRouterUpgradeThreshold = aThreshold;
-}
-
-uint8_t MleRouter::GetRouterDowngradeThreshold(void) const
-{
-    return mRouterDowngradeThreshold;
-}
-
-void MleRouter::SetRouterDowngradeThreshold(uint8_t aThreshold)
-{
-    mRouterDowngradeThreshold = aThreshold;
-}
-
 bool MleRouter::HandleAdvertiseTimer(void *aContext)
 {
     MleRouter *obj = static_cast<MleRouter *>(aContext);
@@ -3276,31 +3246,6 @@ exit:
     return rval;
 }
 
-uint8_t MleRouter::GetRouterIdSequence(void) const
-{
-    return mRouterIdSequence;
-}
-
-uint8_t MleRouter::GetLeaderWeight(void) const
-{
-    return mLeaderWeight;
-}
-
-void MleRouter::SetLeaderWeight(uint8_t aWeight)
-{
-    mLeaderWeight = aWeight;
-}
-
-uint32_t MleRouter::GetLeaderPartitionId(void) const
-{
-    return mFixedLeaderPartitionId;
-}
-
-void MleRouter::SetLeaderPartitionId(uint32_t aPartitionId)
-{
-    mFixedLeaderPartitionId = aPartitionId;
-}
-
 ThreadError MleRouter::SetPreferredRouterId(uint8_t aRouterId)
 {
     ThreadError error = kThreadError_None;
@@ -3314,16 +3259,6 @@ ThreadError MleRouter::SetPreferredRouterId(uint8_t aRouterId)
 
 exit:
     return error;
-}
-
-void MleRouter::SetPreviousPartitionId(uint32_t aPartitionId)
-{
-    mPreviousPartitionId = aPartitionId;
-}
-
-uint32_t MleRouter::GetPreviousPartitionId(void) const
-{
-    return mPreviousPartitionId;
 }
 
 void MleRouter::SetRouterId(uint8_t aRouterId)

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -154,7 +154,7 @@ public:
      * @returns The Leader Weighting value for this Thread interface.
      *
      */
-    uint8_t GetLeaderWeight(void) const;
+    uint8_t GetLeaderWeight(void) const { return mLeaderWeight; }
 
     /**
      * This method sets the Leader Weighting value for this Thread interface.
@@ -162,7 +162,7 @@ public:
      * @param[in]  aWeight  The Leader Weighting value.
      *
      */
-    void SetLeaderWeight(uint8_t aWeight);
+    void SetLeaderWeight(uint8_t aWeight) { mLeaderWeight = aWeight; }
 
     /**
      * This method returns the fixed Partition Id of Thread network partition for certification testing.
@@ -170,7 +170,7 @@ public:
      * @returns The Partition Id for this Thread network partition.
      *
      */
-    uint32_t GetLeaderPartitionId(void) const;
+    uint32_t GetLeaderPartitionId(void) const { return mFixedLeaderPartitionId; }
 
     /**
      * This method sets the fixed Partition Id for Thread network partition for certification testing.
@@ -178,7 +178,7 @@ public:
      * @param[in]  aPartitionId  The Leader Partition Id.
      *
      */
-    void SetLeaderPartitionId(uint32_t aPartitionId);
+    void SetLeaderPartitionId(uint32_t aPartitionId) { mFixedLeaderPartitionId = aPartitionId; }
 
     /**
      * This method sets the preferred Router Id. Upon becoming a router/leader the node
@@ -198,7 +198,7 @@ public:
      * This method gets the Partition Id which the device joined successfully once.
      *
      */
-    uint32_t GetPreviousPartitionId(void) const;
+    uint32_t GetPreviousPartitionId(void) const { return mPreviousPartitionId; }
 
     /**
      * This method sets the Partition Id which the device joins successfully.
@@ -206,7 +206,7 @@ public:
      * @param[in]  aPartitionId   The Partition Id.
      *
      */
-    void SetPreviousPartitionId(uint32_t aPartitionId);
+    void SetPreviousPartitionId(uint32_t aPartitionId) { mPreviousPartitionId = aPartitionId; }
 
     /**
      * This method sets the Router Id.
@@ -232,7 +232,7 @@ public:
      * @returns The NETWORK_ID_TIMEOUT value.
      *
      */
-    uint8_t GetNetworkIdTimeout(void) const;
+    uint8_t GetNetworkIdTimeout(void) const { return mNetworkIdTimeout; }
 
     /**
      * This method sets the NETWORK_ID_TIMEOUT value.
@@ -240,7 +240,7 @@ public:
      * @param[in]  aTimeout  The NETWORK_ID_TIMEOUT value.
      *
      */
-    void SetNetworkIdTimeout(uint8_t aTimeout);
+    void SetNetworkIdTimeout(uint8_t aTimeout) { mNetworkIdTimeout = aTimeout; }
 
     /**
      * This method returns the route cost to a RLOC16.
@@ -268,7 +268,7 @@ public:
      * @returns The current Router ID Sequence value.
      *
      */
-    uint8_t GetRouterIdSequence(void) const;
+    uint8_t GetRouterIdSequence(void) const { return mRouterIdSequence; }
 
     /**
      * This method returns the ROUTER_UPGRADE_THRESHOLD value.
@@ -276,7 +276,7 @@ public:
      * @returns The ROUTER_UPGRADE_THRESHOLD value.
      *
      */
-    uint8_t GetRouterUpgradeThreshold(void) const;
+    uint8_t GetRouterUpgradeThreshold(void) const { return mRouterUpgradeThreshold; }
 
     /**
      * This method sets the ROUTER_UPGRADE_THRESHOLD value.
@@ -284,7 +284,7 @@ public:
      * @returns The ROUTER_UPGRADE_THRESHOLD value.
      *
      */
-    void SetRouterUpgradeThreshold(uint8_t aThreshold);
+    void SetRouterUpgradeThreshold(uint8_t aThreshold) { mRouterUpgradeThreshold = aThreshold; }
 
     /**
      * This method returns the ROUTER_DOWNGRADE_THRESHOLD value.
@@ -292,7 +292,7 @@ public:
      * @returns The ROUTER_DOWNGRADE_THRESHOLD value.
      *
      */
-    uint8_t GetRouterDowngradeThreshold(void) const;
+    uint8_t GetRouterDowngradeThreshold(void) const { return mRouterDowngradeThreshold; }
 
     /**
      * This method sets the ROUTER_DOWNGRADE_THRESHOLD value.
@@ -300,7 +300,7 @@ public:
      * @returns The ROUTER_DOWNGRADE_THRESHOLD value.
      *
      */
-    void SetRouterDowngradeThreshold(uint8_t aThreshold);
+    void SetRouterDowngradeThreshold(uint8_t aThreshold) { mRouterDowngradeThreshold = aThreshold; }
 
     /**
      * This method release a given Router ID.

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -57,7 +57,7 @@ NetworkData::NetworkData(ThreadNetif &aThreadNetif, bool aLocal):
     mLength = 0;
 }
 
-otInstance *NetworkData::GetInstance()
+otInstance *NetworkData::GetInstance(void)
 {
     return mNetif.GetInstance();
 }

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -106,7 +106,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
     /**
      * This method clears the network data.

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -69,16 +69,6 @@ void LeaderBase::Reset(void)
     mNetif.SetStateChangedFlags(OT_THREAD_NETDATA_UPDATED);
 }
 
-uint8_t LeaderBase::GetVersion(void) const
-{
-    return mVersion;
-}
-
-uint8_t LeaderBase::GetStableVersion(void) const
-{
-    return mStableVersion;
-}
-
 ThreadError LeaderBase::GetContext(const Ip6::Address &aAddress, Lowpan::Context &aContext)
 {
     PrefixTlv *prefix;

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -85,7 +85,7 @@ public:
      * @returns The Thread Network Data version.
      *
      */
-    uint8_t GetVersion(void) const;
+    uint8_t GetVersion(void) const { return mVersion; }
 
     /**
      * This method returns the Thread Network Data stable version.
@@ -93,7 +93,7 @@ public:
      * @returns The Thread Network Data stable version.
      *
      */
-    uint8_t GetStableVersion(void) const;
+    uint8_t GetStableVersion(void) const { return mStableVersion; }
 
     /**
      * This method retrieves the 6LoWPAN Context information based on a given IPv6 address.

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -71,7 +71,7 @@ NetworkDiagnostic::NetworkDiagnostic(ThreadNetif &aThreadNetif) :
     mNetif.GetCoapServer().AddResource(mDiagnosticReset);
 }
 
-otInstance *NetworkDiagnostic::GetInstance()
+otInstance *NetworkDiagnostic::GetInstance(void)
 {
     return mNetif.GetInstance();
 }

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -1,3 +1,4 @@
+
 /*
  *  Copyright (c) 2016, The OpenThread Authors.
  *  All rights reserved.
@@ -146,11 +147,6 @@ ThreadError ThreadNetif::Down(void)
     return kThreadError_None;
 }
 
-bool ThreadNetif::IsUp(void) const
-{
-    return mIsUp;
-}
-
 ThreadError ThreadNetif::GetLinkAddress(Ip6::LinkAddress &address) const
 {
     address.mType = Ip6::LinkAddress::kEui64;
@@ -175,12 +171,7 @@ exit:
     return error;
 }
 
-ThreadError ThreadNetif::SendMessage(Message &message)
-{
-    return mMeshForwarder.SendMessage(message);
-}
-
-otInstance *ThreadNetif::GetInstance()
+otInstance *ThreadNetif::GetInstance(void)
 {
     return otInstanceFromThreadNetif(this);
 }

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -124,7 +124,7 @@ public:
      * @retval FALSE  If the Thread network interface is not enabled.
      *
      */
-    bool IsUp(void) const;
+    bool IsUp(void) const { return mIsUp; }
 
     /**
      * This method retrieves the link address.
@@ -142,7 +142,7 @@ public:
      * @retval kThreadError_None  Successfully submitted the message to the interface.
      *
      */
-    ThreadError SendMessage(Message &aMessage);
+    ThreadError SendMessage(Message &aMessage) { return mMeshForwarder.SendMessage(aMessage); }
 
     /**
      * This method performs a route lookup.
@@ -325,7 +325,7 @@ public:
      * @returns The pointer to the parent otInstance structure.
      *
      */
-    otInstance *GetInstance();
+    otInstance *GetInstance(void);
 
 private:
     Coap::Server mCoapServer;
@@ -376,7 +376,6 @@ private:
     AnnounceBeginServer mAnnounceBegin;
     PanIdQueryServer mPanIdQuery;
     EnergyScanServer mEnergyScan;
-
 };
 
 /**


### PR DESCRIPTION
This commit moves the implementation of simple methods (e.g., getters,
and setters) across different classes in OpenThread to the corresponding
class header file to help with complier inline optimization.