### PR TITLE
Adding new ot API `otNetDataGetNextRoute()` in `netdata.h`

### DIFF
--- a/include/openthread/netdata.h
+++ b/include/openthread/netdata.h
@@ -148,6 +148,22 @@ OTAPI ThreadError OTCALL otNetDataAddRoute(otInstance *aInstance, const otExtern
 OTAPI ThreadError OTCALL otNetDataRemoveRoute(otInstance *aInstance, const otIp6Prefix *aPrefix);
 
 /**
+ * This function gets the next external route in the Network Data.
+ *
+ * @param[in]     aInstance  A pointer to an OpenThread instance.
+ * @param[in]     aLocal     TRUE to retrieve from the local Network Data, FALSE for partition's Network Data
+ * @param[inout]  aIterator  A pointer to the Network Data iterator context. To get the first external route entry
+                             it should be set to OT_NETWORK_DATA_ITERATOR_INIT.
+ * @param[out]    aConfig    A pointer to where the External Route information will be placed.
+ *
+ * @retval kThreadError_None      Successfully found the next External Route.
+ * @retval kThreadError_NotFound  No subsequent external route entry exists in the Thread Network Data.
+ *
+ */
+ThreadError otNetDataGetNextRoute(otInstance *aInstance, bool aLocal, otNetworkDataIterator *aIterator,
+                                  otExternalRouteConfig *aConfig);
+
+/**
  * Immediately register the local network data with the Leader.
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.

--- a/src/core/api/netdata_api.cpp
+++ b/src/core/api/netdata_api.cpp
@@ -138,6 +138,26 @@ ThreadError otNetDataRemoveRoute(otInstance *aInstance, const otIp6Prefix *aPref
                                                                               aPrefix->mLength);
 }
 
+ThreadError otNetDataGetNextRoute(otInstance *aInstance, bool aLocal, otNetworkDataIterator *aIterator,
+                                  otExternalRouteConfig *aConfig)
+{
+    ThreadError error = kThreadError_None;
+
+    VerifyOrExit(aIterator && aConfig, error = kThreadError_InvalidArgs);
+
+    if (aLocal)
+    {
+        error = aInstance->mThreadNetif.GetNetworkDataLocal().GetNextExternalRoute(aIterator, aConfig);
+    }
+    else
+    {
+        error = aInstance->mThreadNetif.GetNetworkDataLeader().GetNextExternalRoute(aIterator, aConfig);
+    }
+
+exit:
+    return error;
+}
+
 ThreadError otNetDataRegister(otInstance *aInstance)
 {
     return aInstance->mThreadNetif.GetNetworkDataLocal().SendServerDataNotification();

--- a/src/core/thread/network_data_local_mtd.hpp
+++ b/src/core/thread/network_data_local_mtd.hpp
@@ -59,6 +59,7 @@ public:
 
     void GetNetworkData(bool, uint8_t *, uint8_t &aDataLength) { aDataLength = 0; }
     ThreadError GetNextOnMeshPrefix(otNetworkDataIterator *, otBorderRouterConfig *) { return kThreadError_NotFound; }
+    ThreadError GetNextExternalRoute(otNetworkDataIterator *, otExternalRouteConfig *) { return kThreadError_NotFound; }
     void ClearResubmitDelayTimer(void) { }
 
 };


### PR DESCRIPTION
New method for iterating through the "external route" entries in the
network data.