### PR TITLE
[dataset] Thread device should send /c/ps if it has pending dataset when attaching to the partition which doesn't have

### DIFF
--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -1043,6 +1043,7 @@ void PendingDatasetBase::ClearNetwork(void)
 {
     mNetwork.Clear();
     mDelayTimer.Stop();
+    DatasetManager::HandleNetworkUpdate();
 }
 
 void PendingDatasetBase::HandleDetach(void)

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -440,7 +440,6 @@ protected:
     static void HandleDelayTimer(Timer &aTimer);
     void HandleDelayTimer(void);
     void StartDelayTimer(void);
-    void HandleNetworkUpdate(void);
 
     TimerMilli mDelayTimer;
 


### PR DESCRIPTION
Previous [L#2798 before PR#1929](https://github.com/openthread/openthread/pull/1929/files#diff-84a897c448e39fcbd8f2c6c8b49b650bL2798) would do two things:
1) clear `mNetwork`
2) `HandleNetworkUpdate` which would trigger /c/ps if it locally has newer dataset.

This PR supplements the second operation when `ClearNetwork()`

To fix 9.2.7 Leader scenario.