### PR TITLE
libtool: build both static and dynamic versions of libs.

### DIFF
--- a/examples/apps/cli/Makefile.am
+++ b/examples/apps/cli/Makefile.am
@@ -61,7 +61,7 @@ endif # OPENTHREAD_ENABLE_DIAG
 
 if OPENTHREAD_EXAMPLES_POSIX
 LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/posix/libopenthread-posix.a       \
+    $(top_builddir)/examples/platforms/posix/.libs/libopenthread-posix.a \
     -lstdc++                                                             \
     $(NULL)
 endif # OPENTHREAD_EXAMPLES_POSIX
@@ -123,7 +123,7 @@ ot_cli_ftd_CPPFLAGS                                                    = \
 
 ot_cli_ftd_LDADD                                                       = \
     $(top_builddir)/src/cli/libopenthread-cli.a                          \
-    $(top_builddir)/src/core/libopenthread-ftd.a                         \
+    $(top_builddir)/src/core/.libs/libopenthread-ftd.a                   \
     $(LDADD_COMMON)                                                      \
     $(NULL)
 
@@ -146,7 +146,7 @@ ot_cli_mtd_CPPFLAGS                                                    = \
 
 ot_cli_mtd_LDADD                                                       = \
     $(top_builddir)/src/cli/libopenthread-cli.a                          \
-    $(top_builddir)/src/core/libopenthread-mtd.a                         \
+    $(top_builddir)/src/core/.libs/libopenthread-mtd.a                   \
     $(LDADD_COMMON)                                                      \
     $(NULL)
 

--- a/examples/apps/ncp/Makefile.am
+++ b/examples/apps/ncp/Makefile.am
@@ -61,7 +61,7 @@ endif
 
 if OPENTHREAD_EXAMPLES_POSIX
 LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/posix/libopenthread-posix.a       \
+    $(top_builddir)/examples/platforms/posix/.libs/libopenthread-posix.a \
     -lstdc++                                                             \
     $(NULL)
 endif # OPENTHREAD_EXAMPLES_POSIX
@@ -123,7 +123,7 @@ ot_ncp_ftd_CPPFLAGS                                                    = \
 
 ot_ncp_ftd_LDADD                                                       = \
     $(top_builddir)/src/ncp/libopenthread-ncp.a                          \
-    $(top_builddir)/src/core/libopenthread-ftd.a                         \
+    $(top_builddir)/src/core/.libs/libopenthread-ftd.a                   \
     $(LDADD_COMMON)                                                      \
     $(NULL)
 
@@ -146,7 +146,7 @@ ot_ncp_mtd_CPPFLAGS                                                    = \
 
 ot_ncp_mtd_LDADD                                                       = \
     $(top_builddir)/src/ncp/libopenthread-ncp.a                          \
-    $(top_builddir)/src/core/libopenthread-mtd.a                         \
+    $(top_builddir)/src/core/.libs/libopenthread-mtd.a                   \
     $(LDADD_COMMON)                                                      \
     $(NULL)
 

--- a/examples/platforms/posix/Makefile.am
+++ b/examples/platforms/posix/Makefile.am
@@ -28,16 +28,16 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-lib_LIBRARIES                             = libopenthread-posix.a
+lib_LTLIBRARIES                           = libopenthread-posix.la
 
-libopenthread_posix_a_CPPFLAGS            = \
+libopenthread_posix_la_CPPFLAGS           = \
     -I$(top_srcdir)/include                 \
     -I$(top_srcdir)/examples/platforms      \
     -I$(top_srcdir)/src/core                \
     -D_GNU_SOURCE                           \
     $(NULL)
 
-libopenthread_posix_a_SOURCES             = \
+libopenthread_posix_la_SOURCES            = \
     alarm.c                                 \
     misc.c                                  \
     logging.c                               \
@@ -49,13 +49,13 @@ libopenthread_posix_a_SOURCES             = \
     $(NULL)
 
 if OPENTHREAD_ENABLE_DIAG
-libopenthread_posix_a_SOURCES            += \
+libopenthread_posix_la_SOURCES           += \
     diag.c                                  \
     $(NULL)
 endif
 
 if OPENTHREAD_ENABLE_NCP_SPI
-libopenthread_posix_a_SOURCES            += \
+libopenthread_posix_la_SOURCES           += \
     spi-stubs.c                             \
     $(NULL)
 endif
@@ -65,8 +65,8 @@ noinst_HEADERS                            = \
     $(NULL)
 
 Dash                                      = -
-libopenthread_posix_a_LIBADD              = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
+libopenthread_posix_la_LIBADD             = \
+    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.lo")
 
 if OPENTHREAD_BUILD_COVERAGE
 CLEANFILES                                = $(wildcard *.gcda *.gcno)

