### PR TITLE
Make Network Diagnostic optional for MTD.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -569,6 +569,38 @@ AM_CONDITIONAL([OPENTHREAD_ENABLE_BORDER_AGENT_PROXY], [test "${enable_border_ag
 AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_BORDER_AGENT_PROXY],[${OPENTHREAD_ENABLE_BORDER_AGENT_PROXY}],[Define to 1 to enable the border agent proxy feature.])
 
 #
+# Thread Network Diagnostic for MTD
+#
+
+AC_ARG_ENABLE(mtd_network_diagnostic,
+    [AS_HELP_STRING([--enable-mtd-network-diagnostic],[Enable network diagnostic support for MTD @<:@default=yes@:>@.])],
+    [
+        case "${enableval}" in
+
+        no|yes)
+            enable_mtd_network_diagnostic=${enableval}
+            ;;
+
+        *)
+            AC_MSG_ERROR([Invalid value ${enable_mtd_network_diagnostic} for --enable-mtd-network-diagnostic])
+            ;;
+        esac
+    ],
+    [enable_mtd_network_diagnostic=yes])
+
+if test "$enable_mtd_network_diagnostic" = "yes"; then
+    OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC=1
+else
+    OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC=0
+fi
+
+AC_MSG_CHECKING([whether to enable the network diagnostic for MTD])
+AC_MSG_RESULT(${enable_mtd_network_diagnostic})
+AC_SUBST(OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC)
+AM_CONDITIONAL([OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC], [test "${enable_mtd_network_diagnostic}" = "yes"])
+AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC],[${OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC}],[Define to 1 to enable network diagnostic for MTD.])
+
+#
 # Thread Commissioner
 #
 
