### PR TITLE
Make spinel file more portable to different platforms

### DIFF
--- a/src/ncp/Makefile.am
+++ b/src/ncp/Makefile.am
@@ -28,85 +28,87 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-EXTRA_DIST                          = \
-    PROTOCOL.md                       \
+EXTRA_DIST                                        = \
+    PROTOCOL.md                                     \
     $(NULL)
 
 # Pull in the sources that comprise the OpenThread NCP library.
 
-lib_LIBRARIES                       = \
-    libopenthread-ncp-mtd.a           \
-    libopenthread-ncp-ftd.a           \
+lib_LIBRARIES                                     = \
+    libopenthread-ncp-mtd.a                         \
+    libopenthread-ncp-ftd.a                         \
     $(NULL)
 
 
-COMMON_CPPFLAGS        = \
-    -I$(top_srcdir)/include             \
-    -I$(top_srcdir)/src                 \
-    -I$(top_srcdir)/src/core            \
-    -I$(top_srcdir)/third_party         \
-    -D_GNU_SOURCE                       \
-    $(OPENTHREAD_TARGET_DEFINES)        \
+COMMON_CPPFLAGS                                   = \
+    -I$(top_srcdir)/include                         \
+    -I$(top_srcdir)/src                             \
+    -I$(top_srcdir)/src/core                        \
+    -I$(top_srcdir)/third_party                     \
+    -D_GNU_SOURCE                                   \
+    '-DSPINEL_PLATFORM_HEADER="spinel_platform.h"'  \
+    $(OPENTHREAD_TARGET_DEFINES)                    \
     $(NULL)
 
 
-COMMON_CXXFLAGS                     = \
-    -I$(top_srcdir)/include           \
-    -I$(top_srcdir)/src               \
-    -I$(top_srcdir)/src/core          \
-    -I$(top_srcdir)/third_party       \
-    -D_GNU_SOURCE                     \
-    $(OPENTHREAD_TARGET_DEFINES)      \
+COMMON_CXXFLAGS                                   = \
+    -I$(top_srcdir)/include                         \
+    -I$(top_srcdir)/src                             \
+    -I$(top_srcdir)/src/core                        \
+    -I$(top_srcdir)/third_party                     \
+    -D_GNU_SOURCE                                   \
+    $(OPENTHREAD_TARGET_DEFINES)                    \
     $(NULL)
 
-libopenthread_ncp_mtd_a_CPPFLAGS    = \
-    -DOPENTHREAD_MTD=1                \
-    $(COMMON_CXXFLAGS)                \
+libopenthread_ncp_mtd_a_CPPFLAGS                  = \
+    -DOPENTHREAD_MTD=1                              \
+    $(COMMON_CXXFLAGS)                              \
     $(NULL)
 
-libopenthread_ncp_ftd_a_CPPFLAGS    = \
-    -DOPENTHREAD_FTD=1                \
-    $(COMMON_CXXFLAGS)                \
+libopenthread_ncp_ftd_a_CPPFLAGS                  = \
+    -DOPENTHREAD_FTD=1                              \
+    $(COMMON_CXXFLAGS)                              \
     $(NULL)
 
-COMMON_SOURCES                      = \
-    ncp_base.cpp                      \
-    ncp_base.hpp                      \
-    ncp_buffer.cpp                    \
-    ncp_buffer.hpp                    \
-    spinel.c                          \
-    spinel.h                          \
-    ncp_spi.cpp                       \
-    ncp_spi.hpp                       \
-    hdlc.cpp                          \
-    hdlc.hpp                          \
-    ncp_uart.cpp                      \
-    ncp_uart.hpp                      \
+COMMON_SOURCES                                    = \
+    ncp_base.cpp                                    \
+    ncp_base.hpp                                    \
+    ncp_buffer.cpp                                  \
+    ncp_buffer.hpp                                  \
+    spinel.c                                        \
+    spinel.h                                        \
+    spinel_platform.h                               \
+    ncp_spi.cpp                                     \
+    ncp_spi.hpp                                     \
+    hdlc.cpp                                        \
+    hdlc.hpp                                        \
+    ncp_uart.cpp                                    \
+    ncp_uart.hpp                                    \
     $(NULL)
 
-libopenthread_ncp_mtd_a_SOURCES     = \
-   $(COMMON_SOURCES)                  \
+libopenthread_ncp_mtd_a_SOURCES                   = \
+   $(COMMON_SOURCES)                                \
    $(NULL)
 
