### PR TITLE
Increase local buf for version.

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1505,7 +1505,7 @@ exit:
 
 ThreadError NcpBase::OutboundFrameFeedVPacked(const char *pack_format, va_list args)
 {
-    uint8_t buf[64];
+    uint8_t buf[96];
     ThreadError errorCode = kThreadError_NoBufs;
     spinel_ssize_t packed_len;
 


### PR DESCRIPTION
Under certain conditions it was found that otGetVersionString() would return a string that could not be spinel packed into the available 64 byte buffer.  The buffer has been increased to 96 to compensate.