### PR TITLE
Timer: Make Timer implementation robust against late firing platform alarm

### DIFF
--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -250,6 +250,17 @@ public:
     static uint32_t MsecToHours(uint32_t aMilliseconds) { return MsecToSec(aMilliseconds / 3600u); }
 
 private:
+    /**
+     * This method indicates if the fire time of this timer is strictly before the fire time of a second given timer.
+     *
+     * @param[in]  aTimer   A reference to the second timer object.
+     *
+     * @retval TRUE  If the fire time of this timer object is strictly before aTimer's fire time
+     * @retval FALSE If the fire time of this timer object is the same or after aTimer's fire time.
+     *
+     */
+    bool DoesFireBefore(const Timer &aTimer);
+
     void Fired(void) { mHandler(mContext); }
 
     TimerScheduler &mScheduler;

--- a/tests/unit/test_windows.cpp
+++ b/tests/unit/test_windows.cpp
@@ -79,6 +79,7 @@ namespace ot
 
 // test_timer.cpp
 int TestOneTimer();
+int TestTwoTimers();
 int TestTenTimers();
 
 // test_toolchain.cpp
@@ -159,6 +160,7 @@ namespace ot
 
         // test_timer.cpp
         TEST_METHOD(TestOneTimer) { ::TestOneTimer(); }
+        TEST_METHOD(TestTwoTimers) { ::TestTwoTimers(); }
         TEST_METHOD(TestTenTimers) { ::TestTenTimers(); }
 
         // test_ncp_buffer.cpp


### PR DESCRIPTION
This commit changes the timer code to make the implementation robust against late firing platform alarm case. In particular, it addresses the (rare corner-case) scenario where alarm fire is late and the head timer in the linked-list is already expired and then a new timer is started with maximum interval. This can possibly violate the requirement for `TimerScheduler::IsStringlyBefore()` method that the two times being compared should not differ more than the maximum interval `Timer::kMaxDt`. To address this, a new method
`Timer::DoesFireBefore()` is added to compare fire time of two timers which checks for expired timers.

This commit also updates the timer unit test to add test cases related to the late firing alarm.

Thanks to @pvanhorn  for noticing the issue.