### PR TITLE
[instance] single instance optimization feature

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -507,6 +507,37 @@ AC_MSG_CHECKING([sould NCP support UART])
 AC_MSG_RESULT([${OPENTHREAD_ENABLE_UART}])
 
 #
+# Multiple OpenThread Instances
+#
+
+AC_ARG_ENABLE(multiple-instances,
+    [AS_HELP_STRING([--enable-multiple-instances],[Enable support for multiple OpenThread instances @<:@default=no@:>@.])],
+    [
+        case "${enableval}" in
+
+        no|yes)
+            enable_multiple_instances=${enableval}
+            ;;
+
+        *)
+            AC_MSG_ERROR([Invalid value ${enable_multiple_instances} for --enable-multiple-instances])
+            ;;
+        esac
+    ],
+    [enable_multiple_instances=no])
+
+if test "$enable_multiple_instances" = "yes"; then
+    OPENTHREAD_ENABLE_MULTIPLE_INSTANCES=1
+else
+    OPENTHREAD_ENABLE_MULTIPLE_INSTANCES=0
+fi
+
+AC_MSG_RESULT(${enable_multiple_instances})
+AC_SUBST(OPENTHREAD_ENABLE_MULTIPLE_INSTANCES)
+AM_CONDITIONAL([OPENTHREAD_ENABLE_MULTIPLE_INSTANCES], [test "${enable_multiple_instances}" = "yes"])
+AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_MULTIPLE_INSTANCES],[${OPENTHREAD_ENABLE_MULTIPLE_INSTANCES}],[Define to 1 if you want to enable support for multiple OpenThread instances.])
+
+#
 # Builtin mbedtls
 #
 
@@ -1382,6 +1413,7 @@ AC_MSG_NOTICE([
   OpenThread NCP-MTD support                : ${enable_ncp_app_mtd}
   OpenThread NCP-FTD support                : ${enable_ncp_app_ftd}
   OpenThread NCP-BUS Configuration          : ${with_ncp_bus}
+  OpenThread Multiple Instances support     : ${enable_multiple_instances}
   OpenThread MTD Network Diagnostic support : ${enable_mtd_network_diagnostic}
   OpenThread builtin mbedtls support        : ${enable_builtin_mbedtls}
   OpenThread TMF Proxy support              : ${enable_tmf_proxy}

--- a/etc/visual-studio/UnitTests.vcxproj
+++ b/etc/visual-studio/UnitTests.vcxproj
@@ -49,7 +49,6 @@
         %(PreprocessorDefinitions)
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
-        OPENTHREAD_MULTIPLE_INSTANCE;
         OPENTHREAD_FTD=1;
       </PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/etc/visual-studio/libopenthread-cli.vcxproj
+++ b/etc/visual-studio/libopenthread-cli.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="openthread.configuration.props" /> 
+  <Import Project="openthread.configuration.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{41B32069-632E-4578-855B-A36EBFA80B56}</ProjectGuid>
     <Keyword>StaticLibrary</Keyword>
@@ -40,7 +40,6 @@
         %(PreprocessorDefinitions);
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
-        OPENTHREAD_MULTIPLE_INSTANCE;
         OPENTHREAD_FTD=1;
         OTBUILD;
       </PreprocessorDefinitions>

--- a/etc/visual-studio/libopenthread-ncp-spi.vcxproj
+++ b/etc/visual-studio/libopenthread-ncp-spi.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="openthread.configuration.props" /> 
+  <Import Project="openthread.configuration.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B92F449E-0FD9-44FC-ACFA-6521A3240CA2}</ProjectGuid>
     <Keyword>StaticLibrary</Keyword>
@@ -40,7 +40,6 @@
         %(PreprocessorDefinitions);
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
-        OPENTHREAD_MULTIPLE_INSTANCE;
         OPENTHREAD_FTD=1;
         OPENTHREAD_ENABLE_NCP_SPI=1;
         OPENTHREAD_ENABLE_NCP_UART=0;

--- a/etc/visual-studio/libopenthread-ncp-uart.vcxproj
+++ b/etc/visual-studio/libopenthread-ncp-uart.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="openthread.configuration.props" /> 
+  <Import Project="openthread.configuration.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D94867D2-6DAE-47E2-962A-5E8E658134D1}</ProjectGuid>
     <Keyword>StaticLibrary</Keyword>
@@ -40,7 +40,6 @@
         %(PreprocessorDefinitions);
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
-        OPENTHREAD_MULTIPLE_INSTANCE;
         OPENTHREAD_FTD=1;
         OPENTHREAD_ENABLE_NCP_SPI=0;
         OPENTHREAD_ENABLE_NCP_UART=1;

--- a/etc/visual-studio/libopenthread.vcxproj
+++ b/etc/visual-studio/libopenthread.vcxproj
@@ -40,7 +40,6 @@
         %(PreprocessorDefinitions);
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
-        OPENTHREAD_MULTIPLE_INSTANCE;
         OPENTHREAD_FTD=1;
         OTBUILD;
       </PreprocessorDefinitions>
@@ -77,6 +76,7 @@
     <ClCompile Include="..\..\src\core\coap\coap_header.cpp" />
     <ClCompile Include="..\..\src\core\coap\coap_secure.cpp" />
     <ClCompile Include="..\..\src\core\common\crc16.cpp" />
+    <ClCompile Include="..\..\src\core\common\locator.cpp" />
     <ClCompile Include="..\..\src\core\common\logging.cpp" />
     <ClCompile Include="..\..\src\core\common\message.cpp" />
     <ClCompile Include="..\..\src\core\common\tasklet.cpp" />
@@ -149,8 +149,10 @@
     <ClInclude Include="..\..\src\core\coap\coap_secure.hpp" />
     <ClInclude Include="..\..\src\core\common\code_utils.hpp" />
     <ClInclude Include="..\..\src\core\common\crc16.hpp" />
+    <ClInclude Include="..\..\src\core\common\context.hpp" />
     <ClInclude Include="..\..\src\core\common\debug.hpp" />
     <ClInclude Include="..\..\src\core\common\encoding.hpp" />
+    <ClInclude Include="..\..\src\core\common\locator.hpp" />
     <ClInclude Include="..\..\src\core\common\logging.hpp" />
     <ClInclude Include="..\..\src\core\common\message.hpp" />
     <ClInclude Include="..\..\src\core\common\new.hpp" />

--- a/etc/visual-studio/libopenthread.vcxproj.filters
+++ b/etc/visual-studio/libopenthread.vcxproj.filters
@@ -126,6 +126,9 @@
     <ClCompile Include="..\..\src\core\coap\coap_secure.cpp">
       <Filter>Source Files\coap</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\core\common\locator.cpp">
+      <Filter>Source Files\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\core\common\logging.cpp">
       <Filter>Source Files\common</Filter>
     </ClCompile>
@@ -335,10 +338,16 @@
     <ClInclude Include="..\..\src\core\common\code_utils.hpp">
       <Filter>Header Files\common</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\core\common\context.hpp">
+      <Filter>Header Files\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\core\common\debug.hpp">
       <Filter>Header Files\common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\core\common\encoding.hpp">
+      <Filter>Header Files\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\common\locator.hpp">
       <Filter>Header Files\common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\core\common\logging.hpp">

--- a/etc/visual-studio/libopenthread_k.vcxproj
+++ b/etc/visual-studio/libopenthread_k.vcxproj
@@ -42,7 +42,6 @@
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
         OPENTHREAD_PROJECT_CORE_CONFIG_FILE="openthread-core-windows-config.h";
         WINDOWS_LOGGING;
-        OPENTHREAD_MULTIPLE_INSTANCE;
         OPENTHREAD_FTD=1;
         HAVE_STDBOOL_H=1;
         HAVE_STDINT_H=1;
@@ -86,6 +85,7 @@
     <ClCompile Include="..\..\src\core\coap\coap_header.cpp" />
     <ClCompile Include="..\..\src\core\coap\coap_secure.cpp" />
     <ClCompile Include="..\..\src\core\common\crc16.cpp" />
+    <ClCompile Include="..\..\src\core\common\locator.cpp" />
     <ClCompile Include="..\..\src\core\common\logging.cpp" />
     <ClCompile Include="..\..\src\core\common\message.cpp" />
     <ClCompile Include="..\..\src\core\common\tasklet.cpp" />
@@ -180,9 +180,11 @@
     <ClInclude Include="..\..\src\core\coap\coap_header.hpp" />
     <ClInclude Include="..\..\src\core\coap\coap_secure.hpp" />
     <ClInclude Include="..\..\src\core\common\code_utils.hpp" />
+    <ClInclude Include="..\..\src\core\common\context.hpp" />
     <ClInclude Include="..\..\src\core\common\crc16.hpp" />
     <ClInclude Include="..\..\src\core\common\debug.hpp" />
     <ClInclude Include="..\..\src\core\common\encoding.hpp" />
+    <ClInclude Include="..\..\src\core\common\locator.hpp" />
     <ClInclude Include="..\..\src\core\common\logging.hpp" />
     <ClInclude Include="..\..\src\core\common\message.hpp" />
     <ClInclude Include="..\..\src\core\common\new.hpp" />

--- a/etc/visual-studio/libopenthread_k.vcxproj.filters
+++ b/etc/visual-studio/libopenthread_k.vcxproj.filters
@@ -126,6 +126,9 @@
     <ClCompile Include="..\..\src\core\coap\coap_secure.cpp">
       <Filter>Source Files\coap</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\core\common\locator.cpp">
+      <Filter>Source Files\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\core\common\logging.cpp">
       <Filter>Source Files\common</Filter>
     </ClCompile>
@@ -335,10 +338,16 @@
     <ClInclude Include="..\..\src\core\common\code_utils.hpp">
       <Filter>Header Files\common</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\core\common\context.hpp">
+      <Filter>Header Files\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\core\common\debug.hpp">
       <Filter>Header Files\common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\core\common\encoding.hpp">
+      <Filter>Header Files\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\common\locator.hpp">
       <Filter>Header Files\common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\core\common\logging.hpp">

--- a/etc/visual-studio/mbedtls.vcxproj
+++ b/etc/visual-studio/mbedtls.vcxproj
@@ -39,7 +39,7 @@
       <PreprocessorDefinitions>
         ;%(PreprocessorDefinitions);
         MBEDTLS_CONFIG_FILE="mbedtls-config.h";
-        OPENTHREAD_MULTIPLE_INSTANCE;
+        OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         ..\..\include;

--- a/etc/visual-studio/mbedtls_k.vcxproj
+++ b/etc/visual-studio/mbedtls_k.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="openthread.configuration.props" /> 
+  <Import Project="openthread.configuration.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{69BE8E8C-CF1E-46D6-932B-DB435F47059B}</ProjectGuid>
     <TemplateGuid>{8c0e3d8b-df43-455b-815a-4a0e72973bc6}</TemplateGuid>
@@ -50,7 +50,6 @@
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
         HAVE_STDBOOL_H=1;
         HAVE_STDINT_H=1;
-        OPENTHREAD_MULTIPLE_INSTANCE;
       </PreprocessorDefinitions>
       <DisableSpecificWarnings>4132;4242;4245;4603;4627;4986;4987;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <WarningLevel>Level4</WarningLevel>

--- a/etc/visual-studio/ot-cli.vcxproj
+++ b/etc/visual-studio/ot-cli.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="openthread.configuration.props" /> 
+  <Import Project="openthread.configuration.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{91D3ADEA-F1FE-4433-95B6-F8F6A7CF7BAF}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -40,7 +40,6 @@
         %(PreprocessorDefinitions);
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
         OPENTHREAD_FTD=1;
-        OPENTHREAD_MULTIPLE_INSTANCE;
       </PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);

--- a/etc/visual-studio/ot-ncp-spi.vcxproj
+++ b/etc/visual-studio/ot-ncp-spi.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="openthread.configuration.props" /> 
+  <Import Project="openthread.configuration.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B4C744EC-B662-46C6-A076-FB58FA8FDF1B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -40,7 +40,6 @@
         %(PreprocessorDefinitions);
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
         OPENTHREAD_FTD=1;
-        OPENTHREAD_MULTIPLE_INSTANCE;
         OPENTHREAD_ENABLE_NCP_SPI=1;
         OPENTHREAD_ENABLE_NCP_UART=0;
       </PreprocessorDefinitions>

--- a/etc/visual-studio/ot-ncp-uart.vcxproj
+++ b/etc/visual-studio/ot-ncp-uart.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="openthread.configuration.props" /> 
+  <Import Project="openthread.configuration.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{9EEF9DCD-EA8F-4154-BD02-AB2B31CEC324}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -40,7 +40,6 @@
         %(PreprocessorDefinitions);
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
         OPENTHREAD_FTD=1;
-        OPENTHREAD_MULTIPLE_INSTANCE;
         OPENTHREAD_ENABLE_NCP_SPI=0;
         OPENTHREAD_ENABLE_NCP_UART=1;
       </PreprocessorDefinitions>

--- a/etc/visual-studio/otLwf.vcxproj
+++ b/etc/visual-studio/otLwf.vcxproj
@@ -43,7 +43,6 @@
         OPENTHREAD_FTD=1;
         OPENTHREAD_CONFIG_FILE="openthread-windows-config.h";
         OPENTHREAD_PROJECT_CORE_CONFIG_FILE="openthread-core-windows-config.h";
-        OPENTHREAD_MULTIPLE_INSTANCE;
       </PreProcessorDefinitions>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);

--- a/examples/apps/ncp/main.c
+++ b/examples/apps/ncp/main.c
@@ -35,7 +35,7 @@
 #include <openthread/openthread.h>
 #include <openthread/platform/platform.h>
 
-#ifdef OPENTHREAD_MULTIPLE_INSTANCE
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
 void *otPlatCAlloc(size_t aNum, size_t aSize)
 {
     return calloc(aNum, aSize);
@@ -56,14 +56,14 @@ int main(int argc, char *argv[])
 {
     otInstance *sInstance;
 
-#ifdef OPENTHREAD_MULTIPLE_INSTANCE
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
     size_t otInstanceBufferLength = 0;
     uint8_t *otInstanceBuffer = NULL;
 #endif
 
     PlatformInit(argc, argv);
 
-#ifdef OPENTHREAD_MULTIPLE_INSTANCE
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
     // Call to query the buffer size
     (void)otInstanceInit(NULL, &otInstanceBufferLength);
 
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
     // Initialize OpenThread with the buffer
     sInstance = otInstanceInit(otInstanceBuffer, &otInstanceBufferLength);
 #else
-    sInstance = otInstanceInit();
+    sInstance = otInstanceInitSingle();
 #endif
     assert(sInstance);
 
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
     }
 
     // otInstanceFinalize(sInstance);
-#ifdef OPENTHREAD_MULTIPLE_INSTANCE
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
     // free(otInstanceBuffer);
 #endif
 

--- a/include/openthread-windows-config.h
+++ b/include/openthread-windows-config.h
@@ -32,6 +32,10 @@
 /* Define to 1 to enable the NCP SPI interface. */
 // On the command line: #define OPENTHREAD_ENABLE_NCP_SPI  1
 
+/* Define to 1 if you want to enable support for multiple OpenThread
+   instances. */
+#define OPENTHREAD_ENABLE_MULTIPLE_INSTANCES 1
+
 /* Define to 1 if you want to enable default log output. */
 #define OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT 1
 

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -35,6 +35,8 @@
 #ifndef OPENTHREAD_INSTANCE_H_
 #define OPENTHREAD_INSTANCE_H_
 
+#include <stdlib.h>
+
 #include <openthread/types.h>
 #include <openthread/platform/logging.h>
 
@@ -157,16 +159,18 @@ OTAPI uint32_t OTCALL otGetCompartmentId(otInstance *aInstance);
 
 #else // OTDLL
 
-#ifdef OPENTHREAD_MULTIPLE_INSTANCE
 /**
  * This function initializes the OpenThread library.
+ *
  *
  * This function initializes OpenThread and prepares it for subsequent OpenThread API calls.  This function must be
  * called before any other calls to OpenThread. By default, OpenThread is initialized in the 'enabled' state.
  *
+ * This function is available and can only be used when support for multiple OpenThread instances is enabled.
+ *
  * @param[in]    aInstanceBuffer      The buffer for OpenThread to use for allocating the otInstance structure.
- * @param[inout] aInstanceBufferSize  On input, the size of aInstanceBuffer. On output, if not enough space for otInstance,
-                                      the number of bytes required for otInstance.
+ * @param[inout] aInstanceBufferSize  On input, the size of aInstanceBuffer. On output, if not enough space for
+ *                                    otInstance, the number of bytes required for otInstance.
  *
  * @retval otInstance*  The new OpenThread instance structure.
  *
@@ -174,18 +178,19 @@ OTAPI uint32_t OTCALL otGetCompartmentId(otInstance *aInstance);
  *
  */
 otInstance *otInstanceInit(void *aInstanceBuffer, size_t *aInstanceBufferSize);
-#else // OPENTHREAD_MULTIPLE_INSTANCE
+
 /**
- * This function initializes the static instance of the OpenThread library.
+ * This function initializes the static single instance of the OpenThread library.
  *
  * This function initializes OpenThread and prepares it for subsequent OpenThread API calls.  This function must be
  * called before any other calls to OpenThread. By default, OpenThread is initialized in the 'enabled' state.
  *
- * @retval otInstance*  The new OpenThread instance structure.
+ * This function is available and can only be used when support for multiple OpenThread instances is disabled.
+ *
+ * @retval The new single OpenThread instance structure.
  *
  */
-otInstance *otInstanceInit(void);
-#endif // OPENTHREAD_MULTIPLE_INSTANCE
+otInstance *otInstanceInitSingle(void);
 
 /**
  * This function disables the OpenThread library.

--- a/include/openthread/platform/memory.h
+++ b/include/openthread/platform/memory.h
@@ -49,9 +49,9 @@ extern "C" {
  *
  */
 
-// Currently, OpenThread only requires dynamic memory allocation when supporting multiple
-// simultaneous instances, for MbedTls.
-#ifdef OPENTHREAD_MULTIPLE_INSTANCE
+/*
+ * OpenThread only requires dynamic memory allocation when supporting multiple simultaneous instances, for MbedTls.
+ */
 
 /**
  * Dynamically allocates new memory. On platforms that support it, should just redirect to calloc. For
@@ -60,6 +60,8 @@ extern "C" {
  *   "The calloc() function contiguously allocates enough space for count objects that are size bytes of
  *   memory each and returns a pointer to the allocated memory. The allocated memory is filled with bytes
  *   of value zero."
+ *
+ * This function is available and can ONLY be used only when support for multiple OpenThread instances is enabled.
  *
  * @param[in] aNum   The number of blocks to allocate
  * @param[in] aSize  The size of each block to allocate
@@ -72,11 +74,11 @@ void *otPlatCAlloc(size_t aNum, size_t aSize);
 /**
  * Frees memory that was dynamically allocated.
  *
+ * This function is available and can ONLY be used only when support for multiple OpenThread instances is enabled.
+ *
  * @param[in] aPtr  A pointer the memory blocks to free. The pointer may be NULL.
  */
 void otPlatFree(void *aPtr);
-
-#endif
 
 /**
  * @}

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1682,9 +1682,9 @@ exit:
     AppendResult(error);
 }
 
-void Interpreter::s_HandlePingTimer(void *aContext)
+void Interpreter::s_HandlePingTimer(Timer &aTimer)
 {
-    static_cast<Interpreter *>(aContext)->HandlePingTimer();
+    GetOwner(aTimer).HandlePingTimer();
 }
 
 void Interpreter::HandlePingTimer()
@@ -3180,6 +3180,17 @@ void Interpreter::HandleDiagnosticGetResponse(Message &aMessage, const Ip6::Mess
     mServer->OutputFormat("\r\n");
 }
 #endif
+
+Interpreter &Interpreter::GetOwner(const Context &aContext)
+{
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    Interpreter &interpreter = *static_cast<Interpreter *>(aContext.GetContext());
+#else
+    Interpreter &interpreter = Uart::sUartServer->GetInterpreter();
+    OT_UNUSED_VARIABLE(aContext);
+#endif
+    return interpreter;
+}
 
 }  // namespace Cli
 }  // namespace ot

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -50,6 +50,7 @@
 #endif
 
 #include "common/code_utils.hpp"
+#include "common/context.hpp"
 
 #ifndef OTDLL
 #include <openthread/dhcp6_client.h>
@@ -283,7 +284,7 @@ private:
 #ifndef OTDLL
     static void s_HandleIcmpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo,
                                     const otIcmp6Header *aIcmpHeader);
-    static void s_HandlePingTimer(void *aContext);
+    static void s_HandlePingTimer(Timer &aTimer);
 #endif
     static void OTCALL s_HandleActiveScanResult(otActiveScanResult *aResult, void *aContext);
     static void OTCALL s_HandleNetifStateChanged(uint32_t aFlags, void *aContext);
@@ -328,6 +329,8 @@ private:
 #if OPENTHREAD_ENABLE_DNS_CLIENT
     void HandleDnsResponse(const char *aHostname, Ip6::Address &aAddress, uint32_t aTtl, otError aResult);
 #endif
+
+    static Interpreter &GetOwner(const Context &aContext);
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
 

--- a/src/cli/cli_uart.hpp
+++ b/src/cli/cli_uart.hpp
@@ -91,6 +91,14 @@ public:
      */
     int OutputFormatV(const char *aFmt, va_list aAp);
 
+    /**
+     * This method returns a reference to the interpreter object.
+     *
+     * @returns A reference to the interpreter object.
+     *
+     */
+    Interpreter &GetInterpreter(void) { return mInterpreter; }
+
     void ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength);
     void SendDoneTask(void);
 

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -119,6 +119,7 @@ SOURCES_COMMON                      = \
     coap/coap_secure.cpp              \
     common/crc16.cpp                  \
     common/logging.cpp                \
+    common/locator.cpp                \
     common/message.cpp                \
     common/tasklet.cpp                \
     common/timer.cpp                  \
@@ -199,14 +200,17 @@ HEADERS_COMMON                      = \
     openthread-core-config.h          \
     openthread-core-default-config.h  \
     openthread-instance.h             \
+    openthread-single-instance.h      \
     api/link_raw.hpp                  \
     coap/coap.hpp                     \
     coap/coap_header.hpp              \
     coap/coap_secure.hpp              \
     common/code_utils.hpp             \
+    common/context.hpp                \
     common/crc16.hpp                  \
     common/debug.hpp                  \
     common/encoding.hpp               \
+    common/locator.hpp                \
     common/logging.hpp                \
     common/message.hpp                \
     common/settings.hpp               \

--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -40,13 +40,45 @@
 #include <openthread/platform/settings.h>
 
 #include "openthread-instance.h"
+#include "openthread-single-instance.h"
 #include "common/logging.hpp"
 #include "common/new.hpp"
 
-#ifndef OPENTHREAD_MULTIPLE_INSTANCE
+#if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+
 static otDEFINE_ALIGNED_VAR(sInstanceRaw, sizeof(otInstance), uint64_t);
 otInstance *sInstance = NULL;
-#endif
+
+otInstance *otGetInstance(void)
+{
+    return sInstance;
+}
+
+ot::ThreadNetif &otGetThreadNetif(void)
+{
+    return sInstance->mThreadNetif;
+}
+
+ot::MeshForwarder &otGetMeshForwarder(void)
+{
+    return sInstance->mThreadNetif.GetMeshForwarder();
+}
+
+ot::TimerScheduler &otGetTimerScheduler(void)
+{
+    return sInstance->mIp6.mTimerScheduler;
+}
+
+ot::TaskletScheduler &otGetTaskletScheduler(void)
+{
+    return sInstance->mIp6.mTaskletScheduler;
+}
+
+ot::Ip6::Ip6 &otGetIp6(void)
+{
+    return sInstance->mIp6;
+}
+#endif // #if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
 
 otInstance::otInstance(void) :
     mReceiveIp6DatagramCallback(NULL),
@@ -95,11 +127,11 @@ void otInstancePostConstructor(otInstance *aInstance)
 #endif
 }
 
-#ifdef OPENTHREAD_MULTIPLE_INSTANCE
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
 
 otInstance *otInstanceInit(void *aInstanceBuffer, size_t *aInstanceBufferSize)
 {
-    otInstance *aInstance = NULL;
+    otInstance *instance = NULL;
 
     otLogFuncEntry();
 
@@ -111,26 +143,30 @@ otInstance *otInstanceInit(void *aInstanceBuffer, size_t *aInstanceBufferSize)
     VerifyOrExit(aInstanceBuffer != NULL);
 
     // Construct the context
-    aInstance = new(aInstanceBuffer)otInstance();
+    instance = new(aInstanceBuffer)otInstance();
 
     // Execute post constructor operations
-    otInstancePostConstructor(aInstance);
+    otInstancePostConstructor(instance);
 
-    otLogInfoApi(aInstance, "otInstance Initialized");
+    otLogInfoApi(instance, "otInstance Initialized");
 
 exit:
 
     otLogFuncExit();
-    return aInstance;
+    return instance;
 }
 
-#else
+#else // #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
 
-otInstance *otInstanceInit()
+otInstance *otInstanceInitSingle(void)
 {
     otLogFuncEntry();
 
     VerifyOrExit(sInstance == NULL);
+
+    // We need to ensure `sInstance` pointer is correctly set
+    // before any object constructor is called.
+    sInstance = reinterpret_cast<otInstance *>(&sInstanceRaw);
 
     // Construct the context
     sInstance = new(&sInstanceRaw)otInstance();
@@ -146,7 +182,7 @@ exit:
     return sInstance;
 }
 
