### PR TITLE
[alarm] Update usec-alarm API to use single 32-bit microsecond

### DIFF
--- a/include/openthread/platform/alarm.h
+++ b/include/openthread/platform/alarm.h
@@ -29,7 +29,7 @@
 /**
  * @file
  * @brief
- *   This file includes the platform abstraction for the alarm service.
+ *   This file includes the platform abstraction for the millisecond alarm service.
  */
 
 #ifndef ALARM_H_

--- a/include/openthread/platform/usec-alarm.h
+++ b/include/openthread/platform/usec-alarm.h
@@ -51,16 +51,6 @@ extern "C" {
  */
 
 /**
- * This structure represents time in microseconds.
- *
- */
-typedef struct
-{
-    uint32_t mMs;  ///< Time in milliseconds.
-    uint16_t mUs;  ///< Time fraction in microseconds.
-} otPlatUsecAlarmTime;
-
-/**
  * This defines the callback for indicating when the alarm has expired.
  *
  * @param[in]  aContext  A pointer to arbitrary context information.
@@ -69,20 +59,17 @@ typedef struct
 typedef void (*otPlatUsecAlarmHandler)(void *aContext);
 
 /**
- * Set the alarm to fire at @p aDt milliseconds and microseconds after @p aT0.
+ * Set the alarm to fire at @p aDt microseconds after @p aT0.
  *
  * @param[in]  aInstance  The OpenThread instance structure.
  * @param[in]  aT0        The reference time.
- * @param[in]  aDt        The time delay in milliseconds and microseconds from @p aT0.
+ * @param[in]  aDt        The time delay in microseconds from @p aT0.
  * @param[in]  aHandler   A pointer to a function that is called when the timer expires.
  * @param[in]  aContext   A pointer to arbitrary context information.
  *
  */
-void otPlatUsecAlarmStartAt(otInstance *aInstance,
-                            const otPlatUsecAlarmTime *aT0,
-                            const otPlatUsecAlarmTime *aDt,
-                            otPlatUsecAlarmHandler aHandler,
-                            void *aContext);
+void otPlatUsecAlarmStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt,
+                            otPlatUsecAlarmHandler aHandler, void *aContext);
 
 /**
  * Stop the alarm.
@@ -95,10 +82,10 @@ void otPlatUsecAlarmStop(otInstance *aInstance);
 /**
  * Get the current time.
  *
- * @param[out]  aNow  The current time in milliseconds and microseconds.
+ * @param[out]  aNow  The current time in microseconds.
  *
  */
-void otPlatUsecAlarmGetNow(otPlatUsecAlarmTime *aNow);
+uint32_t otPlatUsecAlarmGetNow(void);
 
 /**
  * @}

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -556,22 +556,14 @@ void LinkRaw::StartCsmaBackoff(void)
     backoff = (otPlatRandomGet() % (1UL << backoffExponent));
     backoff *= (static_cast<uint32_t>(Mac::kUnitBackoffPeriod) * OT_RADIO_SYMBOL_TIME);
 
-#if OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_BACKOFF_TIMER
-    otPlatUsecAlarmTime now;
-    otPlatUsecAlarmTime delay;
-
-    otPlatUsecAlarmGetNow(&now);
-    delay.mMs = backoff / 1000UL;
-    delay.mUs = backoff - (delay.mMs * 1000UL);
-
     otLogDebgPlat(aInstance, "LinkRaw Starting RetransmitTimeout Timer (%d ms)", backoff);
     mTimerReason = kTimerReasonRetransmitTimeout;
-    otPlatUsecAlarmStartAt(&mInstance, &now, &delay, &HandleTimer, this);
+
+#if OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_BACKOFF_TIMER
+    otPlatUsecAlarmStartAt(&mInstance, otPlatUsecAlarmGetNow(), backoff, &HandleTimer, this);
 #else // OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_BACKOFF_TIMER
-    mTimerReason = kTimerReasonRetransmitTimeout;
     mTimer.Start(backoff / 1000UL);
 #endif // OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_BACKOFF_TIMER
-
 }
 
 #endif // OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -99,14 +99,7 @@ void Mac::StartCsmaBackoff(void)
         backoff *= (static_cast<uint32_t>(kUnitBackoffPeriod) * OT_RADIO_SYMBOL_TIME);
 
 #if OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_BACKOFF_TIMER
-        otPlatUsecAlarmTime now;
-        otPlatUsecAlarmTime delay;
-
-        otPlatUsecAlarmGetNow(&now);
-        delay.mMs = backoff / 1000UL;
-        delay.mUs = backoff - (delay.mMs * 1000UL);
-
-        otPlatUsecAlarmStartAt(GetInstance(), &now, &delay, &Mac::HandleBeginTransmit, this);
+        otPlatUsecAlarmStartAt(GetInstance(), otPlatUsecAlarmGetNow(), backoff, &Mac::HandleBeginTransmit, this);
 #else // OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_BACKOFF_TIMER
         mBackoffTimer.Start(backoff / 1000UL);
 #endif // OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_BACKOFF_TIMER


### PR DESCRIPTION
To move forward #1945, this PR:

- Update the usec-alarm API to use single 32-bit microsecond
- Update nRf52840's alarm implementation to support the new usec-alarm API
- So both milliseconds timer and microsecond timer will maintain 32-bit time