### PR TITLE
Enhance transmit done callback by passing up the ACK frame

### DIFF
--- a/examples/drivers/windows/otLwf/radio.c
+++ b/examples/drivers/windows/otLwf/radio.c
@@ -594,7 +594,15 @@ otLwfRadioTransmitFrameDone(
             pFilter->otLastTransmitError = OT_ERROR_ABORT;
         }
 
-        otPlatRadioTransmitDone(pFilter->otCtx, &pFilter->otTransmitFrame, pFilter->otLastTransmitFramePending, pFilter->otLastTransmitError);
+        if (((pFilter->otTransmitFrame.mPsdu[0] & IEEE802154_ACK_REQUEST) == 0) ||
+            pFilter->otLastTransmitError != OT_ERROR_NONE)
+        {
+            otPlatRadioTxDone(pFilter->otCtx, &pFilter->otTransmitFrame, NULL, pFilter->otLastTransmitError);
+        }
+        else
+        {
+            otPlatRadioTxDone(pFilter->otCtx, &pFilter->otTransmitFrame, &pFilter->otReceiveFrame, pFilter->otLastTransmitError);
+        }
     }
 
     LogFuncExit(DRIVER_DATA_PATH);

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -513,7 +513,7 @@ void cc2538RadioProcess(otInstance *aInstance)
             else
 #endif
             {
-                otPlatRadioTransmitDone(aInstance, &sTransmitFrame, false, sTransmitError);
+                otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, sTransmitError);
             }
         }
         else if (sReceiveFrame.mLength == IEEE802154_ACK_LENGTH &&
@@ -532,8 +532,7 @@ void cc2538RadioProcess(otInstance *aInstance)
             else
 #endif
             {
-                otPlatRadioTransmitDone(aInstance, &sTransmitFrame, (sReceiveFrame.mPsdu[0] & IEEE802154_FRAME_PENDING) != 0,
-                                        sTransmitError);
+                otPlatRadioTxDone(aInstance, &sTransmitFrame, &sReceiveFrame, sTransmitError);
             }
         }
     }

--- a/examples/platforms/cc2650/openthread-core-cc2650-config.h
+++ b/examples/platforms/cc2650/openthread-core-cc2650-config.h
@@ -36,5 +36,13 @@
  */
 #define OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS 32
 
+/**
+  * @def OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE
+  *
+  * Define to 1 if you want use legacy transmit done.
+  *
+  */
+#define OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE 1
+
 #endif /* OPENTHREAD_CORE_CC2650_CONFIG_H_ */
 

--- a/examples/platforms/da15000/radio.c
+++ b/examples/platforms/da15000/radio.c
@@ -429,15 +429,16 @@ void da15000RadioProcess(otInstance *aInstance)
 {
     if (sSendFrameDone)
     {
-        // Check FP bit in ACK response
-        if ((sTransmitFrame.mPsdu[0] & IEEE802154_ACK_REQUEST)     != 0 &&
-            (sReceiveFrame.mPsdu[0]  & IEEE802154_FRAME_TYPE_MASK) != 0)
-        {
-            sFramePending = ((sReceiveFrame.mPsdu[0] & IEEE802154_FRAME_PENDING) != 0);
-        }
-
         sRadioState = kStateReceive;
-        otPlatRadioTransmitDone(aInstance, &sTransmitFrame, sFramePending, sTransmitStatus);
+
+        if (((sTransmitFrame.mPsdu[0] & IEEE802154_ACK_REQUEST) == 0) || sTransmitStatus != OT_ERROR_NONE)
+        {
+            otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, sTransmitStatus);
+        }
+        else
+        {
+            otPlatRadioTxDone(aInstance, &sTransmitFrame, &sReceiveFrame, sTransmitStatus);
+        }
 
         sFramePending = false;
         sSendFrameDone = false;

--- a/examples/platforms/efr32/radio.c
+++ b/examples/platforms/efr32/radio.c
@@ -740,7 +740,7 @@ void efr32RadioProcess(otInstance *aInstance)
             else
 #endif
             {
-                otPlatRadioTransmitDone(aInstance, &sTransmitFrame, false, sTransmitError);
+                otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, sTransmitError);
             }
         }
         else if (sReceiveFrame.mLength == IEEE802154_ACK_LENGTH &&
@@ -761,9 +761,7 @@ void efr32RadioProcess(otInstance *aInstance)
 #endif
             {
                 otLogInfoPlat(sInstance, "Received ACK:%d", sReceiveFrame.mLength);
-                otPlatRadioTransmitDone(aInstance, &sTransmitFrame,
-                                        (sReceiveFrame.mPsdu[0] & IEEE802154_FRAME_PENDING) != 0,
-                                        sTransmitError);
+                otPlatRadioTxDone(aInstance, &sTransmitFrame, &sReceiveFrame, sTransmitError);
             }
         }
     }

