### PR TITLE
[cli] fix for Dialog IDE

### DIFF
--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -94,7 +94,7 @@ struct Command
 class Interpreter
 {
     friend class Coap;
-    friend class Udp;
+    friend class UdpExample;
 
 public:
 
@@ -392,7 +392,7 @@ private:
     char mResolvingHostname[OT_DNS_MAX_HOSTNAME_LENGTH];
 #endif
 
-    Udp mUdp;
+    UdpExample mUdp;
 
 #endif
 

--- a/src/cli/cli_instance.cpp
+++ b/src/cli/cli_instance.cpp
@@ -46,6 +46,7 @@ namespace ot {
 
 namespace Cli {
 
+#ifdef OTDLL
 void Interpreter::CacheInstances()
 {
     if (mApiInstance)
@@ -118,6 +119,7 @@ void Interpreter::ProcessInstance(int argc, char *argv[])
 exit:
     AppendResult(error);
 }
+#endif
 
 }  // namespace Cli
 }  // namespace ot

--- a/src/cli/cli_udp_example.cpp
+++ b/src/cli/cli_udp_example.cpp
@@ -45,17 +45,17 @@ using ot::Encoding::BigEndian::HostSwap16;
 namespace ot {
 namespace Cli {
 
-const struct Udp::Command Udp::sCommands[] =
+const struct UdpExample::Command UdpExample::sCommands[] =
 {
-    { "help", &Udp::ProcessHelp },
-    { "bind", &Udp::ProcessBind },
-    { "close", &Udp::ProcessClose },
-    { "connect", &Udp::ProcessConnect },
-    { "open", &Udp::ProcessOpen },
-    { "send", &Udp::ProcessSend }
+    { "help", &UdpExample::ProcessHelp },
+    { "bind", &UdpExample::ProcessBind },
+    { "close", &UdpExample::ProcessClose },
+    { "connect", &UdpExample::ProcessConnect },
+    { "open", &UdpExample::ProcessOpen },
+    { "send", &UdpExample::ProcessSend }
 };
 
-otError Udp::ProcessHelp(int argc, char *argv[])
+otError UdpExample::ProcessHelp(int argc, char *argv[])
 {
     for (unsigned int i = 0; i < sizeof(sCommands) / sizeof(sCommands[0]); i++)
     {
@@ -68,7 +68,7 @@ otError Udp::ProcessHelp(int argc, char *argv[])
     return OT_ERROR_NONE;
 }
 
-otError Udp::ProcessBind(int argc, char *argv[])
+otError UdpExample::ProcessBind(int argc, char *argv[])
 {
     otError error;
     otSockAddr sockaddr;
@@ -92,7 +92,7 @@ exit:
     return error;
 }
 
-otError Udp::ProcessConnect(int argc, char *argv[])
+otError UdpExample::ProcessConnect(int argc, char *argv[])
 {
     otError error;
     otSockAddr sockaddr;
@@ -116,7 +116,7 @@ exit:
     return error;
 }
 
-otError Udp::ProcessClose(int argc, char *argv[])
+otError UdpExample::ProcessClose(int argc, char *argv[])
 {
     OT_UNUSED_VARIABLE(argc);
     OT_UNUSED_VARIABLE(argv);
@@ -124,7 +124,7 @@ otError Udp::ProcessClose(int argc, char *argv[])
     return otUdpClose(&mSocket);
 }
 
-otError Udp::ProcessOpen(int argc, char *argv[])
+otError UdpExample::ProcessOpen(int argc, char *argv[])
 {
     OT_UNUSED_VARIABLE(argc);
     OT_UNUSED_VARIABLE(argv);
@@ -132,7 +132,7 @@ otError Udp::ProcessOpen(int argc, char *argv[])
     return otUdpOpen(mInterpreter.mInstance, &mSocket, HandleUdpReceive, this);
 }
 
-otError Udp::ProcessSend(int argc, char *argv[])
+otError UdpExample::ProcessSend(int argc, char *argv[])
 {
     otError error;
     otMessageInfo messageInfo;
@@ -174,7 +174,7 @@ exit:
     return error;
 }
 
-otError Udp::Process(int argc, char *argv[])
+otError UdpExample::Process(int argc, char *argv[])
 {
     otError error = OT_ERROR_PARSE;
 
@@ -190,12 +190,12 @@ otError Udp::Process(int argc, char *argv[])
     return error;
 }
 
-void Udp::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
+void UdpExample::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Udp *>(aContext)->HandleUdpReceive(aMessage, aMessageInfo);
+    static_cast<UdpExample *>(aContext)->HandleUdpReceive(aMessage, aMessageInfo);
 }
 
-void Udp::HandleUdpReceive(otMessage *aMessage, const otMessageInfo *aMessageInfo)
+void UdpExample::HandleUdpReceive(otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
     uint8_t buf[1500];
     int length;

--- a/src/cli/cli_udp_example.hpp
+++ b/src/cli/cli_udp_example.hpp
@@ -46,7 +46,7 @@ class Interpreter;
  * This class implements a CLI-based UDP example.
  *
  */
-class Udp
+class UdpExample
 {
 public:
     /**
@@ -55,7 +55,7 @@ public:
      * @param[in]  aInterpreter  The CLI interpreter.
      *
      */
-    Udp(Interpreter &aInterpreter): mInterpreter(aInterpreter) { }
+    UdpExample(Interpreter &aInterpreter): mInterpreter(aInterpreter) { }
 
     /**
      * This method interprets a list of CLI arguments.
@@ -70,7 +70,7 @@ private:
     struct Command
     {
         const char *mName;
-        otError(Udp::*mCommand)(int argc, char *argv[]);
+        otError(UdpExample::*mCommand)(int argc, char *argv[]);
     };
 
     otError ProcessHelp(int argc, char *argv[]);

--- a/src/ncp/changed_props_set.hpp
+++ b/src/ncp/changed_props_set.hpp
@@ -33,6 +33,8 @@
 #ifndef CHANGED_PROPS_SET_HPP_
 #define CHANGED_PROPS_SET_HPP_
 
+#include <stddef.h>
+
 #include <openthread/types.h>
 
 #include "spinel.h"


### PR DESCRIPTION
Minor changes to ease Open Thread handling in Dialog SDK.

 - UDP class definition was duplicated
 - inclusion for "NULL" definition has been added (stddef.h)