### PR TITLE
Multiple default gateways

### DIFF
--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -386,7 +386,9 @@ ThreadError LeaderBase::DefaultRouteLookup(PrefixTlv &aPrefix, uint16_t *aRloc16
             if (route == NULL ||
                 entry->GetPreference() > route->GetPreference() ||
                 (entry->GetPreference() == route->GetPreference() &&
-                 mNetif.GetMle().GetCost(entry->GetRloc()) < mNetif.GetMle().GetCost(route->GetRloc())))
+                 (entry->GetRloc() == mNetif.GetMle().GetRloc16() ||
+                  (route->GetRloc() != mNetif.GetMle().GetRloc16() &&
+                   mNetif.GetMle().GetCost(entry->GetRloc()) < mNetif.GetMle().GetCost(route->GetRloc())))))
             {
                 route = entry;
             }


### PR DESCRIPTION
This PR fixes the issue that packets cannot go out from Thread network when multiple border router provides the same prefix with default route flag on.

This is caused by node choosing other border routers in `DefaultRouteLookup()`  even when itself is the same preferred gateway for the prefix.