### PR TITLE
Separate Link Quality name from LQI

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -208,10 +208,10 @@ Print table of attached children.
 
 ```bash
 > child table
-| ID  | RLOC16 | Timeout    | Age        | LQI In | C_VN |R|S|D|N| Extended MAC     |
-+-----+--------+------------+------------+--------+------+-+-+-+-+------------------+
-|   1 | 0xe001 |        240 |         44 |      3 |  237 |1|1|1|1| d28d7f875888fccb |
-|   2 | 0xe002 |        240 |         27 |      3 |  237 |0|1|0|1| e2b3540590b0fd87 |
+| ID  | RLOC16 | Timeout    | Age        | LQ In | C_VN |R|S|D|N| Extended MAC     |
++-----+--------+------------+------------+-------+------+-+-+-+-+------------------+
+|   1 | 0xe001 |        240 |         44 |     3 |  237 |1|1|1|1| d28d7f875888fccb |
+|   2 | 0xe002 |        240 |         27 |     3 |  237 |0|1|0|1| e2b3540590b0fd87 |
 Done
 ```
 
@@ -228,7 +228,7 @@ Mode: rsn
 Net Data: 184
 Timeout: 100
 Age: 0
-LQI: 3
+Link Quality In: 3
 RSSI: -20
 Done
 ```
@@ -1237,6 +1237,9 @@ Get the diagnostic information for a Thread Router as parent.
 > parent
 Ext Addr: be1857c6c21dce55
 Rloc: 5c00
+Link Quality In: 3
+Link Quality Out: 3
+Age: 20
 Done
 ```
 
@@ -1385,10 +1388,10 @@ Print table of routers.
 
 ```bash
 > router table
-| ID | RLOC16 | Next Hop | Path Cost | LQI In | LQI Out | Age | Extended MAC     |
-+----+--------+----------+-----------+--------+---------+-----+------------------+
-| 21 | 0x5400 |       21 |         0 |      3 |       3 |   5 | d28d7f875888fccb |
-| 56 | 0xe000 |       56 |         0 |      0 |       0 | 182 | f2d92a82c8d8fe43 |
+| ID | RLOC16 | Next Hop | Path Cost | LQ In | LQ Out | Age | Extended MAC     |
++----+--------+----------+-----------+-------+--------+-----+------------------+
+| 21 | 0x5400 |       21 |         0 |     3 |      3 |   5 | d28d7f875888fccb |
+| 56 | 0xe000 |       56 |         0 |     0 |      0 | 182 | f2d92a82c8d8fe43 |
 Done
 ```
 
@@ -1405,8 +1408,8 @@ Next Hop: c800
 Link: 1
 Ext Addr: e2b3540590b0fd87
 Cost: 0
