### PR TITLE
Make default mbedTLS heap size configurable

### DIFF
--- a/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
+++ b/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
@@ -123,4 +123,12 @@
  */
 #define OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE                     (4096 * sizeof(void *))
 
+/**
+ * @def OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE_NO_DTLS
+ *
+ * The size of mbedTLS heap buffer when DTLS is disabled.
+ *
+ */
+#define OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE_NO_DTLS             2048
+
 #endif  // OPENTHREAD_CORE_NRF52840_CONFIG_H_

--- a/src/core/crypto/mbedtls.hpp
+++ b/src/core/crypto/mbedtls.hpp
@@ -64,9 +64,9 @@ public:
     enum
     {
 #if OPENTHREAD_ENABLE_DTLS
-        kMemorySize = OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE, ///< Size of memory buffer (bytes).
+        kMemorySize = OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE,          ///< Size of memory buffer (bytes).
 #else
-        kMemorySize = 384,                                 ///< Size of memory buffer (bytes).
+        kMemorySize = OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE_NO_DTLS,  ///< Size of memory buffer (bytes).
 #endif
     };
 

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -726,6 +726,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE_NO_DTLS
+ *
+ * The size of mbedTLS heap buffer when DTLS is disabled.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE_NO_DTLS
+#define OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE_NO_DTLS             384
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
  *
  * Enable setting steering data out of band.


### PR DESCRIPTION
This PR provides a solution for issue pointed out in #1750 , without modyfing SHA context size for nrf52840. Please check that PR for more information.
