### PR TITLE
Remove unnecessary configure options from pretty check.

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -37,7 +37,7 @@ set -x
 [ $BUILD_TARGET != pretty-check ] || {
     export PATH=/tmp/astyle/build/gcc/bin:$PATH || die
     ./bootstrap || die
-    ./configure --enable-cli-app=all --enable-ncp-app=all --enable-diag --enable-dhcp6-client --enable-dhcp6-server --enable-dns-client --enable-commissioner --enable-joiner --enable-application-coap --with-examples=posix || die
+    ./configure || die
     make pretty-check || die
 }
 


### PR DESCRIPTION
#1620 makes it unnecessary to add configure options to ensure pretty-check coverage.