### PR TITLE
Append Commissioning Data when transmitting stable Network Data

### DIFF
--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -83,6 +83,7 @@ void NetworkData::GetNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLen
 
     if (aStable)
     {
+        SetCommissioningDataStable(aData, aDataLength);
         RemoveTemporaryData(aData, aDataLength);
     }
 }
@@ -423,6 +424,22 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, Pref
             aPrefix.SetSubTlvsLength(aPrefix.GetSubTlvsLength() - length);
             aDataLength -= length;
         }
+    }
+}
+
+void NetworkData::SetCommissioningDataStable(uint8_t *aData, uint8_t aDataLength)
+{
+    NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(aData);
+    NetworkDataTlv *end = reinterpret_cast<NetworkDataTlv *>(aData + aDataLength);
+
+    while (cur < end)
+    {
+        if (cur->GetType() == NetworkDataTlv::kTypeCommissioningData)
+        {
+            cur->SetStable();
+        }
+
+        cur = cur->GetNext();
     }
 }
 

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -329,6 +329,15 @@ protected:
     void RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, PrefixTlv &aPrefix);
 
     /**
+     * This method sets stable bit in Commissioning Data TLV.
+     *
+     * @param[inout]  aData        A pointer to the Network Data to modify.
+     * @param[in]     aDataLength  The size of the Network Data in bytes.
+     *
+     */
+    void SetCommissioningDataStable(uint8_t *aData, uint8_t aDataLength);
+
+    /**
      * This method computes the number of IPv6 Prefix bits that match.
      *
      * @param[in]  a        A pointer to the first IPv6 Prefix.


### PR DESCRIPTION
According to Thread specification when stable Network Data is transmitted it must include a Commissioning Data TLV with the Stable flag set to one. This PR provides required feature. Without this patch certification test 7.1.3 in Thread Harness 1.1.0 fails.