### PR TITLE
[spinel] Remove `#include <openthread/config.h> from `spinel.c`

### DIFF
--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -43,9 +43,6 @@
 // MARK: -
 // MARK: Headers
 
-
-#include <openthread/config.h>
-
 #include "spinel.h"
 
 #include <assert.h>


### PR DESCRIPTION
The `<openthread/config.h>` header file is already included from OpenThread specific platform header file `spinel_platform.h`.

Removing it to keep `spinel.h` portable.