### PR TITLE
CoAP: Send requests using application coap

### DIFF
--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -135,7 +135,7 @@ otMessage *otCoapNewMessage(otInstance *aInstance, const otCoapHeader *aHeader)
 {
     Message *message;
     VerifyOrExit(aHeader != NULL, message = NULL);
-    message = aInstance->mThreadNetif.GetCoap().NewMessage(*(static_cast<const Coap::Header *>(aHeader)));
+    message = aInstance->mApplicationCoap.NewMessage(*(static_cast<const Coap::Header *>(aHeader)));
 exit:
     return message;
 }
@@ -143,7 +143,7 @@ exit:
 ThreadError otCoapSendRequest(otInstance *aInstance, otMessage *aMessage, const otMessageInfo *aMessageInfo,
                               otCoapResponseHandler aHandler, void *aContext)
 {
-    return aInstance->mThreadNetif.GetCoap().SendMessage(
+    return aInstance->mApplicationCoap.SendMessage(
                *static_cast<Message *>(aMessage),
                *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
                aHandler, aContext);


### PR DESCRIPTION
Temporary workaround for #1662.

I did not add mPort variable to Coap::Client as there is in Coap::Server, therefore if the client is stopped and re-started the port is reset. Do you want me to add mPort, so that the client would act more like the server and not autoreset the port?