### PR TITLE
Diag: Refine diag send codes

### DIFF
--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -508,7 +508,7 @@ void cc2538RadioProcess(otInstance *aInstance)
 
             if (otPlatDiagModeGet())
             {
-                otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, false, sTransmitError);
+                otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, sTransmitError);
             }
             else
 #endif
@@ -522,18 +522,7 @@ void cc2538RadioProcess(otInstance *aInstance)
         {
             sState = OT_RADIO_STATE_RECEIVE;
 
-#if OPENTHREAD_ENABLE_DIAG
-
-            if (otPlatDiagModeGet())
-            {
-                otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, (sReceiveFrame.mPsdu[0] & IEEE802154_FRAME_PENDING) != 0,
-                                            sTransmitError);
-            }
-            else
-#endif
-            {
-                otPlatRadioTxDone(aInstance, &sTransmitFrame, &sReceiveFrame, sTransmitError);
-            }
+            otPlatRadioTxDone(aInstance, &sTransmitFrame, &sReceiveFrame, sTransmitError);
         }
     }
 

--- a/examples/platforms/cc2650/radio.c
+++ b/examples/platforms/cc2650/radio.c
@@ -1826,7 +1826,7 @@ void cc2650RadioProcess(otInstance *aInstance)
 
         if (otPlatDiagModeGet())
         {
-            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, sReceivedAckPendingBit, sTransmitError);
+            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, sTransmitError);
         }
         else
 #endif /* OPENTHREAD_ENABLE_DIAG */

--- a/examples/platforms/efr32/radio.c
+++ b/examples/platforms/efr32/radio.c
@@ -735,7 +735,7 @@ void efr32RadioProcess(otInstance *aInstance)
 
             if (otPlatDiagModeGet())
             {
-                otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, false, sTransmitError);
+                otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, sTransmitError);
             }
             else
 #endif
@@ -749,20 +749,8 @@ void efr32RadioProcess(otInstance *aInstance)
         {
             sState = OT_RADIO_STATE_RECEIVE;
 
-#if OPENTHREAD_ENABLE_DIAG
-
-            if (otPlatDiagModeGet())
-            {
-                otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame,
-                                            (sReceiveFrame.mPsdu[0] & IEEE802154_FRAME_PENDING) != 0,
-                                            sTransmitError);
-            }
-            else
-#endif
-            {
-                otLogInfoPlat(sInstance, "Received ACK:%d", sReceiveFrame.mLength);
-                otPlatRadioTxDone(aInstance, &sTransmitFrame, &sReceiveFrame, sTransmitError);
-            }
+            otLogInfoPlat(sInstance, "Received ACK:%d", sReceiveFrame.mLength);
+            otPlatRadioTxDone(aInstance, &sTransmitFrame, &sReceiveFrame, sTransmitError);
         }
     }
 

--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -522,8 +522,7 @@ void nrf5RadioProcess(otInstance *aInstance)
 
         if (otPlatDiagModeGet())
         {
-            bool pendingBit = ((sAckFrame.mPsdu != NULL) && (sAckFrame.mPsdu[1] & PENDING_BIT)) ? true : false;
-            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, pendingBit, OT_ERROR_NONE);
+            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, OT_ERROR_NONE);
         }
         else
 #endif
@@ -547,7 +546,7 @@ void nrf5RadioProcess(otInstance *aInstance)
 
         if (otPlatDiagModeGet())
         {
-            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, false, OT_ERROR_CHANNEL_ACCESS_FAILURE);
+            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, OT_ERROR_CHANNEL_ACCESS_FAILURE);
         }
         else
 #endif

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -123,15 +123,6 @@ static inline bool isSecurityEnabled(const uint8_t *frame)
     return (frame[0] & IEEE802154_SECURITY_ENABLED) != 0;
 }
 
-#if OPENTHREAD_ENABLE_DIAG
-
-static inline bool isFramePending(const uint8_t *frame)
-{
-    return (frame[0] & IEEE802154_FRAME_PENDING) != 0;
-}
-
-#endif // #if OPENTHREAD_ENABLE_DIAG
-
 static inline bool isAckRequested(const uint8_t *frame)
 {
     return (frame[0] & IEEE802154_ACK_REQUEST) != 0;
@@ -499,17 +490,7 @@ void radioReceive(otInstance *aInstance)
         sState = OT_RADIO_STATE_RECEIVE;
         sAckWait = false;
 
-#if OPENTHREAD_ENABLE_DIAG
-
-        if (otPlatDiagModeGet())
-        {
-            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, isFramePending(sReceiveFrame.mPsdu), OT_ERROR_NONE);
-        }
-        else
-#endif
-        {
-            otPlatRadioTxDone(aInstance, &sTransmitFrame, &sReceiveFrame, OT_ERROR_NONE);
-        }
+        otPlatRadioTxDone(aInstance, &sTransmitFrame, &sReceiveFrame, OT_ERROR_NONE);
     }
     else if ((sState == OT_RADIO_STATE_RECEIVE || sState == OT_RADIO_STATE_TRANSMIT) &&
              (sReceiveFrame.mChannel == sReceiveMessage.mChannel))
