### PR TITLE
[radio] remove deprecated transmit done api

### DIFF
--- a/examples/platforms/cc2650/openthread-core-cc2650-config.h
+++ b/examples/platforms/cc2650/openthread-core-cc2650-config.h
@@ -36,13 +36,5 @@
  */
 #define OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS 32
 
-/**
-  * @def OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE
-  *
-  * Define to 1 if you want use legacy transmit done.
-  *
-  */
-#define OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE 1
-
 #endif /* OPENTHREAD_CORE_CC2650_CONFIG_H_ */
 

--- a/examples/platforms/cc2650/radio.c
+++ b/examples/platforms/cc2650/radio.c
@@ -51,6 +51,7 @@
 
 enum
 {
+    IEEE802154_ACK_LENGTH = 5,
     CC2650_RECEIVE_SENSITIVITY = -100,  // dBm
 };
 
@@ -1840,7 +1841,23 @@ void cc2650RadioProcess(otInstance *aInstance)
         else
 #endif /* OPENTHREAD_ENABLE_DIAG */
         {
-            otPlatRadioTransmitDone(aInstance, &sTransmitFrame, sReceivedAckPendingBit, sTransmitError);
+            // TODO: pass received ACK frame instead of generating one.
+            otRadioFrame ackFrame;
+            uint8_t psdu[IEEE802154_ACK_LENGTH];
+
+            ackFrame.mPsdu = psdu;
+            ackFrame.mLength = IEEE802154_ACK_LENGTH;
+            ackFrame.mPsdu[0] = IEEE802154_FRAME_TYPE_ACK;
+
+            if (sReceivedAckPendingBit)
+            {
+                ackFrame.mPsdu[0] |= IEEE802154_FRAME_PENDING;
+            }
+
+            ackFrame.mPsdu[1] = 0;
+            ackFrame.mPsdu[2] = sTransmitFrame.mPsdu[IEEE802154_DSN_OFFSET];
+
+            otPlatRadioTxDone(aInstance, &sTransmitFrame, &ackFrame, sTransmitError);
         }
     }
 

--- a/examples/platforms/cc2652/openthread-core-cc2652-config.h
+++ b/examples/platforms/cc2652/openthread-core-cc2652-config.h
@@ -60,13 +60,5 @@
  */
 #define OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT        1
 
-/**
-  * @def OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE
-  *
-  * Define to 1 if you want use legacy transmit done.
-  *
-  */
-#define OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE             1
-
 #endif /* OPENTHREAD_CORE_CC2650_CONFIG_H_ */
 

--- a/examples/platforms/gp712/Makefile.am
+++ b/examples/platforms/gp712/Makefile.am
@@ -30,19 +30,17 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 lib_LIBRARIES                             = libopenthread-gp712.a
 
-libopenthread_gp712_a_CPPFLAGS           =  \
+libopenthread_gp712_a_CPPFLAGS            = \
     -I$(top_srcdir)/include                 \
     -I$(top_srcdir)/examples/platforms      \
-    -I$(top_srcdir)/examples/platforms/utils\
     -I$(top_srcdir)/src/core                \
     -lrt                                    \
     -lpthread                               \
     $(NULL)
 
-libopenthread_gp712_settings.cpp: $(srcdir)/../utils/settings.cpp
-	cp $? $@
-
-CLEANFILES = libopenthread_gp712_settings.cpp
+Dash                                      = -
+libopenthread_gp712_a_LIBADD              = \
+    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
 
 libopenthread_gp712_a_SOURCES             = \
     alarm.c                                 \
@@ -53,7 +51,6 @@ libopenthread_gp712_a_SOURCES             = \
     random.c                                \
     uart-posix.c                            \
     flash.c                                 \
-    libopenthread_gp712_settings.cpp        \
     $(NULL)
 
 #    uart-socket.c                           \
@@ -67,7 +64,7 @@ endif
 
 
 if OPENTHREAD_BUILD_COVERAGE
-CLEANFILES                               += $(wildcard *.gcda *.gcno)
+CLEANFILES                                = $(wildcard *.gcda *.gcno)
 endif # OPENTHREAD_BUILD_COVERAGE
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/gp712/alarm.c
+++ b/examples/platforms/gp712/alarm.c
@@ -38,7 +38,7 @@
 
 #include <openthread/openthread.h>
 #include <openthread/platform/platform.h>
