### PR TITLE
[mac] update the log message for otPlatRadioSleep() failure

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1155,15 +1155,12 @@ otError Mac::RadioSleep(void)
 
 #endif
 
-    SuccessOrExit(error = otPlatRadioSleep(&GetInstance()));
+    error = otPlatRadioSleep(&GetInstance());
+    VerifyOrExit(error != OT_ERROR_NONE);
+
+    otLogWarnMac(GetInstance(), "otPlatRadioSleep() failed with error %s", otThreadErrorToString(error));
 
 exit:
-
-    if (error != OT_ERROR_NONE)
-    {
-        otLogWarnMac(GetInstance(), "otPlatRadioSleep() failed with error %s", otThreadErrorToString(error));
-    }
-
     return error;
 }
 


### PR DESCRIPTION

This change ensures that we don't get extra logs with `INAVLID_STATE` error when `OPENTHREAD_CONFIG_STAY_AWAKE_BETWEEN_FRAGMENTS` is enabled and sleep is delayed.