### PR TITLE
Select the appropriate source address

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -973,9 +973,11 @@ const NetifUnicastAddress *Ip6::SelectSourceAddress(MessageInfo &aMessageInfo)
         for (const NetifUnicastAddress *addr = netif->mUnicastAddresses; addr; addr = addr->GetNext())
         {
             uint8_t destinationScope;
+            uint8_t candidateMatchedLength;
 
             candidateAddr = &addr->GetAddress();
-            destinationScope = (destination->PrefixMatch(*candidateAddr) >= addr->mPrefixLength) ?
+            candidateMatchedLength = destination->PrefixMatch(*candidateAddr);
+            destinationScope = (candidateMatchedLength >= addr->mPrefixLength) ?
                                addr->GetScope() : destination->GetScope();
 
             if (candidateAddr->IsAnycastRoutingLocator())
@@ -1028,7 +1030,7 @@ const NetifUnicastAddress *Ip6::SelectSourceAddress(MessageInfo &aMessageInfo)
                 rvalAddr = addr;
                 rvalIface = candidateId;
             }
-            else if (destination->PrefixMatch(*candidateAddr) > destination->PrefixMatch(rvalAddr->GetAddress()))
+            else if (candidateMatchedLength > destination->PrefixMatch(rvalAddr->GetAddress()))
             {
                 // Rule 6: Prefer matching label
                 // Rule 7: Prefer public address

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -972,10 +972,11 @@ const NetifUnicastAddress *Ip6::SelectSourceAddress(MessageInfo &aMessageInfo)
 
         for (const NetifUnicastAddress *addr = netif->mUnicastAddresses; addr; addr = addr->GetNext())
         {
-            candidateAddr = &addr->GetAddress();
-            uint8_t destinationScope = (destination->PrefixMatch(*candidateAddr) >= addr->mPrefixLength) ?
-                                       addr->GetScope() : destination->GetScope();
+            uint8_t destinationScope;
 
+            candidateAddr = &addr->GetAddress();
+            destinationScope = (destination->PrefixMatch(*candidateAddr) >= addr->mPrefixLength) ?
+                               addr->GetScope() : destination->GetScope();
 
             if (candidateAddr->IsAnycastRoutingLocator())
             {

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -999,7 +999,6 @@ const NetifUnicastAddress *Ip6::SelectSourceAddress(MessageInfo &aMessageInfo)
                 // Rule 1: Prefer same address
                 rvalAddr = addr;
                 rvalIface = candidateId;
-                rvalPrefixMatched = candidatePrefixMatched;
                 ExitNow();
             }
             else if (addr->GetScope() < rvalAddr->GetScope())


### PR DESCRIPTION
Currently the result of `SelectSourceAddress()` are mostly wrong after adding an external address. For example,
```
ipaddr add fd11:22::2
```
Then ping the leader,
```
ping ping fdde:ad00:beef:0:0:ff:fe00:fc00
```
It always select the `fd11:22::2` as the source address. The cause is `NetifUnicastAddress::GetScope()` returns the `OverrideScope`, which may return more detailed scope than `Address::GetScope()`.

To solve this issue, the destination must know the same detailed scope as the candidate address. This PR calculates the detailed scope by comparing prefix with the candidate address.

This PR also moves multicast check out from the inner loop.