### PR TITLE
[iar] IAR warning fixes

### DIFF
--- a/include/openthread/platform/toolchain.h
+++ b/include/openthread/platform/toolchain.h
@@ -190,6 +190,45 @@ extern "C" {
 #endif
 
 /**
+ * @def OT_UNUSED_VARIABLE
+ *
+ * Suppress unused variable warning in specific toolchains.
+ *
+ */
+
+/**
+ * @def OT_UNREACHABLE_CODE
+ *
+ * Suppress Unreachable code warning in specific toolchains.
+ *
+ */
+
+#if defined(__ICCARM__)
+
+#define OT_UNUSED_VARIABLE(VARIABLE)    \
+    do                                  \
+    {                                   \
+        if (VARIABLE) {}                \
+    } while (false)
+
+#define OT_UNREACHABLE_CODE(CODE)       \
+    _Pragma("diag_suppress=Pe111")      \
+    CODE                                \
+    _Pragma("diag_default=Pe111")
+
+#else
+
+#define OT_UNUSED_VARIABLE(VARIABLE)    \
+    do                                  \
+    {                                   \
+        (void)(VARIABLE);               \
+    } while (false)
+
+#define OT_UNREACHABLE_CODE(CODE)  CODE
+
+#endif
+
+/**
  * @}
  *
  */

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -367,11 +367,10 @@ exit:
 otError Dataset::ProcessMasterKey(otInstance *aInstance, int argc, char *argv[])
 {
     otError error = OT_ERROR_NONE;
-    int keyLength;
     uint8_t key[OT_MASTER_KEY_SIZE];
 
     VerifyOrExit(argc > 0, error = OT_ERROR_PARSE);
-    VerifyOrExit((keyLength = Interpreter::Hex2Bin(argv[0], key, sizeof(key))) == OT_MASTER_KEY_SIZE,
+    VerifyOrExit((Interpreter::Hex2Bin(argv[0], key, sizeof(key))) == OT_MASTER_KEY_SIZE,
                  error = OT_ERROR_PARSE);
 
     memcpy(sDataset.mMasterKey.m8, key, sizeof(sDataset.mMasterKey));

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -554,7 +554,7 @@ void LinkRaw::StartCsmaBackoff(void)
     }
 
     backoff = (otPlatRandomGet() % (1UL << backoffExponent));
-    backoff *= (Mac::kUnitBackoffPeriod * OT_RADIO_SYMBOL_TIME);
+    backoff *= (static_cast<uint32_t>(Mac::kUnitBackoffPeriod) * OT_RADIO_SYMBOL_TIME);
 
 #if OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_BACKOFF_TIMER
     otPlatUsecAlarmTime now;

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1409,7 +1409,6 @@ void Mac::ReceiveDoneTask(Frame *aFrame, otError aError)
     PanId panid;
     Neighbor *neighbor;
     otMacWhitelistEntry *whitelistEntry;
-    otMacBlacklistEntry *blacklistEntry;
     int8_t rssi;
     bool receive = false;
     uint8_t commandId;
@@ -1479,7 +1478,7 @@ void Mac::ReceiveDoneTask(Frame *aFrame, otError aError)
     // Source Blacklist Processing
     if (srcaddr.mLength != 0 && mBlacklist.IsEnabled())
     {
-        VerifyOrExit((blacklistEntry = mBlacklist.Find(srcaddr.mExtAddress)) == NULL, error = OT_ERROR_BLACKLIST_FILTERED);
+        VerifyOrExit((mBlacklist.Find(srcaddr.mExtAddress)) == NULL, error = OT_ERROR_BLACKLIST_FILTERED);
     }
 
     // Destination Address Filtering
@@ -1665,8 +1664,6 @@ exit:
             break;
         }
     }
-
-    OT_UNUSED_VARIABLE(blacklistEntry);
 }
 
 otError Mac::HandleMacCommand(Frame &aFrame)

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -96,7 +96,7 @@ void Mac::StartCsmaBackoff(void)
         }
 
         backoff = (otPlatRandomGet() % (1UL << backoffExponent));