-LQI In: 3
-LQI Out: 3
+Link Quality In: 3
+Link Quality Out: 3
 Age: 3
 Done
 ```
@@ -1420,8 +1423,8 @@ Next Hop: c800
 Link: 1
 Ext Addr: e2b3540590b0fd87
 Cost: 0
-LQI In: 3
-LQI Out: 3
+Link Quality In: 3
+Link Quality Out: 3
 Age: 7
 Done
 ```

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -514,8 +514,8 @@ void Interpreter::ProcessChild(int argc, char *argv[])
     {
         if (isTable)
         {
-            mServer->OutputFormat("| ID  | RLOC16 | Timeout    | Age        | LQI In | C_VN |R|S|D|N| Extended MAC     |\r\n");
-            mServer->OutputFormat("+-----+--------+------------+------------+--------+------+-+-+-+-+------------------+\r\n");
+            mServer->OutputFormat("| ID  | RLOC16 | Timeout    | Age        | LQ In | C_VN |R|S|D|N| Extended MAC     |\r\n");
+            mServer->OutputFormat("+-----+--------+------------+------------+-------+------+-+-+-+-+------------------+\r\n");
         }
 
         maxChildren = otThreadGetMaxAllowedChildren(mInstance);
@@ -544,7 +544,7 @@ void Interpreter::ProcessChild(int argc, char *argv[])
                     mServer->OutputFormat("| 0x%04x ", childInfo.mRloc16);
                     mServer->OutputFormat("| %10d ", childInfo.mTimeout);
                     mServer->OutputFormat("| %10d ", childInfo.mAge);
-                    mServer->OutputFormat("| %6d ", childInfo.mLinkQualityIn);
+                    mServer->OutputFormat("| %5d ", childInfo.mLinkQualityIn);
                     mServer->OutputFormat("| %4d ", childInfo.mNetworkDataVersion);
                     mServer->OutputFormat("|%1d", childInfo.mRxOnWhenIdle);
                     mServer->OutputFormat("|%1d", childInfo.mSecureDataRequest);
@@ -609,7 +609,7 @@ void Interpreter::ProcessChild(int argc, char *argv[])
     mServer->OutputFormat("Net Data: %d\r\n", childInfo.mNetworkDataVersion);
     mServer->OutputFormat("Timeout: %d\r\n", childInfo.mTimeout);
     mServer->OutputFormat("Age: %d\r\n", childInfo.mAge);
-    mServer->OutputFormat("LQI: %d\r\n", childInfo.mLinkQualityIn);
+    mServer->OutputFormat("Link Quality In: %d\r\n", childInfo.mLinkQualityIn);
     mServer->OutputFormat("RSSI: %d\r\n", childInfo.mAverageRssi);
 
 exit:
@@ -2174,8 +2174,8 @@ void Interpreter::ProcessRouter(int argc, char *argv[])
     {
         if (isTable)
         {
-            mServer->OutputFormat("| ID | RLOC16 | Next Hop | Path Cost | LQI In | LQI Out | Age | Extended MAC     |\r\n");
-            mServer->OutputFormat("+----+--------+----------+-----------+--------+---------+-----+------------------+\r\n");
+            mServer->OutputFormat("| ID | RLOC16 | Next Hop | Path Cost | LQ In | LQ Out | Age | Extended MAC     |\r\n");
+            mServer->OutputFormat("+----+--------+----------+-----------+-------+--------+-----+------------------+\r\n");
         }
 
         for (uint8_t i = 0; ; i++)
@@ -2194,8 +2194,8 @@ void Interpreter::ProcessRouter(int argc, char *argv[])
                     mServer->OutputFormat("| 0x%04x ", routerInfo.mRloc16);
                     mServer->OutputFormat("| %8d ", routerInfo.mNextHop);
                     mServer->OutputFormat("| %9d ", routerInfo.mPathCost);
-                    mServer->OutputFormat("| %6d ", routerInfo.mLinkQualityIn);
-                    mServer->OutputFormat("| %7d ", routerInfo.mLinkQualityOut);
+                    mServer->OutputFormat("| %5d ", routerInfo.mLinkQualityIn);
+                    mServer->OutputFormat("| %6d ", routerInfo.mLinkQualityOut);
                     mServer->OutputFormat("| %3d ", routerInfo.mAge);
                     mServer->OutputFormat("| ");
 
@@ -2237,8 +2237,8 @@ void Interpreter::ProcessRouter(int argc, char *argv[])
 
             mServer->OutputFormat("\r\n");
             mServer->OutputFormat("Cost: %d\r\n", routerInfo.mPathCost);
-            mServer->OutputFormat("LQI In: %d\r\n", routerInfo.mLinkQualityIn);
-            mServer->OutputFormat("LQI Out: %d\r\n", routerInfo.mLinkQualityOut);
+            mServer->OutputFormat("Link Quality In: %d\r\n", routerInfo.mLinkQualityIn);
+            mServer->OutputFormat("Link Quality Out: %d\r\n", routerInfo.mLinkQualityOut);
             mServer->OutputFormat("Age: %d\r\n", routerInfo.mAge);
         }
     }

