### PR TITLE
Allow to clear Operation Dataset when a new network parameter is set.

### DIFF
--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -188,7 +188,7 @@ exit:
 
 ThreadError DatasetManager::Clear(uint8_t &aFlags, bool aOnlyClearNetwork)
 {
-    if (!aOnlyClearNetwork && mLocal.Compare(mNetwork) == 0)
+    if (!aOnlyClearNetwork)
     {
         mLocal.Clear(true);
     }


### PR DESCRIPTION
This PR introduces simple fix for #1638