### PR TITLE
logging: `otSetDynamicLogLevel()` returning `OT_ERROR_DISABLED_FEATURE` when not enabled.

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -278,8 +278,9 @@ otLogLevel otGetDynamicLogLevel(otInstance *aInstance);
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aLogLevel The dynamic log level.
  *
- * @retval OT_ERROR_NONE          The log level was changed successfully.
- * @retval OT_ERROR_NOT_CAPABLE   The dynamic log level is not supported.
+ * @retval OT_ERROR_NONE               The log level was changed successfully.
+ * @retval OT_ERROR_DISABLED_FEATURE   The dynamic log level feature is disabled.
+ *                                     (@sa `OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL` configuration option).
  *
  */
 otError otSetDynamicLogLevel(otInstance *aInstance, otLogLevel aLogLevel);

--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -239,7 +239,7 @@ otError otSetDynamicLogLevel(otInstance *aInstance, otLogLevel aLogLevel)
 #if OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
     aInstance->mLogLevel = aLogLevel;
 #else
-    error = OT_ERROR_NOT_CAPABLE;
+    error = OT_ERROR_DISABLED_FEATURE;
     (void)aInstance;
     (void)aLogLevel;
 #endif

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -3735,7 +3735,7 @@ otError NcpBase::SetPropertyHandler_HOST_POWER_STATE(uint8_t header, spinel_prop
     if (parsedLength > 0)
     {
         switch (value)
-        {        
+        {
         case SPINEL_HOST_POWER_STATE_OFFLINE:
         case SPINEL_HOST_POWER_STATE_DEEP_SLEEP:
         case SPINEL_HOST_POWER_STATE_LOW_POWER:
@@ -6025,7 +6025,7 @@ otError NcpBase::SetPropertyHandler_DEBUG_NCP_LOG_LEVEL(uint8_t header, spinel_p
         }
         else
         {
-            if (errorCode == OT_ERROR_NOT_CAPABLE)
+            if (errorCode == OT_ERROR_DISABLED_FEATURE)
             {
                 errorCode = SendLastStatus(header, SPINEL_STATUS_INVALID_COMMAND_FOR_PROP);
             }


### PR DESCRIPTION
Making the returned error type consistent with other cases. 