### PR TITLE
Use `Child` methods in `SourceMatchController`

### DIFF
--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -347,8 +347,6 @@ private:
  */
 class Child : public Neighbor
 {
-    friend class SourceMatchController;
-
 public:
     enum
     {


### PR DESCRIPTION
This removes the need for `SourceMatchController` to be a friend
class of the `Child` to access its private member variables.