### PR TITLE
No payload no marker

### DIFF
--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -266,6 +266,7 @@ ThreadError Coap::ProcessClient(int argc, char *argv[])
     otMessage *message = NULL;
     otMessageInfo messageInfo;
     otCoapHeader header;
+    uint16_t payloadLength = 0;
 
     // Default parameters
     char coapUri[kMaxUriLength] = "test";
@@ -330,15 +331,23 @@ ThreadError Coap::ProcessClient(int argc, char *argv[])
     otCoapHeaderInit(&header, coapType, coapCode);
     otCoapHeaderGenerateToken(&header, Thread::Coap::Header::kDefaultTokenLength);
     SuccessOrExit(error = otCoapHeaderAppendUriPathOptions(&header, coapUri));
-    otCoapHeaderSetPayloadMarker(&header);
+
+    if (argc > 4)
+    {
+        payloadLength = static_cast<uint16_t>(strlen(argv[4]));
+        if (payloadLength > 0)
+        {
+            otCoapHeaderSetPayloadMarker(&header);
+        }
+    }
 
     message = otCoapNewMessage(sInstance, &header);
     VerifyOrExit(message != NULL, error = kThreadError_NoBufs);
 
     // Embed content into message if given
-    if (argc > 4)
+    if (payloadLength > 0)
     {
-        SuccessOrExit(error = otMessageAppend(message, argv[4], static_cast<uint16_t>(strlen(argv[4]))));
+        SuccessOrExit(error = otMessageAppend(message, argv[4], payloadLength);
     }
 
     memset(&messageInfo, 0, sizeof(messageInfo));

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -335,6 +335,7 @@ ThreadError Coap::ProcessClient(int argc, char *argv[])
     if (argc > 4)
     {
         payloadLength = static_cast<uint16_t>(strlen(argv[4]));
+
         if (payloadLength > 0)
         {
             otCoapHeaderSetPayloadMarker(&header);
@@ -347,7 +348,7 @@ ThreadError Coap::ProcessClient(int argc, char *argv[])
     // Embed content into message if given
     if (payloadLength > 0)
     {
-        SuccessOrExit(error = otMessageAppend(message, argv[4], payloadLength);
+        SuccessOrExit(error = otMessageAppend(message, argv[4], payloadLength));
     }
 
     memset(&messageInfo, 0, sizeof(messageInfo));

--- a/src/core/coap/coap_header.cpp
+++ b/src/core/coap/coap_header.cpp
@@ -96,6 +96,10 @@ ThreadError Header::FromMessage(const Message &aMessage, uint16_t aMetadataSize)
         if (mHeader.mBytes[mHeaderLength] == 0xff)
         {
             mHeaderLength += sizeof(uint8_t);
+            length -= sizeof(uint8_t);
+            // RFC7252: The presence of a marker followed by a zero-length payload MUST be processed
+            // as a message format error.
+            VerifyOrExit(length > 0, error = kThreadError_Parse);
             ExitNow(error = kThreadError_None);
         }
 


### PR DESCRIPTION
cli CoAP client always sets the payload marker, which may cause some CoAP server failed to parse the packet.
Also the current CoAP parser doesn't verify the payload marker. This PR,

* Set payload marker when required in cli CoAP client.
* Raise parse error when payload marker present but without payload.