### PR TITLE
fix compiling NCP self test

### DIFF
--- a/src/ncp/Makefile.am
+++ b/src/ncp/Makefile.am
@@ -50,24 +50,14 @@ COMMON_CPPFLAGS                                   = \
     $(OPENTHREAD_TARGET_DEFINES)                    \
     $(NULL)
 
-
-COMMON_CXXFLAGS                                   = \
-    -I$(top_srcdir)/include                         \
-    -I$(top_srcdir)/src                             \
-    -I$(top_srcdir)/src/core                        \
-    -I$(top_srcdir)/third_party                     \
-    -D_GNU_SOURCE                                   \
-    $(OPENTHREAD_TARGET_DEFINES)                    \
-    $(NULL)
-
 libopenthread_ncp_mtd_a_CPPFLAGS                  = \
     -DOPENTHREAD_MTD=1                              \
-    $(COMMON_CXXFLAGS)                              \
+    $(COMMON_CPPFLAGS)                              \
     $(NULL)
 
 libopenthread_ncp_ftd_a_CPPFLAGS                  = \
     -DOPENTHREAD_FTD=1                              \
-    $(COMMON_CXXFLAGS)                              \
+    $(COMMON_CPPFLAGS)                              \
     $(NULL)
 
 COMMON_SOURCES                                    = \
@@ -101,7 +91,7 @@ if OPENTHREAD_BUILD_TESTS
 
 noinst_PROGRAMS                                   = spinel-test
 spinel_test_SOURCES                               = spinel.c
-spinel_test_CFLAGS                                = -DSPINEL_SELF_TEST=1 -D_GNU_SOURCE -I$(top_srcdir)/src/core
+spinel_test_CFLAGS                                = -DSPINEL_SELF_TEST=1 $(COMMON_CPPFLAGS)
 
 TESTS                                             = spinel-test
 

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1892,10 +1892,6 @@ const char *spinel_capability_to_cstr(unsigned int capability)
 
 #if SPINEL_SELF_TEST
 
-#include <stdlib.h>
-#include "utils/wrap_string.h"
-
-
 int
 main(void)
 {


### PR DESCRIPTION
When building OpenThread on macOS, got this error.
```cpp
src/ncp/spinel.c:1896:
src/core/utils/wrap_string.h:67:9: error: 'strlcpy' macro redefined [-Werror,-Wmacro-redefined]
#define strlcpy( D, S, N )  missing_strlcpy( D, S, N )
        ^
/usr/include/secure/_string.h:104:9: note: previous definition is here
#define strlcpy(dest, src, len)                                 \
        ^
src/ncp/spinel.c:1896:
src/core/utils/wrap_string.h:71:9: error: 'strlcat' macro redefined [-Werror,-Wmacro-redefined]
#define strlcat( D, S, N )  missing_strlcat( D, S, N )
        ^
/usr/include/secure/_string.h:110:9: note: previous definition is here
#define strlcat(dest, src, len)                                 \
        ^
```
This is caused by not including the generated config header `openthread-config.h` for `spinel-test`. Some issues introduced by previous PRs,
1. in src/ncp/Makefile.am, `COMMON_CXXFLAGS` is misused or mis-named and `COMMON_CPPFLAGS` is not used at all.
2. even building spinel-test, `SPINEL_PLATFORM_HEADER` should be included in case for missing functions.

This PR fixes these issues.