### PR TITLE
[supervision] Update logs to show when a supervision message is sent/received

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1725,6 +1725,7 @@ void MeshForwarder::HandleReceivedFrame(Mac::Frame &aFrame)
     uint8_t payloadLength;
     uint8_t commandId;
     otError error = OT_ERROR_NONE;
+    char stringBuffer[Mac::Frame::kInfoStringSize];
 
     if (!mEnabled)
     {
@@ -1766,7 +1767,10 @@ void MeshForwarder::HandleReceivedFrame(Mac::Frame &aFrame)
         }
         else
         {
-            error = OT_ERROR_NOT_LOWPAN_DATA_FRAME;
+            VerifyOrExit(payloadLength == 0, error = OT_ERROR_NOT_LOWPAN_DATA_FRAME);
+
+            otLogInfoMac(GetInstance(), "Received empty payload frame, %s",
+                         aFrame.ToInfoString(stringBuffer, sizeof(stringBuffer)));
         }
 
         break;
@@ -1794,13 +1798,12 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
-        char stringBuffer[Mac::Frame::kInfoStringSize];
-
         otLogInfoMac(GetInstance(), "Dropping rx frame, error:%s, %s", otThreadErrorToString(error),
                      aFrame.ToInfoString(stringBuffer, sizeof(stringBuffer)));
 
-        OT_UNUSED_VARIABLE(stringBuffer);
     }
+
+    OT_UNUSED_VARIABLE(stringBuffer);
 }
 
 void MeshForwarder::HandleMesh(uint8_t *aFrame, uint8_t aFrameLength, const Mac::Address &aMacSource,

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -118,6 +118,8 @@ void ChildSupervisor::SendMessage(Child &aChild)
     SuccessOrExit(error = netif.SendMessage(*message));
     message = NULL;
 
+    otLogInfoMle(GetInstance(), "Sending supervision message to child 0x%04x", aChild.GetRloc16());
+
 exit:
 
     if (message != NULL)


### PR DESCRIPTION
This commit updates the logs in supervision module to indicate when a supervision message is sent to a sleepy child It also adds a new log in `MeshForwarder::HandleReceivedFrame()` to indicate when an
empty payload frame is received.