### PR TITLE
Remove use of CoAP kAckTimeout in Link Raw API.

### DIFF
--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -377,7 +377,7 @@ ThreadError LinkRaw::DoTransmit(RadioPacket *aPacket)
     {
         otLogDebgPlat(aInstance, "LinkRaw Starting AckTimeout Timer");
         mTimerReason = kTimerReasonAckTimeout;
-        mTimer.Start(kAckTimeout);
+        mTimer.Start(Mac::kAckTimeout);
     }
 
 #endif

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -265,7 +265,7 @@ void JoinerRouter::HandleRelayTransmit(Coap::Header &aHeader, Message &aMessage,
     SuccessOrExit(error = Tlv::GetValueOffset(aMessage, Tlv::kJoinerDtlsEncapsulation, offset, length));
 
     VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
-    message->SetPriority(kMeshCoPMessagePriority);
+    message->SetPriority(Coap::kMeshCoPMessagePriority);
     message->SetLinkSecurityEnabled(false);
 
     while (length)

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -45,7 +45,6 @@
 namespace Thread {
 
 class ThreadNetif;
-using namespace Coap;
 
 namespace NetworkDiagnostic {
 


### PR DESCRIPTION
This PR fixes #1540 

Link Raw have started ACK timer with 2 miliseconds defined by `CoAP::kAckTimeout` instead of 16 miliseconds defined by `Mac::kAckTimeout`.

On nRF52840 it caused aborting of sending MLE Child ID Request which couldn't be transmitted in that short time.

Additionally the root cause has been removed.