### PR TITLE
[harness-automation] fix for test cases with many devices

### DIFF
--- a/tools/harness-automation/autothreadharness/harness_case.py
+++ b/tools/harness-automation/autothreadharness/harness_case.py
@@ -544,6 +544,8 @@ class HarnessCase(unittest.TestCase):
                     time.sleep(5)
 
                 button_next.click()
+                if not wait_until(lambda: self._browser.current_url.endswith('TestExecution.html'), 20):
+                    raise Exception('Failed to load TestExecution page')
             except FailError:
                 raise
             except:


### PR DESCRIPTION
There was a problem with running test cases with many golden devices (around 30). Time needed to load the TestExecution page after clicking the Next button is so long for those cases that automation tool was starting the test bed preparation step once again and deleting devices which were already configured. I added an explicit wait after clicking the Next button to avoid this situation. 