### PR TITLE
[build] create separate linker map files for each application binary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1079,6 +1079,30 @@ AM_CONDITIONAL([OPENTHREAD_ENABLE_BORDER_ROUTER], [test "${enable_border_router}
 AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_BORDER_ROUTER],[${OPENTHREAD_ENABLE_BORDER_ROUTER}],[Define to 1 if you want to enable Border Router])
 
 #
+# Linker Map Output
+#
+
+AC_ARG_ENABLE(linker-map,
+    [AS_HELP_STRING([--enable-linker-map],[Enable linker map output @<:@default=no@:>@.])],
+    [
+        case "${enableval}" in
+
+        no|yes)
+            enable_linker_map=${enableval}
+            ;;
+
+        *)
+            AC_MSG_ERROR([Invalid value ${enable_linker_map} for --enable-linker-map])
+            ;;
+        esac
+    ],
+    [enable_linker_map=no])
+
+AC_MSG_CHECKING([whether to enable linker map output])
+AC_MSG_RESULT(${enable_linker_map})
+AM_CONDITIONAL([OPENTHREAD_ENABLE_LINKER_MAP], [test "${enable_linker_map}" = "yes"])
+
+#
 # Examples
 #
 
@@ -1410,6 +1434,7 @@ AC_MSG_NOTICE([
   Assembler flags                           : ${CCASFLAGS:--}
   Link flags                                : ${LDFLAGS:--}
   Link libraries                            : ${LIBS}
+  Link maps                                 : ${enable_linker_map}
   Pretty                                    : ${PRETTY:--}
   Pretty args                               : ${PRETTY_ARGS:--}
   Pretty check                              : ${PRETTY_CHECK:--}

--- a/examples/Makefile-cc2538
+++ b/examples/Makefile-cc2538
@@ -48,6 +48,7 @@ configure_OPTIONS               = \
     --enable-diag                 \
     --with-examples=cc2538        \
     --with-platform-info=CC2538   \
+    --enable-linker-map           \
     $(NULL)
 
 include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
@@ -91,7 +92,6 @@ LDFLAGS                        += \
     -specs=nano.specs             \
     -specs=nosys.specs            \
     -Wl,--gc-sections             \
-    -Wl,-Map=map.map              \
     $(NULL)
 
 ECHO                            := @echo

--- a/examples/Makefile-cc2650
+++ b/examples/Makefile-cc2650
@@ -47,6 +47,7 @@ configure_OPTIONS               = \
     --with-ncp-bus=uart           \
     --with-examples=cc2650        \
     --with-platform-info=cc2650   \
+    --enable-linker-map           \
     MBEDTLS_CPPFLAGS="$(CC2650_MBEDTLS_CPPFLAGS)" \
     $(NULL)
 
@@ -93,7 +94,6 @@ LDFLAGS                        += \
     -specs=nano.specs             \
     -specs=nosys.specs            \
     -Wl,--gc-sections             \
-    -Wl,-Map=map.map              \
     $(NULL)
 
 ECHO                            := @echo

--- a/examples/Makefile-da15000
+++ b/examples/Makefile-da15000
@@ -47,6 +47,7 @@ configure_OPTIONS               = \
     --with-ncp-bus=uart           \
     --with-examples=da15000       \
     --with-platform-info=DA15000  \
+    --enable-linker-map           \
     $(NULL)
 
 include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
@@ -90,7 +91,6 @@ LDFLAGS                        += \
     -specs=nano.specs             \
     -specs=nosys.specs            \
     -Wl,--gc-sections             \
-    -Wl,-Map=map.map              \
     $(NULL)
 
 ECHO                            := @echo

--- a/examples/Makefile-efr32
+++ b/examples/Makefile-efr32
@@ -48,6 +48,7 @@ configure_OPTIONS               = \
     --enable-diag                 \
     --with-examples=efr32         \
     --with-platform-info=EFR32    \
+    --enable-linker-map           \
     MBEDTLS_CPPFLAGS="$(EFR32_MBEDTLS_CPPFLAGS)" \
     $(NULL)
 
@@ -105,7 +106,6 @@ LDFLAGS                        += \
     -specs=nano.specs             \
     -specs=nosys.specs            \
     -Wl,--gc-sections             \
-    -Wl,-Map=map.map              \
     $(NULL)
 
 ECHO                            := @echo

--- a/examples/Makefile-emsk
+++ b/examples/Makefile-emsk
@@ -47,6 +47,7 @@ configure_OPTIONS               = \
     --with-ncp-bus=uart           \
     --with-examples=emsk          \
     --with-platform-info=EMSK     \
+    --enable-linker-map           \
     $(NULL)
 
 ifeq ($(CERT_LOG),1)
@@ -112,7 +113,6 @@ LDFLAGS                        += \
     -nostartfiles                 \
     -specs=nano.specs             \
     -Wl,--gc-sections             \
-    -Wl,-Map=map.map              \
     -Wl,--defsym=_STACKSIZE=524288 \
     -Wl,--defsym=_HEAPSIZE=524288 \
     $(NULL)

--- a/examples/Makefile-gp712
+++ b/examples/Makefile-gp712
@@ -94,7 +94,6 @@ LDFLAGS                        += \
     $(COMMONCFLAGS)               \
     $(target_LDFLAGS)             \
     -Wl,--gc-sections             \
-    -Wl,-Map=map.map              \
     -lrt                          \
     -lpthread                     \
     $(NULL)

--- a/examples/Makefile-kw41z
+++ b/examples/Makefile-kw41z
@@ -48,6 +48,7 @@ configure_OPTIONS               = \
     --enable-diag                 \
     --with-examples=kw41z         \
     --with-platform-info=KW41Z    \
+    --enable-linker-map           \
     $(NULL)
 
 include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
@@ -90,7 +91,6 @@ LDFLAGS                        += \
     -specs=nano.specs             \
     -specs=nosys.specs            \
     -Wl,--gc-sections             \
-    -Wl,-Map=map.map              \
     $(NULL)
 
 ECHO                            := @echo

--- a/examples/Makefile-nrf52840
+++ b/examples/Makefile-nrf52840
@@ -48,6 +48,7 @@ configure_OPTIONS                                 = \
     --enable-diag                                   \
     --with-examples=nrf52840                        \
     --with-platform-info=NRF52840                   \
+    --enable-linker-map                             \
     MBEDTLS_CPPFLAGS="$(NRF52840_MBEDTLS_CPPFLAGS)" \
     $(NULL)
 
@@ -106,7 +107,6 @@ LDFLAGS                        += \
     -specs=nano.specs             \
     -specs=nosys.specs            \
     -Wl,--gc-sections             \
-    -Wl,-Map=map.map              \
     $(NULL)
 
 CCASFLAGS                       += \

--- a/examples/apps/cli/Makefile.am
+++ b/examples/apps/cli/Makefile.am
@@ -199,6 +199,11 @@ ot_cli_mtd_SOURCES                                                     = \
     $(SOURCES_COMMON)                                                    \
     $(NULL)
 
+if OPENTHREAD_ENABLE_LINKER_MAP
+ot_cli_ftd_LDFLAGS                                                    += -Wl,-Map=ot-cli-ftd.map
+ot_cli_mtd_LDFLAGS                                                    += -Wl,-Map=ot-cli-mtd.map
+endif
+
 if OPENTHREAD_BUILD_COVERAGE
 CLEANFILES                                                             = $(wildcard *.gcda *.gcno)
 endif # OPENTHREAD_BUILD_COVERAGE

--- a/examples/apps/ncp/Makefile.am
+++ b/examples/apps/ncp/Makefile.am
@@ -191,6 +191,11 @@ ot_ncp_mtd_SOURCES                                                     = \
     $(SOURCES_COMMON)                                                    \
     $(NULL)
 
+if OPENTHREAD_ENABLE_LINKER_MAP
+ot_ncp_ftd_LDFLAGS                                                    += -Wl,-Map=ot-ncp-ftd.map
+ot_ncp_mtd_LDFLAGS                                                    += -Wl,-Map=ot-ncp-mtd.map
+endif
+
 if OPENTHREAD_BUILD_COVERAGE
 CLEANFILES                                                             = $(wildcard *.gcda *.gcno)
 endif # OPENTHREAD_BUILD_COVERAGE


### PR DESCRIPTION
Previously, a global 'map.map' filename was used.  However, when
building FTD and MTD versions of a given application, the 'map.map'
files would overwrite each other.  This commit gives different filenames
to each .map file for a given binary.

Resolves #1956.