### PR TITLE
[mle] remove and add the multicast addresses when mesh-local prefix changes

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -137,7 +137,6 @@ Mle::Mle(ThreadNetif &aThreadNetif) :
     mMeshLocal64.mValid = true;
     mMeshLocal64.mScopeOverride = Ip6::Address::kRealmLocalScope;
     mMeshLocal64.mScopeOverrideValid = true;
-    SetMeshLocalPrefix(meshLocalPrefix); // Also calls AddUnicastAddress
 
     // mesh-local 16
     mMeshLocal16.GetAddress().mFields.m16[4] = HostSwap16(0x0000);
@@ -157,13 +156,16 @@ Mle::Mle(ThreadNetif &aThreadNetif) :
     mLinkLocalAllThreadNodes.GetAddress().mFields.m16[0] = HostSwap16(0xff32);
     mLinkLocalAllThreadNodes.GetAddress().mFields.m16[6] = HostSwap16(0x0000);
     mLinkLocalAllThreadNodes.GetAddress().mFields.m16[7] = HostSwap16(0x0001);
-    aThreadNetif.SubscribeMulticast(mLinkLocalAllThreadNodes);
 
     // realm-local all thread nodes
     mRealmLocalAllThreadNodes.GetAddress().mFields.m16[0] = HostSwap16(0xff33);
     mRealmLocalAllThreadNodes.GetAddress().mFields.m16[6] = HostSwap16(0x0000);
     mRealmLocalAllThreadNodes.GetAddress().mFields.m16[7] = HostSwap16(0x0001);
-    aThreadNetif.SubscribeMulticast(mRealmLocalAllThreadNodes);
+
+    SetMeshLocalPrefix(meshLocalPrefix);
+
+    // `SetMeshLocalPrefix()` also adds the Mesh-Local EID and subscribes
+    // to the Link- and Realm-Local All Thread Nodes multicast addresses.
 
     mNetifCallback.Set(&Mle::HandleNetifStateChanged, this);
     aThreadNetif.RegisterCallback(mNetifCallback);
@@ -719,9 +721,11 @@ otError Mle::SetMeshLocalPrefix(const uint8_t *aMeshLocalPrefix)
         ExitNow();
     }
 
-    // We must remove the old address before adding the new one.
+    // We must remove the old addresses before adding the new ones.
     netif.RemoveUnicastAddress(mMeshLocal64);
     netif.RemoveUnicastAddress(mMeshLocal16);
+    netif.UnsubscribeMulticast(mLinkLocalAllThreadNodes);
+    netif.UnsubscribeMulticast(mRealmLocalAllThreadNodes);
 
     memcpy(mMeshLocal64.GetAddress().mFields.m8, aMeshLocalPrefix, 8);
     memcpy(mMeshLocal16.GetAddress().mFields.m8, mMeshLocal64.GetAddress().mFields.m8, 8);
@@ -732,8 +736,10 @@ otError Mle::SetMeshLocalPrefix(const uint8_t *aMeshLocalPrefix)
     mRealmLocalAllThreadNodes.GetAddress().mFields.m8[3] = 64;
     memcpy(mRealmLocalAllThreadNodes.GetAddress().mFields.m8 + 4, mMeshLocal64.GetAddress().mFields.m8, 8);
 
-    // Add the address back into the table.
+    // Add the addresses back into the table.
     netif.AddUnicastAddress(mMeshLocal64);
+    netif.SubscribeMulticast(mLinkLocalAllThreadNodes);
+    netif.SubscribeMulticast(mRealmLocalAllThreadNodes);
 
     if (mRole >= OT_DEVICE_ROLE_CHILD)
     {


### PR DESCRIPTION
This commit changes how the link-local and the realm-local all-thread
multicast addresses are maintained. A change in mesh-local prefix
triggers a re-calculation of multicast addresses. When such a change
happens the old addresses are first removed/unsubscribed from the
interface and then the new ones are subscribed to. This ensures that
`OT_CHANGED_IP6_MULTICAST_(UN)SUBSRCRIBED` flags are set properly and
host/user is informed of the change of the multicast addresses.