### PR TITLE
[doxygen] grammar and tag fixes

### DIFF
--- a/include/openthread/border_router.h
+++ b/include/openthread/border_router.h
@@ -44,6 +44,9 @@ extern "C" {
 /**
  * @addtogroup api-border-router
  *
+ * @brief
+ *  This module includes functions to manage local network data with the OpenThread Border Router.
+ *
  * @{
  *
  */

--- a/include/openthread/child_supervision.h
+++ b/include/openthread/child_supervision.h
@@ -29,7 +29,7 @@
 /**
  * @file
  * @brief
- *   This file includes the OenThread API for child supervision feature
+ *   This file includes the OpenThread API for child supervision feature
  */
 
 #ifndef OPENTHREAD_CHILD_SUPERVISION_H_

--- a/include/openthread/platform/spi-slave.h
+++ b/include/openthread/platform/spi-slave.h
@@ -75,7 +75,7 @@ extern "C" {
  * @param[in] aInputBufLen       Value of aInputBufLen from last call to `otPlatSpiSlavePrepareTransaction()`
  * @param[in] aTransactionLength Length of the completed transaction, in bytes.
  *
- * @returns  TRUE if after this call returns the platform should invoke the the process callback `aProcessCallback`,
+ * @returns  TRUE if after this call returns the platform should invoke the process callback `aProcessCallback`,
  *           FALSE if there is nothing to process and no need to invoke the process callback.
  */
 typedef bool (*otPlatSpiSlaveTransactionCompleteCallback)(void *aContext, uint8_t *aOutputBuf, uint16_t aOutputBufLen,

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1720,7 +1720,7 @@ Done
 
 ### macfilter rss clear
 
-Clear all the the received signal strength or received link quality settings.
+Clear all the received signal strength or received link quality settings.
 
 ```bash
 > macfilter rss clear

--- a/src/core/crypto/heap.hpp
+++ b/src/core/crypto/heap.hpp
@@ -57,7 +57,7 @@ namespace Crypto {
  *     | 2 bytes |  n bytes | 2 bytes |
  *     +------------------------------+
  *
- * Since block metadata is of 4-byte size, mSize and mNext are separated at the begining
+ * Since block metadata is of 4-byte size, mSize and mNext are separated at the beginning
  * and end of the block to make sure the mMemory is aligned with long.
  *
  */

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -395,7 +395,7 @@ public:
     /**
      * This method returns the offset from the transmission time to the end of trickle interval.
      *
-     * @returns The offset from the the transmission time to the end of trickle interval.
+     * @returns The offset from the transmission time to the end of trickle interval.
      *
      */
     uint8_t GetIntervalOffset(void) const { return mIntervalOffset; }
@@ -403,7 +403,7 @@ public:
     /**
      * This method sets the offset from the transmission time to the end of trickle interval.
      *
-     * @param[in]  aIntervalOffset  The offset from the the transmission time to the end of trickle interval.
+     * @param[in]  aIntervalOffset  The offset from the transmission time to the end of trickle interval.
      *
      */
     void SetIntervalOffset(uint8_t aIntervalOffset) { mIntervalOffset = aIntervalOffset; }

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -69,7 +69,7 @@ otError RssAverager::Add(int8_t aRss)
         aRss = 0;
     }
 
-    // Multiply the the RSS value by a precision multiple (currently -8).
+    // Multiply the RSS value by a precision multiple (currently -8).
 
     newValue = static_cast<uint16_t>(-aRss);
     newValue <<= kPrecisionBitShift;

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -182,7 +182,7 @@ public:
     /**
      * This method returns a reference to the dhcp server object.
      *
-     * @returns A reference to the the dhcp server object.
+     * @returns A reference to the dhcp server object.
      *
      */
     Dhcp6::Dhcp6Server &GetDhcp6Server(void) { return mDhcp6Server; }

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -206,7 +206,7 @@ protected:
      *
      * If no buffer space is available, this method should discard and clear the frame before returning an error status.
      * In case of success, the passed-in message @aMessage should be owned by outbound buffer and should be freed
-     * when either the the frame is successfully sent and removed or if the frame is discarded.
+     * when either the frame is successfully sent and removed or if the frame is discarded.
      *
      * @param[in]  aMessage         A reference to the message to be added to current frame.
      *

--- a/src/ncp/ncp_buffer.hpp
+++ b/src/ncp/ncp_buffer.hpp
@@ -192,7 +192,7 @@ public:
      * `OT_ERROR_NO_BUFS`.
      *
      * In case of success, the passed-in message @p aMessage will be owned by the frame buffer instance and will be
-     * freed when either the the frame is removed or discarded. In case of failure @p aMessage remains unchanged.
+     * freed when either the frame is removed or discarded. In case of failure @p aMessage remains unchanged.
      *
      * @param[in] aMessage              A message to be added to current frame.
      *

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -1001,7 +1001,7 @@ typedef enum
      *
      * Required capability: SPINEL_CAP_OOB_STEERING_DATA.
      *
-     * Writing to this property allows to set/update the the MLE Discovery Response steering data out of band.
+     * Writing to this property allows to set/update the MLE Discovery Response steering data out of band.
      *
      *  - All zeros to clear the steering data (indicating that there is no steering data).
      *  - All 0xFFs to set steering data/bloom filter to accept/allow all.

--- a/tools/spi-hdlc-adapter/README.md
+++ b/tools/spi-hdlc-adapter/README.md
@@ -38,7 +38,7 @@ protocol document.
 *   `--spi-cs-delay[=usec]`: Specify the delay after C̅S̅ assertion,
     in microseconds. Default is 20µs. Note that this may need to be
     set to zero for spi-hdlc-adapter to work with some SPI drivers.
-*   `--spi-align-allowance[=n]`: Specify the the maximum number of 0xFF
+*   `--spi-align-allowance[=n]`: Specify the maximum number of 0xFF
     bytes to clip from start of MISO frame. This makes this tool usable
     with SPI slaves which have buggy SPI blocks that prepend up to
     three 0xFF bytes to the start of MISO frame. Default value is `0`.

--- a/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
+++ b/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
@@ -1457,7 +1457,7 @@ static void print_help(void)
     "    --spi-mode[=mode] ............ Specify the SPI mode to use (0-3).\n"
     "    --spi-speed[=hertz] .......... Specify the SPI speed in hertz.\n"
     "    --spi-cs-delay[=usec] ........ Specify the delay after C̅S̅ assertion, in µsec\n"
-    "    --spi-align-allowance[=n] .... Specify the the maximum number of FF bytes to\n"
+    "    --spi-align-allowance[=n] .... Specify the maximum number of FF bytes to\n"
     "                                   clip from start of MISO frame. Max value is 3.\n"
     "    --spi-small-packet=[n] ....... Specify the smallest packet we can receive\n"
     "                                   in a single transaction(larger packets will\n"


### PR DESCRIPTION
- Replaced all instances of "the the" in comments with "the"
- Couple of Doxygen tag fixes (Border Router brief, misspellings)