### PR TITLE
[mac] Print warnings on failure, not success

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1098,9 +1098,10 @@ otError Mac::RadioTransmit(Frame *aSendFrame)
     SuccessOrExit(error = otPlatRadioTransmit(&GetInstance(), static_cast<otRadioFrame *>(aSendFrame)));
 
 exit:
-    if(error != OT_ERROR_NONE)
+
+    if (error != OT_ERROR_NONE)
     {
-    	otLogWarnMac(GetInstance(), "otPlatRadioTransmit() failed with error %s", otThreadErrorToString(error));
+        otLogWarnMac(GetInstance(), "otPlatRadioTransmit() failed with error %s", otThreadErrorToString(error));
     }
 
     return error;
@@ -1123,9 +1124,10 @@ otError Mac::RadioReceive(uint8_t aChannel)
     SuccessOrExit(error = otPlatRadioReceive(&GetInstance(), aChannel));
 
 exit:
-    if(error != OT_ERROR_NONE)
+
+    if (error != OT_ERROR_NONE)
     {
-    	otLogWarnMac(GetInstance(), "otPlatRadioReceive() failed with error %s", otThreadErrorToString(error));
+        otLogWarnMac(GetInstance(), "otPlatRadioReceive() failed with error %s", otThreadErrorToString(error));
     }
 
     return error;
@@ -1156,9 +1158,10 @@ otError Mac::RadioSleep(void)
     SuccessOrExit(error = otPlatRadioSleep(&GetInstance()));
 
 exit:
-    if(error != OT_ERROR_NONE)
+
+    if (error != OT_ERROR_NONE)
     {
-    	otLogWarnMac(GetInstance(), "otPlatRadioSleep() failed with error %s", otThreadErrorToString(error));
+        otLogWarnMac(GetInstance(), "otPlatRadioSleep() failed with error %s", otThreadErrorToString(error));
     }
 
     return error;

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1097,9 +1097,12 @@ otError Mac::RadioTransmit(Frame *aSendFrame)
 
     SuccessOrExit(error = otPlatRadioTransmit(&GetInstance(), static_cast<otRadioFrame *>(aSendFrame)));
 
-    otLogWarnMac(GetInstance(), "otPlatRadioTransmit() failed with error %s", otThreadErrorToString(error));
-
 exit:
+    if(error != OT_ERROR_NONE)
+    {
+    	otLogWarnMac(GetInstance(), "otPlatRadioTransmit() failed with error %s", otThreadErrorToString(error));
+    }
+
     return error;
 }
 
@@ -1119,9 +1122,12 @@ otError Mac::RadioReceive(uint8_t aChannel)
 
     SuccessOrExit(error = otPlatRadioReceive(&GetInstance(), aChannel));
 
-    otLogWarnMac(GetInstance(), "otPlatRadioReceive() failed with error %s", otThreadErrorToString(error));
-
 exit:
+    if(error != OT_ERROR_NONE)
+    {
+    	otLogWarnMac(GetInstance(), "otPlatRadioReceive() failed with error %s", otThreadErrorToString(error));
+    }
+
     return error;
 }
 
@@ -1146,11 +1152,15 @@ otError Mac::RadioSleep(void)
     }
 
 #endif
+
     SuccessOrExit(error = otPlatRadioSleep(&GetInstance()));
 
-    otLogWarnMac(GetInstance(), "otPlatRadioSleep() failed with error %s", otThreadErrorToString(error));
-
 exit:
+    if(error != OT_ERROR_NONE)
+    {
+    	otLogWarnMac(GetInstance(), "otPlatRadioSleep() failed with error %s", otThreadErrorToString(error));
+    }
+
     return error;
 }
 


### PR DESCRIPTION
Warning messages for Mac::RadioSleep, Mac::RadioTransmit and Mac::RadioReceive were being printed on success rather than failure. This small fix corrects that.