### PR TITLE
still return the parent info even if device is router

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -304,9 +304,6 @@ otError otThreadGetParentInfo(otInstance *aInstance, otRouterInfo *aParentInfo)
     otError error = OT_ERROR_NONE;
     Router *parent;
 
-    VerifyOrExit(aInstance->mThreadNetif.GetMle().GetRole() == OT_DEVICE_ROLE_CHILD,
-                 error = OT_ERROR_INVALID_STATE);
-
     VerifyOrExit(aParentInfo != NULL, error = OT_ERROR_INVALID_ARGS);
 
     parent = aInstance->mThreadNetif.GetMle().GetParent();


### PR DESCRIPTION
@chshu ,  are there any consideration for #1868? 
We may need some revert. Or else router 8.2.x would fail due to #1868 because TH needs the parent information of the joiner to know MAC address of the joiner router (DUT) even when the joiner becomes router.
