### PR TITLE
Restore stdout when restoring POSIX UART

### DIFF
--- a/examples/platforms/posix/uart-posix.c
+++ b/examples/platforms/posix/uart-posix.c
@@ -73,6 +73,7 @@ void platformUartRestore(void)
 {
     restore_stdin_termios();
     restore_stdout_termios();
+    dup2(s_out_fd, STDOUT_FILENO);
 }
 
 otError otPlatUartEnable(void)


### PR DESCRIPTION
This PR fixes the issue that resetting POSIX simulation causes wpantund running abnormal.

This is caused by not restoring STDOUT before `reset` which calls `execvp()`.