### PR TITLE
[tests] fix some unit tests random fail issue

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -52,6 +52,7 @@ Dataset::Dataset(const Tlv::Type aType) :
     mLength(0),
     mType(aType)
 {
+    memset(mTlvs, 0, sizeof(mTlvs));
 }
 
 void Dataset::Clear(void)

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -495,7 +495,7 @@ exit:
         (void)aValue;
         (void)aValueLength;
 
-        return OT_ERROR_NONE;
+        return OT_ERROR_NOT_FOUND;
     }
 
     otError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)


### PR DESCRIPTION
It fixes the travis check failure like: [failure logs](https://travis-ci.org/openthread/openthread/jobs/251069738#L2125).

Current unit tests (for example: test_message_queue) are built on [test_platform](https://github.com/openthread/openthread/blob/master/tests/unit/test_platform.cpp), by the end of the tests, they will call into: `testFreeInstance()` -> `otInstanceFinalize()` -> ... -> `ActiveDatasetBase::HandleDetach()` -> `DatasetManager::ApplyConfiguration()` -> `DatasetLocal::Get()`.

The issue happens in `DatasetManager::ApplyConfiguration()`, since `otPlatSettingsGet()` in test_platform always return `OT_ERROR_NONE`, then `DatasetLocal::Get()` will return a random values Dataset with 256 bytes length.