### PR TITLE
[cli] add neighbor command

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -41,6 +41,7 @@ OpenThread test scripts use the CLI to execute test cases.
 * [macfilter](#macfilter)
 * [masterkey](#masterkey)
 * [mode](#mode)
+* [neighbor](#neighbor-list)
 * [netdataregister](#netdataregister)
 * [networkdiagnostic](#networkdiagnostic-get-addr-type-)
 * [networkidtimeout](#networkidtimeout)
@@ -1088,6 +1089,30 @@ Set the Thread Device Mode value.
 
 ```bash
 > mode rsdn
+Done
+```
+
+### neighbor list
+
+List RLOC16 of neighbors.
+
+```bash
+> neighbor list
+0xcc01 0xc800 0xf000
+Done
+```
+
+### neighbor table
+
+Print table of neighbors.
+
+```bash
+> neighbor table
+| Role | RLOC16 | Age | Avg RSSI | Last RSSI |R|S|D|N| Extended MAC     |
++------+--------+-----+----------+-----------+-+-+-+-+------------------+
+|   C  | 0xcc01 |  96 |      -46 |       -46 |1|1|1|1| 1eb9ba8a6522636b |
+|   R  | 0xc800 |   2 |      -29 |       -29 |1|0|1|1| 9a91556102c39ddb |
+|   R  | 0xf000 |   3 |      -28 |       -28 |1|0|1|1| 0ad7ed6beaa6016d |
 Done
 ```
 

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -252,6 +252,9 @@ private:
     void ProcessLinkQuality(int argc, char *argv[]);
     void ProcessMasterKey(int argc, char *argv[]);
     void ProcessMode(int argc, char *argv[]);
+#if OPENTHREAD_FTD
+    void ProcessNeighbor(int argc, char *argv[]);
+#endif
 #if OPENTHREAD_ENABLE_BORDER_ROUTER
     void ProcessNetworkDataRegister(int argc, char *argv[]);
 #endif


### PR DESCRIPTION
This PR add a `neighbor` CLI command that enables to easily print all devices that we have direct link to with some basic link information.