### PR TITLE
Don't return parent info if the device is not a child

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1531,6 +1531,9 @@ void Interpreter::ProcessParent(int argc, char *argv[])
     mServer->OutputFormat("\r\n");
 
     mServer->OutputFormat("Rloc: %x\r\n", parentInfo.mRloc16);
+    mServer->OutputFormat("Link Quality In: %d\r\n", parentInfo.mLinkQualityIn);
+    mServer->OutputFormat("Link Quality Out: %d\r\n", parentInfo.mLinkQualityOut);
+    mServer->OutputFormat("Age: %d\r\n", parentInfo.mAge);
 
 exit:
     (void)argc;

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -304,6 +304,9 @@ otError otThreadGetParentInfo(otInstance *aInstance, otRouterInfo *aParentInfo)
     otError error = OT_ERROR_NONE;
     Router *parent;
 
+    VerifyOrExit(aInstance->mThreadNetif.GetMle().GetRole() == OT_DEVICE_ROLE_CHILD,
+                 error = OT_ERROR_INVALID_STATE);
+
     VerifyOrExit(aParentInfo != NULL, error = OT_ERROR_INVALID_ARGS);
 
     parent = aInstance->mThreadNetif.GetMle().GetParent();


### PR DESCRIPTION
* Fix the issue that the previous parent information could be retrieved even after the device is not a child

* Print more parent information in CLI