### PR TITLE
Update travis script "pretty-check" to add more config features

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -37,7 +37,7 @@ set -x
 [ $BUILD_TARGET != pretty-check ] || {
     export PATH=/tmp/astyle/build/gcc/bin:$PATH || die
     ./bootstrap || die
-    ./configure --enable-ftd --enable-cli --enable-diag --enable-dhcp6-client --enable-dhcp6-server --enable-dns-client --enable-commissioner --enable-joiner --with-examples=posix || die
+    ./configure --enable-ftd --enable-cli --enable-ncp --enable-diag --enable-dhcp6-client --enable-dhcp6-server --enable-dns-client --enable-commissioner --enable-joiner --enable-jam-detection --enable-raw-link-api --with-examples=posix || die
     make pretty-check || die
 }
 


### PR DESCRIPTION
This commit adds the following to the `configure` options under
"pretty-check" build in travis script:
 - `enable-ncp`,
 - `enable-jam-detection`,
 - `enable-raw-link-api`.

 This ensures that source files for these features are included in
 the travis "pretty-check" build.