### PR TITLE
[mle] feature - inform previous parent on attach to a new parent

### DIFF
--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -851,6 +851,19 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_INFORM_PREVIOUS_PARENT_ON_REATTACH
+ *
+ * Define as 1 for a child to inform its previous parent when it attaches to a new parent.
+ *
+ * If this feature is enabled, when a device attaches to a new parent, it will send an IP message (with empty payload
+ * and mesh-local IP address as the source address) to its previous parent.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_INFORM_PREVIOUS_PARENT_ON_REATTACH
+#define OPENTHREAD_CONFIG_INFORM_PREVIOUS_PARENT_ON_REATTACH    0
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_NCP_ENABLE_PEEK_POKE
  *
  * Define as 1 to enable peek/poke functionality on NCP.
@@ -872,7 +885,6 @@
 #ifndef OPENTHREAD_CONFIG_STAY_AWAKE_BETWEEN_FRAGMENTS
 #define OPENTHREAD_CONFIG_STAY_AWAKE_BETWEEN_FRAGMENTS          0
 #endif
-
 
 /*
  * @def OPENTHREAD_CONFIG_ENABLE_DEBUG_UART

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1371,6 +1371,10 @@ private:
     bool IsBetterParent(uint16_t aRloc16, uint8_t aLinkQuality, ConnectivityTlv &aConnectivityTlv);
     void ResetParentCandidate(void);
 
+#if OPENTHREAD_CONFIG_INFORM_PREVIOUS_PARENT_ON_REATTACH
+    otError InformPreviousParent(void);
+#endif
+
     static Mle &GetOwner(const Context &aContext);
 
     MessageQueue mDelayedResponses;
@@ -1406,6 +1410,10 @@ private:
     void *mDiscoverContext;
     bool mIsDiscoverInProgress;
     bool mEnableEui64Filtering;
+
+#if OPENTHREAD_CONFIG_INFORM_PREVIOUS_PARENT_ON_REATTACH
+    uint16_t mPreviousParentRloc;
+#endif
 
     uint8_t mAnnounceChannel;
     uint8_t mPreviousChannel;


### PR DESCRIPTION
This commit adds a new feature for a child to inform its previous
parent when it attaches to a new parent. OpenThread config option
`CONFIG_INFORM_PREVIOUS_PARENT_ON_REATTACH` controls the behavior of
this feature (default is disabled). If this feature is enabled, after
a device attaches to a new parent, it sends an IP message (with empty
payload) to its previous parent.