### PR TITLE
spinel: Add support for filtering unsolicited property updates.

### DIFF
--- a/doc/spinel-protocol-src/spinel-commands.md
+++ b/doc/spinel-protocol-src/spinel-commands.md
@@ -35,7 +35,7 @@ instead with the value set to the generated status code for the error.
 
 
 
-## CMD 2: (Host->NCP) CMD_PROP_VALUE_GET {#prop-value-get}
+## CMD 2: (Host->NCP) CMD_PROP_VALUE_GET {#cmd-prop-value-get}
 
 Octets: |    1   |          1         |   1-3
 --------|--------|--------------------|---------
@@ -52,7 +52,7 @@ instead with the value set to the generated status code for the error.
 
 
 
-## CMD 3: (Host->NCP) CMD_PROP_VALUE_SET {#prop-value-set}
+## CMD 3: (Host->NCP) CMD_PROP_VALUE_SET {#cmd-prop-value-set}
 
 Octets: |    1   |          1         |   1-3   |    *n*
 --------|--------|--------------------|---------|------------
@@ -71,7 +71,7 @@ with the value set to the generated status code for the error.
 
 
 
-## CMD 4: (Host->NCP) CMD_PROP_VALUE_INSERT {#prop-value-insert}
+## CMD 4: (Host->NCP) CMD_PROP_VALUE_INSERT {#cmd-prop-value-insert}
 
 Octets: |    1   |          1            |   1-3   |    *n*
 --------|--------|-----------------------|---------|------------
@@ -99,7 +99,7 @@ with the value set to the generated status code for the error.
 
 
 
-## CMD 5: (Host->NCP) CMD_PROP_VALUE_REMOVE {#prop-value-remove}
+## CMD 5: (Host->NCP) CMD_PROP_VALUE_REMOVE {#cmd-prop-value-remove}
 
 Octets: |    1   |          1            |   1-3   |    *n*
 --------|--------|-----------------------|---------|------------
@@ -128,7 +128,7 @@ If an error occurs, the value of `PROP_LAST_STATUS` will be emitted
 with the value set to the generated status code for the error.
 
 
-## CMD 6: (NCP->Host) CMD_PROP_VALUE_IS {#prop-value-is}
+## CMD 6: (NCP->Host) CMD_PROP_VALUE_IS {#cmd-prop-value-is}
 
 Octets: |    1   |          1        |   1-3   |    *n*
 --------|--------|-------------------|---------|------------
@@ -145,7 +145,7 @@ the current value of the given property.
 
 
 
-## CMD 7: (NCP->Host) CMD_PROP_VALUE_INSERTED {#prop-value-inserted}
+## CMD 7: (NCP->Host) CMD_PROP_VALUE_INSERTED {#cmd-prop-value-inserted}
 
 Octets: |    1   |            1            |   1-3   |    *n*
 --------|--------|-------------------------|---------|------------
@@ -170,7 +170,7 @@ helps to eliminate redundant data.
 The resulting order of items in the list is defined by the given
 property.
 
-## CMD 8: (NCP->Host) CMD_PROP_VALUE_REMOVED {#prop-value-removed}
+## CMD 8: (NCP->Host) CMD_PROP_VALUE_REMOVED {#cmd-prop-value-removed}
 
 Octets: |    1   |            1           |   1-3   |    *n*
 --------|--------|------------------------|---------|------------
@@ -247,7 +247,7 @@ See (#security-considerations) for more information.
 
 This command requires the capability `CAP_PEEK_POKE` to be present.
 
-## CMD 21: (Host->NCP) CMD_PROP_VALUE_MULTI_GET {#prop-value-multi-get}
+## CMD 21: (Host->NCP) CMD_PROP_VALUE_MULTI_GET {#cmd-prop-value-multi-get}
 
 *   Argument-Encoding: `A(i)`
 *   Required Capability: `CAP_CMD_MULTI`
@@ -266,7 +266,7 @@ Not all properties can be fetched using this method. As a general rule
 of thumb, any property that blocks when getting will fail for that
 individual property with `STATUS_INVALID_COMMAND_FOR_PROP`.
 
-## CMD 22: (Host->NCP) CMD_PROP_VALUE_MULTI_SET {#prop-value-multi-set}
+## CMD 22: (Host->NCP) CMD_PROP_VALUE_MULTI_SET {#cmd-prop-value-multi-set}
 
 *   Argument-Encoding: `A(iD)`
 *   Required Capability: `CAP_CMD_MULTI`
@@ -299,7 +299,7 @@ Not all properties can be set using this method. As a general rule
 of thumb, any property that blocks when setting will fail for that
 individual property with `STATUS_INVALID_COMMAND_FOR_PROP`.
 
-## CMD 23: (NCP->Host) CMD_PROP_VALUES_ARE {#prop-values-are}
+## CMD 23: (NCP->Host) CMD_PROP_VALUES_ARE {#cmd-prop-values-are}
 
 *   Argument-Encoding: `A(iD)`
 *   Required Capability: `CAP_CMD_MULTI`

--- a/doc/spinel-protocol-src/spinel-feature-gpio.md
+++ b/doc/spinel-protocol-src/spinel-feature-gpio.md
@@ -13,7 +13,7 @@ Support for this feature can be determined by the presence of `CAP_GPIO`.
 
 *   Argument-Encoding: `A(t(CCU))`
 *   Type: Read-write (Writable only using `CMD_PROP_VALUE_INSERT`,
-    (#prop-value-insert))
+    (#cmd-prop-value-insert))
 
 An array of structures which contain the following fields:
 

--- a/doc/spinel-protocol-src/spinel-prop-overview.md
+++ b/doc/spinel-protocol-src/spinel-prop-overview.md
@@ -8,16 +8,16 @@ In Spinel, properties are keyed by an unsigned integer between 0 and 2,097,151 (
 
 Properties may support one or more of the following methods:
 
-*   `VALUE_GET` ((#prop-value-get))
-*   `VALUE_SET` ((#prop-value-set))
-*   `VALUE_INSERT`  ((#prop-value-insert))
-*   `VALUE_REMOVE`  ((#prop-value-remove))
+*   `VALUE_GET` ((#cmd-prop-value-get))
+*   `VALUE_SET` ((#cmd-prop-value-set))
+*   `VALUE_INSERT`  ((#cmd-prop-value-insert))
+*   `VALUE_REMOVE`  ((#cmd-prop-value-remove))
 
 Additionally, the NCP can send updates to the host (either synchronously or asynchronously) that inform the host about changes to specific properties:
 
-*   `VALUE_IS`  ((#prop-value-is))
-*   `VALUE_INSERTED`  ((#prop-value-inserted))
-*   `VALUE_REMOVED`  ((#prop-value-removed))
+*   `VALUE_IS`  ((#cmd-prop-value-is))
+*   `VALUE_INSERTED`  ((#cmd-prop-value-inserted))
+*   `VALUE_REMOVED`  ((#cmd-prop-value-removed))
 
 ## Property Types ###
 


### PR DESCRIPTION
This new capability and set of properties allows the host to instruct the NCP to temporarily cease sending unsolicited updates for specific properties.

The filter is opt-out: you must specify the properties that you are NOT interested in. There is an additional read-only property which lists all of the properties which you may opt-out of unsolicited updates from.