-#include <openthread/platform/alarm.h>
+#include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
 #include "alarm_qorvo.h"
 
@@ -46,24 +46,24 @@ void qorvoAlarmInit(void)
 {
 }
 
-uint32_t otPlatAlarmGetNow(void)
+uint32_t otPlatAlarmMilliGetNow(void)
 {
     return qorvoAlarmGetTimeMs();
 }
 
 static void qorvoAlarmFired(void *aInstance)
 {
-    otPlatAlarmFired((otInstance *)aInstance);
+    otPlatAlarmMilliFired((otInstance *)aInstance);
 }
 
-void otPlatAlarmStartAt(otInstance *aInstance, uint32_t t0, uint32_t dt)
+void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t t0, uint32_t dt)
 {
     (void)t0;
     qorvoAlarmUnScheduleEventArg((qorvoAlarmCallback_t)qorvoAlarmFired, aInstance);
     qorvoAlarmScheduleEventArg(dt * 1000, qorvoAlarmFired, aInstance);
 }
 
-void otPlatAlarmStop(otInstance *aInstance)
+void otPlatAlarmMilliStop(otInstance *aInstance)
 {
     qorvoAlarmUnScheduleEventArg((qorvoAlarmCallback_t)qorvoAlarmFired, aInstance);
 }

--- a/examples/platforms/gp712/diag.c
+++ b/examples/platforms/gp712/diag.c
@@ -33,7 +33,7 @@
 
 #include <openthread/config.h>
 #include <openthread/openthread.h>
-#include <openthread/platform/alarm.h>
+#include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/radio.h>
 
 /**

--- a/examples/platforms/gp712/openthread-core-gp712-config.h
+++ b/examples/platforms/gp712/openthread-core-gp712-config.h
@@ -34,13 +34,4 @@
 #ifndef OPENTHREAD_CORE_GP712_CONFIG_H_
 #define OPENTHREAD_CORE_GP712_CONFIG_H_
 
-/**
-  * @def OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE
-  *
-  * Define to 1 if you want use legacy transmit done.
-  *
-  */
-#define OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE 1
-
-
 #endif  // OPENTHREAD_CORE_GP712_CONFIG_H_

--- a/examples/platforms/gp712/radio.c
+++ b/examples/platforms/gp712/radio.c
@@ -196,7 +196,23 @@ exit:
 
 void cbQorvoRadioTransmitDone(otRadioFrame *aPacket, bool aFramePending, otError aError)
 {
-    otPlatRadioTransmitDone(pQorvoInstance, aPacket, aFramePending, aError);
+    // TODO: pass received ACK frame instead of generating one.
+    otRadioFrame ackFrame;
+    uint8_t psdu[IEEE802154_ACK_LENGTH];
+
+    ackFrame.mPsdu = psdu;
+    ackFrame.mLength = IEEE802154_ACK_LENGTH;
+    ackFrame.mPsdu[0] = IEEE802154_FRAME_TYPE_ACK;
+
+    if (aFramePending)
+    {
+        ackFrame.mPsdu[0] |= IEEE802154_FRAME_PENDING;
+    }
+
+    ackFrame.mPsdu[1] = 0;
+    ackFrame.mPsdu[2] = aPacket->mPsdu[IEEE802154_DSN_OFFSET];
+
+    otPlatRadioTxDone(pQorvoInstance, aPacket, &ackFrame, aError);
 }
 
 void cbQorvoRadioReceiveDone(otRadioFrame *aPacket, otError aError)

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -588,21 +588,21 @@ void platformRadioProcess(otInstance *aInstance)
     }
 }
 
