### PR TITLE
[cert-mgmt] workaround: reuse existing active/pending dataset for partial dataset from thread device

### DIFF
--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -522,6 +522,7 @@ otError DatasetManager::Set(Coap::Header &aHeader, Message &aMessage, const Ip6:
             mNetwork.Set(netif.GetActiveDataset().GetNetwork());
         }
     }
+
 #if 0
     // Interim workaround for certification:
     // Thread specification requires entire dataset for MGMT_ACTIVE_SET.req/MGMT_PENDING_SET.req from thread device.
@@ -535,6 +536,7 @@ otError DatasetManager::Set(Coap::Header &aHeader, Message &aMessage, const Ip6:
     {
         mNetwork.Clear();
     }
+
 #endif
 
     if (type == Tlv::kPendingTimestamp || !doesAffectConnectivity)


### PR DESCRIPTION
As in the comment, it is an interim workaround to pass the 9.2.5 as #1999 tries to fix before all stack vendors reach consensus.