### PR TITLE
[spinel] support in place unpack

### DIFF
--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -25,6 +25,11 @@
  *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * @file
+ *   This file contains definitions of spinel API.
+ */
+
 #ifndef SPINEL_HEADER_INCLUDED
 #define SPINEL_HEADER_INCLUDED 1
 
@@ -1455,7 +1460,57 @@ SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_vpack(uint8_t *data_out, spinel
                                                        const char *pack_format, va_list args);
 SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_unpack(const uint8_t *data_in, spinel_size_t data_len,
                                                         const char *pack_format, ...);
+/**
+ * This function parses spinel data similar to sscanf().
+ *
+ * This function actually calls spinel_datatype_vunpack_in_place() to parse data.
+ *
+ * @param[in]   data_in     A pointer to the data to parse.
+ * @param[in]   data_len    The length of @p data_in in bytes.
+ * @param[in]   pack_format C string that contains a format string follows the same specification of spinel.
+ * @param[in]   ...         Additional arguments depending on the format string @p pack_format.
+ *
+ * @returns The parsed length in bytes.
+ *
+ * @note This function behaves different from `spinel_datatype_unpack()`:
+ *       - This function expects composite data arguments of pointer to data type, while `spinel_datatype_unpack()`
+ *         expects them of pointer to data type pointer. For example, if `SPINEL_DATATYPE_EUI64_C` is present in
+ *         @p pack_format, this function expects a `spinel_eui64_t *` is included in variable arguments, while
+ *         `spinel_datatype_unpack()` expects a `spinel_eui64_t **` is included.
+ *       - For `SPINEL_DATATYPE_UTF8_C`, this function expects two arguments, the first of type `char *` and the
+ *         second is of type `size_t` to indicate length of the provided buffer in the first argument just like
+ *         `strncpy()`, while `spinel_datatype_unpack()` only expects a `const char **`.
+ *
+ * @sa spinel_datatype_vunpack_in_place()
+ *
+ */
+SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_unpack_in_place(const uint8_t *data_in, spinel_size_t data_len,
+                                                        const char *pack_format, ...);
 SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_vunpack(const uint8_t *data_in, spinel_size_t data_len,
+                                                         const char *pack_format, va_list args);
+/**
+ * This function parses spinel data similar to vsscanf().
+ *
+ * @param[in]   data_in     A pointer to the data to parse.
+ * @param[in]   data_len    The length of @p data_in in bytes.
+ * @param[in]   pack_format C string that contains a format string follows the same specification of spinel.
+ * @param[in]   args        A value identifying a variable arguments list.
+ *
+ * @returns The parsed length in bytes.
+ *
+ * @note This function behaves different from `spinel_datatype_vunpack()`:
+ *       - This function expects composite data arguments of pointer to data type, while `spinel_datatype_vunpack()`
+ *         expects them of pointer to data type pointer. For example, if `SPINEL_DATATYPE_EUI64_C` is present in
+ *         @p pack_format, this function expects a `spinel_eui64_t *` is included in variable arguments, while
+ *         `spinel_datatype_vunpack()` expects a `spinel_eui64_t **` is included.
+ *       - For `SPINEL_DATATYPE_UTF8_C`, this function expects two arguments, the first of type `char *` and the
+ *         second is of type `size_t` to indicate length of the provided buffer in the first argument just like
+ *         `strncpy()`, while `spinel_datatype_vunpack()` only expects a `const char **`.
+ *
+ * @sa spinel_datatype_unpack_in_place()
+ *
+ */
+SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_vunpack_in_place(const uint8_t *data_in, spinel_size_t data_len,
                                                          const char *pack_format, va_list args);
 
 SPINEL_API_EXTERN spinel_ssize_t spinel_packed_uint_decode(const uint8_t *bytes, spinel_size_t len,


### PR DESCRIPTION
This RP added a new API `spinel_datatype_unpack_in_place ()` in spinel parser to support parsing composite data and filling in supplied buffers.

The current parser API returns data only valid inside the frame handler. This makes it hard to implement a general property getter like `GetProperty(spinel_key_t aKey, const char *aFormat, ...)` where the `aFormat` is the structure of the expected response. The newly added API accepts composite-type data pointer instead of pointer to composite-type data pointer, which would save repeated code for parsing and simplify host side implementing general getter for spinel properties.