### PR TITLE
[mle] fix reattach attempts after reset

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -481,7 +481,11 @@ otError Mle::BecomeDetached(void)
 
     VerifyOrExit(mRole != OT_DEVICE_ROLE_DISABLED, error = OT_ERROR_INVALID_STATE);
 
-    netif.GetPendingDataset().HandleDetach();
+    // not in reattach stage after reset
+    if (mReattachState == kReattachStop)
+    {
+        netif.GetPendingDataset().HandleDetach();
+    }
 
     SetStateDetached();
     SetRloc16(Mac::kShortAddrInvalid);


### PR DESCRIPTION
To fix 9.2.8 failing issue introduced in #1929 .

After reset, when `thread start`, device should try re-sync, re-attach using active operational dataset first and if fails reattach using pending operational dataset.

Without this PR, if `thread start` at T (>=delaytimer) after reset, because alarm component has already inited after reset, so if failed to re-sync, in `netif.GetPendingDataset().HandleDetach()`, the retrieved delaytimer value would be 0, thus the pending dataset would take effect immediately. Then the device would not try to reattach using active operational dataset.