### PR TITLE
CoAP: add generic uint option support

### DIFF
--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -258,6 +258,21 @@ void otCoapHeaderGenerateToken(otCoapHeader *aHeader, uint8_t aTokenLength);
 ThreadError otCoapHeaderAppendOption(otCoapHeader *aHeader, const otCoapOption *aOption);
 
 /**
+ * This function appends an unsigned integer CoAP option as specified in
+ * https://tools.ietf.org/html/rfc7252#section-3.2
+ *
+ * @param[inout]  aHeader  A pointer to the CoAP header.
+ * @param[in]     aNumber  The CoAP Option number.
+ * @param[in]     aValue   The CoAP Option unsigned integer value.
+ *
+ * @retval kThreadError_None         Successfully appended the option.
+ * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
+ * @retval kThreadError_NoBufs       The option length exceeds the buffer size.
+ *
+ */
+ThreadError otCoapHeaderAppendUintOption(otCoapHeader *aHeader, uint16_t aNumber, uint32_t aValue);
+
+/**
  * This function appends an Observe option.
  *
  * @param[inout]  aHeader   A pointer to the CoAP header.

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -61,6 +61,11 @@ ThreadError otCoapHeaderAppendOption(otCoapHeader *aHeader, const otCoapOption *
     return static_cast<Coap::Header *>(aHeader)->AppendOption(*static_cast<const Coap::Header::Option *>(aOption));
 }
 
+ThreadError otCoapHeaderAppendUintOption(otCoapHeader *aHeader, uint16_t aNumber, uint32_t aValue)
+{
+    return static_cast<Coap::Header *>(aHeader)->AppendUintOption(aNumber, aValue);
+}
+
 ThreadError otCoapHeaderAppendObserveOption(otCoapHeader *aHeader, uint32_t aObserve)
 {
     return static_cast<Coap::Header *>(aHeader)->AppendObserveOption(aObserve);

--- a/src/core/coap/coap_header.cpp
+++ b/src/core/coap/coap_header.cpp
@@ -268,23 +268,28 @@ exit:
     return error;
 }
 
-ThreadError Header::AppendObserveOption(uint32_t aObserve)
+ThreadError Header::AppendUintOption(uint16_t aNumber, uint32_t aValue)
 {
     Option coapOption;
 
-    aObserve = Encoding::BigEndian::HostSwap32(aObserve & 0xFFFFFF);
-    coapOption.mNumber = kCoapOptionObserve;
+    aValue = Encoding::BigEndian::HostSwap32(aValue);
+    coapOption.mNumber = aNumber;
     coapOption.mLength = 4;
-    coapOption.mValue = reinterpret_cast<uint8_t *>(&aObserve);
+    coapOption.mValue = reinterpret_cast<uint8_t *>(&aValue);
 
-    // skip preceding zeros, but make sure mLength is at least 1
-    while (coapOption.mValue[0] == 0 && coapOption.mLength > 1)
+    // skip preceding zeros
+    while (coapOption.mValue[0] == 0 && coapOption.mLength > 0)
     {
         coapOption.mValue++;
         coapOption.mLength--;
     }
 
     return AppendOption(coapOption);
+}
+
+ThreadError Header::AppendObserveOption(uint32_t aObserve)
+{
+    return AppendUintOption(kCoapOptionObserve, aObserve & 0xFFFFFF);
 }
 
 ThreadError Header::AppendUriPathOptions(const char *aUriPath)
@@ -314,33 +319,12 @@ exit:
 
 ThreadError Header::AppendContentFormatOption(MediaType aType)
 {
-    Option coapOption;
-    uint8_t type = static_cast<uint8_t>(aType);
-
-    coapOption.mNumber = kCoapOptionContentFormat;
-    coapOption.mLength = 1;
-    coapOption.mValue = &type;
-
-    return AppendOption(coapOption);
+    return AppendUintOption(kCoapOptionContentFormat, aType);
 }
 
 ThreadError Header::AppendMaxAgeOption(uint32_t aMaxAge)
 {
-    Option coapOption;
-
-    aMaxAge = Encoding::BigEndian::HostSwap32(aMaxAge);
-    coapOption.mNumber = kCoapOptionMaxAge;
-    coapOption.mLength = 4;
-    coapOption.mValue = reinterpret_cast<uint8_t *>(&aMaxAge);
-
-    // skip preceding zeros, but make sure mLength is at least 1
-    while (coapOption.mValue[0] == 0 && coapOption.mLength > 1)
-    {
-        coapOption.mValue++;
-        coapOption.mLength--;
-    }
-
-    return AppendOption(coapOption);
+    return AppendUintOption(kCoapOptionMaxAge, aMaxAge);
 }
 
 ThreadError Header::AppendUriQueryOption(const char *aUriQuery)

--- a/src/core/coap/coap_header.hpp
+++ b/src/core/coap/coap_header.hpp
@@ -274,6 +274,20 @@ public:
     ThreadError AppendOption(const Option &aOption);
 
     /**
+     * This method appends an unsigned integer CoAP option as specified in
+     * https://tools.ietf.org/html/rfc7252#section-3.2
+     *
+     * @param[in]  aNumber  The CoAP Option number.
+     * @param[in]  aValue   The CoAP Option unsigned integer value.
+     *
+     * @retval kThreadError_None         Successfully appended the option.
+     * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
+     * @retval kThreadError_NoBufs       The option length exceeds the buffer size.
+     *
+     */
+    ThreadError AppendUintOption(uint16_t aNumber, uint32_t aValue);
+
+    /**
      * This method appends an Observe option.
      *
      * @param[in]  aObserve  Observe field value.


### PR DESCRIPTION
P.S. Not sure why I had the idea that the value cannot be of zero length. RFCs seems to suggest that empty option is perfectly viable, i.e. defaults to 0.