### PR TITLE
disable commissioner related CoAP resource before accepted

### DIFF
--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -86,14 +86,14 @@ otInstance *Commissioner::GetInstance(void)
     return mNetif.GetInstance();
 }
 
-void Commissioner::SetUpCoap()
+void Commissioner::AddCoapResources()
 {
     mNetif.GetCoapServer().AddResource(mRelayReceive);
     mNetif.GetCoapServer().AddResource(mDatasetChanged);
     mNetif.GetSecureCoapServer().AddResource(mJoinerFinalize);
 }
 
-void Commissioner::TearDownCoap()
+void Commissioner::RemoveCoapResources()
 {
     mNetif.GetCoapServer().RemoveResource(mRelayReceive);
     mNetif.GetCoapServer().AddResource(mDatasetChanged);
@@ -129,7 +129,7 @@ ThreadError Commissioner::Stop(void)
     mNetif.GetSecureCoapServer().Stop();
 
     mState = kCommissionerStateDisabled;
-    TearDownCoap();
+    RemoveCoapResources();
     mTransmitAttempts = 0;
 
     mTimer.Stop();
@@ -654,7 +654,7 @@ void Commissioner::HandleLeaderPetitionResponse(Coap::Header *aHeader, Message *
     VerifyOrExit(sessionId.IsValid());
     mSessionId = sessionId.GetCommissionerSessionId();
 
-    SetUpCoap();
+    AddCoapResources();
     mState = kCommissionerStateActive;
 
     mTransmitAttempts = 0;
@@ -757,7 +757,7 @@ exit:
 
     if (mState != kCommissionerStateActive)
     {
-        TearDownCoap();
+        RemoveCoapResources();
     }
 
     otLogFuncExit();

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -79,14 +79,25 @@ Commissioner::Commissioner(ThreadNetif &aThreadNetif):
     mNetif(aThreadNetif)
 {
     memset(mJoiners, 0, sizeof(mJoiners));
-    mNetif.GetCoapServer().AddResource(mRelayReceive);
-    mNetif.GetCoapServer().AddResource(mDatasetChanged);
-    mNetif.GetSecureCoapServer().AddResource(mJoinerFinalize);
 }
 
 otInstance *Commissioner::GetInstance(void)
 {
     return mNetif.GetInstance();
+}
+
+void Commissioner::SetUpCoap()
+{
+    mNetif.GetCoapServer().AddResource(mRelayReceive);
+    mNetif.GetCoapServer().AddResource(mDatasetChanged);
+    mNetif.GetSecureCoapServer().AddResource(mJoinerFinalize);
+}
+
+void Commissioner::TearDownCoap()
+{
+    mNetif.GetCoapServer().RemoveResource(mRelayReceive);
+    mNetif.GetCoapServer().AddResource(mDatasetChanged);
+    mNetif.GetSecureCoapServer().AddResource(mJoinerFinalize);
 }
 
 ThreadError Commissioner::Start(void)
@@ -118,6 +129,7 @@ ThreadError Commissioner::Stop(void)
     mNetif.GetSecureCoapServer().Stop();
 
     mState = kCommissionerStateDisabled;
+    TearDownCoap();
     mTransmitAttempts = 0;
 
     mTimer.Stop();
@@ -642,7 +654,9 @@ void Commissioner::HandleLeaderPetitionResponse(Coap::Header *aHeader, Message *
     VerifyOrExit(sessionId.IsValid());
     mSessionId = sessionId.GetCommissionerSessionId();
 
+    SetUpCoap();
     mState = kCommissionerStateActive;
+
     mTransmitAttempts = 0;
     mTimer.Start(Timer::SecToMsec(kKeepAliveTimeout) / 2);
 
@@ -740,6 +754,12 @@ void Commissioner::HandleLeaderKeepAliveResponse(Coap::Header *aHeader, Message 
     mTimer.Start(Timer::SecToMsec(kKeepAliveTimeout) / 2);
 
 exit:
+
+    if (mState != kCommissionerStateActive)
+    {
+        TearDownCoap();
+    }
+
     otLogFuncExit();
 }
 
@@ -763,6 +783,8 @@ void Commissioner::HandleRelayReceive(Coap::Header &aHeader, Message &aMessage, 
     bool enableJoiner = false;
 
     otLogFuncEntry();
+
+    VerifyOrExit(mState == kCommissionerStateActive, error = kThreadError_InvalidState);
 
     VerifyOrExit(aHeader.GetType() == kCoapTypeNonConfirmable &&
                  aHeader.GetCode() == kCoapRequestPost);

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -86,14 +86,14 @@ otInstance *Commissioner::GetInstance(void)
     return mNetif.GetInstance();
 }
 
-void Commissioner::AddCoapResources()
+void Commissioner::AddCoapResources(void)
 {
     mNetif.GetCoapServer().AddResource(mRelayReceive);
     mNetif.GetCoapServer().AddResource(mDatasetChanged);
     mNetif.GetSecureCoapServer().AddResource(mJoinerFinalize);
 }
 
-void Commissioner::RemoveCoapResources()
+void Commissioner::RemoveCoapResources(void)
 {
     mNetif.GetCoapServer().RemoveResource(mRelayReceive);
     mNetif.GetCoapServer().AddResource(mDatasetChanged);

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -209,6 +209,9 @@ private:
         kRemoveJoinerDelay    = 20,     ///< Delay to remove successfully joined joiner
     };
 
+    void SetUpCoap();
+    void TearDownCoap();
+
     static void HandleTimer(void *aContext);
     void HandleTimer(void);
 

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -209,8 +209,8 @@ private:
         kRemoveJoinerDelay    = 20,     ///< Delay to remove successfully joined joiner
     };
 
-    void AddCoapResources();
-    void RemoveCoapResources();
+    void AddCoapResources(void);
+    void RemoveCoapResources(void);
 
     static void HandleTimer(void *aContext);
     void HandleTimer(void);

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -209,8 +209,8 @@ private:
         kRemoveJoinerDelay    = 20,     ///< Delay to remove successfully joined joiner
     };
 
-    void SetUpCoap();
-    void TearDownCoap();
+    void AddCoapResources();
+    void RemoveCoapResources();
 
     static void HandleTimer(void *aContext);
     void HandleTimer(void);


### PR DESCRIPTION
Currently OpenThread implemented functionality as a on-mesh commissioner. As on-mesh commissioner it's also a border agent of itself. However, this built-in border agent functionality always handles requests to `/c/rx` even not started or not accepted as a commissioner. This behavior prevents a thread node being a simple border agent, and also interferes implementing border agent on host side.

This PR adjusted installing commissioner related CoAP resource only after the node becomes active commissioner.