### PR TITLE
Enable scan-build for all features

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -43,7 +43,27 @@ set -x
 
 [ $BUILD_TARGET != scan-build ] || {
     ./bootstrap || die
-    scan-build ./configure --with-examples=posix --enable-cli-app=all --enable-ncp-app=all --with-ncp-bus=uart || die
+    scan-build ./configure                \
+        --enable-cli-app=all              \
+        --enable-ncp-app=all              \
+        --with-ncp-bus=uart               \
+        --enable-diag                     \
+        --enable-default-logging          \
+        --enable-raw-link-api=yes         \
+        --with-examples=posix             \
+        --with-platform-info=POSIX        \
+        --enable-application-coap         \
+        --enable-border-agent-proxy       \
+        --enable-cert-log                 \
+        --enable-commissioner             \
+        --enable-dhcp6-client             \
+        --enable-dhcp6-server             \
+        --enable-dns-client               \
+        --enable-jam-detection            \
+        --enable-joiner                   \
+        --enable-legacy                   \
+        --enable-mac-whitelist            \
+        --enable-mtd-network-diagnostic || die
     scan-build --status-bugs -analyze-headers -v make || die
 }
 

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -1805,6 +1805,14 @@ class VendorStackVersionTlv: public Tlv
 {
 public:
     /**
+     * Default constructor.
+     *
+     */
+    VendorStackVersionTlv(void) :
+        mBuildRevision(0),
+        mMinorMajor(0) {}
+
+    /**
      * This method initializes the TLV.
      *
      */

--- a/third_party/mbedtls/Makefile.am
+++ b/third_party/mbedtls/Makefile.am
@@ -99,6 +99,7 @@ MBEDTLS_ABS_SRCDIR                           := $(abspath $(top_srcdir)/third_pa
 
 EXTRA_DIST                                                         += \
     patch/0001-Fix-commissioning-problem-with-retransmissions.patch   \
+    patch/0002-Fix-warning-dead-store.patch                           \
     $(NULL)
 
 repo/library/libmbedcrypto_a-ssl_tls.$(OBJEXT): $(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched
@@ -110,11 +111,22 @@ $(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched: $(MBEDTLS_ABS_SRCDIR)/patch/0001-Fi
 	patch $(MBEDTLS_ABS_SRCDIR)/repo/library/ssl_tls.c $<
 	cp $(MBEDTLS_ABS_SRCDIR)/patch/0001-Fix-commissioning-problem-with-retransmissions.patch $@
 
+repo/library/libmbedcrypto_a-ssl_srv.$(OBJEXT): $(MBEDTLS_SRCDIR)/library/ssl_srv.c.patched
+
+$(MBEDTLS_SRCDIR)/library/ssl_srv.c.patched: $(MBEDTLS_ABS_SRCDIR)/patch/0002-Fix-warning-dead-store.patch
+	chmod u+w $(MBEDTLS_ABS_SRCDIR)/repo/library/
+	chmod u+w $(MBEDTLS_ABS_SRCDIR)/repo/library/ssl_srv.c
+	if [ -e $@ ]; then patch -R $(MBEDTLS_ABS_SRCDIR)/repo/library/ssl_srv.c $@; fi
+	patch $(MBEDTLS_ABS_SRCDIR)/repo/library/ssl_srv.c $<
+	cp $(MBEDTLS_ABS_SRCDIR)/patch/0002-Fix-warning-dead-store.patch $@
+
 all-local: libmbedcrypto.a
 	if [ -e $(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched ]; then patch -R $(MBEDTLS_ABS_SRCDIR)/repo/library/ssl_tls.c $(MBEDTLS_ABS_SRCDIR)/patch/0001-Fix-commissioning-problem-with-retransmissions.patch; rm -f $(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched; fi
+	if [ -e $(MBEDTLS_SRCDIR)/library/ssl_srv.c.patched ]; then patch -R $(MBEDTLS_ABS_SRCDIR)/repo/library/ssl_srv.c $(MBEDTLS_ABS_SRCDIR)/patch/0002-Fix-warning-dead-store.patch; rm -f $(MBEDTLS_SRCDIR)/library/ssl_srv.c.patched; fi
 
 clean-local:
 	if [ -e $(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched ]; then patch -R $(MBEDTLS_ABS_SRCDIR)/repo/library/ssl_tls.c $(MBEDTLS_ABS_SRCDIR)/patch/0001-Fix-commissioning-problem-with-retransmissions.patch; rm -f $(MBEDTLS_SRCDIR)/library/ssl_tls.c.patched; fi
+	if [ -e $(MBEDTLS_SRCDIR)/library/ssl_srv.c.patched ]; then patch -R $(MBEDTLS_ABS_SRCDIR)/repo/library/ssl_srv.c $(MBEDTLS_ABS_SRCDIR)/patch/0002-Fix-warning-dead-store.patch; rm -f $(MBEDTLS_SRCDIR)/library/ssl_srv.c.patched; fi
 
 endif  # OPENTHREAD_ENABLE_DTLS
 

--- a/third_party/mbedtls/patch/0002-Fix-warning-dead-store.patch
+++ b/third_party/mbedtls/patch/0002-Fix-warning-dead-store.patch
@@ -1,0 +1,14 @@
+diff --git a/third_party/mbedtls/repo/library/ssl_srv.c b/third_party/mbedtls/repo/library/ssl_srv.c
+index fc0d2d7b..fad54dd8 100644
+--- a/third_party/mbedtls/repo/library/ssl_srv.c
++++ b/third_party/mbedtls/repo/library/ssl_srv.c
+@@ -3017,6 +3017,9 @@ curve_matching_done:
+           MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED ||
+           MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED */
+ 
++    // mask dead store of p
++    (void)p;
++
+     ssl->out_msglen  = 4 + n;
+     ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
+     ssl->out_msg[0]  = MBEDTLS_SSL_HS_SERVER_KEY_EXCHANGE;


### PR DESCRIPTION
This PR aims at enabling scan-build for all features's code.

1. Enabled all features when build target of scan-build.
2. Fixed currently found warnings.