### PR TITLE
Explicitly set RLOC as source address

### DIFF
--- a/src/core/meshcop/border_agent_proxy.cpp
+++ b/src/core/meshcop/border_agent_proxy.cpp
@@ -148,6 +148,7 @@ ThreadError BorderAgentProxy::Send(Message &aMessage, uint16_t aLocator, uint16_
 
     VerifyOrExit(mStreamHandler != NULL, error = kThreadError_InvalidState);
 
+    messageInfo.SetSockAddr(mMeshLocal16);
     messageInfo.SetPeerAddr(mMeshLocal16);
     messageInfo.GetPeerAddr().mFields.m16[7] = HostSwap16(aLocator);
     messageInfo.SetPeerPort(aPort);


### PR DESCRIPTION
This is a quick fix of the issue that the CoAP client chooses the wrong source address when forwarding the packet from border agent.