### PR TITLE
close radio on reset

### DIFF
--- a/examples/platforms/posix/misc.c
+++ b/examples/platforms/posix/misc.c
@@ -53,6 +53,7 @@ void otPlatReset(otInstance *aInstance)
     argv[gArgumentsCount] = NULL;
 
     platformUartRestore();
+    platformRadioClose();
 
     execvp(argv[0], argv);
     perror("reset failed");

--- a/examples/platforms/posix/platform-posix.h
+++ b/examples/platforms/posix/platform-posix.h
@@ -120,6 +120,12 @@ void platformAlarmProcess(otInstance *aInstance);
 void platformRadioInit(void);
 
 /**
+ * This function close the radio service used by OpenThread.
+ *
+ */
+void platformRadioClose(void);
+
+/**
  * This function updates the file descriptor sets with file descriptors used by the radio driver.
  *
  * @param[inout]  aReadFdSet   A pointer to the read file descriptors.

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -375,6 +375,11 @@ void platformRadioInit(void)
     sAckFrame.mPsdu = sAckMessage.mPsdu;
 }
 
+void platformRadioClose(void)
+{
+    close(sSockFd);
+}
+
 bool otPlatRadioIsEnabled(otInstance *aInstance)
 {
     (void)aInstance;


### PR DESCRIPTION
This PR close the radio on reset to fixes the `port already in use` error after resetting posix simulation.