### PR TITLE
configure.ac: Remove "OpenThread Default logging" line from summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1393,7 +1393,6 @@ AC_MSG_NOTICE([
   OpenThread Diagnostics support            : ${enable_diag}
   OpenThread Child Supervision support      : ${enable_child_supervision}
   OpenThread Legacy network support         : ${enable_legacy}
-  OpenThread Default logging support        : ${enable_default_logging}
   OpenThread Certification log support      : ${enable_cert_log}
   OpenThread DHCPv6 Server support          : ${enable_dhcp6_server}
   OpenThread DHCPv6 Client support          : ${enable_dhcp6_client}


### PR DESCRIPTION
Setting  moved to core config in https://github.com/openthread/openthread/pull/1879