### PR TITLE
[instance-locator] use reference instead of pointer

### DIFF
--- a/include/openthread/platform/logging-windows.h
+++ b/include/openthread/platform/logging-windows.h
@@ -157,236 +157,236 @@
 // ==API==
 
 // begin_wpp config
-// USEPREFIX (otLogCritApi, "[%p]API%!SPACE!", CTX);
+// USEPREFIX (otLogCritApi, "[%p]API%!SPACE!", &CTX);
 // otLogCritApi{LEVEL=TRACE_LEVEL_ERROR,FLAGS=OT_API}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogWarnApi, "[%p]API%!SPACE!", CTX);
+// USEPREFIX (otLogWarnApi, "[%p]API%!SPACE!", &CTX);
 // otLogWarnApi{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_API}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogInfoApi, "[%p]API%!SPACE!", CTX);
+// USEPREFIX (otLogInfoApi, "[%p]API%!SPACE!", &CTX);
 // otLogInfoApi{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_API}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogDebgApi, "[%p]API%!SPACE!", CTX);
+// USEPREFIX (otLogDebgApi, "[%p]API%!SPACE!", &CTX);
 // otLogDebgApi{LEVEL=TRACE_LEVEL_VERBOSE,FLAGS=OT_API}(CTX, MSG, ...);
 // end_wpp
 
 // ==NCP==
 
 // begin_wpp config
-// USEPREFIX (otLogCritNcp, "[%p]NCP%!SPACE!", CTX);
+// USEPREFIX (otLogCritNcp, "[%p]NCP%!SPACE!", &CTX);
 // otLogCritNcp{LEVEL=TRACE_LEVEL_ERROR,FLAGS=OT_NCP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogWarnNcp, "[%p]NCP%!SPACE!", CTX);
+// USEPREFIX (otLogWarnNcp, "[%p]NCP%!SPACE!", &CTX);
 // otLogWarnNcp{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_NCP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogInfoNcp, "[%p]NCP%!SPACE!", CTX);
+// USEPREFIX (otLogInfoNcp, "[%p]NCP%!SPACE!", &CTX);
 // otLogInfoNcp{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_NCP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogDebgNcp, "[%p]NCP%!SPACE!", CTX);
+// USEPREFIX (otLogDebgNcp, "[%p]NCP%!SPACE!", &CTX);
 // otLogDebgNcp{LEVEL=TRACE_LEVEL_VERBOSE,FLAGS=OT_NCP}(CTX, MSG, ...);
 // end_wpp
 
 // ==MESHCOP==
 
 // begin_wpp config
-// USEPREFIX (otLogCritMeshCoP, "[%p]MESHCOP%!SPACE!", CTX);
+// USEPREFIX (otLogCritMeshCoP, "[%p]MESHCOP%!SPACE!", &CTX);
 // otLogCritMeshCoP{LEVEL=TRACE_LEVEL_ERROR,FLAGS=OT_MESHCOP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogWarnMeshCoP, "[%p]MESHCOP%!SPACE!", CTX);
+// USEPREFIX (otLogWarnMeshCoP, "[%p]MESHCOP%!SPACE!", &CTX);
 // otLogWarnMeshCoP{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_MESHCOP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogInfoMeshCoP, "[%p]MESHCOP%!SPACE!", CTX);
+// USEPREFIX (otLogInfoMeshCoP, "[%p]MESHCOP%!SPACE!", &CTX);
 // otLogInfoMeshCoP{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_MESHCOP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogDebgMeshCoP, "[%p]MESHCOP%!SPACE!", CTX);
+// USEPREFIX (otLogDebgMeshCoP, "[%p]MESHCOP%!SPACE!", &CTX);
 // otLogDebgMeshCoP{LEVEL=TRACE_LEVEL_VERBOSE,FLAGS=OT_MESHCOP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogCertMeshCoP, "[%p]MESHCOP%!SPACE!", CTX);
+// USEPREFIX (otLogCertMeshCoP, "[%p]MESHCOP%!SPACE!", &CTX);
 // otLogCertMeshCoP{LEVEL=TRACE_LEVEL_VERBOSE,FLAGS=OT_MESHCOP}(CTX, MSG, ...);
 // end_wpp
 
 // ==MBEDTLS==
 
 // begin_wpp config
-// USEPREFIX (otLogCritMbedTls, "[%p]MBED%!SPACE!", CTX);
+// USEPREFIX (otLogCritMbedTls, "[%p]MBED%!SPACE!", &CTX);
 // otLogCritMbedTls{LEVEL=TRACE_LEVEL_ERROR,FLAGS=OT_MBEDTLS}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogWarnMbedTls, "[%p]MBED%!SPACE!", CTX);
+// USEPREFIX (otLogWarnMbedTls, "[%p]MBED%!SPACE!", &CTX);
 // otLogWarnMbedTls{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_MBEDTLS}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogInfoMbedTls, "[%p]MBED%!SPACE!", CTX);
+// USEPREFIX (otLogInfoMbedTls, "[%p]MBED%!SPACE!", &CTX);
 // otLogInfoMbedTls{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_MBEDTLS}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogDebgMbedTls, "[%p]MBED%!SPACE!", CTX);
+// USEPREFIX (otLogDebgMbedTls, "[%p]MBED%!SPACE!", &CTX);
 // otLogDebgMbedTls{LEVEL=TRACE_LEVEL_VERBOSE,FLAGS=OT_MBEDTLS}(CTX, MSG, ...);
 // end_wpp
 
 // ==MLE==
 
 // begin_wpp config
-// USEPREFIX (otLogCritMle, "[%p]MLE%!SPACE!", CTX);
+// USEPREFIX (otLogCritMle, "[%p]MLE%!SPACE!", &CTX);
 // otLogCritMle{LEVEL=TRACE_LEVEL_ERROR,FLAGS=OT_MLE}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogWarnMle, "[%p]MLE%!SPACE!", CTX);
+// USEPREFIX (otLogWarnMle, "[%p]MLE%!SPACE!", &CTX);
 // otLogWarnMle{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_MLE}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogWarnMleErr, "[%p]MLE%!SPACE!", CTX);
+// USEPREFIX (otLogWarnMleErr, "[%p]MLE%!SPACE!", &CTX);
 // otLogWarnMleErr{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_MLE}(CTX, EXP, MSG, ...);
 // USESUFFIX(otLogWarnMleErr, ", %!otError!", EXP);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogInfoMle, "[%p]MLE%!SPACE!", CTX);
+// USEPREFIX (otLogInfoMle, "[%p]MLE%!SPACE!", &CTX);
 // otLogInfoMle{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_MLE}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogDebgMle, "[%p]MLE%!SPACE!", CTX);
+// USEPREFIX (otLogDebgMle, "[%p]MLE%!SPACE!", &CTX);
 // otLogDebgMle{LEVEL=TRACE_LEVEL_VERBOSE,FLAGS=OT_MLE}(CTX, MSG, ...);
 // end_wpp
 
 // ==ARP==
 
 // begin_wpp config
-// USEPREFIX (otLogCritArp, "[%p]ARP%!SPACE!", CTX);
+// USEPREFIX (otLogCritArp, "[%p]ARP%!SPACE!", &CTX);
 // otLogCritArp{LEVEL=TRACE_LEVEL_ERROR,FLAGS=OT_ARP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogWarnArp, "[%p]ARP%!SPACE!", CTX);
+// USEPREFIX (otLogWarnArp, "[%p]ARP%!SPACE!", &CTX);
 // otLogWarnArp{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_ARP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogInfoArp, "[%p]ARP%!SPACE!", CTX);
+// USEPREFIX (otLogInfoArp, "[%p]ARP%!SPACE!", &CTX);
 // otLogInfoArp{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_ARP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogDebgArp, "[%p]ARP%!SPACE!", CTX);
+// USEPREFIX (otLogDebgArp, "[%p]ARP%!SPACE!", &CTX);
 // otLogDebgArp{LEVEL=TRACE_LEVEL_VERBOSE,FLAGS=OT_ARP}(CTX, MSG, ...);
 // end_wpp
 
 // ==NETD==
 
 // begin_wpp config
-// USEPREFIX (otLogCritNetData, "[%p]NETD%!SPACE!", CTX);
+// USEPREFIX (otLogCritNetData, "[%p]NETD%!SPACE!", &CTX);
 // otLogCritNetData{LEVEL=TRACE_LEVEL_ERROR,FLAGS=OT_NETD}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogWarnNetData, "[%p]NETD%!SPACE!", CTX);
+// USEPREFIX (otLogWarnNetData, "[%p]NETD%!SPACE!", &CTX);
 // otLogWarnNetData{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_NETD}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogInfoNetData, "[%p]NETD%!SPACE!", CTX);
+// USEPREFIX (otLogInfoNetData, "[%p]NETD%!SPACE!", &CTX);
 // otLogInfoNetData{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_NETD}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogDebgNetData, "[%p]NETD%!SPACE!", CTX);
+// USEPREFIX (otLogDebgNetData, "[%p]NETD%!SPACE!", &CTX);
 // otLogDebgNetData{LEVEL=TRACE_LEVEL_VERBOSE,FLAGS=OT_NETD}(CTX, MSG, ...);
 // end_wpp
 
 // ==ICMP==
 
 // begin_wpp config
-// USEPREFIX (otLogCritIcmp, "[%p]ICMP%!SPACE!", CTX);
+// USEPREFIX (otLogCritIcmp, "[%p]ICMP%!SPACE!", &CTX);
 // otLogCritIcmp{LEVEL=TRACE_LEVEL_ERROR,FLAGS=OT_ICMP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogWarnIcmp, "[%p]ICMP%!SPACE!", CTX);
+// USEPREFIX (otLogWarnIcmp, "[%p]ICMP%!SPACE!", &CTX);
 // otLogWarnIcmp{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_ICMP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogInfoIcmp, "[%p]ICMP%!SPACE!", CTX);
+// USEPREFIX (otLogInfoIcmp, "[%p]ICMP%!SPACE!", &CTX);
 // otLogInfoIcmp{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_ICMP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogDebgIcmp, "[%p]ICMP%!SPACE!", CTX);
+// USEPREFIX (otLogDebgIcmp, "[%p]ICMP%!SPACE!", &CTX);
 // otLogDebgIcmp{LEVEL=TRACE_LEVEL_VERBOSE,FLAGS=OT_ICMP}(CTX, MSG, ...);
 // end_wpp
 
 // ==IPV6==
 
 // begin_wpp config
-// USEPREFIX (otLogCritIp6, "[%p]IP6%!SPACE!", CTX);
+// USEPREFIX (otLogCritIp6, "[%p]IP6%!SPACE!", &CTX);
 // otLogCritIp6{LEVEL=TRACE_LEVEL_ERROR,FLAGS=OT_IPV6}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogWarnIp6, "[%p]IP6%!SPACE!", CTX);
+// USEPREFIX (otLogWarnIp6, "[%p]IP6%!SPACE!", &CTX);
 // otLogWarnIp6{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_IPV6}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogInfoIp6, "[%p]IP6%!SPACE!", CTX);
+// USEPREFIX (otLogInfoIp6, "[%p]IP6%!SPACE!", &CTX);
 // otLogInfoIp6{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_IPV6}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogDebgIp6, "[%p]IP6%!SPACE!", CTX);
+// USEPREFIX (otLogDebgIp6, "[%p]IP6%!SPACE!", &CTX);
 // otLogDebgIp6{LEVEL=TRACE_LEVEL_VERBOSE,FLAGS=OT_IPV6}(CTX, MSG, ...);
 // end_wpp
 
 // ==MAC==
 
 // begin_wpp config
-// USEPREFIX (otLogCritMac, "[%p]MAC%!SPACE!", CTX);
+// USEPREFIX (otLogCritMac, "[%p]MAC%!SPACE!", &CTX);
 // otLogCritMac{LEVEL=TRACE_LEVEL_ERROR,FLAGS=OT_MAC}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogWarnMac, "[%p]MAC%!SPACE!", CTX);
+// USEPREFIX (otLogWarnMac, "[%p]MAC%!SPACE!", &CTX);
 // otLogWarnMac{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_MAC}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogInfoMac, "[%p]MAC%!SPACE!", CTX);
+// USEPREFIX (otLogInfoMac, "[%p]MAC%!SPACE!", &CTX);
 // otLogInfoMac{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_MAC}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogDebgMac, "[%p]MAC%!SPACE!", CTX);
+// USEPREFIX (otLogDebgMac, "[%p]MAC%!SPACE!", &CTX);
 // otLogDebgMac{LEVEL=TRACE_LEVEL_VERBOSE,FLAGS=OT_MAC}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogDebgMacErr, "[%p]MAC%!SPACE!", CTX);
