### PR TITLE
[meshcop] remove RAM buffers for local operational datasets

### DIFF
--- a/etc/visual-studio/libopenthread.vcxproj
+++ b/etc/visual-studio/libopenthread.vcxproj
@@ -96,6 +96,7 @@
     <ClCompile Include="..\..\src\core\meshcop\announce_begin_client.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\commissioner.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\dataset.cpp" />
+    <ClCompile Include="..\..\src\core\meshcop\dataset_local.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\dataset_manager.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\dataset_manager_ftd.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\dtls.cpp" />
@@ -177,6 +178,7 @@
     <ClInclude Include="..\..\src\core\meshcop\announce_begin_client.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\commissioner.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\dataset.hpp" />
+    <ClInclude Include="..\..\src\core\meshcop\dataset_local.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\dataset_manager.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\dtls.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\energy_scan_client.hpp" />

--- a/etc/visual-studio/libopenthread.vcxproj.filters
+++ b/etc/visual-studio/libopenthread.vcxproj.filters
@@ -249,6 +249,9 @@
     <ClCompile Include="..\..\src\core\meshcop\dataset.cpp">
       <Filter>Source Files\thread</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\core\meshcop\dataset_local.cpp">
+      <Filter>Source Files\thread</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\core\meshcop\dataset_manager.cpp">
       <Filter>Source Files\thread</Filter>
     </ClCompile>
@@ -507,6 +510,9 @@
       <Filter>Header Files\meshcop</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\core\meshcop\dataset.hpp">
+      <Filter>Header Files\thread</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\meshcop\dataset_local.hpp">
       <Filter>Header Files\thread</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\core\meshcop\dataset_manager.hpp">

--- a/etc/visual-studio/libopenthread_k.vcxproj
+++ b/etc/visual-studio/libopenthread_k.vcxproj
@@ -103,6 +103,7 @@
     <ClCompile Include="..\..\src\core\mac\mac_whitelist.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\commissioner.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\dataset.cpp" />
+    <ClCompile Include="..\..\src\core\meshcop\dataset_local.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\dataset_manager.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\dataset_manager_ftd.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\dtls.cpp" />
@@ -209,6 +210,7 @@
     <ClInclude Include="..\..\src\core\meshcop\announce_begin_client.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\commissioner.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\dataset.hpp" />
+    <ClInclude Include="..\..\src\core\meshcop\dataset_local.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\dataset_manager.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\dtls.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\energy_scan_client.hpp" />

--- a/etc/visual-studio/libopenthread_k.vcxproj.filters
+++ b/etc/visual-studio/libopenthread_k.vcxproj.filters
@@ -252,6 +252,9 @@
     <ClCompile Include="..\..\src\core\meshcop\dataset.cpp">
       <Filter>Source Files\thread</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\core\meshcop\dataset_local.cpp">
+      <Filter>Source Files\thread</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\core\meshcop\dataset_manager.cpp">
       <Filter>Source Files\thread</Filter>
     </ClCompile>
@@ -507,6 +510,9 @@
       <Filter>Header Files\meshcop</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\core\meshcop\dataset.hpp">
+      <Filter>Header Files\thread</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\meshcop\dataset_local.hpp">
       <Filter>Header Files\thread</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\core\meshcop\dataset_manager.hpp">

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -232,21 +232,29 @@ otError Dataset::ProcessHelp(otInstance *aInstance, int argc, char *argv[])
 otError Dataset::ProcessActive(otInstance *aInstance, int argc, char *argv[])
 {
     otOperationalDataset dataset;
-    otDatasetGetActive(aInstance, &dataset);
+    otError error;
 
+    SuccessOrExit(error = otDatasetGetActive(aInstance, &dataset));
+    error = Print(dataset);
+
+exit:
     OT_UNUSED_VARIABLE(argc);
     OT_UNUSED_VARIABLE(argv);
-    return Print(dataset);
+    return error;
 }
 
 otError Dataset::ProcessPending(otInstance *aInstance, int argc, char *argv[])
 {
     otOperationalDataset dataset;
-    otDatasetGetPending(aInstance, &dataset);
+    otError error;
 
+    SuccessOrExit(error = otDatasetGetPending(aInstance, &dataset));
+    error = Print(dataset);
+
+exit:
     OT_UNUSED_VARIABLE(argc);
     OT_UNUSED_VARIABLE(argv);
-    return Print(dataset);
+    return error;
 }
 
 #if OPENTHREAD_FTD

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -138,6 +138,7 @@ SOURCES_COMMON                      = \
     meshcop/announce_begin_client.cpp \
     meshcop/commissioner.cpp          \
     meshcop/dataset.cpp               \
+    meshcop/dataset_local.cpp         \
     meshcop/dataset_manager.cpp       \
     meshcop/dataset_manager_ftd.cpp   \
     meshcop/dtls.cpp                  \
@@ -236,6 +237,7 @@ HEADERS_COMMON                      = \
     meshcop/announce_begin_client.hpp \
     meshcop/commissioner.hpp          \
     meshcop/dataset.hpp               \
+    meshcop/dataset_local.hpp         \
     meshcop/dataset_manager.hpp       \
     meshcop/dataset_manager_ftd.hpp   \
     meshcop/dataset_manager_mtd.hpp   \

--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -60,7 +60,7 @@ otError otDatasetGetActive(otInstance *aInstance, otOperationalDataset *aDataset
 
     VerifyOrExit(aDataset != NULL, error = OT_ERROR_INVALID_ARGS);
 
-    aInstance->mThreadNetif.GetActiveDataset().GetLocal().Get(*aDataset);
+    error = aInstance->mThreadNetif.GetActiveDataset().GetLocal().Get(*aDataset);
 
 exit:
     return error;
@@ -72,7 +72,7 @@ otError otDatasetGetPending(otInstance *aInstance, otOperationalDataset *aDatase
 
     VerifyOrExit(aDataset != NULL, error = OT_ERROR_INVALID_ARGS);
 
-    aInstance->mThreadNetif.GetPendingDataset().GetLocal().Get(*aDataset);
+    error = aInstance->mThreadNetif.GetPendingDataset().GetLocal().Get(*aDataset);
 
 exit:
     return error;

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -55,8 +55,8 @@ otError otLinkSetChannel(otInstance *aInstance, uint8_t aChannel)
                  error = OT_ERROR_INVALID_STATE);
 
     error = aInstance->mThreadNetif.GetMac().SetChannel(aChannel);
-    aInstance->mThreadNetif.GetActiveDataset().Clear(false);
-    aInstance->mThreadNetif.GetPendingDataset().Clear(false);
+    aInstance->mThreadNetif.GetActiveDataset().Clear();
+    aInstance->mThreadNetif.GetPendingDataset().Clear();
 
 exit:
     return error;
@@ -117,8 +117,8 @@ otError otLinkSetPanId(otInstance *aInstance, otPanId aPanId)
                  error = OT_ERROR_INVALID_STATE);
 
     error = aInstance->mThreadNetif.GetMac().SetPanId(aPanId);
