### PR TITLE
[docker] add a Dockerfile

### DIFF
--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:trusty
+
+# quiets some stdin errors
+ENV DEBIAN_FRONTEND noninteractive
+
+# wpandtund runtime & build requirements
+RUN apt-get -qq update && \
+  apt-get install -yqq software-properties-common && \
+  add-apt-repository -y ppa:terry.guo/gcc-arm-embedded && \
+  apt-get update -qq && \
+  apt-get install -yqq build-essential git make autoconf autoconf-archive \
+                      automake dbus libtool gcc g++ gperf flex bison texinfo \
+                      ncurses-dev libexpat-dev python sed python-pip gawk \
+                      libreadline6-dev libreadline6 libdbus-1-dev libboost-dev && \
+  apt-get install -yq --force-yes gcc-arm-none-eabi
+
+RUN pip install pexpect
+
+# Install OpenThread & wpandtund...
+WORKDIR ~/src
+
+# install wpantund
+RUN git clone --recursive https://github.com/openthread/wpantund.git && \
+  cd wpantund && \
+  git checkout full/master && \
+  ./configure --sysconfdir=/etc && \
+  make && make install && sudo service dbus restart && \
+  cd ..
+
+# install OpenThread
+RUN git clone --recursive https://github.com/openthread/openthread.git && \
+  cd openthread && ./bootstrap && cd ..


### PR DESCRIPTION
I was running through the [Openthread simulation](https://codelabs.developers.google.com/codelabs/openthread-simulation/index.html) and saw that the instructions called for using Vagrant with Virtualbox. I have no interest in running Virtualbox anymore, so I whipped up a Dockerfile using the provisioning steps that were in the Vagrantfile.

After doing a `docker build .` with this Dockerfile, I can `docker run -it <image-tag> bash` and work through the simulation just fine. Using `docker exec -it <container-name> bash` is the equivalent of `vagrant ssh` and lets me run multiple processes in the container that can connect to each other. The basic Thread network simulation seems to work just fine using this Dockerfile.

Maybe it would also make sense to update the openthread-simulation codelab in the future so that nobody else needs to deal w/ Virtualbox's side effects.