### PR TITLE
Update `configure.ac` to include `strnlen` under `enable_no_executables_hack`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -175,6 +175,7 @@ then
     # being performed later in the configuration process.
     ac_cv_func_strlcat=${ac_cv_func_strlcat-no}
     ac_cv_func_strlcpy=${ac_cv_func_strlcpy-no}
+    ac_cv_func_strnlen=${ac_cv_func_strnlen-no}
 else
     AC_MSG_RESULT([no])
 fi
@@ -349,7 +350,7 @@ NL_ENABLE_TESTS([yes])
 
 AM_CONDITIONAL([OPENTHREAD_BUILD_TESTS], [test "${nl_cv_build_tests}" = "yes"])
 
-# 
+#
 # CLI Library
 #
 AC_ARG_ENABLE(cli-app,


### PR DESCRIPTION
This would address issue https://github.com/openthread/openthread/issues/1681

Also see: https://github.com/openthread/openthread/commit/812cc838ebe8bec59831273d5e296f32ade0ffa4#commitcomment-21953634