### PR TITLE
[tests] add missing message type

### DIFF
--- a/tests/scripts/thread-cert/message.py
+++ b/tests/scripts/thread-cert/message.py
@@ -45,9 +45,10 @@ class MessageType(IntEnum):
     MLE = 0
     COAP = 1
     ICMP = 2
-    ACK = 3 
+    ACK = 3
     BEACON = 4
     DATA = 5
+    COMMAND = 6
 
 
 class Message(object):
@@ -110,6 +111,10 @@ class Message(object):
 
         elif self._mac_header.frame_type == mac802154.MacHeader.FrameType.DATA:
             self._type = MessageType.DATA
+        elif self._mac_header.frame_type == mac802154.MacHeader.FrameType.COMMAND:
+            self._type = MessageType.COMMAND
+        else:
+            raise ValueError('Invalid mac frame type %d' % self._mac_header.frame_type)
 
     @property
     def ipv6_packet(self):


### PR DESCRIPTION
This PR eliminates the following exceptions when running unit tests.

```
fdde:ad00:beef:0:b8f5:2c06:21fa:8a30
Done
> 3: thread stop
EXCEPTION: None is not a valid MessageType
thread stop
Done
> 3: ifconfig down
ifconfig down
Done
> EXCEPTION: None is not a valid MessageType
EXCEPTION: None is not a valid MessageType
EXCEPTION: None is not a valid MessageType
EXCEPTION: None is not a valid MessageType
EXCEPTION: None is not a valid MessageType
EXCEPTION: None is not a valid MessageType
EXCEPTION: None is not a valid MessageType
EXCEPTION: None is not a valid MessageType
EXCEPTION: None is not a valid MessageType
EXCEPTION: None is not a valid MessageType
```