### PR TITLE
[netif] add linklocal/realmlocal allnodes/allrouters multicast addresses to list

### DIFF
--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -1028,8 +1028,8 @@ typedef struct otNetifAddress
  */
 typedef struct otNetifMulticastAddress
 {
-    otIp6Address                    mAddress;   ///< The IPv6 multicast address.
-    struct otNetifMulticastAddress *mNext;      ///< A pointer to the next network interface multicast address.
+    otIp6Address                          mAddress;   ///< The IPv6 multicast address.
+    const struct otNetifMulticastAddress *mNext;      ///< A pointer to the next network interface multicast address.
 } otNetifMulticastAddress;
 
 /**

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -159,7 +159,7 @@ public:
      * @returns A pointer to the next multicast address.
      *
      */
-    const NetifMulticastAddress *GetNext(void) const { return static_cast<NetifMulticastAddress *>(mNext); }
+    const NetifMulticastAddress *GetNext(void) const { return static_cast<const NetifMulticastAddress *>(mNext); }
 
     /**
      * This method returns the next multicast address subscribed to the interface.
@@ -167,7 +167,9 @@ public:
      * @returns A pointer to the next multicast address.
      *
      */
-    NetifMulticastAddress *GetNext(void) { return static_cast<NetifMulticastAddress *>(mNext); }
+    NetifMulticastAddress *GetNext(void) {
+        return static_cast<NetifMulticastAddress *>(const_cast<otNetifMulticastAddress *>(mNext));
+    }
 };
 
 /**
@@ -362,14 +364,20 @@ public:
     /**
      * This method subscribes the network interface to the link-local and realm-local all routers address.
      *
+     * @retval OT_ERROR_NONE     Successfully subscribed to the link-local and realm-local all routers address
+     * @retval OT_ERROR_ALREADY  The multicast addresses are already subscribed.
+     *
      */
-    void SubscribeAllRoutersMulticast(void) { mAllRoutersSubscribed = true; }
+    otError SubscribeAllRoutersMulticast(void);
 
     /**
      * This method unsubscribes the network interface to the link-local and realm-local all routers address.
      *
+     * @retval OT_ERROR_NONE       Successfully unsubscribed from the link-local and realm-local all routers address
+     * @retval OT_ERROR_NOT_FOUND  The multicast addresses were not found.
+     *
      */
-    void UnsubscribeAllRoutersMulticast(void) { mAllRoutersSubscribed = false; }
+    otError UnsubscribeAllRoutersMulticast(void);
 
     /**
      * This method returns a pointer to the list of multicast addresses.
@@ -395,8 +403,8 @@ public:
      *
      * @param[in]  aAddress  A reference to the multicast address.
      *
-     * @retval OT_ERROR_NONE     Successfully unsubscribed to @p aAddress.
-     * @retval OT_ERROR_ALREADY  The multicast address is already unsubscribed.
+     * @retval OT_ERROR_NONE       Successfully unsubscribed @p aAddress.
+     * @retval OT_ERROR_NOT_FOUND  The multicast address was not found.
      *
      */
     otError UnsubscribeMulticast(const NetifMulticastAddress &aAddress);
@@ -529,7 +537,6 @@ private:
     NetifUnicastAddress *mUnicastAddresses;
     NetifMulticastAddress *mMulticastAddresses;
     int8_t mInterfaceId;
-    bool mAllRoutersSubscribed;
     bool mMulticastPromiscuous;
     Tasklet mStateChangedTask;
     Netif *mNext;
@@ -538,6 +545,12 @@ private:
 
     NetifUnicastAddress mExtUnicastAddresses[OPENTHREAD_CONFIG_MAX_EXT_IP_ADDRS];
     NetifMulticastAddress mExtMulticastAddresses[OPENTHREAD_CONFIG_MAX_EXT_MULTICAST_IP_ADDRS];
+
+    static const otNetifMulticastAddress kRealmLocalAllMplForwardersMulticastAddress;
+    static const otNetifMulticastAddress kLinkLocalAllNodesMulticastAddress;
+    static const otNetifMulticastAddress kRealmLocalAllNodesMulticastAddress;
+    static const otNetifMulticastAddress kLinkLocalAllRoutersMulticastAddress;
+    static const otNetifMulticastAddress kRealmLocalAllRoutersMulticastAddress;
 };
 
 /**


### PR DESCRIPTION
Certain multicast addresses like "ff03::01" (Link-Local All-Nodes)
are fixed and will not change. The commit defines them as constant
entries which are then appended into the `mMulticastAddresses`
linked-list.