### PR TITLE
[message] decouple message and ip6

### DIFF
--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -86,16 +86,17 @@ otInstance::otInstance(void) :
 #if OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER
     mTimerMicroScheduler(this),
 #endif
-    mThreadNetif(mIp6)
+    mThreadNetif(mIp6),
 #if OPENTHREAD_ENABLE_RAW_LINK_API
-    , mLinkRaw(*this)
+    mLinkRaw(*this),
 #endif // OPENTHREAD_ENABLE_RAW_LINK_API
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
-    , mApplicationCoap(mThreadNetif)
+    mApplicationCoap(mThreadNetif),
 #endif // OPENTHREAD_ENABLE_APPLICATION_COAP
 #if OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
-    , mLogLevel(static_cast<otLogLevel>(OPENTHREAD_CONFIG_LOG_LEVEL))
+    mLogLevel(static_cast<otLogLevel>(OPENTHREAD_CONFIG_LOG_LEVEL)),
 #endif // OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
+    mMessagePool(this)
 {
 }
 

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -172,7 +172,7 @@ otError otIp6Send(otInstance *aInstance, otMessage *aMessage)
 
 otMessage *otIp6NewMessage(otInstance *aInstance, bool aLinkSecurityEnabled)
 {
-    Message *message = aInstance->mIp6.mMessagePool.New(Message::kTypeIp6, 0);
+    Message *message = aInstance->mMessagePool.New(Message::kTypeIp6, 0);
 
     if (message)
     {

--- a/src/core/api/message_api.cpp
+++ b/src/core/api/message_api.cpp
@@ -154,7 +154,7 @@ void otMessageGetBufferInfo(otInstance *aInstance, otBufferInfo *aBufferInfo)
 {
     aBufferInfo->mTotalBuffers = OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS;
 
-    aBufferInfo->mFreeBuffers = aInstance->mThreadNetif.GetIp6().mMessagePool.GetFreeBufferCount();
+    aBufferInfo->mFreeBuffers = aInstance->mMessagePool.GetFreeBufferCount();
 
     aInstance->mThreadNetif.GetMeshForwarder().GetSendQueue().GetInfo(aBufferInfo->m6loSendMessages,
                                                                       aBufferInfo->m6loSendBuffers);

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -34,6 +34,7 @@
 
 #include "common/logging.hpp"
 #include "meshcop/dtls.hpp"
+#include "openthread-instance.h"
 #include "thread/thread_netif.hpp"
 
 #if OPENTHREAD_ENABLE_DTLS
@@ -218,7 +219,7 @@ void CoapSecure::HandleDtlsReceive(uint8_t *aBuf, uint16_t aLength)
 
     otLogFuncEntry();
 
-    VerifyOrExit((message = GetNetif().GetIp6().mMessagePool.New(Message::kTypeIp6, 0)) != NULL);
+    VerifyOrExit((message = GetInstance()->mMessagePool.New(Message::kTypeIp6, 0)) != NULL);
     SuccessOrExit(message->Append(aBuf, aLength));
 
     Coap::Receive(*message, mPeerAddress);

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -710,6 +710,24 @@ exit:
     return rval;
 }
 
+uint16_t Message::UpdateChecksum(uint16_t aChecksum, uint16_t aValue)
+{
+    uint16_t result = aChecksum + aValue;
+    return result + (result < aChecksum);
+}
+
+uint16_t Message::UpdateChecksum(uint16_t aChecksum, const void *aBuf, uint16_t aLength)
+{
+    const uint8_t *bytes = reinterpret_cast<const uint8_t *>(aBuf);
+
+    for (int i = 0; i < aLength; i++)
+    {
+        aChecksum = UpdateChecksum(aChecksum, (i & 1) ? bytes[i] : static_cast<uint16_t>(bytes[i] << 8));
+    }
+
+    return aChecksum;
+}
+
 uint16_t Message::UpdateChecksum(uint16_t aChecksum, uint16_t aOffset, uint16_t aLength) const
 {
     Buffer *curBuffer;
@@ -730,7 +748,7 @@ uint16_t Message::UpdateChecksum(uint16_t aChecksum, uint16_t aOffset, uint16_t 
             bytesToCover = aLength;
         }
 
-        aChecksum = Ip6::Ip6::UpdateChecksum(aChecksum, GetFirstData() + aOffset, bytesToCover);
+        aChecksum = Message::UpdateChecksum(aChecksum, GetFirstData() + aOffset, bytesToCover);
 
         aLength -= bytesToCover;
         bytesCovered += bytesToCover;
@@ -765,7 +783,7 @@ uint16_t Message::UpdateChecksum(uint16_t aChecksum, uint16_t aOffset, uint16_t 
             bytesToCover = aLength;
         }
 
-        aChecksum = Ip6::Ip6::UpdateChecksum(aChecksum, curBuffer->GetData() + aOffset, bytesToCover);
+        aChecksum = Message::UpdateChecksum(aChecksum, curBuffer->GetData() + aOffset, bytesToCover);
 
         aLength -= bytesToCover;
         bytesCovered += bytesToCover;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -646,6 +646,29 @@ public:
     const RssAverager &GetRssAverager(void) const { return mBuffer.mHead.mInfo.mRssAverager; }
 
     /**
+     * This static method updates a checksum.
+     *
+     * @param[in]  aChecksum  The checksum value to update.
+     * @param[in]  aValue     The 16-bit value to update @p aChecksum with.
+     *
+     * @returns The updated checksum.
+     *
+     */
+    static uint16_t UpdateChecksum(uint16_t aChecksum, uint16_t aValue);
+
+    /**
+     * This static method updates a checksum.
+     *
+     * @param[in]  aChecksum  The checksum value to update.
+     * @param[in]  aBuf       A pointer to a buffer.
+     * @param[in]  aLength    The number of bytes in @p aBuf.
+     *
+     * @returns The updated checksum.
+     *
+     */
+    static uint16_t UpdateChecksum(uint16_t aChecksum, const void *aBuf, uint16_t aLength);
+
+    /**
      * This method is used to update a checksum value.
      *
      * @param[in]  aChecksum  Initial checksum value.

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -172,29 +172,6 @@ public:
      * This static method updates a checksum.
      *
      * @param[in]  aChecksum  The checksum value to update.
-     * @param[in]  aValue     The 16-bit value to update @p aChecksum with.
-     *
-     * @returns The updated checksum.
-     *
-     */
-    static uint16_t UpdateChecksum(uint16_t aChecksum, uint16_t aValue);
-
-    /**
-     * This static method updates a checksum.
-     *
-     * @param[in]  aChecksum  The checksum value to update.
-     * @param[in]  aBuf       A pointer to a buffer.
-     * @param[in]  aLength    The number of bytes in @p aBuf.
-     *
-     * @returns The updated checksum.
-     *
-     */
-    static uint16_t UpdateChecksum(uint16_t aChecksum, const void *aBuf, uint16_t aLength);
-
-    /**
-     * This static method updates a checksum.
-     *
-     * @param[in]  aChecksum  The checksum value to update.
      * @param[in]  aAddress   A reference to an IPv6 address.
      *
      * @returns The updated checksum.
@@ -371,8 +348,6 @@ public:
     Icmp mIcmp;
     Udp mUdp;
     Mpl mMpl;
-
-    MessagePool mMessagePool;
 
 private:
     static void HandleSendQueue(Tasklet &aTasklet);

--- a/src/core/openthread-instance.h
+++ b/src/core/openthread-instance.h
@@ -102,6 +102,7 @@ typedef struct otInstance
 #if OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
     otLogLevel mLogLevel;
 #endif // OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
+    ot::MessagePool mMessagePool;
 
     // Constructor
     otInstance(void);

--- a/src/core/thread/data_poll_manager.cpp
+++ b/src/core/thread/data_poll_manager.cpp
@@ -108,7 +108,7 @@ otError DataPollManager::SendDataPoll(void)
         VerifyOrExit(message->GetType() != Message::kTypeMacDataPoll, error = OT_ERROR_ALREADY);
     }
 
-    message = meshForwarder.GetNetif().GetIp6().mMessagePool.New(Message::kTypeMacDataPoll, 0);
+    message = meshForwarder.GetInstance()->mMessagePool.New(Message::kTypeMacDataPoll, 0);
     VerifyOrExit(message != NULL, error = OT_ERROR_NO_BUFS);
 
     error = meshForwarder.SendMessage(*message);

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1921,7 +1921,7 @@ void MeshForwarder::HandleMesh(uint8_t *aFrame, uint8_t aFrameLength, const Mac:
         meshHeader.SetHopsLeft(meshHeader.GetHopsLeft() - 1);
         meshHeader.AppendTo(aFrame);
 
-        VerifyOrExit((message = netif.GetIp6().mMessagePool.New(Message::kType6lowpan, 0)) != NULL,
+        VerifyOrExit((message = netif.GetInstance()->mMessagePool.New(Message::kType6lowpan, 0)) != NULL,
                      error = OT_ERROR_NO_BUFS);
         SuccessOrExit(error = message->SetLength(aFrameLength));
         message->Write(0, aFrameLength, aFrame);
@@ -2009,7 +2009,7 @@ void MeshForwarder::HandleFragment(uint8_t *aFrame, uint8_t aFrameLength,
         aFrame += fragmentHeader->GetHeaderLength();
         aFrameLength -= fragmentHeader->GetHeaderLength();
 
-        VerifyOrExit((message = netif.GetIp6().mMessagePool.New(Message::kTypeIp6, 0)) != NULL,
+        VerifyOrExit((message = netif.GetInstance()->mMessagePool.New(Message::kTypeIp6, 0)) != NULL,
                      error = OT_ERROR_NO_BUFS);
         message->SetLinkSecurityEnabled(aMessageInfo.mLinkSecurity);
         message->SetPanId(aMessageInfo.mPanId);
@@ -2190,7 +2190,7 @@ void MeshForwarder::HandleLowpanHC(uint8_t *aFrame, uint8_t aFrameLength,
     Message *message;
     int headerLength;
 
-    VerifyOrExit((message = netif.GetIp6().mMessagePool.New(Message::kTypeIp6, 0)) != NULL,
+    VerifyOrExit((message = netif.GetInstance()->mMessagePool.New(Message::kTypeIp6, 0)) != NULL,
                  error = OT_ERROR_NO_BUFS);
     message->SetLinkSecurityEnabled(aMessageInfo.mLinkSecurity);
     message->SetPanId(aMessageInfo.mPanId);

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -104,7 +104,7 @@ void ChildSupervisor::SendMessage(Child &aChild)
 
     VerifyOrExit(aChild.GetIndirectMessageCount() == 0);
 
-    message = netif.GetIp6().mMessagePool.New(Message::kTypeSupervision, sizeof(uint8_t));
+    message = netif.GetInstance()->mMessagePool.New(Message::kTypeSupervision, sizeof(uint8_t));
     VerifyOrExit(message != NULL);
 
     // Supervision message is an empty payload 15.4 data frame.

--- a/tests/unit/test_lowpan.cpp
+++ b/tests/unit/test_lowpan.cpp
@@ -176,7 +176,7 @@ static void Test(TestIphcVector &aVector, bool aCompress, bool aDecompress)
 
     if (aCompress)
     {
-        VerifyOrQuit((message = sIp6->mMessagePool.New(Message::kTypeIp6, 0)) != NULL,
+        VerifyOrQuit((message = sInstance->mMessagePool.New(Message::kTypeIp6, 0)) != NULL,
                      "6lo: Ip6::NewMessage failed");
 
         aVector.GetUncompressedStream(*message);
@@ -211,7 +211,7 @@ static void Test(TestIphcVector &aVector, bool aCompress, bool aDecompress)
 
     if (aDecompress)
     {
-        VerifyOrQuit((message = sIp6->mMessagePool.New(Message::kTypeIp6, 0)) != NULL,
+        VerifyOrQuit((message = sInstance->mMessagePool.New(Message::kTypeIp6, 0)) != NULL,
                      "6lo: Ip6::NewMessage failed");
 
         int decompressedBytes = sLowpan->Decompress(*message, aVector.mMacSource, aVector.mMacDestination,

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -47,7 +47,7 @@ void TestMessage(void)
     instance = testInitInstance();
     VerifyOrQuit(instance != NULL, "Null OpenThread instance\n");
 
-    messagePool = &instance->mIp6.mMessagePool;
+    messagePool = &instance->mMessagePool;
 
     for (unsigned i = 0; i < sizeof(writeBuffer); i++)
     {

--- a/tests/unit/test_message_queue.cpp
+++ b/tests/unit/test_message_queue.cpp
@@ -87,7 +87,7 @@ void TestMessageQueue(void)
     sInstance = testInitInstance();
     VerifyOrQuit(sInstance != NULL, "Null instance");
 
-    sMessagePool = &sInstance->mIp6.mMessagePool;
+    sMessagePool = &sInstance->mMessagePool;
 
     for (int i = 0; i < kNumTestMessages; i++)
     {

--- a/tests/unit/test_ncp_buffer.cpp
+++ b/tests/unit/test_ncp_buffer.cpp
@@ -377,7 +377,7 @@ void TestNcpFrameBuffer(void)
     NcpFrameBuffer::WritePosition pos1, pos2;
 
     sInstance = testInitInstance();
-    sMessagePool = &sInstance->mIp6.mMessagePool;
+    sMessagePool = &sInstance->mMessagePool;
 
     for (i = 0; i < sizeof(buffer); i++)
     {
@@ -1000,7 +1000,7 @@ void TestFuzzNcpFrameBuffer(void)
     uint32_t lensArrayCount[kNumPrios];
 
     sInstance = testInitInstance();
-    sMessagePool = &sInstance->mIp6.mMessagePool;
+    sMessagePool = &sInstance->mMessagePool;
 
     memset(buffer, 0, sizeof(buffer));
 

--- a/tests/unit/test_priority_queue.cpp
+++ b/tests/unit/test_priority_queue.cpp
@@ -221,7 +221,7 @@ void TestPriorityQueue(void)
     instance = testInitInstance();
     VerifyOrQuit(instance != NULL, "Null OpenThread instance\n");
 
-    messagePool = &instance->mIp6.mMessagePool;
+    messagePool = &instance->mMessagePool;
 
     // Allocate messages with different priorities.
     for (int i = 0; i < kNumTestMessages; i++)


### PR DESCRIPTION
This PR simply decouples message and ip6 by moving `UpdateChecksum()` from `Ip6` to `Message` and moving `MessagePool` into `otInstance`. After this PR, `Message` no logger depends on `Ip6`.