-    aInstance->mThreadNetif.GetActiveDataset().Clear(false);
-    aInstance->mThreadNetif.GetPendingDataset().Clear(false);
+    aInstance->mThreadNetif.GetActiveDataset().Clear();
+    aInstance->mThreadNetif.GetPendingDataset().Clear();
 
 exit:
     return error;

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -75,8 +75,8 @@ otError otThreadSetExtendedPanId(otInstance *aInstance, const uint8_t *aExtended
     mlPrefix[7] = 0x00;
     aInstance->mThreadNetif.GetMle().SetMeshLocalPrefix(mlPrefix);
 
-    aInstance->mThreadNetif.GetActiveDataset().Clear(false);
-    aInstance->mThreadNetif.GetPendingDataset().Clear(false);
+    aInstance->mThreadNetif.GetActiveDataset().Clear();
+    aInstance->mThreadNetif.GetPendingDataset().Clear();
 
 exit:
     return error;
@@ -165,8 +165,8 @@ otError otThreadSetMasterKey(otInstance *aInstance, const otMasterKey *aKey)
                  error = OT_ERROR_INVALID_STATE);
 
     error = aInstance->mThreadNetif.GetKeyManager().SetMasterKey(*aKey);
-    aInstance->mThreadNetif.GetActiveDataset().Clear(false);
-    aInstance->mThreadNetif.GetPendingDataset().Clear(false);
+    aInstance->mThreadNetif.GetActiveDataset().Clear();
+    aInstance->mThreadNetif.GetPendingDataset().Clear();
 
 exit:
     return error;
@@ -190,8 +190,8 @@ otError otThreadSetMeshLocalPrefix(otInstance *aInstance, const uint8_t *aMeshLo
                  error = OT_ERROR_INVALID_STATE);
 
     error = aInstance->mThreadNetif.GetMle().SetMeshLocalPrefix(aMeshLocalPrefix);
-    aInstance->mThreadNetif.GetActiveDataset().Clear(false);
-    aInstance->mThreadNetif.GetPendingDataset().Clear(false);
+    aInstance->mThreadNetif.GetActiveDataset().Clear();
+    aInstance->mThreadNetif.GetPendingDataset().Clear();
 
 exit:
     return error;
@@ -215,8 +215,8 @@ otError otThreadSetNetworkName(otInstance *aInstance, const char *aNetworkName)
                  error = OT_ERROR_INVALID_STATE);
 
     error = aInstance->mThreadNetif.GetMac().SetNetworkName(aNetworkName);
-    aInstance->mThreadNetif.GetActiveDataset().Clear(false);
-    aInstance->mThreadNetif.GetPendingDataset().Clear(false);
+    aInstance->mThreadNetif.GetActiveDataset().Clear();
+    aInstance->mThreadNetif.GetPendingDataset().Clear();
 
 exit:
     return error;

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -266,8 +266,8 @@ otError otThreadSetPSKc(otInstance *aInstance, const uint8_t *aPSKc)
                  error = OT_ERROR_INVALID_STATE);
 
     aInstance->mThreadNetif.GetKeyManager().SetPSKc(aPSKc);
-    aInstance->mThreadNetif.GetActiveDataset().Clear(false);
-    aInstance->mThreadNetif.GetPendingDataset().Clear(false);
+    aInstance->mThreadNetif.GetActiveDataset().Clear();
+    aInstance->mThreadNetif.GetPendingDataset().Clear();
 
 exit:
     return error;

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2016, The OpenThread Authors.
+ *  Copyright (c) 2016-2017, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -32,77 +32,88 @@
  *
  */
 
+#define WPP_NAME "dataset_local.tmh"
+
 #include <openthread/config.h>
 
-#include "dataset.hpp"
+#include "dataset_local.hpp"
 
 #include <stdio.h>
 
-#include "openthread-instance.h"
+#include <openthread/platform/settings.h>
+
 #include "common/code_utils.hpp"
+#include "common/logging.hpp"
 #include "common/settings.hpp"
