### PR TITLE
[build] simplify platform-specific Makefile configuration.

### DIFF
--- a/examples/apps/cli/Makefile.am
+++ b/examples/apps/cli/Makefile.am
@@ -27,27 +27,27 @@
 #
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
+include $(top_srcdir)/examples/platforms/Makefile.platform.am
 
 bin_PROGRAMS                                                           = \
     $(NULL)
 
-CPPFLAGS_COMMON                                                        = \
+CPPFLAGS_COMMON                                                       += \
     -I$(top_srcdir)/include                                              \
     -I$(top_srcdir)/src/core                                             \
     -I$(top_srcdir)/examples/platforms                                   \
     $(NULL)
 
-LDADD_COMMON                                                           = \
+LDADD_COMMON                                                          += \
     $(NULL)
 
-LDFLAGS_COMMON                                                         = \
+LDFLAGS_COMMON                                                        += \
     $(NULL)
 
-LIBTOOLFLAGS_COMMON                                                    = \
-    --preserve-dup-deps                                                  \
+LIBTOOLFLAGS_COMMON                                                   += \
     $(NULL)
 
-SOURCES_COMMON                                                         = \
+SOURCES_COMMON                                                        += \
     main.c                                                               \
     $(NULL)
 
@@ -62,124 +62,6 @@ LDADD_COMMON                                                          += \
     $(top_builddir)/src/diag/libopenthread-diag.a                        \
     $(NULL)
 endif # OPENTHREAD_ENABLE_DIAG
-
-if OPENTHREAD_EXAMPLES_POSIX
-LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/posix/libopenthread-posix.a       \
-    -lstdc++                                                             \
-    $(NULL)
-endif # OPENTHREAD_EXAMPLES_POSIX
-
-if OPENTHREAD_EXAMPLES_CC2538
-LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/cc2538/libopenthread-cc2538.a     \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        += \
-    -T $(top_srcdir)/examples/platforms/cc2538/cc2538.ld                 \
-    $(NULL)
-endif # OPENTHREAD_EXAMPLES_CC2538
-
-if OPENTHREAD_EXAMPLES_CC2650
-CPPFLAGS_COMMON                                                       += \
-    -I$(top_srcdir)/third_party/ti/devices/cc26x0                        \
-    $(NULL)
-
-LDADD_COMMON                                                          +=      \
-    $(top_builddir)/examples/platforms/cc2650/libopenthread-cc2650.a          \
-    $(top_srcdir)/third_party/ti/devices/cc26x0/driverlib/bin/gcc/driverlib.a \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        +=       \
-    -T $(top_srcdir)/third_party/ti/devices/cc26x0/linker_files/cc26x0f128.lds \
-    $(NULL)
-
-endif #OPENTHREAD_EXAMPLES_CC2650
-
-if OPENTHREAD_EXAMPLES_CC2652
-CPPFLAGS_COMMON                                                       += \
-    -I$(top_srcdir)/third_party/ti/devices/cc26x2                        \
-    $(NULL)
-
-LDADD_COMMON                                                          +=      \
-    $(top_builddir)/examples/platforms/cc2652/libopenthread-cc2652.a          \
-    $(top_srcdir)/third_party/ti/devices/cc26x2/driverlib/bin/gcc/driverlib.a \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        +=      \
-    -T $(top_srcdir)/third_party/ti/devices/cc26x2/linker_files/cc26x2r1f.lds \
-    $(NULL)
-
-endif #OPENTHREAD_EXAMPLES_CC2652
-
-if OPENTHREAD_EXAMPLES_DA15000
-LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/da15000/libopenthread-da15000.a   \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        += \
-    -T $(top_srcdir)/third_party/dialog/DialogSDK/bsp/ldfile/da15000.ld  \
-    $(NULL)
-endif # OPENTHREAD_EXAMPLES_DA15000
-
-if OPENTHREAD_EXAMPLES_EFR32
-    LDADD_COMMON                                                      += \
-    $(top_builddir)/examples/platforms/efr32/libopenthread-efr32.a       \
-    $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v1.1/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg12_gcc_release.a \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        += \
-    -T $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v1.1/platform/Device/SiliconLabs/EFR32MG12P/Source/GCC/efr32mg12p.ld \
-    $(NULL)
-endif # OPENTHREAD_EXAMPLES_EFR32
-
-if OPENTHREAD_EXAMPLES_EMSK
-LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/emsk/libopenthread-emsk.a         \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        += \
-    -T $(top_srcdir)/examples/platforms/emsk/emsk.ld                     \
-    $(NULL)
-endif # OPENTHREAD_EXAMPLES_EMSK
-
-if OPENTHREAD_EXAMPLES_GP712
-LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/gp712/libopenthread-gp712.a       \
-    $(top_srcdir)/third_party/Qorvo/gp712/libQorvoRPi.a                  \
-    $(NULL)
-
-endif # OPENTHREAD_EXAMPLES_GP712
-
-if OPENTHREAD_EXAMPLES_NRF52840
-LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/nrf52840/libopenthread-nrf52840.a \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        += \
-    -T $(top_srcdir)/examples/platforms/nrf52840/nrf52840.ld             \
-    $(NULL)
-endif
-
-if OPENTHREAD_EXAMPLES_KW41Z
-LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/kw41z/libopenthread-kw41z.a       \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        += \
-    -T $(top_srcdir)/examples/platforms/kw41z/MKW41Z512xxx4.ld           \
-    $(NULL)
-endif # OPENTHREAD_EXAMPLES_KW41Z
-
-if OPENTHREAD_EXAMPLES_SAMR21
-LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/samr21/libopenthread-samr21.a     \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        += \
-    -T $(top_srcdir)/third_party/microchip/include/samr21x18a.ld         \
-    $(NULL)
-endif # OPENTHREAD_EXAMPLES_SAMR21
 
 if OPENTHREAD_ENABLE_CLI_FTD
 bin_PROGRAMS                                                          += \
