### PR TITLE
Implement reset on POSIX

### DIFF
--- a/examples/platforms/posix/misc.c
+++ b/examples/platforms/posix/misc.c
@@ -28,12 +28,38 @@
 
 #include "platform-posix.h"
 
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
 #include <openthread/types.h>
 #include <openthread/platform/misc.h>
 
+#ifndef _WIN32
+extern int      gArgumentsCount;
+extern char   **gArguments;
+#endif
+
 void otPlatReset(otInstance *aInstance)
 {
-    // This function does nothing on the Posix platform.
+#ifndef _WIN32
+    char *argv[gArgumentsCount + 1];
+
+    for (int i = 0; i < gArgumentsCount; ++i)
+    {
+        argv[i] = gArguments[i];
+    }
+
+    argv[gArgumentsCount] = NULL;
+
+    platformUartRestore();
+
+    execvp(argv[0], argv);
+    perror("reset failed");
+    exit(EXIT_FAILURE);
+#else
+    // This function does nothing on the Windows platform.
+#endif // _WIN32
     (void)aInstance;
 }
 

--- a/examples/platforms/posix/platform-posix.h
+++ b/examples/platforms/posix/platform-posix.h
@@ -163,4 +163,10 @@ void platformUartUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, fd_set *aE
  */
 void platformUartProcess(void);
 
+/**
+ * This function restores the Uart.
+ *
+ */
+void platformUartRestore(void);
+
 #endif  // PLATFORM_POSIX_H_

--- a/examples/platforms/posix/platform.c
+++ b/examples/platforms/posix/platform.c
@@ -53,6 +53,11 @@
 uint32_t NODE_ID = 1;
 uint32_t WELLKNOWN_NODE_ID = 34;
 
+#ifndef _WIN32
+int     gArgumentsCount = 0;
+char  **gArguments = NULL;
+#endif
+
 void PlatformInit(int argc, char *argv[])
 {
     char *endptr;
@@ -65,6 +70,9 @@ void PlatformInit(int argc, char *argv[])
 #ifndef _WIN32
     openlog(basename(argv[0]), LOG_PID, LOG_USER);
     setlogmask(setlogmask(0) & LOG_UPTO(LOG_NOTICE));
+
+    gArgumentsCount = argc;
+    gArguments = argv;
 #endif
 
     NODE_ID = (uint32_t)strtol(argv[1], &endptr, 0);

--- a/examples/platforms/posix/uart-posix.c
+++ b/examples/platforms/posix/uart-posix.c
@@ -69,6 +69,12 @@ static void restore_stdout_termios(void)
     tcsetattr(s_out_fd, TCSAFLUSH, &original_stdout_termios);
 }
 
+void platformUartRestore(void)
+{
+    restore_stdin_termios();
+    restore_stdout_termios();
+}
+
 otError otPlatUartEnable(void)
 {
     otError error = OT_ERROR_NONE;


### PR DESCRIPTION
Sometimes we need simulate reset operation of device to verify behavior after device reset. However, this is not implemented on POSIX currently.

This PR implements reset on POSIX by execvp() the process.