### PR TITLE
[meshcop] do not check keep-alive timeout when active commissioner re-petitions

### DIFF
--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -91,9 +91,13 @@ void Leader::HandlePetition(Coap::Header &aHeader, Message &aMessage, const Ip6:
     SuccessOrExit(Tlv::GetTlv(aMessage, Tlv::kCommissionerId, sizeof(commissionerId), commissionerId));
     VerifyOrExit(commissionerId.IsValid());
 
-    if (strncmp(commissionerId.GetCommissionerId(), mCommissionerId.GetCommissionerId(), sizeof(mCommissionerId)))
+    if (mTimer.IsRunning())
     {
-        VerifyOrExit(!mTimer.IsRunning());
+        VerifyOrExit(!strncmp(commissionerId.GetCommissionerId(), mCommissionerId.GetCommissionerId(),
+                              sizeof(mCommissionerId)));
+
+        mTimer.Stop();
+        ResignCommissioner();
     }
 
     data.mBorderAgentLocator.Init();

--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -96,7 +96,6 @@ void Leader::HandlePetition(Coap::Header &aHeader, Message &aMessage, const Ip6:
         VerifyOrExit(!strncmp(commissionerId.GetCommissionerId(), mCommissionerId.GetCommissionerId(),
                               sizeof(mCommissionerId)));
 
-        mTimer.Stop();
         ResignCommissioner();
     }
 
@@ -196,7 +195,6 @@ void Leader::HandleKeepAlive(Coap::Header &aHeader, Message &aMessage, const Ip6
     else if (state.GetState() != StateTlv::kAccept)
     {
         responseState = StateTlv::kReject;
-        mTimer.Stop();
         ResignCommissioner();
     }
     else
@@ -317,6 +315,7 @@ void Leader::SetEmptyCommissionerData(void)
 
 void Leader::ResignCommissioner(void)
 {
+    mTimer.Stop();
     SetEmptyCommissionerData();
 
     otLogInfoMeshCoP(GetInstance(), "commissioner inactive");

--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -91,7 +91,10 @@ void Leader::HandlePetition(Coap::Header &aHeader, Message &aMessage, const Ip6:
     SuccessOrExit(Tlv::GetTlv(aMessage, Tlv::kCommissionerId, sizeof(commissionerId), commissionerId));
     VerifyOrExit(commissionerId.IsValid());
 
-    VerifyOrExit(!mTimer.IsRunning());
+    if (strncmp(commissionerId.GetCommissionerId(), mCommissionerId.GetCommissionerId(), sizeof(mCommissionerId)))
+    {
+        VerifyOrExit(!mTimer.IsRunning());
+    }
 
     data.mBorderAgentLocator.Init();
     data.mBorderAgentLocator.SetBorderAgentLocator(HostSwap16(aMessageInfo.GetPeerAddr().mFields.m16[7]));


### PR DESCRIPTION
This commit allows a recorded active commissioner's petitioning immediately accepted, but no need to wait until keep-alive timer expires.