### PR TITLE
[Timer] Let Timer could use different Timer Schedulers

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -243,7 +243,7 @@ Interpreter::Interpreter(otInstance *aInstance):
     mLength(8),
     mCount(1),
     mInterval(1000),
-    mPingTimer(aInstance->mIp6.mTimerScheduler, &Interpreter::s_HandlePingTimer, this),
+    mPingTimer(&Interpreter::s_HandlePingTimer, this),
 #if OPENTHREAD_ENABLE_DNS_CLIENT
     mResolvingInProgress(0),
 #endif
@@ -1607,7 +1607,7 @@ void Interpreter::HandleIcmpReceive(Message &aMessage, const Ip6::MessageInfo &a
     if (aMessage.Read(aMessage.GetOffset(), sizeof(uint32_t), &timestamp) >=
         static_cast<int>(sizeof(uint32_t)))
     {
-        mServer->OutputFormat(" time=%dms", Timer::GetNow() - HostSwap32(timestamp));
+        mServer->OutputFormat(" time=%dms", TimerScheduler::GetNow() - HostSwap32(timestamp));
     }
 
     mServer->OutputFormat("\r\n");
@@ -1632,7 +1632,7 @@ void Interpreter::ProcessPing(int argc, char *argv[])
         }
         else
         {
-            mPingTimer.Stop();
+            mPingTimer.Stop(mInstance->mIp6.mMsecTimerScheduler);
         }
 
         ExitNow();
@@ -1690,7 +1690,7 @@ void Interpreter::s_HandlePingTimer(Timer &aTimer)
 void Interpreter::HandlePingTimer()
 {
     otError error = OT_ERROR_NONE;
-    uint32_t timestamp = HostSwap32(Timer::GetNow());
+    uint32_t timestamp = HostSwap32(TimerScheduler::GetNow());
 
     otMessage *message;
     const otMessageInfo *messageInfo = static_cast<const otMessageInfo *>(&mMessageInfo);
@@ -1711,7 +1711,7 @@ exit:
 
     if (mCount)
     {
-        mPingTimer.Start(mInterval);
+        mPingTimer.Start(mInstance->mIp6.mMsecTimerScheduler, mInterval);
     }
 }
 #endif

--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -64,11 +64,6 @@ ot::MeshForwarder &otGetMeshForwarder(void)
     return sInstance->mThreadNetif.GetMeshForwarder();
 }
 
