### PR TITLE
Restrict the non joinable beacons

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -637,7 +637,6 @@ void Mac::SendBeaconRequest(Frame &aFrame)
     aFrame.SetDstPanId(kShortAddrBroadcast);
     aFrame.SetDstAddr(kShortAddrBroadcast);
     aFrame.SetCommandId(Frame::kMacCmdBeaconRequest);
-
     otLogInfoMac(GetInstance(), "Sending Beacon Request");
 }
 
@@ -1574,7 +1573,11 @@ ThreadError Mac::HandleMacCommand(Frame &aFrame)
         mCounters.mRxBeaconRequest++;
         otLogInfoMac(GetInstance(), "Received Beacon Request");
 
-        if (mBeaconsEnabled)
+        if ((mBeaconsEnabled)
+#if OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE
+            && (IsBeaconJoinable())
+#endif // OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE
+           )
         {
             mTransmitBeacon = true;
 
@@ -1654,6 +1657,27 @@ void Mac::ResetCounters(void)
 {
     memset(&mCounters, 0, sizeof(mCounters));
 }
+
+#if OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE
+bool Mac::IsBeaconJoinable(void)
+{
+    uint8_t numUnsecurePorts;
+    bool joinable = false;
+
+    mNetif.GetIp6Filter().GetUnsecurePorts(numUnsecurePorts);
+
+    if (numUnsecurePorts)
+    {
+        joinable = true;
+    }
+    else
+    {
+        joinable = false;
+    }
+
+    return joinable;
+}
+#endif // OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE
 
 }  // namespace Mac
 }  // namespace ot

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -591,6 +591,17 @@ public:
      */
     void ResetCounters(void);
 
+#if OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE
+    /**
+     * This method indicates if the beacon is joinable or non-joinable
+     *
+     * @retval true   Beacon is joinable.
+     * @retval false  Beacon is non-joinable.
+     *
+     */
+    bool IsBeaconJoinable(void);
+#endif // OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE
+
     /**
      * This method returns the MAC counter.
      *

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -726,6 +726,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE
+ *
+ * Define to 1 if you want to enable beacon response for joinable networks.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE
+#define OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE         0
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE
  *
  * The size of mbedTLS heap buffer when DTLS is enabled.


### PR DESCRIPTION
Respond to the beacon requests with the beacon only if they are joinable to
reduce the traffic.