### PR TITLE
[mac] change tx state behavior

### DIFF
--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -661,10 +661,11 @@ private:
     };
 
     void GenerateNonce(const ExtAddress &aAddress, uint32_t aFrameCounter, uint8_t aSecurityLevel, uint8_t *aNonce);
-    void NextOperation(void);
     void ProcessTransmitSecurity(Frame &aFrame);
     otError ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, Neighbor *aNeighbor);
-    void ScheduleNextTransmission(void);
+    void PutRadioInIdleMode(void);
+    void StartOperation(void);
+    void FinishOperation(void);
     void SentFrame(otError aError);
     void SendBeaconRequest(Frame &aFrame);
     void SendBeacon(Frame &aFrame);
@@ -712,13 +713,13 @@ private:
 
     enum
     {
-        kStateIdle = 0,
-        kStateActiveScan,
-        kStateEnergyScan,
-        kStateTransmitBeacon,
-        kStateTransmitData,
+        kOperationNone = 0,
+        kOperationActiveScan,
+        kOperationEnergyScan,
+        kOperationTransmitBeacon,
+        kOperationTransmitData,
     };
-    uint8_t mState;
+    uint8_t mOperation;
 
     uint8_t mBeaconSequence;
     uint8_t mDataSequence;


### PR DESCRIPTION
This commit changes how the `Mac::mState` behaves. It tracks the
current active tx related operation (e.g., active/energy scan,  beacon
tx or data tx). The state can be changed to a non-idle state  from
`ShceduleNextTransmission()` and is set back to `kStateIdle` when  the
operation is finished (e.g, when scan finished). The change in
`ScheduleNextTransmission()` ensures that next operation is not
scheduled until the current one is finished.