### PR TITLE
[Spinel protocol spec] Update the Copyright Notice.

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -34,8 +34,8 @@ EXTRA_DIST                                      = \
     $(srcdir)/images/Open-Thread-Logo-200x42.png  \
     $(srcdir)/images/openthread_contrib.png       \
     $(srcdir)/images/openthread_logo.png          \
-    draft-spinel-protocol.txt                     \
-    draft-spinel-protocol.html                    \
+    draft-rquattle-spinel-unified.html            \
+    draft-rquattle-spinel-unified.txt             \
     $(NULL)
 
 #

--- a/doc/draft-rquattle-spinel-unified.html
+++ b/doc/draft-rquattle-spinel-unified.html
@@ -385,7 +385,7 @@
 <link href="#rfc.section.2" rel="Chapter" title="2 Frame Format"/>
 <link href="#rfc.section.2.1" rel="Chapter" title="2.1 Header Format"/>
 <link href="#rfc.section.2.1.1" rel="Chapter" title="2.1.1 FLG: Flag"/>
-<link href="#rfc.section.2.1.2" rel="Chapter" title="2.1.2 IID: Interface Identifier"/>
+<link href="#rfc.section.2.1.2" rel="Chapter" title="2.1.2 NLI: Network Link Identifier"/>
 <link href="#rfc.section.2.1.3" rel="Chapter" title="2.1.3 TID: Transaction Identifier"/>
 <link href="#rfc.section.2.1.4" rel="Chapter" title="2.1.4 Command Identifier (CMD)"/>
 <link href="#rfc.section.2.1.5" rel="Chapter" title="2.1.5 Command Payload (Optional)"/>
@@ -462,7 +462,9 @@
 <link href="#rfc.section.5.6.7" rel="Chapter" title="5.6.7 PROP 70: PROP_NET_MASTER_KEY"/>
 <link href="#rfc.section.5.6.8" rel="Chapter" title="5.6.8 PROP 71: PROP_NET_KEY_SEQUENCE_COUNTER"/>
 <link href="#rfc.section.5.6.9" rel="Chapter" title="5.6.9 PROP 72: PROP_NET_PARTITION_ID"/>
-<link href="#rfc.section.5.6.10" rel="Chapter" title="5.6.10 PROP 73: PROP_NET_KEY_SWITCH_GUARDTIME"/>
+<link href="#rfc.section.5.6.10" rel="Chapter" title="5.6.10 PROP 73: PROP_NET_REQUIRE_JOIN_EXISTING"/>
+<link href="#rfc.section.5.6.11" rel="Chapter" title="5.6.11 PROP 74: PROP_NET_KEY_SWITCH_GUARDTIME"/>
+<link href="#rfc.section.5.6.12" rel="Chapter" title="5.6.12 PROP 75: PROP_NET_PSKC"/>
 <link href="#rfc.section.5.7" rel="Chapter" title="5.7 IPv6 Properties"/>
 <link href="#rfc.section.5.7.1" rel="Chapter" title="5.7.1 PROP 96: PROP_IPV6_LL_ADDR"/>
 <link href="#rfc.section.5.7.2" rel="Chapter" title="5.7.2 PROP 97: PROP_IPV6_ML_ADDR"/>
@@ -471,6 +473,7 @@
 <link href="#rfc.section.5.7.5" rel="Chapter" title="5.7.5 PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD"/>
 <link href="#rfc.section.5.8" rel="Chapter" title="5.8 Debug Properties"/>
 <link href="#rfc.section.5.8.1" rel="Chapter" title="5.8.1 PROP 16384: SPINEL_PROP_DEBUG_TEST_ASSERT"/>
+<link href="#rfc.section.5.8.2" rel="Chapter" title="5.8.2 PROP 16385: SPINEL_PROP_DEBUG_NCP_LOG_LEVEL"/>
 <link href="#rfc.section.6" rel="Chapter" title="6 Status Codes"/>
 <link href="#rfc.section.7" rel="Chapter" title="7 Technology: Thread"/>
 <link href="#rfc.section.7.1" rel="Chapter" title="7.1 Thread Capabilities"/>
@@ -505,6 +508,10 @@
 <link href="#rfc.section.7.2.28" rel="Chapter" title="7.2.28 PROP 5388: PROP_THREAD_CHILD_COUNT_MAX"/>
 <link href="#rfc.section.7.2.29" rel="Chapter" title="7.2.29 PROP 5389: PROP_THREAD_LEADER_NETWORK_DATA"/>
 <link href="#rfc.section.7.2.30" rel="Chapter" title="7.2.30 PROP 5390: PROP_THREAD_STABLE_LEADER_NETWORK_DATA"/>
+<link href="#rfc.section.7.2.31" rel="Chapter" title="7.2.31 PROP 5391: PROP_THREAD_JOINERS"/>
+<link href="#rfc.section.7.2.32" rel="Chapter" title="7.2.32 PROP 5392: PROP_THREAD_COMMISSIONER_ENABLED"/>
+<link href="#rfc.section.7.2.33" rel="Chapter" title="7.2.33 PROP 5393: PROP_THREAD_BA_PROXY_ENABLED"/>
+<link href="#rfc.section.7.2.34" rel="Chapter" title="7.2.34 PROP 5394: PROP_THREAD_BA_PROXY_STREAM"/>
 <link href="#rfc.section.8" rel="Chapter" title="8 Feature: Network Save"/>
 <link href="#rfc.section.8.1" rel="Chapter" title="8.1 Commands"/>
 <link href="#rfc.section.8.1.1" rel="Chapter" title="8.1.1 CMD 9: (Host-&gt;NCP) CMD_NET_SAVE"/>
@@ -574,17 +581,17 @@
 <link href="#rfc.appendix.C.8" rel="Chapter" title="C.8 Adding an on-mesh prefix"/>
 <link href="#rfc.appendix.C.9" rel="Chapter" title="C.9 Entering low-power modes"/>
 <link href="#rfc.appendix.C.10" rel="Chapter" title="C.10 Sniffing raw packets"/>
-<link href="#rfc.appendix.D" rel="Chapter" title="D Acknowledgments"/>
-<link href="#rfc.appendix.E" rel="Chapter" title="E Glossary"/>
+<link href="#rfc.appendix.D" rel="Chapter" title="D Glossary"/>
+<link href="#rfc.appendix.E" rel="Chapter" title="E Acknowledgments"/>
 <link href="#rfc.authors" rel="Chapter"/>
 
 
-  <meta name="generator" content="xml2rfc version 2.5.1 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.5.2 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
-  <meta name="dct.creator" content="Quattlebaum, R." />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-spinel-protocol-6d981f72" />
-  <meta name="dct.issued" scheme="ISO8601" content="2017-3-20" />
+  <meta name="dct.creator" content="Quattlebaum, R. and j. woodyatt" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-rquattle-spinel-unified-86157e99-dirty" />
+  <meta name="dct.issued" scheme="ISO8601" content="2017-5-1" />
   <meta name="dct.abstract" content="This document describes a general management protocol for enabling a host device to communicate with and manage a Network Control Processor (NCP).  " />
   <meta name="description" content="This document describes a general management protocol for enabling a host device to communicate with and manage a Network Control Processor (NCP).  " />
 
@@ -601,11 +608,15 @@
 </tr>
 <tr>
   <td class="left"></td>
-  <td class="right">Nest Labs</td>
+  <td class="right">j. woodyatt</td>
 </tr>
 <tr>
   <td class="left"></td>
-  <td class="right">March 20, 2017</td>
+  <td class="right">Nest Labs, Inc.</td>
+</tr>
+<tr>
+  <td class="left"></td>
+  <td class="right">May 1, 2017</td>
 </tr>
 
     	
@@ -613,7 +624,7 @@
   </table>
 
   <p class="title">Spinel Host-Controller Protocol<br />
-  <span class="filename">draft-spinel-protocol-6d981f72</span></p>
+  <span class="filename">draft-rquattle-spinel-unified-86157e99-dirty</span></p>
   
   <h1 id="rfc.abstract">
   <a href="#rfc.abstract">Abstract</a>
@@ -621,27 +632,16 @@
 <p>This document describes a general management protocol for enabling a host device to communicate with and manage a Network Control Processor (NCP).  </p>
 <p>While initially designed to support Thread-based NCPs, the NCP protocol has been designed with a layered approach that allows it to be easily adapted to other network technologies in the future.  </p>
 <h1>
-  <a>Status of This Document</a>
+  <a>Status of This Memo</a>
 </h1>
-<p>This document is a work in progress and subject to change.  </p>
+<p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.  </p>
+<p>This document is not an Internet Standards Track specification; it is published for informational purposes.  </p>
+<p>This document may not be modified, and derivative works of it may not be created, and it may not be published except as an Internet-Draft.  </p>
 <h1>
   <a>Copyright Notice</a>
 </h1>
-<p>Copyright (c) 2016, Nest Labs, Inc.  All rights reserved.  </p>
-<p>
-  <a id="CREF1" class="info">[CREF1]<span class="info">RQ: We may want to consider a license more appropriate for documentation.</span></a>
-</p>
-<p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: </p>
-<p/>
-
-<ol>
-  <li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</li>
-  <li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.</li>
-  <li>Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.</li>
-</ol>
-
-<p> </p>
-<p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  </p>
+<p>Copyright (c) 2017 IETF Trust and the persons identified as the document authors. All rights reserved.  </p>
+<p>This document is subject to BCP 78 and the IETF Trust&#8217;s Legal Provisions Relating to IETF Documents (<span>&lt;</span><a href="http://trustee.ietf.org/license-info">http://trustee.ietf.org/license-info</a><span>&gt;</span>) in effect on the date of publication of this document. Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  </p>
 
   
   <hr class="noprint" />
@@ -659,7 +659,7 @@
 </ul></ul><li>2.   <a href="#rfc.section.2">Frame Format</a></li>
 <ul><li>2.1.   <a href="#rfc.section.2.1">Header Format</a></li>
 <ul><li>2.1.1.   <a href="#rfc.section.2.1.1">FLG: Flag</a></li>
-<li>2.1.2.   <a href="#rfc.section.2.1.2">IID: Interface Identifier</a></li>
+<li>2.1.2.   <a href="#rfc.section.2.1.2">NLI: Network Link Identifier</a></li>
 <li>2.1.3.   <a href="#rfc.section.2.1.3">TID: Transaction Identifier</a></li>
 <li>2.1.4.   <a href="#rfc.section.2.1.4">Command Identifier (CMD)</a></li>
 <li>2.1.5.   <a href="#rfc.section.2.1.5">Command Payload (Optional)</a></li>
@@ -736,7 +736,9 @@
 <li>5.6.7.   <a href="#rfc.section.5.6.7">PROP 70: PROP_NET_MASTER_KEY</a></li>
 <li>5.6.8.   <a href="#rfc.section.5.6.8">PROP 71: PROP_NET_KEY_SEQUENCE_COUNTER</a></li>
 <li>5.6.9.   <a href="#rfc.section.5.6.9">PROP 72: PROP_NET_PARTITION_ID</a></li>
-<li>5.6.10.   <a href="#rfc.section.5.6.10">PROP 73: PROP_NET_KEY_SWITCH_GUARDTIME</a></li>
+<li>5.6.10.   <a href="#rfc.section.5.6.10">PROP 73: PROP_NET_REQUIRE_JOIN_EXISTING</a></li>
+<li>5.6.11.   <a href="#rfc.section.5.6.11">PROP 74: PROP_NET_KEY_SWITCH_GUARDTIME</a></li>
+<li>5.6.12.   <a href="#rfc.section.5.6.12">PROP 75: PROP_NET_PSKC</a></li>
 </ul><li>5.7.   <a href="#rfc.section.5.7">IPv6 Properties</a></li>
 <ul><li>5.7.1.   <a href="#rfc.section.5.7.1">PROP 96: PROP_IPV6_LL_ADDR</a></li>
 <li>5.7.2.   <a href="#rfc.section.5.7.2">PROP 97: PROP_IPV6_ML_ADDR</a></li>
@@ -745,6 +747,7 @@
 <li>5.7.5.   <a href="#rfc.section.5.7.5">PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD</a></li>
 </ul><li>5.8.   <a href="#rfc.section.5.8">Debug Properties</a></li>
 <ul><li>5.8.1.   <a href="#rfc.section.5.8.1">PROP 16384: SPINEL_PROP_DEBUG_TEST_ASSERT</a></li>
+<li>5.8.2.   <a href="#rfc.section.5.8.2">PROP 16385: SPINEL_PROP_DEBUG_NCP_LOG_LEVEL</a></li>
 </ul></ul><li>6.   <a href="#rfc.section.6">Status Codes</a></li>
 <li>7.   <a href="#rfc.section.7">Technology: Thread</a></li>
 <ul><li>7.1.   <a href="#rfc.section.7.1">Thread Capabilities</a></li>
@@ -779,6 +782,10 @@
 <li>7.2.28.   <a href="#rfc.section.7.2.28">PROP 5388: PROP_THREAD_CHILD_COUNT_MAX</a></li>
 <li>7.2.29.   <a href="#rfc.section.7.2.29">PROP 5389: PROP_THREAD_LEADER_NETWORK_DATA</a></li>
 <li>7.2.30.   <a href="#rfc.section.7.2.30">PROP 5390: PROP_THREAD_STABLE_LEADER_NETWORK_DATA</a></li>
+<li>7.2.31.   <a href="#rfc.section.7.2.31">PROP 5391: PROP_THREAD_JOINERS</a></li>
+<li>7.2.32.   <a href="#rfc.section.7.2.32">PROP 5392: PROP_THREAD_COMMISSIONER_ENABLED</a></li>
+<li>7.2.33.   <a href="#rfc.section.7.2.33">PROP 5393: PROP_THREAD_BA_PROXY_ENABLED</a></li>
+<li>7.2.34.   <a href="#rfc.section.7.2.34">PROP 5394: PROP_THREAD_BA_PROXY_STREAM</a></li>
 </ul></ul><li>8.   <a href="#rfc.section.8">Feature: Network Save</a></li>
 <ul><li>8.1.   <a href="#rfc.section.8.1">Commands</a></li>
 <ul><li>8.1.1.   <a href="#rfc.section.8.1.1">CMD 9: (Host-&gt;NCP) CMD_NET_SAVE</a></li>
@@ -848,9 +855,9 @@
 <li>C.8.   <a href="#rfc.appendix.C.8">Adding an on-mesh prefix</a></li>
 <li>C.9.   <a href="#rfc.appendix.C.9">Entering low-power modes</a></li>
 <li>C.10.   <a href="#rfc.appendix.C.10">Sniffing raw packets</a></li>
