### PR TITLE
Rename border agent proxy to TMF proxy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -537,36 +537,36 @@ AC_MSG_RESULT(${enable_builtin_mbedtls})
 AM_CONDITIONAL([OPENTHREAD_ENABLE_BUILTIN_MBEDTLS], [test "${enable_builtin_mbedtls}" = "yes"])
 
 #
-# Thread Border Agent Proxy
+# Thread TMF Proxy
 #
 
-AC_MSG_CHECKING([whether to enable border router proxy])
-AC_ARG_ENABLE(border_agent_proxy,
-    [AS_HELP_STRING([--enable-border-agent-proxy],[Enable border agent proxy support @<:@default=no@:>@.])],
+AC_MSG_CHECKING([whether to enable TMF proxy])
+AC_ARG_ENABLE(tmf_proxy,
+    [AS_HELP_STRING([--enable-tmf-proxy],[Enable TMF proxy support @<:@default=no@:>@.])],
     [
         case "${enableval}" in
 
         no|yes)
-            enable_border_agent_proxy=${enableval}
+            enable_tmf_proxy=${enableval}
             ;;
 
         *)
-            AC_MSG_ERROR([Invalid value ${enable_border_agent_proxy} for --enable-border-agent-proxy])
+            AC_MSG_ERROR([Invalid value ${enable_tmf_proxy} for --enable-tmf-proxy])
             ;;
         esac
     ],
-    [enable_border_agent_proxy=no])
+    [enable_tmf_proxy=no])
 
-if test "$enable_border_agent_proxy" = "yes"; then
-    OPENTHREAD_ENABLE_BORDER_AGENT_PROXY=1
+if test "$enable_tmf_proxy" = "yes"; then
+    OPENTHREAD_ENABLE_TMF_PROXY=1
 else
-    OPENTHREAD_ENABLE_BORDER_AGENT_PROXY=0
+    OPENTHREAD_ENABLE_TMF_PROXY=0
 fi
 
-AC_MSG_RESULT(${enable_border_agent_proxy})
-AC_SUBST(OPENTHREAD_ENABLE_BORDER_AGENT_PROXY)
-AM_CONDITIONAL([OPENTHREAD_ENABLE_BORDER_AGENT_PROXY], [test "${enable_border_agent_proxy}" = "yes"])
-AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_BORDER_AGENT_PROXY],[${OPENTHREAD_ENABLE_BORDER_AGENT_PROXY}],[Define to 1 to enable the border agent proxy feature.])
+AC_MSG_RESULT(${enable_tmf_proxy})
+AC_SUBST(OPENTHREAD_ENABLE_TMF_PROXY)
+AM_CONDITIONAL([OPENTHREAD_ENABLE_TMF_PROXY], [test "${enable_tmf_proxy}" = "yes"])
+AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_TMF_PROXY],[${OPENTHREAD_ENABLE_TMF_PROXY}],[Define to 1 to enable the TMF proxy feature.])
 
 #
 # Thread Network Diagnostic for MTD
