### PR TITLE
Set mbedTLS debug level according to that of OpenThread

### DIFF
--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -103,8 +103,8 @@ otError Dtls::Start(bool aClient, ConnectedHandler aConnectedHandler, ReceiveHan
     mbedtls_ctr_drbg_init(&mCtrDrbg);
     mbedtls_entropy_init(&mEntropy);
 
-    mbedtls_debug_set_threshold(4);
-
+    // mbedTLS's debug level is almost the same as OpenThread's
+    mbedtls_debug_set_threshold(OPENTHREAD_CONFIG_LOG_LEVEL);
     otPlatRadioGetIeeeEui64(GetInstance(), eui64.m8);
     rval = mbedtls_ctr_drbg_seed(&mCtrDrbg, mbedtls_entropy_func, &mEntropy, eui64.m8, sizeof(eui64));
     VerifyOrExit(rval == 0);


### PR DESCRIPTION
Currently, no matter what debug level OpenThread configured, mbedTLS's debug level is the same `4`, i.e. `DEBUG`. Although OpenThread does filter out logs according to its own log level, setting fixed debug level of mbedTLS may use more CPU.

This PR simply sets the debug level of mbedTLS according to OpenThread's configured debug level.