### PR TITLE
[meshcop] give priority to better matches during join, not channel

### DIFF
--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -213,6 +213,7 @@ void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
             {
                 VerifyOrExit(aResult->mLqi > mJoinerRouterLqi);
             }
+
             mJoinerRouterIsSpecific = true;
         }
         else

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -205,7 +205,6 @@ void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
         {
             VerifyOrExit(!mJoinerRouterIsSpecific);
             VerifyOrExit(aResult->mLqi > mJoinerRouterLqi);
-            mJoinerRouterIsSpecific = false;
         }
         else if (steeringData.GetBit(mCcitt % steeringData.GetNumBits()) &&
                  steeringData.GetBit(mAnsi % steeringData.GetNumBits()))
@@ -214,6 +213,7 @@ void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
             {
                 VerifyOrExit(aResult->mLqi > mJoinerRouterLqi);
             }
+            mJoinerRouterIsSpecific = true;
         }
         else
         {

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -205,6 +205,7 @@ void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
         {
             VerifyOrExit(!mJoinerRouterIsSpecific);
             VerifyOrExit(aResult->mLqi > mJoinerRouterLqi);
+            mJoinerRouterIsSpecific = false;
         }
         else if (steeringData.GetBit(mCcitt % steeringData.GetNumBits()) &&
                  steeringData.GetBit(mAnsi % steeringData.GetNumBits()))
@@ -220,7 +221,6 @@ void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
             ExitNow();
         }
 
-        mJoinerRouterIsSpecific = !steeringData.DoesAllowAny();
         mJoinerUdpPort = aResult->mJoinerUdpPort;
         mJoinerRouterPanId = aResult->mPanId;
         mJoinerRouterChannel = aResult->mChannel;

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -67,7 +67,9 @@ Joiner::Joiner(ThreadNetif &aNetif):
     mContext(NULL),
     mCcitt(0),
     mAnsi(0),
+    mJoinerRouterIsSpecific(false),
     mJoinerRouterChannel(0),
+    mJoinerRouterLqi(0),
     mJoinerRouterPanId(0),
     mJoinerUdpPort(0),
     mVendorName(NULL),
