### PR TITLE
Require Thread Master Key to be 16 bytes.

### DIFF
--- a/examples/drivers/windows/otApi/otApi.cpp
+++ b/examples/drivers/windows/otApi/otApi.cpp
@@ -1598,34 +1598,22 @@ otThreadSetLinkMode(
 }
 
 OTAPI 
-const uint8_t *
+const otMasterKey *
 OTCALL
 otThreadGetMasterKey(
-    _In_ otInstance *aInstance, 
-    _Out_ uint8_t *aKeyLength
+    _In_ otInstance *aInstance
     )
 {
-    if (aInstance == nullptr || aKeyLength == nullptr) return nullptr;
+    if (aInstance == nullptr) return nullptr;
 
-    *aKeyLength = 0;
-
-    struct otMasterKeyAndLength
-    {
-        otMasterKey Key;
-        uint8_t Length;
-    };
-    otMasterKeyAndLength *Result = (otMasterKeyAndLength*)malloc(sizeof(otMasterKeyAndLength));
+    otMasterKey *Result = (otMasterKey*)malloc(sizeof(otMasterKey));
     if (Result == nullptr) return nullptr;
     if (QueryIOCTL(aInstance, IOCTL_OTLWF_OT_MASTER_KEY, Result) != ERROR_SUCCESS)
     {
         free(Result);
         return nullptr;
     }
-    else
-    {
-        *aKeyLength = Result->Length;
-    }
-    return (uint8_t*)Result;
+    return Result;
 }
 
 OTAPI
@@ -1633,18 +1621,12 @@ ThreadError
 OTCALL
 otThreadSetMasterKey(
     _In_ otInstance *aInstance, 
-    const uint8_t *aKey, 
-    uint8_t aKeyLength
+    const otMasterKey *aKey
     )
 {
     if (aInstance == nullptr) return kThreadError_InvalidArgs;
     
-    BYTE Buffer[sizeof(GUID) + sizeof(otMasterKey) + sizeof(uint8_t)];
-    memcpy_s(Buffer, sizeof(Buffer), &aInstance->InterfaceGuid, sizeof(GUID));
-    memcpy_s(Buffer + sizeof(GUID), sizeof(Buffer) - sizeof(GUID), aKey, aKeyLength);
-    memcpy_s(Buffer + sizeof(GUID) + sizeof(otMasterKey), sizeof(Buffer) - sizeof(GUID) - sizeof(otMasterKey), &aKeyLength, sizeof(aKeyLength));
-    
-    return DwordToThreadError(SendIOCTL(aInstance->ApiHandle, IOCTL_OTLWF_OT_MASTER_KEY, Buffer, sizeof(Buffer), nullptr, 0));
+    return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_MASTER_KEY, aKey));
 }
 
 OTAPI 

--- a/examples/drivers/windows/otNodeApi/otNodeApi.cpp
+++ b/examples/drivers/windows/otNodeApi/otNodeApi.cpp
@@ -1200,14 +1200,14 @@ OTNODEAPI int32_t OTCALL otNodeSetMasterkey(otNode* aNode, const char *aMasterke
     printf("%d: masterkey %s\r\n", aNode->mId, aMasterkey);
 
     int keyLength;
-    uint8_t key[OT_MASTER_KEY_SIZE];
-    if ((keyLength = Hex2Bin(aMasterkey, key, sizeof(key))) != OT_MASTER_KEY_SIZE)
+    otMasterKey key;
+    if ((keyLength = Hex2Bin(aMasterkey, key.m8, sizeof(key.m8))) != OT_MASTER_KEY_SIZE)
     {
         printf("invalid length key %d\r\n", keyLength);
         return kThreadError_Parse;
     }
 
-    auto error = otThreadSetMasterKey(aNode->mInstance, key, (uint8_t)keyLength);
+    auto error = otThreadSetMasterKey(aNode->mInstance, &key);
     otLogFuncExit();
     return error;
 }
