### PR TITLE
[mbedtls] patch for slow crypto calculations

### DIFF
--- a/third_party/mbedtls/patch/0001-Fix-commissioning-problem-with-retransmissions.patch
+++ b/third_party/mbedtls/patch/0001-Fix-commissioning-problem-with-retransmissions.patch
@@ -1,8 +1,22 @@
-diff --git a/third_party/mbedtls/repo/library/ssl_tls.c b/third_party/mbedtls/repo/library/ssl_tls.c
-index 84a04ae..72e4684 100644
---- a/third_party/mbedtls/repo/library/ssl_tls.c
-+++ b/third_party/mbedtls/repo/library/ssl_tls.c
-@@ -3070,6 +3070,23 @@ static int ssl_reassemble_dtls_handshake( mbedtls_ssl_context *ssl )
+diff --git a/third_party/mbedtls/repo.patched/library/ssl_tls.c b/third_party/mbedtls/repo.patched/library/ssl_tls.c
+index 84a04ae..b983646 100644
+--- a/third_party/mbedtls/repo.patched/library/ssl_tls.c
++++ b/third_party/mbedtls/repo.patched/library/ssl_tls.c
+@@ -53,6 +53,13 @@
+ #include "mbedtls/oid.h"
+ #endif
+ 
++#ifndef MBEDTLS_SLOW_CPU
++#define MBEDTLS_SLOW_CPU 0
++#endif //ndef MBEDTLS_SLOW_CPU
++#ifndef MBEDTLS_COMPUTATION_UNTILL_SEQ_NR
++#define MBEDTLS_COMPUTATION_UNTILL_SEQ_NR 6
++#endif //ndef MBEDTLS_COMPUTATION_UNTILL_SEQ_NR
++
+ /* Implementation that should never be optimized out by the compiler */
+ static void mbedtls_zeroize( void *v, size_t n ) {
+     volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+@@ -3070,6 +3077,16 @@ static int ssl_reassemble_dtls_handshake( mbedtls_ssl_context *ssl )
  }
  #endif /* MBEDTLS_SSL_PROTO_DTLS */
  
@@ -16,17 +30,10 @@ index 84a04ae..72e4684 100644
 +            ( (uint64_t) buf[5]       ) );
 +}
 +
-+#ifndef OT_DTLS_SLOW_CPU
-+#define OT_DTLS_SLOW_CPU 1
-+#endif //ndef OT_DTLS_SLOW_CPU
-+#ifndef OT_DTLS_COMPUTATION_UNTILL_SEQ_NR
-+#define OT_DTLS_COMPUTATION_UNTILL_SEQ_NR 6
-+#endif //ndef OT_DTLS_COMPUTATION_UNTILL_SEQ_NR
-+
  int mbedtls_ssl_prepare_handshake_record( mbedtls_ssl_context *ssl )
  {
      if( ssl->in_msglen < mbedtls_ssl_hs_hdr_len( ssl ) )
-@@ -3101,8 +3118,22 @@ int mbedtls_ssl_prepare_handshake_record( mbedtls_ssl_context *ssl )
+@@ -3101,8 +3118,19 @@ int mbedtls_ssl_prepare_handshake_record( mbedtls_ssl_context *ssl )
              /* Retransmit only on last message from previous flight, to avoid
               * too many retransmissions.
               * Besides, No sane server ever retransmits HelloVerifyRequest */
@@ -36,30 +43,19 @@ index 84a04ae..72e4684 100644
 +            MBEDTLS_SSL_DEBUG_MSG( 1, ( "dtls seq %d", (uint32_t) (rec_seqnum&0xFFFFFFFF)));
 +            if( (recv_msg_seq == ssl->handshake->in_flight_start_seq - 1) 
 +                && (ssl->in_msg[0] != MBEDTLS_SSL_HS_HELLO_VERIFY_REQUEST) 
-+#if OT_DTLS_SLOW_CPU == 1
++#if MBEDTLS_SLOW_CPU == 1
 +                /* if the crypto calculations take longer then the timeout
 +                 * then don't reply to retransmissions that are currently in the rx queue.
 +                 * Since the calculation time is deterministic, we know how many messages
 +                 * from the queue need to be skipped; i.e. -> we don't trigger
 +                 * retransmits on them */
-+                && (ssl->in_msg[0] != MBEDTLS_SSL_HS_SERVER_HELLO)
-+                && (ssl->in_msg[0] != MBEDTLS_SSL_HS_SERVER_KEY_EXCHANGE)
-+                && (ssl->in_msg[0] != MBEDTLS_SSL_HS_SERVER_HELLO_DONE)
-+                && (rec_seqnum     >  OT_DTLS_COMPUTATION_UNTILL_SEQ_NR)
++                && (rec_seqnum     >  MBEDTLS_COMPUTATION_UNTILL_SEQ_NR)
 +#endif
 +                )
              {
                  MBEDTLS_SSL_DEBUG_MSG( 2, ( "received message from last flight, "
                                      "message_seq = %d, start_of_flight = %d",
-@@ -3122,7 +3153,6 @@ int mbedtls_ssl_prepare_handshake_record( mbedtls_ssl_context *ssl )
-                                     recv_msg_seq,
-                                     ssl->handshake->in_msg_seq ) );
-             }
--
-             return( MBEDTLS_ERR_SSL_WANT_READ );
-         }
-         /* Wait until message completion to increment in_msg_seq */
-@@ -3191,16 +3221,6 @@ static void ssl_dtls_replay_reset( mbedtls_ssl_context *ssl )
+@@ -3191,16 +3219,6 @@ static void ssl_dtls_replay_reset( mbedtls_ssl_context *ssl )
      ssl->in_window = 0;
  }
  
