### PR TITLE
[mac] track and ensure a single operation running at a time

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -870,6 +870,19 @@ exit:
     return error;
 }
 
+bool Frame::IsDataRequestCommand(void)
+{
+    bool isDataRequest = false;
+    uint8_t commandId = 0;
+
+    VerifyOrExit(GetType() == kFcfFrameMacCmd);
+    SuccessOrExit(GetCommandId(commandId));
+    isDataRequest = (commandId == kMacCmdDataRequest);
+
+exit:
+    return isDataRequest;
+}
+
 uint8_t Frame::GetHeaderLength(void)
 {
     return static_cast<uint8_t>(GetPayload() - GetPsdu());

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -542,6 +542,14 @@ public:
     otError SetCommandId(uint8_t aCommandId);
 
     /**
+     * This method indicates whether the frame is a MAC Data Request command (data poll)
+     *
+     * @returns TRUE if frame is a MAC Data Request command, FALSE otherwise.
+     *
+     */
+    bool IsDataRequestCommand(void);
+
+    /**
      * This method returns the MAC Frame Length.
      *
      * @returns The MAC Frame Length.


### PR DESCRIPTION
This commit contains different changes and enhancement to MAC layer implementation.

It changes how the MAC layer maintains its operations. It is ensured that only a single operation is active at a time. 

An operation can be:
- active or energy scan,
- beacon or data frame transmission,
- waiting for data (after data poll ack with frame pending), or,
- idle operation (where radio is put in either rx or sleep mode).

Method `StartOperation()` starts an operation and `FinishOperation()` is used to indicate when is is done. If there is an ongoing operation, a subsequent call to `StartOperation()` ensures that the next operation is marked as pending and gets started after the current one is finished.

This commit also changes the `StartCsmaBackoff()` implementation such that the radio is put in either receive or sleep mode depending on the state `mRxOnWhenIdle` before starting the backoff timer. This ensures that on a sleepy device the radio is put to sleep while backing off for all transmission attempts including any MAC retries.

Another change added in this commit is to allow a received data frame to be processed during an ongoing active/energy scan only if the current scan channel matches the receive channel.

This commit also update `Mac::Frame` class by adding a new helper method `IsDataRequestCommand()` to indicate if the frame is a MAC Data Request command (data poll). Also it adds `const` qualifier to some of `Mac::Frame` getter methods.