### PR TITLE
[srv_data] refine the server data registration

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -774,6 +774,10 @@ otError Mle::SetRloc16(uint16_t aRloc16)
         // mesh-local 16
         mMeshLocal16.GetAddress().mFields.m16[7] = HostSwap16(aRloc16);
         netif.AddUnicastAddress(mMeshLocal16);
+
+#if OPENTHREAD_ENABLE_BORDER_ROUTER
+        netif.GetNetworkDataLocal().UpdateNetworkDataRloc();
+#endif
     }
 
     netif.GetMac().SetShortAddress(aRloc16);
@@ -1282,7 +1286,7 @@ void Mle::HandleNetifStateChanged(uint32_t aFlags)
         }
 
 #if OPENTHREAD_ENABLE_BORDER_ROUTER
-        netif.GetNetworkDataLocal().SendServerDataNotification();
+        netif.GetNetworkDataLocal().UpdateConsistency();
 #endif
     }
 
@@ -2349,6 +2353,10 @@ otError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo
             delay = otPlatRandomGet() % kMleMaxResponseDelay;
             SendDataRequest(aMessageInfo.GetPeerAddr(), tlvs, sizeof(tlvs), delay);
         }
+
+#if OPENTHREAD_ENABLE_BORDER_ROUTER
+        netif.GetNetworkDataLocal().SendServerDataNotification();
+#endif
     }
 
 exit:

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1511,10 +1511,6 @@ otError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::Messa
 
     UpdateRoutes(route, routerId);
 
-#if OPENTHREAD_ENABLE_BORDER_ROUTER
-    netif.GetNetworkDataLocal().SendServerDataNotification();
-#endif
-
 exit:
     return error;
 }

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -130,6 +130,18 @@ public:
      */
     otError SendServerDataNotification(void);
 
+    /**
+     * This method updates the consistency of local networkdata and leader networkdata.
+     *
+     */
+    void UpdateConsistency(void);
+
+    /**
+     * This method updates the rloc of local networkdata if any.
+     *
+     */
+    void UpdateNetworkDataRloc(void);
+
 private:
     otError UpdateRloc(void);
     otError UpdateRloc(PrefixTlv &aPrefix);
@@ -139,6 +151,7 @@ private:
     bool IsOnMeshPrefixConsistent(void);
     bool IsExternalRouteConsistent(void);
 
+    bool mUpdating;
     uint16_t mOldRloc;
 };
 


### PR DESCRIPTION
Unstable issue in 7.1.8
Two separated continuous prefix configurations would cause three SRV_DATA.ntf (- two due to network data register, between which when processing the network data update event after the first registration, the device would think its local network data is not consistent with leader network data, so additional one is triggered). Harness sometimes wrongly take the third srv_data.ntf as the last srv_data.ntf it want to check which should be sent by the parent on behalf of the lost MED border router.