+#include "meshcop/dataset.hpp"
 #include "meshcop/meshcop_tlvs.hpp"
 #include "thread/mle_tlvs.hpp"
 
 namespace ot {
 namespace MeshCoP {
 
-Dataset::Dataset(const Tlv::Type aType) :
+DatasetLocal::DatasetLocal(otInstance *aInstance, const Tlv::Type aType) :
+    InstanceLocator(aInstance),
     mUpdateTime(0),
-    mLength(0),
     mType(aType)
 {
 }
 
-void Dataset::Clear(void)
+void DatasetLocal::Clear(void)
 {
-    mLength = 0;
+    otPlatSettingsDelete(GetInstance(), GetSettingsKey(), -1);
 }
 
-Tlv *Dataset::Get(Tlv::Type aType)
+bool DatasetLocal::IsPresent(void) const
 {
-    Tlv *cur = reinterpret_cast<Tlv *>(mTlvs);
-    Tlv *end = reinterpret_cast<Tlv *>(mTlvs + mLength);
-    Tlv *rval = NULL;
+    return otPlatSettingsGet(GetInstance(), GetSettingsKey(), 0, NULL, NULL) == OT_ERROR_NONE;
+}
 
-    while (cur < end)
+otError DatasetLocal::Get(Dataset &aDataset)
+{
+    DelayTimerTlv *delayTimer;
+    uint32_t elapsed;
+    otError error;
+
+    aDataset.mLength = sizeof(aDataset.mTlvs);
+
+    error = otPlatSettingsGet(GetInstance(), GetSettingsKey(), 0, aDataset.mTlvs, &aDataset.mLength);
+    SuccessOrExit(error);
+
+    delayTimer = static_cast<DelayTimerTlv *>(aDataset.Get(Tlv::kDelayTimer));
+    VerifyOrExit(delayTimer);
+
+    elapsed = Timer::GetNow() - mUpdateTime;
+
+    if (delayTimer->GetDelayTimer() > elapsed)
     {
-        if (cur->GetType() == aType)
-        {
-            ExitNow(rval = cur);
-        }
-
-        cur = cur->GetNext();
+        delayTimer->SetDelayTimer(delayTimer->GetDelayTimer() - elapsed);
+    }
+    else
+    {
+        delayTimer->SetDelayTimer(0);
     }
 
-exit:
-    return rval;
-}
-
-const Tlv *Dataset::Get(Tlv::Type aType) const
-{
-    const Tlv *cur = reinterpret_cast<const Tlv *>(mTlvs);
-    const Tlv *end = reinterpret_cast<const Tlv *>(mTlvs + mLength);
-    const Tlv *rval = NULL;
-
-    while (cur < end)
-    {
-        if (cur->GetType() == aType)
-        {
-            ExitNow(rval = cur);
-        }
-
-        cur = cur->GetNext();
-    }
+    aDataset.mUpdateTime = Timer::GetNow();
 
 exit:
-    return rval;
+    return error;
 }
 
-void Dataset::Get(otOperationalDataset &aDataset) const
+otError DatasetLocal::Get(otOperationalDataset &aDataset) const
 {
-    const Tlv *cur = reinterpret_cast<const Tlv *>(mTlvs);
-    const Tlv *end = reinterpret_cast<const Tlv *>(mTlvs + mLength);
+    Dataset    dataset(mType);
+    otError    error;
+    const Tlv *cur;
+    const Tlv *end;
+
+    dataset.mLength = sizeof(dataset.mTlvs);
+
+    error = otPlatSettingsGet(GetInstance(), GetSettingsKey(), 0, dataset.mTlvs, &dataset.mLength);
+    SuccessOrExit(error);
+
+    cur = reinterpret_cast<const Tlv *>(dataset.mTlvs);
+    end = reinterpret_cast<const Tlv *>(dataset.mTlvs + dataset.mLength);
 
     memset(&aDataset, 0, sizeof(aDataset));
 
@@ -129,9 +140,9 @@ void Dataset::Get(otOperationalDataset &aDataset) const
 
         case Tlv::kChannelMask:
         {
-            uint8_t length = cur->GetLength();
+            uint8_t tlvLength = cur->GetLength();
             const uint8_t *entry = reinterpret_cast<const uint8_t *>(cur) + sizeof(Tlv);
-            const uint8_t *entryEnd =  entry + length;
+            const uint8_t *entryEnd =  entry + tlvLength;
 
             while (entry < entryEnd)
             {
@@ -232,28 +243,17 @@ void Dataset::Get(otOperationalDataset &aDataset) const
 
         cur = cur->GetNext();
     }
-}
 
-otError Dataset::Set(const Dataset &aDataset)
-{
-    memcpy(mTlvs, aDataset.mTlvs, aDataset.mLength);
-    mLength = aDataset.mLength;
-
-    if (mType == Tlv::kActiveTimestamp)
-    {
-        Remove(Tlv::kPendingTimestamp);
-        Remove(Tlv::kDelayTimer);
-    }
-
-    mUpdateTime = aDataset.GetUpdateTime();
-
-    return OT_ERROR_NONE;
+exit:
+    return error;
 }
 
 #if OPENTHREAD_FTD
-otError Dataset::Set(const otOperationalDataset &aDataset)
+
+otError DatasetLocal::Set(const otOperationalDataset &aDataset)
 {
     otError error = OT_ERROR_NONE;
+    Dataset dataset(mType);
     MeshCoP::ActiveTimestampTlv activeTimestampTlv;
 
     VerifyOrExit(aDataset.mIsActiveTimestampSet, error = OT_ERROR_INVALID_ARGS);
@@ -261,7 +261,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
     activeTimestampTlv.Init();
     activeTimestampTlv.SetSeconds(aDataset.mActiveTimestamp);
     activeTimestampTlv.SetTicks(0);
-    Set(activeTimestampTlv);
+    dataset.Set(activeTimestampTlv);
 
     if (mType == Tlv::kPendingTimestamp)
     {
@@ -272,14 +272,14 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         pendingTimestampTlv.Init();
         pendingTimestampTlv.SetSeconds(aDataset.mPendingTimestamp);
         pendingTimestampTlv.SetTicks(0);
-        Set(pendingTimestampTlv);
+        dataset.Set(pendingTimestampTlv);
 
         if (aDataset.mIsDelaySet)
         {
             MeshCoP::DelayTimerTlv tlv;
             tlv.Init();
             tlv.SetDelayTimer(aDataset.mDelay);
-            Set(tlv);
+            dataset.Set(tlv);
         }
     }
 
@@ -289,7 +289,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         tlv.Init();
         tlv.SetChannelPage(0);
         tlv.SetChannel(aDataset.mChannel);
-        Set(tlv);
+        dataset.Set(tlv);
     }
 
     if (aDataset.mIsChannelMaskPage0Set)
@@ -297,7 +297,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         MeshCoP::ChannelMask0Tlv tlv;
         tlv.Init();
         tlv.SetMask(aDataset.mChannelMaskPage0);
-        Set(tlv);
+        dataset.Set(tlv);
     }
 
     if (aDataset.mIsExtendedPanIdSet)
@@ -305,7 +305,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         MeshCoP::ExtendedPanIdTlv tlv;
         tlv.Init();
         tlv.SetExtendedPanId(aDataset.mExtendedPanId.m8);
-        Set(tlv);
+        dataset.Set(tlv);
     }
 
     if (aDataset.mIsMeshLocalPrefixSet)
@@ -313,7 +313,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         MeshCoP::MeshLocalPrefixTlv tlv;
         tlv.Init();
         tlv.SetMeshLocalPrefix(aDataset.mMeshLocalPrefix.m8);
-        Set(tlv);
+        dataset.Set(tlv);
     }
 
     if (aDataset.mIsMasterKeySet)
@@ -321,7 +321,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         MeshCoP::NetworkMasterKeyTlv tlv;
         tlv.Init();
         tlv.SetNetworkMasterKey(aDataset.mMasterKey);
-        Set(tlv);
+        dataset.Set(tlv);
     }
 
     if (aDataset.mIsNetworkNameSet)
@@ -329,7 +329,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         MeshCoP::NetworkNameTlv tlv;
         tlv.Init();
         tlv.SetNetworkName(aDataset.mNetworkName.m8);
-        Set(tlv);
+        dataset.Set(tlv);
     }
 
     if (aDataset.mIsPanIdSet)
@@ -337,7 +337,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         MeshCoP::PanIdTlv tlv;
         tlv.Init();
         tlv.SetPanId(aDataset.mPanId);
-        Set(tlv);
+        dataset.Set(tlv);
     }
 
     if (aDataset.mIsPSKcSet)
@@ -345,7 +345,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         MeshCoP::PSKcTlv tlv;
         tlv.Init();
         tlv.SetPSKc(aDataset.mPSKc.m8);
-        Set(tlv);
+        dataset.Set(tlv);
     }
 
     if (aDataset.mIsSecurityPolicySet)
@@ -354,77 +354,49 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         tlv.Init();
         tlv.SetRotationTime(aDataset.mSecurityPolicy.mRotationTime);
         tlv.SetFlags(aDataset.mSecurityPolicy.mFlags);
-        Set(tlv);
+        dataset.Set(tlv);
     }
 
-    mUpdateTime = Timer::GetNow();
+    if (dataset.GetSize() == 0)
+    {
+        error = otPlatSettingsDelete(GetInstance(), GetSettingsKey(), 0);
+        otLogInfoMeshCoP(GetInstance(), "%s dataset deleted", mType == Tlv::kActiveTimestamp ? "Active" : "Pending");
+    }
+    else
+    {
+        error = otPlatSettingsSet(GetInstance(), GetSettingsKey(), dataset.GetBytes(), dataset.GetSize());
+        otLogInfoMeshCoP(GetInstance(), "%s dataset set", mType == Tlv::kActiveTimestamp ? "Active" : "Pending");
+    }
 
 exit:
     return error;
 }
+
 #endif  // OPENTHREAD_FTD
 
