### PR TITLE
[mesh-forwarder] remove `BUSY` error log in `ScheduleTransmissionTask()`

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -318,13 +318,12 @@ void MeshForwarder::ScheduleTransmissionTask(Tasklet &aTasklet)
 void MeshForwarder::ScheduleTransmissionTask(void)
 {
     ThreadNetif &netif = GetNetif();
-    otError error = OT_ERROR_NONE;
     uint8_t numChildren;
     uint8_t childIndex;
     uint8_t nextIndex;
     Child *children;
 
-    VerifyOrExit(mSendBusy == false, error = OT_ERROR_BUSY);
+    VerifyOrExit(mSendBusy == false);
 
     UpdateIndirectMessages();
 
@@ -404,12 +403,7 @@ void MeshForwarder::ScheduleTransmissionTask(void)
     }
 
 exit:
-
-    if (error != OT_ERROR_NONE)
-    {
-        otLogWarnMac(GetInstance(), "Error while scheduling transmission task: %s",
-                     otThreadErrorToString(error));
-    }
+    return;
 }
 
 otError MeshForwarder::SendMessage(Message &aMessage)


### PR DESCRIPTION
This commit removes the `error` from `ScheduleTransmissionTask()` and also removes the corresponding log line printing the error. The BUSY error log is not really helpful as `ScheduleTransmissionTask` is posted whenever a new messages is queued and within this method it is first checked if we are busy (i.e., in middle of an earlier tx) and simply return and wait for end of current tx to process the next one.