@@ -534,7 +515,7 @@ void radioSendMessage(otInstance *aInstance)
 
         if (otPlatDiagModeGet())
         {
-            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, false, OT_ERROR_NONE);
+            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, OT_ERROR_NONE);
         }
         else
 #endif

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -470,15 +470,12 @@ void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable);
  *
  * @param[in]  aInstance      The OpenThread instance structure.
  * @param[in]  aFrame         A pointer to the frame that was transmitted.
- * @param[in]  aFramePending  TRUE if an ACK frame was received and the Frame Pending bit was set.
- * @param[in]  aError  OT_ERROR_NONE when the frame was transmitted, OT_ERROR_NO_ACK when the frame was
- *                     transmitted but no ACK was received, OT_ERROR_CHANNEL_ACCESS_FAILURE when the transmission
- *                     could not take place due to activity on the channel, OT_ERROR_ABORT when transmission was
- *                     aborted for other reasons.
+ * @param[in]  aError         OT_ERROR_NONE when the frame was transmitted, OT_ERROR_CHANNEL_ACCESS_FAILURE when the
+ *                            transmission could not take place due to activity on the channel, OT_ERROR_ABORT when
+ *                            transmission was aborted for other reasons.
  *
  */
-extern void otPlatDiagRadioTransmitDone(otInstance *aInstance, otRadioFrame *aFrame, bool aFramePending,
-                                        otError aError);
+extern void otPlatDiagRadioTransmitDone(otInstance *aInstance, otRadioFrame *aFrame, otError aError);
 
 /**
  * The radio driver calls this method to notify OpenThread diagnostics module of a received frame.

--- a/src/diag/diag_process.cpp
+++ b/src/diag/diag_process.cpp
@@ -187,11 +187,6 @@ otError Diag::ParseLong(char *argv, long &value)
 
 void Diag::TxPacket()
 {
-    if (sTxPackets > 0)
-    {
-        sTxPackets--;
-    }
-
     sTxPacket->mLength = sTxLen;
     sTxPacket->mChannel = sChannel;
     sTxPacket->mPower = sTxPower;
@@ -344,17 +339,22 @@ exit:
     AppendErrorResult(error, aOutput, aOutputMaxLen);
 }
 
-void Diag::DiagTransmitDone(otInstance *aInstance, bool aRxPending, otError aError)
+void Diag::DiagTransmitDone(otInstance *aInstance, otError aError)
 {
     (void)aInstance;
-    if (!aRxPending && aError == OT_ERROR_NONE)
+    if (aError == OT_ERROR_NONE)
     {
         sStats.sent_packets++;
 
-        if (sTxPackets > 0)
+        if (sTxPackets > 1)
         {
+            sTxPackets--;
             TxPacket();
         }
+    }
+    else
+    {
+        TxPacket();
     }
 }
 
@@ -396,11 +396,11 @@ extern "C" void otPlatDiagAlarmFired(otInstance *aInstance)
     Diag::AlarmFired(aInstance);
 }
 
-extern "C" void otPlatDiagRadioTransmitDone(otInstance *aInstance, otRadioFrame *aFrame, bool aRxPending, otError aError)
+extern "C" void otPlatDiagRadioTransmitDone(otInstance *aInstance, otRadioFrame *aFrame, otError aError)
 {
     (void)aFrame;
 
-    Diag::DiagTransmitDone(aInstance, aRxPending, aError);
+    Diag::DiagTransmitDone(aInstance, aError);
 }
 
 extern "C" void otPlatDiagRadioReceiveDone(otInstance *aInstance, otRadioFrame *aFrame, otError aError)

--- a/src/diag/diag_process.hpp
+++ b/src/diag/diag_process.hpp
@@ -68,7 +68,7 @@ public:
     static char *ProcessCmd(int argc, char *argv[]);
     static bool isEnabled(void);
 
-    static void DiagTransmitDone(otInstance *aInstance, bool aRxPending, otError aError);
+    static void DiagTransmitDone(otInstance *aInstance, otError aError);
     static void DiagReceiveDone(otInstance *aInstance, otRadioFrame *aFrame, otError aError);
     static void AlarmFired(otInstance *aInstance);
 

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -383,7 +383,7 @@ exit:
     {
     }
 
-    void otPlatDiagRadioTransmitDone(otInstance *, otRadioFrame *, bool, otError)
+    void otPlatDiagRadioTransmitDone(otInstance *, otRadioFrame *, otError)
     {
     }
 


### PR DESCRIPTION
* Diag module should continue to send next packet even if the last transmission failed

* Remove unnecessary aFramePending parameter from diag transmit done callback