### PR TITLE
Free response on failure

### DIFF
--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -227,7 +227,7 @@ public:
     Resource *GetNext(void) const { return static_cast<Resource *>(mNext); };
 
 private:
-    void HandleRequest(Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo) {
+    void HandleRequest(Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo) const {
         mHandler(mContext, &aHeader, &aMessage, &aMessageInfo);
     }
 };


### PR DESCRIPTION
Fix CoAP issues,
* Directly call `Coap::Send()` to resend cached response and free it on failure. 
* Output `Receive failed` only on failure.
* Make `Resource::HandleRequest()` const.