### PR TITLE
NcpBase: Fix insert handler for `MAC_WHITELIST` property

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -7036,7 +7036,7 @@ otError NcpBase::InsertPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop
     int8_t rssi = RSSI_OVERRIDE_DISABLED;
 
 
-    if (value_len > static_cast<spinel_ssize_t>(sizeof(ext_addr)))
+    if (value_len > static_cast<spinel_ssize_t>(sizeof(otExtAddress)))
     {
         parsedLength = spinel_datatype_unpack(
                            value_ptr,


### PR DESCRIPTION
Use `sizeof(otExtAddress)` directly when checking the length of value
portion of spinel frame (instead of using the `sizeof` variable which
is a pointer to an `otExtAddress`).