### PR TITLE
Adding `mNextHopIsDevice` to `otExternalRouteConfig`

### DIFF
--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -743,6 +743,15 @@ typedef struct otExternalRouteConfig
      * TRUE, if this configuration is considered Stable Network Data.  FALSE, otherwise.
      */
     bool mStable : 1;
+
+    /**
+     * TRUE if the external route entry's next hop is this device itself (i.e., the route was added earlier by this
+     * device). FALSE otherwise.
+     *
+     * This value is ignored when adding an external route. For any added route the next hop is this device.
+     */
+    bool mNextHopIsThisDevice : 1;
+
 } otExternalRouteConfig;
 
 /**

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -202,6 +202,7 @@ otError NetworkData::GetNextExternalRoute(otNetworkDataIterator *aIterator, uint
         aConfig->mPrefix.mLength = prefix->GetPrefixLength();
         aConfig->mPreference = hasRouteEntry->GetPreference();
         aConfig->mStable = cur->IsStable();
+        aConfig->mNextHopIsThisDevice = (hasRouteEntry->GetRloc() == mNetif.GetMle().GetRloc16());
 
         *aIterator = static_cast<otNetworkDataIterator>(reinterpret_cast<uint8_t *>(cur->GetNext()) - mTlvs);
 


### PR DESCRIPTION
This commit adds a new field in `otExternalRouteConfig` to indicate
if for the external route entry, the next hop is the device itself.