### PR TITLE
Separate response support

### DIFF
--- a/src/core/coap/coap_base.cpp
+++ b/src/core/coap/coap_base.cpp
@@ -86,5 +86,31 @@ void CoapBase::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMes
                                                  *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
+ThreadError CoapBase::SendEmptyMessage(Header::Type aType, const Header &aRequestHeader,
+                                       const Ip6::MessageInfo &aMessageInfo)
+{
+    ThreadError error = kThreadError_None;
+    Coap::Header responseHeader;
+    Message *message = NULL;
+
+    VerifyOrExit(aRequestHeader.GetType() == kCoapTypeConfirmable, error = kThreadError_InvalidArgs);
+
+    responseHeader.Init(aType, kCoapCodeEmpty);
+    responseHeader.SetMessageId(aRequestHeader.GetMessageId());
+
+    VerifyOrExit((message = NewMessage(responseHeader)) != NULL, error = kThreadError_NoBufs);
+
+    SuccessOrExit(error = mSender(this, *message, aMessageInfo));
+
+exit:
+
+    if (error != kThreadError_None && message != NULL)
+    {
+        message->Free();
+    }
+
+    return error;
+}
+
 }  // namespace Coap
 }  // namespace Thread

--- a/src/core/coap/coap_base.hpp
+++ b/src/core/coap/coap_base.hpp
@@ -152,6 +152,51 @@ public:
      */
     uint16_t GetPort(void) { return mSocket.GetSockName().mPort; };
 
+    /**
+     * This method sends a CoAP empty message.
+     *
+     * @param[in]  aType           The message type
+     * @param[in]  aRequestHeader  A reference to the CoAP Header that was used in CoAP request.
+     * @param[in]  aMessageInfo    The message info corresponding to the CoAP request.
+     *
+     * @retval kThreadError_None         Successfully enqueued the CoAP response message.
+     * @retval kThreadError_NoBufs       Insufficient buffers available to send the CoAP response.
+     * @retval kThreadError_InvalidArgs  The @p aRequestHeader header is not of confirmable type.
+     *
+     */
+    ThreadError SendEmptyMessage(Header::Type aType, const Header &aRequestHeader,
+                                 const Ip6::MessageInfo &aMessageInfo);
+
+    /**
+     * This method sends a CoAP reset message.
+     *
+     * @param[in]  aRequestHeader  A reference to the CoAP Header that was used in CoAP request.
+     * @param[in]  aMessageInfo    The message info corresponding to the CoAP request.
+     *
+     * @retval kThreadError_None         Successfully enqueued the CoAP response message.
+     * @retval kThreadError_NoBufs       Insufficient buffers available to send the CoAP response.
+     * @retval kThreadError_InvalidArgs  The @p aRequestHeader header is not of confirmable type.
+     *
+     */
+    ThreadError SendReset(Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo) {
+        return SendEmptyMessage(kCoapTypeReset, aRequestHeader, aMessageInfo);
+    };
+
+    /**
+     * This method sends a CoAP ACK empty message which is used in Separate Response for confirmable requests.
+     *
+     * @param[in]  aRequestHeader  A reference to the CoAP Header that was used in CoAP request.
+     * @param[in]  aMessageInfo    The message info corresponding to the CoAP request.
+     *
+     * @retval kThreadError_None         Successfully enqueued the CoAP response message.
+     * @retval kThreadError_NoBufs       Insufficient buffers available to send the CoAP response.
+     * @retval kThreadError_InvalidArgs  The @p aRequestHeader header is not of confirmable type.
+     *
+     */
+    ThreadError SendAck(Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo) {
+        return SendEmptyMessage(kCoapTypeAcknowledgment, aRequestHeader, aMessageInfo);
+    };
+
 protected:
     ThreadError Start(const Ip6::SockAddr &aSockAddr);
     ThreadError Stop(void);