@@ -1215,15 +1215,14 @@ OTNODEAPI int32_t OTCALL otNodeSetMasterkey(otNode* aNode, const char *aMasterke
 OTNODEAPI const char* OTCALL otNodeGetMasterkey(otNode* aNode)
 {
     otLogFuncEntryMsg("[%d]", aNode->mId);
-    uint8_t aKeyLength = 0;
-    auto aMasterKey = otThreadGetMasterKey(aNode->mInstance, &aKeyLength);
-    uint8_t strLength = 2*aKeyLength + 1;
+    auto aMasterKey = otThreadGetMasterKey(aNode->mInstance);
+    uint8_t strLength = 2*sizeof(otMasterKey) + 1;
     char* str = (char*)malloc(strLength);
     if (str != nullptr)
     {
         aNode->mMemoryToFree.push_back(str);
-        for (int i = 0; i < aKeyLength; i++)
-            sprintf_s(str + i * 2, strLength - (2 * i), "%02x", aMasterKey[i]);
+        for (int i = 0; i < sizeof(otMasterKey); i++)
+            sprintf_s(str + i * 2, strLength - (2 * i), "%02x", aMasterKey->m8[i]);
         printf("%d: masterkey\r\n%s\r\n", aNode->mId, str);
     }
     otFreeMemory(aMasterKey);

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -232,14 +232,12 @@ OTAPI ThreadError OTCALL otThreadSetLinkMode(otInstance *aInstance, otLinkModeCo
  * Get the thrMasterKey.
  *
  * @param[in]   aInstance   A pointer to an OpenThread instance.
- * @param[out]  aKeyLength  A pointer to an unsigned 8-bit value that the function will set to the number of bytes that
- *                          represent the thrMasterKey. Caller may set to NULL.
  *
  * @returns A pointer to a buffer containing the thrMasterKey.
  *
  * @sa otThreadSetMasterKey
  */
-OTAPI const uint8_t *OTCALL otThreadGetMasterKey(otInstance *aInstance, uint8_t *aKeyLength);
+OTAPI const otMasterKey *OTCALL otThreadGetMasterKey(otInstance *aInstance);
 
 /**
  * Set the thrMasterKey.
@@ -250,7 +248,6 @@ OTAPI const uint8_t *OTCALL otThreadGetMasterKey(otInstance *aInstance, uint8_t 
  *
  * @param[in]  aInstance   A pointer to an OpenThread instance.
  * @param[in]  aKey        A pointer to a buffer containing the thrMasterKey.
- * @param[in]  aKeyLength  Number of bytes representing the thrMasterKey stored at aKey. Valid range is [0, 16].
  *
  * @retval kThreadErrorNone           Successfully set the thrMasterKey.
  * @retval kThreadErrorInvalidArgs    If aKeyLength is larger than 16.
@@ -258,7 +255,7 @@ OTAPI const uint8_t *OTCALL otThreadGetMasterKey(otInstance *aInstance, uint8_t 
  *
  * @sa otThreadGetMasterKey
  */
-OTAPI ThreadError OTCALL otThreadSetMasterKey(otInstance *aInstance, const uint8_t *aKey, uint8_t aKeyLength);
+OTAPI ThreadError OTCALL otThreadSetMasterKey(otInstance *aInstance, const otMasterKey *aKey);
 
 /**
  * Get the thrPSKc.

--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -213,10 +213,13 @@ typedef enum ThreadError
  * This structure represents a Thread Master Key.
  *
  */
-typedef struct otMasterKey
+OT_TOOL_PACKED_BEGIN
+struct otMasterKey
 {
     uint8_t m8[OT_MASTER_KEY_SIZE];
-} otMasterKey;
+} OT_TOOL_PACKED_END;
+
+typedef struct otMasterKey otMasterKey;
 
 #define OT_NETWORK_NAME_MAX_SIZE   16  ///< Maximum size of the Thread Network Name field (bytes)
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1354,10 +1354,9 @@ void Interpreter::ProcessMasterKey(int argc, char *argv[])
 
     if (argc == 0)
     {
-        uint8_t keyLength;
-        otBufferPtr key(otThreadGetMasterKey(mInstance, &keyLength));
+        otBufferPtr key(reinterpret_cast<const uint8_t *>(otThreadGetMasterKey(mInstance)));
 
-        for (int i = 0; i < keyLength; i++)
+        for (int i = 0; i < OT_MASTER_KEY_SIZE; i++)
         {
             sServer->OutputFormat("%02x", key[i]);
         }
@@ -1366,11 +1365,10 @@ void Interpreter::ProcessMasterKey(int argc, char *argv[])
     }
     else
     {
-        int keyLength;
-        uint8_t key[OT_MASTER_KEY_SIZE];
+        otMasterKey key;
 
-        VerifyOrExit((keyLength = Hex2Bin(argv[0], key, sizeof(key))) == OT_MASTER_KEY_SIZE, error = kThreadError_Parse);
-        SuccessOrExit(error = otThreadSetMasterKey(mInstance, key, static_cast<uint8_t>(keyLength)));
+        VerifyOrExit(Hex2Bin(argv[0], key.m8, sizeof(key.m8)) == OT_MASTER_KEY_SIZE, error = kThreadError_Parse);
+        SuccessOrExit(error = otThreadSetMasterKey(mInstance, &key));
     }
 
 exit:

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -170,19 +170,20 @@ exit:
 }
 #endif
 
-const uint8_t *otThreadGetMasterKey(otInstance *aInstance, uint8_t *aKeyLength)
+const otMasterKey *otThreadGetMasterKey(otInstance *aInstance)
 {
-    return aInstance->mThreadNetif.GetKeyManager().GetMasterKey(aKeyLength);
+    return &aInstance->mThreadNetif.GetKeyManager().GetMasterKey();
 }
 
-ThreadError otThreadSetMasterKey(otInstance *aInstance, const uint8_t *aKey, uint8_t aKeyLength)
+ThreadError otThreadSetMasterKey(otInstance *aInstance, const otMasterKey *aKey)
 {
     ThreadError error = kThreadError_None;
 
+    VerifyOrExit(aKey != NULL, error = kThreadError_InvalidArgs);
     VerifyOrExit(aInstance->mThreadNetif.GetMle().GetDeviceState() == Mle::kDeviceStateDisabled,
                  error = kThreadError_InvalidState);
 
-    error = aInstance->mThreadNetif.GetKeyManager().SetMasterKey(aKey, aKeyLength);
+    error = aInstance->mThreadNetif.GetKeyManager().SetMasterKey(*aKey);
     aInstance->mThreadNetif.GetActiveDataset().Clear(false);
     aInstance->mThreadNetif.GetPendingDataset().Clear(false);
 

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -188,7 +188,7 @@ void Dataset::Get(otOperationalDataset &aDataset) const
         case Tlv::kNetworkMasterKey:
         {
             const NetworkMasterKeyTlv *tlv = static_cast<const NetworkMasterKeyTlv *>(cur);
-            memcpy(aDataset.mMasterKey.m8, tlv->GetNetworkMasterKey(), sizeof(aDataset.mMasterKey));
+            aDataset.mMasterKey = tlv->GetNetworkMasterKey();
             aDataset.mIsMasterKeySet = true;
             break;
         }
@@ -328,7 +328,7 @@ ThreadError Dataset::Set(const otOperationalDataset &aDataset)
     {
         MeshCoP::NetworkMasterKeyTlv tlv;
         tlv.Init();
-        tlv.SetNetworkMasterKey(aDataset.mMasterKey.m8);
+        tlv.SetNetworkMasterKey(aDataset.mMasterKey);
         Set(tlv);
     }
 

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -131,7 +131,7 @@ ThreadError DatasetManager::ApplyConfiguration(void)
         case Tlv::kNetworkMasterKey:
         {
             const NetworkMasterKeyTlv *key = static_cast<const NetworkMasterKeyTlv *>(cur);
-            mNetif.GetKeyManager().SetMasterKey(key->GetNetworkMasterKey(), key->GetLength());
+            mNetif.GetKeyManager().SetMasterKey(key->GetNetworkMasterKey());
             break;
         }
 
@@ -461,8 +461,7 @@ ThreadError DatasetManager::Set(Coap::Header &aHeader, Message &aMessage, const 
 
     // check network master key
     if (Tlv::GetTlv(aMessage, Tlv::kNetworkMasterKey, sizeof(masterKey), masterKey) == kThreadError_None &&
-        memcmp(masterKey.GetNetworkMasterKey(), mNetif.GetKeyManager().GetMasterKey(NULL),
-               masterKey.GetLength()))
+        memcmp(&masterKey.GetNetworkMasterKey(), &mNetif.GetKeyManager().GetMasterKey(), OT_MASTER_KEY_SIZE))
     {
         doesAffectConnectivity = true;
         doesAffectMasterKey = true;
@@ -471,8 +470,7 @@ ThreadError DatasetManager::Set(Coap::Header &aHeader, Message &aMessage, const 
     // check active timestamp rollback
     if (type == Tlv::kPendingTimestamp &&
         (masterKey.GetLength() == 0 ||
-         memcmp(masterKey.GetNetworkMasterKey(), mNetif.GetKeyManager().GetMasterKey(NULL),
-                masterKey.GetLength()) == 0))
+         memcmp(&masterKey.GetNetworkMasterKey(), &mNetif.GetKeyManager().GetMasterKey(), OT_MASTER_KEY_SIZE) == 0))
     {
         // no change to master key, active timestamp must be ahead
         const Timestamp *localActiveTimestamp = mNetif.GetActiveDataset().GetNetwork().GetTimestamp();
@@ -666,7 +664,7 @@ ThreadError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset,
     {
         NetworkMasterKeyTlv masterkey;
         masterkey.Init();
-        masterkey.SetNetworkMasterKey(aDataset.mMasterKey.m8);
+        masterkey.SetNetworkMasterKey(aDataset.mMasterKey);
         SuccessOrExit(error = message->Append(&masterkey, sizeof(masterkey)));
     }
 

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -137,7 +137,7 @@ ThreadError ActiveDataset::GenerateLocal(void)
     {
         NetworkMasterKeyTlv tlv;
         tlv.Init();
-        tlv.SetNetworkMasterKey(mNetif.GetKeyManager().GetMasterKey(NULL));
+        tlv.SetNetworkMasterKey(mNetif.GetKeyManager().GetMasterKey());
         mLocal.Set(tlv);
     }
 

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -429,7 +429,7 @@ void Joiner::HandleJoinerEntrust(Coap::Header &aHeader, Message &aMessage, const
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kNetworkKeySequence, sizeof(networkKeySeq), networkKeySeq));
     VerifyOrExit(networkKeySeq.IsValid(), error = kThreadError_Parse);
 
-    mNetif.GetKeyManager().SetMasterKey(masterKey.GetNetworkMasterKey(), masterKey.GetLength());
+    mNetif.GetKeyManager().SetMasterKey(masterKey.GetNetworkMasterKey());
     mNetif.GetKeyManager().SetCurrentKeySequence(networkKeySeq.GetNetworkKeySequence());
     mNetif.GetMle().SetMeshLocalPrefix(meshLocalPrefix.GetMeshLocalPrefix());
     mNetif.GetMac().SetExtendedPanId(extendedPanId.GetExtendedPanId());

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -345,7 +345,7 @@ ThreadError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMes
     message->SetSubType(Message::kSubTypeJoinerEntrust);
 
     masterKey.Init();
-    masterKey.SetNetworkMasterKey(mNetif.GetKeyManager().GetMasterKey(NULL));
+    masterKey.SetNetworkMasterKey(mNetif.GetKeyManager().GetMasterKey());
     SuccessOrExit(error = message->Append(&masterKey, sizeof(masterKey)));
 
     meshLocalPrefix.Init();

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -437,7 +437,7 @@ public:
      * @returns The Network Master Key value.
      *
      */
-    const uint8_t *GetNetworkMasterKey(void) const { return mNetworkMasterKey; }
+    const otMasterKey &GetNetworkMasterKey(void) const { return mNetworkMasterKey; }
 
     /**
      * This method sets the Network Master Key value.
@@ -445,12 +445,12 @@ public:
      * @param[in]  aNetworkMasterKey  A pointer to the Network Master Key value.
      *
      */
-    void SetNetworkMasterKey(const uint8_t *aNetworkMasterKey) {
-        memcpy(mNetworkMasterKey, aNetworkMasterKey, sizeof(mNetworkMasterKey));
+    void SetNetworkMasterKey(const otMasterKey &aNetworkMasterKey) {
+        mNetworkMasterKey = aNetworkMasterKey;
     }
 
 private:
-    uint8_t mNetworkMasterKey[16];
+    otMasterKey mNetworkMasterKey;
 } OT_TOOL_PACKED_END;
 
 /**

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -54,7 +54,6 @@ static const uint8_t kThreadString[] =
 
 KeyManager::KeyManager(ThreadNetif &aThreadNetif):
     mNetif(aThreadNetif),
-    mMasterKeyLength(0),
     mKeySequence(0),
     mMacFrameCounter(0),
     mMleFrameCounter(0),
@@ -92,28 +91,21 @@ void KeyManager::SetPSKc(const uint8_t *aPSKc)
 }
 #endif
 
-const uint8_t *KeyManager::GetMasterKey(uint8_t *aKeyLength) const
+const otMasterKey &KeyManager::GetMasterKey(void) const
 {
-    if (aKeyLength)
-    {
-        *aKeyLength = mMasterKeyLength;
-    }
-
     return mMasterKey;
 }
 
-ThreadError KeyManager::SetMasterKey(const void *aKey, uint8_t aKeyLength)
+ThreadError KeyManager::SetMasterKey(const otMasterKey &aKey)
 {
     ThreadError error = kThreadError_None;
     Router *routers;
     Child *children;
     uint8_t num;
 
-    VerifyOrExit(aKeyLength <= sizeof(mMasterKey), error = kThreadError_InvalidArgs);
-    VerifyOrExit((mMasterKeyLength != aKeyLength) || (memcmp(mMasterKey, aKey, aKeyLength) != 0));
+    VerifyOrExit(memcmp(&mMasterKey, &aKey, sizeof(mMasterKey)) != 0);
 
-    memcpy(mMasterKey, aKey, aKeyLength);
-    mMasterKeyLength = aKeyLength;
+    mMasterKey = aKey;
     mKeySequence = 0;
     ComputeKey(mKeySequence, mKey);
 
@@ -154,7 +146,7 @@ ThreadError KeyManager::ComputeKey(uint32_t aKeySequence, uint8_t *aKey)
     Crypto::HmacSha256 hmac;
     uint8_t keySequenceBytes[4];
 
-    hmac.Start(mMasterKey, mMasterKeyLength);
+    hmac.Start(mMasterKey.m8, sizeof(mMasterKey.m8));
 
     keySequenceBytes[0] = (aKeySequence >> 24) & 0xff;
     keySequenceBytes[1] = (aKeySequence >> 16) & 0xff;

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -83,26 +83,23 @@ public:
     void Stop(void);
 
     /**
-     * This method returns a pointer to the Thread Master Key
+     * This method returns a reference to the Thread Master Key
      *
-     * @param[out]  aKeyLength  A pointer where the key length value will be placed.
-     *
-     * @returns A pointer to the Thread Master Key.
+     * @returns A reference to the Thread Master Key.
      *
      */
-    const uint8_t *GetMasterKey(uint8_t *aKeyLength) const;
+    const otMasterKey &GetMasterKey(void) const;
 
     /**
      * This method sets the Thread Master Key.
      *
-     * @param[in]  aKey        A pointer to the Thread Master Key.
-     * @param[in]  aKeyLength  The length of @p aKey.
+     * @param[in]  aKey        A reference to the Thread Master Key.
      *
      * @retval kThreadError_None         Successfully set the Thread Master Key.
      * @retval kThreadError_InvalidArgs  The @p aKeyLength value was invalid.
      *
      */
-    ThreadError SetMasterKey(const void *aKey, uint8_t aKeyLength);
+    ThreadError SetMasterKey(const otMasterKey &aKey);
 
     /**
      * This method returns a pointer to the PSKc.
@@ -344,8 +341,7 @@ private:
 
     ThreadNetif &mNetif;
 
-    uint8_t mMasterKey[kMaxKeyLength];
-    uint8_t mMasterKeyLength;
+    otMasterKey mMasterKey;
 
     uint32_t mKeySequence;
     uint8_t mKey[Crypto::HmacSha256::kHashSize];

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -54,10 +54,12 @@ using ot::Encoding::BigEndian::HostSwap16;
 
 namespace ot {
 
-static const uint8_t kThreadMasterKey[] =
+static const otMasterKey kThreadMasterKey =
 {
-    0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
-    0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+    {
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+        0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+    }
 };
 
 ThreadNetif::ThreadNetif(Ip6::Ip6 &aIp6):
@@ -112,7 +114,7 @@ ThreadNetif::ThreadNetif(Ip6::Ip6 &aIp6):
     mEnergyScan(*this)
 
 {
-    mKeyManager.SetMasterKey(kThreadMasterKey, sizeof(kThreadMasterKey));
+    mKeyManager.SetMasterKey(kThreadMasterKey);
     mCoapServer.SetInterceptor(&ThreadNetif::TmfFilter);
 }
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -2257,18 +2257,13 @@ ThreadError NcpBase::GetPropertyHandler_NET_XPANID(uint8_t header, spinel_prop_k
 
 ThreadError NcpBase::GetPropertyHandler_NET_MASTER_KEY(uint8_t header, spinel_prop_key_t key)
 {
-    const uint8_t *ptr(NULL);
-    uint8_t len(0);
-
-    ptr = otThreadGetMasterKey(mInstance, &len);
-
     return SendPropertyUpdate(
                header,
                SPINEL_CMD_PROP_VALUE_IS,
                key,
                SPINEL_DATATYPE_DATA_S,
-               ptr,
-               len
+               otThreadGetMasterKey(mInstance)->m8,
+               OT_MASTER_KEY_SIZE
            );
 }
 
@@ -4423,9 +4418,9 @@ ThreadError NcpBase::SetPropertyHandler_NET_MASTER_KEY(uint8_t header, spinel_pr
                        &len
                    );
 
-    if ((parsedLength > 0) && (len < 100))
+    if ((parsedLength > 0) && (len == OT_MASTER_KEY_SIZE))
     {
-        errorCode = otThreadSetMasterKey(mInstance, ptr, static_cast<uint8_t>(len));
+        errorCode = otThreadSetMasterKey(mInstance, reinterpret_cast<const otMasterKey *>(ptr));
 
         if (errorCode == kThreadError_None)
         {


### PR DESCRIPTION
- Update code to use `otMasterKey` type.

Resolves #1700.