### PR TITLE
Add settings version support and delete different version settings

### DIFF
--- a/examples/platforms/utils/settings.cpp
+++ b/examples/platforms/utils/settings.cpp
@@ -385,6 +385,14 @@ ThreadError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, 
                 index++;
             }
         }
+        else if ((block.key & OT_SETTINGS_KEY_ID_MASK) == (aKey & OT_SETTINGS_KEY_ID_MASK) &&
+                 (block.flag & kBlockDeleteFlag))
+        {
+            // delete the settings which have the same key id, but have different version
+            // TODO: we could also read this kind of settings, and provide them to upper layer for version migration
+            block.flag &= (~kBlockDeleteFlag);
+            utilsFlashWrite(address, reinterpret_cast<uint8_t *>(&block), sizeof(block));
+        }
 
         address += (getAlignLength(block.length) + sizeof(struct settingsBlock));
     }

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -41,6 +41,10 @@
 extern "C" {
 #endif
 
+#define OT_SETTINGS_KEY_ID_MASK       0x00ff
+
+#define OT_SETTINGS_KEY_VERSION_MASK  0xff00
+
 /**
  * Performs any initialization for the settings subsystem, if necessary.
  *

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -44,12 +44,12 @@ extern "C" {
  */
 enum
 {
-    kKeyActiveDataset   = 0x0001,
-    kKeyPendingDataset  = 0x0002,
-    kKeyNetworkInfo     = 0x0003,
-    kKeyParentInfo      = 0x0004,
-    kKeyChildInfo       = 0x0005,
-    kKeyThreadAutoStart = 0x0006,
+    kKeyActiveDataset   = 0x0001,  // key id: 01, version: 00
+    kKeyPendingDataset  = 0x0002,  // key id: 02, version: 00
+    kKeyNetworkInfo     = 0x0003,  // key id: 03, version: 00
+    kKeyParentInfo      = 0x0004,  // key id: 04, version: 00
+    kKeyChildInfo       = 0x0005,  // key id: 05, version: 00
+    kKeyThreadAutoStart = 0x0006,  // key id: 06, version: 00
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
This is a proposal for moving forward #1435:

* Separate the settings key into two parts: key id and version

* Delete the settings which have the same key id, but have different version

For short term, I think it is acceptable to delete these network information related settings if the version is different, so the device will reattach and retrieve them.

For future consideration, we could enhance it to read the different version settings, and provide them to upper layer for version migration.