+// USEPREFIX (otLogDebgMacErr, "[%p]MAC%!SPACE!", &CTX);
 // otLogDebgMacErr{LEVEL=TRACE_LEVEL_VERBOSE,FLAGS=OT_MAC}(CTX, EXP, MSG, ...);
 // USESUFFIX(otLogDebgMacErr, ", %!otError!", EXP);
 // end_wpp
@@ -394,22 +394,22 @@
 // ==MEM==
 
 // begin_wpp config
-// USEPREFIX (otLogCritMem, "[%p]MEM%!SPACE!", CTX);
+// USEPREFIX (otLogCritMem, "[%p]MEM%!SPACE!", &CTX);
 // otLogCritMem{LEVEL=TRACE_LEVEL_ERROR,FLAGS=OT_MEM}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogWarnMem, "[%p]MEM%!SPACE!", CTX);
+// USEPREFIX (otLogWarnMem, "[%p]MEM%!SPACE!", &CTX);
 // otLogWarnMem{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_MEM}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogInfoMem, "[%p]MEM%!SPACE!", CTX);
+// USEPREFIX (otLogInfoMem, "[%p]MEM%!SPACE!", &CTX);
 // otLogInfoMem{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_MEM}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogDebgMem, "[%p]MEM%!SPACE!", CTX);
+// USEPREFIX (otLogDebgMem, "[%p]MEM%!SPACE!", &CTX);
 // otLogDebgMem{LEVEL=TRACE_LEVEL_VERBOSE,FLAGS=OT_MEM}(CTX, MSG, ...);
 // end_wpp
 
@@ -422,50 +422,50 @@
 // ==MEM==
 
 // begin_wpp config
-// USEPREFIX (otLogCritNetDiag, "[%p]NETD%!SPACE!", CTX);
+// USEPREFIX (otLogCritNetDiag, "[%p]NETD%!SPACE!", &CTX);
 // otLogCritNetDiag{LEVEL=TRACE_LEVEL_ERROR,FLAGS=OT_NDIAG}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogWarnNetDiag, "[%p]NETD%!SPACE!", CTX);
+// USEPREFIX (otLogWarnNetDiag, "[%p]NETD%!SPACE!", &CTX);
 // otLogWarnNetDiag{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_NDIAG}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogInfoNetDiag, "[%p]NETD%!SPACE!", CTX);
+// USEPREFIX (otLogInfoNetDiag, "[%p]NETD%!SPACE!", &CTX);
 // otLogInfoNetDiag{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_NDIAG}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogDebgNetDiag, "[%p]NETD%!SPACE!", CTX);
+// USEPREFIX (otLogDebgNetDiag, "[%p]NETD%!SPACE!", &CTX);
 // otLogDebgNetDiag{LEVEL=TRACE_LEVEL_VERBOSE,FLAGS=OT_NDIAG}(CTX, MSG, ...);
 // end_wpp
 
 // ==COAP==
 
 // begin_wpp config
-// USEPREFIX (otLogCritCoap, "[%p]COAP%!SPACE!", CTX);
+// USEPREFIX (otLogCritCoap, "[%p]COAP%!SPACE!", &CTX);
 // otLogCritCoap{LEVEL=TRACE_LEVEL_ERROR,FLAGS=OT_COAP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogWarnCoap, "[%p]COAP%!SPACE!", CTX);
+// USEPREFIX (otLogWarnCoap, "[%p]COAP%!SPACE!", &CTX);
 // otLogWarnCoap{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_COAP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogInfoCoap, "[%p]COAP%!SPACE!", CTX);
+// USEPREFIX (otLogInfoCoap, "[%p]COAP%!SPACE!", &CTX);
 // otLogInfoCoap{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_COAP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogInfoCoapErr, "[%p]COAP%!SPACE!", CTX);
+// USEPREFIX (otLogInfoCoapErr, "[%p]COAP%!SPACE!", &CTX);
 // otLogInfoCoapErr{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_COAP}(CTX, EXP, MSG, ...);
 // USESUFFIX(otLogInfoCoapErr, ", %!otError!", EXP);
 // end_wpp
 
 // begin_wpp config
-// USEPREFIX (otLogDebgCoap, "[%p]COAP%!SPACE!", CTX);
+// USEPREFIX (otLogDebgCoap, "[%p]COAP%!SPACE!", &CTX);
 // otLogDebgCoap{LEVEL=TRACE_LEVEL_VERBOSE,FLAGS=OT_COAP}(CTX, MSG, ...);
 // end_wpp
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -244,7 +244,7 @@ Interpreter::Interpreter(otInstance *aInstance):
     mLength(8),
     mCount(1),
     mInterval(1000),
-    mPingTimer(aInstance, &Interpreter::s_HandlePingTimer, this),
+    mPingTimer(*aInstance, &Interpreter::s_HandlePingTimer, this),
 #if OPENTHREAD_ENABLE_DNS_CLIENT
     mResolvingInProgress(0),
 #endif

--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -82,10 +82,11 @@ otInstance::otInstance(void) :
     mActiveScanCallbackContext(NULL),
     mEnergyScanCallback(NULL),
     mEnergyScanCallbackContext(NULL),
-    mTimerMilliScheduler(this),
+    mTimerMilliScheduler(*this),
 #if OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER
-    mTimerMicroScheduler(this),
+    mTimerMicroScheduler(*this),
 #endif
+    mIp6(*this),
     mThreadNetif(mIp6),
 #if OPENTHREAD_ENABLE_RAW_LINK_API
     mLinkRaw(*this),
@@ -96,7 +97,7 @@ otInstance::otInstance(void) :
 #if OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
     mLogLevel(static_cast<otLogLevel>(OPENTHREAD_CONFIG_LOG_LEVEL)),
 #endif // OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
-    mMessagePool(this)
+    mMessagePool(*this)
 {
 }
 
@@ -148,7 +149,7 @@ otInstance *otInstanceInit(void *aInstanceBuffer, size_t *aInstanceBufferSize)
     // Execute post constructor operations
     otInstancePostConstructor(instance);
 
-    otLogInfoApi(instance, "otInstance Initialized");
+    otLogInfoApi(*instance, "otInstance Initialized");
 
 exit:
 
@@ -179,7 +180,7 @@ otInstance *otInstanceInitSingle(void)
     // Execute post constructor operations
     otInstancePostConstructor(sInstance);
 
-    otLogInfoApi(sInstance, "otInstance Initialized");
+    otLogInfoApi(*sInstance, "otInstance Initialized");
 
 exit:
 

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -269,14 +269,14 @@ LinkRaw::LinkRaw(otInstance &aInstance):
     mTransmitDoneCallback(NULL),
     mEnergyScanDoneCallback(NULL)
 #if OPENTHREAD_LINKRAW_TIMER_REQUIRED
-    , mTimer(&aInstance, &LinkRaw::HandleTimer, this)
+    , mTimer(aInstance, &LinkRaw::HandleTimer, this)
     , mTimerReason(kTimerReasonNone)
 #if OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER
-    , mTimerMicro(&aInstance, &LinkRaw::HandleTimer, this)
+    , mTimerMicro(aInstance, &LinkRaw::HandleTimer, this)
 #endif
 #endif // OPENTHREAD_LINKRAW_TIMER_REQUIRED
 #if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ENERGY_SCAN
