### PR TITLE
[nRF52840] fix spacing/alignment in diag ("make pretty" with --enable-diag)

### DIFF
--- a/examples/platforms/nrf52840/Makefile.am
+++ b/examples/platforms/nrf52840/Makefile.am
@@ -51,7 +51,7 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/segger_rtt                                               \
     $(NULL)
 
-PLATFORM_SOURCES                                                                                           = \
+PLATFORM_COMMON_SOURCES                                                                                    = \
     alarm.c                                                                                                  \
     flash.c                                                                                                  \
     logging.c                                                                                                \
@@ -96,9 +96,17 @@ SOFTDEVICE_CPPFLAGS                                                             
     -DRAAL_SOFTDEVICE=1                                                                                      \
     $(NULL)
 
+PLATFORM_DIAG_SOURCES                                                                                      = \
+    diag.c                                                                                                   \
+    $(NULL)
+
+PLATFORM_SOURCES                                                                                           = \
+    $(PLATFORM_COMMON_SOURCES)                                                                               \
+    $(NULL)
+
 if OPENTHREAD_ENABLE_DIAG
 PLATFORM_SOURCES                                                                                          += \
-    diag.c                                                                                                   \
+    $(PLATFORM_DIAG_SOURCES)                                                                                 \
     $(NULL)
 endif
 
@@ -218,7 +226,8 @@ noinst_HEADERS                                                                  
     $(NULL)
 
 PRETTY_FILES                                                                                               = \
-    $(PLATFORM_SOURCES)                                                                                      \
+    $(PLATFORM_COMMON_SOURCES)                                                                               \
+    $(PLATFORM_DIAG_SOURCES)                                                                                 \
     $(NULL)
 
 Dash                                                                                                       = -

--- a/examples/platforms/nrf52840/diag.c
+++ b/examples/platforms/nrf52840/diag.c
@@ -252,8 +252,8 @@ static void processTemp(otInstance *aInstance, int argc, char *argv[], char *aOu
     // Convert the temperature measurement to a decimal value, in degrees Celsius
     snprintf(aOutput, aOutputMaxLen, "%" PRId32 ".%02" PRId32 "\r\n", temperature / 4, 25 * (temperature % 4));
 
-    exit:
-        appendErrorResult(error, aOutput, aOutputMaxLen);
+exit:
+    appendErrorResult(error, aOutput, aOutputMaxLen);
 }
 
 static void processCcaThreshold(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)


### PR DESCRIPTION
Noticed "make pretty-check" failing when `--enable-diag` is added...This is result of "make pretty" run. 