-void radioTransmit(struct RadioMessage *msg, const struct otRadioFrame *pkt)
+void radioTransmit(struct RadioMessage *aMessage, const struct otRadioFrame *aFrame)
 {
     uint32_t i;
     struct sockaddr_in sockaddr;
 
     uint16_t crc = 0;
-    uint16_t crc_offset = pkt->mLength - sizeof(uint16_t);
+    uint16_t crc_offset = aFrame->mLength - sizeof(uint16_t);
 
     for (i = 0; i < crc_offset; i++)
     {
-        crc = crc16_citt(crc, msg->mPsdu[i]);
+        crc = crc16_citt(crc, aMessage->mPsdu[i]);
     }
 
-    msg->mPsdu[crc_offset] = crc & 0xff;
-    msg->mPsdu[crc_offset + 1] = crc >> 8;
+    aMessage->mPsdu[crc_offset] = crc & 0xff;
+    aMessage->mPsdu[crc_offset + 1] = crc >> 8;
 
     memset(&sockaddr, 0, sizeof(sockaddr));
     sockaddr.sin_family = AF_INET;
@@ -618,7 +618,7 @@ void radioTransmit(struct RadioMessage *msg, const struct otRadioFrame *pkt)
         }
 
         sockaddr.sin_port = htons(9000 + sPortOffset + i);
-        rval = sendto(sSockFd, (const char *)msg, 1 + pkt->mLength,
+        rval = sendto(sSockFd, (const char *)aMessage, 1 + aFrame->mLength,
                       0, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
 
         if (rval < 0)

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -421,22 +421,6 @@ extern void otPlatRadioTxDone(otInstance *aInstance, otRadioFrame *aFrame, otRad
                               otError aError);
 
 /**
- * The radio driver calls this method to notify OpenThread that the transmission has completed,
- * this function is going to be deprecated, new add platfroms should not use this callback function.
- *
- * @param[in]  aInstance      The OpenThread instance structure.
- * @param[in]  aFrame         A pointer to the frame that was transmitted.
- * @param[in]  aFramePending  TRUE if an ACK frame was received and the Frame Pending bit was set.
- * @param[in]  aError         OT_ERROR_NONE when the frame was transmitted, OT_ERROR_NO_ACK when the frame was
- *                            transmitted but no ACK was received, OT_ERROR_CHANNEL_ACCESS_FAILURE when the transmission
- *                            could not take place due to activity on the channel, OT_ERROR_ABORT when transmission was
- *                            aborted for other reasons.
- *
- */
-extern void otPlatRadioTransmitDone(otInstance *aInstance, otRadioFrame *aFrame, bool aFramePending,
-                                    otError aError);
-
-/**
  * Get the most recent RSSI measurement.
  *
  * @param[in] aInstance  The OpenThread instance structure.

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -508,21 +508,6 @@ public:
      */
     void TransmitStartedTask(otRadioFrame *aFrame);
 
-#if OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE
-    /**
-     * This method is called to handle transmit events.
-     *
-     * @param[in]  aFrame         A pointer to the frame that was transmitted.
-     * @param[in]  aFramePending  TRUE if an ACK frame was received and the Frame Pending bit was set.
-     * @param[in]  aError         OT_ERROR_NONE when the frame was transmitted, OT_ERROR_NO_ACK when the frame was
-     *                            transmitted but no ACK was received, OT_ERROR_CHANNEL_ACCESS_FAILURE when the
-     *                            transmission could not take place due to activity on the channel, OT_ERROR_ABORT when
-     *                            transmission was aborted for other reasons.
-     *
-     */
-    void TransmitDoneTask(otRadioFrame *aFrame, bool aRxPending, otError aError);
-
-#else // #if OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE
     /**
      * This method is called to handle transmit events.
      *
@@ -535,7 +520,6 @@ public:
      *
      */
     void TransmitDoneTask(otRadioFrame *aFrame, otRadioFrame *aAckFrame, otError aError);
-#endif // OPENTHREAD_CONFIG_LEGACY_TRANSMIT_DONE
 
     /**
      * This method returns if an active scan is in progress.


### PR DESCRIPTION
This commit removes the deprecated API otPlatRadioTransmitDone() to prevent new platforms using this API.

Some platforms still uses the deprecated API. This commit generates ACK frame according to the Frame Pending flag and the sent frame.

This commit does not define an API for generating ACK frame because the frame should not be generated by sender. Platforms not passing the received ACK frame should remove the code generating ACK frame soon.

This commit also fixes the build failures on the gp712 platform.