--- a/examples/platforms/utils/Makefile.am
+++ b/examples/platforms/utils/Makefile.am
@@ -28,21 +28,21 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-lib_LIBRARIES                           = libopenthread-platform-utils.a
+lib_LTLIBRARIES                          = libopenthread-platform-utils.la
 
-libopenthread_platform_utils_a_CPPFLAGS = \
-    -I$(top_srcdir)/include               \
-    -I$(top_srcdir)/examples/platforms    \
-    -I$(top_srcdir)/src/core              \
+libopenthread_platform_utils_la_CPPFLAGS = \
+    -I$(top_srcdir)/include                \
+    -I$(top_srcdir)/examples/platforms     \
+    -I$(top_srcdir)/src/core               \
     $(NULL)
 
-libopenthread_platform_utils_a_SOURCES  = \
-    settings.cpp                          \
+libopenthread_platform_utils_la_SOURCES  = \
+    settings.cpp                           \
     $(NULL)
 
-noinst_HEADERS                          = \
-    code_utils.h                          \
-    flash.h                               \
+noinst_HEADERS                           = \
+    code_utils.h                           \
+    flash.h                                \
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -28,7 +28,7 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-lib_LIBRARIES                       = \
+lib_LTLIBRARIES                     = \
     $(NULL)
 
 CPPFLAGS_COMMON                     = \
@@ -218,31 +218,31 @@ SOURCES_COMMON                     += \
 endif  # OPENTHREAD_ENABLE_RAW_LINK_API
 
 if OPENTHREAD_ENABLE_FTD
-lib_LIBRARIES                      += \
-    libopenthread-ftd.a               \
+lib_LTLIBRARIES                    += \
+    libopenthread-ftd.la              \
     $(NULL)
 
-libopenthread_ftd_a_CPPFLAGS        = \
+libopenthread_ftd_la_CPPFLAGS       = \
     $(CPPFLAGS_COMMON)                \
     $(NULL)
 
-libopenthread_ftd_a_SOURCES         = \
+libopenthread_ftd_la_SOURCES        = \
     $(SOURCES_COMMON)                 \
     $(SOURCES_FTD)                    \
     $(SOURCES_MISSING)                \
     $(NULL)
 endif # OPENTHREAD_ENABLE_FTD
 
-lib_LIBRARIES                      += \
-    libopenthread-mtd.a               \
+lib_LTLIBRARIES                    += \
+    libopenthread-mtd.la              \
     $(NULL)
 
-libopenthread_mtd_a_CPPFLAGS        = \
+libopenthread_mtd_la_CPPFLAGS       = \
     $(CPPFLAGS_COMMON)                \
     -DOPENTHREAD_MTD                  \
     $(NULL)
 
-libopenthread_mtd_a_SOURCES         = \
+libopenthread_mtd_la_SOURCES        = \
     $(SOURCES_COMMON)                 \
     $(SOURCES_MISSING)                \
     $(NULL)

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -59,14 +59,14 @@ if OPENTHREAD_ENABLE_NCP
 
 COMMON_LDADD                                                        = \
     $(top_builddir)/src/ncp/libopenthread-ncp.a                       \
-    $(top_builddir)/src/core/libopenthread-ftd.a                      \
+    $(top_builddir)/src/core/.libs/libopenthread-ftd.a                \
     -lpthread                                                         \
     $(NULL)
 
 else
 
 COMMON_LDADD                                                        = \
-    $(top_builddir)/src/core/libopenthread-ftd.a                      \
+    $(top_builddir)/src/core/.libs/libopenthread-ftd.a                \
     -lpthread                                                         \
     $(NULL)
 
@@ -172,8 +172,8 @@ test_toolchain_LDADD         = $(COMMON_LDADD)
 test_toolchain_SOURCES       = test_platform.cpp test_toolchain.cpp test_toolchain_c.c
 
 if OPENTHREAD_ENABLE_DIAG
-test_diag_LDADD              = $(top_builddir)/src/diag/libopenthread-diag.a                  \
-                               $(top_builddir)/examples/platforms/posix/libopenthread-posix.a \
+test_diag_LDADD              = $(top_builddir)/src/diag/libopenthread-diag.a                        \
+                               $(top_builddir)/examples/platforms/posix/.libs/libopenthread-posix.a \
                                $(NULL)
 test_diag_SOURCES            = test_diag.cpp
 endif


### PR DESCRIPTION
Adjusts autotools scripts to build both static and dynamic versions of core, platform-posix, and platform-utils libraries.  The main use case for this is to allow directly calling the openthread library APIs from python using simple ctypes wrappers (which require dynamic linkage), similar to what is done by the windows thread-cert framework. 