### PR TITLE
[mac] Ensure to clear `mDelaySleep` flag after delaying sleep

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1126,8 +1126,9 @@ void Mac::RadioSleep(void)
 
     if (mDelaySleep)
     {
-        // Restart delay sleep timer
+        // Start delay sleep timer
         mReceiveTimer.Start(kSleepDelay);
+        mDelaySleep = false;
     }
     else
 #endif


### PR DESCRIPTION
This commit fixes an issue related to the OpenThread feature
`OPENTHREAD_CONFIG_STAY_AWAKE_BETWEEN_FRAGMENTS` to  ensure that
`mDelaySleep` flag is cleared after timer starts so that sleep is
delayed only once.