### PR TITLE
`Ncp`: Update the get handler for list of off-mesh routes (from network data)

### DIFF
--- a/doc/spinel-protocol-src/spinel-tech-thread.md
+++ b/doc/spinel-protocol-src/spinel-tech-thread.md
@@ -96,9 +96,9 @@ Data per item is:
   defined. Assumed to be true for set, insert and replace. Clear if
   the on mesh network was defined by another node.
 
-### PROP 91: PROP_THREAD_LOCAL_ROUTES
+### PROP 91: PROP_THREAD_OFF_MESH_ROUTES
 * Type: Read-Write
-* Packed-Encoding: `A(t(6CbC))`
+* Packed-Encoding: `A(t(6CbCb))`
 
 Data per item is:
 
@@ -106,6 +106,10 @@ Data per item is:
 * `C`: Prefix length, in bits
 * `b`: Stable flag
 * `C`: Other flags
+* `b`: "Is defined locally" flag. Set if this route info was locally
+  defined as part of local network data. Assumed to be true for set,
+  insert and replace. Clear if the route is part of partition's network
+  data.
 
 ### PROP 92: PROP_THREAD_ASSISTING_PORTS
 * Type: Read-Write

--- a/examples/drivers/windows/otLwf/iocontrol.c
+++ b/examples/drivers/windows/otLwf/iocontrol.c
@@ -43,7 +43,7 @@ typedef struct _OTLWF_IOCTL_HANDLER
     OTLWF_TUN_IOCTL_FUNC*   tunFunc;
 } OTLWF_IOCTL_HANDLER;
 
