### PR TITLE
[mac] enable radio layer before setting radio parameters

### DIFF
--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -310,7 +310,7 @@ extern "C" {
 #define otLogCritMle(aInstance, aFormat, ...) otLogCrit(&aInstance, OT_LOG_REGION_MLE, aFormat, ## __VA_ARGS__)
 #define otLogWarnMle(aInstance, aFormat, ...) otLogWarn(&aInstance, OT_LOG_REGION_MLE, aFormat, ## __VA_ARGS__)
 #define otLogWarnMleErr(aInstance, aError, aFormat, ...)                    \
-    otLogWarn(&aInstance, OT_LOG_REGION_MAC, "Error %s: " aFormat, otThreadErrorToString(aError), ## __VA_ARGS__)
+    otLogWarn(&aInstance, OT_LOG_REGION_MLE, "Error %s: " aFormat, otThreadErrorToString(aError), ## __VA_ARGS__)
 #define otLogInfoMle(aInstance, aFormat, ...) otLogInfo(&aInstance, OT_LOG_REGION_MLE, aFormat, ## __VA_ARGS__)
 #define otLogDebgMle(aInstance, aFormat, ...) otLogDebg(&aInstance, OT_LOG_REGION_MLE, aFormat, ## __VA_ARGS__)
 #else

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -185,13 +185,13 @@ Mac::Mac(ThreadNetif &aThreadNetif):
 
     memset(&mCounters, 0, sizeof(otMacCounters));
 
+    otPlatRadioEnable(&GetInstance());
+
     SetExtendedPanId(sExtendedPanidInit);
     SetNetworkName(sNetworkNameInit);
     SetPanId(mPanId);
     SetExtAddress(mExtAddress);
     SetShortAddress(mShortAddress);
-
-    otPlatRadioEnable(&GetInstance());
 }
 
 otError Mac::ActiveScan(uint32_t aScanChannels, uint16_t aScanDuration, ActiveScanHandler aHandler, void *aContext)


### PR DESCRIPTION
This PR adjust the order for calling radio layer API to make sure `otPlatRadioEnable()` is the first call to radio layer. This mainly addresses the issue of `otInstance` which is not provided when initializing radio layer.