### PR TITLE
[fuzz] enable Thread protocols and set state to Leader

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2073,13 +2073,17 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     {
         length = aMessage.Read(aMessage.GetOffset(), sizeof(buf), buf);
         aesCcm.Payload(buf, buf, length, false);
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
         aMessage.Write(aMessage.GetOffset(), length, buf);
+#endif
         aMessage.MoveOffset(length);
     }
 
     tagLength = sizeof(tag);
     aesCcm.Finalize(tag, &tagLength);
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     VerifyOrExit(messageTagLength == tagLength && memcmp(messageTag, tag, tagLength) == 0);
+#endif
 
     if (keySequence > netif.GetKeyManager().GetCurrentKeySequence())
     {

--- a/tests/fuzz/ip6_send.cpp
+++ b/tests/fuzz/ip6_send.cpp
@@ -33,6 +33,7 @@
 #include <openthread/link.h>
 #include <openthread/message.h>
 #include <openthread/thread.h>
+#include <openthread/thread_ftd.h>
 #include <openthread/types.h>
 
 #include "common/code_utils.hpp"
@@ -41,12 +42,16 @@ static otInstance *sInstance;
 
 extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv)
 {
-    (void)argc;
-    (void)argv;
+    const otPanId panId = 0xdead;
 
     sInstance = otInstanceInitSingle();
-    otLinkSetPanId(sInstance, (otPanId)0xdead);
+    otLinkSetPanId(sInstance, panId);
     otIp6SetEnabled(sInstance, true);
+    otThreadSetEnabled(sInstance, true);
+    otThreadBecomeLeader(sInstance);
+
+    (void)argc;
+    (void)argv;
 
     return 0;
 }

--- a/tests/fuzz/radio_receive_done.cpp
+++ b/tests/fuzz/radio_receive_done.cpp
@@ -33,6 +33,7 @@
 #include <openthread/ip6.h>
 #include <openthread/link.h>
 #include <openthread/thread.h>
+#include <openthread/thread_ftd.h>
 #include <openthread/types.h>
 #include <openthread/platform/radio.h>
 
@@ -42,12 +43,16 @@ static otInstance *sInstance;
 
 extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv)
 {
-    (void)argc;
-    (void)argv;
+    const otPanId panId = 0xdead;
 
     sInstance = otInstanceInitSingle();
-    otLinkSetPanId(sInstance, (otPanId)0xdead);
+    otLinkSetPanId(sInstance, panId);
     otIp6SetEnabled(sInstance, true);
+    otThreadSetEnabled(sInstance, true);
+    otThreadBecomeLeader(sInstance);
+
+    (void)argc;
+    (void)argv;
 
     return 0;
 }


### PR DESCRIPTION
This commit:

- Enables Thread-related protocols and sets the device role state to Leader
  in fuzz tests.

- Bypasses AES-CCM decryption and authentication in fuzz tests.