### PR TITLE
[cert] increase retransmission period for data poll

### DIFF
--- a/src/core/thread/data_poll_manager.hpp
+++ b/src/core/thread/data_poll_manager.hpp
@@ -198,7 +198,7 @@ private:
     enum  // Poll period under different conditions (in milliseconds).
     {
         kAttachDataPollPeriod   = OPENTHREAD_CONFIG_ATTACH_DATA_POLL_PERIOD,  ///< Poll period during attach.
-        kRetxPollPeriod         = 500,                                        ///< Poll retx period due to tx failure.
+        kRetxPollPeriod         = 1000,                                       ///< Poll retx period due to tx failure.
         kNoBufferRetxPollPeriod = 200,                                        ///< Poll retx due to no buffer space.
         kFastPollPeriod         = 188,                                        ///< Period used for fast polls.
         kMinPollPeriod          = 10,                                         ///< Minimum allowed poll period.


### PR DESCRIPTION
In 9.2.13, Commissioner would issue the energy scan command with (count, channelnum, scan duration, period) as (2, 1, 1000, 32) and the scan process would last about 2064ms, during which no hardware ack for any unicast packet because the radio is not in receive state.

Currently the whole retransmission process for data poll would last 500ms * 4 = 2s if no ack. Afterwards it will reattach, which finally cause no energy report from OT SED for the last energy scan command destined to all thread nodes broadcast address.

Increasing the retransmission period could help to ensure cert 9.2.13 SED pass stably  [DEV-1577](https://threadgroup.atlassian.net/browse/DEV-1577).

@abtink , is this update ok for you?



