### PR TITLE
[meshcop] add length check to steering data before checking bloom filter

### DIFF
--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -562,7 +562,7 @@ public:
      * @retval FALSE  If the TLV does not appear to be well-formed.
      *
      */
-    bool IsValid(void) const { return GetLength() <= sizeof(*this) - sizeof(Tlv); }
+    bool IsValid(void) const { return ((GetLength() != 0) && (GetLength() <= sizeof(*this) - sizeof(Tlv))); }
 
     /**
      * This method sets all bits in the Bloom Filter to zero.


### PR DESCRIPTION
We found cases where the device hits a fault when steering data matches
the bloom filter on receiving MLE discovery response. This can happen
when steering data TLV is present, but the steering data is empty.
Adding a length check will prevent the fault.