### PR TITLE
[network-data] iterate over all external routes or on-mesh prefix entries

### DIFF
--- a/doc/spinel-protocol-src/spinel-tech-thread.md
+++ b/doc/spinel-protocol-src/spinel-tech-thread.md
@@ -95,6 +95,8 @@ Data per item is:
 * `b`: "Is defined locally" flag. Set if this network was locally
   defined. Assumed to be true for set, insert and replace. Clear if
   the on mesh network was defined by another node.
+* `S`: The RLOC16 of the device that registered this on-mesh prefix entry.
+  This value is not used and ignored when adding an on-mesh prefix.
 
 ### PROP 91: PROP_THREAD_OFF_MESH_ROUTES
 * Type: Read-Write
@@ -114,6 +116,8 @@ Data per item is:
   route is this device itself (i.e., route was added by this device)
   This value is ignored when adding an external route. For any added
   route the next hop is this device.
+* `S`: The RLOC16 of the device that registered this route entry.
+  This value is not used and ignored when adding a route.
 
 ### PROP 92: PROP_THREAD_ASSISTING_PORTS
 * Type: Read-Write

--- a/examples/drivers/windows/otLwf/iocontrol.c
+++ b/examples/drivers/windows/otLwf/iocontrol.c
@@ -4833,12 +4833,12 @@ otLwfIoCtl_otNextOnMeshPrefix(
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
 
-    if (InBufferLength >= sizeof(BOOLEAN) + sizeof(uint8_t) &&
-        *OutBufferLength >= sizeof(uint8_t) + sizeof(otBorderRouterConfig))
+    if (InBufferLength >= sizeof(BOOLEAN) + sizeof(uint16_t) &&
+        *OutBufferLength >= sizeof(uint16_t) + sizeof(otBorderRouterConfig))
     {
         BOOLEAN aLocal = *(BOOLEAN*)InBuffer;
-        uint8_t aIterator = *(uint8_t*)(InBuffer + sizeof(BOOLEAN));
-        otBorderRouterConfig* aConfig = (otBorderRouterConfig*)((PUCHAR)OutBuffer + sizeof(uint8_t));
+        uint16_t aIterator = *(uint16_t*)(InBuffer + sizeof(BOOLEAN));
+        otBorderRouterConfig* aConfig = (otBorderRouterConfig*)((PUCHAR)OutBuffer + sizeof(uint16_t));
         if (aLocal)
         {
             status = ThreadErrorToNtstatus(
@@ -4860,7 +4860,7 @@ otLwfIoCtl_otNextOnMeshPrefix(
         *OutBufferLength = sizeof(uint8_t) + sizeof(otBorderRouterConfig);
         if (status == STATUS_SUCCESS)
         {
-            *(uint8_t*)OutBuffer = aIterator;
+            *(uint16_t*)OutBuffer = aIterator;
         }
     }
     else

--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -696,7 +696,7 @@ typedef struct otIp6Prefix
 
 #define OT_NETWORK_DATA_ITERATOR_INIT  0  ///< Initializer for otNetworkDataIterator.
 
-typedef uint8_t otNetworkDataIterator;  ///< Used to iterate through Network Data information.
+typedef uint16_t otNetworkDataIterator;  ///< Used to iterate through Network Data information.
 
 /**
  * This structure represents a Border Router configuration.
@@ -763,6 +763,13 @@ typedef struct otExternalRouteConfig
      * The prefix for the off-mesh route.
      */
     otIp6Prefix mPrefix;
+
+    /**
+     * The Rloc associated with the external route entry.
+     *
+     * This value is ignored when adding an external route. For any added route the device's Rloc will be used.
+     */
+    uint16_t mRloc16;
 
     /**
      * A 2-bit signed integer indicating router preference as defined in RFC 4291.

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -353,6 +353,21 @@ private:
         kDataResubmitDelay = 300000,  ///< DATA_RESUBMIT_DELAY (miliseconds)
     };
 
+    class NetworkDataIterator
+    {
+    public:
+        NetworkDataIterator(otNetworkDataIterator *aIterator):
+            mIteratorBuffer(reinterpret_cast<uint8_t *>(aIterator)) { }
+
+        uint8_t GetTlvsIndex(void) const { return mIteratorBuffer[0]; }
+        uint8_t GetEntryIndex(void) const { return mIteratorBuffer[1]; }
+        void SetTlvsIndex(uint8_t aIndex) { mIteratorBuffer[0] = aIndex; }
+        void SetEntryIndex(uint8_t aIndex) { mIteratorBuffer[1] = aIndex; }
+
+    private:
+        uint8_t *mIteratorBuffer;
+    };
+
     const bool      mLocal;
     bool            mLastAttemptWait;
     uint32_t        mLastAttempt;

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -1078,12 +1078,14 @@ otError NcpBase::GetPropertyHandler_THREAD_ON_MESH_NETS(uint8_t aHeader, spinel_
                             SPINEL_DATATYPE_BOOL_S          // isStable
                             SPINEL_DATATYPE_UINT8_S         // Flags
                             SPINEL_DATATYPE_BOOL_S          // isLocal
+                            SPINEL_DATATYPE_UINT16_S        // RLOC16
                         ),
                         &borderRouterConfig.mPrefix,
                         64,
                         borderRouterConfig.mStable,
                         flags,
-                        false
+                        false,
+                        borderRouterConfig.mRloc16
                     ));
     }
 
@@ -1108,12 +1110,14 @@ otError NcpBase::GetPropertyHandler_THREAD_ON_MESH_NETS(uint8_t aHeader, spinel_
                             SPINEL_DATATYPE_BOOL_S          // isStable
                             SPINEL_DATATYPE_UINT8_S         // Flags
                             SPINEL_DATATYPE_BOOL_S          // isLocal
+                            SPINEL_DATATYPE_UINT16_S        // RLOC16
                         ),
                         &borderRouterConfig.mPrefix,
                         64,
                         borderRouterConfig.mStable,
                         flags,
-                        true
+                        true,
+                        borderRouterConfig.mRloc16
                     ));
     }
 #endif // OPENTHREAD_ENABLE_BORDER_ROUTER
@@ -1801,13 +1805,15 @@ otError NcpBase::GetPropertyHandler_THREAD_OFF_MESH_ROUTES(uint8_t aHeader, spin
                             SPINEL_DATATYPE_UINT8_S         // Route Preference Flags
                             SPINEL_DATATYPE_BOOL_S          // IsLocal
                             SPINEL_DATATYPE_BOOL_S          // NextHopIsThisDevice
+                            SPINEL_DATATYPE_UINT16_S        // RLOC16
                         ),
                         &external_route_config.mPrefix.mPrefix,
                         external_route_config.mPrefix.mLength,
                         external_route_config.mStable,
                         ExternalRoutePreferenceToFlagByte(external_route_config.mPreference),
                         false,
-                        external_route_config.mNextHopIsThisDevice
+                        external_route_config.mNextHopIsThisDevice,
+                        external_route_config.mRloc16
                     ));
     }
 
@@ -1823,13 +1829,15 @@ otError NcpBase::GetPropertyHandler_THREAD_OFF_MESH_ROUTES(uint8_t aHeader, spin
                             SPINEL_DATATYPE_UINT8_S         // Route Preference Flags
                             SPINEL_DATATYPE_BOOL_S          // IsLocal
                             SPINEL_DATATYPE_BOOL_S          // NextHopIsThisDevice
+                            SPINEL_DATATYPE_UINT16_S        // RLOC16
                         ),
                         &external_route_config.mPrefix.mPrefix,
                         external_route_config.mPrefix.mLength,
                         external_route_config.mStable,
                         ExternalRoutePreferenceToFlagByte(external_route_config.mPreference),
                         true,
-                        external_route_config.mNextHopIsThisDevice
+                        external_route_config.mNextHopIsThisDevice,
+                        external_route_config.mRloc16
                     ));
     }
 #endif // OPENTHREAD_ENABLE_BORDER_ROUTER

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -807,7 +807,7 @@ typedef enum
                                         = SPINEL_PROP_THREAD__BEGIN + 8, ///< [D]
     SPINEL_PROP_THREAD_STABLE_NETWORK_DATA_VERSION
                                         = SPINEL_PROP_THREAD__BEGIN + 9,  ///< [S]
-    SPINEL_PROP_THREAD_ON_MESH_NETS     = SPINEL_PROP_THREAD__BEGIN + 10, ///< array(ipv6prefix,prefixlen,stable,flags,isLocal) [A(t(6CbCb))]
+    SPINEL_PROP_THREAD_ON_MESH_NETS     = SPINEL_PROP_THREAD__BEGIN + 10, ///< array(ipv6prefix,prefixlen,stable,flags,isLocal,rloc6) [A(t(6CbCbS))]
 
     /// Off-mesh routes
     /** Format: [A(t(6CbCbb))]
@@ -826,6 +826,8 @@ typedef enum
      *       route is this device itself (i.e., route was added by this device)
      *       This value is ignored when adding an external route. For any added
      *       route the next hop is this device.
+     *  `S`: The RLOC16 of the device that registered this route entry.
+     *       This value is not used and ignored when adding a route.
      *
      */
     SPINEL_PROP_THREAD_OFF_MESH_ROUTES  = SPINEL_PROP_THREAD__BEGIN + 11,


### PR DESCRIPTION
The same external route or on-mesh prefix can be registered by
different devices with different flags (e.g., different preference
level). This info is stored in network data as part of the
BorderRouterEntry TLV. This commit changes the methods
`GetNextOnMeshPrefix()` and `GetNextExternalRoute()`  to ensure that
different entries corresponding to the same prefix are provided
separately when iterating over all entries (i.e., without giving
a specific RLOC16).

To implement this the `otNetworkDataIterator` is changed to track
both the index into the `mTlvs` buffer and the entry index.

This commit also appends an RLOC16 field to the struct packing
format of `SPINEL_PROP_THREAD_ON_MESH_NETS and `OFF_MESH_ROUTES`
spinel properties and updates the implementation and documentation
accordingly.