### PR TITLE
[tests] change to test mtd apps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,9 @@ matrix:
     - env: BUILD_TARGET="posix-ncp" VERBOSE=1
       os: linux
       compiler: gcc
+    - env: BUILD_TARGET="posix-mtd" VERBOSE=1
+      os: linux
+      compiler: gcc
     - env: BUILD_TARGET="pretty-check"
       os: linux
     - env: BUILD_TARGET="scan-build" CC="clang" CXX="clang++"

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -39,7 +39,7 @@ cd /tmp || die
 [ $TRAVIS_OS_NAME != linux ] || {
     sudo apt-get update || die
 
-    [ $BUILD_TARGET != posix-distcheck -a $BUILD_TARGET != posix-32-bit -a $BUILD_TARGET != posix-ncp ] || {
+    [ $BUILD_TARGET != posix-distcheck -a $BUILD_TARGET != posix-32-bit -a $BUILD_TARGET != posix-mtd -a $BUILD_TARGET != posix-ncp ] || {
         pip install --upgrade pip || die
         pip install --user -r $TRAVIS_BUILD_DIR/tests/scripts/thread-cert/requirements.txt || die
         [ $BUILD_TARGET != posix-ncp ] || {
@@ -85,7 +85,7 @@ cd /tmp || die
         arc-elf32-gcc --version || die
     }
 
-    [ $BUILD_TARGET != posix-32-bit ] || {
+    [ $BUILD_TARGET != posix-32-bit -a $BUILD_TARGET != posix-mtd ] || {
         sudo apt-get install g++-multilib || die
     }
 

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -261,6 +261,11 @@ set -x
     COVERAGE=1 CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 make -f examples/Makefile-posix check || die
 }
 
+[ $BUILD_TARGET != posix-mtd ] || {
+    ./bootstrap || die
+    COVERAGE=1 CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 USE_MTD=1 make -f examples/Makefile-posix check || die
+}
+
 [ $BUILD_TARGET != posix-ncp-spi ] || {
     ./bootstrap || die
     make -f examples/Makefile-posix check configure_OPTIONS="--enable-ncp-app=ftd --with-ncp-bus=spi --with-examples=posix" || die

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -194,7 +194,7 @@ otError Dataset::Print(otOperationalDataset &aDataset)
 
 otError Dataset::Process(otInstance *aInstance, int argc, char *argv[], Server &aServer)
 {
-    otError error = OT_ERROR_NONE;
+    otError error = OT_ERROR_PARSE;
 
     sServer = &aServer;
 

--- a/tests/scripts/thread-cert/Cert_5_1_02_ChildAddressTimeout.py
+++ b/tests/scripts/thread-cert/Cert_5_1_02_ChildAddressTimeout.py
@@ -40,13 +40,14 @@ ED = 3
 SED = 4
 SNIFFER = 5
 
+MTDS = [ED, SED]
 
 class Cert_5_1_02_ChildAddressTimeout(unittest.TestCase):
 
     def setUp(self):
         self.nodes = {}
         for i in range(1, 5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
+++ b/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
@@ -40,7 +40,7 @@ class Cert_5_1_07_MaxChildCount(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1, 13):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i >= 3))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
@@ -40,11 +40,13 @@ REED = 5
 ED2 = 6
 ED3 = 7
 
+MTDS = [ED1, ED2, ED3]
+
 class Cert_5_2_5_AddressQuery(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,8):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_3_02_RealmLocal.py
+++ b/tests/scripts/thread-cert/Cert_5_3_02_RealmLocal.py
@@ -41,7 +41,7 @@ class Cert_5_3_2_RealmLocal(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == SED1))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_3_03_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_03_AddressQuery.py
@@ -42,7 +42,7 @@ class Cert_5_3_3_AddressQuery(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED2))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_3_04_AddressMapCache.py
+++ b/tests/scripts/thread-cert/Cert_5_3_04_AddressMapCache.py
@@ -40,11 +40,13 @@ ED3 = 5
 ED4 = 6
 ED5 = 7
 
+MTDS = [SED1, ED2, ED3, ED4, ED5]
+
 class Cert_5_3_4_AddressMapCache(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,8):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
+++ b/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
@@ -39,11 +39,13 @@ ED1 = 4
 ED2 = 5
 ED3 = 6
 
+MTDS = [ED1, ED2, ED3]
+
 class Cert_5_3_7_DuplicateAddress(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,7):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_3_08_ChildAddressSet.py
+++ b/tests/scripts/thread-cert/Cert_5_3_08_ChildAddressSet.py
@@ -38,11 +38,13 @@ ED2 = 3
 ED3 = 4
 ED4 = 5
 
+MTDS = [ED1, ED2, ED3, ED4]
+
 class Cert_5_3_8_ChildAddressSet(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_3_09_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_09_AddressQuery.py
@@ -42,7 +42,7 @@ class Cert_5_3_09_AddressQuery(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == SED1))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
@@ -42,7 +42,7 @@ class Cert_5_3_10_AddressQuery(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == SED2))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_5_02_LeaderReboot.py
+++ b/tests/scripts/thread-cert/Cert_5_5_02_LeaderReboot.py
@@ -40,7 +40,7 @@ class Cert_5_5_2_LeaderReboot(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,4):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_5_03_SplitMergeChildren.py
+++ b/tests/scripts/thread-cert/Cert_5_5_03_SplitMergeChildren.py
@@ -39,11 +39,13 @@ ED1 = 4
 ED2 = 5
 ED3 = 6
 
+MTDS = [ED1, ED2, ED3]
+
 class Cert_5_5_3_SplitMergeChildren(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,7):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_5_05_SplitMergeREED.py
+++ b/tests/scripts/thread-cert/Cert_5_5_05_SplitMergeREED.py
@@ -49,7 +49,7 @@ class Cert_5_5_5_SplitMergeREED(unittest.TestCase):
         self.nodes[LEADER].set_mode('rsdn')
         for i in range(ROUTER2, ROUTER15+1):
             self.nodes[LEADER].add_whitelist(self.nodes[i].get_addr64())
-        self.nodes[LEADER].enable_whitelist()            
+        self.nodes[LEADER].enable_whitelist()
 
         for i in range(ROUTER2, ROUTER15+1):
             self.nodes[i].set_panid(0xface)

--- a/tests/scripts/thread-cert/Cert_5_5_08_SplitRoutersLostLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_5_08_SplitRoutersLostLeader.py
@@ -42,7 +42,7 @@ class Cert_5_5_8_SplitRoutersLostLeader(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED1))
 
         self.nodes[LEADER1].set_panid(0xface)
         self.nodes[LEADER1].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py