-const Timestamp *Dataset::GetTimestamp(void) const
+otError DatasetLocal::Set(const Dataset &aDataset)
 {
-    const Timestamp *timestamp = NULL;
+    Dataset dataset(aDataset);
+    otError error;
 
     if (mType == Tlv::kActiveTimestamp)
     {
-        const ActiveTimestampTlv *tlv = static_cast<const ActiveTimestampTlv *>(Get(mType));
-        VerifyOrExit(tlv != NULL);
-        timestamp = static_cast<const Timestamp *>(tlv);
+        dataset.Remove(Tlv::kPendingTimestamp);
+        dataset.Remove(Tlv::kDelayTimer);
+    }
+
+    if (dataset.GetSize() == 0)
+    {
+        error = otPlatSettingsDelete(GetInstance(), GetSettingsKey(), 0);
+        otLogInfoMeshCoP(GetInstance(), "%s dataset deleted", mType == Tlv::kActiveTimestamp ? "Active" : "Pending");
     }
     else
     {
-        const PendingTimestampTlv *tlv = static_cast<const PendingTimestampTlv *>(Get(mType));
-        VerifyOrExit(tlv != NULL);
-        timestamp = static_cast<const Timestamp *>(tlv);
+        error = otPlatSettingsSet(GetInstance(), GetSettingsKey(), dataset.GetBytes(), dataset.GetSize());
+        otLogInfoMeshCoP(GetInstance(), "%s dataset set", mType == Tlv::kActiveTimestamp ? "Active" : "Pending");
     }
 
-exit:
-    return timestamp;
-}
-
-void Dataset::SetTimestamp(const Timestamp &aTimestamp)
-{
-    if (mType == Tlv::kActiveTimestamp)
-    {
-        ActiveTimestampTlv activeTimestamp;
-        activeTimestamp.Init();
-        *static_cast<Timestamp *>(&activeTimestamp) = aTimestamp;
-        Set(activeTimestamp);
-    }
-    else
-    {
-        PendingTimestampTlv pendingTimestamp;
-        pendingTimestamp.Init();
-        *static_cast<Timestamp *>(&pendingTimestamp) = aTimestamp;
-        Set(pendingTimestamp);
-    }
-}
-
-otError Dataset::Set(const Tlv &aTlv)
-{
-    otError error = OT_ERROR_NONE;
-    uint16_t bytesAvailable = sizeof(mTlvs) - mLength;
-    Tlv *old = Get(aTlv.GetType());
-
-    if (old != NULL)
-    {
-        bytesAvailable += sizeof(Tlv) + old->GetLength();
-    }
-
-    VerifyOrExit(sizeof(Tlv) + aTlv.GetLength() <= bytesAvailable, error = OT_ERROR_NO_BUFS);
-
-    // remove old TLV
-    if (old != NULL)
-    {
-        Remove(reinterpret_cast<uint8_t *>(old), sizeof(Tlv) + old->GetLength());
-    }
-
-    // add new TLV
-    memcpy(mTlvs + mLength, &aTlv, sizeof(Tlv) + aTlv.GetLength());
-    mLength += sizeof(Tlv) + aTlv.GetLength();
+    SuccessOrExit(error);
 
     mUpdateTime = Timer::GetNow();
 
@@ -432,12 +404,14 @@ exit:
     return error;
 }
 
-otError Dataset::Set(const Message &aMessage, uint16_t aOffset, uint8_t aLength)
+otError DatasetLocal::Restore(void)
 {
-    otError error = OT_ERROR_NONE;
+    Dataset dataset(mType);
+    otError error;
 
-    VerifyOrExit(aLength == aMessage.Read(aOffset, aLength, mTlvs), error = OT_ERROR_INVALID_ARGS);
-    mLength = aLength;
+    dataset.mLength = sizeof(dataset.mTlvs);
+    error = otPlatSettingsGet(GetInstance(), GetSettingsKey(), 0, dataset.mTlvs, &dataset.mLength);
+    SuccessOrExit(error);
 
     mUpdateTime = Timer::GetNow();
 
@@ -445,70 +419,7 @@ exit:
     return error;
 }
 
-void Dataset::Remove(Tlv::Type aType)
-{
-    Tlv *tlv;
-
-    VerifyOrExit((tlv = Get(aType)) != NULL);
-    Remove(reinterpret_cast<uint8_t *>(tlv), sizeof(Tlv) + tlv->GetLength());
-
-exit:
-    return;
-}
-
-otError Dataset::AppendMleDatasetTlv(Message &aMessage) const
-{
-    otError error = OT_ERROR_NONE;
-    Mle::Tlv tlv;
-    Mle::Tlv::Type type;
-    const Tlv *cur = reinterpret_cast<const Tlv *>(mTlvs);
-    const Tlv *end = reinterpret_cast<const Tlv *>(mTlvs + mLength);
-
-    VerifyOrExit(mLength > 0);
-
-    type = (mType == Tlv::kActiveTimestamp ? Mle::Tlv::kActiveDataset : Mle::Tlv::kPendingDataset);
-
-    tlv.SetType(type);
-    tlv.SetLength(static_cast<uint8_t>(mLength) - sizeof(Tlv) - sizeof(Timestamp));
-    SuccessOrExit(error = aMessage.Append(&tlv, sizeof(Tlv)));
-
-    while (cur < end)
-    {
-        if (cur->GetType() == mType)
-        {
-            ; // skip Active or Pending Timestamp TLV
-        }
-        else if (cur->GetType() == Tlv::kDelayTimer)
-        {
-            uint32_t elapsed = Timer::GetNow() - mUpdateTime;
-            DelayTimerTlv delayTimer;
-
-            memcpy(&delayTimer, cur, sizeof(delayTimer));
-
-            if (delayTimer.GetDelayTimer() > elapsed)
-            {
-                delayTimer.SetDelayTimer(delayTimer.GetDelayTimer() - elapsed);
-            }
-            else
-            {
-                delayTimer.SetDelayTimer(0);
-            }
-
-            SuccessOrExit(error = aMessage.Append(&delayTimer, sizeof(delayTimer)));
-        }
-        else
-        {
-            SuccessOrExit(error = aMessage.Append(cur, sizeof(Tlv) + cur->GetLength()));
-        }
-
-        cur = cur->GetNext();
-    }
-
-exit:
-    return error;
-}
-
-uint16_t Dataset::GetSettingsKey(void)
+uint16_t DatasetLocal::GetSettingsKey(void) const
 {
     uint16_t rval;
 
@@ -524,10 +435,35 @@ uint16_t Dataset::GetSettingsKey(void)
     return rval;
 }
 
-void Dataset::Remove(uint8_t *aStart, uint8_t aLength)
+int DatasetLocal::Compare(const Timestamp *aCompareTimestamp)
 {
-    memmove(aStart, aStart + aLength, mLength - (static_cast<uint8_t>(aStart - mTlvs) + aLength));
-    mLength -= aLength;
+    const Timestamp *thisTimestamp;
+    Dataset dataset(mType);
+    int rval = 1;
+
+    SuccessOrExit(Get(dataset));
+
+    thisTimestamp = dataset.GetTimestamp();
+
+    if (aCompareTimestamp == NULL && thisTimestamp == NULL)
+    {
+        rval = 0;
+    }
+    else if (aCompareTimestamp == NULL && thisTimestamp != NULL)
+    {
+        rval = -1;
+    }
+    else if (aCompareTimestamp != NULL && thisTimestamp == NULL)
+    {
+        rval = 1;
+    }
+    else
+    {
+        rval = thisTimestamp->Compare(*aCompareTimestamp);
+    }
+
+exit:
+    return rval;
 }
 
 }  // namespace MeshCoP

