### PR TITLE
some enhancements and bug fixes

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2389,10 +2389,6 @@ ThreadError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInf
         VerifyOrExit(diff > 0);
     }
 
-    // Network Data
-    SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kNetworkData, sizeof(networkData), networkData));
-    VerifyOrExit(networkData.IsValid(), error = kThreadError_Parse);
-
     // Active Timestamp
     if (Tlv::GetTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp) == kThreadError_None)
     {
@@ -2435,10 +2431,14 @@ ThreadError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInf
         pendingTimestamp.SetLength(0);
     }
 
-    // Network Data
-    mNetif.GetNetworkDataLeader().SetNetworkData(leaderData.GetDataVersion(), leaderData.GetStableDataVersion(),
-                                                 (mDeviceMode & ModeTlv::kModeFullNetworkData) == 0,
-                                                 networkData.GetNetworkData(), networkData.GetLength());
+    if (Tlv::GetTlv(aMessage, Tlv::kNetworkData, sizeof(networkData), networkData) == kThreadError_None)
+    {
+        VerifyOrExit(networkData.IsValid(), error = kThreadError_Parse);
+
+        mNetif.GetNetworkDataLeader().SetNetworkData(leaderData.GetDataVersion(), leaderData.GetStableDataVersion(),
+                                                     (mDeviceMode & ModeTlv::kModeFullNetworkData) == 0,
+                                                     networkData.GetNetworkData(), networkData.GetLength());
+    }
 
     // Active Dataset
     if (activeTimestamp.GetLength() > 0)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2157,10 +2157,11 @@ ThreadError MleRouter::HandleChildUpdateRequest(const Message &aMessage, const I
 
     tlvs[tlvslength++] = Tlv::kSourceAddress;
 
-    if ((child == NULL) || (child->GetState() != Neighbor::kStateValid))
+    // Not proceed if the Child Update Request is from the peer which is not the device's child or
+    // which was the device's child but becomes invalid.
+    if (child == NULL || child->GetState() == Neighbor::kStateInvalid)
     {
-        // Send Child Update Response with status TLV(error) for invalid non-sleepy child
-        // No Child Update Response for invalid sleepy child
+        // For invalid non-sleepy child, Send Child Update Response with status TLV (error)
         if (mode.GetMode() & ModeTlv::kModeRxOnWhenIdle)
         {
             tlvs[tlvslength++] = Tlv::kStatus;


### PR DESCRIPTION
This PR is to
1) Fix child's restoring process if child is rebooted shortly after the parent's reset;
2) Reduce unnecessary `SetNetworkData()` operation, thus reduce extra message exchange.