-</ul><li>Appendix D.   <a href="#rfc.appendix.D">Acknowledgments</a></li>
-<li>Appendix E.   <a href="#rfc.appendix.E">Glossary</a></li>
-<li><a href="#rfc.authors">Author's Address</a></li>
+</ul><li>Appendix D.   <a href="#rfc.appendix.D">Glossary</a></li>
+<li>Appendix E.   <a href="#rfc.appendix.E">Acknowledgments</a></li>
+<li><a href="#rfc.authors">Authors' Addresses</a></li>
 
 
   </ul>
@@ -1023,17 +1030,17 @@
 <pre>
   0   1   2   3   4   5   6   7
 +---+---+---+---+---+---+---+---+
-|  FLG  |  IID  |      TID      |
+|  FLG  |  NLI  |      TID      |
 +---+---+---+---+---+---+---+---+
 </pre>
 <p>
-  <a id="CREF2" class="info">[CREF2]<span class="info">RQ: Eventually, when https://github.com/miekg/mmark/issues/95 is addressed, the above table should be swapped out with this: | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | |---|---|---|---|---|---|---|---| |  FLG ||  IID ||      TID   ||||</span></a>
+  <a id="CREF1" class="info">[CREF1]<span class="info">RQ: Eventually, when https://github.com/miekg/mmark/issues/95 is addressed, the above table should be swapped out with this: | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | |---|---|---|---|---|---|---|---| |  FLG ||  NLI ||      TID   ||||</span></a>
 </p>
 <h1 id="rfc.section.2.1.1"><a href="#rfc.section.2.1.1">2.1.1.</a> <a href="#flg-flag" id="flg-flag">FLG: Flag</a></h1>
 <p id="rfc.section.2.1.1.p.1">The flag field of the header byte (<samp>FLG</samp>) is always set to the value two (or <samp>10</samp> in binary). Any frame received with these bits set to any other value else MUST NOT be considered a Spinel frame.  </p>
 <p id="rfc.section.2.1.1.p.2">This convention allows Spinel to be line compatible with BTLE HCI. By defining the first two bit in this way we can disambiguate between Spinel frames and HCI frames (which always start with either <samp>0x01</samp> or <samp>0x04</samp>) without any additional framing overhead.  </p>
-<h1 id="rfc.section.2.1.2"><a href="#rfc.section.2.1.2">2.1.2.</a> <a href="#iid-interface-identifier" id="iid-interface-identifier">IID: Interface Identifier</a></h1>
-<p id="rfc.section.2.1.2.p.1">The Interface Identifier (IID) is a number between 0 and 3 which identifies which subinterface the frame is intended for. This allows the protocol to support connecting to more than one network at once.  The first subinterface (0) is considered the primary subinterface and MUST be supported. Support for all other subinterfaces is OPTIONAL.  </p>
+<h1 id="rfc.section.2.1.2"><a href="#rfc.section.2.1.2">2.1.2.</a> <a href="#nli-network-link-identifier" id="nli-network-link-identifier">NLI: Network Link Identifier</a></h1>
+<p id="rfc.section.2.1.2.p.1">The Network Link Identifier (NLI) is a number between 0 and 3, which is associated by the OS with one of up to four IPv6 zone indices corresponding to conceptual IPv6 interfaces on the NCP. This allows the protocol to support IPv6 nodes connecting simultaneously to more than one IPv6 network link using a single NCP instance. The first Network Link Identifier (0) MUST refer to a distinguished conceptual interface provided by the NCP for its IPv6 link type. The other three Network Link Identifiers (1, 2 and 3) MAY be dissociated from any conceptual interface.  </p>
 <h1 id="rfc.section.2.1.3"><a href="#rfc.section.2.1.3">2.1.3.</a> <a href="#tid-transaction-identifier" id="tid-transaction-identifier">TID: Transaction Identifier</a></h1>
 <p id="rfc.section.2.1.3.p.1">The least significant bits of the header represent the Transaction Identifier(TID). The TID is used for correlating responses to the commands which generated them.  </p>
 <p id="rfc.section.2.1.3.p.2">When a command is sent from the host, any reply to that command sent by the NCP will use the same value for the TID. When the host receives a frame that matches the TID of the command it sent, it can easily recognize that frame as the actual response to that command.  </p>
@@ -1267,7 +1274,7 @@
 <p id="rfc.section.3.3.p.3">This dichotomy allows for more efficient encoding by eliminating redundency. If the rest of the buffer is a data blob, encoding the length would be redundant because we already know how many bytes are in the rest of the buffer.  </p>
 <p id="rfc.section.3.3.p.4">In some cases we use <samp>d</samp> even if it is the last field in a type signature.  We do this to allow for us to be able to append additional fields to the type signature if necessary in the future. This is usually the case with embedded structs, like in the scan results.  </p>
 <p id="rfc.section.3.3.p.5">For example, let's say we have a buffer that is encoded with the datatype signature of <samp>CLLD</samp>. In this case, it is pretty easy to tell where the start and end of the data blob is: the start is 9 bytes from the start of the buffer, and its length is the length of the buffer minus 9. (9 is the number of bytes taken up by a byte and two longs) </p>
-<p id="rfc.section.3.3.p.6">The datatype signature <samp>CLLDU</samp> is illegal because we can't determine where the last field (a zero-terminated UTF8 string) starts. But the datatype <samp>CLLdU</samp> <em>is</em> legal, because the parser can determine the exact length of the data blob&#8212;allowing it to know where the start of the next field would be.  </p>
+<p id="rfc.section.3.3.p.6">The datatype signature <samp>CLLDU</samp> is illegal because we can't determine where the last field (a zero-terminated UTF8 string) starts. But the datatype <samp>CLLdU</samp> <em>is</em> legal, because the parser can determine the exact length of the data blob-- allowing it to know where the start of the next field would be.  </p>
 <h1 id="rfc.section.3.4"><a href="#rfc.section.3.4">3.4.</a> <a href="#structured-data" id="structured-data">Structured Data</a></h1>
 <p id="rfc.section.3.4.p.1">The structure data type (<samp>t(...)</samp>) is a way of bundling together several fields into a single structure. It can be thought of as a <samp>d</samp> type except that instead of being opaque, the fields in the content are known. This is useful for things like scan results where you have substructures which are defined by different layers.  </p>
 <p id="rfc.section.3.4.p.2">For example, consider the type signature <samp>Lt(ES)t(6C)</samp>. In this hypothetical case, the first struct is defined by the MAC layer, and the second struct is defined by the PHY layer. Because of the use of structures, we know exactly what part comes from that layer.  Additionally, we can add fields to each structure without introducing backward compatability problems: Data encoded as <samp>Lt(ESU)t(6C)</samp> (Notice the extra <samp>U</samp>) will decode just fine as <samp>Lt(ES)t(6C)</samp>. Additionally, if we don't care about the MAC layer and only care about the network layer, we could parse as <samp>Lt()t(6C)</samp>.  </p>
@@ -2005,6 +2012,8 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
   <li>49: <samp>CAP_ROLE_SLEEPY</samp></li>
   <li>52: <samp>CAP_NET_THREAD_1_0</samp></li>
   <li>512: <samp>CAP_MAC_WHITELIST</samp></li>
+  <li>1024: <samp>CAP_THREAD_COMMISSIONER</samp></li>
+  <li>1025: <samp>CAP_THREAD_BA_PROXY</samp></li>
 </ul>
 
 <p> </p>
@@ -2802,12 +2811,30 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 
 <p> </p>
 <p id="rfc.section.5.6.9.p.2">The partition ID of the partition that this node is a member of.  </p>
-<h1 id="rfc.section.5.6.10"><a href="#rfc.section.5.6.10">5.6.10.</a> <a href="#prop-net-key-swtich-guardtime" id="prop-net-key-swtich-guardtime">PROP 73: PROP_NET_KEY_SWITCH_GUARDTIME</a></h1>
+<h1 id="rfc.section.5.6.10"><a href="#rfc.section.5.6.10">5.6.10.</a> <a href="#prop-net-require-join-existing" id="prop-net-require-join-existing">PROP 73: PROP_NET_REQUIRE_JOIN_EXISTING</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>b</samp></li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.5.6.11"><a href="#rfc.section.5.6.11">5.6.11.</a> <a href="#prop-net-key-swtich-guardtime" id="prop-net-key-swtich-guardtime">PROP 74: PROP_NET_KEY_SWITCH_GUARDTIME</a></h1>
 <p/>
 
 <ul>
   <li>Type: Read-Write</li>
   <li>Packed-Encoding: <samp>L</samp></li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.5.6.12"><a href="#rfc.section.5.6.12">5.6.12.</a> <a href="#prop-net-pskc" id="prop-net-pskc">PROP 75: PROP_NET_PSKC</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>D</samp></li>
 </ul>
 
 <p> </p>
@@ -2885,6 +2912,31 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 
 <p> </p>
 <p id="rfc.section.5.8.1.p.2">Reading this property will cause an assert on the NCP. This is intended for testing the assert functionality of underlying platform/NCP. Assert should ideally cause the NCP to reset, but if <samp>assert</samp> is not supported or disabled boolean value of <samp>false</samp> is returned in response.  </p>
+<h1 id="rfc.section.5.8.2"><a href="#rfc.section.5.8.2">5.8.2.</a> <a href="#prop-debug-ncp-log-level" id="prop-debug-ncp-log-level">PROP 16385: SPINEL_PROP_DEBUG_NCP_LOG_LEVEL</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>C</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.5.8.2.p.2">Provides access to the NCP log level. Currently defined values are (which follows the RFC 5424): </p>
+<p/>
+
+<ul>
+  <li>0: Emergency (emerg).</li>
+  <li>1: Alert (alert).</li>
+  <li>2: Critical (crit).</li>
+  <li>3: Error (err).</li>
+  <li>4: Warning (warn).</li>
+  <li>5: Notice (notice).</li>
+  <li>6: Information (info).</li>
+  <li>7: Debug (debug).</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.5.8.2.p.4">If the NCP supports dynamic log level control, setting this property changes the log level accordingly. Getting the value returns the current log level.  If the dynamic log level control is not supported, setting this property returns a LAST_STATUS with SPINEL_STATUS_INVALID_COMMAND_FOR_PROP status.  </p>
 <h1 id="rfc.section.6"><a href="#rfc.section.6">6.</a> <a href="#status-codes" id="status-codes">Status Codes</a></h1>
 <p id="rfc.section.6.p.1">Status codes are sent from the NCP to the host via <samp>PROP_LAST_STATUS</samp> using the <samp>CMD_VALUE_IS</samp> command to indicate the return status of a previous command. As with any response, the TID field of the FLAG byte is used to correlate the response with the request.  </p>
 <p id="rfc.section.6.p.2">Note that most successfully executed commands do not indicate a last status of <samp>STATUS_OK</samp>. The usual way the NCP indicates a successful command is to mirror the property change back to the host. For example, if you do a <samp>CMD_VALUE_SET</samp> on <samp>PROP_PHY_ENABLED</samp>, the NCP would indicate success by responding with a <samp>CMD_VALUE_IS</samp> for <samp>PROP_PHY_ENABLED</samp>. If the command failed, <samp>PROP_LAST_STATUS</samp> would be emitted instead.  </p>
@@ -3278,6 +3330,90 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 
 <p> </p>
 <p id="rfc.section.7.2.30.p.2">The stable leader network data.  </p>
+<h1 id="rfc.section.7.2.31"><a href="#rfc.section.7.2.31">7.2.31.</a> <a href="#prop-thread-joiners" id="prop-thread-joiners">PROP 5391: PROP_THREAD_JOINERS</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Insert/Remove Only (optionally Read-Write)</li>
+  <li>Packed-Encoding: <samp>A(t(ULE))</samp></li>
+  <li>Required capability: <samp>CAP_THREAD_COMMISSIONER</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.31.p.2">Data per item is: </p>
+<p/>
+
+<ul>
+  <li><samp>U</samp>: PSKd</li>
+  <li><samp>L</samp>: Timeout in seconds</li>
+  <li><samp>E</samp>: Extended/long address (optional)</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.31.p.4">Passess Pre-Shared Key for the Device to the NCP in the commissioning process.  When the Extended address is ommited all Devices which provided a valid PSKd are allowed to join the Thread Network.  </p>
+<h1 id="rfc.section.7.2.32"><a href="#rfc.section.7.2.32">7.2.32.</a> <a href="#prop-thread-commissioner-enabled" id="prop-thread-commissioner-enabled">PROP 5392: PROP_THREAD_COMMISSIONER_ENABLED</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Write only (optionally Read-Write)</li>
+  <li>Packed-Encoding: <samp>b</samp></li>
+  <li>Required capability: <samp>CAP_THREAD_COMMISSIONER</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.32.p.2">Set to true to enable the native commissioner. It is mandatory before adding the joiner to the network.  </p>
+<h1 id="rfc.section.7.2.33"><a href="#rfc.section.7.2.33">7.2.33.</a> <a href="#prop-thread-ba-proxy-enabled" id="prop-thread-ba-proxy-enabled">PROP 5393: PROP_THREAD_BA_PROXY_ENABLED</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write</li>
+  <li>Packed-Encoding: <samp>b</samp></li>
+  <li>Required capability: <samp>CAP_THREAD_BA_PROXY</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.33.p.2">Set to true to enable the border agent proxy.  </p>
+<h1 id="rfc.section.7.2.34"><a href="#rfc.section.7.2.34">7.2.34.</a> <a href="#prop-thread-ba-proxy-stream" id="prop-thread-ba-proxy-stream">PROP 5394: PROP_THREAD_BA_PROXY_STREAM</a></h1>
+<p/>
+
+<ul>
+  <li>Type: Read-Write-Stream</li>
+  <li>Packed-Encoding: <samp>dSS</samp></li>
+  <li>Required capability: <samp>CAP_THREAD_BA_PROXY</samp></li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.2.34.p.2">Data per item is: </p>
+<p/>
+
+<ul>
+  <li><samp>d</samp>: CoAP frame</li>
+  <li><samp>S</samp>: source/destination RLOC/ALOC</li>
+  <li><samp>S</samp>: source/destination port</li>
+</ul>
+
+<p> </p>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+  <thead>
+    <tr>
+      <th class="center">Octects:</th>
+      <th class="center">2</th>
+      <th class="center">n</th>
+      <th class="center">2</th>
+      <th class="center">2</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="center">Fields:</td>
+      <td class="center">Length</td>
+      <td class="center">CoAP</td>
+      <td class="center">locator</td>
+      <td class="center">port</td>
+    </tr>
+  </tbody>
+</table>
+<p id="rfc.section.7.2.34.p.4">This property allows the host to send and receive border-agent-related CoAP requests/responses from the NCP's RLOC address. This allows the host driver to implement a Thread border agent.  </p>
 <h1 id="rfc.section.8"><a href="#rfc.section.8">8.</a> <a href="#feature-network-save" id="feature-network-save">Feature: Network Save</a></h1>
 <p id="rfc.section.8.p.1">The network save/recall feature is an optional NCP capability that, when present, allows the host to save and recall network credentials and state to and from nonvolatile storage.  </p>
 <p id="rfc.section.8.p.2">The presence of the save/recall feature can be detected by checking for the presence of the <samp>CAP_NET_SAVE</samp> capability in <samp>PROP_CAPS</samp>.  </p>
