### PR TITLE
[message-pool] evict indirect message buffers if no available buffers

### DIFF
--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -174,6 +174,15 @@ public:
     void RemoveMessages(Child &aChild, uint8_t aSubType);
 
     /**
+     * This method evicts the first indirect message in the indirect send queue.
+     *
+     * @retval OT_ERROR_NONE       Successfully evicted an indirect message.
+     * @retval OT_ERROR_NOT_FOUND  No indirect messages available to evict.
+     *
+     */
+    otError EvictIndirectMessage(void);
+
+    /**
      * This method returns a reference to the send queue.
      *
      * @returns  A reference to the send queue.
@@ -281,6 +290,7 @@ private:
     otError HandleDatagram(Message &aMessage, const otThreadLinkInfo &aLinkInfo,
                            const Mac::Address &aMacSource);
     void ClearReassemblyList(void);
+    void RemoveMessage(Message &aMessage);
 
     static void HandleReceivedFrame(Mac::Receiver &aReceiver, Mac::Frame &aFrame);
     void HandleReceivedFrame(Mac::Frame &aFrame);


### PR DESCRIPTION
Message buffer allocation can fail if there are no available message
buffers.  Without a way to evict messages, critical messages (i.e. MLE
Advertisements) needed to maintain the Thread network cannot be generated.

This commit takes a first step towards evicting queued message buffers. In
particular, this commit evicts indirect messages from the head of queue
until there are enough available buffers.

Future commits will seek to implement fairness and priority mechanisms to
better select which messages are evicted from the send queue.