### PR TITLE
Ensure fairness in handling of data polls from sleepy children

### DIFF
--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -316,6 +316,7 @@ private:
     uint8_t  mSendMessageMaxMacTxAttempts;
     uint8_t  mSendMessageKeyId;
     uint8_t  mSendMessageDataSequenceNumber;
+    uint8_t  mStartChildIndex;
 
     Mac::Address mMacSource;
     Mac::Address mMacDest;
@@ -335,8 +336,6 @@ private:
     bool mScanning;
 
     DataPollManager mDataPollManager;
-
-
     SourceMatchController mSourceMatchController;
 };
 


### PR DESCRIPTION
To ensure fairness in handling of data requests (data polls) from
sleepy children, once a message is scheduled and prepared for
indirect transmission to a child, the child index is remembered
and in the subsequent tx schedule, the check for data polls begins
from the next child index.