-ot::TimerScheduler &otGetTimerScheduler(void)
-{
-    return sInstance->mIp6.mTimerScheduler;
-}
-
 ot::TaskletScheduler &otGetTaskletScheduler(void)
 {
     return sInstance->mIp6.mTaskletScheduler;

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -317,7 +317,8 @@ otError otThreadGetParentInfo(otInstance *aInstance, otRouterInfo *aParentInfo)
     aParentInfo->mPathCost        = parent->GetCost();
     aParentInfo->mLinkQualityIn   = parent->GetLinkInfo().GetLinkQuality(aInstance->mThreadNetif.GetMac().GetNoiseFloor());
     aParentInfo->mLinkQualityOut  = parent->GetLinkQualityOut();
-    aParentInfo->mAge             = static_cast<uint8_t>(Timer::MsecToSec(Timer::GetNow() - parent->GetLastHeard()));
+    aParentInfo->mAge             = static_cast<uint8_t>(Timer::MsecToSec(TimerScheduler::GetNow() -
+                                                                          parent->GetLastHeard()));
     aParentInfo->mAllocated       = parent->IsAllocated();
     aParentInfo->mLinkEstablished = parent->GetState() == Neighbor::kStateValid;
 

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -253,7 +253,7 @@ public:
      *
      */
     EnqueuedResponseHeader(const Ip6::MessageInfo &aMessageInfo):
-        mDequeueTime(Timer::GetNow() + Timer::SecToMsec(kExchangeLifetime)),
+        mDequeueTime(TimerScheduler::GetNow() + Timer::SecToMsec(kExchangeLifetime)),
         mMessageInfo(aMessageInfo) {}
 
     /**
@@ -324,7 +324,7 @@ private:
  * This class caches CoAP responses to implement message deduplication.
  *
  */
-class ResponsesQueue
+class ResponsesQueue: public ThreadNetifLocator
 {
 public:
     /**

--- a/src/core/common/locator.cpp
+++ b/src/core/common/locator.cpp
@@ -54,11 +54,6 @@ otInstance *MeshForwarderLocator::GetInstance(void) const
     return otInstanceFromThreadNetif(&GetMeshForwarder().GetNetif());
 }
 
-otInstance *TimerSchedulerLocator::GetInstance(void) const
-{
-    return otInstanceFromIp6(Ip6::Ip6FromTimerScheduler(&GetTimerScheduler()));
-}
-
 otInstance *TaskletSchedulerLocator::GetInstance(void) const
 {
     return otInstanceFromIp6(Ip6::Ip6FromTaskletScheduler(&GetTaskletScheduler()));

--- a/src/core/common/locator.hpp
+++ b/src/core/common/locator.hpp
@@ -46,7 +46,7 @@ namespace ot {
 class ThreadNetif;
 class MeshForwarder;
 class TaskletScheduler;
-class TimerScheduler;
+class MsecTimerScheduler;
 namespace Ip6 { class Ip6; }
 
 /**
@@ -166,47 +166,6 @@ protected:
      *
      */
     MeshForwarderLocator(MeshForwarder &aMeshForwarder): Locator(aMeshForwarder) { }
-};
-
-/**
- * This class implements a locator for TimerScheduler object.
- *
- */
-class TimerSchedulerLocator: private Locator<TimerScheduler>
-{
-public:
-    /**
-     * This method returns a reference to the TimerScheduler.
-     *
-     * @returns   A reference to the TimerScheduler.
-     *
-     */
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    TimerScheduler &GetTimerScheduler(void) const { return mLocatorObject; }
-#else
-    TimerScheduler &GetTimerScheduler(void) const { return otGetTimerScheduler(); }
-#endif
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure, or NULL if the instance has been finalized.
-     *
-     */
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    otInstance *GetInstance(void) const;
-#else
-    otInstance *GetInstance(void) const { return otGetInstance(); }
-#endif
-
-protected:
-    /**
-     * This constructor initializes the object.
-     *
-     * @param[in]  aTimerScheduler  A reference to the TimerScheduler.
-     *
-     */
-    TimerSchedulerLocator(TimerScheduler &aTimerScheduler): Locator(aTimerScheduler) { }
 };
 
 /**

--- a/src/core/common/trickle_timer.hpp
+++ b/src/core/common/trickle_timer.hpp
@@ -53,7 +53,7 @@ namespace ot {
  * This class implements a trickle timer.
  *
  */
-class TrickleTimer: public Timer
+class TrickleTimer: public ThreadNetifLocator, public Timer
 {
 public:
 
@@ -80,14 +80,14 @@ public:
     /**
      * This constructor creates a trickle timer instance.
      *
-     * @param[in]  aScheduler               A reference to the timer scheduler.
+     * @param[in]  aThreadNetif             A reference to the Thread network interface.
      * @param[in]  aRedundancyConstant      The redundancy constant for the timer, k.
      * @param[in]  aTransmitHandler         A pointer to a function that is called when transmission should occur.
      * @param[in]  aIntervalExpiredHandler  An optional pointer to a function that is called when the interval expires.
      * @param[in]  aContext                 A pointer to arbitrary context information.
      *
      */
-    TrickleTimer(TimerScheduler &aScheduler,
+    TrickleTimer(ThreadNetif &aThreadNetif,
 #ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
                  uint32_t aRedundancyConstant,
 #endif

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -57,7 +57,7 @@ Dtls::Dtls(ThreadNetif &aNetif):
     ThreadNetifLocator(aNetif),
     mPskLength(0),
     mStarted(false),
-    mTimer(aNetif.GetIp6().mTimerScheduler, &Dtls::HandleTimer, this),
+    mTimer(&Dtls::HandleTimer, this),
     mTimerIntermediate(0),
     mTimerSet(false),
     mReceiveMessage(NULL),
@@ -311,7 +311,7 @@ int Dtls::HandleMbedtlsGetTimer(void)
     {
         rval = 2;
     }
-    else if (static_cast<int32_t>(mTimerIntermediate - Timer::GetNow()) <= 0)
+    else if (static_cast<int32_t>(mTimerIntermediate - TimerScheduler::GetNow()) <= 0)
     {
         rval = 1;
     }
@@ -335,13 +335,13 @@ void Dtls::HandleMbedtlsSetTimer(uint32_t aIntermediate, uint32_t aFinish)
     if (aFinish == 0)
     {
         mTimerSet = false;
-        mTimer.Stop();
+        mTimer.Stop(GetNetif().GetIp6().mMsecTimerScheduler);
     }
     else
     {
         mTimerSet = true;
-        mTimer.Start(aFinish);
-        mTimerIntermediate = Timer::GetNow() + aIntermediate;
+        mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, aFinish);
+        mTimerIntermediate = TimerScheduler::GetNow() + aIntermediate;
     }
 }
 

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -74,7 +74,7 @@ Joiner::Joiner(ThreadNetif &aNetif):
     mVendorModel(NULL),
     mVendorSwVersion(NULL),
     mVendorData(NULL),
-    mTimer(aNetif.GetIp6().mTimerScheduler, &Joiner::HandleTimer, this),
+    mTimer(&Joiner::HandleTimer, this),
     mJoinerEntrust(OT_URI_PATH_JOINER_ENTRUST, &Joiner::HandleJoinerEntrust, this)
 {
     aNetif.GetCoap().AddResource(mJoinerEntrust);
@@ -251,7 +251,7 @@ void Joiner::HandleSecureCoapClientConnect(bool aConnected)
         {
             mState = kStateConnected;
             SendJoinerFinalize();
-            mTimer.Start(kTimeout);
+            mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, kTimeout);
         }
         else
         {
@@ -369,7 +369,7 @@ void Joiner::HandleJoinerFinalizeResponse(Coap::Header *aHeader, Message *aMessa
     VerifyOrExit(state.IsValid());
 
     mState = kStateEntrust;
-    mTimer.Start(kTimeout);
+    mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, kTimeout);
 
     otLogInfoMeshCoP(GetInstance(), "received joiner finalize response %d", static_cast<uint8_t>(state.GetState()));
 #if OPENTHREAD_ENABLE_CERT_LOG
@@ -443,7 +443,7 @@ void Joiner::HandleJoinerEntrust(Coap::Header &aHeader, Message &aMessage, const
     SendJoinerEntrustResponse(aHeader, aMessageInfo);
 
     // Delay extended address configuration to allow DTLS wrap up.
-    mTimer.Start(kConfigExtAddressDelay);
+    mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, kConfigExtAddressDelay);
 
 exit:
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -61,7 +61,7 @@ JoinerRouter::JoinerRouter(ThreadNetif &aNetif):
     ThreadNetifLocator(aNetif),
     mSocket(aNetif.GetIp6().mUdp),
     mRelayTransmit(OT_URI_PATH_RELAY_TX, &JoinerRouter::HandleRelayTransmit, this),
-    mTimer(aNetif.GetIp6().mTimerScheduler, &JoinerRouter::HandleTimer, this),
+    mTimer(&JoinerRouter::HandleTimer, this),
     mJoinerUdpPort(0),
     mIsJoinerPortConfigured(false),
     mExpectJoinEntRsp(false)
@@ -407,13 +407,13 @@ otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessage
     messageInfo = aMessageInfo;
     messageInfo.SetPeerPort(kCoapUdpPort);
 
-    delayedMessage = DelayedJoinEntHeader(Timer::GetNow() + kDelayJoinEnt, messageInfo, aKek.GetKek());
+    delayedMessage = DelayedJoinEntHeader(TimerScheduler::GetNow() + kDelayJoinEnt, messageInfo, aKek.GetKek());
     SuccessOrExit(delayedMessage.AppendTo(*message));
     mDelayedJoinEnts.Enqueue(*message);
 
     if (!mTimer.IsRunning())
     {
-        mTimer.Start(kDelayJoinEnt);
+        mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, kDelayJoinEnt);
     }
 
 exit:
@@ -442,7 +442,7 @@ void JoinerRouter::SendDelayedJoinerEntrust(void)
     ThreadNetif &netif = GetNetif();
     DelayedJoinEntHeader delayedJoinEnt;
     Message *message = mDelayedJoinEnts.GetHead();
-    uint32_t now = Timer::GetNow();
+    uint32_t now = TimerScheduler::GetNow();
     Ip6::MessageInfo messageInfo;
 
     VerifyOrExit(message != NULL);
@@ -457,7 +457,7 @@ void JoinerRouter::SendDelayedJoinerEntrust(void)
 
     if (delayedJoinEnt.IsLater(now))
     {
-        mTimer.Start(delayedJoinEnt.GetSendTime() - now);
+        mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, delayedJoinEnt.GetSendTime() - now);
     }
     else
     {
@@ -475,7 +475,7 @@ void JoinerRouter::SendDelayedJoinerEntrust(void)
         if (SendJoinerEntrust(*message, messageInfo) != OT_ERROR_NONE)
         {
             message->Free();
-            mTimer.Start(0);
+            mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, 0);
         }
     }
 

