### PR TITLE
Adding `topology.cpp`

### DIFF
--- a/etc/visual-studio/libopenthread.vcxproj
+++ b/etc/visual-studio/libopenthread.vcxproj
@@ -138,6 +138,7 @@
     <ClCompile Include="..\..\src\core\thread\panid_query_server.cpp" />
     <ClCompile Include="..\..\src\core\thread\src_match_controller.cpp" />
     <ClCompile Include="..\..\src\core\thread\thread_netif.cpp" />
+    <ClCompile Include="..\..\src\core\thread\topology.cpp" />
     <ClCompile Include="..\..\src\core\utils\slaac_address.cpp" />
     <ClCompile Include="..\..\src\core\utils\jam_detector.cpp" />
     <ClCompile Include="..\..\src\missing\strlcpy\strlcpy.c" />

--- a/etc/visual-studio/libopenthread.vcxproj.filters
+++ b/etc/visual-studio/libopenthread.vcxproj.filters
@@ -237,6 +237,9 @@
     <ClCompile Include="..\..\src\core\thread\thread_netif.cpp">
       <Filter>Source Files\thread</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\core\thread\topology.cpp">
+      <Filter>Source Files\thread</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\core\net\udp6.cpp">
       <Filter>Source Files\net</Filter>
     </ClCompile>

--- a/etc/visual-studio/libopenthread_k.vcxproj
+++ b/etc/visual-studio/libopenthread_k.vcxproj
@@ -143,6 +143,7 @@
     <ClCompile Include="..\..\src\core\thread\panid_query_server.cpp" />
     <ClCompile Include="..\..\src\core\thread\src_match_controller.cpp" />
     <ClCompile Include="..\..\src\core\thread\thread_netif.cpp" />
+    <ClCompile Include="..\..\src\core\thread\topology.cpp" />
     <ClCompile Include="..\..\src\core\utils\slaac_address.cpp" />
     <ClCompile Include="..\..\src\core\utils\jam_detector.cpp" />
     <ClCompile Include="..\..\src\missing\strlcat\strlcat.c" />

--- a/etc/visual-studio/libopenthread_k.vcxproj.filters
+++ b/etc/visual-studio/libopenthread_k.vcxproj.filters
@@ -240,6 +240,9 @@
     <ClCompile Include="..\..\src\core\thread\thread_netif.cpp">
       <Filter>Source Files\thread</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\core\thread\topology.cpp">
+      <Filter>Source Files\thread</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\core\net\udp6.cpp">
       <Filter>Source Files\net</Filter>
     </ClCompile>

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -72,7 +72,7 @@ libopenthread_mtd_a_CPPFLAGS        = \
 #     All code(files) should be compiled
 #     Even if it is not used or required
 #
-#     For example: In the MTD build, some features 
+#     For example: In the MTD build, some features
 #     are disabled and thus in the traditional scheme
 #     source files could be excluded SOURCES_COMMON
 #     via makefile IF/ELSE/ENDIF constructs.
@@ -176,6 +176,7 @@ SOURCES_COMMON                      = \
     thread/panid_query_server.cpp     \
     thread/src_match_controller.cpp   \
     thread/thread_netif.cpp           \
+    thread/topology.cpp               \
     utils/jam_detector.cpp            \
     utils/slaac_address.cpp           \
     $(NULL)

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2016-2017, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for maintaining Thread network topologies.
+ */
+
+#define WPP_NAME "topology.tmh"
+
+#include <common/code_utils.hpp>
+#include <common/debug.hpp>
+#include <common/logging.hpp>
+#include <thread/topology.hpp>
+
+namespace Thread {
+
+void Neighbor::GenerateChallenge(void)
+{
+    for (uint8_t i = 0; i < sizeof(mValidPending.mPending.mChallenge); i++)
+    {
+        mValidPending.mPending.mChallenge[i] = static_cast<uint8_t>(otPlatRandomGet());
+    }
+}
+
+void Child::GenerateChallenge(void)
+{
+    for (uint8_t i = 0; i < sizeof(mAttachChallenge); i++)
+    {
+        mAttachChallenge[i] = static_cast<uint8_t>(otPlatRandomGet());
+    }
+}
+
+const Mac::Address &Child::GetMacAddress(Mac::Address &aMacAddress) const
+{
+    if (mUseShortAddress)
+    {
+        aMacAddress.mShortAddress = GetRloc16();
+        aMacAddress.mLength = sizeof(aMacAddress.mShortAddress);
+    }
+    else
+    {
+        aMacAddress.mExtAddress = GetExtAddress();
+        aMacAddress.mLength = sizeof(aMacAddress.mExtAddress);
+    }
+
+    return aMacAddress;
+}
+
+}  // namespace Thread

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -89,16 +89,7 @@ public:
      * @returns `true` if the neighbor is in valid, restored, or being restored states, `false` otherwise.
      *
      */
-    bool IsStateValidOrRestoring(void) const {
-        switch (mState) {
-        case kStateValid:
-        case kStateRestored:
-            return true;
-
-        default:
-            return false;
-        }
-    }
+    bool IsStateValidOrRestoring(void) const { return (mState == kStateValid) || (mState == kStateRestored); }
 
     /**
      * This method gets the device mode flags.
@@ -306,11 +297,7 @@ public:
      * This method generates a new challenge value for MLE Link Request/Response exchanges.
      *
      */
-    void GenerateChallenge(void) {
-        for (uint8_t i = 0; i < sizeof(mValidPending.mPending.mChallenge); i++) {
-            mValidPending.mPending.mChallenge[i] = static_cast<uint8_t>(otPlatRandomGet());
-        }
-    }
+    void GenerateChallenge(void);
 
     /**
      * This method returns the current challenge value for MLE Link Request/Response exchanges.
@@ -421,11 +408,7 @@ public:
      * This method generates a new challenge value to use during a child attach.
      *
      */
-    void GenerateChallenge(void) {
-        for (uint8_t i = 0; i < sizeof(mAttachChallenge); i++) {
-            mAttachChallenge[i] = static_cast<uint8_t>(otPlatRandomGet());
-        }
-    }
+    void GenerateChallenge(void);
 
     /**
      * This method gets the current challenge value used during attach.
@@ -634,18 +617,7 @@ public:
      * @returns A (const) reference to the mac address @a aMacAddress.
      *
      */
-    const Mac::Address &GetMacAddress(Mac::Address &aMacAddress) const {
-        if (mUseShortAddress) {
-            aMacAddress.mShortAddress = GetRloc16();
-            aMacAddress.mLength = sizeof(aMacAddress.mShortAddress);
-        }
-        else {
-            aMacAddress.mExtAddress = GetExtAddress();
-            aMacAddress.mLength = sizeof(aMacAddress.mExtAddress);
-        }
-
-        return aMacAddress;
-    }
+    const Mac::Address &GetMacAddress(Mac::Address &aMacAddress) const;
 
 private:
     Ip6::Address mIp6Address[kMaxIp6AddressPerChild];  ///< Registered IPv6 addresses


### PR DESCRIPTION
This commit adds `topology.cpp` corresponding to `topology.hpp`. It
also moves some of the `Child` or `Neighbor` method implementations
to the `cpp` file.