### PR TITLE
[travis] add new configurations to travis posix test builds

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -205,6 +205,48 @@ set -x
     git clean -xfd || die
     ./bootstrap || die
     CPPFLAGS=-DOPENTHREAD_CONFIG_LOG_LEVEL=OT_LOG_LEVEL_DEBG make -f examples/Makefile-posix || die
+
+    git checkout -- . || die
+    git clean -xfd || die
+    ./bootstrap || die
+    ./configure                             \
+        --enable-ncp-app=all                \
+        --with-ncp-bus=spi                  \
+        --with-examples=posix               \
+        --enable-diag                       \
+        --enable-legacy                     \
+        --enable-jam-detection              \
+        --enable-child-supervision          \
+        --enable-border-router              \
+        --enable-mac-filter                 \
+        --disable-docs                      \
+        --disable-test || die
+    make -j 8 || die
+
+    git checkout -- . || die
+    git clean -xfd || die
+    ./bootstrap || die
+    ./configure                             \
+        --enable-cli-app=mtd                \
+        --with-ncp-bus=spi                  \
+        --with-examples=posix               \
+        --enable-legacy                     \
+        --enable-child-supervision          \
+        --enable-border-router              \
+        --enable-mac-filter                 \
+        --disable-docs                      \
+        --disable-test || die
+    make -j 8 || die
+
+    git checkout -- . || die
+    git clean -xfd || die
+    ./bootstrap || die
+    ./configure                             \
+        --enable-cli-app=all                \
+        --enable-ncp-app=all                \
+        --with-ncp-bus=uart                 \
+        --with-examples=posix || die
+    make -j 8 || die
 }
 
 [ $BUILD_TARGET != posix-distcheck ] || {


### PR DESCRIPTION
This commit adds 3 new configurations to travis test build under the
BUILD_TARGET posix. The first two are representatives of common router
and SED devices. The last configuration disables all features.