### PR TITLE
Change `enable-default-logging` build feature to a config option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -838,36 +838,6 @@ AM_CONDITIONAL([OPENTHREAD_ENABLE_CHILD_SUPERVISION], [test "${enable_child_supe
 AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_CHILD_SUPERVISION],[${OPENTHREAD_ENABLE_CHILD_SUPERVISION}],[Define to 1 if you want to use child supervision feature])
 
 #
-# Default Logging
-#
-
-AC_ARG_ENABLE(default_logging,
-    [AS_HELP_STRING([--enable-default-logging],[Enable default logging support @<:@default=no@:>@.])],
-    [
-        case "${enableval}" in
-
-        no|yes)
-            enable_default_logging=${enableval}
-            ;;
-
-        *)
-            AC_MSG_ERROR([Invalid value ${enable_default_logging} for --enable-default-logging])
-            ;;
-        esac
-    ],
-    [enable_default_logging=no])
-
-if test "$enable_default_logging" = "yes"; then
-    OPENTHREAD_ENABLE_DEFAULT_LOGGING=1
-else
-    OPENTHREAD_ENABLE_DEFAULT_LOGGING=0
-fi
-
-AC_SUBST(OPENTHREAD_ENABLE_DEFAULT_LOGGING)
-AM_CONDITIONAL([OPENTHREAD_ENABLE_DEFAULT_LOGGING], [test "${enable_default_logging}" = "yes"])
-AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_DEFAULT_LOGGING],[${OPENTHREAD_ENABLE_DEFAULT_LOGGING}],[Define to 1 if you want to enable default logging])
-
-#
 # Log for certification test
 #
 

--- a/examples/Makefile-cc2538
+++ b/examples/Makefile-cc2538
@@ -50,7 +50,6 @@ configure_OPTIONS               = \
     --with-platform-info=CC2538   \
     $(NULL)
 
-DEFAULT_LOGGING ?= 1
 include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..

--- a/examples/Makefile-da15000
+++ b/examples/Makefile-da15000
@@ -49,7 +49,6 @@ configure_OPTIONS               = \
     --with-platform-info=DA15000  \
     $(NULL)
 
-DEFAULT_LOGGING ?= 1
 include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..

--- a/examples/Makefile-efr32
+++ b/examples/Makefile-efr32
@@ -51,7 +51,6 @@ configure_OPTIONS               = \
     MBEDTLS_CPPFLAGS="$(EFR32_MBEDTLS_CPPFLAGS)" \
     $(NULL)
 
-DEFAULT_LOGGING ?= 1
 include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..

--- a/examples/Makefile-emsk
+++ b/examples/Makefile-emsk
@@ -45,7 +45,6 @@ configure_OPTIONS               = \
     --enable-cli-app=all          \
     --enable-ncp-app=all          \
     --with-ncp-bus=uart           \
-    --enable-default-logging      \
     --with-examples=emsk          \
     --with-platform-info=EMSK     \
     $(NULL)

--- a/examples/Makefile-kw41z
+++ b/examples/Makefile-kw41z
@@ -50,7 +50,6 @@ configure_OPTIONS               = \
     --with-platform-info=KW41Z    \
     $(NULL)
 
-DEFAULT_LOGGING ?= 1
 include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..

--- a/examples/Makefile-posix
+++ b/examples/Makefile-posix
@@ -41,9 +41,17 @@ RM_F                           := rm -f
 
 BuildJobs                      ?= 10
 
+TopSourceDir                   := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..
+AbsTopSourceDir                := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))..
+
+CONFIG_FILE      = OPENTHREAD_PROJECT_CORE_CONFIG_FILE='\"openthread-core-posix-config.h\"'
+CONFIG_FILE_PATH = $(AbsTopSourceDir)/examples/platforms/posix/
+
 COMMONCFLAGS                   := \
     -O1                           \
     -g                            \
+    -D$(CONFIG_FILE)              \
+    -I$(CONFIG_FILE_PATH)         \
     $(NULL)
 
 CPPFLAGS                       += \
