### PR TITLE
MLE: Fix restore of rx-on children.

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2204,7 +2204,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     case Header::kCommandChildUpdateRequest:
         if (mRole == OT_DEVICE_ROLE_LEADER || mRole == OT_DEVICE_ROLE_ROUTER)
         {
-            mNetif.GetMle().HandleChildUpdateRequest(aMessage, aMessageInfo);
+            mNetif.GetMle().HandleChildUpdateRequest(aMessage, aMessageInfo, keySequence);
         }
         else
         {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2215,7 +2215,8 @@ exit:
     return error;
 }
 
-otError MleRouter::HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError MleRouter::HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
+                                            uint32_t aKeySequence)
 {
     static const uint8_t kMaxResponseTlvs = 10;
 
@@ -2314,6 +2315,12 @@ otError MleRouter::HandleChildUpdateRequest(const Message &aMessage, const Ip6::
     }
 
     child->SetLastHeard(Timer::GetNow());
+
+    if (child->IsStateRestoring())
+    {
+        SetChildStateToValid(child);
+        child->SetKeySequence(aKeySequence);
+    }
 
     SendChildUpdateResponse(child, aMessageInfo, tlvs, tlvslength, &challenge);
 

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -691,7 +691,8 @@ private:
     otError HandleParentRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     otError HandleChildIdRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
                                  uint32_t aKeySequence);
-    otError HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
+                                     uint32_t aKeySequence);
     otError HandleChildUpdateResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo,
                                       uint32_t aKeySequence);
     otError HandleDataRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/thread/mle_router_mtd.hpp
+++ b/src/core/thread/mle_router_mtd.hpp
@@ -139,7 +139,7 @@ private:
     otError HandleAdvertisement(const Message &, const Ip6::MessageInfo &) { return OT_ERROR_DROP; }
     otError HandleParentRequest(const Message &, const Ip6::MessageInfo &) { return OT_ERROR_DROP; }
     otError HandleChildIdRequest(const Message &, const Ip6::MessageInfo &, uint32_t) { return OT_ERROR_DROP; }
-    otError HandleChildUpdateRequest(const Message &, const Ip6::MessageInfo &) { return OT_ERROR_DROP; }
+    otError HandleChildUpdateRequest(const Message &, const Ip6::MessageInfo &, uint32_t) { return OT_ERROR_DROP; }
     otError HandleChildUpdateResponse(const Message &, const Ip6::MessageInfo &, uint32_t) { return OT_ERROR_DROP; }
     otError HandleDataRequest(const Message &, const Ip6::MessageInfo &) { return OT_ERROR_DROP; }
     otError HandleNetworkDataUpdateRouter(void) { return OT_ERROR_NONE; }

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -84,13 +84,21 @@ public:
     void SetState(State aState) { mState = static_cast<uint8_t>(aState); }
 
     /**
+     * Check if the neighbor/child is being restored.
+     *
+     * @returns TRUE if the neighbor is being restored, FALSE otherwise.
+     *
+     */
+    bool IsStateRestoring(void) const { return (mState == kStateRestored) || (mState == kStateChildUpdateRequest); }
+
+    /**
      * Check if the neighbor/child is in valid state or if it is being restored.
      * When in these states messages can be sent to and/or received from the neighbor/child.
      *
      * @returns TRUE if the neighbor is in valid, restored, or being restored states, FALSE otherwise.
      *
      */
-    bool IsStateValidOrRestoring(void) const { return (mState == kStateValid) || (mState == kStateRestored); }
+    bool IsStateValidOrRestoring(void) const { return (mState == kStateValid) || IsStateRestoring(); }
 
     /**
      * This method gets the device mode flags.


### PR DESCRIPTION
Since #1821 following situation makes restored rx-on child unusable.

1. Node A joins Thread Network - operates as Leader/Router
2. Node B joins Thread Network as rx-on child of Node A
3. Node A and Node B turns off
4. Node A reboots and joins to Thread Network again.
5. Node A restores Node B child and sets its state to `kStateChildUpdateRequest`
6. Node A sends Child Update Request only once, without any reply from Node B
7. Node B reboots and sends Child Update Request (to ensure parent is still there)
8. Node A gets Child Update Request and replies with Child Update Response.

From now Node B cannot communicate with Node A using non MLE messages since its state remains unchanged (`kStateChildUpdateRequest`), state is changed to `kStateValid `only inside `HandleChildUpdateResponse `or `SendChildIdResponse `functions.

This PR fixes it by setting `kStateValid `state for restored child in `HandleChildUpdateRequest`. Mechanism is coppied from `HandleChildUpdateResponse`.
