### PR TITLE
Apply `#include` code style.

### DIFF
--- a/examples/apps/cli/main.c
+++ b/examples/apps/cli/main.c
@@ -32,13 +32,12 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/openthread.h"
-#include "openthread/cli.h"
-#include "openthread/diag.h"
-#include "openthread/platform/platform.h"
-
-#include <openthread-core-config.h>
 #include <assert.h>
+
+#include <openthread/cli.h>
+#include <openthread/diag.h>
+#include <openthread/openthread.h>
+#include <openthread/platform/platform.h>
 
 #ifdef OPENTHREAD_MULTIPLE_INSTANCE
 void *otPlatCAlloc(size_t aNum, size_t aSize)

--- a/examples/apps/ncp/main.c
+++ b/examples/apps/ncp/main.c
@@ -32,13 +32,12 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/openthread.h"
-#include "openthread/diag.h"
-#include "openthread/ncp.h"
-#include "openthread/platform/platform.h"
+#include <assert.h>
 
-#include <openthread-core-config.h>
-#include <common/debug.hpp>
+#include <openthread/diag.h>
+#include <openthread/ncp.h>
+#include <openthread/openthread.h>
+#include <openthread/platform/platform.h>
 
 #ifdef OPENTHREAD_MULTIPLE_INSTANCE
 void *otPlatCAlloc(size_t aNum, size_t aSize)

--- a/examples/platforms/cc2538/alarm.c
+++ b/examples/platforms/cc2538/alarm.c
@@ -36,10 +36,11 @@
 #include <stdint.h>
 
 #include <openthread-config.h>
-#include "openthread/openthread.h"
-#include "openthread/platform/platform.h"
-#include "openthread/platform/alarm.h"
-#include "openthread/platform/diag.h"
+#include <openthread/openthread.h>
+#include <openthread/platform/alarm.h>
+#include <openthread/platform/diag.h>
+#include <openthread/platform/platform.h>
+
 #include "platform-cc2538.h"
 
 enum

--- a/examples/platforms/cc2538/diag.c
+++ b/examples/platforms/cc2538/diag.c
@@ -32,10 +32,10 @@
 #include <sys/time.h>
 
 #include <openthread-config.h>
-#include "openthread/openthread.h"
+#include <openthread/openthread.h>
+#include <openthread/platform/alarm.h>
+#include <openthread/platform/radio.h>
 
-#include "openthread/platform/alarm.h"
-#include "openthread/platform/radio.h"
 #include "platform-cc2538.h"
 
 /**

--- a/examples/platforms/cc2538/flash.c
+++ b/examples/platforms/cc2538/flash.c
@@ -26,18 +26,18 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <fcntl.h>
 
 #include <openthread-config.h>
-#include "openthread/platform/alarm.h"
-#include <utils/flash.h>
+#include <openthread/platform/alarm.h>
 
-#include <utils/code_utils.h>
 #include "platform-cc2538.h"
 #include "rom-utility.h"
+#include "utils/code_utils.h"
+#include "utils/flash.h"
 
 #define FLASH_CTRL_FCTL_BUSY   0x00000080
 

--- a/examples/platforms/cc2538/misc.c
+++ b/examples/platforms/cc2538/misc.c
@@ -26,8 +26,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "openthread/types.h"
-#include "openthread/platform/misc.h"
+#include <openthread/types.h>
+#include <openthread/platform/misc.h>
+
 #include "platform-cc2538.h"
 
 void otPlatReset(otInstance *aInstance)

--- a/examples/platforms/cc2538/platform-cc2538.h
+++ b/examples/platforms/cc2538/platform-cc2538.h
@@ -37,7 +37,7 @@
 
 #include <stdint.h>
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #include "cc2538-reg.h"
 

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -33,15 +33,14 @@
  */
 
 #include <openthread-config.h>
+#include <openthread/openthread.h>
+#include <openthread/platform/diag.h>
+#include <openthread/platform/platform.h>
+#include <openthread/platform/radio.h>
 
-#include "openthread/openthread.h"
-#include "openthread/platform/platform.h"
-#include "openthread/platform/radio.h"
-#include "openthread/platform/diag.h"
-
-#include <utils/code_utils.h>
-#include <common/logging.hpp>
 #include "platform-cc2538.h"
