### PR TITLE
cosmetic update wrap_stdbool.h

### DIFF
--- a/src/core/utils/wrap_stdbool.h
+++ b/src/core/utils/wrap_stdbool.h
@@ -44,7 +44,7 @@
 /* c++ has a built in bool */
 #else
 
-#if defined(_MSC_VER)
+#if HAVE__BOOL
 #define bool _Bool
 #else
 typedef _Bool bool;


### PR DESCRIPTION
I think it's more correct to use the "HAVE__BOOL" to check for the existence of _Bool or not, since this is the variable which is created by the automake tools for exactly that purpose. The comment in openthread-config.h is:
/* Define to 1 if the system has the type `_Bool'. */
#define HAVE__BOOL 1