@@ -196,6 +78,7 @@ ot_cli_ftd_LDADD                                                       = \
     $(top_builddir)/src/core/libopenthread-ftd.a                         \
     $(LDADD_COMMON)                                                      \
     $(top_builddir)/src/core/libopenthread-ftd.a                         \
+    $(LDADD_COMMON)                                                      \
     $(NULL)
 
 ot_cli_ftd_LDFLAGS                                                     = \
@@ -225,6 +108,7 @@ ot_cli_mtd_LDADD                                                       = \
     $(top_builddir)/src/core/libopenthread-mtd.a                         \
     $(LDADD_COMMON)                                                      \
     $(top_builddir)/src/core/libopenthread-mtd.a                         \
+    $(LDADD_COMMON)                                                      \
     $(NULL)
 
 ot_cli_mtd_LDFLAGS                                                     = \

--- a/examples/apps/ncp/Makefile.am
+++ b/examples/apps/ncp/Makefile.am
@@ -27,27 +27,27 @@
 #
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
+include $(top_srcdir)/examples/platforms/Makefile.platform.am
 
 bin_PROGRAMS                                                           = \
     $(NULL)
 
-CPPFLAGS_COMMON                                                        = \
+CPPFLAGS_COMMON                                                       += \
     -I$(top_srcdir)/include                                              \
     -I$(top_srcdir)/src/core                                             \
     -I$(top_srcdir)/examples/platforms                                   \
     $(NULL)
 
-LDADD_COMMON                                                           = \
+LDADD_COMMON                                                          += \
     $(NULL)
 
-LDFLAGS_COMMON                                                         = \
+LDFLAGS_COMMON                                                        += \
     $(NULL)
 
-LIBTOOLFLAGS_COMMON                                                    = \
-    --preserve-dup-deps                                                  \
+LIBTOOLFLAGS_COMMON                                                   += \
     $(NULL)
 
-SOURCES_COMMON                                                         = \
+SOURCES_COMMON                                                        += \
     main.c                                                               \
     $(NULL)
 
@@ -62,116 +62,6 @@ LDADD_COMMON                                                          += \
     $(top_builddir)/src/diag/libopenthread-diag.a                        \
     $(NULL)
 endif
