### PR TITLE
Ensure to set Extended Address's local bit

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -154,13 +154,7 @@ Mac::Mac(ThreadNetif &aThreadNetif):
     mTxFrame(static_cast<Frame *>(otPlatRadioGetTransmitBuffer(aThreadNetif.GetInstance()))),
     mKeyIdMode2FrameCounter(0)
 {
-    for (size_t i = 0; i < sizeof(mExtAddress); i++)
-    {
-        mExtAddress.m8[i] = static_cast<uint8_t>(otPlatRandomGet());
-    }
-
-    mExtAddress.SetGroup(false);
-    mExtAddress.SetLocal(true);
+    GenerateExtAddress(&mExtAddress);
 
     ClearNoiseFloorAverage(mNoiseFloor);
 
@@ -432,6 +426,17 @@ void Mac::SetRxOnWhenIdle(bool aRxOnWhenIdle)
     {
         NextOperation();
     }
+}
+
+void Mac::GenerateExtAddress(ExtAddress *aExtAddress)
+{
+    for (size_t i = 0; i < sizeof(ExtAddress); i++)
+    {
+        aExtAddress->m8[i] = static_cast<uint8_t>(otPlatRandomGet());
+    }
+
+    aExtAddress->SetGroup(false);
+    aExtAddress->SetLocal(true);
 }
 
 void Mac::SetExtAddress(const ExtAddress &aExtAddress)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -349,6 +349,14 @@ public:
     ThreadError SendFrameRequest(Sender &aSender);
 
     /**
+     * This method generates a random IEEE 802.15.4 Extended Address.
+     *
+     * @param[out]  aExtAddress  A pointer to where the generated Extended Address is placed.
+     *
+     */
+    void GenerateExtAddress(ExtAddress *aExtAddress);
+
+    /**
      * This method returns a pointer to the IEEE 802.15.4 Extended Address.
      *
      * @returns A pointer to the IEEE 802.15.4 Extended Address.

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -503,11 +503,7 @@ void Joiner::HandleTimer(void)
     case kStateJoined:
         Mac::ExtAddress extAddress;
 
-        for (size_t i = 0; i < sizeof(extAddress); i++)
-        {
-            extAddress.m8[i] = static_cast<uint8_t>(otPlatRandomGet());
-        }
-
+        mNetif.GetMac().GenerateExtAddress(&extAddress);
         mNetif.GetMac().SetExtAddress(extAddress);
         mNetif.GetMle().UpdateLinkLocalAddress();
 


### PR DESCRIPTION
As described in Spec section 3.2, Table 3-2 7.4.1:

> If the 64-bit value resulting after either SHA-256 computation or random generation has the second least significant bit of octet 0 (also called U/L or X bit in IEEE EUI-64 terminology) set to 0, the value provided to the MAC sub-layer as the aExtendedAddress SHALL be modified to have the respective bit set to 1 in order to adhere to a locally administered EUI-64 format.

This PR:
* Create a new `GenerateExtAddress()` method;
* Fix the issue that the extended address U/L bit may not be set, which is generated after join success.
