### PR TITLE
[commissioning] improve handling of OT_ERROR_NO_BUFS

### DIFF
--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -252,21 +252,22 @@ otError CoapSecure::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, uint8_
         mTransmitMessage->SetLinkSecurityEnabled(false);
     }
 
+    SuccessOrExit(error = mTransmitMessage->Append(aBuf, aLength));
+
     // Set message sub type in case Joiner Finalize Response is appended to the message.
     if (aMessageSubType != Message::kSubTypeNone)
     {
         mTransmitMessage->SetSubType(aMessageSubType);
     }
 
-    VerifyOrExit(mTransmitMessage->Append(aBuf, aLength) == OT_ERROR_NONE, error = OT_ERROR_NO_BUFS);
-
     mTransmitTask.Post();
 
 exit:
 
-    if (error != OT_ERROR_NONE && mTransmitMessage != NULL)
+    if (error != OT_ERROR_NONE && mTransmitMessage != NULL && mTransmitMessage->GetLength() == 0)
     {
         mTransmitMessage->Free();
+        mTransmitMessage = NULL;
     }
 
     otLogFuncExitErr(error);

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -1025,7 +1025,7 @@ otError Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::MessageInf
     tlv.SetLength(aMessage.GetLength());
     SuccessOrExit(error = message->Append(&tlv, sizeof(tlv)));
     offset = message->GetLength();
-    message->SetLength(offset + aMessage.GetLength());
+    SuccessOrExit(error = message->SetLength(offset + aMessage.GetLength()));
     aMessage.CopyTo(0, offset, aMessage.GetLength(), *message);
 
     messageInfo.SetPeerAddr(netif.GetMle().GetMeshLocal16());


### PR DESCRIPTION
This commit makes the following changes:

1. Check return value of SetLength() when forming a RLY_TX.ntf message.

2. When accepting data to transmit from mbedtls, only free the message
   buffer if the message buffer is empty.  Otherwise, attempt to transmit
   the message buffer that was already formed.

3. When freeing the transmit message buffer for mbedtls, set the transmit
   message buffer pointer to NULL.