-#endif
+#endif // #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
 
 void otInstanceFinalize(otInstance *aInstance)
 {
@@ -156,9 +192,10 @@ void otInstanceFinalize(otInstance *aInstance)
     (void)otThreadSetEnabled(aInstance, false);
     (void)otIp6SetEnabled(aInstance, false);
 
-#ifndef OPENTHREAD_MULTIPLE_INSTANCE
+#if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
     sInstance = NULL;
 #endif
+
     otLogFuncExit();
 }
 

--- a/src/core/api/link_raw.hpp
+++ b/src/core/api/link_raw.hpp
@@ -111,6 +111,8 @@ public:
     void InvokeEnergyScanDone(int8_t aEnergyScanMaxRssi);
 
 private:
+    otError DoTransmit(otRadioFrame *aFrame);
+    static LinkRaw &GetOwner(const Context &aContext);
 
     otInstance             &mInstance;
     bool                    mEnabled;
@@ -118,8 +120,6 @@ private:
     otLinkRawReceiveDone    mReceiveDoneCallback;
     otLinkRawTransmitDone   mTransmitDoneCallback;
     otLinkRawEnergyScanDone mEnergyScanDoneCallback;
-
-    otError DoTransmit(otRadioFrame *aFrame);
 
 #if OPENTHREAD_LINKRAW_TIMER_REQUIRED
 
@@ -135,6 +135,7 @@ private:
     TimerReason             mTimerReason;
 
     static void HandleTimer(void *aContext);
+    static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
 
 #endif // OPENTHREAD_LINKRAW_TIMER_REQUIRED
@@ -158,7 +159,7 @@ private:
     Tasklet                 mEnergyScanTask;
     int8_t                  mEnergyScanRssi;
 
-    static void HandleEnergyScanTask(void *aContext);
+    static void HandleEnergyScanTask(Tasklet &aTasklet);
     void HandleEnergyScanTask(void);
 
 #endif // OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ENERGY_SCAN

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -33,6 +33,7 @@
 
 #include "coap/coap_header.hpp"
 #include "common/debug.hpp"
+#include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/timer.hpp"
 #include "net/ip6.hpp"
@@ -407,20 +408,22 @@ private:
     };
 
     void DequeueResponse(Message &aMessage) { mQueue.Dequeue(aMessage); aMessage.Free(); }
+    static ResponsesQueue &GetOwner(const Context &aContext);
+    static void HandleTimer(Timer &aTimer);
+    void HandleTimer(void);
 
     MessageQueue mQueue;
     Timer        mTimer;
-
-    static void HandleTimer(void *aContext);
-    void HandleTimer(void);
 };
 
 /**
  * This class implements the CoAP client and server.
  *
  */
