### PR TITLE
[mle] fix partition merging bug when determining singleton partitions

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1175,23 +1175,8 @@ bool MleRouter::IsSingleton(void)
 {
     bool rval = true;
 
-    switch (mRole)
+    if (IsAttached() && ((mDeviceMode & ModeTlv::kModeFFD) != 0))
     {
-    case OT_DEVICE_ROLE_DISABLED:
-    case OT_DEVICE_ROLE_DETACHED:
-        ExitNow(rval = true);
-        break;
-
-    case OT_DEVICE_ROLE_CHILD:
-        ExitNow(rval = ((mDeviceMode & ModeTlv::kModeFFD) == 0));
-        break;
-
-    case OT_DEVICE_ROLE_ROUTER:
-        ExitNow(rval = false);
-        break;
-
-    case OT_DEVICE_ROLE_LEADER:
-
         // not a singleton if any other routers exist
         for (int i = 0; i <= kMaxRouterId; i++)
         {
@@ -1200,17 +1185,6 @@ bool MleRouter::IsSingleton(void)
                 ExitNow(rval = false);
             }
         }
-
-        // not a singleton if any children are REEDs
-        for (int i = 0; i < mMaxChildrenAllowed; i++)
-        {
-            if (mChildren[i].GetState() == Neighbor::kStateValid && mChildren[i].IsFullThreadDevice())
-            {
-                ExitNow(rval = false);
-            }
-        }
-
-        break;
     }
 
 exit:


### PR DESCRIPTION
The Thread 1.1.1 Specification currently defines a "singleton" as a Thread
network partition that consists of a single router that has no
router-eligible end device children.  At the same time, Thread 1.1.1 does
not provide a way for a router to decipher between a Full End Device (FED)
and a router-eligible end device (REED).  This ambiguity can cause two
partitions to avoid merging, since each partition may determine that they
are higher priority than the other.

This commit makes the change to counting only active routers, which
eliminates the ambiguity above.