### PR TITLE
[meshcop] fix network name overflow

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -188,6 +188,7 @@ void Dataset::Get(otOperationalDataset &aDataset) const
         {
             const NetworkNameTlv *tlv = static_cast<const NetworkNameTlv *>(cur);
             memcpy(aDataset.mNetworkName.m8, tlv->GetNetworkName(), tlv->GetLength());
+            aDataset.mNetworkName.m8[tlv->GetLength()] = '\0';
             aDataset.mIsNetworkNameSet = true;
             break;
         }

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -196,6 +196,7 @@ otError DatasetLocal::Get(otOperationalDataset &aDataset) const
         {
             const NetworkNameTlv *tlv = static_cast<const NetworkNameTlv *>(cur);
             memcpy(aDataset.mNetworkName.m8, tlv->GetNetworkName(), tlv->GetLength());
+            aDataset.mNetworkName.m8[tlv->GetLength()] = '\0';
             aDataset.mIsNetworkNameSet = true;
             break;
         }

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -151,8 +151,8 @@ otError DatasetManager::ApplyConfiguration(void)
         {
             const NetworkNameTlv *name = static_cast<const NetworkNameTlv *>(cur);
             otNetworkName networkName;
-            memset(networkName.m8, 0, sizeof(networkName));
             memcpy(networkName.m8, name->GetNetworkName(), name->GetLength());
+            networkName.m8[name->GetLength()] = '\0';
             netif.GetMac().SetNetworkName(networkName.m8);
             break;
         }

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -435,7 +435,13 @@ void Joiner::HandleJoinerEntrust(Coap::Header &aHeader, Message &aMessage, const
     netif.GetKeyManager().SetCurrentKeySequence(networkKeySeq.GetNetworkKeySequence());
     netif.GetMle().SetMeshLocalPrefix(meshLocalPrefix.GetMeshLocalPrefix());
     netif.GetMac().SetExtendedPanId(extendedPanId.GetExtendedPanId());
-    netif.GetMac().SetNetworkName(networkName.GetNetworkName());
+
+    {
+        otNetworkName name;
+        memcpy(name.m8, networkName.GetNetworkName(), networkName.GetLength());
+        name.m8[networkName.GetLength()] = '\0';
+        netif.GetMac().SetNetworkName(name.m8);
+    }
 
     otLogInfoMeshCoP(GetInstance(), "join success!");
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3098,6 +3098,7 @@ otError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::Message
             aMessage.Read(offset, sizeof(networkName), &networkName);
             VerifyOrExit(networkName.IsValid(), error = OT_ERROR_PARSE);
             memcpy(&result.mNetworkName, networkName.GetNetworkName(), networkName.GetLength());
+            result.mNetworkName.m8[networkName.GetLength()] = '\0';
             break;
 
         case MeshCoP::Tlv::kSteeringData:


### PR DESCRIPTION
This PR fixes the network name overflow issue.

`NetworkNameTlv::mNetworkName` is not null-terminated. In `Joiner::HandleJoinerEntrust`, it is passed it to `Mac::SetNetworkName()` and causes stack corrupted. This happens more on 32bit system than 64bit system.