### PR TITLE
[platform] add PlatformEventSignalPending to platform module

### DIFF
--- a/examples/platforms/nrf52840/alarm.c
+++ b/examples/platforms/nrf52840/alarm.c
@@ -43,6 +43,7 @@
 #include <openthread/platform/alarm-micro.h>
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
+#include <openthread/platform/platform.h>
 
 #include "platform-config.h"
 #include "platform-nrf5.h"
@@ -180,6 +181,7 @@ static void HandleCompareMatch(AlarmIndex aIndex, bool aSkipCheck)
         nrf_rtc_int_disable(RTC_INSTANCE, sChannelData[aIndex].mCompareInt);
 
         sTimerData[aIndex].mFireAlarm = true;
+        PlatformEventSignalPending();
     }
 }
 

--- a/examples/platforms/nrf52840/platform.c
+++ b/examples/platforms/nrf52840/platform.c
@@ -89,3 +89,8 @@ void PlatformProcessDrivers(otInstance *aInstance)
     nrf5RadioProcess(aInstance);
     nrf5UartProcess();
 }
+
+__WEAK void PlatformEventSignalPending(void)
+{
+    // Intentionally empty
+}

--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -44,9 +44,10 @@
 
 #include <common/code_utils.hpp>
 #include <platform-config.h>
-#include <openthread/platform/logging.h>
-#include <openthread/platform/radio.h>
 #include <openthread/platform/diag.h>
+#include <openthread/platform/logging.h>
+#include <openthread/platform/platform.h>
+#include <openthread/platform/radio.h>
 
 #include "platform-nrf5.h"
 
@@ -140,6 +141,8 @@ static void setPendingEvent(RadioPendingEvents aEvent)
         pendingEvents |= bitToSet;
     }
     while (__STREXW(pendingEvents, (unsigned long volatile *)&sPendingEvents));
+
+    PlatformEventSignalPending();
 }
 
 static void resetPendingEvent(RadioPendingEvents aEvent)

--- a/examples/platforms/nrf52840/uart.c
+++ b/examples/platforms/nrf52840/uart.c
@@ -39,6 +39,7 @@
 #include <stdint.h>
 
 #include <openthread/types.h>
+#include <openthread/platform/platform.h>
 #include <openthread/platform/toolchain.h>
 #include <openthread/platform/uart.h>
 #include <utils/code_utils.h>
@@ -263,6 +264,7 @@ void UARTE0_UART0_IRQHandler(void)
         {
             sReceiveBuffer[sReceiveHead] = byte;
             sReceiveHead = (sReceiveHead + 1) % UART_RX_BUFFER_SIZE;
+            PlatformEventSignalPending();
         }
     }
 
@@ -281,6 +283,7 @@ void UARTE0_UART0_IRQHandler(void)
         {
             sTransmitDone = true;
             nrf_uart_task_trigger(UART_INSTANCE, NRF_UART_TASK_STOPTX);
+            PlatformEventSignalPending();
         }
     }
 }

--- a/include/openthread/platform/platform.h
+++ b/include/openthread/platform/platform.h
@@ -61,6 +61,12 @@ void PlatformDeinit(void);
  */
 void PlatformProcessDrivers(otInstance *aInstance);
 
+/**
+ * This function is called whenever platform drivers needs processing.
+ *
+ */
+extern void PlatformEventSignalPending(void);
+
 #ifdef __cplusplus
 }  // end of extern "C"
 #endif


### PR DESCRIPTION
Add PlatformEventSignalPending allowing device drivers to signal that they need processing. It's useful when working with RTOSes.