### PR TITLE
[key-manager] fix bug that prevents local key rotation

### DIFF
--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -172,7 +172,7 @@ void KeyManager::SetCurrentKeySequence(uint32_t aKeySequence)
         mKeyRotationTimer.IsRunning() &&
         mKeySwitchGuardEnabled)
     {
-        VerifyOrExit(mHoursSinceKeyRotation < mKeySwitchGuardTime);
+        VerifyOrExit(mHoursSinceKeyRotation >= mKeySwitchGuardTime);
     }
 
     mKeySequence = aKeySequence;


### PR DESCRIPTION
Before rotating the key sequence counter, there is a check against the key
rotating guard time.  The key switch guard time is intended to prevent
the key sequence counter from advancing too quickly.  However, the existing
implementation only allowed the key sequence counter to increment if the
key switch guard time had *not* expired.  Because the key rotation period
is larger than the key switch guard time, the key would never rotate.

This commit fixes the logic to check if the key switch guard time *has*
expired, when performing a key rotation.