### PR TITLE
Clear leader data on detach

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -261,6 +261,7 @@ otError Mle::Stop(bool aClearNetworkDatasets)
     mNetif.RemoveUnicastAddress(mMeshLocal16);
     mNetif.GetNetworkDataLocal().Clear();
     mNetif.GetNetworkDataLeader().Clear();
+    memset(&mLeaderData, 0, sizeof(mLeaderData));
 
     if (aClearNetworkDatasets)
     {


### PR DESCRIPTION
The effect of not clearing leader data in detached state is, when the
device attaches back, network data is never requested when leader data
is handled.