-        backoff *= (kUnitBackoffPeriod * OT_RADIO_SYMBOL_TIME);
+        backoff *= (static_cast<uint32_t>(kUnitBackoffPeriod) * OT_RADIO_SYMBOL_TIME);
 
 #if OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_BACKOFF_TIMER
         otPlatUsecAlarmTime now;
@@ -1665,6 +1665,8 @@ exit:
             break;
         }
     }
+
+    OT_UNUSED_VARIABLE(blacklistEntry);
 }
 
 otError Mac::HandleMacCommand(Frame &aFrame)

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -491,7 +491,7 @@ otError Dtls::MapError(int rval)
 void Dtls::HandleMbedtlsDebug(void *ctx, int level, const char *, int, const char *str)
 {
     Dtls *pThis = static_cast<Dtls *>(ctx);
-    (void)pThis;
+    OT_UNUSED_VARIABLE(pThis);
 
     switch (level)
     {

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -446,7 +446,13 @@ void Joiner::HandleJoinerEntrust(Coap::Header &aHeader, Message &aMessage, const
     mTimer.Start(kConfigExtAddressDelay);
 
 exit:
-    OT_UNUSED_VARIABLE(error);
+
+    if (error != OT_ERROR_NONE)
+    {
+        otLogWarnMeshCoP(GetInstance(), "Error while processing joiner entrust: %s",
+                         otThreadErrorToString(error));
+    }
+
     otLogFuncExit();
 }
 

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -446,6 +446,7 @@ void Joiner::HandleJoinerEntrust(Coap::Header &aHeader, Message &aMessage, const
     mTimer.Start(kConfigExtAddressDelay);
 
 exit:
+    OT_UNUSED_VARIABLE(error);
     otLogFuncExit();
 }
 

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -491,6 +491,7 @@ void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessag
     }
 
 exit:
+    OT_UNUSED_VARIABLE(error);
     return;
 }
 

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -491,7 +491,13 @@ void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessag
     }
 
 exit:
-    OT_UNUSED_VARIABLE(error);
+
+    if (error != OT_ERROR_NONE)
+    {
+        otLogWarnArp(GetInstance(), "Error while processing address error notification: %s",
+                     otThreadErrorToString(error));
+    }
+
     return;
 }
 

--- a/src/core/thread/data_poll_manager.cpp
+++ b/src/core/thread/data_poll_manager.cpp
@@ -380,7 +380,8 @@ uint32_t DataPollManager::CalculatePollPeriod(void) const
 
     if (period == 0)
     {
-        period = Timer::SecToMsec(mMeshForwarder.GetNetif().GetMle().GetTimeout()) -  kRetxPollPeriod * kMaxPollRetxAttempts;
+        period = Timer::SecToMsec(mMeshForwarder.GetNetif().GetMle().GetTimeout()) -
+                 static_cast<uint32_t>(kRetxPollPeriod) * kMaxPollRetxAttempts;
 
         if (period == 0)
         {

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -333,7 +333,7 @@ void MeshForwarder::ScheduleTransmissionTask(void)
     }
 
 exit:
-    (void) error;
+    OT_UNUSED_VARIABLE(error);
 }
 
 otError MeshForwarder::SendMessage(Message &aMessage)

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -333,7 +333,12 @@ void MeshForwarder::ScheduleTransmissionTask(void)
     }
 
 exit:
-    OT_UNUSED_VARIABLE(error);
+
+    if (error != OT_ERROR_NONE)
+    {
+        otLogWarnMac(GetInstance(), "Error while scheduling transmission task: %s",
+                     otThreadErrorToString(error));
+    }
 }
 
 otError MeshForwarder::SendMessage(Message &aMessage)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -590,7 +590,8 @@ otError Mle::SetStateChild(uint16_t aRloc16)
 
     if ((mDeviceMode & ModeTlv::kModeRxOnWhenIdle) != 0)
     {
-        mParentRequestTimer.Start(Timer::SecToMsec(mTimeout) - kUnicastRetransmissionDelay * kMaxChildKeepAliveAttempts);
+        mParentRequestTimer.Start(Timer::SecToMsec(mTimeout) -
+                                  static_cast<uint32_t>(kUnicastRetransmissionDelay) * kMaxChildKeepAliveAttempts);
     }
 
     if ((mDeviceMode & ModeTlv::kModeFFD) != 0)