-class Coap
+class Coap: public ThreadNetifLocator
 {
+    friend class ResponsesQueue;
+
 public:
     /**
      * This function pointer is called before CoAP server processing a CoAP packets.
@@ -661,7 +664,6 @@ protected:
      */
     virtual void Receive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    ThreadNetif &mNetif;
     Ip6::UdpSocket mSocket;
 
 private:
@@ -686,8 +688,10 @@ private:
     otError SendCopy(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     otError SendEmptyMessage(Header::Type aType, const Header &aRequestHeader,
                              const Ip6::MessageInfo &aMessageInfo);
-    static void HandleRetransmissionTimer(void *aContext);
+    static void HandleRetransmissionTimer(Timer &aTimer);
     void HandleRetransmissionTimer(void);
+
+    static Coap &GetOwner(const Context &aContext);
 
     MessageQueue mPendingRequests;
     uint16_t mMessageId;

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -211,8 +211,10 @@ private:
     static otError HandleDtlsSend(void *aContext, const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
     otError HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
 
-    static void HandleUdpTransmit(void *aContext);
+    static void HandleUdpTransmit(Tasklet &aTasklet);
     void HandleUdpTransmit(void);
+
+    static CoapSecure &GetOwner(const Context &aContext);
 
     Ip6::MessageInfo mPeerAddress;
     ConnectedCallback mConnectedCallback;

--- a/src/core/common/context.hpp
+++ b/src/core/common/context.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2016, The OpenThread Authors.
+ *  Copyright (c) 2017, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -26,74 +26,77 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * @file
+ *   This file includes definitions for maintaining a pointer to arbitrary context information.
+ */
+
+#ifndef CONTEXT_HPP_
+#define CONTEXT_HPP_
+
 #include <openthread/config.h>
+#include <openthread/platform/toolchain.h>
 
-#include <assert.h>
+#include "openthread-core-config.h"
 
-#include <openthread/cli.h>
-#include <openthread/diag.h>
-#include <openthread/openthread.h>
-#include <openthread/platform/platform.h>
+namespace ot {
+
+/**
+ * @addtogroup core-context
+ *
+ * @brief
+ *   This module includes definitions for maintaining a pointer to arbitrary context information.
+ *
+ * @{
+ *
+ */
+
+/**
+ * This class implements definitions for maintaining a pointer to arbitrary context information.
+ *
+ * This is used as base class for objects that provide a callback or handler (e.g., Timer or Tasklet).
+ *
+ */
+class Context
+{
+public:
 
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-void *otPlatCAlloc(size_t aNum, size_t aSize)
-{
-    return calloc(aNum, aSize);
-}
-
-void otPlatFree(void *aPtr)
-{
-    free(aPtr);
-}
+    /**
+     * This method returns the pointer to the arbitrary context information.
+     *
+     * @returns The pointer to the context information.
+     *
+     */
+    void *GetContext(void) const { return mContext; }
 #endif
 
-void otTaskletsSignalPending(otInstance *aInstance)
-{
-    (void)aInstance;
-}
-
-int main(int argc, char *argv[])
-{
-    otInstance *sInstance;
-
+protected:
+    /**
+     * This constructor initializes the context object.
+     *
+     * @param[in]  aContext    A pointer to arbitrary context information.
+     *
+     */
+    Context(void *aContext)
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    size_t otInstanceBufferLength = 0;
-    uint8_t *otInstanceBuffer = NULL;
+        : mContext(aContext)
 #endif
-
-    PlatformInit(argc, argv);
-
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    // Call to query the buffer size
-    (void)otInstanceInit(NULL, &otInstanceBufferLength);
-
-    // Call to allocate the buffer
-    otInstanceBuffer = (uint8_t *)malloc(otInstanceBufferLength);
-    assert(otInstanceBuffer);
-
-    // Initialize OpenThread with the buffer
-    sInstance = otInstanceInit(otInstanceBuffer, &otInstanceBufferLength);
-#else
-    sInstance = otInstanceInitSingle();
-#endif
-    assert(sInstance);
-
-    otCliUartInit(sInstance);
-
-#if OPENTHREAD_ENABLE_DIAG
-    otDiagInit(sInstance);
-#endif
-
-    while (1)
     {
-        otTaskletsProcess(sInstance);
-        PlatformProcessDrivers(sInstance);
+        OT_UNUSED_VARIABLE(aContext);
     }
 
-    // otInstanceFinalize(sInstance);
+private:
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    // free(otInstanceBuffer);
+    void *mContext;
 #endif
+};
 
-    return 0;
-}
+/**
+ * @}
+ *
+ */
+
+}  // namespace ot
+
+#endif  // CONTEXT_HPP_

--- a/src/core/common/locator.hpp
+++ b/src/core/common/locator.hpp
@@ -1,0 +1,341 @@
+/*
+ *  Copyright (c) 2017, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for locator class for OpenThread objects.
+ */
+
+#ifndef LOCATOR_HPP_
+#define LOCATOR_HPP_
+
+#include <openthread/config.h>
+
+#include <openthread/types.h>
+
+#include "openthread-core-config.h"
+#include "openthread-single-instance.h"
+
+namespace ot {
+
+class ThreadNetif;
+class MeshForwarder;
+class TaskletScheduler;
+class TimerScheduler;
+namespace Ip6 { class Ip6; }
+
+/**
+ * @addtogroup core-locator
+ *
+ * @brief
+ *   This module includes definitions for locator base class for OpenThread objects.
+ *
+ * @{
+ *
+ */
+
+/**
+ * This template class implements the base locator for OpenThread objects.
+ *
+ */
+template <typename Type>
+class Locator
+{
+protected:
+    /**
+     * This constructor initializes the locator.
+     *
+     * @param[in]  aObject  A reference to the object.
+     *
+     */
+    Locator(Type &aObject)
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+        : mLocatorObject(aObject)
+#endif
+    {
+        OT_UNUSED_VARIABLE(aObject);
+    }
+
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    Type &mLocatorObject;
+#endif
+};
+
+/**
+ * This class implements a locator for ThreadNetif object.
+ *
+ */
+class ThreadNetifLocator: private Locator<ThreadNetif>
+{
+public:
+    /**
+     * This method returns a reference to the thread network interface.
+     *
+     * @returns   A reference to the thread network interface.
+     *
+     */
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    ThreadNetif &GetNetif(void) const { return mLocatorObject; }
+#else
+    ThreadNetif &GetNetif(void) const { return otGetThreadNetif(); }
+#endif
+
+    /**
+     * This method returns the pointer to the parent otInstance structure.
+     *
+     * @returns The pointer to the parent otInstance structure, or NULL if the instance has been finalized.
+     *
+     */
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    otInstance *GetInstance(void) const;
+#else
+    otInstance *GetInstance(void) const { return otGetInstance(); }
+#endif
+
+protected:
+    /**
+     * This constructor initializes the object.
+     *
+     * @param[in]  aThreadNetif  A reference to the thread network interface.
+     *
+     */
+    ThreadNetifLocator(ThreadNetif &aThreadNetif): Locator(aThreadNetif) { }
+};
+
+/**
+ * This class implements a locator for MeshForwarder object.
+ *
+ */
+class MeshForwarderLocator: private Locator<MeshForwarder>
+{
+public:
+    /**
+     * This method returns a reference to the MeshForwarder.
+     *
+     * @returns   A reference to the MeshForwarder.
+     *
+     */
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    MeshForwarder &GetMeshForwarder(void) const { return mLocatorObject; }
+#else
+    MeshForwarder &GetMeshForwarder(void) const { return otGetMeshForwarder(); }
+#endif
+
+    /**
+     * This method returns the pointer to the parent otInstance structure.
+     *
+     * @returns The pointer to the parent otInstance structure, or NULL if the instance has been finalized.
+     *
+     */
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    otInstance *GetInstance(void) const;
+#else
+    otInstance *GetInstance(void) const { return otGetInstance(); }
+#endif
+
+protected:
+    /**
+     * This constructor initializes the object.
+     *
+     * @param[in]  aMeshForwarder  A reference to the MeshForwarder.
+     *
+     */
+    MeshForwarderLocator(MeshForwarder &aMeshForwarder): Locator(aMeshForwarder) { }
+};
+
+/**
+ * This class implements a locator for TimerScheduler object.
+ *
+ */
+class TimerSchedulerLocator: private Locator<TimerScheduler>
+{
+public:
+    /**
+     * This method returns a reference to the TimerScheduler.
+     *
+     * @returns   A reference to the TimerScheduler.
+     *
+     */
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    TimerScheduler &GetTimerScheduler(void) const { return mLocatorObject; }
+#else
+    TimerScheduler &GetTimerScheduler(void) const { return otGetTimerScheduler(); }
+#endif
+
+    /**
+     * This method returns the pointer to the parent otInstance structure.
+     *
+     * @returns The pointer to the parent otInstance structure, or NULL if the instance has been finalized.
+     *
+     */
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    otInstance *GetInstance(void) const;
+#else
+    otInstance *GetInstance(void) const { return otGetInstance(); }
+#endif
+
+protected:
+    /**
+     * This constructor initializes the object.
+     *
+     * @param[in]  aTimerScheduler  A reference to the TimerScheduler.
+     *
+     */
+    TimerSchedulerLocator(TimerScheduler &aTimerScheduler): Locator(aTimerScheduler) { }
+};
+
+/**
+ * This class implements a locator for TaskletScheduler object.
+ *
+ */
+class TaskletSchedulerLocator: private Locator<TaskletScheduler>
+{
+public:
+    /**
+     * This method returns a reference to the TaskletScheduler.
+     *
+     * @returns   A reference to the TaskletScheduler.
+     *
+     */
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    TaskletScheduler &GetTaskletScheduler(void) const { return mLocatorObject; }
+#else
+    TaskletScheduler &GetTaskletScheduler(void) const { return otGetTaskletScheduler(); }
+#endif
+
+    /**
+     * This method returns the pointer to the parent otInstance structure.
+     *
+     * @returns The pointer to the parent otInstance structure, or NULL if the instance has been finalized.
+     *
+     */
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    otInstance *GetInstance(void) const;
+#else
+    otInstance *GetInstance(void) const { return otGetInstance(); }
+#endif
+
+protected:
+    /**
+     * This constructor initializes the object.
+     *
+     * @param[in]  aTaskletScheduler  A reference to the TaskletScheduler.
+     *
+     */
+    TaskletSchedulerLocator(TaskletScheduler &aTaskletScheduler): Locator(aTaskletScheduler) { }
+};
+
+/**
+ * This class implements a locator for Ip6 object.
+ *
+ */
+class Ip6Locator: private Locator<Ip6::Ip6>
+{
+public:
+    /**
+     * This method returns a reference to the Ip6.
+     *
+     * @returns   A reference to the Ip6.
+     *
+     */
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    Ip6::Ip6 &GetIp6(void) const { return mLocatorObject; }
+#else
+    Ip6::Ip6 &GetIp6(void) const { return otGetIp6(); }
+#endif
+
+    /**
+     * This method returns the pointer to the parent otInstance structure.
+     *
+     * @returns The pointer to the parent otInstance structure, or NULL if the instance has been finalized.
+     *
+     */
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    otInstance *GetInstance(void) const;
+#else
+    otInstance *GetInstance(void) const { return otGetInstance(); }
+#endif
+
+protected:
+    /**
+     * This constructor initializes the object.
+     *
+     * @param[in]  aIp6  A reference to the Ip6.
+     *
+     */
+    Ip6Locator(Ip6::Ip6 &aIp6): Locator(aIp6) { }
+};
+
+/**
+ * This class implements locator for  otInstance object
+ *
+ */
+class InstanceLocator
+{
+public:
+    /**
+     * This method returns the pointer to the parent otInstance structure.
+     *
+     * @returns The pointer to the parent otInstance structure, or NULL if the instance has been finalized.
+     *
+     */
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    otInstance *GetInstance(void) const { return mInstance; }
+#else
+    otInstance *GetInstance(void) const { return otGetInstance(); }
+#endif
+
+protected:
+    /**
+     * This constructor initializes the object.
+     *
+     * @param[in]  aInstance  A pointer to the otInstance.
+     *
+     */
+    InstanceLocator(otInstance *aInstance)
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+        : mInstance(aInstance)
+#endif
+    {
+        OT_UNUSED_VARIABLE(aInstance);
+    }
+
+private:
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    otInstance *mInstance;
+#endif
+};
+
+/**
+ * @}
+ *
+ */
+
+}  // namespace ot
+
+#endif  // LOCATOR_HPP_

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -45,12 +45,12 @@
 namespace ot {
 
 MessagePool::MessagePool(otInstance *aInstance) :
-    mInstance(aInstance),
+    InstanceLocator(aInstance),
     mAllQueue()
 {
 #if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
     // Initialize Platform buffer pool management.
-    otPlatMessagePoolInit(mInstance, kNumBuffers, sizeof(Buffer));
+    otPlatMessagePoolInit(GetInstance(), kNumBuffers, sizeof(Buffer));
 #else
     memset(mBuffers, 0, sizeof(mBuffers));
 
@@ -64,8 +64,6 @@ MessagePool::MessagePool(otInstance *aInstance) :
     mBuffers[kNumBuffers - 1].SetNextBuffer(NULL);
     mNumFreeBuffers = kNumBuffers;
 #endif
-
-    OT_UNUSED_VARIABLE(mInstance);
 }
 
 Message *MessagePool::New(uint8_t aType, uint16_t aReserved)
@@ -108,7 +106,7 @@ Buffer *MessagePool::NewBuffer(void)
 
 #if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
 
-    buffer = static_cast<Buffer *>(otPlatMessagePoolNew(mInstance));
+    buffer = static_cast<Buffer *>(otPlatMessagePoolNew(GetInstance()));
 
 #else
 
@@ -124,7 +122,7 @@ Buffer *MessagePool::NewBuffer(void)
 
     if (buffer == NULL)
     {
-        otLogInfoMem(mInstance, "No available message buffer");
+        otLogInfoMem(GetInstance(), "No available message buffer");
     }
 
     return buffer;
@@ -138,7 +136,7 @@ otError MessagePool::FreeBuffers(Buffer *aBuffer)
     {
         tmpBuffer = aBuffer->GetNextBuffer();
 #if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
-        otPlatMessagePoolFree(mInstance, aBuffer);
+        otPlatMessagePoolFree(GetInstance(), aBuffer);
 #else // OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
         aBuffer->SetNextBuffer(mFreeBuffers);
         mFreeBuffers = aBuffer;
@@ -155,7 +153,7 @@ otError MessagePool::ReclaimBuffers(int aNumBuffers)
     uint16_t numFreeBuffers;
 
 #if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
-    numFreeBuffers = otPlatMessagePoolNumFreeBuffers(mInstance);
+    numFreeBuffers = otPlatMessagePoolNumFreeBuffers(GetInstance());
 #else
     numFreeBuffers = mNumFreeBuffers;
 #endif

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -44,6 +44,7 @@
 
 #include "openthread-core-config.h"
 #include "common/code_utils.hpp"
+#include "common/locator.hpp"
 #include "mac/mac_frame.hpp"
 
 namespace ot {
@@ -967,7 +968,7 @@ private:
  * This class represents a message pool
  *
  */
-class MessagePool
+class MessagePool: public InstanceLocator
 {
     friend class Message;
     friend class MessageQueue;
@@ -1105,7 +1106,7 @@ public:
      *
      */
 #if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
-    uint16_t GetFreeBufferCount(void) const { return otPlatMessagePoolNumFreeBuffers(mInstance); }
+    uint16_t GetFreeBufferCount(void) const { return otPlatMessagePoolNumFreeBuffers(GetInstance()); }
 #else
     uint16_t GetFreeBufferCount(void) const { return mNumFreeBuffers; }
 #endif
@@ -1127,7 +1128,6 @@ private:
     Buffer   *mFreeBuffers;
 #endif
 
-    otInstance *mInstance;
     PriorityQueue mAllQueue;
 };
 

--- a/src/core/common/tasklet.hpp
+++ b/src/core/common/tasklet.hpp
@@ -38,9 +38,10 @@
 
 #include <openthread/tasklet.h>
 
-namespace ot {
+#include "common/context.hpp"
+#include "common/locator.hpp"
 
-namespace Ip6 { class Ip6; }
+namespace ot {
 
 class TaskletScheduler;
 
@@ -58,7 +59,7 @@ class TaskletScheduler;
  * This class is used to represent a tasklet.
  *
  */
-class Tasklet
+class Tasklet: public TaskletSchedulerLocator, public Context
 {
     friend class TaskletScheduler;
 
@@ -66,10 +67,10 @@ public:
     /**
      * This function pointer is called when the tasklet is run.
      *
-     * @param[in]  aContext  A pointer to arbitrary context information.
+     * @param[in]  aTasklet  A reference to the tasklet being run.
      *
      */
-    typedef void (*Handler)(void *aContext);
+    typedef void (*Handler)(Tasklet &aTasklet);
 
     /**
      * This constructor creates a tasklet instance.
@@ -88,11 +89,9 @@ public:
     otError Post(void);
 
 private:
-    void RunTask(void) { mHandler(mContext); }
+    void RunTask(void) { mHandler(*this); }
 
-    TaskletScheduler &mScheduler;
     Handler           mHandler;
-    void             *mContext;
     Tasklet          *mNext;
 };
 
@@ -133,14 +132,6 @@ public:
      *
      */
     void ProcessQueuedTasklets(void);
-
-    /**
-     * This method returns the pointer to the parent Ip6 structure.
-     *
-     * @returns The pointer to the parent Ip6 structure.
-     *
-     */
-    Ip6::Ip6 *GetIp6(void);
 
 private:
     Tasklet *PopTasklet(void);

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -40,7 +40,9 @@
 #include <openthread/types.h>
 #include <openthread/platform/alarm.h>
 
+#include "common/context.hpp"
 #include "common/debug.hpp"
+#include "common/locator.hpp"
 #include "common/tasklet.hpp"
 
 namespace ot {
@@ -133,7 +135,7 @@ private:
  * This class implements a timer.
  *
  */
-class Timer
+class Timer: public TimerSchedulerLocator, public Context
 {
     friend class TimerScheduler;
 
@@ -147,9 +149,10 @@ public:
     /**
      * This function pointer is called when the timer expires.
      *
-     * @param[in]  aContext  A pointer to arbitrary context information.
+     * @param[in]  aTimer    A reference to the expired timer instance.
+     *
      */
-    typedef void (*Handler)(void *aContext);
+    typedef void (*Handler)(Timer &aTimer);
 
     /**
      * This constructor creates a timer instance.
@@ -160,9 +163,9 @@ public:
      *
      */
     Timer(TimerScheduler &aScheduler, Handler aHandler, void *aContext):
-        mScheduler(aScheduler),
+        TimerSchedulerLocator(aScheduler),
+        Context(aContext),
         mHandler(aHandler),
-        mContext(aContext),
         mFireTime(0),
         mNext(this) {
     }
@@ -201,13 +204,17 @@ public:
      *                  (aDt must be smaller than or equal to kMaxDt).
      *
      */
-    void StartAt(uint32_t aT0, uint32_t aDt) { assert(aDt <= kMaxDt); mFireTime = aT0 + aDt; mScheduler.Add(*this); }
+    void StartAt(uint32_t aT0, uint32_t aDt) {
+        assert(aDt <= kMaxDt);
+        mFireTime = aT0 + aDt;
+        GetTimerScheduler().Add(*this);
+    }
 
     /**
      * This method stops the timer.
      *
      */
-    void Stop(void) { mScheduler.Remove(*this); }
+    void Stop(void) { GetTimerScheduler().Remove(*this); }
 
     /**
      * This static method returns the current time in milliseconds.
@@ -245,11 +252,9 @@ private:
      */
     bool DoesFireBefore(const Timer &aTimer);
 
-    void Fired(void) { mHandler(mContext); }
+    void Fired(void) { mHandler(*this); }
 
-    TimerScheduler &mScheduler;
     Handler         mHandler;
-    void           *mContext;
     uint32_t        mFireTime;
     Timer          *mNext;
 };

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -37,6 +37,7 @@
 
 #include <openthread/platform/random.h>
 
+#include "openthread-instance.h"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 
@@ -49,7 +50,7 @@ TrickleTimer::TrickleTimer(
 #endif
     Handler aTransmitHandler, Handler aIntervalExpiredHandler, void *aContext)
     :
-    mTimer(aScheduler, HandleTimerFired, this),
+    Timer(aScheduler, HandleTimerFired, aContext),
 #ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
     k(aRedundancyConstant),
     c(0),
@@ -61,8 +62,7 @@ TrickleTimer::TrickleTimer(
     t(0),
     mPhase(kPhaseDormant),
     mTransmitHandler(aTransmitHandler),
-    mIntervalExpiredHandler(aIntervalExpiredHandler),
-    mContext(aContext)
+    mIntervalExpiredHandler(aIntervalExpiredHandler)
 {
 }
 
@@ -97,7 +97,7 @@ void TrickleTimer::Start(uint32_t aIntervalMin, uint32_t aIntervalMax, Mode aMod
 void TrickleTimer::Stop(void)
 {
     mPhase = kPhaseDormant;
-    mTimer.Stop();
+    Timer::Stop();
 }
 
 #ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
@@ -117,7 +117,7 @@ void TrickleTimer::IndicateInconsistent(void)
         I = Imin;
 
         // Stop the existing timer
-        mTimer.Stop();
+        Timer::Stop();
 
         // Start a new interval
         StartNewInterval();
@@ -156,13 +156,12 @@ void TrickleTimer::StartNewInterval(void)
     }
 
     // Start the timer for 't' milliseconds from now
-    mTimer.Start(t);
+    Timer::Start(t);
 }
 
-void TrickleTimer::HandleTimerFired(void *aContext)
+void TrickleTimer::HandleTimerFired(Timer &aTimer)
 {
-    TrickleTimer *obj = static_cast<TrickleTimer *>(aContext);
-    obj->HandleTimerFired();
+    static_cast<TrickleTimer *>(&aTimer)->HandleTimerFired();
 }
 
 void TrickleTimer::HandleTimerFired(void)
@@ -205,7 +204,7 @@ void TrickleTimer::HandleTimerFired(void)
                 mPhase = kPhaseInterval;
 
                 // Start the time for 'I - t' milliseconds
-                mTimer.Start(I - t);
+                Timer::Start(I - t);
             }
         }
 

--- a/src/core/common/trickle_timer.hpp
+++ b/src/core/common/trickle_timer.hpp
@@ -34,6 +34,7 @@
 #ifndef TRICKLE_TIMER_HPP_
 #define TRICKLE_TIMER_HPP_
 
+#include "common/context.hpp"
 #include "common/timer.hpp"
 
 namespace ot {
@@ -52,7 +53,7 @@ namespace ot {
  * This class implements a trickle timer.
  *
  */
-class TrickleTimer
+class TrickleTimer: public Timer
 {
 public:
 
@@ -69,12 +70,12 @@ public:
     /**
      * This function pointer is called when the timer expires.
      *
-     * @param[in]  aContext  A pointer to arbitrary context information.
+     * @param[in]  aTimer  A reference to the expired timer.
      *
      * @retval TRUE   If the trickle timer should continue running.
      * @retval FALSE  If the trickle timer should stop running.
      */
-    typedef bool (*Handler)(void *aContext);
+    typedef bool (*Handler)(TrickleTimer &aTimer);
 
     /**
      * This constructor creates a trickle timer instance.
@@ -111,6 +112,17 @@ public:
     void Start(uint32_t aIntervalMin, uint32_t aIntervalMax, Mode aMode);
 
     /**
+     * This method start the trickle timer.
+     *
+     * @param[in]  aStartTime    The start time.
+     * @param[in]  aIntervalMin  The minimum interval for the timer, Imin.
+     * @param[in]  aIntervalMax  The maximum interval for the timer, Imax.
+     * @param[in]  aMode         The operating mode for the timer.
+     *
+     */
+    void StartAt(uint32_t aStartTime, uint32_t aIntervalMin, uint32_t aIntervalMax, Mode aMode);
+
+    /**
      * This method stops the trickle timer.
      *
      */
@@ -131,13 +143,16 @@ public:
     void IndicateInconsistent(void);
 
 private:
-    bool TransmitFired(void) { return mTransmitHandler(mContext); }
-    bool IntervalExpiredFired(void) { return mIntervalExpiredHandler ? mIntervalExpiredHandler(mContext) : true; }
+    bool TransmitFired(void) { return mTransmitHandler(*this); }
+    bool IntervalExpiredFired(void) { return mIntervalExpiredHandler ? mIntervalExpiredHandler(*this) : true; }
 
     void StartNewInterval(void);
 
-    static void HandleTimerFired(void *aContext);
+    static void HandleTimerFired(Timer &aTimer);
     void HandleTimerFired(void);
+
+    // Shadow base class method to ensure it is hidden.
+    void StartAt(void) { }
 
     typedef enum Phase
     {
@@ -148,8 +163,6 @@ private:
         ///< Indicates that when the timer expires, it should process interval expiration callbacks
         kPhaseInterval   = 3,
     } Phase;
-
-    Timer mTimer;
 
 #ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
     // Redundancy constant
@@ -177,7 +190,6 @@ private:
     // Callback variables
     Handler mTransmitHandler;
     Handler mIntervalExpiredHandler;
-    void *mContext;
 };
 
 /**

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -114,12 +114,12 @@ void Mac::StartCsmaBackoff(void)
 }
 
 Mac::Mac(ThreadNetif &aThreadNetif):
+    ThreadNetifLocator(aThreadNetif),
     mMacTimer(aThreadNetif.GetIp6().mTimerScheduler, &Mac::HandleMacTimer, this),
 #if !OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_BACKOFF_TIMER
     mBackoffTimer(aThreadNetif.GetIp6().mTimerScheduler, &Mac::HandleBeginTransmit, this),
 #endif
     mReceiveTimer(aThreadNetif.GetIp6().mTimerScheduler, &Mac::HandleReceiveTimer, this),
-    mNetif(aThreadNetif),
     mShortAddress(kShortAddrInvalid),
     mPanId(kPanIdBroadcast),
     mChannel(OPENTHREAD_CONFIG_DEFAULT_CHANNEL),
@@ -166,11 +166,6 @@ Mac::Mac(ThreadNetif &aThreadNetif):
     SetShortAddress(mShortAddress);
 
     otPlatRadioEnable(GetInstance());
-}
-
-otInstance *Mac::GetInstance(void)
-{
-    return mNetif.GetInstance();
 }
 
 otError Mac::ActiveScan(uint32_t aScanChannels, uint16_t aScanDuration, ActiveScanHandler aHandler, void *aContext)
@@ -372,9 +367,9 @@ exit:
     return;
 }
 
-void Mac::HandleEnergyScanSampleRssi(void *aContext)
+void Mac::HandleEnergyScanSampleRssi(Tasklet &aTasklet)
 {
-    static_cast<Mac *>(aContext)->HandleEnergyScanSampleRssi();
+    GetOwner(aTasklet).HandleEnergyScanSampleRssi();
 }
 
 void Mac::HandleEnergyScanSampleRssi(void)
@@ -667,12 +662,12 @@ void Mac::SendBeacon(Frame &aFrame)
 
     beaconPayload = reinterpret_cast<BeaconPayload *>(beacon->GetPayload());
 
-    if (mNetif.GetKeyManager().GetSecurityPolicyFlags() & OT_SECURITY_POLICY_BEACONS)
+    if (GetNetif().GetKeyManager().GetSecurityPolicyFlags() & OT_SECURITY_POLICY_BEACONS)
     {
         beaconPayload->Init();
 
         // set the Joining Permitted flag
-        mNetif.GetIp6Filter().GetUnsecurePorts(numUnsecurePorts);
+        GetNetif().GetIp6Filter().GetUnsecurePorts(numUnsecurePorts);
 
         if (numUnsecurePorts)
         {
@@ -698,6 +693,7 @@ void Mac::SendBeacon(Frame &aFrame)
 
 void Mac::ProcessTransmitSecurity(Frame &aFrame)
 {
+    KeyManager &keyManager = GetNetif().GetKeyManager();
     uint32_t frameCounter = 0;
     uint8_t securityLevel;
     uint8_t keyIdMode;
@@ -717,19 +713,19 @@ void Mac::ProcessTransmitSecurity(Frame &aFrame)
     switch (keyIdMode)
     {
     case Frame::kKeyIdMode0:
-        key = mNetif.GetKeyManager().GetKek();
+        key = keyManager.GetKek();
         extAddress = &mExtAddress;
 
         if (!aFrame.IsARetransmission())
         {
-            aFrame.SetFrameCounter(mNetif.GetKeyManager().GetKekFrameCounter());
-            mNetif.GetKeyManager().IncrementKekFrameCounter();
+            aFrame.SetFrameCounter(keyManager.GetKekFrameCounter());
+            keyManager.IncrementKekFrameCounter();
         }
 
         break;
 
     case Frame::kKeyIdMode1:
-        key = mNetif.GetKeyManager().GetCurrentMacKey();
+        key = keyManager.GetCurrentMacKey();
         extAddress = &mExtAddress;
 
         // If the frame is marked as a retransmission, the `Mac::Sender` which
@@ -740,9 +736,9 @@ void Mac::ProcessTransmitSecurity(Frame &aFrame)
 
         if (!aFrame.IsARetransmission())
         {
-            aFrame.SetFrameCounter(mNetif.GetKeyManager().GetMacFrameCounter());
-            mNetif.GetKeyManager().IncrementMacFrameCounter();
-            aFrame.SetKeyId((mNetif.GetKeyManager().GetCurrentKeySequence() & 0x7f) + 1);
+            aFrame.SetFrameCounter(keyManager.GetMacFrameCounter());
+            keyManager.IncrementMacFrameCounter();
+            aFrame.SetKeyId((keyManager.GetCurrentKeySequence() & 0x7f) + 1);
         }
 
         break;
@@ -785,6 +781,11 @@ exit:
 void Mac::HandleBeginTransmit(void *aContext)
 {
     static_cast<Mac *>(aContext)->HandleBeginTransmit();
+}
+
+void Mac::HandleBeginTransmit(Timer &aTimer)
+{
+    GetOwner(aTimer).HandleBeginTransmit();
 }
 
 void Mac::HandleBeginTransmit(void)
@@ -1002,7 +1003,7 @@ void Mac::TransmitDoneTask(otRadioFrame *aFrame, otRadioFrame *aAckFrame, otErro
         Neighbor *neighbor;
 
         framePending = ackFrame->GetFramePending();
-        neighbor = mNetif.GetMle().GetNeighbor(addr);
+        neighbor = GetNetif().GetMle().GetNeighbor(addr);
 
         if (neighbor != NULL)
         {
@@ -1124,9 +1125,9 @@ void Mac::RadioSleep(void)
     }
 }
 
-void Mac::HandleMacTimer(void *aContext)
+void Mac::HandleMacTimer(Timer &aTimer)
 {
-    static_cast<Mac *>(aContext)->HandleMacTimer();
+    GetOwner(aTimer).HandleMacTimer();
 }
 
 void Mac::HandleMacTimer(void)
@@ -1189,9 +1190,9 @@ exit:
     return;
 }
 
-void Mac::HandleReceiveTimer(void *aContext)
+void Mac::HandleReceiveTimer(Timer &aTimer)
 {
-    static_cast<Mac *>(aContext)->HandleReceiveTimer();
+    GetOwner(aTimer).HandleReceiveTimer();
 }
 
 void Mac::HandleReceiveTimer(void)
@@ -1322,6 +1323,7 @@ exit:
 
 otError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, Neighbor *aNeighbor)
 {
+    KeyManager &keyManager = GetNetif().GetKeyManager();
     otError error = OT_ERROR_NONE;
     uint8_t securityLevel;
     uint8_t keyIdMode;
@@ -1351,7 +1353,7 @@ otError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, Neig
     switch (keyIdMode)
     {
     case Frame::kKeyIdMode0:
-        VerifyOrExit((macKey = mNetif.GetKeyManager().GetKek()) != NULL, error = OT_ERROR_SECURITY);
+        VerifyOrExit((macKey = keyManager.GetKek()) != NULL, error = OT_ERROR_SECURITY);
         extAddress = &aSrcAddr.mExtAddress;
         break;
 
@@ -1361,23 +1363,23 @@ otError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, Neig
         aFrame.GetKeyId(keyid);
         keyid--;
 
-        if (keyid == (mNetif.GetKeyManager().GetCurrentKeySequence() & 0x7f))
+        if (keyid == (keyManager.GetCurrentKeySequence() & 0x7f))
         {
             // same key index
-            keySequence = mNetif.GetKeyManager().GetCurrentKeySequence();
-            macKey = mNetif.GetKeyManager().GetCurrentMacKey();
+            keySequence = keyManager.GetCurrentKeySequence();
+            macKey = keyManager.GetCurrentMacKey();
         }
-        else if (keyid == ((mNetif.GetKeyManager().GetCurrentKeySequence() - 1) & 0x7f))
+        else if (keyid == ((keyManager.GetCurrentKeySequence() - 1) & 0x7f))
         {
             // previous key index
-            keySequence = mNetif.GetKeyManager().GetCurrentKeySequence() - 1;
-            macKey = mNetif.GetKeyManager().GetTemporaryMacKey(keySequence);
+            keySequence = keyManager.GetCurrentKeySequence() - 1;
+            macKey = keyManager.GetTemporaryMacKey(keySequence);
         }
-        else if (keyid == ((mNetif.GetKeyManager().GetCurrentKeySequence() + 1) & 0x7f))
+        else if (keyid == ((keyManager.GetCurrentKeySequence() + 1) & 0x7f))
         {
             // next key index
-            keySequence = mNetif.GetKeyManager().GetCurrentKeySequence() + 1;
-            macKey = mNetif.GetKeyManager().GetTemporaryMacKey(keySequence);
+            keySequence = keyManager.GetCurrentKeySequence() + 1;
+            macKey = keyManager.GetTemporaryMacKey(keySequence);
         }
         else
         {
@@ -1444,9 +1446,9 @@ otError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, Neig
 
         aNeighbor->SetLinkFrameCounter(frameCounter + 1);
 
-        if (keySequence > mNetif.GetKeyManager().GetCurrentKeySequence())
+        if (keySequence > keyManager.GetCurrentKeySequence())
         {
-            mNetif.GetKeyManager().SetCurrentKeySequence(keySequence);
+            keyManager.SetCurrentKeySequence(keySequence);
         }
     }
 
@@ -1506,7 +1508,7 @@ void Mac::ReceiveDoneTask(Frame *aFrame, otError aError)
     SuccessOrExit(error = aFrame->ValidatePsdu());
 
     aFrame->GetSrcAddr(srcaddr);
-    neighbor = mNetif.GetMle().GetNeighbor(srcaddr);
+    neighbor = GetNetif().GetMle().GetNeighbor(srcaddr);
 
     switch (srcaddr.mLength)
     {
@@ -1857,7 +1859,7 @@ bool Mac::IsBeaconJoinable(void)
     uint8_t numUnsecurePorts;
     bool joinable = false;
 
-    mNetif.GetIp6Filter().GetUnsecurePorts(numUnsecurePorts);
+    GetNetif().GetIp6Filter().GetUnsecurePorts(numUnsecurePorts);
 
     if (numUnsecurePorts)
     {
@@ -1871,6 +1873,17 @@ bool Mac::IsBeaconJoinable(void)
     return joinable;
 }
 #endif // OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE
+
+Mac &Mac::GetOwner(const Context &aContext)
+{
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    Mac &mac = *static_cast<Mac *>(aContext.GetContext());
+#else
+    Mac &mac = otGetInstance()->mThreadNetif.GetMac();
+    OT_UNUSED_VARIABLE(aContext);
+#endif
+    return mac;
+}
 
 }  // namespace Mac
 }  // namespace ot

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -37,6 +37,8 @@
 #include <openthread/platform/radio.h>
 
 #include "openthread-core-config.h"
+#include "common/context.hpp"
+#include "common/locator.hpp"
 #include "common/tasklet.hpp"
 #include "common/timer.hpp"
 #include "mac/mac_blacklist.hpp"
@@ -101,7 +103,7 @@ enum
  * This class implements a MAC receiver client.
  *
  */
-class Receiver
+class Receiver: public Context
 {
     friend class Mac;
 
@@ -109,20 +111,20 @@ public:
     /**
      * This function pointer is called when a MAC frame is received.
      *
-     * @param[in]  aContext  A pointer to arbitrary context information.
+     * @param[in]  aReceiver A reference to the MAC receiver client object.
      * @param[in]  aFrame    A reference to the MAC frame.
      *
      */
-    typedef void (*ReceiveFrameHandler)(void *aContext, Frame &aFrame);
+    typedef void (*ReceiveFrameHandler)(Receiver &aReceiver, Frame &aFrame);
 
     /**
      * This function pointer is called on a data request command (data poll) timeout, i.e., when the ack in response to
      * a data request command indicated a frame is pending, but no frame was received after `kDataPollTimeout` interval.
      *
-     * @param[in]  aContext  A pointer to arbitrary context information.
+     * @param[in]  aReceiver  A reference to the MAC receiver client object.
      *
      */
-    typedef void (*DataPollTimeoutHandler)(void *aContext);
+    typedef void (*DataPollTimeoutHandler)(Receiver &aReceiver);
 
     /**
      * This constructor creates a MAC receiver client.
@@ -132,24 +134,24 @@ public:
      * @param[in]  aContext              A pointer to arbitrary context information.
      *
      */
-    Receiver(ReceiveFrameHandler aReceiveFrameHandler, DataPollTimeoutHandler aPollTimeoutHandler, void *aContext) {
-        mReceiveFrameHandler = aReceiveFrameHandler;
-        mPollTimeoutHandler = aPollTimeoutHandler;
-        mContext = aContext;
-        mNext = NULL;
+    Receiver(ReceiveFrameHandler aReceiveFrameHandler, DataPollTimeoutHandler aPollTimeoutHandler, void *aContext):
+        Context(aContext),
+        mReceiveFrameHandler(aReceiveFrameHandler),
+        mPollTimeoutHandler(aPollTimeoutHandler),
+        mNext(NULL) {
     }
 
 private:
-    void HandleReceivedFrame(Frame &frame) { mReceiveFrameHandler(mContext, frame); }
+    void HandleReceivedFrame(Frame &frame) { mReceiveFrameHandler(*this, frame); }
+
     void HandleDataPollTimeout(void) {
         if (mPollTimeoutHandler != NULL) {
-            mPollTimeoutHandler(mContext);
+            mPollTimeoutHandler(*this);
         }
     }
 
     ReceiveFrameHandler mReceiveFrameHandler;
     DataPollTimeoutHandler mPollTimeoutHandler;
-    void *mContext;
     Receiver *mNext;
 };
 
@@ -157,7 +159,7 @@ private:
  * This class implements a MAC sender client.
  *
  */
-class Sender
+class Sender: public Context
 {
     friend class Mac;
 
@@ -165,21 +167,21 @@ public:
     /**
      * This function pointer is called when the MAC is about to transmit the frame.
      *
-     * @param[in]  aContext  A pointer to arbitrary context information.
+     * @param[in]  aSender   A reference to the MAC sender client object.
      * @param[in]  aFrame    A reference to the MAC frame buffer.
      *
      */
-    typedef otError(*FrameRequestHandler)(void *aContext, Frame &aFrame);
+    typedef otError(*FrameRequestHandler)(Sender &aSender, Frame &aFrame);
 
     /**
      * This function pointer is called when the MAC is done sending the frame.
      *
-     * @param[in]  aContext  A pointer to arbitrary context information.
+     * @param[in]  aSender   A reference to the MAC sender client object.
      * @param[in]  aFrame    A reference to the MAC frame buffer that was sent.
      * @param[in]  aError    The status of the last MSDU transmission.
      *
      */
-    typedef void (*SentFrameHandler)(void *aContext, Frame &aFrame, otError aError);
+    typedef void (*SentFrameHandler)(Sender &aSender, Frame &aFrame, otError aError);
 
     /**
      * This constructor creates a MAC sender client.
@@ -189,20 +191,19 @@ public:
      * @param[in]  aContext              A pointer to arbitrary context information.
      *
      */
-    Sender(FrameRequestHandler aFrameRequestHandler, SentFrameHandler aSentFrameHandler, void *aContext) {
-        mFrameRequestHandler = aFrameRequestHandler;
-        mSentFrameHandler = aSentFrameHandler;
-        mContext = aContext;
-        mNext = NULL;
+    Sender(FrameRequestHandler aFrameRequestHandler, SentFrameHandler aSentFrameHandler, void *aContext):
+        Context(aContext),
+        mFrameRequestHandler(aFrameRequestHandler),
+        mSentFrameHandler(aSentFrameHandler),
+        mNext(NULL) {
     }
 
 private:
-    otError HandleFrameRequest(Frame &frame) { return mFrameRequestHandler(mContext, frame); }
-    void HandleSentFrame(Frame &frame, otError error) { mSentFrameHandler(mContext, frame, error); }
+    otError HandleFrameRequest(Frame &frame) { return mFrameRequestHandler(*this, frame); }
+    void HandleSentFrame(Frame &frame, otError error) { mSentFrameHandler(*this, frame, error); }
 
     FrameRequestHandler mFrameRequestHandler;
     SentFrameHandler mSentFrameHandler;
-    void *mContext;
     Sender *mNext;
 };
 
@@ -210,7 +211,7 @@ private:
  * This class implements the IEEE 802.15.4 MAC.
  *
  */
-class Mac
+class Mac: public ThreadNetifLocator
 {
 public:
     /**
@@ -220,14 +221,6 @@ public:
      *
      */
     explicit Mac(ThreadNetif &aThreadNetif);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This function pointer is called on receiving an IEEE 802.15.4 Beacon during an Active Scan.
@@ -256,7 +249,7 @@ public:
      * @param[out] aResult                  A reference to `otActiveScanResult` where the result is stored.
      *
      * @retval OT_ERROR_NONE            Successfully converted the beacon into active scan result.
-     * @retavl OT_ERROR_INVALID_ARGS    The @a aBeaconFrame was NULL.
+     * @retval OT_ERROR_INVALID_ARGS    The @a aBeaconFrame was NULL.
      * @retval OT_ERROR_PARSE           Failed parsing the beacon frame.
      *
      */
@@ -679,13 +672,14 @@ private:
     void StartEnergyScan(void);
     otError HandleMacCommand(Frame &aFrame);
 
-    static void HandleMacTimer(void *aContext);
+    static void HandleMacTimer(Timer &aTimer);
     void HandleMacTimer(void);
     static void HandleBeginTransmit(void *aContext);
+    static void HandleBeginTransmit(Timer &aTimer);
     void HandleBeginTransmit(void);
-    static void HandleReceiveTimer(void *aContext);
+    static void HandleReceiveTimer(Timer &aTimer);
     void HandleReceiveTimer(void);
-    static void HandleEnergyScanSampleRssi(void *aContext);
+    static void HandleEnergyScanSampleRssi(Tasklet &aTasklet);
     void HandleEnergyScanSampleRssi(void);
 
     void StartCsmaBackoff(void);
@@ -695,13 +689,13 @@ private:
     otError RadioReceive(uint8_t aChannel);
     void RadioSleep(void);
 
+    static Mac &GetOwner(const Context &aContext);
+
     Timer mMacTimer;
 #if !OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_BACKOFF_TIMER
     Timer mBackoffTimer;
 #endif
     Timer mReceiveTimer;
-
-    ThreadNetif &mNetif;
 
     ExtAddress mExtAddress;
     ShortAddress mShortAddress;

--- a/src/core/meshcop/announce_begin_client.hpp
+++ b/src/core/meshcop/announce_begin_client.hpp
@@ -35,19 +35,18 @@
 #define ANNOUNCE_BEGIN_CLIENT_HPP_
 
 #include "openthread-core-config.h"
+#include "common/locator.hpp"
 #include "coap/coap.hpp"
 #include "net/ip6_address.hpp"
 #include "net/udp6.hpp"
 
 namespace ot {
 
-class ThreadNetif;
-
 /**
  * This class implements handling Announce Begin Requests.
  *
  */
-class AnnounceBeginClient
+class AnnounceBeginClient: public ThreadNetifLocator
 {
 public:
     /**
@@ -55,14 +54,6 @@ public:
      *
      */
     AnnounceBeginClient(ThreadNetif &aThreadNetif);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This method sends a Announce Begin message.
@@ -76,9 +67,6 @@ public:
      *
      */
     otError SendRequest(uint32_t aChannelMask, uint8_t aCount, uint16_t mPeriod, const Ip6::Address &aAddress);
-
-private:
-    ThreadNetif &mNetif;
 };
 
 /**

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -39,6 +39,7 @@
 #include "openthread-core-config.h"
 #include "coap/coap.hpp"
 #include "coap/coap_secure.hpp"
+#include "common/locator.hpp"
 #include "common/timer.hpp"
 #include "mac/mac_frame.hpp"
 #include "meshcop/announce_begin_client.hpp"
@@ -54,7 +55,7 @@ class ThreadNetif;
 
 namespace MeshCoP {
 
-class Commissioner
+class Commissioner: public ThreadNetifLocator
 {
 public:
     /**
@@ -64,14 +65,6 @@ public:
      *
      */
     Commissioner(ThreadNetif &aThreadNetif);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This method starts the Commissioner service.
@@ -219,10 +212,10 @@ private:
     void AddCoapResources(void);
     void RemoveCoapResources(void);
 
-    static void HandleTimer(void *aContext);
+    static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
 
-    static void HandleJoinerExpirationTimer(void *aContext);
+    static void HandleJoinerExpirationTimer(Timer &aTimer);
     void HandleJoinerExpirationTimer(void);
 
     void UpdateJoinerExpirationTimer(void);
@@ -265,6 +258,8 @@ private:
     otError SendPetition(void);
     otError SendKeepAlive(void);
 
+    static Commissioner &GetOwner(const Context &aContext);
+
     otCommissionerState mState;
 
     struct Joiner
@@ -293,8 +288,6 @@ private:
     Coap::Resource mRelayReceive;
     Coap::Resource mDatasetChanged;
     Coap::Resource mJoinerFinalize;
-
-    ThreadNetif &mNetif;
 };
 
 }  // namespace MeshCoP

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -40,6 +40,7 @@
 
 #include <openthread/platform/settings.h>
 
+#include "openthread-instance.h"
 #include "common/code_utils.hpp"
 #include "common/settings.hpp"
 #include "meshcop/meshcop_tlvs.hpp"
@@ -49,9 +50,9 @@ namespace ot {
 namespace MeshCoP {
 
 Dataset::Dataset(otInstance *aInstance, const Tlv::Type aType) :
+    InstanceLocator(aInstance),
     mType(aType),
-    mLength(0),
-    mInstance(aInstance)
+    mLength(0)
 {
 }
 
@@ -61,7 +62,7 @@ void Dataset::Clear(bool isLocal)
 
     if (isLocal)
     {
-        otPlatSettingsDelete(mInstance, GetSettingsKey(), -1);
+        otPlatSettingsDelete(GetInstance(), GetSettingsKey(), -1);
     }
 }
 
@@ -436,7 +437,7 @@ otError Dataset::Restore(void)
     otError error;
     uint16_t length = sizeof(mTlvs);
 
-    error = otPlatSettingsGet(mInstance, GetSettingsKey(), 0, mTlvs, &length);
+    error = otPlatSettingsGet(GetInstance(), GetSettingsKey(), 0, mTlvs, &length);
     mLength = (error == OT_ERROR_NONE) ? length : 0;
 
     return error;
@@ -449,11 +450,11 @@ otError Dataset::Store(void)
 
     if (mLength == 0)
     {
-        error = otPlatSettingsDelete(mInstance, key, 0);
+        error = otPlatSettingsDelete(GetInstance(), key, 0);
     }
     else
     {
-        error = otPlatSettingsSet(mInstance, key, mTlvs, mLength);
+        error = otPlatSettingsSet(GetInstance(), key, mTlvs, mLength);
     }
 
     return error;

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -35,13 +35,14 @@
 #ifndef MESHCOP_DATASET_HPP_
 #define MESHCOP_DATASET_HPP_
 
+#include "common/locator.hpp"
 #include "common/message.hpp"
 #include "meshcop/meshcop_tlvs.hpp"
 
 namespace ot {
 namespace MeshCoP {
 
-class Dataset
+class Dataset: public InstanceLocator
 {
 public:
     enum
@@ -193,7 +194,6 @@ private:
     Tlv::Type  mType;            ///< Active or Pending
     uint8_t    mTlvs[kMaxSize];  ///< The Dataset buffer
     uint16_t   mLength;          ///< The number of valid bytes in @var mTlvs
-    otInstance *mInstance;       ///< The pointer to an OpenThread instance
 };
 
 }  // namespace MeshCoP

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -39,6 +39,7 @@
 #include <mbedtls/debug.h>
 #include <openthread/platform/radio.h>
 
+#include "openthread-instance.h"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/encoding.hpp"
@@ -53,6 +54,7 @@ namespace ot {
 namespace MeshCoP {
 
 Dtls::Dtls(ThreadNetif &aNetif):
+    ThreadNetifLocator(aNetif),
     mPskLength(0),
     mStarted(false),
     mTimer(aNetif.GetIp6().mTimerScheduler, &Dtls::HandleTimer, this),
@@ -66,8 +68,7 @@ Dtls::Dtls(ThreadNetif &aNetif):
     mSendHandler(NULL),
     mContext(NULL),
     mClient(false),
-    mMessageSubType(0),
-    mNetif(aNetif)
+    mMessageSubType(0)
 {
     memset(mPsk, 0, sizeof(mPsk));
     memset(&mEntropy, 0, sizeof(mEntropy));
@@ -76,11 +77,6 @@ Dtls::Dtls(ThreadNetif &aNetif):
     memset(&mConf, 0, sizeof(mConf));
     memset(&mCookieCtx, 0, sizeof(mCookieCtx));
     mProvisioningUrl.Init();
-}
-
-otInstance *Dtls::GetInstance(void)
-{
-    return mNetif.GetInstance();
 }
 
 otError Dtls::Start(bool aClient, ConnectedHandler aConnectedHandler, ReceiveHandler aReceiveHandler,
@@ -366,7 +362,7 @@ int Dtls::HandleMbedtlsExportKeys(const unsigned char *aMasterSecret, const unsi
     sha256.Update(aKeyBlock, 2 * static_cast<uint16_t>(aMacLength + aKeyLength + aIvLength));
     sha256.Finish(kek);
 
-    mNetif.GetKeyManager().SetKek(kek);
+    GetNetif().GetKeyManager().SetKek(kek);
 
     otLogInfoMeshCoP(GetInstance(), "Generated KEK");
 
@@ -374,9 +370,9 @@ int Dtls::HandleMbedtlsExportKeys(const unsigned char *aMasterSecret, const unsi
     return 0;
 }
 
-void Dtls::HandleTimer(void *aContext)
+void Dtls::HandleTimer(Timer &aTimer)
 {
-    static_cast<Dtls *>(aContext)->HandleTimer();
+    GetOwner(aTimer).HandleTimer();
 }
 
 void Dtls::HandleTimer(void)
@@ -512,6 +508,17 @@ void Dtls::HandleMbedtlsDebug(void *ctx, int level, const char *, int, const cha
         otLogDebgMbedTls(pThis->GetInstance(), "%s", str);
         break;
     }
+}
+
+Dtls &Dtls::GetOwner(const Context &aContext)
+{
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    Dtls &dtls = *static_cast<Dtls *>(aContext.GetContext());
+#else
+    Dtls &dtls = otGetThreadNetif().GetDtls();
+    OT_UNUSED_VARIABLE(aContext);
+#endif
+    return dtls;
 }
 
 }  // namespace MeshCoP

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -43,6 +43,7 @@
 #include <mbedtls/certs.h>
 #include <mbedtls/ssl_cookie.h>
 
+#include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/timer.hpp"
 #include "crypto/sha256.hpp"
@@ -54,7 +55,7 @@ class ThreadNetif;
 
 namespace MeshCoP {
 
-class Dtls
+class Dtls: public ThreadNetifLocator
 {
 public:
     enum
@@ -70,14 +71,6 @@ public:
      *
      */
     Dtls(ThreadNetif &aNetif);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This function pointer is called when a connection is established or torn down.
@@ -224,11 +217,13 @@ private:
     int HandleMbedtlsExportKeys(const unsigned char *aMasterSecret, const unsigned char *aKeyBlock,
                                 size_t aMacLength, size_t aKeyLength, size_t aIvLength);
 
-    static void HandleTimer(void *aContext);
+    static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
 
     void Close(void);
     void Process(void);
+
+    static Dtls &GetOwner(const Context &aContext);
 
     uint8_t mPsk[kPskMaxLength];
     uint8_t mPskLength;
@@ -255,8 +250,6 @@ private:
     bool mClient;
 
     uint8_t mMessageSubType;
-
-    ThreadNetif &mNetif;
 };
 
 }  // namespace MeshCoP

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -56,23 +56,19 @@ using ot::Encoding::BigEndian::HostSwap32;
 namespace ot {
 
 EnergyScanClient::EnergyScanClient(ThreadNetif &aThreadNetif) :
-    mEnergyScan(OT_URI_PATH_ENERGY_REPORT, &EnergyScanClient::HandleReport, this),
-    mNetif(aThreadNetif)
+    ThreadNetifLocator(aThreadNetif),
+    mEnergyScan(OT_URI_PATH_ENERGY_REPORT, &EnergyScanClient::HandleReport, this)
 {
     mContext = NULL;
     mCallback = NULL;
-    mNetif.GetCoap().AddResource(mEnergyScan);
-}
-
-otInstance *EnergyScanClient::GetInstance(void)
-{
-    return mNetif.GetInstance();
+    aThreadNetif.GetCoap().AddResource(mEnergyScan);
 }
 
 otError EnergyScanClient::SendQuery(uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod,
                                     uint16_t aScanDuration, const Ip6::Address &aAddress,
                                     otCommissionerEnergyReportCallback aCallback, void *aContext)
 {
+    ThreadNetif &netif = GetNetif();
     otError error = OT_ERROR_NONE;
     Coap::Header header;
     MeshCoP::CommissionerSessionIdTlv sessionId;
@@ -83,7 +79,7 @@ otError EnergyScanClient::SendQuery(uint32_t aChannelMask, uint8_t aCount, uint1
     Ip6::MessageInfo messageInfo;
     Message *message = NULL;
 
-    VerifyOrExit(mNetif.GetCommissioner().IsActive(), error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(netif.GetCommissioner().IsActive(), error = OT_ERROR_INVALID_STATE);
 
     header.Init(aAddress.IsMulticast() ? OT_COAP_TYPE_NON_CONFIRMABLE : OT_COAP_TYPE_CONFIRMABLE,
                 OT_COAP_CODE_POST);
@@ -91,11 +87,11 @@ otError EnergyScanClient::SendQuery(uint32_t aChannelMask, uint8_t aCount, uint1
     header.AppendUriPathOptions(OT_URI_PATH_ENERGY_SCAN);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL,
+    VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(netif.GetCoap(), header)) != NULL,
                  error = OT_ERROR_NO_BUFS);
 
     sessionId.Init();
-    sessionId.SetCommissionerSessionId(mNetif.GetCommissioner().GetSessionId());
+    sessionId.SetCommissionerSessionId(netif.GetCommissioner().GetSessionId());
     SuccessOrExit(error = message->Append(&sessionId, sizeof(sessionId)));
 
     channelMask.Init();
@@ -114,11 +110,11 @@ otError EnergyScanClient::SendQuery(uint32_t aChannelMask, uint8_t aCount, uint1
     scanDuration.SetScanDuration(aScanDuration);
     SuccessOrExit(error = message->Append(&scanDuration, sizeof(scanDuration)));
 
-    messageInfo.SetSockAddr(mNetif.GetMle().GetMeshLocal16());
+    messageInfo.SetSockAddr(netif.GetMle().GetMeshLocal16());
     messageInfo.SetPeerAddr(aAddress);
     messageInfo.SetPeerPort(kCoapUdpPort);
-    messageInfo.SetInterfaceId(mNetif.GetInterfaceId());
-    SuccessOrExit(error = mNetif.GetCoap().SendMessage(*message, messageInfo));
+    messageInfo.SetInterfaceId(netif.GetInterfaceId());
+    SuccessOrExit(error = netif.GetCoap().SendMessage(*message, messageInfo));
 
     otLogInfoMeshCoP(GetInstance(), "sent energy scan query");
 
@@ -145,6 +141,7 @@ void EnergyScanClient::HandleReport(void *aContext, otCoapHeader *aHeader, otMes
 
 void EnergyScanClient::HandleReport(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
+    ThreadNetif &netif = GetNetif();
     MeshCoP::ChannelMask0Tlv channelMask;
     Ip6::MessageInfo responseInfo(aMessageInfo);
 
@@ -171,7 +168,7 @@ void EnergyScanClient::HandleReport(Coap::Header &aHeader, Message &aMessage, co
         mCallback(channelMask.GetMask(), energyList.list, energyList.tlv.GetLength(), mContext);
     }
 
-    SuccessOrExit(mNetif.GetCoap().SendEmptyAck(aHeader, responseInfo));
+    SuccessOrExit(netif.GetCoap().SendEmptyAck(aHeader, responseInfo));
 
     otLogInfoMeshCoP(GetInstance(), "sent energy scan report response");
 

--- a/src/core/meshcop/energy_scan_client.hpp
+++ b/src/core/meshcop/energy_scan_client.hpp
@@ -38,6 +38,7 @@
 
 #include "openthread-core-config.h"
 #include "coap/coap.hpp"
+#include "common/locator.hpp"
 #include "net/ip6_address.hpp"
 #include "net/udp6.hpp"
 
@@ -49,7 +50,7 @@ class ThreadNetif;
  * This class implements handling PANID Query Requests.
  *
  */
-class EnergyScanClient
+class EnergyScanClient: public ThreadNetifLocator
 {
 public:
     /**
@@ -57,14 +58,6 @@ public:
      *
      */
     EnergyScanClient(ThreadNetif &aThreadNetif);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This method sends an Energy Scan Query message.
@@ -93,8 +86,6 @@ private:
     void *mContext;
 
     Coap::Resource mEnergyScan;
-
-    ThreadNetif &mNetif;
 };
 
 /**

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -40,6 +40,7 @@
 #include "coap/coap_header.hpp"
 #include "coap/coap_secure.hpp"
 #include "common/crc16.hpp"
+#include "common/locator.hpp"
 #include "common/message.hpp"
 #include "meshcop/dtls.hpp"
 #include "meshcop/meshcop_tlvs.hpp"
@@ -51,7 +52,7 @@ class ThreadNetif;
 
 namespace MeshCoP {
 
-class Joiner
+class Joiner: public ThreadNetifLocator
 {
 public:
     /**
@@ -61,14 +62,6 @@ public:
      *
      */
     Joiner(ThreadNetif &aThreadNetif);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This method starts the Joiner service.
@@ -108,7 +101,7 @@ private:
     static void HandleDiscoverResult(otActiveScanResult *aResult, void *aContext);
     void HandleDiscoverResult(otActiveScanResult *aResult);
 
-    static void HandleTimer(void *aContext);
+    static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
 
     void Close(void);
@@ -127,6 +120,8 @@ private:
                                     const otMessageInfo *aMessageInfo);
     void HandleJoinerEntrust(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     void SendJoinerEntrustResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aRequestInfo);
+
+    static Joiner &GetOwner(const Context &aContext);
 
     enum State
     {
@@ -157,7 +152,6 @@ private:
 
     Timer mTimer;
     Coap::Resource mJoinerEntrust;
-    ThreadNetif &mNetif;
 };
 
 }  // namespace MeshCoP

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -38,6 +38,7 @@
 
 #include "coap/coap.hpp"
 #include "coap/coap_header.hpp"
+#include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/timer.hpp"
 #include "mac/mac_frame.hpp"
@@ -51,7 +52,7 @@ class ThreadNetif;
 
 namespace MeshCoP {
 
-class JoinerRouter
+class JoinerRouter: public ThreadNetifLocator
 {
 public:
     /**
@@ -61,14 +62,6 @@ public:
      *
      */
     JoinerRouter(ThreadNetif &aNetif);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This method returns the Joiner UDP Port.
@@ -109,7 +102,7 @@ private:
     void HandleJoinerEntrustResponse(Coap::Header *aHeader, Message *aMessage,
                                      const Ip6::MessageInfo *aMessageInfo, otError result);
 
-    static void HandleTimer(void *aContext);
+    static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
 
     otError DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessageInfo, const JoinerRouterKekTlv &aKek);
@@ -118,11 +111,12 @@ private:
 
     otError GetBorderAgentRloc(uint16_t &aRloc);
 
+    static JoinerRouter &GetOwner(const Context &aContext);
+
     Ip6::NetifCallback mNetifCallback;
 
     Ip6::UdpSocket mSocket;
     Coap::Resource mRelayTransmit;
-    ThreadNetif &mNetif;
 
     Timer mTimer;
     MessageQueue mDelayedJoinEnts;

--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -43,6 +43,7 @@
 
 #include <openthread/platform/random.h>
 
+#include "openthread-instance.h"
 #include "coap/coap_header.hpp"
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
@@ -56,20 +57,15 @@ namespace ot {
 namespace MeshCoP {
 
 Leader::Leader(ThreadNetif &aThreadNetif):
+    ThreadNetifLocator(aThreadNetif),
     mPetition(OT_URI_PATH_LEADER_PETITION, Leader::HandlePetition, this),
     mKeepAlive(OT_URI_PATH_LEADER_KEEP_ALIVE, Leader::HandleKeepAlive, this),
     mTimer(aThreadNetif.GetIp6().mTimerScheduler, HandleTimer, this),
     mDelayTimerMinimal(DelayTimerTlv::kDelayTimerMinimal),
-    mSessionId(0xffff),
-    mNetif(aThreadNetif)
+    mSessionId(0xffff)
 {
-    mNetif.GetCoap().AddResource(mPetition);
-    mNetif.GetCoap().AddResource(mKeepAlive);
-}
-
-otInstance *Leader::GetInstance(void)
-{
-    return mNetif.GetInstance();
+    aThreadNetif.GetCoap().AddResource(mPetition);
+    aThreadNetif.GetCoap().AddResource(mKeepAlive);
 }
 
 void Leader::HandlePetition(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
@@ -109,7 +105,8 @@ void Leader::HandlePetition(Coap::Header &aHeader, Message &aMessage, const Ip6:
     data.mSteeringData.SetLength(1);
     data.mSteeringData.Clear();
 
-    SuccessOrExit(mNetif.GetNetworkDataLeader().SetCommissioningData(reinterpret_cast<uint8_t *>(&data), data.GetLength()));
+    SuccessOrExit(GetNetif().GetNetworkDataLeader().SetCommissioningData(reinterpret_cast<uint8_t *>(&data),
+                                                                         data.GetLength()));
 
     mCommissionerId = commissionerId;
 
@@ -124,6 +121,7 @@ exit:
 otError Leader::SendPetitionResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
                                      StateTlv::State aState)
 {
+    ThreadNetif &netif = GetNetif();
     otError error = OT_ERROR_NONE;
     Coap::Header responseHeader;
     StateTlv state;
@@ -133,7 +131,7 @@ otError Leader::SendPetitionResponse(const Coap::Header &aRequestHeader, const I
     responseHeader.SetDefaultResponseHeader(aRequestHeader);
     responseHeader.SetPayloadMarker();
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), responseHeader)) != NULL, error = OT_ERROR_NO_BUFS);
+    VerifyOrExit((message = NewMeshCoPMessage(netif.GetCoap(), responseHeader)) != NULL, error = OT_ERROR_NO_BUFS);
 
     state.Init();
     state.SetState(aState);
@@ -152,7 +150,7 @@ otError Leader::SendPetitionResponse(const Coap::Header &aRequestHeader, const I
         SuccessOrExit(error = message->Append(&sessionId, sizeof(sessionId)));
     }
 
-    SuccessOrExit(error = mNetif.GetCoap().SendMessage(*message, aMessageInfo));
+    SuccessOrExit(error = netif.GetCoap().SendMessage(*message, aMessageInfo));
 
     otLogInfoMeshCoP(GetInstance(), "sent petition response");
 
@@ -212,22 +210,22 @@ exit:
 otError Leader::SendKeepAliveResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
                                       StateTlv::State aState)
 {
+    ThreadNetif &netif = GetNetif();
     otError error = OT_ERROR_NONE;
     Coap::Header responseHeader;
     StateTlv state;
     Message *message;
 
-
     responseHeader.SetDefaultResponseHeader(aRequestHeader);
     responseHeader.SetPayloadMarker();
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), responseHeader)) != NULL, error = OT_ERROR_NO_BUFS);
+    VerifyOrExit((message = NewMeshCoPMessage(netif.GetCoap(), responseHeader)) != NULL, error = OT_ERROR_NO_BUFS);
 
     state.Init();
     state.SetState(aState);
     SuccessOrExit(error = message->Append(&state, sizeof(state)));
 
-    SuccessOrExit(error = mNetif.GetCoap().SendMessage(*message, aMessageInfo));
+    SuccessOrExit(error = netif.GetCoap().SendMessage(*message, aMessageInfo));
 
     otLogInfoMeshCoP(GetInstance(), "sent keep alive response");
 
@@ -243,6 +241,7 @@ exit:
 
 otError Leader::SendDatasetChanged(const Ip6::Address &aAddress)
 {
+    ThreadNetif &netif = GetNetif();
     otError error = OT_ERROR_NONE;
     Coap::Header header;
     Ip6::MessageInfo messageInfo;
@@ -252,12 +251,12 @@ otError Leader::SendDatasetChanged(const Ip6::Address &aAddress)
     header.SetToken(Coap::Header::kDefaultTokenLength);
     header.AppendUriPathOptions(OT_URI_PATH_DATASET_CHANGED);
 
-    VerifyOrExit((message = NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = OT_ERROR_NO_BUFS);
+    VerifyOrExit((message = NewMeshCoPMessage(netif.GetCoap(), header)) != NULL, error = OT_ERROR_NO_BUFS);
 
-    messageInfo.SetSockAddr(mNetif.GetMle().GetMeshLocal16());
+    messageInfo.SetSockAddr(netif.GetMle().GetMeshLocal16());
     messageInfo.SetPeerAddr(aAddress);
     messageInfo.SetPeerPort(kCoapUdpPort);
-    SuccessOrExit(error = mNetif.GetCoap().SendMessage(*message, messageInfo));
+    SuccessOrExit(error = netif.GetCoap().SendMessage(*message, messageInfo));
 
     otLogInfoMeshCoP(GetInstance(), "sent dataset changed");
 
@@ -287,14 +286,14 @@ uint32_t Leader::GetDelayTimerMinimal(void) const
     return mDelayTimerMinimal;
 }
 
-void Leader::HandleTimer(void *aContext)
+void Leader::HandleTimer(Timer &aTimer)
 {
-    static_cast<Leader *>(aContext)->HandleTimer();
+    GetOwner(aTimer).HandleTimer();
 }
 
 void Leader::HandleTimer(void)
 {
-    VerifyOrExit(mNetif.GetMle().GetRole() == OT_DEVICE_ROLE_LEADER);
+    VerifyOrExit(GetNetif().GetMle().GetRole() == OT_DEVICE_ROLE_LEADER);
 
     ResignCommissioner();
 
@@ -309,8 +308,8 @@ void Leader::SetEmptyCommissionerData(void)
     mCommissionerSessionId.Init();
     mCommissionerSessionId.SetCommissionerSessionId(++mSessionId);
 
-    mNetif.GetNetworkDataLeader().SetCommissioningData(reinterpret_cast<uint8_t *>(&mCommissionerSessionId),
-                                                       sizeof(Tlv) + mCommissionerSessionId.GetLength());
+    GetNetif().GetNetworkDataLeader().SetCommissioningData(reinterpret_cast<uint8_t *>(&mCommissionerSessionId),
+                                                           sizeof(Tlv) + mCommissionerSessionId.GetLength());
 }
 
 void Leader::ResignCommissioner(void)
@@ -319,6 +318,17 @@ void Leader::ResignCommissioner(void)
     SetEmptyCommissionerData();
 
     otLogInfoMeshCoP(GetInstance(), "commissioner inactive");
+}
+
+Leader &Leader::GetOwner(const Context &aContext)
+{
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    Leader &leader = *static_cast<Leader *>(aContext.GetContext());
+#else
+    Leader &leader = otGetThreadNetif().GetLeader();
+    OT_UNUSED_VARIABLE(aContext);
+#endif
+    return leader;
 }
 
 }  // namespace MeshCoP

--- a/src/core/meshcop/leader.hpp
+++ b/src/core/meshcop/leader.hpp
@@ -35,6 +35,7 @@
 #define MESHCOP_LEADER_HPP_
 
 #include "coap/coap.hpp"
+#include "common/locator.hpp"
 #include "common/timer.hpp"
 #include "meshcop/meshcop_tlvs.hpp"
 #include "net/udp6.hpp"
@@ -58,7 +59,7 @@ public:
     SteeringDataTlv mSteeringData;
 } OT_TOOL_PACKED_END;
 
-class Leader
+class Leader: public ThreadNetifLocator
 {
 public:
     /**
@@ -68,14 +69,6 @@ public:
      *
      */
     Leader(ThreadNetif &aThreadNetif);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This method sends a MGMT_DATASET_CHANGED message to commissioner.
@@ -119,7 +112,7 @@ private:
         kTimeoutLeaderPetition = 50, ///< TIMEOUT_LEAD_PET (seconds)
     };
 
-    static void HandleTimer(void *aContext);
+    static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
 
     static void HandlePetition(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
@@ -138,6 +131,8 @@ private:
 
     void ResignCommissioner(void);
 
+    static Leader &GetOwner(const Context &aContext);
+
     Coap::Resource mPetition;
     Coap::Resource mKeepAlive;
     Timer mTimer;
@@ -146,7 +141,6 @@ private:
 
     CommissionerIdTlv mCommissionerId;
     uint16_t mSessionId;
-    ThreadNetif &mNetif;
 };
 
 }  // namespace MeshCoP

--- a/src/core/meshcop/panid_query_client.hpp
+++ b/src/core/meshcop/panid_query_client.hpp
@@ -38,6 +38,7 @@
 
 #include "openthread-core-config.h"
 #include "coap/coap.hpp"
+#include "common/locator.hpp"
 #include "net/ip6_address.hpp"
 #include "net/udp6.hpp"
 
@@ -49,7 +50,7 @@ class ThreadNetif;
  * This class implements handling PANID Query Requests.
  *
  */
-class PanIdQueryClient
+class PanIdQueryClient: public ThreadNetifLocator
 {
 public:
     /**
@@ -57,14 +58,6 @@ public:
      *
      */
     PanIdQueryClient(ThreadNetif &aThreadNetif);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This method sends a PAN ID Query message.
@@ -91,8 +84,6 @@ private:
     void *mContext;
 
     Coap::Resource mPanIdQuery;
-
-    ThreadNetif &mNetif;
 };
 
 /**

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -36,6 +36,7 @@
 
 #include <openthread/dhcp6_client.h>
 
+#include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/timer.hpp"
 #include "common/trickle_timer.hpp"
@@ -167,7 +168,7 @@ private:
  * This class implements DHCPv6 Client.
  *
  */
-class Dhcp6Client
+class Dhcp6Client: public ThreadNetifLocator
 {
 public:
     /**
@@ -177,14 +178,6 @@ public:
      *
      */
     explicit Dhcp6Client(ThreadNetif &aThreadNetif);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This method update addresses that shall be automatically created using DHCP.
@@ -226,13 +219,14 @@ private:
     otError ProcessStatusCode(Message &aMessage, uint16_t aOffset);
     otError ProcessIaAddress(Message &aMessage, uint16_t aOffset);
 
-    static bool HandleTrickleTimer(void *aContext);
+    static bool HandleTrickleTimer(TrickleTimer &aTrickleTimer);
     bool HandleTrickleTimer(void);
+
+    static Dhcp6Client &GetOwner(const Context &aContext);
 
     TrickleTimer mTrickleTimer;
 
     Ip6::UdpSocket mSocket;
-    ThreadNetif &mNetif;
 
     uint8_t mTransactionId[kTransactionIdSize];
     uint32_t mStartTime;

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -36,6 +36,7 @@
 
 #include <openthread/types.h>
 
+#include "common/locator.hpp"
 #include "mac/mac_frame.hpp"
 #include "mac/mac.hpp"
 #include "net/dhcp6.hpp"
@@ -99,7 +100,7 @@ private:
     otIp6Prefix mIp6Prefix;                  ///< prefix
 } OT_TOOL_PACKED_END;
 
-class Dhcp6Server
+class Dhcp6Server: public ThreadNetifLocator
 {
 public:
     /**
@@ -148,8 +149,6 @@ private:
     otError SendReply(otIp6Address &aDst, uint8_t *aTransactionId, ClientIdentifier &aClientIdentifier, IaNa &aIaNa);
 
     Ip6::UdpSocket mSocket;
-
-    ThreadNetif &mNetif;
 
     Ip6::NetifUnicastAddress mAgentsAloc[OPENTHREAD_CONFIG_NUM_DHCP_PREFIXES];
     PrefixAgent mPrefixAgents[OPENTHREAD_CONFIG_NUM_DHCP_PREFIXES];

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -35,6 +35,7 @@
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "net/udp6.hpp"
+#include "thread/thread_netif.hpp"
 
 #if OPENTHREAD_ENABLE_DNS_CLIENT
 
@@ -381,9 +382,9 @@ void Client::FinalizeDnsTransaction(Message &aQuery, const QueryMetadata &aQuery
     }
 }
 
-void Client::HandleRetransmissionTimer(void *aContext)
+void Client::HandleRetransmissionTimer(Timer &aTimer)
 {
-    static_cast<Client *>(aContext)->HandleRetransmissionTimer();
+    GetOwner(aTimer).HandleRetransmissionTimer();
 }
 
 void Client::HandleRetransmissionTimer(void)
@@ -516,6 +517,17 @@ exit:
     }
 
     return;
+}
+
+Client &Client::GetOwner(const Context &aContext)
+{
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    Client &client = *static_cast<Client *>(aContext.GetContext());
+#else
+    Client &client = otGetThreadNetif().GetDnsClient();
+    OT_UNUSED_VARIABLE(aContext);
+#endif
+    return client;
 }
 
 }  // namespace Coap

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -46,7 +46,6 @@
 namespace ot {
 namespace Dns {
 
-
 /**
  * This class implements metadata required for DNS retransmission.
  *
@@ -245,11 +244,13 @@ private:
                                 otIp6Address *aAddress, uint32_t aTtl,
                                 otError aResult);
 
-    static void HandleRetransmissionTimer(void *aContext);
+    static void HandleRetransmissionTimer(Timer &aTimer);
     void HandleRetransmissionTimer(void);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+
+    static Client &GetOwner(const Context &aContext);
 
     Ip6::UdpSocket mSocket;
 

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -37,6 +37,7 @@
 #include <openthread/icmp6.h>
 
 #include "common/encoding.hpp"
+#include "common/locator.hpp"
 #include "net/ip6_headers.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
@@ -219,7 +220,7 @@ private:
  * This class implements ICMPv6.
  *
  */
-class Icmp
+class Icmp: public Ip6Locator
 {
 public:
     /**
@@ -229,14 +230,6 @@ public:
      *
      */
     Icmp(Ip6 &aIp6);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This method returns a new ICMP message with sufficient header space reserved.
@@ -337,8 +330,6 @@ private:
 
     uint16_t mEchoSequence;
     bool mIsEchoEnabled;
-
-    Ip6 &mIp6;
 };
 
 /**

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -421,9 +421,9 @@ exit:
     return error;
 }
 
-void Ip6::HandleSendQueue(void *aContext)
+void Ip6::HandleSendQueue(Tasklet &aTasklet)
 {
-    static_cast<Ip6 *>(aContext)->HandleSendQueue();
+    GetOwner(aTasklet).HandleSendQueue();
 }
 
 void Ip6::HandleSendQueue(void)
@@ -1117,6 +1117,17 @@ exit:
 otInstance *Ip6::GetInstance(void)
 {
     return otInstanceFromIp6(this);
+}
+
+Ip6 &Ip6::GetOwner(const Context &aContext)
+{
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    Ip6 &ip6 = *static_cast<Ip6 *>(aContext.GetContext());
+#else
+    Ip6 &ip6 = otGetIp6();
+    OT_UNUSED_VARIABLE(aContext);
+#endif
+    return ip6;
 }
 
 const char *Ip6::IpProtoToString(IpProto aIpProto)

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -377,7 +377,7 @@ public:
     TimerScheduler mTimerScheduler;
 
 private:
-    static void HandleSendQueue(void *aContext);
+    static void HandleSendQueue(Tasklet &aTasklet);
     void HandleSendQueue(void);
 
     otError ProcessReceiveCallback(const Message &aMessage, const MessageInfo &aMessageInfo, uint8_t aIpProto,
@@ -392,6 +392,8 @@ private:
     otError HandleOptions(Message &aMessage, Header &aHeader, bool &aForward);
     otError HandlePayload(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aIpProto);
     int8_t FindForwardInterfaceId(const MessageInfo &aMessageInfo);
+
+    static Ip6 &GetOwner(const Context &aContext);
 
     bool mForwardingEnabled;
 

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -36,6 +36,7 @@
 
 #include <openthread/types.h>
 
+#include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/timer.hpp"
 #include "net/ip6_headers.hpp"
@@ -427,7 +428,7 @@ private:
  * This class implements MPL message processing.
  *
  */
-class Mpl
+class Mpl: public Ip6Locator
 {
 public:
     /**
@@ -526,13 +527,13 @@ private:
     void UpdateBufferedSet(uint16_t aSeedId, uint8_t aSequence);
     void AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSequence, bool aIsOutbound);
 
-    static void HandleSeedSetTimer(void *aContext);
+    static void HandleSeedSetTimer(Timer &aTimer);
     void HandleSeedSetTimer(void);
 
-    static void HandleRetransmissionTimer(void *aContext);
+    static void HandleRetransmissionTimer(Timer &aTimer);
     void HandleRetransmissionTimer(void);
 
-    Ip6 &mIp6;
+    static Mpl &GetOwner(const Context &aContext);
 
     Timer mSeedSetTimer;
     Timer mRetransmissionTimer;

--- a/src/core/net/ip6_routes.cpp
+++ b/src/core/net/ip6_routes.cpp
@@ -44,8 +44,8 @@ namespace ot {
 namespace Ip6 {
 
 Routes::Routes(Ip6 &aIp6):
-    mRoutes(NULL),
-    mIp6(aIp6)
+    Ip6Locator(aIp6),
+    mRoutes(NULL)
 {
 }
 
@@ -117,7 +117,7 @@ int8_t Routes::Lookup(const Address &aSource, const Address &aDestination)
         rval = cur->mInterfaceId;
     }
 
-    for (Netif *netif = mIp6.GetNetifList(); netif; netif = netif->GetNext())
+    for (Netif *netif = GetIp6().GetNetifList(); netif; netif = netif->GetNext())
     {
         if (netif->RouteLookup(aSource, aDestination, &prefixMatch) == OT_ERROR_NONE &&
             static_cast<int8_t>(prefixMatch) > maxPrefixMatch)

--- a/src/core/net/ip6_routes.hpp
+++ b/src/core/net/ip6_routes.hpp
@@ -36,6 +36,7 @@
 
 #include <openthread/types.h>
 
+#include "common/locator.hpp"
 #include "common/message.hpp"
 #include "net/ip6_address.hpp"
 #include "net/ip6_routes.hpp"
@@ -68,7 +69,7 @@ struct Route
  * This class implements IPv6 route management.
  *
  */
-class Routes
+class Routes: public Ip6Locator
 {
 public:
     /**
@@ -114,7 +115,6 @@ public:
 
 private:
     Route *mRoutes;
-    Ip6 &mIp6;
 };
 
 /**

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -34,6 +34,7 @@
 #ifndef NET_NETIF_HPP_
 #define NET_NETIF_HPP_
 
+#include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/tasklet.hpp"
 #include "mac/mac_frame.hpp"
@@ -247,7 +248,7 @@ private:
  * This class implements an IPv6 network interface.
  *
  */
-class Netif
+class Netif: public Ip6Locator
 {
     friend class Ip6;
 
@@ -260,14 +261,6 @@ public:
      *
      */
     Netif(Ip6 &aIp6, int8_t aInterfaceId);
-
-    /**
-     * This method returns a reference to the IPv6 network object.
-     *
-     * @returns A reference to the IPv6 network object.
-     *
-     */
-    Ip6 &GetIp6(void) { return mIp6; }
 
     /**
      * This method returns the next network interface in the list.
@@ -527,12 +520,10 @@ public:
     virtual otError RouteLookup(const Address &aSource, const Address &aDestination,
                                 uint8_t *aPrefixMatch) = 0;
 
-protected:
-    Ip6 &mIp6;
-
 private:
-    static void HandleStateChangedTask(void *aContext);
+    static void HandleStateChangedTask(Tasklet &aTasklet);
     void HandleStateChangedTask(void);
+    static Netif &GetOwner(const Context &aContext);
 
     NetifCallback *mCallbacks;
     NetifUnicastAddress *mUnicastAddresses;

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -128,9 +128,9 @@ exit:
 }
 
 Udp::Udp(Ip6 &aIp6):
+    Ip6Locator(aIp6),
     mEphemeralPort(kDynamicPortMin),
-    mSockets(NULL),
-    mIp6(aIp6)
+    mSockets(NULL)
 {
 }
 
@@ -192,12 +192,12 @@ uint16_t Udp::GetEphemeralPort(void)
 
 Message *Udp::NewMessage(uint16_t aReserved)
 {
-    return mIp6.NewMessage(sizeof(UdpHeader) + aReserved);
+    return GetIp6().NewMessage(sizeof(UdpHeader) + aReserved);
 }
 
 otError Udp::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, IpProto aIpProto)
 {
-    return mIp6.SendDatagram(aMessage, aMessageInfo, aIpProto);
+    return GetIp6().SendDatagram(aMessage, aMessageInfo, aIpProto);
 }
 
 otError Udp::HandleMessage(Message &aMessage, MessageInfo &aMessageInfo)

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -36,6 +36,7 @@
 
 #include <openthread/udp.h>
 
+#include "common/locator.hpp"
 #include "net/ip6_headers.hpp"
 
 namespace ot {
@@ -160,7 +161,7 @@ private:
  * This class implements core UDP message handling.
  *
  */
-class Udp
+class Udp: public Ip6Locator
 {
     friend class UdpSocket;
 
@@ -256,8 +257,6 @@ private:
     };
     uint16_t mEphemeralPort;
     UdpSocket *mSockets;
-
-    Ip6 &mIp6;
 };
 
 OT_TOOL_PACKED_BEGIN

--- a/src/core/openthread-instance.h
+++ b/src/core/openthread-instance.h
@@ -44,11 +44,10 @@
 #include <openthread/platform/logging.h>
 
 #include "openthread-core-config.h"
-
+#include "openthread-single-instance.h"
 #if OPENTHREAD_ENABLE_RAW_LINK_API
 #include "api/link_raw.hpp"
 #endif
-
 #include "coap/coap.hpp"
 #include "crypto/mbedtls.hpp"
 #include "net/ip6.hpp"
@@ -78,7 +77,7 @@ typedef struct otInstance
     // State
     //
 
-#ifndef OPENTHREAD_MULTIPLE_INSTANCE
+#if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
     ot::Crypto::MbedTls mMbedTls;
 #endif
     ot::Ip6::Ip6 mIp6;

--- a/src/core/openthread-single-instance.h
+++ b/src/core/openthread-single-instance.h
@@ -1,0 +1,108 @@
+/*
+ *  Copyright (c) 2017, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * @brief
+ *  This file defines the getter functions for single instance OpenThread objects.
+ */
+
+#ifndef SINGLE_OPENTHREAD_INSTANCE_H_
+#define SINGLE_OPENTHREAD_INSTANCE_H_
+
+#include <openthread/config.h>
+
+#include <openthread/types.h>
+
+#include "openthread-core-config.h"
+
+
+#if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+
+namespace ot {
+
+class ThreadNetif;
+class MeshForwarder;
+class TimerScheduler;
+class TaskletScheduler;
+namespace Ip6 { class Ip6; }
+
+} // namespace ot
+
+/**
+ * This function returns a pointer to the single otInstance (if initialized and ready).
+ *
+ * @returns A pointer to single otInstance structure, or NULL if the instance is not ready, i.e. either it is not yet
+ *          initialized (no call to `otInstanceInitSingle()`) or it is finalized (call to `otInstanceFinalize()`).
+ *
+ */
+otInstance *otGetInstance(void);
+
+/**
+ * This function returns a reference to the single thread network interface instance.
+ *
+ * @returns A reference to the thread network interface instance.
+ *
+ */
+ot::ThreadNetif &otGetThreadNetif(void);
+
+/**
+ * This function returns a reference to the single MeshForwarder instance.
+ *
+ * @returns A reference to the MeshForwarder instance.
+ *
+ */
+ot::MeshForwarder &otGetMeshForwarder(void);
+
+/**
+ * This function returns a reference to the single TimerScheduler instance.
+ *
+ * @returns A reference to the TimerScheduler instance.
+ *
+ */
+ot::TimerScheduler &otGetTimerScheduler(void);
+
+/**
+ * This function returns a reference to the single TaskletShceduler instance.
+ *
+ * @returns A reference to the TaskletShceduler instance.
+ *
+ */
+ot::TaskletScheduler &otGetTaskletScheduler(void);
+
+/**
+ * This function returns a reference to the single Ip6 instance.
+ *
+ * @returns A reference to the Ip6 instance.
+ *
+ */
+ot::Ip6::Ip6 &otGetIp6(void);
+
+#endif // #if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+
+#endif  // SINGLE_OPENTHREAD_INSTANCE_H_

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -41,6 +41,7 @@
 
 #include <openthread/platform/random.h>
 
+#include "openthread-instance.h"
 #include "coap/coap_header.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
@@ -58,25 +59,20 @@ using ot::Encoding::BigEndian::HostSwap16;
 namespace ot {
 
 AddressResolver::AddressResolver(ThreadNetif &aThreadNetif) :
+    ThreadNetifLocator(aThreadNetif),
     mAddressError(OT_URI_PATH_ADDRESS_ERROR, &AddressResolver::HandleAddressError, this),
     mAddressQuery(OT_URI_PATH_ADDRESS_QUERY, &AddressResolver::HandleAddressQuery, this),
     mAddressNotification(OT_URI_PATH_ADDRESS_NOTIFY, &AddressResolver::HandleAddressNotification, this),
     mIcmpHandler(&AddressResolver::HandleIcmpReceive, this),
-    mTimer(aThreadNetif.GetIp6().mTimerScheduler, &AddressResolver::HandleTimer, this),
-    mNetif(aThreadNetif)
+    mTimer(aThreadNetif.GetIp6().mTimerScheduler, &AddressResolver::HandleTimer, this)
 {
     Clear();
 
-    mNetif.GetCoap().AddResource(mAddressError);
-    mNetif.GetCoap().AddResource(mAddressQuery);
-    mNetif.GetCoap().AddResource(mAddressNotification);
+    aThreadNetif.GetCoap().AddResource(mAddressError);
+    aThreadNetif.GetCoap().AddResource(mAddressQuery);
+    aThreadNetif.GetCoap().AddResource(mAddressNotification);
 
-    mNetif.GetIp6().mIcmp.RegisterHandler(mIcmpHandler);
-}
-
-otInstance *AddressResolver::GetInstance(void)
-{
-    return mNetif.GetInstance();
+    aThreadNetif.GetIp6().mIcmp.RegisterHandler(mIcmpHandler);
 }
 
 void AddressResolver::Clear()
@@ -233,6 +229,7 @@ exit:
 
 otError AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
 {
+    ThreadNetif &netif = GetNetif();
     otError error;
     Message *message;
     Coap::Header header;
@@ -243,7 +240,7 @@ otError AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
     header.AppendUriPathOptions(OT_URI_PATH_ADDRESS_QUERY);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
+    VerifyOrExit((message = netif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     targetTlv.Init();
     targetTlv.SetTarget(aEid);
@@ -251,11 +248,11 @@ otError AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
 
     messageInfo.GetPeerAddr().mFields.m16[0] = HostSwap16(0xff03);
     messageInfo.GetPeerAddr().mFields.m16[7] = HostSwap16(0x0002);
-    messageInfo.SetSockAddr(mNetif.GetMle().GetMeshLocal16());
+    messageInfo.SetSockAddr(netif.GetMle().GetMeshLocal16());
     messageInfo.SetPeerPort(kCoapUdpPort);
-    messageInfo.SetInterfaceId(mNetif.GetInterfaceId());
+    messageInfo.SetInterfaceId(netif.GetInterfaceId());
 
-    SuccessOrExit(error = mNetif.GetCoap().SendMessage(*message, messageInfo));
+    SuccessOrExit(error = netif.GetCoap().SendMessage(*message, messageInfo));
 
     otLogInfoArp(GetInstance(), "Sent address query");
 
@@ -285,6 +282,7 @@ void AddressResolver::HandleAddressNotification(void *aContext, otCoapHeader *aH
 void AddressResolver::HandleAddressNotification(Coap::Header &aHeader, Message &aMessage,
                                                 const Ip6::MessageInfo &aMessageInfo)
 {
+    ThreadNetif &netif = GetNetif();
     ThreadTargetTlv targetTlv;
     ThreadMeshLocalEidTlv mlIidTlv;
     ThreadRloc16Tlv rloc16Tlv;
@@ -351,12 +349,12 @@ void AddressResolver::HandleAddressNotification(Coap::Header &aHeader, Message &
             mCache[i].mState = Cache::kStateCached;
             MarkCacheEntryAsUsed(mCache[i]);
 
-            if (mNetif.GetCoap().SendEmptyAck(aHeader, aMessageInfo) == OT_ERROR_NONE)
+            if (netif.GetCoap().SendEmptyAck(aHeader, aMessageInfo) == OT_ERROR_NONE)
             {
                 otLogInfoArp(GetInstance(), "Sent address notification acknowledgment");
             }
 
-            mNetif.GetMeshForwarder().HandleResolved(*targetTlv.GetTarget(), OT_ERROR_NONE);
+            netif.GetMeshForwarder().HandleResolved(*targetTlv.GetTarget(), OT_ERROR_NONE);
             break;
         }
     }
@@ -368,6 +366,7 @@ exit:
 otError AddressResolver::SendAddressError(const ThreadTargetTlv &aTarget, const ThreadMeshLocalEidTlv &aEid,
                                           const Ip6::Address *aDestination)
 {
+    ThreadNetif &netif = GetNetif();
     otError error;
     Message *message;
     Coap::Header header;
@@ -378,7 +377,7 @@ otError AddressResolver::SendAddressError(const ThreadTargetTlv &aTarget, const 
     header.AppendUriPathOptions(OT_URI_PATH_ADDRESS_ERROR);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
+    VerifyOrExit((message = netif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     SuccessOrExit(error = message->Append(&aTarget, sizeof(aTarget)));
     SuccessOrExit(error = message->Append(&aEid, sizeof(aEid)));
@@ -393,11 +392,11 @@ otError AddressResolver::SendAddressError(const ThreadTargetTlv &aTarget, const 
         memcpy(&messageInfo.GetPeerAddr(), aDestination, sizeof(messageInfo.GetPeerAddr()));
     }
 
-    messageInfo.SetSockAddr(mNetif.GetMle().GetMeshLocal16());
+    messageInfo.SetSockAddr(netif.GetMle().GetMeshLocal16());
     messageInfo.SetPeerPort(kCoapUdpPort);
-    messageInfo.SetInterfaceId(mNetif.GetInterfaceId());
+    messageInfo.SetInterfaceId(netif.GetInterfaceId());
 
-    SuccessOrExit(error = mNetif.GetCoap().SendMessage(*message, messageInfo));
+    SuccessOrExit(error = netif.GetCoap().SendMessage(*message, messageInfo));
 
     otLogInfoArp(GetInstance(), "Sent address error");
 
@@ -422,6 +421,7 @@ void AddressResolver::HandleAddressError(void *aContext, otCoapHeader *aHeader, 
 void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessage,
                                          const Ip6::MessageInfo &aMessageInfo)
 {
+    ThreadNetif &netif = GetNetif();
     otError error = OT_ERROR_NONE;
     ThreadTargetTlv targetTlv;
     ThreadMeshLocalEidTlv mlIidTlv;
@@ -437,7 +437,7 @@ void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessag
 
     if (aHeader.IsConfirmable() && !aMessageInfo.GetSockAddr().IsMulticast())
     {
-        if (mNetif.GetCoap().SendEmptyAck(aHeader, aMessageInfo) == OT_ERROR_NONE)
+        if (netif.GetCoap().SendEmptyAck(aHeader, aMessageInfo) == OT_ERROR_NONE)
         {
             otLogInfoArp(GetInstance(), "Sent address error notification acknowledgment");
         }
@@ -449,18 +449,18 @@ void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessag
     SuccessOrExit(error = ThreadTlv::GetTlv(aMessage, ThreadTlv::kMeshLocalEid, sizeof(mlIidTlv), mlIidTlv));
     VerifyOrExit(mlIidTlv.IsValid(), error = OT_ERROR_PARSE);
 
-    for (const Ip6::NetifUnicastAddress *address = mNetif.GetUnicastAddresses(); address; address = address->GetNext())
+    for (const Ip6::NetifUnicastAddress *address = netif.GetUnicastAddresses(); address; address = address->GetNext())
     {
         if (memcmp(&address->mAddress, targetTlv.GetTarget(), sizeof(address->mAddress)) == 0 &&
-            memcmp(mNetif.GetMle().GetMeshLocal64().GetIid(), mlIidTlv.GetIid(), 8))
+            memcmp(netif.GetMle().GetMeshLocal64().GetIid(), mlIidTlv.GetIid(), 8))
         {
             // Target EID matches address and Mesh Local EID differs
-            mNetif.RemoveUnicastAddress(*address);
+            netif.RemoveUnicastAddress(*address);
             ExitNow();
         }
     }
 
-    children = mNetif.GetMle().GetChildren(&numChildren);
+    children = netif.GetMle().GetChildren(&numChildren);
 
     memcpy(&macAddr, mlIidTlv.GetIid(), sizeof(macAddr));
     macAddr.m8[0] ^= 0x2;
@@ -512,6 +512,7 @@ void AddressResolver::HandleAddressQuery(void *aContext, otCoapHeader *aHeader, 
 void AddressResolver::HandleAddressQuery(Coap::Header &aHeader, Message &aMessage,
                                          const Ip6::MessageInfo &aMessageInfo)
 {
+    ThreadNetif &netif = GetNetif();
     ThreadTargetTlv targetTlv;
     ThreadMeshLocalEidTlv mlIidTlv;
     ThreadLastTransactionTimeTlv lastTransactionTimeTlv;
@@ -530,14 +531,14 @@ void AddressResolver::HandleAddressQuery(Coap::Header &aHeader, Message &aMessag
 
     lastTransactionTimeTlv.Init();
 
-    if (mNetif.IsUnicastAddress(*targetTlv.GetTarget()))
+    if (netif.IsUnicastAddress(*targetTlv.GetTarget()))
     {
-        mlIidTlv.SetIid(mNetif.GetMle().GetMeshLocal64().GetIid());
+        mlIidTlv.SetIid(netif.GetMle().GetMeshLocal64().GetIid());
         SendAddressQueryResponse(targetTlv, mlIidTlv, NULL, aMessageInfo.GetPeerAddr());
         ExitNow();
     }
 
-    children = mNetif.GetMle().GetChildren(&numChildren);
+    children = netif.GetMle().GetChildren(&numChildren);
 
     for (int i = 0; i < numChildren; i++)
     {
@@ -571,6 +572,7 @@ void AddressResolver::SendAddressQueryResponse(const ThreadTargetTlv &aTargetTlv
                                                const ThreadLastTransactionTimeTlv *aLastTransactionTimeTlv,
                                                const Ip6::Address &aDestination)
 {
+    ThreadNetif &netif = GetNetif();
     otError error;
     Message *message;
     Coap::Header header;
@@ -581,13 +583,13 @@ void AddressResolver::SendAddressQueryResponse(const ThreadTargetTlv &aTargetTlv
     header.AppendUriPathOptions(OT_URI_PATH_ADDRESS_NOTIFY);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = mNetif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
+    VerifyOrExit((message = netif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     SuccessOrExit(error = message->Append(&aTargetTlv, sizeof(aTargetTlv)));
     SuccessOrExit(error = message->Append(&aMlIidTlv, sizeof(aMlIidTlv)));
 
     rloc16Tlv.Init();
-    rloc16Tlv.SetRloc16(mNetif.GetMle().GetRloc16());
+    rloc16Tlv.SetRloc16(netif.GetMle().GetRloc16());
     SuccessOrExit(error = message->Append(&rloc16Tlv, sizeof(rloc16Tlv)));
 
     if (aLastTransactionTimeTlv != NULL)
@@ -596,10 +598,10 @@ void AddressResolver::SendAddressQueryResponse(const ThreadTargetTlv &aTargetTlv
     }
 
     messageInfo.SetPeerAddr(aDestination);
-    messageInfo.SetSockAddr(mNetif.GetMle().GetMeshLocal16());
+    messageInfo.SetSockAddr(netif.GetMle().GetMeshLocal16());
     messageInfo.SetPeerPort(kCoapUdpPort);
 
-    SuccessOrExit(error = mNetif.GetCoap().SendMessage(*message, messageInfo));
+    SuccessOrExit(error = netif.GetCoap().SendMessage(*message, messageInfo));
 
     otLogInfoArp(GetInstance(), "Sent address notification");
 
@@ -611,9 +613,9 @@ exit:
     }
 }
 
-void AddressResolver::HandleTimer(void *aContext)
+void AddressResolver::HandleTimer(Timer &aTimer)
 {
-    static_cast<AddressResolver *>(aContext)->HandleTimer();
+    GetOwner(aTimer).HandleTimer();
 }
 
 void AddressResolver::HandleTimer()
@@ -647,7 +649,7 @@ void AddressResolver::HandleTimer()
                     mCache[i].mRetryTimeout = kAddressQueryMaxRetryDelay;
                 }
 
-                mNetif.GetMeshForwarder().HandleResolved(mCache[i].mTarget, OT_ERROR_DROP);
+                GetNetif().GetMeshForwarder().HandleResolved(mCache[i].mTarget, OT_ERROR_DROP);
             }
         }
         else if (mCache[i].mRetryTimeout > 0)
@@ -693,6 +695,17 @@ void AddressResolver::HandleIcmpReceive(Message &aMessage, const Ip6::MessageInf
 
 exit:
     OT_UNUSED_VARIABLE(aMessageInfo);
+}
+
+AddressResolver &AddressResolver::GetOwner(const Context &aContext)
+{
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    AddressResolver &resolver = *static_cast<AddressResolver *>(aContext.GetContext());
+#else
+    AddressResolver &resolver = otGetThreadNetif().GetAddressResolver();
+    OT_UNUSED_VARIABLE(aContext);
+#endif
+    return resolver;
 }
 
 }  // namespace ot

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -38,6 +38,7 @@
 
 #include "openthread-core-config.h"
 #include "coap/coap.hpp"
+#include "common/locator.hpp"
 #include "common/timer.hpp"
 #include "mac/mac.hpp"
 #include "net/icmp6.hpp"
@@ -64,7 +65,7 @@ class ThreadTargetTlv;
  * This class implements the EID-to-RLOC mapping and caching.
  *
  */
-class AddressResolver
+class AddressResolver: public ThreadNetifLocator
 {
 public:
     /**
@@ -72,14 +73,6 @@ public:
      *
      */
     explicit AddressResolver(ThreadNetif &aThreadNetif);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This method clears the EID-to-RLOC cache.
@@ -186,8 +179,10 @@ private:
                                   const otIcmp6Header *aIcmpHeader);
     void HandleIcmpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo, const Ip6::IcmpHeader &aIcmpHeader);
 
-    static void HandleTimer(void *aContext);
+    static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
+
+    static AddressResolver &GetOwner(const Context &aContext);
 
     Coap::Resource mAddressError;
     Coap::Resource mAddressQuery;
@@ -195,8 +190,6 @@ private:
     Cache mCache[kCacheEntries];
     Ip6::IcmpHandler mIcmpHandler;
     Timer mTimer;
-
-    ThreadNetif &mNetif;
 };
 
 /**

--- a/src/core/thread/announce_begin_server.hpp
+++ b/src/core/thread/announce_begin_server.hpp
@@ -38,18 +38,17 @@
 
 #include "openthread-core-config.h"
 #include "coap/coap.hpp"
+#include "common/locator.hpp"
 #include "common/timer.hpp"
 #include "net/ip6_address.hpp"
 
 namespace ot {
 
-class ThreadNetif;
-
 /**
  * This class implements handling Announce Begin Requests.
  *
  */
-class AnnounceBeginServer
+class AnnounceBeginServer: public ThreadNetifLocator
 {
 public:
     /**
@@ -57,14 +56,6 @@ public:
      *
      */
     AnnounceBeginServer(ThreadNetif &aThreadNetif);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This method begins the MLE Announce transmission process using Count=3 and Period=1s.
@@ -99,8 +90,10 @@ private:
                               const otMessageInfo *aMessageInfo);
     void HandleRequest(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleTimer(void *aContext);
+    static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
+
+    static AnnounceBeginServer &GetOwner(const Context &aContext);
 
     uint32_t mChannelMask;
     uint16_t mPeriod;
@@ -110,7 +103,6 @@ private:
     Timer mTimer;
 
     Coap::Resource mAnnounceBegin;
-    ThreadNetif &mNetif;
 };
 
 /**

--- a/src/core/thread/data_poll_manager.cpp
+++ b/src/core/thread/data_poll_manager.cpp
@@ -37,6 +37,7 @@
 #include "data_poll_manager.hpp"
 #include <openthread/platform/random.h>
 
+#include "openthread-instance.h"
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
 #include "common/message.hpp"
@@ -49,7 +50,7 @@
 namespace ot {
 
 DataPollManager::DataPollManager(MeshForwarder &aMeshForwarder):
-    mMeshForwarder(aMeshForwarder),
+    MeshForwarderLocator(aMeshForwarder),
     mTimer(aMeshForwarder.GetNetif().GetIp6().mTimerScheduler, &DataPollManager::HandlePollTimer, this),
     mTimerStartTime(0),
     mExternalPollPeriod(0),
@@ -64,17 +65,12 @@ DataPollManager::DataPollManager(MeshForwarder &aMeshForwarder):
 {
 }
 
-otInstance *DataPollManager::GetInstance(void)
-{
-    return mMeshForwarder.GetInstance();
-}
-
 otError DataPollManager::StartPolling(void)
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(!mEnabled, error = OT_ERROR_ALREADY);
-    VerifyOrExit((mMeshForwarder.GetNetif().GetMle().GetDeviceMode() & Mle::ModeTlv::kModeFFD) == 0,
+    VerifyOrExit((GetMeshForwarder().GetNetif().GetMle().GetDeviceMode() & Mle::ModeTlv::kModeFFD) == 0,
                  error = OT_ERROR_INVALID_STATE);
 
     mEnabled = true;
@@ -98,23 +94,24 @@ void DataPollManager::StopPolling(void)
 
 otError DataPollManager::SendDataPoll(void)
 {
+    MeshForwarder &meshForwarder = GetMeshForwarder();
     otError error;
     Message *message;
 
     VerifyOrExit(mEnabled, error = OT_ERROR_INVALID_STATE);
-    VerifyOrExit(!mMeshForwarder.GetNetif().GetMac().GetRxOnWhenIdle(), error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(!meshForwarder.GetNetif().GetMac().GetRxOnWhenIdle(), error = OT_ERROR_INVALID_STATE);
 
     mTimer.Stop();
 
-    for (message = mMeshForwarder.GetSendQueue().GetHead(); message; message = message->GetNext())
+    for (message = meshForwarder.GetSendQueue().GetHead(); message; message = message->GetNext())
     {
         VerifyOrExit(message->GetType() != Message::kTypeMacDataPoll, error = OT_ERROR_ALREADY);
     }
 
-    message = mMeshForwarder.GetNetif().GetIp6().mMessagePool.New(Message::kTypeMacDataPoll, 0);
+    message = meshForwarder.GetNetif().GetIp6().mMessagePool.New(Message::kTypeMacDataPoll, 0);
     VerifyOrExit(message != NULL, error = OT_ERROR_NO_BUFS);
 
-    error = mMeshForwarder.SendMessage(*message);
+    error = meshForwarder.SendMessage(*message);
 
     if (error != OT_ERROR_NONE)
     {
@@ -380,7 +377,7 @@ uint32_t DataPollManager::CalculatePollPeriod(void) const
 
     if (period == 0)
     {
-        period = Timer::SecToMsec(mMeshForwarder.GetNetif().GetMle().GetTimeout()) -
+        period = Timer::SecToMsec(GetMeshForwarder().GetNetif().GetMle().GetTimeout()) -
                  static_cast<uint32_t>(kRetxPollPeriod) * kMaxPollRetxAttempts;
 
         if (period == 0)
@@ -392,9 +389,20 @@ uint32_t DataPollManager::CalculatePollPeriod(void) const
     return period;
 }
 
-void DataPollManager::HandlePollTimer(void *aContext)
+void DataPollManager::HandlePollTimer(Timer &aTimer)
 {
-    static_cast<DataPollManager *>(aContext)->SendDataPoll();
+    GetOwner(aTimer).SendDataPoll();
+}
+
+DataPollManager &DataPollManager::GetOwner(Context &aContext)
+{
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    DataPollManager &manager = *static_cast<DataPollManager *>(aContext.GetContext());
+#else
+    DataPollManager &manager = otGetMeshForwarder().GetDataPollManager();
+    OT_UNUSED_VARIABLE(aContext);
+#endif
+    return manager;
 }
 
 }  // namespace ot

--- a/src/core/thread/data_poll_manager.hpp
+++ b/src/core/thread/data_poll_manager.hpp
@@ -38,12 +38,11 @@
 
 #include "openthread-core-config.h"
 #include "common/code_utils.hpp"
+#include "common/locator.hpp"
 #include "common/timer.hpp"
 #include "mac/mac_frame.hpp"
 
 namespace ot {
-
-class MeshForwarder;
 
 /**
  * @addtogroup core-data-poll-manager
@@ -59,7 +58,7 @@ class MeshForwarder;
  *
  */
 
-class DataPollManager
+class DataPollManager: public MeshForwarderLocator
 {
 public:
     enum
@@ -75,14 +74,6 @@ public:
      *
      */
     explicit DataPollManager(MeshForwarder &aMeshForwarder);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This method instructs the data poll manager to start sending periodic data polls.
@@ -218,9 +209,9 @@ private:
 
     void ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector);
     uint32_t CalculatePollPeriod(void) const;
-    static void HandlePollTimer(void *aContext);
+    static void HandlePollTimer(Timer &aTimer);
+    static DataPollManager &GetOwner(Context &aContext);
 
-    MeshForwarder &mMeshForwarder;
     Timer     mTimer;
     uint32_t  mTimerStartTime;
     uint32_t  mExternalPollPeriod;

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -34,14 +34,11 @@
 #define WPP_NAME "energy_scan_server.tmh"
 #include <openthread/config.h>
 
-
-
 #include "energy_scan_server.hpp"
-
-
 
 #include <openthread/platform/random.h>
 
+#include "openthread-instance.h"
 #include "coap/coap_header.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
@@ -54,6 +51,7 @@
 namespace ot {
 
 EnergyScanServer::EnergyScanServer(ThreadNetif &aThreadNetif) :
+    ThreadNetifLocator(aThreadNetif),
     mChannelMask(0),
     mChannelMaskCurrent(0),
     mPeriod(0),
@@ -62,18 +60,12 @@ EnergyScanServer::EnergyScanServer(ThreadNetif &aThreadNetif) :
     mActive(false),
     mScanResultsLength(0),
     mTimer(aThreadNetif.GetIp6().mTimerScheduler, &EnergyScanServer::HandleTimer, this),
-    mEnergyScan(OT_URI_PATH_ENERGY_SCAN, &EnergyScanServer::HandleRequest, this),
-    mNetif(aThreadNetif)
+    mEnergyScan(OT_URI_PATH_ENERGY_SCAN, &EnergyScanServer::HandleRequest, this)
 {
     mNetifCallback.Set(&EnergyScanServer::HandleNetifStateChanged, this);
-    mNetif.RegisterCallback(mNetifCallback);
+    aThreadNetif.RegisterCallback(mNetifCallback);
 
-    mNetif.GetCoap().AddResource(mEnergyScan);
-}
-
-otInstance *EnergyScanServer::GetInstance(void)
-{
-    return mNetif.GetInstance();
+    aThreadNetif.GetCoap().AddResource(mEnergyScan);
 }
 
 void EnergyScanServer::HandleRequest(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
@@ -119,7 +111,7 @@ void EnergyScanServer::HandleRequest(Coap::Header &aHeader, Message &aMessage, c
 
     if (aHeader.IsConfirmable() && !aMessageInfo.GetSockAddr().IsMulticast())
     {
-        SuccessOrExit(mNetif.GetCoap().SendEmptyAck(aHeader, responseInfo));
+        SuccessOrExit(GetNetif().GetCoap().SendEmptyAck(aHeader, responseInfo));
         otLogInfoMeshCoP(GetInstance(), "sent energy scan query response");
     }
 
@@ -127,9 +119,9 @@ exit:
     return;
 }
 
-void EnergyScanServer::HandleTimer(void *aContext)
+void EnergyScanServer::HandleTimer(Timer &aTimer)
 {
-    static_cast<EnergyScanServer *>(aContext)->HandleTimer();
+    GetOwner(aTimer).HandleTimer();
 }
 
 void EnergyScanServer::HandleTimer(void)
@@ -140,7 +132,7 @@ void EnergyScanServer::HandleTimer(void)
     {
         // grab the lowest channel to scan
         uint32_t channelMask = mChannelMaskCurrent & ~(mChannelMaskCurrent - 1);
-        mNetif.GetMac().EnergyScan(channelMask, mScanDuration, HandleScanResult, this);
+        GetNetif().GetMac().EnergyScan(channelMask, mScanDuration, HandleScanResult, this);
     }
     else
     {
@@ -203,7 +195,7 @@ otError EnergyScanServer::SendReport(void)
     header.AppendUriPathOptions(OT_URI_PATH_ENERGY_REPORT);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL,
+    VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(GetNetif().GetCoap(), header)) != NULL,
                  error = OT_ERROR_NO_BUFS);
 
     channelMask.Init();
@@ -215,10 +207,10 @@ otError EnergyScanServer::SendReport(void)
     SuccessOrExit(error = message->Append(&energyList, sizeof(energyList)));
     SuccessOrExit(error = message->Append(mScanResults, mScanResultsLength));
 
-    messageInfo.SetSockAddr(mNetif.GetMle().GetMeshLocal16());
+    messageInfo.SetSockAddr(GetNetif().GetMle().GetMeshLocal16());
     messageInfo.SetPeerAddr(mCommissioner);
     messageInfo.SetPeerPort(kCoapUdpPort);
-    SuccessOrExit(error = mNetif.GetCoap().SendMessage(*message, messageInfo));
+    SuccessOrExit(error = GetNetif().GetCoap().SendMessage(*message, messageInfo));
 
     otLogInfoMeshCoP(GetInstance(), "sent scan results");
 
@@ -243,11 +235,22 @@ void EnergyScanServer::HandleNetifStateChanged(uint32_t aFlags)
 {
     if ((aFlags & OT_CHANGED_THREAD_NETDATA) != 0 &&
         !mActive &&
-        mNetif.GetNetworkDataLeader().GetCommissioningData() == NULL)
+        GetNetif().GetNetworkDataLeader().GetCommissioningData() == NULL)
     {
         mActive = false;
         mTimer.Stop();
     }
+}
+
+EnergyScanServer &EnergyScanServer::GetOwner(const Context &aContext)
+{
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    EnergyScanServer &server = *static_cast<EnergyScanServer *>(aContext.GetContext());
+#else
+    EnergyScanServer &server = otGetThreadNetif().GetEnergyScanServer();
+    OT_UNUSED_VARIABLE(aContext);
+#endif
+    return server;
 }
 
 }  // namespace ot

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -38,6 +38,7 @@
 
 #include "openthread-core-config.h"
 #include "coap/coap.hpp"
+#include "common/locator.hpp"
 #include "common/timer.hpp"
 #include "net/ip6_address.hpp"
 #include "net/udp6.hpp"
@@ -54,7 +55,7 @@ class ThreadTargetTlv;
  * This class implements handling Energy Scan Requests.
  *
  */
-class EnergyScanServer
+class EnergyScanServer: public ThreadNetifLocator
 {
 public:
     /**
@@ -62,14 +63,6 @@ public:
      *
      */
     EnergyScanServer(ThreadNetif &aThreadNetif);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
 private:
     enum
@@ -85,13 +78,15 @@ private:
     static void HandleScanResult(void *aContext, otEnergyScanResult *aResult);
     void HandleScanResult(otEnergyScanResult *aResult);
 
-    static void HandleTimer(void *aContext);
+    static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
 
     static void HandleNetifStateChanged(uint32_t aFlags, void *aContext);
     void HandleNetifStateChanged(uint32_t aFlags);
 
     otError SendReport(void);
+
+    static EnergyScanServer &GetOwner(const Context &aContext);
 
     Ip6::Address mCommissioner;
     uint32_t mChannelMask;
@@ -109,8 +104,6 @@ private:
     Ip6::NetifCallback mNetifCallback;
 
     Coap::Resource mEnergyScan;
-
-    ThreadNetif &mNetif;
 };
 
 /**

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -38,12 +38,11 @@
 
 #include <openthread/types.h>
 
+#include "common/locator.hpp"
 #include "common/timer.hpp"
 #include "crypto/hmac_sha256.hpp"
 
 namespace ot {
-
-class ThreadNetif;
 
 /**
  * @addtogroup core-security
@@ -54,7 +53,7 @@ class ThreadNetif;
  * @{
  */
 
-class KeyManager
+class KeyManager: public ThreadNetifLocator
 {
 public:
     enum
@@ -337,10 +336,10 @@ private:
     otError ComputeKey(uint32_t aKeySequence, uint8_t *aKey);
 
     void StartKeyRotationTimer(void);
-    static void HandleKeyRotationTimer(void *aContext);
+    static void HandleKeyRotationTimer(Timer &aTimer);
     void HandleKeyRotationTimer(void);
 
-    ThreadNetif &mNetif;
+    static KeyManager &GetOwner(const Context &aContext);
 
     otMasterKey mMasterKey;
 

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -34,16 +34,13 @@
 #ifndef LOWPAN_HPP_
 #define LOWPAN_HPP_
 
+#include "common/locator.hpp"
 #include "common/message.hpp"
 #include "mac/mac_frame.hpp"
 #include "net/ip6.hpp"
 #include "net/ip6_address.hpp"
 
 namespace ot {
-
-class ThreadNetif;
-
-namespace NetworkData { class Leader; }
 
 /**
  * @addtogroup core-6lowpan
@@ -79,7 +76,7 @@ struct Context
  * This class implements LOWPAN_IPHC header compression.
  *
  */
-class Lowpan
+class Lowpan: public ThreadNetifLocator
 {
 public:
     /**
@@ -209,8 +206,6 @@ private:
 
     static otError CopyContext(const Context &aContext, Ip6::Address &aAddress);
     static otError ComputeIid(const Mac::Address &aMacAddr, const Context &aContext, Ip6::Address &aIpAddress);
-
-    NetworkData::Leader &mNetworkData;
 };
 
 /**

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -37,6 +37,7 @@
 #include <openthread/types.h>
 
 #include "openthread-core-config.h"
+#include "common/locator.hpp"
 #include "common/tasklet.hpp"
 #include "mac/mac.hpp"
 #include "net/ip6.hpp"
@@ -70,7 +71,7 @@ struct ThreadMessageInfo;
  * This class implements mesh forwarding within Thread.
  *
  */
-class MeshForwarder
+class MeshForwarder: public ThreadNetifLocator
 {
 public:
     /**
@@ -80,14 +81,6 @@ public:
      *
      */
     explicit MeshForwarder(ThreadNetif &aThreadNetif);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This method enables mesh forwarding and the IEEE 802.15.4 MAC layer.
@@ -170,13 +163,6 @@ public:
      *
      */
     void UpdateIndirectMessages(void);
-
-    /**
-     * This method returns a reference to the thread network interface instance.
-     *
-     * @ returns   A reference to the thread network interface instance.
-     */
-    ThreadNetif &GetNetif(void) { return mNetif; }
 
     /**
      * This method returns a reference to the send queue.
@@ -285,29 +271,28 @@ private:
                            const Mac::Address &aMacSource);
     void ClearReassemblyList(void);
 
-    static void HandleReceivedFrame(void *aContext, Mac::Frame &aFrame);
+    static void HandleReceivedFrame(Mac::Receiver &aReceiver, Mac::Frame &aFrame);
     void HandleReceivedFrame(Mac::Frame &aFrame);
-    static otError HandleFrameRequest(void *aContext, Mac::Frame &aFrame);
+    static otError HandleFrameRequest(Mac::Sender &aSender, Mac::Frame &aFrame);
     otError HandleFrameRequest(Mac::Frame &aFrame);
-    static void HandleSentFrame(void *aContext, Mac::Frame &aFrame, otError aError);
+    static void HandleSentFrame(Mac::Sender &aSender, Mac::Frame &aFrame, otError aError);
     void HandleSentFrame(Mac::Frame &aFrame, otError aError);
-    static void HandleDiscoverTimer(void *aContext);
+    static void HandleDiscoverTimer(Timer &aTimer);
     void HandleDiscoverTimer(void);
-    static void HandleReassemblyTimer(void *aContext);
+    static void HandleReassemblyTimer(Timer &aTimer);
     void HandleReassemblyTimer(void);
-    static void ScheduleTransmissionTask(void *aContext);
+    static void ScheduleTransmissionTask(Tasklet &aTasklet);
     void ScheduleTransmissionTask(void);
-    static void HandleDataPollTimeout(void *aContext);
+    static void HandleDataPollTimeout(Mac::Receiver &aReceiver);
 
     otError AddPendingSrcMatchEntries(void);
     otError AddSrcMatchEntry(Child &aChild);
     void ClearSrcMatchEntry(Child &aChild);
 
+    static MeshForwarder &GetOwner(const Context &aContext);
+
     void LogIp6Message(MessageAction aAction, const Message &aMessage, const Mac::Address *aMacAddress,
                        otError aError);
-
-
-    ThreadNetif           &mNetif;
 
     Mac::Receiver         mMacReceiver;
     Mac::Sender           mMacSender;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -37,6 +37,7 @@
 #include <openthread/openthread.h>
 
 #include "common/encoding.hpp"
+#include "common/locator.hpp"
 #include "common/timer.hpp"
 #include "mac/mac.hpp"
 #include "meshcop/joiner_router.hpp"
@@ -446,7 +447,7 @@ private:
  * This class implements MLE functionality required by the Thread EndDevices, Router, and Leader roles.
  *
  */
-class Mle
+class Mle: public ThreadNetifLocator
 {
 public:
     /**
@@ -456,14 +457,6 @@ public:
      *
      */
     explicit Mle(ThreadNetif &aThreadNetif);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This method enables MLE.
@@ -1319,8 +1312,6 @@ protected:
      */
     otError AddDelayedResponse(Message &aMessage, const Ip6::Address &aDestination, uint16_t aDelay);
 
-    ThreadNetif           &mNetif;            ///< The Thread Network Interface object.
-
     LeaderDataTlv mLeaderData;              ///< Last received Leader Data TLV.
     bool mRetrieveNewNetworkData;           ///< Indicating new Network Data is needed if set.
 
@@ -1380,13 +1371,13 @@ private:
 
     static void HandleNetifStateChanged(uint32_t aFlags, void *aContext);
     void HandleNetifStateChanged(uint32_t aFlags);
-    static void HandleParentRequestTimer(void *aContext);
+    static void HandleParentRequestTimer(Timer &aTimer);
     void HandleParentRequestTimer(void);
-    static void HandleDelayedResponseTimer(void *aContext);
+    static void HandleDelayedResponseTimer(Timer &aTimer);
     void HandleDelayedResponseTimer(void);
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    static void HandleSendChildUpdateRequest(void *aContext);
+    static void HandleSendChildUpdateRequest(Tasklet &aTasklet);
     void HandleSendChildUpdateRequest(void);
 
     otError HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
@@ -1406,6 +1397,8 @@ private:
 
     bool IsBetterParent(uint16_t aRloc16, uint8_t aLinkQuality, ConnectivityTlv &aConnectivityTlv);
     void ResetParentCandidate(void);
+
+    static Mle &GetOwner(const Context &aContext);
 
     MessageQueue mDelayedResponses;
 

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -773,10 +773,12 @@ private:
     uint8_t AllocateRouterId(uint8_t aRouterId);
     bool InRouterIdMask(uint8_t aRouterId);
 
-    static bool HandleAdvertiseTimer(void *aContext);
+    static bool HandleAdvertiseTimer(TrickleTimer &aTimer);
     bool HandleAdvertiseTimer(void);
-    static void HandleStateUpdateTimer(void *aContext);
+    static void HandleStateUpdateTimer(Timer &aTimer);
     void HandleStateUpdateTimer(void);
+
+    static MleRouter &GetOwner(const Context &aContext);
 
     TrickleTimer mAdvertiseTimer;
     Timer mStateUpdateTimer;

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -37,6 +37,7 @@
 #include <openthread/types.h>
 
 #include "coap/coap.hpp"
+#include "common/locator.hpp"
 #include "net/udp6.hpp"
 #include "thread/lowpan.hpp"
 #include "thread/mle_router.hpp"
@@ -83,7 +84,7 @@ namespace NetworkData {
  * This class implements Network Data processing.
  *
  */
-class NetworkData
+class NetworkData: public ThreadNetifLocator
 {
 public:
     enum
@@ -99,14 +100,6 @@ public:
      *
      */
     NetworkData(ThreadNetif &aThreadNetif, bool aLocal);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This method clears the network data.
@@ -353,8 +346,6 @@ protected:
 
     uint8_t mTlvs[kMaxSize];  ///< The Network Data buffer.
     uint8_t mLength;          ///< The number of valid bytes in @var mTlvs.
-
-    ThreadNetif &mNetif;
 
 private:
     enum

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -69,19 +69,20 @@ void LeaderBase::Reset(void)
     mVersion = static_cast<uint8_t>(otPlatRandomGet());
     mStableVersion = static_cast<uint8_t>(otPlatRandomGet());
     mLength = 0;
-    mNetif.SetStateChangedFlags(OT_CHANGED_THREAD_NETDATA);
+    GetNetif().SetStateChangedFlags(OT_CHANGED_THREAD_NETDATA);
 }
 
 otError LeaderBase::GetContext(const Ip6::Address &aAddress, Lowpan::Context &aContext)
 {
+    ThreadNetif &netif = GetNetif();
     PrefixTlv *prefix;
     ContextTlv *contextTlv;
 
     aContext.mPrefixLength = 0;
 
-    if (PrefixMatch(mNetif.GetMle().GetMeshLocalPrefix(), aAddress.mFields.m8, 64) >= 0)
+    if (PrefixMatch(netif.GetMle().GetMeshLocalPrefix(), aAddress.mFields.m8, 64) >= 0)
     {
-        aContext.mPrefix = mNetif.GetMle().GetMeshLocalPrefix();
+        aContext.mPrefix = netif.GetMle().GetMeshLocalPrefix();
         aContext.mPrefixLength = 64;
         aContext.mContextId = 0;
         aContext.mCompressFlag = true;
@@ -130,7 +131,7 @@ otError LeaderBase::GetContext(uint8_t aContextId, Lowpan::Context &aContext)
 
     if (aContextId == 0)
     {
-        aContext.mPrefix = mNetif.GetMle().GetMeshLocalPrefix();
+        aContext.mPrefix = GetNetif().GetMle().GetMeshLocalPrefix();
         aContext.mPrefixLength = 64;
         aContext.mContextId = 0;
         aContext.mCompressFlag = true;
@@ -202,7 +203,7 @@ bool LeaderBase::IsOnMesh(const Ip6::Address &aAddress)
     PrefixTlv *prefix;
     bool rval = false;
 
-    if (memcmp(aAddress.mFields.m8, mNetif.GetMle().GetMeshLocalPrefix(), 8) == 0)
+    if (memcmp(aAddress.mFields.m8, GetNetif().GetMle().GetMeshLocalPrefix(), 8) == 0)
     {
         ExitNow(rval = true);
     }
@@ -278,6 +279,7 @@ exit:
 otError LeaderBase::ExternalRouteLookup(uint8_t aDomainId, const Ip6::Address &aDestination,
                                         uint8_t *aPrefixMatch, uint16_t *aRloc16)
 {
+    ThreadNetif &netif = GetNetif();
     otError error = OT_ERROR_NO_ROUTE;
     PrefixTlv *prefix;
     HasRouteTlv *hasRoute;
@@ -325,7 +327,7 @@ otError LeaderBase::ExternalRouteLookup(uint8_t aDomainId, const Ip6::Address &a
                     if (rvalRoute == NULL ||
                         entry->GetPreference() > rvalRoute->GetPreference() ||
                         (entry->GetPreference() == rvalRoute->GetPreference() &&
-                         mNetif.GetMle().GetCost(entry->GetRloc()) < mNetif.GetMle().GetCost(rvalRoute->GetRloc())))
+                         netif.GetMle().GetCost(entry->GetRloc()) < netif.GetMle().GetCost(rvalRoute->GetRloc())))
                     {
                         rvalRoute = entry;
                         rval_plen = static_cast<uint8_t>(plen);
@@ -356,6 +358,7 @@ otError LeaderBase::ExternalRouteLookup(uint8_t aDomainId, const Ip6::Address &a
 
 otError LeaderBase::DefaultRouteLookup(PrefixTlv &aPrefix, uint16_t *aRloc16)
 {
+    ThreadNetif &netif = GetNetif();
     otError error = OT_ERROR_NO_ROUTE;
     BorderRouterTlv *borderRouter;
     BorderRouterEntry *entry;
@@ -382,9 +385,9 @@ otError LeaderBase::DefaultRouteLookup(PrefixTlv &aPrefix, uint16_t *aRloc16)
             if (route == NULL ||
                 entry->GetPreference() > route->GetPreference() ||
                 (entry->GetPreference() == route->GetPreference() &&
-                 (entry->GetRloc() == mNetif.GetMle().GetRloc16() ||
-                  (route->GetRloc() != mNetif.GetMle().GetRloc16() &&
-                   mNetif.GetMle().GetCost(entry->GetRloc()) < mNetif.GetMle().GetCost(route->GetRloc())))))
+                 (entry->GetRloc() == netif.GetMle().GetRloc16() ||
+                  (route->GetRloc() != netif.GetMle().GetRloc16() &&
+                   netif.GetMle().GetCost(entry->GetRloc()) < netif.GetMle().GetCost(route->GetRloc())))))
             {
                 route = entry;
             }
@@ -419,7 +422,7 @@ void LeaderBase::SetNetworkData(uint8_t aVersion, uint8_t aStableVersion, bool a
 
     otDumpDebgNetData(GetInstance(), "set network data", mTlvs, mLength);
 
-    mNetif.SetStateChangedFlags(OT_CHANGED_THREAD_NETDATA);
+    GetNetif().SetStateChangedFlags(OT_CHANGED_THREAD_NETDATA);
 }
 
 otError LeaderBase::SetCommissioningData(const uint8_t *aValue, uint8_t aValueLength)
@@ -442,7 +445,7 @@ otError LeaderBase::SetCommissioningData(const uint8_t *aValue, uint8_t aValueLe
     }
 
     mVersion++;
-    mNetif.SetStateChangedFlags(OT_CHANGED_THREAD_NETDATA);
+    GetNetif().SetStateChangedFlags(OT_CHANGED_THREAD_NETDATA);
 
 exit:
     return error;

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -40,6 +40,7 @@
 #include "network_data_leader.hpp"
 #include <openthread/platform/random.h>
 
+#include "openthread-instance.h"
 #include "coap/coap_header.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
@@ -81,30 +82,36 @@ void Leader::Reset(void)
 
 void Leader::Start(void)
 {
-    mNetif.GetCoap().AddResource(mServerData);
-    mNetif.GetCoap().AddResource(mCommissioningDataGet);
-    mNetif.GetCoap().AddResource(mCommissioningDataSet);
+    Coap::Coap &coap = GetNetif().GetCoap();
+
+    coap.AddResource(mServerData);
+    coap.AddResource(mCommissioningDataGet);
+    coap.AddResource(mCommissioningDataSet);
 }
 
 void Leader::Stop(void)
 {
-    mNetif.GetCoap().RemoveResource(mServerData);
-    mNetif.GetCoap().RemoveResource(mCommissioningDataGet);
-    mNetif.GetCoap().RemoveResource(mCommissioningDataSet);
+    Coap::Coap &coap = GetNetif().GetCoap();
+
+    coap.RemoveResource(mServerData);
+    coap.RemoveResource(mCommissioningDataGet);
+    coap.RemoveResource(mCommissioningDataSet);
 }
 
 void Leader::IncrementVersion(void)
 {
-    if (mNetif.GetMle().GetRole() == OT_DEVICE_ROLE_LEADER)
+    ThreadNetif &netif = GetNetif();
+
+    if (netif.GetMle().GetRole() == OT_DEVICE_ROLE_LEADER)
     {
         mVersion++;
-        mNetif.SetStateChangedFlags(OT_CHANGED_THREAD_NETDATA);
+        netif.SetStateChangedFlags(OT_CHANGED_THREAD_NETDATA);
     }
 }
 
 void Leader::IncrementStableVersion(void)
 {
-    if (mNetif.GetMle().GetRole() == OT_DEVICE_ROLE_LEADER)
+    if (GetNetif().GetMle().GetRole() == OT_DEVICE_ROLE_LEADER)
     {
         mStableVersion++;
     }
@@ -137,7 +144,7 @@ void Leader::RemoveBorderRouter(uint16_t aRloc16)
         mStableVersion++;
     }
 
-    mNetif.SetStateChangedFlags(OT_CHANGED_THREAD_NETDATA);
+    GetNetif().SetStateChangedFlags(OT_CHANGED_THREAD_NETDATA);
 
 exit:
     return;
@@ -172,7 +179,7 @@ void Leader::HandleServerData(Coap::Header &aHeader, Message &aMessage,
                             networkData.GetTlvs(), networkData.GetLength());
     }
 
-    SuccessOrExit(mNetif.GetCoap().SendEmptyAck(aHeader, aMessageInfo));
+    SuccessOrExit(GetNetif().GetCoap().SendEmptyAck(aHeader, aMessageInfo));
 
     otLogInfoNetData(GetInstance(), "Sent network data registration acknowledgment");
 
@@ -198,7 +205,7 @@ void Leader::HandleCommissioningSet(Coap::Header &aHeader, Message &aMessage, co
     bool hasValidTlv = false;
     uint16_t sessionId = 0;
 
-    VerifyOrExit(mNetif.GetMle().GetRole() == OT_DEVICE_ROLE_LEADER, state = MeshCoP::StateTlv::kReject);
+    VerifyOrExit(GetNetif().GetMle().GetRole() == OT_DEVICE_ROLE_LEADER, state = MeshCoP::StateTlv::kReject);
 
     aMessage.Read(offset, length, tlvs);
 
@@ -266,7 +273,7 @@ void Leader::HandleCommissioningSet(Coap::Header &aHeader, Message &aMessage, co
 
 exit:
 
-    if (mNetif.GetMle().GetRole() == OT_DEVICE_ROLE_LEADER)
+    if (GetNetif().GetMle().GetRole() == OT_DEVICE_ROLE_LEADER)
     {
         SendCommissioningSetResponse(aHeader, aMessageInfo, state);
     }
@@ -309,6 +316,7 @@ void Leader::HandleCommissioningGet(Coap::Header &aHeader, Message &aMessage, co
 void Leader::SendCommissioningGetResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
                                           uint8_t *aTlvs, uint8_t aLength)
 {
+    ThreadNetif &netif = GetNetif();
     otError error = OT_ERROR_NONE;
     Coap::Header responseHeader;
     Message *message;
@@ -319,7 +327,7 @@ void Leader::SendCommissioningGetResponse(const Coap::Header &aRequestHeader, co
     responseHeader.SetDefaultResponseHeader(aRequestHeader);
     responseHeader.SetPayloadMarker();
 
-    VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(mNetif.GetCoap(), responseHeader)) != NULL,
+    VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(netif.GetCoap(), responseHeader)) != NULL,
                  error = OT_ERROR_NO_BUFS);
 
     for (NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs);
@@ -363,7 +371,7 @@ void Leader::SendCommissioningGetResponse(const Coap::Header &aRequestHeader, co
         message->SetLength(message->GetLength() - 1);
     }
 
-    SuccessOrExit(error = mNetif.GetCoap().SendMessage(*message, aMessageInfo));
+    SuccessOrExit(error = netif.GetCoap().SendMessage(*message, aMessageInfo));
 
     otLogInfoMeshCoP(GetInstance(), "sent commissioning dataset get response");
 
@@ -378,6 +386,7 @@ exit:
 void Leader::SendCommissioningSetResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
                                           MeshCoP::StateTlv::State aState)
 {
+    ThreadNetif &netif = GetNetif();
     otError error = OT_ERROR_NONE;
     Coap::Header responseHeader;
     Message *message;
@@ -386,14 +395,14 @@ void Leader::SendCommissioningSetResponse(const Coap::Header &aRequestHeader, co
     responseHeader.SetDefaultResponseHeader(aRequestHeader);
     responseHeader.SetPayloadMarker();
 
-    VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(mNetif.GetCoap(), responseHeader)) != NULL,
+    VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(netif.GetCoap(), responseHeader)) != NULL,
                  error = OT_ERROR_NO_BUFS);
 
     state.Init();
     state.SetState(aState);
     SuccessOrExit(error = message->Append(&state, sizeof(state)));
 
-    SuccessOrExit(error = mNetif.GetCoap().SendMessage(*message, aMessageInfo));
+    SuccessOrExit(error = netif.GetCoap().SendMessage(*message, aMessageInfo));
 
     otLogInfoMeshCoP(GetInstance(), "sent commissioning dataset set response");
 
@@ -585,7 +594,7 @@ otError Leader::RegisterNetworkData(uint16_t aRloc16, uint8_t *aTlvs, uint8_t aT
         }
     }
 
-    mNetif.SetStateChangedFlags(OT_CHANGED_THREAD_NETDATA);
+    GetNetif().SetStateChangedFlags(OT_CHANGED_THREAD_NETDATA);
 
 exit:
     return error;
@@ -769,7 +778,7 @@ otError Leader::FreeContext(uint8_t aContextId)
     mContextUsed &= ~(1 << aContextId);
     mVersion++;
     mStableVersion++;
-    mNetif.SetStateChangedFlags(OT_CHANGED_THREAD_NETDATA);
+    GetNetif().SetStateChangedFlags(OT_CHANGED_THREAD_NETDATA);
     return OT_ERROR_NONE;
 }
 
@@ -1041,10 +1050,9 @@ otError Leader::RemoveContext(PrefixTlv &aPrefix, uint8_t aContextId)
     return OT_ERROR_NONE;
 }
 
-void Leader::HandleTimer(void *aContext)
+void Leader::HandleTimer(Timer &aTimer)
 {
-    Leader *obj = reinterpret_cast<Leader *>(aContext);
-    obj->HandleTimer();
+    GetOwner(aTimer).HandleTimer();
 }
 
 void Leader::HandleTimer(void)
@@ -1072,6 +1080,17 @@ void Leader::HandleTimer(void)
     {
         mTimer.Start(kStateUpdatePeriod);
     }
+}
+
+Leader &Leader::GetOwner(const Context &aContext)
+{
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    Leader &leader = *static_cast<Leader *>(aContext.GetContext());
+#else
+    Leader &leader = otGetThreadNetif().GetNetworkDataLeader();
+    OT_UNUSED_VARIABLE(aContext);
+#endif
+    return leader;
 }
 
 }  // namespace NetworkData

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -145,7 +145,7 @@ private:
                                  const otMessageInfo *aMessageInfo);
     void HandleServerData(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleTimer(void *aContext);
+    static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
 
     otError RegisterNetworkData(uint16_t aRloc16, uint8_t *aTlvs, uint8_t aTlvsLength);
@@ -184,6 +184,7 @@ private:
                                       uint8_t *aTlvs, uint8_t aLength);
     void SendCommissioningSetResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
                                       MeshCoP::StateTlv::State aState);
+    static Leader &GetOwner(const Context &aContext);
 
     /**
      * Thread Specification Constants

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -38,11 +38,10 @@
 
 #include "openthread-core-config.h"
 #include "coap/coap.hpp"
+#include "common/locator.hpp"
 #include "net/udp6.hpp"
 
 namespace ot {
-
-class ThreadNetif;
 
 namespace NetworkDiagnostic {
 
@@ -63,7 +62,7 @@ class NetworkDiagnosticTlv;
  * This class implements the Network Diagnostic processing.
  *
  */
-class NetworkDiagnostic
+class NetworkDiagnostic: public ThreadNetifLocator
 {
 public:
     /**
@@ -71,14 +70,6 @@ public:
      *
      */
     explicit NetworkDiagnostic(ThreadNetif &aThreadNetif);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance();
 
     /**
      * This method registers a callback to provide received raw DIAG_GET.rsp or an DIAG_GET.ans payload.
@@ -142,8 +133,6 @@ private:
     Coap::Resource mDiagnosticGetQuery;
     Coap::Resource mDiagnosticGetAnswer;
     Coap::Resource mDiagnosticReset;
-
-    ThreadNetif &mNetif;
 
     otReceiveDiagnosticGetCallback mReceiveDiagnosticGetCallback;
     void *mReceiveDiagnosticGetCallbackContext;

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -39,6 +39,7 @@
 
 #include <openthread/platform/random.h>
 
+#include "openthread-instance.h"
 #include "coap/coap_header.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
@@ -51,18 +52,13 @@
 namespace ot {
 
 PanIdQueryServer::PanIdQueryServer(ThreadNetif &aThreadNetif) :
+    ThreadNetifLocator(aThreadNetif),
     mChannelMask(0),
     mPanId(Mac::kPanIdBroadcast),
     mTimer(aThreadNetif.GetIp6().mTimerScheduler, &PanIdQueryServer::HandleTimer, this),
-    mPanIdQuery(OT_URI_PATH_PANID_QUERY, &PanIdQueryServer::HandleQuery, this),
-    mNetif(aThreadNetif)
+    mPanIdQuery(OT_URI_PATH_PANID_QUERY, &PanIdQueryServer::HandleQuery, this)
 {
-    mNetif.GetCoap().AddResource(mPanIdQuery);
-}
-
-otInstance *PanIdQueryServer::GetInstance()
-{
-    return mNetif.GetInstance();
+    aThreadNetif.GetCoap().AddResource(mPanIdQuery);
 }
 
 void PanIdQueryServer::HandleQuery(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
@@ -94,7 +90,7 @@ void PanIdQueryServer::HandleQuery(Coap::Header &aHeader, Message &aMessage, con
 
     if (aHeader.IsConfirmable() && !aMessageInfo.GetSockAddr().IsMulticast())
     {
-        SuccessOrExit(mNetif.GetCoap().SendEmptyAck(aHeader, responseInfo));
+        SuccessOrExit(GetNetif().GetCoap().SendEmptyAck(aHeader, responseInfo));
         otLogInfoMeshCoP(GetInstance(), "sent panid query response");
     }
 
@@ -128,6 +124,7 @@ void PanIdQueryServer::HandleScanResult(Mac::Frame *aFrame)
 
 otError PanIdQueryServer::SendConflict(void)
 {
+    ThreadNetif &netif = GetNetif();
     otError error = OT_ERROR_NONE;
     Coap::Header header;
     MeshCoP::ChannelMask0Tlv channelMask;
@@ -140,7 +137,7 @@ otError PanIdQueryServer::SendConflict(void)
     header.AppendUriPathOptions(OT_URI_PATH_PANID_CONFLICT);
     header.SetPayloadMarker();
 
-    VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(mNetif.GetCoap(), header)) != NULL, error = OT_ERROR_NO_BUFS);
+    VerifyOrExit((message = MeshCoP::NewMeshCoPMessage(netif.GetCoap(), header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     channelMask.Init();
     channelMask.SetMask(mChannelMask);
@@ -150,10 +147,10 @@ otError PanIdQueryServer::SendConflict(void)
     panId.SetPanId(mPanId);
     SuccessOrExit(error = message->Append(&panId, sizeof(panId)));
 
-    messageInfo.SetSockAddr(mNetif.GetMle().GetMeshLocal16());
+    messageInfo.SetSockAddr(netif.GetMle().GetMeshLocal16());
     messageInfo.SetPeerAddr(mCommissioner);
     messageInfo.SetPeerPort(kCoapUdpPort);
-    SuccessOrExit(error = mNetif.GetCoap().SendMessage(*message, messageInfo));
+    SuccessOrExit(error = netif.GetCoap().SendMessage(*message, messageInfo));
 
     otLogInfoMeshCoP(GetInstance(), "sent panid conflict");
 
@@ -167,15 +164,26 @@ exit:
     return error;
 }
 
-void PanIdQueryServer::HandleTimer(void *aContext)
+void PanIdQueryServer::HandleTimer(Timer &aTimer)
 {
-    static_cast<PanIdQueryServer *>(aContext)->HandleTimer();
+    GetOwner(aTimer).HandleTimer();
 }
 
 void PanIdQueryServer::HandleTimer(void)
 {
-    mNetif.GetMac().ActiveScan(mChannelMask, 0, HandleScanResult, this);
+    GetNetif().GetMac().ActiveScan(mChannelMask, 0, HandleScanResult, this);
     mChannelMask = 0;
+}
+
+PanIdQueryServer &PanIdQueryServer::GetOwner(const Context &aContext)
+{
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    PanIdQueryServer &server = *static_cast<PanIdQueryServer *>(aContext.GetContext());
+#else
+    PanIdQueryServer &server = otGetThreadNetif().GetPanIdQueryServer();
+    OT_UNUSED_VARIABLE(aContext);
+#endif
+    return server;
 }
 
 }  // namespace ot

--- a/src/core/thread/panid_query_server.hpp
+++ b/src/core/thread/panid_query_server.hpp
@@ -38,6 +38,7 @@
 
 #include "openthread-core-config.h"
 #include "coap/coap.hpp"
+#include "common/locator.hpp"
 #include "common/timer.hpp"
 #include "net/ip6_address.hpp"
 #include "net/udp6.hpp"
@@ -54,7 +55,7 @@ class ThreadTargetTlv;
  * This class implements handling PANID Query Requests.
  *
  */
-class PanIdQueryServer
+class PanIdQueryServer: public ThreadNetifLocator
 {
 public:
     /**
@@ -62,14 +63,6 @@ public:
      *
      */
     PanIdQueryServer(ThreadNetif &aThreadNetif);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance();
 
 private:
     enum
@@ -83,12 +76,14 @@ private:
     static void HandleScanResult(void *aContext, Mac::Frame *aFrame);
     void HandleScanResult(Mac::Frame *aFrame);
 
-    static void HandleTimer(void *aContext);
+    static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 
     otError SendConflict(void);
+
+    static PanIdQueryServer &GetOwner(const Context &aContext);
 
     Ip6::Address mCommissioner;
     uint32_t mChannelMask;
@@ -97,8 +92,6 @@ private:
     Timer mTimer;
 
     Coap::Resource mPanIdQuery;
-
-    ThreadNetif &mNetif;
 };
 
 /**

--- a/src/core/thread/src_match_controller.cpp
+++ b/src/core/thread/src_match_controller.cpp
@@ -46,15 +46,10 @@
 namespace ot {
 
 SourceMatchController::SourceMatchController(MeshForwarder &aMeshForwarder) :
-    mMeshForwarder(aMeshForwarder),
+    MeshForwarderLocator(aMeshForwarder),
     mEnabled(false)
 {
     ClearTable();
-}
-
-otInstance *SourceMatchController::GetInstance(void)
-{
-    return mMeshForwarder.GetInstance();
 }
 
 void SourceMatchController::IncrementMessageCount(Child &aChild)
@@ -227,7 +222,7 @@ otError SourceMatchController::AddPendingEntries(void)
     uint8_t numChildren;
     Child *child;
 
-    child = mMeshForwarder.GetNetif().GetMle().GetChildren(&numChildren);
+    child = GetMeshForwarder().GetNetif().GetMle().GetChildren(&numChildren);
 
     for (uint8_t i = 0; i < numChildren; i++, child++)
     {

--- a/src/core/thread/src_match_controller.hpp
+++ b/src/core/thread/src_match_controller.hpp
@@ -37,11 +37,10 @@
 #include <openthread/types.h>
 
 #include "openthread-core-config.h"
+#include "common/locator.hpp"
 #include "thread/topology.hpp"
 
 namespace ot {
-
-class MeshForwarder;
 
 /**
  * @addtogroup core-source-match-controller
@@ -65,7 +64,7 @@ class MeshForwarder;
  * address or an extended/long address can be added to the source address match table.
  *
  */
-class SourceMatchController
+class SourceMatchController: public MeshForwarderLocator
 {
 public:
     /**
@@ -75,14 +74,6 @@ public:
      *
      */
     explicit SourceMatchController(MeshForwarder &aMeshForwarder);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This method returns the current state of source address matching.
@@ -191,7 +182,6 @@ private:
      */
     otError AddPendingEntries(void);
 
-    MeshForwarder &mMeshForwarder;
     bool mEnabled;
 };
 

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -121,7 +121,7 @@ otError ThreadNetif::Up(void)
 {
     if (!mIsUp)
     {
-        mIp6.AddNetif(*this);
+        GetIp6().AddNetif(*this);
         mMeshForwarder.Start();
         mCoap.Start(kCoapUdpPort);
 #if OPENTHREAD_ENABLE_DNS_CLIENT
@@ -144,7 +144,7 @@ otError ThreadNetif::Down(void)
     mChildSupervisor.Stop();
     mMleRouter.Disable();
     mMeshForwarder.Stop();
-    mIp6.RemoveNetif(*this);
+    GetIp6().RemoveNetif(*this);
     RemoveAllExternalUnicastAddresses();
     UnsubscribeAllExternalMulticastAddresses();
     mIsUp = false;
@@ -197,11 +197,6 @@ otError ThreadNetif::TmfFilter(const Message &aMessage, const Ip6::MessageInfo &
 exit:
     OT_UNUSED_VARIABLE(aMessage);
     return error;
-}
-
-otInstance *ThreadNetif::GetInstance(void)
-{
-    return otInstanceFromThreadNetif(this);
 }
 
 }  // namespace ot

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -397,12 +397,20 @@ public:
     Utils::SupervisionListener &GetSupervisionListener(void) { return mSupervisionListener; }
 
     /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
+      * This method returns a reference to the energy scan server object.
+      *
+      * @returns A reference to the energy scan server object.
+      *
+      */
+    EnergyScanServer &GetEnergyScanServer(void) { return mEnergyScan; }
+
+    /**
+      * This method returns a reference to the PAN ID query server object.
+      *
+      * @returns A reference to the PAN ID query server object.
+      *
+      */
+    PanIdQueryServer &GetPanIdQueryServer(void) { return mPanIdQuery; }
 
 private:
     static otError TmfFilter(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, void *aContext);

--- a/src/core/utils/child_supervision.hpp
+++ b/src/core/utils/child_supervision.hpp
@@ -37,6 +37,8 @@
 
 #include <openthread/config.h>
 
+#include "openthread-core-config.h"
+#include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/timer.hpp"
 #include "mac/mac_frame.hpp"
@@ -85,7 +87,7 @@ namespace Utils {
  * This class implements a child supervisor.
  *
  */
-class ChildSupervisor
+class ChildSupervisor: public ThreadNetifLocator
 {
 public:
     /**
@@ -154,10 +156,10 @@ private:
     };
 
     void SendMessage(Child &aChild);
-    static void HandleTimer(void *aContext);
+    static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
+    static ChildSupervisor &GetOwner(const Context &aContext);
 
-    ThreadNetif &mNetif;
     Timer        mTimer;
     uint16_t     mSupervisionInterval;
 };
@@ -184,7 +186,7 @@ public:
  * This class implements a child supervision listener.
  *
  */
-class SupervisionListener
+class SupervisionListener: public ThreadNetifLocator
 {
 public:
     /**
@@ -246,10 +248,10 @@ private:
     };
 
     void RestartTimer(void);
-    static void HandleTimer(void *aContext);
+    static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
+    static SupervisionListener &GetOwner(const Context &aContext);
 
-    ThreadNetif &mNetif;
     Timer mTimer;
     uint16_t mTimeout;
 };

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -38,6 +38,7 @@
 #include <openthread/openthread.h>
 #include <openthread/platform/random.h>
 
+#include "openthread-instance.h"
 #include "common/code_utils.hpp"
 #include "thread/thread_netif.hpp"
 
@@ -47,7 +48,7 @@ namespace ot {
 namespace Utils {
 
 JamDetector::JamDetector(ThreadNetif &aNetif) :
-    mNetif(aNetif),
+    ThreadNetifLocator(aNetif),
     mHandler(NULL),
     mContext(NULL),
     mRssiThreshold(kDefaultRssiThreshold),
@@ -135,9 +136,9 @@ exit:
     return error;
 }
 
-void JamDetector::HandleTimer(void *aContext)
+void JamDetector::HandleTimer(Timer &aTimer)
 {
-    static_cast<JamDetector *>(aContext)->HandleTimer();
+    GetOwner(aTimer).HandleTimer();
 }
 
 void JamDetector::HandleTimer(void)
@@ -147,7 +148,7 @@ void JamDetector::HandleTimer(void)
 
     VerifyOrExit(mEnabled);
 
-    rssi = otPlatRadioGetRssi(mNetif.GetInstance());
+    rssi = otPlatRadioGetRssi(GetNetif().GetInstance());
 
     // If the RSSI is valid, check if it exceeds the threshold
     // and try to update the history bit map
@@ -237,6 +238,17 @@ void JamDetector::UpdateJamState(void)
     {
         mHandler(mJamState, mContext);
     }
+}
+
+JamDetector &JamDetector::GetOwner(const Context &aContext)
+{
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    JamDetector &detector = *static_cast<JamDetector *>(aContext.GetContext());
+#else
+    JamDetector &detector = otGetThreadNetif().GetJamDetector();
+    OT_UNUSED_VARIABLE(aContext);
+#endif
+    return detector;
 }
 
 }  // namespace Utils

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -36,6 +36,7 @@
 
 #include <openthread/config.h>
 
+#include "common/locator.hpp"
 #include "common/timer.hpp"
 #include "utils/wrap_stdint.h"
 
@@ -45,7 +46,7 @@ class ThreadNetif;
 
 namespace Utils {
 
-class JamDetector
+class JamDetector: public ThreadNetifLocator
 {
 public:
 
@@ -173,10 +174,11 @@ public:
     uint64_t GetHistoryBitmap(void) const { return mHistoryBitmap; }
 
 private:
-    static void HandleTimer(void *aContext);
+    static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
     void UpdateHistory(bool aThresholdExceeded);
     void UpdateJamState(void);
+    static JamDetector &GetOwner(const Context &aContext);
 
 private:
     enum
@@ -191,7 +193,6 @@ private:
 
     };
 
-    ThreadNetif &mNetif;
     Handler      mHandler;                  // Handler/callback to inform about jamming state
     void        *mContext;                  // Context for handler/callback
     int8_t       mRssiThreshold;            // RSSI threshold for jam detection

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1192,10 +1192,10 @@ void NcpBase::HandleNetifStateChanged(uint32_t aFlags, void *aContext)
     obj->mUpdateChangedPropsTask.Post();
 }
 
-void NcpBase::UpdateChangedProps(void *aContext)
+void NcpBase::UpdateChangedProps(Tasklet &aTasklet)
 {
-    NcpBase *obj = static_cast<NcpBase *>(aContext);
-    obj->UpdateChangedProps();
+    OT_UNUSED_VARIABLE(aTasklet);
+    GetNcpInstance()->UpdateChangedProps();
 }
 
 void NcpBase::UpdateChangedProps(void)

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -210,7 +210,7 @@ private:
     static void HandleJamStateChange_Jump(bool aJamState, void *aContext);
     void HandleJamStateChange(bool aJamState);
 
-    static void UpdateChangedProps(void *aContext);
+    static void UpdateChangedProps(Tasklet &aTasklet);
     void UpdateChangedProps(void);
 
     static void SendDoneTask(void *aContext);

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -311,9 +311,10 @@ exit:
     return errorCode;
 }
 
-void NcpSpi::PrepareTxFrame(void *aContext)
+void NcpSpi::PrepareTxFrame(Tasklet &aTasklet)
 {
-    static_cast<NcpSpi *>(aContext)->PrepareTxFrame();
+    OT_UNUSED_VARIABLE(aTasklet);
+    static_cast<NcpSpi *>(GetNcpInstance())->PrepareTxFrame();
 }
 
 void NcpSpi::PrepareTxFrame(void)

--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -84,7 +84,7 @@ private:
     static void HandleFrameAddedToTxBuffer(void *aContext, NcpFrameBuffer::FrameTag aFrameTag,
                                            NcpFrameBuffer *aNcpFrameBuffer);
 
-    static void PrepareTxFrame(void *context);
+    static void PrepareTxFrame(Tasklet &aTasklet);
     void PrepareTxFrame(void);
     void HandleRxFrame(void);
 

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -122,11 +122,10 @@ void NcpUart::HandleFrameAddedToNcpBuffer(void)
     }
 }
 
-void NcpUart::EncodeAndSendToUart(void *aContext)
+void NcpUart::EncodeAndSendToUart(Tasklet &aTasklet)
 {
-    NcpUart *obj = static_cast<NcpUart *>(aContext);
-
-    obj->EncodeAndSendToUart();
+    OT_UNUSED_VARIABLE(aTasklet);
+    static_cast<NcpUart *>(GetNcpInstance())->EncodeAndSendToUart();
 }
 
 // This method encodes a frame from the tx frame buffer (mTxFrameBuffer) into the uart buffer and sends it over uart.

--- a/src/ncp/ncp_uart.hpp
+++ b/src/ncp/ncp_uart.hpp
@@ -101,7 +101,7 @@ private:
     void            TxFrameBufferHasData(void);
     void            HandleFrameAddedToNcpBuffer(void);
 
-    static void     EncodeAndSendToUart(void *aContext);
+    static void     EncodeAndSendToUart(Tasklet &aTasklet);
     static void     HandleFrame(void *context, uint8_t *aBuf, uint16_t aBufLength);
     static void     HandleError(void *context, otError aError, uint8_t *aBuf, uint16_t aBufLength);
     static void     HandleFrameAddedToNcpBuffer(void *aContext, NcpFrameBuffer::FrameTag aTag,

--- a/tests/unit/test_aes.cpp
+++ b/tests/unit/test_aes.cpp
@@ -26,19 +26,15 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "utils/wrap_string.h"
-
+#include <openthread/config.h>
 #include <openthread/openthread.h>
 
 #include "common/debug.hpp"
 #include "crypto/aes_ccm.hpp"
-#include "crypto/mbedtls.hpp"
+#include "utils/wrap_string.h"
 
+#include "test_platform.h"
 #include "test_util.h"
-
-#ifndef OPENTHREAD_MULTIPLE_INSTANCE
-static ot::Crypto::MbedTls mbedtls;
-#endif
 
 /**
  * Verifies test vectors from IEEE 802.15.4-2006 Annex C Section C.2.1
@@ -78,6 +74,7 @@ void TestMacBeaconFrame(void)
         0xB5, 0x53
     };
 
+    otInstance *instance = testInitInstance();
     ot::Crypto::AesCcm aesCcm;
     uint32_t headerLength = sizeof(test) - 8;
     uint32_t payloadLength = 0;
@@ -88,6 +85,8 @@ void TestMacBeaconFrame(void)
         0xAC, 0xDE, 0x48, 0x00, 0x00, 0x00, 0x00, 0x01,
         0x00, 0x00, 0x00, 0x05, 0x02,
     };
+
+    VerifyOrQuit(instance != NULL, "Null OpenThread instance");
 
     aesCcm.SetKey(key, sizeof(key));
     aesCcm.Init(headerLength, payloadLength, tagLength, nonce, sizeof(nonce));
@@ -103,6 +102,8 @@ void TestMacBeaconFrame(void)
 
     VerifyOrQuit(memcmp(test, decrypted, sizeof(decrypted)) == 0,
                  "TestMacBeaconFrame decrypt failed");
+
+    testFreeInstance(instance);
 }
 
 /**

--- a/tests/unit/test_diag.cpp
+++ b/tests/unit/test_diag.cpp
@@ -26,11 +26,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "utils/wrap_string.h"
-
 #include <openthread/diag.h>
 #include <openthread/platform/platform.h>
 #include <openthread/platform/radio.h>
+
+#include "utils/wrap_string.h"
 
 #include "test_util.h"
 

--- a/tests/unit/test_fuzz.cpp
+++ b/tests/unit/test_fuzz.cpp
@@ -109,7 +109,7 @@ void TestFuzz(uint32_t aSeconds)
     Log("Initialized seed = 0x%X", seed);
 #endif
 
-#ifdef OPENTHREAD_MULTIPLE_INSTANCE
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
     size_t otInstanceBufferLength = 0;
     uint8_t *otInstanceBuffer = NULL;
 
@@ -124,7 +124,7 @@ void TestFuzz(uint32_t aSeconds)
     // Initialize OpenThread with the buffer
     aInstance = otInstanceInit(otInstanceBuffer, &otInstanceBufferLength);
 #else
-    aInstance = otInstanceInit();
+    aInstance = otInstanceInitSingle();
 #endif
 
     VerifyOrQuit(aInstance != NULL, "Failed to initialize otInstance");
@@ -196,7 +196,7 @@ void TestFuzz(uint32_t aSeconds)
     // Clean up the instance
     otInstanceFinalize(aInstance);
 
-#ifdef OPENTHREAD_MULTIPLE_INSTANCE
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
     free(otInstanceBuffer);
 #endif
 }

--- a/tests/unit/test_hmac_sha256.cpp
+++ b/tests/unit/test_hmac_sha256.cpp
@@ -26,19 +26,15 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "utils/wrap_string.h"
-
+#include <openthread/config.h>
 #include <openthread/openthread.h>
 
 #include "common/debug.hpp"
 #include "crypto/hmac_sha256.hpp"
-#include "crypto/mbedtls.hpp"
+#include "utils/wrap_string.h"
 
+#include "test_platform.h"
 #include "test_util.h"
-
-#ifndef OPENTHREAD_MULTIPLE_INSTANCE
-static ot::Crypto::MbedTls mMbedTls;
-#endif
 
 void TestHmacSha256(void)
 {
@@ -66,8 +62,11 @@ void TestHmacSha256(void)
         },
     };
 
+    otInstance *instance = testInitInstance();
     ot::Crypto::HmacSha256 hmac;
     uint8_t hash[ot::Crypto::HmacSha256::kHashSize];
+
+    VerifyOrQuit(instance != NULL, "Null OpenThread instance");
 
     for (int i = 0; tests[i].key != NULL; i++)
     {
@@ -78,6 +77,8 @@ void TestHmacSha256(void)
         VerifyOrQuit(memcmp(hash, tests[i].hash, sizeof(tests[i].hash)) == 0,
                      "HMAC-SHA-256 failed\n");
     }
+
+    testFreeInstance(instance);
 }
 
 #ifdef ENABLE_TEST_MAIN

--- a/tests/unit/test_link_quality.cpp
+++ b/tests/unit/test_link_quality.cpp
@@ -26,11 +26,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "utils/wrap_string.h"
-
 #include <openthread/openthread.h>
 
 #include "thread/link_quality.hpp"
+#include "utils/wrap_string.h"
 
 #include "test_util.h"
 

--- a/tests/unit/test_lowpan.hpp
+++ b/tests/unit/test_lowpan.hpp
@@ -29,14 +29,15 @@
 #ifndef TEST_LOWPAN_HPP
 #define TEST_LOWPAN_HPP
 
-#include "utils/wrap_stdint.h"
 
 #include <openthread/openthread.h>
 
+#include "openthread-instance.h"
 #include "mac/mac.hpp"
 #include "net/ip6_headers.hpp"
 #include "thread/lowpan.hpp"
 #include "thread/thread_netif.hpp"
+#include "utils/wrap_stdint.h"
 
 namespace ot {
 

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -26,12 +26,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "utils/wrap_string.h"
-
 #include <openthread/openthread.h>
 
 #include "common/debug.hpp"
 #include "mac/mac_frame.hpp"
+#include "utils/wrap_string.h"
 
 #include "test_util.h"
 

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -26,30 +26,35 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "utils/wrap_string.h"
-
 #include <openthread/openthread.h>
 
 #include "openthread-instance.h"
 #include "common/debug.hpp"
 #include "common/message.hpp"
+#include "utils/wrap_string.h"
 
+#include "test_platform.h"
 #include "test_util.h"
 
 void TestMessage(void)
 {
-    otInstance instance;
-    ot::MessagePool messagePool(&instance);
+    otInstance *instance;
+    ot::MessagePool *messagePool;
     ot::Message *message;
     uint8_t writeBuffer[1024];
     uint8_t readBuffer[1024];
+
+    instance = testInitInstance();
+    VerifyOrQuit(instance != NULL, "Null OpenThread instance\n");
+
+    messagePool = &instance->mIp6.mMessagePool;
 
     for (unsigned i = 0; i < sizeof(writeBuffer); i++)
     {
         writeBuffer[i] = static_cast<uint8_t>(random());
     }
 
-    VerifyOrQuit((message = messagePool.New(ot::Message::kTypeIp6, 0)) != NULL,
+    VerifyOrQuit((message = messagePool->New(ot::Message::kTypeIp6, 0)) != NULL,
                  "Message::New failed\n");
     SuccessOrQuit(message->SetLength(sizeof(writeBuffer)),
                   "Message::SetLength failed\n");
@@ -63,6 +68,8 @@ void TestMessage(void)
                  "Message::GetLength failed\n");
     SuccessOrQuit(message->Free(),
                   "Message::Free failed\n");
+
+    testFreeInstance(instance);
 }
 
 #ifdef ENABLE_TEST_MAIN

--- a/tests/unit/test_ncp_buffer.cpp
+++ b/tests/unit/test_ncp_buffer.cpp
@@ -35,6 +35,7 @@
 #include "common/message.hpp"
 #include "ncp/ncp_buffer.hpp"
 
+#include "test_platform.h"
 #include "test_util.h"
 
 namespace ot {
@@ -54,8 +55,8 @@ static const uint8_t sHelloText[]      = "Hello there!";
 static const uint8_t sMottoText[]      = "Think good thoughts, say good words, do good deeds!";
 static const uint8_t sMysteryText[]    = "4871(\\):|(3$}{4|/4/2%14(\\)";
 
-static otInstance sInstance;
-static MessagePool sMessagePool(&sInstance);
+static otInstance *sInstance;
+static MessagePool *sMessagePool;
 
 struct CallbackContext
 {
@@ -187,7 +188,7 @@ void WriteTestFrame1(NcpFrameBuffer &aNcpBuffer)
     Message *message;
     CallbackContext oldContext;
 
-    message = sMessagePool.New(Message::kTypeIp6, 0);
+    message = sMessagePool->New(Message::kTypeIp6, 0);
     VerifyOrQuit(message != NULL, "Null Message");
     SuccessOrQuit(message->SetLength(sizeof(sMottoText)), "Could not set the length of message.");
     message->Write(0, sizeof(sMottoText), sMottoText);
@@ -235,12 +236,12 @@ void WriteTestFrame2(NcpFrameBuffer &aNcpBuffer)
     Message *message2;
     CallbackContext oldContext = sContext;
 
-    message1 = sMessagePool.New(Message::kTypeIp6, 0);
+    message1 = sMessagePool->New(Message::kTypeIp6, 0);
     VerifyOrQuit(message1 != NULL, "Null Message");
     SuccessOrQuit(message1->SetLength(sizeof(sMysteryText)), "Could not set the length of message.");
     message1->Write(0, sizeof(sMysteryText), sMysteryText);
 
-    message2 = sMessagePool.New(Message::kTypeIp6, 0);
+    message2 = sMessagePool->New(Message::kTypeIp6, 0);
     VerifyOrQuit(message2 != NULL, "Null Message");
     SuccessOrQuit(message2->SetLength(sizeof(sHelloText)), "Could not set the length of message.");
     message2->Write(0, sizeof(sHelloText), sHelloText);
@@ -282,7 +283,7 @@ void WriteTestFrame3(NcpFrameBuffer &aNcpBuffer)
     Message *message1;
     CallbackContext oldContext = sContext;
 
-    message1 = sMessagePool.New(Message::kTypeIp6, 0);
+    message1 = sMessagePool->New(Message::kTypeIp6, 0);
     VerifyOrQuit(message1 != NULL, "Null Message");
 
     // An empty message with no content.
@@ -326,6 +327,9 @@ void TestNcpFrameBuffer(void)
     Message *message;
     uint8_t readBuffer[16];
     uint16_t readLen, readOffset;
+
+    sInstance = testInitInstance();
+    sMessagePool = &sInstance->mIp6.mMessagePool;
 
     for (i = 0; i < sizeof(buffer); i++)
     {
@@ -423,7 +427,7 @@ void TestNcpFrameBuffer(void)
         ncpBuffer.InFrameBegin();
         ncpBuffer.InFrameFeedData(sHelloText, sizeof(sHelloText));
 
-        message = sMessagePool.New(Message::kTypeIp6, 0);
+        message = sMessagePool->New(Message::kTypeIp6, 0);
         VerifyOrQuit(message != NULL, "Null Message");
         SuccessOrQuit(message->SetLength(sizeof(sMysteryText)), "Could not set the length of message.");
         message->Write(0, sizeof(sMysteryText), sMysteryText);
@@ -509,6 +513,8 @@ void TestNcpFrameBuffer(void)
 
     VerifyOrQuit(readOffset == sizeof(sMottoText), "Read len does not match expected length.");
     printf("\n -- PASS\n");
+
+    testFreeInstance(sInstance);
 }
 
 /**
@@ -614,6 +620,9 @@ void TestFuzzNcpFrameBuffer(void)
     uint32_t lensArrayStart;
     uint32_t lensArrayCount;
 
+    sInstance = testInitInstance();
+    sMessagePool = &sInstance->mIp6.mMessagePool;
+
     memset(buffer, 0, sizeof(buffer));
 
     memset(lensArray, 0, sizeof(lensArray));
@@ -682,6 +691,8 @@ void TestFuzzNcpFrameBuffer(void)
     }
 
     printf("\n -- PASS\n");
+
+    testFreeInstance(sInstance);
 }
 
 }  // namespace ot

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -77,11 +77,45 @@ void testPlatResetToDefaults(void)
     g_testPlatRadioGetTransmitBuffer = NULL;
 }
 
+otInstance *testInitInstance(void)
+{
+    otInstance *instance = NULL;
+
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    size_t instaneBufferLength = 0;
+    uint8_t *instanceBuffer = NULL;
+
+    // Call to query the buffer size
+    (void)otInstanceInit(NULL, &instaneBufferLength);
+
+    // Call to allocate the buffer
+    instanceBuffer = (uint8_t *)malloc(instaneBufferLength);
+    VerifyOrQuit(instanceBuffer != NULL, "Failed to allocate otInstance");
+    memset(instanceBuffer, 0, instaneBufferLength);
+
+    // Initialize OpenThread with the buffer
+    instance = otInstanceInit(instanceBuffer, &instaneBufferLength);
+#else
+    instance = otInstanceInitSingle();
+#endif
+
+    return instance;
+}
+
+void testFreeInstance(otInstance *aInstance)
+{
+    otInstanceFinalize(aInstance);
+
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    free(aInstance);
+#endif
+}
+
 bool sDiagMode = false;
 
 extern "C" {
 
-#ifdef OPENTHREAD_MULTIPLE_INSTANCE
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
     void *otPlatCAlloc(size_t aNum, size_t aSize)
     {
         return calloc(aNum, aSize);

--- a/tests/unit/test_platform.h
+++ b/tests/unit/test_platform.h
@@ -37,6 +37,7 @@
 
 #include <string.h>
 
+#include <openthread/config.h>
 #include <openthread/openthread.h>
 #include <openthread/platform/alarm.h>
 #include <openthread/platform/logging.h>
@@ -87,6 +88,9 @@ extern testPlatRadioDisable             g_testPlatRadioDisable;
 extern testPlatRadioReceive             g_testPlatRadioReceive;
 extern testPlatRadioTransmit            g_testPlatRadioTransmit;
 extern testPlatRadioGetTransmitBuffer   g_testPlatRadioGetTransmitBuffer;
+
+otInstance *testInitInstance(void);
+void testFreeInstance(otInstance *aInstance);
 
 // Resets platform functions to defaults
 void testPlatResetToDefaults(void);

--- a/tests/unit/test_toolchain.cpp
+++ b/tests/unit/test_toolchain.cpp
@@ -27,12 +27,12 @@
  */
 
 #include <stdio.h>
-#include "utils/wrap_stdint.h"
 
 #include <openthread/platform/toolchain.h>
 
 #include "thread/topology.hpp"
 #include "test_util.h"
+#include "utils/wrap_stdint.h"
 
 extern "C" {
     uint32_t otNetifAddress_Size_c();

--- a/third_party/mbedtls/mbedtls-config.h
+++ b/third_party/mbedtls/mbedtls-config.h
@@ -30,8 +30,9 @@
 
 #include <stdlib.h>
 
-#include "openthread/platform/logging.h"
-#include "openthread/platform/memory.h"
+#include <openthread/config.h>
+#include <openthread/platform/logging.h>
+#include <openthread/platform/memory.h>
 
 #if defined(_WIN32)
 #include <stdarg.h>
@@ -1973,7 +1974,7 @@ __inline int windows_kernel_snprintf(char * s, size_t n, const char * format, ..
  *
  * Enable this module to enable the buffer memory allocator.
  */
-#ifndef OPENTHREAD_MULTIPLE_INSTANCE
+#if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
 #define MBEDTLS_MEMORY_BUFFER_ALLOC_C
 #endif
 
@@ -2547,7 +2548,7 @@ __inline int windows_kernel_snprintf(char * s, size_t n, const char * format, ..
 
 /* Platform options */
 //#define MBEDTLS_PLATFORM_STD_MEM_HDR   <stdlib.h> /**< Header to include if MBEDTLS_PLATFORM_NO_STD_FUNCTIONS is defined. Don't define if no header is needed. */
-#ifdef OPENTHREAD_MULTIPLE_INSTANCE
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
 #define MBEDTLS_PLATFORM_STD_CALLOC    otPlatCAlloc /**< Default allocator to use, can be undefined */
 #define MBEDTLS_PLATFORM_STD_FREE        otPlatFree /**< Default free to use, can be undefined */
 #endif


### PR DESCRIPTION
This commit adds single-instance optimization feature. This feature is enabled through configure option `--enable-single-instance-opt` and by default it is disabled.

This feature aims to simplify the code and also reduce memory/RAM use of OpenThread by implementing two optimizations:

(1) OpenThread objects/classes typically keep a reference to a higher-level object (e.g., many classes keep track of `ThreadNetif` reference which is expected as an input parameter of the object's constructor). This is used by the object to access other objects/methods within OpenThread class hierarchy including the containing `otInstance`. When single-instance optimization is enabled the reference member variables are removed and instead global functions are used to access the singleton objects from one class to the other.

To implement this, a group of `<Object>Tracker` classes are defined (e.g., `ThreadNetifTracker`, `Ip6Tracker, etc.) which keep track of an OpenThread object reference. The tracker classes are used as base class of other OpenThread classes which require tracking of a reference to another object.

The `Tracker` classes also provide implementation of `GetInstance()` method which returns a pointer to containing `otInstance` strcut. This is then inherited by all sub-classes and thus removing the need to
define this in every other class.

(2) OpenThread objects which provide a callback/handler (e.g., `Timer` ,`Tasklet`, etc.) have `void *mContext` member variable which is used to keep track of the owner of the object. When single-instance optimization is enabled the `mConext` member variable is removed since the owner is expected to be a singleton and can be uniquely determined from the callback function.

To implement this, two changes are made: First the handler methods are modified to provide a reference to the object (e.g., `Timer` handler will provide a `Timer &aTimer` as a parameter of its handler callback). Second, a new base class `Context` is introduced which hides the implementation providing an arbitrary context information and classes that provide handler callback publicly inherit the `Context`. A new static method `GetOwner(aContext)` is added to classes which own a callback providing object. This method help convert a `Context` to the reference to the owner class object.