-    , mEnergyScanTask(&aInstance, &LinkRaw::HandleEnergyScanTask, this)
+    , mEnergyScanTask(aInstance, &LinkRaw::HandleEnergyScanTask, this)
 #endif // OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ENERGY_SCAN
 {
     // Query the capabilities to check asserts
@@ -386,7 +386,7 @@ otError LinkRaw::DoTransmit(otRadioFrame *aFrame)
 
 void LinkRaw::InvokeTransmitDone(otRadioFrame *aFrame, bool aFramePending, otError aError)
 {
-    otLogDebgPlat(aInstance, "LinkRaw Transmit Done (err=0x%x)", aError);
+    otLogDebgPlat(&mInstance, "LinkRaw Transmit Done (err=0x%x)", aError);
 
 #if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ACK_TIMEOUT
     mTimer.Stop();
@@ -427,11 +427,11 @@ void LinkRaw::InvokeTransmitDone(otRadioFrame *aFrame, bool aFramePending, otErr
     {
         if (aError == OT_ERROR_NONE)
         {
-            otLogInfoPlat(aInstance, "LinkRaw Invoke Transmit Done");
+            otLogInfoPlat(&mInstance, "LinkRaw Invoke Transmit Done");
         }
         else
         {
-            otLogWarnPlat(aInstance, "LinkRaw Invoke Transmit Failed (err=0x%x)", aError);
+            otLogWarnPlat(&mInstance, "LinkRaw Invoke Transmit Failed (err=0x%x)", aError);
         }
 
         mTransmitDoneCallback(&mInstance, aFrame, aFramePending, aError);
@@ -559,7 +559,7 @@ void LinkRaw::StartCsmaBackoff(void)
     backoff = (otPlatRandomGet() % (1UL << backoffExponent));
     backoff *= (static_cast<uint32_t>(Mac::kUnitBackoffPeriod) * OT_RADIO_SYMBOL_TIME);
 
-    otLogDebgPlat(aInstance, "LinkRaw Starting RetransmitTimeout Timer (%d ms)", backoff);
+    otLogDebgPlat(&mInstance, "LinkRaw Starting RetransmitTimeout Timer (%d ms)", backoff);
     mTimerReason = kTimerReasonRetransmitTimeout;
 
 #if OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -219,7 +219,7 @@ void CoapSecure::HandleDtlsReceive(uint8_t *aBuf, uint16_t aLength)
 
     otLogFuncEntry();
 
-    VerifyOrExit((message = GetInstance()->mMessagePool.New(Message::kTypeIp6, 0)) != NULL);
+    VerifyOrExit((message = GetInstance().mMessagePool.New(Message::kTypeIp6, 0)) != NULL);
     SuccessOrExit(message->Append(aBuf, aLength));
 
     Coap::Receive(*message, mPeerAddress);

--- a/src/core/common/locator.cpp
+++ b/src/core/common/locator.cpp
@@ -44,19 +44,19 @@ namespace ot {
 
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
 
-otInstance *ThreadNetifLocator::GetInstance(void) const
+otInstance &ThreadNetifLocator::GetInstance(void) const
 {
-    return otInstanceFromThreadNetif(&GetNetif());
+    return *otInstanceFromThreadNetif(&GetNetif());
 }
 
-otInstance *MeshForwarderLocator::GetInstance(void) const
+otInstance &MeshForwarderLocator::GetInstance(void) const
 {
-    return otInstanceFromThreadNetif(&GetMeshForwarder().GetNetif());
+    return *otInstanceFromThreadNetif(&GetMeshForwarder().GetNetif());
 }
 
-otInstance *Ip6Locator::GetInstance(void) const
+otInstance &Ip6Locator::GetInstance(void) const
 {
-    return otInstanceFromIp6(&GetIp6());
+    return *otInstanceFromIp6(&GetIp6());
 }
 
 #endif // #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES

--- a/src/core/common/locator.hpp
+++ b/src/core/common/locator.hpp
@@ -105,15 +105,15 @@ public:
 #endif
 
     /**
-     * This method returns the pointer to the parent otInstance structure.
+     * This method returns the reference to the parent otInstance structure.
      *
-     * @returns The pointer to the parent otInstance structure, or NULL if the instance has been finalized.
+     * @returns A reference to the parent otInstance structure.
      *
      */
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    otInstance *GetInstance(void) const;
+    otInstance &GetInstance(void) const;
 #else
-    otInstance *GetInstance(void) const { return otGetInstance(); }
+    otInstance &GetInstance(void) const { return *otGetInstance(); }
 #endif
 
 protected:
@@ -146,15 +146,15 @@ public:
 #endif
 
     /**
-     * This method returns the pointer to the parent otInstance structure.
+     * This method returns the reference to the parent otInstance structure.
      *
-     * @returns The pointer to the parent otInstance structure, or NULL if the instance has been finalized.
+     * @returns A reference to the parent otInstance structure.
      *
      */
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    otInstance *GetInstance(void) const;
+    otInstance &GetInstance(void) const;
 #else
-    otInstance *GetInstance(void) const { return otGetInstance(); }
+    otInstance &GetInstance(void) const { return *otGetInstance(); }
 #endif
 
 protected:
@@ -187,15 +187,15 @@ public:
 #endif
 
     /**
-     * This method returns the pointer to the parent otInstance structure.
+     * This method returns the reference to the parent otInstance structure.
      *
-     * @returns The pointer to the parent otInstance structure, or NULL if the instance has been finalized.
+     * @returns A reference to the parent otInstance structure.
      *
      */
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    otInstance *GetInstance(void) const;
+    otInstance &GetInstance(void) const;
 #else
-    otInstance *GetInstance(void) const { return otGetInstance(); }
+    otInstance &GetInstance(void) const { return *otGetInstance(); }
 #endif
 
 protected:
@@ -212,19 +212,19 @@ protected:
  * This class implements locator for  otInstance object
  *
  */
-class InstanceLocator
+class InstanceLocator: private Locator<otInstance>
 {
 public:
     /**
-     * This method returns the pointer to the parent otInstance structure.
+     * This method returns a reference to the parent otInstance structure.
      *
-     * @returns The pointer to the parent otInstance structure, or NULL if the instance has been finalized.
+     * @returns A reference to the parent otInstance structure.
      *
      */
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    otInstance *GetInstance(void) const { return mInstance; }
+    otInstance &GetInstance(void) const { return mLocatorObject; }
 #else
-    otInstance *GetInstance(void) const { return otGetInstance(); }
+    otInstance &GetInstance(void) const { return *otGetInstance(); }
 #endif
 
 protected:
@@ -234,18 +234,7 @@ protected:
      * @param[in]  aInstance  A pointer to the otInstance.
      *
      */
-    InstanceLocator(otInstance *aInstance)
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-        : mInstance(aInstance)
-#endif
-    {
-        OT_UNUSED_VARIABLE(aInstance);
-    }
-
-private:
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    otInstance *mInstance;
-#endif
+    InstanceLocator(otInstance &aInstance): Locator(aInstance) { }
 };
 
 /**

--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -73,9 +73,10 @@ extern "C" {
  *
  * Logging at log level critical.
  *
- * @param[in]  aRegion  The log region.
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance A pointer to the OpenThread instance.
+ * @param[in]  aRegion   The log region.
+ * @param[in]  aFormat   A pointer to the format string.
+ * @param[in]  ...       Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_CRIT
@@ -90,9 +91,10 @@ extern "C" {
  *
  * Logging at log level warning.
  *
- * @param[in]  aRegion  The log region.
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance A pointer to the OpenThread instance.
+ * @param[in]  aRegion   The log region.
+ * @param[in]  aFormat   A pointer to the format string.
+ * @param[in]  ...       Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
@@ -107,9 +109,10 @@ extern "C" {
  *
  * Logging at log level info.
  *
- * @param[in]  aRegion  The log region.
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance A pointer to the OpenThread instance.
+ * @param[in]  aRegion   The log region.
+ * @param[in]  aFormat   A pointer to the format string.
+ * @param[in]  ...       Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
@@ -124,9 +127,10 @@ extern "C" {
  *
  * Logging at log level debug.
  *
- * @param[in]  aRegion  The log region.
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance A pointer to the OpenThread instance.
+ * @param[in]  aRegion   The log region.
+ * @param[in]  aFormat   A pointer to the format string.
+ * @param[in]  ...       Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG
@@ -143,8 +147,9 @@ extern "C" {
  *
  * This method generates a log with level critical for the API region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -153,8 +158,9 @@ extern "C" {
  *
  * This method generates a log with level warning for the API region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -163,8 +169,9 @@ extern "C" {
  *
  * This method generates a log with level info for the API region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -173,15 +180,16 @@ extern "C" {
  *
  * This method generates a log with level debug for the API region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_API == 1
-#define otLogCritApi(aInstance, aFormat, ...) otLogCrit(aInstance, OT_LOG_REGION_API, aFormat, ## __VA_ARGS__)
-#define otLogWarnApi(aInstance, aFormat, ...) otLogWarn(aInstance, OT_LOG_REGION_API, aFormat, ## __VA_ARGS__)
-#define otLogInfoApi(aInstance, aFormat, ...) otLogInfo(aInstance, OT_LOG_REGION_API, aFormat, ## __VA_ARGS__)
-#define otLogDebgApi(aInstance, aFormat, ...) otLogDebg(aInstance, OT_LOG_REGION_API, aFormat, ## __VA_ARGS__)
+#define otLogCritApi(aInstance, aFormat, ...) otLogCrit(&aInstance, OT_LOG_REGION_API, aFormat, ## __VA_ARGS__)
+#define otLogWarnApi(aInstance, aFormat, ...) otLogWarn(&aInstance, OT_LOG_REGION_API, aFormat, ## __VA_ARGS__)
+#define otLogInfoApi(aInstance, aFormat, ...) otLogInfo(&aInstance, OT_LOG_REGION_API, aFormat, ## __VA_ARGS__)
+#define otLogDebgApi(aInstance, aFormat, ...) otLogDebg(&aInstance, OT_LOG_REGION_API, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCritApi(aInstance, aFormat, ...)
 #define otLogWarnApi(aInstance, aFormat, ...)
@@ -194,8 +202,10 @@ extern "C" {
  *
  * This method generates a log with level critical for the MLE region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
  *
  */
 
@@ -204,8 +214,9 @@ extern "C" {
  *
  * This method generates a log with level warning for the MLE region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -214,8 +225,9 @@ extern "C" {
  *
  * This method generates a log with level info for the MLE region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -224,15 +236,20 @@ extern "C" {
  *
  * This method generates a log with level debug for the MLE region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MLE == 1
-#define otLogCritMeshCoP(aInstance, aFormat, ...) otLogCrit(aInstance, OT_LOG_REGION_MESH_COP, aFormat, ## __VA_ARGS__)
-#define otLogWarnMeshCoP(aInstance, aFormat, ...) otLogWarn(aInstance, OT_LOG_REGION_MESH_COP, aFormat, ## __VA_ARGS__)
-#define otLogInfoMeshCoP(aInstance, aFormat, ...) otLogInfo(aInstance, OT_LOG_REGION_MESH_COP, aFormat, ## __VA_ARGS__)
-#define otLogDebgMeshCoP(aInstance, aFormat, ...) otLogDebg(aInstance, OT_LOG_REGION_MESH_COP, aFormat, ## __VA_ARGS__)
+#define otLogCritMeshCoP(aInstance, aFormat, ...)                        \
+    otLogCrit(&aInstance, OT_LOG_REGION_MESH_COP, aFormat, ## __VA_ARGS__)
+#define otLogWarnMeshCoP(aInstance, aFormat, ...)                        \
+    otLogWarn(&aInstance, OT_LOG_REGION_MESH_COP, aFormat, ## __VA_ARGS__)
+#define otLogInfoMeshCoP(aInstance, aFormat, ...)                        \
+    otLogInfo(&aInstance, OT_LOG_REGION_MESH_COP, aFormat, ## __VA_ARGS__)
+#define otLogDebgMeshCoP(aInstance, aFormat, ...)                        \
+    otLogDebg(&aInstance, OT_LOG_REGION_MESH_COP, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCritMeshCoP(aInstance, aFormat, ...)
 #define otLogWarnMeshCoP(aInstance, aFormat, ...)
@@ -250,8 +267,9 @@ extern "C" {
  *
  * This method generates a log with level critical for the MLE region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -260,9 +278,10 @@ extern "C" {
  *
  * This method generates a log with level warning for the MLE region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
- *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ * *
  */
 
 /**
@@ -270,9 +289,10 @@ extern "C" {
  *
  * This method generates a log with level info for the MLE region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
- *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ * *
  */
 
 /**
@@ -280,17 +300,19 @@ extern "C" {
  *
  * This method generates a log with level debug for the MLE region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MLE == 1
-#define otLogCritMle(aInstance, aFormat, ...) otLogCrit(aInstance, OT_LOG_REGION_MLE, aFormat, ## __VA_ARGS__)
-#define otLogWarnMle(aInstance, aFormat, ...) otLogWarn(aInstance, OT_LOG_REGION_MLE, aFormat, ## __VA_ARGS__)
+#define otLogCritMle(aInstance, aFormat, ...) otLogCrit(&aInstance, OT_LOG_REGION_MLE, aFormat, ## __VA_ARGS__)
+#define otLogWarnMle(aInstance, aFormat, ...) otLogWarn(&aInstance, OT_LOG_REGION_MLE, aFormat, ## __VA_ARGS__)
 #define otLogWarnMleErr(aInstance, aError, aFormat, ...)                    \
-    otLogWarn(aInstance, OT_LOG_REGION_MAC, "Error %s: " aFormat, otThreadErrorToString(aError), ## __VA_ARGS__)
-#define otLogInfoMle(aInstance, aFormat, ...) otLogInfo(aInstance, OT_LOG_REGION_MLE, aFormat, ## __VA_ARGS__)
-#define otLogDebgMle(aInstance, aFormat, ...) otLogDebg(aInstance, OT_LOG_REGION_MLE, aFormat, ## __VA_ARGS__)
+    otLogWarn(&aInstance, OT_LOG_REGION_MAC, "Error %s: " aFormat, otThreadErrorToString(aError), ## __VA_ARGS__)
+#define otLogInfoMle(aInstance, aFormat, ...) otLogInfo(&aInstance, OT_LOG_REGION_MLE, aFormat, ## __VA_ARGS__)
+#define otLogDebgMle(aInstance, aFormat, ...) otLogDebg(&aInstance, OT_LOG_REGION_MLE, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCritMle(aInstance, aFormat, ...)
 #define otLogWarnMle(aInstance, aFormat, ...)
@@ -304,8 +326,10 @@ extern "C" {
  *
  * This method generates a log with level critical for the EID-to-RLOC mapping region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
  *
  */
 
@@ -314,8 +338,9 @@ extern "C" {
  *
  * This method generates a log with level warning for the EID-to-RLOC mapping region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -324,8 +349,9 @@ extern "C" {
  *
  * This method generates a log with level info for the EID-to-RLOC mapping region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -334,15 +360,16 @@ extern "C" {
  *
  * This method generates a log with level debug for the EID-to-RLOC mapping region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_ARP == 1
-#define otLogCritArp(aInstance, aFormat, ...) otLogCrit(aInstance, OT_LOG_REGION_ARP, aFormat, ## __VA_ARGS__)
-#define otLogWarnArp(aInstance, aFormat, ...) otLogWarn(aInstance, OT_LOG_REGION_ARP, aFormat, ## __VA_ARGS__)
-#define otLogInfoArp(aInstance, aFormat, ...) otLogInfo(aInstance, OT_LOG_REGION_ARP, aFormat, ## __VA_ARGS__)
-#define otLogDebgArp(aInstance, aFormat, ...) otLogDebg(aInstance, OT_LOG_REGION_ARP, aFormat, ## __VA_ARGS__)
+#define otLogCritArp(aInstance, aFormat, ...) otLogCrit(&aInstance, OT_LOG_REGION_ARP, aFormat, ## __VA_ARGS__)
+#define otLogWarnArp(aInstance, aFormat, ...) otLogWarn(&aInstance, OT_LOG_REGION_ARP, aFormat, ## __VA_ARGS__)
+#define otLogInfoArp(aInstance, aFormat, ...) otLogInfo(&aInstance, OT_LOG_REGION_ARP, aFormat, ## __VA_ARGS__)
+#define otLogDebgArp(aInstance, aFormat, ...) otLogDebg(&aInstance, OT_LOG_REGION_ARP, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCritArp(aInstance, aFormat, ...)
 #define otLogWarnArp(aInstance, aFormat, ...)
@@ -355,8 +382,9 @@ extern "C" {
  *
  * This method generates a log with level critical for the Network Data region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -365,8 +393,9 @@ extern "C" {
  *
  * This method generates a log with level warning for the Network Data region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -375,8 +404,9 @@ extern "C" {
  *
  * This method generates a log with level info for the Network Data region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -385,15 +415,20 @@ extern "C" {
  *
  * This method generates a log with level debug for the Network Data region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_NETDATA == 1
-#define otLogCritNetData(aInstance, aFormat, ...) otLogCrit(aInstance, OT_LOG_REGION_NET_DATA, aFormat, ## __VA_ARGS__)
-#define otLogWarnNetData(aInstance, aFormat, ...) otLogWarn(aInstance, OT_LOG_REGION_NET_DATA, aFormat, ## __VA_ARGS__)
-#define otLogInfoNetData(aInstance, aFormat, ...) otLogInfo(aInstance, OT_LOG_REGION_NET_DATA, aFormat, ## __VA_ARGS__)
-#define otLogDebgNetData(aInstance, aFormat, ...) otLogDebg(aInstance, OT_LOG_REGION_NET_DATA, aFormat, ## __VA_ARGS__)
+#define otLogCritNetData(aInstance, aFormat, ...)                        \
+    otLogCrit(&aInstance, OT_LOG_REGION_NET_DATA, aFormat, ## __VA_ARGS__)
+#define otLogWarnNetData(aInstance, aFormat, ...)                        \
+    otLogWarn(&aInstance, OT_LOG_REGION_NET_DATA, aFormat, ## __VA_ARGS__)
+#define otLogInfoNetData(aInstance, aFormat, ...)                        \
+    otLogInfo(&aInstance, OT_LOG_REGION_NET_DATA, aFormat, ## __VA_ARGS__)
+#define otLogDebgNetData(aInstance, aFormat, ...)                        \
+    otLogDebg(&aInstance, OT_LOG_REGION_NET_DATA, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCritNetData(aInstance, aFormat, ...)
 #define otLogWarnNetData(aInstance, aFormat, ...)
@@ -406,8 +441,9 @@ extern "C" {
  *
  * This method generates a log with level critical for the ICMPv6 region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -416,8 +452,9 @@ extern "C" {
  *
  * This method generates a log with level warning for the ICMPv6 region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -426,8 +463,9 @@ extern "C" {
  *
  * This method generates a log with level info for the ICMPv6 region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -436,15 +474,16 @@ extern "C" {
  *
  * This method generates a log with level debug for the ICMPv6 region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_ICMP == 1
-#define otLogCritIcmp(aInstance, aFormat, ...) otLogCrit(aInstance, OT_LOG_REGION_ICMP, aFormat, ## __VA_ARGS__)
-#define otLogWarnIcmp(aInstance, aFormat, ...) otLogWarn(aInstance, OT_LOG_REGION_ICMP, aFormat, ## __VA_ARGS__)
-#define otLogInfoIcmp(aInstance, aFormat, ...) otLogInfo(aInstance, OT_LOG_REGION_ICMP, aFormat, ## __VA_ARGS__)
-#define otLogDebgIcmp(aInstance, aFormat, ...) otLogDebg(aInstance, OT_LOG_REGION_ICMP, aFormat, ## __VA_ARGS__)
+#define otLogCritIcmp(aInstance, aFormat, ...) otLogCrit(&aInstance, OT_LOG_REGION_ICMP, aFormat, ## __VA_ARGS__)
+#define otLogWarnIcmp(aInstance, aFormat, ...) otLogWarn(&aInstance, OT_LOG_REGION_ICMP, aFormat, ## __VA_ARGS__)
+#define otLogInfoIcmp(aInstance, aFormat, ...) otLogInfo(&aInstance, OT_LOG_REGION_ICMP, aFormat, ## __VA_ARGS__)
+#define otLogDebgIcmp(aInstance, aFormat, ...) otLogDebg(&aInstance, OT_LOG_REGION_ICMP, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCritIcmp(aInstance, aFormat, ...)
 #define otLogWarnIcmp(aInstance, aFormat, ...)
@@ -457,8 +496,9 @@ extern "C" {
  *
  * This method generates a log with level critical for the IPv6 region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -467,8 +507,9 @@ extern "C" {
  *
  * This method generates a log with level warning for the IPv6 region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -477,8 +518,9 @@ extern "C" {
  *
  * This method generates a log with level info for the IPv6 region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -487,15 +529,16 @@ extern "C" {
  *
  * This method generates a log with level debug for the IPv6 region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_IP6 == 1
-#define otLogCritIp6(aInstance, aFormat, ...) otLogCrit(aInstance, OT_LOG_REGION_IP6, aFormat, ## __VA_ARGS__)
-#define otLogWarnIp6(aInstance, aFormat, ...) otLogWarn(aInstance, OT_LOG_REGION_IP6, aFormat, ## __VA_ARGS__)
-#define otLogInfoIp6(aInstance, aFormat, ...) otLogInfo(aInstance, OT_LOG_REGION_IP6, aFormat, ## __VA_ARGS__)
-#define otLogDebgIp6(aInstance, aFormat, ...) otLogDebg(aInstance, OT_LOG_REGION_IP6, aFormat, ## __VA_ARGS__)
+#define otLogCritIp6(aInstance, aFormat, ...) otLogCrit(&aInstance, OT_LOG_REGION_IP6, aFormat, ## __VA_ARGS__)
+#define otLogWarnIp6(aInstance, aFormat, ...) otLogWarn(&aInstance, OT_LOG_REGION_IP6, aFormat, ## __VA_ARGS__)
+#define otLogInfoIp6(aInstance, aFormat, ...) otLogInfo(&aInstance, OT_LOG_REGION_IP6, aFormat, ## __VA_ARGS__)
+#define otLogDebgIp6(aInstance, aFormat, ...) otLogDebg(&aInstance, OT_LOG_REGION_IP6, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCritIp6(aInstance, aFormat, ...)
 #define otLogWarnIp6(aInstance, aFormat, ...)
@@ -508,9 +551,11 @@ extern "C" {
  *
  * This method generates a log with level critical for the MAC region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
+
  */
 
 /**
@@ -518,8 +563,9 @@ extern "C" {
  *
  * This method generates a log with level warning for the MAC region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -528,8 +574,9 @@ extern "C" {
  *
  * This method generates a log with level info for the MAC region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -538,16 +585,17 @@ extern "C" {
  *
  * This method generates a log with level debug for the MAC region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MAC == 1
-#define otLogCritMac(aInstance, aFormat, ...) otLogCrit(aInstance, OT_LOG_REGION_MAC, aFormat, ## __VA_ARGS__)
-#define otLogWarnMac(aInstance, aFormat, ...) otLogWarn(aInstance, OT_LOG_REGION_MAC, aFormat, ## __VA_ARGS__)
-#define otLogInfoMac(aInstance, aFormat, ...) otLogInfo(aInstance, OT_LOG_REGION_MAC, aFormat, ## __VA_ARGS__)
-#define otLogDebgMac(aInstance, aFormat, ...) otLogDebg(aInstance, OT_LOG_REGION_MAC, aFormat, ## __VA_ARGS__)
-#define otLogDebgMacErr(aInstance, aError, aFormat, ...)                    \
+#define otLogCritMac(aInstance, aFormat, ...) otLogCrit(&aInstance, OT_LOG_REGION_MAC, aFormat, ## __VA_ARGS__)
+#define otLogWarnMac(aInstance, aFormat, ...) otLogWarn(&aInstance, OT_LOG_REGION_MAC, aFormat, ## __VA_ARGS__)
+#define otLogInfoMac(aInstance, aFormat, ...) otLogInfo(&aInstance, OT_LOG_REGION_MAC, aFormat, ## __VA_ARGS__)
+#define otLogDebgMac(aInstance, aFormat, ...) otLogDebg(&aInstance, OT_LOG_REGION_MAC, aFormat, ## __VA_ARGS__)
+#define otLogDebgMacErr(aInstance, aError, aFormat, ...)                 \
     otLogWarn(aInstance, OT_LOG_REGION_MAC, "Error %s: " aFormat, otThreadErrorToString(aError), ## __VA_ARGS__)
 #else
 #define otLogCritMac(aInstance, aFormat, ...)
@@ -562,8 +610,10 @@ extern "C" {
  *
  * This method generates a log with level critical for the memory region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
  *
  */
 
@@ -572,8 +622,10 @@ extern "C" {
  *
  * This method generates a log with level warning for the memory region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
  *
  */
 
@@ -582,8 +634,9 @@ extern "C" {
  *
  * This method generates a log with level info for the memory region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -592,15 +645,16 @@ extern "C" {
  *
  * This method generates a log with level debug for the memory region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MEM == 1
-#define otLogCritMem(aInstance, aFormat, ...) otLogCrit(aInstance, OT_LOG_REGION_MEM, aFormat, ## __VA_ARGS__)
-#define otLogWarnMem(aInstance, aFormat, ...) otLogWarn(aInstance, OT_LOG_REGION_MEM, aFormat, ## __VA_ARGS__)
-#define otLogInfoMem(aInstance, aFormat, ...) otLogInfo(aInstance, OT_LOG_REGION_MEM, aFormat, ## __VA_ARGS__)
-#define otLogDebgMem(aInstance, aFormat, ...) otLogDebg(aInstance, OT_LOG_REGION_MEM, aFormat, ## __VA_ARGS__)
+#define otLogCritMem(aInstance, aFormat, ...) otLogCrit(&aInstance, OT_LOG_REGION_MEM, aFormat, ## __VA_ARGS__)
+#define otLogWarnMem(aInstance, aFormat, ...) otLogWarn(&aInstance, OT_LOG_REGION_MEM, aFormat, ## __VA_ARGS__)
+#define otLogInfoMem(aInstance, aFormat, ...) otLogInfo(&aInstance, OT_LOG_REGION_MEM, aFormat, ## __VA_ARGS__)
+#define otLogDebgMem(aInstance, aFormat, ...) otLogDebg(&aInstance, OT_LOG_REGION_MEM, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCritMem(aInstance, aFormat, ...)
 #define otLogWarnMem(aInstance, aFormat, ...)
@@ -613,8 +667,9 @@ extern "C" {
  *
  * This method generates a log with level critical for the NETDIAG region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -623,8 +678,9 @@ extern "C" {
  *
  * This method generates a log with level warning for the NETDIAG region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -633,8 +689,9 @@ extern "C" {
  *
  * This method generates a log with level info for the NETDIAG region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -643,15 +700,20 @@ extern "C" {
  *
  * This method generates a log with level debug for the NETDIAG region.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_NETDIAG == 1
-#define otLogCritNetDiag(aInstance, aFormat, ...) otLogCrit(aInstance, OT_LOG_REGION_NET_DIAG, aFormat, ## __VA_ARGS__)
-#define otLogWarnNetDiag(aInstance, aFormat, ...) otLogWarn(aInstance, OT_LOG_REGION_NET_DIAG, aFormat, ## __VA_ARGS__)
-#define otLogInfoNetDiag(aInstance, aFormat, ...) otLogInfo(aInstance, OT_LOG_REGION_NET_DIAG, aFormat, ## __VA_ARGS__)
-#define otLogDebgNetDiag(aInstance, aFormat, ...) otLogDebg(aInstance, OT_LOG_REGION_NET_DIAG, aFormat, ## __VA_ARGS__)
+#define otLogCritNetDiag(aInstance, aFormat, ...)                        \
+    otLogCrit(&aInstance, OT_LOG_REGION_NET_DIAG, aFormat, ## __VA_ARGS__)
+#define otLogWarnNetDiag(aInstance, aFormat, ...)                        \
+    otLogWarn(&aInstance, OT_LOG_REGION_NET_DIAG, aFormat, ## __VA_ARGS__)
+#define otLogInfoNetDiag(aInstance, aFormat, ...)                        \
+    otLogInfo(&aInstance, OT_LOG_REGION_NET_DIAG, aFormat, ## __VA_ARGS__)
+#define otLogDebgNetDiag(aInstance, aFormat, ...)                        \
+    otLogDebg(&aInstance, OT_LOG_REGION_NET_DIAG, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCritNetDiag(aInstance, aFormat, ...)
 #define otLogWarnNetDiag(aInstance, aFormat, ...)
@@ -664,15 +726,76 @@ extern "C" {
  *
  * This method generates a log with level none for the certification test.
  *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
  *
  */
 #if OPENTHREAD_ENABLE_CERT_LOG
-#define otLogCertMeshCoP(aInstance, aFormat, ...)                           \
-    _otLogFormatter(aInstance, OT_LOG_LEVEL_NONE, OT_LOG_REGION_MESH_COP, aFormat, ## __VA_ARGS__)
+#define otLogCertMeshCoP(aInstance, aFormat, ...)                        \
+    _otLogFormatter(&aInstance, OT_LOG_LEVEL_NONE, OT_LOG_REGION_MESH_COP, aFormat, ## __VA_ARGS__)
 #else
 #define otLogCertMeshCoP(aInstance, aFormat, ...)
+#endif
+
+
+/**
+ * @def otLogCritCoap
+ *
+ * This method generates a log with level critical for the CoAP region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogWarnCoap
+ *
+ * This method generates a log with level warning for the CoAP region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogInfoCoap
+ *
+ * This method generates a log with level info for the CoAP region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogDebgCoap
+ *
+ * This method generates a log with level debug for the CoAP region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+#if OPENTHREAD_CONFIG_LOG_COAP == 1
+#define otLogCritCoap(aInstance, aFormat, ...) otLogCrit(&aInstance, OT_LOG_REGION_COAP, aFormat, ## __VA_ARGS__)
+#define otLogWarnCoap(aInstance, aFormat, ...) otLogWarn(&aInstance, OT_LOG_REGION_COAP, aFormat, ## __VA_ARGS__)
+#define otLogInfoCoap(aInstance, aFormat, ...) otLogInfo(&aInstance, OT_LOG_REGION_COAP, aFormat, ## __VA_ARGS__)
+#define otLogInfoCoapErr(aInstance, aError, aFormat, ...)                \
+    otLogInfo(&aInstance, OT_LOG_REGION_COAP, "Error %s: " aFormat, otThreadErrorToString(aError), ## __VA_ARGS__)
+#define otLogDebgCoap(aInstance, aFormat, ...) otLogDebg(&aInstance, OT_LOG_REGION_COAP, aFormat, ## __VA_ARGS__)
+#else
+#define otLogCritCoap(aInstance, aFormat, ...)
+#define otLogWarnCoap(aInstance, aFormat, ...)
+#define otLogInfoCoap(aInstance, aFormat, ...)
+#define otLogInfoCoapErr(aInstance, aError, aFormat, ...)
+#define otLogDebgCoap(aInstance, aFormat, ...)
 #endif
 
 /**
@@ -680,8 +803,9 @@ extern "C" {
 *
 * This method generates a log with level critical for the Platform region.
 *
-* @param[in]  aFormat  A pointer to the format string.
-* @param[in]  ...      Arguments for the format specification.
+* @param[in]  aInstance A pointer to the OpenThread instance.
+* @param[in]  aFormat   A pointer to the format string.
+* @param[in]  ...       Arguments for the format specification.
 *
 */
 
@@ -690,8 +814,9 @@ extern "C" {
 *
 * This method generates a log with level warning for the Platform region.
 *
-* @param[in]  aFormat  A pointer to the format string.
-* @param[in]  ...      Arguments for the format specification.
+* @param[in]  aInstance A pointer to the OpenThread instance.
+* @param[in]  aFormat   A pointer to the format string.
+* @param[in]  ...       Arguments for the format specification.
 *
 */
 
@@ -700,8 +825,9 @@ extern "C" {
 *
 * This method generates a log with level info for the Platform region.
 *
-* @param[in]  aFormat  A pointer to the format string.
-* @param[in]  ...      Arguments for the format specification.
+* @param[in]  aInstance A pointer to the OpenThread instance.
+* @param[in]  aFormat   A pointer to the format string.
+* @param[in]  ...       Arguments for the format specification.
 *
 */
 
@@ -710,8 +836,9 @@ extern "C" {
 *
 * This method generates a log with level debug for the Platform region.
 *
-* @param[in]  aFormat  A pointer to the format string.
-* @param[in]  ...      Arguments for the format specification.
+* @param[in]  aInstance A pointer to the OpenThread instance.
+* @param[in]  aFormat   A pointer to the format string.
+* @param[in]  ...       Arguments for the format specification.
 *
 */
 #if OPENTHREAD_CONFIG_LOG_PLATFORM == 1
@@ -726,60 +853,6 @@ extern "C" {
 #define otLogDebgPlat(aInstance, aFormat, ...)
 #endif
 
-/**
- * @def otLogCritCoap
- *
- * This method generates a log with level critical for the CoAP region.
- *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
- *
- */
-
-/**
- * @def otLogWarnCoap
- *
- * This method generates a log with level warning for the CoAP region.
- *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
- *
- */
-
-/**
- * @def otLogInfoCoap
- *
- * This method generates a log with level info for the CoAP region.
- *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
- *
- */
-
-/**
- * @def otLogDebgCoap
- *
- * This method generates a log with level debug for the CoAP region.
- *
- * @param[in]  aFormat  A pointer to the format string.
- * @param[in]  ...      Arguments for the format specification.
- *
- */
-#if OPENTHREAD_CONFIG_LOG_COAP == 1
-#define otLogCritCoap(aInstance, aFormat, ...) otLogCrit(aInstance, OT_LOG_REGION_COAP, aFormat, ## __VA_ARGS__)
-#define otLogWarnCoap(aInstance, aFormat, ...) otLogWarn(aInstance, OT_LOG_REGION_COAP, aFormat, ## __VA_ARGS__)
-#define otLogInfoCoap(aInstance, aFormat, ...) otLogInfo(aInstance, OT_LOG_REGION_COAP, aFormat, ## __VA_ARGS__)
-#define otLogInfoCoapErr(aInstance, aError, aFormat, ...)               \
-    otLogInfo(aInstance, OT_LOG_REGION_COAP, "Error %s: " aFormat, otThreadErrorToString(aError), ## __VA_ARGS__)
-#define otLogDebgCoap(aInstance, aFormat, ...) otLogDebg(aInstance, OT_LOG_REGION_COAP, aFormat, ## __VA_ARGS__)
-#else
-#define otLogCritCoap(aInstance, aFormat, ...)
-#define otLogWarnCoap(aInstance, aFormat, ...)
-#define otLogInfoCoap(aInstance, aFormat, ...)
-#define otLogInfoCoapErr(aInstance, aError, aFormat, ...)
-#define otLogDebgCoap(aInstance, aFormat, ...)
-#endif
-
 #endif // WINDOWS_LOGGING
 
 /**
@@ -787,15 +860,16 @@ extern "C" {
  *
  * This method generates a memory dump with log level critical.
  *
- * @param[in]  aRegion  The log region.
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aRegion      The log region.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_CRIT
 #define otDumpCrit(aInstance, aRegion, aId, aBuf, aLength)                  \
-    otDump(aInstance, OT_LOG_LEVEL_CRIT, aRegion, aId, aBuf, aLength)
+    otDump(&aInstance, OT_LOG_LEVEL_CRIT, aRegion, aId, aBuf, aLength)
 #else
 #define otDumpCrit(aInstance, aRegion, aId, aBuf, aLength)
 #endif
@@ -805,15 +879,16 @@ extern "C" {
  *
  * This method generates a memory dump with log level warning.
  *
- * @param[in]  aRegion  The log region.
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aRegion      The log region.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
 #define otDumpWarn(aInstance, aRegion, aId, aBuf, aLength)                  \
-    otDump(aInstance, OT_LOG_LEVEL_WARN, aRegion, aId, aBuf, aLength)
+    otDump(&aInstance, OT_LOG_LEVEL_WARN, aRegion, aId, aBuf, aLength)
 #else
 #define otDumpWarn(aInstance, aRegion, aId, aBuf, aLength)
 #endif
@@ -823,15 +898,16 @@ extern "C" {
  *
  * This method generates a memory dump with log level info.
  *
- * @param[in]  aRegion  The log region.
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aRegion      The log region.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
 #define otDumpInfo(aInstance, aRegion, aId, aBuf, aLength)                  \
-    otDump(aInstance, OT_LOG_LEVEL_INFO, aRegion, aId, aBuf, aLength)
+    otDump(&aInstance, OT_LOG_LEVEL_INFO, aRegion, aId, aBuf, aLength)
 #else
 #define otDumpInfo(aInstance, aRegion, aId, aBuf, aLength)
 #endif
@@ -841,15 +917,16 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug.
  *
- * @param[in]  aRegion  The log region.
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aRegion      The log region.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG
 #define otDumpDebg(aInstance, aRegion, aId, aBuf, aLength)                  \
-    otDump(aInstance, OT_LOG_LEVEL_DEBG, aRegion, aId, aBuf, aLength)
+    otDump(&aInstance, OT_LOG_LEVEL_DEBG, aRegion, aId, aBuf, aLength)
 #else
 #define otDumpDebg(aInstance, aRegion, aId, aBuf, aLength)
 #endif
@@ -859,9 +936,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region Network Data.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -870,20 +948,19 @@ extern "C" {
  *
  * This method generates a memory dump with log level warning and region Network Data.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
 /**
  * @def otDumpInfoNetData
  *
- * This method generates a memory dump with log level info and region Network Data.
- *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -892,16 +969,21 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region Network Data.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_NETDATA == 1
-#define otDumpCritNetData(aInstance, aId, aBuf, aLength) otDumpCrit(aInstance, OT_LOG_REGION_NET_DATA, aId, aBuf, aLength)
-#define otDumpWarnNetData(aInstance, aId, aBuf, aLength) otDumpWarn(aInstance, OT_LOG_REGION_NET_DATA, aId, aBuf, aLength)
-#define otDumpInfoNetData(aInstance, aId, aBuf, aLength) otDumpInfo(aInstance, OT_LOG_REGION_NET_DATA, aId, aBuf, aLength)
-#define otDumpDebgNetData(aInstance, aId, aBuf, aLength) otDumpDebg(aInstance, OT_LOG_REGION_NET_DATA, aId, aBuf, aLength)
+#define otDumpCritNetData(aInstance, aId, aBuf, aLength)                 \
+    otDumpCrit(aInstance, OT_LOG_REGION_NET_DATA, aId, aBuf, aLength)
+#define otDumpWarnNetData(aInstance, aId, aBuf, aLength)                 \
+    otDumpWarn(aInstance, OT_LOG_REGION_NET_DATA, aId, aBuf, aLength)
+#define otDumpInfoNetData(aInstance, aId, aBuf, aLength)                 \
+    otDumpInfo(aInstance, OT_LOG_REGION_NET_DATA, aId, aBuf, aLength)
+#define otDumpDebgNetData(aInstance, aId, aBuf, aLength)                 \
+    otDumpDebg(aInstance, OT_LOG_REGION_NET_DATA, aId, aBuf, aLength)
 #else
 #define otDumpCritNetData(aInstance, aId, aBuf, aLength)
 #define otDumpWarnNetData(aInstance, aId, aBuf, aLength)
@@ -914,9 +996,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region MLE.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -925,9 +1008,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level warning and region MLE.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -936,9 +1020,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level info and region MLE.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -947,9 +1032,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region MLE.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MLE == 1
@@ -969,9 +1055,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region EID-to-RLOC mapping.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -980,9 +1067,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level warning and region EID-to-RLOC mapping.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -991,9 +1079,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level info and region EID-to-RLOC mapping.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -1002,9 +1091,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region EID-to-RLOC mapping.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_ARP == 1
@@ -1024,9 +1114,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region ICMPv6.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -1035,9 +1126,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level warning and region ICMPv6.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -1046,9 +1138,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level info and region ICMPv6.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -1057,16 +1150,21 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region ICMPv6.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_ICMP == 1
-#define otDumpCritIcmp(aInstance, aId, aBuf, aLength) otDumpCrit(aInstance, OT_LOG_REGION_ICMP, aId, aBuf, aLength)
-#define otDumpWarnIcmp(aInstance, aId, aBuf, aLength) otDumpWarn(aInstance, OT_LOG_REGION_ICMP, aId, aBuf, aLength)
-#define otDumpInfoIcmp(aInstance, aId, aBuf, aLength) otDumpInfo(aInstance, OT_LOG_REGION_ICMP, aId, aBuf, aLength)
-#define otDumpDebgIcmp(aInstance, aId, aBuf, aLength) otDumpDebg(aInstance, OT_LOG_REGION_ICMP, aId, aBuf, aLength)
+#define otDumpCritIcmp(aInstance, aId, aBuf, aLength)                    \
+    otDumpCrit(aInstance, OT_LOG_REGION_ICMP, aId, aBuf, aLength)
+#define otDumpWarnIcmp(aInstance, aId, aBuf, aLength)                    \
+    otDumpWarn(aInstance, OT_LOG_REGION_ICMP, aId, aBuf, aLength)
+#define otDumpInfoIcmp(aInstance, aId, aBuf, aLength)                    \
+    otDumpInfo(aInstance, OT_LOG_REGION_ICMP, aId, aBuf, aLength)
+#define otDumpDebgIcmp(aInstance, aId, aBuf, aLength)                    \
+    otDumpDebg(aInstance, OT_LOG_REGION_ICMP, aId, aBuf, aLength)
 #else
 #define otDumpCritIcmp(aInstance, aId, aBuf, aLength)
 #define otDumpWarnIcmp(aInstance, aId, aBuf, aLength)
@@ -1079,9 +1177,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region IPv6.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -1090,9 +1189,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level warning and region IPv6.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -1101,9 +1201,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level info and region IPv6.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -1112,9 +1213,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region IPv6.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_IP6 == 1
@@ -1134,9 +1236,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region MAC.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -1145,9 +1248,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level warning and region MAC.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -1156,9 +1260,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level info and region MAC.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -1167,9 +1272,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region MAC.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MAC == 1
@@ -1189,9 +1295,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region memory.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -1200,9 +1307,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level warning and region memory.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -1211,9 +1319,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level info and region memory.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 
@@ -1222,9 +1331,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region memory.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MEM == 1
@@ -1244,14 +1354,15 @@ extern "C" {
  *
  * This method generates a memory dump with log level none for the certification test.
  *
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
 #if OPENTHREAD_ENABLE_CERT_LOG
 #define otDumpCertMeshCoP(aInstance, aId, aBuf, aLength)                    \
-    otDump(aInstance, OT_LOG_LEVEL_NONE, OT_LOG_REGION_MESH_COP, aId, aBuf, aLength)
+    otDump(&aInstance, OT_LOG_LEVEL_NONE, OT_LOG_REGION_MESH_COP, aId, aBuf, aLength)
 #else
 #define otDumpCertMeshCoP(aInstance, aId, aBuf, aLength)
 #endif
@@ -1259,11 +1370,12 @@ extern "C" {
 /**
  * This method dumps bytes to the log in a human-readable fashion.
  *
- * @param[in]  aLevel   The log level.
- * @param[in]  aRegion  The log region.
- * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf     A pointer to the buffer.
- * @param[in]  aLength  Number of bytes to print.
+ * @param[in]  aInstance A pointer to the instance.
+ * @param[in]  aLevel    The log level.
+ * @param[in]  aRegion   The log region.
+ * @param[in]  aId       A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf      A pointer to the buffer.
+ * @param[in]  aLength   Number of bytes to print.
  *
  */
 void otDump(otInstance *aIntsance, otLogLevel aLevel, otLogRegion aRegion, const char *aId, const void *aBuf,
@@ -1350,7 +1462,7 @@ const char *otLogRegionToString(otLogRegion aRegion);
 /**
 * Local/private macro to format the log message
 */
-#define _otLogFormatter(aInstace, aLogLevel, aRegion, aFormat, ...)         \
+#define _otLogFormatter(aInstance, aLogLevel, aRegion, aFormat, ...)         \
     _otDynamicLog(                                                          \
         aInstance,                                                          \
         aLogLevel,                                                          \

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -44,13 +44,13 @@
 
 namespace ot {
 
-MessagePool::MessagePool(otInstance *aInstance) :
+MessagePool::MessagePool(otInstance &aInstance) :
     InstanceLocator(aInstance),
     mAllQueue()
 {
 #if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
     // Initialize Platform buffer pool management.
-    otPlatMessagePoolInit(GetInstance(), kNumBuffers, sizeof(Buffer));
+    otPlatMessagePoolInit(&GetInstance(), kNumBuffers, sizeof(Buffer));
 #else
     memset(mBuffers, 0, sizeof(mBuffers));
 
@@ -106,7 +106,7 @@ Buffer *MessagePool::NewBuffer(void)
 
 #if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
 
-    buffer = static_cast<Buffer *>(otPlatMessagePoolNew(GetInstance()));
+    buffer = static_cast<Buffer *>(otPlatMessagePoolNew(&GetInstance()));
 
 #else
 
@@ -136,7 +136,7 @@ otError MessagePool::FreeBuffers(Buffer *aBuffer)
     {
         tmpBuffer = aBuffer->GetNextBuffer();
 #if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
-        otPlatMessagePoolFree(GetInstance(), aBuffer);
+        otPlatMessagePoolFree(&GetInstance(), aBuffer);
 #else // OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
         aBuffer->SetNextBuffer(mFreeBuffers);
         mFreeBuffers = aBuffer;
@@ -153,7 +153,7 @@ otError MessagePool::ReclaimBuffers(int aNumBuffers)
     uint16_t numFreeBuffers;
 
 #if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
-    numFreeBuffers = otPlatMessagePoolNumFreeBuffers(GetInstance());
+    numFreeBuffers = otPlatMessagePoolNumFreeBuffers(&GetInstance());
 #else
     numFreeBuffers = mNumFreeBuffers;
 #endif

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -1107,7 +1107,7 @@ public:
      * This constructor initializes the object.
      *
      */
-    MessagePool(otInstance *aInstance);
+    MessagePool(otInstance &aInstance);
 
     /**
      * This method is used to obtain a new message. The default priority `kDefaultMessagePriority`
@@ -1157,7 +1157,7 @@ public:
      *
      */
 #if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
-    uint16_t GetFreeBufferCount(void) const { return otPlatMessagePoolNumFreeBuffers(GetInstance()); }
+    uint16_t GetFreeBufferCount(void) const { return otPlatMessagePoolNumFreeBuffers(&GetInstance()); }
 #else
     uint16_t GetFreeBufferCount(void) const { return mNumFreeBuffers; }
 #endif

--- a/src/core/common/tasklet.cpp
+++ b/src/core/common/tasklet.cpp
@@ -44,7 +44,7 @@
 
 namespace ot {
 
-Tasklet::Tasklet(otInstance *aInstance, Handler aHandler, void *aContext):
+Tasklet::Tasklet(otInstance &aInstance, Handler aHandler, void *aContext):
     InstanceLocator(aInstance),
     Context(aContext),
     mHandler(aHandler),
@@ -54,7 +54,7 @@ Tasklet::Tasklet(otInstance *aInstance, Handler aHandler, void *aContext):
 
 otError Tasklet::Post(void)
 {
-    return GetInstance()->mTaskletScheduler.Post(*this);
+    return GetInstance().mTaskletScheduler.Post(*this);
 }
 
 TaskletScheduler::TaskletScheduler(void):
@@ -73,7 +73,7 @@ otError TaskletScheduler::Post(Tasklet &aTasklet)
     {
         mHead = &aTasklet;
         mTail = &aTasklet;
-        otTaskletsSignalPending(aTasklet.GetInstance());
+        otTaskletsSignalPending(&aTasklet.GetInstance());
     }
     else
     {
@@ -118,7 +118,7 @@ void TaskletScheduler::ProcessQueuedTasklets(void)
         {
             if (mHead != NULL)
             {
-                otTaskletsSignalPending(mHead->GetInstance());
+                otTaskletsSignalPending(&mHead->GetInstance());
             }
 
             break;

--- a/src/core/common/tasklet.hpp
+++ b/src/core/common/tasklet.hpp
@@ -75,12 +75,12 @@ public:
     /**
      * This constructor creates a tasklet instance.
      *
-     * @param[in]  aInstance   A pointer to the instance object.
+     * @param[in]  aInstance   A reference to the instance object.
      * @param[in]  aHandler    A pointer to a function that is called when the tasklet is run.
      * @param[in]  aContext    A pointer to arbitrary context information.
      *
      */
-    Tasklet(otInstance *aInstance, Handler aHandler, void *aContext);
+    Tasklet(otInstance &aInstance, Handler aHandler, void *aContext);
 
     /**
      * This method puts the tasklet on the run queue.

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -89,7 +89,7 @@ void TimerMilli::Stop(void)
 
 TimerMilliScheduler &TimerMilli::GetTimerMilliScheduler(void) const
 {
-    return GetInstance()->mTimerMilliScheduler;
+    return GetInstance().mTimerMilliScheduler;
 }
 
 void TimerScheduler::Add(Timer &aTimer, const AlarmApi &aAlarmApi)
@@ -168,14 +168,14 @@ void TimerScheduler::SetAlarm(const AlarmApi &aAlarmApi)
 {
     if (mHead == NULL)
     {
-        aAlarmApi.AlarmStop(GetInstance());
+        aAlarmApi.AlarmStop(&GetInstance());
     }
     else
     {
         uint32_t now = aAlarmApi.AlarmGetNow();
         uint32_t remaining = IsStrictlyBefore(now, mHead->mFireTime) ? (mHead->mFireTime - now) : 0;
 
-        aAlarmApi.AlarmStartAt(GetInstance(), now, remaining);
+        aAlarmApi.AlarmStartAt(&GetInstance(), now, remaining);
     }
 }
 
@@ -246,7 +246,7 @@ void TimerMicro::Stop(void)
 
 TimerMicroScheduler &TimerMicro::GetTimerMicroScheduler(void) const
 {
-    return GetInstance()->mTimerMicroScheduler;
+    return GetInstance().mTimerMicroScheduler;
 }
 
 extern "C" void otPlatAlarmMicroFired(otInstance *aInstance)

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -86,12 +86,12 @@ public:
     /**
      * This constructor creates a timer instance.
      *
-     * @param[in]  aInstance   A pointer to the instance.
+     * @param[in]  aInstance   A reference to the instance.
      * @param[in]  aHandler    A pointer to a function that is called when the timer expires.
      * @param[in]  aContext    A pointer to arbitrary context information.
      *
      */
-    Timer(otInstance *aInstance, Handler aHandler, void *aContext):
+    Timer(otInstance &aInstance, Handler aHandler, void *aContext):
         InstanceLocator(aInstance),
         Context(aContext),
         mHandler(aHandler),
@@ -146,12 +146,12 @@ public:
     /**
      * This constructor creates a millisecond timer instance.
      *
-     * @param[in]  aInstance   A pointer to the instance.
+     * @param[in]  aInstance   A reference to the instance.
      * @param[in]  aHandler    A pointer to a function that is called when the timer expires.
      * @param[in]  aContext    A pointer to arbitrary context information.
      *
      */
-    TimerMilli(otInstance *aInstance, Handler aHandler, void *aContext):
+    TimerMilli(otInstance &aInstance, Handler aHandler, void *aContext):
         Timer(aInstance, aHandler, aContext) {
     }
 
@@ -238,10 +238,10 @@ protected:
     /**
      * This constructor initializes the object.
      *
-     * @param[in]  aInstance  A pointer to the instance object.
+     * @param[in]  aInstance  A reference to the instance object.
      *
      */
-    TimerScheduler(otInstance *aInstance):
+    TimerScheduler(otInstance &aInstance):
         InstanceLocator(aInstance),
         mHead(NULL) {
     }
@@ -308,10 +308,10 @@ public:
     /**
      * This constructor initializes the object.
      *
-     * @param[in]  aInstance  A pointer to the instance object.
+     * @param[in]  aInstance  A reference to the instance object.
      *
      */
-    TimerMilliScheduler(otInstance *aInstance):
+    TimerMilliScheduler(otInstance &aInstance):
         TimerScheduler(aInstance) {
     }
 
@@ -354,12 +354,12 @@ public:
     /**
      * This constructor creates a timer instance.
      *
-     * @param[in]  aInstance   A pointer to the instance object.
+     * @param[in]  aInstance   A reference to the instance object.
      * @param[in]  aHandler    A pointer to a function that is called when the timer expires.
      * @param[in]  aContext    A pointer to arbitrary context information.
      *
      */
-    TimerMicro(otInstance *aInstance, Handler aHandler, void *aContext):
+    TimerMicro(otInstance &aInstance, Handler aHandler, void *aContext):
         Timer(aInstance, aHandler, aContext) {
     }
 
@@ -416,10 +416,10 @@ public:
     /**
      * This constructor initializes the object.
      *
-     * @param[in]  aInstance  A pointer to the instance object.
+     * @param[in]  aInstance  A reference to the instance object.
      *
      */
-    TimerMicroScheduler(otInstance *aInstance):
+    TimerMicroScheduler(otInstance &aInstance):
         TimerScheduler(aInstance) {
     }
 

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -43,7 +43,7 @@
 namespace ot {
 
 TrickleTimer::TrickleTimer(
-    otInstance *aInstance,
+    otInstance &aInstance,
 #ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
     uint32_t aRedundancyConstant,
 #endif

--- a/src/core/common/trickle_timer.hpp
+++ b/src/core/common/trickle_timer.hpp
@@ -80,14 +80,14 @@ public:
     /**
      * This constructor creates a trickle timer instance.
      *
-     * @param[in]  aInstance                A pointer to the instance.
+     * @param[in]  aInstance                A reference to the instance.
      * @param[in]  aRedundancyConstant      The redundancy constant for the timer, k.
      * @param[in]  aTransmitHandler         A pointer to a function that is called when transmission should occur.
      * @param[in]  aIntervalExpiredHandler  An optional pointer to a function that is called when the interval expires.
      * @param[in]  aContext                 A pointer to arbitrary context information.
      *
      */
-    TrickleTimer(otInstance *aInstance,
+    TrickleTimer(otInstance &aInstance,
 #ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
                  uint32_t aRedundancyConstant,
 #endif

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -627,7 +627,7 @@ public:
      * @returns The noise floor value in dBm.
      *
      */
-    int8_t GetNoiseFloor(void) { return otPlatRadioGetReceiveSensitivity(GetInstance()); }
+    int8_t GetNoiseFloor(void) { return otPlatRadioGetReceiveSensitivity(&GetInstance()); }
 
     /**
      * This method indicates whether or not CSMA backoff is supported by the radio layer.

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -52,7 +52,7 @@
 namespace ot {
 namespace MeshCoP {
 
-DatasetLocal::DatasetLocal(otInstance *aInstance, const Tlv::Type aType) :
+DatasetLocal::DatasetLocal(otInstance &aInstance, const Tlv::Type aType) :
     InstanceLocator(aInstance),
     mUpdateTime(0),
     mType(aType)
@@ -61,12 +61,12 @@ DatasetLocal::DatasetLocal(otInstance *aInstance, const Tlv::Type aType) :
 
 void DatasetLocal::Clear(void)
 {
-    otPlatSettingsDelete(GetInstance(), GetSettingsKey(), -1);
+    otPlatSettingsDelete(&GetInstance(), GetSettingsKey(), -1);
 }
 
 bool DatasetLocal::IsPresent(void) const
 {
-    return otPlatSettingsGet(GetInstance(), GetSettingsKey(), 0, NULL, NULL) == OT_ERROR_NONE;
+    return otPlatSettingsGet(&GetInstance(), GetSettingsKey(), 0, NULL, NULL) == OT_ERROR_NONE;
 }
 
 otError DatasetLocal::Get(Dataset &aDataset)
@@ -76,7 +76,7 @@ otError DatasetLocal::Get(Dataset &aDataset)
     otError error;
 
     aDataset.mLength = sizeof(aDataset.mTlvs);
-    error = otPlatSettingsGet(GetInstance(), GetSettingsKey(), 0, aDataset.mTlvs, &aDataset.mLength);
+    error = otPlatSettingsGet(&GetInstance(), GetSettingsKey(), 0, aDataset.mTlvs, &aDataset.mLength);
     VerifyOrExit(error == OT_ERROR_NONE, aDataset.mLength = 0);
 
     delayTimer = static_cast<DelayTimerTlv *>(aDataset.Get(Tlv::kDelayTimer));
@@ -109,7 +109,7 @@ otError DatasetLocal::Get(otOperationalDataset &aDataset) const
     memset(&aDataset, 0, sizeof(aDataset));
 
     dataset.mLength = sizeof(dataset.mTlvs);
-    error = otPlatSettingsGet(GetInstance(), GetSettingsKey(), 0, dataset.mTlvs, &dataset.mLength);
+    error = otPlatSettingsGet(&GetInstance(), GetSettingsKey(), 0, dataset.mTlvs, &dataset.mLength);
     SuccessOrExit(error);
 
     cur = reinterpret_cast<const Tlv *>(dataset.mTlvs);
@@ -357,12 +357,12 @@ otError DatasetLocal::Set(const otOperationalDataset &aDataset)
 
     if (dataset.GetSize() == 0)
     {
-        error = otPlatSettingsDelete(GetInstance(), GetSettingsKey(), 0);
+        error = otPlatSettingsDelete(&GetInstance(), GetSettingsKey(), 0);
         otLogInfoMeshCoP(GetInstance(), "%s dataset deleted", mType == Tlv::kActiveTimestamp ? "Active" : "Pending");
     }
     else
     {
-        error = otPlatSettingsSet(GetInstance(), GetSettingsKey(), dataset.GetBytes(), dataset.GetSize());
+        error = otPlatSettingsSet(&GetInstance(), GetSettingsKey(), dataset.GetBytes(), dataset.GetSize());
         otLogInfoMeshCoP(GetInstance(), "%s dataset set", mType == Tlv::kActiveTimestamp ? "Active" : "Pending");
     }
 
@@ -385,12 +385,12 @@ otError DatasetLocal::Set(const Dataset &aDataset)
 
     if (dataset.GetSize() == 0)
     {
-        error = otPlatSettingsDelete(GetInstance(), GetSettingsKey(), 0);
+        error = otPlatSettingsDelete(&GetInstance(), GetSettingsKey(), 0);
         otLogInfoMeshCoP(GetInstance(), "%s dataset deleted", mType == Tlv::kActiveTimestamp ? "Active" : "Pending");
     }
     else
     {
-        error = otPlatSettingsSet(GetInstance(), GetSettingsKey(), dataset.GetBytes(), dataset.GetSize());
+        error = otPlatSettingsSet(&GetInstance(), GetSettingsKey(), dataset.GetBytes(), dataset.GetSize());
         otLogInfoMeshCoP(GetInstance(), "%s dataset set", mType == Tlv::kActiveTimestamp ? "Active" : "Pending");
     }
 

--- a/src/core/meshcop/dataset_local.hpp
+++ b/src/core/meshcop/dataset_local.hpp
@@ -48,11 +48,11 @@ public:
     /**
      * This constructor initializes the object.
      *
-     * @param[in]  aInstance  A pointer to an OpenThread instance.
+     * @param[in]  aInstance  A reference to an OpenThread instance.
      * @param[in]  aType      The type of the dataset, active or pending.
      *
      */
-    DatasetLocal(otInstance *aInstance, const Tlv::Type aType);
+    DatasetLocal(otInstance &aInstance, const Tlv::Type aType);
 
     /**
      * This method indicates whether this is an Active or Pending Dataset.

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -101,7 +101,7 @@ otError Dtls::Start(bool aClient, ConnectedHandler aConnectedHandler, ReceiveHan
 
     // mbedTLS's debug level is almost the same as OpenThread's
     mbedtls_debug_set_threshold(OPENTHREAD_CONFIG_LOG_LEVEL);
-    otPlatRadioGetIeeeEui64(GetInstance(), eui64.m8);
+    otPlatRadioGetIeeeEui64(&GetInstance(), eui64.m8);
     rval = mbedtls_ctr_drbg_seed(&mCtrDrbg, mbedtls_entropy_func, &mEntropy, eui64.m8, sizeof(eui64));
     VerifyOrExit(rval == 0);
 

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -695,7 +695,7 @@ otError Dhcp6Client::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
             address->mValidLifetime = option.GetValidLifetime();
             address->mAddress.mPreferred = address->mPreferredLifetime != 0;
             address->mAddress.mValid = address->mValidLifetime != 0;
-            otIp6AddUnicastAddress(GetNetif().GetInstance(), &address->mAddress);
+            otIp6AddUnicastAddress(&GetNetif().GetInstance(), &address->mAddress);
             break;
         }
     }

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -52,13 +52,14 @@
 namespace ot {
 namespace Ip6 {
 
-Ip6::Ip6(void):
+Ip6::Ip6(otInstance &aInstance):
+    InstanceLocator(aInstance),
     mRoutes(*this),
     mIcmp(*this),
     mUdp(*this),
     mMpl(*this),
     mForwardingEnabled(false),
-    mSendQueueTask(GetInstance(), HandleSendQueue, this),
+    mSendQueueTask(aInstance, HandleSendQueue, this),
     mReceiveIp6DatagramCallback(NULL),
     mReceiveIp6DatagramCallbackContext(NULL),
     mIsReceiveIp6FilterEnabled(false),
@@ -68,8 +69,8 @@ Ip6::Ip6(void):
 
 Message *Ip6::NewMessage(uint16_t aReserved)
 {
-    return GetInstance()->mMessagePool.New(Message::kTypeIp6,
-                                           sizeof(Header) + sizeof(HopByHopHeader) + sizeof(OptionMpl) + aReserved);
+    return GetInstance().mMessagePool.New(Message::kTypeIp6,
+                                          sizeof(Header) + sizeof(HopByHopHeader) + sizeof(OptionMpl) + aReserved);
 }
 
 uint16_t Ip6::UpdateChecksum(uint16_t aChecksum, const Address &aAddress)
@@ -1094,11 +1095,6 @@ int8_t Ip6::GetOnLinkNetif(const Address &aAddress)
 
 exit:
     return rval;
-}
-
-otInstance *Ip6::GetInstance(void)
-{
-    return otInstanceFromIp6(this);
 }
 
 Ip6 &Ip6::GetOwner(const Context &aContext)

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -40,6 +40,7 @@
 #include <openthread/udp.h>
 
 #include "common/encoding.hpp"
+#include "common/locator.hpp"
 #include "common/message.hpp"
 #include "net/icmp6.hpp"
 #include "net/ip6_address.hpp"
@@ -95,7 +96,7 @@ namespace Ip6 {
  * This class implements the core IPv6 message processing.
  *
  */
-class Ip6
+class Ip6 : public InstanceLocator
 {
 public:
     enum
@@ -116,8 +117,11 @@ public:
 
     /**
      * This constructor initializes the object.
+     *
+     * @param[in]  aInstance   A reference to the otInstance object.
+     *
      */
-    Ip6(void);
+    Ip6(otInstance &aInstance);
 
     /**
      * This method sends an IPv6 datagram.
@@ -319,14 +323,6 @@ public:
      *
      */
     int8_t GetOnLinkNetif(const Address &aAddress);
-
-    /**
-     * This method returns the pointer to the parent otInstance structure.
-     *
-     * @returns The pointer to the parent otInstance structure.
-     *
-     */
-    otInstance *GetInstance(void);
 
     /**
      * This method returns a reference to the send queue.

--- a/src/core/thread/data_poll_manager.cpp
+++ b/src/core/thread/data_poll_manager.cpp
@@ -108,7 +108,7 @@ otError DataPollManager::SendDataPoll(void)
         VerifyOrExit(message->GetType() != Message::kTypeMacDataPoll, error = OT_ERROR_ALREADY);
     }
 
-    message = meshForwarder.GetInstance()->mMessagePool.New(Message::kTypeMacDataPoll, 0);
+    message = GetInstance().mMessagePool.New(Message::kTypeMacDataPoll, 0);
     VerifyOrExit(message != NULL, error = OT_ERROR_NO_BUFS);
 
     error = meshForwarder.SendMessage(*message);

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1921,7 +1921,7 @@ void MeshForwarder::HandleMesh(uint8_t *aFrame, uint8_t aFrameLength, const Mac:
         meshHeader.SetHopsLeft(meshHeader.GetHopsLeft() - 1);
         meshHeader.AppendTo(aFrame);
 
-        VerifyOrExit((message = netif.GetInstance()->mMessagePool.New(Message::kType6lowpan, 0)) != NULL,
+        VerifyOrExit((message = GetInstance().mMessagePool.New(Message::kType6lowpan, 0)) != NULL,
                      error = OT_ERROR_NO_BUFS);
         SuccessOrExit(error = message->SetLength(aFrameLength));
         message->Write(0, aFrameLength, aFrame);
@@ -2009,7 +2009,7 @@ void MeshForwarder::HandleFragment(uint8_t *aFrame, uint8_t aFrameLength,
         aFrame += fragmentHeader->GetHeaderLength();
         aFrameLength -= fragmentHeader->GetHeaderLength();
 
-        VerifyOrExit((message = netif.GetInstance()->mMessagePool.New(Message::kTypeIp6, 0)) != NULL,
+        VerifyOrExit((message = GetInstance().mMessagePool.New(Message::kTypeIp6, 0)) != NULL,
                      error = OT_ERROR_NO_BUFS);
         message->SetLinkSecurityEnabled(aMessageInfo.mLinkSecurity);
         message->SetPanId(aMessageInfo.mPanId);
@@ -2190,7 +2190,7 @@ void MeshForwarder::HandleLowpanHC(uint8_t *aFrame, uint8_t aFrameLength,
     Message *message;
     int headerLength;
 
-    VerifyOrExit((message = netif.GetInstance()->mMessagePool.New(Message::kTypeIp6, 0)) != NULL,
+    VerifyOrExit((message = GetInstance().mMessagePool.New(Message::kTypeIp6, 0)) != NULL,
                  error = OT_ERROR_NO_BUFS);
     message->SetLinkSecurityEnabled(aMessageInfo.mLinkSecurity);
     message->SetPanId(aMessageInfo.mPanId);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -204,7 +204,7 @@ otError Mle::Start(bool aEnableReattach, bool aAnnounceAttach)
     otLogFuncEntry();
 
     // cannot bring up the interface if IEEE 802.15.4 promiscuous mode is enabled
-    VerifyOrExit(otPlatRadioGetPromiscuous(netif.GetInstance()) == false, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(otPlatRadioGetPromiscuous(&netif.GetInstance()) == false, error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(netif.IsUp(), error = OT_ERROR_INVALID_STATE);
 
     mRole = OT_DEVICE_ROLE_DETACHED;
@@ -278,7 +278,7 @@ otError Mle::Restore(void)
     netif.GetPendingDataset().Restore();
 
     length = sizeof(networkInfo);
-    SuccessOrExit(error = otPlatSettingsGet(netif.GetInstance(), Settings::kKeyNetworkInfo, 0,
+    SuccessOrExit(error = otPlatSettingsGet(&netif.GetInstance(), Settings::kKeyNetworkInfo, 0,
                                             reinterpret_cast<uint8_t *>(&networkInfo), &length));
     VerifyOrExit(length >= sizeof(networkInfo), error = OT_ERROR_NOT_FOUND);
 
@@ -305,7 +305,7 @@ otError Mle::Restore(void)
     if (!IsActiveRouter(networkInfo.mRloc16))
     {
         length = sizeof(parentInfo);
-        SuccessOrExit(error = otPlatSettingsGet(netif.GetInstance(), Settings::kKeyParentInfo, 0,
+        SuccessOrExit(error = otPlatSettingsGet(&netif.GetInstance(), Settings::kKeyParentInfo, 0,
                                                 reinterpret_cast<uint8_t *>(&parentInfo), &length));
         VerifyOrExit(length >= sizeof(parentInfo), error = OT_ERROR_PARSE);
 
@@ -374,7 +374,7 @@ otError Mle::Store(void)
             memset(&parentInfo, 0, sizeof(parentInfo));
             memcpy(&parentInfo.mExtAddress, &mParent.GetExtAddress(), sizeof(parentInfo.mExtAddress));
 
-            SuccessOrExit(error = otPlatSettingsSet(netif.GetInstance(), Settings::kKeyParentInfo,
+            SuccessOrExit(error = otPlatSettingsSet(&netif.GetInstance(), Settings::kKeyParentInfo,
                                                     reinterpret_cast<uint8_t *>(&parentInfo), sizeof(parentInfo)));
         }
     }
@@ -382,7 +382,7 @@ otError Mle::Store(void)
     {
         // when not attached, read out any existing values so that we do not change them
         uint16_t length = sizeof(networkInfo);
-        IgnoreReturnValue(otPlatSettingsGet(netif.GetInstance(), Settings::kKeyNetworkInfo, 0,
+        IgnoreReturnValue(otPlatSettingsGet(&netif.GetInstance(), Settings::kKeyNetworkInfo, 0,
                                             reinterpret_cast<uint8_t *>(&networkInfo), &length));
     }
 
@@ -393,7 +393,7 @@ otError Mle::Store(void)
     networkInfo.mMacFrameCounter = netif.GetKeyManager().GetMacFrameCounter() +
                                    OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD;
 
-    SuccessOrExit(error = otPlatSettingsSet(netif.GetInstance(), Settings::kKeyNetworkInfo,
+    SuccessOrExit(error = otPlatSettingsSet(&netif.GetInstance(), Settings::kKeyNetworkInfo,
                                             reinterpret_cast<uint8_t *>(&networkInfo), sizeof(networkInfo)));
 
     netif.GetKeyManager().SetStoredMleFrameCounter(networkInfo.mMleFrameCounter);
@@ -3109,7 +3109,7 @@ otError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::Message
                 Crc16 ansi(Crc16::kAnsi);
 
                 // Get Factory set EUI64
-                otPlatRadioGetIeeeEui64(GetInstance(), mfgEUI64.m8);
+                otPlatRadioGetIeeeEui64(&GetInstance(), mfgEUI64.m8);
 
                 // Compute bloom filter
                 for (size_t i = 0; i < sizeof(mfgEUI64.m8); i++)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3502,7 +3502,7 @@ otError MleRouter::RestoreChildren(void)
         uint16_t length;
 
         length = sizeof(childInfo);
-        SuccessOrExit(error = otPlatSettingsGet(GetInstance(), Settings::kKeyChildInfo, i,
+        SuccessOrExit(error = otPlatSettingsGet(&GetInstance(), Settings::kKeyChildInfo, i,
                                                 reinterpret_cast<uint8_t *>(&childInfo), &length));
         VerifyOrExit(length >= sizeof(childInfo), error = OT_ERROR_PARSE);
 
@@ -3531,13 +3531,13 @@ otError MleRouter::RemoveStoredChild(uint16_t aChildRloc16)
         Settings::ChildInfo childInfo;
         uint16_t length = sizeof(childInfo);
 
-        SuccessOrExit(error = otPlatSettingsGet(GetInstance(), Settings::kKeyChildInfo, i,
+        SuccessOrExit(error = otPlatSettingsGet(&GetInstance(), Settings::kKeyChildInfo, i,
                                                 reinterpret_cast<uint8_t *>(&childInfo), &length));
         VerifyOrExit(length == sizeof(childInfo), error = OT_ERROR_PARSE);
 
         if (childInfo.mRloc16 == aChildRloc16)
         {
-            error = otPlatSettingsDelete(GetNetif().GetInstance(), Settings::kKeyChildInfo, i);
+            error = otPlatSettingsDelete(&GetInstance(), Settings::kKeyChildInfo, i);
             ExitNow();
         }
     }
@@ -3563,7 +3563,7 @@ otError MleRouter::StoreChild(uint16_t aChildRloc16)
     childInfo.mRloc16  = child->GetRloc16();
     childInfo.mMode    = child->GetDeviceMode();
 
-    error = otPlatSettingsAdd(GetInstance(), Settings::kKeyChildInfo, reinterpret_cast<uint8_t *>(&childInfo),
+    error = otPlatSettingsAdd(&GetInstance(), Settings::kKeyChildInfo, reinterpret_cast<uint8_t *>(&childInfo),
                               sizeof(childInfo));
 
 exit:
@@ -3574,7 +3574,7 @@ otError MleRouter::RefreshStoredChildren(void)
 {
     otError error = OT_ERROR_NONE;
 
-    SuccessOrExit(error = otPlatSettingsDelete(GetInstance(), Settings::kKeyChildInfo, -1));
+    SuccessOrExit(error = otPlatSettingsDelete(&GetInstance(), Settings::kKeyChildInfo, -1));
 
     for (uint8_t i = 0; i < kMaxChildren; i++)
     {

--- a/src/core/thread/src_match_controller.cpp
+++ b/src/core/thread/src_match_controller.cpp
@@ -109,15 +109,15 @@ exit:
 
 void SourceMatchController::ClearTable(void)
 {
-    otPlatRadioClearSrcMatchShortEntries(GetInstance());
-    otPlatRadioClearSrcMatchExtEntries(GetInstance());
+    otPlatRadioClearSrcMatchShortEntries(&GetInstance());
+    otPlatRadioClearSrcMatchExtEntries(&GetInstance());
     otLogDebgMac(GetInstance(), "SrcAddrMatch - Cleared all entries");
 }
 
 void SourceMatchController::Enable(bool aEnable)
 {
     mEnabled = aEnable;
-    otPlatRadioEnableSrcMatch(GetInstance(), mEnabled);
+    otPlatRadioEnableSrcMatch(&GetInstance(), mEnabled);
     otLogDebgMac(GetInstance(), "SrcAddrMatch - %sabling", mEnabled ? "En" : "Dis");
 }
 
@@ -146,7 +146,7 @@ otError SourceMatchController::AddAddress(const Child &aChild)
 
     if (aChild.IsIndirectSourceMatchShort())
     {
-        error = otPlatRadioAddSrcMatchShortEntry(GetInstance(), aChild.GetRloc16());
+        error = otPlatRadioAddSrcMatchShortEntry(&GetInstance(), aChild.GetRloc16());
 
         otLogDebgMac(GetInstance(), "SrcAddrMatch - Adding short addr: 0x%04x -- %s (%d)",
                      aChild.GetRloc16(), otThreadErrorToString(error), error);
@@ -160,7 +160,7 @@ otError SourceMatchController::AddAddress(const Child &aChild)
             addr[i] = aChild.GetExtAddress().m8[sizeof(addr) - 1 - i];
         }
 
-        error = otPlatRadioAddSrcMatchExtEntry(GetInstance(), addr);
+        error = otPlatRadioAddSrcMatchExtEntry(&GetInstance(), addr);
 
         otLogDebgMac(GetInstance(), "SrcAddrMatch - Adding addr: %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x -- %s (%d)",
                      addr[7], addr[6], addr[5], addr[4], addr[3], addr[2], addr[1], addr[0],
@@ -183,7 +183,7 @@ void SourceMatchController::ClearEntry(Child &aChild)
 
     if (aChild.IsIndirectSourceMatchShort())
     {
-        error = otPlatRadioClearSrcMatchShortEntry(GetInstance(), aChild.GetRloc16());
+        error = otPlatRadioClearSrcMatchShortEntry(&GetInstance(), aChild.GetRloc16());
 
         otLogDebgMac(GetInstance(), "SrcAddrMatch - Clearing short address: 0x%04x -- %s (%d)",
                      aChild.GetRloc16(), otThreadErrorToString(error), error);
@@ -197,7 +197,7 @@ void SourceMatchController::ClearEntry(Child &aChild)
             addr[i] = aChild.GetExtAddress().m8[sizeof(aChild.GetExtAddress()) - 1 - i];
         }
 
-        error = otPlatRadioClearSrcMatchExtEntry(GetInstance(), addr);
+        error = otPlatRadioClearSrcMatchExtEntry(&GetInstance(), addr);
 
         otLogDebgMac(GetInstance(), "SrcAddrMatch - Clearing addr: %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x -- %s (%d)",
                      addr[7], addr[6], addr[5], addr[4], addr[3], addr[2], addr[1], addr[0],

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -104,7 +104,7 @@ void ChildSupervisor::SendMessage(Child &aChild)
 
     VerifyOrExit(aChild.GetIndirectMessageCount() == 0);
 
-    message = netif.GetInstance()->mMessagePool.New(Message::kTypeSupervision, sizeof(uint8_t));
+    message = netif.GetInstance().mMessagePool.New(Message::kTypeSupervision, sizeof(uint8_t));
     VerifyOrExit(message != NULL);
 
     // Supervision message is an empty payload 15.4 data frame.

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -148,7 +148,7 @@ void JamDetector::HandleTimer(void)
 
     VerifyOrExit(mEnabled);
 
-    rssi = otPlatRadioGetRssi(GetNetif().GetInstance());
+    rssi = otPlatRadioGetRssi(&GetInstance());
 
     // If the RSSI is valid, check if it exceeds the threshold
     // and try to update the history bit map

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -669,7 +669,7 @@ NcpBase::NcpBase(otInstance *aInstance):
     mDiscoveryScanJoinerFlag(false),
     mDiscoveryScanEnableFiltering(false),
     mDiscoveryScanPanId(0xffff),
-    mUpdateChangedPropsTask(aInstance, &NcpBase::UpdateChangedProps, this),
+    mUpdateChangedPropsTask(*aInstance, &NcpBase::UpdateChangedProps, this),
     mThreadChangedFlags(0),
     mChangedPropsSet(),
     mHostPowerState(SPINEL_HOST_POWER_STATE_ONLINE),

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -105,7 +105,7 @@ NcpSpi::NcpSpi(otInstance *aInstance) :
     mTxState(kTxStateIdle),
     mHandlingRxFrame(false),
     mResetFlag(true),
-    mPrepareTxFrameTask(aInstance, &NcpSpi::PrepareTxFrame, this),
+    mPrepareTxFrameTask(*aInstance, &NcpSpi::PrepareTxFrame, this),
     mSendFrameLen(0)
 {
     memset(mSendFrame, 0, kSpiHeaderLength);

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -98,7 +98,7 @@ NcpUart::NcpUart(otInstance *aInstance):
     mUartBuffer(),
     mState(kStartingFrame),
     mByte(0),
-    mUartSendTask(aInstance, EncodeAndSendToUart, this)
+    mUartSendTask(*aInstance, EncodeAndSendToUart, this)
 {
     mTxFrameBuffer.SetFrameAddedCallback(HandleFrameAddedToNcpBuffer, this);
 

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -82,19 +82,19 @@ otInstance *testInitInstance(void)
     otInstance *instance = NULL;
 
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    size_t instaneBufferLength = 0;
+    size_t instanceBufferLength = 0;
     uint8_t *instanceBuffer = NULL;
 
     // Call to query the buffer size
-    (void)otInstanceInit(NULL, &instaneBufferLength);
+    (void)otInstanceInit(NULL, &instanceBufferLength);
 
     // Call to allocate the buffer
-    instanceBuffer = (uint8_t *)malloc(instaneBufferLength);
+    instanceBuffer = (uint8_t *)malloc(instanceBufferLength);
     VerifyOrQuit(instanceBuffer != NULL, "Failed to allocate otInstance");
-    memset(instanceBuffer, 0, instaneBufferLength);
+    memset(instanceBuffer, 0, instanceBufferLength);
 
     // Initialize OpenThread with the buffer
-    instance = otInstanceInit(instanceBuffer, &instaneBufferLength);
+    instance = otInstanceInit(instanceBuffer, &instanceBufferLength);
 #else
     instance = otInstanceInitSingle();
 #endif

--- a/tests/unit/test_timer.cpp
+++ b/tests/unit/test_timer.cpp
@@ -85,7 +85,7 @@ void InitCounters(void)
 class TestTimer: public ot::TimerMilli
 {
 public:
-    TestTimer(otInstance *aInstance):
+    TestTimer(otInstance &aInstance):
         ot::TimerMilli(aInstance, TestTimer::HandleTimerFired, NULL),
         mFiredCounter(0)
     { }
@@ -115,7 +115,7 @@ int TestOneTimer(void)
     const uint32_t kTimeT0 = 1000;
     const uint32_t kTimerInterval = 10;
     otInstance *instance = testInitInstance();
-    TestTimer timer(instance);
+    TestTimer timer(*instance);
 
     // Test one Timer basic operation.
 
@@ -241,8 +241,8 @@ int TestTwoTimers(void)
     const uint32_t kTimeT0 = 1000;
     const uint32_t kTimerInterval = 10;
     otInstance *instance = testInitInstance();
-    TestTimer timer1(instance);
-    TestTimer timer2(instance);
+    TestTimer timer1(*instance);
+    TestTimer timer2(*instance);
 
     InitTestTimer();
     printf("TestTwoTimers() ");
@@ -526,16 +526,16 @@ static void TenTimers(uint32_t aTimeShift)
 
     otInstance *instance = testInitInstance();
 
-    TestTimer timer0(instance);
-    TestTimer timer1(instance);
-    TestTimer timer2(instance);
-    TestTimer timer3(instance);
-    TestTimer timer4(instance);
-    TestTimer timer5(instance);
-    TestTimer timer6(instance);
-    TestTimer timer7(instance);
-    TestTimer timer8(instance);
-    TestTimer timer9(instance);
+    TestTimer timer0(*instance);
+    TestTimer timer1(*instance);
+    TestTimer timer2(*instance);
+    TestTimer timer3(*instance);
+    TestTimer timer4(*instance);
+    TestTimer timer5(*instance);
+    TestTimer timer6(*instance);
+    TestTimer timer7(*instance);
+    TestTimer timer8(*instance);
+    TestTimer timer9(*instance);
     TestTimer *timers[kNumTimers] =
     {
         &timer0,


### PR DESCRIPTION
This commit changes the `InstanceLocator` class to keep track of a
reference to `otInstance` (instead of a pointer) to make it behave
similar to other `ObjectLocator` classes. The method `GetInstance()`
in all locator objects is updated to provide a reference (instead
of a pointer) to `otInstance`.

The logging macros are updated such that a reference to `otInstance`
is passed as  first argument (with the exception of
`otLog<Level>Plat()` macros which are used by platform code in C
domain). The documentation for log macros are also updated.