@@ -1384,7 +1384,7 @@ AC_MSG_NOTICE([
   OpenThread NCP-BUS Configuration          : ${with_ncp_bus}
   OpenThread MTD Network Diagnostic support : ${enable_mtd_network_diagnostic}
   OpenThread builtin mbedtls support        : ${enable_builtin_mbedtls}
-  OpenThread Border Agent Proxy support     : ${enable_border_agent_proxy}
+  OpenThread TMF Proxy support              : ${enable_tmf_proxy}
   OpenThread Commissioner support           : ${enable_commissioner}
   OpenThread Joiner support                 : ${enable_joiner}
   OpenThread DTLS support                   : ${enable_dtls}

--- a/doc/draft-rquattle-spinel-unified.html
+++ b/doc/draft-rquattle-spinel-unified.html
@@ -510,8 +510,8 @@
 <link href="#rfc.section.7.2.30" rel="Chapter" title="7.2.30 PROP 5390: PROP_THREAD_STABLE_LEADER_NETWORK_DATA"/>
 <link href="#rfc.section.7.2.31" rel="Chapter" title="7.2.31 PROP 5391: PROP_THREAD_JOINERS"/>
 <link href="#rfc.section.7.2.32" rel="Chapter" title="7.2.32 PROP 5392: PROP_THREAD_COMMISSIONER_ENABLED"/>
-<link href="#rfc.section.7.2.33" rel="Chapter" title="7.2.33 PROP 5393: PROP_THREAD_BA_PROXY_ENABLED"/>
-<link href="#rfc.section.7.2.34" rel="Chapter" title="7.2.34 PROP 5394: PROP_THREAD_BA_PROXY_STREAM"/>
+<link href="#rfc.section.7.2.33" rel="Chapter" title="7.2.33 PROP 5393: PROP_THREAD_TMF_PROXY_ENABLED"/>
+<link href="#rfc.section.7.2.34" rel="Chapter" title="7.2.34 PROP 5394: PROP_THREAD_TMF_PROXY_STREAM"/>
 <link href="#rfc.section.8" rel="Chapter" title="8 Feature: Network Save"/>
 <link href="#rfc.section.8.1" rel="Chapter" title="8.1 Commands"/>
 <link href="#rfc.section.8.1.1" rel="Chapter" title="8.1.1 CMD 9: (Host-&gt;NCP) CMD_NET_SAVE"/>
@@ -784,8 +784,8 @@
 <li>7.2.30.   <a href="#rfc.section.7.2.30">PROP 5390: PROP_THREAD_STABLE_LEADER_NETWORK_DATA</a></li>
 <li>7.2.31.   <a href="#rfc.section.7.2.31">PROP 5391: PROP_THREAD_JOINERS</a></li>
 <li>7.2.32.   <a href="#rfc.section.7.2.32">PROP 5392: PROP_THREAD_COMMISSIONER_ENABLED</a></li>
-<li>7.2.33.   <a href="#rfc.section.7.2.33">PROP 5393: PROP_THREAD_BA_PROXY_ENABLED</a></li>
-<li>7.2.34.   <a href="#rfc.section.7.2.34">PROP 5394: PROP_THREAD_BA_PROXY_STREAM</a></li>
+<li>7.2.33.   <a href="#rfc.section.7.2.33">PROP 5393: PROP_THREAD_TMF_PROXY_ENABLED</a></li>
+<li>7.2.34.   <a href="#rfc.section.7.2.34">PROP 5394: PROP_THREAD_TMF_PROXY_STREAM</a></li>
 </ul></ul><li>8.   <a href="#rfc.section.8">Feature: Network Save</a></li>
 <ul><li>8.1.   <a href="#rfc.section.8.1">Commands</a></li>
 <ul><li>8.1.1.   <a href="#rfc.section.8.1.1">CMD 9: (Host-&gt;NCP) CMD_NET_SAVE</a></li>
@@ -2013,7 +2013,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
   <li>52: <samp>CAP_NET_THREAD_1_0</samp></li>
   <li>512: <samp>CAP_MAC_WHITELIST</samp></li>
   <li>1024: <samp>CAP_THREAD_COMMISSIONER</samp></li>
-  <li>1025: <samp>CAP_THREAD_BA_PROXY</samp></li>
+  <li>1025: <samp>CAP_THREAD_TMF_PROXY</samp></li>
 </ul>
 
 <p> </p>
@@ -3362,24 +3362,24 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
 
 <p> </p>
 <p id="rfc.section.7.2.32.p.2">Set to true to enable the native commissioner. It is mandatory before adding the joiner to the network.  </p>
-<h1 id="rfc.section.7.2.33"><a href="#rfc.section.7.2.33">7.2.33.</a> <a href="#prop-thread-ba-proxy-enabled" id="prop-thread-ba-proxy-enabled">PROP 5393: PROP_THREAD_BA_PROXY_ENABLED</a></h1>
+<h1 id="rfc.section.7.2.33"><a href="#rfc.section.7.2.33">7.2.33.</a> <a href="#prop-thread-tmf-proxy-enabled" id="prop-thread-tmf-proxy-enabled">PROP 5393: PROP_THREAD_TMF_PROXY_ENABLED</a></h1>
 <p/>
 
 <ul>
   <li>Type: Read-Write</li>
   <li>Packed-Encoding: <samp>b</samp></li>
-  <li>Required capability: <samp>CAP_THREAD_BA_PROXY</samp></li>
+  <li>Required capability: <samp>CAP_THREAD_TMF_PROXY</samp></li>
 </ul>
 
 <p> </p>
-<p id="rfc.section.7.2.33.p.2">Set to true to enable the border agent proxy.  </p>
-<h1 id="rfc.section.7.2.34"><a href="#rfc.section.7.2.34">7.2.34.</a> <a href="#prop-thread-ba-proxy-stream" id="prop-thread-ba-proxy-stream">PROP 5394: PROP_THREAD_BA_PROXY_STREAM</a></h1>
+<p id="rfc.section.7.2.33.p.2">Set to true to enable the TMF proxy.  </p>
+<h1 id="rfc.section.7.2.34"><a href="#rfc.section.7.2.34">7.2.34.</a> <a href="#prop-thread-tmf-proxy-stream" id="prop-thread-tmf-proxy-stream">PROP 5394: PROP_THREAD_TMF_PROXY_STREAM</a></h1>
 <p/>
 
 <ul>
   <li>Type: Read-Write-Stream</li>
   <li>Packed-Encoding: <samp>dSS</samp></li>
-  <li>Required capability: <samp>CAP_THREAD_BA_PROXY</samp></li>
+  <li>Required capability: <samp>CAP_THREAD_TMF_PROXY</samp></li>
 </ul>
 
 <p> </p>
@@ -3413,7 +3413,7 @@ STACK-NAME/STACK-VERSION[BUILD_INFO][; OTHER_INFO]; BUILD_DATE_AND_TIME
     </tr>
   </tbody>
 </table>
-<p id="rfc.section.7.2.34.p.4">This property allows the host to send and receive border-agent-related CoAP requests/responses from the NCP's RLOC address. This allows the host driver to implement a Thread border agent.  </p>
+<p id="rfc.section.7.2.34.p.4">This property allows the host to send and receive TMF messages from the NCP's RLOC address and support Thread-specific border router functions.  </p>
 <h1 id="rfc.section.8"><a href="#rfc.section.8">8.</a> <a href="#feature-network-save" id="feature-network-save">Feature: Network Save</a></h1>
 <p id="rfc.section.8.p.1">The network save/recall feature is an optional NCP capability that, when present, allows the host to save and recall network credentials and state to and from nonvolatile storage.  </p>
 <p id="rfc.section.8.p.2">The presence of the save/recall feature can be detected by checking for the presence of the <samp>CAP_NET_SAVE</samp> capability in <samp>PROP_CAPS</samp>.  </p>

--- a/doc/draft-rquattle-spinel-unified.txt
+++ b/doc/draft-rquattle-spinel-unified.txt
@@ -213,8 +213,8 @@ Quattlebaum & woodyatt  Expires November 2, 2017                [Page 3]
        7.2.30. PROP 5390: PROP_THREAD_STABLE_LEADER_NETWORK_DATA . .  51
        7.2.31. PROP 5391: PROP_THREAD_JOINERS  . . . . . . . . . . .  51
        7.2.32. PROP 5392: PROP_THREAD_COMMISSIONER_ENABLED . . . . .  51
-       7.2.33. PROP 5393: PROP_THREAD_BA_PROXY_ENABLED . . . . . . .  51
-       7.2.34. PROP 5394: PROP_THREAD_BA_PROXY_STREAM  . . . . . . .  52
+       7.2.33. PROP 5393: PROP_THREAD_TMF_PROXY_ENABLED  . . . . . .  51
+       7.2.34. PROP 5394: PROP_THREAD_TMF_PROXY_STREAM . . . . . . .  52
    8.  Feature: Network Save . . . . . . . . . . . . . . . . . . . .  52
      8.1.  Commands  . . . . . . . . . . . . . . . . . . . . . . . .  52
        8.1.1.  CMD 9: (Host->NCP) CMD_NET_SAVE . . . . . . . . . . .  52
@@ -1591,7 +1591,7 @@ Quattlebaum & woodyatt  Expires November 2, 2017               [Page 28]
    o  52: "CAP_NET_THREAD_1_0"
    o  512: "CAP_MAC_WHITELIST"
    o  1024: "CAP_THREAD_COMMISSIONER"
-   o  1025: "CAP_THREAD_BA_PROXY"
+   o  1025: "CAP_THREAD_TMF_PROXY"
 
    Additionally, future capability allocations SHALL be made from the
    following allocation plan:
@@ -2845,11 +2845,11 @@ Quattlebaum & woodyatt  Expires November 2, 2017               [Page 50]
    Set to true to enable the native commissioner.  It is mandatory
    before adding the joiner to the network.
 
-7.2.33.  PROP 5393: PROP_THREAD_BA_PROXY_ENABLED
+7.2.33.  PROP 5393: PROP_THREAD_TMF_PROXY_ENABLED
 
    o  Type: Read-Write
    o  Packed-Encoding: "b"
-   o  Required capability: "CAP_THREAD_BA_PROXY"
+   o  Required capability: "CAP_THREAD_TMF_PROXY"
 
 
 
@@ -2858,13 +2858,13 @@ Quattlebaum & woodyatt  Expires November 2, 2017               [Page 51]
                     Spinel Protocol (86157e99-dirty)            May 2017
 
 
-   Set to true to enable the border agent proxy.
+   Set to true to enable the TMF proxy.
 
-7.2.34.  PROP 5394: PROP_THREAD_BA_PROXY_STREAM
+7.2.34.  PROP 5394: PROP_THREAD_TMF_PROXY_STREAM
 
    o  Type: Read-Write-Stream
    o  Packed-Encoding: "dSS"
-   o  Required capability: "CAP_THREAD_BA_PROXY"
+   o  Required capability: "CAP_THREAD_TMF_PROXY"
 
    Data per item is:
 
@@ -2878,9 +2878,9 @@ Quattlebaum & woodyatt  Expires November 2, 2017               [Page 51]
                | Fields:  | Length | CoAP | locator | port |
                +----------+--------+------+---------+------+
 
-   This property allows the host to send and receive border-agent-
-   related CoAP requests/responses from the NCP's RLOC address.  This
-   allows the host driver to implement a Thread border agent.
+   This property allows the host to send and receive TMF messages
+   from the NCP's RLOC address and support Thread-specific border
+   router functions.
 
 8.  Feature: Network Save
 

--- a/doc/spinel-protocol-src/spinel-prop-core.md
+++ b/doc/spinel-protocol-src/spinel-prop-core.md
@@ -159,7 +159,7 @@ Currently defined values are:
  * 513: `CAP_MAC_RAW`
  * 514: `CAP_OOB_STEERING_DATA`
  * 1024: `CAP_THREAD_COMMISSIONER`
- * 1025: `CAP_THREAD_BA_PROXY`
+ * 1025: `CAP_THREAD_TMF_PROXY`
 
 
 Additionally, future capability allocations SHALL be made from the

--- a/doc/spinel-protocol-src/spinel-tech-thread.md
+++ b/doc/spinel-protocol-src/spinel-tech-thread.md
@@ -262,19 +262,19 @@ are allowed to join the Thread(R) Network.
 
 Set to true to enable the native commissioner. It is mandatory before adding the joiner to the network.
 
-### PROP 5393: PROP_THREAD_BA_PROXY_ENABLED {#prop-thread-ba-proxy-enabled}
+### PROP 5393: PROP_THREAD_TMF_PROXY_ENABLED {#prop-thread-tmf-proxy-enabled}
 
 * Type: Read-Write
 * Packed-Encoding: `b`
-* Required capability: `CAP_THREAD_BA_PROXY`
+* Required capability: `CAP_THREAD_TMF_PROXY`
 
-Set to true to enable the border agent proxy.
+Set to true to enable the TMF proxy.
 
-### PROP 5394: PROP_THREAD_BA_PROXY_STREAM {#prop-thread-ba-proxy-stream}
+### PROP 5394: PROP_THREAD_TMF_PROXY_STREAM {#prop-thread-tmf-proxy-stream}
 
 * Type: Read-Write-Stream
 * Packed-Encoding: `dSS`
-* Required capability: `CAP_THREAD_BA_PROXY`
+* Required capability: `CAP_THREAD_TMF_PROXY`
 
 Data per item is:
 
@@ -286,9 +286,8 @@ Octects: | 2      | *n*  |    2    |  2
 ---------|--------|------|---------|-------
 Fields:  | Length | CoAP | locator | port
 
-This property allows the host to send and receive border-agent-related
-CoAP requests/responses from the NCP's RLOC address. This allows the
-host driver to implement a Thread(R) border agent.
+This property allows the host to send and receive TMF messages from
+the NCP's RLOC address and support Thread-specific border router functions.
 
 
 ### PROP 5395: PROP_THREAD_DISOVERY_SCAN_JOINER_FLAG {#prop-thread-discovery-scan-joiner-flag}

--- a/examples/Makefile-posix
+++ b/examples/Makefile-posix
@@ -98,7 +98,7 @@ configure_OPTIONS                   = \
     --with-examples=posix             \
     --with-platform-info=POSIX        \
     --enable-application-coap         \
-    --enable-border-agent-proxy       \
+    --enable-tmf-proxy                \
     --enable-cert-log                 \
     --enable-commissioner             \
     --enable-dhcp6-client             \

--- a/examples/common-switches.mk
+++ b/examples/common-switches.mk
@@ -26,8 +26,8 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-ifeq ($(BA_PROXY),1)
-configure_OPTIONS              += --enable-border-agent-proxy
+ifeq ($(TMF_PROXY),1)
+configure_OPTIONS              += --enable-tmf-proxy
 endif
 
 ifeq ($(BORDER_ROUTER),1)

--- a/include/openthread-windows-config.h
+++ b/include/openthread-windows-config.h
@@ -62,8 +62,8 @@
 /* Define to 1 to enable MAC whitelist/blacklist feature. */
 #define OPENTHREAD_ENABLE_MAC_WHITELIST 1
 
-/* Define to 1 to enable border agent proxy feature. */
-#define OPENTHREAD_ENABLE_BORDER_AGENT_PROXY 0
+/* Define to 1 to enable TMF proxy feature. */
+#define OPENTHREAD_ENABLE_TMF_PROXY 0
 
 /* Define to 1 to enable raw link-layer API. */
 #ifdef _KERNEL_MODE

--- a/include/openthread/Makefile.am
+++ b/include/openthread/Makefile.am
@@ -49,7 +49,6 @@ PRETTY_SUBDIRS                          = \
 openthread_headers                      = \
     child_supervision.h                   \
     cli.h                                 \
-    border_agent_proxy.h                  \
     coap.h                                \
     commissioner.h                        \
     crypto.h                              \
@@ -74,6 +73,7 @@ openthread_headers                      = \
     tasklet.h                             \
     thread.h                              \
     thread_ftd.h                          \
+    tmf_proxy.h                           \
     types.h                               \
     udp.h                                 \
     $(NULL)

--- a/include/openthread/openthread.h
+++ b/include/openthread/openthread.h
@@ -93,7 +93,7 @@ extern "C" {
  *
  * @{
  *
- * @defgroup api-border-agent   Border Agent
+ * @defgroup api-tmf-proxy      TMF Proxy
  * @defgroup api-commissioner   Commissioner
  * @defgroup api-thread-general General
  * @brief This module includes functions for all Thread roles.

--- a/include/openthread/tmf_proxy.h
+++ b/include/openthread/tmf_proxy.h
@@ -29,11 +29,11 @@
 /**
  * @file
  * @brief
- *   This file includes the OpenThread API for Border Agent Proxy feature.
+ *   This file includes the OpenThread API for TMF Proxy feature.
  */
 
-#ifndef OPENTHREAD_BORDER_AGENT_PROXY_H_
-#define OPENTHREAD_BORDER_AGENT_PROXY_H_
+#ifndef OPENTHREAD_TMF_PROXY_H_
+#define OPENTHREAD_TMF_PROXY_H_
 
 #ifdef OPENTHREAD_CONFIG_FILE
 #include OPENTHREAD_CONFIG_FILE
@@ -48,50 +48,51 @@ extern "C" {
 #endif
 
 /**
- * @addtogroup api-border-agent
+ * @addtogroup api-tmf-proxy
  *
  * @brief
- *   This module includes functions for signal border agent proxy feature.
+ *   This module includes functions for TMF proxy feature.
  *
  * @{
  *
  */
 
 /**
- * This function pointer is called when a CoAP packet for border agent is received.
+ * This function pointer is called when a TMF packet for host is received.
  *
  * @param[in]  aMessage  A pointer to the CoAP Message.
  * @param[in]  aContext  A pointer to application-specific context.
  *
  */
-typedef void (*otBorderAgentProxyStreamHandler)(otMessage *aMessage, uint16_t aLocator, uint16_t aPort, void *aContext);
+typedef void (*otTmfProxyStreamHandler)(otMessage *aMessage, uint16_t aLocator, uint16_t aPort,
+                                        void *aContext);
 
 /**
- * Start the border agent proxy.
+ * Start the TMF proxy.
  *
  * @param[in]  aInstance            A pointer to an OpenThread instance.
- * @param[in]  aHandler             A pointer to a function called to deliver packet to border agent.
+ * @param[in]  aHandler             A pointer to a function called to deliver TMF packet to host.
  * @param[in]  aContext             A pointer to application-specific context.
  *
- * @retval OT_ERROR_NONE        Successfully started the border agent proxy.
+ * @retval OT_ERROR_NONE        Successfully started the TMF proxy.
  * @retval OT_ERROR_ALREADY     Border agent proxy has been started before.
  *
  */
-otError otBorderAgentProxyStart(otInstance *aInstance, otBorderAgentProxyStreamHandler aHandler, void *aContext);
+otError otTmfProxyStart(otInstance *aInstance, otTmfProxyStreamHandler aHandler, void *aContext);
 
 /**
- * Stop the border agent proxy.
+ * Stop the TMF proxy.
  *
  * @param[in]  aInstance            A pointer to an OpenThread instance.
  *
- * @retval OT_ERROR_NONE        Successfully stopped the border agent proxy.
+ * @retval OT_ERROR_NONE        Successfully stopped the TMF proxy.
  * @retval OT_ERROR_ALREADY     Border agent proxy is already stopped.
  *
  */
-otError otBorderAgentProxyStop(otInstance *aInstance);
+otError otTmfProxyStop(otInstance *aInstance);
 
 /**
- * Send packet through border agent proxy.
+ * Send packet through TMF proxy.
  *
  * @param[in]  aInstance            A pointer to an OpenThread instance.
  * @param[in]  aMessage             A pointer to the CoAP Message.
@@ -104,17 +105,17 @@ otError otBorderAgentProxyStop(otInstance *aInstance);
  * @warning No matter the call success or fail, the message is freed.
  *
  */
-otError otBorderAgentProxySend(otInstance *aInstance, otMessage *aMessage,
-                               uint16_t aLocator, uint16_t aPort);
+otError otTmfProxySend(otInstance *aInstance, otMessage *aMessage,
+                       uint16_t aLocator, uint16_t aPort);
 
 /**
- * Get the border agent proxy status (enabled/disabled)
+ * Get the TMF proxy status (enabled/disabled)
  *
  * @param[in]  aInstance            A pointer to an OpenThread instance.
  *
- * @returns The border agent proxy status (true if enabled, false otherwise).
+ * @returns The TMF proxy status (true if enabled, false otherwise).
  */
-bool otBorderAgentProxyIsEnabled(otInstance *aInstance);
+bool otTmfProxyIsEnabled(otInstance *aInstance);
 
 /**
  * @}
@@ -125,4 +126,4 @@ bool otBorderAgentProxyIsEnabled(otInstance *aInstance);
 }  // extern "C"
 #endif
 
-#endif  // OPENTHREAD_BORDER_AGENT_PROXY_H_
+#endif  // OPENTHREAD_TMF_PROXY_H_

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -90,7 +90,6 @@ libopenthread_mtd_a_CPPFLAGS        = \
 #
 
 SOURCES_COMMON                      = \
-    api/border_agent_proxy_api.cpp    \
     api/coap_api.cpp                  \
     api/commissioner_api.cpp          \
     api/child_supervision_api.cpp     \
@@ -113,6 +112,7 @@ SOURCES_COMMON                      = \
     api/tasklet_api.cpp               \
     api/thread_api.cpp                \
     api/thread_ftd_api.cpp            \
+    api/tmf_proxy_api.cpp             \
     api/udp_api.cpp                   \
     coap/coap.cpp                     \
     coap/coap_header.cpp              \
@@ -135,7 +135,6 @@ SOURCES_COMMON                      = \
     mac/mac_frame.cpp                 \
     mac/mac_whitelist.cpp             \
     meshcop/announce_begin_client.cpp \
-    meshcop/border_agent_proxy.cpp    \
     meshcop/commissioner.cpp          \
     meshcop/dataset.cpp               \
     meshcop/dataset_manager.cpp       \
@@ -177,6 +176,7 @@ SOURCES_COMMON                      = \
     thread/panid_query_server.cpp     \
     thread/src_match_controller.cpp   \
     thread/thread_netif.cpp           \
+    thread/tmf_proxy.cpp              \
     thread/topology.cpp               \
     utils/child_supervision.cpp       \
     utils/jam_detector.cpp            \
@@ -230,7 +230,6 @@ HEADERS_COMMON                      = \
     mac/mac_whitelist_impl.hpp        \
     mac/mac_whitelist_stub.hpp        \
     meshcop/announce_begin_client.hpp \
-    meshcop/border_agent_proxy.hpp    \
     meshcop/commissioner.hpp          \
     meshcop/dataset.hpp               \
     meshcop/dataset_manager.hpp       \
@@ -288,6 +287,7 @@ HEADERS_COMMON                      = \
     thread/thread_netif.hpp           \
     thread/thread_tlvs.hpp            \
     thread/thread_uri_paths.hpp       \
+    thread/tmf_proxy.hpp              \
     thread/topology.hpp               \
     utils/child_supervision.hpp       \
     utils/slaac_address.hpp           \

--- a/src/core/api/tmf_proxy_api.cpp
+++ b/src/core/api/tmf_proxy_api.cpp
@@ -28,36 +28,33 @@
 
 /**
  * @file
- *   This file implements the OpenThread Border Agent Proxy API.
+ *   This file implements the OpenThread TMF proxy API.
  */
 
-#include <openthread/border_agent_proxy.h>
+#include <openthread/tmf_proxy.h>
 
 #include "openthread-instance.h"
 
-using namespace ot;
+#if OPENTHREAD_FTD && OPENTHREAD_ENABLE_TMF_PROXY
 
-#if OPENTHREAD_FTD && OPENTHREAD_ENABLE_BORDER_AGENT_PROXY
-
-otError otBorderAgentProxyStart(otInstance *aInstance, otBorderAgentProxyStreamHandler aBorderAgentProxyCallback,
-                                void *aContext)
+otError otTmfProxyStart(otInstance *aInstance, otTmfProxyStreamHandler aTmfProxyCallback, void *aContext)
 {
-    return aInstance->mThreadNetif.GetBorderAgentProxy().Start(aBorderAgentProxyCallback, aContext);
+    return aInstance->mThreadNetif.GetTmfProxy().Start(aTmfProxyCallback, aContext);
 }
 
-otError otBorderAgentProxyStop(otInstance *aInstance)
+otError otTmfProxyStop(otInstance *aInstance)
 {
-    return aInstance->mThreadNetif.GetBorderAgentProxy().Stop();
+    return aInstance->mThreadNetif.GetTmfProxy().Stop();
 }
 
-otError otBorderAgentProxySend(otInstance *aInstance, otMessage *aMessage, uint16_t aLocator, uint16_t aPort)
+otError otTmfProxySend(otInstance *aInstance, otMessage *aMessage, uint16_t aLocator, uint16_t aPort)
 {
-    return aInstance->mThreadNetif.GetBorderAgentProxy().Send(*static_cast<Message *>(aMessage), aLocator, aPort);
+    return aInstance->mThreadNetif.GetTmfProxy().Send(*static_cast<ot::Message *>(aMessage), aLocator, aPort);
 }
 
-bool otBorderAgentProxyIsEnabled(otInstance *aInstance)
+bool otTmfProxyIsEnabled(otInstance *aInstance)
 {
-    return aInstance->mThreadNetif.GetBorderAgentProxy().IsEnabled();
+    return aInstance->mThreadNetif.GetTmfProxy().IsEnabled();
 }
 
-#endif // OPENTHREAD_FTD && OPENTHREAD_ENABLE_BORDER_AGENT_PROXY
+#endif // OPENTHREAD_FTD && OPENTHREAD_ENABLE_TMF_PROXY

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -103,9 +103,9 @@ ThreadNetif::ThreadNetif(Ip6::Ip6 &aIp6):
     mJamDetector(*this),
 #endif // OPENTHREAD_ENABLE_JAM_DETECTTION
 #if OPENTHREAD_FTD
-#if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY
-    mBorderAgentProxy(mMleRouter.GetMeshLocal16(), mCoap),
-#endif // OPENTHREAD_ENABLE_BORDER_AGENT_PROXY
+#if OPENTHREAD_ENABLE_TMF_PROXY
+    mTmfProxy(mMleRouter.GetMeshLocal16(), mCoap),
+#endif // OPENTHREAD_ENABLE_TMF_PROXY
     mJoinerRouter(*this),
     mLeader(*this),
     mAddressResolver(*this),

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -46,9 +46,9 @@
 #include "coap/coap_secure.hpp"
 #include "mac/mac.hpp"
 
-#if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
-#include "meshcop/border_agent_proxy.hpp"
-#endif // OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
+#if OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
+#include "thread/tmf_proxy.hpp"
+#endif // OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
 
 #if OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
 #include "meshcop/commissioner.hpp"
@@ -374,15 +374,15 @@ public:
     Utils::JamDetector &GetJamDetector(void) { return mJamDetector; }
 #endif // OPENTHREAD_ENABLE_JAM_DETECTION
 
-#if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
+#if OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
     /**
-     * This method returns the border agent proxy object.
+     * This method returns the TMF proxy object.
      *
-     * @returns Reference to the border agent proxy object.
+     * @returns Reference to the TMF proxy object.
      *
      */
-    MeshCoP::BorderAgentProxy &GetBorderAgentProxy(void) { return mBorderAgentProxy; }
-#endif // OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
+    TmfProxy &GetTmfProxy(void) { return mTmfProxy; }
+#endif // OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
 
     /**
      * This method returns a reference to the child supervisor object.
@@ -455,9 +455,9 @@ private:
     Utils::JamDetector mJamDetector;
 #endif // OPENTHREAD_ENABLE_JAM_DETECTION
 
-#if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
-    MeshCoP::BorderAgentProxy mBorderAgentProxy;
-#endif // OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
+#if OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
+    TmfProxy mTmfProxy;
+#endif // OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
 
 #if OPENTHREAD_FTD
     MeshCoP::JoinerRouter mJoinerRouter;

--- a/src/core/thread/tmf_proxy.cpp
+++ b/src/core/thread/tmf_proxy.cpp
@@ -28,10 +28,10 @@
 
 /**
  * @file
- *   This file implements the border agent proxy.
+ *   This file implements the TMF proxy.
  */
 
-#define WPP_NAME "border_agent_proxy.tmh"
+#define WPP_NAME "tmf_proxy.tmh"
 
 #ifdef OPENTHREAD_CONFIG_FILE
 #include OPENTHREAD_CONFIG_FILE
@@ -39,7 +39,7 @@
 #include <openthread-config.h>
 #endif
 
-#include "border_agent_proxy.hpp"
+#include "tmf_proxy.hpp"
 
 #include <openthread/types.h>
 
@@ -48,13 +48,12 @@
 #include "thread/thread_tlvs.hpp"
 #include "thread/thread_uri_paths.hpp"
 
-#if OPENTHREAD_FTD && OPENTHREAD_ENABLE_BORDER_AGENT_PROXY
+#if OPENTHREAD_FTD && OPENTHREAD_ENABLE_TMF_PROXY
 
 namespace ot {
-namespace MeshCoP {
 
-BorderAgentProxy::BorderAgentProxy(const Ip6::Address &aMeshLocal16, Coap::Coap &aCoap):
-    mRelayReceive(OT_URI_PATH_RELAY_RX, &BorderAgentProxy::HandleRelayReceive, this),
+TmfProxy::TmfProxy(const Ip6::Address &aMeshLocal16, Coap::Coap &aCoap):
+    mRelayReceive(OT_URI_PATH_RELAY_RX, &TmfProxy::HandleRelayReceive, this),
     mStreamHandler(NULL),
     mContext(NULL),
     mMeshLocal16(aMeshLocal16),
@@ -62,7 +61,7 @@ BorderAgentProxy::BorderAgentProxy(const Ip6::Address &aMeshLocal16, Coap::Coap 
 {
 }
 
-otError BorderAgentProxy::Start(otBorderAgentProxyStreamHandler aStreamHandler, void *aContext)
+otError TmfProxy::Start(otTmfProxyStreamHandler aStreamHandler, void *aContext)
 {
     otError error = OT_ERROR_NONE;
 
@@ -76,7 +75,7 @@ exit:
     return error;
 }
 
-otError BorderAgentProxy::Stop(void)
+otError TmfProxy::Stop(void)
 {
     otError error = OT_ERROR_NONE;
 
@@ -90,33 +89,33 @@ exit:
     return error;
 }
 
-bool BorderAgentProxy::IsEnabled(void) const
+bool TmfProxy::IsEnabled(void) const
 {
     return mStreamHandler != NULL;
 }
 
-void BorderAgentProxy::HandleRelayReceive(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                          const otMessageInfo *aMessageInfo)
+void TmfProxy::HandleRelayReceive(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
+                                  const otMessageInfo *aMessageInfo)
 {
-    static_cast<BorderAgentProxy *>(aContext)->DeliverMessage(
+    static_cast<TmfProxy *>(aContext)->DeliverMessage(
         *static_cast<Coap::Header *>(aHeader), *static_cast<Message *>(aMessage),
         *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
-void BorderAgentProxy::HandleResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
-                                      const otMessageInfo *aMessageInfo, otError aResult)
+void TmfProxy::HandleResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
+                              const otMessageInfo *aMessageInfo, otError aResult)
 {
     VerifyOrExit(aResult == OT_ERROR_NONE);
 
-    static_cast<BorderAgentProxy *>(aContext)->DeliverMessage(*static_cast<Coap::Header *>(aHeader),
-                                                              *static_cast<Message *>(aMessage),
-                                                              *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<TmfProxy *>(aContext)->DeliverMessage(*static_cast<Coap::Header *>(aHeader),
+                                                      *static_cast<Message *>(aMessage),
+                                                      *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 exit:
     return;
 }
 
-void BorderAgentProxy::DeliverMessage(Coap::Header &aHeader, Message &aMessage,
-                                      const Ip6::MessageInfo &aMessageInfo)
+void TmfProxy::DeliverMessage(Coap::Header &aHeader, Message &aMessage,
+                              const Ip6::MessageInfo &aMessageInfo)
 {
     otError error = OT_ERROR_NONE;
     uint16_t rloc;
@@ -140,7 +139,7 @@ exit:
     }
 }
 
-otError BorderAgentProxy::Send(Message &aMessage, uint16_t aLocator, uint16_t aPort)
+otError TmfProxy::Send(Message &aMessage, uint16_t aLocator, uint16_t aPort)
 {
     otError error = OT_ERROR_NONE;
     Ip6::MessageInfo messageInfo;
@@ -155,7 +154,7 @@ otError BorderAgentProxy::Send(Message &aMessage, uint16_t aLocator, uint16_t aP
     if (aPort == kCoapUdpPort)
     {
         // this is request to server, send with client
-        error = mCoap.SendMessage(aMessage, messageInfo, BorderAgentProxy::HandleResponse, this);
+        error = mCoap.SendMessage(aMessage, messageInfo, TmfProxy::HandleResponse, this);
     }
     else
     {
@@ -172,7 +171,6 @@ exit:
     return error;
 }
 
-}  // namespace MeshCoP
 }  // namespace ot
 
-#endif // OPENTHREAD_FTD && OPENTHREAD_ENABLE_BORDER_AGENT_PROXY
+#endif // OPENTHREAD_FTD && OPENTHREAD_ENABLE_TMF_PROXY

--- a/src/core/thread/tmf_proxy.hpp
+++ b/src/core/thread/tmf_proxy.hpp
@@ -28,45 +28,44 @@
 
 /**
  * @file
- *   This file includes definitions for border agent proxy.
+ *   This file includes definitions for TMF proxy.
  */
 
-#ifndef BORDER_AGENT_PROXY_HPP_
-#define BORDER_AGENT_PROXY_HPP_
+#ifndef TMF_PROXY_HPP_
+#define TMF_PROXY_HPP_
 
-#include <openthread/border_agent_proxy.h>
+#include <openthread/tmf_proxy.h>
 
 #include "openthread-core-config.h"
 #include "coap/coap.hpp"
 
 namespace ot {
-namespace MeshCoP {
 
-class BorderAgentProxy
+class TmfProxy
 {
 public:
     /**
-     * This constructor initializes the border agent proxy.
+     * This constructor initializes the TMF proxy.
      *
      * @param[in]   aMeshLocal16    A reference to the Mesh Local Routing Locator.
      * @param[in]   aCoap           A reference to the Management CoAP Service.
      *
      */
-    BorderAgentProxy(const Ip6::Address &aMeshLocal16, Coap::Coap &aCoap);
+    TmfProxy(const Ip6::Address &aMeshLocal16, Coap::Coap &aCoap);
 
     /**
-     * This method enables the border agent proxy service.
+     * This method enables the TMF proxy service.
      *
      * @retval OT_ERROR_NONE            Successfully started the service.
      * @retval OT_ERROR_ALREADY         The service already started.
      *
      */
-    otError Start(otBorderAgentProxyStreamHandler aStreamHandler, void *aContext);
+    otError Start(otTmfProxyStreamHandler aStreamHandler, void *aContext);
 
     /**
-     * This method disables the border agent proxy service.
+     * This method disables the TMF proxy service.
      *
-     * @retval OT_ERROR_NONE            Successfully stopped the border agent proxy service.
+     * @retval OT_ERROR_NONE            Successfully stopped the TMF proxy service.
      * @retval OT_ERROR_ALREADY         The service already stopped.
      *
      */
@@ -88,7 +87,7 @@ public:
     otError Send(Message &aMessage, uint16_t aLocator, uint16_t aPort);
 
     /**
-     * This method indicates whether or not the border agent proxy service is enabled.
+     * This method indicates whether or not the TMF proxy service is enabled.
      *
      * @retval  TRUE    If the service is enabled.
      * @retval  FALSE   If the service is disabled.
@@ -108,14 +107,13 @@ private:
 
 
     Coap::Resource mRelayReceive;
-    otBorderAgentProxyStreamHandler mStreamHandler;
+    otTmfProxyStreamHandler mStreamHandler;
     void *mContext;
 
     const Ip6::Address &mMeshLocal16;
     Coap::Coap &mCoap;
 };
 
-}  // namespace MeshCoP
 }  // namespace ot
 
-#endif  // BORDER_AGENT_PROXY_HPP_
+#endif  // TMF_PROXY_HPP_

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -41,8 +41,8 @@
 #include <stdarg.h>
 #include <stdlib.h>
 
-#if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
-#include <openthread/border_agent_proxy.h>
+#if OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
+#include <openthread/tmf_proxy.h>
 #endif
 
 #if OPENTHREAD_ENABLE_BORDER_ROUTER
@@ -220,8 +220,8 @@ const NcpBase::GetPropertyHandlerEntry NcpBase::mGetPropertyHandlerTable[] =
     { SPINEL_PROP_JAM_DETECT_HISTORY_BITMAP, &NcpBase::GetPropertyHandler_JAM_DETECT_HISTORY_BITMAP },
 #endif
 
-#if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
-    { SPINEL_PROP_THREAD_BA_PROXY_ENABLED, &NcpBase::GetPropertyHandler_BA_PROXY_ENABLED },
+#if OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
+    { SPINEL_PROP_THREAD_TMF_PROXY_ENABLED, &NcpBase::GetPropertyHandler_TMF_PROXY_ENABLED },
 #endif
 
     { SPINEL_PROP_CNTR_TX_PKT_TOTAL, &NcpBase::GetPropertyHandler_MAC_CNTR },
@@ -359,10 +359,10 @@ const NcpBase::SetPropertyHandlerEntry NcpBase::mSetPropertyHandlerTable[] =
     { SPINEL_PROP_JAM_DETECT_BUSY, &NcpBase::SetPropertyHandler_JAM_DETECT_BUSY },
 #endif
 
-#if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
-    { SPINEL_PROP_THREAD_BA_PROXY_ENABLED, &NcpBase::SetPropertyHandler_BA_PROXY_ENABLED },
-    { SPINEL_PROP_THREAD_BA_PROXY_STREAM, &NcpBase::SetPropertyHandler_THREAD_BA_PROXY_STREAM },
-#endif // OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
+#if OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
+    { SPINEL_PROP_THREAD_TMF_PROXY_ENABLED, &NcpBase::SetPropertyHandler_TMF_PROXY_ENABLED },
+    { SPINEL_PROP_THREAD_TMF_PROXY_STREAM, &NcpBase::SetPropertyHandler_THREAD_TMF_PROXY_STREAM },
+#endif // OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
 
 #if OPENTHREAD_ENABLE_DIAG
     { SPINEL_PROP_NEST_STREAM_MFG, &NcpBase::SetPropertyHandler_NEST_STREAM_MFG },
@@ -681,13 +681,13 @@ NcpFrameBuffer::FrameTag NcpBase::GetLastOutboundFrameTag(void)
     return mTxFrameBuffer.InFrameGetLastTag();
 }
 
-#if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
-void NcpBase::HandleBorderAgentProxyStream(otMessage *aMessage, uint16_t aLocator, uint16_t aPort, void *aContext)
+#if OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
+void NcpBase::HandleTmfProxyStream(otMessage *aMessage, uint16_t aLocator, uint16_t aPort, void *aContext)
 {
-    static_cast<NcpBase *>(aContext)->HandleBorderAgentProxyStream(aMessage, aLocator, aPort);
+    static_cast<NcpBase *>(aContext)->HandleTmfProxyStream(aMessage, aLocator, aPort);
 }
 
-void NcpBase::HandleBorderAgentProxyStream(otMessage *aMessage, uint16_t aLocator, uint16_t aPort)
+void NcpBase::HandleTmfProxyStream(otMessage *aMessage, uint16_t aLocator, uint16_t aPort)
 {
     otError errorCode = OT_ERROR_NONE;
     uint16_t length = otMessageGetLength(aMessage);
@@ -699,7 +699,7 @@ void NcpBase::HandleBorderAgentProxyStream(otMessage *aMessage, uint16_t aLocato
                         SPINEL_DATATYPE_COMMAND_PROP_S SPINEL_DATATYPE_UINT16_S,
                         SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
                         SPINEL_CMD_PROP_VALUE_IS,
-                        SPINEL_PROP_THREAD_BA_PROXY_STREAM,
+                        SPINEL_PROP_THREAD_TMF_PROXY_STREAM,
                         length
                     ));
 
@@ -733,7 +733,7 @@ exit:
         SendLastStatus(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_STATUS_DROPPED);
     }
 }
-#endif // OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
+#endif // OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
 
 // ----------------------------------------------------------------------------
 // MARK: Outbound Datagram Handling
@@ -2053,8 +2053,8 @@ otError NcpBase::GetPropertyHandler_CAPS(uint8_t header, spinel_prop_key_t key)
                     ));
 #endif
 
-#if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
-    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_UINT_PACKED_S, SPINEL_CAP_THREAD_BA_PROXY));
+#if OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
+    SuccessOrExit(errorCode = OutboundFrameFeedPacked(SPINEL_DATATYPE_UINT_PACKED_S, SPINEL_CAP_THREAD_TMF_PROXY));
 #endif
 
     // End adding capabilities /////////////////////////////////////////////////
@@ -3322,18 +3322,18 @@ otError NcpBase::GetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_key_t
     return SendLastStatus(header, SPINEL_STATUS_UNIMPLEMENTED);
 }
 
-#if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
-otError NcpBase::GetPropertyHandler_BA_PROXY_ENABLED(uint8_t header, spinel_prop_key_t key)
+#if OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
+otError NcpBase::GetPropertyHandler_TMF_PROXY_ENABLED(uint8_t header, spinel_prop_key_t key)
 {
     return SendPropertyUpdate(
                header,
                SPINEL_CMD_PROP_VALUE_IS,
                key,
                SPINEL_DATATYPE_BOOL_S,
-               otBorderAgentProxyIsEnabled(mInstance)
+               otTmfProxyIsEnabled(mInstance)
            );
 }
-#endif // OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
+#endif // OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
 
 #if OPENTHREAD_ENABLE_JAM_DETECTION
 
@@ -5232,8 +5232,8 @@ otError NcpBase::SetPropertyHandler_STREAM_NET_INSECURE(uint8_t header, spinel_p
     return errorCode;
 }
 
-#if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
-otError NcpBase::SetPropertyHandler_THREAD_BA_PROXY_STREAM(uint8_t header, spinel_prop_key_t key,
+#if OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
+otError NcpBase::SetPropertyHandler_THREAD_TMF_PROXY_STREAM(uint8_t header, spinel_prop_key_t key,
                                                            const uint8_t *value_ptr, uint16_t value_len)
 {
     spinel_ssize_t parsedLength;
@@ -5243,7 +5243,7 @@ otError NcpBase::SetPropertyHandler_THREAD_BA_PROXY_STREAM(uint8_t header, spine
     uint16_t locator;
     uint16_t port;
 
-    // THREAD_BA_PROXY_STREAM requires layer 2 security.
+    // THREAD_TMF_PROXY_STREAM requires layer 2 security.
     otMessage *message = otIp6NewMessage(mInstance, true);
 
     if (message == NULL)
@@ -5278,7 +5278,7 @@ otError NcpBase::SetPropertyHandler_THREAD_BA_PROXY_STREAM(uint8_t header, spine
 
     if (errorCode == OT_ERROR_NONE)
     {
-        errorCode = otBorderAgentProxySend(mInstance, message, locator, port);
+        errorCode = otTmfProxySend(mInstance, message, locator, port);
     }
     else if (message)
     {
@@ -5303,7 +5303,7 @@ otError NcpBase::SetPropertyHandler_THREAD_BA_PROXY_STREAM(uint8_t header, spine
 
     return errorCode;
 }
-#endif // OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
+#endif // OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
 
 otError NcpBase::SetPropertyHandler_STREAM_NET(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                uint16_t value_len)
@@ -6563,8 +6563,8 @@ otError NcpBase::SetPropertyHandler_THREAD_NETWORK_ID_TIMEOUT(uint8_t header, sp
 }
 #endif  // OPENTHREAD_FTD
 
-#if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
-otError NcpBase::SetPropertyHandler_BA_PROXY_ENABLED(uint8_t header, spinel_prop_key_t key,
+#if OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
+otError NcpBase::SetPropertyHandler_TMF_PROXY_ENABLED(uint8_t header, spinel_prop_key_t key,
                                                      const uint8_t *value_ptr, uint16_t value_len)
 {
     bool isEnabled;
@@ -6582,11 +6582,11 @@ otError NcpBase::SetPropertyHandler_BA_PROXY_ENABLED(uint8_t header, spinel_prop
     {
         if (isEnabled)
         {
-            SuccessOrExit(errorCode = otBorderAgentProxyStart(mInstance, &NcpBase::HandleBorderAgentProxyStream, this));
+            SuccessOrExit(errorCode = otTmfProxyStart(mInstance, &NcpBase::HandleTmfProxyStream, this));
         }
         else
         {
-            SuccessOrExit(errorCode = otBorderAgentProxyStop(mInstance));
+            SuccessOrExit(errorCode = otTmfProxyStop(mInstance));
         }
 
         SuccessOrExit(errorCode = HandleCommandPropertyGet(header, key));
@@ -6605,7 +6605,7 @@ exit:
 
     return errorCode;
 }
-#endif // OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
+#endif // OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
 
 #if OPENTHREAD_ENABLE_JAM_DETECTION
 

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -151,14 +151,14 @@ private:
 
     NcpFrameBuffer::FrameTag GetLastOutboundFrameTag(void);
 
-#if OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
+#if OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
     /**
-     * Trampoline for HandleBorderAgentProxyStream().
+     * Trampoline for HandleTmfProxyStream().
      */
-    static void HandleBorderAgentProxyStream(otMessage *aMessage, uint16_t aLocator, uint16_t aPort, void *aContext);
+    static void HandleTmfProxyStream(otMessage *aMessage, uint16_t aLocator, uint16_t aPort, void *aContext);
 
-    void HandleBorderAgentProxyStream(otMessage *aMessage, uint16_t aLocator, uint16_t aPort);
-#endif // OPENTHREAD_ENABLE_BORDER_AGENT_PROXY && OPENTHREAD_FTD
+    void HandleTmfProxyStream(otMessage *aMessage, uint16_t aLocator, uint16_t aPort);
+#endif // OPENTHREAD_ENABLE_TMF_PROXY && OPENTHREAD_FTD
 
     /**
      * Trampoline for NcpFrameBuffer FrameRemoved Callback.
@@ -440,7 +440,7 @@ private:
     otError GetPropertyHandler_THREAD_COMMISSIONER_ENABLED(uint8_t header, spinel_prop_key_t key);
 #endif
 
-    otError GetPropertyHandler_BA_PROXY_ENABLED(uint8_t header, spinel_prop_key_t key);
+    otError GetPropertyHandler_TMF_PROXY_ENABLED(uint8_t header, spinel_prop_key_t key);
 
 #if OPENTHREAD_ENABLE_JAM_DETECTION
     otError GetPropertyHandler_JAM_DETECT_ENABLE(uint8_t header, spinel_prop_key_t key);
@@ -509,7 +509,7 @@ private:
     otError SetPropertyHandler_THREAD_RLOC16_DEBUG_PASSTHRU(uint8_t header, spinel_prop_key_t key,
                                                             const uint8_t *value_ptr, uint16_t value_len);
 
-    otError SetPropertyHandler_THREAD_BA_PROXY_STREAM(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_THREAD_TMF_PROXY_STREAM(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                       uint16_t value_len);
 #if OPENTHREAD_ENABLE_RAW_LINK_API
     otError SetPropertyHandler_PHY_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
@@ -597,7 +597,7 @@ private:
                                                            const uint8_t *value_ptr, uint16_t value_len);
 #endif
 
-    otError SetPropertyHandler_BA_PROXY_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
+    otError SetPropertyHandler_TMF_PROXY_ENABLED(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                                 uint16_t value_len);
 #if OPENTHREAD_ENABLE_JAM_DETECTION
     otError SetPropertyHandler_JAM_DETECT_ENABLE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1276,12 +1276,12 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_THREAD_COMMISSIONER_ENABLED";
         break;
 
-    case SPINEL_PROP_THREAD_BA_PROXY_ENABLED:
-        ret = "PROP_THREAD_BA_PROXY_ENABLED";
+    case SPINEL_PROP_THREAD_TMF_PROXY_ENABLED:
+        ret = "PROP_THREAD_TMF_PROXY_ENABLED";
         break;
 
-    case SPINEL_PROP_THREAD_BA_PROXY_STREAM:
-        ret = "PROP_THREAD_BA_PROXY_STREAM";
+    case SPINEL_PROP_THREAD_TMF_PROXY_STREAM:
+        ret = "PROP_THREAD_TMF_PROXY_STREAM";
         break;
 
     case SPINEL_PROP_THREAD_DISCOVERY_SCAN_JOINER_FLAG:
@@ -1863,8 +1863,8 @@ const char *spinel_capability_to_cstr(unsigned int capability)
         ret = "CAP_THREAD_COMMISSIONER";
         break;
 
-    case SPINEL_CAP_THREAD_BA_PROXY:
-        ret = "CAP_THREAD_BA_PROXY";
+    case SPINEL_CAP_THREAD_TMF_PROXY:
+        ret = "CAP_THREAD_TMF_PROXY";
         break;
 
     case SPINEL_CAP_NEST_LEGACY_INTERFACE:

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -378,7 +378,7 @@ enum
 
     SPINEL_CAP_THREAD__BEGIN            = 1024,
     SPINEL_CAP_THREAD_COMMISSIONER      = (SPINEL_CAP_THREAD__BEGIN + 0),
-    SPINEL_CAP_THREAD_BA_PROXY          = (SPINEL_CAP_THREAD__BEGIN + 1),
+    SPINEL_CAP_THREAD_TMF_PROXY         = (SPINEL_CAP_THREAD__BEGIN + 1),
     SPINEL_CAP_THREAD__END              = 1152,
 
     SPINEL_CAP_NEST__BEGIN              = 15296,
@@ -865,17 +865,18 @@ typedef enum
     SPINEL_PROP_THREAD_COMMISSIONER_ENABLED
                                         = SPINEL_PROP_THREAD_EXT__BEGIN + 16,
 
-    /// Thread border agent proxy enable
+    /// Thread TMF proxy enable
     /** Format `b`
      *
      * Default value is `false`.
      */
-    SPINEL_PROP_THREAD_BA_PROXY_ENABLED = SPINEL_PROP_THREAD_EXT__BEGIN + 17,
+    SPINEL_PROP_THREAD_TMF_PROXY_ENABLED
+                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 17,
 
-    /// Thread border agent proxy stream
+    /// Thread TMF proxy stream
     /** Format `dSS`
      */
-    SPINEL_PROP_THREAD_BA_PROXY_STREAM  = SPINEL_PROP_THREAD_EXT__BEGIN + 18,
+    SPINEL_PROP_THREAD_TMF_PROXY_STREAM = SPINEL_PROP_THREAD_EXT__BEGIN + 18,
 
     /// Thread "joiner" flag used during discovery scan operation
     /** Format `b`


### PR DESCRIPTION
There are new TMF messages except border agent's need to be handled on host side, border agent proxy cannot exactly show the actual functionality.

This PR renames the Border Agent Proxy to TMF Proxy, both in source code and spinel protocol.