### PR TITLE
[mle] don't send unnecessary MLE Link Request

### DIFF
--- a/src/core/thread/mle_constants.hpp
+++ b/src/core/thread/mle_constants.hpp
@@ -65,6 +65,7 @@ enum
     kMaxResponseDelay              = 1000,  ///< Maximum delay before responding to a multicast request
     kMaxChildIdRequestTimeout      = 5000,  ///< Maximum delay for receiving a Child ID Request
     kMaxChildUpdateResponseTimeout = 2000,  ///< Maximum delay for receiving a Child Update Response
+    kMaxLinkRequestTimeout         = 2000,  ///< Maximum delay for receiving a Link Accept
     kMinTimeout                    = (((kMaxChildKeepAliveAttempts + 1) * kUnicastRetransmissionDelay) / 1000),  ///< Minimum timeout(s)
 };
 


### PR DESCRIPTION
I noticed an issue that when a device send Link Request and Advertisement in very short interval, it's neighbor (no link yet) will send two separate messages: one is Link Accept and Request, another is Link Request, which I think is unnecessary. This PR saves this kind of traffic.