### PR TITLE
Skip performing "make pretty" on copied `strlcpy.c` and `strlcat.c`

### DIFF
--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -96,6 +96,19 @@ SOURCES_COMMON                      = \
     utils/slaac_address.cpp           \
     $(NULL)
 
+SOURCES_FTD                         = \
+    meshcop/dataset_manager_ftd.cpp   \
+    meshcop/joiner_router.cpp         \
+    meshcop/leader.cpp                \
+    thread/address_resolver.cpp       \
+    thread/mle_router.cpp             \
+    thread/network_data_leader_ftd.cpp \
+    thread/network_data_local.cpp     \
+    $(NULL)
+
+SOURCES_MISSING                     = \
+    $(NULL)
+
 if MISSING_STRLCPY
 ###############################################################
 # You'll see something similar to the next four lines in all
@@ -118,7 +131,7 @@ strlcpy.c: $(top_srcdir)/src/missing/strlcpy/strlcpy.c
 	$(AM_V_GEN)cp $< $@
 .INTERMEDIATE: strlcpy.c
 CPPFLAGS_COMMON += -I$(top_srcdir)/src/missing/strlcpy
-SOURCES_COMMON += strlcpy.c
+SOURCES_MISSING += strlcpy.c
 endif
 
 if MISSING_STRLCAT
@@ -127,7 +140,7 @@ strlcat.c: $(top_srcdir)/src/missing/strlcat/strlcat.c
 	$(AM_V_GEN)cp $< $@
 .INTERMEDIATE: strlcat.c
 CPPFLAGS_COMMON += -I$(top_srcdir)/src/missing/strlcat
-SOURCES_COMMON += strlcat.c
+SOURCES_MISSING += strlcat.c
 endif
 
 if OPENTHREAD_ENABLE_APPLICATION_COAP
@@ -214,13 +227,8 @@ libopenthread_ftd_a_CPPFLAGS        = \
 
 libopenthread_ftd_a_SOURCES         = \
     $(SOURCES_COMMON)                 \
-    meshcop/dataset_manager_ftd.cpp   \
-    meshcop/joiner_router.cpp         \
-    meshcop/leader.cpp                \
-    thread/address_resolver.cpp       \
-    thread/mle_router.cpp             \
-    thread/network_data_leader_ftd.cpp \
-    thread/network_data_local.cpp     \
+    $(SOURCES_FTD)                    \
+    $(SOURCES_MISSING)                \
     $(NULL)
 endif # OPENTHREAD_ENABLE_FTD
 
@@ -235,6 +243,7 @@ libopenthread_mtd_a_CPPFLAGS        = \
 
 libopenthread_mtd_a_SOURCES         = \
     $(SOURCES_COMMON)                 \
+    $(SOURCES_MISSING)                \
     $(NULL)
 
 noinst_HEADERS                      = \
@@ -341,6 +350,11 @@ noinst_HEADERS                      = \
     thread/topology.hpp               \
     utils/slaac_address.hpp           \
     utils/jam_detector.hpp            \
+    $(NULL)
+
+PRETTY_FILES                        = \
+    $(SOURCES_COMMON)                 \
+    $(SOURCES_FTD)                    \
     $(NULL)
 
 if OPENTHREAD_BUILD_COVERAGE


### PR DESCRIPTION
This would help when we go to uncrustify...
(astyles ignored any missing files during "make pretty", but uncrustify fails if a file is missing)...