### PR TITLE
Filter TMF messages for security

### DIFF
--- a/src/core/coap/coap_server.cpp
+++ b/src/core/coap/coap_server.cpp
@@ -44,6 +44,7 @@ Server::Server(Ip6::Netif &aNetif, uint16_t aPort, SenderFunction aSender, Recei
 {
     mPort = aPort;
     mResources = NULL;
+    mInterceptor = NULL;
 }
 
 ThreadError Server::Start(void)
@@ -137,6 +138,11 @@ void Server::ProcessReceivedMessage(Message &aMessage, const Ip6::MessageInfo &a
     char *curUriPath = uriPath;
     const Header::Option *coapOption;
     Message *response;
+
+    if (mInterceptor != NULL)
+    {
+        SuccessOrExit(mInterceptor(&aMessage, &aMessageInfo));
+    }
 
     SuccessOrExit(header.FromMessage(aMessage, 0));
     aMessage.MoveOffset(header.GetLength());

--- a/src/core/coap/coap_server.cpp
+++ b/src/core/coap/coap_server.cpp
@@ -141,7 +141,7 @@ void Server::ProcessReceivedMessage(Message &aMessage, const Ip6::MessageInfo &a
 
     if (mInterceptor != NULL)
     {
-        SuccessOrExit(mInterceptor(&aMessage, &aMessageInfo));
+        SuccessOrExit(mInterceptor(aMessage, aMessageInfo));
     }
 
     SuccessOrExit(header.FromMessage(aMessage, 0));

--- a/src/core/coap/coap_server.hpp
+++ b/src/core/coap/coap_server.hpp
@@ -292,8 +292,10 @@ public:
      * @param[in]   aMessage        A pointer to the message.
      @ @param[in]   aMessageInfo    A pointer to the message info associated with @p aMessage.
      *
-     * @retval  kThreadError_None   allow server to continue processing, otherwise the message
-     *                              should be dropped.
+     * @retval  kThreadError_None       Server should continue processing this message, other
+     *                                  return values indicates the server should stop processing
+     *                                  this message.
+     * @retval  kThreadError_Security   The message does not comply with security rules.
      *
      */
     typedef ThreadError(* Interceptor)(const otMessage *aMessage, const otMessageInfo *aMessageInfo);

--- a/src/core/coap/coap_server.hpp
+++ b/src/core/coap/coap_server.hpp
@@ -290,8 +290,8 @@ public:
     /**
      * This function pointer is called before CoAP server processing a CoAP packets.
      *
-     * @param[in]   aMessage        A pointer to the message.
-     @ @param[in]   aMessageInfo    A pointer to the message info associated with @p aMessage.
+     * @param[in]   aMessage        A reference to the message.
+     @ @param[in]   aMessageInfo    A reference to the message info associated with @p aMessage.
      *
      * @retval  kThreadError_None       Server should continue processing this message, other
      *                                  return values indicates the server should stop processing
@@ -299,7 +299,7 @@ public:
      * @retval  kThreadError_Security   The message does not comply with security rules.
      *
      */
-    typedef ThreadError(* Interceptor)(const otMessage *aMessage, const otMessageInfo *aMessageInfo);
+    typedef ThreadError(* Interceptor)(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     /**
      * This constructor initializes the object.

--- a/src/core/coap/coap_server.hpp
+++ b/src/core/coap/coap_server.hpp
@@ -288,6 +288,17 @@ class Server : public CoapBase
 {
 public:
     /**
+     * This function pointer is called before CoAP server processing a CoAP packets.
+     * @param[in]   aMessage        A pointer to the message.
+     @ @param[in]   aMessageInfo    A pointer to the message info associated with @p aMessage.
+     *
+     * @retval  kThreadError_None   allow server to continue processing, otherwise the message
+     *                              should be dropped.
+     *
+     */
+    typedef ThreadError(* Interceptor)(const otMessage *aMessage, const otMessageInfo *aMessageInfo);
+
+    /**
      * This constructor initializes the object.
      *
      * @param[in]  aNetif    A reference to the network interface that CoAP server should be assigned to.
@@ -371,6 +382,16 @@ public:
 
     const MessageQueue &GetCachedResponses(void) const { return mResponsesQueue.GetResponses(); }
 
+    /**
+     * This method sets interceptor to be called before processing a CoAP packet.
+     *
+     * @param[in]   aInterceptor    A pointer to the interceptor.
+     *
+     */
+    void SetInterceptor(Interceptor aInterpreter) {
+        mInterceptor = aInterpreter;
+    }
+
 protected:
     void ProcessReceivedMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
@@ -386,6 +407,7 @@ private:
     uint16_t mPort;
     Resource *mResources;
 
+    Interceptor    mInterceptor;
     ResponsesQueue mResponsesQueue;
 };
 

--- a/src/core/coap/coap_server.hpp
+++ b/src/core/coap/coap_server.hpp
@@ -289,6 +289,7 @@ class Server : public CoapBase
 public:
     /**
      * This function pointer is called before CoAP server processing a CoAP packets.
+     *
      * @param[in]   aMessage        A pointer to the message.
      @ @param[in]   aMessageInfo    A pointer to the message info associated with @p aMessage.
      *

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -172,21 +172,20 @@ exit:
     return error;
 }
 
-ThreadError ThreadNetif::TmfFilter(const otMessage *aMessage, const otMessageInfo *aMessageInfo)
+ThreadError ThreadNetif::TmfFilter(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    const Ip6::MessageInfo &messageInfo = *static_cast<const Ip6::MessageInfo *>(aMessageInfo);
     ThreadError error = kThreadError_None;
 
     // A TMF message must comply one of the following rules:
     // 1. Source address is RLOC or ALOC, and destination address is RLOC, ALOC or realm-local multicast.
     // 2. Both source and destination addresses are link-local.(for Joiner Entrust)
-    VerifyOrExit(((messageInfo.GetPeerAddr().IsRoutingLocator() ||
-                   messageInfo.GetPeerAddr().IsAnycastRoutingLocator()) &&
-                  (messageInfo.GetSockAddr().IsRoutingLocator() ||
-                   messageInfo.GetSockAddr().IsAnycastRoutingLocator() ||
-                   messageInfo.GetSockAddr().IsRealmLocalMulticast())) ||
-                 (messageInfo.GetPeerAddr().IsLinkLocal() &&
-                  messageInfo.GetSockAddr().IsLinkLocal()),
+    VerifyOrExit(((aMessageInfo.GetPeerAddr().IsRoutingLocator() ||
+                   aMessageInfo.GetPeerAddr().IsAnycastRoutingLocator()) &&
+                  (aMessageInfo.GetSockAddr().IsRoutingLocator() ||
+                   aMessageInfo.GetSockAddr().IsAnycastRoutingLocator() ||
+                   aMessageInfo.GetSockAddr().IsRealmLocalMulticast())) ||
+                 (aMessageInfo.GetPeerAddr().IsLinkLocal() &&
+                  aMessageInfo.GetSockAddr().IsLinkLocal()),
                  error = kThreadError_Security);
 
 exit:

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -177,11 +177,13 @@ ThreadError ThreadNetif::TmfFilter(const otMessage *aMessage, const otMessageInf
     const Ip6::MessageInfo &messageInfo = *static_cast<const Ip6::MessageInfo *>(aMessageInfo);
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(messageInfo.GetSockAddr().IsRoutingLocator() ||
-                 messageInfo.GetPeerAddr().IsRoutingLocator() ||
-                 messageInfo.GetSockAddr().IsLinkLocal() ||
-                 messageInfo.GetSockAddr().IsAnycastRoutingLocator() ||
-                 messageInfo.GetPeerAddr().IsAnycastRoutingLocator(),
+    VerifyOrExit(((messageInfo.GetPeerAddr().IsRoutingLocator() ||
+                   messageInfo.GetPeerAddr().IsAnycastRoutingLocator()) &&
+                  (messageInfo.GetSockAddr().IsRoutingLocator() ||
+                   messageInfo.GetSockAddr().IsAnycastRoutingLocator() ||
+                   messageInfo.GetSockAddr().IsRealmLocalMulticast())) ||
+                 (messageInfo.GetPeerAddr().IsLinkLocal() &&
+                  messageInfo.GetSockAddr().IsLinkLocal()),
                  error = kThreadError_Security);
 
 exit:

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -100,6 +100,7 @@ ThreadNetif::ThreadNetif(Ip6::Ip6 &aIp6):
 
 {
     mKeyManager.SetMasterKey(kThreadMasterKey, sizeof(kThreadMasterKey));
+    mCoapServer.SetInterceptor(&ThreadNetif::TmfFilter);
 }
 
 ThreadError ThreadNetif::Up(void)
@@ -168,6 +169,23 @@ ThreadError ThreadNetif::RouteLookup(const Ip6::Address &source, const Ip6::Addr
     }
 
 exit:
+    return error;
+}
+
+ThreadError ThreadNetif::TmfFilter(const otMessage *aMessage, const otMessageInfo *aMessageInfo)
+{
+    const Ip6::MessageInfo &messageInfo = *static_cast<const Ip6::MessageInfo *>(aMessageInfo);
+    ThreadError error = kThreadError_None;
+
+    VerifyOrExit(messageInfo.GetSockAddr().IsRoutingLocator() ||
+                 messageInfo.GetPeerAddr().IsRoutingLocator() ||
+                 messageInfo.GetSockAddr().IsLinkLocal() ||
+                 messageInfo.GetSockAddr().IsAnycastRoutingLocator() ||
+                 messageInfo.GetPeerAddr().IsAnycastRoutingLocator(),
+                 error = kThreadError_Security);
+
+exit:
+    (void)aMessage;
     return error;
 }
 

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -177,6 +177,9 @@ ThreadError ThreadNetif::TmfFilter(const otMessage *aMessage, const otMessageInf
     const Ip6::MessageInfo &messageInfo = *static_cast<const Ip6::MessageInfo *>(aMessageInfo);
     ThreadError error = kThreadError_None;
 
+    // A TMF message must comply one of the following rules:
+    // 1. Source address is RLOC or ALOC, and destination address is RLOC, ALOC or realm-local multicast.
+    // 2. Both source and destination addresses are link-local.(for Joiner Entrust)
     VerifyOrExit(((messageInfo.GetPeerAddr().IsRoutingLocator() ||
                    messageInfo.GetPeerAddr().IsAnycastRoutingLocator()) &&
                   (messageInfo.GetSockAddr().IsRoutingLocator() ||

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -328,6 +328,8 @@ public:
     otInstance *GetInstance(void);
 
 private:
+    static ThreadError TmfFilter(const otMessage *aMessage, const otMessageInfo *aMessageInfo);
+
     Coap::Server mCoapServer;
     Coap::Client mCoapClient;
     AddressResolver mAddressResolver;

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -328,7 +328,7 @@ public:
     otInstance *GetInstance(void);
 
 private:
-    static ThreadError TmfFilter(const otMessage *aMessage, const otMessageInfo *aMessageInfo);
+    static ThreadError TmfFilter(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     Coap::Server mCoapServer;
     Coap::Client mCoapClient;


### PR DESCRIPTION
According to spec 1.1, section 10.6.2
> A TMF CoAP message sent to the Thread Management UDP port (:MM) MUST comply with at least one of these addressing rules:
> * The IPv6 source address is an RLOC or ALOC.
> * The IPv6 destination address is an RLOC or ALOC.
> * The IPv6 destination address is a Link-Local address.

This PR,

* adds a general interceptor feature to CoAP server.
* filters out messages not complying with the addressing rules of TMF.