--- a/src/core/coap/coap_base.hpp
+++ b/src/core/coap/coap_base.hpp
@@ -153,21 +153,6 @@ public:
     uint16_t GetPort(void) { return mSocket.GetSockName().mPort; };
 
     /**
-     * This method sends a CoAP empty message.
-     *
-     * @param[in]  aType           The message type
-     * @param[in]  aRequestHeader  A reference to the CoAP Header that was used in CoAP request.
-     * @param[in]  aMessageInfo    The message info corresponding to the CoAP request.
-     *
-     * @retval kThreadError_None         Successfully enqueued the CoAP response message.
-     * @retval kThreadError_NoBufs       Insufficient buffers available to send the CoAP response.
-     * @retval kThreadError_InvalidArgs  The @p aRequestHeader header is not of confirmable type.
-     *
-     */
-    ThreadError SendEmptyMessage(Header::Type aType, const Header &aRequestHeader,
-                                 const Ip6::MessageInfo &aMessageInfo);
-
-    /**
      * This method sends a CoAP reset message.
      *
      * @param[in]  aRequestHeader  A reference to the CoAP Header that was used in CoAP request.
@@ -206,6 +191,22 @@ protected:
     ReceiverFunction mReceiver;
 
 private:
+
+    /**
+     * This method sends a CoAP empty message, i.e. a header-only message with code equals kCoapCodeEmpty.
+     *
+     * @param[in]  aType           The message type
+     * @param[in]  aRequestHeader  A reference to the CoAP Header that was used in CoAP request.
+     * @param[in]  aMessageInfo    The message info corresponding to the CoAP request.
+     *
+     * @retval kThreadError_None         Successfully enqueued the CoAP response message.
+     * @retval kThreadError_NoBufs       Insufficient buffers available to send the CoAP response.
+     * @retval kThreadError_InvalidArgs  The @p aRequestHeader header is not of confirmable type.
+     *
+     */
+    ThreadError SendEmptyMessage(Header::Type aType, const Header &aRequestHeader,
+                                 const Ip6::MessageInfo &aMessageInfo);
+
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 };
 

--- a/src/core/coap/coap_client.cpp
+++ b/src/core/coap/coap_client.cpp
@@ -414,11 +414,8 @@ void Client::ProcessReceivedMessage(Message &aMessage, const Ip6::MessageInfo &a
         SendAck(responseHeader, aMessageInfo);
 
     case kCoapTypeNonConfirmable:
-        if (responseHeader.IsResponse() && responseHeader.IsTokenEqual(requestHeader))
-        {
-            // Separate response.
-            FinalizeCoapTransaction(*message, requestMetadata, &responseHeader, &aMessage, &aMessageInfo, kThreadError_None);
-        }
+        // Separate response.
+        FinalizeCoapTransaction(*message, requestMetadata, &responseHeader, &aMessage, &aMessageInfo, kThreadError_None);
 
         break;
     }

--- a/src/core/coap/coap_client.cpp
+++ b/src/core/coap/coap_client.cpp
@@ -413,6 +413,9 @@ void Client::ProcessReceivedMessage(Message &aMessage, const Ip6::MessageInfo &a
         // Send empty ACK if it is a CON message.
         SendAck(responseHeader, aMessageInfo);
 
+        // fall through
+        ;
+
     case kCoapTypeNonConfirmable:
         // Separate response.
         FinalizeCoapTransaction(*message, requestMetadata, &responseHeader, &aMessage, &aMessageInfo, kThreadError_None);

--- a/src/core/coap/coap_client.hpp
+++ b/src/core/coap/coap_client.hpp
@@ -241,14 +241,6 @@ private:
                                  Message *aResponse, const Ip6::MessageInfo *aMessageInfo, ThreadError aResult);
 
     ThreadError SendCopy(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    void SendEmptyMessage(const Ip6::Address &aAddress, uint16_t aPort, uint16_t aMessageId, Header::Type aType);
-    void SendReset(const Ip6::Address &aAddress, uint16_t aPort, uint16_t aMessageId) {
-        SendEmptyMessage(aAddress, aPort, aMessageId, kCoapTypeReset);
-    };
-    void SendEmptyAck(const Ip6::Address &aAddress, uint16_t aPort, uint16_t aMessageId) {
-        SendEmptyMessage(aAddress, aPort, aMessageId, kCoapTypeAcknowledgment);
-    };
-
     static void HandleRetransmissionTimer(void *aContext);
     void HandleRetransmissionTimer(void);
 


### PR DESCRIPTION
Separate response is required for Border Agent handling COMM_PET and COMM_KA requests from commissioner. *Empty Message* is required by both client and server. Currently only client implemented this feature.
This PR,
* [x] Moved *Empty Message* from `CoapClient` to `CoapBase`.
* [x] Adjusted *Empty Message* related API.