@@ -2979,7 +2980,8 @@ otError Mle::HandleChildUpdateResponse(const Message &aMessage, const Ip6::Messa
         }
         else
         {
-            mParentRequestTimer.Start(Timer::SecToMsec(mTimeout) - kUnicastRetransmissionDelay * kMaxChildKeepAliveAttempts);
+            mParentRequestTimer.Start(Timer::SecToMsec(mTimeout) -
+                                      static_cast<uint32_t>(kUnicastRetransmissionDelay) * kMaxChildKeepAliveAttempts);
             mNetif.GetMeshForwarder().SetRxOnWhenIdle(true);
         }
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -857,7 +857,6 @@ void NcpBase::HandleRawFrame(const otRadioFrame *aFrame, void *aContext)
 
 void NcpBase::HandleRawFrame(const otRadioFrame *aFrame)
 {
-    otError error = OT_ERROR_NONE;
     uint16_t flags = 0;
 
     if (!mIsRawStreamEnabled)
@@ -865,7 +864,7 @@ void NcpBase::HandleRawFrame(const otRadioFrame *aFrame)
         goto exit;
     }
 
-    SuccessOrExit(error = OutboundFrameBegin());
+    SuccessOrExit(OutboundFrameBegin());
 
     if (aFrame->mDidTX)
     {
@@ -874,40 +873,39 @@ void NcpBase::HandleRawFrame(const otRadioFrame *aFrame)
 
     // Append frame header and frame length
     SuccessOrExit(
-        error = OutboundFrameFeedPacked(
-                    SPINEL_DATATYPE_COMMAND_PROP_S SPINEL_DATATYPE_UINT16_S,
-                    SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
-                    SPINEL_CMD_PROP_VALUE_IS,
-                    SPINEL_PROP_STREAM_RAW,
-                    aFrame->mLength
-                ));
+        OutboundFrameFeedPacked(
+            SPINEL_DATATYPE_COMMAND_PROP_S SPINEL_DATATYPE_UINT16_S,
+            SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
+            SPINEL_CMD_PROP_VALUE_IS,
+            SPINEL_PROP_STREAM_RAW,
+            aFrame->mLength
+        ));
 
     // Append the frame contents
-    SuccessOrExit(error = OutboundFrameFeedData(aFrame->mPsdu, aFrame->mLength));
+    SuccessOrExit(OutboundFrameFeedData(aFrame->mPsdu, aFrame->mLength));
 
     // Append metadata (rssi, etc)
     SuccessOrExit(
-        error = OutboundFrameFeedPacked(
-                    SPINEL_DATATYPE_INT8_S
-                    SPINEL_DATATYPE_INT8_S
-                    SPINEL_DATATYPE_UINT16_S
-                    SPINEL_DATATYPE_STRUCT_S(  // PHY-data
-                        SPINEL_DATATYPE_NULL_S // Empty for now
-                    )
-                    SPINEL_DATATYPE_STRUCT_S(  // Vendor-data
-                        SPINEL_DATATYPE_NULL_S // Empty for now
-                    ),
-                    aFrame->mPower,   // TX Power
-                    -128,             // Noise Floor (Currently unused)
-                    flags             // Flags
+        OutboundFrameFeedPacked(
+            SPINEL_DATATYPE_INT8_S
+            SPINEL_DATATYPE_INT8_S
+            SPINEL_DATATYPE_UINT16_S
+            SPINEL_DATATYPE_STRUCT_S(  // PHY-data
+                SPINEL_DATATYPE_NULL_S // Empty for now
+            )
+            SPINEL_DATATYPE_STRUCT_S(  // Vendor-data
+                SPINEL_DATATYPE_NULL_S // Empty for now
+            ),
+            aFrame->mPower,   // TX Power
+            -128,             // Noise Floor (Currently unused)
+            flags             // Flags
 
-                   // Skip PHY and Vendor data for now
-                ));
+           // Skip PHY and Vendor data for now
+        ));
 
-    SuccessOrExit(error = OutboundFrameSend());
+    SuccessOrExit(OutboundFrameSend());
 
 exit:
-    OT_UNUSED_VARIABLE(error);
     return;
 }
 