--- a/src/core/meshcop/dataset_local.hpp
+++ b/src/core/meshcop/dataset_local.hpp
@@ -1,0 +1,169 @@
+/*
+ *  Copyright (c) 2016-2017, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for managing MeshCoP Datasets.
+ *
+ */
+
+#ifndef MESHCOP_DATASET_LOCAL_HPP_
+#define MESHCOP_DATASET_LOCAL_HPP_
+
+#include "common/locator.hpp"
+#include "meshcop/dataset.hpp"
+#include "meshcop/meshcop_tlvs.hpp"
+
+namespace ot {
+namespace MeshCoP {
+
+class DatasetLocal: public InstanceLocator
+{
+public:
+    /**
+     * This constructor initializes the object.
+     *
+     * @param[in]  aInstance  A pointer to an OpenThread instance.
+     * @param[in]  aType      The type of the dataset, active or pending.
+     *
+     */
+    DatasetLocal(otInstance *aInstance, const Tlv::Type aType);
+
+    /**
+     * This method indicates whether this is an Active or Pending Dataset.
+     *
+     * @retval Tlv::kActiveTimestamp when this is an Active Dataset.
+     * @retval Tlv::kPendingTimetamp when this is a Pending Dataset.
+     *
+     */
+    Tlv::Type GetType(void) const { return mType; }
+
+    /**
+     * This method clears the Dataset.
+     *
+     */
+    void Clear(void);
+
+    /**
+     * This method indicates whether or not the dataset is present in non-volatile memory.
+     *
+     * @retval TRUE   if the dataset is present in non-volatile memory.
+     * @retval FALSE  if the dataset is not present in non-volatile memory.
+     *
+     */
+    bool IsPresent(void) const;
+
+    /**
+     * This method returns a pointer to the Active or Pending Timestamp value.
+     *
+     * @returns  A pointer to the Active or Pending Timestamp value or NULL if the dataset is invalid.
+     *
+     */
+    const Timestamp *GetTimestamp(void) const;
+
+    /**
+     * This method retrieves the dataset from non-volatile memory.
+     *
+     * @param[out]  aDataset  Where to place the dataset.
+     *
+     * @retval OT_ERROR_NONE       Successfully retrieved the dataset.
+     * @retval OT_ERROR_NOT_FOUND  There is no corresponding dataset stored in non-volatile memory.
+     *
+     */
+    otError Get(Dataset &aDataset);
+
+    /**
+     * This method retrieves the dataset from non-volatile memory.
+     *
+     * @param[out]  aDataset  Where to place the dataset.
+     *
+     * @retval OT_ERROR_NONE       Successfully retrieved the dataset.
+     * @retval OT_ERROR_NOT_FOUND  There is no corresponding dataset stored in non-volatile memory.
+     *
+     */
+    otError Get(otOperationalDataset &aDataset) const;
+
+    /**
+     * This method returns the local time this dataset was last updated or restored.
+     *
+     * @returns The local time this dataset was last updated or restored.
+     *
+     */
+    uint32_t GetUpdateTime(void) const { return mUpdateTime; }
+
+#if OPENTHREAD_FTD
+    /**
+     * This method stores the dataset into non-volatile memory.
+     *
+     * @retval OT_ERROR_NONE  Successfully stored the dataset.
+     *
+     */
+    otError Set(const otOperationalDataset &aDataset);
+#endif
+
+    /**
+     * This method stores the dataset into non-volatile memory.
+     *
+     * @retval OT_ERROR_NONE  Successfully stored the dataset.
+     *
+     */
+    otError Set(const Dataset &aDataset);
+
+    /**
+     * This method restores dataset from non-volatile memory.
+     *
+     * @retval OT_ERROR_NONE       Successfully restore the dataset.
+     * @retval OT_ERROR_NOT_FOUND  There is no corresponding dataset stored in non-volatile memory.
+     *
+     */
+    otError Restore(void);
+
+    /**
+     * This method compares this dataset to another based on the timestamp.
+     *
+     * @param[in]  aCompare  A reference to the timestamp to compare.
+     *
+     * @retval -1  if @p aCompare is older than this dataset.
+     * @retval  0  if @p aCompare is equal to this dataset.
+     * @retval  1  if @p aCompare is newer than this dataset.
+     *
+     */
+    int Compare(const Timestamp *aCompare);
+
+private:
+    uint16_t GetSettingsKey(void) const;
+    void SetTimestamp(const Dataset &aDataset);
+
+    uint32_t    mUpdateTime;      ///< Local time last updated
+    Tlv::Type   mType;            ///< Active or Pending
+};
+
+}  // namespace MeshCoP
+}  // namespace ot
+
+#endif  // MESHCOP_DATASET_LOCAL_HPP_

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -41,6 +41,7 @@
 #include "common/locator.hpp"
 #include "common/timer.hpp"
 #include "meshcop/dataset.hpp"
+#include "meshcop/dataset_local.hpp"
 #include "net/udp6.hpp"
 #include "thread/mle.hpp"
 #include "thread/network_data_leader.hpp"
