### PR TITLE
[mle] fix bug in child link sync after reset

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1286,8 +1286,7 @@ void Mle::HandleParentRequestTimer(void)
         break;
 
     case kParentSynchronize:
-        mParentRequestState = kParentIdle;
-        BecomeChild(kAttachAny);
+        SendChildUpdateRequest();
         break;
 
     case kParentRequestStart:


### PR DESCRIPTION
This commit fixes a bug when a child coming out of reset attempts to
re-establish the link to its parent.  Upon coming out of reset, a child
will restore state from non-volatile memory, including its IEEE 802.15.4
Short Address.  If the child fails to receive an MLE Child Update Response,
it begins the normal MLE Attach process in search for a new parent.  However,
prior to this commit, the device would not reset its state back to the
detached state.  As a result, a child may be stuck sending IEEE 802.15.4
Data Request messages using its old (probably invalid) Short Address.

This commit also enables retransmission of MLE Child Update Request
messages immediately after a reset.  This increases the child's likelihood
of maintaining its existing parent, which is a desirable property in Thread.