### PR TITLE
Pass packet to host and keep Hop Limit unchanged

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -643,6 +643,7 @@ ThreadError Ip6::HandleDatagram(Message &message, Netif *netif, int8_t interface
     bool multicastPromiscuous = false;
     uint8_t nextHeader;
     uint8_t hopLimit;
+    int8_t forwardInterfaceId;
 
     otLogFuncEntry();
 
@@ -748,6 +749,19 @@ ThreadError Ip6::HandleDatagram(Message &message, Netif *netif, int8_t interface
 
     if (forward)
     {
+        forwardInterfaceId = FindForwardInterfaceId(messageInfo);
+
+        if (forwardInterfaceId == 0)
+        {
+            // try passing to host
+            SuccessOrExit(error = ProcessReceiveCallback(message, messageInfo, nextHeader));
+
+            // the caller transfers custody in the success case, so free the message here
+            message.Free();
+
+            ExitNow();
+        }
+
         if (netif != NULL)
         {
             header.SetHopLimit(header.GetHopLimit() - 1);
@@ -762,7 +776,10 @@ ThreadError Ip6::HandleDatagram(Message &message, Netif *netif, int8_t interface
         {
             hopLimit = header.GetHopLimit();
             message.Write(Header::GetHopLimitOffset(), Header::GetHopLimitSize(), &hopLimit);
-            SuccessOrExit(error = ForwardMessage(message, messageInfo, nextHeader));
+
+            // submit message to interface
+            VerifyOrExit((netif = GetNetifById(forwardInterfaceId)) != NULL, error = kThreadError_NoRoute);
+            SuccessOrExit(error = netif->SendMessage(message));
         }
     }
 
@@ -777,11 +794,9 @@ exit:
     return error;
 }
 
-ThreadError Ip6::ForwardMessage(Message &message, MessageInfo &messageInfo, uint8_t ipproto)
+int8_t Ip6::FindForwardInterfaceId(const MessageInfo &messageInfo)
 {
-    ThreadError error = kThreadError_None;
     int8_t interfaceId;
-    Netif *netif;
 
     otLogFuncEntry();
 
@@ -807,35 +822,12 @@ ThreadError Ip6::ForwardMessage(Message &message, MessageInfo &messageInfo, uint
     }
     else
     {
-        // try passing to host
-        error = ProcessReceiveCallback(message, messageInfo, ipproto);
-
-        switch (error)
-        {
-        case kThreadError_None:
-            // the caller transfers custody in the success case, so free the message here
-            message.Free();
-            break;
-
-        case kThreadError_NoRoute:
-            otDumpDebgIp6(GetInstance(), "no route", &messageInfo.GetSockAddr(), 16);
-            break;
-
-        default:
-            break;
-        }
-
-        ExitNow();
+        interfaceId = 0;
     }
 
-    // submit message to interface
-    VerifyOrExit((netif = GetNetifById(interfaceId)) != NULL, error = kThreadError_NoRoute);
-    SuccessOrExit(error = netif->SendMessage(message));
+    otLogFuncExit();
 
-exit:
-
-    otLogFuncExitErr(error);
-    return error;
+    return interfaceId;
 }
 
 ThreadError Ip6::AddNetif(Netif &aNetif)

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -378,7 +378,7 @@ private:
     ThreadError RemoveMplOption(Message &aMessage);
     ThreadError HandleOptions(Message &message, Header &header, bool &forward);
     ThreadError HandlePayload(Message &message, MessageInfo &messageInfo, uint8_t ipproto);
-    ThreadError ForwardMessage(Message &message, MessageInfo &messageInfo, uint8_t ipproto);
+    int8_t FindForwardInterfaceId(const MessageInfo &messageInfo);
 
     bool mForwardingEnabled;
 


### PR DESCRIPTION
Since NCP and Host are single node in terms of network, this PR keeps the Hop Limit  unchanged when "forwarding" to Host side.