### PR TITLE
Timer: Modify timer implementation to store fire time

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -405,7 +405,7 @@ Message *Coap::CopyAndEnqueueMessage(const Message &aMessage, uint16_t aCopyLeng
     if (mRetransmissionTimer.IsRunning())
     {
         // If timer is already running, check if it should be restarted with earlier fire time.
-        alarmFireTime = mRetransmissionTimer.Gett0() + mRetransmissionTimer.Getdt();
+        alarmFireTime = mRetransmissionTimer.GetFireTime();
 
         if (aCoapMetadata.IsEarlier(alarmFireTime))
         {

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -69,7 +69,7 @@ void TimerScheduler::Add(Timer &aTimer)
 
         for (cur = mHead; cur; cur = cur->mNext)
         {
-            if (TimerCompare(aTimer, *cur))
+            if (IsStrictlyBefore(aTimer.mFireTime, cur->mFireTime))
             {
                 if (prev)
                 {
@@ -126,18 +126,14 @@ exit:
 
 void TimerScheduler::SetAlarm(void)
 {
-    uint32_t now = otPlatAlarmGetNow();
-    uint32_t elapsed;
-    uint32_t remaining;
-
     if (mHead == NULL)
     {
         otPlatAlarmStop(GetIp6()->GetInstance());
     }
     else
     {
-        elapsed = now - mHead->mT0;
-        remaining = (mHead->mDt > elapsed) ? mHead->mDt - elapsed : 0;
+        uint32_t now = otPlatAlarmGetNow();
+        uint32_t remaining = IsStrictlyBefore(now, mHead->mFireTime) ? (mHead->mFireTime - now) : 0;
 
         otPlatAlarmStartAt(GetIp6()->GetInstance(), now, remaining);
     }
@@ -146,21 +142,17 @@ void TimerScheduler::SetAlarm(void)
 extern "C" void otPlatAlarmFired(otInstance *aInstance)
 {
     otLogFuncEntry();
-    aInstance->mIp6.mTimerScheduler.FireTimers();
+    aInstance->mIp6.mTimerScheduler.ProcessTimers();
     otLogFuncExit();
 }
 
-void TimerScheduler::FireTimers(void)
+void TimerScheduler::ProcessTimers(void)
 {
-    uint32_t now = otPlatAlarmGetNow();
-    uint32_t elapsed;
     Timer *timer = mHead;
 
     if (timer)
     {
-        elapsed = now - timer->mT0;
-
-        if (elapsed >= timer->mDt)
+        if (!IsStrictlyBefore(otPlatAlarmGetNow(), timer->mFireTime))
         {
             Remove(*timer);
             timer->Fired();
@@ -181,39 +173,16 @@ Ip6::Ip6 *TimerScheduler::GetIp6(void)
     return Ip6::Ip6FromTimerScheduler(this);
 }
 
-bool TimerScheduler::TimerCompare(const Timer &aTimerA, const Timer &aTimerB)
+bool TimerScheduler::IsStrictlyBefore(uint32_t aTimeA, uint32_t aTimeB)
 {
-    uint32_t now = otPlatAlarmGetNow();
-    uint32_t elapsedA = now - aTimerA.mT0;
-    uint32_t elapsedB = now - aTimerB.mT0;
-    bool retval = false;
+    uint32_t diff = aTimeA - aTimeB;
 
-    if (aTimerA.mDt >= elapsedA && aTimerB.mDt >= elapsedB)
-    {
-        uint32_t remainingA = aTimerA.mDt - elapsedA;
-        uint32_t remainingB = aTimerB.mDt - elapsedB;
+    // Three cases:
+    // 1) aTimeA is before  aTimeB  =>  Difference is negative (last bit of difference is set)   => Returning true.
+    // 2) aTimeA is same as aTimeB  =>  Difference is zero     (last bit of difference is clear) => Returning false.
+    // 3) aTimeA is after   aTimeB  =>  Difference is positive (last bit of difference is clear) => Returning false.
 
-        if (remainingA < remainingB)
-        {
-            retval = true;
-        }
-    }
-    else if (aTimerA.mDt < elapsedA && aTimerB.mDt >= elapsedB)
-    {
-        retval = true;
-    }
-    else if (aTimerA.mDt < elapsedA && aTimerB.mDt < elapsedB)
-    {
-        uint32_t expiredByA = elapsedA - aTimerA.mDt;
-        uint32_t expiredByB = elapsedB - aTimerB.mDt;
-
-        if (expiredByB < expiredByA)
-        {
-            retval = true;
-        }
-    }
-
-    return retval;
+    return ((diff & (1UL << 31)) != 0);
 }
 
 }  // namespace ot

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -169,7 +169,7 @@ Message *Client::CopyAndEnqueueMessage(const Message &aMessage, const QueryMetad
     if (mRetransmissionTimer.IsRunning())
     {
         // If timer is already running, check if it should be restarted with earlier fire time.
-        nextTransmissionTime = mRetransmissionTimer.Gett0() + mRetransmissionTimer.Getdt();
+        nextTransmissionTime = mRetransmissionTimer.GetFireTime();
 
         if (aQueryMetadata.IsEarlier(nextTransmissionTime))
         {

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -192,7 +192,7 @@ void Mpl::AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSeque
     if (mRetransmissionTimer.IsRunning())
     {
         // If timer is already running, check if it should be restarted with earlier fire time.
-        nextTransmissionTime = mRetransmissionTimer.Gett0() + mRetransmissionTimer.Getdt();
+        nextTransmissionTime = mRetransmissionTimer.GetFireTime();
 
         if (messageMetadata.IsEarlier(nextTransmissionTime))
         {

--- a/src/core/thread/data_poll_manager.cpp
+++ b/src/core/thread/data_poll_manager.cpp
@@ -51,6 +51,7 @@ namespace ot {
 DataPollManager::DataPollManager(MeshForwarder &aMeshForwarder):
     mMeshForwarder(aMeshForwarder),
     mTimer(aMeshForwarder.GetNetif().GetIp6().mTimerScheduler, &DataPollManager::HandlePollTimer, this),
+    mTimerStartTime(0),
     mExternalPollPeriod(0),
     mPollPeriod(0),
     mEnabled(false),
@@ -327,11 +328,12 @@ void DataPollManager::ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector)
 
     if (mTimer.IsRunning())
     {
-        mTimer.StartAt(mTimer.Gett0(), mPollPeriod);
+        mTimer.StartAt(mTimerStartTime, mPollPeriod);
     }
     else
     {
-        mTimer.Start(mPollPeriod);
+        mTimerStartTime = Timer::GetNow();
+        mTimer.StartAt(mTimerStartTime, mPollPeriod);
     }
 }
 

--- a/src/core/thread/data_poll_manager.hpp
+++ b/src/core/thread/data_poll_manager.hpp
@@ -222,6 +222,7 @@ private:
 
     MeshForwarder &mMeshForwarder;
     Timer     mTimer;
+    uint32_t  mTimerStartTime;
     uint32_t  mExternalPollPeriod;
     uint32_t  mPollPeriod;
 

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -272,7 +272,7 @@ public:
      * This method sets the KeyRotation time.
      *
      * The KeyRotation time is the time interval after witch security key will be automatically rotated.
-     * It's value shall be in range [kMinKeyRotationTime, kMaxKeyRotationTime].
+     * Its value shall be larger than or equal to kMinKeyRotationTime.
      *
      * @param[in]  aKeyRotation  The KeyRotation value in hours.
      *
@@ -328,14 +328,15 @@ private:
     enum
     {
         kMinKeyRotationTime = 1,
-        kMaxKeyRotationTime = 0xffffffff / 3600u / 1000u,
         kDefaultKeyRotationTime = 672,
         kDefaultKeySwitchGuardTime = 624,
         kMacKeyOffset = 16,
+        kOneHourIntervalInMsec = 3600u * 1000u,
     };
 
     otError ComputeKey(uint32_t aKeySequence, uint8_t *aKey);
 
+    void StartKeyRotationTimer(void);
     static void HandleKeyRotationTimer(void *aContext);
     void HandleKeyRotationTimer(void);
 
@@ -353,6 +354,7 @@ private:
     uint32_t mStoredMacFrameCounter;
     uint32_t mStoredMleFrameCounter;
 
+    uint32_t mHoursSinceKeyRotation;
     uint32_t mKeyRotationTime;
     uint32_t mKeySwitchGuardTime;
     bool     mKeySwitchGuardEnabled;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1975,7 +1975,7 @@ otError Mle::AddDelayedResponse(Message &aMessage, const Ip6::Address &aDestinat
     if (mDelayedResponseTimer.IsRunning())
     {
         // If timer is already running, check if it should be restarted with earlier fire time.
-        alarmFireTime = mDelayedResponseTimer.Gett0() + mDelayedResponseTimer.Getdt();
+        alarmFireTime = mDelayedResponseTimer.GetFireTime();
 
         if (delayedResponse.IsEarlier(alarmFireTime))
         {


### PR DESCRIPTION
This commit changes the `Timer` class to store the fire time instead
of start time and duration. This simplifies the `Timer` implementation
and reduces the size of a `Timer` instance. The `test_timer` unit test
is also updated to add new test cases to verify correct timer behavior
during 32-bit timer wrap.

This commit also simplifies the key rotation implementation in
`KeyManager` class. Since the key rotation time and guard time are
provided in hours unit and can span multiple days, the code tracks
number of hours since last key rotation in `mHoursSinceKeyRotation`
(using a one hour interval timer). This is then used to decide when/if
to change the key sequence.