### PR TITLE
NcpBase: Add support for Blacklist

### DIFF
--- a/doc/spinel-protocol-src/spinel-prop-mac.md
+++ b/doc/spinel-protocol-src/spinel-prop-mac.md
@@ -125,7 +125,7 @@ per scanned channel with following format:
 ### PROP 4864: PROP_MAC_WHITELIST  {#prop-mac-whitelist}
 * Type: Read-Write
 * Packed-Encoding: `A(T(Ec))`
-* **OPTIONAL**
+* Required capability: `CAP_MAC_WHITELIST`
 
 Structure Parameters:
 
@@ -139,6 +139,7 @@ Structure Parameters:
 ### PROP 4865: PROP_MAC_WHITELIST_ENABLED  {#prop-mac-whitelist-enabled}
 * Type: Read-Write
 * Packed-Encoding: `b`
+* Required capability: `CAP_MAC_WHITELIST`
 
 ### PROP 4867: SPINEL_PROP_MAC_SRC_MATCH_ENABLED  {#prop-mac-src-match-enabled}
 * Type: Write
@@ -170,4 +171,18 @@ is only available if the `SPINEL_CAP_MAC_RAW` capability is present.
 Structure Parameters:
 
 * `E`: EUI64 address for hardware generated ACKs
+
+### PROP 4870: PROP_MAC_BLACKLIST  {#prop-mac-blacklist}
+* Type: Read-Write
+* Packed-Encoding: `A(T(E))`
+* Required capability: `CAP_MAC_WHITELIST`
+
+Structure Parameters:
+
+* `E`: EUI64 address of node
+
+### PROP 4871: PROP_MAC_BLACKLIST_ENABLED  {#prop-mac-blacklist-enabled}
+* Type: Read-Write
+* Packed-Encoding: `b`
+* Required capability: `CAP_MAC_WHITELIST`
 

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -407,6 +407,8 @@ private:
 #if OPENTHREAD_ENABLE_MAC_WHITELIST
     otError GetPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key);
     otError GetPropertyHandler_MAC_WHITELIST_ENABLED(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_MAC_BLACKLIST(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_MAC_BLACKLIST_ENABLED(uint8_t header, spinel_prop_key_t key);
 #endif
     otError GetPropertyHandler_THREAD_MODE(uint8_t header, spinel_prop_key_t key);
     otError GetPropertyHandler_THREAD_CHILD_TIMEOUT(uint8_t header, spinel_prop_key_t key);
@@ -521,6 +523,10 @@ private:
                                              uint16_t value_len);
     otError SetPropertyHandler_MAC_WHITELIST_ENABLED(uint8_t header, spinel_prop_key_t key,
                                                      const uint8_t *value_ptr, uint16_t value_len);
+    otError SetPropertyHandler_MAC_BLACKLIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                             uint16_t value_len);
+    otError SetPropertyHandler_MAC_BLACKLIST_ENABLED(uint8_t header, spinel_prop_key_t key,
+                                                     const uint8_t *value_ptr, uint16_t value_len);
 #endif
 #if OPENTHREAD_ENABLE_RAW_LINK_API
     otError SetPropertyHandler_MAC_SRC_MATCH_ENABLED(uint8_t header, spinel_prop_key_t key,
@@ -626,6 +632,8 @@ private:
 #if OPENTHREAD_ENABLE_MAC_WHITELIST
     otError InsertPropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                 uint16_t value_len);
+    otError InsertPropertyHandler_MAC_BLACKLIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                uint16_t value_len);
 #endif
 #if OPENTHREAD_ENABLE_COMMISSIONER
     otError InsertPropertyHandler_THREAD_JOINERS(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
@@ -648,6 +656,8 @@ private:
                                                          const uint8_t *value_ptr, uint16_t value_len);
 #if OPENTHREAD_ENABLE_MAC_WHITELIST
     otError RemovePropertyHandler_MAC_WHITELIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+                                                uint16_t value_len);
+    otError RemovePropertyHandler_MAC_BLACKLIST(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                 uint16_t value_len);
 #endif
 #if OPENTHREAD_FTD

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1092,6 +1092,14 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_MAC_SRC_MATCH_EXTENDED_ADDRESSES";
         break;
 
+    case SPINEL_PROP_MAC_BLACKLIST:
+        ret = "PROP_MAC_BLACKLIST";
+        break;
+
+    case SPINEL_PROP_MAC_BLACKLIST_ENABLED:
+        ret = "PROP_MAC_BLACKLIST_ENABLED";
+        break;
+
     case SPINEL_PROP_NET_SAVED:
         ret = "PROP_NET_SAVED";
         break;

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -668,6 +668,20 @@ typedef enum
      */
     SPINEL_PROP_MAC_SRC_MATCH_EXTENDED_ADDRESSES
                                         = SPINEL_PROP_MAC_EXT__BEGIN + 5,
+
+    /// MAC Blacklist
+    /** Format: `A(t(E))`
+     *
+     * Structure Parameters:
+     *
+     * * `E`: EUI64 address of node
+     */
+    SPINEL_PROP_MAC_BLACKLIST           = SPINEL_PROP_MAC_EXT__BEGIN + 6,
+
+    /// MAC Blacklist Enabled Flag
+    /** Format: `b`
+     */
+    SPINEL_PROP_MAC_BLACKLIST_ENABLED   = SPINEL_PROP_MAC_EXT__BEGIN + 7,
     SPINEL_PROP_MAC_EXT__END            = 0x1400,
 
     SPINEL_PROP_NET__BEGIN              = 0x40,


### PR DESCRIPTION
This commit defines new spinel properties related to blacklist. It
also adds implementation of get/set/insert/remove handlers for the
new properties. The spinel draft documentation is also updated.