### PR TITLE
Fix wrong pretty configuration file path in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -335,9 +335,9 @@ fi
 #
 
 AC_SUBST(PRETTY, ["\${abs_top_srcdir}/.astyle/astyle-wrap.sh"])
-AC_SUBST(PRETTY_ARGS, ["astyle --options=\${abs_top_builddir}/.astyle/astyle-opts"])
+AC_SUBST(PRETTY_ARGS, ["astyle --options=\${abs_top_srcdir}/.astyle/astyle-opts"])
 AC_SUBST(PRETTY_CHECK, ["\${abs_top_srcdir}/.astyle/astyle-wrap.sh"])
-AC_SUBST(PRETTY_CHECK_ARGS, ["astyle --options=\${abs_top_builddir}/.astyle/astyle-opts --dry-run"])
+AC_SUBST(PRETTY_CHECK_ARGS, ["astyle --options=\${abs_top_srcdir}/.astyle/astyle-opts --dry-run"])
 
 #
 # Tests


### PR DESCRIPTION
It's annoying that in order to `make pretty`, `configure` must be run at the root of this repo. This is caused by wrong configuration path in configure.ac.

This PR fixes the wrong pretty configuration file path. With this PR, one can make pretty inside build path like this(assuming called `make -f examples/Makefile-posix` before on macOS),
```sh
make -C build/x86_64-apple-darwin pretty
```
no need to do the following.
```sh
./configure
make pretty
make distclean
```