### PR TITLE
Add makefile to provide common build switches

### DIFF
--- a/examples/Makefile-cc2538
+++ b/examples/Makefile-cc2538
@@ -46,30 +46,12 @@ configure_OPTIONS               = \
     --enable-ncp-app=all          \
     --with-ncp-bus=uart           \
     --enable-diag                 \
-    --enable-default-logging      \
     --with-examples=cc2538        \
     --with-platform-info=CC2538   \
     $(NULL)
 
-ifeq ($(CERT_LOG),1)
-configure_OPTIONS              += --enable-cert-log
-endif
-
-ifeq ($(COMMISSIONER),1)
-configure_OPTIONS              += --enable-commissioner
-endif
-
-ifeq ($(JOINER),1)
-configure_OPTIONS              += --enable-joiner
-endif
-
-ifeq ($(DHCP6_SERVER),1)
-configure_OPTIONS              += --enable-dhcp6-server
-endif
-
-ifeq ($(DHCP6_CLIENT),1)
-configure_OPTIONS              += --enable-dhcp6-client
-endif
+DEFAULT_LOGGING ?= 1
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..
 AbsTopSourceDir                 := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))..

--- a/examples/Makefile-cc2650
+++ b/examples/Makefile-cc2650
@@ -50,11 +50,7 @@ configure_OPTIONS               = \
     MBEDTLS_CPPFLAGS="$(CC2650_MBEDTLS_CPPFLAGS)" \
     $(NULL)
 
-ifeq ($(DISABLE_DOC),1)
-configure_OPTIONS              += \
-    --disable-docs                \
-    $(NULL)
-endif
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 CC2650_MBEDTLS_CPPFLAGS  = -DMBEDTLS_CONFIG_FILE='\"cc2650-mbedtls-config.h\"'
 CC2650_MBEDTLS_CPPFLAGS += -I$(PWD)/examples/platforms/cc2650/crypto

--- a/examples/Makefile-da15000
+++ b/examples/Makefile-da15000
@@ -45,30 +45,12 @@ configure_OPTIONS               = \
     --enable-cli-app=all          \
     --enable-ncp-app=all          \
     --with-ncp-bus=uart           \
-    --enable-default-logging      \
     --with-examples=da15000       \
     --with-platform-info=DA15000  \
     $(NULL)
 
-ifeq ($(CERT_LOG),1)
-configure_OPTIONS              += --enable-cert-log
-endif
-
-ifeq ($(COMMISSIONER),1)
-configure_OPTIONS              += --enable-commissioner
-endif
-
-ifeq ($(JOINER),1)
-configure_OPTIONS              += --enable-joiner
-endif
-
-ifeq ($(DHCP6_SERVER),1)
-configure_OPTIONS              += --enable-dhcp6-server
-endif
-
-ifeq ($(DHCP6_CLIENT),1)
-configure_OPTIONS              += --enable-dhcp6-client
-endif
+DEFAULT_LOGGING ?= 1
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..
 AbsTopSourceDir                 := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))..

--- a/examples/Makefile-efr32
+++ b/examples/Makefile-efr32
@@ -46,39 +46,13 @@ configure_OPTIONS               = \
     --enable-ncp-app=all          \
     --with-ncp-bus=uart           \
     --enable-diag                 \
-    --enable-default-logging      \
     --with-examples=efr32         \
     --with-platform-info=EFR32    \
     MBEDTLS_CPPFLAGS="$(EFR32_MBEDTLS_CPPFLAGS)" \
     $(NULL)
 
-ifeq ($(CERT_LOG),1)
-configure_OPTIONS              += --enable-cert-log
-endif
-
-ifeq ($(COMMISSIONER),1)
-configure_OPTIONS              += --enable-commissioner
-endif
-
-ifeq ($(JOINER),1)
-configure_OPTIONS              += --enable-joiner
-endif
-
-ifeq ($(DHCP6_SERVER),1)
-configure_OPTIONS              += --enable-dhcp6-server
-endif
-
-ifeq ($(DHCP6_CLIENT),1)
-configure_OPTIONS              += --enable-dhcp6-client
-endif
-
-ifeq ($(JAM_DETECTION),1)
-configure_OPTIONS              += --enable-jam-detection
-endif
-
-ifeq ($(DNS_CLIENT),1)
-configure_OPTIONS              += --enable-dns-client
-endif
+DEFAULT_LOGGING ?= 1
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..
 AbsTopSourceDir                 := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))..

--- a/examples/Makefile-nrf52840
+++ b/examples/Makefile-nrf52840
@@ -51,61 +51,7 @@ configure_OPTIONS                                 = \
     MBEDTLS_CPPFLAGS="$(NRF52840_MBEDTLS_CPPFLAGS)" \
     $(NULL)
 
