### PR TITLE
[link-quality] Introduce `RssAverager` and keep track of average RSS for a received message

### DIFF
--- a/include/openthread/message.h
+++ b/include/openthread/message.h
@@ -164,6 +164,14 @@ bool otMessageIsLinkSecurityEnabled(otMessage *aMessage);
 void otMessageSetDirectTransmission(otMessage *aMessage, bool aEnabled);
 
 /**
+ * This function returns the average RSS (received signal strength) associated with the message.
+ *
+ * @returns The average RSS value (in dBm) or OT_RADIO_RSSI_INVALID if no average/RSS is available.
+ *
+ */
+int8_t otMessageGetRss(otMessage *aMessage);
+
+/**
  * Append bytes to a message.
  *
  * @param[in]  aMessage  A pointer to a message buffer.

--- a/src/core/api/message_api.cpp
+++ b/src/core/api/message_api.cpp
@@ -87,6 +87,12 @@ void otMessageSetDirectTransmission(otMessage *aMessage, bool aEnabled)
     }
 }
 
+int8_t otMessageGetRss(otMessage *aMessage)
+{
+    Message *message = static_cast<Message *>(aMessage);
+    return message->GetAverageRss();
+}
+
 otError otMessageAppend(otMessage *aMessage, const void *aBuf, uint16_t aLength)
 {
     Message *message = static_cast<Message *>(aMessage);

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -315,7 +315,7 @@ otError otThreadGetParentInfo(otInstance *aInstance, otRouterInfo *aParentInfo)
     aParentInfo->mRouterId        = Mle::Mle::GetRouterId(parent->GetRloc16());
     aParentInfo->mNextHop         = parent->GetNextHop();
     aParentInfo->mPathCost        = parent->GetCost();
-    aParentInfo->mLinkQualityIn   = parent->GetLinkInfo().GetLinkQuality(aInstance->mThreadNetif.GetMac().GetNoiseFloor());
+    aParentInfo->mLinkQualityIn   = parent->GetLinkInfo().GetLinkQuality();
     aParentInfo->mLinkQualityOut  = parent->GetLinkQualityOut();
     aParentInfo->mAge             = static_cast<uint8_t>(TimerMilli::MsecToSec(TimerMilli::GetNow() -
                                                                                parent->GetLastHeard()));

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -36,52 +36,34 @@
 #include "link_quality.hpp"
 
 #include <stdio.h>
-#include "utils/wrap_string.h"
 
 #include "common/code_utils.hpp"
+#include "utils/wrap_string.h"
 
 namespace ot {
 
-enum
+// This array gives the decimal point digits representing 0/8, 1/8, ..., 7/8 (does not include the '.').
+static const char *const kDigitsString[8] =
 {
-    kDefaultNoiseFloor = -100, // Default noise floor used if no average value is available.
+    // 0/8,  1/8,   2/8,   3/8,   4/8,   5/8,   6/8,   7/8
+    "0",     "125", "25",  "375", "5",   "625", "75",  "875"
 };
 
-// This array gives the decimal point digits representing 0/8, 1/8, ..., 7/8 (it does not include the '.').
-static const char *const kLinkQualityDecimalDigitsString[8] =
+void RssAverager::Reset(void)
 {
-    // 0/8, 1/8,   2/8,   3/8,   4/8,   5/8,   6/8,   7/8
-    "000", "125", "250", "375", "500", "625", "750", "875"
-};
-
-const char LinkQualityInfo::kUnknownRssString[] = "Unknown RSS";
-
-//-------------------------------------------------------------------------------
-
-LinkQualityInfo::LinkQualityInfo(void)
-{
-    Clear();
+    mAverage = 0;
+    mCount = 0;
 }
 
-void LinkQualityInfo::Clear(void)
+otError RssAverager::Add(int8_t aRss)
 {
-    mRssAverage  = 0;
-    mCount       = 0;
-    mLinkQuality = 0;
-    mLastRss     = 0;
-}
+    otError error = OT_ERROR_NONE;
+    uint16_t newValue;
+    uint16_t oldAverage;
 
-void LinkQualityInfo::AddRss(int8_t aNoiseFloor, int8_t aRss)
-{
-    uint16_t    newValue;
-    uint16_t    oldAverage;
+    VerifyOrExit(aRss != OT_RADIO_RSSI_INVALID, error = OT_ERROR_INVALID_ARGS);
 
-    VerifyOrExit(aRss != OT_RADIO_RSSI_INVALID);
-
-    mLastRss = aRss;
-
-    // Restrict/Cap the RSS value to the closed range [0, -128] so the value can fit in 8 bits.
-
+    // Restrict the RSS value to the closed range [0, -128] so the RSS times precision multiple can fit in 11 bits.
     if (aRss > 0)
     {
         aRss = 0;
@@ -90,116 +72,109 @@ void LinkQualityInfo::AddRss(int8_t aNoiseFloor, int8_t aRss)
     // Multiply the the RSS value by a precision multiple (currently -8).
 
     newValue = static_cast<uint16_t>(-aRss);
-    newValue <<= kRssAveragePrecisionMultipleBitShift;
+    newValue <<= kPrecisionBitShift;
 
-    oldAverage = mRssAverage;
-
-    if (mCount >= kRssCountForWeightCoefficientOneEighth)
-    {
-        // New average = old average * 7/8 + new value * 1/8
-        mRssAverage = static_cast<uint16_t>(((oldAverage << 3) - oldAverage + newValue) >> 3);
-    }
-    else if (mCount >= kRssCountForWeightCoefficientOneFourth)
-    {
-        // New average = old average * 3/4 + new value * 1/4
-        mRssAverage = static_cast<uint16_t>(((oldAverage << 2) - oldAverage + newValue) >> 2);
-    }
-    else if (mCount >= kRssCountForWeightCoefficientOneHalf)
-    {
-        // New average = old average * 1/2 + new value * 1/2
-        mRssAverage = (oldAverage + newValue) >> 1;
-    }
-    else
-    {
-        mRssAverage = newValue;
-    }
-
-    if (mCount < kRssCountMax)
-    {
-        mCount++;
-    }
-
-    UpdateLinkQuality(aNoiseFloor);
-
-exit:
-    return;
-}
-
-int8_t LinkQualityInfo::GetAverageRss(void) const
-{
-    int8_t average = OT_RADIO_RSSI_INVALID;
-
-    if (mCount != 0)
-    {
-        average = -static_cast<int8_t>(mRssAverage >> kRssAveragePrecisionMultipleBitShift);
-
-        // Check for round up (e.g. average of -71.5 --> -72)
-
-        if ((mRssAverage & kRssAveragePrecisionMultipleBitMask) >= (kRssAveragePrecisionMultiple >> 1))
-        {
-            average--;
-        }
-    }
-
-    return average;
-}
-
-uint16_t LinkQualityInfo::GetAverageRssAsEncodedWord(void) const
-{
-    return mRssAverage;
-}
-
-otError LinkQualityInfo::GetAverageRssAsString(char *aCharBuffer, size_t aBufferLen) const
-{
-    otError error = OT_ERROR_NONE;
-    int charsWritten = 0;
+    oldAverage = mAverage;
 
     if (mCount == 0)
     {
-        charsWritten = static_cast<int>(strlcpy(aCharBuffer, kUnknownRssString, aBufferLen));
+        mCount++;
+        mAverage = newValue;
+    }
+    else if (mCount < (1 << kCoeffBitShift) - 1)
+    {
+        mCount++;
+
+        // Maintain arithmetic mean.
+        // newAverage = newValue * (1/mCount) + oldAverage * ((mCount -1)/mCount)
+        mAverage = static_cast<uint16_t>(((oldAverage * (mCount - 1)) + newValue) / mCount);
     }
     else
     {
-        charsWritten = snprintf(aCharBuffer, aBufferLen, "%d.%s dBm",
-                                -(mRssAverage >> kRssAveragePrecisionMultipleBitShift),
-                                kLinkQualityDecimalDigitsString[mRssAverage & kRssAveragePrecisionMultipleBitMask]);
+        // Maintain exponentially weighted moving average using coefficient of (1/2^kCoeffBitShift).
+        // newAverage = + newValue * 1/2^j + oldAverage * (1 - 1/2^j), for j = kCoeffBitShift.
+
+        mAverage = static_cast<uint16_t>(((oldAverage << kCoeffBitShift) - oldAverage + newValue) >> kCoeffBitShift);
     }
-
-    VerifyOrExit(charsWritten >= 0, error = OT_ERROR_NO_BUFS);
-
-    VerifyOrExit(charsWritten < static_cast<int>(aBufferLen), error = OT_ERROR_NO_BUFS);
 
 exit:
     return error;
 }
 
-uint8_t LinkQualityInfo::GetLinkMargin(int8_t aNoiseFloor) const
+int8_t RssAverager::GetAverage(void) const
 {
-    return ConvertRssToLinkMargin(aNoiseFloor, GetAverageRss());
-}
+    int8_t average;
 
-uint8_t LinkQualityInfo::GetLinkQuality(int8_t aNoiseFloor)
-{
-    UpdateLinkQuality(aNoiseFloor);
+    VerifyOrExit(mCount != 0, average = OT_RADIO_RSSI_INVALID);
 
-    return mLinkQuality;
-}
+    average = -static_cast<int8_t>(mAverage >> kPrecisionBitShift);
 
-int8_t LinkQualityInfo::GetLastRss(void) const
-{
-    return mLastRss;
-}
+    // Check for possible round up (e.g., average of -71.5 --> -72)
 
-void LinkQualityInfo::UpdateLinkQuality(int8_t aNoiseFloor)
-{
-    if (mCount != 0)
+    if ((mAverage & kPrecisionBitMask) >= (kPrecision >> 1))
     {
-        mLinkQuality = CalculateLinkQuality(GetLinkMargin(aNoiseFloor), mLinkQuality);
+        average--;
+    }
+
+exit:
+    return average;
+}
+
+const char *RssAverager::ToString(char *aBuf, uint16_t aSize) const
+{
+    if (mCount == 0)
+    {
+        VerifyOrExit(aSize > 0);
+        *aBuf = 0;
     }
     else
     {
-        mLinkQuality = CalculateLinkQuality(GetLinkMargin(aNoiseFloor), kNoLastLinkQualityValue);
+        snprintf(aBuf, aSize, "%d.%s", -(mAverage >> kPrecisionBitShift), kDigitsString[mAverage & kPrecisionBitMask]);
     }
+
+exit:
+    return aBuf;
+}
+
+LinkQualityInfo::LinkQualityInfo(void):
+    mLastRss(OT_RADIO_RSSI_INVALID)
+{
+    mRssAverager.Reset();
+    SetLinkQuality(0);
+}
+
+void LinkQualityInfo::Clear(void)
+{
+    mRssAverager.Reset();
+    SetLinkQuality(0);
+    mLastRss = OT_RADIO_RSSI_INVALID;
+}
+
+void LinkQualityInfo::AddRss(int8_t aNoiseFloor, int8_t aRss)
+{
+    uint8_t oldLinkQuality = kNoLinkQuality;
+
+    if (mRssAverager.HasAverage())
+    {
+        oldLinkQuality = GetLinkQuality();
+    }
+
+    SuccessOrExit(mRssAverager.Add(aRss));
+
+    SetLinkQuality(CalculateLinkQuality(GetLinkMargin(aNoiseFloor), oldLinkQuality));
+
+exit:
+    return;
+}
+
+const char *LinkQualityInfo::ToInfoString(char *aBuf, uint16_t aSize) const
+{
+    char rssString[RssAverager::kStringSize];
+
+    snprintf(aBuf, aSize, "aveRss:%s, lastRss:%d, linkQuality:%d",
+             mRssAverager.ToString(rssString, sizeof(rssString)), GetLastRss(), GetLinkQuality());
+
+    return aBuf;
 }
 
 uint8_t LinkQualityInfo::ConvertRssToLinkMargin(int8_t aNoiseFloor, int8_t aRss)
@@ -216,7 +191,7 @@ uint8_t LinkQualityInfo::ConvertRssToLinkMargin(int8_t aNoiseFloor, int8_t aRss)
 
 uint8_t LinkQualityInfo::ConvertLinkMarginToLinkQuality(uint8_t aLinkMargin)
 {
-    return CalculateLinkQuality(aLinkMargin, kNoLastLinkQualityValue);
+    return CalculateLinkQuality(aLinkMargin, kNoLinkQuality);
 }
 
 uint8_t LinkQualityInfo::ConvertRssToLinkQuality(int8_t aNoiseFloor, int8_t aRss)
@@ -229,26 +204,26 @@ uint8_t LinkQualityInfo::CalculateLinkQuality(uint8_t aLinkMargin, uint8_t aLast
     uint8_t threshold1, threshold2, threshold3;
     uint8_t linkQuality = 0;
 
-    threshold1 = kLinkMarginThresholdForLinkQuality1;
-    threshold2 = kLinkMarginThresholdForLinkQuality2;
-    threshold3 = kLinkMarginThresholdForLinkQuality3;
+    threshold1 = kThreshold1;
+    threshold2 = kThreshold2;
+    threshold3 = kThreshold3;
 
     // Apply the hysteresis threshold based on the last link quality value.
 
     switch (aLastLinkQuality)
     {
     case 0:
-        threshold1 += kLinkMarginHysteresisThreshold;
+        threshold1 += kHysteresisThreshold;
 
     // Intentional fall-through to next case.
 
     case 1:
-        threshold2 += kLinkMarginHysteresisThreshold;
+        threshold2 += kHysteresisThreshold;
 
     // Intentional fall-through to next case.
 
     case 2:
-        threshold3 += kLinkMarginHysteresisThreshold;
+        threshold3 += kHysteresisThreshold;
 
     // Intentional fall-through to next case.
 

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -34,8 +34,6 @@
 #ifndef LINK_QUALITY_HPP_
 #define LINK_QUALITY_HPP_
 
-#include <stdio.h>
-
 #include <openthread/platform/radio.h>
 #include <openthread/types.h>
 
@@ -50,23 +48,132 @@ namespace ot {
  * @{
  */
 