@@ -1042,10 +1040,9 @@ void NcpBase::LinkRawReceiveDone(otInstance *, otRadioFrame *aFrame, otError aEr
 
 void NcpBase::LinkRawReceiveDone(otRadioFrame *aFrame, otError aError)
 {
-    otError error = OT_ERROR_NONE;
     uint16_t flags = 0;
 
-    SuccessOrExit(error = OutboundFrameBegin());
+    SuccessOrExit(OutboundFrameBegin());
 
     if (aFrame->mDidTX)
     {
@@ -1054,45 +1051,44 @@ void NcpBase::LinkRawReceiveDone(otRadioFrame *aFrame, otError aError)
 
     // Append frame header and frame length
     SuccessOrExit(
-        error = OutboundFrameFeedPacked(
-                    SPINEL_DATATYPE_COMMAND_PROP_S SPINEL_DATATYPE_UINT16_S,
-                    SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
-                    SPINEL_CMD_PROP_VALUE_IS,
-                    SPINEL_PROP_STREAM_RAW,
-                    (aError == OT_ERROR_NONE) ? aFrame->mLength : 0
-                ));
+        OutboundFrameFeedPacked(
+            SPINEL_DATATYPE_COMMAND_PROP_S SPINEL_DATATYPE_UINT16_S,
+            SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0,
+            SPINEL_CMD_PROP_VALUE_IS,
+            SPINEL_PROP_STREAM_RAW,
+            (aError == OT_ERROR_NONE) ? aFrame->mLength : 0
+        ));
 
     if (aError == OT_ERROR_NONE)
     {
         // Append the frame contents
-        SuccessOrExit(error = OutboundFrameFeedData(aFrame->mPsdu, aFrame->mLength));
+        SuccessOrExit(OutboundFrameFeedData(aFrame->mPsdu, aFrame->mLength));
     }
 
     // Append metadata (rssi, etc)
     SuccessOrExit(
-        error = OutboundFrameFeedPacked(
-                    SPINEL_DATATYPE_INT8_S
-                    SPINEL_DATATYPE_INT8_S
-                    SPINEL_DATATYPE_UINT16_S
-                    SPINEL_DATATYPE_STRUCT_S( // PHY-data
-                        SPINEL_DATATYPE_UINT8_S // 802.15.4 channel
-                        SPINEL_DATATYPE_UINT8_S // 802.15.4 LQI
-                    )
-                    SPINEL_DATATYPE_STRUCT_S( // Vendor-data
-                        SPINEL_DATATYPE_UINT_PACKED_S
-                    ),
-                    aFrame->mPower,    // TX Power
-                    -128,              // Noise Floor (Currently unused)
-                    flags,             // Flags
-                    aFrame->mChannel,  // Receive channel
-                    aFrame->mLqi,      // Link quality indicator
-                    aError             // Receive error
-                ));
+        OutboundFrameFeedPacked(
+            SPINEL_DATATYPE_INT8_S
+            SPINEL_DATATYPE_INT8_S
+            SPINEL_DATATYPE_UINT16_S
+            SPINEL_DATATYPE_STRUCT_S( // PHY-data
+                SPINEL_DATATYPE_UINT8_S // 802.15.4 channel
+                SPINEL_DATATYPE_UINT8_S // 802.15.4 LQI
+            )
+            SPINEL_DATATYPE_STRUCT_S( // Vendor-data
+                SPINEL_DATATYPE_UINT_PACKED_S
+            ),
+            aFrame->mPower,    // TX Power
+            -128,              // Noise Floor (Currently unused)
+            flags,             // Flags
+            aFrame->mChannel,  // Receive channel
+            aFrame->mLqi,      // Link quality indicator
+            aError             // Receive error
+        ));
 
-    SuccessOrExit(error = OutboundFrameSend());
+    SuccessOrExit(OutboundFrameSend());
 
 exit:
-    OT_UNUSED_VARIABLE(error);
     return;
 }
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -475,7 +475,7 @@ static spinel_status_t ThreadErrorToSpinelStatus(otError aError)
 
     default:
         // Unknown error code. Wrap it as a Spinel status and return that.
-        ret = static_cast<spinel_status_t>(SPINEL_STATUS_STACK_NATIVE__BEGIN + aError);
+        ret = static_cast<spinel_status_t>(SPINEL_STATUS_STACK_NATIVE__BEGIN + static_cast<uint32_t>(aError));
         break;
     }
 
