### PR TITLE
NcpSpi/Spi-slave: Ensure OT APIs are not called from ISR context

### DIFF
--- a/examples/platforms/posix/spi-stubs.c
+++ b/examples/platforms/posix/spi-stubs.c
@@ -36,9 +36,11 @@
 
 // Spi-slave stubs
 
-otError otPlatSpiSlaveEnable(otPlatSpiSlaveTransactionCompleteCallback aCallback, void *aContext)
+otError otPlatSpiSlaveEnable(otPlatSpiSlaveTransactionCompleteCallback aCompleteCallback,
+                             otPlatSpiSlaveTransactionProcessCallback aProcessCallback, void *aContext)
 {
-    (void)aCallback;
+    (void)aCompleteCallback;
+    (void)aProcessCallback;
     (void)aContext;
 
     fprintf(stderr, "\nNo SPI support for posix platform.");

--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -77,16 +77,17 @@ private:
         kTxStateHandlingSendDone    // The frame was sent successfully, waiting to prepare the next one (if any).
     };
 
-    static void SpiTransactionComplete(void *context, uint8_t *aOutputBuf, uint16_t aOutputBufLen, uint8_t *aInputBuf,
+    static bool SpiTransactionComplete(void *aContext, uint8_t *aOutputBuf, uint16_t aOutputBufLen, uint8_t *aInputBuf,
                                        uint16_t aInputBufLen, uint16_t aTransactionLength);
-    void SpiTransactionComplete(uint8_t *aOutputBuf, uint16_t aOutputBufLen, uint8_t *aInputBuf, uint16_t aInputBufLen,
+    bool SpiTransactionComplete(uint8_t *aOutputBuf, uint16_t aOutputBufLen, uint8_t *aInputBuf, uint16_t aInputBufLen,
                                 uint16_t aTransactionLength);
 
-    static void HandleRxFrame(void *context);
-    void HandleRxFrame(void);
+    static void SpiTransactionProcess(void *aContext);
+    void SpiTransactionProcess(void);
 
     static void PrepareTxFrame(void *context);
     void PrepareTxFrame(void);
+    void HandleRxFrame(void);
 
     static void TxFrameBufferHasData(void *aContext, NcpFrameBuffer *aNcpFrameBuffer);
 
@@ -96,7 +97,6 @@ private:
     volatile bool mHandlingRxFrame;
     volatile bool mResetFlag;
 
-    Tasklet mHandleRxFrameTask;
     Tasklet mPrepareTxFrameTask;
 
     uint16_t mSendFrameLen;


### PR DESCRIPTION
This commit changes the `spi-slave.h` platform functions by modifying
how the callbacks for a completed SPI transaction are used/invoked.

There are two callbacks for when a SPI transaction completes: The
`TransactionCompleteCallback` can be called from ISR context and it
prepares  the next transaction based on current internal `NcpSpi`
state quickly. This callback returns a `bool` to indicate to  platform
spi-slave driver if further processing is required. If `true` is
returned, the platform spi-slave driver is expected to invoke the
newly introduced callback `TransactionProcessCallback` from the same
OS context that all OpenThread APIs and callbacks are called. This
basically, divides the processing into two parts, one part from ISR
and second follow up from OpenThread context.

This change is to address an issue with current model where OpenThread
APIs (e.g., posting a tasklet) could be called from an ISR context
(which was unsafe and could possibly lead to dropping/missing a posted
tasklet).