### PR TITLE
[build] removed duplicate from source file list

### DIFF
--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -96,7 +96,6 @@ SOURCES_COMMON                      = \
     api/dataset_api.cpp               \
     api/dataset_ftd_api.cpp           \
     api/dhcp6_api.cpp                 \
-    api/dhcp6_api.cpp                 \
     api/dns_api.cpp                   \
     api/icmp6_api.cpp                 \
     api/instance_api.cpp              \


### PR DESCRIPTION
The list of source files in the Makefile.am from scr/core contains a duplicate entry for 'api/dhcp6_api.cpp'