### PR TITLE
Fix inherits implicit virtual warning.

### DIFF
--- a/src/cli/cli_uart.hpp
+++ b/src/cli/cli_uart.hpp
@@ -66,7 +66,7 @@ public:
      * @returns The number of bytes placed in the output queue.
      *
      */
-    int Output(const char *aBuf, uint16_t aBufLength);
+    virtual int Output(const char *aBuf, uint16_t aBufLength);
 
     /**
      * This method delivers formatted output to the client.
@@ -77,7 +77,7 @@ public:
      * @returns The number of bytes placed in the output queue.
      *
      */
-    int OutputFormat(const char *fmt, ...);
+    virtual int OutputFormat(const char *fmt, ...);
 
     /**
      * This method delivers formatted output to the client.

--- a/src/cli/cli_udp.hpp
+++ b/src/cli/cli_udp.hpp
@@ -74,7 +74,7 @@ public:
      * @returns The number of bytes placed in the output queue.
      *
      */
-    int Output(const char *aBuf, uint16_t aBufLength);
+    virtual int Output(const char *aBuf, uint16_t aBufLength);
 
     /**
      * This method delivers formatted output to the client.
@@ -85,7 +85,7 @@ public:
      * @returns The number of bytes placed in the output queue.
      *
      */
-    int OutputFormat(const char *fmt, ...);
+    virtual int OutputFormat(const char *fmt, ...);
 
 private:
     enum

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -132,7 +132,7 @@ public:
      * @param[out]  aAddress  A reference to the link address.
      *
      */
-    ThreadError GetLinkAddress(Ip6::LinkAddress &aAddress) const;
+    virtual ThreadError GetLinkAddress(Ip6::LinkAddress &aAddress) const;
 
     /**
      * This method submits a message to the network interface.
@@ -142,7 +142,7 @@ public:
      * @retval kThreadError_None  Successfully submitted the message to the interface.
      *
      */
-    ThreadError SendMessage(Message &aMessage) { return mMeshForwarder.SendMessage(aMessage); }
+    virtual ThreadError SendMessage(Message &aMessage) { return mMeshForwarder.SendMessage(aMessage); }
 
     /**
      * This method performs a route lookup.
@@ -155,7 +155,7 @@ public:
      * @retval kThreadError_NoRoute  Could not find a valid route.
      *
      */
-    ThreadError RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination, uint8_t *aPrefixMatch);
+    virtual ThreadError RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination, uint8_t *aPrefixMatch);
 
     /**
      * This method returns a reference to the address resolver object.


### PR DESCRIPTION
Nit: Fix warning in arm compiler: 
e.g. `thread_netif.hpp(135): warning:  #1300-D: GetLinkAddress inherits implicit virtual`
