### PR TITLE
[mbedtls] move heap into otInstance.

### DIFF
--- a/src/core/crypto/mbedtls.cpp
+++ b/src/core/crypto/mbedtls.cpp
@@ -38,20 +38,22 @@
 #include <mbedtls/platform.h>
 
 #include "heap.hpp"
+#include "openthread-instance.h"
+#include "openthread-single-instance.h"
+
+#if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
 
 namespace ot {
 namespace Crypto {
 
-static Heap sHeap;
-
 static void *CAlloc(size_t aCount, size_t aSize)
 {
-    return sHeap.CAlloc(aCount, aSize);
+    return otGetInstance()->mMbedTlsHeap.CAlloc(aCount, aSize);
 }
 
 static void Free(void *aPointer)
 {
-    sHeap.Free(aPointer);
+    return otGetInstance()->mMbedTlsHeap.Free(aPointer);
 }
 
 MbedTls::MbedTls(void)
@@ -61,3 +63,5 @@ MbedTls::MbedTls(void)
 
 }  // namespace Crypto
 }  // namespace ot
+
+#endif // #if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES

--- a/src/core/crypto/mbedtls.hpp
+++ b/src/core/crypto/mbedtls.hpp
@@ -34,6 +34,8 @@
 #ifndef OT_MBEDTLS_HPP_
 #define OT_MBEDTLS_HPP_
 
+#if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+
 namespace ot {
 namespace Crypto {
 
@@ -65,5 +67,7 @@ public:
 
 }  // namespace Crypto
 }  // namespace ot
+
+#endif // #if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
 
 #endif  // OT_MBEDTLS_HPP_

--- a/src/core/openthread-instance.h
+++ b/src/core/openthread-instance.h
@@ -49,6 +49,7 @@
 #include "api/link_raw.hpp"
 #endif
 #include "coap/coap.hpp"
+#include "crypto/heap.hpp"
 #include "crypto/mbedtls.hpp"
 #include "net/ip6.hpp"
 #include "thread/thread_netif.hpp"
@@ -79,6 +80,7 @@ typedef struct otInstance
 
 #if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
     ot::Crypto::MbedTls mMbedTls;
+    ot::Crypto::Heap    mMbedTlsHeap;
 #endif
     ot::Ip6::Ip6 mIp6;
     ot::ThreadNetif mThreadNetif;

--- a/tests/unit/test_heap.cpp
+++ b/tests/unit/test_heap.cpp
@@ -93,7 +93,7 @@ void TestAllocateRandomly(size_t aSizeLimit, unsigned int aSeed)
 
     do
     {
-        size_t size = sizeof(Node) + rand() % aSizeLimit;
+        size_t size = sizeof(Node) + static_cast<size_t>(rand()) % aSizeLimit;
         Log("TestAllocateRandomly allocating %zu bytes...", size);
         last->mNext = static_cast<Node *>(heap.CAlloc(1, size));
 
@@ -109,7 +109,7 @@ void TestAllocateRandomly(size_t aSizeLimit, unsigned int aSeed)
         ++nnodes;
 
         // 50% probability to randomly free a node.
-        size_t freeIndex = rand() % (nnodes * 2);
+        size_t freeIndex = static_cast<size_t>(rand()) % (nnodes * 2);
 
         if (freeIndex > nnodes)
         {

--- a/tests/unit/test_hmac_sha256.cpp
+++ b/tests/unit/test_hmac_sha256.cpp
@@ -63,19 +63,23 @@ void TestHmacSha256(void)
     };
 
     otInstance *instance = testInitInstance();
-    ot::Crypto::HmacSha256 hmac;
-    uint8_t hash[ot::Crypto::HmacSha256::kHashSize];
 
-    VerifyOrQuit(instance != NULL, "Null OpenThread instance");
-
-    for (int i = 0; tests[i].key != NULL; i++)
+    // Make sure hmac is destructed before freeing instance.
     {
-        hmac.Start(reinterpret_cast<const uint8_t *>(tests[i].key), static_cast<uint16_t>(strlen(tests[i].key)));
-        hmac.Update(reinterpret_cast<const uint8_t *>(tests[i].data), static_cast<uint16_t>(strlen(tests[i].data)));
-        hmac.Finish(hash);
+        ot::Crypto::HmacSha256 hmac;
+        uint8_t hash[ot::Crypto::HmacSha256::kHashSize];
 
-        VerifyOrQuit(memcmp(hash, tests[i].hash, sizeof(tests[i].hash)) == 0,
-                     "HMAC-SHA-256 failed\n");
+        VerifyOrQuit(instance != NULL, "Null OpenThread instance");
+
+        for (int i = 0; tests[i].key != NULL; i++)
+        {
+            hmac.Start(reinterpret_cast<const uint8_t *>(tests[i].key), static_cast<uint16_t>(strlen(tests[i].key)));
+            hmac.Update(reinterpret_cast<const uint8_t *>(tests[i].data), static_cast<uint16_t>(strlen(tests[i].data)));
+            hmac.Finish(hash);
+
+            VerifyOrQuit(memcmp(hash, tests[i].hash, sizeof(tests[i].hash)) == 0,
+                         "HMAC-SHA-256 failed\n");
+        }
     }
 
     testFreeInstance(instance);


### PR DESCRIPTION
This PR mainly moves heap of mbedtls into otInstance to fix #1990 .

Also fixed two warnings.