### PR TITLE
Fix multicast from Ncp Host going back to host

### DIFF
--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -162,8 +162,8 @@ otError otIp6Send(otInstance *aInstance, otMessage *aMessage)
 
     otLogFuncEntry();
 
-    error = aInstance->mIp6.SendFromNcpHost(*static_cast<Message *>(aMessage),
-                                            aInstance->mThreadNetif.GetInterfaceId());
+    error = aInstance->mIp6.SendRaw(*static_cast<Message *>(aMessage),
+                                    aInstance->mThreadNetif.GetInterfaceId());
 
     otLogFuncExitErr(error);
 

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -162,8 +162,8 @@ otError otIp6Send(otInstance *aInstance, otMessage *aMessage)
 
     otLogFuncEntry();
 
-    error = aInstance->mIp6.HandleDatagram(*static_cast<Message *>(aMessage), NULL,
-                                           aInstance->mThreadNetif.GetInterfaceId(), NULL, true);
+    error = aInstance->mIp6.SendFromNcpHost(*static_cast<Message *>(aMessage),
+                                            aInstance->mThreadNetif.GetInterfaceId());
 
     otLogFuncExitErr(error);
 

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -654,7 +654,7 @@ exit:
     return error;
 }
 
-otError Ip6::SendFromNcpHost(Message &aMessage, int8_t aInterfaceId)
+otError Ip6::SendRaw(Message &aMessage, int8_t aInterfaceId)
 {
     otError error = OT_ERROR_NONE;
     Header header;

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -133,6 +133,18 @@ public:
     otError SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, IpProto aIpProto);
 
     /**
+     * This method sends a IPv6 datagram as Ncp Host.
+     *
+     * @param[in]  aMessage          A reference to the message.
+     * @param[in]  aInterfaceId      The interface identifier of the network interface that received the message.
+     *
+     * @retval OT_ERROR_NONE   Successfully processed the message.
+     * @retval OT_ERROR_DROP   Message processing failed and the message should be dropped.
+     *
+     */
+    otError SendFromNcpHost(Message &aMessage, int8_t aInterfaceId);
+
+    /**
      * This method processes a received IPv6 datagram.
      *
      * @param[in]  aMessage          A reference to the message.

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -133,7 +133,7 @@ public:
     otError SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, IpProto aIpProto);
 
     /**
-     * This method sends a IPv6 datagram as Ncp Host.
+     * This method sends a raw IPv6 datagram with a fully formed IPv6 header.
      *
      * @param[in]  aMessage          A reference to the message.
      * @param[in]  aInterfaceId      The interface identifier of the network interface that received the message.
@@ -142,7 +142,7 @@ public:
      * @retval OT_ERROR_DROP   Message processing failed and the message should be dropped.
      *
      */
-    otError SendFromNcpHost(Message &aMessage, int8_t aInterfaceId);
+    otError SendRaw(Message &aMessage, int8_t aInterfaceId);
 
     /**
      * This method processes a received IPv6 datagram.


### PR DESCRIPTION
This PR fixes the issue that multicast packet coming from Host will be delivered back to host once.

This issue is caused by the NCP node doesn't process the MPL header added by itself, as a result, when the multicast packets come back from other nodes, they will be treated as if the packet have never come to the NCP node.

To fixes this, this PR creates a new interface for sending IPv6 packet for host, where the packet will be added with MPL header if it's multicast and the `HandleDatagram()` will remember this multicast packet, and will not process it again.