-ifeq ($(DEFAULT_LOGGING),1)
-configure_OPTIONS              += --enable-default-logging
-endif
-
-ifeq ($(CERT_LOG),1)
-configure_OPTIONS              += --enable-cert-log
-endif
-
-ifeq ($(COMMISSIONER),1)
-configure_OPTIONS              += --enable-commissioner
-endif
-
-ifeq ($(JOINER),1)
-configure_OPTIONS              += --enable-joiner
-endif
-
-ifeq ($(JAM_DETECTION),1)
-configure_OPTIONS              += --enable-jam-detection
-endif
-
-ifeq ($(MAC_WHITELIST),1)
-configure_OPTIONS              += --enable-mac-whitelist
-endif
-
-ifeq ($(COAP),1)
-configure_OPTIONS              += --enable-application-coap
-endif
-
-ifeq ($(LEGACY),1)
-configure_OPTIONS              += --enable-legacy
-endif
-
-ifeq ($(DHCP6_SERVER),1)
-configure_OPTIONS              += --enable-dhcp6-server
-endif
-
-ifeq ($(DHCP6_CLIENT),1)
-configure_OPTIONS              += --enable-dhcp6-client
-endif
-
-ifeq ($(DNS_CLIENT),1)
-configure_OPTIONS              += --enable-dns-client
-endif
-
-ifeq ($(COVERAGE),1)
-configure_OPTIONS              += --enable-coverage --enable-commissioner --enable-joiner --enable-dhcp6-client --enable-dhcp6-server --enable-dns-client
-endif
-
-ifeq ($(DEBUG),1)
-configure_OPTIONS              += --enable-debug --enable-optimization=no
-endif
-
-ifeq ($(DISABLE_DOC),1)
-configure_OPTIONS              += --disable-docs
-endif
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 ifdef SRC_PATH
 configure_OPTIONS              += --srcdir="$(SRC_PATH)"

--- a/examples/Makefile-posix
+++ b/examples/Makefile-posix
@@ -104,21 +104,6 @@ configure_OPTIONS                   = \
     --enable-mtd-network-diagnostic   \
     $(NULL)
 
-ifeq ($(COVERAGE),1)
-configure_OPTIONS              += --enable-coverage
-else
-configure_OPTIONS              +=
-endif
-
-# If the user has asserted DEBUG, alter the configuration options
-# accordingly.
-
-ifeq ($(DEBUG),1)
-configure_OPTIONS              += --enable-debug --enable-optimization=no
-else
-configure_OPTIONS              +=
-endif
-
 ifndef BuildJobs
 BuildJobs := $(shell getconf _NPROCESSORS_ONLN)
 endif

--- a/examples/common-switches.mk
+++ b/examples/common-switches.mk
@@ -1,0 +1,87 @@
+#
+#  Copyright (c) 2016, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+ifeq ($(BA_PROXY),1)
+configure_OPTIONS              += --enable-border-agent-proxy
+endif
+
+ifeq ($(CERT_LOG),1)
+configure_OPTIONS              += --enable-cert-log
+endif
+
+ifeq ($(COMMISSIONER),1)
+configure_OPTIONS              += --enable-commissioner
+endif
+
+ifeq ($(COVERAGE),1)
+configure_OPTIONS              += --enable-coverage
+endif
+
+ifeq ($(DEBUG),1)
+configure_OPTIONS              += --enable-debug --enable-optimization=no
+endif
+
+ifeq ($(DHCP6_CLIENT),1)
+configure_OPTIONS              += --enable-dhcp6-client
+endif
+
+ifeq ($(DHCP6_SERVER),1)
+configure_OPTIONS              += --enable-dhcp6-server
+endif
+
+ifeq ($(DEFAULT_LOGGING),1)
+configure_OPTIONS              += --enable-default-logging
+endif
+
+ifeq ($(DISABLE_DOC),1)
+configure_OPTIONS              += --disable-docs
+endif
+
+ifeq ($(DNS_CLIENT),1)
+configure_OPTIONS              += --enable-dns-client
+endif
+
+ifeq ($(JAM_DETECTION),1)
+configure_OPTIONS              += --enable-jam-detection
+endif
+
+ifeq ($(JOINER),1)
+configure_OPTIONS              += --enable-joiner
+endif
+
+ifeq ($(LEGACY),1)
+configure_OPTIONS              += --enable-legacy
+endif
+
+ifeq ($(MAC_WHITELIST),1)
+configure_OPTIONS              += --enable-mac-whitelist
+endif
+
+ifeq ($(COAP),1)
+configure_OPTIONS              += --enable-application-coap
+endif


### PR DESCRIPTION
This PR creates a common makefile to provide common building switches. Each platform can set the default switch value. For example, to enable DEFAULT_LOGGING by default, add the following line before the `include` directive.
```
DEFAULT_LOGGING ?= 1
```

This PR aimed at not changing the current default configuration for each platform. If anything changed unwanted, please give comments.