--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -60,7 +60,7 @@ Leader::Leader(ThreadNetif &aThreadNetif):
     ThreadNetifLocator(aThreadNetif),
     mPetition(OT_URI_PATH_LEADER_PETITION, Leader::HandlePetition, this),
     mKeepAlive(OT_URI_PATH_LEADER_KEEP_ALIVE, Leader::HandleKeepAlive, this),
-    mTimer(aThreadNetif.GetIp6().mTimerScheduler, HandleTimer, this),
+    mTimer(HandleTimer, this),
     mDelayTimerMinimal(DelayTimerTlv::kDelayTimerMinimal),
     mSessionId(0xffff)
 {
@@ -111,7 +111,7 @@ void Leader::HandlePetition(Coap::Header &aHeader, Message &aMessage, const Ip6:
     mCommissionerId = commissionerId;
 
     state = StateTlv::kAccept;
-    mTimer.Start(Timer::SecToMsec(kTimeoutLeaderPetition));
+    mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, Timer::SecToMsec(kTimeoutLeaderPetition));
 
 exit:
     OT_UNUSED_VARIABLE(aMessageInfo);
@@ -198,7 +198,7 @@ void Leader::HandleKeepAlive(Coap::Header &aHeader, Message &aMessage, const Ip6
     else
     {
         responseState = StateTlv::kAccept;
-        mTimer.Start(Timer::SecToMsec(kTimeoutLeaderPetition));
+        mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, Timer::SecToMsec(kTimeoutLeaderPetition));
     }
 
     SendKeepAliveResponse(aHeader, aMessageInfo, responseState);
@@ -314,7 +314,7 @@ void Leader::SetEmptyCommissionerData(void)
 
 void Leader::ResignCommissioner(void)
 {
-    mTimer.Stop();
+    mTimer.Stop(GetNetif().GetIp6().mMsecTimerScheduler);
     SetEmptyCommissionerData();
 
     otLogInfoMeshCoP(GetInstance(), "commissioner inactive");

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -59,7 +59,7 @@ namespace Dhcp6 {
 
 Dhcp6Client::Dhcp6Client(ThreadNetif &aThreadNetif) :
     ThreadNetifLocator(aThreadNetif),
-    mTrickleTimer(aThreadNetif.GetIp6().mTimerScheduler, &Dhcp6Client::HandleTrickleTimer, NULL, this),
+    mTrickleTimer(aThreadNetif, &Dhcp6Client::HandleTrickleTimer, NULL, this),
     mSocket(aThreadNetif.GetIp6().mUdp),
     mStartTime(0),
     mAddresses(NULL),
@@ -345,7 +345,7 @@ bool Dhcp6Client::HandleTrickleTimer(void)
     switch (mIdentityAssociationHead->GetStatus())
     {
     case IdentityAssociation::kStatusSolicit:
-        mStartTime = otPlatAlarmGetNow();
+        mStartTime = TimerScheduler::GetNow();
         mIdentityAssociationHead->SetStatus(IdentityAssociation::kStatusSoliciting);
 
     // fall through
@@ -427,7 +427,7 @@ otError Dhcp6Client::AppendElapsedTime(Message &aMessage)
     ElapsedTime option;
 
     option.Init();
-    option.SetElapsedTime(static_cast<uint16_t>(Timer::MsecToSec(otPlatAlarmGetNow() - mStartTime)));
+    option.SetElapsedTime(static_cast<uint16_t>(Timer::MsecToSec(TimerScheduler::GetNow() - mStartTime)));
     return aMessage.Append(&option, sizeof(option));
 }
 

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -32,6 +32,7 @@
 #include <openthread/dns.h>
 #include <openthread/types.h>
 
+#include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/timer.hpp"
 #include "net/dns_headers.hpp"
@@ -147,7 +148,7 @@ private:
  * This class implements DNS client.
  *
  */
-class Client
+class Client: public ThreadNetifLocator
 {
 public:
     /**
@@ -156,11 +157,7 @@ public:
      * @param[in]  aNetif    A reference to the network interface that DNS client should be assigned to.
      *
      */
-    Client(Ip6::Netif &aNetif):
-        mSocket(aNetif.GetIp6().mUdp),
-        mMessageId(0),
-        mRetransmissionTimer(aNetif.GetIp6().mTimerScheduler, &Client::HandleRetransmissionTimer, this) {
-    };
+    explicit Client(ThreadNetif &aNetif);
 
     /**
      * This method starts the DNS client.

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -374,7 +374,7 @@ public:
 
     MessagePool mMessagePool;
     TaskletScheduler mTaskletScheduler;
-    TimerScheduler mTimerScheduler;
+    TimerScheduler mMsecTimerScheduler;
 
 private:
     static void HandleSendQueue(Tasklet &aTasklet);
@@ -414,7 +414,7 @@ static inline Ip6 *Ip6FromTaskletScheduler(TaskletScheduler *aTaskletScheduler)
 
 static inline Ip6 *Ip6FromTimerScheduler(TimerScheduler *aTimerScheduler)
 {
-    return (Ip6 *)CONTAINING_RECORD(aTimerScheduler, Ip6, mTimerScheduler);
+    return (Ip6 *)CONTAINING_RECORD(aTimerScheduler, Ip6, mMsecTimerScheduler);
 }
 
 /**

--- a/src/core/openthread-single-instance.h
+++ b/src/core/openthread-single-instance.h
@@ -48,7 +48,7 @@ namespace ot {
 
 class ThreadNetif;
 class MeshForwarder;
-class TimerScheduler;
+class MsecTimerScheduler;
 class TaskletScheduler;
 namespace Ip6 { class Ip6; }
 
@@ -78,14 +78,6 @@ ot::ThreadNetif &otGetThreadNetif(void);
  *
  */
 ot::MeshForwarder &otGetMeshForwarder(void);
-
-/**
- * This function returns a reference to the single TimerScheduler instance.
- *
- * @returns A reference to the TimerScheduler instance.
- *
- */
-ot::TimerScheduler &otGetTimerScheduler(void);
 
 /**
  * This function returns a reference to the single TaskletShceduler instance.

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -64,7 +64,7 @@ AddressResolver::AddressResolver(ThreadNetif &aThreadNetif) :
     mAddressQuery(OT_URI_PATH_ADDRESS_QUERY, &AddressResolver::HandleAddressQuery, this),
     mAddressNotification(OT_URI_PATH_ADDRESS_NOTIFY, &AddressResolver::HandleAddressNotification, this),
     mIcmpHandler(&AddressResolver::HandleIcmpReceive, this),
-    mTimer(aThreadNetif.GetIp6().mTimerScheduler, &AddressResolver::HandleTimer, this)
+    mTimer(&AddressResolver::HandleTimer, this)
 {
     Clear();
 
@@ -260,7 +260,7 @@ exit:
 
     if (mTimer.IsRunning() == false)
     {
-        mTimer.Start(kStateUpdatePeriod);
+        mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, kStateUpdatePeriod);
     }
 
     if (error != OT_ERROR_NONE && message != NULL)
@@ -557,7 +557,7 @@ void AddressResolver::HandleAddressQuery(Coap::Header &aHeader, Message &aMessag
             }
 
             mlIidTlv.SetIid(children[i].GetExtAddress());
-            lastTransactionTimeTlv.SetTime(Timer::GetNow() - children[i].GetLastHeard());
+            lastTransactionTimeTlv.SetTime(TimerScheduler::GetNow() - children[i].GetLastHeard());
             SendAddressQueryResponse(targetTlv, mlIidTlv, &lastTransactionTimeTlv, aMessageInfo.GetPeerAddr());
             ExitNow();
         }
@@ -660,7 +660,7 @@ void AddressResolver::HandleTimer()
 
     if (continueTimer)
     {
-        mTimer.Start(kStateUpdatePeriod);
+        mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, kStateUpdatePeriod);
     }
 }
 

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -58,7 +58,7 @@ AnnounceBeginServer::AnnounceBeginServer(ThreadNetif &aThreadNetif) :
     mPeriod(0),
     mCount(0),
     mChannel(0),
-    mTimer(aThreadNetif.GetIp6().mTimerScheduler, &AnnounceBeginServer::HandleTimer, this),
+    mTimer(&AnnounceBeginServer::HandleTimer, this),
     mAnnounceBegin(OT_URI_PATH_ANNOUNCE_BEGIN, &AnnounceBeginServer::HandleRequest, this)
 {
     aThreadNetif.GetCoap().AddResource(mAnnounceBegin);
@@ -84,7 +84,7 @@ otError AnnounceBeginServer::SendAnnounce(uint32_t aChannelMask, uint8_t aCount,
         VerifyOrExit(mChannel <= OT_RADIO_CHANNEL_MAX, error = OT_ERROR_INVALID_ARGS);
     }
 
-    mTimer.Start(mPeriod);
+    mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, mPeriod);
 
 exit:
     return error;
@@ -140,7 +140,7 @@ void AnnounceBeginServer::HandleTimer(void)
     {
         if (mChannelMask & (1 << mChannel))
         {
-            mTimer.Start(mPeriod);
+            mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, mPeriod);
             break;
         }
 

--- a/src/core/thread/data_poll_manager.cpp
+++ b/src/core/thread/data_poll_manager.cpp
@@ -51,7 +51,7 @@ namespace ot {
 
 DataPollManager::DataPollManager(MeshForwarder &aMeshForwarder):
     MeshForwarderLocator(aMeshForwarder),
-    mTimer(aMeshForwarder.GetNetif().GetIp6().mTimerScheduler, &DataPollManager::HandlePollTimer, this),
+    mTimer(&DataPollManager::HandlePollTimer, this),
     mTimerStartTime(0),
     mExternalPollPeriod(0),
     mPollPeriod(0),
@@ -82,7 +82,7 @@ exit:
 
 void DataPollManager::StopPolling(void)
 {
-    mTimer.Stop();
+    mTimer.Stop(GetMeshForwarder().GetNetif().GetIp6().mMsecTimerScheduler);
     mAttachMode = false;
     mRetxMode = false;
     mNoBufferRetxMode = false;
@@ -101,7 +101,7 @@ otError DataPollManager::SendDataPoll(void)
     VerifyOrExit(mEnabled, error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(!meshForwarder.GetNetif().GetMac().GetRxOnWhenIdle(), error = OT_ERROR_INVALID_STATE);
 
-    mTimer.Stop();
+    mTimer.Stop(GetMeshForwarder().GetNetif().GetIp6().mMsecTimerScheduler);
 
     for (message = meshForwarder.GetSendQueue().GetHead(); message; message = message->GetNext())
     {
@@ -325,12 +325,12 @@ void DataPollManager::ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector)
 
     if (mTimer.IsRunning())
     {
-        mTimer.StartAt(mTimerStartTime, mPollPeriod);
+        mTimer.StartAt(GetMeshForwarder().GetNetif().GetIp6().mMsecTimerScheduler, mTimerStartTime, mPollPeriod);
     }
     else
     {
-        mTimerStartTime = Timer::GetNow();
-        mTimer.StartAt(mTimerStartTime, mPollPeriod);
+        mTimerStartTime = TimerScheduler::GetNow();
+        mTimer.StartAt(GetMeshForwarder().GetNetif().GetIp6().mMsecTimerScheduler, mTimerStartTime, mPollPeriod);
     }
 }
 

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -59,7 +59,7 @@ EnergyScanServer::EnergyScanServer(ThreadNetif &aThreadNetif) :
     mCount(0),
     mActive(false),
     mScanResultsLength(0),
-    mTimer(aThreadNetif.GetIp6().mTimerScheduler, &EnergyScanServer::HandleTimer, this),
+    mTimer(&EnergyScanServer::HandleTimer, this),
     mEnergyScan(OT_URI_PATH_ENERGY_SCAN, &EnergyScanServer::HandleRequest, this)
 {
     mNetifCallback.Set(&EnergyScanServer::HandleNetifStateChanged, this);
@@ -105,7 +105,7 @@ void EnergyScanServer::HandleRequest(Coap::Header &aHeader, Message &aMessage, c
     mScanDuration = scanDuration.GetScanDuration();
     mScanResultsLength = 0;
     mActive = true;
-    mTimer.Start(kScanDelay);
+    mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, kScanDelay);
 
     mCommissioner = aMessageInfo.GetPeerAddr();
 
@@ -169,11 +169,11 @@ void EnergyScanServer::HandleScanResult(otEnergyScanResult *aResult)
 
         if (mCount)
         {
-            mTimer.Start(mPeriod);
+            mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, mPeriod);
         }
         else
         {
-            mTimer.Start(kReportDelay);
+            mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, kReportDelay);
         }
     }
 
@@ -238,7 +238,7 @@ void EnergyScanServer::HandleNetifStateChanged(uint32_t aFlags)
         GetNetif().GetNetworkDataLeader().GetCommissioningData() == NULL)
     {
         mActive = false;
-        mTimer.Stop();
+        mTimer.Stop(GetNetif().GetIp6().mMsecTimerScheduler);
     }
 }
 

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -61,7 +61,7 @@ KeyManager::KeyManager(ThreadNetif &aThreadNetif):
     mKeyRotationTime(kDefaultKeyRotationTime),
     mKeySwitchGuardTime(kDefaultKeySwitchGuardTime),
     mKeySwitchGuardEnabled(false),
-    mKeyRotationTimer(aThreadNetif.GetIp6().mTimerScheduler, &KeyManager::HandleKeyRotationTimer, this),
+    mKeyRotationTimer(&KeyManager::HandleKeyRotationTimer, this),
     mKekFrameCounter(0),
     mSecurityPolicyFlags(0xff)
 {
@@ -75,7 +75,7 @@ void KeyManager::Start(void)
 
 void KeyManager::Stop(void)
 {
-    mKeyRotationTimer.Stop();
+    mKeyRotationTimer.Stop(GetNetif().GetIp6().mMsecTimerScheduler);
 }
 
 #if OPENTHREAD_FTD
@@ -246,7 +246,7 @@ exit:
 void KeyManager::StartKeyRotationTimer(void)
 {
     mHoursSinceKeyRotation = 0;
-    mKeyRotationTimer.Start(kOneHourIntervalInMsec);
+    mKeyRotationTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, kOneHourIntervalInMsec);
 }
 
 void KeyManager::HandleKeyRotationTimer(Timer &aTimer)
@@ -265,7 +265,8 @@ void KeyManager::HandleKeyRotationTimer(void)
     // rotation timer (and the `mHoursSinceKeyRotation`) if it updates the key
     // sequence.
 
-    mKeyRotationTimer.StartAt(mKeyRotationTimer.GetFireTime(), kOneHourIntervalInMsec);
+    mKeyRotationTimer.StartAt(GetNetif().GetIp6().mMsecTimerScheduler, mKeyRotationTimer.GetFireTime(),
+                              kOneHourIntervalInMsec);
 
     if (mHoursSinceKeyRotation >= mKeyRotationTime)
     {

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -608,7 +608,8 @@ otError NetworkData::SendServerDataNotification(uint16_t aRloc16)
     Message *message = NULL;
     Ip6::MessageInfo messageInfo;
 
-    VerifyOrExit(!mLastAttemptWait || static_cast<int32_t>(Timer::GetNow() - mLastAttempt) < kDataResubmitDelay,
+    VerifyOrExit(!mLastAttemptWait ||
+                 static_cast<int32_t>(TimerScheduler::GetNow() - mLastAttempt) < kDataResubmitDelay,
                  error = OT_ERROR_ALREADY);
 
     header.Init(OT_COAP_TYPE_CONFIRMABLE, OT_COAP_CODE_POST);
@@ -642,7 +643,7 @@ otError NetworkData::SendServerDataNotification(uint16_t aRloc16)
 
     if (mLocal)
     {
-        mLastAttempt = Timer::GetNow();
+        mLastAttempt = TimerScheduler::GetNow();
         mLastAttemptWait = true;
     }
 

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -63,7 +63,7 @@ namespace NetworkData {
 
 Leader::Leader(ThreadNetif &aThreadNetif):
     LeaderBase(aThreadNetif),
-    mTimer(aThreadNetif.GetIp6().mTimerScheduler, &Leader::HandleTimer, this),
+    mTimer(&Leader::HandleTimer, this),
     mServerData(OT_URI_PATH_SERVER_DATA, &Leader::HandleServerData, this),
     mCommissioningDataGet(OT_URI_PATH_COMMISSIONER_GET, &Leader::HandleCommissioningGet, this),
     mCommissioningDataSet(OT_URI_PATH_COMMISSIONER_SET, &Leader::HandleCommissioningSet, this)
@@ -897,14 +897,14 @@ otError Leader::RemoveRloc(PrefixTlv &prefix, uint16_t aRloc16)
         if (prefix.GetSubTlvsLength() == sizeof(ContextTlv))
         {
             context->ClearCompress();
-            mContextLastUsed[context->GetContextId() - kMinContextId] = Timer::GetNow();
+            mContextLastUsed[context->GetContextId() - kMinContextId] = TimerScheduler::GetNow();
 
             if (mContextLastUsed[context->GetContextId() - kMinContextId] == 0)
             {
                 mContextLastUsed[context->GetContextId() - kMinContextId] = 1;
             }
 
-            mTimer.Start(kStateUpdatePeriod);
+            mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, kStateUpdatePeriod);
         }
         else
         {
@@ -1066,7 +1066,7 @@ void Leader::HandleTimer(void)
             continue;
         }
 
-        if ((Timer::GetNow() - mContextLastUsed[i]) >= Timer::SecToMsec(mContextIdReuseDelay))
+        if ((TimerScheduler::GetNow() - mContextLastUsed[i]) >= Timer::SecToMsec(mContextIdReuseDelay))
         {
             FreeContext(kMinContextId + i);
         }
@@ -1078,7 +1078,7 @@ void Leader::HandleTimer(void)
 
     if (contextsWaiting)
     {
-        mTimer.Start(kStateUpdatePeriod);
+        mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, kStateUpdatePeriod);
     }
 }
 

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -55,7 +55,7 @@ PanIdQueryServer::PanIdQueryServer(ThreadNetif &aThreadNetif) :
     ThreadNetifLocator(aThreadNetif),
     mChannelMask(0),
     mPanId(Mac::kPanIdBroadcast),
-    mTimer(aThreadNetif.GetIp6().mTimerScheduler, &PanIdQueryServer::HandleTimer, this),
+    mTimer(&PanIdQueryServer::HandleTimer, this),
     mPanIdQuery(OT_URI_PATH_PANID_QUERY, &PanIdQueryServer::HandleQuery, this)
 {
     aThreadNetif.GetCoap().AddResource(mPanIdQuery);
@@ -86,7 +86,7 @@ void PanIdQueryServer::HandleQuery(Coap::Header &aHeader, Message &aMessage, con
     mChannelMask = channelMask.GetMask();
     mCommissioner = aMessageInfo.GetPeerAddr();
     mPanId = panId.GetPanId();
-    mTimer.Start(kScanDelay);
+    mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, kScanDelay);
 
     if (aHeader.IsConfirmable() && !aMessageInfo.GetSockAddr().IsMulticast())
     {

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -52,7 +52,7 @@ namespace Utils {
 
 ChildSupervisor::ChildSupervisor(ThreadNetif &aThreadNetif) :
     ThreadNetifLocator(aThreadNetif),
-    mTimer(aThreadNetif.GetIp6().mTimerScheduler, &ChildSupervisor::HandleTimer, this),
+    mTimer(&ChildSupervisor::HandleTimer, this),
     mSupervisionInterval(kDefaultSupervisionInterval)
 {
 }
@@ -61,7 +61,7 @@ void ChildSupervisor::Start(void)
 {
     VerifyOrExit(mSupervisionInterval != 0);
     VerifyOrExit(!mTimer.IsRunning());
-    mTimer.Start(kOneSecond);
+    mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, kOneSecond);
 
 exit:
     return;
@@ -69,7 +69,7 @@ exit:
 
 void ChildSupervisor::Stop(void)
 {
-    mTimer.Stop();
+    mTimer.Stop(GetNetif().GetIp6().mMsecTimerScheduler);
 }
 
 void ChildSupervisor::SetSupervisionInterval(uint16_t aInterval)
@@ -160,7 +160,7 @@ void ChildSupervisor::HandleTimer(void)
         }
     }
 
-    mTimer.Start(kOneSecond);
+    mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, kOneSecond);
 
 exit:
     return;
@@ -181,7 +181,7 @@ ChildSupervisor &ChildSupervisor::GetOwner(const Context &aContext)
 
 SupervisionListener::SupervisionListener(ThreadNetif &aThreadNetif) :
     ThreadNetifLocator(aThreadNetif),
-    mTimer(aThreadNetif.GetIp6().mTimerScheduler, &SupervisionListener::HandleTimer, this),
+    mTimer(&SupervisionListener::HandleTimer, this),
     mTimeout(0)
 {
     SetTimeout(kDefaultTimeout);
@@ -194,7 +194,7 @@ void SupervisionListener::Start(void)
 
 void SupervisionListener::Stop(void)
 {
-    mTimer.Stop();
+    mTimer.Stop(GetNetif().GetIp6().mMsecTimerScheduler);
 }
 
 void SupervisionListener::SetTimeout(uint16_t aTimeout)
@@ -230,11 +230,11 @@ void SupervisionListener::RestartTimer(void)
     if ((mTimeout != 0) && (netif.GetMle().GetRole() == OT_DEVICE_ROLE_CHILD) &&
         (netif.GetMeshForwarder().GetRxOnWhenIdle() == false))
     {
-        mTimer.Start(Timer::SecToMsec(mTimeout));
+        mTimer.Start(GetNetif().GetIp6().mMsecTimerScheduler, Timer::SecToMsec(mTimeout));
     }
     else
     {
-        mTimer.Stop();
+        mTimer.Stop(GetNetif().GetIp6().mMsecTimerScheduler);
     }
 }
 

--- a/tests/unit/test_timer.cpp
+++ b/tests/unit/test_timer.cpp
@@ -85,8 +85,8 @@ void InitCounters(void)
 class TestTimer: public ot::Timer
 {
 public:
-    TestTimer(otInstance *aInstance):
-        ot::Timer(aInstance->mIp6.mTimerScheduler, TestTimer::HandleTimerFired, NULL),
+    TestTimer():
+        ot::Timer(TestTimer::HandleTimerFired, NULL),
         mFiredCounter(0)
     { }
 
@@ -108,14 +108,14 @@ private:
 };
 
 /**
- * Test the TimerScheduler's behavior of one timer started and fired.
+ * Test the MsecTimerScheduler's behavior of one timer started and fired.
  */
 int TestOneTimer(void)
 {
     const uint32_t kTimeT0 = 1000;
     const uint32_t kTimerInterval = 10;
     otInstance *instance = testInitInstance();
-    TestTimer timer(instance);
+    TestTimer timer;
 
     // Test one Timer basic operation.
 
@@ -125,7 +125,7 @@ int TestOneTimer(void)
     printf("TestOneTimer() ");
 
     sNow = kTimeT0;
-    timer.Start(kTimerInterval);
+    timer.Start(instance->mIp6.mMsecTimerScheduler, kTimerInterval);
 
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart]    == 1, "TestOneTimer: Start CallCount Failed.\n");
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop]     == 0, "TestOneTimer: Stop CallCount Failed.\n");
@@ -149,7 +149,7 @@ int TestOneTimer(void)
     InitCounters();
 
     sNow = 0 - (kTimerInterval - 2);
-    timer.Start(kTimerInterval);
+    timer.Start(instance->mIp6.mMsecTimerScheduler, kTimerInterval);
 
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart]    == 1,        "TestOneTimer: Start CallCount Failed.\n");
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop]     == 0,        "TestOneTimer: Stop CallCount Failed.\n");
@@ -173,7 +173,7 @@ int TestOneTimer(void)
     InitCounters();
 
     sNow = kTimeT0;