-OTLWF_IOCTL_HANDLER IoCtls[] = 
+OTLWF_IOCTL_HANDLER IoCtls[] =
 {
     { "IOCTL_OTLWF_OT_ENABLED",                     NULL },
     { "IOCTL_OTLWF_OT_INTERFACE",                   REF_IOCTL_FUNC_WITH_TUN(otInterface) },
@@ -170,7 +170,7 @@ otLwfIoCtlEnumerateInterfaces(
     NTSTATUS status = STATUS_SUCCESS;
     ULONG NewOutBufferLength = 0;
     POTLWF_INTERFACE_LIST pInterfaceList = (POTLWF_INTERFACE_LIST)OutBuffer;
-    
+
     UNREFERENCED_PARAMETER(InBuffer);
     UNREFERENCED_PARAMETER(InBufferLength);
 
@@ -246,7 +246,7 @@ otLwfIoCtlQueryInterface(
         status = STATUS_BUFFER_TOO_SMALL;
         goto error;
     }
-    
+
     PGUID pInterfaceGuid = (PGUID)InBuffer;
     POTLWF_DEVICE pDevice = (POTLWF_DEVICE)OutBuffer;
 
@@ -304,7 +304,7 @@ otLwfIoCtlOpenThreadControl(
         status = STATUS_DEVICE_DOES_NOT_EXIST;
         goto error;
     }
-    
+
     if (pFilter->DeviceStatus == OTLWF_DEVICE_STATUS_RADIO_MODE)
     {
         // Pend the Irp for processing on the OpenThread event processing thread
@@ -352,13 +352,13 @@ otLwfCompleteOpenThreadIrp(
     ULONG IoControlCode = IrpSp->Parameters.DeviceIoControl.IoControlCode;
 
     ULONG OrigOutBufferLength = OutBufferLength;
-        
+
     NTSTATUS status = STATUS_NOT_IMPLEMENTED;
-    
+
     ULONG FuncCode = ((IoControlCode >> 2) & 0xFFF) - 100;
     if (FuncCode < ARRAYSIZE(IoCtls))
     {
-        LogVerbose(DRIVER_IOCTL, "Processing Irp=%p, for %s (In:%u,Out:%u)", 
+        LogVerbose(DRIVER_IOCTL, "Processing Irp=%p, for %s (In:%u,Out:%u)",
                     Irp, IoCtls[FuncCode].Name, InBufferLength, OutBufferLength);
 
         if (IoCtls[FuncCode].otFunc)
@@ -370,7 +370,7 @@ otLwfCompleteOpenThreadIrp(
             OutBufferLength = 0;
         }
 
-        LogVerbose(DRIVER_IOCTL, "Completing Irp=%p, with %!STATUS! for %s (Out:%u)", 
+        LogVerbose(DRIVER_IOCTL, "Completing Irp=%p, with %!STATUS! for %s (Out:%u)",
                     Irp, status, IoCtls[FuncCode].Name, OutBufferLength);
     }
     else
@@ -404,13 +404,13 @@ otLwfTunIoCtl(
     ULONG InBufferLength = IrpSp->Parameters.DeviceIoControl.InputBufferLength - sizeof(GUID);
     ULONG OutBufferLength = IrpSp->Parameters.DeviceIoControl.OutputBufferLength;
     ULONG IoControlCode = IrpSp->Parameters.DeviceIoControl.IoControlCode;
-        
+
     NTSTATUS status = STATUS_NOT_IMPLEMENTED;
-    
+
     ULONG FuncCode = ((IoControlCode >> 2) & 0xFFF) - 100;
     if (FuncCode < ARRAYSIZE(IoCtls))
     {
-        LogVerbose(DRIVER_IOCTL, "Processing Irp=%p, for %s (In:%u,Out:%u)", 
+        LogVerbose(DRIVER_IOCTL, "Processing Irp=%p, for %s (In:%u,Out:%u)",
                     Irp, IoCtls[FuncCode].Name, InBufferLength, OutBufferLength);
 
         if (IoCtls[FuncCode].tunFunc)
@@ -420,7 +420,7 @@ otLwfTunIoCtl(
 
         if (!NT_SUCCESS(status))
         {
-            LogVerbose(DRIVER_IOCTL, "Completing Irp=%p, with %!STATUS! for %s", 
+            LogVerbose(DRIVER_IOCTL, "Completing Irp=%p, with %!STATUS! for %s",
                         Irp, status, IoCtls[FuncCode].Name);
         }
     }
@@ -497,12 +497,12 @@ otLwfTunIoCtl_otInterface(
         {
             // Make sure our addresses are in sync
             (void)otLwfInitializeAddresses(pFilter);
-            
+
             // Sync the current addresses
             KeSetEvent(&pFilter->TunWorkerThreadAddressChangedEvent, IO_NO_INCREMENT, FALSE);
         }
 
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -515,7 +515,7 @@ otLwfTunIoCtl_otInterface(
     }
     else if (OutBufferLength >= sizeof(BOOLEAN))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -601,7 +601,7 @@ otLwfTunIoCtl_otThread(
 
     if (InBufferLength >= sizeof(BOOLEAN))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -614,7 +614,7 @@ otLwfTunIoCtl_otThread(
     }
     else if (OutBufferLength >= sizeof(BOOLEAN))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -671,9 +671,9 @@ otLwfIoCtl_otActiveScan(
         uint16_t aScanDuration = *(uint16_t*)(InBuffer + sizeof(uint32_t));
         status = ThreadErrorToNtstatus(
             otLinkActiveScan(
-                pFilter->otCtx, 
-                aScanChannels, 
-                aScanDuration, 
+                pFilter->otCtx,
+                aScanChannels,
+                aScanDuration,
                 otLwfActiveScanCallback,
                 pFilter)
             );
@@ -705,7 +705,7 @@ otLwfTunIoCtl_otActiveScan(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     if (InBufferLength >= sizeof(uint32_t) + sizeof(uint16_t))
     {
         uint32_t aScanChannels = *(uint32_t*)InBuffer;
@@ -717,7 +717,7 @@ otLwfTunIoCtl_otActiveScan(
         status = otLwfCmdSetProp(pFilter, SPINEL_PROP_MAC_SCAN_MASK, SPINEL_DATATYPE_UINT16_S, aScanDuration);
         if (!NT_SUCCESS(status)) goto error;
 
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -730,7 +730,7 @@ otLwfTunIoCtl_otActiveScan(
     }
     else if (OutBufferLength >= sizeof(BOOLEAN))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -791,9 +791,9 @@ otLwfIoCtl_otEnergyScan(
         uint16_t aScanDuration = *(uint16_t*)(InBuffer + sizeof(uint32_t));
         status = ThreadErrorToNtstatus(
             otLinkEnergyScan(
-                pFilter->otCtx, 
-                aScanChannels, 
-                aScanDuration, 
+                pFilter->otCtx,
+                aScanChannels,
+                aScanDuration,
                 otLwfEnergyScanCallback,
                 pFilter)
             );
@@ -825,7 +825,7 @@ otLwfTunIoCtl_otEnergyScan(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     if (InBufferLength >= sizeof(uint32_t) + sizeof(uint16_t))
     {
         uint32_t aScanChannels = *(uint32_t*)InBuffer;
@@ -837,7 +837,7 @@ otLwfTunIoCtl_otEnergyScan(
         status = otLwfCmdSetProp(pFilter, SPINEL_PROP_MAC_SCAN_MASK, SPINEL_DATATYPE_UINT16_S, aScanDuration);
         if (!NT_SUCCESS(status)) goto error;
 
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -850,7 +850,7 @@ otLwfTunIoCtl_otEnergyScan(
     }
     else if (OutBufferLength >= sizeof(BOOLEAN))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -913,8 +913,8 @@ otLwfIoCtl_otDiscover(
         bool aEnableEui64Filtering = *(uint8_t*)(InBuffer + sizeof(uint32_t) + sizeof(uint16_t) + sizeof(uint8_t));
         status = ThreadErrorToNtstatus(
             otThreadDiscover(
-                pFilter->otCtx, 
-                aScanChannels, 
+                pFilter->otCtx,
+                aScanChannels,
                 aPanid,
                 aJoiner,
                 aEnableEui64Filtering,
@@ -984,7 +984,7 @@ otLwfTunIoCtl_otChannel(
 
     if (InBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -997,7 +997,7 @@ otLwfTunIoCtl_otChannel(
     }
     else if (OutBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -1083,7 +1083,7 @@ otLwfTunIoCtl_otChildTimeout(
 
     if (InBufferLength >= sizeof(uint32_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -1096,7 +1096,7 @@ otLwfTunIoCtl_otChildTimeout(
     }
     else if (OutBufferLength >= sizeof(uint32_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -1181,7 +1181,7 @@ otLwfTunIoCtl_otExtendedAddress(
 
     if (InBufferLength >= sizeof(otExtAddress))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -1194,7 +1194,7 @@ otLwfTunIoCtl_otExtendedAddress(
     }
     else if (OutBufferLength >= sizeof(otExtAddress))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -1281,7 +1281,7 @@ otLwfTunIoCtl_otExtendedPanId(
 
     if (InBufferLength >= sizeof(otExtendedPanId))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -1295,7 +1295,7 @@ otLwfTunIoCtl_otExtendedPanId(
     }
     else if (OutBufferLength >= sizeof(otExtendedPanId))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -1324,8 +1324,8 @@ otLwfTunIoCtl_otExtendedPanId_Handler(
     if (Key == SPINEL_PROP_NET_XPANID)
     {
         uint8_t *data = NULL;
-        spinel_size_t aExtPanIdLen; 
-        if (try_spinel_datatype_unpack(Data, DataLength, SPINEL_DATATYPE_DATA_S, &data, &aExtPanIdLen) && data != NULL && 
+        spinel_size_t aExtPanIdLen;
+        if (try_spinel_datatype_unpack(Data, DataLength, SPINEL_DATATYPE_DATA_S, &data, &aExtPanIdLen) && data != NULL &&
             aExtPanIdLen == sizeof(otExtendedPanId))
         {
             memcpy(OutBuffer, data, sizeof(otExtendedPanId));
@@ -1443,7 +1443,7 @@ otLwfTunIoCtl_otLeaderRloc(
 
     if (InBufferLength >= sizeof(otIp6Address))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -1456,7 +1456,7 @@ otLwfTunIoCtl_otLeaderRloc(
     }
     else if (OutBufferLength >= sizeof(otIp6Address))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -1508,7 +1508,7 @@ otLwfIoCtl_otLinkMode(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     static_assert(sizeof(otLinkModeConfig) == 4, "The size of otLinkModeConfig should be 4 bytes");
     if (InBufferLength >= sizeof(otLinkModeConfig))
     {
@@ -1560,7 +1560,7 @@ otLwfTunIoCtl_otLinkMode(
         if (aLinkMode->mDeviceType)         numeric_mode |= kThreadMode_FullFunctionDevice;
         if (aLinkMode->mNetworkData)        numeric_mode |= kThreadMode_FullNetworkData;
 
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -1573,7 +1573,7 @@ otLwfTunIoCtl_otLinkMode(
     }
     else if (OutBufferLength >= sizeof(otLinkModeConfig))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -1605,7 +1605,7 @@ otLwfTunIoCtl_otLinkMode_Handler(
         if (try_spinel_datatype_unpack(Data, DataLength, SPINEL_DATATYPE_UINT8_S, &numeric_mode))
         {
             otLinkModeConfig* aLinkMode = (otLinkModeConfig*)OutBuffer;
-            
+
             aLinkMode->mRxOnWhenIdle = ((numeric_mode & kThreadMode_RxOnWhenIdle) == kThreadMode_RxOnWhenIdle);
             aLinkMode->mSecureDataRequests = ((numeric_mode & kThreadMode_SecureDataRequest) == kThreadMode_SecureDataRequest);
             aLinkMode->mDeviceType = ((numeric_mode & kThreadMode_FullFunctionDevice) == kThreadMode_FullFunctionDevice);
@@ -1667,7 +1667,7 @@ otLwfTunIoCtl_otMasterKey(
 
     if (InBufferLength >= sizeof(otMasterKey))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -1681,7 +1681,7 @@ otLwfTunIoCtl_otMasterKey(
     }
     else if (OutBufferLength >= sizeof(otMasterKey))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -1710,8 +1710,8 @@ otLwfTunIoCtl_otMasterKey_Handler(
     if (Key == SPINEL_PROP_NET_MASTER_KEY)
     {
         uint8_t *data = NULL;
-        spinel_size_t aKeyLength; 
-        if (try_spinel_datatype_unpack(Data, DataLength, SPINEL_DATATYPE_DATA_S, &data, &aKeyLength) && data != NULL && 
+        spinel_size_t aKeyLength;
+        if (try_spinel_datatype_unpack(Data, DataLength, SPINEL_DATATYPE_DATA_S, &data, &aKeyLength) && data != NULL &&
             aKeyLength == sizeof(otMasterKey))
         {
             memcpy(OutBuffer, data, sizeof(otMasterKey));
@@ -1771,7 +1771,7 @@ otLwfTunIoCtl_otPSKc(
 
     if (InBufferLength >= sizeof(otPSKc))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -1785,7 +1785,7 @@ otLwfTunIoCtl_otPSKc(
     }
     else if (OutBufferLength >= sizeof(otPSKc))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -1814,8 +1814,8 @@ otLwfTunIoCtl_otPSKc_Handler(
     if (Key == SPINEL_PROP_NET_PSKC)
     {
         uint8_t *data = NULL;
-        spinel_size_t aPSKcLength; 
-        if (try_spinel_datatype_unpack(Data, DataLength, SPINEL_DATATYPE_DATA_S, &data, &aPSKcLength) && data != NULL && 
+        spinel_size_t aPSKcLength;
+        if (try_spinel_datatype_unpack(Data, DataLength, SPINEL_DATATYPE_DATA_S, &data, &aPSKcLength) && data != NULL &&
             aPSKcLength == sizeof(otPSKc))
         {
             memcpy(OutBuffer, data, sizeof(otPSKc));
@@ -1839,7 +1839,7 @@ otLwfIoCtl_otMeshLocalEid(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     UNREFERENCED_PARAMETER(InBuffer);
     UNREFERENCED_PARAMETER(InBufferLength);
 
@@ -1874,7 +1874,7 @@ otLwfTunIoCtl_otMeshLocalEid(
 
     if (OutBufferLength >= sizeof(otIp6Address))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -1964,7 +1964,7 @@ otLwfTunIoCtl_otMeshLocalPrefix(
         otIp6Address aAddress = {0};
         memcpy(&aAddress, InBuffer, sizeof(otMeshLocalPrefix));
 
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -1977,7 +1977,7 @@ otLwfTunIoCtl_otMeshLocalPrefix(
     }
     else if (OutBufferLength >= sizeof(otMeshLocalPrefix))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -2067,7 +2067,7 @@ otLwfTunIoCtl_otNetworkName(
 
     if (InBufferLength >= sizeof(otNetworkName))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -2080,7 +2080,7 @@ otLwfTunIoCtl_otNetworkName(
     }
     else if (OutBufferLength >= sizeof(otNetworkName))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -2167,7 +2167,7 @@ otLwfTunIoCtl_otPanId(
 
     if (InBufferLength >= sizeof(otPanId))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -2180,7 +2180,7 @@ otLwfTunIoCtl_otPanId(
     }
     else if (OutBufferLength >= sizeof(otPanId))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -2266,7 +2266,7 @@ otLwfTunIoCtl_otRouterRollEnabled(
 
     if (InBufferLength >= sizeof(BOOLEAN))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -2279,7 +2279,7 @@ otLwfTunIoCtl_otRouterRollEnabled(
     }
     else if (OutBufferLength >= sizeof(BOOLEAN))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -2365,7 +2365,7 @@ otLwfTunIoCtl_otShortAddress(
 
     if (OutBufferLength >= sizeof(otShortAddress))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -2517,7 +2517,7 @@ otLwfTunIoCtl_otLocalLeaderWeight(
 
     if (InBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -2530,7 +2530,7 @@ otLwfTunIoCtl_otLocalLeaderWeight(
     }
     else if (OutBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -2583,7 +2583,7 @@ otLwfIoCtl_otAddBorderRouter(
 
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     if (InBufferLength >= sizeof(otBorderRouterConfig))
     {
         status = ThreadErrorToNtstatus(otNetDataAddPrefixInfo(pFilter->otCtx, (otBorderRouterConfig*)InBuffer));
@@ -2615,7 +2615,7 @@ otLwfTunIoCtl_otAddBorderRouter(
     NTSTATUS status = STATUS_INVALID_PARAMETER;
 
     UNREFERENCED_PARAMETER(OutBufferLength);
-    
+
     if (InBufferLength >= sizeof(otBorderRouterConfig))
     {
         const otBorderRouterConfig *aConfig = (otBorderRouterConfig*)InBuffer;
@@ -2630,7 +2630,7 @@ otLwfTunIoCtl_otAddBorderRouter(
         if (aConfig->mDefaultRoute) flags |= kDefaultRouteFlag;
         if (aConfig->mOnMesh)       flags |= kOnMeshFlag;
 
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -2664,7 +2664,7 @@ otLwfIoCtl_otRemoveBorderRouter(
 
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     if (InBufferLength >= sizeof(otIp6Prefix))
     {
         status = ThreadErrorToNtstatus(otNetDataRemovePrefixInfo(pFilter->otCtx, (otIp6Prefix*)InBuffer));
@@ -2687,7 +2687,7 @@ otLwfTunIoCtl_otRemoveBorderRouter(
     NTSTATUS status = STATUS_INVALID_PARAMETER;
 
     UNREFERENCED_PARAMETER(OutBufferLength);
-    
+
     if (InBufferLength >= sizeof(otIp6Prefix))
     {
         const otIp6Prefix *aPrefix = (otIp6Prefix*)InBuffer;
@@ -2695,7 +2695,7 @@ otLwfTunIoCtl_otRemoveBorderRouter(
         otIp6Address prefix = {0};
         memcpy_s(&prefix, sizeof(prefix), &aPrefix->mPrefix, aPrefix->mLength);
 
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -2727,7 +2727,7 @@ otLwfIoCtl_otAddExternalRoute(
 
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     if (InBufferLength >= sizeof(otExternalRouteConfig))
     {
         status = ThreadErrorToNtstatus(otNetDataAddRoute(pFilter->otCtx, (otExternalRouteConfig*)InBuffer));
@@ -2750,7 +2750,7 @@ otLwfTunIoCtl_otAddExternalRoute(
     NTSTATUS status = STATUS_INVALID_PARAMETER;
 
     UNREFERENCED_PARAMETER(OutBufferLength);
-    
+
     if (InBufferLength >= sizeof(otBorderRouterConfig))
     {
         const otBorderRouterConfig *aConfig = (otBorderRouterConfig*)InBuffer;
@@ -2765,13 +2765,13 @@ otLwfTunIoCtl_otAddExternalRoute(
         if (aConfig->mDefaultRoute) flags |= kDefaultRouteFlag;
         if (aConfig->mOnMesh)       flags |= kOnMeshFlag;
 
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
                 NULL,
                 SPINEL_CMD_PROP_VALUE_INSERT,
-                SPINEL_PROP_THREAD_LOCAL_ROUTES,
+                SPINEL_PROP_THREAD_OFF_MESH_ROUTES,
                 sizeof(otIp6Address) + 3 * sizeof(uint8_t),
                 "6CbC",
                 &prefix,
@@ -2799,7 +2799,7 @@ otLwfIoCtl_otRemoveExternalRoute(
 
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     if (InBufferLength >= sizeof(otIp6Prefix))
     {
         status = ThreadErrorToNtstatus(otNetDataRemoveRoute(pFilter->otCtx, (otIp6Prefix*)InBuffer));
@@ -2822,7 +2822,7 @@ otLwfTunIoCtl_otRemoveExternalRoute(
     NTSTATUS status = STATUS_INVALID_PARAMETER;
 
     UNREFERENCED_PARAMETER(OutBufferLength);
-    
+
     if (InBufferLength >= sizeof(otIp6Prefix))
     {
         const otIp6Prefix *aPrefix = (otIp6Prefix*)InBuffer;
@@ -2830,13 +2830,13 @@ otLwfTunIoCtl_otRemoveExternalRoute(
         otIp6Address prefix = {0};
         memcpy_s(&prefix, sizeof(prefix), &aPrefix->mPrefix, aPrefix->mLength);
 
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
                 NULL,
                 SPINEL_CMD_PROP_VALUE_REMOVE,
-                SPINEL_PROP_THREAD_LOCAL_ROUTES,
+                SPINEL_PROP_THREAD_OFF_MESH_ROUTES,
                 sizeof(otIp6Address) + sizeof(uint8_t),
                 "6C",
                 &prefix,
@@ -2864,7 +2864,7 @@ otLwfIoCtl_otSendServerData(
     UNREFERENCED_PARAMETER(InBufferLength);
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     status = ThreadErrorToNtstatus(otNetDataRegister(pFilter->otCtx));
 
     return status;
@@ -2919,7 +2919,7 @@ otLwfTunIoCtl_otContextIdReuseDelay(
 
     if (InBufferLength >= sizeof(uint32_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -2932,7 +2932,7 @@ otLwfTunIoCtl_otContextIdReuseDelay(
     }
     else if (OutBufferLength >= sizeof(uint32_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -3018,7 +3018,7 @@ otLwfTunIoCtl_otKeySequenceCounter(
 
     if (InBufferLength >= sizeof(uint32_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -3031,7 +3031,7 @@ otLwfTunIoCtl_otKeySequenceCounter(
     }
     else if (OutBufferLength >= sizeof(uint32_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -3117,7 +3117,7 @@ otLwfTunIoCtl_otNetworkIdTimeout(
 
     if (InBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -3130,7 +3130,7 @@ otLwfTunIoCtl_otNetworkIdTimeout(
     }
     else if (OutBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -3216,7 +3216,7 @@ otLwfTunIoCtl_otRouterUpgradeThreshold(
 
     if (InBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -3229,7 +3229,7 @@ otLwfTunIoCtl_otRouterUpgradeThreshold(
     }
     else if (OutBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -3315,7 +3315,7 @@ otLwfTunIoCtl_otRouterDowngradeThreshold(
 
     if (InBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -3328,7 +3328,7 @@ otLwfTunIoCtl_otRouterDowngradeThreshold(
     }
     else if (OutBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -3381,7 +3381,7 @@ otLwfIoCtl_otReleaseRouterId(
 
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     if (InBufferLength >= sizeof(uint8_t))
     {
         status = ThreadErrorToNtstatus(otThreadReleaseRouterId(pFilter->otCtx, *(uint8_t*)InBuffer));
@@ -3407,7 +3407,7 @@ otLwfTunIoCtl_otReleaseRouterId(
 
     if (InBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -3472,7 +3472,7 @@ otLwfTunIoCtl_otMacWhitelistEnabled(
 
     if (InBufferLength >= sizeof(BOOLEAN))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -3485,7 +3485,7 @@ otLwfTunIoCtl_otMacWhitelistEnabled(
     }
     else if (OutBufferLength >= sizeof(BOOLEAN))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -3538,7 +3538,7 @@ otLwfIoCtl_otAddMacWhitelist(
 
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     if (InBufferLength >= sizeof(otExtAddress) + sizeof(int8_t))
     {
         int8_t aRssi = *(int8_t*)(InBuffer + sizeof(otExtAddress));
@@ -3577,7 +3577,7 @@ otLwfTunIoCtl_otAddMacWhitelist(
             aRssi = *(int8_t*)(InBuffer + sizeof(otExtAddress));
         }
 
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -3609,7 +3609,7 @@ otLwfIoCtl_otRemoveMacWhitelist(
 
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     if (InBufferLength >= sizeof(otExtAddress))
     {
         otLinkRemoveWhitelist(pFilter->otCtx, (uint8_t*)InBuffer);
@@ -3636,7 +3636,7 @@ otLwfTunIoCtl_otRemoveMacWhitelist(
 
     if (InBufferLength >= sizeof(otExtAddress))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -3664,14 +3664,14 @@ otLwfIoCtl_otMacWhitelistEntry(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
-    if (InBufferLength >= sizeof(uint8_t) && 
+
+    if (InBufferLength >= sizeof(uint8_t) &&
         *OutBufferLength >= sizeof(otMacWhitelistEntry))
     {
         status = ThreadErrorToNtstatus(
             otLinkGetWhitelistEntry(
-                pFilter->otCtx, 
-                *(uint8_t*)InBuffer, 
+                pFilter->otCtx,
+                *(uint8_t*)InBuffer,
                 (otMacWhitelistEntry*)OutBuffer)
             );
         *OutBufferLength = sizeof(otMacWhitelistEntry);
@@ -3702,7 +3702,7 @@ otLwfIoCtl_otClearMacWhitelist(
     UNREFERENCED_PARAMETER(InBufferLength);
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     otLinkClearWhitelist(pFilter->otCtx);
 
     return status;
@@ -3724,8 +3724,8 @@ otLwfTunIoCtl_otClearMacWhitelist(
     UNREFERENCED_PARAMETER(InBuffer);
     UNREFERENCED_PARAMETER(InBufferLength);
     UNREFERENCED_PARAMETER(OutBufferLength);
-    
-    status = 
+
+    status =
         otLwfTunSendCommandForIrp(
             pFilter,
             pIrp,
@@ -3751,7 +3751,7 @@ otLwfIoCtl_otDeviceRole(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     if (InBufferLength >= sizeof(uint8_t))
     {
         otDeviceRole role = *(uint8_t*)InBuffer;
@@ -3833,7 +3833,7 @@ otLwfTunIoCtl_otDeviceRole(
             break;
         }
 
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -3846,7 +3846,7 @@ otLwfTunIoCtl_otDeviceRole(
     }
     else if (OutBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -3914,14 +3914,14 @@ otLwfIoCtl_otChildInfoById(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
-    if (InBufferLength >= sizeof(uint16_t) && 
+
+    if (InBufferLength >= sizeof(uint16_t) &&
         *OutBufferLength >= sizeof(otChildInfo))
     {
         status = ThreadErrorToNtstatus(
             otThreadGetChildInfoById(
-                pFilter->otCtx, 
-                *(uint16_t*)InBuffer, 
+                pFilter->otCtx,
+                *(uint16_t*)InBuffer,
                 (otChildInfo*)OutBuffer)
             );
         *OutBufferLength = sizeof(otChildInfo);
@@ -3947,14 +3947,14 @@ otLwfIoCtl_otChildInfoByIndex(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
-    if (InBufferLength >= sizeof(uint8_t) && 
+
+    if (InBufferLength >= sizeof(uint8_t) &&
         *OutBufferLength >= sizeof(otChildInfo))
     {
         status = ThreadErrorToNtstatus(
             otThreadGetChildInfoByIndex(
-                pFilter->otCtx, 
-                *(uint8_t*)InBuffer, 
+                pFilter->otCtx,
+                *(uint8_t*)InBuffer,
                 (otChildInfo*)OutBuffer)
             );
         *OutBufferLength = sizeof(otChildInfo);
@@ -3980,14 +3980,14 @@ otLwfIoCtl_otEidCacheEntry(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
-    if (InBufferLength >= sizeof(uint8_t) && 
+
+    if (InBufferLength >= sizeof(uint8_t) &&
         *OutBufferLength >= sizeof(otEidCacheEntry))
     {
         status = ThreadErrorToNtstatus(
             otThreadGetEidCacheEntry(
-                pFilter->otCtx, 
-                *(uint8_t*)InBuffer, 
+                pFilter->otCtx,
+                *(uint8_t*)InBuffer,
                 (otEidCacheEntry*)OutBuffer)
             );
         *OutBufferLength = sizeof(otEidCacheEntry);
@@ -4013,7 +4013,7 @@ otLwfIoCtl_otLeaderData(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     UNREFERENCED_PARAMETER(InBuffer);
     UNREFERENCED_PARAMETER(InBufferLength);
 
@@ -4043,7 +4043,7 @@ otLwfIoCtl_otLeaderRouterId(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     UNREFERENCED_PARAMETER(InBuffer);
     UNREFERENCED_PARAMETER(InBufferLength);
 
@@ -4079,7 +4079,7 @@ otLwfTunIoCtl_otLeaderRouterId(
 
     if (OutBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -4129,7 +4129,7 @@ otLwfIoCtl_otLeaderWeight(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     UNREFERENCED_PARAMETER(InBuffer);
     UNREFERENCED_PARAMETER(InBufferLength);
 
@@ -4165,7 +4165,7 @@ otLwfTunIoCtl_otLeaderWeight(
 
     if (OutBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -4215,7 +4215,7 @@ otLwfIoCtl_otNetworkDataVersion(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     UNREFERENCED_PARAMETER(InBuffer);
     UNREFERENCED_PARAMETER(InBufferLength);
 
@@ -4251,7 +4251,7 @@ otLwfTunIoCtl_otNetworkDataVersion(
 
     if (OutBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -4301,7 +4301,7 @@ otLwfIoCtl_otPartitionId(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     UNREFERENCED_PARAMETER(InBuffer);
     UNREFERENCED_PARAMETER(InBufferLength);
 
@@ -4337,7 +4337,7 @@ otLwfTunIoCtl_otPartitionId(
 
     if (OutBufferLength >= sizeof(uint32_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -4387,7 +4387,7 @@ otLwfIoCtl_otRloc16(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     UNREFERENCED_PARAMETER(InBuffer);
     UNREFERENCED_PARAMETER(InBufferLength);
 
@@ -4423,7 +4423,7 @@ otLwfTunIoCtl_otRloc16(
 
     if (OutBufferLength >= sizeof(uint16_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -4473,7 +4473,7 @@ otLwfIoCtl_otRouterIdSequence(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     UNREFERENCED_PARAMETER(InBuffer);
     UNREFERENCED_PARAMETER(InBufferLength);
 
@@ -4504,14 +4504,14 @@ otLwfIoCtl_otRouterInfo(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
-    if (InBufferLength >= sizeof(uint16_t) && 
+
+    if (InBufferLength >= sizeof(uint16_t) &&
         *OutBufferLength >= sizeof(otRouterInfo))
     {
         status = ThreadErrorToNtstatus(
             otThreadGetRouterInfo(
-                pFilter->otCtx, 
-                *(uint16_t*)InBuffer, 
+                pFilter->otCtx,
+                *(uint16_t*)InBuffer,
                 (otRouterInfo*)OutBuffer)
             );
         *OutBufferLength = sizeof(otRouterInfo);
@@ -4537,7 +4537,7 @@ otLwfIoCtl_otStableNetworkDataVersion(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     UNREFERENCED_PARAMETER(InBuffer);
     UNREFERENCED_PARAMETER(InBufferLength);
 
@@ -4573,7 +4573,7 @@ otLwfTunIoCtl_otStableNetworkDataVersion(
 
     if (OutBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -4661,7 +4661,7 @@ otLwfIoCtl_otAddMacBlacklist(
 
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     if (InBufferLength >= sizeof(otExtAddress))
     {
         status = ThreadErrorToNtstatus(otLinkAddBlacklist(pFilter->otCtx, (uint8_t*)InBuffer));
@@ -4686,7 +4686,7 @@ otLwfIoCtl_otRemoveMacBlacklist(
 
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     if (InBufferLength >= sizeof(otExtAddress))
     {
         otLinkRemoveBlacklist(pFilter->otCtx, (uint8_t*)InBuffer);
@@ -4709,14 +4709,14 @@ otLwfIoCtl_otMacBlacklistEntry(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
-    if (InBufferLength >= sizeof(uint8_t) && 
+
+    if (InBufferLength >= sizeof(uint8_t) &&
         *OutBufferLength >= sizeof(otMacBlacklistEntry))
     {
         status = ThreadErrorToNtstatus(
             otLinkGetBlacklistEntry(
-                pFilter->otCtx, 
-                *(uint8_t*)InBuffer, 
+                pFilter->otCtx,
+                *(uint8_t*)InBuffer,
                 (otMacBlacklistEntry*)OutBuffer)
             );
         *OutBufferLength = sizeof(otMacBlacklistEntry);
@@ -4747,7 +4747,7 @@ otLwfIoCtl_otClearMacBlacklist(
     UNREFERENCED_PARAMETER(InBufferLength);
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     otLinkClearBlacklist(pFilter->otCtx);
 
     return status;
@@ -4800,8 +4800,8 @@ otLwfIoCtl_otNextOnMeshPrefix(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
-    if (InBufferLength >= sizeof(BOOLEAN) + sizeof(uint8_t) && 
+
+    if (InBufferLength >= sizeof(BOOLEAN) + sizeof(uint8_t) &&
         *OutBufferLength >= sizeof(uint8_t) + sizeof(otBorderRouterConfig))
     {
         BOOLEAN aLocal = *(BOOLEAN*)InBuffer;
@@ -4809,8 +4809,8 @@ otLwfIoCtl_otNextOnMeshPrefix(
         otBorderRouterConfig* aConfig = (otBorderRouterConfig*)((PUCHAR)OutBuffer + sizeof(uint8_t));
         status = ThreadErrorToNtstatus(
             otNetDataGetNextPrefixInfo(
-                pFilter->otCtx, 
-                aLocal, 
+                pFilter->otCtx,
+                aLocal,
                 &aIterator,
                 aConfig)
             );
@@ -4913,8 +4913,8 @@ otLwfIoCtl_otAssignLinkQuality(
     if (InBufferLength >= sizeof(otExtAddress) + sizeof(uint8_t))
     {
         otLinkSetAssignLinkQuality(
-            pFilter->otCtx, 
-            (uint8_t*)InBuffer, 
+            pFilter->otCtx,
+            (uint8_t*)InBuffer,
             *(uint8_t*)(InBuffer + sizeof(otExtAddress)));
         status = STATUS_SUCCESS;
         *OutBufferLength = 0;
@@ -4924,8 +4924,8 @@ otLwfIoCtl_otAssignLinkQuality(
     {
         status = ThreadErrorToNtstatus(
             otLinkGetAssignLinkQuality(
-                pFilter->otCtx, 
-                (uint8_t*)InBuffer, 
+                pFilter->otCtx,
+                (uint8_t*)InBuffer,
                 (uint8_t*)OutBuffer)
             );
         *OutBufferLength = sizeof(uint32_t);
@@ -4956,7 +4956,7 @@ otLwfIoCtl_otPlatformReset(
     UNREFERENCED_PARAMETER(InBufferLength);
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     otInstanceReset(pFilter->otCtx);
 
     return status;
@@ -4980,7 +4980,7 @@ otLwfIoCtl_otFactoryReset(
     UNREFERENCED_PARAMETER(InBufferLength);
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     otInstanceFactoryReset(pFilter->otCtx);
 
     return status;
@@ -5002,8 +5002,8 @@ otLwfTunIoCtl_otPlatformReset(
     UNREFERENCED_PARAMETER(InBuffer);
     UNREFERENCED_PARAMETER(InBufferLength);
     UNREFERENCED_PARAMETER(OutBufferLength);
-    
-    status = 
+
+    status =
         otLwfTunSendCommandForIrp(
             pFilter,
             pIrp,
@@ -5029,10 +5029,10 @@ otLwfIoCtl_otParentInfo(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     UNREFERENCED_PARAMETER(InBuffer);
     UNREFERENCED_PARAMETER(InBufferLength);
-    
+
     static_assert(sizeof(otRouterInfo) == 20, "The size of otRouterInfo should be 20 bytes");
     if (*OutBufferLength >= sizeof(otRouterInfo))
     {
@@ -5065,7 +5065,7 @@ otLwfTunIoCtl_otParentInfo(
 
     if (OutBufferLength >= sizeof(otRouterInfo))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -5117,7 +5117,7 @@ otLwfIoCtl_otSingleton(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     UNREFERENCED_PARAMETER(InBuffer);
     UNREFERENCED_PARAMETER(InBufferLength);
 
@@ -5148,7 +5148,7 @@ otLwfIoCtl_otMacCounters(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     UNREFERENCED_PARAMETER(InBuffer);
     UNREFERENCED_PARAMETER(InBufferLength);
 
@@ -5164,7 +5164,7 @@ otLwfIoCtl_otMacCounters(
     }
 
     return status;
-}    
+}
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
@@ -5215,7 +5215,7 @@ otLwfTunIoCtl_otMaxChildren(
 
     if (InBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -5228,7 +5228,7 @@ otLwfTunIoCtl_otMaxChildren(
     }
     else if (OutBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -5276,12 +5276,12 @@ otLwfIoCtl_otCommissionerStart(
             PVOID           OutBuffer,
     _Inout_ PULONG          OutBufferLength
     )
-{    
+{
     UNREFERENCED_PARAMETER(InBuffer);
     UNREFERENCED_PARAMETER(InBufferLength);
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     return ThreadErrorToNtstatus(otCommissionerStart(pFilter->otCtx));
 }
 
@@ -5303,7 +5303,7 @@ otLwfIoCtl_otCommissionerStop(
     UNREFERENCED_PARAMETER(InBufferLength);
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     status = ThreadErrorToNtstatus(otCommissionerStop(pFilter->otCtx));
 
     return status;
@@ -5322,10 +5322,10 @@ otLwfIoCtl_otJoinerStart(
     )
 {
     NTSTATUS status = STATUS_SUCCESS;
-    
+
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     if (InBufferLength >= sizeof(otCommissionConfig))
     {
         otCommissionConfig *aConfig = (otCommissionConfig*)InBuffer;
@@ -5384,7 +5384,7 @@ otLwfIoCtl_otJoinerStop(
     UNREFERENCED_PARAMETER(InBufferLength);
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     status = ThreadErrorToNtstatus(otJoinerStop(pFilter->otCtx));
 
     return status;
@@ -5403,7 +5403,7 @@ otLwfIoCtl_otCommissionerPanIdQuery(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     *OutBufferLength = 0;
     UNREFERENCED_PARAMETER(OutBuffer);
 
@@ -5415,8 +5415,8 @@ otLwfIoCtl_otCommissionerPanIdQuery(
 
         status = ThreadErrorToNtstatus(
             otCommissionerPanIdQuery(
-                pFilter->otCtx, 
-                aPanId, 
+                pFilter->otCtx,
+                aPanId,
                 aChannelMask,
                 aAddress,
                 otLwfCommissionerPanIdConflictCallback,
@@ -5425,7 +5425,7 @@ otLwfIoCtl_otCommissionerPanIdQuery(
     }
 
     return status;
-}    
+}
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
@@ -5440,7 +5440,7 @@ otLwfIoCtl_otCommissionerEnergyScan(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     *OutBufferLength = 0;
     UNREFERENCED_PARAMETER(OutBuffer);
 
@@ -5517,7 +5517,7 @@ otLwfTunIoCtl_otRouterSelectionJitter(
 
     if (InBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -5530,7 +5530,7 @@ otLwfTunIoCtl_otRouterSelectionJitter(
     }
     else if (OutBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -5599,7 +5599,7 @@ otLwfIoCtl_otJoinerUdpPort(
     }
 
     return status;
-}    
+}
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
@@ -5614,7 +5614,7 @@ otLwfIoCtl_otSendDiagnosticGet(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     *OutBufferLength = 0;
     UNREFERENCED_PARAMETER(OutBuffer);
 
@@ -5637,7 +5637,7 @@ otLwfIoCtl_otSendDiagnosticGet(
     }
 
     return status;
-}   
+}
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
@@ -5652,7 +5652,7 @@ otLwfIoCtl_otSendDiagnosticReset(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     *OutBufferLength = 0;
     UNREFERENCED_PARAMETER(OutBuffer);
 
@@ -5690,10 +5690,10 @@ otLwfIoCtl_otCommissionerAddJoiner(
     )
 {
     NTSTATUS status = STATUS_SUCCESS;
-    
+
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     if (InBufferLength >= sizeof(uint8_t) + sizeof(otExtAddress))
     {
         const ULONG aPSKdBufferLength = InBufferLength - sizeof(uint8_t) - sizeof(otExtAddress) - sizeof(uint32_t);
@@ -5730,10 +5730,10 @@ otLwfIoCtl_otCommissionerRemoveJoiner(
     )
 {
     NTSTATUS status = STATUS_SUCCESS;
-    
+
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     if (InBufferLength >= sizeof(uint8_t) + sizeof(otExtAddress))
     {
         uint8_t aExtAddressValid = *(uint8_t*)InBuffer;
@@ -5758,10 +5758,10 @@ otLwfIoCtl_otCommissionerProvisioningUrl(
     )
 {
     NTSTATUS status = STATUS_SUCCESS;
-    
+
     UNREFERENCED_PARAMETER(OutBuffer);
     *OutBufferLength = 0;
-    
+
     if (InBufferLength <= OPENTHREAD_PROV_URL_MAX_LENGTH + 1)
     {
         char *aProvisioningUrl = InBufferLength > 1 ? (char*)InBuffer : NULL;
@@ -5791,7 +5791,7 @@ otLwfIoCtl_otCommissionerAnnounceBegin(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     *OutBufferLength = 0;
     UNREFERENCED_PARAMETER(OutBuffer);
 
@@ -5831,7 +5831,7 @@ otLwfIoCtl_otSendActiveGet(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     *OutBufferLength = 0;
     UNREFERENCED_PARAMETER(OutBuffer);
 
@@ -5872,7 +5872,7 @@ otLwfIoCtl_otSendActiveSet(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     *OutBufferLength = 0;
     UNREFERENCED_PARAMETER(OutBuffer);
 
@@ -5910,7 +5910,7 @@ otLwfIoCtl_otSendPendingGet(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     *OutBufferLength = 0;
     UNREFERENCED_PARAMETER(OutBuffer);
 
@@ -5951,7 +5951,7 @@ otLwfIoCtl_otSendPendingSet(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     *OutBufferLength = 0;
     UNREFERENCED_PARAMETER(OutBuffer);
 
@@ -5989,7 +5989,7 @@ otLwfIoCtl_otSendMgmtCommissionerGet(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     *OutBufferLength = 0;
     UNREFERENCED_PARAMETER(OutBuffer);
 
@@ -6025,7 +6025,7 @@ otLwfIoCtl_otSendMgmtCommissionerSet(
     )
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
-    
+
     *OutBufferLength = 0;
     UNREFERENCED_PARAMETER(OutBuffer);
 
@@ -6099,7 +6099,7 @@ otLwfTunIoCtl_otKeySwitchGuardtime(
 
     if (InBufferLength >= sizeof(uint32_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -6112,7 +6112,7 @@ otLwfTunIoCtl_otKeySwitchGuardtime(
     }
     else if (OutBufferLength >= sizeof(uint32_t))
     {
-        status = 
+        status =
             otLwfTunSendCommandForIrp(
                 pFilter,
                 pIrp,
@@ -6165,7 +6165,7 @@ otLwfIoCtl_otThreadAutoStart(
 
     if (InBufferLength >= sizeof(BOOLEAN))
     {
-        status = 
+        status =
             ThreadErrorToNtstatus(
                 otThreadSetAutoStart(
                     pFilter->otCtx,
@@ -6206,7 +6206,7 @@ otLwfIoCtl_otThreadPreferredRouterId(
 
     if (InBufferLength >= sizeof(uint8_t))
     {
-        status = 
+        status =
             ThreadErrorToNtstatus(
                 otThreadSetPreferredRouterId(
                     pFilter->otCtx,

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -382,7 +382,7 @@ private:
     otError GetPropertyHandler_IPV6_ROUTE_TABLE(uint8_t header, spinel_prop_key_t key);
     otError GetPropertyHandler_IPV6_ICMP_PING_OFFLOAD(uint8_t header, spinel_prop_key_t key);
     otError GetPropertyHandler_THREAD_RLOC16_DEBUG_PASSTHRU(uint8_t header, spinel_prop_key_t key);
-    otError GetPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_THREAD_OFF_MESH_ROUTES(uint8_t header, spinel_prop_key_t key);
     otError GetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_key_t key);
     otError GetPropertyHandler_MAC_SCAN_MASK(uint8_t header, spinel_prop_key_t key);
     otError GetPropertyHandler_MAC_SCAN_PERIOD(uint8_t header, spinel_prop_key_t key);
@@ -612,7 +612,7 @@ private:
 #endif
     otError InsertPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key,
                                                          const uint8_t *value_ptr, uint16_t value_len);
-    otError InsertPropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key,
+    otError InsertPropertyHandler_THREAD_OFF_MESH_ROUTES(uint8_t header, spinel_prop_key_t key,
                                                           const uint8_t *value_ptr, uint16_t value_len);
     otError InsertPropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key,
                                                           const uint8_t *value_ptr, uint16_t value_len);
@@ -633,7 +633,7 @@ private:
 #endif
     otError RemovePropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key,
                                                          const uint8_t *value_ptr, uint16_t value_len);
-    otError RemovePropertyHandler_THREAD_LOCAL_ROUTES(uint8_t header, spinel_prop_key_t key,
+    otError RemovePropertyHandler_THREAD_OFF_MESH_ROUTES(uint8_t header, spinel_prop_key_t key,
                                                           const uint8_t *value_ptr, uint16_t value_len);
     otError RemovePropertyHandler_THREAD_ON_MESH_NETS(uint8_t header, spinel_prop_key_t key,
                                                           const uint8_t *value_ptr, uint16_t value_len);

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1152,8 +1152,8 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_THREAD_ON_MESH_NETS";
         break;
 
-    case SPINEL_PROP_THREAD_LOCAL_ROUTES:
-        ret = "PROP_THREAD_LOCAL_ROUTES";
+    case SPINEL_PROP_THREAD_OFF_MESH_ROUTES:
+        ret = "PROP_THREAD_OFF_MESH_ROUTES";
         break;
 
     case SPINEL_PROP_THREAD_ASSISTING_PORTS:

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -725,8 +725,8 @@ typedef enum
                                         = SPINEL_PROP_THREAD__BEGIN + 8, ///< [D]
     SPINEL_PROP_THREAD_STABLE_NETWORK_DATA_VERSION
                                         = SPINEL_PROP_THREAD__BEGIN + 9,  ///< [S]
-    SPINEL_PROP_THREAD_ON_MESH_NETS     = SPINEL_PROP_THREAD__BEGIN + 10, ///< array(ipv6prefix,prefixlen,stable,flags) [A(t(6CbC))]
-    SPINEL_PROP_THREAD_LOCAL_ROUTES     = SPINEL_PROP_THREAD__BEGIN + 11, ///< array(ipv6prefix,prefixlen,stable,flags) [A(t(6CbC))]
+    SPINEL_PROP_THREAD_ON_MESH_NETS     = SPINEL_PROP_THREAD__BEGIN + 10, ///< array(ipv6prefix,prefixlen,stable,flags,isLocal) [A(t(6CbCb))]
+    SPINEL_PROP_THREAD_OFF_MESH_ROUTES  = SPINEL_PROP_THREAD__BEGIN + 11, ///< array(ipv6prefix,prefixlen,stable,flags,isLocal) [A(t(6CbCb))]
     SPINEL_PROP_THREAD_ASSISTING_PORTS  = SPINEL_PROP_THREAD__BEGIN + 12, ///< array(portn) [A(S)]
     SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE
                                         = SPINEL_PROP_THREAD__BEGIN + 13, ///< [b]


### PR DESCRIPTION
This commit renames the spinel property `THREAD_LOCAL_ROUTES` to
`THREAD_OFF_MESH_ROUTES` and updates the get handler for this property
to include `isLocal` flag which specifies if the route is from local
network data or partition's network data (this change makes the
`OFF_MESH_ROUTES` behavior similar to other network data related
property `ON_MESH_NETS`). The spinel draft documentation is also
updated.