### PR TITLE
Recalculate CRC16 when starting joining

### DIFF
--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -67,8 +67,6 @@ Joiner::Joiner(ThreadNetif &aNetif):
     mState(kStateIdle),
     mCallback(NULL),
     mContext(NULL),
-    mCcitt(Crc16::kCcitt),
-    mAnsi(Crc16::kAnsi),
     mJoinerRouterChannel(0),
     mJoinerRouterPanId(0),
     mJoinerUdpPort(0),
@@ -94,6 +92,8 @@ ThreadError Joiner::Start(const char *aPSKd, const char *aProvisioningUrl,
 {
     ThreadError error;
     Mac::ExtAddress extAddress;
+    Crc16 ccitt(Crc16::kCcitt);
+    Crc16 ansi(Crc16::kAnsi);
 
     otLogFuncEntry();
 
@@ -106,9 +106,12 @@ ThreadError Joiner::Start(const char *aPSKd, const char *aProvisioningUrl,
 
     for (size_t i = 0; i < sizeof(extAddress); i++)
     {
-        mCcitt.Update(extAddress.m8[i]);
-        mAnsi.Update(extAddress.m8[i]);
+        ccitt.Update(extAddress.m8[i]);
+        ansi.Update(extAddress.m8[i]);
     }
+
+    mCcitt = ccitt.Get();
+    mAnsi = ansi.Get();
 
     error = mNetif.GetSecureCoapClient().GetDtls().SetPsk(reinterpret_cast<const uint8_t *>(aPSKd),
                                                           static_cast<uint8_t>(strlen(aPSKd)));
@@ -191,8 +194,8 @@ void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
         memcpy(steeringData.GetValue(), aResult->mSteeringData.m8, steeringData.GetLength());
 
         if (steeringData.DoesAllowAny() ||
-            (steeringData.GetBit(mCcitt.Get() % steeringData.GetNumBits()) &&
-             steeringData.GetBit(mAnsi.Get() % steeringData.GetNumBits())))
+            (steeringData.GetBit(mCcitt % steeringData.GetNumBits()) &&
+             steeringData.GetBit(mAnsi % steeringData.GetNumBits())))
         {
             mJoinerUdpPort = aResult->mJoinerUdpPort;
             mJoinerRouterPanId = aResult->mPanId;

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -67,6 +67,8 @@ Joiner::Joiner(ThreadNetif &aNetif):
     mState(kStateIdle),
     mCallback(NULL),
     mContext(NULL),
+    mCcitt(0),
+    mAnsi(0),
     mJoinerRouterChannel(0),
     mJoinerRouterPanId(0),
     mJoinerUdpPort(0),

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -142,8 +142,8 @@ private:
     otJoinerCallback mCallback;
     void *mContext;
 
-    Crc16 mCcitt;
-    Crc16 mAnsi;
+    uint16_t mCcitt;
+    uint16_t mAnsi;
 
     uint8_t mJoinerRouterChannel;
     uint16_t mJoinerRouterPanId;


### PR DESCRIPTION
Currently joiner can only successfully join once without factory reset. This is caused by not re-initializing the CRC computers when a new start a joining attempt. This fixes this issue.