@@ -54,34 +55,154 @@ namespace MeshCoP {
 class DatasetManager: public ThreadNetifLocator
 {
 public:
-    Dataset &GetLocal(void) { return mLocal; }
+    /**
+     * This method returns a reference to the Timestamp.
+     *
+     * @returns A pointer to the Timestamp.
+     *
+     */
+    const Timestamp *GetTimestamp(void) const;
+
+    /**
+     * This method compares @p aTimestamp to the dataset's timestamp value.
+     *
+     * @param[in]  aCompare  A reference to the timestamp to compare.
+     *
+     * @retval -1  if @p aCompare is older than this dataset.
+     * @retval  0  if @p aCompare is equal to this dataset.
+     * @retval  1  if @p aCompare is newer than this dataset.
+     *
+     */
+    int Compare(const Timestamp &aTimestamp) const;
+
+    /**
+     * This method appends the MLE Dataset TLV but excluding MeshCoP Sub Timestamp TLV.
+     *
+     * @retval OT_ERROR_NONE     Successfully append MLE Dataset TLV without MeshCoP Sub Timestamp TLV.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to append the message with MLE Dataset TLV.
+     *
+     */
+    otError AppendMleDatasetTlv(Message &aMessage) const;
+
+    /**
+     * This method returns a pointer to the TLV.
+     *
+     * @returns A pointer to the TLV or NULL if none is found.
+     *
+     */
+    const Tlv *GetTlv(Tlv::Type aType) const;
+
+    /**
+     * This method returns the Operational Dataset stored in non-volatile memory.
+     *
+     * @retval A reference to the Operational Dataset stored in non-volatile memory.
+     *
+     */
+    DatasetLocal &GetLocal(void) { return mLocal; }
+
+    /**
+     * This method returns the Operational Dataset for the attached partition.
+     *
+     * When not attached to a partition, the returned dataset is the one stored in non-volatile memory.
+     *
+     * @retval A reference to the Operational Dataset for the attached partition.
+     *
+     */
     Dataset &GetNetwork(void) { return mNetwork; }
 
+    /**
+     * This method applies the Active or Pending Dataset to the Thread interface.
+     *
+     * @retval OT_ERROR_NONE  Successfully applied configuration.
+     *
+     */
     otError ApplyConfiguration(void);
 
 protected:
-    enum
-    {
-        kFlagLocalUpdated   = 1 << 0,
-        kFlagNetworkUpdated = 1 << 1,
-    };
 
+    /**
+     * This constructor initializes the object.
+     *
+     * @param[in]  aThreadNetif   A reference to the Thread network interface.
+     * @param[in]  aType          Identifies Active or Pending Operational Dataset.
+     * @param[in]  aUriSet        The URI-PATH for setting the Operational Dataset.
+     * @param[in]  aUriGet        The URI-PATH for getting the Operational Dataset.
+     * @param[in]  aTimerHandler  The registration timer handler.
+     *
+     */
     DatasetManager(ThreadNetif &aThreadNetif, const Tlv::Type aType, const char *aUriSet, const char *aUriGet,
                    Timer::Handler aTimerHander);
 
-    otError Clear(uint8_t &aFlags, bool aOnlyClearNetwork);
+    /**
+     * This method restores the Operational Dataset from non-volatile memory.
+     *
+     * @retval OT_ERROR_NONE       Successfully restore the dataset.
+     * @retval OT_ERROR_NOT_FOUND  There is no corresponding dataset stored in non-volatile memory.
+     *
+     */
+    otError Restore(void);
 
-    otError Set(const Dataset &aDataset);
+    /**
+     * This method clears the Operational Dataset.
+     *
+     */
+    void Clear(void);
 
-    otError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength,
-                uint8_t &aFlags);
+    /**
+     * This method updates the Operational Dataset when detaching from the network.
+     *
+     * On detach, the Operational Dataset is restored from non-volatile memory.
+     *
+     */
+    void HandleDetach(void);
 
-    void Get(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    /**
+     * This method sets the Operational Dataset in non-volatile memory.
+     *
+     * @param[in]  aDataset  The Operational Dataset.
+     *
+     */
+    void Set(const Dataset &aDataset);
 
-    void HandleNetworkUpdate(uint8_t &aFlags);
+    /**
+     * This method sets the Operational Dataset for the partition.
+     *
+     * This method also updates the non-volatile version if the partition's Operational Dataset is newer.
+     *
+     * @param[in]  aTimestamp  The timestamp for the Operational Dataset.
+     * @param[in]  aMessage    The message buffer.
+     * @param[in]  aOffset     The offset where the Operational Dataset begins.
+     * @param[in]  aLength     The length of the Operational Dataset.
+     *
+     */
+    otError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
+
+    /**
+     * This method handles a MGMT_GET request message.
+     *
+     * @param[in]  aHeader       The CoAP header.
+     * @param[in]  aMessage      The CoAP message buffer.
+     * @parma[in]  aMessageInfo  The message info.
+     *
+     */
+    void Get(const Coap::Header &aHeader, const Message &aMessage, const Ip6::MessageInfo &aMessageInfo) const;
+
+    /**
+     * This method compares the partition's Operational Dataset with that stored in non-volatile memory.
+     *
+     * If the partition's Operational Dataset is newer, the non-volatile storage is updated.
+     * If the partition's Operational Dataset is older, the registration process is started.
+     *
+     */
+    void HandleNetworkUpdate(void);
+
+    /**
+     * This method initiates a network data registration message with the Leader.
+     *
+     */
     void HandleTimer(void);
 
-    Dataset mLocal;
+    DatasetLocal mLocal;
     Dataset mNetwork;
 
 private:
@@ -90,7 +211,8 @@ private:
 
     otError Register(void);
     void SendGetResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
-                         uint8_t *aTlvs, uint8_t aLength);
+                         uint8_t *aTlvs, uint8_t aLength) const;
+
     Timer mTimer;
 
     const char *mUriSet;
@@ -98,11 +220,50 @@ private:
 
 #if OPENTHREAD_FTD
 public:
+    /**
+     * This method sends a MGMT_SET request to the Leader.
+     *
+     * @parma[in]  aDataset  The Operational Datset.
+     * @param[in]  aTlvs     Any additional raw TLVs to include.
+     * @param[in]  aLength   Number of bytes in @p aTlvs.
+     *
+     * @retval OT_ERROR_NONE on success.
+     *
+     */
     otError SendSetRequest(const otOperationalDataset &aDataset, const uint8_t *aTlvs, uint8_t aLength);
+
+    /**
+     * This method sends a MGMT_GET request.
+     *
+     * @param[in]  aTlvTypes  The list of TLV types to request.
+     * @param[in]  aLength    Number of bytes in @p aTlvTypes.
+     * @parma[in]  aAddress   The IPv6 destination address for the MGMT_GET request.
+     *
+     * @retval OT_ERROR_NONE on success.
+     *
+     */
     otError SendGetRequest(const uint8_t *aTlvTypes, uint8_t aLength, const otIp6Address *aAddress);
 
 protected:
