### PR TITLE
`Ncp`: Simplify handling of NCP instance object from callbacks and C APIs

### DIFF
--- a/src/ncp/hdlc.hpp
+++ b/src/ncp/hdlc.hpp
@@ -190,7 +190,8 @@ public:
      * @param[in]  aContext       A pointer to arbitrary context information.
      *
      */
-    Decoder(uint8_t *aOutBuf, uint16_t aOutLength, FrameHandler aFrameHandler, ErrorHandler aErrorHandler, void *aContext);
+    Decoder(uint8_t *aOutBuf, uint16_t aOutLength, FrameHandler aFrameHandler, ErrorHandler aErrorHandler,
+            void *aContext);
 
     /**
      * This method streams bytes into the decoder.

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -64,8 +64,6 @@
 namespace Thread
 {
 
-static NcpBase *sNcpContext = NULL;
-
 #define NCP_INVALID_SCAN_CHANNEL              (-1)
 #define NCP_PLAT_RESET_REASON                 (1U<<31)
 #define NCP_ON_MESH_NETS_CHANGED_BIT_FLAG     (1U<<30)
@@ -511,6 +509,8 @@ static uint8_t BorderRouterConfigToFlagByte(const otBorderRouterConfig &config)
 // MARK: Class Boilerplate
 // ----------------------------------------------------------------------------
 
+NcpBase *NcpBase::sNcpInstance = NULL;
+
 NcpBase::NcpBase(otInstance *aInstance):
     mInstance(aInstance),
     mTxFrameBuffer(mTxBuffer, sizeof(mTxBuffer)),
@@ -550,7 +550,7 @@ NcpBase::NcpBase(otInstance *aInstance):
 {
     assert(mInstance != NULL);
 
-    sNcpContext = this;
+    sNcpInstance = this;
 
     otSetStateChangedCallback(mInstance, &NcpBase::HandleNetifStateChanged, this);
     otIp6SetReceiveCallback(mInstance, &NcpBase::HandleDatagramFromStack, this);
@@ -565,6 +565,11 @@ NcpBase::NcpBase(otInstance *aInstance):
     mLegacyHandlers = NULL;
     memset(mLegacyUlaPrefix, 0, sizeof(mLegacyUlaPrefix));
 #endif
+}
+
+NcpBase *NcpBase::GetNcpInstance(void)
+{
+    return sNcpInstance;
 }
 
 // ----------------------------------------------------------------------------
@@ -846,7 +851,7 @@ void NcpBase::HandleEnergyScanResult(otEnergyScanResult *aResult)
 
 void NcpBase::LinkRawReceiveDone(otInstance *, RadioPacket *aPacket, ThreadError aError)
 {
-    sNcpContext->LinkRawReceiveDone(aPacket, aError);
+    sNcpInstance->LinkRawReceiveDone(aPacket, aError);
 }
 
 void NcpBase::LinkRawReceiveDone(RadioPacket *aPacket, ThreadError aError)
@@ -913,7 +918,7 @@ exit:
 
 void NcpBase::LinkRawTransmitDone(otInstance *, RadioPacket *aPacket, bool aFramePending, ThreadError aError)
 {
-    sNcpContext->LinkRawTransmitDone(aPacket, aFramePending, aError);
+    sNcpInstance->LinkRawTransmitDone(aPacket, aFramePending, aError);
 }
 
 void NcpBase::LinkRawTransmitDone(RadioPacket *, bool aFramePending, ThreadError aError)
@@ -936,7 +941,7 @@ void NcpBase::LinkRawTransmitDone(RadioPacket *, bool aFramePending, ThreadError
 
 void NcpBase::LinkRawEnergyScanDone(otInstance *, int8_t aEnergyScanMaxRssi)
 {
-    sNcpContext->LinkRawEnergyScanDone(aEnergyScanMaxRssi);
+    sNcpInstance->LinkRawEnergyScanDone(aEnergyScanMaxRssi);
 }
 
 void NcpBase::LinkRawEnergyScanDone(int8_t aEnergyScanMaxRssi)
@@ -6646,10 +6651,11 @@ ThreadError NcpBase::StreamWrite(int aStreamId, const uint8_t *aDataPtr, int aDa
 ThreadError otNcpStreamWrite(int aStreamId, const uint8_t* aDataPtr, int aDataLen)
 {
     ThreadError errorCode  = kThreadError_InvalidState;
+    Thread::NcpBase *ncp = Thread::NcpBase::GetNcpInstance();
 
-    if (Thread::sNcpContext)
+    if (ncp != NULL)
     {
-        errorCode = Thread::sNcpContext->StreamWrite(aStreamId, aDataPtr, aDataLen);
+        errorCode = ncp->StreamWrite(aStreamId, aDataPtr, aDataLen);
     }
 
     return errorCode;
@@ -6662,7 +6668,12 @@ ThreadError otNcpStreamWrite(int aStreamId, const uint8_t* aDataPtr, int aDataLe
 void otNcpRegisterLegacyHandlers(const otNcpLegacyHandlers *aHandlers)
 {
 #if OPENTHREAD_ENABLE_LEGACY
-    Thread::sNcpContext->RegisterLegacyHandlers(aHandlers);
+    Thread::NcpBase *ncp = Thread::NcpBase::GetNcpInstance();
+
+    if (ncp != NULL)
+    {
+        ncp->RegisterLegacyHandlers(aHandlers);
+    }
 #else
     (void)aHandlers;
 #endif
@@ -6671,7 +6682,12 @@ void otNcpRegisterLegacyHandlers(const otNcpLegacyHandlers *aHandlers)
 void otNcpHandleDidReceiveNewLegacyUlaPrefix(const uint8_t *aUlaPrefix)
 {
 #if OPENTHREAD_ENABLE_LEGACY
-    Thread::sNcpContext->HandleDidReceiveNewLegacyUlaPrefix(aUlaPrefix);
+    Thread::NcpBase *ncp = Thread::NcpBase::GetNcpInstance();
+
+    if (ncp != NULL)
+    {
+        ncp->HandleDidReceiveNewLegacyUlaPrefix(aUlaPrefix);
+    }
 #else
     (void)aUlaPrefix;
 #endif
@@ -6680,7 +6696,12 @@ void otNcpHandleDidReceiveNewLegacyUlaPrefix(const uint8_t *aUlaPrefix)
 void otNcpHandleLegacyNodeDidJoin(const otExtAddress *aExtAddr)
 {
 #if OPENTHREAD_ENABLE_LEGACY
-    Thread::sNcpContext->HandleLegacyNodeDidJoin(aExtAddr);
+    Thread::NcpBase *ncp = Thread::NcpBase::GetNcpInstance();
+
+    if (ncp != NULL)
+    {
+        ncp->HandleLegacyNodeDidJoin(aExtAddr);
+    }
 #else
     (void)aExtAddr;
 #endif

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -63,10 +63,13 @@ public:
      */
     NcpBase(otInstance *aInstance);
 
