### PR TITLE
Fix wrong UDP length when decompressing IP-in-IP 6LoWPAN fragments

### DIFF
--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -1074,7 +1074,7 @@ int Lowpan::Decompress(Message &aMessage, const Mac::Address &aMacSource, const 
                 remaining--;
 
                 VerifyOrExit((rval = Decompress(aMessage, aMacSource, aMacDest, cur, remaining,
-                                                (aDatagramLength ? aDatagramLength - aMessage.GetLength() : 0))) >= 0);
+                                                aDatagramLength)) >= 0);
             }
             else
             {
@@ -1101,7 +1101,7 @@ int Lowpan::Decompress(Message &aMessage, const Mac::Address &aMacSource, const 
 
     if (aDatagramLength)
     {
-        ip6PayloadLength = HostSwap16(aDatagramLength - sizeof(Ip6::Header));
+        ip6PayloadLength = HostSwap16(aDatagramLength - currentOffset - sizeof(Ip6::Header));
     }
     else
     {


### PR DESCRIPTION
This PR fixes the wrong UDP length computed when decompressing 6LoWPAN fragments. This causes UDP in IP-in-IP packets cannot be handled for failing checksum verification.

The cause of this issue is that UDP length is computed based on the original *datagram size*, however, when manipulating the IP-in-IP, this size is decreased by size of the outside IP header. This PR fixes this by keeping the original *datagram size* and calculating the IP payload length based on the `currentOffset`.