@@ -119,6 +121,8 @@ otError Joiner::Start(const char *aPSKd, const char *aProvisioningUrl,
     SuccessOrExit(error);
 
     mJoinerRouterPanId = Mac::kPanIdBroadcast;
+    mJoinerRouterLqi = 0;
+    mJoinerRouterIsSpecific = false;
     SuccessOrExit(error = netif.GetMle().Discover(0, netif.GetMac().GetPanId(), true, false, HandleDiscoverResult,
                                                   this));
 
@@ -197,19 +201,31 @@ void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
         steeringData.SetLength(aResult->mSteeringData.mLength);
         memcpy(steeringData.GetValue(), aResult->mSteeringData.m8, steeringData.GetLength());
 
-        if (steeringData.DoesAllowAny() ||
-            (steeringData.GetBit(mCcitt % steeringData.GetNumBits()) &&
-             steeringData.GetBit(mAnsi % steeringData.GetNumBits())))
+        if (steeringData.DoesAllowAny())
         {
-            mJoinerUdpPort = aResult->mJoinerUdpPort;
-            mJoinerRouterPanId = aResult->mPanId;
-            mJoinerRouterChannel = aResult->mChannel;
-            memcpy(&mJoinerRouter, &aResult->mExtAddress, sizeof(mJoinerRouter));
+            VerifyOrExit(!mJoinerRouterIsSpecific);
+            VerifyOrExit(aResult->mLqi > mJoinerRouterLqi);
+        }
+        else if (steeringData.GetBit(mCcitt % steeringData.GetNumBits()) &&
+                 steeringData.GetBit(mAnsi % steeringData.GetNumBits()))
+        {
+            if (mJoinerRouterIsSpecific)
+            {
+                VerifyOrExit(aResult->mLqi > mJoinerRouterLqi);
+            }
         }
         else
         {
             otLogDebgMeshCoP(GetInstance(), "Steering data does not include this device");
+            ExitNow();
         }
+
+        mJoinerRouterIsSpecific = !steeringData.DoesAllowAny();
+        mJoinerUdpPort = aResult->mJoinerUdpPort;
+        mJoinerRouterPanId = aResult->mPanId;
+        mJoinerRouterChannel = aResult->mChannel;
+        mJoinerRouterLqi = aResult->mLqi;
+        memcpy(&mJoinerRouter, &aResult->mExtAddress, sizeof(mJoinerRouter));
     }
     else if (mJoinerRouterPanId != Mac::kPanIdBroadcast)
     {

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -69,7 +69,7 @@ Joiner::Joiner(ThreadNetif &aNetif):
     mAnsi(0),
     mJoinerRouterIsSpecific(false),
     mJoinerRouterChannel(0),
-    mJoinerRouterLqi(0),
+    mJoinerRouterRssi(0),
     mJoinerRouterPanId(0),
     mJoinerUdpPort(0),
     mVendorName(NULL),
@@ -121,7 +121,7 @@ otError Joiner::Start(const char *aPSKd, const char *aProvisioningUrl,
     SuccessOrExit(error);
 
     mJoinerRouterPanId = Mac::kPanIdBroadcast;
-    mJoinerRouterLqi = 0;
+    mJoinerRouterRssi = 0;
     mJoinerRouterIsSpecific = false;
     SuccessOrExit(error = netif.GetMle().Discover(0, netif.GetMac().GetPanId(), true, false, HandleDiscoverResult,
                                                   this));
@@ -204,14 +204,14 @@ void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
         if (steeringData.DoesAllowAny())
         {
             VerifyOrExit(!mJoinerRouterIsSpecific);
-            VerifyOrExit(aResult->mLqi > mJoinerRouterLqi);
+            VerifyOrExit(aResult->mRssi > mJoinerRouterRssi);
         }
         else if (steeringData.GetBit(mCcitt % steeringData.GetNumBits()) &&
                  steeringData.GetBit(mAnsi % steeringData.GetNumBits()))
         {
             if (mJoinerRouterIsSpecific)
             {
-                VerifyOrExit(aResult->mLqi > mJoinerRouterLqi);
+                VerifyOrExit(aResult->mRssi > mJoinerRouterRssi);
             }
 
             mJoinerRouterIsSpecific = true;
@@ -225,7 +225,7 @@ void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
         mJoinerUdpPort = aResult->mJoinerUdpPort;
         mJoinerRouterPanId = aResult->mPanId;
         mJoinerRouterChannel = aResult->mChannel;
-        mJoinerRouterLqi = aResult->mLqi;
+        mJoinerRouterRssi = aResult->mRssi;
         memcpy(&mJoinerRouter, &aResult->mExtAddress, sizeof(mJoinerRouter));
     }
     else if (mJoinerRouterPanId != Mac::kPanIdBroadcast)

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -140,7 +140,6 @@ private:
     uint16_t mCcitt;
     uint16_t mAnsi;
 
-
     bool mJoinerRouterIsSpecific;
     uint8_t mJoinerRouterChannel;
     uint8_t mJoinerRouterLqi;

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -142,7 +142,7 @@ private:
 
     bool mJoinerRouterIsSpecific;
     uint8_t mJoinerRouterChannel;
-    uint8_t mJoinerRouterLqi;
+    uint8_t mJoinerRouterRssi;
     uint16_t mJoinerRouterPanId;
     uint16_t mJoinerUdpPort;
     Mac::ExtAddress mJoinerRouter;

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -140,7 +140,10 @@ private:
     uint16_t mCcitt;
     uint16_t mAnsi;
 
+
+    bool mJoinerRouterIsSpecific;
     uint8_t mJoinerRouterChannel;
+    uint8_t mJoinerRouterLqi;
     uint16_t mJoinerRouterPanId;
     uint16_t mJoinerUdpPort;
     Mac::ExtAddress mJoinerRouter;

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -142,7 +142,7 @@ private:
 
     bool mJoinerRouterIsSpecific;
     uint8_t mJoinerRouterChannel;
-    uint8_t mJoinerRouterRssi;
+    int8_t mJoinerRouterRssi;
     uint16_t mJoinerRouterPanId;
     uint16_t mJoinerUdpPort;
     Mac::ExtAddress mJoinerRouter;


### PR DESCRIPTION
Previous behaviour of the joiner would result in the joiner joining
the network with the highest channel number, rather than the most
suitable. This commit utilises the priority specified in thread spec
1.1.1 section 8.4.4.1.2 to choose the most suited network for joining.
This removes the bug where it would be impossible to join the desired
network due to another network on a higher channel allowing all joiners
in the steering data.

There is still further work to be done to fully match the spec here, as
currently there is no queue mechanic to try a different network if the
DTLS handshake fails.

More info: #2136 