-libopenthread_ncp_ftd_a_SOURCES     = \
-   $(COMMON_SOURCES)                  \
+libopenthread_ncp_ftd_a_SOURCES                   = \
+   $(COMMON_SOURCES)                                \
    $(NULL)
 
-include_HEADERS                     = \
+include_HEADERS                                   = \
     $(NULL)
 
 if OPENTHREAD_BUILD_TESTS
 
-noinst_PROGRAMS                     = spinel-test
-spinel_test_SOURCES                 = spinel.c
-spinel_test_CFLAGS                  = -DSPINEL_SELF_TEST=1 -D_GNU_SOURCE -I$(top_srcdir)/src/core
+noinst_PROGRAMS                                   = spinel-test
+spinel_test_SOURCES                               = spinel.c
+spinel_test_CFLAGS                                = -DSPINEL_SELF_TEST=1 -D_GNU_SOURCE -I$(top_srcdir)/src/core
 
-TESTS = spinel-test
+TESTS                                             = spinel-test
 
 install-headers: install-includeHEADERS
 
 if OPENTHREAD_BUILD_COVERAGE
-CLEANFILES                          = $(wildcard *.gcda *.gcno)
+CLEANFILES                                        = $(wildcard *.gcda *.gcno)
 endif # OPENTHREAD_BUILD_COVERAGE
 endif # OPENTHREAD_BUILD_TESTS
 

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -43,20 +43,20 @@
 // MARK: -
 // MARK: Headers
 
-#ifdef OPENTHREAD_CONFIG_FILE
-#include OPENTHREAD_CONFIG_FILE
-#else
-#include <openthread-config.h>
-#endif
-
 #include "spinel.h"
 
 #include <assert.h>
+#include <errno.h>
+
+#ifndef SPINEL_PLATFORM_HEADER
+/* These are all already included in the spinel platform header
+ * if SPINEL_PLATFORM_HEADER was defined.
+ */
 #include <stdio.h>
 #include <stdlib.h>
-#include "utils/wrap_string.h"
-#include <errno.h>
-#include "utils/wrap_stdbool.h"
+#include <string.h>
+#endif // #ifndef SPINEL_PLATFORM_HEADER
+
 // ----------------------------------------------------------------------------
 // MARK: -
 

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -28,9 +28,13 @@
 #ifndef SPINEL_HEADER_INCLUDED
 #define SPINEL_HEADER_INCLUDED 1
 
+#ifdef SPINEL_PLATFORM_HEADER
+#include SPINEL_PLATFORM_HEADER
+#else // ifdef SPINEL_PLATFORM_HEADER
 #include <stdarg.h>
-#include "utils/wrap_stdbool.h"
-#include "utils/wrap_stdint.h"
+#include <stdbool.h>
+#include <stdint.h>
+#endif // else SPINEL_PLATFORM_HEADER
 
 // ----------------------------------------------------------------------------
 

--- a/src/ncp/spinel_platform.h
+++ b/src/ncp/spinel_platform.h
@@ -1,0 +1,65 @@
+/*
+ *    Copyright (c) 2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+ *    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SPINEL_PLATFORM_OPENTHREAD_H_
+#define SPINEL_PLATFORM_OPENTHREAD_H_
+
+/**
+ * This is the platform header file used for spinel on
+ * OpenThread.
+ *
+ * To make spinel code more portable, all header file
+ * `#include`s are defined in a platform specific header
+ * file "spinel_platform.h" which is then included from
+ * "spinel.h".
+ *
+ * This file should include the following header files (or
+ * their equivalent on the platform):
+ *
+ *   #include <stdarg.h>
+ *   #include <stdbool.h>
+ *   #include <stdint.h>
+ *   #include <stdio.h>
+ *   #include <stdlib.h>
+ *   #include <string.h>
+ *
+ */
+
+#ifdef OPENTHREAD_CONFIG_FILE
+#include OPENTHREAD_CONFIG_FILE
+#else
+#include <openthread-config.h>
+#endif
+
+#include <stdarg.h>
+#include "utils/wrap_stdbool.h"
+#include "utils/wrap_stdint.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include "utils/wrap_string.h"
+
+#endif // SPINEL_PLATFORM_OPENTHREAD_H_


### PR DESCRIPTION
To make spinel source code more portable, some of the header file `#include`s
are moved to a platform specific header file "spinel_platform.h" which
is then included from  "spinel.h".  The platform header file should
include the following standard headers (or their equivalent on the
platform):

   #include <stdarg.h>
   #include <stdbool.h>
   #include <stdint.h>
   #include <stdio.h>
   #include <stdlib.h>
   #include <string.h>

This commit also adds OpenThread specific "spienl_platform.h".