-
-if OPENTHREAD_EXAMPLES_POSIX
-LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/posix/libopenthread-posix.a       \
-    -lstdc++                                                             \
-    $(NULL)
-endif # OPENTHREAD_EXAMPLES_POSIX
-
-if OPENTHREAD_EXAMPLES_CC2538
-LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/cc2538/libopenthread-cc2538.a     \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        += \
-    -T $(top_srcdir)/examples/platforms/cc2538/cc2538.ld                 \
-    $(NULL)
-endif # OPENTHREAD_EXAMPLES_CC2538
-
-if OPENTHREAD_EXAMPLES_CC2650
-CPPFLAGS_COMMON                                                       += \
-    -I$(top_srcdir)/third_party/ti/devices/cc26x0                        \
-    $(NULL)
-
-LDADD_COMMON                                                          +=      \
-    $(top_builddir)/examples/platforms/cc2650/libopenthread-cc2650.a          \
-    $(top_srcdir)/third_party/ti/devices/cc26x0/driverlib/bin/gcc/driverlib.a \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        +=       \
-    -T $(top_srcdir)/third_party/ti/devices/cc26x0/linker_files/cc26x0f128.lds \
-    $(NULL)
-
-endif # OPENTHREAD_EXAMPLES_CC2650
-
-if OPENTHREAD_EXAMPLES_CC2652
-CPPFLAGS_COMMON                                                       += \
-    -I$(top_srcdir)/third_party/ti/devices/cc26x2                        \
-    $(NULL)
-
-LDADD_COMMON                                                          +=      \
-    $(top_builddir)/examples/platforms/cc2652/libopenthread-cc2652.a          \
-    $(top_srcdir)/third_party/ti/devices/cc26x2/driverlib/bin/gcc/driverlib.a \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        +=      \
-    -T $(top_srcdir)/third_party/ti/devices/cc26x2/linker_files/cc26x2r1f.lds \
-    $(NULL)
-
-endif # OPENTHREAD_EXAMPLES_CC2652
-
-if OPENTHREAD_EXAMPLES_DA15000
-LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/da15000/libopenthread-da15000.a   \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        += \
-    -T $(top_srcdir)/third_party/dialog/DialogSDK/bsp/ldfile/da15000.ld  \
-    $(NULL)
-endif # OPENTHREAD_EXAMPLES_DA15000
-
-if OPENTHREAD_EXAMPLES_EFR32
-LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/efr32/libopenthread-efr32.a       \
-    $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v1.1/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg12_gcc_release.a \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        += \
-    -T $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v1.1/platform/Device/SiliconLabs/EFR32MG12P/Source/GCC/efr32mg12p.ld \
-    $(NULL)
-endif # OPENTHREAD_EXAMPLES_EFR32
-
-if OPENTHREAD_EXAMPLES_EMSK
-LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/emsk/libopenthread-emsk.a         \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        += \
-    -T $(top_srcdir)/examples/platforms/emsk/emsk.ld                     \
-    $(NULL)
-endif # OPENTHREAD_EXAMPLES_EMSK
-
-if OPENTHREAD_EXAMPLES_NRF52840
-LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/nrf52840/libopenthread-nrf52840.a \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        += \
-    -T $(top_srcdir)/examples/platforms/nrf52840/nrf52840.ld             \
-    $(NULL)
-endif
-
-if OPENTHREAD_EXAMPLES_KW41Z
-LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/kw41z/libopenthread-kw41z.a       \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        += \
-    -T $(top_srcdir)/examples/platforms/kw41z/MKW41Z512xxx4.ld           \
-    $(NULL)
-endif # OPENTHREAD_EXAMPLES_KW41Z
-
-if OPENTHREAD_EXAMPLES_SAMR21
-LDADD_COMMON                                                          += \
-    $(top_builddir)/examples/platforms/samr21/libopenthread-samr21.a     \
-    $(NULL)
-
-LDFLAGS_COMMON                                                        += \
-    -T $(top_srcdir)/third_party/microchip/include/samr21x18a.ld         \
-    $(NULL)
-endif # OPENTHREAD_EXAMPLES_SAMR21
 
 if OPENTHREAD_ENABLE_NCP_FTD
 bin_PROGRAMS                                                          += \
@@ -188,6 +78,7 @@ ot_ncp_ftd_LDADD                                                       = \
     $(top_builddir)/src/core/libopenthread-ftd.a                         \
     $(LDADD_COMMON)                                                      \
     $(top_builddir)/src/core/libopenthread-ftd.a                         \
+    $(LDADD_COMMON)                                                      \
     $(NULL)
 
 ot_ncp_ftd_LDFLAGS                                                     = \
@@ -217,6 +108,7 @@ ot_ncp_mtd_LDADD                                                       = \
     $(top_builddir)/src/core/libopenthread-mtd.a                         \
     $(LDADD_COMMON)                                                      \
     $(top_builddir)/src/core/libopenthread-mtd.a                         \
+    $(LDADD_COMMON)                                                      \
     $(NULL)
 
 ot_ncp_mtd_LDFLAGS                                                     = \

