### PR TITLE
Use short address for src match table after rx of data poll with short addr

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1491,12 +1491,16 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, ThreadError aError)
                 child->SetIndirectFragmentOffset(0);
                 child->SetIndirectMessage(NULL);
 
-                // add short address for subsequent indirect messages after
-                // one indirect message to valid sleepy devices is sent out successfully
-                if (aError == kThreadError_None)
-                {
-                    mSourceMatchController.SetSrcMatchAsShort(*child, true);
-                }
+                // Enable short source address matching after the first indirect
+                // message transmission attempt to the child. We intentionally do
+                // not check for successful tx here to address the scenario where
+                // the child does receive "Child ID Response" but parent misses the
+                // 15.4 ack from child. If the "Child ID Response" does not make it
+                // to the child, then the child will need to send a new "Child ID
+                // Request" which will cause the parent to switch to using long
+                // address mode for source address matching.
+
+                mSourceMatchController.SetSrcMatchAsShort(*child, true);
             }
 
             childIndex = mNetif.GetMle().GetChildIndex(*child);

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -171,15 +171,6 @@ public:
     void UpdateIndirectMessages(void);
 
     /**
-     * This method sets whether or not to perform source matching on the extended or short address for Frame Pending determination.
-     *
-     * @param[in]  aChild       A reference to the child.
-     * @param[in]  aMatchShort  TRUE to match on short source address, FALSE otherwise.
-     *
-     */
-    void SetSrcMatchAsShort(Child &aChild, bool aMatchShort);
-
-    /**
      * This method returns a reference to the thread network interface instance.
      *
      * @ returns   A reference to the thread network interface instance.


### PR DESCRIPTION
This commit adds logic to start using short address for the source
address matching table when we receive a secure 802.15.4 data
request command (data poll) from the child using short address as
its source.

This change addresses the following (rare but sort of unrecoverable) scenario:
- MLE Child Id Response is sent to child, child does receive it but ack is not received by parent.
- Parent then does not consider the "Child id response" tx successful.
- In existing code, parent switches to using short address in src match table only after a successful indirect tx to child, so it keeps using long address for the child.
- We end up in state where parent can receive from child, but all tx to child fails.
- Child sends data poll with short address, parent acks with "pending" bit clear (since the child is src address match table with its long address), so the child goes to sleep after data poll.
- Parent handles data poll, tries to send queued to child (which is already sleep) and all tx fails.