### PR TITLE
[settings] save `RouterRoleEnabled` as part of `NetworkInfo` in non-volatile memory

### DIFF
--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -81,6 +81,7 @@ enum
  */
 struct NetworkInfo
 {
+    // Version 1
     uint8_t          mRole;                    ///< Current Thread role.
     uint8_t          mDeviceMode;              ///< Device mode setting.
     uint16_t         mRloc16;                  ///< RLOC16
@@ -90,6 +91,24 @@ struct NetworkInfo
     uint32_t         mPreviousPartitionId;     ///< PartitionId
     Mac::ExtAddress  mExtAddress;              ///< Extended Address
     uint8_t          mMlIid[OT_IP6_IID_SIZE];  ///< IID from ML-EID
+
+    // Version 2
+    uint8_t          mRouterRoleEnabled;       ///< Is router role enabled.
+};
+
+enum
+{
+    /**
+     * Defines the size (in bytes) of the Network Info version 1 (up to and including `mMlIid` field).
+     *
+     */
+    kNetworkInfoV1Size = offsetof(NetworkInfo, mMlIid) + sizeof(NetworkInfo().mMlIid),
+
+    /**
+    * Defines the size (in bytes) of the Network Info version 2 (up to and including `mRouterRoleEnabeld).
+    *
+    */
+    kNetworkInfoV2Size = sizeof(NetworkInfo),
 };
 
 /**

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -278,7 +278,8 @@ otError Mle::Restore(void)
     length = sizeof(networkInfo);
     SuccessOrExit(error = otPlatSettingsGet(netif.GetInstance(), Settings::kKeyNetworkInfo, 0,
                                             reinterpret_cast<uint8_t *>(&networkInfo), &length));
-    VerifyOrExit(length >= sizeof(networkInfo), error = OT_ERROR_NOT_FOUND);
+
+    VerifyOrExit(length >= Settings::kNetworkInfoV1Size, error = OT_ERROR_NOT_FOUND);
 
     netif.GetKeyManager().SetCurrentKeySequence(networkInfo.mKeySequence);
     netif.GetKeyManager().SetMleFrameCounter(networkInfo.mMleFrameCounter);
@@ -298,6 +299,11 @@ otError Mle::Restore(void)
     if (networkInfo.mRloc16 == Mac::kShortAddrInvalid)
     {
         ExitNow();
+    }
+
+    if (length >= Settings::kNetworkInfoV2Size)
+    {
+        netif.GetMle().SetRouterRoleEnabled(networkInfo.mRouterRoleEnabled != 0);
     }
 
     if (!IsActiveRouter(networkInfo.mRloc16))
@@ -364,6 +370,7 @@ otError Mle::Store(void)
         networkInfo.mPreviousPartitionId = mLeaderData.GetPartitionId();
         memcpy(networkInfo.mExtAddress.m8, netif.GetMac().GetExtAddress(), sizeof(networkInfo.mExtAddress));
         memcpy(networkInfo.mMlIid, &mMeshLocal64.GetAddress().mFields.m8[OT_IP6_PREFIX_SIZE], OT_IP6_IID_SIZE);
+        networkInfo.mRouterRoleEnabled = netif.GetMle().IsRouterRoleEnabled() ? 1 : 0;
 
         if (mRole == OT_DEVICE_ROLE_CHILD)
         {

--- a/src/core/thread/mle_router_mtd.hpp
+++ b/src/core/thread/mle_router_mtd.hpp
@@ -52,6 +52,9 @@ public:
 
     bool IsSingleton(void) { return false; }
 
+    bool IsRouterRoleEnabled(void) const { return false; }
+    void SetRouterRoleEnabled(bool) { }
+
     otError BecomeRouter(ThreadStatusTlv::Status) { return OT_ERROR_NOT_CAPABLE; }
     otError BecomeLeader(void) { return OT_ERROR_NOT_CAPABLE; }
 


### PR DESCRIPTION
This commit adds a new field `mRouterRoleEnabled in `NetworkInfo`
structure which contains info that is saved to non-volatile memory.
This ensures that a device configured to act as end-device only does
not become a router after a reset.