### PR TITLE
[ncp-uart] fix the bug in uart encoder

### DIFF
--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -137,7 +137,7 @@ void NcpUart::EncodeAndSendToUart(void)
 {
     uint16_t len;
 
-    while (!mTxFrameBuffer.IsEmpty())
+    while (!mTxFrameBuffer.IsEmpty() || (mState == kFinalizingFrame))
     {
         switch (mState)
         {
@@ -159,7 +159,7 @@ void NcpUart::EncodeAndSendToUart(void)
             {
                 mByte = mTxFrameBuffer.OutFrameReadByte();
 
-            case kEncodingFrame:
+        case kEncodingFrame:
 
                 SuccessOrExit(mFrameEncoder.Encode(mByte, mUartBuffer));
             }


### PR DESCRIPTION
This commit fixes an issue with the `NcpUart::EncodeAndSendToUart()`
code where the last message can be removed from `mTxFrameBuffer`
and if we ran out of buffer and cannot finalize the HDLC encoded
frame, the final bytes would not be sent until next message is
queued in `mTxBuffer`.