### PR TITLE
Clean up error type and names.

### DIFF
--- a/examples/apps/windows/MainPage.xaml.cpp
+++ b/examples/apps/windows/MainPage.xaml.cpp
@@ -169,7 +169,7 @@ void MainPage::ShowInterfaceDetails(otAdapter^ adapter)
         {
             uint8_t index = 0;
             otChildInfo childInfo;
-            while (kThreadError_None == otThreadGetChildInfoByIndex((otInstance*)(void*)adapter->RawHandle, index, &childInfo))
+            while (OT_ERROR_NONE == otThreadGetChildInfoByIndex((otInstance*)(void*)adapter->RawHandle, index, &childInfo))
             {
                 index++;
             }

--- a/examples/apps/windows/otAdapter.h
+++ b/examples/apps/windows/otAdapter.h
@@ -581,23 +581,23 @@ private:
 
     static HRESULT
     TheadErrorToHResult(
-        int /* ThreadError */ error
+        int /* otError */ error
     )
     {
         switch (error)
         {
-        case kThreadError_NoBufs:           return E_OUTOFMEMORY;
-        case kThreadError_Drop:
-        case kThreadError_NoRoute:          return HRESULT_FROM_WIN32(ERROR_NETWORK_UNREACHABLE);
-        case kThreadError_InvalidArgs:      return E_INVALIDARG;
-        case kThreadError_Security:         return E_ACCESSDENIED;
-        case kThreadError_NotCapable:
-        case kThreadError_NotImplemented:   return E_NOTIMPL;
-        case kThreadError_InvalidState:     return E_NOT_VALID_STATE;
-        case kThreadError_NotFound:         return HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
-        case kThreadError_Already:          return HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS);
-        case kThreadError_ResponseTimeout:  return HRESULT_FROM_WIN32(ERROR_TIMEOUT);
-        default:                            return E_FAIL;
+        case OT_ERROR_NO_BUFS:           return E_OUTOFMEMORY;
+        case OT_ERROR_DROP:
+        case OT_ERROR_NO_ROUTE:          return HRESULT_FROM_WIN32(ERROR_NETWORK_UNREACHABLE);
+        case OT_ERROR_INVALID_ARGS:      return E_INVALIDARG;
+        case OT_ERROR_SECURITY:          return E_ACCESSDENIED;
+        case OT_ERROR_NOT_CAPABLE:
+        case OT_ERROR_NOT_IMPLEMENTED:   return E_NOTIMPL;
+        case OT_ERROR_INVALID_STATE:     return E_NOT_VALID_STATE;
+        case OT_ERROR_NOT_FOUND:         return HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
+        case OT_ERROR_ALREADY:           return HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS);
+        case OT_ERROR_RESPONSE_TIMEOUT:  return HRESULT_FROM_WIN32(ERROR_TIMEOUT);
+        default:                         return E_FAIL;
         }
     }
 };

--- a/examples/drivers/windows/include/otLwfIoctl.h
+++ b/examples/drivers/windows/include/otLwfIoctl.h
@@ -37,7 +37,7 @@
 
 #include <openthread/types.h>
 
-__inline LONG ThreadErrorToNtstatus(ThreadError error) { return (LONG)-((int)error); }
+__inline LONG ThreadErrorToNtstatus(otError error) { return (LONG)-((int)error); }
 
 // User-mode IOCTL path for CreateFile
 #define OTLWF_IOCLT_PATH      TEXT("\\\\.\\\\otlwf")
@@ -128,7 +128,7 @@ typedef enum _OTLWF_NOTIF_TYPE
             // Payload for OTLWF_NOTIF_JOINER_COMPLETE
             struct
             {
-                ThreadError             Error;
+                otError             Error;
             } JoinerCompletePayload;
         };
     } OTLWF_NOTIFICATION, *POTLWF_NOTIFICATION;

--- a/examples/drivers/windows/otApi/otApi.cpp
+++ b/examples/drivers/windows/otApi/otApi.cpp
@@ -942,18 +942,18 @@ SetIOCTL(
     return SendIOCTL(aInstance->ApiHandle, dwIoControlCode, &aInstance->InterfaceGuid, sizeof(GUID), nullptr, 0);
 }
 
-ThreadError
+otError
 DwordToThreadError(
     DWORD dwError
     )
 {
     if (((int)dwError) > 0)
     {
-        return kThreadError_Error;
+        return OT_ERROR_GENERIC;
     }
     else
     {
-        return (ThreadError)(-(int)dwError);
+        return (otError)(-(int)dwError);
     }
 }
 
@@ -1189,14 +1189,14 @@ otGetVersionString()
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otIp6SetEnabled(
     _In_ otInstance *aInstance,
     bool aEnabled
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_INTERFACE, (BOOLEAN)aEnabled));
 }
 
@@ -1213,26 +1213,26 @@ otIp6IsEnabled(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otThreadSetEnabled(
     _In_ otInstance *aInstance,
     bool aEnabled
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_THREAD, (BOOLEAN)aEnabled));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadSetAutoStart(
     _In_ otInstance *aInstance,
     bool aStartAutomatically
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_THREAD_AUTO_START, (BOOLEAN)(aStartAutomatically ? TRUE : FALSE)));
 }
 
@@ -1261,7 +1261,7 @@ otThreadIsSingleton(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otLinkActiveScan(
     _In_ otInstance *aInstance, 
@@ -1271,7 +1271,7 @@ otLinkActiveScan(
     _In_ void *aCallbackContext
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
 
     aInstance->ApiHandle->SetCallback(
         aInstance->ApiHandle->ActiveScanCallbacks,
@@ -1295,7 +1295,7 @@ otLinkIsActiveScanInProgress(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL 
 otLinkEnergyScan(
     _In_ otInstance *aInstance, 
@@ -1305,7 +1305,7 @@ otLinkEnergyScan(
     _In_ void *aCallbackContext
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
 
     aInstance->ApiHandle->SetCallback(
         aInstance->ApiHandle->EnergyScanCallbacks,
@@ -1329,7 +1329,7 @@ otLinkIsEnergyScanInProgress(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otThreadDiscover(
     _In_ otInstance *aInstance, 
@@ -1341,7 +1341,7 @@ otThreadDiscover(
     void *aCallbackContext
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
 
     aInstance->ApiHandle->SetCallback(
         aInstance->ApiHandle->DiscoverCallbacks,
@@ -1365,15 +1365,15 @@ otIsDiscoverInProgress(
 }
 
 OTAPI 
-ThreadError
+otError
 OTCALL
 otLinkSendDataRequest(
     _In_ otInstance *aInstance
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     UNREFERENCED_PARAMETER(aInstance);
-    return kThreadError_NotImplemented; // TODO
+    return OT_ERROR_NOT_IMPLEMENTED; // TODO
 }
 
 OTAPI 
@@ -1389,29 +1389,29 @@ otLinkGetChannel(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otLinkSetChannel(
     _In_ otInstance *aInstance, 
     uint8_t aChannel
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_CHANNEL, aChannel));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otDatasetSetDelayTimerMinimal(
     _In_ otInstance *aInstance,
     uint32_t aDelayTimerMinimal
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     // TODO
     UNREFERENCED_PARAMETER(aDelayTimerMinimal);
-    return kThreadError_NotImplemented;
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
 OTAPI
@@ -1439,14 +1439,14 @@ otThreadGetMaxAllowedChildren(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otThreadSetMaxAllowedChildren(
     _In_ otInstance *aInstance, 
     uint8_t aMaxChildren
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_MAX_CHILDREN, aMaxChildren));
 }
 
@@ -1494,14 +1494,14 @@ otLinkGetExtendedAddress(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otLinkSetExtendedAddress(
     _In_ otInstance *aInstance, 
     const otExtAddress *aExtendedAddress
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_EXTENDED_ADDRESS, aExtendedAddress));
 }
 
@@ -1524,14 +1524,14 @@ otThreadGetExtendedPanId(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otThreadSetExtendedPanId(
     _In_ otInstance *aInstance, 
     const uint8_t *aExtendedPanId
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_EXTENDED_PANID, (const otExtendedPanId*)aExtendedPanId));
 }
 
@@ -1560,14 +1560,14 @@ otLinkGetJoinerId(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otThreadGetLeaderRloc(
     _In_ otInstance *aInstance, 
     _Out_ otIp6Address *aLeaderRloc
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(QueryIOCTL(aInstance, IOCTL_OTLWF_OT_LEADER_RLOC, aLeaderRloc));
 }
 
@@ -1585,14 +1585,14 @@ otThreadGetLinkMode(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otThreadSetLinkMode(
     _In_ otInstance *aInstance, 
     otLinkModeConfig aConfig
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     static_assert(sizeof(otLinkModeConfig) == 4, "The size of otLinkModeConfig should be 4 bytes");
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_LINK_MODE, aConfig));
 }
@@ -1617,14 +1617,14 @@ otThreadGetMasterKey(
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadSetMasterKey(
     _In_ otInstance *aInstance, 
     const otMasterKey *aKey
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_MASTER_KEY, aKey));
 }
@@ -1649,14 +1649,14 @@ otThreadGetPSKc(
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadSetPSKc(
     _In_ otInstance *aInstance, 
     const uint8_t *aPSKc 
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     
     BYTE Buffer[sizeof(GUID) + sizeof(otPSKc)];
     memcpy_s(Buffer, sizeof(Buffer), &aInstance->InterfaceGuid, sizeof(GUID));
@@ -1723,19 +1723,19 @@ otThreadGetMeshLocalPrefix(
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadSetMeshLocalPrefix(
     _In_ otInstance *aInstance, 
     const uint8_t *aMeshLocalPrefix
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_MESH_LOCAL_PREFIX, (const otMeshLocalPrefix*)aMeshLocalPrefix));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadGetNetworkDataLeader(
     _In_ otInstance *aInstance, 
@@ -1744,16 +1744,16 @@ otThreadGetNetworkDataLeader(
     _Out_ uint8_t *aDataLength
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     UNREFERENCED_PARAMETER(aInstance);
     UNREFERENCED_PARAMETER(aStable);
     UNREFERENCED_PARAMETER(aData);
     UNREFERENCED_PARAMETER(aDataLength);
-    return kThreadError_NotImplemented; // TODO
+    return OT_ERROR_NOT_IMPLEMENTED; // TODO
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadGetNetworkDataLocal(
     _In_ otInstance *aInstance, 
@@ -1762,12 +1762,12 @@ otThreadGetNetworkDataLocal(
     _Out_ uint8_t *aDataLength
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     UNREFERENCED_PARAMETER(aInstance);
     UNREFERENCED_PARAMETER(aStable);
     UNREFERENCED_PARAMETER(aData);
     UNREFERENCED_PARAMETER(aDataLength);
-    return kThreadError_NotImplemented; // TODO
+    return OT_ERROR_NOT_IMPLEMENTED; // TODO
 }
 
 OTAPI
@@ -1789,14 +1789,14 @@ otThreadGetNetworkName(
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadSetNetworkName(
     _In_ otInstance *aInstance, 
     _In_ const char *aNetworkName
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
 
     otNetworkName Buffer = {0};
     strcpy_s(Buffer.m8, sizeof(Buffer), aNetworkName);
@@ -1804,7 +1804,7 @@ otThreadSetNetworkName(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otNetDataGetNextPrefixInfo(
     _In_ otInstance *aInstance, 
@@ -1813,13 +1813,13 @@ otNetDataGetNextPrefixInfo(
     _Out_ otBorderRouterConfig *aConfig
     )
 {
-    if (aInstance == nullptr || aConfig == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr || aConfig == nullptr) return OT_ERROR_INVALID_ARGS;
     
     BOOLEAN aLocal = _aLocal ? TRUE : FALSE;
     PackedBuffer3<GUID,BOOLEAN,otNetworkDataIterator> InBuffer(aInstance->InterfaceGuid, aLocal, *aIterator);
     BYTE OutBuffer[sizeof(uint8_t) + sizeof(otBorderRouterConfig)];
 
-    ThreadError aError = 
+    otError aError = 
         DwordToThreadError(
             SendIOCTL(
                 aInstance->ApiHandle, 
@@ -1827,7 +1827,7 @@ otNetDataGetNextPrefixInfo(
                 &InBuffer, sizeof(InBuffer), 
                 OutBuffer, sizeof(OutBuffer)));
 
-    if (aError == kThreadError_None)
+    if (aError == OT_ERROR_NONE)
     {
         memcpy(aIterator, OutBuffer, sizeof(uint8_t));
         memcpy(aConfig, OutBuffer + sizeof(uint8_t), sizeof(otBorderRouterConfig));
@@ -1853,14 +1853,14 @@ otLinkGetPanId(
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otLinkSetPanId(
     _In_ otInstance *aInstance, 
     otPanId aPanId
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_PAN_ID, aPanId));
 }
 
@@ -1888,14 +1888,14 @@ otThreadSetRouterRoleEnabled(
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadSetPreferredRouterId(
     _In_ otInstance *aInstance,
     uint8_t aRouterId
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_PAN_ID, aRouterId));
 }
 
@@ -2049,14 +2049,14 @@ otIp6GetUnicastAddresses(
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otIp6AddUnicastAddress(
     _In_ otInstance *aInstance, 
     const otNetifAddress *aAddress
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
 
     // Put the current thead in the correct compartment
     bool RevertCompartmentOnExit = false;
@@ -2067,7 +2067,7 @@ otIp6AddUnicastAddress(
         if ((dwError = SetCurrentThreadCompartmentId(aInstance->CompartmentID)) != ERROR_SUCCESS)
         {
             LogError(API_DEFAULT, "SetCurrentThreadCompartmentId failed, %!WINERROR!", dwError);
-            return kThreadError_Failed;
+            return OT_ERROR_FAILED;
         }
         RevertCompartmentOnExit = true;
     }
@@ -2109,21 +2109,21 @@ otIp6AddUnicastAddress(
     if (dwError != ERROR_SUCCESS)
     {
         LogError(API_DEFAULT, "CreateUnicastIpAddressEntry failed %!WINERROR!", dwError);
-        return kThreadError_Failed;
+        return OT_ERROR_FAILED;
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otIp6RemoveUnicastAddress(
     _In_ otInstance *aInstance, 
     const otIp6Address *aAddress
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
 
     // Put the current thead in the correct compartment
     bool RevertCompartmentOnExit = false;
@@ -2134,7 +2134,7 @@ otIp6RemoveUnicastAddress(
         if ((dwError = SetCurrentThreadCompartmentId(aInstance->CompartmentID)) != ERROR_SUCCESS)
         {
             LogError(API_DEFAULT, "SetCurrentThreadCompartmentId failed, %!WINERROR!", dwError);
-            return kThreadError_Failed;
+            return OT_ERROR_FAILED;
         }
         RevertCompartmentOnExit = true;
     }
@@ -2159,14 +2159,14 @@ otIp6RemoveUnicastAddress(
     if (dwError != ERROR_SUCCESS)
     {
         LogError(API_DEFAULT, "DeleteUnicastIpAddressEntry failed %!WINERROR!", dwError);
-        return kThreadError_Failed;
+        return OT_ERROR_FAILED;
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 OTAPI
-ThreadError 
+otError 
 OTCALL
 otSetStateChangedCallback(
     _In_ otInstance *aInstance, 
@@ -2174,13 +2174,13 @@ otSetStateChangedCallback(
     _In_ void *aContext
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     bool success = 
         aInstance->ApiHandle->SetCallback(
             aInstance->ApiHandle->StateChangedCallbacks,
             aInstance->InterfaceGuid, aCallback, aContext
             );
-    return success ? kThreadError_None : kThreadError_Already;
+    return success ? OT_ERROR_NONE : OT_ERROR_ALREADY;
 }
 
 OTAPI
@@ -2200,55 +2200,55 @@ otRemoveStateChangeCallback(
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otDatasetGetActive(
     _In_ otInstance *aInstance, 
     _Out_ otOperationalDataset *aDataset
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(QueryIOCTL(aInstance, IOCTL_OTLWF_OT_ACTIVE_DATASET, aDataset));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otDatasetSetActive(
     _In_ otInstance *aInstance, 
     const otOperationalDataset *aDataset
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_ACTIVE_DATASET, aDataset));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otDatasetGetPending(
     _In_ otInstance *aInstance, 
     _Out_ otOperationalDataset *aDataset
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(QueryIOCTL(aInstance, IOCTL_OTLWF_OT_PENDING_DATASET, aDataset));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otDatasetSetPending(
     _In_ otInstance *aInstance, 
     const otOperationalDataset *aDataset
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_PENDING_DATASET, aDataset));
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otDatasetSendMgmtActiveGet(
     _In_ otInstance *aInstance, 
@@ -2257,13 +2257,13 @@ otDatasetSendMgmtActiveGet(
     _In_opt_ const otIp6Address *aAddress
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
-    if (aTlvTypes == nullptr && aLength != 0) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
+    if (aTlvTypes == nullptr && aLength != 0) return OT_ERROR_INVALID_ARGS;
     
     DWORD BufferSize = sizeof(GUID) + sizeof(uint8_t) + aLength;
     if (aAddress) BufferSize += sizeof(otIp6Address);
     PBYTE Buffer = (PBYTE)malloc(BufferSize);
-    if (Buffer == nullptr) return kThreadError_NoBufs;
+    if (Buffer == nullptr) return OT_ERROR_NO_BUFS;
 
     memcpy_s(Buffer, BufferSize, &aInstance->InterfaceGuid, sizeof(GUID));
     memcpy_s(Buffer + sizeof(GUID), BufferSize - sizeof(GUID), &aLength, sizeof(aLength));
@@ -2272,7 +2272,7 @@ otDatasetSendMgmtActiveGet(
     if (aAddress)
         memcpy_s(Buffer + sizeof(GUID) + sizeof(uint8_t) + aLength, BufferSize - sizeof(GUID) - sizeof(uint8_t) - aLength, aAddress, sizeof(otIp6Address));
     
-    ThreadError result = 
+    otError result = 
         DwordToThreadError(SendIOCTL(aInstance->ApiHandle, IOCTL_OTLWF_OT_SEND_ACTIVE_GET, Buffer, BufferSize, nullptr, 0));
 
     free(Buffer);
@@ -2280,7 +2280,7 @@ otDatasetSendMgmtActiveGet(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otDatasetSendMgmtActiveSet(
     _In_ otInstance *aInstance, 
@@ -2289,12 +2289,12 @@ otDatasetSendMgmtActiveSet(
     uint8_t aLength
     )
 {
-    if (aInstance == nullptr || aDataset == nullptr) return kThreadError_InvalidArgs;
-    if (aTlvs == nullptr && aLength != 0) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr || aDataset == nullptr) return OT_ERROR_INVALID_ARGS;
+    if (aTlvs == nullptr && aLength != 0) return OT_ERROR_INVALID_ARGS;
     
     DWORD BufferSize = sizeof(GUID) + sizeof(otOperationalDataset) + sizeof(uint8_t) + aLength;
     PBYTE Buffer = (PBYTE)malloc(BufferSize);
-    if (Buffer == nullptr) return kThreadError_NoBufs;
+    if (Buffer == nullptr) return OT_ERROR_NO_BUFS;
 
     memcpy_s(Buffer, BufferSize, &aInstance->InterfaceGuid, sizeof(GUID));
     memcpy_s(Buffer + sizeof(GUID), BufferSize - sizeof(GUID), aDataset, sizeof(otOperationalDataset));
@@ -2302,7 +2302,7 @@ otDatasetSendMgmtActiveSet(
     if (aLength > 0)
         memcpy_s(Buffer + sizeof(GUID) + sizeof(otOperationalDataset) + sizeof(uint8_t), BufferSize - sizeof(GUID) - sizeof(otOperationalDataset) - sizeof(uint8_t), aTlvs, aLength);
     
-    ThreadError result = 
+    otError result = 
         DwordToThreadError(SendIOCTL(aInstance->ApiHandle, IOCTL_OTLWF_OT_SEND_ACTIVE_SET, Buffer, BufferSize, nullptr, 0));
 
     free(Buffer);
@@ -2310,7 +2310,7 @@ otDatasetSendMgmtActiveSet(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otDatasetSendMgmtPendingGet(
     _In_ otInstance *aInstance, 
@@ -2319,13 +2319,13 @@ otDatasetSendMgmtPendingGet(
     _In_opt_ const otIp6Address *aAddress
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
-    if (aTlvTypes == nullptr && aLength != 0) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
+    if (aTlvTypes == nullptr && aLength != 0) return OT_ERROR_INVALID_ARGS;
     
     DWORD BufferSize = sizeof(GUID) + sizeof(uint8_t) + aLength;
     if (aAddress) BufferSize += sizeof(otIp6Address);
     PBYTE Buffer = (PBYTE)malloc(BufferSize);
-    if (Buffer == nullptr) return kThreadError_NoBufs;
+    if (Buffer == nullptr) return OT_ERROR_NO_BUFS;
 
     memcpy_s(Buffer, BufferSize, &aInstance->InterfaceGuid, sizeof(GUID));
     memcpy_s(Buffer + sizeof(GUID), BufferSize - sizeof(GUID), &aLength, sizeof(aLength));
@@ -2334,7 +2334,7 @@ otDatasetSendMgmtPendingGet(
     if (aAddress)
         memcpy_s(Buffer + sizeof(GUID) + sizeof(uint8_t) + aLength, BufferSize - sizeof(GUID) - sizeof(uint8_t) - aLength, aAddress, sizeof(otIp6Address));
     
-    ThreadError result = 
+    otError result = 
         DwordToThreadError(SendIOCTL(aInstance->ApiHandle, IOCTL_OTLWF_OT_SEND_PENDING_GET, Buffer, BufferSize, nullptr, 0));
 
     free(Buffer);
@@ -2342,7 +2342,7 @@ otDatasetSendMgmtPendingGet(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otDatasetSendMgmtPendingSet(
     _In_ otInstance *aInstance, 
@@ -2351,12 +2351,12 @@ otDatasetSendMgmtPendingSet(
     uint8_t aLength
     )
 {
-    if (aInstance == nullptr || aDataset == nullptr) return kThreadError_InvalidArgs;
-    if (aTlvs == nullptr && aLength != 0) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr || aDataset == nullptr) return OT_ERROR_INVALID_ARGS;
+    if (aTlvs == nullptr && aLength != 0) return OT_ERROR_INVALID_ARGS;
     
     DWORD BufferSize = sizeof(GUID) + sizeof(otOperationalDataset) + sizeof(uint8_t) + aLength;
     PBYTE Buffer = (PBYTE)malloc(BufferSize);
-    if (Buffer == nullptr) return kThreadError_NoBufs;
+    if (Buffer == nullptr) return OT_ERROR_NO_BUFS;
 
     memcpy_s(Buffer, BufferSize, &aInstance->InterfaceGuid, sizeof(GUID));
     memcpy_s(Buffer + sizeof(GUID), BufferSize - sizeof(GUID), aDataset, sizeof(otOperationalDataset));
@@ -2364,7 +2364,7 @@ otDatasetSendMgmtPendingSet(
     if (aLength > 0)
         memcpy_s(Buffer + sizeof(GUID) + sizeof(otOperationalDataset) + sizeof(uint8_t), BufferSize - sizeof(GUID) - sizeof(otOperationalDataset) - sizeof(uint8_t), aTlvs, aLength);
     
-    ThreadError result = 
+    otError result = 
         DwordToThreadError(SendIOCTL(aInstance->ApiHandle, IOCTL_OTLWF_OT_SEND_PENDING_SET, Buffer, BufferSize, nullptr, 0));
 
     free(Buffer);
@@ -2453,73 +2453,73 @@ otThreadGetJoinerUdpPort(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL 
 otThreadSetJoinerUdpPort(
     _In_ otInstance *aInstance, 
     uint16_t aJoinerUdpPort
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_JOINER_UDP_PORT, aJoinerUdpPort));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otNetDataAddPrefixInfo(
     _In_ otInstance *aInstance, 
     const otBorderRouterConfig *aConfig
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_ADD_BORDER_ROUTER, aConfig));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otNetDataRemovePrefixInfo(
     _In_ otInstance *aInstance, 
     const otIp6Prefix *aPrefix
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_REMOVE_BORDER_ROUTER, aPrefix));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otNetDataAddRoute(
     _In_ otInstance *aInstance, 
     const otExternalRouteConfig *aConfig
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_ADD_EXTERNAL_ROUTE, aConfig));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otNetDataRemoveRoute(
     _In_ otInstance *aInstance, 
     const otIp6Prefix *aPrefix
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_REMOVE_EXTERNAL_ROUTE, aPrefix));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otNetDataRegister(
     _In_ otInstance *aInstance
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_SEND_SERVER_DATA));
 }
 
@@ -2685,31 +2685,31 @@ otThreadSetRouterSelectionJitter(
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadReleaseRouterId(
     _In_ otInstance *aInstance, 
     uint8_t aRouterId
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_RELEASE_ROUTER_ID, aRouterId));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otLinkAddWhitelist(
     _In_ otInstance *aInstance, 
     const uint8_t *aExtAddr
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_ADD_MAC_WHITELIST, (const otExtAddress*)aExtAddr));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otLinkAddWhitelistRssi(
     _In_ otInstance *aInstance, 
@@ -2717,7 +2717,7 @@ otLinkAddWhitelistRssi(
     int8_t aRssi
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     
     PackedBuffer3<GUID,otExtAddress,int8_t> Buffer(aInstance->InterfaceGuid, *(otExtAddress*)aExtAddr, aRssi);
     return DwordToThreadError(SendIOCTL(aInstance->ApiHandle, IOCTL_OTLWF_OT_ADD_MAC_WHITELIST, &Buffer, sizeof(Buffer), nullptr, 0));
@@ -2735,7 +2735,7 @@ otLinkRemoveWhitelist(
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otLinkGetWhitelistEntry(
     _In_ otInstance *aInstance, 
@@ -2743,7 +2743,7 @@ otLinkGetWhitelistEntry(
     _Out_ otMacWhitelistEntry *aEntry
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(QueryIOCTL(aInstance, IOCTL_OTLWF_OT_MAC_WHITELIST_ENTRY, &aIndex, aEntry));
 }
 
@@ -2781,25 +2781,25 @@ otLinkIsWhitelistEnabled(
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadBecomeDetached(
     _In_ otInstance *aInstance
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_DEVICE_ROLE, (uint8_t)kDeviceRoleDetached));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadBecomeChild(
     _In_ otInstance *aInstance, 
     otMleAttachFilter aFilter
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
 
     uint8_t Role = kDeviceRoleDetached;
     uint8_t Filter = (uint8_t)aFilter;
@@ -2809,36 +2809,36 @@ otThreadBecomeChild(
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadBecomeRouter(
     _In_ otInstance *aInstance
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_DEVICE_ROLE, (uint8_t)kDeviceRoleRouter));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadBecomeLeader(
     _In_ otInstance *aInstance
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_DEVICE_ROLE, (uint8_t)kDeviceRoleLeader));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otLinkAddBlacklist(
     _In_ otInstance *aInstance, 
     const uint8_t *aExtAddr
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_ADD_MAC_BLACKLIST, (const otExtAddress*)aExtAddr));
 }
 
@@ -2854,7 +2854,7 @@ otLinkRemoveBlacklist(
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otLinkGetBlacklistEntry(
     _In_ otInstance *aInstance, 
@@ -2862,7 +2862,7 @@ otLinkGetBlacklistEntry(
     _Out_ otMacBlacklistEntry *aEntry
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(QueryIOCTL(aInstance, IOCTL_OTLWF_OT_MAC_BLACKLIST_ENTRY, &aIndex, aEntry));
 }
 
@@ -2900,7 +2900,7 @@ otLinkIsBlacklistEnabled(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otLinkGetAssignLinkQuality(
     _In_ otInstance *aInstance, 
@@ -2908,7 +2908,7 @@ otLinkGetAssignLinkQuality(
     _Out_ uint8_t *aLinkQuality
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(QueryIOCTL(aInstance, IOCTL_OTLWF_OT_ASSIGN_LINK_QUALITY, (otExtAddress*)aExtAddr, aLinkQuality));
 }
 
@@ -2947,7 +2947,7 @@ otInstanceFactoryReset(
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadGetChildInfoById(
     _In_ otInstance *aInstance, 
@@ -2955,12 +2955,12 @@ otThreadGetChildInfoById(
     _Out_ otChildInfo *aChildInfo
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(QueryIOCTL(aInstance, IOCTL_OTLWF_OT_CHILD_INFO_BY_ID, &aChildId, aChildInfo));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadGetChildInfoByIndex(
     _In_ otInstance *aInstance, 
@@ -2968,12 +2968,12 @@ otThreadGetChildInfoByIndex(
     _Out_ otChildInfo *aChildInfo
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(QueryIOCTL(aInstance, IOCTL_OTLWF_OT_CHILD_INFO_BY_INDEX, &aChildIndex, aChildInfo));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadGetNextNeighborInfo(
     _In_ otInstance *aInstance,
@@ -2981,10 +2981,10 @@ otThreadGetNextNeighborInfo(
     _Out_ otNeighborInfo *aInfo
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     UNREFERENCED_PARAMETER(aIterator);
     UNREFERENCED_PARAMETER(aInfo);
-    return kThreadError_NotImplemented; // TODO
+    return OT_ERROR_NOT_IMPLEMENTED; // TODO
 }
 
 OTAPI
@@ -3000,7 +3000,7 @@ otThreadGetDeviceRole(
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadGetEidCacheEntry(
     _In_ otInstance *aInstance, 
@@ -3008,19 +3008,19 @@ otThreadGetEidCacheEntry(
     _Out_ otEidCacheEntry *aEntry
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(QueryIOCTL(aInstance, IOCTL_OTLWF_OT_EID_CACHE_ENTRY, &aIndex, aEntry));
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadGetLeaderData(
     _In_ otInstance *aInstance, 
     _Out_ otLeaderData *aLeaderData
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(QueryIOCTL(aInstance, IOCTL_OTLWF_OT_LEADER_DATA, aLeaderData));
 }
 
@@ -3097,7 +3097,7 @@ otThreadGetRouterIdSequence(
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otThreadGetRouterInfo(
     _In_ otInstance *aInstance, 
@@ -3105,19 +3105,19 @@ otThreadGetRouterInfo(
     _Out_ otRouterInfo *aRouterInfo
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(QueryIOCTL(aInstance, IOCTL_OTLWF_OT_ROUTER_INFO, &aRouterId, aRouterInfo));
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otThreadGetParentInfo(
     _In_ otInstance *aInstance, 
     _Out_ otRouterInfo *aParentInfo
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     static_assert(sizeof(otRouterInfo) == 20, "The size of otRouterInfo should be 20 bytes");
     return DwordToThreadError(QueryIOCTL(aInstance, IOCTL_OTLWF_OT_PARENT_INFO, aParentInfo));
 }
@@ -3179,14 +3179,14 @@ otIsIp6AddressEqual(
 }
 
 OTAPI
-ThreadError 
+otError 
 OTCALL
 otIp6AddressFromString(
     const char *str, 
     otIp6Address *address
     )
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t *dst = reinterpret_cast<uint8_t *>(address->mFields.m8);
     uint8_t *endp = reinterpret_cast<uint8_t *>(address->mFields.m8 + 15);
     uint8_t *colonp = NULL;
@@ -3215,7 +3215,7 @@ otIp6AddressFromString(
             {
                 if (dst + 2 > endp)
                 {
-                    error = kThreadError_Parse;
+                    error = OT_ERROR_PARSE;
                     goto exit;
                 }
                 *(dst + 1) = static_cast<uint8_t>(val >> 8);
@@ -3228,7 +3228,7 @@ otIp6AddressFromString(
             {
                 if (!(colonp == nullptr || first))
                 {
-                    error = kThreadError_Parse;
+                    error = OT_ERROR_PARSE;
                     goto exit;
                 }
                 colonp = dst;
@@ -3245,7 +3245,7 @@ otIp6AddressFromString(
         {
             if (!('0' <= ch && ch <= '9'))
             {
-                error = kThreadError_Parse;
+                error = OT_ERROR_PARSE;
                 goto exit;
             }
         }
@@ -3254,7 +3254,7 @@ otIp6AddressFromString(
         val = static_cast<uint16_t>((val << 4) | d);
         if (!(++count <= 4))
         {
-            error = kThreadError_Parse;
+            error = OT_ERROR_PARSE;
             goto exit;
         }
     }
@@ -3311,142 +3311,134 @@ OTAPI
 const char *
 OTCALL
 otThreadErrorToString(
-    ThreadError aError
+    otError aError
     )
 {
     const char *retval;
 
     switch (aError)
     {
-    case kThreadError_None:
+    case OT_ERROR_NONE:
         retval = "None";
         break;
 
-    case kThreadError_Failed:
+    case OT_ERROR_FAILED:
         retval = "Failed";
         break;
 
-    case kThreadError_Drop:
+    case OT_ERROR_DROP:
         retval = "Drop";
         break;
 
-    case kThreadError_NoBufs:
+    case OT_ERROR_NO_BUFS:
         retval = "NoBufs";
         break;
 
-    case kThreadError_NoRoute:
+    case OT_ERROR_NO_ROUTE:
         retval = "NoRoute";
         break;
 
-    case kThreadError_Busy:
+    case OT_ERROR_BUSY:
         retval = "Busy";
         break;
 
-    case kThreadError_Parse:
+    case OT_ERROR_PARSE:
         retval = "Parse";
         break;
 
-    case kThreadError_InvalidArgs:
+    case OT_ERROR_INVALID_ARGS:
         retval = "InvalidArgs";
         break;
 
-    case kThreadError_Security:
+    case OT_ERROR_SECURITY:
         retval = "Security";
         break;
 
-    case kThreadError_AddressQuery:
+    case OT_ERROR_ADDRESS_QUERY:
         retval = "AddressQuery";
         break;
 
-    case kThreadError_NoAddress:
+    case OT_ERROR_NO_ADDRESS:
         retval = "NoAddress";
         break;
 
-    case kThreadError_NotReceiving:
-        retval = "NotReceiving";
-        break;
-
-    case kThreadError_Abort:
+    case OT_ERROR_ABORT:
         retval = "Abort";
         break;
 
-    case kThreadError_NotImplemented:
+    case OT_ERROR_NOT_IMPLEMENTED:
         retval = "NotImplemented";
         break;
 
-    case kThreadError_InvalidState:
+    case OT_ERROR_INVALID_STATE:
         retval = "InvalidState";
         break;
 
-    case kThreadError_NoTasklets:
-        retval = "NoTasklets";
-        break;
-
-    case kThreadError_NoAck:
+    case OT_ERROR_NO_ACK:
         retval = "NoAck";
         break;
 
-    case kThreadError_ChannelAccessFailure:
+    case OT_ERROR_CHANNEL_ACCESS_FAILURE:
         retval = "ChannelAccessFailure";
         break;
 
-    case kThreadError_Detached:
+    case OT_ERROR_DETACHED:
         retval = "Detached";
         break;
 
-    case kThreadError_FcsErr:
+    case OT_ERROR_FCS:
         retval = "FcsErr";
         break;
 
-    case kThreadError_NoFrameReceived:
+    case OT_ERROR_NO_FRAME_RECEIVED:
         retval = "NoFrameReceived";
         break;
 
-    case kThreadError_UnknownNeighbor:
+    case OT_ERROR_UNKNOWN_NEIGHBOR:
         retval = "UnknownNeighbor";
         break;
 
-    case kThreadError_InvalidSourceAddress:
+    case OT_ERROR_INVALID_SOURCE_ADDRESS:
         retval = "InvalidSourceAddress";
         break;
 
-    case kThreadError_WhitelistFiltered:
+    case OT_ERROR_WHITELIST_FILTERED:
         retval = "WhitelistFiltered";
         break;
 
-    case kThreadError_DestinationAddressFiltered:
+    case OT_ERROR_DESTINATION_ADDRESS_FILTERED:
         retval = "DestinationAddressFiltered";
         break;
 
-    case kThreadError_NotFound:
+    case OT_ERROR_NOT_FOUND:
         retval = "NotFound";
         break;
 
-    case kThreadError_Already:
+    case OT_ERROR_ALREADY:
         retval = "Already";
         break;
 
-    case kThreadError_BlacklistFiltered:
+    case OT_ERROR_BLACKLIST_FILTERED:
         retval = "BlacklistFiltered";
         break;
 
-    case kThreadError_Ipv6AddressCreationFailure:
+    case OT_ERROR_IP6_ADDRESS_CREATION_FAILURE:
         retval = "Ipv6AddressCreationFailure";
         break;
 
-    case kThreadError_NotCapable:
+    case OT_ERROR_NOT_CAPABLE:
         retval = "NotCapable";
         break;
 
-    case kThreadError_ResponseTimeout:
+    case OT_ERROR_RESPONSE_TIMEOUT:
         retval = "ResponseTimeout";
         break;
 
-    case kThreadError_Duplicated:
+    case OT_ERROR_DUPLICATED:
         retval = "Duplicated";
         break;
 
-    case kThreadError_Error:
+    case OT_ERROR_GENERIC:
         retval = "GenericError";
         break;
 
@@ -3459,7 +3451,7 @@ otThreadErrorToString(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL 
 otThreadSendDiagnosticGet(
     _In_ otInstance *aInstance, 
@@ -3468,19 +3460,19 @@ otThreadSendDiagnosticGet(
     uint8_t aCount
     )
 {
-    if (aInstance == nullptr || aDestination == nullptr) return kThreadError_InvalidArgs;
-    if (aTlvTypes == nullptr && aCount != 0) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr || aDestination == nullptr) return OT_ERROR_INVALID_ARGS;
+    if (aTlvTypes == nullptr && aCount != 0) return OT_ERROR_INVALID_ARGS;
     
     DWORD BufferSize = sizeof(GUID) + sizeof(otIp6Address) + sizeof(uint8_t) + aCount;
     PBYTE Buffer = (PBYTE)malloc(BufferSize);
-    if (Buffer == nullptr) return kThreadError_NoBufs;
+    if (Buffer == nullptr) return OT_ERROR_NO_BUFS;
 
     memcpy_s(Buffer, BufferSize, &aInstance->InterfaceGuid, sizeof(GUID));
     memcpy_s(Buffer + sizeof(GUID), BufferSize - sizeof(GUID), aDestination, sizeof(otIp6Address));
     memcpy_s(Buffer + sizeof(GUID) + sizeof(otIp6Address), BufferSize - sizeof(GUID) - sizeof(otIp6Address), &aCount, sizeof(aCount));
     memcpy_s(Buffer + sizeof(GUID) + sizeof(otIp6Address) + sizeof(uint8_t), BufferSize - sizeof(GUID) - sizeof(otIp6Address) - sizeof(uint8_t), aTlvTypes, aCount);
     
-    ThreadError result = 
+    otError result = 
         DwordToThreadError(SendIOCTL(aInstance->ApiHandle, IOCTL_OTLWF_OT_SEND_DIAGNOSTIC_GET, Buffer, BufferSize, nullptr, 0));
 
     free(Buffer);
@@ -3488,7 +3480,7 @@ otThreadSendDiagnosticGet(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL 
 otThreadSendDiagnosticReset(
     _In_ otInstance *aInstance, 
@@ -3497,19 +3489,19 @@ otThreadSendDiagnosticReset(
     uint8_t aCount
     )
 {
-    if (aInstance == nullptr || aDestination == nullptr) return kThreadError_InvalidArgs;
-    if (aTlvTypes == nullptr && aCount != 0) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr || aDestination == nullptr) return OT_ERROR_INVALID_ARGS;
+    if (aTlvTypes == nullptr && aCount != 0) return OT_ERROR_INVALID_ARGS;
     
     DWORD BufferSize = sizeof(GUID) + sizeof(otIp6Address) + sizeof(uint8_t) + aCount;
     PBYTE Buffer = (PBYTE)malloc(BufferSize);
-    if (Buffer == nullptr) return kThreadError_NoBufs;
+    if (Buffer == nullptr) return OT_ERROR_NO_BUFS;
 
     memcpy_s(Buffer, BufferSize, &aInstance->InterfaceGuid, sizeof(GUID));
     memcpy_s(Buffer + sizeof(GUID), BufferSize - sizeof(GUID), aDestination, sizeof(otIp6Address));
     memcpy_s(Buffer + sizeof(GUID) + sizeof(otIp6Address), BufferSize - sizeof(GUID) - sizeof(otIp6Address), &aCount, sizeof(aCount));
     memcpy_s(Buffer + sizeof(GUID) + sizeof(otIp6Address) + sizeof(uint8_t), BufferSize - sizeof(GUID) - sizeof(otIp6Address) - sizeof(uint8_t), aTlvTypes, aCount);
     
-    ThreadError result = 
+    otError result = 
         DwordToThreadError(SendIOCTL(aInstance->ApiHandle, IOCTL_OTLWF_OT_SEND_DIAGNOSTIC_RESET, Buffer, BufferSize, nullptr, 0));
 
     free(Buffer);
@@ -3517,18 +3509,18 @@ otThreadSendDiagnosticReset(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otCommissionerStart(
     _In_ otInstance *aInstance
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_COMMISIONER_START));
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otCommissionerAddJoiner(
     _In_ otInstance *aInstance, 
@@ -3537,12 +3529,12 @@ otCommissionerAddJoiner(
     uint32_t aTimeout
     )
 {
-    if (aInstance == nullptr || aPSKd == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr || aPSKd == nullptr) return OT_ERROR_INVALID_ARGS;
 
     size_t aPSKdLength = strnlen(aPSKd, OPENTHREAD_PSK_MAX_LENGTH + 1);
     if (aPSKdLength > OPENTHREAD_PSK_MAX_LENGTH)
     {
-        return kThreadError_InvalidArgs;
+        return OT_ERROR_INVALID_ARGS;
     }
 
     uint8_t aExtAddressValid = aExtAddress ? 1 : 0;
@@ -3560,14 +3552,14 @@ otCommissionerAddJoiner(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otCommissionerRemoveJoiner(
     _In_ otInstance *aInstance, 
     const otExtAddress *aExtAddress
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
 
     uint8_t aExtAddressValid = aExtAddress ? 1 : 0;
     
@@ -3581,19 +3573,19 @@ otCommissionerRemoveJoiner(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otCommissionerSetProvisioningUrl(
     _In_ otInstance *aInstance,
     const char *aProvisioningUrl
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
 
     size_t aProvisioningUrlLength = aProvisioningUrl ? strnlen(aProvisioningUrl, OPENTHREAD_PROV_URL_MAX_LENGTH + 1) : 0;
     if (aProvisioningUrlLength > OPENTHREAD_PROV_URL_MAX_LENGTH)
     {
-        return kThreadError_InvalidArgs;
+        return OT_ERROR_INVALID_ARGS;
     }
     
     const ULONG BufferLength = sizeof(GUID) + (ULONG)aProvisioningUrlLength + 1;
@@ -3606,7 +3598,7 @@ otCommissionerSetProvisioningUrl(
 }
 
 OTAPI
-ThreadError
+otError
 OTCALL
 otCommissionerAnnounceBegin(
     otInstance *aInstance,
@@ -3616,25 +3608,25 @@ otCommissionerAnnounceBegin(
     const otIp6Address *aAddress
     )
 {
-    if (aInstance == nullptr || aAddress == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr || aAddress == nullptr) return OT_ERROR_INVALID_ARGS;
 
     PackedBuffer5<GUID,uint32_t,uint8_t,uint16_t,otIp6Address> Buffer(aInstance->InterfaceGuid, aChannelMask, aCount, aPeriod, *aAddress);
     return DwordToThreadError(SendIOCTL(aInstance->ApiHandle, IOCTL_OTLWF_OT_COMMISIONER_ANNOUNCE_BEGIN, &Buffer, sizeof(Buffer), nullptr, 0));
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otCommissionerStop(
     _In_ otInstance *aInstance
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_COMMISIONER_STOP));
 }
 
 OTAPI
-ThreadError 
+otError 
 OTCALL
 otCommissionerEnergyScan(
     _In_ otInstance *aInstance, 
@@ -3647,7 +3639,7 @@ otCommissionerEnergyScan(
     _In_ void *aContext
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
 
     aInstance->ApiHandle->SetCallback(
         aInstance->ApiHandle->CommissionerEnergyReportCallbacks,
@@ -3659,7 +3651,7 @@ otCommissionerEnergyScan(
 }
 
 OTAPI
-ThreadError 
+otError 
 OTCALL
 otCommissionerPanIdQuery(
     _In_ otInstance *aInstance, 
@@ -3670,7 +3662,7 @@ otCommissionerPanIdQuery(
     _In_ void *aContext
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
 
     aInstance->ApiHandle->SetCallback(
         aInstance->ApiHandle->CommissionerPanIdConflictCallbacks,
@@ -3682,7 +3674,7 @@ otCommissionerPanIdQuery(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL 
 otCommissionerSendMgmtGet(
     _In_ otInstance *aInstance, 
@@ -3690,19 +3682,19 @@ otCommissionerSendMgmtGet(
     uint8_t aLength
 )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
-    if (aTlvs == nullptr && aLength != 0) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
+    if (aTlvs == nullptr && aLength != 0) return OT_ERROR_INVALID_ARGS;
     
     DWORD BufferSize = sizeof(GUID) + sizeof(uint8_t) + aLength;
     PBYTE Buffer = (PBYTE)malloc(BufferSize);
-    if (Buffer == nullptr) return kThreadError_NoBufs;
+    if (Buffer == nullptr) return OT_ERROR_NO_BUFS;
 
     memcpy_s(Buffer, BufferSize, &aInstance->InterfaceGuid, sizeof(GUID));
     memcpy_s(Buffer + sizeof(GUID), BufferSize - sizeof(GUID), &aLength, sizeof(aLength));
     if (aLength > 0)
         memcpy_s(Buffer + sizeof(GUID) + sizeof(uint8_t), BufferSize - sizeof(GUID) - sizeof(uint8_t), aTlvs, aLength);
     
-    ThreadError result = 
+    otError result = 
         DwordToThreadError(SendIOCTL(aInstance->ApiHandle, IOCTL_OTLWF_OT_SEND_MGMT_COMMISSIONER_GET, Buffer, BufferSize, nullptr, 0));
 
     free(Buffer);
@@ -3710,7 +3702,7 @@ otCommissionerSendMgmtGet(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL 
 otCommissionerSendMgmtSet(
     _In_ otInstance *aInstance,
@@ -3719,12 +3711,12 @@ otCommissionerSendMgmtSet(
     uint8_t aLength
     )
 {
-    if (aInstance == nullptr || aDataset == nullptr) return kThreadError_InvalidArgs;
-    if (aTlvs == nullptr && aLength != 0) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr || aDataset == nullptr) return OT_ERROR_INVALID_ARGS;
+    if (aTlvs == nullptr && aLength != 0) return OT_ERROR_INVALID_ARGS;
     
     DWORD BufferSize = sizeof(GUID) + sizeof(otCommissioningDataset) + sizeof(uint8_t) + aLength;
     PBYTE Buffer = (PBYTE)malloc(BufferSize);
-    if (Buffer == nullptr) return kThreadError_NoBufs;
+    if (Buffer == nullptr) return OT_ERROR_NO_BUFS;
 
     memcpy_s(Buffer, BufferSize, &aInstance->InterfaceGuid, sizeof(GUID));
     memcpy_s(Buffer + sizeof(GUID), BufferSize - sizeof(GUID), aDataset, sizeof(otCommissioningDataset));
@@ -3732,7 +3724,7 @@ otCommissionerSendMgmtSet(
     if (aLength > 0)
         memcpy_s(Buffer + sizeof(GUID) + sizeof(otCommissioningDataset) + sizeof(uint8_t), BufferSize - sizeof(GUID) - sizeof(otCommissioningDataset) - sizeof(uint8_t), aTlvs, aLength);
     
-    ThreadError result = 
+    otError result = 
         DwordToThreadError(SendIOCTL(aInstance->ApiHandle, IOCTL_OTLWF_OT_SEND_MGMT_COMMISSIONER_SET, Buffer, BufferSize, nullptr, 0));
 
     free(Buffer);
@@ -3752,7 +3744,7 @@ otCommissionerGetSessionId(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otJoinerStart(
     _In_ otInstance *aInstance,
@@ -3766,7 +3758,7 @@ otJoinerStart(
     _In_ void *aCallbackContext
     )
 {
-    if (aInstance == nullptr || aPSKd == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr || aPSKd == nullptr) return OT_ERROR_INVALID_ARGS;
 
     otCommissionConfig config = {0};
 
@@ -3784,7 +3776,7 @@ otJoinerStart(
         aVendorSwVersionLength > OPENTHREAD_VENDOR_SW_VERSION_MAX_LENGTH ||
         aVendorDataLength > OPENTHREAD_VENDOR_DATA_MAX_LENGTH)
     {
-        return kThreadError_InvalidArgs;
+        return OT_ERROR_INVALID_ARGS;
     }
 
     memcpy_s(config.PSKd, sizeof(config.PSKd), aPSKd, aPSKdLength);
@@ -3801,7 +3793,7 @@ otJoinerStart(
 
     auto ret = DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_JOINER_START, (const otCommissionConfig*)&config));
 
-    if (ret != kThreadError_None)
+    if (ret != OT_ERROR_NONE)
     {
         aInstance->ApiHandle->SetCallback(
             aInstance->ApiHandle->JoinerCallbacks,
@@ -3813,12 +3805,12 @@ otJoinerStart(
 }
 
 OTAPI 
-ThreadError 
+otError 
 OTCALL
 otJoinerStop(
     _In_ otInstance *aInstance
     )
 {
-    if (aInstance == nullptr) return kThreadError_InvalidArgs;
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_JOINER_STOP));
 }

--- a/examples/drivers/windows/otCli/main.cpp
+++ b/examples/drivers/windows/otCli/main.cpp
@@ -62,14 +62,14 @@ int main(int argc, char *argv[])
     return NO_ERROR;
 }
 
-EXTERN_C ThreadError otPlatUartEnable(void)
+EXTERN_C otError otPlatUartEnable(void)
 {
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-EXTERN_C ThreadError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
+EXTERN_C otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (!skipNextLine)
     {

--- a/examples/drivers/windows/otLwf/address.c
+++ b/examples/drivers/windows/otLwf/address.c
@@ -343,11 +343,11 @@ otLwfEventProcessingAddressChanged(
                 LogInfo(DRIVER_DEFAULT, "Filter %p trying to add/update address: %!IPV6ADDR!", pFilter, pAddr);
 
                 // Add (or update) the address to OpenThread
-                ThreadError otError = otIp6AddUnicastAddress(pFilter->otCtx, &otAddr);
-                if (otError != kThreadError_None)
+                otError otError = otIp6AddUnicastAddress(pFilter->otCtx, &otAddr);
+                if (otError != OT_ERROR_NONE)
                 {
                     LogError(DRIVER_DEFAULT, "otIp6AddUnicastAddress failed, %!otError!", otError);
-                    ShouldDelete = otError == kThreadError_NoBufs ? TRUE : FALSE;
+                    ShouldDelete = otError == OT_ERROR_NO_BUFS ? TRUE : FALSE;
                 }
             }
 

--- a/examples/drivers/windows/otLwf/command.c
+++ b/examples/drivers/windows/otLwf/command.c
@@ -899,7 +899,7 @@ otLwfCmdSendMacFrameComplete(
 {
     UNREFERENCED_PARAMETER(Context);
 
-    pFilter->otLastTransmitError = kThreadError_Abort;
+    pFilter->otLastTransmitError = OT_ERROR_ABORT;
 
     if (Data && Command == SPINEL_CMD_PROP_VALUE_IS)
     {
@@ -911,7 +911,7 @@ otLwfCmdSendMacFrameComplete(
             {
                 if (spinel_status == SPINEL_STATUS_OK)
                 {
-                    pFilter->otLastTransmitError = kThreadError_None;
+                    pFilter->otLastTransmitError = OT_ERROR_NONE;
                     (void)spinel_datatype_unpack(
                         Data + packed_len,
                         DataLength - (spinel_size_t)packed_len,
@@ -961,7 +961,7 @@ otLwfCmdSendMacFrameAsync(
     if (!NT_SUCCESS(status))
     {
         LogError(DRIVER_DEFAULT, "Set SPINEL_PROP_STREAM_RAW failed, %!STATUS!", status);
-        pFilter->otLastTransmitError = kThreadError_Abort;
+        pFilter->otLastTransmitError = OT_ERROR_ABORT;
         KeSetEvent(&pFilter->SendNetBufferListComplete, IO_NO_INCREMENT, FALSE);
     }
 }
@@ -1015,7 +1015,7 @@ otLwfGetPropHandler(
         }
         else
         {
-            ThreadError errorCode = SpinelStatusToThreadError(spinel_status);
+            otError errorCode = SpinelStatusToThreadError(spinel_status);
             LogVerbose(DRIVER_DEFAULT, "Get key=%u failed with %!otError!", CmdContext->Key, errorCode);
             CmdContext->Status = ThreadErrorToNtstatus(errorCode);
         }
@@ -1170,7 +1170,7 @@ otLwfSetPropHandler(
         }
         else
         {
-            ThreadError errorCode = SpinelStatusToThreadError(spinel_status);
+            otError errorCode = SpinelStatusToThreadError(spinel_status);
             LogVerbose(DRIVER_DEFAULT, "Set key=%u failed with %!otError!", CmdContext->Key, errorCode);
             CmdContext->Status = ThreadErrorToNtstatus(errorCode);
         }
@@ -1333,75 +1333,75 @@ otLwfCmdRemoveProp(
 // General Spinel Helpers
 //
 
-ThreadError
+otError
 SpinelStatusToThreadError(
     spinel_status_t error
     )
 {
-    ThreadError ret;
+    otError ret;
 
     switch (error)
     {
     case SPINEL_STATUS_OK:
-        ret = kThreadError_None;
+        ret = OT_ERROR_NONE;
         break;
 
     case SPINEL_STATUS_FAILURE:
-        ret = kThreadError_Failed;
+        ret = OT_ERROR_FAILED;
         break;
 
     case SPINEL_STATUS_DROPPED:
-        ret = kThreadError_Drop;
+        ret = OT_ERROR_DROP;
         break;
 
     case SPINEL_STATUS_NOMEM:
-        ret = kThreadError_NoBufs;
+        ret = OT_ERROR_NO_BUFS;
         break;
 
     case SPINEL_STATUS_BUSY:
-        ret = kThreadError_Busy;
+        ret = OT_ERROR_BUSY;
         break;
 
     case SPINEL_STATUS_PARSE_ERROR:
-        ret = kThreadError_Parse;
+        ret = OT_ERROR_PARSE;
         break;
 
     case SPINEL_STATUS_INVALID_ARGUMENT:
-        ret = kThreadError_InvalidArgs;
+        ret = OT_ERROR_INVALID_ARGS;
         break;
 
     case SPINEL_STATUS_UNIMPLEMENTED:
-        ret = kThreadError_NotImplemented;
+        ret = OT_ERROR_NOT_IMPLEMENTED;
         break;
 
     case SPINEL_STATUS_INVALID_STATE:
-        ret = kThreadError_InvalidState;
+        ret = OT_ERROR_INVALID_STATE;
         break;
 
     case SPINEL_STATUS_NO_ACK:
-        ret = kThreadError_NoAck;
+        ret = OT_ERROR_NO_ACK;
         break;
 
     case SPINEL_STATUS_CCA_FAILURE:
-        ret = kThreadError_ChannelAccessFailure;
+        ret = OT_ERROR_CHANNEL_ACCESS_FAILURE;
         break;
 
     case SPINEL_STATUS_ALREADY:
-        ret = kThreadError_Already;
+        ret = OT_ERROR_ALREADY;
         break;
 
     case SPINEL_STATUS_ITEM_NOT_FOUND:
-        ret = kThreadError_NotFound;
+        ret = OT_ERROR_NOT_FOUND;
         break;
 
     default:
         if (error >= SPINEL_STATUS_STACK_NATIVE__BEGIN && error <= SPINEL_STATUS_STACK_NATIVE__END)
         {
-            ret = (ThreadError)(error - SPINEL_STATUS_STACK_NATIVE__BEGIN);
+            ret = (otError)(error - SPINEL_STATUS_STACK_NATIVE__BEGIN);
         }
         else
         {
-            ret = kThreadError_Failed;
+            ret = OT_ERROR_FAILED;
         }
         break;
     }

--- a/examples/drivers/windows/otLwf/command.h
+++ b/examples/drivers/windows/otLwf/command.h
@@ -188,7 +188,7 @@ otLwfCmdRemoveProp(
 // General Spinel Helpers
 //
 
-ThreadError
+otError
 SpinelStatusToThreadError(
     spinel_status_t error
     );

--- a/examples/drivers/windows/otLwf/eventprocessing.c
+++ b/examples/drivers/windows/otLwf/eventprocessing.c
@@ -901,7 +901,7 @@ otLwfEventWorkerThread(
                             // Copy NB data into message
                             if (NT_SUCCESS(CopyDataBuffer(CurrNb, NET_BUFFER_DATA_LENGTH(CurrNb), MessageBuffer)))
                             {
-                                ThreadError error = kThreadError_None;
+                                otError error = OT_ERROR_NONE;
 
                                 // Create a new message
                                 otMessage *message = otIp6NewMessage(pFilter->otCtx, TRUE);
@@ -909,7 +909,7 @@ otLwfEventWorkerThread(
                                 {
                                     // Write to the message
                                     error = otMessageAppend(message, MessageBuffer, (uint16_t)NET_BUFFER_DATA_LENGTH(CurrNb));
-                                    if (error != kThreadError_None)
+                                    if (error != OT_ERROR_NONE)
                                     {
                                         LogError(DRIVER_DATA_PATH, "otAppendMessage failed with %!otError!", error);
                                         otMessageFree(message);
@@ -928,7 +928,7 @@ otLwfEventWorkerThread(
 
                                         // Send message (it will free 'message')
                                         error = otIp6Send(pFilter->otCtx, message);
-                                        if (error != kThreadError_None)
+                                        if (error != OT_ERROR_NONE)
                                         {
                                             LogError(DRIVER_DATA_PATH, "otSendIp6Datagram failed with %!otError!", error);
                                         }
@@ -1003,7 +1003,7 @@ otLwfEventWorkerThread(
                         length -= pFilter->otReceiveFrame.mLength;
                     }
 
-                    ThreadError errorCode;
+                    otError errorCode;
                     int8_t noiseFloor = -128;
                     uint16_t flags = 0;
                     if (try_spinel_datatype_unpack(

--- a/examples/drivers/windows/otLwf/filter.h
+++ b/examples/drivers/windows/otLwf/filter.h
@@ -255,7 +255,7 @@ typedef struct _MS_FILTER
         uint8_t                     otTransmitMessage[kMaxPHYPacketSize];
         RadioPacket                 otReceiveFrame;
         RadioPacket                 otTransmitFrame;
-        ThreadError                 otLastTransmitError;
+        otError                     otLastTransmitError;
         BOOLEAN                     otLastTransmitFramePending;
         CHAR                        otLastEnergyScanMaxRssi;
 

--- a/examples/drivers/windows/otLwf/radio.h
+++ b/examples/drivers/windows/otLwf/radio.h
@@ -81,7 +81,7 @@ enum
 VOID otLwfRadioInit(_In_ PMS_FILTER pFilter);
 
 // Indicates a received frame from the radio layer
-VOID otLwfRadioReceiveFrame(_In_ PMS_FILTER pFilter, _In_ ThreadError errorCode);
+VOID otLwfRadioReceiveFrame(_In_ PMS_FILTER pFilter, _In_ otError errorCode);
 
 // Indicates the transmit frame is ready to send to the radio layer
 VOID otLwfRadioTransmitFrame(_In_ PMS_FILTER pFilter);

--- a/examples/drivers/windows/otLwf/settings.c
+++ b/examples/drivers/windows/otLwf/settings.c
@@ -439,25 +439,25 @@ error:
     return status;
 }
 
-ThreadError otPlatSettingsBeginChange(otInstance *otCtx)
+otError otPlatSettingsBeginChange(otInstance *otCtx)
 {
     UNREFERENCED_PARAMETER(otCtx);
-    return kThreadError_NotImplemented;
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-ThreadError otPlatSettingsCommitChange(otInstance *otCtx)
+otError otPlatSettingsCommitChange(otInstance *otCtx)
 {
     UNREFERENCED_PARAMETER(otCtx);
-    return kThreadError_NotImplemented;
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-ThreadError otPlatSettingsAbandonChange(otInstance *otCtx)
+otError otPlatSettingsAbandonChange(otInstance *otCtx)
 {
     UNREFERENCED_PARAMETER(otCtx);
-    return kThreadError_NotImplemented;
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-ThreadError otPlatSettingsGet(otInstance *otCtx, uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength)
+otError otPlatSettingsGet(otInstance *otCtx, uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength)
 {
     NT_ASSERT(otCtx);
     PMS_FILTER pFilter = otCtxToFilter(otCtx);
@@ -470,10 +470,10 @@ ThreadError otPlatSettingsGet(otInstance *otCtx, uint16_t aKey, int aIndex, uint
             aValue,
             aValueLength);
 
-    return NT_SUCCESS(status) ? kThreadError_None : kThreadError_NotFound;
+    return NT_SUCCESS(status) ? OT_ERROR_NONE : OT_ERROR_NOT_FOUND;
 }
 
-ThreadError otPlatSettingsSet(otInstance *otCtx, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+otError otPlatSettingsSet(otInstance *otCtx, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
 {
     NT_ASSERT(otCtx);
     PMS_FILTER pFilter = otCtxToFilter(otCtx);
@@ -486,10 +486,10 @@ ThreadError otPlatSettingsSet(otInstance *otCtx, uint16_t aKey, const uint8_t *a
             aValue,
             aValueLength);
 
-    return NT_SUCCESS(status) ? kThreadError_None : kThreadError_Failed;
+    return NT_SUCCESS(status) ? OT_ERROR_NONE : OT_ERROR_FAILED;
 }
 
-ThreadError otPlatSettingsAdd(otInstance *otCtx, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+otError otPlatSettingsAdd(otInstance *otCtx, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
 {
     NT_ASSERT(otCtx);
     PMS_FILTER pFilter = otCtxToFilter(otCtx);
@@ -504,10 +504,10 @@ ThreadError otPlatSettingsAdd(otInstance *otCtx, uint16_t aKey, const uint8_t *a
             aValue,
             aValueLength);
 
-    return NT_SUCCESS(status) ? kThreadError_None : kThreadError_Failed;
+    return NT_SUCCESS(status) ? OT_ERROR_NONE : OT_ERROR_FAILED;
 }
 
-ThreadError otPlatSettingsDelete(otInstance *otCtx, uint16_t aKey, int aIndex)
+otError otPlatSettingsDelete(otInstance *otCtx, uint16_t aKey, int aIndex)
 {
     NT_ASSERT(otCtx);
     PMS_FILTER pFilter = otCtxToFilter(otCtx);
@@ -518,7 +518,7 @@ ThreadError otPlatSettingsDelete(otInstance *otCtx, uint16_t aKey, int aIndex)
             aKey,
             aIndex);
 
-    return NT_SUCCESS(status) ? kThreadError_None : kThreadError_Failed;
+    return NT_SUCCESS(status) ? OT_ERROR_NONE : OT_ERROR_FAILED;
 }
 
 void otPlatSettingsWipe(otInstance *otCtx)

--- a/examples/drivers/windows/otLwf/thread.c
+++ b/examples/drivers/windows/otLwf/thread.c
@@ -430,7 +430,7 @@ uint32_t otPlatRandomGet()
     return (uint32_t)RtlRandomEx(&Counter.LowPart);
 }
 
-ThreadError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
+otError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
 {
     // Just use the system-preferred random number generator algorithm
     NTSTATUS status = 
@@ -444,10 +444,10 @@ ThreadError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
     if (!NT_SUCCESS(status))
     {
         LogError(DRIVER_DEFAULT, "BCryptGenRandom failed, %!STATUS!", status);
-        return kThreadError_Failed;
+        return OT_ERROR_FAILED;
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 void otTaskletsSignalPending(_In_ otInstance *otCtx)
@@ -705,7 +705,7 @@ void otLwfCommissionerPanIdConflictCallback(uint16_t aPanId, uint32_t aChannelMa
     LogFuncExit(DRIVER_DEFAULT);
 }
 
-void otLwfJoinerCallback(ThreadError aError, _In_ void *aContext)
+void otLwfJoinerCallback(otError aError, _In_ void *aContext)
 {
     LogFuncEntry(DRIVER_DEFAULT);
 

--- a/examples/drivers/windows/otLwf/thread.h
+++ b/examples/drivers/windows/otLwf/thread.h
@@ -162,7 +162,7 @@ void otLwfEnergyScanCallback(_In_ otEnergyScanResult *aResult, _In_ void *aConte
 void otLwfDiscoverCallback(_In_ otActiveScanResult *aResult, _In_ void *aContext);
 void otLwfCommissionerEnergyReportCallback(uint32_t aChannelMask, const uint8_t *aEnergyList, uint8_t aEnergyListLength, void *aContext);
 void otLwfCommissionerPanIdConflictCallback(uint16_t aPanId, uint32_t aChannelMask, _In_ void *aContext);
-void otLwfJoinerCallback(ThreadError aError, _In_ void *aContext);
+void otLwfJoinerCallback(otError aError, _In_ void *aContext);
 
 //
 // Value Callbacks

--- a/examples/drivers/windows/otNodeApi/otNodeApi.cpp
+++ b/examples/drivers/windows/otNodeApi/otNodeApi.cpp
@@ -66,8 +66,8 @@ HANDLE gDeviceArrivalEvent = nullptr;
 
 otApiInstance *gApiInstance = nullptr;
 
-_Success_(return == kThreadError_None)
-ThreadError otNodeParsePrefix(const char *aStrPrefix, _Out_ otIp6Prefix *aPrefix)
+_Success_(return == OT_ERROR_NONE)
+otError otNodeParsePrefix(const char *aStrPrefix, _Out_ otIp6Prefix *aPrefix)
 {
     char *prefixLengthStr;
     char *endptr;
@@ -75,13 +75,13 @@ ThreadError otNodeParsePrefix(const char *aStrPrefix, _Out_ otIp6Prefix *aPrefix
     if ((prefixLengthStr = (char*)strchr(aStrPrefix, '/')) == NULL)
     {
         printf("invalid prefix (%s)!\r\n", aStrPrefix);
-        return kThreadError_InvalidArgs;
+        return OT_ERROR_INVALID_ARGS;
     }
 
     *prefixLengthStr++ = '\0';
     
     auto error = otIp6AddressFromString(aStrPrefix, &aPrefix->mPrefix);
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         printf("ipaddr (%s) to string failed, 0x%x!\r\n", aStrPrefix, error);
         return error;
@@ -92,10 +92,10 @@ ThreadError otNodeParsePrefix(const char *aStrPrefix, _Out_ otIp6Prefix *aPrefix
     if (*endptr != '\0')
     {
         printf("invalid prefix ending (%s)!\r\n", aStrPrefix);
-        return kThreadError_Parse;
+        return OT_ERROR_PARSE;
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 void OTCALL otNodeDeviceAvailabilityChanged(bool aAdded, const GUID *, void *)
@@ -1012,7 +1012,7 @@ OTNODEAPI int32_t OTCALL otNodeCommissionerJoinerAdd(otNode* aNode, const char *
 
     const uint32_t kDefaultJoinerTimeout = 120;
 
-    ThreadError error;
+    otError error;
     
     if (strcmp(aExtAddr, "*") == 0)
     {
@@ -1022,7 +1022,7 @@ OTNODEAPI int32_t OTCALL otNodeCommissionerJoinerAdd(otNode* aNode, const char *
     {
         otExtAddress extAddr;
         if (Hex2Bin(aExtAddr, extAddr.m8, sizeof(extAddr)) != sizeof(extAddr))
-            return kThreadError_Parse;
+            return OT_ERROR_PARSE;
 
         error = otCommissionerAddJoiner(aNode->mInstance, &extAddr, aPSKd, kDefaultJoinerTimeout);
     }
@@ -1104,9 +1104,9 @@ OTNODEAPI int32_t OTCALL otNodeAddWhitelist(otNode* aNode, const char *aExtAddr,
 
     uint8_t extAddr[8];
     if (Hex2Bin(aExtAddr, extAddr, sizeof(extAddr)) != sizeof(extAddr))
-        return kThreadError_Parse;
+        return OT_ERROR_PARSE;
 
-    ThreadError error;
+    otError error;
     if (aRssi == 0)
     {
         error = otLinkAddWhitelist(aNode->mInstance, extAddr);
@@ -1126,7 +1126,7 @@ OTNODEAPI int32_t OTCALL otNodeRemoveWhitelist(otNode* aNode, const char *aExtAd
 
     uint8_t extAddr[8];
     if (Hex2Bin(aExtAddr, extAddr, sizeof(extAddr)) != sizeof(extAddr))
-        return kThreadError_InvalidArgs;
+        return OT_ERROR_INVALID_ARGS;
 
     otLinkRemoveWhitelist(aNode->mInstance, extAddr);
     otLogFuncExit();
@@ -1204,7 +1204,7 @@ OTNODEAPI int32_t OTCALL otNodeSetMasterkey(otNode* aNode, const char *aMasterke
     if ((keyLength = Hex2Bin(aMasterkey, key.m8, sizeof(key.m8))) != OT_MASTER_KEY_SIZE)
     {
         printf("invalid length key %d\r\n", keyLength);
-        return kThreadError_Parse;
+        return OT_ERROR_PARSE;
     }
 
     auto error = otThreadSetMasterKey(aNode->mInstance, &key);
@@ -1239,7 +1239,7 @@ OTNODEAPI int32_t OTCALL otNodeSetPSKc(otNode* aNode, const char *aPSKc)
     if (Hex2Bin(aPSKc, pskc, sizeof(pskc)) != OT_PSKC_MAX_SIZE)
     {
         printf("invalid pskc %s\r\n", aPSKc);
-        return kThreadError_Parse;
+        return OT_ERROR_PARSE;
     }
 
     auto error = otThreadSetPSKc(aNode->mInstance, pskc);
@@ -1399,7 +1399,7 @@ OTNODEAPI int32_t OTCALL otNodeSetState(otNode* aNode, const char *aState)
     otLogFuncEntryMsg("[%d]", aNode->mId);
     printf("%d: state %s\r\n", aNode->mId, aState);
 
-    ThreadError error;
+    otError error;
     if (strcmp(aState, "detached") == 0)
     {
         error = otThreadBecomeDetached(aNode->mInstance);
@@ -1418,7 +1418,7 @@ OTNODEAPI int32_t OTCALL otNodeSetState(otNode* aNode, const char *aState)
     }
     else
     {
-        error = kThreadError_InvalidArgs;
+        error = OT_ERROR_INVALID_ARGS;
     }
     otLogFuncExit();
     return error;
@@ -1467,7 +1467,7 @@ OTNODEAPI int32_t OTCALL otNodeAddIpAddr(otNode* aNode, const char *aAddr)
 
     otNetifAddress aAddress;
     auto error = otIp6AddressFromString(aAddr, &aAddress.mAddress);
-    if (error != kThreadError_None) return error;
+    if (error != OT_ERROR_NONE) return error;
 
     aAddress.mPrefixLength = 64;
     aAddress.mPreferred = true;
@@ -1559,7 +1559,7 @@ OTNODEAPI int32_t OTCALL otNodeAddPrefix(otNode* aNode, const char *aPrefix, con
     otBorderRouterConfig config = {0};
 
     auto error = otNodeParsePrefix(aPrefix, &config.mPrefix);
-    if (error != kThreadError_None) return error;
+    if (error != OT_ERROR_NONE) return error;
     
     const char *index = aFlags;
     while (*index)
@@ -1588,7 +1588,7 @@ OTNODEAPI int32_t OTCALL otNodeAddPrefix(otNode* aNode, const char *aPrefix, con
             config.mStable = true;
             break;
         default:
-            return kThreadError_InvalidArgs;
+            return OT_ERROR_INVALID_ARGS;
         }
 
         index++;
@@ -1608,7 +1608,7 @@ OTNODEAPI int32_t OTCALL otNodeAddPrefix(otNode* aNode, const char *aPrefix, con
     }
     else
     {
-        return kThreadError_InvalidArgs;
+        return OT_ERROR_INVALID_ARGS;
     }
 
     auto result = otNetDataAddPrefixInfo(aNode->mInstance, &config);
@@ -1622,7 +1622,7 @@ OTNODEAPI int32_t OTCALL otNodeRemovePrefix(otNode* aNode, const char *aPrefix)
 
     otIp6Prefix prefix;
     auto error = otNodeParsePrefix(aPrefix, &prefix);
-    if (error != kThreadError_None) return error;
+    if (error != OT_ERROR_NONE) return error;
 
     auto result = otNetDataRemovePrefixInfo(aNode->mInstance, &prefix);
     otLogFuncExit();
@@ -1635,7 +1635,7 @@ OTNODEAPI int32_t OTCALL otNodeAddRoute(otNode* aNode, const char *aPrefix, cons
     otExternalRouteConfig config = {0};
 
     auto error = otNodeParsePrefix(aPrefix, &config.mPrefix);
-    if (error != kThreadError_None) return error;
+    if (error != OT_ERROR_NONE) return error;
     
     if (strcmp(aPreference, "high") == 0)
     {
@@ -1651,7 +1651,7 @@ OTNODEAPI int32_t OTCALL otNodeAddRoute(otNode* aNode, const char *aPrefix, cons
     }
     else
     {
-        return kThreadError_InvalidArgs;
+        return OT_ERROR_INVALID_ARGS;
     }
 
     auto result = otNetDataAddRoute(aNode->mInstance, &config);
@@ -1665,7 +1665,7 @@ OTNODEAPI int32_t OTCALL otNodeRemoveRoute(otNode* aNode, const char *aPrefix)
 
     otIp6Prefix prefix;
     auto error = otNodeParsePrefix(aPrefix, &prefix);
-    if (error != kThreadError_None) return error;
+    if (error != OT_ERROR_NONE) return error;
 
     auto result = otNetDataRemoveRoute(aNode->mInstance, &prefix);
     otLogFuncExit();
@@ -1700,7 +1700,7 @@ OTNODEAPI int32_t OTCALL otNodeEnergyScan(otNode* aNode, uint32_t aMask, uint8_t
 
     otIp6Address address = {0};
     auto error = otIp6AddressFromString(aAddr, &address);
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         printf("otIp6AddressFromString(%s) failed, 0x%x!\r\n", aAddr, error);
         return error;
@@ -1709,13 +1709,13 @@ OTNODEAPI int32_t OTCALL otNodeEnergyScan(otNode* aNode, uint32_t aMask, uint8_t
     ResetEvent(aNode->mEnergyScanEvent);
 
     error = otCommissionerEnergyScan(aNode->mInstance, aMask, aCount, aPeriod, aDuration, &address, otNodeCommissionerEnergyReportCallback, aNode);
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         printf("otCommissionerEnergyScan failed, 0x%x!\r\n", error);
         return error;
     }
 
-    auto result = WaitForSingleObject(aNode->mEnergyScanEvent, 8000) == WAIT_OBJECT_0 ? kThreadError_None : kThreadError_NotFound;
+    auto result = WaitForSingleObject(aNode->mEnergyScanEvent, 8000) == WAIT_OBJECT_0 ? OT_ERROR_NONE : OT_ERROR_NOT_FOUND;
     otLogFuncExit();
     return result;
 }
@@ -1734,7 +1734,7 @@ OTNODEAPI int32_t OTCALL otNodePanIdQuery(otNode* aNode, uint16_t aPanId, uint32
 
     otIp6Address address = {0};
     auto error = otIp6AddressFromString(aAddr, &address);
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         printf("otIp6AddressFromString(%s) failed, 0x%x!\r\n", aAddr, error);
         return error;
@@ -1743,13 +1743,13 @@ OTNODEAPI int32_t OTCALL otNodePanIdQuery(otNode* aNode, uint16_t aPanId, uint32
     ResetEvent(aNode->mPanIdConflictEvent);
 
     error = otCommissionerPanIdQuery(aNode->mInstance, aPanId, aMask, &address, otNodeCommissionerPanIdConflictCallback, aNode);
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         printf("otCommissionerPanIdQuery failed, 0x%x!\r\n", error);
         return error;
     }
 
-    auto result = WaitForSingleObject(aNode->mPanIdConflictEvent, 8000) == WAIT_OBJECT_0 ? kThreadError_None : kThreadError_NotFound;
+    auto result = WaitForSingleObject(aNode->mPanIdConflictEvent, 8000) == WAIT_OBJECT_0 ? OT_ERROR_NONE : OT_ERROR_NOT_FOUND;
     otLogFuncExit();
     return result;
 }
@@ -1770,7 +1770,7 @@ OTNODEAPI uint32_t OTCALL otNodePing(otNode* aNode, const char *aAddr, uint16_t 
     // Convert string to destination address
     otIp6Address otDestinationAddress = {0};
     auto error = otIp6AddressFromString(aAddr, &otDestinationAddress);
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         printf("otIp6AddressFromString(%s) failed!\r\n", aAddr);
         return 0;
@@ -1940,7 +1940,7 @@ OTNODEAPI int32_t OTCALL otNodeCommissionerAnnounceBegin(otNode* aNode, uint32_t
 
     otIp6Address aAddress;
     auto error = otIp6AddressFromString(aAddr, &aAddress);
-    if (error != kThreadError_None) return error;
+    if (error != OT_ERROR_NONE) return error;
 
     auto result = otCommissionerAnnounceBegin(aNode->mInstance, aChannelMask, aCount, aPeriod, &aAddress);
     otLogFuncExit();
@@ -1981,7 +1981,7 @@ OTNODEAPI int32_t OTCALL otNodeSetActiveDataset(otNode* aNode, uint64_t aTimesta
         if ((keyLength = Hex2Bin(aMasterKey, aDataset.mMasterKey.m8, sizeof(aDataset.mMasterKey))) != OT_MASTER_KEY_SIZE)
         {
             printf("invalid length key %d\r\n", keyLength);
-            return kThreadError_Parse;
+            return OT_ERROR_PARSE;
         }
         aDataset.mIsMasterKeySet = true;
     }
@@ -2070,7 +2070,7 @@ OTNODEAPI int32_t OTCALL otNodeSendPendingSet(otNode* aNode, uint64_t aActiveTim
         if ((keyLength = Hex2Bin(aMasterKey, aDataset.mMasterKey.m8, sizeof(aDataset.mMasterKey))) != OT_MASTER_KEY_SIZE)
         {
             printf("invalid length key %d\r\n", keyLength);
-            return kThreadError_Parse;
+            return OT_ERROR_PARSE;
         }
         aDataset.mIsMasterKeySet = true;
     }
@@ -2079,7 +2079,7 @@ OTNODEAPI int32_t OTCALL otNodeSendPendingSet(otNode* aNode, uint64_t aActiveTim
     {
         otIp6Address prefix;
         auto error = otIp6AddressFromString(aMeshLocal, &prefix);
-        if (error != kThreadError_None) return error;
+        if (error != OT_ERROR_NONE) return error;
         memcpy(aDataset.mMeshLocalPrefix.m8, prefix.mFields.m8, sizeof(aDataset.mMeshLocalPrefix.m8));
         aDataset.mIsMeshLocalPrefixSet = true;
     }
@@ -2133,7 +2133,7 @@ OTNODEAPI int32_t OTCALL otNodeSendActiveSet(otNode* aNode, uint64_t aActiveTime
         if ((keyLength = Hex2Bin(aExtPanId, aDataset.mExtendedPanId.m8, sizeof(aDataset.mExtendedPanId))) != OT_EXT_PAN_ID_SIZE)
         {
             printf("invalid length ext pan id %d\r\n", keyLength);
-            return kThreadError_Parse;
+            return OT_ERROR_PARSE;
         }
         aDataset.mIsExtendedPanIdSet = true;
     }
@@ -2144,7 +2144,7 @@ OTNODEAPI int32_t OTCALL otNodeSendActiveSet(otNode* aNode, uint64_t aActiveTime
         if ((keyLength = Hex2Bin(aMasterKey, aDataset.mMasterKey.m8, sizeof(aDataset.mMasterKey))) != OT_MASTER_KEY_SIZE)
         {
             printf("invalid length key %d\r\n", keyLength);
-            return kThreadError_Parse;
+            return OT_ERROR_PARSE;
         }
         aDataset.mIsMasterKeySet = true;
     }
@@ -2153,7 +2153,7 @@ OTNODEAPI int32_t OTCALL otNodeSendActiveSet(otNode* aNode, uint64_t aActiveTime
     {
         otIp6Address prefix;
         auto error = otIp6AddressFromString(aMeshLocal, &prefix);
-        if (error != kThreadError_None) return error;
+        if (error != OT_ERROR_NONE) return error;
         memcpy(aDataset.mMeshLocalPrefix.m8, prefix.mFields.m8, sizeof(aDataset.mMeshLocalPrefix.m8));
         aDataset.mIsMeshLocalPrefixSet = true;
     }
@@ -2170,7 +2170,7 @@ OTNODEAPI int32_t OTCALL otNodeSendActiveSet(otNode* aNode, uint64_t aActiveTime
         if ((length = Hex2Bin(aBinary,tlvs, sizeof(tlvs))) < 0)
         {
             printf("invalid length tlvs %d\r\n", length);
-            return kThreadError_Parse;
+            return OT_ERROR_PARSE;
         }
         tlvsLength = (uint8_t)length;
     }

--- a/examples/platforms/cc2538/diag.c
+++ b/examples/platforms/cc2538/diag.c
@@ -72,7 +72,7 @@ void otPlatDiagTxPowerSet(int8_t aTxPower)
     (void) aTxPower;
 }
 
-void otPlatDiagRadioReceived(otInstance *aInstance, RadioPacket *aFrame, ThreadError aError)
+void otPlatDiagRadioReceived(otInstance *aInstance, RadioPacket *aFrame, otError aError)
 {
     (void) aInstance;
     (void) aFrame;

--- a/examples/platforms/cc2538/flash.c
+++ b/examples/platforms/cc2538/flash.c
@@ -46,34 +46,34 @@ enum
     FLASH_PAGE_SIZE = 0x800,
 };
 
-static ThreadError romStatusToThread(int32_t aStatus)
+static otError romStatusToThread(int32_t aStatus)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     switch (aStatus)
     {
     case 0:
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
         break;
 
     case -1:
-        error = kThreadError_Failed;
+        error = OT_ERROR_FAILED;
         break;
 
     case -2:
-        error = kThreadError_InvalidArgs;
+        error = OT_ERROR_INVALID_ARGS;
         break;
 
     default:
-        error = kThreadError_Abort;
+        error = OT_ERROR_ABORT;
     }
 
     return error;
 }
 
-ThreadError utilsFlashInit(void)
+otError utilsFlashInit(void)
 {
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 uint32_t utilsFlashGetSize(void)
@@ -83,13 +83,13 @@ uint32_t utilsFlashGetSize(void)
     return reg ? (0x20000 * reg) : 0x10000;
 }
 
-ThreadError utilsFlashErasePage(uint32_t aAddress)
+otError utilsFlashErasePage(uint32_t aAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     int32_t status;
     uint32_t address;
 
-    otEXPECT_ACTION(aAddress < utilsFlashGetSize(), error = kThreadError_InvalidArgs);
+    otEXPECT_ACTION(aAddress < utilsFlashGetSize(), error = OT_ERROR_INVALID_ARGS);
 
     address = FLASH_BASE + aAddress - (aAddress & (FLASH_PAGE_SIZE - 1));
     status = ROM_PageErase(address, FLASH_PAGE_SIZE);
@@ -99,9 +99,9 @@ exit:
     return error;
 }
 
-ThreadError utilsFlashStatusWait(uint32_t aTimeout)
+otError utilsFlashStatusWait(uint32_t aTimeout)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint32_t start = otPlatAlarmGetNow();
     uint32_t busy = 1;
 
@@ -110,7 +110,7 @@ ThreadError utilsFlashStatusWait(uint32_t aTimeout)
         busy = HWREG(FLASH_CTRL_FCTL) & FLASH_CTRL_FCTL_BUSY;
     }
 
-    otEXPECT_ACTION(!busy, error = kThreadError_Busy);
+    otEXPECT_ACTION(!busy, error = OT_ERROR_BUSY);
 
 exit:
     return error;
@@ -137,7 +137,7 @@ uint32_t utilsFlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
             busy = HWREG(FLASH_CTRL_FCTL) & FLASH_CTRL_FCTL_BUSY;
         }
 
-        otEXPECT(romStatusToThread(status) == kThreadError_None);
+        otEXPECT(romStatusToThread(status) == OT_ERROR_NONE);
         size += 4;
         data++;
         aAddress += 4;

--- a/examples/platforms/cc2538/random.c
+++ b/examples/platforms/cc2538/random.c
@@ -91,12 +91,12 @@ uint32_t otPlatRandomGet(void)
     return random;
 }
 
-ThreadError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
+otError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t channel = 0;
 
-    otEXPECT_ACTION(aOutput, error = kThreadError_InvalidArgs);
+    otEXPECT_ACTION(aOutput, error = OT_ERROR_INVALID_ARGS);
 
     if (otPlatRadioIsEnabled(sInstance))
     {

--- a/examples/platforms/cc2538/uart.c
+++ b/examples/platforms/cc2538/uart.c
@@ -67,7 +67,7 @@ typedef struct RecvBuffer
 
 static RecvBuffer sReceive;
 
-ThreadError otPlatUartEnable(void)
+otError otPlatUartEnable(void)
 {
     uint32_t div;
 
@@ -108,19 +108,19 @@ ThreadError otPlatUartEnable(void)
     // enable interrupts
     HWREG(NVIC_EN0) = 1 << ((INT_UART0 - 16) & 31);
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatUartDisable(void)
+otError otPlatUartDisable(void)
 {
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
+otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    otEXPECT_ACTION(sTransmitBuffer == NULL, error = kThreadError_Busy);
+    otEXPECT_ACTION(sTransmitBuffer == NULL, error = OT_ERROR_BUSY);
 
     sTransmitBuffer = aBuf;
     sTransmitLength = aBufLength;

--- a/examples/platforms/cc2650/diag.c
+++ b/examples/platforms/cc2650/diag.c
@@ -70,7 +70,7 @@ void otPlatDiagTxPowerSet(int8_t aTxPower)
     (void) aTxPower;
 }
 
-void otPlatDiagRadioReceived(otInstance *aInstance, RadioPacket *aFrame, ThreadError aError)
+void otPlatDiagRadioReceived(otInstance *aInstance, RadioPacket *aFrame, otError aError)
 {
     (void) aInstance;
     (void) aFrame;

--- a/examples/platforms/cc2650/flash.c
+++ b/examples/platforms/cc2650/flash.c
@@ -33,9 +33,9 @@
  * not enough space on the cc2650 to support NV as an SoC.
  */
 
-ThreadError utilsFlashInit(void)
+otError utilsFlashInit(void)
 {
-    return kThreadError_NotImplemented;
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
 uint32_t utilsFlashGetSize(void)
@@ -43,16 +43,16 @@ uint32_t utilsFlashGetSize(void)
     return 0;
 }
 
-ThreadError utilsFlashErasePage(uint32_t aAddress)
+otError utilsFlashErasePage(uint32_t aAddress)
 {
     (void)aAddress;
-    return kThreadError_NotImplemented;
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-ThreadError utilsFlashStatusWait(uint32_t aTimeout)
+otError utilsFlashStatusWait(uint32_t aTimeout)
 {
     (void)aTimeout;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 uint32_t utilsFlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize)

--- a/examples/platforms/cc2650/random.c
+++ b/examples/platforms/cc2650/random.c
@@ -122,16 +122,15 @@ static int TRNGPoll(unsigned char *aOutput, size_t aLen)
 /**
  * Function documented in platform/random.h
  */
-ThreadError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
+otError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     size_t length = aOutputLength;
 
-    otEXPECT_ACTION(aOutput, error = kThreadError_InvalidArgs);
+    otEXPECT_ACTION(aOutput, error = OT_ERROR_INVALID_ARGS);
 
-    otEXPECT_ACTION(TRNGPoll((unsigned char *)aOutput, length) != 0, error = kThreadError_Failed);
+    otEXPECT_ACTION(TRNGPoll((unsigned char *)aOutput, length) != 0, error = OT_ERROR_FAILED);
 
 exit:
     return error;
 }
-

--- a/examples/platforms/cc2650/uart.c
+++ b/examples/platforms/cc2650/uart.c
@@ -61,7 +61,7 @@ void UART0_intHandler(void);
 /**
  * Function documented in platform/uart.h
  */
-ThreadError otPlatUartEnable(void)
+otError otPlatUartEnable(void)
 {
     PRCMPowerDomainOn(PRCM_DOMAIN_SERIAL);
 
@@ -81,13 +81,13 @@ ThreadError otPlatUartEnable(void)
     UARTIntEnable(UART0_BASE, UART_INT_RX | UART_INT_RT);
     UARTIntRegister(UART0_BASE, UART0_intHandler);
     UARTEnable(UART0_BASE);
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 /**
  * Function documented in platform/uart.h
  */
-ThreadError otPlatUartDisable(void)
+otError otPlatUartDisable(void)
 {
     UARTDisable(UART0_BASE);
     UARTIntUnregister(UART0_BASE);
@@ -104,16 +104,16 @@ ThreadError otPlatUartDisable(void)
      * serial power domain
      */
     PRCMPowerDomainOff(PRCM_DOMAIN_SERIAL);
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 /**
  * Function documented in platform/uart.h
  */
-ThreadError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
+otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
-    ThreadError error = kThreadError_None;
-    otEXPECT_ACTION(sSendBuffer == NULL, error = kThreadError_Busy);
+    otError error = OT_ERROR_NONE;
+    otEXPECT_ACTION(sSendBuffer == NULL, error = OT_ERROR_BUSY);
 
     sSendBuffer = aBuf;
     sSendLen = aBufLength;

--- a/examples/platforms/da15000/flash.c
+++ b/examples/platforms/da15000/flash.c
@@ -53,14 +53,14 @@ QSPI_SECTION static  uint8_t qspi_get_erase_status(void)
 volatile bool  DisableErase = false;
 
 // Erase QSPI memory section as non-blocking function. Remember to check utilsFlashStatusWait before write or read!!
-ThreadError utilsFlashErasePage(uint32_t aAddress)
+otError utilsFlashErasePage(uint32_t aAddress)
 {
 
     uint32_t flash_offset = (aAddress) & ~(FLASH_SECTOR_SIZE - 1);
 
     if (DisableErase)
     {
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
 
     qspi_automode_init();
@@ -68,7 +68,7 @@ ThreadError utilsFlashErasePage(uint32_t aAddress)
 
     CACHE->CACHE_CTRL1_REG = CACHE_CACHE_CTRL1_REG_CACHE_FLUSH_Msk;
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 
@@ -78,7 +78,7 @@ uint32_t utilsFlashGetSize(void)
     return (uint32_t)FLASH_BUFFER_SIZE;
 }
 
-ThreadError utilsFlashStatusWait(uint32_t aTimeout)
+otError utilsFlashStatusWait(uint32_t aTimeout)
 {
 
     sWaitStatusTimeout = otPlatAlarmGetNow();
@@ -87,25 +87,25 @@ ThreadError utilsFlashStatusWait(uint32_t aTimeout)
 
     if (qspi_get_erase_status())
     {
-        return kThreadError_Busy;
+        return OT_ERROR_BUSY;
     }
     else
     {
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
 }
 
-ThreadError utilsFlashInit(void)
+otError utilsFlashInit(void)
 {
     qspi_automode_flash_power_up();
 
-    if (utilsFlashStatusWait(1000) == kThreadError_Busy)
+    if (utilsFlashStatusWait(1000) == OT_ERROR_BUSY)
     {
-        return kThreadError_Failed;
+        return OT_ERROR_FAILED;
     }
     else
     {
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
 }
 

--- a/examples/platforms/da15000/radio.c
+++ b/examples/platforms/da15000/radio.c
@@ -72,7 +72,7 @@ static uint8_t     sTransmitPsdu[kMaxPHYPacketSize];
 static uint8_t     sReceivePsdu[kMaxPHYPacketSize];
 static RadioPacket sTransmitFrame;
 static RadioPacket sReceiveFrame;
-static ThreadError sTransmitStatus;
+static otError sTransmitStatus;
 
 static bool sFramePending     = false;
 static bool sSendFrameDone    = false;
@@ -139,13 +139,13 @@ void otPlatRadioSetShortAddress(otInstance *aInstance, uint16_t address)
     FTDF_setValue(FTDF_PIB_SHORT_ADDRESS, &address);
 }
 
-ThreadError otPlatRadioEnable(otInstance *aInstance)
+otError otPlatRadioEnable(otInstance *aInstance)
 {
     uint8_t defaultChannel;
     uint8_t maxRetries;
 
-    ThreadError error = kThreadError_None;
-    otEXPECT_ACTION(sRadioState == kStateDisabled, error = kThreadError_InvalidState);
+    otError error = OT_ERROR_NONE;
+    otEXPECT_ACTION(sRadioState == kStateDisabled, error = OT_ERROR_INVALID_STATE);
 
     sThreadInstance = aInstance;
     sTransmitFrame.mPsdu = sTransmitPsdu;
@@ -170,13 +170,13 @@ exit:
     return error;
 }
 
-ThreadError otPlatRadioDisable(otInstance *aInstance)
+otError otPlatRadioDisable(otInstance *aInstance)
 {
     (void)aInstance;
 
     sRadioState = kStateDisabled;
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 bool otPlatRadioIsEnabled(otInstance *aInstance)
@@ -186,23 +186,23 @@ bool otPlatRadioIsEnabled(otInstance *aInstance)
     return (sRadioState != kStateDisabled);
 }
 
-ThreadError otPlatRadioSleep(otInstance *aInstance)
+otError otPlatRadioSleep(otInstance *aInstance)
 {
     (void)aInstance;
 
     if (sRadioState == kStateReceive && sSleepInitDelay == 0)
     {
         sSleepInitDelay = otPlatAlarmGetNow();
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
     else if ((otPlatAlarmGetNow() - sSleepInitDelay) < 3000)
     {
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
 
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otEXPECT_ACTION(((sRadioState == kStateReceive) || (sRadioState == kStateSleep)),
-                    error = kThreadError_InvalidState);
+                    error = OT_ERROR_INVALID_STATE);
 
     sGoSleep = true;
     sRadioState = kStateSleep;
@@ -211,12 +211,12 @@ exit:
     return error;
 }
 
-ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
+otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 {
     (void)aInstance;
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    otEXPECT_ACTION(sRadioState != kStateDisabled, error = kThreadError_InvalidState);
+    otEXPECT_ACTION(sRadioState != kStateDisabled, error = OT_ERROR_INVALID_STATE);
 
     ad_ftdf_wake_up();
     sChannel = aChannel;
@@ -236,7 +236,7 @@ void otPlatRadioEnableSrcMatch(otInstance *aInstance, bool aEnable)
     (void)aEnable;
 }
 
-ThreadError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
+otError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
 {
     (void)aInstance;
 
@@ -244,10 +244,10 @@ ThreadError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16
     uint8_t entryIdx;
 
     // check if address already stored
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otEXPECT(!FTDF_fpprLookupShortAddress(aShortAddress, &entry, &entryIdx));
 
-    otEXPECT_ACTION(FTDF_fpprGetFreeShortAddress(&entry, &entryIdx), error = kThreadError_NoBufs);
+    otEXPECT_ACTION(FTDF_fpprGetFreeShortAddress(&entry, &entryIdx), error = OT_ERROR_NO_BUFS);
 
     FTDF_fpprSetShortAddress(entry, entryIdx, aShortAddress);
     FTDF_fpprSetShortAddressValid(entry, entryIdx, FTDF_TRUE);
@@ -257,7 +257,7 @@ exit:
 
 }
 
-ThreadError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
+otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
 {
     (void)aInstance;
 
@@ -271,10 +271,10 @@ ThreadError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t 
     addr = addrL | (addrH << 32);
 
     // check if address already stored
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otEXPECT(!FTDF_fpprLookupExtAddress(addr, &entry));
 
-    otEXPECT_ACTION(FTDF_fpprGetFreeExtAddress(&entry), error = kThreadError_NoBufs);
+    otEXPECT_ACTION(FTDF_fpprGetFreeExtAddress(&entry), error = OT_ERROR_NO_BUFS);
 
     FTDF_fpprSetExtAddress(entry, addr);
     FTDF_fpprSetExtAddressValid(entry, FTDF_TRUE);
@@ -283,15 +283,15 @@ exit:
     return error;
 }
 
-ThreadError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
+otError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
 {
     (void)aInstance;
 
     uint8_t entry;
     uint8_t entryIdx;
 
-    ThreadError error = kThreadError_None;
-    otEXPECT_ACTION(FTDF_fpprLookupShortAddress(aShortAddress, &entry, &entryIdx), error = kThreadError_NoAddress);
+    otError error = OT_ERROR_NONE;
+    otEXPECT_ACTION(FTDF_fpprLookupShortAddress(aShortAddress, &entry, &entryIdx), error = OT_ERROR_NO_ADDRESS);
 
     FTDF_fpprSetShortAddress(entry, entryIdx, 0);
     FTDF_fpprSetShortAddressValid(entry, entryIdx, FTDF_FALSE);
@@ -300,7 +300,7 @@ exit:
     return error;
 }
 
-ThreadError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
+otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
 {
     (void)aInstance;
 
@@ -313,8 +313,8 @@ ThreadError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_
     addrH = (aExtAddress[0] << 24) | (aExtAddress[1] << 16) | (aExtAddress[2] << 8) | (aExtAddress[3] << 0);
     addr = addrL | (addrH << 32);
 
-    ThreadError error = kThreadError_None;
-    otEXPECT_ACTION(FTDF_fpprLookupExtAddress(addr, &entry), error = kThreadError_NoAddress);
+    otError error = OT_ERROR_NONE;
+    otEXPECT_ACTION(FTDF_fpprLookupExtAddress(addr, &entry), error = OT_ERROR_NO_ADDRESS);
 
     FTDF_fpprSetExtAddress(entry, 0);
     FTDF_fpprSetExtAddressValid(entry, FTDF_FALSE);
@@ -363,14 +363,14 @@ RadioPacket *otPlatRadioGetTransmitBuffer(otInstance *aInstance)
     return &sTransmitFrame;
 }
 
-ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
+otError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
 {
     (void)aInstance;
 
     uint8_t csmaSuppress;
 
-    ThreadError error = kThreadError_None;
-    otEXPECT_ACTION(sRadioState != kStateDisabled, error = kThreadError_InvalidState);
+    otError error = OT_ERROR_NONE;
+    otEXPECT_ACTION(sRadioState != kStateDisabled, error = OT_ERROR_INVALID_STATE);
 
     csmaSuppress = 0;
     ad_ftdf_send_frame_simple(aPacket->mLength, aPacket->mPsdu, aPacket->mChannel, 0, csmaSuppress); //Prio 0 for all.
@@ -409,13 +409,13 @@ void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable)
     sRadioPromiscuous = aEnable;
 }
 
-ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration)
+otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration)
 {
     (void)aInstance;
     (void)aScanChannel;
     (void)aScanDuration;
 
-    return kThreadError_NotImplemented;
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
 void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
@@ -460,20 +460,20 @@ void FTDF_sendFrameTransparentConfirm(void *handle, FTDF_Bitmap32 status)
     switch (status)
     {
     case FTDF_TRANSPARENT_SEND_SUCCESSFUL:
-        sTransmitStatus = kThreadError_None;
+        sTransmitStatus = OT_ERROR_NONE;
         break;
 
     case FTDF_TRANSPARENT_CSMACA_FAILURE:
-        sTransmitStatus = kThreadError_ChannelAccessFailure;
+        sTransmitStatus = OT_ERROR_CHANNEL_ACCESS_FAILURE;
         break;
 
     case FTDF_TRANSPARENT_NO_ACK:
-        sTransmitStatus = kThreadError_NoAck;
+        sTransmitStatus = OT_ERROR_NO_ACK;
         sSleepInitDelay = 0;
         break;
 
     default:
-        sTransmitStatus = kThreadError_Abort;
+        sTransmitStatus = OT_ERROR_ABORT;
         break;
     }
 
@@ -494,11 +494,11 @@ void FTDF_rcvFrameTransparent(FTDF_DataLength frameLength,
 
     if (status == FTDF_TRANSPARENT_RCV_SUCCESSFUL)
     {
-        otPlatRadioReceiveDone(sThreadInstance, &sReceiveFrame, kThreadError_None);
+        otPlatRadioReceiveDone(sThreadInstance, &sReceiveFrame, OT_ERROR_NONE);
     }
     else
     {
-        otPlatRadioReceiveDone(sThreadInstance, &sReceiveFrame, kThreadError_Abort);
+        otPlatRadioReceiveDone(sThreadInstance, &sReceiveFrame, OT_ERROR_ABORT);
     }
 
     if (sRadioState != kStateDisabled)

--- a/examples/platforms/da15000/random.c
+++ b/examples/platforms/da15000/random.c
@@ -93,7 +93,7 @@ uint32_t otPlatRandomGet(void)
     return mlcg;
 }
 
-ThreadError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
+otError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
 {
 
     for (uint16_t length = 0; length < aOutputLength; length++)
@@ -101,5 +101,5 @@ ThreadError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
         aOutput[length] = (uint8_t)otPlatRandomGet();
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }

--- a/examples/platforms/da15000/uart.c
+++ b/examples/platforms/da15000/uart.c
@@ -49,9 +49,9 @@ static int sInFd;
 static int sOutFd;
 void UartBuffClear(void);
 
-ThreadError otPlatUartEnable(void)
+otError otPlatUartEnable(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uart_config uart_init =
     {
         .baud_rate = HW_UART_BAUDRATE_9600,
@@ -76,9 +76,9 @@ ThreadError otPlatUartEnable(void)
     return error;
 }
 
-ThreadError otPlatUartDisable(void)
+otError otPlatUartDisable(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     close(sInFd);
     close(sOutFd);
@@ -117,9 +117,9 @@ void UartBuffClear(void)
 }
 
 
-ThreadError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
+otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     hw_uart_write_buffer(HW_UART1, aBuf, aBufLength);
 
     otPlatUartSendDone();

--- a/examples/platforms/efr32/diag.c
+++ b/examples/platforms/efr32/diag.c
@@ -77,7 +77,7 @@ void otPlatDiagTxPowerSet(int8_t aTxPower)
     (void) aTxPower;
 }
 
-void otPlatDiagRadioReceived(otInstance *aInstance, RadioPacket *aFrame, ThreadError aError)
+void otPlatDiagRadioReceived(otInstance *aInstance, RadioPacket *aFrame, otError aError)
 {
     (void) aInstance;
     (void) aFrame;

--- a/examples/platforms/efr32/flash.c
+++ b/examples/platforms/efr32/flash.c
@@ -48,32 +48,32 @@ static inline uint32_t mapAddress(uint32_t aAddress)
     return aAddress + FLASH_DATA_START_ADDR;
 }
 
-static ThreadError returnTypeConvert(int32_t aStatus)
+static otError returnTypeConvert(int32_t aStatus)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     switch (aStatus)
     {
     case mscReturnOk:
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
         break;
 
     case mscReturnInvalidAddr:
     case mscReturnUnaligned:
-        error = kThreadError_InvalidArgs;
+        error = OT_ERROR_INVALID_ARGS;
         break;
 
     default:
-        error = kThreadError_Failed;
+        error = OT_ERROR_FAILED;
     }
 
     return error;
 }
 
-ThreadError utilsFlashInit(void)
+otError utilsFlashInit(void)
 {
     MSC_Init();
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 uint32_t utilsFlashGetSize(void)
@@ -81,7 +81,7 @@ uint32_t utilsFlashGetSize(void)
     return FLASH_DATA_END_ADDR - FLASH_DATA_START_ADDR;
 }
 
-ThreadError utilsFlashErasePage(uint32_t aAddress)
+otError utilsFlashErasePage(uint32_t aAddress)
 {
     int32_t status;
 
@@ -90,16 +90,16 @@ ThreadError utilsFlashErasePage(uint32_t aAddress)
     return returnTypeConvert(status);
 }
 
-ThreadError utilsFlashStatusWait(uint32_t aTimeout)
+otError utilsFlashStatusWait(uint32_t aTimeout)
 {
-    ThreadError error = kThreadError_Busy;
+    otError error = OT_ERROR_BUSY;
     uint32_t start = otPlatAlarmGetNow();
 
     do
     {
         if (MSC->STATUS & MSC_STATUS_WDATAREADY)
         {
-            error = kThreadError_None;
+            error = OT_ERROR_NONE;
             break;
         }
     }
@@ -118,7 +118,7 @@ uint32_t utilsFlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
                     (!(aAddress & 3)) && (!(aSize & 3)), rval = 0);
 
     status = MSC_WriteWord((uint32_t *)mapAddress(aAddress), aData, aSize);
-    otEXPECT_ACTION(returnTypeConvert(status) == kThreadError_None, rval = 0);
+    otEXPECT_ACTION(returnTypeConvert(status) == OT_ERROR_NONE, rval = 0);
 
 exit:
     return rval;

--- a/examples/platforms/efr32/radio.c
+++ b/examples/platforms/efr32/radio.c
@@ -77,11 +77,11 @@ static PhyState       sState             = kStateDisabled;
 static uint8_t        sReceiveBuffer[IEEE802154_MAX_LENGTH + 1 + sizeof(RAIL_RxPacketInfo_t)];
 static uint8_t        sReceivePsdu[IEEE802154_MAX_LENGTH];
 static RadioPacket    sReceiveFrame;
-static ThreadError    sReceiveError;
+static otError    sReceiveError;
 
 static RadioPacket    sTransmitFrame;
 static uint8_t        sTransmitPsdu[IEEE802154_MAX_LENGTH];
-static ThreadError    sTransmitError;
+static otError    sTransmitError;
 
 typedef struct        srcMatchEntry
 {
@@ -226,7 +226,7 @@ bool otPlatRadioIsEnabled(otInstance *aInstance)
     return (sState != kStateDisabled);
 }
 
-ThreadError otPlatRadioEnable(otInstance *aInstance)
+otError otPlatRadioEnable(otInstance *aInstance)
 {
     CORE_DECLARE_IRQ_STATE;
     CORE_ENTER_CRITICAL();
@@ -238,10 +238,10 @@ ThreadError otPlatRadioEnable(otInstance *aInstance)
 
 exit:
     CORE_EXIT_CRITICAL();
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatRadioDisable(otInstance *aInstance)
+otError otPlatRadioDisable(otInstance *aInstance)
 {
     CORE_DECLARE_IRQ_STATE;
     CORE_ENTER_CRITICAL();
@@ -253,19 +253,19 @@ ThreadError otPlatRadioDisable(otInstance *aInstance)
 
 exit:
     CORE_EXIT_CRITICAL();
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatRadioSleep(otInstance *aInstance)
+otError otPlatRadioSleep(otInstance *aInstance)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     (void)aInstance;
 
     CORE_DECLARE_IRQ_STATE;
     CORE_ENTER_CRITICAL();
 
     otEXPECT_ACTION((sState != kStateTransmit) && (sState != kStateDisabled),
-                    error = kThreadError_InvalidState);
+                    error = OT_ERROR_INVALID_STATE);
 
     otLogInfoPlat(sInstance, "State=kStateSleep", NULL);
     sState = kStateSleep;
@@ -281,15 +281,15 @@ exit:
     return error;
 }
 
-ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
+otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     (void)aInstance;
 
     CORE_DECLARE_IRQ_STATE;
     CORE_ENTER_CRITICAL();
 
-    otEXPECT_ACTION(sState != kStateDisabled, error = kThreadError_InvalidState);
+    otEXPECT_ACTION(sState != kStateDisabled, error = OT_ERROR_INVALID_STATE);
 
     otLogInfoPlat(sInstance, "State=kStateReceive", NULL);
     sState = kStateReceive;
@@ -311,9 +311,9 @@ exit:
     return error;
 }
 
-ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
+otError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     RAIL_CsmaConfig_t csmaConfig = RAIL_CSMA_CONFIG_802_15_4_2003_2p4_GHz_OQPSK_CSMA;
     RAIL_TxData_t tx_data;
     uint8_t frame[IEEE802154_MAX_LENGTH + 1];
@@ -323,10 +323,10 @@ ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
     CORE_ENTER_CRITICAL();
 
     otEXPECT_ACTION((sState != kStateDisabled) && (sState != kStateTransmit),
-                    error = kThreadError_InvalidState);
+                    error = OT_ERROR_INVALID_STATE);
 
     sState = kStateTransmit;
-    sTransmitError = kThreadError_None;
+    sTransmitError = OT_ERROR_NONE;
     sTransmitBusy = true;
 
     frame[0] = aPacket->mLength;
@@ -502,10 +502,10 @@ void otPlatRadioEnableSrcMatch(otInstance *aInstance, bool aEnable)
     CORE_EXIT_CRITICAL();
 }
 
-ThreadError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
+otError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
 {
     (void)aInstance;
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     int8_t entry = -1;
 
     CORE_DECLARE_IRQ_STATE;
@@ -515,7 +515,7 @@ ThreadError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16
     otLogDebgPlat(sInstance, "Add ShortAddr entry: %d", entry);
 
     otEXPECT_ACTION(entry >= 0 && entry < RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM,
-                    error = kThreadError_NoBufs);
+                    error = OT_ERROR_NO_BUFS);
 
     addToSrcMatchShortIndirect(entry, aShortAddress);
 
@@ -524,9 +524,9 @@ exit:
     return error;
 }
 
-ThreadError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
+otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     int8_t entry = -1;
     (void)aInstance;
 
@@ -537,7 +537,7 @@ ThreadError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t 
     otLogDebgPlat(sInstance, "Add ExtAddr entry: %d", entry);
 
     otEXPECT_ACTION(entry >= 0 && entry < RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM,
-                    error = kThreadError_NoBufs);
+                    error = OT_ERROR_NO_BUFS);
 
     addToSrcMatchExtIndirect(entry, aExtAddress);
 
@@ -546,9 +546,9 @@ exit:
     return error;
 }
 
-ThreadError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
+otError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     int8_t entry = -1;
     (void)aInstance;
 
@@ -559,7 +559,7 @@ ThreadError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint
     otLogDebgPlat(sInstance, "Clear ShortAddr entry: %d", entry);
 
     otEXPECT_ACTION(entry >= 0 && entry < RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM,
-                    error = kThreadError_NoAddress);
+                    error = OT_ERROR_NO_ADDRESS);
 
     removeFromSrcMatchShortIndirect(entry);
 
@@ -568,9 +568,9 @@ exit:
     return error;
 }
 
-ThreadError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
+otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     int8_t entry = -1;
     (void)aInstance;
 
@@ -581,7 +581,7 @@ ThreadError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_
     otLogDebgPlat(sInstance, "Clear ExtAddr entry: %d", entry);
 
     otEXPECT_ACTION(entry >= 0 && entry < RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM,
-                    error = kThreadError_NoAddress);
+                    error = OT_ERROR_NO_ADDRESS);
 
     removeFromSrcMatchExtIndirect(entry);
 
@@ -627,12 +627,12 @@ void RAILCb_IEEE802154_DataRequestCommand(RAIL_IEEE802154_Address_t *aAddress)
     }
 }
 
-ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration)
+otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration)
 {
     (void)aInstance;
     (void)aScanChannel;
     (void)aScanDuration;
-    return kThreadError_NotImplemented;
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
 void RAILCb_TxRadioStatus(uint8_t aStatus)
@@ -640,12 +640,12 @@ void RAILCb_TxRadioStatus(uint8_t aStatus)
     switch (aStatus)
     {
     case RAIL_TX_CONFIG_CHANNEL_BUSY:
-        sTransmitError = kThreadError_ChannelAccessFailure;
+        sTransmitError = OT_ERROR_CHANNEL_ACCESS_FAILURE;
         sTransmitBusy = false;
         break;
 
     case RAIL_TX_CONFIG_TX_ABORTED:
-        sTransmitError = kThreadError_Abort;
+        sTransmitError = OT_ERROR_ABORT;
         sTransmitBusy = false;
         break;
 
@@ -657,7 +657,7 @@ void RAILCb_TxRadioStatus(uint8_t aStatus)
 void RAILCb_TxPacketSent(RAIL_TxPacketInfo_t *aTxPacketInfo)
 {
     (void)aTxPacketInfo;
-    sTransmitError = kThreadError_None;
+    sTransmitError = OT_ERROR_NONE;
     sTransmitBusy = false;
 }
 
@@ -685,7 +685,7 @@ void RAILCb_RxPacketReceived(void *aRxPacketHandle)
     sReceiveFrame.mPower = rxPacketInfo->appendedInfo.rssiLatch;
     sReceiveFrame.mLqi = rxPacketInfo->appendedInfo.lqi;
     sReceiveFrame.mLength = length;
-    sReceiveError = kThreadError_None;
+    sReceiveError = OT_ERROR_NONE;
 
 exit:
     return;
@@ -722,9 +722,9 @@ void efr32RadioProcess(otInstance *aInstance)
 
     if (sState == kStateTransmit && sTransmitBusy == false)
     {
-        if (sTransmitError != kThreadError_None || (sTransmitFrame.mPsdu[0] & IEEE802154_ACK_REQUEST) == 0)
+        if (sTransmitError != OT_ERROR_NONE || (sTransmitFrame.mPsdu[0] & IEEE802154_ACK_REQUEST) == 0)
         {
-            if (sTransmitError != kThreadError_None)
+            if (sTransmitError != OT_ERROR_NONE)
             {
                 otLogDebgPlat(sInstance, "Transmit failed ErrorCode=%d", sTransmitError);
             }

--- a/examples/platforms/efr32/random.c
+++ b/examples/platforms/efr32/random.c
@@ -91,11 +91,11 @@ uint32_t otPlatRandomGet(void)
     return random;
 }
 
-ThreadError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
+otError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    otEXPECT_ACTION(aOutput, error = kThreadError_InvalidArgs);
+    otEXPECT_ACTION(aOutput, error = OT_ERROR_INVALID_ARGS);
 
     for (uint16_t length = 0; length < aOutputLength; length++)
     {

--- a/examples/platforms/efr32/uart.c
+++ b/examples/platforms/efr32/uart.c
@@ -69,7 +69,7 @@ typedef struct RecvBuffer
 
 static RecvBuffer     sReceive;
 
-ThreadError otPlatUartEnable(void)
+otError otPlatUartEnable(void)
 {
     USART_TypeDef           *usart = USART0;
     USART_InitAsync_TypeDef init   = USART_INITASYNC_DEFAULT;
@@ -114,7 +114,7 @@ ThreadError otPlatUartEnable(void)
     /* Finally enable it */
     USART_Enable(usart, usartEnable);
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 void USART0_RX_IRQHandler(void)
@@ -132,16 +132,16 @@ void USART0_RX_IRQHandler(void)
     }
 }
 
-ThreadError otPlatUartDisable(void)
+otError otPlatUartDisable(void)
 {
-    return kThreadError_NotImplemented;
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-ThreadError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
+otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    otEXPECT_ACTION(sTransmitBuffer == NULL, error = kThreadError_Busy);
+    otEXPECT_ACTION(sTransmitBuffer == NULL, error = OT_ERROR_BUSY);
 
     sTransmitBuffer = aBuf;
     sTransmitLength = aBufLength;

--- a/examples/platforms/emsk/flash.c
+++ b/examples/platforms/emsk/flash.c
@@ -74,10 +74,10 @@
 #endif // SETTINGS_CONFIG_PAGE_NUM
 #define SETTINGS_CONFIG_PAGE_NUM    1
 
-ThreadError utilsFlashInit(void)
+otError utilsFlashInit(void)
 {
     flash_init();
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 uint32_t utilsFlashGetSize(void)
@@ -85,26 +85,26 @@ uint32_t utilsFlashGetSize(void)
     return (uint32_t)FLASH_SECTOR_SIZE;
 }
 
-ThreadError utilsFlashErasePage(uint32_t aAddress)
+otError utilsFlashErasePage(uint32_t aAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     int32_t status;
 
     otEXPECT_ACTION((aAddress >= OPENTHREAD_FLASH_BASE) && (aAddress < (OPENTHREAD_FLASH_BASE + OPENTHREAD_FLASH_SIZE - 1)),
-                    error = kThreadError_InvalidArgs);
+                    error = OT_ERROR_INVALID_ARGS);
 
     /* Use 2 sectors in the implementation, cannot erase the address over the boundry */
     status = flash_erase(aAddress, FLASH_SECTOR_SIZE);
 
-    otEXPECT_ACTION(status != -1, error = kThreadError_Failed);
+    otEXPECT_ACTION(status != -1, error = OT_ERROR_FAILED);
 
 exit:
     return error;
 }
 
-ThreadError utilsFlashStatusWait(uint32_t aTimeout)
+otError utilsFlashStatusWait(uint32_t aTimeout)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint32_t start = otPlatAlarmGetNow();
     bool busy = true;
     uint32_t status = 0x01;
@@ -115,7 +115,7 @@ ThreadError utilsFlashStatusWait(uint32_t aTimeout)
         busy =  status & 0x01;
     }
 
-    otEXPECT_ACTION(!busy, error = kThreadError_Busy);
+    otEXPECT_ACTION(!busy, error = OT_ERROR_BUSY);
 
 exit:
     return error;

--- a/examples/platforms/emsk/radio.c
+++ b/examples/platforms/emsk/radio.c
@@ -103,8 +103,8 @@ static RadioPacket sTransmitFrame;
 static RadioPacket sReceiveFrame;
 static RadioPacket sAckFrame;
 
-static ThreadError sTransmitError;
-static ThreadError sReceiveError;
+static otError sTransmitError;
+static otError sReceiveError;
 
 static uint8_t sTransmitPsdu[IEEE802154_MAX_LENGTH];
 static uint8_t sReceivePsdu[IEEE802154_MAX_LENGTH];
@@ -326,34 +326,34 @@ bool otPlatRadioIsEnabled(otInstance *aInstance)
     return (sState != kStateDisabled);
 }
 
-ThreadError otPlatRadioEnable(otInstance *aInstance)
+otError otPlatRadioEnable(otInstance *aInstance)
 {
     if (!otPlatRadioIsEnabled(aInstance))
     {
         sState = kStateSleep;
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatRadioDisable(otInstance *aInstance)
+otError otPlatRadioDisable(otInstance *aInstance)
 {
     if (otPlatRadioIsEnabled(aInstance))
     {
         sState = kStateDisabled;
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatRadioSleep(otInstance *aInstance)
+otError otPlatRadioSleep(otInstance *aInstance)
 {
-    ThreadError error = kThreadError_InvalidState;
+    otError error = OT_ERROR_INVALID_STATE;
     (void)aInstance;
 
     if (sState == kStateSleep || sState == kStateReceive)
     {
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
         sState = kStateSleep;
         disableReceiver();
     }
@@ -361,14 +361,14 @@ ThreadError otPlatRadioSleep(otInstance *aInstance)
     return error;
 }
 
-ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
+otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 {
-    ThreadError error = kThreadError_InvalidState;
+    otError error = OT_ERROR_INVALID_STATE;
     (void)aInstance;
 
     if (sState != kStateDisabled)
     {
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
         sState = kStateReceive;
         setChannel(aChannel);
         sReceiveFrame.mChannel = aChannel;
@@ -378,15 +378,15 @@ ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
     return error;
 }
 
-ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
+otError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
 {
-    ThreadError error = kThreadError_InvalidState;
+    otError error = OT_ERROR_INVALID_STATE;
     (void)aInstance;
     (void)aPacket;
 
     if (sState == kStateReceive)
     {
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
         sState = kStateTransmit;
     }
 
@@ -476,7 +476,7 @@ void radioTransmitMessage(otInstance *aInstance)
     (void)aInstance;
     uint8_t header_len = 0;
 
-    sTransmitError = kThreadError_None;
+    sTransmitError = OT_ERROR_NONE;
     setChannel(sTransmitFrame.mChannel);
 
     uint8_t reg = mrf24j40_read_short_ctrl_reg(MRF24J40_TXNCON);
@@ -547,7 +547,7 @@ void emskRadioProcess(otInstance *aInstance)
     {
         radioTransmitMessage(aInstance);
 
-        if (sTransmitError != kThreadError_None || (sTransmitFrame.mPsdu[0] & IEEE802154_ACK_REQUEST) == 0)
+        if (sTransmitError != OT_ERROR_NONE || (sTransmitFrame.mPsdu[0] & IEEE802154_ACK_REQUEST) == 0)
         {
             sState = kStateReceive;
             otPlatRadioTransmitDone(aInstance, &sTransmitFrame, false, sTransmitError);
@@ -620,32 +620,32 @@ void otPlatRadioEnableSrcMatch(otInstance *aInstance, bool aEnable)
     (void)aEnable;
 }
 
-ThreadError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
+otError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
 {
     (void)aInstance;
     (void)aShortAddress;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
+otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
 {
     (void)aInstance;
     (void)aExtAddress;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
+otError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
 {
     (void)aInstance;
     (void)aShortAddress;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
+otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
 {
     (void)aInstance;
     (void)aExtAddress;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 void otPlatRadioClearSrcMatchShortEntries(otInstance *aInstance)
@@ -658,12 +658,12 @@ void otPlatRadioClearSrcMatchExtEntries(otInstance *aInstance)
     (void)aInstance;
 }
 
-ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration)
+otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration)
 {
     (void)aInstance;
     (void)aScanChannel;
     (void)aScanDuration;
-    return kThreadError_NotImplemented;
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
 void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)

--- a/examples/platforms/emsk/random.c
+++ b/examples/platforms/emsk/random.c
@@ -64,12 +64,12 @@ uint32_t otPlatRandomGet(void)
     return (uint32_t)rand();
 }
 
-ThreadError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
+otError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t channel = 0;
 
-    otEXPECT_ACTION(aOutput && aOutputLength, error = kThreadError_InvalidArgs);
+    otEXPECT_ACTION(aOutput && aOutputLength, error = OT_ERROR_INVALID_ARGS);
 
     /* disable radio*/
     if (otPlatRadioIsEnabled(sInstance))
@@ -85,7 +85,7 @@ ThreadError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
      * Please see Note in `<path-to-openthread>/examples/platforms/emsk/README.md`
      * for TRNG features on EMSK.
      */
-    otEXPECT_ACTION(aOutput && aOutputLength, error = kThreadError_InvalidArgs);
+    otEXPECT_ACTION(aOutput && aOutputLength, error = OT_ERROR_INVALID_ARGS);
 
     for (uint16_t length = 0; length < aOutputLength; length++)
     {

--- a/examples/platforms/emsk/uart.c
+++ b/examples/platforms/emsk/uart.c
@@ -60,10 +60,10 @@ static uint16_t sReceiveHead = 0;
 
 static DEV_UART *consoleUart;
 
-ThreadError otPlatUartEnable(void)
+otError otPlatUartEnable(void)
 {
     int32_t stateUart = 0;
-    ThreadError error = kThreadError_Drop;
+    otError error = OT_ERROR_DROP;
 
     /* UART in embARC */
     consoleUart = uart_get_dev(BOARD_CONSOLE_UART_ID);
@@ -75,12 +75,12 @@ ThreadError otPlatUartEnable(void)
     if (stateUart == E_OPNED)
     {
         consoleUart->uart_control(UART_CMD_SET_BAUD, (void *)(BOARD_CONSOLE_UART_BAUD));
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
         DBG("Set Console UART Baudrate to %d.\r\n", BOARD_CONSOLE_UART_BAUD);
     }
     else if (stateUart == E_OK)
     {
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
         DBG("Open Console UART Successfully.\r\n");
     }
     else
@@ -94,16 +94,16 @@ exit:
 
 }
 
-ThreadError otPlatUartDisable(void)
+otError otPlatUartDisable(void)
 {
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
+otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    otEXPECT_ACTION(sTransmitBuffer == NULL, error = kThreadError_Busy);
+    otEXPECT_ACTION(sTransmitBuffer == NULL, error = OT_ERROR_BUSY);
 
     sTransmitBuffer = aBuf;
     sTransmitLength = aBufLength;

--- a/examples/platforms/kw41z/diag.c
+++ b/examples/platforms/kw41z/diag.c
@@ -75,7 +75,7 @@ void otPlatDiagTxPowerSet(int8_t aTxPower)
     (void) aTxPower;
 }
 
-void otPlatDiagRadioReceived(otInstance *aInstance, RadioPacket *aFrame, ThreadError aError)
+void otPlatDiagRadioReceived(otInstance *aInstance, RadioPacket *aFrame, otError aError)
 {
     (void) aInstance;
     (void) aFrame;

--- a/examples/platforms/kw41z/flash.c
+++ b/examples/platforms/kw41z/flash.c
@@ -35,13 +35,13 @@
 
 static flash_config_t sFlashConfig;
 
-ThreadError utilsFlashInit(void)
+otError utilsFlashInit(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (FLASH_Init(&sFlashConfig) != kStatus_FLASH_Success)
     {
-        error = kThreadError_Failed;
+        error = OT_ERROR_FAILED;
     }
 
     return error;
@@ -52,39 +52,39 @@ uint32_t utilsFlashGetSize(void)
     return FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE;
 }
 
-ThreadError utilsFlashErasePage(uint32_t aAddress)
+otError utilsFlashErasePage(uint32_t aAddress)
 {
-    ThreadError error;
+    otError error;
     status_t status;
 
     status = FLASH_Erase(&sFlashConfig, aAddress, FSL_FEATURE_FLASH_PFLASH_BLOCK_SECTOR_SIZE, kFLASH_ApiEraseKey);
 
     if (status == kStatus_FLASH_Success)
     {
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
     }
     else if (status == kStatus_FLASH_AlignmentError)
     {
-        error = kThreadError_InvalidArgs;
+        error = OT_ERROR_INVALID_ARGS;
     }
     else
     {
-        error = kThreadError_Failed;
+        error = OT_ERROR_FAILED;
     }
 
     return error;
 }
 
-ThreadError utilsFlashStatusWait(uint32_t aTimeout)
+otError utilsFlashStatusWait(uint32_t aTimeout)
 {
-    ThreadError error = kThreadError_Busy;
+    otError error = OT_ERROR_BUSY;
     uint32_t start = otPlatAlarmGetNow();
 
     do
     {
         if (FTFA->FSTAT & FTFA_FSTAT_CCIF_MASK)
         {
-            error = kThreadError_None;
+            error = OT_ERROR_NONE;
             break;
         }
     }

--- a/examples/platforms/kw41z/random.c
+++ b/examples/platforms/kw41z/random.c
@@ -66,13 +66,13 @@ uint32_t otPlatRandomGet(void)
     return (uint32_t)rand();
 }
 
-ThreadError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
+otError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
 {
-    ThreadError status = kThreadError_None;
+    otError status = OT_ERROR_NONE;
 
-    otEXPECT_ACTION((aOutput != NULL), status = kThreadError_InvalidArgs);
+    otEXPECT_ACTION((aOutput != NULL), status = OT_ERROR_INVALID_ARGS);
 
-    otEXPECT_ACTION(TRNG_GetRandomData(TRNG0, aOutput, aOutputLength) == kStatus_Success, status = kThreadError_Failed);
+    otEXPECT_ACTION(TRNG_GetRandomData(TRNG0, aOutput, aOutputLength) == kStatus_Success, status = OT_ERROR_FAILED);
 
 exit:
     return status;

--- a/examples/platforms/kw41z/uart.c
+++ b/examples/platforms/kw41z/uart.c
@@ -71,7 +71,7 @@ typedef struct RecvBuffer
 
 static RecvBuffer sReceive;
 
-ThreadError otPlatUartEnable(void)
+otError otPlatUartEnable(void)
 {
     lpuart_config_t config;
 
@@ -96,20 +96,20 @@ ThreadError otPlatUartEnable(void)
     NVIC_ClearPendingIRQ(LPUART0_IRQn);
     NVIC_EnableIRQ(LPUART0_IRQn);
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatUartDisable(void)
+otError otPlatUartDisable(void)
 {
     NVIC_DisableIRQ(LPUART0_IRQn);
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
+otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    otEXPECT_ACTION(sTransmitBuffer == NULL, error = kThreadError_Busy);
+    otEXPECT_ACTION(sTransmitBuffer == NULL, error = OT_ERROR_BUSY);
 
     sTransmitBuffer = aBuf + 1;
     sTransmitLength = aBufLength - 1;

--- a/examples/platforms/nrf52840/diag.c
+++ b/examples/platforms/nrf52840/diag.c
@@ -68,16 +68,16 @@ static int32_t sTxRequestedCount = 1;
 static int16_t sID = -1;
 static struct PlatformDiagMessage sDiagMessage = {.mMessageDescriptor = "DiagMessage", .mChannel = 0, .mID = 0, .mCnt = 0};
 
-static ThreadError parseLong(char *argv, long *aValue)
+static otError parseLong(char *argv, long *aValue)
 {
     char *endptr;
     *aValue = strtol(argv, &endptr, 0);
-    return (*endptr == '\0') ? kThreadError_None : kThreadError_Parse;
+    return (*endptr == '\0') ? OT_ERROR_NONE : OT_ERROR_PARSE;
 }
 
-static void appendErrorResult(ThreadError aError, char *aOutput, size_t aOutputMaxLen)
+static void appendErrorResult(otError aError, char *aOutput, size_t aOutputMaxLen)
 {
-    if (aError != kThreadError_None)
+    if (aError != OT_ERROR_NONE)
     {
         snprintf(aOutput, aOutputMaxLen, "failed\r\nstatus %#x\r\n", aError);
     }
@@ -86,9 +86,9 @@ static void appendErrorResult(ThreadError aError, char *aOutput, size_t aOutputM
 static void processListen(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
     (void) aInstance;
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    otEXPECT_ACTION(otPlatDiagModeGet(), error = kThreadError_InvalidState);
+    otEXPECT_ACTION(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
 
     if (argc == 0)
     {
@@ -99,7 +99,7 @@ static void processListen(otInstance *aInstance, int argc, char *argv[], char *a
         long value;
 
         error = parseLong(argv[0], &value);
-        otEXPECT(error == kThreadError_None);
+        otEXPECT(error == OT_ERROR_NONE);
         sListen = (bool)(value);
         snprintf(aOutput, aOutputMaxLen, "set listen to %s\r\nstatus 0x%02x\r\n", sListen == true ? "yes" : "no", error);
     }
@@ -112,9 +112,9 @@ static void processID(otInstance *aInstance, int argc, char *argv[], char *aOutp
 {
     (void) aInstance;
 
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    otEXPECT_ACTION(otPlatDiagModeGet(), error = kThreadError_InvalidState);
+    otEXPECT_ACTION(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
 
     if (argc == 0)
     {
@@ -125,8 +125,8 @@ static void processID(otInstance *aInstance, int argc, char *argv[], char *aOutp
         long value;
 
         error = parseLong(argv[0], &value);
-        otEXPECT(error == kThreadError_None);
-        otEXPECT_ACTION(value >= 0, error = kThreadError_InvalidArgs);
+        otEXPECT(error == OT_ERROR_NONE);
+        otEXPECT_ACTION(value >= 0, error = OT_ERROR_INVALID_ARGS);
         sID = (int16_t)(value);
         snprintf(aOutput, aOutputMaxLen, "set ID to %" PRId16 "\r\nstatus 0x%02x\r\n", sID, error);
     }
@@ -138,9 +138,9 @@ exit:
 static void processTransmit(otInstance *aInstance, int argc, char *argv[], char *aOutput,
                             size_t aOutputMaxLen)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    otEXPECT_ACTION(otPlatDiagModeGet(), error = kThreadError_InvalidState);
+    otEXPECT_ACTION(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
 
     if (argc == 0)
     {
@@ -169,11 +169,11 @@ static void processTransmit(otInstance *aInstance, int argc, char *argv[], char 
     {
         long value;
 
-        otEXPECT_ACTION(argc == 2, error = kThreadError_InvalidArgs);
+        otEXPECT_ACTION(argc == 2, error = OT_ERROR_INVALID_ARGS);
 
         error = parseLong(argv[1], &value);
-        otEXPECT(error == kThreadError_None);
-        otEXPECT_ACTION(value > 0, error = kThreadError_InvalidArgs);
+        otEXPECT(error == OT_ERROR_NONE);
+        otEXPECT_ACTION(value > 0, error = OT_ERROR_INVALID_ARGS);
         sTxPeriod = (uint32_t)(value);
         snprintf(aOutput, aOutputMaxLen, "set diagnostic messages interval to %" PRIu32 " ms\r\nstatus 0x%02x\r\n", sTxPeriod,
                  error);
@@ -182,11 +182,11 @@ static void processTransmit(otInstance *aInstance, int argc, char *argv[], char 
     {
         long value;
 
-        otEXPECT_ACTION(argc == 2, error = kThreadError_InvalidArgs);
+        otEXPECT_ACTION(argc == 2, error = OT_ERROR_INVALID_ARGS);
 
         error = parseLong(argv[1], &value);
-        otEXPECT(error == kThreadError_None);
-        otEXPECT_ACTION((value > 0) || (value == -1), error = kThreadError_InvalidArgs);
+        otEXPECT(error == OT_ERROR_NONE);
+        otEXPECT_ACTION((value > 0) || (value == -1), error = OT_ERROR_INVALID_ARGS);
         sTxRequestedCount = (uint32_t)(value);
         snprintf(aOutput, aOutputMaxLen, "set diagnostic messages count to %" PRId32 "\r\nstatus 0x%02x\r\n", sTxRequestedCount,
                  error);
@@ -242,11 +242,11 @@ void otPlatDiagTxPowerSet(int8_t aTxPower)
     sTxPower = aTxPower;
 }
 
-void otPlatDiagRadioReceived(otInstance *aInstance, RadioPacket *aFrame, ThreadError aError)
+void otPlatDiagRadioReceived(otInstance *aInstance, RadioPacket *aFrame, otError aError)
 {
     (void) aInstance;
 
-    if (sListen && (aError == kThreadError_None))
+    if (sListen && (aError == OT_ERROR_NONE))
     {
         if (aFrame->mLength == sizeof(struct PlatformDiagMessage))
         {

--- a/examples/platforms/nrf52840/flash.c
+++ b/examples/platforms/nrf52840/flash.c
@@ -51,13 +51,13 @@ static inline uint32_t mapAddress(uint32_t aAddress)
     return aAddress + FLASH_START_ADDR;
 }
 
-ThreadError utilsFlashInit(void)
+otError utilsFlashInit(void)
 {
     // Just ensure that the start and end addresses are page-aligned.
     assert((FLASH_START_ADDR % FLASH_PAGE_SIZE) == 0);
     assert((FLASH_END_ADDR % FLASH_PAGE_SIZE) == 0);
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 uint32_t utilsFlashGetSize(void)
@@ -65,10 +65,10 @@ uint32_t utilsFlashGetSize(void)
     return FLASH_END_ADDR - FLASH_START_ADDR;
 }
 
-ThreadError utilsFlashErasePage(uint32_t aAddress)
+otError utilsFlashErasePage(uint32_t aAddress)
 {
-    ThreadError error = kThreadError_None;
-    otEXPECT_ACTION(aAddress < utilsFlashGetSize(), error = kThreadError_InvalidArgs);
+    otError error = OT_ERROR_NONE;
+    otEXPECT_ACTION(aAddress < utilsFlashGetSize(), error = OT_ERROR_INVALID_ARGS);
 
     nrf_nvmc_page_erase(mapAddress(aAddress & FLASH_PAGE_ADDR_MASK));
 
@@ -76,15 +76,15 @@ exit:
     return error;
 }
 
-ThreadError utilsFlashStatusWait(uint32_t aTimeout)
+otError utilsFlashStatusWait(uint32_t aTimeout)
 {
-    ThreadError error = kThreadError_Busy;
+    otError error = OT_ERROR_BUSY;
 
     if (aTimeout == 0)
     {
         if (NRF_NVMC->READY == NVMC_READY_READY_Ready)
         {
-            error = kThreadError_None;
+            error = OT_ERROR_NONE;
         }
     }
     else
@@ -95,7 +95,7 @@ ThreadError utilsFlashStatusWait(uint32_t aTimeout)
         {
             if (NRF_NVMC->READY == NVMC_READY_READY_Ready)
             {
-                error = kThreadError_None;
+                error = OT_ERROR_NONE;
                 break;
             }
         }

--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -236,39 +236,39 @@ PhyState otPlatRadioGetState(otInstance *aInstance)
     return kStateReceive; // It is the default state. Return it in case of unknown.
 }
 
-ThreadError otPlatRadioEnable(otInstance *aInstance)
+otError otPlatRadioEnable(otInstance *aInstance)
 {
     (void) aInstance;
 
-    ThreadError error;
+    otError error;
 
     if (sDisabled)
     {
         sDisabled = false;
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
     }
     else
     {
-        error = kThreadError_InvalidState;
+        error = OT_ERROR_INVALID_STATE;
     }
 
     return error;
 }
 
-ThreadError otPlatRadioDisable(otInstance *aInstance)
+otError otPlatRadioDisable(otInstance *aInstance)
 {
     (void) aInstance;
 
-    ThreadError error;
+    otError error;
 
     if (!sDisabled)
     {
         sDisabled = true;
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
     }
     else
     {
-        error = kThreadError_InvalidState;
+        error = OT_ERROR_INVALID_STATE;
     }
 
     return error;
@@ -281,7 +281,7 @@ bool otPlatRadioIsEnabled(otInstance *aInstance)
     return !sDisabled;
 }
 
-ThreadError otPlatRadioSleep(otInstance *aInstance)
+otError otPlatRadioSleep(otInstance *aInstance)
 {
     (void) aInstance;
 
@@ -295,20 +295,20 @@ ThreadError otPlatRadioSleep(otInstance *aInstance)
         setPendingEvent(kPendingEventSleep);
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
+otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 {
     (void) aInstance;
 
     nrf_drv_radio802154_receive(aChannel);
     clearPendingEvents();
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
+otError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
 {
     (void) aInstance;
 
@@ -324,7 +324,7 @@ ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
         setPendingEvent(kPendingEventChannelAccessFailure);
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 RadioPacket *otPlatRadioGetTransmitBuffer(otInstance *aInstance)
@@ -369,79 +369,79 @@ void otPlatRadioEnableSrcMatch(otInstance *aInstance, bool aEnable)
     nrf_drv_radio802154_auto_pending_bit_set(aEnable);
 }
 
-ThreadError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
+otError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
 {
     (void) aInstance;
 
-    ThreadError error;
+    otError error;
 
     uint8_t shortAddress[SHORT_ADDRESS_SIZE];
     convertShortAddress(shortAddress, aShortAddress);
 
     if (nrf_drv_radio802154_pending_bit_for_addr_set(shortAddress, false))
     {
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
     }
     else
     {
-        error = kThreadError_NoBufs;
+        error = OT_ERROR_NO_BUFS;
     }
 
     return error;
 }
 
-ThreadError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
+otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
 {
     (void) aInstance;
 
-    ThreadError error;
+    otError error;
 
     if (nrf_drv_radio802154_pending_bit_for_addr_set(aExtAddress, true))
     {
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
     }
     else
     {
-        error = kThreadError_NoBufs;
+        error = OT_ERROR_NO_BUFS;
     }
 
     return error;
 }
 
-ThreadError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
+otError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
 {
     (void) aInstance;
 
-    ThreadError error;
+    otError error;
 
     uint8_t shortAddress[SHORT_ADDRESS_SIZE];
     convertShortAddress(shortAddress, aShortAddress);
 
     if (nrf_drv_radio802154_pending_bit_for_addr_clear(shortAddress, false))
     {
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
     }
     else
     {
-        error = kThreadError_NoAddress;
+        error = OT_ERROR_NO_ADDRESS;
     }
 
     return error;
 }
 
-ThreadError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
+otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
 {
     (void) aInstance;
 
-    ThreadError error;
+    otError error;
 
     if (nrf_drv_radio802154_pending_bit_for_addr_clear(aExtAddress, true))
     {
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
     }
     else
     {
-        error = kThreadError_NoAddress;
+        error = OT_ERROR_NO_ADDRESS;
     }
 
     return error;
@@ -461,7 +461,7 @@ void otPlatRadioClearSrcMatchExtEntries(otInstance *aInstance)
     nrf_drv_radio802154_pending_bit_for_addr_reset(true);
 }
 
-ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration)
+otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration)
 {
     (void) aInstance;
 
@@ -479,7 +479,7 @@ ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, u
         setPendingEvent(kPendingEventEnergyDetectionStart);
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
@@ -499,12 +499,12 @@ void nrf5RadioProcess(otInstance *aInstance)
 
             if (otPlatDiagModeGet())
             {
-                otPlatDiagRadioReceiveDone(aInstance, &sReceivedFrames[i], kThreadError_None);
+                otPlatDiagRadioReceiveDone(aInstance, &sReceivedFrames[i], OT_ERROR_NONE);
             }
             else
 #endif
             {
-                otPlatRadioReceiveDone(aInstance, &sReceivedFrames[i], kThreadError_None);
+                otPlatRadioReceiveDone(aInstance, &sReceivedFrames[i], OT_ERROR_NONE);
             }
 
             uint8_t *bufferAddress = &sReceivedFrames[i].mPsdu[-1];
@@ -519,12 +519,12 @@ void nrf5RadioProcess(otInstance *aInstance)
 
         if (otPlatDiagModeGet())
         {
-            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, sTransmitPendingBit, kThreadError_None);
+            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, sTransmitPendingBit, OT_ERROR_NONE);
         }
         else
 #endif
         {
-            otPlatRadioTransmitDone(aInstance, &sTransmitFrame, sTransmitPendingBit, kThreadError_None);
+            otPlatRadioTransmitDone(aInstance, &sTransmitFrame, sTransmitPendingBit, OT_ERROR_NONE);
         }
 
         resetPendingEvent(kPendingEventFrameTransmitted);
@@ -536,12 +536,12 @@ void nrf5RadioProcess(otInstance *aInstance)
 
         if (otPlatDiagModeGet())
         {
-            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, false, kThreadError_ChannelAccessFailure);
+            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, false, OT_ERROR_CHANNEL_ACCESS_FAILURE);
         }
         else
 #endif
         {
-            otPlatRadioTransmitDone(aInstance, &sTransmitFrame, false, kThreadError_ChannelAccessFailure);
+            otPlatRadioTransmitDone(aInstance, &sTransmitFrame, false, OT_ERROR_CHANNEL_ACCESS_FAILURE);
         }
 
         resetPendingEvent(kPendingEventChannelAccessFailure);

--- a/examples/platforms/nrf52840/random.c
+++ b/examples/platforms/nrf52840/random.c
@@ -150,12 +150,12 @@ uint32_t otPlatRandomGet(void)
     return (uint32_t)rand();
 }
 
-ThreadError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
+otError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    otEXPECT_ACTION(aOutput, error = kThreadError_InvalidArgs);
-    otEXPECT_ACTION(!bufferIsEmpty(), error = kThreadError_Failed);
+    otEXPECT_ACTION(aOutput, error = OT_ERROR_INVALID_ARGS);
+    otEXPECT_ACTION(!bufferIsEmpty(), error = OT_ERROR_FAILED);
 
     uint16_t copyLength = (uint16_t)bufferCount();
 

--- a/examples/platforms/nrf52840/uart.c
+++ b/examples/platforms/nrf52840/uart.c
@@ -191,7 +191,7 @@ void nrf5UartDeinit(void)
     nrf_uart_int_disable(UART_INSTANCE, NRF_UART_INT_MASK_RXDRDY | NRF_UART_INT_MASK_ERROR);
 }
 
-ThreadError otPlatUartEnable(void)
+otError otPlatUartEnable(void)
 {
     // Start HFCLK
     nrf_drv_clock_hfclk_request(NULL);
@@ -202,10 +202,10 @@ ThreadError otPlatUartEnable(void)
     nrf_uart_enable(UART_INSTANCE);
     nrf_uart_task_trigger(UART_INSTANCE, NRF_UART_TASK_STARTRX);
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatUartDisable(void)
+otError otPlatUartDisable(void)
 {
     // Disable UART instance.
     nrf_uart_disable(UART_INSTANCE);
@@ -213,14 +213,14 @@ ThreadError otPlatUartDisable(void)
     // Release HF clock.
     nrf_drv_clock_hfclk_release();
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
+otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    otEXPECT_ACTION(sTransmitBuffer == NULL, error = kThreadError_Busy);
+    otEXPECT_ACTION(sTransmitBuffer == NULL, error = OT_ERROR_BUSY);
 
     // Set up transmit buffer and its size without counting first triggered byte.
     sTransmitBuffer = aBuf;

--- a/examples/platforms/posix/diag.c
+++ b/examples/platforms/posix/diag.c
@@ -72,7 +72,7 @@ void otPlatDiagTxPowerSet(int8_t aTxPower)
     (void) aTxPower;
 }
 
-void otPlatDiagRadioReceived(otInstance *aInstance, RadioPacket *aFrame, ThreadError aError)
+void otPlatDiagRadioReceived(otInstance *aInstance, RadioPacket *aFrame, otError aError)
 {
     (void) aInstance;
     (void) aFrame;

--- a/examples/platforms/posix/flash-windows-stubs.c
+++ b/examples/platforms/posix/flash-windows-stubs.c
@@ -28,9 +28,9 @@
 
 #include "platform-posix.h"
 
-ThreadError utilsFlashInit(void)
+otError utilsFlashInit(void)
 {
-    return kThreadError_NotImplemented;
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
 uint32_t utilsFlashGetSize(void)
@@ -38,14 +38,14 @@ uint32_t utilsFlashGetSize(void)
     return 0;
 }
 
-ThreadError utilsFlashErasePage(uint32_t aAddress)
+otError utilsFlashErasePage(uint32_t aAddress)
 {
-    return kThreadError_NotImplemented;
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-ThreadError utilsFlashStatusWait(uint32_t aTimeout)
+otError utilsFlashStatusWait(uint32_t aTimeout)
 {
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 uint32_t utilsFlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize)

--- a/examples/platforms/posix/flash.c
+++ b/examples/platforms/posix/flash.c
@@ -50,9 +50,9 @@ enum
     FLASH_PAGE_NUM = 128,
 };
 
-ThreadError utilsFlashInit(void)
+otError utilsFlashInit(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     char fileName[20];
     struct stat st;
     bool create = false;
@@ -77,14 +77,14 @@ ThreadError utilsFlashInit(void)
     sFlashFd = open(fileName, O_RDWR | O_CREAT, 0666);
     lseek(sFlashFd, 0, SEEK_SET);
 
-    otEXPECT_ACTION(sFlashFd >= 0, error = kThreadError_Failed);
+    otEXPECT_ACTION(sFlashFd >= 0, error = OT_ERROR_FAILED);
 
     if (create)
     {
         for (uint16_t index = 0; index < FLASH_PAGE_NUM; index++)
         {
             error = utilsFlashErasePage(index * FLASH_PAGE_SIZE);
-            otEXPECT(error == kThreadError_None);
+            otEXPECT(error == OT_ERROR_NONE);
         }
     }
 
@@ -97,14 +97,14 @@ uint32_t utilsFlashGetSize(void)
     return FLASH_SIZE;
 }
 
-ThreadError utilsFlashErasePage(uint32_t aAddress)
+otError utilsFlashErasePage(uint32_t aAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint32_t address;
     uint8_t dummyPage[ FLASH_SIZE ];
 
-    otEXPECT_ACTION(sFlashFd >= 0, error = kThreadError_Failed);
-    otEXPECT_ACTION(aAddress < FLASH_SIZE, error = kThreadError_InvalidArgs);
+    otEXPECT_ACTION(sFlashFd >= 0, error = OT_ERROR_FAILED);
+    otEXPECT_ACTION(aAddress < FLASH_SIZE, error = OT_ERROR_INVALID_ARGS);
 
     // Get start address of the flash page that includes aAddress
     address = aAddress & (~(uint32_t)(FLASH_PAGE_SIZE - 1));
@@ -115,17 +115,17 @@ ThreadError utilsFlashErasePage(uint32_t aAddress)
     // Write the page
     ssize_t r;
     r =  pwrite(sFlashFd, &(dummyPage[0]), FLASH_PAGE_SIZE, address);
-    otEXPECT_ACTION(((int)r) == ((int)(FLASH_PAGE_SIZE)), error = kThreadError_Failed);
+    otEXPECT_ACTION(((int)r) == ((int)(FLASH_PAGE_SIZE)), error = OT_ERROR_FAILED);
 
 
 exit:
     return error;
 }
 
-ThreadError utilsFlashStatusWait(uint32_t aTimeout)
+otError utilsFlashStatusWait(uint32_t aTimeout)
 {
     (void)aTimeout;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 uint32_t utilsFlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize)

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -386,48 +386,48 @@ bool otPlatRadioIsEnabled(otInstance *aInstance)
     return (sState != kStateDisabled) ? true : false;
 }
 
-ThreadError otPlatRadioEnable(otInstance *aInstance)
+otError otPlatRadioEnable(otInstance *aInstance)
 {
     if (!otPlatRadioIsEnabled(aInstance))
     {
         sState = kStateSleep;
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatRadioDisable(otInstance *aInstance)
+otError otPlatRadioDisable(otInstance *aInstance)
 {
     if (otPlatRadioIsEnabled(aInstance))
     {
         sState = kStateDisabled;
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatRadioSleep(otInstance *aInstance)
+otError otPlatRadioSleep(otInstance *aInstance)
 {
-    ThreadError error = kThreadError_InvalidState;
+    otError error = OT_ERROR_INVALID_STATE;
     (void)aInstance;
 
     if (sState == kStateSleep || sState == kStateReceive)
     {
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
         sState = kStateSleep;
     }
 
     return error;
 }
 
-ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
+otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 {
-    ThreadError error = kThreadError_InvalidState;
+    otError error = OT_ERROR_INVALID_STATE;
     (void)aInstance;
 
     if (sState != kStateDisabled)
     {
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
         sState = kStateReceive;
         sAckWait = false;
         sReceiveFrame.mChannel = aChannel;
@@ -436,15 +436,15 @@ ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
     return error;
 }
 
-ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
+otError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
 {
-    ThreadError error = kThreadError_InvalidState;
+    otError error = OT_ERROR_INVALID_STATE;
     (void)aInstance;
     (void)aPacket;
 
     if (sState == kStateReceive)
     {
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
         sState = kStateTransmit;
     }
 
@@ -499,12 +499,12 @@ void radioReceive(otInstance *aInstance)
 
         if (otPlatDiagModeGet())
         {
-            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, isFramePending(sReceiveFrame.mPsdu), kThreadError_None);
+            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, isFramePending(sReceiveFrame.mPsdu), OT_ERROR_NONE);
         }
         else
 #endif
         {
-            otPlatRadioTransmitDone(aInstance, &sTransmitFrame, isFramePending(sReceiveFrame.mPsdu), kThreadError_None);
+            otPlatRadioTransmitDone(aInstance, &sTransmitFrame, isFramePending(sReceiveFrame.mPsdu), OT_ERROR_NONE);
         }
     }
     else if ((sState == kStateReceive || sState == kStateTransmit) &&
@@ -530,12 +530,12 @@ void radioSendMessage(otInstance *aInstance)
 
         if (otPlatDiagModeGet())
         {
-            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, false, kThreadError_None);
+            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, false, OT_ERROR_NONE);
         }
         else
 #endif
         {
-            otPlatRadioTransmitDone(aInstance, &sTransmitFrame, false, kThreadError_None);
+            otPlatRadioTransmitDone(aInstance, &sTransmitFrame, false, OT_ERROR_NONE);
         }
     }
 }
@@ -640,12 +640,12 @@ void radioSendAck(void)
 
 void radioProcessFrame(otInstance *aInstance)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otPanId dstpan;
     otShortAddress short_address;
     otExtAddress ext_address;
 
-    otEXPECT_ACTION(sPromiscuous == false, error = kThreadError_None);
+    otEXPECT_ACTION(sPromiscuous == false, error = OT_ERROR_NONE);
 
     switch (sReceiveFrame.mPsdu[1] & IEEE802154_DST_ADDR_MASK)
     {
@@ -657,7 +657,7 @@ void radioProcessFrame(otInstance *aInstance)
         short_address = getShortAddress(sReceiveFrame.mPsdu);
         otEXPECT_ACTION((dstpan == IEEE802154_BROADCAST || dstpan == sPanid) &&
                         (short_address == IEEE802154_BROADCAST || short_address == sShortAddress),
-                        error = kThreadError_Abort);
+                        error = OT_ERROR_ABORT);
         break;
 
     case IEEE802154_DST_ADDR_EXT:
@@ -665,11 +665,11 @@ void radioProcessFrame(otInstance *aInstance)
         getExtAddress(sReceiveFrame.mPsdu, &ext_address);
         otEXPECT_ACTION((dstpan == IEEE802154_BROADCAST || dstpan == sPanid) &&
                         memcmp(&ext_address, sExtendedAddress, sizeof(ext_address)) == 0,
-                        error = kThreadError_Abort);
+                        error = OT_ERROR_ABORT);
         break;
 
     default:
-        error = kThreadError_Abort;
+        error = OT_ERROR_ABORT;
         goto exit;
     }
 
@@ -688,12 +688,12 @@ exit:
 
     if (otPlatDiagModeGet())
     {
-        otPlatDiagRadioReceiveDone(aInstance, error == kThreadError_None ? &sReceiveFrame : NULL, error);
+        otPlatDiagRadioReceiveDone(aInstance, error == OT_ERROR_NONE ? &sReceiveFrame : NULL, error);
     }
     else
 #endif
     {
-        otPlatRadioReceiveDone(aInstance, error == kThreadError_None ? &sReceiveFrame : NULL, error);
+        otPlatRadioReceiveDone(aInstance, error == OT_ERROR_NONE ? &sReceiveFrame : NULL, error);
     }
 }
 
@@ -703,32 +703,32 @@ void otPlatRadioEnableSrcMatch(otInstance *aInstance, bool aEnable)
     (void)aEnable;
 }
 
-ThreadError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
+otError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
 {
     (void)aInstance;
     (void)aShortAddress;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
+otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
 {
     (void)aInstance;
     (void)aExtAddress;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
+otError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
 {
     (void)aInstance;
     (void)aShortAddress;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
+otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
 {
     (void)aInstance;
     (void)aExtAddress;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 void otPlatRadioClearSrcMatchShortEntries(otInstance *aInstance)
@@ -741,12 +741,12 @@ void otPlatRadioClearSrcMatchExtEntries(otInstance *aInstance)
     (void)aInstance;
 }
 
-ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration)
+otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration)
 {
     (void)aInstance;
     (void)aScanChannel;
     (void)aScanDuration;
-    return kThreadError_NotImplemented;
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
 void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)

--- a/examples/platforms/posix/random.c
+++ b/examples/platforms/posix/random.c
@@ -48,10 +48,10 @@ void platformRandomInit(void)
 {
 #if __SANITIZE_ADDRESS__ == 0
 
-    ThreadError error;
+    otError error;
 
     error = otPlatRandomGetTrue((uint8_t *)&sState, sizeof(sState));
-    assert(error == kThreadError_None);
+    assert(error == OT_ERROR_NONE);
 
 #else  // __SANITIZE_ADDRESS__
 
@@ -83,22 +83,22 @@ uint32_t otPlatRandomGet(void)
     return mlcg;
 }
 
-ThreadError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
+otError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
 #if __SANITIZE_ADDRESS__ == 0
 
     FILE *file = NULL;
     size_t readLength;
 
-    otEXPECT_ACTION(aOutput && aOutputLength, error = kThreadError_InvalidArgs);
+    otEXPECT_ACTION(aOutput && aOutputLength, error = OT_ERROR_INVALID_ARGS);
 
     file = fopen("/dev/urandom", "rb");
-    otEXPECT_ACTION(file != NULL, error = kThreadError_Failed);
+    otEXPECT_ACTION(file != NULL, error = OT_ERROR_FAILED);
 
     readLength = fread(aOutput, 1, aOutputLength, file);
-    otEXPECT_ACTION(readLength == aOutputLength, error = kThreadError_Failed);
+    otEXPECT_ACTION(readLength == aOutputLength, error = OT_ERROR_FAILED);
 
 exit:
 
@@ -117,7 +117,7 @@ exit:
      * implementation below is only used to enable continuous
      * integration checks with Address Sanitizer enabled.
      */
-    otEXPECT_ACTION(aOutput && aOutputLength, error = kThreadError_InvalidArgs);
+    otEXPECT_ACTION(aOutput && aOutputLength, error = OT_ERROR_INVALID_ARGS);
 
     for (uint16_t length = 0; length < aOutputLength; length++)
     {

--- a/examples/platforms/posix/spi-stubs.c
+++ b/examples/platforms/posix/spi-stubs.c
@@ -36,7 +36,7 @@
 
 // Spi-slave stubs
 
-ThreadError otPlatSpiSlaveEnable(otPlatSpiSlaveTransactionCompleteCallback aCallback, void *aContext)
+otError otPlatSpiSlaveEnable(otPlatSpiSlaveTransactionCompleteCallback aCallback, void *aContext)
 {
     (void)aCallback;
     (void)aContext;
@@ -44,14 +44,14 @@ ThreadError otPlatSpiSlaveEnable(otPlatSpiSlaveTransactionCompleteCallback aCall
     fprintf(stderr, "\nNo SPI support for posix platform.");
     exit(0);
 
-    return kThreadError_NotImplemented;
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
 void otPlatSpiSlaveDisable(void)
 {
 }
 
-ThreadError otPlatSpiSlavePrepareTransaction(uint8_t *aOutputBuf, uint16_t aOutputBufLen, uint8_t *aInputBuf,
+otError otPlatSpiSlavePrepareTransaction(uint8_t *aOutputBuf, uint16_t aOutputBufLen, uint8_t *aInputBuf,
                                              uint16_t aInputBufLen, bool aRequestTransactionFlag)
 {
     (void)aOutputBuf;
@@ -60,7 +60,7 @@ ThreadError otPlatSpiSlavePrepareTransaction(uint8_t *aOutputBuf, uint16_t aOutp
     (void)aInputBufLen;
     (void)aRequestTransactionFlag;
 
-    return kThreadError_NotImplemented;
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
 // Uart

--- a/examples/platforms/posix/uart-posix.c
+++ b/examples/platforms/posix/uart-posix.c
@@ -69,9 +69,9 @@ static void restore_stdout_termios(void)
     tcsetattr(s_out_fd, TCSAFLUSH, &original_stdout_termios);
 }
 
-ThreadError otPlatUartEnable(void)
+otError otPlatUartEnable(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     struct termios termios;
 
 #ifdef OPENTHREAD_TARGET_LINUX
@@ -103,7 +103,7 @@ ThreadError otPlatUartEnable(void)
     if (isatty(s_in_fd))
     {
         // get current configuration
-        otEXPECT_ACTION(tcgetattr(s_in_fd, &termios) == 0, perror("tcgetattr"); error = kThreadError_Error);
+        otEXPECT_ACTION(tcgetattr(s_in_fd, &termios) == 0, perror("tcgetattr"); error = OT_ERROR_GENERIC);
 
         // Set up the termios settings for raw mode. This turns
         // off input/output processing, line processing, and character processing.
@@ -119,16 +119,16 @@ ThreadError otPlatUartEnable(void)
         termios.c_cc[VTIME] = 0;
 
         // configure baud rate
-        otEXPECT_ACTION(cfsetispeed(&termios, B115200) == 0, perror("cfsetispeed"); error = kThreadError_Error);
+        otEXPECT_ACTION(cfsetispeed(&termios, B115200) == 0, perror("cfsetispeed"); error = OT_ERROR_GENERIC);
 
         // set configuration
-        otEXPECT_ACTION(tcsetattr(s_in_fd, TCSANOW, &termios) == 0, perror("tcsetattr"); error = kThreadError_Error);
+        otEXPECT_ACTION(tcsetattr(s_in_fd, TCSANOW, &termios) == 0, perror("tcsetattr"); error = OT_ERROR_GENERIC);
     }
 
     if (isatty(s_out_fd))
     {
         // get current configuration
-        otEXPECT_ACTION(tcgetattr(s_out_fd, &termios) == 0, perror("tcgetattr"); error = kThreadError_Error);
+        otEXPECT_ACTION(tcgetattr(s_out_fd, &termios) == 0, perror("tcgetattr"); error = OT_ERROR_GENERIC);
 
         // Set up the termios settings for raw mode. This turns
         // off input/output processing, line processing, and character processing.
@@ -141,10 +141,10 @@ ThreadError otPlatUartEnable(void)
         termios.c_cflag |= HUPCL | CREAD | CLOCAL;
 
         // configure baud rate
-        otEXPECT_ACTION(cfsetospeed(&termios, B115200) == 0, perror("cfsetospeed"); error = kThreadError_Error);
+        otEXPECT_ACTION(cfsetospeed(&termios, B115200) == 0, perror("cfsetospeed"); error = OT_ERROR_GENERIC);
 
         // set configuration
-        otEXPECT_ACTION(tcsetattr(s_out_fd, TCSANOW, &termios) == 0, perror("tcsetattr"); error = kThreadError_Error);
+        otEXPECT_ACTION(tcsetattr(s_out_fd, TCSANOW, &termios) == 0, perror("tcsetattr"); error = OT_ERROR_GENERIC);
     }
 
     return error;
@@ -155,9 +155,9 @@ exit:
     return error;
 }
 
-ThreadError otPlatUartDisable(void)
+otError otPlatUartDisable(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     close(s_in_fd);
     close(s_out_fd);
@@ -165,11 +165,11 @@ ThreadError otPlatUartDisable(void)
     return error;
 }
 
-ThreadError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
+otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    otEXPECT_ACTION(s_write_length == 0, error = kThreadError_Busy);
+    otEXPECT_ACTION(s_write_length == 0, error = OT_ERROR_BUSY);
 
     s_write_buffer = aBuf;
     s_write_length = aBufLength;

--- a/examples/platforms/posix/uart-windows.c
+++ b/examples/platforms/posix/uart-windows.c
@@ -74,16 +74,16 @@ windowsUartWorkerThread(
     return NO_ERROR;
 }
 
-ThreadError otPlatUartEnable(void)
+otError otPlatUartEnable(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     // Create the worker thread stop event
-    otEXPECT_ACTION((s_StopWorkerEvent = CreateEvent(NULL, TRUE, FALSE, NULL)) != NULL, error = kThreadError_Error);
+    otEXPECT_ACTION((s_StopWorkerEvent = CreateEvent(NULL, TRUE, FALSE, NULL)) != NULL, error = OT_ERROR_GENERIC);
 
     // Start the worker thread
     otEXPECT_ACTION((s_WorkerThread = CreateThread(NULL, 0, windowsUartWorkerThread, NULL, 0, NULL)) != NULL,
-		    error = kThreadError_Error);
+		    error = OT_ERROR_GENERIC);
 
     return error;
 
@@ -93,9 +93,9 @@ exit:
     return error;
 }
 
-ThreadError otPlatUartDisable(void)
+otError otPlatUartDisable(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     // Set the shutdown event
     SetEvent(s_StopWorkerEvent);
@@ -112,13 +112,13 @@ ThreadError otPlatUartDisable(void)
     return error;
 }
 
-ThreadError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
+otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     DWORD dwNumCharsWritten = 0;
     otEXPECT_ACTION(WriteConsoleA(GetStdHandle(STD_OUTPUT_HANDLE), aBuf, aBufLength, &dwNumCharsWritten, NULL),
-		    error = kThreadError_Error);
+		    error = OT_ERROR_GENERIC);
 
     otPlatUartSendDone();
 

--- a/examples/platforms/utils/flash.h
+++ b/examples/platforms/utils/flash.h
@@ -46,10 +46,10 @@ extern "C" {
 /**
  * Perform any initialization for flash driver.
  *
- * @retval ::kThreadError_None    Initialize flash driver success.
- * @retval ::kThreadError_Failed  Initialize flash driver fail.
+ * @retval ::OT_ERROR_NONE    Initialize flash driver success.
+ * @retval ::OT_ERROR_FAILED  Initialize flash driver fail.
  */
-ThreadError utilsFlashInit(void);
+otError utilsFlashInit(void);
 
 /**
  * Get the size of flash that can be read/write by the caller.
@@ -69,11 +69,11 @@ uint32_t utilsFlashGetSize(void);
  *
  * @param[in]  aAddress  The start address of the flash to erase.
  *
- * @retval kThreadError_None           Erase flash operation is started.
- * @retval kThreadError_Failed         Erase flash operation is not started.
- * @retval kThreadError_InvalidArgs    aAddress is out of range of flash or not aligend.
+ * @retval OT_ERROR_NONE           Erase flash operation is started.
+ * @retval OT_ERROR_FAILED         Erase flash operation is not started.
+ * @retval OT_ERROR_INVALID_ARGS    aAddress is out of range of flash or not aligend.
  */
-ThreadError utilsFlashErasePage(uint32_t aAddress);
+otError utilsFlashErasePage(uint32_t aAddress);
 
 /**
   * Check whether flash is ready or busy.
@@ -82,10 +82,10 @@ ThreadError utilsFlashErasePage(uint32_t aAddress);
   *                       zero indicates that it is a polling function, and returns current status of flash immediately.
   *                       non-zero indicates that it is blocking there until the operation is done and become ready, or timeout expires.
   *
-  * @retval kThreadError_None           Flash is ready for any operation.
-  * @retval kThreadError_Busy           Flash is busy.
+  * @retval OT_ERROR_NONE           Flash is ready for any operation.
+  * @retval OT_ERROR_BUSY           Flash is busy.
   */
-ThreadError utilsFlashStatusWait(uint32_t aTimeout);
+otError utilsFlashStatusWait(uint32_t aTimeout);
 
 /**
  * Write flash. The write operation only clears bits, but never set bits.

--- a/examples/platforms/utils/settings.cpp
+++ b/examples/platforms/utils/settings.cpp
@@ -216,10 +216,10 @@ exit:
     return settingsSize - sSettingsUsedSize;
 }
 
-static ThreadError addSetting(otInstance *aInstance, uint16_t aKey, bool aIndex0, const uint8_t *aValue,
-                              uint16_t aValueLength)
+static otError addSetting(otInstance *aInstance, uint16_t aKey, bool aIndex0, const uint8_t *aValue,
+                          uint16_t aValueLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     OT_TOOL_PACKED_BEGIN
     struct addSettingsBlock
     {
@@ -245,7 +245,7 @@ static ThreadError addSetting(otInstance *aInstance, uint16_t aKey, bool aIndex0
         settingsSize)
     {
         otEXPECT_ACTION(swapSettingsBlock(aInstance) >= (getAlignLength(addBlock.block.length) + sizeof(struct settingsBlock)),
-                        error = kThreadError_NoBufs);
+                        error = OT_ERROR_NO_BUFS);
     }
 
     utilsFlashWrite(sSettingsBaseAddress + sSettingsUsedSize,
@@ -320,27 +320,27 @@ void otPlatSettingsInit(otInstance *aInstance)
     }
 }
 
-ThreadError otPlatSettingsBeginChange(otInstance *aInstance)
+otError otPlatSettingsBeginChange(otInstance *aInstance)
 {
     (void)aInstance;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatSettingsCommitChange(otInstance *aInstance)
+otError otPlatSettingsCommitChange(otInstance *aInstance)
 {
     (void)aInstance;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatSettingsAbandonChange(otInstance *aInstance)
+otError otPlatSettingsAbandonChange(otInstance *aInstance)
 {
     (void)aInstance;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength)
+otError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength)
 {
-    ThreadError error = kThreadError_NotFound;
+    otError error = OT_ERROR_NOT_FOUND;
     uint32_t address = sSettingsBaseAddress + kSettingsFlagSize;
     uint16_t valueLength = 0;
     int index = 0;
@@ -379,7 +379,7 @@ ThreadError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, 
                     }
 
                     valueLength = block.length;
-                    error = kThreadError_None;
+                    error = OT_ERROR_NONE;
                 }
 
                 index++;
@@ -397,23 +397,23 @@ ThreadError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, 
     return error;
 }
 
-ThreadError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+otError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
 {
     return addSetting(aInstance, aKey, true, aValue, aValueLength);
 }
 
-ThreadError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+otError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
 {
     uint16_t length;
     bool index0;
 
-    index0 = (otPlatSettingsGet(aInstance, aKey, 0, NULL, &length) == kThreadError_NotFound ? true : false);
+    index0 = (otPlatSettingsGet(aInstance, aKey, 0, NULL, &length) == OT_ERROR_NOT_FOUND ? true : false);
     return addSetting(aInstance, aKey, index0, aValue, aValueLength);
 }
 
-ThreadError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
+otError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
 {
-    ThreadError error = kThreadError_NotFound;
+    otError error = OT_ERROR_NOT_FOUND;
     uint32_t address = sSettingsBaseAddress + kSettingsFlagSize;
     int index = 0;
 
@@ -436,7 +436,7 @@ ThreadError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aInde
             {
                 if (aIndex == index || aIndex == -1)
                 {
-                    error = kThreadError_None;
+                    error = OT_ERROR_NONE;
                     block.flag &= (~kBlockDeleteFlag);
                     utilsFlashWrite(address, reinterpret_cast<uint8_t *>(&block), sizeof(block));
                 }

--- a/include/openthread/border_agent_proxy.h
+++ b/include/openthread/border_agent_proxy.h
@@ -73,22 +73,22 @@ typedef void (*otBorderAgentProxyStreamHandler)(otMessage *aMessage, uint16_t aL
  * @param[in]  aHandler             A pointer to a function called to deliver packet to border agent.
  * @param[in]  aContext             A pointer to application-specific context.
  *
- * @retval kThreadError_None        Successfully started the border agent proxy.
- * @retval kThreadError_Already     Border agent proxy has been started before.
+ * @retval OT_ERROR_NONE        Successfully started the border agent proxy.
+ * @retval OT_ERROR_ALREADY     Border agent proxy has been started before.
  *
  */
-ThreadError otBorderAgentProxyStart(otInstance *aInstance, otBorderAgentProxyStreamHandler aHandler, void *aContext);
+otError otBorderAgentProxyStart(otInstance *aInstance, otBorderAgentProxyStreamHandler aHandler, void *aContext);
 
 /**
  * Stop the border agent proxy.
  *
  * @param[in]  aInstance            A pointer to an OpenThread instance.
  *
- * @retval kThreadError_None        Successfully stopped the border agent proxy.
- * @retval kThreadError_Already     Border agent proxy is already stopped.
+ * @retval OT_ERROR_NONE        Successfully stopped the border agent proxy.
+ * @retval OT_ERROR_ALREADY     Border agent proxy is already stopped.
  *
  */
-ThreadError otBorderAgentProxyStop(otInstance *aInstance);
+otError otBorderAgentProxyStop(otInstance *aInstance);
 
 /**
  * Send packet through border agent proxy.
@@ -98,14 +98,14 @@ ThreadError otBorderAgentProxyStop(otInstance *aInstance);
  * @param[in]  aLocator             Rloc of destination.
  * @param[in]  aPort                Port of destination.
  *
- * @retval kThreadError_None            Successfully send the message.
- * @retval kThreadError_InvalidState    Border agent proxy is not started.
+ * @retval OT_ERROR_NONE             Successfully send the message.
+ * @retval OT_ERROR_INVALID_STATE    Border agent proxy is not started.
  *
  * @warning No matter the call success or fail, the message is freed.
  *
  */
-ThreadError otBorderAgentProxySend(otInstance *aInstance, otMessage *aMessage,
-                                   uint16_t aLocator, uint16_t aPort);
+otError otBorderAgentProxySend(otInstance *aInstance, otMessage *aMessage,
+                               uint16_t aLocator, uint16_t aPort);
 
 /**
  * Get the border agent proxy status (enabled/disabled)

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -186,13 +186,13 @@ typedef struct otCoapHeader
  * @param[in]  aMessageInfo  A pointer to the message info for @p aMessage. NULL if no response was received.
  * @param[in]  aResult       A result of the CoAP transaction.
  *
- * @retval  kThreadError_None             A response was received successfully.
- * @retval  kThreadError_Abort            A CoAP transaction was reseted by peer.
- * @retval  kThreadError_ResponseTimeout  No response or acknowledgment received during timeout period.
+ * @retval  OT_ERROR_NONE              A response was received successfully.
+ * @retval  OT_ERROR_ABORT             A CoAP transaction was reseted by peer.
+ * @retval  OT_ERROR_RESPONSE_TIMEOUT  No response or acknowledgment received during timeout period.
  *
  */
 typedef void (*otCoapResponseHandler)(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                      const otMessageInfo *aMessageInfo, ThreadError aResult);
+                                      const otMessageInfo *aMessageInfo, otError aResult);
 
 /**
  * This function pointer is called when a CoAP request with a given Uri-Path is received.
@@ -254,12 +254,12 @@ void otCoapHeaderGenerateToken(otCoapHeader *aHeader, uint8_t aTokenLength);
  * @param[inout]  aHeader  A pointer to the CoAP header.
  * @param[in]     aOption  A pointer to the CoAP option.
  *
- * @retval kThreadError_None         Successfully appended the option.
- * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
- * @retval kThreadError_NoBufs       The option length exceeds the buffer size.
+ * @retval OT_ERROR_NONE          Successfully appended the option.
+ * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
+ * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
  *
  */
-ThreadError otCoapHeaderAppendOption(otCoapHeader *aHeader, const otCoapOption *aOption);
+otError otCoapHeaderAppendOption(otCoapHeader *aHeader, const otCoapOption *aOption);
 
 /**
  * This function appends an unsigned integer CoAP option as specified in
@@ -269,12 +269,12 @@ ThreadError otCoapHeaderAppendOption(otCoapHeader *aHeader, const otCoapOption *
  * @param[in]     aNumber  The CoAP Option number.
  * @param[in]     aValue   The CoAP Option unsigned integer value.
  *
- * @retval kThreadError_None         Successfully appended the option.
- * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
- * @retval kThreadError_NoBufs       The option length exceeds the buffer size.
+ * @retval OT_ERROR_NONE          Successfully appended the option.
+ * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
+ * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
  *
  */
-ThreadError otCoapHeaderAppendUintOption(otCoapHeader *aHeader, uint16_t aNumber, uint32_t aValue);
+otError otCoapHeaderAppendUintOption(otCoapHeader *aHeader, uint16_t aNumber, uint32_t aValue);
 
 /**
  * This function appends an Observe option.
@@ -282,11 +282,11 @@ ThreadError otCoapHeaderAppendUintOption(otCoapHeader *aHeader, uint16_t aNumber
  * @param[inout]  aHeader   A pointer to the CoAP header.
  * @param[in]     aObserve  Observe field value.
  *
- * @retval kThreadError_None         Successfully appended the option.
- * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
- * @retval kThreadError_NoBufs       The option length exceeds the buffer size.
+ * @retval OT_ERROR_NONE          Successfully appended the option.
+ * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
+ * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
  */
-ThreadError otCoapHeaderAppendObserveOption(otCoapHeader *aHeader, uint32_t aObserve);
+otError otCoapHeaderAppendObserveOption(otCoapHeader *aHeader, uint32_t aObserve);
 
 /**
  * This function appends an Uri-Path option.
@@ -294,12 +294,12 @@ ThreadError otCoapHeaderAppendObserveOption(otCoapHeader *aHeader, uint32_t aObs
  * @param[inout]  aHeader   A pointer to the CoAP header.
  * @param[in]     aUriPath  A pointer to a NULL-terminated string.
  *
- * @retval kThreadError_None         Successfully appended the option.
- * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
- * @retval kThreadError_NoBufs       The option length exceeds the buffer size.
+ * @retval OT_ERROR_NONE          Successfully appended the option.
+ * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
+ * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
  *
  */
-ThreadError otCoapHeaderAppendUriPathOptions(otCoapHeader *aHeader, const char *aUriPath);
+otError otCoapHeaderAppendUriPathOptions(otCoapHeader *aHeader, const char *aUriPath);
 
 /**
  * This function appends a Max-Age option.
@@ -307,11 +307,11 @@ ThreadError otCoapHeaderAppendUriPathOptions(otCoapHeader *aHeader, const char *
  * @param[inout]  aHeader   A pointer to the CoAP header.
  * @param[in]     aMaxAge   The Max-Age value.
  *
- * @retval kThreadError_None         Successfully appended the option.
- * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
- * @retval kThreadError_NoBufs       The option length exceeds the buffer size.
+ * @retval OT_ERROR_NONE          Successfully appended the option.
+ * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
+ * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
  */
-ThreadError otCoapHeaderAppendMaxAgeOption(otCoapHeader *aHeader, uint32_t aMaxAge);
+otError otCoapHeaderAppendMaxAgeOption(otCoapHeader *aHeader, uint32_t aMaxAge);
 
 /**
  * This function appends a single Uri-Query option.
@@ -319,19 +319,19 @@ ThreadError otCoapHeaderAppendMaxAgeOption(otCoapHeader *aHeader, uint32_t aMaxA
  * @param[inout]  aHeader   A pointer to the CoAP header.
  * @param[in]     aUriQuery A pointer to NULL-terminated string, which should contain a single key=value pair.
  *
- * @retval kThreadError_None         Successfully appended the option.
- * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
- * @retval kThreadError_NoBufs       The option length exceeds the buffer size.
+ * @retval OT_ERROR_NONE          Successfully appended the option.
+ * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
+ * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
  */
-ThreadError otCoapHeaderAppendUriQueryOption(otCoapHeader *aHeader, const char *aUriQuery);
+otError otCoapHeaderAppendUriQueryOption(otCoapHeader *aHeader, const char *aUriQuery);
 
 /**
  * This function adds Payload Marker indicating beginning of the payload to the CoAP header.
  *
  * @param[inout]  aHeader  A pointer to the CoAP header.
  *
- * @retval kThreadError_None    Payload Marker successfully added.
- * @retval kThreadError_NoBufs  Header Payload Marker exceeds the buffer size.
+ * @retval OT_ERROR_NONE     Payload Marker successfully added.
+ * @retval OT_ERROR_NO_BUFS  Header Payload Marker exceeds the buffer size.
  *
  */
 void otCoapHeaderSetPayloadMarker(otCoapHeader *aHeader);
@@ -438,12 +438,12 @@ otMessage *otCoapNewMessage(otInstance *aInstance, const otCoapHeader *aHeader);
  * @param[in]  aHandler      A function pointer that shall be called on response reception or timeout.
  * @param[in]  aContext      A pointer to arbitrary context information. May be NULL if not used.
  *
- * @retval kThreadError_None   Successfully sent CoAP message.
- * @retval kThreadError_NoBufs Failed to allocate retransmission data.
+ * @retval OT_ERROR_NONE    Successfully sent CoAP message.
+ * @retval OT_ERROR_NO_BUFS Failed to allocate retransmission data.
  *
  */
-ThreadError otCoapSendRequest(otInstance *aInstance, otMessage *aMessage, const otMessageInfo *aMessageInfo,
-                              otCoapResponseHandler aHandler, void *aContext);
+otError otCoapSendRequest(otInstance *aInstance, otMessage *aMessage, const otMessageInfo *aMessageInfo,
+                          otCoapResponseHandler aHandler, void *aContext);
 
 /**
  * This function starts the CoAP server.
@@ -451,20 +451,20 @@ ThreadError otCoapSendRequest(otInstance *aInstance, otMessage *aMessage, const 
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  * @param[in]  aPort      The local UDP port to bind to.
  *
- * @retval kThreadError_None  Successfully started the CoAP server.
+ * @retval OT_ERROR_NONE  Successfully started the CoAP server.
  *
  */
-ThreadError otCoapStart(otInstance *aInstance, uint16_t aPort);
+otError otCoapStart(otInstance *aInstance, uint16_t aPort);
 
 /**
  * This function stops the CoAP server.
  *
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  *
- * @retval kThreadError_None  Successfully stopped the CoAP server.
+ * @retval OT_ERROR_NONE  Successfully stopped the CoAP server.
  *
  */
-ThreadError otCoapStop(otInstance *aInstance);
+otError otCoapStop(otInstance *aInstance);
 
 /**
  * This function adds a resource to the CoAP server.
@@ -472,11 +472,11 @@ ThreadError otCoapStop(otInstance *aInstance);
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  * @param[in]  aResource  A pointer to the resource.
  *
- * @retval kThreadError_None     Successfully added @p aResource.
- * @retval kThreadError_Already  The @p aResource was already added.
+ * @retval OT_ERROR_NONE     Successfully added @p aResource.
+ * @retval OT_ERROR_ALREADY  The @p aResource was already added.
  *
  */
-ThreadError otCoapAddResource(otInstance *aInstance, otCoapResource *aResource);
+otError otCoapAddResource(otInstance *aInstance, otCoapResource *aResource);
 
 /**
  * This function removes a resource from the CoAP server.
@@ -503,11 +503,11 @@ void otCoapSetDefaultHandler(otInstance *aInstance, otCoapRequestHandler aHandle
  * @param[in]  aMessage      A pointer to the CoAP response to send.
  * @param[in]  aMessageInfo  A pointer to the message info associated with @p aMessage.
  *
- * @retval kThreadError_None    Successfully enqueued the CoAP response message.
- * @retval kThreadError_NoBufs  Insufficient buffers available to send the CoAP response.
+ * @retval OT_ERROR_NONE     Successfully enqueued the CoAP response message.
+ * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to send the CoAP response.
  *
  */
-ThreadError otCoapSendResponse(otInstance *aInstance, otMessage *aMessage, const otMessageInfo *aMessageInfo);
+otError otCoapSendResponse(otInstance *aInstance, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 #endif // OPENTHREAD_ENABLE_APPLICATION_COAP
 
 /**

--- a/include/openthread/commissioner.h
+++ b/include/openthread/commissioner.h
@@ -57,20 +57,20 @@ extern "C" {
  *
  * @param[in]  aInstance         A pointer to an OpenThread instance.
  *
- * @retval kThreadError_None     Successfully started the Commissioner role.
+ * @retval OT_ERROR_NONE     Successfully started the Commissioner role.
  *
  */
-OTAPI ThreadError OTCALL otCommissionerStart(otInstance *aInstance);
+OTAPI otError OTCALL otCommissionerStart(otInstance *aInstance);
 
 /**
  * This function disables the Thread Commissioner role.
  *
  * @param[in]  aInstance         A pointer to an OpenThread instance.
  *
- * @retval kThreadError_None     Successfully stopped the Commissioner role.
+ * @retval OT_ERROR_NONE     Successfully stopped the Commissioner role.
  *
  */
-OTAPI ThreadError OTCALL otCommissionerStop(otInstance *aInstance);
+OTAPI otError OTCALL otCommissionerStop(otInstance *aInstance);
 
 /**
  * This function adds a Joiner entry.
@@ -80,16 +80,16 @@ OTAPI ThreadError OTCALL otCommissionerStop(otInstance *aInstance);
  * @param[in]  aPSKd                 A pointer to the PSKd.
  * @param[in]  aTimeout              A time after which a Joiner is automatically removed, in seconds.
  *
- * @retval kThreadError_None         Successfully added the Joiner.
- * @retval kThreadError_NoBufs       No buffers available to add the Joiner.
- * @retval kThreadError_InvalidArgs  @p aExtAddress or @p aPSKd is invalid.
- * @retval kThreadError_InvalidState The commissioner is not active.
+ * @retval OT_ERROR_NONE          Successfully added the Joiner.
+ * @retval OT_ERROR_NO_BUFS       No buffers available to add the Joiner.
+ * @retval OT_ERROR_INVALID_ARGS  @p aExtAddress or @p aPSKd is invalid.
+ * @retval OT_ERROR_INVALID_STATE The commissioner is not active.
  *
  * @note Only use this after successfully started the Commissioner role by otCommissionerStart().
  *
  */
-OTAPI ThreadError OTCALL otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *aExtAddress,
-                                                 const char *aPSKd, uint32_t aTimeout);
+OTAPI otError OTCALL otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *aExtAddress,
+                                             const char *aPSKd, uint32_t aTimeout);
 
 /**
  * This function removes a Joiner entry.
@@ -97,15 +97,15 @@ OTAPI ThreadError OTCALL otCommissionerAddJoiner(otInstance *aInstance, const ot
  * @param[in]  aInstance             A pointer to an OpenThread instance.
  * @param[in]  aExtAddress           A pointer to the Joiner's extended address or NULL for any Joiner.
  *
- * @retval kThreadError_None         Successfully removed the Joiner.
- * @retval kThreadError_NotFound     The Joiner specified by @p aExtAddress was not found.
- * @retval kThreadError_InvalidArgs  @p aExtAddress is invalid.
- * @retval kThreadError_InvalidState The commissioner is not active.
+ * @retval OT_ERROR_NONE          Successfully removed the Joiner.
+ * @retval OT_ERROR_NOT_FOUND     The Joiner specified by @p aExtAddress was not found.
+ * @retval OT_ERROR_INVALID_ARGS  @p aExtAddress is invalid.
+ * @retval OT_ERROR_INVALID_STATE The commissioner is not active.
  *
  * @note Only use this after successfully started the Commissioner role by otCommissionerStart().
  *
  */
-OTAPI ThreadError OTCALL otCommissionerRemoveJoiner(otInstance *aInstance, const otExtAddress *aExtAddress);
+OTAPI otError OTCALL otCommissionerRemoveJoiner(otInstance *aInstance, const otExtAddress *aExtAddress);
 
 /**
  * This function sets the Provisioning URL.
@@ -113,11 +113,11 @@ OTAPI ThreadError OTCALL otCommissionerRemoveJoiner(otInstance *aInstance, const
  * @param[in]  aInstance             A pointer to an OpenThread instance.
  * @param[in]  aProvisioningUrl      A pointer to the Provisioning URL (may be NULL).
  *
- * @retval kThreadError_None         Successfully set the Provisioning URL.
- * @retval kThreadError_InvalidArgs  @p aProvisioningUrl is invalid.
+ * @retval OT_ERROR_NONE          Successfully set the Provisioning URL.
+ * @retval OT_ERROR_INVALID_ARGS  @p aProvisioningUrl is invalid.
  *
  */
-OTAPI ThreadError OTCALL otCommissionerSetProvisioningUrl(otInstance *aInstance, const char *aProvisioningUrl);
+OTAPI otError OTCALL otCommissionerSetProvisioningUrl(otInstance *aInstance, const char *aProvisioningUrl);
 
 /**
  * This function sends an Announce Begin message.
@@ -128,16 +128,16 @@ OTAPI ThreadError OTCALL otCommissionerSetProvisioningUrl(otInstance *aInstance,
  * @param[in]  aPeriod               The time between energy measurements (milliseconds).
  * @param[in]  aAddress              A pointer to the IPv6 destination.
  *
- * @retval kThreadError_None         Successfully enqueued the Announce Begin message.
- * @retval kThreadError_NoBufs       Insufficient buffers to generate an Announce Begin message.
- * @retval kThreadError_InvalidState The commissioner is not active.
+ * @retval OT_ERROR_NONE          Successfully enqueued the Announce Begin message.
+ * @retval OT_ERROR_NO_BUFS       Insufficient buffers to generate an Announce Begin message.
+ * @retval OT_ERROR_INVALID_STATE The commissioner is not active.
  *
  * @note Only use this after successfully started the Commissioner role by otCommissionerStart().
  *
  */
-OTAPI ThreadError OTCALL otCommissionerAnnounceBegin(otInstance *aInstance, uint32_t aChannelMask, uint8_t aCount,
-                                                     uint16_t aPeriod,
-                                                     const otIp6Address *aAddress);
+OTAPI otError OTCALL otCommissionerAnnounceBegin(otInstance *aInstance, uint32_t aChannelMask, uint8_t aCount,
+                                                 uint16_t aPeriod,
+                                                 const otIp6Address *aAddress);
 
 /**
  * This function pointer is called when the Commissioner receives an Energy Report.
@@ -163,16 +163,16 @@ typedef void (OTCALL *otCommissionerEnergyReportCallback)(uint32_t aChannelMask,
  * @param[in]  aCallback             A pointer to a function called on receiving an Energy Report message.
  * @param[in]  aContext              A pointer to application-specific context.
  *
- * @retval kThreadError_None         Successfully enqueued the Energy Scan Query message.
- * @retval kThreadError_NoBufs       Insufficient buffers to generate an Energy Scan Query message.
- * @retval kThreadError_InvalidState The commissioner is not active.
+ * @retval OT_ERROR_NONE          Successfully enqueued the Energy Scan Query message.
+ * @retval OT_ERROR_NO_BUFS       Insufficient buffers to generate an Energy Scan Query message.
+ * @retval OT_ERROR_INVALID_STATE The commissioner is not active.
  *
  * @note Only use this after successfully started the Commissioner role by otCommissionerStart().
  *
  */
-OTAPI ThreadError OTCALL otCommissionerEnergyScan(otInstance *aInstance, uint32_t aChannelMask, uint8_t aCount,
-                                                  uint16_t aPeriod, uint16_t aScanDuration, const otIp6Address *aAddress,
-                                                  otCommissionerEnergyReportCallback aCallback, void *aContext);
+OTAPI otError OTCALL otCommissionerEnergyScan(otInstance *aInstance, uint32_t aChannelMask, uint8_t aCount,
+                                              uint16_t aPeriod, uint16_t aScanDuration, const otIp6Address *aAddress,
+                                              otCommissionerEnergyReportCallback aCallback, void *aContext);
 
 /**
  * This function pointer is called when the Commissioner receives a PAN ID Conflict message.
@@ -194,16 +194,16 @@ typedef void (OTCALL *otCommissionerPanIdConflictCallback)(uint16_t aPanId, uint
  * @param[in]  aCallback             A pointer to a function called on receiving an Energy Report message.
  * @param[in]  aContext              A pointer to application-specific context.
  *
- * @retval kThreadError_None         Successfully enqueued the PAN ID Query message.
- * @retval kThreadError_NoBufs       Insufficient buffers to generate a PAN ID Query message.
- * @retval kThreadError_InvalidState The commissioner is not active.
+ * @retval OT_ERROR_NONE          Successfully enqueued the PAN ID Query message.
+ * @retval OT_ERROR_NO_BUFS       Insufficient buffers to generate a PAN ID Query message.
+ * @retval OT_ERROR_INVALID_STATE The commissioner is not active.
  *
  * @note Only use this after successfully started the Commissioner role by otCommissionerStart().
  *
  */
-OTAPI ThreadError OTCALL otCommissionerPanIdQuery(otInstance *aInstance, uint16_t aPanId, uint32_t aChannelMask,
-                                                  const otIp6Address *aAddress,
-                                                  otCommissionerPanIdConflictCallback aCallback, void *aContext);
+OTAPI otError OTCALL otCommissionerPanIdQuery(otInstance *aInstance, uint16_t aPanId, uint32_t aChannelMask,
+                                              const otIp6Address *aAddress,
+                                              otCommissionerPanIdConflictCallback aCallback, void *aContext);
 
 /**
  * This function sends MGMT_COMMISSIONER_GET.
@@ -212,11 +212,11 @@ OTAPI ThreadError OTCALL otCommissionerPanIdQuery(otInstance *aInstance, uint16_
  * @param[in]  aTlvs      A pointer to TLVs.
  * @param[in]  aLength    The length of TLVs.
  *
- * @retval kThreadError_None         Successfully send the meshcop dataset command.
- * @retval kThreadError_NoBufs       Insufficient buffer space to send.
+ * @retval OT_ERROR_NONE          Successfully send the meshcop dataset command.
+ * @retval OT_ERROR_NO_BUFS       Insufficient buffer space to send.
  *
  */
-OTAPI ThreadError OTCALL otCommissionerSendMgmtGet(otInstance *aInstance, const uint8_t *aTlvs, uint8_t aLength);
+OTAPI otError OTCALL otCommissionerSendMgmtGet(otInstance *aInstance, const uint8_t *aTlvs, uint8_t aLength);
 
 /**
  * This function sends MGMT_COMMISSIONER_SET.
@@ -226,12 +226,12 @@ OTAPI ThreadError OTCALL otCommissionerSendMgmtGet(otInstance *aInstance, const 
  * @param[in]  aTlvs      A pointer to TLVs.
  * @param[in]  aLength    The length of TLVs.
  *
- * @retval kThreadError_None         Successfully send the meshcop dataset command.
- * @retval kThreadError_NoBufs       Insufficient buffer space to send.
+ * @retval OT_ERROR_NONE          Successfully send the meshcop dataset command.
+ * @retval OT_ERROR_NO_BUFS       Insufficient buffer space to send.
  *
  */
-OTAPI ThreadError OTCALL otCommissionerSendMgmtSet(otInstance *aInstance, const otCommissioningDataset *aDataset,
-                                                   const uint8_t *aTlvs, uint8_t aLength);
+OTAPI otError OTCALL otCommissionerSendMgmtSet(otInstance *aInstance, const otCommissioningDataset *aDataset,
+                                               const uint8_t *aTlvs, uint8_t aLength);
 
 /**
  * This function returns the Commissioner Session ID.
@@ -266,13 +266,13 @@ OTAPI otCommissionerState OTCALL otCommissionerGetState(otInstance *aInstance);
  * @param[in]  aExtPanId     The extended pan id for PSKc computation.
  * @param[out] aPSKc         A pointer to where the generated PSKc will be placed.
  *
- * @retval kThreadErrorNone          Successfully generate PSKc.
- * @retval kThreadError_InvalidArgs  If any of the input arguments is invalid.
+ * @retval OT_ERROR_NONE          Successfully generate PSKc.
+ * @retval OT_ERROR_INVALID_ARGS  If any of the input arguments is invalid.
  *
  */
-OTAPI ThreadError OTCALL otCommissionerGeneratePSKc(otInstance *aInstance, const char *aPassPhrase,
-                                                    const char *aNetworkName, const uint8_t *aExtPanId,
-                                                    uint8_t *aPSKc);
+OTAPI otError OTCALL otCommissionerGeneratePSKc(otInstance *aInstance, const char *aPassPhrase,
+                                                const char *aNetworkName, const uint8_t *aExtPanId,
+                                                uint8_t *aPSKc);
 
 /**
  * @}

--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -64,11 +64,11 @@ OTAPI bool OTCALL otDatasetIsCommissioned(otInstance *aInstance);
  * @param[in]   aInstance A pointer to an OpenThread instance.
  * @param[out]  aDataset  A pointer to where the Active Operational Dataset will be placed.
  *
- * @retval kThreadError_None         Successfully retrieved the Active Operational Dataset.
- * @retval kThreadError_InvalidArgs  @p aDataset was NULL.
+ * @retval OT_ERROR_NONE          Successfully retrieved the Active Operational Dataset.
+ * @retval OT_ERROR_INVALID_ARGS  @p aDataset was NULL.
  *
  */
-OTAPI ThreadError OTCALL otDatasetGetActive(otInstance *aInstance, otOperationalDataset *aDataset);
+OTAPI otError OTCALL otDatasetGetActive(otInstance *aInstance, otOperationalDataset *aDataset);
 
 /**
  * This function gets the Pending Operational Dataset.
@@ -76,11 +76,11 @@ OTAPI ThreadError OTCALL otDatasetGetActive(otInstance *aInstance, otOperational
  * @param[in]   aInstance A pointer to an OpenThread instance.
  * @param[out]  aDataset  A pointer to where the Pending Operational Dataset will be placed.
  *
- * @retval kThreadError_None         Successfully retrieved the Pending Operational Dataset.
- * @retval kThreadError_InvalidArgs  @p aDataset was NULL.
+ * @retval OT_ERROR_NONE          Successfully retrieved the Pending Operational Dataset.
+ * @retval OT_ERROR_INVALID_ARGS  @p aDataset was NULL.
  *
  */
-OTAPI ThreadError OTCALL otDatasetGetPending(otInstance *aInstance, otOperationalDataset *aDataset);
+OTAPI otError OTCALL otDatasetGetPending(otInstance *aInstance, otOperationalDataset *aDataset);
 
 /**
  * @}

--- a/include/openthread/dataset_ftd.h
+++ b/include/openthread/dataset_ftd.h
@@ -54,12 +54,12 @@ extern "C" {
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aDataset  A pointer to the Active Operational Dataset.
  *
- * @retval kThreadError_None         Successfully set the Active Operational Dataset.
- * @retval kThreadError_NoBufs       Insufficient buffer space to set the Active Operational Datset.
- * @retval kThreadError_InvalidArgs  @p aDataset was NULL.
+ * @retval OT_ERROR_NONE          Successfully set the Active Operational Dataset.
+ * @retval OT_ERROR_NO_BUFS       Insufficient buffer space to set the Active Operational Datset.
+ * @retval OT_ERROR_INVALID_ARGS  @p aDataset was NULL.
  *
  */
-OTAPI ThreadError OTCALL otDatasetSetActive(otInstance *aInstance, const otOperationalDataset *aDataset);
+OTAPI otError OTCALL otDatasetSetActive(otInstance *aInstance, const otOperationalDataset *aDataset);
 
 /**
  * This function sets the Pending Operational Dataset.
@@ -67,12 +67,12 @@ OTAPI ThreadError OTCALL otDatasetSetActive(otInstance *aInstance, const otOpera
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aDataset  A pointer to the Pending Operational Dataset.
  *
- * @retval kThreadError_None         Successfully set the Pending Operational Dataset.
- * @retval kThreadError_NoBufs       Insufficient buffer space to set the Pending Operational Dataset.
- * @retval kThreadError_InvalidArgs  @p aDataset was NULL.
+ * @retval OT_ERROR_NONE          Successfully set the Pending Operational Dataset.
+ * @retval OT_ERROR_NO_BUFS       Insufficient buffer space to set the Pending Operational Dataset.
+ * @retval OT_ERROR_INVALID_ARGS  @p aDataset was NULL.
  *
  */
-OTAPI ThreadError OTCALL otDatasetSetPending(otInstance *aInstance, const otOperationalDataset *aDataset);
+OTAPI otError OTCALL otDatasetSetPending(otInstance *aInstance, const otOperationalDataset *aDataset);
 
 /**
  * This function sends MGMT_ACTIVE_GET.
@@ -82,12 +82,12 @@ OTAPI ThreadError OTCALL otDatasetSetPending(otInstance *aInstance, const otOper
  * @param[in]  aLength    The length of TLV Types.
  * @param[in]  aAddress   A pointer to the IPv6 destination, if it is NULL, will use Leader ALOC as default.
  *
- * @retval kThreadError_None         Successfully send the meshcop dataset command.
- * @retval kThreadError_NoBufs       Insufficient buffer space to send.
+ * @retval OT_ERROR_NONE          Successfully send the meshcop dataset command.
+ * @retval OT_ERROR_NO_BUFS       Insufficient buffer space to send.
  *
  */
-OTAPI ThreadError OTCALL otDatasetSendMgmtActiveGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength,
-                                                    const otIp6Address *aAddress);
+OTAPI otError OTCALL otDatasetSendMgmtActiveGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength,
+                                                const otIp6Address *aAddress);
 
 /**
  * This function sends MGMT_ACTIVE_SET.
@@ -97,12 +97,12 @@ OTAPI ThreadError OTCALL otDatasetSendMgmtActiveGet(otInstance *aInstance, const
  * @param[in]  aTlvs      A pointer to TLVs.
  * @param[in]  aLength    The length of TLVs.
  *
- * @retval kThreadError_None         Successfully send the meshcop dataset command.
- * @retval kThreadError_NoBufs       Insufficient buffer space to send.
+ * @retval OT_ERROR_NONE          Successfully send the meshcop dataset command.
+ * @retval OT_ERROR_NO_BUFS       Insufficient buffer space to send.
  *
  */
-OTAPI ThreadError OTCALL otDatasetSendMgmtActiveSet(otInstance *aInstance, const otOperationalDataset *aDataset,
-                                                    const uint8_t *aTlvs, uint8_t aLength);
+OTAPI otError OTCALL otDatasetSendMgmtActiveSet(otInstance *aInstance, const otOperationalDataset *aDataset,
+                                                const uint8_t *aTlvs, uint8_t aLength);
 
 /**
  * This function sends MGMT_PENDING_GET.
@@ -112,12 +112,12 @@ OTAPI ThreadError OTCALL otDatasetSendMgmtActiveSet(otInstance *aInstance, const
  * @param[in]  aLength    The length of TLV Types.
  * @param[in]  aAddress   A pointer to the IPv6 destination, if it is NULL, will use Leader ALOC as default.
  *
- * @retval kThreadError_None         Successfully send the meshcop dataset command.
- * @retval kThreadError_NoBufs       Insufficient buffer space to send.
+ * @retval OT_ERROR_NONE          Successfully send the meshcop dataset command.
+ * @retval OT_ERROR_NO_BUFS       Insufficient buffer space to send.
  *
  */
-OTAPI ThreadError OTCALL otDatasetSendMgmtPendingGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength,
-                                                     const otIp6Address *aAddress);
+OTAPI otError OTCALL otDatasetSendMgmtPendingGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength,
+                                                 const otIp6Address *aAddress);
 
 /**
  * This function sends MGMT_PENDING_SET.
@@ -127,12 +127,12 @@ OTAPI ThreadError OTCALL otDatasetSendMgmtPendingGet(otInstance *aInstance, cons
  * @param[in]  aTlvs      A pointer to TLVs.
  * @param[in]  aLength    The length of TLVs.
  *
- * @retval kThreadError_None         Successfully send the meshcop dataset command.
- * @retval kThreadError_NoBufs       Insufficient buffer space to send.
+ * @retval OT_ERROR_NONE          Successfully send the meshcop dataset command.
+ * @retval OT_ERROR_NO_BUFS       Insufficient buffer space to send.
  *
  */
-OTAPI ThreadError OTCALL otDatasetSendMgmtPendingSet(otInstance *aInstance, const otOperationalDataset *aDataset,
-                                                     const uint8_t *aTlvs, uint8_t aLength);
+OTAPI otError OTCALL otDatasetSendMgmtPendingSet(otInstance *aInstance, const otOperationalDataset *aDataset,
+                                                 const uint8_t *aTlvs, uint8_t aLength);
 
 /**
  * Get minimal delay timer.
@@ -150,11 +150,11 @@ OTAPI uint32_t OTCALL otDatasetGetDelayTimerMinimal(otInstance *aInstance);
  * @param[in]  aInstance           A pointer to an OpenThread instance.
  * @param[in]  aDelayTimerMinimal  The value of minimal delay timer (in ms).
  *
- * @retval  kThreadError_None         Successfully set minimal delay timer.
- * @retval  kThreadError_InvalidArgs  If @p aDelayTimerMinimal is not valid.
+ * @retval  OT_ERROR_NONE          Successfully set minimal delay timer.
+ * @retval  OT_ERROR_INVALID_ARGS  If @p aDelayTimerMinimal is not valid.
  *
  */
-OTAPI ThreadError OTCALL otDatasetSetDelayTimerMinimal(otInstance *aInstance, uint32_t aDelayTimerMinimal);
+OTAPI otError OTCALL otDatasetSetDelayTimerMinimal(otInstance *aInstance, uint32_t aDelayTimerMinimal);
 
 /**
  * @}

--- a/include/openthread/dns.h
+++ b/include/openthread/dns.h
@@ -83,16 +83,16 @@ typedef struct otDnsQuery
  * @param[in]  aTtl       Specifies the maximum time in seconds that the resource record may be cached.
  * @param[in]  aResult    A result of the DNS transaction.
  *
- * @retval  kThreadError_None             A response was received successfully and IPv6 address is provided
- *                                        in @p aAddress.
- * @retval  kThreadError_Abort            A DNS transaction was aborted by stack.
- * @retval  kThreadError_ResponseTimeout  No DNS response has been received within timeout.
- * @retval  kThreadError_NotFound         A response was received but no IPv6 address has been found.
- * @retval  kThreadError_Failed           A response was received but status code is different than success.
+ * @retval  OT_ERROR_NONE              A response was received successfully and IPv6 address is provided
+ *                                     in @p aAddress.
+ * @retval  OT_ERROR_ABORT             A DNS transaction was aborted by stack.
+ * @retval  OT_ERROR_RESPONSE_TIMEOUT  No DNS response has been received within timeout.
+ * @retval  OT_ERROR_NOT_FOUND         A response was received but no IPv6 address has been found.
+ * @retval  OT_ERROR_FAILED            A response was received but status code is different than success.
  *
  */
 typedef void (*otDnsResponseHandler)(void *aContext, const char *aHostname, otIp6Address *aAddress,
-                                     uint32_t aTtl, ThreadError aResult);
+                                     uint32_t aTtl, otError aResult);
 
 #if OPENTHREAD_ENABLE_DNS_CLIENT
 /**
@@ -104,8 +104,8 @@ typedef void (*otDnsResponseHandler)(void *aContext, const char *aHostname, otIp
  * @param[in]  aContext    A pointer to arbitrary context information.
  *
  */
-ThreadError otDnsClientQuery(otInstance *aInstance, const otDnsQuery *aQuery, otDnsResponseHandler aHandler,
-                             void *aContext);
+otError otDnsClientQuery(otInstance *aInstance, const otDnsQuery *aQuery, otDnsResponseHandler aHandler,
+                         void *aContext);
 #endif
 
 /**

--- a/include/openthread/icmp6.h
+++ b/include/openthread/icmp6.h
@@ -83,7 +83,7 @@ void otIcmp6SetEchoEnabled(otInstance *aInstance, bool aEnabled);
  *                       an ICMPv6 message is received.
  *
  */
-ThreadError otIcmp6RegisterHandler(otInstance *aInstance, otIcmp6Handler *aHandler);
+otError otIcmp6RegisterHandler(otInstance *aInstance, otIcmp6Handler *aHandler);
 
 /**
  * This function sends an ICMPv6 Echo Request via the Thread interface.
@@ -95,8 +95,8 @@ ThreadError otIcmp6RegisterHandler(otInstance *aInstance, otIcmp6Handler *aHandl
  *                           May be zero.
  *
  */
-ThreadError otIcmp6SendEchoRequest(otInstance *aInstance, otMessage *aMessage,
-                                   const otMessageInfo *aMessageInfo, uint16_t aIdentifier);
+otError otIcmp6SendEchoRequest(otInstance *aInstance, otMessage *aMessage,
+                               const otMessageInfo *aMessageInfo, uint16_t aIdentifier);
 
 /**
  * @}

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -215,12 +215,12 @@ typedef void (OTCALL *otStateChangedCallback)(uint32_t aFlags, void *aContext);
  * @param[in]  aCallback  A pointer to a function that is called with certain configuration or state changes.
  * @param[in]  aContext   A pointer to application-specific context.
  *
- * @retval kThreadError_None    Added the callback to the list of callbacks.
- * @retval kThreadError_NoBufs  Could not add the callback due to resource constraints.
+ * @retval OT_ERROR_NONE     Added the callback to the list of callbacks.
+ * @retval OT_ERROR_NO_BUFS  Could not add the callback due to resource constraints.
  *
  */
-OTAPI ThreadError OTCALL otSetStateChangedCallback(otInstance *aInstance, otStateChangedCallback aCallback,
-                                                   void *aContext);
+OTAPI otError OTCALL otSetStateChangedCallback(otInstance *aInstance, otStateChangedCallback aCallback,
+                                               void *aContext);
 
 /**
  * This function removes a callback to indicate when certain configuration or state changes within OpenThread.
@@ -256,11 +256,11 @@ OTAPI void OTCALL otInstanceFactoryReset(otInstance *aInstance);
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.
  *
- * @retval kThreadError_None  All persistent info/state was erased successfully.
- * @retval kThreadError_InvalidState  Device is not in `disabled` state/role.
+ * @retval OT_ERROR_NONE           All persistent info/state was erased successfully.
+ * @retval OT_ERROR_INVALID_STATE  Device is not in `disabled` state/role.
  *
  */
-ThreadError otInstanceErasePersistentInfo(otInstance *aInstance);
+otError otInstanceErasePersistentInfo(otInstance *aInstance);
 
 /**
  * This function returns the current dynamic log level.
@@ -278,11 +278,11 @@ otLogLevel otGetDynamicLogLevel(otInstance *aInstance);
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aLogLevel The dynamic log level.
  *
- * @retval kThreadError_None         The log level was changed successfully.
- * @retval kThreadError_NotCapable   The dynamic log level is not supported.
+ * @retval OT_ERROR_NONE          The log level was changed successfully.
+ * @retval OT_ERROR_NOT_CAPABLE   The dynamic log level is not supported.
  *
  */
-ThreadError otSetDynamicLogLevel(otInstance *aInstance, otLogLevel aLogLevel);
+otError otSetDynamicLogLevel(otInstance *aInstance, otLogLevel aLogLevel);
 
 /**
  * @}

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -60,11 +60,11 @@ extern "C" {
  * @param[in] aInstance A pointer to an OpenThread instance.
  * @param[in] aEnabled  TRUE to enable IPv6, FALSE otherwise.
  *
- * @retval kThreadError_None          Successfully enabled the IPv6 interface,
- *                                    or the interface was already enabled.
+ * @retval OT_ERROR_NONE          Successfully enabled the IPv6 interface,
+ *                                or the interface was already enabled.
  *
  */
-OTAPI ThreadError OTCALL otIp6SetEnabled(otInstance *aInstance, bool aEnabled);
+OTAPI otError OTCALL otIp6SetEnabled(otInstance *aInstance, bool aEnabled);
 
 /**
  * This function indicates whether or not the IPv6 interface is up.
@@ -86,11 +86,11 @@ OTAPI bool OTCALL otIp6IsEnabled(otInstance *aInstance);
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aAddress  A pointer to a Network Interface Address.
  *
- * @retval kThreadErrorNone          Successfully added (or updated) the Network Interface Address.
- * @retval kThreadError_InvalidArgs  The IP Address indicated by @p aAddress is an internal address.
- * @retval kThreadError_NoBufs       The Network Interface is already storing the maximum allowed external addresses.
+ * @retval OT_ERROR_NONE          Successfully added (or updated) the Network Interface Address.
+ * @retval OT_ERROR_INVALID_ARGS  The IP Address indicated by @p aAddress is an internal address.
+ * @retval OT_ERROR_NO_BUFS       The Network Interface is already storing the maximum allowed external addresses.
  */
-OTAPI ThreadError OTCALL otIp6AddUnicastAddress(otInstance *aInstance, const otNetifAddress *aAddress);
+OTAPI otError OTCALL otIp6AddUnicastAddress(otInstance *aInstance, const otNetifAddress *aAddress);
 
 /**
  * Remove a Network Interface Address from the Thread interface.
@@ -98,11 +98,11 @@ OTAPI ThreadError OTCALL otIp6AddUnicastAddress(otInstance *aInstance, const otN
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aAddress  A pointer to an IP Address.
  *
- * @retval kThreadErrorNone          Successfully removed the Network Interface Address.
- * @retval kThreadError_InvalidArgs  The IP Address indicated by @p aAddress is an internal address.
- * @retval kThreadError_NotFound     The IP Address indicated by @p aAddress was not found.
+ * @retval OT_ERROR_NONE          Successfully removed the Network Interface Address.
+ * @retval OT_ERROR_INVALID_ARGS  The IP Address indicated by @p aAddress is an internal address.
+ * @retval OT_ERROR_NOT_FOUND     The IP Address indicated by @p aAddress was not found.
  */
-OTAPI ThreadError OTCALL otIp6RemoveUnicastAddress(otInstance *aInstance, const otIp6Address *aAddress);
+OTAPI otError OTCALL otIp6RemoveUnicastAddress(otInstance *aInstance, const otIp6Address *aAddress);
 
 /**
  * Get the list of IPv6 addresses assigned to the Thread interface.
@@ -122,11 +122,11 @@ OTAPI const otNetifAddress *OTCALL otIp6GetUnicastAddresses(otInstance *aInstanc
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aAddress  A pointer to an IP Address.
  *
- * @retval kThreadErrorNone          Successfully subscribed to the Network Interface Multicast Address.
- * @retval kThreadError_InvalidArgs  The IP Address indicated by @p aAddress is invalid address.
- * @retval kThreadError_NoBufs       The Network Interface is already storing the maximum allowed external multicast addresses.
+ * @retval OT_ERROR_NONE          Successfully subscribed to the Network Interface Multicast Address.
+ * @retval OT_ERROR_INVALID_ARGS  The IP Address indicated by @p aAddress is invalid address.
+ * @retval OT_ERROR_NO_BUFS       The Network Interface is already storing the maximum allowed external multicast addresses.
  */
-ThreadError otIp6SubscribeMulticastAddress(otInstance *aInstance, const otIp6Address *aAddress);
+otError otIp6SubscribeMulticastAddress(otInstance *aInstance, const otIp6Address *aAddress);
 
 /**
  * Unsubscribe the Thread interface to a Network Interface Multicast Address.
@@ -134,11 +134,11 @@ ThreadError otIp6SubscribeMulticastAddress(otInstance *aInstance, const otIp6Add
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aAddress  A pointer to an IP Address.
  *
- * @retval kThreadErrorNone          Successfully unsubscribed to the Network Interface Multicast Address.
- * @retval kThreadError_InvalidArgs  The IP Address indicated by @p aAddress is an internal address.
- * @retval kThreadError_NotFound     The IP Address indicated by @p aAddress was not found.
+ * @retval OT_ERROR_NONE          Successfully unsubscribed to the Network Interface Multicast Address.
+ * @retval OT_ERROR_INVALID_ARGS  The IP Address indicated by @p aAddress is an internal address.
+ * @retval OT_ERROR_NOT_FOUND     The IP Address indicated by @p aAddress was not found.
  */
-ThreadError otIp6UnsubscribeMulticastAddress(otInstance *aInstance, const otIp6Address *aAddress);
+otError otIp6UnsubscribeMulticastAddress(otInstance *aInstance, const otIp6Address *aAddress);
 
 /**
  * Get the list of IPv6 multicast addresses subscribed to the Thread interface.
@@ -175,11 +175,11 @@ void otIp6SetMulticastPromiscuousEnabled(otInstance *aInstance, bool aEnabled);
  * @param[inout]  aAddress   A pointer to structure containing IPv6 address for which IID is being created.
  * @param[inout]  aContext   A pointer to creator-specific context.
  *
- * @retval kThreadError_None                        Created valid IID for given IPv6 address.
- * @retval kThreadError_Ipv6AddressCreationFailure  Creation of valid IID for given IPv6 address failed.
+ * @retval OT_ERROR_NONE                        Created valid IID for given IPv6 address.
+ * @retval OT_ERROR_IP6_ADDRESS_CREATION_FAILURE  Creation of valid IID for given IPv6 address failed.
  *
  */
-typedef ThreadError(*otIp6SlaacIidCreate)(otInstance *aInstance, otNetifAddress *aAddress, void *aContext);
+typedef otError(*otIp6SlaacIidCreate)(otInstance *aInstance, otNetifAddress *aAddress, void *aContext);
 
 /**
  * Update all automatically created IPv6 addresses for prefixes from current Network Data with SLAAC procedure.
@@ -201,10 +201,10 @@ void otIp6SlaacUpdate(otInstance *aInstance, otNetifAddress *aAddresses, uint32_
  * @param[inout]  aAddresses  A pointer to structure containing IPv6 address for which IID is being created.
  * @param[in]     aContext    A pointer to unused data.
  *
- * @retval kThreadError_None  Created valid IID for given IPv6 address.
+ * @retval OT_ERROR_NONE  Created valid IID for given IPv6 address.
  *
  */
-ThreadError otIp6CreateRandomIid(otInstance *aInstance, otNetifAddress *aAddresses, void *aContext);
+otError otIp6CreateRandomIid(otInstance *aInstance, otNetifAddress *aAddresses, void *aContext);
 
 /**
  * Create IID for given IPv6 address using extended MAC address.
@@ -213,10 +213,10 @@ ThreadError otIp6CreateRandomIid(otInstance *aInstance, otNetifAddress *aAddress
  * @param[inout]  aAddresses  A pointer to structure containing IPv6 address for which IID is being created.
  * @param[in]     aContext    A pointer to unused data.
  *
- * @retval kThreadError_None  Created valid IID for given IPv6 address.
+ * @retval OT_ERROR_NONE  Created valid IID for given IPv6 address.
  *
  */
-ThreadError otIp6CreateMacIid(otInstance *aInstance, otNetifAddress *aAddresses, void *aContext);
+otError otIp6CreateMacIid(otInstance *aInstance, otNetifAddress *aAddresses, void *aContext);
 
 /**
  * Create semantically opaque IID for given IPv6 address.
@@ -225,11 +225,11 @@ ThreadError otIp6CreateMacIid(otInstance *aInstance, otNetifAddress *aAddresses,
  * @param[inout]  aAddresses  A pointer to structure containing IPv6 address for which IID is being created.
  * @param[inout]  aContext    A pointer to a otSemanticallyOpaqueIidGeneratorData structure.
  *
- * @retval kThreadError_None                        Created valid IID for given IPv6 address.
- * @retval kThreadError_Ipv6AddressCreationFailure  Could not create valid IID for given IPv6 address.
+ * @retval OT_ERROR_NONE                         Created valid IID for given IPv6 address.
+ * @retval OT_ERROR_IP6_ADDRESS_CREATION_FAILURE  Could not create valid IID for given IPv6 address.
  *
  */
-ThreadError otIp6CreateSemanticallyOpaqueIid(otInstance *aInstance, otNetifAddress *aAddresses, void *aContext);
+otError otIp6CreateSemanticallyOpaqueIid(otInstance *aInstance, otNetifAddress *aAddresses, void *aContext);
 
 /**
  * Allocate a new message buffer for sending an IPv6 message.
@@ -303,7 +303,7 @@ void otIp6SetReceiveFilterEnabled(otInstance *aInstance, bool aEnabled);
  * @param[in]  aMessage  A pointer to the message buffer containing the IPv6 datagram.
  *
  */
-ThreadError otIp6Send(otInstance *aInstance, otMessage *aMessage);
+otError otIp6Send(otInstance *aInstance, otMessage *aMessage);
 
 /**
  * This function adds a port to the allowed unsecured port list.
@@ -311,11 +311,11 @@ ThreadError otIp6Send(otInstance *aInstance, otMessage *aMessage);
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aPort     The port value.
  *
- * @retval kThreadError_None    The port was successfully added to the allowed unsecure port list.
- * @retval kThreadError_NoBufs  The unsecure port list is full.
+ * @retval OT_ERROR_NONE     The port was successfully added to the allowed unsecure port list.
+ * @retval OT_ERROR_NO_BUFS  The unsecure port list is full.
  *
  */
-ThreadError otIp6AddUnsecurePort(otInstance *aInstance, uint16_t aPort);
+otError otIp6AddUnsecurePort(otInstance *aInstance, uint16_t aPort);
 
 /**
  * This function removes a port from the allowed unsecure port list.
@@ -323,11 +323,11 @@ ThreadError otIp6AddUnsecurePort(otInstance *aInstance, uint16_t aPort);
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aPort     The port value.
  *
- * @retval kThreadError_None      The port was successfully removed from the allowed unsecure port list.
- * @retval kThreadError_NotFound  The port was not found in the unsecure port list.
+ * @retval OT_ERROR_NONE       The port was successfully removed from the allowed unsecure port list.
+ * @retval OT_ERROR_NOT_FOUND  The port was not found in the unsecure port list.
  *
  */
-ThreadError otIp6RemoveUnsecurePort(otInstance *aInstance, uint16_t aPort);
+otError otIp6RemoveUnsecurePort(otInstance *aInstance, uint16_t aPort);
 
 /**
  * This function returns a pointer to the unsecure port list.
@@ -359,10 +359,10 @@ OTAPI bool OTCALL otIp6IsAddressEqual(const otIp6Address *a, const otIp6Address 
  * @param[in]   aString   A pointer to a NULL-terminated string.
  * @param[out]  aAddress  A pointer to an IPv6 address.
  *
- * @retval kThreadErrorNone        Successfully parsed the string.
- * @retval kThreadErrorInvalidArg  Failed to parse the string.
+ * @retval OT_ERROR_NONE          Successfully parsed the string.
+ * @retval OT_ERROR_INVALID_ARGS  Failed to parse the string.
  */
-OTAPI ThreadError OTCALL otIp6AddressFromString(const char *aString, otIp6Address *aAddress);
+OTAPI otError OTCALL otIp6AddressFromString(const char *aString, otIp6Address *aAddress);
 
 /**
  * This function returns the prefix match length (bits) for two IPv6 addresses.

--- a/include/openthread/jam_detection.h
+++ b/include/openthread/jam_detection.h
@@ -74,10 +74,10 @@ typedef void (*otJamDetectionCallback)(bool aJamState, void *aContext);
  * @param[in]  aInstance       A pointer to an OpenThread instance.
  * @param[in]  aRssiThreshold  The RSSI threshold.
  *
- * @retval kThreadErrorNone    Successfully set the threshold.
+ * @retval OT_ERROR_NONE    Successfully set the threshold.
  *
  */
-ThreadError otJamDetectionSetRssiThreshold(otInstance *aInstance, int8_t aRssiThreshold);
+otError otJamDetectionSetRssiThreshold(otInstance *aInstance, int8_t aRssiThreshold);
 
 /**
  * Get the Jam Detection RSSI Threshold (in dBm).
@@ -94,11 +94,11 @@ int8_t otJamDetectionGetRssiThreshold(otInstance *aInstance);
  * @param[in]  aInstance            A pointer to an OpenThread instance.
  * @param[in]  aWindow              The Jam Detection window (valid range is 1 to 63)
  *
- * @retval kThreadErrorNone         Successfully set the window.
- * @retval kThreadErrorInvalidArgs  The given input parameter not within valid range (1-63)
+ * @retval OT_ERROR_NONE          Successfully set the window.
+ * @retval OT_ERROR_INVALID_ARGS  The given input parameter not within valid range (1-63)
  *
  */
-ThreadError otJamDetectionSetWindow(otInstance *aInstance, uint8_t aWindow);
+otError otJamDetectionSetWindow(otInstance *aInstance, uint8_t aWindow);
 
 /**
  * Get the Jam Detection Detection Window (in seconds).
@@ -119,11 +119,11 @@ uint8_t otJamDetectionGetWindow(otInstance *aInstance);
  * @param[in]  aBusyPeriod          The Jam Detection busy period (should be non-zero and
                                     less than or equal to Jam Detection Window)
  *
- * @retval kThreadErrorNone         Successfully set the window.
- * @retval kThreadErrorInvalidArgs  The given input is not within the valid range.
+ * @retval OT_ERROR_NONE          Successfully set the window.
+ * @retval OT_ERROR_INVALID_ARGS  The given input is not within the valid range.
  *
  */
-ThreadError otJamDetectionSetBusyPeriod(otInstance *aInstance, uint8_t aBusyPeriod);
+otError otJamDetectionSetBusyPeriod(otInstance *aInstance, uint8_t aBusyPeriod);
 
 /**
  * Get the Jam Detection Busy Period (in seconds)
@@ -141,22 +141,22 @@ uint8_t otJamDetectionGetBusyPeriod(otInstance *aInstance);
  * @param[in]  aCallback            A pointer to a function called to notify of jamming state change.
  * @param[in]  aContext             A pointer to application-specific context.
  *
- * @retval kThreadErrorNone         Successfully started the jamming detection.
- * @retval kThreadErrorAlready      Jam detection has been started before.
+ * @retval OT_ERROR_NONE         Successfully started the jamming detection.
+ * @retval OT_ERROR_ALREADY      Jam detection has been started before.
  *
  */
-ThreadError otJamDetectionStart(otInstance *aInstance, otJamDetectionCallback aCallback, void *aContext);
+otError otJamDetectionStart(otInstance *aInstance, otJamDetectionCallback aCallback, void *aContext);
 
 /**
  * Stop the jamming detection.
  *
  * @param[in]  aInstance            A pointer to an OpenThread instance.
  *
- * @retval kThreadErrorNone         Successfully stopped the jamming detection.
- * @retval kThreadErrorAlready      Jam detection is already stopped.
+ * @retval OT_ERROR_NONE         Successfully stopped the jamming detection.
+ * @retval OT_ERROR_ALREADY      Jam detection is already stopped.
  *
  */
-ThreadError otJamDetectionStop(otInstance *aInstance);
+otError otJamDetectionStop(otInstance *aInstance);
 
 /**
  * Get the Jam Detection Status (enabled/disabled)

--- a/include/openthread/joiner.h
+++ b/include/openthread/joiner.h
@@ -55,14 +55,14 @@ extern "C" {
 /**
  * This function pointer is called to notify the completion of a join operation.
  *
- * @param[in]  aError    kThreadError_None if the join process succeeded.
- *                       kThreadError_Security if the join process failed due to security credentials.
- *                       kThreadError_NotFound if no joinable network was discovered.
- *                       kThreadError_ResponseTimeout if a response timed out.
+ * @param[in]  aError    OT_ERROR_NONE if the join process succeeded.
+ *                       OT_ERROR_SECURITY if the join process failed due to security credentials.
+ *                       OT_ERROR_NOT_FOUND if no joinable network was discovered.
+ *                       OT_ERROR_RESPONSE_TIMEOUT if a response timed out.
  * @param[in]  aContext  A pointer to application-specific context.
  *
  */
-typedef void (OTCALL *otJoinerCallback)(ThreadError aError, void *aContext);
+typedef void (OTCALL *otJoinerCallback)(otError aError, void *aContext);
 
 /**
  * This function enables the Thread Joiner role.
@@ -77,14 +77,14 @@ typedef void (OTCALL *otJoinerCallback)(ThreadError aError, void *aContext);
  * @param[in]  aCallback         A pointer to a function that is called when the join operation completes.
  * @param[in]  aContext          A pointer to application-specific context.
  *
- * @retval kThreadError_None         Successfully started the Commissioner role.
- * @retval kThreadError_InvalidArgs  @p aPSKd or @p aProvisioningUrl is invalid.
+ * @retval OT_ERROR_NONE          Successfully started the Commissioner role.
+ * @retval OT_ERROR_INVALID_ARGS  @p aPSKd or @p aProvisioningUrl is invalid.
  *
  */
-OTAPI ThreadError OTCALL otJoinerStart(otInstance *aInstance, const char *aPSKd, const char *aProvisioningUrl,
-                                       const char *aVendorName, const char *aVendorModel,
-                                       const char *aVendorSwVersion, const char *aVendorData,
-                                       otJoinerCallback aCallback, void *aContext);
+OTAPI otError OTCALL otJoinerStart(otInstance *aInstance, const char *aPSKd, const char *aProvisioningUrl,
+                                   const char *aVendorName, const char *aVendorModel,
+                                   const char *aVendorSwVersion, const char *aVendorData,
+                                   otJoinerCallback aCallback, void *aContext);
 
 /**
  * This function disables the Thread Joiner role.
@@ -92,7 +92,7 @@ OTAPI ThreadError OTCALL otJoinerStart(otInstance *aInstance, const char *aPSKd,
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  *
  */
-OTAPI ThreadError OTCALL otJoinerStop(otInstance *aInstance);
+OTAPI otError OTCALL otJoinerStop(otInstance *aInstance);
 
 /**
  * @}

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -71,12 +71,12 @@ typedef void (OTCALL *otHandleActiveScanResult)(otActiveScanResult *aResult, voi
  * @param[in]  aCallback         A pointer to a function called on receiving a beacon or scan completes.
  * @param[in]  aCallbackContext  A pointer to application-specific context.
  *
- * @retval kThreadError_None  Accepted the Active Scan request.
- * @retval kThreadError_Busy  Already performing an Active Scan.
+ * @retval OT_ERROR_NONE  Accepted the Active Scan request.
+ * @retval OT_ERROR_BUSY  Already performing an Active Scan.
  *
  */
-OTAPI ThreadError OTCALL otLinkActiveScan(otInstance *aInstance, uint32_t aScanChannels, uint16_t aScanDuration,
-                                          otHandleActiveScanResult aCallback, void *aCallbackContext);
+OTAPI otError OTCALL otLinkActiveScan(otInstance *aInstance, uint32_t aScanChannels, uint16_t aScanDuration,
+                                      otHandleActiveScanResult aCallback, void *aCallbackContext);
 
 /**
  * This function indicates whether or not an IEEE 802.15.4 Active Scan is currently in progress.
@@ -106,12 +106,12 @@ typedef void (OTCALL *otHandleEnergyScanResult)(otEnergyScanResult *aResult, voi
  * @param[in]  aCallback         A pointer to a function called to pass on scan result on indicate scan completion.
  * @param[in]  aCallbackContext  A pointer to application-specific context.
  *
- * @retval kThreadError_None  Accepted the Energy Scan request.
- * @retval kThreadError_Busy  Could not start the energy scan.
+ * @retval OT_ERROR_NONE  Accepted the Energy Scan request.
+ * @retval OT_ERROR_BUSY  Could not start the energy scan.
  *
  */
-OTAPI ThreadError OTCALL otLinkEnergyScan(otInstance *aInstance, uint32_t aScanChannels, uint16_t aScanDuration,
-                                          otHandleEnergyScanResult aCallback, void *aCallbackContext);
+OTAPI otError OTCALL otLinkEnergyScan(otInstance *aInstance, uint32_t aScanChannels, uint16_t aScanDuration,
+                                      otHandleEnergyScanResult aCallback, void *aCallbackContext);
 
 /**
  * This function indicates whether or not an IEEE 802.15.4 Energy Scan is currently in progress.
@@ -128,13 +128,13 @@ OTAPI bool OTCALL otLinkIsEnergyScanInProgress(otInstance *aInstance);
  *
  * @param[in] aInstance  A pointer to an OpenThread instance.
  *
- * @retval kThreadError_None          Successfully enqueued an IEEE 802.15.4 Data Request message.
- * @retval kThreadError_Already       An IEEE 802.15.4 Data Request message is already enqueued.
- * @retval kThreadError_InvalidState  Device is not in rx-off-when-idle mode.
- * @retval kThreadError_NoBufs        Insufficient message buffers available.
+ * @retval OT_ERROR_NONE           Successfully enqueued an IEEE 802.15.4 Data Request message.
+ * @retval OT_ERROR_ALREADY        An IEEE 802.15.4 Data Request message is already enqueued.
+ * @retval OT_ERROR_INVALID_STATE  Device is not in rx-off-when-idle mode.
+ * @retval OT_ERROR_NO_BUFS        Insufficient message buffers available.
  *
  */
-OTAPI ThreadError OTCALL otLinkSendDataRequest(otInstance *aInstance);
+OTAPI otError OTCALL otLinkSendDataRequest(otInstance *aInstance);
 
 /**
  * This function indicates whether or not an IEEE 802.15.4 MAC is in the transmit state.
@@ -171,13 +171,13 @@ OTAPI uint8_t OTCALL otLinkGetChannel(otInstance *aInstance);
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aChannel  The IEEE 802.15.4 channel.
  *
- * @retval  kThreadErrorNone          Successfully set the channel.
- * @retval  kThreadErrorInvalidArgs   If @p aChnanel is not in the range [11, 26].
- * @retval kThreadError_InvalidState  Thread protocols are enabled.
+ * @retval  OT_ERROR_NONE           Successfully set the channel.
+ * @retval  OT_ERROR_INVALID_ARGS   If @p aChnanel is not in the range [11, 26].
+ * @retval  OT_ERROR_INVALID_STATE  Thread protocols are enabled.
  *
  * @sa otLinkGetChannel
  */
-OTAPI ThreadError OTCALL otLinkSetChannel(otInstance *aInstance, uint8_t aChannel);
+OTAPI otError OTCALL otLinkSetChannel(otInstance *aInstance, uint8_t aChannel);
 
 /**
  * Get the IEEE 802.15.4 Extended Address.
@@ -196,12 +196,12 @@ OTAPI const uint8_t *OTCALL otLinkGetExtendedAddress(otInstance *aInstance);
  * @param[in]  aInstance         A pointer to an OpenThread instance.
  * @param[in]  aExtendedAddress  A pointer to the IEEE 802.15.4 Extended Address.
  *
- * @retval kThreadError_None          Successfully set the IEEE 802.15.4 Extended Address.
- * @retval kThreadError_InvalidArgs   @p aExtendedAddress was NULL.
- * @retval kThraedError_InvalidState  Thread protocols are enabled.
+ * @retval OT_ERROR_NONE           Successfully set the IEEE 802.15.4 Extended Address.
+ * @retval OT_ERROR_INVALID_ARGS   @p aExtendedAddress was NULL.
+ * @retval OT_ERROR_INVALID_STATE  Thread protocols are enabled.
  *
  */
-OTAPI ThreadError OTCALL otLinkSetExtendedAddress(otInstance *aInstance, const otExtAddress *aExtendedAddress);
+OTAPI otError OTCALL otLinkSetExtendedAddress(otInstance *aInstance, const otExtAddress *aExtendedAddress);
 
 /**
  * Get the factory-assigned IEEE EUI-64.
@@ -264,13 +264,13 @@ OTAPI otPanId OTCALL otLinkGetPanId(otInstance *aInstance);
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aPanId    The IEEE 802.15.4 PAN ID.
  *
- * @retval kThreadError_None          Successfully set the PAN ID.
- * @retval kThreadError_InvalidArgs   If aPanId is not in the range [0, 65534].
- * @retval kThreadError_InvalidState  Thread protocols are enabled.
+ * @retval OT_ERROR_NONE           Successfully set the PAN ID.
+ * @retval OT_ERROR_INVALID_ARGS   If aPanId is not in the range [0, 65534].
+ * @retval OT_ERROR_INVALID_STATE  Thread protocols are enabled.
  *
  * @sa otLinkGetPanId
  */
-OTAPI ThreadError OTCALL otLinkSetPanId(otInstance *aInstance, otPanId aPanId);
+OTAPI otError OTCALL otLinkSetPanId(otInstance *aInstance, otPanId aPanId);
 
 /**
  * Get the data poll period of sleepy end device.
@@ -311,8 +311,8 @@ OTAPI otShortAddress OTCALL otLinkGetShortAddress(otInstance *aInstance);
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aExtAddr  A pointer to the IEEE 802.15.4 Extended Address.
  *
- * @retval kThreadErrorNone    Successfully added to the MAC whitelist.
- * @retval kThreadErrorNoBufs  No buffers available for a new MAC whitelist entry.
+ * @retval OT_ERROR_NONE     Successfully added to the MAC whitelist.
+ * @retval OT_ERROR_NO_BUFS  No buffers available for a new MAC whitelist entry.
  *
  * @sa otLinkAddWhitelistRssi
  * @sa otLinkRemoveWhitelist
@@ -320,7 +320,7 @@ OTAPI otShortAddress OTCALL otLinkGetShortAddress(otInstance *aInstance);
  * @sa otLinkGetWhitelistEntry
  * @sa otLinkSetWhitelistEnabled
  */
-OTAPI ThreadError OTCALL otLinkAddWhitelist(otInstance *aInstance, const uint8_t *aExtAddr);
+OTAPI otError OTCALL otLinkAddWhitelist(otInstance *aInstance, const uint8_t *aExtAddr);
 
 /**
  * Add an IEEE 802.15.4 Extended Address to the MAC whitelist and fix the RSSI value.
@@ -329,8 +329,8 @@ OTAPI ThreadError OTCALL otLinkAddWhitelist(otInstance *aInstance, const uint8_t
  * @param[in]  aExtAddr  A pointer to the IEEE 802.15.4 Extended Address.
  * @param[in]  aRssi     The RSSI in dBm to use when receiving messages from aExtAddr.
  *
- * @retval kThreadErrorNone    Successfully added to the MAC whitelist.
- * @retval kThreadErrorNoBufs  No buffers available for a new MAC whitelist entry.
+ * @retval OT_ERROR_NONE     Successfully added to the MAC whitelist.
+ * @retval OT_ERROR_NO_BUFS  No buffers available for a new MAC whitelist entry.
  *
  * @sa otLinkAddWhitelistRssi
  * @sa otLinkRemoveWhitelist
@@ -339,7 +339,7 @@ OTAPI ThreadError OTCALL otLinkAddWhitelist(otInstance *aInstance, const uint8_t
  * @sa otLinkIsWhitelistEnabled
  * @sa otLinkSetWhitelistEnabled
  */
-OTAPI ThreadError OTCALL otLinkAddWhitelistRssi(otInstance *aInstance, const uint8_t *aExtAddr, int8_t aRssi);
+OTAPI otError OTCALL otLinkAddWhitelistRssi(otInstance *aInstance, const uint8_t *aExtAddr, int8_t aRssi);
 
 /**
  * Remove an IEEE 802.15.4 Extended Address from the MAC whitelist.
@@ -363,11 +363,11 @@ OTAPI void OTCALL otLinkRemoveWhitelist(otInstance *aInstance, const uint8_t *aE
  * @param[in]   aIndex    An index into the MAC whitelist table.
  * @param[out]  aEntry    A pointer to where the information is placed.
  *
- * @retval kThreadError_None         Successfully retrieved the MAC whitelist entry.
- * @retval kThreadError_InvalidArgs  @p aIndex is out of bounds or @p aEntry is NULL.
+ * @retval OT_ERROR_NONE          Successfully retrieved the MAC whitelist entry.
+ * @retval OT_ERROR_INVALID_ARGS  @p aIndex is out of bounds or @p aEntry is NULL.
  *
  */
-OTAPI ThreadError OTCALL otLinkGetWhitelistEntry(otInstance *aInstance, uint8_t aIndex, otMacWhitelistEntry *aEntry);
+OTAPI otError OTCALL otLinkGetWhitelistEntry(otInstance *aInstance, uint8_t aIndex, otMacWhitelistEntry *aEntry);
 
 /**
  * Remove all entries from the MAC whitelist.
@@ -420,8 +420,8 @@ OTAPI bool OTCALL otLinkIsWhitelistEnabled(otInstance *aInstance);
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aExtAddr  A pointer to the IEEE 802.15.4 Extended Address.
  *
- * @retval kThreadErrorNone    Successfully added to the MAC blacklist.
- * @retval kThreadErrorNoBufs  No buffers available for a new MAC blacklist entry.
+ * @retval OT_ERROR_NONE     Successfully added to the MAC blacklist.
+ * @retval OT_ERROR_NO_BUFS  No buffers available for a new MAC blacklist entry.
  *
  * @sa otLinkRemoveBlacklist
  * @sa otLinkClearBlacklist
@@ -429,7 +429,7 @@ OTAPI bool OTCALL otLinkIsWhitelistEnabled(otInstance *aInstance);
  * @sa otLinkIsBlacklistEnabled
  * @sa otLinkSetBlacklistEnabled
  */
-OTAPI ThreadError OTCALL otLinkAddBlacklist(otInstance *aInstance, const uint8_t *aExtAddr);
+OTAPI otError OTCALL otLinkAddBlacklist(otInstance *aInstance, const uint8_t *aExtAddr);
 
 /**
  * Remove an IEEE 802.15.4 Extended Address from the MAC blacklist.
@@ -452,11 +452,11 @@ OTAPI void OTCALL otLinkRemoveBlacklist(otInstance *aInstance, const uint8_t *aE
  * @param[in]   aIndex    An index into the MAC Blacklist table.
  * @param[out]  aEntry    A pointer to where the information is placed.
  *
- * @retval kThreadError_None         Successfully retrieved the MAC Blacklist entry.
- * @retval kThreadError_InvalidArgs  @p aIndex is out of bounds or @p aEntry is NULL.
+ * @retval OT_ERROR_NONE          Successfully retrieved the MAC Blacklist entry.
+ * @retval OT_ERROR_INVALID_ARGS  @p aIndex is out of bounds or @p aEntry is NULL.
  *
  */
-OTAPI ThreadError OTCALL otLinkGetBlacklistEntry(otInstance *aInstance, uint8_t aIndex, otMacBlacklistEntry *aEntry);
+OTAPI otError OTCALL otLinkGetBlacklistEntry(otInstance *aInstance, uint8_t aIndex, otMacBlacklistEntry *aEntry);
 
 /**
  *  Remove all entries from the MAC Blacklist.
@@ -508,13 +508,13 @@ OTAPI bool OTCALL otLinkIsBlacklistEnabled(otInstance *aInstance);
  * @param[in]  aExtAddr  A pointer to the IEEE 802.15.4 Extended Address.
  * @param[in]  aLinkQuality A pointer to the assigned link quality.
  *
- * @retval kThreadError_None  Successfully retrieved the link quality to aLinkQuality.
- * @retval kThreadError_InvalidState  No attached child matches with a given extended address.
+ * @retval OT_ERROR_NONE           Successfully retrieved the link quality to aLinkQuality.
+ * @retval OT_ERROR_INVALID_STATE  No attached child matches with a given extended address.
  *
  * @sa otLinkSetAssignLinkQuality
  */
-OTAPI ThreadError OTCALL otLinkGetAssignLinkQuality(otInstance *aInstance, const uint8_t *aExtAddr,
-                                                    uint8_t *aLinkQuality);
+OTAPI otError OTCALL otLinkGetAssignLinkQuality(otInstance *aInstance, const uint8_t *aExtAddr,
+                                                uint8_t *aLinkQuality);
 
 /**
  * Set the link quality which is on the link to a given extended address.
@@ -580,12 +580,12 @@ bool otLinkIsPromiscuous(otInstance *aInstance);
  * @param[in]  aInstance     A pointer to an OpenThread instance.
  * @param[in]  aPromiscuous  true to enable promiscuous mode, or false otherwise.
  *
- * @retval kThreadError_None          Successfully enabled promiscuous mode.
- * @retval kThreadError_InvalidState  Could not enable promiscuous mode because
- *                                    the Thread interface is enabled.
+ * @retval OT_ERROR_NONE           Successfully enabled promiscuous mode.
+ * @retval OT_ERROR_INVALID_STATE  Could not enable promiscuous mode because
+ *                                 the Thread interface is enabled.
  *
  */
-ThreadError otLinkSetPromiscuous(otInstance *aInstance, bool aPromiscuous);
+otError otLinkSetPromiscuous(otInstance *aInstance, bool aPromiscuous);
 
 /**
  * @}

--- a/include/openthread/link_raw.h
+++ b/include/openthread/link_raw.h
@@ -58,11 +58,11 @@ extern "C" {
  * @param[in] aInstance     A pointer to an OpenThread instance.
  * @param[in] aEnabled      TRUE to enable raw link-layer, FALSE otherwise.
  *
- * @retval kThreadError_None            If the enable state was successfully set.
- * @retval kThreadError_InvalidState    If the OpenThread Ip6 interface is already enabled.
+ * @retval OT_ERROR_NONE            If the enable state was successfully set.
+ * @retval OT_ERROR_INVALID_STATE   If the OpenThread Ip6 interface is already enabled.
  *
  */
-ThreadError otLinkRawSetEnable(otInstance *aInstance, bool aEnabled);
+otError otLinkRawSetEnable(otInstance *aInstance, bool aEnabled);
 
 /**
  * This function indicates whether or not the raw link-layer is enabled.
@@ -81,11 +81,11 @@ bool otLinkRawIsEnabled(otInstance *aInstance);
  * @param[in] aInstance      A pointer to an OpenThread instance.
  * @param[in] aPanId         The IEEE 802.15.4 PAN ID.
  *
- * @retval kThreadError_None            If successful.
- * @retval kThreadError_InvalidState    If the raw link-layer isn't enabled.
+ * @retval OT_ERROR_NONE             If successful.
+ * @retval OT_ERROR_INVALID_STATE    If the raw link-layer isn't enabled.
  *
  */
-ThreadError otLinkRawSetPanId(otInstance *aInstance, uint16_t aPanId);
+otError otLinkRawSetPanId(otInstance *aInstance, uint16_t aPanId);
 
 /**
  * This function sets the IEEE 802.15.4 Extended Address.
@@ -93,11 +93,11 @@ ThreadError otLinkRawSetPanId(otInstance *aInstance, uint16_t aPanId);
  * @param[in]  aInstance         A pointer to an OpenThread instance.
  * @param[in]  aExtendedAddress  A pointer to the IEEE 802.15.4 Extended Address.
  *
- * @retval kThreadError_None            If successful.
- * @retval kThreadError_InvalidState    If the raw link-layer isn't enabled.
+ * @retval OT_ERROR_NONE             If successful.
+ * @retval OT_ERROR_INVALID_STATE    If the raw link-layer isn't enabled.
  *
  */
-ThreadError otLinkRawSetExtendedAddress(otInstance *aInstance, const otExtAddress *aExtendedAddress);
+otError otLinkRawSetExtendedAddress(otInstance *aInstance, const otExtAddress *aExtendedAddress);
 
 /**
  * Set the Short Address for address filtering.
@@ -105,11 +105,11 @@ ThreadError otLinkRawSetExtendedAddress(otInstance *aInstance, const otExtAddres
  * @param[in] aInstance      A pointer to an OpenThread instance.
  * @param[in] aShortAddress  The IEEE 802.15.4 Short Address.
  *
- * @retval kThreadError_None            If successful.
- * @retval kThreadError_InvalidState    If the raw link-layer isn't enabled.
+ * @retval OT_ERROR_NONE             If successful.
+ * @retval OT_ERROR_INVALID_STATE    If the raw link-layer isn't enabled.
  *
  */
-ThreadError otLinkRawSetShortAddress(otInstance *aInstance, uint16_t aShortAddress);
+otError otLinkRawSetShortAddress(otInstance *aInstance, uint16_t aShortAddress);
 
 /**
  * This function gets the status of promiscuous mode.
@@ -128,11 +128,11 @@ bool otLinkRawGetPromiscuous(otInstance *aInstance);
  * @param[in]  aInstance    A pointer to an OpenThread instance.
  * @param[in]  aEnable      A value to enable or disable promiscuous mode.
  *
- * @retval kThreadError_None            If successful.
- * @retval kThreadError_InvalidState    If the raw link-layer isn't enabled.
+ * @retval OT_ERROR_NONE             If successful.
+ * @retval OT_ERROR_INVALID_STATE    If the raw link-layer isn't enabled.
  *
  */
-ThreadError otLinkRawSetPromiscuous(otInstance *aInstance, bool aEnable);
+otError otLinkRawSetPromiscuous(otInstance *aInstance, bool aEnable);
 
 /**
  * Transition the radio from Receive to Sleep.
@@ -140,23 +140,23 @@ ThreadError otLinkRawSetPromiscuous(otInstance *aInstance, bool aEnable);
  *
  * @param[in] aInstance  A pointer to an OpenThread instance.
  *
- * @retval kThreadError_None            Successfully transitioned to Sleep.
- * @retval kThreadError_Busy            The radio was transmitting
- * @retval kThreadError_InvalidState    The radio was disabled
+ * @retval OT_ERROR_NONE             Successfully transitioned to Sleep.
+ * @retval OT_ERROR_BUSY             The radio was transmitting
+ * @retval OT_ERROR_INVALID_STATE    The radio was disabled
  *
  */
-ThreadError otLinkRawSleep(otInstance *aInstance);
+otError otLinkRawSleep(otInstance *aInstance);
 
 /**
  * This function pointer on receipt of a IEEE 802.15.4 frame.
  *
  * @param[in]  aInstance    A pointer to an OpenThread instance.
  * @param[in]  aPacket      A pointer to the received packet or NULL if the receive operation was aborted.
- * @param[in]  aaError      kThreadError_None when successfully received a frame.
- *                          kThreadError_Abort when reception was aborted and a frame was not received.
+ * @param[in]  aError       OT_ERROR_NONE when successfully received a frame.
+ *                          OT_ERROR_ABORT when reception was aborted and a frame was not received.
  *
  */
-typedef void (OTCALL *otLinkRawReceiveDone)(otInstance *aInstance, RadioPacket *aPacket, ThreadError aError);
+typedef void (OTCALL *otLinkRawReceiveDone)(otInstance *aInstance, RadioPacket *aPacket, otError aError);
 
 /**
  * Transitioning the radio from Sleep to Receive.
@@ -166,11 +166,11 @@ typedef void (OTCALL *otLinkRawReceiveDone)(otInstance *aInstance, RadioPacket *
  * @param[in]  aChannel     The channel to use for receiving.
  * @param[in]  aCallback    A pointer to a function called on receipt of a IEEE 802.15.4 frame.
  *
- * @retval kThreadError_None            Successfully transitioned to Receive.
- * @retval kThreadError_InvalidState    The radio was disabled or transmitting.
+ * @retval OT_ERROR_NONE             Successfully transitioned to Receive.
+ * @retval OT_ERROR_INVALID_STATE    The radio was disabled or transmitting.
  *
  */
-ThreadError otLinkRawReceive(otInstance *aInstance, uint8_t aChannel, otLinkRawReceiveDone aCallback);
+otError otLinkRawReceive(otInstance *aInstance, uint8_t aChannel, otLinkRawReceiveDone aCallback);
 
 /**
  * The radio transitions from Transmit to Receive.
@@ -192,15 +192,15 @@ RadioPacket *otLinkRawGetTransmitBuffer(otInstance *aInstance);
  * @param[in]  aInstance        A pointer to an OpenThread instance.
  * @param[in]  aPacket          A pointer to the packet that was transmitted.
  * @param[in]  aFramePending    TRUE if an ACK frame was received and the Frame Pending bit was set.
- * @param[in]  aError           kThreadError_None when the frame was transmitted.
- *                              kThreadError_NoAck when the frame was transmitted but no ACK was received
- *                              kThreadError_ChannelAccessFailure when the transmission could not take place
+ * @param[in]  aError           OT_ERROR_NONE when the frame was transmitted.
+ *                              OT_ERROR_NO_ACK when the frame was transmitted but no ACK was received
+ *                              OT_ERROR_CHANNEL_ACCESS_FAILURE when the transmission could not take place
                                     due to activity on the channel.
- *                              kThreadError_Abort when transmission was aborted for other reasons.
+ *                              OT_ERROR_ABORT when transmission was aborted for other reasons.
  *
  */
 typedef void (*otLinkRawTransmitDone)(otInstance *aInstance, RadioPacket *aPacket, bool aFramePending,
-                                      ThreadError aError);
+                                      otError aError);
 
 /**
  * This method begins the transmit sequence on the radio.
@@ -216,11 +216,11 @@ typedef void (*otLinkRawTransmitDone)(otInstance *aInstance, RadioPacket *aPacke
  * @param[in]  aPacket      A pointer to the packet that was transmitted.
  * @param[in]  aCallback    A pointer to a function called on completion of the transmission.
  *
- * @retval kThreadError_None         Successfully transitioned to Transmit.
- * @retval kThreadError_InvalidState The radio was not in the Receive state.
+ * @retval OT_ERROR_NONE          Successfully transitioned to Transmit.
+ * @retval OT_ERROR_INVALID_STATE The radio was not in the Receive state.
  *
  */
-ThreadError otLinkRawTransmit(otInstance *aInstance, RadioPacket *aPacket, otLinkRawTransmitDone aCallback);
+otError otLinkRawTransmit(otInstance *aInstance, RadioPacket *aPacket, otLinkRawTransmitDone aCallback);
 
 /**
  * Get the most recent RSSI measurement.
@@ -259,13 +259,13 @@ typedef void (*otLinkRawEnergyScanDone)(otInstance *aInstance, int8_t aEnergySca
  * @param[in]  aScanDuration    The duration, in milliseconds, for the channel to be scanned.
  * @param[in]  aCallback        A pointer to a function called on completion of a scanned channel.
  *
- * @retval kThreadError_None            Successfully started scanning the channel.
- * @retval kThreadError_NotImplemented  The radio doesn't support energy scanning.
- * @retval kThreadError_InvalidState    If the raw link-layer isn't enabled.
+ * @retval OT_ERROR_NONE             Successfully started scanning the channel.
+ * @retval OT_ERROR_NOT_IMPLEMENTED  The radio doesn't support energy scanning.
+ * @retval OT_ERROR_INVALID_STATE    If the raw link-layer isn't enabled.
  *
  */
-ThreadError otLinkRawEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration,
-                                otLinkRawEnergyScanDone aCallback);
+otError otLinkRawEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration,
+                            otLinkRawEnergyScanDone aCallback);
 
 /**
  * Enable/Disable source match for AutoPend.
@@ -273,11 +273,11 @@ ThreadError otLinkRawEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uin
  * @param[in]  aInstance    A pointer to an OpenThread instance.
  * @param[in]  aEnable      Enable/disable source match for automatical pending.
  *
- * @retval kThreadError_None            If successful.
- * @retval kThreadError_InvalidState    If the raw link-layer isn't enabled.
+ * @retval OT_ERROR_NONE             If successful.
+ * @retval OT_ERROR_INVALID_STATE    If the raw link-layer isn't enabled.
  *
  */
-ThreadError otLinkRawSrcMatchEnable(otInstance *aInstance, bool aEnable);
+otError otLinkRawSrcMatchEnable(otInstance *aInstance, bool aEnable);
 
 /**
  * Adding short address to the source match table.
@@ -285,12 +285,12 @@ ThreadError otLinkRawSrcMatchEnable(otInstance *aInstance, bool aEnable);
  * @param[in]  aInstance        A pointer to an OpenThread instance.
  * @param[in]  aShortAddress    The short address to be added.
  *
- * @retval kThreadError_None            Successfully added short address to the source match table.
- * @retval kThreadError_NoBufs          No available entry in the source match table.
- * @retval kThreadError_InvalidState    If the raw link-layer isn't enabled.
+ * @retval OT_ERROR_NONE             Successfully added short address to the source match table.
+ * @retval OT_ERROR_NO_BUFS          No available entry in the source match table.
+ * @retval OT_ERROR_INVALID_STATE    If the raw link-layer isn't enabled.
  *
  */
-ThreadError otLinkRawSrcMatchAddShortEntry(otInstance *aInstance, const uint16_t aShortAddress);
+otError otLinkRawSrcMatchAddShortEntry(otInstance *aInstance, const uint16_t aShortAddress);
 
 /**
  * Adding extended address to the source match table.
@@ -298,12 +298,12 @@ ThreadError otLinkRawSrcMatchAddShortEntry(otInstance *aInstance, const uint16_t
  * @param[in]  aInstance        A pointer to an OpenThread instance.
  * @param[in]  aExtAddress      The extended address to be added.
  *
- * @retval kThreadError_None            Successfully added extended address to the source match table.
- * @retval kThreadError_NoBufs          No available entry in the source match table.
- * @retval kThreadError_InvalidState    If the raw link-layer isn't enabled.
+ * @retval OT_ERROR_NONE             Successfully added extended address to the source match table.
+ * @retval OT_ERROR_NO_BUFS          No available entry in the source match table.
+ * @retval OT_ERROR_INVALID_STATE    If the raw link-layer isn't enabled.
  *
  */
-ThreadError otLinkRawSrcMatchAddExtEntry(otInstance *aInstance, const uint8_t *aExtAddress);
+otError otLinkRawSrcMatchAddExtEntry(otInstance *aInstance, const uint8_t *aExtAddress);
 
 /**
  * Removing short address to the source match table.
@@ -311,12 +311,12 @@ ThreadError otLinkRawSrcMatchAddExtEntry(otInstance *aInstance, const uint8_t *a
  * @param[in]  aInstance        A pointer to an OpenThread instance.
  * @param[in]  aShortAddress    The short address to be removed.
  *
- * @retval kThreadError_None            Successfully removed short address from the source match table.
- * @retval kThreadError_NoAddress       The short address is not in source match table.
- * @retval kThreadError_InvalidState    If the raw link-layer isn't enabled.
+ * @retval OT_ERROR_NONE             Successfully removed short address from the source match table.
+ * @retval OT_ERROR_NO_ADDRESS       The short address is not in source match table.
+ * @retval OT_ERROR_INVALID_STATE    If the raw link-layer isn't enabled.
  *
  */
-ThreadError otLinkRawSrcMatchClearShortEntry(otInstance *aInstance, const uint16_t aShortAddress);
+otError otLinkRawSrcMatchClearShortEntry(otInstance *aInstance, const uint16_t aShortAddress);
 
 /**
  * Removing extended address to the source match table of the radio.
@@ -324,34 +324,34 @@ ThreadError otLinkRawSrcMatchClearShortEntry(otInstance *aInstance, const uint16
  * @param[in]  aInstance        A pointer to an OpenThread instance.
  * @param[in]  aExtAddress      The extended address to be removed.
  *
- * @retval kThreadError_None            Successfully removed the extended address from the source match table.
- * @retval kThreadError_NoAddress       The extended address is not in source match table.
- * @retval kThreadError_InvalidState    If the raw link-layer isn't enabled.
+ * @retval OT_ERROR_NONE             Successfully removed the extended address from the source match table.
+ * @retval OT_ERROR_NO_ADDRESS       The extended address is not in source match table.
+ * @retval OT_ERROR_INVALID_STATE    If the raw link-layer isn't enabled.
  *
  */
-ThreadError otLinkRawSrcMatchClearExtEntry(otInstance *aInstance, const uint8_t *aExtAddress);
+otError otLinkRawSrcMatchClearExtEntry(otInstance *aInstance, const uint8_t *aExtAddress);
 
 /**
  * Removing all the short addresses from the source match table.
  *
  * @param[in]  aInstance    A pointer to an OpenThread instance.
  *
- * @retval kThreadError_None            If successful.
- * @retval kThreadError_InvalidState    If the raw link-layer isn't enabled.
+ * @retval OT_ERROR_NONE             If successful.
+ * @retval OT_ERROR_INVALID_STATE    If the raw link-layer isn't enabled.
  *
  */
-ThreadError otLinkRawSrcMatchClearShortEntries(otInstance *aInstance);
+otError otLinkRawSrcMatchClearShortEntries(otInstance *aInstance);
 
 /**
  * Removing all the extended addresses from the source match table.
  *
  * @param[in]  aInstance    A pointer to an OpenThread instance.
  *
- * @retval kThreadError_None            If successful.
- * @retval kThreadError_InvalidState    If the raw link-layer isn't enabled.
+ * @retval OT_ERROR_NONE             If successful.
+ * @retval OT_ERROR_INVALID_STATE    If the raw link-layer isn't enabled.
  *
  */
-ThreadError otLinkRawSrcMatchClearExtEntries(otInstance *aInstance);
+otError otLinkRawSrcMatchClearExtEntries(otInstance *aInstance);
 
 /**
  * @}

--- a/include/openthread/message.h
+++ b/include/openthread/message.h
@@ -56,7 +56,7 @@ extern "C" {
  *
  * @param[in]  aMessage  A pointer to a message buffer.
  *
- * @retval kThreadErrorNone  Successfully freed the message buffer.
+ * @retval OT_ERROR_NONE  Successfully freed the message buffer.
  *
  * @sa otMessageAppend
  * @sa otMessageGetLength
@@ -66,7 +66,7 @@ extern "C" {
  * @sa otMessageRead
  * @sa otMessageWrite
  */
-ThreadError otMessageFree(otMessage *aMessage);
+otError otMessageFree(otMessage *aMessage);
 
 /**
  * Get the message length in bytes.
@@ -92,8 +92,8 @@ uint16_t otMessageGetLength(otMessage *aMessage);
  * @param[in]  aMessage  A pointer to a message buffer.
  * @param[in]  aLength   A length in bytes.
  *
- * @retval kThreadErrorNone    Successfully set the message length.
- * @retval kThreadErrorNoBufs  No available buffers to grow the message.
+ * @retval OT_ERROR_NONE     Successfully set the message length.
+ * @retval OT_ERROR_NO_BUFS  No available buffers to grow the message.
  *
  * @sa otMessageFree
  * @sa otMessageAppend
@@ -103,7 +103,7 @@ uint16_t otMessageGetLength(otMessage *aMessage);
  * @sa otMessageRead
  * @sa otMessageWrite
  */
-ThreadError otMessageSetLength(otMessage *aMessage, uint16_t aLength);
+otError otMessageSetLength(otMessage *aMessage, uint16_t aLength);
 
 /**
  * Get the message offset in bytes.
@@ -128,8 +128,8 @@ uint16_t otMessageGetOffset(otMessage *aMessage);
  * @param[in]  aMessage  A pointer to a message buffer.
  * @param[in]  aOffset   An offset in bytes.
  *
- * @retval kThreadErrorNone        Successfully set the message offset.
- * @retval kThreadErrorInvalidArg  The offset is beyond the message length.
+ * @retval OT_ERROR_NONE          Successfully set the message offset.
+ * @retval OT_ERROR_INVALID_ARGS  The offset is beyond the message length.
  *
  * @sa otMessageFree
  * @sa otMessageAppend
@@ -139,7 +139,7 @@ uint16_t otMessageGetOffset(otMessage *aMessage);
  * @sa otMessageRead
  * @sa otMessageWrite
  */
-ThreadError otMessageSetOffset(otMessage *aMessage, uint16_t aOffset);
+otError otMessageSetOffset(otMessage *aMessage, uint16_t aOffset);
 
 /**
  * This function indicates whether or not link security is enabled for the message.
@@ -170,8 +170,8 @@ void otMessageSetDirectTransmission(otMessage *aMessage, bool aEnabled);
  * @param[in]  aBuf      A pointer to the data to append.
  * @param[in]  aLength   Number of bytes to append.
  *
- * @retval kThreadErrorNone    Successfully appended to the message
- * @retval kThreadErrorNoBufs  No available buffers to grow the message.
+ * @retval OT_ERROR_NONE     Successfully appended to the message
+ * @retval OT_ERROR_NO_BUFS  No available buffers to grow the message.
  *
  * @sa otMessageFree
  * @sa otMessageGetLength
@@ -181,7 +181,7 @@ void otMessageSetDirectTransmission(otMessage *aMessage, bool aEnabled);
  * @sa otMessageRead
  * @sa otMessageWrite
  */
-ThreadError otMessageAppend(otMessage *aMessage, const void *aBuf, uint16_t aLength);
+otError otMessageAppend(otMessage *aMessage, const void *aBuf, uint16_t aLength);
 
 /**
  * Read bytes from a message.
@@ -250,11 +250,11 @@ void otMessageQueueInit(otMessageQueue *aQueue);
  * @param[in]  aQueue    A pointer to the message queue.
  * @param[in]  aMessage  The message to add.
  *
- * @retval kThreadError_None     Successfully added the message to the queue.
- * @retval kThreadError_Already  The message is already enqueued in a queue.
+ * @retval OT_ERROR_NONE     Successfully added the message to the queue.
+ * @retval OT_ERROR_ALREADY  The message is already enqueued in a queue.
  *
  */
-ThreadError otMessageQueueEnqueue(otMessageQueue *aQueue, otMessage *aMessage);
+otError otMessageQueueEnqueue(otMessageQueue *aQueue, otMessage *aMessage);
 
 /**
  * This function removes a message from the given message queue.
@@ -262,11 +262,11 @@ ThreadError otMessageQueueEnqueue(otMessageQueue *aQueue, otMessage *aMessage);
  * @param[in]  aQueue    A pointer to the message queue.
  * @param[in]  aMessage  The message to remove.
  *
- * @retval kThreadError_None      Successfully removed the message from the queue.
- * @retval kThreadError_NotFound  The message is not enqueued in this queue.
+ * @retval OT_ERROR_NONE       Successfully removed the message from the queue.
+ * @retval OT_ERROR_NOT_FOUND  The message is not enqueued in this queue.
  *
  */
-ThreadError otMessageQueueDequeue(otMessageQueue *aQueue, otMessage *aMessage);
+otError otMessageQueueDequeue(otMessageQueue *aQueue, otMessage *aMessage);
 
 /**
  * This function returns a pointer to the message at the head of the queue.

--- a/include/openthread/ncp.h
+++ b/include/openthread/ncp.h
@@ -76,12 +76,12 @@ void otNcpInit(otInstance *aInstance);
  *                        If aDataLen is non-zero, this param MUST NOT be NULL.
  * @param[in]  aDataLen   The number of bytes of data from aDataPtr to send.
  *
- * @retval kThreadError_None  The data was queued for delivery to the host.
- * @retval kThreadError_Busy  There are not enough resources to complete this
- *                            request. This is usually a temporary condition.
- * @retval kThreadError_InvalidArgs The given aStreamId was invalid.
+ * @retval OT_ERROR_NONE         The data was queued for delivery to the host.
+ * @retval OT_ERROR_BUSY         There are not enough resources to complete this
+ *                               request. This is usually a temporary condition.
+ * @retval OT_ERROR_INVALID_ARGS The given aStreamId was invalid.
 */
-ThreadError otNcpStreamWrite(int aStreamId, const uint8_t *aDataPtr, int aDataLen);
+otError otNcpStreamWrite(int aStreamId, const uint8_t *aDataPtr, int aDataLen);
 
 
 //-----------------------------------------------------------------------------------------

--- a/include/openthread/netdata.h
+++ b/include/openthread/netdata.h
@@ -57,8 +57,8 @@ extern "C" {
  * @param[inout]  aDataLength  On entry, size of the data buffer pointed to by @p aData.
  *                             On exit, number of copied bytes.
  */
-OTAPI ThreadError OTCALL otNetDataGetLeader(otInstance *aInstance, bool aStable, uint8_t *aData,
-                                            uint8_t *aDataLength);
+OTAPI otError OTCALL otNetDataGetLeader(otInstance *aInstance, bool aStable, uint8_t *aData,
+                                        uint8_t *aDataLength);
 
 /**
  * This method provides a full or stable copy of the local Thread Network Data.
@@ -69,8 +69,8 @@ OTAPI ThreadError OTCALL otNetDataGetLeader(otInstance *aInstance, bool aStable,
  * @param[inout]  aDataLength  On entry, size of the data buffer pointed to by @p aData.
  *                             On exit, number of copied bytes.
  */
-OTAPI ThreadError OTCALL otNetDataGetLocal(otInstance *aInstance, bool aStable, uint8_t *aData,
-                                           uint8_t *aDataLength);
+OTAPI otError OTCALL otNetDataGetLocal(otInstance *aInstance, bool aStable, uint8_t *aData,
+                                       uint8_t *aDataLength);
 
 /**
  * This function gets the next On Mesh Prefix in the Network Data.
@@ -81,12 +81,12 @@ OTAPI ThreadError OTCALL otNetDataGetLocal(otInstance *aInstance, bool aStable, 
                              it should be set to OT_NETWORK_DATA_ITERATOR_INIT.
  * @param[out]    aConfig    A pointer to where the On Mesh Prefix information will be placed.
  *
- * @retval kThreadError_None      Successfully found the next On Mesh prefix.
- * @retval kThreadError_NotFound  No subsequent On Mesh prefix exists in the Thread Network Data.
+ * @retval OT_ERROR_NONE       Successfully found the next On Mesh prefix.
+ * @retval OT_ERROR_NOT_FOUND  No subsequent On Mesh prefix exists in the Thread Network Data.
  *
  */
-OTAPI ThreadError OTCALL otNetDataGetNextPrefixInfo(otInstance *aInstance, bool aLocal,
-                                                    otNetworkDataIterator *aIterator, otBorderRouterConfig *aConfig);
+OTAPI otError OTCALL otNetDataGetNextPrefixInfo(otInstance *aInstance, bool aLocal,
+                                                otNetworkDataIterator *aIterator, otBorderRouterConfig *aConfig);
 
 /**
  * Add a border router configuration to the local network data.
@@ -94,14 +94,14 @@ OTAPI ThreadError OTCALL otNetDataGetNextPrefixInfo(otInstance *aInstance, bool 
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aConfig   A pointer to the border router configuration.
  *
- * @retval kThreadErrorNone         Successfully added the configuration to the local network data.
- * @retval kThreadErrorInvalidArgs  One or more configuration parameters were invalid.
- * @retval kThreadErrorSize         Not enough room is available to add the configuration to the local network data.
+ * @retval OT_ERROR_NONE          Successfully added the configuration to the local network data.
+ * @retval OT_ERROR_INVALID_ARGS  One or more configuration parameters were invalid.
+ * @retval OT_ERROR_NO_BUFS       Not enough room is available to add the configuration to the local network data.
  *
  * @sa otRemoveBorderRouter
  * @sa otSendServerData
  */
-OTAPI ThreadError OTCALL otNetDataAddPrefixInfo(otInstance *aInstance, const otBorderRouterConfig *aConfig);
+OTAPI otError OTCALL otNetDataAddPrefixInfo(otInstance *aInstance, const otBorderRouterConfig *aConfig);
 
 /**
  * Remove a border router configuration from the local network data.
@@ -109,12 +109,12 @@ OTAPI ThreadError OTCALL otNetDataAddPrefixInfo(otInstance *aInstance, const otB
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aPrefix   A pointer to an IPv6 prefix.
  *
- * @retval kThreadErrorNone  Successfully removed the configuration from the local network data.
+ * @retval OT_ERROR_NONE  Successfully removed the configuration from the local network data.
  *
  * @sa otAddBorderRouter
  * @sa otSendServerData
  */
-OTAPI ThreadError OTCALL otNetDataRemovePrefixInfo(otInstance *aInstance, const otIp6Prefix *aPrefix);
+OTAPI otError OTCALL otNetDataRemovePrefixInfo(otInstance *aInstance, const otIp6Prefix *aPrefix);
 
 /**
  * Add an external route configuration to the local network data.
@@ -122,14 +122,14 @@ OTAPI ThreadError OTCALL otNetDataRemovePrefixInfo(otInstance *aInstance, const 
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aConfig   A pointer to the external route configuration.
  *
- * @retval kThreadErrorNone         Successfully added the configuration to the local network data.
- * @retval kThreadErrorInvalidArgs  One or more configuration parameters were invalid.
- * @retval kThreadErrorSize         Not enough room is available to add the configuration to the local network data.
+ * @retval OT_ERROR_NONE          Successfully added the configuration to the local network data.
+ * @retval OT_ERROR_INVALID_ARGS  One or more configuration parameters were invalid.
+ * @retval OT_ERROR_NO_BUFS       Not enough room is available to add the configuration to the local network data.
  *
  * @sa otRemoveExternalRoute
  * @sa otSendServerData
  */
-OTAPI ThreadError OTCALL otNetDataAddRoute(otInstance *aInstance, const otExternalRouteConfig *aConfig);
+OTAPI otError OTCALL otNetDataAddRoute(otInstance *aInstance, const otExternalRouteConfig *aConfig);
 
 /**
  * Remove an external route configuration from the local network data.
@@ -137,12 +137,12 @@ OTAPI ThreadError OTCALL otNetDataAddRoute(otInstance *aInstance, const otExtern
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aPrefix   A pointer to an IPv6 prefix.
  *
- * @retval kThreadErrorNone  Successfully removed the configuration from the local network data.
+ * @retval OT_ERROR_NONE  Successfully removed the configuration from the local network data.
  *
  * @sa otAddExternalRoute
  * @sa otSendServerData
  */
-OTAPI ThreadError OTCALL otNetDataRemoveRoute(otInstance *aInstance, const otIp6Prefix *aPrefix);
+OTAPI otError OTCALL otNetDataRemoveRoute(otInstance *aInstance, const otIp6Prefix *aPrefix);
 
 /**
  * This function gets the next external route in the Network Data.
@@ -153,26 +153,26 @@ OTAPI ThreadError OTCALL otNetDataRemoveRoute(otInstance *aInstance, const otIp6
                              it should be set to OT_NETWORK_DATA_ITERATOR_INIT.
  * @param[out]    aConfig    A pointer to where the External Route information will be placed.
  *
- * @retval kThreadError_None      Successfully found the next External Route.
- * @retval kThreadError_NotFound  No subsequent external route entry exists in the Thread Network Data.
+ * @retval OT_ERROR_NONE       Successfully found the next External Route.
+ * @retval OT_ERROR_NOT_FOUND  No subsequent external route entry exists in the Thread Network Data.
  *
  */
-ThreadError otNetDataGetNextRoute(otInstance *aInstance, bool aLocal, otNetworkDataIterator *aIterator,
-                                  otExternalRouteConfig *aConfig);
+otError otNetDataGetNextRoute(otInstance *aInstance, bool aLocal, otNetworkDataIterator *aIterator,
+                              otExternalRouteConfig *aConfig);
 
 /**
  * Immediately register the local network data with the Leader.
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.
  *
- * retval kThreadErrorNone  Successfully queued a Server Data Request message for delivery.
+ * retval OT_ERROR_NONE  Successfully queued a Server Data Request message for delivery.
  *
  * @sa otAddBorderRouter
  * @sa otRemoveBorderRouter
  * @sa otAddExternalRoute
  * @sa otRemoveExternalRoute
  */
-OTAPI ThreadError OTCALL otNetDataRegister(otInstance *aInstance);
+OTAPI otError OTCALL otNetDataRegister(otInstance *aInstance);
 
 /**
  * Get the Network Data Version.

--- a/include/openthread/openthread.h
+++ b/include/openthread/openthread.h
@@ -154,14 +154,14 @@ extern "C" {
 OTAPI const char *OTCALL otGetVersionString(void);
 
 /**
- * This function converts a ThreadError enum into a string.
+ * This function converts a otError enum into a string.
  *
- * @param[in]  aError     A ThreadError enum.
+ * @param[in]  aError     A otError enum.
  *
  * @returns  A string representation of a ThreadError.
  *
  */
-OTAPI const char *OTCALL otThreadErrorToString(ThreadError aError);
+OTAPI const char *OTCALL otThreadErrorToString(otError aError);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/openthread/platform/diag.h
+++ b/include/openthread/platform/diag.h
@@ -108,7 +108,7 @@ void otPlatDiagTxPowerSet(int8_t aTxPower);
  * @param[in]   aError      The received radio frame status.
  *
  */
-void otPlatDiagRadioReceived(otInstance *aInstance, RadioPacket *aFrame, ThreadError aError);
+void otPlatDiagRadioReceived(otInstance *aInstance, RadioPacket *aFrame, otError aError);
 
 /**
  * This function processes the alarm event.

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -219,19 +219,19 @@ PhyState otPlatRadioGetState(otInstance *aInstance);
  *
  * @param[in] aInstance  The OpenThread instance structure.
  *
- * @retval kThreadError_None     Successfully enabled.
- * @retval kThreadError_Failure  The radio could not be enabled.
+ * @retval OT_ERROR_NONE     Successfully enabled.
+ * @retval OT_ERROR_FAILED   The radio could not be enabled.
  */
-ThreadError otPlatRadioEnable(otInstance *aInstance);
+otError otPlatRadioEnable(otInstance *aInstance);
 
 /**
  * Disable the radio.
  *
  * @param[in] aInstance  The OpenThread instance structure.
  *
- * @retval kThreadError_None  Successfully transitioned to Disabled.
+ * @retval OT_ERROR_NONE  Successfully transitioned to Disabled.
  */
-ThreadError otPlatRadioDisable(otInstance *aInstance);
+otError otPlatRadioDisable(otInstance *aInstance);
 
 /**
  * Check whether radio is enabled or not.
@@ -249,11 +249,11 @@ bool otPlatRadioIsEnabled(otInstance *aInstance);
  *
  * @param[in] aInstance  The OpenThread instance structure.
  *
- * @retval kThreadError_None         Successfully transitioned to Sleep.
- * @retval kThreadError_Busy         The radio was transmitting
- * @retval kThreadError_InvalidState The radio was disabled
+ * @retval OT_ERROR_NONE          Successfully transitioned to Sleep.
+ * @retval OT_ERROR_BUSY          The radio was transmitting
+ * @retval OT_ERROR_INVALID_STATE The radio was disabled
  */
-ThreadError otPlatRadioSleep(otInstance *aInstance);
+otError otPlatRadioSleep(otInstance *aInstance);
 
 /**
  * Transitioning the radio from Sleep to Receive.
@@ -262,10 +262,10 @@ ThreadError otPlatRadioSleep(otInstance *aInstance);
  * @param[in]  aInstance  The OpenThread instance structure.
  * @param[in]  aChannel   The channel to use for receiving.
  *
- * @retval kThreadError_None         Successfully transitioned to Receive.
- * @retval kThreadError_InvalidState The radio was disabled or transmitting.
+ * @retval OT_ERROR_NONE          Successfully transitioned to Receive.
+ * @retval OT_ERROR_INVALID_STATE The radio was disabled or transmitting.
  */
-ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel);
+otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel);
 
 /**
  * Enable/Disable source address match feature.
@@ -292,10 +292,10 @@ void otPlatRadioEnableSrcMatch(otInstance *aInstance, bool aEnable);
  * @param[in]  aInstance      The OpenThread instance structure.
  * @param[in]  aShortAddress  The short address to be added.
  *
- * @retval kThreadError_None     Successfully added short address to the source match table.
- * @retval kThreadError_NoBufs   No available entry in the source match table.
+ * @retval OT_ERROR_NONE      Successfully added short address to the source match table.
+ * @retval OT_ERROR_NO_BUFS   No available entry in the source match table.
  */
-ThreadError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress);
+otError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress);
 
 /**
  * Add an extended address to the source address match table.
@@ -303,10 +303,10 @@ ThreadError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16
  * @param[in]  aInstance    The OpenThread instance structure.
  * @param[in]  aExtAddress  The extended address to be added.
  *
- * @retval kThreadError_None     Successfully added extended address to the source match table.
- * @retval kThreadError_NoBufs   No available entry in the source match table.
+ * @retval OT_ERROR_NONE      Successfully added extended address to the source match table.
+ * @retval OT_ERROR_NO_BUFS   No available entry in the source match table.
  */
-ThreadError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress);
+otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress);
 
 /**
  * Remove a short address from the source address match table.
@@ -314,10 +314,10 @@ ThreadError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t 
  * @param[in]  aInstance      The OpenThread instance structure.
  * @param[in]  aShortAddress  The short address to be removed.
  *
- * @retval kThreadError_None        Successfully removed short address from the source match table.
- * @retval kThreadError_NoAddress   The short address is not in source address match table.
+ * @retval OT_ERROR_NONE        Successfully removed short address from the source match table.
+ * @retval OT_ERROR_NO_ADDRESS  The short address is not in source address match table.
  */
-ThreadError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress);
+otError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress);
 
 /**
  * Remove an extended address from the source address match table.
@@ -325,10 +325,10 @@ ThreadError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint
  * @param[in]  aInstance    The OpenThread instance structure.
  * @param[in]  aExtAddress  The extended address to be removed.
  *
- * @retval kThreadError_None        Successfully removed the extended address from the source match table.
- * @retval kThreadError_NoAddress   The extended address is not in source address match table.
+ * @retval OT_ERROR_NONE        Successfully removed the extended address from the source match table.
+ * @retval OT_ERROR_NO_ADDRESS  The extended address is not in source address match table.
  */
-ThreadError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress);
+otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress);
 
 /**
  * Clear all short addresses from the source address match table.
@@ -351,12 +351,12 @@ void otPlatRadioClearSrcMatchExtEntries(otInstance *aInstance);
  *
  * @param[in]  aInstance The OpenThread instance structure.
  * @param[in]  aPacket   A pointer to the received packet or NULL if the receive operation failed.
- * @param[in]  aError    kThreadError_None when successfully received a frame, kThreadError_Abort when reception
- *                       was aborted and a frame was not received, kThreadError_NoBufs when a frame could not be
+ * @param[in]  aError    OT_ERROR_NONE when successfully received a frame, OT_ERROR_ABORT when reception
+ *                       was aborted and a frame was not received, OT_ERROR_NO_BUFS when a frame could not be
  *                       received due to lack of rx buffer space.
  *
  */
-extern void otPlatRadioReceiveDone(otInstance *aInstance, RadioPacket *aPacket, ThreadError aError);
+extern void otPlatRadioReceiveDone(otInstance *aInstance, RadioPacket *aPacket, otError aError);
 
 /**
  * The radio transitions from Transmit to Receive.
@@ -384,10 +384,10 @@ RadioPacket *otPlatRadioGetTransmitBuffer(otInstance *aInstance);
  * @param[in] aInstance  The OpenThread instance structure.
  * @param[in] aPacket    A pointer to the packet that will be transmitted.
  *
- * @retval kThreadError_None         Successfully transitioned to Transmit.
- * @retval kThreadError_InvalidState The radio was not in the Receive state.
+ * @retval OT_ERROR_NONE          Successfully transitioned to Transmit.
+ * @retval OT_ERROR_INVALID_STATE The radio was not in the Receive state.
  */
-ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket);
+otError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket);
 
 /**
  * The radio driver calls this method to notify OpenThread that the transmission has completed.
@@ -395,14 +395,14 @@ ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket);
  * @param[in]  aInstance      The OpenThread instance structure.
  * @param[in]  aPacket        A pointer to the packet that was transmitted.
  * @param[in]  aFramePending  TRUE if an ACK frame was received and the Frame Pending bit was set.
- * @param[in]  aError  kThreadError_None when the frame was transmitted, kThreadError_NoAck when the frame was
- *                     transmitted but no ACK was received, kThreadError_ChannelAccessFailure when the transmission
- *                     could not take place due to activity on the channel, kThreadError_Abort when transmission was
+ * @param[in]  aError  OT_ERROR_NONE when the frame was transmitted, OT_ERROR_NO_ACK when the frame was
+ *                     transmitted but no ACK was received, OT_ERROR_CHANNEL_ACCESS_FAILURE when the transmission
+ *                     could not take place due to activity on the channel, OT_ERROR_ABORT when transmission was
  *                     aborted for other reasons.
  *
  */
 extern void otPlatRadioTransmitDone(otInstance *aInstance, RadioPacket *aPacket, bool aFramePending,
-                                    ThreadError aError);
+                                    otError aError);
 
 /**
  * Get the most recent RSSI measurement.
@@ -455,26 +455,26 @@ void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable);
  * @param[in]  aInstance      The OpenThread instance structure.
  * @param[in]  aPacket        A pointer to the packet that was transmitted.
  * @param[in]  aFramePending  TRUE if an ACK frame was received and the Frame Pending bit was set.
- * @param[in]  aError  kThreadError_None when the frame was transmitted, kThreadError_NoAck when the frame was
- *                     transmitted but no ACK was received, kThreadError_ChannelAccessFailure when the transmission
- *                     could not take place due to activity on the channel, kThreadError_Abort when transmission was
+ * @param[in]  aError  OT_ERROR_NONE when the frame was transmitted, OT_ERROR_NO_ACK when the frame was
+ *                     transmitted but no ACK was received, OT_ERROR_CHANNEL_ACCESS_FAILURE when the transmission
+ *                     could not take place due to activity on the channel, OT_ERROR_ABORT when transmission was
  *                     aborted for other reasons.
  *
  */
 extern void otPlatDiagRadioTransmitDone(otInstance *aInstance, RadioPacket *aPacket, bool aFramePending,
-                                        ThreadError aError);
+                                        otError aError);
 
 /**
  * The radio driver calls this method to notify OpenThread diagnostics module of a received packet.
  *
  * @param[in]  aInstance The OpenThread instance structure.
  * @param[in]  aPacket   A pointer to the received packet or NULL if the receive operation failed.
- * @param[in]  aError    kThreadError_None when successfully received a frame, kThreadError_Abort when reception
- *                       was aborted and a frame was not received, kThreadError_NoBufs when a frame could not be
+ * @param[in]  aError    OT_ERROR_NONE when successfully received a frame, OT_ERROR_ABORT when reception
+ *                       was aborted and a frame was not received, OT_ERROR_NO_BUFS when a frame could not be
  *                       received due to lack of rx buffer space.
  *
  */
-extern void otPlatDiagRadioReceiveDone(otInstance *aInstance, RadioPacket *aPacket, ThreadError aError);
+extern void otPlatDiagRadioReceiveDone(otInstance *aInstance, RadioPacket *aPacket, otError aError);
 
 /**
  * This method begins the energy scan sequence on the radio.
@@ -483,10 +483,10 @@ extern void otPlatDiagRadioReceiveDone(otInstance *aInstance, RadioPacket *aPack
  * @param[in] aScanChannel   The channel to perform the energy scan on.
  * @param[in] aScanDuration  The duration, in milliseconds, for the channel to be scanned.
  *
- * @retval kThreadError_None            Successfully started scanning the channel.
- * @retval kThreadError_NotImplemented  The radio doesn't support energy scanning.
+ * @retval OT_ERROR_NONE             Successfully started scanning the channel.
+ * @retval OT_ERROR_NOT_IMPLEMENTED  The radio doesn't support energy scanning.
  */
-ThreadError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration);
+otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration);
 
 /**
  * The radio driver calls this method to notify OpenThread that the energy scan is complete.

--- a/include/openthread/platform/random.h
+++ b/include/openthread/platform/random.h
@@ -71,12 +71,12 @@ uint32_t otPlatRandomGet(void);
  * @param[out]  aOutput              A pointer to where the true random values are placed.  Must not be NULL.
  * @param[in]   aOutputLength        Size of @p aBuffer.
  *
- * @retval kThreadError_None         Successfully filled @p aBuffer with true random values.
- * @retval kThreadError_Fail         Failed to fill @p aBuffer with true random values.
- * @retval kThreadError_InvalidArgs  @p aBuffer was set to NULL.
+ * @retval OT_ERROR_NONE          Successfully filled @p aBuffer with true random values.
+ * @retval OT_ERROR_FAILED         Failed to fill @p aBuffer with true random values.
+ * @retval OT_ERROR_INVALID_ARGS  @p aBuffer was set to NULL.
  *
  */
-ThreadError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength);
+otError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength);
 
 /**
  * @}

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -71,38 +71,38 @@ void otPlatSettingsInit(otInstance *aInstance);
  *  called.
  *
  *  The implementation of this function is optional. If not
- *  implemented, it should return kThreadError_None.
+ *  implemented, it should return OT_ERROR_NONE.
  *
  * @param[in]  aInstance
  *             The OpenThread instance structure.
  *
- *  @retval kThreadError_None    The settings commit lock has been set.
- *  @retval kThreadError_Already The commit lock is already set.
+ *  @retval OT_ERROR_NONE    The settings commit lock has been set.
+ *  @retval OT_ERROR_ALREADY The commit lock is already set.
  *
  *  @sa otPlatSettingsCommitChange(), otPlatSettingsAbandonChange()
  */
-ThreadError otPlatSettingsBeginChange(otInstance *aInstance);
+otError otPlatSettingsBeginChange(otInstance *aInstance);
 
 /// Commit all settings changes since previous call to otPlatSettingsBeginChange()
 /** This function is called at the end of a sequence of changes.
  *  The implementation of this function is optional. If not
- *  implemented, it should return kThreadError_NotImplemented.
+ *  implemented, it should return OT_ERROR_NOT_IMPLEMENTED.
  *
  *  @param[in]  aInstance
  *              The OpenThread instance structure.
  *
- *  @retval kThreadError_None
+ *  @retval OT_ERROR_NONE
  *          The changes made since the last call to
  *          otPlatSettingsBeginChange() have been successfully
  *          committed.
- *  @retval kThreadError_InvalidState
+ *  @retval OT_ERROR_INVALID_STATE
  *          otPlatSettingsBeginChange() has not been called.
- *  @retval kThreadError_NotImplemented
+ *  @retval OT_ERROR_NOT_IMPLEMENTED
  *          This function is not implemented on this platform.
  *
  *  @sa otPlatSettingsBeginChange(), otPlatSettingsAbandonChange()
  */
-ThreadError otPlatSettingsCommitChange(otInstance *aInstance);
+otError otPlatSettingsCommitChange(otInstance *aInstance);
 
 /// Abandon all settings changes since previous call to otPlatSettingsBeginChange()
 /** This function may be called at the end of a sequence of changes.
@@ -111,23 +111,23 @@ ThreadError otPlatSettingsCommitChange(otInstance *aInstance);
  *  rolled back and abandoned.
  *
  *  The implementation of this function is optional. If not
- *  implemented, it should return kThreadError_NotImplemented.
+ *  implemented, it should return OT_ERROR_NOT_IMPLEMENTED.
  *
  *  @param[in]  aInstance
  *              The OpenThread instance structure.
  *
- *  @retval kThreadError_None
+ *  @retval OT_ERROR_NONE
  *          The changes made since the last call to
  *          otPlatSettingsBeginChange() have been successfully
  *          rolled back.
- *  @retval kThreadError_InvalidState
+ *  @retval OT_ERROR_INVALID_STATE
  *          otPlatSettingsBeginChange() has not been called.
- *  @retval kThreadError_NotImplemented
+ *  @retval OT_ERROR_NOT_IMPLEMENTED
  *          This function is not implemented on this platform.
  *
  *  @sa otPlatSettingsBeginChange(), otPlatSettingsCommitChange()
  */
-ThreadError otPlatSettingsAbandonChange(otInstance *aInstance);
+otError otPlatSettingsAbandonChange(otInstance *aInstance);
 
 /// Fetches the value of a setting
 /** This function fetches the value of the setting identified
@@ -165,15 +165,15 @@ ThreadError otPlatSettingsAbandonChange(otInstance *aInstance);
  *                 length of the setting is written. This may be
  *                 set to NULL if performing a presence check.
  *
- *  @retval kThreadError_None
+ *  @retval OT_ERROR_NONE
  *          The given setting was found and fetched successfully.
- *  @retval kThreadError_NotFound
+ *  @retval OT_ERROR_NOT_FOUND
  *          The given setting was not found in the setting store.
- *  @retval kThreadError_NotImplemented
+ *  @retval OT_ERROR_NOT_IMPLEMENTED
  *          This function is not implemented on this platform.
  */
-ThreadError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue,
-                              uint16_t *aValueLength);
+otError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue,
+                          uint16_t *aValueLength);
 
 /// Sets or replaces the value of a setting
 /** This function sets or replaces the value of a setting
@@ -196,12 +196,12 @@ ThreadError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, 
  *              The length of the data pointed to by aValue.
  *              May be zero.
  *
- *  @retval kThreadError_None
+ *  @retval OT_ERROR_NONE
  *          The given setting was changed or staged.
- *  @retval kThreadError_NotImplemented
+ *  @retval OT_ERROR_NOT_IMPLEMENTED
  *          This function is not implemented on this platform.
  */
-ThreadError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
+otError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
 
 /// Adds a value to a setting
 /** This function adds the value to a setting
@@ -229,12 +229,12 @@ ThreadError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_
  *                The length of the data pointed to by aValue.
  *                May be zero.
  *
- * @retval kThreadError_None
+ * @retval OT_ERROR_NONE
  *         The given setting was added or staged to be added.
- * @retval kThreadError_NotImplemented
+ * @retval OT_ERROR_NOT_IMPLEMENTED
  *         This function is not implemented on this platform.
  */
-ThreadError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
+otError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
 
 /// Removes a setting from the setting store
 /** This function deletes a specific value from the
@@ -252,14 +252,14 @@ ThreadError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_
  *             The index of the value to be removed. If set to
  *             -1, all values for this aKey will be removed.
  *
- *  @retval kThreadError_None
+ *  @retval OT_ERROR_NONE
  *          The given key and index was found and removed successfully.
- *  @retval kThreadError_NotFound
+ *  @retval OT_ERROR_NOT_FOUND
  *          The given key or index  was not found in the setting store.
- *  @retval kThreadError_NotImplemented
+ *  @retval OT_ERROR_NOT_IMPLEMENTED
  *          This function is not implemented on this platform.
  */
-ThreadError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex);
+otError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex);
 
 /// Removes all settings from the setting store
 /** This function deletes all settings from the settings

--- a/include/openthread/platform/spi-slave.h
+++ b/include/openthread/platform/spi-slave.h
@@ -87,12 +87,12 @@ typedef void (*otPlatSpiSlaveTransactionCompleteCallback)(void *aContext, uint8_
  * @param[in] aCallback          Pointer to transaction complete callback.
  * @param[in] aContext           Context pointer to be passed to transaction complete callback.
  *
- * @retval kThreadError_None     Successfully enabled the SPI Slave interface.
- * @retval kThreadError_Already  SPI Slave interface is already enabled.
- * @retval kThreadError_Failed   Failed to enable the SPI Slave interface.
+ * @retval OT_ERROR_NONE     Successfully enabled the SPI Slave interface.
+ * @retval OT_ERROR_ALREADY  SPI Slave interface is already enabled.
+ * @retval OT_ERROR_FAILED   Failed to enable the SPI Slave interface.
  *
  */
-ThreadError otPlatSpiSlaveEnable(otPlatSpiSlaveTransactionCompleteCallback aCallback, void *aContext);
+otError otPlatSpiSlaveEnable(otPlatSpiSlaveTransactionCompleteCallback aCallback, void *aContext);
 
 /**
  * Shutdown and disable the SPI slave interface.
@@ -122,7 +122,7 @@ void otPlatSpiSlaveDisable(void);
 * 30 bytes, the value 30 is passed to the transaction complete callback.
  *
  * Any call to this function while a transaction is in progress will cause all of the arguments to be ignored and the
- * return value to be `kThreadError_Busy`.
+ * return value to be `OT_ERROR_BUSY`.
  *
  * @param[in] aOutputBuf              Data to be written to MISO pin
  * @param[in] aOutputBufLen           Size of the output buffer, in bytes
@@ -130,13 +130,13 @@ void otPlatSpiSlaveDisable(void);
  * @param[in] aInputBufLen            Size of the input buffer, in bytes
  * @param[in] aRequestTransactionFlag Set to true if host interrupt should be set
  *
- * @retval kThreadError_None          Transaction was successfully prepared.
- * @retval kThreadError_Busy          A transaction is currently in progress.
- * @retval kThreadError_InvalidState  otPlatSpiSlaveEnable() hasn't been called.
+ * @retval OT_ERROR_NONE           Transaction was successfully prepared.
+ * @retval OT_ERROR_BUSY           A transaction is currently in progress.
+ * @retval OT_ERROR_INVALID_STATE  otPlatSpiSlaveEnable() hasn't been called.
  *
  */
-ThreadError otPlatSpiSlavePrepareTransaction(uint8_t *aOutputBuf, uint16_t aOutputBufLen, uint8_t *aInputBuf,
-                                             uint16_t aInputBufLen, bool aRequestTransactionFlag);
+otError otPlatSpiSlavePrepareTransaction(uint8_t *aOutputBuf, uint16_t aOutputBufLen, uint8_t *aInputBuf,
+                                         uint16_t aInputBufLen, bool aRequestTransactionFlag);
 
 /**
  * @}

--- a/include/openthread/platform/uart.h
+++ b/include/openthread/platform/uart.h
@@ -56,20 +56,20 @@ extern "C" {
 /**
  * Enable the UART.
  *
- * @retval kThreadError_None    Successfully enabled the UART.
- * @retval kThreadError_Failed  Failed to enabled the UART.
+ * @retval OT_ERROR_NONE    Successfully enabled the UART.
+ * @retval OT_ERROR_FAILED  Failed to enabled the UART.
  *
  */
-ThreadError otPlatUartEnable(void);
+otError otPlatUartEnable(void);
 
 /**
  * Disable the UART.
  *
- * @retval kThreadError_None    Successfully disabled the UART.
- * @retval kThreadError_Failed  Failed to disable the UART.
+ * @retval OT_ERROR_NONE    Successfully disabled the UART.
+ * @retval OT_ERROR_FAILED  Failed to disable the UART.
  *
  */
-ThreadError otPlatUartDisable(void);
+otError otPlatUartDisable(void);
 
 /**
  * Send bytes over the UART.
@@ -77,11 +77,11 @@ ThreadError otPlatUartDisable(void);
  * @param[in] aBuf        A pointer to the data buffer.
  * @param[in] aBufLength  Number of bytes to transmit.
  *
- * @retval kThreadError_None    Successfully started transmission.
- * @retval kThreadError_Failed  Failed to start the transmission.
+ * @retval OT_ERROR_NONE    Successfully started transmission.
+ * @retval OT_ERROR_FAILED  Failed to start the transmission.
  *
  */
-ThreadError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength);
+otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength);
 
 /**
  * The UART driver calls this method to notify OpenThread that the requested bytes have been sent.

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -58,11 +58,11 @@ extern "C" {
  * @param[in] aInstance A pointer to an OpenThread instance.
  * @param[in] aEnabled  TRUE if Thread is enabled, FALSE otherwise.
  *
- * @retval kThreadError_None          Successfully started Thread protocol operation.
- * @retval kThreadError_InvalidState  The network interface was not not up.
+ * @retval OT_ERROR_NONE           Successfully started Thread protocol operation.
+ * @retval OT_ERROR_INVALID_STATE  The network interface was not not up.
  *
  */
-OTAPI ThreadError OTCALL otThreadSetEnabled(otInstance *aInstance, bool aEnabled);
+OTAPI otError OTCALL otThreadSetEnabled(otInstance *aInstance, bool aEnabled);
 
 /**
  * This function queries if the Thread stack is configured to automatically start on reinitialization.
@@ -83,7 +83,7 @@ OTAPI bool OTCALL otThreadGetAutoStart(otInstance *aInstance);
  * @param[in] aStartAutomatically   TRUE to automatically start; FALSE to not automatically start.
  *
  */
-OTAPI ThreadError OTCALL otThreadSetAutoStart(otInstance *aInstance, bool aStartAutomatically);
+OTAPI otError OTCALL otThreadSetAutoStart(otInstance *aInstance, bool aStartAutomatically);
 
 /**
  * This function indicates whether a node is the only router on the network.
@@ -108,13 +108,13 @@ OTAPI bool OTCALL otThreadIsSingleton(otInstance *aInstance);
  *                                    scan completes.
  * @param[in]  aCallbackContext       A pointer to application-specific context.
  *
- * @retval kThreadError_None  Accepted the Thread Discovery request.
- * @retval kThreadError_Busy  Already performing an Thread Discovery.
+ * @retval OT_ERROR_NONE  Accepted the Thread Discovery request.
+ * @retval OT_ERROR_BUSY  Already performing an Thread Discovery.
  *
  */
-OTAPI ThreadError OTCALL otThreadDiscover(otInstance *aInstance, uint32_t aScanChannels, uint16_t aPanid, bool aJoiner,
-                                          bool aEnableEui64Filtering, otHandleActiveScanResult aCallback,
-                                          void *aCallbackContext);
+OTAPI otError OTCALL otThreadDiscover(otInstance *aInstance, uint32_t aScanChannels, uint16_t aPanid, bool aJoiner,
+                                      bool aEnableEui64Filtering, otHandleActiveScanResult aCallback,
+                                      void *aCallbackContext);
 
 /**
  * This function determines if an MLE Thread Discovery is currently in progress.
@@ -167,12 +167,12 @@ OTAPI const uint8_t *OTCALL otThreadGetExtendedPanId(otInstance *aInstance);
  * @param[in]  aInstance       A pointer to an OpenThread instance.
  * @param[in]  aExtendedPanId  A pointer to the IEEE 802.15.4 Extended PAN ID.
  *
- * @retval kThreadError_None          Successfully set the Extended PAN ID.
- * @retval kThreadError_InvalidState  Thread protocols are enabled.
+ * @retval OT_ERROR_NONE           Successfully set the Extended PAN ID.
+ * @retval OT_ERROR_INVALID_STATE  Thread protocols are enabled.
  *
  * @sa otThreadGetExtendedPanId
  */
-OTAPI ThreadError OTCALL otThreadSetExtendedPanId(otInstance *aInstance, const uint8_t *aExtendedPanId);
+OTAPI otError OTCALL otThreadSetExtendedPanId(otInstance *aInstance, const uint8_t *aExtendedPanId);
 
 /**
  * This function returns a pointer to the Leader's RLOC.
@@ -180,12 +180,12 @@ OTAPI ThreadError OTCALL otThreadSetExtendedPanId(otInstance *aInstance, const u
  * @param[in]   aInstance    A pointer to an OpenThread instance.
  * @param[out]  aLeaderRloc  A pointer to where the Leader's RLOC will be written.
  *
- * @retval kThreadError_None         The Leader's RLOC was successfully written to @p aLeaderRloc.
- * @retval kThreadError_InvalidArgs  @p aLeaderRloc was NULL.
- * @retval kThreadError_Detached     Not currently attached to a Thread Partition.
+ * @retval OT_ERROR_NONE          The Leader's RLOC was successfully written to @p aLeaderRloc.
+ * @retval OT_ERROR_INVALID_ARGS  @p aLeaderRloc was NULL.
+ * @retval OT_ERROR_DETACHED      Not currently attached to a Thread Partition.
  *
  */
-OTAPI ThreadError OTCALL otThreadGetLeaderRloc(otInstance *aInstance, otIp6Address *aLeaderRloc);
+OTAPI otError OTCALL otThreadGetLeaderRloc(otInstance *aInstance, otIp6Address *aLeaderRloc);
 
 /**
  * Get the MLE Link Mode configuration.
@@ -204,11 +204,11 @@ OTAPI otLinkModeConfig OTCALL otThreadGetLinkMode(otInstance *aInstance);
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aConfig   A pointer to the Link Mode configuration.
  *
- * @retval kThreadErrorNone  Successfully set the MLE Link Mode configuration.
+ * @retval OT_ERROR_NONE  Successfully set the MLE Link Mode configuration.
  *
  * @sa otThreadGetLinkMode
  */
-OTAPI ThreadError OTCALL otThreadSetLinkMode(otInstance *aInstance, otLinkModeConfig aConfig);
+OTAPI otError OTCALL otThreadSetLinkMode(otInstance *aInstance, otLinkModeConfig aConfig);
 
 /**
  * Get the thrMasterKey.
@@ -231,13 +231,13 @@ OTAPI const otMasterKey *OTCALL otThreadGetMasterKey(otInstance *aInstance);
  * @param[in]  aInstance   A pointer to an OpenThread instance.
  * @param[in]  aKey        A pointer to a buffer containing the thrMasterKey.
  *
- * @retval kThreadErrorNone           Successfully set the thrMasterKey.
- * @retval kThreadErrorInvalidArgs    If aKeyLength is larger than 16.
- * @retval kThreadError_InvalidState  Thread protocols are enabled.
+ * @retval OT_ERROR_NONE            Successfully set the thrMasterKey.
+ * @retval OT_ERROR_INVALID_ARGS    If aKeyLength is larger than 16.
+ * @retval OT_ERROR_INVALID_STATE   Thread protocols are enabled.
  *
  * @sa otThreadGetMasterKey
  */
-OTAPI ThreadError OTCALL otThreadSetMasterKey(otInstance *aInstance, const otMasterKey *aKey);
+OTAPI otError OTCALL otThreadSetMasterKey(otInstance *aInstance, const otMasterKey *aKey);
 
 /**
  * This function returns a pointer to the Mesh Local EID.
@@ -269,11 +269,11 @@ OTAPI const uint8_t *OTCALL otThreadGetMeshLocalPrefix(otInstance *aInstance);
  * @param[in]  aInstance         A pointer to an OpenThread instance.
  * @param[in]  aMeshLocalPrefix  A pointer to the Mesh Local Prefix.
  *
- * @retval kThreadError_None          Successfully set the Mesh Local Prefix.
- * @retval kThreadError_InvalidState  Thread protocols are enabled.
+ * @retval OT_ERROR_NONE           Successfully set the Mesh Local Prefix.
+ * @retval OT_ERROR_INVALID_STATE  Thread protocols are enabled.
  *
  */
-OTAPI ThreadError OTCALL otThreadSetMeshLocalPrefix(otInstance *aInstance, const uint8_t *aMeshLocalPrefix);
+OTAPI otError OTCALL otThreadSetMeshLocalPrefix(otInstance *aInstance, const uint8_t *aMeshLocalPrefix);
 
 /**
  * Get the Thread Network Name.
@@ -296,12 +296,12 @@ OTAPI const char *OTCALL otThreadGetNetworkName(otInstance *aInstance);
  * @param[in]  aInstance     A pointer to an OpenThread instance.
  * @param[in]  aNetworkName  A pointer to the Thread Network Name.
  *
- * @retval kThreadErrorNone           Successfully set the Thread Network Name.
- * @retval kThreadError_InvalidState  Thread protocols are enabled.
+ * @retval OT_ERROR_NONE           Successfully set the Thread Network Name.
+ * @retval OT_ERROR_INVALID_STATE  Thread protocols are enabled.
  *
  * @sa otThreadGetNetworkName
  */
-OTAPI ThreadError OTCALL otThreadSetNetworkName(otInstance *aInstance, const char *aNetworkName);
+OTAPI otError OTCALL otThreadSetNetworkName(otInstance *aInstance, const char *aNetworkName);
 
 /**
  * Get the thrKeySequenceCounter.
@@ -350,10 +350,10 @@ OTAPI void OTCALL otThreadSetKeySwitchGuardTime(otInstance *aInstance, uint32_t 
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.
  *
- * @retval kThreadErrorNone          Successfully detached from the Thread network.
- * @retval kThreadErrorInvalidState  Thread is disabled.
+ * @retval OT_ERROR_NONE           Successfully detached from the Thread network.
+ * @retval OT_ERROR_INVALID_STATE  Thread is disabled.
  */
-OTAPI ThreadError OTCALL otThreadBecomeDetached(otInstance *aInstance);
+OTAPI otError OTCALL otThreadBecomeDetached(otInstance *aInstance);
 
 /**
  * Attempt to reattach as a child.
@@ -361,10 +361,10 @@ OTAPI ThreadError OTCALL otThreadBecomeDetached(otInstance *aInstance);
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aFilter   Identifies whether to join any, same, or better partition.
  *
- * @retval kThreadErrorNone          Successfully begin attempt to become a child.
- * @retval kThreadErrorInvalidState  Thread is disabled.
+ * @retval OT_ERROR_NONE           Successfully begin attempt to become a child.
+ * @retval OT_ERROR_INVALID_STATE  Thread is disabled.
  */
-OTAPI ThreadError OTCALL otThreadBecomeChild(otInstance *aInstance, otMleAttachFilter aFilter);
+OTAPI otError OTCALL otThreadBecomeChild(otInstance *aInstance, otMleAttachFilter aFilter);
 
 /**
  * This function gets the next neighbor information. It is used to go through the entries of
@@ -375,13 +375,13 @@ OTAPI ThreadError OTCALL otThreadBecomeChild(otInstance *aInstance, otMleAttachF
                              it should be set to OT_NEIGHBOR_INFO_ITERATOR_INIT.
  * @param[out]    aInfo      A pointer to where the neighbor information will be placed.
  *
- * @retval kThreadError_None         Successfully found the next neighbor entry in table.
- * @retval kThreadError_NotFound     No subsequent neighbor entry exists in the table.
- * @retval kThreadError_InvalidArgs  @p aIterator or @p aInfo was NULL.
+ * @retval OT_ERROR_NONE         Successfully found the next neighbor entry in table.
+ * @retval OT_ERROR_NOT_FOUND     No subsequent neighbor entry exists in the table.
+ * @retval OT_ERROR_INVALID_ARGS  @p aIterator or @p aInfo was NULL.
  *
  */
-OTAPI ThreadError OTCALL otThreadGetNextNeighborInfo(otInstance *aInstance, otNeighborInfoIterator *aIterator,
-                                                     otNeighborInfo *aInfo);
+OTAPI otError OTCALL otThreadGetNextNeighborInfo(otInstance *aInstance, otNeighborInfoIterator *aIterator,
+                                                 otNeighborInfo *aInfo);
 
 /**
  * Get the device role.
@@ -402,12 +402,12 @@ OTAPI otDeviceRole OTCALL otThreadGetDeviceRole(otInstance *aInstance);
  * @param[in]   aInstance    A pointer to an OpenThread instance.
  * @param[out]  aLeaderData  A pointer to where the leader data is placed.
  *
- * @retval kThreadError_None         Successfully retrieved the leader data.
- * @retval kThreadError_Detached     Not currently attached.
- * @retval kThreadError_InvalidArgs  @p aLeaderData is NULL.
+ * @retval OT_ERROR_NONE          Successfully retrieved the leader data.
+ * @retval OT_ERROR_DETACHED      Not currently attached.
+ * @retval OT_ERROR_INVALID_ARGS  @p aLeaderData is NULL.
  *
  */
-OTAPI ThreadError OTCALL otThreadGetLeaderData(otInstance *aInstance, otLeaderData *aLeaderData);
+OTAPI otError OTCALL otThreadGetLeaderData(otInstance *aInstance, otLeaderData *aLeaderData);
 
 /**
  * Get the Leader's Router ID.
@@ -452,7 +452,7 @@ OTAPI uint16_t OTCALL otThreadGetRloc16(otInstance *aInstance);
  * @param[out]  aParentInfo  A pointer to where the parent router information is placed.
  *
  */
-OTAPI ThreadError OTCALL otThreadGetParentInfo(otInstance *aInstance, otRouterInfo *aParentInfo);
+OTAPI otError OTCALL otThreadGetParentInfo(otInstance *aInstance, otRouterInfo *aParentInfo);
 
 /**
  * The function retrieves the average RSSI for the Thread Parent.
@@ -461,7 +461,7 @@ OTAPI ThreadError OTCALL otThreadGetParentInfo(otInstance *aInstance, otRouterIn
  * @param[out]  aParentRssi  A pointer to where the parent rssi should be placed.
  *
  */
-OTAPI ThreadError OTCALL otThreadGetParentAverageRssi(otInstance *aInstance, int8_t *aParentRssi);
+OTAPI otError OTCALL otThreadGetParentAverageRssi(otInstance *aInstance, int8_t *aParentRssi);
 
 /**
  * The function retrieves the RSSI of the last packet from the Thread Parent.
@@ -469,11 +469,11 @@ OTAPI ThreadError OTCALL otThreadGetParentAverageRssi(otInstance *aInstance, int
  * @param[in]   aInstance    A pointer to an OpenThread instance.
  * @param[out]  aLastRssi    A pointer to where the last rssi should be placed.
  *
- * @retval kThreadError_None         Successfully retrieved the RSSI data.
- * @retval kThreadError_Failed       Unable to get RSSI data.
- * @retval kThreadError_InvalidArgs  @p aLastRssi is NULL.
+ * @retval OT_ERROR_NONE          Successfully retrieved the RSSI data.
+ * @retval OT_ERROR_FAILED        Unable to get RSSI data.
+ * @retval OT_ERROR_INVALID_ARGS  @p aLastRssi is NULL.
  */
-OTAPI ThreadError OTCALL otThreadGetParentLastRssi(otInstance *aInstance, int8_t *aLastRssi);
+OTAPI otError OTCALL otThreadGetParentLastRssi(otInstance *aInstance, int8_t *aLastRssi);
 
 /**
  * This function pointer is called when Network Diagnostic Get response is received.
@@ -508,8 +508,8 @@ void otThreadSetReceiveDiagnosticGetCallback(otInstance *aInstance, otReceiveDia
  * @param[in]  aCount         Number of types in aTlvTypes
  *
  */
-OTAPI ThreadError OTCALL otThreadSendDiagnosticGet(otInstance *aInstance, const otIp6Address *aDestination,
-                                                   const uint8_t aTlvTypes[], uint8_t aCount);
+OTAPI otError OTCALL otThreadSendDiagnosticGet(otInstance *aInstance, const otIp6Address *aDestination,
+                                               const uint8_t aTlvTypes[], uint8_t aCount);
 
 /**
  * Send a Network Diagnostic Reset request.
@@ -520,8 +520,8 @@ OTAPI ThreadError OTCALL otThreadSendDiagnosticGet(otInstance *aInstance, const 
  * @param[in]  aCount         Number of types in aTlvTypes
  *
  */
-OTAPI ThreadError OTCALL otThreadSendDiagnosticReset(otInstance *aInstance, const otIp6Address *aDestination,
-                                                     const uint8_t aTlvTypes[], uint8_t aCount);
+OTAPI otError OTCALL otThreadSendDiagnosticReset(otInstance *aInstance, const otIp6Address *aDestination,
+                                                 const uint8_t aTlvTypes[], uint8_t aCount);
 
 /**
  * @}

--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -70,13 +70,13 @@ OTAPI uint8_t OTCALL otThreadGetMaxAllowedChildren(otInstance *aInstance);
  * @param[in]  aInstance     A pointer to an OpenThread instance.
  * @param[in]  aMaxChildren  The maximum allowed children.
  *
- * @retval  kThreadError_None          Successfully set the max.
- * @retval  kThreadError_InvalidArgs   If @p aMaxChildren is not in the range [1, OPENTHREAD_CONFIG_MAX_CHILDREN].
- * @retval  kThreadError_InvalidState  If Thread isn't stopped.
+ * @retval  OT_ERROR_NONE           Successfully set the max.
+ * @retval  OT_ERROR_INVALID_ARGS   If @p aMaxChildren is not in the range [1, OPENTHREAD_CONFIG_MAX_CHILDREN].
+ * @retval  OT_ERROR_INVALID_STATE  If Thread isn't stopped.
  *
  * @sa otThreadGetMaxAllowedChildren, otThreadStop
  */
-OTAPI ThreadError OTCALL otThreadSetMaxAllowedChildren(otInstance *aInstance, uint8_t aMaxChildren);
+OTAPI otError OTCALL otThreadSetMaxAllowedChildren(otInstance *aInstance, uint8_t aMaxChildren);
 
 /**
  * This function indicates whether or not the Router Role is enabled.
@@ -109,11 +109,11 @@ OTAPI void OTCALL otThreadSetRouterRoleEnabled(otInstance *aInstance, bool aEnab
  * @param[in]  aInstance    A pointer to an OpenThread instance.
  * @param[in]  aRouterId    The preferred Router Id.
  *
- * @retval kThreadError_None         Successfully set the preferred Router Id.
- * @retval kThreadError_InvalidState Could not set (role is not detached or disabled)
+ * @retval OT_ERROR_NONE          Successfully set the preferred Router Id.
+ * @retval OT_ERROR_INVALID_STATE Could not set (role is not detached or disabled)
  *
  */
-OTAPI ThreadError OTCALL otThreadSetPreferredRouterId(otInstance *aInstance, uint8_t aRouterId);
+OTAPI otError OTCALL otThreadSetPreferredRouterId(otInstance *aInstance, uint8_t aRouterId);
 
 /**
  * Get the Thread Leader Weight used when operating in the Leader role.
@@ -172,17 +172,17 @@ OTAPI uint16_t OTCALL otThreadGetJoinerUdpPort(otInstance *aInstance);
  * @param[in]  aInstance       A pointer to an OpenThread instance.
  * @param[in]  aJoinerUdpPort  The Joiner UDP Port number.
  *
- * @retval  kThreadError_None  Successfully set the Joiner UDP Port.
+ * @retval  OT_ERROR_NONE  Successfully set the Joiner UDP Port.
  *
  * @sa otThreadGetJoinerUdpPort
  */
-OTAPI ThreadError OTCALL otThreadSetJoinerUdpPort(otInstance *aInstance, uint16_t aJoinerUdpPort);
+OTAPI otError OTCALL otThreadSetJoinerUdpPort(otInstance *aInstance, uint16_t aJoinerUdpPort);
 
 /**
  * Set Steering data out of band
  *
  * Configuration option `OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB` should be set to enable setting of steering
- * data out of band. Otherwise calling this function does nothing and it returns `kThreadError_DisabledFeature`
+ * data out of band. Otherwise calling this function does nothing and it returns `OT_ERROR_DISABLED_FEATURE`
  * error.
  *
  * @param[in]  aInstance       A pointer to an OpenThread instance.
@@ -191,11 +191,11 @@ OTAPI ThreadError OTCALL otThreadSetJoinerUdpPort(otInstance *aInstance, uint16_
  *                             All 0xFFs to set steering data/bloom filter to accept/allow all.
  *                             A specific EUI64 which is then added to current steering data/bloom filter.
  *
- * @retval  kThreadError_None              Successfully set/updated the steering data.
- * @retval  kThreadError_DisabledFeature   Feature is disabled, not capable of setting steering data out of band.
+ * @retval  OT_ERROR_NONE              Successfully set/updated the steering data.
+ * @retval  OT_ERROR_DISABLED_FEATURE  Feature is disabled, not capable of setting steering data out of band.
  *
  */
-ThreadError otThreadSetSteeringData(otInstance *aInstance, otExtAddress *aExtAddress);
+otError otThreadSetSteeringData(otInstance *aInstance, otExtAddress *aExtAddress);
 
 /**
  * Get the CONTEXT_ID_REUSE_DELAY parameter used in the Leader role.
@@ -266,29 +266,29 @@ OTAPI void OTCALL otThreadSetRouterUpgradeThreshold(otInstance *aInstance, uint8
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  * @param[in]  aRouterId  The Router ID to release. Valid range is [0, 62].
  *
- * @retval kThreadError_None  Successfully released the Router ID specified by aRouterId.
+ * @retval OT_ERROR_NONE  Successfully released the Router ID specified by aRouterId.
  */
-OTAPI ThreadError OTCALL otThreadReleaseRouterId(otInstance *aInstance, uint8_t aRouterId);
+OTAPI otError OTCALL otThreadReleaseRouterId(otInstance *aInstance, uint8_t aRouterId);
 
 /**
  * Attempt to become a router.
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.
  *
- * @retval kThreadError_None         Successfully begin attempt to become a router.
- * @retval kThreadError_InvalidState Thread is disabled.
+ * @retval OT_ERROR_NONE           Successfully begin attempt to become a router.
+ * @retval OT_ERROR_INVALID_STATE  Thread is disabled.
  */
-OTAPI ThreadError OTCALL otThreadBecomeRouter(otInstance *aInstance);
+OTAPI otError OTCALL otThreadBecomeRouter(otInstance *aInstance);
 
 /**
  * Become a leader and start a new partition.
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.
  *
- * @retval kThreadError_None          Successfully became a leader and started a new partition.
- * @retval kThreadError_InvalidState  Thread is disabled.
+ * @retval OT_ERROR_NONE           Successfully became a leader and started a new partition.
+ * @retval OT_ERROR_INVALID_STATE  Thread is disabled.
  */
-OTAPI ThreadError OTCALL otThreadBecomeLeader(otInstance *aInstance);
+OTAPI otError OTCALL otThreadBecomeLeader(otInstance *aInstance);
 
 /**
  * Get the ROUTER_DOWNGRADE_THRESHOLD parameter used in the Router role.
@@ -339,12 +339,12 @@ OTAPI void OTCALL otThreadSetRouterSelectionJitter(otInstance *aInstance, uint8_
  * @param[in]   aChildId    The Child ID or RLOC16 for the attached child.
  * @param[out]  aChildInfo  A pointer to where the child information is placed.
  *
- * @retval kThreadError_None         @p aChildInfo was successfully updated with the info for the given ID.
- * @retval kThreadError_NotFound     No valid child with this Child ID.
- * @retval kThreadError_InvalidArgs  If @p aChildInfo is NULL.
+ * @retval OT_ERROR_NONE          @p aChildInfo was successfully updated with the info for the given ID.
+ * @retval OT_ERROR_NOT_FOUND     No valid child with this Child ID.
+ * @retval OT_ERROR_INVALID_ARGS  If @p aChildInfo is NULL.
  *
  */
-OTAPI ThreadError OTCALL otThreadGetChildInfoById(otInstance *aInstance, uint16_t aChildId, otChildInfo *aChildInfo);
+OTAPI otError OTCALL otThreadGetChildInfoById(otInstance *aInstance, uint16_t aChildId, otChildInfo *aChildInfo);
 
 /**
  * The function retains diagnostic information for an attached Child by the internal table index.
@@ -353,16 +353,16 @@ OTAPI ThreadError OTCALL otThreadGetChildInfoById(otInstance *aInstance, uint16_
  * @param[in]   aChildIndex  The table index.
  * @param[out]  aChildInfo   A pointer to where the child information is placed.
  *
- * @retval kThreadError_None            @p aChildInfo was successfully updated with the info for the given index.
- * @retval kThreadError_NotFound        No valid child at this index.
- * @retval kThreadError_InvalidArgs     Either @p aChildInfo is NULL, or @p aChildIndex is out of range (higher
- *                                      than max table index).
+ * @retval OT_ERROR_NONE             @p aChildInfo was successfully updated with the info for the given index.
+ * @retval OT_ERROR_NOT_FOUND        No valid child at this index.
+ * @retval OT_ERROR_INVALID_ARGS     Either @p aChildInfo is NULL, or @p aChildIndex is out of range (higher
+ *                                   than max table index).
  *
  * @sa otGetMaxAllowedChildren
  *
  */
-OTAPI ThreadError OTCALL otThreadGetChildInfoByIndex(otInstance *aInstance, uint8_t aChildIndex,
-                                                     otChildInfo *aChildInfo);
+OTAPI otError OTCALL otThreadGetChildInfoByIndex(otInstance *aInstance, uint8_t aChildIndex,
+                                                 otChildInfo *aChildInfo);
 
 /**
  * Get the current Router ID Sequence.
@@ -381,7 +381,7 @@ OTAPI uint8_t OTCALL otThreadGetRouterIdSequence(otInstance *aInstance);
  * @param[out]  aRouterInfo  A pointer to where the router information is placed.
  *
  */
-OTAPI ThreadError OTCALL otThreadGetRouterInfo(otInstance *aInstance, uint16_t aRouterId, otRouterInfo *aRouterInfo);
+OTAPI otError OTCALL otThreadGetRouterInfo(otInstance *aInstance, uint16_t aRouterId, otRouterInfo *aRouterInfo);
 
 /**
  * This function gets an EID cache entry.
@@ -390,11 +390,11 @@ OTAPI ThreadError OTCALL otThreadGetRouterInfo(otInstance *aInstance, uint16_t a
  * @param[in]   aIndex    An index into the EID cache table.
  * @param[out]  aEntry    A pointer to where the EID information is placed.
  *
- * @retval kThreadError_None         Successfully retrieved the EID cache entry.
- * @retval kThreadError_InvalidArgs  @p aIndex was out of bounds or @p aEntry was NULL.
+ * @retval OT_ERROR_NONE          Successfully retrieved the EID cache entry.
+ * @retval OT_ERROR_INVALID_ARGS  @p aIndex was out of bounds or @p aEntry was NULL.
  *
  */
-OTAPI ThreadError OTCALL otThreadGetEidCacheEntry(otInstance *aInstance, uint8_t aIndex, otEidCacheEntry *aEntry);
+OTAPI otError OTCALL otThreadGetEidCacheEntry(otInstance *aInstance, uint8_t aIndex, otEidCacheEntry *aEntry);
 
 /**
  * Get the thrPSKc.
@@ -417,12 +417,12 @@ OTAPI const uint8_t *OTCALL otThreadGetPSKc(otInstance *aInstance);
  * @param[in]  aInstance   A pointer to an OpenThread instance.
  * @param[in]  aPSKc       A pointer to a buffer containing the thrPSKc.
  *
- * @retval kThreadError_None            Successfully set the thrPSKc.
- * @retval kThreadError_InvalidState    Thread protocols are enabled.
+ * @retval OT_ERROR_NONE           Successfully set the thrPSKc.
+ * @retval OT_ERROR_INVALID_STATE  Thread protocols are enabled.
  *
  * @sa otThreadGetPSKc
  */
-OTAPI ThreadError OTCALL otThreadSetPSKc(otInstance *aInstance, const uint8_t *aPSKc);
+OTAPI otError OTCALL otThreadSetPSKc(otInstance *aInstance, const uint8_t *aPSKc);
 
 /**
  * @}

--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -94,128 +94,184 @@ typedef struct otDeviceList
 /**
  * This enumeration represents error codes used throughout OpenThread.
  */
-typedef enum ThreadError
+typedef enum otError
 {
-    kThreadError_None = 0,
-    kThreadError_Failed = 1,
-    kThreadError_Drop = 2,
-    kThreadError_NoBufs = 3,
-    kThreadError_NoRoute = 4,
-    kThreadError_Busy = 5,
-    kThreadError_Parse = 6,
-    kThreadError_InvalidArgs = 7,
-    kThreadError_Security = 8,
-    kThreadError_AddressQuery = 9,
-    kThreadError_NoAddress = 10,
-    kThreadError_NotReceiving = 11,
-    kThreadError_Abort = 12,
-    kThreadError_NotImplemented = 13,
-    kThreadError_InvalidState = 14,
-    kThreadError_NoTasklets = 15,
+    /**
+     * No error.
+     */
+    OT_ERROR_NONE = 0,
+
+    /**
+     * Operational failed.
+     */
+    OT_ERROR_FAILED = 1,
+
+    /**
+     * Message was dropped.
+     */
+    OT_ERROR_DROP = 2,
+
+    /**
+     * Insufficient buffers.
+     */
+    OT_ERROR_NO_BUFS = 3,
+
+    /**
+     * No route available.
+     */
+    OT_ERROR_NO_ROUTE = 4,
+
+    /**
+     * Service is busy and could not service the operation.
+     */
+    OT_ERROR_BUSY = 5,
+
+    /**
+     * Failed to parse message or arguments.
+     */
+    OT_ERROR_PARSE = 6,
+
+    /**
+     * Input arguments are invalid.
+     */
+    OT_ERROR_INVALID_ARGS = 7,
+
+    /**
+     * Security checks failed.
+     */
+    OT_ERROR_SECURITY = 8,
+
+    /**
+     * Address resolution requires an address query operation.
+     */
+    OT_ERROR_ADDRESS_QUERY = 9,
+
+    /**
+     * Address is not in the source match table.
+     */
+    OT_ERROR_NO_ADDRESS = 10,
+
+    /**
+     * Operation was aborted.
+     */
+    OT_ERROR_ABORT = 11,
+
+    /**
+     * Function or method is not implemented.
+     */
+    OT_ERROR_NOT_IMPLEMENTED = 12,
+
+    /**
+     * Cannot complete due to invalid state.
+     */
+    OT_ERROR_INVALID_STATE = 13,
 
     /**
      * No acknowledgment was received after macMaxFrameRetries (IEEE 802.15.4-2006).
      */
-    kThreadError_NoAck = 16,
+    OT_ERROR_NO_ACK = 14,
 
     /**
      * A transmission could not take place due to activity on the channel, i.e., the CSMA-CA mechanism has failed
      * (IEEE 802.15.4-2006).
      */
-    kThreadError_ChannelAccessFailure = 17,
+    OT_ERROR_CHANNEL_ACCESS_FAILURE = 15,
 
     /**
      * Not currently attached to a Thread Partition.
      */
-    kThreadError_Detached = 18,
+    OT_ERROR_DETACHED = 16,
 
     /**
      * FCS check failure while receiving.
      */
-    kThreadError_FcsErr = 19,
+    OT_ERROR_FCS = 17,
 
     /**
      * No frame received.
      */
-    kThreadError_NoFrameReceived = 20,
+    OT_ERROR_NO_FRAME_RECEIVED = 18,
 
     /**
      * Received a frame from an unknown neighbor.
      */
-    kThreadError_UnknownNeighbor = 21,
+    OT_ERROR_UNKNOWN_NEIGHBOR = 19,
 
     /**
      * Received a frame from an invalid source address.
      */
-    kThreadError_InvalidSourceAddress = 22,
+    OT_ERROR_INVALID_SOURCE_ADDRESS = 20,
 
     /**
      * Received a frame filtered by the whitelist.
      */
-    kThreadError_WhitelistFiltered = 23,
+    OT_ERROR_WHITELIST_FILTERED = 21,
 
     /**
      * Received a frame filtered by the destination address check.
      */
-    kThreadError_DestinationAddressFiltered = 24,
+    OT_ERROR_DESTINATION_ADDRESS_FILTERED = 22,
 
     /**
      * The requested item could not be found.
      */
-    kThreadError_NotFound = 25,
+    OT_ERROR_NOT_FOUND = 23,
 
     /**
      * The operation is already in progress.
      */
-    kThreadError_Already = 26,
+    OT_ERROR_ALREADY = 24,
 
     /**
      * Received a frame filtered by the blacklist.
      */
-    kThreadError_BlacklistFiltered = 27,
+    OT_ERROR_BLACKLIST_FILTERED = 25,
 
     /**
      * The creation of IPv6 address failed.
      */
-    kThreadError_Ipv6AddressCreationFailure = 28,
+    OT_ERROR_IP6_ADDRESS_CREATION_FAILURE = 26,
 
     /**
      * Operation prevented by mode flags
      */
-    kThreadError_NotCapable = 29,
+    OT_ERROR_NOT_CAPABLE = 27,
 
     /**
      * Coap response or acknowledgment or DNS response not received.
      */
-    kThreadError_ResponseTimeout = 30,
+    OT_ERROR_RESPONSE_TIMEOUT = 28,
 
     /**
      * Received a duplicated frame.
      */
-    kThreadError_Duplicated = 31,
+    OT_ERROR_DUPLICATED = 29,
 
     /**
      * Message is being dropped from reassembly list due to timeout.
      */
-    kThreadError_ReassemblyTimeout = 32,
+    OT_ERROR_REASSEMBLY_TIMEOUT = 30,
 
     /**
      * Message is not a TMF Message.
      */
-    kThreadError_NotTmf = 33,
+    OT_ERROR_NOT_TMF = 31,
 
     /**
      * Received a non-lowpan data frame.
      */
-    kThreadError_NonLowpanDataFrame = 34,
+    OT_ERROR_NOT_LOWPAN_DATA_FRAME = 32,
 
     /**
      * A feature/functionality disabled by build-time configuration options.
      */
-    kThreadError_DisabledFeature = 35,
+    OT_ERROR_DISABLED_FEATURE = 33,
 
-    kThreadError_Error = 255,
-} ThreadError;
+    /**
+     * Generic error (should not use).
+     */
+    OT_ERROR_GENERIC = 255,
+} otError;
 
 #define OT_IP6_IID_SIZE            8   ///< Size of an IPv6 Interface Identifier (bytes)
 

--- a/include/openthread/udp.h
+++ b/include/openthread/udp.h
@@ -93,8 +93,8 @@ otMessage *otUdpNewMessage(otInstance *aInstance, bool aLinkSecurityEnabled);
  * @param[in]  aCallback  A pointer to the application callback function.
  * @param[in]  aContext   A pointer to application-specific context.
  *
- * @retval kThreadErrorNone         Successfully opened the socket.
- * @retval kThreadErrorInvalidArgs  Given socket structure was already opened.
+ * @retval OT_ERROR_NONE         Successfully opened the socket.
+ * @retval OT_ERROR_INVALID_ARGS  Given socket structure was already opened.
  *
  * @sa otUdpNewMessage
  * @sa otUdpClose
@@ -103,14 +103,14 @@ otMessage *otUdpNewMessage(otInstance *aInstance, bool aLinkSecurityEnabled);
  * @sa otUdpSend
  *
  */
-ThreadError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aContext);
+otError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aContext);
 
 /**
  * Close a UDP/IPv6 socket.
  *
  * @param[in]  aSocket  A pointer to a UDP socket structure.
  *
- * @retval kThreadErrorNone  Successfully closed the socket.
+ * @retval OT_ERROR_NONE  Successfully closed the socket.
  *
  * @sa otUdpNewMessage
  * @sa otUdpOpen
@@ -119,7 +119,7 @@ ThreadError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive 
  * @sa otUdpSend
  *
  */
-ThreadError otUdpClose(otUdpSocket *aSocket);
+otError otUdpClose(otUdpSocket *aSocket);
 
 /**
  * Bind a UDP/IPv6 socket.
@@ -127,7 +127,7 @@ ThreadError otUdpClose(otUdpSocket *aSocket);
  * @param[in]  aSocket    A pointer to a UDP socket structure.
  * @param[in]  aSockName  A pointer to an IPv6 socket address structure.
  *
- * @retval kThreadErrorNone  Bind operation was successful.
+ * @retval OT_ERROR_NONE  Bind operation was successful.
  *
  * @sa otUdpNewMessage
  * @sa otUdpOpen
@@ -136,7 +136,7 @@ ThreadError otUdpClose(otUdpSocket *aSocket);
  * @sa otUdpSend
  *
  */
-ThreadError otUdpBind(otUdpSocket *aSocket, otSockAddr *aSockName);
+otError otUdpBind(otUdpSocket *aSocket, otSockAddr *aSockName);
 
 /**
  * Connect a UDP/IPv6 socket.
@@ -144,7 +144,7 @@ ThreadError otUdpBind(otUdpSocket *aSocket, otSockAddr *aSockName);
  * @param[in]  aSocket    A pointer to a UDP socket structure.
  * @param[in]  aSockName  A pointer to an IPv6 socket address structure.
  *
- * @retval kThreadErrorNone  Connect operation was successful.
+ * @retval OT_ERROR_NONE  Connect operation was successful.
  *
  * @sa otUdpNewMessage
  * @sa otUdpOpen
@@ -153,7 +153,7 @@ ThreadError otUdpBind(otUdpSocket *aSocket, otSockAddr *aSockName);
  * @sa otUdpSend
  *
  */
-ThreadError otUdpConnect(otUdpSocket *aSocket, otSockAddr *aSockName);
+otError otUdpConnect(otUdpSocket *aSocket, otSockAddr *aSockName);
 
 /**
  * Send a UDP/IPv6 message.
@@ -170,7 +170,7 @@ ThreadError otUdpConnect(otUdpSocket *aSocket, otSockAddr *aSockName);
  * @sa otUdpSend
  *
  */
-ThreadError otUdpSend(otUdpSocket *aSocket, otMessage *aMessage, const otMessageInfo *aMessageInfo);
+otError otUdpSend(otUdpSocket *aSocket, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 
 /**
  * @}

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -312,9 +312,9 @@ int Interpreter::Hex2Bin(const char *aHex, uint8_t *aBin, uint16_t aBinLength)
     return static_cast<int>(cur - aBin);
 }
 
-void Interpreter::AppendResult(ThreadError aError)
+void Interpreter::AppendResult(otError aError)
 {
-    if (aError == kThreadError_None)
+    if (aError == OT_ERROR_NONE)
     {
         sServer->OutputFormat("Done\r\n");
     }
@@ -332,18 +332,18 @@ void Interpreter::OutputBytes(const uint8_t *aBytes, uint8_t aLength)
     }
 }
 
-ThreadError Interpreter::ParseLong(char *argv, long &value)
+otError Interpreter::ParseLong(char *argv, long &value)
 {
     char *endptr;
     value = strtol(argv, &endptr, 0);
-    return (*endptr == '\0') ? kThreadError_None : kThreadError_Parse;
+    return (*endptr == '\0') ? OT_ERROR_NONE : OT_ERROR_PARSE;
 }
 
-ThreadError Interpreter::ParseUnsignedLong(char *argv, unsigned long &value)
+otError Interpreter::ParseUnsignedLong(char *argv, unsigned long &value)
 {
     char *endptr;
     value = strtoul(argv, &endptr, 0);
-    return (*endptr == '\0') ? kThreadError_None : kThreadError_Parse;
+    return (*endptr == '\0') ? OT_ERROR_NONE : OT_ERROR_PARSE;
 }
 
 void Interpreter::ProcessHelp(int argc, char *argv[])
@@ -359,7 +359,7 @@ void Interpreter::ProcessHelp(int argc, char *argv[])
 
 void Interpreter::ProcessAutoStart(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (argc == 0)
     {
@@ -382,7 +382,7 @@ void Interpreter::ProcessAutoStart(int argc, char *argv[])
     }
     else
     {
-        error = kThreadError_InvalidArgs;
+        error = OT_ERROR_INVALID_ARGS;
     }
 
     AppendResult(error);
@@ -390,7 +390,7 @@ void Interpreter::ProcessAutoStart(int argc, char *argv[])
 
 void Interpreter::ProcessBlacklist(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otMacBlacklistEntry entry;
     int argcur = 0;
     uint8_t extAddr[8];
@@ -408,7 +408,7 @@ void Interpreter::ProcessBlacklist(int argc, char *argv[])
 
         for (uint8_t i = 0; ; i++)
         {
-            if (otLinkGetBlacklistEntry(mInstance, i, &entry) != kThreadError_None)
+            if (otLinkGetBlacklistEntry(mInstance, i, &entry) != OT_ERROR_NONE)
             {
                 break;
             }
@@ -425,11 +425,11 @@ void Interpreter::ProcessBlacklist(int argc, char *argv[])
     }
     else if (strcmp(argv[argcur], "add") == 0)
     {
-        VerifyOrExit(++argcur < argc, error = kThreadError_Parse);
-        VerifyOrExit(Hex2Bin(argv[argcur], extAddr, sizeof(extAddr)) == sizeof(extAddr), error = kThreadError_Parse);
+        VerifyOrExit(++argcur < argc, error = OT_ERROR_PARSE);
+        VerifyOrExit(Hex2Bin(argv[argcur], extAddr, sizeof(extAddr)) == sizeof(extAddr), error = OT_ERROR_PARSE);
 
         otLinkAddBlacklist(mInstance, extAddr);
-        VerifyOrExit(otLinkAddBlacklist(mInstance, extAddr) == kThreadError_None, error = kThreadError_Parse);
+        VerifyOrExit(otLinkAddBlacklist(mInstance, extAddr) == OT_ERROR_NONE, error = OT_ERROR_PARSE);
     }
     else if (strcmp(argv[argcur], "clear") == 0)
     {
@@ -445,8 +445,8 @@ void Interpreter::ProcessBlacklist(int argc, char *argv[])
     }
     else if (strcmp(argv[argcur], "remove") == 0)
     {
-        VerifyOrExit(++argcur < argc, error = kThreadError_Parse);
-        VerifyOrExit(Hex2Bin(argv[argcur], extAddr, sizeof(extAddr)) == sizeof(extAddr), error = kThreadError_Parse);
+        VerifyOrExit(++argcur < argc, error = OT_ERROR_PARSE);
+        VerifyOrExit(Hex2Bin(argv[argcur], extAddr, sizeof(extAddr)) == sizeof(extAddr), error = OT_ERROR_PARSE);
         otLinkRemoveBlacklist(mInstance, extAddr);
     }
 
@@ -473,12 +473,12 @@ void Interpreter::ProcessBufferInfo(int argc, char *argv[])
     sServer->OutputFormat("coap: %d %d\r\n", bufferInfo.mCoapMessages, bufferInfo.mCoapBuffers);
     sServer->OutputFormat("coap secure: %d %d\r\n", bufferInfo.mCoapSecureMessages, bufferInfo.mCoapSecureBuffers);
 
-    AppendResult(kThreadError_None);
+    AppendResult(OT_ERROR_NONE);
 }
 
 void Interpreter::ProcessChannel(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
     if (argc == 0)
@@ -498,13 +498,13 @@ exit:
 #if OPENTHREAD_FTD
 void Interpreter::ProcessChild(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otChildInfo childInfo;
     uint8_t maxChildren;
     long value;
     bool isTable = false;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
 
     if (strcmp(argv[0], "list") == 0 || (isTable = (strcmp(argv[0], "table") == 0)))
     {
@@ -521,10 +521,10 @@ void Interpreter::ProcessChild(int argc, char *argv[])
 
             switch (otThreadGetChildInfoByIndex(mInstance, i, &childInfo))
             {
-            case kThreadError_None:
+            case OT_ERROR_NONE:
                 break;
 
-            case kThreadError_NotFound:
+            case OT_ERROR_NOT_FOUND:
                 continue;
 
             default:
@@ -614,7 +614,7 @@ exit:
 
 void Interpreter::ProcessChildMax(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
     if (argc == 0)
@@ -634,7 +634,7 @@ exit:
 
 void Interpreter::ProcessChildTimeout(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
     if (argc == 0)
@@ -655,7 +655,7 @@ exit:
 
 void Interpreter::ProcessCoap(int argc, char *argv[])
 {
-    ThreadError error;
+    otError error;
     error = Coap::Process(mInstance, argc, argv, *sServer);
     AppendResult(error);
 }
@@ -665,7 +665,7 @@ void Interpreter::ProcessCoap(int argc, char *argv[])
 #if OPENTHREAD_FTD
 void Interpreter::ProcessContextIdReuseDelay(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
     if (argc == 0)
@@ -731,7 +731,7 @@ void Interpreter::ProcessCounters(int argc, char *argv[])
 
 void Interpreter::ProcessDataset(int argc, char *argv[])
 {
-    ThreadError error;
+    otError error;
     error = Dataset::Process(mInstance, argc, argv, *sServer);
     AppendResult(error);
 }
@@ -739,7 +739,7 @@ void Interpreter::ProcessDataset(int argc, char *argv[])
 #if OPENTHREAD_FTD
 void Interpreter::ProcessDelayTimerMin(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (argc == 0)
     {
@@ -753,7 +753,7 @@ void Interpreter::ProcessDelayTimerMin(int argc, char *argv[])
     }
     else
     {
-        error = kThreadError_InvalidArgs;
+        error = OT_ERROR_INVALID_ARGS;
     }
 
 exit:
@@ -763,7 +763,7 @@ exit:
 
 void Interpreter::ProcessDiscover(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint32_t scanChannels = 0;
     long value;
 
@@ -787,18 +787,18 @@ exit:
 #if OPENTHREAD_ENABLE_DNS_CLIENT
 void Interpreter::ProcessDns(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long port = OT_DNS_DEFAULT_DNS_SERVER_PORT;
     Ip6::MessageInfo messageInfo;
     otDnsQuery query;
 
-    VerifyOrExit(argc > 0, error = kThreadError_InvalidArgs);
+    VerifyOrExit(argc > 0, error = OT_ERROR_INVALID_ARGS);
 
     if (strcmp(argv[0], "resolve") == 0)
     {
-        VerifyOrExit(!mResolvingInProgress, error = kThreadError_Busy);
-        VerifyOrExit(argc > 1, error = kThreadError_InvalidArgs);
-        VerifyOrExit(strlen(argv[1]) < OT_DNS_MAX_HOSTNAME_LENGTH, error = kThreadError_InvalidArgs);
+        VerifyOrExit(!mResolvingInProgress, error = OT_ERROR_BUSY);
+        VerifyOrExit(argc > 1, error = OT_ERROR_INVALID_ARGS);
+        VerifyOrExit(strlen(argv[1]) < OT_DNS_MAX_HOSTNAME_LENGTH, error = OT_ERROR_INVALID_ARGS);
 
         strcpy(mResolvingHostname, argv[1]);
 
@@ -833,7 +833,7 @@ void Interpreter::ProcessDns(int argc, char *argv[])
     }
     else
     {
-        ExitNow(error = kThreadError_InvalidArgs);
+        ExitNow(error = OT_ERROR_INVALID_ARGS);
     }
 
 exit:
@@ -841,18 +841,18 @@ exit:
 }
 
 void Interpreter::s_HandleDnsResponse(void *aContext, const char *aHostname, otIp6Address *aAddress,
-                                      uint32_t aTtl, ThreadError aResult)
+                                      uint32_t aTtl, otError aResult)
 {
     static_cast<Interpreter *>(aContext)->HandleDnsResponse(aHostname,
                                                             *static_cast<Ip6::Address *>(aAddress),
                                                             aTtl, aResult);
 }
 
-void Interpreter::HandleDnsResponse(const char *aHostname, Ip6::Address &aAddress, uint32_t aTtl, ThreadError aResult)
+void Interpreter::HandleDnsResponse(const char *aHostname, Ip6::Address &aAddress, uint32_t aTtl, otError aResult)
 {
     sServer->OutputFormat("DNS response for %s - ", aHostname);
 
-    if (aResult == kThreadError_None)
+    if (aResult == OT_ERROR_NONE)
     {
         sServer->OutputFormat("[%x:%x:%x:%x:%x:%x:%x:%x] TTL: %d\r\n",
                               HostSwap16(aAddress.mFields.m16[0]),
@@ -903,16 +903,16 @@ void Interpreter::ProcessEidCache(int argc, char *argv[])
 exit:
     (void)argc;
     (void)argv;
-    AppendResult(kThreadError_None);
+    AppendResult(OT_ERROR_NONE);
 }
 #endif  // OPENTHREAD_FTD
 
 void Interpreter::ProcessEui64(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otExtAddress extAddress;
 
-    VerifyOrExit(argc == 0, error = kThreadError_Parse);
+    VerifyOrExit(argc == 0, error = OT_ERROR_PARSE);
 
     otLinkGetFactoryAssignedIeeeEui64(mInstance, &extAddress);
     OutputBytes(extAddress.m8, OT_EXT_ADDRESS_SIZE);
@@ -925,7 +925,7 @@ exit:
 
 void Interpreter::ProcessExtAddress(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (argc == 0)
     {
@@ -937,7 +937,7 @@ void Interpreter::ProcessExtAddress(int argc, char *argv[])
     {
         otExtAddress extAddress;
 
-        VerifyOrExit(Hex2Bin(argv[0], extAddress.m8, sizeof(otExtAddress)) >= 0, error = kThreadError_Parse);
+        VerifyOrExit(Hex2Bin(argv[0], extAddress.m8, sizeof(otExtAddress)) >= 0, error = OT_ERROR_PARSE);
 
         error = otLinkSetExtendedAddress(mInstance, &extAddress);
     }
@@ -957,7 +957,7 @@ void Interpreter::ProcessExit(int argc, char *argv[])
 
 void Interpreter::ProcessExtPanId(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (argc == 0)
     {
@@ -969,7 +969,7 @@ void Interpreter::ProcessExtPanId(int argc, char *argv[])
     {
         uint8_t extPanId[8];
 
-        VerifyOrExit(Hex2Bin(argv[0], extPanId, sizeof(extPanId)) >= 0, error = kThreadError_Parse);
+        VerifyOrExit(Hex2Bin(argv[0], extPanId, sizeof(extPanId)) >= 0, error = OT_ERROR_PARSE);
 
         error = otThreadSetExtendedPanId(mInstance, extPanId);
     }
@@ -987,10 +987,10 @@ void Interpreter::ProcessFactoryReset(int argc, char *argv[])
 
 void Interpreter::ProcessHashMacAddress(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otExtAddress hashMacAddress;
 
-    VerifyOrExit(argc == 0, error = kThreadError_Parse);
+    VerifyOrExit(argc == 0, error = OT_ERROR_PARSE);
 
     otLinkGetJoinerId(mInstance, &hashMacAddress);
     OutputBytes(hashMacAddress.m8, OT_EXT_ADDRESS_SIZE);
@@ -1003,7 +1003,7 @@ exit:
 
 void Interpreter::ProcessIfconfig(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (argc == 0)
     {
@@ -1029,12 +1029,12 @@ exit:
     AppendResult(error);
 }
 
-ThreadError Interpreter::ProcessIpAddrAdd(int argc, char *argv[])
+otError Interpreter::ProcessIpAddrAdd(int argc, char *argv[])
 {
-    ThreadError error;
+    otError error;
     otNetifAddress aAddress;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
 
     SuccessOrExit(error = otIp6AddressFromString(argv[0], &aAddress.mAddress));
     aAddress.mPrefixLength = 64;
@@ -1046,12 +1046,12 @@ exit:
     return error;
 }
 
-ThreadError Interpreter::ProcessIpAddrDel(int argc, char *argv[])
+otError Interpreter::ProcessIpAddrDel(int argc, char *argv[])
 {
-    ThreadError error;
+    otError error;
     struct otIp6Address address;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
 
     SuccessOrExit(error = otIp6AddressFromString(argv[0], &address));
     error = otIp6RemoveUnicastAddress(mInstance, &address);
@@ -1062,7 +1062,7 @@ exit:
 
 void Interpreter::ProcessIpAddr(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (argc == 0)
     {
@@ -1098,12 +1098,12 @@ exit:
 }
 
 #ifndef OTDLL
-ThreadError Interpreter::ProcessIpMulticastAddrAdd(int argc, char *argv[])
+otError Interpreter::ProcessIpMulticastAddrAdd(int argc, char *argv[])
 {
-    ThreadError error;
+    otError error;
     struct otIp6Address address;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
 
     SuccessOrExit(error = otIp6AddressFromString(argv[0], &address));
     error = otIp6SubscribeMulticastAddress(mInstance, &address);
@@ -1112,12 +1112,12 @@ exit:
     return error;
 }
 
-ThreadError Interpreter::ProcessIpMulticastAddrDel(int argc, char *argv[])
+otError Interpreter::ProcessIpMulticastAddrDel(int argc, char *argv[])
 {
-    ThreadError error;
+    otError error;
     struct otIp6Address address;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
 
     SuccessOrExit(error = otIp6AddressFromString(argv[0], &address));
     error = otIp6UnsubscribeMulticastAddress(mInstance, &address);
@@ -1126,9 +1126,9 @@ exit:
     return error;
 }
 
-ThreadError Interpreter::ProcessMulticastPromiscuous(int argc, char *argv[])
+otError Interpreter::ProcessMulticastPromiscuous(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (argc == 0)
     {
@@ -1153,7 +1153,7 @@ ThreadError Interpreter::ProcessMulticastPromiscuous(int argc, char *argv[])
         }
         else
         {
-            ExitNow(error = kThreadError_Parse);
+            ExitNow(error = OT_ERROR_PARSE);
         }
     }
 
@@ -1163,7 +1163,7 @@ exit:
 
 void Interpreter::ProcessIpMulticastAddr(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (argc == 0)
     {
@@ -1203,10 +1203,10 @@ exit:
 
 void Interpreter::ProcessKeySequence(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
-    VerifyOrExit(argc == 1 || argc == 2, error = kThreadError_Parse);
+    VerifyOrExit(argc == 1 || argc == 2, error = OT_ERROR_PARSE);
 
     if (strcmp(argv[0], "counter") == 0)
     {
@@ -1239,7 +1239,7 @@ exit:
 
 void Interpreter::ProcessLeaderData(int argc, char *argv[])
 {
-    ThreadError error;
+    otError error;
     otLeaderData leaderData;
 
     SuccessOrExit(error = otThreadGetLeaderData(mInstance, &leaderData));
@@ -1259,7 +1259,7 @@ exit:
 #if OPENTHREAD_FTD
 void Interpreter::ProcessLeaderPartitionId(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     unsigned long value;
 
     if (argc == 0)
@@ -1278,7 +1278,7 @@ exit:
 
 void Interpreter::ProcessLeaderWeight(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
     if (argc == 0)
@@ -1298,18 +1298,18 @@ exit:
 
 void Interpreter::ProcessLinkQuality(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t extAddress[8];
     uint8_t linkQuality;
     long value;
 
-    VerifyOrExit(argc > 0, error = kThreadError_InvalidArgs);
-    VerifyOrExit(Hex2Bin(argv[0], extAddress, OT_EXT_ADDRESS_SIZE) >= 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(Hex2Bin(argv[0], extAddress, OT_EXT_ADDRESS_SIZE) >= 0, error = OT_ERROR_PARSE);
 
     if (argc == 1)
     {
-        VerifyOrExit(otLinkGetAssignLinkQuality(mInstance, extAddress, &linkQuality) == kThreadError_None,
-                     error = kThreadError_InvalidArgs);
+        VerifyOrExit(otLinkGetAssignLinkQuality(mInstance, extAddress, &linkQuality) == OT_ERROR_NONE,
+                     error = OT_ERROR_INVALID_ARGS);
         sServer->OutputFormat("%d\r\n", linkQuality);
     }
     else
@@ -1325,7 +1325,7 @@ exit:
 #if OPENTHREAD_FTD
 void Interpreter::ProcessPSKc(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (argc == 0)
     {
@@ -1342,7 +1342,7 @@ void Interpreter::ProcessPSKc(int argc, char *argv[])
     {
         uint8_t newPSKc[OT_PSKC_MAX_SIZE];
 
-        VerifyOrExit(Hex2Bin(argv[0], newPSKc, sizeof(newPSKc)) == OT_PSKC_MAX_SIZE, error = kThreadError_Parse);
+        VerifyOrExit(Hex2Bin(argv[0], newPSKc, sizeof(newPSKc)) == OT_PSKC_MAX_SIZE, error = OT_ERROR_PARSE);
         SuccessOrExit(error = otThreadSetPSKc(mInstance, newPSKc));
     }
 
@@ -1353,7 +1353,7 @@ exit:
 
 void Interpreter::ProcessMasterKey(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (argc == 0)
     {
@@ -1370,7 +1370,7 @@ void Interpreter::ProcessMasterKey(int argc, char *argv[])
     {
         otMasterKey key;
 
-        VerifyOrExit(Hex2Bin(argv[0], key.m8, sizeof(key.m8)) == OT_MASTER_KEY_SIZE, error = kThreadError_Parse);
+        VerifyOrExit(Hex2Bin(argv[0], key.m8, sizeof(key.m8)) == OT_MASTER_KEY_SIZE, error = OT_ERROR_PARSE);
         SuccessOrExit(error = otThreadSetMasterKey(mInstance, &key));
     }
 
@@ -1380,7 +1380,7 @@ exit:
 
 void Interpreter::ProcessMode(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otLinkModeConfig linkMode;
 
     memset(&linkMode, 0, sizeof(otLinkModeConfig));
@@ -1434,7 +1434,7 @@ void Interpreter::ProcessMode(int argc, char *argv[])
                 break;
 
             default:
-                ExitNow(error = kThreadError_Parse);
+                ExitNow(error = OT_ERROR_PARSE);
             }
         }
 
@@ -1447,7 +1447,7 @@ exit:
 
 void Interpreter::ProcessNetworkDataRegister(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     SuccessOrExit(error = otNetDataRegister(mInstance));
 
 exit:
@@ -1459,7 +1459,7 @@ exit:
 #if OPENTHREAD_FTD
 void Interpreter::ProcessNetworkIdTimeout(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
     if (argc == 0)
@@ -1479,7 +1479,7 @@ exit:
 
 void Interpreter::ProcessNetworkName(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (argc == 0)
     {
@@ -1497,7 +1497,7 @@ exit:
 
 void Interpreter::ProcessPanId(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
     if (argc == 0)
@@ -1516,7 +1516,7 @@ exit:
 
 void Interpreter::ProcessParent(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otRouterInfo parentInfo;
 
     SuccessOrExit(error = otThreadGetParentInfo(mInstance, &parentInfo));
@@ -1579,12 +1579,12 @@ exit:
 
 void Interpreter::ProcessPing(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t index = 1;
     long value;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
-    VerifyOrExit(!sPingTimer.IsRunning(), error = kThreadError_Busy);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
+    VerifyOrExit(!sPingTimer.IsRunning(), error = OT_ERROR_BUSY);
 
     memset(&sMessageInfo, 0, sizeof(sMessageInfo));
     SuccessOrExit(error = sMessageInfo.GetPeerAddr().FromString(argv[0]));
@@ -1614,7 +1614,7 @@ void Interpreter::ProcessPing(int argc, char *argv[])
             break;
 
         default:
-            ExitNow(error = kThreadError_Parse);
+            ExitNow(error = OT_ERROR_PARSE);
         }
 
         index++;
@@ -1635,13 +1635,13 @@ void Interpreter::s_HandlePingTimer(void *aContext)
 
 void Interpreter::HandlePingTimer()
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint32_t timestamp = HostSwap32(Timer::GetNow());
 
     otMessage *message;
     const otMessageInfo *messageInfo = static_cast<const otMessageInfo *>(&sMessageInfo);
 
-    VerifyOrExit((message = otIp6NewMessage(mInstance, true)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = otIp6NewMessage(mInstance, true)) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = otMessageAppend(message, &timestamp, sizeof(timestamp)));
     SuccessOrExit(error = otMessageSetLength(message, sLength));
     SuccessOrExit(error = otIcmp6SendEchoRequest(mInstance, message, messageInfo, 1));
@@ -1650,7 +1650,7 @@ void Interpreter::HandlePingTimer()
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         otMessageFree(message);
     }
@@ -1664,7 +1664,7 @@ exit:
 
 void Interpreter::ProcessPollPeriod(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
     if (argc == 0)
@@ -1684,7 +1684,7 @@ exit:
 #ifndef OTDLL
 void Interpreter::ProcessPromiscuous(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (argc == 0)
     {
@@ -1787,9 +1787,9 @@ void Interpreter::HandleLinkPcapReceive(const RadioPacket *aFrame)
 }
 #endif
 
-ThreadError Interpreter::ProcessPrefixAdd(int argc, char *argv[])
+otError Interpreter::ProcessPrefixAdd(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otBorderRouterConfig config;
     int argcur = 0;
 
@@ -1811,7 +1811,7 @@ ThreadError Interpreter::ProcessPrefixAdd(int argc, char *argv[])
 
     if (*endptr != '\0')
     {
-        ExitNow(error = kThreadError_Parse);
+        ExitNow(error = OT_ERROR_PARSE);
     }
 
     argcur++;
@@ -1865,7 +1865,7 @@ ThreadError Interpreter::ProcessPrefixAdd(int argc, char *argv[])
                     break;
 
                 default:
-                    ExitNow(error = kThreadError_Parse);
+                    ExitNow(error = OT_ERROR_PARSE);
                 }
             }
         }
@@ -1877,9 +1877,9 @@ exit:
     return error;
 }
 
-ThreadError Interpreter::ProcessPrefixRemove(int argc, char *argv[])
+otError Interpreter::ProcessPrefixRemove(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     struct otIp6Prefix prefix;
     int argcur = 0;
 
@@ -1901,7 +1901,7 @@ ThreadError Interpreter::ProcessPrefixRemove(int argc, char *argv[])
 
     if (*endptr != '\0')
     {
-        ExitNow(error = kThreadError_Parse);
+        ExitNow(error = OT_ERROR_PARSE);
     }
 
     error = otNetDataRemovePrefixInfo(mInstance, &prefix);
@@ -1911,12 +1911,12 @@ exit:
     return error;
 }
 
-ThreadError Interpreter::ProcessPrefixList(void)
+otError Interpreter::ProcessPrefixList(void)
 {
     otNetworkDataIterator iterator = OT_NETWORK_DATA_ITERATOR_INIT;
     otBorderRouterConfig config;
 
-    while (otNetDataGetNextPrefixInfo(mInstance, true, &iterator, &config) == kThreadError_None)
+    while (otNetDataGetNextPrefixInfo(mInstance, true, &iterator, &config) == OT_ERROR_NONE)
     {
         sServer->OutputFormat("%x:%x:%x:%x::/%d ",
                               HostSwap16(config.mPrefix.mPrefix.mFields.m16[0]),
@@ -1976,12 +1976,12 @@ ThreadError Interpreter::ProcessPrefixList(void)
         }
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 void Interpreter::ProcessPrefix(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (argc == 0)
     {
@@ -1997,7 +1997,7 @@ void Interpreter::ProcessPrefix(int argc, char *argv[])
     }
     else
     {
-        ExitNow(error = kThreadError_Parse);
+        ExitNow(error = OT_ERROR_PARSE);
     }
 
 exit:
@@ -2007,10 +2007,10 @@ exit:
 #if OPENTHREAD_FTD
 void Interpreter::ProcessReleaseRouterId(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
 
     SuccessOrExit(error = ParseLong(argv[0], value));
     SuccessOrExit(error = otThreadReleaseRouterId(mInstance, static_cast<uint8_t>(value)));
@@ -2035,9 +2035,9 @@ void Interpreter::ProcessRloc16(int argc, char *argv[])
     (void)argv;
 }
 
-ThreadError Interpreter::ProcessRouteAdd(int argc, char *argv[])
+otError Interpreter::ProcessRouteAdd(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otExternalRouteConfig config;
     int argcur = 0;
 
@@ -2046,7 +2046,7 @@ ThreadError Interpreter::ProcessRouteAdd(int argc, char *argv[])
     char *prefixLengthStr;
     char *endptr;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
 
     if ((prefixLengthStr = strchr(argv[argcur], '/')) == NULL)
     {
@@ -2061,7 +2061,7 @@ ThreadError Interpreter::ProcessRouteAdd(int argc, char *argv[])
 
     if (*endptr != '\0')
     {
-        ExitNow(error = kThreadError_Parse);
+        ExitNow(error = OT_ERROR_PARSE);
     }
 
     argcur++;
@@ -2086,7 +2086,7 @@ ThreadError Interpreter::ProcessRouteAdd(int argc, char *argv[])
         }
         else
         {
-            ExitNow(error = kThreadError_Parse);
+            ExitNow(error = OT_ERROR_PARSE);
         }
     }
 
@@ -2096,9 +2096,9 @@ exit:
     return error;
 }
 
-ThreadError Interpreter::ProcessRouteRemove(int argc, char *argv[])
+otError Interpreter::ProcessRouteRemove(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     struct otIp6Prefix prefix;
     int argcur = 0;
 
@@ -2106,7 +2106,7 @@ ThreadError Interpreter::ProcessRouteRemove(int argc, char *argv[])
     char *prefixLengthStr;
     char *endptr;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
 
     if ((prefixLengthStr = strchr(argv[argcur], '/')) == NULL)
     {
@@ -2121,7 +2121,7 @@ ThreadError Interpreter::ProcessRouteRemove(int argc, char *argv[])
 
     if (*endptr != '\0')
     {
-        ExitNow(error = kThreadError_Parse);
+        ExitNow(error = OT_ERROR_PARSE);
     }
 
     error = otNetDataRemoveRoute(mInstance, &prefix);
@@ -2132,9 +2132,9 @@ exit:
 
 void Interpreter::ProcessRoute(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
 
     if (strcmp(argv[0], "add") == 0)
     {
@@ -2146,7 +2146,7 @@ void Interpreter::ProcessRoute(int argc, char *argv[])
     }
     else
     {
-        ExitNow(error = kThreadError_Parse);
+        ExitNow(error = OT_ERROR_PARSE);
     }
 
 exit:
@@ -2156,12 +2156,12 @@ exit:
 #if OPENTHREAD_FTD
 void Interpreter::ProcessRouter(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otRouterInfo routerInfo;
     long value;
     bool isTable = false;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
 
     if (strcmp(argv[0], "list") == 0 || (isTable = (strcmp(argv[0], "table") == 0)))
     {
@@ -2173,7 +2173,7 @@ void Interpreter::ProcessRouter(int argc, char *argv[])
 
         for (uint8_t i = 0; ; i++)
         {
-            if (otThreadGetRouterInfo(mInstance, i, &routerInfo) != kThreadError_None)
+            if (otThreadGetRouterInfo(mInstance, i, &routerInfo) != OT_ERROR_NONE)
             {
                 sServer->OutputFormat("\r\n");
                 ExitNow();
@@ -2242,7 +2242,7 @@ exit:
 
 void Interpreter::ProcessRouterDowngradeThreshold(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
     if (argc == 0)
@@ -2261,7 +2261,7 @@ exit:
 
 void Interpreter::ProcessRouterRole(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (argc == 0)
     {
@@ -2284,7 +2284,7 @@ void Interpreter::ProcessRouterRole(int argc, char *argv[])
     }
     else
     {
-        ExitNow(error = kThreadError_Parse);
+        ExitNow(error = OT_ERROR_PARSE);
     }
 
 exit:
@@ -2293,7 +2293,7 @@ exit:
 
 void Interpreter::ProcessRouterSelectionJitter(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
     if (argc == 0)
@@ -2303,7 +2303,7 @@ void Interpreter::ProcessRouterSelectionJitter(int argc, char *argv[])
     else
     {
         SuccessOrExit(error = ParseLong(argv[0], value));
-        VerifyOrExit(0 < value && value < 256, error = kThreadError_InvalidArgs);
+        VerifyOrExit(0 < value && value < 256, error = OT_ERROR_INVALID_ARGS);
         otThreadSetRouterSelectionJitter(mInstance, static_cast<uint8_t>(value));
     }
 
@@ -2313,7 +2313,7 @@ exit:
 
 void Interpreter::ProcessRouterUpgradeThreshold(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
     if (argc == 0)
@@ -2333,7 +2333,7 @@ exit:
 
 void Interpreter::ProcessScan(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint32_t scanChannels = 0;
     long value;
 
@@ -2386,7 +2386,7 @@ exit:
 
 void Interpreter::ProcessSingleton(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (otThreadIsSingleton(mInstance))
     {
@@ -2405,7 +2405,7 @@ void Interpreter::ProcessSingleton(int argc, char *argv[])
 
 void Interpreter::ProcessState(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (argc == 0)
     {
@@ -2467,7 +2467,7 @@ void Interpreter::ProcessState(int argc, char *argv[])
 #endif  // OPENTHREAD_FTD
         else
         {
-            ExitNow(error = kThreadError_Parse);
+            ExitNow(error = OT_ERROR_PARSE);
         }
     }
 
@@ -2477,9 +2477,9 @@ exit:
 
 void Interpreter::ProcessThread(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_Parse;
+    otError error = OT_ERROR_PARSE;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
 
     if (strcmp(argv[0], "start") == 0)
     {
@@ -2498,7 +2498,7 @@ exit:
 
 void Interpreter::ProcessTxPowerMax(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
     if (argc == 0)
@@ -2519,7 +2519,7 @@ void Interpreter::ProcessVersion(int argc, char *argv[])
 {
     otStringPtr version(otGetVersionString());
     sServer->OutputFormat("%s\r\n", (const char *)version);
-    AppendResult(kThreadError_None);
+    AppendResult(OT_ERROR_NONE);
     (void)argc;
     (void)argv;
 }
@@ -2528,9 +2528,9 @@ void Interpreter::ProcessVersion(int argc, char *argv[])
 
 void Interpreter::ProcessCommissioner(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
 
     if (strcmp(argv[0], "start") == 0)
     {
@@ -2545,7 +2545,7 @@ void Interpreter::ProcessCommissioner(int argc, char *argv[])
         otExtAddress addr;
         const otExtAddress *addrPtr;
 
-        VerifyOrExit(argc > 2, error = kThreadError_Parse);
+        VerifyOrExit(argc > 2, error = OT_ERROR_PARSE);
 
         if (strcmp(argv[2], "*") == 0)
         {
@@ -2553,13 +2553,13 @@ void Interpreter::ProcessCommissioner(int argc, char *argv[])
         }
         else
         {
-            VerifyOrExit(Hex2Bin(argv[2], addr.m8, sizeof(addr)) == sizeof(addr), error = kThreadError_Parse);
+            VerifyOrExit(Hex2Bin(argv[2], addr.m8, sizeof(addr)) == sizeof(addr), error = OT_ERROR_PARSE);
             addrPtr = &addr;
         }
 
         if (strcmp(argv[1], "add") == 0)
         {
-            VerifyOrExit(argc > 3, error = kThreadError_Parse);
+            VerifyOrExit(argc > 3, error = OT_ERROR_PARSE);
             // Timeout parameter is optional - if not specified, use default value.
             unsigned long timeout = kDefaultJoinerTimeout;
 
@@ -2586,7 +2586,7 @@ void Interpreter::ProcessCommissioner(int argc, char *argv[])
         long period;
         otIp6Address address;
 
-        VerifyOrExit(argc > 4, error = kThreadError_Parse);
+        VerifyOrExit(argc > 4, error = OT_ERROR_PARSE);
 
         // mask
         SuccessOrExit(error = ParseLong(argv[1], mask));
@@ -2614,7 +2614,7 @@ void Interpreter::ProcessCommissioner(int argc, char *argv[])
         long scanDuration;
         otIp6Address address;
 
-        VerifyOrExit(argc > 5, error = kThreadError_Parse);
+        VerifyOrExit(argc > 5, error = OT_ERROR_PARSE);
 
         // mask
         SuccessOrExit(error = ParseLong(argv[1], mask));
@@ -2646,7 +2646,7 @@ void Interpreter::ProcessCommissioner(int argc, char *argv[])
         long mask;
         otIp6Address address;
 
-        VerifyOrExit(argc > 3, error = kThreadError_Parse);
+        VerifyOrExit(argc > 3, error = OT_ERROR_PARSE);
 
         // panid
         SuccessOrExit(error = ParseLong(argv[1], panid));
@@ -2672,7 +2672,7 @@ void Interpreter::ProcessCommissioner(int argc, char *argv[])
 
         for (uint8_t index = 1; index < argc; index++)
         {
-            VerifyOrExit(static_cast<size_t>(length) < sizeof(tlvs), error = kThreadError_NoBufs);
+            VerifyOrExit(static_cast<size_t>(length) < sizeof(tlvs), error = OT_ERROR_NO_BUFS);
 
             if (strcmp(argv[index], "locator") == 0)
             {
@@ -2692,16 +2692,16 @@ void Interpreter::ProcessCommissioner(int argc, char *argv[])
             }
             else if (strcmp(argv[index], "binary") == 0)
             {
-                VerifyOrExit(++index < argc, error = kThreadError_Parse);
+                VerifyOrExit(++index < argc, error = OT_ERROR_PARSE);
                 value = static_cast<long>(strlen(argv[index]) + 1) / 2;
-                VerifyOrExit(static_cast<size_t>(value) <= (sizeof(tlvs) - static_cast<size_t>(length)), error = kThreadError_NoBufs);
+                VerifyOrExit(static_cast<size_t>(value) <= (sizeof(tlvs) - static_cast<size_t>(length)), error = OT_ERROR_NO_BUFS);
                 VerifyOrExit(Interpreter::Hex2Bin(argv[index], tlvs + length, static_cast<uint16_t>(value)) >= 0,
-                             error = kThreadError_Parse);
+                             error = OT_ERROR_PARSE);
                 length += value;
             }
             else
             {
-                ExitNow(error = kThreadError_Parse);
+                ExitNow(error = OT_ERROR_PARSE);
             }
         }
 
@@ -2714,57 +2714,57 @@ void Interpreter::ProcessCommissioner(int argc, char *argv[])
         long value;
         int length = 0;
 
-        VerifyOrExit(argc > 0, error = kThreadError_Parse);
+        VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
 
         memset(&dataset, 0, sizeof(dataset));
 
         for (uint8_t index = 1; index < argc; index++)
         {
-            VerifyOrExit(static_cast<size_t>(length) < sizeof(tlvs), error = kThreadError_NoBufs);
+            VerifyOrExit(static_cast<size_t>(length) < sizeof(tlvs), error = OT_ERROR_NO_BUFS);
 
             if (strcmp(argv[index], "locator") == 0)
             {
-                VerifyOrExit(++index < argc, error = kThreadError_Parse);
+                VerifyOrExit(++index < argc, error = OT_ERROR_PARSE);
                 dataset.mIsLocatorSet = true;
                 SuccessOrExit(error = Interpreter::ParseLong(argv[index], value));
                 dataset.mLocator = static_cast<uint16_t>(value);
             }
             else if (strcmp(argv[index], "sessionid") == 0)
             {
-                VerifyOrExit(++index < argc, error = kThreadError_Parse);
+                VerifyOrExit(++index < argc, error = OT_ERROR_PARSE);
                 dataset.mIsSessionIdSet = true;
                 SuccessOrExit(error = Interpreter::ParseLong(argv[index], value));
                 dataset.mSessionId = static_cast<uint16_t>(value);
             }
             else if (strcmp(argv[index], "steeringdata") == 0)
             {
-                VerifyOrExit(++index < argc, error = kThreadError_Parse);
+                VerifyOrExit(++index < argc, error = OT_ERROR_PARSE);
                 dataset.mIsSteeringDataSet = true;
                 length = static_cast<int>((strlen(argv[index]) + 1) / 2);
-                VerifyOrExit(static_cast<size_t>(length) <= OT_STEERING_DATA_MAX_LENGTH, error = kThreadError_NoBufs);
+                VerifyOrExit(static_cast<size_t>(length) <= OT_STEERING_DATA_MAX_LENGTH, error = OT_ERROR_NO_BUFS);
                 VerifyOrExit(Interpreter::Hex2Bin(argv[index], dataset.mSteeringData.m8, static_cast<uint16_t>(length)) >= 0,
-                             error = kThreadError_Parse);
+                             error = OT_ERROR_PARSE);
                 dataset.mSteeringData.mLength = static_cast<uint8_t>(length);
                 length = 0;
             }
             else if (strcmp(argv[index], "joinerudpport") == 0)
             {
-                VerifyOrExit(++index < argc, error = kThreadError_Parse);
+                VerifyOrExit(++index < argc, error = OT_ERROR_PARSE);
                 dataset.mIsJoinerUdpPortSet = true;
                 SuccessOrExit(error = Interpreter::ParseLong(argv[index], value));
                 dataset.mJoinerUdpPort = static_cast<uint16_t>(value);
             }
             else if (strcmp(argv[index], "binary") == 0)
             {
-                VerifyOrExit(++index < argc, error = kThreadError_Parse);
+                VerifyOrExit(++index < argc, error = OT_ERROR_PARSE);
                 length = static_cast<int>((strlen(argv[index]) + 1) / 2);
-                VerifyOrExit(static_cast<size_t>(length) <= sizeof(tlvs), error = kThreadError_NoBufs);
+                VerifyOrExit(static_cast<size_t>(length) <= sizeof(tlvs), error = OT_ERROR_NO_BUFS);
                 VerifyOrExit(Interpreter::Hex2Bin(argv[index], tlvs, static_cast<uint16_t>(length)) >= 0,
-                             error = kThreadError_Parse);
+                             error = OT_ERROR_PARSE);
             }
             else
             {
-                ExitNow(error = kThreadError_Parse);
+                ExitNow(error = OT_ERROR_PARSE);
             }
         }
 
@@ -2814,14 +2814,14 @@ void Interpreter::HandlePanIdConflict(uint16_t aPanId, uint32_t aChannelMask)
 
 void Interpreter::ProcessJoiner(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
 
     if (strcmp(argv[0], "start") == 0)
     {
         const char *provisioningUrl;
-        VerifyOrExit(argc > 1, error = kThreadError_Parse);
+        VerifyOrExit(argc > 1, error = OT_ERROR_PARSE);
         provisioningUrl = (argc > 2) ? argv[2] : NULL;
         otJoinerStart(mInstance, argv[1], provisioningUrl,
                       PACKAGE_NAME, PLATFORM_INFO, PACKAGE_VERSION, NULL,
@@ -2838,16 +2838,16 @@ exit:
 
 #endif // OPENTHREAD_ENABLE_JOINER
 
-void OTCALL Interpreter::s_HandleJoinerCallback(ThreadError aError, void *aContext)
+void OTCALL Interpreter::s_HandleJoinerCallback(otError aError, void *aContext)
 {
     static_cast<Interpreter *>(aContext)->HandleJoinerCallback(aError);
 }
 
-void Interpreter::HandleJoinerCallback(ThreadError aError)
+void Interpreter::HandleJoinerCallback(otError aError)
 {
     switch (aError)
     {
-    case kThreadError_None:
+    case OT_ERROR_NONE:
         sServer->OutputFormat("Join success\r\n");
         break;
 
@@ -2860,7 +2860,7 @@ void Interpreter::HandleJoinerCallback(ThreadError aError)
 #if OPENTHREAD_FTD
 void Interpreter::ProcessJoinerPort(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
     if (argc == 0)
@@ -2880,7 +2880,7 @@ exit:
 
 void Interpreter::ProcessWhitelist(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otMacWhitelistEntry entry;
     int argcur = 0;
     uint8_t extAddr[8];
@@ -2899,7 +2899,7 @@ void Interpreter::ProcessWhitelist(int argc, char *argv[])
 
         for (uint8_t i = 0; ; i++)
         {
-            if (otLinkGetWhitelistEntry(mInstance, i, &entry) != kThreadError_None)
+            if (otLinkGetWhitelistEntry(mInstance, i, &entry) != OT_ERROR_NONE)
             {
                 break;
             }
@@ -2921,18 +2921,18 @@ void Interpreter::ProcessWhitelist(int argc, char *argv[])
     }
     else if (strcmp(argv[argcur], "add") == 0)
     {
-        VerifyOrExit(++argcur < argc, error = kThreadError_Parse);
-        VerifyOrExit(Hex2Bin(argv[argcur], extAddr, sizeof(extAddr)) == sizeof(extAddr), error = kThreadError_Parse);
+        VerifyOrExit(++argcur < argc, error = OT_ERROR_PARSE);
+        VerifyOrExit(Hex2Bin(argv[argcur], extAddr, sizeof(extAddr)) == sizeof(extAddr), error = OT_ERROR_PARSE);
 
         if (++argcur < argc)
         {
             rssi = static_cast<int8_t>(strtol(argv[argcur], NULL, 0));
-            VerifyOrExit(otLinkAddWhitelistRssi(mInstance, extAddr, rssi) == kThreadError_None, error = kThreadError_Parse);
+            VerifyOrExit(otLinkAddWhitelistRssi(mInstance, extAddr, rssi) == OT_ERROR_NONE, error = OT_ERROR_PARSE);
         }
         else
         {
             otLinkAddWhitelist(mInstance, extAddr);
-            VerifyOrExit(otLinkAddWhitelist(mInstance, extAddr) == kThreadError_None, error = kThreadError_Parse);
+            VerifyOrExit(otLinkAddWhitelist(mInstance, extAddr) == OT_ERROR_NONE, error = OT_ERROR_PARSE);
         }
     }
     else if (strcmp(argv[argcur], "clear") == 0)
@@ -2949,8 +2949,8 @@ void Interpreter::ProcessWhitelist(int argc, char *argv[])
     }
     else if (strcmp(argv[argcur], "remove") == 0)
     {
-        VerifyOrExit(++argcur < argc, error = kThreadError_Parse);
-        VerifyOrExit(Hex2Bin(argv[argcur], extAddr, sizeof(extAddr)) == sizeof(extAddr), error = kThreadError_Parse);
+        VerifyOrExit(++argcur < argc, error = OT_ERROR_PARSE);
+        VerifyOrExit(Hex2Bin(argv[argcur], extAddr, sizeof(extAddr)) == sizeof(extAddr), error = OT_ERROR_PARSE);
         otLinkRemoveWhitelist(mInstance, extAddr);
     }
 
@@ -3013,7 +3013,7 @@ void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength, Server &aServer)
     // Error prompt for unsupported commands
     if (i == sizeof(sCommands) / sizeof(sCommands[0]))
     {
-        AppendResult(kThreadError_Parse);
+        AppendResult(OT_ERROR_PARSE);
     }
 
 exit:
@@ -3057,13 +3057,13 @@ exit:
 #if OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
 void Interpreter::ProcessNetworkDiagnostic(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     struct otIp6Address address;
     uint8_t payload[2 + OT_NETWORK_DIAGNOSTIC_TYPELIST_MAX_ENTRIES];  // TypeList Type(1B), len(1B), type list
     uint8_t payloadIndex = 0;
     uint8_t paramIndex = 0;
 
-    VerifyOrExit(argc > 1 + 1, error = kThreadError_Parse);
+    VerifyOrExit(argc > 1 + 1, error = OT_ERROR_PARSE);
 
     SuccessOrExit(error = otIp6AddressFromString(argv[1], &address));
 

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -119,11 +119,11 @@ public:
      * @param[in]   aString  A pointer to the ASCII string.
      * @param[out]  aLong    A reference to where the parsed long is placed.
      *
-     * @retval kThreadError_None   Successfully parsed the ASCII string.
-     * @retval kThreadError_Parse  Could not parse the ASCII string.
+     * @retval OT_ERROR_NONE   Successfully parsed the ASCII string.
+     * @retval OT_ERROR_PARSE  Could not parse the ASCII string.
      *
      */
-    static ThreadError ParseLong(char *aString, long &aLong);
+    static otError ParseLong(char *aString, long &aLong);
 
     /**
      * This method parses an ASCII string as an unsigned long.
@@ -131,11 +131,11 @@ public:
      * @param[in]   aString          A pointer to the ASCII string.
      * @param[out]  aUnsignedLong    A reference to where the parsed unsigned long is placed.
      *
-     * @retval kThreadError_None   Successfully parsed the ASCII string.
-     * @retval kThreadError_Parse  Could not parse the ASCII string.
+     * @retval OT_ERROR_NONE   Successfully parsed the ASCII string.
+     * @retval OT_ERROR_PARSE  Could not parse the ASCII string.
      *
      */
-    static ThreadError ParseUnsignedLong(char *aString, unsigned long &aUnsignedLong);
+    static otError ParseUnsignedLong(char *aString, unsigned long &aUnsignedLong);
 
     /**
      * This method converts a hex string to binary.
@@ -156,7 +156,7 @@ private:
         kDefaultJoinerTimeout = 120,    ///< Default timeout for Joiners, in seconds.
     };
 
-    void AppendResult(ThreadError error);
+    void AppendResult(otError error);
     void OutputBytes(const uint8_t *aBytes, uint8_t aLength);
 
     void ProcessHelp(int argc, char *argv[]);
@@ -203,13 +203,13 @@ private:
     void ProcessHashMacAddress(int argc, char *argv[]);
     void ProcessIfconfig(int argc, char *argv[]);
     void ProcessIpAddr(int argc, char *argv[]);
-    ThreadError ProcessIpAddrAdd(int argc, char *argv[]);
-    ThreadError ProcessIpAddrDel(int argc, char *argv[]);
+    otError ProcessIpAddrAdd(int argc, char *argv[]);
+    otError ProcessIpAddrDel(int argc, char *argv[]);
     void ProcessIpMulticastAddr(int argc, char *argv[]);
 #ifndef OTDLL
-    ThreadError ProcessIpMulticastAddrAdd(int argc, char *argv[]);
-    ThreadError ProcessIpMulticastAddrDel(int argc, char *argv[]);
-    ThreadError ProcessMulticastPromiscuous(int argc, char *argv[]);
+    otError ProcessIpMulticastAddrAdd(int argc, char *argv[]);
+    otError ProcessIpMulticastAddrDel(int argc, char *argv[]);
+    otError ProcessMulticastPromiscuous(int argc, char *argv[]);
 #endif
 #if OPENTHREAD_ENABLE_JOINER
     void ProcessJoiner(int argc, char *argv[]);
@@ -239,9 +239,9 @@ private:
     void ProcessPing(int argc, char *argv[]);
     void ProcessPollPeriod(int argc, char *argv[]);
     void ProcessPrefix(int argc, char *argv[]);
-    ThreadError ProcessPrefixAdd(int argc, char *argv[]);
-    ThreadError ProcessPrefixRemove(int argc, char *argv[]);
-    ThreadError ProcessPrefixList(void);
+    otError ProcessPrefixAdd(int argc, char *argv[]);
+    otError ProcessPrefixRemove(int argc, char *argv[]);
+    otError ProcessPrefixList(void);
     void ProcessPromiscuous(int argc, char *argv[]);
 #if OPENTHREAD_FTD
     void ProcessPSKc(int argc, char *argv[]);
@@ -249,8 +249,8 @@ private:
 #endif
     void ProcessReset(int argc, char *argv[]);
     void ProcessRoute(int argc, char *argv[]);
-    ThreadError ProcessRouteAdd(int argc, char *argv[]);
-    ThreadError ProcessRouteRemove(int argc, char *argv[]);
+    otError ProcessRouteAdd(int argc, char *argv[]);
+    otError ProcessRouteRemove(int argc, char *argv[]);
 #if OPENTHREAD_FTD
     void ProcessRouter(int argc, char *argv[]);
     void ProcessRouterDowngradeThreshold(int argc, char *argv[]);
@@ -289,11 +289,11 @@ private:
     static void OTCALL s_HandleDiagnosticGetResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo,
                                                      void *aContext);
 #endif
-    static void OTCALL s_HandleJoinerCallback(ThreadError aError, void *aContext);
+    static void OTCALL s_HandleJoinerCallback(otError aError, void *aContext);
 
 #if OPENTHREAD_ENABLE_DNS_CLIENT
     static void s_HandleDnsResponse(void *aContext, const char *aHostname, otIp6Address *aAddress,
-                                    uint32_t aTtl, ThreadError aResult);
+                                    uint32_t aTtl, otError aResult);
 #endif
 
 #ifndef OTDLL
@@ -315,10 +315,10 @@ private:
 #ifndef OTDLL
     void HandleDiagnosticGetResponse(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 #endif
-    void HandleJoinerCallback(ThreadError aError);
+    void HandleJoinerCallback(otError aError);
 
 #if OPENTHREAD_ENABLE_DNS_CLIENT
-    void HandleDnsResponse(const char *aHostname, Ip6::Address &aAddress, uint32_t aTtl, ThreadError aResult);
+    void HandleDnsResponse(const char *aHostname, Ip6::Address &aAddress, uint32_t aTtl, otError aResult);
 #endif
 
     static const struct Command sCommands[];

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -105,9 +105,9 @@ void Coap::OutputBytes(const uint8_t *aBytes, uint8_t aLength)
     }
 }
 
-ThreadError Coap::Process(otInstance *aInstance, int argc, char *argv[], Server &aServer)
+otError Coap::Process(otInstance *aInstance, int argc, char *argv[], Server &aServer)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     sInstance = aInstance;
     sServer = &aServer;
@@ -115,7 +115,7 @@ ThreadError Coap::Process(otInstance *aInstance, int argc, char *argv[], Server 
     sResource.mContext = aInstance;
     sResource.mHandler = (otCoapRequestHandler) &Coap::s_HandleServerResponse;
 
-    VerifyOrExit(argc > 0, error = kThreadError_InvalidArgs);
+    VerifyOrExit(argc > 0, error = OT_ERROR_INVALID_ARGS);
 
     for (unsigned int i = 0; i < sizeof(sCommands) / sizeof(sCommands[0]); i++)
     {
@@ -130,11 +130,11 @@ exit:
     return error;
 }
 
-ThreadError Coap::ProcessServer(int argc, char *argv[])
+otError Coap::ProcessServer(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(argc > 0, error = kThreadError_InvalidArgs);
+    VerifyOrExit(argc > 0, error = OT_ERROR_INVALID_ARGS);
 
     ConvertToLower(argv[0]);
 
@@ -164,7 +164,7 @@ ThreadError Coap::ProcessServer(int argc, char *argv[])
     }
     else
     {
-        ExitNow(error = kThreadError_InvalidArgs);
+        ExitNow(error = OT_ERROR_INVALID_ARGS);
     }
 
 exit:
@@ -179,7 +179,7 @@ void OTCALL Coap::s_HandleServerResponse(void *aContext, otCoapHeader *aHeader, 
 
 void Coap::HandleServerResponse(otCoapHeader *aHeader, otMessage *aMessage, otMessageInfo *aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otCoapHeader responseHeader;
     otMessage *responseMessage;
     otCoapCode responseCode = kCoapCodeEmpty;
@@ -241,7 +241,7 @@ void Coap::HandleServerResponse(otCoapHeader *aHeader, otMessage *aMessage, otMe
         }
 
         responseMessage = otCoapNewMessage(sInstance, &responseHeader);
-        VerifyOrExit(responseMessage != NULL, error = kThreadError_NoBufs);
+        VerifyOrExit(responseMessage != NULL, error = OT_ERROR_NO_BUFS);
 
         if (otCoapHeaderGetCode(aHeader) == kCoapRequestGet)
         {
@@ -253,7 +253,7 @@ void Coap::HandleServerResponse(otCoapHeader *aHeader, otMessage *aMessage, otMe
 
 exit:
 
-    if (error != kThreadError_None && responseMessage != NULL)
+    if (error != OT_ERROR_NONE && responseMessage != NULL)
     {
         sServer->OutputFormat("Cannot send CoAP response message: Error %d\r\n", error);
         otMessageFree(responseMessage);
@@ -267,9 +267,9 @@ exit:
     }
 }
 
-ThreadError Coap::ProcessClient(int argc, char *argv[])
+otError Coap::ProcessClient(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otMessage *message = NULL;
     otMessageInfo messageInfo;
     otCoapHeader header;
@@ -281,7 +281,7 @@ ThreadError Coap::ProcessClient(int argc, char *argv[])
     otCoapCode coapCode = kCoapRequestGet;
     otIp6Address coapDestinationIp;
 
-    VerifyOrExit(argc > 0, error = kThreadError_InvalidArgs);
+    VerifyOrExit(argc > 0, error = OT_ERROR_INVALID_ARGS);
 
     // CoAP-Code
     ConvertToLower(argv[0]);
@@ -304,7 +304,7 @@ ThreadError Coap::ProcessClient(int argc, char *argv[])
     }
     else
     {
-        ExitNow(error = kThreadError_Parse);
+        ExitNow(error = OT_ERROR_PARSE);
     }
 
     // Destination IPv6 address
@@ -314,7 +314,7 @@ ThreadError Coap::ProcessClient(int argc, char *argv[])
     }
     else
     {
-        ExitNow(error = kThreadError_InvalidArgs);
+        ExitNow(error = OT_ERROR_INVALID_ARGS);
     }
 
     // CoAP-URI
@@ -324,7 +324,7 @@ ThreadError Coap::ProcessClient(int argc, char *argv[])
     }
     else
     {
-        ExitNow(error = kThreadError_InvalidArgs);
+        ExitNow(error = OT_ERROR_INVALID_ARGS);
     }
 
     // CoAP-Type
@@ -350,7 +350,7 @@ ThreadError Coap::ProcessClient(int argc, char *argv[])
     }
 
     message = otCoapNewMessage(sInstance, &header);
-    VerifyOrExit(message != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit(message != NULL, error = OT_ERROR_NO_BUFS);
 
     // Embed content into message if given
     if (payloadLength > 0)
@@ -377,7 +377,7 @@ ThreadError Coap::ProcessClient(int argc, char *argv[])
 
 exit:
 
-    if ((error != kThreadError_None) && (message != NULL))
+    if ((error != OT_ERROR_NONE) && (message != NULL))
     {
         otMessageFree(message);
     }
@@ -386,15 +386,15 @@ exit:
 }
 
 void OTCALL Coap::s_HandleClientResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                         otMessageInfo *aMessageInfo, ThreadError aResult)
+                                         otMessageInfo *aMessageInfo, otError aResult)
 {
     static_cast<Coap *>(aContext)->HandleClientResponse(aHeader, aMessage, aMessageInfo, aResult);
 }
 
 void Coap::HandleClientResponse(otCoapHeader *aHeader, otMessage *aMessage, otMessageInfo *aMessageInfo,
-                                ThreadError aResult)
+                                otError aResult)
 {
-    if (aResult != kThreadError_None)
+    if (aResult != OT_ERROR_NONE)
     {
         sServer->OutputFormat("Error receiving CoAP response message: %d", aResult);
     }

--- a/src/cli/cli_coap.hpp
+++ b/src/cli/cli_coap.hpp
@@ -49,7 +49,7 @@ namespace Cli {
 struct CoapCommand
 {
     const char *mName;                                 ///< A pointer to the command string.
-    ThreadError(*mCommand)(int argc, char *argv[]);    ///< A function pointer to process the command.
+    otError(*mCommand)(int argc, char *argv[]);    ///< A function pointer to process the command.
 };
 
 /**
@@ -68,7 +68,7 @@ public:
      * @param[in]  aServer  A reference to the CLI server.
      *
      */
-    static ThreadError Process(otInstance *aInstance, int argc, char *argv[], Server &aServer);
+    static otError Process(otInstance *aInstance, int argc, char *argv[], Server &aServer);
 
 private:
     enum
@@ -80,16 +80,16 @@ private:
     static void ConvertToLower(char *aString);
     static void OutputBytes(const uint8_t *aBytes, uint8_t aLength);
 
-    static ThreadError ProcessClient(int argc, char *argv[]);
-    static ThreadError ProcessServer(int argc, char *argv[]);
+    static otError ProcessClient(int argc, char *argv[]);
+    static otError ProcessServer(int argc, char *argv[]);
 
     static void OTCALL s_HandleServerResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
                                               otMessageInfo *aMessageInfo);
     static void HandleServerResponse(otCoapHeader *aHeader, otMessage *aMessage, otMessageInfo *aMessageInfo);
     static void OTCALL s_HandleClientResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                              otMessageInfo *aMessageInfo, ThreadError aResult);
+                                              otMessageInfo *aMessageInfo, otError aResult);
     static void HandleClientResponse(otCoapHeader *aHeader, otMessage *aMessage, otMessageInfo *aMessageInfo,
-                                     ThreadError aResult);
+                                     otError aResult);
 
     static const CoapCommand sCommands[];
     static Server *sServer;

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -92,7 +92,7 @@ void Dataset::OutputBytes(const uint8_t *aBytes, uint8_t aLength)
     }
 }
 
-ThreadError Dataset::Print(otOperationalDataset &aDataset)
+otError Dataset::Print(otOperationalDataset &aDataset)
 {
     if (aDataset.mIsPendingTimestampSet)
     {
@@ -193,12 +193,12 @@ ThreadError Dataset::Print(otOperationalDataset &aDataset)
         sServer->OutputFormat("\r\n");
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Dataset::Process(otInstance *aInstance, int argc, char *argv[], Server &aServer)
+otError Dataset::Process(otInstance *aInstance, int argc, char *argv[], Server &aServer)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     sServer = &aServer;
 
@@ -220,7 +220,7 @@ exit:
     return error;
 }
 
-ThreadError Dataset::ProcessHelp(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessHelp(otInstance *aInstance, int argc, char *argv[])
 {
     for (unsigned int i = 0; i < sizeof(sCommands) / sizeof(sCommands[0]); i++)
     {
@@ -230,10 +230,10 @@ ThreadError Dataset::ProcessHelp(otInstance *aInstance, int argc, char *argv[])
     (void)aInstance;
     (void)argc;
     (void)argv;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Dataset::ProcessActive(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessActive(otInstance *aInstance, int argc, char *argv[])
 {
     otOperationalDataset dataset;
     otDatasetGetActive(aInstance, &dataset);
@@ -243,7 +243,7 @@ ThreadError Dataset::ProcessActive(otInstance *aInstance, int argc, char *argv[]
     return Print(dataset);
 }
 
-ThreadError Dataset::ProcessPending(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessPending(otInstance *aInstance, int argc, char *argv[])
 {
     otOperationalDataset dataset;
     otDatasetGetPending(aInstance, &dataset);
@@ -254,12 +254,12 @@ ThreadError Dataset::ProcessPending(otInstance *aInstance, int argc, char *argv[
 }
 
 #if OPENTHREAD_FTD
-ThreadError Dataset::ProcessActiveTimestamp(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessActiveTimestamp(otInstance *aInstance, int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
     SuccessOrExit(error = Interpreter::ParseLong(argv[0], value));
     sDataset.mActiveTimestamp = static_cast<uint64_t>(value);
     sDataset.mIsActiveTimestampSet = true;
@@ -270,12 +270,12 @@ exit:
     return error;
 }
 
-ThreadError Dataset::ProcessChannel(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessChannel(otInstance *aInstance, int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
     SuccessOrExit(error = Interpreter::ParseLong(argv[0], value));
     sDataset.mChannel = static_cast<uint16_t>(value);
     sDataset.mIsChannelSet = true;
@@ -286,12 +286,12 @@ exit:
     return error;
 }
 
-ThreadError Dataset::ProcessChannelMask(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessChannelMask(otInstance *aInstance, int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
     SuccessOrExit(error = Interpreter::ParseLong(argv[0], value));
     sDataset.mChannelMaskPage0 = static_cast<uint32_t>(value);
     sDataset.mIsChannelMaskPage0Set = true;
@@ -301,20 +301,20 @@ exit:
     return error;
 }
 
-ThreadError Dataset::ProcessClear(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessClear(otInstance *aInstance, int argc, char *argv[])
 {
     memset(&sDataset, 0, sizeof(sDataset));
     (void)aInstance;
     (void)argc;
     (void)argv;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Dataset::ProcessCommit(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessCommit(otInstance *aInstance, int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(argc > 0, error = kThreadError_InvalidArgs);
+    VerifyOrExit(argc > 0, error = OT_ERROR_INVALID_ARGS);
 
     if (strcmp(argv[0], "active") == 0)
     {
@@ -326,7 +326,7 @@ ThreadError Dataset::ProcessCommit(otInstance *aInstance, int argc, char *argv[]
     }
     else
     {
-        ExitNow(error = kThreadError_Parse);
+        ExitNow(error = OT_ERROR_PARSE);
     }
 
     (void)aInstance;
@@ -335,12 +335,12 @@ exit:
     return error;
 }
 
-ThreadError Dataset::ProcessDelay(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessDelay(otInstance *aInstance, int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
     SuccessOrExit(error = Interpreter::ParseLong(argv[0], value));
     sDataset.mDelay = static_cast<uint32_t>(value);
     sDataset.mIsDelaySet = true;
@@ -351,13 +351,13 @@ exit:
     return error;
 }
 
-ThreadError Dataset::ProcessExtPanId(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessExtPanId(otInstance *aInstance, int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t extPanId[OT_EXT_PAN_ID_SIZE];
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
-    VerifyOrExit(Interpreter::Hex2Bin(argv[0], extPanId, sizeof(extPanId)) >= 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
+    VerifyOrExit(Interpreter::Hex2Bin(argv[0], extPanId, sizeof(extPanId)) >= 0, error = OT_ERROR_PARSE);
 
     memcpy(sDataset.mExtendedPanId.m8, extPanId, sizeof(sDataset.mExtendedPanId));
     sDataset.mIsExtendedPanIdSet = true;
@@ -368,15 +368,15 @@ exit:
     return error;
 }
 
-ThreadError Dataset::ProcessMasterKey(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessMasterKey(otInstance *aInstance, int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     int keyLength;
     uint8_t key[OT_MASTER_KEY_SIZE];
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
     VerifyOrExit((keyLength = Interpreter::Hex2Bin(argv[0], key, sizeof(key))) == OT_MASTER_KEY_SIZE,
-                 error = kThreadError_Parse);
+                 error = OT_ERROR_PARSE);
 
     memcpy(sDataset.mMasterKey.m8, key, sizeof(sDataset.mMasterKey));
     sDataset.mIsMasterKeySet = true;
@@ -387,12 +387,12 @@ exit:
     return error;
 }
 
-ThreadError Dataset::ProcessMeshLocalPrefix(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessMeshLocalPrefix(otInstance *aInstance, int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otIp6Address prefix;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
     SuccessOrExit(error = otIp6AddressFromString(argv[0], &prefix));
 
     memcpy(sDataset.mMeshLocalPrefix.m8, prefix.mFields.m8, sizeof(sDataset.mMeshLocalPrefix.m8));
@@ -404,13 +404,13 @@ exit:
     return error;
 }
 
-ThreadError Dataset::ProcessNetworkName(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessNetworkName(otInstance *aInstance, int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     size_t length;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
-    VerifyOrExit((length = strlen(argv[0])) <= OT_NETWORK_NAME_MAX_SIZE, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
+    VerifyOrExit((length = strlen(argv[0])) <= OT_NETWORK_NAME_MAX_SIZE, error = OT_ERROR_PARSE);
 
     memset(&sDataset.mNetworkName, 0, sizeof(sDataset.mNetworkName));
     memcpy(sDataset.mNetworkName.m8, argv[0], length);
@@ -422,12 +422,12 @@ exit:
     return error;
 }
 
-ThreadError Dataset::ProcessPanId(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessPanId(otInstance *aInstance, int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
     SuccessOrExit(error = Interpreter::ParseLong(argv[0], value));
     sDataset.mPanId = static_cast<otPanId>(value);
     sDataset.mIsPanIdSet = true;
@@ -438,12 +438,12 @@ exit:
     return error;
 }
 
-ThreadError Dataset::ProcessPendingTimestamp(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessPendingTimestamp(otInstance *aInstance, int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
     SuccessOrExit(error = Interpreter::ParseLong(argv[0], value));
     sDataset.mPendingTimestamp = static_cast<uint64_t>(value);
     sDataset.mIsPendingTimestampSet = true;
@@ -454,16 +454,16 @@ exit:
     return error;
 }
 
-ThreadError Dataset::ProcessMgmtSetCommand(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessMgmtSetCommand(otInstance *aInstance, int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otOperationalDataset dataset;
     uint8_t tlvs[128];
     long value;
     int length = 0;
     otIp6Address prefix;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
 
     memset(&dataset, 0, sizeof(dataset));
 
@@ -471,89 +471,89 @@ ThreadError Dataset::ProcessMgmtSetCommand(otInstance *aInstance, int argc, char
     {
         if (strcmp(argv[index], "activetimestamp") == 0)
         {
-            VerifyOrExit(index < argc, error = kThreadError_Parse);
+            VerifyOrExit(index < argc, error = OT_ERROR_PARSE);
             dataset.mIsActiveTimestampSet = true;
             SuccessOrExit(error = Interpreter::ParseLong(argv[++index], value));
             dataset.mActiveTimestamp = static_cast<uint64_t>(value);
         }
         else if (strcmp(argv[index], "pendingtimestamp") == 0)
         {
-            VerifyOrExit(index < argc, error = kThreadError_Parse);
+            VerifyOrExit(index < argc, error = OT_ERROR_PARSE);
             dataset.mIsPendingTimestampSet = true;
             SuccessOrExit(error = Interpreter::ParseLong(argv[++index], value));
             dataset.mPendingTimestamp = static_cast<uint64_t>(value);
         }
         else if (strcmp(argv[index], "masterkey") == 0)
         {
-            VerifyOrExit(index < argc, error = kThreadError_Parse);
+            VerifyOrExit(index < argc, error = OT_ERROR_PARSE);
             dataset.mIsMasterKeySet = true;
             VerifyOrExit((length = Interpreter::Hex2Bin(argv[++index], dataset.mMasterKey.m8,
-                                                        sizeof(dataset.mMasterKey.m8))) == OT_MASTER_KEY_SIZE, error = kThreadError_Parse);
+                                                        sizeof(dataset.mMasterKey.m8))) == OT_MASTER_KEY_SIZE, error = OT_ERROR_PARSE);
             length = 0;
         }
         else if (strcmp(argv[index], "networkname") == 0)
         {
-            VerifyOrExit(index < argc, error = kThreadError_Parse);
+            VerifyOrExit(index < argc, error = OT_ERROR_PARSE);
             dataset.mIsNetworkNameSet = true;
             VerifyOrExit((length = static_cast<int>(strlen(argv[++index]))) <= OT_NETWORK_NAME_MAX_SIZE,
-                         error = kThreadError_Parse);
+                         error = OT_ERROR_PARSE);
             memset(&dataset.mNetworkName, 0, sizeof(sDataset.mNetworkName));
             memcpy(dataset.mNetworkName.m8, argv[index], static_cast<size_t>(length));
             length = 0;
         }
         else if (strcmp(argv[index], "extpanid") == 0)
         {
-            VerifyOrExit(index < argc, error = kThreadError_Parse);
+            VerifyOrExit(index < argc, error = OT_ERROR_PARSE);
             dataset.mIsExtendedPanIdSet = true;
             VerifyOrExit(Interpreter::Hex2Bin(argv[++index], dataset.mExtendedPanId.m8,
-                                              sizeof(dataset.mExtendedPanId.m8)) >= 0, error = kThreadError_Parse);
+                                              sizeof(dataset.mExtendedPanId.m8)) >= 0, error = OT_ERROR_PARSE);
         }
         else if (strcmp(argv[index], "localprefix") == 0)
         {
-            VerifyOrExit(index < argc, error = kThreadError_Parse);
+            VerifyOrExit(index < argc, error = OT_ERROR_PARSE);
             dataset.mIsMeshLocalPrefixSet = true;
             SuccessOrExit(error = otIp6AddressFromString(argv[++index], &prefix));
             memcpy(dataset.mMeshLocalPrefix.m8, prefix.mFields.m8, sizeof(dataset.mMeshLocalPrefix.m8));
         }
         else if (strcmp(argv[index], "delaytimer") == 0)
         {
-            VerifyOrExit(index < argc, error = kThreadError_Parse);
+            VerifyOrExit(index < argc, error = OT_ERROR_PARSE);
             dataset.mIsDelaySet = true;
             SuccessOrExit(error = Interpreter::ParseLong(argv[++index], value));
             dataset.mDelay = static_cast<uint32_t>(value);
         }
         else if (strcmp(argv[index], "panid") == 0)
         {
-            VerifyOrExit(index < argc, error = kThreadError_Parse);
+            VerifyOrExit(index < argc, error = OT_ERROR_PARSE);
             dataset.mIsPanIdSet = true;
             SuccessOrExit(error = Interpreter::ParseLong(argv[++index], value));
             dataset.mPanId = static_cast<otPanId>(value);
         }
         else if (strcmp(argv[index], "channel") == 0)
         {
-            VerifyOrExit(index < argc, error = kThreadError_Parse);
+            VerifyOrExit(index < argc, error = OT_ERROR_PARSE);
             dataset.mIsChannelSet = true;
             SuccessOrExit(error = Interpreter::ParseLong(argv[++index], value));
             dataset.mChannel = static_cast<uint16_t>(value);
         }
         else if (strcmp(argv[index], "channelmask") == 0)
         {
-            VerifyOrExit(index < argc, error = kThreadError_Parse);
+            VerifyOrExit(index < argc, error = OT_ERROR_PARSE);
             dataset.mIsChannelMaskPage0Set = true;
             SuccessOrExit(error = Interpreter::ParseLong(argv[++index], value));
             dataset.mChannelMaskPage0 = static_cast<uint32_t>(value);
         }
         else if (strcmp(argv[index], "binary") == 0)
         {
-            VerifyOrExit((index + 1) < argc, error = kThreadError_Parse);
+            VerifyOrExit((index + 1) < argc, error = OT_ERROR_PARSE);
             length = static_cast<int>((strlen(argv[++index]) + 1) / 2);
-            VerifyOrExit(static_cast<size_t>(length) <= sizeof(tlvs), error = kThreadError_NoBufs);
+            VerifyOrExit(static_cast<size_t>(length) <= sizeof(tlvs), error = OT_ERROR_NO_BUFS);
             VerifyOrExit(Interpreter::Hex2Bin(argv[index], tlvs, static_cast<uint16_t>(length)) >= 0,
-                         error = kThreadError_Parse);
+                         error = OT_ERROR_PARSE);
         }
         else
         {
-            ExitNow(error = kThreadError_Parse);
+            ExitNow(error = OT_ERROR_PARSE);
         }
     }
 
@@ -567,7 +567,7 @@ ThreadError Dataset::ProcessMgmtSetCommand(otInstance *aInstance, int argc, char
     }
     else
     {
-        ExitNow(error = kThreadError_Parse);
+        ExitNow(error = OT_ERROR_PARSE);
     }
 
     (void)aInstance;
@@ -576,9 +576,9 @@ exit:
     return error;
 }
 
-ThreadError Dataset::ProcessMgmtGetCommand(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessMgmtGetCommand(otInstance *aInstance, int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otOperationalDataset dataset;
     uint8_t tlvs[32];
     long value;
@@ -586,13 +586,13 @@ ThreadError Dataset::ProcessMgmtGetCommand(otInstance *aInstance, int argc, char
     bool destAddrSpecified = false;
     otIp6Address address;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
 
     memset(&dataset, 0, sizeof(dataset));
 
     for (uint8_t index = 1; index < argc; index++)
     {
-        VerifyOrExit(static_cast<size_t>(length) < sizeof(tlvs), error = kThreadError_NoBufs);
+        VerifyOrExit(static_cast<size_t>(length) < sizeof(tlvs), error = OT_ERROR_NO_BUFS);
 
         if (strcmp(argv[index], "activetimestamp") == 0)
         {
@@ -632,22 +632,22 @@ ThreadError Dataset::ProcessMgmtGetCommand(otInstance *aInstance, int argc, char
         }
         else if (strcmp(argv[index], "binary") == 0)
         {
-            VerifyOrExit((index + 1) < argc, error = kThreadError_Parse);
+            VerifyOrExit((index + 1) < argc, error = OT_ERROR_PARSE);
             value = static_cast<long>(strlen(argv[++index]) + 1) / 2;
-            VerifyOrExit(static_cast<size_t>(value) <= (sizeof(tlvs) - static_cast<size_t>(length)), error = kThreadError_NoBufs);
+            VerifyOrExit(static_cast<size_t>(value) <= (sizeof(tlvs) - static_cast<size_t>(length)), error = OT_ERROR_NO_BUFS);
             VerifyOrExit(Interpreter::Hex2Bin(argv[index], tlvs + length, static_cast<uint16_t>(value)) >= 0,
-                         error = kThreadError_Parse);
+                         error = OT_ERROR_PARSE);
             length += value;
         }
         else if (strcmp(argv[index], "address") == 0)
         {
-            VerifyOrExit(index < argc, error = kThreadError_Parse);
+            VerifyOrExit(index < argc, error = OT_ERROR_PARSE);
             SuccessOrExit(error = otIp6AddressFromString(argv[++index], &address));
             destAddrSpecified = true;
         }
         else
         {
-            ExitNow(error = kThreadError_Parse);
+            ExitNow(error = OT_ERROR_PARSE);
         }
     }
 
@@ -663,7 +663,7 @@ ThreadError Dataset::ProcessMgmtGetCommand(otInstance *aInstance, int argc, char
     }
     else
     {
-        ExitNow(error = kThreadError_Parse);
+        ExitNow(error = OT_ERROR_PARSE);
     }
 
     (void)aInstance;
@@ -672,16 +672,16 @@ exit:
     return error;
 }
 
-ThreadError Dataset::ProcessPSKc(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessPSKc(otInstance *aInstance, int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint16_t length;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
     length = static_cast<uint16_t>((strlen(argv[0]) + 1) / 2);
-    VerifyOrExit(length <= OT_PSKC_MAX_SIZE, error = kThreadError_NoBufs);
+    VerifyOrExit(length <= OT_PSKC_MAX_SIZE, error = OT_ERROR_NO_BUFS);
     VerifyOrExit(Interpreter::Hex2Bin(argv[0], sDataset.mPSKc.m8 + OT_PSKC_MAX_SIZE - length, length) == length,
-                 error = kThreadError_Parse);
+                 error = OT_ERROR_PARSE);
 
     sDataset.mIsPSKcSet = true;
     (void)aInstance;
@@ -690,12 +690,12 @@ exit:
     return error;
 }
 
-ThreadError Dataset::ProcessSecurityPolicy(otInstance *aInstance, int argc, char *argv[])
+otError Dataset::ProcessSecurityPolicy(otInstance *aInstance, int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
-    VerifyOrExit(argc > 0, error = kThreadError_Parse);
+    VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
 
     SuccessOrExit(error = Interpreter::ParseLong(argv[0], value));
     sDataset.mSecurityPolicy.mRotationTime = static_cast<uint16_t>(value);
@@ -728,7 +728,7 @@ ThreadError Dataset::ProcessSecurityPolicy(otInstance *aInstance, int argc, char
                 break;
 
             default:
-                ExitNow(error = kThreadError_Parse);
+                ExitNow(error = OT_ERROR_PARSE);
             }
         }
     }

--- a/src/cli/cli_dataset.hpp
+++ b/src/cli/cli_dataset.hpp
@@ -47,9 +47,8 @@ namespace Cli {
  */
 struct DatasetCommand
 {
-    const char *mName;                                                      ///< A pointer to the command string.
-    ThreadError(*mCommand)(otInstance *aInstance, int argc,
-                           char *argv[]);    ///< A function pointer to process the command.
+    const char *mName;                                                  ///< A pointer to the command string.
+    otError(*mCommand)(otInstance *aInstance, int argc, char *argv[]);  ///< A function pointer to process the command.
 };
 
 /**
@@ -66,31 +65,31 @@ public:
      * @param[in]  argv  A pointer to an array of command line arguments.
      *
      */
-    static ThreadError Process(otInstance *aInstance, int argc, char *argv[], Server &aServer);
+    static otError Process(otInstance *aInstance, int argc, char *argv[], Server &aServer);
 
 private:
     static void OutputBytes(const uint8_t *aBytes, uint8_t aLength);
-    static ThreadError Print(otOperationalDataset &aDataset);
+    static otError Print(otOperationalDataset &aDataset);
 
-    static ThreadError ProcessHelp(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessActive(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessActiveTimestamp(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessChannel(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessChannelMask(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessClear(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessCommit(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessDelay(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessExtPanId(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessMasterKey(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessMeshLocalPrefix(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessNetworkName(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessPanId(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessPending(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessPendingTimestamp(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessMgmtSetCommand(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessMgmtGetCommand(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessPSKc(otInstance *aInstance, int argc, char *argv[]);
-    static ThreadError ProcessSecurityPolicy(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessHelp(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessActive(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessActiveTimestamp(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessChannel(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessChannelMask(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessClear(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessCommit(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessDelay(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessExtPanId(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessMasterKey(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessMeshLocalPrefix(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessNetworkName(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessPanId(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessPending(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessPendingTimestamp(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessMgmtSetCommand(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessMgmtGetCommand(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessPSKc(otInstance *aInstance, int argc, char *argv[]);
+    static otError ProcessSecurityPolicy(otInstance *aInstance, int argc, char *argv[]);
 
     static const DatasetCommand sCommands[];
     static otOperationalDataset sDataset;

--- a/src/cli/cli_instance.cpp
+++ b/src/cli/cli_instance.cpp
@@ -93,7 +93,7 @@ void Interpreter::ProcessInstanceList(int argc, char *argv[])
 
 void Interpreter::ProcessInstance(int argc, char *argv[])
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
     if (argc == 0)
@@ -113,7 +113,7 @@ void Interpreter::ProcessInstance(int argc, char *argv[])
     else
     {
         SuccessOrExit(error = ParseLong(argv[0], value));
-        VerifyOrExit(value >= 0 && value < mInstancesLength, error = kThreadError_InvalidArgs);
+        VerifyOrExit(value >= 0 && value < mInstancesLength, error = OT_ERROR_INVALID_ARGS);
 
         mInstanceIndex = (uint8_t)value;
         mInstance = mInstances[mInstanceIndex].aInstance;

--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -138,9 +138,9 @@ void Uart::ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength)
     }
 }
 
-ThreadError Uart::ProcessCommand(void)
+otError Uart::ProcessCommand(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (mRxBuffer[mRxLength - 1] == '\n')
     {

--- a/src/cli/cli_uart.hpp
+++ b/src/cli/cli_uart.hpp
@@ -104,7 +104,7 @@ private:
         kMaxLineLength = 128,
     };
 
-    ThreadError ProcessCommand(void);
+    otError ProcessCommand(void);
     void Send(void);
 
     char mRxBuffer[kRxBufferSize];

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -57,9 +57,9 @@ Udp::Udp(otInstance *aInstance, Interpreter *aInterpreter):
     memset(&mPeer, 0, sizeof(mPeer));
 }
 
-ThreadError Udp::Start(void)
+otError Udp::Start(void)
 {
-    ThreadError error;
+    otError error;
 
     otSockAddr sockaddr;
     memset(&sockaddr, 0, sizeof(otSockAddr));
@@ -105,17 +105,17 @@ exit:
 
 int Udp::Output(const char *aBuf, uint16_t aBufLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otMessage *message;
 
-    VerifyOrExit((message = otUdpNewMessage(mInstance, true)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = otUdpNewMessage(mInstance, true)) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = otMessageSetLength(message, aBufLength));
     otMessageWrite(message, 0, aBuf, aBufLength);
     SuccessOrExit(error = otUdpSend(&mSocket, message, &mPeer));
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         otMessageFree(message);
         aBufLength = 0;

--- a/src/cli/cli_udp.hpp
+++ b/src/cli/cli_udp.hpp
@@ -61,10 +61,10 @@ public:
     /**
      * This method starts the CLI server.
      *
-     * @retval kThreadError_None  Successfully started the server.
+     * @retval OT_ERROR_NONE  Successfully started the server.
      *
      */
-    ThreadError Start(void);
+    otError Start(void);
 
     /**
      * This method delivers raw characters to the client.

--- a/src/core/api/border_agent_proxy_api.cpp
+++ b/src/core/api/border_agent_proxy_api.cpp
@@ -39,18 +39,18 @@ using namespace ot;
 
 #if OPENTHREAD_FTD && OPENTHREAD_ENABLE_BORDER_AGENT_PROXY
 
-ThreadError otBorderAgentProxyStart(otInstance *aInstance, otBorderAgentProxyStreamHandler aBorderAgentProxyCallback,
-                                    void *aContext)
+otError otBorderAgentProxyStart(otInstance *aInstance, otBorderAgentProxyStreamHandler aBorderAgentProxyCallback,
+                                void *aContext)
 {
     return aInstance->mThreadNetif.GetBorderAgentProxy().Start(aBorderAgentProxyCallback, aContext);
 }
 
-ThreadError otBorderAgentProxyStop(otInstance *aInstance)
+otError otBorderAgentProxyStop(otInstance *aInstance)
 {
     return aInstance->mThreadNetif.GetBorderAgentProxy().Stop();
 }
 
-ThreadError otBorderAgentProxySend(otInstance *aInstance, otMessage *aMessage, uint16_t aLocator, uint16_t aPort)
+otError otBorderAgentProxySend(otInstance *aInstance, otMessage *aMessage, uint16_t aLocator, uint16_t aPort)
 {
     return aInstance->mThreadNetif.GetBorderAgentProxy().Send(*static_cast<Message *>(aMessage), aLocator, aPort);
 }

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -56,32 +56,32 @@ void otCoapHeaderGenerateToken(otCoapHeader *aHeader, uint8_t aTokenLength)
     static_cast<Coap::Header *>(aHeader)->SetToken(aTokenLength);
 }
 
-ThreadError otCoapHeaderAppendOption(otCoapHeader *aHeader, const otCoapOption *aOption)
+otError otCoapHeaderAppendOption(otCoapHeader *aHeader, const otCoapOption *aOption)
 {
     return static_cast<Coap::Header *>(aHeader)->AppendOption(*static_cast<const Coap::Header::Option *>(aOption));
 }
 
-ThreadError otCoapHeaderAppendUintOption(otCoapHeader *aHeader, uint16_t aNumber, uint32_t aValue)
+otError otCoapHeaderAppendUintOption(otCoapHeader *aHeader, uint16_t aNumber, uint32_t aValue)
 {
     return static_cast<Coap::Header *>(aHeader)->AppendUintOption(aNumber, aValue);
 }
 
-ThreadError otCoapHeaderAppendObserveOption(otCoapHeader *aHeader, uint32_t aObserve)
+otError otCoapHeaderAppendObserveOption(otCoapHeader *aHeader, uint32_t aObserve)
 {
     return static_cast<Coap::Header *>(aHeader)->AppendObserveOption(aObserve);
 }
 
-ThreadError otCoapHeaderAppendUriPathOptions(otCoapHeader *aHeader, const char *aUriPath)
+otError otCoapHeaderAppendUriPathOptions(otCoapHeader *aHeader, const char *aUriPath)
 {
     return static_cast<Coap::Header *>(aHeader)->AppendUriPathOptions(aUriPath);
 }
 
-ThreadError otCoapHeaderAppendMaxAgeOption(otCoapHeader *aHeader, uint32_t aMaxAge)
+otError otCoapHeaderAppendMaxAgeOption(otCoapHeader *aHeader, uint32_t aMaxAge)
 {
     return static_cast<Coap::Header *>(aHeader)->AppendMaxAgeOption(aMaxAge);
 }
 
-ThreadError otCoapHeaderAppendUriQueryOption(otCoapHeader *aHeader, const char *aUriQuery)
+otError otCoapHeaderAppendUriQueryOption(otCoapHeader *aHeader, const char *aUriQuery)
 {
     return static_cast<Coap::Header *>(aHeader)->AppendUriQueryOption(aUriQuery);
 }
@@ -140,8 +140,8 @@ exit:
     return message;
 }
 
-ThreadError otCoapSendRequest(otInstance *aInstance, otMessage *aMessage, const otMessageInfo *aMessageInfo,
-                              otCoapResponseHandler aHandler, void *aContext)
+otError otCoapSendRequest(otInstance *aInstance, otMessage *aMessage, const otMessageInfo *aMessageInfo,
+                          otCoapResponseHandler aHandler, void *aContext)
 {
     return aInstance->mApplicationCoap.SendMessage(
                *static_cast<Message *>(aMessage),
@@ -149,17 +149,17 @@ ThreadError otCoapSendRequest(otInstance *aInstance, otMessage *aMessage, const 
                aHandler, aContext);
 }
 
-ThreadError otCoapStart(otInstance *aInstance, uint16_t aPort)
+otError otCoapStart(otInstance *aInstance, uint16_t aPort)
 {
     return aInstance->mApplicationCoap.Start(aPort);
 }
 
-ThreadError otCoapStop(otInstance *aInstance)
+otError otCoapStop(otInstance *aInstance)
 {
     return aInstance->mApplicationCoap.Stop();
 }
 
-ThreadError otCoapAddResource(otInstance *aInstance, otCoapResource *aResource)
+otError otCoapAddResource(otInstance *aInstance, otCoapResource *aResource)
 {
     return aInstance->mApplicationCoap.AddResource(*static_cast<Coap::Resource *>(aResource));
 }
@@ -174,7 +174,7 @@ void otCoapSetDefaultHandler(otInstance *aInstance, otCoapRequestHandler aHandle
     aInstance->mApplicationCoap.SetDefaultHandler(aHandler, aContext);
 }
 
-ThreadError otCoapSendResponse(otInstance *aInstance, otMessage *aMessage, const otMessageInfo *aMessageInfo)
+otError otCoapSendResponse(otInstance *aInstance, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
     return aInstance->mApplicationCoap.SendMessage(
                *static_cast<Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo));

--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -39,64 +39,64 @@ using namespace ot;
 
 #if OPENTHREAD_FTD && OPENTHREAD_ENABLE_COMMISSIONER
 
-ThreadError otCommissionerStart(otInstance *aInstance)
+otError otCommissionerStart(otInstance *aInstance)
 {
     return aInstance->mThreadNetif.GetCommissioner().Start();
 }
 
-ThreadError otCommissionerStop(otInstance *aInstance)
+otError otCommissionerStop(otInstance *aInstance)
 {
     return aInstance->mThreadNetif.GetCommissioner().Stop();
 }
 
-ThreadError otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *aExtAddress, const char *aPSKd,
-                                    uint32_t aTimeout)
+otError otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *aExtAddress, const char *aPSKd,
+                                uint32_t aTimeout)
 {
     return aInstance->mThreadNetif.GetCommissioner().AddJoiner(static_cast<const Mac::ExtAddress *>(aExtAddress), aPSKd,
                                                                aTimeout);
 }
 
-ThreadError otCommissionerRemoveJoiner(otInstance *aInstance, const otExtAddress *aExtAddress)
+otError otCommissionerRemoveJoiner(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
     return aInstance->mThreadNetif.GetCommissioner().RemoveJoiner(static_cast<const Mac::ExtAddress *>(aExtAddress), 0);
 }
 
-ThreadError otCommissionerSetProvisioningUrl(otInstance *aInstance, const char *aProvisioningUrl)
+otError otCommissionerSetProvisioningUrl(otInstance *aInstance, const char *aProvisioningUrl)
 {
     return aInstance->mThreadNetif.GetCommissioner().SetProvisioningUrl(aProvisioningUrl);
 }
 
-ThreadError otCommissionerAnnounceBegin(otInstance *aInstance, uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod,
-                                        const otIp6Address *aAddress)
+otError otCommissionerAnnounceBegin(otInstance *aInstance, uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod,
+                                    const otIp6Address *aAddress)
 {
     return aInstance->mThreadNetif.GetCommissioner().mAnnounceBegin.SendRequest(aChannelMask, aCount, aPeriod,
                                                                                 *static_cast<const Ip6::Address *>(aAddress));
 }
 
-ThreadError otCommissionerEnergyScan(otInstance *aInstance, uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod,
-                                     uint16_t aScanDuration, const otIp6Address *aAddress,
-                                     otCommissionerEnergyReportCallback aCallback, void *aContext)
+otError otCommissionerEnergyScan(otInstance *aInstance, uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod,
+                                 uint16_t aScanDuration, const otIp6Address *aAddress,
+                                 otCommissionerEnergyReportCallback aCallback, void *aContext)
 {
     return aInstance->mThreadNetif.GetCommissioner().mEnergyScan.SendQuery(aChannelMask, aCount, aPeriod, aScanDuration,
                                                                            *static_cast<const Ip6::Address *>(aAddress),
                                                                            aCallback, aContext);
 }
 
-ThreadError otCommissionerPanIdQuery(otInstance *aInstance, uint16_t aPanId, uint32_t aChannelMask,
-                                     const otIp6Address *aAddress,
-                                     otCommissionerPanIdConflictCallback aCallback, void *aContext)
+otError otCommissionerPanIdQuery(otInstance *aInstance, uint16_t aPanId, uint32_t aChannelMask,
+                                 const otIp6Address *aAddress,
+                                 otCommissionerPanIdConflictCallback aCallback, void *aContext)
 {
     return aInstance->mThreadNetif.GetCommissioner().mPanIdQuery.SendQuery(
                aPanId, aChannelMask, *static_cast<const Ip6::Address *>(aAddress), aCallback, aContext);
 }
 
-ThreadError otCommissionerSendMgmtGet(otInstance *aInstance, const uint8_t *aTlvs, uint8_t aLength)
+otError otCommissionerSendMgmtGet(otInstance *aInstance, const uint8_t *aTlvs, uint8_t aLength)
 {
     return aInstance->mThreadNetif.GetCommissioner().SendMgmtCommissionerGetRequest(aTlvs, aLength);
 }
 
-ThreadError otCommissionerSendMgmtSet(otInstance *aInstance, const otCommissioningDataset *aDataset,
-                                      const uint8_t *aTlvs, uint8_t aLength)
+otError otCommissionerSendMgmtSet(otInstance *aInstance, const otCommissioningDataset *aDataset,
+                                  const uint8_t *aTlvs, uint8_t aLength)
 {
     return aInstance->mThreadNetif.GetCommissioner().SendMgmtCommissionerSetRequest(*aDataset, aTlvs, aLength);
 }
@@ -111,8 +111,8 @@ otCommissionerState otCommissionerGetState(otInstance *aInstance)
     return aInstance->mThreadNetif.GetCommissioner().GetState();
 }
 
-ThreadError otCommissionerGeneratePSKc(otInstance *aInstance, const char *aPassPhrase, const char *aNetworkName,
-                                       const uint8_t *aExtPanId, uint8_t *aPSKc)
+otError otCommissionerGeneratePSKc(otInstance *aInstance, const char *aPassPhrase, const char *aNetworkName,
+                                   const uint8_t *aExtPanId, uint8_t *aPSKc)
 {
     return aInstance->mThreadNetif.GetCommissioner().GeneratePSKc(aPassPhrase, aNetworkName, aExtPanId, aPSKc);
 }

--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -52,11 +52,11 @@ bool otDatasetIsCommissioned(otInstance *aInstance)
     return false;
 }
 
-ThreadError otDatasetGetActive(otInstance *aInstance, otOperationalDataset *aDataset)
+otError otDatasetGetActive(otInstance *aInstance, otOperationalDataset *aDataset)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aDataset != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aDataset != NULL, error = OT_ERROR_INVALID_ARGS);
 
     aInstance->mThreadNetif.GetActiveDataset().GetLocal().Get(*aDataset);
 
@@ -64,11 +64,11 @@ exit:
     return error;
 }
 
-ThreadError otDatasetGetPending(otInstance *aInstance, otOperationalDataset *aDataset)
+otError otDatasetGetPending(otInstance *aInstance, otOperationalDataset *aDataset)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aDataset != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aDataset != NULL, error = OT_ERROR_INVALID_ARGS);
 
     aInstance->mThreadNetif.GetPendingDataset().GetLocal().Get(*aDataset);
 

--- a/src/core/api/dataset_ftd_api.cpp
+++ b/src/core/api/dataset_ftd_api.cpp
@@ -39,11 +39,11 @@
 
 using namespace ot;
 
-ThreadError otDatasetSetActive(otInstance *aInstance, const otOperationalDataset *aDataset)
+otError otDatasetSetActive(otInstance *aInstance, const otOperationalDataset *aDataset)
 {
-    ThreadError error;
+    otError error;
 
-    VerifyOrExit(aDataset != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aDataset != NULL, error = OT_ERROR_INVALID_ARGS);
 
     error = aInstance->mThreadNetif.GetActiveDataset().Set(*aDataset);
 
@@ -51,11 +51,11 @@ exit:
     return error;
 }
 
-ThreadError otDatasetSetPending(otInstance *aInstance, const otOperationalDataset *aDataset)
+otError otDatasetSetPending(otInstance *aInstance, const otOperationalDataset *aDataset)
 {
-    ThreadError error;
+    otError error;
 
-    VerifyOrExit(aDataset != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aDataset != NULL, error = OT_ERROR_INVALID_ARGS);
 
     error = aInstance->mThreadNetif.GetPendingDataset().Set(*aDataset);
 
@@ -63,26 +63,26 @@ exit:
     return error;
 }
 
-ThreadError otDatasetSendMgmtActiveGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength,
-                                       const otIp6Address *aAddress)
+otError otDatasetSendMgmtActiveGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength,
+                                   const otIp6Address *aAddress)
 {
     return aInstance->mThreadNetif.GetActiveDataset().SendGetRequest(aTlvTypes, aLength, aAddress);
 }
 
-ThreadError otDatasetSendMgmtActiveSet(otInstance *aInstance, const otOperationalDataset *aDataset,
-                                       const uint8_t *aTlvs, uint8_t aLength)
+otError otDatasetSendMgmtActiveSet(otInstance *aInstance, const otOperationalDataset *aDataset,
+                                   const uint8_t *aTlvs, uint8_t aLength)
 {
     return aInstance->mThreadNetif.GetActiveDataset().SendSetRequest(*aDataset, aTlvs, aLength);
 }
 
-ThreadError otDatasetSendMgmtPendingGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength,
-                                        const otIp6Address *aAddress)
+otError otDatasetSendMgmtPendingGet(otInstance *aInstance, const uint8_t *aTlvTypes, uint8_t aLength,
+                                    const otIp6Address *aAddress)
 {
     return aInstance->mThreadNetif.GetPendingDataset().SendGetRequest(aTlvTypes, aLength, aAddress);
 }
 
-ThreadError otDatasetSendMgmtPendingSet(otInstance *aInstance, const otOperationalDataset *aDataset,
-                                        const uint8_t *aTlvs, uint8_t aLength)
+otError otDatasetSendMgmtPendingSet(otInstance *aInstance, const otOperationalDataset *aDataset,
+                                    const uint8_t *aTlvs, uint8_t aLength)
 {
     return aInstance->mThreadNetif.GetPendingDataset().SendSetRequest(*aDataset, aTlvs, aLength);
 }
@@ -92,7 +92,7 @@ uint32_t otDatasetGetDelayTimerMinimal(otInstance *aInstance)
     return aInstance->mThreadNetif.GetLeader().GetDelayTimerMinimal();
 }
 
-ThreadError otDatasetSetDelayTimerMinimal(otInstance *aInstance, uint32_t aDelayTimerMinimal)
+otError otDatasetSetDelayTimerMinimal(otInstance *aInstance, uint32_t aDelayTimerMinimal)
 {
     return aInstance->mThreadNetif.GetLeader().SetDelayTimerMinimal(aDelayTimerMinimal);
 }

--- a/src/core/api/dns_api.cpp
+++ b/src/core/api/dns_api.cpp
@@ -38,8 +38,8 @@
 using namespace ot;
 
 #if OPENTHREAD_ENABLE_DNS_CLIENT
-ThreadError otDnsClientQuery(otInstance *aInstance, const otDnsQuery *aQuery, otDnsResponseHandler aHandler,
-                             void *aContext)
+otError otDnsClientQuery(otInstance *aInstance, const otDnsQuery *aQuery, otDnsResponseHandler aHandler,
+                         void *aContext)
 {
     return aInstance->mThreadNetif.GetDnsClient().Query(aQuery, aHandler, aContext);
 }

--- a/src/core/api/icmp6_api.cpp
+++ b/src/core/api/icmp6_api.cpp
@@ -47,13 +47,13 @@ void otIcmp6SetEchoEnabled(otInstance *aInstance, bool aEnabled)
     aInstance->mIp6.mIcmp.SetEchoEnabled(aEnabled);
 }
 
-ThreadError otIcmp6RegisterHandler(otInstance *aInstance, otIcmp6Handler *aHandler)
+otError otIcmp6RegisterHandler(otInstance *aInstance, otIcmp6Handler *aHandler)
 {
     return aInstance->mIp6.mIcmp.RegisterHandler(*static_cast<Ip6::IcmpHandler *>(aHandler));
 }
 
-ThreadError otIcmp6SendEchoRequest(otInstance *aInstance, otMessage *aMessage,
-                                   const otMessageInfo *aMessageInfo, uint16_t aIdentifier)
+otError otIcmp6SendEchoRequest(otInstance *aInstance, otMessage *aMessage,
+                               const otMessageInfo *aMessageInfo, uint16_t aIdentifier)
 {
     return aInstance->mIp6.mIcmp.SendEchoRequest(*static_cast<Message *>(aMessage),
                                                  *static_cast<const Ip6::MessageInfo *>(aMessageInfo),

--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -85,10 +85,10 @@ void otInstancePostConstructor(otInstance *aInstance)
     // If auto start is configured, do that now
     if (otThreadGetAutoStart(aInstance))
     {
-        if (otIp6SetEnabled(aInstance, true) == kThreadError_None)
+        if (otIp6SetEnabled(aInstance, true) == OT_ERROR_NONE)
         {
             // Only try to start Thread if we could bring up the interface
-            if (otThreadSetEnabled(aInstance, true) != kThreadError_None)
+            if (otThreadSetEnabled(aInstance, true) != OT_ERROR_NONE)
             {
                 // Bring the interface down if Thread failed to start
                 otIp6SetEnabled(aInstance, false);
@@ -166,9 +166,9 @@ void otInstanceFinalize(otInstance *aInstance)
     otLogFuncExit();
 }
 
-ThreadError otSetStateChangedCallback(otInstance *aInstance, otStateChangedCallback aCallback, void *aCallbackContext)
+otError otSetStateChangedCallback(otInstance *aInstance, otStateChangedCallback aCallback, void *aCallbackContext)
 {
-    ThreadError error = kThreadError_NoBufs;
+    otError error = OT_ERROR_NO_BUFS;
 
     for (size_t i = 0; i < OPENTHREAD_CONFIG_MAX_STATECHANGE_HANDLERS; i++)
     {
@@ -207,11 +207,11 @@ void otInstanceFactoryReset(otInstance *aInstance)
     otPlatReset(aInstance);
 }
 
-ThreadError otInstanceErasePersistentInfo(otInstance *aInstance)
+otError otInstanceErasePersistentInfo(otInstance *aInstance)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(otThreadGetDeviceRole(aInstance) == kDeviceRoleDisabled, error = kThreadError_InvalidState);
+    VerifyOrExit(otThreadGetDeviceRole(aInstance) == kDeviceRoleDisabled, error = OT_ERROR_INVALID_STATE);
     otPlatSettingsWipe(aInstance);
 
 exit:
@@ -232,14 +232,14 @@ otLogLevel otGetDynamicLogLevel(otInstance *aInstance)
     return logLevel;
 }
 
-ThreadError otSetDynamicLogLevel(otInstance *aInstance, otLogLevel aLogLevel)
+otError otSetDynamicLogLevel(otInstance *aInstance, otLogLevel aLogLevel)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
 #if OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
     aInstance->mLogLevel = aLogLevel;
 #else
-    error = kThreadError_NotCapable;
+    error = OT_ERROR_NOT_CAPABLE;
     (void)aInstance;
     (void)aLogLevel;
 #endif

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -41,23 +41,23 @@
 
 using namespace ot;
 
-ThreadError otIp6SetEnabled(otInstance *aInstance, bool aEnabled)
+otError otIp6SetEnabled(otInstance *aInstance, bool aEnabled)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     otLogFuncEntry();
 
     if (aEnabled)
     {
 #if OPENTHREAD_ENABLE_RAW_LINK_API
-        VerifyOrExit(!aInstance->mLinkRaw.IsEnabled(), error = kThreadError_InvalidState);
+        VerifyOrExit(!aInstance->mLinkRaw.IsEnabled(), error = OT_ERROR_INVALID_STATE);
 #endif // OPENTHREAD_ENABLE_RAW_LINK_API
         error = aInstance->mThreadNetif.Up();
     }
     else
     {
 #if OPENTHREAD_ENABLE_RAW_LINK_API
-        VerifyOrExit(!aInstance->mLinkRaw.IsEnabled(), error = kThreadError_InvalidState);
+        VerifyOrExit(!aInstance->mLinkRaw.IsEnabled(), error = OT_ERROR_INVALID_STATE);
 #endif // OPENTHREAD_ENABLE_RAW_LINK_API
         error = aInstance->mThreadNetif.Down();
     }
@@ -79,12 +79,12 @@ const otNetifAddress *otIp6GetUnicastAddresses(otInstance *aInstance)
     return aInstance->mThreadNetif.GetUnicastAddresses();
 }
 
-ThreadError otIp6AddUnicastAddress(otInstance *aInstance, const otNetifAddress *address)
+otError otIp6AddUnicastAddress(otInstance *aInstance, const otNetifAddress *address)
 {
     return aInstance->mThreadNetif.AddExternalUnicastAddress(*static_cast<const Ip6::NetifUnicastAddress *>(address));
 }
 
-ThreadError otIp6RemoveUnicastAddress(otInstance *aInstance, const otIp6Address *address)
+otError otIp6RemoveUnicastAddress(otInstance *aInstance, const otIp6Address *address)
 {
     return aInstance->mThreadNetif.RemoveExternalUnicastAddress(*static_cast<const Ip6::Address *>(address));
 }
@@ -94,12 +94,12 @@ const otNetifMulticastAddress *otIp6GetMulticastAddresses(otInstance *aInstance)
     return aInstance->mThreadNetif.GetMulticastAddresses();
 }
 
-ThreadError otIp6SubscribeMulticastAddress(otInstance *aInstance, const otIp6Address *aAddress)
+otError otIp6SubscribeMulticastAddress(otInstance *aInstance, const otIp6Address *aAddress)
 {
     return aInstance->mThreadNetif.SubscribeExternalMulticast(*static_cast<const Ip6::Address *>(aAddress));
 }
 
-ThreadError otIp6UnsubscribeMulticastAddress(otInstance *aInstance, const otIp6Address *aAddress)
+otError otIp6UnsubscribeMulticastAddress(otInstance *aInstance, const otIp6Address *aAddress)
 {
     return aInstance->mThreadNetif.UnsubscribeExternalMulticast(*static_cast<const Ip6::Address *>(aAddress));
 }
@@ -120,21 +120,21 @@ void otIp6SlaacUpdate(otInstance *aInstance, otNetifAddress *aAddresses, uint32_
     Utils::Slaac::UpdateAddresses(aInstance, aAddresses, aNumAddresses, aIidCreate, aContext);
 }
 
-ThreadError otIp6CreateRandomIid(otInstance *aInstance, otNetifAddress *aAddress, void *aContext)
+otError otIp6CreateRandomIid(otInstance *aInstance, otNetifAddress *aAddress, void *aContext)
 {
     return Utils::Slaac::CreateRandomIid(aInstance, aAddress, aContext);
 }
 
-ThreadError otIp6CreateMacIid(otInstance *aInstance, otNetifAddress *aAddress, void *)
+otError otIp6CreateMacIid(otInstance *aInstance, otNetifAddress *aAddress, void *)
 {
     memcpy(&aAddress->mAddress.mFields.m8[OT_IP6_ADDRESS_SIZE - OT_IP6_IID_SIZE],
            aInstance->mThreadNetif.GetMac().GetExtAddress(), OT_IP6_IID_SIZE);
     aAddress->mAddress.mFields.m8[OT_IP6_ADDRESS_SIZE - OT_IP6_IID_SIZE] ^= 0x02;
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError otIp6CreateSemanticallyOpaqueIid(otInstance *aInstance, otNetifAddress *aAddress, void *aContext)
+otError otIp6CreateSemanticallyOpaqueIid(otInstance *aInstance, otNetifAddress *aAddress, void *aContext)
 {
     return static_cast<Utils::SemanticallyOpaqueIidGenerator *>(aContext)->CreateIid(aInstance, aAddress);
 }
@@ -154,9 +154,9 @@ void otIp6SetReceiveFilterEnabled(otInstance *aInstance, bool aEnabled)
     aInstance->mIp6.SetReceiveIp6FilterEnabled(aEnabled);
 }
 
-ThreadError otIp6Send(otInstance *aInstance, otMessage *aMessage)
+otError otIp6Send(otInstance *aInstance, otMessage *aMessage)
 {
-    ThreadError error;
+    otError error;
 
     otLogFuncEntry();
 
@@ -180,12 +180,12 @@ otMessage *otIp6NewMessage(otInstance *aInstance, bool aLinkSecurityEnabled)
     return message;
 }
 
-ThreadError otIp6AddUnsecurePort(otInstance *aInstance, uint16_t aPort)
+otError otIp6AddUnsecurePort(otInstance *aInstance, uint16_t aPort)
 {
     return aInstance->mThreadNetif.GetIp6Filter().AddUnsecurePort(aPort);
 }
 
-ThreadError otIp6RemoveUnsecurePort(otInstance *aInstance, uint16_t aPort)
+otError otIp6RemoveUnsecurePort(otInstance *aInstance, uint16_t aPort)
 {
     return aInstance->mThreadNetif.GetIp6Filter().RemoveUnsecurePort(aPort);
 }
@@ -200,7 +200,7 @@ bool otIp6IsAddressEqual(const otIp6Address *a, const otIp6Address *b)
     return *static_cast<const Ip6::Address *>(a) == *static_cast<const Ip6::Address *>(b);
 }
 
-ThreadError otIp6AddressFromString(const char *str, otIp6Address *address)
+otError otIp6AddressFromString(const char *str, otIp6Address *address)
 {
     return static_cast<Ip6::Address *>(address)->FromString(str);
 }

--- a/src/core/api/jam_detection_api.cpp
+++ b/src/core/api/jam_detection_api.cpp
@@ -39,7 +39,7 @@ using namespace ot;
 
 #if OPENTHREAD_ENABLE_JAM_DETECTION
 
-ThreadError otJamDetectionSetRssiThreshold(otInstance *aInstance, int8_t aRssiThreshold)
+otError otJamDetectionSetRssiThreshold(otInstance *aInstance, int8_t aRssiThreshold)
 {
     return aInstance->mThreadNetif.GetJamDetector().SetRssiThreshold(aRssiThreshold);
 }
@@ -49,7 +49,7 @@ int8_t otJamDetectionGetRssiThreshold(otInstance *aInstance)
     return aInstance->mThreadNetif.GetJamDetector().GetRssiThreshold();
 }
 
-ThreadError otJamDetectionSetWindow(otInstance *aInstance, uint8_t aWindow)
+otError otJamDetectionSetWindow(otInstance *aInstance, uint8_t aWindow)
 {
     return aInstance->mThreadNetif.GetJamDetector().SetWindow(aWindow);
 }
@@ -59,7 +59,7 @@ uint8_t otJamDetectionGetWindow(otInstance *aInstance)
     return aInstance->mThreadNetif.GetJamDetector().GetWindow();
 }
 
-ThreadError otJamDetectionSetBusyPeriod(otInstance *aInstance, uint8_t aBusyPeriod)
+otError otJamDetectionSetBusyPeriod(otInstance *aInstance, uint8_t aBusyPeriod)
 {
     return aInstance->mThreadNetif.GetJamDetector().SetBusyPeriod(aBusyPeriod);
 }
@@ -69,12 +69,12 @@ uint8_t otJamDetectionGetBusyPeriod(otInstance *aInstance)
     return aInstance->mThreadNetif.GetJamDetector().GetBusyPeriod();
 }
 
-ThreadError otJamDetectionStart(otInstance *aInstance, otJamDetectionCallback aCallback, void *aContext)
+otError otJamDetectionStart(otInstance *aInstance, otJamDetectionCallback aCallback, void *aContext)
 {
     return aInstance->mThreadNetif.GetJamDetector().Start(aCallback, aContext);
 }
 
-ThreadError otJamDetectionStop(otInstance *aInstance)
+otError otJamDetectionStop(otInstance *aInstance)
 {
     return aInstance->mThreadNetif.GetJamDetector().Stop();
 }

--- a/src/core/api/joiner_api.cpp
+++ b/src/core/api/joiner_api.cpp
@@ -39,17 +39,17 @@ using namespace ot;
 
 #if OPENTHREAD_ENABLE_JOINER
 
-ThreadError otJoinerStart(otInstance *aInstance, const char *aPSKd, const char *aProvisioningUrl,
-                          const char *aVendorName, const char *aVendorModel,
-                          const char *aVendorSwVersion, const char *aVendorData,
-                          otJoinerCallback aCallback, void *aContext)
+otError otJoinerStart(otInstance *aInstance, const char *aPSKd, const char *aProvisioningUrl,
+                      const char *aVendorName, const char *aVendorModel,
+                      const char *aVendorSwVersion, const char *aVendorData,
+                      otJoinerCallback aCallback, void *aContext)
 {
     return aInstance->mThreadNetif.GetJoiner().Start(aPSKd, aProvisioningUrl,
                                                      aVendorName, aVendorModel, aVendorSwVersion, aVendorData,
                                                      aCallback, aContext);
 }
 
-ThreadError otJoinerStop(otInstance *aInstance)
+otError otJoinerStop(otInstance *aInstance)
 {
     return aInstance->mThreadNetif.GetJoiner().Stop();
 }

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -45,12 +45,12 @@ uint8_t otLinkGetChannel(otInstance *aInstance)
     return aInstance->mThreadNetif.GetMac().GetChannel();
 }
 
-ThreadError otLinkSetChannel(otInstance *aInstance, uint8_t aChannel)
+otError otLinkSetChannel(otInstance *aInstance, uint8_t aChannel)
 {
-    ThreadError error;
+    otError error;
 
     VerifyOrExit(aInstance->mThreadNetif.GetMle().GetDeviceState() == Mle::kDeviceStateDisabled,
-                 error = kThreadError_InvalidState);
+                 error = OT_ERROR_INVALID_STATE);
 
     error = aInstance->mThreadNetif.GetMac().SetChannel(aChannel);
     aInstance->mThreadNetif.GetActiveDataset().Clear(false);
@@ -65,13 +65,13 @@ const uint8_t *otLinkGetExtendedAddress(otInstance *aInstance)
     return reinterpret_cast<const uint8_t *>(aInstance->mThreadNetif.GetMac().GetExtAddress());
 }
 
-ThreadError otLinkSetExtendedAddress(otInstance *aInstance, const otExtAddress *aExtAddress)
+otError otLinkSetExtendedAddress(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aExtAddress != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aExtAddress != NULL, error = OT_ERROR_INVALID_ARGS);
     VerifyOrExit(aInstance->mThreadNetif.GetMle().GetDeviceState() == Mle::kDeviceStateDisabled,
-                 error = kThreadError_InvalidState);
+                 error = OT_ERROR_INVALID_STATE);
 
     aInstance->mThreadNetif.GetMac().SetExtAddress(*static_cast<const Mac::ExtAddress *>(aExtAddress));
 
@@ -107,12 +107,12 @@ otPanId otLinkGetPanId(otInstance *aInstance)
     return aInstance->mThreadNetif.GetMac().GetPanId();
 }
 
-ThreadError otLinkSetPanId(otInstance *aInstance, otPanId aPanId)
+otError otLinkSetPanId(otInstance *aInstance, otPanId aPanId)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aInstance->mThreadNetif.GetMle().GetDeviceState() == Mle::kDeviceStateDisabled,
-                 error = kThreadError_InvalidState);
+                 error = OT_ERROR_INVALID_STATE);
 
     error = aInstance->mThreadNetif.GetMac().SetPanId(aPanId);
     aInstance->mThreadNetif.GetActiveDataset().Clear(false);
@@ -132,7 +132,7 @@ void otLinkSetPollPeriod(otInstance *aInstance, uint32_t aPollPeriod)
     aInstance->mThreadNetif.GetMeshForwarder().GetDataPollManager().SetExternalPollPeriod(aPollPeriod);
 }
 
-ThreadError otLinkSendDataRequest(otInstance *aInstance)
+otError otLinkSendDataRequest(otInstance *aInstance)
 {
     return aInstance->mThreadNetif.GetMeshForwarder().GetDataPollManager().SendDataPoll();
 }
@@ -142,25 +142,25 @@ otShortAddress otLinkGetShortAddress(otInstance *aInstance)
     return aInstance->mThreadNetif.GetMac().GetShortAddress();
 }
 
-ThreadError otLinkAddWhitelist(otInstance *aInstance, const uint8_t *aExtAddr)
+otError otLinkAddWhitelist(otInstance *aInstance, const uint8_t *aExtAddr)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (aInstance->mThreadNetif.GetMac().GetWhitelist().Add(*reinterpret_cast<const Mac::ExtAddress *>(aExtAddr)) == NULL)
     {
-        error = kThreadError_NoBufs;
+        error = OT_ERROR_NO_BUFS;
     }
 
     return error;
 }
 
-ThreadError otLinkAddWhitelistRssi(otInstance *aInstance, const uint8_t *aExtAddr, int8_t aRssi)
+otError otLinkAddWhitelistRssi(otInstance *aInstance, const uint8_t *aExtAddr, int8_t aRssi)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otMacWhitelistEntry *entry;
 
     entry = aInstance->mThreadNetif.GetMac().GetWhitelist().Add(*reinterpret_cast<const Mac::ExtAddress *>(aExtAddr));
-    VerifyOrExit(entry != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit(entry != NULL, error = OT_ERROR_NO_BUFS);
     aInstance->mThreadNetif.GetMac().GetWhitelist().SetFixedRssi(*entry, aRssi);
 
 exit:
@@ -177,11 +177,11 @@ void otLinkClearWhitelist(otInstance *aInstance)
     aInstance->mThreadNetif.GetMac().GetWhitelist().Clear();
 }
 
-ThreadError otLinkGetWhitelistEntry(otInstance *aInstance, uint8_t aIndex, otMacWhitelistEntry *aEntry)
+otError otLinkGetWhitelistEntry(otInstance *aInstance, uint8_t aIndex, otMacWhitelistEntry *aEntry)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aEntry != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aEntry != NULL, error = OT_ERROR_INVALID_ARGS);
     error = aInstance->mThreadNetif.GetMac().GetWhitelist().GetEntry(aIndex, *aEntry);
 
 exit:
@@ -198,13 +198,13 @@ bool otLinkIsWhitelistEnabled(otInstance *aInstance)
     return aInstance->mThreadNetif.GetMac().GetWhitelist().IsEnabled();
 }
 
-ThreadError otLinkAddBlacklist(otInstance *aInstance, const uint8_t *aExtAddr)
+otError otLinkAddBlacklist(otInstance *aInstance, const uint8_t *aExtAddr)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (aInstance->mThreadNetif.GetMac().GetBlacklist().Add(*reinterpret_cast<const Mac::ExtAddress *>(aExtAddr)) == NULL)
     {
-        error = kThreadError_NoBufs;
+        error = OT_ERROR_NO_BUFS;
     }
 
     return error;
@@ -220,11 +220,11 @@ void otLinkClearBlacklist(otInstance *aInstance)
     aInstance->mThreadNetif.GetMac().GetBlacklist().Clear();
 }
 
-ThreadError otLinkGetBlacklistEntry(otInstance *aInstance, uint8_t aIndex, otMacBlacklistEntry *aEntry)
+otError otLinkGetBlacklistEntry(otInstance *aInstance, uint8_t aIndex, otMacBlacklistEntry *aEntry)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aEntry != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aEntry != NULL, error = OT_ERROR_INVALID_ARGS);
     error = aInstance->mThreadNetif.GetMac().GetBlacklist().GetEntry(aIndex, *aEntry);
 
 exit:
@@ -241,7 +241,7 @@ bool otLinkIsBlacklistEnabled(otInstance *aInstance)
     return aInstance->mThreadNetif.GetMac().GetBlacklist().IsEnabled();
 }
 
-ThreadError otLinkGetAssignLinkQuality(otInstance *aInstance, const uint8_t *aExtAddr, uint8_t *aLinkQuality)
+otError otLinkGetAssignLinkQuality(otInstance *aInstance, const uint8_t *aExtAddr, uint8_t *aLinkQuality)
 {
     Mac::ExtAddress extAddress;
 
@@ -271,12 +271,12 @@ bool otLinkIsPromiscuous(otInstance *aInstance)
     return aInstance->mThreadNetif.GetMac().IsPromiscuous();
 }
 
-ThreadError otLinkSetPromiscuous(otInstance *aInstance, bool aPromiscuous)
+otError otLinkSetPromiscuous(otInstance *aInstance, bool aPromiscuous)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     // cannot enable IEEE 802.15.4 promiscuous mode if the Thread interface is enabled
-    VerifyOrExit(aInstance->mThreadNetif.IsUp() == false, error = kThreadError_InvalidState);
+    VerifyOrExit(aInstance->mThreadNetif.IsUp() == false, error = OT_ERROR_INVALID_STATE);
 
     aInstance->mThreadNetif.GetMac().SetPromiscuous(aPromiscuous);
 
@@ -289,8 +289,8 @@ const otMacCounters *otLinkGetCounters(otInstance *aInstance)
     return &aInstance->mThreadNetif.GetMac().GetCounters();
 }
 
-ThreadError otLinkActiveScan(otInstance *aInstance, uint32_t aScanChannels, uint16_t aScanDuration,
-                             otHandleActiveScanResult aCallback, void *aCallbackContext)
+otError otLinkActiveScan(otInstance *aInstance, uint32_t aScanChannels, uint16_t aScanDuration,
+                         otHandleActiveScanResult aCallback, void *aCallbackContext)
 {
     aInstance->mActiveScanCallback = aCallback;
     aInstance->mActiveScanCallbackContext = aCallbackContext;
@@ -315,8 +315,8 @@ exit:
     return;
 }
 
-ThreadError otLinkEnergyScan(otInstance *aInstance, uint32_t aScanChannels, uint16_t aScanDuration,
-                             otHandleEnergyScanResult aCallback, void *aCallbackContext)
+otError otLinkEnergyScan(otInstance *aInstance, uint32_t aScanChannels, uint16_t aScanDuration,
+                         otHandleEnergyScanResult aCallback, void *aCallbackContext)
 {
     aInstance->mEnergyScanCallback = aCallback;
     aInstance->mEnergyScanCallbackContext = aCallbackContext;

--- a/src/core/api/link_raw.hpp
+++ b/src/core/api/link_raw.hpp
@@ -78,31 +78,31 @@ public:
      * This method starts a (recurring) Receive on the link-layer.
      *
      */
-    ThreadError Receive(uint8_t aChannel, otLinkRawReceiveDone aCallback);
+    otError Receive(uint8_t aChannel, otLinkRawReceiveDone aCallback);
 
     /**
      * This method invokes the mReceiveDoneCallback, if set.
      *
      */
-    void InvokeReceiveDone(RadioPacket *aPacket, ThreadError aError);
+    void InvokeReceiveDone(RadioPacket *aPacket, otError aError);
 
     /**
      * This method starts a (single) Transmit on the link-layer.
      *
      */
-    ThreadError Transmit(RadioPacket *aPacket, otLinkRawTransmitDone aCallback);
+    otError Transmit(RadioPacket *aPacket, otLinkRawTransmitDone aCallback);
 
     /**
      * This method invokes the mTransmitDoneCallback, if set.
      *
      */
-    void InvokeTransmitDone(RadioPacket *aPacket, bool aFramePending, ThreadError aError);
+    void InvokeTransmitDone(RadioPacket *aPacket, bool aFramePending, otError aError);
 
     /**
      * This method starts a (single) Enery Scan on the link-layer.
      *
      */
-    ThreadError EnergyScan(uint8_t aScanChannel, uint16_t aScanDuration, otLinkRawEnergyScanDone aCallback);
+    otError EnergyScan(uint8_t aScanChannel, uint16_t aScanDuration, otLinkRawEnergyScanDone aCallback);
 
     /**
      * This method invokes the mEnergyScanDoneCallback, if set.
@@ -119,7 +119,7 @@ private:
     otLinkRawTransmitDone   mTransmitDoneCallback;
     otLinkRawEnergyScanDone mEnergyScanDoneCallback;
 
-    ThreadError DoTransmit(RadioPacket *aPacket);
+    otError DoTransmit(RadioPacket *aPacket);
 
 #if OPENTHREAD_LINKRAW_TIMER_REQUIRED
 

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -40,11 +40,11 @@
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
 
-ThreadError otLinkRawSetEnable(otInstance *aInstance, bool aEnabled)
+otError otLinkRawSetEnable(otInstance *aInstance, bool aEnabled)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(!aInstance->mThreadNetif.IsUp(), error = kThreadError_InvalidState);
+    VerifyOrExit(!aInstance->mThreadNetif.IsUp(), error = OT_ERROR_INVALID_STATE);
 
     otLogInfoPlat(aInstance, "LinkRaw Enabled=%d", aEnabled ? 1 : 0);
 
@@ -59,11 +59,11 @@ bool otLinkRawIsEnabled(otInstance *aInstance)
     return aInstance->mLinkRaw.IsEnabled();
 }
 
-ThreadError otLinkRawSetPanId(otInstance *aInstance, uint16_t aPanId)
+otError otLinkRawSetPanId(otInstance *aInstance, uint16_t aPanId)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = kThreadError_InvalidState);
+    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = OT_ERROR_INVALID_STATE);
 
     otPlatRadioSetPanId(aInstance, aPanId);
 
@@ -71,12 +71,12 @@ exit:
     return error;
 }
 
-ThreadError otLinkRawSetExtendedAddress(otInstance *aInstance, const otExtAddress *aExtendedAddress)
+otError otLinkRawSetExtendedAddress(otInstance *aInstance, const otExtAddress *aExtendedAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t buf[sizeof(otExtAddress)];
 
-    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = kThreadError_InvalidState);
+    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = OT_ERROR_INVALID_STATE);
 
     for (size_t i = 0; i < sizeof(buf); i++)
     {
@@ -89,11 +89,11 @@ exit:
     return error;
 }
 
-ThreadError otLinkRawSetShortAddress(otInstance *aInstance, uint16_t aShortAddress)
+otError otLinkRawSetShortAddress(otInstance *aInstance, uint16_t aShortAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = kThreadError_InvalidState);
+    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = OT_ERROR_INVALID_STATE);
 
     otPlatRadioSetShortAddress(aInstance, aShortAddress);
 
@@ -106,11 +106,11 @@ bool otLinkRawGetPromiscuous(otInstance *aInstance)
     return otPlatRadioGetPromiscuous(aInstance);
 }
 
-ThreadError otLinkRawSetPromiscuous(otInstance *aInstance, bool aEnable)
+otError otLinkRawSetPromiscuous(otInstance *aInstance, bool aEnable)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = kThreadError_InvalidState);
+    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = OT_ERROR_INVALID_STATE);
 
     otLogInfoPlat(aInstance, "LinkRaw Promiscuous=%d", aEnable ? 1 : 0);
 
@@ -120,11 +120,11 @@ exit:
     return error;
 }
 
-ThreadError otLinkRawSleep(otInstance *aInstance)
+otError otLinkRawSleep(otInstance *aInstance)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = kThreadError_InvalidState);
+    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = OT_ERROR_INVALID_STATE);
 
     otLogInfoPlat(aInstance, "LinkRaw Sleep");
 
@@ -134,7 +134,7 @@ exit:
     return error;
 }
 
-ThreadError otLinkRawReceive(otInstance *aInstance, uint8_t aChannel, otLinkRawReceiveDone aCallback)
+otError otLinkRawReceive(otInstance *aInstance, uint8_t aChannel, otLinkRawReceiveDone aCallback)
 {
     otLogInfoPlat(aInstance, "LinkRaw Recv (Channel %d)", aChannel);
     return aInstance->mLinkRaw.Receive(aChannel, aCallback);
@@ -152,7 +152,7 @@ exit:
     return buffer;
 }
 
-ThreadError otLinkRawTransmit(otInstance *aInstance, RadioPacket *aPacket, otLinkRawTransmitDone aCallback)
+otError otLinkRawTransmit(otInstance *aInstance, RadioPacket *aPacket, otLinkRawTransmitDone aCallback)
 {
     otLogInfoPlat(aInstance, "LinkRaw Transmit (%d bytes on channel %d)", aPacket->mLength, aPacket->mChannel);
     return aInstance->mLinkRaw.Transmit(aPacket, aCallback);
@@ -168,17 +168,17 @@ otRadioCaps otLinkRawGetCaps(otInstance *aInstance)
     return aInstance->mLinkRaw.GetCaps();
 }
 
-ThreadError otLinkRawEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration,
-                                otLinkRawEnergyScanDone aCallback)
+otError otLinkRawEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration,
+                            otLinkRawEnergyScanDone aCallback)
 {
     return aInstance->mLinkRaw.EnergyScan(aScanChannel, aScanDuration, aCallback);
 }
 
-ThreadError otLinkRawSrcMatchEnable(otInstance *aInstance, bool aEnable)
+otError otLinkRawSrcMatchEnable(otInstance *aInstance, bool aEnable)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = kThreadError_InvalidState);
+    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = OT_ERROR_INVALID_STATE);
 
     otPlatRadioEnableSrcMatch(aInstance, aEnable);
 
@@ -186,11 +186,11 @@ exit:
     return error;
 }
 
-ThreadError otLinkRawSrcMatchAddShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
+otError otLinkRawSrcMatchAddShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = kThreadError_InvalidState);
+    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = OT_ERROR_INVALID_STATE);
 
     error = otPlatRadioAddSrcMatchShortEntry(aInstance, aShortAddress);
 
@@ -198,11 +198,11 @@ exit:
     return error;
 }
 
-ThreadError otLinkRawSrcMatchAddExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
+otError otLinkRawSrcMatchAddExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = kThreadError_InvalidState);
+    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = OT_ERROR_INVALID_STATE);
 
     error = otPlatRadioAddSrcMatchExtEntry(aInstance, aExtAddress);
 
@@ -210,11 +210,11 @@ exit:
     return error;
 }
 
-ThreadError otLinkRawSrcMatchClearShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
+otError otLinkRawSrcMatchClearShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = kThreadError_InvalidState);
+    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = OT_ERROR_INVALID_STATE);
 
     error = otPlatRadioClearSrcMatchShortEntry(aInstance, aShortAddress);
 
@@ -222,11 +222,11 @@ exit:
     return error;
 }
 
-ThreadError otLinkRawSrcMatchClearExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
+otError otLinkRawSrcMatchClearExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = kThreadError_InvalidState);
+    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = OT_ERROR_INVALID_STATE);
 
     error = otPlatRadioClearSrcMatchExtEntry(aInstance, aExtAddress);
 
@@ -234,11 +234,11 @@ exit:
     return error;
 }
 
-ThreadError otLinkRawSrcMatchClearShortEntries(otInstance *aInstance)
+otError otLinkRawSrcMatchClearShortEntries(otInstance *aInstance)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = kThreadError_InvalidState);
+    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = OT_ERROR_INVALID_STATE);
 
     otPlatRadioClearSrcMatchShortEntries(aInstance);
 
@@ -246,11 +246,11 @@ exit:
     return error;
 }
 
-ThreadError otLinkRawSrcMatchClearExtEntries(otInstance *aInstance)
+otError otLinkRawSrcMatchClearExtEntries(otInstance *aInstance)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = kThreadError_InvalidState);
+    VerifyOrExit(aInstance->mLinkRaw.IsEnabled(), error = OT_ERROR_INVALID_STATE);
 
     otPlatRadioClearSrcMatchExtEntries(aInstance);
 
@@ -304,9 +304,9 @@ otRadioCaps LinkRaw::GetCaps()
     return RadioCaps;
 }
 
-ThreadError LinkRaw::Receive(uint8_t aChannel, otLinkRawReceiveDone aCallback)
+otError LinkRaw::Receive(uint8_t aChannel, otLinkRawReceiveDone aCallback)
 {
-    ThreadError error = kThreadError_InvalidState;
+    otError error = OT_ERROR_INVALID_STATE;
 
     if (mEnabled)
     {
@@ -318,11 +318,11 @@ ThreadError LinkRaw::Receive(uint8_t aChannel, otLinkRawReceiveDone aCallback)
     return error;
 }
 
-void LinkRaw::InvokeReceiveDone(RadioPacket *aPacket, ThreadError aError)
+void LinkRaw::InvokeReceiveDone(RadioPacket *aPacket, otError aError)
 {
     if (mReceiveDoneCallback)
     {
-        if (aError == kThreadError_None)
+        if (aError == OT_ERROR_NONE)
         {
             otLogInfoPlat(&mInstance, "LinkRaw Invoke Receive Done (%d bytes)", aPacket->mLength);
         }
@@ -335,9 +335,9 @@ void LinkRaw::InvokeReceiveDone(RadioPacket *aPacket, ThreadError aError)
     }
 }
 
-ThreadError LinkRaw::Transmit(RadioPacket *aPacket, otLinkRawTransmitDone aCallback)
+otError LinkRaw::Transmit(RadioPacket *aPacket, otLinkRawTransmitDone aCallback)
 {
-    ThreadError error = kThreadError_InvalidState;
+    otError error = OT_ERROR_INVALID_STATE;
 
     if (mEnabled)
     {
@@ -350,7 +350,7 @@ ThreadError LinkRaw::Transmit(RadioPacket *aPacket, otLinkRawTransmitDone aCallb
 
         // Start the transmission backlog logic
         StartCsmaBackoff();
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
 #else
         // Let the hardware do the transmission logic
         error = DoTransmit(aPacket);
@@ -360,9 +360,9 @@ ThreadError LinkRaw::Transmit(RadioPacket *aPacket, otLinkRawTransmitDone aCallb
     return error;
 }
 
-ThreadError LinkRaw::DoTransmit(RadioPacket *aPacket)
+otError LinkRaw::DoTransmit(RadioPacket *aPacket)
 {
-    ThreadError error = otPlatRadioTransmit(&mInstance, aPacket);
+    otError error = otPlatRadioTransmit(&mInstance, aPacket);
 
 #if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ACK_TIMEOUT
 
@@ -380,7 +380,7 @@ ThreadError LinkRaw::DoTransmit(RadioPacket *aPacket)
     return error;
 }
 
-void LinkRaw::InvokeTransmitDone(RadioPacket *aPacket, bool aFramePending, ThreadError aError)
+void LinkRaw::InvokeTransmitDone(RadioPacket *aPacket, bool aFramePending, otError aError)
 {
     otLogDebgPlat(aInstance, "LinkRaw Transmit Done (err=0x%x)", aError);
 
@@ -390,7 +390,7 @@ void LinkRaw::InvokeTransmitDone(RadioPacket *aPacket, bool aFramePending, Threa
 
 #if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT
 
-    if (aError == kThreadError_ChannelAccessFailure)
+    if (aError == OT_ERROR_CHANNEL_ACCESS_FAILURE)
     {
         if (mCsmaAttempts < Mac::kMaxCSMABackoffs)
         {
@@ -404,7 +404,7 @@ void LinkRaw::InvokeTransmitDone(RadioPacket *aPacket, bool aFramePending, Threa
         mCsmaAttempts = 0;
     }
 
-    if (aError == kThreadError_NoAck)
+    if (aError == OT_ERROR_NO_ACK)
     {
         if (mTransmitAttempts < aPacket->mMaxTxAttempts)
         {
@@ -421,7 +421,7 @@ void LinkRaw::InvokeTransmitDone(RadioPacket *aPacket, bool aFramePending, Threa
 
     if (mTransmitDoneCallback)
     {
-        if (aError == kThreadError_None)
+        if (aError == OT_ERROR_NONE)
         {
             otLogInfoPlat(aInstance, "LinkRaw Invoke Transmit Done");
         }
@@ -440,9 +440,9 @@ exit:
 #endif
 }
 
-ThreadError LinkRaw::EnergyScan(uint8_t aScanChannel, uint16_t aScanDuration, otLinkRawEnergyScanDone aCallback)
+otError LinkRaw::EnergyScan(uint8_t aScanChannel, uint16_t aScanDuration, otLinkRawEnergyScanDone aCallback)
 {
-    ThreadError error = kThreadError_InvalidState;
+    otError error = OT_ERROR_INVALID_STATE;
 
     if (mEnabled)
     {
@@ -497,7 +497,7 @@ void LinkRaw::HandleTimer(void)
         otPlatRadioReceive(&mInstance, mReceiveChannel);
 
         // Invoke completion callback for transmit
-        InvokeTransmitDone(otPlatRadioGetTransmitBuffer(&mInstance), false, kThreadError_NoAck);
+        InvokeTransmitDone(otPlatRadioGetTransmitBuffer(&mInstance), false, OT_ERROR_NO_ACK);
         break;
     }
 
@@ -510,9 +510,9 @@ void LinkRaw::HandleTimer(void)
         RadioPacket *aPacket = otPlatRadioGetTransmitBuffer(&mInstance);
 
         // Start the  transmit now
-        ThreadError error = DoTransmit(aPacket);
+        otError error = DoTransmit(aPacket);
 
-        if (error != kThreadError_None)
+        if (error != OT_ERROR_NONE)
         {
             InvokeTransmitDone(aPacket, false, error);
         }

--- a/src/core/api/message_api.cpp
+++ b/src/core/api/message_api.cpp
@@ -37,7 +37,7 @@
 
 using namespace ot;
 
-ThreadError otMessageFree(otMessage *aMessage)
+otError otMessageFree(otMessage *aMessage)
 {
     return static_cast<Message *>(aMessage)->Free();
 }
@@ -48,7 +48,7 @@ uint16_t otMessageGetLength(otMessage *aMessage)
     return message->GetLength();
 }
 
-ThreadError otMessageSetLength(otMessage *aMessage, uint16_t aLength)
+otError otMessageSetLength(otMessage *aMessage, uint16_t aLength)
 {
     Message *message = static_cast<Message *>(aMessage);
     return message->SetLength(aLength);
@@ -60,7 +60,7 @@ uint16_t otMessageGetOffset(otMessage *aMessage)
     return message->GetOffset();
 }
 
-ThreadError otMessageSetOffset(otMessage *aMessage, uint16_t aOffset)
+otError otMessageSetOffset(otMessage *aMessage, uint16_t aOffset)
 {
     Message *message = static_cast<Message *>(aMessage);
     return message->SetOffset(aOffset);
@@ -86,7 +86,7 @@ void otMessageSetDirectTransmission(otMessage *aMessage, bool aEnabled)
     }
 }
 
-ThreadError otMessageAppend(otMessage *aMessage, const void *aBuf, uint16_t aLength)
+otError otMessageAppend(otMessage *aMessage, const void *aBuf, uint16_t aLength)
 {
     Message *message = static_cast<Message *>(aMessage);
     return message->Append(aBuf, aLength);
@@ -109,14 +109,14 @@ void otMessageQueueInit(otMessageQueue *aQueue)
     aQueue->mData = NULL;
 }
 
-ThreadError otMessageQueueEnqueue(otMessageQueue *aQueue, otMessage *aMessage)
+otError otMessageQueueEnqueue(otMessageQueue *aQueue, otMessage *aMessage)
 {
     Message *message = static_cast<Message *>(aMessage);
     MessageQueue *queue = static_cast<MessageQueue *>(aQueue);
     return queue->Enqueue(*message);
 }
 
-ThreadError otMessageQueueDequeue(otMessageQueue *aQueue, otMessage *aMessage)
+otError otMessageQueueDequeue(otMessageQueue *aQueue, otMessage *aMessage)
 {
     Message *message = static_cast<Message *>(aMessage);
     MessageQueue *queue = static_cast<MessageQueue *>(aQueue);

--- a/src/core/api/netdata_api.cpp
+++ b/src/core/api/netdata_api.cpp
@@ -37,11 +37,11 @@
 
 using namespace ot;
 
-ThreadError otNetDataGetLeader(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_t *aDataLength)
+otError otNetDataGetLeader(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_t *aDataLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aData != NULL && aDataLength != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aData != NULL && aDataLength != NULL, error = OT_ERROR_INVALID_ARGS);
 
     aInstance->mThreadNetif.GetNetworkDataLeader().GetNetworkData(aStable, aData, *aDataLength);
 
@@ -49,11 +49,11 @@ exit:
     return error;
 }
 
-ThreadError otNetDataGetLocal(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_t *aDataLength)
+otError otNetDataGetLocal(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_t *aDataLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aData != NULL && aDataLength != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aData != NULL && aDataLength != NULL, error = OT_ERROR_INVALID_ARGS);
 
     aInstance->mThreadNetif.GetNetworkDataLocal().GetNetworkData(aStable, aData, *aDataLength);
 
@@ -61,7 +61,7 @@ exit:
     return error;
 }
 
-ThreadError otNetDataAddPrefixInfo(otInstance *aInstance, const otBorderRouterConfig *aConfig)
+otError otNetDataAddPrefixInfo(otInstance *aInstance, const otBorderRouterConfig *aConfig)
 {
     uint8_t flags = 0;
 
@@ -100,17 +100,17 @@ ThreadError otNetDataAddPrefixInfo(otInstance *aInstance, const otBorderRouterCo
                                                                          aConfig->mPreference, flags, aConfig->mStable);
 }
 
-ThreadError otNetDataRemovePrefixInfo(otInstance *aInstance, const otIp6Prefix *aPrefix)
+otError otNetDataRemovePrefixInfo(otInstance *aInstance, const otIp6Prefix *aPrefix)
 {
     return aInstance->mThreadNetif.GetNetworkDataLocal().RemoveOnMeshPrefix(aPrefix->mPrefix.mFields.m8, aPrefix->mLength);
 }
 
-ThreadError otNetDataGetNextPrefixInfo(otInstance *aInstance, bool aLocal, otNetworkDataIterator *aIterator,
-                                       otBorderRouterConfig *aConfig)
+otError otNetDataGetNextPrefixInfo(otInstance *aInstance, bool aLocal, otNetworkDataIterator *aIterator,
+                                   otBorderRouterConfig *aConfig)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aIterator && aConfig, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aIterator && aConfig, error = OT_ERROR_INVALID_ARGS);
 
     if (aLocal)
     {
@@ -125,25 +125,25 @@ exit:
     return error;
 }
 
-ThreadError otNetDataAddRoute(otInstance *aInstance, const otExternalRouteConfig *aConfig)
+otError otNetDataAddRoute(otInstance *aInstance, const otExternalRouteConfig *aConfig)
 {
     return aInstance->mThreadNetif.GetNetworkDataLocal().AddHasRoutePrefix(aConfig->mPrefix.mPrefix.mFields.m8,
                                                                            aConfig->mPrefix.mLength,
                                                                            aConfig->mPreference, aConfig->mStable);
 }
 
-ThreadError otNetDataRemoveRoute(otInstance *aInstance, const otIp6Prefix *aPrefix)
+otError otNetDataRemoveRoute(otInstance *aInstance, const otIp6Prefix *aPrefix)
 {
     return aInstance->mThreadNetif.GetNetworkDataLocal().RemoveHasRoutePrefix(aPrefix->mPrefix.mFields.m8,
                                                                               aPrefix->mLength);
 }
 
-ThreadError otNetDataGetNextRoute(otInstance *aInstance, bool aLocal, otNetworkDataIterator *aIterator,
-                                  otExternalRouteConfig *aConfig)
+otError otNetDataGetNextRoute(otInstance *aInstance, bool aLocal, otNetworkDataIterator *aIterator,
+                              otExternalRouteConfig *aConfig)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aIterator && aConfig, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aIterator && aConfig, error = OT_ERROR_INVALID_ARGS);
 
     if (aLocal)
     {
@@ -158,7 +158,7 @@ exit:
     return error;
 }
 
-ThreadError otNetDataRegister(otInstance *aInstance)
+otError otNetDataRegister(otInstance *aInstance)
 {
     return aInstance->mThreadNetif.GetNetworkDataLocal().SendServerDataNotification();
 }

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -57,13 +57,13 @@ const uint8_t *otThreadGetExtendedPanId(otInstance *aInstance)
     return aInstance->mThreadNetif.GetMac().GetExtendedPanId();
 }
 
-ThreadError otThreadSetExtendedPanId(otInstance *aInstance, const uint8_t *aExtendedPanId)
+otError otThreadSetExtendedPanId(otInstance *aInstance, const uint8_t *aExtendedPanId)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t mlPrefix[8];
 
     VerifyOrExit(aInstance->mThreadNetif.GetMle().GetDeviceState() == Mle::kDeviceStateDisabled,
-                 error = kThreadError_InvalidState);
+                 error = OT_ERROR_INVALID_STATE);
 
     aInstance->mThreadNetif.GetMac().SetExtendedPanId(aExtendedPanId);
 
@@ -80,11 +80,11 @@ exit:
     return error;
 }
 
-ThreadError otThreadGetLeaderRloc(otInstance *aInstance, otIp6Address *aAddress)
+otError otThreadGetLeaderRloc(otInstance *aInstance, otIp6Address *aAddress)
 {
-    ThreadError error;
+    otError error;
 
-    VerifyOrExit(aAddress != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aAddress != NULL, error = OT_ERROR_INVALID_ARGS);
 
     error = aInstance->mThreadNetif.GetMle().GetLeaderAddress(*static_cast<Ip6::Address *>(aAddress));
 
@@ -122,7 +122,7 @@ otLinkModeConfig otThreadGetLinkMode(otInstance *aInstance)
     return config;
 }
 
-ThreadError otThreadSetLinkMode(otInstance *aInstance, otLinkModeConfig aConfig)
+otError otThreadSetLinkMode(otInstance *aInstance, otLinkModeConfig aConfig)
 {
     uint8_t mode = 0;
 
@@ -154,13 +154,13 @@ const otMasterKey *otThreadGetMasterKey(otInstance *aInstance)
     return &aInstance->mThreadNetif.GetKeyManager().GetMasterKey();
 }
 
-ThreadError otThreadSetMasterKey(otInstance *aInstance, const otMasterKey *aKey)
+otError otThreadSetMasterKey(otInstance *aInstance, const otMasterKey *aKey)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aKey != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aKey != NULL, error = OT_ERROR_INVALID_ARGS);
     VerifyOrExit(aInstance->mThreadNetif.GetMle().GetDeviceState() == Mle::kDeviceStateDisabled,
-                 error = kThreadError_InvalidState);
+                 error = OT_ERROR_INVALID_STATE);
 
     error = aInstance->mThreadNetif.GetKeyManager().SetMasterKey(*aKey);
     aInstance->mThreadNetif.GetActiveDataset().Clear(false);
@@ -180,12 +180,12 @@ const uint8_t *otThreadGetMeshLocalPrefix(otInstance *aInstance)
     return aInstance->mThreadNetif.GetMle().GetMeshLocalPrefix();
 }
 
-ThreadError otThreadSetMeshLocalPrefix(otInstance *aInstance, const uint8_t *aMeshLocalPrefix)
+otError otThreadSetMeshLocalPrefix(otInstance *aInstance, const uint8_t *aMeshLocalPrefix)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aInstance->mThreadNetif.GetMle().GetDeviceState() == Mle::kDeviceStateDisabled,
-                 error = kThreadError_InvalidState);
+                 error = OT_ERROR_INVALID_STATE);
 
     error = aInstance->mThreadNetif.GetMle().SetMeshLocalPrefix(aMeshLocalPrefix);
     aInstance->mThreadNetif.GetActiveDataset().Clear(false);
@@ -200,12 +200,12 @@ const char *otThreadGetNetworkName(otInstance *aInstance)
     return aInstance->mThreadNetif.GetMac().GetNetworkName();
 }
 
-ThreadError otThreadSetNetworkName(otInstance *aInstance, const char *aNetworkName)
+otError otThreadSetNetworkName(otInstance *aInstance, const char *aNetworkName)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aInstance->mThreadNetif.GetMle().GetDeviceState() == Mle::kDeviceStateDisabled,
-                 error = kThreadError_InvalidState);
+                 error = OT_ERROR_INVALID_STATE);
 
     error = aInstance->mThreadNetif.GetMac().SetNetworkName(aNetworkName);
     aInstance->mThreadNetif.GetActiveDataset().Clear(false);
@@ -235,21 +235,21 @@ void otThreadSetKeySwitchGuardTime(otInstance *aInstance, uint32_t aKeySwitchGua
     aInstance->mThreadNetif.GetKeyManager().SetKeySwitchGuardTime(aKeySwitchGuardTime);
 }
 
-ThreadError otThreadBecomeDetached(otInstance *aInstance)
+otError otThreadBecomeDetached(otInstance *aInstance)
 {
     return aInstance->mThreadNetif.GetMle().BecomeDetached();
 }
 
-ThreadError otThreadBecomeChild(otInstance *aInstance, otMleAttachFilter aFilter)
+otError otThreadBecomeChild(otInstance *aInstance, otMleAttachFilter aFilter)
 {
     return aInstance->mThreadNetif.GetMle().BecomeChild(aFilter);
 }
 
-ThreadError otThreadGetNextNeighborInfo(otInstance *aInstance, otNeighborInfoIterator *aIterator, otNeighborInfo *aInfo)
+otError otThreadGetNextNeighborInfo(otInstance *aInstance, otNeighborInfoIterator *aIterator, otNeighborInfo *aInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit((aInfo != NULL) && (aIterator != NULL), error = kThreadError_InvalidArgs);
+    VerifyOrExit((aInfo != NULL) && (aIterator != NULL), error = OT_ERROR_INVALID_ARGS);
 
     error = aInstance->mThreadNetif.GetMle().GetNextNeighborInfo(*aIterator, *aInfo);
 
@@ -287,11 +287,11 @@ otDeviceRole otThreadGetDeviceRole(otInstance *aInstance)
     return rval;
 }
 
-ThreadError otThreadGetLeaderData(otInstance *aInstance, otLeaderData *aLeaderData)
+otError otThreadGetLeaderData(otInstance *aInstance, otLeaderData *aLeaderData)
 {
-    ThreadError error;
+    otError error;
 
-    VerifyOrExit(aLeaderData != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aLeaderData != NULL, error = OT_ERROR_INVALID_ARGS);
 
     error = aInstance->mThreadNetif.GetMle().GetLeaderData(*aLeaderData);
 
@@ -319,12 +319,12 @@ uint16_t otThreadGetRloc16(otInstance *aInstance)
     return aInstance->mThreadNetif.GetMle().GetRloc16();
 }
 
-ThreadError otThreadGetParentInfo(otInstance *aInstance, otRouterInfo *aParentInfo)
+otError otThreadGetParentInfo(otInstance *aInstance, otRouterInfo *aParentInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Router *parent;
 
-    VerifyOrExit(aParentInfo != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aParentInfo != NULL, error = OT_ERROR_INVALID_ARGS);
 
     parent = aInstance->mThreadNetif.GetMle().GetParent();
     memcpy(aParentInfo->mExtAddress.m8, &parent->GetExtAddress(), sizeof(aParentInfo->mExtAddress));
@@ -343,33 +343,33 @@ exit:
     return error;
 }
 
-ThreadError otThreadGetParentAverageRssi(otInstance *aInstance, int8_t *aParentRssi)
+otError otThreadGetParentAverageRssi(otInstance *aInstance, int8_t *aParentRssi)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Router *parent;
 
-    VerifyOrExit(aParentRssi != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aParentRssi != NULL, error = OT_ERROR_INVALID_ARGS);
 
     parent = aInstance->mThreadNetif.GetMle().GetParent();
     *aParentRssi = parent->GetLinkInfo().GetAverageRss();
 
-    VerifyOrExit(*aParentRssi != LinkQualityInfo::kUnknownRss, error = kThreadError_Failed);
+    VerifyOrExit(*aParentRssi != LinkQualityInfo::kUnknownRss, error = OT_ERROR_FAILED);
 
 exit:
     return error;
 }
 
-ThreadError otThreadGetParentLastRssi(otInstance *aInstance, int8_t *aLastRssi)
+otError otThreadGetParentLastRssi(otInstance *aInstance, int8_t *aLastRssi)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Router *parent;
 
-    VerifyOrExit(aLastRssi != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aLastRssi != NULL, error = OT_ERROR_INVALID_ARGS);
 
     parent = aInstance->mThreadNetif.GetMle().GetParent();
     *aLastRssi = parent->GetLinkInfo().GetLastRss();
 
-    VerifyOrExit(*aLastRssi != LinkQualityInfo::kUnknownRss, error = kThreadError_Failed);
+    VerifyOrExit(*aLastRssi != LinkQualityInfo::kUnknownRss, error = OT_ERROR_FAILED);
 
 exit:
     return error;
@@ -421,8 +421,8 @@ void otThreadSetReceiveDiagnosticGetCallback(otInstance *aInstance, otReceiveDia
     aInstance->mThreadNetif.GetNetworkDiagnostic().SetReceiveDiagnosticGetCallback(aCallback, aCallbackContext);
 }
 
-ThreadError otThreadSendDiagnosticGet(otInstance *aInstance, const otIp6Address *aDestination,
-                                      const uint8_t aTlvTypes[], uint8_t aCount)
+otError otThreadSendDiagnosticGet(otInstance *aInstance, const otIp6Address *aDestination,
+                                  const uint8_t aTlvTypes[], uint8_t aCount)
 {
     return aInstance->mThreadNetif.GetNetworkDiagnostic().SendDiagnosticGet(*static_cast<const Ip6::Address *>
                                                                             (aDestination),
@@ -430,8 +430,8 @@ ThreadError otThreadSendDiagnosticGet(otInstance *aInstance, const otIp6Address 
                                                                             aCount);
 }
 
-ThreadError otThreadSendDiagnosticReset(otInstance *aInstance, const otIp6Address *aDestination,
-                                        const uint8_t aTlvTypes[], uint8_t aCount)
+otError otThreadSendDiagnosticReset(otInstance *aInstance, const otIp6Address *aDestination,
+                                    const uint8_t aTlvTypes[], uint8_t aCount)
 {
     return aInstance->mThreadNetif.GetNetworkDiagnostic().SendDiagnosticReset(*static_cast<const Ip6::Address *>
                                                                               (aDestination),
@@ -440,16 +440,16 @@ ThreadError otThreadSendDiagnosticReset(otInstance *aInstance, const otIp6Addres
 }
 #endif // OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
 
-ThreadError otThreadSetEnabled(otInstance *aInstance, bool aEnabled)
+otError otThreadSetEnabled(otInstance *aInstance, bool aEnabled)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     otLogFuncEntry();
 
     if (aEnabled)
     {
         VerifyOrExit(aInstance->mThreadNetif.GetMac().GetPanId() != Mac::kPanIdBroadcast,
-                     error = kThreadError_InvalidState);
+                     error = OT_ERROR_INVALID_STATE);
         error = aInstance->mThreadNetif.GetMle().Start(true, false);
     }
     else
@@ -469,7 +469,7 @@ bool otThreadGetAutoStart(otInstance *aInstance)
     uint16_t autoStartLength = sizeof(autoStart);
 
     if (otPlatSettingsGet(aInstance, Settings::kKeyThreadAutoStart, 0, &autoStart, &autoStartLength) !=
-        kThreadError_None)
+        OT_ERROR_NONE)
     {
         autoStart = 0;
     }
@@ -481,7 +481,7 @@ bool otThreadGetAutoStart(otInstance *aInstance)
 #endif
 }
 
-ThreadError otThreadSetAutoStart(otInstance *aInstance, bool aStartAutomatically)
+otError otThreadSetAutoStart(otInstance *aInstance, bool aStartAutomatically)
 {
 #if OPENTHREAD_CONFIG_ENABLE_AUTO_START_SUPPORT
     uint8_t autoStart = aStartAutomatically ? 1 : 0;
@@ -489,7 +489,7 @@ ThreadError otThreadSetAutoStart(otInstance *aInstance, bool aStartAutomatically
 #else
     (void)aInstance;
     (void)aStartAutomatically;
-    return kThreadError_NotImplemented;
+    return OT_ERROR_NOT_IMPLEMENTED;
 #endif
 }
 
@@ -498,8 +498,8 @@ bool otThreadIsSingleton(otInstance *aInstance)
     return aInstance->mThreadNetif.GetMle().IsSingleton();
 }
 
-ThreadError otThreadDiscover(otInstance *aInstance, uint32_t aScanChannels, uint16_t aPanId, bool aJoiner,
-                             bool aEnableEui64Filtering, otHandleActiveScanResult aCallback, void *aCallbackContext)
+otError otThreadDiscover(otInstance *aInstance, uint32_t aScanChannels, uint16_t aPanId, bool aJoiner,
+                         bool aEnableEui64Filtering, otHandleActiveScanResult aCallback, void *aCallbackContext)
 {
     return aInstance->mThreadNetif.GetMle().Discover(aScanChannels, aPanId, aJoiner, aEnableEui64Filtering, aCallback,
                                                      aCallbackContext);

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -57,7 +57,7 @@ uint8_t otThreadGetMaxAllowedChildren(otInstance *aInstance)
     return aNumChildren;
 }
 
-ThreadError otThreadSetMaxAllowedChildren(otInstance *aInstance, uint8_t aMaxChildren)
+otError otThreadSetMaxAllowedChildren(otInstance *aInstance, uint8_t aMaxChildren)
 {
     return aInstance->mThreadNetif.GetMle().SetMaxAllowedChildren(aMaxChildren);
 }
@@ -72,7 +72,7 @@ void otThreadSetRouterRoleEnabled(otInstance *aInstance, bool aEnabled)
     aInstance->mThreadNetif.GetMle().SetRouterRoleEnabled(aEnabled);
 }
 
-ThreadError otThreadSetPreferredRouterId(otInstance *aInstance, uint8_t aRouterId)
+otError otThreadSetPreferredRouterId(otInstance *aInstance, uint8_t aRouterId)
 {
     return aInstance->mThreadNetif.GetMle().SetPreferredRouterId(aRouterId);
 }
@@ -102,7 +102,7 @@ uint16_t otThreadGetJoinerUdpPort(otInstance *aInstance)
     return aInstance->mThreadNetif.GetJoinerRouter().GetJoinerUdpPort();
 }
 
-ThreadError otThreadSetJoinerUdpPort(otInstance *aInstance, uint16_t aJoinerUdpPort)
+otError otThreadSetJoinerUdpPort(otInstance *aInstance, uint16_t aJoinerUdpPort)
 {
     return aInstance->mThreadNetif.GetJoinerRouter().SetJoinerUdpPort(aJoinerUdpPort);
 }
@@ -137,14 +137,14 @@ void otThreadSetRouterUpgradeThreshold(otInstance *aInstance, uint8_t aThreshold
     aInstance->mThreadNetif.GetMle().SetRouterUpgradeThreshold(aThreshold);
 }
 
-ThreadError otThreadReleaseRouterId(otInstance *aInstance, uint8_t aRouterId)
+otError otThreadReleaseRouterId(otInstance *aInstance, uint8_t aRouterId)
 {
     return aInstance->mThreadNetif.GetMle().ReleaseRouterId(aRouterId);
 }
 
-ThreadError otThreadBecomeRouter(otInstance *aInstance)
+otError otThreadBecomeRouter(otInstance *aInstance)
 {
-    ThreadError error = kThreadError_InvalidState;
+    otError error = OT_ERROR_INVALID_STATE;
 
     switch (aInstance->mThreadNetif.GetMle().GetDeviceState())
     {
@@ -158,14 +158,14 @@ ThreadError otThreadBecomeRouter(otInstance *aInstance)
 
     case Mle::kDeviceStateRouter:
     case Mle::kDeviceStateLeader:
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
         break;
     }
 
     return error;
 }
 
-ThreadError otThreadBecomeLeader(otInstance *aInstance)
+otError otThreadBecomeLeader(otInstance *aInstance)
 {
     return aInstance->mThreadNetif.GetMle().BecomeLeader();
 }
@@ -190,11 +190,11 @@ void otThreadSetRouterSelectionJitter(otInstance *aInstance, uint8_t aRouterJitt
     aInstance->mThreadNetif.GetMle().SetRouterSelectionJitter(aRouterJitter);
 }
 
-ThreadError otThreadGetChildInfoById(otInstance *aInstance, uint16_t aChildId, otChildInfo *aChildInfo)
+otError otThreadGetChildInfoById(otInstance *aInstance, uint16_t aChildId, otChildInfo *aChildInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aChildInfo != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aChildInfo != NULL, error = OT_ERROR_INVALID_ARGS);
 
     error = aInstance->mThreadNetif.GetMle().GetChildInfoById(aChildId, *aChildInfo);
 
@@ -202,11 +202,11 @@ exit:
     return error;
 }
 
-ThreadError otThreadGetChildInfoByIndex(otInstance *aInstance, uint8_t aChildIndex, otChildInfo *aChildInfo)
+otError otThreadGetChildInfoByIndex(otInstance *aInstance, uint8_t aChildIndex, otChildInfo *aChildInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aChildInfo != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aChildInfo != NULL, error = OT_ERROR_INVALID_ARGS);
 
     error = aInstance->mThreadNetif.GetMle().GetChildInfoByIndex(aChildIndex, *aChildInfo);
 
@@ -219,11 +219,11 @@ uint8_t otThreadGetRouterIdSequence(otInstance *aInstance)
     return aInstance->mThreadNetif.GetMle().GetRouterIdSequence();
 }
 
-ThreadError otThreadGetRouterInfo(otInstance *aInstance, uint16_t aRouterId, otRouterInfo *aRouterInfo)
+otError otThreadGetRouterInfo(otInstance *aInstance, uint16_t aRouterId, otRouterInfo *aRouterInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aRouterInfo != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aRouterInfo != NULL, error = OT_ERROR_INVALID_ARGS);
 
     error = aInstance->mThreadNetif.GetMle().GetRouterInfo(aRouterId, *aRouterInfo);
 
@@ -231,20 +231,20 @@ exit:
     return error;
 }
 
-ThreadError otThreadGetEidCacheEntry(otInstance *aInstance, uint8_t aIndex, otEidCacheEntry *aEntry)
+otError otThreadGetEidCacheEntry(otInstance *aInstance, uint8_t aIndex, otEidCacheEntry *aEntry)
 {
-    ThreadError error;
+    otError error;
 
-    VerifyOrExit(aEntry != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aEntry != NULL, error = OT_ERROR_INVALID_ARGS);
     error = aInstance->mThreadNetif.GetAddressResolver().GetEntry(aIndex, *aEntry);
 
 exit:
     return error;
 }
 
-ThreadError otThreadSetSteeringData(otInstance *aInstance, otExtAddress *aExtAddress)
+otError otThreadSetSteeringData(otInstance *aInstance, otExtAddress *aExtAddress)
 {
-    ThreadError error;
+    otError error;
 
 #if OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
     error = aInstance->mThreadNetif.GetMle().SetSteeringData(aExtAddress);
@@ -252,7 +252,7 @@ ThreadError otThreadSetSteeringData(otInstance *aInstance, otExtAddress *aExtAdd
     (void)aInstance;
     (void)aExtAddress;
 
-    error = kThreadError_DisabledFeature;
+    error = OT_ERROR_DISABLED_FEATURE;
 #endif  // OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
 
     return error;
@@ -263,11 +263,12 @@ const uint8_t *otThreadGetPSKc(otInstance *aInstance)
     return aInstance->mThreadNetif.GetKeyManager().GetPSKc();
 }
 
-ThreadError otThreadSetPSKc(otInstance *aInstance, const uint8_t *aPSKc)
+otError otThreadSetPSKc(otInstance *aInstance, const uint8_t *aPSKc)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
+
     VerifyOrExit(aInstance->mThreadNetif.GetMle().GetDeviceState() == Mle::kDeviceStateDisabled,
-                 error = kThreadError_InvalidState);
+                 error = OT_ERROR_INVALID_STATE);
 
     aInstance->mThreadNetif.GetKeyManager().SetPSKc(aPSKc);
     aInstance->mThreadNetif.GetActiveDataset().Clear(false);

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -49,9 +49,9 @@ otMessage *otUdpNewMessage(otInstance *aInstance, bool aLinkSecurityEnabled)
     return message;
 }
 
-ThreadError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aCallbackContext)
+otError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aCallbackContext)
 {
-    ThreadError error = kThreadError_InvalidArgs;
+    otError error = OT_ERROR_INVALID_ARGS;
     Ip6::UdpSocket *socket = static_cast<Ip6::UdpSocket *>(aSocket);
 
     if (socket->mTransport == NULL)
@@ -63,16 +63,16 @@ ThreadError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive 
     return error;
 }
 
-ThreadError otUdpClose(otUdpSocket *aSocket)
+otError otUdpClose(otUdpSocket *aSocket)
 {
-    ThreadError error = kThreadError_InvalidState;
+    otError error = OT_ERROR_INVALID_STATE;
     Ip6::UdpSocket *socket = static_cast<Ip6::UdpSocket *>(aSocket);
 
     if (socket->mTransport != NULL)
     {
         error = socket->Close();
 
-        if (error == kThreadError_None)
+        if (error == OT_ERROR_NONE)
         {
             socket->mTransport = NULL;
         }
@@ -81,19 +81,19 @@ ThreadError otUdpClose(otUdpSocket *aSocket)
     return error;
 }
 
-ThreadError otUdpBind(otUdpSocket *aSocket, otSockAddr *aSockName)
+otError otUdpBind(otUdpSocket *aSocket, otSockAddr *aSockName)
 {
     Ip6::UdpSocket *socket = static_cast<Ip6::UdpSocket *>(aSocket);
     return socket->Bind(*static_cast<const Ip6::SockAddr *>(aSockName));
 }
 
-ThreadError otUdpConnect(otUdpSocket *aSocket, otSockAddr *aSockName)
+otError otUdpConnect(otUdpSocket *aSocket, otSockAddr *aSockName)
 {
     Ip6::UdpSocket *socket = static_cast<Ip6::UdpSocket *>(aSocket);
     return socket->Connect(*static_cast<const Ip6::SockAddr *>(aSockName));
 }
 
-ThreadError otUdpSend(otUdpSocket *aSocket, otMessage *aMessage, const otMessageInfo *aMessageInfo)
+otError otUdpSend(otUdpSocket *aSocket, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
     Ip6::UdpSocket *socket = static_cast<Ip6::UdpSocket *>(aSocket);
     return socket->SendTo(*static_cast<Message *>(aMessage),

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -125,11 +125,11 @@ public:
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None    Successfully appended the bytes.
-     * @retval kThreadError_NoBufs  Insufficient available buffers to grow the message.
+     * @retval OT_ERROR_NONE     Successfully appended the bytes.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
      *
      */
-    ThreadError AppendTo(Message &aMessage) const {
+    otError AppendTo(Message &aMessage) const {
         return aMessage.Append(this, sizeof(*this));
     };
 
@@ -260,10 +260,10 @@ public:
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None    Successfully appended the bytes.
-     * @retval kThreadError_NoBufs  Insufficient available buffers to grow the message.
+     * @retval OT_ERROR_NONE     Successfully appended the bytes.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
      */
-    ThreadError AppendTo(Message &aMessage) const { return aMessage.Append(this, sizeof(*this)); }
+    otError AppendTo(Message &aMessage) const { return aMessage.Append(this, sizeof(*this)); }
 
     /**
      * This method reads request data from the message.
@@ -284,7 +284,7 @@ public:
      *
      */
     static void RemoveFrom(Message &aMessage) {
-        assert(aMessage.SetLength(aMessage.GetLength() - sizeof(EnqueuedResponseHeader)) == kThreadError_None);
+        assert(aMessage.SetLength(aMessage.GetLength() - sizeof(EnqueuedResponseHeader)) == OT_ERROR_NONE);
     }
 
     /**
@@ -366,14 +366,14 @@ public:
      * @param[in]  aMessageInfo  The message info containing source endpoint address and port.
      * @param[out] aResponse     A pointer to a copy of a cached CoAP response matching given arguments.
      *
-     * @retval kThreadError_None      Matching response found and successfully created a copy.
-     * @retval kThreadError_NoBufs    Matching response found but there is not sufficient buffer to create a copy.
-     * @retval kThreadError_NotFound  Matching response not found.
+     * @retval OT_ERROR_NONE       Matching response found and successfully created a copy.
+     * @retval OT_ERROR_NO_BUFS    Matching response found but there is not sufficient buffer to create a copy.
+     * @retval OT_ERROR_NOT_FOUND  Matching response not found.
      *
      */
-    ThreadError GetMatchedResponseCopy(const Header &aHeader,
-                                       const Ip6::MessageInfo &aMessageInfo,
-                                       Message **aResponse);
+    otError GetMatchedResponseCopy(const Header &aHeader,
+                                   const Ip6::MessageInfo &aMessageInfo,
+                                   Message **aResponse);
 
     /**
      * Get a copy of CoAP response from the cache that matches given Message ID and source endpoint.
@@ -382,15 +382,15 @@ public:
      * @param[in]  aMessageInfo  The message info containing source endpoint address and port.
      * @param[out] aResponse     A pointer to a copy of a cached CoAP response matching given arguments.
      *
-     * @retval kThreadError_None      Matching response found and successfully created a copy.
-     * @retval kThreadError_NoBufs    Matching response found but there is not sufficient buffer to create a copy.
-     * @retval kThreadError_NotFound  Matching response not found.
-     * @retval kThreadError_Parse     Could not parse CoAP header in the request message.
+     * @retval OT_ERROR_NONE       Matching response found and successfully created a copy.
+     * @retval OT_ERROR_NO_BUFS    Matching response found but there is not sufficient buffer to create a copy.
+     * @retval OT_ERROR_NOT_FOUND  Matching response not found.
+     * @retval OT_ERROR_PARSE      Could not parse CoAP header in the request message.
      *
      */
-    ThreadError GetMatchedResponseCopy(const Message &aRequest,
-                                       const Ip6::MessageInfo &aMessageInfo,
-                                       Message **aResponse);
+    otError GetMatchedResponseCopy(const Message &aRequest,
+                                   const Ip6::MessageInfo &aMessageInfo,
+                                   Message **aResponse);
 
     /**
      * Get a reference to the cached CoAP responses queue.
@@ -428,13 +428,13 @@ public:
      * @param[in]   aMessage        A reference to the message.
      @ @param[in]   aMessageInfo    A reference to the message info associated with @p aMessage.
      *
-     * @retval  kThreadError_None       Server should continue processing this message, other
-     *                                  return values indicates the server should stop processing
-     *                                  this message.
-     * @retval  kThreadError_NotTmf     The message is not a TMF message.
+     * @retval  OT_ERROR_NONE       Server should continue processing this message, other
+     *                              return values indicates the server should stop processing
+     *                              this message.
+     * @retval  OT_ERROR_NOT_TMF    The message is not a TMF message.
      *
      */
-    typedef ThreadError(* Interceptor)(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    typedef otError(* Interceptor)(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     /**
      * This constructor initializes the object.
@@ -449,18 +449,18 @@ public:
      *
      * @param[in]  aPort  The local UDP port to bind to.
      *
-     * @retval kThreadError_None  Successfully started the CoAP service.
+     * @retval OT_ERROR_NONE  Successfully started the CoAP service.
      *
      */
-    ThreadError Start(uint16_t aPort);
+    otError Start(uint16_t aPort);
 
     /**
      * This method stops the CoAP service.
      *
-     * @retval kThreadError_None  Successfully stopped the CoAP service.
+     * @retval OT_ERROR_NONE  Successfully stopped the CoAP service.
      *
      */
-    ThreadError Stop(void);
+    otError Stop(void);
 
     /**
      * This method returns a port number used by CoAP service.
@@ -471,25 +471,15 @@ public:
     uint16_t GetPort(void) { return mSocket.GetSockName().mPort; };
 
     /**
-     * This method sets CoAP server's port number.
-     *
-     * @param[in]  aPort  A port number to set.
-     *
-     * @retval kThreadError_None  Binding with a port succeeded.
-     *
-     */
-    ThreadError SetPort(uint16_t aPort);
-
-    /**
      * This method adds a resource to the CoAP server.
      *
      * @param[in]  aResource  A reference to the resource.
      *
-     * @retval kThreadError_None     Successfully added @p aResource.
-     * @retval kThreadError_Already  The @p aResource was already added.
+     * @retval OT_ERROR_NONE     Successfully added @p aResource.
+     * @retval OT_ERROR_ALREADY  The @p aResource was already added.
      *
      */
-    ThreadError AddResource(Resource &aResource);
+    otError AddResource(Resource &aResource);
 
     /**
      * This method removes a resource from the CoAP server.
@@ -529,12 +519,12 @@ public:
      * @param[in]  aHandler      A function pointer that shall be called on response reception or time-out.
      * @param[in]  aContext      A pointer to arbitrary context information.
      *
-     * @retval kThreadError_None   Successfully sent CoAP message.
-     * @retval kThreadError_NoBufs Failed to allocate retransmission data.
+     * @retval OT_ERROR_NONE     Successfully sent CoAP message.
+     * @retval OT_ERROR_NO_BUFS  Failed to allocate retransmission data.
      *
      */
-    ThreadError SendMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
-                            otCoapResponseHandler aHandler = NULL, void *aContext = NULL);
+    otError SendMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
+                        otCoapResponseHandler aHandler = NULL, void *aContext = NULL);
 
     /**
      * This method sends a CoAP reset message.
@@ -542,12 +532,12 @@ public:
      * @param[in]  aRequestHeader  A reference to the CoAP Header that was used in CoAP request.
      * @param[in]  aMessageInfo    The message info corresponding to the CoAP request.
      *
-     * @retval kThreadError_None         Successfully enqueued the CoAP response message.
-     * @retval kThreadError_NoBufs       Insufficient buffers available to send the CoAP response.
-     * @retval kThreadError_InvalidArgs  The @p aRequestHeader header is not of confirmable type.
+     * @retval OT_ERROR_NONE          Successfully enqueued the CoAP response message.
+     * @retval OT_ERROR_NO_BUFS       Insufficient buffers available to send the CoAP response.
+     * @retval OT_ERROR_INVALID_ARGS  The @p aRequestHeader header is not of confirmable type.
      *
      */
-    ThreadError SendReset(Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo) {
+    otError SendReset(Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo) {
         return SendEmptyMessage(kCoapTypeReset, aRequestHeader, aMessageInfo);
     };
 
@@ -558,12 +548,12 @@ public:
      * @param[in]  aRequestHeader  A reference to the CoAP Header that was used in CoAP request.
      * @param[in]  aMessageInfo    The message info corresponding to the CoAP request.
      *
-     * @retval kThreadError_None         Successfully enqueued the CoAP response message.
-     * @retval kThreadError_NoBufs       Insufficient buffers available to send the CoAP response.
-     * @retval kThreadError_InvalidArgs  The @p aRequestHeader header is not of confirmable type.
+     * @retval OT_ERROR_NONE          Successfully enqueued the CoAP response message.
+     * @retval OT_ERROR_NO_BUFS       Insufficient buffers available to send the CoAP response.
+     * @retval OT_ERROR_INVALID_ARGS  The @p aRequestHeader header is not of confirmable type.
      *
      */
-    ThreadError SendHeaderResponse(Header::Code aCode, const Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo);
+    otError SendHeaderResponse(Header::Code aCode, const Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo);
 
     /**
      * This method sends a CoAP ACK empty message which is used in Separate Response for confirmable requests.
@@ -571,12 +561,12 @@ public:
      * @param[in]  aRequestHeader  A reference to the CoAP Header that was used in CoAP request.
      * @param[in]  aMessageInfo    The message info corresponding to the CoAP request.
      *
-     * @retval kThreadError_None         Successfully enqueued the CoAP response message.
-     * @retval kThreadError_NoBufs       Insufficient buffers available to send the CoAP response.
-     * @retval kThreadError_InvalidArgs  The @p aRequestHeader header is not of confirmable type.
+     * @retval OT_ERROR_NONE          Successfully enqueued the CoAP response message.
+     * @retval OT_ERROR_NO_BUFS       Insufficient buffers available to send the CoAP response.
+     * @retval OT_ERROR_INVALID_ARGS  The @p aRequestHeader header is not of confirmable type.
      *
      */
-    ThreadError SendAck(Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo) {
+    otError SendAck(Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo) {
         return SendEmptyMessage(kCoapTypeAcknowledgment, aRequestHeader, aMessageInfo);
     };
 
@@ -586,15 +576,15 @@ public:
      * @param[in]  aRequestHeader  A reference to the CoAP Header that was used in CoAP request.
      * @param[in]  aMessageInfo    The message info corresponding to the CoAP request.
      *
-     * @retval kThreadError_None         Successfully enqueued the CoAP response message.
-     * @retval kThreadError_NoBufs       Insufficient buffers available to send the CoAP response.
-     * @retval kThreadError_InvalidArgs  The @p aRequestHeader header is not of confirmable type.
+     * @retval OT_ERROR_NONE          Successfully enqueued the CoAP response message.
+     * @retval OT_ERROR_NO_BUFS       Insufficient buffers available to send the CoAP response.
+     * @retval OT_ERROR_INVALID_ARGS  The @p aRequestHeader header is not of confirmable type.
      *
      */
-    ThreadError SendEmptyAck(const Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo) {
+    otError SendEmptyAck(const Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo) {
         return (aRequestHeader.GetType() == kCoapTypeConfirmable ?
                 SendHeaderResponse(kCoapResponseChanged, aRequestHeader, aMessageInfo) :
-                kThreadError_InvalidArgs);
+                OT_ERROR_INVALID_ARGS);
     }
 
     /**
@@ -603,11 +593,11 @@ public:
      * @param[in]  aRequestHeader        A reference to the CoAP Header that was used in CoAP request.
      * @param[in]  aMessageInfo          The message info corresponding to the CoAP request.
      *
-     * @retval kThreadError_None         Successfully enqueued the CoAP response message.
-     * @retval kThreadError_NoBufs       Insufficient buffers available to send the CoAP response.
+     * @retval OT_ERROR_NONE         Successfully enqueued the CoAP response message.
+     * @retval OT_ERROR_NO_BUFS      Insufficient buffers available to send the CoAP response.
      *
      */
-    ThreadError SendNotFound(const Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo) {
+    otError SendNotFound(const Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo) {
         return SendHeaderResponse(kCoapResponseNotFound, aRequestHeader, aMessageInfo);
     }
 
@@ -617,11 +607,11 @@ public:
      * @param[in]  aHandler  A function pointer that should be called when the transaction ends.
      * @param[in]  aContext  A pointer to arbitrary context information.
      *
-     * @retval kThreadError_None      Successfully aborted CoAP transactions.
-     * @retval kThreadError_NotFound  CoAP transaction associated with given handler was not found.
+     * @retval OT_ERROR_NONE       Successfully aborted CoAP transactions.
+     * @retval OT_ERROR_NOT_FOUND  CoAP transaction associated with given handler was not found.
      *
      */
-    ThreadError AbortTransaction(otCoapResponseHandler aHandler, void *aContext);
+    otError AbortTransaction(otCoapResponseHandler aHandler, void *aContext);
 
     /**
      * This method sets interceptor to be called before processing a CoAP packet.
@@ -657,7 +647,7 @@ protected:
      * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
      *
      */
-    virtual ThreadError Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    virtual otError Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     /**
      * This method receives a message.
@@ -685,14 +675,14 @@ private:
     Message *FindRelatedRequest(const Header &aResponseHeader, const Ip6::MessageInfo &aMessageInfo,
                                 Header &aRequestHeader, CoapMetadata &aCoapMetadata);
     void FinalizeCoapTransaction(Message &aRequest, const CoapMetadata &aCoapMetadata, Header *aResponseHeader,
-                                 Message *aResponse, const Ip6::MessageInfo *aMessageInfo, ThreadError aResult);
+                                 Message *aResponse, const Ip6::MessageInfo *aMessageInfo, otError aResult);
 
     void ProcessReceivedRequest(Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     void ProcessReceivedResponse(Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    ThreadError SendCopy(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError SendEmptyMessage(Header::Type aType, const Header &aRequestHeader,
-                                 const Ip6::MessageInfo &aMessageInfo);
+    otError SendCopy(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError SendEmptyMessage(Header::Type aType, const Header &aRequestHeader,
+                             const Ip6::MessageInfo &aMessageInfo);
     static void HandleRetransmissionTimer(void *aContext);
     void HandleRetransmissionTimer(void);
 

--- a/src/core/coap/coap_header.hpp
+++ b/src/core/coap/coap_header.hpp
@@ -111,11 +111,11 @@ public:
      * @param[in]  aMessage       A reference to the message.
      * @param[in]  aMetadataSize  A size of metadata appended to the message.
      *
-     * @retval kThreadError_None   Successfully parsed the message.
-     * @retval kThreadError_Parse  Failed to parse the message.
+     * @retval OT_ERROR_NONE   Successfully parsed the message.
+     * @retval OT_ERROR_PARSE  Failed to parse the message.
      *
      */
-    ThreadError FromMessage(const Message &aMessage, uint16_t aMetadataSize);
+    otError FromMessage(const Message &aMessage, uint16_t aMetadataSize);
 
     /**
      * This method returns the Version value.
@@ -266,12 +266,12 @@ public:
      *
      * @param[in]  aOption  The CoAP Option.
      *
-     * @retval kThreadError_None         Successfully appended the option.
-     * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
-     * @retval kThreadError_NoBufs       The option length exceeds the buffer size.
+     * @retval OT_ERROR_NONE          Successfully appended the option.
+     * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
+     * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
      *
      */
-    ThreadError AppendOption(const Option &aOption);
+    otError AppendOption(const Option &aOption);
 
     /**
      * This method appends an unsigned integer CoAP option as specified in
@@ -280,35 +280,35 @@ public:
      * @param[in]  aNumber  The CoAP Option number.
      * @param[in]  aValue   The CoAP Option unsigned integer value.
      *
-     * @retval kThreadError_None         Successfully appended the option.
-     * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
-     * @retval kThreadError_NoBufs       The option length exceeds the buffer size.
+     * @retval OT_ERROR_NONE          Successfully appended the option.
+     * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
+     * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
      *
      */
-    ThreadError AppendUintOption(uint16_t aNumber, uint32_t aValue);
+    otError AppendUintOption(uint16_t aNumber, uint32_t aValue);
 
     /**
      * This method appends an Observe option.
      *
      * @param[in]  aObserve  Observe field value.
      *
-     * @retval kThreadError_None         Successfully appended the option.
-     * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
-     * @retval kThreadError_NoBufs       The option length exceeds the buffer size.
+     * @retval OT_ERROR_NONE          Successfully appended the option.
+     * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
+     * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
      */
-    ThreadError AppendObserveOption(uint32_t aObserve);
+    otError AppendObserveOption(uint32_t aObserve);
 
     /**
      * This method appends a Uri-Path option.
      *
      * @param[in]  aUriPath  A pointer to a NULL-terminated string.
      *
-     * @retval kThreadError_None         Successfully appended the option.
-     * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
-     * @retval kThreadError_NoBufs       The option length exceeds the buffer size.
+     * @retval OT_ERROR_NONE          Successfully appended the option.
+     * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
+     * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
      *
      */
-    ThreadError AppendUriPathOptions(const char *aUriPath);
+    otError AppendUriPathOptions(const char *aUriPath);
 
     /**
      * Media Types
@@ -324,34 +324,34 @@ public:
      *
      * @param[in]  aType  The Media Type value.
      *
-     * @retval kThreadError_None         Successfully appended the option.
-     * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
-     * @retval kThreadError_NoBufs       The option length exceeds the buffer size.
+     * @retval OT_ERROR_NONE          Successfully appended the option.
+     * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
+     * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
      *
      */
-    ThreadError AppendContentFormatOption(MediaType aType);
+    otError AppendContentFormatOption(MediaType aType);
 
     /**
      * This method appends a Max-Age option.
      *
      * @param[in]  aMaxAge  The Max-Age value.
      *
-     * @retval kThreadError_None         Successfully appended the option.
-     * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
-     * @retval kThreadError_NoBufs       The option length exceeds the buffer size.
+     * @retval OT_ERROR_NONE          Successfully appended the option.
+     * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
+     * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
      */
-    ThreadError AppendMaxAgeOption(uint32_t aMaxAge);
+    otError AppendMaxAgeOption(uint32_t aMaxAge);
 
     /**
      * This method appends a single Uri-Query option.
      *
      * @param[in]  aUriQuery  A pointer to NULL-terminated string, which should contain a single key=value pair.
      *
-     * @retval kThreadError_None         Successfully appended the option.
-     * @retval kThreadError_InvalidArgs  The option type is not equal or greater than the last option type.
-     * @retval kThreadError_NoBufs       The option length exceeds the buffer size.
+     * @retval OT_ERROR_NONE          Successfully appended the option.
+     * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
+     * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
      */
-    ThreadError AppendUriQueryOption(const char *aUriQuery);
+    otError AppendUriQueryOption(const char *aUriQuery);
 
     /**
      * This method returns a pointer to the first option.
@@ -372,11 +372,11 @@ public:
     /**
      * This method adds Payload Marker indicating beginning of the payload to the CoAP header.
      *
-     * @retval kThreadError_None    Payload Marker successfully added.
-     * @retval kThreadError_NoBufs  Header Payload Marker exceeds the buffer size.
+     * @retval OT_ERROR_NONE     Payload Marker successfully added.
+     * @retval OT_ERROR_NO_BUFS  Header Payload Marker exceeds the buffer size.
      *
      */
-    ThreadError SetPayloadMarker(void);
+    otError SetPayloadMarker(void);
 
     /**
      * This method returns a pointer to the first byte of the header.

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -61,9 +61,9 @@ CoapSecure::CoapSecure(ThreadNetif &aNetif):
 {
 }
 
-ThreadError CoapSecure::Start(uint16_t aPort, TransportCallback aCallback, void *aContext)
+otError CoapSecure::Start(uint16_t aPort, TransportCallback aCallback, void *aContext)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     mTransportCallback = aCallback;
     mTransportContext = aContext;
 
@@ -77,7 +77,7 @@ ThreadError CoapSecure::Start(uint16_t aPort, TransportCallback aCallback, void 
     return error;
 }
 
-ThreadError CoapSecure::Stop(void)
+otError CoapSecure::Stop(void)
 {
     if (IsConnectionActive())
     {
@@ -96,7 +96,7 @@ ThreadError CoapSecure::Stop(void)
     return Coap::Stop();
 }
 
-ThreadError CoapSecure::Connect(const Ip6::MessageInfo &aMessageInfo, ConnectedCallback aCallback, void *aContext)
+otError CoapSecure::Connect(const Ip6::MessageInfo &aMessageInfo, ConnectedCallback aCallback, void *aContext)
 {
     mPeerAddress = aMessageInfo;
     mConnectedCallback = aCallback;
@@ -116,7 +116,7 @@ bool CoapSecure::IsConnected(void)
     return mNetif.GetDtls().IsConnected();
 }
 
-ThreadError CoapSecure::Disconnect(void)
+otError CoapSecure::Disconnect(void)
 {
     return mNetif.GetDtls().Stop();
 }
@@ -126,18 +126,18 @@ MeshCoP::Dtls &CoapSecure::GetDtls(void)
     return mNetif.GetDtls();
 }
 
-ThreadError CoapSecure::SetPsk(const uint8_t *aPsk, uint8_t aPskLength)
+otError CoapSecure::SetPsk(const uint8_t *aPsk, uint8_t aPskLength)
 {
     return mNetif.GetDtls().SetPsk(aPsk, aPskLength);
 }
 
-ThreadError CoapSecure::SendMessage(Message &aMessage, otCoapResponseHandler aHandler, void *aContext)
+otError CoapSecure::SendMessage(Message &aMessage, otCoapResponseHandler aHandler, void *aContext)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     otLogFuncEntry();
 
-    VerifyOrExit(IsConnected(), error = kThreadError_InvalidState);
+    VerifyOrExit(IsConnected(), error = OT_ERROR_INVALID_STATE);
 
     error = Coap::SendMessage(aMessage, mPeerAddress, aHandler, aContext);
 
@@ -146,13 +146,13 @@ exit:
     return error;
 }
 
-ThreadError CoapSecure::SendMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
-                                    otCoapResponseHandler aHandler, void *aContext)
+otError CoapSecure::SendMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
+                                otCoapResponseHandler aHandler, void *aContext)
 {
     return Coap::SendMessage(aMessage, aMessageInfo, aHandler, aContext);
 }
 
-ThreadError CoapSecure::Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError CoapSecure::Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     (void)aMessageInfo;
     return mNetif.GetDtls().Send(aMessage, aMessage.GetLength());
@@ -235,20 +235,20 @@ exit:
     otLogFuncExit();
 }
 
-ThreadError CoapSecure::HandleDtlsSend(void *aContext, const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType)
+otError CoapSecure::HandleDtlsSend(void *aContext, const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType)
 {
     return static_cast<CoapSecure *>(aContext)->HandleDtlsSend(aBuf, aLength, aMessageSubType);
 }
 
-ThreadError CoapSecure::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType)
+otError CoapSecure::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     otLogFuncEntry();
 
     if (mTransmitMessage == NULL)
     {
-        VerifyOrExit((mTransmitMessage = mSocket.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
+        VerifyOrExit((mTransmitMessage = mSocket.NewMessage(0)) != NULL, error = OT_ERROR_NO_BUFS);
         mTransmitMessage->SetSubType(aMessageSubType);
         mTransmitMessage->SetLinkSecurityEnabled(false);
     }
@@ -259,13 +259,13 @@ ThreadError CoapSecure::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, ui
         mTransmitMessage->SetSubType(aMessageSubType);
     }
 
-    VerifyOrExit(mTransmitMessage->Append(aBuf, aLength) == kThreadError_None, error = kThreadError_NoBufs);
+    VerifyOrExit(mTransmitMessage->Append(aBuf, aLength) == OT_ERROR_NONE, error = OT_ERROR_NO_BUFS);
 
     mTransmitTask.Post();
 
 exit:
 
-    if (error != kThreadError_None && mTransmitMessage != NULL)
+    if (error != OT_ERROR_NONE && mTransmitMessage != NULL)
     {
         mTransmitMessage->Free();
     }
@@ -282,11 +282,11 @@ void CoapSecure::HandleUdpTransmit(void *aContext)
 
 void CoapSecure::HandleUdpTransmit(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     otLogFuncEntry();
 
-    VerifyOrExit(mTransmitMessage != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit(mTransmitMessage != NULL, error = OT_ERROR_NO_BUFS);
 
     if (mTransportCallback)
     {
@@ -299,7 +299,7 @@ void CoapSecure::HandleUdpTransmit(void)
 
 exit:
 
-    if (error != kThreadError_None && mTransmitMessage != NULL)
+    if (error != OT_ERROR_NONE && mTransmitMessage != NULL)
     {
         mTransmitMessage->Free();
     }

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -63,7 +63,7 @@ public:
      * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
      *
      */
-    typedef ThreadError(*TransportCallback)(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    typedef otError(*TransportCallback)(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     /**
      * This constructor initializes the object.
@@ -81,18 +81,18 @@ public:
      *                        If NULL, the message is sent directly to the socket.
      * @param[in]  aContext   A pointer to arbitrary context information.
      *
-     * @retval kThreadError_None  Successfully started the CoAP agent.
+     * @retval OT_ERROR_NONE  Successfully started the CoAP agent.
      *
      */
-    ThreadError Start(uint16_t aPort, TransportCallback aCallback = NULL, void *aContext = NULL);
+    otError Start(uint16_t aPort, TransportCallback aCallback = NULL, void *aContext = NULL);
 
     /**
      * This method stops the secure CoAP agent.
      *
-     * @retval kThreadError_None  Successfully stopped the secure CoAP agent.
+     * @retval OT_ERROR_NONE  Successfully stopped the secure CoAP agent.
      *
      */
-    ThreadError Stop(void);
+    otError Stop(void);
 
     /**
      * This method initializes DTLS session with a peer.
@@ -100,10 +100,10 @@ public:
      * @param[in]  aMessageInfo  A reference to an address of the peer.
      * @param[in]  aCallback     A pointer to a function that will be called once DTLS connection is established.
      *
-     * @retval kThreadError_None  Successfully started DTLS connection.
+     * @retval OT_ERROR_NONE  Successfully started DTLS connection.
      *
      */
-    ThreadError Connect(const Ip6::MessageInfo &aMessageInfo, ConnectedCallback aCallback, void *aContext);
+    otError Connect(const Ip6::MessageInfo &aMessageInfo, ConnectedCallback aCallback, void *aContext);
 
     /**
      * This method indicates whether or not the DTLS session is active.
@@ -126,10 +126,10 @@ public:
     /**
      * This method stops the DTLS connection.
      *
-     * @retval kThreadError_None  Successfully stopped the DTLS connection.
+     * @retval OT_ERROR_NONE  Successfully stopped the DTLS connection.
      *
      */
-    ThreadError Disconnect(void);
+    otError Disconnect(void);
 
     /**
      * This method returns a reference to the DTLS object.
@@ -145,11 +145,11 @@ public:
      * @param[in]  aPSK        A pointer to the PSK.
      * @param[in]  aPskLength  The PSK length.
      *
-     * @retval kThreadError_None         Successfully set the PSK.
-     * @retval kThreadError_InvalidArgs  The PSK is invalid.
+     * @retval OT_ERROR_NONE          Successfully set the PSK.
+     * @retval OT_ERROR_INVALID_ARGS  The PSK is invalid.
      *
      */
-    ThreadError SetPsk(const uint8_t *aPsk, uint8_t aPskLength);
+    otError SetPsk(const uint8_t *aPsk, uint8_t aPskLength);
 
     /**
      * This method sends a CoAP message over secure DTLS connection.
@@ -162,12 +162,12 @@ public:
      * @param[in]  aHandler      A function pointer that shall be called on response reception or time-out.
      * @param[in]  aContext      A pointer to arbitrary context information.
      *
-     * @retval kThreadError_None         Successfully sent CoAP message.
-     * @retval kThreadError_NoBufs       Failed to allocate retransmission data.
-     * @retvak kThreadError_InvalidState DTLS connection was not initialized.
+     * @retval OT_ERROR_NONE           Successfully sent CoAP message.
+     * @retval OT_ERROR_NO_BUFS        Failed to allocate retransmission data.
+     * @retvak OT_ERROR_INVALID_STATE  DTLS connection was not initialized.
      *
      */
-    ThreadError SendMessage(Message &aMessage, otCoapResponseHandler aHandler = NULL, void *aContext = NULL);
+    otError SendMessage(Message &aMessage, otCoapResponseHandler aHandler = NULL, void *aContext = NULL);
 
     /**
      * This method sends a CoAP message over secure DTLS connection.
@@ -181,13 +181,13 @@ public:
      * @param[in]  aHandler      A function pointer that shall be called on response reception or time-out.
      * @param[in]  aContext      A pointer to arbitrary context information.
      *
-     * @retval kThreadError_None         Successfully sent CoAP message.
-     * @retval kThreadError_NoBufs       Failed to allocate retransmission data.
-     * @retvak kThreadError_InvalidState DTLS connection was not initialized.
+     * @retval OT_ERROR_NONE           Successfully sent CoAP message.
+     * @retval OT_ERROR_NO_BUFS        Failed to allocate retransmission data.
+     * @retvak OT_ERROR_INVALID_STATE  DTLS connection was not initialized.
      *
      */
-    ThreadError SendMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
-                            otCoapResponseHandler aHandler = NULL, void *aContext = NULL);
+    otError SendMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
+                        otCoapResponseHandler aHandler = NULL, void *aContext = NULL);
 
     /**
      * This method is used to pass messages to the secure CoAP server.
@@ -200,7 +200,7 @@ public:
     void Receive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
 private:
-    virtual ThreadError Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    virtual otError Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     static void HandleDtlsConnected(void *aContext, bool aConnected);
     void HandleDtlsConnected(bool aConnected);
@@ -208,8 +208,8 @@ private:
     static void HandleDtlsReceive(void *aContext, uint8_t *aBuf, uint16_t aLength);
     void HandleDtlsReceive(uint8_t *aBuf, uint16_t aLength);
 
-    static ThreadError HandleDtlsSend(void *aContext, const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
-    ThreadError HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
+    static otError HandleDtlsSend(void *aContext, const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
+    otError HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
 
     static void HandleUdpTransmit(void *aContext);
     void HandleUdpTransmit(void);

--- a/src/core/common/logging.cpp
+++ b/src/core/common/logging.cpp
@@ -263,157 +263,149 @@ const char *otLogRegionToString(otLogRegion aRegion)
 }
 #endif // OPENTHREAD_CONFIG_LOG_PREPEND_REGION
 
-const char *otThreadErrorToString(ThreadError aError)
+const char *otThreadErrorToString(otError aError)
 {
     const char *retval;
 
     switch (aError)
     {
-    case kThreadError_None:
+    case OT_ERROR_NONE:
         retval = "None";
         break;
 
-    case kThreadError_Failed:
+    case OT_ERROR_FAILED:
         retval = "Failed";
         break;
 
-    case kThreadError_Drop:
+    case OT_ERROR_DROP:
         retval = "Drop";
         break;
 
-    case kThreadError_NoBufs:
+    case OT_ERROR_NO_BUFS:
         retval = "NoBufs";
         break;
 
-    case kThreadError_NoRoute:
+    case OT_ERROR_NO_ROUTE:
         retval = "NoRoute";
         break;
 
-    case kThreadError_Busy:
+    case OT_ERROR_BUSY:
         retval = "Busy";
         break;
 
-    case kThreadError_Parse:
+    case OT_ERROR_PARSE:
         retval = "Parse";
         break;
 
-    case kThreadError_InvalidArgs:
+    case OT_ERROR_INVALID_ARGS:
         retval = "InvalidArgs";
         break;
 
-    case kThreadError_Security:
+    case OT_ERROR_SECURITY:
         retval = "Security";
         break;
 
-    case kThreadError_AddressQuery:
+    case OT_ERROR_ADDRESS_QUERY:
         retval = "AddressQuery";
         break;
 
-    case kThreadError_NoAddress:
+    case OT_ERROR_NO_ADDRESS:
         retval = "NoAddress";
         break;
 
-    case kThreadError_NotReceiving:
-        retval = "NotReceiving";
-        break;
-
-    case kThreadError_Abort:
+    case OT_ERROR_ABORT:
         retval = "Abort";
         break;
 
-    case kThreadError_NotImplemented:
+    case OT_ERROR_NOT_IMPLEMENTED:
         retval = "NotImplemented";
         break;
 
-    case kThreadError_InvalidState:
+    case OT_ERROR_INVALID_STATE:
         retval = "InvalidState";
         break;
 
-    case kThreadError_NoTasklets:
-        retval = "NoTasklets";
-        break;
-
-    case kThreadError_NoAck:
+    case OT_ERROR_NO_ACK:
         retval = "NoAck";
         break;
 
-    case kThreadError_ChannelAccessFailure:
+    case OT_ERROR_CHANNEL_ACCESS_FAILURE:
         retval = "ChannelAccessFailure";
         break;
 
-    case kThreadError_Detached:
+    case OT_ERROR_DETACHED:
         retval = "Detached";
         break;
 
-    case kThreadError_FcsErr:
+    case OT_ERROR_FCS:
         retval = "FcsErr";
         break;
 
-    case kThreadError_NoFrameReceived:
+    case OT_ERROR_NO_FRAME_RECEIVED:
         retval = "NoFrameReceived";
         break;
 
-    case kThreadError_UnknownNeighbor:
+    case OT_ERROR_UNKNOWN_NEIGHBOR:
         retval = "UnknownNeighbor";
         break;
 
-    case kThreadError_InvalidSourceAddress:
+    case OT_ERROR_INVALID_SOURCE_ADDRESS:
         retval = "InvalidSourceAddress";
         break;
 
-    case kThreadError_WhitelistFiltered:
+    case OT_ERROR_WHITELIST_FILTERED:
         retval = "WhitelistFiltered";
         break;
 
-    case kThreadError_DestinationAddressFiltered:
+    case OT_ERROR_DESTINATION_ADDRESS_FILTERED:
         retval = "DestinationAddressFiltered";
         break;
 
-    case kThreadError_NotFound:
+    case OT_ERROR_NOT_FOUND:
         retval = "NotFound";
         break;
 
-    case kThreadError_Already:
+    case OT_ERROR_ALREADY:
         retval = "Already";
         break;
 
-    case kThreadError_BlacklistFiltered:
+    case OT_ERROR_BLACKLIST_FILTERED:
         retval = "BlacklistFiltered";
         break;
 
-    case kThreadError_Ipv6AddressCreationFailure:
+    case OT_ERROR_IP6_ADDRESS_CREATION_FAILURE:
         retval = "Ipv6AddressCreationFailure";
         break;
 
-    case kThreadError_NotCapable:
+    case OT_ERROR_NOT_CAPABLE:
         retval = "NotCapable";
         break;
 
-    case kThreadError_ResponseTimeout:
+    case OT_ERROR_RESPONSE_TIMEOUT:
         retval = "ResponseTimeout";
         break;
 
-    case kThreadError_Duplicated:
+    case OT_ERROR_DUPLICATED:
         retval = "Duplicated";
         break;
 
-    case kThreadError_ReassemblyTimeout:
+    case OT_ERROR_REASSEMBLY_TIMEOUT:
         retval = "ReassemblyTimeout";
         break;
 
-    case kThreadError_NotTmf:
+    case OT_ERROR_NOT_TMF:
         retval = "NotTmf";
         break;
 
-    case kThreadError_NonLowpanDataFrame:
+    case OT_ERROR_NOT_LOWPAN_DATA_FRAME:
         retval = "NonLowpanDataFrame";
         break;
 
-    case kThreadError_DisabledFeature:
+    case OT_ERROR_DISABLED_FEATURE:
         retval = "DisabledFeature";
         break;
 
-    case kThreadError_Error:
+    case OT_ERROR_GENERIC:
         retval = "GenericError";
         break;
 

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -86,7 +86,7 @@ Message *MessagePool::New(uint8_t aType, uint16_t aReserved)
     message->SetLinkSecurityEnabled(true);
     message->SetPriority(kDefaultMessagePriority);
 
-    if (message->SetLength(0) != kThreadError_None)
+    if (message->SetLength(0) != OT_ERROR_NONE)
     {
         Free(message);
         message = NULL;
@@ -96,7 +96,7 @@ exit:
     return message;
 }
 
-ThreadError MessagePool::Free(Message *aMessage)
+otError MessagePool::Free(Message *aMessage)
 {
     assert(aMessage->Next(MessageInfo::kListAll) == NULL &&
            aMessage->Prev(MessageInfo::kListAll) == NULL);
@@ -135,7 +135,7 @@ Buffer *MessagePool::NewBuffer(void)
     return buffer;
 }
 
-ThreadError MessagePool::FreeBuffers(Buffer *aBuffer)
+otError MessagePool::FreeBuffers(Buffer *aBuffer)
 {
     Buffer *tmpBuffer;
 
@@ -152,10 +152,10 @@ ThreadError MessagePool::FreeBuffers(Buffer *aBuffer)
         aBuffer = tmpBuffer;
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError MessagePool::ReclaimBuffers(int aNumBuffers)
+otError MessagePool::ReclaimBuffers(int aNumBuffers)
 {
     uint16_t numFreeBuffers;
 
@@ -170,11 +170,11 @@ ThreadError MessagePool::ReclaimBuffers(int aNumBuffers)
     //the second comparison wont be attempted.
     if (aNumBuffers < 0 || aNumBuffers <= numFreeBuffers)
     {
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
     else
     {
-        return kThreadError_NoBufs;
+        return OT_ERROR_NO_BUFS;
     }
 }
 
@@ -235,9 +235,9 @@ MessagePool::Iterator MessagePool::GetAllMessagesHead(void) const
     return Iterator(head);
 }
 
-ThreadError Message::ResizeMessage(uint16_t aLength)
+otError Message::ResizeMessage(uint16_t aLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     // add buffers
     Buffer *curBuffer = this;
@@ -249,7 +249,7 @@ ThreadError Message::ResizeMessage(uint16_t aLength)
         if (curBuffer->GetNextBuffer() == NULL)
         {
             curBuffer->SetNextBuffer(GetMessagePool()->NewBuffer());
-            VerifyOrExit(curBuffer->GetNextBuffer() != NULL, error = kThreadError_NoBufs);
+            VerifyOrExit(curBuffer->GetNextBuffer() != NULL, error = OT_ERROR_NO_BUFS);
         }
 
         curBuffer = curBuffer->GetNextBuffer();
@@ -267,7 +267,7 @@ exit:
     return error;
 }
 
-ThreadError Message::Free(void)
+otError Message::Free(void)
 {
     return GetMessagePool()->Free(this);
 }
@@ -296,9 +296,9 @@ exit:
     return next;
 }
 
-ThreadError Message::SetLength(uint16_t aLength)
+otError Message::SetLength(uint16_t aLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint16_t totalLengthRequest = GetReserved() + aLength;
     uint16_t totalLengthCurrent = GetReserved() + GetLength();
     int bufs = 0;
@@ -334,12 +334,12 @@ uint8_t Message::GetBufferCount(void) const
     return rval;
 }
 
-ThreadError Message::MoveOffset(int aDelta)
+otError Message::MoveOffset(int aDelta)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     assert(GetOffset() + aDelta <= GetLength());
-    VerifyOrExit(GetOffset() + aDelta <= GetLength(), error = kThreadError_InvalidArgs);
+    VerifyOrExit(GetOffset() + aDelta <= GetLength(), error = OT_ERROR_INVALID_ARGS);
 
     mBuffer.mHead.mInfo.mOffset += static_cast<int16_t>(aDelta);
     assert(mBuffer.mHead.mInfo.mOffset <= GetLength());
@@ -348,12 +348,12 @@ exit:
     return error;
 }
 
-ThreadError Message::SetOffset(uint16_t aOffset)
+otError Message::SetOffset(uint16_t aOffset)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     assert(aOffset <= GetLength());
-    VerifyOrExit(aOffset <= GetLength(), error = kThreadError_InvalidArgs);
+    VerifyOrExit(aOffset <= GetLength(), error = OT_ERROR_INVALID_ARGS);
 
     mBuffer.mHead.mInfo.mOffset = aOffset;
 
@@ -377,12 +377,12 @@ bool Message::IsSubTypeMle(void) const
     return rval;
 }
 
-ThreadError Message::SetPriority(uint8_t aPriority)
+otError Message::SetPriority(uint8_t aPriority)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     PriorityQueue *priorityQueue = NULL;
 
-    VerifyOrExit(aPriority < kNumPriorities, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aPriority < kNumPriorities, error = OT_ERROR_INVALID_ARGS);
 
     VerifyOrExit(IsInAQueue(), mBuffer.mHead.mInfo.mPriority = aPriority);
     VerifyOrExit(mBuffer.mHead.mInfo.mPriority != aPriority);
@@ -412,9 +412,9 @@ exit:
     return error;
 }
 
-ThreadError Message::Append(const void *aBuf, uint16_t aLength)
+otError Message::Append(const void *aBuf, uint16_t aLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint16_t oldLength = GetLength();
     int bytesWritten;
 
@@ -428,14 +428,14 @@ exit:
     return error;
 }
 
-ThreadError Message::Prepend(const void *aBuf, uint16_t aLength)
+otError Message::Prepend(const void *aBuf, uint16_t aLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Buffer *newBuffer = NULL;
 
     while (aLength > GetReserved())
     {
-        VerifyOrExit((newBuffer = GetMessagePool()->NewBuffer()) != NULL, error = kThreadError_NoBufs);
+        VerifyOrExit((newBuffer = GetMessagePool()->NewBuffer()) != NULL, error = OT_ERROR_NO_BUFS);
 
         newBuffer->SetNextBuffer(GetNextBuffer());
         SetNextBuffer(newBuffer);
@@ -463,7 +463,7 @@ exit:
     return error;
 }
 
-ThreadError Message::RemoveHeader(uint16_t aLength)
+otError Message::RemoveHeader(uint16_t aLength)
 {
     assert(aLength <= mBuffer.mHead.mInfo.mLength);
 
@@ -479,7 +479,7 @@ ThreadError Message::RemoveHeader(uint16_t aLength)
         mBuffer.mHead.mInfo.mOffset = 0;
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 uint16_t Message::Read(uint16_t aOffset, uint16_t aLength, void *aBuf) const
@@ -658,10 +658,10 @@ int Message::CopyTo(uint16_t aSourceOffset, uint16_t aDestinationOffset, uint16_
 
 Message *Message::Clone(uint16_t aLength) const
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Message *messageCopy;
 
-    VerifyOrExit((messageCopy = GetMessagePool()->New(GetType(), GetReserved())) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((messageCopy = GetMessagePool()->New(GetType(), GetReserved())) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = messageCopy->SetLength(aLength));
     CopyTo(0, 0, aLength, *messageCopy);
 
@@ -674,7 +674,7 @@ Message *Message::Clone(uint16_t aLength) const
 
 exit:
 
-    if (error != kThreadError_None && messageCopy != NULL)
+    if (error != OT_ERROR_NONE && messageCopy != NULL)
     {
         messageCopy->Free();
         messageCopy = NULL;
@@ -852,11 +852,11 @@ Message *MessageQueue::GetHead(void) const
     return (GetTail() == NULL) ? NULL : GetTail()->Next(MessageInfo::kListInterface);
 }
 
-ThreadError MessageQueue::Enqueue(Message &aMessage)
+otError MessageQueue::Enqueue(Message &aMessage)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(!aMessage.IsInAQueue(), error = kThreadError_Already);
+    VerifyOrExit(!aMessage.IsInAQueue(), error = OT_ERROR_ALREADY);
 
     aMessage.SetMessageQueue(this);
 
@@ -867,11 +867,11 @@ exit:
     return error;
 }
 
-ThreadError MessageQueue::Dequeue(Message &aMessage)
+otError MessageQueue::Dequeue(Message &aMessage)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aMessage.GetMessageQueue() == this, error = kThreadError_NotFound);
+    VerifyOrExit(aMessage.GetMessageQueue() == this, error = OT_ERROR_NOT_FOUND);
 
     RemoveFromList(MessageInfo::kListInterface, aMessage);
     aMessage.GetMessagePool()->GetAllMessagesQueue()->RemoveFromList(MessageInfo::kListAll, aMessage);
@@ -1014,11 +1014,11 @@ void PriorityQueue::RemoveFromList(uint8_t aList, Message &aMessage)
     aMessage.Prev(aList) = NULL;
 }
 
-ThreadError PriorityQueue::Enqueue(Message &aMessage)
+otError PriorityQueue::Enqueue(Message &aMessage)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(!aMessage.IsInAQueue(), error = kThreadError_Already);
+    VerifyOrExit(!aMessage.IsInAQueue(), error = OT_ERROR_ALREADY);
 
     aMessage.SetPriorityQueue(this);
 
@@ -1029,11 +1029,11 @@ exit:
     return error;
 }
 
-ThreadError PriorityQueue::Dequeue(Message &aMessage)
+otError PriorityQueue::Dequeue(Message &aMessage)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aMessage.GetPriorityQueue() == this, error = kThreadError_NotFound);
+    VerifyOrExit(aMessage.GetPriorityQueue() == this, error = OT_ERROR_NOT_FOUND);
 
     RemoveFromList(MessageInfo::kListInterface, aMessage);
     aMessage.GetMessagePool()->GetAllMessagesQueue()->RemoveFromList(MessageInfo::kListAll, aMessage);

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -236,7 +236,7 @@ public:
      * This method frees this message buffer.
      *
      */
-    ThreadError Free(void);
+    otError Free(void);
 
     /**
      * This method returns a pointer to the next message in the same interface list.
@@ -258,12 +258,11 @@ public:
      *
      * @param[in]  aLength  Requested number of bytes in the message.
      *
-     * @retval kThreadError_None    Successfully set the length of the message.
-     * @retval kThreadError_NoBufs  Failed to grow the size of the message because insufficient buffers were
-     *                              available.
+     * @retval OT_ERROR_NONE     Successfully set the length of the message.
+     * @retval OT_ERROR_NO_BUFS  Failed to grow the size of the message because insufficient buffers were available.
      *
      */
-    ThreadError SetLength(uint16_t aLength);
+    otError SetLength(uint16_t aLength);
 
     /**
      * This method returns the number of buffers in the message.
@@ -284,22 +283,22 @@ public:
      *
      * @param[in]  aDelta  The number of bytes to move the current offset, which may be positive or negative.
      *
-     * @retval kThreadError_None         Successfully moved the byte offset.
-     * @retval kThreadError_InvalidArgs  The resulting byte offset is not within the existing message.
+     * @retval OT_ERROR_NONE          Successfully moved the byte offset.
+     * @retval OT_ERROR_INVALID_ARGS  The resulting byte offset is not within the existing message.
      *
      */
-    ThreadError MoveOffset(int aDelta);
+    otError MoveOffset(int aDelta);
 
     /**
      * This method sets the byte offset within the message.
      *
      * @param[in]  aOffset  The number of bytes to move the current offset, which may be positive or negative.
      *
-     * @retval kThreadError_None         Successfully moved the byte offset.
-     * @retval kThreadError_InvalidArgs  The requested byte offset is not within the existing message.
+     * @retval OT_ERROR_NONE          Successfully moved the byte offset.
+     * @retval OT_ERROR_INVALID_ARGS  The requested byte offset is not within the existing message.
      *
      */
-    ThreadError SetOffset(uint16_t aOffset);
+    otError SetOffset(uint16_t aOffset);
 
     /**
      * This method returns the type of the message.
@@ -357,11 +356,11 @@ public:
      *
      * @param[in]  aPrority  The message priority level.
      *
-     * @retval kThreadError_None          Successfully set the priority for the message.
-     * @retval kThreadError_InvalidArgs   Priority level is not invalid.
+     * @retval OT_ERROR_NONE           Successfully set the priority for the message.
+     * @retval OT_ERROR_INVALID_ARGS   Priority level is not invalid.
      *
      */
-    ThreadError SetPriority(uint8_t aPriority);
+    otError SetPriority(uint8_t aPriority);
 
     /**
      * This method prepends bytes to the front of the message.
@@ -371,21 +370,21 @@ public:
      * @param[in]  aBuf     A pointer to a data buffer.
      * @param[in]  aLength  The number of bytes to prepend.
      *
-     * @retval kThreadError_None    Successfully prepended the bytes.
-     * @retval kThreadError_NoBufs  Not enough reserved bytes in the message.
+     * @retval OT_ERROR_NONE     Successfully prepended the bytes.
+     * @retval OT_ERROR_NO_BUFS  Not enough reserved bytes in the message.
      *
      */
-    ThreadError Prepend(const void *aBuf, uint16_t aLength);
+    otError Prepend(const void *aBuf, uint16_t aLength);
 
     /**
      * This method removes header bytes from the message.
      *
      * @param[in]  aLength  Number of header bytes to remove.
      *
-     * @retval kThreadError_None  Successfully removed header bytes from the message.
+     * @retval OT_ERROR_NONE  Successfully removed header bytes from the message.
      *
      */
-    ThreadError RemoveHeader(uint16_t aLength);
+    otError RemoveHeader(uint16_t aLength);
 
     /**
      * This method appends bytes to the end of the message.
@@ -395,11 +394,11 @@ public:
      * @param[in]  aBuf     A pointer to a data buffer.
      * @param[in]  aLength  The number of bytes to append.
      *
-     * @retval kThreadError_None    Successfully appended the bytes.
-     * @retval kThreadError_NoBufs  Insufficient available buffers to grow the message.
+     * @retval OT_ERROR_NONE     Successfully appended the bytes.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
      *
      */
-    ThreadError Append(const void *aBuf, uint16_t aLength);
+    otError Append(const void *aBuf, uint16_t aLength);
 
     /**
      * This method reads bytes from the message.
@@ -746,11 +745,11 @@ private:
      *
      * @param[in]  aLength  The number of bytes that the message buffer needs to handle.
      *
-     * @retval kThreadError_None          Successfully resized the message.
-     * @retval kThreadError_InvalidArags  Could not grow the message due to insufficient available message buffers.
+     * @retval OT_ERROR_NONE     Successfully resized the message.
+     * @retval OT_ERROR_NO_BUFS  Could not grow the message due to insufficient available message buffers.
      *
      */
-    ThreadError ResizeMessage(uint16_t aLength);
+    otError ResizeMessage(uint16_t aLength);
 };
 
 /**
@@ -782,22 +781,22 @@ public:
      *
      * @param[in]  aMessage  The message to add.
      *
-     * @retval kThreadError_None     Successfully added the message to the list.
-     * @retval kThreadError_Already  The message is already enqueued in a list.
+     * @retval OT_ERROR_NONE     Successfully added the message to the list.
+     * @retval OT_ERROR_ALREADY  The message is already enqueued in a list.
      *
      */
-    ThreadError Enqueue(Message &aMessage);
+    otError Enqueue(Message &aMessage);
 
     /**
      * This method removes a message from the list.
      *
      * @param[in]  aMessage  The message to remove.
      *
-     * @retval kThreadError_None      Successfully removed the message from the list.
-     * @retval kThreadError_NotFound  The message is not enqueued in a list.
+     * @retval OT_ERROR_NONE       Successfully removed the message from the list.
+     * @retval OT_ERROR_NOT_FOUND  The message is not enqueued in a list.
      *
      */
-    ThreadError Dequeue(Message &aMessage);
+    otError Dequeue(Message &aMessage);
 
     /**
      * This method returns the number of messages and buffers enqueued.
@@ -886,22 +885,22 @@ public:
      *
      * @param[in]  aMessage  The message to add.
      *
-     * @retval kThreadError_None     Successfully added the message to the list.
-     * @retval kThreadError_Already  The message is already enqueued in a list.
+     * @retval OT_ERROR_NONE     Successfully added the message to the list.
+     * @retval OT_ERROR_ALREADY  The message is already enqueued in a list.
      *
      */
-    ThreadError Enqueue(Message &aMessage);
+    otError Enqueue(Message &aMessage);
 
     /**
      * This method removes a message from the list.
      *
      * @param[in]  aMessage  The message to remove.
      *
-     * @retval kThreadError_None      Successfully removed the message from the list.
-     * @retval kThreadError_NotFound  The message is not enqueued in a list.
+     * @retval OT_ERROR_NONE       Successfully removed the message from the list.
+     * @retval OT_ERROR_NOT_FOUND  The message is not enqueued in a list.
      *
      */
-    ThreadError Dequeue(Message &aMessage);
+    otError Dequeue(Message &aMessage);
 
     /**
      * This method returns the number of messages and buffers enqueued.
@@ -1079,11 +1078,11 @@ public:
      *
      * @param[in]  aMessage  The message to free.
      *
-     * @retval kThreadError_None         Successfully freed the message.
-     * @retval kThreadError_InvalidArgs  The message is already freed.
+     * @retval OT_ERROR_NONE          Successfully freed the message.
+     * @retval OT_ERROR_INVALID_ARGS  The message is already freed.
      *
      */
-    ThreadError Free(Message *aMessage);
+    otError Free(Message *aMessage);
 
     /**
      * This method returns a pointer to the first message (head) in the all-messages list.
@@ -1122,8 +1121,8 @@ private:
     };
 
     Buffer *NewBuffer(void);
-    ThreadError FreeBuffers(Buffer *aBuffer);
-    ThreadError ReclaimBuffers(int aNumBuffers);
+    otError FreeBuffers(Buffer *aBuffer);
+    otError ReclaimBuffers(int aNumBuffers);
     PriorityQueue *GetAllMessagesQueue(void) { return &mAllQueue; }
 
 #if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT == 0

--- a/src/core/common/tasklet.cpp
+++ b/src/core/common/tasklet.cpp
@@ -55,7 +55,7 @@ Tasklet::Tasklet(TaskletScheduler &aScheduler, Handler aHandler, void *aContext)
 {
 }
 
-ThreadError Tasklet::Post(void)
+otError Tasklet::Post(void)
 {
     return mScheduler.Post(*this);
 }
@@ -66,11 +66,11 @@ TaskletScheduler::TaskletScheduler(void):
 {
 }
 
-ThreadError TaskletScheduler::Post(Tasklet &aTasklet)
+otError TaskletScheduler::Post(Tasklet &aTasklet)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mTail != &aTasklet && aTasklet.mNext == NULL, error = kThreadError_Already);
+    VerifyOrExit(mTail != &aTasklet && aTasklet.mNext == NULL, error = OT_ERROR_ALREADY);
 
     if (mTail == NULL)
     {

--- a/src/core/common/tasklet.hpp
+++ b/src/core/common/tasklet.hpp
@@ -85,7 +85,7 @@ public:
      * This method puts the tasklet on the run queue.
      *
      */
-    ThreadError Post(void);
+    otError Post(void);
 
 private:
     void RunTask(void) { mHandler(mContext); }
@@ -114,10 +114,10 @@ public:
      *
      * @param[in]  aTasklet  A reference to the tasklet to enqueue.
      *
-     * @retval kThreadError_None  Successfully enqueued the tasklet.
-     * @retval kThreadError_Already  The tasklet was already enqueued.
+     * @retval OT_ERROR_NONE     Successfully enqueued the tasklet.
+     * @retval OT_ERROR_ALREADY  The tasklet was already enqueued.
      */
-    ThreadError Post(Tasklet &aTasklet);
+    otError Post(Tasklet &aTasklet);
 
     /**
      * This method indicates whether or not there are tasklets pending.

--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -44,9 +44,9 @@
 
 namespace ot {
 
-ThreadError Tlv::Get(const Message &aMessage, uint8_t aType, uint16_t aMaxLength, Tlv &aTlv)
+otError Tlv::Get(const Message &aMessage, uint8_t aType, uint16_t aMaxLength, Tlv &aTlv)
 {
-    ThreadError error = kThreadError_NotFound;
+    otError error = OT_ERROR_NOT_FOUND;
     uint16_t offset;
 
     SuccessOrExit(error = GetOffset(aMessage, aType, offset));
@@ -63,9 +63,9 @@ exit:
     return error;
 }
 
-ThreadError Tlv::GetOffset(const Message &aMessage, uint8_t aType, uint16_t &aOffset)
+otError Tlv::GetOffset(const Message &aMessage, uint8_t aType, uint16_t &aOffset)
 {
-    ThreadError error = kThreadError_NotFound;
+    otError error = OT_ERROR_NOT_FOUND;
     uint16_t offset = aMessage.GetOffset();
     uint16_t end = aMessage.GetLength();
     Tlv tlv;
@@ -86,7 +86,7 @@ ThreadError Tlv::GetOffset(const Message &aMessage, uint8_t aType, uint16_t &aOf
         else if (tlv.GetType() == aType && (offset + sizeof(tlv) + tlv.GetLength()) <= end)
         {
             aOffset = offset;
-            ExitNow(error = kThreadError_None);
+            ExitNow(error = OT_ERROR_NONE);
         }
         else
         {
@@ -98,9 +98,9 @@ exit:
     return error;
 }
 
-ThreadError Tlv::GetValueOffset(const Message &aMessage, uint8_t aType, uint16_t &aOffset, uint16_t &aLength)
+otError Tlv::GetValueOffset(const Message &aMessage, uint8_t aType, uint16_t &aOffset, uint16_t &aLength)
 {
-    ThreadError error = kThreadError_NotFound;
+    otError error = OT_ERROR_NOT_FOUND;
     uint16_t offset = aMessage.GetOffset();
     uint16_t end = aMessage.GetLength();
 
@@ -125,7 +125,7 @@ ThreadError Tlv::GetValueOffset(const Message &aMessage, uint8_t aType, uint16_t
         {
             aOffset = offset;
             aLength = length;
-            ExitNow(error = kThreadError_None);
+            ExitNow(error = OT_ERROR_NONE);
         }
 
         offset += length;

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -146,11 +146,11 @@ public:
      * @param[in]   aMaxLength  Maximum number of bytes to read.
      * @param[out]  aTlv        A reference to the TLV that will be copied to.
      *
-     * @retval kThreadError_None      Successfully copied the TLV.
-     * @retval kThreadError_NotFound  Could not find the TLV with Type @p aType.
+     * @retval OT_ERROR_NONE       Successfully copied the TLV.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the TLV with Type @p aType.
      *
      */
-    static ThreadError Get(const Message &aMessage, uint8_t aType, uint16_t aMaxLength, Tlv &aTlv);
+    static otError Get(const Message &aMessage, uint8_t aType, uint16_t aMaxLength, Tlv &aTlv);
 
     /**
      * This static method obtains the offset of a TLV within @p aMessage.
@@ -159,11 +159,11 @@ public:
      * @param[in]   aType       The Type value to search for.
      * @param[out]  aOffset     A reference to the offset of the TLV.
      *
-     * @retval kThreadError_None      Successfully copied the TLV.
-     * @retval kThreadError_NotFound  Could not find the TLV with Type @p aType.
+     * @retval OT_ERROR_NONE       Successfully copied the TLV.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the TLV with Type @p aType.
      *
      */
-    static ThreadError GetOffset(const Message &aMessage, uint8_t aType, uint16_t &aOffset);
+    static otError GetOffset(const Message &aMessage, uint8_t aType, uint16_t &aOffset);
 
     /**
      * This static method finds the offset and length of a given TLV type.
@@ -173,11 +173,11 @@ public:
      * @param[out]  aOffset     The offset where the value starts.
      * @param[out]  aLength     The length of the value.
      *
-     * @retval kThreadError_None      Successfully found the TLV.
-     * @retval kThreadError_NotFound  Could not find the TLV with Type @p aType.
+     * @retval OT_ERROR_NONE       Successfully found the TLV.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the TLV with Type @p aType.
      *
      */
-    static ThreadError GetValueOffset(const Message &aMesasge, uint8_t aType, uint16_t &aOffset, uint16_t &aLength);
+    static otError GetValueOffset(const Message &aMesasge, uint8_t aType, uint16_t &aOffset, uint16_t &aLength);
 
 protected:
     /**

--- a/src/core/crypto/aes_ccm.cpp
+++ b/src/core/crypto/aes_ccm.cpp
@@ -45,10 +45,10 @@
 namespace ot {
 namespace Crypto {
 
-ThreadError AesCcm::SetKey(const uint8_t *aKey, uint16_t aKeyLength)
+otError AesCcm::SetKey(const uint8_t *aKey, uint16_t aKeyLength)
 {
     mEcb.SetKey(aKey, 8 * aKeyLength);
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 void AesCcm::Init(uint32_t aHeaderLength, uint32_t aPlainTextLength, uint8_t aTagLength,

--- a/src/core/crypto/aes_ccm.hpp
+++ b/src/core/crypto/aes_ccm.hpp
@@ -64,7 +64,7 @@ public:
      * @param[in]  aKeyLength  Length of the key in bytes.
      *
      */
-    ThreadError SetKey(const uint8_t *aKey, uint16_t aKeyLength);
+    otError SetKey(const uint8_t *aKey, uint16_t aKeyLength);
 
     /**
      * This method initializes the AES CCM computation.

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -173,9 +173,9 @@ otInstance *Mac::GetInstance(void)
     return mNetif.GetInstance();
 }
 
-ThreadError Mac::ActiveScan(uint32_t aScanChannels, uint16_t aScanDuration, ActiveScanHandler aHandler, void *aContext)
+otError Mac::ActiveScan(uint32_t aScanChannels, uint16_t aScanDuration, ActiveScanHandler aHandler, void *aContext)
 {
-    ThreadError error;
+    otError error;
 
     SuccessOrExit(error = Scan(kScanTypeActive, aScanChannels, aScanDuration, aContext));
     mActiveScanHandler = aHandler;
@@ -184,9 +184,9 @@ exit:
     return error;
 }
 
-ThreadError Mac::EnergyScan(uint32_t aScanChannels, uint16_t aScanDuration, EnergyScanHandler aHandler, void *aContext)
+otError Mac::EnergyScan(uint32_t aScanChannels, uint16_t aScanDuration, EnergyScanHandler aHandler, void *aContext)
 {
-    ThreadError error;
+    otError error;
 
     SuccessOrExit(error = Scan(kScanTypeEnergy, aScanChannels, aScanDuration, aContext));
     mEnergyScanHandler = aHandler;
@@ -195,12 +195,12 @@ exit:
     return error;
 }
 
-ThreadError Mac::Scan(ScanType aScanType, uint32_t aScanChannels, uint16_t aScanDuration, void *aContext)
+otError Mac::Scan(ScanType aScanType, uint32_t aScanChannels, uint16_t aScanDuration, void *aContext)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     VerifyOrExit((mState != kStateActiveScan) && (mState != kStateEnergyScan) && (mPendingScanRequest == kScanTypeNone),
-                 error = kThreadError_Busy);
+                 error = OT_ERROR_BUSY);
 
     mScanContext = aContext;
     mScanChannels = (aScanChannels == 0) ? static_cast<uint32_t>(kScanChannelsAll) : aScanChannels;
@@ -251,9 +251,9 @@ bool Mac::IsInTransmitState(void)
     return (mState == kStateTransmitData) || (mState == kStateTransmitBeacon);
 }
 
-ThreadError Mac::ConvertBeaconToActiveScanResult(Frame *aBeaconFrame, otActiveScanResult &aResult)
+otError Mac::ConvertBeaconToActiveScanResult(Frame *aBeaconFrame, otActiveScanResult &aResult)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Address address;
     Beacon *beacon = NULL;
     BeaconPayload *beaconPayload = NULL;
@@ -262,11 +262,11 @@ ThreadError Mac::ConvertBeaconToActiveScanResult(Frame *aBeaconFrame, otActiveSc
 
     memset(&aResult, 0, sizeof(otActiveScanResult));
 
-    VerifyOrExit(aBeaconFrame != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aBeaconFrame != NULL, error = OT_ERROR_INVALID_ARGS);
 
-    VerifyOrExit(aBeaconFrame->GetType() == Frame::kFcfFrameBeacon, error = kThreadError_Parse);
+    VerifyOrExit(aBeaconFrame->GetType() == Frame::kFcfFrameBeacon, error = OT_ERROR_PARSE);
     SuccessOrExit(error = aBeaconFrame->GetSrcAddr(address));
-    VerifyOrExit(address.mLength == sizeof(address.mExtAddress), error = kThreadError_Parse);
+    VerifyOrExit(address.mLength == sizeof(address.mExtAddress), error = OT_ERROR_PARSE);
     memcpy(&aResult.mExtAddress, &address.mExtAddress, sizeof(aResult.mExtAddress));
 
     aBeaconFrame->GetSrcPanId(aResult.mPanId);
@@ -309,9 +309,9 @@ void Mac::StartEnergyScan(void)
     }
     else
     {
-        ThreadError error = otPlatRadioEnergyScan(GetInstance(), mScanChannel, mScanDuration);
+        otError error = otPlatRadioEnergyScan(GetInstance(), mScanChannel, mScanDuration);
 
-        if (error != kThreadError_None)
+        if (error != OT_ERROR_NONE)
         {
             // Cancel scan
             mEnergyScanHandler(mScanContext, NULL);
@@ -399,7 +399,7 @@ exit:
     return;
 }
 
-ThreadError Mac::RegisterReceiver(Receiver &aReceiver)
+otError Mac::RegisterReceiver(Receiver &aReceiver)
 {
     assert(mReceiveTail != &aReceiver && aReceiver.mNext == NULL);
 
@@ -414,7 +414,7 @@ ThreadError Mac::RegisterReceiver(Receiver &aReceiver)
         mReceiveTail = &aReceiver;
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 void Mac::SetRxOnWhenIdle(bool aRxOnWhenIdle)
@@ -473,16 +473,16 @@ void Mac::GetHashMacAddress(ExtAddress *aHashMacAddress)
     otLogFuncExitMsg("%llX", HostSwap64(*reinterpret_cast<uint64_t *>(aHashMacAddress)));
 }
 
-ThreadError Mac::SetShortAddress(ShortAddress aShortAddress)
+otError Mac::SetShortAddress(ShortAddress aShortAddress)
 {
     otLogFuncEntryMsg("%d", aShortAddress);
     mShortAddress = aShortAddress;
     otPlatRadioSetShortAddress(GetInstance(), aShortAddress);
     otLogFuncExit();
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Mac::SetChannel(uint8_t aChannel)
+otError Mac::SetChannel(uint8_t aChannel)
 {
     otLogFuncEntryMsg("%d", aChannel);
     mChannel = aChannel;
@@ -493,16 +493,16 @@ ThreadError Mac::SetChannel(uint8_t aChannel)
     }
 
     otLogFuncExit();
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Mac::SetNetworkName(const char *aNetworkName)
+otError Mac::SetNetworkName(const char *aNetworkName)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     otLogFuncEntryMsg("%s", aNetworkName);
 
-    VerifyOrExit(strlen(aNetworkName) <= OT_NETWORK_NAME_MAX_SIZE, error = kThreadError_InvalidArgs);
+    VerifyOrExit(strlen(aNetworkName) <= OT_NETWORK_NAME_MAX_SIZE, error = OT_ERROR_INVALID_ARGS);
 
     (void)strlcpy(mNetworkName.m8, aNetworkName, sizeof(mNetworkName));
 
@@ -511,26 +511,26 @@ exit:
     return error;
 }
 
-ThreadError Mac::SetPanId(PanId aPanId)
+otError Mac::SetPanId(PanId aPanId)
 {
     otLogFuncEntryMsg("%d", aPanId);
     mPanId = aPanId;
     otPlatRadioSetPanId(GetInstance(), mPanId);
     otLogFuncExit();
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Mac::SetExtendedPanId(const uint8_t *aExtPanId)
+otError Mac::SetExtendedPanId(const uint8_t *aExtPanId)
 {
     memcpy(mExtendedPanId.m8, aExtPanId, sizeof(mExtendedPanId));
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Mac::SendFrameRequest(Sender &aSender)
+otError Mac::SendFrameRequest(Sender &aSender)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mSendTail != &aSender && aSender.mNext == NULL, error = kThreadError_Already);
+    VerifyOrExit(mSendTail != &aSender && aSender.mNext == NULL, error = OT_ERROR_ALREADY);
 
     if (mSendHead == NULL)
     {
@@ -786,7 +786,7 @@ void Mac::HandleBeginTransmit(void *aContext)
 void Mac::HandleBeginTransmit(void)
 {
     Frame &sendFrame(*mTxFrame);
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (mCsmaAttempts == 0 && mTransmitAttempts == 0)
     {
@@ -836,9 +836,9 @@ void Mac::HandleBeginTransmit(void)
     }
 
     error = otPlatRadioReceive(GetInstance(), sendFrame.GetChannel());
-    assert(error == kThreadError_None);
+    assert(error == OT_ERROR_NONE);
     error = otPlatRadioTransmit(GetInstance(), static_cast<RadioPacket *>(&sendFrame));
-    assert(error == kThreadError_None);
+    assert(error == OT_ERROR_NONE);
 
     if (sendFrame.GetAckRequest() && !(otPlatRadioGetCaps(GetInstance()) & kRadioCapsAckTimeout))
     {
@@ -854,14 +854,14 @@ void Mac::HandleBeginTransmit(void)
 
 exit:
 
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
-        TransmitDoneTask(mTxFrame, false, kThreadError_Abort);
+        TransmitDoneTask(mTxFrame, false, OT_ERROR_ABORT);
     }
 }
 
 extern "C" void otPlatRadioTransmitDone(otInstance *aInstance, RadioPacket *aPacket, bool aRxPending,
-                                        ThreadError aError)
+                                        otError aError)
 {
     otLogFuncEntryMsg("%!otError!, aRxPending=%u", aError, aRxPending ? 1 : 0);
 
@@ -880,7 +880,7 @@ extern "C" void otPlatRadioTransmitDone(otInstance *aInstance, RadioPacket *aPac
     otLogFuncExit();
 }
 
-void Mac::TransmitDoneTask(RadioPacket *aPacket, bool aRxPending, ThreadError aError)
+void Mac::TransmitDoneTask(RadioPacket *aPacket, bool aRxPending, otError aError)
 {
     mMacTimer.Stop();
 
@@ -901,18 +901,18 @@ void Mac::TransmitDoneTask(RadioPacket *aPacket, bool aRxPending, ThreadError aE
         mCounters.mTxUnicast++;
     }
 
-    if (aError == kThreadError_Abort)
+    if (aError == OT_ERROR_ABORT)
     {
         mCounters.mTxErrAbort++;
     }
 
-    if (aError == kThreadError_ChannelAccessFailure)
+    if (aError == OT_ERROR_CHANNEL_ACCESS_FAILURE)
     {
         mCounters.mTxErrCca++;
     }
 
     if (!RadioSupportsCsmaBackoff() &&
-        aError == kThreadError_ChannelAccessFailure &&
+        aError == OT_ERROR_CHANNEL_ACCESS_FAILURE &&
         mCsmaAttempts < kMaxCSMABackoffs)
     {
         mCsmaAttempts++;
@@ -1000,7 +1000,7 @@ void Mac::HandleMacTimer(void)
             mCounters.mTxUnicast++;
         }
 
-        SentFrame(kThreadError_NoAck);
+        SentFrame(OT_ERROR_NO_ACK);
         break;
 
     default:
@@ -1032,7 +1032,7 @@ void Mac::HandleReceiveTimer(void)
     }
 }
 
-void Mac::SentFrame(ThreadError aError)
+void Mac::SentFrame(otError aError)
 {
     Frame &sendFrame(*mTxFrame);
     Sender *sender;
@@ -1041,12 +1041,12 @@ void Mac::SentFrame(ThreadError aError)
 
     switch (aError)
     {
-    case kThreadError_None:
+    case OT_ERROR_NONE:
         break;
 
-    case kThreadError_ChannelAccessFailure:
-    case kThreadError_Abort:
-    case kThreadError_NoAck:
+    case OT_ERROR_CHANNEL_ACCESS_FAILURE:
+    case OT_ERROR_ABORT:
+    case OT_ERROR_NO_ACK:
     {
         char stringBuffer[Frame::kInfoStringSize];
 
@@ -1079,7 +1079,7 @@ void Mac::SentFrame(ThreadError aError)
     {
         mCounters.mTxAckRequested++;
 
-        if (aError == kThreadError_None)
+        if (aError == OT_ERROR_NONE)
         {
             mCounters.mTxAcked++;
         }
@@ -1141,9 +1141,9 @@ exit:
     return;
 }
 
-ThreadError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, Neighbor *aNeighbor)
+otError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, Neighbor *aNeighbor)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t securityLevel;
     uint8_t keyIdMode;
     uint32_t frameCounter;
@@ -1172,12 +1172,12 @@ ThreadError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, 
     switch (keyIdMode)
     {
     case Frame::kKeyIdMode0:
-        VerifyOrExit((macKey = mNetif.GetKeyManager().GetKek()) != NULL, error = kThreadError_Security);
+        VerifyOrExit((macKey = mNetif.GetKeyManager().GetKek()) != NULL, error = OT_ERROR_SECURITY);
         extAddress = &aSrcAddr.mExtAddress;
         break;
 
     case Frame::kKeyIdMode1:
-        VerifyOrExit(aNeighbor != NULL, error = kThreadError_Security);
+        VerifyOrExit(aNeighbor != NULL, error = OT_ERROR_SECURITY);
 
         aFrame.GetKeyId(keyid);
         keyid--;
@@ -1202,7 +1202,7 @@ ThreadError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, 
         }
         else
         {
-            ExitNow(error = kThreadError_Security);
+            ExitNow(error = OT_ERROR_SECURITY);
         }
 
         // If the frame is from a neighbor not in valid state (e.g., it is from a child being
@@ -1214,18 +1214,18 @@ ThreadError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, 
         {
             if (keySequence < aNeighbor->GetKeySequence())
             {
-                ExitNow(error = kThreadError_Security);
+                ExitNow(error = OT_ERROR_SECURITY);
             }
             else if (keySequence == aNeighbor->GetKeySequence())
             {
                 if ((frameCounter + 1) < aNeighbor->GetLinkFrameCounter())
                 {
-                    ExitNow(error = kThreadError_Security);
+                    ExitNow(error = OT_ERROR_SECURITY);
                 }
                 else if ((frameCounter + 1) == aNeighbor->GetLinkFrameCounter())
                 {
                     // drop duplicated packets
-                    ExitNow(error = kThreadError_Duplicated);
+                    ExitNow(error = OT_ERROR_DUPLICATED);
                 }
             }
         }
@@ -1240,7 +1240,7 @@ ThreadError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, 
         break;
 
     default:
-        ExitNow(error = kThreadError_Security);
+        ExitNow(error = OT_ERROR_SECURITY);
         break;
     }
 
@@ -1253,7 +1253,7 @@ ThreadError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, 
     aesCcm.Payload(aFrame.GetPayload(), aFrame.GetPayload(), aFrame.GetPayloadLength(), false);
     aesCcm.Finalize(tag, &tagLength);
 
-    VerifyOrExit(memcmp(tag, aFrame.GetFooter(), tagLength) == 0, error = kThreadError_Security);
+    VerifyOrExit(memcmp(tag, aFrame.GetFooter(), tagLength) == 0, error = OT_ERROR_SECURITY);
 
     if ((keyIdMode == Frame::kKeyIdMode1) && (aNeighbor->GetState() == Neighbor::kStateValid))
     {
@@ -1277,7 +1277,7 @@ exit:
     return error;
 }
 
-extern "C" void otPlatRadioReceiveDone(otInstance *aInstance, RadioPacket *aFrame, ThreadError aError)
+extern "C" void otPlatRadioReceiveDone(otInstance *aInstance, RadioPacket *aFrame, otError aError)
 {
     otLogFuncEntryMsg("%!otError!", aError);
 
@@ -1296,7 +1296,7 @@ extern "C" void otPlatRadioReceiveDone(otInstance *aInstance, RadioPacket *aFram
     otLogFuncExit();
 }
 
-void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
+void Mac::ReceiveDoneTask(Frame *aFrame, otError aError)
 {
     Address srcaddr;
     Address dstaddr;
@@ -1307,12 +1307,12 @@ void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
     int8_t rssi;
     bool receive = false;
     uint8_t commandId;
-    ThreadError error = aError;
+    otError error = aError;
 
     mCounters.mRxTotal++;
 
-    VerifyOrExit(error == kThreadError_None);
-    VerifyOrExit(aFrame != NULL, error = kThreadError_NoFrameReceived);
+    VerifyOrExit(error == OT_ERROR_NONE);
+    VerifyOrExit(aFrame != NULL, error = OT_ERROR_NO_FRAME_RECEIVED);
 
     aFrame->SetSecurityValid(false);
 
@@ -1339,7 +1339,7 @@ void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
 
         if (neighbor == NULL)
         {
-            ExitNow(error = kThreadError_UnknownNeighbor);
+            ExitNow(error = OT_ERROR_UNKNOWN_NEIGHBOR);
         }
 
         srcaddr.mLength = sizeof(srcaddr.mExtAddress);
@@ -1350,21 +1350,21 @@ void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
         break;
 
     default:
-        ExitNow(error = kThreadError_InvalidSourceAddress);
+        ExitNow(error = OT_ERROR_INVALID_SOURCE_ADDRESS);
     }
 
     // Duplicate Address Protection
     if (memcmp(&srcaddr.mExtAddress, &mExtAddress, sizeof(srcaddr.mExtAddress)) == 0)
     {
-        ExitNow(error = kThreadError_InvalidSourceAddress);
+        ExitNow(error = OT_ERROR_INVALID_SOURCE_ADDRESS);
     }
 
     // Source Whitelist Processing
     if (srcaddr.mLength != 0 && mWhitelist.IsEnabled())
     {
-        VerifyOrExit((whitelistEntry = mWhitelist.Find(srcaddr.mExtAddress)) != NULL, error = kThreadError_WhitelistFiltered);
+        VerifyOrExit((whitelistEntry = mWhitelist.Find(srcaddr.mExtAddress)) != NULL, error = OT_ERROR_WHITELIST_FILTERED);
 
-        if (mWhitelist.GetFixedRssi(*whitelistEntry, rssi) == kThreadError_None)
+        if (mWhitelist.GetFixedRssi(*whitelistEntry, rssi) == OT_ERROR_NONE)
         {
             aFrame->mPower = rssi;
         }
@@ -1373,7 +1373,7 @@ void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
     // Source Blacklist Processing
     if (srcaddr.mLength != 0 && mBlacklist.IsEnabled())
     {
-        VerifyOrExit((blacklistEntry = mBlacklist.Find(srcaddr.mExtAddress)) == NULL, error = kThreadError_BlacklistFiltered);
+        VerifyOrExit((blacklistEntry = mBlacklist.Find(srcaddr.mExtAddress)) == NULL, error = OT_ERROR_BLACKLIST_FILTERED);
     }
 
     // Destination Address Filtering
@@ -1388,14 +1388,14 @@ void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
         aFrame->GetDstPanId(panid);
         VerifyOrExit((panid == kShortAddrBroadcast || panid == mPanId) &&
                      ((mRxOnWhenIdle && dstaddr.mShortAddress == kShortAddrBroadcast) ||
-                      dstaddr.mShortAddress == mShortAddress), error = kThreadError_DestinationAddressFiltered);
+                      dstaddr.mShortAddress == mShortAddress), error = OT_ERROR_DESTINATION_ADDRESS_FILTERED);
         break;
 
     case sizeof(ExtAddress):
         aFrame->GetDstPanId(panid);
         VerifyOrExit(panid == mPanId &&
                      memcmp(&dstaddr.mExtAddress, &mExtAddress, sizeof(dstaddr.mExtAddress)) == 0,
-                     error = kThreadError_DestinationAddressFiltered);
+                     error = OT_ERROR_DESTINATION_ADDRESS_FILTERED);
         break;
     }
 
@@ -1429,14 +1429,14 @@ void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
             case Neighbor::kStateChildUpdateRequest:
 
                 // Only accept a "MAC Data Request" frame from a child being restored.
-                VerifyOrExit(aFrame->GetType() == Frame::kFcfFrameMacCmd, error = kThreadError_Drop);
-                VerifyOrExit(aFrame->GetCommandId(commandId) == kThreadError_None, error = kThreadError_Drop);
-                VerifyOrExit(commandId == Frame::kMacCmdDataRequest, error = kThreadError_Drop);
+                VerifyOrExit(aFrame->GetType() == Frame::kFcfFrameMacCmd, error = OT_ERROR_DROP);
+                VerifyOrExit(aFrame->GetCommandId(commandId) == OT_ERROR_NONE, error = OT_ERROR_DROP);
+                VerifyOrExit(commandId == Frame::kMacCmdDataRequest, error = OT_ERROR_DROP);
 
                 break;
 
             default:
-                ExitNow(error = kThreadError_UnknownNeighbor);
+                ExitNow(error = OT_ERROR_UNKNOWN_NEIGHBOR);
             }
         }
     }
@@ -1466,9 +1466,9 @@ void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
         switch (aFrame->GetType())
         {
         case Frame::kFcfFrameMacCmd:
-            if (HandleMacCommand(*aFrame) == kThreadError_Drop)
+            if (HandleMacCommand(*aFrame) == OT_ERROR_DROP)
             {
-                ExitNow(error = kThreadError_None);
+                ExitNow(error = OT_ERROR_NONE);
             }
 
             receive = true;
@@ -1504,7 +1504,7 @@ void Mac::ReceiveDoneTask(Frame *aFrame, ThreadError aError)
 
 exit:
 
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         if (aFrame == NULL)
         {
@@ -1522,35 +1522,35 @@ exit:
 
         switch (error)
         {
-        case kThreadError_Security:
+        case OT_ERROR_SECURITY:
             mCounters.mRxErrSec++;
             break;
 
-        case kThreadError_FcsErr:
+        case OT_ERROR_FCS:
             mCounters.mRxErrFcs++;
             break;
 
-        case kThreadError_NoFrameReceived:
+        case OT_ERROR_NO_FRAME_RECEIVED:
             mCounters.mRxErrNoFrame++;
             break;
 
-        case kThreadError_UnknownNeighbor:
+        case OT_ERROR_UNKNOWN_NEIGHBOR:
             mCounters.mRxErrUnknownNeighbor++;
             break;
 
-        case kThreadError_InvalidSourceAddress:
+        case OT_ERROR_INVALID_SOURCE_ADDRESS:
             mCounters.mRxErrInvalidSrcAddr++;
             break;
 
-        case kThreadError_WhitelistFiltered:
+        case OT_ERROR_WHITELIST_FILTERED:
             mCounters.mRxWhitelistFiltered++;
             break;
 
-        case kThreadError_DestinationAddressFiltered:
+        case OT_ERROR_DESTINATION_ADDRESS_FILTERED:
             mCounters.mRxDestAddrFiltered++;
             break;
 
-        case kThreadError_Duplicated:
+        case OT_ERROR_DUPLICATED:
             mCounters.mRxDuplicated++;
             break;
 
@@ -1561,9 +1561,9 @@ exit:
     }
 }
 
-ThreadError Mac::HandleMacCommand(Frame &aFrame)
+otError Mac::HandleMacCommand(Frame &aFrame)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t commandId;
 
     aFrame.GetCommandId(commandId);
@@ -1586,7 +1586,7 @@ ThreadError Mac::HandleMacCommand(Frame &aFrame)
             }
         }
 
-        ExitNow(error = kThreadError_Drop);
+        ExitNow(error = OT_ERROR_DROP);
 
     case Frame::kMacCmdDataRequest:
         mCounters.mRxDataPoll++;

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -168,7 +168,7 @@ public:
      * @param[in]  aFrame    A reference to the MAC frame buffer.
      *
      */
-    typedef ThreadError(*FrameRequestHandler)(void *aContext, Frame &aFrame);
+    typedef otError(*FrameRequestHandler)(void *aContext, Frame &aFrame);
 
     /**
      * This function pointer is called when the MAC is done sending the frame.
@@ -178,7 +178,7 @@ public:
      * @param[in]  aError    The status of the last MSDU transmission.
      *
      */
-    typedef void (*SentFrameHandler)(void *aContext, Frame &aFrame, ThreadError aError);
+    typedef void (*SentFrameHandler)(void *aContext, Frame &aFrame, otError aError);
 
     /**
      * This constructor creates a MAC sender client.
@@ -196,8 +196,8 @@ public:
     }
 
 private:
-    ThreadError HandleFrameRequest(Frame &frame) { return mFrameRequestHandler(mContext, frame); }
-    void HandleSentFrame(Frame &frame, ThreadError error) { mSentFrameHandler(mContext, frame, error); }
+    otError HandleFrameRequest(Frame &frame) { return mFrameRequestHandler(mContext, frame); }
+    void HandleSentFrame(Frame &frame, otError error) { mSentFrameHandler(mContext, frame, error); }
 
     FrameRequestHandler mFrameRequestHandler;
     SentFrameHandler mSentFrameHandler;
@@ -246,7 +246,7 @@ public:
      * @param[in]  aContext       A pointer to arbitrary context information.
      *
      */
-    ThreadError ActiveScan(uint32_t aScanChannels, uint16_t aScanDuration, ActiveScanHandler aHandler, void *aContext);
+    otError ActiveScan(uint32_t aScanChannels, uint16_t aScanDuration, ActiveScanHandler aHandler, void *aContext);
 
     /**
      * This method converts a beacon frame to an active scan result of type `otActiveScanResult`.
@@ -254,12 +254,12 @@ public:
      * @param[in]  aBeaconFrame             A pointer to a beacon frame.
      * @param[out] aResult                  A reference to `otActiveScanResult` where the result is stored.
      *
-     * @retval kThreadError_None            Successfully converted the beacon into active scan result.
-     * @retavl kThreadError_InvalidArgs     The @a aBeaconFrame was NULL.
-     * @retval kThreadError_Parse           Failed parsing the beacon frame.
+     * @retval OT_ERROR_NONE            Successfully converted the beacon into active scan result.
+     * @retavl OT_ERROR_INVALID_ARGS    The @a aBeaconFrame was NULL.
+     * @retval OT_ERROR_PARSE           Failed parsing the beacon frame.
      *
      */
-    ThreadError ConvertBeaconToActiveScanResult(Frame *aBeaconFrame, otActiveScanResult &aResult);
+    otError ConvertBeaconToActiveScanResult(Frame *aBeaconFrame, otActiveScanResult &aResult);
 
     /**
      * This function pointer is called during an "Energy Scan" when the result for a channel is ready or the scan
@@ -279,11 +279,11 @@ public:
      * @param[in]  aHandler          A pointer to a function called to pass on scan result or indicate scan completion.
      * @param[in]  aContext          A pointer to arbitrary context information.
      *
-     * @retval kThreadError_None  Accepted the Energy Scan request.
-     * @retval kThreadError_Busy  Could not start the energy scan.
+     * @retval OT_ERROR_NONE  Accepted the Energy Scan request.
+     * @retval OT_ERROR_BUSY  Could not start the energy scan.
      *
      */
-    ThreadError EnergyScan(uint32_t aScanChannels, uint16_t aScanDuration, EnergyScanHandler aHandler, void *aContext);
+    otError EnergyScan(uint32_t aScanChannels, uint16_t aScanDuration, EnergyScanHandler aHandler, void *aContext);
 
     /**
      * This method indicates the energy scan for the current channel is complete.
@@ -330,22 +330,22 @@ public:
      *
      * @param[in]  aReceiver  A reference to the MAC receiver client.
      *
-     * @retval kThreadError_None  Successfully registered the receiver.
-     * @retval kThreadError_Already  The receiver was already registered.
+     * @retval OT_ERROR_NONE     Successfully registered the receiver.
+     * @retval OT_ERROR_ALREADY  The receiver was already registered.
      *
      */
-    ThreadError RegisterReceiver(Receiver &aReceiver);
+    otError RegisterReceiver(Receiver &aReceiver);
 
     /**
      * This method registers a new MAC sender client.
      *
      * @param[in]  aSender  A reference to the MAC sender client.
      *
-     * @retval kThreadError_None  Successfully registered the sender.
-     * @retval kThreadError_Already  The sender was already registered.
+     * @retval OT_ERROR_NONE     Successfully registered the sender.
+     * @retval OT_ERROR_ALREADY  The sender was already registered.
      *
      */
-    ThreadError SendFrameRequest(Sender &aSender);
+    otError SendFrameRequest(Sender &aSender);
 
     /**
      * This method generates a random IEEE 802.15.4 Extended Address.
@@ -395,10 +395,10 @@ public:
      *
      * @param[in]  aShortAddress  The IEEE 802.15.4 Short Address.
      *
-     * @retval kThreadError_None  Successfully set the IEEE 802.15.4 Short Address.
+     * @retval OT_ERROR_NONE  Successfully set the IEEE 802.15.4 Short Address.
      *
      */
-    ThreadError SetShortAddress(ShortAddress aShortAddress);
+    otError SetShortAddress(ShortAddress aShortAddress);
 
     /**
      * This method returns the IEEE 802.15.4 Channel.
@@ -413,10 +413,10 @@ public:
      *
      * @param[in]  aChannel  The IEEE 802.15.4 Channel.
      *
-     * @retval kThreadError_None  Successfully set the IEEE 802.15.4 Channel.
+     * @retval OT_ERROR_NONE  Successfully set the IEEE 802.15.4 Channel.
      *
      */
-    ThreadError SetChannel(uint8_t aChannel);
+    otError SetChannel(uint8_t aChannel);
 
     /**
      * This method returns the maximum transmit power in dBm.
@@ -447,10 +447,10 @@ public:
      *
      * @param[in]  aNetworkName  A pointer to the IEEE 802.15.4 Network Name.
      *
-     * @retval kThreadError_None  Successfully set the IEEE 802.15.4 Network Name.
+     * @retval OT_ERROR_NONE  Successfully set the IEEE 802.15.4 Network Name.
      *
      */
-    ThreadError SetNetworkName(const char *aNetworkName);
+    otError SetNetworkName(const char *aNetworkName);
 
     /**
      * This method returns the IEEE 802.15.4 PAN ID.
@@ -465,10 +465,10 @@ public:
      *
      * @param[in]  aPanId  The IEEE 802.15.4 PAN ID.
      *
-     * @retval kThreadError_None  Successfully set the IEEE 802.15.4 PAN ID.
+     * @retval OT_ERROR_NONE  Successfully set the IEEE 802.15.4 PAN ID.
      *
      */
-    ThreadError SetPanId(uint16_t aPanId);
+    otError SetPanId(uint16_t aPanId);
 
     /**
      * This method returns the IEEE 802.15.4 Extended PAN ID.
@@ -483,10 +483,10 @@ public:
      *
      * @param[in]  aExtPanId  The IEEE 802.15.4 Extended PAN ID.
      *
-     * @retval kThreadError_None  Successfully set the IEEE 802.15.4 Extended PAN ID.
+     * @retval OT_ERROR_NONE  Successfully set the IEEE 802.15.4 Extended PAN ID.
      *
      */
-    ThreadError SetExtendedPanId(const uint8_t *aExtPanId);
+    otError SetExtendedPanId(const uint8_t *aExtPanId);
 
     /**
      * This method returns the MAC whitelist filter.
@@ -508,23 +508,23 @@ public:
      * This method is called to handle receive events.
      *
      * @param[in]  aFrame  A pointer to the received frame, or NULL if the receive operation aborted.
-     * @param[in]  aError  ::kThreadError_None when successfully received a frame, ::kThreadError_Abort when reception
+     * @param[in]  aError  OT_ERROR_NONE when successfully received a frame, OT_ERROR_ABORT when reception
      *                     was aborted and a frame was not received.
      *
      */
-    void ReceiveDoneTask(Frame *aFrame, ThreadError aError);
+    void ReceiveDoneTask(Frame *aFrame, otError aError);
 
     /**
      * This method is called to handle transmit events.
      *
      * @param[in]  aFramePending  TRUE if an ACK frame was received and the Frame Pending bit was set.
-     * @param[in]  aError  ::kThreadError_None when the frame was transmitted, ::kThreadError_NoAck when the frame was
-     *                     transmitted but no ACK was received, ::kThreadError_ChannelAccessFailure when the transmission
-     *                     could not take place due to activity on the channel, ::kThreadError_Abort when transmission
+     * @param[in]  aError  OT_ERROR_NONE when the frame was transmitted, OT_ERROR_NO_ACK when the frame was
+     *                     transmitted but no ACK was received, OT_ERROR_CHANNEL_ACCESS_FAILURE when the transmission
+     *                     could not take place due to activity on the channel, OT_ERROR_ABORT when transmission
      *                     was aborted for other reasons.
      *
      */
-    void TransmitDoneTask(RadioPacket *aPacket, bool aRxPending, ThreadError aError);
+    void TransmitDoneTask(RadioPacket *aPacket, bool aRxPending, otError aError);
 
     /**
      * This method returns if an active scan is in progress.
@@ -641,14 +641,14 @@ private:
     void GenerateNonce(const ExtAddress &aAddress, uint32_t aFrameCounter, uint8_t aSecurityLevel, uint8_t *aNonce);
     void NextOperation(void);
     void ProcessTransmitSecurity(Frame &aFrame);
-    ThreadError ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, Neighbor *aNeighbor);
+    otError ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, Neighbor *aNeighbor);
     void ScheduleNextTransmission(void);
-    void SentFrame(ThreadError aError);
+    void SentFrame(otError aError);
     void SendBeaconRequest(Frame &aFrame);
     void SendBeacon(Frame &aFrame);
     void StartBackoff(void);
     void StartEnergyScan(void);
-    ThreadError HandleMacCommand(Frame &aFrame);
+    otError HandleMacCommand(Frame &aFrame);
 
     static void HandleMacTimer(void *aContext);
     void HandleMacTimer(void);
@@ -660,7 +660,7 @@ private:
     void HandleEnergyScanSampleRssi(void);
 
     void StartCsmaBackoff(void);
-    ThreadError Scan(ScanType aType, uint32_t aScanChannels, uint16_t aScanDuration, void *aContext);
+    otError Scan(ScanType aType, uint32_t aScanChannels, uint16_t aScanDuration, void *aContext);
 
     Timer mMacTimer;
 #if !OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_BACKOFF_TIMER

--- a/src/core/mac/mac_blacklist.cpp
+++ b/src/core/mac/mac_blacklist.cpp
@@ -58,11 +58,11 @@ Blacklist::Blacklist(void)
     }
 }
 
-ThreadError Blacklist::GetEntry(uint8_t aIndex, Entry &aEntry) const
+otError Blacklist::GetEntry(uint8_t aIndex, Entry &aEntry) const
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aIndex < kMaxEntries, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aIndex < kMaxEntries, error = OT_ERROR_INVALID_ARGS);
 
     memcpy(&aEntry.mExtAddress, &mBlacklist[aIndex].mExtAddress, sizeof(aEntry.mExtAddress));
     aEntry.mValid = mBlacklist[aIndex].mValid;

--- a/src/core/mac/mac_blacklist_impl.hpp
+++ b/src/core/mac/mac_blacklist_impl.hpp
@@ -101,11 +101,11 @@ public:
      * @param[in]   aIndex  An index into the MAC blacklist table.
      * @param[out]  aEntry  A reference to where the information is placed.
      *
-     * @retval kThreadError_None         Successfully retrieved the MAC blacklist entry.
-     * @retval kThreadError_InvalidArgs  @p aIndex is out of bounds or @p aEntry is NULL.
+     * @retval OT_ERROR_NONE          Successfully retrieved the MAC blacklist entry.
+     * @retval OT_ERROR_INVALID_ARGS  @p aIndex is out of bounds or @p aEntry is NULL.
      *
      */
-    ThreadError GetEntry(uint8_t aIndex, Entry &aEntry) const;
+    otError GetEntry(uint8_t aIndex, Entry &aEntry) const;
 
     /**
      * This method adds an Extended Address to the blacklist filter.

--- a/src/core/mac/mac_blacklist_stub.hpp
+++ b/src/core/mac/mac_blacklist_stub.hpp
@@ -56,7 +56,7 @@ public:
 
     int GetMaxEntries(void) const { return 0; }
 
-    ThreadError GetEntry(uint8_t, Entry &) const { return kThreadError_NotImplemented; }
+    otError GetEntry(uint8_t, Entry &) const { return OT_ERROR_NOT_IMPLEMENTED; }
 
     Entry *Add(const ExtAddress &) { return NULL; }
 

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -77,7 +77,7 @@ const char *Address::ToString(char *aBuf, uint16_t aSize) const
     return aBuf;
 }
 
-ThreadError Frame::InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl)
+otError Frame::InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl)
 {
     uint8_t *bytes = GetPsdu();
     uint8_t length = 0;
@@ -174,12 +174,12 @@ ThreadError Frame::InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl)
 
     SetPsduLength(length + GetFooterLength());
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Frame::ValidatePsdu(void)
+otError Frame::ValidatePsdu(void)
 {
-    ThreadError error = kThreadError_Parse;
+    otError error = OT_ERROR_PARSE;
     uint8_t offset = 0;
     uint16_t fcf;
     uint8_t footerLength = kFcsSize;
@@ -291,7 +291,7 @@ ThreadError Frame::ValidatePsdu(void)
 
     VerifyOrExit((offset + footerLength) <= GetPsduLength());
 
-    error = kThreadError_None;
+    error = OT_ERROR_NONE;
 
 exit:
     return error;
@@ -379,12 +379,12 @@ exit:
     return cur;
 }
 
-ThreadError Frame::GetDstPanId(PanId &aPanId)
+otError Frame::GetDstPanId(PanId &aPanId)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t *buf;
 
-    VerifyOrExit((buf = FindDstPanId()) != NULL, error = kThreadError_Parse);
+    VerifyOrExit((buf = FindDstPanId()) != NULL, error = OT_ERROR_PARSE);
 
     aPanId = static_cast<uint16_t>((buf[1] << 8) | buf[0]);
 
@@ -392,7 +392,7 @@ exit:
     return error;
 }
 
-ThreadError Frame::SetDstPanId(PanId aPanId)
+otError Frame::SetDstPanId(PanId aPanId)
 {
     uint8_t *buf;
 
@@ -402,7 +402,7 @@ ThreadError Frame::SetDstPanId(PanId aPanId)
     buf[0] = aPanId & 0xff;
     buf[1] = aPanId >> 8;
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 uint8_t *Frame::FindDstAddr(void)
@@ -419,13 +419,13 @@ uint8_t *Frame::FindDstAddr(void)
     return cur;
 }
 
-ThreadError Frame::GetDstAddr(Address &aAddress)
+otError Frame::GetDstAddr(Address &aAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t *buf;
     uint16_t fcf = static_cast<uint16_t>((GetPsdu()[1] << 8) | GetPsdu()[0]);
 
-    VerifyOrExit(buf = FindDstAddr(), error = kThreadError_Parse);
+    VerifyOrExit(buf = FindDstAddr(), error = OT_ERROR_PARSE);
 
     switch (fcf & Frame::kFcfDstAddrMask)
     {
@@ -453,7 +453,7 @@ exit:
     return error;
 }
 
-ThreadError Frame::SetDstAddr(ShortAddress aShortAddress)
+otError Frame::SetDstAddr(ShortAddress aShortAddress)
 {
     uint8_t *buf;
     uint16_t fcf = static_cast<uint16_t>((GetPsdu()[1] << 8) | GetPsdu()[0]);
@@ -466,10 +466,10 @@ ThreadError Frame::SetDstAddr(ShortAddress aShortAddress)
     buf[0] = aShortAddress & 0xff;
     buf[1] = aShortAddress >> 8;
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Frame::SetDstAddr(const ExtAddress &aExtAddress)
+otError Frame::SetDstAddr(const ExtAddress &aExtAddress)
 {
     uint8_t *buf;
     uint16_t fcf = static_cast<uint16_t>((GetPsdu()[1] << 8) | GetPsdu()[0]);
@@ -484,7 +484,7 @@ ThreadError Frame::SetDstAddr(const ExtAddress &aExtAddress)
         buf[i] = aExtAddress.m8[sizeof(ExtAddress) - 1 - i];
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 uint8_t *Frame::FindSrcPanId(void)
@@ -519,12 +519,12 @@ exit:
     return cur;
 }
 
-ThreadError Frame::GetSrcPanId(PanId &aPanId)
+otError Frame::GetSrcPanId(PanId &aPanId)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t *buf;
 
-    VerifyOrExit((buf = FindSrcPanId()) != NULL, error = kThreadError_Parse);
+    VerifyOrExit((buf = FindSrcPanId()) != NULL, error = OT_ERROR_PARSE);
 
     aPanId = static_cast<uint16_t>((buf[1] << 8) | buf[0]);
 
@@ -532,12 +532,12 @@ exit:
     return error;
 }
 
-ThreadError Frame::SetSrcPanId(PanId aPanId)
+otError Frame::SetSrcPanId(PanId aPanId)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t *buf;
 
-    VerifyOrExit((buf = FindSrcPanId()) != NULL, error = kThreadError_Parse);
+    VerifyOrExit((buf = FindSrcPanId()) != NULL, error = OT_ERROR_PARSE);
 
     buf[0] = aPanId & 0xff;
     buf[1] = aPanId >> 8;
@@ -577,13 +577,13 @@ uint8_t *Frame::FindSrcAddr(void)
     return cur;
 }
 
-ThreadError Frame::GetSrcAddr(Address &address)
+otError Frame::GetSrcAddr(Address &address)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t *buf;
     uint16_t fcf = static_cast<uint16_t>((GetPsdu()[1] << 8) | GetPsdu()[0]);
 
-    VerifyOrExit((buf = FindSrcAddr()) != NULL, error = kThreadError_Parse);
+    VerifyOrExit((buf = FindSrcAddr()) != NULL, error = OT_ERROR_PARSE);
 
     switch (fcf & Frame::kFcfSrcAddrMask)
     {
@@ -611,7 +611,7 @@ exit:
     return error;
 }
 
-ThreadError Frame::SetSrcAddr(ShortAddress aShortAddress)
+otError Frame::SetSrcAddr(ShortAddress aShortAddress)
 {
     uint8_t *buf;
     uint16_t fcf = static_cast<uint16_t>((GetPsdu()[1] << 8) | GetPsdu()[0]);
@@ -624,10 +624,10 @@ ThreadError Frame::SetSrcAddr(ShortAddress aShortAddress)
     buf[0] = aShortAddress & 0xff;
     buf[1] = aShortAddress >> 8;
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Frame::SetSrcAddr(const ExtAddress &aExtAddress)
+otError Frame::SetSrcAddr(const ExtAddress &aExtAddress)
 {
     uint8_t *buf;
     uint16_t fcf = static_cast<uint16_t>((GetPsdu()[1] << 8) | GetPsdu()[0]);
@@ -642,7 +642,7 @@ ThreadError Frame::SetSrcAddr(const ExtAddress &aExtAddress)
         buf[i] = aExtAddress.m8[sizeof(aExtAddress) - 1 - i];
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 uint8_t *Frame::FindSecurityHeader(void)
@@ -695,12 +695,12 @@ exit:
     return cur;
 }
 
-ThreadError Frame::GetSecurityLevel(uint8_t &aSecurityLevel)
+otError Frame::GetSecurityLevel(uint8_t &aSecurityLevel)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t *buf;
 
-    VerifyOrExit((buf = FindSecurityHeader()) != NULL, error = kThreadError_Parse);
+    VerifyOrExit((buf = FindSecurityHeader()) != NULL, error = OT_ERROR_PARSE);
 
     aSecurityLevel = buf[0] & kSecLevelMask;
 
@@ -708,12 +708,12 @@ exit:
     return error;
 }
 
-ThreadError Frame::GetKeyIdMode(uint8_t &aKeyIdMode)
+otError Frame::GetKeyIdMode(uint8_t &aKeyIdMode)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t *buf;
 
-    VerifyOrExit((buf = FindSecurityHeader()) != NULL, error = kThreadError_Parse);
+    VerifyOrExit((buf = FindSecurityHeader()) != NULL, error = OT_ERROR_PARSE);
 
     aKeyIdMode = buf[0] & kKeyIdModeMask;
 
@@ -721,12 +721,12 @@ exit:
     return error;
 }
 
-ThreadError Frame::GetFrameCounter(uint32_t &aFrameCounter)
+otError Frame::GetFrameCounter(uint32_t &aFrameCounter)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t *buf;
 
-    VerifyOrExit((buf = FindSecurityHeader()) != NULL, error = kThreadError_Parse);
+    VerifyOrExit((buf = FindSecurityHeader()) != NULL, error = OT_ERROR_PARSE);
 
     // Security Control
     buf += kSecurityControlSize;
@@ -740,7 +740,7 @@ exit:
     return error;
 }
 
-ThreadError Frame::SetFrameCounter(uint32_t aFrameCounter)
+otError Frame::SetFrameCounter(uint32_t aFrameCounter)
 {
     uint8_t *buf;
 
@@ -755,7 +755,7 @@ ThreadError Frame::SetFrameCounter(uint32_t aFrameCounter)
     buf[2] = (aFrameCounter >> 16) & 0xff;
     buf[3] = (aFrameCounter >> 24) & 0xff;
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 const uint8_t *Frame::GetKeySource(void)
@@ -812,13 +812,13 @@ void Frame::SetKeySource(const uint8_t *aKeySource)
     memcpy(buf, aKeySource, keySourceLength);
 }
 
-ThreadError Frame::GetKeyId(uint8_t &aKeyId)
+otError Frame::GetKeyId(uint8_t &aKeyId)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t keySourceLength;
     uint8_t *buf;
 
-    VerifyOrExit((buf = FindSecurityHeader()) != NULL, error = kThreadError_Parse);
+    VerifyOrExit((buf = FindSecurityHeader()) != NULL, error = OT_ERROR_PARSE);
 
     keySourceLength = GetKeySourceLength(buf[0] & kKeyIdModeMask);
 
@@ -830,7 +830,7 @@ exit:
     return error;
 }
 
-ThreadError Frame::SetKeyId(uint8_t aKeyId)
+otError Frame::SetKeyId(uint8_t aKeyId)
 {
     uint8_t keySourceLength;
     uint8_t *buf;
@@ -844,27 +844,27 @@ ThreadError Frame::SetKeyId(uint8_t aKeyId)
 
     buf[0] = aKeyId;
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Frame::GetCommandId(uint8_t &aCommandId)
+otError Frame::GetCommandId(uint8_t &aCommandId)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t *buf;
 
-    VerifyOrExit((buf = GetPayload()) != NULL, error = kThreadError_Parse);
+    VerifyOrExit((buf = GetPayload()) != NULL, error = OT_ERROR_PARSE);
     aCommandId = buf[-1];
 
 exit:
     return error;
 }
 
-ThreadError Frame::SetCommandId(uint8_t aCommandId)
+otError Frame::SetCommandId(uint8_t aCommandId)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t *buf;
 
-    VerifyOrExit((buf = GetPayload()) != NULL, error = kThreadError_Parse);
+    VerifyOrExit((buf = GetPayload()) != NULL, error = OT_ERROR_PARSE);
     buf[-1] = aCommandId;
 
 exit:
@@ -923,10 +923,10 @@ uint8_t Frame::GetPayloadLength(void)
     return GetPsduLength() - (GetHeaderLength() + GetFooterLength());
 }
 
-ThreadError Frame::SetPayloadLength(uint8_t aLength)
+otError Frame::SetPayloadLength(uint8_t aLength)
 {
     SetPsduLength(GetHeaderLength() + GetFooterLength() + aLength);
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 uint8_t *Frame::GetHeader(void)
@@ -1059,7 +1059,7 @@ const char *Frame::ToInfoString(char *aBuf, uint16_t aSize)
         break;
 
     case kFcfFrameMacCmd:
-        if (GetCommandId(commandId) != kThreadError_None)
+        if (GetCommandId(commandId) != OT_ERROR_NONE)
         {
             commandId = 0xff;
         }
@@ -1088,12 +1088,12 @@ const char *Frame::ToInfoString(char *aBuf, uint16_t aSize)
         break;
     }
 
-    if (GetSrcAddr(src) != kThreadError_None)
+    if (GetSrcAddr(src) != OT_ERROR_NONE)
     {
         src.mLength = 0;
     }
 
-    if (GetDstAddr(dst) != kThreadError_None)
+    if (GetDstAddr(dst) != OT_ERROR_NONE)
     {
         dst.mLength = 0;
     }

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -263,20 +263,20 @@ public:
      * @param[in]  aFcf     The Frame Control field.
      * @param[in]  aSecCtl  The Security Control field.
      *
-     * @retval kThreadError_None         Successfully initialized the MAC header.
-     * @retval kThreadError_InvalidArgs  Invalid values for @p aFcf and/or @p aSecCtl.
+     * @retval OT_ERROR_NONE          Successfully initialized the MAC header.
+     * @retval OT_ERROR_INVALID_ARGS  Invalid values for @p aFcf and/or @p aSecCtl.
      *
      */
-    ThreadError InitMacHeader(uint16_t aFcf, uint8_t aSecCtl);
+    otError InitMacHeader(uint16_t aFcf, uint8_t aSecCtl);
 
     /**
      * This method validates the frame.
      *
-     * @retval kThreadError_None    Successfully parsed the MAC header.
-     * @retval kThreadError_Parse   Failed to parse through the MAC header.
+     * @retval OT_ERROR_NONE    Successfully parsed the MAC header.
+     * @retval OT_ERROR_PARSE   Failed to parse through the MAC header.
      *
      */
-    ThreadError ValidatePsdu(void);
+    otError ValidatePsdu(void);
 
     /**
      * This method returns the IEEE 802.15.4 Frame Type.
@@ -350,140 +350,140 @@ public:
      *
      * @param[out]  aPanId  The Destination PAN Identifier.
      *
-     * @retval kThreadError_None   Successfully retrieved the Destination PAN Identifier.
+     * @retval OT_ERROR_NONE   Successfully retrieved the Destination PAN Identifier.
      *
      */
-    ThreadError GetDstPanId(PanId &aPanId);
+    otError GetDstPanId(PanId &aPanId);
 
     /**
      * This method sets the Destination PAN Identifier.
      *
      * @param[in]  aPanId  The Destination PAN Identifier.
      *
-     * @retval kThreadError_None   Successfully set the Destination PAN Identifier.
+     * @retval OT_ERROR_NONE   Successfully set the Destination PAN Identifier.
      *
      */
-    ThreadError SetDstPanId(PanId aPanId);
+    otError SetDstPanId(PanId aPanId);
 
     /**
      * This method gets the Destination Address.
      *
      * @param[out]  aAddress  The Destination Address.
      *
-     * @retval kThreadError_None  Successfully retrieved the Destination Address.
+     * @retval OT_ERROR_NONE  Successfully retrieved the Destination Address.
      *
      */
-    ThreadError GetDstAddr(Address &aAddress);
+    otError GetDstAddr(Address &aAddress);
 
     /**
      * This method sets the Destination Address.
      *
      * @param[in]  aShortAddress  The Destination Address.
      *
-     * @retval kThreadError_None  Successfully set the Destination Address.
+     * @retval OT_ERROR_NONE  Successfully set the Destination Address.
      *
      */
-    ThreadError SetDstAddr(ShortAddress aShortAddress);
+    otError SetDstAddr(ShortAddress aShortAddress);
 
     /**
      * This method sets the Destination Address.
      *
      * @param[in]  aExtAddress  The Destination Address.
      *
-     * @retval kThreadError_None  Successfully set the Destination Address.
+     * @retval OT_ERROR_NONE  Successfully set the Destination Address.
      *
      */
-    ThreadError SetDstAddr(const ExtAddress &aExtAddress);
+    otError SetDstAddr(const ExtAddress &aExtAddress);
 
     /**
      * This method gets the Source PAN Identifier.
      *
      * @param[out]  aPanId  The Source PAN Identifier.
      *
-     * @retval kThreadError_None   Successfully retrieved the Source PAN Identifier.
+     * @retval OT_ERROR_NONE   Successfully retrieved the Source PAN Identifier.
      *
      */
-    ThreadError GetSrcPanId(PanId &aPanId);
+    otError GetSrcPanId(PanId &aPanId);
 
     /**
      * This method sets the Source PAN Identifier.
      *
      * @param[in]  aPanId  The Source PAN Identifier.
      *
-     * @retval kThreadError_None   Successfully set the Source PAN Identifier.
+     * @retval OT_ERROR_NONE   Successfully set the Source PAN Identifier.
      *
      */
-    ThreadError SetSrcPanId(PanId aPanId);
+    otError SetSrcPanId(PanId aPanId);
 
     /**
      * This method gets the Source Address.
      *
      * @param[out]  aAddress  The Source Address.
      *
-     * @retval kThreadError_None  Successfully retrieved the Source Address.
+     * @retval OT_ERROR_NONE  Successfully retrieved the Source Address.
      *
      */
-    ThreadError GetSrcAddr(Address &aAddress);
+    otError GetSrcAddr(Address &aAddress);
 
     /**
      * This method gets the Source Address.
      *
      * @param[in]  aShortAddress  The Source Address.
      *
-     * @retval kThreadError_None  Successfully set the Source Address.
+     * @retval OT_ERROR_NONE  Successfully set the Source Address.
      *
      */
-    ThreadError SetSrcAddr(ShortAddress aShortAddress);
+    otError SetSrcAddr(ShortAddress aShortAddress);
 
     /**
      * This method gets the Source Address.
      *
      * @param[in]  aExtAddress  The Source Address.
      *
-     * @retval kThreadError_None  Successfully set the Source Address.
+     * @retval OT_ERROR_NONE  Successfully set the Source Address.
      *
      */
-    ThreadError SetSrcAddr(const ExtAddress &aExtAddress);
+    otError SetSrcAddr(const ExtAddress &aExtAddress);
 
     /**
      * This method gets the Security Level Identifier.
      *
      * @param[out]  aSecurityLevel  The Security Level Identifier.
      *
-     * @retval kThreadError_None  Successfully retrieved the Security Level Identifier.
+     * @retval OT_ERROR_NONE  Successfully retrieved the Security Level Identifier.
      *
      */
-    ThreadError GetSecurityLevel(uint8_t &aSecurityLevel);
+    otError GetSecurityLevel(uint8_t &aSecurityLevel);
 
     /**
      * This method gets the Key Identifier Mode.
      *
      * @param[out]  aSecurityLevel  The Key Identifier Mode.
      *
-     * @retval kThreadError_None  Successfully retrieved the Key Identifier Mode.
+     * @retval OT_ERROR_NONE  Successfully retrieved the Key Identifier Mode.
      *
      */
-    ThreadError GetKeyIdMode(uint8_t &aKeyIdMode);
+    otError GetKeyIdMode(uint8_t &aKeyIdMode);
 
     /**
      * This method gets the Frame Counter.
      *
      * @param[out]  aFrameCounter  The Frame Counter.
      *
-     * @retval kThreadError_None  Successfully retrieved the Frame Counter.
+     * @retval OT_ERROR_NONE  Successfully retrieved the Frame Counter.
      *
      */
-    ThreadError GetFrameCounter(uint32_t &aFrameCounter);
+    otError GetFrameCounter(uint32_t &aFrameCounter);
 
     /**
      * This method sets the Frame Counter.
      *
      * @param[in]  aFrameCounter  The Frame Counter.
      *
-     * @retval kThreadError_None  Successfully set the Frame Counter.
+     * @retval OT_ERROR_NONE  Successfully set the Frame Counter.
      *
      */
-    ThreadError SetFrameCounter(uint32_t aFrameCounter);
+    otError SetFrameCounter(uint32_t aFrameCounter);
 
     /**
      * This method returns a pointer to the Key Source.
@@ -506,40 +506,40 @@ public:
      *
      * @param[out]  aKeyId  The Key Identifier.
      *
-     * @retval kThreadError_None  Successfully retrieved the Key Identifier.
+     * @retval OT_ERROR_NONE  Successfully retrieved the Key Identifier.
      *
      */
-    ThreadError GetKeyId(uint8_t &aKeyId);
+    otError GetKeyId(uint8_t &aKeyId);
 
     /**
      * This method sets the Key Identifier.
      *
      * @param[in]  aKeyId  The Key Identifier.
      *
-     * @retval kThreadError_None  Successfully set the Key Identifier.
+     * @retval OT_ERROR_NONE  Successfully set the Key Identifier.
      *
      */
-    ThreadError SetKeyId(uint8_t aKeyId);
+    otError SetKeyId(uint8_t aKeyId);
 
     /**
      * This method gets the Command ID.
      *
      * @param[out]  aCommandId  The Command ID.
      *
-     * @retval kThreadError_None  Successfully retrieved the Command ID.
+     * @retval OT_ERROR_NONE  Successfully retrieved the Command ID.
      *
      */
-    ThreadError GetCommandId(uint8_t &aCommandId);
+    otError GetCommandId(uint8_t &aCommandId);
 
     /**
      * This method sets the Command ID.
      *
      * @param[in]  aCommandId  The Command ID.
      *
-     * @retval kThreadError_None  Successfully set the Command ID.
+     * @retval OT_ERROR_NONE  Successfully set the Command ID.
      *
      */
-    ThreadError SetCommandId(uint8_t aCommandId);
+    otError SetCommandId(uint8_t aCommandId);
 
     /**
      * This method returns the MAC Frame Length.
@@ -554,11 +554,11 @@ public:
      *
      * @param[in]  aLength  The MAC Frame Length.
      *
-     * @retval kThreadError_None         Successfully set the MAC Frame Length.
-     * @retval kThreadError_InvalidArgs  The @p aLength value was invalid.
+     * @retval OT_ERROR_NONE          Successfully set the MAC Frame Length.
+     * @retval OT_ERROR_INVALID_ARGS  The @p aLength value was invalid.
      *
      */
-    ThreadError SetLength(uint8_t aLength) { SetPsduLength(aLength); return kThreadError_None; }
+    otError SetLength(uint8_t aLength) { SetPsduLength(aLength); return OT_ERROR_NONE; }
 
     /**
      * This method returns the MAC header size.
@@ -595,11 +595,11 @@ public:
     /**
      * This method sets the MAC Payload length.
      *
-     * @retval kThreadError_None         Successfully set the MAC Payload length.
-     * @retval kThreadError_InvalidArgs  The @p aLength value was invalid.
+     * @retval OT_ERROR_NONE          Successfully set the MAC Payload length.
+     * @retval OT_ERROR_INVALID_ARGS  The @p aLength value was invalid.
      *
      */
-    ThreadError SetPayloadLength(uint8_t aLength);
+    otError SetPayloadLength(uint8_t aLength);
 
     /**
      * This method returns the IEEE 802.15.4 channel used for transmission or reception.

--- a/src/core/mac/mac_whitelist.cpp
+++ b/src/core/mac/mac_whitelist.cpp
@@ -58,11 +58,11 @@ Whitelist::Whitelist(void)
     }
 }
 
-ThreadError Whitelist::GetEntry(uint8_t aIndex, Entry &aEntry) const
+otError Whitelist::GetEntry(uint8_t aIndex, Entry &aEntry) const
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aIndex < kMaxEntries, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aIndex < kMaxEntries, error = OT_ERROR_INVALID_ARGS);
 
     memcpy(&aEntry.mExtAddress, &mWhitelist[aIndex].mExtAddress, sizeof(aEntry.mExtAddress));
     aEntry.mRssi = mWhitelist[aIndex].mRssi;
@@ -141,11 +141,11 @@ void Whitelist::ClearFixedRssi(Entry &aEntry)
     aEntry.mFixedRssi = false;
 }
 
-ThreadError Whitelist::GetFixedRssi(Entry &aEntry, int8_t &rssi) const
+otError Whitelist::GetFixedRssi(Entry &aEntry, int8_t &rssi) const
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aEntry.mValid && aEntry.mFixedRssi, error = kThreadError_Error);
+    VerifyOrExit(aEntry.mValid && aEntry.mFixedRssi, error = OT_ERROR_INVALID_ARGS);
     rssi = aEntry.mRssi;
 
 exit:

--- a/src/core/mac/mac_whitelist_impl.hpp
+++ b/src/core/mac/mac_whitelist_impl.hpp
@@ -101,11 +101,11 @@ public:
      * @param[in]   aIndex  An index into the MAC whitelist table.
      * @param[out]  aEntry  A reference to where the information is placed.
      *
-     * @retval kThreadError_None         Successfully retrieved the MAC whitelist entry.
-     * @retval kThreadError_InvalidArgs  @p aIndex is out of bounds or @p aEntry is NULL.
+     * @retval OT_ERROR_NONE          Successfully retrieved the MAC whitelist entry.
+     * @retval OT_ERROR_INVALID_ARGS  @p aIndex is out of bounds or @p aEntry is NULL.
      *
      */
-    ThreadError GetEntry(uint8_t aIndex, Entry &aEntry) const;
+    otError GetEntry(uint8_t aIndex, Entry &aEntry) const;
 
     /**
      * This method adds an Extended Address to the whitelist filter.
@@ -155,11 +155,11 @@ public:
      * @param[in]   aEntry  A reference to the whitelist entry.
      * @param[out]  aRssi   A reference to the RSSI variable.
      *
-     * @retval kThreadError_None        A fixed RSSI is set and written to @p aRssi.
-     * @retval kThreadError_InvalidArg  A fixed RSSI was not set.
+     * @retval OT_ERROR_NONE          A fixed RSSI is set and written to @p aRssi.
+     * @retval OT_ERROR_INVALID_ARGS  A fixed RSSI was not set.
      *
      */
-    ThreadError GetFixedRssi(Entry &aEntry, int8_t &aRssi) const;
+    otError GetFixedRssi(Entry &aEntry, int8_t &aRssi) const;
 
     /**
      * This method sets a fixed RSSI value for all received messages matching @p aEntry.

--- a/src/core/mac/mac_whitelist_stub.hpp
+++ b/src/core/mac/mac_whitelist_stub.hpp
@@ -56,7 +56,7 @@ public:
 
     int GetMaxEntries(void) const { return 0; }
 
-    ThreadError GetEntry(uint8_t, Entry &) const { return kThreadError_NotImplemented; }
+    otError GetEntry(uint8_t, Entry &) const { return OT_ERROR_NOT_IMPLEMENTED; }
 
     Entry *Add(const ExtAddress &) { return NULL; }
 
@@ -68,7 +68,7 @@ public:
 
     void ClearFixedRssi(Entry &) { }
 
-    ThreadError GetFixedRssi(Entry &, int8_t &) const { return kThreadError_NotImplemented; }
+    otError GetFixedRssi(Entry &, int8_t &) const { return OT_ERROR_NOT_IMPLEMENTED; }
 
     void SetFixedRssi(Entry &, int8_t) { }
 };

--- a/src/core/meshcop/announce_begin_client.cpp
+++ b/src/core/meshcop/announce_begin_client.cpp
@@ -66,10 +66,10 @@ otInstance *AnnounceBeginClient::GetInstance(void)
     return mNetif.GetInstance();
 }
 
-ThreadError AnnounceBeginClient::SendRequest(uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod,
-                                             const Ip6::Address &aAddress)
+otError AnnounceBeginClient::SendRequest(uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod,
+                                         const Ip6::Address &aAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header header;
     MeshCoP::CommissionerSessionIdTlv sessionId;
     MeshCoP::ChannelMask0Tlv channelMask;
@@ -79,7 +79,7 @@ ThreadError AnnounceBeginClient::SendRequest(uint32_t aChannelMask, uint8_t aCou
     Ip6::MessageInfo messageInfo;
     Message *message = NULL;
 
-    VerifyOrExit(mNetif.GetCommissioner().GetState() == kCommissionerStateActive, error = kThreadError_InvalidState);
+    VerifyOrExit(mNetif.GetCommissioner().GetState() == kCommissionerStateActive, error = OT_ERROR_INVALID_STATE);
 
     header.Init(aAddress.IsMulticast() ? kCoapTypeNonConfirmable : kCoapTypeConfirmable,
                 kCoapRequestPost);
@@ -88,7 +88,7 @@ ThreadError AnnounceBeginClient::SendRequest(uint32_t aChannelMask, uint8_t aCou
     header.SetPayloadMarker();
 
     VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL,
-                 error = kThreadError_NoBufs);
+                 error = OT_ERROR_NO_BUFS);
 
     sessionId.Init();
     sessionId.SetCommissionerSessionId(mNetif.GetCommissioner().GetSessionId());
@@ -117,7 +117,7 @@ ThreadError AnnounceBeginClient::SendRequest(uint32_t aChannelMask, uint8_t aCou
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }

--- a/src/core/meshcop/announce_begin_client.hpp
+++ b/src/core/meshcop/announce_begin_client.hpp
@@ -71,11 +71,11 @@ public:
      * @param[in]  aCount         The number of energy measurements per channel.
      * @param[in]  aPeriod        The time between energy measurements (milliseconds).
      *
-     * @retval kThreadError_None    Successfully enqueued the Announce Begin message.
-     * @retval kThreadError_NoBufs  Insufficient buffers to generate a Announce Begin message.
+     * @retval OT_ERROR_NONE     Successfully enqueued the Announce Begin message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers to generate a Announce Begin message.
      *
      */
-    ThreadError SendRequest(uint32_t aChannelMask, uint8_t aCount, uint16_t mPeriod, const Ip6::Address &aAddress);
+    otError SendRequest(uint32_t aChannelMask, uint8_t aCount, uint16_t mPeriod, const Ip6::Address &aAddress);
 
 private:
     ThreadNetif &mNetif;

--- a/src/core/meshcop/border_agent_proxy.cpp
+++ b/src/core/meshcop/border_agent_proxy.cpp
@@ -62,11 +62,11 @@ BorderAgentProxy::BorderAgentProxy(const Ip6::Address &aMeshLocal16, Coap::Coap 
 {
 }
 
-ThreadError BorderAgentProxy::Start(otBorderAgentProxyStreamHandler aStreamHandler, void *aContext)
+otError BorderAgentProxy::Start(otBorderAgentProxyStreamHandler aStreamHandler, void *aContext)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(!mStreamHandler, error = kThreadError_Already);
+    VerifyOrExit(!mStreamHandler, error = OT_ERROR_ALREADY);
 
     mCoap.AddResource(mRelayReceive);
     mStreamHandler = aStreamHandler;
@@ -76,11 +76,11 @@ exit:
     return error;
 }
 
-ThreadError BorderAgentProxy::Stop(void)
+otError BorderAgentProxy::Stop(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mStreamHandler != NULL, error = kThreadError_Already);
+    VerifyOrExit(mStreamHandler != NULL, error = OT_ERROR_ALREADY);
 
     mCoap.RemoveResource(mRelayReceive);
 
@@ -104,9 +104,9 @@ void BorderAgentProxy::HandleRelayReceive(void *aContext, otCoapHeader *aHeader,
 }
 
 void BorderAgentProxy::HandleResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                      const otMessageInfo *aMessageInfo, ThreadError aResult)
+                                      const otMessageInfo *aMessageInfo, otError aResult)
 {
-    VerifyOrExit(aResult == kThreadError_None);
+    VerifyOrExit(aResult == OT_ERROR_NONE);
 
     static_cast<BorderAgentProxy *>(aContext)->DeliverMessage(*static_cast<Coap::Header *>(aHeader),
                                                               *static_cast<Message *>(aMessage),
@@ -118,14 +118,14 @@ exit:
 void BorderAgentProxy::DeliverMessage(Coap::Header &aHeader, Message &aMessage,
                                       const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint16_t rloc;
     uint16_t port;
     Message *message = NULL;
 
-    VerifyOrExit(mStreamHandler != NULL, error = kThreadError_InvalidState);
+    VerifyOrExit(mStreamHandler != NULL, error = OT_ERROR_INVALID_STATE);
 
-    VerifyOrExit((message = aMessage.Clone()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = aMessage.Clone()) != NULL, error = OT_ERROR_NO_BUFS);
     message->RemoveHeader(message->GetOffset() - aHeader.GetLength());
 
     rloc = HostSwap16(aMessageInfo.GetPeerAddr().mFields.m16[7]);
@@ -134,18 +134,18 @@ void BorderAgentProxy::DeliverMessage(Coap::Header &aHeader, Message &aMessage,
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
 }
 
-ThreadError BorderAgentProxy::Send(Message &aMessage, uint16_t aLocator, uint16_t aPort)
+otError BorderAgentProxy::Send(Message &aMessage, uint16_t aLocator, uint16_t aPort)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Ip6::MessageInfo messageInfo;
 
-    VerifyOrExit(mStreamHandler != NULL, error = kThreadError_InvalidState);
+    VerifyOrExit(mStreamHandler != NULL, error = OT_ERROR_INVALID_STATE);
 
     messageInfo.SetSockAddr(mMeshLocal16);
     messageInfo.SetPeerAddr(mMeshLocal16);
@@ -164,7 +164,7 @@ ThreadError BorderAgentProxy::Send(Message &aMessage, uint16_t aLocator, uint16_
 
 exit:
 
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         aMessage.Free();
     }

--- a/src/core/meshcop/border_agent_proxy.hpp
+++ b/src/core/meshcop/border_agent_proxy.hpp
@@ -57,20 +57,20 @@ public:
     /**
      * This method enables the border agent proxy service.
      *
-     * @retval kThreadError_None            Successfully started the service.
-     * @retval kThreadError_Already         The service already started.
+     * @retval OT_ERROR_NONE            Successfully started the service.
+     * @retval OT_ERROR_ALREADY         The service already started.
      *
      */
-    ThreadError Start(otBorderAgentProxyStreamHandler aStreamHandler, void *aContext);
+    otError Start(otBorderAgentProxyStreamHandler aStreamHandler, void *aContext);
 
     /**
      * This method disables the border agent proxy service.
      *
-     * @retval kThreadError_None            Successfully stopped the border agent proxy service.
-     * @retval kThreadError_Already         The service already stopped.
+     * @retval OT_ERROR_NONE            Successfully stopped the border agent proxy service.
+     * @retval OT_ERROR_ALREADY         The service already stopped.
      *
      */
-    ThreadError Stop(void);
+    otError Stop(void);
 
     /**
      * This method sends the message into the thread network.
@@ -79,13 +79,13 @@ public:
      * @param[in]   aLocator    The destination's RLOC16 or ALOC16.
      * @param[in]   aPort       The destination port.
      *
-     * @retval kThreadError_None            Successfully send the message.
-     * @retval kThreadError_InvalidState    Border agent proxy is not started.
+     * @retval OT_ERROR_NONE             Successfully send the message.
+     * @retval OT_ERROR_INVALID_STATE    Border agent proxy is not started.
      *
      * @warning No matter the call success or fail, the message is freed.
      *
      */
-    ThreadError Send(Message &aMessage, uint16_t aLocator, uint16_t aPort);
+    otError Send(Message &aMessage, uint16_t aLocator, uint16_t aPort);
 
     /**
      * This method indicates whether or not the border agent proxy service is enabled.
@@ -102,7 +102,7 @@ private:
                                    const otMessageInfo *aMessageInfo);
 
     static void HandleResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                               const otMessageInfo *aMessageInfo, ThreadError aResult);
+                               const otMessageInfo *aMessageInfo, otError aResult);
 
     void DeliverMessage(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -103,12 +103,12 @@ void Commissioner::RemoveCoapResources(void)
     mNetif.GetCoapSecure().RemoveResource(mJoinerFinalize);
 }
 
-ThreadError Commissioner::Start(void)
+otError Commissioner::Start(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     otLogFuncEntry();
-    VerifyOrExit(mState == kCommissionerStateDisabled, error = kThreadError_InvalidState);
+    VerifyOrExit(mState == kCommissionerStateDisabled, error = OT_ERROR_INVALID_STATE);
 
     SuccessOrExit(error = mNetif.GetCoapSecure().Start(OPENTHREAD_CONFIG_JOINER_UDP_PORT, SendRelayTransmit, this));
 
@@ -122,12 +122,12 @@ exit:
     return error;
 }
 
-ThreadError Commissioner::Stop(void)
+otError Commissioner::Stop(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     otLogFuncEntry();
-    VerifyOrExit(mState != kCommissionerStateDisabled, error = kThreadError_InvalidState);
+    VerifyOrExit(mState != kCommissionerStateDisabled, error = OT_ERROR_INVALID_STATE);
 
     mNetif.GetCoapSecure().Stop();
 
@@ -146,14 +146,14 @@ exit:
     return error;
 }
 
-ThreadError Commissioner::SendCommissionerSet(void)
+otError Commissioner::SendCommissionerSet(void)
 {
-    ThreadError error;
+    otError error;
     otCommissioningDataset dataset;
     SteeringDataTlv steeringData;
 
     otLogFuncEntry();
-    VerifyOrExit(mState == kCommissionerStateActive, error = kThreadError_InvalidState);
+    VerifyOrExit(mState == kCommissionerStateActive, error = OT_ERROR_INVALID_STATE);
 
     memset(&dataset, 0, sizeof(dataset));
 
@@ -207,14 +207,14 @@ void Commissioner::ClearJoiners(void)
     otLogFuncExit();
 }
 
-ThreadError Commissioner::AddJoiner(const Mac::ExtAddress *aExtAddress, const char *aPSKd, uint32_t aTimeout)
+otError Commissioner::AddJoiner(const Mac::ExtAddress *aExtAddress, const char *aPSKd, uint32_t aTimeout)
 {
-    ThreadError error = kThreadError_NoBufs;
+    otError error = OT_ERROR_NO_BUFS;
 
-    VerifyOrExit(mState == kCommissionerStateActive, error = kThreadError_InvalidState);
+    VerifyOrExit(mState == kCommissionerStateActive, error = OT_ERROR_INVALID_STATE);
 
     otLogFuncEntryMsg("%llX, %s", (aExtAddress ? HostSwap64(*reinterpret_cast<const uint64_t *>(aExtAddress)) : 0), aPSKd);
-    VerifyOrExit(strlen(aPSKd) <= Dtls::kPskMaxLength, error = kThreadError_InvalidArgs);
+    VerifyOrExit(strlen(aPSKd) <= Dtls::kPskMaxLength, error = OT_ERROR_INVALID_ARGS);
     RemoveJoiner(aExtAddress, 0);  // remove imediately
 
     for (size_t i = 0; i < sizeof(mJoiners) / sizeof(mJoiners[0]); i++)
@@ -242,7 +242,7 @@ ThreadError Commissioner::AddJoiner(const Mac::ExtAddress *aExtAddress, const ch
 
         SendCommissionerSet();
 
-        ExitNow(error = kThreadError_None);
+        ExitNow(error = OT_ERROR_NONE);
     }
 
 exit:
@@ -250,11 +250,11 @@ exit:
     return error;
 }
 
-ThreadError Commissioner::RemoveJoiner(const Mac::ExtAddress *aExtAddress, uint32_t aDelay)
+otError Commissioner::RemoveJoiner(const Mac::ExtAddress *aExtAddress, uint32_t aDelay)
 {
-    ThreadError error = kThreadError_NotFound;
+    otError error = OT_ERROR_NOT_FOUND;
 
-    VerifyOrExit(mState == kCommissionerStateActive, error = kThreadError_InvalidState);
+    VerifyOrExit(mState == kCommissionerStateActive, error = OT_ERROR_INVALID_STATE);
 
     otLogFuncEntryMsg("%llX", (aExtAddress ? HostSwap64(*reinterpret_cast<const uint64_t *>(aExtAddress)) : 0));
 
@@ -295,7 +295,7 @@ ThreadError Commissioner::RemoveJoiner(const Mac::ExtAddress *aExtAddress, uint3
             SendCommissionerSet();
         }
 
-        ExitNow(error = kThreadError_None);
+        ExitNow(error = OT_ERROR_NONE);
     }
 
 exit:
@@ -303,7 +303,7 @@ exit:
     return error;
 }
 
-ThreadError Commissioner::SetProvisioningUrl(const char *aProvisioningUrl)
+otError Commissioner::SetProvisioningUrl(const char *aProvisioningUrl)
 {
     return mNetif.GetDtls().mProvisioningUrl.SetProvisioningUrl(aProvisioningUrl);
 }
@@ -400,10 +400,10 @@ void Commissioner::UpdateJoinerExpirationTimer(void)
     }
 }
 
-ThreadError Commissioner::SendMgmtCommissionerGetRequest(const uint8_t *aTlvs,
-                                                         uint8_t aLength)
+otError Commissioner::SendMgmtCommissionerGetRequest(const uint8_t *aTlvs,
+                                                     uint8_t aLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header header;
     Message *message;
     Ip6::MessageInfo messageInfo;
@@ -420,7 +420,7 @@ ThreadError Commissioner::SendMgmtCommissionerGetRequest(const uint8_t *aTlvs,
         header.SetPayloadMarker();
     }
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     if (aLength > 0)
     {
@@ -440,7 +440,7 @@ ThreadError Commissioner::SendMgmtCommissionerGetRequest(const uint8_t *aTlvs,
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -450,7 +450,7 @@ exit:
 }
 
 void Commissioner::HandleMgmtCommissionerGetResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                                     const otMessageInfo *aMessageInfo, ThreadError aResult)
+                                                     const otMessageInfo *aMessageInfo, otError aResult)
 {
     static_cast<Commissioner *>(aContext)->HandleMgmtCommissisonerGetResponse(
         static_cast<Coap::Header *>(aHeader), static_cast<Message *>(aMessage),
@@ -458,24 +458,24 @@ void Commissioner::HandleMgmtCommissionerGetResponse(void *aContext, otCoapHeade
 }
 
 void Commissioner::HandleMgmtCommissisonerGetResponse(Coap::Header *aHeader, Message *aMessage,
-                                                      const Ip6::MessageInfo *aMessageInfo, ThreadError aResult)
+                                                      const Ip6::MessageInfo *aMessageInfo, otError aResult)
 {
     (void) aMessage;
     (void) aMessageInfo;
 
     otLogFuncEntry();
 
-    VerifyOrExit(aResult == kThreadError_None && aHeader->GetCode() == kCoapResponseChanged);
+    VerifyOrExit(aResult == OT_ERROR_NONE && aHeader->GetCode() == kCoapResponseChanged);
     otLogInfoMeshCoP(GetInstance(), "received MGMT_COMMISSIONER_GET response");
 
 exit:
     otLogFuncExit();
 }
 
-ThreadError Commissioner::SendMgmtCommissionerSetRequest(const otCommissioningDataset &aDataset,
-                                                         const uint8_t *aTlvs, uint8_t aLength)
+otError Commissioner::SendMgmtCommissionerSetRequest(const otCommissioningDataset &aDataset,
+                                                     const uint8_t *aTlvs, uint8_t aLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header header;
     Message *message;
     Ip6::MessageInfo messageInfo;
@@ -487,7 +487,7 @@ ThreadError Commissioner::SendMgmtCommissionerSetRequest(const otCommissioningDa
     header.AppendUriPathOptions(OT_URI_PATH_COMMISSIONER_SET);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     if (aDataset.mIsLocatorSet)
     {
@@ -543,7 +543,7 @@ ThreadError Commissioner::SendMgmtCommissionerSetRequest(const otCommissioningDa
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -553,7 +553,7 @@ exit:
 }
 
 void Commissioner::HandleMgmtCommissionerSetResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                                     const otMessageInfo *aMessageInfo, ThreadError aResult)
+                                                     const otMessageInfo *aMessageInfo, otError aResult)
 {
     static_cast<Commissioner *>(aContext)->HandleMgmtCommissisonerSetResponse(
         static_cast<Coap::Header *>(aHeader), static_cast<Message *>(aMessage),
@@ -561,23 +561,23 @@ void Commissioner::HandleMgmtCommissionerSetResponse(void *aContext, otCoapHeade
 }
 
 void Commissioner::HandleMgmtCommissisonerSetResponse(Coap::Header *aHeader, Message *aMessage,
-                                                      const Ip6::MessageInfo *aMessageInfo, ThreadError aResult)
+                                                      const Ip6::MessageInfo *aMessageInfo, otError aResult)
 {
     (void) aMessage;
     (void) aMessageInfo;
 
     otLogFuncEntry();
 
-    VerifyOrExit(aResult == kThreadError_None && aHeader->GetCode() == kCoapResponseChanged);
+    VerifyOrExit(aResult == OT_ERROR_NONE && aHeader->GetCode() == kCoapResponseChanged);
     otLogInfoMeshCoP(GetInstance(), "received MGMT_COMMISSIONER_SET response");
 
 exit:
     otLogFuncExit();
 }
 
-ThreadError Commissioner::SendPetition(void)
+otError Commissioner::SendPetition(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header header;
     Message *message = NULL;
     Ip6::MessageInfo messageInfo;
@@ -592,7 +592,7 @@ ThreadError Commissioner::SendPetition(void)
     header.AppendUriPathOptions(OT_URI_PATH_LEADER_PETITION);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     commissionerId.Init();
     commissionerId.SetCommissionerId("OpenThread Commissioner");
@@ -609,7 +609,7 @@ ThreadError Commissioner::SendPetition(void)
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -619,7 +619,7 @@ exit:
 }
 
 void Commissioner::HandleLeaderPetitionResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                                const otMessageInfo *aMessageInfo, ThreadError aResult)
+                                                const otMessageInfo *aMessageInfo, otError aResult)
 {
     static_cast<Commissioner *>(aContext)->HandleLeaderPetitionResponse(
         static_cast<Coap::Header *>(aHeader), static_cast<Message *>(aMessage),
@@ -628,7 +628,7 @@ void Commissioner::HandleLeaderPetitionResponse(void *aContext, otCoapHeader *aH
 }
 
 void Commissioner::HandleLeaderPetitionResponse(Coap::Header *aHeader, Message *aMessage,
-                                                const Ip6::MessageInfo *aMessageInfo, ThreadError aResult)
+                                                const Ip6::MessageInfo *aMessageInfo, otError aResult)
 {
     (void) aMessageInfo;
 
@@ -639,7 +639,7 @@ void Commissioner::HandleLeaderPetitionResponse(Coap::Header *aHeader, Message *
     otLogFuncEntry();
 
     VerifyOrExit(mState == kCommissionerStatePetition, mState = kCommissionerStateDisabled);
-    VerifyOrExit(aResult == kThreadError_None &&
+    VerifyOrExit(aResult == OT_ERROR_NONE &&
                  aHeader->GetCode() == kCoapResponseChanged, retransmit = true);
 
     otLogInfoMeshCoP(GetInstance(), "received Leader Petition response");
@@ -676,9 +676,9 @@ exit:
     otLogFuncExit();
 }
 
-ThreadError Commissioner::SendKeepAlive(void)
+otError Commissioner::SendKeepAlive(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header header;
     Message *message = NULL;
     Ip6::MessageInfo messageInfo;
@@ -692,7 +692,7 @@ ThreadError Commissioner::SendKeepAlive(void)
     header.AppendUriPathOptions(OT_URI_PATH_LEADER_KEEP_ALIVE);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     state.Init();
     state.SetState(mState == kCommissionerStateActive ? StateTlv::kAccept : StateTlv::kReject);
@@ -712,7 +712,7 @@ ThreadError Commissioner::SendKeepAlive(void)
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -722,7 +722,7 @@ exit:
 }
 
 void Commissioner::HandleLeaderKeepAliveResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                                 const otMessageInfo *aMessageInfo, ThreadError aResult)
+                                                 const otMessageInfo *aMessageInfo, otError aResult)
 {
     static_cast<Commissioner *>(aContext)->HandleLeaderKeepAliveResponse(
         static_cast<Coap::Header *>(aHeader), static_cast<Message *>(aMessage),
@@ -730,7 +730,7 @@ void Commissioner::HandleLeaderKeepAliveResponse(void *aContext, otCoapHeader *a
 }
 
 void Commissioner::HandleLeaderKeepAliveResponse(Coap::Header *aHeader, Message *aMessage,
-                                                 const Ip6::MessageInfo *aMessageInfo, ThreadError aResult)
+                                                 const Ip6::MessageInfo *aMessageInfo, otError aResult)
 {
     (void) aMessageInfo;
 
@@ -739,7 +739,7 @@ void Commissioner::HandleLeaderKeepAliveResponse(Coap::Header *aHeader, Message 
     otLogFuncEntry();
 
     VerifyOrExit(mState == kCommissionerStateActive, mState = kCommissionerStateDisabled);
-    VerifyOrExit(aResult == kThreadError_None &&
+    VerifyOrExit(aResult == OT_ERROR_NONE &&
                  aHeader->GetCode() == kCoapResponseChanged, mState = kCommissionerStateDisabled);
 
     otLogInfoMeshCoP(GetInstance(), "received Leader Petition response");
@@ -771,7 +771,7 @@ void Commissioner::HandleRelayReceive(void *aContext, otCoapHeader *aHeader, otM
 
 void Commissioner::HandleRelayReceive(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error;
+    otError error;
     JoinerUdpPortTlv joinerPort;
     JoinerIidTlv joinerIid;
     JoinerRouterLocatorTlv joinerRloc;
@@ -782,22 +782,22 @@ void Commissioner::HandleRelayReceive(Coap::Header &aHeader, Message &aMessage, 
 
     otLogFuncEntry();
 
-    VerifyOrExit(mState == kCommissionerStateActive, error = kThreadError_InvalidState);
+    VerifyOrExit(mState == kCommissionerStateActive, error = OT_ERROR_INVALID_STATE);
 
     VerifyOrExit(aHeader.GetType() == kCoapTypeNonConfirmable &&
                  aHeader.GetCode() == kCoapRequestPost);
 
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kJoinerUdpPort, sizeof(joinerPort), joinerPort));
-    VerifyOrExit(joinerPort.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(joinerPort.IsValid(), error = OT_ERROR_PARSE);
 
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kJoinerIid, sizeof(joinerIid), joinerIid));
-    VerifyOrExit(joinerIid.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(joinerIid.IsValid(), error = OT_ERROR_PARSE);
 
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kJoinerRouterLocator, sizeof(joinerRloc), joinerRloc));
-    VerifyOrExit(joinerRloc.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(joinerRloc.IsValid(), error = OT_ERROR_PARSE);
 
     SuccessOrExit(error = Tlv::GetValueOffset(aMessage, Tlv::kJoinerDtlsEncapsulation, offset, length));
-    VerifyOrExit(length <= aMessage.GetLength() - offset, error = kThreadError_Parse);
+    VerifyOrExit(length <= aMessage.GetLength() - offset, error = OT_ERROR_PARSE);
 
     if (!mNetif.GetCoapSecure().IsConnectionActive())
     {
@@ -893,7 +893,7 @@ void Commissioner::HandleJoinerFinalize(Coap::Header &aHeader, Message &aMessage
     otLogFuncEntry();
     otLogInfoMeshCoP(GetInstance(), "received joiner finalize");
 
-    if (Tlv::GetTlv(aMessage, Tlv::kProvisioningUrl, sizeof(provisioningUrl), provisioningUrl) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kProvisioningUrl, sizeof(provisioningUrl), provisioningUrl) == OT_ERROR_NONE)
     {
         if (provisioningUrl.GetLength() != mNetif.GetDtls().mProvisioningUrl.GetLength() ||
             memcmp(provisioningUrl.GetProvisioningUrl(), mNetif.GetDtls().mProvisioningUrl.GetProvisioningUrl(),
@@ -921,7 +921,7 @@ exit:
 
 void Commissioner::SendJoinFinalizeResponse(const Coap::Header &aRequestHeader, StateTlv::State aState)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header responseHeader;
     Ip6::MessageInfo joinerMessageInfo;
     MeshCoP::StateTlv stateTlv;
@@ -934,7 +934,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Header &aRequestHeader, 
     responseHeader.SetPayloadMarker();
 
     VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoapSecure(), responseHeader)) != NULL,
-                 error = kThreadError_NoBufs);
+                 error = OT_ERROR_NO_BUFS);
 
     message->SetSubType(Message::kSubTypeJoinerFinalizeResponse);
 
@@ -964,7 +964,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Header &aRequestHeader, 
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -972,15 +972,15 @@ exit:
     otLogFuncExit();
 }
 
-ThreadError Commissioner::SendRelayTransmit(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError Commissioner::SendRelayTransmit(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     return static_cast<Commissioner *>(aContext)->SendRelayTransmit(aMessage, aMessageInfo);
 }
 
-ThreadError Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     (void)aMessageInfo;
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header header;
     JoinerUdpPortTlv udpPort;
     JoinerIidTlv iid;
@@ -996,7 +996,7 @@ ThreadError Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::Messag
     header.AppendUriPathOptions(OT_URI_PATH_RELAY_TX);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     udpPort.Init();
     udpPort.SetUdpPort(mJoinerPort);
@@ -1036,7 +1036,7 @@ ThreadError Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::Messag
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -1045,16 +1045,16 @@ exit:
     return error;
 }
 
-ThreadError Commissioner::GeneratePSKc(const char *aPassPhrase, const char *aNetworkName, const uint8_t *aExtPanId,
-                                       uint8_t *aPSKc)
+otError Commissioner::GeneratePSKc(const char *aPassPhrase, const char *aNetworkName, const uint8_t *aExtPanId,
+                                   uint8_t *aPSKc)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     const char *saltPrefix = "Thread";
     uint8_t salt[OT_PBKDF2_SALT_MAX_LEN];
     uint16_t saltLen = 0;
 
     VerifyOrExit((strlen(aPassPhrase) >= OT_COMMISSIONING_PASSPHRASE_MIN_SIZE) &&
-                 (strlen(aPassPhrase) <= OT_COMMISSIONING_PASSPHRASE_MAX_SIZE), error = kThreadError_InvalidArgs);
+                 (strlen(aPassPhrase) <= OT_COMMISSIONING_PASSPHRASE_MAX_SIZE), error = OT_ERROR_INVALID_ARGS);
 
     memset(salt, 0, sizeof(salt));
     memcpy(salt, saltPrefix, strlen(saltPrefix));

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -76,18 +76,18 @@ public:
     /**
      * This method starts the Commissioner service.
      *
-     * @retval kThreadError_None  Successfully started the Commissioner service.
+     * @retval OT_ERROR_NONE  Successfully started the Commissioner service.
      *
      */
-    ThreadError Start(void);
+    otError Start(void);
 
     /**
      * This method stops the Commissioner service.
      *
-     * @retval kThreadError_None  Successfully stopped the Commissioner service.
+     * @retval OT_ERROR_NONE  Successfully stopped the Commissioner service.
      *
      */
-    ThreadError Stop(void);
+    otError Stop(void);
 
     /**
      * This method clears all Joiner entries.
@@ -102,11 +102,11 @@ public:
      * @param[in]  aPSKd            A pointer to the PSKd.
      * @param[in]  aTimeout         A time after which a Joiner is automatically removed, in seconds.
      *
-     * @retval kThreadError_None    Successfully added the Joiner.
-     * @retval kThreadError_NoBufs  No buffers available to add the Joiner.
+     * @retval OT_ERROR_NONE     Successfully added the Joiner.
+     * @retval OT_ERROR_NO_BUFS  No buffers available to add the Joiner.
      *
      */
-    ThreadError AddJoiner(const Mac::ExtAddress *aExtAddress, const char *aPSKd, uint32_t aTimeout);
+    otError AddJoiner(const Mac::ExtAddress *aExtAddress, const char *aPSKd, uint32_t aTimeout);
 
     /**
      * This method removes a Joiner entry.
@@ -114,22 +114,22 @@ public:
      * @param[in]  aExtAddress        A pointer to the Joiner's extended address or NULL for any Joiner.
      * @param[in]  aDelay             The delay to remove Joiner (in seconds).
      *
-     * @retval kThreadError_None      Successfully added the Joiner.
-     * @retval kThreadError_NotFound  The Joiner specified by @p aExtAddress was not found.
+     * @retval OT_ERROR_NONE       Successfully added the Joiner.
+     * @retval OT_ERROR_NOT_FOUND  The Joiner specified by @p aExtAddress was not found.
      *
      */
-    ThreadError RemoveJoiner(const Mac::ExtAddress *aExtAddress, uint32_t aDelay);
+    otError RemoveJoiner(const Mac::ExtAddress *aExtAddress, uint32_t aDelay);
 
     /**
      * This method sets the Provisioning URL.
      *
      * @param[in]  aProvisioningUrl  A pointer to the Provisioning URL (may be NULL).
      *
-     * @retval kThreadError_None         Successfully added the Joiner.
-     * @retval kThreadError_InvalidArgs  @p aProvisioningUrl is invalid.
+     * @retval OT_ERROR_NONE          Successfully added the Joiner.
+     * @retval OT_ERROR_INVALID_ARGS  @p aProvisioningUrl is invalid.
      *
      */
-    ThreadError SetProvisioningUrl(const char *aProvisioningUrl);
+    otError SetProvisioningUrl(const char *aProvisioningUrl);
 
     /**
      * This method returns the Commissioner Session ID.
@@ -157,11 +157,11 @@ public:
      * @param[in]  aTlvs        A pointer to Commissioning Data TLVs.
      * @param[in]  aLength      The length of requested TLVs in bytes.
      *
-     * @retval kThreadError_None     Send MGMT_COMMISSIONER_GET successfully.
-     * @retval kThreadError_Failed   Send MGMT_COMMISSIONER_GET fail.
+     * @retval OT_ERROR_NONE     Send MGMT_COMMISSIONER_GET successfully.
+     * @retval OT_ERROR_FAILED   Send MGMT_COMMISSIONER_GET fail.
      *
      */
-    ThreadError SendMgmtCommissionerGetRequest(const uint8_t *aTlvs, uint8_t aLength);
+    otError SendMgmtCommissionerGetRequest(const uint8_t *aTlvs, uint8_t aLength);
 
     /**
      * This method sends MGMT_COMMISSIONER_SET.
@@ -170,12 +170,12 @@ public:
      * @param[in]  aTlvs        A pointer to user specific Commissioning Data TLVs.
      * @param[in]  aLength      The length of user specific TLVs in bytes.
      *
-     * @retval kThreadError_None     Send MGMT_COMMISSIONER_SET successfully.
-     * @retval kThreadError_Failed   Send MGMT_COMMISSIONER_SET fail.
+     * @retval OT_ERROR_NONE     Send MGMT_COMMISSIONER_SET successfully.
+     * @retval OT_ERROR_FAILED   Send MGMT_COMMISSIONER_SET fail.
      *
      */
-    ThreadError SendMgmtCommissionerSetRequest(const otCommissioningDataset &aDataset,
-                                               const uint8_t *aTlvs, uint8_t aLength);
+    otError SendMgmtCommissionerSetRequest(const otCommissioningDataset &aDataset,
+                                           const uint8_t *aTlvs, uint8_t aLength);
 
     /**
      * This static method generates PSKc.
@@ -187,12 +187,12 @@ public:
      * @param[in]  aExtPanId     The extended pan id for PSKc computation.
      * @param[out] aPSKc         A pointer to where the generated PSKc will be placed.
      *
-     * @retval kThreadErrorNone          Successfully generate PSKc.
-     * @retval kThreadError_InvalidArgs  If the length of passphrase is out of range.
+     * @retval OT_ERROR_NONE          Successfully generate PSKc.
+     * @retval OT_ERROR_INVALID_ARGS  If the length of passphrase is out of range.
      *
      */
-    static ThreadError GeneratePSKc(const char *aPassPhrase, const char *aNetworkName, const uint8_t *aExtPanId,
-                                    uint8_t *aPSKc);
+    static otError GeneratePSKc(const char *aPassPhrase, const char *aNetworkName, const uint8_t *aExtPanId,
+                                uint8_t *aPSKc);
 
     AnnounceBeginClient mAnnounceBegin;
     EnergyScanClient mEnergyScan;
@@ -220,21 +220,21 @@ private:
     void UpdateJoinerExpirationTimer(void);
 
     static void HandleMgmtCommissionerSetResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                                  const otMessageInfo *aMessageInfo, ThreadError aResult);
+                                                  const otMessageInfo *aMessageInfo, otError aResult);
     void HandleMgmtCommissisonerSetResponse(Coap::Header *aHeader, Message *aMessage,
-                                            const Ip6::MessageInfo *aMessageInfo, ThreadError aResult);
+                                            const Ip6::MessageInfo *aMessageInfo, otError aResult);
     static void HandleMgmtCommissionerGetResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                                  const otMessageInfo *aMessageInfo, ThreadError aResult);
+                                                  const otMessageInfo *aMessageInfo, otError aResult);
     void HandleMgmtCommissisonerGetResponse(Coap::Header *aHeader, Message *aMessage,
-                                            const Ip6::MessageInfo *aMessageInfo, ThreadError aResult);
+                                            const Ip6::MessageInfo *aMessageInfo, otError aResult);
     static void HandleLeaderPetitionResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                             const otMessageInfo *aMessageInfo, ThreadError aResult);
+                                             const otMessageInfo *aMessageInfo, otError aResult);
     void HandleLeaderPetitionResponse(Coap::Header *aHeader, Message *aMessage,
-                                      const Ip6::MessageInfo *aMessageInfo, ThreadError aResult);
+                                      const Ip6::MessageInfo *aMessageInfo, otError aResult);
     static void HandleLeaderKeepAliveResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                              const otMessageInfo *aMessageInfo, ThreadError aResult);
+                                              const otMessageInfo *aMessageInfo, otError aResult);
     void HandleLeaderKeepAliveResponse(Coap::Header *aHeader, Message *aMessage,
-                                       const Ip6::MessageInfo *aMessageInfo, ThreadError aResult);
+                                       const Ip6::MessageInfo *aMessageInfo, otError aResult);
 
     static void HandleRelayReceive(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
                                    const otMessageInfo *aMessageInfo);
@@ -250,12 +250,12 @@ private:
 
     void SendJoinFinalizeResponse(const Coap::Header &aRequestHeader, StateTlv::State aState);
 
-    static ThreadError SendRelayTransmit(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError SendRelayTransmit(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    static otError SendRelayTransmit(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError SendRelayTransmit(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    ThreadError SendCommissionerSet(void);
-    ThreadError SendPetition(void);
-    ThreadError SendKeepAlive(void);
+    otError SendCommissionerSet(void);
+    otError SendPetition(void);
+    otError SendKeepAlive(void);
 
     otCommissionerState mState;
 

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -244,7 +244,7 @@ void Dataset::Get(otOperationalDataset &aDataset) const
     }
 }
 
-ThreadError Dataset::Set(const Dataset &aDataset)
+otError Dataset::Set(const Dataset &aDataset)
 {
     memcpy(mTlvs, aDataset.mTlvs, aDataset.mLength);
     mLength = aDataset.mLength;
@@ -255,16 +255,16 @@ ThreadError Dataset::Set(const Dataset &aDataset)
         Remove(Tlv::kDelayTimer);
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 #if OPENTHREAD_FTD
-ThreadError Dataset::Set(const otOperationalDataset &aDataset)
+otError Dataset::Set(const otOperationalDataset &aDataset)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     MeshCoP::ActiveTimestampTlv activeTimestampTlv;
 
-    VerifyOrExit(aDataset.mIsActiveTimestampSet, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aDataset.mIsActiveTimestampSet, error = OT_ERROR_INVALID_ARGS);
 
     activeTimestampTlv.Init();
     activeTimestampTlv.SetSeconds(aDataset.mActiveTimestamp);
@@ -275,7 +275,7 @@ ThreadError Dataset::Set(const otOperationalDataset &aDataset)
     {
         MeshCoP::PendingTimestampTlv pendingTimestampTlv;
 
-        VerifyOrExit(aDataset.mIsPendingTimestampSet, error = kThreadError_InvalidArgs);
+        VerifyOrExit(aDataset.mIsPendingTimestampSet, error = OT_ERROR_INVALID_ARGS);
 
         pendingTimestampTlv.Init();
         pendingTimestampTlv.SetSeconds(aDataset.mPendingTimestamp);
@@ -435,20 +435,20 @@ int Dataset::Compare(const Dataset &aCompare) const
     return rval;
 }
 
-ThreadError Dataset::Restore(void)
+otError Dataset::Restore(void)
 {
-    ThreadError error;
+    otError error;
     uint16_t length = sizeof(mTlvs);
 
     error = otPlatSettingsGet(mInstance, GetSettingsKey(), 0, mTlvs, &length);
-    mLength = (error == kThreadError_None) ? length : 0;
+    mLength = (error == OT_ERROR_NONE) ? length : 0;
 
     return error;
 }
 
-ThreadError Dataset::Store(void)
+otError Dataset::Store(void)
 {
-    ThreadError error;
+    otError error;
     uint16_t key = GetSettingsKey();
 
     if (mLength == 0)
@@ -463,9 +463,9 @@ ThreadError Dataset::Store(void)
     return error;
 }
 
-ThreadError Dataset::Set(const Tlv &aTlv)
+otError Dataset::Set(const Tlv &aTlv)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint16_t bytesAvailable = sizeof(mTlvs) - mLength;
     Tlv *old = Get(aTlv.GetType());
 
@@ -474,7 +474,7 @@ ThreadError Dataset::Set(const Tlv &aTlv)
         bytesAvailable += sizeof(Tlv) + old->GetLength();
     }
 
-    VerifyOrExit(sizeof(Tlv) + aTlv.GetLength() <= bytesAvailable, error = kThreadError_NoBufs);
+    VerifyOrExit(sizeof(Tlv) + aTlv.GetLength() <= bytesAvailable, error = OT_ERROR_NO_BUFS);
 
     // remove old TLV
     if (old != NULL)
@@ -490,11 +490,11 @@ exit:
     return error;
 }
 
-ThreadError Dataset::Set(const Message &aMessage, uint16_t aOffset, uint8_t aLength)
+otError Dataset::Set(const Message &aMessage, uint16_t aOffset, uint8_t aLength)
 {
     aMessage.Read(aOffset, aLength, mTlvs);
     mLength = aLength;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 void Dataset::Remove(Tlv::Type aType)
@@ -508,9 +508,9 @@ exit:
     return;
 }
 
-ThreadError Dataset::AppendMleDatasetTlv(Message &aMessage)
+otError Dataset::AppendMleDatasetTlv(Message &aMessage)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Mle::Tlv tlv;
     Mle::Tlv::Type type;
     Tlv *cur = reinterpret_cast<Tlv *>(mTlvs);

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -134,38 +134,38 @@ public:
     /**
      * This method restores dataset from non-volatile memory.
      *
-     * @retval kThreadError_None      Successfully restore the dataset.
-     * @retval kThreadError_NotFound  There is no corresponding dataset stored in non-volatile memory.
+     * @retval OT_ERROR_NONE       Successfully restore the dataset.
+     * @retval OT_ERROR_NOT_FOUND  There is no corresponding dataset stored in non-volatile memory.
      *
      */
-    ThreadError Restore(void);
+    otError Restore(void);
 
     /**
      * This method stores dataset into non-volatile memory.
      *
-     * @retval kThreadError_None      Successfully store the dataset.
-     * @retval kThreadError_NoBufs    Could not store the dataset due to insufficient memory space.
+     * @retval OT_ERROR_NONE       Successfully store the dataset.
+     * @retval OT_ERROR_NO_BUFS    Could not store the dataset due to insufficient memory space.
      *
      */
-    ThreadError Store(void);
+    otError Store(void);
 
     /**
      * This method sets a TLV in the Dataset.
      *
      * @param[in]  aTlv  A reference to the TLV.
      *
-     * @retval kThreadError_None    Successfully set the TLV.
-     * @retval kThreadError_NoBufs  Could not set the TLV due to insufficient buffer space.
+     * @retval OT_ERROR_NONE     Successfully set the TLV.
+     * @retval OT_ERROR_NO_BUFS  Could not set the TLV due to insufficient buffer space.
      *
      */
-    ThreadError Set(const Tlv &aTlv);
+    otError Set(const Tlv &aTlv);
 
-    ThreadError Set(const Message &aMessage, uint16_t aOffset, uint8_t aLength);
+    otError Set(const Message &aMessage, uint16_t aOffset, uint8_t aLength);
 
-    ThreadError Set(const Dataset &aDataset);
+    otError Set(const Dataset &aDataset);
 
 #if OPENTHREAD_FTD
-    ThreadError Set(const otOperationalDataset &aDataset);
+    otError Set(const otOperationalDataset &aDataset);
 #endif
 
     /**
@@ -179,11 +179,11 @@ public:
     /**
      * This method appends the MLE Dataset TLV but excluding MeshCoP Sub Timestamp TLV.
      *
-     * @retval kThreadError_None    Successfully append MLE Dataset TLV without MeshCoP Sub Timestamp TLV.
-     * @retval kThreadError_NoBufs  Insufficient available buffers to append the message with MLE Dataset TLV.
+     * @retval OT_ERROR_NONE     Successfully append MLE Dataset TLV without MeshCoP Sub Timestamp TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to append the message with MLE Dataset TLV.
      *
      */
-    ThreadError AppendMleDatasetTlv(Message &aMessage);
+    otError AppendMleDatasetTlv(Message &aMessage);
 
 private:
     uint16_t GetSettingsKey(void);

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -81,9 +81,9 @@ otInstance *DatasetManager::GetInstance(void)
     return mNetif.GetInstance();
 }
 
-ThreadError DatasetManager::ApplyConfiguration(void)
+otError DatasetManager::ApplyConfiguration(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Dataset *dataset;
     const Tlv *cur;
     const Tlv *end;
@@ -174,9 +174,9 @@ ThreadError DatasetManager::ApplyConfiguration(void)
 }
 
 #if OPENTHREAD_FTD
-ThreadError DatasetManager::Set(const otOperationalDataset &aDataset, uint8_t &aFlags)
+otError DatasetManager::Set(const otOperationalDataset &aDataset, uint8_t &aFlags)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     SuccessOrExit(error = mLocal.Set(aDataset));
     mLocal.Store();
@@ -205,7 +205,7 @@ exit:
 }
 #endif // OPENTHREAD_FTD
 
-ThreadError DatasetManager::Clear(uint8_t &aFlags, bool aOnlyClearNetwork)
+otError DatasetManager::Clear(uint8_t &aFlags, bool aOnlyClearNetwork)
 {
     if (!aOnlyClearNetwork)
     {
@@ -214,10 +214,10 @@ ThreadError DatasetManager::Clear(uint8_t &aFlags, bool aOnlyClearNetwork)
 
     mNetwork.Clear(false);
     HandleNetworkUpdate(aFlags);
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError DatasetManager::Set(const Dataset &aDataset)
+otError DatasetManager::Set(const Dataset &aDataset)
 {
     mNetwork.Set(aDataset);
 
@@ -227,13 +227,13 @@ ThreadError DatasetManager::Set(const Dataset &aDataset)
         mLocal.Store();
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError DatasetManager::Set(const Timestamp &aTimestamp, const Message &aMessage,
-                                uint16_t aOffset, uint8_t aLength, uint8_t &aFlags)
+otError DatasetManager::Set(const Timestamp &aTimestamp, const Message &aMessage,
+                            uint16_t aOffset, uint8_t aLength, uint8_t &aFlags)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     SuccessOrExit(error = mNetwork.Set(aMessage, aOffset, aLength));
     mNetwork.SetTimestamp(aTimestamp);
@@ -299,9 +299,9 @@ exit:
     return;
 }
 
-ThreadError DatasetManager::Register(void)
+otError DatasetManager::Register(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header header;
     Message *message;
     Ip6::MessageInfo messageInfo;
@@ -317,7 +317,7 @@ ThreadError DatasetManager::Register(void)
         pending->UpdateDelayTimer();
     }
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     SuccessOrExit(error = message->Append(mLocal.GetBytes(), mLocal.GetSize()));
 
@@ -330,7 +330,7 @@ ThreadError DatasetManager::Register(void)
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -363,7 +363,7 @@ void DatasetManager::Get(Coap::Header &aHeader, Message &aMessage, const Ip6::Me
 }
 
 #if OPENTHREAD_FTD
-ThreadError DatasetManager::Set(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError DatasetManager::Set(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     Tlv tlv;
     Timestamp *timestamp;
@@ -406,14 +406,14 @@ ThreadError DatasetManager::Set(Coap::Header &aHeader, Message &aMessage, const 
 
     type = (strcmp(mUriSet, OT_URI_PATH_ACTIVE_SET) == 0 ? Tlv::kActiveTimestamp : Tlv::kPendingTimestamp);
 
-    if (Tlv::GetTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp) != kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp) != OT_ERROR_NONE)
     {
         ExitNow(state = StateTlv::kReject);
     }
 
     VerifyOrExit(activeTimestamp.IsValid(), state = StateTlv::kReject);
 
-    if (Tlv::GetTlv(aMessage, Tlv::kPendingTimestamp, sizeof(pendingTimestamp), pendingTimestamp) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kPendingTimestamp, sizeof(pendingTimestamp), pendingTimestamp) == OT_ERROR_NONE)
     {
         VerifyOrExit(pendingTimestamp.IsValid(), state = StateTlv::kReject);
     }
@@ -427,7 +427,7 @@ ThreadError DatasetManager::Set(Coap::Header &aHeader, Message &aMessage, const 
                  state = StateTlv::kReject);
 
     // check channel
-    if (Tlv::GetTlv(aMessage, Tlv::kChannel, sizeof(channel), channel) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kChannel, sizeof(channel), channel) == OT_ERROR_NONE)
     {
         VerifyOrExit(channel.IsValid() &&
                      channel.GetChannel() >= kPhyMinChannel &&
@@ -441,7 +441,7 @@ ThreadError DatasetManager::Set(Coap::Header &aHeader, Message &aMessage, const 
     }
 
     // check PAN ID
-    if (Tlv::GetTlv(aMessage, Tlv::kPanId, sizeof(panId), panId) == kThreadError_None &&
+    if (Tlv::GetTlv(aMessage, Tlv::kPanId, sizeof(panId), panId) == OT_ERROR_NONE &&
         panId.IsValid() &&
         panId.GetPanId() != mNetif.GetMac().GetPanId())
     {
@@ -449,7 +449,7 @@ ThreadError DatasetManager::Set(Coap::Header &aHeader, Message &aMessage, const 
     }
 
     // check mesh local prefix
-    if (Tlv::GetTlv(aMessage, Tlv::kMeshLocalPrefix, sizeof(meshLocalPrefix), meshLocalPrefix) == kThreadError_None &&
+    if (Tlv::GetTlv(aMessage, Tlv::kMeshLocalPrefix, sizeof(meshLocalPrefix), meshLocalPrefix) == OT_ERROR_NONE &&
         memcmp(meshLocalPrefix.GetMeshLocalPrefix(), mNetif.GetMle().GetMeshLocalPrefix(),
                meshLocalPrefix.GetLength()))
     {
@@ -457,7 +457,7 @@ ThreadError DatasetManager::Set(Coap::Header &aHeader, Message &aMessage, const 
     }
 
     // check network master key
-    if (Tlv::GetTlv(aMessage, Tlv::kNetworkMasterKey, sizeof(masterKey), masterKey) == kThreadError_None &&
+    if (Tlv::GetTlv(aMessage, Tlv::kNetworkMasterKey, sizeof(masterKey), masterKey) == OT_ERROR_NONE &&
         memcmp(&masterKey.GetNetworkMasterKey(), &mNetif.GetKeyManager().GetMasterKey(), OT_MASTER_KEY_SIZE))
     {
         doesAffectConnectivity = true;
@@ -477,7 +477,7 @@ ThreadError DatasetManager::Set(Coap::Header &aHeader, Message &aMessage, const 
     }
 
     // check commissioner session id
-    if (Tlv::GetTlv(aMessage, Tlv::kCommissionerSessionId, sizeof(sessionId), sessionId) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kCommissionerSessionId, sizeof(sessionId), sessionId) == OT_ERROR_NONE)
     {
         CommissionerSessionIdTlv *localId;
 
@@ -583,12 +583,12 @@ exit:
         SendSetResponse(aHeader, aMessageInfo, state);
     }
 
-    return state == StateTlv::kAccept ? kThreadError_None : kThreadError_Drop;
+    return state == StateTlv::kAccept ? OT_ERROR_NONE : OT_ERROR_DROP;
 }
 
-ThreadError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, const uint8_t *aTlvs, uint8_t aLength)
+otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, const uint8_t *aTlvs, uint8_t aLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header header;
     Message *message;
     Ip6::MessageInfo messageInfo;
@@ -598,7 +598,7 @@ ThreadError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset,
     header.AppendUriPathOptions(mUriSet);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = OT_ERROR_NO_BUFS);
 
 #if OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
     bool isCommissioner;
@@ -738,7 +738,7 @@ ThreadError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset,
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -746,10 +746,10 @@ exit:
     return error;
 }
 
-ThreadError DatasetManager::SendGetRequest(const uint8_t *aTlvTypes, const uint8_t aLength,
-                                           const otIp6Address *aAddress)
+otError DatasetManager::SendGetRequest(const uint8_t *aTlvTypes, const uint8_t aLength,
+                                       const otIp6Address *aAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header header;
     Message *message;
     Ip6::MessageInfo messageInfo;
@@ -764,8 +764,7 @@ ThreadError DatasetManager::SendGetRequest(const uint8_t *aTlvTypes, const uint8
         header.SetPayloadMarker();
     }
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = kThreadError_NoBufs);
-
+    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     if (aLength > 0)
     {
@@ -792,7 +791,7 @@ ThreadError DatasetManager::SendGetRequest(const uint8_t *aTlvTypes, const uint8
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -803,7 +802,7 @@ exit:
 void DatasetManager::SendSetResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
                                      StateTlv::State aState)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header responseHeader;
     Message *message;
     StateTlv state;
@@ -811,7 +810,7 @@ void DatasetManager::SendSetResponse(const Coap::Header &aRequestHeader, const I
     responseHeader.SetDefaultResponseHeader(aRequestHeader);
     responseHeader.SetPayloadMarker();
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), responseHeader)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), responseHeader)) != NULL, error = OT_ERROR_NO_BUFS);
 
     state.Init();
     state.SetState(aState);
@@ -823,7 +822,7 @@ void DatasetManager::SendSetResponse(const Coap::Header &aRequestHeader, const I
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -834,7 +833,7 @@ void DatasetManager::SendGetResponse(const Coap::Header &aRequestHeader, const I
                                      uint8_t *aTlvs, uint8_t aLength)
 {
     Tlv *tlv;
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header responseHeader;
     Message *message;
     uint8_t index;
@@ -843,7 +842,7 @@ void DatasetManager::SendGetResponse(const Coap::Header &aRequestHeader, const I
     responseHeader.SetDefaultResponseHeader(aRequestHeader);
     responseHeader.SetPayloadMarker();
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), responseHeader)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), responseHeader)) != NULL, error = OT_ERROR_NO_BUFS);
 
     if (aLength == 0)
     {
@@ -890,7 +889,7 @@ void DatasetManager::SendGetResponse(const Coap::Header &aRequestHeader, const I
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -903,9 +902,9 @@ ActiveDatasetBase::ActiveDatasetBase(ThreadNetif &aThreadNetif):
     mNetif.GetCoap().AddResource(mResourceGet);
 }
 
-ThreadError ActiveDatasetBase::Restore(void)
+otError ActiveDatasetBase::Restore(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     SuccessOrExit(error = mLocal.Restore());
     SuccessOrExit(error = DatasetManager::ApplyConfiguration());
@@ -914,9 +913,9 @@ exit:
     return error;
 }
 
-ThreadError ActiveDatasetBase::Clear(bool aOnlyClearNetwork)
+otError ActiveDatasetBase::Clear(bool aOnlyClearNetwork)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t flags;
 
     SuccessOrExit(error = DatasetManager::Clear(flags, aOnlyClearNetwork));
@@ -926,9 +925,9 @@ exit:
 }
 
 #if OPENTHREAD_FTD
-ThreadError ActiveDatasetBase::Set(const otOperationalDataset &aDataset)
+otError ActiveDatasetBase::Set(const otOperationalDataset &aDataset)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t flags;
 
     SuccessOrExit(error = DatasetManager::Set(aDataset, flags));
@@ -939,9 +938,9 @@ exit:
 }
 #endif // OPENTHREAD_FTD
 
-ThreadError ActiveDatasetBase::Set(const Dataset &aDataset)
+otError ActiveDatasetBase::Set(const Dataset &aDataset)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     SuccessOrExit(error = DatasetManager::Set(aDataset));
     DatasetManager::ApplyConfiguration();
@@ -956,10 +955,10 @@ exit:
     return error;
 }
 
-ThreadError ActiveDatasetBase::Set(const Timestamp &aTimestamp, const Message &aMessage,
-                                   uint16_t aOffset, uint8_t aLength)
+otError ActiveDatasetBase::Set(const Timestamp &aTimestamp, const Message &aMessage,
+                               uint16_t aOffset, uint8_t aLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t flags;
 
     SuccessOrExit(error = DatasetManager::Set(aTimestamp, aMessage, aOffset, aLength, flags));
@@ -992,9 +991,9 @@ PendingDatasetBase::PendingDatasetBase(ThreadNetif &aThreadNetif):
     mNetif.GetCoap().AddResource(mResourceGet);
 }
 
-ThreadError PendingDatasetBase::Restore(void)
+otError PendingDatasetBase::Restore(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     SuccessOrExit(error = mLocal.Restore());
 
@@ -1004,9 +1003,9 @@ exit:
     return error;
 }
 
-ThreadError PendingDatasetBase::Clear(bool aOnlyClearNetwork)
+otError PendingDatasetBase::Clear(bool aOnlyClearNetwork)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t flags;
 
     SuccessOrExit(error = DatasetManager::Clear(flags, aOnlyClearNetwork));
@@ -1017,9 +1016,9 @@ exit:
 }
 
 #if OPENTHREAD_FTD
-ThreadError PendingDatasetBase::Set(const otOperationalDataset &aDataset)
+otError PendingDatasetBase::Set(const otOperationalDataset &aDataset)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t flags;
 
     SuccessOrExit(error = DatasetManager::Set(aDataset, flags));
@@ -1030,9 +1029,9 @@ exit:
 }
 #endif // OPENTHREAD_FTD
 
-ThreadError PendingDatasetBase::Set(const Dataset &aDataset)
+otError PendingDatasetBase::Set(const Dataset &aDataset)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     SuccessOrExit(error = DatasetManager::Set(aDataset));
     ResetDelayTimer(kFlagLocalUpdated | kFlagNetworkUpdated);
@@ -1041,10 +1040,10 @@ exit:
     return error;
 }
 
-ThreadError PendingDatasetBase::Set(const Timestamp &aTimestamp, const Message &aMessage,
-                                    uint16_t aOffset, uint8_t aLength)
+otError PendingDatasetBase::Set(const Timestamp &aTimestamp, const Message &aMessage,
+                                uint16_t aOffset, uint8_t aLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t flags;
 
     SuccessOrExit(error = DatasetManager::Set(aTimestamp, aMessage, aOffset, aLength, flags));

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -65,7 +65,7 @@ public:
     Dataset &GetLocal(void) { return mLocal; }
     Dataset &GetNetwork(void) { return mNetwork; }
 
-    ThreadError ApplyConfiguration(void);
+    otError ApplyConfiguration(void);
 
 protected:
     enum
@@ -76,12 +76,12 @@ protected:
 
     DatasetManager(ThreadNetif &aThreadNetif, const Tlv::Type aType, const char *aUriSet, const char *aUriGet);
 
-    ThreadError Clear(uint8_t &aFlags, bool aOnlyClearNetwork);
+    otError Clear(uint8_t &aFlags, bool aOnlyClearNetwork);
 
-    ThreadError Set(const Dataset &aDataset);
+    otError Set(const Dataset &aDataset);
 
-    ThreadError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength,
-                    uint8_t &aFlags);
+    otError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength,
+                uint8_t &aFlags);
 
     void Get(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
@@ -99,7 +99,7 @@ private:
     static void HandleTimer(void *aContext);
     void HandleTimer(void);
 
-    ThreadError Register(void);
+    otError Register(void);
     void SendGetResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
                          uint8_t *aTlvs, uint8_t aLength);
 
@@ -110,12 +110,12 @@ private:
 
 #if OPENTHREAD_FTD
 public:
-    ThreadError SendSetRequest(const otOperationalDataset &aDataset, const uint8_t *aTlvs, uint8_t aLength);
-    ThreadError SendGetRequest(const uint8_t *aTlvTypes, uint8_t aLength, const otIp6Address *aAddress);
+    otError SendSetRequest(const otOperationalDataset &aDataset, const uint8_t *aTlvs, uint8_t aLength);
+    otError SendGetRequest(const uint8_t *aTlvTypes, uint8_t aLength, const otIp6Address *aAddress);
 
 protected:
-    ThreadError Set(const otOperationalDataset &aDataset, uint8_t &aFlags);
-    ThreadError Set(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError Set(const otOperationalDataset &aDataset, uint8_t &aFlags);
+    otError Set(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
 private:
     void SendSetResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo, StateTlv::State aState);
@@ -127,17 +127,17 @@ class ActiveDatasetBase: public DatasetManager
 public:
     ActiveDatasetBase(ThreadNetif &aThreadNetif);
 
-    ThreadError Restore(void);
+    otError Restore(void);
 
-    ThreadError Clear(bool aOnlyClearNetwork);
+    otError Clear(bool aOnlyClearNetwork);
 
 #if OPENTHREAD_FTD
-    ThreadError Set(const otOperationalDataset &aDataset);
+    otError Set(const otOperationalDataset &aDataset);
 #endif
 
-    ThreadError Set(const Dataset &aDataset);
+    otError Set(const Dataset &aDataset);
 
-    ThreadError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
+    otError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
 
 private:
     static void HandleGet(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
@@ -152,17 +152,17 @@ class PendingDatasetBase: public DatasetManager
 public:
     PendingDatasetBase(ThreadNetif &aThreadNetif);
 
-    ThreadError Restore(void);
+    otError Restore(void);
 
-    ThreadError Clear(bool aOnlyClearNetwork);
+    otError Clear(bool aOnlyClearNetwork);
 
 #if OPENTHREAD_FTD
-    ThreadError Set(const otOperationalDataset &aDataset);
+    otError Set(const otOperationalDataset &aDataset);
 #endif
 
-    ThreadError Set(const Dataset &aDataset);
+    otError Set(const Dataset &aDataset);
 
-    ThreadError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
+    otError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
 
     void UpdateDelayTimer(void);
 

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -76,12 +76,12 @@ bool ActiveDataset::IsTlvInitialized(Tlv::Type aType)
     return mLocal.Get(aType) != NULL;
 }
 
-ThreadError ActiveDataset::GenerateLocal(void)
+otError ActiveDataset::GenerateLocal(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otOperationalDataset dataset;
 
-    VerifyOrExit(mNetif.GetMle().IsAttached(), error = kThreadError_InvalidState);
+    VerifyOrExit(mNetif.GetMle().IsAttached(), error = OT_ERROR_INVALID_STATE);
 
     memset(&dataset, 0, sizeof(dataset));
 

--- a/src/core/meshcop/dataset_manager_ftd.hpp
+++ b/src/core/meshcop/dataset_manager_ftd.hpp
@@ -50,7 +50,7 @@ class ActiveDataset: public ActiveDatasetBase
 public:
     ActiveDataset(ThreadNetif &aThreadNetif);
 
-    ThreadError GenerateLocal(void);
+    otError GenerateLocal(void);
 
     void StartLeader(void);
 

--- a/src/core/meshcop/dataset_manager_mtd.hpp
+++ b/src/core/meshcop/dataset_manager_mtd.hpp
@@ -48,7 +48,7 @@ class ActiveDataset: public ActiveDatasetBase
 public:
     ActiveDataset(ThreadNetif &aThreadNetif) : ActiveDatasetBase(aThreadNetif) { }
 
-    ThreadError GenerateLocal(void) { return kThreadError_NotImplemented; }
+    otError GenerateLocal(void) { return OT_ERROR_NOT_IMPLEMENTED; }
 };
 
 class PendingDataset: public PendingDatasetBase

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -107,7 +107,7 @@ public:
      * @param[in]  aMessageSubtype  A message sub type information for the sender.
      *
      */
-    typedef ThreadError(*SendHandler)(void *aContext, const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
+    typedef otError(*SendHandler)(void *aContext, const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
 
     /**
      * This method starts the DTLS service.
@@ -118,19 +118,19 @@ public:
      * @param[in]  aSendHandler       A pointer to the send handler.
      * @param[in]  aContext           A pointer to application-specific context.
      *
-     * @retval kThreadError_None      Successfully started the DTLS service.
+     * @retval OT_ERROR_NONE      Successfully started the DTLS service.
      *
      */
-    ThreadError Start(bool aClient, ConnectedHandler aConnectedHandler, ReceiveHandler aReceiveHandler,
-                      SendHandler aSendHandler, void *aContext);
+    otError Start(bool aClient, ConnectedHandler aConnectedHandler, ReceiveHandler aReceiveHandler,
+                  SendHandler aSendHandler, void *aContext);
 
     /**
      * This method stops the DTLS service.
      *
-     * @retval kThreadError_None  Successfully stopped the DTLS service.
+     * @retval OT_ERROR_NONE  Successfully stopped the DTLS service.
      *
      */
-    ThreadError Stop(void);
+    otError Stop(void);
 
     /**
      * This method indicates whether or not the DTLS service is active.
@@ -145,11 +145,11 @@ public:
      *
      * @param[in]  aPSK  A pointer to the PSK.
      *
-     * @retval kThreadError_None         Successfully set the PSK.
-     * @retval kThreadError_InvalidArgs  The PSK is invalid.
+     * @retval OT_ERROR_NONE          Successfully set the PSK.
+     * @retval OT_ERROR_INVALID_ARGS  The PSK is invalid.
      *
      */
-    ThreadError SetPsk(const uint8_t *aPsk, uint8_t aPskLength);
+    otError SetPsk(const uint8_t *aPsk, uint8_t aPskLength);
 
     /**
      * This method sets the Client ID used for generating the Hello Cookie.
@@ -157,10 +157,10 @@ public:
      * @param[in]  aClientId  A pointer to the Client ID.
      * @param[in]  aLength    Number of bytes in the Client ID.
      *
-     * @retval kThreadError_None  Successfully set the Client ID.
+     * @retval OT_ERROR_NONE  Successfully set the Client ID.
      *
      */
-    ThreadError SetClientId(const uint8_t *aClientId, uint8_t aLength);
+    otError SetClientId(const uint8_t *aClientId, uint8_t aLength);
 
     /**
      * This method indicates whether or not the DTLS session is connected.
@@ -177,11 +177,11 @@ public:
      * @param[in]  aMessage  A message to send via DTLS.
      * @param[in]  aLength   Number of bytes in the data buffer.
      *
-     * @retval kThreadError_None    Successfully sent the data via the DTLS session.
-     * @retval kThreadError_NoBufs  A message is too long.
+     * @retval OT_ERROR_NONE     Successfully sent the data via the DTLS session.
+     * @retval OT_ERROR_NO_BUFS  A message is too long.
      *
      */
-    ThreadError Send(Message &aMessage, uint16_t aLength);
+    otError Send(Message &aMessage, uint16_t aLength);
 
     /**
      * This method provides a received DTLS message to the DTLS object.
@@ -190,10 +190,10 @@ public:
      * @param[in]  aOffset   The offset within @p aMessage where the DTLS message starts.
      * @param[in]  aLength   The size of the DTLS message (bytes).
      *
-     * @retval kThreadError_None  Successfully processed the received DTLS message.
+     * @retval OT_ERROR_NONE  Successfully processed the received DTLS message.
      *
      */
-    ThreadError Receive(Message &aMessage, uint16_t aOffset, uint16_t aLength);
+    otError Receive(Message &aMessage, uint16_t aOffset, uint16_t aLength);
 
     /**
      * The provisioning URL is placed here so that both the Commissioner and Joiner can share the same object.
@@ -202,7 +202,7 @@ public:
     ProvisioningUrlTlv mProvisioningUrl;
 
 private:
-    static ThreadError MapError(int rval);
+    static otError MapError(int rval);
 
     static void HandleMbedtlsDebug(void *ctx, int level, const char *file, int line, const char *str);
 

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -74,11 +74,11 @@ otInstance *EnergyScanClient::GetInstance(void)
     return mNetif.GetInstance();
 }
 
-ThreadError EnergyScanClient::SendQuery(uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod,
-                                        uint16_t aScanDuration, const Ip6::Address &aAddress,
-                                        otCommissionerEnergyReportCallback aCallback, void *aContext)
+otError EnergyScanClient::SendQuery(uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod,
+                                    uint16_t aScanDuration, const Ip6::Address &aAddress,
+                                    otCommissionerEnergyReportCallback aCallback, void *aContext)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header header;
     MeshCoP::CommissionerSessionIdTlv sessionId;
     MeshCoP::ChannelMask0Tlv channelMask;
@@ -88,7 +88,7 @@ ThreadError EnergyScanClient::SendQuery(uint32_t aChannelMask, uint8_t aCount, u
     Ip6::MessageInfo messageInfo;
     Message *message = NULL;
 
-    VerifyOrExit(mNetif.GetCommissioner().GetState() == kCommissionerStateActive, error = kThreadError_InvalidState);
+    VerifyOrExit(mNetif.GetCommissioner().GetState() == kCommissionerStateActive, error = OT_ERROR_INVALID_STATE);
 
     header.Init(aAddress.IsMulticast() ? kCoapTypeNonConfirmable : kCoapTypeConfirmable,
                 kCoapRequestPost);
@@ -97,7 +97,7 @@ ThreadError EnergyScanClient::SendQuery(uint32_t aChannelMask, uint8_t aCount, u
     header.SetPayloadMarker();
 
     VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL,
-                 error = kThreadError_NoBufs);
+                 error = OT_ERROR_NO_BUFS);
 
     sessionId.Init();
     sessionId.SetCommissionerSessionId(mNetif.GetCommissioner().GetSessionId());
@@ -132,7 +132,7 @@ ThreadError EnergyScanClient::SendQuery(uint32_t aChannelMask, uint8_t aCount, u
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }

--- a/src/core/meshcop/energy_scan_client.hpp
+++ b/src/core/meshcop/energy_scan_client.hpp
@@ -77,12 +77,12 @@ public:
      * @param[in]  aCallback      A pointer to a function called on receiving an Energy Report message.
      * @param[in]  aContext       A pointer to application-specific context.
      *
-     * @retval kThreadError_None    Successfully enqueued the Energy Scan Query message.
-     * @retval kThreadError_NoBufs  Insufficient buffers to generate an Energy Scan Query message.
+     * @retval OT_ERROR_NONE     Successfully enqueued the Energy Scan Query message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers to generate an Energy Scan Query message.
      *
      */
-    ThreadError SendQuery(uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod, uint16_t aScanDuration,
-                          const Ip6::Address &aAddress, otCommissionerEnergyReportCallback aCallback, void *aContext);
+    otError SendQuery(uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod, uint16_t aScanDuration,
+                      const Ip6::Address &aAddress, otCommissionerEnergyReportCallback aCallback, void *aContext);
 
 private:
     static void HandleReport(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -82,21 +82,21 @@ public:
      * @param[in]  aCallback         A pointer to a function that is called when the join operation completes.
      * @param[in]  aContext          A pointer to application-specific context.
      *
-     * @retval kThreadError_None  Successfully started the Joiner service.
+     * @retval OT_ERROR_NONE  Successfully started the Joiner service.
      *
      */
-    ThreadError Start(const char *aPSKd, const char *aProvisioningUrl,
-                      const char *aVendorName, const char *aVendorModel,
-                      const char *aVendorSwVersion, const char *aVendorData,
-                      otJoinerCallback aCallback, void *aContext);
+    otError Start(const char *aPSKd, const char *aProvisioningUrl,
+                  const char *aVendorName, const char *aVendorModel,
+                  const char *aVendorSwVersion, const char *aVendorData,
+                  otJoinerCallback aCallback, void *aContext);
 
     /**
      * This method stops the Joiner service.
      *
-     * @retval kThreadError_None  Successfully stopped the Joiner service.
+     * @retval OT_ERROR_NONE  Successfully stopped the Joiner service.
      *
      */
-    ThreadError Stop(void);
+    otError Stop(void);
 
 private:
     enum
@@ -112,16 +112,16 @@ private:
     void HandleTimer(void);
 
     void Close(void);
-    void Complete(ThreadError aError);
+    void Complete(otError aError);
 
     static void HandleSecureCoapClientConnect(bool aConnected, void *aContext);
     void HandleSecureCoapClientConnect(bool aConnected);
 
     void SendJoinerFinalize(void);
     static void HandleJoinerFinalizeResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                             const otMessageInfo *aMessageInfo, ThreadError aResult);
+                                             const otMessageInfo *aMessageInfo, otError aResult);
     void HandleJoinerFinalizeResponse(Coap::Header *aHeader, Message *aMessage,
-                                      const Ip6::MessageInfo *aMessageInfo, ThreadError aResult);
+                                      const Ip6::MessageInfo *aMessageInfo, otError aResult);
 
     static void HandleJoinerEntrust(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
                                     const otMessageInfo *aMessageInfo);

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -112,14 +112,14 @@ exit:
     return;
 }
 
-ThreadError JoinerRouter::GetBorderAgentRloc(uint16_t &aRloc)
+otError JoinerRouter::GetBorderAgentRloc(uint16_t &aRloc)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     BorderAgentLocatorTlv *borderAgentLocator;
 
     borderAgentLocator = static_cast<BorderAgentLocatorTlv *>(mNetif.GetNetworkDataLeader().GetCommissioningDataSubTlv(
                                                                   Tlv::kBorderAgentLocator));
-    VerifyOrExit(borderAgentLocator != NULL, error = kThreadError_NotFound);
+    VerifyOrExit(borderAgentLocator != NULL, error = OT_ERROR_NOT_FOUND);
 
     aRloc = borderAgentLocator->GetBorderAgentLocator();
 
@@ -144,14 +144,14 @@ exit:
     return rval;
 }
 
-ThreadError JoinerRouter::SetJoinerUdpPort(uint16_t aJoinerUdpPort)
+otError JoinerRouter::SetJoinerUdpPort(uint16_t aJoinerUdpPort)
 {
     otLogFuncEntry();
     mJoinerUdpPort = aJoinerUdpPort;
     mIsJoinerPortConfigured = true;
     HandleNetifStateChanged(OT_THREAD_NETDATA_UPDATED);
     otLogFuncExit();
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 void JoinerRouter::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
@@ -162,7 +162,7 @@ void JoinerRouter::HandleUdpReceive(void *aContext, otMessage *aMessage, const o
 
 void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error;
+    otError error;
     Message *message = NULL;
     Coap::Header header;
     Ip6::MessageInfo messageInfo;
@@ -183,7 +183,7 @@ void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &a
     header.AppendUriPathOptions(OT_URI_PATH_RELAY_RX);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     udpPort.Init();
     udpPort.SetUdpPort(aMessageInfo.GetPeerPort());
@@ -228,7 +228,7 @@ void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &a
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -246,7 +246,7 @@ void JoinerRouter::HandleRelayTransmit(void *aContext, otCoapHeader *aHeader, ot
 
 void JoinerRouter::HandleRelayTransmit(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error;
+    otError error;
     JoinerUdpPortTlv joinerPort;
     JoinerIidTlv joinerIid;
     JoinerRouterKekTlv kek;
@@ -257,19 +257,19 @@ void JoinerRouter::HandleRelayTransmit(Coap::Header &aHeader, Message &aMessage,
 
     otLogFuncEntry();
     VerifyOrExit(aHeader.GetType() == kCoapTypeNonConfirmable &&
-                 aHeader.GetCode() == kCoapRequestPost, error = kThreadError_Drop);
+                 aHeader.GetCode() == kCoapRequestPost, error = OT_ERROR_DROP);
 
     otLogInfoMeshCoP(GetInstance(), "Received relay transmit");
 
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kJoinerUdpPort, sizeof(joinerPort), joinerPort));
-    VerifyOrExit(joinerPort.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(joinerPort.IsValid(), error = OT_ERROR_PARSE);
 
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kJoinerIid, sizeof(joinerIid), joinerIid));
-    VerifyOrExit(joinerIid.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(joinerIid.IsValid(), error = OT_ERROR_PARSE);
 
     SuccessOrExit(error = Tlv::GetValueOffset(aMessage, Tlv::kJoinerDtlsEncapsulation, offset, length));
 
-    VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = OT_ERROR_NO_BUFS);
     message->SetPriority(kMeshCoPMessagePriority);
     message->SetLinkSecurityEnabled(false);
 
@@ -299,7 +299,7 @@ void JoinerRouter::HandleRelayTransmit(Coap::Header &aHeader, Message &aMessage,
 
     SuccessOrExit(error = mSocket.SendTo(*message, messageInfo));
 
-    if (Tlv::GetTlv(aMessage, Tlv::kJoinerRouterKek, sizeof(kek), kek) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kJoinerRouterKek, sizeof(kek), kek) == OT_ERROR_NONE)
     {
         otLogInfoMeshCoP(GetInstance(), "Received kek");
 
@@ -309,7 +309,7 @@ void JoinerRouter::HandleRelayTransmit(Coap::Header &aHeader, Message &aMessage,
 exit:
     (void)aMessageInfo;
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -318,10 +318,10 @@ exit:
 }
 
 
-ThreadError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessageInfo,
-                                                    const JoinerRouterKekTlv &aKek)
+otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessageInfo,
+                                                const JoinerRouterKekTlv &aKek)
 {
-    ThreadError error;
+    otError error;
     Message *message = NULL;
     Coap::Header header;
     Ip6::MessageInfo messageInfo;
@@ -341,7 +341,7 @@ ThreadError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMes
     header.AppendUriPathOptions(OT_URI_PATH_JOINER_ENTRUST);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = OT_ERROR_NO_BUFS);
     message->SetSubType(Message::kSubTypeJoinerEntrust);
 
     masterKey.Init();
@@ -422,7 +422,7 @@ ThreadError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMes
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -475,7 +475,7 @@ void JoinerRouter::SendDelayedJoinerEntrust(void)
         // Send the message.
         memcpy(&messageInfo, delayedJoinEnt.GetMessageInfo(), sizeof(messageInfo));
 
-        if (SendJoinerEntrust(*message, messageInfo) != kThreadError_None)
+        if (SendJoinerEntrust(*message, messageInfo) != OT_ERROR_NONE)
         {
             message->Free();
             mTimer.Start(0);
@@ -486,9 +486,9 @@ exit:
     return ;
 }
 
-ThreadError JoinerRouter::SendJoinerEntrust(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError JoinerRouter::SendJoinerEntrust(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error;
+    otError error;
 
     mNetif.GetCoap().AbortTransaction(&JoinerRouter::HandleJoinerEntrustResponse, this);
 
@@ -506,7 +506,7 @@ exit:
 }
 
 void JoinerRouter::HandleJoinerEntrustResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                               const otMessageInfo *aMessageInfo, ThreadError aResult)
+                                               const otMessageInfo *aMessageInfo, otError aResult)
 {
     static_cast<JoinerRouter *>(aContext)->HandleJoinerEntrustResponse(static_cast<Coap::Header *>(aHeader),
                                                                        static_cast<Message *>(aMessage),
@@ -515,14 +515,14 @@ void JoinerRouter::HandleJoinerEntrustResponse(void *aContext, otCoapHeader *aHe
 }
 
 void JoinerRouter::HandleJoinerEntrustResponse(Coap::Header *aHeader, Message *aMessage,
-                                               const Ip6::MessageInfo *aMessageInfo, ThreadError aResult)
+                                               const Ip6::MessageInfo *aMessageInfo, otError aResult)
 {
     (void)aMessageInfo;
 
     mExpectJoinEntRsp = false;
     SendDelayedJoinerEntrust();
 
-    VerifyOrExit(aResult == kThreadError_None && aHeader != NULL && aMessage != NULL);
+    VerifyOrExit(aResult == OT_ERROR_NONE && aHeader != NULL && aMessage != NULL);
 
     VerifyOrExit(aHeader->GetCode() == kCoapResponseChanged);
 

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -83,10 +83,10 @@ public:
      *
      * @param[in]  The Joiner UDP Port number.
      *
-     * @retval kThreadError_None    Successfully set the Joiner UDP Port.
+     * @retval OT_ERROR_NONE    Successfully set the Joiner UDP Port.
      *
      */
-    ThreadError SetJoinerUdpPort(uint16_t aJoinerUdpPort);
+    otError SetJoinerUdpPort(uint16_t aJoinerUdpPort);
 
 private:
     enum
@@ -105,18 +105,18 @@ private:
     void HandleRelayTransmit(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     static void HandleJoinerEntrustResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                            const otMessageInfo *aMessageInfo, ThreadError result);
+                                            const otMessageInfo *aMessageInfo, otError result);
     void HandleJoinerEntrustResponse(Coap::Header *aHeader, Message *aMessage,
-                                     const Ip6::MessageInfo *aMessageInfo, ThreadError result);
+                                     const Ip6::MessageInfo *aMessageInfo, otError result);
 
     static void HandleTimer(void *aContext);
     void HandleTimer(void);
 
-    ThreadError DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessageInfo, const JoinerRouterKekTlv &aKek);
+    otError DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessageInfo, const JoinerRouterKekTlv &aKek);
     void SendDelayedJoinerEntrust(void);
-    ThreadError SendJoinerEntrust(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError SendJoinerEntrust(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    ThreadError GetBorderAgentRloc(uint16_t &aRloc);
+    otError GetBorderAgentRloc(uint16_t &aRloc);
 
     Ip6::NetifCallback mNetifCallback;
 
@@ -164,11 +164,11 @@ public:
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None    Successfully appended the bytes.
-     * @retval kThreadError_NoBufs  Insufficient available buffers to grow the message.
+     * @retval OT_ERROR_NONE     Successfully appended the bytes.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
      *
      */
-    ThreadError AppendTo(Message &aMessage) {
+    otError AppendTo(Message &aMessage) {
         return aMessage.Append(this, sizeof(*this));
     }
 
@@ -189,10 +189,10 @@ public:
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None  Successfully removed the header.
+     * @retval OT_ERROR_NONE  Successfully removed the header.
      *
      */
-    static ThreadError RemoveFrom(Message &aMessage) {
+    static otError RemoveFrom(Message &aMessage) {
         return aMessage.SetLength(aMessage.GetLength() - sizeof(DelayedJoinEntHeader));
     }
 

--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -119,10 +119,10 @@ exit:
     SendPetitionResponse(aHeader, aMessageInfo, state);
 }
 
-ThreadError Leader::SendPetitionResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
-                                         StateTlv::State aState)
+otError Leader::SendPetitionResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
+                                     StateTlv::State aState)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header responseHeader;
     StateTlv state;
     CommissionerSessionIdTlv sessionId;
@@ -131,7 +131,7 @@ ThreadError Leader::SendPetitionResponse(const Coap::Header &aRequestHeader, con
     responseHeader.SetDefaultResponseHeader(aRequestHeader);
     responseHeader.SetPayloadMarker();
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), responseHeader)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), responseHeader)) != NULL, error = OT_ERROR_NO_BUFS);
 
     state.Init();
     state.SetState(aState);
@@ -156,7 +156,7 @@ ThreadError Leader::SendPetitionResponse(const Coap::Header &aRequestHeader, con
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -208,10 +208,10 @@ exit:
     return;
 }
 
-ThreadError Leader::SendKeepAliveResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
-                                          StateTlv::State aState)
+otError Leader::SendKeepAliveResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
+                                      StateTlv::State aState)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header responseHeader;
     StateTlv state;
     Message *message;
@@ -220,7 +220,7 @@ ThreadError Leader::SendKeepAliveResponse(const Coap::Header &aRequestHeader, co
     responseHeader.SetDefaultResponseHeader(aRequestHeader);
     responseHeader.SetPayloadMarker();
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), responseHeader)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), responseHeader)) != NULL, error = OT_ERROR_NO_BUFS);
 
     state.Init();
     state.SetState(aState);
@@ -232,7 +232,7 @@ ThreadError Leader::SendKeepAliveResponse(const Coap::Header &aRequestHeader, co
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -240,9 +240,9 @@ exit:
     return error;
 }
 
-ThreadError Leader::SendDatasetChanged(const Ip6::Address &aAddress)
+otError Leader::SendDatasetChanged(const Ip6::Address &aAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header header;
     Ip6::MessageInfo messageInfo;
     Message *message;
@@ -251,7 +251,7 @@ ThreadError Leader::SendDatasetChanged(const Ip6::Address &aAddress)
     header.SetToken(Coap::Header::kDefaultTokenLength);
     header.AppendUriPathOptions(OT_URI_PATH_DATASET_CHANGED);
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     messageInfo.SetSockAddr(mNetif.GetMle().GetMeshLocal16());
     messageInfo.SetPeerAddr(aAddress);
@@ -262,7 +262,7 @@ ThreadError Leader::SendDatasetChanged(const Ip6::Address &aAddress)
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -270,11 +270,11 @@ exit:
     return error;
 }
 
-ThreadError Leader::SetDelayTimerMinimal(uint32_t aDelayTimerMinimal)
+otError Leader::SetDelayTimerMinimal(uint32_t aDelayTimerMinimal)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     VerifyOrExit((aDelayTimerMinimal != 0 && aDelayTimerMinimal < DelayTimerTlv::kDelayTimerDefault),
-                 error = kThreadError_InvalidArgs);
+                 error = OT_ERROR_INVALID_ARGS);
     mDelayTimerMinimal = aDelayTimerMinimal;
 
 exit:

--- a/src/core/meshcop/leader.hpp
+++ b/src/core/meshcop/leader.hpp
@@ -82,22 +82,22 @@ public:
      *
      * @param[in]  aAddress   The IPv6 address of destination.
      *
-     * @retval kThreadError_None    Successfully send MGMT_DATASET_CHANGED message.
-     * @retval kThreadError_NoBufs  Insufficient buffers to generate a MGMT_DATASET_CHANGED message.
+     * @retval OT_ERROR_NONE     Successfully send MGMT_DATASET_CHANGED message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers to generate a MGMT_DATASET_CHANGED message.
      *
      */
-    ThreadError SendDatasetChanged(const Ip6::Address &aAddress);
+    otError SendDatasetChanged(const Ip6::Address &aAddress);
 
     /**
      * This method sets minimal delay timer.
      *
      * @param[in]  aDelayTimerMinimal The value of minimal delay timer (in ms).
      *
-     * @retval  kThreadError_None        Successfully set the minimal delay timer.
-     * @retval  kThreadError_InvalidArgs If @p aDelayTimerMinimal is not valid.
+     * @retval  OT_ERROR_NONE         Successfully set the minimal delay timer.
+     * @retval  OT_ERROR_INVALID_ARGS If @p aDelayTimerMinimal is not valid.
      *
      */
-    ThreadError SetDelayTimerMinimal(uint32_t aDelayTimerMinimal);
+    otError SetDelayTimerMinimal(uint32_t aDelayTimerMinimal);
 
     /**
      * This method gets minimal delay timer.
@@ -125,14 +125,14 @@ private:
     static void HandlePetition(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
                                const otMessageInfo *aMessageInfo);
     void HandlePetition(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError SendPetitionResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
-                                     StateTlv::State aState);
+    otError SendPetitionResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
+                                 StateTlv::State aState);
 
     static void HandleKeepAlive(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
                                 const otMessageInfo *aMessageInfo);
     void HandleKeepAlive(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError SendKeepAliveResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
-                                      StateTlv::State aState);
+    otError SendKeepAliveResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
+                                  StateTlv::State aState);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -142,11 +142,11 @@ public:
      * @param[in]   aMaxLength  Maximum number of bytes to read.
      * @param[out]  aTlv        A reference to the TLV that will be copied to.
      *
-     * @retval kThreadError_None      Successfully copied the TLV.
-     * @retval kThreadError_NotFound  Could not find the TLV with Type @p aType.
+     * @retval OT_ERROR_NONE       Successfully copied the TLV.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the TLV with Type @p aType.
      *
      */
-    static ThreadError GetTlv(const Message &aMessage, Type aType, uint16_t aMaxLength, Tlv &aTlv) {
+    static otError GetTlv(const Message &aMessage, Type aType, uint16_t aMaxLength, Tlv &aTlv) {
         return ot::Tlv::Get(aMessage, static_cast<uint8_t>(aType), aMaxLength, aTlv);
     }
 
@@ -158,11 +158,11 @@ public:
      * @param[out]  aOffset     The offset where the value starts.
      * @param[out]  aLength     The length of the value.
      *
-     * @retval kThreadError_None      Successfully found the TLV.
-     * @retval kThreadError_NotFound  Could not find the TLV with Type @p aType.
+     * @retval OT_ERROR_NONE       Successfully found the TLV.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the TLV with Type @p aType.
      *
      */
-    static ThreadError GetValueOffset(const Message &aMessage, Type aType, uint16_t &aOffset, uint16_t &aLength) {
+    static otError GetValueOffset(const Message &aMessage, Type aType, uint16_t &aOffset, uint16_t &aLength) {
         return ot::Tlv::GetValueOffset(aMessage, static_cast<uint8_t>(aType), aOffset, aLength);
     }
 
@@ -1528,11 +1528,11 @@ public:
      * @param[in]  aProvisioningUrl  A pointer to the Provisioning URL value.
      *
      */
-    ThreadError SetProvisioningUrl(const char *aProvisioningUrl) {
-        ThreadError error = kThreadError_None;
+    otError SetProvisioningUrl(const char *aProvisioningUrl) {
+        otError error = OT_ERROR_NONE;
         size_t len = aProvisioningUrl ? strnlen(aProvisioningUrl, kMaxLength + 1) : 0;
 
-        VerifyOrExit(len <= kMaxLength, error = kThreadError_InvalidArgs);
+        VerifyOrExit(len <= kMaxLength, error = OT_ERROR_INVALID_ARGS);
         SetLength(static_cast<uint8_t>(len));
 
         if (len > 0) {
@@ -1589,11 +1589,11 @@ public:
      * @param[in]  aVendorName  A pointer to the Vendor Name value.
      *
      */
-    ThreadError SetVendorName(const char *aVendorName) {
-        ThreadError error = kThreadError_None;
+    otError SetVendorName(const char *aVendorName) {
+        otError error = OT_ERROR_NONE;
         size_t len = (aVendorName == NULL) ? 0 : strnlen(aVendorName, sizeof(mVendorName) + 1);
 
-        VerifyOrExit(len <= sizeof(mVendorName), error = kThreadError_InvalidArgs);
+        VerifyOrExit(len <= sizeof(mVendorName), error = OT_ERROR_INVALID_ARGS);
         SetLength(static_cast<uint8_t>(len));
 
         if (len > 0) {
@@ -1650,11 +1650,11 @@ public:
      * @param[in]  aVendorModel  A pointer to the Vendor Model value.
      *
      */
-    ThreadError SetVendorModel(const char *aVendorModel) {
-        ThreadError error = kThreadError_None;
+    otError SetVendorModel(const char *aVendorModel) {
+        otError error = OT_ERROR_NONE;
         size_t len = (aVendorModel == NULL) ? 0 : strnlen(aVendorModel, sizeof(mVendorModel) + 1);
 
-        VerifyOrExit(len <= sizeof(mVendorModel), error = kThreadError_InvalidArgs);
+        VerifyOrExit(len <= sizeof(mVendorModel), error = OT_ERROR_INVALID_ARGS);
         SetLength(static_cast<uint8_t>(len));
 
         if (len > 0) {
@@ -1711,11 +1711,11 @@ public:
      * @param[in]  aVendorSwVersion  A pointer to the Vendor SW Version value.
      *
      */
-    ThreadError SetVendorSwVersion(const char *aVendorSwVersion) {
-        ThreadError error = kThreadError_None;
+    otError SetVendorSwVersion(const char *aVendorSwVersion) {
+        otError error = OT_ERROR_NONE;
         size_t len = (aVendorSwVersion == NULL) ? 0 : strnlen(aVendorSwVersion, sizeof(mVendorSwVersion) + 1);
 
-        VerifyOrExit(len <= sizeof(mVendorSwVersion), error = kThreadError_InvalidArgs);
+        VerifyOrExit(len <= sizeof(mVendorSwVersion), error = OT_ERROR_INVALID_ARGS);
         SetLength(static_cast<uint8_t>(len));
 
         if (len > 0) {
@@ -1772,11 +1772,11 @@ public:
      * @param[in]  aVendorData  A pointer to the Vendor Data value.
      *
      */
-    ThreadError SetVendorData(const char *aVendorData) {
-        ThreadError error = kThreadError_None;
+    otError SetVendorData(const char *aVendorData) {
+        otError error = OT_ERROR_NONE;
         size_t len = (aVendorData == NULL) ? 0 : strnlen(aVendorData, sizeof(mVendorData) + 1);
 
-        VerifyOrExit(len <= sizeof(mVendorData), error = kThreadError_InvalidArgs);
+        VerifyOrExit(len <= sizeof(mVendorData), error = OT_ERROR_INVALID_ARGS);
         SetLength(static_cast<uint8_t>(len));
 
         if (len > 0) {

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -70,10 +70,10 @@ otInstance *PanIdQueryClient::GetInstance(void)
     return mNetif.GetInstance();
 }
 
-ThreadError PanIdQueryClient::SendQuery(uint16_t aPanId, uint32_t aChannelMask, const Ip6::Address &aAddress,
-                                        otCommissionerPanIdConflictCallback aCallback, void *aContext)
+otError PanIdQueryClient::SendQuery(uint16_t aPanId, uint32_t aChannelMask, const Ip6::Address &aAddress,
+                                    otCommissionerPanIdConflictCallback aCallback, void *aContext)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header header;
     MeshCoP::CommissionerSessionIdTlv sessionId;
     MeshCoP::ChannelMask0Tlv channelMask;
@@ -81,7 +81,7 @@ ThreadError PanIdQueryClient::SendQuery(uint16_t aPanId, uint32_t aChannelMask, 
     Ip6::MessageInfo messageInfo;
     Message *message = NULL;
 
-    VerifyOrExit(mNetif.GetCommissioner().GetState() == kCommissionerStateActive, error = kThreadError_InvalidState);
+    VerifyOrExit(mNetif.GetCommissioner().GetState() == kCommissionerStateActive, error = OT_ERROR_INVALID_STATE);
 
     header.Init(aAddress.IsMulticast() ? kCoapTypeNonConfirmable : kCoapTypeConfirmable,
                 kCoapRequestPost);
@@ -90,7 +90,7 @@ ThreadError PanIdQueryClient::SendQuery(uint16_t aPanId, uint32_t aChannelMask, 
     header.SetPayloadMarker();
 
     VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL,
-                 error = kThreadError_NoBufs);
+                 error = OT_ERROR_NO_BUFS);
 
     sessionId.Init();
     sessionId.SetCommissionerSessionId(mNetif.GetCommissioner().GetSessionId());
@@ -117,7 +117,7 @@ ThreadError PanIdQueryClient::SendQuery(uint16_t aPanId, uint32_t aChannelMask, 
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }

--- a/src/core/meshcop/panid_query_client.hpp
+++ b/src/core/meshcop/panid_query_client.hpp
@@ -75,12 +75,12 @@ public:
      * @param[in]  aCallback      A pointer to a function called on receiving an Energy Report message.
      * @param[in]  aContext       A pointer to application-specific context.
      *
-     * @retval kThreadError_None    Successfully enqueued the PAN ID Query message.
-     * @retval kThreadError_NoBufs  Insufficient buffers to generate a PAN ID Query message.
+     * @retval OT_ERROR_NONE     Successfully enqueued the PAN ID Query message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers to generate a PAN ID Query message.
      *
      */
-    ThreadError SendQuery(uint16_t aPanId, uint32_t aChannelMask, const Ip6::Address &aAddress,
-                          otCommissionerPanIdConflictCallback aCallback, void *aContext);
+    otError SendQuery(uint16_t aPanId, uint32_t aChannelMask, const Ip6::Address &aAddress,
+                      otCommissionerPanIdConflictCallback aCallback, void *aContext);
 
 private:
     static void HandleConflict(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -108,7 +108,7 @@ void Dhcp6Client::UpdateAddresses(otInstance *aInstance, otDhcpAddress *aAddress
         found = false;
         iterator = OT_NETWORK_DATA_ITERATOR_INIT;
 
-        while ((otNetDataGetNextPrefixInfo(aInstance, false, &iterator, &config)) == kThreadError_None)
+        while ((otNetDataGetNextPrefixInfo(aInstance, false, &iterator, &config)) == OT_ERROR_NONE)
         {
             if (!config.mDhcp)
             {
@@ -135,7 +135,7 @@ void Dhcp6Client::UpdateAddresses(otInstance *aInstance, otDhcpAddress *aAddress
     // add IdentityAssociation for new configured prefix
     iterator = OT_NETWORK_DATA_ITERATOR_INIT;
 
-    while (otNetDataGetNextPrefixInfo(aInstance, false, &iterator, &config) == kThreadError_None)
+    while (otNetDataGetNextPrefixInfo(aInstance, false, &iterator, &config) == OT_ERROR_NONE)
     {
         if (!config.mDhcp)
         {
@@ -270,7 +270,7 @@ exit:
     return;
 }
 
-ThreadError Dhcp6Client::Start(void)
+otError Dhcp6Client::Start(void)
 {
     Ip6::SockAddr sockaddr;
 
@@ -280,13 +280,13 @@ ThreadError Dhcp6Client::Start(void)
 
     ProcessNextIdentityAssociation();
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Dhcp6Client::Stop(void)
+otError Dhcp6Client::Stop(void)
 {
     mSocket.Close();
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 bool Dhcp6Client::ProcessNextIdentityAssociation()
@@ -379,13 +379,13 @@ exit:
     return rval;
 }
 
-ThreadError Dhcp6Client::Solicit(uint16_t aRloc16)
+otError Dhcp6Client::Solicit(uint16_t aRloc16)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Message *message;
     Ip6::MessageInfo messageInfo;
 
-    VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = OT_ERROR_NO_BUFS);
 
     SuccessOrExit(error = AppendHeader(*message));
     SuccessOrExit(error = AppendElapsedTime(*message));
@@ -410,7 +410,7 @@ ThreadError Dhcp6Client::Solicit(uint16_t aRloc16)
 
 exit:
 
-    if (message != NULL && error != kThreadError_None)
+    if (message != NULL && error != OT_ERROR_NONE)
     {
         message->Free();
     }
@@ -418,7 +418,7 @@ exit:
     return error;
 }
 
-ThreadError Dhcp6Client::AppendHeader(Message &aMessage)
+otError Dhcp6Client::AppendHeader(Message &aMessage)
 {
     Dhcp6Header header;
 
@@ -428,7 +428,7 @@ ThreadError Dhcp6Client::AppendHeader(Message &aMessage)
     return aMessage.Append(&header, sizeof(header));
 }
 
-ThreadError Dhcp6Client::AppendElapsedTime(Message &aMessage)
+otError Dhcp6Client::AppendElapsedTime(Message &aMessage)
 {
     ElapsedTime option;
 
@@ -437,7 +437,7 @@ ThreadError Dhcp6Client::AppendElapsedTime(Message &aMessage)
     return aMessage.Append(&option, sizeof(option));
 }
 
-ThreadError Dhcp6Client::AppendClientIdentifier(Message &aMessage)
+otError Dhcp6Client::AppendClientIdentifier(Message &aMessage)
 {
     ClientIdentifier option;
 
@@ -448,15 +448,15 @@ ThreadError Dhcp6Client::AppendClientIdentifier(Message &aMessage)
     return aMessage.Append(&option, sizeof(option));
 }
 
-ThreadError Dhcp6Client::AppendIaNa(Message &aMessage, uint16_t aRloc16)
+otError Dhcp6Client::AppendIaNa(Message &aMessage, uint16_t aRloc16)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t count = 0;
     uint16_t length = 0;
     IdentityAssociation *identityAssociation = NULL;
     IaNa option;
 
-    VerifyOrExit(mIdentityAssociationHead, error = kThreadError_Drop);
+    VerifyOrExit(mIdentityAssociationHead, error = OT_ERROR_DROP);
 
     for (identityAssociation = mIdentityAssociationHead; identityAssociation;
          identityAssociation = identityAssociation->GetNext())
@@ -486,13 +486,13 @@ exit:
     return error;
 }
 
-ThreadError Dhcp6Client::AppendIaAddress(Message &aMessage, uint16_t aRloc16)
+otError Dhcp6Client::AppendIaAddress(Message &aMessage, uint16_t aRloc16)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     IdentityAssociation *identityAssociation = NULL;
     IaAddress option;
 
-    VerifyOrExit(mIdentityAssociationHead, error = kThreadError_Drop);
+    VerifyOrExit(mIdentityAssociationHead, error = OT_ERROR_DROP);
 
     option.Init();
 
@@ -513,7 +513,7 @@ exit:
     return error;
 }
 
-ThreadError Dhcp6Client::AppendRapidCommit(Message &aMessage)
+otError Dhcp6Client::AppendRapidCommit(Message &aMessage)
 {
     RapidCommit option;
 
@@ -592,23 +592,23 @@ exit:
     return 0;
 }
 
-ThreadError Dhcp6Client::ProcessServerIdentifier(Message &aMessage, uint16_t aOffset)
+otError Dhcp6Client::ProcessServerIdentifier(Message &aMessage, uint16_t aOffset)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     ServerIdentifier option;
 
     VerifyOrExit(((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)) &&
                   (option.GetLength() == (sizeof(option) - sizeof(Dhcp6Option))) &&
                   (option.GetDuidType() == kDuidLL) &&
                   (option.GetDuidHardwareType() == kHardwareTypeEui64)),
-                 error = kThreadError_Parse);
+                 error = OT_ERROR_PARSE);
 exit:
     return error;
 }
 
-ThreadError Dhcp6Client::ProcessClientIdentifier(Message &aMessage, uint16_t aOffset)
+otError Dhcp6Client::ProcessClientIdentifier(Message &aMessage, uint16_t aOffset)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     ClientIdentifier option;
 
     VerifyOrExit((((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)) &&
@@ -617,24 +617,24 @@ ThreadError Dhcp6Client::ProcessClientIdentifier(Message &aMessage, uint16_t aOf
                    (option.GetDuidHardwareType() == kHardwareTypeEui64)) &&
                   (!memcmp(option.GetDuidLinkLayerAddress(), mNetif.GetMac().GetExtAddress(),
                            sizeof(Mac::ExtAddress)))),
-                 error = kThreadError_Parse);
+                 error = OT_ERROR_PARSE);
 exit:
     return error;
 }
 
-ThreadError Dhcp6Client::ProcessIaNa(Message &aMessage, uint16_t aOffset)
+otError Dhcp6Client::ProcessIaNa(Message &aMessage, uint16_t aOffset)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     IaNa option;
     uint16_t optionOffset;
     uint16_t length;
 
-    VerifyOrExit(aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option), error = kThreadError_Parse);
+    VerifyOrExit(aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option), error = OT_ERROR_PARSE);
 
     aOffset += sizeof(option);
     length = option.GetLength() - (sizeof(option) - sizeof(Dhcp6Option));
 
-    VerifyOrExit(length <= aMessage.GetLength() - aOffset, error = kThreadError_Parse);
+    VerifyOrExit(length <= aMessage.GetLength() - aOffset, error = OT_ERROR_PARSE);
 
     if ((optionOffset = FindOption(aMessage, aOffset, length, kOptionStatusCode)) > 0)
     {
@@ -658,23 +658,23 @@ exit:
     return error;
 }
 
-ThreadError Dhcp6Client::ProcessStatusCode(Message &aMessage, uint16_t aOffset)
+otError Dhcp6Client::ProcessStatusCode(Message &aMessage, uint16_t aOffset)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     StatusCode option;
 
     VerifyOrExit(((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)) &&
                   (option.GetLength() == (sizeof(option) - sizeof(Dhcp6Option))) &&
                   (option.GetStatusCode() == kStatusSuccess)),
-                 error = kThreadError_Parse);
+                 error = OT_ERROR_PARSE);
 
 exit:
     return error;
 }
 
-ThreadError Dhcp6Client::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
+otError Dhcp6Client::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     IdentityAssociation *identityAssociation = NULL;
     otDhcpAddress *address = NULL;
     otIp6Prefix *prefix  = NULL;
@@ -683,7 +683,7 @@ ThreadError Dhcp6Client::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
 
     VerifyOrExit(((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)) &&
                   (option.GetLength() == (sizeof(option) - sizeof(Dhcp6Option)))),
-                 error = kThreadError_Parse);
+                 error = OT_ERROR_PARSE);
 
     for (uint8_t i = 0; i < mNumAddresses; i++)
     {

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -198,33 +198,33 @@ public:
     void UpdateAddresses(otInstance *aInstance, otDhcpAddress *aAddresses, uint32_t aNumAddresses, void *aContext);
 
 private:
-    ThreadError Start(void);
-    ThreadError Stop(void);
+    otError Start(void);
+    otError Stop(void);
 
-    ThreadError Solicit(uint16_t aRloc16);
+    otError Solicit(uint16_t aRloc16);
 
     void AddIdentityAssociation(uint16_t aRloc16, otIp6Prefix &aIp6Prefix);
     void RemoveIdentityAssociation(uint16_t aRloc16, otIp6Prefix &aIp6Prefix);
 
     bool ProcessNextIdentityAssociation(void);
 
-    ThreadError AppendHeader(Message &aMessage);
-    ThreadError AppendClientIdentifier(Message &aMessage);
-    ThreadError AppendIaNa(Message &aMessage, uint16_t aRloc16);
-    ThreadError AppendIaAddress(Message &aMessage, uint16_t aRloc16);
-    ThreadError AppendElapsedTime(Message &aMessage);
-    ThreadError AppendRapidCommit(Message &aMessage);
+    otError AppendHeader(Message &aMessage);
+    otError AppendClientIdentifier(Message &aMessage);
+    otError AppendIaNa(Message &aMessage, uint16_t aRloc16);
+    otError AppendIaAddress(Message &aMessage, uint16_t aRloc16);
+    otError AppendElapsedTime(Message &aMessage);
+    otError AppendRapidCommit(Message &aMessage);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     void ProcessReply(Message &aMessage);
     uint16_t FindOption(Message &aMessage, uint16_t aOffset, uint16_t aLength, Code aCode);
-    ThreadError ProcessServerIdentifier(Message &aMessage, uint16_t aOffset);
-    ThreadError ProcessClientIdentifier(Message &aMessage, uint16_t aOffset);
-    ThreadError ProcessIaNa(Message &aMessage, uint16_t aOffset);
-    ThreadError ProcessStatusCode(Message &aMessage, uint16_t aOffset);
-    ThreadError ProcessIaAddress(Message &aMessage, uint16_t aOffset);
+    otError ProcessServerIdentifier(Message &aMessage, uint16_t aOffset);
+    otError ProcessClientIdentifier(Message &aMessage, uint16_t aOffset);
+    otError ProcessIaNa(Message &aMessage, uint16_t aOffset);
+    otError ProcessStatusCode(Message &aMessage, uint16_t aOffset);
+    otError ProcessIaAddress(Message &aMessage, uint16_t aOffset);
 
     static bool HandleTrickleTimer(void *aContext);
     bool HandleTrickleTimer(void);

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -71,9 +71,9 @@ Dhcp6Server::Dhcp6Server(ThreadNetif &aThreadNetif):
     mPrefixAgentsMask = 0;
 }
 
-ThreadError Dhcp6Server::UpdateService(void)
+otError Dhcp6Server::UpdateService(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     bool found;
     uint8_t i;
     uint16_t rloc16 = mNetif.GetMle().GetRloc16();
@@ -95,7 +95,7 @@ ThreadError Dhcp6Server::UpdateService(void)
         address = &(mAgentsAloc[i].GetAddress());
         iterator = OT_NETWORK_DATA_ITERATOR_INIT;
 
-        while (mNetif.GetNetworkDataLeader().GetNextOnMeshPrefix(&iterator, rloc16, &config) == kThreadError_None)
+        while (mNetif.GetNetworkDataLeader().GetNextOnMeshPrefix(&iterator, rloc16, &config) == OT_ERROR_NONE)
         {
             if (!config.mDhcp)
             {
@@ -125,7 +125,7 @@ ThreadError Dhcp6Server::UpdateService(void)
     // add dhcp agent aloc and prefix delegation
     iterator = OT_NETWORK_DATA_ITERATOR_INIT;
 
-    while (mNetif.GetNetworkDataLeader().GetNextOnMeshPrefix(&iterator, rloc16, &config) == kThreadError_None)
+    while (mNetif.GetNetworkDataLeader().GetNextOnMeshPrefix(&iterator, rloc16, &config) == OT_ERROR_NONE)
     {
         found = false;
 
@@ -177,7 +177,7 @@ ThreadError Dhcp6Server::UpdateService(void)
         // if no available Dhcp Agent Aloc resources
         if (i == OPENTHREAD_CONFIG_NUM_DHCP_PREFIXES)
         {
-            ExitNow(error = kThreadError_NoBufs);
+            ExitNow(error = OT_ERROR_NO_BUFS);
         }
     }
 
@@ -194,25 +194,25 @@ exit:
     return error;
 }
 
-ThreadError Dhcp6Server::Start(void)
+otError Dhcp6Server::Start(void)
 {
     Ip6::SockAddr sockaddr;
     sockaddr.mPort = kDhcpServerPort;
     mSocket.Open(&Dhcp6Server::HandleUdpReceive, this);
     mSocket.Bind(sockaddr);
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Dhcp6Server::Stop(void)
+otError Dhcp6Server::Stop(void)
 {
     mSocket.Close();
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Dhcp6Server::AddPrefixAgent(otIp6Prefix &aIp6Prefix)
+otError Dhcp6Server::AddPrefixAgent(otIp6Prefix &aIp6Prefix)
 {
-    ThreadError error = kThreadError_NoBufs;
+    otError error = OT_ERROR_NO_BUFS;
 
     for (uint8_t i = 0; i < OPENTHREAD_CONFIG_NUM_DHCP_PREFIXES; i++)
     {
@@ -223,16 +223,16 @@ ThreadError Dhcp6Server::AddPrefixAgent(otIp6Prefix &aIp6Prefix)
 
         mPrefixAgents[i].SetPrefix(aIp6Prefix);
         mPrefixAgentsCount++;
-        ExitNow(error = kThreadError_None);
+        ExitNow(error = OT_ERROR_NONE);
     }
 
 exit:
     return error;
 }
 
-ThreadError Dhcp6Server::RemovePrefixAgent(const uint8_t *aIp6Address)
+otError Dhcp6Server::RemovePrefixAgent(const uint8_t *aIp6Address)
 {
-    ThreadError error = kThreadError_NotFound;
+    otError error = OT_ERROR_NOT_FOUND;
     otIp6Prefix *prefix = NULL;
 
     for (uint8_t i = 0; i < OPENTHREAD_CONFIG_NUM_DHCP_PREFIXES; i++)
@@ -248,7 +248,7 @@ ThreadError Dhcp6Server::RemovePrefixAgent(const uint8_t *aIp6Address)
         {
             memset(&(mPrefixAgents[i]), 0, sizeof(PrefixAgent));
             mPrefixAgentsCount--;
-            ExitNow(error = kThreadError_None);
+            ExitNow(error = OT_ERROR_NONE);
         }
     }
 
@@ -333,43 +333,43 @@ uint16_t Dhcp6Server::FindOption(Message &aMessage, uint16_t aOffset, uint16_t a
 exit:
     return 0;
 }
-ThreadError Dhcp6Server::ProcessClientIdentifier(Message &aMessage, uint16_t aOffset, ClientIdentifier &aClient)
+otError Dhcp6Server::ProcessClientIdentifier(Message &aMessage, uint16_t aOffset, ClientIdentifier &aClient)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     VerifyOrExit(((aMessage.Read(aOffset, sizeof(aClient), &aClient) == sizeof(aClient)) &&
                   (aClient.GetLength() == (sizeof(aClient) - sizeof(Dhcp6Option))) &&
                   (aClient.GetDuidType() == kDuidLL) &&
                   (aClient.GetDuidHardwareType() == kHardwareTypeEui64)),
-                 error = kThreadError_Parse);
+                 error = OT_ERROR_PARSE);
 exit:
     return error;
 }
 
-ThreadError Dhcp6Server::ProcessElapsedTime(Message &aMessage, uint16_t aOffset)
+otError Dhcp6Server::ProcessElapsedTime(Message &aMessage, uint16_t aOffset)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     ElapsedTime option;
 
     VerifyOrExit(((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)) &&
                   (option.GetLength() == ((sizeof(option) - sizeof(Dhcp6Option))))),
-                 error = kThreadError_Parse);
+                 error = OT_ERROR_PARSE);
 exit:
     return error;
 }
 
-ThreadError Dhcp6Server::ProcessIaNa(Message &aMessage, uint16_t aOffset, IaNa &aIaNa)
+otError Dhcp6Server::ProcessIaNa(Message &aMessage, uint16_t aOffset, IaNa &aIaNa)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint16_t optionOffset;
     uint16_t length;
 
-    VerifyOrExit((aMessage.Read(aOffset, sizeof(aIaNa), &aIaNa) == sizeof(aIaNa)), error = kThreadError_Parse);
+    VerifyOrExit((aMessage.Read(aOffset, sizeof(aIaNa), &aIaNa) == sizeof(aIaNa)), error = OT_ERROR_PARSE);
 
     aOffset += sizeof(aIaNa);
     length = aIaNa.GetLength() + sizeof(Dhcp6Option) - sizeof(IaNa);
 
-    VerifyOrExit(length <= aMessage.GetLength() - aOffset, error = kThreadError_Parse);
+    VerifyOrExit(length <= aMessage.GetLength() - aOffset, error = OT_ERROR_PARSE);
 
     mPrefixAgentsMask = 0;
 
@@ -386,15 +386,15 @@ exit:
     return error;
 }
 
-ThreadError Dhcp6Server::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
+otError Dhcp6Server::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otIp6Prefix *prefix = NULL;
     IaAddress option;
 
     VerifyOrExit(((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)) &&
                   option.GetLength() == (sizeof(option) - sizeof(Dhcp6Option))),
-                 error = kThreadError_Parse);
+                 error = OT_ERROR_PARSE);
 
     // mask matching prefix
     for (uint8_t i = 0; i < OPENTHREAD_CONFIG_NUM_DHCP_PREFIXES; i++)
@@ -417,13 +417,13 @@ exit:
     return error;
 }
 
-ThreadError Dhcp6Server::SendReply(otIp6Address &aDst, uint8_t *aTransactionId, ClientIdentifier &aClient, IaNa &aIaNa)
+otError Dhcp6Server::SendReply(otIp6Address &aDst, uint8_t *aTransactionId, ClientIdentifier &aClient, IaNa &aIaNa)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Ip6::MessageInfo messageInfo;
     Message *message;
 
-    VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, aTransactionId));
     SuccessOrExit(error = AppendServerIdentifier(*message));
     SuccessOrExit(error = AppendClientIdentifier(*message, aClient));
@@ -439,7 +439,7 @@ ThreadError Dhcp6Server::SendReply(otIp6Address &aDst, uint8_t *aTransactionId, 
 
 exit:
 
-    if (message != NULL && error != kThreadError_None)
+    if (message != NULL && error != OT_ERROR_NONE)
     {
         message->Free();
     }
@@ -447,7 +447,7 @@ exit:
     return error;
 }
 
-ThreadError Dhcp6Server::AppendHeader(Message &aMessage, uint8_t *aTransactionId)
+otError Dhcp6Server::AppendHeader(Message &aMessage, uint8_t *aTransactionId)
 {
     Dhcp6Header header;
 
@@ -457,14 +457,14 @@ ThreadError Dhcp6Server::AppendHeader(Message &aMessage, uint8_t *aTransactionId
     return aMessage.Append(&header, sizeof(header));
 }
 
-ThreadError Dhcp6Server::AppendClientIdentifier(Message &aMessage, ClientIdentifier &aClient)
+otError Dhcp6Server::AppendClientIdentifier(Message &aMessage, ClientIdentifier &aClient)
 {
     return aMessage.Append(&aClient, sizeof(aClient));
 }
 
-ThreadError Dhcp6Server::AppendServerIdentifier(Message &aMessage)
+otError Dhcp6Server::AppendServerIdentifier(Message &aMessage)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     ServerIdentifier option;
 
     option.Init();
@@ -477,9 +477,9 @@ exit:
     return error;
 }
 
-ThreadError Dhcp6Server::AppendIaNa(Message &aMessage, IaNa &aIaNa)
+otError Dhcp6Server::AppendIaNa(Message &aMessage, IaNa &aIaNa)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint16_t length = 0;
 
     if (mPrefixAgentsMask)
@@ -508,7 +508,7 @@ exit:
     return error;
 }
 
-ThreadError Dhcp6Server::AppendStatusCode(Message &aMessage, Status aStatus)
+otError Dhcp6Server::AppendStatusCode(Message &aMessage, Status aStatus)
 {
     StatusCode option;
 
@@ -517,9 +517,9 @@ ThreadError Dhcp6Server::AppendStatusCode(Message &aMessage, Status aStatus)
     return aMessage.Append(&option, sizeof(option));
 }
 
-ThreadError Dhcp6Server::AppendIaAddress(Message &aMessage, ClientIdentifier &aClient)
+otError Dhcp6Server::AppendIaAddress(Message &aMessage, ClientIdentifier &aClient)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     otIp6Prefix *prefix = NULL;
 
     // if specified, only apply specified prefixes
@@ -553,9 +553,9 @@ exit:
     return error;
 }
 
-ThreadError Dhcp6Server::AddIaAddress(Message &aMessage, otIp6Prefix &aIp6Prefix, ClientIdentifier &aClient)
+otError Dhcp6Server::AddIaAddress(Message &aMessage, otIp6Prefix &aIp6Prefix, ClientIdentifier &aClient)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     IaAddress option;
 
     option.Init();
@@ -568,7 +568,7 @@ exit:
     return error;
 }
 
-ThreadError Dhcp6Server::AppendRapidCommit(Message &aMessage)
+otError Dhcp6Server::AppendRapidCommit(Message &aMessage)
 {
     RapidCommit option;
 

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -114,25 +114,25 @@ public:
      * This method updates DHCP Agents and DHCP Alocs.
      *
      */
-    ThreadError UpdateService();
+    otError UpdateService();
 
 private:
-    ThreadError Start(void);
-    ThreadError Stop(void);
+    otError Start(void);
+    otError Stop(void);
 
-    ThreadError AddPrefixAgent(otIp6Prefix &aIp6Prefix);
-    ThreadError RemovePrefixAgent(const uint8_t *aIp6Address);
+    otError AddPrefixAgent(otIp6Prefix &aIp6Prefix);
+    otError RemovePrefixAgent(const uint8_t *aIp6Address);
 
-    ThreadError AppendHeader(Message &aMessage, uint8_t *aTransactionId);
-    ThreadError AppendClientIdentifier(Message &aMessage, ClientIdentifier &aClient);
-    ThreadError AppendServerIdentifier(Message &aMessage);
-    ThreadError AppendIaNa(Message &aMessage, IaNa &aIaNa);
-    ThreadError AppendStatusCode(Message &aMessage, Status aStatusCode);
-    ThreadError AppendIaAddress(Message &aMessage, ClientIdentifier &aClient);
-    ThreadError AppendRapidCommit(Message &aMessage);
-    ThreadError AppendVendorSpecificInformation(Message &aMessage);
+    otError AppendHeader(Message &aMessage, uint8_t *aTransactionId);
+    otError AppendClientIdentifier(Message &aMessage, ClientIdentifier &aClient);
+    otError AppendServerIdentifier(Message &aMessage);
+    otError AppendIaNa(Message &aMessage, IaNa &aIaNa);
+    otError AppendStatusCode(Message &aMessage, Status aStatusCode);
+    otError AppendIaAddress(Message &aMessage, ClientIdentifier &aClient);
+    otError AppendRapidCommit(Message &aMessage);
+    otError AppendVendorSpecificInformation(Message &aMessage);
 
-    ThreadError AddIaAddress(Message &aMessage, otIp6Prefix &aIp6Prefix, ClientIdentifier &aClient);
+    otError AddIaAddress(Message &aMessage, otIp6Prefix &aIp6Prefix, ClientIdentifier &aClient);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
@@ -140,12 +140,12 @@ private:
     void ProcessSolicit(Message &aMessage, otIp6Address &aDst, uint8_t *aTransactionId);
 
     uint16_t FindOption(Message &aMessage, uint16_t aOffset, uint16_t aLength, Code aCode);
-    ThreadError ProcessClientIdentifier(Message &aMessage, uint16_t aOffset, ClientIdentifier &aClient);
-    ThreadError ProcessIaNa(Message &aMessage, uint16_t aOffset, IaNa &aIaNa);
-    ThreadError ProcessIaAddress(Message &aMessage, uint16_t aOffset);
-    ThreadError ProcessElapsedTime(Message &aMessage, uint16_t aOffset);
+    otError ProcessClientIdentifier(Message &aMessage, uint16_t aOffset, ClientIdentifier &aClient);
+    otError ProcessIaNa(Message &aMessage, uint16_t aOffset, IaNa &aIaNa);
+    otError ProcessIaAddress(Message &aMessage, uint16_t aOffset);
+    otError ProcessElapsedTime(Message &aMessage, uint16_t aOffset);
 
-    ThreadError SendReply(otIp6Address &aDst, uint8_t *aTransactionId, ClientIdentifier &aClientIdentifier, IaNa &aIaNa);
+    otError SendReply(otIp6Address &aDst, uint8_t *aTransactionId, ClientIdentifier &aClientIdentifier, IaNa &aIaNa);
 
     Ip6::UdpSocket mSocket;
 

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -81,11 +81,11 @@ public:
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None    Successfully appended the bytes.
-     * @retval kThreadError_NoBufs  Insufficient available buffers to grow the message.
+     * @retval OT_ERROR_NONE     Successfully appended the bytes.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
      *
      */
-    ThreadError AppendTo(Message &aMessage) const {
+    otError AppendTo(Message &aMessage) const {
         return aMessage.Append(this, sizeof(*this));
     };
 
@@ -166,18 +166,18 @@ public:
     /**
      * This method starts the DNS client.
      *
-     * @retval kThreadError_None     Successfully started the DNS client.
-     * @retval kThreadError_Already  The socket is already open.
+     * @retval OT_ERROR_NONE     Successfully started the DNS client.
+     * @retval OT_ERROR_ALREADY  The socket is already open.
      */
-    ThreadError Start(void);
+    otError Start(void);
 
     /**
      * This method stops the DNS client.
      *
-     * @retval kThreadError_None  Successfully stopped the DNS client.
+     * @retval OT_ERROR_NONE  Successfully stopped the DNS client.
      *
      */
-    ThreadError Stop(void);
+    otError Stop(void);
 
     /**
      * This method sends a DNS query.
@@ -186,12 +186,12 @@ public:
      * @param[in]  aHandler  A function pointer that shall be called on response reception or time-out.
      * @param[in]  aContext  A pointer to arbitrary context information.
      *
-     * @retval kThreadError_None         Successfully sent DNS query.
-     * @retval kThreadError_NoBufs       Failed to allocate retransmission data.
-     * @retval kThreadError_InvalidArgs  Invalid arguments supplied.
+     * @retval OT_ERROR_NONE          Successfully sent DNS query.
+     * @retval OT_ERROR_NO_BUFS       Failed to allocate retransmission data.
+     * @retval OT_ERROR_INVALID_ARGS  Invalid arguments supplied.
      *
      */
-    ThreadError Query(const otDnsQuery *aQuery, otDnsResponseHandler aHandler, void *aContext);
+    otError Query(const otDnsQuery *aQuery, otDnsResponseHandler aHandler, void *aContext);
 
     /**
      * This method returns a port number used by DNS client.
@@ -233,17 +233,17 @@ private:
     Message *NewMessage(const Header &aHeader);
     Message *CopyAndEnqueueMessage(const Message &aMessage, const QueryMetadata &aQueryMetadata);
     void DequeueMessage(Message &aMessage);
-    ThreadError SendMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError SendCopy(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError SendMessage(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError SendCopy(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    ThreadError AppendCompressedHostname(Message &aMessage, const char *aHostname);
-    ThreadError CompareQuestions(Message &aMessageResponse, Message &aMessageQuery, uint16_t &aOffset);
-    ThreadError SkipHostname(Message &aMessage, uint16_t &aOffset);
+    otError AppendCompressedHostname(Message &aMessage, const char *aHostname);
+    otError CompareQuestions(Message &aMessageResponse, Message &aMessageQuery, uint16_t &aOffset);
+    otError SkipHostname(Message &aMessage, uint16_t &aOffset);
 
     Message *FindRelatedQuery(const Header &aResponseHeader, QueryMetadata &aQueryMetadata);
     void FinalizeDnsTransaction(Message &aQuery, const QueryMetadata &aQueryMetadata,
                                 otIp6Address *aAddress, uint32_t aTtl,
-                                ThreadError aResult);
+                                otError aResult);
 
     static void HandleRetransmissionTimer(void *aContext);
     void HandleRetransmissionTimer(void);

--- a/src/core/net/dns_headers.hpp
+++ b/src/core/net/dns_headers.hpp
@@ -567,11 +567,11 @@ public:
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None    Successfully appended the bytes.
-     * @retval kThreadError_NoBufs  Insufficient available buffers to grow the message.
+     * @retval OT_ERROR_NONE     Successfully appended the bytes.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
      *
      */
-    ThreadError AppendTo(Message &aMessage) const {
+    otError AppendTo(Message &aMessage) const {
         return aMessage.Append(this, sizeof(*this));
     };
 

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -245,11 +245,11 @@ public:
      *
      * @param[in]  aHandler  A reference to the ICMPv6 handler.
      *
-     * @retval kThreadError_None     Successfully registered the ICMPv6 handler.
-     * @retval kThreadError_Already  The ICMPv6 handler is already registered.
+     * @retval OT_ERROR_NONE     Successfully registered the ICMPv6 handler.
+     * @retval OT_ERROR_ALREADY  The ICMPv6 handler is already registered.
      *
      */
-    ThreadError RegisterHandler(IcmpHandler &aHandler);
+    otError RegisterHandler(IcmpHandler &aHandler);
 
     /**
      * This method sends an ICMPv6 Echo Request message.
@@ -259,11 +259,11 @@ public:
      * @param[in]  aIdentifier   An identifier to aid in matching Echo Replies to this Echo Request.
      *                           May be zero.
      *
-     * @retval kThreadError_None    Successfully enqueued the ICMPv6 Echo Request message.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to generate an ICMPv6 Echo Request message.
+     * @retval OT_ERROR_NONE     Successfully enqueued the ICMPv6 Echo Request message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to generate an ICMPv6 Echo Request message.
      *
      */
-    ThreadError SendEchoRequest(Message &aMessage, const MessageInfo &aMessageInfo, uint16_t aIdentifier);
+    otError SendEchoRequest(Message &aMessage, const MessageInfo &aMessageInfo, uint16_t aIdentifier);
 
     /**
      * This method sends an ICMPv6 error message.
@@ -273,12 +273,12 @@ public:
      * @param[in]  aMessageInfo  A reference to the message info.
      * @param[in]  aHeader       The IPv6 header of the error-causing message.
      *
-     * @retval kThreadError_None    Successfully enqueued the ICMPv6 error message.
-     * @retval kThreadError_NoBufs  Insufficient buffers available.
+     * @retval OT_ERROR_NONE     Successfully enqueued the ICMPv6 error message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available.
      *
      */
-    ThreadError SendError(IcmpHeader::Type aType, IcmpHeader::Code aCode, const MessageInfo &aMessageInfo,
-                          const Header &aHeader);
+    otError SendError(IcmpHeader::Type aType, IcmpHeader::Code aCode, const MessageInfo &aMessageInfo,
+                      const Header &aHeader);
 
     /**
      * This method handles an ICMPv6 message.
@@ -286,12 +286,12 @@ public:
      * @param[in]  aMessage      A reference to the ICMPv6 message.
      * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
      *
-     * @retval kThreadError_None    Successfully processed the ICMPv6 message.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to generate the reply.
-     * @retval kThreadError_Drop    The ICMPv6 message was invalid and dropped.
+     * @retval OT_ERROR_NONE     Successfully processed the ICMPv6 message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to generate the reply.
+     * @retval OT_ERROR_DROP     The ICMPv6 message was invalid and dropped.
      *
      */
-    ThreadError HandleMessage(Message &aMessage, MessageInfo &aMessageInfo);
+    otError HandleMessage(Message &aMessage, MessageInfo &aMessageInfo);
 
     /**
      * This method updates the ICMPv6 checksum.
@@ -299,11 +299,11 @@ public:
      * @param[in]  aMessage               A reference to the ICMPv6 message.
      * @param[in]  aPseudoHeaderChecksum  The pseudo-header checksum value.
      *
-     * @retval kThreadError_None         Successfully updated the ICMPv6 checksum.
-     * @retval kThreadError_InvalidArgs  The message was invalid.
+     * @retval OT_ERROR_NONE          Successfully updated the ICMPv6 checksum.
+     * @retval OT_ERROR_INVALID_ARGS  The message was invalid.
      *
      */
-    ThreadError UpdateChecksum(Message &aMessage, uint16_t aPseudoHeaderChecksum);
+    otError UpdateChecksum(Message &aMessage, uint16_t aPseudoHeaderChecksum);
 
     /**
      * This method indicates whether or not ICMPv6 Echo processing is enabled.
@@ -323,7 +323,7 @@ public:
     void SetEchoEnabled(bool aEnabled) { mIsEchoEnabled = aEnabled; }
 
 private:
-    ThreadError HandleEchoRequest(Message &aMessage, const MessageInfo &aMessageInfo);
+    otError HandleEchoRequest(Message &aMessage, const MessageInfo &aMessageInfo);
 
     IcmpHandler *mHandlers;
 

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -126,11 +126,11 @@ public:
      * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
      * @param[in]  aIpProto      The Internet Protocol value.
      *
-     * @retval kThreadError_None    Successfully enqueued the message into an output interface.
-     * @retval kThreadError_NoBufs  Insufficient available buffer to add the IPv6 headers.
+     * @retval OT_ERROR_NONE     Successfully enqueued the message into an output interface.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffer to add the IPv6 headers.
      *
      */
-    ThreadError SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, IpProto aIpProto);
+    otError SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, IpProto aIpProto);
 
     /**
      * This method processes a received IPv6 datagram.
@@ -141,12 +141,12 @@ public:
      * @param[in]  aLinkMessageInfo  A pointer to link-specific message information.
      * @param[in]  aFromNcpHost      TRUE if the message was submitted by the NCP host, FALSE otherwise.
      *
-     * @retval kThreadError_None   Successfully processed the message.
-     * @retval kThreadError_Drop   Message processing failed and the message should be dropped.
+     * @retval OT_ERROR_NONE   Successfully processed the message.
+     * @retval OT_ERROR_DROP   Message processing failed and the message should be dropped.
      *
      */
-    ThreadError HandleDatagram(Message &aMessage, Netif *aNetif, int8_t aInterfaceId,
-                               const void *aLinkMessageInfo, bool aFromNcpHost);
+    otError HandleDatagram(Message &aMessage, Netif *aNetif, int8_t aInterfaceId,
+                           const void *aLinkMessageInfo, bool aFromNcpHost);
 
 
     /**
@@ -265,22 +265,22 @@ public:
      *
      * @param  aNetif  A reference to the network interface.
      *
-     * @retval kThreadError_None  Successfully enabled the network interface.
-     * @retval KThreadError_Already  The network interface was already enabled.
+     * @retval OT_ERROR_NONE     Successfully enabled the network interface.
+     * @retval OT_ERROR_ALREADY  The network interface was already enabled.
      *
      */
-    ThreadError AddNetif(Netif &aNetif);
+    otError AddNetif(Netif &aNetif);
 
     /**
      * This method disables the network interface.
      *
      * @param  aNetif  A reference to the network interface.
      *
-     * @retval kThreadError_None  Successfully disabled the network interface.
-     * @retval KThreadError_NotFound  The network interface was already disabled.
+     * @retval OT_ERROR_NONE       Successfully disabled the network interface.
+     * @retval OT_ERROR_NOT_FOUND  The network interface was already disabled.
      *
      */
-    ThreadError RemoveNetif(Netif &aNetif);
+    otError RemoveNetif(Netif &aNetif);
 
     /**
      * This method returns the network interface list.
@@ -368,17 +368,17 @@ private:
     static void HandleSendQueue(void *aContext);
     void HandleSendQueue(void);
 
-    ThreadError ProcessReceiveCallback(const Message &aMessage, const MessageInfo &aMessageInfo, uint8_t aIpProto,
-                                       bool aFromNcpHost);
-    ThreadError HandleExtensionHeaders(Message &aMessage, Header &aHeader, uint8_t &aNextHeader, bool aForward,
-                                       bool aReceive);
-    ThreadError HandleFragment(Message &aMessage);
-    ThreadError AddMplOption(Message &aMessage, Header &aHeader);
-    ThreadError AddTunneledMplOption(Message &aMessage, Header &aHeader, MessageInfo &aMessageInfo);
-    ThreadError InsertMplOption(Message &aMessage, Header &aHeader, MessageInfo &aMessageInfo);
-    ThreadError RemoveMplOption(Message &aMessage);
-    ThreadError HandleOptions(Message &aMessage, Header &aHeader, bool &aForward);
-    ThreadError HandlePayload(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aIpProto);
+    otError ProcessReceiveCallback(const Message &aMessage, const MessageInfo &aMessageInfo, uint8_t aIpProto,
+                                   bool aFromNcpHost);
+    otError HandleExtensionHeaders(Message &aMessage, Header &aHeader, uint8_t &aNextHeader, bool aForward,
+                                   bool aReceive);
+    otError HandleFragment(Message &aMessage);
+    otError AddMplOption(Message &aMessage, Header &aHeader);
+    otError AddTunneledMplOption(Message &aMessage, Header &aHeader, MessageInfo &aMessageInfo);
+    otError InsertMplOption(Message &aMessage, Header &aHeader, MessageInfo &aMessageInfo);
+    otError RemoveMplOption(Message &aMessage);
+    otError HandleOptions(Message &aMessage, Header &aHeader, bool &aForward);
+    otError HandlePayload(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aIpProto);
     int8_t FindForwardInterfaceId(const MessageInfo &aMessageInfo);
 
     bool mForwardingEnabled;

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -229,9 +229,9 @@ bool Address::operator!=(const Address &aOther) const
     return memcmp(mFields.m8, aOther.mFields.m8, sizeof(mFields.m8)) != 0;
 }
 
-ThreadError Address::FromString(const char *aBuf)
+otError Address::FromString(const char *aBuf)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t *dst = reinterpret_cast<uint8_t *>(mFields.m8);
     uint8_t *endp = reinterpret_cast<uint8_t *>(mFields.m8 + 15);
     uint8_t *colonp = NULL;
@@ -258,7 +258,7 @@ ThreadError Address::FromString(const char *aBuf)
         {
             if (count)
             {
-                VerifyOrExit(dst + 2 <= endp, error = kThreadError_Parse);
+                VerifyOrExit(dst + 2 <= endp, error = OT_ERROR_PARSE);
                 *(dst + 1) = static_cast<uint8_t>(val >> 8);
                 *(dst + 2) = static_cast<uint8_t>(val);
                 dst += 2;
@@ -267,7 +267,7 @@ ThreadError Address::FromString(const char *aBuf)
             }
             else if (ch == ':')
             {
-                VerifyOrExit(colonp == NULL || first, error = kThreadError_Parse);
+                VerifyOrExit(colonp == NULL || first, error = OT_ERROR_PARSE);
                 colonp = dst;
             }
 
@@ -280,12 +280,12 @@ ThreadError Address::FromString(const char *aBuf)
         }
         else
         {
-            VerifyOrExit('0' <= ch && ch <= '9', error = kThreadError_Parse);
+            VerifyOrExit('0' <= ch && ch <= '9', error = OT_ERROR_PARSE);
         }
 
         first = false;
         val = static_cast<uint16_t>((val << 4) | d);
-        VerifyOrExit(++count <= 4, error = kThreadError_Parse);
+        VerifyOrExit(++count <= 4, error = OT_ERROR_PARSE);
     }
 
     while (colonp && dst > colonp)

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -324,11 +324,11 @@ public:
      *
      * @param[in]  aBuf  A pointer to the NULL-terminated string.
      *
-     * @retval kThreadError_None         Successfully parsed the IPv6 address string.
-     * @retval kTheradError_InvalidArgs  Failed to parse the IPv6 address string.
+     * @retval OT_ERROR_NONE          Successfully parsed the IPv6 address string.
+     * @retval OT_ERROR_INVALID_ARGS  Failed to parse the IPv6 address string.
      *
      */
-    ThreadError FromString(const char *aBuf);
+    otError FromString(const char *aBuf);
 
     /**
      * This method converts an IPv6 address object to a NULL-terminated string.

--- a/src/core/net/ip6_filter.cpp
+++ b/src/core/net/ip6_filter.cpp
@@ -117,9 +117,9 @@ exit:
     return rval;
 }
 
-ThreadError Filter::AddUnsecurePort(uint16_t aPort)
+otError Filter::AddUnsecurePort(uint16_t aPort)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     for (int i = 0; i < kMaxUnsecurePorts; i++)
     {
@@ -138,15 +138,15 @@ ThreadError Filter::AddUnsecurePort(uint16_t aPort)
         }
     }
 
-    ExitNow(error = kThreadError_NoBufs);
+    ExitNow(error = OT_ERROR_NO_BUFS);
 
 exit:
     return error;
 }
 
-ThreadError Filter::RemoveUnsecurePort(uint16_t aPort)
+otError Filter::RemoveUnsecurePort(uint16_t aPort)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     for (int i = 0; i < kMaxUnsecurePorts; i++)
     {
@@ -165,7 +165,7 @@ ThreadError Filter::RemoveUnsecurePort(uint16_t aPort)
         }
     }
 
-    ExitNow(error = kThreadError_NotFound);
+    ExitNow(error = OT_ERROR_NOT_FOUND);
 
 exit:
     return error;

--- a/src/core/net/ip6_filter.hpp
+++ b/src/core/net/ip6_filter.hpp
@@ -80,22 +80,22 @@ public:
      *
      * @param[in]  aPort  The port value.
      *
-     * @retval kThreadError_None    The port was successfully added to the allowed unsecure port list.
-     * @retval kThreadError_NoBufs  The unsecure port list is full.
+     * @retval OT_ERROR_NONE     The port was successfully added to the allowed unsecure port list.
+     * @retval OT_ERROR_NO_BUFS  The unsecure port list is full.
      *
      */
-    ThreadError AddUnsecurePort(uint16_t aPort);
+    otError AddUnsecurePort(uint16_t aPort);
 
     /**
      * This method removes a port from the allowed unsecure port list.
      *
      * @param[in]  aPort  The port value.
      *
-     * @retval kThreadError_None      The port was successfully removed from the allowed unsecure port list.
-     * @retval kThreadError_NotFound  The port was not found in the unsecure port list.
+     * @retval OT_ERROR_NONE       The port was successfully removed from the allowed unsecure port list.
+     * @retval OT_ERROR_NOT_FOUND  The port was not found in the unsecure port list.
      *
      */
-    ThreadError RemoveUnsecurePort(uint16_t aPort);
+    otError RemoveUnsecurePort(uint16_t aPort);
 
     /**
      * This method returns a pointer to the unsecure port list.

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -90,9 +90,9 @@ void Mpl::InitOption(OptionMpl &aOption, const Address &aAddress)
     }
 }
 
-ThreadError Mpl::UpdateSeedSet(uint16_t aSeedId, uint8_t aSequence)
+otError Mpl::UpdateSeedSet(uint16_t aSeedId, uint8_t aSequence)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     MplSeedEntry *entry = NULL;
     int8_t diff;
 
@@ -111,13 +111,13 @@ ThreadError Mpl::UpdateSeedSet(uint16_t aSeedId, uint8_t aSequence)
             entry = &mSeedSet[i];
             diff = static_cast<int8_t>(aSequence - entry->GetSequence());
 
-            VerifyOrExit(diff > 0, error = kThreadError_Drop);
+            VerifyOrExit(diff > 0, error = OT_ERROR_DROP);
 
             break;
         }
     }
 
-    VerifyOrExit(entry != NULL, error = kThreadError_Drop);
+    VerifyOrExit(entry != NULL, error = OT_ERROR_DROP);
 
     entry->SetSeedId(aSeedId);
     entry->SetSequence(aSequence);
@@ -168,19 +168,19 @@ exit:
 void Mpl::AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSequence, bool aIsOutbound)
 {
     uint32_t now = Timer::GetNow();
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Message *messageCopy = NULL;
     MplBufferedMessageMetadata messageMetadata;
     uint32_t nextTransmissionTime;
     uint8_t hopLimit = 0;
 
     VerifyOrExit(GetTimerExpirations() > 0);
-    VerifyOrExit((messageCopy = aMessage.Clone()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((messageCopy = aMessage.Clone()) != NULL, error = OT_ERROR_NO_BUFS);
 
     if (!aIsOutbound)
     {
         aMessage.Read(Header::GetHopLimitOffset(), Header::GetHopLimitSize(), &hopLimit);
-        VerifyOrExit(hopLimit-- > 1, error = kThreadError_Drop);
+        VerifyOrExit(hopLimit-- > 1, error = OT_ERROR_DROP);
         messageCopy->Write(Header::GetHopLimitOffset(), Header::GetHopLimitSize(), &hopLimit);
     }
 
@@ -211,21 +211,21 @@ void Mpl::AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSeque
 
 exit:
 
-    if (error != kThreadError_None && messageCopy != NULL)
+    if (error != OT_ERROR_NONE && messageCopy != NULL)
     {
         messageCopy->Free();
     }
 }
 
-ThreadError Mpl::ProcessOption(Message &aMessage, const Address &aAddress, bool aIsOutbound)
+otError Mpl::ProcessOption(Message &aMessage, const Address &aAddress, bool aIsOutbound)
 {
-    ThreadError error;
+    otError error;
     OptionMpl option;
 
     VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(option), &option) >= OptionMpl::kMinLength &&
                  (option.GetSeedIdLength() == OptionMpl::kSeedIdLength0 ||
                   option.GetSeedIdLength() == OptionMpl::kSeedIdLength2),
-                 error = kThreadError_Drop);
+                 error = OT_ERROR_DROP);
 
     if (option.GetSeedIdLength() == OptionMpl::kSeedIdLength0)
     {
@@ -239,7 +239,7 @@ ThreadError Mpl::ProcessOption(Message &aMessage, const Address &aAddress, bool 
     // Check if the MPL Data Message is new.
     error = UpdateSeedSet(option.GetSeedId(), option.GetSequence());
 
-    if (error == kThreadError_None)
+    if (error == OT_ERROR_NONE)
     {
         AddBufferedMessage(aMessage, option.GetSeedId(), option.GetSequence(), aIsOutbound);
     }
@@ -247,7 +247,7 @@ ThreadError Mpl::ProcessOption(Message &aMessage, const Address &aAddress, bool 
     {
         // In case MPL Data Message is generated locally, ignore potential error of the MPL Seed Set
         // to allow subsequent retransmissions with the same sequence number.
-        ExitNow(error = kThreadError_None);
+        ExitNow(error = OT_ERROR_NONE);
     }
 
 exit:

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -263,11 +263,11 @@ public:
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None    Successfully appended the bytes.
-     * @retval kThreadError_NoBufs  Insufficient available buffers to grow the message.
+     * @retval OT_ERROR_NONE     Successfully appended the bytes.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
      *
      */
-    ThreadError AppendTo(Message &aMessage) const {
+    otError AppendTo(Message &aMessage) const {
         return aMessage.Append(this, sizeof(*this));
     };
 
@@ -288,10 +288,10 @@ public:
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None  Successfully removed the header.
+     * @retval OT_ERROR_NONE  Successfully removed the header.
      *
      */
-    ThreadError RemoveFrom(Message &aMessage) {
+    otError RemoveFrom(Message &aMessage) {
         return aMessage.SetLength(aMessage.GetLength() - sizeof(*this));
     };
 
@@ -457,11 +457,11 @@ public:
      * @param[in]  aAddress    A reference to the IPv6 Source Address.
      * @param[in]  aIsOutbound TRUE if this message was locally generated, FALSE otherwise.
      *
-     * @retval kThreadError_None  Successfully processed the MPL option.
-     * @retval kThreadError_Drop  The MPL message is a duplicate and should be dropped.
+     * @retval OT_ERROR_NONE  Successfully processed the MPL option.
+     * @retval OT_ERROR_DROP  The MPL message is a duplicate and should be dropped.
      *
      */
-    ThreadError ProcessOption(Message &aMessage, const Address &aAddress, bool aIsOutbound);
+    otError ProcessOption(Message &aMessage, const Address &aAddress, bool aIsOutbound);
 
     /**
      * This method returns the MPL Seed Id value.
@@ -522,7 +522,7 @@ private:
         kDataMessageInterval = 64
     };
 
-    ThreadError UpdateSeedSet(uint16_t aSeedId, uint8_t aSequence);
+    otError UpdateSeedSet(uint16_t aSeedId, uint8_t aSequence);
     void UpdateBufferedSet(uint16_t aSeedId, uint8_t aSequence);
     void AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSequence, bool aIsOutbound);
 

--- a/src/core/net/ip6_routes.cpp
+++ b/src/core/net/ip6_routes.cpp
@@ -53,13 +53,13 @@ Routes::Routes(Ip6 &aIp6):
 {
 }
 
-ThreadError Routes::Add(Route &aRoute)
+otError Routes::Add(Route &aRoute)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     for (Route *cur = mRoutes; cur; cur = cur->mNext)
     {
-        VerifyOrExit(cur != &aRoute, error = kThreadError_Already);
+        VerifyOrExit(cur != &aRoute, error = OT_ERROR_ALREADY);
     }
 
     aRoute.mNext = mRoutes;
@@ -69,7 +69,7 @@ exit:
     return error;
 }
 
-ThreadError Routes::Remove(Route &aRoute)
+otError Routes::Remove(Route &aRoute)
 {
     if (&aRoute == mRoutes)
     {
@@ -89,7 +89,7 @@ ThreadError Routes::Remove(Route &aRoute)
 
     aRoute.mNext = NULL;
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 int8_t Routes::Lookup(const Address &aSource, const Address &aDestination)
@@ -123,7 +123,7 @@ int8_t Routes::Lookup(const Address &aSource, const Address &aDestination)
 
     for (Netif *netif = mIp6.GetNetifList(); netif; netif = netif->GetNext())
     {
-        if (netif->RouteLookup(aSource, aDestination, &prefixMatch) == kThreadError_None &&
+        if (netif->RouteLookup(aSource, aDestination, &prefixMatch) == OT_ERROR_NONE &&
             static_cast<int8_t>(prefixMatch) > maxPrefixMatch)
         {
             maxPrefixMatch = static_cast<int8_t>(prefixMatch);

--- a/src/core/net/ip6_routes.hpp
+++ b/src/core/net/ip6_routes.hpp
@@ -84,22 +84,22 @@ public:
      *
      * @param[in]  aRoute  A reference to the IPv6 route.
      *
-     * @retval kThreadError_None  Successfully added the route.
-     * @retval kThreadError_Already  The route was already added.
+     * @retval OT_ERROR_NONE     Successfully added the route.
+     * @retval OT_ERROR_ALREADY  The route was already added.
      *
      */
-    ThreadError Add(Route &aRoute);
+    otError Add(Route &aRoute);
 
     /**
      * This method removes an IPv6 route.
      *
      * @param[in]  aRoute  A reference to the IPv6 route.
      *
-     * @retval kThreadError_None         Successfully removed the route.
-     * @retval kThreadError_NotFound  The route was not added.
+     * @retval OT_ERROR_NONE       Successfully removed the route.
+     * @retval OT_ERROR_NOT_FOUND  The route was not added.
      *
      */
-    ThreadError Remove(Route &aRoute);
+    otError Remove(Route &aRoute);
 
     /**
      * This method performs source-destination route lookup.

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -71,15 +71,15 @@ Netif::Netif(Ip6 &aIp6, int8_t aInterfaceId):
     }
 }
 
-ThreadError Netif::RegisterCallback(NetifCallback &aCallback)
+otError Netif::RegisterCallback(NetifCallback &aCallback)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     for (NetifCallback *cur = mCallbacks; cur; cur = cur->mNext)
     {
         if (cur == &aCallback)
         {
-            ExitNow(error = kThreadError_Already);
+            ExitNow(error = OT_ERROR_ALREADY);
         }
     }
 
@@ -90,9 +90,9 @@ exit:
     return error;
 }
 
-ThreadError Netif::RemoveCallback(NetifCallback &aCallback)
+otError Netif::RemoveCallback(NetifCallback &aCallback)
 {
-    ThreadError error = kThreadError_Already;
+    otError error = OT_ERROR_ALREADY;
     NetifCallback *prev = NULL;
 
     for (NetifCallback *cur = mCallbacks; cur; cur = cur->mNext)
@@ -109,7 +109,7 @@ ThreadError Netif::RemoveCallback(NetifCallback &aCallback)
             }
 
             cur->mNext = NULL;
-            error = kThreadError_None;
+            error = OT_ERROR_NONE;
             break;
         }
 
@@ -145,15 +145,15 @@ exit:
     return rval;
 }
 
-ThreadError Netif::SubscribeMulticast(NetifMulticastAddress &aAddress)
+otError Netif::SubscribeMulticast(NetifMulticastAddress &aAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     for (NetifMulticastAddress *cur = mMulticastAddresses; cur; cur = cur->GetNext())
     {
         if (cur == &aAddress)
         {
-            ExitNow(error = kThreadError_Already);
+            ExitNow(error = OT_ERROR_ALREADY);
         }
     }
 
@@ -164,9 +164,9 @@ exit:
     return error;
 }
 
-ThreadError Netif::UnsubscribeMulticast(const NetifMulticastAddress &aAddress)
+otError Netif::UnsubscribeMulticast(const NetifMulticastAddress &aAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (mMulticastAddresses == &aAddress)
     {
@@ -185,21 +185,21 @@ ThreadError Netif::UnsubscribeMulticast(const NetifMulticastAddress &aAddress)
         }
     }
 
-    ExitNow(error = kThreadError_Error);
+    ExitNow(error = OT_ERROR_NOT_FOUND);
 
 exit:
     return error;
 }
 
-ThreadError Netif::SubscribeExternalMulticast(const Address &aAddress)
+otError Netif::SubscribeExternalMulticast(const Address &aAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     NetifMulticastAddress *entry;
     size_t num = sizeof(mExtMulticastAddresses) / sizeof(mExtMulticastAddresses[0]);
 
     if (IsMulticastSubscribed(aAddress))
     {
-        ExitNow(error = kThreadError_Already);
+        ExitNow(error = OT_ERROR_ALREADY);
     }
 
     // Find an available entry in the `mExtMulticastAddresses` array.
@@ -212,7 +212,7 @@ ThreadError Netif::SubscribeExternalMulticast(const Address &aAddress)
         }
     }
 
-    VerifyOrExit(num > 0, error = kThreadError_NoBufs);
+    VerifyOrExit(num > 0, error = OT_ERROR_NO_BUFS);
 
     // Copy the address into the available entry and add it to linked-list.
     entry->mAddress = aAddress;
@@ -223,9 +223,9 @@ exit:
     return error;
 }
 
-ThreadError Netif::UnsubscribeExternalMulticast(const Address &aAddress)
+otError Netif::UnsubscribeExternalMulticast(const Address &aAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     NetifMulticastAddress *entry;
     NetifMulticastAddress *last = NULL;
     size_t num = sizeof(mExtMulticastAddresses) / sizeof(mExtMulticastAddresses[0]);
@@ -235,7 +235,7 @@ ThreadError Netif::UnsubscribeExternalMulticast(const Address &aAddress)
         if (memcmp(&entry->mAddress, &aAddress, sizeof(otIp6Address)) == 0)
         {
             VerifyOrExit((entry >= &mExtMulticastAddresses[0]) && (entry < &mExtMulticastAddresses[num]),
-                         error = kThreadError_InvalidArgs);
+                         error = OT_ERROR_INVALID_ARGS);
 
             if (last)
             {
@@ -252,7 +252,7 @@ ThreadError Netif::UnsubscribeExternalMulticast(const Address &aAddress)
         last = entry;
     }
 
-    VerifyOrExit(entry != NULL, error = kThreadError_NotFound);
+    VerifyOrExit(entry != NULL, error = OT_ERROR_NOT_FOUND);
 
     // To mark the address entry as unused/available, set the `mNext` pointer back to the entry itself.
     entry->mNext = entry;
@@ -275,15 +275,15 @@ void Netif::UnsubscribeAllExternalMulticastAddresses(void)
     }
 }
 
-ThreadError Netif::AddUnicastAddress(NetifUnicastAddress &aAddress)
+otError Netif::AddUnicastAddress(NetifUnicastAddress &aAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     for (NetifUnicastAddress *cur = mUnicastAddresses; cur; cur = cur->GetNext())
     {
         if (cur == &aAddress)
         {
-            ExitNow(error = kThreadError_Already);
+            ExitNow(error = OT_ERROR_ALREADY);
         }
     }
 
@@ -296,9 +296,9 @@ exit:
     return error;
 }
 
-ThreadError Netif::RemoveUnicastAddress(const NetifUnicastAddress &aAddress)
+otError Netif::RemoveUnicastAddress(const NetifUnicastAddress &aAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (mUnicastAddresses == &aAddress)
     {
@@ -317,11 +317,11 @@ ThreadError Netif::RemoveUnicastAddress(const NetifUnicastAddress &aAddress)
         }
     }
 
-    ExitNow(error = kThreadError_NotFound);
+    ExitNow(error = OT_ERROR_NOT_FOUND);
 
 exit:
 
-    if (error != kThreadError_NotFound)
+    if (error != OT_ERROR_NOT_FOUND)
     {
         SetStateChangedFlags(aAddress.mRloc ? OT_IP6_RLOC_REMOVED : OT_IP6_ADDRESS_REMOVED);
     }
@@ -329,9 +329,9 @@ exit:
     return error;
 }
 
-ThreadError Netif::AddExternalUnicastAddress(const NetifUnicastAddress &aAddress)
+otError Netif::AddExternalUnicastAddress(const NetifUnicastAddress &aAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     NetifUnicastAddress *entry;
     size_t num = sizeof(mExtUnicastAddresses) / sizeof(mExtUnicastAddresses[0]);
 
@@ -340,7 +340,7 @@ ThreadError Netif::AddExternalUnicastAddress(const NetifUnicastAddress &aAddress
         if (memcmp(&entry->mAddress, &aAddress.mAddress, sizeof(otIp6Address)) == 0)
         {
             VerifyOrExit((entry >= &mExtUnicastAddresses[0]) && (entry < &mExtUnicastAddresses[num]),
-                         error = kThreadError_InvalidArgs);
+                         error = OT_ERROR_INVALID_ARGS);
 
             entry->mPrefixLength = aAddress.mPrefixLength;
             entry->mPreferred = aAddress.mPreferred;
@@ -359,7 +359,7 @@ ThreadError Netif::AddExternalUnicastAddress(const NetifUnicastAddress &aAddress
         }
     }
 
-    VerifyOrExit(num > 0, error = kThreadError_NoBufs);
+    VerifyOrExit(num > 0, error = OT_ERROR_NO_BUFS);
 
     // Copy the new address into the available entry and insert it in linked-list.
     *entry = aAddress;
@@ -372,9 +372,9 @@ exit:
     return error;
 }
 
-ThreadError Netif::RemoveExternalUnicastAddress(const Address &aAddress)
+otError Netif::RemoveExternalUnicastAddress(const Address &aAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     NetifUnicastAddress *entry;
     NetifUnicastAddress *last = NULL;
     size_t num = sizeof(mExtUnicastAddresses) / sizeof(mExtUnicastAddresses[0]);
@@ -384,7 +384,7 @@ ThreadError Netif::RemoveExternalUnicastAddress(const Address &aAddress)
         if (memcmp(&entry->mAddress, &aAddress, sizeof(otIp6Address)) == 0)
         {
             VerifyOrExit((entry >= &mExtUnicastAddresses[0]) && (entry < &mExtUnicastAddresses[num]),
-                         error = kThreadError_InvalidArgs);
+                         error = OT_ERROR_INVALID_ARGS);
 
             if (last)
             {
@@ -401,7 +401,7 @@ ThreadError Netif::RemoveExternalUnicastAddress(const Address &aAddress)
         last = entry;
     }
 
-    VerifyOrExit(entry != NULL, error = kThreadError_NotFound);
+    VerifyOrExit(entry != NULL, error = OT_ERROR_NOT_FOUND);
 
     // To mark the address entry as unused/available, set the `mNext` pointer back to the entry itself.
     entry->mNext = entry;

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -297,46 +297,46 @@ public:
      *
      * @param[in]  aAddress  A reference to the unicast address.
      *
-     * @retval kThreadError_None     Successfully added the unicast address.
-     * @retval kThreadError_Already  The unicast address was already added.
+     * @retval OT_ERROR_NONE      Successfully added the unicast address.
+     * @retval OT_ERROR_ALREADY  The unicast address was already added.
      *
      */
-    ThreadError AddUnicastAddress(NetifUnicastAddress &aAddress);
+    otError AddUnicastAddress(NetifUnicastAddress &aAddress);
 
     /**
      * This method removes a unicast address from the network interface.
      *
      * @param[in]  aAddress  A reference to the unicast address.
      *
-     * @retval kThreadError_None      Successfully removed the unicast address.
-     * @retval kThreadError_NotFound  The unicast address wasn't found to be removed.
+     * @retval OT_ERROR_NONE       Successfully removed the unicast address.
+     * @retval OT_ERROR_NOT_FOUND  The unicast address wasn't found to be removed.
      *
      */
-    ThreadError RemoveUnicastAddress(const NetifUnicastAddress &aAddress);
+    otError RemoveUnicastAddress(const NetifUnicastAddress &aAddress);
 
     /**
      * This method adds an external (to OpenThread) unicast address to the network interface.
      *
      * @param[in]  aAddress  A reference to the unicast address.
      *
-     * @retval kThreadError_None         Successfully added (or updated) the unicast address.
-     * @retval kThreadError_InvalidArgs  The address indicated by @p aAddress is an internal address.
-     * @retval kThreadError_NoBufs       The maximum number of allowed external addresses are already added.
+     * @retval OT_ERROR_NONE          Successfully added (or updated) the unicast address.
+     * @retval OT_ERROR_INVALID_ARGS  The address indicated by @p aAddress is an internal address.
+     * @retval OT_ERROR_NO_BUFS       The maximum number of allowed external addresses are already added.
      *
      */
-    ThreadError AddExternalUnicastAddress(const NetifUnicastAddress &aAddress);
+    otError AddExternalUnicastAddress(const NetifUnicastAddress &aAddress);
 
     /**
      * This method removes a external (to OpenThread) unicast address from the network interface.
      *
      * @param[in]  aAddress  A reference to the unicast address.
      *
-     * @retval kThreadError_None         Successfully removed the unicast address.
-     * @retval kThreadError_InvalidArgs  The address indicated by @p aAddress is an internal address.
-     * @retval kThreadError_NotFound     The unicast address was not found.
+     * @retval OT_ERROR_NONE          Successfully removed the unicast address.
+     * @retval OT_ERROR_INVALID_ARGS  The address indicated by @p aAddress is an internal address.
+     * @retval OT_ERROR_NOT_FOUND     The unicast address was not found.
      *
      */
-    ThreadError RemoveExternalUnicastAddress(const Address &aAddress);
+    otError RemoveExternalUnicastAddress(const Address &aAddress);
 
     /**
      * This method removes all the previously added external (to OpenThread) unicast addresses from the
@@ -391,47 +391,47 @@ public:
      *
      * @param[in]  aAddress  A reference to the multicast address.
      *
-     * @retval kThreadError_None     Successfully subscribed to @p aAddress.
-     * @retval kThreadError_Already  The multicast address is already subscribed.
+     * @retval OT_ERROR_NONE     Successfully subscribed to @p aAddress.
+     * @retval OT_ERROR_ALREADY  The multicast address is already subscribed.
      *
      */
-    ThreadError SubscribeMulticast(NetifMulticastAddress &aAddress);
+    otError SubscribeMulticast(NetifMulticastAddress &aAddress);
 
     /**
      * This method unsubscribes the network interface to a multicast address.
      *
      * @param[in]  aAddress  A reference to the multicast address.
      *
-     * @retval kThreadError_None     Successfully unsubscribed to @p aAddress.
-     * @retval kThreadError_Already  The multicast address is already unsubscribed.
+     * @retval OT_ERROR_NONE     Successfully unsubscribed to @p aAddress.
+     * @retval OT_ERROR_ALREADY  The multicast address is already unsubscribed.
      *
      */
-    ThreadError UnsubscribeMulticast(const NetifMulticastAddress &aAddress);
+    otError UnsubscribeMulticast(const NetifMulticastAddress &aAddress);
 
     /**
      * This method subscribes the network interface to the external (to OpenThread) multicast address.
      *
      * @param[in]  aAddress  A reference to the multicast address.
      *
-     * @retval kThreadError_None         Successfully subscribed to @p aAddress.
-     * @retval kThreadError_Already      The multicast address is already subscribed.
-     * @retval kThreadError_InvalidArgs  The address indicated by @p aAddress is an internal multicast address.
-     * @retval kThreadError_NoBufs       The maximum number of allowed external multicast addresses are already added.
+     * @retval OT_ERROR_NONE          Successfully subscribed to @p aAddress.
+     * @retval OT_ERROR_ALREADY       The multicast address is already subscribed.
+     * @retval OT_ERROR_INVALID_ARGS  The address indicated by @p aAddress is an internal multicast address.
+     * @retval OT_ERROR_NO_BUFS       The maximum number of allowed external multicast addresses are already added.
      *
      */
-    ThreadError SubscribeExternalMulticast(const Address &aAddress);
+    otError SubscribeExternalMulticast(const Address &aAddress);
 
     /**
      * This method unsubscribes the network interface to the external (to OpenThread) multicast address.
      *
      * @param[in]  aAddress  A reference to the multicast address.
      *
-     * @retval kThreadError_None         Successfully unsubscribed to the unicast address.
-     * @retval kThreadError_InvalidArgs  The address indicated by @p aAddress is an internal address.
-     * @retval kThreadError_NotFound     The multicast address was not found.
+     * @retval OT_ERROR_NONE          Successfully unsubscribed to the unicast address.
+     * @retval OT_ERROR_INVALID_ARGS  The address indicated by @p aAddress is an internal address.
+     * @retval OT_ERROR_NOT_FOUND     The multicast address was not found.
      *
      */
-    ThreadError UnsubscribeExternalMulticast(const Address &aAddress);
+    otError UnsubscribeExternalMulticast(const Address &aAddress);
 
     /**
      * This method unsubscribes the network interface from all previously added external (to OpenThread) multicast
@@ -460,20 +460,20 @@ public:
      *
      * @param[in]  aCallback  A reference to the callback.
      *
-     * @retval kThreadError_None    Successfully registered the callback.
-     * @retval kThreadError_Already The callback was already registered.
+     * @retval OT_ERROR_NONE    Successfully registered the callback.
+     * @retval OT_ERROR_ALREADY The callback was already registered.
      */
-    ThreadError RegisterCallback(NetifCallback &aCallback);
+    otError RegisterCallback(NetifCallback &aCallback);
 
     /**
      * This method removes a network interface callback.
      *
      * @param[in]  aCallback  A reference to the callback.
      *
-     * @retval kThreadError_None    Successfully removed the callback.
-     * @retval kThreadError_Already The callback was not in the list.
+     * @retval OT_ERROR_NONE    Successfully removed the callback.
+     * @retval OT_ERROR_ALREADY The callback was not in the list.
      */
-    ThreadError RemoveCallback(NetifCallback &aCallback);
+    otError RemoveCallback(NetifCallback &aCallback);
 
     /**
      * This method indicates whether or not a state changed callback is pending.
@@ -498,20 +498,20 @@ public:
      *
      * @param[in]  aMessage  A reference to the IPv6 message.
      *
-     * @retval kThreadError_None  Successfully enqueued the IPv6 message.
+     * @retval OT_ERROR_NONE  Successfully enqueued the IPv6 message.
      *
      */
-    virtual ThreadError SendMessage(Message &aMessage) = 0;
+    virtual otError SendMessage(Message &aMessage) = 0;
 
     /**
      * This virtual method fills out @p aAddress with the link address.
      *
      * @param[out]  aAddress  A reference to the link address.
      *
-     * @retval kThreadError_None  Successfully retrieved the link address.
+     * @retval OT_ERROR_NONE  Successfully retrieved the link address.
      *
      */
-    virtual ThreadError GetLinkAddress(LinkAddress &aAddress) const = 0;
+    virtual otError GetLinkAddress(LinkAddress &aAddress) const = 0;
 
     /**
      * This virtual method performs a source-destination route lookup.
@@ -520,12 +520,12 @@ public:
      * @param[in]   aDestination  A reference to the IPv6 destination address.
      * @param[out]  aPrefixMatch  The longest prefix match result.
      *
-     * @retval kThreadError_None     Successfully found a route.
-     * @retval kThreadError_NoRoute  No route to destination.
+     * @retval OT_ERROR_NONE      Successfully found a route.
+     * @retval OT_ERROR_NO_ROUTE  No route to destination.
      *
      */
-    virtual ThreadError RouteLookup(const Address &aSource, const Address &aDestination,
-                                    uint8_t *aPrefixMatch) = 0;
+    virtual otError RouteLookup(const Address &aSource, const Address &aDestination,
+                                uint8_t *aPrefixMatch) = 0;
 
 protected:
     Ip6 &mIp6;

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -86,39 +86,38 @@ public:
      * @param[in]  aHandler  A pointer to a function that is called when receiving UDP messages.
      * @param[in]  aContext  A pointer to arbitrary context information.
      *
-     * @retval kThreadError_None     Successfully opened the socket.
-     * @retval kThreadError_Already  The socket is already open.
+     * @retval OT_ERROR_NONE     Successfully opened the socket.
+     * @retval OT_ERROR_ALREADY  The socket is already open.
      *
      */
-    ThreadError Open(otUdpReceive aHandler, void *aContext);
+    otError Open(otUdpReceive aHandler, void *aContext);
 
     /**
      * This method binds the UDP socket.
      *
      * @param[in]  aSockAddr  A reference to the socket address.
      *
-     * @retval kThreadError_None  Successfully bound the socket.
+     * @retval OT_ERROR_NONE  Successfully bound the socket.
      *
      */
-    ThreadError Bind(const SockAddr &aSockAddr);
+    otError Bind(const SockAddr &aSockAddr);
 
     /**
      * This method connects the UDP socket.
      *
      * @param[in]  aSockAddr  A reference to the socket address.
      *
-     * @retval kThreadError_None  Successfully connected the socket.
+     * @retval OT_ERROR_NONE  Successfully connected the socket.
      */
-    ThreadError Connect(const SockAddr &aSockAddr);
+    otError Connect(const SockAddr &aSockAddr);
 
     /**
      * This method closes the UDP socket.
      *
-     * @retval kThreadError_None  Successfully closed the UDP socket.
-     * @retval kThreadErrorBusy   The socket is already closed.
+     * @retval OT_ERROR_NONE  Successfully closed the UDP socket.
      *
      */
-    ThreadError Close(void);
+    otError Close(void);
 
     /**
      * This method sends a UDP message.
@@ -126,11 +125,11 @@ public:
      * @param[in]  aMessage      The message to send.
      * @param[in]  aMessageInfo  The message info associated with @p aMessage.
      *
-     * @retval kThreadError_None    Successfully sent the UDP message.
-     * @retval kThreadError_NoBufs  Insufficient available buffer to add the UDP and IPv6 headers.
+     * @retval OT_ERROR_NONE     Successfully sent the UDP message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffer to add the UDP and IPv6 headers.
      *
      */
-    ThreadError SendTo(Message &aMessage, const MessageInfo &aMessageInfo);
+    otError SendTo(Message &aMessage, const MessageInfo &aMessageInfo);
 
     /**
      * This method returns the local socket address.
@@ -179,20 +178,20 @@ public:
      *
      * @param[in]  aSocket  A reference to the UDP socket.
      *
-     * @retval kThreadError_None  Successfully added the UDP socket.
+     * @retval OT_ERROR_NONE  Successfully added the UDP socket.
      *
      */
-    ThreadError AddSocket(UdpSocket &aSocket);
+    otError AddSocket(UdpSocket &aSocket);
 
     /**
      * This method removes a UDP socket.
      *
      * @param[in]  aSocket  A reference to the UDP socket.
      *
-     * @retval kThreadError_None  Successfully removed the UDP socket.
+     * @retval OT_ERROR_NONE  Successfully removed the UDP socket.
      *
      */
-    ThreadError RemoveSocket(UdpSocket &aSocket);
+    otError RemoveSocket(UdpSocket &aSocket);
 
     /**
      * This method returns a new ephemeral port.
@@ -219,11 +218,11 @@ public:
      * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
      * @param[in]  aIpProto      The Internet Protocol value.
      *
-     * @retval kThreadError_None    Successfully enqueued the message into an output interface.
-     * @retval kThreadError_NoBufs  Insufficient available buffer to add the IPv6 headers.
+     * @retval OT_ERROR_NONE     Successfully enqueued the message into an output interface.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffer to add the IPv6 headers.
      *
      */
-    ThreadError SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, IpProto aIpProto);
+    otError SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, IpProto aIpProto);
 
     /**
      * This method handles a received UDP message.
@@ -231,11 +230,11 @@ public:
      * @param[in]  aMessage      A reference to the UDP message to process.
      * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
      *
-     * @retval kThreadError_None  Successfully processed the UDP message.
-     * @retval kThreadError_Drop  Could not fully process the UDP message.
+     * @retval OT_ERROR_NONE  Successfully processed the UDP message.
+     * @retval OT_ERROR_DROP  Could not fully process the UDP message.
      *
      */
-    ThreadError HandleMessage(Message &aMessage, MessageInfo &aMessageInfo);
+    otError HandleMessage(Message &aMessage, MessageInfo &aMessageInfo);
 
     /**
      * This method updates the UDP checksum.
@@ -243,11 +242,11 @@ public:
      * @param[in]  aMessage               A reference to the UDP message.
      * @param[in]  aPseudoHeaderChecksum  The pseudo-header checksum value.
      *
-     * @retval kThreadError_None         Successfully updated the UDP checksum.
-     * @retval kThreadError_InvalidArgs  The message was invalid.
+     * @retval OT_ERROR_NONE          Successfully updated the UDP checksum.
+     * @retval OT_ERROR_INVALID_ARGS  The message was invalid.
      *
      */
-    ThreadError UpdateChecksum(Message &aMessage, uint16_t aPseudoHeaderChecksum);
+    otError UpdateChecksum(Message &aMessage, uint16_t aPseudoHeaderChecksum);
 
 private:
     enum

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -93,11 +93,11 @@ void AddressResolver::Clear()
     }
 }
 
-ThreadError AddressResolver::GetEntry(uint8_t aIndex, otEidCacheEntry &aEntry) const
+otError AddressResolver::GetEntry(uint8_t aIndex, otEidCacheEntry &aEntry) const
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aIndex < kCacheEntries, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aIndex < kCacheEntries, error = OT_ERROR_INVALID_ARGS);
     memcpy(&aEntry.mTarget, &mCache[aIndex].mTarget, sizeof(aEntry.mTarget));
     aEntry.mRloc16 = mCache[aIndex].mRloc16;
     aEntry.mValid = mCache[aIndex].mState == Cache::kStateCached;
@@ -170,9 +170,9 @@ void AddressResolver::InvalidateCacheEntry(Cache &aEntry)
     otLogInfoArp(GetInstance(), "cache entry removed!");
 }
 
-ThreadError AddressResolver::Resolve(const Ip6::Address &aEid, uint16_t &aRloc16)
+otError AddressResolver::Resolve(const Ip6::Address &aEid, uint16_t &aRloc16)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Cache *entry = NULL;
 
     for (int i = 0; i < kCacheEntries; i++)
@@ -192,7 +192,7 @@ ThreadError AddressResolver::Resolve(const Ip6::Address &aEid, uint16_t &aRloc16
         entry = NewCacheEntry();
     }
 
-    VerifyOrExit(entry != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit(entry != NULL, error = OT_ERROR_NO_BUFS);
 
     switch (entry->mState)
     {
@@ -204,23 +204,23 @@ ThreadError AddressResolver::Resolve(const Ip6::Address &aEid, uint16_t &aRloc16
         entry->mRetryTimeout = kAddressQueryInitialRetryDelay;
         entry->mState = Cache::kStateQuery;
         SendAddressQuery(aEid);
-        error = kThreadError_AddressQuery;
+        error = OT_ERROR_ADDRESS_QUERY;
         break;
 
     case Cache::kStateQuery:
         if (entry->mTimeout > 0)
         {
-            error = kThreadError_AddressQuery;
+            error = OT_ERROR_ADDRESS_QUERY;
         }
         else if (entry->mTimeout == 0 && entry->mRetryTimeout == 0)
         {
             entry->mTimeout = kAddressQueryTimeout;
             SendAddressQuery(aEid);
-            error = kThreadError_AddressQuery;
+            error = OT_ERROR_ADDRESS_QUERY;
         }
         else
         {
-            error = kThreadError_Drop;
+            error = OT_ERROR_DROP;
         }
 
         break;
@@ -235,9 +235,9 @@ exit:
     return error;
 }
 
-ThreadError AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
+otError AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
 {
-    ThreadError error;
+    otError error;
     Message *message;
     Coap::Header header;
     ThreadTargetTlv targetTlv;
@@ -247,7 +247,7 @@ ThreadError AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
     header.AppendUriPathOptions(OT_URI_PATH_ADDRESS_QUERY);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     targetTlv.Init();
     targetTlv.SetTarget(aEid);
@@ -270,7 +270,7 @@ exit:
         mTimer.Start(kStateUpdatePeriod);
     }
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -313,7 +313,7 @@ void AddressResolver::HandleAddressNotification(Coap::Header &aHeader, Message &
     lastTransactionTime = 0;
 
     if (ThreadTlv::GetTlv(aMessage, ThreadTlv::kLastTransactionTime, sizeof(lastTransactionTimeTlv),
-                          lastTransactionTimeTlv) == kThreadError_None)
+                          lastTransactionTimeTlv) == OT_ERROR_NONE)
     {
         VerifyOrExit(lastTransactionTimeTlv.IsValid());
         lastTransactionTime = lastTransactionTimeTlv.GetTime();
@@ -355,12 +355,12 @@ void AddressResolver::HandleAddressNotification(Coap::Header &aHeader, Message &
             mCache[i].mState = Cache::kStateCached;
             MarkCacheEntryAsUsed(mCache[i]);
 
-            if (mNetif.GetCoap().SendEmptyAck(aHeader, aMessageInfo) == kThreadError_None)
+            if (mNetif.GetCoap().SendEmptyAck(aHeader, aMessageInfo) == OT_ERROR_NONE)
             {
                 otLogInfoArp(GetInstance(), "Sent address notification acknowledgment");
             }
 
-            mNetif.GetMeshForwarder().HandleResolved(*targetTlv.GetTarget(), kThreadError_None);
+            mNetif.GetMeshForwarder().HandleResolved(*targetTlv.GetTarget(), OT_ERROR_NONE);
             break;
         }
     }
@@ -369,10 +369,10 @@ exit:
     return;
 }
 
-ThreadError AddressResolver::SendAddressError(const ThreadTargetTlv &aTarget, const ThreadMeshLocalEidTlv &aEid,
-                                              const Ip6::Address *aDestination)
+otError AddressResolver::SendAddressError(const ThreadTargetTlv &aTarget, const ThreadMeshLocalEidTlv &aEid,
+                                          const Ip6::Address *aDestination)
 {
-    ThreadError error;
+    otError error;
     Message *message;
     Coap::Header header;
     Ip6::MessageInfo messageInfo;
@@ -382,7 +382,7 @@ ThreadError AddressResolver::SendAddressError(const ThreadTargetTlv &aTarget, co
     header.AppendUriPathOptions(OT_URI_PATH_ADDRESS_ERROR);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     SuccessOrExit(error = message->Append(&aTarget, sizeof(aTarget)));
     SuccessOrExit(error = message->Append(&aEid, sizeof(aEid)));
@@ -407,7 +407,7 @@ ThreadError AddressResolver::SendAddressError(const ThreadTargetTlv &aTarget, co
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -426,7 +426,7 @@ void AddressResolver::HandleAddressError(void *aContext, otCoapHeader *aHeader, 
 void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessage,
                                          const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     ThreadTargetTlv targetTlv;
     ThreadMeshLocalEidTlv mlIidTlv;
     Child *children;
@@ -435,23 +435,23 @@ void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessag
     Ip6::Address destination;
 
     VerifyOrExit(aHeader.GetType() == kCoapTypeConfirmable &&
-                 aHeader.GetCode() == kCoapRequestPost, error = kThreadError_Drop);
+                 aHeader.GetCode() == kCoapRequestPost, error = OT_ERROR_DROP);
 
     otLogInfoArp(GetInstance(), "Received address error notification");
 
     if (aHeader.IsConfirmable() && !aMessageInfo.GetSockAddr().IsMulticast())
     {
-        if (mNetif.GetCoap().SendEmptyAck(aHeader, aMessageInfo) == kThreadError_None)
+        if (mNetif.GetCoap().SendEmptyAck(aHeader, aMessageInfo) == OT_ERROR_NONE)
         {
             otLogInfoArp(GetInstance(), "Sent address error notification acknowledgment");
         }
     }
 
     SuccessOrExit(error = ThreadTlv::GetTlv(aMessage, ThreadTlv::kTarget, sizeof(targetTlv), targetTlv));
-    VerifyOrExit(targetTlv.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(targetTlv.IsValid(), error = OT_ERROR_PARSE);
 
     SuccessOrExit(error = ThreadTlv::GetTlv(aMessage, ThreadTlv::kMeshLocalEid, sizeof(mlIidTlv), mlIidTlv));
-    VerifyOrExit(mlIidTlv.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(mlIidTlv.IsValid(), error = OT_ERROR_PARSE);
 
     for (const Ip6::NetifUnicastAddress *address = mNetif.GetUnicastAddresses(); address; address = address->GetNext())
     {
@@ -568,7 +568,7 @@ void AddressResolver::SendAddressQueryResponse(const ThreadTargetTlv &aTargetTlv
                                                const ThreadLastTransactionTimeTlv *aLastTransactionTimeTlv,
                                                const Ip6::Address &aDestination)
 {
-    ThreadError error;
+    otError error;
     Message *message;
     Coap::Header header;
     ThreadRloc16Tlv rloc16Tlv;
@@ -578,7 +578,7 @@ void AddressResolver::SendAddressQueryResponse(const ThreadTargetTlv &aTargetTlv
     header.AppendUriPathOptions(OT_URI_PATH_ADDRESS_NOTIFY);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     SuccessOrExit(error = message->Append(&aTargetTlv, sizeof(aTargetTlv)));
     SuccessOrExit(error = message->Append(&aMlIidTlv, sizeof(aMlIidTlv)));
@@ -602,7 +602,7 @@ void AddressResolver::SendAddressQueryResponse(const ThreadTargetTlv &aTargetTlv
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -644,7 +644,7 @@ void AddressResolver::HandleTimer()
                     mCache[i].mRetryTimeout = kAddressQueryMaxRetryDelay;
                 }
 
-                mNetif.GetMeshForwarder().HandleResolved(mCache[i].mTarget, kThreadError_Drop);
+                mNetif.GetMeshForwarder().HandleResolved(mCache[i].mTarget, OT_ERROR_DROP);
             }
         }
         else if (mCache[i].mRetryTimeout > 0)

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -93,11 +93,11 @@ public:
      * @param[in]   aIndex  An index into the EID cache table.
      * @param[out]  aEntry  A pointer to where the EID information is placed.
      *
-     * @retval kThreadError_None         Successfully retrieved the EID cache entry.
-     * @retval kThreadError_InvalidArgs  @p aIndex was out of bounds or @p aEntry was NULL.
+     * @retval OT_ERROR_NONE          Successfully retrieved the EID cache entry.
+     * @retval OT_ERROR_INVALID_ARGS  @p aIndex was out of bounds or @p aEntry was NULL.
      *
      */
-    ThreadError GetEntry(uint8_t aIndex, otEidCacheEntry &aEntry) const;
+    otError GetEntry(uint8_t aIndex, otEidCacheEntry &aEntry) const;
 
     /**
      * This method removes a Router ID from the EID-to-RLOC cache.
@@ -113,11 +113,11 @@ public:
      * @param[in]   aEid     A reference to the EID.
      * @param[out]  aRloc16  The RLOC16 corresponding to @p aEid.
      *
-     * @retval kTheradError_None          Successfully provided the RLOC16.
-     * @retval kThreadError_AddressQuery  Initiated an Address Query.
+     * @retval OT_ERROR_NONE           Successfully provided the RLOC16.
+     * @retval OT_ERROR_ADDRESS_QUERY  Initiated an Address Query.
      *
      */
-    ThreadError Resolve(const Ip6::Address &aEid, Mac::ShortAddress &aRloc16);
+    otError Resolve(const Ip6::Address &aEid, Mac::ShortAddress &aRloc16);
 
 private:
     enum
@@ -161,9 +161,9 @@ private:
     void MarkCacheEntryAsUsed(Cache &aEntry);
     void InvalidateCacheEntry(Cache &aEntry);
 
-    ThreadError SendAddressQuery(const Ip6::Address &aEid);
-    ThreadError SendAddressError(const ThreadTargetTlv &aTarget, const ThreadMeshLocalEidTlv &aEid,
-                                 const Ip6::Address *aDestination);
+    otError SendAddressQuery(const Ip6::Address &aEid);
+    otError SendAddressError(const ThreadTargetTlv &aTarget, const ThreadMeshLocalEidTlv &aEid,
+                             const Ip6::Address *aDestination);
     void SendAddressQueryResponse(const ThreadTargetTlv &aTargetTlv, const ThreadMeshLocalEidTlv &aMlEidTlv,
                                   const ThreadLastTransactionTimeTlv *aLastTransactionTimeTlv,
                                   const Ip6::Address &aDestination);

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -72,14 +72,14 @@ otInstance *AnnounceBeginServer::GetInstance(void)
     return mNetif.GetInstance();
 }
 
-ThreadError AnnounceBeginServer::SendAnnounce(uint32_t aChannelMask)
+otError AnnounceBeginServer::SendAnnounce(uint32_t aChannelMask)
 {
     return SendAnnounce(aChannelMask, kDefaultCount, kDefaultPeriod);
 }
 
-ThreadError AnnounceBeginServer::SendAnnounce(uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod)
+otError AnnounceBeginServer::SendAnnounce(uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     mChannelMask = aChannelMask;
     mCount = aCount;
@@ -89,7 +89,7 @@ ThreadError AnnounceBeginServer::SendAnnounce(uint32_t aChannelMask, uint8_t aCo
     while ((mChannelMask & (1 << mChannel)) == 0)
     {
         mChannel++;
-        VerifyOrExit(mChannel <= kPhyMaxChannel, error = kThreadError_InvalidArgs);
+        VerifyOrExit(mChannel <= kPhyMaxChannel, error = OT_ERROR_INVALID_ARGS);
     }
 
     mTimer.Start(mPeriod);

--- a/src/core/thread/announce_begin_server.hpp
+++ b/src/core/thread/announce_begin_server.hpp
@@ -71,10 +71,10 @@ public:
      *
      * @param[in]  aChannelMask   The channels to use for transmission.
      *
-     * @retval kThreadError_None  Successfully started the transmission process.
+     * @retval OT_ERROR_NONE  Successfully started the transmission process.
      *
      */
-    ThreadError SendAnnounce(uint32_t aChannelMask);
+    otError SendAnnounce(uint32_t aChannelMask);
 
     /**
      * This method begins the MLE Announce transmission process.
@@ -83,10 +83,10 @@ public:
      * @param[in]  aCount         The number of transmissions per channel.
      * @param[in]  aPeriod        The time between transmissions (milliseconds).
      *
-     * @retval kThreadError_None  Successfully started the transmission process.
+     * @retval OT_ERROR_NONE  Successfully started the transmission process.
      *
      */
-    ThreadError SendAnnounce(uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod);
+    otError SendAnnounce(uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod);
 
 private:
     enum

--- a/src/core/thread/data_poll_manager.hpp
+++ b/src/core/thread/data_poll_manager.hpp
@@ -87,12 +87,12 @@ public:
     /**
      * This method instructs the data poll manager to start sending periodic data polls.
      *
-     * @retval kThreadError_None            Successfully started sending periodic data polls.
-     * @retval kThreadError_Already         Periodic data poll transmission is already started/enabled.
-     * @retval kThreadError_InvalidState    Device is not in rx-off-when-idle mode.
+     * @retval OT_ERROR_NONE            Successfully started sending periodic data polls.
+     * @retval OT_ERROR_ALREADY         Periodic data poll transmission is already started/enabled.
+     * @retval OT_ERROR_INVALID_STATE   Device is not in rx-off-when-idle mode.
      *
      */
-    ThreadError StartPolling(void);
+    otError StartPolling(void);
 
     /**
      * This method instructs the data poll manager to stop sending periodic data polls.
@@ -103,13 +103,13 @@ public:
     /**
      * This method enqueues a data poll (an IEEE 802.15.4 Data Request) message.
      *
-     * @retval kThreadError_None          Successfully enqueued a data poll message
-     * @retval kThreadError_Already       A data poll message is already enqueued.
-     * @retval kThreadError_InvalidState  Device is not in rx-off-when-idle mode.
-     * @retval kThreadError_NoBufs        Insufficient message buffers available.
+     * @retval OT_ERROR_NONE           Successfully enqueued a data poll message
+     * @retval OT_ERROR_ALREADY        A data poll message is already enqueued.
+     * @retval OT_ERROR_INVALID_STATE  Device is not in rx-off-when-idle mode.
+     * @retval OT_ERROR_NO_BUFS        Insufficient message buffers available.
      *
      */
-    ThreadError SendDataPoll(void);
+    otError SendDataPoll(void);
 
     /**
      * This method sets a user-specified/external data poll period.
@@ -143,7 +143,7 @@ public:
      * @param[in] aError   Error status of a data poll message transmission.
      *
      */
-    void HandlePollSent(ThreadError aError);
+    void HandlePollSent(otError aError);
 
     /**
      * This method informs the data poll manager that a data poll timeout happened, i.e., when the ack in response to

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -190,9 +190,9 @@ exit:
     return;
 }
 
-ThreadError EnergyScanServer::SendReport(void)
+otError EnergyScanServer::SendReport(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header header;
     MeshCoP::ChannelMask0Tlv channelMask;
     MeshCoP::EnergyListTlv energyList;
@@ -205,7 +205,7 @@ ThreadError EnergyScanServer::SendReport(void)
     header.SetPayloadMarker();
 
     VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL,
-                 error = kThreadError_NoBufs);
+                 error = OT_ERROR_NO_BUFS);
 
     channelMask.Init();
     channelMask.SetMask(mChannelMask);
@@ -225,7 +225,7 @@ ThreadError EnergyScanServer::SendReport(void)
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -91,7 +91,7 @@ private:
     static void HandleNetifStateChanged(uint32_t aFlags, void *aContext);
     void HandleNetifStateChanged(uint32_t aFlags);
 
-    ThreadError SendReport(void);
+    otError SendReport(void);
 
     Ip6::Address mCommissioner;
     uint32_t mChannelMask;

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -97,9 +97,9 @@ const otMasterKey &KeyManager::GetMasterKey(void) const
     return mMasterKey;
 }
 
-ThreadError KeyManager::SetMasterKey(const otMasterKey &aKey)
+otError KeyManager::SetMasterKey(const otMasterKey &aKey)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Router *routers;
     Child *children;
     uint8_t num;
@@ -142,7 +142,7 @@ exit:
     return error;
 }
 
-ThreadError KeyManager::ComputeKey(uint32_t aKeySequence, uint8_t *aKey)
+otError KeyManager::ComputeKey(uint32_t aKeySequence, uint8_t *aKey)
 {
     Crypto::HmacSha256 hmac;
     uint8_t keySequenceBytes[4];
@@ -158,7 +158,7 @@ ThreadError KeyManager::ComputeKey(uint32_t aKeySequence, uint8_t *aKey)
 
     hmac.Finish(aKey);
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 void KeyManager::SetCurrentKeySequence(uint32_t aKeySequence)
@@ -251,12 +251,12 @@ void KeyManager::SetKek(const uint8_t *aKek)
     mKekFrameCounter = 0;
 }
 
-ThreadError KeyManager::SetKeyRotation(uint32_t aKeyRotation)
+otError KeyManager::SetKeyRotation(uint32_t aKeyRotation)
 {
-    ThreadError result = kThreadError_None;
+    otError result = OT_ERROR_NONE;
 
-    VerifyOrExit(aKeyRotation >= static_cast<uint32_t>(kMinKeyRotationTime), result = kThreadError_InvalidArgs);
-    VerifyOrExit(aKeyRotation <= static_cast<uint32_t>(kMaxKeyRotationTime), result = kThreadError_InvalidArgs);
+    VerifyOrExit(aKeyRotation >= static_cast<uint32_t>(kMinKeyRotationTime), result = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aKeyRotation <= static_cast<uint32_t>(kMaxKeyRotationTime), result = OT_ERROR_INVALID_ARGS);
 
     mKeyRotationTime = aKeyRotation;
 

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -95,11 +95,11 @@ public:
      *
      * @param[in]  aKey        A reference to the Thread Master Key.
      *
-     * @retval kThreadError_None         Successfully set the Thread Master Key.
-     * @retval kThreadError_InvalidArgs  The @p aKeyLength value was invalid.
+     * @retval OT_ERROR_NONE          Successfully set the Thread Master Key.
+     * @retval OT_ERROR_INVALID_ARGS  The @p aKeyLength value was invalid.
      *
      */
-    ThreadError SetMasterKey(const otMasterKey &aKey);
+    otError SetMasterKey(const otMasterKey &aKey);
 
     /**
      * This method returns a pointer to the PSKc.
@@ -276,11 +276,11 @@ public:
      *
      * @param[in]  aKeyRotation  The KeyRotation value in hours.
      *
-     * @retval  kThreadError_None         KeyRotation time updated.
-     * @retval  kThreadError_InvalidArgs  @p aKeyRotation is out of range.
+     * @retval  OT_ERROR_NONE          KeyRotation time updated.
+     * @retval  OT_ERROR_INVALID_ARGS  @p aKeyRotation is out of range.
      *
      */
-    ThreadError SetKeyRotation(uint32_t aKeyRotation);
+    otError SetKeyRotation(uint32_t aKeyRotation);
 
     /**
      * This method returns the KeySwitchGuardTime.
@@ -334,7 +334,7 @@ private:
         kMacKeyOffset = 16,
     };
 
-    ThreadError ComputeKey(uint32_t aKeySequence, uint8_t *aKey);
+    otError ComputeKey(uint32_t aKeySequence, uint8_t *aKey);
 
     static void HandleKeyRotationTimer(void *aContext);
     void HandleKeyRotationTimer(void);

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -155,9 +155,9 @@ uint16_t LinkQualityInfo::GetAverageRssAsEncodedWord(void) const
     return mRssAverage;
 }
 
-ThreadError LinkQualityInfo::GetAverageRssAsString(char *aCharBuffer, size_t aBufferLen) const
+otError LinkQualityInfo::GetAverageRssAsString(char *aCharBuffer, size_t aBufferLen) const
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     int charsWritten = 0;
 
     if (mCount == 0)
@@ -171,9 +171,9 @@ ThreadError LinkQualityInfo::GetAverageRssAsString(char *aCharBuffer, size_t aBu
                                 kLinkQualityDecimalDigitsString[mRssAverage & kRssAveragePrecisionMultipleBitMask]);
     }
 
-    VerifyOrExit(charsWritten >= 0, error = kThreadError_NoBufs);
+    VerifyOrExit(charsWritten >= 0, error = OT_ERROR_NO_BUFS);
 
-    VerifyOrExit(charsWritten < static_cast<int>(aBufferLen), error = kThreadError_NoBufs);
+    VerifyOrExit(charsWritten < static_cast<int>(aBufferLen), error = OT_ERROR_NO_BUFS);
 
 exit:
     return error;

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -108,11 +108,11 @@ public:
      * @param[out]    aCharBuffer    A char buffer to store the string corresponding to current average value.
      * @param[in]     aBufferLen     The char buffer length.
      *
-     * @retval kThreadError_None     Successfully formed the string in the given char buffer.
-     * @retval kThreadError_NoBufs   The string representation of the average value could not fit in the given buffer.
+     * @retval OT_ERROR_NONE      Successfully formed the string in the given char buffer.
+     * @retval OT_ERROR_NO_BUFS   The string representation of the average value could not fit in the given buffer.
      *
      */
-    ThreadError GetAverageRssAsString(char *aCharBuffer, size_t aBufferLen) const;
+    otError GetAverageRssAsString(char *aCharBuffer, size_t aBufferLen) const;
 
     /**
      * This method returns the link margin. The link margin is calculated using the link's current average received

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -57,7 +57,7 @@ Lowpan::Lowpan(ThreadNetif &aThreadNetif):
 {
 }
 
-ThreadError Lowpan::CopyContext(const Context &aContext, Ip6::Address &aAddress)
+otError Lowpan::CopyContext(const Context &aContext, Ip6::Address &aAddress)
 {
     memcpy(&aAddress, aContext.mPrefix, aContext.mPrefixLength / CHAR_BIT);
 
@@ -67,12 +67,12 @@ ThreadError Lowpan::CopyContext(const Context &aContext, Ip6::Address &aAddress)
         aAddress.mFields.m8[i / CHAR_BIT] |= aContext.mPrefix[i / CHAR_BIT] & (0x80 >> (i % CHAR_BIT));
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Lowpan::ComputeIid(const Mac::Address &aMacAddr, const Context &aContext, Ip6::Address &aIpAddress)
+otError Lowpan::ComputeIid(const Mac::Address &aMacAddr, const Context &aContext, Ip6::Address &aIpAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     switch (aMacAddr.mLength)
     {
@@ -88,7 +88,7 @@ ThreadError Lowpan::ComputeIid(const Mac::Address &aMacAddr, const Context &aCon
         break;
 
     default:
-        ExitNow(error = kThreadError_Parse);
+        ExitNow(error = OT_ERROR_PARSE);
     }
 
     if (aContext.mPrefixLength > 64)
@@ -215,7 +215,7 @@ int Lowpan::CompressMulticast(const Ip6::Address &aIpAddr, uint16_t &aHcCtl, uin
             else
             {
                 // Check if multicast address can be compressed using Context ID 0.
-                if (mNetworkData.GetContext(0, multicastContext) == kThreadError_None &&
+                if (mNetworkData.GetContext(0, multicastContext) == OT_ERROR_NONE &&
                     multicastContext.mPrefixLength == aIpAddr.mFields.m8[3] &&
                     memcmp(multicastContext.mPrefix, aIpAddr.mFields.m8 + 4, 8) == 0)
                 {
@@ -252,14 +252,14 @@ int Lowpan::Compress(Message &aMessage, const Mac::Address &aMacSource, const Ma
 
     aMessage.Read(aMessage.GetOffset(), sizeof(ip6Header), &ip6Header);
 
-    if (mNetworkData.GetContext(ip6Header.GetSource(), srcContext) != kThreadError_None ||
+    if (mNetworkData.GetContext(ip6Header.GetSource(), srcContext) != OT_ERROR_NONE ||
         srcContext.mCompressFlag == false)
     {
         mNetworkData.GetContext(0, srcContext);
         srcContextValid = false;
     }
 
-    if (mNetworkData.GetContext(ip6Header.GetDestination(), dstContext) != kThreadError_None ||
+    if (mNetworkData.GetContext(ip6Header.GetDestination(), dstContext) != OT_ERROR_NONE ||
         dstContext.mCompressFlag == false)
     {
         mNetworkData.GetContext(0, dstContext);
@@ -555,9 +555,9 @@ int Lowpan::CompressUdp(Message &aMessage, uint8_t *aBuf)
     return static_cast<int>(cur - aBuf);
 }
 
-ThreadError Lowpan::DispatchToNextHeader(uint8_t aDispatch, Ip6::IpProto &aNextHeader)
+otError Lowpan::DispatchToNextHeader(uint8_t aDispatch, Ip6::IpProto &aNextHeader)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if ((aDispatch & kExtHdrDispatchMask) == kExtHdrDispatch)
     {
@@ -590,7 +590,7 @@ ThreadError Lowpan::DispatchToNextHeader(uint8_t aDispatch, Ip6::IpProto &aNextH
         ExitNow();
     }
 
-    error = kThreadError_Parse;
+    error = OT_ERROR_PARSE;
 
 exit:
     return error;
@@ -599,7 +599,7 @@ exit:
 int Lowpan::DecompressBaseHeader(Ip6::Header &ip6Header, const Mac::Address &aMacSource, const Mac::Address &aMacDest,
                                  const uint8_t *aBuf, uint16_t aBufLength)
 {
-    ThreadError error = kThreadError_Parse;
+    otError error = OT_ERROR_PARSE;
     const uint8_t *cur = aBuf;
     uint16_t remaining = aBufLength;
     uint16_t hcCtl;
@@ -624,12 +624,12 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &ip6Header, const Mac::Address &aMa
     {
         VerifyOrExit(remaining >= 1);
 
-        if (mNetworkData.GetContext(cur[0] >> 4, srcContext) != kThreadError_None)
+        if (mNetworkData.GetContext(cur[0] >> 4, srcContext) != OT_ERROR_NONE)
         {
             srcContextValid = false;
         }
 
-        if (mNetworkData.GetContext(cur[0] & 0xf, dstContext) != kThreadError_None)
+        if (mNetworkData.GetContext(cur[0] & 0xf, dstContext) != OT_ERROR_NONE)
         {
             dstContextValid = false;
         }
@@ -872,15 +872,15 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &ip6Header, const Mac::Address &aMa
         ip6Header.SetNextHeader(nextHeader);
     }
 
-    error = kThreadError_None;
+    error = OT_ERROR_NONE;
 
 exit:
-    return (error == kThreadError_None) ? static_cast<int>(cur - aBuf) : -1;
+    return (error == OT_ERROR_NONE) ? static_cast<int>(cur - aBuf) : -1;
 }
 
 int Lowpan::DecompressExtensionHeader(Message &aMessage, const uint8_t *aBuf, uint16_t aBufLength)
 {
-    ThreadError error = kThreadError_Parse;
+    otError error = OT_ERROR_PARSE;
     const uint8_t *cur = aBuf;
     uint16_t remaining = aBufLength;
     uint8_t hdr[2];
@@ -952,15 +952,15 @@ int Lowpan::DecompressExtensionHeader(Message &aMessage, const uint8_t *aBuf, ui
         aMessage.MoveOffset(padLength);
     }
 
-    error = kThreadError_None;
+    error = OT_ERROR_NONE;
 
 exit:
-    return (error == kThreadError_None) ? static_cast<int>(cur - aBuf) : -1;
+    return (error == OT_ERROR_NONE) ? static_cast<int>(cur - aBuf) : -1;
 }
 
 int Lowpan::DecompressUdpHeader(Message &aMessage, const uint8_t *aBuf, uint16_t aBufLength, uint16_t aDatagramLength)
 {
-    ThreadError error = kThreadError_Parse;
+    otError error = OT_ERROR_PARSE;
     const uint8_t *cur = aBuf;
     uint16_t remaining = aBufLength;
     Ip6::UdpHeader udpHeader;
@@ -1034,16 +1034,16 @@ int Lowpan::DecompressUdpHeader(Message &aMessage, const uint8_t *aBuf, uint16_t
     SuccessOrExit(aMessage.Append(&udpHeader, sizeof(udpHeader)));
     aMessage.MoveOffset(sizeof(udpHeader));
 
-    error = kThreadError_None;
+    error = OT_ERROR_NONE;
 
 exit:
-    return (error == kThreadError_None) ? static_cast<int>(cur - aBuf) : -1;
+    return (error == OT_ERROR_NONE) ? static_cast<int>(cur - aBuf) : -1;
 }
 
 int Lowpan::Decompress(Message &aMessage, const Mac::Address &aMacSource, const Mac::Address &aMacDest,
                        const uint8_t *aBuf, uint16_t aBufLength, uint16_t aDatagramLength)
 {
-    ThreadError error = kThreadError_Parse;
+    otError error = OT_ERROR_PARSE;
     Ip6::Header ip6Header;
     const uint8_t *cur = aBuf;
     uint16_t remaining = aBufLength;
@@ -1116,23 +1116,23 @@ int Lowpan::Decompress(Message &aMessage, const Mac::Address &aMacSource, const 
     aMessage.Write(currentOffset + Ip6::Header::GetPayloadLengthOffset(),
                    sizeof(ip6PayloadLength), &ip6PayloadLength);
 
-    error = kThreadError_None;
+    error = OT_ERROR_NONE;
 
 exit:
-    return (error == kThreadError_None) ? static_cast<int>(compressedLength) : -1;
+    return (error == OT_ERROR_NONE) ? static_cast<int>(compressedLength) : -1;
 }
 
-ThreadError MeshHeader::Init(const uint8_t *aFrame, uint8_t aFrameLength)
+otError MeshHeader::Init(const uint8_t *aFrame, uint8_t aFrameLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aFrameLength >= 1, error = kThreadError_Failed);
+    VerifyOrExit(aFrameLength >= 1, error = OT_ERROR_FAILED);
     mDispatchHopsLeft = *aFrame++;
     aFrameLength--;
 
     if (IsDeepHopsLeftField())
     {
-        VerifyOrExit(aFrameLength >= 1, error = kThreadError_Failed);
+        VerifyOrExit(aFrameLength >= 1, error = OT_ERROR_FAILED);
         mDeepHopsLeft = *aFrame++;
         aFrameLength--;
     }
@@ -1141,27 +1141,27 @@ ThreadError MeshHeader::Init(const uint8_t *aFrame, uint8_t aFrameLength)
         mDeepHopsLeft = 0;
     }
 
-    VerifyOrExit(aFrameLength >= sizeof(mAddress), error = kThreadError_Failed);
+    VerifyOrExit(aFrameLength >= sizeof(mAddress), error = OT_ERROR_FAILED);
     memcpy(&mAddress, aFrame, sizeof(mAddress));
 
 exit:
     return error;
 }
 
-ThreadError MeshHeader::Init(const Message &aMessage)
+otError MeshHeader::Init(const Message &aMessage)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint16_t offset = 0;
     uint16_t bytesRead;
 
     bytesRead = aMessage.Read(offset, sizeof(mDispatchHopsLeft), &mDispatchHopsLeft);
-    VerifyOrExit(bytesRead == sizeof(mDispatchHopsLeft), error = kThreadError_Failed);
+    VerifyOrExit(bytesRead == sizeof(mDispatchHopsLeft), error = OT_ERROR_FAILED);
     offset += bytesRead;
 
     if (IsDeepHopsLeftField())
     {
         bytesRead = aMessage.Read(offset, sizeof(mDeepHopsLeft), &mDeepHopsLeft);
-        VerifyOrExit(bytesRead == sizeof(mDeepHopsLeft), error = kThreadError_Failed);
+        VerifyOrExit(bytesRead == sizeof(mDeepHopsLeft), error = OT_ERROR_FAILED);
         offset += bytesRead;
     }
     else
@@ -1170,7 +1170,7 @@ ThreadError MeshHeader::Init(const Message &aMessage)
     }
 
     bytesRead = aMessage.Read(offset, sizeof(mAddress), &mAddress);
-    VerifyOrExit(bytesRead == sizeof(mAddress), error = kThreadError_Failed);
+    VerifyOrExit(bytesRead == sizeof(mAddress), error = OT_ERROR_FAILED);
 
 exit:
     return error;

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -205,10 +205,10 @@ private:
 
     int DecompressExtensionHeader(Message &message, const uint8_t *aBuf, uint16_t aBufLength);
     int DecompressUdpHeader(Message &message, const uint8_t *aBuf, uint16_t aBufLength, uint16_t datagramLength);
-    ThreadError DispatchToNextHeader(uint8_t dispatch, Ip6::IpProto &nextHeader);
+    otError DispatchToNextHeader(uint8_t dispatch, Ip6::IpProto &nextHeader);
 
-    static ThreadError CopyContext(const Context &aContext, Ip6::Address &aAddress);
-    static ThreadError ComputeIid(const Mac::Address &aMacAddr, const Context &aContext, Ip6::Address &aIpAddress);
+    static otError CopyContext(const Context &aContext, Ip6::Address &aAddress);
+    static otError ComputeIid(const Mac::Address &aMacAddr, const Context &aContext, Ip6::Address &aIpAddress);
 
     NetworkData::Leader &mNetworkData;
 };
@@ -244,22 +244,22 @@ public:
      * @param[in]  aFrame        The pointer to the frame.
      * @param[in]  aFrameLength  The length of the frame.
      *
-     * @retval kThreadError_None     Mesh Header initialized successfully.
-     * @retval kThreadError_Failed   Mesh header could not be initialized from @p aFrame (e.g., frame not long enough).
+     * @retval OT_ERROR_NONE     Mesh Header initialized successfully.
+     * @retval OT_ERROR_FAILED   Mesh header could not be initialized from @p aFrame (e.g., frame not long enough).
      *
      */
-    ThreadError Init(const uint8_t *aFrame, uint8_t aFrameLength);
+    otError Init(const uint8_t *aFrame, uint8_t aFrameLength);
 
     /**
      * This method initializes the mesh header from a message object @p aMessage.
      *
      * @param[in]  aMessage  The message object.
      *
-     * @retval kThreadError_None     Mesh Header initialized successfully.
-     * @retval kThreadError_Failed   Mesh header could not be initialized from @ aMessage(e.g., not long enough).
+     * @retval OT_ERROR_NONE     Mesh Header initialized successfully.
+     * @retval OT_ERROR_FAILED   Mesh header could not be initialized from @ aMessage(e.g., not long enough).
      *
      */
-    ThreadError Init(const Message &aMessage);
+    otError Init(const Message &aMessage);
 
     /**
      * This method indicates whether or not the header is a Mesh Header.

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -100,9 +100,9 @@ otInstance *MeshForwarder::GetInstance(void)
     return mNetif.GetInstance();
 }
 
-ThreadError MeshForwarder::Start(void)
+otError MeshForwarder::Start(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (mEnabled == false)
     {
@@ -113,9 +113,9 @@ ThreadError MeshForwarder::Start(void)
     return error;
 }
 
-ThreadError MeshForwarder::Stop(void)
+otError MeshForwarder::Stop(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Message *message;
 
     VerifyOrExit(mEnabled == true);
@@ -150,7 +150,7 @@ exit:
     return error;
 }
 
-void MeshForwarder::HandleResolved(const Ip6::Address &aEid, ThreadError aError)
+void MeshForwarder::HandleResolved(const Ip6::Address &aEid, otError aError)
 {
     Message *cur, *next;
     Ip6::Address ip6Dst;
@@ -171,7 +171,7 @@ void MeshForwarder::HandleResolved(const Ip6::Address &aEid, ThreadError aError)
         {
             mResolvingQueue.Dequeue(*cur);
 
-            if (aError == kThreadError_None)
+            if (aError == OT_ERROR_NONE)
             {
                 mSendQueue.Enqueue(*cur);
                 enqueuedMessage = true;
@@ -246,13 +246,13 @@ void MeshForwarder::ScheduleTransmissionTask(void *aContext)
 
 void MeshForwarder::ScheduleTransmissionTask(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t numChildren;
     uint8_t childIndex;
     uint8_t nextIndex;
     Child *children;
 
-    VerifyOrExit(mSendBusy == false, error = kThreadError_Busy);
+    VerifyOrExit(mSendBusy == false, error = OT_ERROR_BUSY);
 
     UpdateIndirectMessages();
 
@@ -335,9 +335,9 @@ exit:
     (void) error;
 }
 
-ThreadError MeshForwarder::SendMessage(Message &aMessage)
+otError MeshForwarder::SendMessage(Message &aMessage)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Neighbor *neighbor;
 
     uint8_t numChildren;
@@ -421,8 +421,8 @@ ThreadError MeshForwarder::SendMessage(Message &aMessage)
 
     case Message::kTypeSupervision:
         child = mNetif.GetChildSupervisor().GetDestination(aMessage);
-        VerifyOrExit(child != NULL, error = kThreadError_Drop);
-        VerifyOrExit(!child->IsRxOnWhenIdle(), error = kThreadError_Drop);
+        VerifyOrExit(child != NULL, error = OT_ERROR_DROP);
+        VerifyOrExit(!child->IsRxOnWhenIdle(), error = OT_ERROR_DROP);
 
         aMessage.SetChildMask(mNetif.GetMle().GetChildIndex(*child));
         mSourceMatchController.IncrementMessageCount(*child);
@@ -438,9 +438,9 @@ exit:
     return error;
 }
 
-ThreadError MeshForwarder::PrepareDiscoverRequest(void)
+otError MeshForwarder::PrepareDiscoverRequest(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     VerifyOrExit(!mScanning);
 
@@ -457,7 +457,7 @@ ThreadError MeshForwarder::PrepareDiscoverRequest(void)
         if (mScanChannel > kPhyMaxChannel)
         {
             mNetif.GetMle().HandleDiscoverComplete();
-            ExitNow(error = kThreadError_Drop);
+            ExitNow(error = OT_ERROR_DROP);
         }
     }
 
@@ -470,7 +470,7 @@ exit:
 Message *MeshForwarder::GetDirectTransmission(void)
 {
     Message *curMessage, *nextMessage;
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     for (curMessage = mSendQueue.GetHead(); curMessage; curMessage = nextMessage)
     {
@@ -501,22 +501,22 @@ Message *MeshForwarder::GetDirectTransmission(void)
             ExitNow();
 
         case Message::kTypeSupervision:
-            error = kThreadError_Drop;
+            error = OT_ERROR_DROP;
             break;
         }
 
         switch (error)
         {
-        case kThreadError_None:
+        case OT_ERROR_NONE:
             ExitNow();
 
-        case kThreadError_AddressQuery:
+        case OT_ERROR_ADDRESS_QUERY:
             mSendQueue.Dequeue(*curMessage);
             mResolvingQueue.Enqueue(*curMessage);
             continue;
 
-        case kThreadError_Drop:
-        case kThreadError_NoBufs:
+        case OT_ERROR_DROP:
+        case OT_ERROR_NO_BUFS:
             mSendQueue.Dequeue(*curMessage);
             curMessage->Free();
             continue;
@@ -566,7 +566,7 @@ Message *MeshForwarder::GetIndirectTransmission(Child &aChild)
     {
         Mac::Address macAddr;
 
-        LogIp6Message(kMessagePrepareIndirect, *message, &aChild.GetMacAddress(macAddr), kThreadError_None);
+        LogIp6Message(kMessagePrepareIndirect, *message, &aChild.GetMacAddress(macAddr), OT_ERROR_NONE);
     }
 
     return message;
@@ -632,9 +632,9 @@ void MeshForwarder::PrepareIndirectTransmission(Message &aMessage, const Child &
     }
 }
 
-ThreadError MeshForwarder::UpdateMeshRoute(Message &aMessage)
+otError MeshForwarder::UpdateMeshRoute(Message &aMessage)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Lowpan::MeshHeader meshHeader;
     Neighbor *neighbor;
     uint16_t nextHop;
@@ -654,7 +654,7 @@ ThreadError MeshForwarder::UpdateMeshRoute(Message &aMessage)
 
     if (neighbor == NULL)
     {
-        ExitNow(error = kThreadError_Drop);
+        ExitNow(error = OT_ERROR_DROP);
     }
 
     mMacDest.mLength = sizeof(mMacDest.mShortAddress);
@@ -670,9 +670,9 @@ exit:
     return error;
 }
 
-ThreadError MeshForwarder::UpdateIp6Route(Message &aMessage)
+otError MeshForwarder::UpdateIp6Route(Message &aMessage)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Ip6::Header ip6Header;
 
     mAddMeshHeader = false;
@@ -690,7 +690,7 @@ ThreadError MeshForwarder::UpdateIp6Route(Message &aMessage)
         }
         else
         {
-            ExitNow(error = kThreadError_Drop);
+            ExitNow(error = OT_ERROR_DROP);
         }
 
         break;
@@ -718,7 +718,7 @@ ThreadError MeshForwarder::UpdateIp6Route(Message &aMessage)
         }
         else
         {
-            ExitNow(error = kThreadError_Drop);
+            ExitNow(error = OT_ERROR_DROP);
         }
 
         break;
@@ -742,7 +742,7 @@ ThreadError MeshForwarder::UpdateIp6Route(Message &aMessage)
                 {
                     rloc16 = HostSwap16(ip6Header.GetDestination().mFields.m16[7]);
                     VerifyOrExit(mNetif.GetMle().IsRouterIdValid(mNetif.GetMle().GetRouterId(rloc16)),
-                                 error = kThreadError_Drop);
+                                 error = OT_ERROR_DROP);
                     mMeshDest = rloc16;
                 }
                 else if (mNetif.GetMle().IsAnycastLocator(ip6Header.GetDestination()))
@@ -761,8 +761,8 @@ ThreadError MeshForwarder::UpdateIp6Route(Message &aMessage)
                         uint8_t routerId;
                         VerifyOrExit((mNetif.GetNetworkDataLeader().GetRlocByContextId(
                                           static_cast<uint8_t>(aloc16 & Mle::kAloc16DhcpAgentMask),
-                                          agentRloc16) == kThreadError_None),
-                                     error = kThreadError_Drop);
+                                          agentRloc16) == OT_ERROR_NONE),
+                                     error = OT_ERROR_DROP);
 
                         routerId = mNetif.GetMle().GetRouterId(agentRloc16);
 
@@ -783,7 +783,7 @@ ThreadError MeshForwarder::UpdateIp6Route(Message &aMessage)
                     else
                     {
                         // TODO: support ALOC for Service, Commissioner, Neighbor Discovery Agent
-                        ExitNow(error = kThreadError_Drop);
+                        ExitNow(error = OT_ERROR_DROP);
                     }
                 }
                 else if ((neighbor = mNetif.GetMle().GetNeighbor(ip6Header.GetDestination())) != NULL)
@@ -804,7 +804,7 @@ ThreadError MeshForwarder::UpdateIp6Route(Message &aMessage)
                     );
                 }
 
-                VerifyOrExit(mMeshDest != Mac::kShortAddrInvalid, error = kThreadError_Drop);
+                VerifyOrExit(mMeshDest != Mac::kShortAddrInvalid, error = OT_ERROR_DROP);
 
                 if (mNetif.GetMle().GetNeighbor(mMeshDest) != NULL)
                 {
@@ -868,7 +868,7 @@ void MeshForwarder::SetRxOnWhenIdle(bool aRxOnWhenIdle)
     }
 }
 
-ThreadError MeshForwarder::GetMacSourceAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr)
+otError MeshForwarder::GetMacSourceAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr)
 {
     aMacAddr.mLength = sizeof(aMacAddr.mExtAddress);
     aMacAddr.mExtAddress.Set(aIp6Addr);
@@ -879,10 +879,10 @@ ThreadError MeshForwarder::GetMacSourceAddress(const Ip6::Address &aIp6Addr, Mac
         aMacAddr.mShortAddress = mNetif.GetMac().GetShortAddress();
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError MeshForwarder::GetMacDestinationAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr)
+otError MeshForwarder::GetMacDestinationAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr)
 {
     if (aIp6Addr.IsMulticast())
     {
@@ -911,21 +911,21 @@ ThreadError MeshForwarder::GetMacDestinationAddress(const Ip6::Address &aIp6Addr
         aMacAddr.mExtAddress.Set(aIp6Addr);
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError MeshForwarder::HandleFrameRequest(void *aContext, Mac::Frame &aFrame)
+otError MeshForwarder::HandleFrameRequest(void *aContext, Mac::Frame &aFrame)
 {
     return static_cast<MeshForwarder *>(aContext)->HandleFrameRequest(aFrame);
 }
 
-ThreadError MeshForwarder::HandleFrameRequest(Mac::Frame &aFrame)
+otError MeshForwarder::HandleFrameRequest(Mac::Frame &aFrame)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Mac::Address macDest;
     Child *child = NULL;
 
-    VerifyOrExit(mEnabled, error = kThreadError_Abort);
+    VerifyOrExit(mEnabled, error = OT_ERROR_ABORT);
 
     mSendBusy = true;
 
@@ -968,7 +968,7 @@ ThreadError MeshForwarder::HandleFrameRequest(Mac::Frame &aFrame)
 
         // `SendFragment()` fails with `NotCapable` error if the message is MLE (with
         // no link layer security) and also requires fragmentation.
-        if (error == kThreadError_NotCapable)
+        if (error == OT_ERROR_NOT_CAPABLE)
         {
             // Enable security and try again.
             mSendMessage->SetLinkSecurityEnabled(true);
@@ -992,7 +992,7 @@ ThreadError MeshForwarder::HandleFrameRequest(Mac::Frame &aFrame)
         break;
     }
 
-    assert(error == kThreadError_None);
+    assert(error == OT_ERROR_NONE);
 
     aFrame.GetDstAddr(macDest);
 
@@ -1030,7 +1030,7 @@ exit:
     return error;
 }
 
-ThreadError MeshForwarder::SendPoll(Message &aMessage, Mac::Frame &aFrame)
+otError MeshForwarder::SendPoll(Message &aMessage, Mac::Frame &aFrame)
 {
     Mac::Address macSource;
     uint16_t fcf;
@@ -1083,10 +1083,10 @@ ThreadError MeshForwarder::SendPoll(Message &aMessage, Mac::Frame &aFrame)
 
     mMessageNextOffset = aMessage.GetLength();
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError MeshForwarder::SendMesh(Message &aMessage, Mac::Frame &aFrame)
+otError MeshForwarder::SendMesh(Message &aMessage, Mac::Frame &aFrame)
 {
     uint16_t fcf;
 
@@ -1107,10 +1107,10 @@ ThreadError MeshForwarder::SendMesh(Message &aMessage, Mac::Frame &aFrame)
 
     mMessageNextOffset = aMessage.GetLength();
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError MeshForwarder::SendFragment(Message &aMessage, Mac::Frame &aFrame)
+otError MeshForwarder::SendFragment(Message &aMessage, Mac::Frame &aFrame)
 {
     Mac::Address meshDest, meshSource;
     uint16_t fcf;
@@ -1124,7 +1124,7 @@ ThreadError MeshForwarder::SendFragment(Message &aMessage, Mac::Frame &aFrame)
     uint16_t fragmentLength;
     uint16_t dstpan;
     uint8_t secCtl = Mac::Frame::kSecNone;
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (mAddMeshHeader)
     {
@@ -1279,7 +1279,7 @@ ThreadError MeshForwarder::SendFragment(Message &aMessage, Mac::Frame &aFrame)
             if ((!aMessage.IsLinkSecurityEnabled()) && aMessage.IsSubTypeMle())
             {
                 aMessage.SetOffset(0);
-                ExitNow(error = kThreadError_NotCapable);
+                ExitNow(error = OT_ERROR_NOT_CAPABLE);
             }
 
             // write Fragment header
@@ -1355,7 +1355,7 @@ exit:
     return error;
 }
 
-ThreadError MeshForwarder::SendEmptyFrame(Mac::Frame &aFrame, bool aAckRequest)
+otError MeshForwarder::SendEmptyFrame(Mac::Frame &aFrame, bool aAckRequest)
 {
     uint16_t fcf;
     uint8_t secCtl;
@@ -1414,15 +1414,15 @@ ThreadError MeshForwarder::SendEmptyFrame(Mac::Frame &aFrame, bool aAckRequest)
     aFrame.SetPayloadLength(0);
     aFrame.SetFramePending(false);
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-void MeshForwarder::HandleSentFrame(void *aContext, Mac::Frame &aFrame, ThreadError aError)
+void MeshForwarder::HandleSentFrame(void *aContext, Mac::Frame &aFrame, otError aError)
 {
     static_cast<MeshForwarder *>(aContext)->HandleSentFrame(aFrame, aError);
 }
 
-void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, ThreadError aError)
+void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, otError aError)
 {
     Mac::Address macDest;
     Child *child;
@@ -1444,7 +1444,7 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, ThreadError aError)
     {
         switch (aError)
         {
-        case kThreadError_None:
+        case OT_ERROR_NONE:
             if (aFrame.GetAckRequest())
             {
                 neighbor->ResetLinkFailures();
@@ -1452,11 +1452,11 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, ThreadError aError)
 
             break;
 
-        case kThreadError_ChannelAccessFailure:
-        case kThreadError_Abort:
+        case OT_ERROR_CHANNEL_ACCESS_FAILURE:
+        case OT_ERROR_ABORT:
             break;
 
-        case kThreadError_NoAck:
+        case OT_ERROR_NO_ACK:
             neighbor->IncrementLinkFailures();
 
             if (mNetif.GetMle().IsActiveRouter(neighbor->GetRloc16()))
@@ -1485,7 +1485,7 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, ThreadError aError)
         {
             switch (aError)
             {
-            case kThreadError_None:
+            case OT_ERROR_NONE:
                 child->ResetIndirectTxAttempts();
                 break;
 
@@ -1563,7 +1563,7 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, ThreadError aError)
             }
         }
 
-        if (aError == kThreadError_None)
+        if (aError == OT_ERROR_NONE)
         {
             mNetif.GetChildSupervisor().UpdateOnSend(*child);
         }
@@ -1679,11 +1679,11 @@ void MeshForwarder::HandleReceivedFrame(Mac::Frame &aFrame)
     uint8_t *payload;
     uint8_t payloadLength;
     uint8_t commandId;
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (!mEnabled)
     {
-        ExitNow(error = kThreadError_InvalidState);
+        ExitNow(error = OT_ERROR_INVALID_STATE);
     }
 
     SuccessOrExit(error = aFrame.GetSrcAddr(macSource));
@@ -1721,7 +1721,7 @@ void MeshForwarder::HandleReceivedFrame(Mac::Frame &aFrame)
         }
         else
         {
-            error = kThreadError_NonLowpanDataFrame;
+            error = OT_ERROR_NOT_LOWPAN_DATA_FRAME;
         }
 
         break;
@@ -1735,19 +1735,19 @@ void MeshForwarder::HandleReceivedFrame(Mac::Frame &aFrame)
         }
         else
         {
-            error = kThreadError_Drop;
+            error = OT_ERROR_DROP;
         }
 
         break;
 
     default:
-        error = kThreadError_Drop;
+        error = OT_ERROR_DROP;
         break;
     }
 
 exit:
 
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         char stringBuffer[Mac::Frame::kInfoStringSize];
 
@@ -1761,17 +1761,17 @@ exit:
 void MeshForwarder::HandleMesh(uint8_t *aFrame, uint8_t aFrameLength, const Mac::Address &aMacSource,
                                const ThreadMessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Message *message = NULL;
     Mac::Address meshDest;
     Mac::Address meshSource;
     Lowpan::MeshHeader meshHeader;
 
     // Check the mesh header
-    VerifyOrExit(meshHeader.Init(aFrame, aFrameLength) == kThreadError_None, error = kThreadError_Drop);
+    VerifyOrExit(meshHeader.Init(aFrame, aFrameLength) == OT_ERROR_NONE, error = OT_ERROR_DROP);
 
     // Security Check: only process Mesh Header frames that had security enabled.
-    VerifyOrExit(aMessageInfo.mLinkSecurity && meshHeader.IsValid(), error = kThreadError_Security);
+    VerifyOrExit(aMessageInfo.mLinkSecurity && meshHeader.IsValid(), error = OT_ERROR_SECURITY);
 
     meshSource.mLength = sizeof(meshSource.mShortAddress);
     meshSource.mShortAddress = meshHeader.GetSource();
@@ -1793,7 +1793,7 @@ void MeshForwarder::HandleMesh(uint8_t *aFrame, uint8_t aFrameLength, const Mac:
         }
         else
         {
-            ExitNow(error = kThreadError_Parse);
+            ExitNow(error = OT_ERROR_PARSE);
         }
     }
     else if (meshHeader.GetHopsLeft() > 0)
@@ -1806,7 +1806,7 @@ void MeshForwarder::HandleMesh(uint8_t *aFrame, uint8_t aFrameLength, const Mac:
         meshHeader.AppendTo(aFrame);
 
         VerifyOrExit((message = mNetif.GetIp6().mMessagePool.New(Message::kType6lowpan, 0)) != NULL,
-                     error = kThreadError_NoBufs);
+                     error = OT_ERROR_NO_BUFS);
         SuccessOrExit(error = message->SetLength(aFrameLength));
         message->Write(0, aFrameLength, aFrame);
         message->SetLinkSecurityEnabled(aMessageInfo.mLinkSecurity);
@@ -1817,7 +1817,7 @@ void MeshForwarder::HandleMesh(uint8_t *aFrame, uint8_t aFrameLength, const Mac:
 
 exit:
 
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         char srcStringBuffer[Mac::Address::kAddressStringSize];
 
@@ -1839,14 +1839,14 @@ exit:
     }
 }
 
-ThreadError MeshForwarder::CheckReachability(uint8_t *aFrame, uint8_t aFrameLength,
-                                             const Mac::Address &aMeshSource, const Mac::Address &aMeshDest)
+otError MeshForwarder::CheckReachability(uint8_t *aFrame, uint8_t aFrameLength,
+                                         const Mac::Address &aMeshSource, const Mac::Address &aMeshDest)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Ip6::Header ip6Header;
     Lowpan::MeshHeader meshHeader;
 
-    VerifyOrExit(meshHeader.Init(aFrame, aFrameLength) == kThreadError_None, error = kThreadError_Drop);
+    VerifyOrExit(meshHeader.Init(aFrame, aFrameLength) == OT_ERROR_NONE, error = OT_ERROR_DROP);
 
     // skip mesh header
     aFrame += meshHeader.GetHeaderLength();
@@ -1856,7 +1856,7 @@ ThreadError MeshForwarder::CheckReachability(uint8_t *aFrame, uint8_t aFrameLeng
     if (aFrameLength >= 1 &&
         reinterpret_cast<Lowpan::FragmentHeader *>(aFrame)->IsFragmentHeader())
     {
-        VerifyOrExit(sizeof(Lowpan::FragmentHeader) <= aFrameLength, error = kThreadError_Drop);
+        VerifyOrExit(sizeof(Lowpan::FragmentHeader) <= aFrameLength, error = OT_ERROR_DROP);
         VerifyOrExit(reinterpret_cast<Lowpan::FragmentHeader *>(aFrame)->GetDatagramOffset() == 0);
 
         aFrame += reinterpret_cast<Lowpan::FragmentHeader *>(aFrame)->GetHeaderLength();
@@ -1867,7 +1867,7 @@ ThreadError MeshForwarder::CheckReachability(uint8_t *aFrame, uint8_t aFrameLeng
     VerifyOrExit(aFrameLength >= 1 && Lowpan::Lowpan::IsLowpanHc(aFrame));
 
     VerifyOrExit(mNetif.GetLowpan().DecompressBaseHeader(ip6Header, aMeshSource, aMeshDest, aFrame, aFrameLength) > 0,
-                 error = kThreadError_Drop);
+                 error = OT_ERROR_DROP);
 
     error = mNetif.GetMle().CheckReachability(aMeshSource.mShortAddress, aMeshDest.mShortAddress, ip6Header);
 
@@ -1879,7 +1879,7 @@ void MeshForwarder::HandleFragment(uint8_t *aFrame, uint8_t aFrameLength,
                                    const Mac::Address &aMacSource, const Mac::Address &aMacDest,
                                    const ThreadMessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Lowpan::FragmentHeader *fragmentHeader = reinterpret_cast<Lowpan::FragmentHeader *>(aFrame);
     uint16_t datagramLength = fragmentHeader->GetDatagramSize();
     uint16_t datagramTag = fragmentHeader->GetDatagramTag();
@@ -1892,17 +1892,17 @@ void MeshForwarder::HandleFragment(uint8_t *aFrame, uint8_t aFrameLength,
         aFrameLength -= fragmentHeader->GetHeaderLength();
 
         VerifyOrExit((message = mNetif.GetIp6().mMessagePool.New(Message::kTypeIp6, 0)) != NULL,
-                     error = kThreadError_NoBufs);
+                     error = OT_ERROR_NO_BUFS);
         message->SetLinkSecurityEnabled(aMessageInfo.mLinkSecurity);
         message->SetPanId(aMessageInfo.mPanId);
         headerLength = mNetif.GetLowpan().Decompress(*message, aMacSource, aMacDest, aFrame, aFrameLength,
                                                      datagramLength);
-        VerifyOrExit(headerLength > 0, error = kThreadError_Parse);
+        VerifyOrExit(headerLength > 0, error = OT_ERROR_PARSE);
 
         aFrame += headerLength;
         aFrameLength -= static_cast<uint8_t>(headerLength);
 
-        VerifyOrExit(datagramLength >= message->GetOffset() + aFrameLength, error = kThreadError_Parse);
+        VerifyOrExit(datagramLength >= message->GetOffset() + aFrameLength, error = OT_ERROR_PARSE);
 
         SuccessOrExit(error = message->SetLength(datagramLength));
 
@@ -1914,7 +1914,7 @@ void MeshForwarder::HandleFragment(uint8_t *aFrame, uint8_t aFrameLength,
         message->MoveOffset(aFrameLength);
 
         // Security Check
-        VerifyOrExit(mNetif.GetIp6Filter().Accept(*message), error = kThreadError_Drop);
+        VerifyOrExit(mNetif.GetIp6Filter().Accept(*message), error = OT_ERROR_DROP);
 
         // Allow re-assembly of only one message at a time on a SED by clearing
         // any remaining fragments in reassembly list upon receiving of a new
@@ -1963,7 +1963,7 @@ void MeshForwarder::HandleFragment(uint8_t *aFrame, uint8_t aFrameLength,
             }
         }
 
-        VerifyOrExit(message != NULL, error = kThreadError_Drop);
+        VerifyOrExit(message != NULL, error = OT_ERROR_DROP);
 
         // copy Fragment
         message->Write(message->GetOffset(), aFrameLength, aFrame);
@@ -1972,7 +1972,7 @@ void MeshForwarder::HandleFragment(uint8_t *aFrame, uint8_t aFrameLength,
 
 exit:
 
-    if (error == kThreadError_None)
+    if (error == OT_ERROR_NONE)
     {
         if (message->GetOffset() >= message->GetLength())
         {
@@ -2018,7 +2018,7 @@ void MeshForwarder::ClearReassemblyList(void)
         next = message->GetNext();
         mReassemblyList.Dequeue(*message);
 
-        LogIp6Message(kMessageDrop, *message, NULL, kThreadError_NoFrameReceived);
+        LogIp6Message(kMessageDrop, *message, NULL, OT_ERROR_NO_FRAME_RECEIVED);
 
         message->Free();
     }
@@ -2047,7 +2047,7 @@ void MeshForwarder::HandleReassemblyTimer()
         {
             mReassemblyList.Dequeue(*message);
 
-            LogIp6Message(kMessageDrop, *message, NULL, kThreadError_ReassemblyTimeout);
+            LogIp6Message(kMessageDrop, *message, NULL, OT_ERROR_REASSEMBLY_TIMEOUT);
 
             message->Free();
         }
@@ -2063,17 +2063,17 @@ void MeshForwarder::HandleLowpanHC(uint8_t *aFrame, uint8_t aFrameLength,
                                    const Mac::Address &aMacSource, const Mac::Address &aMacDest,
                                    const ThreadMessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Message *message;
     int headerLength;
 
     VerifyOrExit((message = mNetif.GetIp6().mMessagePool.New(Message::kTypeIp6, 0)) != NULL,
-                 error = kThreadError_NoBufs);
+                 error = OT_ERROR_NO_BUFS);
     message->SetLinkSecurityEnabled(aMessageInfo.mLinkSecurity);
     message->SetPanId(aMessageInfo.mPanId);
 
     headerLength = mNetif.GetLowpan().Decompress(*message, aMacSource, aMacDest, aFrame, aFrameLength, 0);
-    VerifyOrExit(headerLength > 0, error = kThreadError_Parse);
+    VerifyOrExit(headerLength > 0, error = OT_ERROR_PARSE);
 
     aFrame += headerLength;
     aFrameLength -= static_cast<uint8_t>(headerLength);
@@ -2082,11 +2082,11 @@ void MeshForwarder::HandleLowpanHC(uint8_t *aFrame, uint8_t aFrameLength,
     message->Write(message->GetOffset(), aFrameLength, aFrame);
 
     // Security Check
-    VerifyOrExit(mNetif.GetIp6Filter().Accept(*message), error = kThreadError_Drop);
+    VerifyOrExit(mNetif.GetIp6Filter().Accept(*message), error = OT_ERROR_DROP);
 
 exit:
 
-    if (error == kThreadError_None)
+    if (error == OT_ERROR_NONE)
     {
         HandleDatagram(*message, aMessageInfo, aMacSource);
     }
@@ -2115,10 +2115,10 @@ exit:
     }
 }
 
-ThreadError MeshForwarder::HandleDatagram(Message &aMessage, const ThreadMessageInfo &aMessageInfo,
-                                          const Mac::Address &aMacSource)
+otError MeshForwarder::HandleDatagram(Message &aMessage, const ThreadMessageInfo &aMessageInfo,
+                                      const Mac::Address &aMacSource)
 {
-    LogIp6Message(kMessageReceive, aMessage, &aMacSource, kThreadError_None);
+    LogIp6Message(kMessageReceive, aMessage, &aMacSource, OT_ERROR_NONE);
 
     return mNetif.GetIp6().HandleDatagram(aMessage, &mNetif, mNetif.GetInterfaceId(), &aMessageInfo, false);
 }
@@ -2159,7 +2159,7 @@ void MeshForwarder::HandleDataPollTimeout(void *aContext)
 #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OPENTHREAD_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MAC == 1)
 
 void MeshForwarder::LogIp6Message(MessageAction aAction, const Message &aMessage, const Mac::Address *aMacAddress,
-                                  ThreadError aError)
+                                  otError aError)
 {
     uint16_t checksum = 0;
     Ip6::Header ip6Header;
@@ -2213,7 +2213,7 @@ void MeshForwarder::LogIp6Message(MessageAction aAction, const Message &aMessage
         break;
 
     case kMessageTransmit:
-        actionText = (aError == kThreadError_None) ? "Sent" : "Failed to send";
+        actionText = (aError == OT_ERROR_NONE) ? "Sent" : "Failed to send";
         break;
 
     case kMessagePrepareIndirect:
@@ -2263,8 +2263,8 @@ void MeshForwarder::LogIp6Message(MessageAction aAction, const Message &aMessage
         (aMacAddress == NULL) ? "" : ((aAction == kMessageReceive) ? ", from:" : ", to:"),
         (aMacAddress == NULL) ? "" : aMacAddress->ToString(stringBuffer, sizeof(stringBuffer)),
         aMessage.IsLinkSecurityEnabled() ? "yes" : "no",
-        (aError == kThreadError_None) ? "" : ", error:",
-        (aError == kThreadError_None) ? "" : otThreadErrorToString(aError),
+        (aError == OT_ERROR_NONE) ? "" : ", error:",
+        (aError == OT_ERROR_NONE) ? "" : otThreadErrorToString(aError),
         priorityText
     );
 
@@ -2280,7 +2280,7 @@ exit:
 
 #else // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OPENTHREAD_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MAC == 1)
 
-void MeshForwarder::LogIp6Message(MessageAction, const Message &, const Mac::Address *, ThreadError)
+void MeshForwarder::LogIp6Message(MessageAction, const Message &, const Mac::Address *, otError)
 {
 }
 

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -92,39 +92,39 @@ public:
     /**
      * This method enables mesh forwarding and the IEEE 802.15.4 MAC layer.
      *
-     * @retval kThreadError_None          Successfully enabled the mesh forwarder.
+     * @retval OT_ERROR_NONE          Successfully enabled the mesh forwarder.
      *
      */
-    ThreadError Start(void);
+    otError Start(void);
 
     /**
      * This method disables mesh forwarding and the IEEE 802.15.4 MAC layer.
      *
-     * @retval kThreadError_None          Successfully disabled the mesh forwarder.
+     * @retval OT_ERROR_NONE          Successfully disabled the mesh forwarder.
      *
      */
-    ThreadError Stop(void);
+    otError Stop(void);
 
     /**
      * This method submits a message to the mesh forwarder for forwarding.
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None     Successfully enqueued the message.
-     * @retval kThreadError_Already  The message was already enqueued.
-     * @retval kThreadError_Drop     The message could not be sent and should be dropped.
+     * @retval OT_ERROR_NONE     Successfully enqueued the message.
+     * @retval OT_ERROR_ALREADY  The message was already enqueued.
+     * @retval OT_ERROR_DROP     The message could not be sent and should be dropped.
      *
      */
-    ThreadError SendMessage(Message &aMessage);
+    otError SendMessage(Message &aMessage);
 
     /**
      * This method is called by the address resolver when an EID-to-RLOC mapping has been resolved.
      *
      * @param[in]  aEid    A reference to the EID that has been resolved.
-     * @param[in]  aError  kThreadError_None on success and kThreadError_Drop otherwise.
+     * @param[in]  aError  OT_ERROR_NONE on success and OT_ERROR_DROP otherwise.
      *
      */
-    void HandleResolved(const Ip6::Address &aEid, ThreadError aError);
+    void HandleResolved(const Ip6::Address &aEid, otError aError);
 
     /**
      * This method sets the radio receiver and polling timer off.
@@ -249,14 +249,14 @@ private:
         kMessageDrop,                    ///< Indicates that the message is being dropped from reassembly list.
     };
 
-    ThreadError CheckReachability(uint8_t *aFrame, uint8_t aFrameLength,
-                                  const Mac::Address &aMeshSource, const Mac::Address &aMeshDest);
+    otError CheckReachability(uint8_t *aFrame, uint8_t aFrameLength,
+                              const Mac::Address &aMeshSource, const Mac::Address &aMeshDest);
 
-    ThreadError GetMacDestinationAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr);
-    ThreadError GetMacSourceAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr);
+    otError GetMacDestinationAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr);
+    otError GetMacSourceAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr);
     Message *GetDirectTransmission(void);
     Message *GetIndirectTransmission(Child &aChild);
-    ThreadError PrepareDiscoverRequest(void);
+    otError PrepareDiscoverRequest(void);
     void PrepareIndirectTransmission(Message &aMessage, const Child &aChild);
     void HandleMesh(uint8_t *aFrame, uint8_t aPayloadLength, const Mac::Address &aMacSource,
                     const ThreadMessageInfo &aMessageInfo);
@@ -267,22 +267,22 @@ private:
                         const Mac::Address &aMacSource, const Mac::Address &aMacDest,
                         const ThreadMessageInfo &aMessageInfo);
     void HandleDataRequest(const Mac::Address &aMacSource, const ThreadMessageInfo &aMessageInfo);
-    ThreadError SendPoll(Message &aMessage, Mac::Frame &aFrame);
-    ThreadError SendMesh(Message &aMessage, Mac::Frame &aFrame);
-    ThreadError SendFragment(Message &aMessage, Mac::Frame &aFrame);
-    ThreadError SendEmptyFrame(Mac::Frame &aFrame, bool aAckRequest);
-    ThreadError UpdateIp6Route(Message &aMessage);
-    ThreadError UpdateMeshRoute(Message &aMessage);
-    ThreadError HandleDatagram(Message &aMessage, const ThreadMessageInfo &aMessageInfo,
-                               const Mac::Address &aMacSource);
+    otError SendPoll(Message &aMessage, Mac::Frame &aFrame);
+    otError SendMesh(Message &aMessage, Mac::Frame &aFrame);
+    otError SendFragment(Message &aMessage, Mac::Frame &aFrame);
+    otError SendEmptyFrame(Mac::Frame &aFrame, bool aAckRequest);
+    otError UpdateIp6Route(Message &aMessage);
+    otError UpdateMeshRoute(Message &aMessage);
+    otError HandleDatagram(Message &aMessage, const ThreadMessageInfo &aMessageInfo,
+                           const Mac::Address &aMacSource);
     void ClearReassemblyList(void);
 
     static void HandleReceivedFrame(void *aContext, Mac::Frame &aFrame);
     void HandleReceivedFrame(Mac::Frame &aFrame);
-    static ThreadError HandleFrameRequest(void *aContext, Mac::Frame &aFrame);
-    ThreadError HandleFrameRequest(Mac::Frame &aFrame);
-    static void HandleSentFrame(void *aContext, Mac::Frame &aFrame, ThreadError aError);
-    void HandleSentFrame(Mac::Frame &aFrame, ThreadError aError);
+    static otError HandleFrameRequest(void *aContext, Mac::Frame &aFrame);
+    otError HandleFrameRequest(Mac::Frame &aFrame);
+    static void HandleSentFrame(void *aContext, Mac::Frame &aFrame, otError aError);
+    void HandleSentFrame(Mac::Frame &aFrame, otError aError);
     static void HandleDiscoverTimer(void *aContext);
     void HandleDiscoverTimer(void);
     static void HandleReassemblyTimer(void *aContext);
@@ -291,12 +291,12 @@ private:
     void ScheduleTransmissionTask(void);
     static void HandleDataPollTimeout(void *aContext);
 
-    ThreadError AddPendingSrcMatchEntries(void);
-    ThreadError AddSrcMatchEntry(Child &aChild);
+    otError AddPendingSrcMatchEntries(void);
+    otError AddSrcMatchEntry(Child &aChild);
     void ClearSrcMatchEntry(Child &aChild);
 
     void LogIp6Message(MessageAction aAction, const Message &aMessage, const Mac::Address *aMacAddress,
-                       ThreadError aError);
+                       otError aError);
 
     ThreadNetif &mNetif;
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -184,9 +184,9 @@ otInstance *Mle::GetInstance(void)
     return mNetif.GetInstance();
 }
 
-ThreadError Mle::Enable(void)
+otError Mle::Enable(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Ip6::SockAddr sockaddr;
 
     // memcpy(&sockaddr.mAddr, &mLinkLocal64.GetAddress(), sizeof(sockaddr.mAddr));
@@ -198,9 +198,9 @@ exit:
     return error;
 }
 
-ThreadError Mle::Disable(void)
+otError Mle::Disable(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     SuccessOrExit(error = Stop(false));
     SuccessOrExit(error = mSocket.Close());
@@ -209,15 +209,15 @@ exit:
     return error;
 }
 
-ThreadError Mle::Start(bool aEnableReattach, bool aAnnounceAttach)
+otError Mle::Start(bool aEnableReattach, bool aAnnounceAttach)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     otLogFuncEntry();
 
     // cannot bring up the interface if IEEE 802.15.4 promiscuous mode is enabled
-    VerifyOrExit(otPlatRadioGetPromiscuous(mNetif.GetInstance()) == false, error = kThreadError_InvalidState);
-    VerifyOrExit(mNetif.IsUp(), error = kThreadError_InvalidState);
+    VerifyOrExit(otPlatRadioGetPromiscuous(mNetif.GetInstance()) == false, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(mNetif.IsUp(), error = OT_ERROR_INVALID_STATE);
 
     mDeviceState = kDeviceStateDetached;
     mNetif.SetStateChangedFlags(OT_NET_ROLE);
@@ -236,7 +236,7 @@ ThreadError Mle::Start(bool aEnableReattach, bool aAnnounceAttach)
     }
     else if (IsActiveRouter(GetRloc16()))
     {
-        if (mNetif.GetMle().BecomeRouter(ThreadStatusTlv::kTooFewRouters) != kThreadError_None)
+        if (mNetif.GetMle().BecomeRouter(ThreadStatusTlv::kTooFewRouters) != OT_ERROR_NONE)
         {
             BecomeChild(kMleAttachAnyPartition);
         }
@@ -253,7 +253,7 @@ exit:
     return error;
 }
 
-ThreadError Mle::Stop(bool aClearNetworkDatasets)
+otError Mle::Stop(bool aClearNetworkDatasets)
 {
     otLogFuncEntry();
     mNetif.GetKeyManager().Stop();
@@ -270,12 +270,12 @@ ThreadError Mle::Stop(bool aClearNetworkDatasets)
 
     mDeviceState = kDeviceStateDisabled;
     otLogFuncExit();
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Mle::Restore(void)
+otError Mle::Restore(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Settings::NetworkInfo networkInfo;
     Settings::ParentInfo parentInfo;
     uint16_t length;
@@ -286,8 +286,8 @@ ThreadError Mle::Restore(void)
     length = sizeof(networkInfo);
     SuccessOrExit(error = otPlatSettingsGet(mNetif.GetInstance(), Settings::kKeyNetworkInfo, 0,
                                             reinterpret_cast<uint8_t *>(&networkInfo), &length));
-    VerifyOrExit(length == sizeof(networkInfo), error = kThreadError_NotFound);
-    VerifyOrExit(networkInfo.mDeviceState >= kDeviceStateChild, error = kThreadError_NotFound);
+    VerifyOrExit(length == sizeof(networkInfo), error = OT_ERROR_NOT_FOUND);
+    VerifyOrExit(networkInfo.mDeviceState >= kDeviceStateChild, error = OT_ERROR_NOT_FOUND);
 
     mDeviceMode = networkInfo.mDeviceMode;
     SetRloc16(networkInfo.mRloc16);
@@ -306,7 +306,7 @@ ThreadError Mle::Restore(void)
         length = sizeof(parentInfo);
         SuccessOrExit(error = otPlatSettingsGet(mNetif.GetInstance(), Settings::kKeyParentInfo, 0,
                                                 reinterpret_cast<uint8_t *>(&parentInfo), &length));
-        VerifyOrExit(length >= sizeof(parentInfo), error = kThreadError_Parse);
+        VerifyOrExit(length >= sizeof(parentInfo), error = OT_ERROR_PARSE);
 
         memset(&mParent, 0, sizeof(mParent));
         mParent.SetExtAddress(*static_cast<Mac::ExtAddress *>(&parentInfo.mExtAddress));
@@ -328,8 +328,8 @@ ThreadError Mle::Restore(void)
         // refresh the info to ensure that the non-volatile settings
         // stay in sync with the child table.
 
-        case kThreadError_Failed:
-        case kThreadError_NoBufs:
+        case OT_ERROR_FAILED:
+        case OT_ERROR_NO_BUFS:
             mNetif.GetMle().RefreshStoredChildren();
             break;
 
@@ -342,13 +342,13 @@ exit:
     return error;
 }
 
-ThreadError Mle::Store(void)
+otError Mle::Store(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Settings::NetworkInfo networkInfo;
     Settings::ParentInfo parentInfo;
 
-    VerifyOrExit(IsAttached(), error = kThreadError_InvalidState);
+    VerifyOrExit(IsAttached(), error = OT_ERROR_INVALID_STATE);
 
     if (mNetif.GetActiveDataset().GetLocal().GetTimestamp() == NULL)
     {
@@ -394,17 +394,17 @@ exit:
     return error;
 }
 
-ThreadError Mle::Discover(uint32_t aScanChannels, uint16_t aPanId, bool aJoiner, bool aEnableEui64Filtering,
-                          DiscoverHandler aCallback, void *aContext)
+otError Mle::Discover(uint32_t aScanChannels, uint16_t aPanId, bool aJoiner, bool aEnableEui64Filtering,
+                      DiscoverHandler aCallback, void *aContext)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Message *message = NULL;
     Ip6::Address destination;
     Tlv tlv;
     MeshCoP::DiscoveryRequestTlv discoveryRequest;
     uint16_t startOffset;
 
-    VerifyOrExit(!mIsDiscoverInProgress, error = kThreadError_Busy);
+    VerifyOrExit(!mIsDiscoverInProgress, error = OT_ERROR_BUSY);
 
     mEnableEui64Filtering = aEnableEui64Filtering;
 
@@ -412,7 +412,7 @@ ThreadError Mle::Discover(uint32_t aScanChannels, uint16_t aPanId, bool aJoiner,
     mDiscoverContext = aContext;
     mNetif.GetMeshForwarder().SetDiscoverParameters(aScanChannels);
 
-    VerifyOrExit((message = NewMleMessage()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     message->SetSubType(Message::kSubTypeMleDiscoverRequest);
     message->SetPanId(aPanId);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandDiscoveryRequest));
@@ -443,7 +443,7 @@ ThreadError Mle::Discover(uint32_t aScanChannels, uint16_t aPanId, bool aJoiner,
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -463,13 +463,13 @@ void Mle::HandleDiscoverComplete(void)
     mDiscoverHandler(NULL, mDiscoverContext);
 }
 
-ThreadError Mle::BecomeDetached(void)
+otError Mle::BecomeDetached(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     otLogFuncEntry();
 
-    VerifyOrExit(mDeviceState != kDeviceStateDisabled, error = kThreadError_InvalidState);
+    VerifyOrExit(mDeviceState != kDeviceStateDisabled, error = OT_ERROR_INVALID_STATE);
 
     if (mReattachState == kReattachStop)
     {
@@ -486,18 +486,18 @@ exit:
     return error;
 }
 
-ThreadError Mle::BecomeChild(otMleAttachFilter aFilter)
+otError Mle::BecomeChild(otMleAttachFilter aFilter)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     otLogFuncEntry();
 
-    VerifyOrExit(mDeviceState != kDeviceStateDisabled, error = kThreadError_InvalidState);
-    VerifyOrExit(mParentRequestState == kParentIdle, error = kThreadError_Busy);
+    VerifyOrExit(mDeviceState != kDeviceStateDisabled, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(mParentRequestState == kParentIdle, error = OT_ERROR_BUSY);
 
     if (mReattachState == kReattachStart)
     {
-        if (mNetif.GetActiveDataset().Restore() == kThreadError_None)
+        if (mNetif.GetActiveDataset().Restore() == OT_ERROR_NONE)
         {
             mReattachState = kReattachActive;
         }
@@ -544,7 +544,7 @@ bool Mle::IsAttached(void) const
             mDeviceState == kDeviceStateLeader);
 }
 
-ThreadError Mle::SetStateDetached(void)
+otError Mle::SetStateDetached(void)
 {
     if (mDeviceState != kDeviceStateDetached)
     {
@@ -566,10 +566,10 @@ ThreadError Mle::SetStateDetached(void)
     mNetif.GetIp6().mMpl.SetTimerExpirations(0);
 
     otLogInfoMle(GetInstance(), "Mode -> Detached");
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Mle::SetStateChild(uint16_t aRloc16)
+otError Mle::SetStateChild(uint16_t aRloc16)
 {
     if (mDeviceState != kDeviceStateChild)
     {
@@ -610,10 +610,10 @@ ThreadError Mle::SetStateChild(uint16_t aRloc16)
     }
 
     otLogInfoMle(GetInstance(), "Mode -> Child");
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Mle::SetTimeout(uint32_t aTimeout)
+otError Mle::SetTimeout(uint32_t aTimeout)
 {
     VerifyOrExit(mTimeout != aTimeout);
 
@@ -632,16 +632,16 @@ ThreadError Mle::SetTimeout(uint32_t aTimeout)
     }
 
 exit:
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Mle::SetDeviceMode(uint8_t aDeviceMode)
+otError Mle::SetDeviceMode(uint8_t aDeviceMode)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t oldMode = mDeviceMode;
 
     VerifyOrExit((aDeviceMode & ModeTlv::kModeFFD) == 0 || (aDeviceMode & ModeTlv::kModeRxOnWhenIdle) != 0,
-                 error = kThreadError_InvalidArgs);
+                 error = OT_ERROR_INVALID_ARGS);
     VerifyOrExit(mDeviceMode != aDeviceMode);
 
     mDeviceMode = aDeviceMode;
@@ -671,7 +671,7 @@ exit:
     return error;
 }
 
-ThreadError Mle::UpdateLinkLocalAddress(void)
+otError Mle::UpdateLinkLocalAddress(void)
 {
     mNetif.RemoveUnicastAddress(mLinkLocal64);
     mLinkLocal64.GetAddress().SetIid(*mNetif.GetMac().GetExtAddress());
@@ -679,7 +679,7 @@ ThreadError Mle::UpdateLinkLocalAddress(void)
 
     mNetif.SetStateChangedFlags(OT_IP6_LL_ADDR_CHANGED);
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 const uint8_t *Mle::GetMeshLocalPrefix(void) const
@@ -687,7 +687,7 @@ const uint8_t *Mle::GetMeshLocalPrefix(void) const
     return mMeshLocal16.GetAddress().mFields.m8;
 }
 
-ThreadError Mle::SetMeshLocalPrefix(const uint8_t *aMeshLocalPrefix)
+otError Mle::SetMeshLocalPrefix(const uint8_t *aMeshLocalPrefix)
 {
     if (memcmp(mMeshLocal64.GetAddress().mFields.m8, aMeshLocalPrefix, 8) == 0)
     {
@@ -726,7 +726,7 @@ ThreadError Mle::SetMeshLocalPrefix(const uint8_t *aMeshLocalPrefix)
     mNetif.SetStateChangedFlags(OT_IP6_ML_ADDR_CHANGED);
 
 exit:
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 const Ip6::Address *Mle::GetLinkLocalAllThreadNodesAddress(void) const
@@ -744,7 +744,7 @@ uint16_t Mle::GetRloc16(void) const
     return mNetif.GetMac().GetShortAddress();
 }
 
-ThreadError Mle::SetRloc16(uint16_t aRloc16)
+otError Mle::SetRloc16(uint16_t aRloc16)
 {
     mNetif.RemoveUnicastAddress(mMeshLocal16);
 
@@ -758,7 +758,7 @@ ThreadError Mle::SetRloc16(uint16_t aRloc16)
     mNetif.GetMac().SetShortAddress(aRloc16);
     mNetif.GetIp6().mMpl.SetSeedId(aRloc16);
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 uint8_t Mle::GetLeaderId(void) const
@@ -788,11 +788,11 @@ const Ip6::Address &Mle::GetMeshLocal64(void) const
     return mMeshLocal64.GetAddress();
 }
 
-ThreadError Mle::GetLeaderAddress(Ip6::Address &aAddress) const
+otError Mle::GetLeaderAddress(Ip6::Address &aAddress) const
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(GetRloc16() != Mac::kShortAddrInvalid, error = kThreadError_Detached);
+    VerifyOrExit(GetRloc16() != Mac::kShortAddrInvalid, error = OT_ERROR_DETACHED);
 
     memcpy(&aAddress, &mMeshLocal16.GetAddress(), 8);
     aAddress.mFields.m16[4] = HostSwap16(0x0000);
@@ -804,11 +804,11 @@ exit:
     return error;
 }
 
-ThreadError Mle::GetLeaderAloc(Ip6::Address &aAddress) const
+otError Mle::GetLeaderAloc(Ip6::Address &aAddress) const
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(GetRloc16() != Mac::kShortAddrInvalid, error = kThreadError_Detached);
+    VerifyOrExit(GetRloc16() != Mac::kShortAddrInvalid, error = OT_ERROR_DETACHED);
 
     memcpy(&aAddress, &mMeshLocal16.GetAddress(), 8);
     aAddress.mFields.m16[4] = HostSwap16(0x0000);
@@ -820,11 +820,11 @@ exit:
     return error;
 }
 
-ThreadError Mle::AddLeaderAloc(void)
+otError Mle::AddLeaderAloc(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mDeviceState == kDeviceStateLeader, error = kThreadError_InvalidState);
+    VerifyOrExit(mDeviceState == kDeviceStateLeader, error = OT_ERROR_INVALID_STATE);
 
     SuccessOrExit(error = GetLeaderAloc(mLeaderAloc.GetAddress()));
 
@@ -841,13 +841,13 @@ const LeaderDataTlv &Mle::GetLeaderDataTlv(void)
     return mLeaderData;
 }
 
-ThreadError Mle::GetLeaderData(otLeaderData &aLeaderData)
+otError Mle::GetLeaderData(otLeaderData &aLeaderData)
 {
     const LeaderDataTlv &leaderData(GetLeaderDataTlv());
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     VerifyOrExit(mDeviceState != kDeviceStateDisabled && mDeviceState != kDeviceStateDetached,
-                 error = kThreadError_Detached);
+                 error = OT_ERROR_DETACHED);
 
     aLeaderData.mPartitionId = leaderData.GetPartitionId();
     aLeaderData.mWeighting = leaderData.GetWeighting();
@@ -859,15 +859,15 @@ exit:
     return error;
 }
 
-ThreadError Mle::GetAssignLinkQuality(const Mac::ExtAddress aMacAddr, uint8_t &aLinkQuality)
+otError Mle::GetAssignLinkQuality(const Mac::ExtAddress aMacAddr, uint8_t &aLinkQuality)
 {
-    ThreadError error;
+    otError error;
 
-    VerifyOrExit((memcmp(aMacAddr.m8, mAddr64.m8, OT_EXT_ADDRESS_SIZE)) == 0, error = kThreadError_InvalidArgs);
+    VerifyOrExit((memcmp(aMacAddr.m8, mAddr64.m8, OT_EXT_ADDRESS_SIZE)) == 0, error = OT_ERROR_INVALID_ARGS);
 
     aLinkQuality = mAssignLinkQuality;
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 
 exit:
     return error;
@@ -935,9 +935,9 @@ exit:
     return message;
 }
 
-ThreadError Mle::AppendHeader(Message &aMessage, Header::Command aCommand)
+otError Mle::AppendHeader(Message &aMessage, Header::Command aCommand)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Header header;
 
     header.Init();
@@ -960,7 +960,7 @@ exit:
     return error;
 }
 
-ThreadError Mle::AppendSourceAddress(Message &aMessage)
+otError Mle::AppendSourceAddress(Message &aMessage)
 {
     SourceAddressTlv tlv;
 
@@ -970,7 +970,7 @@ ThreadError Mle::AppendSourceAddress(Message &aMessage)
     return aMessage.Append(&tlv, sizeof(tlv));
 }
 
-ThreadError Mle::AppendStatus(Message &aMessage, StatusTlv::Status aStatus)
+otError Mle::AppendStatus(Message &aMessage, StatusTlv::Status aStatus)
 {
     StatusTlv tlv;
 
@@ -980,7 +980,7 @@ ThreadError Mle::AppendStatus(Message &aMessage, StatusTlv::Status aStatus)
     return aMessage.Append(&tlv, sizeof(tlv));
 }
 
-ThreadError Mle::AppendMode(Message &aMessage, uint8_t aMode)
+otError Mle::AppendMode(Message &aMessage, uint8_t aMode)
 {
     ModeTlv tlv;
 
@@ -990,7 +990,7 @@ ThreadError Mle::AppendMode(Message &aMessage, uint8_t aMode)
     return aMessage.Append(&tlv, sizeof(tlv));
 }
 
-ThreadError Mle::AppendTimeout(Message &aMessage, uint32_t aTimeout)
+otError Mle::AppendTimeout(Message &aMessage, uint32_t aTimeout)
 {
     TimeoutTlv tlv;
 
@@ -1000,9 +1000,9 @@ ThreadError Mle::AppendTimeout(Message &aMessage, uint32_t aTimeout)
     return aMessage.Append(&tlv, sizeof(tlv));
 }
 
-ThreadError Mle::AppendChallenge(Message &aMessage, const uint8_t *aChallenge, uint8_t aChallengeLength)
+otError Mle::AppendChallenge(Message &aMessage, const uint8_t *aChallenge, uint8_t aChallengeLength)
 {
-    ThreadError error;
+    otError error;
     Tlv tlv;
 
     tlv.SetType(Tlv::kChallenge);
@@ -1014,9 +1014,9 @@ exit:
     return error;
 }
 
-ThreadError Mle::AppendResponse(Message &aMessage, const uint8_t *aResponse, uint8_t aResponseLength)
+otError Mle::AppendResponse(Message &aMessage, const uint8_t *aResponse, uint8_t aResponseLength)
 {
-    ThreadError error;
+    otError error;
     Tlv tlv;
 
     tlv.SetType(Tlv::kResponse);
@@ -1029,7 +1029,7 @@ exit:
     return error;
 }
 
-ThreadError Mle::AppendLinkFrameCounter(Message &aMessage)
+otError Mle::AppendLinkFrameCounter(Message &aMessage)
 {
     LinkFrameCounterTlv tlv;
 
@@ -1039,7 +1039,7 @@ ThreadError Mle::AppendLinkFrameCounter(Message &aMessage)
     return aMessage.Append(&tlv, sizeof(tlv));
 }
 
-ThreadError Mle::AppendMleFrameCounter(Message &aMessage)
+otError Mle::AppendMleFrameCounter(Message &aMessage)
 {
     MleFrameCounterTlv tlv;
 
@@ -1049,7 +1049,7 @@ ThreadError Mle::AppendMleFrameCounter(Message &aMessage)
     return aMessage.Append(&tlv, sizeof(tlv));
 }
 
-ThreadError Mle::AppendAddress16(Message &aMessage, uint16_t aRloc16)
+otError Mle::AppendAddress16(Message &aMessage, uint16_t aRloc16)
 {
     Address16Tlv tlv;
 
@@ -1059,7 +1059,7 @@ ThreadError Mle::AppendAddress16(Message &aMessage, uint16_t aRloc16)
     return aMessage.Append(&tlv, sizeof(tlv));
 }
 
-ThreadError Mle::AppendLeaderData(Message &aMessage)
+otError Mle::AppendLeaderData(Message &aMessage)
 {
     mLeaderData.Init();
     mLeaderData.SetDataVersion(mNetif.GetNetworkDataLeader().GetVersion());
@@ -1075,9 +1075,9 @@ void Mle::FillNetworkDataTlv(NetworkDataTlv &aTlv, bool aStableOnly)
     aTlv.SetLength(length);
 }
 
-ThreadError Mle::AppendNetworkData(Message &aMessage, bool aStableOnly)
+otError Mle::AppendNetworkData(Message &aMessage, bool aStableOnly)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     NetworkDataTlv tlv;
 
     tlv.Init();
@@ -1089,9 +1089,9 @@ exit:
     return error;
 }
 
-ThreadError Mle::AppendTlvRequest(Message &aMessage, const uint8_t *aTlvs, uint8_t aTlvsLength)
+otError Mle::AppendTlvRequest(Message &aMessage, const uint8_t *aTlvs, uint8_t aTlvsLength)
 {
-    ThreadError error;
+    otError error;
     Tlv tlv;
 
     tlv.SetType(Tlv::kTlvRequest);
@@ -1104,7 +1104,7 @@ exit:
     return error;
 }
 
-ThreadError Mle::AppendScanMask(Message &aMessage, uint8_t aScanMask)
+otError Mle::AppendScanMask(Message &aMessage, uint8_t aScanMask)
 {
     ScanMaskTlv tlv;
 
@@ -1114,7 +1114,7 @@ ThreadError Mle::AppendScanMask(Message &aMessage, uint8_t aScanMask)
     return aMessage.Append(&tlv, sizeof(tlv));
 }
 
-ThreadError Mle::AppendLinkMargin(Message &aMessage, uint8_t aLinkMargin)
+otError Mle::AppendLinkMargin(Message &aMessage, uint8_t aLinkMargin)
 {
     LinkMarginTlv tlv;
 
@@ -1124,7 +1124,7 @@ ThreadError Mle::AppendLinkMargin(Message &aMessage, uint8_t aLinkMargin)
     return aMessage.Append(&tlv, sizeof(tlv));
 }
 
-ThreadError Mle::AppendVersion(Message &aMessage)
+otError Mle::AppendVersion(Message &aMessage)
 {
     VersionTlv tlv;
 
@@ -1134,9 +1134,9 @@ ThreadError Mle::AppendVersion(Message &aMessage)
     return aMessage.Append(&tlv, sizeof(tlv));
 }
 
-ThreadError Mle::AppendAddressRegistration(Message &aMessage)
+otError Mle::AppendAddressRegistration(Message &aMessage)
 {
-    ThreadError error;
+    otError error;
     Tlv tlv;
     AddressRegistrationEntry entry;
     Lowpan::Context context;
@@ -1154,7 +1154,7 @@ ThreadError Mle::AppendAddressRegistration(Message &aMessage)
             continue;
         }
 
-        if (mNetif.GetNetworkDataLeader().GetContext(addr->GetAddress(), context) == kThreadError_None)
+        if (mNetif.GetNetworkDataLeader().GetContext(addr->GetAddress(), context) == OT_ERROR_NONE)
         {
             // compressed entry
             entry.SetContextId(context.mContextId);
@@ -1178,9 +1178,9 @@ exit:
     return error;
 }
 
-ThreadError Mle::AppendActiveTimestamp(Message &aMessage, bool aCouldUseLocal)
+otError Mle::AppendActiveTimestamp(Message &aMessage, bool aCouldUseLocal)
 {
-    ThreadError error;
+    otError error;
     ActiveTimestampTlv timestampTlv;
     const MeshCoP::Timestamp *timestamp;
 
@@ -1189,7 +1189,7 @@ ThreadError Mle::AppendActiveTimestamp(Message &aMessage, bool aCouldUseLocal)
         timestamp = mNetif.GetActiveDataset().GetLocal().GetTimestamp();
     }
 
-    VerifyOrExit(timestamp, error = kThreadError_None);
+    VerifyOrExit(timestamp, error = OT_ERROR_NONE);
 
     timestampTlv.Init();
     *static_cast<MeshCoP::Timestamp *>(&timestampTlv) = *timestamp;
@@ -1199,14 +1199,14 @@ exit:
     return error;
 }
 
-ThreadError Mle::AppendPendingTimestamp(Message &aMessage)
+otError Mle::AppendPendingTimestamp(Message &aMessage)
 {
-    ThreadError error;
+    otError error;
     PendingTimestampTlv timestampTlv;
     const MeshCoP::Timestamp *timestamp;
 
     timestamp = mNetif.GetPendingDataset().GetNetwork().GetTimestamp();
-    VerifyOrExit(timestamp && timestamp->GetSeconds() != 0, error = kThreadError_None);
+    VerifyOrExit(timestamp && timestamp->GetSeconds() != 0, error = OT_ERROR_NONE);
 
     timestampTlv.Init();
     *static_cast<MeshCoP::Timestamp *>(&timestampTlv) = *timestamp;
@@ -1331,7 +1331,7 @@ void Mle::HandleParentRequestTimer(void)
 
             if (mReattachState == kReattachActive)
             {
-                if (mNetif.GetPendingDataset().Restore() == kThreadError_None)
+                if (mNetif.GetPendingDataset().Restore() == OT_ERROR_NONE)
                 {
                     mNetif.GetPendingDataset().ApplyConfiguration();
                     mReattachState = kReattachPending;
@@ -1367,7 +1367,7 @@ void Mle::HandleParentRequestTimer(void)
                         SendOrphanAnnounce();
                         BecomeDetached();
                     }
-                    else if (mNetif.GetMle().BecomeLeader() != kThreadError_None)
+                    else if (mNetif.GetMle().BecomeLeader() != OT_ERROR_NONE)
                     {
                         mParentRequestState = kParentIdle;
                         BecomeDetached();
@@ -1457,7 +1457,7 @@ void Mle::HandleDelayedResponseTimer(void)
             DelayedResponseHeader::RemoveFrom(*message);
 
             // Send the message.
-            if (SendMessage(*message, delayedResponse.GetDestination()) == kThreadError_None)
+            if (SendMessage(*message, delayedResponse.GetDestination()) == OT_ERROR_NONE)
             {
                 otLogInfoMle(GetInstance(), "Sent delayed response");
             }
@@ -1476,9 +1476,9 @@ void Mle::HandleDelayedResponseTimer(void)
     }
 }
 
-ThreadError Mle::SendParentRequest(void)
+otError Mle::SendParentRequest(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Message *message;
     uint8_t scanMask = 0;
     Ip6::Address destination;
@@ -1510,7 +1510,7 @@ ThreadError Mle::SendParentRequest(void)
         break;
     }
 
-    VerifyOrExit((message = NewMleMessage()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandParentRequest));
     SuccessOrExit(error = AppendMode(*message, mDeviceMode));
     SuccessOrExit(error = AppendChallenge(*message, mParentRequest.mChallenge, sizeof(mParentRequest.mChallenge)));
@@ -1542,22 +1542,22 @@ exit:
         mParentRequestTimer.Start(kParentRequestChildTimeout);
     }
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Mle::SendChildIdRequest(void)
+otError Mle::SendChildIdRequest(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t tlvs[] = {Tlv::kAddress16, Tlv::kNetworkData, Tlv::kRoute};
     Message *message;
     Ip6::Address destination;
 
-    VerifyOrExit((message = NewMleMessage()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandChildIdRequest));
     SuccessOrExit(error = AppendResponse(*message, mChildIdRequest.mChallenge, mChildIdRequest.mChallengeLength));
     SuccessOrExit(error = AppendLinkFrameCounter(*message));
@@ -1589,7 +1589,7 @@ ThreadError Mle::SendChildIdRequest(void)
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -1597,13 +1597,13 @@ exit:
     return error;
 }
 
-ThreadError Mle::SendDataRequest(const Ip6::Address &aDestination, const uint8_t *aTlvs, uint8_t aTlvsLength,
-                                 uint16_t aDelay)
+otError Mle::SendDataRequest(const Ip6::Address &aDestination, const uint8_t *aTlvs, uint8_t aTlvsLength,
+                             uint16_t aDelay)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Message *message;
 
-    VerifyOrExit((message = NewMleMessage()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandDataRequest));
     SuccessOrExit(error = AppendTlvRequest(*message, aTlvs, aTlvsLength));
     SuccessOrExit(error = AppendActiveTimestamp(*message, false));
@@ -1627,7 +1627,7 @@ ThreadError Mle::SendDataRequest(const Ip6::Address &aDestination, const uint8_t
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -1654,9 +1654,9 @@ void Mle::HandleSendChildUpdateRequest(void)
     }
 }
 
-ThreadError Mle::SendChildUpdateRequest(void)
+otError Mle::SendChildUpdateRequest(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Ip6::Address destination;
     Message *message = NULL;
 
@@ -1670,7 +1670,7 @@ ThreadError Mle::SendChildUpdateRequest(void)
     mParentRequestTimer.Start(kUnicastRetransmissionDelay);
     mChildUpdateAttempts++;
 
-    VerifyOrExit((message = NewMleMessage()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     message->SetSubType(Message::kSubTypeMleChildUpdateRequest);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandChildUpdateRequest));
     SuccessOrExit(error = AppendMode(*message, mDeviceMode));
@@ -1724,7 +1724,7 @@ ThreadError Mle::SendChildUpdateRequest(void)
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -1732,13 +1732,13 @@ exit:
     return error;
 }
 
-ThreadError Mle::SendChildUpdateResponse(const uint8_t *aTlvs, uint8_t aNumTlvs, const ChallengeTlv &aChallenge)
+otError Mle::SendChildUpdateResponse(const uint8_t *aTlvs, uint8_t aNumTlvs, const ChallengeTlv &aChallenge)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Ip6::Address destination;
     Message *message;
 
-    VerifyOrExit((message = NewMleMessage()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandChildUpdateResponse));
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
@@ -1782,7 +1782,7 @@ ThreadError Mle::SendChildUpdateResponse(const uint8_t *aTlvs, uint8_t aNumTlvs,
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -1790,16 +1790,16 @@ exit:
     return error;
 }
 
-ThreadError Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce)
+otError Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     ChannelTlv channel;
     PanIdTlv panid;
     ActiveTimestampTlv activeTimestamp;
     Ip6::Address destination;
     Message *message;
 
-    VerifyOrExit((message = NewMleMessage()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     message->SetLinkSecurityEnabled(true);
     message->SetSubType(Message::kSubTypeMleAnnounce);
     message->SetChannel(aChannel);
@@ -1837,7 +1837,7 @@ ThreadError Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce)
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -1885,9 +1885,9 @@ exit:
     return;
 }
 
-ThreadError Mle::SendMessage(Message &aMessage, const Ip6::Address &aDestination)
+otError Mle::SendMessage(Message &aMessage, const Ip6::Address &aDestination)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Header header;
     uint32_t keySequence;
     uint8_t nonce[13];
@@ -1951,9 +1951,9 @@ exit:
     return error;
 }
 
-ThreadError Mle::AddDelayedResponse(Message &aMessage, const Ip6::Address &aDestination, uint16_t aDelay)
+otError Mle::AddDelayedResponse(Message &aMessage, const Ip6::Address &aDestination, uint16_t aDelay)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint32_t alarmFireTime;
     uint32_t sendTime = otPlatAlarmGetNow() + aDelay;
 
@@ -2230,9 +2230,9 @@ exit:
     return;
 }
 
-ThreadError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Mac::ExtAddress macAddr;
     bool isNeighbor;
     Neighbor *neighbor;
@@ -2244,11 +2244,11 @@ ThreadError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::Message
 
     // Source Address
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kSourceAddress, sizeof(sourceAddress), sourceAddress));
-    VerifyOrExit(sourceAddress.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(sourceAddress.IsValid(), error = OT_ERROR_PARSE);
 
     // Leader Data
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLeaderData, sizeof(leaderData), leaderData));
-    VerifyOrExit(leaderData.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(leaderData.IsValid(), error = OT_ERROR_PARSE);
 
     otLogInfoMle(GetInstance(), "Received advertisement from %04x", sourceAddress.GetRloc16());
 
@@ -2280,7 +2280,7 @@ ThreadError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::Message
             SetLeaderData(leaderData.GetPartitionId(), leaderData.GetWeighting(), leaderData.GetLeaderRouterId());
 
             if ((mDeviceMode & ModeTlv::kModeFFD) &&
-                (Tlv::GetTlv(aMessage, Tlv::kRoute, sizeof(route), route) == kThreadError_None) &&
+                (Tlv::GetTlv(aMessage, Tlv::kRoute, sizeof(route), route) == OT_ERROR_NONE) &&
                 route.IsValid())
             {
                 // Overwrite Route Data
@@ -2317,7 +2317,7 @@ ThreadError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::Message
 
 exit:
 
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         otLogWarnMleErr(GetInstance(), error, "Failed to process Advertisement");
     }
@@ -2325,15 +2325,15 @@ exit:
     return error;
 }
 
-ThreadError Mle::HandleDataResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError Mle::HandleDataResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error;
+    otError error;
 
     otLogInfoMle(GetInstance(), "Received Data Response");
 
     error = HandleLeaderData(aMessage, aMessageInfo);
 
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         otLogWarnMleErr(GetInstance(), error, "Failed to process Data Response");
     }
@@ -2341,9 +2341,9 @@ ThreadError Mle::HandleDataResponse(const Message &aMessage, const Ip6::MessageI
     return error;
 }
 
-ThreadError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     LeaderDataTlv leaderData;
     NetworkDataTlv networkData;
     ActiveTimestampTlv activeTimestamp;
@@ -2356,7 +2356,7 @@ ThreadError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInf
 
     // Leader Data
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLeaderData, sizeof(leaderData), leaderData));
-    VerifyOrExit(leaderData.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(leaderData.IsValid(), error = OT_ERROR_PARSE);
 
     if ((leaderData.GetPartitionId() != mLeaderData.GetPartitionId()) ||
         (leaderData.GetWeighting() != mLeaderData.GetWeighting()) ||
@@ -2369,7 +2369,7 @@ ThreadError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInf
         }
         else
         {
-            ExitNow(error = kThreadError_Drop);
+            ExitNow(error = OT_ERROR_DROP);
         }
     }
     else if (!mRetrieveNewNetworkData)
@@ -2390,17 +2390,17 @@ ThreadError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInf
     }
 
     // Active Timestamp
-    if (Tlv::GetTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp) == OT_ERROR_NONE)
     {
         const MeshCoP::Timestamp *timestamp;
 
-        VerifyOrExit(activeTimestamp.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(activeTimestamp.IsValid(), error = OT_ERROR_PARSE);
         timestamp = mNetif.GetActiveDataset().GetNetwork().GetTimestamp();
 
         // if received timestamp does not match the local value and message does not contain the dataset,
         // send MLE Data Request
         if ((timestamp == NULL || timestamp->Compare(activeTimestamp) != 0) &&
-            (Tlv::GetOffset(aMessage, Tlv::kActiveDataset, activeDatasetOffset) != kThreadError_None))
+            (Tlv::GetOffset(aMessage, Tlv::kActiveDataset, activeDatasetOffset) != OT_ERROR_NONE))
         {
             ExitNow(dataRequest = true);
         }
@@ -2411,17 +2411,17 @@ ThreadError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInf
     }
 
     // Pending Timestamp
-    if (Tlv::GetTlv(aMessage, Tlv::kPendingTimestamp, sizeof(pendingTimestamp), pendingTimestamp) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kPendingTimestamp, sizeof(pendingTimestamp), pendingTimestamp) == OT_ERROR_NONE)
     {
         const MeshCoP::Timestamp *timestamp;
 
-        VerifyOrExit(pendingTimestamp.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(pendingTimestamp.IsValid(), error = OT_ERROR_PARSE);
         timestamp = mNetif.GetPendingDataset().GetNetwork().GetTimestamp();
 
         // if received timestamp does not match the local value and message does not contain the dataset,
         // send MLE Data Request
         if ((timestamp == NULL || timestamp->Compare(pendingTimestamp) != 0) &&
-            (Tlv::GetOffset(aMessage, Tlv::kPendingDataset, pendingDatasetOffset) != kThreadError_None))
+            (Tlv::GetOffset(aMessage, Tlv::kPendingDataset, pendingDatasetOffset) != OT_ERROR_NONE))
         {
             ExitNow(dataRequest = true);
         }
@@ -2431,9 +2431,9 @@ ThreadError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInf
         pendingTimestamp.SetLength(0);
     }
 
-    if (Tlv::GetTlv(aMessage, Tlv::kNetworkData, sizeof(networkData), networkData) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kNetworkData, sizeof(networkData), networkData) == OT_ERROR_NONE)
     {
-        VerifyOrExit(networkData.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(networkData.IsValid(), error = OT_ERROR_PARSE);
 
         mNetif.GetNetworkDataLeader().SetNetworkData(leaderData.GetDataVersion(), leaderData.GetStableDataVersion(),
                                                      (mDeviceMode & ModeTlv::kModeFullNetworkData) == 0,
@@ -2540,10 +2540,10 @@ void Mle::ResetParentCandidate(void)
     mParentCandidate.SetState(Neighbor::kStateInvalid);
 }
 
-ThreadError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
-                                      uint32_t aKeySequence)
+otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
+                                  uint32_t aKeySequence)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     const ThreadMessageInfo *threadMessageInfo = static_cast<const ThreadMessageInfo *>(aMessageInfo.GetLinkInfo());
     ResponseTlv response;
     SourceAddressTlv sourceAddress;
@@ -2563,19 +2563,19 @@ ThreadError Mle::HandleParentResponse(const Message &aMessage, const Ip6::Messag
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kResponse, sizeof(response), response));
     VerifyOrExit(response.IsValid() &&
                  memcmp(response.GetResponse(), mParentRequest.mChallenge, response.GetLength()) == 0,
-                 error = kThreadError_Parse);
+                 error = OT_ERROR_PARSE);
 
     // Source Address
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kSourceAddress, sizeof(sourceAddress), sourceAddress));
-    VerifyOrExit(sourceAddress.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(sourceAddress.IsValid(), error = OT_ERROR_PARSE);
 
     // Leader Data
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLeaderData, sizeof(leaderData), leaderData));
-    VerifyOrExit(leaderData.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(leaderData.IsValid(), error = OT_ERROR_PARSE);
 
     // Link Quality
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLinkMargin, sizeof(linkMarginTlv), linkMarginTlv));
-    VerifyOrExit(linkMarginTlv.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(linkMarginTlv.IsValid(), error = OT_ERROR_PARSE);
 
     linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(mNetif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
 
@@ -2590,7 +2590,7 @@ ThreadError Mle::HandleParentResponse(const Message &aMessage, const Ip6::Messag
 
     // Connectivity
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kConnectivity, sizeof(connectivity), connectivity));
-    VerifyOrExit(connectivity.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(connectivity.IsValid(), error = OT_ERROR_PARSE);
 
     if ((mDeviceMode & ModeTlv::kModeFFD) && (mDeviceState != kDeviceStateDetached))
     {
@@ -2637,10 +2637,10 @@ ThreadError Mle::HandleParentResponse(const Message &aMessage, const Ip6::Messag
 
     // Link Frame Counter
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLinkFrameCounter, sizeof(linkFrameCounter), linkFrameCounter));
-    VerifyOrExit(linkFrameCounter.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(linkFrameCounter.IsValid(), error = OT_ERROR_PARSE);
 
     // Mle Frame Counter
-    if (Tlv::GetTlv(aMessage, Tlv::kMleFrameCounter, sizeof(mleFrameCounter), mleFrameCounter) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kMleFrameCounter, sizeof(mleFrameCounter), mleFrameCounter) == OT_ERROR_NONE)
     {
         VerifyOrExit(mleFrameCounter.IsValid());
     }
@@ -2651,7 +2651,7 @@ ThreadError Mle::HandleParentResponse(const Message &aMessage, const Ip6::Messag
 
     // Challenge
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kChallenge, sizeof(challenge), challenge));
-    VerifyOrExit(challenge.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(challenge.IsValid(), error = OT_ERROR_PARSE);
     memcpy(mChildIdRequest.mChallenge, challenge.GetChallenge(), challenge.GetLength());
     mChildIdRequest.mChallengeLength = challenge.GetLength();
 
@@ -2678,7 +2678,7 @@ ThreadError Mle::HandleParentResponse(const Message &aMessage, const Ip6::Messag
 
 exit:
 
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         otLogWarnMleErr(GetInstance(), error, "Failed to process Parent Response");
     }
@@ -2686,9 +2686,9 @@ exit:
     return error;
 }
 
-ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     LeaderDataTlv leaderData;
     SourceAddressTlv sourceAddress;
     Address16Tlv shortAddress;
@@ -2705,26 +2705,26 @@ ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::Messa
 
     // Leader Data
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLeaderData, sizeof(leaderData), leaderData));
-    VerifyOrExit(leaderData.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(leaderData.IsValid(), error = OT_ERROR_PARSE);
 
     // Source Address
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kSourceAddress, sizeof(sourceAddress), sourceAddress));
-    VerifyOrExit(sourceAddress.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(sourceAddress.IsValid(), error = OT_ERROR_PARSE);
 
     // ShortAddress
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kAddress16, sizeof(shortAddress), shortAddress));
-    VerifyOrExit(shortAddress.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(shortAddress.IsValid(), error = OT_ERROR_PARSE);
 
     // Network Data
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kNetworkData, sizeof(networkData), networkData));
 
     // Active Timestamp
-    if (Tlv::GetTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp) == OT_ERROR_NONE)
     {
-        VerifyOrExit(activeTimestamp.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(activeTimestamp.IsValid(), error = OT_ERROR_PARSE);
 
         // Active Dataset
-        if (Tlv::GetOffset(aMessage, Tlv::kActiveDataset, offset) == kThreadError_None)
+        if (Tlv::GetOffset(aMessage, Tlv::kActiveDataset, offset) == OT_ERROR_NONE)
         {
             aMessage.Read(offset, sizeof(tlv), &tlv);
             mNetif.GetActiveDataset().Set(activeTimestamp, aMessage, offset + sizeof(tlv), tlv.GetLength());
@@ -2743,12 +2743,12 @@ ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::Messa
     }
 
     // Pending Timestamp
-    if (Tlv::GetTlv(aMessage, Tlv::kPendingTimestamp, sizeof(pendingTimestamp), pendingTimestamp) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kPendingTimestamp, sizeof(pendingTimestamp), pendingTimestamp) == OT_ERROR_NONE)
     {
-        VerifyOrExit(pendingTimestamp.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(pendingTimestamp.IsValid(), error = OT_ERROR_PARSE);
 
         // Pending Dataset
-        if (Tlv::GetOffset(aMessage, Tlv::kPendingDataset, offset) == kThreadError_None)
+        if (Tlv::GetOffset(aMessage, Tlv::kPendingDataset, offset) == OT_ERROR_NONE)
         {
             aMessage.Read(offset, sizeof(tlv), &tlv);
             mNetif.GetPendingDataset().Set(pendingTimestamp, aMessage, offset + sizeof(tlv), tlv.GetLength());
@@ -2777,7 +2777,7 @@ ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::Messa
     }
 
     // Route
-    if ((Tlv::GetTlv(aMessage, Tlv::kRoute, sizeof(route), route) == kThreadError_None) &&
+    if ((Tlv::GetTlv(aMessage, Tlv::kRoute, sizeof(route), route) == OT_ERROR_NONE) &&
         (mDeviceMode & ModeTlv::kModeFFD))
     {
         SuccessOrExit(error = mNetif.GetMle().ProcessRouteTlv(route));
@@ -2798,7 +2798,7 @@ ThreadError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::Messa
 
 exit:
 
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         otLogWarnMleErr(GetInstance(), error, "Failed to process Child ID Response");
     }
@@ -2807,11 +2807,11 @@ exit:
     return error;
 }
 
-ThreadError Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     static const uint8_t kMaxResponseTlvs = 5;
 
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     SourceAddressTlv sourceAddress;
     LeaderDataTlv leaderData;
     NetworkDataTlv networkData;
@@ -2825,13 +2825,13 @@ ThreadError Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::Me
 
     // Source Address
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kSourceAddress, sizeof(sourceAddress), sourceAddress));
-    VerifyOrExit(sourceAddress.IsValid(), error = kThreadError_Parse);
-    VerifyOrExit(mParent.GetRloc16() == sourceAddress.GetRloc16(), error = kThreadError_Drop);
+    VerifyOrExit(sourceAddress.IsValid(), error = OT_ERROR_PARSE);
+    VerifyOrExit(mParent.GetRloc16() == sourceAddress.GetRloc16(), error = OT_ERROR_DROP);
 
     // Leader Data
-    if (Tlv::GetTlv(aMessage, Tlv::kLeaderData, sizeof(leaderData), leaderData) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kLeaderData, sizeof(leaderData), leaderData) == OT_ERROR_NONE)
     {
-        VerifyOrExit(leaderData.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(leaderData.IsValid(), error = OT_ERROR_PARSE);
         SetLeaderData(leaderData.GetPartitionId(), leaderData.GetWeighting(), leaderData.GetLeaderRouterId());
 
         if ((mDeviceMode & ModeTlv::kModeFullNetworkData &&
@@ -2843,9 +2843,9 @@ ThreadError Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::Me
         }
 
         // Network Data
-        if (Tlv::GetTlv(aMessage, Tlv::kNetworkData, sizeof(networkData), networkData) == kThreadError_None)
+        if (Tlv::GetTlv(aMessage, Tlv::kNetworkData, sizeof(networkData), networkData) == OT_ERROR_NONE)
         {
-            VerifyOrExit(networkData.IsValid(), error = kThreadError_Parse);
+            VerifyOrExit(networkData.IsValid(), error = OT_ERROR_PARSE);
             mNetif.GetNetworkDataLeader().SetNetworkData(leaderData.GetDataVersion(),
                                                          leaderData.GetStableDataVersion(),
                                                          (mDeviceMode & ModeTlv::kModeFullNetworkData) == 0,
@@ -2855,18 +2855,18 @@ ThreadError Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::Me
     }
 
     // TLV Request
-    if (Tlv::GetTlv(aMessage, Tlv::kTlvRequest, sizeof(tlvRequest), tlvRequest) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kTlvRequest, sizeof(tlvRequest), tlvRequest) == OT_ERROR_NONE)
     {
-        VerifyOrExit(tlvRequest.IsValid() && tlvRequest.GetLength() <= sizeof(tlvs), error = kThreadError_Parse);
+        VerifyOrExit(tlvRequest.IsValid() && tlvRequest.GetLength() <= sizeof(tlvs), error = OT_ERROR_PARSE);
         memcpy(tlvs, tlvRequest.GetTlvs(), tlvRequest.GetLength());
         numTlvs += tlvRequest.GetLength();
     }
 
     // Challenge
-    if (Tlv::GetTlv(aMessage, Tlv::kChallenge, sizeof(challenge), challenge) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kChallenge, sizeof(challenge), challenge) == OT_ERROR_NONE)
     {
-        VerifyOrExit(challenge.IsValid(), error = kThreadError_Parse);
-        VerifyOrExit(static_cast<size_t>(numTlvs + 3) <= sizeof(tlvs), error = kThreadError_NoBufs);
+        VerifyOrExit(challenge.IsValid(), error = OT_ERROR_PARSE);
+        VerifyOrExit(static_cast<size_t>(numTlvs + 3) <= sizeof(tlvs), error = OT_ERROR_NO_BUFS);
         tlvs[numTlvs++] = Tlv::kResponse;
         tlvs[numTlvs++] = Tlv::kMleFrameCounter;
         tlvs[numTlvs++] = Tlv::kLinkFrameCounter;
@@ -2883,9 +2883,9 @@ exit:
     return error;
 }
 
-ThreadError Mle::HandleChildUpdateResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError Mle::HandleChildUpdateResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     StatusTlv status;
     ModeTlv mode;
     ResponseTlv response;
@@ -2897,7 +2897,7 @@ ThreadError Mle::HandleChildUpdateResponse(const Message &aMessage, const Ip6::M
     otLogInfoMle(GetInstance(), "Received Child Update Response from parent");
 
     // Status
-    if (Tlv::GetTlv(aMessage, Tlv::kStatus, sizeof(status), status) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kStatus, sizeof(status), status) == OT_ERROR_NONE)
     {
         BecomeDetached();
         ExitNow();
@@ -2905,27 +2905,27 @@ ThreadError Mle::HandleChildUpdateResponse(const Message &aMessage, const Ip6::M
 
     // Mode
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kMode, sizeof(mode), mode));
-    VerifyOrExit(mode.IsValid(), error = kThreadError_Parse);
-    VerifyOrExit(mode.GetMode() == mDeviceMode, error = kThreadError_Drop);
+    VerifyOrExit(mode.IsValid(), error = OT_ERROR_PARSE);
+    VerifyOrExit(mode.GetMode() == mDeviceMode, error = OT_ERROR_DROP);
 
     switch (mDeviceState)
     {
     case kDeviceStateDetached:
         // Response
         SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kResponse, sizeof(response), response));
-        VerifyOrExit(response.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(response.IsValid(), error = OT_ERROR_PARSE);
         VerifyOrExit(memcmp(response.GetResponse(), mParentRequest.mChallenge,
                             sizeof(mParentRequest.mChallenge)) == 0,
-                     error = kThreadError_Drop);
+                     error = OT_ERROR_DROP);
 
         SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLinkFrameCounter, sizeof(linkFrameCounter),
                                           linkFrameCounter));
-        VerifyOrExit(linkFrameCounter.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(linkFrameCounter.IsValid(), error = OT_ERROR_PARSE);
 
         if (Tlv::GetTlv(aMessage, Tlv::kMleFrameCounter, sizeof(mleFrameCounter), mleFrameCounter) ==
-            kThreadError_None)
+            OT_ERROR_NONE)
         {
-            VerifyOrExit(mleFrameCounter.IsValid(), error = kThreadError_Parse);
+            VerifyOrExit(mleFrameCounter.IsValid(), error = OT_ERROR_PARSE);
         }
         else
         {
@@ -2943,7 +2943,7 @@ ThreadError Mle::HandleChildUpdateResponse(const Message &aMessage, const Ip6::M
     case kDeviceStateChild:
         // Source Address
         SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kSourceAddress, sizeof(sourceAddress), sourceAddress));
-        VerifyOrExit(sourceAddress.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(sourceAddress.IsValid(), error = OT_ERROR_PARSE);
 
         if (GetRouterId(sourceAddress.GetRloc16()) != GetRouterId(GetRloc16()))
         {
@@ -2955,9 +2955,9 @@ ThreadError Mle::HandleChildUpdateResponse(const Message &aMessage, const Ip6::M
         SuccessOrExit(error = HandleLeaderData(aMessage, aMessageInfo));
 
         // Timeout optional
-        if (Tlv::GetTlv(aMessage, Tlv::kTimeout, sizeof(timeout), timeout) == kThreadError_None)
+        if (Tlv::GetTlv(aMessage, Tlv::kTimeout, sizeof(timeout), timeout) == OT_ERROR_NONE)
         {
-            VerifyOrExit(timeout.IsValid(), error = kThreadError_Parse);
+            VerifyOrExit(timeout.IsValid(), error = OT_ERROR_PARSE);
             mTimeout = timeout.GetTimeout();
         }
 
@@ -2984,7 +2984,7 @@ ThreadError Mle::HandleChildUpdateResponse(const Message &aMessage, const Ip6::M
 
 exit:
 
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         otLogWarnMleErr(GetInstance(), error, "Failed to process Child Update Response");
     }
@@ -2992,9 +2992,9 @@ exit:
     return error;
 }
 
-ThreadError Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     ChannelTlv channel;
     ActiveTimestampTlv timestamp;
     const MeshCoP::Timestamp *localTimestamp;
@@ -3003,13 +3003,13 @@ ThreadError Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo 
     otLogInfoMle(GetInstance(), "Received announce");
 
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kChannel, sizeof(channel), channel));
-    VerifyOrExit(channel.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(channel.IsValid(), error = OT_ERROR_PARSE);
 
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kActiveTimestamp, sizeof(timestamp), timestamp));
-    VerifyOrExit(timestamp.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(timestamp.IsValid(), error = OT_ERROR_PARSE);
 
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kPanId, sizeof(panid), panid));
-    VerifyOrExit(panid.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(panid.IsValid(), error = OT_ERROR_PARSE);
 
     localTimestamp = mNetif.GetActiveDataset().GetNetwork().GetTimestamp();
 
@@ -3032,9 +3032,9 @@ exit:
     return error;
 }
 
-ThreadError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     const ThreadMessageInfo *threadMessageInfo = static_cast<const ThreadMessageInfo *>(aMessageInfo.GetLinkInfo());
     Tlv tlv;
     MeshCoP::Tlv meshcopTlv;
@@ -3049,7 +3049,7 @@ ThreadError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::Mes
 
     otLogInfoMle(GetInstance(), "Handle discovery response");
 
-    VerifyOrExit(mIsDiscoverInProgress, error = kThreadError_Drop);
+    VerifyOrExit(mIsDiscoverInProgress, error = OT_ERROR_DROP);
 
     offset = aMessage.GetOffset();
     end = aMessage.GetLength();
@@ -3067,7 +3067,7 @@ ThreadError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::Mes
         offset += sizeof(tlv) + tlv.GetLength();
     }
 
-    VerifyOrExit(offset < end, error = kThreadError_Parse);
+    VerifyOrExit(offset < end, error = OT_ERROR_PARSE);
 
     offset += sizeof(tlv);
     end = offset + tlv.GetLength();
@@ -3088,26 +3088,26 @@ ThreadError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::Mes
         {
         case MeshCoP::Tlv::kDiscoveryResponse:
             aMessage.Read(offset, sizeof(discoveryResponse), &discoveryResponse);
-            VerifyOrExit(discoveryResponse.IsValid(), error = kThreadError_Parse);
+            VerifyOrExit(discoveryResponse.IsValid(), error = OT_ERROR_PARSE);
             result.mVersion = discoveryResponse.GetVersion();
             result.mIsNative = discoveryResponse.IsNativeCommissioner();
             break;
 
         case MeshCoP::Tlv::kExtendedPanId:
             aMessage.Read(offset, sizeof(extPanId), &extPanId);
-            VerifyOrExit(extPanId.IsValid(), error = kThreadError_Parse);
+            VerifyOrExit(extPanId.IsValid(), error = OT_ERROR_PARSE);
             memcpy(&result.mExtendedPanId, extPanId.GetExtendedPanId(), sizeof(result.mExtendedPanId));
             break;
 
         case MeshCoP::Tlv::kNetworkName:
             aMessage.Read(offset, sizeof(networkName), &networkName);
-            VerifyOrExit(networkName.IsValid(), error = kThreadError_Parse);
+            VerifyOrExit(networkName.IsValid(), error = OT_ERROR_PARSE);
             memcpy(&result.mNetworkName, networkName.GetNetworkName(), networkName.GetLength());
             break;
 
         case MeshCoP::Tlv::kSteeringData:
             aMessage.Read(offset, sizeof(steeringData), &steeringData);
-            VerifyOrExit(steeringData.IsValid(), error = kThreadError_Parse);
+            VerifyOrExit(steeringData.IsValid(), error = OT_ERROR_PARSE);
 
             // Pass up MLE discovery responses only if the steering data is set to all 0xFFs,
             // or if it matches the factory set EUI64.
@@ -3131,7 +3131,7 @@ ThreadError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::Mes
                 if (!steeringData.GetBit(ccitt.Get() % steeringData.GetNumBits()) ||
                     !steeringData.GetBit(ansi.Get() % steeringData.GetNumBits()))
                 {
-                    ExitNow(error = kThreadError_None);
+                    ExitNow(error = OT_ERROR_NONE);
                 }
             }
 
@@ -3142,7 +3142,7 @@ ThreadError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::Mes
 
         case MeshCoP::Tlv::kJoinerUdpPort:
             aMessage.Read(offset, sizeof(JoinerUdpPort), &JoinerUdpPort);
-            VerifyOrExit(JoinerUdpPort.IsValid(), error = kThreadError_Parse);
+            VerifyOrExit(JoinerUdpPort.IsValid(), error = OT_ERROR_PARSE);
             result.mJoinerUdpPort = JoinerUdpPort.GetUdpPort();
             break;
 
@@ -3158,7 +3158,7 @@ ThreadError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::Mes
 
 exit:
 
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         otLogWarnMleErr(GetInstance(), error, "Failed to process Discovery Response");
     }
@@ -3245,19 +3245,19 @@ Router *Mle::GetParent(void)
     return &mParent;
 }
 
-ThreadError Mle::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, Ip6::Header &aIp6Header)
+otError Mle::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, Ip6::Header &aIp6Header)
 {
-    ThreadError error = kThreadError_Drop;
+    otError error = OT_ERROR_DROP;
     Ip6::MessageInfo messageInfo;
 
     if (aMeshDest != GetRloc16())
     {
-        ExitNow(error = kThreadError_None);
+        ExitNow(error = OT_ERROR_NONE);
     }
 
     if (mNetif.IsUnicastAddress(aIp6Header.GetDestination()))
     {
-        ExitNow(error = kThreadError_None);
+        ExitNow(error = OT_ERROR_NONE);
     }
 
     messageInfo.GetPeerAddr() = GetMeshLocal16();

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -370,11 +370,11 @@ public:
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None    Successfully appended the bytes.
-     * @retval kThreadError_NoBufs  Insufficient available buffers to grow the message.
+     * @retval OT_ERROR_NONE     Successfully appended the bytes.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
      *
      */
-    ThreadError AppendTo(Message &aMessage) {
+    otError AppendTo(Message &aMessage) {
         return aMessage.Append(this, sizeof(*this));
     };
 
@@ -395,10 +395,10 @@ public:
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None  Successfully removed the header.
+     * @retval OT_ERROR_NONE  Successfully removed the header.
      *
      */
-    static ThreadError RemoveFrom(Message &aMessage) {
+    static otError RemoveFrom(Message &aMessage) {
         return aMessage.SetLength(aMessage.GetLength() - sizeof(DelayedResponseHeader));
     };
 
@@ -469,19 +469,19 @@ public:
     /**
      * This method enables MLE.
      *
-     * @retval kThreadError_None     Successfully enabled MLE.
-     * @retval kThreadError_Already  MLE was already enabled.
+     * @retval OT_ERROR_NONE     Successfully enabled MLE.
+     * @retval OT_ERROR_ALREADY  MLE was already enabled.
      *
      */
-    ThreadError Enable(void);
+    otError Enable(void);
 
     /**
      * This method disables MLE.
      *
-     * @retval kThreadError_None     Successfully disabled MLE.
+     * @retval OT_ERROR_NONE     Successfully disabled MLE.
      *
      */
-    ThreadError Disable(void);
+    otError Disable(void);
 
     /**
      * This method starts the MLE protocol operation.
@@ -490,39 +490,39 @@ public:
      * @param[in]  aAnnounceAttach True if attach on the announced thread network with newer active timestamp,
      *                             or False if not.
      *
-     * @retval kThreadError_None     Successfully started the protocol operation.
-     * @retval kThreadError_Already  The protocol operation was already started.
+     * @retval OT_ERROR_NONE     Successfully started the protocol operation.
+     * @retval OT_ERROR_ALREADY  The protocol operation was already started.
      *
      */
-    ThreadError Start(bool aEnableReattach, bool aAnnounceAttach);
+    otError Start(bool aEnableReattach, bool aAnnounceAttach);
 
     /**
      * This method stops the MLE protocol operation.
      *
      * @param[in]  aClearNetworkDatasets  True to clear network datasets, False not.
      *
-     * @retval kThreadError_None  Successfully stopped the protocol operation.
+     * @retval OT_ERROR_NONE  Successfully stopped the protocol operation.
      *
      */
-    ThreadError Stop(bool aClearNetworkDatasets);
+    otError Stop(bool aClearNetworkDatasets);
 
     /**
      * This method restores network information from non-volatile memory.
      *
-     * @retval kThreadError_None      Successfully restore the network information.
-     * @retval kThreadError_NotFound  There is no valid network information stored in non-volatile memory.
+     * @retval OT_ERROR_NONE       Successfully restore the network information.
+     * @retval OT_ERROR_NOT_FOUND  There is no valid network information stored in non-volatile memory.
      *
      */
-    ThreadError Restore(void);
+    otError Restore(void);
 
     /**
      * This method stores network information into non-volatile memory.
      *
-     * @retval kThreadError_None      Successfully store the network information.
-     * @retval kThreadError_NoBufs    Could not store the network information due to insufficient memory space.
+     * @retval OT_ERROR_NONE       Successfully store the network information.
+     * @retval OT_ERROR_NO_BUFS    Could not store the network information due to insufficient memory space.
      *
      */
-    ThreadError Store(void);
+    otError Store(void);
 
     /**
      * This function pointer is called on receiving an MLE Discovery Response message.
@@ -543,13 +543,13 @@ public:
      * @param[in]  aHandler               A pointer to a function that is called on receiving an MLE Discovery Response.
      * @param[in]  aContext               A pointer to arbitrary context information.
      *
-     * @retval kThreadError_None  Successfully started a Thread Discovery.
-     * @retval kThreadError_Busy  Thread Discovery is already in progress.
+     * @retval OT_ERROR_NONE  Successfully started a Thread Discovery.
+     * @retval OT_ERROR_BUSY  Thread Discovery is already in progress.
      *
      */
-    ThreadError Discover(uint32_t aScanChannels, uint16_t aPanId, bool aJoiner, bool aEnableEui64Filtering,
-                         DiscoverHandler aCallback,
-                         void *aContext);
+    otError Discover(uint32_t aScanChannels, uint16_t aPanId, bool aJoiner, bool aEnableEui64Filtering,
+                     DiscoverHandler aCallback,
+                     void *aContext);
 
     /**
      * This method indicates whether or not an MLE Thread Discovery is currently in progress.
@@ -571,32 +571,32 @@ public:
      * @param[in]  aChannel        The channel to use when transmitting.
      * @param[in]  aOrphanAnnounce To indicate if MLE Announce is sent from an orphan end device.
      *
-     * @retval kThreadError_None    Successfully generated an MLE Announce message.
-     * @retval kThreadError_NoBufs  Insufficient buffers to generate the MLE Announce message.
+     * @retval OT_ERROR_NONE     Successfully generated an MLE Announce message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers to generate the MLE Announce message.
      *
      */
-    ThreadError SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce);
+    otError SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce);
 
     /**
      * This method causes the Thread interface to detach from the Thread network.
      *
-     * @retval kThreadError_None          Successfully detached from the Thread network.
-     * @retval kThreadError_InvalidState  MLE is Disabled.
+     * @retval OT_ERROR_NONE           Successfully detached from the Thread network.
+     * @retval OT_ERROR_INVALID_STATE  MLE is Disabled.
      *
      */
-    ThreadError BecomeDetached(void);
+    otError BecomeDetached(void);
 
     /**
      * This method causes the Thread interface to attempt an MLE attach.
      *
      * @param[in]  aFilter  Indicates what partitions to attach to.
      *
-     * @retval kThreadError_None          Successfully began the attach process.
-     * @retval kThreadError_InvalidState  MLE is Disabled.
-     * @retval kThreadError_Busy          An attach process is in progress.
+     * @retval OT_ERROR_NONE           Successfully began the attach process.
+     * @retval OT_ERROR_INVALID_STATE  MLE is Disabled.
+     * @retval OT_ERROR_BUSY           An attach process is in progress.
      *
      */
-    ThreadError BecomeChild(otMleAttachFilter aFilter);
+    otError BecomeChild(otMleAttachFilter aFilter);
 
     /**
      * This method indicates whether or not the Thread device is attached to a Thread network.
@@ -626,11 +626,11 @@ public:
     /**
      * This method sets the Device Mode as reported in the Mode TLV.
      *
-     * @retval kThreadError_None         Successfully set the Mode TLV.
-     * @retval kThreadError_InvalidArgs  The mode combination specified in @p aMode is invalid.
+     * @retval OT_ERROR_NONE          Successfully set the Mode TLV.
+     * @retval OT_ERROR_INVALID_ARGS  The mode combination specified in @p aMode is invalid.
      *
      */
-    ThreadError SetDeviceMode(uint8_t aMode);
+    otError SetDeviceMode(uint8_t aMode);
 
     /**
      * This method returns a pointer to the Mesh Local Prefix.
@@ -645,20 +645,20 @@ public:
      *
      * @param[in]  aPrefix  A pointer to the Mesh Local Prefix.
      *
-     * @retval kThreadError_None  Successfully set the Mesh Local Prefix.
+     * @retval OT_ERROR_NONE  Successfully set the Mesh Local Prefix.
      *
      */
-    ThreadError SetMeshLocalPrefix(const uint8_t *aPrefix);
+    otError SetMeshLocalPrefix(const uint8_t *aPrefix);
 
     /**
      * This method updates the link local address.
      *
      * Call this method when the IEEE 802.15.4 Extended Address has changed.
      *
-     * @retval kThreadError_None  Successfully updated the link local address.
+     * @retval OT_ERROR_NONE  Successfully updated the link local address.
      *
      */
-    ThreadError UpdateLinkLocalAddress(void);
+    otError UpdateLinkLocalAddress(void);
 
     /**
      * This method returns a pointer to the link-local all Thread nodes multicast address.
@@ -714,7 +714,7 @@ public:
      * This method sets the MLE Timeout value.
      *
      */
-    ThreadError SetTimeout(uint32_t aTimeout);
+    otError SetTimeout(uint32_t aTimeout);
 
     /**
      * This method returns the RLOC16 assigned to the Thread interface.
@@ -753,32 +753,32 @@ public:
      *
      * @param[out]  aAddress  A reference to the Leader's RLOC.
      *
-     * @retval kThreadError_None   Successfully retrieved the Leader's RLOC.
-     * @retval kThreadError_Error  The Thread interface is not currently attached to a Thread Partition.
+     * @retval OT_ERROR_NONE      Successfully retrieved the Leader's RLOC.
+     * @retval OT_ERROR_DETACHED  The Thread interface is not currently attached to a Thread Partition.
      *
      */
-    ThreadError GetLeaderAddress(Ip6::Address &aAddress) const;
+    otError GetLeaderAddress(Ip6::Address &aAddress) const;
 
     /**
      * This method retrieves the Leader's ALOC.
      *
      * @param[out]  aAddress  A reference to the Leader's ALOC.
      *
-     * @retval kThreadError_None   Successfully retrieved the Leader's ALOC.
-     * @retval kThreadError_Error  The Thread interface is not currently attached to a Thread Partition.
+     * @retval OT_ERROR_NONE      Successfully retrieved the Leader's ALOC.
+     * @retval OT_ERROR_DETACHED  The Thread interface is not currently attached to a Thread Partition.
      *
      */
-    ThreadError GetLeaderAloc(Ip6::Address &aAddress) const;
+    otError GetLeaderAloc(Ip6::Address &aAddress) const;
 
     /**
      * This method adds Leader's ALOC to its Thread interface.
      *
-     * @retval kThreadError_None           Successfully added the Leader's ALOC.
-     * @retval kThreadError_Busy           The Leader's ALOC address was already added.
-     * @retval kThreadError_InvalidState   The device's role is not Leader.
+     * @retval OT_ERROR_NONE            Successfully added the Leader's ALOC.
+     * @retval OT_ERROR_BUSY            The Leader's ALOC address was already added.
+     * @retval OT_ERROR_INVALID_STATE   The device's role is not Leader.
      *
      */
-    ThreadError AddLeaderAloc(void);
+    otError AddLeaderAloc(void);
 
     /**
      * This method returns the most recently received Leader Data TLV.
@@ -793,11 +793,11 @@ public:
      *
      * @param[out]  aLeaderData  A reference to where the leader data is placed.
      *
-     * @retval kThreadError_None         Successfully retrieved the leader data.
-     * @retval kThreadError_Detached     Not currently attached.
+     * @retval OT_ERROR_NONE         Successfully retrieved the leader data.
+     * @retval OT_ERROR_DETACHED     Not currently attached.
      *
      */
-    ThreadError GetLeaderData(otLeaderData &aLeaderData);
+    otError GetLeaderData(otLeaderData &aLeaderData);
 
     /**
      * This method returns the link quality on the link to a given extended address.
@@ -805,11 +805,11 @@ public:
      * @param[in]  aMacAddr  The IEEE 802.15.4 Extended Mac Address.
      * @param[in]  aLinkQuality A reference to the assigned link quality.
      *
-     * @retval kThreadError_None         Successfully retrieve the link quality to aLinkQuality.
-     * @retval kThreadError_InvalidArgs  No match found with a given extended address.
+     * @retval OT_ERROR_NONE          Successfully retrieve the link quality to aLinkQuality.
+     * @retval OT_ERROR_INVALID_ARGS  No match found with a given extended address.
      *
      */
-    ThreadError GetAssignLinkQuality(const Mac::ExtAddress aMacAddr, uint8_t &aLinkQuality);
+    otError GetAssignLinkQuality(const Mac::ExtAddress aMacAddr, uint8_t &aLinkQuality);
 
     /**
      * This method sets the link quality on the link to a given extended address.
@@ -898,22 +898,22 @@ protected:
      * @param[in]  aMessage  A reference to the message.
      * @param[in]  aCommand  The MLE Command Type.
      *
-     * @retval kThreadError_None    Successfully appended the header.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the header.
+     * @retval OT_ERROR_NONE     Successfully appended the header.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the header.
      *
      */
-    ThreadError AppendHeader(Message &aMessage, Header::Command aCommand);
+    otError AppendHeader(Message &aMessage, Header::Command aCommand);
 
     /**
      * This method appends a Source Address TLV to a message.
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None    Successfully appended the Source Address TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the Source Address TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Source Address TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Source Address TLV.
      *
      */
-    ThreadError AppendSourceAddress(Message &aMessage);
+    otError AppendSourceAddress(Message &aMessage);
 
     /**
      * This method appends a Mode TLV to a message.
@@ -921,11 +921,11 @@ protected:
      * @param[in]  aMessage  A reference to the message.
      * @param[in]  aMode     The Device Mode value.
      *
-     * @retval kThreadError_None    Successfully appended the Mode TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the Mode TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Mode TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Mode TLV.
      *
      */
-    ThreadError AppendMode(Message &aMessage, uint8_t aMode);
+    otError AppendMode(Message &aMessage, uint8_t aMode);
 
     /**
      * This method appends a Timeout TLV to a message.
@@ -933,11 +933,11 @@ protected:
      * @param[in]  aMessage  A reference to the message.
      * @param[in]  aTimeout  The Timeout value.
      *
-     * @retval kThreadError_None    Successfully appended the Timeout TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the Timeout TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Timeout TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Timeout TLV.
      *
      */
-    ThreadError AppendTimeout(Message &aMessage, uint32_t aTimeout);
+    otError AppendTimeout(Message &aMessage, uint32_t aTimeout);
 
     /**
      * This method appends a Challenge TLV to a message.
@@ -946,11 +946,11 @@ protected:
      * @param[in]  aChallenge        A pointer to the Challenge value.
      * @param[in]  aChallengeLength  The length of the Challenge value in bytes.
      *
-     * @retval kThreadError_None    Successfully appended the Challenge TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the Challenge TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Challenge TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Challenge TLV.
      *
      */
-    ThreadError AppendChallenge(Message &aMessage, const uint8_t *aChallenge, uint8_t aChallengeLength);
+    otError AppendChallenge(Message &aMessage, const uint8_t *aChallenge, uint8_t aChallengeLength);
 
     /**
      * This method appends a Response TLV to a message.
@@ -959,33 +959,33 @@ protected:
      * @param[in]  aResponse        A pointer to the Response value.
      * @param[in]  aResponseLength  The length of the Response value in bytes.
      *
-     * @retval kThreadError_None    Successfully appended the Response TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the Response TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Response TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Response TLV.
      *
      */
-    ThreadError AppendResponse(Message &aMessage, const uint8_t *aResponse, uint8_t aResponseLength);
+    otError AppendResponse(Message &aMessage, const uint8_t *aResponse, uint8_t aResponseLength);
 
     /**
      * This method appends a Link Frame Counter TLV to a message.
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None    Successfully appended the Link Frame Counter TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the Link Frame Counter TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Link Frame Counter TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Link Frame Counter TLV.
      *
      */
-    ThreadError AppendLinkFrameCounter(Message &aMessage);
+    otError AppendLinkFrameCounter(Message &aMessage);
 
     /**
      * This method appends an MLE Frame Counter TLV to a message.
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None    Successfully appended the Frame Counter TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the MLE Frame Counter TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Frame Counter TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the MLE Frame Counter TLV.
      *
      */
-    ThreadError AppendMleFrameCounter(Message &aMessage);
+    otError AppendMleFrameCounter(Message &aMessage);
 
     /**
      * This method appends an Address16 TLV to a message.
@@ -993,11 +993,11 @@ protected:
      * @param[in]  aMessage  A reference to the message.
      * @param[in]  aRloc16   The RLOC16 value.
      *
-     * @retval kThreadError_None    Successfully appended the Address16 TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the Address16 TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Address16 TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Address16 TLV.
      *
      */
-    ThreadError AppendAddress16(Message &aMessage, uint16_t aRloc16);
+    otError AppendAddress16(Message &aMessage, uint16_t aRloc16);
 
     /**
      * This method appends a Network Data TLV to the message.
@@ -1005,11 +1005,11 @@ protected:
      * @param[in]  aMessage     A reference to the message.
      * @param[in]  aStableOnly  TRUE to append stable data, FALSE otherwise.
      *
-     * @retval kThreadError_None    Successfully appended the Network Data TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the Network Data TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Network Data TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Network Data TLV.
      *
      */
-    ThreadError AppendNetworkData(Message &aMessage, bool aStableOnly);
+    otError AppendNetworkData(Message &aMessage, bool aStableOnly);
 
     /**
      * This method appends a TLV Request TLV to a message.
@@ -1018,22 +1018,22 @@ protected:
      * @param[in]  aTlvs        A pointer to the list of TLV types.
      * @param[in]  aTlvsLength  The number of TLV types in @p aTlvs
      *
-     * @retval kThreadError_None    Successfully appended the TLV Request TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the TLV Request TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the TLV Request TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the TLV Request TLV.
      *
      */
-    ThreadError AppendTlvRequest(Message &aMessage, const uint8_t *aTlvs, uint8_t aTlvsLength);
+    otError AppendTlvRequest(Message &aMessage, const uint8_t *aTlvs, uint8_t aTlvsLength);
 
     /**
      * This method appends a Leader Data TLV to a message.
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None    Successfully appended the Leader Data TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the Leader Data TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Leader Data TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Leader Data TLV.
      *
      */
-    ThreadError AppendLeaderData(Message &aMessage);
+    otError AppendLeaderData(Message &aMessage);
 
     /**
      * This method appends a Scan Mask TLV to a message.
@@ -1041,11 +1041,11 @@ protected:
      * @param[in]  aMessage   A reference to the message.
      * @param[in]  aScanMask  The Scan Mask value.
      *
-     * @retval kThreadError_None    Successfully appended the Scan Mask TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the Scan Mask TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Scan Mask TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Scan Mask TLV.
      *
      */
-    ThreadError AppendScanMask(Message &aMessage, uint8_t aScanMask);
+    otError AppendScanMask(Message &aMessage, uint8_t aScanMask);
 
     /**
      * This method appends a Status TLV to a message.
@@ -1053,11 +1053,11 @@ protected:
      * @param[in]  aMessage  A reference to the message.
      * @param[in]  aStatus   The Status value.
      *
-     * @retval kThreadError_None    Successfully appended the Status TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the Status TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Status TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Status TLV.
      *
      */
-    ThreadError AppendStatus(Message &aMessage, StatusTlv::Status aStatus);
+    otError AppendStatus(Message &aMessage, StatusTlv::Status aStatus);
 
     /**
      * This method appends a Link Margin TLV to a message.
@@ -1065,33 +1065,33 @@ protected:
      * @param[in]  aMessage     A reference to the message.
      * @param[in]  aLinkMargin  The Link Margin value.
      *
-     * @retval kThreadError_None    Successfully appended the Link Margin TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the Link Margin TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Link Margin TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Link Margin TLV.
      *
      */
-    ThreadError AppendLinkMargin(Message &aMessage, uint8_t aLinkMargin);
+    otError AppendLinkMargin(Message &aMessage, uint8_t aLinkMargin);
 
     /**
      * This method appends a Version TLV to a message.
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None    Successfully appended the Version TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the Version TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Version TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Version TLV.
      *
      */
-    ThreadError AppendVersion(Message &aMessage);
+    otError AppendVersion(Message &aMessage);
 
     /**
      * This method appends an Address Registration TLV to a message.
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None    Successfully appended the Address Registration TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the Address Registration TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Address Registration TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Address Registration TLV.
      *
      */
-    ThreadError AppendAddressRegistration(Message &aMessage);
+    otError AppendAddressRegistration(Message &aMessage);
 
     /**
      * This method appends a Active Timestamp TLV to a message.
@@ -1099,33 +1099,33 @@ protected:
      * @param[in]  aMessage  A reference to the message.
      * @param[in]  aCouldUseLocal  True to use local Active Timestamp when network Active Timestamp is not available, False not.
      *
-     * @retval kThreadError_None    Successfully appended the Active Timestamp TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the Active Timestamp TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Active Timestamp TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Active Timestamp TLV.
      *
      */
-    ThreadError AppendActiveTimestamp(Message &aMessage, bool aCouldUseLocal);
+    otError AppendActiveTimestamp(Message &aMessage, bool aCouldUseLocal);
 
     /**
      * This method appends a Pending Timestamp TLV to a message.
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None    Successfully appended the Pending Timestamp TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the Pending Timestamp TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Pending Timestamp TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Pending Timestamp TLV.
      *
      */
-    ThreadError AppendPendingTimestamp(Message &aMessage);
+    otError AppendPendingTimestamp(Message &aMessage);
 
     /**
      * This method appends a Thread Discovery TLV to a message.
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None    Successfully appended the Thread Discovery TLV.
-     * @retval kThreadError_NoBufs  Insufficient buffers available to append the Address Registration TLV.
+     * @retval OT_ERROR_NONE     Successfully appended the Thread Discovery TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Address Registration TLV.
      *
      */
-    ThreadError AppendDiscovery(Message &aMessage);
+    otError AppendDiscovery(Message &aMessage);
 
     /**
      * This method checks if the destination is reachable.
@@ -1134,11 +1134,11 @@ protected:
      * @param[in]  aMeshDest    The RLOC16 of the destination.
      * @param[in]  aIp6Header   The IPv6 header of the message.
      *
-     * @retval kThreadError_None  The destination is reachable.
-     * @retval kThreadError_Drop  The destination is not reachable and the message should be dropped.
+     * @retval OT_ERROR_NONE  The destination is reachable.
+     * @retval OT_ERROR_DROP  The destination is not reachable and the message should be dropped.
      *
      */
-    ThreadError CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, Ip6::Header &aIp6Header);
+    otError CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, Ip6::Header &aIp6Header);
 
     /**
      * This method returns a pointer to the neighbor object.
@@ -1198,21 +1198,21 @@ protected:
      * @param[in]  aTlvsLength   The number of TLV types in @p aTlvs.
      * @param[in]  aDelay        Delay in milliseconds before the Data Request message is sent.
      *
-     * @retval kThreadError_None    Successfully generated an MLE Data Request message.
-     * @retval kThreadError_NoBufs  Insufficient buffers to generate the MLE Data Request message.
+     * @retval OT_ERROR_NONE     Successfully generated an MLE Data Request message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers to generate the MLE Data Request message.
      *
      */
-    ThreadError SendDataRequest(const Ip6::Address &aDestination, const uint8_t *aTlvs, uint8_t aTlvsLength,
-                                uint16_t aDelay);
+    otError SendDataRequest(const Ip6::Address &aDestination, const uint8_t *aTlvs, uint8_t aTlvsLength,
+                            uint16_t aDelay);
 
     /**
      * This method generates an MLE Child Update Request message.
      *
-     * @retval kThreadError_None    Successfully generated an MLE Child Update Request message.
-     * @retval kThreadError_NoBufs  Insufficient buffers to generate the MLE Child Update Request message.
+     * @retval OT_ERROR_NONE     Successfully generated an MLE Child Update Request message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers to generate the MLE Child Update Request message.
      *
      */
-    ThreadError SendChildUpdateRequest(void);
+    otError SendChildUpdateRequest(void);
 
     /**
      * This method generates an MLE Child Update Response message.
@@ -1221,11 +1221,11 @@ protected:
      * @param[in]  aNumTlvs      The number of TLV types in @p aTlvs.
      * @param[in]  aChallenge    The Challenge TLV for the response.
      *
-     * @retval kThreadError_None    Successfully generated an MLE Child Update Response message.
-     * @retval kThreadError_NoBufs  Insufficient buffers to generate the MLE Child Update Response message.
+     * @retval OT_ERROR_NONE     Successfully generated an MLE Child Update Response message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers to generate the MLE Child Update Response message.
      *
      */
-    ThreadError SendChildUpdateResponse(const uint8_t *aTlvs, uint8_t aNumTlvs, const ChallengeTlv &aChallenge);
+    otError SendChildUpdateResponse(const uint8_t *aTlvs, uint8_t aNumTlvs, const ChallengeTlv &aChallenge);
 
     /**
      * This method submits an MLE message to the UDP socket.
@@ -1233,37 +1233,37 @@ protected:
      * @param[in]  aMessage      A reference to the message.
      * @param[in]  aDestination  A reference to the IPv6 address of the destination.
      *
-     * @retval kThreadError_None    Successfully submitted the MLE message.
-     * @retval kThreadError_NoBufs  Insufficient buffers to form the rest of the MLE message.
+     * @retval OT_ERROR_NONE     Successfully submitted the MLE message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers to form the rest of the MLE message.
      *
      */
-    ThreadError SendMessage(Message &aMessage, const Ip6::Address &aDestination);
+    otError SendMessage(Message &aMessage, const Ip6::Address &aDestination);
 
     /**
      * This method sets the RLOC16 assigned to the Thread interface.
      *
      * @param[in]  aRloc16  The RLOC16 to set.
      *
-     * @retval kThreadError_None  Successfully set the RLOC16.
+     * @retval OT_ERROR_NONE  Successfully set the RLOC16.
      *
      */
-    ThreadError SetRloc16(uint16_t aRloc16);
+    otError SetRloc16(uint16_t aRloc16);
 
     /**
      * This method sets the Device State to Detached.
      *
-     * @retval kThreadError_None  Successfully set the Device State to Detached.
+     * @retval OT_ERROR_NONE  Successfully set the Device State to Detached.
      *
      */
-    ThreadError SetStateDetached(void);
+    otError SetStateDetached(void);
 
     /**
      * This method sets the Device State to Child.
      *
-     * @retval kThreadError_None  Successfully set the Device State to Child.
+     * @retval OT_ERROR_NONE  Successfully set the Device State to Child.
      *
      */
-    ThreadError SetStateChild(uint16_t aRloc16);
+    otError SetStateChild(uint16_t aRloc16);
 
     /**
      * This method sets the Leader's Partition ID, Weighting, and Router ID values.
@@ -1282,11 +1282,11 @@ protected:
      * @param[in]  aDestination  The IPv6 address of the recipient of the message.
      * @param[in]  aDelay        The delay in milliseconds before transmission of the message.
      *
-     * @retval kThreadError_None    Successfully queued the message to transmit after the delay.
-     * @retval kThreadError_NoBufs  Insufficient buffers to queue the message.
+     * @retval OT_ERROR_NONE     Successfully queued the message to transmit after the delay.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffers to queue the message.
      *
      */
-    ThreadError AddDelayedResponse(Message &aMessage, const Ip6::Address &aDestination, uint16_t aDelay);
+    otError AddDelayedResponse(Message &aMessage, const Ip6::Address &aDestination, uint16_t aDelay);
 
     ThreadNetif           &mNetif;            ///< The Thread Network Interface object.
 
@@ -1358,19 +1358,19 @@ private:
     static void HandleSendChildUpdateRequest(void *aContext);
     void HandleSendChildUpdateRequest(void);
 
-    ThreadError HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError HandleChildIdResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError HandleChildUpdateResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError HandleDataResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
-                                     uint32_t aKeySequence);
-    ThreadError HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError HandleDiscoveryResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError HandleChildIdResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError HandleChildUpdateResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError HandleDataResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
+                                 uint32_t aKeySequence);
+    otError HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError HandleDiscoveryResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    ThreadError SendParentRequest(void);
-    ThreadError SendChildIdRequest(void);
+    otError SendParentRequest(void);
+    otError SendChildIdRequest(void);
     void SendOrphanAnnounce(void);
 
     bool IsBetterParent(uint16_t aRloc16, uint8_t aLinkQuality, ConnectivityTlv &aConnectivityTlv);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -194,13 +194,13 @@ exit:
     return rval;
 }
 
-ThreadError MleRouter::ReleaseRouterId(uint8_t aRouterId)
+otError MleRouter::ReleaseRouterId(uint8_t aRouterId)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Router *router = GetRouter(aRouterId);
 
-    VerifyOrExit(router != NULL, error = kThreadError_InvalidArgs);
-    VerifyOrExit(mDeviceState == kDeviceStateLeader, error = kThreadError_InvalidState);
+    VerifyOrExit(router != NULL, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(mDeviceState == kDeviceStateLeader, error = OT_ERROR_INVALID_STATE);
 
     otLogInfoMle(GetInstance(), "delete router id %d", aRouterId);
     router->SetAllocated(false);
@@ -232,13 +232,13 @@ uint32_t MleRouter::GetLeaderAge(void) const
     return Timer::MsecToSec(Timer::GetNow() - mRouterIdSequenceLastUpdated);
 }
 
-ThreadError MleRouter::BecomeRouter(ThreadStatusTlv::Status aStatus)
+otError MleRouter::BecomeRouter(ThreadStatusTlv::Status aStatus)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mDeviceState != kDeviceStateDisabled, error = kThreadError_InvalidState);
-    VerifyOrExit(mDeviceState != kDeviceStateRouter, error = kThreadError_None);
-    VerifyOrExit(IsRouterRoleEnabled(), error = kThreadError_NotCapable);
+    VerifyOrExit(mDeviceState != kDeviceStateDisabled, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(mDeviceState != kDeviceStateRouter, error = OT_ERROR_NONE);
+    VerifyOrExit(IsRouterRoleEnabled(), error = OT_ERROR_NOT_CAPABLE);
 
     for (int i = 0; i <= kMaxRouterId; i++)
     {
@@ -273,15 +273,15 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::BecomeLeader(void)
+otError MleRouter::BecomeLeader(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t routerId;
     Router *router;
 
-    VerifyOrExit(mDeviceState != kDeviceStateDisabled, error = kThreadError_InvalidState);
-    VerifyOrExit(mDeviceState != kDeviceStateLeader, error = kThreadError_None);
-    VerifyOrExit(IsRouterRoleEnabled(), error = kThreadError_NotCapable);
+    VerifyOrExit(mDeviceState != kDeviceStateDisabled, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(mDeviceState != kDeviceStateLeader, error = OT_ERROR_NONE);
+    VerifyOrExit(IsRouterRoleEnabled(), error = OT_ERROR_NOT_CAPABLE);
 
     for (int i = 0; i <= kMaxRouterId; i++)
     {
@@ -293,7 +293,7 @@ ThreadError MleRouter::BecomeLeader(void)
 
     routerId = IsRouterIdValid(mPreviousRouterId) ? AllocateRouterId(mPreviousRouterId) : AllocateRouterId();
     router = GetRouter(routerId);
-    VerifyOrExit(router != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit(router != NULL, error = OT_ERROR_NO_BUFS);
 
     SetRouterId(routerId);
 
@@ -332,9 +332,9 @@ void MleRouter::StopLeader(void)
     mNetif.UnsubscribeAllRoutersMulticast();
 }
 
-ThreadError MleRouter::HandleDetachStart(void)
+otError MleRouter::HandleDetachStart(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     mNetif.GetAddressResolver().Clear();
 
@@ -349,9 +349,9 @@ ThreadError MleRouter::HandleDetachStart(void)
     return error;
 }
 
-ThreadError MleRouter::HandleChildStart(otMleAttachFilter aFilter)
+otError MleRouter::HandleChildStart(otMleAttachFilter aFilter)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     mRouterIdSequenceLastUpdated = Timer::GetNow();
     mRouterSelectionJitterTimeout = (otPlatRandomGet() % mRouterSelectionJitter) + 1;
 
@@ -365,7 +365,7 @@ ThreadError MleRouter::HandleChildStart(otMleAttachFilter aFilter)
 
     mNetif.SubscribeAllRoutersMulticast();
 
-    VerifyOrExit(IsRouterIdValid(mPreviousRouterId), error = kThreadError_InvalidState);
+    VerifyOrExit(IsRouterIdValid(mPreviousRouterId), error = OT_ERROR_INVALID_STATE);
 
     switch (aFilter)
     {
@@ -415,7 +415,7 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::SetStateRouter(uint16_t aRloc16)
+otError MleRouter::SetStateRouter(uint16_t aRloc16)
 {
     if (mDeviceState != kDeviceStateRouter)
     {
@@ -447,10 +447,10 @@ ThreadError MleRouter::SetStateRouter(uint16_t aRloc16)
     }
 
     otLogInfoMle(GetInstance(), "Mode -> Router");
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError MleRouter::SetStateLeader(uint16_t aRloc16)
+otError MleRouter::SetStateLeader(uint16_t aRloc16)
 {
     if (mDeviceState != kDeviceStateLeader)
     {
@@ -489,7 +489,7 @@ ThreadError MleRouter::SetStateLeader(uint16_t aRloc16)
     }
 
     otLogInfoMle(GetInstance(), "Mode -> Leader %d", mLeaderData.GetPartitionId());
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 bool MleRouter::HandleAdvertiseTimer(void *aContext)
@@ -533,13 +533,13 @@ exit:
     return;
 }
 
-ThreadError MleRouter::SendAdvertisement(void)
+otError MleRouter::SendAdvertisement(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Ip6::Address destination;
     Message *message;
 
-    VerifyOrExit((message = NewMleMessage()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandAdvertisement));
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
@@ -569,7 +569,7 @@ ThreadError MleRouter::SendAdvertisement(void)
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -577,17 +577,17 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::SendLinkRequest(Neighbor *aNeighbor)
+otError MleRouter::SendLinkRequest(Neighbor *aNeighbor)
 {
     static const uint8_t detachedTlvs[] = {Tlv::kAddress16, Tlv::kRoute};
     static const uint8_t routerTlvs[] = {Tlv::kLinkMargin};
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Message *message;
     Ip6::Address destination;
 
     memset(&destination, 0, sizeof(destination));
 
-    VerifyOrExit((message = NewMleMessage()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandLinkRequest));
     SuccessOrExit(error = AppendVersion(*message));
 
@@ -643,7 +643,7 @@ ThreadError MleRouter::SendLinkRequest(Neighbor *aNeighbor)
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -651,9 +651,9 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Neighbor *neighbor = NULL;
     Mac::ExtAddress macAddr;
     ChallengeTlv challenge;
@@ -666,31 +666,31 @@ ThreadError MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::Mes
     otLogInfoMle(GetInstance(), "Received link request");
 
     VerifyOrExit(GetDeviceState() == kDeviceStateRouter ||
-                 GetDeviceState() == kDeviceStateLeader, error = kThreadError_InvalidState);
+                 GetDeviceState() == kDeviceStateLeader, error = OT_ERROR_INVALID_STATE);
 
-    VerifyOrExit(mParentRequestState == kParentIdle, error = kThreadError_InvalidState);
+    VerifyOrExit(mParentRequestState == kParentIdle, error = OT_ERROR_INVALID_STATE);
 
     macAddr.Set(aMessageInfo.GetPeerAddr());
 
     // Challenge
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kChallenge, sizeof(challenge), challenge));
-    VerifyOrExit(challenge.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(challenge.IsValid(), error = OT_ERROR_PARSE);
 
     // Version
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kVersion, sizeof(version), version));
-    VerifyOrExit(version.IsValid() && version.GetVersion() == kVersion, error = kThreadError_Parse);
+    VerifyOrExit(version.IsValid() && version.GetVersion() == kVersion, error = OT_ERROR_PARSE);
 
     // Leader Data
-    if (Tlv::GetTlv(aMessage, Tlv::kLeaderData, sizeof(leaderData), leaderData) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kLeaderData, sizeof(leaderData), leaderData) == OT_ERROR_NONE)
     {
-        VerifyOrExit(leaderData.IsValid(), error = kThreadError_Parse);
-        VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId(), error = kThreadError_InvalidState);
+        VerifyOrExit(leaderData.IsValid(), error = OT_ERROR_PARSE);
+        VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId(), error = OT_ERROR_INVALID_STATE);
     }
 
     // Source Address
-    if (Tlv::GetTlv(aMessage, Tlv::kSourceAddress, sizeof(sourceAddress), sourceAddress) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kSourceAddress, sizeof(sourceAddress), sourceAddress) == OT_ERROR_NONE)
     {
-        VerifyOrExit(sourceAddress.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(sourceAddress.IsValid(), error = OT_ERROR_PARSE);
 
         rloc16 = sourceAddress.GetRloc16();
 
@@ -705,7 +705,7 @@ ThreadError MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::Mes
         {
             // source is a router
             neighbor = GetRouter(GetRouterId(rloc16));
-            VerifyOrExit(neighbor != NULL, error = kThreadError_Parse);
+            VerifyOrExit(neighbor != NULL, error = OT_ERROR_PARSE);
 
             if (neighbor->GetState() != Neighbor::kStateValid)
             {
@@ -735,13 +735,13 @@ ThreadError MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::Mes
         VerifyOrExit((neighbor = GetNeighbor(macAddr)) != NULL &&
                      neighbor->GetState() == Neighbor::kStateValid &&
                      IsActiveRouter(neighbor->GetRloc16()),
-                     error = kThreadError_Drop);
+                     error = OT_ERROR_DROP);
     }
 
     // TLV Request
-    if (Tlv::GetTlv(aMessage, Tlv::kTlvRequest, sizeof(tlvRequest), tlvRequest) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kTlvRequest, sizeof(tlvRequest), tlvRequest) == OT_ERROR_NONE)
     {
-        VerifyOrExit(tlvRequest.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(tlvRequest.IsValid(), error = OT_ERROR_PARSE);
     }
     else
     {
@@ -754,10 +754,10 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo, Neighbor *aNeighbor,
-                                      const TlvRequestTlv &aTlvRequest, const ChallengeTlv &aChallenge)
+otError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo, Neighbor *aNeighbor,
+                                  const TlvRequestTlv &aTlvRequest, const ChallengeTlv &aChallenge)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     const ThreadMessageInfo *threadMessageInfo = static_cast<const ThreadMessageInfo *>(aMessageInfo.GetLinkInfo());
     static const uint8_t routerTlvs[] = {Tlv::kLinkMargin};
     Message *message;
@@ -767,7 +767,7 @@ ThreadError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo, Neig
     command = (aNeighbor == NULL || aNeighbor->GetState() == Neighbor::kStateValid) ?
               Header::kCommandLinkAccept : Header::kCommandLinkAcceptAndRequest;
 
-    VerifyOrExit((message = NewMleMessage()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, command));
     SuccessOrExit(error = AppendVersion(*message));
     SuccessOrExit(error = AppendSourceAddress(*message));
@@ -801,7 +801,7 @@ ThreadError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo, Neig
             break;
 
         case Tlv::kAddress16:
-            VerifyOrExit(aNeighbor != NULL, error = kThreadError_Drop);
+            VerifyOrExit(aNeighbor != NULL, error = OT_ERROR_DROP);
             SuccessOrExit(error = AppendAddress16(*message, aNeighbor->GetRloc16()));
             break;
 
@@ -809,7 +809,7 @@ ThreadError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo, Neig
             break;
 
         default:
-            ExitNow(error = kThreadError_Drop);
+            ExitNow(error = OT_ERROR_DROP);
         }
     }
 
@@ -838,7 +838,7 @@ ThreadError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo, Neig
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -846,24 +846,24 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::HandleLinkAccept(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
-                                        uint32_t aKeySequence)
+otError MleRouter::HandleLinkAccept(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
+                                    uint32_t aKeySequence)
 {
     otLogInfoMle(GetInstance(), "Received link accept");
     return HandleLinkAccept(aMessage, aMessageInfo, aKeySequence, false);
 }
 
-ThreadError MleRouter::HandleLinkAcceptAndRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
-                                                  uint32_t aKeySequence)
+otError MleRouter::HandleLinkAcceptAndRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
+                                              uint32_t aKeySequence)
 {
     otLogInfoMle(GetInstance(), "Received link accept and request");
     return HandleLinkAccept(aMessage, aMessageInfo, aKeySequence, true);
 }
 
-ThreadError MleRouter::HandleLinkAccept(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
-                                        uint32_t aKeySequence, bool aRequest)
+otError MleRouter::HandleLinkAccept(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
+                                    uint32_t aKeySequence, bool aRequest)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     const ThreadMessageInfo *threadMessageInfo = static_cast<const ThreadMessageInfo *>(aMessageInfo.GetLinkInfo());
     Router *router;
     Neighbor *neighbor;
@@ -885,15 +885,15 @@ ThreadError MleRouter::HandleLinkAccept(const Message &aMessage, const Ip6::Mess
 
     // Version
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kVersion, sizeof(version), version));
-    VerifyOrExit(version.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(version.IsValid(), error = OT_ERROR_PARSE);
 
     // Response
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kResponse, sizeof(response), response));
-    VerifyOrExit(response.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(response.IsValid(), error = OT_ERROR_PARSE);
 
     // Source Address
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kSourceAddress, sizeof(sourceAddress), sourceAddress));
-    VerifyOrExit(sourceAddress.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(sourceAddress.IsValid(), error = OT_ERROR_PARSE);
 
     // Remove stale neighbors
     if ((neighbor = GetNeighbor(macAddr)) != NULL &&
@@ -905,42 +905,42 @@ ThreadError MleRouter::HandleLinkAccept(const Message &aMessage, const Ip6::Mess
     // Link-Layer Frame Counter
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLinkFrameCounter, sizeof(linkFrameCounter),
                                       linkFrameCounter));
-    VerifyOrExit(linkFrameCounter.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(linkFrameCounter.IsValid(), error = OT_ERROR_PARSE);
 
     // MLE Frame Counter
     if (Tlv::GetTlv(aMessage, Tlv::kMleFrameCounter, sizeof(mleFrameCounter), mleFrameCounter) ==
-        kThreadError_None)
+        OT_ERROR_NONE)
     {
-        VerifyOrExit(mleFrameCounter.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(mleFrameCounter.IsValid(), error = OT_ERROR_PARSE);
     }
     else
     {
         mleFrameCounter.SetFrameCounter(linkFrameCounter.GetFrameCounter());
     }
 
-    VerifyOrExit(IsActiveRouter(sourceAddress.GetRloc16()), error = kThreadError_Parse);
+    VerifyOrExit(IsActiveRouter(sourceAddress.GetRloc16()), error = OT_ERROR_PARSE);
 
     routerId = GetRouterId(sourceAddress.GetRloc16());
     router = GetRouter(routerId);
 
-    VerifyOrExit(router != NULL, error = kThreadError_Parse);
+    VerifyOrExit(router != NULL, error = OT_ERROR_PARSE);
 
     // verify response
     switch (router->GetState())
     {
     case Neighbor::kStateLinkRequest:
         VerifyOrExit(memcmp(router->GetChallenge(), response.GetResponse(), router->GetChallengeSize()) == 0,
-                     error = kThreadError_Error);
+                     error = OT_ERROR_SECURITY);
         break;
 
     case Neighbor::kStateInvalid:
     case Neighbor::kStateValid:
         VerifyOrExit((mChallengeTimeout > 0) && (memcmp(mChallenge, response.GetResponse(), sizeof(mChallenge)) == 0),
-                     error = kThreadError_Error);
+                     error = OT_ERROR_SECURITY);
         break;
 
     default:
-        ExitNow(error = kThreadError_InvalidState);
+        ExitNow(error = OT_ERROR_INVALID_STATE);
     }
 
     switch (mDeviceState)
@@ -952,17 +952,17 @@ ThreadError MleRouter::HandleLinkAccept(const Message &aMessage, const Ip6::Mess
     case kDeviceStateDetached:
         // Address16
         SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kAddress16, sizeof(address16), address16));
-        VerifyOrExit(address16.IsValid(), error = kThreadError_Parse);
-        VerifyOrExit(GetRloc16() == address16.GetRloc16(), error = kThreadError_Drop);
+        VerifyOrExit(address16.IsValid(), error = OT_ERROR_PARSE);
+        VerifyOrExit(GetRloc16() == address16.GetRloc16(), error = OT_ERROR_DROP);
 
         // Route
         SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kRoute, sizeof(route), route));
-        VerifyOrExit(route.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(route.IsValid(), error = OT_ERROR_PARSE);
         SuccessOrExit(error = ProcessRouteTlv(route));
 
         // Leader Data
         SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLeaderData, sizeof(leaderData), leaderData));
-        VerifyOrExit(leaderData.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(leaderData.IsValid(), error = OT_ERROR_PARSE);
         SetLeaderData(leaderData.GetPartitionId(), leaderData.GetWeighting(), leaderData.GetLeaderRouterId());
 
         if (mLeaderData.GetLeaderRouterId() == GetRouterId(GetRloc16()))
@@ -981,7 +981,7 @@ ThreadError MleRouter::HandleLinkAccept(const Message &aMessage, const Ip6::Mess
 
     case kDeviceStateChild:
         SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLinkMargin, sizeof(linkMargin), linkMargin));
-        VerifyOrExit(linkMargin.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(linkMargin.IsValid(), error = OT_ERROR_PARSE);
         router->SetLinkQualityOut(LinkQualityInfo::ConvertLinkMarginToLinkQuality(linkMargin.GetLinkMargin()));
         break;
 
@@ -989,12 +989,12 @@ ThreadError MleRouter::HandleLinkAccept(const Message &aMessage, const Ip6::Mess
     case kDeviceStateLeader:
         // Leader Data
         SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLeaderData, sizeof(leaderData), leaderData));
-        VerifyOrExit(leaderData.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(leaderData.IsValid(), error = OT_ERROR_PARSE);
         VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId());
 
         // Link Margin
         SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLinkMargin, sizeof(linkMargin), linkMargin));
-        VerifyOrExit(linkMargin.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(linkMargin.IsValid(), error = OT_ERROR_PARSE);
         router->SetLinkQualityOut(LinkQualityInfo::ConvertLinkMarginToLinkQuality(linkMargin.GetLinkMargin()));
 
         // update routing table
@@ -1023,12 +1023,12 @@ ThreadError MleRouter::HandleLinkAccept(const Message &aMessage, const Ip6::Mess
     {
         // Challenge
         SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kChallenge, sizeof(challenge), challenge));
-        VerifyOrExit(challenge.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(challenge.IsValid(), error = OT_ERROR_PARSE);
 
         // TLV Request
-        if (Tlv::GetTlv(aMessage, Tlv::kTlvRequest, sizeof(tlvRequest), tlvRequest) == kThreadError_None)
+        if (Tlv::GetTlv(aMessage, Tlv::kTlvRequest, sizeof(tlvRequest), tlvRequest) == OT_ERROR_NONE)
         {
-            VerifyOrExit(tlvRequest.IsValid(), error = kThreadError_Parse);
+            VerifyOrExit(tlvRequest.IsValid(), error = OT_ERROR_PARSE);
         }
         else
         {
@@ -1136,11 +1136,11 @@ exit:
     return rval;
 }
 
-ThreadError MleRouter::SetRouterSelectionJitter(uint8_t aRouterJitter)
+otError MleRouter::SetRouterSelectionJitter(uint8_t aRouterJitter)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aRouterJitter > 0, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aRouterJitter > 0, error = OT_ERROR_INVALID_ARGS);
 
     mRouterSelectionJitter = aRouterJitter;
 
@@ -1148,9 +1148,9 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::ProcessRouteTlv(const RouteTlv &aRoute)
+otError MleRouter::ProcessRouteTlv(const RouteTlv &aRoute)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     mRouterIdSequence = aRoute.GetRouterIdSequence();
     mRouterIdSequenceLastUpdated = Timer::GetNow();
@@ -1170,7 +1170,7 @@ ThreadError MleRouter::ProcessRouteTlv(const RouteTlv &aRoute)
     if (GetDeviceState() == kDeviceStateRouter && !mRouters[mRouterId].IsAllocated())
     {
         BecomeDetached();
-        ExitNow(error = kThreadError_NoRoute);
+        ExitNow(error = OT_ERROR_NO_ROUTE);
     }
 
 exit:
@@ -1262,9 +1262,9 @@ uint8_t MleRouter::GetActiveRouterCount(void) const
     return rval;
 }
 
-ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     const ThreadMessageInfo *threadMessageInfo = static_cast<const ThreadMessageInfo *>(aMessageInfo.GetLinkInfo());
     Mac::ExtAddress macAddr;
     SourceAddressTlv sourceAddress;
@@ -1280,7 +1280,7 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
 
     // Source Address
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kSourceAddress, sizeof(sourceAddress), sourceAddress));
-    VerifyOrExit(sourceAddress.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(sourceAddress.IsValid(), error = OT_ERROR_PARSE);
 
     // Remove stale neighbors
     if ((neighbor = GetNeighbor(macAddr)) != NULL &&
@@ -1291,11 +1291,11 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
 
     // Leader Data
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLeaderData, sizeof(leaderData), leaderData));
-    VerifyOrExit(leaderData.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(leaderData.IsValid(), error = OT_ERROR_PARSE);
 
     // Route Data
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kRoute, sizeof(route), route));
-    VerifyOrExit(route.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(route.IsValid(), error = OT_ERROR_PARSE);
 
     partitionId = leaderData.GetPartitionId();
 
@@ -1308,7 +1308,7 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
         if (partitionId == mLastPartitionId && (mDeviceMode & ModeTlv::kModeFFD))
         {
             VerifyOrExit((static_cast<int8_t>(route.GetRouterIdSequence() - mLastPartitionRouterIdSequence) > 0),
-                         error = kThreadError_Drop);
+                         error = OT_ERROR_DROP);
         }
 
         if (GetDeviceState() == kDeviceStateChild &&
@@ -1333,14 +1333,14 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
             BecomeChild(kMleAttachBetterPartition);
         }
 
-        ExitNow(error = kThreadError_Drop);
+        ExitNow(error = OT_ERROR_DROP);
     }
     else if (leaderData.GetLeaderRouterId() != GetLeaderId())
     {
         if (GetDeviceState() != kDeviceStateChild)
         {
             BecomeDetached();
-            error = kThreadError_Drop;
+            error = OT_ERROR_DROP;
         }
 
         ExitNow();
@@ -1349,7 +1349,7 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
     VerifyOrExit(IsActiveRouter(sourceAddress.GetRloc16()));
     routerId = GetRouterId(sourceAddress.GetRloc16());
     router = GetRouter(routerId);
-    VerifyOrExit(router != NULL, error = kThreadError_Parse);
+    VerifyOrExit(router != NULL, error = OT_ERROR_PARSE);
 
     if ((mDeviceMode & ModeTlv::kModeFFD) &&
         static_cast<int8_t>(route.GetRouterIdSequence() - mRouterIdSequence) > 0)
@@ -1406,7 +1406,7 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
             if (mParent.GetRloc16() != sourceAddress.GetRloc16())
             {
                 BecomeDetached();
-                ExitNow(error = kThreadError_NoRoute);
+                ExitNow(error = OT_ERROR_NO_ROUTE);
             }
 
             if (mDeviceMode & ModeTlv::kModeFFD)
@@ -1447,7 +1447,7 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
             router->ResetLinkFailures();
             router->SetState(Neighbor::kStateLinkRequest);
             SendLinkRequest(router);
-            ExitNow(error = kThreadError_NoRoute);
+            ExitNow(error = OT_ERROR_NO_ROUTE);
         }
 
         router->SetLastHeard(Timer::GetNow());
@@ -1482,7 +1482,7 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
         // router is not in list, reject
         if (!router->IsAllocated())
         {
-            ExitNow(error = kThreadError_NoRoute);
+            ExitNow(error = OT_ERROR_NO_ROUTE);
         }
 
         // Send link request if no link to router
@@ -1495,7 +1495,7 @@ ThreadError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::M
             router->SetState(Neighbor::kStateLinkRequest);
             router->SetDataRequestPending(false);
             SendLinkRequest(router);
-            ExitNow(error = kThreadError_NoRoute);
+            ExitNow(error = OT_ERROR_NO_ROUTE);
         }
 
         router->SetLastHeard(Timer::GetNow());
@@ -1635,9 +1635,9 @@ void MleRouter::UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId)
 #endif
 }
 
-ThreadError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     const ThreadMessageInfo *threadMessageInfo = static_cast<const ThreadMessageInfo *>(aMessageInfo.GetLinkInfo());
     Mac::ExtAddress macAddr;
     VersionTlv version;
@@ -1656,24 +1656,24 @@ ThreadError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::M
     // 2. It is disconnected from its Partition (that is, it has not
     // received an updated ID sequence number within LEADER_TIMEOUT
     // seconds
-    VerifyOrExit(GetLeaderAge() < mNetworkIdTimeout, error = kThreadError_Drop);
+    VerifyOrExit(GetLeaderAge() < mNetworkIdTimeout, error = OT_ERROR_DROP);
 
     // 3. Its current routing path cost to the Leader is infinite.
     VerifyOrExit(GetDeviceState() == kDeviceStateLeader ||
                  GetLinkCost(GetLeaderId()) < kMaxRouteCost ||
                  (GetDeviceState() == kDeviceStateChild && mRouters[GetLeaderId()].GetCost() + 1 < kMaxRouteCost) ||
                  (mRouters[GetLeaderId()].GetCost() + GetLinkCost(mRouters[GetLeaderId()].GetNextHop()) < kMaxRouteCost),
-                 error = kThreadError_Drop);
+                 error = OT_ERROR_DROP);
 
     macAddr.Set(aMessageInfo.GetPeerAddr());
 
     // Version
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kVersion, sizeof(version), version));
-    VerifyOrExit(version.IsValid() && version.GetVersion() == kVersion, error = kThreadError_Parse);
+    VerifyOrExit(version.IsValid() && version.GetVersion() == kVersion, error = OT_ERROR_PARSE);
 
     // Scan Mask
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kScanMask, sizeof(scanMask), scanMask));
-    VerifyOrExit(scanMask.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(scanMask.IsValid(), error = OT_ERROR_PARSE);
 
     switch (GetDeviceState())
     {
@@ -1693,7 +1693,7 @@ ThreadError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::M
 
     // Challenge
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kChallenge, sizeof(challenge), challenge));
-    VerifyOrExit(challenge.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(challenge.IsValid(), error = OT_ERROR_PARSE);
 
     child = FindChild(macAddr);
 
@@ -1902,14 +1902,14 @@ exit:
     return;
 }
 
-ThreadError MleRouter::SendParentResponse(Child *aChild, const ChallengeTlv &challenge, bool aRoutersOnlyRequest)
+otError MleRouter::SendParentResponse(Child *aChild, const ChallengeTlv &challenge, bool aRoutersOnlyRequest)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Ip6::Address destination;
     Message *message;
     uint16_t delay;
 
-    VerifyOrExit((message = NewMleMessage()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandParentResponse));
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
@@ -1955,15 +1955,15 @@ ThreadError MleRouter::SendParentResponse(Child *aChild, const ChallengeTlv &cha
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError MleRouter::UpdateChildAddresses(const AddressRegistrationTlv &aTlv, Child &aChild)
+otError MleRouter::UpdateChildAddresses(const AddressRegistrationTlv &aTlv, Child &aChild)
 {
     const AddressRegistrationEntry *entry;
     Ip6::Address address;
@@ -2018,7 +2018,7 @@ ThreadError MleRouter::UpdateChildAddresses(const AddressRegistrationTlv &aTlv, 
                 continue;
             }
 
-            if (child->FindIp6Address(address, &index) == kThreadError_None)
+            if (child->FindIp6Address(address, &index) == OT_ERROR_NONE)
             {
                 child->RemoveIp6Address(index);
             }
@@ -2037,13 +2037,13 @@ ThreadError MleRouter::UpdateChildAddresses(const AddressRegistrationTlv &aTlv, 
 
     (void)stringBuffer;
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError MleRouter::HandleChildIdRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
-                                            uint32_t aKeySequence)
+otError MleRouter::HandleChildIdRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
+                                        uint32_t aKeySequence)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     const ThreadMessageInfo *threadMessageInfo = static_cast<const ThreadMessageInfo *>(aMessageInfo.GetLinkInfo());
     Mac::ExtAddress macAddr;
     ResponseTlv response;
@@ -2061,29 +2061,29 @@ ThreadError MleRouter::HandleChildIdRequest(const Message &aMessage, const Ip6::
     otLogInfoMle(GetInstance(), "Received Child ID Request");
 
     // only process message when operating as a child, router, or leader
-    VerifyOrExit(mDeviceState >= kDeviceStateChild, error = kThreadError_InvalidState);
+    VerifyOrExit(mDeviceState >= kDeviceStateChild, error = OT_ERROR_INVALID_STATE);
 
     // Find Child
     macAddr.Set(aMessageInfo.GetPeerAddr());
 
-    VerifyOrExit((child = FindChild(macAddr)) != NULL, error = kThreadError_Already);
+    VerifyOrExit((child = FindChild(macAddr)) != NULL, error = OT_ERROR_ALREADY);
 
     // Response
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kResponse, sizeof(response), response));
     VerifyOrExit(response.IsValid() &&
                  memcmp(response.GetResponse(), child->GetChallenge(), child->GetChallengeSize()) == 0,
-                 error = kThreadError_Security);
+                 error = OT_ERROR_SECURITY);
 
     // Link-Layer Frame Counter
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLinkFrameCounter, sizeof(linkFrameCounter),
                                       linkFrameCounter));
-    VerifyOrExit(linkFrameCounter.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(linkFrameCounter.IsValid(), error = OT_ERROR_PARSE);
 
     // MLE Frame Counter
     if (Tlv::GetTlv(aMessage, Tlv::kMleFrameCounter, sizeof(mleFrameCounter), mleFrameCounter) ==
-        kThreadError_None)
+        OT_ERROR_NONE)
     {
-        VerifyOrExit(mleFrameCounter.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(mleFrameCounter.IsValid(), error = OT_ERROR_PARSE);
     }
     else
     {
@@ -2092,11 +2092,11 @@ ThreadError MleRouter::HandleChildIdRequest(const Message &aMessage, const Ip6::
 
     // Mode
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kMode, sizeof(mode), mode));
-    VerifyOrExit(mode.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(mode.IsValid(), error = OT_ERROR_PARSE);
 
     // Timeout
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kTimeout, sizeof(timeout), timeout));
-    VerifyOrExit(timeout.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(timeout.IsValid(), error = OT_ERROR_PARSE);
 
     // Ip6 Address
     address.SetLength(0);
@@ -2104,28 +2104,28 @@ ThreadError MleRouter::HandleChildIdRequest(const Message &aMessage, const Ip6::
     if ((mode.GetMode() & ModeTlv::kModeFFD) == 0)
     {
         SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kAddressRegistration, sizeof(address), address));
-        VerifyOrExit(address.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(address.IsValid(), error = OT_ERROR_PARSE);
     }
 
     // TLV Request
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kTlvRequest, sizeof(tlvRequest), tlvRequest));
     VerifyOrExit(tlvRequest.IsValid() && tlvRequest.GetLength() <= Child::kMaxRequestTlvs,
-                 error = kThreadError_Parse);
+                 error = OT_ERROR_PARSE);
 
     // Active Timestamp
     activeTimestamp.SetLength(0);
 
-    if (Tlv::GetTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp) == OT_ERROR_NONE)
     {
-        VerifyOrExit(activeTimestamp.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(activeTimestamp.IsValid(), error = OT_ERROR_PARSE);
     }
 
     // Pending Timestamp
     pendingTimestamp.SetLength(0);
 
-    if (Tlv::GetTlv(aMessage, Tlv::kPendingTimestamp, sizeof(pendingTimestamp), pendingTimestamp) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kPendingTimestamp, sizeof(pendingTimestamp), pendingTimestamp) == OT_ERROR_NONE)
     {
-        VerifyOrExit(pendingTimestamp.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(pendingTimestamp.IsValid(), error = OT_ERROR_PARSE);
     }
 
     // Remove from router table
@@ -2216,11 +2216,11 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError MleRouter::HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     static const uint8_t kMaxResponseTlvs = 10;
 
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Mac::ExtAddress macAddr;
     ModeTlv mode;
     ChallengeTlv challenge;
@@ -2236,7 +2236,7 @@ ThreadError MleRouter::HandleChildUpdateRequest(const Message &aMessage, const I
 
     // Mode
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kMode, sizeof(mode), mode));
-    VerifyOrExit(mode.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(mode.IsValid(), error = OT_ERROR_PARSE);
 
     // Find Child
     macAddr.Set(aMessageInfo.GetPeerAddr());
@@ -2265,46 +2265,46 @@ ThreadError MleRouter::HandleChildUpdateRequest(const Message &aMessage, const I
     tlvs[tlvslength++] = Tlv::kLeaderData;
 
     // Challenge
-    if (Tlv::GetTlv(aMessage, Tlv::kChallenge, sizeof(challenge), challenge) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kChallenge, sizeof(challenge), challenge) == OT_ERROR_NONE)
     {
-        VerifyOrExit(challenge.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(challenge.IsValid(), error = OT_ERROR_PARSE);
         tlvs[tlvslength++] = Tlv::kResponse;
         tlvs[tlvslength++] = Tlv::kMleFrameCounter;
         tlvs[tlvslength++] = Tlv::kLinkFrameCounter;
     }
 
     // Ip6 Address TLV
-    if (Tlv::GetTlv(aMessage, Tlv::kAddressRegistration, sizeof(address), address) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kAddressRegistration, sizeof(address), address) == OT_ERROR_NONE)
     {
-        VerifyOrExit(address.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(address.IsValid(), error = OT_ERROR_PARSE);
         UpdateChildAddresses(address, *child);
         tlvs[tlvslength++] = Tlv::kAddressRegistration;
     }
 
     // Leader Data
-    if (Tlv::GetTlv(aMessage, Tlv::kLeaderData, sizeof(leaderData), leaderData) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kLeaderData, sizeof(leaderData), leaderData) == OT_ERROR_NONE)
     {
-        VerifyOrExit(leaderData.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(leaderData.IsValid(), error = OT_ERROR_PARSE);
     }
 
     // Timeout
-    if (Tlv::GetTlv(aMessage, Tlv::kTimeout, sizeof(timeout), timeout) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kTimeout, sizeof(timeout), timeout) == OT_ERROR_NONE)
     {
-        VerifyOrExit(timeout.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(timeout.IsValid(), error = OT_ERROR_PARSE);
         child->SetTimeout(timeout.GetTimeout());
         tlvs[tlvslength++] = Tlv::kTimeout;
     }
 
     // TLV Request
-    if (Tlv::GetTlv(aMessage, Tlv::kTlvRequest, sizeof(tlvRequest), tlvRequest) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kTlvRequest, sizeof(tlvRequest), tlvRequest) == OT_ERROR_NONE)
     {
         uint8_t tlv;
         TlvRequestIterator iterator =  TLVREQUESTTLV_ITERATOR_INIT;
 
         VerifyOrExit(tlvRequest.IsValid() && tlvRequest.GetLength() <= (Child::kMaxRequestTlvs - tlvslength),
-                     error = kThreadError_Parse);
+                     error = OT_ERROR_PARSE);
 
-        while (tlvRequest.GetNextTlv(iterator, tlv) == kThreadError_None)
+        while (tlvRequest.GetNextTlv(iterator, tlv) == OT_ERROR_NONE)
         {
             // Here skips Tlv::kLeaderData because it has already been included by default
             if (tlv != Tlv::kLeaderData)
@@ -2322,10 +2322,10 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::HandleChildUpdateResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
-                                                 uint32_t aKeySequence)
+otError MleRouter::HandleChildUpdateResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
+                                             uint32_t aKeySequence)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     const ThreadMessageInfo *threadMessageInfo = static_cast<const ThreadMessageInfo *>(aMessageInfo.GetLinkInfo());
     Mac::ExtAddress macAddr;
     SourceAddressTlv sourceAddress;
@@ -2342,55 +2342,55 @@ ThreadError MleRouter::HandleChildUpdateResponse(const Message &aMessage, const 
     // Find Child
     macAddr.Set(aMessageInfo.GetPeerAddr());
 
-    VerifyOrExit((child = FindChild(macAddr)) != NULL, error = kThreadError_NotFound);
+    VerifyOrExit((child = FindChild(macAddr)) != NULL, error = OT_ERROR_NOT_FOUND);
 
     // Source Address
-    if (Tlv::GetTlv(aMessage, Tlv::kSourceAddress, sizeof(sourceAddress), sourceAddress) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kSourceAddress, sizeof(sourceAddress), sourceAddress) == OT_ERROR_NONE)
     {
-        VerifyOrExit(sourceAddress.IsValid(), error = kThreadError_Parse);
-        VerifyOrExit(child->GetRloc16() == sourceAddress.GetRloc16(), error = kThreadError_Parse);
+        VerifyOrExit(sourceAddress.IsValid(), error = OT_ERROR_PARSE);
+        VerifyOrExit(child->GetRloc16() == sourceAddress.GetRloc16(), error = OT_ERROR_PARSE);
     }
 
     // Response
-    if (Tlv::GetTlv(aMessage, Tlv::kResponse, sizeof(response), response) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kResponse, sizeof(response), response) == OT_ERROR_NONE)
     {
         VerifyOrExit(response.IsValid() &&
                      memcmp(response.GetResponse(), child->GetChallenge(), child->GetChallengeSize()) == 0,
-                     error = kThreadError_Security);
+                     error = OT_ERROR_SECURITY);
     }
 
     // Link-Layer Frame Counter
-    if (Tlv::GetTlv(aMessage, Tlv::kLinkFrameCounter, sizeof(linkFrameCounter), linkFrameCounter) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kLinkFrameCounter, sizeof(linkFrameCounter), linkFrameCounter) == OT_ERROR_NONE)
     {
-        VerifyOrExit(linkFrameCounter.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(linkFrameCounter.IsValid(), error = OT_ERROR_PARSE);
         child->SetLinkFrameCounter(linkFrameCounter.GetFrameCounter());
     }
 
     // MLE Frame Counter
-    if (Tlv::GetTlv(aMessage, Tlv::kMleFrameCounter, sizeof(mleFrameCounter), mleFrameCounter) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kMleFrameCounter, sizeof(mleFrameCounter), mleFrameCounter) == OT_ERROR_NONE)
     {
-        VerifyOrExit(mleFrameCounter.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(mleFrameCounter.IsValid(), error = OT_ERROR_PARSE);
         child->SetMleFrameCounter(mleFrameCounter.GetFrameCounter());
     }
 
     // Timeout
-    if (Tlv::GetTlv(aMessage, Tlv::kTimeout, sizeof(timeout), timeout) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kTimeout, sizeof(timeout), timeout) == OT_ERROR_NONE)
     {
-        VerifyOrExit(timeout.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(timeout.IsValid(), error = OT_ERROR_PARSE);
         child->SetTimeout(timeout.GetTimeout());
     }
 
     // Ip6 Address
-    if (Tlv::GetTlv(aMessage, Tlv::kAddressRegistration, sizeof(address), address) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kAddressRegistration, sizeof(address), address) == OT_ERROR_NONE)
     {
-        VerifyOrExit(address.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(address.IsValid(), error = OT_ERROR_PARSE);
         UpdateChildAddresses(address, *child);
     }
 
     // Leader Data
-    if (Tlv::GetTlv(aMessage, Tlv::kLeaderData, sizeof(leaderData), leaderData) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kLeaderData, sizeof(leaderData), leaderData) == OT_ERROR_NONE)
     {
-        VerifyOrExit(leaderData.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(leaderData.IsValid(), error = OT_ERROR_PARSE);
 
         if (child->IsFullNetworkData())
         {
@@ -2411,9 +2411,9 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::HandleDataRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError MleRouter::HandleDataRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     TlvRequestTlv tlvRequest;
     ActiveTimestampTlv activeTimestamp;
     PendingTimestampTlv pendingTimestamp;
@@ -2424,22 +2424,22 @@ ThreadError MleRouter::HandleDataRequest(const Message &aMessage, const Ip6::Mes
 
     // TLV Request
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kTlvRequest, sizeof(tlvRequest), tlvRequest));
-    VerifyOrExit(tlvRequest.IsValid() && tlvRequest.GetLength() <= sizeof(tlvs), error = kThreadError_Parse);
+    VerifyOrExit(tlvRequest.IsValid() && tlvRequest.GetLength() <= sizeof(tlvs), error = OT_ERROR_PARSE);
 
     // Active Timestamp
     activeTimestamp.SetLength(0);
 
-    if (Tlv::GetTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp) == OT_ERROR_NONE)
     {
-        VerifyOrExit(activeTimestamp.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(activeTimestamp.IsValid(), error = OT_ERROR_PARSE);
     }
 
     // Pending Timestamp
     pendingTimestamp.SetLength(0);
 
-    if (Tlv::GetTlv(aMessage, Tlv::kPendingTimestamp, sizeof(pendingTimestamp), pendingTimestamp) == kThreadError_None)
+    if (Tlv::GetTlv(aMessage, Tlv::kPendingTimestamp, sizeof(pendingTimestamp), pendingTimestamp) == OT_ERROR_NONE)
     {
-        VerifyOrExit(pendingTimestamp.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(pendingTimestamp.IsValid(), error = OT_ERROR_PARSE);
     }
 
     memset(tlvs, Tlv::kInvalid, sizeof(tlvs));
@@ -2466,7 +2466,7 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::HandleNetworkDataUpdateRouter(void)
+otError MleRouter::HandleNetworkDataUpdateRouter(void)
 {
     static const uint8_t tlvs[] = {Tlv::kNetworkData};
     Ip6::Address destination;
@@ -2511,13 +2511,13 @@ ThreadError MleRouter::HandleNetworkDataUpdateRouter(void)
     }
 
 exit:
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 #if OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
-ThreadError MleRouter::SetSteeringData(otExtAddress *aExtAddress)
+otError MleRouter::SetSteeringData(otExtAddress *aExtAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t nullExtAddr[OT_EXT_ADDRESS_SIZE];
     uint8_t allowAnyExtAddr[OT_EXT_ADDRESS_SIZE];
 
@@ -2547,9 +2547,9 @@ ThreadError MleRouter::SetSteeringData(otExtAddress *aExtAddress)
 }
 #endif // OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
 
-ThreadError MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Tlv tlv;
     MeshCoP::Tlv meshcopTlv;
     MeshCoP::DiscoveryRequestTlv discoveryRequest;
@@ -2560,7 +2560,7 @@ ThreadError MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6
     otLogInfoMle(GetInstance(), "Received discovery request");
 
     // only Routers and REEDs respond
-    VerifyOrExit((mDeviceMode & ModeTlv::kModeFFD) != 0, error = kThreadError_InvalidState);
+    VerifyOrExit((mDeviceMode & ModeTlv::kModeFFD) != 0, error = OT_ERROR_INVALID_STATE);
 
     offset = aMessage.GetOffset();
     end = aMessage.GetLength();
@@ -2578,7 +2578,7 @@ ThreadError MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6
         offset += sizeof(tlv) + tlv.GetLength();
     }
 
-    VerifyOrExit(offset < end, error = kThreadError_Parse);
+    VerifyOrExit(offset < end, error = OT_ERROR_PARSE);
 
     offset += sizeof(tlv);
     end = offset + sizeof(tlv) + tlv.GetLength();
@@ -2591,7 +2591,7 @@ ThreadError MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6
         {
         case MeshCoP::Tlv::kDiscoveryRequest:
             aMessage.Read(offset, sizeof(discoveryRequest), &discoveryRequest);
-            VerifyOrExit(discoveryRequest.IsValid(), error = kThreadError_Parse);
+            VerifyOrExit(discoveryRequest.IsValid(), error = OT_ERROR_PARSE);
 
             if (discoveryRequest.IsJoiner())
             {
@@ -2604,7 +2604,7 @@ ThreadError MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6
                 else // if steering data is not set out of band, fall back to network data
 #endif // OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
                 {
-                    VerifyOrExit(mNetif.GetNetworkDataLeader().IsJoiningEnabled(), error = kThreadError_NotCapable);
+                    VerifyOrExit(mNetif.GetNetworkDataLeader().IsJoiningEnabled(), error = OT_ERROR_NOT_CAPABLE);
                 }
             }
 
@@ -2612,9 +2612,9 @@ ThreadError MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6
 
         case MeshCoP::Tlv::kExtendedPanId:
             aMessage.Read(offset, sizeof(extPanId), &extPanId);
-            VerifyOrExit(extPanId.IsValid(), error = kThreadError_Parse);
+            VerifyOrExit(extPanId.IsValid(), error = OT_ERROR_PARSE);
             VerifyOrExit(memcmp(mNetif.GetMac().GetExtendedPanId(), extPanId.GetExtendedPanId(), OT_EXT_PAN_ID_SIZE),
-                         error = kThreadError_Drop);
+                         error = OT_ERROR_DROP);
             break;
 
         default:
@@ -2628,7 +2628,7 @@ ThreadError MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6
 
 exit:
 
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         otLogWarnMleErr(GetInstance(), error, "Failed to process Discovery Request");
     }
@@ -2636,9 +2636,9 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint16_t aPanId)
+otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint16_t aPanId)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Message *message;
     uint16_t startOffset;
     Tlv tlv;
@@ -2649,7 +2649,7 @@ ThreadError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, u
     MeshCoP::Tlv *steeringData;
     uint16_t delay;
 
-    VerifyOrExit((message = NewMleMessage()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     message->SetSubType(Message::kSubTypeMleDiscoverResponse);
     message->SetPanId(aPanId);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandDiscoveryResponse));
@@ -2721,7 +2721,7 @@ ThreadError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, u
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -2729,13 +2729,13 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::SendChildIdResponse(Child *aChild)
+otError MleRouter::SendChildIdResponse(Child *aChild)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Ip6::Address destination;
     Message *message;
 
-    VerifyOrExit((message = NewMleMessage()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandChildIdResponse));
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
@@ -2808,7 +2808,7 @@ ThreadError MleRouter::SendChildIdResponse(Child *aChild)
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -2816,10 +2816,10 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::SendChildUpdateRequest(Child *aChild)
+otError MleRouter::SendChildUpdateRequest(Child *aChild)
 {
     static const uint8_t tlvs[] = {Tlv::kTimeout, Tlv::kAddressRegistration};
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Ip6::Address destination;
     Message *message;
 
@@ -2837,7 +2837,7 @@ ThreadError MleRouter::SendChildUpdateRequest(Child *aChild)
         }
     }
 
-    VerifyOrExit((message = NewMleMessage()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     message->SetSubType(Message::kSubTypeMleChildUpdateRequest);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandChildUpdateRequest));
     SuccessOrExit(error = AppendSourceAddress(*message));
@@ -2860,7 +2860,7 @@ ThreadError MleRouter::SendChildUpdateRequest(Child *aChild)
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -2868,14 +2868,14 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::SendChildUpdateResponse(Child *aChild, const Ip6::MessageInfo &aMessageInfo,
-                                               const uint8_t *aTlvs, uint8_t aTlvslength,
-                                               const ChallengeTlv *aChallenge)
+otError MleRouter::SendChildUpdateResponse(Child *aChild, const Ip6::MessageInfo &aMessageInfo,
+                                           const uint8_t *aTlvs, uint8_t aTlvslength,
+                                           const ChallengeTlv *aChallenge)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Message *message;
 
-    VerifyOrExit((message = NewMleMessage()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandChildUpdateResponse));
 
     for (int i = 0; i < aTlvslength; i++)
@@ -2932,23 +2932,23 @@ ThreadError MleRouter::SendChildUpdateResponse(Child *aChild, const Ip6::Message
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError MleRouter::SendDataResponse(const Ip6::Address &aDestination, const uint8_t *aTlvs, uint8_t aTlvsLength,
-                                        uint16_t aDelay)
+otError MleRouter::SendDataResponse(const Ip6::Address &aDestination, const uint8_t *aTlvs, uint8_t aTlvsLength,
+                                    uint16_t aDelay)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Message *message;
     Neighbor *neighbor;
     bool stableOnly;
 
-    VerifyOrExit((message = NewMleMessage()) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandDataResponse));
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
@@ -2988,7 +2988,7 @@ ThreadError MleRouter::SendDataResponse(const Ip6::Address &aDestination, const 
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -3052,15 +3052,15 @@ Child *MleRouter::GetChildren(uint8_t *numChildren)
     return mChildren;
 }
 
-ThreadError MleRouter::SetMaxAllowedChildren(uint8_t aMaxChildren)
+otError MleRouter::SetMaxAllowedChildren(uint8_t aMaxChildren)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     // Ensure the value is between 1 and kMaxChildren
-    VerifyOrExit(aMaxChildren > 0 && aMaxChildren <= kMaxChildren, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aMaxChildren > 0 && aMaxChildren <= kMaxChildren, error = OT_ERROR_INVALID_ARGS);
 
     // Do not allow setting max children if MLE is running
-    VerifyOrExit(GetDeviceState() == kDeviceStateDisabled, error = kThreadError_InvalidState);
+    VerifyOrExit(GetDeviceState() == kDeviceStateDisabled, error = OT_ERROR_INVALID_STATE);
 
     // Save the value
     mMaxChildrenAllowed = aMaxChildren;
@@ -3069,19 +3069,19 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::RemoveNeighbor(const Mac::Address &aAddress)
+otError MleRouter::RemoveNeighbor(const Mac::Address &aAddress)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Neighbor *neighbor;
 
-    VerifyOrExit((neighbor = GetNeighbor(aAddress)) != NULL, error = kThreadError_NotFound);
+    VerifyOrExit((neighbor = GetNeighbor(aAddress)) != NULL, error = OT_ERROR_NOT_FOUND);
     SuccessOrExit(error = RemoveNeighbor(*neighbor));
 
 exit:
     return error;
 }
 
-ThreadError MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
+otError MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
 {
     switch (mDeviceState)
     {
@@ -3140,7 +3140,7 @@ ThreadError MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
     aNeighbor.GetLinkInfo().Clear();
     aNeighbor.SetState(Neighbor::kStateInvalid);
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 Neighbor *MleRouter::GetNeighbor(uint16_t aAddress)
@@ -3290,7 +3290,7 @@ Neighbor *MleRouter::GetNeighbor(const Ip6::Address &aAddress)
         ExitNow(rval = GetNeighbor(macaddr));
     }
 
-    if (mNetif.GetNetworkDataLeader().GetContext(aAddress, context) != kThreadError_None)
+    if (mNetif.GetNetworkDataLeader().GetContext(aAddress, context) != OT_ERROR_NONE)
     {
         context.mContextId = 0xff;
     }
@@ -3313,7 +3313,7 @@ Neighbor *MleRouter::GetNeighbor(const Ip6::Address &aAddress)
             ExitNow(rval = child);
         }
 
-        if (child->FindIp6Address(aAddress, NULL) == kThreadError_None)
+        if (child->FindIp6Address(aAddress, NULL) == OT_ERROR_NONE)
         {
             ExitNow(rval = child);
         }
@@ -3419,13 +3419,13 @@ exit:
     return rval;
 }
 
-ThreadError MleRouter::SetPreferredRouterId(uint8_t aRouterId)
+otError MleRouter::SetPreferredRouterId(uint8_t aRouterId)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     VerifyOrExit(
         (mDeviceState == kDeviceStateDetached) || (mDeviceState == kDeviceStateDisabled),
-        error = kThreadError_InvalidState
+        error = OT_ERROR_INVALID_STATE
     );
 
     mPreviousRouterId = aRouterId;
@@ -3474,9 +3474,9 @@ exit:
     return rval;
 }
 
-ThreadError MleRouter::GetChildInfoById(uint16_t aChildId, otChildInfo &aChildInfo)
+otError MleRouter::GetChildInfoById(uint16_t aChildId, otChildInfo &aChildInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Child *child;
 
     if ((aChildId & ~kMaxChildId) != 0)
@@ -3484,27 +3484,27 @@ ThreadError MleRouter::GetChildInfoById(uint16_t aChildId, otChildInfo &aChildIn
         aChildId = GetChildId(aChildId);
     }
 
-    VerifyOrExit((child = FindChild(aChildId)) != NULL, error = kThreadError_NotFound);
+    VerifyOrExit((child = FindChild(aChildId)) != NULL, error = OT_ERROR_NOT_FOUND);
     error = GetChildInfo(*child, aChildInfo);
 
 exit:
     return error;
 }
 
-ThreadError MleRouter::GetChildInfoByIndex(uint8_t aChildIndex, otChildInfo &aChildInfo)
+otError MleRouter::GetChildInfoByIndex(uint8_t aChildIndex, otChildInfo &aChildInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aChildIndex < mMaxChildrenAllowed, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aChildIndex < mMaxChildrenAllowed, error = OT_ERROR_INVALID_ARGS);
     error = GetChildInfo(mChildren[aChildIndex], aChildInfo);
 
 exit:
     return error;
 }
 
-ThreadError MleRouter::RestoreChildren(void)
+otError MleRouter::RestoreChildren(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     for (uint8_t i = 0; ; i++)
     {
@@ -3515,9 +3515,9 @@ ThreadError MleRouter::RestoreChildren(void)
         length = sizeof(childInfo);
         SuccessOrExit(error = otPlatSettingsGet(mNetif.GetInstance(), Settings::kKeyChildInfo, i,
                                                 reinterpret_cast<uint8_t *>(&childInfo), &length));
-        VerifyOrExit(length >= sizeof(childInfo), error = kThreadError_Parse);
+        VerifyOrExit(length >= sizeof(childInfo), error = OT_ERROR_PARSE);
 
-        VerifyOrExit((child = NewChild()) != NULL, error = kThreadError_NoBufs);
+        VerifyOrExit((child = NewChild()) != NULL, error = OT_ERROR_NO_BUFS);
         memset(child, 0, sizeof(*child));
 
         child->SetExtAddress(*static_cast<Mac::ExtAddress *>(&childInfo.mExtAddress));
@@ -3533,9 +3533,9 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::RemoveStoredChild(uint16_t aChildRloc16)
+otError MleRouter::RemoveStoredChild(uint16_t aChildRloc16)
 {
-    ThreadError error = kThreadError_NotFound;
+    otError error = OT_ERROR_NOT_FOUND;
 
     for (uint8_t i = 0; i < kMaxChildren; i++)
     {
@@ -3544,7 +3544,7 @@ ThreadError MleRouter::RemoveStoredChild(uint16_t aChildRloc16)
 
         SuccessOrExit(error = otPlatSettingsGet(mNetif.GetInstance(), Settings::kKeyChildInfo, i,
                                                 reinterpret_cast<uint8_t *>(&childInfo), &length));
-        VerifyOrExit(length == sizeof(childInfo), error = kThreadError_Parse);
+        VerifyOrExit(length == sizeof(childInfo), error = OT_ERROR_PARSE);
 
         if (childInfo.mRloc16 == aChildRloc16)
         {
@@ -3557,13 +3557,13 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::StoreChild(uint16_t aChildRloc16)
+otError MleRouter::StoreChild(uint16_t aChildRloc16)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Child *child;
     Settings::ChildInfo childInfo;
 
-    VerifyOrExit((child = FindChild(GetChildId(aChildRloc16))) != NULL, error = kThreadError_NotFound);
+    VerifyOrExit((child = FindChild(GetChildId(aChildRloc16))) != NULL, error = OT_ERROR_NOT_FOUND);
 
     IgnoreReturnValue(RemoveStoredChild(aChildRloc16));
 
@@ -3581,9 +3581,9 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::RefreshStoredChildren(void)
+otError MleRouter::RefreshStoredChildren(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     SuccessOrExit(error = otPlatSettingsDelete(mNetif.GetInstance(), Settings::kKeyChildInfo, -1));
 
@@ -3599,11 +3599,11 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::GetChildInfo(Child &aChild, otChildInfo &aChildInfo)
+otError MleRouter::GetChildInfo(Child &aChild, otChildInfo &aChildInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aChild.GetState() == Neighbor::kStateValid, error = kThreadError_NotFound);
+    VerifyOrExit(aChild.GetState() == Neighbor::kStateValid, error = OT_ERROR_NOT_FOUND);
 
     memset(&aChildInfo, 0, sizeof(aChildInfo));
     memcpy(&aChildInfo.mExtAddress, &aChild.GetExtAddress(), sizeof(aChildInfo.mExtAddress));
@@ -3626,9 +3626,9 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::GetRouterInfo(uint16_t aRouterId, otRouterInfo &aRouterInfo)
+otError MleRouter::GetRouterInfo(uint16_t aRouterId, otRouterInfo &aRouterInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Router *router;
     uint8_t routerId;
 
@@ -3642,7 +3642,7 @@ ThreadError MleRouter::GetRouterInfo(uint16_t aRouterId, otRouterInfo &aRouterIn
     }
 
     router = GetRouter(routerId);
-    VerifyOrExit(router != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(router != NULL, error = OT_ERROR_INVALID_ARGS);
 
     memcpy(&aRouterInfo.mExtAddress, &router->GetExtAddress(), sizeof(aRouterInfo.mExtAddress));
 
@@ -3660,9 +3660,9 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::GetNextNeighborInfo(otNeighborInfoIterator &aIterator, otNeighborInfo &aNeighInfo)
+otError MleRouter::GetNextNeighborInfo(otNeighborInfoIterator &aIterator, otNeighborInfo &aNeighInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Neighbor *neighbor = NULL;
     int16_t index;
 
@@ -3702,7 +3702,7 @@ ThreadError MleRouter::GetNextNeighborInfo(otNeighborInfoIterator &aIterator, ot
     }
 
     aIterator = -index;
-    error = kThreadError_NotFound;
+    error = OT_ERROR_NOT_FOUND;
 
 exit:
 
@@ -3739,7 +3739,7 @@ void MleRouter::ResolveRoutingLoops(uint16_t aSourceMac, uint16_t aDestRloc16)
     }
 }
 
-ThreadError MleRouter::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, Ip6::Header &aIp6Header)
+otError MleRouter::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, Ip6::Header &aIp6Header)
 {
     Ip6::MessageInfo messageInfo;
 
@@ -3754,12 +3754,12 @@ ThreadError MleRouter::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDes
         if (mNetif.IsUnicastAddress(aIp6Header.GetDestination()))
         {
             // IPv6 destination is this device
-            return kThreadError_None;
+            return OT_ERROR_NONE;
         }
         else if (GetNeighbor(aIp6Header.GetDestination()) != NULL)
         {
             // IPv6 destination is an RFD child
-            return kThreadError_None;
+            return OT_ERROR_NONE;
         }
     }
     else if (GetRouterId(aMeshDest) == mRouterId)
@@ -3767,13 +3767,13 @@ ThreadError MleRouter::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDes
         // mesh destination is a child of this device
         if (GetChild(aMeshDest))
         {
-            return kThreadError_None;
+            return OT_ERROR_NONE;
         }
     }
     else if (GetNextHop(aMeshDest) != Mac::kShortAddrInvalid)
     {
         // forwarding to another router and route is known
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
 
     messageInfo.GetPeerAddr() = GetMeshLocal16();
@@ -3784,12 +3784,12 @@ ThreadError MleRouter::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDes
                                     kIcmp6CodeDstUnreachNoRoute,
                                     messageInfo, aIp6Header);
 
-    return kThreadError_Drop;
+    return OT_ERROR_DROP;
 }
 
-ThreadError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
+otError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header header;
     ThreadExtMacAddressTlv macAddr64Tlv;
     ThreadRloc16Tlv rlocTlv;
@@ -3802,7 +3802,7 @@ ThreadError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
     header.AppendUriPathOptions(OT_URI_PATH_ADDRESS_SOLICIT);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     macAddr64Tlv.Init();
     macAddr64Tlv.SetMacAddr(*mNetif.GetMac().GetExtAddress());
@@ -3830,7 +3830,7 @@ ThreadError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -3838,9 +3838,9 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::SendAddressRelease(void)
+otError MleRouter::SendAddressRelease(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header header;
     ThreadRloc16Tlv rlocTlv;
     ThreadExtMacAddressTlv macAddr64Tlv;
@@ -3852,7 +3852,7 @@ ThreadError MleRouter::SendAddressRelease(void)
     header.AppendUriPathOptions(OT_URI_PATH_ADDRESS_RELEASE);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     rlocTlv.Init();
     rlocTlv.SetRloc16(GetRloc16(mRouterId));
@@ -3871,7 +3871,7 @@ ThreadError MleRouter::SendAddressRelease(void)
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -3880,7 +3880,7 @@ exit:
 }
 
 void MleRouter::HandleAddressSolicitResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                             const otMessageInfo *aMessageInfo, ThreadError aResult)
+                                             const otMessageInfo *aMessageInfo, otError aResult)
 {
     static_cast<MleRouter *>(aContext)->HandleAddressSolicitResponse(static_cast<Coap::Header *>(aHeader),
                                                                      static_cast<Message *>(aMessage),
@@ -3889,7 +3889,7 @@ void MleRouter::HandleAddressSolicitResponse(void *aContext, otCoapHeader *aHead
 }
 
 void MleRouter::HandleAddressSolicitResponse(Coap::Header *aHeader, Message *aMessage,
-                                             const Ip6::MessageInfo *aMessageInfo, ThreadError aResult)
+                                             const Ip6::MessageInfo *aMessageInfo, otError aResult)
 {
     (void)aResult;
     (void)aMessageInfo;
@@ -3901,7 +3901,7 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Header *aHeader, Message *aMe
     Router *router;
     bool old;
 
-    VerifyOrExit(aResult == kThreadError_None && aHeader != NULL && aMessage != NULL);
+    VerifyOrExit(aResult == OT_ERROR_NONE && aHeader != NULL && aMessage != NULL);
 
     VerifyOrExit(aHeader->GetCode() == kCoapResponseChanged);
 
@@ -4017,7 +4017,7 @@ void MleRouter::HandleAddressSolicit(void *aContext, otCoapHeader *aHeader, otMe
 
 void MleRouter::HandleAddressSolicit(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     ThreadExtMacAddressTlv macAddr64Tlv;
     ThreadRloc16Tlv rlocTlv;
     ThreadStatusTlv statusTlv;
@@ -4025,15 +4025,15 @@ void MleRouter::HandleAddressSolicit(Coap::Header &aHeader, Message &aMessage, c
     Router *router = NULL;
 
     VerifyOrExit(aHeader.GetType() == kCoapTypeConfirmable && aHeader.GetCode() == kCoapRequestPost,
-                 error = kThreadError_Parse);
+                 error = OT_ERROR_PARSE);
 
     otLogInfoMle(GetInstance(), "Received address solicit");
 
     SuccessOrExit(error = ThreadTlv::GetTlv(aMessage, ThreadTlv::kExtMacAddress, sizeof(macAddr64Tlv), macAddr64Tlv));
-    VerifyOrExit(macAddr64Tlv.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(macAddr64Tlv.IsValid(), error = OT_ERROR_PARSE);
 
     SuccessOrExit(error = ThreadTlv::GetTlv(aMessage, ThreadTlv::kStatus, sizeof(statusTlv), statusTlv));
-    VerifyOrExit(statusTlv.IsValid(), error = kThreadError_Parse);
+    VerifyOrExit(statusTlv.IsValid(), error = OT_ERROR_PARSE);
 
     // see if allocation already exists
     for (uint8_t i = 0; i <= kMaxRouterId; i++)
@@ -4057,14 +4057,14 @@ void MleRouter::HandleAddressSolicit(Coap::Header &aHeader, Message &aMessage, c
         break;
 
     default:
-        ExitNow(error = kThreadError_Parse);
+        ExitNow(error = OT_ERROR_PARSE);
         break;
     }
 
-    if (ThreadTlv::GetTlv(aMessage, ThreadTlv::kRloc16, sizeof(rlocTlv), rlocTlv) == kThreadError_None)
+    if (ThreadTlv::GetTlv(aMessage, ThreadTlv::kRloc16, sizeof(rlocTlv), rlocTlv) == OT_ERROR_NONE)
     {
         // specific Router ID requested
-        VerifyOrExit(rlocTlv.IsValid(), error = kThreadError_Parse);
+        VerifyOrExit(rlocTlv.IsValid(), error = OT_ERROR_PARSE);
         routerId = GetRouterId(rlocTlv.GetRloc16());
         router = GetRouter(routerId);
 
@@ -4111,7 +4111,7 @@ void MleRouter::HandleAddressSolicit(Coap::Header &aHeader, Message &aMessage, c
 
 exit:
 
-    if (error == kThreadError_None)
+    if (error == OT_ERROR_NONE)
     {
         SendAddressSolicitResponse(aHeader, routerId, aMessageInfo);
     }
@@ -4120,7 +4120,7 @@ exit:
 void MleRouter::SendAddressSolicitResponse(const Coap::Header &aRequestHeader, uint8_t aRouterId,
                                            const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header responseHeader;
     ThreadStatusTlv statusTlv;
     ThreadRouterMaskTlv routerMaskTlv;
@@ -4130,7 +4130,7 @@ void MleRouter::SendAddressSolicitResponse(const Coap::Header &aRequestHeader, u
     responseHeader.SetDefaultResponseHeader(aRequestHeader);
     responseHeader.SetPayloadMarker();
 
-    VerifyOrExit((message = mNetif.GetCoap().NewMessage(responseHeader)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoap().NewMessage(responseHeader)) != NULL, error = OT_ERROR_NO_BUFS);
 
     statusTlv.Init();
     statusTlv.SetStatus(!IsRouterIdValid(aRouterId) ? statusTlv.kNoAddressAvailable : statusTlv.kSuccess);
@@ -4163,7 +4163,7 @@ void MleRouter::SendAddressSolicitResponse(const Coap::Header &aRequestHeader, u
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -4327,9 +4327,9 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
     tlv.SetSedDatagramCount(1);
 }
 
-ThreadError MleRouter::AppendConnectivity(Message &aMessage)
+otError MleRouter::AppendConnectivity(Message &aMessage)
 {
-    ThreadError error;
+    otError error;
     ConnectivityTlv tlv;
 
     tlv.Init();
@@ -4341,9 +4341,9 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::AppendChildAddresses(Message &aMessage, Child &aChild)
+otError MleRouter::AppendChildAddresses(Message &aMessage, Child &aChild)
 {
-    ThreadError error;
+    otError error;
     Tlv tlv;
     AddressRegistrationEntry entry;
     Lowpan::Context context;
@@ -4360,7 +4360,7 @@ ThreadError MleRouter::AppendChildAddresses(Message &aMessage, Child &aChild)
             break;
         }
 
-        if (mNetif.GetNetworkDataLeader().GetContext(aChild.GetIp6Address(i), context) == kThreadError_None)
+        if (mNetif.GetNetworkDataLeader().GetContext(aChild.GetIp6Address(i), context) == OT_ERROR_NONE)
         {
             // compressed entry
             entry.SetContextId(context.mContextId);
@@ -4452,9 +4452,9 @@ void MleRouter::FillRouteTlv(RouteTlv &tlv)
     tlv.SetRouteDataLength(routeCount);
 }
 
-ThreadError MleRouter::AppendRoute(Message &aMessage)
+otError MleRouter::AppendRoute(Message &aMessage)
 {
-    ThreadError error;
+    otError error;
     RouteTlv tlv;
     tlv.Init();
     FillRouteTlv(tlv);
@@ -4463,9 +4463,9 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::AppendActiveDataset(Message &aMessage)
+otError MleRouter::AppendActiveDataset(Message &aMessage)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     VerifyOrExit(mNetif.GetActiveDataset().GetNetwork().GetSize() > 0);
 
@@ -4475,9 +4475,9 @@ exit:
     return error;
 }
 
-ThreadError MleRouter::AppendPendingDataset(Message &aMessage)
+otError MleRouter::AppendPendingDataset(Message &aMessage)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     VerifyOrExit(mNetif.GetPendingDataset().GetNetwork().GetSize() > 0);
 

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -116,22 +116,22 @@ public:
      *
      * @param[in]  aStatus  The reason for requesting a Router ID.
      *
-     * @retval kThreadError_None          Successfully generated an Address Solicit message.
-     * @retval kThreadError_NotCapable    Device is not capable of becoming a router
-     * @retval kThreadError_InvalidState  Thread is not enabled
+     * @retval OT_ERROR_NONE           Successfully generated an Address Solicit message.
+     * @retval OT_ERROR_NOT_CAPABLE    Device is not capable of becoming a router
+     * @retval OT_ERROR_INVALID_STATE  Thread is not enabled
      *
      */
-    ThreadError BecomeRouter(ThreadStatusTlv::Status aStatus);
+    otError BecomeRouter(ThreadStatusTlv::Status aStatus);
 
     /**
      * This method causes the Thread interface to become a Leader and start a new partition.
      *
-     * @retval kThreadError_None          Successfully become a Leader and started a new partition.
-     * @retval kThreadError_NotCapable    Device is not capable of becoming a leader
-     * @retval kThreadError_InvalidState  Thread is not enabled
+     * @retval OT_ERROR_NONE           Successfully become a Leader and started a new partition.
+     * @retval OT_ERROR_NOT_CAPABLE    Device is not capable of becoming a leader
+     * @retval OT_ERROR_INVALID_STATE  Thread is not enabled
      *
      */
-    ThreadError BecomeLeader(void);
+    otError BecomeLeader(void);
 
     /**
      * This method returns the number of active routers.
@@ -189,11 +189,11 @@ public:
      *
      * @param[in]  aRouterId             The preferred Router Id.
      *
-     * @retval kThreadError_None         Successfully set the preferred Router Id.
-     * @retval kThreadError_InvalidState Could not set (role is other than detached and disabled)
+     * @retval OT_ERROR_NONE          Successfully set the preferred Router Id.
+     * @retval OT_ERROR_INVALID_STATE Could not set (role is other than detached and disabled)
      *
      */
-    ThreadError SetPreferredRouterId(uint8_t aRouterId);
+    otError SetPreferredRouterId(uint8_t aRouterId);
 
     /**
      * This method gets the Partition Id which the device joined successfully once.
@@ -287,7 +287,7 @@ public:
      * @returns The ROUTER_SELECTION_JITTER value.
      *
      */
-    ThreadError SetRouterSelectionJitter(uint8_t aRouterJitter);
+    otError SetRouterSelectionJitter(uint8_t aRouterJitter);
 
     /**
      * This method returns the current Router ID Sequence value.
@@ -334,32 +334,32 @@ public:
      *
      * @param[in]  aRouterId  The Router ID to release.
      *
-     * @retval kThreadError_None          Successfully released the Router ID.
-     * @retval kThreadError_InvalidState  The Router ID was not allocated.
+     * @retval OT_ERROR_NONE           Successfully released the Router ID.
+     * @retval OT_ERROR_INVALID_STATE  The Router ID was not allocated.
      *
      */
-    ThreadError ReleaseRouterId(uint8_t aRouterId);
+    otError ReleaseRouterId(uint8_t aRouterId);
 
     /**
      * This method removes a link to a neighbor.
      *
      * @param[in]  aAddress  The link address of the neighbor.
      *
-     * @retval kThreadError_None      Successfully removed the neighbor.
-     * @retval kThreadError_NotFound  Could not find the neighbor.
+     * @retval OT_ERROR_NONE       Successfully removed the neighbor.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the neighbor.
      *
      */
-    ThreadError RemoveNeighbor(const Mac::Address &aAddress);
+    otError RemoveNeighbor(const Mac::Address &aAddress);
 
     /**
      * This method removes a link to a neighbor.
      *
      * @param[in]  aNeighbor  A reference to the neighbor object.
      *
-     * @retval kThreadError_None      Successfully removed the neighbor.
+     * @retval OT_ERROR_NONE      Successfully removed the neighbor.
      *
      */
-    ThreadError RemoveNeighbor(Neighbor &aNeighbor);
+    otError RemoveNeighbor(Neighbor &aNeighbor);
 
     /**
      * This method returns a pointer to a Child object.
@@ -416,54 +416,54 @@ public:
      *
      * @param[in]  aMaxChildren  The max children allowed value.
      *
-     * @retval  kThreadError_None          Successfully set the max.
-     * @retval  kThreadError_InvalidArgs   If @p aMaxChildren is not in the range [1, kMaxChildren].
-     * @retval  kThreadError_InvalidState  If MLE has already been started.
+     * @retval  OT_ERROR_NONE           Successfully set the max.
+     * @retval  OT_ERROR_INVALID_ARGS   If @p aMaxChildren is not in the range [1, kMaxChildren].
+     * @retval  OT_ERROR_INVALID_STATE  If MLE has already been started.
      *
      */
-    ThreadError SetMaxAllowedChildren(uint8_t aMaxChildren);
+    otError SetMaxAllowedChildren(uint8_t aMaxChildren);
 
     /**
      * This method restores children information from non-volatile memory.
      *
-     * @retval  kThreadError_None     Successfully restored children information.
-     * @retval  kThreadError_Failed   The saved child info in non-volatile memory is invalid.
-     * @retval  kThreadError_NoBufs   More children in settings than max children.
+     * @retval  OT_ERROR_NONE     Successfully restored children information.
+     * @retval  OT_ERROR_FAILED   The saved child info in non-volatile memory is invalid.
+     * @retval  OT_ERROR_NO_BUFS  More children in settings than max children.
      *
      */
-    ThreadError RestoreChildren(void);
+    otError RestoreChildren(void);
 
     /**
      * This method remove a stored child information from non-volatile memory.
      *
      * @param[in]  aChildRloc16   The child RLOC16 to remove.
      *
-     * @retval  kThreadError_None       Successfully remove child.
-     * @retval  kThreadError_NotFound   There is no specified child stored in non-volatile memory.
+     * @retval  OT_ERROR_NONE        Successfully remove child.
+     * @retval  OT_ERROR_NOT_FOUND   There is no specified child stored in non-volatile memory.
      *
      */
-    ThreadError RemoveStoredChild(uint16_t aChildRloc16);
+    otError RemoveStoredChild(uint16_t aChildRloc16);
 
     /**
      * This method store a child information into non-volatile memory.
      *
      * @param[in]  aChildRloc16   The child RLOC16 to store.
      *
-     * @retval  kThreadError_None     Successfully store child.
-     * @retval  kThreadError_NoBufs   Insufficient available buffers to store child.
+     * @retval  OT_ERROR_NONE      Successfully store child.
+     * @retval  OT_ERROR_NO_BUFS   Insufficient available buffers to store child.
      *
      */
-    ThreadError StoreChild(uint16_t aChildRloc16);
+    otError StoreChild(uint16_t aChildRloc16);
 
     /**
      * This method refreshes all the saved children information in non-volatile memory by first erasing any saved
      * child information in non-volatile memory and then saving all children info.
      *
-     * @retval  kThreadError_None     Successfully refreshed all children info in non-volatile memory
-     * @retval  kThreadError_NoBufs   Insufficient available buffers to store child.
+     * @retval  OT_ERROR_NONE      Successfully refreshed all children info in non-volatile memory
+     * @retval  OT_ERROR_NO_BUFS   Insufficient available buffers to store child.
      *
      */
-    ThreadError RefreshStoredChildren(void);
+    otError RefreshStoredChildren(void);
 
     /**
      * This method returns a pointer to a Neighbor object.
@@ -512,7 +512,7 @@ public:
      * @param[out]  aChildInfo  The child information.
      *
      */
-    ThreadError GetChildInfoById(uint16_t aChildId, otChildInfo &aChildInfo);
+    otError GetChildInfoById(uint16_t aChildId, otChildInfo &aChildInfo);
 
     /**
      * This method retains diagnostic information for an attached child by the internal table index.
@@ -521,7 +521,7 @@ public:
      * @param[out]  aChildInfo   The child information.
      *
      */
-    ThreadError GetChildInfoByIndex(uint8_t aChildIndex, otChildInfo &aChildInfo);
+    otError GetChildInfoByIndex(uint8_t aChildIndex, otChildInfo &aChildInfo);
 
     /**
      * This method gets the next neighbor information. It is used to iterate through the entries of
@@ -531,11 +531,11 @@ public:
                                  it should be set to OT_NEIGHBOR_INFO_ITERATOR_INIT.
      * @param[out]    aNeighInfo The neighbor information.
      *
-     * @retval kThreadError_None         Successfully found the next neighbor entry in table.
-     * @retval kThreadError_NotFound     No subsequent neighbor entry exists in the table.
+     * @retval OT_ERROR_NONE          Successfully found the next neighbor entry in table.
+     * @retval OT_ERROR_NOT_FOUND     No subsequent neighbor entry exists in the table.
      *
      */
-    ThreadError GetNextNeighborInfo(otNeighborInfoIterator &aIterator, otNeighborInfo &aNeighInfo);
+    otError GetNextNeighborInfo(otNeighborInfoIterator &aIterator, otNeighborInfo &aNeighInfo);
 
     /**
      * This method returns a pointer to a Router array.
@@ -574,7 +574,7 @@ public:
      * @param[out]  aRouterInfo  The router information.
      *
      */
-    ThreadError GetRouterInfo(uint16_t aRouterId, otRouterInfo &aRouterInfo);
+    otError GetRouterInfo(uint16_t aRouterId, otRouterInfo &aRouterInfo);
 
     /**
      * This method indicates whether or not the given Thread partition attributes are preferred.
@@ -599,11 +599,11 @@ public:
      * @param[in]  aMeshDest    The RLOC16 of the destination.
      * @param[in]  aIp6Header   A reference to the IPv6 header of the message.
      *
-     * @retval kThreadError_None  The destination is reachable.
-     * @retval kThreadError_Drop  The destination is not reachable and the message should be dropped.
+     * @retval OT_ERROR_NONE  The destination is reachable.
+     * @retval OT_ERROR_DROP  The destination is not reachable and the message should be dropped.
      *
      */
-    ThreadError CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, Ip6::Header &aIp6Header);
+    otError CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, Ip6::Header &aIp6Header);
 
     /**
      * This method resolves 2-hop routing loops.
@@ -644,11 +644,11 @@ public:
     /**
       * This method generates an MLE Child Update Request message to be sent to the parent.
       *
-      * @retval kThreadError_None    Successfully generated an MLE Child Update Request message.
-      * @retval kThreadError_NoBufs  Insufficient buffers to generate the MLE Child Update Request message.
+      * @retval OT_ERROR_NONE     Successfully generated an MLE Child Update Request message.
+      * @retval OT_ERROR_NO_BUFS  Insufficient buffers to generate the MLE Child Update Request message.
       *
       */
-    ThreadError SendChildUpdateRequest(void) { return Mle::SendChildUpdateRequest(); }
+    otError SendChildUpdateRequest(void) { return Mle::SendChildUpdateRequest(); }
 
 #if OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
     /**
@@ -659,10 +659,10 @@ public:
      *                          All 0xFFs sets steering data to 0xFF
      *                          Anything else is used to compute the bloom filter
      *
-     * @retval kThreadError_None  Steering data was set
+     * @retval OT_ERROR_NONE  Steering data was set
      *
      */
-    ThreadError SetSteeringData(otExtAddress *aExtAddress);
+    otError SetSteeringData(otExtAddress *aExtAddress);
 #endif // OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
 
 private:
@@ -673,61 +673,61 @@ private:
         kUnsolicitedDataResponseJitter = 500u,  ///< Maximum delay before unsolicited Data Response in milliseconds.
     };
 
-    ThreadError AppendConnectivity(Message &aMessage);
-    ThreadError AppendChildAddresses(Message &aMessage, Child &aChild);
-    ThreadError AppendRoute(Message &aMessage);
-    ThreadError AppendActiveDataset(Message &aMessage);
-    ThreadError AppendPendingDataset(Message &aMessage);
-    ThreadError GetChildInfo(Child &aChild, otChildInfo &aChildInfo);
-    ThreadError HandleDetachStart(void);
-    ThreadError HandleChildStart(otMleAttachFilter aFilter);
-    ThreadError HandleLinkRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError HandleLinkAccept(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, uint32_t aKeySequence);
-    ThreadError HandleLinkAccept(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, uint32_t aKeySequence,
-                                 bool request);
-    ThreadError HandleLinkAcceptAndRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
-                                           uint32_t aKeySequence);
-    ThreadError HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError HandleParentRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError HandleChildIdRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
-                                     uint32_t aKeySequence);
-    ThreadError HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError HandleChildUpdateResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
-                                          uint32_t aKeySequence);
-    ThreadError HandleDataRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    ThreadError HandleNetworkDataUpdateRouter(void);
-    ThreadError HandleDiscoveryRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError AppendConnectivity(Message &aMessage);
+    otError AppendChildAddresses(Message &aMessage, Child &aChild);
+    otError AppendRoute(Message &aMessage);
+    otError AppendActiveDataset(Message &aMessage);
+    otError AppendPendingDataset(Message &aMessage);
+    otError GetChildInfo(Child &aChild, otChildInfo &aChildInfo);
+    otError HandleDetachStart(void);
+    otError HandleChildStart(otMleAttachFilter aFilter);
+    otError HandleLinkRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError HandleLinkAccept(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, uint32_t aKeySequence);
+    otError HandleLinkAccept(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, uint32_t aKeySequence,
+                             bool request);
+    otError HandleLinkAcceptAndRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
+                                       uint32_t aKeySequence);
+    otError HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError HandleParentRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError HandleChildIdRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
+                                 uint32_t aKeySequence);
+    otError HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError HandleChildUpdateResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
+                                      uint32_t aKeySequence);
+    otError HandleDataRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError HandleNetworkDataUpdateRouter(void);
+    otError HandleDiscoveryRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    ThreadError ProcessRouteTlv(const RouteTlv &aRoute);
+    otError ProcessRouteTlv(const RouteTlv &aRoute);
     void StopAdvertiseTimer(void);
     void ResetAdvertiseInterval(void);
-    ThreadError SendAddressSolicit(ThreadStatusTlv::Status aStatus);
-    ThreadError SendAddressRelease(void);
+    otError SendAddressSolicit(ThreadStatusTlv::Status aStatus);
+    otError SendAddressRelease(void);
     void SendAddressSolicitResponse(const Coap::Header &aRequest, uint8_t aRouterId,
                                     const Ip6::MessageInfo &aMessageInfo);
-    ThreadError SendAdvertisement(void);
-    ThreadError SendLinkRequest(Neighbor *aNeighbor);
-    ThreadError SendLinkAccept(const Ip6::MessageInfo &aMessageInfo, Neighbor *aNeighbor,
-                               const TlvRequestTlv &aTlvRequest, const ChallengeTlv &aChallenge);
-    ThreadError SendParentResponse(Child *aChild, const ChallengeTlv &aChallenge, bool aRoutersOnlyRequest);
-    ThreadError SendChildIdResponse(Child *aChild);
-    ThreadError SendChildUpdateRequest(Child *aChild);
-    ThreadError SendChildUpdateResponse(Child *aChild, const Ip6::MessageInfo &aMessageInfo,
-                                        const uint8_t *aTlvs, uint8_t aTlvsLength,  const ChallengeTlv *challenge);
-    ThreadError SendDataResponse(const Ip6::Address &aDestination, const uint8_t *aTlvs, uint8_t aTlvsLength,
-                                 uint16_t aDelay);
-    ThreadError SendDiscoveryResponse(const Ip6::Address &aDestination, uint16_t aPanId);
+    otError SendAdvertisement(void);
+    otError SendLinkRequest(Neighbor *aNeighbor);
+    otError SendLinkAccept(const Ip6::MessageInfo &aMessageInfo, Neighbor *aNeighbor,
+                           const TlvRequestTlv &aTlvRequest, const ChallengeTlv &aChallenge);
+    otError SendParentResponse(Child *aChild, const ChallengeTlv &aChallenge, bool aRoutersOnlyRequest);
+    otError SendChildIdResponse(Child *aChild);
+    otError SendChildUpdateRequest(Child *aChild);
+    otError SendChildUpdateResponse(Child *aChild, const Ip6::MessageInfo &aMessageInfo,
+                                    const uint8_t *aTlvs, uint8_t aTlvsLength,  const ChallengeTlv *challenge);
+    otError SendDataResponse(const Ip6::Address &aDestination, const uint8_t *aTlvs, uint8_t aTlvsLength,
+                             uint16_t aDelay);
+    otError SendDiscoveryResponse(const Ip6::Address &aDestination, uint16_t aPanId);
 
-    ThreadError SetStateRouter(uint16_t aRloc16);
-    ThreadError SetStateLeader(uint16_t aRloc16);
+    otError SetStateRouter(uint16_t aRloc16);
+    otError SetStateLeader(uint16_t aRloc16);
     void StopLeader(void);
-    ThreadError UpdateChildAddresses(const AddressRegistrationTlv &aTlv, Child &aChild);
+    otError UpdateChildAddresses(const AddressRegistrationTlv &aTlv, Child &aChild);
     void UpdateRoutes(const RouteTlv &aTlv, uint8_t aRouterId);
 
     static void HandleAddressSolicitResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                             const otMessageInfo *aMessageInfo, ThreadError result);
+                                             const otMessageInfo *aMessageInfo, otError result);
     void HandleAddressSolicitResponse(Coap::Header *aHeader, Message *aMessage,
-                                      const Ip6::MessageInfo *aMessageInfo, ThreadError result);
+                                      const Ip6::MessageInfo *aMessageInfo, otError result);
     static void HandleAddressRelease(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
                                      const otMessageInfo *aMessageInfo);
     void HandleAddressRelease(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/thread/mle_router_mtd.hpp
+++ b/src/core/thread/mle_router_mtd.hpp
@@ -52,8 +52,8 @@ public:
 
     bool IsSingleton(void) { return false; }
 
-    ThreadError BecomeRouter(ThreadStatusTlv::Status) { return kThreadError_NotCapable; }
-    ThreadError BecomeLeader(void) { return kThreadError_NotCapable; }
+    otError BecomeRouter(ThreadStatusTlv::Status) { return OT_ERROR_NOT_CAPABLE; }
+    otError BecomeLeader(void) { return OT_ERROR_NOT_CAPABLE; }
 
     uint8_t GetActiveRouterCount(void) const { return 0; }
 
@@ -73,8 +73,8 @@ public:
 
     uint8_t GetRouterIdSequence(void) const { return 0; }
 
-    ThreadError RemoveNeighbor(const Mac::Address &) { return BecomeDetached(); }
-    ThreadError RemoveNeighbor(Neighbor &) { return BecomeDetached(); }
+    otError RemoveNeighbor(const Mac::Address &) { return BecomeDetached(); }
+    otError RemoveNeighbor(Neighbor &) { return BecomeDetached(); }
 
     Child *GetChild(uint16_t) { return NULL; }
     Child *GetChild(const Mac::ExtAddress &) { return NULL; }
@@ -90,17 +90,17 @@ public:
         return NULL;
     }
 
-    ThreadError RestoreChildren(void) {return kThreadError_NotImplemented; }
-    ThreadError RemoveStoredChild(uint16_t) {return kThreadError_NotImplemented; }
-    ThreadError StoreChild(uint16_t) {return kThreadError_NotImplemented; }
-    ThreadError RefreshStoredChildren(void) { return kThreadError_NotImplemented; }
+    otError RestoreChildren(void) {return OT_ERROR_NOT_IMPLEMENTED; }
+    otError RemoveStoredChild(uint16_t) {return OT_ERROR_NOT_IMPLEMENTED; }
+    otError StoreChild(uint16_t) {return OT_ERROR_NOT_IMPLEMENTED; }
+    otError RefreshStoredChildren(void) { return OT_ERROR_NOT_IMPLEMENTED; }
 
     Neighbor *GetNeighbor(uint16_t aAddress) { return Mle::GetNeighbor(aAddress); }
     Neighbor *GetNeighbor(const Mac::ExtAddress &aAddress) { return Mle::GetNeighbor(aAddress); }
     Neighbor *GetNeighbor(const Mac::Address &aAddress) { return Mle::GetNeighbor(aAddress); }
     Neighbor *GetNeighbor(const Ip6::Address &aAddress) { return Mle::GetNeighbor(aAddress); }
 
-    ThreadError GetNextNeighborInfo(otNeighborInfoIterator &, otNeighborInfo &) { return kThreadError_NotImplemented; }
+    otError GetNextNeighborInfo(otNeighborInfoIterator &, otNeighborInfo &) { return OT_ERROR_NOT_IMPLEMENTED; }
 
     Router *GetRouters(uint8_t *aNumRouters) {
         if (aNumRouters != NULL) {
@@ -114,7 +114,7 @@ public:
 
     void ResolveRoutingLoops(uint16_t, uint16_t) { }
 
-    ThreadError CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, Ip6::Header &aIp6Header) {
+    otError CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, Ip6::Header &aIp6Header) {
         return Mle::CheckReachability(aMeshSource, aMeshDest, aIp6Header);
     }
 
@@ -123,30 +123,30 @@ public:
     void FillConnectivityTlv(ConnectivityTlv &) { }
     void FillRouteTlv(RouteTlv &) { }
 
-    ThreadError SendChildUpdateRequest(void) { return Mle::SendChildUpdateRequest(); }
+    otError SendChildUpdateRequest(void) { return Mle::SendChildUpdateRequest(); }
 
 #if OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
-    ThreadError SetSteeringData(otExtAddress *) { return kThreadError_NotImplemented; };
+    otError SetSteeringData(otExtAddress *) { return OT_ERROR_NOT_IMPLEMENTED; };
 #endif // OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
 
 private:
-    ThreadError HandleDetachStart(void) { return kThreadError_None; }
-    ThreadError HandleChildStart(otMleAttachFilter) { return kThreadError_None; }
-    ThreadError HandleLinkRequest(const Message &, const Ip6::MessageInfo &) { return kThreadError_Drop; }
-    ThreadError HandleLinkAccept(const Message &, const Ip6::MessageInfo &, uint32_t) { return kThreadError_Drop; }
-    ThreadError HandleLinkAccept(const Message &, const Ip6::MessageInfo &, uint32_t, bool) { return kThreadError_Drop; }
-    ThreadError HandleLinkAcceptAndRequest(const Message &, const Ip6::MessageInfo &, uint32_t) { return kThreadError_Drop; }
-    ThreadError HandleAdvertisement(const Message &, const Ip6::MessageInfo &) { return kThreadError_Drop; }
-    ThreadError HandleParentRequest(const Message &, const Ip6::MessageInfo &) { return kThreadError_Drop; }
-    ThreadError HandleChildIdRequest(const Message &, const Ip6::MessageInfo &, uint32_t) { return kThreadError_Drop; }
-    ThreadError HandleChildUpdateRequest(const Message &, const Ip6::MessageInfo &) { return kThreadError_Drop; }
-    ThreadError HandleChildUpdateResponse(const Message &, const Ip6::MessageInfo &, uint32_t) { return kThreadError_Drop; }
-    ThreadError HandleDataRequest(const Message &, const Ip6::MessageInfo &) { return kThreadError_Drop; }
-    ThreadError HandleNetworkDataUpdateRouter(void) { return kThreadError_None; }
-    ThreadError HandleDiscoveryRequest(const Message &, const Ip6::MessageInfo &) { return kThreadError_Drop; }
+    otError HandleDetachStart(void) { return OT_ERROR_NONE; }
+    otError HandleChildStart(otMleAttachFilter) { return OT_ERROR_NONE; }
+    otError HandleLinkRequest(const Message &, const Ip6::MessageInfo &) { return OT_ERROR_DROP; }
+    otError HandleLinkAccept(const Message &, const Ip6::MessageInfo &, uint32_t) { return OT_ERROR_DROP; }
+    otError HandleLinkAccept(const Message &, const Ip6::MessageInfo &, uint32_t, bool) { return OT_ERROR_DROP; }
+    otError HandleLinkAcceptAndRequest(const Message &, const Ip6::MessageInfo &, uint32_t) { return OT_ERROR_DROP; }
+    otError HandleAdvertisement(const Message &, const Ip6::MessageInfo &) { return OT_ERROR_DROP; }
+    otError HandleParentRequest(const Message &, const Ip6::MessageInfo &) { return OT_ERROR_DROP; }
+    otError HandleChildIdRequest(const Message &, const Ip6::MessageInfo &, uint32_t) { return OT_ERROR_DROP; }
+    otError HandleChildUpdateRequest(const Message &, const Ip6::MessageInfo &) { return OT_ERROR_DROP; }
+    otError HandleChildUpdateResponse(const Message &, const Ip6::MessageInfo &, uint32_t) { return OT_ERROR_DROP; }
+    otError HandleDataRequest(const Message &, const Ip6::MessageInfo &) { return OT_ERROR_DROP; }
+    otError HandleNetworkDataUpdateRouter(void) { return OT_ERROR_NONE; }
+    otError HandleDiscoveryRequest(const Message &, const Ip6::MessageInfo &) { return OT_ERROR_DROP; }
 
     void StopAdvertiseTimer(void) { }
-    ThreadError ProcessRouteTlv(const RouteTlv &aRoute) { (void)aRoute; return kThreadError_None; }
+    otError ProcessRouteTlv(const RouteTlv &aRoute) { (void)aRoute; return OT_ERROR_NONE; }
 };
 
 }  // namespace Mle

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -134,11 +134,11 @@ public:
      * @param[in]   aMaxLength  Maximum number of bytes to read.
      * @param[out]  aTlv        A reference to the TLV that will be copied to.
      *
-     * @retval kThreadError_None      Successfully copied the TLV.
-     * @retval kThreadError_NotFound  Could not find the TLV with Type @p aType.
+     * @retval OT_ERROR_NONE       Successfully copied the TLV.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the TLV with Type @p aType.
      *
      */
-    static ThreadError GetTlv(const Message &aMessage, Type aType, uint16_t aMaxLength, Tlv &aTlv) {
+    static otError GetTlv(const Message &aMessage, Type aType, uint16_t aMaxLength, Tlv &aTlv) {
         return ot::Tlv::Get(aMessage, static_cast<uint8_t>(aType), aMaxLength, aTlv);
     }
 
@@ -149,11 +149,11 @@ public:
      * @param[in]   aType       The Type value to search for.
      * @param[out]  aOffset     A reference to the offset of the TLV.
      *
-     * @retval kThreadError_None      Successfully copied the TLV.
-     * @retval kThreadError_NotFound  Could not find the TLV with Type @p aType.
+     * @retval OT_ERROR_NONE       Successfully copied the TLV.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the TLV with Type @p aType.
      *
      */
-    static ThreadError GetOffset(const Message &aMessage, Type aType, uint16_t &aOffset) {
+    static otError GetOffset(const Message &aMessage, Type aType, uint16_t &aOffset) {
         return ot::Tlv::GetOffset(aMessage, static_cast<uint8_t>(aType), aOffset);
     }
 
@@ -878,17 +878,17 @@ public:
     /**
      * This method provides the next Tlv in the TlvRequestTlv.
      *
-     * @retval kThreadError_None       Successfully found the next Tlv.
-     * @retval kThreadError_NotFound   No subsequent Tlv exists in TlvRequestTlv.
+     * @retval OT_ERROR_NONE        Successfully found the next Tlv.
+     * @retval OT_ERROR_NOT_FOUND   No subsequent Tlv exists in TlvRequestTlv.
      *
      */
-    ThreadError GetNextTlv(TlvRequestIterator &aIterator, uint8_t &aTlv) {
-        ThreadError error = kThreadError_NotFound;
+    otError GetNextTlv(TlvRequestIterator &aIterator, uint8_t &aTlv) {
+        otError error = OT_ERROR_NOT_FOUND;
 
         if (aIterator < GetLength()) {
             aTlv = mTlvs[aIterator];
             aIterator = static_cast<TlvRequestIterator>(aIterator + sizeof(uint8_t));
-            error = kThreadError_None;
+            error = OT_ERROR_NONE;
         }
 
         return error;

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -87,15 +87,15 @@ void NetworkData::GetNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLen
     }
 }
 
-ThreadError NetworkData::GetNextOnMeshPrefix(otNetworkDataIterator *aIterator, otBorderRouterConfig *aConfig)
+otError NetworkData::GetNextOnMeshPrefix(otNetworkDataIterator *aIterator, otBorderRouterConfig *aConfig)
 {
     return GetNextOnMeshPrefix(aIterator, Mac::kShortAddrBroadcast, aConfig);
 }
 
-ThreadError NetworkData::GetNextOnMeshPrefix(otNetworkDataIterator *aIterator, uint16_t aRloc16,
-                                             otBorderRouterConfig *aConfig)
+otError NetworkData::GetNextOnMeshPrefix(otNetworkDataIterator *aIterator, uint16_t aRloc16,
+                                         otBorderRouterConfig *aConfig)
 {
-    ThreadError error = kThreadError_NotFound;
+    otError error = OT_ERROR_NOT_FOUND;
     NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs + *aIterator);
     NetworkDataTlv *end = reinterpret_cast<NetworkDataTlv *>(mTlvs + mLength);
 
@@ -146,22 +146,22 @@ ThreadError NetworkData::GetNextOnMeshPrefix(otNetworkDataIterator *aIterator, u
 
         *aIterator = static_cast<otNetworkDataIterator>(reinterpret_cast<uint8_t *>(cur->GetNext()) - mTlvs);
 
-        ExitNow(error = kThreadError_None);
+        ExitNow(error = OT_ERROR_NONE);
     }
 
 exit:
     return error;
 }
 
-ThreadError NetworkData::GetNextExternalRoute(otNetworkDataIterator *aIterator, otExternalRouteConfig *aConfig)
+otError NetworkData::GetNextExternalRoute(otNetworkDataIterator *aIterator, otExternalRouteConfig *aConfig)
 {
     return GetNextExternalRoute(aIterator, Mac::kShortAddrBroadcast, aConfig);
 }
 
-ThreadError NetworkData::GetNextExternalRoute(otNetworkDataIterator *aIterator, uint16_t aRloc16,
-                                              otExternalRouteConfig *aConfig)
+otError NetworkData::GetNextExternalRoute(otNetworkDataIterator *aIterator, uint16_t aRloc16,
+                                          otExternalRouteConfig *aConfig)
 {
-    ThreadError error = kThreadError_NotFound;
+    otError error = OT_ERROR_NOT_FOUND;
     NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs + *aIterator);
     NetworkDataTlv *end = reinterpret_cast<NetworkDataTlv *>(mTlvs + mLength);
 
@@ -205,7 +205,7 @@ ThreadError NetworkData::GetNextExternalRoute(otNetworkDataIterator *aIterator, 
 
         *aIterator = static_cast<otNetworkDataIterator>(reinterpret_cast<uint8_t *>(cur->GetNext()) - mTlvs);
 
-        ExitNow(error = kThreadError_None);
+        ExitNow(error = OT_ERROR_NONE);
     }
 
 exit:
@@ -218,13 +218,13 @@ bool NetworkData::ContainsOnMeshPrefixes(NetworkData &aCompare, uint16_t aRloc16
     otBorderRouterConfig outerConfig;
     bool rval = true;
 
-    while (aCompare.GetNextOnMeshPrefix(&outerIterator, aRloc16, &outerConfig) == kThreadError_None)
+    while (aCompare.GetNextOnMeshPrefix(&outerIterator, aRloc16, &outerConfig) == OT_ERROR_NONE)
     {
         otNetworkDataIterator innerIterator = OT_NETWORK_DATA_ITERATOR_INIT;
         otBorderRouterConfig innerConfig;
-        ThreadError error;
+        otError error;
 
-        while ((error = GetNextOnMeshPrefix(&innerIterator, aRloc16, &innerConfig)) == kThreadError_None)
+        while ((error = GetNextOnMeshPrefix(&innerIterator, aRloc16, &innerConfig)) == OT_ERROR_NONE)
         {
             if (memcmp(&outerConfig, &innerConfig, (sizeof(outerConfig) - sizeof(outerConfig.mRloc16))) == 0)
             {
@@ -232,7 +232,7 @@ bool NetworkData::ContainsOnMeshPrefixes(NetworkData &aCompare, uint16_t aRloc16
             }
         }
 
-        if (error != kThreadError_None)
+        if (error != OT_ERROR_NONE)
         {
             ExitNow(rval = false);
         }
@@ -248,13 +248,13 @@ bool NetworkData::ContainsExternalRoutes(NetworkData &aCompare, uint16_t aRloc16
     otExternalRouteConfig outerConfig;
     bool rval = true;
 
-    while (aCompare.GetNextExternalRoute(&outerIterator, aRloc16, &outerConfig) == kThreadError_None)
+    while (aCompare.GetNextExternalRoute(&outerIterator, aRloc16, &outerConfig) == OT_ERROR_NONE)
     {
         otNetworkDataIterator innerIterator = OT_NETWORK_DATA_ITERATOR_INIT;
         otExternalRouteConfig innerConfig;
-        ThreadError error;
+        otError error;
 
-        while ((error = GetNextExternalRoute(&innerIterator, aRloc16, &innerConfig)) == kThreadError_None)
+        while ((error = GetNextExternalRoute(&innerIterator, aRloc16, &innerConfig)) == OT_ERROR_NONE)
         {
             if (memcmp(&outerConfig, &innerConfig, sizeof(outerConfig)) == 0)
             {
@@ -262,7 +262,7 @@ bool NetworkData::ContainsExternalRoutes(NetworkData &aCompare, uint16_t aRloc16
             }
         }
 
-        if (error != kThreadError_None)
+        if (error != OT_ERROR_NONE)
         {
             ExitNow(rval = false);
         }
@@ -587,42 +587,42 @@ int8_t NetworkData::PrefixMatch(const uint8_t *a, const uint8_t *b, uint8_t aLen
     return (rval >= aLength) ? rval : -1;
 }
 
-ThreadError NetworkData::Insert(uint8_t *aStart, uint8_t aLength)
+otError NetworkData::Insert(uint8_t *aStart, uint8_t aLength)
 {
     assert(aLength + mLength <= sizeof(mTlvs) &&
            mTlvs <= aStart &&
            aStart <= mTlvs + mLength);
     memmove(aStart + aLength, aStart, mLength - static_cast<size_t>(aStart - mTlvs));
     mLength += aLength;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError NetworkData::Remove(uint8_t *aStart, uint8_t aLength)
+otError NetworkData::Remove(uint8_t *aStart, uint8_t aLength)
 {
     assert(aLength <= mLength &&
            mTlvs <= aStart &&
            (aStart - mTlvs) + aLength <= mLength);
     memmove(aStart, aStart + aLength, mLength - (static_cast<size_t>(aStart - mTlvs) + aLength));
     mLength -= aLength;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError NetworkData::SendServerDataNotification(uint16_t aRloc16)
+otError NetworkData::SendServerDataNotification(uint16_t aRloc16)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header header;
     Message *message = NULL;
     Ip6::MessageInfo messageInfo;
 
     VerifyOrExit(!mLastAttemptWait || static_cast<int32_t>(Timer::GetNow() - mLastAttempt) < kDataResubmitDelay,
-                 error = kThreadError_Already);
+                 error = OT_ERROR_ALREADY);
 
     header.Init(kCoapTypeConfirmable, kCoapRequestPost);
     header.SetToken(Coap::Header::kDefaultTokenLength);
     header.AppendUriPathOptions(OT_URI_PATH_SERVER_DATA);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     if (mLocal)
     {
@@ -656,7 +656,7 @@ ThreadError NetworkData::SendServerDataNotification(uint16_t aRloc16)
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -130,11 +130,11 @@ public:
      * @param[inout]  aIterator  A pointer to the Network Data iterator context.
      * @param[out]    aConfig    A pointer to where the On Mesh Prefix information will be placed.
      *
-     * @retval kThreadError_None      Successfully found the next On Mesh prefix.
-     * @retval kThreadError_NotFound  No subsequent On Mesh prefix exists in the Thread Network Data.
+     * @retval OT_ERROR_NONE       Successfully found the next On Mesh prefix.
+     * @retval OT_ERROR_NOT_FOUND  No subsequent On Mesh prefix exists in the Thread Network Data.
      *
      */
-    ThreadError GetNextOnMeshPrefix(otNetworkDataIterator *aIterator, otBorderRouterConfig *aConfig);
+    otError GetNextOnMeshPrefix(otNetworkDataIterator *aIterator, otBorderRouterConfig *aConfig);
 
     /**
      * This method provides the next On Mesh prefix in the Thread Network Data for a given RLOC16.
@@ -143,11 +143,11 @@ public:
      * @param[in]     aRloc16    The RLOC16 value.
      * @param[out]    aConfig    A pointer to where the On Mesh Prefix information will be placed.
      *
-     * @retval kThreadError_None      Successfully found the next On Mesh prefix.
-     * @retval kThreadError_NotFound  No subsequent On Mesh prefix exists in the Thread Network Data.
+     * @retval OT_ERROR_NONE       Successfully found the next On Mesh prefix.
+     * @retval OT_ERROR_NOT_FOUND  No subsequent On Mesh prefix exists in the Thread Network Data.
      *
      */
-    ThreadError GetNextOnMeshPrefix(otNetworkDataIterator *aIterator, uint16_t aRloc16, otBorderRouterConfig *aConfig);
+    otError GetNextOnMeshPrefix(otNetworkDataIterator *aIterator, uint16_t aRloc16, otBorderRouterConfig *aConfig);
 
     /**
      * This method provides the next external route in the Thread Network Data.
@@ -155,11 +155,11 @@ public:
      * @param[inout]  aIterator  A pointer to the Network Data iterator context.
      * @param[out]    aConfig    A pointer to where the external route information will be placed.
      *
-     * @retval kThreadError_None      Successfully found the next external route.
-     * @retval kThreadError_NotFound  No subsequent external route exists in the Thread Network Data.
+     * @retval OT_ERROR_NONE       Successfully found the next external route.
+     * @retval OT_ERROR_NOT_FOUND  No subsequent external route exists in the Thread Network Data.
      *
      */
-    ThreadError GetNextExternalRoute(otNetworkDataIterator *aIterator, otExternalRouteConfig *aConfig);
+    otError GetNextExternalRoute(otNetworkDataIterator *aIterator, otExternalRouteConfig *aConfig);
 
     /**
      * This method provides the next external route in the Thread Network Data for a given RLOC16.
@@ -168,12 +168,12 @@ public:
      * @param[in]     aRloc16    The RLOC16 value.
      * @param[out]    aConfig    A pointer to where the external route information will be placed.
      *
-     * @retval kThreadError_None      Successfully found the next external route.
-     * @retval kThreadError_NotFound  No subsequent external route exists in the Thread Network Data.
+     * @retval OT_ERROR_NONE       Successfully found the next external route.
+     * @retval OT_ERROR_NOT_FOUND  No subsequent external route exists in the Thread Network Data.
      *
      */
-    ThreadError GetNextExternalRoute(otNetworkDataIterator *aIterator, uint16_t aRloc16,
-                                     otExternalRouteConfig *aConfig);
+    otError GetNextExternalRoute(otNetworkDataIterator *aIterator, uint16_t aRloc16,
+                                 otExternalRouteConfig *aConfig);
 
     /**
      * This method indicates whether or not the Thread Network Data contains all of the on mesh prefix information
@@ -290,11 +290,11 @@ protected:
      * @param[in]  aStart   A pointer to the beginning of the insertion.
      * @param[in]  aLength  The number of bytes to insert.
      *
-     * @retval kThreadError_None         Successfully inserted bytes.
-     * @retval kThreadError_NoBufs       Insufficient buffer space to insert bytes.
+     * @retval OT_ERROR_NONE          Successfully inserted bytes.
+     * @retval OT_ERROR_NO_BUFS       Insufficient buffer space to insert bytes.
      *
      */
-    ThreadError Insert(uint8_t *aStart, uint8_t aLength);
+    otError Insert(uint8_t *aStart, uint8_t aLength);
 
     /**
      * This method removes bytes from the Network Data.
@@ -302,10 +302,10 @@ protected:
      * @param[in]  aStart   A pointer to the beginning of the removal.
      * @param[in]  aLength  The number of bytes to remove.
      *
-     * @retval kThreadError_None    Successfully removed bytes.
+     * @retval OT_ERROR_NONE    Successfully removed bytes.
      *
      */
-    ThreadError Remove(uint8_t *aStart, uint8_t aLength);
+    otError Remove(uint8_t *aStart, uint8_t aLength);
 
     /**
      * This method strips non-stable data from the Thread Network Data.
@@ -345,11 +345,11 @@ protected:
      *
      * @param[in]  aRloc16  The old RLOC16 value that was previously registered.
      *
-     * @retval kThreadError_None    Successfully enqueued the notification message.
-     * @retval kThreadError_NoBufs  Insufficient message buffers to generate the notification message.
+     * @retval OT_ERROR_NONE     Successfully enqueued the notification message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient message buffers to generate the notification message.
      *
      */
-    ThreadError SendServerDataNotification(uint16_t aRloc16);
+    otError SendServerDataNotification(uint16_t aRloc16);
 
     uint8_t mTlvs[kMaxSize];  ///< The Network Data buffer.
     uint8_t mLength;          ///< The number of valid bytes in @var mTlvs.

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -76,7 +76,7 @@ void LeaderBase::Reset(void)
     mNetif.SetStateChangedFlags(OT_THREAD_NETDATA_UPDATED);
 }
 
-ThreadError LeaderBase::GetContext(const Ip6::Address &aAddress, Lowpan::Context &aContext)
+otError LeaderBase::GetContext(const Ip6::Address &aAddress, Lowpan::Context &aContext)
 {
     PrefixTlv *prefix;
     ContextTlv *contextTlv;
@@ -123,12 +123,12 @@ ThreadError LeaderBase::GetContext(const Ip6::Address &aAddress, Lowpan::Context
         }
     }
 
-    return (aContext.mPrefixLength > 0) ? kThreadError_None : kThreadError_Error;
+    return (aContext.mPrefixLength > 0) ? OT_ERROR_NONE : OT_ERROR_NOT_FOUND;
 }
 
-ThreadError LeaderBase::GetContext(uint8_t aContextId, Lowpan::Context &aContext)
+otError LeaderBase::GetContext(uint8_t aContextId, Lowpan::Context &aContext)
 {
-    ThreadError error = kThreadError_Error;
+    otError error = OT_ERROR_NOT_FOUND;
     PrefixTlv *prefix;
     ContextTlv *contextTlv;
 
@@ -138,7 +138,7 @@ ThreadError LeaderBase::GetContext(uint8_t aContextId, Lowpan::Context &aContext
         aContext.mPrefixLength = 64;
         aContext.mContextId = 0;
         aContext.mCompressFlag = true;
-        ExitNow(error = kThreadError_None);
+        ExitNow(error = OT_ERROR_NONE);
     }
 
     for (NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs);
@@ -167,7 +167,7 @@ ThreadError LeaderBase::GetContext(uint8_t aContextId, Lowpan::Context &aContext
         aContext.mPrefixLength = prefix->GetPrefixLength();
         aContext.mContextId = contextTlv->GetContextId();
         aContext.mCompressFlag = contextTlv->IsCompress();
-        ExitNow(error = kThreadError_None);
+        ExitNow(error = OT_ERROR_NONE);
     }
 
 exit:
@@ -175,23 +175,23 @@ exit:
 }
 
 #if OPENTHREAD_ENABLE_DHCP6_SERVER || OPENTHREAD_ENABLE_DHCP6_CLIENT
-ThreadError LeaderBase::GetRlocByContextId(uint8_t aContextId, uint16_t &aRloc16)
+otError LeaderBase::GetRlocByContextId(uint8_t aContextId, uint16_t &aRloc16)
 {
-    ThreadError error = kThreadError_NotFound;
+    otError error = OT_ERROR_NOT_FOUND;
     Lowpan::Context lowpanContext;
 
-    if ((GetContext(aContextId, lowpanContext)) == kThreadError_None)
+    if ((GetContext(aContextId, lowpanContext)) == OT_ERROR_NONE)
     {
         otNetworkDataIterator iterator = OT_NETWORK_DATA_ITERATOR_INIT;
         otBorderRouterConfig config;
 
-        while (GetNextOnMeshPrefix(&iterator, &config) == kThreadError_None)
+        while (GetNextOnMeshPrefix(&iterator, &config) == OT_ERROR_NONE)
         {
             if (otIp6PrefixMatch(&(config.mPrefix.mPrefix),
                                  reinterpret_cast<const otIp6Address *>(lowpanContext.mPrefix)) >= config.mPrefix.mLength)
             {
                 aRloc16 = config.mRloc16;
-                ExitNow(error = kThreadError_None);
+                ExitNow(error = OT_ERROR_NONE);
             }
         }
     }
@@ -239,10 +239,10 @@ exit:
     return rval;
 }
 
-ThreadError LeaderBase::RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination,
-                                    uint8_t *aPrefixMatch, uint16_t *aRloc16)
+otError LeaderBase::RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination,
+                                uint8_t *aPrefixMatch, uint16_t *aRloc16)
 {
-    ThreadError error = kThreadError_NoRoute;
+    otError error = OT_ERROR_NO_ROUTE;
     PrefixTlv *prefix;
 
     for (NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs);
@@ -258,19 +258,19 @@ ThreadError LeaderBase::RouteLookup(const Ip6::Address &aSource, const Ip6::Addr
 
         if (PrefixMatch(prefix->GetPrefix(), aSource.mFields.m8, prefix->GetPrefixLength()) >= 0)
         {
-            if (ExternalRouteLookup(prefix->GetDomainId(), aDestination, aPrefixMatch, aRloc16) == kThreadError_None)
+            if (ExternalRouteLookup(prefix->GetDomainId(), aDestination, aPrefixMatch, aRloc16) == OT_ERROR_NONE)
             {
-                ExitNow(error = kThreadError_None);
+                ExitNow(error = OT_ERROR_NONE);
             }
 
-            if (DefaultRouteLookup(*prefix, aRloc16) == kThreadError_None)
+            if (DefaultRouteLookup(*prefix, aRloc16) == OT_ERROR_NONE)
             {
                 if (aPrefixMatch)
                 {
                     *aPrefixMatch = 0;
                 }
 
-                ExitNow(error = kThreadError_None);
+                ExitNow(error = OT_ERROR_NONE);
             }
         }
     }
@@ -279,10 +279,10 @@ exit:
     return error;
 }
 
-ThreadError LeaderBase::ExternalRouteLookup(uint8_t aDomainId, const Ip6::Address &aDestination,
-                                            uint8_t *aPrefixMatch, uint16_t *aRloc16)
+otError LeaderBase::ExternalRouteLookup(uint8_t aDomainId, const Ip6::Address &aDestination,
+                                        uint8_t *aPrefixMatch, uint16_t *aRloc16)
 {
-    ThreadError error = kThreadError_NoRoute;
+    otError error = OT_ERROR_NO_ROUTE;
     PrefixTlv *prefix;
     HasRouteTlv *hasRoute;
     HasRouteEntry *entry;
@@ -352,15 +352,15 @@ ThreadError LeaderBase::ExternalRouteLookup(uint8_t aDomainId, const Ip6::Addres
             *aPrefixMatch = rval_plen;
         }
 
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
     }
 
     return error;
 }
 
-ThreadError LeaderBase::DefaultRouteLookup(PrefixTlv &aPrefix, uint16_t *aRloc16)
+otError LeaderBase::DefaultRouteLookup(PrefixTlv &aPrefix, uint16_t *aRloc16)
 {
-    ThreadError error = kThreadError_NoRoute;
+    otError error = OT_ERROR_NO_ROUTE;
     BorderRouterTlv *borderRouter;
     BorderRouterEntry *entry;
     BorderRouterEntry *route = NULL;
@@ -402,7 +402,7 @@ ThreadError LeaderBase::DefaultRouteLookup(PrefixTlv &aPrefix, uint16_t *aRloc16
             *aRloc16 = route->GetRloc();
         }
 
-        error = kThreadError_None;
+        error = OT_ERROR_NONE;
     }
 
     return error;
@@ -426,13 +426,13 @@ void LeaderBase::SetNetworkData(uint8_t aVersion, uint8_t aStableVersion, bool a
     mNetif.SetStateChangedFlags(OT_THREAD_NETDATA_UPDATED);
 }
 
-ThreadError LeaderBase::SetCommissioningData(const uint8_t *aValue, uint8_t aValueLength)
+otError LeaderBase::SetCommissioningData(const uint8_t *aValue, uint8_t aValueLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t remaining = kMaxSize - mLength;
     CommissioningDataTlv *commissioningDataTlv;
 
-    VerifyOrExit(sizeof(NetworkDataTlv) + aValueLength < remaining, error = kThreadError_NoBufs);
+    VerifyOrExit(sizeof(NetworkDataTlv) + aValueLength < remaining, error = OT_ERROR_NO_BUFS);
 
     RemoveCommissioningData();
 
@@ -518,9 +518,9 @@ exit:
     return rval;
 }
 
-ThreadError LeaderBase::RemoveCommissioningData(void)
+otError LeaderBase::RemoveCommissioningData(void)
 {
-    ThreadError error = kThreadError_NotFound;
+    otError error = OT_ERROR_NOT_FOUND;
 
     for (NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs);
          cur < reinterpret_cast<NetworkDataTlv *>(mTlvs + mLength);
@@ -529,7 +529,7 @@ ThreadError LeaderBase::RemoveCommissioningData(void)
         if (cur->GetType() == NetworkDataTlv::kTypeCommissioningData)
         {
             Remove(reinterpret_cast<uint8_t *>(cur), sizeof(NetworkDataTlv) + cur->GetLength());
-            ExitNow(error = kThreadError_None);
+            ExitNow(error = OT_ERROR_NONE);
         }
     }
 

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -101,11 +101,11 @@ public:
      * @param[in]   aAddress  A reference to an IPv6 address.
      * @param[out]  aContext  A reference to 6LoWPAN Context information.
      *
-     * @retval kThreadError_None      Successfully retrieved 6LoWPAN Context information.
-     * @retval kThreadError_NotFound  Could not find the 6LoWPAN Context information.
+     * @retval OT_ERROR_NONE       Successfully retrieved 6LoWPAN Context information.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the 6LoWPAN Context information.
      *
      */
-    ThreadError GetContext(const Ip6::Address &aAddress, Lowpan::Context &aContext);
+    otError GetContext(const Ip6::Address &aAddress, Lowpan::Context &aContext);
 
     /**
      * This method retrieves the 6LoWPAN Context information based on a given Context ID.
@@ -113,11 +113,11 @@ public:
      * @param[in]   aContextId  The Context ID value.
      * @param[out]  aContext    A reference to the 6LoWPAN Context information.
      *
-     * @retval kThreadError_None      Successfully retrieved 6LoWPAN Context information.
-     * @retval kThreadError_NotFound  Could not find the 6LoWPAN Context information.
+     * @retval OT_ERROR_NONE       Successfully retrieved 6LoWPAN Context information.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the 6LoWPAN Context information.
      *
      */
-    ThreadError GetContext(uint8_t aContextId, Lowpan::Context &aContext);
+    otError GetContext(uint8_t aContextId, Lowpan::Context &aContext);
 
     /**
      * This method indicates whether or not the given IPv6 address is on-mesh.
@@ -138,12 +138,12 @@ public:
      * @param[out]  aPrefixMatch  A pointer to the longest prefix match length in bits.
      * @param[out]  aRloc16       A pointer to the RLOC16 for the selected route.
      *
-     * @retval kThreadError_None     Successfully found a route.
-     * @retval kThreadError_NoRoute  No valid route was found.
+     * @retval OT_ERROR_NONE      Successfully found a route.
+     * @retval OT_ERROR_NO_ROUTE  No valid route was found.
      *
      */
-    ThreadError RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination,
-                            uint8_t *aPrefixMatch, uint16_t *aRloc16);
+    otError RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination,
+                        uint8_t *aPrefixMatch, uint16_t *aRloc16);
 
     /**
      * This method is used by non-Leader devices to set newly received Network Data from the Leader.
@@ -163,11 +163,11 @@ public:
      *
      * @param[in]  aRloc16  The invalid RLOC16 to notify.
      *
-     * @retval kThreadError_None    Successfully enqueued the notification message.
-     * @retval kThreadError_NoBufs  Insufficient message buffers to generate the notification message.
+     * @retval OT_ERROR_NONE     Successfully enqueued the notification message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient message buffers to generate the notification message.
      *
      */
-    ThreadError SendServerDataNotification(uint16_t aRloc16);
+    otError SendServerDataNotification(uint16_t aRloc16);
 
     /**
      * This method returns a pointer to the Commissioning Data.
@@ -203,11 +203,11 @@ public:
      * @param[in]  aValue        A pointer to the Commissioning Data value.
      * @param[in]  aValueLength  The length of @p aValue.
      *
-     * @retval kThreadError_None    Successfully added the Commissioning Data.
-     * @retval kThreadError_NoBufs  Insufficient space to add the Commissioning Data.
+     * @retval OT_ERROR_NONE     Successfully added the Commissioning Data.
+     * @retval OT_ERROR_NO_BUFS  Insufficient space to add the Commissioning Data.
      *
      */
-    ThreadError SetCommissioningData(const uint8_t *aValue, uint8_t aValueLength);
+    otError SetCommissioningData(const uint8_t *aValue, uint8_t aValueLength);
 
 #if OPENTHREAD_ENABLE_DHCP6_SERVER || OPENTHREAD_ENABLE_DHCP6_CLIENT
     /**
@@ -216,11 +216,11 @@ public:
      * @param[in]  aContextId      A pointer to the Commissioning Data value.
      * @param[out] aRloc16         The reference of which for output the Rloc16.
      *
-     * @retval kThreadError_None      Successfully get the Rloc of Dhcp Agent.
-     * @retval kThreadError_NotFound  The specified @p aContextId could not be found.
+     * @retval OT_ERROR_NONE       Successfully get the Rloc of Dhcp Agent.
+     * @retval OT_ERROR_NOT_FOUND  The specified @p aContextId could not be found.
      *
      */
-    ThreadError GetRlocByContextId(uint8_t aContextId, uint16_t &aRloc16);
+    otError GetRlocByContextId(uint8_t aContextId, uint16_t &aRloc16);
 #endif  // OPENTHREAD_ENABLE_DHCP6_SERVER || OPENTHREAD_ENABLE_DHCP6_CLIENT
 
 protected:
@@ -228,11 +228,11 @@ protected:
     uint8_t         mVersion;
 
 private:
-    ThreadError RemoveCommissioningData(void);
+    otError RemoveCommissioningData(void);
 
-    ThreadError ExternalRouteLookup(uint8_t aDomainId, const Ip6::Address &destination,
-                                    uint8_t *aPrefixMatch, uint16_t *aRloc16);
-    ThreadError DefaultRouteLookup(PrefixTlv &aPrefix, uint16_t *aRloc16);
+    otError ExternalRouteLookup(uint8_t aDomainId, const Ip6::Address &destination,
+                                uint8_t *aPrefixMatch, uint16_t *aRloc16);
+    otError DefaultRouteLookup(PrefixTlv &aPrefix, uint16_t *aRloc16);
 };
 
 /**

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -120,10 +120,10 @@ uint32_t Leader::GetContextIdReuseDelay(void) const
     return mContextIdReuseDelay;
 }
 
-ThreadError Leader::SetContextIdReuseDelay(uint32_t aDelay)
+otError Leader::SetContextIdReuseDelay(uint32_t aDelay)
 {
     mContextIdReuseDelay = aDelay;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 void Leader::RemoveBorderRouter(uint16_t aRloc16)
@@ -164,14 +164,14 @@ void Leader::HandleServerData(Coap::Header &aHeader, Message &aMessage,
 
     otLogInfoNetData(GetInstance(), "Received network data registration");
 
-    if (ThreadTlv::GetTlv(aMessage, ThreadTlv::kRloc16, sizeof(rloc16), rloc16) == kThreadError_None)
+    if (ThreadTlv::GetTlv(aMessage, ThreadTlv::kRloc16, sizeof(rloc16), rloc16) == OT_ERROR_NONE)
     {
         VerifyOrExit(rloc16.IsValid());
         RemoveBorderRouter(rloc16.GetRloc16());
     }
 
     if (ThreadTlv::GetTlv(aMessage, ThreadTlv::kThreadNetworkData, sizeof(networkData), networkData) ==
-        kThreadError_None)
+        OT_ERROR_NONE)
     {
         RegisterNetworkData(HostSwap16(aMessageInfo.mPeerAddr.mFields.m16[7]),
                             networkData.GetTlvs(), networkData.GetLength());
@@ -314,7 +314,7 @@ void Leader::HandleCommissioningGet(Coap::Header &aHeader, Message &aMessage, co
 void Leader::SendCommissioningGetResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
                                           uint8_t *aTlvs, uint8_t aLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header responseHeader;
     Message *message;
     uint8_t index;
@@ -325,7 +325,7 @@ void Leader::SendCommissioningGetResponse(const Coap::Header &aRequestHeader, co
     responseHeader.SetPayloadMarker();
 
     VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(mNetif.GetCoap(), responseHeader)) != NULL,
-                 error = kThreadError_NoBufs);
+                 error = OT_ERROR_NO_BUFS);
 
     for (NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs);
          cur < reinterpret_cast<NetworkDataTlv *>(mTlvs + mLength);
@@ -339,7 +339,7 @@ void Leader::SendCommissioningGetResponse(const Coap::Header &aRequestHeader, co
         }
     }
 
-    VerifyOrExit(data && length, error = kThreadError_Drop);
+    VerifyOrExit(data && length, error = OT_ERROR_DROP);
 
     if (aLength == 0)
     {
@@ -374,7 +374,7 @@ void Leader::SendCommissioningGetResponse(const Coap::Header &aRequestHeader, co
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -383,7 +383,7 @@ exit:
 void Leader::SendCommissioningSetResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
                                           MeshCoP::StateTlv::State aState)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header responseHeader;
     Message *message;
     MeshCoP::StateTlv state;
@@ -392,7 +392,7 @@ void Leader::SendCommissioningSetResponse(const Coap::Header &aRequestHeader, co
     responseHeader.SetPayloadMarker();
 
     VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(mNetif.GetCoap(), responseHeader)) != NULL,
-                 error = kThreadError_NoBufs);
+                 error = OT_ERROR_NO_BUFS);
 
     state.Init();
     state.SetState(aState);
@@ -404,7 +404,7 @@ void Leader::SendCommissioningSetResponse(const Coap::Header &aRequestHeader, co
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -550,9 +550,9 @@ exit:
     return rval;
 }
 
-ThreadError Leader::RegisterNetworkData(uint16_t aRloc16, uint8_t *aTlvs, uint8_t aTlvsLength)
+otError Leader::RegisterNetworkData(uint16_t aRloc16, uint8_t *aTlvs, uint8_t aTlvsLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     bool rlocIn = false;
     bool rlocStable = false;
     bool stableUpdated = false;
@@ -596,7 +596,7 @@ exit:
     return error;
 }
 
-ThreadError Leader::AddNetworkData(uint8_t *aTlvs, uint8_t aTlvsLength)
+otError Leader::AddNetworkData(uint8_t *aTlvs, uint8_t aTlvsLength)
 {
     NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(aTlvs);
     NetworkDataTlv *end = reinterpret_cast<NetworkDataTlv *>(aTlvs + aTlvsLength);
@@ -619,10 +619,10 @@ ThreadError Leader::AddNetworkData(uint8_t *aTlvs, uint8_t aTlvsLength)
 
     otDumpDebgNetData(GetInstance(), "add done", mTlvs, mLength);
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Leader::AddPrefix(PrefixTlv &aPrefix)
+otError Leader::AddPrefix(PrefixTlv &aPrefix)
 {
     NetworkDataTlv *cur = aPrefix.GetSubTlvs();
     NetworkDataTlv *end = aPrefix.GetNext();
@@ -646,12 +646,12 @@ ThreadError Leader::AddPrefix(PrefixTlv &aPrefix)
         cur = cur->GetNext();
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Leader::AddHasRoute(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute)
+otError Leader::AddHasRoute(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     PrefixTlv *dstPrefix;
     HasRouteTlv *dstHasRoute;
 
@@ -689,9 +689,9 @@ ThreadError Leader::AddHasRoute(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute)
     return error;
 }
 
-ThreadError Leader::AddBorderRouter(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter)
+otError Leader::AddBorderRouter(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     PrefixTlv *dstPrefix;
     ContextTlv *dstContext;
     BorderRouterTlv *dstBorderRouter;
@@ -719,7 +719,7 @@ ThreadError Leader::AddBorderRouter(PrefixTlv &aPrefix, BorderRouterTlv &aBorder
         dstContext->SetContextLength(aPrefix.GetPrefixLength());
     }
 
-    VerifyOrExit(dstContext != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit(dstContext != NULL, error = OT_ERROR_NO_BUFS);
     mContextLastUsed[dstContext->GetContextId() - kMinContextId] = 0;
 
 
@@ -767,7 +767,7 @@ exit:
     return rval;
 }
 
-ThreadError Leader::FreeContext(uint8_t aContextId)
+otError Leader::FreeContext(uint8_t aContextId)
 {
     otLogInfoNetData(GetInstance(), "Free Context Id = %d", aContextId);
     RemoveContext(aContextId);
@@ -775,18 +775,18 @@ ThreadError Leader::FreeContext(uint8_t aContextId)
     mVersion++;
     mStableVersion++;
     mNetif.SetStateChangedFlags(OT_THREAD_NETDATA_UPDATED);
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Leader::SendServerDataNotification(uint16_t aRloc16)
+otError Leader::SendServerDataNotification(uint16_t aRloc16)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     bool rlocIn = false;
     bool rlocStable = false;
 
     RlocLookup(aRloc16, rlocIn, rlocStable, mTlvs, mLength);
 
-    VerifyOrExit(rlocIn, error = kThreadError_NotFound);
+    VerifyOrExit(rlocIn, error = OT_ERROR_NOT_FOUND);
 
     SuccessOrExit(error = NetworkData::SendServerDataNotification(aRloc16));
 
@@ -794,7 +794,7 @@ exit:
     return error;
 }
 
-ThreadError Leader::RemoveRloc(uint16_t aRloc16)
+otError Leader::RemoveRloc(uint16_t aRloc16)
 {
     NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs);
     NetworkDataTlv *end;
@@ -835,10 +835,10 @@ ThreadError Leader::RemoveRloc(uint16_t aRloc16)
 
     otDumpDebgNetData(GetInstance(), "remove done", mTlvs, mLength);
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Leader::RemoveRloc(PrefixTlv &prefix, uint16_t aRloc16)
+otError Leader::RemoveRloc(PrefixTlv &prefix, uint16_t aRloc16)
 {
     NetworkDataTlv *cur = prefix.GetSubTlvs();
     NetworkDataTlv *end;
@@ -909,10 +909,10 @@ ThreadError Leader::RemoveRloc(PrefixTlv &prefix, uint16_t aRloc16)
         }
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Leader::RemoveRloc(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute, uint16_t aRloc16)
+otError Leader::RemoveRloc(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute, uint16_t aRloc16)
 {
     HasRouteEntry *entry;
 
@@ -932,10 +932,10 @@ ThreadError Leader::RemoveRloc(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute, uint1
         break;
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Leader::RemoveRloc(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter, uint16_t aRloc16)
+otError Leader::RemoveRloc(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter, uint16_t aRloc16)
 {
     BorderRouterEntry *entry;
 
@@ -955,10 +955,10 @@ ThreadError Leader::RemoveRloc(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRoute
         break;
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Leader::RemoveContext(uint8_t aContextId)
+otError Leader::RemoveContext(uint8_t aContextId)
 {
     NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs);
     NetworkDataTlv *end;
@@ -999,10 +999,10 @@ ThreadError Leader::RemoveContext(uint8_t aContextId)
 
     otDumpDebgNetData(GetInstance(), "remove done", mTlvs, mLength);
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Leader::RemoveContext(PrefixTlv &aPrefix, uint8_t aContextId)
+otError Leader::RemoveContext(PrefixTlv &aPrefix, uint8_t aContextId)
 {
     NetworkDataTlv *cur = aPrefix.GetSubTlvs();
     NetworkDataTlv *end;
@@ -1043,7 +1043,7 @@ ThreadError Leader::RemoveContext(PrefixTlv &aPrefix, uint8_t aContextId)
         cur = cur->GetNext();
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 void Leader::HandleTimer(void *aContext)

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -119,7 +119,7 @@ public:
      * @param[in]  aDelay  The CONTEXT_ID_REUSE_DELAY value.
      *
      */
-    ThreadError SetContextIdReuseDelay(uint32_t aDelay);
+    otError SetContextIdReuseDelay(uint32_t aDelay);
 
     /**
      * This method removes Network Data associated with a given RLOC16.
@@ -134,11 +134,11 @@ public:
      *
      * @param[in]  aRloc16  The invalid RLOC16 to notify.
      *
-     * @retval kThreadError_None    Successfully enqueued the notification message.
-     * @retval kThreadError_NoBufs  Insufficient message buffers to generate the notification message.
+     * @retval OT_ERROR_NONE     Successfully enqueued the notification message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient message buffers to generate the notification message.
      *
      */
-    ThreadError SendServerDataNotification(uint16_t aRloc16);
+    otError SendServerDataNotification(uint16_t aRloc16);
 
 private:
     static void HandleServerData(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
@@ -148,25 +148,25 @@ private:
     static void HandleTimer(void *aContext);
     void HandleTimer(void);
 
-    ThreadError RegisterNetworkData(uint16_t aRloc16, uint8_t *aTlvs, uint8_t aTlvsLength);
+    otError RegisterNetworkData(uint16_t aRloc16, uint8_t *aTlvs, uint8_t aTlvsLength);
 
-    ThreadError AddHasRoute(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute);
-    ThreadError AddBorderRouter(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter);
-    ThreadError AddNetworkData(uint8_t *aTlv, uint8_t aTlvLength);
-    ThreadError AddPrefix(PrefixTlv &aTlv);
+    otError AddHasRoute(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute);
+    otError AddBorderRouter(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter);
+    otError AddNetworkData(uint8_t *aTlv, uint8_t aTlvLength);
+    otError AddPrefix(PrefixTlv &aTlv);
 
     int AllocateContext(void);
-    ThreadError FreeContext(uint8_t aContextId);
+    otError FreeContext(uint8_t aContextId);
 
-    ThreadError RemoveContext(uint8_t aContextId);
-    ThreadError RemoveContext(PrefixTlv &aPrefix, uint8_t aContextId);
+    otError RemoveContext(uint8_t aContextId);
+    otError RemoveContext(PrefixTlv &aPrefix, uint8_t aContextId);
 
-    ThreadError RemoveCommissioningData(void);
+    otError RemoveCommissioningData(void);
 
-    ThreadError RemoveRloc(uint16_t aRloc16);
-    ThreadError RemoveRloc(PrefixTlv &aPrefix, uint16_t aRloc16);
-    ThreadError RemoveRloc(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute, uint16_t aRloc16);
-    ThreadError RemoveRloc(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter, uint16_t aRloc16);
+    otError RemoveRloc(uint16_t aRloc16);
+    otError RemoveRloc(PrefixTlv &aPrefix, uint16_t aRloc16);
+    otError RemoveRloc(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute, uint16_t aRloc16);
+    otError RemoveRloc(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter, uint16_t aRloc16);
 
     void RlocLookup(uint16_t aRloc16, bool &aIn, bool &aStable, uint8_t *aTlvs, uint8_t aTlvsLength);
     bool IsStableUpdated(uint16_t aRloc16, uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aTlvsBase,

--- a/src/core/thread/network_data_leader_mtd.hpp
+++ b/src/core/thread/network_data_leader_mtd.hpp
@@ -53,7 +53,7 @@ public:
     void IncrementVersion(void) { }
     void IncrementStableVersion(void) { }
 
-    ThreadError SendServerDataNotification(uint16_t) { return kThreadError_NotImplemented; }
+    otError SendServerDataNotification(uint16_t) { return OT_ERROR_NOT_IMPLEMENTED; }
 };
 
 }  // namespace NetworkData

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -56,16 +56,16 @@ Local::Local(ThreadNetif &aThreadNetif):
 {
 }
 
-ThreadError Local::AddOnMeshPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, int8_t aPrf,
-                                   uint8_t aFlags, bool aStable)
+otError Local::AddOnMeshPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, int8_t aPrf,
+                               uint8_t aFlags, bool aStable)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     PrefixTlv *prefixTlv;
     BorderRouterTlv *brTlv;
 
     VerifyOrExit(Ip6::Address::PrefixMatch(aPrefix, mNetif.GetMle().GetMeshLocalPrefix(),
                                            (aPrefixLength + 7) / 8) < Ip6::Address::kMeshLocalPrefixLength,
-                 error = kThreadError_InvalidArgs);
+                 error = OT_ERROR_INVALID_ARGS);
 
     RemoveOnMeshPrefix(aPrefix, aPrefixLength);
 
@@ -96,13 +96,13 @@ exit:
     return error;
 }
 
-ThreadError Local::RemoveOnMeshPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength)
+otError Local::RemoveOnMeshPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     PrefixTlv *tlv;
 
-    VerifyOrExit((tlv = FindPrefix(aPrefix, aPrefixLength)) != NULL, error = kThreadError_Error);
-    VerifyOrExit(FindBorderRouter(*tlv) != NULL, error = kThreadError_Error);
+    VerifyOrExit((tlv = FindPrefix(aPrefix, aPrefixLength)) != NULL, error = OT_ERROR_NOT_FOUND);
+    VerifyOrExit(FindBorderRouter(*tlv) != NULL, error = OT_ERROR_NOT_FOUND);
     Remove(reinterpret_cast<uint8_t *>(tlv), sizeof(NetworkDataTlv) + tlv->GetLength());
     ClearResubmitDelayTimer();
 
@@ -111,7 +111,7 @@ exit:
     return error;
 }
 
-ThreadError Local::AddHasRoutePrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, int8_t aPrf, bool aStable)
+otError Local::AddHasRoutePrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, int8_t aPrf, bool aStable)
 {
     PrefixTlv *prefixTlv;
     HasRouteTlv *hasRouteTlv;
@@ -139,16 +139,16 @@ ThreadError Local::AddHasRoutePrefix(const uint8_t *aPrefix, uint8_t aPrefixLeng
     ClearResubmitDelayTimer();
 
     otDumpDebgNetData(GetInstance(), "add route done", mTlvs, mLength);
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Local::RemoveHasRoutePrefix(const uint8_t *aPrefix, uint8_t aPrefixLength)
+otError Local::RemoveHasRoutePrefix(const uint8_t *aPrefix, uint8_t aPrefixLength)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     PrefixTlv *tlv;
 
-    VerifyOrExit((tlv = FindPrefix(aPrefix, aPrefixLength)) != NULL, error = kThreadError_Error);
-    VerifyOrExit(FindHasRoute(*tlv) != NULL, error = kThreadError_Error);
+    VerifyOrExit((tlv = FindPrefix(aPrefix, aPrefixLength)) != NULL, error = OT_ERROR_NOT_FOUND);
+    VerifyOrExit(FindHasRoute(*tlv) != NULL, error = OT_ERROR_NOT_FOUND);
     Remove(reinterpret_cast<uint8_t *>(tlv), sizeof(NetworkDataTlv) + tlv->GetLength());
     ClearResubmitDelayTimer();
 
@@ -157,7 +157,7 @@ exit:
     return error;
 }
 
-ThreadError Local::UpdateRloc(void)
+otError Local::UpdateRloc(void)
 {
     for (NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs);
          cur < reinterpret_cast<NetworkDataTlv *>(mTlvs + mLength);
@@ -177,10 +177,10 @@ ThreadError Local::UpdateRloc(void)
 
     ClearResubmitDelayTimer();
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Local::UpdateRloc(PrefixTlv &aPrefix)
+otError Local::UpdateRloc(PrefixTlv &aPrefix)
 {
     for (NetworkDataTlv *cur = aPrefix.GetSubTlvs(); cur < aPrefix.GetNext(); cur = cur->GetNext())
     {
@@ -200,21 +200,21 @@ ThreadError Local::UpdateRloc(PrefixTlv &aPrefix)
         }
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Local::UpdateRloc(HasRouteTlv &aHasRoute)
+otError Local::UpdateRloc(HasRouteTlv &aHasRoute)
 {
     HasRouteEntry *entry = aHasRoute.GetEntry(0);
     entry->SetRloc(mNetif.GetMle().GetRloc16());
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError Local::UpdateRloc(BorderRouterTlv &aBorderRouter)
+otError Local::UpdateRloc(BorderRouterTlv &aBorderRouter)
 {
     BorderRouterEntry *entry = aBorderRouter.GetEntry(0);
     entry->SetRloc(mNetif.GetMle().GetRloc16());
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 bool Local::IsOnMeshPrefixConsistent(void)
@@ -229,9 +229,9 @@ bool Local::IsExternalRouteConsistent(void)
             ContainsExternalRoutes(mNetif.GetNetworkDataLeader(), mNetif.GetMle().GetRloc16()));
 }
 
-ThreadError Local::SendServerDataNotification(void)
+otError Local::SendServerDataNotification(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint16_t rloc = mNetif.GetMle().GetRloc16();
 
     if ((mNetif.GetMle().GetDeviceMode() & Mle::ModeTlv::kModeFFD) != 0 &&
@@ -239,7 +239,7 @@ ThreadError Local::SendServerDataNotification(void)
         (mNetif.GetMle().GetDeviceState() < Mle::kDeviceStateRouter) &&
         (mNetif.GetMle().GetActiveRouterCount() < mNetif.GetMle().GetRouterUpgradeThreshold()))
     {
-        ExitNow(error = kThreadError_InvalidState);
+        ExitNow(error = OT_ERROR_INVALID_STATE);
     }
 
     UpdateRloc();

--- a/src/core/thread/network_data_local_ftd.hpp
+++ b/src/core/thread/network_data_local_ftd.hpp
@@ -75,13 +75,13 @@ public:
      * @param[in]  aFlags         The Border Router Flags value.
      * @param[in]  aStable        The Stable value.
      *
-     * @retval kThreadError_None        Successfully added the Border Router entry.
-     * @retval kThreadError_NoBufs      Insufficient space to add the Border Router entry.
-     * @retval kThreadError_InvalidArgs The prefix is mesh local prefix.
+     * @retval OT_ERROR_NONE         Successfully added the Border Router entry.
+     * @retval OT_ERROR_NO_BUFS      Insufficient space to add the Border Router entry.
+     * @retval OT_ERROR_INVALID_ARGS The prefix is mesh local prefix.
      *
      */
-    ThreadError AddOnMeshPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, int8_t aPrf, uint8_t aFlags,
-                                bool aStable);
+    otError AddOnMeshPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, int8_t aPrf, uint8_t aFlags,
+                            bool aStable);
 
     /**
      * This method removes a Border Router entry from the Thread Network Data.
@@ -89,11 +89,11 @@ public:
      * @param[in]  aPrefix        A pointer to the prefix.
      * @param[in]  aPrefixLength  The length of @p aPrefix in bytes.
      *
-     * @retval kThreadError_None      Successfully removed the Border Router entry.
-     * @retval kThreadError_NotFound  Could not find the Border Router entry.
+     * @retval OT_ERROR_NONE       Successfully removed the Border Router entry.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the Border Router entry.
      *
      */
-    ThreadError RemoveOnMeshPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength);
+    otError RemoveOnMeshPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength);
 
     /**
      * This method adds a Has Route entry to the Thread Network data.
@@ -103,11 +103,11 @@ public:
      * @param[in]  aPrf           The preference value.
      * @param[in]  aStable        The Stable value.
      *
-     * @retval kThreadError_None    Successfully added the Has Route entry.
-     * @retval kThreadError_NoBufs  Insufficient space to add the Has Route entry.
+     * @retval OT_ERROR_NONE     Successfully added the Has Route entry.
+     * @retval OT_ERROR_NO_BUFS  Insufficient space to add the Has Route entry.
      *
      */
-    ThreadError AddHasRoutePrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, int8_t aPrf, bool aStable);
+    otError AddHasRoutePrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, int8_t aPrf, bool aStable);
 
     /**
      * This method removes a Border Router entry from the Thread Network Data.
@@ -115,26 +115,26 @@ public:
      * @param[in]  aPrefix        A pointer to the prefix.
      * @param[in]  aPrefixLength  The length of @p aPrefix in bytes.
      *
-     * @retval kThreadError_None      Successfully removed the Border Router entry.
-     * @retval kThreadError_NotFound  Could not find the Border Router entry.
+     * @retval OT_ERROR_NONE       Successfully removed the Border Router entry.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the Border Router entry.
      *
      */
-    ThreadError RemoveHasRoutePrefix(const uint8_t *aPrefix, uint8_t aPrefixLength);
+    otError RemoveHasRoutePrefix(const uint8_t *aPrefix, uint8_t aPrefixLength);
 
     /**
      * This method sends a Server Data Notification message to the Leader.
      *
-     * @retval kThreadError_None    Successfully enqueued the notification message.
-     * @retval kThreadError_NoBufs  Insufficient message buffers to generate the notification message.
+     * @retval OT_ERROR_NONE     Successfully enqueued the notification message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient message buffers to generate the notification message.
      *
      */
-    ThreadError SendServerDataNotification(void);
+    otError SendServerDataNotification(void);
 
 private:
-    ThreadError UpdateRloc(void);
-    ThreadError UpdateRloc(PrefixTlv &aPrefix);
-    ThreadError UpdateRloc(HasRouteTlv &aHasRoute);
-    ThreadError UpdateRloc(BorderRouterTlv &aBorderRouter);
+    otError UpdateRloc(void);
+    otError UpdateRloc(PrefixTlv &aPrefix);
+    otError UpdateRloc(HasRouteTlv &aHasRoute);
+    otError UpdateRloc(BorderRouterTlv &aBorderRouter);
 
     bool IsOnMeshPrefixConsistent(void);
     bool IsExternalRouteConsistent(void);

--- a/src/core/thread/network_data_local_mtd.hpp
+++ b/src/core/thread/network_data_local_mtd.hpp
@@ -49,17 +49,17 @@ public:
 
     void Clear(void) { }
 
-    ThreadError AddOnMeshPrefix(const uint8_t *, uint8_t, int8_t, uint8_t, bool) { return kThreadError_NotImplemented; }
-    ThreadError RemoveOnMeshPrefix(const uint8_t *, uint8_t) { return kThreadError_NotImplemented; }
+    otError AddOnMeshPrefix(const uint8_t *, uint8_t, int8_t, uint8_t, bool) { return OT_ERROR_NOT_IMPLEMENTED; }
+    otError RemoveOnMeshPrefix(const uint8_t *, uint8_t) { return OT_ERROR_NOT_IMPLEMENTED; }
 
-    ThreadError AddHasRoutePrefix(const uint8_t *, uint8_t, int8_t, bool) { return kThreadError_NotImplemented; }
-    ThreadError RemoveHasRoutePrefix(const uint8_t *, uint8_t) { return kThreadError_NotImplemented; }
+    otError AddHasRoutePrefix(const uint8_t *, uint8_t, int8_t, bool) { return OT_ERROR_NOT_IMPLEMENTED; }
+    otError RemoveHasRoutePrefix(const uint8_t *, uint8_t) { return OT_ERROR_NOT_IMPLEMENTED; }
 
-    ThreadError SendServerDataNotification(void) { return kThreadError_NotImplemented; }
+    otError SendServerDataNotification(void) { return OT_ERROR_NOT_IMPLEMENTED; }
 
     void GetNetworkData(bool, uint8_t *, uint8_t &aDataLength) { aDataLength = 0; }
-    ThreadError GetNextOnMeshPrefix(otNetworkDataIterator *, otBorderRouterConfig *) { return kThreadError_NotFound; }
-    ThreadError GetNextExternalRoute(otNetworkDataIterator *, otExternalRouteConfig *) { return kThreadError_NotFound; }
+    otError GetNextOnMeshPrefix(otNetworkDataIterator *, otBorderRouterConfig *) { return OT_ERROR_NOT_FOUND; }
+    otError GetNextExternalRoute(otNetworkDataIterator *, otExternalRouteConfig *) { return OT_ERROR_NOT_FOUND; }
     void ClearResubmitDelayTimer(void) { }
 
 };

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -92,10 +92,10 @@ void NetworkDiagnostic::SetReceiveDiagnosticGetCallback(otReceiveDiagnosticGetCa
     mReceiveDiagnosticGetCallbackContext = aCallbackContext;
 }
 
-ThreadError NetworkDiagnostic::SendDiagnosticGet(const Ip6::Address &aDestination, const uint8_t aTlvTypes[],
-                                                 uint8_t aCount)
+otError NetworkDiagnostic::SendDiagnosticGet(const Ip6::Address &aDestination, const uint8_t aTlvTypes[],
+                                             uint8_t aCount)
 {
-    ThreadError error;
+    otError error;
     Message *message;
     Coap::Header header;
     Ip6::MessageInfo messageInfo;
@@ -120,7 +120,7 @@ ThreadError NetworkDiagnostic::SendDiagnosticGet(const Ip6::Address &aDestinatio
         header.SetPayloadMarker();
     }
 
-    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     SuccessOrExit(error = message->Append(aTlvTypes, aCount));
 
@@ -135,7 +135,7 @@ ThreadError NetworkDiagnostic::SendDiagnosticGet(const Ip6::Address &aDestinatio
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -144,7 +144,7 @@ exit:
 }
 
 void NetworkDiagnostic::HandleDiagnosticGetResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                                    const otMessageInfo *aMessageInfo, ThreadError aResult)
+                                                    const otMessageInfo *aMessageInfo, otError aResult)
 {
     static_cast<NetworkDiagnostic *>(aContext)->HandleDiagnosticGetResponse(*static_cast<Coap::Header *>(aHeader),
                                                                             *static_cast<Message *>(aMessage),
@@ -154,9 +154,9 @@ void NetworkDiagnostic::HandleDiagnosticGetResponse(void *aContext, otCoapHeader
 
 void NetworkDiagnostic::HandleDiagnosticGetResponse(Coap::Header &aHeader, Message &aMessage,
                                                     const Ip6::MessageInfo &aMessageInfo,
-                                                    ThreadError aResult)
+                                                    otError aResult)
 {
-    VerifyOrExit(aResult == kThreadError_None);
+    VerifyOrExit(aResult == OT_ERROR_NONE);
     VerifyOrExit(aHeader.GetCode() == kCoapResponseChanged);
 
     otLogInfoNetDiag(GetInstance(), "Received diagnostic get response");
@@ -199,9 +199,9 @@ exit:
     return;
 }
 
-ThreadError NetworkDiagnostic::AppendIp6AddressList(Message &aMessage)
+otError NetworkDiagnostic::AppendIp6AddressList(Message &aMessage)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Ip6AddressListTlv tlv;
     uint8_t count = 0;
 
@@ -225,9 +225,9 @@ exit:
     return error;
 }
 
-ThreadError NetworkDiagnostic::AppendChildTable(Message &aMessage)
+otError NetworkDiagnostic::AppendChildTable(Message &aMessage)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t count = 0;
     uint8_t timeout = 0;
     uint8_t numChildren;
@@ -271,10 +271,10 @@ exit:
     return error;
 }
 
-ThreadError NetworkDiagnostic::FillRequestedTlvs(Message &aRequest, Message &aResponse,
-                                                 NetworkDiagnosticTlv &aNetworkDiagnosticTlv)
+otError NetworkDiagnostic::FillRequestedTlvs(Message &aRequest, Message &aResponse,
+                                             NetworkDiagnosticTlv &aNetworkDiagnosticTlv)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint16_t offset = 0;
     uint8_t type;
 
@@ -282,7 +282,7 @@ ThreadError NetworkDiagnostic::FillRequestedTlvs(Message &aRequest, Message &aRe
 
     for (uint32_t i = 0; i < aNetworkDiagnosticTlv.GetLength(); i++)
     {
-        VerifyOrExit(aRequest.Read(offset, sizeof(type), &type) == sizeof(type), error = kThreadError_Drop);
+        VerifyOrExit(aRequest.Read(offset, sizeof(type), &type) == sizeof(type), error = OT_ERROR_DROP);
 
         otLogInfoNetDiag(GetInstance(), "Received diagnostic get type %d", type);
 
@@ -417,7 +417,7 @@ ThreadError NetworkDiagnostic::FillRequestedTlvs(Message &aRequest, Message &aRe
         }
 
         default:
-            ExitNow(error = kThreadError_Drop);
+            ExitNow(error = OT_ERROR_DROP);
         }
 
         offset += sizeof(type);
@@ -438,27 +438,27 @@ void NetworkDiagnostic::HandleDiagnosticGetQuery(void *aContext, otCoapHeader *a
 void NetworkDiagnostic::HandleDiagnosticGetQuery(Coap::Header &aHeader, Message &aMessage,
                                                  const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Message *message = NULL;
     NetworkDiagnosticTlv networkDiagnosticTlv;
     Coap::Header header;
     Ip6::MessageInfo messageInfo;
 
-    VerifyOrExit(aHeader.GetCode() == kCoapRequestPost, error = kThreadError_Drop);
+    VerifyOrExit(aHeader.GetCode() == kCoapRequestPost, error = OT_ERROR_DROP);
 
     otLogInfoNetDiag(GetInstance(), "Received diagnostic get query");
 
     VerifyOrExit((aMessage.Read(aMessage.GetOffset(), sizeof(NetworkDiagnosticTlv),
-                                &networkDiagnosticTlv) == sizeof(NetworkDiagnosticTlv)), error = kThreadError_Drop);
+                                &networkDiagnosticTlv) == sizeof(NetworkDiagnosticTlv)), error = OT_ERROR_DROP);
 
-    VerifyOrExit(networkDiagnosticTlv.GetType() == NetworkDiagnosticTlv::kTypeList, error = kThreadError_Drop);
+    VerifyOrExit(networkDiagnosticTlv.GetType() == NetworkDiagnosticTlv::kTypeList, error = OT_ERROR_DROP);
 
-    VerifyOrExit((static_cast<TypeListTlv *>(&networkDiagnosticTlv)->IsValid()), error = kThreadError_Drop);
+    VerifyOrExit((static_cast<TypeListTlv *>(&networkDiagnosticTlv)->IsValid()), error = OT_ERROR_DROP);
 
     // DIAG_GET.qry may be sent as a confirmable message.
     if (aHeader.GetType() == kCoapTypeConfirmable)
     {
-        if (mNetif.GetCoap().SendEmptyAck(aHeader, aMessageInfo) == kThreadError_None)
+        if (mNetif.GetCoap().SendEmptyAck(aHeader, aMessageInfo) == OT_ERROR_NONE)
         {
             otLogInfoNetDiag(GetInstance(), "Sent diagnostic get query acknowledgment");
         }
@@ -473,7 +473,7 @@ void NetworkDiagnostic::HandleDiagnosticGetQuery(Coap::Header &aHeader, Message 
         header.SetPayloadMarker();
     }
 
-    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     messageInfo.SetPeerAddr(aMessageInfo.GetPeerAddr());
     messageInfo.SetSockAddr(mNetif.GetMle().GetMeshLocal16());
@@ -488,7 +488,7 @@ void NetworkDiagnostic::HandleDiagnosticGetQuery(Coap::Header &aHeader, Message 
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
@@ -505,28 +505,28 @@ void NetworkDiagnostic::HandleDiagnosticGetRequest(void *aContext, otCoapHeader 
 void NetworkDiagnostic::HandleDiagnosticGetRequest(Coap::Header &aHeader, Message &aMessage,
                                                    const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Message *message = NULL;
     NetworkDiagnosticTlv networkDiagnosticTlv;
     Coap::Header header;
     Ip6::MessageInfo messageInfo(aMessageInfo);
 
     VerifyOrExit(aHeader.GetType() == kCoapTypeConfirmable &&
-                 aHeader.GetCode() == kCoapRequestPost, error = kThreadError_Drop);
+                 aHeader.GetCode() == kCoapRequestPost, error = OT_ERROR_DROP);
 
     otLogInfoNetDiag(GetInstance(), "Received diagnostic get request");
 
     VerifyOrExit((aMessage.Read(aMessage.GetOffset(), sizeof(NetworkDiagnosticTlv),
-                                &networkDiagnosticTlv) == sizeof(NetworkDiagnosticTlv)), error = kThreadError_Drop);
+                                &networkDiagnosticTlv) == sizeof(NetworkDiagnosticTlv)), error = OT_ERROR_DROP);
 
-    VerifyOrExit(networkDiagnosticTlv.GetType() == NetworkDiagnosticTlv::kTypeList, error = kThreadError_Drop);
+    VerifyOrExit(networkDiagnosticTlv.GetType() == NetworkDiagnosticTlv::kTypeList, error = OT_ERROR_DROP);
 
-    VerifyOrExit((static_cast<TypeListTlv *>(&networkDiagnosticTlv)->IsValid()), error = kThreadError_Drop);
+    VerifyOrExit((static_cast<TypeListTlv *>(&networkDiagnosticTlv)->IsValid()), error = OT_ERROR_DROP);
 
     header.SetDefaultResponseHeader(aHeader);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     SuccessOrExit(error = FillRequestedTlvs(aMessage, *message, networkDiagnosticTlv));
 
@@ -542,16 +542,16 @@ void NetworkDiagnostic::HandleDiagnosticGetRequest(Coap::Header &aHeader, Messag
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }
 }
 
-ThreadError NetworkDiagnostic::SendDiagnosticReset(const Ip6::Address &aDestination, const uint8_t aTlvTypes[],
-                                                   uint8_t aCount)
+otError NetworkDiagnostic::SendDiagnosticReset(const Ip6::Address &aDestination, const uint8_t aTlvTypes[],
+                                               uint8_t aCount)
 {
-    ThreadError error;
+    otError error;
     Message *message;
     Coap::Header header;
     Ip6::MessageInfo messageInfo;
@@ -565,7 +565,7 @@ ThreadError NetworkDiagnostic::SendDiagnosticReset(const Ip6::Address &aDestinat
         header.SetPayloadMarker();
     }
 
-    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = kThreadError_NoBufs);
+    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     SuccessOrExit(error = message->Append(aTlvTypes, aCount));
 
@@ -580,7 +580,7 @@ ThreadError NetworkDiagnostic::SendDiagnosticReset(const Ip6::Address &aDestinat
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -99,7 +99,7 @@ public:
      * @param[in] aCount        Number of types in aTlvTypes
      *
      */
-    ThreadError SendDiagnosticGet(const Ip6::Address &aDestination, const uint8_t aTlvTypes[], uint8_t aCount);
+    otError SendDiagnosticGet(const Ip6::Address &aDestination, const uint8_t aTlvTypes[], uint8_t aCount);
 
     /**
      * This method sends Diagnostic Reset request.
@@ -109,13 +109,13 @@ public:
      * @param[in] aCount        Number of types in aTlvTypes
      *
      */
-    ThreadError SendDiagnosticReset(const Ip6::Address &aDestination, const uint8_t aTlvTypes[], uint8_t aCount);
+    otError SendDiagnosticReset(const Ip6::Address &aDestination, const uint8_t aTlvTypes[], uint8_t aCount);
 
 private:
 
-    ThreadError AppendIp6AddressList(Message &aMessage);
-    ThreadError AppendChildTable(Message &aMessage);
-    ThreadError FillRequestedTlvs(Message &aRequest, Message &aResponse, NetworkDiagnosticTlv &aNetworkDiagnosticTlv);
+    otError AppendIp6AddressList(Message &aMessage);
+    otError AppendChildTable(Message &aMessage);
+    otError FillRequestedTlvs(Message &aRequest, Message &aResponse, NetworkDiagnosticTlv &aNetworkDiagnosticTlv);
 
     static void HandleDiagnosticGetRequest(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
                                            const otMessageInfo *aMessageInfo);
@@ -126,9 +126,9 @@ private:
     void HandleDiagnosticGetQuery(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     static void HandleDiagnosticGetResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                            const otMessageInfo *aMessageInfo, ThreadError aResult);
+                                            const otMessageInfo *aMessageInfo, otError aResult);
     void HandleDiagnosticGetResponse(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
-                                     ThreadError aResult);
+                                     otError aResult);
 
     static void HandleDiagnosticGetAnswer(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
                                           const otMessageInfo *aMessageInfo);

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -124,11 +124,11 @@ public:
      * @param[in]   aMaxLength  Maximum number of bytes to read.
      * @param[out]  aTlv        A reference to the TLV that will be copied to.
      *
-     * @retval kThreadError_None      Successfully copied the TLV.
-     * @retval kThreadError_NotFound  Could not find the TLV with Type @p aType.
+     * @retval OT_ERROR_NONE       Successfully copied the TLV.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the TLV with Type @p aType.
      *
      */
-    static ThreadError GetTlv(const Message &aMessage, Type aType, uint16_t aMaxLength, Tlv &aTlv) {
+    static otError GetTlv(const Message &aMessage, Type aType, uint16_t aMaxLength, Tlv &aTlv) {
         return ot::Tlv::Get(aMessage, static_cast<uint8_t>(aType), aMaxLength, aTlv);
     }
 
@@ -139,11 +139,11 @@ public:
      * @param[in]   aType       The Type value to search for.
      * @param[out]  aOffset     A reference to the offset of the TLV.
      *
-     * @retval kThreadError_None      Successfully copied the TLV.
-     * @retval kThreadError_NotFound  Could not find the TLV with Type @p aType.
+     * @retval OT_ERROR_NONE       Successfully copied the TLV.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the TLV with Type @p aType.
      *
      */
-    static ThreadError GetOffset(const Message &aMessage, Type aType, uint16_t &aOffset) {
+    static otError GetOffset(const Message &aMessage, Type aType, uint16_t &aOffset) {
         return ot::Tlv::GetOffset(aMessage, static_cast<uint8_t>(aType), aOffset);
     }
 

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -130,9 +130,9 @@ void PanIdQueryServer::HandleScanResult(Mac::Frame *aFrame)
     }
 }
 
-ThreadError PanIdQueryServer::SendConflict(void)
+otError PanIdQueryServer::SendConflict(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     Coap::Header header;
     MeshCoP::ChannelMask0Tlv channelMask;
     MeshCoP::PanIdTlv panId;
@@ -144,8 +144,7 @@ ThreadError PanIdQueryServer::SendConflict(void)
     header.AppendUriPathOptions(OT_URI_PATH_PANID_CONFLICT);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL,
-                 error = kThreadError_NoBufs);
+    VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     channelMask.Init();
     channelMask.SetMask(mChannelMask);
@@ -164,7 +163,7 @@ ThreadError PanIdQueryServer::SendConflict(void)
 
 exit:
 
-    if (error != kThreadError_None && message != NULL)
+    if (error != OT_ERROR_NONE && message != NULL)
     {
         message->Free();
     }

--- a/src/core/thread/panid_query_server.hpp
+++ b/src/core/thread/panid_query_server.hpp
@@ -88,7 +88,7 @@ private:
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 
-    ThreadError SendConflict(void);
+    otError SendConflict(void);
 
     Ip6::Address mCommissioner;
     uint32_t mChannelMask;

--- a/src/core/thread/src_match_controller.cpp
+++ b/src/core/thread/src_match_controller.cpp
@@ -141,7 +141,7 @@ void SourceMatchController::AddEntry(Child &aChild)
     }
     else
     {
-        VerifyOrExit(AddAddress(aChild) == kThreadError_None, Enable(false));
+        VerifyOrExit(AddAddress(aChild) == OT_ERROR_NONE, Enable(false));
         aChild.SetIndirectSourceMatchPending(false);
     }
 
@@ -149,9 +149,9 @@ exit:
     return;
 }
 
-ThreadError SourceMatchController::AddAddress(const Child &aChild)
+otError SourceMatchController::AddAddress(const Child &aChild)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (aChild.IsIndirectSourceMatchShort())
     {
@@ -181,7 +181,7 @@ ThreadError SourceMatchController::AddAddress(const Child &aChild)
 
 void SourceMatchController::ClearEntry(Child &aChild)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (aChild.IsIndirectSourceMatchPending())
     {
@@ -225,9 +225,9 @@ exit:
     return;
 }
 
-ThreadError SourceMatchController::AddPendingEntries(void)
+otError SourceMatchController::AddPendingEntries(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t numChildren;
     Child *child;
 

--- a/src/core/thread/src_match_controller.hpp
+++ b/src/core/thread/src_match_controller.hpp
@@ -176,20 +176,20 @@ private:
      *
      * @param[in] aChild            A reference to the child
      *
-     * @retval kThreadError_None    Child's address was added successfully to the source match table.
-     * @retval kThreadError_NoBufs  No available space in the source match table.
+     * @retval OT_ERROR_NONE     Child's address was added successfully to the source match table.
+     * @retval OT_ERROR_NO_BUFS  No available space in the source match table.
      *
      */
-    ThreadError AddAddress(const Child &aChild);
+    otError AddAddress(const Child &aChild);
 
     /**
      * This method adds all pending entries to the source match table.
      *
-     * @retval kThreadError_None    All pending entries were successfully added.
-     * @retval kThreadError_NoBufs  No available space in the source match table.
+     * @retval OT_ERROR_NONE     All pending entries were successfully added.
+     * @retval OT_ERROR_NO_BUFS  No available space in the source match table.
      *
      */
-    ThreadError AddPendingEntries(void);
+    otError AddPendingEntries(void);
 
     MeshForwarder &mMeshForwarder;
     bool mEnabled;

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -119,7 +119,7 @@ ThreadNetif::ThreadNetif(Ip6::Ip6 &aIp6):
     mCoap.SetInterceptor(&ThreadNetif::TmfFilter);
 }
 
-ThreadError ThreadNetif::Up(void)
+otError ThreadNetif::Up(void)
 {
     if (!mIsUp)
     {
@@ -134,10 +134,10 @@ ThreadError ThreadNetif::Up(void)
         mIsUp = true;
     }
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError ThreadNetif::Down(void)
+otError ThreadNetif::Down(void)
 {
     mCoap.Stop();
 #if OPENTHREAD_ENABLE_DNS_CLIENT
@@ -155,36 +155,36 @@ ThreadError ThreadNetif::Down(void)
     mDtls.Stop();
 #endif
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError ThreadNetif::GetLinkAddress(Ip6::LinkAddress &address) const
+otError ThreadNetif::GetLinkAddress(Ip6::LinkAddress &address) const
 {
     address.mType = Ip6::LinkAddress::kEui64;
     address.mLength = sizeof(address.mExtAddress);
     memcpy(&address.mExtAddress, mMac.GetExtAddress(), address.mLength);
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError ThreadNetif::RouteLookup(const Ip6::Address &source, const Ip6::Address &destination, uint8_t *prefixMatch)
+otError ThreadNetif::RouteLookup(const Ip6::Address &source, const Ip6::Address &destination, uint8_t *prefixMatch)
 {
-    ThreadError error;
+    otError error;
     uint16_t rloc;
 
     SuccessOrExit(error = mNetworkDataLeader.RouteLookup(source, destination, prefixMatch, &rloc));
 
     if (rloc == mMleRouter.GetRloc16())
     {
-        error = kThreadError_NoRoute;
+        error = OT_ERROR_NO_ROUTE;
     }
 
 exit:
     return error;
 }
 
-ThreadError ThreadNetif::TmfFilter(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError ThreadNetif::TmfFilter(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     // A TMF message must comply at least one of the following rules:
     // 1. The IPv6 source address is RLOC or ALOC.
@@ -195,7 +195,7 @@ ThreadError ThreadNetif::TmfFilter(const Message &aMessage, const Ip6::MessageIn
                  aMessageInfo.GetSockAddr().IsRoutingLocator() ||
                  aMessageInfo.GetSockAddr().IsAnycastRoutingLocator() ||
                  aMessageInfo.GetSockAddr().IsLinkLocal(),
-                 error = kThreadError_NotTmf);
+                 error = OT_ERROR_NOT_TMF);
 exit:
     (void)aMessage;
     return error;

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -114,13 +114,13 @@ public:
      * This method enables the Thread network interface.
      *
      */
-    ThreadError Up(void);
+    otError Up(void);
 
     /**
      * This method disables the Thread network interface.
      *
      */
-    ThreadError Down(void);
+    otError Down(void);
 
     /**
      * This method indicates whether or not the Thread network interface is enabled.
@@ -137,17 +137,17 @@ public:
      * @param[out]  aAddress  A reference to the link address.
      *
      */
-    virtual ThreadError GetLinkAddress(Ip6::LinkAddress &aAddress) const;
+    virtual otError GetLinkAddress(Ip6::LinkAddress &aAddress) const;
 
     /**
      * This method submits a message to the network interface.
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @retval kThreadError_None  Successfully submitted the message to the interface.
+     * @retval OT_ERROR_NONE  Successfully submitted the message to the interface.
      *
      */
-    virtual ThreadError SendMessage(Message &aMessage) { return mMeshForwarder.SendMessage(aMessage); }
+    virtual otError SendMessage(Message &aMessage) { return mMeshForwarder.SendMessage(aMessage); }
 
     /**
      * This method performs a route lookup.
@@ -156,11 +156,11 @@ public:
      * @param[in]   aDestination  A reference to the IPv6 destination address.
      * @param[out]  aPrefixMatch  A pointer where the number of prefix match bits for the chosen route is stored.
      *
-     * @retval kThreadError_None     Successfully found a route.
-     * @retval kThreadError_NoRoute  Could not find a valid route.
+     * @retval OT_ERROR_NONE      Successfully found a route.
+     * @retval OT_ERROR_NO_ROUTE  Could not find a valid route.
      *
      */
-    virtual ThreadError RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination, uint8_t *aPrefixMatch);
+    virtual otError RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination, uint8_t *aPrefixMatch);
 
 #if OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
     /**
@@ -407,7 +407,7 @@ public:
     otInstance *GetInstance(void);
 
 private:
-    static ThreadError TmfFilter(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    static otError TmfFilter(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     Coap::Coap mCoap;
 #if OPENTHREAD_ENABLE_DHCP6_CLIENT

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -102,11 +102,11 @@ public:
      * @param[in]   aMaxLength  Maximum number of bytes to read.
      * @param[out]  aTlv        A reference to the TLV that will be copied to.
      *
-     * @retval kThreadError_None      Successfully copied the TLV.
-     * @retval kThreadError_NotFound  Could not find the TLV with Type @p aType.
+     * @retval OT_ERROR_NONE       Successfully copied the TLV.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the TLV with Type @p aType.
      *
      */
-    static ThreadError GetTlv(const Message &aMessage, Type aType, uint16_t aMaxLength, Tlv &aTlv) {
+    static otError GetTlv(const Message &aMessage, Type aType, uint16_t aMaxLength, Tlv &aTlv) {
         return ot::Tlv::Get(aMessage, static_cast<uint8_t>(aType), aMaxLength, aTlv);
     }
 

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -55,9 +55,9 @@ void Neighbor::GenerateChallenge(void)
     }
 }
 
-ThreadError Child::FindIp6Address(const Ip6::Address &aAddress, uint8_t *aIndex) const
+otError Child::FindIp6Address(const Ip6::Address &aAddress, uint8_t *aIndex) const
 {
-    ThreadError error = kThreadError_NotFound;
+    otError error = OT_ERROR_NOT_FOUND;
 
     for (uint8_t index = 0; index < kMaxIp6AddressPerChild; index++)
     {
@@ -68,7 +68,7 @@ ThreadError Child::FindIp6Address(const Ip6::Address &aAddress, uint8_t *aIndex)
                 *aIndex = index;
             }
 
-            error = kThreadError_None;
+            error = OT_ERROR_NONE;
             break;
         }
     }

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -379,11 +379,11 @@ public:
      * @param[out] aIndex             Pointer to variable where the index of address is provided if address is found in
      *                                the list. @p aIndex can be set NULL if index is not required.
      *
-     * @retval kThreadError_None      Successfully found the address in IPv6 address list and updated @p aIndex.
-     * @retval kThreadError_NotFound  Could not find the address in the list.
+     * @retval OT_ERROR_NONE          Successfully found the address in IPv6 address list and updated @p aIndex.
+     * @retval OT_ERROR_NOT_FOUND     Could not find the address in the list.
      *
      */
-    ThreadError FindIp6Address(const Ip6::Address &aAddress, uint8_t *aIndex) const;
+    otError FindIp6Address(const Ip6::Address &aAddress, uint8_t *aIndex) const;
 
     /**
      * This method removes the address at index @p aIndex.

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -94,7 +94,7 @@ exit:
 void ChildSupervisor::SendMessage(Child &aChild)
 {
     Message *message = NULL;
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     uint8_t childIndex;
 
     VerifyOrExit(aChild.GetIndirectMessageCount() == 0);

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -67,12 +67,12 @@ JamDetector::JamDetector(ThreadNetif &aNetif) :
 {
 }
 
-ThreadError JamDetector::Start(Handler aHandler, void *aContext)
+otError JamDetector::Start(Handler aHandler, void *aContext)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(!mEnabled, error = kThreadError_Already);
-    VerifyOrExit(aHandler != NULL, error = kThreadError_InvalidArgs);
+    VerifyOrExit(!mEnabled, error = OT_ERROR_ALREADY);
+    VerifyOrExit(aHandler != NULL, error = OT_ERROR_INVALID_ARGS);
 
     mHandler = aHandler;
     mContext = aContext;
@@ -91,11 +91,11 @@ exit:
     return error;
 }
 
-ThreadError JamDetector::Stop(void)
+otError JamDetector::Stop(void)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mEnabled, error = kThreadError_Already);
+    VerifyOrExit(mEnabled, error = OT_ERROR_ALREADY);
 
     mEnabled = false;
     mJamState = false;
@@ -106,19 +106,19 @@ exit:
     return error;
 }
 
-ThreadError JamDetector::SetRssiThreshold(int8_t aThreshold)
+otError JamDetector::SetRssiThreshold(int8_t aThreshold)
 {
     mRssiThreshold = aThreshold;
 
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError JamDetector::SetWindow(uint8_t aWindow)
+otError JamDetector::SetWindow(uint8_t aWindow)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aWindow != 0, error = kThreadError_InvalidArgs);
-    VerifyOrExit(aWindow <= kMaxWindow, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aWindow != 0, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aWindow <= kMaxWindow, error = OT_ERROR_INVALID_ARGS);
 
     mWindow = aWindow;
 
@@ -126,12 +126,12 @@ exit:
     return error;
 }
 
-ThreadError JamDetector::SetBusyPeriod(uint8_t aBusyPeriod)
+otError JamDetector::SetBusyPeriod(uint8_t aBusyPeriod)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aBusyPeriod != 0, error = kThreadError_InvalidArgs);
-    VerifyOrExit(aBusyPeriod <= mWindow, error = kThreadError_InvalidArgs);
+    VerifyOrExit(aBusyPeriod != 0, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aBusyPeriod <= mWindow, error = OT_ERROR_INVALID_ARGS);
 
     mBusyPeriod = aBusyPeriod;
 

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -77,20 +77,20 @@ public:
      * @param[in]  aHandler             A pointer to a function called when jamming is detected.
      * @param[in]  aContext             A pointer to application-specific context.
      *
-     * @retval kThreadErrorNone         Successfully started the jamming detection.
-     * @retval kThreadErrorAlready      Jam detection has been started before.
+     * @retval OT_ERROR_NONE            Successfully started the jamming detection.
+     * @retval OT_ERROR_ALREADY         Jam detection has been started before.
      *
      */
-    ThreadError Start(Handler aHandler, void *aContext);
+    otError Start(Handler aHandler, void *aContext);
 
     /**
      * Stop the jamming detection.
      *
-     * @retval kThreadErrorNone         Successfully stopped the jamming detection.
-     * @retval kThreadErrorAlready      Jam detection is already stopped.
+     * @retval OT_ERROR_NONE            Successfully stopped the jamming detection.
+     * @retval OT_ERROR_ALREADY         Jam detection is already stopped.
      *
      */
-    ThreadError Stop(void);
+    otError Stop(void);
 
     /**
      * Get the Jam Detection Status
@@ -111,10 +111,10 @@ public:
      *
      * @param[in]  aRssiThreshold  The RSSI threshold.
      *
-     * @retval kThreadErrorNone    Successfully set the threshold.
+     * @retval OT_ERROR_NONE       Successfully set the threshold.
      *
      */
-    ThreadError SetRssiThreshold(int8_t aThreshold);
+    otError SetRssiThreshold(int8_t aThreshold);
 
     /**
      * Get the Jam Detection RSSI Threshold (in dBm).
@@ -126,13 +126,13 @@ public:
     /**
      * Set the Jam Detection Detection Window (in seconds).
      *
-     * @param[in]  aWindow              The Jam Detection window (valid range is 1 to 63)
+     * @param[in]  aWindow            The Jam Detection window (valid range is 1 to 63)
      *
-     * @retval kThreadErrorNone         Successfully set the window.
-     * @retval kThreadErrorInvalidArgs  The given input parameter not within valid range (1-63)
+     * @retval OT_ERROR_NONE          Successfully set the window.
+     * @retval OT_ERROR_INVALID_ARGS  The given input parameter not within valid range (1-63)
      *
      */
-    ThreadError SetWindow(uint8_t aWindow);
+    otError SetWindow(uint8_t aWindow);
 
     /**
      * Get the Jam Detection Detection Window (in seconds).
@@ -150,11 +150,11 @@ public:
      * @param[in]  aBusyPeriod          The Jam Detection busy period (should be non-zero and
                                         less than or equal to Jam Detection Window)
      *
-     * @retval kThreadErrorNone         Successfully set the window.
-     * @retval kThreadErrorInvalidArgs  The given input is not within the valid range.
+     * @retval OT_ERROR_NONE            Successfully set the window.
+     * @retval OT_ERROR_INVALID_ARGS    The given input is not within the valid range.
      *
      */
-    ThreadError SetBusyPeriod(uint8_t aBusyPeriod);
+    otError SetBusyPeriod(uint8_t aBusyPeriod);
 
     /**
      * Get the Jam Detection Busy Period (in seconds)

--- a/src/core/utils/slaac_address.hpp
+++ b/src/core/utils/slaac_address.hpp
@@ -63,11 +63,11 @@ public:
      * @param[inout]  aAddress   A pointer to structure containing IPv6 address for which IID is being created.
      * @param[in]     aContext   A pointer to creator-specific context.
      *
-     * @retval  kThreadError_None    if generated valid IID.
-     * @retval  kThreadError_Failed  if creating IID failed.
+     * @retval  OT_ERROR_NONE    if generated valid IID.
+     * @retval  OT_ERROR_FAILED  if creating IID failed.
      *
      */
-    typedef ThreadError(*IidCreator)(otInstance *aInstance, otNetifAddress *aAddress, void *aContext);
+    typedef otError(*IidCreator)(otInstance *aInstance, otNetifAddress *aAddress, void *aContext);
 
     /**
      * This function update addresses that shall be automatically created using SLAAC.
@@ -89,9 +89,9 @@ public:
      * @param[inout]  aAddress   A pointer to structure containing IPv6 address for which IID is being created.
      * @param[in]     aContext   Unused pointer.
      *
-     * @retval  kThreadError_None  Generated valid IID.
+     * @retval  OT_ERROR_NONE  Generated valid IID.
      */
-    static ThreadError CreateRandomIid(otInstance *aInstance, otNetifAddress *aAddress, void *aContext);
+    static otError CreateRandomIid(otInstance *aInstance, otNetifAddress *aAddress, void *aContext);
 };
 
 /**
@@ -110,12 +110,12 @@ public:
      * @param[in]     aInstance  A pointer to an OpenThread instance.
      * @param[inout]  aAddress   A pointer to structure containing IPv6 address for which IID is being created.
      *
-     * @retval  kThreadError_None                        Generated valid IID.
-     * @retval  kThreadError_InvalidArgs                 Any given parameter is invalid.
-     * @retval  kThreadError_Ipv6AddressCreationFailure  Could not generate IID due to RFC 7217 restrictions.
+     * @retval  OT_ERROR_NONE                          Generated valid IID.
+     * @retval  OT_ERROR_INVALID_ARGS                  Any given parameter is invalid.
+     * @retval  OT_ERROR_IP6_ADDRESS_CREATION_FAILURE  Could not generate IID due to RFC 7217 restrictions.
      *
      */
-    ThreadError CreateIid(otInstance *aInstance, otNetifAddress *aAddress);
+    otError CreateIid(otInstance *aInstance, otNetifAddress *aAddress);
 
 private:
     enum
@@ -131,12 +131,12 @@ private:
      * @param[in]     aInstance  A pointer to an OpenThread instance.
      * @param[inout]  aAddress   A pointer to structure containing IPv6 address for which IID is being created.
      *
-     * @retval  kThreadError_None                        Generated valid IID.
-     * @retval  kThreadError_InvalidArgs                 Any given parameter is invalid.
-     * @retval  kThreadError_Ipv6AddressCreationFailure  Could not generate IID due to RFC 7217 restrictions.
+     * @retval  OT_ERROR_NONE                          Generated valid IID.
+     * @retval  OT_ERROR_INVALID_ARGS                  Any given parameter is invalid.
+     * @retval  OT_ERROR_IP6_ADDRESS_CREATION_FAILURE  Could not generate IID due to RFC 7217 restrictions.
      *
      */
-    ThreadError CreateIidOnce(otInstance *aInstance, otNetifAddress *aAddress);
+    otError CreateIidOnce(otInstance *aInstance, otNetifAddress *aAddress);
 
     /**
      * This method checks if created IPv6 address is already registered in the Thread interface.

--- a/src/diag/diag_process.cpp
+++ b/src/diag/diag_process.cpp
@@ -121,9 +121,9 @@ bool Diag::isEnabled()
     return otPlatDiagModeGet();
 }
 
-void Diag::AppendErrorResult(ThreadError aError, char *aOutput, size_t aOutputMaxLen)
+void Diag::AppendErrorResult(otError aError, char *aOutput, size_t aOutputMaxLen)
 {
-    if (aError != kThreadError_None)
+    if (aError != OT_ERROR_NONE)
     {
         snprintf(aOutput, aOutputMaxLen, "failed\r\nstatus %#x\r\n", aError);
     }
@@ -131,7 +131,7 @@ void Diag::AppendErrorResult(ThreadError aError, char *aOutput, size_t aOutputMa
 
 void Diag::ProcessStart(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     // enable radio
     otPlatRadioEnable(sContext);
@@ -160,9 +160,9 @@ exit:
 
 void Diag::ProcessStop(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(otPlatDiagModeGet(), error = kThreadError_InvalidState);
+    VerifyOrExit(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
 
     otPlatAlarmStop(sContext);
     otPlatDiagModeSet(false);
@@ -178,11 +178,11 @@ exit:
     AppendErrorResult(error, aOutput, aOutputMaxLen);
 }
 
-ThreadError Diag::ParseLong(char *argv, long &value)
+otError Diag::ParseLong(char *argv, long &value)
 {
     char *endptr;
     value = strtol(argv, &endptr, 0);
-    return (*endptr == '\0') ? kThreadError_None : kThreadError_Parse;
+    return (*endptr == '\0') ? OT_ERROR_NONE : OT_ERROR_PARSE;
 }
 
 void Diag::TxPacket()
@@ -205,9 +205,9 @@ void Diag::TxPacket()
 
 void Diag::ProcessChannel(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(otPlatDiagModeGet(), error = kThreadError_InvalidState);
+    VerifyOrExit(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
 
     if (argc == 0)
     {
@@ -218,7 +218,7 @@ void Diag::ProcessChannel(int argc, char *argv[], char *aOutput, size_t aOutputM
         long value;
 
         SuccessOrExit(error = ParseLong(argv[0], value));
-        VerifyOrExit(value >= kPhyMinChannel && value <= kPhyMaxChannel, error = kThreadError_InvalidArgs);
+        VerifyOrExit(value >= kPhyMinChannel && value <= kPhyMaxChannel, error = OT_ERROR_INVALID_ARGS);
         sChannel = static_cast<uint8_t>(value);
 
         // listen on the set channel immediately
@@ -233,9 +233,9 @@ exit:
 
 void Diag::ProcessPower(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(otPlatDiagModeGet(), error = kThreadError_InvalidState);
+    VerifyOrExit(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
 
     if (argc == 0)
     {
@@ -257,17 +257,17 @@ exit:
 
 void Diag::ProcessSend(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     long value;
 
-    VerifyOrExit(otPlatDiagModeGet(), error = kThreadError_InvalidState);
-    VerifyOrExit(argc == 2, error = kThreadError_InvalidArgs);
+    VerifyOrExit(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(argc == 2, error = OT_ERROR_INVALID_ARGS);
 
     SuccessOrExit(error = ParseLong(argv[0], value));
     sTxPackets = static_cast<uint32_t>(value);
 
     SuccessOrExit(error = ParseLong(argv[1], value));
-    VerifyOrExit(value <= kMaxPHYPacketSize, error = kThreadError_InvalidArgs);
+    VerifyOrExit(value <= kMaxPHYPacketSize, error = OT_ERROR_INVALID_ARGS);
     sTxLen = static_cast<uint8_t>(value);
 
     snprintf(aOutput, aOutputMaxLen, "sending %#x packet(s), length %#x\r\nstatus 0x%02x\r\n", static_cast<int>(sTxPackets), static_cast<int>(sTxLen), error);
@@ -279,10 +279,10 @@ exit:
 
 void Diag::ProcessRepeat(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(otPlatDiagModeGet(), error = kThreadError_InvalidState);
-    VerifyOrExit(argc > 0, error = kThreadError_InvalidArgs);
+    VerifyOrExit(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(argc > 0, error = OT_ERROR_INVALID_ARGS);
 
     if (strcmp(argv[0], "stop") == 0)
     {
@@ -294,13 +294,13 @@ void Diag::ProcessRepeat(int argc, char *argv[], char *aOutput, size_t aOutputMa
     {
         long value;
 
-        VerifyOrExit(argc == 2, error = kThreadError_InvalidArgs);
+        VerifyOrExit(argc == 2, error = OT_ERROR_INVALID_ARGS);
 
         SuccessOrExit(error = ParseLong(argv[0], value));
         sTxPeriod = static_cast<uint32_t>(value);
 
         SuccessOrExit(error = ParseLong(argv[1], value));
-        VerifyOrExit(value <= kMaxPHYPacketSize, error = kThreadError_InvalidArgs);
+        VerifyOrExit(value <= kMaxPHYPacketSize, error = OT_ERROR_INVALID_ARGS);
         sTxLen = static_cast<uint8_t>(value);
 
         sRepeatActive = true;
@@ -315,9 +315,9 @@ exit:
 
 void Diag::ProcessSleep(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(otPlatDiagModeGet(), error = kThreadError_InvalidState);
+    VerifyOrExit(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
 
     otPlatRadioSleep(sContext);
     snprintf(aOutput, aOutputMaxLen, "sleeping now...\r\n");
@@ -330,9 +330,9 @@ exit:
 
 void Diag::ProcessStats(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(otPlatDiagModeGet(), error = kThreadError_InvalidState);
+    VerifyOrExit(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
 
     snprintf(aOutput, aOutputMaxLen, "received packets: %d\r\nsent packets: %d\r\nfirst received packet: rssi=%d, lqi=%d\r\n",
             static_cast<int>(sStats.received_packets), static_cast<int>(sStats.sent_packets),
@@ -344,10 +344,10 @@ exit:
     AppendErrorResult(error, aOutput, aOutputMaxLen);
 }
 
-void Diag::DiagTransmitDone(otInstance *aInstance, bool aRxPending, ThreadError aError)
+void Diag::DiagTransmitDone(otInstance *aInstance, bool aRxPending, otError aError)
 {
     (void)aInstance;
-    if (!aRxPending && aError == kThreadError_None)
+    if (!aRxPending && aError == OT_ERROR_NONE)
     {
         sStats.sent_packets++;
 
@@ -358,10 +358,10 @@ void Diag::DiagTransmitDone(otInstance *aInstance, bool aRxPending, ThreadError 
     }
 }
 
-void Diag::DiagReceiveDone(otInstance *aInstance, RadioPacket *aFrame, ThreadError aError)
+void Diag::DiagReceiveDone(otInstance *aInstance, RadioPacket *aFrame, otError aError)
 {
     (void)aInstance;
-    if (aError == kThreadError_None)
+    if (aError == OT_ERROR_NONE)
     {
         // for sensitivity test, only record the rssi and lqi for the first packet
         if (sStats.received_packets == 0)
@@ -396,14 +396,14 @@ extern "C" void otPlatDiagAlarmFired(otInstance *aInstance)
     Diag::AlarmFired(aInstance);
 }
 
-extern "C" void otPlatDiagRadioTransmitDone(otInstance *aInstance, RadioPacket *aPacket, bool aRxPending, ThreadError aError)
+extern "C" void otPlatDiagRadioTransmitDone(otInstance *aInstance, RadioPacket *aPacket, bool aRxPending, otError aError)
 {
     (void)aPacket;
 
     Diag::DiagTransmitDone(aInstance, aRxPending, aError);
 }
 
-extern "C" void otPlatDiagRadioReceiveDone(otInstance *aInstance, RadioPacket *aFrame, ThreadError aError)
+extern "C" void otPlatDiagRadioReceiveDone(otInstance *aInstance, RadioPacket *aFrame, otError aError)
 {
     Diag::DiagReceiveDone(aInstance, aFrame, aError);
 }

--- a/src/diag/diag_process.hpp
+++ b/src/diag/diag_process.hpp
@@ -68,12 +68,12 @@ public:
     static char *ProcessCmd(int argc, char *argv[]);
     static bool isEnabled(void);
 
-    static void DiagTransmitDone(otInstance *aInstance, bool aRxPending, ThreadError aError);
-    static void DiagReceiveDone(otInstance *aInstance, RadioPacket *aFrame, ThreadError aError);
+    static void DiagTransmitDone(otInstance *aInstance, bool aRxPending, otError aError);
+    static void DiagReceiveDone(otInstance *aInstance, RadioPacket *aFrame, otError aError);
     static void AlarmFired(otInstance *aInstance);
 
 private:
-    static void AppendErrorResult(ThreadError error, char *aOutput, size_t aOutputMaxLen);
+    static void AppendErrorResult(otError error, char *aOutput, size_t aOutputMaxLen);
     static void ProcessSleep(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
     static void ProcessStart(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
     static void ProcessStop(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
@@ -83,7 +83,7 @@ private:
     static void ProcessChannel(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
     static void ProcessPower(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
     static void TxPacket(void);
-    static ThreadError ParseLong(char *aString, long &aLong);
+    static otError ParseLong(char *aString, long &aLong);
 
     static char sDiagOutput[];
     static const struct Command sCommands[];

--- a/src/ncp/hdlc.cpp
+++ b/src/ncp/hdlc.cpp
@@ -139,11 +139,11 @@ Encoder::BufferWriteIterator::BufferWriteIterator(void)
     mRemainingLength = 0;
 }
 
-ThreadError Encoder::BufferWriteIterator::WriteByte(uint8_t aByte)
+otError Encoder::BufferWriteIterator::WriteByte(uint8_t aByte)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mRemainingLength > 0, error = kThreadError_NoBufs);
+    VerifyOrExit(mRemainingLength > 0, error = OT_ERROR_NO_BUFS);
 
     *mWritePointer++ = aByte;
     mRemainingLength--;
@@ -162,20 +162,20 @@ Encoder::Encoder(void):
 {
 }
 
-ThreadError Encoder::Init(BufferWriteIterator &aIterator)
+otError Encoder::Init(BufferWriteIterator &aIterator)
 {
     mFcs = kInitFcs;
 
     return aIterator.WriteByte(kFlagSequence);
 }
 
-ThreadError Encoder::Encode(uint8_t aInByte, BufferWriteIterator &aIterator)
+otError Encoder::Encode(uint8_t aInByte, BufferWriteIterator &aIterator)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
 
     if (HdlcByteNeedsEscape(aInByte))
     {
-        VerifyOrExit(aIterator.CanWrite(2) , error = kThreadError_NoBufs);
+        VerifyOrExit(aIterator.CanWrite(2) , error = OT_ERROR_NO_BUFS);
 
         aIterator.WriteByte(kEscapeSequence);
         aIterator.WriteByte(aInByte ^ 0x20);
@@ -191,9 +191,9 @@ exit:
     return error;
 }
 
-ThreadError Encoder::Encode(const uint8_t *aInBuf, uint16_t aInLength, BufferWriteIterator &aIterator)
+otError Encoder::Encode(const uint8_t *aInBuf, uint16_t aInLength, BufferWriteIterator &aIterator)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     BufferWriteIterator oldIterator(aIterator);
     uint16_t oldFcs = mFcs;
 
@@ -203,7 +203,7 @@ ThreadError Encoder::Encode(const uint8_t *aInBuf, uint16_t aInLength, BufferWri
     }
 
 exit:
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         aIterator = oldIterator;
         mFcs = oldFcs;
@@ -212,9 +212,9 @@ exit:
     return error;
 }
 
-ThreadError Encoder::Finalize(BufferWriteIterator &aIterator)
+otError Encoder::Finalize(BufferWriteIterator &aIterator)
 {
-    ThreadError error = kThreadError_None;
+    otError error = OT_ERROR_NONE;
     BufferWriteIterator oldIterator(aIterator);
     uint16_t oldFcs = mFcs;
     uint16_t fcs = mFcs;
@@ -227,7 +227,7 @@ ThreadError Encoder::Finalize(BufferWriteIterator &aIterator)
     SuccessOrExit(error = aIterator.WriteByte(kFlagSequence));
 
 exit:
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         aIterator = oldIterator;
         mFcs = oldFcs;
@@ -286,7 +286,7 @@ void Decoder::Decode(const uint8_t *aInBuf, uint16_t aInLength)
                     }
                     else if (mErrorHandler != NULL)
                     {
-                        mErrorHandler(mContext, kThreadError_Parse, mOutBuf, mOutOffset);
+                        mErrorHandler(mContext, OT_ERROR_PARSE, mOutBuf, mOutOffset);
                     }
                 }
 
@@ -305,7 +305,7 @@ void Decoder::Decode(const uint8_t *aInBuf, uint16_t aInLength)
                 {
                     if (mErrorHandler != NULL)
                     {
-                        mErrorHandler(mContext, kThreadError_NoBufs, mOutBuf, mOutOffset);
+                        mErrorHandler(mContext, OT_ERROR_NO_BUFS, mOutBuf, mOutOffset);
                     }
                     mState = kStateNoSync;
                 }
@@ -327,7 +327,7 @@ void Decoder::Decode(const uint8_t *aInBuf, uint16_t aInLength)
             {
                 if (mErrorHandler != NULL)
                 {
-                    mErrorHandler(mContext, kThreadError_NoBufs, mOutBuf, mOutOffset);
+                    mErrorHandler(mContext, OT_ERROR_NO_BUFS, mOutBuf, mOutOffset);
                 }
                 mState = kStateNoSync;
             }

--- a/src/ncp/hdlc.hpp
+++ b/src/ncp/hdlc.hpp
@@ -66,11 +66,11 @@ public:
         /**
          * This method writes a byte to the buffer and updates the iterator (if space is available).
          *
-         * @retval kThreadError_None    Successfully wrote the byte and updates the iterator.
-         * @retval kThreadError_NoBufs  Insufficient buffer space.
+         * @retval OT_ERROR_NONE     Successfully wrote the byte and updates the iterator.
+         * @retval OT_ERROR_NO_BUFS  Insufficient buffer space.
          *
          */
-        ThreadError WriteByte(uint8_t aByte);
+        otError WriteByte(uint8_t aByte);
 
         /**
          * This method checks if there is buffer space available to write @p aWriteLength bytes.
@@ -102,11 +102,11 @@ public:
      *
      * @param[inout] aIterator      A reference to a buffer write iterator. On successful exit, the iterator is updated.
      *
-     * @retval kThreadError_None    Successfully started the HDLC frame.
-     * @retval kThreadError_NoBufs  Insufficient buffer space available to start the HDLC frame.
+     * @retval OT_ERROR_NONE     Successfully started the HDLC frame.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffer space available to start the HDLC frame.
      *
      */
-    ThreadError Init(BufferWriteIterator &aIterator);
+    otError Init(BufferWriteIterator &aIterator);
 
     /**
      * This method encodes a single byte into a buffer at @p aIterator.
@@ -116,11 +116,11 @@ public:
      * @param[in]    aInByte        A byte to encode and add.
      * @param[inout] aIterator      A reference to a write buffer iterator. On successful exit, the iterator is updated.
      *
-     * @retval kThreadError_None    Successfully encoded and added the byte.
-     * @retval kThreadError_NoBufs  Insufficient buffer space available to encode and add the byte.
+     * @retval OT_ERROR_NONE     Successfully encoded and added the byte.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffer space available to encode and add the byte.
      *
      */
-    ThreadError Encode(uint8_t aInByte, BufferWriteIterator &aIterator);
+    otError Encode(uint8_t aInByte, BufferWriteIterator &aIterator);
 
     /**
      * This method encodes the frame into a buffer at @p aIterator.
@@ -132,22 +132,22 @@ public:
      * @param[in]    aInLength      The number of bytes in @p aInBuf to encode.
      * @param[inout] aIterator      A reference to a write buffer iterator. On successful exit, the iterator is updated.
      *
-     * @retval kThreadError_None    Successfully encoded the HDLC frame.
-     * @retval kThreadError_NoBufs  Insufficient buffer space available to encode the HDLC frame.
+     * @retval OT_ERROR_NONE     Successfully encoded the HDLC frame.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffer space available to encode the HDLC frame.
      *
      */
-    ThreadError Encode(const uint8_t *aInBuf, uint16_t aInLength, BufferWriteIterator &aIterator);
+    otError Encode(const uint8_t *aInBuf, uint16_t aInLength, BufferWriteIterator &aIterator);
 
     /**
      * This method finalizes an HDLC frame.
      *
      * @param[inout] aIterator      A reference to a write buffer iterator. On successful exit, the iterator is updated.
      *
-     * @retval kThreadError_None    Successfully ended the HDLC frame.
-     * @retval kThreadError_NoBufs  Insufficient buffer space available to end the HDLC frame.
+     * @retval OT_ERROR_NONE     Successfully ended the HDLC frame.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffer space available to end the HDLC frame.
      *
      */
-    ThreadError Finalize(BufferWriteIterator &aIterator);
+    otError Finalize(BufferWriteIterator &aIterator);
 
 private:
     uint16_t mFcs;
@@ -179,7 +179,7 @@ public:
      * @param[in]  aFrameLength  The frame length in bytes.
      *
      */
-    typedef void (*ErrorHandler)(void *aContext, ThreadError aError, uint8_t *aFrame, uint16_t aFrameLength);
+    typedef void (*ErrorHandler)(void *aContext, otError aError, uint8_t *aFrame, uint16_t aFrameLength);
 
     /**
      * This constructor initializes the decoder.

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -406,61 +406,61 @@ const NcpBase::RemovePropertyHandlerEntry NcpBase::mRemovePropertyHandlerTable[]
 // MARK: Utility Functions
 // ----------------------------------------------------------------------------
 
-static spinel_status_t ThreadErrorToSpinelStatus(ThreadError error)
+static spinel_status_t ThreadErrorToSpinelStatus(otError error)
 {
     spinel_status_t ret;
 
     switch (error)
     {
-    case kThreadError_None:
+    case OT_ERROR_NONE:
         ret = SPINEL_STATUS_OK;
         break;
 
-    case kThreadError_Failed:
+    case OT_ERROR_FAILED:
         ret = SPINEL_STATUS_FAILURE;
         break;
 
-    case kThreadError_Drop:
+    case OT_ERROR_DROP:
         ret = SPINEL_STATUS_DROPPED;
         break;
 
-    case kThreadError_NoBufs:
+    case OT_ERROR_NO_BUFS:
         ret = SPINEL_STATUS_NOMEM;
         break;
 
-    case kThreadError_Busy:
+    case OT_ERROR_BUSY:
         ret = SPINEL_STATUS_BUSY;
         break;
 
-    case kThreadError_Parse:
+    case OT_ERROR_PARSE:
         ret = SPINEL_STATUS_PARSE_ERROR;
         break;
 
-    case kThreadError_InvalidArgs:
+    case OT_ERROR_INVALID_ARGS:
         ret = SPINEL_STATUS_INVALID_ARGUMENT;
         break;
 
-    case kThreadError_NotImplemented:
+    case OT_ERROR_NOT_IMPLEMENTED:
         ret = SPINEL_STATUS_UNIMPLEMENTED;
         break;
 
-    case kThreadError_InvalidState:
+    case OT_ERROR_INVALID_STATE:
         ret = SPINEL_STATUS_INVALID_STATE;
         break;
 
-    case kThreadError_NoAck:
+    case OT_ERROR_NO_ACK:
         ret = SPINEL_STATUS_NO_ACK;
         break;
 
-    case kThreadError_ChannelAccessFailure:
+    case OT_ERROR_CHANNEL_ACCESS_FAILURE:
         ret = SPINEL_STATUS_CCA_FAILURE;
         break;
 
-    case kThreadError_Already:
+    case OT_ERROR_ALREADY:
         ret = SPINEL_STATUS_ALREADY;
         break;
 
-    case kThreadError_NotFound:
+    case OT_ERROR_NOT_FOUND:
         ret = SPINEL_STATUS_ITEM_NOT_FOUND;
         break;
 
@@ -626,22 +626,22 @@ NcpBase *NcpBase::GetNcpInstance(void)
 // MARK: Outbound Frame methods
 // ----------------------------------------------------------------------------
 
-ThreadError NcpBase::OutboundFrameBegin(void)
+otError NcpBase::OutboundFrameBegin(void)
 {
     return mTxFrameBuffer.InFrameBegin();
 }
 
-ThreadError NcpBase::OutboundFrameFeedData(const uint8_t *aDataBuffer, uint16_t aDataBufferLength)
+otError NcpBase::OutboundFrameFeedData(const uint8_t *aDataBuffer, uint16_t aDataBufferLength)
 {
     return mTxFrameBuffer.InFrameFeedData(aDataBuffer, aDataBufferLength);
 }
 
-ThreadError NcpBase::OutboundFrameFeedMessage(otMessage *aMessage)
+otError NcpBase::OutboundFrameFeedMessage(otMessage *aMessage)
 {
     return mTxFrameBuffer.InFrameFeedMessage(aMessage);
 }
 
-ThreadError NcpBase::OutboundFrameEnd(void)
+otError NcpBase::OutboundFrameEnd(void)
 {
     return mTxFrameBuffer.InFrameEnd();
 }
@@ -654,7 +654,7 @@ void NcpBase::HandleBorderAgentProxyStream(otMessage *aMessage, uint16_t aLocato
 
 void NcpBase::HandleBorderAgentProxyStream(otMessage *aMessage, uint16_t aLocator, uint16_t aPort)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint16_t length = otMessageGetLength(aMessage);
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
@@ -686,7 +686,7 @@ exit:
         otMessageFree(aMessage);
     }
 
-    if (errorCode != kThreadError_None)
+    if (errorCode != OT_ERROR_NONE)
     {
         SendLastStatus(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_STATUS_DROPPED);
     }
@@ -704,7 +704,7 @@ void NcpBase::HandleDatagramFromStack(otMessage *aMessage, void *aContext)
 
 void NcpBase::HandleDatagramFromStack(otMessage *aMessage)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     bool isSecure = otMessageIsLinkSecurityEnabled(aMessage);
     uint16_t length = otMessageGetLength(aMessage);
 
@@ -739,7 +739,7 @@ exit:
         otMessageFree(aMessage);
     }
 
-    if (errorCode != kThreadError_None)
+    if (errorCode != OT_ERROR_NONE)
     {
         SendLastStatus(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_STATUS_DROPPED);
         mDroppedOutboundIpFrameCounter++;
@@ -768,7 +768,7 @@ void NcpBase::HandleRawFrame(const RadioPacket *aFrame, void *aContext)
 
 void NcpBase::HandleRawFrame(const RadioPacket *aFrame)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint16_t flags = 0;
 
     if (!mIsRawStreamEnabled)
@@ -840,7 +840,7 @@ void NcpBase::HandleActiveScanResult_Jump(otActiveScanResult *aResult, void *aCo
 
 void NcpBase::HandleActiveScanResult(otActiveScanResult *aResult)
 {
-    ThreadError errorCode;
+    otError errorCode;
 
     if (aResult)
     {
@@ -894,7 +894,7 @@ void NcpBase::HandleActiveScanResult(otActiveScanResult *aResult)
         // If we could not send the end of scan indicator message now (no
         // buffer space), we set `mShouldSignalEndOfScan` to true to send
         // it out when buffer space becomes available.
-        if (errorCode != kThreadError_None)
+        if (errorCode != OT_ERROR_NONE)
         {
             mShouldSignalEndOfScan = true;
         }
@@ -908,7 +908,7 @@ void NcpBase::HandleEnergyScanResult_Jump(otEnergyScanResult *aResult, void *aCo
 
 void NcpBase::HandleEnergyScanResult(otEnergyScanResult *aResult)
 {
-    ThreadError errorCode;
+    otError errorCode;
 
     if (aResult)
     {
@@ -936,7 +936,7 @@ void NcpBase::HandleEnergyScanResult(otEnergyScanResult *aResult)
         // If we could not send the end of scan indicator message now (no
         // buffer space), we set `mShouldSignalEndOfScan` to true to send
         // it out when buffer space becomes available.
-        if (errorCode != kThreadError_None)
+        if (errorCode != OT_ERROR_NONE)
         {
             mShouldSignalEndOfScan = true;
         }
@@ -949,14 +949,14 @@ void NcpBase::HandleEnergyScanResult(otEnergyScanResult *aResult)
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
 
-void NcpBase::LinkRawReceiveDone(otInstance *, RadioPacket *aPacket, ThreadError aError)
+void NcpBase::LinkRawReceiveDone(otInstance *, RadioPacket *aPacket, otError aError)
 {
     sNcpInstance->LinkRawReceiveDone(aPacket, aError);
 }
 
-void NcpBase::LinkRawReceiveDone(RadioPacket *aPacket, ThreadError aError)
+void NcpBase::LinkRawReceiveDone(RadioPacket *aPacket, otError aError)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint16_t flags = 0;
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
@@ -973,11 +973,11 @@ void NcpBase::LinkRawReceiveDone(RadioPacket *aPacket, ThreadError aError)
             SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
             SPINEL_CMD_PROP_VALUE_IS,
             SPINEL_PROP_STREAM_RAW,
-            (aError == kThreadError_None) ? aPacket->mLength : 0
+            (aError == OT_ERROR_NONE) ? aPacket->mLength : 0
         )
     );
 
-    if (aError == kThreadError_None)
+    if (aError == OT_ERROR_NONE)
     {
         // Append the frame contents
         SuccessOrExit(
@@ -1016,12 +1016,12 @@ exit:
     return;
 }
 
-void NcpBase::LinkRawTransmitDone(otInstance *, RadioPacket *aPacket, bool aFramePending, ThreadError aError)
+void NcpBase::LinkRawTransmitDone(otInstance *, RadioPacket *aPacket, bool aFramePending, otError aError)
 {
     sNcpInstance->LinkRawTransmitDone(aPacket, aFramePending, aError);
 }
 
-void NcpBase::LinkRawTransmitDone(RadioPacket *, bool aFramePending, ThreadError aError)
+void NcpBase::LinkRawTransmitDone(RadioPacket *, bool aFramePending, otError aError)
 {
     if (mCurTransmitTID)
     {
@@ -1245,22 +1245,22 @@ exit:
 // MARK: Serial Traffic Glue
 // ----------------------------------------------------------------------------
 
-void NcpBase::HandleFrameTransmitDone(void *aContext, ThreadError aError)
+void NcpBase::HandleFrameTransmitDone(void *aContext, otError aError)
 {
     NcpBase *obj = static_cast<NcpBase *>(aContext);
     obj->HandleFrameTransmitDone(aError);
 }
 
-void NcpBase::HandleFrameTransmitDone(ThreadError aError)
+void NcpBase::HandleFrameTransmitDone(otError aError)
 {
     (void) aError;
 
     mHostPowerStateInProgress = false;
 }
 
-ThreadError NcpBase::OutboundFrameSend(void)
+otError NcpBase::OutboundFrameSend(void)
 {
-    ThreadError errorCode;
+    otError errorCode;
 
     SuccessOrExit(errorCode = OutboundFrameEnd());
 
@@ -1277,7 +1277,7 @@ void NcpBase::HandleReceive(const uint8_t *buf, uint16_t bufLength)
     spinel_ssize_t parsedLength;
     const uint8_t *arg_ptr = NULL;
     unsigned int arg_len = 0;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     spinel_tid_t tid = 0;
 
     parsedLength = spinel_datatype_unpack(buf, bufLength, SPINEL_DATATYPE_COMMAND_S SPINEL_DATATYPE_DATA_S, &header, &command, &arg_ptr, &arg_len);
@@ -1305,7 +1305,7 @@ void NcpBase::HandleReceive(const uint8_t *buf, uint16_t bufLength)
         errorCode = SendLastStatus(header, SPINEL_STATUS_PARSE_ERROR);
     }
 
-    if (errorCode == kThreadError_NoBufs)
+    if (errorCode == OT_ERROR_NO_BUFS)
     {
         // If we cannot send a response due to buffer space not being
         // available, we remember the TID of command so to send an
@@ -1432,13 +1432,13 @@ void NcpBase::IncrementFrameErrorCounter(void)
 // MARK: Inbound Command Handlers
 // ----------------------------------------------------------------------------
 
-ThreadError NcpBase::HandleCommand(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len)
+otError NcpBase::HandleCommand(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len)
 {
     unsigned i;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     // Skip if this isn't a spinel frame
-    VerifyOrExit((SPINEL_HEADER_FLAG & header) == SPINEL_HEADER_FLAG, errorCode = kThreadError_InvalidArgs);
+    VerifyOrExit((SPINEL_HEADER_FLAG & header) == SPINEL_HEADER_FLAG, errorCode = OT_ERROR_INVALID_ARGS);
 
     // We only support IID zero for now.
     VerifyOrExit(
@@ -1467,10 +1467,10 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::HandleCommandPropertyGet(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::HandleCommandPropertyGet(uint8_t header, spinel_prop_key_t key)
 {
     unsigned i;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     for (i = 0; i < sizeof(mGetPropertyHandlerTable) / sizeof(mGetPropertyHandlerTable[0]); i++)
     {
@@ -1492,11 +1492,11 @@ ThreadError NcpBase::HandleCommandPropertyGet(uint8_t header, spinel_prop_key_t 
     return errorCode;
 }
 
-ThreadError NcpBase::HandleCommandPropertySet(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::HandleCommandPropertySet(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                               uint16_t value_len)
 {
     unsigned i;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     for (i = 0; i < sizeof(mSetPropertyHandlerTable) / sizeof(mSetPropertyHandlerTable[0]); i++)
     {
@@ -1518,11 +1518,11 @@ ThreadError NcpBase::HandleCommandPropertySet(uint8_t header, spinel_prop_key_t 
     return errorCode;
 }
 
-ThreadError NcpBase::HandleCommandPropertyInsert(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::HandleCommandPropertyInsert(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                  uint16_t value_len)
 {
     unsigned i;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     for (i = 0; i < sizeof(mInsertPropertyHandlerTable) / sizeof(mInsertPropertyHandlerTable[0]); i++)
     {
@@ -1544,11 +1544,11 @@ ThreadError NcpBase::HandleCommandPropertyInsert(uint8_t header, spinel_prop_key
     return errorCode;
 }
 
-ThreadError NcpBase::HandleCommandPropertyRemove(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::HandleCommandPropertyRemove(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                  uint16_t value_len)
 {
     unsigned i;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     for (i = 0; i < sizeof(mRemovePropertyHandlerTable) / sizeof(mRemovePropertyHandlerTable[0]); i++)
     {
@@ -1576,7 +1576,7 @@ ThreadError NcpBase::HandleCommandPropertyRemove(uint8_t header, spinel_prop_key
 // ----------------------------------------------------------------------------
 
 
-ThreadError NcpBase::SendLastStatus(uint8_t header, spinel_status_t lastStatus)
+otError NcpBase::SendLastStatus(uint8_t header, spinel_status_t lastStatus)
 {
     if (SPINEL_HEADER_GET_IID(header) == 0)
     {
@@ -1592,10 +1592,10 @@ ThreadError NcpBase::SendLastStatus(uint8_t header, spinel_status_t lastStatus)
            );
 }
 
-ThreadError NcpBase::SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key,
+otError NcpBase::SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key,
                                         const char *pack_format, ...)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     va_list     args;
 
     va_start(args, pack_format);
@@ -1609,10 +1609,10 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key,
+otError NcpBase::SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key,
                                         const uint8_t *value_ptr, uint16_t value_len)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
     SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, command, key));
@@ -1623,9 +1623,9 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key, otMessage *aMessage)
+otError NcpBase::SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key, otMessage *aMessage)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
     SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, command, key));
@@ -1648,10 +1648,10 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::OutboundFrameFeedVPacked(const char *pack_format, va_list args)
+otError NcpBase::OutboundFrameFeedVPacked(const char *pack_format, va_list args)
 {
     uint8_t buf[96];
-    ThreadError errorCode = kThreadError_NoBufs;
+    otError errorCode = OT_ERROR_NO_BUFS;
     spinel_ssize_t packed_len;
 
     packed_len = spinel_datatype_vpack(buf, sizeof(buf), pack_format, args);
@@ -1664,9 +1664,9 @@ ThreadError NcpBase::OutboundFrameFeedVPacked(const char *pack_format, va_list a
     return errorCode;
 }
 
-ThreadError NcpBase::OutboundFrameFeedPacked(const char *pack_format, ...)
+otError NcpBase::OutboundFrameFeedPacked(const char *pack_format, ...)
 {
-    ThreadError errorCode;
+    otError errorCode;
     va_list args;
 
     va_start(args, pack_format);
@@ -1680,7 +1680,7 @@ ThreadError NcpBase::OutboundFrameFeedPacked(const char *pack_format, ...)
 // MARK: Individual Command Handlers
 // ----------------------------------------------------------------------------
 
-ThreadError NcpBase::CommandHandler_NOOP(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len)
+otError NcpBase::CommandHandler_NOOP(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len)
 {
     (void)command;
     (void)arg_ptr;
@@ -1689,10 +1689,10 @@ ThreadError NcpBase::CommandHandler_NOOP(uint8_t header, unsigned int command, c
     return SendLastStatus(header, SPINEL_STATUS_OK);
 }
 
-ThreadError NcpBase::CommandHandler_RESET(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+otError NcpBase::CommandHandler_RESET(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
                                           uint16_t arg_len)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     // We aren't using any of the arguments to this function.
     (void)header;
@@ -1713,7 +1713,7 @@ ThreadError NcpBase::CommandHandler_RESET(uint8_t header, unsigned int command, 
 
     errorCode = SendLastStatus(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_STATUS_RESET_SOFTWARE);
 
-    if (errorCode != kThreadError_None)
+    if (errorCode != OT_ERROR_NONE)
     {
         mChangedFlags |= NCP_PLAT_RESET_REASON;
         mUpdateChangedPropsTask.Post();
@@ -1722,12 +1722,12 @@ ThreadError NcpBase::CommandHandler_RESET(uint8_t header, unsigned int command, 
     return errorCode;
 }
 
-ThreadError NcpBase::CommandHandler_PROP_VALUE_GET(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+otError NcpBase::CommandHandler_PROP_VALUE_GET(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
                                                    uint16_t arg_len)
 {
     unsigned int propKey = 0;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(arg_ptr, arg_len, SPINEL_DATATYPE_UINT_PACKED_S, &propKey);
 
@@ -1745,14 +1745,14 @@ ThreadError NcpBase::CommandHandler_PROP_VALUE_GET(uint8_t header, unsigned int 
     return errorCode;
 }
 
-ThreadError NcpBase::CommandHandler_PROP_VALUE_SET(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+otError NcpBase::CommandHandler_PROP_VALUE_SET(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
                                                    uint16_t arg_len)
 {
     unsigned int propKey = 0;
     spinel_ssize_t parsedLength;
     const uint8_t *value_ptr;
     unsigned int value_len;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(arg_ptr, arg_len, SPINEL_DATATYPE_UINT_PACKED_S SPINEL_DATATYPE_DATA_S, &propKey, &value_ptr, &value_len);
 
@@ -1771,14 +1771,14 @@ ThreadError NcpBase::CommandHandler_PROP_VALUE_SET(uint8_t header, unsigned int 
     return errorCode;
 }
 
-ThreadError NcpBase::CommandHandler_PROP_VALUE_INSERT(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+otError NcpBase::CommandHandler_PROP_VALUE_INSERT(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
                                                       uint16_t arg_len)
 {
     unsigned int propKey = 0;
     spinel_ssize_t parsedLength;
     const uint8_t *value_ptr;
     unsigned int value_len;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(arg_ptr, arg_len, SPINEL_DATATYPE_UINT_PACKED_S SPINEL_DATATYPE_DATA_S, &propKey, &value_ptr, &value_len);
 
@@ -1797,14 +1797,14 @@ ThreadError NcpBase::CommandHandler_PROP_VALUE_INSERT(uint8_t header, unsigned i
     return errorCode;
 }
 
-ThreadError NcpBase::CommandHandler_PROP_VALUE_REMOVE(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+otError NcpBase::CommandHandler_PROP_VALUE_REMOVE(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
                                                       uint16_t arg_len)
 {
     unsigned int propKey = 0;
     spinel_ssize_t parsedLength;
     const uint8_t *value_ptr;
     unsigned int value_len;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(arg_ptr, arg_len, SPINEL_DATATYPE_UINT_PACKED_S SPINEL_DATATYPE_DATA_S, &propKey, &value_ptr, &value_len);
 
@@ -1823,7 +1823,7 @@ ThreadError NcpBase::CommandHandler_PROP_VALUE_REMOVE(uint8_t header, unsigned i
     return errorCode;
 }
 
-ThreadError NcpBase::CommandHandler_NET_SAVE(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+otError NcpBase::CommandHandler_NET_SAVE(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
                                              uint16_t arg_len)
 {
     (void)command;
@@ -1833,7 +1833,7 @@ ThreadError NcpBase::CommandHandler_NET_SAVE(uint8_t header, unsigned int comman
     return SendLastStatus(header, SPINEL_STATUS_UNIMPLEMENTED);
 }
 
-ThreadError NcpBase::CommandHandler_NET_CLEAR(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+otError NcpBase::CommandHandler_NET_CLEAR(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
                                               uint16_t arg_len)
 {
     (void)command;
@@ -1843,7 +1843,7 @@ ThreadError NcpBase::CommandHandler_NET_CLEAR(uint8_t header, unsigned int comma
     return SendLastStatus(header, ThreadErrorToSpinelStatus(otInstanceErasePersistentInfo(mInstance)));
 }
 
-ThreadError NcpBase::CommandHandler_NET_RECALL(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+otError NcpBase::CommandHandler_NET_RECALL(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
                                                uint16_t arg_len)
 {
     (void)command;
@@ -1858,12 +1858,12 @@ ThreadError NcpBase::CommandHandler_NET_RECALL(uint8_t header, unsigned int comm
 // ----------------------------------------------------------------------------
 
 
-ThreadError NcpBase::GetPropertyHandler_LAST_STATUS(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_LAST_STATUS(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(header, SPINEL_CMD_PROP_VALUE_IS, key, SPINEL_DATATYPE_UINT_PACKED_S, mLastStatus);
 }
 
-ThreadError NcpBase::GetPropertyHandler_PROTOCOL_VERSION(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_PROTOCOL_VERSION(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -1875,7 +1875,7 @@ ThreadError NcpBase::GetPropertyHandler_PROTOCOL_VERSION(uint8_t header, spinel_
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_INTERFACE_TYPE(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_INTERFACE_TYPE(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -1886,7 +1886,7 @@ ThreadError NcpBase::GetPropertyHandler_INTERFACE_TYPE(uint8_t header, spinel_pr
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_VENDOR_ID(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_VENDOR_ID(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -1897,9 +1897,9 @@ ThreadError NcpBase::GetPropertyHandler_VENDOR_ID(uint8_t header, spinel_prop_ke
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_CAPS(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_CAPS(uint8_t header, spinel_prop_key_t key)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
     SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS, key));
@@ -1946,7 +1946,7 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_NCP_VERSION(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_NCP_VERSION(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -1957,7 +1957,7 @@ ThreadError NcpBase::GetPropertyHandler_NCP_VERSION(uint8_t header, spinel_prop_
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_INTERFACE_COUNT(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_INTERFACE_COUNT(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -1968,7 +1968,7 @@ ThreadError NcpBase::GetPropertyHandler_INTERFACE_COUNT(uint8_t header, spinel_p
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key)
 {
     // Always online at the moment
     return SendPropertyUpdate(
@@ -1980,7 +1980,7 @@ ThreadError NcpBase::GetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_HWADDR(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_HWADDR(uint8_t header, spinel_prop_key_t key)
 {
     otExtAddress hwAddr;
     otLinkGetFactoryAssignedIeeeEui64(mInstance, &hwAddr);
@@ -1994,7 +1994,7 @@ ThreadError NcpBase::GetPropertyHandler_HWADDR(uint8_t header, spinel_prop_key_t
             );
 }
 
-ThreadError NcpBase::GetPropertyHandler_LOCK(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_LOCK(uint8_t header, spinel_prop_key_t key)
 {
     // TODO: Implement property lock (Needs API!)
     (void)key;
@@ -2002,7 +2002,7 @@ ThreadError NcpBase::GetPropertyHandler_LOCK(uint8_t header, spinel_prop_key_t k
     return SendLastStatus(header, SPINEL_STATUS_UNIMPLEMENTED);
 }
 
-ThreadError NcpBase::GetPropertyHandler_HOST_POWER_STATE(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_HOST_POWER_STATE(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2013,7 +2013,7 @@ ThreadError NcpBase::GetPropertyHandler_HOST_POWER_STATE(uint8_t header, spinel_
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                 header,
@@ -2028,7 +2028,7 @@ ThreadError NcpBase::GetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_
             );
 }
 
-ThreadError NcpBase::GetPropertyHandler_PHY_FREQ(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_PHY_FREQ(uint8_t header, spinel_prop_key_t key)
 {
     uint32_t freq_khz(0);
     const uint8_t chan(otLinkGetChannel(mInstance));
@@ -2055,12 +2055,12 @@ ThreadError NcpBase::GetPropertyHandler_PHY_FREQ(uint8_t header, spinel_prop_key
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_PHY_CHAN_SUPPORTED(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_PHY_CHAN_SUPPORTED(uint8_t header, spinel_prop_key_t key)
 {
     return GetPropertyHandler_ChannelMaskHelper(header, key, mSupportedChannelMask);
 }
 
-ThreadError NcpBase::GetPropertyHandler_PHY_CHAN(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_PHY_CHAN(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2071,7 +2071,7 @@ ThreadError NcpBase::GetPropertyHandler_PHY_CHAN(uint8_t header, spinel_prop_key
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_PHY_RSSI(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_PHY_RSSI(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2082,7 +2082,7 @@ ThreadError NcpBase::GetPropertyHandler_PHY_RSSI(uint8_t header, spinel_prop_key
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_PHY_TX_POWER(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_PHY_TX_POWER(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2093,7 +2093,7 @@ ThreadError NcpBase::GetPropertyHandler_PHY_TX_POWER(uint8_t header, spinel_prop
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_PHY_RX_SENSITIVITY(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_PHY_RX_SENSITIVITY(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2104,9 +2104,9 @@ ThreadError NcpBase::GetPropertyHandler_PHY_RX_SENSITIVITY(uint8_t header, spine
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_prop_key_t key)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
     if (otLinkRawIsEnabled(mInstance))
@@ -2167,7 +2167,7 @@ ThreadError NcpBase::GetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_pr
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_MAC_SCAN_PERIOD(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_MAC_SCAN_PERIOD(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2178,9 +2178,9 @@ ThreadError NcpBase::GetPropertyHandler_MAC_SCAN_PERIOD(uint8_t header, spinel_p
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_ChannelMaskHelper(uint8_t header, spinel_prop_key_t key, uint32_t channel_mask)
+otError NcpBase::GetPropertyHandler_ChannelMaskHelper(uint8_t header, spinel_prop_key_t key, uint32_t channel_mask)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
     SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS, key));
@@ -2199,12 +2199,12 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_MAC_SCAN_MASK(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_MAC_SCAN_MASK(uint8_t header, spinel_prop_key_t key)
 {
     return GetPropertyHandler_ChannelMaskHelper(header, key, mChannelMask);
 }
 
-ThreadError NcpBase::GetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2215,7 +2215,7 @@ ThreadError NcpBase::GetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_pr
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_MAC_PROMISCUOUS_MODE(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_MAC_PROMISCUOUS_MODE(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2228,7 +2228,7 @@ ThreadError NcpBase::GetPropertyHandler_MAC_PROMISCUOUS_MODE(uint8_t header, spi
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_MAC_15_4_LADDR(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_MAC_15_4_LADDR(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2239,7 +2239,7 @@ ThreadError NcpBase::GetPropertyHandler_MAC_15_4_LADDR(uint8_t header, spinel_pr
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_MAC_15_4_SADDR(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_MAC_15_4_SADDR(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2250,7 +2250,7 @@ ThreadError NcpBase::GetPropertyHandler_MAC_15_4_SADDR(uint8_t header, spinel_pr
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_MAC_EXTENDED_ADDR(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_MAC_EXTENDED_ADDR(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2261,7 +2261,7 @@ ThreadError NcpBase::GetPropertyHandler_MAC_EXTENDED_ADDR(uint8_t header, spinel
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_MAC_RAW_STREAM_ENABLED(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_MAC_RAW_STREAM_ENABLED(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2272,7 +2272,7 @@ ThreadError NcpBase::GetPropertyHandler_MAC_RAW_STREAM_ENABLED(uint8_t header, s
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_NET_SAVED(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_NET_SAVED(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2283,7 +2283,7 @@ ThreadError NcpBase::GetPropertyHandler_NET_SAVED(uint8_t header, spinel_prop_ke
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_NET_IF_UP(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_NET_IF_UP(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2294,7 +2294,7 @@ ThreadError NcpBase::GetPropertyHandler_NET_IF_UP(uint8_t header, spinel_prop_ke
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_NET_STACK_UP(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_NET_STACK_UP(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2305,7 +2305,7 @@ ThreadError NcpBase::GetPropertyHandler_NET_STACK_UP(uint8_t header, spinel_prop
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key_t key)
 {
     spinel_net_role_t role(SPINEL_NET_ROLE_DETACHED);
 
@@ -2339,7 +2339,7 @@ ThreadError NcpBase::GetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_NET_NETWORK_NAME(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_NET_NETWORK_NAME(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2350,7 +2350,7 @@ ThreadError NcpBase::GetPropertyHandler_NET_NETWORK_NAME(uint8_t header, spinel_
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_NET_XPANID(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_NET_XPANID(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2362,7 +2362,7 @@ ThreadError NcpBase::GetPropertyHandler_NET_XPANID(uint8_t header, spinel_prop_k
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_NET_MASTER_KEY(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_NET_MASTER_KEY(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2374,7 +2374,7 @@ ThreadError NcpBase::GetPropertyHandler_NET_MASTER_KEY(uint8_t header, spinel_pr
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_NET_KEY_SEQUENCE_COUNTER(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_NET_KEY_SEQUENCE_COUNTER(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2385,7 +2385,7 @@ ThreadError NcpBase::GetPropertyHandler_NET_KEY_SEQUENCE_COUNTER(uint8_t header,
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_NET_PARTITION_ID(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_NET_PARTITION_ID(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2396,7 +2396,7 @@ ThreadError NcpBase::GetPropertyHandler_NET_PARTITION_ID(uint8_t header, spinel_
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_NET_KEY_SWITCH_GUARDTIME(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_NET_KEY_SWITCH_GUARDTIME(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2407,7 +2407,7 @@ ThreadError NcpBase::GetPropertyHandler_NET_KEY_SWITCH_GUARDTIME(uint8_t header,
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_NETWORK_DATA_VERSION(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_NETWORK_DATA_VERSION(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2418,7 +2418,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_NETWORK_DATA_VERSION(uint8_t head
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_STABLE_NETWORK_DATA_VERSION(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_STABLE_NETWORK_DATA_VERSION(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2429,9 +2429,9 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_STABLE_NETWORK_DATA_VERSION(uint8
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_NETWORK_DATA(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_NETWORK_DATA(uint8_t header, spinel_prop_key_t key)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint8_t network_data[255];
     uint8_t network_data_len = 255;
 
@@ -2451,9 +2451,9 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_STABLE_NETWORK_DATA(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_STABLE_NETWORK_DATA(uint8_t header, spinel_prop_key_t key)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint8_t network_data[255];
     uint8_t network_data_len = 255;
 
@@ -2473,9 +2473,9 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_LEADER_NETWORK_DATA(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_LEADER_NETWORK_DATA(uint8_t header, spinel_prop_key_t key)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint8_t network_data[255];
     uint8_t network_data_len = 255;
 
@@ -2495,9 +2495,9 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_STABLE_LEADER_NETWORK_DATA(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_STABLE_LEADER_NETWORK_DATA(uint8_t header, spinel_prop_key_t key)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint8_t network_data[255];
     uint8_t network_data_len = 255;
 
@@ -2517,7 +2517,7 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_LEADER_RID(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_LEADER_RID(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2529,7 +2529,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_LEADER_RID(uint8_t header, spinel
 }
 
 #if OPENTHREAD_FTD
-ThreadError NcpBase::GetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2541,7 +2541,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT(uint8_t heade
 }
 #endif  // OPENTHREAD_FTD
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2552,14 +2552,14 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_LEADER_WEIGHT(uint8_t header, spi
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_LEADER_ADDR(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_LEADER_ADDR(uint8_t header, spinel_prop_key_t key)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     otIp6Address address;
 
     errorCode = otThreadGetLeaderRloc(mInstance, &address);
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         errorCode = SendPropertyUpdate(
                         header,
@@ -2577,14 +2577,14 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_LEADER_ADDR(uint8_t header, spine
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_PARENT(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_PARENT(uint8_t header, spinel_prop_key_t key)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     otRouterInfo parentInfo;
 
     errorCode = otThreadGetParentInfo(mInstance, &parentInfo);
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         errorCode = SendPropertyUpdate(
                         header,
@@ -2604,9 +2604,9 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_PARENT(uint8_t header, spinel_pro
 }
 
 #if OPENTHREAD_FTD
-ThreadError NcpBase::GetPropertyHandler_THREAD_CHILD_TABLE(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_CHILD_TABLE(uint8_t header, spinel_prop_key_t key)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     otChildInfo childInfo;
     uint8_t maxChildren;
     uint8_t modeFlags;
@@ -2622,7 +2622,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_CHILD_TABLE(uint8_t header, spine
     {
         errorCode = otThreadGetChildInfoByIndex(mInstance, index, &childInfo);
 
-        if (errorCode != kThreadError_None)
+        if (errorCode != OT_ERROR_NONE)
         {
             continue;
         }
@@ -2682,9 +2682,9 @@ exit:
 }
 #endif  // OPENTHREAD_FTD
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_NEIGHBOR_TABLE(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_NEIGHBOR_TABLE(uint8_t header, spinel_prop_key_t key)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     otNeighborInfoIterator iter = OT_NEIGHBOR_INFO_ITERATOR_INIT;
     otNeighborInfo neighInfo;
     uint8_t modeFlags;
@@ -2694,7 +2694,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_NEIGHBOR_TABLE(uint8_t header, sp
     SuccessOrExit(errorCode = OutboundFrameBegin());
     SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS, key));
 
-    while (otThreadGetNextNeighborInfo(mInstance, &iter, &neighInfo) == kThreadError_None)
+    while (otThreadGetNextNeighborInfo(mInstance, &iter, &neighInfo) == OT_ERROR_NONE)
     {
         modeFlags = 0;
 
@@ -2752,9 +2752,9 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint8_t num_entries = 0;
     const uint16_t *ports = otIp6GetUnsecurePorts(mInstance, &num_entries);
 
@@ -2772,7 +2772,7 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
         header,
@@ -2784,7 +2784,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8
 }
 
 #if OPENTHREAD_FTD
-ThreadError NcpBase::GetPropertyHandler_THREAD_ROUTER_ROLE_ENABLED(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_ROUTER_ROLE_ENABLED(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
         header,
@@ -2796,9 +2796,9 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_ROUTER_ROLE_ENABLED(uint8_t heade
 }
 #endif  // OPENTHREAD_FTD
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     otBorderRouterConfig border_router_config;
     uint8_t flags;
 
@@ -2812,7 +2812,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spin
     {
         errorCode = otNetDataGetNextPrefixInfo(mInstance, false, &iter, &border_router_config);
 
-        if (errorCode != kThreadError_None)
+        if (errorCode != OT_ERROR_NONE)
         {
             break;
         }
@@ -2840,7 +2840,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spin
     {
         errorCode = otNetDataGetNextPrefixInfo(mInstance, true, &iter, &border_router_config);
 
-        if (errorCode != kThreadError_None)
+        if (errorCode != OT_ERROR_NONE)
         {
             break;
         }
@@ -2870,7 +2870,7 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_DISCOVERY_SCAN_JOINER_FLAG(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_DISCOVERY_SCAN_JOINER_FLAG(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2881,7 +2881,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_DISCOVERY_SCAN_JOINER_FLAG(uint8_
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_DISCOVERY_SCAN_ENABLE_FILTERING(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_DISCOVERY_SCAN_ENABLE_FILTERING(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2892,7 +2892,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_DISCOVERY_SCAN_ENABLE_FILTERING(u
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_DISCOVERY_SCAN_PANID(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_DISCOVERY_SCAN_PANID(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -2903,9 +2903,9 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_DISCOVERY_SCAN_PANID(uint8_t head
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_IPV6_ML_PREFIX(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_IPV6_ML_PREFIX(uint8_t header, spinel_prop_key_t key)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     const uint8_t *ml_prefix = otThreadGetMeshLocalPrefix(mInstance);
 
     if (ml_prefix)
@@ -2939,9 +2939,9 @@ ThreadError NcpBase::GetPropertyHandler_IPV6_ML_PREFIX(uint8_t header, spinel_pr
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_IPV6_ML_ADDR(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_IPV6_ML_ADDR(uint8_t header, spinel_prop_key_t key)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     const otIp6Address *ml64 = otThreadGetMeshLocalEid(mInstance);
 
     if (ml64)
@@ -2967,7 +2967,7 @@ ThreadError NcpBase::GetPropertyHandler_IPV6_ML_ADDR(uint8_t header, spinel_prop
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_IPV6_LL_ADDR(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_IPV6_LL_ADDR(uint8_t header, spinel_prop_key_t key)
 {
     // TODO!
     (void)key;
@@ -2975,9 +2975,9 @@ ThreadError NcpBase::GetPropertyHandler_IPV6_LL_ADDR(uint8_t header, spinel_prop
     return SendLastStatus(header, SPINEL_STATUS_UNIMPLEMENTED);
 }
 
-ThreadError NcpBase::GetPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     mDisableStreamWrite = true;
 
@@ -3003,7 +3003,7 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_IPV6_ROUTE_TABLE(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_IPV6_ROUTE_TABLE(uint8_t header, spinel_prop_key_t key)
 {
     // TODO: Implement get route table
     (void)key;
@@ -3011,7 +3011,7 @@ ThreadError NcpBase::GetPropertyHandler_IPV6_ROUTE_TABLE(uint8_t header, spinel_
     return SendLastStatus(header, SPINEL_STATUS_UNIMPLEMENTED);
 }
 
-ThreadError NcpBase::GetPropertyHandler_IPV6_ICMP_PING_OFFLOAD(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_IPV6_ICMP_PING_OFFLOAD(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -3022,7 +3022,7 @@ ThreadError NcpBase::GetPropertyHandler_IPV6_ICMP_PING_OFFLOAD(uint8_t header, s
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_RLOC16_DEBUG_PASSTHRU(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_RLOC16_DEBUG_PASSTHRU(uint8_t header, spinel_prop_key_t key)
 {
     // Note reverse logic: passthru enabled = filter disabled
     return SendPropertyUpdate(
@@ -3034,9 +3034,9 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_RLOC16_DEBUG_PASSTHRU(uint8_t hea
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     otExternalRouteConfig external_route_config;
     otNetworkDataIterator iter = OT_NETWORK_DATA_ITERATOR_INIT;
     uint8_t flags;
@@ -3047,7 +3047,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spin
     SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS,
                                                       key));
 
-    while (otNetDataGetNextRoute(mInstance, false, &iter, &external_route_config) == kThreadError_None)
+    while (otNetDataGetNextRoute(mInstance, false, &iter, &external_route_config) == OT_ERROR_NONE)
     {
         flags = static_cast<uint8_t>(external_route_config.mPreference);
         flags <<= SPINEL_NET_FLAG_PREFERENCE_OFFSET;
@@ -3073,7 +3073,7 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_key_t key)
 {
     // TODO: Implement explicit data poll.
     (void)key;
@@ -3082,7 +3082,7 @@ ThreadError NcpBase::GetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_k
 }
 
 #if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
-ThreadError NcpBase::GetPropertyHandler_BA_PROXY_ENABLED(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_BA_PROXY_ENABLED(uint8_t header, spinel_prop_key_t key)
 {
    return SendPropertyUpdate(
                header,
@@ -3096,7 +3096,7 @@ ThreadError NcpBase::GetPropertyHandler_BA_PROXY_ENABLED(uint8_t header, spinel_
 
 #if OPENTHREAD_ENABLE_JAM_DETECTION
 
-ThreadError NcpBase::GetPropertyHandler_JAM_DETECT_ENABLE(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_JAM_DETECT_ENABLE(uint8_t header, spinel_prop_key_t key)
 {
    return SendPropertyUpdate(
                header,
@@ -3107,7 +3107,7 @@ ThreadError NcpBase::GetPropertyHandler_JAM_DETECT_ENABLE(uint8_t header, spinel
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_JAM_DETECTED(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_JAM_DETECTED(uint8_t header, spinel_prop_key_t key)
 {
    return SendPropertyUpdate(
                header,
@@ -3118,7 +3118,7 @@ ThreadError NcpBase::GetPropertyHandler_JAM_DETECTED(uint8_t header, spinel_prop
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_JAM_DETECT_RSSI_THRESHOLD(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_JAM_DETECT_RSSI_THRESHOLD(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -3129,7 +3129,7 @@ ThreadError NcpBase::GetPropertyHandler_JAM_DETECT_RSSI_THRESHOLD(uint8_t header
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_JAM_DETECT_WINDOW(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_JAM_DETECT_WINDOW(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -3140,7 +3140,7 @@ ThreadError NcpBase::GetPropertyHandler_JAM_DETECT_WINDOW(uint8_t header, spinel
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_JAM_DETECT_BUSY(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_JAM_DETECT_BUSY(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -3151,7 +3151,7 @@ ThreadError NcpBase::GetPropertyHandler_JAM_DETECT_BUSY(uint8_t header, spinel_p
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_JAM_DETECT_HISTORY_BITMAP(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_JAM_DETECT_HISTORY_BITMAP(uint8_t header, spinel_prop_key_t key)
 {
     uint64_t historyBitmap = otJamDetectionGetHistoryBitmap(mInstance);
 
@@ -3167,11 +3167,11 @@ ThreadError NcpBase::GetPropertyHandler_JAM_DETECT_HISTORY_BITMAP(uint8_t header
 
 #endif // OPENTHREAD_ENABLE_JAM_DETECTION
 
-ThreadError NcpBase::GetPropertyHandler_MAC_CNTR(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_MAC_CNTR(uint8_t header, spinel_prop_key_t key)
 {
     uint32_t value;
     const otMacCounters *macCounters;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     macCounters = otLinkGetCounters(mInstance);
 
@@ -3321,10 +3321,10 @@ bail:
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_NCP_CNTR(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_NCP_CNTR(uint8_t header, spinel_prop_key_t key)
 {
     uint32_t value;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     switch (key)
     {
@@ -3386,9 +3386,9 @@ bail:
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_MSG_BUFFER_COUNTERS(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_MSG_BUFFER_COUNTERS(uint8_t header, spinel_prop_key_t key)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     otBufferInfo bufferInfo;
 
     otMessageGetBufferInfo(mInstance, &bufferInfo);
@@ -3419,7 +3419,7 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_DEBUG_TEST_ASSERT(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_DEBUG_TEST_ASSERT(uint8_t header, spinel_prop_key_t key)
 {
     assert(false);
 
@@ -3437,7 +3437,7 @@ ThreadError NcpBase::GetPropertyHandler_DEBUG_TEST_ASSERT(uint8_t header, spinel
             );
 }
 
-ThreadError NcpBase::GetPropertyHandler_DEBUG_NCP_LOG_LEVEL(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_DEBUG_NCP_LOG_LEVEL(uint8_t header, spinel_prop_key_t key)
 {
     uint8_t logLevel = 0;
 
@@ -3473,21 +3473,21 @@ ThreadError NcpBase::GetPropertyHandler_DEBUG_NCP_LOG_LEVEL(uint8_t header, spin
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key)
 {
     otMacWhitelistEntry entry;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     mDisableStreamWrite = true;
 
     SuccessOrExit(errorCode = OutboundFrameBegin());
     SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_COMMAND_PROP_S, header, SPINEL_CMD_PROP_VALUE_IS, key));
 
-    for (uint8_t i = 0; (i != 255) && (errorCode == kThreadError_None); i++)
+    for (uint8_t i = 0; (i != 255) && (errorCode == OT_ERROR_NONE); i++)
     {
         errorCode = otLinkGetWhitelistEntry(mInstance, i, &entry);
 
-        if (errorCode != kThreadError_None)
+        if (errorCode != OT_ERROR_NONE)
         {
             break;
         }
@@ -3510,7 +3510,7 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::GetPropertyHandler_MAC_WHITELIST_ENABLED(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_MAC_WHITELIST_ENABLED(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -3522,7 +3522,7 @@ ThreadError NcpBase::GetPropertyHandler_MAC_WHITELIST_ENABLED(uint8_t header, sp
 }
 
 #if OPENTHREAD_FTD
-ThreadError NcpBase::GetPropertyHandler_NET_PSKC(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_NET_PSKC(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -3535,7 +3535,7 @@ ThreadError NcpBase::GetPropertyHandler_NET_PSKC(uint8_t header, spinel_prop_key
 }
 #endif // OPENTHREAD_FTD
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_key_t key)
 {
     uint8_t numeric_mode(0);
     otLinkModeConfig mode_config(otThreadGetLinkMode(mInstance));
@@ -3570,7 +3570,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_
 }
 
 #if OPENTHREAD_FTD
-ThreadError NcpBase::GetPropertyHandler_THREAD_CHILD_COUNT_MAX(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_CHILD_COUNT_MAX(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -3582,7 +3582,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_CHILD_COUNT_MAX(uint8_t header, s
 }
 #endif  // OPENTHREAD_FTD
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_CHILD_TIMEOUT(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_CHILD_TIMEOUT(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -3593,7 +3593,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_CHILD_TIMEOUT(uint8_t header, spi
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_RLOC16(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_RLOC16(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -3605,7 +3605,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_RLOC16(uint8_t header, spinel_pro
 }
 
 #if OPENTHREAD_FTD
-ThreadError NcpBase::GetPropertyHandler_THREAD_ROUTER_UPGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_ROUTER_UPGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -3616,7 +3616,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_ROUTER_UPGRADE_THRESHOLD(uint8_t 
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_ROUTER_DOWNGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_ROUTER_DOWNGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -3627,7 +3627,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_ROUTER_DOWNGRADE_THRESHOLD(uint8_
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_ROUTER_SELECTION_JITTER(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_ROUTER_SELECTION_JITTER(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -3638,7 +3638,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_ROUTER_SELECTION_JITTER(uint8_t h
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -3649,7 +3649,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t heade
            );
 }
 
-ThreadError NcpBase::GetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -3662,7 +3662,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header
 #endif  // OPENTHREAD_FTD
 
 #if OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
-ThreadError NcpBase::GetPropertyHandler_THREAD_COMMISSIONER_ENABLED(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_THREAD_COMMISSIONER_ENABLED(uint8_t header, spinel_prop_key_t key)
 {
     bool isEnabled = false;
     if (otCommissionerGetState(mInstance) == kCommissionerStateActive)
@@ -3678,7 +3678,7 @@ ThreadError NcpBase::GetPropertyHandler_THREAD_COMMISSIONER_ENABLED(uint8_t head
 }
 #endif
 
-ThreadError NcpBase::GetPropertyHandler_NET_REQUIRE_JOIN_EXISTING(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_NET_REQUIRE_JOIN_EXISTING(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -3690,7 +3690,7 @@ ThreadError NcpBase::GetPropertyHandler_NET_REQUIRE_JOIN_EXISTING(uint8_t header
 }
 
 #if OPENTHREAD_ENABLE_LEGACY
-ThreadError NcpBase::GetPropertyHandler_NEST_LEGACY_ULA_PREFIX(uint8_t header, spinel_prop_key_t key)
+otError NcpBase::GetPropertyHandler_NEST_LEGACY_ULA_PREFIX(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
@@ -3707,7 +3707,7 @@ ThreadError NcpBase::GetPropertyHandler_NEST_LEGACY_ULA_PREFIX(uint8_t header, s
 // MARK: Individual Property Setters
 // ----------------------------------------------------------------------------
 
-ThreadError NcpBase::SetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                     uint16_t value_len)
 {
     // TODO: Implement POWER_STATE
@@ -3718,12 +3718,12 @@ ThreadError NcpBase::SetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_
     return SendLastStatus(header, SPINEL_STATUS_UNIMPLEMENTED);
 }
 
-ThreadError NcpBase::SetPropertyHandler_HOST_POWER_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_HOST_POWER_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                          uint16_t value_len)
 {
     uint8_t value;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -3757,10 +3757,10 @@ ThreadError NcpBase::SetPropertyHandler_HOST_POWER_STATE(uint8_t header, spinel_
     }
     else
     {
-        errorCode = kThreadError_Parse;
+        errorCode = OT_ERROR_PARSE;
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         mHostPowerStateHeader = 0;
 
@@ -3768,7 +3768,7 @@ ThreadError NcpBase::SetPropertyHandler_HOST_POWER_STATE(uint8_t header, spinel_
 
         if (mHostPowerState != SPINEL_HOST_POWER_STATE_ONLINE)
         {
-            if (errorCode == kThreadError_None)
+            if (errorCode == OT_ERROR_NONE)
             {
                 mTxFrameBuffer.SetFrameTransmitCallback(&NcpBase::HandleFrameTransmitDone, this);
             }
@@ -3776,7 +3776,7 @@ ThreadError NcpBase::SetPropertyHandler_HOST_POWER_STATE(uint8_t header, spinel_
             mHostPowerStateInProgress = true;
         }
 
-        if (errorCode != kThreadError_None)
+        if (errorCode != OT_ERROR_NONE)
         {
             mHostPowerStateHeader = header;
         }
@@ -3791,12 +3791,12 @@ ThreadError NcpBase::SetPropertyHandler_HOST_POWER_STATE(uint8_t header, spinel_
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
 
-ThreadError NcpBase::SetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                     uint16_t value_len)
 {
     bool value = false;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -3822,7 +3822,7 @@ ThreadError NcpBase::SetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_
             errorCode = otLinkRawSetEnable(mInstance, true);
 
             // If we have raw stream enabled already, start receiving
-            if (errorCode == kThreadError_None && mIsRawStreamEnabled)
+            if (errorCode == OT_ERROR_NONE && mIsRawStreamEnabled)
             {
                 errorCode = otLinkRawReceive(mInstance, mCurReceiveChannel, &NcpBase::LinkRawReceiveDone);
             }
@@ -3830,10 +3830,10 @@ ThreadError NcpBase::SetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_
     }
     else
     {
-        errorCode = kThreadError_Parse;
+        errorCode = OT_ERROR_PARSE;
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         errorCode = HandleCommandPropertyGet(header, key);
     }
@@ -3847,12 +3847,12 @@ ThreadError NcpBase::SetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_
 
 #endif // OPENTHREAD_ENABLE_RAW_LINK_API
 
-ThreadError NcpBase::SetPropertyHandler_PHY_TX_POWER(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_PHY_TX_POWER(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                      uint16_t value_len)
 {
     int8_t value = 0;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -3875,12 +3875,12 @@ ThreadError NcpBase::SetPropertyHandler_PHY_TX_POWER(uint8_t header, spinel_prop
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_PHY_CHAN(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_PHY_CHAN(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                  uint16_t value_len)
 {
     unsigned int i = 0;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -3895,7 +3895,7 @@ ThreadError NcpBase::SetPropertyHandler_PHY_CHAN(uint8_t header, spinel_prop_key
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
 
-         if (errorCode == kThreadError_None)
+         if (errorCode == OT_ERROR_NONE)
          {
              // Cache the channel. If the raw link layer isn't enabled yet, the otSetChannel call
              // doesn't call into the radio layer to set the channel. We will have to do it
@@ -3912,7 +3912,7 @@ ThreadError NcpBase::SetPropertyHandler_PHY_CHAN(uint8_t header, spinel_prop_key
 
 #endif // OPENTHREAD_ENABLE_RAW_LINK_API
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = HandleCommandPropertyGet(header, key);
         }
@@ -3929,12 +3929,12 @@ ThreadError NcpBase::SetPropertyHandler_PHY_CHAN(uint8_t header, spinel_prop_key
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_MAC_PROMISCUOUS_MODE(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_MAC_PROMISCUOUS_MODE(uint8_t header, spinel_prop_key_t key,
                                                              const uint8_t *value_ptr, uint16_t value_len)
 {
     uint8_t i = 0;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -3949,21 +3949,21 @@ ThreadError NcpBase::SetPropertyHandler_MAC_PROMISCUOUS_MODE(uint8_t header, spi
         {
         case SPINEL_MAC_PROMISCUOUS_MODE_OFF:
             otPlatRadioSetPromiscuous(mInstance, false);
-            errorCode = kThreadError_None;
+            errorCode = OT_ERROR_NONE;
             break;
 
         case SPINEL_MAC_PROMISCUOUS_MODE_NETWORK:
         case SPINEL_MAC_PROMISCUOUS_MODE_FULL:
             otPlatRadioSetPromiscuous(mInstance, true);
-            errorCode = kThreadError_None;
+            errorCode = OT_ERROR_NONE;
             break;
 
         default:
-            errorCode = kThreadError_InvalidArgs;
+            errorCode = OT_ERROR_INVALID_ARGS;
             break;
         }
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = HandleCommandPropertyGet(header, key);
         }
@@ -3980,10 +3980,10 @@ ThreadError NcpBase::SetPropertyHandler_MAC_PROMISCUOUS_MODE(uint8_t header, spi
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_MAC_SCAN_MASK(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_MAC_SCAN_MASK(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                       uint16_t value_len)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint32_t new_mask(0);
 
     for (; value_len != 0; value_len--, value_ptr++)
@@ -3992,14 +3992,14 @@ ThreadError NcpBase::SetPropertyHandler_MAC_SCAN_MASK(uint8_t header, spinel_pro
             || (mSupportedChannelMask & (1 << value_ptr[0])) == 0
            )
         {
-            errorCode = kThreadError_InvalidArgs;
+            errorCode = OT_ERROR_INVALID_ARGS;
             break;
         }
 
         new_mask |= (1 << value_ptr[0]);
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         mChannelMask = new_mask;
         errorCode = HandleCommandPropertyGet(header, key);
@@ -4012,12 +4012,12 @@ ThreadError NcpBase::SetPropertyHandler_MAC_SCAN_MASK(uint8_t header, spinel_pro
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_MAC_SCAN_PERIOD(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_MAC_SCAN_PERIOD(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                         uint16_t value_len)
 {
     uint16_t tmp(mScanPeriod);
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -4039,12 +4039,12 @@ ThreadError NcpBase::SetPropertyHandler_MAC_SCAN_PERIOD(uint8_t header, spinel_p
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_NET_REQUIRE_JOIN_EXISTING(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_NET_REQUIRE_JOIN_EXISTING(uint8_t header, spinel_prop_key_t key,
                                                                   const uint8_t *value_ptr, uint16_t value_len)
 {
     bool tmp(mRequireJoinExistingNetwork);
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -4081,12 +4081,12 @@ uint8_t IndexOfMSB(uint32_t aValue)
     return index;
 }
 
-ThreadError NcpBase::SetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                        uint16_t value_len)
 {
     uint8_t state = 0;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -4100,14 +4100,14 @@ ThreadError NcpBase::SetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_pr
         switch (state)
         {
         case SPINEL_SCAN_STATE_IDLE:
-            errorCode = kThreadError_None;
+            errorCode = OT_ERROR_NONE;
             break;
 
         case SPINEL_SCAN_STATE_BEACON:
 #if OPENTHREAD_ENABLE_RAW_LINK_API
             if (otLinkRawIsEnabled(mInstance))
             {
-                errorCode = kThreadError_NotImplemented;
+                errorCode = OT_ERROR_NOT_IMPLEMENTED;
             }
             else
 #endif // OPENTHREAD_ENABLE_RAW_LINK_API
@@ -4121,7 +4121,7 @@ ThreadError NcpBase::SetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_pr
                             );
             }
 
-            if (errorCode == kThreadError_None)
+            if (errorCode == OT_ERROR_NONE)
             {
                 mShouldSignalEndOfScan = false;
             }
@@ -4150,12 +4150,12 @@ ThreadError NcpBase::SetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_pr
                     }
                     else
                     {
-                        errorCode = kThreadError_InvalidArgs;
+                        errorCode = OT_ERROR_INVALID_ARGS;
                     }
                 }
                 else
                 {
-                    errorCode = kThreadError_InvalidState;
+                    errorCode = OT_ERROR_INVALID_STATE;
                 }
             }
             else
@@ -4170,7 +4170,7 @@ ThreadError NcpBase::SetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_pr
                             );
             }
 
-            if (errorCode == kThreadError_None)
+            if (errorCode == OT_ERROR_NONE)
             {
                 mShouldSignalEndOfScan = false;
             }
@@ -4189,7 +4189,7 @@ ThreadError NcpBase::SetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_pr
                             this
                         );
 
-            if (errorCode == kThreadError_None)
+            if (errorCode == OT_ERROR_NONE)
             {
                 mShouldSignalEndOfScan = false;
             }
@@ -4197,11 +4197,11 @@ ThreadError NcpBase::SetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_pr
             break;
 
         default:
-            errorCode = kThreadError_InvalidArgs;
+            errorCode = OT_ERROR_INVALID_ARGS;
             break;
         }
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = HandleCommandPropertyGet(header, key);
         }
@@ -4218,12 +4218,12 @@ ThreadError NcpBase::SetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_pr
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                        uint16_t value_len)
 {
     uint16_t tmp;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -4236,7 +4236,7 @@ ThreadError NcpBase::SetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_pr
     {
         errorCode = otLinkSetPanId(mInstance, tmp);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = HandleCommandPropertyGet(header, key);
         }
@@ -4253,12 +4253,12 @@ ThreadError NcpBase::SetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_pr
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_MAC_15_4_LADDR(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_MAC_15_4_LADDR(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                        uint16_t value_len)
 {
     otExtAddress *tmp;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -4271,7 +4271,7 @@ ThreadError NcpBase::SetPropertyHandler_MAC_15_4_LADDR(uint8_t header, spinel_pr
     {
         errorCode = otLinkSetExtendedAddress(mInstance, tmp);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = HandleCommandPropertyGet(header, key);
         }
@@ -4288,12 +4288,12 @@ ThreadError NcpBase::SetPropertyHandler_MAC_15_4_LADDR(uint8_t header, spinel_pr
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_MAC_RAW_STREAM_ENABLED(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_MAC_RAW_STREAM_ENABLED(uint8_t header, spinel_prop_key_t key,
                                                                const uint8_t *value_ptr,uint16_t value_len)
 {
     bool value = false;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -4320,10 +4320,10 @@ ThreadError NcpBase::SetPropertyHandler_MAC_RAW_STREAM_ENABLED(uint8_t header, s
     }
     else
     {
-        errorCode = kThreadError_Parse;
+        errorCode = OT_ERROR_PARSE;
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         mIsRawStreamEnabled = value;
         errorCode = HandleCommandPropertyGet(header, key);
@@ -4338,12 +4338,12 @@ ThreadError NcpBase::SetPropertyHandler_MAC_RAW_STREAM_ENABLED(uint8_t header, s
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
 
-ThreadError NcpBase::SetPropertyHandler_MAC_15_4_SADDR(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_MAC_15_4_SADDR(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                        uint16_t value_len)
 {
     uint16_t tmp;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -4356,7 +4356,7 @@ ThreadError NcpBase::SetPropertyHandler_MAC_15_4_SADDR(uint8_t header, spinel_pr
     {
         errorCode = otLinkRawSetShortAddress(mInstance, tmp);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = HandleCommandPropertyGet(header, key);
         }
@@ -4373,10 +4373,10 @@ ThreadError NcpBase::SetPropertyHandler_MAC_15_4_SADDR(uint8_t header, spinel_pr
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_STREAM_RAW(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_STREAM_RAW(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                    uint16_t value_len)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     if (otLinkRawIsEnabled(mInstance))
     {
@@ -4416,15 +4416,15 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_RAW(uint8_t header, spinel_prop_k
         }
         else
         {
-            errorCode = kThreadError_Parse;
+            errorCode = OT_ERROR_PARSE;
         }
     }
     else
     {
-        errorCode = kThreadError_InvalidState;
+        errorCode = OT_ERROR_INVALID_STATE;
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         // Don't do anything here yet. We will complete the transaction when we get a transmit done callback
     }
@@ -4440,12 +4440,12 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_RAW(uint8_t header, spinel_prop_k
 
 #endif // OPENTHREAD_ENABLE_RAW_LINK_API
 
-ThreadError NcpBase::SetPropertyHandler_NET_IF_UP(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_NET_IF_UP(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                     uint16_t value_len)
 {
     bool value = false;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -4460,10 +4460,10 @@ ThreadError NcpBase::SetPropertyHandler_NET_IF_UP(uint8_t header, spinel_prop_ke
     }
     else
     {
-        errorCode = kThreadError_Parse;
+        errorCode = OT_ERROR_PARSE;
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         errorCode = HandleCommandPropertyGet(header, key);
     }
@@ -4475,12 +4475,12 @@ ThreadError NcpBase::SetPropertyHandler_NET_IF_UP(uint8_t header, spinel_prop_ke
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_NET_STACK_UP(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_NET_STACK_UP(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                   uint16_t value_len)
 {
     bool value = false;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -4528,10 +4528,10 @@ ThreadError NcpBase::SetPropertyHandler_NET_STACK_UP(uint8_t header, spinel_prop
     }
     else
     {
-        errorCode = kThreadError_Parse;
+        errorCode = OT_ERROR_PARSE;
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         errorCode = HandleCommandPropertyGet(header, key);
     }
@@ -4543,12 +4543,12 @@ ThreadError NcpBase::SetPropertyHandler_NET_STACK_UP(uint8_t header, spinel_prop
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                  uint16_t value_len)
 {
     unsigned int i(0);
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -4580,7 +4580,7 @@ ThreadError NcpBase::SetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key
             break;
         }
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = HandleCommandPropertyGet(header, key);
         }
@@ -4597,13 +4597,13 @@ ThreadError NcpBase::SetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_NET_NETWORK_NAME(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_NET_NETWORK_NAME(uint8_t header, spinel_prop_key_t key,
                                                          const uint8_t *value_ptr,
                                                          uint16_t value_len)
 {
     const char *string(NULL);
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -4616,7 +4616,7 @@ ThreadError NcpBase::SetPropertyHandler_NET_NETWORK_NAME(uint8_t header, spinel_
     {
         errorCode = otThreadSetNetworkName(mInstance, string);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = HandleCommandPropertyGet(header, key);
         }
@@ -4633,13 +4633,13 @@ ThreadError NcpBase::SetPropertyHandler_NET_NETWORK_NAME(uint8_t header, spinel_
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_NET_XPANID(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_NET_XPANID(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                    uint16_t value_len)
 {
     const uint8_t *ptr = NULL;
     spinel_size_t len;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -4662,13 +4662,13 @@ ThreadError NcpBase::SetPropertyHandler_NET_XPANID(uint8_t header, spinel_prop_k
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_NET_MASTER_KEY(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_NET_MASTER_KEY(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                        uint16_t value_len)
 {
     const uint8_t *ptr = NULL;
     spinel_size_t len;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -4682,7 +4682,7 @@ ThreadError NcpBase::SetPropertyHandler_NET_MASTER_KEY(uint8_t header, spinel_pr
     {
         errorCode = otThreadSetMasterKey(mInstance, reinterpret_cast<const otMasterKey *>(ptr));
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = HandleCommandPropertyGet(header, key);
         }
@@ -4699,13 +4699,13 @@ ThreadError NcpBase::SetPropertyHandler_NET_MASTER_KEY(uint8_t header, spinel_pr
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_NET_KEY_SEQUENCE_COUNTER(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_NET_KEY_SEQUENCE_COUNTER(uint8_t header, spinel_prop_key_t key,
                                                          const uint8_t *value_ptr,
                                                          uint16_t value_len)
 {
     unsigned int i(0);
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -4727,13 +4727,13 @@ ThreadError NcpBase::SetPropertyHandler_NET_KEY_SEQUENCE_COUNTER(uint8_t header,
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_NET_KEY_SWITCH_GUARDTIME(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_NET_KEY_SWITCH_GUARDTIME(uint8_t header, spinel_prop_key_t key,
                                                          const uint8_t *value_ptr,
                                                          uint16_t value_len)
 {
     unsigned int i(0);
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -4756,10 +4756,10 @@ ThreadError NcpBase::SetPropertyHandler_NET_KEY_SWITCH_GUARDTIME(uint8_t header,
 }
 
 #if OPENTHREAD_FTD
-ThreadError NcpBase::SetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key,
                                                                    const uint8_t *value_ptr, uint16_t value_len)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint8_t value = 0;
     spinel_ssize_t parsedLength;
 
@@ -4776,10 +4776,10 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT(uint8_t heade
     }
     else
     {
-        errorCode = kThreadError_Parse;
+        errorCode = OT_ERROR_PARSE;
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         errorCode = HandleCommandPropertyGet(header, key);
     }
@@ -4792,11 +4792,11 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT(uint8_t heade
 }
 #endif  // OPENTHREAD_FTD
 
-ThreadError NcpBase::SetPropertyHandler_STREAM_NET_INSECURE(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_STREAM_NET_INSECURE(uint8_t header, spinel_prop_key_t key,
                                                             const uint8_t *value_ptr, uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     const uint8_t *frame_ptr(NULL);
     unsigned int frame_len(0);
     const uint8_t *meta_ptr(NULL);
@@ -4807,7 +4807,7 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_NET_INSECURE(uint8_t header, spin
 
     if (message == NULL)
     {
-        errorCode = kThreadError_NoBufs;
+        errorCode = OT_ERROR_NO_BUFS;
     }
     else
     {
@@ -4830,7 +4830,7 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_NET_INSECURE(uint8_t header, spin
         errorCode = otMessageAppend(message, frame_ptr, static_cast<uint16_t>(frame_len));
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         // Ensure the insecure message is forwarded using direct transmission.
         otMessageSetDirectTransmission(message, true);
@@ -4842,7 +4842,7 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_NET_INSECURE(uint8_t header, spin
         otMessageFree(message);
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         mInboundInsecureIpFrameCounter++;
 
@@ -4866,11 +4866,11 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_NET_INSECURE(uint8_t header, spin
 }
 
 #if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
-ThreadError NcpBase::SetPropertyHandler_THREAD_BA_PROXY_STREAM(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_BA_PROXY_STREAM(uint8_t header, spinel_prop_key_t key,
                                                                const uint8_t *value_ptr, uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     const uint8_t *frame_ptr(NULL);
     unsigned int frame_len(0);
     uint16_t locator;
@@ -4881,7 +4881,7 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_BA_PROXY_STREAM(uint8_t header, s
 
     if (message == NULL)
     {
-        errorCode = kThreadError_NoBufs;
+        errorCode = OT_ERROR_NO_BUFS;
     }
     else
     {
@@ -4901,11 +4901,11 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_BA_PROXY_STREAM(uint8_t header, s
         }
         else
         {
-            errorCode = kThreadError_Parse;
+            errorCode = OT_ERROR_PARSE;
         }
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         errorCode = otBorderAgentProxySend(mInstance, message, locator, port);
     }
@@ -4914,7 +4914,7 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_BA_PROXY_STREAM(uint8_t header, s
         otMessageFree(message);
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         if (SPINEL_HEADER_GET_TID(header) != 0)
         {
@@ -4934,11 +4934,11 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_BA_PROXY_STREAM(uint8_t header, s
 }
 #endif // OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
 
-ThreadError NcpBase::SetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                    uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     const uint8_t *frame_ptr(NULL);
     unsigned int frame_len(0);
     const uint8_t *meta_ptr(NULL);
@@ -4949,7 +4949,7 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_k
 
     if (message == NULL)
     {
-        errorCode = kThreadError_NoBufs;
+        errorCode = OT_ERROR_NO_BUFS;
     }
     else
     {
@@ -4972,7 +4972,7 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_k
         errorCode = otMessageAppend(message, frame_ptr, static_cast<uint16_t>(frame_len));
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         errorCode = otIp6Send(mInstance, message);
     }
@@ -4981,7 +4981,7 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_k
         otMessageFree(message);
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         mInboundSecureIpFrameCounter++;
 
@@ -5005,10 +5005,10 @@ ThreadError NcpBase::SetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_k
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_IPV6_ML_PREFIX(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_IPV6_ML_PREFIX(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                        uint16_t value_len)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     if (value_len >= 8)
     {
@@ -5017,10 +5017,10 @@ ThreadError NcpBase::SetPropertyHandler_IPV6_ML_PREFIX(uint8_t header, spinel_pr
     }
     else
     {
-        errorCode = kThreadError_Parse;
+        errorCode = OT_ERROR_PARSE;
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         errorCode = HandleCommandPropertyGet(header, key);
     }
@@ -5032,12 +5032,12 @@ ThreadError NcpBase::SetPropertyHandler_IPV6_ML_PREFIX(uint8_t header, spinel_pr
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_IPV6_ICMP_PING_OFFLOAD(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_IPV6_ICMP_PING_OFFLOAD(uint8_t header, spinel_prop_key_t key,
                                                                const uint8_t *value_ptr, uint16_t value_len)
 {
     bool isEnabled(false);
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -5060,12 +5060,12 @@ ThreadError NcpBase::SetPropertyHandler_IPV6_ICMP_PING_OFFLOAD(uint8_t header, s
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_THREAD_RLOC16_DEBUG_PASSTHRU(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_RLOC16_DEBUG_PASSTHRU(uint8_t header, spinel_prop_key_t key,
                                                                      const uint8_t *value_ptr, uint16_t value_len)
 {
     bool isEnabled(false);
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -5089,12 +5089,12 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_RLOC16_DEBUG_PASSTHRU(uint8_t hea
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_THREAD_DISCOVERY_SCAN_JOINER_FLAG(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_DISCOVERY_SCAN_JOINER_FLAG(uint8_t header, spinel_prop_key_t key,
                                                                           const uint8_t *value_ptr, uint16_t value_len)
 {
     bool joinerFlag = false;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -5117,13 +5117,13 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_DISCOVERY_SCAN_JOINER_FLAG(uint8_
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_THREAD_DISCOVERY_SCAN_ENABLE_FILTERING(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_DISCOVERY_SCAN_ENABLE_FILTERING(uint8_t header, spinel_prop_key_t key,
                                                                                const uint8_t *value_ptr,
                                                                                uint16_t value_len)
 {
     bool isEnabled = false;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -5146,12 +5146,12 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_DISCOVERY_SCAN_ENABLE_FILTERING(u
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_THREAD_DISCOVERY_SCAN_PANID(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_DISCOVERY_SCAN_PANID(uint8_t header, spinel_prop_key_t key,
                                                                     const uint8_t *value_ptr, uint16_t value_len)
 {
     uint16_t panid;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -5174,10 +5174,10 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_DISCOVERY_SCAN_PANID(uint8_t head
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
                                                                const uint8_t *value_ptr, uint16_t value_len)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint8_t num_entries = 0;
     const uint16_t *ports = otIp6GetUnsecurePorts(mInstance, &num_entries);
     spinel_ssize_t parsedLength = 1;
@@ -5188,7 +5188,7 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, s
     {
         errorCode = otIp6RemoveUnsecurePort(mInstance, *ports);
 
-        if (errorCode != kThreadError_None)
+        if (errorCode != OT_ERROR_NONE)
         {
             break;
         }
@@ -5196,7 +5196,7 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, s
         ports_changed++;
     }
 
-    while ((errorCode == kThreadError_None)
+    while ((errorCode == OT_ERROR_NONE)
            && (parsedLength > 0)
            && (value_len >= 2)
           )
@@ -5216,10 +5216,10 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, s
         }
         else
         {
-            errorCode = kThreadError_Parse;
+            errorCode = OT_ERROR_PARSE;
         }
 
-        if (errorCode != kThreadError_None)
+        if (errorCode != OT_ERROR_NONE)
         {
             break;
         }
@@ -5230,7 +5230,7 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, s
         ports_changed++;
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         errorCode = HandleCommandPropertyGet(header, key);
     }
@@ -5252,12 +5252,12 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, s
 }
 
 #if OPENTHREAD_FTD
-ThreadError NcpBase::SetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key,
                                                               const uint8_t *value_ptr, uint16_t value_len)
 {
     bool value = false;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     bool should_register_with_leader = false;
 
     parsedLength = spinel_datatype_unpack(
@@ -5276,10 +5276,10 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8
     }
     else
     {
-        errorCode = kThreadError_Parse;
+        errorCode = OT_ERROR_PARSE;
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         errorCode = HandleCommandPropertyGet(header, key);
     }
@@ -5296,12 +5296,12 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_THREAD_ROUTER_ROLE_ENABLED(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_ROUTER_ROLE_ENABLED(uint8_t header, spinel_prop_key_t key,
                                                    const uint8_t *value_ptr, uint16_t value_len)
 {
     bool isEnabled;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -5326,12 +5326,12 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_ROUTER_ROLE_ENABLED(uint8_t heade
 
 #if OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
 
-ThreadError NcpBase::SetPropertyHandler_THREAD_THREAD_STEERING_DATA(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_THREAD_STEERING_DATA(uint8_t header, spinel_prop_key_t key,
                                                                     const uint8_t *value_ptr, uint16_t value_len)
 {
     otExtAddress *extAddress;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -5344,7 +5344,7 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_THREAD_STEERING_DATA(uint8_t head
     {
         errorCode = otThreadSetSteeringData(mInstance, extAddress);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = SendPropertyUpdate(
                             header,
@@ -5371,10 +5371,10 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_THREAD_STEERING_DATA(uint8_t head
 
 #endif  // #if OPENTHREAD_FTD
 
-ThreadError NcpBase::SetPropertyHandler_CNTR_RESET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_CNTR_RESET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                    uint16_t value_len)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint8_t value = 0;
     spinel_ssize_t parsedLength;
 
@@ -5390,16 +5390,16 @@ ThreadError NcpBase::SetPropertyHandler_CNTR_RESET(uint8_t header, spinel_prop_k
         if (value == 1)
         {
             // TODO: Implement counter reset!
-            errorCode = kThreadError_NotImplemented;
+            errorCode = OT_ERROR_NOT_IMPLEMENTED;
         }
         else
         {
-            errorCode = kThreadError_InvalidArgs;
+            errorCode = OT_ERROR_INVALID_ARGS;
         }
     }
     else
     {
-        errorCode = kThreadError_Parse;
+        errorCode = OT_ERROR_PARSE;
     }
 
     (void)key;
@@ -5411,12 +5411,12 @@ ThreadError NcpBase::SetPropertyHandler_CNTR_RESET(uint8_t header, spinel_prop_k
 }
 
 #if OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
-ThreadError NcpBase::SetPropertyHandler_THREAD_COMMISSIONER_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_THREAD_COMMISSIONER_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                                     uint16_t value_len)
 {
     bool value = false;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     (void)key;
 
     parsedLength = spinel_datatype_unpack(
@@ -5439,23 +5439,23 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_COMMISSIONER_ENABLED(uint8_t head
     }
     else
     {
-        errorCode = kThreadError_Parse;
+        errorCode = OT_ERROR_PARSE;
     }
 
     return SendLastStatus(header, ThreadErrorToSpinelStatus(errorCode));
 }
 #endif // OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
 
-ThreadError NcpBase::SetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                       uint16_t value_len)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     spinel_ssize_t parsedLength = 1;
 
     // First, clear the whitelist.
     otLinkClearWhitelist(mInstance);
 
-    while ((errorCode == kThreadError_None)
+    while ((errorCode == OT_ERROR_NONE)
            && (parsedLength > 0)
            && (value_len > 0)
           )
@@ -5489,7 +5489,7 @@ ThreadError NcpBase::SetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_pro
 
         if (parsedLength <= 0)
         {
-            errorCode = kThreadError_Parse;
+            errorCode = OT_ERROR_PARSE;
             break;
         }
 
@@ -5506,7 +5506,7 @@ ThreadError NcpBase::SetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_pro
         value_len -= parsedLength;
     }
 
-    if (errorCode == kThreadError_None)
+    if (errorCode == OT_ERROR_NONE)
     {
         errorCode = HandleCommandPropertyGet(header, key);
     }
@@ -5524,12 +5524,12 @@ ThreadError NcpBase::SetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_pro
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_MAC_WHITELIST_ENABLED(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_MAC_WHITELIST_ENABLED(uint8_t header, spinel_prop_key_t key,
                                                               const uint8_t *value_ptr, uint16_t value_len)
 {
     bool isEnabled;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -5553,12 +5553,12 @@ ThreadError NcpBase::SetPropertyHandler_MAC_WHITELIST_ENABLED(uint8_t header, sp
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
 
-ThreadError NcpBase::SetPropertyHandler_MAC_SRC_MATCH_ENABLED(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_MAC_SRC_MATCH_ENABLED(uint8_t header, spinel_prop_key_t key,
                                                               const uint8_t *value_ptr, uint16_t value_len)
 {
     bool isEnabled;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -5570,7 +5570,7 @@ ThreadError NcpBase::SetPropertyHandler_MAC_SRC_MATCH_ENABLED(uint8_t header, sp
     if (parsedLength > 0)
     {
         errorCode = otLinkRawSrcMatchEnable(mInstance, isEnabled);
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = HandleCommandPropertyGet(header, key);
         }
@@ -5587,10 +5587,10 @@ ThreadError NcpBase::SetPropertyHandler_MAC_SRC_MATCH_ENABLED(uint8_t header, sp
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_MAC_SRC_MATCH_SHORT_ADDRESSES(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_MAC_SRC_MATCH_SHORT_ADDRESSES(uint8_t header, spinel_prop_key_t key,
                                                                       const uint8_t *value_ptr, uint16_t value_len)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     spinel_status_t errorStatus = SPINEL_STATUS_OK;
     const uint8_t *data = value_ptr;
     uint16_t data_len = value_len;
@@ -5598,7 +5598,7 @@ ThreadError NcpBase::SetPropertyHandler_MAC_SRC_MATCH_SHORT_ADDRESSES(uint8_t he
     // Clear the list first
     errorCode = otLinkRawSrcMatchClearShortEntries(mInstance);
 
-    VerifyOrExit(errorCode == kThreadError_None,
+    VerifyOrExit(errorCode == OT_ERROR_NONE,
         errorStatus = ThreadErrorToSpinelStatus(errorCode));
 
     // Loop through the addresses and add them
@@ -5621,7 +5621,7 @@ ThreadError NcpBase::SetPropertyHandler_MAC_SRC_MATCH_SHORT_ADDRESSES(uint8_t he
 
         errorCode = otLinkRawSrcMatchAddShortEntry(mInstance, short_address);
 
-        VerifyOrExit(errorCode == kThreadError_None,
+        VerifyOrExit(errorCode == OT_ERROR_NONE,
             errorStatus = ThreadErrorToSpinelStatus(errorCode));
     }
 
@@ -5644,10 +5644,10 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_MAC_SRC_MATCH_EXTENDED_ADDRESSES(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_MAC_SRC_MATCH_EXTENDED_ADDRESSES(uint8_t header, spinel_prop_key_t key,
                                                                          const uint8_t *value_ptr, uint16_t value_len)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     spinel_status_t errorStatus = SPINEL_STATUS_OK;
     const uint8_t *data = value_ptr;
     uint16_t data_len = value_len;
@@ -5655,7 +5655,7 @@ ThreadError NcpBase::SetPropertyHandler_MAC_SRC_MATCH_EXTENDED_ADDRESSES(uint8_t
     // Clear the list first
     errorCode = otLinkRawSrcMatchClearExtEntries(mInstance);
 
-    VerifyOrExit(errorCode == kThreadError_None,
+    VerifyOrExit(errorCode == OT_ERROR_NONE,
         errorStatus = ThreadErrorToSpinelStatus(errorCode));
 
     // Loop through the addresses and add them
@@ -5678,7 +5678,7 @@ ThreadError NcpBase::SetPropertyHandler_MAC_SRC_MATCH_EXTENDED_ADDRESSES(uint8_t
 
         errorCode = otLinkRawSrcMatchAddExtEntry(mInstance, ext_address);
 
-        VerifyOrExit(errorCode == kThreadError_None,
+        VerifyOrExit(errorCode == OT_ERROR_NONE,
             errorStatus = ThreadErrorToSpinelStatus(errorCode));
     }
 
@@ -5704,13 +5704,13 @@ exit:
 #endif
 
 #if OPENTHREAD_FTD
-ThreadError NcpBase::SetPropertyHandler_NET_PSKC(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_NET_PSKC(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                  uint16_t value_len)
 {
     const uint8_t *ptr = NULL;
     spinel_size_t len;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -5723,7 +5723,7 @@ ThreadError NcpBase::SetPropertyHandler_NET_PSKC(uint8_t header, spinel_prop_key
     if ((parsedLength > 0) && (len == sizeof(spinel_net_pskc_t)))
     {
         errorCode = otThreadSetPSKc(mInstance, ptr);
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = HandleCommandPropertyGet(header, key);
         }
@@ -5742,13 +5742,13 @@ ThreadError NcpBase::SetPropertyHandler_NET_PSKC(uint8_t header, spinel_prop_key
 }
 #endif // OPENTHREAD_FTD
 
-ThreadError NcpBase::SetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                     uint16_t value_len)
 {
     uint8_t numeric_mode = 0;
     otLinkModeConfig mode_config;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -5767,7 +5767,7 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_
 
         errorCode = otThreadSetLinkMode(mInstance, mode_config);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = HandleCommandPropertyGet(header, key);
         }
@@ -5785,12 +5785,12 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_
 }
 
 #if OPENTHREAD_FTD
-ThreadError NcpBase::SetPropertyHandler_THREAD_CHILD_COUNT_MAX(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_CHILD_COUNT_MAX(uint8_t header, spinel_prop_key_t key,
                                                                const uint8_t *value_ptr, uint16_t value_len)
 {
     uint8_t n = 0;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -5813,12 +5813,12 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_CHILD_COUNT_MAX(uint8_t header, s
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_THREAD_CHILD_TIMEOUT(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_CHILD_TIMEOUT(uint8_t header, spinel_prop_key_t key,
                                                              const uint8_t *value_ptr, uint16_t value_len)
 {
     uint32_t i = 0;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -5841,12 +5841,12 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_CHILD_TIMEOUT(uint8_t header, spi
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_THREAD_ROUTER_UPGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_ROUTER_UPGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key,
                                                                         const uint8_t *value_ptr, uint16_t value_len)
 {
     uint8_t i = 0;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -5869,12 +5869,12 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_ROUTER_UPGRADE_THRESHOLD(uint8_t 
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_THREAD_ROUTER_DOWNGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_ROUTER_DOWNGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key,
                                                                           const uint8_t *value_ptr, uint16_t value_len)
 {
     uint8_t i = 0;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -5897,12 +5897,12 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_ROUTER_DOWNGRADE_THRESHOLD(uint8_
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_THREAD_ROUTER_SELECTION_JITTER(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_ROUTER_SELECTION_JITTER(uint8_t header, spinel_prop_key_t key,
                                                                        const uint8_t *value_ptr, uint16_t value_len)
 {
     uint8_t i = 0;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -5925,12 +5925,12 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_ROUTER_SELECTION_JITTER(uint8_t h
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_THREAD_PREFERRED_ROUTER_ID(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_PREFERRED_ROUTER_ID(uint8_t header, spinel_prop_key_t key,
                                                                    const uint8_t *value_ptr, uint16_t value_len)
 {
     uint8_t router_id = 0;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -5943,7 +5943,7 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_PREFERRED_ROUTER_ID(uint8_t heade
     {
         errorCode = otThreadSetPreferredRouterId(mInstance, router_id);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = SendPropertyUpdate(
                header,
@@ -5967,13 +5967,13 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_PREFERRED_ROUTER_ID(uint8_t heade
 }
 #endif  // OPENTHREAD_FTD
 
-ThreadError NcpBase::SetPropertyHandler_DEBUG_NCP_LOG_LEVEL(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_DEBUG_NCP_LOG_LEVEL(uint8_t header, spinel_prop_key_t key,
                                                             const uint8_t *value_ptr, uint16_t value_len)
 {
     uint8_t spinelNcpLogLevel = 0;
     otLogLevel logLevel;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -6010,22 +6010,22 @@ ThreadError NcpBase::SetPropertyHandler_DEBUG_NCP_LOG_LEVEL(uint8_t header, spin
             break;
 
         default:
-            errorCode = kThreadError_InvalidArgs;
+            errorCode = OT_ERROR_INVALID_ARGS;
             break;
         }
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = otSetDynamicLogLevel(mInstance, logLevel);
         }
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = HandleCommandPropertyGet(header, key);
         }
         else
         {
-            if (errorCode == kThreadError_NotCapable)
+            if (errorCode == OT_ERROR_NOT_CAPABLE)
             {
                 errorCode = SendLastStatus(header, SPINEL_STATUS_INVALID_COMMAND_FOR_PROP);
             }
@@ -6044,12 +6044,12 @@ ThreadError NcpBase::SetPropertyHandler_DEBUG_NCP_LOG_LEVEL(uint8_t header, spin
 }
 
 #if OPENTHREAD_FTD
-ThreadError NcpBase::SetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t header, spinel_prop_key_t key,
                                                                    const uint8_t *value_ptr, uint16_t value_len)
 {
     uint32_t i = 0;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -6072,12 +6072,12 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t heade
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header, spinel_prop_key_t key,
                                                                   const uint8_t *value_ptr, uint16_t value_len)
 {
     uint8_t i = 0;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -6102,12 +6102,12 @@ ThreadError NcpBase::SetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header
 #endif  // OPENTHREAD_FTD
 
 #if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
-ThreadError NcpBase::SetPropertyHandler_BA_PROXY_ENABLED(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_BA_PROXY_ENABLED(uint8_t header, spinel_prop_key_t key,
                                                          const uint8_t *value_ptr, uint16_t value_len)
 {
     bool isEnabled;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -6131,12 +6131,12 @@ ThreadError NcpBase::SetPropertyHandler_BA_PROXY_ENABLED(uint8_t header, spinel_
     }
     else
     {
-        errorCode = kThreadError_Parse;
+        errorCode = OT_ERROR_PARSE;
     }
 
 exit:
 
-    if (errorCode != kThreadError_None)
+    if (errorCode != OT_ERROR_NONE)
     {
         errorCode = SendLastStatus(header, ThreadErrorToSpinelStatus(errorCode));
     }
@@ -6147,12 +6147,12 @@ exit:
 
 #if OPENTHREAD_ENABLE_JAM_DETECTION
 
-ThreadError NcpBase::SetPropertyHandler_JAM_DETECT_ENABLE(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_JAM_DETECT_ENABLE(uint8_t header, spinel_prop_key_t key,
                                                           const uint8_t *value_ptr, uint16_t value_len)
 {
     bool isEnabled;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -6182,12 +6182,12 @@ ThreadError NcpBase::SetPropertyHandler_JAM_DETECT_ENABLE(uint8_t header, spinel
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_JAM_DETECT_RSSI_THRESHOLD(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_JAM_DETECT_RSSI_THRESHOLD(uint8_t header, spinel_prop_key_t key,
                                                                   const uint8_t *value_ptr, uint16_t value_len)
 {
     int8_t value = 0;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -6200,7 +6200,7 @@ ThreadError NcpBase::SetPropertyHandler_JAM_DETECT_RSSI_THRESHOLD(uint8_t header
     {
         errorCode = otJamDetectionSetRssiThreshold(mInstance, value);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = HandleCommandPropertyGet(header, key);
         }
@@ -6217,12 +6217,12 @@ ThreadError NcpBase::SetPropertyHandler_JAM_DETECT_RSSI_THRESHOLD(uint8_t header
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_JAM_DETECT_WINDOW(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_JAM_DETECT_WINDOW(uint8_t header, spinel_prop_key_t key,
                                                           const uint8_t *value_ptr, uint16_t value_len)
 {
     uint8_t value = 0;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -6235,7 +6235,7 @@ ThreadError NcpBase::SetPropertyHandler_JAM_DETECT_WINDOW(uint8_t header, spinel
     {
         errorCode = otJamDetectionSetWindow(mInstance, value);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = HandleCommandPropertyGet(header, key);
         }
@@ -6252,12 +6252,12 @@ ThreadError NcpBase::SetPropertyHandler_JAM_DETECT_WINDOW(uint8_t header, spinel
     return errorCode;
 }
 
-ThreadError NcpBase::SetPropertyHandler_JAM_DETECT_BUSY(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_JAM_DETECT_BUSY(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                         uint16_t value_len)
 {
     uint8_t value = 0;
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -6270,7 +6270,7 @@ ThreadError NcpBase::SetPropertyHandler_JAM_DETECT_BUSY(uint8_t header, spinel_p
     {
         errorCode = otJamDetectionSetBusyPeriod(mInstance, value);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = HandleCommandPropertyGet(header, key);
         }
@@ -6294,7 +6294,7 @@ void NcpBase::HandleJamStateChange_Jump(bool aJamState, void *aContext)
 
 void NcpBase::HandleJamStateChange(bool aJamState)
 {
-    ThreadError errorCode;
+    otError errorCode;
 
     errorCode = SendPropertyUpdate(
         SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
@@ -6307,7 +6307,7 @@ void NcpBase::HandleJamStateChange(bool aJamState)
     // If we could not send the jam state change indicator (no
     // buffer space), we set `mShouldSignalJamStateChange` to true to send
     // it out when buffer space becomes available.
-    if (errorCode != kThreadError_None)
+    if (errorCode != OT_ERROR_NONE)
     {
         mShouldSignalJamStateChange = true;
     }
@@ -6316,13 +6316,13 @@ void NcpBase::HandleJamStateChange(bool aJamState)
 #endif // OPENTHREAD_ENABLE_JAM_DETECTION
 
 #if OPENTHREAD_ENABLE_DIAG
-ThreadError NcpBase::SetPropertyHandler_NEST_STREAM_MFG(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+otError NcpBase::SetPropertyHandler_NEST_STREAM_MFG(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                         uint16_t value_len)
 {
     char *string(NULL);
     char *output(NULL);
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     parsedLength = spinel_datatype_unpack(
                        value_ptr,
@@ -6354,10 +6354,10 @@ ThreadError NcpBase::SetPropertyHandler_NEST_STREAM_MFG(uint8_t header, spinel_p
 #endif
 
 #if OPENTHREAD_ENABLE_LEGACY
-ThreadError NcpBase::SetPropertyHandler_NEST_LEGACY_ULA_PREFIX(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::SetPropertyHandler_NEST_LEGACY_ULA_PREFIX(uint8_t header, spinel_prop_key_t key,
                                                                 const uint8_t *value_ptr, uint16_t value_len)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     const uint8_t *ptr = NULL;
     spinel_size_t len;
     spinel_ssize_t parsedLength;
@@ -6400,11 +6400,11 @@ ThreadError NcpBase::SetPropertyHandler_NEST_LEGACY_ULA_PREFIX(uint8_t header, s
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
 
-ThreadError NcpBase::InsertPropertyHandler_MAC_SRC_MATCH_SHORT_ADDRESSES(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::InsertPropertyHandler_MAC_SRC_MATCH_SHORT_ADDRESSES(uint8_t header, spinel_prop_key_t key,
                                                                          const uint8_t *value_ptr, uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     spinel_status_t errorStatus = SPINEL_STATUS_OK;
     uint16_t short_address;
 
@@ -6419,7 +6419,7 @@ ThreadError NcpBase::InsertPropertyHandler_MAC_SRC_MATCH_SHORT_ADDRESSES(uint8_t
 
     errorCode = otLinkRawSrcMatchAddShortEntry(mInstance, short_address);
 
-    VerifyOrExit(errorCode == kThreadError_None,
+    VerifyOrExit(errorCode == OT_ERROR_NONE,
                  errorStatus = ThreadErrorToSpinelStatus(errorCode));
 
     errorCode =
@@ -6441,11 +6441,11 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::InsertPropertyHandler_MAC_SRC_MATCH_EXTENDED_ADDRESSES(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::InsertPropertyHandler_MAC_SRC_MATCH_EXTENDED_ADDRESSES(uint8_t header, spinel_prop_key_t key,
                                                                             const uint8_t *value_ptr, uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     spinel_status_t errorStatus = SPINEL_STATUS_OK;
     uint8_t *ext_address = NULL;
 
@@ -6460,7 +6460,7 @@ ThreadError NcpBase::InsertPropertyHandler_MAC_SRC_MATCH_EXTENDED_ADDRESSES(uint
 
     errorCode = otLinkRawSrcMatchAddExtEntry(mInstance, ext_address);
 
-    VerifyOrExit(errorCode == kThreadError_None,
+    VerifyOrExit(errorCode == OT_ERROR_NONE,
                  errorStatus = ThreadErrorToSpinelStatus(errorCode));
 
     errorCode =
@@ -6484,11 +6484,11 @@ exit:
 
 #endif
 
-ThreadError NcpBase::InsertPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::InsertPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key,
                                                               const uint8_t *value_ptr, uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     spinel_status_t errorStatus = SPINEL_STATUS_OK;
     otNetifAddress netif_addr;
     otIp6Address *addr_ptr;
@@ -6515,7 +6515,7 @@ ThreadError NcpBase::InsertPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, sp
 
     errorCode = otIp6AddUnicastAddress(mInstance, &netif_addr);
 
-    VerifyOrExit(errorCode == kThreadError_None,
+    VerifyOrExit(errorCode == OT_ERROR_NONE,
                  errorStatus = ThreadErrorToSpinelStatus(errorCode));
 
     errorCode = SendPropertyUpdate(
@@ -6538,11 +6538,11 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::InsertPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::InsertPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key,
                                                                const uint8_t *value_ptr, uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     otExternalRouteConfig ext_route_config;
     otIp6Address *addr_ptr;
@@ -6573,7 +6573,7 @@ ThreadError NcpBase::InsertPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, s
         ext_route_config.mPreference = ((flags & SPINEL_NET_FLAG_PREFERENCE_MASK) >> SPINEL_NET_FLAG_PREFERENCE_OFFSET);
         errorCode = otNetDataAddRoute(mInstance, &ext_route_config);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = SendPropertyUpdate(
                             header,
@@ -6597,11 +6597,11 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::InsertPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::InsertPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key,
                                                                const uint8_t *value_ptr, uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     otBorderRouterConfig border_router_config;
     otIp6Address *addr_ptr;
@@ -6640,7 +6640,7 @@ ThreadError NcpBase::InsertPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, s
 
         errorCode = otNetDataAddPrefixInfo(mInstance, &border_router_config);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = SendPropertyUpdate(
                             header,
@@ -6664,11 +6664,11 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::InsertPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::InsertPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
                                                                   const uint8_t *value_ptr, uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint16_t port;
 
     parsedLength = spinel_datatype_unpack(
@@ -6682,7 +6682,7 @@ ThreadError NcpBase::InsertPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header
     {
         errorCode = otIp6AddUnsecurePort(mInstance, port);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = SendPropertyUpdate(
                             header,
@@ -6705,10 +6705,10 @@ ThreadError NcpBase::InsertPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header
     return errorCode;
 }
 
-ThreadError NcpBase::InsertPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::InsertPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key,
                                                          const uint8_t *value_ptr, uint16_t value_len)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     spinel_ssize_t parsedLength;
     otExtAddress *ext_addr = NULL;
     int8_t rssi = RSSI_OVERRIDE_DISABLED;
@@ -6745,7 +6745,7 @@ ThreadError NcpBase::InsertPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_
             errorCode = otLinkAddWhitelistRssi(mInstance, ext_addr->m8, rssi);
         }
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = SendPropertyUpdate(
                             header,
@@ -6769,11 +6769,11 @@ ThreadError NcpBase::InsertPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_
 }
 
 #if OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
-ThreadError NcpBase::InsertPropertyHandler_THREAD_JOINERS(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::InsertPropertyHandler_THREAD_JOINERS(uint8_t header, spinel_prop_key_t key,
                                                           const uint8_t *value_ptr, uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     otExtAddress *ot_ext_address = NULL;
     const char *aPSKd = NULL;
@@ -6809,7 +6809,7 @@ ThreadError NcpBase::InsertPropertyHandler_THREAD_JOINERS(uint8_t header, spinel
     {
         errorCode = otCommissionerAddJoiner(mInstance, ot_ext_address, aPSKd, joiner_timeout);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = SendPropertyUpdate(
                             header,
@@ -6840,11 +6840,11 @@ exit:
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
 
-ThreadError NcpBase::RemovePropertyHandler_MAC_SRC_MATCH_SHORT_ADDRESSES(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::RemovePropertyHandler_MAC_SRC_MATCH_SHORT_ADDRESSES(uint8_t header, spinel_prop_key_t key,
                                                                          const uint8_t *value_ptr, uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint16_t short_address;
 
     parsedLength = spinel_datatype_unpack(
@@ -6858,7 +6858,7 @@ ThreadError NcpBase::RemovePropertyHandler_MAC_SRC_MATCH_SHORT_ADDRESSES(uint8_t
     {
         errorCode = otLinkRawSrcMatchClearShortEntry(mInstance, short_address);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = SendPropertyUpdate(
                             header,
@@ -6881,11 +6881,11 @@ ThreadError NcpBase::RemovePropertyHandler_MAC_SRC_MATCH_SHORT_ADDRESSES(uint8_t
     return errorCode;
 }
 
-ThreadError NcpBase::RemovePropertyHandler_MAC_SRC_MATCH_EXTENDED_ADDRESSES(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::RemovePropertyHandler_MAC_SRC_MATCH_EXTENDED_ADDRESSES(uint8_t header, spinel_prop_key_t key,
                                                                             const uint8_t *value_ptr, uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint8_t *ext_address;
 
     parsedLength = spinel_datatype_unpack(
@@ -6899,7 +6899,7 @@ ThreadError NcpBase::RemovePropertyHandler_MAC_SRC_MATCH_EXTENDED_ADDRESSES(uint
     {
         errorCode = otLinkRawSrcMatchClearExtEntry(mInstance, ext_address);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = SendPropertyUpdate(
                             header,
@@ -6924,11 +6924,11 @@ ThreadError NcpBase::RemovePropertyHandler_MAC_SRC_MATCH_EXTENDED_ADDRESSES(uint
 
 #endif
 
-ThreadError NcpBase::RemovePropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::RemovePropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key,
                                                               const uint8_t *value_ptr, uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     otIp6Address *addr_ptr;
 
     parsedLength = spinel_datatype_unpack(
@@ -6942,7 +6942,7 @@ ThreadError NcpBase::RemovePropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, sp
     {
         errorCode = otIp6RemoveUnicastAddress(mInstance, addr_ptr);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = SendPropertyUpdate(
                             header,
@@ -6965,11 +6965,11 @@ ThreadError NcpBase::RemovePropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, sp
     return errorCode;
 }
 
-ThreadError NcpBase::RemovePropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::RemovePropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key,
                                                                const uint8_t *value_ptr, uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     otIp6Prefix ip6_prefix;
     memset(&ip6_prefix, 0, sizeof(otIp6Prefix));
@@ -6993,7 +6993,7 @@ ThreadError NcpBase::RemovePropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, s
         ip6_prefix.mPrefix = *addr_ptr;
         errorCode = otNetDataRemoveRoute(mInstance, &ip6_prefix);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = SendPropertyUpdate(
                             header,
@@ -7017,11 +7017,11 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::RemovePropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::RemovePropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key,
                                                                const uint8_t *value_ptr, uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     otIp6Prefix ip6_prefix;
     memset(&ip6_prefix, 0, sizeof(otIp6Prefix));
@@ -7045,7 +7045,7 @@ ThreadError NcpBase::RemovePropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, s
         ip6_prefix.mPrefix = *addr_ptr;
         errorCode = otNetDataRemovePrefixInfo(mInstance, &ip6_prefix);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = SendPropertyUpdate(
                             header,
@@ -7069,11 +7069,11 @@ exit:
     return errorCode;
 }
 
-ThreadError NcpBase::RemovePropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::RemovePropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
                                                                   const uint8_t *value_ptr, uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint16_t port;
 
     parsedLength = spinel_datatype_unpack(
@@ -7087,7 +7087,7 @@ ThreadError NcpBase::RemovePropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header
     {
         errorCode = otIp6RemoveUnsecurePort(mInstance, port);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = SendPropertyUpdate(
                             header,
@@ -7111,11 +7111,11 @@ ThreadError NcpBase::RemovePropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header
 }
 
 #if OPENTHREAD_FTD
-ThreadError NcpBase::RemovePropertyHandler_THREAD_ACTIVE_ROUTER_IDS(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::RemovePropertyHandler_THREAD_ACTIVE_ROUTER_IDS(uint8_t header, spinel_prop_key_t key,
                                                                   const uint8_t *value_ptr, uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint8_t router_id;
 
     parsedLength = spinel_datatype_unpack(
@@ -7129,7 +7129,7 @@ ThreadError NcpBase::RemovePropertyHandler_THREAD_ACTIVE_ROUTER_IDS(uint8_t head
     {
         errorCode = otThreadReleaseRouterId(mInstance, router_id);
 
-        if (errorCode == kThreadError_None)
+        if (errorCode == OT_ERROR_NONE)
         {
             errorCode = SendPropertyUpdate(
                             header,
@@ -7153,10 +7153,10 @@ ThreadError NcpBase::RemovePropertyHandler_THREAD_ACTIVE_ROUTER_IDS(uint8_t head
 }
 #endif  // OPENTHREAD_FTD
 
-ThreadError NcpBase::RemovePropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key,
+otError NcpBase::RemovePropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key,
                                                          const uint8_t *value_ptr, uint16_t value_len)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     spinel_ssize_t parsedLength;
     otExtAddress *ext_addr_ptr = NULL;
 
@@ -7266,9 +7266,9 @@ exit:
 
 #endif // OPENTHREAD_ENABLE_LEGACY
 
-ThreadError NcpBase::StreamWrite(int aStreamId, const uint8_t *aDataPtr, int aDataLen)
+otError NcpBase::StreamWrite(int aStreamId, const uint8_t *aDataPtr, int aDataLen)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
 
     if (aStreamId == 0)
     {
@@ -7287,7 +7287,7 @@ ThreadError NcpBase::StreamWrite(int aStreamId, const uint8_t *aDataPtr, int aDa
     }
     else
     {
-        errorCode = kThreadError_InvalidState;
+        errorCode = OT_ERROR_INVALID_STATE;
     }
 
     return errorCode;
@@ -7300,9 +7300,9 @@ ThreadError NcpBase::StreamWrite(int aStreamId, const uint8_t *aDataPtr, int aDa
 // MARK: Virtual Datastream I/O (Public API)
 // ----------------------------------------------------------------------------
 
-ThreadError otNcpStreamWrite(int aStreamId, const uint8_t* aDataPtr, int aDataLen)
+otError otNcpStreamWrite(int aStreamId, const uint8_t* aDataPtr, int aDataLen)
 {
-    ThreadError errorCode  = kThreadError_InvalidState;
+    otError errorCode  = OT_ERROR_INVALID_STATE;
     ot::NcpBase *ncp = ot::NcpBase::GetNcpInstance();
 
     if (ncp != NULL)

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -76,11 +76,11 @@ protected:
     /**
      * This method is called to start a new outbound frame.
      *
-     * @retval kThreadError_None      Successfully started a new frame.
-     * @retval kThreadError_NoBufs    Insufficient buffer space available to start a new frame.
+     * @retval OT_ERROR_NONE       Successfully started a new frame.
+     * @retval OT_ERROR_NO_BUFS    Insufficient buffer space available to start a new frame.
      *
      */
-    ThreadError OutboundFrameBegin(void);
+    otError OutboundFrameBegin(void);
 
     /**
      * This method adds data to the current outbound frame being written.
@@ -90,11 +90,11 @@ protected:
      * @param[in]  aDataBuffer        A pointer to data buffer.
      * @param[in]  aDataBufferLength  The length of the data buffer.
      *
-     * @retval kThreadError_None      Successfully added new data to the frame.
-     * @retval kThreadError_NoBufs    Insufficient buffer space available to add data.
+     * @retval OT_ERROR_NONE       Successfully added new data to the frame.
+     * @retval OT_ERROR_NO_BUFS    Insufficient buffer space available to add data.
      *
      */
-    ThreadError OutboundFrameFeedData(const uint8_t *aDataBuffer, uint16_t aDataBufferLength);
+    otError OutboundFrameFeedData(const uint8_t *aDataBuffer, uint16_t aDataBufferLength);
 
     /**
      * This method adds a message to the current outbound frame being written.
@@ -105,22 +105,22 @@ protected:
      *
      * @param[in]  aMessage         A reference to the message to be added to current frame.
      *
-     * @retval kThreadError_None    Successfully added the message to the frame.
-     * @retval kThreadError_NoBufs  Insufficient buffer space available to add message.
+     * @retval OT_ERROR_NONE     Successfully added the message to the frame.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffer space available to add message.
      *
      */
-    ThreadError OutboundFrameFeedMessage(otMessage *aMessage);
+    otError OutboundFrameFeedMessage(otMessage *aMessage);
 
     /**
      * This method finalizes and sends the current outbound frame
      *
      * If no buffer space is available, this method should discard and clear the frame before returning an error status.
      *
-     * @retval kThreadError_None    Successfully added the message to the frame.
-     * @retval kThreadError_NoBufs  Insufficient buffer space available to add message.
+     * @retval OT_ERROR_NONE     Successfully added the message to the frame.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffer space available to add message.
      *
      */
-    ThreadError OutboundFrameEnd(void);
+    otError OutboundFrameEnd(void);
 
     /**
      * This method is called by the framer whenever a framing error
@@ -152,7 +152,7 @@ protected:
 
 private:
 
-    ThreadError OutboundFrameSend(void);
+    otError OutboundFrameSend(void);
 
 #if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
     /**
@@ -217,17 +217,17 @@ private:
     /**
      * Trampoline for LinkRawReceiveDone().
      */
-    static void LinkRawReceiveDone(otInstance *aInstance, RadioPacket *aPacket, ThreadError aError);
+    static void LinkRawReceiveDone(otInstance *aInstance, RadioPacket *aPacket, otError aError);
 
-    void LinkRawReceiveDone(RadioPacket *aPacket, ThreadError aError);
+    void LinkRawReceiveDone(RadioPacket *aPacket, otError aError);
 
     /**
      * Trampoline for LinkRawTransmitDone().
      */
     static void LinkRawTransmitDone(otInstance *aInstance, RadioPacket *aPacket, bool aFramePending,
-                                    ThreadError aError);
+                                    otError aError);
 
-    void LinkRawTransmitDone(RadioPacket *aPacket, bool aFramePending, ThreadError aError);
+    void LinkRawTransmitDone(RadioPacket *aPacket, bool aFramePending, otError aError);
 
     /**
      * Trampoline for LinkRawEnergyScanDone().
@@ -240,50 +240,50 @@ private:
 
     static void HandleNetifStateChanged(uint32_t flags, void *context);
 
-    static void HandleFrameTransmitDone(void *aContext, ThreadError aError);
+    static void HandleFrameTransmitDone(void *aContext, otError aError);
 
-    void HandleFrameTransmitDone(ThreadError aError);
-
-private:
-
-    ThreadError OutboundFrameFeedPacked(const char *pack_format, ...);
-
-    ThreadError OutboundFrameFeedVPacked(const char *pack_format, va_list args);
+    void HandleFrameTransmitDone(otError aError);
 
 private:
 
-    ThreadError HandleCommand(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
+    otError OutboundFrameFeedPacked(const char *pack_format, ...);
 
-    ThreadError HandleCommandPropertyGet(uint8_t header, spinel_prop_key_t key);
+    otError OutboundFrameFeedVPacked(const char *pack_format, va_list args);
 
-    ThreadError HandleCommandPropertySet(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+private:
+
+    otError HandleCommand(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
+
+    otError HandleCommandPropertyGet(uint8_t header, spinel_prop_key_t key);
+
+    otError HandleCommandPropertySet(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                          uint16_t value_len);
 
-    ThreadError HandleCommandPropertyInsert(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError HandleCommandPropertyInsert(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                             uint16_t value_len);
 
-    ThreadError HandleCommandPropertyRemove(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError HandleCommandPropertyRemove(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                             uint16_t value_len);
 
-    ThreadError SendLastStatus(uint8_t header, spinel_status_t lastStatus);
+    otError SendLastStatus(uint8_t header, spinel_status_t lastStatus);
 
 private:
 
-    ThreadError SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key, const uint8_t *value_ptr,
                                    uint16_t value_len);
 
-    ThreadError SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key, otMessage *message);
+    otError SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key, otMessage *message);
 
-    ThreadError SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key, const char *format, ...);
+    otError SendPropertyUpdate(uint8_t header, uint8_t command, spinel_prop_key_t key, const char *format, ...);
 
 private:
 
-    typedef ThreadError(NcpBase::*CommandHandlerType)(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+    typedef otError(NcpBase::*CommandHandlerType)(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
                                                       uint16_t arg_len);
 
-    typedef ThreadError(NcpBase::*GetPropertyHandlerType)(uint8_t header, spinel_prop_key_t key);
+    typedef otError(NcpBase::*GetPropertyHandlerType)(uint8_t header, spinel_prop_key_t key);
 
-    typedef ThreadError(NcpBase::*SetPropertyHandlerType)(uint8_t header, spinel_prop_key_t key,
+    typedef otError(NcpBase::*SetPropertyHandlerType)(uint8_t header, spinel_prop_key_t key,
                                                           const uint8_t *value_ptr, uint16_t value_len);
 
     struct CommandHandlerEntry
@@ -322,332 +322,332 @@ private:
     static const InsertPropertyHandlerEntry mInsertPropertyHandlerTable[];
     static const RemovePropertyHandlerEntry mRemovePropertyHandlerTable[];
 
-    ThreadError CommandHandler_NOOP(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
-    ThreadError CommandHandler_RESET(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
-    ThreadError CommandHandler_PROP_VALUE_GET(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+    otError CommandHandler_NOOP(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
+    otError CommandHandler_RESET(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
+    otError CommandHandler_PROP_VALUE_GET(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
                                               uint16_t arg_len);
-    ThreadError CommandHandler_PROP_VALUE_SET(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+    otError CommandHandler_PROP_VALUE_SET(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
                                               uint16_t arg_len);
-    ThreadError CommandHandler_PROP_VALUE_INSERT(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+    otError CommandHandler_PROP_VALUE_INSERT(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
                                                  uint16_t arg_len);
-    ThreadError CommandHandler_PROP_VALUE_REMOVE(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+    otError CommandHandler_PROP_VALUE_REMOVE(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
                                                  uint16_t arg_len);
-    ThreadError CommandHandler_NET_SAVE(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
-    ThreadError CommandHandler_NET_CLEAR(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+    otError CommandHandler_NET_SAVE(uint8_t header, unsigned int command, const uint8_t *arg_ptr, uint16_t arg_len);
+    otError CommandHandler_NET_CLEAR(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
                                          uint16_t arg_len);
-    ThreadError CommandHandler_NET_RECALL(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
+    otError CommandHandler_NET_RECALL(uint8_t header, unsigned int command, const uint8_t *arg_ptr,
                                           uint16_t arg_len);
 
-    ThreadError GetPropertyHandler_ChannelMaskHelper(uint8_t header, spinel_prop_key_t key, uint32_t channel_mask);
+    otError GetPropertyHandler_ChannelMaskHelper(uint8_t header, spinel_prop_key_t key, uint32_t channel_mask);
 
-    ThreadError GetPropertyHandler_LAST_STATUS(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_PROTOCOL_VERSION(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_INTERFACE_TYPE(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_VENDOR_ID(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_CAPS(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_NCP_VERSION(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_INTERFACE_COUNT(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_HWADDR(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_LOCK(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_HOST_POWER_STATE(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_PHY_FREQ(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_PHY_CHAN_SUPPORTED(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_PHY_CHAN(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_PHY_RSSI(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_PHY_TX_POWER(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_PHY_RX_SENSITIVITY(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_MAC_15_4_LADDR(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_MAC_15_4_SADDR(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_MAC_RAW_STREAM_ENABLED(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_MAC_EXTENDED_ADDR(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_NET_SAVED(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_NET_IF_UP(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_NET_STACK_UP(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_NET_NETWORK_NAME(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_NET_XPANID(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_NET_MASTER_KEY(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_NET_KEY_SEQUENCE_COUNTER(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_NET_PARTITION_ID(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_NET_KEY_SWITCH_GUARDTIME(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_LEADER(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_IPV6_ML_PREFIX(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_IPV6_ML_ADDR(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_IPV6_LL_ADDR(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_IPV6_ROUTE_TABLE(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_IPV6_ICMP_PING_OFFLOAD(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_RLOC16_DEBUG_PASSTHRU(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_MAC_SCAN_MASK(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_MAC_SCAN_PERIOD(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_LEADER_ADDR(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_PARENT(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_NEIGHBOR_TABLE(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_LEADER_RID(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_NETWORK_DATA(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_NETWORK_DATA_VERSION(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_STABLE_NETWORK_DATA(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_STABLE_NETWORK_DATA_VERSION(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_LEADER_NETWORK_DATA(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_STABLE_LEADER_NETWORK_DATA(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_MAC_PROMISCUOUS_MODE(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_MAC_CNTR(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_NCP_CNTR(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_MSG_BUFFER_COUNTERS(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_MAC_WHITELIST_ENABLED(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_CHILD_TIMEOUT(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_RLOC16(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_NET_REQUIRE_JOIN_EXISTING(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_DEBUG_TEST_ASSERT(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_DEBUG_NCP_LOG_LEVEL(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_DISCOVERY_SCAN_JOINER_FLAG(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_DISCOVERY_SCAN_ENABLE_FILTERING(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_DISCOVERY_SCAN_PANID(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_LAST_STATUS(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_PROTOCOL_VERSION(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_INTERFACE_TYPE(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_VENDOR_ID(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_CAPS(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_NCP_VERSION(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_INTERFACE_COUNT(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_HWADDR(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_LOCK(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_HOST_POWER_STATE(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_PHY_FREQ(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_PHY_CHAN_SUPPORTED(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_PHY_CHAN(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_PHY_RSSI(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_PHY_TX_POWER(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_PHY_RX_SENSITIVITY(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_MAC_15_4_LADDR(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_MAC_15_4_SADDR(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_MAC_RAW_STREAM_ENABLED(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_MAC_EXTENDED_ADDR(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_NET_SAVED(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_NET_IF_UP(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_NET_STACK_UP(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_NET_NETWORK_NAME(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_NET_XPANID(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_NET_MASTER_KEY(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_NET_KEY_SEQUENCE_COUNTER(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_NET_PARTITION_ID(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_NET_KEY_SWITCH_GUARDTIME(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_LEADER(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_IPV6_ML_PREFIX(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_IPV6_ML_ADDR(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_IPV6_LL_ADDR(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_IPV6_ROUTE_TABLE(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_IPV6_ICMP_PING_OFFLOAD(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_RLOC16_DEBUG_PASSTHRU(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_MAC_SCAN_MASK(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_MAC_SCAN_PERIOD(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_LEADER_ADDR(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_PARENT(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_NEIGHBOR_TABLE(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_LEADER_RID(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_NETWORK_DATA(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_NETWORK_DATA_VERSION(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_STABLE_NETWORK_DATA(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_STABLE_NETWORK_DATA_VERSION(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_LEADER_NETWORK_DATA(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_STABLE_LEADER_NETWORK_DATA(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_MAC_PROMISCUOUS_MODE(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_MAC_CNTR(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_NCP_CNTR(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_MSG_BUFFER_COUNTERS(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_MAC_WHITELIST_ENABLED(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_CHILD_TIMEOUT(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_RLOC16(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_NET_REQUIRE_JOIN_EXISTING(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_DEBUG_TEST_ASSERT(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_DEBUG_NCP_LOG_LEVEL(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_DISCOVERY_SCAN_JOINER_FLAG(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_DISCOVERY_SCAN_ENABLE_FILTERING(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_DISCOVERY_SCAN_PANID(uint8_t header, spinel_prop_key_t key);
 
 #if OPENTHREAD_FTD
-    ThreadError GetPropertyHandler_THREAD_CHILD_TABLE(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_ROUTER_ROLE_ENABLED(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_NET_PSKC(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_CHILD_COUNT_MAX(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_ROUTER_UPGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_ROUTER_DOWNGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_ROUTER_SELECTION_JITTER(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_CHILD_TABLE(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_ROUTER_ROLE_ENABLED(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_NET_PSKC(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_CHILD_COUNT_MAX(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_ROUTER_UPGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_ROUTER_DOWNGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_ROUTER_SELECTION_JITTER(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header, spinel_prop_key_t key);
 #endif // #if OPENTHREAD_FTD
 
 #if OPENTHREAD_ENABLE_COMMISSIONER
-    ThreadError GetPropertyHandler_THREAD_COMMISSIONER_ENABLED(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_COMMISSIONER_ENABLED(uint8_t header, spinel_prop_key_t key);
 #endif
 
-    ThreadError GetPropertyHandler_BA_PROXY_ENABLED(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_BA_PROXY_ENABLED(uint8_t header, spinel_prop_key_t key);
 
 #if OPENTHREAD_ENABLE_JAM_DETECTION
-    ThreadError GetPropertyHandler_JAM_DETECT_ENABLE(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_JAM_DETECTED(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_JAM_DETECT_RSSI_THRESHOLD(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_JAM_DETECT_WINDOW(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_JAM_DETECT_BUSY(uint8_t header, spinel_prop_key_t key);
-    ThreadError GetPropertyHandler_JAM_DETECT_HISTORY_BITMAP(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_JAM_DETECT_ENABLE(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_JAM_DETECTED(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_JAM_DETECT_RSSI_THRESHOLD(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_JAM_DETECT_WINDOW(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_JAM_DETECT_BUSY(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_JAM_DETECT_HISTORY_BITMAP(uint8_t header, spinel_prop_key_t key);
 #endif
 
 #if OPENTHREAD_ENABLE_LEGACY
-    ThreadError GetPropertyHandler_NEST_LEGACY_ULA_PREFIX(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_NEST_LEGACY_ULA_PREFIX(uint8_t header, spinel_prop_key_t key);
 #endif
 
 
-    ThreadError SetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                uint16_t value_len);
-    ThreadError SetPropertyHandler_HOST_POWER_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
-                                                    uint16_t value_len);
-    ThreadError SetPropertyHandler_PHY_TX_POWER(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_HOST_POWER_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                 uint16_t value_len);
-    ThreadError SetPropertyHandler_PHY_CHAN(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_PHY_TX_POWER(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                             uint16_t value_len);
-    ThreadError SetPropertyHandler_MAC_SCAN_MASK(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_PHY_CHAN(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                            uint16_t value_len);
+    otError SetPropertyHandler_MAC_SCAN_MASK(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                  uint16_t value_len);
-    ThreadError SetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_MAC_SCAN_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                   uint16_t value_len);
-    ThreadError SetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_MAC_15_4_PANID(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                   uint16_t value_len);
-    ThreadError SetPropertyHandler_MAC_15_4_LADDR(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_MAC_15_4_LADDR(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                   uint16_t value_len);
-    ThreadError SetPropertyHandler_MAC_RAW_STREAM_ENABLED(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_MAC_RAW_STREAM_ENABLED(uint8_t header, spinel_prop_key_t key,
                                                           const uint8_t *value_ptr, uint16_t value_len);
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
-    ThreadError SetPropertyHandler_MAC_15_4_SADDR(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_MAC_15_4_SADDR(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                   uint16_t value_len);
-    ThreadError SetPropertyHandler_STREAM_RAW(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_STREAM_RAW(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                               uint16_t value_len);
 #endif // OPENTHREAD_ENABLE_RAW_LINK_API
 
-    ThreadError SetPropertyHandler_NET_IF_UP(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_NET_IF_UP(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                              uint16_t value_len);
-    ThreadError SetPropertyHandler_NET_STACK_UP(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_NET_STACK_UP(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                 uint16_t value_len);
-    ThreadError SetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_NET_ROLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                             uint16_t value_len);
-    ThreadError SetPropertyHandler_NET_NETWORK_NAME(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_NET_NETWORK_NAME(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                     uint16_t value_len);
-    ThreadError SetPropertyHandler_NET_XPANID(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_NET_XPANID(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                               uint16_t value_len);
-    ThreadError SetPropertyHandler_NET_MASTER_KEY(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_NET_MASTER_KEY(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                   uint16_t value_len);
-    ThreadError SetPropertyHandler_NET_KEY_SEQUENCE_COUNTER(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_NET_KEY_SEQUENCE_COUNTER(uint8_t header, spinel_prop_key_t key,
                                                             const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_NET_KEY_SWITCH_GUARDTIME(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_NET_KEY_SWITCH_GUARDTIME(uint8_t header, spinel_prop_key_t key,
                                                             const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_STREAM_NET_INSECURE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_STREAM_NET_INSECURE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                        uint16_t value_len);
-    ThreadError SetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                               uint16_t value_len);
-    ThreadError SetPropertyHandler_IPV6_ML_PREFIX(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_IPV6_ML_PREFIX(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                   uint16_t value_len);
-    ThreadError SetPropertyHandler_IPV6_ICMP_PING_OFFLOAD(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_IPV6_ICMP_PING_OFFLOAD(uint8_t header, spinel_prop_key_t key,
                                                           const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_THREAD_RLOC16_DEBUG_PASSTHRU(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_THREAD_RLOC16_DEBUG_PASSTHRU(uint8_t header, spinel_prop_key_t key,
                                                                 const uint8_t *value_ptr, uint16_t value_len);
 
-    ThreadError SetPropertyHandler_THREAD_BA_PROXY_STREAM(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_THREAD_BA_PROXY_STREAM(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                           uint16_t value_len);
 #if OPENTHREAD_ENABLE_RAW_LINK_API
-    ThreadError SetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                uint16_t value_len);
 #endif // OPENTHREAD_ENABLE_RAW_LINK_API
 
-    ThreadError SetPropertyHandler_MAC_PROMISCUOUS_MODE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_MAC_PROMISCUOUS_MODE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                         uint16_t value_len);
-    ThreadError SetPropertyHandler_MAC_SCAN_PERIOD(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_MAC_SCAN_PERIOD(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                    uint16_t value_len);
-    ThreadError SetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                  uint16_t value_len);
-    ThreadError SetPropertyHandler_MAC_WHITELIST_ENABLED(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_MAC_WHITELIST_ENABLED(uint8_t header, spinel_prop_key_t key,
                                                          const uint8_t *value_ptr, uint16_t value_len);
 #if OPENTHREAD_ENABLE_RAW_LINK_API
-    ThreadError SetPropertyHandler_MAC_SRC_MATCH_ENABLED(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_MAC_SRC_MATCH_ENABLED(uint8_t header, spinel_prop_key_t key,
                                                          const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_MAC_SRC_MATCH_SHORT_ADDRESSES(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_MAC_SRC_MATCH_SHORT_ADDRESSES(uint8_t header, spinel_prop_key_t key,
                                                                  const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_MAC_SRC_MATCH_EXTENDED_ADDRESSES(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_MAC_SRC_MATCH_EXTENDED_ADDRESSES(uint8_t header, spinel_prop_key_t key,
                                                                     const uint8_t *value_ptr, uint16_t value_len);
 #endif
 #if OPENTHREAD_FTD
-    ThreadError SetPropertyHandler_NET_PSKC(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_NET_PSKC(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                             uint16_t value_len);
 #endif
-    ThreadError SetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                uint16_t value_len);
 
 #if OPENTHREAD_FTD
-    ThreadError SetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT(uint8_t header, spinel_prop_key_t key,
                                                               const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_THREAD_CHILD_COUNT_MAX(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_THREAD_CHILD_COUNT_MAX(uint8_t header, spinel_prop_key_t key,
                                                           const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_THREAD_CHILD_TIMEOUT(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_THREAD_CHILD_TIMEOUT(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                         uint16_t value_len);
-    ThreadError SetPropertyHandler_THREAD_ROUTER_UPGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_THREAD_ROUTER_UPGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key,
                                                                    const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_THREAD_ROUTER_DOWNGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_THREAD_ROUTER_DOWNGRADE_THRESHOLD(uint8_t header, spinel_prop_key_t key,
                                                                      const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_THREAD_ROUTER_SELECTION_JITTER(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_THREAD_ROUTER_SELECTION_JITTER(uint8_t header, spinel_prop_key_t key,
                                                                   const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_THREAD_CONTEXT_REUSE_DELAY(uint8_t header, spinel_prop_key_t key,
                                                               const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header, spinel_prop_key_t key,
                                                              const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_THREAD_PREFERRED_ROUTER_ID(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_THREAD_PREFERRED_ROUTER_ID(uint8_t header, spinel_prop_key_t key,
                                                               const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE(uint8_t header, spinel_prop_key_t key,
                                                                       const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_THREAD_ROUTER_ROLE_ENABLED(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_THREAD_ROUTER_ROLE_ENABLED(uint8_t header, spinel_prop_key_t key,
                                                               const uint8_t *value_ptr, uint16_t value_len);
 #if OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
-    ThreadError SetPropertyHandler_THREAD_THREAD_STEERING_DATA(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_THREAD_THREAD_STEERING_DATA(uint8_t header, spinel_prop_key_t key,
                                                                const uint8_t *value_ptr, uint16_t value_len);
 #endif
 
 #endif // #if OPENTHREAD_FTD
 
-    ThreadError SetPropertyHandler_THREAD_DISCOVERY_SCAN_JOINER_FLAG(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_THREAD_DISCOVERY_SCAN_JOINER_FLAG(uint8_t header, spinel_prop_key_t key,
                                                                      const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_THREAD_DISCOVERY_SCAN_ENABLE_FILTERING(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_THREAD_DISCOVERY_SCAN_ENABLE_FILTERING(uint8_t header, spinel_prop_key_t key,
                                                                           const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_THREAD_DISCOVERY_SCAN_PANID(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_THREAD_DISCOVERY_SCAN_PANID(uint8_t header, spinel_prop_key_t key,
                                                                const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
                                                           const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_NET_REQUIRE_JOIN_EXISTING(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_NET_REQUIRE_JOIN_EXISTING(uint8_t header, spinel_prop_key_t key,
                                                              const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_CNTR_RESET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_CNTR_RESET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                               uint16_t value_len);
-    ThreadError SetPropertyHandler_DEBUG_NCP_LOG_LEVEL(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_DEBUG_NCP_LOG_LEVEL(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                    uint16_t value_len);
 #if OPENTHREAD_ENABLE_COMMISSIONER
-    ThreadError SetPropertyHandler_THREAD_COMMISSIONER_ENABLED(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_THREAD_COMMISSIONER_ENABLED(uint8_t header, spinel_prop_key_t key,
                                                                const uint8_t *value_ptr, uint16_t value_len);
 #endif
 
-    ThreadError SetPropertyHandler_BA_PROXY_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_BA_PROXY_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                     uint16_t value_len);
 #if OPENTHREAD_ENABLE_JAM_DETECTION
-    ThreadError SetPropertyHandler_JAM_DETECT_ENABLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_JAM_DETECT_ENABLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                      uint16_t value_len);
-    ThreadError SetPropertyHandler_JAM_DETECT_RSSI_THRESHOLD(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_JAM_DETECT_RSSI_THRESHOLD(uint8_t header, spinel_prop_key_t key,
                                                              const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError SetPropertyHandler_JAM_DETECT_WINDOW(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_JAM_DETECT_WINDOW(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                      uint16_t value_len);
-    ThreadError SetPropertyHandler_JAM_DETECT_BUSY(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_JAM_DETECT_BUSY(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                    uint16_t value_len);
 #endif
 
 #if OPENTHREAD_ENABLE_DIAG
-    ThreadError SetPropertyHandler_NEST_STREAM_MFG(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_NEST_STREAM_MFG(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                    uint16_t value_len);
 #endif
 
 #if OPENTHREAD_ENABLE_LEGACY
-    ThreadError SetPropertyHandler_NEST_LEGACY_ULA_PREFIX(uint8_t header, spinel_prop_key_t key,
+    otError SetPropertyHandler_NEST_LEGACY_ULA_PREFIX(uint8_t header, spinel_prop_key_t key,
                                                           const uint8_t *value_ptr, uint16_t value_len);
 #endif
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
-    ThreadError InsertPropertyHandler_MAC_SRC_MATCH_SHORT_ADDRESSES(uint8_t header, spinel_prop_key_t key,
+    otError InsertPropertyHandler_MAC_SRC_MATCH_SHORT_ADDRESSES(uint8_t header, spinel_prop_key_t key,
                                                                     const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError InsertPropertyHandler_MAC_SRC_MATCH_EXTENDED_ADDRESSES(uint8_t header, spinel_prop_key_t key,
+    otError InsertPropertyHandler_MAC_SRC_MATCH_EXTENDED_ADDRESSES(uint8_t header, spinel_prop_key_t key,
                                                                        const uint8_t *value_ptr, uint16_t value_len);
 #endif
-    ThreadError InsertPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key,
+    otError InsertPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key,
                                                          const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError InsertPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key,
+    otError InsertPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key,
                                                           const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError InsertPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key,
+    otError InsertPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key,
                                                           const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError InsertPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
+    otError InsertPropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
                                                              const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError InsertPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError InsertPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                     uint16_t value_len);
 #if OPENTHREAD_ENABLE_COMMISSIONER
-    ThreadError InsertPropertyHandler_THREAD_JOINERS(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError InsertPropertyHandler_THREAD_JOINERS(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
             uint16_t value_len);
 #endif
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
-    ThreadError RemovePropertyHandler_MAC_SRC_MATCH_SHORT_ADDRESSES(uint8_t header, spinel_prop_key_t key,
+    otError RemovePropertyHandler_MAC_SRC_MATCH_SHORT_ADDRESSES(uint8_t header, spinel_prop_key_t key,
                                                                     const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError RemovePropertyHandler_MAC_SRC_MATCH_EXTENDED_ADDRESSES(uint8_t header, spinel_prop_key_t key,
+    otError RemovePropertyHandler_MAC_SRC_MATCH_EXTENDED_ADDRESSES(uint8_t header, spinel_prop_key_t key,
                                                                        const uint8_t *value_ptr, uint16_t value_len);
 #endif
-    ThreadError RemovePropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key,
+    otError RemovePropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key,
                                                          const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError RemovePropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key,
+    otError RemovePropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key,
                                                           const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError RemovePropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key,
+    otError RemovePropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key,
                                                           const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError RemovePropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
+    otError RemovePropertyHandler_THREAD_ASSISTING_PORTS(uint8_t header, spinel_prop_key_t key,
                                                              const uint8_t *value_ptr, uint16_t value_len);
-    ThreadError RemovePropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError RemovePropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                     uint16_t value_len);
 #if OPENTHREAD_FTD
-    ThreadError RemovePropertyHandler_THREAD_ACTIVE_ROUTER_IDS(uint8_t header, spinel_prop_key_t key,
+    otError RemovePropertyHandler_THREAD_ACTIVE_ROUTER_IDS(uint8_t header, spinel_prop_key_t key,
                                                                const uint8_t *value_ptr, uint16_t value_len);
 #endif
 
 public:
-    ThreadError StreamWrite(int aStreamId, const uint8_t *aDataPtr, int aDataLen);
+    otError StreamWrite(int aStreamId, const uint8_t *aDataPtr, int aDataLen);
 
 #if OPENTHREAD_ENABLE_LEGACY
 public:

--- a/src/ncp/ncp_buffer.hpp
+++ b/src/ncp/ncp_buffer.hpp
@@ -58,7 +58,7 @@ public:
      * @param[in]  aError           An error value representing the success or failure of the frame transmit attempt.
      *
      */
-    typedef void (*FrameTransmitCallback)(void *aContext, ThreadError aError);
+    typedef void (*FrameTransmitCallback)(void *aContext, otError aError);
 
     /**
      * This constructor creates an NCP frame buffer.
@@ -101,11 +101,11 @@ public:
      * If there is a previous frame being written (`InFrameEnd()` has not yet been called on the frame), this method
      * will discard and clear the previous unfinished frame.
      *
-     * @retval kThreadError_None      Successfully started a new frame.
-     * @retval kThreadError_NoBufs    Insufficient buffer space available to start a new frame.
+     * @retval OT_ERROR_NONE      Successfully started a new frame.
+     * @retval OT_ERROR_NO_BUFS   Insufficient buffer space available to start a new frame.
      *
      */
-    ThreadError InFrameBegin(void);
+    otError InFrameBegin(void);
 
     /**
      * This method adds data to the current input frame being written to the buffer.
@@ -115,11 +115,11 @@ public:
      * @param[in]  aDataBuffer        A pointer to data buffer.
      * @param[in]  aDataBufferLength  The length of the data buffer.
      *
-     * @retval kThreadError_None      Successfully added new data to the frame.
-     * @retval kThreadError_NoBufs    Insufficient buffer space available to add data.
+     * @retval OT_ERROR_NONE      Successfully added new data to the frame.
+     * @retval OT_ERROR_NO_BUFS   Insufficient buffer space available to add data.
      *
      */
-    ThreadError InFrameFeedData(const uint8_t *aDataBuffer, uint16_t aDataBufferLength);
+    otError InFrameFeedData(const uint8_t *aDataBuffer, uint16_t aDataBufferLength);
 
     /**
      * This method adds a message to the current input frame being written to the buffer.
@@ -130,22 +130,22 @@ public:
      *
      * @param[in]  aMessage         A  message to be added to current frame.
      *
-     * @retval kThreadError_None    Successfully added the message to the frame.
-     * @retval kThreadError_NoBufs  Insufficient buffer space available to add message.
+     * @retval OT_ERROR_NONE     Successfully added the message to the frame.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffer space available to add message.
      *
      */
-    ThreadError InFrameFeedMessage(otMessage *aMessage);
+    otError InFrameFeedMessage(otMessage *aMessage);
 
     /**
      * This method finalizes/ends the current input frame being written to the buffer.
      *
      * If no buffer space is available, this method will discard and clear the frame before returning an error status.
      *
-     * @retval kThreadError_None    Successfully added the message to the frame.
-     * @retval kThreadError_NoBufs  Insufficient buffer space available to add message.
+     * @retval OT_ERROR_NONE     Successfully added the message to the frame.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffer space available to add message.
      *
      */
-    ThreadError InFrameEnd(void);
+    otError InFrameEnd(void);
 
     /**
      * This method checks if the buffer is empty. An non-empty buffer contains at least one full frame for reading.
@@ -165,11 +165,11 @@ public:
      * If part of current frame has already been read, a sub-sequent call to this method will reset the read offset
      * back to beginning of current output frame.
      *
-     * @retval kThreadError_None      Successfully started/prepared a new output frame for reading.
-     * @retval kThreadError_NotFound  No frame available in buffer for reading.
+     * @retval OT_ERROR_NONE       Successfully started/prepared a new output frame for reading.
+     * @retval OT_ERROR_NOT_FOUND  No frame available in buffer for reading.
      *
      */
-    ThreadError OutFrameBegin(void);
+    otError OutFrameBegin(void);
 
     /**
      * This method checks if the current output frame (being read) has ended.
@@ -223,11 +223,11 @@ public:
      *
      * If the remove operation causes the buffer to become empty this method will invoke the `EmptyBufferCallback`.
      *
-     * @retval kThreadError_None      Successfully removed the front frame.
-     * @retval kThreadError_NotFound  No frame available in NCP frame buffer to remove.
+     * @retval OT_ERROR_NONE       Successfully removed the front frame.
+     * @retval OT_ERROR_NOT_FOUND  No frame available in NCP frame buffer to remove.
      *
      */
-    ThreadError OutFrameRemove(void);
+    otError OutFrameRemove(void);
 
     /**
      * This method returns the number of bytes (length) of current/front frame in the NCP frame buffer.
@@ -250,11 +250,11 @@ public:
      * @param[in]  aFrameTransmitCallback   Callback invoked when NcpBuffer transmits the current last frame.
      * @param[in]  aContex                  A pointer to arbitrary context information.
      *
-     * @retval kThreadError_None      Successfully accepted the callback.
-     * @retval kThreadError_Busy      The feature is already in use and busy.
+     * @retval OT_ERROR_NONE      Successfully accepted the callback.
+     * @retval OT_ERROR_BUSY      The feature is already in use and busy.
      *
      */
-    ThreadError SetFrameTransmitCallback(FrameTransmitCallback aFrameTransmitCallback, void *aContext);
+    otError SetFrameTransmitCallback(FrameTransmitCallback aFrameTransmitCallback, void *aContext);
 
 private:
 
@@ -334,15 +334,15 @@ private:
     uint16_t        ReadUint16At(uint8_t *aBufPtr);
     void            WriteUint16At(uint8_t *aBufPtr, uint16_t aValue);
 
-    ThreadError     InFrameFeedByte(uint8_t aByte);
-    ThreadError     InFrameBeginSegment(void);
+    otError     InFrameFeedByte(uint8_t aByte);
+    otError     InFrameBeginSegment(void);
     void            InFrameEndSegment(uint16_t aSegmentHeaderFlags);
     void            InFrameDiscard(void);
 
-    ThreadError     OutFramePrepareSegment(void);
+    otError     OutFramePrepareSegment(void);
     void            OutFrameMoveToNextSegment(void);
-    ThreadError     OutFramePrepareMessage(void);
-    ThreadError     OutFrameFillMessageBuffer(void);
+    otError     OutFramePrepareMessage(void);
+    otError     OutFrameFillMessageBuffer(void);
 
     // Instance variables
 

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -232,9 +232,9 @@ void NcpSpi::TxFrameBufferHasData(void)
     mPrepareTxFrameTask.Post();
 }
 
-ThreadError NcpSpi::PrepareNextSpiSendFrame(void)
+otError NcpSpi::PrepareNextSpiSendFrame(void)
 {
-    ThreadError errorCode = kThreadError_None;
+    otError errorCode = OT_ERROR_NONE;
     uint16_t frameLength;
     uint16_t readLength;
 
@@ -248,7 +248,7 @@ ThreadError NcpSpi::PrepareNextSpiSendFrame(void)
     SuccessOrExit(errorCode = mTxFrameBuffer.OutFrameBegin());
 
     frameLength = mTxFrameBuffer.OutFrameGetLength();
-    VerifyOrExit(frameLength <= sizeof(mSendFrame) - kSpiHeaderLength, errorCode = kThreadError_NoBufs);
+    VerifyOrExit(frameLength <= sizeof(mSendFrame) - kSpiHeaderLength, errorCode = OT_ERROR_NO_BUFS);
 
     spi_header_set_data_len(mSendFrame, frameLength);
 
@@ -256,7 +256,7 @@ ThreadError NcpSpi::PrepareNextSpiSendFrame(void)
     spi_header_set_accept_len(mSendFrame, 0);
 
     readLength = mTxFrameBuffer.OutFrameRead(frameLength, mSendFrame + kSpiHeaderLength);
-    VerifyOrExit(readLength == frameLength, errorCode = kThreadError_Failed);
+    VerifyOrExit(readLength == frameLength, errorCode = OT_ERROR_FAILED);
 
     mSendFrameLen = frameLength + kSpiHeaderLength;
 
@@ -265,15 +265,15 @@ ThreadError NcpSpi::PrepareNextSpiSendFrame(void)
     errorCode = otPlatSpiSlavePrepareTransaction(mSendFrame, mSendFrameLen, mEmptyReceiveFrame,
                                                  sizeof(mEmptyReceiveFrame), true);
 
-    if (errorCode == kThreadError_Busy)
+    if (errorCode == OT_ERROR_BUSY)
     {
         // Being busy is OK. We will get the transaction
         // set up properly when the current transaction
         // is completed.
-        errorCode = kThreadError_None;
+        errorCode = OT_ERROR_NONE;
     }
 
-    if (errorCode != kThreadError_None)
+    if (errorCode != OT_ERROR_NONE)
     {
         mTxState = kTxStateIdle;
         mPrepareTxFrameTask.Post();

--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -89,7 +89,7 @@ private:
     static void TxFrameBufferHasData(void *aContext, NcpFrameBuffer *aNcpFrameBuffer);
     void TxFrameBufferHasData(void);
 
-    ThreadError PrepareNextSpiSendFrame(void);
+    otError PrepareNextSpiSendFrame(void);
 
     TxState mTxState;
     bool mHandlingRxFrame;

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -187,7 +187,7 @@ exit:
 
     if (len > 0)
     {
-        if (otPlatUartSend(mUartBuffer.GetBuffer(), len) != kThreadError_None)
+        if (otPlatUartSend(mUartBuffer.GetBuffer(), len) != OT_ERROR_NONE)
         {
             assert(false);
         }
@@ -236,12 +236,12 @@ void NcpUart::HandleFrame(uint8_t *aBuf, uint16_t aBufLength)
     super_t::HandleReceive(aBuf, aBufLength);
 }
 
-void NcpUart::HandleError(void *aContext, ThreadError aError, uint8_t *aBuf, uint16_t aBufLength)
+void NcpUart::HandleError(void *aContext, otError aError, uint8_t *aBuf, uint16_t aBufLength)
 {
     static_cast<NcpUart *>(aContext)->HandleError(aError, aBuf, aBufLength);
 }
 
-void NcpUart::HandleError(ThreadError aError, uint8_t *aBuf, uint16_t aBufLength)
+void NcpUart::HandleError(otError aError, uint8_t *aBuf, uint16_t aBufLength)
 {
     char hexbuf[128];
     uint16_t i = 0;

--- a/src/ncp/ncp_uart.hpp
+++ b/src/ncp/ncp_uart.hpp
@@ -101,12 +101,12 @@ private:
 
     void            EncodeAndSendToUart(void);
     void            HandleFrame(uint8_t *aBuf, uint16_t aBufLength);
-    void            HandleError(ThreadError aError, uint8_t *aBuf, uint16_t aBufLength);
+    void            HandleError(otError aError, uint8_t *aBuf, uint16_t aBufLength);
     void            TxFrameBufferHasData(void);
 
     static void     EncodeAndSendToUart(void *aContext);
     static void     HandleFrame(void *context, uint8_t *aBuf, uint16_t aBufLength);
-    static void     HandleError(void *context, ThreadError aError, uint8_t *aBuf, uint16_t aBufLength);
+    static void     HandleError(void *context, otError aError, uint8_t *aBuf, uint16_t aBufLength);
     static void     TxFrameBufferHasData(void *aContext, NcpFrameBuffer *aNcpFrameBuffer);
 
     Hdlc::Encoder   mFrameEncoder;

--- a/tests/unit/test_diag.cpp
+++ b/tests/unit/test_diag.cpp
@@ -57,14 +57,14 @@ extern "C" void otPlatAlarmFired(otInstance *)
 {
 }
 
-extern "C" void otPlatRadioTransmitDone(otInstance *, RadioPacket *aFrame, bool aRxPending, ThreadError aError)
+extern "C" void otPlatRadioTransmitDone(otInstance *, RadioPacket *aFrame, bool aRxPending, otError aError)
 {
     (void)aFrame;
     (void)aRxPending;
     (void)aError;
 }
 
-extern "C" void otPlatRadioReceiveDone(otInstance *, RadioPacket *aFrame, ThreadError aError)
+extern "C" void otPlatRadioReceiveDone(otInstance *, RadioPacket *aFrame, otError aError)
 {
     (void)aFrame;
     (void)aError;
@@ -88,7 +88,7 @@ void TestDiag()
         },
         {
             "diag send 10 100\n",
-            "failed\r\nstatus 0xe\r\n",
+            "failed\r\nstatus 0xd\r\n",
         },
         {
             "diag start\n",

--- a/tests/unit/test_fuzz.cpp
+++ b/tests/unit/test_fuzz.cpp
@@ -42,40 +42,40 @@ bool testFuzzRadioIsEnabled(otInstance *)
     return g_fRadioEnabled;
 }
 
-ThreadError testFuzzRadioEnable(otInstance *)
+otError testFuzzRadioEnable(otInstance *)
 {
 #ifdef DBG_FUZZ
     Log("Radio enabled");
 #endif
     g_fRadioEnabled = true;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError testFuzzRadioDisable(otInstance *)
+otError testFuzzRadioDisable(otInstance *)
 {
 #ifdef DBG_FUZZ
     Log("Radio disabled");
 #endif
     g_fRadioEnabled = false;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError testFuzzRadioReceive(otInstance *, uint8_t aChannel)
+otError testFuzzRadioReceive(otInstance *, uint8_t aChannel)
 {
 #ifdef DBG_FUZZ
     Log("==> receive");
 #endif
     g_RecvChannel = aChannel;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
-ThreadError testFuzzRadioTransmit(otInstance *)
+otError testFuzzRadioTransmit(otInstance *)
 {
 #ifdef DBG_FUZZ
     Log("==> transmit");
 #endif
     g_fTransmit = true;
-    return kThreadError_None;
+    return OT_ERROR_NONE;
 }
 
 RadioPacket *testFuzztRadioGetTransmitBuffer(otInstance *)
@@ -151,7 +151,7 @@ void TestFuzz(uint32_t aSeconds)
             if (g_fTransmit)
             {
                 g_fTransmit = false;
-                otPlatRadioTransmitDone(aInstance, &g_TransmitRadioPacket, true, kThreadError_None);
+                otPlatRadioTransmitDone(aInstance, &g_TransmitRadioPacket, true, OT_ERROR_NONE);
 #ifdef DBG_FUZZ
                 Log("<== transmit");
 #endif
@@ -178,7 +178,7 @@ void TestFuzz(uint32_t aSeconds)
                 g_RecvChannel = 0;
 
                 // Indicate the receive complete
-                otPlatRadioReceiveDone(aInstance, &fuzzPacket, kThreadError_None);
+                otPlatRadioReceiveDone(aInstance, &fuzzPacket, OT_ERROR_NONE);
 
                 countRecv++;
 #ifdef DBG_FUZZ

--- a/tests/unit/test_lowpan.cpp
+++ b/tests/unit/test_lowpan.cpp
@@ -181,7 +181,7 @@ static void Test(TestIphcVector &aVector, bool aCompress, bool aDecompress)
         int compressBytes = sMockLowpan.Compress(*message, aVector.mMacSource, aVector.mMacDestination,
                                                  result);
 
-        if (aVector.mError == kThreadError_None)
+        if (aVector.mError == OT_ERROR_NONE)
         {
             // Append payload to the LOWPAN_IPHC.
             message->Read(message->GetOffset(),
@@ -216,7 +216,7 @@ static void Test(TestIphcVector &aVector, bool aCompress, bool aDecompress)
 
         message->Read(0, message->GetLength(), result);
 
-        if (aVector.mError == kThreadError_None)
+        if (aVector.mError == OT_ERROR_NONE)
         {
             // Append payload to the IPv6 Packet.
             memcpy(result + message->GetLength(), iphc + decompressedBytes,
@@ -279,7 +279,7 @@ static void TestFullyCompressableLongAddresses(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -305,7 +305,7 @@ static void TestFullyCompressableShortAddresses(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -331,7 +331,7 @@ static void TestFullyCompressableShortLongAddresses(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -357,7 +357,7 @@ static void TestFullyCompressableLongShortAddresses(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -383,7 +383,7 @@ static void TestSourceUnspecifiedAddress(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -414,7 +414,7 @@ static void TestSource128bitDestination128bitAddresses(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -443,7 +443,7 @@ static void TestSource64bitDestination64bitLongAddresses(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -472,7 +472,7 @@ static void TestSource64bitDestination64bitShortAddresses(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -498,7 +498,7 @@ static void TestSource16bitDestination16bitAddresses(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -524,7 +524,7 @@ static void TestSourceCompressedDestination16bitAddresses(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -553,7 +553,7 @@ static void TestSourceCompressedDestination128bitAddresses(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -583,7 +583,7 @@ static void TestMulticast128bitAddress(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -611,7 +611,7 @@ static void TestMulticast48bitAddress(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -639,7 +639,7 @@ static void TestMulticast32bitAddress(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -665,7 +665,7 @@ static void TestMulticast8bitAddress(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -694,7 +694,7 @@ static void TestStatefulSource64bitDestination64bitContext0(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -723,7 +723,7 @@ static void TestStatefulSource64bitDestination64bitContext0IfContextInLine(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform decompression test only.
     Test(testVector, false, true);
@@ -749,7 +749,7 @@ static void TestStatefulSource16bitDestination16bitContext0(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -775,7 +775,7 @@ static void TestStatefulCompressableLongAddressesContext0(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -801,7 +801,7 @@ static void TestStatefulCompressableShortAddressesContext0(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -827,7 +827,7 @@ static void TestStatefulCompressableLongShortAddressesContext0(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -857,7 +857,7 @@ static void TestStatefulSource64bitDestination128bitContext1(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -886,7 +886,7 @@ static void TestStatefulSource64bitDestination64bitContext1(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -917,7 +917,7 @@ static void TestStatefulSourceDestinationInlineContext2CIDFalse(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression test only.
     Test(testVector, true, false);
@@ -945,7 +945,7 @@ static void TestStatefulMulticastDestination48bitContext0(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform decompression tests.
     Test(testVector, true, true);
@@ -971,7 +971,7 @@ static void TestTrafficClassFlowLabel3Bytes(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -997,7 +997,7 @@ static void TestTrafficClassFlowLabel1Byte(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1023,7 +1023,7 @@ static void TestTrafficClassFlowLabel1ByteEcnOnly(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1049,7 +1049,7 @@ static void TestTrafficClassFlowLabelInline(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1075,7 +1075,7 @@ static void TestHopLimit1(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1101,7 +1101,7 @@ static void TestHopLimit255(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1127,7 +1127,7 @@ static void TestHopLimitInline(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1156,7 +1156,7 @@ static void TestUdpSourceDestinationInline(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(48);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1185,7 +1185,7 @@ static void TestUdpSourceInlineDestination8bit(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(48);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1214,7 +1214,7 @@ static void TestUdpSource8bitDestinationInline(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(48);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1243,7 +1243,7 @@ static void TestUdpFullyCompressed(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(48);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1272,7 +1272,7 @@ static void TestUdpFullyCompressedMulticast(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(48);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1298,7 +1298,7 @@ static void TestUdpWithoutNhc(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(40);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform only decompression test.
     Test(testVector, false, true);
@@ -1330,7 +1330,7 @@ static void TestExtensionHeaderHopByHopNoPadding(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(48);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1362,7 +1362,7 @@ static void TestExtensionHeaderHopByHopPad1(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(48);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1394,7 +1394,7 @@ static void TestExtensionHeaderHopByHopPadN2(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(48);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1426,7 +1426,7 @@ static void TestExtensionHeaderHopByHopPadN3(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(48);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1458,7 +1458,7 @@ static void TestExtensionHeaderHopByHopPadN4(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(48);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1493,7 +1493,7 @@ static void TestExtensionHeaderHopByHopPadN5(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(56);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1530,7 +1530,7 @@ static void TestExtensionHeaderHopByHopPadN6(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(64);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1566,7 +1566,7 @@ static void TestExtensionHeaderHopByHopPadN7(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(64);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1601,7 +1601,7 @@ static void TestExtensionHeaderHopByHopPadN2UdpFullyCompressed(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(56);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1643,7 +1643,7 @@ static void TestIpInIpHopByHopPadN2UdpSourceDestinationInline(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(96);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1676,7 +1676,7 @@ static void TestIpInIpWithoutExtensionHeader(void)
     // Set payload and error.
     testVector.SetPayload(sTestPayloadDefault, sizeof(sTestPayloadDefault));
     testVector.SetPayloadOffset(80);
-    testVector.SetError(kThreadError_None);
+    testVector.SetError(OT_ERROR_NONE);
 
     // Perform compression and decompression tests.
     Test(testVector, true, true);
@@ -1695,7 +1695,7 @@ static void TestErrorNoIphcDispatch(void)
     testVector.SetIphcHeader(iphc, sizeof(iphc));
 
     // Set payload and error.
-    testVector.SetError(kThreadError_Parse);
+    testVector.SetError(OT_ERROR_PARSE);
 
     // Perform decompression test.
     Test(testVector, false, true);
@@ -1714,7 +1714,7 @@ static void TestErrorTruncatedIphc(void)
     testVector.SetIphcHeader(iphc, sizeof(iphc));
 
     // Set payload and error.
-    testVector.SetError(kThreadError_Parse);
+    testVector.SetError(OT_ERROR_PARSE);
 
     // Perform decompression test.
     Test(testVector, false, true);
@@ -1733,7 +1733,7 @@ static void TestErrorReservedValueDestination0100(void)
     testVector.SetIphcHeader(iphc, sizeof(iphc));
 
     // Set payload and error.
-    testVector.SetError(kThreadError_Parse);
+    testVector.SetError(OT_ERROR_PARSE);
 
     // Perform decompression test.
     Test(testVector, false, true);
@@ -1752,7 +1752,7 @@ static void TestErrorReservedValueDestination1101(void)
     testVector.SetIphcHeader(iphc, sizeof(iphc));
 
     // Set payload and error.
-    testVector.SetError(kThreadError_Parse);
+    testVector.SetError(OT_ERROR_PARSE);
 
     // Perform decompression test.
     Test(testVector, false, true);
@@ -1771,7 +1771,7 @@ static void TestErrorReservedValueDestination1110(void)
     testVector.SetIphcHeader(iphc, sizeof(iphc));
 
     // Set payload and error.
-    testVector.SetError(kThreadError_Parse);
+    testVector.SetError(OT_ERROR_PARSE);
 
     // Perform decompression test.
     Test(testVector, false, true);
@@ -1790,7 +1790,7 @@ static void TestErrorReservedValueDestination1111(void)
     testVector.SetIphcHeader(iphc, sizeof(iphc));
 
     // Set payload and error.
-    testVector.SetError(kThreadError_Parse);
+    testVector.SetError(OT_ERROR_PARSE);
 
     // Perform decompression test.
     Test(testVector, false, true);
@@ -1809,7 +1809,7 @@ static void TestErrorUnknownNhc(void)
     testVector.SetIphcHeader(iphc, sizeof(iphc));
 
     // Set payload and error.
-    testVector.SetError(kThreadError_Parse);
+    testVector.SetError(OT_ERROR_PARSE);
 
     // Perform decompression test.
     Test(testVector, false, true);
@@ -1828,7 +1828,7 @@ static void TestErrorReservedNhc5(void)
     testVector.SetIphcHeader(iphc, sizeof(iphc));
 
     // Set payload and error.
-    testVector.SetError(kThreadError_Parse);
+    testVector.SetError(OT_ERROR_PARSE);
 
     // Perform decompression test.
     Test(testVector, false, true);
@@ -1847,7 +1847,7 @@ static void TestErrorReservedNhc6(void)
     testVector.SetIphcHeader(iphc, sizeof(iphc));
 
     // Set payload and error.
-    testVector.SetError(kThreadError_Parse);
+    testVector.SetError(OT_ERROR_PARSE);
 
     // Perform decompression test.
     Test(testVector, false, true);

--- a/tests/unit/test_lowpan.hpp
+++ b/tests/unit/test_lowpan.hpp
@@ -201,7 +201,7 @@ public:
      * @param aError  Expected result.
      *
      */
-    void SetError(ThreadError aError) { mError = aError; }
+    void SetError(otError aError) { mError = aError; }
 
     /**
      * This method initializes IPv6 Payload (uncompressed data).
@@ -274,7 +274,7 @@ public:
      *
      */
     Payload           mPayload;
-    ThreadError       mError;
+    otError       mError;
     const char       *mTestName;
 };
 

--- a/tests/unit/test_message_queue.cpp
+++ b/tests/unit/test_message_queue.cpp
@@ -77,7 +77,7 @@ void TestMessageQueue(void)
     ot::MessagePool messagePool(&instance);
     ot::MessageQueue messageQueue;
     ot::Message *msg[kNumTestMessages];
-    ThreadError error;
+    otError error;
     uint16_t msgCount, bufferCount;
 
     for (int i = 0; i < kNumTestMessages; i++)
@@ -142,9 +142,10 @@ void TestMessageQueue(void)
     SuccessOrQuit(messageQueue.Enqueue(*msg[0]), "MessageQueue::Enqueue() failed.\n");
     VerifyMessageQueueContent(messageQueue, 1, msg[0]);
     error = messageQueue.Enqueue(*msg[0]);
-    VerifyOrQuit(error == kThreadError_Already, "Enqueuing an already queued message did not fail as expected.\n");
+    VerifyOrQuit(error == OT_ERROR_ALREADY, "Enqueuing an already queued message did not fail as expected.\n");
     error = messageQueue.Dequeue(*msg[1]);
-    VerifyOrQuit(error == kThreadError_NotFound, "Dequeuing a message not in the queue did not fail as expected.\n");
+    VerifyOrQuit(error == OT_ERROR_NOT_FOUND,
+                 "Dequeuing a message not in the queue did not fail as expected.\n");
 }
 
 // This function verifies the content of the message queue to match the passed in messages
@@ -189,7 +190,7 @@ void TestMessageQueueOtApis(void)
     otMessageQueue queue, queue2;
 
     otMessage *msg[kNumTestMessages];
-    ThreadError error;
+    otError error;
     otMessage *message;
 
 #ifdef OPENTHREAD_MULTIPLE_INSTANCE
@@ -243,9 +244,10 @@ void TestMessageQueueOtApis(void)
 
     // Check the expected failure cases for the enqueue and dequeue:
     error = otMessageQueueEnqueue(&queue, msg[2]);
-    VerifyOrQuit(error == kThreadError_Already, "Enqueuing an already queued message did not fail as expected.\n");
+    VerifyOrQuit(error == OT_ERROR_ALREADY, "Enqueuing an already queued message did not fail as expected.\n");
     error = otMessageQueueDequeue(&queue, msg[0]);
-    VerifyOrQuit(error == kThreadError_NotFound, "Dequeuing a message not in the queue did not fail as expected.\n");
+    VerifyOrQuit(error == OT_ERROR_NOT_FOUND,
+                 "Dequeuing a message not in the queue did not fail as expected.\n");
 
     // Check the failure cases for otMessageQueueGetNext()
     message = otMessageQueueGetNext(&queue, NULL);

--- a/tests/unit/test_ncp_buffer.cpp
+++ b/tests/unit/test_ncp_buffer.cpp
@@ -419,7 +419,7 @@ void TestNcpFrameBuffer(void)
 
     VerifyOrQuit(ncpBuffer.IsEmpty() == true, "IsEmpty() is incorrect when buffer is empty.");
     VerifyOrQuit(ncpBuffer.OutFrameHasEnded() == true, "OutFrameHasEnded() is incorrect when no data in buffer.");
-    VerifyOrQuit(ncpBuffer.OutFrameRemove() == kThreadError_NotFound,
+    VerifyOrQuit(ncpBuffer.OutFrameRemove() == OT_ERROR_NOT_FOUND,
                  "Remove() returned incorrect error status when buffer is empty.");
     VerifyOrQuit(ncpBuffer.OutFrameGetLength() == 0, "OutFrameGetLength() returned non-zero length when buffer is empty.");
     VerifyOrQuit(oldContext.mEmptyCount + 1 == context.mEmptyCount, "Empty callback was not invoked.");
@@ -432,7 +432,7 @@ void TestNcpFrameBuffer(void)
 
     VerifyOrQuit(ncpBuffer.IsEmpty() == true, "IsEmpty() is incorrect when buffer is empty.");
     VerifyOrQuit(ncpBuffer.OutFrameHasEnded() == true, "OutFrameHasEnded() is incorrect when no data in buffer.");
-    VerifyOrQuit(ncpBuffer.OutFrameRemove() == kThreadError_NotFound,
+    VerifyOrQuit(ncpBuffer.OutFrameRemove() == OT_ERROR_NOT_FOUND,
                  "Remove() returned incorrect error status when buffer is empty.");
     VerifyOrQuit(ncpBuffer.OutFrameGetLength() == 0, "OutFrameGetLength() returned non-zero length when buffer is empty.");
     VerifyOrQuit(oldContext.mEmptyCount + 1 == context.mEmptyCount, "Empty callback was not invoked.");

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -188,7 +188,7 @@ extern "C" {
         }
     }
 
-    ThreadError otPlatRadioEnable(otInstance *aInstance)
+    otError otPlatRadioEnable(otInstance *aInstance)
     {
         if (g_testPlatRadioEnable)
         {
@@ -196,11 +196,11 @@ extern "C" {
         }
         else
         {
-            return kThreadError_None;
+            return OT_ERROR_NONE;
         }
     }
 
-    ThreadError otPlatRadioDisable(otInstance *aInstance)
+    otError otPlatRadioDisable(otInstance *aInstance)
     {
         if (g_testPlatRadioEnable)
         {
@@ -208,16 +208,16 @@ extern "C" {
         }
         else
         {
-            return kThreadError_None;
+            return OT_ERROR_NONE;
         }
     }
 
-    ThreadError otPlatRadioSleep(otInstance *)
+    otError otPlatRadioSleep(otInstance *)
     {
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
 
-    ThreadError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
+    otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
     {
         if (g_testPlatRadioReceive)
         {
@@ -225,11 +225,11 @@ extern "C" {
         }
         else
         {
-            return kThreadError_None;
+            return OT_ERROR_NONE;
         }
     }
 
-    ThreadError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
+    otError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket)
     {
         (void)aPacket;
 
@@ -239,7 +239,7 @@ extern "C" {
         }
         else
         {
-            return kThreadError_None;
+            return OT_ERROR_NONE;
         }
     }
 
@@ -276,32 +276,32 @@ extern "C" {
         (void)aEnable;
     }
 
-    ThreadError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
+    otError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
     {
         (void)aInstance;
         (void)aShortAddress;
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
 
-    ThreadError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
+    otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
     {
         (void)aInstance;
         (void)aExtAddress;
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
 
-    ThreadError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
+    otError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
     {
         (void)aInstance;
         (void)aShortAddress;
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
 
-    ThreadError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
+    otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const uint8_t *aExtAddress)
     {
         (void)aInstance;
         (void)aExtAddress;
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
 
     void otPlatRadioClearSrcMatchShortEntries(otInstance *aInstance)
@@ -314,9 +314,9 @@ extern "C" {
         (void)aInstance;
     }
 
-    ThreadError otPlatRadioEnergyScan(otInstance *, uint8_t, uint16_t)
+    otError otPlatRadioEnergyScan(otInstance *, uint8_t, uint16_t)
     {
-        return kThreadError_NotImplemented;
+        return OT_ERROR_NOT_IMPLEMENTED;
     }
 
     void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
@@ -343,11 +343,11 @@ extern "C" {
 #endif
     }
 
-    ThreadError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
+    otError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
     {
-        ThreadError error = kThreadError_None;
+        otError error = OT_ERROR_NONE;
 
-        VerifyOrExit(aOutput, error = kThreadError_InvalidArgs);
+        VerifyOrExit(aOutput, error = OT_ERROR_INVALID_ARGS);
 
         for (uint16_t length = 0; length < aOutputLength; length++)
         {
@@ -383,11 +383,11 @@ exit:
     {
     }
 
-    void otPlatDiagRadioTransmitDone(otInstance *, RadioPacket *, bool, ThreadError)
+    void otPlatDiagRadioTransmitDone(otInstance *, RadioPacket *, bool, otError)
     {
     }
 
-    void otPlatDiagRadioReceiveDone(otInstance *, RadioPacket *, ThreadError)
+    void otPlatDiagRadioReceiveDone(otInstance *, RadioPacket *, otError)
     {
     }
 
@@ -431,29 +431,29 @@ exit:
         (void)aInstance;
     }
 
-    ThreadError otPlatSettingsBeginChange(otInstance *aInstance)
+    otError otPlatSettingsBeginChange(otInstance *aInstance)
     {
         (void)aInstance;
 
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
 
-    ThreadError otPlatSettingsCommitChange(otInstance *aInstance)
+    otError otPlatSettingsCommitChange(otInstance *aInstance)
     {
         (void)aInstance;
 
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
 
-    ThreadError otPlatSettingsAbandonChange(otInstance *aInstance)
+    otError otPlatSettingsAbandonChange(otInstance *aInstance)
     {
         (void)aInstance;
 
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
 
-    ThreadError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue,
-                                  uint16_t *aValueLength)
+    otError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue,
+                              uint16_t *aValueLength)
     {
         (void)aInstance;
         (void)aKey;
@@ -461,36 +461,36 @@ exit:
         (void)aValue;
         (void)aValueLength;
 
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
 
-    ThreadError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+    otError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
     {
         (void)aInstance;
         (void)aKey;
         (void)aValue;
         (void)aValueLength;
 
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
 
-    ThreadError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+    otError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
     {
         (void)aInstance;
         (void)aKey;
         (void)aValue;
         (void)aValueLength;
 
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
 
-    ThreadError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
+    otError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
     {
         (void)aInstance;
         (void)aKey;
         (void)aIndex;
 
-        return kThreadError_None;
+        return OT_ERROR_NONE;
     }
 
     void otPlatSettingsWipe(otInstance *aInstance)

--- a/tests/unit/test_platform.h
+++ b/tests/unit/test_platform.h
@@ -71,10 +71,10 @@ typedef void (*testPlatRadioSetExtendedAddress)(otInstance *, uint8_t *);
 typedef void (*testPlatRadioSetShortAddress)(otInstance *, uint16_t);
 
 typedef bool(*testPlatRadioIsEnabled)(otInstance *);
-typedef ThreadError(*testPlatRadioEnable)(otInstance *);
-typedef ThreadError(*testPlatRadioDisable)(otInstance *);
-typedef ThreadError(*testPlatRadioReceive)(otInstance *, uint8_t);
-typedef ThreadError(*testPlatRadioTransmit)(otInstance *);
+typedef otError(*testPlatRadioEnable)(otInstance *);
+typedef otError(*testPlatRadioDisable)(otInstance *);
+typedef otError(*testPlatRadioReceive)(otInstance *, uint8_t);
+typedef otError(*testPlatRadioTransmit)(otInstance *);
 typedef RadioPacket *(*testPlatRadioGetTransmitBuffer)(otInstance *);
 
 extern otRadioCaps                      g_testPlatRadioCaps;

--- a/tests/unit/test_priority_queue.cpp
+++ b/tests/unit/test_priority_queue.cpp
@@ -236,7 +236,7 @@ void TestPriorityQueue(void)
 
     // Check the failure case for `SetPriority` for invalid argument.
     VerifyOrQuit(
-        msgHigh[2]->SetPriority(ot::Message::kNumPriorities) == kThreadError_InvalidArgs,
+        msgHigh[2]->SetPriority(ot::Message::kNumPriorities) == OT_ERROR_INVALID_ARGS,
         "Message::SetPriority() with out of range value did not fail as expected.\n"
     );
 
@@ -319,11 +319,11 @@ void TestPriorityQueue(void)
     SuccessOrQuit(queue.Enqueue(*msgHigh[0]), "PriorityQueue::Enqueue() failed.\n");
     VerifyPriorityQueueContent(queue, 1, msgHigh[0]);
     VerifyOrQuit(
-        queue.Enqueue(*msgHigh[0]) == kThreadError_Already,
+        queue.Enqueue(*msgHigh[0]) == OT_ERROR_ALREADY,
         "Enqueuing an already queued message did not fail as expected.\n"
     );
     VerifyOrQuit(
-        queue.Dequeue(*msgMed[0]) == kThreadError_NotFound,
+        queue.Dequeue(*msgMed[0]) == OT_ERROR_NOT_FOUND,
         "Dequeuing a message not queued, did not fail as expected.\n"
     );
     SuccessOrQuit(queue.Dequeue(*msgHigh[0]), "PriorityQueue::Dequeue() failed.\n");

--- a/tests/unit/test_util.h
+++ b/tests/unit/test_util.h
@@ -45,7 +45,7 @@ extern "C" {
 
 #define SuccessOrQuit(ERR, MSG)                 \
   do { \
-    if ((ERR) != kThreadError_None)     \
+    if ((ERR) != OT_ERROR_NONE)     \
     { \
       fprintf(stderr, "%s FAILED: ", __FUNCTION__); \
       fputs(MSG, stderr); \
@@ -68,7 +68,7 @@ extern "C" {
 // I would use the above definition for CompileTimeAssert, but I am getting the following errors
 // when I run 'make -f examples/Makefile-posix distcheck':
 //
-//      error: typedef ‘__C_ASSERT__’ locally defined but not used [-Werror=unused-local-typedefs]
+//      error: typedef "__C_ASSERT__" locally defined but not used [-Werror=unused-local-typedefs]
 //
 #define CompileTimeAssert(COND, MSG)
 
@@ -86,7 +86,7 @@ extern utAssertTrue s_AssertTrue;
 typedef void (*utLogMessage)(const char *format, ...);
 extern utLogMessage s_LogMessage;
 
-#define SuccessOrQuit(ERR, MSG) s_AssertTrue((ERR) == kThreadError_None, L##MSG)
+#define SuccessOrQuit(ERR, MSG) s_AssertTrue((ERR) == OT_ERROR_NONE, L##MSG)
 
 #define VerifyOrQuit(ERR, MSG) s_AssertTrue(ERR, L##MSG)
 

--- a/third_party/mbedtls/hardware_entropy.c
+++ b/third_party/mbedtls/hardware_entropy.c
@@ -29,13 +29,13 @@
 
 int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen)
 {
-    ThreadError error;
+    otError error;
 
     (void)data;
 
     error = otPlatRandomGetTrue((uint8_t *)output, (uint16_t)len);
 
-    if (error != kThreadError_None)
+    if (error != OT_ERROR_NONE)
     {
         return MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
     }


### PR DESCRIPTION
There are a number of types and names in the public includes that do not adhere to the OpenThread coding style.  This is the first (an by far the largest) in a series of PRs to bring them in alignment.