### PR TITLE
`LinkQualityInfo`: Ensure not to add an invalid/unknown RSS to average.

### DIFF
--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -76,23 +76,25 @@ void LinkQualityInfo::Clear(void)
     mLastRss     = 0;
 }
 
-void LinkQualityInfo::AddRss(LinkQualityInfo &aNoiseFloor, int8_t anRss)
+void LinkQualityInfo::AddRss(LinkQualityInfo &aNoiseFloor, int8_t aRss)
 {
     uint16_t    newValue;
     uint16_t    oldAverage;
 
-    mLastRss = anRss;
+    VerifyOrExit(aRss != kUnknownRss);
+
+    mLastRss = aRss;
 
     // Restrict/Cap the RSS value to the closed range [0, -128] so the value can fit in 8 bits.
 
-    if (anRss > 0)
+    if (aRss > 0)
     {
-        anRss = 0;
+        aRss = 0;
     }
 
     // Multiply the the RSS value by a precision multiple (currently -8).
 
-    newValue = static_cast<uint16_t>(-anRss);
+    newValue = static_cast<uint16_t>(-aRss);
     newValue <<= kRssAveragePrecisionMultipleBitShift;
 
     oldAverage = mRssAverage;
@@ -123,6 +125,9 @@ void LinkQualityInfo::AddRss(LinkQualityInfo &aNoiseFloor, int8_t anRss)
     }
 
     UpdateLinkQuality(aNoiseFloor);
+
+exit:
+    return;
 }
 
 int8_t LinkQualityInfo::GetAverageRss(void) const
@@ -202,11 +207,11 @@ void LinkQualityInfo::UpdateLinkQuality(LinkQualityInfo &aNoiseFloor)
     }
 }
 
-uint8_t LinkQualityInfo::ConvertRssToLinkMargin(LinkQualityInfo &aNoiseFloor, int8_t anRss)
+uint8_t LinkQualityInfo::ConvertRssToLinkMargin(LinkQualityInfo &aNoiseFloor, int8_t aRss)
 {
-    int8_t linkMargin = anRss - GetAverageNoiseFloor(aNoiseFloor);
+    int8_t linkMargin = aRss - GetAverageNoiseFloor(aNoiseFloor);
 
-    if (linkMargin < 0 || anRss == kUnknownRss)
+    if (linkMargin < 0 || aRss == kUnknownRss)
     {
         linkMargin = 0;
     }
@@ -219,9 +224,9 @@ uint8_t LinkQualityInfo::ConvertLinkMarginToLinkQuality(uint8_t aLinkMargin)
     return CalculateLinkQuality(aLinkMargin, kNoLastLinkQualityValue);
 }
 
-uint8_t LinkQualityInfo::ConvertRssToLinkQuality(LinkQualityInfo &aNoiseFloor, int8_t anRss)
+uint8_t LinkQualityInfo::ConvertRssToLinkQuality(LinkQualityInfo &aNoiseFloor, int8_t aRss)
 {
-    return ConvertLinkMarginToLinkQuality(ConvertRssToLinkMargin(aNoiseFloor, anRss));
+    return ConvertLinkMarginToLinkQuality(ConvertRssToLinkMargin(aNoiseFloor, aRss));
 }
 
 uint8_t LinkQualityInfo::CalculateLinkQuality(uint8_t aLinkMargin, uint8_t aLastLinkQuality)

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -77,10 +77,10 @@ public:
      * This method adds a new received signal strength (RSS) value to the average.
      *
      * @param[in] aNoiseFloor  A reference to the noise floor state.
-     * @param[in] anRss        A new received signal strength value (in dBm) to be added to the average.
+     * @param[in] aRss         A new received signal strength value (in dBm) to be added to the average.
      *
      */
-    void AddRss(LinkQualityInfo &aNoiseFloor, int8_t anRss);
+    void AddRss(LinkQualityInfo &aNoiseFloor, int8_t aRss);
 
     /**
      * This method returns the current average signal strength value.
@@ -152,12 +152,12 @@ public:
      * This method converts a received signal strength value to a link margin value.
      *
      * @param[in]  aNoiseFloor  A reference to the noise state.
-     * @param[in]  anRss        The received signal strength value (in dBm).
+     * @param[in]  aRss         The received signal strength value (in dBm).
      *
      * @returns The link margin value.
      *
      */
-    static uint8_t ConvertRssToLinkMargin(LinkQualityInfo &aNoiseFloor, int8_t anRss);
+    static uint8_t ConvertRssToLinkMargin(LinkQualityInfo &aNoiseFloor, int8_t aRss);
 
     /**
      * This method converts a link margin value to a link quality value.
@@ -173,12 +173,12 @@ public:
      * This method converts a received signal strength value to a link quality value.
      *
      * @param[in]  aNoiseFloor  A reference to the noise state.
-     * @param[in]  anRss        The received signal strength value (in dBm).
+     * @param[in]  aRss         The received signal strength value (in dBm).
      *
      * @returns The link quality value (0-3).
      *
      */
-    static uint8_t ConvertRssToLinkQuality(LinkQualityInfo &aNoiseFloor, int8_t anRss);
+    static uint8_t ConvertRssToLinkQuality(LinkQualityInfo &aNoiseFloor, int8_t aRss);
 
 private:
     enum


### PR DESCRIPTION
This commit also fixes some of the argument variable names in `LinkQualityInfo` class.