### PR TITLE
Plat nrf52840: undefine "MBEDTLS_SHA256_ALT" for interoperability.

### DIFF
--- a/examples/platforms/nrf52840/crypto/nrf52840-mbedtls-config.h
+++ b/examples/platforms/nrf52840/crypto/nrf52840-mbedtls-config.h
@@ -26,4 +26,6 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
- #define MBEDTLS_SHA256_ALT
+/* MBEDTLS_SHA256_ALT was used to redefine context structure.
+   Undefine it now to enable default mbedTLS implementation. */
+#undef MBEDTLS_SHA256_ALT

--- a/examples/platforms/nrf52840/crypto/sha256_alt.h
+++ b/examples/platforms/nrf52840/crypto/sha256_alt.h
@@ -107,8 +107,4 @@ void mbedtls_sha256_process(mbedtls_sha256_context *ctx, const unsigned char dat
 #endif
 
 #endif /* MBEDTLS_SHA256_ALT */
-
-/* MBEDTLS_SHA256_ALT was used to redifine context structure. Undefine it now to enable default mbedTLS implementation. */
-#undef MBEDTLS_SHA256_ALT
-
 #endif /* MBEDTLS_SHA256_ALT_H */


### PR DESCRIPTION
When I try to do interop testing with nrf52840 and cc2538, notice that nrf52840 doesn't attach to the thread network formed by cc2538, nrf52840 becomes Leader as well. From pcap file, notice that the MIC code of MLE message cannot be decrypted correctly.

This should be caused by using a different `mbedtls_sha256_context` structure with the definition in mbedTLS. Although uncomment the macro `MBEDTLS_SHA256_ALT`, mbedTLS would use the sha256 context defined in `sha256_alt.h`. That causes getting a different MLE key to encrypt/decrypt MLE messages. So uncomment `MBEDTLS_SHA256_ALT` in MBEDTLS_USER_CONFIG_FILE to enable all default sha256 implementation. Please have a check. Thanks.