### PR TITLE
CCA Failure count when using radio CSMA support

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -858,14 +858,17 @@ void Mac::TransmitDoneTask(RadioPacket *aPacket, bool aRxPending, ThreadError aE
         mCounters.mTxErrAbort++;
     }
 
+    if (aError == kThreadError_ChannelAccessFailure)
+    {
+        mCounters.mTxErrCca++;
+    }
+
     if (!RadioSupportsCsmaBackoff() &&
         aError == kThreadError_ChannelAccessFailure &&
         mCsmaAttempts < kMaxCSMABackoffs)
     {
         mCsmaAttempts++;
         StartCsmaBackoff();
-
-        mCounters.mTxErrCca++;
 
         ExitNow();
     }


### PR DESCRIPTION
Moved the cca error counter so that it will count even when using radio csma rather then OT csma