### PR TITLE
Remove use of OPENTHREAD_CONFIG option from API header file `thread_ftd.h`

### DIFF
--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -112,8 +112,9 @@ OTAPI bool OTCALL otThreadIsSingleton(otInstance *aInstance);
  * @retval kThreadError_Busy  Already performing an Thread Discovery.
  *
  */
-OTAPI ThreadError OTCALL otThreadDiscover(otInstance *aInstance, uint32_t aScanChannels, uint16_t aPanId, bool aJoiner,
-                                          bool aEnableEui64Filtering, otHandleActiveScanResult aCallback, void *aCallbackContext);
+OTAPI ThreadError OTCALL otThreadDiscover(otInstance *aInstance, uint32_t aScanChannels, uint16_t aPanid, bool aJoiner,
+                                          bool aEnableEui64Filtering, otHandleActiveScanResult aCallback,
+                                          void *aCallbackContext);
 
 /**
  * This function determines if an MLE Thread Discovery is currently in progress.

--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -70,7 +70,7 @@ OTAPI uint8_t OTCALL otThreadGetMaxAllowedChildren(otInstance *aInstance);
  * @param[in]  aInstance     A pointer to an OpenThread instance.
  * @param[in]  aMaxChildren  The maximum allowed children.
  *
- * @retval  kThreadErrorNone           Successfully set the max.
+ * @retval  kThreadError_None          Successfully set the max.
  * @retval  kThreadError_InvalidArgs   If @p aMaxChildren is not in the range [1, OPENTHREAD_CONFIG_MAX_CHILDREN].
  * @retval  kThreadError_InvalidState  If Thread isn't stopped.
  *
@@ -172,27 +172,30 @@ OTAPI uint16_t OTCALL otThreadGetJoinerUdpPort(otInstance *aInstance);
  * @param[in]  aInstance       A pointer to an OpenThread instance.
  * @param[in]  aJoinerUdpPort  The Joiner UDP Port number.
  *
- * @retval  kThreadErrorNone   Successfully set the Joiner UDP Port.
+ * @retval  kThreadError_None  Successfully set the Joiner UDP Port.
  *
  * @sa otThreadGetJoinerUdpPort
  */
 OTAPI ThreadError OTCALL otThreadSetJoinerUdpPort(otInstance *aInstance, uint16_t aJoinerUdpPort);
 
-#if OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
 /**
  * Set Steering data out of band
  *
- * @param[in]  aInstance       A pointer to an OpenThread instance.
- * @param[in]  aExtAddress     Address to indicate steering data.
- *                             All zeros indicate that there is no steering data
- *                             All 0xFFs indicate that there is no filtering
- *                             Specific MAC address
+ * Configuration option `OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB` should be set to enable setting of steering
+ * data out of band. Otherwise calling this function does nothing and it returns `kThreadError_DisabledFeature`
+ * error.
  *
- * @retval  kThreadErrorNone   Successfully set steering data
+ * @param[in]  aInstance       A pointer to an OpenThread instance.
+ * @param[in]  aExtAddress     Address used to update the steering data.
+ *                             All zeros to clear the steering data (no steering data).
+ *                             All 0xFFs to set steering data/bloom filter to accept/allow all.
+ *                             A specific EUI64 which is then added to current steering data/bloom filter.
+ *
+ * @retval  kThreadError_None              Successfully set/updated the steering data.
+ * @retval  kThreadError_DisabledFeature   Feature is disabled, not capable of setting steering data out of band.
  *
  */
 ThreadError otThreadSetSteeringData(otInstance *aInstance, otExtAddress *aExtAddress);
-#endif // OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
 
 /**
  * Get the CONTEXT_ID_REUSE_DELAY parameter used in the Leader role.
@@ -263,7 +266,7 @@ OTAPI void OTCALL otThreadSetRouterUpgradeThreshold(otInstance *aInstance, uint8
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  * @param[in]  aRouterId  The Router ID to release. Valid range is [0, 62].
  *
- * @retval kThreadErrorNone  Successfully released the Router ID specified by aRouterId.
+ * @retval kThreadError_None  Successfully released the Router ID specified by aRouterId.
  */
 OTAPI ThreadError OTCALL otThreadReleaseRouterId(otInstance *aInstance, uint8_t aRouterId);
 
@@ -272,8 +275,8 @@ OTAPI ThreadError OTCALL otThreadReleaseRouterId(otInstance *aInstance, uint8_t 
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.
  *
- * @retval kThreadErrorNone         Successfully begin attempt to become a router.
- * @retval kThreadErrorInvalidState Thread is disabled.
+ * @retval kThreadError_None         Successfully begin attempt to become a router.
+ * @retval kThreadError_InvalidState Thread is disabled.
  */
 OTAPI ThreadError OTCALL otThreadBecomeRouter(otInstance *aInstance);
 
@@ -282,8 +285,8 @@ OTAPI ThreadError OTCALL otThreadBecomeRouter(otInstance *aInstance);
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.
  *
- * @retval kThreadErrorNone          Successfully became a leader and started a new partition.
- * @retval kThreadErrorInvalidState  Thread is disabled.
+ * @retval kThreadError_None          Successfully became a leader and started a new partition.
+ * @retval kThreadError_InvalidState  Thread is disabled.
  */
 OTAPI ThreadError OTCALL otThreadBecomeLeader(otInstance *aInstance);
 

--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -209,6 +209,11 @@ typedef enum ThreadError
      */
     kThreadError_NonLowpanDataFrame = 34,
 
+    /**
+     * A feature/functionality disabled by build-time configuration options.
+     */
+    kThreadError_DisabledFeature = 35,
+
     kThreadError_Error = 255,
 } ThreadError;
 

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -31,12 +31,19 @@
  *   This file implements the OpenThread Thread API (FTD only).
  */
 
-#if OPENTHREAD_FTD
-
 #define WPP_NAME "thread_ftd_api.tmh"
+
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
+#if OPENTHREAD_FTD
 
 #include <openthread/thread_ftd.h>
 
+#include "openthread-core-config.h"
 #include "openthread-instance.h"
 
 using namespace ot;
@@ -237,11 +244,21 @@ exit:
     return error;
 }
 
-#if OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
+
 ThreadError otThreadSetSteeringData(otInstance *aInstance, otExtAddress *aExtAddress)
 {
-    return aInstance->mThreadNetif.GetMle().SetSteeringData(aExtAddress);
+    ThreadError error;
+
+#if OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
+    error = aInstance->mThreadNetif.GetMle().SetSteeringData(aExtAddress);
+#else
+    (void)aInstance;
+    (void)aExtAddress;
+
+    error = kThreadError_DisabledFeature;
+#endif  // OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
+
+    return error;
 }
-#endif // OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
 
 #endif // OPENTHREAD_FTD

--- a/src/core/common/logging.cpp
+++ b/src/core/common/logging.cpp
@@ -405,6 +405,10 @@ const char *otThreadErrorToString(ThreadError aError)
         retval = "NonLowpanDataFrame";
         break;
 
+    case kThreadError_DisabledFeature:
+        retval = "DisabledFeature";
+        break;
+
     case kThreadError_Error:
         retval = "GenericError";
         break;


### PR DESCRIPTION
This commit removes the use of an OpenThread configuration option
`OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB` from API header file
`thread_ftd.h`. It also changes the `otThreadSetSteeringData()` to
return `NotCapable` error when this option is disabled. This commit
also includes minor typo fixes in the comments of the same file(s).