### PR TITLE
Provide a helper method `Mac:ConvertBeaconToActiveScanResult()`

### DIFF
--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -306,42 +306,9 @@ void HandleActiveScanResult(void *aContext, Mac::Frame *aFrame)
 {
     otInstance *aInstance = static_cast<otInstance *>(aContext);
     otActiveScanResult result;
-    Mac::Address address;
-    Mac::Beacon *beacon = NULL;
-    Mac::BeaconPayload *beaconPayload = NULL;
-    uint8_t payloadLength;
 
-    memset(&result, 0, sizeof(otActiveScanResult));
-
-    if (aFrame == NULL)
-    {
-        aInstance->mActiveScanCallback(NULL, aInstance->mActiveScanCallbackContext);
-        ExitNow();
-    }
-
-    SuccessOrExit(aFrame->GetSrcAddr(address));
-    VerifyOrExit(address.mLength == sizeof(address.mExtAddress));
-    memcpy(&result.mExtAddress, &address.mExtAddress, sizeof(result.mExtAddress));
-
-    aFrame->GetSrcPanId(result.mPanId);
-    result.mChannel = aFrame->GetChannel();
-    result.mRssi = aFrame->GetPower();
-    result.mLqi = aFrame->GetLqi();
-
-    payloadLength = aFrame->GetPayloadLength();
-
-    beacon = reinterpret_cast<Mac::Beacon *>(aFrame->GetPayload());
-    beaconPayload = reinterpret_cast<Mac::BeaconPayload *>(beacon->GetPayload());
-
-    if ((payloadLength >= (sizeof(*beacon) + sizeof(*beaconPayload))) && beacon->IsValid() && beaconPayload->IsValid())
-    {
-        result.mVersion = beaconPayload->GetProtocolVersion();
-        result.mIsJoinable = beaconPayload->IsJoiningPermitted();
-        result.mIsNative = beaconPayload->IsNative();
-        memcpy(&result.mNetworkName, beaconPayload->GetNetworkName(), sizeof(result.mNetworkName));
-        memcpy(&result.mExtendedPanId, beaconPayload->GetExtendedPanId(), sizeof(result.mExtendedPanId));
-    }
-
+    VerifyOrExit(aFrame != NULL, aInstance->mActiveScanCallback(NULL, aInstance->mActiveScanCallbackContext));
+    Mac::Mac::ConvertBeaconToActiveScanResult(aFrame, result);
     aInstance->mActiveScanCallback(&result, aInstance->mActiveScanCallbackContext);
 
 exit:

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -250,11 +250,24 @@ public:
     ThreadError ActiveScan(uint32_t aScanChannels, uint16_t aScanDuration, ActiveScanHandler aHandler, void *aContext);
 
     /**
+     * This static method converts a beacon frame to an active scan result of type `otActiveScanResult`.
+     *
+     * @param[in]  aBeaconFrame             A pointer to a beacon frame.
+     * @param[out] aResult                  A reference to `otActiveScanResult` where the result is stored.
+     *
+     * @retval kThreadError_None            Successfully converted the beacon into active scan result.
+     * @retavl kThreadError_InvalidArgs     The @a aBeaconFrame was NULL.
+     * @retval kThreadError_Parse           Failed parsing the beacon frame.
+     *
+     */
+    static ThreadError ConvertBeaconToActiveScanResult(Frame *aBeaconFrame, otActiveScanResult &aResult);
+
+    /**
      * This function pointer is called during an "Energy Scan" when the result for a channel is ready or the scan
      * completes.
      *
-     * @param[in]  aResult   A valid pointer to the energy scan result information or NULL when the energy scan completes.
      * @param[in]  aContext  A pointer to arbitrary context information.
+     * @param[in]  aResult   A valid pointer to the energy scan result information or NULL when the energy scan completes.
      *
      */
     typedef void (*EnergyScanHandler)(void *aContext, otEnergyScanResult *aResult);


### PR DESCRIPTION
This commit provides a new static helper method in `Mac` class
`ConvertBeaconToActiveScanResult()` to convert a received beacon frame
(from active scan operation) to a `otActiveScanResult` struct. This
is in turn used to simplify the `HandleActiveScanResult()` callback
implementation in `linke_api.cpp`.