### PR TITLE
[dtls] introduce default sub-type and ensure InterfaceId is correctly set

### DIFF
--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -170,6 +170,7 @@ void CoapSecure::Receive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo
 
         mPeerAddress.SetPeerAddr(aMessageInfo.GetPeerAddr());
         mPeerAddress.SetPeerPort(aMessageInfo.GetPeerPort());
+        mPeerAddress.SetInterfaceId(aMessageInfo.GetInterfaceId());
 
         if (netif.IsUnicastAddress(aMessageInfo.GetSockAddr()))
         {
@@ -178,7 +179,8 @@ void CoapSecure::Receive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo
 
         mPeerAddress.SetSockPort(aMessageInfo.GetSockPort());
 
-        netif.GetDtls().Start(false, HandleDtlsConnected, HandleDtlsReceive, HandleDtlsSend, this);
+        netif.GetDtls().Start(false, &CoapSecure::HandleDtlsConnected,
+                              &CoapSecure::HandleDtlsReceive, CoapSecure::HandleDtlsSend, this);
     }
     else
     {

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -68,7 +68,8 @@ Dtls::Dtls(ThreadNetif &aNetif):
     mSendHandler(NULL),
     mContext(NULL),
     mClient(false),
-    mMessageSubType(0)
+    mMessageSubType(0),
+    mMessageDefaultSubType(0)
 {
     memset(mPsk, 0, sizeof(mPsk));
     memset(&mEntropy, 0, sizeof(mEntropy));
@@ -209,7 +210,11 @@ otError Dtls::Send(Message &aMessage, uint16_t aLength)
     VerifyOrExit(aLength <= kApplicationDataMaxLength, error = OT_ERROR_NO_BUFS);
 
     // Store message specific sub type.
-    mMessageSubType = aMessage.GetSubType();
+    if (aMessage.GetSubType() != Message::kSubTypeNone)
+    {
+        mMessageSubType = aMessage.GetSubType();
+    }
+
     aMessage.Read(0, aLength, buffer);
 
     SuccessOrExit(error = MapError(mbedtls_ssl_write(&mSsl, buffer, aLength)));
@@ -246,7 +251,7 @@ int Dtls::HandleMbedtlsTransmit(const unsigned char *aBuf, size_t aLength)
     error = mSendHandler(mContext, aBuf, static_cast<uint16_t>(aLength), mMessageSubType);
 
     // Restore default sub type.
-    mMessageSubType = 0;
+    mMessageSubType = mMessageDefaultSubType;
 
     switch (error)
     {

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -68,8 +68,8 @@ Dtls::Dtls(ThreadNetif &aNetif):
     mSendHandler(NULL),
     mContext(NULL),
     mClient(false),
-    mMessageSubType(0),
-    mMessageDefaultSubType(0)
+    mMessageSubType(Message::kSubTypeNone),
+    mMessageDefaultSubType(Message::kSubTypeNone)
 {
     memset(mPsk, 0, sizeof(mPsk));
     memset(&mEntropy, 0, sizeof(mEntropy));
@@ -93,7 +93,7 @@ otError Dtls::Start(bool aClient, ConnectedHandler aConnectedHandler, ReceiveHan
     mContext = aContext;
     mClient = aClient;
     mReceiveMessage = NULL;
-    mMessageSubType = 0;
+    mMessageSubType = Message::kSubTypeNone;
 
     mbedtls_ssl_init(&mSsl);
     mbedtls_ssl_config_init(&mConf);

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -189,6 +189,15 @@ public:
     otError Receive(Message &aMessage, uint16_t aOffset, uint16_t aLength);
 
     /**
+     * This method sets the default message sub-type that will be used for all messages without defined
+     * sub-type.
+     *
+     * @param[in]  aMessageSubType  The default message sub-type.
+     *
+     */
+    void SetDefaultMessageSubType(uint8_t aMessageSubType) { mMessageDefaultSubType = aMessageSubType; }
+
+    /**
      * The provisioning URL is placed here so that both the Commissioner and Joiner can share the same object.
      *
      */
@@ -250,6 +259,7 @@ private:
     bool mClient;
 
     uint8_t mMessageSubType;
+    uint8_t mMessageDefaultSubType;
 };
 
 }  // namespace MeshCoP


### PR DESCRIPTION
This PR:
 - Ensures that Interface Id is correctly set in coap_secure. For direct DTLS communication (without relaying like in commissioning, handshake message fails -
 https://github.com/openthread/openthread/blob/master/src/core/net/ip6.cpp#L364)
 - Adds possibility to specify default message sub-type for DTLS messages (not only for data messages as it is already done now, but also for non-data DTLS messages)