@@ -3886,12 +4022,12 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 <h1 id="rfc.appendix.A.3"><a href="#rfc.appendix.A.3">A.3.</a> <a href="#i2c-recommendations" id="i2c-recommendations">I&#178;C Recommendations</a></h1>
 <p id="rfc.section.A.3.p.1">TBD </p>
 <p>
-  <a id="CREF3" class="info">[CREF3]<span class="info">RQ: It may make sense to have a look at what Bluetooth HCI is doing for native I&#178;C framing and go with that.</span></a>
+  <a id="CREF2" class="info">[CREF2]<span class="info">RQ: It may make sense to have a look at what Bluetooth HCI is doing for native I&#178;C framing and go with that.</span></a>
 </p>
 <h1 id="rfc.appendix.A.4"><a href="#rfc.appendix.A.4">A.4.</a> <a href="#native-usb-recommendations" id="native-usb-recommendations">Native USB Recommendations</a></h1>
 <p id="rfc.section.A.4.p.1">TBD </p>
 <p>
-  <a id="CREF4" class="info">[CREF4]<span class="info">RQ: It may make sense to have a look at what Bluetooth HCI is doing for native USB framing and go with that.</span></a>
+  <a id="CREF3" class="info">[CREF3]<span class="info">RQ: It may make sense to have a look at what Bluetooth HCI is doing for native USB framing and go with that.</span></a>
 </p>
 <h1 id="rfc.appendix.B"><a href="#rfc.appendix.B">Appendix B.</a> <a href="#test-vectors" id="test-vectors">Test Vectors</a></h1>
 <h1 id="rfc.appendix.B.1"><a href="#rfc.appendix.B.1">B.1.</a> <a href="#test-vector-packed-unsigned-integer" id="test-vector-packed-unsigned-integer">Test Vector: Packed Unsigned Integer</a></h1>
@@ -3966,13 +4102,13 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
   </tbody>
 </table>
 <p>
-  <a id="CREF5" class="info">[CREF5]<span class="info">RQ: The PUI test-vector encodings need to be verified.</span></a>
+  <a id="CREF4" class="info">[CREF4]<span class="info">RQ: The PUI test-vector encodings need to be verified.</span></a>
 </p>
 <h1 id="rfc.appendix.B.2"><a href="#rfc.appendix.B.2">B.2.</a> <a href="#test-vector-reset-command" id="test-vector-reset-command">Test Vector: Reset Command</a></h1>
 <p/>
 
 <ul>
-  <li>IID: 0</li>
+  <li>NLI: 0</li>
   <li>TID: 0</li>
   <li>CMD: 1 (<samp>CMD_RESET</samp>)</li>
 </ul>
@@ -3986,7 +4122,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 <p/>
 
 <ul>
-  <li>IID: 0</li>
+  <li>NLI: 0</li>
   <li>TID: 0</li>
   <li>CMD: 6 (<samp>CMD_VALUE_IS</samp>)</li>
   <li>PROP: 0 (<samp>PROP_LAST_STATUS</samp>)</li>
@@ -4002,7 +4138,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 <p/>
 
 <ul>
-  <li>IID: 0</li>
+  <li>NLI: 0</li>
   <li>TID: 0</li>
   <li>CMD: 7 (<samp>CMD_VALUE_INSERTED</samp>)</li>
   <li>PROP: 51 (<samp>PROP_MAC_SCAN_BEACON</samp>)</li>
@@ -4019,18 +4155,18 @@ FE
 <h1 id="rfc.appendix.B.5"><a href="#rfc.appendix.B.5">B.5.</a> <a href="#test-vector-inbound-ipv6-packet" id="test-vector-inbound-ipv6-packet">Test Vector: Inbound IPv6 Packet</a></h1>
 <p id="rfc.section.B.5.p.1">CMD_VALUE_IS(PROP_STREAM_NET) </p>
 <p>
-  <a id="CREF6" class="info">[CREF6]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
+  <a id="CREF5" class="info">[CREF5]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
 </p>
 <h1 id="rfc.appendix.B.6"><a href="#rfc.appendix.B.6">B.6.</a> <a href="#test-vector-outbound-ipv6-packet" id="test-vector-outbound-ipv6-packet">Test Vector: Outbound IPv6 Packet</a></h1>
 <p id="rfc.section.B.6.p.1">CMD_VALUE_SET(PROP_STREAM_NET) </p>
 <p>
-  <a id="CREF7" class="info">[CREF7]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
+  <a id="CREF6" class="info">[CREF6]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
 </p>
 <h1 id="rfc.appendix.B.7"><a href="#rfc.appendix.B.7">B.7.</a> <a href="#test-vector-fetch-list-of-onmesh-networks" id="test-vector-fetch-list-of-onmesh-networks">Test Vector: Fetch list of on-mesh networks</a></h1>
 <p/>
 
 <ul>
-  <li>IID: 0</li>
+  <li>NLI: 0</li>
   <li>TID: 4</li>
   <li>CMD: 2 (<samp>CMD_VALUE_GET</samp>)</li>
   <li>PROP: 90 (<samp>PROP_THREAD_ON_MESH_NETS</samp>)</li>
@@ -4045,7 +4181,7 @@ FE
 <p/>
 
 <ul>
-  <li>IID: 0</li>
+  <li>NLI: 0</li>
   <li>TID: 4</li>
   <li>CMD: 6 (<samp>CMD_VALUE_IS</samp>)</li>
   <li>PROP: 90 (<samp>PROP_THREAD_ON_MESH_NETS</samp>)</li>
@@ -4087,7 +4223,7 @@ FE
 <p/>
 
 <ul>
-  <li>IID: 0</li>
+  <li>NLI: 0</li>
   <li>TID: 5</li>
   <li>CMD: 4 (<samp>CMD_VALUE_INSERT</samp>)</li>
   <li>PROP: 90 (<samp>PROP_THREAD_ON_MESH_NETS</samp>)</li>
@@ -4119,13 +4255,13 @@ FE
 01 ?? 01
 </pre>
 <p>
-  <a id="CREF8" class="info">[CREF8]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
+  <a id="CREF7" class="info">[CREF7]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
 </p>
 <h1 id="rfc.appendix.B.10"><a href="#rfc.appendix.B.10">B.10.</a> <a href="#test-vector-insertion-notification-of-an-onmesh-network" id="test-vector-insertion-notification-of-an-onmesh-network">Test Vector: Insertion notification of an on-mesh network</a></h1>
 <p/>
 
 <ul>
-  <li>IID: 0</li>
+  <li>NLI: 0</li>
   <li>TID: 5</li>
   <li>CMD: 7 (<samp>CMD_VALUE_INSERTED</samp>)</li>
   <li>PROP: 90 (<samp>PROP_THREAD_ON_MESH_NETS</samp>)</li>
@@ -4157,13 +4293,13 @@ FE
 01 ?? 01
 </pre>
 <p>
-  <a id="CREF9" class="info">[CREF9]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
+  <a id="CREF8" class="info">[CREF8]<span class="info">RQ: FIXME: This test vector is incomplete.</span></a>
 </p>
 <h1 id="rfc.appendix.B.11"><a href="#rfc.appendix.B.11">B.11.</a> <a href="#test-vector-removing-a-local-onmesh-network" id="test-vector-removing-a-local-onmesh-network">Test Vector: Removing a local on-mesh network</a></h1>
 <p/>
 
 <ul>
-  <li>IID: 0</li>
+  <li>NLI: 0</li>
   <li>TID: 6</li>
   <li>CMD: 5 (<samp>CMD_VALUE_REMOVE</samp>)</li>
   <li>PROP: 90 (<samp>PROP_THREAD_ON_MESH_NETS</samp>)</li>
@@ -4179,7 +4315,7 @@ FE
 <p/>
 
 <ul>
-  <li>IID: 0</li>
+  <li>NLI: 0</li>
   <li>TID: 6</li>
   <li>CMD: 8 (<samp>CMD_VALUE_REMOVED</samp>)</li>
   <li>PROP: 90 (<samp>PROP_THREAD_ON_MESH_NETS</samp>)</li>
@@ -4194,7 +4330,7 @@ FE
 <h1 id="rfc.appendix.C"><a href="#rfc.appendix.C">Appendix C.</a> <a href="#example-sessions" id="example-sessions">Example Sessions</a></h1>
 <h1 id="rfc.appendix.C.1"><a href="#rfc.appendix.C.1">C.1.</a> <a href="#ncp-initialization" id="ncp-initialization">NCP Initialization</a></h1>
 <p>
-  <a id="CREF10" class="info">[CREF10]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF9" class="info">[CREF9]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p id="rfc.section.C.1.p.2">Check the protocol version to see if it is supported: </p>
 <p/>
@@ -4251,7 +4387,7 @@ FE
 <p> </p>
 <h1 id="rfc.appendix.C.2"><a href="#rfc.appendix.C.2">C.2.</a> <a href="#attaching-to-a-network" id="attaching-to-a-network">Attaching to a network</a></h1>
 <p>
-  <a id="CREF11" class="info">[CREF11]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF10" class="info">[CREF10]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p id="rfc.section.C.2.p.2">We make the assumption that the NCP is not currently associated with a network.  </p>
 <p id="rfc.section.C.2.p.3">Set the network properties, if they were not already set: </p>
@@ -4305,7 +4441,7 @@ FE
 <p> </p>
 <h1 id="rfc.appendix.C.3"><a href="#rfc.appendix.C.3">C.3.</a> <a href="#successfully-joining-a-preexisting-network" id="successfully-joining-a-preexisting-network">Successfully joining a pre-existing network</a></h1>
 <p>
-  <a id="CREF12" class="info">[CREF12]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF11" class="info">[CREF11]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p id="rfc.section.C.3.p.2">This example session is identical to the above session up to the point where we set PROP_NET_IF_UP to true. From there, the behavior changes.  </p>
 <p/>
@@ -4375,7 +4511,7 @@ FE
 <p id="rfc.section.C.5.p.1">TBD </p>
 <h1 id="rfc.appendix.C.6"><a href="#rfc.appendix.C.6">C.6.</a> <a href="#attaching-to-a-saved-network" id="attaching-to-a-saved-network">Attaching to a saved network</a></h1>
 <p>
-  <a id="CREF13" class="info">[CREF13]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF12" class="info">[CREF12]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p id="rfc.section.C.6.p.2">Recall the saved network if you haven't already done so: </p>
 <p/>
@@ -4415,7 +4551,7 @@ FE
 <p> </p>
 <h1 id="rfc.appendix.C.7"><a href="#rfc.appendix.C.7">C.7.</a> <a href="#ncp-software-reset" id="ncp-software-reset">NCP Software Reset</a></h1>
 <p>
-  <a id="CREF14" class="info">[CREF14]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF13" class="info">[CREF13]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p/>
 
@@ -4432,7 +4568,7 @@ FE
 <p id="rfc.section.C.9.p.1">TBD </p>
 <h1 id="rfc.appendix.C.10"><a href="#rfc.appendix.C.10">C.10.</a> <a href="#sniffing-raw-packets" id="sniffing-raw-packets">Sniffing raw packets</a></h1>
 <p>
-  <a id="CREF15" class="info">[CREF15]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
+  <a id="CREF14" class="info">[CREF14]<span class="info">RQ: FIXME: This example session is incomplete.</span></a>
 </p>
 <p id="rfc.section.C.10.p.2">This assumes that the NCP has been initialized.  </p>
 <p id="rfc.section.C.10.p.3">Optionally set the channel: </p>
@@ -4482,29 +4618,23 @@ FE
 
 <p> </p>
 <p id="rfc.section.C.10.p.13">This mode may be entered even when associated with a network.  In that case, you should set <samp>PROP_MAC_PROMISCUOUS_MODE</samp> to <samp>MAC_PROMISCUOUS_MODE_PROMISCUOUS</samp> or <samp>MAC_PROMISCUOUS_MODE_NORMAL</samp>, so that you can avoid receiving packets from other networks or that are destined for other nodes.  </p>
-<h1 id="rfc.appendix.D"><a href="#rfc.appendix.D">Appendix D.</a> <a href="#acknowledgments" id="acknowledgments">Acknowledgments</a></h1>
-<p id="rfc.section.D.p.1">Special thanks to Abtin Keshavarzian, Martin Turon, Arjuna Sivasithambaresan and Jonathan Hui for their substantial contributions and feedback related to this document.  </p>
+<h1 id="rfc.appendix.D"><a href="#rfc.appendix.D">Appendix D.</a> <a href="#glossary" id="glossary">Glossary</a></h1>
 <p>
-  <a id="CREF16" class="info">[CREF16]<span class="info">RQ: If I have missed anyone who has contributed to this document, please let me know ASAP.</span></a>
-</p>
-<p id="rfc.section.D.p.3">This document was prepared using <a href="https://github.com/miekg/mmark">mmark</a> by (Miek Gieben) and <a href="http://xml2rfc.ietf.org/">xml2rfc (version 2)</a>.  </p>
-<h1 id="rfc.appendix.E"><a href="#rfc.appendix.E">Appendix E.</a> <a href="#glossary" id="glossary">Glossary</a></h1>
-<p>
-  <a id="CREF17" class="info">[CREF17]<span class="info">RQ: Alphabetize before finalization.</span></a>
+  <a id="CREF15" class="info">[CREF15]<span class="info">RQ: Alphabetize before finalization.</span></a>
 </p>
 <p/>
 
 <dl>
   <dt>NCP</dt>
-  <dd style="margin-left: 8"><br/> Acronym for Network Control Processor.</dd>
-  <dt>Host</dt>
-  <dd style="margin-left: 8"><br/> Computer or Micro-controller which controls the NCP.</dd>
+  <dd style="margin-left: 8"><br/> Network Control Processor.</dd>
+  <dt>OS</dt>
+  <dd style="margin-left: 8"><br/> Operating System, i.e. the IPv6 node using Spinel to control and manage one or more of its IPv6 network interfaces.</dd>
   <dt>TID</dt>
