### PR TITLE
fix get parent priority issue

### DIFF
--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -1023,7 +1023,7 @@ public:
      * @returns The Parent Priority value.
      *
      */
-    int8_t GetParentPriority(void) const { return (mParentPriority & kParentPriorityMask) >> kParentPriorityOffset; }
+    int8_t GetParentPriority(void) const { return (static_cast<int8_t>(mParentPriority & kParentPriorityMask)) >> kParentPriorityOffset; }
 
     /**
      * This method sets the Parent Priority value.


### PR DESCRIPTION
The previous `GetParentPriority()` returns `3` instead of `-1` when the priority is `-1 (11) Low`.