--- a/src/core/thread/mle_constants.hpp
+++ b/src/core/thread/mle_constants.hpp
@@ -107,19 +107,19 @@ enum
 
 enum
 {
-    kLqi3LinkCost               = 1,    ///< Link Cost for LQI 3
-    kLqi2LinkCost               = 2,    ///< Link Cost for LQI 2
-    kLqi1LinkCost               = 4,    ///< Link Cost for LQI 1
-    kLqi0LinkCost               = 16,   ///< Link Cost for LQI 0
+    kLinkQuality3LinkCost       = 1,    ///< Link Cost for Link Quality 3
+    kLinkQuality2LinkCost       = 2,    ///< Link Cost for Link Quality 2
+    kLinkQuality1LinkCost       = 4,    ///< Link Cost for Link Quality 1
+    kLinkQuality0LinkCost       = 16,   ///< Link Cost for Link Quality 0
 };
 
 // add for certification testing
 enum
 {
-    kMinAssignedLinkMargin3     = 0x15, ///< minimal link margin for LQI 3 (21 - 255)
-    kMinAssignedLinkMargin2     = 0x0b, ///< minimal link margin for LQI 2 (11 - 20)
-    kMinAssignedLinkMargin1     = 0x03, ///< minimal link margin for LQI 1 (3 - 9)
-    kMinAssignedLinkMargin0     = 0x00, ///< minimal link margin for LQI 0 (0 - 2)
+    kMinAssignedLinkMargin3     = 0x15, ///< minimal link margin for Link Quality 3 (21 - 255)
+    kMinAssignedLinkMargin2     = 0x0b, ///< minimal link margin for Link Quality 2 (11 - 20)
+    kMinAssignedLinkMargin1     = 0x03, ///< minimal link margin for Link Quality 1 (3 - 9)
+    kMinAssignedLinkMargin0     = 0x00, ///< minimal link margin for Link Quality 0 (0 - 2)
 };
 
 /**

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1088,21 +1088,21 @@ exit:
     return rval;
 }
 
-uint8_t MleRouter::LqiToCost(uint8_t aLqi)
+uint8_t MleRouter::LinkQualityToCost(uint8_t aLinkQuality)
 {
-    switch (aLqi)
+    switch (aLinkQuality)
     {
     case 1:
-        return kLqi1LinkCost;
+        return kLinkQuality1LinkCost;
 
     case 2:
-        return kLqi2LinkCost;
+        return kLinkQuality2LinkCost;
 
     case 3:
-        return kLqi3LinkCost;
+        return kLinkQuality3LinkCost;
 
     default:
-        return kLqi0LinkCost;
+        return kLinkQuality0LinkCost;
     }
 }
 
@@ -1129,7 +1129,7 @@ uint8_t MleRouter::GetLinkCost(uint8_t aRouterId)
         rval = mAssignLinkQuality;
     }
 
-    rval = LqiToCost(rval);
+    rval = LinkQualityToCost(rval);
 
 exit:
     return rval;
@@ -1515,7 +1515,7 @@ void MleRouter::UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId)
     uint8_t newCost;
     uint8_t oldNextHop;
     uint8_t cost;
-    uint8_t lqi;
+    uint8_t linkQuality;
     bool update;
 
     // update routes
@@ -1538,11 +1538,11 @@ void MleRouter::UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId)
 
             if (i == mRouterId)
             {
-                lqi = aRoute.GetLinkQualityIn(routeCount);
+                linkQuality = aRoute.GetLinkQualityIn(routeCount);
 
-                if (mRouters[aRouterId].GetLinkQualityOut() != lqi)
+                if (mRouters[aRouterId].GetLinkQualityOut() != linkQuality)
                 {
-                    mRouters[aRouterId].SetLinkQualityOut(lqi);
+                    mRouters[aRouterId].SetLinkQualityOut(linkQuality);
                     update = true;
                 }
             }
@@ -4226,7 +4226,7 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
 {
     ConnectivityTlv &tlv = aTlv;
     uint8_t cost;
-    uint8_t lqi;
+    uint8_t linkQuality;
     uint8_t numChildren = 0;
 
     for (int i = 0; i < mMaxChildrenAllowed; i++)
@@ -4276,7 +4276,7 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
             break;
         }
 
-        cost += LqiToCost(mParent.GetLinkInfo().GetLinkQuality(mNetif.GetMac().GetNoiseFloor()));
+        cost += LinkQualityToCost(mParent.GetLinkInfo().GetLinkQuality(mNetif.GetMac().GetNoiseFloor()));
         break;
 
     case OT_DEVICE_ROLE_ROUTER:
@@ -4308,14 +4308,14 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
             continue;
         }
 
-        lqi = mRouters[i].GetLinkInfo().GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
+        linkQuality = mRouters[i].GetLinkInfo().GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
 
-        if (lqi > mRouters[i].GetLinkQualityOut())
+        if (linkQuality > mRouters[i].GetLinkQualityOut())
         {
-            lqi = mRouters[i].GetLinkQualityOut();
+            linkQuality = mRouters[i].GetLinkQualityOut();
         }
 
-        switch (lqi)
+        switch (linkQuality)
         {
         case 1:
             tlv.SetLinkQuality1(tlv.GetLinkQuality1() + 1);
@@ -4506,8 +4506,8 @@ bool MleRouter::HasMinDowngradeNeighborRouters(void)
 bool MleRouter::HasOneNeighborwithComparableConnectivity(const RouteTlv &aRoute, uint8_t aRouterId)
 {
     bool rval = true;
-    uint8_t localLqi = 0;
-    uint8_t peerLqi = 0;
+    uint8_t localLinkQuality = 0;
+    uint8_t peerLinkQuality = 0;
     uint8_t routerCount = 0;
 
     // process local neighbor routers
@@ -4529,14 +4529,14 @@ bool MleRouter::HasOneNeighborwithComparableConnectivity(const RouteTlv &aRoute,
                 continue;
             }
 
-            localLqi = mRouters[i].GetLinkInfo().GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
+            localLinkQuality = mRouters[i].GetLinkInfo().GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
 
-            if (localLqi > mRouters[i].GetLinkQualityOut())
+            if (localLinkQuality > mRouters[i].GetLinkQualityOut())
             {
-                localLqi = mRouters[i].GetLinkQualityOut();
+                localLinkQuality = mRouters[i].GetLinkQualityOut();
             }
 
-            if (localLqi >= 2)
+            if (localLinkQuality >= 2)
             {
                 // check if this neighbor router is in peer Route64 TLV
                 if (aRoute.IsRouterIdSet(i) == false)
@@ -4544,16 +4544,16 @@ bool MleRouter::HasOneNeighborwithComparableConnectivity(const RouteTlv &aRoute,
                     ExitNow(rval = false);
                 }
 
-                // get the peer's two-way lqi to this router
-                peerLqi = aRoute.GetLinkQualityIn(routerCount);
+                // get the peer's two-way link quality to this router
+                peerLinkQuality = aRoute.GetLinkQualityIn(routerCount);
 
-                if (peerLqi > aRoute.GetLinkQualityOut(routerCount))
+                if (peerLinkQuality > aRoute.GetLinkQualityOut(routerCount))
                 {
-                    peerLqi = aRoute.GetLinkQualityOut(routerCount);
+                    peerLinkQuality = aRoute.GetLinkQualityOut(routerCount);
                 }
 
-                // compare local lqi to this router with peer's
-                if (peerLqi >= localLqi)
+                // compare local link quality to this router with peer's
+                if (peerLinkQuality >= localLinkQuality)
                 {
                     routerCount++;
                     continue;
@@ -4648,7 +4648,7 @@ exit:
 
 uint8_t MleRouter::GetMinDowngradeNeighborRouters(void)
 {
-    uint8_t lqi;
+    uint8_t linkQuality;
     uint8_t routerCount = 0;
 
     for (uint8_t i = 0; i <= kMaxRouterId; i++)
@@ -4658,14 +4658,14 @@ uint8_t MleRouter::GetMinDowngradeNeighborRouters(void)
             continue;
         }
 
-        lqi = mRouters[i].GetLinkInfo().GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
+        linkQuality = mRouters[i].GetLinkInfo().GetLinkQuality(mNetif.GetMac().GetNoiseFloor());
 
-        if (lqi > mRouters[i].GetLinkQualityOut())
+        if (linkQuality > mRouters[i].GetLinkQualityOut())
         {
-            lqi = mRouters[i].GetLinkQualityOut();
+            linkQuality = mRouters[i].GetLinkQualityOut();
         }
 
-        if (lqi >= 2)
+        if (linkQuality >= 2)
         {
             routerCount++;
         }

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -736,7 +736,7 @@ private:
                                      const otMessageInfo *aMessageInfo);
     void HandleAddressSolicit(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static uint8_t LqiToCost(uint8_t aLqi);
+    static uint8_t LinkQualityToCost(uint8_t aLinkQuality);
 
     Child *NewChild(void);
     Child *FindChild(uint16_t aChildId);


### PR DESCRIPTION
The Link Quality defined in Thread specification is different from the LQI defined in IEEE 802.15.4, separate their names to void confusing.