@@ -86,7 +94,6 @@ configure_OPTIONS                   = \
     --enable-ncp-app=all              \
     --with-ncp-bus=uart               \
     --enable-diag                     \
-    --enable-default-logging          \
     --enable-raw-link-api=yes         \
     --with-examples=posix             \
     --with-platform-info=POSIX        \

--- a/examples/common-switches.mk
+++ b/examples/common-switches.mk
@@ -62,10 +62,6 @@ ifeq ($(DHCP6_SERVER),1)
 configure_OPTIONS              += --enable-dhcp6-server
 endif
 
-ifeq ($(DEFAULT_LOGGING),1)
-configure_OPTIONS              += --enable-default-logging
-endif
-
 ifeq ($(DISABLE_DOC),1)
 configure_OPTIONS              += --disable-docs
 endif

--- a/examples/platforms/da15000/openthread-core-da15000-config.h
+++ b/examples/platforms/da15000/openthread-core-da15000-config.h
@@ -36,6 +36,14 @@
 
 #define SETTINGS_CONFIG_BASE_ADDRESS 		(0x7B000)
 
+/**
+ * @def OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT
+ *
+ * Define to 1 to enable default log output.
+ *
+ */
+#define OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT             1
+
  /**
   * @def OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ACK_TIMEOUT
   *

--- a/examples/platforms/efr32/openthread-core-efr32-config.h
+++ b/examples/platforms/efr32/openthread-core-efr32-config.h
@@ -36,6 +36,14 @@
 #define OPENTHREAD_CORE_EFR32_CONFIG_H_
 
 /**
+ * @def OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT
+ *
+ * Define to 1 to enable default log output.
+ *
+ */
+#define OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT            1
+
+/*
  * @def OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT
  *
  * Define to 1 if you want to enable software retransmission logic.

--- a/examples/platforms/emsk/openthread-core-emsk-config.h
+++ b/examples/platforms/emsk/openthread-core-emsk-config.h
@@ -34,6 +34,14 @@
 #ifndef OPENTHREAD_CORE_EMSK_CONFIG_H_
 #define OPENTHREAD_CORE_EMSK_CONFIG_H_
 
+/**
+ * @def OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT
+ *
+ * Define to 1 to enable default log output.
+ *
+ */
+#define OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT             1
+
  /**
   * @def OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ACK_TIMEOUT
   *

--- a/examples/platforms/kw41z/openthread-core-kw41z-config.h
+++ b/examples/platforms/kw41z/openthread-core-kw41z-config.h
@@ -36,6 +36,14 @@
 #define OPENTHREAD_CORE_KW41Z_CONFIG_H_
 
 /**
+ * @def OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT
+ *
+ * Define to 1 to enable default log output.
+ *
+ */
+#define OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT             1
+
+/**
  * @def SETTINGS_CONFIG_BASE_ADDRESS
  *
  * The base address of settings.

--- a/examples/platforms/nrf52840/logging.c
+++ b/examples/platforms/nrf52840/logging.c
@@ -45,7 +45,7 @@
 #include <openthread-config.h>
 #include <openthread/types.h>
 
-#if (OPENTHREAD_ENABLE_DEFAULT_LOGGING == 0)
+#if (OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT == 0)
 #include <segger_rtt/SEGGER_RTT.h>
 
 #if (LOG_RTT_COLOR_ENABLE == 1)
@@ -174,4 +174,4 @@ exit:
     return;
 }
 
-#endif // (OPENTHREAD_ENABLE_DEFAULT_LOGGING == 0)
+#endif // (OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT == 0)

--- a/examples/platforms/nrf52840/platform.c
+++ b/examples/platforms/nrf52840/platform.c
@@ -54,14 +54,14 @@ void PlatformInit(int argc, char *argv[])
     nrf5MiscInit();
     nrf5CryptoInit();
     nrf5RadioInit();
-#if (OPENTHREAD_ENABLE_DEFAULT_LOGGING == 0)
+#if (OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT == 0)
     nrf5LogInit();
 #endif
 }
 
 void PlatformDeinit(void)
 {
-#if (OPENTHREAD_ENABLE_DEFAULT_LOGGING == 0)
+#if (OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT == 0)
     nrf5LogDeinit();
 #endif
     nrf5RadioDeinit();

--- a/examples/platforms/posix/openthread-core-posix-config.h
+++ b/examples/platforms/posix/openthread-core-posix-config.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2016, The OpenThread Authors.
+ *  Copyright (c) 2017, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -28,11 +28,12 @@
 
 /**
  * @file
- *   This file includes cc2538 compile-time configuration constants for OpenThread.
+ *   This file includes posix compile-time configuration constants
+ *   for OpenThread.
  */
 
