### PR TITLE
[mac] fix tx counters

### DIFF
--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -951,6 +951,7 @@ typedef struct otMacCounters
     uint32_t mTxRetry;                ///< The number of retransmission times.
     uint32_t mTxErrCca;               ///< The number of CCA failure times.
     uint32_t mTxErrAbort;             ///< The number of frame transmission failures due to abort error.
+    uint32_t mTxErrBusyChannel;       ///< The number of frames that were dropped due to a busy channel.
     uint32_t mRxTotal;                ///< The total number of received packets.
     uint32_t mRxUnicast;              ///< The total number of unicast packets received.
     uint32_t mRxBroadcast;            ///< The total number of broadcast packets received.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -660,6 +660,7 @@ void Interpreter::ProcessCounters(int argc, char *argv[])
             mServer->OutputFormat("    TxOther: %d\r\n", counters->mTxOther);
             mServer->OutputFormat("    TxRetry: %d\r\n", counters->mTxRetry);
             mServer->OutputFormat("    TxErrCca: %d\r\n", counters->mTxErrCca);
+            mServer->OutputFormat("    TxErrBusyChannel: %d\r\n", counters->mTxErrBusyChannel);
             mServer->OutputFormat("RxTotal: %d\r\n", counters->mRxTotal);
             mServer->OutputFormat("    RxUnicast: %d\r\n", counters->mRxUnicast);
             mServer->OutputFormat("    RxBroadcast: %d\r\n", counters->mRxBroadcast);


### PR DESCRIPTION
Current implementation increments `mTxTotal`, `mTxBroadcast` and `mTxUnicast` after each CCA failure, which leads  to erroneus frame numbers in case of CCA errors. This PR fixes this issue by increasing counters only once per frame.

Also I've added a `mTxBusyChannel` field to the counter to keep track of how many MAC frames were dropped due to multiple CCA failures.