-protected:
-
-    // The pointer to the OpenThread instance
-    otInstance* mInstance;
+    /**
+     * This static method returns the pointer to the single NCP instance.
+     *
+     @returns Pointer to the single NCP instance.
+     *
+     */
+    static NcpBase *GetNcpInstance(void);
 
 protected:
 
@@ -593,6 +596,8 @@ public:
 #endif
 
 protected:
+    static NcpBase *sNcpInstance;
+    otInstance* mInstance;
     NcpFrameBuffer  mTxFrameBuffer;
 
 private:
@@ -602,17 +607,11 @@ private:
     };
 
     spinel_status_t mLastStatus;
-
     uint32_t mSupportedChannelMask;
-
     uint32_t mChannelMask;
-
     uint16_t mScanPeriod;
-
     Tasklet mUpdateChangedPropsTask;
-
     uint32_t mChangedFlags;
-
     bool mShouldSignalEndOfScan;
 
 #if OPENTHREAD_ENABLE_JAM_DETECTION
@@ -620,11 +619,8 @@ private:
 #endif
 
     spinel_tid_t mDroppedReplyTid;
-
     uint16_t mDroppedReplyTidBitSet;
-
     spinel_tid_t mNextExpectedTid;
-
     uint8_t mTxBuffer[kTxBufferSize];
 
     bool mAllowLocalNetworkDataChange;

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -35,6 +35,7 @@
 
 #include <common/code_utils.hpp>
 #include <common/new.hpp>
+#include <common/debug.hpp>
 #include <net/ip6.hpp>
 #include <ncp/ncp_spi.hpp>
 #include <core/openthread-core-config.h>
