### PR TITLE
[address-resolver] verify query sent successfully

### DIFF
--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -273,13 +273,13 @@ otError AddressResolver::Resolve(const Ip6::Address &aEid, uint16_t &aRloc16)
     switch (entry->mState)
     {
     case Cache::kStateInvalid:
+        SuccessOrExit(error = SendAddressQuery(aEid));
         entry->mTarget = aEid;
         entry->mRloc16 = Mac::kShortAddrInvalid;
         entry->mTimeout = kAddressQueryTimeout;
         entry->mFailures = 0;
         entry->mRetryTimeout = kAddressQueryInitialRetryDelay;
         entry->mState = Cache::kStateQuery;
-        SendAddressQuery(aEid);
         error = OT_ERROR_ADDRESS_QUERY;
         break;
 
@@ -290,8 +290,8 @@ otError AddressResolver::Resolve(const Ip6::Address &aEid, uint16_t &aRloc16)
         }
         else if (entry->mTimeout == 0 && entry->mRetryTimeout == 0)
         {
+            SuccessOrExit(error = SendAddressQuery(aEid));
             entry->mTimeout = kAddressQueryTimeout;
-            SendAddressQuery(aEid);
             error = OT_ERROR_ADDRESS_QUERY;
         }
         else

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -117,6 +117,7 @@ public:
      *
      * @retval OT_ERROR_NONE           Successfully provided the RLOC16.
      * @retval OT_ERROR_ADDRESS_QUERY  Initiated an Address Query.
+     * @retval OT_ERROR_NO_BUFS        Insufficient buffer space available to send Address Query.
      *
      */
     otError Resolve(const Ip6::Address &aEid, Mac::ShortAddress &aRloc16);


### PR DESCRIPTION
This PR adds checking for return value of `SendAddressQuery()` which could fail for no buffer.