### PR TITLE
Implement reset on POSIX

### DIFF
--- a/examples/platforms/posix/misc.c
+++ b/examples/platforms/posix/misc.c
@@ -28,12 +28,31 @@
 
 #include "platform-posix.h"
 
+#include <unistd.h>
+
 #include <openthread/types.h>
 #include <openthread/platform/misc.h>
 
+extern int      gArgumentsCount;
+extern char   **gArguments;
+
 void otPlatReset(otInstance *aInstance)
 {
-    // This function does nothing on the Posix platform.
+    char *argv[gArgumentsCount + 1];
+
+    for (int i = 0; i < gArgumentsCount; ++i)
+    {
+        argv[i] = gArguments[i];
+    }
+
+    argv[gArgumentsCount] = NULL;
+
+    platformUartRestore();
+
+    execvp(argv[0], argv);
+    perror("reset failed");
+    exit(EXIT_FAILURE);
+
     (void)aInstance;
 }
 

--- a/examples/platforms/posix/platform-posix.h
+++ b/examples/platforms/posix/platform-posix.h
@@ -163,4 +163,10 @@ void platformUartUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, fd_set *aE
  */
 void platformUartProcess(void);
 
+/**
+ * This function restores the Uart.
+ *
+ */
+void platformUartRestore(void);
+
 #endif  // PLATFORM_POSIX_H_

--- a/examples/platforms/posix/platform.c
+++ b/examples/platforms/posix/platform.c
@@ -53,6 +53,9 @@
 uint32_t NODE_ID = 1;
 uint32_t WELLKNOWN_NODE_ID = 34;
 
+int     gArgumentsCount = 0;
+char  **gArguments = NULL;
+
 void PlatformInit(int argc, char *argv[])
 {
     char *endptr;
@@ -74,6 +77,9 @@ void PlatformInit(int argc, char *argv[])
         fprintf(stderr, "Invalid NODE_ID: %s\n", argv[1]);
         exit(EXIT_FAILURE);
     }
+
+    gArgumentsCount = argc;
+    gArguments = argv;
 
     platformAlarmInit();
     platformRadioInit();

--- a/examples/platforms/posix/uart-posix.c
+++ b/examples/platforms/posix/uart-posix.c
@@ -69,6 +69,12 @@ static void restore_stdout_termios(void)
     tcsetattr(s_out_fd, TCSAFLUSH, &original_stdout_termios);
 }
 
+void platformUartRestore(void)
+{
+    restore_stdin_termios();
+    restore_stdout_termios();
+}
+
 otError otPlatUartEnable(void)
 {
     otError error = OT_ERROR_NONE;


### PR DESCRIPTION
Sometimes we need simulate *reset* operation on device to verify behavior after device reset. However, this is not implemented on POSIX currently. 

This PR implements `reset` on POSIX by `execvp()` the process.