@@ -48,11 +49,17 @@
 namespace Thread {
 
 static otDEFINE_ALIGNED_VAR(sNcpRaw, sizeof(NcpSpi), uint64_t);
-static NcpSpi *sNcpSpi;
 
 extern "C" void otNcpInit(otInstance *aInstance)
 {
-    sNcpSpi = new(&sNcpRaw) NcpSpi(aInstance);
+    NcpSpi *ncpSpi = NULL;
+
+    ncpSpi = new(&sNcpRaw) NcpSpi(aInstance);
+
+    if (ncpSpi == NULL || ncpSpi != NcpBase::GetNcpInstance())
+    {
+        assert(false);
+    }
 }
 
 static void spi_header_set_flag_byte(uint8_t *header, uint8_t value)
@@ -234,10 +241,9 @@ NcpSpi::SpiTransactionComplete(
 
 void NcpSpi::TxFrameBufferHasData(void *aContext, NcpFrameBuffer *aNcpFrameBuffer)
 {
-    (void)aContext;
     (void)aNcpFrameBuffer;
 
-    sNcpSpi->TxFrameBufferHasData();
+    static_cast<NcpSpi *>(aContext)->TxFrameBufferHasData();
 }
 
 void NcpSpi::TxFrameBufferHasData(void)

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -43,6 +43,7 @@
 #include <stdio.h>
 #include <common/code_utils.hpp>
 #include <common/new.hpp>
+#include <common/debug.hpp>
 #include <net/ip6.hpp>
 #include <ncp/ncp_uart.hpp>
 #include <core/openthread-core-config.h>
@@ -51,11 +52,16 @@
 namespace Thread {
 
 static otDEFINE_ALIGNED_VAR(sNcpRaw, sizeof(NcpUart), uint64_t);
-static NcpUart *sNcpUart;
 
 extern "C" void otNcpInit(otInstance *aInstance)
 {
-    sNcpUart = new(&sNcpRaw) NcpUart(aInstance);
+    NcpUart *ncpUart = NULL;
+    ncpUart = new(&sNcpRaw) NcpUart(aInstance);
+
+    if (ncpUart == NULL || ncpUart != NcpBase::GetNcpInstance())
+    {
+        assert(false);
+    }
 }
 
 NcpUart::UartTxBuffer::UartTxBuffer(void)
@@ -100,10 +106,9 @@ NcpUart::NcpUart(otInstance *aInstance):
 
 void NcpUart::TxFrameBufferHasData(void *aContext, NcpFrameBuffer *aNcpFrameBuffer)
 {
-    (void)aContext;
     (void)aNcpFrameBuffer;
 
-    sNcpUart->TxFrameBufferHasData();
+    static_cast<NcpUart *>(aContext)->TxFrameBufferHasData();
 }
 
 void NcpUart::TxFrameBufferHasData(void)
@@ -177,7 +182,12 @@ exit:
 
 extern "C" void otPlatUartSendDone(void)
 {
-    sNcpUart->HandleUartSendDone();
+    NcpUart *ncpUart = static_cast<NcpUart *>(NcpBase::GetNcpInstance());
+
+    if (ncpUart != NULL)
+    {
+        ncpUart->HandleUartSendDone();
+    }
 }
 
 void NcpUart::HandleUartSendDone(void)
@@ -189,7 +199,12 @@ void NcpUart::HandleUartSendDone(void)
 
 extern "C" void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength)
 {
-    sNcpUart->HandleUartReceiveDone(aBuf, aBufLength);
+    NcpUart *ncpUart = static_cast<NcpUart *>(NcpBase::GetNcpInstance());
+
+    if (ncpUart != NULL)
+    {
+        ncpUart->HandleUartReceiveDone(aBuf, aBufLength);
+    }
 }
 
 void NcpUart::HandleUartReceiveDone(const uint8_t *aBuf, uint16_t aBufLength)
@@ -197,10 +212,9 @@ void NcpUart::HandleUartReceiveDone(const uint8_t *aBuf, uint16_t aBufLength)
     mFrameDecoder.Decode(aBuf, aBufLength);
 }
 
-void NcpUart::HandleFrame(void *context, uint8_t *aBuf, uint16_t aBufLength)
+void NcpUart::HandleFrame(void *aContext, uint8_t *aBuf, uint16_t aBufLength)
 {
-    sNcpUart->HandleFrame(aBuf, aBufLength);
-    (void)context;
+    static_cast<NcpUart *>(aContext)->HandleFrame(aBuf, aBufLength);
 }
 
 void NcpUart::HandleFrame(uint8_t *aBuf, uint16_t aBufLength)
@@ -208,10 +222,9 @@ void NcpUart::HandleFrame(uint8_t *aBuf, uint16_t aBufLength)
     super_t::HandleReceive(aBuf, aBufLength);
 }
 
-void NcpUart::HandleError(void *context, ThreadError aError, uint8_t *aBuf, uint16_t aBufLength)
+void NcpUart::HandleError(void *aContext, ThreadError aError, uint8_t *aBuf, uint16_t aBufLength)
 {
-    sNcpUart->HandleError(aError, aBuf, aBufLength);
-    (void)context;
+    static_cast<NcpUart *>(aContext)->HandleError(aError, aBuf, aBufLength);
 }
 
 void NcpUart::HandleError(ThreadError aError, uint8_t *aBuf, uint16_t aBufLength)


### PR DESCRIPTION
This commit makes the following changes:

- It adds a static class member variable `sNcpInstance` and a static
  getter method `GetNcpInstance()` to `NcpBase` class.

- It updates `NcpBase` and its sub-classes `NcpUart` and `NcpSpi` to
  use the new method from the callbacks and C APIs (combining/replacing
  3 separate static variables tracking the NCP instance).