--- a/examples/platforms/Makefile.platform.am
+++ b/examples/platforms/Makefile.platform.am
@@ -1,0 +1,86 @@
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# This utility Makefile is included by the application Makefile.am as follows:
+#
+# include $(top_srcdir)/examples/platforms/Makefile.platform.am
+#
+# It will automatically set required flags and libraries to link based on
+# the selected platform and feature options set via configure.
+#
+
+CPPFLAGS_COMMON     = $(NULL)
+LDADD_COMMON        = $(NULL)
+LDFLAGS_COMMON      = $(NULL)
+SOURCES_COMMON      = $(NULL)
+LIBTOOLFLAGS_COMMON = --preserve-dup-deps
+
+if OPENTHREAD_EXAMPLES_CC2538
+include $(top_srcdir)/examples/platforms/cc2538/Makefile.platform.am
+endif
+
+if OPENTHREAD_EXAMPLES_CC2650
+include $(top_srcdir)/examples/platforms/cc2650/Makefile.platform.am
+endif
+
+if OPENTHREAD_EXAMPLES_CC2652
+include $(top_srcdir)/examples/platforms/cc2652/Makefile.platform.am
+endif
+
+if OPENTHREAD_EXAMPLES_DA15000
+include $(top_srcdir)/examples/platforms/da15000/Makefile.platform.am
+endif
+
+if OPENTHREAD_EXAMPLES_EFR32
+include $(top_srcdir)/examples/platforms/efr32/Makefile.platform.am
+endif
+
+if OPENTHREAD_EXAMPLES_EMSK
+include $(top_srcdir)/examples/platforms/emsk/Makefile.platform.am
+endif
+
+if OPENTHREAD_EXAMPLES_GP712
+include $(top_srcdir)/examples/platforms/gp712/Makefile.platform.am
+endif
+
+if OPENTHREAD_EXAMPLES_KW41Z
+include $(top_srcdir)/examples/platforms/kw41z/Makefile.platform.am
+endif
+
+if OPENTHREAD_EXAMPLES_NRF52840
+include $(top_srcdir)/examples/platforms/nrf52840/Makefile.platform.am
+endif
+
+if OPENTHREAD_EXAMPLES_SAMR21
+include $(top_srcdir)/examples/platforms/samr21/Makefile.platform.am
+endif # OPENTHREAD_EXAMPLES_SAMR21
+
+if OPENTHREAD_EXAMPLES_POSIX
+include $(top_srcdir)/examples/platforms/posix/Makefile.platform.am
+endif

--- a/examples/platforms/cc2538/Makefile.platform.am
+++ b/examples/platforms/cc2538/Makefile.platform.am
@@ -1,0 +1,39 @@
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# cc2538 platform-specific Makefile
+#
+
+LDADD_COMMON                                                          += \
+    $(top_builddir)/examples/platforms/cc2538/libopenthread-cc2538.a     \
+    $(NULL)
+
+LDFLAGS_COMMON                                                        += \
+    -T $(top_srcdir)/examples/platforms/cc2538/cc2538.ld                 \
+    $(NULL)

--- a/examples/platforms/cc2650/Makefile.platform.am
+++ b/examples/platforms/cc2650/Makefile.platform.am
@@ -1,0 +1,44 @@
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# cc2650 platform-specific Makefile
+#
+
+CPPFLAGS_COMMON                                                             += \
+    -I$(top_srcdir)/third_party/ti/devices/cc26x0                              \
+    $(NULL)
+
+LDADD_COMMON                                                                += \
+    $(top_builddir)/examples/platforms/cc2650/libopenthread-cc2650.a           \
+    $(top_srcdir)/third_party/ti/devices/cc26x0/driverlib/bin/gcc/driverlib.a  \
+    $(NULL)
+
+LDFLAGS_COMMON                                                              += \
+    -T $(top_srcdir)/third_party/ti/devices/cc26x0/linker_files/cc26x0f128.lds \
+    $(NULL)

--- a/examples/platforms/cc2652/Makefile.platform.am
+++ b/examples/platforms/cc2652/Makefile.platform.am
@@ -1,0 +1,44 @@
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# cc2652 platform-specific Makefile
+#
+
+CPPFLAGS_COMMON                                                            += \
+    -I$(top_srcdir)/third_party/ti/devices/cc26x2                             \
+    $(NULL)
+
+LDADD_COMMON                                                               += \
+    $(top_builddir)/examples/platforms/cc2652/libopenthread-cc2652.a          \
+    $(top_srcdir)/third_party/ti/devices/cc26x2/driverlib/bin/gcc/driverlib.a \
+    $(NULL)
+
+LDFLAGS_COMMON                                                             += \
+    -T $(top_srcdir)/third_party/ti/devices/cc26x2/linker_files/cc26x2r1f.lds \
+    $(NULL)

