### PR TITLE
[cc2538] fix FLASH settings location

### DIFF
--- a/examples/platforms/cc2538/cc2538-reg.h
+++ b/examples/platforms/cc2538/cc2538-reg.h
@@ -202,7 +202,6 @@
 #define SOC_ADC_ADCCON1_RCTRL0                  0x00000004  // ADCCON1 RCTRL bit 0
 #define SOC_ADC_ADCCON1_RCTRL1                  0x00000008  // ADCCON1 RCTRL bit 1
 
-// #define FLASH_BASE                              0x00200000  // Flash base address
 #define FLASH_CTRL_FCTL                         0x400D3008  // Flash control
 #define FLASH_CTRL_DIECFG0                      0x400D3014  // Flash information
 

--- a/examples/platforms/cc2538/cc2538.ld
+++ b/examples/platforms/cc2538/cc2538.ld
@@ -54,8 +54,8 @@ _FLASH_end              = (_FLASH_start + _FLASH_size_bytes);
 _FLASH_cca_page         = (_FLASH_end - (1 * _FLASH_page_size));
 
 /*
- * Openthread NV storage goes in the settings page.
- * Openthread requires at least 2 adjacent pages, call them A and B.
+ * OpenThread NV storage goes in the settings page.
+ * OpenThread requires at least 2 adjacent pages, call them A and B.
  */
 _FLASH_settings_pageB   = (_FLASH_end - (2 * _FLASH_page_size));
 _FLASH_settings_pageA   = (_FLASH_end - (3 * _FLASH_page_size));

--- a/examples/platforms/cc2538/cc2538.ld
+++ b/examples/platforms/cc2538/cc2538.ld
@@ -62,10 +62,23 @@ _FLASH_settings_pageA   = (_FLASH_end - (3 * _FLASH_page_size));
 
 MEMORY
 {
-  FLASH (rx) :     ORIGIN = _FLASH_start,     LENGTH = _FLASH_usable_size
-  FLASH_CCA (rx) : ORIGIN = (_FLASH_cca_page + 0x7d4)   LENGTH = 0x2c
-  SRAM (rwx) :     ORIGIN = 0x20000000,       LENGTH = 32K
+  /* would like to use SYMBOLS (from above)here but we cannot
+   * GCC version 4.9 does not support symbolic expressions here.
+   * But later versions do support the feature.
+   */
+  FLASH (rx) :     ORIGIN = 0x00200000,     LENGTH = 0x0007c000
+  FLASH_CCA (rx) : ORIGIN = 0x0027FFD4,     LENGTH = 0x2c
+  SRAM (rwx) :     ORIGIN = 0x20000000,     LENGTH = 32K
 }
+/*
+ * To safty check what would have been the SYMBOL values
+ * we use these ASSERTS to verify things are still good.
+ */
+ASSERT( _FLASH_start       == 0x00200000, "invalid flash start address for cc2538")
+ASSERT( _FLASH_cca_page    == 0x0027f800, "invalid cca start address for cc2538")
+ASSERT( _FLASH_usable_size == 0x0007e800, "Invalid usable size for this config")
+
+
 
 ENTRY(flash_cca_lock_page)
 SECTIONS

--- a/examples/platforms/cc2538/flash.c
+++ b/examples/platforms/cc2538/flash.c
@@ -37,10 +37,10 @@
 #include <openthread/platform/alarm-milli.h>
 
 #include "platform-cc2538.h"
-#include "utils/wrap_string.h"
 #include "rom-utility.h"
 #include "utils/code_utils.h"
 #include "utils/flash.h"
+#include "utils/wrap_string.h"
 
 #define FLASH_CTRL_FCTL_BUSY   0x00000080
 

--- a/examples/platforms/cc2538/flash.c
+++ b/examples/platforms/cc2538/flash.c
@@ -31,13 +31,13 @@
 
 #include <fcntl.h>
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
 
 #include <openthread/platform/alarm-milli.h>
 
 #include "platform-cc2538.h"
+#include "utils/wrap_string.h"
 #include "rom-utility.h"
 #include "utils/code_utils.h"
 #include "utils/flash.h"

--- a/examples/platforms/cc2538/openthread-core-cc2538-config.h
+++ b/examples/platforms/cc2538/openthread-core-cc2538-config.h
@@ -75,7 +75,7 @@
  */
 #define SETTINGS_CONFIG_BASE_ADDRESS                           0
 
-/*
+/**
  * The CC2538 linker script sets aside 2 pages.
  */
 #define SETTINGS_CONFIG_PAGE_NUM                               2

--- a/examples/platforms/cc2538/openthread-core-cc2538-config.h
+++ b/examples/platforms/cc2538/openthread-core-cc2538-config.h
@@ -76,13 +76,13 @@
 #define SETTINGS_CONFIG_BASE_ADDRESS                           0
 
 /**
- * The CC2538 linker script sets aside 2 pages.
+ * @def The CC2538 linker script sets aside 2 pages.
  */
 #define SETTINGS_CONFIG_PAGE_NUM                               2
 
 /**
- * The page size of settings, 2K bytes
+ * @def The page size of settings, 2K bytes
  */
-#define  SETTINGS_CONFIG_PAGE_SIZE                             2048
+#define SETTINGS_CONFIG_PAGE_SIZE                              2048
 
 #endif  // OPENTHREAD_CORE_CC2538_CONFIG_H_


### PR DESCRIPTION
Openthread settings are stored in onchip system flash in 2 pages (2K bytes each, total 4Kbytes), current location is at offset 0x03900 (physical location: 0x00239000 to 0x00239fff) which is near the center of the 512K bytes of available FLASH memory, as the application grows (ie: Compile: -Ofast vrs -Os [space], or turn on features [Lots of logging]) eventually the code grows and overflows address flash offset 0x03900

This moves the two pages to the last few pages of FLASH - specifically the page allocation is:
(N-3) - Settings Page A
(N-2) - Settings Page B
(N-1) - Physical last page of FLASH, also known as the CCA where various factory settings are stored.
Where N is the number of pages, which is either:  most commonly (512K/2K) or certain variants (256K/2K)

Resolves #2069.