### PR TITLE
[ncp] add support for Spinel vendor specific commands

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -861,6 +861,38 @@ AM_CONDITIONAL([OPENTHREAD_ENABLE_LEGACY], [test "${enable_legacy}" = "yes"])
 AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_LEGACY],[${OPENTHREAD_ENABLE_LEGACY}],[Define to 1 if you want to use legacy network support])
 
 #
+# Vendor Specific Spinel Command Handler
+#
+
+AC_ARG_ENABLE(spinelvendor,
+    [AS_HELP_STRING([--enable-spinelvendor],[Enable Spinel vendor command support @<:@default=no@:>@.])],
+    [
+        case "${enableval}" in
+
+        no|yes)
+            enable_vendor=${enableval}
+            ;;
+
+        *)
+            AC_MSG_ERROR([Invalid value ${enable_vendor} for --enable-spinelvendor])
+            ;;
+        esac
+    ],
+    [enable_vendor=no])
+
+if test "$enable_vendor" = "yes"; then
+    OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT=1
+else
+    OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT=0
+fi
+
+AC_MSG_CHECKING([whether to enable spinel vendor command support])
+AC_MSG_RESULT(${enable_vendor})
+AC_SUBST(OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT)
+AM_CONDITIONAL([OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT], [test "${enable_vendor}" = "yes"])
+AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT],[${OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT}],[Define to 1 if you want to implement Spinel vendor command support])
+
+#
 # Child Supervision
 #
 
@@ -1473,6 +1505,7 @@ AC_MSG_NOTICE([
   OpenThread MAC Filter support             : ${enable_mac_filter}
   OpenThread Diagnostics support            : ${enable_diag}
   OpenThread Child Supervision support      : ${enable_child_supervision}
+  OpenThread Spinel vendor specific support : ${enable_vendor}
   OpenThread Legacy network support         : ${enable_legacy}
   OpenThread Certification log support      : ${enable_cert_log}
   OpenThread DHCPv6 Server support          : ${enable_dhcp6_server}

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1001,7 +1001,7 @@ otError NcpBase::HandleCommand(uint8_t aHeader, unsigned int aCommand, const uin
         error = SendLastStatus(aHeader, SPINEL_STATUS_INVALID_INTERFACE)
     );
 #if OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT
-    if (aCommand >= SPINEL_CMD_VENDOR__BEGIN && aCommand <= SPINEL_CMD_VENDOR__END)
+    if (aCommand >= SPINEL_CMD_VENDOR__BEGIN && aCommand < SPINEL_CMD_VENDOR__END)
     {
         error = VendorCommandHandler(aHeader, aCommand, aArgPtr, aArgLen);
     }

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -371,6 +371,10 @@ private:
     void HandleTmfProxyStream(otMessage *aMessage, uint16_t aLocator, uint16_t aPort);
 #endif // OPENTHREAD_FTD && OPENTHREAD_ENABLE_TMF_PROXY
 
+#if OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT
+    otError VendorCommandHandler(uint8_t aHeader, unsigned int aCommand, const uint8_t *aArgPtr, uint16_t aArgLen);
+#endif // OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT
+
     NCP_COMMAND_HANDLER(NOOP);
     NCP_COMMAND_HANDLER(RESET);
     NCP_COMMAND_HANDLER(PROP_VALUE_GET);


### PR DESCRIPTION
This change satisfies issue #2057.

A build option has been added to allow Openthread to call a Vendor specific command handler for Spinel messages whose command values fall in the vendor reserved range.  This option is disabled by default.  When enabled the vendor is responsible for implementing the NcpBase::VendorCommandHandler(...).

Making this handler a member of NcpBase the implementation is allowed to take advantage of all the existing methods and resources NcpBase offers in order to service the request.