### PR TITLE
Active Scan callback / Add/Update the logs in `Mac` class

### DIFF
--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -193,6 +193,7 @@ typedef enum ThreadError
      * Received a duplicated frame.
      */
     kThreadError_Duplicated = 31,
+
     kThreadError_Error = 255,
 } ThreadError;
 

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -232,11 +232,12 @@ public:
     /**
      * This function pointer is called on receiving an IEEE 802.15.4 Beacon during an Active Scan.
      *
-     * @param[in]  aContext       A pointer to arbitrary context information.
-     * @param[in]  aBeaconFrame   A pointer to the Beacon frame.
+     * @param[in]  aContext  A pointer to arbitrary context information.
+     * @param[in]  aResult   A pointer to the active scan result (corresponding to the received beacon), or NULL to
+     *                       indicate end of active scan.
      *
      */
-    typedef void (*ActiveScanHandler)(void *aContext, Frame *aBeaconFrame);
+    typedef void (*ActiveScanHandler)(void *aContext, otActiveScanResult *aResult);
 
     /**
      * This method starts an IEEE 802.15.4 Active Scan.
@@ -253,8 +254,8 @@ public:
      * This function pointer is called during an "Energy Scan" when the result for a channel is ready or the scan
      * completes.
      *
-     * @param[in]  aResult   A valid pointer to the energy scan result information or NULL when the energy scan completes.
      * @param[in]  aContext  A pointer to arbitrary context information.
+     * @param[in]  aResult   A pointer to the energy scan result information or NULL to indicate end of scan.
      *
      */
     typedef void (*EnergyScanHandler)(void *aContext, otEnergyScanResult *aResult);
@@ -629,6 +630,7 @@ private:
     void StartBackoff(void);
     void StartEnergyScan(void);
     ThreadError HandleMacCommand(Frame &aFrame);
+    ThreadError HandleBeacon(Frame &aFrame);
 
     static void HandleMacTimer(void *aContext);
     void HandleMacTimer(void);

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -156,7 +156,7 @@ struct Address
 {
     enum
     {
-        kAddressStringSize =  24,    ///< Max chars needed for a string representation of address (@sa ToString()).
+        kAddressStringSize = 18,     ///< Max chars needed for a string representation of address (@sa ToString()).
     };
 
     uint8_t mLength;                 ///< Length of address in bytes.
@@ -254,6 +254,8 @@ public:
         kMacCmdBeaconRequest               = 7,
         kMacCmdCoordinatorRealignment      = 8,
         kMacCmdGtsRequest                  = 9,
+
+        kInfoStringSize =  110,   ///< Max chars needed for the info string representation (@sa ToInfoString()).
     };
 
     /**
@@ -747,6 +749,17 @@ public:
      */
     uint8_t *GetFooter(void);
 
+    /**
+     * This method returns information about the frame object as a NULL-terminated string.
+     *
+     * @param[out]  aBuf   A pointer to the string buffer
+     * @param[in]   aSize  The maximum size of the string buffer.
+     *
+     * @returns A pointer to the char string buffer.
+     *
+     */
+    const char *ToInfoString(char *aBuf, uint16_t aSize);
+
 private:
     uint8_t *FindSequence(void);
     uint8_t *FindDstPanId(void);
@@ -815,6 +828,7 @@ public:
         kProtocolId       = 3,                      ///< Thread Protocol ID.
         kNetworkNameSize  = 16,                     ///< Size of Thread Network Name (bytes).
         kExtPanIdSize     = 8,                      ///< Size of Thread Extended PAN ID.
+        kInfoStringSize   = 92,                     ///< Max chars for the info string (@sa ToInfoString()).
     };
 
     enum
@@ -946,6 +960,17 @@ public:
      *
      */
     void SetExtendedPanId(const uint8_t *aExtPanId) { memcpy(mExtendedPanId, aExtPanId, sizeof(mExtendedPanId)); }
+
+    /**
+     * This method returns information about the Beacon as a NULL-terminated string.
+     *
+     * @param[out]  aBuf   A pointer to the string buffer
+     * @param[in]   aSize  The maximum size of the string buffer.
+     *
+     * @returns A pointer to the char string buffer.
+     *
+     */
+    const char *ToInfoString(char *aBuf, uint16_t aSize);
 
 private:
     uint8_t  mProtocolId;

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -98,22 +98,18 @@ exit:
     return;
 }
 
-void PanIdQueryServer::HandleScanResult(void *aContext, Mac::Frame *aFrame)
+void PanIdQueryServer::HandleScanResult(void *aContext, otActiveScanResult *aResult)
 {
-    static_cast<PanIdQueryServer *>(aContext)->HandleScanResult(aFrame);
+    static_cast<PanIdQueryServer *>(aContext)->HandleScanResult(aResult);
 }
 
-void PanIdQueryServer::HandleScanResult(Mac::Frame *aFrame)
+void PanIdQueryServer::HandleScanResult(otActiveScanResult *aResult)
 {
-    uint16_t panId;
-
-    if (aFrame != NULL)
+    if (aResult != NULL)
     {
-        aFrame->GetSrcPanId(panId);
-
-        if (panId == mPanId)
+        if (aResult->mPanId == mPanId)
         {
-            mChannelMask |= 1 << aFrame->GetChannel();
+            mChannelMask |= 1 << aResult->mChannel;
         }
     }
     else if (mChannelMask != 0)

--- a/src/core/thread/panid_query_server.hpp
+++ b/src/core/thread/panid_query_server.hpp
@@ -82,8 +82,8 @@ private:
     static void HandleQuery(void *aContext, otCoapHeader *aHeader, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void HandleQuery(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleScanResult(void *aContext, Mac::Frame *aFrame);
-    void HandleScanResult(Mac::Frame *aFrame);
+    static void HandleScanResult(void *aContext, otActiveScanResult *aResult);
+    void HandleScanResult(otActiveScanResult *aResult);
 
     static void HandleTimer(void *aContext);
     void HandleTimer(void);


### PR DESCRIPTION
This PR has two different commits:

**Change `Mac::ActiveScan()` callback to provide `otActiveResult`**
This commit changes the active scan callback to directly provide a pointer to `otActiveScanResult` struct instead of a beacon `Frame`. The code which converts the beacon frame into an `otActiveScanResult` is moved into `Mac` class as a new method `Mac::HandleBeacon()`

**Add/Update the logs in `Mac` class**
This commit contains the following changes:
- Updates logs for a failed tx or rx to include info about the frame (len, seq number, type, src/dst address, etc.).
- Adds detailed logs about transmitted or received Beacon frames (network name, xpanid, protocol id, version, joinability, native flag, ...)
- Adds helper method `ToInfoString()` to `Frame` and `BeaconPyalod` classes to provide a debug info string representation of the object.


