### PR TITLE
`DataPollManager`: Simplify restarting of data poll timer.

### DIFF
--- a/src/core/thread/data_poll_manager.cpp
+++ b/src/core/thread/data_poll_manager.cpp
@@ -329,16 +329,7 @@ void DataPollManager::ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector)
 
     if (mTimer.IsRunning())
     {
-        uint32_t elapsedTime = Timer::GetNow() - mTimer.Gett0();
-
-        if (elapsedTime >= mPollPeriod)
-        {
-            SendDataPoll();
-        }
-        else
-        {
-            mTimer.Start(mPollPeriod - elapsedTime);
-        }
+        mTimer.StartAt(mTimer.Gett0(), mPollPeriod);
     }
     else
     {


### PR DESCRIPTION

Note that the `Timer` implementation handles the case of an already expired timer (this takes care of the  `if (elapsedTime >= mPollPeriod)` case). Also using `mTimer.StartAt(mTimer.Gett0(), ...)` ensures that the new poll interval starts exactly from previous start time.