### PR TITLE
[mle] do not restore last partition id after boot

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1343,10 +1343,11 @@ protected:
     };
     ReattachState mReattachState;
 
-    TimerMilli mParentRequestTimer;    ///< The timer for driving the Parent Request process.
-    TimerMilli mDelayedResponseTimer;  ///< The timer to delay MLE responses.
-    uint8_t mLastPartitionRouterIdSequence;
-    uint32_t mLastPartitionId;
+    TimerMilli mParentRequestTimer;          ///< The timer for driving the Parent Request process.
+    TimerMilli mDelayedResponseTimer;        ///< The timer to delay MLE responses.
+    uint32_t mLastPartitionId;               ///< The partition ID of the previous Thread partition
+    uint8_t mLastPartitionRouterIdSequence;  ///< The router ID sequence from the previous Thread partition
+    uint8_t mLastPartitionIdTimeout;         ///< The time remaining to avoid the previous Thread partition
 
     uint8_t mParentLeaderCost;
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1339,7 +1339,9 @@ otError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::Messa
         otLogInfoMle(GetInstance(), "Different partition (peer:%d, local:%d)",
                      leaderData.GetPartitionId(), mLeaderData.GetPartitionId());
 
-        if (partitionId == mLastPartitionId && (mDeviceMode & ModeTlv::kModeFFD))
+        if ((mDeviceMode & ModeTlv::kModeFFD) &&
+            (mLastPartitionIdTimeout > 0) &&
+            (partitionId == mLastPartitionId))
         {
             VerifyOrExit((static_cast<int8_t>(route.GetRouterIdSequence() - mLastPartitionRouterIdSequence) > 0),
                          error = OT_ERROR_DROP);
@@ -1774,6 +1776,11 @@ void MleRouter::HandleStateUpdateTimer(void)
     if (mChallengeTimeout > 0)
     {
         mChallengeTimeout--;
+    }
+
+    if (mLastPartitionIdTimeout > 0)
+    {
+        mLastPartitionIdTimeout--;
     }
 
     if (mRouterSelectionJitterTimeout > 0)


### PR DESCRIPTION
While the previous partition ID is stored in non-volatile memory, the last
known router ID sequence for that previous partition is not.  As a result,
a node coming out of reset that initially fails to reattach to the previous
partition may not be able to reattach until the router ID sequence value
wraps.  This commit also limits the time window with which to avoid the
previous partition ID.