### PR TITLE
Add missing error information.

### DIFF
--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -314,7 +314,7 @@ ThreadError Dataset::ProcessCommit(otInstance *aInstance, int argc, char *argv[]
 {
     ThreadError error = kThreadError_None;
 
-    VerifyOrExit(argc > 0);
+    VerifyOrExit(argc > 0, error = kThreadError_InvalidArgs);
 
     if (strcmp(argv[0], "active") == 0)
     {

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -156,14 +156,15 @@ ThreadError Icmp::HandleMessage(Message &aMessage, MessageInfo &aMessageInfo)
     IcmpHeader icmp6Header;
     uint16_t checksum;
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(icmp6Header), &icmp6Header) == sizeof(icmp6Header));
+    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(icmp6Header), &icmp6Header) == sizeof(icmp6Header),
+                 error = kThreadError_Parse);
     payloadLength = aMessage.GetLength() - aMessage.GetOffset();
 
     // verify checksum
     checksum = Ip6::ComputePseudoheaderChecksum(aMessageInfo.GetPeerAddr(), aMessageInfo.GetSockAddr(),
                                                 payloadLength, kProtoIcmp6);
     checksum = aMessage.UpdateChecksum(checksum, aMessage.GetOffset(), payloadLength);
-    VerifyOrExit(checksum == 0xffff);
+    VerifyOrExit(checksum == 0xffff, error = kThreadError_Parse);
 
     if (mIsEchoEnabled && (icmp6Header.GetType() == kIcmp6TypeEchoRequest))
     {

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -178,8 +178,7 @@ ThreadError Ip6::InsertMplOption(Message &aMessage, Header &aIp6Header, MessageI
     ThreadError error = kThreadError_None;
 
     VerifyOrExit(aIp6Header.GetDestination().IsMulticast() &&
-                 aIp6Header.GetDestination().GetScope() >= Address::kRealmLocalScope,
-                 error = kThreadError_InvalidArgs);
+                 aIp6Header.GetDestination().GetScope() >= Address::kRealmLocalScope);
 
     if (aIp6Header.GetDestination().IsRealmLocalMulticast())
     {
@@ -717,7 +716,7 @@ ThreadError Ip6::HandleDatagram(Message &message, Netif *netif, int8_t interface
         {
             forward = true;
 
-            if (fromLocalHost && header.GetDestination().GetScope() >= Address::kRealmLocalScope)
+            if (fromLocalHost)
             {
                 SuccessOrExit(error = InsertMplOption(message, header, messageInfo));
             }

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -220,9 +220,10 @@ ThreadError Udp::HandleMessage(Message &aMessage, MessageInfo &aMessageInfo)
     checksum = Ip6::ComputePseudoheaderChecksum(aMessageInfo.GetPeerAddr(), aMessageInfo.GetSockAddr(),
                                                 payloadLength, kProtoUdp);
     checksum = aMessage.UpdateChecksum(checksum, aMessage.GetOffset(), payloadLength);
-    VerifyOrExit(checksum == 0xffff);
+    VerifyOrExit(checksum == 0xffff, error = kThreadError_Drop);
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(udpHeader), &udpHeader) == sizeof(udpHeader));
+    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(udpHeader), &udpHeader) == sizeof(udpHeader),
+                 error = kThreadError_Parse);
     aMessage.MoveOffset(sizeof(udpHeader));
     aMessageInfo.mPeerPort = udpHeader.GetSourcePort();
     aMessageInfo.mSockPort = udpHeader.GetDestinationPort();

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -89,7 +89,7 @@ ThreadError AnnounceBeginServer::SendAnnounce(uint32_t aChannelMask, uint8_t aCo
     while ((mChannelMask & (1 << mChannel)) == 0)
     {
         mChannel++;
-        VerifyOrExit(mChannel <= kPhyMaxChannel);
+        VerifyOrExit(mChannel <= kPhyMaxChannel, error = kThreadError_InvalidArgs);
     }
 
     mTimer.Start(mPeriod);

--- a/src/core/thread/src_match_controller.cpp
+++ b/src/core/thread/src_match_controller.cpp
@@ -237,7 +237,7 @@ ThreadError SourceMatchController::AddPendingEntries(void)
     {
         if (child->IsStateValidOrRestoring() && child->IsIndirectSourceMatchPending())
         {
-            SuccessOrExit(AddAddress(*child));
+            SuccessOrExit(error = AddAddress(*child));
             child->SetIndirectSourceMatchPending(false);
         }
     }


### PR DESCRIPTION
When I debugging an issue that device doesn't respond to discovery request, I found some error information are not exposed during `HandleDiscoveryRequest` which lead me to the wrong way. After scanning the project, I found more. This PR simply adds these error information. However since I'm not 100% sure if some of these error information should be exposed, please give comments if I'm wrong. Thanks.