### PR TITLE
Fix CoAP client cli payload argument

### DIFF
--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -335,7 +335,7 @@ ThreadError Coap::ProcessClient(int argc, char *argv[])
     // Embed content into message if given
     if (argc > 4)
     {
-        SuccessOrExit(error = otMessageAppend(message, &argv[4], sizeof(argv[4])));
+        SuccessOrExit(error = otMessageAppend(message, argv[4], static_cast<uint16_t>(strlen(argv[4]))));
     }
 
     memset(&messageInfo, 0, sizeof(messageInfo));


### PR DESCRIPTION
CoAP client cli passes wrong length of payload argument. This PR uses strlen to get the payload length.