### PR TITLE
[address-resolver] inspect forwarded frames to update address cache

### DIFF
--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -101,6 +101,15 @@ public:
     void Remove(uint8_t aRouterId);
 
     /**
+     * This method updates an existing cache entry for the EID, if one exists.
+     *
+     * @param[in]  aEid     A reference to the EID.
+     * @param[in]  aRloc16  The RLOC16 corresponding to @p aEid.
+     *
+     */
+    void UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16);
+
+    /**
      * This method returns the RLOC16 for a given EID, or initiates an Address Query if the mapping is not known.
      *
      * @param[in]   aEid     A reference to the EID.
@@ -128,6 +137,11 @@ private:
         kAddressQueryTimeout           = OPENTHREAD_CONFIG_ADDRESS_QUERY_TIMEOUT, // in seconds
         kAddressQueryInitialRetryDelay = OPENTHREAD_CONFIG_ADDRESS_QUERY_INITIAL_RETRY_DELAY, // in seconds
         kAddressQueryMaxRetryDelay     = OPENTHREAD_CONFIG_ADDRESS_QUERY_MAX_RETRY_DELAY, // in seconds
+    };
+
+    enum
+    {
+        kLastTransactionTimeInvalid = 0xffffffff,  ///< Used when entry is populated using forwarded data message.
     };
 
     struct Cache

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1911,7 +1911,9 @@ void MeshForwarder::HandleMesh(uint8_t *aFrame, uint8_t aFrameLength, const Mac:
     meshDest.mLength = sizeof(meshDest.mShortAddress);
     meshDest.mShortAddress = meshHeader.GetDestination();
 
+#if OPENTHREAD_FTD
     UpdateRoutes(aFrame, aFrameLength, meshSource, meshDest);
+#endif // OPENTHREAD_FTD
 
     if (meshDest.mShortAddress == netif.GetMac().GetShortAddress())
     {
@@ -1974,6 +1976,7 @@ exit:
     }
 }
 
+#if OPENTHREAD_FTD
 void MeshForwarder::UpdateRoutes(uint8_t *aFrame, uint8_t aFrameLength,
                                  const Mac::Address &aMeshSource, const Mac::Address &aMeshDest)
 {
@@ -2007,6 +2010,8 @@ void MeshForwarder::UpdateRoutes(uint8_t *aFrame, uint8_t aFrameLength,
     neighbor = netif.GetMle().GetNeighbor(ip6Header.GetSource());
     VerifyOrExit(neighbor != NULL && !neighbor->IsFullThreadDevice());
 
+    netif.GetAddressResolver().UpdateCacheEntry(ip6Header.GetSource(), meshHeader.GetSource());
+
     if (Mle::Mle::GetRouterId(meshHeader.GetSource()) != Mle::Mle::GetRouterId(GetNetif().GetMac().GetShortAddress()))
     {
         netif.GetMle().RemoveNeighbor(*neighbor);
@@ -2015,6 +2020,7 @@ void MeshForwarder::UpdateRoutes(uint8_t *aFrame, uint8_t aFrameLength,
 exit:
     return;
 }
+#endif // OPENTHREAD_FTD
 
 otError MeshForwarder::CheckReachability(uint8_t *aFrame, uint8_t aFrameLength,
                                          const Mac::Address &aMeshSource, const Mac::Address &aMeshDest)


### PR DESCRIPTION
This commit adds logic to inspect forwarded frames and update the address
cache.  If an entry exists for the given IPv6 Source Address and the
RLOC16 source differs, the address cache entry is updated.