### PR TITLE
[mle] reset last heard on receiving MLE Parent Request

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1706,7 +1706,10 @@ otError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::Messa
         child->ResetLinkFailures();
         child->SetState(Neighbor::kStateParentRequest);
         child->SetDataRequestPending(false);
+    }
 
+    if (!child->IsStateValidOrRestoring())
+    {
         child->SetLastHeard(TimerMilli::GetNow());
         child->SetTimeout(TimerMilli::MsecToSec(kMaxChildIdRequestTimeout));
     }


### PR DESCRIPTION
When a child is not attached, set the last heard and timeout values on
receiving an MLE Parent Request message.  This ensures that the child
state is not prematurely timed out when a child is trying to attach.