### PR TITLE
[nrf52840] add basic gpio diag commands

### DIFF
--- a/examples/platforms/nrf52840/DIAG.md
+++ b/examples/platforms/nrf52840/DIAG.md
@@ -6,9 +6,9 @@ New commands allow for more accurate low level radio testing.
 
 ### New commands
  * [diag ccathreshold](#diag-ccathreshold)
+ * [diag gpio](#diag-gpio)
  * [diag id](#diag-id)
  * [diag listen](#diag-listen)
- * [diag gpio](#diag-gpio)
  * [diag temp](#diag-temp)
  * [diag transmit](#diag-transmit)
 
@@ -53,26 +53,8 @@ Value range 0 to 255.
 
 Default: `45`.
 
-### diag id
-Get board ID.
-
-### diag id \<id\>
-Set board ID.
-
-Value range 0 to 32767.
-
-Default: `-1`.
-
-### diag listen
-Get listen state.
-
-### diag listen \<listen\>
-Set listen state.
-
-`0` disable listen state.<br />
-`1` enable listen state.
-
-Default: listen disabled.
+### diag gpio
+Set of commands for managing gpio pins.
 
 ### diag gpio \<pinnum\>
 Return the current value of the gpio.
@@ -82,7 +64,7 @@ contiguous number space as follows:
 ```
    pinnum = (port * 32) + pin
 ```
-See also the NRF_GPIO_PIN_MAP macro.
+See also the [`NRF_GPIO_PIN_MAP`](../../../third_party/NordicSemiconductor/hal/nrf_gpio.h) macro.
 
 ```bash
 > diag gpio 47
@@ -116,6 +98,27 @@ Sets the given output gpio to low.
 > diag gpio clr 47
 gpio 47 = 0
 ```
+
+### diag id
+Get board ID.
+
+### diag id \<id\>
+Set board ID.
+
+Value range 0 to 32767.
+
+Default: `-1`.
+
+### diag listen
+Get listen state.
+
+### diag listen \<listen\>
+Set listen state.
+
+`0` disable listen state.<br />
+`1` enable listen state.
+
+Default: listen disabled.
 
 ### diag temp
 Get temperature from internal temperature sensor, in degrees Celsius.

--- a/examples/platforms/nrf52840/DIAG.md
+++ b/examples/platforms/nrf52840/DIAG.md
@@ -76,6 +76,14 @@ Default: listen disabled.
 
 ### diag gpio \<pinnum\>
 Return the current value of the gpio.
+
+Note: \<pinnum\> is an integer that combines port and pin into a single,
+contiguous number space as follows:
+```
+   pinnum = (port * 32) + pin
+```
+See also the NRF_GPIO_PIN_MAP macro.
+
 ```bash
 > diag gpio 47
 gpio 47 = 0

--- a/examples/platforms/nrf52840/DIAG.md
+++ b/examples/platforms/nrf52840/DIAG.md
@@ -8,6 +8,7 @@ New commands allow for more accurate low level radio testing.
  * [diag ccathreshold](#diag-ccathreshold)
  * [diag id](#diag-id)
  * [diag listen](#diag-listen)
+ * [diag gpio](#diag-gpio)
  * [diag temp](#diag-temp)
  * [diag transmit](#diag-transmit)
 
@@ -72,6 +73,41 @@ Set listen state.
 `1` enable listen state.
 
 Default: listen disabled.
+
+### diag gpio \<pinnum\>
+Return the current value of the gpio.
+```bash
+> diag gpio 47
+gpio 47 = 0
+```
+
+### diag gpio out \<pinnum\>
+Sets the given gpio to output mode.
+```bash
+> diag gpio out 47
+gpio 47: out
+```
+
+### diag gpio in \<pinnum\>
+Sets the given gpio to input, no pull mode.
+```bash
+> diag gpio in 47
+gpio 47: in no pull
+```
+
+### diag gpio set \<pinnum\>
+Sets the given output gpio to high.
+```bash
+> diag gpio set 47
+gpio 47 = 1
+```
+
+### diag gpio clr \<pinnum\>
+Sets the given output gpio to low.
+```bash
+> diag gpio clr 47
+gpio 47 = 0
+```
 
 ### diag temp
 Get temperature from internal temperature sensor, in degrees Celsius.

--- a/examples/platforms/nrf52840/diag.c
+++ b/examples/platforms/nrf52840/diag.c
@@ -245,7 +245,6 @@ static void processGpio(otInstance *aInstance, int argc, char *argv[],
                         char *aOutput, size_t aOutputMaxLen)
 {
     OT_UNUSED_VARIABLE(aInstance);
-    OT_UNUSED_VARIABLE(argv);
 
     long pinnum;
     otError error = OT_ERROR_NONE;
@@ -307,14 +306,6 @@ static void processGpio(otInstance *aInstance, int argc, char *argv[],
     else
     {
         error = OT_ERROR_INVALID_ARGS;
-        snprintf(aOutput, aOutputMaxLen,
-                 "Error: Illegal arguments\r\n"
-                 "Usage:\r\n"
-                 "   gpio <pinnum>\r\n"
-                 "   gpio out <pinnum>\r\n"
-                 "   gpio in <pinnum>\r\n"
-                 "   gpio set <out pinnum>\r\n"
-                 "   gpio clr <out pinnum>\r\n");
     }
 
 exit:
@@ -379,12 +370,12 @@ exit:
 
 const struct PlatformDiagCommand sCommands[] =
 {
-    { "listen", &processListen },
-    { "transmit", &processTransmit },
-    { "id", &processID },
-    { "gpio", &processGpio },
-    { "temp", &processTemp },
     { "ccathreshold", &processCcaThreshold }
+    { "gpio", &processGpio },
+    { "id", &processID },
+    { "listen", &processListen },
+    { "temp", &processTemp },
+    { "transmit", &processTransmit },
 };
 
 void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)

--- a/examples/platforms/nrf52840/diag.c
+++ b/examples/platforms/nrf52840/diag.c
@@ -261,7 +261,7 @@ static void processGpio(otInstance *aInstance, int argc, char *argv[],
         value = nrf_gpio_pin_read(pinnum);
 
         snprintf(aOutput, aOutputMaxLen, "gpio %d = %d\r\n",
-                 (int)pinnum, (int)value);
+                 (uint8_t)pinnum, (uint8_t)value);
     }
     else if (strcmp(argv[0], "set") == 0)
     {
@@ -271,7 +271,7 @@ static void processGpio(otInstance *aInstance, int argc, char *argv[],
 
         nrf_gpio_pin_set(pinnum);
 
-        snprintf(aOutput, aOutputMaxLen, "gpio %d = 1\r\n", (int)pinnum);
+        snprintf(aOutput, aOutputMaxLen, "gpio %d = 1\r\n", (uint8_t)pinnum);
     }
     else if (strcmp(argv[0], "clr") == 0)
     {
@@ -281,7 +281,7 @@ static void processGpio(otInstance *aInstance, int argc, char *argv[],
 
         nrf_gpio_pin_clear(pinnum);
 
-        snprintf(aOutput, aOutputMaxLen, "gpio %d = 0\r\n", (int)pinnum);
+        snprintf(aOutput, aOutputMaxLen, "gpio %d = 0\r\n", (uint8_t)pinnum);
     }
     else if (strcmp(argv[0], "out") == 0)
     {
@@ -291,7 +291,7 @@ static void processGpio(otInstance *aInstance, int argc, char *argv[],
 
         nrf_gpio_cfg_output(pinnum);
 
-        snprintf(aOutput, aOutputMaxLen, "gpio %d: out\r\n", (int)pinnum);
+        snprintf(aOutput, aOutputMaxLen, "gpio %d: out\r\n", (uint8_t)pinnum);
     }
     else if (strcmp(argv[0], "in") == 0)
     {
@@ -301,7 +301,8 @@ static void processGpio(otInstance *aInstance, int argc, char *argv[],
 
         nrf_gpio_cfg_input(pinnum, NRF_GPIO_PIN_NOPULL);
 
-        snprintf(aOutput, aOutputMaxLen, "gpio %d: in no pull\r\n", (int)pinnum);
+        snprintf(aOutput, aOutputMaxLen, "gpio %d: in no pull\r\n",
+                 (uint8_t)pinnum);
     }
     else
     {
@@ -370,7 +371,7 @@ exit:
 
 const struct PlatformDiagCommand sCommands[] =
 {
-    { "ccathreshold", &processCcaThreshold }
+    { "ccathreshold", &processCcaThreshold },
     { "gpio", &processGpio },
     { "id", &processID },
     { "listen", &processListen },

--- a/examples/platforms/nrf52840/diag.c
+++ b/examples/platforms/nrf52840/diag.c
@@ -37,6 +37,8 @@
 
 #include "platform-nrf5.h"
 
+#include <hal/nrf_gpio.h>
+
 #include <openthread/cli.h>
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
@@ -239,6 +241,76 @@ exit:
     appendErrorResult(error, aOutput, aOutputMaxLen);
 }
 
+static void processGpio(otInstance *aInstance, int argc, char *argv[],
+                        char *aOutput, size_t aOutputMaxLen)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(argv);
+
+    long pinnum;
+    otError error = OT_ERROR_NONE;
+
+    otEXPECT_ACTION(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
+
+    if (argc == 1)
+    {
+        uint32_t value;
+
+        otEXPECT_ACTION(argc == 1, error = OT_ERROR_INVALID_ARGS);
+        error = parseLong(argv[0], &pinnum);
+        otEXPECT(error == OT_ERROR_NONE);
+
+        value = nrf_gpio_pin_read(pinnum);
+
+        snprintf(aOutput, aOutputMaxLen, "gpio %d = %d\r\n",
+                 (int)pinnum, (int)value);
+    }
+    else if (strcmp(argv[0], "set") == 0)
+    {
+        otEXPECT_ACTION(argc == 2, error = OT_ERROR_INVALID_ARGS);
+        error = parseLong(argv[1], &pinnum);
+        otEXPECT(error == OT_ERROR_NONE);
+
+        nrf_gpio_pin_set(pinnum);
+
+        snprintf(aOutput, aOutputMaxLen, "gpio %d = 1\r\n", (int)pinnum);
+    }
+    else if (strcmp(argv[0], "clr") == 0)
+    {
+        otEXPECT_ACTION(argc == 2, error = OT_ERROR_INVALID_ARGS);
+        error = parseLong(argv[1], &pinnum);
+        otEXPECT(error == OT_ERROR_NONE);
+
+        nrf_gpio_pin_clear(pinnum);
+
+        snprintf(aOutput, aOutputMaxLen, "gpio %d = 0\r\n", (int)pinnum);
+    }
+    else if (strcmp(argv[0], "out") == 0)
+    {
+        otEXPECT_ACTION(argc == 2, error = OT_ERROR_INVALID_ARGS);
+        error = parseLong(argv[1], &pinnum);
+        otEXPECT(error == OT_ERROR_NONE);
+
+        nrf_gpio_cfg_output(pinnum);
+
+        snprintf(aOutput, aOutputMaxLen, "gpio %d: out\r\n", (int)pinnum);
+    }
+    else if (strcmp(argv[0], "in") == 0)
+    {
+        otEXPECT_ACTION(argc == 2, error = OT_ERROR_INVALID_ARGS);
+        error = parseLong(argv[1], &pinnum);
+        otEXPECT(error == OT_ERROR_NONE);
+
+        nrf_gpio_cfg_input(pinnum, NRF_GPIO_PIN_NOPULL);
+
+        snprintf(aOutput, aOutputMaxLen, "gpio %d: in no pull\r\n", (int)pinnum);
+    }
+
+exit:
+    appendErrorResult(error, aOutput, aOutputMaxLen);
+}
+
+
 static void processTemp(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
     OT_UNUSED_VARIABLE(aInstance);
@@ -299,6 +371,7 @@ const struct PlatformDiagCommand sCommands[] =
     { "listen", &processListen },
     { "transmit", &processTransmit },
     { "id", &processID },
+    { "gpio", &processGpio },
     { "temp", &processTemp },
     { "ccathreshold", &processCcaThreshold }
 };

--- a/examples/platforms/nrf52840/diag.c
+++ b/examples/platforms/nrf52840/diag.c
@@ -256,7 +256,6 @@ static void processGpio(otInstance *aInstance, int argc, char *argv[],
     {
         uint32_t value;
 
-        otEXPECT_ACTION(argc == 1, error = OT_ERROR_INVALID_ARGS);
         error = parseLong(argv[0], &pinnum);
         otEXPECT(error == OT_ERROR_NONE);
 
@@ -304,6 +303,18 @@ static void processGpio(otInstance *aInstance, int argc, char *argv[],
         nrf_gpio_cfg_input(pinnum, NRF_GPIO_PIN_NOPULL);
 
         snprintf(aOutput, aOutputMaxLen, "gpio %d: in no pull\r\n", (int)pinnum);
+    }
+    else
+    {
+        error = OT_ERROR_INVALID_ARGS;
+        snprintf(aOutput, aOutputMaxLen,
+                 "Error: Illegal arguments\r\n"
+                 "Usage:\r\n"
+                 "   gpio <pinnum>\r\n"
+                 "   gpio out <pinnum>\r\n"
+                 "   gpio in <pinnum>\r\n"
+                 "   gpio set <out pinnum>\r\n"
+                 "   gpio clr <out pinnum>\r\n");
     }
 
 exit:


### PR DESCRIPTION
Add some basic support for gpio control to the extended, platform-specific diags on nrf52840.