--- a/examples/platforms/da15000/Makefile.platform.am
+++ b/examples/platforms/da15000/Makefile.platform.am
@@ -1,0 +1,39 @@
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# da15000 platform-specific Makefile
+#
+
+LDADD_COMMON                                                          += \
+    $(top_builddir)/examples/platforms/da15000/libopenthread-da15000.a   \
+    $(NULL)
+
+LDFLAGS_COMMON                                                        += \
+    -T $(top_srcdir)/third_party/dialog/DialogSDK/bsp/ldfile/da15000.ld  \
+    $(NULL)

--- a/examples/platforms/efr32/Makefile.platform.am
+++ b/examples/platforms/efr32/Makefile.platform.am
@@ -1,0 +1,40 @@
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# efr32 platform-specific Makefile
+#
+
+LDADD_COMMON                                                          += \
+    $(top_builddir)/examples/platforms/efr32/libopenthread-efr32.a       \
+    $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v1.1/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg12_gcc_release.a \
+    $(NULL)
+
+LDFLAGS_COMMON                                                        += \
+    -T $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v1.1/platform/Device/SiliconLabs/EFR32MG12P/Source/GCC/efr32mg12p.ld \
+    $(NULL)

--- a/examples/platforms/emsk/Makefile.platform.am
+++ b/examples/platforms/emsk/Makefile.platform.am
@@ -1,0 +1,39 @@
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# emsk platform-specific Makefile
+#
+
+LDADD_COMMON                                                          += \
+    $(top_builddir)/examples/platforms/emsk/libopenthread-emsk.a         \
+    $(NULL)
+
+LDFLAGS_COMMON                                                        += \
+    -T $(top_srcdir)/examples/platforms/emsk/emsk.ld                     \
+    $(NULL)

--- a/examples/platforms/gp712/Makefile.platform.am
+++ b/examples/platforms/gp712/Makefile.platform.am
@@ -1,0 +1,36 @@
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# gp712 platform-specific Makefile
+#
+
+LDADD_COMMON                                                          += \
+    $(top_builddir)/examples/platforms/gp712/libopenthread-gp712.a       \
+    $(top_srcdir)/third_party/Qorvo/gp712/libQorvoRPi.a                  \
+    $(NULL)

--- a/examples/platforms/kw41z/Makefile.platform.am
+++ b/examples/platforms/kw41z/Makefile.platform.am
@@ -1,0 +1,39 @@
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# kw41z platform-specific Makefile
+#
+
+LDADD_COMMON                                                          += \
+    $(top_builddir)/examples/platforms/kw41z/libopenthread-kw41z.a       \
+    $(NULL)
+
+LDFLAGS_COMMON                                                        += \
+    -T $(top_srcdir)/examples/platforms/kw41z/MKW41Z512xxx4.ld           \
+    $(NULL)

--- a/examples/platforms/nrf52840/Makefile.platform.am
+++ b/examples/platforms/nrf52840/Makefile.platform.am
@@ -1,0 +1,39 @@
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# nrf52840 platform-specific Makefile
+#
+
+LDADD_COMMON                                                          += \
+    $(top_builddir)/examples/platforms/nrf52840/libopenthread-nrf52840.a \
+    $(NULL)
+
+LDFLAGS_COMMON                                                        += \
+    -T $(top_srcdir)/examples/platforms/nrf52840/nrf52840.ld             \
+    $(NULL)

--- a/examples/platforms/posix/Makefile.platform.am
+++ b/examples/platforms/posix/Makefile.platform.am
@@ -1,0 +1,36 @@
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# posix platform-specific Makefile
+#
+
+LDADD_COMMON                                                          += \
+    $(top_builddir)/examples/platforms/posix/libopenthread-posix.a       \
+    -lstdc++                                                             \
+    $(NULL)

--- a/examples/platforms/samr21/Makefile.platform.am
+++ b/examples/platforms/samr21/Makefile.platform.am
@@ -1,0 +1,39 @@
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# samr21 platform-specific Makefile
+#
+
+LDADD_COMMON                                                          += \
+    $(top_builddir)/examples/platforms/samr21/libopenthread-samr21.a     \
+    $(NULL)
+
+LDFLAGS_COMMON                                                        += \
+    -T $(top_srcdir)/third_party/microchip/include/samr21x18a.ld         \
+    $(NULL)


### PR DESCRIPTION
The Makefile.am for each application has to duplicate a large ifdef chain for all possible platforms.

This PR simplifies this aspect of the build system, and allows a more scalable solution for a platform maintainer to control the CPPFLAGS, LDFLAGS, and LDADD options required by their platform.