### PR TITLE
NcpBase: Simplify the set handlers by refactoring common code

### DIFF
--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -453,6 +453,7 @@ private:
     otError GetPropertyHandler_NEST_LEGACY_ULA_PREFIX(uint8_t header, spinel_prop_key_t key);
 #endif
 
+    otError SendSetPropertyResponse(uint8_t aHeader, spinel_prop_key_t aKey, otError aError);
 
     otError SetPropertyHandler_POWER_STATE(uint8_t header, spinel_prop_key_t key, const uint8_t *value_ptr,
                                            uint16_t value_len);


### PR DESCRIPTION
This commit simplifies the set handlers in `NcpBase` by refactoring
common code (which sends the spinel response to the `VALUE_SET`
command) into a new method `SendSetPropertyResponse()`. It also changes
the error handling in set handlers to use `VerifyOrExit`/`SuccessOrExit`.