### PR TITLE
Ensure to include config file in unit tests for strnlen, strlcat, and  strlcpy

### DIFF
--- a/tests/unit/test_strlcat.c
+++ b/tests/unit/test_strlcat.c
@@ -25,6 +25,12 @@
  *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "utils/wrap_string.h"

--- a/tests/unit/test_strlcpy.c
+++ b/tests/unit/test_strlcpy.c
@@ -25,6 +25,12 @@
  *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "utils/wrap_string.h"

--- a/tests/unit/test_strnlen.c
+++ b/tests/unit/test_strnlen.c
@@ -25,6 +25,12 @@
  *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "utils/wrap_string.h"


### PR DESCRIPTION
This commit fixes a compiler error when building/running unit test
on a platform/system which has support for these functions.