### PR TITLE
Add include openthread-config.h to missing_str*.c files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -539,6 +539,7 @@ AM_CONDITIONAL([OPENTHREAD_ENABLE_BUILTIN_MBEDTLS], [test "${enable_builtin_mbed
 # Thread Border Agent Proxy
 #
 
+AC_MSG_CHECKING([whether to enable border router proxy])
 AC_ARG_ENABLE(border_agent_proxy,
     [AS_HELP_STRING([--enable-border-agent-proxy],[Enable border agent proxy support @<:@default=no@:>@.])],
     [
@@ -1132,6 +1133,20 @@ AC_MSG_NOTICE([checking required package dependencies])
 # Check for headers
 #
 
+#---------------------------------------------------
+# Enable BSD Security Features
+# This enables strlcpy() and other friends in GNU land.
+# While the references below generally speak of: "glibc"
+# The ARM Embedded platform uses the nano instance of NEWLIB
+# Which greatly follows and mirrors glibc.
+# --------------------------------------------------
+#
+# References:
+# 1) http://stackoverflow.com/questions/29201515/what-does-d-default-source-do
+# 2) http://man7.org/linux/man-pages/man7/feature_test_macros.7.html
+#
+CFLAGS="${CFLAGS} -D_BSD_SOURCE=1 -D_DEFAULT_SOURCE=1"
+CXXFLAGS="${CXXFLAGS} -D_BSD_SOURCE=1 -D_DEFAULT_SOURCE=1"
 
 OLD_CFLAGS="${CFLAGS}"
 CFLAGS="${CFLAGS} -Wno-error=address"

--- a/src/core/utils/missing_strlcat.c
+++ b/src/core/utils/missing_strlcat.c
@@ -25,6 +25,12 @@
  *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "utils/wrap_string.h"
 
 size_t missing_strlcat(char *dest, const char *src, size_t size)

--- a/src/core/utils/missing_strlcpy.c
+++ b/src/core/utils/missing_strlcpy.c
@@ -25,6 +25,12 @@
  *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "utils/wrap_string.h"
 
 size_t missing_strlcpy(char *dest, const char *src, size_t size)

--- a/src/core/utils/missing_strnlen.c
+++ b/src/core/utils/missing_strnlen.c
@@ -25,6 +25,12 @@
  *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "utils/wrap_string.h"
 
 size_t missing_strnlen(const char *s, size_t maxlen)


### PR DESCRIPTION
Missed in my last commit (#1642) 
the files: src/core/utils/missing_str*.c did not include openthread-config.h
