### PR TITLE
[instance] Check the instance to be valid in platform callbacks

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -187,10 +187,26 @@ otInstance *otInstanceInit(void *aInstanceBuffer, size_t *aInstanceBufferSize);
  *
  * This function is available and can only be used when support for multiple OpenThread instances is disabled.
  *
- * @retval The new single OpenThread instance structure.
+ * @retval A pointer to the single OpenThread instance structure.
  *
  */
 otInstance *otInstanceInitSingle(void);
+
+/**
+ * This function indicates whether or not the instance is valid/initialized.
+ *
+ * For single-instance case, the instance is considered valid if it is acquired and initialized using
+ * `otInstanceInitSingle()`. A subsequent call to `otInstanceFinalize()` causes the instance to be considered as
+ * invalid (not initialized).
+ *
+ * For multi-instance case, any non-NULL instance pointer is considered as valid/initialized.
+ *
+ * @param[in] aInstance A pointer to an OpenThread instance.
+ *
+ * @returns TRUE if the given instance is valid/initialized, FALSE otherwise.
+ *
+ */
+bool otInstanceIsInitialized(otInstance *aInstance);
 
 /**
  * This function disables the OpenThread library.

--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -155,6 +155,11 @@ exit:
     return instance;
 }
 
+bool otInstanceIsInitialized(otInstance *aInstance)
+{
+    return (aInstance != NULL);
+}
+
 #else // #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
 
 otInstance *otInstanceInitSingle(void)
@@ -179,6 +184,11 @@ exit:
 
     otLogFuncExit();
     return sInstance;
+}
+
+bool otInstanceIsInitialized(otInstance *aInstance)
+{
+    return (aInstance != NULL) && (aInstance == sInstance);
 }
 
 #endif // #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES

--- a/src/core/api/tasklet_api.cpp
+++ b/src/core/api/tasklet_api.cpp
@@ -37,6 +37,7 @@
 #include <openthread/tasklet.h>
 
 #include "openthread-instance.h"
+#include "common/code_utils.hpp"
 #include "common/logging.hpp"
 
 using namespace ot;
@@ -44,13 +45,22 @@ using namespace ot;
 void otTaskletsProcess(otInstance *aInstance)
 {
     otLogFuncEntry();
+    VerifyOrExit(otInstanceIsInitialized(aInstance));
     aInstance->mTaskletScheduler.ProcessQueuedTasklets();
+
+exit:
     otLogFuncExit();
 }
 
 bool otTaskletsArePending(otInstance *aInstance)
 {
-    return aInstance->mTaskletScheduler.AreTaskletsPending();
+    bool retval = false;
+
+    VerifyOrExit(otInstanceIsInitialized(aInstance));
+    retval = aInstance->mTaskletScheduler.AreTaskletsPending();
+
+exit:
+    return retval;
 }
 
 #ifndef _MSC_VER

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -216,7 +216,11 @@ bool TimerScheduler::IsStrictlyBefore(uint32_t aTimeA, uint32_t aTimeB)
 extern "C" void otPlatAlarmMilliFired(otInstance *aInstance)
 {
     otLogFuncEntry();
+
+    VerifyOrExit(otInstanceIsInitialized(aInstance));
     aInstance->mTimerMilliScheduler.ProcessTimers();
+
+exit:
     otLogFuncExit();
 }
 
@@ -248,7 +252,11 @@ TimerMicroScheduler &TimerMicro::GetTimerMicroScheduler(void) const
 extern "C" void otPlatAlarmMicroFired(otInstance *aInstance)
 {
     otLogFuncEntry();
+
+    VerifyOrExit(otInstanceIsInitialized(aInstance));
     aInstance->mTimerMicroScheduler.ProcessTimers();
+
+exit:
     otLogFuncExit();
 }
 #endif // OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -308,6 +308,8 @@ void Mac::StartEnergyScan(void)
 
 extern "C" void otPlatRadioEnergyScanDone(otInstance *aInstance, int8_t aEnergyScanMaxRssi)
 {
+    VerifyOrExit(otInstanceIsInitialized(aInstance));
+
 #if OPENTHREAD_ENABLE_RAW_LINK_API
 
     if (aInstance->mLinkRaw.IsEnabled())
@@ -319,6 +321,9 @@ extern "C" void otPlatRadioEnergyScanDone(otInstance *aInstance, int8_t aEnergyS
     {
         aInstance->mThreadNetif.GetMac().EnergyScanDone(aEnergyScanMaxRssi);
     }
+
+exit:
+    return;
 }
 
 void Mac::EnergyScanDone(int8_t aEnergyScanMaxRssi)
@@ -855,9 +860,9 @@ exit:
 extern "C" void otPlatRadioTxStarted(otInstance *aInstance, otRadioFrame *aFrame)
 {
     otLogFuncEntry();
-
+    VerifyOrExit(otInstanceIsInitialized(aInstance));
     aInstance->mThreadNetif.GetMac().TransmitStartedTask(aFrame);
-
+exit:
     otLogFuncExit();
 }
 
@@ -877,6 +882,7 @@ extern "C" void otPlatRadioTransmitDone(otInstance *aInstance, otRadioFrame *aFr
                                         otError aError)
 {
     otLogFuncEntryMsg("%!otError!, aRxPending=%u", aError, aRxPending ? 1 : 0);
+    VerifyOrExit(otInstanceIsInitialized(aInstance));
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
 
@@ -890,6 +896,7 @@ extern "C" void otPlatRadioTransmitDone(otInstance *aInstance, otRadioFrame *aFr
         aInstance->mThreadNetif.GetMac().TransmitDoneTask(aFrame, aRxPending, aError);
     }
 
+exit:
     otLogFuncExit();
 }
 
@@ -971,6 +978,7 @@ extern "C" void otPlatRadioTxDone(otInstance *aInstance, otRadioFrame *aFrame, o
                                   otError aError)
 {
     otLogFuncEntryMsg("%!otError!", aError);
+    VerifyOrExit(otInstanceIsInitialized(aInstance));
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
 
@@ -984,6 +992,7 @@ extern "C" void otPlatRadioTxDone(otInstance *aInstance, otRadioFrame *aFrame, o
         aInstance->mThreadNetif.GetMac().TransmitDoneTask(aFrame, aAckFrame, aError);
     }
 
+exit:
     otLogFuncExit();
 }
 
@@ -1466,6 +1475,7 @@ exit:
 extern "C" void otPlatRadioReceiveDone(otInstance *aInstance, otRadioFrame *aFrame, otError aError)
 {
     otLogFuncEntryMsg("%!otError!", aError);
+    VerifyOrExit(otInstanceIsInitialized(aInstance));
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
 
@@ -1479,6 +1489,7 @@ extern "C" void otPlatRadioReceiveDone(otInstance *aInstance, otRadioFrame *aFra
         aInstance->mThreadNetif.GetMac().ReceiveDoneTask(static_cast<Frame *>(aFrame), aError);
     }
 
+exit:
     otLogFuncExit();
 }
 

--- a/src/diag/diag_process.cpp
+++ b/src/diag/diag_process.cpp
@@ -35,10 +35,12 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "utils/wrap_string.h"
+
+#include <openthread/instance.h>
 
 #include "diag_process.hpp"
 #include "common/code_utils.hpp"
+#include "utils/wrap_string.h"
 
 namespace ot {
 namespace Diagnostics {
@@ -337,7 +339,8 @@ exit:
 
 void Diag::DiagTransmitDone(otInstance *aInstance, otError aError)
 {
-    OT_UNUSED_VARIABLE(aInstance);
+    VerifyOrExit(aInstance == sContext);
+
     if (aError == OT_ERROR_NONE)
     {
         sStats.sent_packets++;
@@ -352,11 +355,15 @@ void Diag::DiagTransmitDone(otInstance *aInstance, otError aError)
     {
         TxPacket();
     }
+
+exit:
+    return;
 }
 
 void Diag::DiagReceiveDone(otInstance *aInstance, otRadioFrame *aFrame, otError aError)
 {
-    OT_UNUSED_VARIABLE(aInstance);
+    VerifyOrExit(aInstance == sContext);
+
     if (aError == OT_ERROR_NONE)
     {
         // for sensitivity test, only record the rssi and lqi for the first packet
@@ -370,10 +377,15 @@ void Diag::DiagReceiveDone(otInstance *aInstance, otRadioFrame *aFrame, otError 
     }
     otPlatDiagRadioReceived(aInstance, aFrame, aError);
     otPlatRadioReceive(aInstance, sChannel);
+
+exit:
+    return;
 }
 
 void Diag::AlarmFired(otInstance *aInstance)
 {
+    VerifyOrExit(aInstance == sContext);
+
     if(sRepeatActive)
     {
         uint32_t now = otPlatAlarmMilliGetNow();
@@ -385,6 +397,9 @@ void Diag::AlarmFired(otInstance *aInstance)
     {
         otPlatDiagAlarmCallback(aInstance);
     }
+
+exit:
+    return;
 }
 
 extern "C" void otPlatDiagAlarmFired(otInstance *aInstance)


### PR DESCRIPTION
This commit adds a new API `otInstanceIsInitialized()` to check if a
given instance is valid, i.e, it has been initialized and not
finalized. We then use this function to verify that passed-in instance
argument in platform callbacks is valid.