### PR TITLE
Add `src/core` header files to PRETTY_FILES.

### DIFF
--- a/examples/platforms/da15000/Makefile.am
+++ b/examples/platforms/da15000/Makefile.am
@@ -105,6 +105,7 @@ noinst_HEADERS                                                                  
 
 PRETTY_FILES                                                                            = \
     $(PLATFORM_SOURCES)                                                                   \
+    $(noinst_HEADERS)                                                                     \
     $(NULL)
 
 Dash                                                                                    = -

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -228,7 +228,7 @@ libopenthread_ftd_a_SOURCES         = \
     $(SOURCES_MISSING)                \
     $(NULL)
 
-noinst_HEADERS                      = \
+HEADERS_COMMON                      = \
     openthread-core-config.h          \
     openthread-core-default-config.h  \
     openthread-instance.h             \
@@ -336,9 +336,13 @@ noinst_HEADERS                      = \
     utils/jam_detector.hpp            \
     $(NULL)
 
+noinst_HEADERS                      = \
+    $(HEADERS_COMMON)                 \
+    $(NULL)
+
 PRETTY_FILES                        = \
     $(SOURCES_COMMON)                 \
-    $(SOURCES_FTD)                    \
+    $(HEADERS_COMMON)                 \
     $(NULL)
 
 if OPENTHREAD_BUILD_COVERAGE

--- a/src/core/meshcop/meshcop.hpp
+++ b/src/core/meshcop/meshcop.hpp
@@ -50,7 +50,7 @@ enum
  * This function create Message for MeshCoP
  *
  */
-inline Message* NewMeshCoPMessage(Coap::CoapBase &aCoapBase, const Coap::Header &aHeader)
+inline Message *NewMeshCoPMessage(Coap::CoapBase &aCoapBase, const Coap::Header &aHeader)
 {
     return aCoapBase.NewMessage(aHeader, kMeshCoPMessagePriority);
 }

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -882,18 +882,16 @@ public:
      * @retval kThreadError_NotFound   No subsequent Tlv exists in TlvRequestTlv.
      *
      */
-    ThreadError GetNextTlv(TlvRequestIterator &aIterator, uint8_t &aTlv)
-    {
+    ThreadError GetNextTlv(TlvRequestIterator &aIterator, uint8_t &aTlv) {
         ThreadError error = kThreadError_NotFound;
 
-        if (aIterator < GetLength())
-        {
+        if (aIterator < GetLength()) {
             aTlv = mTlvs[aIterator];
             aIterator = static_cast<TlvRequestIterator>(aIterator + sizeof(uint8_t));
             error = kThreadError_None;
         }
 
-	return error;
+        return error;
     }
 
     /**
@@ -1014,8 +1012,10 @@ public:
      * @retval FALSE  If the TLV does not appear to be well-formed.
      *
      */
-    bool IsValid(void) const { return (GetLength() == sizeof(*this) - sizeof(Tlv) ||
-                                       GetLength() == sizeof(*this) - sizeof(Tlv) - sizeof(mSedBufferSize) - sizeof(mSedDatagramCount)); }
+    bool IsValid(void) const {
+        return (GetLength() == sizeof(*this) - sizeof(Tlv) ||
+                GetLength() == sizeof(*this) - sizeof(Tlv) - sizeof(mSedBufferSize) - sizeof(mSedDatagramCount));
+    }
 
     /**
      * This method returns the Parent Priority value.

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -349,8 +349,10 @@ public:
      * @retval FALSE  If the TLV does not appear to be well-formed.
      *
      */
-    bool IsValid(void) const { return (GetLength() == sizeof(*this) - sizeof(NetworkDiagnosticTlv) ||
-                                       GetLength() == sizeof(*this) - sizeof(NetworkDiagnosticTlv) - sizeof(mSedBufferSize) - sizeof(mSedDatagramCount)); }
+    bool IsValid(void) const {
+        return (GetLength() == sizeof(*this) - sizeof(NetworkDiagnosticTlv) ||
+                GetLength() == sizeof(*this) - sizeof(NetworkDiagnosticTlv) - sizeof(mSedBufferSize) - sizeof(mSedDatagramCount));
+    }
 
     /**
      * This method returns the Parent Priority value.


### PR DESCRIPTION
#1568 removed header files from being included in the `pretty` and `pretty-check` targets.  This PR brings those back in.  This PR also fixes code style issues that have crept in since.