### PR TITLE
[nRF52840] allow direct transition from TX to SLEEP state

### DIFF
--- a/third_party/NordicSemiconductor/drivers/radio/nrf_drv_radio802154.c
+++ b/third_party/NordicSemiconductor/drivers/radio/nrf_drv_radio802154.c
@@ -184,6 +184,9 @@ bool nrf_drv_radio802154_sleep(void)
     case RADIO_STATE_RX_HEADER:
     case RADIO_STATE_RX_FRAME:
     case RADIO_STATE_TX_ACK:
+    case RADIO_STATE_CCA_BEFORE_TX:
+    case RADIO_STATE_TX_FRAME:
+    case RADIO_STATE_RX_ACK:
         result = nrf_drv_radio802154_request_sleep();
         break;
 


### PR DESCRIPTION
This PR fixes problem with SEDs. It looks that currently SEDs request transition to SLEEP state from TX state on ACK timeout.