### PR TITLE
[nRF52840] pass received frames to MAC layer regardless PHY or MAC state.

### DIFF
--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -621,13 +621,6 @@ void nrf_drv_radio802154_received_raw(uint8_t *p_data, int8_t power, int8_t lqi)
 {
     otRadioFrame *receivedFrame = NULL;
 
-    if (isPendingEventSet(kPendingEventTransmit))
-    {
-        nrf_drv_radio802154_buffer_free_raw(p_data);
-
-        return;
-    }
-
     for (uint32_t i = 0; i < RADIO_RX_BUFFERS; i++)
     {
         if (sReceivedFrames[i].mPsdu == NULL)


### PR DESCRIPTION
This PR fixes rare problem with missing ping replies to MLEID address.

This fix is urgent for us. Please, merge it today if possible.