### PR TITLE
Fixed a build error and runtime crash

### DIFF
--- a/examples/platforms/posix/flash.c
+++ b/examples/platforms/posix/flash.c
@@ -114,7 +114,7 @@ otError utilsFlashErasePage(uint32_t aAddress)
 
     // Write the page
     ssize_t r;
-    r =  pwrite(sFlashFd, &(dummyPage[0]), FLASH_PAGE_SIZE, address);
+    r =  pwrite(sFlashFd, &(dummyPage[0]), FLASH_PAGE_SIZE, (off_t)address);
     otEXPECT_ACTION(((int)r) == ((int)(FLASH_PAGE_SIZE)), error = OT_ERROR_FAILED);
 
 
@@ -141,7 +141,7 @@ uint32_t utilsFlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
         otEXPECT((ret = utilsFlashRead(aAddress + index, &byte, 1)) == 1);
         // Use bitwise AND to emulate the behavior of flash memory
         byte &= aData[index];
-        otEXPECT((ret = (uint32_t)pwrite(sFlashFd, &byte, 1, aAddress + index)) == 1);
+        otEXPECT((ret = (uint32_t)pwrite(sFlashFd, &byte, 1, (off_t)(aAddress + index))) == 1);
     }
 
 exit:
@@ -153,7 +153,7 @@ uint32_t utilsFlashRead(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
     uint32_t ret = 0;
 
     otEXPECT(sFlashFd >= 0 && aAddress < FLASH_SIZE);
-    ret = (uint32_t)pread(sFlashFd, aData, aSize, aAddress);
+    ret = (uint32_t)pread(sFlashFd, aData, aSize, (off_t)aAddress);
 
 exit:
     return ret;

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -328,11 +328,13 @@ otError Coap::ProcessClient(int argc, char *argv[])
     }
 
     // CoAP-Type
-    ConvertToLower(argv[3]);
-
-    if ((argc > 3) && (strcmp(argv[3], "con") == 0))
+    if (argc > 3)
     {
-        coapType = kCoapTypeConfirmable;
+        ConvertToLower(argv[3]);
+        if (strcmp(argv[3], "con") == 0)
+        {
+            coapType = kCoapTypeConfirmable;
+        }
     }
 
     otCoapHeaderInit(&header, coapType, coapCode);

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -331,6 +331,7 @@ otError Coap::ProcessClient(int argc, char *argv[])
     if (argc > 3)
     {
         ConvertToLower(argv[3]);
+
         if (strcmp(argv[3], "con") == 0)
         {
             coapType = kCoapTypeConfirmable;


### PR DESCRIPTION
This PR address two issues.
1. build error on gcc-4.8.5
>/home/ff/Code/ot/examples/../examples/platforms/posix/flash.c:117:61: error: implicit conversion changes signedness: 'uint32_t' (aka 'unsigned int') to '__off_t' (aka 'long') [-Werror,-Wsign-conversion]
    r =  pwrite(sFlashFd, &(dummyPage[0]), FLASH_PAGE_SIZE, address);
         ~~~~~~                                             ^~~~~~~
/home/ff/Code/ot/examples/../examples/platforms/posix/flash.c:144:71: error: implicit conversion changes signedness: 'unsigned int' to '__off_t' (aka 'long') [-Werror,-Wsign-conversion]
        otEXPECT((ret = (uint32_t)pwrite(sFlashFd, &byte, 1, aAddress + index)) == 1);
                                  ~~~~~~                     ~~~~~~~~~^~~~~~~
/home/ff/Code/ot/examples/../examples/platforms/utils/code_utils.h:48:15: note: expanded from macro 'otEXPECT'
        if (!(aCondition))                      \
              ^~~~~~~~~~
/home/ff/Code/ot/examples/../examples/platforms/posix/flash.c:156:51: error: implicit conversion changes signedness: 'uint32_t' (aka 'unsigned int') to '__off_t' (aka 'long') [-Werror,-Wsign-conversion]
    ret = (uint32_t)pread(sFlashFd, aData, aSize, aAddress);
2. Crash when number of arguments of CoAP client is not enough
```
> panid 0xface
Done
> ifconfig up
Done
> thread start
Done
> coap client get fdde:ad00:beef:0:dbaa:f1d0:8afb:30dc testSegmentation fault: 11
```