-    otError Set(const otOperationalDataset &aDataset, uint8_t &aFlags);
+    /**
+     * This method sets the Operational Dataset in non-volatile memory.
+     *
+     * @parma[in]  aDataset  The Operational Dataset.
+     *
+     */
+    otError Set(const otOperationalDataset &aDataset);
+
+    /**
+     * This method handles the MGMT_SET request message.
+     *
+     * @param[in]  aHeader       The CoAP header.
+     * @param[in]  aMessage      The CoAP message buffer.
+     * @parma[in]  aMessageInfo  The message info.
+     *
+     * @retval OT_ERROR_NONE  The MGMT_SET request message was handled successfully.
+     * @retval OT_ERROR_DROP  The MGMT_SET request message was dropped.
+     *
+     */
     otError Set(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
 private:
@@ -113,18 +274,72 @@ private:
 class ActiveDatasetBase: public DatasetManager
 {
 public:
+    /**
+     * Constructor.
+     *
+     * @param[in]  aThreadNetif  The Thread network interface.
+     *
+     */
     ActiveDatasetBase(ThreadNetif &aThreadNetif);
 
+    /**
+     * This method restores the Active Operational Dataset from non-volatile memory.
+     *
+     * This method will also configure the Thread interface using the Active Operational Dataset.
+     *
+     * @retval OT_ERROR_NONE       Successfully restore the dataset.
+     * @retval OT_ERROR_NOT_FOUND  There is no corresponding dataset stored in non-volatile memory.
+     *
+     */
     otError Restore(void);
 
-    otError Clear(bool aOnlyClearNetwork);
+    /**
+     * This method clears the Active Operational Dataset.
+     *
+     */
+    void Clear(void);
+
+    /**
+     * This method updates the Operational Dataset when detaching from the network.
+     *
+     * On detach, the Operational Dataset is restored from non-volatile memory and reconfigures the Thread
+     * interface.
+     *
+     */
+    void HandleDetach(void);
 
 #if OPENTHREAD_FTD
+    /**
+     * This method sets the Operational Dataset in non-volatile memory.
+     *
+     * @parma[in]  aDataset  The Operational Dataset.
+     *
+     */
     otError Set(const otOperationalDataset &aDataset);
 #endif
 
-    otError Set(const Dataset &aDataset);
+    /**
+     * This method sets the Operational Dataset in non-volatile memory.
+     *
+     * This method also reconfigures the Thread interface.
+     *
+     * @param[in]  aDataset  The Operational Dataset.
+     *
+     */
+    void Set(const Dataset &aDataset);
 
+    /**
+     * This method sets the Operational Dataset for the partition.
+     *
+     * This method also reconfigures the Thread interface.
+     * This method also updates the non-volatile version if the partition's Operational Dataset is newer.
+     *
+     * @param[in]  aTimestamp  The timestamp for the Operational Dataset.
+     * @param[in]  aMessage    The message buffer.
+     * @param[in]  aOffset     The offset where the Operational Dataset begins.
+     * @param[in]  aLength     The length of the Operational Dataset.
+     *
+     */
     otError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
 
 private:
@@ -141,34 +356,93 @@ private:
 class PendingDatasetBase: public DatasetManager
 {
 public:
+    /**
+     * Constructor.
+     *
+     * @param[in]  The Thread network interface.
+     *
+     */
     PendingDatasetBase(ThreadNetif &aThreadNetif);
 
+    /**
+     * This method restores the Operational Dataset from non-volatile memory.
+     *
+     * @retval OT_ERROR_NONE       Successfully restore the dataset.
+     * @retval OT_ERROR_NOT_FOUND  There is no corresponding dataset stored in non-volatile memory.
+     *
+     */
     otError Restore(void);
 
-    otError Clear(bool aOnlyClearNetwork);
+    /**
+     * This method clears the Pending Operational Dataset.
+     *
+     * This method also stops the Delay Timer if it was active.
+     *
+     */
+    void Clear(void);
+
+    /**
+     * This method clears the network Pending Operational Dataset.
+     *
+     * This method also stops the Delay Timer if it was active.
+     *
+     */
+    void ClearNetwork(void);
+
+    /**
+     * This method updates the Operational Dataset when detaching from the network.
+     *
+     * On detach, the Operational Dataset is restored from non-volatile memory.
+     *
+     * This method also stops the Delay Timer if it was active.
+     *
+     */
+    void HandleDetach(void);
 
 #if OPENTHREAD_FTD
+    /**
+     * This method sets the Operational Dataset in non-volatile memory.
+     *
+     * This method also starts the Delay Timer.
+     *
+     * @parma[in]  aDataset  The Operational Dataset.
+     *
+     */
     otError Set(const otOperationalDataset &aDataset);
 #endif
 
-    otError Set(const Dataset &aDataset);
+    /**
+     * This method sets the Operational Dataset in non-volatile memory.
+     *
+     * This method also starts the Delay Timer.
+     *
+     * @param[in]  aDataset  The Operational Dataset.
+     *
+     */
+    void Set(const Dataset &aDataset);
 
+    /**
+     * This method sets the Operational Dataset for the partition.
+     *
+     * This method also updates the non-volatile version if the partition's Operational Dataset is newer.
+     *
+     * This method also starts the Delay Timer.
+     *
+     * @param[in]  aTimestamp  The timestamp for the Operational Dataset.
+     * @param[in]  aMessage    The message buffer.
+     * @param[in]  aOffset     The offset where the Operational Dataset begins.
+     * @param[in]  aLength     The length of the Operational Dataset.
+     *
+     */
     otError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
-
-    void UpdateDelayTimer(void);
 
 protected:
     static void HandleDelayTimer(Timer &aTimer);
     void HandleDelayTimer(void);
-
-    void ResetDelayTimer(uint8_t aFlags);
-    void UpdateDelayTimer(Dataset &aDataset, uint32_t &aStartTime);
-
-    void HandleNetworkUpdate(uint8_t &aFlags);
+    void StartDelayTimer(void);
+    void HandleNetworkUpdate(void);
 
     Timer mDelayTimer;
-    uint32_t mLocalTime;
-    uint32_t mNetworkTime;
 
 private:
     static void HandleGet(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -327,7 +327,7 @@ otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessage
     ExtendedPanIdTlv extendedPanId;
     NetworkNameTlv networkName;
     NetworkKeySequenceTlv networkKeySequence;
-    Tlv *tlv;
+    const Tlv *tlv;
 
     DelayedJoinEntHeader delayedMessage;
 
@@ -356,7 +356,7 @@ otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessage
     networkName.SetNetworkName(netif.GetMac().GetNetworkName());
     SuccessOrExit(error = message->Append(&networkName, sizeof(Tlv) + networkName.GetLength()));
 
-    if ((tlv = netif.GetActiveDataset().GetNetwork().Get(Tlv::kActiveTimestamp)) != NULL)
+    if ((tlv = netif.GetActiveDataset().GetTlv(Tlv::kActiveTimestamp)) != NULL)
     {
         SuccessOrExit(error = message->Append(tlv, sizeof(Tlv) + tlv->GetLength()));
     }
@@ -367,7 +367,7 @@ otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessage
         SuccessOrExit(error = message->Append(&activeTimestamp, sizeof(activeTimestamp)));
     }
 
-    if ((tlv = netif.GetActiveDataset().GetNetwork().Get(Tlv::kChannelMask)) != NULL)
+    if ((tlv = netif.GetActiveDataset().GetTlv(Tlv::kChannelMask)) != NULL)
     {
         SuccessOrExit(error = message->Append(tlv, sizeof(Tlv) + tlv->GetLength()));
     }
@@ -378,7 +378,7 @@ otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessage
         SuccessOrExit(error = message->Append(&channelMask, sizeof(channelMask)));
     }
 
-    if ((tlv = netif.GetActiveDataset().GetNetwork().Get(Tlv::kPSKc)) != NULL)
+    if ((tlv = netif.GetActiveDataset().GetTlv(Tlv::kPSKc)) != NULL)
     {
         SuccessOrExit(error = message->Append(tlv, sizeof(Tlv) + tlv->GetLength()));
     }
@@ -389,7 +389,7 @@ otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessage
         SuccessOrExit(error = message->Append(&pskc, sizeof(pskc)));
     }
 
-    if ((tlv = netif.GetActiveDataset().GetNetwork().Get(Tlv::kSecurityPolicy)) != NULL)
+    if ((tlv = netif.GetActiveDataset().GetTlv(Tlv::kSecurityPolicy)) != NULL)
     {
         SuccessOrExit(error = message->Append(tlv, sizeof(Tlv) + tlv->GetLength()));
     }

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1120,14 +1120,12 @@ protected:
      * This method appends a Active Timestamp TLV to a message.
      *
      * @param[in]  aMessage  A reference to the message.
-     * @param[in]  aCouldUseLocal  True to use local Active Timestamp when network Active Timestamp is not available,
-     *                             False not.
      *
      * @retval OT_ERROR_NONE     Successfully appended the Active Timestamp TLV.
      * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Active Timestamp TLV.
      *
      */
-    otError AppendActiveTimestamp(Message &aMessage, bool aCouldUseLocal);
+    otError AppendActiveTimestamp(Message &aMessage);
 
     /**
      * This method appends a Pending Timestamp TLV to a message.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2191,15 +2191,13 @@ otError MleRouter::HandleChildIdRequest(const Message &aMessage, const Ip6::Mess
     }
 
     if (activeTimestamp.GetLength() == 0 ||
-        netif.GetActiveDataset().GetNetwork().GetTimestamp() == NULL ||
-        netif.GetActiveDataset().GetNetwork().GetTimestamp()->Compare(activeTimestamp) != 0)
+        netif.GetActiveDataset().Compare(activeTimestamp) != 0)
     {
         child->SetRequestTlv(numTlvs++, Tlv::kActiveDataset);
     }
 
     if (pendingTimestamp.GetLength() == 0 ||
-        netif.GetPendingDataset().GetNetwork().GetTimestamp() == NULL ||
-        netif.GetPendingDataset().GetNetwork().GetTimestamp()->Compare(pendingTimestamp) != 0)
+        netif.GetPendingDataset().Compare(pendingTimestamp) != 0)
     {
         child->SetRequestTlv(numTlvs++, Tlv::kPendingDataset);
     }
@@ -2465,15 +2463,13 @@ otError MleRouter::HandleDataRequest(const Message &aMessage, const Ip6::Message
     numTlvs = tlvRequest.GetLength();
 
     if (activeTimestamp.GetLength() == 0 ||
-        netif.GetActiveDataset().GetNetwork().GetTimestamp() == NULL ||
-        netif.GetActiveDataset().GetNetwork().GetTimestamp()->Compare(activeTimestamp) != 0)
+        netif.GetActiveDataset().Compare(activeTimestamp))
     {
         tlvs[numTlvs++] = Tlv::kActiveDataset;
     }
 
     if (pendingTimestamp.GetLength() == 0 ||
-        netif.GetPendingDataset().GetNetwork().GetTimestamp() == NULL ||
-        netif.GetPendingDataset().GetNetwork().GetTimestamp()->Compare(pendingTimestamp) != 0)
+        netif.GetPendingDataset().Compare(pendingTimestamp))
     {
         tlvs[numTlvs++] = Tlv::kPendingDataset;
     }
@@ -2747,7 +2743,7 @@ otError MleRouter::SendChildIdResponse(Child *aChild)
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandChildIdResponse));
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
-    SuccessOrExit(error = AppendActiveTimestamp(*message, false));
+    SuccessOrExit(error = AppendActiveTimestamp(*message));
     SuccessOrExit(error = AppendPendingTimestamp(*message));
 
     if (aChild->GetState() != Neighbor::kStateValid)
@@ -2852,7 +2848,7 @@ otError MleRouter::SendChildUpdateRequest(Child *aChild)
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
     SuccessOrExit(error = AppendNetworkData(*message, !aChild->IsFullNetworkData()));
-    SuccessOrExit(error = AppendActiveTimestamp(*message, false));
+    SuccessOrExit(error = AppendActiveTimestamp(*message));
     SuccessOrExit(error = AppendPendingTimestamp(*message));
     SuccessOrExit(error = AppendTlvRequest(*message, tlvs, sizeof(tlvs)));
 
@@ -2915,7 +2911,7 @@ otError MleRouter::SendChildUpdateResponse(Child *aChild, const Ip6::MessageInfo
 
         case Tlv::kNetworkData:
             SuccessOrExit(error = AppendNetworkData(*message, !aChild->IsFullNetworkData()));
-            SuccessOrExit(error = AppendActiveTimestamp(*message, false));
+            SuccessOrExit(error = AppendActiveTimestamp(*message));
             SuccessOrExit(error = AppendPendingTimestamp(*message));
             break;
 
@@ -2967,7 +2963,7 @@ otError MleRouter::SendDataResponse(const Ip6::Address &aDestination, const uint
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandDataResponse));
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
-    SuccessOrExit(error = AppendActiveTimestamp(*message, false));
+    SuccessOrExit(error = AppendActiveTimestamp(*message));
     SuccessOrExit(error = AppendPendingTimestamp(*message));
 
     for (int i = 0; i < aTlvsLength; i++)
@@ -4497,29 +4493,12 @@ exit:
 
 otError MleRouter::AppendActiveDataset(Message &aMessage)
 {
-    ThreadNetif &netif = GetNetif();
-    otError error = OT_ERROR_NONE;
-
-    VerifyOrExit(netif.GetActiveDataset().GetNetwork().GetSize() > 0);
-
-    SuccessOrExit(error = netif.GetActiveDataset().GetNetwork().AppendMleDatasetTlv(aMessage));
-
-exit:
-    return error;
+    return GetNetif().GetActiveDataset().AppendMleDatasetTlv(aMessage);
 }
 
 otError MleRouter::AppendPendingDataset(Message &aMessage)
 {
-    ThreadNetif &netif = GetNetif();
-    otError error = OT_ERROR_NONE;
-
-    VerifyOrExit(netif.GetPendingDataset().GetNetwork().GetSize() > 0);
-
-    netif.GetPendingDataset().UpdateDelayTimer();
-    SuccessOrExit(error = netif.GetPendingDataset().GetNetwork().AppendMleDatasetTlv(aMessage));
-
-exit:
-    return error;
+    return GetNetif().GetPendingDataset().AppendMleDatasetTlv(aMessage);
 }
 
 bool MleRouter::HasMinDowngradeNeighborRouters(void)

--- a/tests/scripts/thread-cert/Cert_9_2_08_PersistentDatasets.py
+++ b/tests/scripts/thread-cert/Cert_9_2_08_PersistentDatasets.py
@@ -45,7 +45,7 @@ LEADER_ACTIVE_TIMESTAMP = 10
 COMMISSIONER_PENDING_CHANNEL = 20
 COMMISSIONER_PENDING_PANID = 0xafce
 
-class Cert_9_2_8_DelayTimer(unittest.TestCase):
+class Cert_9_2_8_PersistentDatasets(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,6):
@@ -129,11 +129,8 @@ class Cert_9_2_8_DelayTimer(unittest.TestCase):
         time.sleep(5)
 
         self.nodes[ROUTER].reset()
-        self._setUpRouter()
         self.nodes[ED].reset()
-        self._setUpEd()
         self.nodes[SED].reset()
-        self._setUpSed()
 
         time.sleep(60)
 
@@ -143,8 +140,15 @@ class Cert_9_2_8_DelayTimer(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_channel(), COMMISSIONER_PENDING_CHANNEL)
         self.assertEqual(self.nodes[COMMISSIONER].get_channel(), COMMISSIONER_PENDING_CHANNEL)
         
+        # reset the devices here again to simulate the fact that the devices were disabled the entire time
+        self.nodes[ROUTER].reset()
+        self._setUpRouter()
         self.nodes[ROUTER].start()
+        self.nodes[ED].reset()
+        self._setUpEd()
         self.nodes[ED].start()
+        self.nodes[SED].reset()
+        self._setUpSed()
         self.nodes[SED].start()
 
         self.assertEqual(self.nodes[ROUTER].get_panid(), PANID_INIT)


### PR DESCRIPTION
The local Active and Pending Operational Datsets are stored in non-volatile
memory.  This commit dynamically retrieves those datasets from non-volatile
memory when they are needed.

This commit also simplifies the use of the Operational Datasets by having the
RAM buffer store the local Operational Dataset when in the detached state.

This PR saves 504 bytes RAM and marginally reduces code size.

Before:
```bash
$ arm-none-eabi-size output/cc2538/bin/ot-cli-ftd
   text	   data	    bss	    dec	    hex	filename
 218820	   4228	  27464	 250512	  3d290	output/cc2538/bin/ot-cli-ftd
```

After:
```bash
$ arm-none-eabi-size output/cc2538/bin/ot-cli-ftd
   text	   data	    bss	    dec	    hex	filename
 218732	   4228	  26960	 249920	  3d040	output/cc2538/bin/ot-cli-ftd
```