@@ -1303,6 +1335,7 @@ AC_MSG_NOTICE([
   OpenThread NCP-MTD support                : ${enable_ncp_app_mtd}
   OpenThread NCP-FTD support                : ${enable_ncp_app_ftd}
   OpenThread NCP-BUS Configuration          : ${with_ncp_bus}
+  OpenThread MTD Network Diagnostic support : ${enable_mtd_network_diagnostic}
   OpenThread builtin mbedtls support        : ${enable_builtin_mbedtls}
   OpenThread Border Agent Proxy support     : ${enable_border_agent_proxy}
   OpenThread Commissioner support           : ${enable_commissioner}

--- a/configure.ac
+++ b/configure.ac
@@ -573,7 +573,7 @@ AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_BORDER_AGENT_PROXY],[${OPENTHREAD_ENABLE_B
 #
 
 AC_ARG_ENABLE(mtd_network_diagnostic,
-    [AS_HELP_STRING([--enable-mtd-network-diagnostic],[Enable network diagnostic support for MTD @<:@default=yes@:>@.])],
+    [AS_HELP_STRING([--enable-mtd-network-diagnostic],[Enable network diagnostic support for MTD @<:@default=no@:>@.])],
     [
         case "${enableval}" in
 
@@ -586,7 +586,7 @@ AC_ARG_ENABLE(mtd_network_diagnostic,
             ;;
         esac
     ],
-    [enable_mtd_network_diagnostic=yes])
+    [enable_mtd_network_diagnostic=no])
 
 if test "$enable_mtd_network_diagnostic" = "yes"; then
     OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC=1

--- a/examples/Makefile-posix
+++ b/examples/Makefile-posix
@@ -81,27 +81,27 @@ TargetTuple                     = $(shell ${AbsTopSourceDir}/third_party/nlbuild
 # If the user has asserted COVERAGE, alter the configuration options
 # accordingly.
 
-configure_OPTIONS               = \
-    --enable-cli-app=all          \
-    --enable-ncp-app=all          \
-    --with-ncp-bus=uart           \
-    --enable-diag                 \
-    --enable-default-logging      \
-    --enable-raw-link-api=yes     \
-    --with-examples=posix         \
-    --with-platform-info=POSIX    \
-    --enable-application-coap     \
-    --enable-border-agent-proxy   \
-    --enable-cert-log             \
-    --enable-commissioner         \
-    --enable-dhcp6-client         \
-    --enable-dhcp6-server         \
-    --enable-dns-client           \
-    --enable-jam-detection        \
-    --enable-joiner               \
-    --enable-legacy               \
-    --enable-mac-whitelist        \
-    --enable-mtd-network-diagnostic=no \
+configure_OPTIONS                   = \
+    --enable-cli-app=all              \
+    --enable-ncp-app=all              \
+    --with-ncp-bus=uart               \
+    --enable-diag                     \
+    --enable-default-logging          \
+    --enable-raw-link-api=yes         \
+    --with-examples=posix             \
+    --with-platform-info=POSIX        \
+    --enable-application-coap         \
+    --enable-border-agent-proxy       \
+    --enable-cert-log                 \
+    --enable-commissioner             \
+    --enable-dhcp6-client             \
+    --enable-dhcp6-server             \
+    --enable-dns-client               \
+    --enable-jam-detection            \
+    --enable-joiner                   \
+    --enable-legacy                   \
+    --enable-mac-whitelist            \
+    --enable-mtd-network-diagnostic   \
     $(NULL)
 
 ifeq ($(COVERAGE),1)

--- a/examples/Makefile-posix
+++ b/examples/Makefile-posix
@@ -101,6 +101,7 @@ configure_OPTIONS               = \
     --enable-joiner               \
     --enable-legacy               \
     --enable-mac-whitelist        \
+    --enable-mtd-network-diagnostic=no \
     $(NULL)
 
 ifeq ($(COVERAGE),1)

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -151,7 +151,9 @@ const struct Command Interpreter::sCommands[] =
     { "masterkey", &Interpreter::ProcessMasterKey },
     { "mode", &Interpreter::ProcessMode },
     { "netdataregister", &Interpreter::ProcessNetworkDataRegister },
+#if OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
     { "networkdiagnostic", &Interpreter::ProcessNetworkDiagnostic },
+#endif // OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
 #if OPENTHREAD_FTD
     { "networkidtimeout", &Interpreter::ProcessNetworkIdTimeout },
 #endif
@@ -238,7 +240,9 @@ Interpreter::Interpreter(otInstance *aInstance):
 #else
     memset(mSlaacAddresses, 0, sizeof(mSlaacAddresses));
     otSetStateChangedCallback(mInstance, &Interpreter::s_HandleNetifStateChanged, this);
+#if OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
     otThreadSetReceiveDiagnosticGetCallback(mInstance, &Interpreter::s_HandleDiagnosticGetResponse, this);
+#endif
 
     mIcmpHandler.mReceiveCallback = Interpreter::s_HandleIcmpReceive;
     mIcmpHandler.mContext         = this;
@@ -3030,6 +3034,7 @@ exit:
     return;
 }
 
+#if OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
 void Interpreter::ProcessNetworkDiagnostic(int argc, char *argv[])
 {
     ThreadError error = kThreadError_None;
@@ -3068,6 +3073,7 @@ void Interpreter::ProcessNetworkDiagnostic(int argc, char *argv[])
 exit:
     AppendResult(error);
 }
+#endif // OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
 
 #ifndef OTDLL
 void Interpreter::s_HandleDiagnosticGetResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo,

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -226,7 +226,9 @@ private:
     void ProcessMasterKey(int argc, char *argv[]);
     void ProcessMode(int argc, char *argv[]);
     void ProcessNetworkDataRegister(int argc, char *argv[]);
+#if OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
     void ProcessNetworkDiagnostic(int argc, char *argv[]);
+#endif // OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
 #if OPENTHREAD_FTD
     void ProcessNetworkIdTimeout(int argc, char *argv[]);
 #endif

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -434,6 +434,12 @@ const char *otGetVersionString(void)
     return sVersion;
 }
 
+ThreadError otThreadSetPreferredRouterId(otInstance *aInstance, uint8_t aRouterId)
+{
+    return aInstance->mThreadNetif.GetMle().SetPreferredRouterId(aRouterId);
+}
+
+#if OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
 void otThreadSetReceiveDiagnosticGetCallback(otInstance *aInstance, otReceiveDiagnosticGetCallback aCallback,
                                              void *aCallbackContext)
 {
@@ -457,6 +463,7 @@ ThreadError otThreadSendDiagnosticReset(otInstance *aInstance, const otIp6Addres
                                                                               aTlvTypes,
                                                                               aCount);
 }
+#endif // OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
 
 ThreadError otThreadSetEnabled(otInstance *aInstance, bool aEnabled)
 {

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -434,11 +434,6 @@ const char *otGetVersionString(void)
     return sVersion;
 }
 
-ThreadError otThreadSetPreferredRouterId(otInstance *aInstance, uint8_t aRouterId)
-{
-    return aInstance->mThreadNetif.GetMle().SetPreferredRouterId(aRouterId);
-}
-
 #if OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
 void otThreadSetReceiveDiagnosticGetCallback(otInstance *aInstance, otReceiveDiagnosticGetCallback aCallback,
                                              void *aCallbackContext)

--- a/src/core/crypto/pbkdf2_cmac.h
+++ b/src/core/crypto/pbkdf2_cmac.h
@@ -59,7 +59,7 @@ extern "C" {
 void otPbkdf2Cmac(
     const uint8_t *aPassword, uint16_t aPasswordLen,
     const uint8_t *aSalt, uint16_t aSaltLen,
-    uint32_t aIterationCounter , uint16_t aKeyLen,
+    uint32_t aIterationCounter, uint16_t aKeyLen,
     uint8_t *aKey);
 
 #ifdef __cplusplus

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -58,6 +58,8 @@
 
 using ot::Encoding::BigEndian::HostSwap16;
 
+#if OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
+
 namespace ot {
 
 namespace NetworkDiagnostic {
@@ -642,3 +644,5 @@ exit:
 }  // namespace NetworkDiagnostic
 
 }  // namespace ot
+
+#endif // OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -82,7 +82,9 @@ ThreadNetif::ThreadNetif(Ip6::Ip6 &aIp6):
     mMleRouter(*this),
     mNetworkDataLocal(*this),
     mNetworkDataLeader(*this),
+#if OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
     mNetworkDiagnostic(*this),
+#endif
 #if OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
     mSecureCoapServer(*this, OPENTHREAD_CONFIG_JOINER_UDP_PORT),
     mCommissioner(*this),

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -161,14 +161,6 @@ public:
      */
     virtual ThreadError RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination, uint8_t *aPrefixMatch);
 
-    /**
-     * This method returns a reference to the address resolver object.
-     *
-     * @returns A reference to the address resolver object.
-     *
-     */
-    AddressResolver &GetAddressResolver(void) { return mAddressResolver; }
-
 #if OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
     /**
      * This method returns a reference to the network diagnostic object.

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -162,12 +162,22 @@ public:
     virtual ThreadError RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination, uint8_t *aPrefixMatch);
 
     /**
+     * This method returns a reference to the address resolver object.
+     *
+     * @returns A reference to the address resolver object.
+     *
+     */
+    AddressResolver &GetAddressResolver(void) { return mAddressResolver; }
+
+#if OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
+    /**
      * This method returns a reference to the network diagnostic object.
      *
      * @returns A reference to the address resolver object.
      *
      */
     NetworkDiagnostic::NetworkDiagnostic &GetNetworkDiagnostic(void) { return mNetworkDiagnostic; }
+#endif // OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
 
 #if OPENTHREAD_ENABLE_DHCP6_CLIENT
     /**
@@ -427,7 +437,9 @@ private:
     Mle::MleRouter mMleRouter;
     NetworkData::Local mNetworkDataLocal;
     NetworkData::Leader mNetworkDataLeader;
+#if OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
     NetworkDiagnostic::NetworkDiagnostic mNetworkDiagnostic;
+#endif // OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
     bool mIsUp;
 
 #if OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD


### PR DESCRIPTION
As the spec says,
> 10.11.2 Diagnostic Commands
> The diagnostic commands provide a mechanism to obtain connectivity, topology and link quality data from all the Thread devices in a Thread Network. The cornerstone of the initial Thread diagnostics protocol is to simply provide a multi-hop query mechanism for TLVs over CoAP. Thread Diagnostic commands MUST be supported by FTDs. Thread Diagnostic commands are optional for MTDs and MAY be supported.

This PR,
* Adds an option to disable Network Diagnostic feature on MTD
* Fixed a style issue in src/core/crypto/pbkdf2_cmac.h