### PR TITLE
Add new line to NCP logging to better support debugging

### DIFF
--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -287,6 +287,8 @@ void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat
     }
     va_end(args);
 
+    otNcpStreamWrite(0, reinterpret_cast<const uint8_t*>("\r\n"), 2);
+
     (void)aLogLevel;
     (void)aLogRegion;
 }


### PR DESCRIPTION
This PR simply appends a new line to NCP logging, otherwise the logging will not be outputted in time and multiple logging message will be put into one line, which is very hard to help debug.