### PR TITLE
[coap] fix secure coap retransmission issue

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -49,10 +49,10 @@
 namespace ot {
 namespace Coap {
 
-Coap::Coap(ThreadNetif &aNetif):
+Coap::Coap(ThreadNetif &aNetif, Timer::Handler aRetransmissionHandler):
     ThreadNetifLocator(aNetif),
     mSocket(aNetif.GetIp6().mUdp),
-    mRetransmissionTimer(aNetif.GetInstance(), &Coap::HandleRetransmissionTimer, this),
+    mRetransmissionTimer(aNetif.GetInstance(), aRetransmissionHandler, this),
     mResources(NULL),
     mContext(NULL),
     mInterceptor(NULL),

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -443,10 +443,11 @@ public:
     /**
      * This constructor initializes the object.
      *
-     * @param[in]  aNetif    A reference to the Netif object.
+     * @param[in]  aNetif                   A reference to the Netif object.
+     * @param[in]  aRetransmissionHandler   An optional pointer to the retransmission handler, used by CoapSecure.
      *
      */
-    Coap(ThreadNetif &aNetif);
+    Coap(ThreadNetif &aNetif, Timer::Handler aRetransmissionHandler = &Coap::HandleRetransmissionTimer);
 
     /**
      * This method starts the CoAP service.
@@ -647,6 +648,12 @@ public:
 
 protected:
     /**
+     * Retransmission timer handler.
+     *
+     */
+    void HandleRetransmissionTimer(void);
+
+    /**
      * This method send a message.
      *
      * @param[in]  aMessage      A reference to the message to send.
@@ -688,8 +695,8 @@ private:
     otError SendCopy(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     otError SendEmptyMessage(Header::Type aType, const Header &aRequestHeader,
                              const Ip6::MessageInfo &aMessageInfo);
+
     static void HandleRetransmissionTimer(Timer &aTimer);
-    void HandleRetransmissionTimer(void);
 
     static Coap &GetOwner(const Context &aContext);
 

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -48,7 +48,7 @@ namespace ot {
 namespace Coap {
 
 CoapSecure::CoapSecure(ThreadNetif &aNetif):
-    Coap(aNetif),
+    Coap(aNetif, &CoapSecure::HandleRetransmissionTimer),
     mConnectedCallback(NULL),
     mConnectedContext(NULL),
     mTransportCallback(NULL),
@@ -318,6 +318,11 @@ CoapSecure &CoapSecure::GetOwner(const Context &aContext)
     OT_UNUSED_VARIABLE(aContext);
 #endif
     return coap;
+}
+
+void CoapSecure::HandleRetransmissionTimer(Timer &aTimer)
+{
+    GetOwner(aTimer).Coap::HandleRetransmissionTimer();
 }
 
 }  // namespace Coap

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -214,6 +214,8 @@ private:
     static void HandleUdpTransmit(Tasklet &aTasklet);
     void HandleUdpTransmit(void);
 
+    static void HandleRetransmissionTimer(Timer &aTimer);
+
     static CoapSecure &GetOwner(const Context &aContext);
 
     Ip6::MessageInfo mPeerAddress;


### PR DESCRIPTION
This PR is a fix proposal for a bug in `SecureCoap` that I've encountered when I was testing commissioning.

A little bit of background - after `GetOwner` method in CoAP was introduced, a problem with a static  handler of `mRetransmissionTimer` showed up. In single instance mode, whenever retransmission timer striked, static `GetOwner` method from `Coap` class was called, regardless if the timer was a member of a `Coap` or `SecureCoap` class.  

As there are separate instances for `Coap` and `SecureCoap`: `mCoap` and `mCoapSecure`, the former one was always returned. In result, there was no chance to handle messages queued for retransmission in an instance of `SecureCoap`. This resulted in commissionig failure in case a retransmission of JoinerFinalize message was needed.

The same pattern would apply for any class that uses inheritance and uses `GetOwner` in static handlers. I've looked through the code and did no find any other case, but I cannot exclude that I've missed something.

The fix proposed extends the `Coap` constructor with an optional parameter -`aRetransmissionHandler`. This way, `SecureCoap` instances can register their own static timer handler and thereby use correct `GetOwner` funcion. I'm open though for discussion, if there is a more graceful way to solve the issue.