-    timer.Start(kTimerInterval);
+    timer.Start(instance->mIp6.mMsecTimerScheduler, kTimerInterval);
 
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart]    == 1, "TestOneTimer: Start CallCount Failed.\n");
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop]     == 0, "TestOneTimer: Stop CallCount Failed.\n");
@@ -197,7 +197,7 @@ int TestOneTimer(void)
     InitCounters();
 
     sNow = kTimeT0;
-    timer.Start(kTimerInterval);
+    timer.Start(instance->mIp6.mMsecTimerScheduler, kTimerInterval);
 
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart]    == 1, "TestOneTimer: Start CallCount Failed.\n");
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop]     == 0, "TestOneTimer: Stop CallCount Failed.\n");
@@ -234,15 +234,15 @@ int TestOneTimer(void)
 }
 
 /**
- * Test the TimerScheduler's behavior of two timers started and fired.
+ * Test the MsecTimerScheduler's behavior of two timers started and fired.
  */
 int TestTwoTimers(void)
 {
     const uint32_t kTimeT0 = 1000;
     const uint32_t kTimerInterval = 10;
     otInstance *instance = testInitInstance();
-    TestTimer timer1(instance);
-    TestTimer timer2(instance);
+    TestTimer timer1;
+    TestTimer timer2;
 
     InitTestTimer();
     printf("TestTwoTimers() ");
@@ -252,7 +252,7 @@ int TestTwoTimers(void)
     InitCounters();
 
     sNow = kTimeT0;
-    timer1.Start(kTimerInterval);
+    timer1.Start(instance->mIp6.mMsecTimerScheduler, kTimerInterval);
 
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart]    == 1,   "TestTwoTimers: Start CallCount Failed.\n");
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop]     == 0,   "TestTwoTimers: Stop CallCount Failed.\n");
@@ -264,7 +264,7 @@ int TestTwoTimers(void)
 
     sNow += kTimerInterval;
 
