### PR TITLE
Keep python dependencies of thread-cert tests in requirements.txt

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -36,18 +36,17 @@ set -x
 
 cd /tmp || die
 
-[ $TRAVIS_OS_NAME != linux ] || {    
+[ $TRAVIS_OS_NAME != linux ] || {
     sudo apt-get update || die
 
-    pip install --upgrade pip || die
-
-    pip install --user pexpect || die
-
-    # Packages used by ncp tools.
-    pip install --user ipaddress || die
-    pip install --user scapy==2.3.2 || die
-    pip install --user pyserial || die
-    pip install --user git+https://github.com/openthread/pyspinel || die
+    [ $BUILD_TARGET != posix-distcheck -a $BUILD_TARGET != posix-32-bit -a $BUILD_TARGET != posix-ncp ] || {
+        pip install --upgrade pip || die
+        pip install --user -r $TRAVIS_BUILD_DIR/tests/scripts/thread-cert/requirements.txt || die
+        [ $BUILD_TARGET != posix-ncp ] || {
+            # Packages used by ncp tools.
+            pip install --user git+https://github.com/openthread/pyspinel || die
+        }
+    }
 
     [ $BUILD_TARGET != pretty-check ] || {
         wget http://jaist.dl.sourceforge.net/project/astyle/astyle/astyle%202.05.1/astyle_2.05.1_linux.tar.gz || die
@@ -98,10 +97,6 @@ cd /tmp || die
     [ $BUILD_TARGET != posix -o $CC != clang ] || {
         sudo apt-get install clang || die
     }
-
-    # Packages used by sniffer
-    pip install --user pycryptodome==3.4.3 || die
-    pip install --user enum34 || die
 }
 
 [ $TRAVIS_OS_NAME != osx ] || {

--- a/tests/scripts/thread-cert/requirements.txt
+++ b/tests/scripts/thread-cert/requirements.txt
@@ -1,0 +1,4 @@
+enum34==1.1.2
+ipaddress==1.0.16
+pexpect==4.0.1
+pycryptodome==3.4.3


### PR DESCRIPTION
1. keep dependency in requirements.txt.
2. remove unnecessary dependencies.
3. only install python dependencies when needed in Travis CI.

more details can be found [here](https://github.com/openthread/pyspinel/pull/11).