### PR TITLE
TEST: clear buffer before send command

### DIFF
--- a/tests/scripts/thread-cert/node_cli.py
+++ b/tests/scripts/thread-cert/node_cli.py
@@ -94,7 +94,16 @@ class otCli:
             self.pexpect.terminate()
             self.pexpect.close(force=True)
 
+
+    def _clear_buffer(self):
+        try:
+            while True:
+                self.pexpect.read_nonblocking(128, 0)
+        except pexpect.TIMEOUT:
+            pass
+
     def send_command(self, cmd):
+        self._clear_buffer()
         print ("%d: %s" % (self.nodeid, cmd))
         self.pexpect.sendline(cmd)
 


### PR DESCRIPTION
When processing outputs of `send_command()`, it didn't clear outputs produced by last call to `send_command()`, which causes some failures. This PR simply clears read buffer before sending commands.