### PR TITLE
[mle] solution for MLE Announce processing corner case

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3014,12 +3014,10 @@ otError Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMe
         }
         else 
         {
-            /*
-                do nothing 
-                timestamps are equal: no behaviour specified by the Thread spec.
-                If SendAnnounce is executed at this point, there exists a scenario where
-                multiple devices keep sending MLE Announce messages to one another indefinitely.
-            */
+            // do nothing 
+            // timestamps are equal: no behaviour specified by the Thread spec.
+            // If SendAnnounce is executed at this point, there exists a scenario where
+            // multiple devices keep sending MLE Announce messages to one another indefinitely.
         }
     }
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3008,7 +3008,19 @@ otError Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMe
     }
     else
     {
-        SendAnnounce(static_cast<uint8_t>(channel.GetChannel()), false);
+        if (localTimestamp->Compare(timestamp) < 0)
+        {
+            SendAnnounce(static_cast<uint8_t>(channel.GetChannel()), false);
+        }
+        else 
+        {
+            /*
+                do nothing 
+                timestamps are equal: no behaviour specified by the Thread spec.
+                If SendAnnounce is executed at this point, there exists a scenario where
+                multiple devices keep sending MLE Announce messages to one another indefinitely.
+            */
+        }
     }
 
 exit:

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3006,19 +3006,16 @@ otError Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMe
         netif.GetMac().SetPanId(panid.GetPanId());
         Start(false, true);
     }
+    else if (localTimestamp->Compare(timestamp) < 0)
+    {
+        SendAnnounce(static_cast<uint8_t>(channel.GetChannel()), false);
+    }
     else
     {
-        if (localTimestamp->Compare(timestamp) < 0)
-        {
-            SendAnnounce(static_cast<uint8_t>(channel.GetChannel()), false);
-        }
-        else 
-        {
-            // do nothing 
-            // timestamps are equal: no behaviour specified by the Thread spec.
-            // If SendAnnounce is executed at this point, there exists a scenario where
-            // multiple devices keep sending MLE Announce messages to one another indefinitely.
-        }
+        // do nothing
+        // timestamps are equal: no behaviour specified by the Thread spec.
+        // If SendAnnounce is executed at this point, there exists a scenario where
+        // multiple devices keep sending MLE Announce messages to one another indefinitely.
     }
 
 exit:


### PR DESCRIPTION
Adding an additional check to prevent executing SendAnnounce in case  localtimestamp and timestamp are equal (see issue #1978)