### PR TITLE
`ip6`: Ensure not to pass a message from local host back to it.

### DIFF
--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -368,7 +368,8 @@ private:
     static void HandleSendQueue(void *aContext);
     void HandleSendQueue(void);
 
-    ThreadError ProcessReceiveCallback(const Message &aMessage, const MessageInfo &aMessageInfo, uint8_t aIpProto);
+    ThreadError ProcessReceiveCallback(const Message &aMessage, const MessageInfo &aMessageInfo, uint8_t aIpProto,
+                                       bool fromLocalHost);
     ThreadError HandleExtensionHeaders(Message &message, Header &header, uint8_t &nextHeader, bool forward,
                                        bool receive);
     ThreadError HandleFragment(Message &message);


### PR DESCRIPTION
The commit makes the following changes:

- We ensure not to pass up a message we received from local host
  back to the host again (this avoids message loops due to incorrect
  route setup on the host).

- We add logs to indicate when the process of passing up a message to
  host fails (e.g., running out of message buffers and thus failing
  to clone the message).