### PR TITLE
Always build platform-utils library

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -41,9 +41,12 @@ EXTRA_DIST                              = \
 
 # Always build (e.g. for 'make all') these subdirectories.
 
-if OPENTHREAD_EXAMPLES
 SUBDIRS                                 = \
     platforms                             \
+    $(NULL)
+    
+if OPENTHREAD_EXAMPLES
+SUBDIRS                                += \
     apps                                  \
     $(NULL)
 endif


### PR DESCRIPTION
This PR solves #1410 behavior, so that platform-utils library
is always built. This allows for using open tread in environments which
keep platform files out of openthread tree.