### PR TITLE
[ncp] fix issues when `OPENTHREAD_ENABLE_RAW_LINK_API` is disabled

### DIFF
--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -328,6 +328,9 @@ private:
                                                 NcpFrameBuffer::Priority aPriority, NcpFrameBuffer *aNcpBuffer);
     void HandleFrameRemovedFromNcpBuffer(NcpFrameBuffer::FrameTag aFrameTag);
 
+    static void HandleRawFrame(const otRadioFrame *aFrame, void *aContext);
+    void HandleRawFrame(const otRadioFrame *aFrame);
+
 #if OPENTHREAD_ENABLE_RAW_LINK_API
 
     static void LinkRawReceiveDone(otInstance *aInstance, otRadioFrame *aFrame, otError aError);
@@ -339,8 +342,6 @@ private:
     static void LinkRawEnergyScanDone(otInstance *aInstance, int8_t aEnergyScanMaxRssi);
     void LinkRawEnergyScanDone(int8_t aEnergyScanMaxRssi);
 
-    static void HandleRawFrame(const otRadioFrame *aFrame, void *aContext);
-    void HandleRawFrame(const otRadioFrame *aFrame);
 #endif // OPENTHREAD_ENABLE_RAW_LINK_API
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
@@ -403,6 +404,7 @@ private:
     NCP_GET_PROP_HANDLER(PHY_RX_SENSITIVITY);
     NCP_GET_PROP_HANDLER(PHY_TX_POWER);
     NCP_SET_PROP_HANDLER(PHY_TX_POWER);
+    NCP_GET_PROP_HANDLER(PHY_ENABLED);
     NCP_SET_PROP_HANDLER(PHY_CHAN);
     NCP_GET_PROP_HANDLER(PHY_CHAN);
 
@@ -437,7 +439,6 @@ private:
     NCP_INSERT_PROP_HANDLER(MAC_SRC_MATCH_EXTENDED_ADDRESSES);
     NCP_REMOVE_PROP_HANDLER(MAC_SRC_MATCH_EXTENDED_ADDRESSES);
 
-    NCP_GET_PROP_HANDLER(PHY_ENABLED);
     NCP_SET_PROP_HANDLER(PHY_ENABLED);
     NCP_SET_PROP_HANDLER(STREAM_RAW);
 #endif // OPENTHREAD_ENABLE_RAW_LINK_API

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -59,6 +59,8 @@
 namespace ot {
 namespace Ncp {
 
+#if OPENTHREAD_ENABLE_RAW_LINK_API
+
 static bool HasOnly1BitSet(uint32_t aValue)
 {
     return aValue != 0 && ((aValue & (aValue - 1)) == 0);
@@ -75,6 +77,8 @@ static uint8_t IndexOfMSB(uint32_t aValue)
 
     return index;
 }
+
+#endif // OPENTHREAD_ENABLE_RAW_LINK_API
 
 static uint8_t BorderRouterConfigToFlagByte(const otBorderRouterConfig &aConfig)
 {


### PR DESCRIPTION
This commit ensues that some properties/methods which are defined under "raw-link-api" feature only are also `#ifdef`ed in the lookup entry table definitions. Another change is related to `HandleRawFrame()` method which is used/needed for packet capture independent of "raw-link-api" feature.

----

This issue seems to be introduced during "ncp-base" refactor. Currently OT build fails if "--enable-raw-link-api=no" feature.


