### PR TITLE
[mesh-forwarder] fix link layer address selection algorithm

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -760,16 +760,17 @@ otError MeshForwarder::UpdateIp6Route(Message &aMessage)
     GetMacSourceAddress(ip6Header.GetSource(), mMacSource);
 
     // 2. Choose correct MAC Destination Address.
-    if (netif.GetMle().GetRole() < OT_DEVICE_ROLE_CHILD)
+    if (netif.GetMle().GetRole() == OT_DEVICE_ROLE_DISABLED ||
+        netif.GetMle().GetRole() == OT_DEVICE_ROLE_DETACHED)
     {
-        // Allow only for Link-local unicasts and multicasts.
+        // Allow only for link-local unicasts and multicasts.
         if (ip6Header.GetDestination().IsLinkLocal() || ip6Header.GetDestination().IsLinkLocalMulticast())
         {
             GetMacDestinationAddress(ip6Header.GetDestination(), mMacDest);
         }
         else
         {
-            ExitNow(error = OT_ERROR_DROP);
+            error = OT_ERROR_DROP;
         }
 
         ExitNow();

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -754,163 +754,149 @@ otError MeshForwarder::UpdateIp6Route(Message &aMessage)
 
     aMessage.Read(0, sizeof(ip6Header), &ip6Header);
 
-    switch (netif.GetMle().GetRole())
+    VerifyOrExit(!ip6Header.GetSource().IsMulticast(), error = OT_ERROR_DROP);
+
+    // 1. Choose correct MAC Source Address.
+    GetMacSourceAddress(ip6Header.GetSource(), mMacSource);
+
+    // 2. Choose correct MAC Destination Address.
+    if (netif.GetMle().GetRole() < OT_DEVICE_ROLE_CHILD)
     {
-    case OT_DEVICE_ROLE_DISABLED:
-    case OT_DEVICE_ROLE_DETACHED:
+        // Allow only for Link-local unicasts and multicasts.
         if (ip6Header.GetDestination().IsLinkLocal() || ip6Header.GetDestination().IsLinkLocalMulticast())
         {
             GetMacDestinationAddress(ip6Header.GetDestination(), mMacDest);
-            GetMacSourceAddress(ip6Header.GetSource(), mMacSource);
         }
         else
         {
             ExitNow(error = OT_ERROR_DROP);
         }
 
-        break;
+        ExitNow();
+    }
 
-    case OT_DEVICE_ROLE_CHILD:
-    case OT_DEVICE_ROLE_ROUTER:
-    case OT_DEVICE_ROLE_LEADER:
+    if (ip6Header.GetDestination().IsMulticast())
+    {
+        mMacDest.mLength = sizeof(mMacDest.mShortAddress);
+
+        // With the exception of MLE multicasts, a Thread End Device transmits multicasts,
+        // as IEEE 802.15.4 unicasts to its parent.
+        if (netif.GetMle().GetRole() == OT_DEVICE_ROLE_CHILD && !aMessage.IsSubTypeMle())
+        {
+            mMacDest.mShortAddress = netif.GetMle().GetNextHop(Mac::kShortAddrBroadcast);
+        }
+        else
+        {
+            mMacDest.mShortAddress = Mac::kShortAddrBroadcast;
+        }
+    }
+    else if (ip6Header.GetDestination().IsLinkLocal())
+    {
+        GetMacDestinationAddress(ip6Header.GetDestination(), mMacDest);
+    }
+    else
+    {
         if (netif.GetMle().IsMinimalEndDevice())
         {
-            if (aMessage.IsLinkSecurityEnabled())
-            {
-                mMacDest.mLength = sizeof(mMacDest.mShortAddress);
-
-                if (ip6Header.GetDestination().IsLinkLocalMulticast())
-                {
-                    mMacDest.mShortAddress = Mac::kShortAddrBroadcast;
-                }
-                else
-                {
-                    mMacDest.mShortAddress = netif.GetMle().GetNextHop(Mac::kShortAddrBroadcast);
-                }
-
-                GetMacSourceAddress(ip6Header.GetSource(), mMacSource);
-            }
-            else if (ip6Header.GetDestination().IsLinkLocal() || ip6Header.GetDestination().IsLinkLocalMulticast())
-            {
-                GetMacDestinationAddress(ip6Header.GetDestination(), mMacDest);
-                GetMacSourceAddress(ip6Header.GetSource(), mMacSource);
-            }
-            else
-            {
-                ExitNow(error = OT_ERROR_DROP);
-            }
+            mMacDest.mLength       = sizeof(mMacDest.mShortAddress);
+            mMacDest.mShortAddress = netif.GetMle().GetNextHop(Mac::kShortAddrBroadcast);
         }
 
 #if OPENTHREAD_FTD
         else
         {
-            uint16_t rloc16;
-            uint16_t aloc16;
             Neighbor *neighbor;
 
-            if (ip6Header.GetDestination().IsLinkLocal() || ip6Header.GetDestination().IsMulticast())
+            if (netif.GetMle().IsRoutingLocator(ip6Header.GetDestination()))
             {
-                GetMacDestinationAddress(ip6Header.GetDestination(), mMacDest);
-                GetMacSourceAddress(ip6Header.GetSource(), mMacSource);
+                uint16_t rloc16 = HostSwap16(ip6Header.GetDestination().mFields.m16[7]);
+                VerifyOrExit(netif.GetMle().IsRouterIdValid(netif.GetMle().GetRouterId(rloc16)),
+                             error = OT_ERROR_DROP);
+                mMeshDest = rloc16;
+            }
+            else if (netif.GetMle().IsAnycastLocator(ip6Header.GetDestination()))
+            {
+                uint16_t aloc16 = HostSwap16(ip6Header.GetDestination().mFields.m16[7]);
+
+                if (aloc16 == Mle::kAloc16Leader)
+                {
+                    mMeshDest = netif.GetMle().GetRloc16(netif.GetMle().GetLeaderId());
+                }
+
+#if OPENTHREAD_ENABLE_DHCP6_SERVER || OPENTHREAD_ENABLE_DHCP6_CLIENT
+                else if ((aloc16 & Mle::kAloc16DhcpAgentMask) != 0)
+                {
+                    uint16_t agentRloc16;
+                    uint8_t routerId;
+                    VerifyOrExit((netif.GetNetworkDataLeader().GetRlocByContextId(
+                                      static_cast<uint8_t>(aloc16 & Mle::kAloc16DhcpAgentMask),
+                                      agentRloc16) == OT_ERROR_NONE),
+                                 error = OT_ERROR_DROP);
+
+                    routerId = netif.GetMle().GetRouterId(agentRloc16);
+
+                    // if agent is active router or the child of the device
+                    if ((netif.GetMle().IsActiveRouter(agentRloc16)) ||
+                        (netif.GetMle().GetRloc16(routerId) == netif.GetMle().GetRloc16()))
+                    {
+                        mMeshDest = agentRloc16;
+                    }
+                    else
+                    {
+                        // use the parent of the ED Agent as Dest
+                        mMeshDest = netif.GetMle().GetRloc16(routerId);
+                    }
+                }
+
+#endif  // OPENTHREAD_ENABLE_DHCP6_SERVER || OPENTHREAD_ENABLE_DHCP6_CLIENT
+                else
+                {
+                    // TODO: support ALOC for Service, Commissioner, Neighbor Discovery Agent
+                    ExitNow(error = OT_ERROR_DROP);
+                }
+            }
+            else if ((neighbor = netif.GetMle().GetNeighbor(ip6Header.GetDestination())) != NULL)
+            {
+                mMeshDest = neighbor->GetRloc16();
+            }
+            else if (netif.GetNetworkDataLeader().IsOnMesh(ip6Header.GetDestination()))
+            {
+                SuccessOrExit(error = netif.GetAddressResolver().Resolve(ip6Header.GetDestination(), mMeshDest));
             }
             else
             {
-                if (netif.GetMle().IsRoutingLocator(ip6Header.GetDestination()))
-                {
-                    rloc16 = HostSwap16(ip6Header.GetDestination().mFields.m16[7]);
-                    VerifyOrExit(netif.GetMle().IsRouterIdValid(netif.GetMle().GetRouterId(rloc16)),
-                                 error = OT_ERROR_DROP);
-                    mMeshDest = rloc16;
-                }
-                else if (netif.GetMle().IsAnycastLocator(ip6Header.GetDestination()))
-                {
-                    aloc16 = HostSwap16(ip6Header.GetDestination().mFields.m16[7]);
+                netif.GetNetworkDataLeader().RouteLookup(
+                    ip6Header.GetSource(),
+                    ip6Header.GetDestination(),
+                    NULL,
+                    &mMeshDest
+                );
+            }
 
-                    if (aloc16 == Mle::kAloc16Leader)
-                    {
-                        mMeshDest = netif.GetMle().GetRloc16(netif.GetMle().GetLeaderId());
-                    }
+            VerifyOrExit(mMeshDest != Mac::kShortAddrInvalid, error = OT_ERROR_DROP);
 
-#if OPENTHREAD_ENABLE_DHCP6_SERVER || OPENTHREAD_ENABLE_DHCP6_CLIENT
-                    else if ((aloc16 & Mle::kAloc16DhcpAgentMask) != 0)
-                    {
-                        uint16_t agentRloc16;
-                        uint8_t routerId;
-                        VerifyOrExit((netif.GetNetworkDataLeader().GetRlocByContextId(
-                                          static_cast<uint8_t>(aloc16 & Mle::kAloc16DhcpAgentMask),
-                                          agentRloc16) == OT_ERROR_NONE),
-                                     error = OT_ERROR_DROP);
+            if (netif.GetMle().GetNeighbor(mMeshDest) != NULL)
+            {
+                // destination is neighbor
+                mMacDest.mLength = sizeof(mMacDest.mShortAddress);
+                mMacDest.mShortAddress = mMeshDest;
+            }
+            else
+            {
+                // destination is not neighbor
+                mMeshSource = netif.GetMac().GetShortAddress();
 
-                        routerId = netif.GetMle().GetRouterId(agentRloc16);
+                SuccessOrExit(error = netif.GetMle().CheckReachability(mMeshSource, mMeshDest, ip6Header));
 
-                        // if agent is active router or the child of the device
-                        if ((netif.GetMle().IsActiveRouter(agentRloc16)) ||
-                            (netif.GetMle().GetRloc16(routerId) == netif.GetMle().GetRloc16()))
-                        {
-                            mMeshDest = agentRloc16;
-                        }
-                        else
-                        {
-                            // use the parent of the ED Agent as Dest
-                            mMeshDest = netif.GetMle().GetRloc16(routerId);
-                        }
-                    }
-
-#endif  // OPENTHREAD_ENABLE_DHCP6_SERVER || OPENTHREAD_ENABLE_DHCP6_CLIENT
-                    else
-                    {
-                        // TODO: support ALOC for Service, Commissioner, Neighbor Discovery Agent
-                        ExitNow(error = OT_ERROR_DROP);
-                    }
-                }
-                else if ((neighbor = netif.GetMle().GetNeighbor(ip6Header.GetDestination())) != NULL)
-                {
-                    mMeshDest = neighbor->GetRloc16();
-                }
-                else if (netif.GetNetworkDataLeader().IsOnMesh(ip6Header.GetDestination()))
-                {
-                    SuccessOrExit(error = netif.GetAddressResolver().Resolve(ip6Header.GetDestination(), mMeshDest));
-                }
-                else
-                {
-                    netif.GetNetworkDataLeader().RouteLookup(
-                        ip6Header.GetSource(),
-                        ip6Header.GetDestination(),
-                        NULL,
-                        &mMeshDest
-                    );
-                }
-
-                VerifyOrExit(mMeshDest != Mac::kShortAddrInvalid, error = OT_ERROR_DROP);
-
-                if (netif.GetMle().GetNeighbor(mMeshDest) != NULL)
-                {
-                    // destination is neighbor
-                    mMacDest.mLength = sizeof(mMacDest.mShortAddress);
-                    mMacDest.mShortAddress = mMeshDest;
-                    GetMacSourceAddress(ip6Header.GetSource(), mMacSource);
-                }
-                else
-                {
-                    // destination is not neighbor
-                    mMeshSource = netif.GetMac().GetShortAddress();
-
-                    SuccessOrExit(error = netif.GetMle().CheckReachability(mMeshSource, mMeshDest, ip6Header));
-
-                    mMacDest.mLength = sizeof(mMacDest.mShortAddress);
-                    mMacDest.mShortAddress = netif.GetMle().GetNextHop(mMeshDest);
-                    mMacSource.mLength = sizeof(mMacSource.mShortAddress);
-                    mMacSource.mShortAddress = mMeshSource;
-                    mAddMeshHeader = true;
-                }
+                mMacDest.mLength = sizeof(mMacDest.mShortAddress);
+                mMacDest.mShortAddress = netif.GetMle().GetNextHop(mMeshDest);
+                mMacSource.mLength = sizeof(mMacSource.mShortAddress);
+                mMacSource.mShortAddress = mMeshSource;
+                mAddMeshHeader = true;
             }
         }
 
 #endif  // OPENTHREAD_FTD
-        break;
-
-    default:
-        break;
     }
 
 exit:
@@ -953,13 +939,16 @@ otError MeshForwarder::GetMacSourceAddress(const Ip6::Address &aIp6Addr, Mac::Ad
 {
     ThreadNetif &netif = GetNetif();
 
-    aMacAddr.mLength = sizeof(aMacAddr.mExtAddress);
     aIp6Addr.ToExtAddress(aMacAddr.mExtAddress);
 
     if (memcmp(&aMacAddr.mExtAddress, netif.GetMac().GetExtAddress(), sizeof(aMacAddr.mExtAddress)) != 0)
     {
         aMacAddr.mLength = sizeof(aMacAddr.mShortAddress);
         aMacAddr.mShortAddress = netif.GetMac().GetShortAddress();
+    }
+    else
+    {
+        aMacAddr.mLength = sizeof(aMacAddr.mExtAddress);
     }
 
     return OT_ERROR_NONE;


### PR DESCRIPTION
This PR fixes #2046.

Now multicasts messages are sent differently by End Devices and Routers.

btw. I was not able to reproduce the point 2 which i have reported (#2046) (i could wrongly identified it).