### PR TITLE
[mac] update ENABLE_BEACON_RSP_WHEN_JOINABLE behavior

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1827,10 +1827,10 @@ otError Mac::HandleMacCommand(Frame &aFrame)
         mCounters.mRxBeaconRequest++;
         otLogInfoMac(GetInstance(), "Received Beacon Request");
 
-        if ((mBeaconsEnabled)
-#if OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE
-            && (IsBeaconJoinable())
-#endif // OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE
+        if (mBeaconsEnabled
+#if OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_WHEN_JOINABLE
+            || IsBeaconJoinable()
+#endif // OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_WHEN_JOINABLE
            )
         {
             StartOperation(kOperationTransmitBeacon);
@@ -1904,7 +1904,7 @@ void Mac::ResetCounters(void)
     memset(&mCounters, 0, sizeof(mCounters));
 }
 
-#if OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE
+#if OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_WHEN_JOINABLE
 bool Mac::IsBeaconJoinable(void)
 {
     uint8_t numUnsecurePorts;
@@ -1923,7 +1923,7 @@ bool Mac::IsBeaconJoinable(void)
 
     return joinable;
 }
-#endif // OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE
+#endif // OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_WHEN_JOINABLE
 
 Mac &Mac::GetOwner(const Context &aContext)
 {

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -587,16 +587,16 @@ public:
      */
     void ResetCounters(void);
 
-#if OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE
+#if OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_WHEN_JOINABLE
     /**
-     * This method indicates if the beacon is joinable or non-joinable
+     * This method indicates if the device is in joinable state or not.
      *
-     * @retval true   Beacon is joinable.
-     * @retval false  Beacon is non-joinable.
+     * @retval true   Device is joinable.
+     * @retval false  Device is non-joinable.
      *
      */
     bool IsBeaconJoinable(void);
-#endif // OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE
+#endif // OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_WHEN_JOINABLE
 
     /**
      * This method returns the MAC counter.

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -753,13 +753,16 @@
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE
+ * @def OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_WHEN_JOINABLE
  *
- * Define to 1 if you want to enable beacon response for joinable networks.
+ * Define to 1 to enable IEEE 802.15.4 Beacons when joining is enabled.
+ *
+ * @note When this feature is enabled, the device will transmit IEEE 802.15.4 Beacons in response to IEEE 802.15.4
+ * Beacon Requests even while the device is not router capable and detached.
  *
  */
-#ifndef OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE
-#define OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_IF_JOINABLE         0
+#ifndef OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_WHEN_JOINABLE
+#define OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_WHEN_JOINABLE       0
 #endif
 
 /**


### PR DESCRIPTION
This commit updates the behavior of `ENABLE_BEACON_RSP_WHEN_JOINABLE`
feature. When enabled the device will respond to beacon request
if device is made joinable independent of the current mode of the
device (i.e., even if it is in child or detached mode).