### PR TITLE
[network-data] fix bug in external route lookup

### DIFF
--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -327,7 +327,9 @@ otError LeaderBase::ExternalRouteLookup(uint8_t aDomainId, const Ip6::Address &a
                     if (rvalRoute == NULL ||
                         entry->GetPreference() > rvalRoute->GetPreference() ||
                         (entry->GetPreference() == rvalRoute->GetPreference() &&
-                         netif.GetMle().GetCost(entry->GetRloc()) < netif.GetMle().GetCost(rvalRoute->GetRloc())))
+                         (entry->GetRloc() == netif.GetMle().GetRloc16() ||
+                          (rvalRoute->GetRloc() != netif.GetMle().GetRloc16() &&
+                           netif.GetMle().GetCost(entry->GetRloc()) < netif.GetMle().GetCost(rvalRoute->GetRloc())))))
                     {
                         rvalRoute = entry;
                         rval_plen = static_cast<uint8_t>(plen);


### PR DESCRIPTION
This commit changes the external route lookup logic to ensure that if
an external route prefix is registered by multiple routers (at same
priority level) within the thread network, during route/destination
lookup on a device which has registered this external route, the
router itself is selected/preferred over other routers. This addresses
an issue where a message destined for the external address can be
passed back and forth between routers.