--- a/examples/platforms/emsk/openthread-core-emsk-config.h
+++ b/examples/platforms/emsk/openthread-core-emsk-config.h
@@ -58,4 +58,12 @@
   */
 #define OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ENERGY_SCAN           0
 
+/**
+  * @def OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE
+  *
+  * Define to 1 if you want use legacy transmit done.
+  *
+  */
+#define OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE 1
+
 #endif  // OPENTHREAD_CORE_EMSK_CONFIG_H_

--- a/examples/platforms/kw41z/openthread-core-kw41z-config.h
+++ b/examples/platforms/kw41z/openthread-core-kw41z-config.h
@@ -74,4 +74,13 @@
  *
  */
 #define OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT            1
+
+/**
+  * @def OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE
+  *
+  * Define to 1 if you want use legacy transmit done.
+  *
+  */
+#define OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE 1
+
 #endif  // OPENTHREAD_CORE_KW41Z_CONFIG_H_

--- a/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
+++ b/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
@@ -131,4 +131,12 @@
  */
 #define OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE_NO_DTLS             2048
 
+/**
+  * @def OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE
+  *
+  * Define to 1 if you want use legacy transmit done.
+  *
+  */
+#define OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE 1
+
 #endif  // OPENTHREAD_CORE_NRF52840_CONFIG_H_

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -504,7 +504,7 @@ void radioReceive(otInstance *aInstance)
         else
 #endif
         {
-            otPlatRadioTransmitDone(aInstance, &sTransmitFrame, isFramePending(sReceiveFrame.mPsdu), OT_ERROR_NONE);
+            otPlatRadioTxDone(aInstance, &sTransmitFrame, &sReceiveFrame, OT_ERROR_NONE);
         }
     }
     else if ((sState == kStateReceive || sState == kStateTransmit) &&
@@ -535,7 +535,7 @@ void radioSendMessage(otInstance *aInstance)
         else
 #endif
         {
-            otPlatRadioTransmitDone(aInstance, &sTransmitFrame, false, OT_ERROR_NONE);
+            otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_NONE);
         }
     }
 }

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -390,15 +390,32 @@ RadioPacket *otPlatRadioGetTransmitBuffer(otInstance *aInstance);
 otError otPlatRadioTransmit(otInstance *aInstance, RadioPacket *aPacket);
 
 /**
- * The radio driver calls this method to notify OpenThread that the transmission has completed.
+ * The radio driver calls this method to notify OpenThread that the transmission has completed,
+ * this callback pass up the ACK frame, new add platforms should use this callback function.
+ *
+ * @param[in]  aInstance      The OpenThread instance structure.
+ * @param[in]  aPacket        A pointer to the packet that was transmitted.
+ * @param[in]  aAckPacket     A pointer to the ACK packet, NULL if no ACK was received.
+ * @param[in]  aError         OT_ERROR_NONE when the frame was transmitted, OT_ERROR_NO_ACK when the frame was
+ *                            transmitted but no ACK was received, OT_ERROR_CHANNEL_ACCESS_FAILURE when the transmission
+ *                            could not take place due to activity on the channel, OT_ERROR_ABORT when transmission was
+ *                            aborted for other reasons.
+ *
+ */
+extern void otPlatRadioTxDone(otInstance *aInstance, RadioPacket *aPacket, RadioPacket *aAckPacket,
+                              otError aError);
+
+/**
+ * The radio driver calls this method to notify OpenThread that the transmission has completed,
+ * this function is going to be deprecated, new add platfroms should not use this callback function.
  *
  * @param[in]  aInstance      The OpenThread instance structure.
  * @param[in]  aPacket        A pointer to the packet that was transmitted.
  * @param[in]  aFramePending  TRUE if an ACK frame was received and the Frame Pending bit was set.
- * @param[in]  aError  OT_ERROR_NONE when the frame was transmitted, OT_ERROR_NO_ACK when the frame was
- *                     transmitted but no ACK was received, OT_ERROR_CHANNEL_ACCESS_FAILURE when the transmission
- *                     could not take place due to activity on the channel, OT_ERROR_ABORT when transmission was
- *                     aborted for other reasons.
+ * @param[in]  aError         OT_ERROR_NONE when the frame was transmitted, OT_ERROR_NO_ACK when the frame was
+ *                            transmitted but no ACK was received, OT_ERROR_CHANNEL_ACCESS_FAILURE when the transmission
+ *                            could not take place due to activity on the channel, OT_ERROR_ABORT when transmission was
+ *                            aborted for other reasons.
  *
  */
 extern void otPlatRadioTransmitDone(otInstance *aInstance, RadioPacket *aPacket, bool aFramePending,

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -514,17 +514,34 @@ public:
      */
     void ReceiveDoneTask(Frame *aFrame, otError aError);
 
+#if OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE
     /**
      * This method is called to handle transmit events.
      *
+     * @param[in]  aPacket        A pointer to the packet that was transmitted.
      * @param[in]  aFramePending  TRUE if an ACK frame was received and the Frame Pending bit was set.
-     * @param[in]  aError  OT_ERROR_NONE when the frame was transmitted, OT_ERROR_NO_ACK when the frame was
-     *                     transmitted but no ACK was received, OT_ERROR_CHANNEL_ACCESS_FAILURE when the transmission
-     *                     could not take place due to activity on the channel, OT_ERROR_ABORT when transmission
-     *                     was aborted for other reasons.
+     * @param[in]  aError         OT_ERROR_NONE when the frame was transmitted, OT_ERROR_NO_ACK when the frame was
+     *                            transmitted but no ACK was received, OT_ERROR_CHANNEL_ACCESS_FAILURE when the transmission
+     *                            could not take place due to activity on the channel, OT_ERROR_ABORT when transmission
+     *                            was aborted for other reasons.
      *
      */
     void TransmitDoneTask(RadioPacket *aPacket, bool aRxPending, otError aError);
+
+#else // #if OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE
+    /**
+     * This method is called to handle transmit events.
+     *
+     * @param[in]  aPacket        A pointer to the packet that was transmitted.
+     * @param[in]  aAckPacket     A pointer to the ACK packet, NULL if no ACK was received.
+     * @param[in]  aError         OT_ERROR_NONE when the frame was transmitted, OT_ERROR_NO_ACK when the frame was
+     *                            transmitted but no ACK was received, OT_ERROR_CHANNEL_ACCESS_FAILURE when the transmission
+     *                            could not take place due to activity on the channel, OT_ERROR_ABORT when transmission
+     *                            was aborted for other reasons.
+     *
+     */
+    void TransmitDoneTask(RadioPacket *aPacket, RadioPacket *aAckPacket, otError aError);
+#endif // OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE
 
     /**
      * This method returns if an active scan is in progress.

--- a/tests/unit/test_diag.cpp
+++ b/tests/unit/test_diag.cpp
@@ -57,10 +57,10 @@ extern "C" void otPlatAlarmFired(otInstance *)
 {
 }
 
-extern "C" void otPlatRadioTransmitDone(otInstance *, RadioPacket *aFrame, bool aRxPending, otError aError)
+extern "C" void otPlatRadioTxDone(otInstance *, RadioPacket *aFrame, RadioPacket *aAckFrame,  otError aError)
 {
     (void)aFrame;
-    (void)aRxPending;
+    (void)aAckFrame;
     (void)aError;
 }
 

--- a/tests/unit/test_fuzz.cpp
+++ b/tests/unit/test_fuzz.cpp
@@ -151,7 +151,7 @@ void TestFuzz(uint32_t aSeconds)
             if (g_fTransmit)
             {
                 g_fTransmit = false;
-                otPlatRadioTransmitDone(aInstance, &g_TransmitRadioPacket, true, OT_ERROR_NONE);
+                otPlatRadioTxDone(aInstance, &g_TransmitRadioPacket, NULL, OT_ERROR_NONE);
 #ifdef DBG_FUZZ
                 Log("<== transmit");
 #endif


### PR DESCRIPTION
Please refer to #1786 for more details.

This PR:
* Add new otPlatRadioTxDone() callback which will pass up ACK frame
* The passed up ACK messages are also used for link quality evaluation
* The new feature are supported by the following platforms with this commit:
    - posix
    - cc2538
    - efr32
    - da15000
 * The new feature are not supported by the following platforms at this moment, 
    since their radio drivers do not pass up ACK frame:
    - cc2650
    - nrf52840
    - kw41z
    - EMSK

Then new platforms are recommended to use the new `otPlatRadioTxDone()` callback, and the previous `otPlatRadioTransmitDone()` is going to be deprecated.