### PR TITLE
Refine parent information storage

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -142,6 +142,15 @@ struct NetworkInfo
 };
 
 /**
+* This structure represents the parent information for persistent storage.
+*
+*/
+struct ParentInfo
+{
+    Mac::ExtAddress  mExtAddress;   ///< Extended Address
+};
+
+/**
  * This class implements MLE Header generation and parsing.
  *
  */


### PR DESCRIPTION
As discussed in #1435, this PR refines the parent information storage.

Only parent's extended address is required for parent synchronization.