### PR TITLE
[ncp] update pass through filter rules

### DIFF
--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -182,21 +182,27 @@ exit:
 
 otError ThreadNetif::TmfFilter(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, void *aContext)
 {
-    otError error = OT_ERROR_NONE;
+    OT_UNUSED_VARIABLE(aMessage);
+
+    return static_cast<ThreadNetif *>(aContext)->IsTmfMessage(aMessageInfo) ? OT_ERROR_NONE : OT_ERROR_NOT_TMF;
+}
+
+bool ThreadNetif::IsTmfMessage(const Ip6::MessageInfo &aMessageInfo)
+{
+    bool rval = true;
 
     // A TMF message must comply with following rules:
     // 1. The destination is a Mesh Local Address or a Link-Local Multicast Address or a Realm-Local Multicast Address,
     //    and the source is a Mesh Local Address.
     // 2. Both the destination and the source are Link-Local Addresses.
-    VerifyOrExit(((static_cast<ThreadNetif *>(aContext)->mMleRouter.IsMeshLocalAddress(aMessageInfo.GetSockAddr()) ||
+    VerifyOrExit(((mMleRouter.IsMeshLocalAddress(aMessageInfo.GetSockAddr()) ||
                    aMessageInfo.GetSockAddr().IsLinkLocalMulticast() ||
                    aMessageInfo.GetSockAddr().IsRealmLocalMulticast()) &&
-                  static_cast<ThreadNetif *>(aContext)->mMleRouter.IsMeshLocalAddress(aMessageInfo.GetPeerAddr())) ||
+                  mMleRouter.IsMeshLocalAddress(aMessageInfo.GetPeerAddr())) ||
                  (aMessageInfo.GetSockAddr().IsLinkLocal() && aMessageInfo.GetPeerAddr().IsLinkLocal()),
-                 error = OT_ERROR_NOT_TMF);
+                 rval = false);
 exit:
-    OT_UNUSED_VARIABLE(aMessage);
-    return error;
+    return rval;
 }
 
 }  // namespace ot

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -412,6 +412,15 @@ public:
       */
     PanIdQueryServer &GetPanIdQueryServer(void) { return mPanIdQuery; }
 
+    /**
+     * This method returns whether Thread Management Framework Addressing Rules are met.
+     *
+     * @retval TRUE   if Thread Management Framework Addressing Rules are met.
+     * @retval FALSE  if Thread Management Framework Addressing Rules are not met.
+     *
+     */
+    bool IsTmfMessage(const Ip6::MessageInfo &aMessageInfo);
+
 private:
     static otError TmfFilter(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, void *aContext);
 


### PR DESCRIPTION
Update NCP filtering rules to exclude:
1. RLOC or ALOC as Destination Address
2. MLE messages
3. TMF messages