### PR TITLE
[mle] do not remove child on receiving an MLE parent request

### DIFF
--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -165,6 +165,16 @@ public:
     void UpdateIndirectMessages(void);
 
     /**
+     * This method frees any messages queued for an existing child.
+     *
+     * @param[in]  aChild    A reference to the child.
+     * @param[in]  aSubType  The message sub-type to remove.
+     *                       Use Message::kSubTypeNone remove all messages for @p aChild.
+     *
+     */
+    void RemoveMessages(Child &aChild, uint8_t aSubType);
+
+    /**
      * This method returns a reference to the send queue.
      *
      * @returns  A reference to the send queue.


### PR DESCRIPTION
MLE Parent Request messages may be sent by an existing child that is
searching for parents or trying to reattach.  Simply receiving an MLE
Parent Request message should not result in Router(s) flushing any
existing state and associated messages for the Child.

This commit makes the following changes:

- RemoveNeighbor() is no longer called from HandleParentRequest.

- MLE Parent Response messages are explicitly marked for direct
  transmission.

- A new method MeshForwarder::RemoveMessages() is introduced to remove
  all messages (direct and indirect) matching a particular sub-type for
  a given child.

- All queued MLE messages are removed for a given child upon receiving
  an MLE Child ID Request message.

- No queued data messages for a given child are removed.