### PR TITLE
[api] expose Thread-specific link information structure

### DIFF
--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -464,7 +464,8 @@ typedef struct otMessageInfo
 
     /**
      * A pointer to link-specific information. In case @p mInterfaceId is set to OT_NETIF_INTERFACE_ID_THREAD,
-     * @p mLinkInfo points to @sa otThreadLinkInfo.
+     * @p mLinkInfo points to @sa otThreadLinkInfo. This field is only valid for messages received from the
+     * Thread radio and is ignored on transmission.
      */
     const void *mLinkInfo;
 } otMessageInfo;
@@ -1061,7 +1062,7 @@ typedef struct otSockAddr
 } otSockAddr;
 
 /**
- * This structure represents Thread-specific link information.
+ * This structure represents link-specific information for messages received from the Thread radio.
  *
  */
 typedef struct otThreadLinkInfo

--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -427,19 +427,46 @@ struct otIp6Address
  */
 typedef struct otIp6Address otIp6Address;
 
-
 /**
  * This structure represents the local and peer IPv6 socket addresses.
  */
 typedef struct otMessageInfo
 {
-    otIp6Address mSockAddr;     ///< The local IPv6 address.
-    otIp6Address mPeerAddr;     ///< The peer IPv6 address.
-    uint16_t     mSockPort;     ///< The local transport-layer port.
-    uint16_t     mPeerPort;     ///< The peer transport-layer port.
-    int8_t       mInterfaceId;  ///< An IPv6 interface identifier.
-    uint8_t      mHopLimit;     ///< The IPv6 Hop Limit.
-    const void  *mLinkInfo;     ///< A pointer to link-specific information.
+    /**
+     * The local IPv6 address.
+     */
+    otIp6Address mSockAddr;
+
+    /**
+     * The peer IPv6 address.
+     */
+    otIp6Address mPeerAddr;
+
+    /**
+     * The local transport-layer port.
+     */
+    uint16_t mSockPort;
+
+    /**
+     * The peer transport-layer port.
+     */
+    uint16_t mPeerPort;
+
+    /**
+     * An IPv6 interface identifier.
+     */
+    int8_t mInterfaceId;
+
+    /**
+     * The IPv6 Hop Limit.
+     */
+    uint8_t mHopLimit;
+
+    /**
+     * A pointer to link-specific information. In case @p mInterfaceId is set to OT_NETIF_INTERFACE_ID_THREAD,
+     * @p mLinkInfo points to @sa otThreadLinkInfo.
+     */
+    const void *mLinkInfo;
 } otMessageInfo;
 
 /**
@@ -1032,6 +1059,19 @@ typedef struct otSockAddr
     uint16_t     mPort;     ///< A transport-layer port.
     int8_t       mScopeId;  ///< An IPv6 scope identifier.
 } otSockAddr;
+
+/**
+ * This structure represents Thread-specific link information.
+ *
+ */
+typedef struct otThreadLinkInfo
+{
+    uint16_t mPanId;         ///< Source PAN ID
+    uint8_t  mChannel;       ///< 802.15.4 Channel
+    int8_t   mRss;           ///< Received Signal Strength in dBm.
+    uint8_t  mLqi;           ///< Link Quality Indicator for a received message.
+    bool     mLinkSecurity;  ///< Indicates whether or not link security is enabled.
+} otThreadLinkInfo;
 
 #ifdef OTDLL
 

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -56,7 +56,6 @@ enum
 };
 
 class MleRouter;
