### PR TITLE
Fix CLI implementation of the child command

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -486,10 +486,18 @@ void Interpreter::ProcessChild(int argc, char *argv[])
 
         for (uint8_t i = 0; i < maxChildren ; i++)
         {
-            if (otThreadGetChildInfoByIndex(mInstance, i, &childInfo) != kThreadError_None)
+
+            switch (otThreadGetChildInfoByIndex(mInstance, i, &childInfo))
             {
-                sServer->OutputFormat("\r\n");
-                ExitNow();
+            case kThreadError_None:
+            	break;
+
+            case kThreadError_NotFound:
+            	continue;
+
+            default:
+            	sServer->OutputFormat("\r\n");
+				ExitNow();
             }
 
             if (childInfo.mTimeout > 0)

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -490,14 +490,14 @@ void Interpreter::ProcessChild(int argc, char *argv[])
             switch (otThreadGetChildInfoByIndex(mInstance, i, &childInfo))
             {
             case kThreadError_None:
-            	break;
+                break;
 
             case kThreadError_NotFound:
-            	continue;
+                continue;
 
             default:
-            	sServer->OutputFormat("\r\n");
-				ExitNow();
+                sServer->OutputFormat("\r\n");
+                ExitNow();
             }
 
             if (childInfo.mTimeout > 0)

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -529,6 +529,8 @@ void Interpreter::ProcessChild(int argc, char *argv[])
                 }
             }
         }
+
+        ExitNow();
     }
 
     SuccessOrExit(error = ParseLong(argv[0], value));


### PR DESCRIPTION
In the previous implementation, if a child was not available at a
certain index, all children at greater indexes would not be
printed for a child list or child table command, despite still being
connected to the node.

This change modifies the logic so that if a child does not exist at
a given index, only that index is disgarded, and future indexes are
checked correctly.