### PR TITLE
`NcpSpi`: Enable full duplex SPI exchange.

### DIFF
--- a/examples/platforms/posix/spi-stubs.c
+++ b/examples/platforms/posix/spi-stubs.c
@@ -52,7 +52,7 @@ void otPlatSpiSlaveDisable(void)
 }
 
 otError otPlatSpiSlavePrepareTransaction(uint8_t *aOutputBuf, uint16_t aOutputBufLen, uint8_t *aInputBuf,
-                                             uint16_t aInputBufLen, bool aRequestTransactionFlag)
+                                         uint16_t aInputBufLen, bool aRequestTransactionFlag)
 {
     (void)aOutputBuf;
     (void)aOutputBufLen;

--- a/include/openthread/platform/spi-slave.h
+++ b/include/openthread/platform/spi-slave.h
@@ -61,7 +61,7 @@ extern "C" {
  * transaction to be valid.
  *
  * Note that this function is always called at the end of a transaction, even if `otPlatSpiSlavePrepareTransaction()`
- *  has not yet been called. In such cases, `aOutputBufLen` and `aInputBufLen` will be zero.
+ * has not yet been called. In such cases, `aOutputBufLen` and `aInputBufLen` will be zero.
  *
  * @param[in] aContext           Context pointer passed into `otPlatSpiSlaveEnable()`.
  * @param[in] aOutputBuf         Value of `aOutputBuf` from last call to `otPlatSpiSlavePrepareTransaction()`.
@@ -117,9 +117,14 @@ void otPlatSpiSlaveDisable(void);
  * ignored until the SPI master finishes the transaction.
  *
  * Note that even if `aInputBufLen` or `aOutputBufLen` (or both) are exhausted before the SPI master finishes a
-* transaction, the ongoing size of the transaction must still be kept track of to be passed to the transaction complete
-* callback. For example, if `aInputBufLen` is equal to 10 and `aOutputBufLen` equal to 20 and the SPI master clocks out
-* 30 bytes, the value 30 is passed to the transaction complete callback.
+ * transaction, the ongoing size of the transaction must still be kept track of to be passed to the transaction
+ * complete callback. For example, if `aInputBufLen` is equal to 10 and `aOutputBufLen` equal to 20 and the SPI master
+ * clocks out 30 bytes, the value 30 is passed to the transaction complete callback.
+ *
+ * If a `NULL` pointer is passed in as `aOutputBuf` or `aInputBuf` it means that that buffer pointer should not change
+ * from its previous/current value. In this case, the corresponding length argument should  be ignored. For example,
+ * `otPlatSpiSlavePrepareTransaction(NULL, 0, aInputBuf, aInputLen, false)` changes the input buffer pointer and its
+ * length but keeps the output buffer pointer same as before.
  *
  * Any call to this function while a transaction is in progress will cause all of the arguments to be ignored and the
  * return value to be `OT_ERROR_BUSY`.

--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -45,35 +45,37 @@ namespace ot {
 
 class NcpSpi : public NcpBase
 {
-    typedef NcpBase super_t;
-
 public:
     /**
-     * Constructor
+     * This constructor initializes the object.
      *
-     * @param[in]  aInstance  The OpenThread instance structure.
+     * @param[in]  aInstance  A pointer to the OpenThread instance structure.
      *
      */
     NcpSpi(otInstance *aInstance);
 
-    void ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength);
-
 private:
     enum
     {
-        kSpiBufferSize   = OPENTHREAD_CONFIG_NCP_SPI_BUFFER_SIZE, // Spi buffer size (should be large enough to fit a
-                                                                  // max length frame + spi header).
-        kSpiHeaderLength = 5,                                     // Size of spi header.
+        /**
+         * SPI tx and rx buffer size (should fit a max length frame + SPI header).
+         *
+         */
+        kSpiBufferSize   = OPENTHREAD_CONFIG_NCP_SPI_BUFFER_SIZE,
+
+        /**
+         * Size of SPI header in bytes.
+         *
+         */
+        kSpiHeaderLength = 5,
     };
 
     enum TxState
     {
-        kTxStateIdle,                      // No frame to send
-        kTxStateSending,                   // A frame is ready to be sent
-        kTxStateHandlingSendDone           // The frame was sent successfully, waiting to prepare the next one (if any)
+        kTxStateIdle,               // No frame to send.
+        kTxStateSending,            // A frame is ready to be sent.
+        kTxStateHandlingSendDone    // The frame was sent successfully, waiting to prepare the next one (if any).
     };
-
-    uint16_t OutboundFrameSize(void);
 
     static void SpiTransactionComplete(void *context, uint8_t *aOutputBuf, uint16_t aOutputBufLen, uint8_t *aInputBuf,
                                        uint16_t aInputBufLen, uint16_t aTransactionLength);
@@ -87,21 +89,22 @@ private:
     void PrepareTxFrame(void);
 
     static void TxFrameBufferHasData(void *aContext, NcpFrameBuffer *aNcpFrameBuffer);
-    void TxFrameBufferHasData(void);
 
     otError PrepareNextSpiSendFrame(void);
 
-    TxState mTxState;
-    bool mHandlingRxFrame;
+    volatile TxState mTxState;
+    volatile bool mHandlingRxFrame;
+    volatile bool mResetFlag;
 
     Tasklet mHandleRxFrameTask;
     Tasklet mPrepareTxFrameTask;
 
-    uint8_t mSendFrame[kSpiBufferSize];
     uint16_t mSendFrameLen;
+    uint8_t mSendFrame[kSpiBufferSize];
     uint8_t mReceiveFrame[kSpiBufferSize];
 
-    uint8_t mEmptySendFrame[kSpiHeaderLength];
+    uint8_t mEmptySendFrameZeroAccept[kSpiHeaderLength];
+    uint8_t mEmptySendFrameFullAccept[kSpiHeaderLength];
     uint8_t mEmptyReceiveFrame[kSpiHeaderLength];
 };
 


### PR DESCRIPTION
This commit implements support for full duplex SPI exchange in
`NcpSpi`. To realize this a slight modification is made to behavior of
`otPlatSpiSlavePrepareTransaction()` under `spi-slave.h` to allow a
`NULL` pointer to be passed in as either `aOutputBuf` or `aInputBuf`
input arguments and for it to mean that that buffer pointer should not
change from its previous/current value. This allows output buffer to
be changed safely from a tasklet when there is new outbound frame without
changing the input buffer pointers.