### PR TITLE
CoAP: Enable response handler for response messages

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -181,7 +181,7 @@ ThreadError Coap::SendMessage(Message &aMessage, const Ip6::MessageInfo &aMessag
         // Create a copy of entire message and enqueue it.
         copyLength = aMessage.GetLength();
     }
-    else if (header.IsNonConfirmable() && header.IsRequest() && (aHandler != NULL))
+    else if (header.IsNonConfirmable() && (aHandler != NULL))
     {
         // As we do not retransmit non confirmable messages, create a copy of header only, for token information.
         copyLength = header.GetLength();
@@ -458,7 +458,9 @@ Message *Coap::FindRelatedRequest(const Header &aResponseHeader, const Ip6::Mess
              aCoapMetadata.mDestinationAddress.IsAnycastRoutingLocator()) &&
             (aCoapMetadata.mDestinationPort == aMessageInfo.GetPeerPort()))
         {
-            assert(aRequestHeader.FromMessage(*message, sizeof(CoapMetadata)) == kThreadError_None);
+            // FromMessage can return kThreadError_Parse if only partial message was stored (header only),
+            // but payload marker is present. Assume, that stored messages are always valid.
+            aRequestHeader.FromMessage(*message, sizeof(CoapMetadata));
 
             switch (aResponseHeader.GetType())
             {


### PR DESCRIPTION
More info in #1662.

Current commit is the workaround I use locally. It's most likely an incomplete solution as it does not return kThreadError_None when sending responses. Only kThreadError_Timeout or _Abort, but in my scenario _Abort is enough to distinguish a Reset message to an Observe notification.

The way I think it should work:

| Message Type |  Success condition | Error conditions  |
| ---------------- |:--------------------:| :------------------:|
| CON Request   | Response              | RST, Timeout       |
| NON Request  | Response               | RST, Timeout      |
| CON Response | ACK                       | RST, Timeout      |
| NON Response | Timeout                | RST                     |

What do you think?