-  <dd style="margin-left: 8"><br/> Transaction Identifier. May be a value between zero and fifteen.  See <a href="#tid-transaction-identifier">Section 2.1.3</a> for more information.</dd>
-  <dt>IID</dt>
-  <dd style="margin-left: 8"><br/> Interface Identifier. May be a value between zero and three.  See <a href="#iid-interface-identifier">Section 2.1.2</a> for more information.</dd>
+  <dd style="margin-left: 8"><br/> Transaction Identifier. May be a value between zero and fifteen. See <a href="#tid-transaction-identifier">Section 2.1.3</a> for more information.</dd>
+  <dt>NLI</dt>
+  <dd style="margin-left: 8"><br/> Network Link Identifier. May be a value between zero and three. See <a href="#nli-network-link-identifier">Section 2.1.2</a> for more information.</dd>
   <dt>PUI</dt>
-  <dd style="margin-left: 8"><br/> Packed Unsigned Integer. A way to serialize an unsigned integer using one, two, or three bytes. Used throughout the Spinel protocol.  See <a href="#packed-unsigned-integer">Section 3.2</a> for more information.</dd>
+  <dd style="margin-left: 8"><br/> Packed Unsigned Integer. A way to serialize an unsigned integer using one, two, or three bytes. Used throughout the Spinel protocol. See <a href="#packed-unsigned-integer">Section 3.2</a> for more information.</dd>
   <dt>FCS</dt>
   <dd style="margin-left: 8"><br/> Final Checksum. Bytes added to the end of a packet to help determine if the packet was received without corruption.</dd>
   <dt>PHY</dt>
@@ -4512,8 +4642,11 @@ FE
 </dl>
 
 <p> </p>
+<h1 id="rfc.appendix.E"><a href="#rfc.appendix.E">Appendix E.</a> <a href="#acknowledgments" id="acknowledgments">Acknowledgments</a></h1>
+<p id="rfc.section.E.p.1">Special thanks to Nick Banks, Jonathan Hui, Abtin Keshavarzian, Piotr Szkotak, Arjuna Sivasithambaresan and Martin Turon for their substantial contributions and feedback related to this document.  </p>
+<p id="rfc.section.E.p.2">This document was prepared using <a href="https://github.com/miekg/mmark">mmark</a> by (Miek Gieben) and <a href="http://xml2rfc.ietf.org/">xml2rfc (version 2)</a>.  </p>
 <h1 id="rfc.authors">
-  <a href="#rfc.authors">Author's Address</a>
+  <a href="#rfc.authors">Authors' Addresses</a>
 </h1>
 <div class="avoidbreak">
   <address class="vcard">
@@ -4523,7 +4656,7 @@ FE
 		<span class="family-name">Quattlebaum</span>
 	  </span>
 	</span>
-	<span class="org vcardline">Nest Labs</span>
+	<span class="org vcardline">Nest Labs, Inc.</span>
 	<span class="adr">
 	  <span class="vcardline">3400 Hillview Ave.</span>
 
@@ -4535,6 +4668,28 @@ FE
 	  <span class="country-name vcardline">USA</span>
 	</span>
 	<span class="vcardline">EMail: <a href="mailto:rquattle@nestlabs.com">rquattle@nestlabs.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">james woodyatt</span> 
+	  <span class="n hidden">
+		<span class="family-name">woodyatt</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Nest Labs, Inc.</span>
+	<span class="adr">
+	  <span class="vcardline">3400 Hillview Ave.</span>
+
+	  <span class="vcardline">
+		<span class="locality">Palo Alto</span>,  
+		<span class="region">California</span> 
+		<span class="code">94304</span>
+	  </span>
+	  <span class="country-name vcardline">USA</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:jhw@nestlabs.com">jhw@nestlabs.com</a></span>
 
   </address>
 </div>

--- a/doc/draft-rquattle-spinel-unified.txt
+++ b/doc/draft-rquattle-spinel-unified.txt
@@ -3,12 +3,13 @@
 
 
                                                           R. Quattlebaum
-                                                               Nest Labs
-                                                          March 20, 2017
+                                                             j. woodyatt
+                                                         Nest Labs, Inc.
+                                                             May 1, 2017
 
 
                     Spinel Host-Controller Protocol
-                     draft-spinel-protocol-6d981f72
+              draft-rquattle-spinel-unified-86157e99-dirty
 
 Abstract
 
@@ -20,50 +21,42 @@ Abstract
    protocol has been designed with a layered approach that allows it to
    be easily adapted to other network technologies in the future.
 
-Status of This Document
+Status of This Memo
 
-   This document is a work in progress and subject to change.
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document may not be modified, and derivative works of it may not
+   be created, and it may not be published except as an Internet-Draft.
 
 Copyright Notice
 
-   Copyright (c) 2016, Nest Labs, Inc.  All rights reserved.
+   Copyright (c) 2017 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
 
-   [CREF1]
-
-   Redistribution and use in source and binary forms, with or without
-   modification, are permitted provided that the following conditions
-   are met:
-
-   1.  Redistributions of source code must retain the above copyright
-       notice, this list of conditions and the following disclaimer.
-   2.  Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in
-       the documentation and/or other materials provided with the
-       distribution.
-   3.  Neither the name of the copyright holder nor the names of its
-       contributors may be used to endorse or promote products derived
-       from this software without specific prior written permission.
-
-   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
-   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents (<http://trustee.ietf.org/
+   license-info>) in effect on the date of publication of this document.
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.
 
 
 
-Quattlebaum            Expires September 21, 2017               [Page 1]
+
+
+
+
+
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017                [Page 1]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
-
-   BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-   OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
-   WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-   POSSIBILITY OF SUCH DAMAGE.
 
 Table of Contents
 
@@ -78,10 +71,10 @@ Table of Contents
    2.  Frame Format  . . . . . . . . . . . . . . . . . . . . . . . .  11
      2.1.  Header Format . . . . . . . . . . . . . . . . . . . . . .  11
        2.1.1.  FLG: Flag . . . . . . . . . . . . . . . . . . . . . .  11
-       2.1.2.  IID: Interface Identifier . . . . . . . . . . . . . .  12
+       2.1.2.  NLI: Network Link Identifier  . . . . . . . . . . . .  12
        2.1.3.  TID: Transaction Identifier . . . . . . . . . . . . .  12
        2.1.4.  Command Identifier (CMD)  . . . . . . . . . . . . . .  12
-       2.1.5.  Command Payload (Optional)  . . . . . . . . . . . . .  12
+       2.1.5.  Command Payload (Optional)  . . . . . . . . . . . . .  13
    3.  Data Packing  . . . . . . . . . . . . . . . . . . . . . . . .  13
      3.1.  Primitive Types . . . . . . . . . . . . . . . . . . . . .  13
      3.2.  Packed Unsigned Integer . . . . . . . . . . . . . . . . .  14
@@ -106,14 +99,6 @@ Table of Contents
      4.15. CMD 23: (NCP->Host) CMD_PROP_VALUES_ARE . . . . . . . . .  24
    5.  Properties  . . . . . . . . . . . . . . . . . . . . . . . . .  24
      5.1.  Property Sections . . . . . . . . . . . . . . . . . . . .  25
-
-
-
-Quattlebaum            Expires September 21, 2017               [Page 2]
-
-                       Spinel Protocol (6d981f72)             March 2017
-
-
      5.2.  Core Properties . . . . . . . . . . . . . . . . . . . . .  25
        5.2.1.  PROP 0: PROP_LAST_STATUS  . . . . . . . . . . . . . .  25
        5.2.2.  PROP 1: PROP_PROTOCOL_VERSION . . . . . . . . . . . .  26
@@ -121,6 +106,14 @@ Quattlebaum            Expires September 21, 2017               [Page 2]
        5.2.4.  PROP 3: PROP_INTERFACE_TYPE . . . . . . . . . . . . .  27
        5.2.5.  PROP 4: PROP_INTERFACE_VENDOR_ID  . . . . . . . . . .  28
        5.2.6.  PROP 5: PROP_CAPS . . . . . . . . . . . . . . . . . .  28
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017                [Page 2]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
+
        5.2.7.  PROP 6: PROP_INTERFACE_COUNT  . . . . . . . . . . . .  29
        5.2.8.  PROP 7: PROP_POWER_STATE  . . . . . . . . . . . . . .  30
        5.2.9.  PROP 8: PROP_HWADDR . . . . . . . . . . . . . . . . .  30
@@ -162,148 +155,155 @@ Quattlebaum            Expires September 21, 2017               [Page 2]
        5.6.5.  PROP 68: PROP_NET_NETWORK_NAME  . . . . . . . . . . .  41
        5.6.6.  PROP 69: PROP_NET_XPANID  . . . . . . . . . . . . . .  41
        5.6.7.  PROP 70: PROP_NET_MASTER_KEY  . . . . . . . . . . . .  41
-
-
-
-Quattlebaum            Expires September 21, 2017               [Page 3]
-
-                       Spinel Protocol (6d981f72)             March 2017
-
-
        5.6.8.  PROP 71: PROP_NET_KEY_SEQUENCE_COUNTER  . . . . . . .  41
        5.6.9.  PROP 72: PROP_NET_PARTITION_ID  . . . . . . . . . . .  41
-       5.6.10. PROP 73: PROP_NET_KEY_SWITCH_GUARDTIME  . . . . . . .  41
+       5.6.10. PROP 73: PROP_NET_REQUIRE_JOIN_EXISTING . . . . . . .  41
+       5.6.11. PROP 74: PROP_NET_KEY_SWITCH_GUARDTIME  . . . . . . .  42
+       5.6.12. PROP 75: PROP_NET_PSKC  . . . . . . . . . . . . . . .  42
      5.7.  IPv6 Properties . . . . . . . . . . . . . . . . . . . . .  42
        5.7.1.  PROP 96: PROP_IPV6_LL_ADDR  . . . . . . . . . . . . .  42
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017                [Page 3]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
+
        5.7.2.  PROP 97: PROP_IPV6_ML_ADDR  . . . . . . . . . . . . .  42
        5.7.3.  PROP 98: PROP_IPV6_ML_PREFIX  . . . . . . . . . . . .  42
        5.7.4.  PROP 99: PROP_IPV6_ADDRESS_TABLE  . . . . . . . . . .  42
-       5.7.5.  PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD . . . . . . . .  42
+       5.7.5.  PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD . . . . . . . .  43
      5.8.  Debug Properties  . . . . . . . . . . . . . . . . . . . .  43
        5.8.1.  PROP 16384: SPINEL_PROP_DEBUG_TEST_ASSERT . . . . . .  43
-   6.  Status Codes  . . . . . . . . . . . . . . . . . . . . . . . .  43
-   7.  Technology: Thread  . . . . . . . . . . . . . . . . . . . . .  44
+       5.8.2.  PROP 16385: SPINEL_PROP_DEBUG_NCP_LOG_LEVEL . . . . .  43
+   6.  Status Codes  . . . . . . . . . . . . . . . . . . . . . . . .  44
+   7.  Technology: Thread  . . . . . . . . . . . . . . . . . . . . .  45
      7.1.  Thread Capabilities . . . . . . . . . . . . . . . . . . .  45
-     7.2.  Thread Properties . . . . . . . . . . . . . . . . . . . .  45
-       7.2.1.  PROP 80: PROP_THREAD_LEADER_ADDR  . . . . . . . . . .  45
-       7.2.2.  PROP 81: PROP_THREAD_PARENT . . . . . . . . . . . . .  45
-       7.2.3.  PROP 82: PROP_THREAD_CHILD_TABLE  . . . . . . . . . .  45
+     7.2.  Thread Properties . . . . . . . . . . . . . . . . . . . .  46
+       7.2.1.  PROP 80: PROP_THREAD_LEADER_ADDR  . . . . . . . . . .  46
+       7.2.2.  PROP 81: PROP_THREAD_PARENT . . . . . . . . . . . . .  46
+       7.2.3.  PROP 82: PROP_THREAD_CHILD_TABLE  . . . . . . . . . .  46
        7.2.4.  PROP 83: PROP_THREAD_LEADER_RID . . . . . . . . . . .  46
        7.2.5.  PROP 84: PROP_THREAD_LEADER_WEIGHT  . . . . . . . . .  46
-       7.2.6.  PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT  . . . . . .  46
-       7.2.7.  PROP 86: PROP_THREAD_NETWORK_DATA . . . . . . . . . .  46
-       7.2.8.  PROP 87: PROP_THREAD_NETWORK_DATA_VERSION . . . . . .  46
-       7.2.9.  PROP 88: PROP_THREAD_STABLE_NETWORK_DATA  . . . . . .  46
-       7.2.10. PROP 89: PROP_THREAD_STABLE_NETWORK_DATA_VERSION  . .  46
+       7.2.6.  PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT  . . . . . .  47
+       7.2.7.  PROP 86: PROP_THREAD_NETWORK_DATA . . . . . . . . . .  47
+       7.2.8.  PROP 87: PROP_THREAD_NETWORK_DATA_VERSION . . . . . .  47
+       7.2.9.  PROP 88: PROP_THREAD_STABLE_NETWORK_DATA  . . . . . .  47
+       7.2.10. PROP 89: PROP_THREAD_STABLE_NETWORK_DATA_VERSION  . .  47
        7.2.11. PROP 90: PROP_THREAD_ON_MESH_NETS . . . . . . . . . .  47
-       7.2.12. PROP 91: PROP_THREAD_LOCAL_ROUTES . . . . . . . . . .  47
-       7.2.13. PROP 92: PROP_THREAD_ASSISTING_PORTS  . . . . . . . .  47
-       7.2.14. PROP 93: PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE  . .  47
-       7.2.15. PROP 94: PROP_THREAD_MODE . . . . . . . . . . . . . .  47
+       7.2.12. PROP 91: PROP_THREAD_LOCAL_ROUTES . . . . . . . . . .  48
+       7.2.13. PROP 92: PROP_THREAD_ASSISTING_PORTS  . . . . . . . .  48
+       7.2.14. PROP 93: PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE  . .  48
+       7.2.15. PROP 94: PROP_THREAD_MODE . . . . . . . . . . . . . .  48
        7.2.16. PROP 5376: PROP_THREAD_CHILD_TIMEOUT  . . . . . . . .  48
        7.2.17. PROP 5377: PROP_THREAD_RLOC16 . . . . . . . . . . . .  48
-       7.2.18. PROP 5378: PROP_THREAD_ROUTER_UPGRADE_THRESHOLD . . .  48
-       7.2.19. PROP 5379: PROP_THREAD_CONTEXT_REUSE_DELAY  . . . . .  48
-       7.2.20. PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT . . . . . .  48
-       7.2.21. PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS  . . . . . .  48
-       7.2.22. PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU  . . . .  48
+       7.2.18. PROP 5378: PROP_THREAD_ROUTER_UPGRADE_THRESHOLD . . .  49
+       7.2.19. PROP 5379: PROP_THREAD_CONTEXT_REUSE_DELAY  . . . . .  49
+       7.2.20. PROP 5380: PROP_THREAD_NETWORK_ID_TIMEOUT . . . . . .  49
+       7.2.21. PROP 5381: PROP_THREAD_ACTIVE_ROUTER_IDS  . . . . . .  49
+       7.2.22. PROP 5382: PROP_THREAD_RLOC16_DEBUG_PASSTHRU  . . . .  49
        7.2.23. PROP 5383: PROP_THREAD_ROUTER_ROLE_ENABLED  . . . . .  49
