### PR TITLE
[nit] fix namespace closure comment

### DIFF
--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -68,5 +68,5 @@ void SteeringDataTlv::ComputeBloomFilter(otExtAddress *aExtAddress)
     SetBit(ansi.Get() % GetNumBits());
 }
 
+}  // namespace MeshCoP
 }  // namespace ot
-}  // namespace Thread


### PR DESCRIPTION
Found a minor comment inconsistency while rebasing to latest master.