-#ifndef OPENTHREAD_CORE_CC2538_CONFIG_H_
-#define OPENTHREAD_CORE_CC2538_CONFIG_H_
+#ifndef OPENTHREAD_CORE_POSIX_CONFIG_H_
+#define OPENTHREAD_CORE_POSIX_CONFIG_H_
 
 /**
  * @def OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT
@@ -40,30 +41,6 @@
  * Define to 1 to enable default log output.
  *
  */
-#define OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT            1
+#define OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT             1
 
- /**
-  * @def OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ACK_TIMEOUT
-  *
-  * Define to 1 if you want to enable software ACK timeout logic.
-  *
-  */
-#define OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ACK_TIMEOUT          1
-
- /**
-  * @def OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT
-  *
-  * Define to 1 if you want to enable software retransmission logic.
-  *
-  */
-#define OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT           1
-
- /**
-  * @def OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ENERGY_SCAN
-  *
-  * Define to 1 if you want to enable software energy scanning logic.
-  *
-  */
-#define OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ENERGY_SCAN          1
-
-#endif  // OPENTHREAD_CORE_CC2538_CONFIG_H_
+#endif  // OPENTHREAD_CORE_POSIX_CONFIG_H_

--- a/include/openthread-windows-config.h
+++ b/include/openthread-windows-config.h
@@ -32,8 +32,8 @@
 /* Define to 1 to enable the NCP SPI interface. */
 // On the command line: #define OPENTHREAD_ENABLE_NCP_SPI  1
 
-/* Define to 1 if you want to enable default logging */
-#define OPENTHREAD_ENABLE_DEFAULT_LOGGING 1
+/* Define to 1 if you want to enable default log output. */
+#define OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT 1
 
 /* Define to 1 to enable the commissioner role. */
 #define OPENTHREAD_ENABLE_COMMISSIONER 1

--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -238,7 +238,7 @@ void Uart::SendDoneTask(void)
     Send();
 }
 
-#if OPENTHREAD_ENABLE_DEFAULT_LOGGING
+#if OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -261,7 +261,7 @@ void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat
 #ifdef __cplusplus
 }  // extern "C"
 #endif
-#endif // OPENTHREAD_ENABLE_DEFAULT_LOGGING
+#endif // OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT
 
 }  // namespace Cli
 }  // namespace ot

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -600,6 +600,19 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT
+ *
+ * Define to 1 to enable default log output.
+ *
+ * When enabled OpenThread provides a default implementation for `otPlatLog()` which is tied to either NCP or CLI
+ * stream writes.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT
+#define OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT             0
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_NUM_DHCP_PREFIXES
  *
  * The number of dhcp prefixes.

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -273,7 +273,7 @@ void NcpUart::HandleError(otError aError, uint8_t *aBuf, uint16_t aBufLength)
     otNcpStreamWrite(0, reinterpret_cast<uint8_t *>(hexbuf + 1), static_cast<int>(strlen(hexbuf) - 1));
 }
 
-#if OPENTHREAD_ENABLE_DEFAULT_LOGGING
+#if OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This commit changes the `--enable-default-logging` option into a
OpenThread config option `OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOGGING`.
Makefiles and project core config header files for different platforms
are also updated accordingly.