-       7.2.24. PROP 5384: PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD . .  49
-       7.2.25. PROP 5385: PROP_THREAD_ROUTER_SELECTION_JITTER  . . .  49
-       7.2.26. PROP 5386: PROP_THREAD_PREFERRED_ROUTER_ID  . . . . .  49
-       7.2.27. PROP 5387: PROP_THREAD_NEIGHBOR_TABLE . . . . . . . .  49
+       7.2.24. PROP 5384: PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD . .  50
+       7.2.25. PROP 5385: PROP_THREAD_ROUTER_SELECTION_JITTER  . . .  50
+       7.2.26. PROP 5386: PROP_THREAD_PREFERRED_ROUTER_ID  . . . . .  50
+       7.2.27. PROP 5387: PROP_THREAD_NEIGHBOR_TABLE . . . . . . . .  50
        7.2.28. PROP 5388: PROP_THREAD_CHILD_COUNT_MAX  . . . . . . .  50
-       7.2.29. PROP 5389: PROP_THREAD_LEADER_NETWORK_DATA  . . . . .  50
-       7.2.30. PROP 5390: PROP_THREAD_STABLE_LEADER_NETWORK_DATA . .  50
-   8.  Feature: Network Save . . . . . . . . . . . . . . . . . . . .  50
-     8.1.  Commands  . . . . . . . . . . . . . . . . . . . . . . . .  50
-       8.1.1.  CMD 9: (Host->NCP) CMD_NET_SAVE . . . . . . . . . . .  50
+       7.2.29. PROP 5389: PROP_THREAD_LEADER_NETWORK_DATA  . . . . .  51
+       7.2.30. PROP 5390: PROP_THREAD_STABLE_LEADER_NETWORK_DATA . .  51
+       7.2.31. PROP 5391: PROP_THREAD_JOINERS  . . . . . . . . . . .  51
+       7.2.32. PROP 5392: PROP_THREAD_COMMISSIONER_ENABLED . . . . .  51
+       7.2.33. PROP 5393: PROP_THREAD_BA_PROXY_ENABLED . . . . . . .  51
+       7.2.34. PROP 5394: PROP_THREAD_BA_PROXY_STREAM  . . . . . . .  52
+   8.  Feature: Network Save . . . . . . . . . . . . . . . . . . . .  52
+     8.1.  Commands  . . . . . . . . . . . . . . . . . . . . . . . .  52
+       8.1.1.  CMD 9: (Host->NCP) CMD_NET_SAVE . . . . . . . . . . .  52
 
 
 
-Quattlebaum            Expires September 21, 2017               [Page 4]
+Quattlebaum & woodyatt  Expires November 2, 2017                [Page 4]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
-       8.1.2.  CMD 10: (Host->NCP) CMD_NET_CLEAR . . . . . . . . . .  51
-       8.1.3.  CMD 11: (Host->NCP) CMD_NET_RECALL  . . . . . . . . .  51
-   9.  Feature: Host Buffer Offload  . . . . . . . . . . . . . . . .  52
-     9.1.  Commands  . . . . . . . . . . . . . . . . . . . . . . . .  52
-       9.1.1.  CMD 12: (NCP->Host) CMD_HBO_OFFLOAD . . . . . . . . .  52
-       9.1.2.  CMD 13: (NCP->Host) CMD_HBO_RECLAIM . . . . . . . . .  52
-       9.1.3.  CMD 14: (NCP->Host) CMD_HBO_DROP  . . . . . . . . . .  52
-       9.1.4.  CMD 15: (Host->NCP) CMD_HBO_OFFLOADED . . . . . . . .  53
-       9.1.5.  CMD 16: (Host->NCP) CMD_HBO_RECLAIMED . . . . . . . .  53
-       9.1.6.  CMD 17: (Host->NCP) CMD_HBO_DROPPED . . . . . . . . .  53
-     9.2.  Properties  . . . . . . . . . . . . . . . . . . . . . . .  53
-       9.2.1.  PROP 10: PROP_HBO_MEM_MAX . . . . . . . . . . . . . .  53
-       9.2.2.  PROP 11: PROP_HBO_BLOCK_MAX . . . . . . . . . . . . .  54
-   10. Feature: Jam Detection  . . . . . . . . . . . . . . . . . . .  54
-     10.1.  Properties . . . . . . . . . . . . . . . . . . . . . . .  54
-       10.1.1.  PROP 4608: PROP_JAM_DETECT_ENABLE  . . . . . . . . .  54
-       10.1.2.  PROP 4609: PROP_JAM_DETECTED . . . . . . . . . . . .  55
-       10.1.3.  PROP 4610: PROP_JAM_DETECT_RSSI_THRESHOLD  . . . . .  55
-       10.1.4.  PROP 4611: PROP_JAM_DETECT_WINDOW  . . . . . . . . .  55
-       10.1.5.  PROP 4612: PROP_JAM_DETECT_BUSY  . . . . . . . . . .  56
-       10.1.6.  PROP 4613: SPINEL_PROP_JAM_DETECT_HISTORY_BITMAP . .  56
-   11. Feature: GPIO Access  . . . . . . . . . . . . . . . . . . . .  56
-     11.1.  Properties . . . . . . . . . . . . . . . . . . . . . . .  57
-       11.1.1.  PROP 4096: PROP_GPIO_CONFIG  . . . . . . . . . . . .  57
-       11.1.2.  PROP 4098: PROP_GPIO_STATE . . . . . . . . . . . . .  58
-       11.1.3.  PROP 4099: PROP_GPIO_STATE_SET . . . . . . . . . . .  58
-       11.1.4.  PROP 4100: PROP_GPIO_STATE_CLEAR . . . . . . . . . .  59
-   12. Feature: True Random Number Generation  . . . . . . . . . . .  59
-     12.1.  Properties . . . . . . . . . . . . . . . . . . . . . . .  59
-       12.1.1.  PROP 4101: PROP_TRNG_32  . . . . . . . . . . . . . .  59
-       12.1.2.  PROP 4102: PROP_TRNG_128 . . . . . . . . . . . . . .  60
-       12.1.3.  PROP 4103: PROP_TRNG_RAW_32  . . . . . . . . . . . .  60
-   13. Security Considerations . . . . . . . . . . . . . . . . . . .  61
-     13.1.  Raw Application Access . . . . . . . . . . . . . . . . .  61
-     14.1.  URIs . . . . . . . . . . . . . . . . . . . . . . . . . .  61
-   Appendix A.  Framing Protocol . . . . . . . . . . . . . . . . . .  61
-     A.1.  UART Recommendations  . . . . . . . . . . . . . . . . . .  61
-       A.1.1.  UART Bit Rate Detection . . . . . . . . . . . . . . .  62
-       A.1.2.  HDLC-Lite . . . . . . . . . . . . . . . . . . . . . .  62
-     A.2.  SPI Recommendations . . . . . . . . . . . . . . . . . . .  63
-       A.2.1.  SPI Framing Protocol  . . . . . . . . . . . . . . . .  64
-     A.3.  I^2C Recommendations  . . . . . . . . . . . . . . . . . .  66
-     A.4.  Native USB Recommendations  . . . . . . . . . . . . . . .  66
-   Appendix B.  Test Vectors . . . . . . . . . . . . . . . . . . . .  66
-     B.1.  Test Vector: Packed Unsigned Integer  . . . . . . . . . .  66
-     B.2.  Test Vector: Reset Command  . . . . . . . . . . . . . . .  66
-     B.3.  Test Vector: Reset Notification . . . . . . . . . . . . .  67
-     B.4.  Test Vector: Scan Beacon  . . . . . . . . . . . . . . . .  67
+       8.1.2.  CMD 10: (Host->NCP) CMD_NET_CLEAR . . . . . . . . . .  53
+       8.1.3.  CMD 11: (Host->NCP) CMD_NET_RECALL  . . . . . . . . .  53
+   9.  Feature: Host Buffer Offload  . . . . . . . . . . . . . . . .  54
+     9.1.  Commands  . . . . . . . . . . . . . . . . . . . . . . . .  54
+       9.1.1.  CMD 12: (NCP->Host) CMD_HBO_OFFLOAD . . . . . . . . .  54
+       9.1.2.  CMD 13: (NCP->Host) CMD_HBO_RECLAIM . . . . . . . . .  54
+       9.1.3.  CMD 14: (NCP->Host) CMD_HBO_DROP  . . . . . . . . . .  54
+       9.1.4.  CMD 15: (Host->NCP) CMD_HBO_OFFLOADED . . . . . . . .  55
+       9.1.5.  CMD 16: (Host->NCP) CMD_HBO_RECLAIMED . . . . . . . .  55
+       9.1.6.  CMD 17: (Host->NCP) CMD_HBO_DROPPED . . . . . . . . .  55
+     9.2.  Properties  . . . . . . . . . . . . . . . . . . . . . . .  55
+       9.2.1.  PROP 10: PROP_HBO_MEM_MAX . . . . . . . . . . . . . .  55
+       9.2.2.  PROP 11: PROP_HBO_BLOCK_MAX . . . . . . . . . . . . .  56
+   10. Feature: Jam Detection  . . . . . . . . . . . . . . . . . . .  56
+     10.1.  Properties . . . . . . . . . . . . . . . . . . . . . . .  56
+       10.1.1.  PROP 4608: PROP_JAM_DETECT_ENABLE  . . . . . . . . .  56
+       10.1.2.  PROP 4609: PROP_JAM_DETECTED . . . . . . . . . . . .  57
+       10.1.3.  PROP 4610: PROP_JAM_DETECT_RSSI_THRESHOLD  . . . . .  57
+       10.1.4.  PROP 4611: PROP_JAM_DETECT_WINDOW  . . . . . . . . .  57
+       10.1.5.  PROP 4612: PROP_JAM_DETECT_BUSY  . . . . . . . . . .  58
+       10.1.6.  PROP 4613: SPINEL_PROP_JAM_DETECT_HISTORY_BITMAP . .  58
+   11. Feature: GPIO Access  . . . . . . . . . . . . . . . . . . . .  58
+     11.1.  Properties . . . . . . . . . . . . . . . . . . . . . . .  59
+       11.1.1.  PROP 4096: PROP_GPIO_CONFIG  . . . . . . . . . . . .  59
+       11.1.2.  PROP 4098: PROP_GPIO_STATE . . . . . . . . . . . . .  60
+       11.1.3.  PROP 4099: PROP_GPIO_STATE_SET . . . . . . . . . . .  60
+       11.1.4.  PROP 4100: PROP_GPIO_STATE_CLEAR . . . . . . . . . .  61
+   12. Feature: True Random Number Generation  . . . . . . . . . . .  61
+     12.1.  Properties . . . . . . . . . . . . . . . . . . . . . . .  61
+       12.1.1.  PROP 4101: PROP_TRNG_32  . . . . . . . . . . . . . .  61
+       12.1.2.  PROP 4102: PROP_TRNG_128 . . . . . . . . . . . . . .  62
+       12.1.3.  PROP 4103: PROP_TRNG_RAW_32  . . . . . . . . . . . .  62
+   13. Security Considerations . . . . . . . . . . . . . . . . . . .  63
+     13.1.  Raw Application Access . . . . . . . . . . . . . . . . .  63
+     14.1.  URIs . . . . . . . . . . . . . . . . . . . . . . . . . .  63
+   Appendix A.  Framing Protocol . . . . . . . . . . . . . . . . . .  63
+     A.1.  UART Recommendations  . . . . . . . . . . . . . . . . . .  63
+       A.1.1.  UART Bit Rate Detection . . . . . . . . . . . . . . .  64
+       A.1.2.  HDLC-Lite . . . . . . . . . . . . . . . . . . . . . .  64
+     A.2.  SPI Recommendations . . . . . . . . . . . . . . . . . . .  65
+       A.2.1.  SPI Framing Protocol  . . . . . . . . . . . . . . . .  66
+     A.3.  I^2C Recommendations  . . . . . . . . . . . . . . . . . .  68
+     A.4.  Native USB Recommendations  . . . . . . . . . . . . . . .  68
+   Appendix B.  Test Vectors . . . . . . . . . . . . . . . . . . . .  68
+     B.1.  Test Vector: Packed Unsigned Integer  . . . . . . . . . .  68
+     B.2.  Test Vector: Reset Command  . . . . . . . . . . . . . . .  68
+     B.3.  Test Vector: Reset Notification . . . . . . . . . . . . .  69
+     B.4.  Test Vector: Scan Beacon  . . . . . . . . . . . . . . . .  69
 
 
 
-Quattlebaum            Expires September 21, 2017               [Page 5]
+Quattlebaum & woodyatt  Expires November 2, 2017                [Page 5]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
-     B.5.  Test Vector: Inbound IPv6 Packet  . . . . . . . . . . . .  67
-     B.6.  Test Vector: Outbound IPv6 Packet . . . . . . . . . . . .  68
-     B.7.  Test Vector: Fetch list of on-mesh networks . . . . . . .  68
-     B.8.  Test Vector: Returned list of on-mesh networks  . . . . .  68
-     B.9.  Test Vector: Adding an on-mesh network  . . . . . . . . .  68
-     B.10. Test Vector: Insertion notification of an on-mesh network  69
-     B.11. Test Vector: Removing a local on-mesh network . . . . . .  69
-     B.12. Test Vector: Removal notification of an on-mesh network .  70
-   Appendix C.  Example Sessions . . . . . . . . . . . . . . . . . .  70
-     C.1.  NCP Initialization  . . . . . . . . . . . . . . . . . . .  70
-     C.2.  Attaching to a network  . . . . . . . . . . . . . . . . .  71
-     C.3.  Successfully joining a pre-existing network . . . . . . .  71
-     C.4.  Unsuccessfully joining a pre-existing network . . . . . .  72
-     C.5.  Detaching from a network  . . . . . . . . . . . . . . . .  72
-     C.6.  Attaching to a saved network  . . . . . . . . . . . . . .  73
-     C.7.  NCP Software Reset  . . . . . . . . . . . . . . . . . . .  73
-     C.8.  Adding an on-mesh prefix  . . . . . . . . . . . . . . . .  73
-     C.9.  Entering low-power modes  . . . . . . . . . . . . . . . .  73
-     C.10. Sniffing raw packets  . . . . . . . . . . . . . . . . . .  73
-   Appendix D.  Acknowledgments  . . . . . . . . . . . . . . . . . .  74
-   Appendix E.  Glossary . . . . . . . . . . . . . . . . . . . . . .  75
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  76
+     B.5.  Test Vector: Inbound IPv6 Packet  . . . . . . . . . . . .  69
+     B.6.  Test Vector: Outbound IPv6 Packet . . . . . . . . . . . .  70
+     B.7.  Test Vector: Fetch list of on-mesh networks . . . . . . .  70
+     B.8.  Test Vector: Returned list of on-mesh networks  . . . . .  70
+     B.9.  Test Vector: Adding an on-mesh network  . . . . . . . . .  70
+     B.10. Test Vector: Insertion notification of an on-mesh network  71
+     B.11. Test Vector: Removing a local on-mesh network . . . . . .  71
+     B.12. Test Vector: Removal notification of an on-mesh network .  72
+   Appendix C.  Example Sessions . . . . . . . . . . . . . . . . . .  72
+     C.1.  NCP Initialization  . . . . . . . . . . . . . . . . . . .  72
+     C.2.  Attaching to a network  . . . . . . . . . . . . . . . . .  73
+     C.3.  Successfully joining a pre-existing network . . . . . . .  73
+     C.4.  Unsuccessfully joining a pre-existing network . . . . . .  74
+     C.5.  Detaching from a network  . . . . . . . . . . . . . . . .  74
+     C.6.  Attaching to a saved network  . . . . . . . . . . . . . .  75
+     C.7.  NCP Software Reset  . . . . . . . . . . . . . . . . . . .  75
+     C.8.  Adding an on-mesh prefix  . . . . . . . . . . . . . . . .  75
+     C.9.  Entering low-power modes  . . . . . . . . . . . . . . . .  75
+     C.10. Sniffing raw packets  . . . . . . . . . . . . . . . . . .  75
+   Appendix D.  Glossary . . . . . . . . . . . . . . . . . . . . . .  76
+   Appendix E.  Acknowledgments  . . . . . . . . . . . . . . . . . .  77
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  78
 
 1.  Introduction
 