@@ -76,7 +72,7 @@ index 84a04ae..72e4684 100644
  /*
   * Return 0 if sequence number is acceptable, -1 otherwise
   */
-@@ -3608,6 +3628,24 @@ static int ssl_parse_record_header( mbedtls_ssl_context *ssl )
+@@ -3608,6 +3626,24 @@ static int ssl_parse_record_header( mbedtls_ssl_context *ssl )
                                          "expected %d, received %d",
                                          ssl->in_epoch, rec_epoch ) );
  
@@ -101,7 +97,7 @@ index 84a04ae..72e4684 100644
  #if defined(MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE) && defined(MBEDTLS_SSL_SRV_C)
              /*
               * Check for an epoch 0 ClientHello. We can't use in_msg here to
-@@ -3737,7 +3775,8 @@ int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl )
+@@ -3737,7 +3773,8 @@ int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl )
  
          ret = mbedtls_ssl_handle_message_type( ssl );
  

--- a/third_party/mbedtls/patch/0001-Fix-commissioning-problem-with-retransmissions.patch
+++ b/third_party/mbedtls/patch/0001-Fix-commissioning-problem-with-retransmissions.patch
@@ -1,8 +1,82 @@
-diff --git a/third_party/mbedtls/repo.patched/library/ssl_tls.c b/third_party/mbedtls/repo.patched/library/ssl_tls.c
-index 84a04ae..2153c80 100644
---- a/third_party/mbedtls/repo.patched/library/ssl_tls.c
-+++ b/third_party/mbedtls/repo.patched/library/ssl_tls.c
-@@ -3608,6 +3608,24 @@ static int ssl_parse_record_header( mbedtls_ssl_context *ssl )
+diff --git a/third_party/mbedtls/repo/library/ssl_tls.c b/third_party/mbedtls/repo/library/ssl_tls.c
+index 84a04ae..72e4684 100644
+--- a/third_party/mbedtls/repo/library/ssl_tls.c
++++ b/third_party/mbedtls/repo/library/ssl_tls.c
+@@ -3070,6 +3070,23 @@ static int ssl_reassemble_dtls_handshake( mbedtls_ssl_context *ssl )
+ }
+ #endif /* MBEDTLS_SSL_PROTO_DTLS */
+ 
++static inline uint64_t ssl_load_six_bytes( unsigned char *buf )
++{
++    return( ( (uint64_t) buf[0] << 40 ) |
++            ( (uint64_t) buf[1] << 32 ) |
++            ( (uint64_t) buf[2] << 24 ) |
++            ( (uint64_t) buf[3] << 16 ) |
++            ( (uint64_t) buf[4] <<  8 ) |
++            ( (uint64_t) buf[5]       ) );
++}
++
++#ifndef OT_DTLS_SLOW_CPU
++#define OT_DTLS_SLOW_CPU 1
++#endif //ndef OT_DTLS_SLOW_CPU
++#ifndef OT_DTLS_COMPUTATION_UNTILL_SEQ_NR
++#define OT_DTLS_COMPUTATION_UNTILL_SEQ_NR 6
++#endif //ndef OT_DTLS_COMPUTATION_UNTILL_SEQ_NR
++
+ int mbedtls_ssl_prepare_handshake_record( mbedtls_ssl_context *ssl )
+ {
+     if( ssl->in_msglen < mbedtls_ssl_hs_hdr_len( ssl ) )
+@@ -3101,8 +3118,22 @@ int mbedtls_ssl_prepare_handshake_record( mbedtls_ssl_context *ssl )
+             /* Retransmit only on last message from previous flight, to avoid
+              * too many retransmissions.
+              * Besides, No sane server ever retransmits HelloVerifyRequest */
+-            if( recv_msg_seq == ssl->handshake->in_flight_start_seq - 1 &&
+-                ssl->in_msg[0] != MBEDTLS_SSL_HS_HELLO_VERIFY_REQUEST )
++            uint64_t rec_seqnum = ssl_load_six_bytes( ssl->in_ctr + 2 );
++            MBEDTLS_SSL_DEBUG_MSG( 1, ( "dtls seq %d", (uint32_t) (rec_seqnum&0xFFFFFFFF)));
++            if( (recv_msg_seq == ssl->handshake->in_flight_start_seq - 1) 
++                && (ssl->in_msg[0] != MBEDTLS_SSL_HS_HELLO_VERIFY_REQUEST) 
++#if OT_DTLS_SLOW_CPU == 1
++                /* if the crypto calculations take longer then the timeout
++                 * then don't reply to retransmissions that are currently in the rx queue.
++                 * Since the calculation time is deterministic, we know how many messages
++                 * from the queue need to be skipped; i.e. -> we don't trigger
++                 * retransmits on them */
++                && (ssl->in_msg[0] != MBEDTLS_SSL_HS_SERVER_HELLO)
++                && (ssl->in_msg[0] != MBEDTLS_SSL_HS_SERVER_KEY_EXCHANGE)
++                && (ssl->in_msg[0] != MBEDTLS_SSL_HS_SERVER_HELLO_DONE)
++                && (rec_seqnum     >  OT_DTLS_COMPUTATION_UNTILL_SEQ_NR)
++#endif
++                )
+             {
+                 MBEDTLS_SSL_DEBUG_MSG( 2, ( "received message from last flight, "
+                                     "message_seq = %d, start_of_flight = %d",
+@@ -3122,7 +3153,6 @@ int mbedtls_ssl_prepare_handshake_record( mbedtls_ssl_context *ssl )
+                                     recv_msg_seq,
+                                     ssl->handshake->in_msg_seq ) );
+             }
+-
+             return( MBEDTLS_ERR_SSL_WANT_READ );
+         }
+         /* Wait until message completion to increment in_msg_seq */
+@@ -3191,16 +3221,6 @@ static void ssl_dtls_replay_reset( mbedtls_ssl_context *ssl )
+     ssl->in_window = 0;
+ }
+ 
+-static inline uint64_t ssl_load_six_bytes( unsigned char *buf )
+-{
+-    return( ( (uint64_t) buf[0] << 40 ) |
+-            ( (uint64_t) buf[1] << 32 ) |
+-            ( (uint64_t) buf[2] << 24 ) |
+-            ( (uint64_t) buf[3] << 16 ) |
+-            ( (uint64_t) buf[4] <<  8 ) |
+-            ( (uint64_t) buf[5]       ) );
+-}
+-
+ /*
+  * Return 0 if sequence number is acceptable, -1 otherwise
+  */
+@@ -3608,6 +3628,24 @@ static int ssl_parse_record_header( mbedtls_ssl_context *ssl )
                                          "expected %d, received %d",
                                          ssl->in_epoch, rec_epoch ) );
  
