### PR TITLE
Update `NcpBuffer` callbacks and their use in `NcpUart` and `NcpSpi`

### DIFF
--- a/src/ncp/ncp_buffer.hpp
+++ b/src/ncp/ncp_buffer.hpp
@@ -69,7 +69,6 @@ public:
     /**
      * This method clears the NCP frame buffer. All the frames are cleared/removed.
      *
-     * @returns Nothing (void).
      */
     void Clear(void);
 
@@ -77,14 +76,12 @@ public:
      * This method sets the callbacks and context. Subsequent calls to this method will overwrite the previous
      * callbacks and context.
      *
-     * @param[in]  aEmptyBufferCallback     Callback invoked when buffer become empty.
-     * @param[in]  aNonEmptyBufferCallback  Callback invoked when buffer transition from empty to non-empty.
+     * @param[in]  aFrameAddedCallback      Callback invoked when a new frame is successfully added to buffer
+     * @param[in]  aFrameRemovedCallback    Callback invoked when a frame is removed from buffer.
      * @param[in]  aContex                  A pointer to arbitrary context information.
      *
-     * @returns    Nothing (void).
-     *
      */
-    void SetCallbacks(BufferCallback aEmptyBufferCallback, BufferCallback aNonEmptyBufferCallback, void *aContext);
+    void SetCallbacks(BufferCallback aFrameAddedCallback,  BufferCallback aFrameRemovedCallback, void *aContext);
 
     /**
      * This method begins a new input frame to be added/written to the frame buffer.
@@ -328,8 +325,8 @@ private:
     uint8_t * const mBufferEnd;                 // Points to after the end of buffer.
     const uint16_t  mBufferLength;              // Length of the the buffer.
 
-    BufferCallback  mEmptyBufferCallback;       // Callback to signal when buffer becomes empty.
-    BufferCallback  mNonEmptyBufferCallback;    // Callback to signal when buffer becomes non-empty.
+    BufferCallback  mFrameAddedCallback;        // Callback to signal when a new frame is added
+    BufferCallback  mFrameRemovedCallback;      // Callback to signal when a frame is removed.
     void *          mCallbackContext;           // Context passed to callbacks.
 
     otMessageQueue  mMessageQueue;              // Main message queue.

--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -56,8 +56,6 @@ public:
      */
     NcpSpi(otInstance *aInstance);
 
-    void ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength);
-
 private:
     enum
     {
@@ -73,21 +71,19 @@ private:
         kTxStateHandlingSendDone           // The frame was sent successfully, waiting to prepare the next one (if any)
     };
 
-    uint16_t OutboundFrameSize(void);
-
     static void SpiTransactionComplete(void *context, uint8_t *aOutputBuf, uint16_t aOutputBufLen, uint8_t *aInputBuf,
                                        uint16_t aInputBufLen, uint16_t aTransactionLength);
     void SpiTransactionComplete(uint8_t *aOutputBuf, uint16_t aOutputBufLen, uint8_t *aInputBuf, uint16_t aInputBufLen,
                                 uint16_t aTransactionLength);
 
-    static void HandleRxFrame(void *context);
-    void HandleRxFrame(void);
+    static void HandleFrameAddedToTxBuffer(void *aContext, NcpFrameBuffer *aNcpFrameBuffer);
+    static void HandleFrameRemovedFromTxBuffer(void *aContext, NcpFrameBuffer *aNcpFrameBuffer);
 
     static void PrepareTxFrame(void *context);
     void PrepareTxFrame(void);
 
-    static void TxFrameBufferHasData(void *aContext, NcpFrameBuffer *aNcpFrameBuffer);
-    void TxFrameBufferHasData(void);
+    static void HandleRxFrame(void *context);
+    void HandleRxFrame(void);
 
     ThreadError PrepareNextSpiSendFrame(void);
 

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -103,24 +103,31 @@ NcpUart::NcpUart(otInstance *aInstance):
     mByte(0),
     mUartSendTask(aInstance->mIp6.mTaskletScheduler, EncodeAndSendToUart, this)
 {
-    mTxFrameBuffer.SetCallbacks(NULL, TxFrameBufferHasData, this);
+    mTxFrameBuffer.SetCallbacks(HandleFrameAddedToNcpBuffer, HandleFrameRemovedFromNcpBuffer, this);
 
     otPlatUartEnable();
 }
 
-void NcpUart::TxFrameBufferHasData(void *aContext, NcpFrameBuffer *aNcpFrameBuffer)
+void NcpUart::HandleFrameAddedToNcpBuffer(void *aContext, NcpFrameBuffer *aNcpFrameBuffer)
 {
     (void)aNcpFrameBuffer;
 
-    static_cast<NcpUart *>(aContext)->TxFrameBufferHasData();
+    static_cast<NcpUart *>(aContext)->HandleFrameAddedToNcpBuffer();
 }
 
-void NcpUart::TxFrameBufferHasData(void)
+void NcpUart::HandleFrameAddedToNcpBuffer(void)
 {
     if (mUartBuffer.IsEmpty())
     {
         mUartSendTask.Post();
     }
+}
+
+void NcpUart::HandleFrameRemovedFromNcpBuffer(void *aContext, NcpFrameBuffer *aNcpFrameBuffer)
+{
+    (void)aNcpFrameBuffer;
+
+    static_cast<NcpUart *>(aContext)->HandleSpaceAvailableInTxBuffer();
 }
 
 void NcpUart::EncodeAndSendToUart(void *aContext)
@@ -159,9 +166,6 @@ void NcpUart::EncodeAndSendToUart(void)
             }
 
             mTxFrameBuffer.OutFrameRemove();
-
-            // Notify the super/base class that there is space available in tx frame buffer for a new frame.
-            super_t::HandleSpaceAvailableInTxBuffer();
 
             mState = kFinalizingFrame;
 

--- a/src/ncp/ncp_uart.hpp
+++ b/src/ncp/ncp_uart.hpp
@@ -102,12 +102,13 @@ private:
     void            EncodeAndSendToUart(void);
     void            HandleFrame(uint8_t *aBuf, uint16_t aBufLength);
     void            HandleError(ThreadError aError, uint8_t *aBuf, uint16_t aBufLength);
-    void            TxFrameBufferHasData(void);
+    void            HandleFrameAddedToNcpBuffer(void);
 
     static void     EncodeAndSendToUart(void *aContext);
     static void     HandleFrame(void *context, uint8_t *aBuf, uint16_t aBufLength);
     static void     HandleError(void *context, ThreadError aError, uint8_t *aBuf, uint16_t aBufLength);
-    static void     TxFrameBufferHasData(void *aContext, NcpFrameBuffer *aNcpFrameBuffer);
+    static void     HandleFrameAddedToNcpBuffer(void *aContext, NcpFrameBuffer *aNcpFrameBuffer);
+    static void     HandleFrameRemovedFromNcpBuffer(void *aContext, NcpFrameBuffer *aNcpFrameBuffer);
 
     Hdlc::Encoder   mFrameEncoder;
     Hdlc::Decoder   mFrameDecoder;


### PR DESCRIPTION
This commit changes the `NcpBuffer` class callbacks by adding
`FrameAddedCallback` and `FrameRemovedCallback` which are respectively
invoked when a frame is added/removed to/from the NCP buffer.

The `NcpSpi` and `NcpUart` implementation are modified to use the new
callbacks.

This commit also updates the `test_ncp_buffer` unit test:

- Additional checks are added for the new callbacks.

- A new fuzz test is added for NCP buffer (where we randomly write
  or read frames (written frames are randomly generated).