@@ -333,9 +333,9 @@ Quattlebaum            Expires September 21, 2017               [Page 5]
 
 
 
-Quattlebaum            Expires September 21, 2017               [Page 6]
+Quattlebaum & woodyatt  Expires November 2, 2017                [Page 6]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    haven't yet been fully specified, as well as some of the impetus for
@@ -389,9 +389,9 @@ Quattlebaum            Expires September 21, 2017               [Page 6]
 
 
 
-Quattlebaum            Expires September 21, 2017               [Page 7]
+Quattlebaum & woodyatt  Expires November 2, 2017                [Page 7]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    encoded (Appendix A.1.2) spinel frames, as if the application were
@@ -445,9 +445,9 @@ Quattlebaum            Expires September 21, 2017               [Page 7]
 
 
 
-Quattlebaum            Expires September 21, 2017               [Page 8]
+Quattlebaum & woodyatt  Expires November 2, 2017                [Page 8]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 1.2.  Property Overview
@@ -501,9 +501,9 @@ Quattlebaum            Expires September 21, 2017               [Page 8]
 
 
 
-Quattlebaum            Expires September 21, 2017               [Page 9]
+Quattlebaum & woodyatt  Expires November 2, 2017                [Page 9]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 1.2.2.1.  Single-Value Properties
@@ -557,9 +557,9 @@ Quattlebaum            Expires September 21, 2017               [Page 9]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 10]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 10]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    All such properties emit changes asynchronously using the "VALUE_IS"
@@ -594,7 +594,7 @@ Quattlebaum            Expires September 21, 2017              [Page 10]
 
                        0   1   2   3   4   5   6   7
                      +---+---+---+---+---+---+---+---+
-                     |  FLG  |  IID  |      TID      |
+                     |  FLG  |  NLI  |      TID      |
                      +---+---+---+---+---+---+---+---+
 
    [CREF1]
@@ -613,18 +613,22 @@ Quattlebaum            Expires September 21, 2017              [Page 10]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 11]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 11]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
-2.1.2.  IID: Interface Identifier
+2.1.2.  NLI: Network Link Identifier
 
-   The Interface Identifier (IID) is a number between 0 and 3 which
-   identifies which subinterface the frame is intended for.  This allows
-   the protocol to support connecting to more than one network at once.
-   The first subinterface (0) is considered the primary subinterface and
-   MUST be supported.  Support for all other subinterfaces is OPTIONAL.
+   The Network Link Identifier (NLI) is a number between 0 and 3, which
+   is associated by the OS with one of up to four IPv6 zone indices
+   corresponding to conceptual IPv6 interfaces on the NCP.  This allows
+   the protocol to support IPv6 nodes connecting simultaneously to more
+   than one IPv6 network link using a single NCP instance.  The first
+   Network Link Identifier (0) MUST refer to a distinguished conceptual
+   interface provided by the NCP for its IPv6 link type.  The other
+   three Network Link Identifiers (1, 2 and 3) MAY be dissociated from
+   any conceptual interface.
 
 2.1.3.  TID: Transaction Identifier
 
@@ -659,20 +663,22 @@ Quattlebaum            Expires September 21, 2017              [Page 11]
           | 2,000,000 - 2,097,151 |   Experimental use only    |
           +-----------------------+----------------------------+
 
+
+
+
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 12]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
+
 2.1.5.  Command Payload (Optional)
 
    Depending on the semantics of the command in question, a payload MAY
    be included in the frame.  The exact composition and length of the
    payload is defined by the command identifier.
-
-
-
-
-
-Quattlebaum            Expires September 21, 2017              [Page 12]
-
-                       Spinel Protocol (6d981f72)             March 2017
-
 
 3.  Data Packing
 
@@ -719,15 +725,9 @@ Quattlebaum            Expires September 21, 2017              [Page 12]
 
 
 
-
-
-
-
-
-
-Quattlebaum            Expires September 21, 2017              [Page 13]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 13]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    +----------+----------------------+---------------------------------+
@@ -781,9 +781,9 @@ Quattlebaum            Expires September 21, 2017              [Page 13]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 14]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 14]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    For all values less than 127, the packed form of the number is simply
@@ -837,9 +837,9 @@ Quattlebaum            Expires September 21, 2017              [Page 14]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 15]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 15]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    tell where the start and end of the data blob is: the start is 9
@@ -850,8 +850,8 @@ Quattlebaum            Expires September 21, 2017              [Page 15]
    The datatype signature "CLLDU" is illegal because we can't determine
    where the last field (a zero-terminated UTF8 string) starts.  But the
    datatype "CLLdU" _is_ legal, because the parser can determine the
-   exact length of the data blob--allowing it to know where the start of
-   the next field would be.
+   exact length of the data blob-- allowing it to know where the start
+   of the next field would be.
 
 3.4.  Structured Data
 
@@ -893,9 +893,9 @@ Quattlebaum            Expires September 21, 2017              [Page 15]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 16]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 16]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    This specification does not define a way to embed an array as a field
@@ -949,9 +949,9 @@ Quattlebaum            Expires September 21, 2017              [Page 16]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 17]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 17]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
             +---------+--------+--------------------+---------+
@@ -1005,9 +1005,9 @@ Quattlebaum            Expires September 21, 2017              [Page 17]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 18]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 18]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    The payload for this command is the property identifier encoded in
@@ -1061,9 +1061,9 @@ Quattlebaum            Expires September 21, 2017              [Page 18]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 19]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 19]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 4.7.  CMD 6: (NCP->Host) CMD_PROP_VALUE_IS
@@ -1117,9 +1117,9 @@ Quattlebaum            Expires September 21, 2017              [Page 19]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 20]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 20]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 4.9.  CMD 8: (NCP->Host) CMD_PROP_VALUE_REMOVED
@@ -1173,9 +1173,9 @@ Quattlebaum            Expires September 21, 2017              [Page 20]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 21]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 21]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    The implementation of this command has security implications.  See
@@ -1229,9 +1229,9 @@ Quattlebaum            Expires September 21, 2017              [Page 21]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 22]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 22]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    Errors fetching individual properties are reflected as indicating a
@@ -1285,9 +1285,9 @@ Quattlebaum            Expires September 21, 2017              [Page 22]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 23]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 23]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 4.15.  CMD 23: (NCP->Host) CMD_PROP_VALUES_ARE
@@ -1341,9 +1341,9 @@ Quattlebaum            Expires September 21, 2017              [Page 23]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 24]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 24]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
     +-----------------------+-----------------------------------------+
@@ -1397,9 +1397,9 @@ Quattlebaum            Expires September 21, 2017              [Page 24]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 25]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 25]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
                          +---------+-------------+
@@ -1453,9 +1453,9 @@ Quattlebaum            Expires September 21, 2017              [Page 25]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 26]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 26]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 5.2.2.2.  Minor Version Number
@@ -1509,9 +1509,9 @@ Quattlebaum            Expires September 21, 2017              [Page 26]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 27]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 27]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    o  2: ZigBeeIP
@@ -1565,9 +1565,9 @@ Quattlebaum            Expires September 21, 2017              [Page 27]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 28]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 28]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    o  10: "CAP_TRNG": Support for true random number generation.  See
@@ -1590,6 +1590,8 @@ Quattlebaum            Expires September 21, 2017              [Page 28]
    o  49: "CAP_ROLE_SLEEPY"
    o  52: "CAP_NET_THREAD_1_0"
    o  512: "CAP_MAC_WHITELIST"
+   o  1024: "CAP_THREAD_COMMISSIONER"
+   o  1025: "CAP_THREAD_BA_PROXY"
 
    Additionally, future capability allocations SHALL be made from the
    following allocation plan:
@@ -1615,16 +1617,18 @@ Quattlebaum            Expires September 21, 2017              [Page 28]
                       | Fields: | "INTERFACE_COUNT" |
                       +---------+-------------------+
 
+
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 29]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
+
    Describes the number of concurrent interfaces supported by this NCP.
    Since the concurrent interface mechanism is still TBD, this value
    MUST always be one.
-
-
-
-Quattlebaum            Expires September 21, 2017              [Page 29]
-
-                       Spinel Protocol (6d981f72)             March 2017
-
 
    This value is encoded as an unsigned 8-bit integer.
 
@@ -1668,19 +1672,19 @@ Quattlebaum            Expires September 21, 2017              [Page 29]
                            | Fields: | HWADDR |
                            +---------+--------+
 
+
+
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 30]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
+
    The static EUI64 address of the device, used as a serial number.
    This value is read-only, but may be writable under certain vendor-
    defined circumstances.
-
-
-
-
-
-
-Quattlebaum            Expires September 21, 2017              [Page 30]
-
-                       Spinel Protocol (6d981f72)             March 2017
-
 
 5.2.10.  PROP 9: PROP_LOCK
 
@@ -1727,16 +1731,15 @@ Quattlebaum            Expires September 21, 2017              [Page 30]
    the NCP's responsibility to insert newline characters where needed,
    just like with any other text stream.
 
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 31]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
+
    To receive the debugging stream, you wait for "CMD_PROP_VALUE_IS"
    commands for this property from the NCP.
-
-
-
-
-Quattlebaum            Expires September 21, 2017              [Page 31]
-
-                       Spinel Protocol (6d981f72)             March 2017
-
 
 5.3.2.  PROP 113: PROP_STREAM_RAW
 
@@ -1786,12 +1789,9 @@ Quattlebaum            Expires September 21, 2017              [Page 31]
 
 
 
-
-
-
-Quattlebaum            Expires September 21, 2017              [Page 32]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 32]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
      +----------+-----------------------+------------+-----+---------+
@@ -1845,9 +1845,9 @@ Quattlebaum            Expires September 21, 2017              [Page 32]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 33]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 33]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
         +---------+----------------+------------+----------------+
@@ -1901,9 +1901,9 @@ Quattlebaum            Expires September 21, 2017              [Page 33]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 34]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 34]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    Any data past the end of "FRAME_DATA_LEN" is considered metadata, the
@@ -1957,9 +1957,9 @@ Quattlebaum            Expires September 21, 2017              [Page 34]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 35]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 35]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    When setting, the value will be rounded down to a value that is
@@ -2013,9 +2013,9 @@ Quattlebaum            Expires September 21, 2017              [Page 35]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 36]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 36]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 5.5.2.  PROP 49: PROP_MAC_SCAN_MASK
@@ -2069,9 +2069,9 @@ Quattlebaum            Expires September 21, 2017              [Page 36]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 37]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 37]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 5.5.5.  PROP 52: PROP_MAC_15_4_LADDR
@@ -2125,9 +2125,9 @@ Quattlebaum            Expires September 21, 2017              [Page 37]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 38]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 38]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    +----+--------------------------------+-----------------------------+
@@ -2181,9 +2181,9 @@ Quattlebaum            Expires September 21, 2017              [Page 38]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 39]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 39]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 5.5.13.  PROP 4868: SPINEL_PROP_MAC_SRC_MATCH_SHORT_ADDRESSES
@@ -2237,9 +2237,9 @@ Quattlebaum            Expires September 21, 2017              [Page 39]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 40]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 40]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    Thread stack operational status.  Non-zero (set to 1) indicates up,
@@ -2285,18 +2285,28 @@ Quattlebaum            Expires September 21, 2017              [Page 40]
 
    The partition ID of the partition that this node is a member of.
 
-5.6.10.  PROP 73: PROP_NET_KEY_SWITCH_GUARDTIME
+5.6.10.  PROP 73: PROP_NET_REQUIRE_JOIN_EXISTING
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "b"
+
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 41]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
+
+5.6.11.  PROP 74: PROP_NET_KEY_SWITCH_GUARDTIME
 
    o  Type: Read-Write
    o  Packed-Encoding: "L"
 
+5.6.12.  PROP 75: PROP_NET_PSKC
 
-
-
-Quattlebaum            Expires September 21, 2017              [Page 41]
-
-                       Spinel Protocol (6d981f72)             March 2017
-
+   o  Type: Read-Write
+   o  Packed-Encoding: "D"
 
 5.7.  IPv6 Properties
 
@@ -2334,6 +2344,16 @@ Quattlebaum            Expires September 21, 2017              [Page 41]
    o  "L": Preferred Lifetime
    o  "C": Flags
 
+
+
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 42]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
+
 5.7.5.  PROP 101: PROP_IPv6_ICMP_PING_OFFLOAD
 
    o  Type: Read-Write
@@ -2343,16 +2363,6 @@ Quattlebaum            Expires September 21, 2017              [Page 41]
    turned on, ping request ICMP packets will not be passed to the host.
 
    Default value is "false".
-
-
-
-
-
-
-Quattlebaum            Expires September 21, 2017              [Page 42]
-
-                       Spinel Protocol (6d981f72)             March 2017
-
 
 5.8.  Debug Properties
 
@@ -2366,6 +2376,39 @@ Quattlebaum            Expires September 21, 2017              [Page 42]
    NCP.  Assert should ideally cause the NCP to reset, but if "assert"
    is not supported or disabled boolean value of "false" is returned in
    response.
