### PR TITLE
[link-quality] add config option for link margin thresholds

### DIFF
--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -478,6 +478,54 @@
 #endif  // OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD
 
 /**
+ * @def OPENTHREAD_CONFIG_LINK_MARGIN_THRESHOLD_1
+ *
+ * The link margin threshold used for link quality 1 in dB.
+ *
+ * Default (per Thread specification): 2 dB.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_LINK_MARGIN_THRESHOLD_1
+#define OPENTHREAD_CONFIG_LINK_MARGIN_THRESHOLD_1               2
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_LINK_MARGIN_THRESHOLD_2
+ *
+ * The link margin threshold used for link quality 2 in dB.
+ *
+ * Default (per Thread specification): 10 dB.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_LINK_MARGIN_THRESHOLD_2
+#define OPENTHREAD_CONFIG_LINK_MARGIN_THRESHOLD_2               10
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_LINK_MARGIN_THRESHOLD_3
+ *
+ * The link margin threshold used for link quality 3 in dB.
+ *
+ * Default (per Thread specification): 20 dB.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_LINK_MARGIN_THRESHOLD_3
+#define OPENTHREAD_CONFIG_LINK_MARGIN_THRESHOLD_3               20
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_LINK_MARGIN_HYSTERESIS_THRESHOLD
+ *
+ * The link margin hysteresis threshold for converting link margin to link quality in dB.
+ *
+ * Default (per Thread specification): 2 dB.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_LINK_MARGIN_HYSTERESIS_THRESHOLD
+#define OPENTHREAD_CONFIG_LINK_MARGIN_HYSTERESIS_THRESHOLD      2
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_LOG_OUTPUT
  *
  * Selects if, and where the LOG output goes to.

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -37,6 +37,8 @@
 #include <openthread/platform/radio.h>
 #include <openthread/types.h>
 
+#include "openthread-core-config.h"
+
 namespace ot {
 
 /**
@@ -302,10 +304,10 @@ private:
     {
         // Constants for obtaining link quality from link margin:
 
-        kThreshold3             = 20,   // Link margin threshold for quality 3 link.
-        kThreshold2             = 10,   // Link margin threshold for quality 2 link.
-        kThreshold1             = 2,    // Link margin threshold for quality 1 link.
-        kHysteresisThreshold    = 2,    // Link margin hysteresis threshold.
+        kThreshold3          = OPENTHREAD_CONFIG_LINK_MARGIN_THRESHOLD_3,   // Threshold for quality 3 link.
+        kThreshold2          = OPENTHREAD_CONFIG_LINK_MARGIN_THRESHOLD_2,   // Threshold for quality 2 link.
+        kThreshold1          = OPENTHREAD_CONFIG_LINK_MARGIN_THRESHOLD_1,   // Threshold for quality 1 link.
+        kHysteresisThreshold = OPENTHREAD_CONFIG_LINK_MARGIN_HYSTERESIS_THRESHOLD,
 
         // constants for test:
 


### PR DESCRIPTION
This commits adds definitions in `openthread-core-default-config`
header file for link margin thresholds. The default values are
set per Thread specification.