### PR TITLE
Use virtual methods instead of function pointers for CoAP

### DIFF
--- a/src/core/coap/coap_base.cpp
+++ b/src/core/coap/coap_base.cpp
@@ -77,8 +77,8 @@ ThreadError CoapBase::Stop(void)
 
 void CoapBase::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<CoapBase *>(aContext)->mReceiver(aContext, *static_cast<Message *>(aMessage),
-                                                 *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<CoapBase *>(aContext)->Receive(*static_cast<Message *>(aMessage),
+                                               *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 ThreadError CoapBase::SendEmptyMessage(Header::Type aType, const Header &aRequestHeader,
@@ -95,7 +95,7 @@ ThreadError CoapBase::SendEmptyMessage(Header::Type aType, const Header &aReques
 
     VerifyOrExit((message = NewMessage(responseHeader)) != NULL, error = kThreadError_NoBufs);
 
-    SuccessOrExit(error = mSender(this, *message, aMessageInfo));
+    SuccessOrExit(error = Send(*message, aMessageInfo));
 
 exit:
 

--- a/src/core/coap/coap_base.hpp
+++ b/src/core/coap/coap_base.hpp
@@ -86,26 +86,6 @@ class CoapBase
 public:
 
     /**
-     * This function pointer is called when CoAP client/server wants to send a message.
-     *
-     * @param[in]  aContext      A pointer to arbitrary context information.
-     * @param[in]  aMessage      A reference to the message to send.
-     * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
-     *
-     */
-    typedef ThreadError(* SenderFunction)(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-
-    /**
-     * This function pointer is called when CoAP client/server receives a message.
-     *
-     * @param[in]  aContext      A pointer to arbitrary context information.
-     * @param[in]  aMessage      A reference to the received message.
-     * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
-     *
-     */
-    typedef void (* ReceiverFunction)(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-
-    /**
      * This constructor initializes the object.
      *
      * @param[in]  aUdp      A reference to the UDP object.
@@ -113,10 +93,8 @@ public:
      * @param[in]  aReceiver A pointer to a function for handling received messages.
      *
      */
-    CoapBase(Ip6::Udp &aUdp, SenderFunction aSender, ReceiverFunction aReceiver):
-        mSocket(aUdp),
-        mSender(aSender),
-        mReceiver(aReceiver) {};
+    CoapBase(Ip6::Udp &aUdp) :
+        mSocket(aUdp) {};
 
     /**
      * This method creates a new message with a CoAP header.
@@ -171,9 +149,27 @@ protected:
     ThreadError Start(const Ip6::SockAddr &aSockAddr);
     ThreadError Stop(void);
 
+    /**
+     * This method send a message.
+     *
+     * @param[in]  aContext      A pointer to arbitrary context information.
+     * @param[in]  aMessage      A reference to the message to send.
+     * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
+     *
+     */
+    virtual ThreadError Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo) = 0;
+
+    /**
+     * This method receives a message.
+     *
+     * @param[in]  aContext      A pointer to arbitrary context information.
+     * @param[in]  aMessage      A reference to the received message.
+     * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
+     *
+     */
+    virtual void Receive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo) = 0;
+
     Ip6::UdpSocket mSocket;
-    SenderFunction mSender;
-    ReceiverFunction mReceiver;
 
 private:
     /**

--- a/src/core/coap/coap_client.cpp
+++ b/src/core/coap/coap_client.cpp
@@ -50,8 +50,8 @@
 namespace ot {
 namespace Coap {
 
-Client::Client(Ip6::Netif &aNetif, SenderFunction aSender, ReceiverFunction aReceiver):
-    CoapBase(aNetif.GetIp6().mUdp, aSender, aReceiver),
+Client::Client(Ip6::Netif &aNetif):
+    CoapBase(aNetif.GetIp6().mUdp),
     mRetransmissionTimer(aNetif.GetIp6().mTimerScheduler, &Client::HandleRetransmissionTimer, this)
 {
     mMessageId = static_cast<uint16_t>(otPlatRandomGet());
@@ -120,7 +120,7 @@ ThreadError Client::SendMessage(Message &aMessage, const Ip6::MessageInfo &aMess
                      error = kThreadError_NoBufs);
     }
 
-    SuccessOrExit(error = mSender(this, aMessage, aMessageInfo));
+    SuccessOrExit(error = Send(aMessage, aMessageInfo));
 
 exit:
 
@@ -223,7 +223,7 @@ ThreadError Client::SendCopy(const Message &aMessage, const Ip6::MessageInfo &aM
                  error = kThreadError_NoBufs);
 
     // Send the copy.
-    SuccessOrExit(error = mSender(this, *messageCopy, aMessageInfo));
+    SuccessOrExit(error = Send(*messageCopy, aMessageInfo));
 
 exit:
 
@@ -360,7 +360,7 @@ void Client::FinalizeCoapTransaction(Message &aRequest, const RequestMetadata &a
     }
 }
 
-void Client::ProcessReceivedMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Client::Receive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     Header responseHeader;
     Header requestHeader;

--- a/src/core/coap/coap_client.hpp
+++ b/src/core/coap/coap_client.hpp
@@ -171,7 +171,7 @@ public:
      * @param[in]  aReceiver A pointer to a function for handling received messages.
      *
      */
-    Client(Ip6::Netif &aNetif, SenderFunction aSender = &Client::Send, ReceiverFunction aReceiver = &Client::Receive);
+    Client(Ip6::Netif &aNetif);
 
     /**
      * This method starts the CoAP client.
@@ -229,7 +229,12 @@ public:
     const MessageQueue &GetRequestMessages(void) const { return mPendingRequests; }
 
 protected:
-    void ProcessReceivedMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    virtual void Receive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+
+    ThreadError Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo) {
+        return mSocket.SendTo(aMessage, aMessageInfo);
+    }
+
 
 private:
     Message *CopyAndEnqueueMessage(const Message &aMessage, uint16_t aCopyLength,
@@ -243,14 +248,6 @@ private:
     ThreadError SendCopy(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     static void HandleRetransmissionTimer(void *aContext);
     void HandleRetransmissionTimer(void);
-
-    static ThreadError Send(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo) {
-        return (static_cast<Client *>(aContext))->mSocket.SendTo(aMessage, aMessageInfo);
-    }
-
-    static void Receive(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo) {
-        (static_cast<Client *>(aContext))->ProcessReceivedMessage(aMessage, aMessageInfo);
-    }
 
     MessageQueue mPendingRequests;
     uint16_t mMessageId;

--- a/src/core/coap/coap_server.cpp
+++ b/src/core/coap/coap_server.cpp
@@ -44,8 +44,8 @@
 namespace ot {
 namespace Coap {
 
-Server::Server(Ip6::Netif &aNetif, uint16_t aPort, SenderFunction aSender, ReceiverFunction aReceiver):
-    CoapBase(aNetif.GetIp6().mUdp, aSender, aReceiver),
+Server::Server(Ip6::Netif &aNetif, uint16_t aPort) :
+    CoapBase(aNetif.GetIp6().mUdp),
     mResponsesQueue(aNetif)
 {
     mPort = aPort;
@@ -110,7 +110,7 @@ ThreadError Server::SendMessage(Message &aMessage, const Ip6::MessageInfo &aMess
 {
     mResponsesQueue.EnqueueResponse(aMessage, aMessageInfo);
 
-    return mSender(this, aMessage, aMessageInfo);
+    return Send(aMessage, aMessageInfo);
 }
 
 ThreadError Server::SendEmptyAck(const Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo)
@@ -137,7 +137,7 @@ exit:
     return error;
 }
 
-void Server::ProcessReceivedMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Server::Receive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     Header header;
     char uriPath[Resource::kMaxReceivedUriPath] = "";

--- a/src/core/coap/coap_server.hpp
+++ b/src/core/coap/coap_server.hpp
@@ -310,8 +310,7 @@ public:
      * @param[in]  aReceiver A pointer to a function for handling received messages.
      *
      */
-    Server(Ip6::Netif &aNetif, uint16_t aPort, SenderFunction aSender = &Server::Send,
-           ReceiverFunction aReceiver = &Server::Receive);
+    Server(Ip6::Netif &aNetif, uint16_t aPort);
 
     /**
      * This method starts the CoAP server.
@@ -396,17 +395,13 @@ public:
     }
 
 protected:
-    void ProcessReceivedMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    virtual void Receive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+
+    virtual ThreadError Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo) {
+        return mSocket.SendTo(aMessage, aMessageInfo);
+    }
 
 private:
-    static ThreadError Send(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo) {
-        return (static_cast<Server *>(aContext))->mSocket.SendTo(aMessage, aMessageInfo);
-    }
-
-    static void Receive(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo) {
-        (static_cast<Server *>(aContext))->ProcessReceivedMessage(aMessage, aMessageInfo);
-    }
-
     uint16_t mPort;
     Resource *mResources;
 

--- a/src/core/coap/secure_coap_client.cpp
+++ b/src/core/coap/secure_coap_client.cpp
@@ -50,7 +50,7 @@ namespace ot {
 namespace Coap {
 
 SecureClient::SecureClient(ThreadNetif &aNetif):
-    Client(aNetif, &SecureClient::Send, &SecureClient::Receive),
+    Client(aNetif),
     mConnectedCallback(NULL),
     mContext(NULL),
     mNetif(aNetif),
@@ -120,20 +120,10 @@ exit:
     return error;
 }
 
-ThreadError SecureClient::Send(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
-{
-    return static_cast<SecureClient *>(aContext)->Send(aMessage, aMessageInfo);
-}
-
 ThreadError SecureClient::Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     (void)aMessageInfo;
     return mNetif.GetDtls().Send(aMessage, aMessage.GetLength());
-}
-
-void SecureClient::Receive(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
-{
-    return static_cast<SecureClient *>(aContext)->Receive(aMessage, aMessageInfo);
 }
 
 void SecureClient::Receive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -176,7 +166,7 @@ void SecureClient::HandleDtlsReceive(uint8_t *aBuf, uint16_t aLength)
     VerifyOrExit((message = mNetif.GetIp6().mMessagePool.New(Message::kTypeIp6, 0)) != NULL);
     SuccessOrExit(message->Append(aBuf, aLength));
 
-    ProcessReceivedMessage(*message, mPeerAddress);
+    Client::Receive(*message, mPeerAddress);
 
 exit:
 

--- a/src/core/coap/secure_coap_client.hpp
+++ b/src/core/coap/secure_coap_client.hpp
@@ -135,10 +135,8 @@ public:
     ThreadError SendMessage(Message &aMessage, otCoapResponseHandler aHandler = NULL, void *aContext = NULL);
 
 private:
-    static ThreadError Send(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     ThreadError Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void Receive(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     void Receive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     static void HandleDtlsConnected(void *aContext, bool aConnected);

--- a/src/core/coap/secure_coap_server.cpp
+++ b/src/core/coap/secure_coap_server.cpp
@@ -50,7 +50,7 @@ namespace ot {
 namespace Coap {
 
 SecureServer::SecureServer(ThreadNetif &aNetif, uint16_t aPort):
-    Server(aNetif, aPort, &SecureServer::Send, &SecureServer::Receive),
+    Server(aNetif, aPort),
     mTransmitCallback(NULL),
     mContext(NULL),
     mNetif(aNetif),
@@ -101,20 +101,10 @@ bool SecureServer::IsConnectionActive(void)
     return mNetif.GetDtls().IsStarted();
 };
 
-ThreadError SecureServer::Send(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
-{
-    return static_cast<SecureServer *>(aContext)->Send(aMessage, aMessageInfo);
-}
-
 ThreadError SecureServer::Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     (void)aMessageInfo;
     return mNetif.GetDtls().Send(aMessage, aMessage.GetLength());
-}
-
-void SecureServer::Receive(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
-{
-    return static_cast<SecureServer *>(aContext)->Receive(aMessage, aMessageInfo);
 }
 
 void SecureServer::Receive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -184,7 +174,7 @@ void SecureServer::HandleDtlsReceive(uint8_t *aBuf, uint16_t aLength)
     VerifyOrExit((message = mNetif.GetIp6().mMessagePool.New(Message::kTypeIp6, 0)) != NULL);
     SuccessOrExit(message->Append(aBuf, aLength));
 
-    ProcessReceivedMessage(*message, mPeerAddress);
+    Server::Receive(*message, mPeerAddress);
 
 exit:
 

--- a/src/core/coap/secure_coap_server.hpp
+++ b/src/core/coap/secure_coap_server.hpp
@@ -114,12 +114,10 @@ public:
      */
     ThreadError SetPsk(const uint8_t *aPsk, uint8_t aPskLength);
 
+protected:
+    virtual ThreadError Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+
 private:
-    static ThreadError Send(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-
-    static void Receive(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-
     static void HandleDtlsConnected(void *aContext, bool aConnected);
     void HandleDtlsConnected(bool aConnected);
 


### PR DESCRIPTION
Currently the sender and receiver are function pointers, and the `aContext` must be the CoAP server or client. The intent of these two function pointers is to allow child class override the behavior, I think virtual methods can better serve the purpose.

This PR simply converts these function pointers to virtual methods and simplified the APIs of CoAP.