+
+/**
+ * This class implements a Received Signal Strength (RSS) averager.
+ *
+ * The average is maintained using an adaptive exponentially weighted moving filter.
+ *
+ */
+class RssAverager
+{
+    friend class LinkQualityInfo;
+
+public:
+    enum
+    {
+        kStringSize = 10,    ///< Max chars needed for a string representation of average (@sa ToString()).
+    };
+
+    /**
+     * This method reset the averager and clears the average value.
+     *
+     */
+    void Reset(void);
+
+    /**
+     * This method indicates whether the averager contains an average (i.e., at least one RSS value has been added).
+     *
+     * @retval true   If the average value is available (at least one RSS value has been added).
+     * @retval false  Averager is empty (no RSS value added yet).
+     *
+     */
+    bool HasAverage(void) const { return (mCount != 0); }
+
+    /**
+     * This method adds a received signal strength (RSS) value to the average.
+     *
+     * If @p aRss is OT_RADIO_RSSI_INVALID, it is ignored and error status OT_ERROR_INVALID_ARGS is returned.
+     * The value of RSS is capped at 0dBm (i.e., for any given RSS value higher than 0dBm, 0dBm is used instead).
+     *
+     * @param[in] aRss                Received signal strength value (in dBm) to be added to the average.
+     *
+     * @retval OT_ERROR_NONE          New RSS value added to average successfully.
+     * @retval OT_ERROR_INVALID_ARGS  Value of @p aRss is OT_RADIO_RSSI_INVALID.
+     *
+     */
+    otError Add(int8_t aRss);
+
+    /**
+     * This method returns the current average signal strength value maintained by the averager.
+     *
+     * @returns The current average value (in dBm) or OT_RADIO_RSSI_INVALID if no average is available.
+     *
+     */
+    int8_t GetAverage(void) const;
+
+    /**
+     * This method returns an raw/encoded version of current average signal strength value. The raw value is the
+     * average multiplied by a precision factor (currently set as -8).
+     *
+     * @returns The current average multiplied by precision factor or zero if no average is available.
+     *
+     */
+    uint16_t GetRaw(void) const { return mAverage; }
+
+    /**
+     * This method converts the current average RSS value to a human-readable string (e.g., "-80.375"). If the
+     * average is unknown, empty string is returned.
+     *
+     * @param[out]  aBuf   A pointer to the char buffer.
+     * @param[in]   aSize  The maximum size of the buffer.
+     *
+     * @returns A pointer to the char string buffer.
+     *
+     */
+    const char *ToString(char *aBuf, uint16_t aSize) const;
+
+private:
+    /*
+     * The RssAverager uses an adaptive exponentially weighted filter to maintain the average. It keeps track of
+     * current average and the number of added RSS values (up to a 8).
+     *
+     * For the first 8 added RSS values, the average is the arithmetic mean of the added values (e.g., if 5 values are
+     * added, the average is sum of the 5 added RSS values divided by 5. After the 8th RSS value, a weighted filter is
+     * used with coefficients (1/8, 7/8), i.e., newAverage = 1/8 * newRss + 7/8 * oldAverage.
+     *
+     * To add to accuracy of the averaging process, the RSS values and the maintained average are multiplied by a
+     * precision factor of -8.
+     *
+     */
+
+    enum
+    {
+        kPrecisionBitShift      = 3,    // Precision multiple for RSS average (1 << PrecisionBitShift).
+        kPrecision              = (1 << kPrecisionBitShift),
+        kPrecisionBitMask       = (kPrecision - 1),
+
+        kCoeffBitShift          = 3,    // Coefficient used for exponentially weighted filter (1 << kCoeffBitShift).
+    };
+
+    // Member variables fit into two bytes.
+
+    uint16_t mAverage     : 11; // The raw average signal strength value (stored as RSS times precision multiple).
+    uint8_t  mCount       : 3;  // Number of RSS values added to averager so far (limited to 2^kCoeffBitShift-1).
+    uint8_t  mLinkQuality : 2;  // Used by friend class LinkQualityInfo to store LinkQuality (0-3) value.
+};
+
 /**
  * This class encapsulates/stores all relevant information about quality of a link, including average received signal
- * strength (RSS), link margin and link quality value (value in 0-3). The average is obtained using an adaptive
- * exponential moving average filter.
+ * strength (RSS), last RSS, link margin, and link quality.
  *
-  */
+ */
 class LinkQualityInfo
 {
 public:
+    enum
+    {
+        kInfoStringSize = 50,    ///< Max chars needed for the info string representation (@sa ToInfoString())
+    };
+
     /**
-     * This constructor initializes an instance of the LinkQualityInfo class.
+     * This constructor initializes the object.
      *
      */
     LinkQualityInfo(void);
 
     /**
-     * This method clears the all the data in this instance.
+     * This method clears the all the data in the object.
      *
      */
     void Clear(void);
@@ -86,7 +193,7 @@ public:
      * @returns The current average value or @c OT_RADIO_RSSI_INVALID if no average is available.
      *
      */
-    int8_t GetAverageRss(void) const;
+    int8_t GetAverageRss(void) const { return mRssAverager.GetAverage(); }
 
     /**
      * This method returns an encoded version of current average signal strength value. The encoded value is the
@@ -95,20 +202,18 @@ public:
      * @returns The current average multiplied by precision factor or zero if no average is available.
      *
      */
-    uint16_t GetAverageRssAsEncodedWord(void) const;
+    uint16_t GetAverageRssRaw(void) const { return mRssAverager.GetRaw(); }
 
     /**
-     * This method provides the current average received signal strength (RSS) as a human-readable string (e.g.,
-     * "-80.375 dBm"). If the average is unknown, "unknown RSS" is used/returned in the buffer.
+     * This method converts the link quality info  to NULL-terminated info/debug human-readable string.
      *
-     * @param[out]    aCharBuffer    A char buffer to store the string corresponding to current average value.
-     * @param[in]     aBufferLen     The char buffer length.
+     * @param[out]  aBuf   A pointer to the string buffer.
+     * @param[in]   aSize  The maximum size of the string buffer.
      *
-     * @retval OT_ERROR_NONE      Successfully formed the string in the given char buffer.
-     * @retval OT_ERROR_NO_BUFS   The string representation of the average value could not fit in the given buffer.
+     * @returns A pointer to the char string buffer.
      *
      */
-    otError GetAverageRssAsString(char *aCharBuffer, size_t aBufferLen) const;
+    const char *ToInfoString(char *aBuf, uint16_t aSize) const;
 
     /**
      * This method returns the link margin. The link margin is calculated using the link's current average received
@@ -119,7 +224,7 @@ public:
      * @returns Link margin derived from average received signal strength and average noise floor.
      *
      */
-    uint8_t GetLinkMargin(int8_t aNoiseFloor) const;
+    uint8_t GetLinkMargin(int8_t aNoiseFloor) const { return ConvertRssToLinkMargin(aNoiseFloor, GetAverageRss()); }
 
     /**
      * Returns the current one-way link quality value. The link quality value is a number 0-3.
@@ -135,8 +240,9 @@ public:
      * @param[in]  aNoiseFloor  The noise floor value (in dBm).
      *
      * @returns The current link quality value (value 0-3 as per Thread specification).
+     *
      */
-    uint8_t GetLinkQuality(int8_t aNoiseFloor);
+    uint8_t GetLinkQuality(void) const { return mRssAverager.mLinkQuality; }
 
     /**
      * Returns the most recent RSS value.
@@ -144,7 +250,7 @@ public:
      * @returns The most recent RSS
      *
      */
-    int8_t GetLastRss(void) const;
+    int8_t GetLastRss(void) const { return mLastRss; }
 
     /**
      * This method converts a received signal strength value to a link margin value.
@@ -183,46 +289,25 @@ private:
     {
         // Constants for obtaining link quality from link margin:
 
-        kLinkMarginThresholdForLinkQuality3    = 20,   // Link margin threshold for quality 3 link.
-        kLinkMarginThresholdForLinkQuality2    = 10,   // Link margin threshold for quality 2 link.
-        kLinkMarginThresholdForLinkQuality1    = 2,    // Link margin threshold for quality 1 link.
-        kLinkMarginHysteresisThreshold         = 2,    // Link margin hysteresis threshold.
+        kThreshold3             = 20,   // Link margin threshold for quality 3 link.
+        kThreshold2             = 10,   // Link margin threshold for quality 2 link.
+        kThreshold1             = 2,    // Link margin threshold for quality 1 link.
+        kHysteresisThreshold    = 2,    // Link margin hysteresis threshold.
 
-        kNoLastLinkQualityValue                = 0xff, // Used to indicate that there is no previous/last link quality.
-
-        // Constants related to RSS adaptive exponential moving average filter:
-
-        kRssAveragePrecisionMultipleBitShift   = 3,    // Precision multiple for RSS average (1 << PrecisionBitShift).
-        kRssAveragePrecisionMultiple           = (1 << kRssAveragePrecisionMultipleBitShift),
-        kRssAveragePrecisionMultipleBitMask    = (kRssAveragePrecisionMultiple - 1),
-
-        kRssCountMax                           = 7,    // mCount max limit value.
-
-        kRssCountForWeightCoefficientOneEighth = 5,    // mCount threshold to use average weight coefficient of 1/8.
-        kRssCountForWeightCoefficientOneFourth = 2,    // mCount threshold to use average weight coefficient of 1/4.
-        kRssCountForWeightCoefficientOneHalf   = 1,    // mCount threshold to use average weight coefficient of 1/2.
+        kNoLinkQuality          = 0xff, // Used to indicate that there is no previous/last link quality.
     };
 
-    /* Private method to update the mLinkQuality value. This is called when a new RSS value is added to average
-     * or when GetLinkQuality() is invoked.
-     */
-    void UpdateLinkQuality(int8_t aNoiseFloor);
+    void SetLinkQuality(uint8_t aLinkQuality) { mRssAverager.mLinkQuality = aLinkQuality; }
 
     /* Static private method to calculate the link quality from a given link margin while taking into account the last
      * link quality value and adding the hysteresis value to the thresholds. If there is no previous value for link
-     * quality, the constant kNoLastLinkQualityValue should be passed as the second argument.
+     * quality, the constant kNoLinkQuality should be passed as the second argument.
      *
      */
     static uint8_t CalculateLinkQuality(uint8_t aLinkMargin, uint8_t aLastLinkQuality);
 
-    static const char kUnknownRssString[];           // Constant string used when RSS average is unknown.
-
-    // All data should fit into a 16-bit (uint16_t) value.
-
-    uint16_t mRssAverage  : 11;  // The encoded average signal strength value (stored as rss times precision multiple).
-    uint8_t  mCount       : 3;   // Number of RSS values added to average so far (limited to kRssCountMax).
-    uint8_t  mLinkQuality : 2;   // Current link quality value (0-3).
-    int8_t   mLastRss;
+    RssAverager mRssAverager;
+    int8_t      mLastRss;
 };
 
 /**

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2515,7 +2515,7 @@ bool Mle::IsBetterParent(uint16_t aRloc16, uint8_t aLinkQuality, ConnectivityTlv
 {
     bool rval = false;
 
-    uint8_t candidateLinkQualityIn = mParentCandidate.GetLinkInfo().GetLinkQuality(GetNetif().GetMac().GetNoiseFloor());
+    uint8_t candidateLinkQualityIn = mParentCandidate.GetLinkInfo().GetLinkQuality();
     uint8_t candidateTwoWayLinkQuality = (candidateLinkQualityIn < mParentCandidate.GetLinkQualityOut())
                                          ?  candidateLinkQualityIn : mParentCandidate.GetLinkQualityOut();
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1123,7 +1123,7 @@ uint8_t MleRouter::GetLinkCost(uint8_t aRouterId)
     // NULL aRouterId indicates non-existing next hop, hence return kMaxRouteCost for it.
     VerifyOrExit(aRouterId != mRouterId && router != NULL && router->GetState() == Neighbor::kStateValid);
 
-    rval = router->GetLinkInfo().GetLinkQuality(GetNetif().GetMac().GetNoiseFloor());
+    rval = router->GetLinkInfo().GetLinkQuality();
 
     if (rval > router->GetLinkQualityOut())
     {
@@ -1637,7 +1637,7 @@ void MleRouter::UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId)
                      GetRloc16(i),
                      GetRloc16(mRouters[i].GetNextHop()),
                      mRouters[i].GetCost(),
-                     GetLinkCost(i), mRouters[i].GetLinkInfo().GetLinkQuality(GetNetif().GetMac().GetNoiseFloor()),
+                     GetLinkCost(i), mRouters[i].GetLinkInfo().GetLinkQuality(),
                      mRouters[i].GetLinkQualityOut());
     }
 
@@ -3624,7 +3624,7 @@ otError MleRouter::GetChildInfo(Child &aChild, otChildInfo &aChildInfo)
     aChildInfo.mChildId            = GetChildId(aChild.GetRloc16());
     aChildInfo.mNetworkDataVersion = aChild.GetNetworkDataVersion();
     aChildInfo.mAge                = TimerMilli::MsecToSec(TimerMilli::GetNow() - aChild.GetLastHeard());
-    aChildInfo.mLinkQualityIn      = aChild.GetLinkInfo().GetLinkQuality(GetNetif().GetMac().GetNoiseFloor());
+    aChildInfo.mLinkQualityIn      = aChild.GetLinkInfo().GetLinkQuality();
     aChildInfo.mAverageRssi        = aChild.GetLinkInfo().GetAverageRss();
     aChildInfo.mLastRssi           = aChild.GetLinkInfo().GetLastRss();
 
@@ -3663,7 +3663,7 @@ otError MleRouter::GetRouterInfo(uint16_t aRouterId, otRouterInfo &aRouterInfo)
     aRouterInfo.mNextHop         = router->GetNextHop();
     aRouterInfo.mLinkEstablished = router->GetState() == Neighbor::kStateValid;
     aRouterInfo.mPathCost        = router->GetCost();
-    aRouterInfo.mLinkQualityIn   = router->GetLinkInfo().GetLinkQuality(GetNetif().GetMac().GetNoiseFloor());
+    aRouterInfo.mLinkQualityIn   = router->GetLinkInfo().GetLinkQuality();
     aRouterInfo.mLinkQualityOut  = router->GetLinkQualityOut();
     aRouterInfo.mAge             = static_cast<uint8_t>(TimerMilli::MsecToSec(TimerMilli::GetNow() -
                                                                               router->GetLastHeard()));
@@ -3725,7 +3725,7 @@ exit:
         aNeighInfo.mRloc16 = neighbor->GetRloc16();
         aNeighInfo.mLinkFrameCounter = neighbor->GetLinkFrameCounter();
         aNeighInfo.mMleFrameCounter = neighbor->GetMleFrameCounter();
-        aNeighInfo.mLinkQualityIn = neighbor->GetLinkInfo().GetLinkQuality(GetNetif().GetMac().GetNoiseFloor());
+        aNeighInfo.mLinkQualityIn = neighbor->GetLinkInfo().GetLinkQuality();
         aNeighInfo.mAverageRssi = neighbor->GetLinkInfo().GetAverageRss();
         aNeighInfo.mLastRssi = neighbor->GetLinkInfo().GetLastRss();
         aNeighInfo.mRxOnWhenIdle = neighbor->IsRxOnWhenIdle();
@@ -4235,7 +4235,6 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
     uint8_t linkQuality;
     uint8_t numChildren = 0;
     int8_t parentPriority = kParentPriorityMedium;
-    int8_t noiseFloor = GetNetif().GetMac().GetNoiseFloor();
 
     if (mParentPriority != kParentPriorityUnspecified)
     {
@@ -4278,7 +4277,7 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
         break;
 
     case OT_DEVICE_ROLE_CHILD:
-        switch (mParent.GetLinkInfo().GetLinkQuality(noiseFloor))
+        switch (mParent.GetLinkInfo().GetLinkQuality())
         {
         case 1:
             tlv.SetLinkQuality1(tlv.GetLinkQuality1() + 1);
@@ -4293,7 +4292,7 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
             break;
         }
 
-        cost += LinkQualityToCost(mParent.GetLinkInfo().GetLinkQuality(noiseFloor));
+        cost += LinkQualityToCost(mParent.GetLinkInfo().GetLinkQuality());
         break;
 
     case OT_DEVICE_ROLE_ROUTER:
@@ -4325,7 +4324,7 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
             continue;
         }
 
-        linkQuality = mRouters[i].GetLinkInfo().GetLinkQuality(noiseFloor);
+        linkQuality = mRouters[i].GetLinkInfo().GetLinkQuality();
 
         if (linkQuality > mRouters[i].GetLinkQualityOut())
         {
@@ -4470,8 +4469,7 @@ void MleRouter::FillRouteTlv(RouteTlv &tlv)
             }
             else
             {
-                tlv.SetLinkQualityIn(routeCount,
-                                     mRouters[i].GetLinkInfo().GetLinkQuality(GetNetif().GetMac().GetNoiseFloor()));
+                tlv.SetLinkQualityIn(routeCount, mRouters[i].GetLinkInfo().GetLinkQuality());
             }
         }
 
@@ -4533,7 +4531,7 @@ bool MleRouter::HasOneNeighborwithComparableConnectivity(const RouteTlv &aRoute,
                 continue;
             }
 
-            localLinkQuality = mRouters[i].GetLinkInfo().GetLinkQuality(GetNetif().GetMac().GetNoiseFloor());
+            localLinkQuality = mRouters[i].GetLinkInfo().GetLinkQuality();
 
             if (localLinkQuality > mRouters[i].GetLinkQualityOut())
             {
@@ -4662,7 +4660,7 @@ uint8_t MleRouter::GetMinDowngradeNeighborRouters(void)
             continue;
         }
 
-        linkQuality = mRouters[i].GetLinkInfo().GetLinkQuality(GetNetif().GetMac().GetNoiseFloor());
+        linkQuality = mRouters[i].GetLinkInfo().GetLinkQuality();
 
         if (linkQuality > mRouters[i].GetLinkQualityOut())
         {


### PR DESCRIPTION
This commit  introduces a new class `RssAverager` (which contains the existing averaging logic from`LinkQualityInfo` class). It also updates `Message` class to maintain the average RSS for a received message (note that a message may be composed of multiple 802.15.4 fragments data frames each received with different signal strength). The `MeshForwarder::LogIp6Message()` is updated to log the RSS value for received/dropped messages.