### PR TITLE
[tests] add traffic analysis for Cert_5_2_06_RouterDowngrade.py

### DIFF
--- a/tests/scripts/thread-cert/Makefile.am
+++ b/tests/scripts/thread-cert/Makefile.am
@@ -121,6 +121,7 @@ EXTRA_DIST                                                         = \
     Cert_9_2_17_Orphan.py                                            \
     Cert_9_2_18_RollBackActiveTimestamp.py                           \
     coap.py                                                          \
+    command.py                                                       \
     common.py                                                        \
     config.py                                                        \
     ipv6.py                                                          \

--- a/tests/scripts/thread-cert/command.py
+++ b/tests/scripts/thread-cert/command.py
@@ -11,9 +11,18 @@ def check_address_notification(command_msg, source_node, destination_node):
     command_msg.assertCoapMessageContainsTlv(network_layer.Rloc16)
     command_msg.assertCoapMessageContainsTlv(network_layer.MlEid)
 
-    #pdb.set_trace()
     source_rloc = source_node.get_ip6_address(config.ADDRESS_TYPE.RLOC)
     assert ipv6.ip_address(source_rloc) == command_msg.ipv6_packet.ipv6_header.source_address, "Error: The IPv6 Source address is not the RLOC of the originator."
 
     destination_rloc = destination_node.get_ip6_address(config.ADDRESS_TYPE.RLOC)
     assert ipv6.ip_address(destination_rloc) == command_msg.ipv6_packet.ipv6_header.destination_address, "Error: The IPv6 Destination address is not the RLOC of the destination."
+
+def check_address_release(command_msg, destination_node):
+    """Verify the message is a properly formatted address release destined to the given node.
+    """
+    command_msg.assertCoapMessageRequestUriPath('/a/ar')
+    command_msg.assertCoapMessageContainsTlv(network_layer.Rloc16)
+    command_msg.assertCoapMessageContainsTlv(network_layer.MacExtendedAddress)
+
+    destination_rloc = destination_node.get_ip6_address(config.ADDRESS_TYPE.RLOC)
+    assert ipv6.ip_address(destination_rloc) == command_msg.ipv6_packet.ipv6_header.destination_address, "Error: The Destination is not RLOC address"

--- a/tests/scripts/thread-cert/config.py
+++ b/tests/scripts/thread-cert/config.py
@@ -51,6 +51,7 @@ DEFAULT_MASTER_KEY = bytearray([0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                                 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff])
 
 ADDRESS_TYPE = Enum('ADDRESS_TYPE', ('LINK_LOCAL', 'GLOBAL', 'RLOC', 'ALOC', 'ML_EID'))
+RSSI = {'LINK_QULITY_0': -100, 'LINK_QULITY_1': -95, 'LINK_QULITY_2': -85, 'LINK_QULITY_3': -65}
 
 SNIFFER_ID = int(os.getenv('SNIFFER_ID', 34))
 PANID = 0xface
@@ -203,6 +204,7 @@ def create_default_uri_path_based_payload_factories():
     return {
         "/a/as": network_layer_tlvs_factory,
         "/a/aq": network_layer_tlvs_factory,
+        "/a/ar": network_layer_tlvs_factory,
         "/a/an": network_layer_tlvs_factory
     }
 


### PR DESCRIPTION
Also add a method in `command.py` to verify a properly formatted address release command message.