### PR TITLE
Include openthread-config.h fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,8 @@ AC_INIT([OPENTHREAD],
         [openthread],
         [http://github.com/openthread/openthread])
 
+AC_DEFINE_UNQUOTED([_openthread_config_h_sentinel_],[1493316498],[This is sentinel to ensure this header is included])
+
 # Tell the rest of the build system the absolute path where the
 # nlbuild-autotools repository is rooted at.
 

--- a/examples/platforms/cc2538/alarm.c
+++ b/examples/platforms/cc2538/alarm.c
@@ -32,10 +32,15 @@
  *
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <openthread-config.h>
 #include "openthread/openthread.h"
 #include "openthread/platform/platform.h"
 #include "openthread/platform/alarm.h"

--- a/examples/platforms/cc2538/diag.c
+++ b/examples/platforms/cc2538/diag.c
@@ -26,12 +26,17 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/time.h>
 
-#include <openthread-config.h>
 #include "openthread/openthread.h"
 
 #include "openthread/platform/alarm.h"

--- a/examples/platforms/cc2538/flash.c
+++ b/examples/platforms/cc2538/flash.c
@@ -26,12 +26,17 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
 
-#include <openthread-config.h>
 #include "openthread/platform/alarm.h"
 #include <utils/flash.h>
 

--- a/examples/platforms/cc2538/misc.c
+++ b/examples/platforms/cc2538/misc.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/types.h"
 #include "openthread/platform/misc.h"
 #include "platform-cc2538.h"

--- a/examples/platforms/cc2538/platform.c
+++ b/examples/platforms/cc2538/platform.c
@@ -32,6 +32,12 @@
  *   This file includes the platform-specific initializers.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "platform-cc2538.h"
 
 otInstance *sInstance;

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -32,7 +32,11 @@
  *
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
 #include <openthread-config.h>
+#endif
 
 #include "openthread/openthread.h"
 #include "openthread/platform/platform.h"

--- a/examples/platforms/cc2538/random.c
+++ b/examples/platforms/cc2538/random.c
@@ -32,6 +32,12 @@
  *
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/types.h"
 #include "openthread/platform/radio.h"
 #include "openthread/platform/random.h"

--- a/examples/platforms/cc2538/uart.c
+++ b/examples/platforms/cc2538/uart.c
@@ -32,6 +32,12 @@
  *
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stddef.h>
 
 #include "openthread/types.h"

--- a/examples/platforms/cc2650/alarm.c
+++ b/examples/platforms/cc2650/alarm.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <openthread/types.h>

--- a/examples/platforms/cc2650/diag.c
+++ b/examples/platforms/cc2650/diag.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/examples/platforms/cc2650/flash.c
+++ b/examples/platforms/cc2650/flash.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "platform-cc2650.h"
 
 /**

--- a/examples/platforms/cc2650/misc.c
+++ b/examples/platforms/cc2650/misc.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <openthread/types.h>
 #include <openthread/platform/misc.h>
 #include <driverlib/sys_ctrl.h>

--- a/examples/platforms/cc2650/radio.c
+++ b/examples/platforms/cc2650/radio.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <openthread/types.h>
 
 #include <assert.h>

--- a/examples/platforms/da15000/flash.c
+++ b/examples/platforms/da15000/flash.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/types.h"
 #include "openthread/platform/alarm.h"
 

--- a/examples/platforms/da15000/logging.c
+++ b/examples/platforms/da15000/logging.c
@@ -31,6 +31,12 @@
 * Platform abstraction for the logging
 *
 */
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/platform/logging.h"
 
 void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)

--- a/examples/platforms/da15000/misc.c
+++ b/examples/platforms/da15000/misc.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/types.h"
 
 #include "openthread/platform/misc.h"

--- a/examples/platforms/da15000/platform.c
+++ b/examples/platforms/da15000/platform.c
@@ -31,6 +31,12 @@
  * This file includes the platform-specific initializers.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <assert.h>
 #include <stdint.h>
 

--- a/examples/platforms/da15000/radio.c
+++ b/examples/platforms/da15000/radio.c
@@ -31,6 +31,12 @@
 * Platform abstraction for radio communication.
 */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <utils/code_utils.h>
 #include "openthread/openthread.h"
 #include "openthread/platform/alarm.h"

--- a/examples/platforms/efr32/alarm.c
+++ b/examples/platforms/efr32/alarm.c
@@ -32,10 +32,15 @@
  *
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <openthread-config.h>
 #include <utils/code_utils.h>
 #include <openthread/platform/platform.h>
 #include <openthread/platform/alarm.h>

--- a/examples/platforms/efr32/diag.c
+++ b/examples/platforms/efr32/diag.c
@@ -32,12 +32,17 @@
  *
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/time.h>
 
-#include <openthread-config.h>
 #include <openthread/platform/alarm.h>
 #include <openthread/platform/radio.h>
 #include "platform-efr32.h"

--- a/examples/platforms/efr32/flash.c
+++ b/examples/platforms/efr32/flash.c
@@ -31,7 +31,12 @@
  *   This file implements the OpenThread platform abstraction for the non-volatile storage.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
 #include <openthread-config.h>
+#endif
+
 #include <openthread/platform/alarm.h>
 #include <utils/flash.h>
 #include <utils/code_utils.h>

--- a/examples/platforms/efr32/logging.c
+++ b/examples/platforms/efr32/logging.c
@@ -38,7 +38,6 @@
 #include <openthread-config.h>
 #endif
 
-
 #include <openthread/platform/logging.h>
 #if OPENTHREAD_ENABLE_CLI_LOGGING
 #include <ctype.h>

--- a/examples/platforms/efr32/misc.c
+++ b/examples/platforms/efr32/misc.c
@@ -31,6 +31,12 @@
  *   This file implements the OpenThread platform abstraction for miscellaneous behaviors.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <openthread/types.h>
 #include <openthread/platform/misc.h>
 

--- a/examples/platforms/efr32/platform.c
+++ b/examples/platforms/efr32/platform.c
@@ -32,6 +32,12 @@
  *   This file includes the platform-specific initializers.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <string.h>
 
 #include <openthread/platform/uart.h>

--- a/examples/platforms/efr32/radio.c
+++ b/examples/platforms/efr32/radio.c
@@ -32,6 +32,12 @@
  *
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <assert.h>
 #include <openthread/types.h>
 #include <openthread-config.h>

--- a/examples/platforms/efr32/random.c
+++ b/examples/platforms/efr32/random.c
@@ -32,6 +32,12 @@
  *
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <utils/code_utils.h>
 #include <openthread/types.h>
 #include <openthread/platform/random.h>

--- a/examples/platforms/efr32/uart.c
+++ b/examples/platforms/efr32/uart.c
@@ -32,6 +32,12 @@
  *
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stddef.h>
 
 #include <utils/code_utils.h>

--- a/examples/platforms/posix/alarm.c
+++ b/examples/platforms/posix/alarm.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "platform-posix.h"
 
 #include <stdbool.h>

--- a/examples/platforms/posix/diag.c
+++ b/examples/platforms/posix/diag.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "platform-posix.h"
 
 #include <stdbool.h>

--- a/examples/platforms/posix/flash-windows-stubs.c
+++ b/examples/platforms/posix/flash-windows-stubs.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "platform-posix.h"
 
 ThreadError utilsFlashInit(void)

--- a/examples/platforms/posix/flash.c
+++ b/examples/platforms/posix/flash.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "platform-posix.h"
 
 #include <stdio.h>

--- a/examples/platforms/posix/misc.c
+++ b/examples/platforms/posix/misc.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "platform-posix.h"
 
 #include "openthread/types.h"

--- a/examples/platforms/posix/platform.c
+++ b/examples/platforms/posix/platform.c
@@ -32,6 +32,12 @@
  *   This file includes the platform-specific initializers.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "platform-posix.h"
 
 #include <assert.h>

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "platform-posix.h"
 
 #include "openthread/platform/diag.h"

--- a/examples/platforms/posix/random.c
+++ b/examples/platforms/posix/random.c
@@ -32,6 +32,12 @@
  *
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <assert.h>
 #include <stdio.h>
 

--- a/examples/platforms/posix/spi-stubs.c
+++ b/examples/platforms/posix/spi-stubs.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "platform-posix.h"
 
 #include <stdio.h>

--- a/examples/platforms/posix/uart-posix.c
+++ b/examples/platforms/posix/uart-posix.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "platform-posix.h"
 
 #include <assert.h>

--- a/examples/platforms/posix/uart-windows.c
+++ b/examples/platforms/posix/uart-windows.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "platform-posix.h"
 
 #include "openthread/platform/uart.h"

--- a/examples/platforms/utils/settings.cpp
+++ b/examples/platforms/utils/settings.cpp
@@ -32,6 +32,12 @@
  *
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdlib.h>
 #include <stddef.h>
 #include "utils/wrap_string.h"

--- a/include/openthread-windows-config.h
+++ b/include/openthread-windows-config.h
@@ -26,6 +26,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+/* This is sentinel to ensure this header is included */
+#define _openthread_config_h_sentinel_ 1493316498
+
 /* Define to 1 to enable the NCP UART interface. */
 // On the command line: #define OPENTHREAD_ENABLE_NCP_UART 0
 

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -34,10 +34,8 @@
 #ifndef CLI_HPP_
 #define CLI_HPP_
 
-#ifdef OPENTHREAD_CONFIG_FILE
-#include OPENTHREAD_CONFIG_FILE
-#else
-#include <openthread-config.h>
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
 #endif
 
 #include <stdarg.h>

--- a/src/core/api/border_agent_proxy_api.cpp
+++ b/src/core/api/border_agent_proxy_api.cpp
@@ -31,6 +31,12 @@
  *   This file implements the OpenThread Border Agent Proxy API.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/border_agent_proxy.h"
 
 #include "openthread-instance.h"

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -31,6 +31,12 @@
  *   This file implements the OpenThread CoAP API.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/coap.h"
 
 #include "openthread-instance.h"

--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -31,6 +31,12 @@
  *   This file implements the OpenThread UDP API.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/commissioner.h"
 
 #include "openthread-instance.h"

--- a/src/core/api/crypto_api.cpp
+++ b/src/core/api/crypto_api.cpp
@@ -31,6 +31,12 @@
  *   This file implements the OpenThread Crypto API.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/crypto.h"
 
 #include "common/debug.hpp"

--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -31,6 +31,12 @@
  *   This file implements the OpenThread Operational Dataset API (for both FTD and MTD).
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/dataset.h"
 
 #include "openthread-instance.h"

--- a/src/core/api/dataset_ftd_api.cpp
+++ b/src/core/api/dataset_ftd_api.cpp
@@ -31,6 +31,12 @@
  *   This file implements the OpenThread Operational Dataset API (FTD only).
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/dataset_ftd.h"
 
 #include "openthread-instance.h"

--- a/src/core/api/dhcp6_api.cpp
+++ b/src/core/api/dhcp6_api.cpp
@@ -31,6 +31,12 @@
  *   This file implements the OpenThread UDP API.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/dhcp6_client.h"
 #include "openthread/dhcp6_server.h"
 

--- a/src/core/api/dns_api.cpp
+++ b/src/core/api/dns_api.cpp
@@ -31,6 +31,12 @@
  *   This file implements the OpenThread UDP API.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/dns.h"
 
 #include "openthread-instance.h"

--- a/src/core/api/icmp6_api.cpp
+++ b/src/core/api/icmp6_api.cpp
@@ -31,6 +31,12 @@
  *   This file implements the OpenThread UDP API.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/icmp6.h"
 
 #include "openthread-instance.h"

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -33,6 +33,12 @@
 
 #define WPP_NAME "ip6_api.tmh"
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/ip6.h"
 
 #include "openthread-instance.h"

--- a/src/core/api/jam_detection_api.cpp
+++ b/src/core/api/jam_detection_api.cpp
@@ -31,6 +31,12 @@
  *   This file implements the OpenThread Jam Detection API.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/jam_detection.h"
 
 #include "openthread-instance.h"

--- a/src/core/api/joiner_api.cpp
+++ b/src/core/api/joiner_api.cpp
@@ -31,6 +31,12 @@
  *   This file implements the OpenThread UDP API.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/joiner.h"
 
 #include "openthread-instance.h"

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -31,6 +31,12 @@
  *   This file implements the OpenThread Link API.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/link.h"
 
 #include "openthread-instance.h"

--- a/src/core/api/link_raw.hpp
+++ b/src/core/api/link_raw.hpp
@@ -34,6 +34,10 @@
 #ifndef LINK_RAW_HPP_
 #define LINK_RAW_HPP_
 
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
+#endif
+
 #include <openthread-core-config.h>
 #include "openthread/link_raw.h"
 

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -31,6 +31,12 @@
  *   This file implements blacklist IEEE 802.15.4 frame filtering based on MAC address.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <common/debug.hpp>
 #include <common/logging.hpp>
 #include "openthread/platform/random.h"

--- a/src/core/api/message_api.cpp
+++ b/src/core/api/message_api.cpp
@@ -31,6 +31,12 @@
  *   This file implements the OpenThread Message API.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/message.h"
 
 #include "openthread-instance.h"

--- a/src/core/api/netdata_api.cpp
+++ b/src/core/api/netdata_api.cpp
@@ -31,6 +31,12 @@
  *   This file implements the OpenThread Network Data API.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/netdata.h"
 
 #include "openthread-instance.h"

--- a/src/core/api/tasklet_api.cpp
+++ b/src/core/api/tasklet_api.cpp
@@ -33,6 +33,12 @@
 
 #define WPP_NAME "tasklet_api.tmh"
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/tasklet.h"
 
 #include "openthread-instance.h"

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -33,6 +33,12 @@
 
 #define WPP_NAME "thread_api.tmh"
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/thread.h"
 
 #include "openthread-instance.h"

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -33,6 +33,12 @@
 
 #define WPP_NAME "thread_ftd_api.tmh"
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/thread_ftd.h"
 
 #include "openthread-instance.h"

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -31,6 +31,12 @@
  *   This file implements the OpenThread UDP API.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "openthread/udp.h"
 
 #include "openthread-instance.h"

--- a/src/core/coap/coap_base.hpp
+++ b/src/core/coap/coap_base.hpp
@@ -29,6 +29,10 @@
 #ifndef COAP_BASE_HPP_
 #define COAP_BASE_HPP_
 
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
+#endif
+
 #include "openthread/coap.h"
 
 #include <coap/coap_header.hpp>

--- a/src/core/common/code_utils.hpp
+++ b/src/core/common/code_utils.hpp
@@ -34,6 +34,10 @@
 #ifndef CODE_UTILS_HPP_
 #define CODE_UTILS_HPP_
 
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
+#endif
+
 #include "utils/wrap_stdbool.h"
 
 // Calculates the aligned variable size.

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -34,10 +34,8 @@
 #ifndef MESSAGE_HPP_
 #define MESSAGE_HPP_
 
-#ifdef OPENTHREAD_CONFIG_FILE
-#include OPENTHREAD_CONFIG_FILE
-#else
-#include <openthread-config.h>
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
 #endif
 
 #include "utils/wrap_stdint.h"

--- a/src/core/crypto/mbedtls.hpp
+++ b/src/core/crypto/mbedtls.hpp
@@ -34,10 +34,8 @@
 #ifndef OT_MBEDTLS_HPP_
 #define OT_MBEDTLS_HPP_
 
-#ifdef OPENTHREAD_CONFIG_FILE
-#include OPENTHREAD_CONFIG_FILE
-#else
-#include <openthread-config.h>
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
 #endif
 
 #include <openthread-core-config.h>

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -34,6 +34,10 @@
 #ifndef MAC_HPP_
 #define MAC_HPP_
 
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
+#endif
+
 #include "openthread/platform/radio.h"
 
 #include <openthread-core-config.h>

--- a/src/core/mac/mac_blacklist.hpp
+++ b/src/core/mac/mac_blacklist.hpp
@@ -26,10 +26,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef OPENTHREAD_CONFIG_FILE
-#include OPENTHREAD_CONFIG_FILE
-#else
-#include <openthread-config.h>
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
 #endif
 
 #if OPENTHREAD_ENABLE_MAC_WHITELIST

--- a/src/core/mac/mac_whitelist.hpp
+++ b/src/core/mac/mac_whitelist.hpp
@@ -26,10 +26,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef OPENTHREAD_CONFIG_FILE
-#include OPENTHREAD_CONFIG_FILE
-#else
-#include <openthread-config.h>
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
 #endif
 
 #if OPENTHREAD_ENABLE_MAC_WHITELIST

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -34,6 +34,10 @@
 #ifndef JOINER_HPP_
 #define JOINER_HPP_
 
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
+#endif
+
 #include "openthread/joiner.h"
 
 #include <coap/coap_header.hpp>

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -34,6 +34,10 @@
 #ifndef NET_NETIF_HPP_
 #define NET_NETIF_HPP_
 
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
+#endif
+
 #include <common/message.hpp>
 #include <common/tasklet.hpp>
 #include <mac/mac_frame.hpp>

--- a/src/core/openthread-instance.h
+++ b/src/core/openthread-instance.h
@@ -35,6 +35,10 @@
 #ifndef OPENTHREADINSTANCE_H_
 #define OPENTHREADINSTANCE_H_
 
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
+#endif
+
 #include "utils/wrap_stdint.h"
 #include "utils/wrap_stdbool.h"
 

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -26,6 +26,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
+#endif
+
 #if OPENTHREAD_MTD
 #include "mle_router_mtd.hpp"
 #elif OPENTHREAD_FTD

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -34,10 +34,8 @@
 #ifndef THREAD_NETIF_HPP_
 #define THREAD_NETIF_HPP_
 
-#ifdef OPENTHREAD_CONFIG_FILE
-#include OPENTHREAD_CONFIG_FILE
-#else
-#include <openthread-config.h>
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
 #endif
 
 #include "openthread/types.h"

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -34,6 +34,10 @@
 #ifndef THREAD_TLVS_HPP_
 #define THREAD_TLVS_HPP_
 
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
+#endif
+
 #include "openthread/types.h"
 
 #include <common/encoding.hpp>

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -34,10 +34,8 @@
 #ifndef JAM_DETECTOR_HPP_
 #define JAM_DETECTOR_HPP_
 
-#ifdef OPENTHREAD_CONFIG_FILE
-#include OPENTHREAD_CONFIG_FILE
-#else
-#include <openthread-config.h>
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
 #endif
 
 #include "utils/wrap_stdint.h"

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -33,10 +33,8 @@
 #ifndef NCP_BASE_HPP_
 #define NCP_BASE_HPP_
 
-#ifdef OPENTHREAD_CONFIG_FILE
-#include OPENTHREAD_CONFIG_FILE
-#else
-#include <openthread-config.h>
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
 #endif
 
 #include "openthread/types.h"

--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -33,10 +33,8 @@
 #ifndef NCP_SPI_HPP_
 #define NCP_SPI_HPP_
 
-#ifdef OPENTHREAD_CONFIG_FILE
-#include OPENTHREAD_CONFIG_FILE
-#else
-#include <openthread-config.h>
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
 #endif
 
 #include <ncp/ncp_base.hpp>

--- a/src/ncp/ncp_uart.hpp
+++ b/src/ncp/ncp_uart.hpp
@@ -33,10 +33,8 @@
 #ifndef NCP_UART_HPP_
 #define NCP_UART_HPP_
 
-#ifdef OPENTHREAD_CONFIG_FILE
-#include OPENTHREAD_CONFIG_FILE
-#else
-#include <openthread-config.h>
+#if !defined(_openthread_config_h_sentinel_)
+#error "Please include <openthread-config.h> first"
 #endif
 
 #include <ncp/ncp_base.hpp>

--- a/tests/unit/test_aes.cpp
+++ b/tests/unit/test_aes.cpp
@@ -26,6 +26,13 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "test_util.h"
 #include "openthread/openthread.h"
 #include <common/debug.hpp>

--- a/tests/unit/test_diag.cpp
+++ b/tests/unit/test_diag.cpp
@@ -26,6 +26,13 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "test_util.h"
 #include "utils/wrap_string.h"
 

--- a/tests/unit/test_fuzz.cpp
+++ b/tests/unit/test_fuzz.cpp
@@ -26,6 +26,13 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "test_platform.h"
 //#include <mac/mac_frame.hpp>
 

--- a/tests/unit/test_hmac_sha256.cpp
+++ b/tests/unit/test_hmac_sha256.cpp
@@ -26,6 +26,13 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "test_util.h"
 #include "openthread/openthread.h"
 #include <common/debug.hpp>

--- a/tests/unit/test_link_quality.cpp
+++ b/tests/unit/test_link_quality.cpp
@@ -26,6 +26,13 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "test_util.h"
 #include "openthread/openthread.h"
 #include <thread/link_quality.hpp>

--- a/tests/unit/test_lowpan.cpp
+++ b/tests/unit/test_lowpan.cpp
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "test_util.hpp"
 #include "test_lowpan.hpp"
 

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -26,6 +26,13 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "test_util.h"
 #include "openthread/openthread.h"
 #include <common/debug.hpp>

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "test_util.h"
 #include "openthread/openthread.h"
 #include <openthread-instance.h>

--- a/tests/unit/test_message_queue.cpp
+++ b/tests/unit/test_message_queue.cpp
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "test_util.h"
 
 #include "openthread/openthread.h"

--- a/tests/unit/test_ncp_buffer.cpp
+++ b/tests/unit/test_ncp_buffer.cpp
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <ctype.h>
 #include "test_util.h"
 #include "openthread/openthread.h"

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "test_platform.h"
 
 #if _WIN32

--- a/tests/unit/test_priority_queue.cpp
+++ b/tests/unit/test_priority_queue.cpp
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "test_util.h"
 #include "openthread/openthread.h"
 #include <openthread-instance.h>

--- a/tests/unit/test_strlcat.c
+++ b/tests/unit/test_strlcat.c
@@ -25,6 +25,12 @@
  *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "utils/wrap_string.h"

--- a/tests/unit/test_strlcpy.c
+++ b/tests/unit/test_strlcpy.c
@@ -25,6 +25,12 @@
  *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "utils/wrap_string.h"

--- a/tests/unit/test_strnlen.c
+++ b/tests/unit/test_strnlen.c
@@ -25,6 +25,12 @@
  *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "utils/wrap_string.h"

--- a/tests/unit/test_timer.cpp
+++ b/tests/unit/test_timer.cpp
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "test_platform.h"
 #include <common/debug.hpp>
 #include <common/timer.hpp>

--- a/tests/unit/test_toolchain.cpp
+++ b/tests/unit/test_toolchain.cpp
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdio.h>
 #include "utils/wrap_stdint.h"
 

--- a/tests/unit/test_toolchain_c.c
+++ b/tests/unit/test_toolchain_c.c
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdio.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/tests/unit/test_util.cpp
+++ b/tests/unit/test_util.cpp
@@ -26,6 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "test_util.h"
 
 #include <vector>

--- a/tests/unit/test_windows.cpp
+++ b/tests/unit/test_windows.cpp
@@ -28,6 +28,14 @@
 
 #include <SDKDDKVer.h>
 #include "CppUnitTest.h"
+
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
+
 #include "test_util.h"
 #include "test_platform.h"
 


### PR DESCRIPTION
In the last pull request (1642) - it was discovered that the 'openthread-config.h' is not consistently included, or is/was included in different ways.  This commit fixes/addresses these issues.

For example:
src/core/common/logging.cpp - includes openthread-config.h as the first step.

In contrast, "src/core/api/coap_api.cpp" - includes 'openthread-instance.h'
Which in turn includes many other openthread headers - 

The result/problem:

Because of the C PreProcessor rules, the various tests such as:
```
#if  SOMETHING_IS_ENABLED
 ... code here ...
#endif
````
Effectively become (C standard is: Undefined preprocessor macro has value 0)
```
#if 0
```
There are other more convoluted forms of this problem.

What's happening in this commit - is the following:

1) All source code includes  "openthread-config.h" (or its defined name) as the first thing.

2) No header file includes "openthread-config.h" any more.

3) In openthread-config.h - we create a sentinel, (a simple define)
Then - in various internal openthread headers, we test for that sentinel
In the correct and proper case (openthread-config.h was included) the sentinel is present
In the error case (somebody forgot to include openthread-config.h, an error is raised.

Item 3 - is exactly automatic policeman policy, to ensure that headers are included in the proper order.