-    timer2.Start(kTimerInterval);
+    timer2.Start(instance->mIp6.mMsecTimerScheduler, kTimerInterval);
 
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart]    == 1,   "TestTwoTimers: Start CallCount Failed.\n");
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop]     == 0,   "TestTwoTimers: Stop CallCount Failed.\n");
@@ -304,7 +304,7 @@ int TestTwoTimers(void)
     timer2.ResetFiredCounter();
 
     sNow = kTimeT0;
-    timer1.Start(kTimerInterval);
+    timer1.Start(instance->mIp6.mMsecTimerScheduler, kTimerInterval);
 
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart]    == 1,   "TestTwoTimers: Start CallCount Failed.\n");
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop]     == 0,   "TestTwoTimers: Stop CallCount Failed.\n");
@@ -316,7 +316,7 @@ int TestTwoTimers(void)
 
     sNow += kTimerInterval;
 
-    timer2.StartAt(kTimeT0, kTimerInterval - 2);  // Timer 2 is even before timer 1
+    timer2.StartAt(instance->mIp6.mMsecTimerScheduler, kTimeT0, kTimerInterval - 2);  // Timer 2 is even before timer 1
 
     VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler]  == 0,   "TestTwoTimers: Handler CallCount Failed.\n");
     VerifyOrQuit(timer1.IsRunning() == true,                      "TestTwoTimers: Timer running Failed.\n");