-struct ThreadMessageInfo;
 
 /**
  * @addtogroup core-mesh-forwarding
@@ -263,21 +262,21 @@ private:
     otError PrepareDiscoverRequest(void);
     void PrepareIndirectTransmission(Message &aMessage, const Child &aChild);
     void HandleMesh(uint8_t *aFrame, uint8_t aPayloadLength, const Mac::Address &aMacSource,
-                    const ThreadMessageInfo &aMessageInfo);
+                    const otThreadLinkInfo &aLinkInfo);
     void HandleFragment(uint8_t *aFrame, uint8_t aPayloadLength,
                         const Mac::Address &aMacSource, const Mac::Address &aMacDest,
-                        const ThreadMessageInfo &aMessageInfo);
+                        const otThreadLinkInfo &aLinkInfo);
     void HandleLowpanHC(uint8_t *aFrame, uint8_t aPayloadLength,
                         const Mac::Address &aMacSource, const Mac::Address &aMacDest,
-                        const ThreadMessageInfo &aMessageInfo);
-    void HandleDataRequest(const Mac::Address &aMacSource, const ThreadMessageInfo &aMessageInfo);
+                        const otThreadLinkInfo &aLinkInfo);
+    void HandleDataRequest(const Mac::Address &aMacSource, const otThreadLinkInfo &aLinkInfo);
     otError SendPoll(Message &aMessage, Mac::Frame &aFrame);
     otError SendMesh(Message &aMessage, Mac::Frame &aFrame);
     otError SendFragment(Message &aMessage, Mac::Frame &aFrame);
     otError SendEmptyFrame(Mac::Frame &aFrame, bool aAckRequest);
     otError UpdateIp6Route(Message &aMessage);
     otError UpdateMeshRoute(Message &aMessage);
-    otError HandleDatagram(Message &aMessage, const ThreadMessageInfo &aMessageInfo,
+    otError HandleDatagram(Message &aMessage, const otThreadLinkInfo &aLinkInfo,
                            const Mac::Address &aMacSource);
     void ClearReassemblyList(void);
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2542,7 +2542,7 @@ otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInf
 {
     ThreadNetif &netif = GetNetif();
     otError error = OT_ERROR_NONE;
-    const ThreadMessageInfo *threadMessageInfo = static_cast<const ThreadMessageInfo *>(aMessageInfo.GetLinkInfo());
+    const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
     ResponseTlv response;
     SourceAddressTlv sourceAddress;
     LeaderDataTlv leaderData;
@@ -2575,7 +2575,7 @@ otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInf
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLinkMargin, sizeof(linkMarginTlv), linkMarginTlv));
     VerifyOrExit(linkMarginTlv.IsValid(), error = OT_ERROR_PARSE);
 
-    linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(netif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
+    linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(netif.GetMac().GetNoiseFloor(), linkInfo->mRss);
 
     if (linkMargin > linkMarginTlv.GetLinkMargin())
     {
@@ -2660,7 +2660,7 @@ otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInf
     mParentCandidate.SetDeviceMode(ModeTlv::kModeFFD | ModeTlv::kModeRxOnWhenIdle | ModeTlv::kModeFullNetworkData |
                                    ModeTlv::kModeSecureDataRequest);
     mParentCandidate.GetLinkInfo().Clear();
-    mParentCandidate.GetLinkInfo().AddRss(netif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
+    mParentCandidate.GetLinkInfo().AddRss(netif.GetMac().GetNoiseFloor(), linkInfo->mRss);
     mParentCandidate.ResetLinkFailures();
     mParentCandidate.SetLinkQualityOut(LinkQualityInfo::ConvertLinkMarginToLinkQuality(linkMarginTlv.GetLinkMargin()));
     mParentCandidate.SetState(Neighbor::kStateValid);
@@ -3040,7 +3040,7 @@ exit:
 otError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     otError error = OT_ERROR_NONE;
-    const ThreadMessageInfo *threadMessageInfo = static_cast<const ThreadMessageInfo *>(aMessageInfo.GetLinkInfo());
+    const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
     Tlv tlv;
     MeshCoP::Tlv meshcopTlv;
     MeshCoP::DiscoveryResponseTlv discoveryResponse;
@@ -3064,10 +3064,10 @@ otError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::Message
     end = offset + tlv.GetLength();
 
     memset(&result, 0, sizeof(result));
-    result.mPanId = threadMessageInfo->mPanId;
-    result.mChannel = threadMessageInfo->mChannel;
-    result.mRssi = threadMessageInfo->mRss;
-    result.mLqi = threadMessageInfo->mLqi;
+    result.mPanId = linkInfo->mPanId;
+    result.mChannel = linkInfo->mChannel;
+    result.mRssi = linkInfo->mRss;
+    result.mLqi = linkInfo->mLqi;
     aMessageInfo.GetPeerAddr().ToExtAddress(*static_cast<Mac::ExtAddress *>(&result.mExtAddress));
 
     // process MeshCoP TLVs

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -715,12 +715,12 @@ otError MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::Message
 
             if (neighbor->GetState() != Neighbor::kStateValid)
             {
-                const ThreadMessageInfo *threadMessageInfo =
-                    static_cast<const ThreadMessageInfo *>(aMessageInfo.GetLinkInfo());
+                const otThreadLinkInfo *linkInfo =
+                    static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
 
                 neighbor->SetExtAddress(macAddr);
                 neighbor->GetLinkInfo().Clear();
-                neighbor->GetLinkInfo().AddRss(GetNetif().GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
+                neighbor->GetLinkInfo().AddRss(GetNetif().GetMac().GetNoiseFloor(), linkInfo->mRss);
                 neighbor->ResetLinkFailures();
                 neighbor->SetState(Neighbor::kStateLinkRequest);
             }
@@ -764,7 +764,7 @@ otError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo, Neighbor
                                   const TlvRequestTlv &aTlvRequest, const ChallengeTlv &aChallenge)
 {
     otError error = OT_ERROR_NONE;
-    const ThreadMessageInfo *threadMessageInfo = static_cast<const ThreadMessageInfo *>(aMessageInfo.GetLinkInfo());
+    const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
     static const uint8_t routerTlvs[] = {Tlv::kLinkMargin};
     Message *message;
     Header::Command command;
@@ -782,7 +782,7 @@ otError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo, Neighbor
     SuccessOrExit(error = AppendMleFrameCounter(*message));
 
     // always append a link margin, regardless of whether or not it was requested
-    linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(GetNetif().GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
+    linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(GetNetif().GetMac().GetNoiseFloor(), linkInfo->mRss);
 
     SuccessOrExit(error = AppendLinkMargin(*message, linkMargin));
 
@@ -863,7 +863,7 @@ otError MleRouter::HandleLinkAccept(const Message &aMessage, const Ip6::MessageI
                                     uint32_t aKeySequence, bool aRequest)
 {
     otError error = OT_ERROR_NONE;
-    const ThreadMessageInfo *threadMessageInfo = static_cast<const ThreadMessageInfo *>(aMessageInfo.GetLinkInfo());
+    const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
     Router *router;
     Neighbor *neighbor;
     Mac::ExtAddress macAddr;
@@ -1013,7 +1013,7 @@ otError MleRouter::HandleLinkAccept(const Message &aMessage, const Ip6::MessageI
     router->SetLastHeard(TimerMilli::GetNow());
     router->SetDeviceMode(ModeTlv::kModeFFD | ModeTlv::kModeRxOnWhenIdle | ModeTlv::kModeFullNetworkData);
     router->GetLinkInfo().Clear();
-    router->GetLinkInfo().AddRss(GetNetif().GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
+    router->GetLinkInfo().AddRss(GetNetif().GetMac().GetNoiseFloor(), linkInfo->mRss);
     router->ResetLinkFailures();
     router->SetState(Neighbor::kStateValid);
     router->SetKeySequence(aKeySequence);
@@ -1259,7 +1259,7 @@ otError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::Messa
 {
     ThreadNetif &netif = GetNetif();
     otError error = OT_ERROR_NONE;
-    const ThreadMessageInfo *threadMessageInfo = static_cast<const ThreadMessageInfo *>(aMessageInfo.GetLinkInfo());
+    const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
     Mac::ExtAddress macAddr;
     SourceAddressTlv sourceAddress;
     LeaderDataTlv leaderData;
@@ -1437,7 +1437,7 @@ otError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::Messa
         {
             router->SetExtAddress(macAddr);
             router->GetLinkInfo().Clear();
-            router->GetLinkInfo().AddRss(netif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
+            router->GetLinkInfo().AddRss(netif.GetMac().GetNoiseFloor(), linkInfo->mRss);
             router->ResetLinkFailures();
             router->SetState(Neighbor::kStateLinkRequest);
             SendLinkRequest(router);
@@ -1484,7 +1484,7 @@ otError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::Messa
         {
             router->SetExtAddress(macAddr);
             router->GetLinkInfo().Clear();
-            router->GetLinkInfo().AddRss(netif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
+            router->GetLinkInfo().AddRss(netif.GetMac().GetNoiseFloor(), linkInfo->mRss);
             router->ResetLinkFailures();
             router->SetState(Neighbor::kStateLinkRequest);
             router->SetDataRequestPending(false);
@@ -1634,7 +1634,7 @@ void MleRouter::UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId)
 otError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     otError error = OT_ERROR_NONE;
-    const ThreadMessageInfo *threadMessageInfo = static_cast<const ThreadMessageInfo *>(aMessageInfo.GetLinkInfo());
+    const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
     Mac::ExtAddress macAddr;
     VersionTlv version;
     ScanMaskTlv scanMask;
@@ -1702,7 +1702,7 @@ otError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::Messa
         // MAC Address
         child->SetExtAddress(macAddr);
         child->GetLinkInfo().Clear();
-        child->GetLinkInfo().AddRss(GetNetif().GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
+        child->GetLinkInfo().AddRss(GetNetif().GetMac().GetNoiseFloor(), linkInfo->mRss);
         child->ResetLinkFailures();
         child->SetState(Neighbor::kStateParentRequest);
         child->SetDataRequestPending(false);
@@ -2029,7 +2029,7 @@ otError MleRouter::HandleChildIdRequest(const Message &aMessage, const Ip6::Mess
 {
     ThreadNetif &netif = GetNetif();
     otError error = OT_ERROR_NONE;
-    const ThreadMessageInfo *threadMessageInfo = static_cast<const ThreadMessageInfo *>(aMessageInfo.GetLinkInfo());
+    const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
     Mac::ExtAddress macAddr;
     ResponseTlv response;
     LinkFrameCounterTlv linkFrameCounter;
@@ -2147,7 +2147,7 @@ otError MleRouter::HandleChildIdRequest(const Message &aMessage, const Ip6::Mess
     child->SetMleFrameCounter(mleFrameCounter.GetFrameCounter());
     child->SetKeySequence(aKeySequence);
     child->SetDeviceMode(mode.GetMode());
-    child->GetLinkInfo().AddRss(netif.GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
+    child->GetLinkInfo().AddRss(netif.GetMac().GetNoiseFloor(), linkInfo->mRss);
     child->SetTimeout(timeout.GetTimeout());
 
     if (mode.GetMode() & ModeTlv::kModeFullNetworkData)
@@ -2319,7 +2319,7 @@ otError MleRouter::HandleChildUpdateResponse(const Message &aMessage, const Ip6:
                                              uint32_t aKeySequence)
 {
     otError error = OT_ERROR_NONE;
-    const ThreadMessageInfo *threadMessageInfo = static_cast<const ThreadMessageInfo *>(aMessageInfo.GetLinkInfo());
+    const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
     Mac::ExtAddress macAddr;
     SourceAddressTlv sourceAddress;
     TimeoutTlv timeout;
@@ -2398,7 +2398,7 @@ otError MleRouter::HandleChildUpdateResponse(const Message &aMessage, const Ip6:
     SetChildStateToValid(child);
     child->SetLastHeard(TimerMilli::GetNow());
     child->SetKeySequence(aKeySequence);
-    child->GetLinkInfo().AddRss(GetNetif().GetMac().GetNoiseFloor(), threadMessageInfo->mRss);
+    child->GetLinkInfo().AddRss(GetNetif().GetMac().GetNoiseFloor(), linkInfo->mRss);
 
 exit:
     return error;

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -486,19 +486,6 @@ private:
 };
 
 /**
- * This structure represents Thread-specific link information.
- *
- */
-struct ThreadMessageInfo
-{
-    uint16_t mPanId;         ///< Source PAN ID
-    uint8_t  mChannel;       ///< 802.15.4 Channel
-    int8_t   mRss;           ///< Received Signal Strength in dBm.
-    uint8_t  mLqi;           ///< Link Quality Indicator for a received message.
-    bool     mLinkSecurity;  ///< Indicates whether or not link security is enabled.
-};
-
-/**
  * @}
  */
 


### PR DESCRIPTION
This PR allows application to read RSSI of the received packet from `otMessageInfo `structure by exposing `otThreadLinkInfo `structure which was previously hidden only in .hpp file.