### PR TITLE
allow anycast locator as source address

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -357,7 +357,6 @@ ThreadError Ip6::SendDatagram(Message &message, MessageInfo &messageInfo, IpProt
     header.SetHopLimit(messageInfo.mHopLimit ? messageInfo.mHopLimit : static_cast<uint8_t>(kDefaultHopLimit));
 
     if (messageInfo.GetSockAddr().IsUnspecified() ||
-        messageInfo.GetSockAddr().IsAnycastRoutingLocator() ||
         messageInfo.GetSockAddr().IsMulticast())
     {
         VerifyOrExit((source = SelectSourceAddress(messageInfo)) != NULL,


### PR DESCRIPTION
According to section 2.2 in [RFC7094](https://tools.ietf.org/html/rfc7094)
> To avoid exposing knowledge about the internal structure of the
      network, it is recommended that anycast servers now take advantage
      of the ability to return responses with the anycast address as the
      source address if possible.

This PR simply allows response with anycast locator as source address.