+
+5.8.2.  PROP 16385: SPINEL_PROP_DEBUG_NCP_LOG_LEVEL
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "C"
+
+   Provides access to the NCP log level.  Currently defined values are
+   (which follows the RFC 5424):
+
+   o  0: Emergency (emerg).
+   o  1: Alert (alert).
+   o  2: Critical (crit).
+   o  3: Error (err).
+   o  4: Warning (warn).
+   o  5: Notice (notice).
+   o  6: Information (info).
+   o  7: Debug (debug).
+
+   If the NCP supports dynamic log level control, setting this property
+   changes the log level accordingly.  Getting the value returns the
+   current log level.  If the dynamic log level control is not
+   supported, setting this property returns a LAST_STATUS with
+   SPINEL_STATUS_INVALID_COMMAND_FOR_PROP status.
+
+
+
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 43]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
 
 6.  Status Codes
 
@@ -2402,14 +2445,6 @@ Quattlebaum            Expires September 21, 2017              [Page 42]
       occurred.
    o  9: "STATUS_PARSE_ERROR": An error has occurred while parsing the
       command.
-
-
-
-Quattlebaum            Expires September 21, 2017              [Page 43]
-
-                       Spinel Protocol (6d981f72)             March 2017
-
-
    o  10: "STATUS_IN_PROGRESS": The operation is in progress and will be
       completed asynchronously.
    o  11: "STATUS_NOMEM": The operation has been prevented due to memory
@@ -2422,6 +2457,15 @@ Quattlebaum            Expires September 21, 2017              [Page 43]
    o  16: "STATUS_CMD_TOO_BIG": The command was too large to fit in the
       internal buffer.
    o  17: "STATUS_NO_ACK": The packet was not acknowledged.
+
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 44]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
+
    o  18: "STATUS_CCA_FAILURE": The packet was not sent due to a CCA
       failure.
    o  19: "STATUS_ALREADY": The operation is already in progress or the
@@ -2457,15 +2501,6 @@ Quattlebaum            Expires September 21, 2017              [Page 43]
    Thread NCPs have the following requirements:
 
    o  The property "PROP_INTERFACE_TYPE" must be 3.
-
-
-
-
-Quattlebaum            Expires September 21, 2017              [Page 44]
-
-                       Spinel Protocol (6d981f72)             March 2017
-
-
    o  The non-optional properties in the following sections MUST be
       implemented: CORE, PHY, MAC, NET, and IPV6.
 
@@ -2478,6 +2513,15 @@ Quattlebaum            Expires September 21, 2017              [Page 44]
 
    o  "CAP_NET_THREAD_1_0" - Indicates that the NCP implements v1.0 of
       the Thread standard.
+
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 45]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
+
    o  "CAP_NET_THREAD_1_1" - Indicates that the NCP implements v1.1 of
       the Thread standard.
 
@@ -2510,18 +2554,6 @@ Quattlebaum            Expires September 21, 2017              [Page 44]
    Table containing the long and short addresses of all the children of
    this node.
 
-
-
-
-
-
-
-
-Quattlebaum            Expires September 21, 2017              [Page 45]
-
-                       Spinel Protocol (6d981f72)             March 2017
-
-
 7.2.4.  PROP 83: PROP_THREAD_LEADER_RID
 
    o  Type: Read-Only
@@ -2535,6 +2567,16 @@ Quattlebaum            Expires September 21, 2017              [Page 45]
    o  Packed-Encoding: "C"
 
    The leader weight of the current leader.
+
+
+
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 46]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
 
 7.2.6.  PROP 85: PROP_THREAD_LOCAL_LEADER_WEIGHT
 
@@ -2567,17 +2609,6 @@ Quattlebaum            Expires September 21, 2017              [Page 45]
    o  Type: Read-Only
    o  Packed-Encoding: "S"
 
-
-
-
-
-
-
-Quattlebaum            Expires September 21, 2017              [Page 46]
-
-                       Spinel Protocol (6d981f72)             March 2017
-
-
 7.2.11.  PROP 90: PROP_THREAD_ON_MESH_NETS
 
    o  Type: Read-Write
@@ -2592,6 +2623,16 @@ Quattlebaum            Expires September 21, 2017              [Page 46]
    o  "b": "Is defined locally" flag.  Set if this network was locally
       defined.  Assumed to be true for set, insert and replace.  Clear
       if the on mesh network was defined by another node.
+
+
+
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 47]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
 
 7.2.12.  PROP 91: PROP_THREAD_LOCAL_ROUTES
 
@@ -2627,13 +2668,6 @@ Quattlebaum            Expires September 21, 2017              [Page 46]
    meaning of the bits in this bitfield are defined by section 4.5.2 of
    the Thread specification.
 
-
-
-Quattlebaum            Expires September 21, 2017              [Page 47]
-
-                       Spinel Protocol (6d981f72)             March 2017
-
-
 7.2.16.  PROP 5376: PROP_THREAD_CHILD_TIMEOUT
 
    o  Type: Read-Write
@@ -2645,6 +2679,16 @@ Quattlebaum            Expires September 21, 2017              [Page 47]
 
    o  Type: Read-Write
    o  Packed-Encoding: "S"
+
+
+
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 48]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
 
 7.2.18.  PROP 5378: PROP_THREAD_ROUTER_UPGRADE_THRESHOLD
 
@@ -2682,14 +2726,6 @@ Quattlebaum            Expires September 21, 2017              [Page 47]
 
    Default value is "false".
 
-
-
-
-Quattlebaum            Expires September 21, 2017              [Page 48]
-
-                       Spinel Protocol (6d981f72)             March 2017
-
-
 7.2.23.  PROP 5383: PROP_THREAD_ROUTER_ROLE_ENABLED
 
    o  Type: Read-Write
@@ -2698,6 +2734,17 @@ Quattlebaum            Expires September 21, 2017              [Page 48]
    Allow the HOST to indicate whether or not the router role is enabled.
    If current role is a router, setting this property to "false" starts
    a re-attach process as an end-device.
+
+
+
+
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 49]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
 
 7.2.24.  PROP 5384: PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD
 
@@ -2738,20 +2785,22 @@ Quattlebaum            Expires September 21, 2017              [Page 48]
    o  "C": Mode (bit-flags)
    o  "b": "true" if neighbor is a child, "false" otherwise.
    o  "L": Link Frame Counter
-
-
-
-Quattlebaum            Expires September 21, 2017              [Page 49]
-
-                       Spinel Protocol (6d981f72)             March 2017
-
-
    o  "L": MLE Frame Counter
 
 7.2.28.  PROP 5388: PROP_THREAD_CHILD_COUNT_MAX
 
    o  Type: Read-Write
    o  Packed-Encoding: "C"
+
+
+
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 50]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
 
    Specifies the maximum number of children currently allowed.  This
    parameter can only be set when Thread protocol operation has been
@@ -2770,6 +2819,68 @@ Quattlebaum            Expires September 21, 2017              [Page 49]
    o  Packed-Encoding: "D"
 
    The stable leader network data.
+
+7.2.31.  PROP 5391: PROP_THREAD_JOINERS
+
+   o  Type: Insert/Remove Only (optionally Read-Write)
+   o  Packed-Encoding: "A(t(ULE))"
+   o  Required capability: "CAP_THREAD_COMMISSIONER"
+
+   Data per item is:
+
+   o  "U": PSKd
+   o  "L": Timeout in seconds
+   o  "E": Extended/long address (optional)
+
+   Passess Pre-Shared Key for the Device to the NCP in the commissioning
+   process.  When the Extended address is ommited all Devices which
+   provided a valid PSKd are allowed to join the Thread Network.
+
+7.2.32.  PROP 5392: PROP_THREAD_COMMISSIONER_ENABLED
+
+   o  Type: Write only (optionally Read-Write)
+   o  Packed-Encoding: "b"
+   o  Required capability: "CAP_THREAD_COMMISSIONER"
+
+   Set to true to enable the native commissioner.  It is mandatory
+   before adding the joiner to the network.
+
+7.2.33.  PROP 5393: PROP_THREAD_BA_PROXY_ENABLED
+
+   o  Type: Read-Write
+   o  Packed-Encoding: "b"
+   o  Required capability: "CAP_THREAD_BA_PROXY"
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 51]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
+
+   Set to true to enable the border agent proxy.
+
+7.2.34.  PROP 5394: PROP_THREAD_BA_PROXY_STREAM
+
+   o  Type: Read-Write-Stream
+   o  Packed-Encoding: "dSS"
+   o  Required capability: "CAP_THREAD_BA_PROXY"
+
+   Data per item is:
+
+   o  "d": CoAP frame
+   o  "S": source/destination RLOC/ALOC
+   o  "S": source/destination port
+
+               +----------+--------+------+---------+------+
+               | Octects: |   2    |  n   |    2    |  2   |
+               +----------+--------+------+---------+------+
+               | Fields:  | Length | CoAP | locator | port |
+               +----------+--------+------+---------+------+
+
+   This property allows the host to send and receive border-agent-
+   related CoAP requests/responses from the NCP's RLOC address.  This
+   allows the host driver to implement a Thread border agent.
 
 8.  Feature: Network Save
 
@@ -2797,9 +2908,10 @@ Quattlebaum            Expires September 21, 2017              [Page 49]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 50]
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 52]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    Save network state command.  Saves any current network credentials
@@ -2853,9 +2965,9 @@ Quattlebaum            Expires September 21, 2017              [Page 50]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 51]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 53]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    This command will typically generated several unsolicited property
@@ -2909,9 +3021,9 @@ Quattlebaum            Expires September 21, 2017              [Page 51]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 52]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 54]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 9.1.4.  CMD 15: (Host->NCP) CMD_HBO_OFFLOADED
@@ -2965,9 +3077,9 @@ Quattlebaum            Expires September 21, 2017              [Page 52]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 53]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 55]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 9.2.2.  PROP 11: PROP_HBO_BLOCK_MAX
@@ -3021,9 +3133,9 @@ Quattlebaum            Expires September 21, 2017              [Page 53]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 54]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 56]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    This property is only available if the "CAP_JAM_DETECT" capability is
@@ -3077,9 +3189,9 @@ Quattlebaum            Expires September 21, 2017              [Page 54]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 55]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 57]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 10.1.5.  PROP 4612: PROP_JAM_DETECT_BUSY
@@ -3133,9 +3245,9 @@ Quattlebaum            Expires September 21, 2017              [Page 55]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 56]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 58]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 11.1.  Properties
@@ -3189,9 +3301,9 @@ Quattlebaum            Expires September 21, 2017              [Page 56]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 57]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 59]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 11.1.2.  PROP 4098: PROP_GPIO_STATE
@@ -3245,9 +3357,9 @@ Quattlebaum            Expires September 21, 2017              [Page 57]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 58]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 60]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 11.1.4.  PROP 4100: PROP_GPIO_STATE_CLEAR
@@ -3301,9 +3413,9 @@ Quattlebaum            Expires September 21, 2017              [Page 58]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 59]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 61]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    o  Each of the 32 bits returned MUST be free of bias and have no
@@ -3357,9 +3469,9 @@ Quattlebaum            Expires September 21, 2017              [Page 59]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 60]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 62]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 13.  Security Considerations
@@ -3413,9 +3525,9 @@ A.1.  UART Recommendations
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 61]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 63]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    the absence of hardware flow control, software flow control (XON/
@@ -3469,9 +3581,9 @@ A.1.2.  HDLC-Lite
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 62]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 64]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    To transmit a frame with HDLC-lite, the 16-bit CRC must first be
@@ -3525,9 +3637,9 @@ A.2.  SPI Recommendations
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 63]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 65]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    The "I&#773;N&#773;T&#773;" signal is used by the NCP to indicate to
@@ -3581,9 +3693,9 @@ A.2.1.  SPI Framing Protocol
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 64]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 66]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    o  "CRC": This bit is set when that device supports writing a 16-bit
@@ -3637,9 +3749,9 @@ Quattlebaum            Expires September 21, 2017              [Page 64]
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 65]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 67]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    must be rejected and the "CRC_FAIL" bit on the next frame (and ONLY
@@ -3680,7 +3792,7 @@ B.1.  Test Vector: Packed Unsigned Integer
 
 B.2.  Test Vector: Reset Command
 
-   o  IID: 0
+   o  NLI: 0
    o  TID: 0
    o  CMD: 1 ("CMD_RESET")
 
@@ -3693,14 +3805,14 @@ B.2.  Test Vector: Reset Command
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 66]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 68]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 B.3.  Test Vector: Reset Notification
 
-   o  IID: 0
+   o  NLI: 0
    o  TID: 0
    o  CMD: 6 ("CMD_VALUE_IS")
    o  PROP: 0 ("PROP_LAST_STATUS")
@@ -3712,7 +3824,7 @@ B.3.  Test Vector: Reset Notification
 
 B.4.  Test Vector: Scan Beacon
 
-   o  IID: 0
+   o  NLI: 0
    o  TID: 0
    o  CMD: 7 ("CMD_VALUE_INSERTED")
    o  PROP: 51 ("PROP_MAC_SCAN_BEACON")
@@ -3749,9 +3861,9 @@ B.5.  Test Vector: Inbound IPv6 Packet
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 67]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 69]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 B.6.  Test Vector: Outbound IPv6 Packet
@@ -3762,7 +3874,7 @@ B.6.  Test Vector: Outbound IPv6 Packet
 
 B.7.  Test Vector: Fetch list of on-mesh networks
 
-   o  IID: 0
+   o  NLI: 0
    o  TID: 4
    o  CMD: 2 ("CMD_VALUE_GET")
    o  PROP: 90 ("PROP_THREAD_ON_MESH_NETS")
@@ -3773,7 +3885,7 @@ B.7.  Test Vector: Fetch list of on-mesh networks
 
 B.8.  Test Vector: Returned list of on-mesh networks
 
-   o  IID: 0
+   o  NLI: 0
    o  TID: 4
    o  CMD: 6 ("CMD_VALUE_IS")
    o  PROP: 90 ("PROP_THREAD_ON_MESH_NETS")
@@ -3794,7 +3906,7 @@ B.8.  Test Vector: Returned list of on-mesh networks
 
 B.9.  Test Vector: Adding an on-mesh network
 
-   o  IID: 0
+   o  NLI: 0
    o  TID: 5
    o  CMD: 4 ("CMD_VALUE_INSERT")
    o  PROP: 90 ("PROP_THREAD_ON_MESH_NETS")
@@ -3805,9 +3917,9 @@ B.9.  Test Vector: Adding an on-mesh network
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 68]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 70]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
        +--------------+---------------+-------------+-------------+
@@ -3825,7 +3937,7 @@ Quattlebaum            Expires September 21, 2017              [Page 68]
 
 B.10.  Test Vector: Insertion notification of an on-mesh network
 
