### PR TITLE
[address-resolver] update/add logs in AddressResolver

### DIFF
--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -150,9 +150,18 @@ private:
         State             mState;
     };
 
+    enum InvalidationReason
+    {
+        kReasonRemovingRouterId,
+        kReasonReceivedIcmpDstUnreachNoRoute,
+        kReasonEvictingForNewEntry,
+    };
+
+    static const char *ConvertInvalidationReasonToString(InvalidationReason aReason);
+
     Cache *NewCacheEntry(void);
     void MarkCacheEntryAsUsed(Cache &aEntry);
-    void InvalidateCacheEntry(Cache &aEntry);
+    void InvalidateCacheEntry(Cache &aEntry, InvalidationReason aReason);
 
     otError SendAddressQuery(const Ip6::Address &aEid);
     otError SendAddressError(const ThreadTargetTlv &aTarget, const ThreadMeshLocalEidTlv &aEid,


### PR DESCRIPTION
The new log show when an address cache entry gets created/updated or removed (and the reason for removal).. Also when address query/notification are sent/received, the new logs give more details like the traget IP address, ...