### PR TITLE
Add config option to allow platform to specify the function/macro for logging

### DIFF
--- a/src/core/common/logging.cpp
+++ b/src/core/common/logging.cpp
@@ -45,7 +45,7 @@
 
 #ifndef WINDOWS_LOGGING
 #define otLogDump(aFormat, ...)                                             \
-    _otPlatLog(aInstance, aLogLevel, aLogRegion, aFormat OPENTHREAD_CONFIG_LOG_SUFFIX, ## __VA_ARGS__)
+    _otDynamicLog(aInstance, aLogLevel, aLogRegion, aFormat OPENTHREAD_CONFIG_LOG_SUFFIX, ## __VA_ARGS__)
 #endif
 
 #ifdef __cplusplus

--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -1244,7 +1244,7 @@ const char *otLogRegionToString(otLogRegion aRegion);
  * Local/private macro to format the log message
  */
 #define _otLogFormatter(aInstance, aLogLevel, aRegion, aFormat, ...)        \
-    _otPlatLog(                                                             \
+    _otDynamicLog(                                                          \
         aInstance,                                                          \
         aLogLevel,                                                          \
         aRegion,                                                            \
@@ -1260,7 +1260,7 @@ const char *otLogRegionToString(otLogRegion aRegion);
 * Local/private macro to format the log message
 */
 #define _otLogFormatter(aInstanc, aLogLevel, aRegion, aFormat, ...)         \
-    _otPlatLog(                                                             \
+    _otDynamicLog(                                                          \
         aInstance,                                                          \
         aLogLevel,                                                          \
         aRegion,                                                            \
@@ -1279,7 +1279,7 @@ const char *otLogRegionToString(otLogRegion aRegion);
 * Local/private macro to format the log message
 */
 #define _otLogFormatter(aInstance, aLogLevel, aRegion, aFormat, ...)        \
-    _otPlatLog(                                                             \
+    _otDynamicLog(                                                          \
         aInstance,                                                          \
         aLogLevel,                                                          \
         aRegion,                                                            \
@@ -1294,7 +1294,7 @@ const char *otLogRegionToString(otLogRegion aRegion);
 * Local/private macro to format the log message
 */
 #define _otLogFormatter(aInstace, aLogLevel, aRegion, aFormat, ...)         \
-    _otPlatLog(                                                             \
+    _otDynamicLog(                                                          \
         aInstance,                                                          \
         aLogLevel,                                                          \
         aRegion,                                                            \
@@ -1306,23 +1306,30 @@ const char *otLogRegionToString(otLogRegion aRegion);
 
 #endif // OPENTHREAD_CONFIG_LOG_PREPEND_REGION
 
-
 #if OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL == 1
 
 /**
 * Local/private macro to dynamically filter log level.
 */
-#define _otPlatLog(aInstance, aLogLevel, aRegion, aFormat, ...)             \
+#define _otDynamicLog(aInstance, aLogLevel, aRegion, aFormat, ...)          \
     do {                                                                    \
         if (otGetDynamicLogLevel(aInstance) >= aLogLevel)                   \
-            otPlatLog(aLogLevel, aRegion, aFormat, ## __VA_ARGS__);         \
+            _otPlatLog(aLogLevel, aRegion, aFormat, ## __VA_ARGS__);        \
     } while (false)
 
 #else // OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
 
-#define _otPlatLog(aInstance, aLogLevel, aRegion, aFormat, ...) otPlatLog(aLogLevel, aRegion, aFormat, ## __VA_ARGS__)
+#define _otDynamicLog(aInstance, aLogLevel, aRegion, aFormat, ...)          \
+    _otPlatLog(aLogLevel, aRegion, aFormat, ## __VA_ARGS__)
 
 #endif // OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
+
+/**
+ * `OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION` is a configuration parameter (see `openthread-core-default-config.h`) which
+ * specifies the function/macro to be used for logging in OpenThread. By default it is set to `otPlatLog()`.
+ */
+#define _otPlatLog(aLogLevel, aRegion, aFormat, ...)                        \
+    OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION(aLogLevel, aRegion, aFormat, ## __VA_ARGS__)
 
 #ifdef __cplusplus
 };

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -566,8 +566,18 @@
  *
  */
 #ifndef OPENTHREAD_CONFIG_LOG_SUFFIX
-#define OPENTHREAD_CONFIG_LOG_SUFFIX                           ""
+#define OPENTHREAD_CONFIG_LOG_SUFFIX                            ""
 #endif  // OPENTHREAD_CONFIG_LOG_SUFFIX
+
+/**
+ * @def OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION
+ *
+ * Defines the name of function/marco used for logging inside Openthread, by default is set to `otPlatLog()`.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION
+#define OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION                     otPlatLog
+#endif
 
 /**
  * @def OPENTHREAD_CONFIG_NUM_DHCP_PREFIXES


### PR DESCRIPTION
Add config option to allow platform to specify the function/macro for logging
    
 This commit adds `OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION` as a new configuration option (set by default as `otPlatLog()`). This allows this allows user to specify the function/macro used for logging inside OpenThread.