### PR TITLE
Posix flash

### DIFF
--- a/examples/platforms/posix/flash.c
+++ b/examples/platforms/posix/flash.c
@@ -56,9 +56,7 @@ otError utilsFlashInit(void)
     char fileName[20];
     struct stat st;
     bool create = false;
-    struct timeval tv;
-
-    gettimeofday(&tv, NULL);
+    const char *offset = getenv("PORT_OFFSET");
 
     memset(&st, 0, sizeof(st));
 
@@ -67,7 +65,12 @@ otError utilsFlashInit(void)
         mkdir("tmp", 0777);
     }
 
-    snprintf(fileName, sizeof(fileName), "tmp/%d_%d.flash", NODE_ID, (uint32_t)tv.tv_usec);
+    if (offset == NULL)
+    {
+        offset = "0";
+    }
+
+    snprintf(fileName, sizeof(fileName), "tmp/%s_%d.flash", offset, NODE_ID);
 
     if (access(fileName, 0))
     {

--- a/third_party/openthread-test-driver/test-driver
+++ b/third_party/openthread-test-driver/test-driver
@@ -121,6 +121,8 @@ estatus=$?
 
 # Return the offset
 rm -rf "${lock_path}.${OFFSET}.lock.d"
+# Remove the flash files
+rm -f tmp/${OFFSET}_*.flash
 
 if test $enable_hard_errors = no && test $estatus -eq 99; then
   tweaked_estatus=1


### PR DESCRIPTION
Currently POSIX simulate flash with file, and the flash cannot be loaded after restart because the filename is based on timestamp. This was designed to support running CI tests simultaneously. However, the design makes flash related features cannot be tested with POSIX simulation.

This PR enhances this by naming the flash file based on the `NODE_ID` and `PORT_OFFSET`. Thus, even running CI tests simultaneously, the flash files will not conflict with each other. With this PR, the POSIX simulation can simulate power off and power on devices by restarting.