### PR TITLE
[commissioning-dataset] add TLV validation in HandleCommissioningSet

### DIFF
--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -237,8 +237,11 @@ void Leader::HandleCommissioningSet(Coap::Header &aHeader, Message &aMessage, co
         }
         else if (type == MeshCoP::Tlv::kCommissionerSessionId)
         {
+            MeshCoP::CommissionerSessionIdTlv *tlv = static_cast<MeshCoP::CommissionerSessionIdTlv *>(cur);
+
+            VerifyOrExit(tlv->IsValid());
+            sessionId = tlv->GetCommissionerSessionId();
             hasSessionId = true;
-            sessionId = static_cast<MeshCoP::CommissionerSessionIdTlv *>(cur)->GetCommissionerSessionId();
         }
         else
         {


### PR DESCRIPTION
This commit adds a validation check when reading the Commissioning
Session ID TLV in HandleCommissioningSet().