### PR TITLE
Stop datasets timers on otInstanceFinalize.

### DIFF
--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -161,6 +161,10 @@ void otInstanceFinalize(otInstance *aInstance)
     (void)otThreadSetEnabled(aInstance, false);
     (void)otIp6SetEnabled(aInstance, false);
 
+    // Ensure that MeshCoP Datasets timers are switched off.
+    aInstance->mThreadNetif.GetActiveDataset().Stop();
+    aInstance->mThreadNetif.GetPendingDataset().Stop();
+
 #ifndef OPENTHREAD_MULTIPLE_INSTANCE
     sInstance = NULL;
 #endif

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -70,6 +70,11 @@ DatasetManager::DatasetManager(ThreadNetif &aThreadNetif, const Tlv::Type aType,
 {
 }
 
+void DatasetManager::Stop(void)
+{
+    mTimer.Stop();
+}
+
 otInstance *DatasetManager::GetInstance(void)
 {
     return mNetif.GetInstance();

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -62,6 +62,12 @@ public:
      */
     otInstance *GetInstance(void);
 
+    /**
+     * This method stops DatasetManager timer.
+     *
+     */
+    void Stop(void);
+
     Dataset &GetLocal(void) { return mLocal; }
     Dataset &GetNetwork(void) { return mNetwork; }
 


### PR DESCRIPTION
This PR stops potentially running timers used by `DatasetManager `for Active and Pending datasets on Thread disable call.
	
Background: Some applications may decide to turn off Thread protocol (also call `PlatformDeinit`) and switch to other activity. This may lead to problem, since timer scheduler is never cleared and may be left with some unhandled tasks that will fire only after timer overflow or reset after Thread is reinitialized again.

What do you think about adding a new method to clear `TimerScheduler `for example on otIp6SetEnabled(false)`?