### PR TITLE
Assert otPlatUartSend errors in NcpUart

### DIFF
--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -176,7 +176,10 @@ exit:
 
     if (len > 0)
     {
-        otPlatUartSend(mUartBuffer.GetBuffer(), len);
+        if (otPlatUartSend(mUartBuffer.GetBuffer(), len) != kThreadError_None)
+        {
+            assert(false);
+        }
     }
 }
 


### PR DESCRIPTION
When otPlatUartSend returns an error, it shall not call otPlatUartSendDone, so the mUartBuffer in NcpUart remains non-empty and the whole NCPUart outgoing communication stalls. This PR fixes the issue by clearing the outgoing buffer if sending fails.