+#include "common/logging.hpp"
+#include "utils/code_utils.h"
 
 enum
 {

--- a/examples/platforms/cc2538/random.c
+++ b/examples/platforms/cc2538/random.c
@@ -32,12 +32,12 @@
  *
  */
 
-#include "openthread/types.h"
-#include "openthread/platform/radio.h"
-#include "openthread/platform/random.h"
+#include <openthread/types.h>
+#include <openthread/platform/radio.h>
+#include <openthread/platform/random.h>
 
-#include <utils/code_utils.h>
 #include "platform-cc2538.h"
+#include "utils/code_utils.h"
 
 static void generateRandom(uint8_t *aOutput, uint16_t aOutputLength)
 {

--- a/examples/platforms/cc2538/uart.c
+++ b/examples/platforms/cc2538/uart.c
@@ -34,11 +34,11 @@
 
 #include <stddef.h>
 
-#include "openthread/types.h"
-#include "openthread/platform/uart.h"
+#include <openthread/types.h>
+#include <openthread/platform/uart.h>
 
-#include <utils/code_utils.h>
 #include "platform-cc2538.h"
+#include "utils/code_utils.h"
 
 enum
 {

--- a/examples/platforms/da15000/alarm.c
+++ b/examples/platforms/da15000/alarm.c
@@ -39,7 +39,9 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include "openthread/platform/alarm.h"
+
+#include <openthread/platform/alarm.h>
+
 #include "hw_timer0.h"
 #include "hw_gpio.h"
 #include "platform-da15000.h"

--- a/examples/platforms/da15000/flash.c
+++ b/examples/platforms/da15000/flash.c
@@ -26,12 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "openthread/types.h"
-#include "openthread/platform/alarm.h"
+#include <openthread-config.h>
+#include <openthread/types.h>
+#include <openthread/platform/alarm.h>
 
 #include "hw_qspi.h"
 #include "qspi_automode.h"
-#include "openthread-config.h"
 
 #define FLASH_SECTOR_SIZE             0x1000
 #define FLASH_BUFFER_SIZE             0x2000

--- a/examples/platforms/da15000/logging.c
+++ b/examples/platforms/da15000/logging.c
@@ -31,7 +31,7 @@
 * Platform abstraction for the logging
 *
 */
-#include "openthread/platform/logging.h"
+#include <openthread/platform/logging.h>
 
 void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
 {

--- a/examples/platforms/da15000/misc.c
+++ b/examples/platforms/da15000/misc.c
@@ -26,9 +26,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include "openthread/platform/misc.h"
+#include <openthread/platform/misc.h>
+
 #include "sdk_defs.h"
 
 void otPlatReset(otInstance *aInstance)

--- a/examples/platforms/da15000/platform-da15000.h
+++ b/examples/platforms/da15000/platform-da15000.h
@@ -29,7 +29,7 @@
 #ifndef PLATFORM_DA15000_H_
 #define PLATFORM_DA15000_H_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 /**
  * This function initializes the radio service used by OpenThread.

--- a/examples/platforms/da15000/platform.c
+++ b/examples/platforms/da15000/platform.c
@@ -34,15 +34,17 @@
 #include <assert.h>
 #include <stdint.h>
 
-#include "openthread/openthread.h"
-#include "openthread/platform/alarm.h"
-#include "openthread/platform/uart.h"
+#include <openthread/openthread.h>
+#include <openthread/platform/alarm.h>
+#include <openthread/platform/uart.h>
+
 #include "platform-da15000.h"
+
 #include "sdk_defs.h"
-#include "hw_cpm.h"
-#include "hw_watchdog.h"
 #include "ftdf.h"
+#include "hw_cpm.h"
 #include "hw_gpio.h"
+#include "hw_watchdog.h"
 
 static bool sBlink = false;
 static int  sMsCounterInit;

--- a/examples/platforms/da15000/radio.c
+++ b/examples/platforms/da15000/radio.c
@@ -31,17 +31,19 @@
 * Platform abstraction for radio communication.
 */
 
-#include <utils/code_utils.h>
-#include "openthread/openthread.h"
-#include "openthread/platform/alarm.h"
-#include "openthread/platform/radio.h"
+#include <openthread/openthread.h>
+#include <openthread/platform/alarm.h>
+#include <openthread/platform/radio.h>
+
+#include "utils/code_utils.h"
+
 #include "platform-da15000.h"
 
-#include <ad_ftdf.h>
-#include <ad_ftdf_phy_api.h>
-#include <hw_rf.h>
-#include <internal.h>
-#include <regmap.h>
+#include "ad_ftdf.h"
+#include "ad_ftdf_phy_api.h"
+#include "hw_rf.h"
+#include "internal.h"
+#include "regmap.h"
 
 #define FACTORY_TEST_TIMESTAMP      (0x7F8EA08) // Register holds a timestamp of facotry test of a chip
 #define FACTORY_TESTER_ID           (0x7F8EA0C) // Register holds test machine ID used for factory test

--- a/examples/platforms/da15000/random.c
+++ b/examples/platforms/da15000/random.c
@@ -34,13 +34,13 @@
  *   This implementation is not a true random number generator and does @em satisfy the Thread requirements.
  */
 
-#include "openthread/platform/random.h"
-#include "platform-da15000.h"
-#include "sdk_defs.h"
-#include "hw_trng.h"
 #include <string.h>
 
+#include <openthread/platform/random.h>
 
+#include "platform-da15000.h"
+#include "hw_trng.h"
+#include "sdk_defs.h"
 
 #define HW_TRNG_RAM             (0x40040000)
 

--- a/examples/platforms/da15000/uart.c
+++ b/examples/platforms/da15000/uart.c
@@ -36,12 +36,13 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <hw_uart.h>
 
-#include "openthread/platform/uart.h"
+#include <openthread/platform/uart.h>
 
-#include <common/code_utils.hpp>
+#include "common/code_utils.hpp"
+
 #include "hw_gpio.h"
+#include "hw_uart.h"
 #include "platform-da15000.h"
 
 static int sInFd;

--- a/examples/platforms/efr32/alarm.c
+++ b/examples/platforms/efr32/alarm.c
@@ -36,10 +36,11 @@
 #include <stdint.h>
 
 #include <openthread-config.h>
-#include <utils/code_utils.h>
-#include <openthread/platform/platform.h>
 #include <openthread/platform/alarm.h>
 #include <openthread/platform/diag.h>
+#include <openthread/platform/platform.h>
+
+#include "utils/code_utils.h"
 
 #include "rail.h"
 

--- a/examples/platforms/efr32/diag.c
+++ b/examples/platforms/efr32/diag.c
@@ -40,6 +40,7 @@
 #include <openthread-config.h>
 #include <openthread/platform/alarm.h>
 #include <openthread/platform/radio.h>
+
 #include "platform-efr32.h"
 
 /**

--- a/examples/platforms/efr32/flash.c
+++ b/examples/platforms/efr32/flash.c
@@ -33,8 +33,9 @@
 
 #include <openthread-config.h>
 #include <openthread/platform/alarm.h>
-#include <utils/flash.h>
-#include <utils/code_utils.h>
+
+#include "utils/code_utils.h"
+#include "utils/flash.h"
 
 #include "em_msc.h"
 

--- a/examples/platforms/efr32/logging.c
+++ b/examples/platforms/efr32/logging.c
@@ -38,19 +38,10 @@
 #include <openthread-config.h>
 #endif
 
-
+#include <openthread/cli.h>
 #include <openthread/platform/logging.h>
-#if OPENTHREAD_ENABLE_CLI_LOGGING
-#include <ctype.h>
-#include <inttypes.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdint.h>
-#include <string.h>
 
-#include <utils/code_utils.h>
-#include <cli.h>
-#endif
+#include "utils/code_utils.h"
 
 void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
 {

--- a/examples/platforms/efr32/platform.c
+++ b/examples/platforms/efr32/platform.c
@@ -35,7 +35,8 @@
 #include <string.h>
 
 #include <openthread/platform/uart.h>
-#include <common/logging.hpp>
+
+#include "common/logging.hpp"
 
 #include "pa.h"
 #include "pti.h"

--- a/examples/platforms/efr32/radio.c
+++ b/examples/platforms/efr32/radio.c
@@ -33,14 +33,15 @@
  */
 
 #include <assert.h>
+
 #include <openthread/types.h>
 #include <openthread-config.h>
-
-#include <common/logging.hpp>
-#include <utils/code_utils.h>
 #include <openthread/platform/platform.h>
 #include <openthread/platform/radio.h>
 #include <openthread/platform/diag.h>
+
+#include "common/logging.hpp"
+#include "utils/code_utils.h"
 
 #include "em_core.h"
 #include "em_system.h"

--- a/examples/platforms/efr32/random.c
+++ b/examples/platforms/efr32/random.c
@@ -32,9 +32,10 @@
  *
  */
 
-#include <utils/code_utils.h>
 #include <openthread/types.h>
 #include <openthread/platform/random.h>
+
+#include "utils/code_utils.h"
 
 #include "em_adc.h"
 #include "em_cmu.h"

--- a/examples/platforms/efr32/uart.c
+++ b/examples/platforms/efr32/uart.c
@@ -34,9 +34,10 @@
 
 #include <stddef.h>
 
-#include <utils/code_utils.h>
 #include <openthread/types.h>
 #include <openthread/platform/uart.h>
+
+#include "utils/code_utils.h"
 
 #include "bspconfig.h"
 #include "em_cmu.h"

--- a/examples/platforms/posix/alarm.c
+++ b/examples/platforms/posix/alarm.c
@@ -32,8 +32,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "openthread/platform/alarm.h"
-#include "openthread/platform/diag.h"
+#include <openthread/platform/alarm.h>
+#include <openthread/platform/diag.h>
 
 static bool s_is_running = false;
 static uint32_t s_alarm = 0;

--- a/examples/platforms/posix/diag.c
+++ b/examples/platforms/posix/diag.c
@@ -34,10 +34,9 @@
 #include <sys/time.h>
 
 #include <openthread-config.h>
-#include "openthread/openthread.h"
-
-#include "openthread/platform/alarm.h"
-#include "openthread/platform/radio.h"
+#include <openthread/openthread.h>
+#include <openthread/platform/alarm.h>
+#include <openthread/platform/radio.h>
 
 /**
  * Diagnostics mode variables.

--- a/examples/platforms/posix/flash.c
+++ b/examples/platforms/posix/flash.c
@@ -28,16 +28,17 @@
 
 #include "platform-posix.h"
 
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <sys/stat.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include <openthread-config.h>
-#include <utils/flash.h>
-#include <utils/code_utils.h>
+
+#include "utils/code_utils.h"
+#include "utils/flash.h"
 
 static int sFlashFd;
 uint32_t sEraseAddress;
@@ -82,7 +83,8 @@ ThreadError utilsFlashInit(void)
     {
         for (uint16_t index = 0; index < FLASH_PAGE_NUM; index++)
         {
-            SuccessOrExit(error = utilsFlashErasePage(index * FLASH_PAGE_SIZE));
+            error = utilsFlashErasePage(index * FLASH_PAGE_SIZE);
+            otEXPECT(error == kThreadError_None);
         }
     }
 
@@ -113,7 +115,7 @@ ThreadError utilsFlashErasePage(uint32_t aAddress)
     // Write the page
     ssize_t r;
     r =  pwrite(sFlashFd, &(dummyPage[0]), FLASH_PAGE_SIZE, address);
-    VerifyOrExit(((int)r) == ((int)(FLASH_PAGE_SIZE)), error = kThreadError_Failed);
+    otEXPECT_ACTION(((int)r) == ((int)(FLASH_PAGE_SIZE)), error = kThreadError_Failed);
 
 
 exit:

--- a/examples/platforms/posix/logging.c
+++ b/examples/platforms/posix/logging.c
@@ -39,7 +39,8 @@
 #include <syslog.h>
 #endif
 
-#include "openthread/platform/logging.h"
+#include <openthread/platform/logging.h>
+
 #include "utils/code_utils.h"
 
 // Macro to append content to end of the log string.

--- a/examples/platforms/posix/misc.c
+++ b/examples/platforms/posix/misc.c
@@ -28,8 +28,8 @@
 
 #include "platform-posix.h"
 
-#include "openthread/types.h"
-#include "openthread/platform/misc.h"
+#include <openthread/types.h>
+#include <openthread/platform/misc.h>
 
 void otPlatReset(otInstance *aInstance)
 {

--- a/examples/platforms/posix/platform-posix.h
+++ b/examples/platforms/posix/platform-posix.h
@@ -41,6 +41,12 @@
 #include <openthread-config.h>
 #endif
 
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
 #if _WIN32
 #include <WinSock2.h>
 #include <WS2tcpip.h>
@@ -75,14 +81,7 @@ __forceinline void timersub(struct timeval *a, struct timeval *b, struct timeval
 #define POLL poll
 #endif
 
-#include "openthread/openthread.h"
-#include <common/code_utils.hpp>
-
-#include <assert.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
+#include <openthread/openthread.h>
 
 /**
  * Unique node ID.

--- a/examples/platforms/posix/platform.c
+++ b/examples/platforms/posix/platform.c
@@ -46,9 +46,9 @@
 #include <syslog.h>
 #endif
 
-#include "openthread/openthread.h"
-#include "openthread/tasklet.h"
-#include "openthread/platform/alarm.h"
+#include <openthread/openthread.h>
+#include <openthread/tasklet.h>
+#include <openthread/platform/alarm.h>
 
 uint32_t NODE_ID = 1;
 uint32_t WELLKNOWN_NODE_ID = 34;

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -28,8 +28,8 @@
 
 #include "platform-posix.h"
 
-#include "openthread/platform/diag.h"
-#include "openthread/platform/radio.h"
+#include <openthread/platform/diag.h>
+#include <openthread/platform/radio.h>
 
 #include "utils/code_utils.h"
 

--- a/examples/platforms/posix/random.c
+++ b/examples/platforms/posix/random.c
@@ -37,10 +37,10 @@
 
 #include "platform-posix.h"
 
-#include "openthread/types.h"
-#include "openthread/platform/random.h"
+#include <openthread/types.h>
+#include <openthread/platform/random.h>
 
-#include <utils/code_utils.h>
+#include "utils/code_utils.h"
 
 static uint32_t sState = 1;
 

--- a/examples/platforms/posix/spi-stubs.c
+++ b/examples/platforms/posix/spi-stubs.c
@@ -31,8 +31,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "openthread/platform/uart.h"
-#include "openthread/platform/spi-slave.h"
+#include <openthread/platform/spi-slave.h>
+#include <openthread/platform/uart.h>
 
 // Spi-slave stubs
 

--- a/examples/platforms/posix/uart-posix.c
+++ b/examples/platforms/posix/uart-posix.c
@@ -29,18 +29,18 @@
 #include "platform-posix.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <poll.h>
+#include <signal.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <termios.h>
 #include <unistd.h>
-#include <errno.h>
-#include <signal.h>
 
-#include "openthread/platform/uart.h"
+#include <openthread/platform/uart.h>
 
-#include <utils/code_utils.h>
+#include "utils/code_utils.h"
 
 #ifdef OPENTHREAD_TARGET_LINUX
 #include <sys/prctl.h>

--- a/examples/platforms/utils/flash.h
+++ b/examples/platforms/utils/flash.h
@@ -37,7 +37,7 @@
 
 #include <stdint.h>
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/border_agent_proxy.h
+++ b/include/openthread/border_agent_proxy.h
@@ -41,7 +41,7 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/cli.h
+++ b/include/openthread/cli.h
@@ -37,7 +37,7 @@
 
 #include <stdint.h>
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -43,8 +43,8 @@
 
 #include <stdint.h>
 
-#include "openthread/types.h"
-#include "openthread/message.h"
+#include <openthread/message.h>
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/commissioner.h
+++ b/include/openthread/commissioner.h
@@ -35,8 +35,8 @@
 #ifndef OPENTHREAD_COMMISSIONER_H_
 #define OPENTHREAD_COMMISSIONER_H_
 
-#include "openthread/types.h"
-#include "openthread/platform/toolchain.h"
+#include <openthread/types.h>
+#include <openthread/platform/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/crypto.h
+++ b/include/openthread/crypto.h
@@ -35,8 +35,8 @@
 #ifndef OPENTHREAD_CRYPTO_H_
 #define OPENTHREAD_CRYPTO_H_
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -35,7 +35,7 @@
 #ifndef OPENTHREAD_DATASET_H_
 #define OPENTHREAD_DATASET_H_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/dataset_ftd.h
+++ b/include/openthread/dataset_ftd.h
@@ -35,7 +35,7 @@
 #ifndef OPENTHREAD_DATASET_FTD_H_
 #define OPENTHREAD_DATASET_FTD_H_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/dhcp6_client.h
+++ b/include/openthread/dhcp6_client.h
@@ -35,7 +35,7 @@
 #ifndef OPENTHREAD_DHCP6_CLIENT_H_
 #define OPENTHREAD_DHCP6_CLIENT_H_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/dhcp6_server.h
+++ b/include/openthread/dhcp6_server.h
@@ -35,7 +35,7 @@
 #ifndef OPENTHREAD_DHCP6_SERVER_H_
 #define OPENTHREAD_DHCP6_SERVER_H_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/diag.h
+++ b/include/openthread/diag.h
@@ -35,7 +35,7 @@
 #ifndef OPENTHREAD_DIAG_H_
 #define OPENTHREAD_DIAG_H_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/dns.h
+++ b/include/openthread/dns.h
@@ -41,8 +41,8 @@
 #include <openthread-config.h>
 #endif
 
-#include <openthread/types.h>
 #include <openthread/message.h>
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/icmp6.h
+++ b/include/openthread/icmp6.h
@@ -35,8 +35,8 @@
 #ifndef OPENTHREAD_ICMP6_H_
 #define OPENTHREAD_ICMP6_H_
 
-#include <openthread/types.h>
 #include <openthread/message.h>
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -35,8 +35,8 @@
 #ifndef OPENTHREAD_INSTANCE_H_
 #define OPENTHREAD_INSTANCE_H_
 
-#include "openthread/types.h"
-#include "openthread/platform/logging.h"
+#include <openthread/types.h>
+#include <openthread/platform/logging.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -35,8 +35,8 @@
 #ifndef OPENTHREAD_IP6_H_
 #define OPENTHREAD_IP6_H_
 
-#include "openthread/message.h"
-#include "platform/radio.h"
+#include <openthread/message.h>
+#include <openthread/platform/radio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/jam_detection.h
+++ b/include/openthread/jam_detection.h
@@ -41,7 +41,7 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/joiner.h
+++ b/include/openthread/joiner.h
@@ -35,8 +35,8 @@
 #ifndef OPENTHREAD_JOINER_H_
 #define OPENTHREAD_JOINER_H_
 
-#include "openthread/types.h"
-#include "openthread/platform/toolchain.h"
+#include <openthread/types.h>
+#include <openthread/platform/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -35,8 +35,8 @@
 #ifndef OPENTHREAD_LINK_H_
 #define OPENTHREAD_LINK_H_
 
-#include "openthread/types.h"
-#include "platform/radio.h"
+#include <openthread/types.h>
+#include <openthread/platform/radio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/link_raw.h
+++ b/include/openthread/link_raw.h
@@ -35,8 +35,8 @@
 #ifndef LINK_RAW_H_
 #define LINK_RAW_H_
 
-#include "openthread/types.h"
-#include "platform/radio.h"
+#include <openthread/types.h>
+#include <openthread/platform/radio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/message.h
+++ b/include/openthread/message.h
@@ -35,7 +35,7 @@
 #ifndef OPENTHREAD_MESSAGE_H_
 #define OPENTHREAD_MESSAGE_H_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/ncp.h
+++ b/include/openthread/ncp.h
@@ -35,7 +35,7 @@
 #ifndef NCP_H_
 #define NCP_H_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/netdata.h
+++ b/include/openthread/netdata.h
@@ -35,7 +35,7 @@
 #ifndef OPENTHREAD_NETDATA_H_
 #define OPENTHREAD_NETDATA_H_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/openthread.h
+++ b/include/openthread/openthread.h
@@ -35,17 +35,16 @@
 #ifndef OPENTHREAD_H_
 #define OPENTHREAD_H_
 
-#include "openthread/types.h"
-
-#include "openthread/crypto.h"
-#include "openthread/dataset.h"
-#include "openthread/instance.h"
-#include "openthread/ip6.h"
-#include "openthread/link.h"
-#include "openthread/message.h"
-#include "openthread/netdata.h"
-#include "openthread/tasklet.h"
-#include "openthread/thread.h"
+#include <openthread/crypto.h>
+#include <openthread/dataset.h>
+#include <openthread/instance.h>
+#include <openthread/ip6.h>
+#include <openthread/link.h>
+#include <openthread/message.h>
+#include <openthread/netdata.h>
+#include <openthread/tasklet.h>
+#include <openthread/thread.h>
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/platform/alarm.h
+++ b/include/openthread/platform/alarm.h
@@ -37,7 +37,7 @@
 
 #include <stdint.h>
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/platform/diag.h
+++ b/include/openthread/platform/diag.h
@@ -39,9 +39,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#include <openthread/platform/radio.h>
-
 #include <openthread/types.h>
+#include <openthread/platform/radio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/platform/messagepool.h
+++ b/include/openthread/platform/messagepool.h
@@ -37,9 +37,8 @@
 
 #include <stdint.h>
 
-#include "openthread/types.h"
-
-#include "openthread/message.h"
+#include <openthread/message.h>
+#include <openthread/types.h>
 
 /**
  * @defgroup messagepool MessagePool

--- a/include/openthread/platform/misc.h
+++ b/include/openthread/platform/misc.h
@@ -37,7 +37,7 @@
 
 #include <stdint.h>
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/platform/platform.h
+++ b/include/openthread/platform/platform.h
@@ -35,7 +35,7 @@
 #ifndef PLATFORM_H_
 #define PLATFORM_H_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -38,7 +38,7 @@
 
 #include <stdint.h>
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/platform/random.h
+++ b/include/openthread/platform/random.h
@@ -37,7 +37,7 @@
 
 #include <stdint.h>
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -35,7 +35,7 @@
 #ifndef OT_PLATFORM_SETTINGS_H
 #define OT_PLATFORM_SETTINGS_H 1
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/platform/spi-slave.h
+++ b/include/openthread/platform/spi-slave.h
@@ -37,7 +37,7 @@
 
 #include <stdint.h>
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/platform/uart.h
+++ b/include/openthread/platform/uart.h
@@ -37,7 +37,7 @@
 
 #include <stdint.h>
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/platform/usec-alarm.h
+++ b/include/openthread/platform/usec-alarm.h
@@ -37,7 +37,7 @@
 
 #include <stdint.h>
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/tasklet.h
+++ b/include/openthread/tasklet.h
@@ -35,7 +35,7 @@
 #ifndef OPENTHREAD_TASKLET_H_
 #define OPENTHREAD_TASKLET_H_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -35,9 +35,9 @@
 #ifndef OPENTHREAD_THREAD_H_
 #define OPENTHREAD_THREAD_H_
 
-#include "openthread/types.h"
-#include "openthread/link.h"
-#include "openthread/message.h"
+#include <openthread/link.h>
+#include <openthread/message.h>
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -35,9 +35,9 @@
 #ifndef OPENTHREAD_THREAD_FTD_H_
 #define OPENTHREAD_THREAD_FTD_H_
 
-#include "openthread/types.h"
-#include "openthread/link.h"
-#include "openthread/message.h"
+#include <openthread/link.h>
+#include <openthread/message.h>
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -41,7 +41,7 @@
 #include <guiddef.h>
 #endif
 
-#include "openthread/platform/toolchain.h"
+#include <openthread/platform/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/udp.h
+++ b/include/openthread/udp.h
@@ -35,8 +35,8 @@
 #ifndef OPENTHREAD_UDP_H_
 #define OPENTHREAD_UDP_H_
 
-#include "openthread/types.h"
-#include "openthread/message.h"
+#include <openthread/message.h>
+#include <openthread/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -37,43 +37,45 @@
 #include <openthread-config.h>
 #endif
 
-#include <stdio.h>
-#include <stdlib.h>
-#include "utils/wrap_string.h"
+#include "cli.hpp"
 
 #ifdef OTDLL
 #include <assert.h>
 #endif
 
-#include "openthread/openthread.h"
-#include "openthread/commissioner.h"
-#include "openthread/joiner.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include "utils/wrap_string.h"
+
+#include <openthread/openthread.h>
+#include <openthread/commissioner.h>
+#include <openthread/joiner.h>
 
 #if OPENTHREAD_FTD
-#include "openthread/dataset_ftd.h"
-#include "openthread/thread_ftd.h"
+#include <openthread/dataset_ftd.h>
+#include <openthread/thread_ftd.h>
 #endif
 
 #ifndef OTDLL
-#include <openthread-instance.h>
-#include "openthread/diag.h"
-#include "openthread/icmp6.h"
+#include <openthread/dhcp6_client.h>
+#include <openthread/dhcp6_server.h>
+#include <openthread/diag.h>
+#include <openthread/icmp6.h>
+#include <openthread/platform/uart.h>
 
-#include <common/new.hpp>
-#include <net/ip6.hpp>
-#include "openthread/dhcp6_client.h"
-#include "openthread/dhcp6_server.h"
-#include "openthread/platform/uart.h"
+#include "openthread-instance.h"
+#include "common/new.hpp"
+#include "net/ip6.hpp"
 #endif
 
-#include <common/encoding.hpp>
-
-#include "cli.hpp"
 #include "cli_dataset.hpp"
 #include "cli_uart.hpp"
+
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
 #include "cli_coap.hpp"
 #endif
+
+#include "common/encoding.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -42,22 +42,23 @@
 
 #include <stdarg.h>
 
-#include "openthread/openthread.h"
-#include "openthread/ip6.h"
-#include "openthread/udp.h"
+#include <openthread/openthread.h>
+#include <openthread/ip6.h>
+#include <openthread/udp.h>
 
-#include <cli/cli_server.hpp>
-#include <common/code_utils.hpp>
+#include "cli/cli_server.hpp"
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
 #include <coap/coap_header.hpp>
 #endif
 
+#include "common/code_utils.hpp"
+
 #ifndef OTDLL
-#include <net/icmp6.hpp>
-#include <common/timer.hpp>
-#include "openthread/dhcp6_client.h"
-#include "openthread/dns.h"
+#include <openthread/dhcp6_client.h>
+#include <openthread/dns.h>
+#include "common/timer.hpp"
+#include "net/icmp6.hpp"
 #endif
 
 #ifdef OTDLL

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -37,13 +37,14 @@
 #include <openthread-config.h>
 #endif
 
-#include <ctype.h>
-#include <cli/cli.hpp>
-
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
 
-#include <cli/cli_coap.hpp>
-#include <coap/coap_header.hpp>
+#include "cli_coap.hpp"
+
+#include <ctype.h>
+
+#include "cli/cli.hpp"
+#include "coap/coap_header.hpp"
 
 namespace ot {
 namespace Cli {

--- a/src/cli/cli_coap.hpp
+++ b/src/cli/cli_coap.hpp
@@ -34,6 +34,11 @@
 #ifndef CLI_COAP_HPP_
 #define CLI_COAP_HPP_
 
+#include <openthread/types.h>
+
+#include "cli/cli.hpp"
+#include "coap/coap_header.hpp"
+
 namespace ot {
 namespace Cli {
 

--- a/src/cli/cli_console.cpp
+++ b/src/cli/cli_console.cpp
@@ -37,14 +37,15 @@
 #include <openthread-config.h>
 #endif
 
+#include "cli_console.hpp"
+
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "utils/wrap_string.h"
 
-#include <cli/cli.hpp>
-#include <cli/cli_console.hpp>
-#include <common/new.hpp>
+#include "cli/cli.hpp"
+#include "common/new.hpp"
 
 namespace ot {
 namespace Cli {

--- a/src/cli/cli_console.hpp
+++ b/src/cli/cli_console.hpp
@@ -34,9 +34,10 @@
 #ifndef CLI_CONSOLE_HPP_
 #define CLI_CONSOLE_HPP_
 
-#include "openthread/cli.h"
+#include <openthread/cli.h>
 
-#include <cli/cli_server.hpp>
+#include "cli/cli.hpp"
+#include "cli/cli_server.hpp"
 
 namespace ot {
 namespace Cli {

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -37,18 +37,19 @@
 #include <openthread-config.h>
 #endif
 
+#include "cli_dataset.hpp"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "utils/wrap_string.h"
 
-#include "openthread/openthread.h"
+#include <openthread/openthread.h>
 
 #if OPENTHREAD_FTD
-#include "openthread/dataset_ftd.h"
+#include <openthread/dataset_ftd.h>
 #endif
 
-#include "cli.hpp"
-#include "cli_dataset.hpp"
+#include "cli/cli.hpp"
 
 namespace ot {
 namespace Cli {

--- a/src/cli/cli_dataset.hpp
+++ b/src/cli/cli_dataset.hpp
@@ -36,7 +36,7 @@
 
 #include <stdarg.h>
 
-#include <cli/cli_server.hpp>
+#include "cli/cli_server.hpp"
 
 namespace ot {
 namespace Cli {

--- a/src/cli/cli_instance.cpp
+++ b/src/cli/cli_instance.cpp
@@ -37,12 +37,13 @@
 #include <openthread-config.h>
 #endif
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "utils/wrap_string.h"
-#include <assert.h>
 
-#include "openthread/openthread.h"
+#include <openthread/openthread.h>
+
 #include "cli.hpp"
 
 namespace ot {

--- a/src/cli/cli_server.hpp
+++ b/src/cli/cli_server.hpp
@@ -34,7 +34,7 @@
 #ifndef CLI_SERVER_HPP_
 #define CLI_SERVER_HPP_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 namespace ot {
 namespace Cli {

--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -37,21 +37,22 @@
 #include <openthread-config.h>
 #endif
 
+#include "cli_uart.hpp"
+
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "utils/wrap_string.h"
 
-#include "openthread/cli.h"
-#include "openthread/platform/logging.h"
-#include "openthread/platform/uart.h"
+#include <openthread/cli.h>
+#include <openthread/platform/logging.h>
+#include <openthread/platform/uart.h>
 
-#include <cli/cli.hpp>
-#include <cli/cli_uart.hpp>
-#include <common/code_utils.hpp>
-#include <common/encoding.hpp>
-#include <common/new.hpp>
-#include <common/tasklet.hpp>
+#include "cli/cli.hpp"
+#include "common/code_utils.hpp"
+#include "common/encoding.hpp"
+#include "common/new.hpp"
+#include "common/tasklet.hpp"
 
 namespace ot {
 namespace Cli {

--- a/src/cli/cli_uart.hpp
+++ b/src/cli/cli_uart.hpp
@@ -34,10 +34,11 @@
 #ifndef CLI_UART_HPP_
 #define CLI_UART_HPP_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <cli/cli_server.hpp>
-#include <common/tasklet.hpp>
+#include "cli/cli.hpp"
+#include "cli/cli_server.hpp"
+#include "common/tasklet.hpp"
 
 namespace ot {
 namespace Cli {

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -37,13 +37,14 @@
 #include <openthread-config.h>
 #endif
 
+#include "cli_udp.hpp"
+
 #include <stdarg.h>
 #include <stdio.h>
 #include "utils/wrap_string.h"
 
-#include <cli/cli.hpp>
-#include <cli/cli_udp.hpp>
-#include <common/code_utils.hpp>
+#include "cli/cli.hpp"
+#include "common/code_utils.hpp"
 
 namespace ot {
 namespace Cli {

--- a/src/cli/cli_udp.hpp
+++ b/src/cli/cli_udp.hpp
@@ -34,9 +34,10 @@
 #ifndef CLI_UDP_HPP_
 #define CLI_UDP_HPP_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <cli/cli_server.hpp>
+#include "cli/cli.hpp"
+#include "cli/cli_server.hpp"
 
 namespace ot {
 namespace Cli {

--- a/src/core/api/border_agent_proxy_api.cpp
+++ b/src/core/api/border_agent_proxy_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread Border Agent Proxy API.
  */
 
-#include "openthread/border_agent_proxy.h"
+#include <openthread/border_agent_proxy.h>
 
 #include "openthread-instance.h"
 

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread CoAP API.
  */
 
-#include "openthread/coap.h"
+#include <openthread/coap.h>
 
 #include "openthread-instance.h"
 #include "coap/coap_header.hpp"

--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread Commissioner API.
  */
 
-#include "openthread/commissioner.h"
+#include <openthread/commissioner.h>
 
 #include "openthread-instance.h"
 

--- a/src/core/api/crypto_api.cpp
+++ b/src/core/api/crypto_api.cpp
@@ -31,12 +31,12 @@
  *   This file implements the OpenThread Crypto API.
  */
 
-#include "openthread/crypto.h"
+#include <openthread/crypto.h>
 
-#include "common/debug.hpp"
 #include "common/code_utils.hpp"
-#include "crypto/hmac_sha256.hpp"
+#include "common/debug.hpp"
 #include "crypto/aes_ccm.hpp"
+#include "crypto/hmac_sha256.hpp"
 
 using namespace ot::Crypto;
 

--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread Operational Dataset API (for both FTD and MTD).
  */
 
-#include "openthread/dataset.h"
+#include <openthread/dataset.h>
 
 #include "openthread-instance.h"
 

--- a/src/core/api/dataset_ftd_api.cpp
+++ b/src/core/api/dataset_ftd_api.cpp
@@ -33,7 +33,7 @@
 
 #if OPENTHREAD_FTD
 
-#include "openthread/dataset_ftd.h"
+#include <openthread/dataset_ftd.h>
 
 #include "openthread-instance.h"
 

--- a/src/core/api/dhcp6_api.cpp
+++ b/src/core/api/dhcp6_api.cpp
@@ -31,8 +31,8 @@
  *   This file implements the OpenThread DHCPv6 API.
  */
 
-#include "openthread/dhcp6_client.h"
-#include "openthread/dhcp6_server.h"
+#include <openthread/dhcp6_client.h>
+#include <openthread/dhcp6_server.h>
 
 #include "openthread-instance.h"
 

--- a/src/core/api/dns_api.cpp
+++ b/src/core/api/dns_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread UDP API.
  */
 
-#include "openthread/dns.h"
+#include <openthread/dns.h>
 
 #include "openthread-instance.h"
 

--- a/src/core/api/icmp6_api.cpp
+++ b/src/core/api/icmp6_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread ICMPv6 API.
  */
 
-#include "openthread/icmp6.h"
+#include <openthread/icmp6.h>
 
 #include "openthread-instance.h"
 

--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -39,12 +39,11 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/instance.h"
-#include "openthread/platform/misc.h"
-#include "openthread/platform/settings.h"
+#include <openthread/instance.h>
+#include <openthread/platform/misc.h>
+#include <openthread/platform/settings.h>
 
 #include "openthread-instance.h"
-
 #include "common/logging.hpp"
 #include "common/new.hpp"
 

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -33,7 +33,7 @@
 
 #define WPP_NAME "ip6_api.tmh"
 
-#include "openthread/ip6.h"
+#include <openthread/ip6.h>
 
 #include "openthread-instance.h"
 #include "common/logging.hpp"

--- a/src/core/api/jam_detection_api.cpp
+++ b/src/core/api/jam_detection_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread Jam Detection API.
  */
 
-#include "openthread/jam_detection.h"
+#include <openthread/jam_detection.h>
 
 #include "openthread-instance.h"
 

--- a/src/core/api/joiner_api.cpp
+++ b/src/core/api/joiner_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread Joiner API.
  */
 
-#include "openthread/joiner.h"
+#include <openthread/joiner.h>
 
 #include "openthread-instance.h"
 

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread Link API.
  */
 
-#include "openthread/link.h"
+#include <openthread/link.h>
 
 #include "openthread-instance.h"
 

--- a/src/core/api/link_raw.hpp
+++ b/src/core/api/link_raw.hpp
@@ -34,8 +34,10 @@
 #ifndef LINK_RAW_HPP_
 #define LINK_RAW_HPP_
 
-#include <openthread-core-config.h>
-#include "openthread/link_raw.h"
+#include <openthread/link_raw.h>
+
+#include "openthread-core-config.h"
+#include "common/timer.hpp"
 
 #if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ACK_TIMEOUT || OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT || OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ENERGY_SCAN
 #define OPENTHREAD_LINKRAW_TIMER_REQUIRED 1

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -31,11 +31,12 @@
  *   This file implements the OpenThread Link Raw API.
  */
 
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include "openthread/platform/random.h"
-#include "openthread/platform/usec-alarm.h"
+#include <openthread/platform/random.h>
+#include <openthread/platform/usec-alarm.h>
+
 #include "openthread-instance.h"
+#include "common/debug.hpp"
+#include "common/logging.hpp"
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
 

--- a/src/core/api/message_api.cpp
+++ b/src/core/api/message_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread Message API.
  */
 
-#include "openthread/message.h"
+#include <openthread/message.h>
 
 #include "openthread-instance.h"
 

--- a/src/core/api/netdata_api.cpp
+++ b/src/core/api/netdata_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread Network Data API.
  */
 
-#include "openthread/netdata.h"
+#include <openthread/netdata.h>
 
 #include "openthread-instance.h"
 

--- a/src/core/api/tasklet_api.cpp
+++ b/src/core/api/tasklet_api.cpp
@@ -33,7 +33,7 @@
 
 #define WPP_NAME "tasklet_api.tmh"
 
-#include "openthread/tasklet.h"
+#include <openthread/tasklet.h>
 
 #include "openthread-instance.h"
 #include "common/logging.hpp"

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -33,12 +33,12 @@
 
 #define WPP_NAME "thread_api.tmh"
 
-#include "openthread/thread.h"
+#include <openthread/thread.h>
+#include <openthread/platform/settings.h>
 
 #include "openthread-instance.h"
 #include "common/logging.hpp"
 #include "common/settings.hpp"
-#include "openthread/platform/settings.h"
 
 using namespace ot;
 

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -35,7 +35,7 @@
 
 #define WPP_NAME "thread_ftd_api.tmh"
 
-#include "openthread/thread_ftd.h"
+#include <openthread/thread_ftd.h>
 
 #include "openthread-instance.h"
 

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread UDP API.
  */
 
-#include "openthread/udp.h"
+#include <openthread/udp.h>
 
 #include "openthread-instance.h"
 

--- a/src/core/coap/coap_base.cpp
+++ b/src/core/coap/coap_base.cpp
@@ -32,8 +32,9 @@
 #include <openthread-config.h>
 #endif
 
-#include <common/code_utils.hpp>
-#include <coap/coap_base.hpp>
+#include "coap_base.hpp"
+
+#include "common/code_utils.hpp"
 
 /**
  * @file

--- a/src/core/coap/coap_base.hpp
+++ b/src/core/coap/coap_base.hpp
@@ -29,12 +29,12 @@
 #ifndef COAP_BASE_HPP_
 #define COAP_BASE_HPP_
 
-#include "openthread/coap.h"
+#include <openthread/coap.h>
 
-#include <coap/coap_header.hpp>
-#include <common/message.hpp>
-#include <net/netif.hpp>
-#include <net/udp6.hpp>
+#include "coap/coap_header.hpp"
+#include "common/message.hpp"
+#include "net/netif.hpp"
+#include "net/udp6.hpp"
 
 /**
  * @file

--- a/src/core/coap/coap_client.cpp
+++ b/src/core/coap/coap_client.cpp
@@ -32,15 +32,15 @@
 #include <openthread-config.h>
 #endif
 
+#include "coap_client.hpp"
+
+#include <openthread/platform/random.h>
+
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "net/ip6.hpp"
+#include "net/udp6.hpp"
 #include "utils/wrap_string.h"
-
-#include "openthread/platform/random.h"
-
-#include <coap/coap_client.hpp>
-#include <common/debug.hpp>
-#include <common/code_utils.hpp>
-#include <net/ip6.hpp>
-#include <net/udp6.hpp>
 
 /**
  * @file

--- a/src/core/coap/coap_client.hpp
+++ b/src/core/coap/coap_client.hpp
@@ -29,14 +29,14 @@
 #ifndef COAP_CLIENT_HPP_
 #define COAP_CLIENT_HPP_
 
-#include "openthread/coap.h"
+#include <openthread/coap.h>
 
-#include <coap/coap_base.hpp>
-#include <coap/coap_header.hpp>
-#include <common/message.hpp>
-#include <common/timer.hpp>
-#include <net/netif.hpp>
-#include <net/udp6.hpp>
+#include "coap/coap_base.hpp"
+#include "coap/coap_header.hpp"
+#include "common/message.hpp"
+#include "common/timer.hpp"
+#include "net/netif.hpp"
+#include "net/udp6.hpp"
 
 /**
  * @file

--- a/src/core/coap/coap_header.cpp
+++ b/src/core/coap/coap_header.cpp
@@ -37,13 +37,14 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/platform/random.h"
+#include "coap_header.hpp"
 
-#include <coap/coap_header.hpp>
-#include <coap/coap_client.hpp>
-#include <common/debug.hpp>
-#include <common/code_utils.hpp>
-#include <common/encoding.hpp>
+#include <openthread/platform/random.h>
+
+#include "coap/coap_client.hpp"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/encoding.hpp"
 
 namespace ot {
 namespace Coap {

--- a/src/core/coap/coap_header.hpp
+++ b/src/core/coap/coap_header.hpp
@@ -36,10 +36,10 @@
 
 #include "utils/wrap_string.h"
 
-#include "openthread/coap.h"
+#include <openthread/coap.h>
 
-#include <common/encoding.hpp>
-#include <common/message.hpp>
+#include "common/encoding.hpp"
+#include "common/message.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 

--- a/src/core/coap/coap_server.cpp
+++ b/src/core/coap/coap_server.cpp
@@ -37,9 +37,10 @@
 #include <openthread-config.h>
 #endif
 
-#include <coap/coap_server.hpp>
-#include <common/code_utils.hpp>
-#include <net/ip6.hpp>
+#include "coap_server.hpp"
+
+#include "common/code_utils.hpp"
+#include "net/ip6.hpp"
 
 namespace ot {
 namespace Coap {

--- a/src/core/coap/coap_server.hpp
+++ b/src/core/coap/coap_server.hpp
@@ -34,15 +34,15 @@
 #ifndef COAP_SERVER_HPP_
 #define COAP_SERVER_HPP_
 
-#include "openthread/coap.h"
+#include <openthread/coap.h>
 
-#include <coap/coap_base.hpp>
-#include <coap/coap_header.hpp>
-#include <common/debug.hpp>
-#include <common/message.hpp>
-#include <common/timer.hpp>
-#include <net/ip6.hpp>
-#include <net/udp6.hpp>
+#include "coap/coap_base.hpp"
+#include "coap/coap_header.hpp"
+#include "common/debug.hpp"
+#include "common/message.hpp"
+#include "common/timer.hpp"
+#include "net/ip6.hpp"
+#include "net/udp6.hpp"
 
 namespace ot {
 namespace Coap {

--- a/src/core/coap/secure_coap_client.cpp
+++ b/src/core/coap/secure_coap_client.cpp
@@ -34,10 +34,11 @@
 #include <openthread-config.h>
 #endif
 
-#include <coap/secure_coap_client.hpp>
-#include <common/logging.hpp>
-#include <meshcop/dtls.hpp>
-#include <thread/thread_netif.hpp>
+#include "secure_coap_client.hpp"
+
+#include "common/logging.hpp"
+#include "meshcop/dtls.hpp"
+#include "thread/thread_netif.hpp"
 
 #if OPENTHREAD_ENABLE_JOINER
 

--- a/src/core/coap/secure_coap_client.hpp
+++ b/src/core/coap/secure_coap_client.hpp
@@ -29,8 +29,8 @@
 #ifndef SECURE_COAP_CLIENT_HPP_
 #define SECURE_COAP_CLIENT_HPP_
 
-#include <coap/coap_client.hpp>
-#include <meshcop/dtls.hpp>
+#include "coap/coap_client.hpp"
+#include "meshcop/dtls.hpp"
 
 /**
  * @file

--- a/src/core/coap/secure_coap_server.cpp
+++ b/src/core/coap/secure_coap_server.cpp
@@ -34,10 +34,11 @@
 #include <openthread-config.h>
 #endif
 
-#include <coap/secure_coap_server.hpp>
-#include <common/logging.hpp>
-#include <meshcop/dtls.hpp>
-#include <thread/thread_netif.hpp>
+#include "secure_coap_server.hpp"
+
+#include "common/logging.hpp"
+#include "meshcop/dtls.hpp"
+#include "thread/thread_netif.hpp"
 
 #if OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
 

--- a/src/core/common/crc16.cpp
+++ b/src/core/common/crc16.cpp
@@ -37,7 +37,7 @@
 #include <openthread-config.h>
 #endif
 
-#include <common/crc16.hpp>
+#include "crc16.hpp"
 
 namespace ot {
 

--- a/src/core/common/debug.hpp
+++ b/src/core/common/debug.hpp
@@ -34,10 +34,11 @@
 #ifndef DEBUG_HPP_
 #define DEBUG_HPP_
 
-#include <openthread-core-config.h>
 #include <ctype.h>
 #include <stdio.h>
 #include "utils/wrap_string.h"
+
+#include "openthread-core-config.h"
 
 #if defined(OPENTHREAD_TARGET_DARWIN) || defined(OPENTHREAD_TARGET_LINUX)
 

--- a/src/core/common/logging.cpp
+++ b/src/core/common/logging.cpp
@@ -39,9 +39,9 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/openthread.h"
+#include "logging.hpp"
 
-#include <common/logging.hpp>
+#include <openthread/openthread.h>
 
 #ifndef WINDOWS_LOGGING
 #define otLogDump(aFormat, ...)                                             \

--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -38,10 +38,11 @@
 #include <stdio.h>
 #include "utils/wrap_string.h"
 
-#include <openthread-core-config.h>
-#include "openthread/types.h"
-#include "openthread/instance.h"
-#include "openthread/platform/logging.h"
+#include <openthread/instance.h>
+#include <openthread/types.h>
+#include <openthread/platform/logging.h>
+
+#include "openthread-core-config.h"
 
 #ifdef WINDOWS_LOGGING
 #ifdef _KERNEL_MODE

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -39,11 +39,12 @@
 #include <openthread-config.h>
 #endif
 
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <common/message.hpp>
-#include <net/ip6.hpp>
+#include "message.hpp"
+
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/logging.hpp"
+#include "net/ip6.hpp"
 
 namespace ot {
 

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -43,12 +43,12 @@
 #include "utils/wrap_stdint.h"
 #include "utils/wrap_string.h"
 
-#include "openthread/message.h"
-#include "openthread/platform/messagepool.h"
+#include <openthread/message.h>
+#include <openthread/platform/messagepool.h>
 
-#include <openthread-core-config.h>
-#include <common/code_utils.hpp>
-#include <mac/mac_frame.hpp>
+#include "openthread-core-config.h"
+#include "common/code_utils.hpp"
+#include "mac/mac_frame.hpp"
 
 namespace ot {
 

--- a/src/core/common/new.hpp
+++ b/src/core/common/new.hpp
@@ -36,7 +36,7 @@
 
 #include <stddef.h>
 
-#include "openthread/platform/toolchain.h"
+#include <openthread/platform/toolchain.h>
 
 inline void *operator new(size_t, void *p) throw() { return p; }
 

--- a/src/core/common/tasklet.cpp
+++ b/src/core/common/tasklet.cpp
@@ -37,12 +37,13 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/openthread.h"
+#include "tasklet.hpp"
 
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/tasklet.hpp>
-#include <net/ip6.hpp>
+#include <openthread/openthread.h>
+
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "net/ip6.hpp"
 
 namespace ot {
 

--- a/src/core/common/tasklet.hpp
+++ b/src/core/common/tasklet.hpp
@@ -34,7 +34,9 @@
 #ifndef TASKLET_HPP_
 #define TASKLET_HPP_
 
-#include "openthread/tasklet.h"
+#include <stdio.h>
+
+#include <openthread/tasklet.h>
 
 namespace ot {
 

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -39,14 +39,15 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/platform/alarm.h"
+#include "timer.hpp"
 
-#include <common/code_utils.hpp>
-#include <common/timer.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <net/ip6.hpp>
-#include <openthread-instance.h>
+#include <openthread/platform/alarm.h>
+
+#include "openthread-instance.h"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/logging.hpp"
+#include "net/ip6.hpp"
 
 namespace ot {
 

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -37,10 +37,10 @@
 #include <stddef.h>
 #include "utils/wrap_stdint.h"
 
-#include "openthread/types.h"
-#include "openthread/platform/alarm.h"
+#include <openthread/types.h>
+#include <openthread/platform/alarm.h>
 
-#include <common/tasklet.hpp>
+#include "common/tasklet.hpp"
 
 namespace ot {
 

--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -37,9 +37,10 @@
 #include <openthread-config.h>
 #endif
 
-#include <common/code_utils.hpp>
-#include <common/message.hpp>
-#include <thread/mle_tlvs.hpp>
+#include "tlvs.hpp"
+
+#include "common/code_utils.hpp"
+#include "common/message.hpp"
 
 namespace ot {
 

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -36,10 +36,10 @@
 
 #include "utils/wrap_string.h"
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <common/encoding.hpp>
-#include <common/message.hpp>
+#include "common/encoding.hpp"
+#include "common/message.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -37,11 +37,12 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/platform/random.h"
+#include "trickle_timer.hpp"
 
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/trickle_timer.hpp>
+#include <openthread/platform/random.h>
+
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
 
 namespace ot {
 

--- a/src/core/common/trickle_timer.hpp
+++ b/src/core/common/trickle_timer.hpp
@@ -34,7 +34,7 @@
 #ifndef TRICKLE_TIMER_HPP_
 #define TRICKLE_TIMER_HPP_
 
-#include <common/timer.hpp>
+#include "common/timer.hpp"
 
 namespace ot {
 

--- a/src/core/crypto/aes_ccm.cpp
+++ b/src/core/crypto/aes_ccm.cpp
@@ -37,9 +37,10 @@
 #include <openthread-config.h>
 #endif
 
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <crypto/aes_ccm.hpp>
+#include "aes_ccm.hpp"
+
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
 
 namespace ot {
 namespace Crypto {

--- a/src/core/crypto/aes_ccm.hpp
+++ b/src/core/crypto/aes_ccm.hpp
@@ -36,9 +36,9 @@
 
 #include "utils/wrap_stdint.h"
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <crypto/aes_ecb.hpp>
+#include "crypto/aes_ecb.hpp"
 
 namespace ot {
 namespace Crypto {

--- a/src/core/crypto/aes_ecb.cpp
+++ b/src/core/crypto/aes_ecb.cpp
@@ -37,7 +37,7 @@
 #include <openthread-config.h>
 #endif
 
-#include <crypto/aes_ecb.hpp>
+#include "aes_ecb.hpp"
 
 namespace ot {
 namespace Crypto {

--- a/src/core/crypto/hmac_sha256.cpp
+++ b/src/core/crypto/hmac_sha256.cpp
@@ -37,7 +37,7 @@
 #include <openthread-config.h>
 #endif
 
-#include <crypto/hmac_sha256.hpp>
+#include "hmac_sha256.hpp"
 
 namespace ot {
 namespace Crypto {

--- a/src/core/crypto/mbedtls.cpp
+++ b/src/core/crypto/mbedtls.cpp
@@ -37,7 +37,7 @@
 #include <openthread-config.h>
 #endif
 
-#include <crypto/mbedtls.hpp>
+#include "mbedtls.hpp"
 
 namespace ot {
 namespace Crypto {

--- a/src/core/crypto/mbedtls.hpp
+++ b/src/core/crypto/mbedtls.hpp
@@ -40,9 +40,9 @@
 #include <openthread-config.h>
 #endif
 
-#include <openthread-core-config.h>
-
 #include <mbedtls/memory_buffer_alloc.h>
+
+#include "openthread-core-config.h"
 
 namespace ot {
 namespace Crypto {

--- a/src/core/crypto/pbkdf2_cmac.cpp
+++ b/src/core/crypto/pbkdf2_cmac.cpp
@@ -37,8 +37,10 @@
 #include <openthread-config.h>
 #endif
 
+#include "pbkdf2_cmac.h"
+
 #include "utils/wrap_string.h"
-#include <crypto/pbkdf2_cmac.h>
+
 #include <mbedtls/cmac.h>
 
 #if OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD

--- a/src/core/crypto/pbkdf2_cmac.h
+++ b/src/core/crypto/pbkdf2_cmac.h
@@ -35,8 +35,8 @@
 #ifndef PBKDF2_CMAC_H_
 #define PBKDF2_CMAC_H_
 
-#include "utils/wrap_stdint.h"
 #include "utils/wrap_stdbool.h"
+#include "utils/wrap_stdint.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/core/crypto/sha256.cpp
+++ b/src/core/crypto/sha256.cpp
@@ -37,7 +37,7 @@
 #include <openthread-config.h>
 #endif
 
-#include <crypto/sha256.hpp>
+#include "sha256.hpp"
 
 namespace ot {
 namespace Crypto {

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -39,23 +39,24 @@
 #include <openthread-config.h>
 #endif
 
+#include "mac.hpp"
+
 #include "utils/wrap_string.h"
 
-#include "openthread/platform/random.h"
-#include "openthread/platform/usec-alarm.h"
+#include <openthread/platform/random.h>
+#include <openthread/platform/usec-alarm.h>
 
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/encoding.hpp>
-#include <common/logging.hpp>
-#include <crypto/aes_ccm.hpp>
-#include <crypto/sha256.hpp>
-#include <mac/mac.hpp>
-#include <mac/mac_frame.hpp>
-#include <thread/link_quality.hpp>
-#include <thread/mle_router.hpp>
-#include <thread/thread_netif.hpp>
-#include <openthread-instance.h>
+#include "openthread-instance.h"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/encoding.hpp"
+#include "common/logging.hpp"
+#include "crypto/aes_ccm.hpp"
+#include "crypto/sha256.hpp"
+#include "mac/mac_frame.hpp"
+#include "thread/link_quality.hpp"
+#include "thread/mle_router.hpp"
+#include "thread/thread_netif.hpp"
 
 using ot::Encoding::BigEndian::HostSwap64;
 

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -34,18 +34,17 @@
 #ifndef MAC_HPP_
 #define MAC_HPP_
 
-#include "openthread/platform/radio.h"
+#include <openthread/platform/radio.h>
 
-#include <openthread-core-config.h>
-
-#include <common/tasklet.hpp>
-#include <common/timer.hpp>
-#include <mac/mac_frame.hpp>
-#include <mac/mac_whitelist.hpp>
-#include <mac/mac_blacklist.hpp>
-#include <thread/key_manager.hpp>
-#include <thread/topology.hpp>
-#include <thread/network_diagnostic_tlvs.hpp>
+#include "openthread-core-config.h"
+#include "common/tasklet.hpp"
+#include "common/timer.hpp"
+#include "mac/mac_blacklist.hpp"
+#include "mac/mac_frame.hpp"
+#include "mac/mac_whitelist.hpp"
+#include "thread/key_manager.hpp"
+#include "thread/network_diagnostic_tlvs.hpp"
+#include "thread/topology.hpp"
 
 namespace ot {
 

--- a/src/core/mac/mac_blacklist.cpp
+++ b/src/core/mac/mac_blacklist.cpp
@@ -37,10 +37,11 @@
 #include <openthread-config.h>
 #endif
 
+#include "mac_blacklist.hpp"
+
 #include "utils/wrap_string.h"
 
-#include <common/code_utils.hpp>
-#include <mac/mac_blacklist.hpp>
+#include "common/code_utils.hpp"
 
 #if OPENTHREAD_ENABLE_MAC_WHITELIST
 

--- a/src/core/mac/mac_blacklist_impl.hpp
+++ b/src/core/mac/mac_blacklist_impl.hpp
@@ -36,9 +36,9 @@
 
 #include "utils/wrap_stdint.h"
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <mac/mac_frame.hpp>
+#include "mac/mac_frame.hpp"
 
 namespace ot {
 namespace Mac {

--- a/src/core/mac/mac_blacklist_stub.hpp
+++ b/src/core/mac/mac_blacklist_stub.hpp
@@ -36,9 +36,9 @@
 
 #include "utils/wrap_stdint.h"
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <mac/mac_frame.hpp>
+#include "mac/mac_frame.hpp"
 
 namespace ot {
 namespace Mac {

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -37,13 +37,14 @@
 #include <openthread-config.h>
 #endif
 
+#include "mac_frame.hpp"
+
 #include <stdio.h>
 #include "utils/wrap_string.h"
 
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <mac/mac_frame.hpp>
-#include <net/ip6_address.hpp>
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "net/ip6_address.hpp"
 
 namespace ot {
 namespace Mac {

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -34,16 +34,15 @@
 #ifndef MAC_FRAME_HPP_
 #define MAC_FRAME_HPP_
 
-#include <openthread-core-config.h>
-
 #include <limits.h>
 #include "utils/wrap_stdint.h"
 #include "utils/wrap_string.h"
 
-#include "openthread/types.h"
-#include "openthread/platform/radio.h"
+#include <openthread/types.h>
+#include <openthread/platform/radio.h>
 
-#include <common/encoding.hpp>
+#include "openthread-core-config.h"
+#include "common/encoding.hpp"
 
 namespace ot {
 

--- a/src/core/mac/mac_whitelist.cpp
+++ b/src/core/mac/mac_whitelist.cpp
@@ -37,10 +37,11 @@
 #include <openthread-config.h>
 #endif
 
+#include "mac_whitelist.hpp"
+
 #include "utils/wrap_string.h"
 
-#include <common/code_utils.hpp>
-#include <mac/mac_whitelist.hpp>
+#include "common/code_utils.hpp"
 
 #if OPENTHREAD_ENABLE_MAC_WHITELIST
 

--- a/src/core/mac/mac_whitelist_impl.hpp
+++ b/src/core/mac/mac_whitelist_impl.hpp
@@ -36,9 +36,9 @@
 
 #include "utils/wrap_stdint.h"
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <mac/mac_frame.hpp>
+#include "mac/mac_frame.hpp"
 
 namespace ot {
 namespace Mac {

--- a/src/core/mac/mac_whitelist_stub.hpp
+++ b/src/core/mac/mac_whitelist_stub.hpp
@@ -36,9 +36,9 @@
 
 #include "utils/wrap_stdint.h"
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <mac/mac_frame.hpp>
+#include "mac/mac_frame.hpp"
 
 namespace ot {
 namespace Mac {

--- a/src/core/meshcop/announce_begin_client.cpp
+++ b/src/core/meshcop/announce_begin_client.cpp
@@ -39,17 +39,18 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/platform/random.h"
+#include "announce_begin_client.hpp"
 
-#include <coap/coap_header.hpp>
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <meshcop/announce_begin_client.hpp>
-#include <meshcop/meshcop.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_uris.hpp>
+#include <openthread/platform/random.h>
+
+#include "coap/coap_header.hpp"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/logging.hpp"
+#include "meshcop/meshcop.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_uris.hpp"
 
 #if OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
 

--- a/src/core/meshcop/announce_begin_client.hpp
+++ b/src/core/meshcop/announce_begin_client.hpp
@@ -34,13 +34,10 @@
 #ifndef ANNOUNCE_BEGIN_CLIENT_HPP_
 #define ANNOUNCE_BEGIN_CLIENT_HPP_
 
-#include <openthread-core-config.h>
-
-#include "openthread/commissioner.h"
-
-#include <coap/coap_client.hpp>
-#include <net/ip6_address.hpp>
-#include <net/udp6.hpp>
+#include "openthread-core-config.h"
+#include "coap/coap_client.hpp"
+#include "net/ip6_address.hpp"
+#include "net/udp6.hpp"
 
 namespace ot {
 

--- a/src/core/meshcop/border_agent_proxy.cpp
+++ b/src/core/meshcop/border_agent_proxy.cpp
@@ -39,13 +39,14 @@
 #include <openthread-config.h>
 #endif
 
-#include <openthread/types.h>
-#include <coap/coap_header.hpp>
-#include <thread/thread_uris.hpp>
-#include <thread/thread_tlvs.hpp>
-#include <net/ip6_address.hpp>
-
 #include "border_agent_proxy.hpp"
+
+#include <openthread/types.h>
+
+#include "coap/coap_header.hpp"
+#include "net/ip6_address.hpp"
+#include "thread/thread_tlvs.hpp"
+#include "thread/thread_uris.hpp"
 
 #if OPENTHREAD_FTD && OPENTHREAD_ENABLE_BORDER_AGENT_PROXY
 

--- a/src/core/meshcop/border_agent_proxy.hpp
+++ b/src/core/meshcop/border_agent_proxy.hpp
@@ -34,11 +34,11 @@
 #ifndef BORDER_AGENT_PROXY_HPP_
 #define BORDER_AGENT_PROXY_HPP_
 
-#include <openthread-core-config.h>
 #include <openthread/border_agent_proxy.h>
 
-#include <coap/coap_client.hpp>
-#include <coap/coap_server.hpp>
+#include "openthread-core-config.h"
+#include "coap/coap_client.hpp"
+#include "coap/coap_server.hpp"
 
 namespace ot {
 namespace MeshCoP {

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -39,23 +39,24 @@
 #include <openthread-config.h>
 #endif
 
+#include "commissioner.hpp"
+
 #include <stdio.h>
 #include "utils/wrap_string.h"
 
-#include "openthread/platform/random.h"
-
-#include <coap/coap_header.hpp>
-#include <common/encoding.hpp>
-#include <common/logging.hpp>
-#include <crypto/pbkdf2_cmac.h>
-#include <meshcop/commissioner.hpp>
-#include <meshcop/joiner_router.hpp>
-#include <meshcop/meshcop.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_tlvs.hpp>
-#include <thread/thread_uris.hpp>
 #include <openthread/types.h>
+#include <openthread/platform/random.h>
+
+#include "coap/coap_header.hpp"
+#include "common/encoding.hpp"
+#include "common/logging.hpp"
+#include "crypto/pbkdf2_cmac.h"
+#include "meshcop/joiner_router.hpp"
+#include "meshcop/meshcop.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_tlvs.hpp"
+#include "thread/thread_uris.hpp"
 
 #if OPENTHREAD_FTD && OPENTHREAD_ENABLE_COMMISSIONER
 

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -34,20 +34,20 @@
 #ifndef COMMISSIONER_HPP_
 #define COMMISSIONER_HPP_
 
-#include <openthread-core-config.h>
-#include "openthread/commissioner.h"
+#include <openthread/commissioner.h>
 
-#include <coap/coap_client.hpp>
-#include <coap/coap_server.hpp>
-#include <coap/secure_coap_server.hpp>
-#include <common/timer.hpp>
-#include <mac/mac_frame.hpp>
-#include <meshcop/announce_begin_client.hpp>
-#include <meshcop/dtls.hpp>
-#include <meshcop/energy_scan_client.hpp>
-#include <meshcop/panid_query_client.hpp>
-#include <net/udp6.hpp>
-#include <thread/mle.hpp>
+#include "openthread-core-config.h"
+#include "coap/coap_client.hpp"
+#include "coap/coap_server.hpp"
+#include "coap/secure_coap_server.hpp"
+#include "common/timer.hpp"
+#include "mac/mac_frame.hpp"
+#include "meshcop/announce_begin_client.hpp"
+#include "meshcop/dtls.hpp"
+#include "meshcop/energy_scan_client.hpp"
+#include "meshcop/panid_query_client.hpp"
+#include "net/udp6.hpp"
+#include "thread/mle.hpp"
 
 namespace ot {
 

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -38,15 +38,16 @@
 #include <openthread-config.h>
 #endif
 
+#include "dataset.hpp"
+
 #include <stdio.h>
 
-#include "openthread/platform/settings.h"
+#include <openthread/platform/settings.h>
 
-#include <common/code_utils.hpp>
-#include <common/settings.hpp>
-#include <meshcop/dataset.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
-#include <thread/mle_tlvs.hpp>
+#include "common/code_utils.hpp"
+#include "common/settings.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "thread/mle_tlvs.hpp"
 
 namespace ot {
 namespace MeshCoP {

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -35,8 +35,8 @@
 #ifndef MESHCOP_DATASET_HPP_
 #define MESHCOP_DATASET_HPP_
 
-#include <common/message.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
+#include "common/message.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
 
 namespace ot {
 namespace MeshCoP {

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -40,27 +40,27 @@
 #include <openthread-config.h>
 #endif
 
+#include "dataset_manager.hpp"
+
 #include <stdio.h>
 
-#include "openthread/platform/random.h"
-#include "openthread/platform/radio.h"
-
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <coap/coap_header.hpp>
-#include <common/debug.hpp>
-#include <common/code_utils.hpp>
-#include <common/logging.hpp>
-#include <common/timer.hpp>
-#include <meshcop/dataset.hpp>
-#include <meshcop/dataset_manager.hpp>
-#include <meshcop/meshcop.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_tlvs.hpp>
-#include <thread/thread_uris.hpp>
-#include <meshcop/leader.hpp>
 #include <openthread/types.h>
+#include <openthread/platform/random.h>
+#include <openthread/platform/radio.h>
+
+#include "coap/coap_header.hpp"
+#include "common/code_utils.hpp"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/logging.hpp"
+#include "common/timer.hpp"
+#include "meshcop/dataset.hpp"
+#include "meshcop/leader.hpp"
+#include "meshcop/meshcop.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_tlvs.hpp"
+#include "thread/thread_uris.hpp"
 
 namespace ot {
 namespace MeshCoP {

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -35,14 +35,14 @@
 #ifndef MESHCOP_DATASET_MANAGER_HPP_
 #define MESHCOP_DATASET_MANAGER_HPP_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <coap/coap_server.hpp>
-#include <common/timer.hpp>
-#include <meshcop/dataset.hpp>
-#include <net/udp6.hpp>
-#include <thread/mle.hpp>
-#include <thread/network_data_leader.hpp>
+#include "coap/coap_server.hpp"
+#include "common/timer.hpp"
+#include "meshcop/dataset.hpp"
+#include "net/udp6.hpp"
+#include "thread/mle.hpp"
+#include "thread/network_data_leader.hpp"
 
 namespace ot {
 

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -44,23 +44,23 @@
 
 #include <stdio.h>
 
-#include "openthread/platform/random.h"
-#include "openthread/platform/radio.h"
+#include <openthread/platform/random.h>
+#include <openthread/platform/radio.h>
 
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <coap/coap_header.hpp>
-#include <common/debug.hpp>
-#include <common/code_utils.hpp>
-#include <common/logging.hpp>
-#include <common/timer.hpp>
-#include <meshcop/dataset.hpp>
-#include <meshcop/dataset_manager.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_tlvs.hpp>
-#include <thread/thread_uris.hpp>
-#include <meshcop/leader.hpp>
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "coap/coap_header.hpp"
+#include "common/debug.hpp"
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+#include "common/timer.hpp"
+#include "meshcop/dataset.hpp"
+#include "meshcop/dataset_manager.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "meshcop/leader.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_tlvs.hpp"
+#include "thread/thread_uris.hpp"
 
 namespace ot {
 namespace MeshCoP {

--- a/src/core/meshcop/dataset_manager_ftd.hpp
+++ b/src/core/meshcop/dataset_manager_ftd.hpp
@@ -35,9 +35,9 @@
 #ifndef MESHCOP_DATASET_MANAGER_FTD_HPP_
 #define MESHCOP_DATASET_MANAGER_FTD_HPP_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <coap/coap_server.hpp>
+#include "coap/coap_server.hpp"
 
 namespace ot {
 

--- a/src/core/meshcop/dataset_manager_mtd.hpp
+++ b/src/core/meshcop/dataset_manager_mtd.hpp
@@ -35,7 +35,7 @@
 #ifndef MESHCOP_DATASET_MANAGER_MTD_HPP_
 #define MESHCOP_DATASET_MANAGER_MTD_HPP_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 namespace ot {
 

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -31,24 +31,25 @@
  *   This file implements the necessary hooks for mbedTLS.
  */
 
+#define WPP_NAME "dtls.tmh"
+
 #ifdef OPENTHREAD_CONFIG_FILE
 #include OPENTHREAD_CONFIG_FILE
 #else
 #include <openthread-config.h>
 #endif
 
-#define WPP_NAME "dtls.tmh"
-
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/encoding.hpp>
-#include <common/logging.hpp>
-#include <common/timer.hpp>
-#include <crypto/sha256.hpp>
-#include <meshcop/dtls.hpp>
-#include <thread/thread_netif.hpp>
+#include "dtls.hpp"
 
 #include <mbedtls/debug.h>
+
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/encoding.hpp"
+#include "common/logging.hpp"
+#include "common/timer.hpp"
+#include "crypto/sha256.hpp"
+#include "thread/thread_netif.hpp"
 
 #if OPENTHREAD_ENABLE_DTLS
 

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -34,12 +34,7 @@
 #ifndef DTLS_HPP_
 #define DTLS_HPP_
 
-#include "openthread/types.h"
-
-#include <common/message.hpp>
-#include <common/timer.hpp>
-#include <crypto/sha256.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
+#include <openthread/types.h>
 
 #include <mbedtls/ssl.h>
 #include <mbedtls/entropy.h>
@@ -47,6 +42,11 @@
 #include <mbedtls/error.h>
 #include <mbedtls/certs.h>
 #include <mbedtls/ssl_cookie.h>
+
+#include "common/message.hpp"
+#include "common/timer.hpp"
+#include "crypto/sha256.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
 
 namespace ot {
 

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -31,26 +31,27 @@
  *   This file implements the Energy Scan Client.
  */
 
+#define WPP_NAME "energy_scan_client.tmh"
+
 #ifdef OPENTHREAD_CONFIG_FILE
 #include OPENTHREAD_CONFIG_FILE
 #else
 #include <openthread-config.h>
 #endif
 
-#define WPP_NAME "energy_scan_client.tmh"
+#include "energy_scan_client.hpp"
 
-#include "openthread/platform/random.h"
+#include <openthread/platform/random.h>
 
-#include <coap/coap_header.hpp>
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/encoding.hpp>
-#include <common/logging.hpp>
-#include <meshcop/energy_scan_client.hpp>
-#include <meshcop/meshcop.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_uris.hpp>
+#include "coap/coap_header.hpp"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/encoding.hpp"
+#include "common/logging.hpp"
+#include "meshcop/meshcop.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_uris.hpp"
 
 #if OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
 

--- a/src/core/meshcop/energy_scan_client.hpp
+++ b/src/core/meshcop/energy_scan_client.hpp
@@ -34,14 +34,13 @@
 #ifndef ENERGY_SCAN_CLIENT_HPP_
 #define ENERGY_SCAN_CLIENT_HPP_
 
-#include <openthread-core-config.h>
+#include <openthread/commissioner.h>
 
-#include "openthread/commissioner.h"
-
-#include <coap/coap_client.hpp>
-#include <coap/coap_server.hpp>
-#include <net/ip6_address.hpp>
-#include <net/udp6.hpp>
+#include "openthread-core-config.h"
+#include "coap/coap_client.hpp"
+#include "coap/coap_server.hpp"
+#include "net/ip6_address.hpp"
+#include "net/udp6.hpp"
 
 namespace ot {
 

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -39,21 +39,22 @@
 #include <openthread-config.h>
 #endif
 
+#include "joiner.hpp"
+
 #include <stdio.h>
 
-#include "openthread/platform/radio.h"
-#include "openthread/platform/random.h"
+#include <openthread/platform/radio.h>
+#include <openthread/platform/random.h>
 
-#include <common/code_utils.hpp>
-#include <common/crc16.hpp>
-#include <common/debug.hpp>
-#include <common/encoding.hpp>
-#include <common/logging.hpp>
-#include <mac/mac_frame.hpp>
-#include <meshcop/joiner.hpp>
-#include <meshcop/meshcop.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_uris.hpp>
+#include "common/code_utils.hpp"
+#include "common/crc16.hpp"
+#include "common/debug.hpp"
+#include "common/encoding.hpp"
+#include "common/logging.hpp"
+#include "mac/mac_frame.hpp"
+#include "meshcop/meshcop.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_uris.hpp"
 
 #if OPENTHREAD_ENABLE_JOINER
 

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -34,16 +34,16 @@
 #ifndef JOINER_HPP_
 #define JOINER_HPP_
 
-#include "openthread/joiner.h"
+#include <openthread/joiner.h>
 
-#include <coap/coap_header.hpp>
-#include <coap/coap_server.hpp>
-#include <coap/secure_coap_client.hpp>
-#include <common/message.hpp>
-#include <common/crc16.hpp>
-#include <net/udp6.hpp>
-#include <meshcop/dtls.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
+#include "coap/coap_header.hpp"
+#include "coap/coap_server.hpp"
+#include "coap/secure_coap_client.hpp"
+#include "common/crc16.hpp"
+#include "common/message.hpp"
+#include "meshcop/dtls.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "net/udp6.hpp"
 
 namespace ot {
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -41,17 +41,18 @@
 #include <openthread-config.h>
 #endif
 
+#include "joiner_router.hpp"
+
 #include <stdio.h>
 
-#include <common/code_utils.hpp>
-#include <common/encoding.hpp>
-#include <common/logging.hpp>
-#include <meshcop/joiner_router.hpp>
-#include <meshcop/meshcop.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
-#include <thread/mle.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_uris.hpp>
+#include "common/code_utils.hpp"
+#include "common/encoding.hpp"
+#include "common/logging.hpp"
+#include "meshcop/meshcop.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "thread/mle.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_uris.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap64;

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -34,18 +34,18 @@
 #ifndef JOINER_ROUTER_HPP_
 #define JOINER_ROUTER_HPP_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <coap/coap_header.hpp>
-#include <coap/coap_client.hpp>
-#include <coap/coap_server.hpp>
-#include <coap/coap_base.hpp>
-#include <common/message.hpp>
-#include <common/timer.hpp>
-#include <mac/mac_frame.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
-#include <net/udp6.hpp>
-#include <thread/key_manager.hpp>
+#include "coap/coap_base.hpp"
+#include "coap/coap_client.hpp"
+#include "coap/coap_header.hpp"
+#include "coap/coap_server.hpp"
+#include "common/message.hpp"
+#include "common/timer.hpp"
+#include "mac/mac_frame.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "net/udp6.hpp"
+#include "thread/key_manager.hpp"
 
 namespace ot {
 

--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -41,19 +41,20 @@
 #include <openthread-config.h>
 #endif
 
+#include "leader.hpp"
+
 #include <stdio.h>
 
-#include "openthread/platform/random.h"
+#include <openthread/platform/random.h>
 
-#include <coap/coap_header.hpp>
-#include <common/code_utils.hpp>
-#include <common/logging.hpp>
-#include <meshcop/leader.hpp>
-#include <meshcop/meshcop.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_tlvs.hpp>
-#include <thread/thread_uris.hpp>
+#include "coap/coap_header.hpp"
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+#include "meshcop/meshcop.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_tlvs.hpp"
+#include "thread/thread_uris.hpp"
 
 namespace ot {
 namespace MeshCoP {

--- a/src/core/meshcop/leader.hpp
+++ b/src/core/meshcop/leader.hpp
@@ -34,12 +34,12 @@
 #ifndef MESHCOP_LEADER_HPP_
 #define MESHCOP_LEADER_HPP_
 
-#include <coap/coap_client.hpp>
-#include <coap/coap_server.hpp>
-#include <common/timer.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
-#include <net/udp6.hpp>
-#include <thread/mle.hpp>
+#include "coap/coap_client.hpp"
+#include "coap/coap_server.hpp"
+#include "common/timer.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "net/udp6.hpp"
+#include "thread/mle.hpp"
 
 namespace ot {
 namespace MeshCoP {

--- a/src/core/meshcop/meshcop.hpp
+++ b/src/core/meshcop/meshcop.hpp
@@ -35,8 +35,8 @@
 #ifndef MESHCOP_HPP_
 #define MESHCOP_HPP_
 
-#include <common/message.hpp>
-#include <coap/coap_base.hpp>
+#include "coap/coap_base.hpp"
+#include "common/message.hpp"
 
 namespace ot {
 namespace MeshCoP {

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -31,7 +31,7 @@
  *   This file implements MechCop TLV helper functions.
  */
 
-#include <meshcop/meshcop_tlvs.hpp>
+#include "meshcop_tlvs.hpp"
 
 namespace ot {
 namespace MeshCoP {

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -37,13 +37,13 @@
 
 #include "utils/wrap_string.h"
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <common/crc16.hpp>
-#include <common/encoding.hpp>
-#include <common/message.hpp>
-#include <common/tlvs.hpp>
-#include <meshcop/timestamp.hpp>
+#include "common/crc16.hpp"
+#include "common/encoding.hpp"
+#include "common/message.hpp"
+#include "common/tlvs.hpp"
+#include "meshcop/timestamp.hpp"
 
 using ot::Encoding::Reverse32;
 using ot::Encoding::BigEndian::HostSwap16;

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -31,6 +31,7 @@
  *   This file implements the PAN ID Query Client.
  */
 
+#define WPP_NAME "panid_query_client.tmh"
 
 #ifdef OPENTHREAD_CONFIG_FILE
 #include OPENTHREAD_CONFIG_FILE
@@ -38,19 +39,18 @@
 #include <openthread-config.h>
 #endif
 
-#define WPP_NAME "panid_query_client.tmh"
+#include "panid_query_client.hpp"
 
-#include "openthread/platform/random.h"
+#include <openthread/platform/random.h>
 
-#include <coap/coap_header.hpp>
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <meshcop/panid_query_client.hpp>
-#include <meshcop/meshcop.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_uris.hpp>
+#include "coap/coap_header.hpp"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/logging.hpp"
+#include "meshcop/meshcop.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_uris.hpp"
 
 #if OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
 

--- a/src/core/meshcop/panid_query_client.hpp
+++ b/src/core/meshcop/panid_query_client.hpp
@@ -34,14 +34,13 @@
 #ifndef PANID_QUERY_CLIENT_HPP_
 #define PANID_QUERY_CLIENT_HPP_
 
-#include <openthread-core-config.h>
+#include <openthread/commissioner.h>
 
-#include "openthread/commissioner.h"
-
-#include <coap/coap_client.hpp>
-#include <coap/coap_server.hpp>
-#include <net/ip6_address.hpp>
-#include <net/udp6.hpp>
+#include "openthread-core-config.h"
+#include "coap/coap_client.hpp"
+#include "coap/coap_server.hpp"
+#include "net/ip6_address.hpp"
+#include "net/udp6.hpp"
 
 namespace ot {
 

--- a/src/core/meshcop/timestamp.cpp
+++ b/src/core/meshcop/timestamp.cpp
@@ -37,11 +37,11 @@
 #include <openthread-config.h>
 #endif
 
+#include "timestamp.hpp"
+
 #include "utils/wrap_string.h"
 
-#include "openthread/types.h"
-
-#include <meshcop/timestamp.hpp>
+#include <openthread/types.h>
 
 namespace ot {
 namespace MeshCoP {

--- a/src/core/meshcop/timestamp.hpp
+++ b/src/core/meshcop/timestamp.hpp
@@ -35,7 +35,11 @@
 #ifndef MESHCOP_TIMESTAMP_HPP_
 #define MESHCOP_TIMESTAMP_HPP_
 
-#include <common/encoding.hpp>
+#include <string.h>
+
+#include <openthread/platform/toolchain.h>
+
+#include "common/encoding.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 

--- a/src/core/net/dhcp6.hpp
+++ b/src/core/net/dhcp6.hpp
@@ -34,8 +34,8 @@
 #ifndef DHCP6_HPP_
 #define DHCP6_HPP_
 
-#include <common/message.hpp>
-#include <net/udp6.hpp>
+#include "common/message.hpp"
+#include "net/udp6.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -39,16 +39,17 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/types.h"
-#include "openthread/platform/random.h"
+#include "dhcp6_client.hpp"
 
-#include <common/code_utils.hpp>
-#include <common/encoding.hpp>
-#include <common/logging.hpp>
-#include <mac/mac.hpp>
-#include <net/dhcp6.hpp>
-#include <net/dhcp6_client.hpp>
-#include <thread/thread_netif.hpp>
+#include <openthread/types.h>
+#include <openthread/platform/random.h>
+
+#include "common/code_utils.hpp"
+#include "common/encoding.hpp"
+#include "common/logging.hpp"
+#include "mac/mac.hpp"
+#include "net/dhcp6.hpp"
+#include "thread/thread_netif.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -34,15 +34,15 @@
 #ifndef DHCP6_CLIENT_HPP_
 #define DHCP6_CLIENT_HPP_
 
-#include "openthread/dhcp6_client.h"
+#include <openthread/dhcp6_client.h>
 
-#include <common/message.hpp>
-#include <common/timer.hpp>
-#include <common/trickle_timer.hpp>
-#include <mac/mac.hpp>
-#include <mac/mac_frame.hpp>
-#include <net/dhcp6.hpp>
-#include <net/udp6.hpp>
+#include "common/message.hpp"
+#include "common/timer.hpp"
+#include "common/trickle_timer.hpp"
+#include "mac/mac.hpp"
+#include "mac/mac_frame.hpp"
+#include "net/dhcp6.hpp"
+#include "net/udp6.hpp"
 
 namespace ot {
 

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -39,14 +39,15 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/types.h"
+#include "dhcp6_server.hpp"
 
-#include <common/code_utils.hpp>
-#include <common/encoding.hpp>
-#include <common/logging.hpp>
-#include <net/dhcp6_server.hpp>
-#include <thread/mle.hpp>
-#include <thread/thread_netif.hpp>
+#include <openthread/types.h>
+
+#include "common/code_utils.hpp"
+#include "common/encoding.hpp"
+#include "common/logging.hpp"
+#include "thread/mle.hpp"
+#include "thread/thread_netif.hpp"
 
 #if OPENTHREAD_ENABLE_DHCP6_SERVER
 

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -34,13 +34,13 @@
 #ifndef DHCP6_SERVER_HPP_
 #define DHCP6_SERVER_HPP_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <mac/mac_frame.hpp>
-#include <mac/mac.hpp>
-#include <net/dhcp6.hpp>
-#include <net/udp6.hpp>
-#include <thread/network_data_leader.hpp>
+#include "mac/mac_frame.hpp"
+#include "mac/mac.hpp"
+#include "net/dhcp6.hpp"
+#include "net/udp6.hpp"
+#include "thread/network_data_leader.hpp"
 
 namespace ot {
 

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -32,12 +32,13 @@
 #include <openthread-config.h>
 #endif
 
+#include "dns_client.hpp"
+
 #include "utils/wrap_string.h"
 
-#include <common/debug.hpp>
-#include <common/code_utils.hpp>
-#include <net/dns_client.hpp>
-#include <net/udp6.hpp>
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "net/udp6.hpp"
 
 #if OPENTHREAD_ENABLE_DNS_CLIENT
 

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -32,11 +32,11 @@
 #include <openthread/dns.h>
 #include <openthread/types.h>
 
-#include <common/message.hpp>
-#include <common/timer.hpp>
-#include <net/dns_headers.hpp>
-#include <net/ip6.hpp>
-#include <net/netif.hpp>
+#include "common/message.hpp"
+#include "common/timer.hpp"
+#include "net/dns_headers.hpp"
+#include "net/ip6.hpp"
+#include "net/netif.hpp"
 
 /**
  * @file

--- a/src/core/net/dns_headers.hpp
+++ b/src/core/net/dns_headers.hpp
@@ -38,8 +38,8 @@
 
 #include <openthread/types.h>
 
-#include <common/encoding.hpp>
-#include <common/message.hpp>
+#include "common/encoding.hpp"
+#include "common/message.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -39,14 +39,15 @@
 #include <openthread-config.h>
 #endif
 
+#include "icmp6.hpp"
+
 #include "utils/wrap_string.h"
 
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <common/message.hpp>
-#include <net/icmp6.hpp>
-#include <net/ip6.hpp>
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/logging.hpp"
+#include "common/message.hpp"
+#include "net/ip6.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -35,8 +35,9 @@
 #define ICMP6_HPP_
 
 #include <openthread/types.h>
-#include <common/encoding.hpp>
-#include <net/ip6_headers.hpp>
+
+#include "common/encoding.hpp"
+#include "net/ip6_headers.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -39,18 +39,19 @@
 #include <openthread-config.h>
 #endif
 
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <common/message.hpp>
-#include <net/icmp6.hpp>
-#include <net/ip6.hpp>
-#include <net/ip6_address.hpp>
-#include <net/ip6_routes.hpp>
-#include <net/netif.hpp>
-#include <net/udp6.hpp>
-#include <thread/mle.hpp>
-#include <openthread-instance.h>
+#include "ip6.hpp"
+
+#include "openthread-instance.h"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/logging.hpp"
+#include "common/message.hpp"
+#include "net/icmp6.hpp"
+#include "net/ip6_address.hpp"
+#include "net/ip6_routes.hpp"
+#include "net/netif.hpp"
+#include "net/udp6.hpp"
+#include "thread/mle.hpp"
 
 namespace ot {
 namespace Ip6 {

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -36,19 +36,19 @@
 
 #include <stddef.h>
 
-#include "openthread/ip6.h"
-#include "openthread/udp.h"
+#include <openthread/ip6.h>
+#include <openthread/udp.h>
 
-#include <common/encoding.hpp>
-#include <common/message.hpp>
-#include <net/icmp6.hpp>
-#include <net/ip6_address.hpp>
-#include <net/ip6_headers.hpp>
-#include <net/ip6_routes.hpp>
-#include <net/ip6_mpl.hpp>
-#include <net/netif.hpp>
-#include <net/socket.hpp>
-#include <net/udp6.hpp>
+#include "common/encoding.hpp"
+#include "common/message.hpp"
+#include "net/icmp6.hpp"
+#include "net/ip6_address.hpp"
+#include "net/ip6_headers.hpp"
+#include "net/ip6_mpl.hpp"
+#include "net/ip6_routes.hpp"
+#include "net/netif.hpp"
+#include "net/socket.hpp"
+#include "net/udp6.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -37,13 +37,14 @@
 #include <openthread-config.h>
 #endif
 
+#include "ip6_address.hpp"
+
 #include <stdio.h>
 #include "utils/wrap_string.h"
 
-#include <common/code_utils.hpp>
-#include <common/encoding.hpp>
-#include <mac/mac_frame.hpp>
-#include <net/ip6_address.hpp>
+#include "common/code_utils.hpp"
+#include "common/encoding.hpp"
+#include "mac/mac_frame.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -36,7 +36,9 @@
 
 #include "utils/wrap_stdint.h"
 
-#include "openthread/types.h"
+#include <openthread/types.h>
+
+#include "mac/mac_frame.hpp"
 
 namespace ot {
 namespace Ip6 {

--- a/src/core/net/ip6_filter.cpp
+++ b/src/core/net/ip6_filter.cpp
@@ -37,14 +37,15 @@
 #include <openthread-config.h>
 #endif
 
+#include "ip6_filter.hpp"
+
 #include <stdio.h>
 
-#include <common/code_utils.hpp>
-#include <net/ip6.hpp>
-#include <net/ip6_filter.hpp>
-#include <net/udp6.hpp>
-#include <net/tcp.hpp>
-#include <thread/mle.hpp>
+#include "common/code_utils.hpp"
+#include "net/ip6.hpp"
+#include "net/tcp.hpp"
+#include "net/udp6.hpp"
+#include "thread/mle.hpp"
 
 namespace ot {
 namespace Ip6 {

--- a/src/core/net/ip6_filter.hpp
+++ b/src/core/net/ip6_filter.hpp
@@ -34,7 +34,9 @@
 #ifndef IP6_FILTER_HPP_
 #define IP6_FILTER_HPP_
 
-#include "openthread/openthread.h"
+#include <openthread/openthread.h>
+
+#include "common/message.hpp"
 
 namespace ot {
 namespace Ip6 {

--- a/src/core/net/ip6_headers.hpp
+++ b/src/core/net/ip6_headers.hpp
@@ -36,13 +36,13 @@
 
 #include <stddef.h>
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <common/encoding.hpp>
-#include <common/message.hpp>
-#include <net/ip6_address.hpp>
-#include <net/netif.hpp>
-#include <net/socket.hpp>
+#include "common/encoding.hpp"
+#include "common/message.hpp"
+#include "net/ip6_address.hpp"
+#include "net/netif.hpp"
+#include "net/socket.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -37,12 +37,13 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/platform/random.h"
+#include "ip6_mpl.hpp"
 
-#include <common/code_utils.hpp>
-#include <common/message.hpp>
-#include <net/ip6.hpp>
-#include <net/ip6_mpl.hpp>
+#include <openthread/platform/random.h>
+
+#include "common/code_utils.hpp"
+#include "common/message.hpp"
+#include "net/ip6.hpp"
 
 namespace ot {
 namespace Ip6 {

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -34,11 +34,11 @@
  *   This file includes definitions for MPL.
  */
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <common/message.hpp>
-#include <common/timer.hpp>
-#include <net/ip6_headers.hpp>
+#include "common/message.hpp"
+#include "common/timer.hpp"
+#include "net/ip6_headers.hpp"
 
 namespace ot {
 namespace Ip6 {

--- a/src/core/net/ip6_routes.cpp
+++ b/src/core/net/ip6_routes.cpp
@@ -37,11 +37,12 @@
 #include <openthread-config.h>
 #endif
 
-#include <net/ip6.hpp>
-#include <net/ip6_routes.hpp>
-#include <net/netif.hpp>
-#include <common/code_utils.hpp>
-#include <common/message.hpp>
+#include "ip6_routes.hpp"
+
+#include "common/code_utils.hpp"
+#include "common/message.hpp"
+#include "net/ip6.hpp"
+#include "net/netif.hpp"
 
 namespace ot {
 namespace Ip6 {

--- a/src/core/net/ip6_routes.hpp
+++ b/src/core/net/ip6_routes.hpp
@@ -34,13 +34,16 @@
  *   This file includes definitions for manipulating IPv6 routing tables.
  */
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <common/message.hpp>
-#include <net/ip6_address.hpp>
+#include "common/message.hpp"
+#include "net/ip6_address.hpp"
+#include "net/ip6_routes.hpp"
 
 namespace ot {
 namespace Ip6 {
+
+class Ip6;
 
 /**
  * @addtogroup core-ip6-ip6

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -36,11 +36,12 @@
 #include <openthread-config.h>
 #endif
 
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/message.hpp>
-#include <net/ip6.hpp>
-#include <net/netif.hpp>
+#include "netif.hpp"
+
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/message.hpp"
+#include "net/ip6.hpp"
 
 namespace ot {
 namespace Ip6 {

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -34,11 +34,11 @@
 #ifndef NET_NETIF_HPP_
 #define NET_NETIF_HPP_
 
-#include <common/message.hpp>
-#include <common/tasklet.hpp>
-#include <mac/mac_frame.hpp>
-#include <net/ip6_address.hpp>
-#include <net/socket.hpp>
+#include "common/message.hpp"
+#include "common/tasklet.hpp"
+#include "mac/mac_frame.hpp"
+#include "net/ip6_address.hpp"
+#include "net/socket.hpp"
 
 namespace ot {
 namespace Ip6 {

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -34,9 +34,9 @@
 #ifndef NET_SOCKET_HPP_
 #define NET_SOCKET_HPP_
 
-#include "openthread/openthread.h"
+#include <openthread/openthread.h>
 
-#include <net/ip6_address.hpp>
+#include "net/ip6_address.hpp"
 
 namespace ot {
 namespace Ip6 {

--- a/src/core/net/tcp.hpp
+++ b/src/core/net/tcp.hpp
@@ -34,9 +34,9 @@
 #ifndef TCP_HPP_
 #define TCP_HPP_
 
-#include "openthread/openthread.h"
+#include <openthread/openthread.h>
 
-#include <net/ip6_headers.hpp>
+#include "net/ip6_headers.hpp"
 
 namespace ot {
 namespace Ip6 {

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -37,12 +37,13 @@
 #include <openthread-config.h>
 #endif
 
+#include "udp6.hpp"
+
 #include <stdio.h>
 
-#include <common/code_utils.hpp>
-#include <common/encoding.hpp>
-#include <net/ip6.hpp>
-#include <net/udp6.hpp>
+#include "common/code_utils.hpp"
+#include "common/encoding.hpp"
+#include "net/ip6.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -34,9 +34,9 @@
 #ifndef UDP6_HPP_
 #define UDP6_HPP_
 
-#include "openthread/udp.h"
+#include <openthread/udp.h>
 
-#include <net/ip6_headers.hpp>
+#include "net/ip6_headers.hpp"
 
 namespace ot {
 namespace Ip6 {

--- a/src/core/openthread-core-config.h
+++ b/src/core/openthread-core-config.h
@@ -40,7 +40,7 @@
 #include OPENTHREAD_PROJECT_CORE_CONFIG_FILE
 #endif
 
-#include <openthread-core-default-config.h>
+#include "openthread-core-default-config.h"
 
 #undef OPENTHREAD_CORE_CONFIG_H_IN
 

--- a/src/core/openthread-instance.h
+++ b/src/core/openthread-instance.h
@@ -35,21 +35,28 @@
 #ifndef OPENTHREADINSTANCE_H_
 #define OPENTHREADINSTANCE_H_
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include "utils/wrap_stdint.h"
 #include "utils/wrap_stdbool.h"
 
-#include <openthread-core-config.h>
+#include <openthread/types.h>
+#include <openthread/platform/logging.h>
 
-#include "openthread/types.h"
-#include "openthread/platform/logging.h"
+#include "openthread-core-config.h"
 
-#include <crypto/mbedtls.hpp>
-#include <net/ip6.hpp>
-#include <thread/thread_netif.hpp>
-#include <coap/coap_server.hpp>
 #if OPENTHREAD_ENABLE_RAW_LINK_API
-#include <api/link_raw.hpp>
+#include "api/link_raw.hpp"
 #endif
+
+#include "coap/coap_server.hpp"
+#include "crypto/mbedtls.hpp"
+#include "net/ip6.hpp"
+#include "thread/thread_netif.hpp"
 
 /**
  * This type represents all the static / global variables used by OpenThread allocated in one place.

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -41,20 +41,21 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/platform/random.h"
+#include "address_resolver.hpp"
 
-#include <coap/coap_header.hpp>
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <common/encoding.hpp>
-#include <mac/mac_frame.hpp>
-#include <thread/address_resolver.hpp>
-#include <thread/mesh_forwarder.hpp>
-#include <thread/mle_router.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_tlvs.hpp>
-#include <thread/thread_uris.hpp>
+#include <openthread/platform/random.h>
+
+#include "coap/coap_header.hpp"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/encoding.hpp"
+#include "common/logging.hpp"
+#include "mac/mac_frame.hpp"
+#include "thread/mesh_forwarder.hpp"
+#include "thread/mle_router.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_tlvs.hpp"
+#include "thread/thread_uris.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -34,16 +34,15 @@
 #ifndef ADDRESS_RESOLVER_HPP_
 #define ADDRESS_RESOLVER_HPP_
 
-#include <openthread-core-config.h>
+#include <openthread/types.h>
 
-#include "openthread/types.h"
-
-#include <coap/coap_client.hpp>
-#include <coap/coap_server.hpp>
-#include <common/timer.hpp>
-#include <mac/mac.hpp>
-#include <net/icmp6.hpp>
-#include <net/udp6.hpp>
+#include "openthread-core-config.h"
+#include "coap/coap_client.hpp"
+#include "coap/coap_server.hpp"
+#include "common/timer.hpp"
+#include "mac/mac.hpp"
+#include "net/icmp6.hpp"
+#include "net/udp6.hpp"
 
 namespace ot {
 

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -39,16 +39,17 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/platform/radio.h"
+#include "announce_begin_server.hpp"
 
-#include <coap/coap_header.hpp>
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
-#include <thread/announce_begin_server.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_uris.hpp>
+#include <openthread/platform/radio.h>
+
+#include "coap/coap_header.hpp"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/logging.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_uris.hpp"
 
 using ot::Encoding::BigEndian::HostSwap32;
 

--- a/src/core/thread/announce_begin_server.hpp
+++ b/src/core/thread/announce_begin_server.hpp
@@ -34,14 +34,13 @@
 #ifndef ANNOUNCE_BEGIN_SERVER_HPP_
 #define ANNOUNCE_BEGIN_SERVER_HPP_
 
-#include <openthread-core-config.h>
+#include <openthread/types.h>
 
-#include "openthread/types.h"
-
-#include <coap/coap_client.hpp>
-#include <coap/coap_server.hpp>
-#include <common/timer.hpp>
-#include <net/ip6_address.hpp>
+#include "openthread-core-config.h"
+#include "coap/coap_client.hpp"
+#include "coap/coap_server.hpp"
+#include "common/timer.hpp"
+#include "net/ip6_address.hpp"
 
 namespace ot {
 

--- a/src/core/thread/data_poll_manager.cpp
+++ b/src/core/thread/data_poll_manager.cpp
@@ -31,25 +31,26 @@
  *   This file implements data poll (mac data request command) manager class.
  */
 
+#define WPP_NAME "data_poll_manager.tmh"
+
 #ifdef OPENTHREAD_CONFIG_FILE
 #include OPENTHREAD_CONFIG_FILE
 #else
 #include <openthread-config.h>
 #endif
 
-#define WPP_NAME "data_poll_manager.tmh"
+#include "data_poll_manager.hpp"
 
-#include "openthread/platform/random.h"
+#include <openthread/platform/random.h>
 
-#include <common/code_utils.hpp>
-#include <common/logging.hpp>
-#include <common/message.hpp>
-#include <net/ip6.hpp>
-#include <net/netif.hpp>
-#include <thread/data_poll_manager.hpp>
-#include <thread/mesh_forwarder.hpp>
-#include <thread/mle.hpp>
-#include <thread/thread_netif.hpp>
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+#include "common/message.hpp"
+#include "net/ip6.hpp"
+#include "net/netif.hpp"
+#include "thread/mesh_forwarder.hpp"
+#include "thread/mle.hpp"
+#include "thread/thread_netif.hpp"
 
 namespace ot {
 

--- a/src/core/thread/data_poll_manager.hpp
+++ b/src/core/thread/data_poll_manager.hpp
@@ -34,10 +34,12 @@
 #ifndef DATA_POLL_MANAGER_HPP_
 #define DATA_POLL_MANAGER_HPP_
 
-#include <openthread-core-config.h>
+#include <openthread/types.h>
 
-#include "openthread/types.h"
-#include <common/code_utils.hpp>
+#include "openthread-core-config.h"
+#include "common/code_utils.hpp"
+#include "common/timer.hpp"
+#include "mac/mac_frame.hpp"
 
 namespace ot {
 

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -31,25 +31,26 @@
  *   This file implements the Energy Scan Server.
  */
 
+#define WPP_NAME "energy_scan_server.tmh"
+
 #ifdef OPENTHREAD_CONFIG_FILE
 #include OPENTHREAD_CONFIG_FILE
 #else
 #include <openthread-config.h>
 #endif
 
-#define WPP_NAME "energy_scan_server.tmh"
+#include "energy_scan_server.hpp"
 
-#include "openthread/platform/random.h"
+#include <openthread/platform/random.h>
 
-#include <coap/coap_header.hpp>
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <meshcop/meshcop.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
-#include <thread/energy_scan_server.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_uris.hpp>
+#include "coap/coap_header.hpp"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/logging.hpp"
+#include "meshcop/meshcop.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_uris.hpp"
 
 namespace ot {
 

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -34,15 +34,14 @@
 #ifndef ENERGY_SCAN_SERVER_HPP_
 #define ENERGY_SCAN_SERVER_HPP_
 
-#include <openthread-core-config.h>
+#include <openthread/types.h>
 
-#include "openthread/types.h"
-
-#include <coap/coap_client.hpp>
-#include <coap/coap_server.hpp>
-#include <common/timer.hpp>
-#include <net/ip6_address.hpp>
-#include <net/udp6.hpp>
+#include "openthread-core-config.h"
+#include "coap/coap_client.hpp"
+#include "coap/coap_server.hpp"
+#include "common/timer.hpp"
+#include "net/ip6_address.hpp"
+#include "net/udp6.hpp"
 
 namespace ot {
 

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -38,12 +38,13 @@
 #include <openthread-config.h>
 #endif
 
-#include <common/code_utils.hpp>
-#include <common/timer.hpp>
-#include <crypto/hmac_sha256.hpp>
-#include <thread/key_manager.hpp>
-#include <thread/mle_router.hpp>
-#include <thread/thread_netif.hpp>
+#include "key_manager.hpp"
+
+#include "common/code_utils.hpp"
+#include "common/timer.hpp"
+#include "crypto/hmac_sha256.hpp"
+#include "thread/mle_router.hpp"
+#include "thread/thread_netif.hpp"
 
 namespace ot {
 

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -36,10 +36,10 @@
 
 #include "utils/wrap_stdint.h"
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <common/timer.hpp>
-#include <crypto/hmac_sha256.hpp>
+#include "common/timer.hpp"
+#include "crypto/hmac_sha256.hpp"
 
 namespace ot {
 

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -37,13 +37,14 @@
 #include <openthread-config.h>
 #endif
 
+#include "link_quality.hpp"
+
 #include <stdio.h>
 #include "utils/wrap_string.h"
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <common/code_utils.hpp>
-#include <thread/link_quality.hpp>
+#include "common/code_utils.hpp"
 
 namespace ot {
 

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -34,7 +34,9 @@
 #ifndef LINK_QUALITY_HPP_
 #define LINK_QUALITY_HPP_
 
-#include "openthread/types.h"
+#include <stdio.h>
+
+#include <openthread/types.h>
 
 namespace ot {
 

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -37,14 +37,15 @@
 #include <openthread-config.h>
 #endif
 
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/encoding.hpp>
-#include <net/ip6.hpp>
-#include <net/udp6.hpp>
-#include <thread/lowpan.hpp>
-#include <thread/network_data_leader.hpp>
-#include <thread/thread_netif.hpp>
+#include "lowpan.hpp"
+
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/encoding.hpp"
+#include "net/ip6.hpp"
+#include "net/udp6.hpp"
+#include "thread/network_data_leader.hpp"
+#include "thread/thread_netif.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -34,10 +34,10 @@
 #ifndef LOWPAN_HPP_
 #define LOWPAN_HPP_
 
-#include <common/message.hpp>
-#include <mac/mac_frame.hpp>
-#include <net/ip6.hpp>
-#include <net/ip6_address.hpp>
+#include "common/message.hpp"
+#include "mac/mac_frame.hpp"
+#include "net/ip6.hpp"
+#include "net/ip6_address.hpp"
 
 namespace ot {
 

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -39,22 +39,23 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/platform/random.h"
+#include "mesh_forwarder.hpp"
 
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <common/encoding.hpp>
-#include <common/message.hpp>
-#include <net/ip6.hpp>
-#include <net/ip6_filter.hpp>
-#include <net/tcp.hpp>
-#include <net/udp6.hpp>
-#include <net/netif.hpp>
-#include <thread/mesh_forwarder.hpp>
-#include <thread/mle_router.hpp>
-#include <thread/mle.hpp>
-#include <thread/thread_netif.hpp>
+#include <openthread/platform/random.h>
+
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/encoding.hpp"
+#include "common/logging.hpp"
+#include "common/message.hpp"
+#include "net/ip6.hpp"
+#include "net/ip6_filter.hpp"
+#include "net/netif.hpp"
+#include "net/tcp.hpp"
+#include "net/udp6.hpp"
+#include "thread/mle.hpp"
+#include "thread/mle_router.hpp"
+#include "thread/thread_netif.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -34,19 +34,18 @@
 #ifndef MESH_FORWARDER_HPP_
 #define MESH_FORWARDER_HPP_
 
-#include <openthread-core-config.h>
+#include <openthread/types.h>
 
-#include "openthread/types.h"
-
-#include <common/tasklet.hpp>
-#include <mac/mac.hpp>
-#include <net/ip6.hpp>
-#include <thread/address_resolver.hpp>
-#include <thread/data_poll_manager.hpp>
-#include <thread/src_match_controller.hpp>
-#include <thread/lowpan.hpp>
-#include <thread/network_data_leader.hpp>
-#include <thread/topology.hpp>
+#include "openthread-core-config.h"
+#include "common/tasklet.hpp"
+#include "mac/mac.hpp"
+#include "net/ip6.hpp"
+#include "thread/address_resolver.hpp"
+#include "thread/data_poll_manager.hpp"
+#include "thread/lowpan.hpp"
+#include "thread/network_data_leader.hpp"
+#include "thread/src_match_controller.hpp"
+#include "thread/topology.hpp"
 
 namespace ot {
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -31,33 +31,34 @@
  *   This file implements MLE functionality required for the Thread Child, Router and Leader roles.
  */
 
+#define WPP_NAME "mle.tmh"
+
 #ifdef OPENTHREAD_CONFIG_FILE
 #include OPENTHREAD_CONFIG_FILE
 #else
 #include <openthread-config.h>
 #endif
 
-#define WPP_NAME "mle.tmh"
+#include "mle.hpp"
 
-#include "openthread/platform/radio.h"
-#include "openthread/platform/random.h"
-#include "openthread/platform/settings.h"
+#include <openthread/platform/radio.h>
+#include <openthread/platform/random.h>
+#include <openthread/platform/settings.h>
 
-#include <thread/mle.hpp>
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <common/encoding.hpp>
-#include <common/settings.hpp>
-#include <crypto/aes_ccm.hpp>
-#include <mac/mac_frame.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
-#include <net/netif.hpp>
-#include <net/udp6.hpp>
-#include <thread/address_resolver.hpp>
-#include <thread/key_manager.hpp>
-#include <thread/mle_router.hpp>
-#include <thread/thread_netif.hpp>
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/encoding.hpp"
+#include "common/logging.hpp"
+#include "common/settings.hpp"
+#include "crypto/aes_ccm.hpp"
+#include "mac/mac_frame.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "net/netif.hpp"
+#include "net/udp6.hpp"
+#include "thread/address_resolver.hpp"
+#include "thread/key_manager.hpp"
+#include "thread/mle_router.hpp"
+#include "thread/thread_netif.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -34,16 +34,16 @@
 #ifndef MLE_HPP_
 #define MLE_HPP_
 
-#include "openthread/openthread.h"
+#include <openthread/openthread.h>
 
-#include <common/encoding.hpp>
-#include <common/timer.hpp>
-#include <mac/mac.hpp>
-#include <net/udp6.hpp>
-#include <thread/mle_constants.hpp>
-#include <thread/mle_tlvs.hpp>
-#include <thread/topology.hpp>
-#include <meshcop/joiner_router.hpp>
+#include "common/encoding.hpp"
+#include "common/timer.hpp"
+#include "mac/mac.hpp"
+#include "meshcop/joiner_router.hpp"
+#include "net/udp6.hpp"
+#include "thread/mle_constants.hpp"
+#include "thread/mle_tlvs.hpp"
+#include "thread/topology.hpp"
 
 namespace ot {
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -40,20 +40,21 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/platform/random.h"
-#include "openthread/platform/settings.h"
+#include "mle_router.hpp"
 
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <common/encoding.hpp>
-#include <common/settings.hpp>
-#include <mac/mac_frame.hpp>
-#include <net/icmp6.hpp>
-#include <thread/mle_router.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_tlvs.hpp>
-#include <thread/thread_uris.hpp>
+#include <openthread/platform/random.h>
+#include <openthread/platform/settings.h>
+
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/encoding.hpp"
+#include "common/logging.hpp"
+#include "common/settings.hpp"
+#include "mac/mac_frame.hpp"
+#include "net/icmp6.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_tlvs.hpp"
+#include "thread/thread_uris.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -36,19 +36,19 @@
 
 #include "utils/wrap_string.h"
 
-#include <coap/coap_header.hpp>
-#include <coap/coap_server.hpp>
-#include <coap/coap_client.hpp>
-#include <common/timer.hpp>
-#include <common/trickle_timer.hpp>
-#include <mac/mac_frame.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
-#include <net/icmp6.hpp>
-#include <net/udp6.hpp>
-#include <thread/mle.hpp>
-#include <thread/mle_tlvs.hpp>
-#include <thread/thread_tlvs.hpp>
-#include <thread/topology.hpp>
+#include "coap/coap_client.hpp"
+#include "coap/coap_header.hpp"
+#include "coap/coap_server.hpp"
+#include "common/timer.hpp"
+#include "common/trickle_timer.hpp"
+#include "mac/mac_frame.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "net/icmp6.hpp"
+#include "net/udp6.hpp"
+#include "thread/mle.hpp"
+#include "thread/mle_tlvs.hpp"
+#include "thread/thread_tlvs.hpp"
+#include "thread/topology.hpp"
 
 namespace ot {
 namespace Mle {

--- a/src/core/thread/mle_router_mtd.hpp
+++ b/src/core/thread/mle_router_mtd.hpp
@@ -36,9 +36,9 @@
 
 #include "utils/wrap_string.h"
 
-#include <thread/mle.hpp>
-#include <thread/mle_tlvs.hpp>
-#include <thread/thread_tlvs.hpp>
+#include "thread/mle.hpp"
+#include "thread/mle_tlvs.hpp"
+#include "thread/thread_tlvs.hpp"
 
 namespace ot {
 namespace Mle {

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -36,14 +36,14 @@
 
 #include "utils/wrap_string.h"
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <common/encoding.hpp>
-#include <common/message.hpp>
-#include <common/tlvs.hpp>
-#include <meshcop/timestamp.hpp>
-#include <net/ip6_address.hpp>
-#include <thread/mle_constants.hpp>
+#include "common/encoding.hpp"
+#include "common/message.hpp"
+#include "common/tlvs.hpp"
+#include "meshcop/timestamp.hpp"
+#include "net/ip6_address.hpp"
+#include "thread/mle_constants.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -39,17 +39,18 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/platform/random.h"
+#include "network_data.hpp"
 
-#include <coap/coap_header.hpp>
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <mac/mac_frame.hpp>
-#include <thread/network_data.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_tlvs.hpp>
-#include <thread/thread_uris.hpp>
+#include <openthread/platform/random.h>
+
+#include "coap/coap_header.hpp"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/logging.hpp"
+#include "mac/mac_frame.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_tlvs.hpp"
+#include "thread/thread_uris.hpp"
 
 namespace ot {
 namespace NetworkData {

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -34,13 +34,13 @@
 #ifndef NETWORK_DATA_HPP_
 #define NETWORK_DATA_HPP_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <coap/coap_client.hpp>
-#include <net/udp6.hpp>
-#include <thread/lowpan.hpp>
-#include <thread/mle_router.hpp>
-#include <thread/network_data_tlvs.hpp>
+#include "coap/coap_client.hpp"
+#include "net/udp6.hpp"
+#include "thread/lowpan.hpp"
+#include "thread/mle_router.hpp"
+#include "thread/network_data_tlvs.hpp"
 
 namespace ot {
 

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -39,22 +39,23 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/platform/random.h"
+#include "network_data_leader.hpp"
 
-#include <coap/coap_header.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <common/code_utils.hpp>
-#include <common/encoding.hpp>
-#include <common/message.hpp>
-#include <common/timer.hpp>
-#include <mac/mac_frame.hpp>
-#include <thread/mle_router.hpp>
-#include <thread/network_data_leader.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_tlvs.hpp>
-#include <thread/thread_uris.hpp>
-#include <thread/lowpan.hpp>
+#include <openthread/platform/random.h>
+
+#include "coap/coap_header.hpp"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/encoding.hpp"
+#include "common/logging.hpp"
+#include "common/message.hpp"
+#include "common/timer.hpp"
+#include "mac/mac_frame.hpp"
+#include "thread/mle_router.hpp"
+#include "thread/lowpan.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_tlvs.hpp"
+#include "thread/thread_uris.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -36,11 +36,11 @@
 
 #include "utils/wrap_stdint.h"
 
-#include <coap/coap_server.hpp>
-#include <common/timer.hpp>
-#include <net/ip6_address.hpp>
-#include <thread/mle_router.hpp>
-#include <thread/network_data.hpp>
+#include "coap/coap_server.hpp"
+#include "common/timer.hpp"
+#include "net/ip6_address.hpp"
+#include "thread/mle_router.hpp"
+#include "thread/network_data.hpp"
 
 namespace ot {
 

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -33,31 +33,32 @@
 
 #if OPENTHREAD_FTD
 
+#define WPP_NAME "network_data_leader_ftd.tmh"
+
 #ifdef OPENTHREAD_CONFIG_FILE
 #include OPENTHREAD_CONFIG_FILE
 #else
 #include <openthread-config.h>
 #endif
 
-#define WPP_NAME "network_data_leader_ftd.tmh"
+#include "network_data_leader.hpp"
 
-#include "openthread/platform/random.h"
+#include <openthread/platform/random.h>
 
-#include <coap/coap_header.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <common/code_utils.hpp>
-#include <common/encoding.hpp>
-#include <common/message.hpp>
-#include <common/timer.hpp>
-#include <mac/mac_frame.hpp>
-#include <meshcop/meshcop.hpp>
-#include <thread/mle_router.hpp>
-#include <thread/network_data_leader.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_tlvs.hpp>
-#include <thread/thread_uris.hpp>
-#include <thread/lowpan.hpp>
+#include "coap/coap_header.hpp"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/encoding.hpp"
+#include "common/logging.hpp"
+#include "common/message.hpp"
+#include "common/timer.hpp"
+#include "mac/mac_frame.hpp"
+#include "meshcop/meshcop.hpp"
+#include "thread/lowpan.hpp"
+#include "thread/mle_router.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_tlvs.hpp"
+#include "thread/thread_uris.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -36,11 +36,11 @@
 
 #include "utils/wrap_stdint.h"
 
-#include <coap/coap_server.hpp>
-#include <common/timer.hpp>
-#include <net/ip6_address.hpp>
-#include <thread/mle_router.hpp>
-#include <thread/network_data.hpp>
+#include "coap/coap_server.hpp"
+#include "common/timer.hpp"
+#include "net/ip6_address.hpp"
+#include "thread/mle_router.hpp"
+#include "thread/network_data.hpp"
 
 namespace ot {
 

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -39,12 +39,13 @@
 #include <openthread-config.h>
 #endif
 
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <common/code_utils.hpp>
-#include <mac/mac_frame.hpp>
-#include <thread/network_data_local.hpp>
-#include <thread/thread_netif.hpp>
+#include "network_data_local.hpp"
+
+#include "common/debug.hpp"
+#include "common/logging.hpp"
+#include "common/code_utils.hpp"
+#include "mac/mac_frame.hpp"
+#include "thread/thread_netif.hpp"
 
 namespace ot {
 namespace NetworkData {

--- a/src/core/thread/network_data_local_ftd.hpp
+++ b/src/core/thread/network_data_local_ftd.hpp
@@ -34,7 +34,7 @@
 #ifndef NETWORK_DATA_LOCAL_HPP_
 #define NETWORK_DATA_LOCAL_HPP_
 
-#include <thread/network_data.hpp>
+#include "thread/network_data.hpp"
 
 namespace ot {
 

--- a/src/core/thread/network_data_local_mtd.hpp
+++ b/src/core/thread/network_data_local_mtd.hpp
@@ -34,7 +34,7 @@
 #ifndef NETWORK_DATA_LOCAL_HPP_
 #define NETWORK_DATA_LOCAL_HPP_
 
-#include <thread/network_data.hpp>
+#include "thread/network_data.hpp"
 
 namespace ot {
 

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -36,8 +36,8 @@
 
 #include "utils/wrap_string.h"
 
-#include <common/encoding.hpp>
-#include <net/ip6_address.hpp>
+#include "common/encoding.hpp"
+#include "net/ip6_address.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -39,22 +39,23 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/platform/random.h"
+#include "network_diagnostic.hpp"
 
-#include <coap/coap_header.hpp>
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <common/encoding.hpp>
-#include <mac/mac_frame.hpp>
-#include <net/netif.hpp>
-#include <thread/mesh_forwarder.hpp>
-#include <thread/mle_router.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_tlvs.hpp>
-#include <thread/thread_uris.hpp>
-#include <thread/network_diagnostic.hpp>
-#include <thread/network_diagnostic_tlvs.hpp>
+#include <openthread/platform/random.h>
+
+#include "coap/coap_header.hpp"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/logging.hpp"
+#include "common/encoding.hpp"
+#include "mac/mac_frame.hpp"
+#include "net/netif.hpp"
+#include "thread/mesh_forwarder.hpp"
+#include "thread/mle_router.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_tlvs.hpp"
+#include "thread/thread_uris.hpp"
+#include "thread/network_diagnostic_tlvs.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -34,13 +34,12 @@
 #ifndef NETWORK_DIAGNOSTIC_HPP_
 #define NETWORK_DIAGNOSTIC_HPP_
 
-#include <openthread-core-config.h>
+#include <openthread/types.h>
 
-#include "openthread/types.h"
-
-#include <coap/coap_client.hpp>
-#include <coap/coap_server.hpp>
-#include <net/udp6.hpp>
+#include "openthread-core-config.h"
+#include "coap/coap_client.hpp"
+#include "coap/coap_server.hpp"
+#include "net/udp6.hpp"
 
 namespace ot {
 

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -36,14 +36,14 @@
 
 #include "utils/wrap_string.h"
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <common/encoding.hpp>
-#include <common/message.hpp>
-#include <common/tlvs.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
-#include <net/ip6_address.hpp>
-#include <thread/mle_constants.hpp>
+#include "common/encoding.hpp"
+#include "common/message.hpp"
+#include "common/tlvs.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "net/ip6_address.hpp"
+#include "thread/mle_constants.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -31,25 +31,26 @@
  *   This file implements the PAN ID Query Server.
  */
 
+#define WPP_NAME "panid_query_server.tmh"
+
 #ifdef OPENTHREAD_CONFIG_FILE
 #include OPENTHREAD_CONFIG_FILE
 #else
 #include <openthread-config.h>
 #endif
 
-#define WPP_NAME "panid_query_server.tmh"
+#include "panid_query_server.hpp"
 
-#include "openthread/platform/random.h"
+#include <openthread/platform/random.h>
 
-#include <coap/coap_header.hpp>
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <meshcop/meshcop.hpp>
-#include <meshcop/meshcop_tlvs.hpp>
-#include <thread/panid_query_server.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_uris.hpp>
+#include "coap/coap_header.hpp"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/logging.hpp"
+#include "meshcop/meshcop.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+#include "thread/thread_netif.hpp"
+#include "thread/thread_uris.hpp"
 
 namespace ot {
 

--- a/src/core/thread/panid_query_server.hpp
+++ b/src/core/thread/panid_query_server.hpp
@@ -34,15 +34,14 @@
 #ifndef PANID_QUERY_SERVER_HPP_
 #define PANID_QUERY_SERVER_HPP_
 
-#include <openthread-core-config.h>
+#include <openthread/types.h>
 
-#include "openthread/types.h"
-
-#include <coap/coap_client.hpp>
-#include <coap/coap_server.hpp>
-#include <common/timer.hpp>
-#include <net/ip6_address.hpp>
-#include <net/udp6.hpp>
+#include "openthread-core-config.h"
+#include "coap/coap_client.hpp"
+#include "coap/coap_server.hpp"
+#include "common/timer.hpp"
+#include "net/ip6_address.hpp"
+#include "net/udp6.hpp"
 
 namespace ot {
 

--- a/src/core/thread/src_match_controller.cpp
+++ b/src/core/thread/src_match_controller.cpp
@@ -39,12 +39,13 @@
 #include <openthread-config.h>
 #endif
 
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <thread/mesh_forwarder.hpp>
-#include <thread/src_match_controller.hpp>
-#include <thread/thread_netif.hpp>
+#include "src_match_controller.hpp"
+
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/logging.hpp"
+#include "thread/mesh_forwarder.hpp"
+#include "thread/thread_netif.hpp"
 
 namespace ot {
 

--- a/src/core/thread/src_match_controller.hpp
+++ b/src/core/thread/src_match_controller.hpp
@@ -34,10 +34,10 @@
 #ifndef SOURCE_MATCH_CONTROLLER_HPP_
 #define SOURCE_MATCH_CONTROLLER_HPP_
 
-#include <openthread-core-config.h>
+#include <openthread/types.h>
 
-#include "openthread/types.h"
-#include <thread/topology.hpp>
+#include "openthread-core-config.h"
+#include "thread/topology.hpp"
 
 namespace ot {
 

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -38,17 +38,18 @@
 #include <openthread-config.h>
 #endif
 
-#include <common/code_utils.hpp>
-#include <common/encoding.hpp>
-#include <common/message.hpp>
-#include <net/ip6.hpp>
-#include <net/netif.hpp>
-#include <net/udp6.hpp>
-#include <thread/mle.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/thread_tlvs.hpp>
-#include <thread/thread_uris.hpp>
-#include <openthread-instance.h>
+#include "thread_netif.hpp"
+
+#include "openthread-instance.h"
+#include "common/code_utils.hpp"
+#include "common/encoding.hpp"
+#include "common/message.hpp"
+#include "net/ip6.hpp"
+#include "net/netif.hpp"
+#include "net/udp6.hpp"
+#include "thread/mle.hpp"
+#include "thread/thread_tlvs.hpp"
+#include "thread/thread_uris.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -40,53 +40,55 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <coap/coap_server.hpp>
-#include <coap/coap_client.hpp>
-#include <coap/secure_coap_client.hpp>
-#include <coap/secure_coap_server.hpp>
-#include <mac/mac.hpp>
-#include <meshcop/dataset_manager.hpp>
-#include <meshcop/joiner_router.hpp>
-#include <meshcop/leader.hpp>
-#include <net/dhcp6.hpp>
-#include <net/dhcp6_client.hpp>
-#include <net/dhcp6_server.hpp>
-#include <net/dns_client.hpp>
-#include <net/ip6_filter.hpp>
-#include <net/netif.hpp>
-#include <thread/address_resolver.hpp>
-#include <thread/announce_begin_server.hpp>
-#include <thread/energy_scan_server.hpp>
-#include <thread/network_diagnostic.hpp>
-#include <thread/key_manager.hpp>
-#include <thread/mesh_forwarder.hpp>
-#include <thread/mle.hpp>
-#include <thread/mle_router.hpp>
-#include <thread/network_data_local.hpp>
-#include <thread/panid_query_server.hpp>
-#include <utils/child_supervision.hpp>
-
-#if OPENTHREAD_ENABLE_JAM_DETECTION
-#include <utils/jam_detector.hpp>
-#endif // OPENTHREAD_ENABLE_JAM_DETECTION
+#include "coap/coap_client.hpp"
+#include "coap/coap_server.hpp"
+#include "coap/secure_coap_client.hpp"
+#include "coap/secure_coap_server.hpp"
+#include "mac/mac.hpp"
 
 #if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
-#include <meshcop/border_agent_proxy.hpp>
+#include "meshcop/border_agent_proxy.hpp"
 #endif // OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
 
 #if OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
-#include <meshcop/commissioner.hpp>
+#include "meshcop/commissioner.hpp"
 #endif  // OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
 
+#include "meshcop/dataset_manager.hpp"
+
 #if OPENTHREAD_ENABLE_DTLS
-#include <meshcop/dtls.hpp>
+#include "meshcop/dtls.hpp"
 #endif  // OPENTHREAD_ENABLE_DTLS
 
 #if OPENTHREAD_ENABLE_JOINER
-#include <meshcop/joiner.hpp>
+#include "meshcop/joiner.hpp"
 #endif  // OPENTHREAD_ENABLE_JOINER
+
+#include "meshcop/joiner_router.hpp"
+#include "meshcop/leader.hpp"
+#include "net/dhcp6.hpp"
+#include "net/dhcp6_client.hpp"
+#include "net/dhcp6_server.hpp"
+#include "net/dns_client.hpp"
+#include "net/ip6_filter.hpp"
+#include "net/netif.hpp"
+#include "thread/address_resolver.hpp"
+#include "thread/announce_begin_server.hpp"
+#include "thread/energy_scan_server.hpp"
+#include "thread/network_diagnostic.hpp"
+#include "thread/key_manager.hpp"
+#include "thread/mesh_forwarder.hpp"
+#include "thread/mle.hpp"
+#include "thread/mle_router.hpp"
+#include "thread/network_data_local.hpp"
+#include "thread/panid_query_server.hpp"
+#include "utils/child_supervision.hpp"
+
+#if OPENTHREAD_ENABLE_JAM_DETECTION
+#include "utils/jam_detector.hpp"
+#endif // OPENTHREAD_ENABLE_JAM_DETECTION
 
 namespace ot {
 

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -34,13 +34,13 @@
 #ifndef THREAD_TLVS_HPP_
 #define THREAD_TLVS_HPP_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
-#include <common/encoding.hpp>
-#include <common/message.hpp>
-#include <common/tlvs.hpp>
-#include <net/ip6_address.hpp>
-#include <thread/mle.hpp>
+#include "common/encoding.hpp"
+#include "common/message.hpp"
+#include "common/tlvs.hpp"
+#include "net/ip6_address.hpp"
+#include "thread/mle.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -39,10 +39,11 @@
 #include <openthread-config.h>
 #endif
 
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <common/logging.hpp>
-#include <thread/topology.hpp>
+#include "topology.hpp"
+
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/logging.hpp"
 
 namespace ot {
 

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -34,13 +34,14 @@
 #ifndef TOPOLOGY_HPP_
 #define TOPOLOGY_HPP_
 
-#include <openthread-core-config.h>
 #include <openthread/platform/random.h>
-#include <mac/mac_frame.hpp>
-#include <net/ip6.hpp>
-#include <thread/mle_tlvs.hpp>
-#include <thread/link_quality.hpp>
-#include <common/message.hpp>
+
+#include "openthread-core-config.h"
+#include "common/message.hpp"
+#include "mac/mac_frame.hpp"
+#include "net/ip6.hpp"
+#include "thread/link_quality.hpp"
+#include "thread/mle_tlvs.hpp"
 
 namespace ot {
 

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -37,12 +37,13 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/openthread.h"
-#include "openthread/platform/random.h"
+#include "jam_detector.hpp"
 
-#include <thread/thread_netif.hpp>
-#include <common/code_utils.hpp>
-#include <utils/jam_detector.hpp>
+#include <openthread/openthread.h>
+#include <openthread/platform/random.h>
+
+#include "common/code_utils.hpp"
+#include "thread/thread_netif.hpp"
 
 #if OPENTHREAD_ENABLE_JAM_DETECTION
 

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -41,7 +41,8 @@
 #endif
 
 #include "utils/wrap_stdint.h"
-#include <common/timer.hpp>
+
+#include "common/timer.hpp"
 
 namespace ot {
 

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -37,16 +37,17 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/openthread.h"
-
-#include <common/debug.hpp>
-#include <common/code_utils.hpp>
-#include <crypto/sha256.hpp>
-#include <mac/mac.hpp>
-#include <net/ip6_address.hpp>
-#include <utils/slaac_address.hpp>
+#include "slaac_address.hpp"
 
 #include "utils/wrap_string.h"
+
+#include <openthread/openthread.h>
+
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "crypto/sha256.hpp"
+#include "mac/mac.hpp"
+#include "net/ip6_address.hpp"
 
 namespace ot {
 namespace Utils {

--- a/src/core/utils/slaac_address.hpp
+++ b/src/core/utils/slaac_address.hpp
@@ -34,8 +34,8 @@
 #ifndef SLAAC_ADDRESS_HPP_
 #define SLAAC_ADDRESS_HPP_
 
-#include "openthread/types.h"
-#include "openthread/platform/random.h"
+#include <openthread/types.h>
+#include <openthread/platform/random.h>
 
 namespace ot {
 namespace Utils {

--- a/src/diag/diag_process.cpp
+++ b/src/diag/diag_process.cpp
@@ -40,9 +40,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "utils/wrap_string.h"
-#include <common/code_utils.hpp>
 
 #include "diag_process.hpp"
+#include "common/code_utils.hpp"
 
 namespace ot {
 namespace Diagnostics {

--- a/src/diag/diag_process.hpp
+++ b/src/diag/diag_process.hpp
@@ -36,10 +36,10 @@
 
 #include <stdarg.h>
 
-#include "openthread/types.h"
-#include "openthread/platform/radio.h"
-#include "openthread/platform/alarm.h"
-#include "openthread/platform/diag.h"
+#include <openthread/types.h>
+#include <openthread/platform/alarm.h>
+#include <openthread/platform/diag.h>
+#include <openthread/platform/radio.h>
 
 namespace ot {
 

--- a/src/diag/openthread-diag.cpp
+++ b/src/diag/openthread-diag.cpp
@@ -35,8 +35,9 @@
 #include <stdlib.h>
 #include "utils/wrap_string.h"
 
-#include "openthread/diag.h"
-#include <diag_process.hpp>
+#include <openthread/diag.h>
+
+#include "diag_process.hpp"
 
 using namespace ot::Diagnostics;
 

--- a/src/ncp/hdlc.cpp
+++ b/src/ncp/hdlc.cpp
@@ -36,9 +36,11 @@
 #include <openthread-config.h>
 #endif
 
+#include "hdlc.hpp"
+
 #include <stdlib.h>
-#include <common/code_utils.hpp>
-#include <ncp/hdlc.hpp>
+
+#include "common/code_utils.hpp"
 
 #if OPENTHREAD_ENABLE_NCP_UART
 

--- a/src/ncp/hdlc.hpp
+++ b/src/ncp/hdlc.hpp
@@ -33,7 +33,7 @@
 #ifndef HDLC_HPP_
 #define HDLC_HPP_
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 namespace ot {
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -36,38 +36,40 @@
 #include <openthread-config.h>
 #endif
 
+#include "ncp_base.hpp"
+
+#include <stdarg.h>
 #include <stdlib.h>
 
-#include "openthread/openthread.h"
-#include "openthread/ncp.h"
-#include "openthread/diag.h"
-#include "openthread/icmp6.h"
-
 #if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
-#include "openthread/border_agent_proxy.h"
-#endif
-
-#if OPENTHREAD_FTD
-#include "openthread/thread_ftd.h"
-#endif
-
-#if OPENTHREAD_ENABLE_JAM_DETECTION
-#include "openthread/jam_detection.h"
+#include <openthread/border_agent_proxy.h>
 #endif
 
 #if OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
-#include "meshcop/commissioner.hpp"
+#include <meshcop/commissioner.hpp>
 #endif
 
-#include "openthread/platform/radio.h"
-#include "openthread/platform/misc.h"
+#include <openthread/diag.h>
+#include <openthread/icmp6.h>
 
-#include <common/code_utils.hpp>
-#include <common/debug.hpp>
-#include <ncp/ncp_base.hpp>
-#include <net/ip6.hpp>
-#include <openthread-instance.h>
-#include <stdarg.h>
+#if OPENTHREAD_ENABLE_JAM_DETECTION
+#include <openthread/jam_detection.h>
+#endif
+
+#include <openthread/ncp.h>
+#include <openthread/openthread.h>
+
+#if OPENTHREAD_FTD
+#include <openthread/thread_ftd.h>
+#endif
+
+#include <openthread/platform/misc.h>
+#include <openthread/platform/radio.h>
+
+#include "openthread-instance.h"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "net/ip6.hpp"
 
 namespace ot
 {

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -39,15 +39,15 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/types.h"
-#include "openthread/message.h"
-#include "openthread/ip6.h"
-#include "openthread/ncp.h"
+#include <openthread/ip6.h>
+#include <openthread/message.h>
+#include <openthread/ncp.h>
+#include <openthread/types.h>
 
-#include <common/tasklet.hpp>
-#include <ncp/ncp_buffer.hpp>
-
+#include "openthread-core-config.h"
 #include "spinel.h"
+#include "common/tasklet.hpp"
+#include "ncp/ncp_buffer.hpp"
 
 namespace ot {
 

--- a/src/ncp/ncp_buffer.cpp
+++ b/src/ncp/ncp_buffer.cpp
@@ -36,9 +36,11 @@
 #include <openthread-config.h>
 #endif
 
+#include "ncp_buffer.hpp"
+
 #include "utils/wrap_string.h"
-#include <common/code_utils.hpp>
-#include <ncp/ncp_buffer.hpp>
+
+#include "common/code_utils.hpp"
 
 namespace ot {
 

--- a/src/ncp/ncp_buffer.hpp
+++ b/src/ncp/ncp_buffer.hpp
@@ -33,8 +33,8 @@
 #ifndef NCP_FRAME_BUFFER_HPP_
 #define NCP_FRAME_BUFFER_HPP_
 
-#include "openthread/types.h"
-#include "openthread/message.h"
+#include <openthread/message.h>
+#include <openthread/types.h>
 
 namespace ot {
 

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -36,16 +36,17 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/ncp.h"
-#include "openthread/platform/spi-slave.h"
+#include "ncp_spi.hpp"
 
-#include <common/code_utils.hpp>
-#include <common/new.hpp>
-#include <common/debug.hpp>
-#include <net/ip6.hpp>
-#include <ncp/ncp_spi.hpp>
-#include <core/openthread-core-config.h>
-#include <openthread-instance.h>
+#include <openthread/ncp.h>
+#include <openthread/platform/spi-slave.h>
+
+#include "openthread-core-config.h"
+#include "openthread-instance.h"
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/new.hpp"
+#include "net/ip6.hpp"
 
 #define SPI_RESET_FLAG          0x80
 #define SPI_CRC_FLAG            0x40

--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -39,7 +39,7 @@
 #include <openthread-config.h>
 #endif
 
-#include <ncp/ncp_base.hpp>
+#include "ncp/ncp_base.hpp"
 
 namespace ot {
 

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -36,18 +36,20 @@
 #include <openthread-config.h>
 #endif
 
-#include "openthread/ncp.h"
-#include "openthread/platform/logging.h"
-#include "openthread/platform/uart.h"
+#include "ncp_uart.hpp"
 
 #include <stdio.h>
-#include <common/code_utils.hpp>
-#include <common/new.hpp>
-#include <common/debug.hpp>
-#include <net/ip6.hpp>
-#include <ncp/ncp_uart.hpp>
-#include <core/openthread-core-config.h>
-#include <openthread-instance.h>
+
+#include <openthread/ncp.h>
+#include <openthread/platform/logging.h>
+#include <openthread/platform/uart.h>
+
+#include "openthread-core-config.h"
+#include "openthread-instance.h"
+#include "common/code_utils.hpp"
+#include "common/new.hpp"
+#include "common/debug.hpp"
+#include "net/ip6.hpp"
 
 #if OPENTHREAD_ENABLE_NCP_UART
 

--- a/src/ncp/ncp_uart.hpp
+++ b/src/ncp/ncp_uart.hpp
@@ -39,8 +39,8 @@
 #include <openthread-config.h>
 #endif
 
-#include <ncp/ncp_base.hpp>
-#include <ncp/hdlc.hpp>
+#include "ncp/hdlc.hpp"
+#include "ncp/ncp_base.hpp"
 
 namespace ot {
 

--- a/tests/unit/test_aes.cpp
+++ b/tests/unit/test_aes.cpp
@@ -26,12 +26,15 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "test_util.h"
-#include "openthread/openthread.h"
-#include <common/debug.hpp>
-#include <crypto/aes_ccm.hpp>
-#include <crypto/mbedtls.hpp>
 #include "utils/wrap_string.h"
+
+#include <openthread/openthread.h>
+
+#include "common/debug.hpp"
+#include "crypto/aes_ccm.hpp"
+#include "crypto/mbedtls.hpp"
+
+#include "test_util.h"
 
 #ifndef OPENTHREAD_MULTIPLE_INSTANCE
 static ot::Crypto::MbedTls mbedtls;

--- a/tests/unit/test_diag.cpp
+++ b/tests/unit/test_diag.cpp
@@ -26,12 +26,13 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "test_util.h"
 #include "utils/wrap_string.h"
 
-#include "openthread/diag.h"
-#include "openthread/platform/platform.h"
-#include "openthread/platform/radio.h"
+#include <openthread/diag.h>
+#include <openthread/platform/platform.h>
+#include <openthread/platform/radio.h>
+
+#include "test_util.h"
 
 extern "C" void otTaskletsSignalPending(otInstance *)
 {

--- a/tests/unit/test_hmac_sha256.cpp
+++ b/tests/unit/test_hmac_sha256.cpp
@@ -26,13 +26,15 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "test_util.h"
-#include "openthread/openthread.h"
-#include <common/debug.hpp>
 #include "utils/wrap_string.h"
 
-#include <crypto/hmac_sha256.hpp>
-#include <crypto/mbedtls.hpp>
+#include <openthread/openthread.h>
+
+#include "common/debug.hpp"
+#include "crypto/hmac_sha256.hpp"
+#include "crypto/mbedtls.hpp"
+
+#include "test_util.h"
 
 #ifndef OPENTHREAD_MULTIPLE_INSTANCE
 static ot::Crypto::MbedTls mMbedTls;

--- a/tests/unit/test_link_quality.cpp
+++ b/tests/unit/test_link_quality.cpp
@@ -26,11 +26,13 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "test_util.h"
-#include "openthread/openthread.h"
-#include <thread/link_quality.hpp>
-
 #include "utils/wrap_string.h"
+
+#include <openthread/openthread.h>
+
+#include "thread/link_quality.hpp"
+
+#include "test_util.h"
 
 namespace ot {
 

--- a/tests/unit/test_lowpan.cpp
+++ b/tests/unit/test_lowpan.cpp
@@ -26,8 +26,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "test_util.hpp"
 #include "test_lowpan.hpp"
+#include "test_util.hpp"
 
 using namespace ot;
 using ot::Encoding::BigEndian::HostSwap16;

--- a/tests/unit/test_lowpan.hpp
+++ b/tests/unit/test_lowpan.hpp
@@ -31,12 +31,12 @@
 
 #include "utils/wrap_stdint.h"
 
-#include "openthread/openthread.h"
+#include <openthread/openthread.h>
 
-#include <mac/mac.hpp>
-#include <net/ip6_headers.hpp>
-#include <thread/thread_netif.hpp>
-#include <thread/lowpan.hpp>
+#include "mac/mac.hpp"
+#include "net/ip6_headers.hpp"
+#include "thread/lowpan.hpp"
+#include "thread/thread_netif.hpp"
 
 namespace ot {
 

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -26,11 +26,14 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "test_util.h"
-#include "openthread/openthread.h"
-#include <common/debug.hpp>
-#include <mac/mac_frame.hpp>
 #include "utils/wrap_string.h"
+
+#include <openthread/openthread.h>
+
+#include "common/debug.hpp"
+#include "mac/mac_frame.hpp"
+
+#include "test_util.h"
 
 namespace ot {
 

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -26,12 +26,15 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "test_util.h"
-#include "openthread/openthread.h"
-#include <openthread-instance.h>
-#include <common/debug.hpp>
-#include <common/message.hpp>
 #include "utils/wrap_string.h"
+
+#include <openthread/openthread.h>
+
+#include "openthread-instance.h"
+#include "common/debug.hpp"
+#include "common/message.hpp"
+
+#include "test_util.h"
 
 void TestMessage(void)
 {

--- a/tests/unit/test_message_queue.cpp
+++ b/tests/unit/test_message_queue.cpp
@@ -26,16 +26,16 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "test_util.h"
-
-#include "openthread/openthread.h"
-
-#include <openthread-instance.h>
-#include <common/debug.hpp>
-#include <common/message.hpp>
-
-#include "utils/wrap_string.h"
 #include <stdarg.h>
+#include "utils/wrap_string.h"
+
+#include <openthread/openthread.h>
+
+#include "openthread-instance.h"
+#include "common/debug.hpp"
+#include "common/message.hpp"
+
+#include "test_util.h"
 
 #define kNumTestMessages      5
 

--- a/tests/unit/test_ncp_buffer.cpp
+++ b/tests/unit/test_ncp_buffer.cpp
@@ -27,12 +27,15 @@
  */
 
 #include <ctype.h>
+
+#include <openthread/openthread.h>
+
+#include "openthread-instance.h"
+#include "common/code_utils.hpp"
+#include "common/message.hpp"
+#include "ncp/ncp_buffer.hpp"
+
 #include "test_util.h"
-#include "openthread/openthread.h"
-#include <openthread-instance.h>
-#include <common/code_utils.hpp>
-#include <common/message.hpp>
-#include <ncp/ncp_buffer.hpp>
 
 namespace ot {
 

--- a/tests/unit/test_platform.h
+++ b/tests/unit/test_platform.h
@@ -37,14 +37,14 @@
 
 #include <string.h>
 
-#include "openthread/openthread.h"
-#include "openthread/platform/alarm.h"
-#include "openthread/platform/logging.h"
-#include "openthread/platform/misc.h"
-#include "openthread/platform/radio.h"
-#include "openthread/platform/random.h"
+#include <openthread/openthread.h>
+#include <openthread/platform/alarm.h>
+#include <openthread/platform/logging.h>
+#include <openthread/platform/misc.h>
+#include <openthread/platform/radio.h>
+#include <openthread/platform/random.h>
 
-#include <common/code_utils.hpp>
+#include "common/code_utils.hpp"
 
 #include "test_util.h"
 

--- a/tests/unit/test_priority_queue.cpp
+++ b/tests/unit/test_priority_queue.cpp
@@ -26,13 +26,16 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "test_util.h"
-#include "openthread/openthread.h"
-#include <openthread-instance.h>
-#include <common/debug.hpp>
-#include <common/message.hpp>
-#include "utils/wrap_string.h"
 #include <stdarg.h>
+#include "utils/wrap_string.h"
+
+#include <openthread/openthread.h>
+#include <openthread-instance.h>
+
+#include "common/debug.hpp"
+#include "common/message.hpp"
+
+#include "test_util.h"
 
 #define kNumTestMessages      3
 

--- a/tests/unit/test_timer.cpp
+++ b/tests/unit/test_timer.cpp
@@ -27,9 +27,10 @@
  */
 
 #include "test_platform.h"
-#include <common/debug.hpp>
-#include <common/timer.hpp>
-#include <openthread-instance.h>
+
+#include "openthread-instance.h"
+#include "common/debug.hpp"
+#include "common/timer.hpp"
 
 enum
 {

--- a/tests/unit/test_toolchain.cpp
+++ b/tests/unit/test_toolchain.cpp
@@ -29,9 +29,9 @@
 #include <stdio.h>
 #include "utils/wrap_stdint.h"
 
-#include "openthread/platform/toolchain.h"
+#include <openthread/platform/toolchain.h>
 
-#include <thread/topology.hpp>
+#include "thread/topology.hpp"
 #include "test_util.h"
 
 extern "C" {

--- a/tests/unit/test_toolchain_c.c
+++ b/tests/unit/test_toolchain_c.c
@@ -26,12 +26,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdio.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
-#include "openthread/platform/toolchain.h"
+#include <openthread/platform/toolchain.h>
 
 #include "test_util.h"
 

--- a/tests/unit/test_util.cpp
+++ b/tests/unit/test_util.cpp
@@ -28,10 +28,10 @@
 
 #include "test_util.h"
 
-#include <vector>
-#include <string>
-#include <sstream>
 #include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
 
 void otTestHexToVector(std::string &aHex, std::vector<uint8_t> &aOutBytes)
 {

--- a/tests/unit/test_util.h
+++ b/tests/unit/test_util.h
@@ -32,7 +32,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "openthread/types.h"
+#include <openthread/types.h>
 
 #ifndef _WIN32
 


### PR DESCRIPTION
Apply the following from [STYLE_GUIDE.md](https://github.com/openthread/openthread/blob/master/STYLE_GUIDE.md)

>  - Preprocessor `#include` directives in a file shall only be preceded by other preprocessor directives or comments.
>  - Preprocessor `#include` directives shall use brace (“<”) and (“>”) style for all public headers, including C and C++ standard library, or other first- and third-party public library headers.
>  - Preprocessor `#include` directives should use double quote (‘“‘) and (‘“‘) style for all private or relative headers.
>  - Preprocessor `#include` directives should be grouped, ordered, or sorted as follows:
>    - This compilation unit's corresponding header, if any.
>    - C++ Standard Library headers
>    - C Standard Library headers
>    - Third-party library headers
>    - First-party library headers
>    - Private or local headers
>    - Alphanumeric order within each subgroup
