### PR TITLE
Use Cryptodome.Cipher in net_crypto.py.

### DIFF
--- a/tests/scripts/thread-cert/net_crypto.py
+++ b/tests/scripts/thread-cert/net_crypto.py
@@ -33,7 +33,7 @@ import struct
 
 from binascii import hexlify
 
-from Crypto.Cipher import AES
+from Cryptodome.Cipher import AES
 
 
 class CryptoEngine:


### PR DESCRIPTION
This PR simply modifies the *net_crypto.py* to use *cryptodome* so that tests can be run under newer python versions.

`AES.MODE_CCM` is not defined by newer version python.