### PR TITLE
[posix] Exit if socket operations fails.

### DIFF
--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -368,7 +368,18 @@ void platformRadioInit(void)
     sockaddr.sin_addr.s_addr = INADDR_ANY;
 
     sSockFd = (int)socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-    bind(sSockFd, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
+
+    if (sSockFd == -1)
+    {
+        perror("socket");
+        exit(EXIT_FAILURE);
+    }
+
+    if (bind(sSockFd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) == -1)
+    {
+        perror("bind");
+        exit(EXIT_FAILURE);
+    }
 
     sReceiveFrame.mPsdu = sReceiveMessage.mPsdu;
     sTransmitFrame.mPsdu = sTransmitMessage.mPsdu;


### PR DESCRIPTION
This PR exits if bind socket fails.

Without checking if it binds successfully, two progress with the same node_id are allowed, and the second one will send data with ephemeral port. It may waste some time to find that there is a duplicate node running.