@@ -27,7 +101,7 @@ index 84a04ae..2153c80 100644
  #if defined(MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE) && defined(MBEDTLS_SSL_SRV_C)
              /*
               * Check for an epoch 0 ClientHello. We can't use in_msg here to
-@@ -3737,7 +3755,8 @@ int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl )
+@@ -3737,7 +3775,8 @@ int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl )
  
          ret = mbedtls_ssl_handle_message_type( ssl );
  


### PR DESCRIPTION
This is a proposal to fix https://github.com/openthread/openthread/issues/2176

There were different ways to fix the slow-crypto issue:
1) rely on local timeout to retransmit iso on retransmits from the remote => this might be a spec violation.
2) skip duplicate messages in the rx queue.

This second solution is what I'm attempting to do. It assumes that there are x retransmits from server in the rx queue (where x depends on the speed of the calculations) and it will not trigger local retransmits as long as the sequence number is lower then what we expect for a _real_ retransmit.

Practically: the commissioning patch has been updated to assure that we don't make those unnecessary retransmits.
I.e.:
- when we process the rx queue and there is a retransmit => we will reply to it
- when we process the rx queue and there are duplicate messages (the original which we are processing + a retransmit) => we only reply to one, avoiding duplicate messages.

The updated patch changes the behaviour much earlier (compared to the previous patch) in handshake, and therefor avoids unnecessary duplicate messages.
The patch has a define which should be updated according to duration of the crypto computation.
With these fixes the sniffer log now looks clean.

Note: I did not yet see a way to set these flags from the OpenThread build environment. That makes it impossible to merge as-is.
Any suggestions how to handle this in the OT build ?

Note 2: I was also looking for a way to make part of the original patch conditional (e.g. only include it on the Nordic platform), as this would also solve our issue, albeit with limited duplicate messages being transmitted. But this would also require conditional mbedtls compilation based on flags from the OT build env.

