### PR TITLE
[nRF52840] Implement additional diag commands in nRF52840 platform.

### DIFF
--- a/examples/platforms/nrf52840/DIAG.md
+++ b/examples/platforms/nrf52840/DIAG.md
@@ -74,7 +74,7 @@ Set listen state.
 Default: listen disabled.
 
 ### diag temp
-Get temperature from internal temperature sensor.
+Get temperature from internal temperature sensor, in degrees Celsius.
 
 ### diag transmit
 Get messages count and interval between them that will be transmitted after `diag transmit start`.

--- a/examples/platforms/nrf52840/DIAG.md
+++ b/examples/platforms/nrf52840/DIAG.md
@@ -5,8 +5,10 @@ nRF52840 port extends [OpenThread Diagnostics Module][DIAG].
 New commands allow for more accurate low level radio testing.
 
 ### New commands
+ * [diag ccathreshold](#diag-ccathreshold)
  * [diag id](#diag-id)
  * [diag listen](#diag-listen)
+ * [diag temp](#diag-temp)
  * [diag transmit](#diag-transmit)
 
 ### Diagnostic radio packet
@@ -40,6 +42,16 @@ If [listen](#diag-listen) mode is enabled and OpenThread was built with `DEFAULT
  }}
 ```
 
+### diag ccathreshold
+Get current CCA threshold.
+
+### diag ccathreshold \<threshold\>
+Set CCA threshold.
+
+Value range 0 to 255.
+
+Default: `45`.
+
 ### diag id
 Get board ID.
 
@@ -60,6 +72,9 @@ Set listen state.
 `1` enable listen state.
 
 Default: listen disabled.
+
+### diag temp
+Get temperature from internal temperature sensor.
 
 ### diag transmit
 Get messages count and interval between them that will be transmitted after `diag transmit start`.
@@ -85,5 +100,8 @@ Stop ongoing transmission regardless of remaining number of messages to be sent.
 
 ### diag transmit start
 Start transmiting messages with specified interval.
+
+### diag transmit carrier
+Start transmitting continuous carrier wave.
 
 [DIAG]: ./../../../src/diag/README.md

--- a/examples/platforms/nrf52840/Makefile.am
+++ b/examples/platforms/nrf52840/Makefile.am
@@ -62,6 +62,7 @@ PLATFORM_SOURCES                                                                
     platform-nrf5.h                                                                                          \
     radio.c                                                                                                  \
     random.c                                                                                                 \
+    temp.c                                                                                                   \
     $(NULL)
 
 SINGLEPHY_SOURCES                                                                                          = \

--- a/examples/platforms/nrf52840/diag.c
+++ b/examples/platforms/nrf52840/diag.c
@@ -32,12 +32,24 @@
 #include <string.h>
 #include <inttypes.h>
 
+#include "platform-nrf5.h"
+
+#include <openthread/cli.h>
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
 #include <openthread/platform/radio.h>
+#include <openthread/platform/toolchain.h>
 
 #include <common/logging.hpp>
 #include <utils/code_utils.h>
+#include <drivers/radio/nrf_drv_radio802154.h>
+
+typedef enum
+{
+    kDiagTransmitModeIdle,
+    kDiagTransmitModePackets,
+    kDiagTransmitModeCarrier
+} DiagTrasmitMode;
 
 struct PlatformDiagCommand
 {
@@ -59,7 +71,7 @@ struct PlatformDiagMessage
  */
 static bool sDiagMode = false;
 static bool sListen = false;
-static bool sTransmitActive = false;
+static DiagTrasmitMode sTransmitMode = kDiagTransmitModeIdle;
 static uint8_t sChannel = 20;
 static int8_t sTxPower = 0;
 static uint32_t sTxPeriod = 1;
@@ -81,6 +93,14 @@ static void appendErrorResult(otError aError, char *aOutput, size_t aOutputMaxLe
     {
         snprintf(aOutput, aOutputMaxLen, "failed\r\nstatus %#x\r\n", aError);
     }
+}
+
+static bool startCarrierTransmision(void)
+{
+    nrf_drv_radio802154_channel_set(sChannel);
+    nrf_drv_radio802154_tx_power_set(sTxPower);
+
+    return nrf_drv_radio802154_continuous_carrier();
 }
 
 static void processListen(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
@@ -150,20 +170,36 @@ static void processTransmit(otInstance *aInstance, int argc, char *argv[], char 
     }
     else if (strcmp(argv[0], "stop") == 0)
     {
+        otEXPECT_ACTION(sTransmitMode != kDiagTransmitModeIdle, error = OT_ERROR_INVALID_STATE);
+
         otPlatAlarmMilliStop(aInstance);
         snprintf(aOutput, aOutputMaxLen, "diagnostic message transmission is stopped\r\nstatus 0x%02x\r\n", error);
-        sTransmitActive = false;
+        sTransmitMode = kDiagTransmitModeIdle;
+        otPlatRadioReceive(aInstance, sChannel);
     }
     else if (strcmp(argv[0], "start") == 0)
     {
+        otEXPECT_ACTION(sTransmitMode == kDiagTransmitModeIdle, error = OT_ERROR_INVALID_STATE);
+
         otPlatAlarmMilliStop(aInstance);
-        sTransmitActive = true;
+        sTransmitMode = kDiagTransmitModePackets;
         sTxCount = sTxRequestedCount;
         uint32_t now = otPlatAlarmMilliGetNow();
         otPlatAlarmMilliStartAt(aInstance, now, sTxPeriod);
         snprintf(aOutput, aOutputMaxLen, "sending %" PRId32 " diagnostic messages with %" PRIu32
                  " ms interval\r\nstatus 0x%02x\r\n",
                  sTxRequestedCount, sTxPeriod, error);
+    }
+    else if (strcmp(argv[0], "carrier") == 0)
+    {
+        otEXPECT_ACTION(sTransmitMode == kDiagTransmitModeIdle, error = OT_ERROR_INVALID_STATE);
+
+        otEXPECT_ACTION(startCarrierTransmision(), error = OT_ERROR_FAILED);
+
+        sTransmitMode = kDiagTransmitModeCarrier;
+
+        snprintf(aOutput, aOutputMaxLen, "sending carrier on channel %d with tx power %d\r\nstatus 0x%02x\r\n",
+                 sChannel, sTxPower, error);
     }
     else if (strcmp(argv[0], "interval") == 0)
     {
@@ -191,6 +227,63 @@ static void processTransmit(otInstance *aInstance, int argc, char *argv[], char 
         snprintf(aOutput, aOutputMaxLen, "set diagnostic messages count to %" PRId32 "\r\nstatus 0x%02x\r\n", sTxRequestedCount,
                  error);
     }
+    else
+    {
+        error = OT_ERROR_INVALID_ARGS;
+    }
+
+exit:
+    appendErrorResult(error, aOutput, aOutputMaxLen);
+}
+
+static void processTemp(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(argv);
+
+    otError error = OT_ERROR_NONE;
+
+    otEXPECT_ACTION(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
+    otEXPECT_ACTION(argc == 0, error = OT_ERROR_INVALID_ARGS);
+
+    int32_t temperature = nrf5TempGet();
+
+    snprintf(aOutput, aOutputMaxLen, "%" PRId32 ".%02" PRId32 "\r\n", temperature / 4, 25 * (temperature % 4));
+
+    exit:
+        appendErrorResult(error, aOutput, aOutputMaxLen);
+}
+
+static void processCcaThreshold(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+{
+    (void) aInstance;
+
+    otError                       error = OT_ERROR_NONE;
+    nrf_drv_radio802154_cca_cfg_t ccaConfig;
+
+    otEXPECT_ACTION(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
+
+    if (argc == 0)
+    {
+        nrf_drv_radio802154_cca_cfg_get(&ccaConfig);
+
+        snprintf(aOutput, aOutputMaxLen, "cca threshold: %u\r\n", ccaConfig.ed_threshold);
+    }
+    else
+    {
+        long value;
+        error = parseLong(argv[0], &value);
+        otEXPECT(error == OT_ERROR_NONE);
+        otEXPECT_ACTION(value >= 0 && value <= 0xFF, error = OT_ERROR_INVALID_ARGS);
+
+        memset(&ccaConfig, 0, sizeof(ccaConfig));
+        ccaConfig.mode         = NRF_RADIO_CCA_MODE_ED;
+        ccaConfig.ed_threshold = (uint8_t)value;
+
+        nrf_drv_radio802154_cca_cfg_set(&ccaConfig);
+        snprintf(aOutput, aOutputMaxLen, "set cca threshold to %u\r\nstatus 0x%02x\r\n",
+                 ccaConfig.ed_threshold, error);
+    }
 
 exit:
     appendErrorResult(error, aOutput, aOutputMaxLen);
@@ -198,9 +291,11 @@ exit:
 
 const struct PlatformDiagCommand sCommands[] =
 {
-    {"listen", &processListen },
-    {"transmit", &processTransmit },
-    {"id", &processID }
+    { "listen", &processListen },
+    { "transmit", &processTransmit },
+    { "id", &processID },
+    { "temp", &processTemp },
+    { "ccathreshold", &processCcaThreshold }
 };
 
 void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
@@ -225,6 +320,17 @@ void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOut
 void otPlatDiagModeSet(bool aMode)
 {
     sDiagMode = aMode;
+
+    if (!sDiagMode)
+    {
+        otPlatRadioReceive(NULL, sChannel);
+        otPlatRadioSleep(NULL);
+    }
+    else
+    {
+        // Reinit
+        sTransmitMode = kDiagTransmitModeIdle;
+    }
 }
 
 bool otPlatDiagModeGet()
@@ -277,7 +383,8 @@ void otPlatDiagRadioReceived(otInstance *aInstance, otRadioFrame *aFrame, otErro
 
 void otPlatDiagAlarmCallback(otInstance *aInstance)
 {
-    if (sTransmitActive)
+
+    if (sTransmitMode == kDiagTransmitModePackets)
     {
         if ((sTxCount > 0) || (sTxCount == -1))
         {
@@ -305,7 +412,7 @@ void otPlatDiagAlarmCallback(otInstance *aInstance)
         }
         else
         {
-            sTransmitActive = false;
+            sTransmitMode = kDiagTransmitModeIdle;
             otPlatAlarmMilliStop(aInstance);
             otPlatLog(OT_LOG_LEVEL_DEBG, OT_LOG_REGION_PLATFORM, "Transmit done");
         }

--- a/examples/platforms/nrf52840/diag.c
+++ b/examples/platforms/nrf52840/diag.c
@@ -248,6 +248,8 @@ static void processTemp(otInstance *aInstance, int argc, char *argv[], char *aOu
 
     int32_t temperature = nrf5TempGet();
 
+    // Measurement resolution is 0.25 degrees Celsius
+    // Convert the temperature measurement to a decimal value, in degrees Celsius
     snprintf(aOutput, aOutputMaxLen, "%" PRId32 ".%02" PRId32 "\r\n", temperature / 4, 25 * (temperature % 4));
 
     exit:

--- a/examples/platforms/nrf52840/platform-nrf5.h
+++ b/examples/platforms/nrf52840/platform-nrf5.h
@@ -167,6 +167,26 @@ bool nrf5FlashIsBusy(void);
  */
 uint32_t nrf5FlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize);
 
+/**
+ * Initialization of temperature controller.
+ *
+ */
+void nrf5TempInit(void);
+
+/**
+ * Deinitialization of temperature controller.
+ *
+ */
+void nrf5TempDeinit(void);
+
+/**
+ * Function for measuring internal temperature.
+ *
+ * @return Temperature value measured.
+ *
+ */
+int32_t nrf5TempGet(void);
+
 #if SOFTDEVICE_PRESENT
 /**
  * Function for translating SoftDevice error into OpenThread's one.

--- a/examples/platforms/nrf52840/temp.c
+++ b/examples/platforms/nrf52840/temp.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2016, The OpenThread Authors.
+ *  Copyright (c) 2017, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -26,63 +26,46 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-/**
- * @file
- *   This file includes the platform-specific initializers.
- *
- */
+#include <limits.h>
+#include <stdint.h>
+#include <string.h>
 
-#include <openthread/platform/logging.h>
+#include <utils/code_utils.h>
+#include <hal/nrf_temp.h>
 
-#include <device/nrf.h>
-#include <drivers/clock/nrf_drv_clock.h>
 #include "platform-nrf5.h"
 
-#include <openthread/config.h>
-
-void __cxa_pure_virtual(void) { while (1); }
-
-void PlatformInit(int argc, char *argv[])
+__STATIC_INLINE void dataReadyEventClear(void)
 {
-    (void)argc;
-    (void)argv;
-
-#if !SOFTDEVICE_PRESENT
-    // Enable I-code cache
-    NRF_NVMC->ICACHECNF = NVMC_ICACHECNF_CACHEEN_Enabled;
-#endif
-
-    nrf_drv_clock_init();
-
-#if (OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT == 0)
-    nrf5LogInit();
-#endif
-    nrf5AlarmInit();
-    nrf5RandomInit();
-    nrf5UartInit();
-    nrf5MiscInit();
-    nrf5CryptoInit();
-    nrf5RadioInit();
-    nrf5TempInit();
+    NRF_TEMP->EVENTS_DATARDY = 0;
+    volatile uint32_t dummy = NRF_TEMP->EVENTS_DATARDY;
+    (void)dummy;
 }
 
-void PlatformDeinit(void)
+void nrf5TempInit(void)
 {
-    nrf5TempDeinit();
-    nrf5RadioDeinit();
-    nrf5CryptoDeinit();
-    nrf5MiscDeinit();
-    nrf5UartDeinit();
-    nrf5RandomDeinit();
-    nrf5AlarmDeinit();
-#if (OPENTHREAD_CONFIG_ENABLE_DEFAULT_LOG_OUTPUT == 0)
-    nrf5LogDeinit();
-#endif
+    nrf_temp_init();
 }
 
-void PlatformProcessDrivers(otInstance *aInstance)
+void nrf5TempDeinit(void)
 {
-    nrf5AlarmProcess(aInstance);
-    nrf5RadioProcess(aInstance);
-    nrf5UartProcess();
+    NRF_TEMP->TASKS_STOP = 1;
+}
+
+int32_t nrf5TempGet(void)
+{
+    NRF_TEMP->TASKS_START = 1;
+
+    while (NRF_TEMP->EVENTS_DATARDY == 0)
+    {
+        ;
+    }
+
+    dataReadyEventClear();
+
+    int32_t temperature = nrf_temp_read();
+
+    NRF_TEMP->TASKS_STOP = 1;
+
+    return temperature;
 }

--- a/third_party/NordicSemiconductor/hal/nrf_temp.h
+++ b/third_party/NordicSemiconductor/hal/nrf_temp.h
@@ -1,0 +1,81 @@
+/* Copyright (c) 2012, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *      list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef NRF_TEMP_H__
+#define NRF_TEMP_H__
+
+#include "nrf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* @defgroup nrf_temperature TEMP (temperature) abstraction
+* @{
+* @ingroup nrf_drivers temperature_example
+* @brief Temperature module init and read functions.
+*
+*/
+
+/**@cond NO_DOXYGEN */
+#define MASK_SIGN           (0x00000200UL)
+#define MASK_SIGN_EXTENSION (0xFFFFFC00UL)
+
+/**
+ * @brief Function for preparing the temp module for temperature measurement.
+ *
+ * This function initializes the TEMP module and writes to the hidden configuration register.
+ */
+static __INLINE void nrf_temp_init(void)
+{
+    /**@note Workaround for PAN_028 rev2.0A anomaly 31 - TEMP: Temperature offset value has to be manually loaded to the TEMP module */
+    *(uint32_t *) 0x4000C504 = 0;
+}
+
+/**
+ * @brief Function for reading temperature measurement.
+ *
+ * The function reads the 10 bit 2's complement value and transforms it to a 32 bit 2's complement value.
+ */
+static __INLINE int32_t nrf_temp_read(void)
+{
+    /**@note Workaround for PAN_028 rev2.0A anomaly 28 - TEMP: Negative measured values are not represented correctly */
+    return ((NRF_TEMP->TEMP & MASK_SIGN) != 0) ? (int32_t)(NRF_TEMP->TEMP | MASK_SIGN_EXTENSION) : (int32_t)(NRF_TEMP->TEMP);
+}
+/**@endcond */
+
+/** @} */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This PR adds additional diagnostic commands in nRF52840 platform:

- `diag temp` for getting temperature from internal temp sensor,
- `diag ccathreshold` for setting/getting CCA threshold,
- `diag transmit carrier` for continuous transmission of carrier wave.