### PR TITLE
Use a new specialized ChildInfo structure for children information persistent storage

### DIFF
--- a/examples/platforms/utils/settings.cpp
+++ b/examples/platforms/utils/settings.cpp
@@ -378,7 +378,7 @@ ThreadError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, 
                         utilsFlashRead(address + sizeof(struct settingsBlock), aValue, readLength);
                     }
 
-                    valueLength = readLength;
+                    valueLength = block.length;
                     error = kThreadError_None;
                 }
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -124,6 +124,24 @@ enum AlocAllocation
 };
 
 /**
+* This structure represents the device's own network information for persistent storage.
+*
+*/
+struct NetworkInfo
+{
+    DeviceState          mDeviceState;                                      ///< Current Thread interface state.
+
+    uint8_t              mDeviceMode;                                       ///< Device mode setting.
+    uint16_t             mRloc16;                                           ///< RLOC16
+    uint32_t             mKeySequence;                                      ///< Key Sequence
+    uint32_t             mMleFrameCounter;                                  ///< MLE Frame Counter
+    uint32_t             mMacFrameCounter;                                  ///< MAC Frame Counter
+    uint32_t             mPreviousPartitionId;                              ///< PartitionId
+    Mac::ExtAddress      mExtAddress;                                       ///< Extended Address
+    uint8_t              mMlIid[OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE];  ///< IID from ML-EID
+};
+
+/**
  * This class implements MLE Header generation and parsing.
  *
  */
@@ -1397,24 +1415,6 @@ private:
     void ResetParentCandidate(void);
 
     MessageQueue mDelayedResponses;
-
-    /**
-     * This struct represents the device's own network information for persistent storage.
-     *
-     */
-    typedef struct NetworkInfo
-    {
-        DeviceState          mDeviceState;                                      ///< Current Thread interface state.
-
-        uint8_t              mDeviceMode;                                       ///< Device mode setting.
-        uint16_t             mRloc16;                                           ///< RLOC16
-        uint32_t             mKeySequence;                                      ///< Key Sequence
-        uint32_t             mMleFrameCounter;                                  ///< MLE Frame Counter
-        uint32_t             mMacFrameCounter;                                  ///< MAC Frame Counter
-        uint32_t             mPreviousPartitionId;                              ///< PartitionId
-        Mac::ExtAddress      mExtAddress;                                       ///< Extended Address
-        uint8_t              mMlIid[OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE];  ///< IID from ML-EID
-    } NetworkInfo;
 
     struct
     {

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -65,6 +65,18 @@ class NetworkDataLeader;
  */
 
 /**
+* This structure represents the child information for persistent storage.
+*
+*/
+struct ChildInfo
+{
+    Mac::ExtAddress  mExtAddress;    ///< Extended Address
+    uint32_t         mTimeout;       ///< Timeout
+    uint16_t         mRloc16;        ///< RLOC16
+    uint8_t          mMode;          ///< The MLE device mode
+};
+
+/**
  * This class implements MLE functionality required by the Thread Router and Leader roles.
  *
  */


### PR DESCRIPTION
Currently, We use **otChildInfo** structure for children information storage, which is not specialized for that purpose, but is used to collect diagnostic information of a child, and contains some unnecessary fields for storage. Another disadvantage is that this structure may be changed for some other purpose (e.g., #1519).

This PR creates a new specialized ChildInfo structure, which will be only used for children information storage:
```
struct ChildInfo
{
    Mac::ExtAddress  mExtAddress;    ///< Extended Address
    uint32_t         mTimeout;       ///< Timeout
    uint16_t         mRloc16;        ///< RLOC16
    uint8_t          mMode : 4;      ///< The MLE device mode
};
```