@@ -351,7 +351,7 @@ int TestTwoTimers(void)
     timer2.ResetFiredCounter();
 
     sNow = kTimeT0;
-    timer1.Start(kTimerInterval);
+    timer1.Start(instance->mIp6.mMsecTimerScheduler, kTimerInterval);
 
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart]    == 1,   "TestTwoTimers: Start CallCount Failed.\n");
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop]     == 0,   "TestTwoTimers: Stop CallCount Failed.\n");
@@ -363,7 +363,7 @@ int TestTwoTimers(void)
 
     sNow += kTimerInterval + 5;
 
-    timer2.Start(ot::Timer::kMaxDt);
+    timer2.Start(instance->mIp6.mMsecTimerScheduler, ot::Timer::kMaxDt);
 
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart]    == 1,   "TestTwoTimers: Start CallCount Failed.\n");
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop]     == 0,   "TestTwoTimers: Stop CallCount Failed.\n");
@@ -403,7 +403,7 @@ int TestTwoTimers(void)
 }
 
 /**
- * Test the TimerScheduler's behavior of ten timers started and fired.
+ * Test the MsecTimerScheduler's behavior of ten timers started and fired.
  *
  * `aTimeShift` is added to the t0 and trigger times for all timers. It can be used to check the ten timer behavior
  * at different start time (e.g., around a 32-bit wrap).
@@ -526,16 +526,16 @@ static void TenTimers(uint32_t aTimeShift)
 
     otInstance *instance = testInitInstance();
 
-    TestTimer timer0(instance);
-    TestTimer timer1(instance);
-    TestTimer timer2(instance);
-    TestTimer timer3(instance);
-    TestTimer timer4(instance);
-    TestTimer timer5(instance);
-    TestTimer timer6(instance);
-    TestTimer timer7(instance);
-    TestTimer timer8(instance);
-    TestTimer timer9(instance);
+    TestTimer timer0;
+    TestTimer timer1;
+    TestTimer timer2;
+    TestTimer timer3;
+    TestTimer timer4;
+    TestTimer timer5;
+    TestTimer timer6;
+    TestTimer timer7;
+    TestTimer timer8;
+    TestTimer timer9;
     TestTimer *timers[kNumTimers] =
     {
         &timer0,
@@ -561,10 +561,10 @@ static void TenTimers(uint32_t aTimeShift)
     for (i = 0; i < kNumTimers ; i++)
     {
         sNow = kTimeT0[i] + aTimeShift;
-        timers[i]->Start(kTimerInterval[i]);
+        timers[i]->Start(instance->mIp6.mMsecTimerScheduler, kTimerInterval[i]);
     }
 
-    // given the order in which timers are started, the TimerScheduler should call otPlatAlarmStartAt 2 times.
+    // given the order in which timers are started, the MsecTimerScheduler should call otPlatAlarmStartAt 2 times.
     // one for timer[0] and one for timer[5] which will supercede timer[0].
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart]    == 2, "TestTenTimer: Start CallCount Failed.\n");
     VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop]     == 0, "TestTenTimer: Stop CallCount Failed.\n");


### PR DESCRIPTION
* Don't bind Timer to TimerSchedulerLocator, and remove TimerSchedulerLocator;

* Specify TimerScheduler when calling Timer::Start() and Timer::Stop();

* Move Timer::GetNow() to TimerScheduler::GetNow();

* Rename current mTimerScheduler to mMsecTimerScheduler.