@@ -907,6 +907,7 @@ void NcpBase::HandleRawFrame(const otRadioFrame *aFrame)
     SuccessOrExit(error = OutboundFrameSend());
 
 exit:
+    OT_UNUSED_VARIABLE(error);
     return;
 }
 
@@ -1091,6 +1092,7 @@ void NcpBase::LinkRawReceiveDone(otRadioFrame *aFrame, otError aError)
     SuccessOrExit(error = OutboundFrameSend());
 
 exit:
+    OT_UNUSED_VARIABLE(error);
     return;
 }
 
@@ -3694,7 +3696,6 @@ otError NcpBase::GetPropertyHandler_MAC_CNTR(uint8_t aHeader, spinel_prop_key_t 
     default:
         error = SendLastStatus(aHeader, SPINEL_STATUS_INTERNAL_ERROR);
         ExitNow();
-        break;
     }
 
     error = SendPropertyUpdate(
@@ -3759,7 +3760,6 @@ otError NcpBase::GetPropertyHandler_NCP_CNTR(uint8_t aHeader, spinel_prop_key_t 
     default:
         error = SendLastStatus(aHeader, SPINEL_STATUS_INTERNAL_ERROR);
         ExitNow();
-        break;
     }
 
     error = SendPropertyUpdate(
@@ -3886,13 +3886,15 @@ otError NcpBase::GetPropertyHandler_DEBUG_TEST_ASSERT(uint8_t aHeader, spinel_pr
     // In such a case we return `false` as the
     // property value to indicate this.
 
-    return SendPropertyUpdate(
-               aHeader,
-               SPINEL_CMD_PROP_VALUE_IS,
-               aKey,
-               SPINEL_DATATYPE_BOOL_S,
-               false
-           );
+    OT_UNREACHABLE_CODE(
+        return SendPropertyUpdate(
+                aHeader,
+                SPINEL_CMD_PROP_VALUE_IS,
+                aKey,
+                SPINEL_DATATYPE_BOOL_S,
+                false
+            );
+    )
 }
 
 otError NcpBase::GetPropertyHandler_DEBUG_NCP_LOG_LEVEL(uint8_t aHeader, spinel_prop_key_t aKey)
@@ -5125,9 +5127,9 @@ otError NcpBase::SetPropertyHandler_STREAM_NET_INSECURE(uint8_t aHeader, spinel_
 
     // We ignore metadata for now.
     // May later include TX power, allow retransmits, etc...
-    (void)metaPtr;
-    (void)metaLen;
-    (void)parsedLength;
+    OT_UNUSED_VARIABLE(metaPtr);
+    OT_UNUSED_VARIABLE(metaLen);
+    OT_UNUSED_VARIABLE(parsedLength);
 
     SuccessOrExit(error = otMessageAppend(message, framePtr, static_cast<uint16_t>(frameLen)));
 
@@ -5268,9 +5270,9 @@ otError NcpBase::SetPropertyHandler_STREAM_NET(uint8_t aHeader, spinel_prop_key_
 
     // We ignore metadata for now.
     // May later include TX power, allow retransmits, etc...
-    (void)metaPtr;
-    (void)metaLen;
-    (void)parsedLength;
+    OT_UNUSED_VARIABLE(metaPtr);
+    OT_UNUSED_VARIABLE(metaLen);
+    OT_UNUSED_VARIABLE(parsedLength);
 
     SuccessOrExit(error = otMessageAppend(message, framePtr, static_cast<uint16_t>(frameLen)));
 
@@ -5306,7 +5308,7 @@ exit:
         error = SendLastStatus(aHeader, ThreadErrorToSpinelStatus(error));
     }
 
-    (void)aKey;
+    OT_UNUSED_VARIABLE(aKey);
 
     return error;
 }


### PR DESCRIPTION
This PR introduces some minor changes that fix warnings thrown by IAR when compiling OpenThread source.

Warnings that IAR produced were:
- Mixed enum types in single statements,
- Variable assigned but not used (IAR does not seem to honor void casting in that case),
- Unreachable code after assert.

The code was compiled with IAR 8.11.
