### PR TITLE
Allow `SuccessOrExit()` to have optional failure statements before exit

### DIFF
--- a/src/core/common/code_utils.hpp
+++ b/src/core/common/code_utils.hpp
@@ -50,13 +50,16 @@
  *  the status is unsuccessful.
  *
  *  @param[in]  aStatus     A scalar status to be evaluated against zero (0).
+ *  @param[in]  ...         An expression or block to execute when the
+ *                          assertion fails.
  *
  */
-#define SuccessOrExit(aStatus)                      \
+#define SuccessOrExit(aStatus, ...)                 \
     do                                              \
     {                                               \
         if ((aStatus) != 0)                         \
         {                                           \
+            __VA_ARGS__;                            \
             goto exit;                              \
         }                                           \
     } while (false)

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1768,7 +1768,7 @@ void MeshForwarder::HandleMesh(uint8_t *aFrame, uint8_t aFrameLength, const Mac:
     Lowpan::MeshHeader meshHeader;
 
     // Check the mesh header
-    VerifyOrExit(meshHeader.Init(aFrame, aFrameLength) == OT_ERROR_NONE, error = OT_ERROR_DROP);
+    SuccessOrExit(meshHeader.Init(aFrame, aFrameLength), error = OT_ERROR_DROP);
 
     // Security Check: only process Mesh Header frames that had security enabled.
     VerifyOrExit(aMessageInfo.mLinkSecurity && meshHeader.IsValid(), error = OT_ERROR_SECURITY);
@@ -1846,7 +1846,7 @@ otError MeshForwarder::CheckReachability(uint8_t *aFrame, uint8_t aFrameLength,
     Ip6::Header ip6Header;
     Lowpan::MeshHeader meshHeader;
 
-    VerifyOrExit(meshHeader.Init(aFrame, aFrameLength) == OT_ERROR_NONE, error = OT_ERROR_DROP);
+    SuccessOrExit(meshHeader.Init(aFrame, aFrameLength) , error = OT_ERROR_DROP);
 
     // skip mesh header
     aFrame += meshHeader.GetHeaderLength();


### PR DESCRIPTION
This commit changes the `SuccessOrExit()` to make it similar to  the
behavior of  `VerifyOrExit()` to include an optional set of statements
to execute when the test fails before the exit.