### PR TITLE
[network-data] add protection against memcpy() memory overwrite

### DIFF
--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -47,7 +47,7 @@ otError otBorderRouterGetNetData(otInstance *aInstance, bool aStable, uint8_t *a
 
     VerifyOrExit(aData != NULL && aDataLength != NULL, error = OT_ERROR_INVALID_ARGS);
 
-    aInstance->mThreadNetif.GetNetworkDataLocal().GetNetworkData(aStable, aData, *aDataLength);
+    error = aInstance->mThreadNetif.GetNetworkDataLocal().GetNetworkData(aStable, aData, *aDataLength);
 
 exit:
     return error;

--- a/src/core/api/netdata_api.cpp
+++ b/src/core/api/netdata_api.cpp
@@ -44,7 +44,7 @@ otError otNetDataGet(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_
 
     VerifyOrExit(aData != NULL && aDataLength != NULL, error = OT_ERROR_INVALID_ARGS);
 
-    aInstance->mThreadNetif.GetNetworkDataLeader().GetNetworkData(aStable, aData, *aDataLength);
+    error = aInstance->mThreadNetif.GetNetworkDataLeader().GetNetworkData(aStable, aData, *aDataLength);
 
 exit:
     return error;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1061,7 +1061,9 @@ otError Mle::AppendLeaderData(Message &aMessage)
 
 void Mle::FillNetworkDataTlv(NetworkDataTlv &aTlv, bool aStableOnly)
 {
-    uint8_t length;
+    uint8_t length = 255; // sizeof( NetworkDataTlv::mNetworkData )
+
+    // Ignore result code, 255 bytes must be enough
     GetNetif().GetNetworkDataLeader().GetNetworkData(aStableOnly, aTlv.GetNetworkData(), length);
     aTlv.SetLength(length);
 }

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1061,9 +1061,9 @@ otError Mle::AppendLeaderData(Message &aMessage)
 
 void Mle::FillNetworkDataTlv(NetworkDataTlv &aTlv, bool aStableOnly)
 {
-    uint8_t length = 255; // sizeof( NetworkDataTlv::mNetworkData )
+    uint8_t length = sizeof( NetworkDataTlv ) - sizeof( Tlv ); // sizeof( NetworkDataTlv::mNetworkData )
 
-    // Ignore result code, 255 bytes must be enough
+    // Ignore result code, provided buffer must be enough
     GetNetif().GetNetworkDataLeader().GetNetworkData(aStableOnly, aTlv.GetNetworkData(), length);
     aTlv.SetLength(length);
 }

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1061,7 +1061,7 @@ otError Mle::AppendLeaderData(Message &aMessage)
 
 void Mle::FillNetworkDataTlv(NetworkDataTlv &aTlv, bool aStableOnly)
 {
-    uint8_t length = sizeof( NetworkDataTlv ) - sizeof( Tlv ); // sizeof( NetworkDataTlv::mNetworkData )
+    uint8_t length = sizeof(NetworkDataTlv) - sizeof(Tlv);     // sizeof( NetworkDataTlv::mNetworkData )
 
     // Ignore result code, provided buffer must be enough
     GetNetif().GetNetworkDataLeader().GetNetworkData(aStableOnly, aTlv.GetNetworkData(), length);

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -66,9 +66,12 @@ void NetworkData::Clear(void)
     mLength = 0;
 }
 
-void NetworkData::GetNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLength)
+otError NetworkData::GetNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLength)
 {
+    otError error = OT_ERROR_NONE;
+
     assert(aData != NULL);
+    VerifyOrExit(aDataLength >= mLength, error = OT_ERROR_NO_BUFS);
 
     memcpy(aData, mTlvs, mLength);
     aDataLength = mLength;
@@ -77,6 +80,9 @@ void NetworkData::GetNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLen
     {
         RemoveTemporaryData(aData, aDataLength);
     }
+
+exit:
+    return error;
 }
 
 otError NetworkData::GetNextOnMeshPrefix(otNetworkDataIterator *aIterator, otBorderRouterConfig *aConfig)

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -114,8 +114,10 @@ public:
      * @param[out]    aData        A pointer to the data buffer.
      * @param[inout]  aDataLength  On entry, size of the data buffer pointed to by @p aData.
      *                             On exit, number of copied bytes.
+     * @retval OT_ERROR_NONE       Successfully copied full Thread Network Data.
+     * @retval OT_ERROR_NO_BUFS    Not enough space to fully copy Thread Network Data.
      */
-    void GetNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLength);
+    otError GetNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLength);
 
     /**
      * This method provides the next On Mesh prefix in the Thread Network Data.

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -114,8 +114,10 @@ public:
      * @param[out]    aData        A pointer to the data buffer.
      * @param[inout]  aDataLength  On entry, size of the data buffer pointed to by @p aData.
      *                             On exit, number of copied bytes.
+     *
      * @retval OT_ERROR_NONE       Successfully copied full Thread Network Data.
      * @retval OT_ERROR_NO_BUFS    Not enough space to fully copy Thread Network Data.
+     *
      */
     otError GetNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLength);
 


### PR DESCRIPTION
This commits prevents memory corruption in case of providing too short buffer to `NetworkData::GetNetworkData`.

`Mle::FillNetworkDataTlv` could be improved to check the size as well (and it is used only in 2 places), though with current structures it is safe, since `NetworkDataTlv` has 255 bytes available anyway. So, I left that relatively intact, to avoid extra runtime checks. 