### PR TITLE
[mle] maintain existing child id whenever possible

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2724,7 +2724,7 @@ otError MleRouter::SendChildIdResponse(Child *aChild)
     SuccessOrExit(error = AppendActiveTimestamp(*message));
     SuccessOrExit(error = AppendPendingTimestamp(*message));
 
-    if (aChild->GetState() != Neighbor::kStateValid)
+    if (aChild->GetRloc16() == 0)
     {
         // pick next Child ID that is not being used
         do


### PR DESCRIPTION
Child IDs are assigned when receiving a Child ID Request.  Prior to this
commit, a new Child ID is assigned whenever the child state is not valid.
A router stores state about its attached children in non-volatile memory.
On a reboot, the router attempts to restore its child links.  As a result,
it is possible for the child to be assigned a new Child ID while it is
being restored.

With this commit, a router only assigns a new Child ID if there is no
existing Child ID state for the given child.