### PR TITLE
NcpBase: Implement the get handler for `IPV6_LL_ADDR` spinel property

### DIFF
--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -276,6 +276,17 @@ OTAPI const uint8_t *OTCALL otThreadGetMeshLocalPrefix(otInstance *aInstance);
 OTAPI otError OTCALL otThreadSetMeshLocalPrefix(otInstance *aInstance, const uint8_t *aMeshLocalPrefix);
 
 /**
+ * This function returns the Thread link-local IPv6 address.
+ *
+ * The Thread link local address is derived using IEEE802.15.4 Extended Address as Interface Identifier.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ *
+ * @returns A pointer to Thread link-local IPv6 address.
+ */
+const otIp6Address *otThreadGetLinkLocalIp6Address(otInstance *aInstance);
+
+/**
  * Get the Thread Network Name.
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -195,6 +195,11 @@ exit:
     return error;
 }
 
+const otIp6Address *otThreadGetLinkLocalIp6Address(otInstance *aInstance)
+{
+    return &aInstance->mThreadNetif.GetMle().GetLinkLocalAddress();
+}
+
 const char *otThreadGetNetworkName(otInstance *aInstance)
 {
     return aInstance->mThreadNetif.GetMac().GetNetworkName();

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -675,6 +675,11 @@ exit:
     return error;
 }
 
+const Ip6::Address &Mle::GetLinkLocalAddress(void) const
+{
+    return mLinkLocal64.GetAddress();
+}
+
 otError Mle::UpdateLinkLocalAddress(void)
 {
     mNetif.RemoveUnicastAddress(mLinkLocal64);

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -651,6 +651,16 @@ public:
     otError SetMeshLocalPrefix(const uint8_t *aPrefix);
 
     /**
+     * This method returns a reference to the Thread link-local address.
+     *
+     * The Thread link local address is derived using IEEE802.15.4 Extended Address as Interface Identifier.
+     *
+     * @returns A reference to the Thread link local address.
+     *
+     */
+    const Ip6::Address &GetLinkLocalAddress(void) const;
+
+    /**
      * This method updates the link local address.
      *
      * Call this method when the IEEE 802.15.4 Extended Address has changed.

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -3121,10 +3121,30 @@ otError NcpBase::GetPropertyHandler_IPV6_ML_ADDR(uint8_t header, spinel_prop_key
 
 otError NcpBase::GetPropertyHandler_IPV6_LL_ADDR(uint8_t header, spinel_prop_key_t key)
 {
-    // TODO!
-    (void)key;
+    otError errorCode = OT_ERROR_NONE;
+    const otIp6Address *address = otThreadGetLinkLocalIp6Address(mInstance);
 
-    return SendLastStatus(header, SPINEL_STATUS_UNIMPLEMENTED);
+    if (address)
+    {
+        errorCode = SendPropertyUpdate(
+                        header,
+                        SPINEL_CMD_PROP_VALUE_IS,
+                        key,
+                        SPINEL_DATATYPE_IPv6ADDR_S,
+                        address
+                    );
+    }
+    else
+    {
+        errorCode = SendPropertyUpdate(
+                        header,
+                        SPINEL_CMD_PROP_VALUE_IS,
+                        key,
+                        SPINEL_DATATYPE_VOID_S
+                    );
+    }
+
+    return errorCode;
 }
 
 otError NcpBase::GetPropertyHandler_IPV6_ADDRESS_TABLE(uint8_t header, spinel_prop_key_t key)


### PR DESCRIPTION
This commit add a new API `otThreadGetLinkLocalIp6Address()` to get the Thread link-local address (which is is derived using IEEE802.15.4 Extended Address as Interface Identifier).  The new API is then used to implement the get handler for spinel property `IPV6_LL_ADDR` in `NcpBase` class.

Should address issue https://github.com/openthread/openthread/issues/1794.