### PR TITLE
fix a wrong usage of spinel_datatype_unpack

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -6506,18 +6506,18 @@ ThreadError NcpBase::RemovePropertyHandler_MAC_WHITELIST(uint8_t header, spinel_
 {
     ThreadError errorCode = kThreadError_None;
     spinel_ssize_t parsedLength;
-    otExtAddress ext_addr;
+    otExtAddress *ext_addr_ptr = NULL;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
                        value_len,
                        SPINEL_DATATYPE_EUI64_S,
-                       &ext_addr
+                       &ext_addr_ptr
                    );
 
     if (parsedLength > 0)
     {
-        otLinkRemoveWhitelist(mInstance, ext_addr.m8);
+        otLinkRemoveWhitelist(mInstance, ext_addr_ptr->m8);
 
         errorCode = SendPropertyUpdate(
                         header,


### PR DESCRIPTION
In current implementation of spinel parser, SPINEL_DATATYPE_EUI64_S only accepts a pointer to a const pointer to receive the address of eui64 in spinel data packets. However in `RemovePropertyHandler_MAC_WHITELIST` an pointer to `otExtAddress` is passed in which may cause unexpected results. This PR corrects this issue.

Besides, I'm also preparing a PR to let spinel parser support fill unpacked value to the user provided memory. This is useful when implementing an synchronized version of higher level API for getting spinel property. The prototype would be something like this,

```
ThreadError
xxxGetProp(otInstance *aInstance,
spinel_prop_key_t aKey, const char* aFormat, ...);
```