### PR TITLE
`Mac`: Increase beacon frame tx attempts

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -759,7 +759,7 @@ void Mac::HandleBeginTransmit(void)
             sendFrame.SetChannel(mChannel);
             SendBeacon(sendFrame);
             sendFrame.SetSequence(mBeaconSequence++);
-            sendFrame.SetMaxTxAttempts(kIndirectFrameMacTxAttempts);
+            sendFrame.SetMaxTxAttempts(kDirectFrameMacTxAttempts);
             break;
 
         case kStateTransmitData:


### PR DESCRIPTION
This commit changes/increases the max attempts for a beacon frame to
`kDirectFrameMacTxAttempts` (direct frame tx attempts).