@@ -37,11 +37,13 @@ ROUTER = 2
 ED1 = 3
 SED1 = 4
 
+MTDS = [ED1, SED1]
+
 class Cert_5_6_1_NetworkDataLeaderAsBr(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
@@ -37,11 +37,13 @@ ROUTER = 2
 ED1 = 3
 SED1 = 4
 
+MTDS = [ED1, SED1]
+
 class Cert_5_6_2_NetworkDataRouterAsBr(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py
@@ -37,11 +37,13 @@ ROUTER = 2
 ED1 = 3
 SED1 = 4
 
+MTDS = [ED1, SED1]
+
 class Cert_5_6_3_NetworkDataRegisterAfterAttachLeader(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
@@ -37,11 +37,13 @@ ROUTER = 2
 ED1 = 3
 SED1 = 4
 
+MTDS = [ED1, SED1]
+
 class Cert_5_6_4_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
@@ -37,11 +37,13 @@ ROUTER = 2
 ED1 = 3
 SED1 = 4
 
+MTDS = [ED1, SED1]
+
 class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
+++ b/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
@@ -37,11 +37,13 @@ ROUTER = 2
 ED1 = 3
 SED1 = 4
 
+MTDS = [ED1, SED1]
+
 class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_6_08_ContextManagement.py
+++ b/tests/scripts/thread-cert/Cert_5_6_08_ContextManagement.py
@@ -40,7 +40,7 @@ class Cert_5_6_8_ContextManagement(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,4):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
+++ b/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
@@ -38,11 +38,13 @@ ROUTER2 = 3
 ED = 4
 SED = 5
 
+MTDS = [ED, SED]
+
 class Cert_5_6_9_NetworkDataForwarding(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_5_8_01_KeySynchronization.py
+++ b/tests/scripts/thread-cert/Cert_5_8_01_KeySynchronization.py
@@ -39,7 +39,7 @@ class Cert_5_8_1_KeySynchronization(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_1_01_RouterAttach.py
+++ b/tests/scripts/thread-cert/Cert_6_1_01_RouterAttach.py
@@ -42,7 +42,7 @@ class Cert_6_1_1_RouterAttach(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_1_02_REEDAttach.py
+++ b/tests/scripts/thread-cert/Cert_6_1_02_REEDAttach.py
@@ -40,7 +40,7 @@ class Cert_6_1_2_REEDAttach(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,4):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
@@ -42,7 +42,7 @@ class Cert_6_1_3_RouterAttachConnectivity(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_1_04_REEDAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_6_1_04_REEDAttachConnectivity.py
@@ -42,7 +42,7 @@ class Cert_6_1_4_REEDAttachConnectivity(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_1_05_RouterAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_6_1_05_RouterAttachLinkQuality.py
@@ -41,7 +41,7 @@ class Cert_6_1_5_RouterAttachLinkQuality(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_1_06_REEDAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_6_1_06_REEDAttachLinkQuality.py
@@ -41,7 +41,7 @@ class Cert_6_1_6_REEDAttachLinkQuality(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_1_07_EDSynchronization.py
+++ b/tests/scripts/thread-cert/Cert_6_1_07_EDSynchronization.py
@@ -42,7 +42,7 @@ class Cert_6_1_7_EDSynchronization(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_2_01_NewPartition.py
+++ b/tests/scripts/thread-cert/Cert_6_2_01_NewPartition.py
@@ -40,7 +40,7 @@ class Cert_6_2_1_NewPartition(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,4):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_2_02_NewPartition.py
+++ b/tests/scripts/thread-cert/Cert_6_2_02_NewPartition.py
@@ -41,7 +41,7 @@ class Cert_6_2_2_NewPartition(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_3_01_OrphanReattach.py
+++ b/tests/scripts/thread-cert/Cert_6_3_01_OrphanReattach.py
@@ -40,7 +40,7 @@ class Cert_6_3_1_OrphanReattach(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,4):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_3_02_NetworkDataUpdate.py
+++ b/tests/scripts/thread-cert/Cert_6_3_02_NetworkDataUpdate.py
@@ -39,7 +39,7 @@ class Cert_5_6_2_NetworkDataUpdate(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_4_01_LinkLocal.py
+++ b/tests/scripts/thread-cert/Cert_6_4_01_LinkLocal.py
@@ -39,7 +39,7 @@ class Cert_6_4_1_LinkLocal(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_4_02_RealmLocal.py
+++ b/tests/scripts/thread-cert/Cert_6_4_02_RealmLocal.py
@@ -40,7 +40,7 @@ class Cert_5_3_2_RealmLocal(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_5_01_ChildResetSynchronize.py
+++ b/tests/scripts/thread-cert/Cert_6_5_01_ChildResetSynchronize.py
@@ -39,7 +39,7 @@ class Cert_6_5_1_ChildResetSynchronize(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_5_02_ChildResetReattach.py
+++ b/tests/scripts/thread-cert/Cert_6_5_02_ChildResetReattach.py
@@ -39,7 +39,7 @@ class Cert_6_5_2_ChildResetReattach(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_6_01_KeyIncrement.py
+++ b/tests/scripts/thread-cert/Cert_6_6_01_KeyIncrement.py
@@ -39,7 +39,7 @@ class Cert_6_6_1_KeyIncrement(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_6_6_02_KeyIncrementRollOver.py
+++ b/tests/scripts/thread-cert/Cert_6_6_02_KeyIncrementRollOver.py
@@ -39,7 +39,7 @@ class Cert_6_6_2_KeyIncrement1(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
@@ -37,11 +37,13 @@ ROUTER = 2
 SED1 = 3
 ED1 = 4
 
+MTDS = [SED1, ED1]
+
 class Cert_7_1_1_BorderRouterAsLeader(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
@@ -37,11 +37,13 @@ ROUTER = 2
 ED2 = 3
 SED2 = 4
 
+MTDS = [ED2, SED2]
+
 class Cert_7_1_2_BorderRouterAsRouter(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
@@ -37,11 +37,13 @@ ROUTER = 2
 SED1 = 3
 ED1 = 4
 
+MTDS = [SED1, ED1]
+
 class Cert_7_1_3_BorderRouterAsLeader(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
@@ -37,11 +37,13 @@ ROUTER = 2
 ED2 = 3
 SED2 = 4
 
+MTDS = [SED2, ED2]
+
 class Cert_7_1_4_BorderRouterAsRouter(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
@@ -37,11 +37,13 @@ ROUTER = 2
 ED2 = 3
 SED2 = 4
 
+MTDS = [ED2, SED2]
+
 class Cert_7_1_5_BorderRouterAsRouter(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_9_2_08_PersistentDatasets.py
+++ b/tests/scripts/thread-cert/Cert_9_2_08_PersistentDatasets.py
@@ -45,11 +45,13 @@ LEADER_ACTIVE_TIMESTAMP = 10
 COMMISSIONER_PENDING_CHANNEL = 20
 COMMISSIONER_PENDING_PANID = 0xafce
 
+MTDS = [ED, SED]
+
 class Cert_9_2_8_PersistentDatasets(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[COMMISSIONER].set_active_dataset(LEADER_ACTIVE_TIMESTAMP, panid=PANID_INIT, channel=CHANNEL_INIT)
         self.nodes[COMMISSIONER].set_mode('rsdn')
@@ -69,11 +71,13 @@ class Cert_9_2_8_PersistentDatasets(unittest.TestCase):
         self.nodes[ROUTER].set_mode('rsdn')
         self._setUpRouter()
 
-        self.nodes[ED].set_active_dataset(LEADER_ACTIVE_TIMESTAMP, panid=PANID_INIT, channel=CHANNEL_INIT)
+        self.nodes[ED].set_channel(CHANNEL_INIT)
+        self.nodes[ED].set_panid(PANID_INIT)
         self.nodes[ED].set_mode('rsn')
         self._setUpEd()
 
-        self.nodes[SED].set_active_dataset(LEADER_ACTIVE_TIMESTAMP, panid=PANID_INIT, channel=CHANNEL_INIT)
+        self.nodes[SED].set_channel(CHANNEL_INIT)
+        self.nodes[SED].set_panid(PANID_INIT)
         self.nodes[SED].set_mode('s')
         self._setUpSed()
 

--- a/tests/scripts/thread-cert/Cert_9_2_10_PendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_10_PendingPartition.py
@@ -44,11 +44,13 @@ ROUTER1 = 3
 ED1 = 4
 SED1 = 5
 
+MTDS = [ED1, SED1]
+
 class Cert_9_2_10_PendingPartition(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[COMMISSIONER].set_active_dataset(15, channel=CHANNEL_INIT, panid=PANID_INIT)
         self.nodes[COMMISSIONER].set_mode('rsdn')
@@ -72,12 +74,14 @@ class Cert_9_2_10_PendingPartition(unittest.TestCase):
         self.nodes[ROUTER1].enable_whitelist()
         self.nodes[ROUTER1].set_router_selection_jitter(1)
 
-        self.nodes[ED1].set_active_dataset(15, channel=CHANNEL_INIT, panid=PANID_INIT)
+        self.nodes[ED1].set_channel(CHANNEL_INIT)
+        self.nodes[ED1].set_panid(PANID_INIT)
         self.nodes[ED1].set_mode('rsn')
         self.nodes[ED1].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ED1].enable_whitelist()
 
-        self.nodes[SED1].set_active_dataset(15, channel=CHANNEL_INIT, panid=PANID_INIT)
+        self.nodes[SED1].set_channel(CHANNEL_INIT)
+        self.nodes[SED1].set_panid(PANID_INIT)
         self.nodes[SED1].set_mode('s')
         self.nodes[SED1].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[SED1].enable_whitelist()

--- a/tests/scripts/thread-cert/Cert_9_2_11_MasterKey.py
+++ b/tests/scripts/thread-cert/Cert_9_2_11_MasterKey.py
@@ -44,11 +44,13 @@ ROUTER1 = 3
 ED1 = 4
 SED1 = 5
 
+MTDS = [ED1, SED1]
+
 class Cert_9_2_11_MasterKey(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[COMMISSIONER].set_active_dataset(10, channel=CHANNEL_INIT, panid=PANID_INIT, master_key=KEY1)
         self.nodes[COMMISSIONER].set_mode('rsdn')
@@ -71,12 +73,16 @@ class Cert_9_2_11_MasterKey(unittest.TestCase):
         self.nodes[ROUTER1].enable_whitelist()
         self.nodes[ROUTER1].set_router_selection_jitter(1)
 
-        self.nodes[ED1].set_active_dataset(10, channel=CHANNEL_INIT, panid=PANID_INIT, master_key=KEY1)
+        self.nodes[ED1].set_channel(CHANNEL_INIT)
+        self.nodes[ED1].set_panid(PANID_INIT)
+        self.nodes[ED1].set_masterkey(KEY1)
         self.nodes[ED1].set_mode('rsn')
         self.nodes[ED1].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ED1].enable_whitelist()
 
-        self.nodes[SED1].set_active_dataset(10, channel=CHANNEL_INIT, panid=PANID_INIT, master_key=KEY1)
+        self.nodes[SED1].set_channel(CHANNEL_INIT)
+        self.nodes[SED1].set_panid(PANID_INIT)
+        self.nodes[SED1].set_masterkey(KEY1)
         self.nodes[SED1].set_mode('s')
         self.nodes[SED1].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[SED1].enable_whitelist()

--- a/tests/scripts/thread-cert/Cert_9_2_12_Announce.py
+++ b/tests/scripts/thread-cert/Cert_9_2_12_Announce.py
@@ -50,7 +50,7 @@ class Cert_9_2_12_Announce(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == MED))
 
         self.nodes[LEADER1].set_active_dataset(DATASET1_TIMESTAMP, channel=DATASET1_CHANNEL, panid=DATASET1_PANID)
         self.nodes[LEADER1].set_mode('rsdn')
@@ -78,7 +78,8 @@ class Cert_9_2_12_Announce(unittest.TestCase):
         self.nodes[ROUTER2].enable_whitelist()
         self.nodes[ROUTER2].set_router_selection_jitter(1)
 
-        self.nodes[MED].set_active_dataset(DATASET2_TIMESTAMP, channel=DATASET2_CHANNEL, panid=DATASET2_PANID)
+        self.nodes[MED].set_channel(DATASET2_CHANNEL)
+        self.nodes[MED].set_panid(DATASET2_PANID)
         self.nodes[MED].set_mode('rsn')
         self.nodes[MED].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[MED].enable_whitelist()

--- a/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
+++ b/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
@@ -41,7 +41,7 @@ class Cert_9_2_13_EnergyScan(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED1))
 
         self.nodes[COMMISSIONER].set_panid(0xface)
         self.nodes[COMMISSIONER].set_mode('rsdn')

--- a/tests/scripts/thread-cert/Cert_9_2_17_Orphan.py
+++ b/tests/scripts/thread-cert/Cert_9_2_17_Orphan.py
@@ -45,7 +45,7 @@ class Cert_9_2_17_Orphan(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,4):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i == ED1))
 
         self.nodes[LEADER1].set_active_dataset(10, channel=CHANNEL1, panid=PANID_INIT, channel_mask=CHANNEL_MASK)
         self.nodes[LEADER1].set_mode('rsdn')
@@ -58,8 +58,9 @@ class Cert_9_2_17_Orphan(unittest.TestCase):
         self.nodes[LEADER2].enable_whitelist()
         self.nodes[LEADER2].set_router_selection_jitter(1)
 
-        self.nodes[ED1].set_active_dataset(10, channel=CHANNEL1, panid=PANID_INIT, channel_mask=CHANNEL_MASK)
+        self.nodes[ED1].set_channel(CHANNEL1)
         self.nodes[ED1].set_mode('rsn')
+        self.nodes[ED1].set_panid(PANID_INIT)
         self.nodes[ED1].add_whitelist(self.nodes[LEADER1].get_addr64())
         self.nodes[ED1].enable_whitelist()
         self.nodes[ED1].set_timeout(3)

--- a/tests/scripts/thread-cert/Cert_9_2_18_RollBackActiveTimestamp.py
+++ b/tests/scripts/thread-cert/Cert_9_2_18_RollBackActiveTimestamp.py
@@ -45,11 +45,13 @@ ROUTER2 = 4
 ED1 = 5
 SED1 = 6
 
+MTDS = [ED1, SED1]
+
 class Cert_9_2_18_RollBackActiveTimestamp(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
         for i in range(1,7):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, (i in MTDS))
 
         self.nodes[COMMISSIONER].set_active_dataset(1, channel=CHANNEL_INIT, panid=PANID_INIT, master_key=KEY1)
         self.nodes[COMMISSIONER].set_mode('rsdn')
@@ -80,13 +82,17 @@ class Cert_9_2_18_RollBackActiveTimestamp(unittest.TestCase):
         self.nodes[ROUTER2].enable_whitelist()
         self.nodes[ROUTER2].set_router_selection_jitter(1)
 
-        self.nodes[ED1].set_active_dataset(1, channel=CHANNEL_INIT, panid=PANID_INIT, master_key=KEY1)
+        self.nodes[ED1].set_channel(CHANNEL_INIT)
+        self.nodes[ED1].set_masterkey(KEY1)
         self.nodes[ED1].set_mode('rsn')
+        self.nodes[ED1].set_panid(PANID_INIT)
         self.nodes[ED1].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ED1].enable_whitelist()
 
-        self.nodes[SED1].set_active_dataset(1, channel=CHANNEL_INIT, panid=PANID_INIT, master_key=KEY1)
+        self.nodes[SED1].set_channel(CHANNEL_INIT)
+        self.nodes[SED1].set_masterkey(KEY1)
         self.nodes[SED1].set_mode('s')
+        self.nodes[SED1].set_panid(PANID_INIT)
         self.nodes[SED1].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[SED1].enable_whitelist()
         self.nodes[SED1].set_timeout(3)

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -37,9 +37,9 @@ else:
 import unittest
 
 class Node:
-    def __init__(self, nodeid):
+    def __init__(self, nodeid, is_mtd=False):
         if sys.platform != 'win32':
-            self.interface = node_cli.otCli(nodeid)
+            self.interface = node_cli.otCli(nodeid, is_mtd)
         else:
             self.interface = node_api.otApi(nodeid)
 
@@ -67,7 +67,7 @@ class Node:
 
     def thread_stop(self):
         self.interface.thread_stop()
-            
+
     def commissioner_start(self):
         self.interface.commissioner_start()
 

--- a/tests/scripts/thread-cert/node_cli.py
+++ b/tests/scripts/thread-cert/node_cli.py
@@ -33,30 +33,33 @@ import time
 import pexpect
 
 class otCli:
-    def __init__(self, nodeid):
+    def __init__(self, nodeid, is_mtd):
         self.nodeid = nodeid
         self.verbose = int(float(os.getenv('VERBOSE', 0)))
         self.node_type = os.getenv('NODE_TYPE', 'sim')
 
+        mode = is_mtd and 'mtd' or 'ftd'
+
         if self.node_type == 'soc':
             self.__init_soc(nodeid)
         elif self.node_type == 'ncp-sim':
-            self.__init_ncp_sim(nodeid)
+            # TODO use mode after ncp-mtd is available.
+            self.__init_ncp_sim(nodeid, 'ftd')
         else:
-            self.__init_sim(nodeid)
+            self.__init_sim(nodeid, mode)
 
         if self.verbose:
             self.pexpect.logfile_read = sys.stdout
 
-    def __init_sim(self, nodeid):
+    def __init_sim(self, nodeid, mode):
         """ Initialize a simulation node. """
         if "OT_CLI_PATH" in os.environ.keys():
             cmd = os.environ['OT_CLI_PATH']
         elif "top_builddir" in os.environ.keys():
             srcdir = os.environ['top_builddir']
-            cmd = '%s/examples/apps/cli/ot-cli-ftd' % srcdir
+            cmd = '%s/examples/apps/cli/ot-cli-%s' % (srcdir, mode)
         else:
-            cmd = './ot-cli-ftd'
+            cmd = './ot-cli-%s' % mode
         cmd += ' %d' % nodeid
         print ("%s" % cmd)
 
@@ -66,13 +69,13 @@ class otCli:
         time.sleep(0.2)
 
 
-    def __init_ncp_sim(self, nodeid):
+    def __init_ncp_sim(self, nodeid, mode):
         """ Initialize an NCP simulation node. """
         if "top_builddir" in os.environ.keys():
             builddir = os.environ['top_builddir']
-            cmd = 'spinel-cli.py -p %s/examples/apps/ncp/ot-ncp-ftd -n' % (builddir)
+            cmd = 'spinel-cli.py -p %s/examples/apps/ncp/ot-ncp-%s -n' % (builddir, mode)
         else:
-            cmd = './ot-ncp-ftd'
+            cmd = './ot-ncp-%s' % mode
         cmd += ' %d' % nodeid
         print ("%s" % cmd)
 

--- a/tests/scripts/thread-cert/node_cli.py
+++ b/tests/scripts/thread-cert/node_cli.py
@@ -38,7 +38,7 @@ class otCli:
         self.verbose = int(float(os.getenv('VERBOSE', 0)))
         self.node_type = os.getenv('NODE_TYPE', 'sim')
 
-        mode = is_mtd and 'mtd' or 'ftd'
+        mode = os.environ.get('USE_MTD') is '1' and is_mtd and 'mtd' or 'ftd'
 
         if self.node_type == 'soc':
             self.__init_soc(nodeid)


### PR DESCRIPTION
Currently all CI tests uses FTD firmware, leaving MTD firmware not tested.

+ Allowed MTD to process advertisement.
+ Added a new test builder for MTD.
+ Changed test scripts to allow simulating MTD device with MTD firmware.
+ Changed test scripts to set MTD's Thread parameters through parameters' setters instead of through active dataset(disabled in MTD). 
+ Show error in cli if `dataset`'s sub-command not found.