-   o  IID: 0
+   o  NLI: 0
    o  TID: 5
    o  CMD: 7 ("CMD_VALUE_INSERTED")
    o  PROP: 90 ("PROP_THREAD_ON_MESH_NETS")
@@ -3846,7 +3958,7 @@ B.10.  Test Vector: Insertion notification of an on-mesh network
 
 B.11.  Test Vector: Removing a local on-mesh network
 
-   o  IID: 0
+   o  NLI: 0
    o  TID: 6
    o  CMD: 5 ("CMD_VALUE_REMOVE")
    o  PROP: 90 ("PROP_THREAD_ON_MESH_NETS")
@@ -3861,14 +3973,14 @@ B.11.  Test Vector: Removing a local on-mesh network
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 69]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 71]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 B.12.  Test Vector: Removal notification of an on-mesh network
 
-   o  IID: 0
+   o  NLI: 0
    o  TID: 6
    o  CMD: 8 ("CMD_VALUE_REMOVED")
    o  PROP: 90 ("PROP_THREAD_ON_MESH_NETS")
@@ -3917,9 +4029,9 @@ C.1.  NCP Initialization
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 70]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 72]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    o  CMD_NET_RECALL
@@ -3973,9 +4085,9 @@ C.3.  Successfully joining a pre-existing network
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 71]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 73]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    This example session is identical to the above session up to the
@@ -4029,9 +4141,9 @@ C.5.  Detaching from a network
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 72]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 74]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
 C.6.  Attaching to a saved network
@@ -4085,9 +4197,9 @@ C.10.  Sniffing raw packets
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 73]
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 75]
 
-                       Spinel Protocol (6d981f72)             March 2017
+                    Spinel Protocol (86157e99-dirty)            May 2017
 
 
    o  CMD_VALUE_SET:PROP_PHY_CHAN:x
@@ -4123,43 +4235,29 @@ Quattlebaum            Expires September 21, 2017              [Page 73]
    so that you can avoid receiving packets from other networks or that
    are destined for other nodes.
 
-Appendix D.  Acknowledgments
-
-   Special thanks to Abtin Keshavarzian, Martin Turon, Arjuna
-   Sivasithambaresan and Jonathan Hui for their substantial
-   contributions and feedback related to this document.
+Appendix D.  Glossary
 
    [CREF15]
 
-   This document was prepared using mmark [5] by (Miek Gieben) and
-   xml2rfc (version 2) [6].
-
-
-
-
-
-
-
-
-Quattlebaum            Expires September 21, 2017              [Page 74]
-
-                       Spinel Protocol (6d981f72)             March 2017
-
-
-Appendix E.  Glossary
-
-   [CREF16]
-
    NCP
-      Acronym for Network Control Processor.
-   Host
-      Computer or Micro-controller which controls the NCP.
+      Network Control Processor.
+   OS
+      Operating System, i.e. the IPv6 node using Spinel to control and
+      manage one or more of its IPv6 network interfaces.
    TID
       Transaction Identifier.  May be a value between zero and fifteen.
       See Section 2.1.3 for more information.
-   IID
-      Interface Identifier.  May be a value between zero and three.  See
-      Section 2.1.2 for more information.
+   NLI
+      Network Link Identifier.  May be a value between zero and three.
+      See Section 2.1.2 for more information.
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 76]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
+
    PUI
       Packed Unsigned Integer.  A way to serialize an unsigned integer
       using one, two, or three bytes.  Used throughout the Spinel
@@ -4172,15 +4270,21 @@ Appendix E.  Glossary
       to the physical implementation and operation of a networking
       medium.
 
-Editorial Comments
+Appendix E.  Acknowledgments
 
-[CREF1] RQ: We may want to consider a license more appropriate for
-        documentation.
+   Special thanks to Nick Banks, Jonathan Hui, Abtin Keshavarzian, Piotr
+   Szkotak, Arjuna Sivasithambaresan and Martin Turon for their
+   substantial contributions and feedback related to this document.
+
+   This document was prepared using mmark [5] by (Miek Gieben) and
+   xml2rfc (version 2) [6].
+
+Editorial Comments
 
 [CREF1] RQ: Eventually, when https://github.com/miekg/mmark/issues/95 is
         addressed, the above table should be swapped out with this: |
         0 | 1 | 2 | 3 | 4 | 5 | 6 |
-        7 | |---|---|---|---|---|---|---|---| | FLG || IID || TID ||||
+        7 | |---|---|---|---|---|---|---|---| | FLG || NLI || TID ||||
 
 [CREF2] RQ: It may make sense to have a look at what Bluetooth HCI is
         doing for native I^2C framing and go with that.
@@ -4194,14 +4298,6 @@ Editorial Comments
 
 [CREF6] RQ: FIXME: This test vector is incomplete.
 
-
-
-
-Quattlebaum            Expires September 21, 2017              [Page 75]
-
-                       Spinel Protocol (6d981f72)             March 2017
-
-
 [CREF7] RQ: FIXME: This test vector is incomplete.
 
 [CREF8] RQ: FIXME: This test vector is incomplete.
@@ -4209,6 +4305,14 @@ Quattlebaum            Expires September 21, 2017              [Page 75]
 [CREF9] RQ: FIXME: This example session is incomplete.
 
 [CREF10] RQ: FIXME: This example session is incomplete.
+
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 77]
+
+                    Spinel Protocol (86157e99-dirty)            May 2017
+
 
 [CREF11] RQ: FIXME: This example session is incomplete.
 
@@ -4218,15 +4322,12 @@ Quattlebaum            Expires September 21, 2017              [Page 75]
 
 [CREF14] RQ: FIXME: This example session is incomplete.
 
-[CREF15] RQ: If I have missed anyone who has contributed to this
-         document, please let me know ASAP.
+[CREF15] RQ: Alphabetize before finalization.
 
-[CREF16] RQ: Alphabetize before finalization.
-
-Author's Address
+Authors' Addresses
 
    Robert S. Quattlebaum
-   Nest Labs
+   Nest Labs, Inc.
    3400 Hillview Ave.
    Palo Alto, California  94304
    USA
@@ -4234,6 +4335,13 @@ Author's Address
    Email: rquattle@nestlabs.com
 
 
+   james woodyatt
+   Nest Labs, Inc.
+   3400 Hillview Ave.
+   Palo Alto, California  94304
+   USA
+
+   Email: jhw@nestlabs.com
 
 
 
@@ -4253,4 +4361,8 @@ Author's Address
 
 
 
-Quattlebaum            Expires September 21, 2017              [Page 76]
+
+
+
+
+Quattlebaum & woodyatt  Expires November 2, 2017               [Page 78]

--- a/doc/spinel-protocol-src/draft-rquattle-spinel-basis.md.in
+++ b/doc/spinel-protocol-src/draft-rquattle-spinel-basis.md.in
@@ -1,24 +1,24 @@
 %%%
-    title       = "Spinel: A basis for control and management of network interface co-processors"
-    abbrev      = "Spinel Basis (@SOURCE_VERSION@)"
-    category    = "std"
-    docName     = "draft-rquattle-spinel-basis-@SOURCE_VERSION@"
-    ipr         = "trust200902"
-    keyword     = ["Spinel", "IPv6", "NCP"]
-    date        = @SOURCE_DATE@
+    title           = "Spinel: A protocol basis for control and management of IPv6 network interface co-processors"
+    abbrev          = "Spinel Basis"
+    category        = "std"
+    docName         = "draft-rquattle-spinel-basis"
+    ipr             = "trust200902"
+    keyword         = ["Spinel", "IPv6", "NCP"]
+    date            = @SOURCE_DATE@
     
     [pi]
-    editing     = "yes"
-    private     = "OpenThread"
-    compact     = "yes"
-    subcompact  = "yes"
-    comments    = "yes"
+    editing         = "yes"
+    private         = "OpenThread"
+    compact         = "yes"
+    subcompact      = "yes"
+    comments        = "yes"
     
     [[author]]
     initials        = "R."
     surname         = "Quattlebaum"
     fullname        = "Robert S. Quattlebaum"
-    organization    = "Nest Labs"
+    organization    = "Nest Labs, Inc."
     
         [author.address]
         email       = "rquattle@nestlabs.com"
@@ -34,11 +34,11 @@
     initials        = "j.h."
     surname         = "woodyatt"
     fullname        = "james woodyatt"
-    organization    = "Google, Inc."
+    organization    = "Nest Labs, Inc."
     role            = "editor"
     
         [author.address]
-        email       = "jhw@google.com"
+        email       = "jhw@nestlabs.com"
         
         [author.address.postal]
         street      = "3400 Hillview Ave."
@@ -51,6 +51,16 @@
 .# Abstract
 
 This document specifies the basis of the Spinel protocol, which facilitates the control and management of IPv6 network interfaces in nodes where general purpose application processors offload network functions at their interfaces to network co-processors (NCP) connected by simple communication links like serial data channels. Spinel was initially designed for use with Thread network co-processors, but its basis is general purpose and intended to be easily adapted to other types of IPv6 network interface.
+
+.# Status of This Memo
+
+This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.
+
+.# Copyright Notice
+
+Copyright (c) 2017 IETF Trust and the persons identified as the document authors. All rights reserved.
+
+This document is subject to BCP 78 and the IETF Trust’s Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document. Please review these documents carefully, as they describe your rights and restrictions with respect to this document. Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.
 
 {mainmatter}
 
@@ -175,10 +185,6 @@ These types of properties generally do not support `VALUE_GET`, as it is meaning
 
 # Acknowledgments #
 
-Special thanks to Abtin Keshavarzian, Martin Turon, Arjuna Sivasithambaresan and Jonathan Hui for their substantial contributions and feedback related to this document.
-
-<!-- Editor
-  -- If we have missed anyone who has contributed to this document, please let the editor know ASAP.
-  -->
+Special thanks to Nick Banks, Jonathan Hui, Abtin Keshavarzian, Piotr Szkotak, Arjuna Sivasithambaresan and Martin Turon for their substantial contributions and feedback related to this document.
 
 This document was prepared using [mmark](https://github.com/miekg/mmark) by (Miek Gieben) and [xml2rfc (version 2)](http://xml2rfc.ietf.org/).

--- a/doc/spinel-protocol-src/draft-rquattle-spinel-unified.md.in
+++ b/doc/spinel-protocol-src/draft-rquattle-spinel-unified.md.in
@@ -1,24 +1,25 @@
 %%%
-    title       = "Spinel Host-Controller Protocol"
-    abbrev      = "Spinel Protocol (@SOURCE_VERSION@)"
-    category    = "info"
-    docName     = "draft-rquattle-spinel-unified-@SOURCE_VERSION@"
-    ipr         = "noDerivativesTrust200902"
-    keyword     = ["Spinel", "IPv6", "NCP"]
-    date        = @SOURCE_DATE@
+    title           = "Spinel Host-Controller Protocol"
+    abbrev          = "Spinel Protocol (@SOURCE_VERSION@)"
+    category        = "info"
+    docName         = "draft-rquattle-spinel-unified-@SOURCE_VERSION@"
+    ipr             = "noDerivativesTrust200902"
+    keyword         = ["Spinel", "IPv6", "NCP"]
+    date            = @SOURCE_DATE@
+    submissionType  = "independent"
     
     [pi]
-    editing     = "yes"
-    private     = "OpenThread"
-    compact     = "yes"
-    subcompact  = "yes"
-    comments    = "yes"
+    editing         = "yes"
+    private         = "OpenThread"
+    compact         = "yes"
+    subcompact      = "yes"
+    comments        = "yes"
     
     [[author]]
     initials        = "R."
     surname         = "Quattlebaum"
     fullname        = "Robert S. Quattlebaum"
-    organization    = "Nest Labs"
+    organization    = "Nest Labs, Inc."
     
         [author.address]
         email       = "rquattle@nestlabs.com"
@@ -31,14 +32,14 @@
         country     = "USA"
     
     [[author]]
+    role            = "editor"
     initials        = "j.h."
     surname         = "woodyatt"
     fullname        = "james woodyatt"
-    organization    = "Google, Inc."
-    role            = "editor"
+    organization    = "Nest Labs, Inc."
     
         [author.address]
-        email       = "jhw@google.com"
+        email       = "jhw@nestlabs.com"
         
         [author.address.postal]
         street      = "3400 Hillview Ave."
@@ -57,47 +58,27 @@ While initially designed to support Thread-based NCPs, the NCP protocol
 has been designed with a layered approach that allows it to be easily
 adapted to other network technologies in the future.
 
-.# Status of This Document
+.# Status of This Memo
 
-This document is a work in progress and subject to change.
+This Internet-Draft is submitted in full conformance with the provisions
+of BCP 78 and BCP 79.
+
+This document is not an Internet Standards Track specification; it is
+published for informational purposes.
+
+This document may not be modified, and derivative works of it may not be
+created, and it may not be published except as an Internet-Draft.
 
 .# Copyright Notice
 
-Copyright (c) 2016-2017, Nest Labs, Inc.
-All rights reserved.
+Copyright (c) 2017 IETF Trust and the persons identified as the document
+authors. All rights reserved.
 
-<!-- RQ
-  -- We may want to consider a license more appropriate for documentation.
-  -->
-
-<!-- jhw
-  -- I have set the IPR field in the preamble to 'noDerivativesTrust200902'
-     while we are not ready to give change control of Spinel to IETF.
-  -->
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-3. Neither the name of the copyright holder nor the
-   names of its contributors may be used to endorse or promote products
-   derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
+This document is subject to BCP 78 and the IETF Trust’s Legal Provisions
+Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect
+on the date of publication of this document. Please review these documents
+carefully, as they describe your rights and restrictions with respect to
+this document.
 
 {mainmatter}
 
@@ -360,14 +341,9 @@ is meaningless.
 
 # Acknowledgments #
 
-Special thanks to Abtin Keshavarzian, Martin Turon, Arjuna Sivasithambaresan
-and Jonathan Hui for their substantial contributions and feedback related
-to this document.
-
-<!-- RQ
-  -- If I have missed anyone who has contributed to this document,
-     please let me know ASAP.
-  -->
+Special thanks to Nick Banks, Jonathan Hui, Abtin Keshavarzian, Piotr
+Szkotak, Arjuna Sivasithambaresan and Martin Turon for their substantial
+contributions and feedback related to this document.
 
 This document was prepared using [mmark](https://github.com/miekg/mmark)
 by (Miek Gieben) and [xml2rfc (version 2)](http://xml2rfc.ietf.org/).


### PR DESCRIPTION
To prepare for submission of draft-rquattle-spinel-unified to IETF as an Internet
Draft, the Status of This Memo and Copyright Notice sections are updated to be in
full conformance with BCP 78, BCP 79 and the IETF Trust's Legal Provisions.