### PR TITLE
[config-header] simplify config header file includes

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -43,13 +43,14 @@
   - Preprocessor `#include` directives shall use brace (“<”) and (“>”) style for all public headers, including C and C++ standard library, or other first- and third-party public library headers.
   - Preprocessor `#include` directives should use double quote (‘“‘) and (‘“‘) style for all private or relative headers.
   - Preprocessor `#include` directives should be grouped, ordered, or sorted as follows:
-    - The `<openthread/config.h>` public header
-    - This compilation unit's corresponding header, if any
+    - If the unit is a core/private header file, `"openthread-core-config.h"` should be the first header file included.
+    - If the unit is a core/private `.c` or `.cpp` file:
+      - If the unit has a corresponding header file, the unit's corresponding header file should be included before any other header file.
+      - If the unit has no corresponding header file, then it should directly include `"openthread-core-config.h"` before any other header file.
     - C++ Standard Library headers
     - C Standard Library headers
     - Third-party library headers
     - First-party library headers
-    - The `"openthread-core-config.h"` private header
     - Private or local headers
     - Alphanumeric order within each subgroup
   - The preprocessor shall not be used to redefine reserved language keywords.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -31,8 +31,6 @@
  *   This file implements the CLI interpreter.
  */
 
-#include <openthread/config.h>
-
 #include "cli.hpp"
 
 #ifdef OTDLL

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -34,7 +34,7 @@
 #ifndef CLI_HPP_
 #define CLI_HPP_
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <stdarg.h>
 

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -31,11 +31,9 @@
  *   This file implements a simple CLI for the CoAP service.
  */
 
-#include <openthread/config.h>
+#include "cli_coap.hpp"
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
-
-#include "cli_coap.hpp"
 
 #include <ctype.h>
 

--- a/src/cli/cli_coap.hpp
+++ b/src/cli/cli_coap.hpp
@@ -34,6 +34,10 @@
 #ifndef CLI_COAP_HPP_
 #define CLI_COAP_HPP_
 
+#include "openthread-core-config.h"
+
+#if OPENTHREAD_ENABLE_APPLICATION_COAP
+
 #include <openthread/types.h>
 
 #include "coap/coap_header.hpp"
@@ -95,5 +99,7 @@ private:
 
 }  // namespace Cli
 }  // namespace ot
+
+#endif  // OPENTHREAD_ENABLE_APPLICATION_COAP
 
 #endif  // CLI_COAP_HPP_

--- a/src/cli/cli_console.cpp
+++ b/src/cli/cli_console.cpp
@@ -31,8 +31,6 @@
  *   This file implements the CLI server on the CONSOLE service.
  */
 
-#include <openthread/config.h>
-
 #include "cli_console.hpp"
 
 #include <stdarg.h>

--- a/src/cli/cli_console.hpp
+++ b/src/cli/cli_console.hpp
@@ -34,6 +34,8 @@
 #ifndef CLI_CONSOLE_HPP_
 #define CLI_CONSOLE_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/cli.h>
 
 #include "cli/cli.hpp"

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -31,8 +31,6 @@
  *   This file implements the CLI interpreter.
  */
 
-#include <openthread/config.h>
-
 #include "cli_dataset.hpp"
 
 #include <stdio.h>

--- a/src/cli/cli_dataset.hpp
+++ b/src/cli/cli_dataset.hpp
@@ -34,6 +34,8 @@
 #ifndef CLI_DATASET_HPP_
 #define CLI_DATASET_HPP_
 
+#include "openthread-core-config.h"
+
 #include <stdarg.h>
 
 #include "cli/cli_server.hpp"

--- a/src/cli/cli_instance.cpp
+++ b/src/cli/cli_instance.cpp
@@ -31,7 +31,7 @@
  *   This file implements the CLI interpreter Instance related functions.
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <assert.h>
 #include <stdio.h>

--- a/src/cli/cli_server.hpp
+++ b/src/cli/cli_server.hpp
@@ -34,6 +34,8 @@
 #ifndef CLI_SERVER_HPP_
 #define CLI_SERVER_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
 namespace ot {

--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -31,8 +31,6 @@
  *   This file implements the CLI server on the UART service.
  */
 
-#include <openthread/config.h>
-
 #include "cli_uart.hpp"
 
 #include <stdarg.h>

--- a/src/cli/cli_uart.hpp
+++ b/src/cli/cli_uart.hpp
@@ -34,6 +34,8 @@
 #ifndef CLI_UART_HPP_
 #define CLI_UART_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
 #include "cli/cli.hpp"

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -31,8 +31,6 @@
  *   This file implements the CLI server on a UDP socket.
  */
 
-#include <openthread/config.h>
-
 #include "cli_udp.hpp"
 
 #include <stdarg.h>

--- a/src/cli/cli_udp.hpp
+++ b/src/cli/cli_udp.hpp
@@ -34,6 +34,8 @@
 #ifndef CLI_UDP_HPP_
 #define CLI_UDP_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
 #include "cli/cli.hpp"

--- a/src/cli/cli_udp_example.cpp
+++ b/src/cli/cli_udp_example.cpp
@@ -33,7 +33,6 @@
 
 #include "cli_udp_example.hpp"
 
-#include <openthread/config.h>
 #include <openthread/message.h>
 #include <openthread/udp.h>
 

--- a/src/cli/cli_udp_example.hpp
+++ b/src/cli/cli_udp_example.hpp
@@ -34,6 +34,8 @@
 #ifndef CLI_UDP_EXAMPLE_HPP_
 #define CLI_UDP_EXAMPLE_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/udp.h>
 #include <openthread/types.h>
 

--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread Border Router API.
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #if OPENTHREAD_ENABLE_BORDER_ROUTER
 

--- a/src/core/api/child_supervision_api.cpp
+++ b/src/core/api/child_supervision_api.cpp
@@ -31,6 +31,7 @@
  *   This file implements the OpenThread child supervision API.
  */
 
+#include "openthread-core-config.h"
 #include "openthread/child_supervision.h"
 
 #include "openthread-instance.h"

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread CoAP API.
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <openthread/coap.h>
 

--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread Commissioner API.
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <openthread/commissioner.h>
 

--- a/src/core/api/crypto_api.cpp
+++ b/src/core/api/crypto_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread Crypto API.
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 #include <openthread/crypto.h>
 
 #include "common/code_utils.hpp"

--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread Operational Dataset API (for both FTD and MTD).
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <openthread/dataset.h>
 

--- a/src/core/api/dataset_ftd_api.cpp
+++ b/src/core/api/dataset_ftd_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread Operational Dataset API (FTD only).
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #if OPENTHREAD_FTD
 

--- a/src/core/api/dhcp6_api.cpp
+++ b/src/core/api/dhcp6_api.cpp
@@ -31,9 +31,9 @@
  *   This file implements the OpenThread DHCPv6 API.
  */
 
-#include <openthread/config.h>
-#include <openthread/dhcp6_client.h>
+#include "openthread-core-config.h"
 
+#include <openthread/dhcp6_client.h>
 #include <openthread/dhcp6_server.h>
 
 #include "openthread-instance.h"

--- a/src/core/api/dns_api.cpp
+++ b/src/core/api/dns_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread UDP API.
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <openthread/dns.h>
 

--- a/src/core/api/icmp6_api.cpp
+++ b/src/core/api/icmp6_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread ICMPv6 API.
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <openthread/icmp6.h>
 

--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -33,7 +33,7 @@
 
 #define WPP_NAME "instance_api.tmh"
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <openthread/instance.h>
 #include <openthread/platform/misc.h>

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -33,7 +33,7 @@
 
 #define WPP_NAME "ip6_api.tmh"
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <openthread/ip6.h>
 

--- a/src/core/api/jam_detection_api.cpp
+++ b/src/core/api/jam_detection_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread Jam Detection API.
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <openthread/jam_detection.h>
 

--- a/src/core/api/joiner_api.cpp
+++ b/src/core/api/joiner_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread Joiner API.
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <openthread/joiner.h>
 

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread Link API.
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <openthread/link.h>
 

--- a/src/core/api/link_raw.hpp
+++ b/src/core/api/link_raw.hpp
@@ -34,9 +34,10 @@
 #ifndef LINK_RAW_HPP_
 #define LINK_RAW_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/link_raw.h>
 
-#include "openthread-core-config.h"
 #include "common/timer.hpp"
 
 #if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ACK_TIMEOUT || OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT || OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ENERGY_SCAN

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread Link Raw API.
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <openthread/platform/random.h>
 

--- a/src/core/api/message_api.cpp
+++ b/src/core/api/message_api.cpp
@@ -30,7 +30,8 @@
  * @file
  *   This file implements the OpenThread Message API.
  */
-#include <openthread/config.h>
+
+#include "openthread-core-config.h"
 
 #include <openthread/message.h>
 

--- a/src/core/api/netdata_api.cpp
+++ b/src/core/api/netdata_api.cpp
@@ -30,7 +30,8 @@
  * @file
  *   This file implements the OpenThread Network Data API.
  */
-#include <openthread/config.h>
+
+#include "openthread-core-config.h"
 
 #include <openthread/netdata.h>
 

--- a/src/core/api/tasklet_api.cpp
+++ b/src/core/api/tasklet_api.cpp
@@ -33,7 +33,8 @@
 
 #define WPP_NAME "tasklet_api.tmh"
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
+
 #include <openthread/tasklet.h>
 
 #include "openthread-instance.h"

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -33,7 +33,7 @@
 
 #define WPP_NAME "thread_api.tmh"
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <openthread/thread.h>
 #include <openthread/platform/settings.h>

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -33,7 +33,7 @@
 
 #define WPP_NAME "thread_ftd_api.tmh"
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #if OPENTHREAD_FTD
 

--- a/src/core/api/tmf_proxy_api.cpp
+++ b/src/core/api/tmf_proxy_api.cpp
@@ -31,7 +31,8 @@
  *   This file implements the OpenThread TMF proxy API.
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
+
 #include <openthread/tmf_proxy.h>
 
 #include "openthread-instance.h"

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -31,7 +31,8 @@
  *   This file implements the OpenThread UDP API.
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
+
 #include <openthread/udp.h>
 
 #include "openthread-instance.h"

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -28,8 +28,6 @@
 
 #define WPP_NAME "coap.tmh"
 
-#include <openthread/config.h>
-
 #include "coap.hpp"
 
 #include <openthread/platform/random.h>

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -29,6 +29,8 @@
 #ifndef COAP_HPP_
 #define COAP_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/coap.h>
 
 #include "coap/coap_header.hpp"

--- a/src/core/coap/coap_header.cpp
+++ b/src/core/coap/coap_header.cpp
@@ -31,8 +31,6 @@
  *   This file implements the CoAP header generation and parsing.
  */
 
-#include <openthread/config.h>
-
 #include "coap_header.hpp"
 
 #include <openthread/platform/random.h>

--- a/src/core/coap/coap_header.hpp
+++ b/src/core/coap/coap_header.hpp
@@ -34,6 +34,8 @@
 #ifndef COAP_HEADER_HPP_
 #define COAP_HEADER_HPP_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_string.h"
 
 #include <openthread/coap.h>

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -28,8 +28,6 @@
 
 #define WPP_NAME "coap_secure.tmh"
 
-#include <openthread/config.h>
-
 #include "coap_secure.hpp"
 
 #include "common/logging.hpp"

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -29,6 +29,8 @@
 #ifndef COAP_SECURE_HPP_
 #define COAP_SECURE_HPP_
 
+#include "openthread-core-config.h"
+
 #include "coap/coap.hpp"
 #include "meshcop/dtls.hpp"
 

--- a/src/core/common/code_utils.hpp
+++ b/src/core/common/code_utils.hpp
@@ -34,6 +34,8 @@
 #ifndef CODE_UTILS_HPP_
 #define CODE_UTILS_HPP_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_stdbool.h"
 
 // Calculates the aligned variable size.

--- a/src/core/common/context.hpp
+++ b/src/core/common/context.hpp
@@ -34,7 +34,8 @@
 #ifndef CONTEXT_HPP_
 #define CONTEXT_HPP_
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
+
 #include <openthread/platform/toolchain.h>
 
 #include "openthread-core-config.h"

--- a/src/core/common/crc16.cpp
+++ b/src/core/common/crc16.cpp
@@ -31,8 +31,6 @@
  *   This file implements CRC16 computations.
  */
 
-#include <openthread/config.h>
-
 #include "crc16.hpp"
 
 namespace ot {

--- a/src/core/common/crc16.hpp
+++ b/src/core/common/crc16.hpp
@@ -34,6 +34,8 @@
 #ifndef CRC16_HPP_
 #define CRC16_HPP_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_stdint.h"
 
 namespace ot {

--- a/src/core/common/debug.hpp
+++ b/src/core/common/debug.hpp
@@ -34,11 +34,11 @@
 #ifndef DEBUG_HPP_
 #define DEBUG_HPP_
 
+#include "openthread-core-config.h"
+
 #include <ctype.h>
 #include <stdio.h>
 #include "utils/wrap_string.h"
-
-#include "openthread-core-config.h"
 
 #if defined(OPENTHREAD_TARGET_DARWIN) || defined(OPENTHREAD_TARGET_LINUX)
 

--- a/src/core/common/encoding.hpp
+++ b/src/core/common/encoding.hpp
@@ -34,6 +34,8 @@
 #ifndef ENCODING_HPP_
 #define ENCODING_HPP_
 
+#include "openthread-core-config.h"
+
 #include <limits.h>
 #include "utils/wrap_stdint.h"
 

--- a/src/core/common/locator.cpp
+++ b/src/core/common/locator.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "locator.tmh"
 
-#include <openthread/config.h>
-
 #include "locator.hpp"
 
 #include "openthread-instance.h"

--- a/src/core/common/locator.hpp
+++ b/src/core/common/locator.hpp
@@ -34,11 +34,10 @@
 #ifndef LOCATOR_HPP_
 #define LOCATOR_HPP_
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <openthread/types.h>
 
-#include "openthread-core-config.h"
 #include "openthread-single-instance.h"
 
 namespace ot {

--- a/src/core/common/logging.cpp
+++ b/src/core/common/logging.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "logging.tmh"
 
-#include <openthread/config.h>
-
 #include "logging.hpp"
 
 #include <openthread/openthread.h>

--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -34,7 +34,7 @@
 #ifndef LOGGING_HPP_
 #define LOGGING_HPP_
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <ctype.h>
 #include <stdio.h>
@@ -43,8 +43,6 @@
 #include <openthread/instance.h>
 #include <openthread/types.h>
 #include <openthread/platform/logging.h>
-
-#include "openthread-core-config.h"
 
 #ifdef WINDOWS_LOGGING
 #ifdef _KERNEL_MODE

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "message.tmh"
 
-#include <openthread/config.h>
-
 #include "message.hpp"
 
 #include "openthread-instance.h"

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -34,7 +34,7 @@
 #ifndef MESSAGE_HPP_
 #define MESSAGE_HPP_
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include "utils/wrap_stdint.h"
 #include "utils/wrap_string.h"
@@ -42,7 +42,6 @@
 #include <openthread/message.h>
 #include <openthread/platform/messagepool.h>
 
-#include "openthread-core-config.h"
 #include "common/code_utils.hpp"
 #include "common/locator.hpp"
 #include "mac/mac_frame.hpp"

--- a/src/core/common/new.hpp
+++ b/src/core/common/new.hpp
@@ -34,6 +34,8 @@
 #ifndef NEW_HPP_
 #define NEW_HPP_
 
+#include "openthread-core-config.h"
+
 #include <stddef.h>
 
 #include <openthread/platform/toolchain.h>

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -34,6 +34,8 @@
 #ifndef SETTINGS_HPP_
 #define SETTINGS_HPP_
 
+#include "openthread-core-config.h"
+
 #include "thread/mle.hpp"
 
 namespace ot {

--- a/src/core/common/tasklet.cpp
+++ b/src/core/common/tasklet.cpp
@@ -31,8 +31,6 @@
  *   This file implements the tasklet scheduler.
  */
 
-#include <openthread/config.h>
-
 #include "tasklet.hpp"
 
 #include <openthread/openthread.h>

--- a/src/core/common/tasklet.hpp
+++ b/src/core/common/tasklet.hpp
@@ -34,6 +34,8 @@
 #ifndef TASKLET_HPP_
 #define TASKLET_HPP_
 
+#include "openthread-core-config.h"
+
 #include <stdio.h>
 
 #include <openthread/tasklet.h>

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "timer.tmh"
 
-#include <openthread/config.h>
-
 #include "timer.hpp"
 
 #include "openthread-instance.h"

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -34,6 +34,8 @@
 #ifndef TIMER_HPP_
 #define TIMER_HPP_
 
+#include "openthread-core-config.h"
+
 #include <stddef.h>
 #include "utils/wrap_stdint.h"
 

--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -31,8 +31,6 @@
  *   This file implements common methods for manipulating MLE TLVs.
  */
 
-#include <openthread/config.h>
-
 #include "tlvs.hpp"
 
 #include "common/code_utils.hpp"

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -34,6 +34,8 @@
 #ifndef TLVS_HPP_
 #define TLVS_HPP_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_string.h"
 
 #include <openthread/types.h>

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -31,8 +31,6 @@
  *   This file implements the trickle timer logic.
  */
 
-#include <openthread/config.h>
-
 #include "trickle_timer.hpp"
 
 #include <openthread/platform/random.h>

--- a/src/core/common/trickle_timer.hpp
+++ b/src/core/common/trickle_timer.hpp
@@ -34,6 +34,8 @@
 #ifndef TRICKLE_TIMER_HPP_
 #define TRICKLE_TIMER_HPP_
 
+#include "openthread-core-config.h"
+
 #include "common/context.hpp"
 #include "common/timer.hpp"
 

--- a/src/core/crypto/aes_ccm.cpp
+++ b/src/core/crypto/aes_ccm.cpp
@@ -31,8 +31,6 @@
  *   This file implements AES-CCM.
  */
 
-#include <openthread/config.h>
-
 #include "aes_ccm.hpp"
 
 #include "common/code_utils.hpp"

--- a/src/core/crypto/aes_ccm.hpp
+++ b/src/core/crypto/aes_ccm.hpp
@@ -34,6 +34,8 @@
 #ifndef AES_CCM_HPP_
 #define AES_CCM_HPP_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_stdint.h"
 
 #include <openthread/types.h>

--- a/src/core/crypto/aes_ecb.cpp
+++ b/src/core/crypto/aes_ecb.cpp
@@ -31,8 +31,6 @@
  *   This file implements AES-ECB.
  */
 
-#include <openthread/config.h>
-
 #include "aes_ecb.hpp"
 
 namespace ot {

--- a/src/core/crypto/aes_ecb.hpp
+++ b/src/core/crypto/aes_ecb.hpp
@@ -34,6 +34,8 @@
 #ifndef AES_ECB_HPP_
 #define AES_ECB_HPP_
 
+#include "openthread-core-config.h"
+
 #include <mbedtls/aes.h>
 
 namespace ot {

--- a/src/core/crypto/heap.hpp
+++ b/src/core/crypto/heap.hpp
@@ -35,11 +35,10 @@
 #ifndef OT_HEAP_HPP_
 #define OT_HEAP_HPP_
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <stddef.h>
 
-#include "openthread-core-config.h"
 #include "utils/wrap_stdint.h"
 
 namespace ot {

--- a/src/core/crypto/hmac_sha256.cpp
+++ b/src/core/crypto/hmac_sha256.cpp
@@ -31,8 +31,6 @@
  *   This file implements HMAC SHA-256.
  */
 
-#include <openthread/config.h>
-
 #include "hmac_sha256.hpp"
 
 namespace ot {

--- a/src/core/crypto/hmac_sha256.hpp
+++ b/src/core/crypto/hmac_sha256.hpp
@@ -34,6 +34,8 @@
 #ifndef HMAC_SHA256_HPP_
 #define HMAC_SHA256_HPP_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_stdint.h"
 
 #include <mbedtls/md.h>

--- a/src/core/crypto/mbedtls.cpp
+++ b/src/core/crypto/mbedtls.cpp
@@ -31,8 +31,6 @@
  *   This file implements the use of mbedTLS.
  */
 
-#include <openthread/config.h>
-
 #include "mbedtls.hpp"
 
 #include <mbedtls/platform.h>

--- a/src/core/crypto/mbedtls.hpp
+++ b/src/core/crypto/mbedtls.hpp
@@ -34,6 +34,8 @@
 #ifndef OT_MBEDTLS_HPP_
 #define OT_MBEDTLS_HPP_
 
+#include "openthread-core-config.h"
+
 #if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
 
 namespace ot {

--- a/src/core/crypto/pbkdf2_cmac.cpp
+++ b/src/core/crypto/pbkdf2_cmac.cpp
@@ -31,8 +31,6 @@
  *   This file implements PBKDF2 using AES-CMAC-PRF-128
  */
 
-#include <openthread/config.h>
-
 #include "pbkdf2_cmac.h"
 
 #include "common/debug.hpp"

--- a/src/core/crypto/pbkdf2_cmac.h
+++ b/src/core/crypto/pbkdf2_cmac.h
@@ -35,6 +35,8 @@
 #ifndef PBKDF2_CMAC_H_
 #define PBKDF2_CMAC_H_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_stdbool.h"
 #include "utils/wrap_stdint.h"
 

--- a/src/core/crypto/sha256.cpp
+++ b/src/core/crypto/sha256.cpp
@@ -31,8 +31,6 @@
  *   This file implements SHA-256.
  */
 
-#include <openthread/config.h>
-
 #include "sha256.hpp"
 
 namespace ot {

--- a/src/core/crypto/sha256.hpp
+++ b/src/core/crypto/sha256.hpp
@@ -34,6 +34,8 @@
 #ifndef SHA256_HPP_
 #define SHA256_HPP_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_stdint.h"
 
 #include <mbedtls/sha256.h>

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "mac.tmh"
 
-#include <openthread/config.h>
-
 #include "mac.hpp"
 
 #include "utils/wrap_string.h"

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -34,9 +34,10 @@
 #ifndef MAC_HPP_
 #define MAC_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/platform/radio.h>
 
-#include "openthread-core-config.h"
 #include "common/context.hpp"
 #include "common/locator.hpp"
 #include "common/tasklet.hpp"

--- a/src/core/mac/mac_filter.cpp
+++ b/src/core/mac/mac_filter.cpp
@@ -31,8 +31,6 @@
  *   This file implements Filter IEEE 802.15.4 frame filtering based on MAC address.
  */
 
-#include <openthread/config.h>
-
 #include "mac_filter.hpp"
 
 #include "openthread/types.h"

--- a/src/core/mac/mac_filter.hpp
+++ b/src/core/mac/mac_filter.hpp
@@ -34,6 +34,8 @@
 #ifndef MAC_FILTER_HPP_
 #define MAC_FILTER_HPP_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_stdint.h"
 
 #include <openthread/types.h>

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -31,8 +31,6 @@
  *   This file implements IEEE 802.15.4 header generation and processing.
  */
 
-#include <openthread/config.h>
-
 #include "mac_frame.hpp"
 
 #include <stdio.h>

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -34,6 +34,8 @@
 #ifndef MAC_FRAME_HPP_
 #define MAC_FRAME_HPP_
 
+#include "openthread-core-config.h"
+
 #include <limits.h>
 #include "utils/wrap_stdint.h"
 #include "utils/wrap_string.h"
@@ -41,7 +43,6 @@
 #include <openthread/types.h>
 #include <openthread/platform/radio.h>
 
-#include "openthread-core-config.h"
 #include "common/encoding.hpp"
 
 namespace ot {

--- a/src/core/meshcop/announce_begin_client.cpp
+++ b/src/core/meshcop/announce_begin_client.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "announce_begin_client.tmh"
 
-#include <openthread/config.h>
-
 #include "announce_begin_client.hpp"
 
 #include <openthread/platform/random.h>

--- a/src/core/meshcop/announce_begin_client.hpp
+++ b/src/core/meshcop/announce_begin_client.hpp
@@ -35,6 +35,7 @@
 #define ANNOUNCE_BEGIN_CLIENT_HPP_
 
 #include "openthread-core-config.h"
+
 #include "common/locator.hpp"
 #include "coap/coap.hpp"
 #include "net/ip6_address.hpp"

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "commissioner.tmh"
 
-#include <openthread/config.h>
-
 #include "commissioner.hpp"
 
 #include <stdio.h>

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -34,9 +34,10 @@
 #ifndef COMMISSIONER_HPP_
 #define COMMISSIONER_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/commissioner.h>
 
-#include "openthread-core-config.h"
 #include "coap/coap.hpp"
 #include "coap/coap_secure.hpp"
 #include "common/locator.hpp"

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -32,8 +32,6 @@
  *
  */
 
-#include <openthread/config.h>
-
 #include "dataset.hpp"
 
 #include <stdio.h>

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -35,6 +35,8 @@
 #ifndef MESHCOP_DATASET_HPP_
 #define MESHCOP_DATASET_HPP_
 
+#include "openthread-core-config.h"
+
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "meshcop/meshcop_tlvs.hpp"

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -34,8 +34,6 @@
 
 #define WPP_NAME "dataset_local.tmh"
 
-#include <openthread/config.h>
-
 #include "dataset_local.hpp"
 
 #include <stdio.h>

--- a/src/core/meshcop/dataset_local.hpp
+++ b/src/core/meshcop/dataset_local.hpp
@@ -35,6 +35,8 @@
 #ifndef MESHCOP_DATASET_LOCAL_HPP_
 #define MESHCOP_DATASET_LOCAL_HPP_
 
+#include "openthread-core-config.h"
+
 #include "common/locator.hpp"
 #include "meshcop/dataset.hpp"
 #include "meshcop/meshcop_tlvs.hpp"

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -34,8 +34,6 @@
 
 #define WPP_NAME "dataset_manager.tmh"
 
-#include <openthread/config.h>
-
 #include "dataset_manager.hpp"
 
 #include <stdio.h>

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -35,6 +35,8 @@
 #ifndef MESHCOP_DATASET_MANAGER_HPP_
 #define MESHCOP_DATASET_MANAGER_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
 #include "coap/coap.hpp"

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -31,12 +31,11 @@
  *   This file implements MeshCoP Datasets manager to process commands.
  *
  */
-
-#if OPENTHREAD_FTD
-
 #define WPP_NAME "dataset_manager_ftd.tmh"
 
-#include <openthread/config.h>
+#include "dataset_manager_ftd.hpp"
+
+#if OPENTHREAD_FTD
 
 #include <stdio.h>
 

--- a/src/core/meshcop/dataset_manager_ftd.hpp
+++ b/src/core/meshcop/dataset_manager_ftd.hpp
@@ -35,9 +35,14 @@
 #ifndef MESHCOP_DATASET_MANAGER_FTD_HPP_
 #define MESHCOP_DATASET_MANAGER_FTD_HPP_
 
+#include "openthread-core-config.h"
+
+#if OPENTHREAD_FTD
+
 #include <openthread/types.h>
 
 #include "coap/coap.hpp"
+#include "meshcop/dataset_manager.hpp"
 
 namespace ot {
 
@@ -87,5 +92,7 @@ private:
 
 }  // namespace MeshCoP
 }  // namespace ot
+
+#endif  // OPENTHREAD_FTD
 
 #endif  // MESHCOP_DATASET_MANAGER_HPP_

--- a/src/core/meshcop/dataset_manager_mtd.hpp
+++ b/src/core/meshcop/dataset_manager_mtd.hpp
@@ -35,6 +35,8 @@
 #ifndef MESHCOP_DATASET_MANAGER_MTD_HPP_
 #define MESHCOP_DATASET_MANAGER_MTD_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
 namespace ot {

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -32,7 +32,6 @@
  */
 
 #define WPP_NAME "dtls.tmh"
-#include <openthread/config.h>
 
 #include "dtls.hpp"
 

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -34,6 +34,8 @@
 #ifndef DTLS_HPP_
 #define DTLS_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
 #include <mbedtls/ssl.h>

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -32,7 +32,6 @@
  */
 
 #define WPP_NAME "energy_scan_client.tmh"
-#include <openthread/config.h>
 
 #include "energy_scan_client.hpp"
 

--- a/src/core/meshcop/energy_scan_client.hpp
+++ b/src/core/meshcop/energy_scan_client.hpp
@@ -34,9 +34,10 @@
 #ifndef ENERGY_SCAN_CLIENT_HPP_
 #define ENERGY_SCAN_CLIENT_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/commissioner.h>
 
-#include "openthread-core-config.h"
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
 #include "net/ip6_address.hpp"

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "joiner.tmh"
 
-#include <openthread/config.h>
-
 #include "joiner.hpp"
 
 #include <stdio.h>

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -34,6 +34,8 @@
 #ifndef JOINER_HPP_
 #define JOINER_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/joiner.h>
 
 #include "coap/coap.hpp"

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -35,8 +35,6 @@
 
 #define WPP_NAME "joiner_router.tmh"
 
-#include <openthread/config.h>
-
 #include "joiner_router.hpp"
 
 #include <stdio.h>

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -34,6 +34,8 @@
 #ifndef JOINER_ROUTER_HPP_
 #define JOINER_ROUTER_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
 #include "coap/coap.hpp"

--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -35,8 +35,6 @@
 
 #define WPP_NAME "leader.tmh"
 
-#include <openthread/config.h>
-
 #include "leader.hpp"
 
 #include <stdio.h>

--- a/src/core/meshcop/leader.hpp
+++ b/src/core/meshcop/leader.hpp
@@ -34,6 +34,8 @@
 #ifndef MESHCOP_LEADER_HPP_
 #define MESHCOP_LEADER_HPP_
 
+#include "openthread-core-config.h"
+
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
 #include "common/timer.hpp"

--- a/src/core/meshcop/meshcop.hpp
+++ b/src/core/meshcop/meshcop.hpp
@@ -35,6 +35,8 @@
 #ifndef MESHCOP_HPP_
 #define MESHCOP_HPP_
 
+#include "openthread-core-config.h"
+
 #include "coap/coap.hpp"
 #include "common/message.hpp"
 

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -35,6 +35,8 @@
 #ifndef MESHCOP_TLVS_HPP_
 #define MESHCOP_TLVS_HPP_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_string.h"
 
 #include <openthread/types.h>

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "panid_query_client.tmh"
 
-#include <openthread/config.h>
-
 #include "panid_query_client.hpp"
 
 #include <openthread/platform/random.h>

--- a/src/core/meshcop/panid_query_client.hpp
+++ b/src/core/meshcop/panid_query_client.hpp
@@ -34,9 +34,10 @@
 #ifndef PANID_QUERY_CLIENT_HPP_
 #define PANID_QUERY_CLIENT_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/commissioner.h>
 
-#include "openthread-core-config.h"
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
 #include "net/ip6_address.hpp"

--- a/src/core/meshcop/timestamp.cpp
+++ b/src/core/meshcop/timestamp.cpp
@@ -31,8 +31,6 @@
  *   This file implements common MeshCoP timestamp processing.
  */
 
-#include <openthread/config.h>
-
 #include "timestamp.hpp"
 
 #include "utils/wrap_string.h"

--- a/src/core/meshcop/timestamp.hpp
+++ b/src/core/meshcop/timestamp.hpp
@@ -35,6 +35,8 @@
 #ifndef MESHCOP_TIMESTAMP_HPP_
 #define MESHCOP_TIMESTAMP_HPP_
 
+#include "openthread-core-config.h"
+
 #include <string.h>
 
 #include <openthread/platform/toolchain.h>

--- a/src/core/net/dhcp6.hpp
+++ b/src/core/net/dhcp6.hpp
@@ -34,6 +34,8 @@
 #ifndef DHCP6_HPP_
 #define DHCP6_HPP_
 
+#include "openthread-core-config.h"
+
 #include "common/message.hpp"
 #include "net/udp6.hpp"
 

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "dhcp6_client.tmh"
 
-#include <openthread/config.h>
-
 #include "dhcp6_client.hpp"
 
 #include <openthread/types.h>

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -34,6 +34,8 @@
 #ifndef DHCP6_CLIENT_HPP_
 #define DHCP6_CLIENT_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/dhcp6_client.h>
 
 #include "common/locator.hpp"

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "dhcp6_server.tmh"
 
-#include <openthread/config.h>
-
 #include "dhcp6_server.hpp"
 
 #include <openthread/types.h>

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -34,6 +34,8 @@
 #ifndef DHCP6_SERVER_HPP_
 #define DHCP6_SERVER_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
 #include "common/locator.hpp"

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -26,8 +26,6 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <openthread/config.h>
-
 #include "dns_client.hpp"
 
 #include "utils/wrap_string.h"

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -29,6 +29,8 @@
 #ifndef DNS_CLIENT_HPP_
 #define DNS_CLIENT_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/dns.h>
 #include <openthread/types.h>
 

--- a/src/core/net/dns_headers.hpp
+++ b/src/core/net/dns_headers.hpp
@@ -34,6 +34,8 @@
 #ifndef DNS_HEADER_HPP_
 #define DNS_HEADER_HPP_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_string.h"
 
 #include <openthread/types.h>

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "icmp6.tmh"
 
-#include <openthread/config.h>
-
 #include "icmp6.hpp"
 
 #include "utils/wrap_string.h"

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -34,6 +34,8 @@
 #ifndef ICMP6_HPP_
 #define ICMP6_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/icmp6.h>
 
 #include "common/encoding.hpp"

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "ip6.tmh"
 
-#include <openthread/config.h>
-
 #include "ip6.hpp"
 
 #include "openthread-instance.h"

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -34,6 +34,8 @@
 #ifndef IP6_HPP_
 #define IP6_HPP_
 
+#include "openthread-core-config.h"
+
 #include <stddef.h>
 
 #include <openthread/ip6.h>

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -31,8 +31,6 @@
  *   This file implements IPv6 addresses.
  */
 
-#include <openthread/config.h>
-
 #include "ip6_address.hpp"
 
 #include <stdio.h>

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -34,6 +34,8 @@
 #ifndef IP6_ADDRESS_HPP_
 #define IP6_ADDRESS_HPP_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_stdint.h"
 
 #include <openthread/types.h>

--- a/src/core/net/ip6_filter.cpp
+++ b/src/core/net/ip6_filter.cpp
@@ -31,8 +31,6 @@
  *   This file implements IPv6 datagram filtering.
  */
 
-#include <openthread/config.h>
-
 #include "ip6_filter.hpp"
 
 #include <stdio.h>

--- a/src/core/net/ip6_filter.hpp
+++ b/src/core/net/ip6_filter.hpp
@@ -34,6 +34,8 @@
 #ifndef IP6_FILTER_HPP_
 #define IP6_FILTER_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/openthread.h>
 
 #include "common/message.hpp"

--- a/src/core/net/ip6_headers.cpp
+++ b/src/core/net/ip6_headers.cpp
@@ -31,8 +31,6 @@
  *   This file implements IP6 header processing.
  */
 
-#include <openthread/config.h>
-
 #include "ip6_headers.hpp"
 
 #include "net/ip6.hpp"

--- a/src/core/net/ip6_headers.hpp
+++ b/src/core/net/ip6_headers.hpp
@@ -34,6 +34,8 @@
 #ifndef IP6_HEADERS_HPP_
 #define IP6_HEADERS_HPP_
 
+#include "openthread-core-config.h"
+
 #include <stddef.h>
 
 #include <openthread/types.h>

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -31,8 +31,6 @@
  *   This file implements MPL.
  */
 
-#include <openthread/config.h>
-
 #include "ip6_mpl.hpp"
 
 #include <openthread/platform/random.h>

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -34,6 +34,8 @@
  *   This file includes definitions for MPL.
  */
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
 #include "common/locator.hpp"

--- a/src/core/net/ip6_routes.cpp
+++ b/src/core/net/ip6_routes.cpp
@@ -31,8 +31,6 @@
  *   This file implements IPv6 route tables.
  */
 
-#include <openthread/config.h>
-
 #include "ip6_routes.hpp"
 
 #include "common/code_utils.hpp"

--- a/src/core/net/ip6_routes.hpp
+++ b/src/core/net/ip6_routes.hpp
@@ -34,6 +34,8 @@
  *   This file includes definitions for manipulating IPv6 routing tables.
  */
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
 #include "common/locator.hpp"

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -30,7 +30,6 @@
  * @file
  *   This file implements IPv6 network interfaces.
  */
-#include <openthread/config.h>
 
 #include "netif.hpp"
 

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -34,6 +34,8 @@
 #ifndef NET_NETIF_HPP_
 #define NET_NETIF_HPP_
 
+#include "openthread-core-config.h"
+
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/tasklet.hpp"

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -34,6 +34,8 @@
 #ifndef NET_SOCKET_HPP_
 #define NET_SOCKET_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/openthread.h>
 
 #include "net/ip6_address.hpp"

--- a/src/core/net/tcp.hpp
+++ b/src/core/net/tcp.hpp
@@ -34,6 +34,8 @@
 #ifndef TCP_HPP_
 #define TCP_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/openthread.h>
 
 #include "net/ip6_headers.hpp"

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -31,8 +31,6 @@
  *   This file implements UDP/IPv6 sockets.
  */
 
-#include <openthread/config.h>
-
 #include "udp6.hpp"
 
 #include <stdio.h>

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -34,6 +34,8 @@
 #ifndef UDP6_HPP_
 #define UDP6_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/udp.h>
 
 #include "common/locator.hpp"

--- a/src/core/openthread-core-config.h
+++ b/src/core/openthread-core-config.h
@@ -34,6 +34,8 @@
 #ifndef OPENTHREAD_CORE_CONFIG_H_
 #define OPENTHREAD_CORE_CONFIG_H_
 
+#include <openthread/config.h>
+
 #define OPENTHREAD_CORE_CONFIG_H_IN
 
 #ifdef OPENTHREAD_PROJECT_CORE_CONFIG_FILE

--- a/src/core/openthread-instance.h
+++ b/src/core/openthread-instance.h
@@ -35,7 +35,7 @@
 #ifndef OPENTHREADINSTANCE_H_
 #define OPENTHREADINSTANCE_H_
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include "utils/wrap_stdint.h"
 #include "utils/wrap_stdbool.h"
@@ -43,7 +43,6 @@
 #include <openthread/types.h>
 #include <openthread/platform/logging.h>
 
-#include "openthread-core-config.h"
 #include "openthread-single-instance.h"
 #if OPENTHREAD_ENABLE_RAW_LINK_API
 #include "api/link_raw.hpp"

--- a/src/core/openthread-single-instance.h
+++ b/src/core/openthread-single-instance.h
@@ -35,11 +35,9 @@
 #ifndef SINGLE_OPENTHREAD_INSTANCE_H_
 #define SINGLE_OPENTHREAD_INSTANCE_H_
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <openthread/types.h>
-
-#include "openthread-core-config.h"
 
 
 #if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -35,8 +35,6 @@
 
 #define WPP_NAME "address_resolver.tmh"
 
-#include <openthread/config.h>
-
 #include "address_resolver.hpp"
 
 #include <openthread/platform/random.h>

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -34,9 +34,10 @@
 #ifndef ADDRESS_RESOLVER_HPP_
 #define ADDRESS_RESOLVER_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
-#include "openthread-core-config.h"
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
 #include "common/timer.hpp"

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "announce_begin_server.tmh"
 
-#include <openthread/config.h>
-
 #include "announce_begin_server.hpp"
 
 #include <openthread/platform/radio.h>

--- a/src/core/thread/announce_begin_server.hpp
+++ b/src/core/thread/announce_begin_server.hpp
@@ -34,9 +34,10 @@
 #ifndef ANNOUNCE_BEGIN_SERVER_HPP_
 #define ANNOUNCE_BEGIN_SERVER_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
-#include "openthread-core-config.h"
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
 #include "common/timer.hpp"

--- a/src/core/thread/data_poll_manager.cpp
+++ b/src/core/thread/data_poll_manager.cpp
@@ -32,9 +32,9 @@
  */
 
 #define WPP_NAME "data_poll_manager.tmh"
-#include <openthread/config.h>
 
 #include "data_poll_manager.hpp"
+
 #include <openthread/platform/random.h>
 
 #include "openthread-instance.h"

--- a/src/core/thread/data_poll_manager.hpp
+++ b/src/core/thread/data_poll_manager.hpp
@@ -34,9 +34,10 @@
 #ifndef DATA_POLL_MANAGER_HPP_
 #define DATA_POLL_MANAGER_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
-#include "openthread-core-config.h"
 #include "common/code_utils.hpp"
 #include "common/locator.hpp"
 #include "common/timer.hpp"

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -32,7 +32,6 @@
  */
 
 #define WPP_NAME "energy_scan_server.tmh"
-#include <openthread/config.h>
 
 #include "energy_scan_server.hpp"
 

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -34,9 +34,10 @@
 #ifndef ENERGY_SCAN_SERVER_HPP_
 #define ENERGY_SCAN_SERVER_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
-#include "openthread-core-config.h"
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
 #include "common/timer.hpp"

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -31,9 +31,6 @@
  *   This file implements Thread security material generation.
  */
 
-
-#include <openthread/config.h>
-
 #include "key_manager.hpp"
 
 #include "openthread-instance.h"

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -34,6 +34,8 @@
 #ifndef KEY_MANAGER_HPP_
 #define KEY_MANAGER_HPP_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_stdint.h"
 
 #include <openthread/types.h>

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -31,8 +31,6 @@
  *   This file implements link quality information processing and storage.
  */
 
-#include <openthread/config.h>
-
 #include "link_quality.hpp"
 
 #include <stdio.h>

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -34,6 +34,8 @@
 #ifndef LINK_QUALITY_HPP_
 #define LINK_QUALITY_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/platform/radio.h>
 #include <openthread/types.h>
 

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -31,8 +31,6 @@
  *   This file implements 6LoWPAN header compression.
  */
 
-#include <openthread/config.h>
-
 #include "lowpan.hpp"
 
 #include "common/code_utils.hpp"

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -34,6 +34,8 @@
 #ifndef LOWPAN_HPP_
 #define LOWPAN_HPP_
 
+#include "openthread-core-config.h"
+
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "mac/mac_frame.hpp"

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "mesh_forwarder.tmh"
 
-#include <openthread/config.h>
-
 #include "mesh_forwarder.hpp"
 
 #include <openthread/platform/random.h>

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -34,9 +34,10 @@
 #ifndef MESH_FORWARDER_HPP_
 #define MESH_FORWARDER_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
-#include "openthread-core-config.h"
 #include "common/locator.hpp"
 #include "common/tasklet.hpp"
 #include "mac/mac.hpp"

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -33,9 +33,8 @@
 
 #define WPP_NAME "mle.tmh"
 
-
-#include <openthread/config.h>
 #include "mle.hpp"
+
 #include <openthread/platform/radio.h>
 #include <openthread/platform/random.h>
 #include <openthread/platform/settings.h>

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -34,6 +34,8 @@
 #ifndef MLE_HPP_
 #define MLE_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/openthread.h>
 
 #include "common/encoding.hpp"

--- a/src/core/thread/mle_constants.hpp
+++ b/src/core/thread/mle_constants.hpp
@@ -34,6 +34,8 @@
 #ifndef MLE_CONSTANTS_HPP_
 #define MLE_CONSTANTS_HPP_
 
+#include "openthread-core-config.h"
+
 namespace ot {
 namespace Mle {
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -34,8 +34,6 @@
 
 #define WPP_NAME "mle_router.tmh"
 
-#include <openthread/config.h>
-
 #include "mle_router.hpp"
 
 #include <openthread/platform/random.h>

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -26,6 +26,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef MLE_ROUTER_HPP_
+#define MLE_ROUTER_HPP_
+
 #if OPENTHREAD_MTD
 #include "mle_router_mtd.hpp"
 #elif OPENTHREAD_FTD
@@ -34,3 +37,4 @@
 #error "Please define OPENTHREAD_MTD=1 or OPENTHREAD_FTD=1"
 #endif
 
+#endif // MLE_ROUTER_HPP_

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -31,8 +31,10 @@
  *   This file includes definitions for MLE functionality required by the Thread Router and Leader roles.
  */
 
-#ifndef MLE_ROUTER_HPP_
-#define MLE_ROUTER_HPP_
+#ifndef MLE_ROUTER_FTD_HPP_
+#define MLE_ROUTER_FTD_HPP_
+
+#include "openthread-core-config.h"
 
 #include "utils/wrap_string.h"
 
@@ -848,4 +850,4 @@ private:
 
 }  // namespace ot
 
-#endif  // MLE_ROUTER_HPP_
+#endif  // MLE_ROUTER_FTD_HPP_

--- a/src/core/thread/mle_router_mtd.hpp
+++ b/src/core/thread/mle_router_mtd.hpp
@@ -31,8 +31,10 @@
  *   This file includes definitions for MLE functionality required by the Thread Router and Leader roles.
  */
 
-#ifndef MLE_ROUTER_HPP_
-#define MLE_ROUTER_HPP_
+#ifndef MLE_ROUTER_MTD_HPP_
+#define MLE_ROUTER_MTD_HPP_
+
+#include "openthread-core-config.h"
 
 #include "utils/wrap_string.h"
 
@@ -155,4 +157,4 @@ private:
 }  // namespace Mle
 }  // namespace ot
 
-#endif  // MLE_ROUTER_HPP_
+#endif  // MLE_ROUTER_MTD_HPP_

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -34,6 +34,8 @@
 #ifndef MLE_TLVS_HPP_
 #define MLE_TLVS_HPP_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_string.h"
 
 #include <openthread/types.h>

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "network_data.tmh"
 
-#include <openthread/config.h>
-
 #include "network_data.hpp"
 
 #include <openthread/platform/random.h>

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -34,6 +34,8 @@
 #ifndef NETWORK_DATA_HPP_
 #define NETWORK_DATA_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
 #include "coap/coap.hpp"

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "network_data_leader.tmh"
 
-#include <openthread/config.h>
-
 #include "network_data_leader.hpp"
 
 #include <openthread/platform/random.h>

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -34,7 +34,7 @@
 #ifndef NETWORK_DATA_LEADER_HPP_
 #define NETWORK_DATA_LEADER_HPP_
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include "utils/wrap_stdint.h"
 

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -35,9 +35,9 @@
 
 
 #define WPP_NAME "network_data_leader_ftd.tmh"
-#include <openthread/config.h>
 
 #include "network_data_leader.hpp"
+
 #include <openthread/platform/random.h>
 
 #include "openthread-instance.h"

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -34,6 +34,8 @@
 #ifndef NETWORK_DATA_LEADER_FTD_HPP_
 #define NETWORK_DATA_LEADER_FTD_HPP_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_stdint.h"
 
 #include "coap/coap.hpp"

--- a/src/core/thread/network_data_leader_mtd.hpp
+++ b/src/core/thread/network_data_leader_mtd.hpp
@@ -34,6 +34,8 @@
 #ifndef NETWORK_DATA_LEADER_MTD_HPP_
 #define NETWORK_DATA_LEADER_MTD_HPP_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_stdint.h"
 
 namespace ot {

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -31,8 +31,6 @@
  *   This file implements the local Thread Network Data.
  */
 
-#include <openthread/config.h>
-
 #include "network_data_local.hpp"
 
 #include "common/debug.hpp"

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -34,6 +34,8 @@
 #ifndef NETWORK_DATA_LOCAL_HPP_
 #define NETWORK_DATA_LOCAL_HPP_
 
+#include "openthread-core-config.h"
+
 #include "thread/network_data.hpp"
 
 namespace ot {

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -34,6 +34,8 @@
 #ifndef NETWORK_DATA_TLVS_HPP_
 #define NETWORK_DATA_TLVS_HPP_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_string.h"
 
 #include "common/encoding.hpp"

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "network_diagnostic.tmh"
 
-#include <openthread/config.h>
-
 #include "network_diagnostic.hpp"
 
 #include <openthread/platform/random.h>

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -34,9 +34,10 @@
 #ifndef NETWORK_DIAGNOSTIC_HPP_
 #define NETWORK_DIAGNOSTIC_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
-#include "openthread-core-config.h"
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
 #include "net/udp6.hpp"

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -34,6 +34,8 @@
 #ifndef NETWORK_DIAGNOSTIC_TLVS_HPP_
 #define NETWORK_DIAGNOSTIC_TLVS_HPP_
 
+#include "openthread-core-config.h"
+
 #include "utils/wrap_string.h"
 
 #include <openthread/types.h>

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -31,9 +31,7 @@
  *   This file implements the PAN ID Query Server.
  */
 
-
 #define WPP_NAME "panid_query_server.tmh"
-#include <openthread/config.h>
 
 #include "panid_query_server.hpp"
 

--- a/src/core/thread/panid_query_server.hpp
+++ b/src/core/thread/panid_query_server.hpp
@@ -34,9 +34,10 @@
 #ifndef PANID_QUERY_SERVER_HPP_
 #define PANID_QUERY_SERVER_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
-#include "openthread-core-config.h"
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
 #include "common/timer.hpp"

--- a/src/core/thread/src_match_controller.cpp
+++ b/src/core/thread/src_match_controller.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "src_match_controller.tmh"
 
-#include <openthread/config.h>
-
 #include "src_match_controller.hpp"
 
 #include "common/code_utils.hpp"

--- a/src/core/thread/src_match_controller.hpp
+++ b/src/core/thread/src_match_controller.hpp
@@ -34,9 +34,10 @@
 #ifndef SOURCE_MATCH_CONTROLLER_HPP_
 #define SOURCE_MATCH_CONTROLLER_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
-#include "openthread-core-config.h"
 #include "common/locator.hpp"
 #include "thread/topology.hpp"
 

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -32,8 +32,6 @@
  *   This file implements the Thread network interface.
  */
 
-#include <openthread/config.h>
-
 #include "thread_netif.hpp"
 
 #include "openthread-instance.h"

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -34,7 +34,7 @@
 #ifndef THREAD_NETIF_HPP_
 #define THREAD_NETIF_HPP_
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <openthread/types.h>
 

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -34,6 +34,8 @@
 #ifndef THREAD_TLVS_HPP_
 #define THREAD_TLVS_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
 #include "common/encoding.hpp"

--- a/src/core/thread/thread_uri_paths.hpp
+++ b/src/core/thread/thread_uri_paths.hpp
@@ -34,6 +34,8 @@
 #ifndef THREAD_URIS_HPP_
 #define THREAD_URIS_HPP_
 
+#include "openthread-core-config.h"
+
 namespace ot {
 
 /**

--- a/src/core/thread/tmf_proxy.cpp
+++ b/src/core/thread/tmf_proxy.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "tmf_proxy.tmh"
 
-#include <openthread/config.h>
-
 #include "tmf_proxy.hpp"
 
 #include <openthread/types.h>

--- a/src/core/thread/tmf_proxy.hpp
+++ b/src/core/thread/tmf_proxy.hpp
@@ -34,9 +34,10 @@
 #ifndef TMF_PROXY_HPP_
 #define TMF_PROXY_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/tmf_proxy.h>
 
-#include "openthread-core-config.h"
 #include "coap/coap.hpp"
 
 namespace ot {

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -33,8 +33,6 @@
 
 #define WPP_NAME "topology.tmh"
 
-#include <openthread/config.h>
-
 #include "topology.hpp"
 
 #include "common/code_utils.hpp"

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -34,9 +34,10 @@
 #ifndef TOPOLOGY_HPP_
 #define TOPOLOGY_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/platform/random.h>
 
-#include "openthread-core-config.h"
 #include "common/message.hpp"
 #include "mac/mac_frame.hpp"
 #include "net/ip6.hpp"

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -31,8 +31,6 @@
  *   This file implements the child supervision feature.
  */
 
-#include <openthread/config.h>
-
 #include "child_supervision.hpp"
 
 #include <openthread/openthread.h>

--- a/src/core/utils/child_supervision.hpp
+++ b/src/core/utils/child_supervision.hpp
@@ -35,9 +35,8 @@
 #ifndef CHILD_SUPERVISION_HPP_
 #define CHILD_SUPERVISION_HPP_
 
-#include <openthread/config.h>
-
 #include "openthread-core-config.h"
+
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/timer.hpp"

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -31,8 +31,6 @@
  *   This file implements the jam detector feature.
  */
 
-#include <openthread/config.h>
-
 #include "jam_detector.hpp"
 
 #include <openthread/openthread.h>

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -34,7 +34,7 @@
 #ifndef JAM_DETECTOR_HPP_
 #define JAM_DETECTOR_HPP_
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include "common/locator.hpp"
 #include "common/timer.hpp"

--- a/src/core/utils/missing_strlcat.c
+++ b/src/core/utils/missing_strlcat.c
@@ -25,7 +25,7 @@
  *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include "utils/wrap_string.h"
 

--- a/src/core/utils/missing_strlcpy.c
+++ b/src/core/utils/missing_strlcpy.c
@@ -25,8 +25,6 @@
  *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <openthread/config.h>
-
 #include "utils/wrap_string.h"
 
 size_t missing_strlcpy(char *dest, const char *src, size_t size)

--- a/src/core/utils/missing_strnlen.c
+++ b/src/core/utils/missing_strnlen.c
@@ -25,8 +25,6 @@
  *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <openthread/config.h>
-
 #include "utils/wrap_string.h"
 
 size_t missing_strnlen(const char *s, size_t maxlen)

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -31,8 +31,6 @@
  *   This file implements the Thread IPv6 global addresses configuration utilities.
  */
 
-#include <openthread/config.h>
-
 #include "slaac_address.hpp"
 
 #include "utils/wrap_string.h"

--- a/src/core/utils/slaac_address.hpp
+++ b/src/core/utils/slaac_address.hpp
@@ -34,6 +34,8 @@
 #ifndef SLAAC_ADDRESS_HPP_
 #define SLAAC_ADDRESS_HPP_
 
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 #include <openthread/platform/random.h>
 

--- a/src/diag/diag_process.cpp
+++ b/src/diag/diag_process.cpp
@@ -31,14 +31,13 @@
  *   This file implements the diagnostics module.
  */
 
-#include <openthread/config.h>
+#include "diag_process.hpp"
 
 #include <stdio.h>
 #include <stdlib.h>
 
 #include <openthread/instance.h>
 
-#include "diag_process.hpp"
 #include "common/code_utils.hpp"
 #include "utils/wrap_string.h"
 

--- a/src/diag/diag_process.hpp
+++ b/src/diag/diag_process.hpp
@@ -34,7 +34,7 @@
 #ifndef DIAG_PROCESS_HPP_
 #define DIAG_PROCESS_HPP_
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <stdarg.h>
 

--- a/src/diag/openthread-diag.cpp
+++ b/src/diag/openthread-diag.cpp
@@ -31,7 +31,7 @@
  *   This file implements the top-level interface to diagnostics module.
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/ncp/changed_props_set.hpp
+++ b/src/ncp/changed_props_set.hpp
@@ -33,6 +33,8 @@
 #ifndef CHANGED_PROPS_SET_HPP_
 #define CHANGED_PROPS_SET_HPP_
 
+#include "openthread-core-config.h"
+
 #include <stddef.h>
 
 #include <openthread/types.h>

--- a/src/ncp/hdlc.cpp
+++ b/src/ncp/hdlc.cpp
@@ -30,8 +30,6 @@
  *   This file implements an HDLC-lite encoder and decoder.
  */
 
-#include <openthread/config.h>
-
 #include "hdlc.hpp"
 
 #include <stdlib.h>

--- a/src/ncp/hdlc.hpp
+++ b/src/ncp/hdlc.hpp
@@ -32,7 +32,9 @@
 
 #ifndef HDLC_HPP_
 #define HDLC_HPP_
-#include <openthread/config.h>
+
+#include "openthread-core-config.h"
+
 #include <openthread/types.h>
 
 namespace ot {

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -30,8 +30,6 @@
  *   This file implements general thread device required Spinel interface to the OpenThread stack.
  */
 
-#include <openthread/config.h>
-
 #include "ncp_base.hpp"
 
 #include <stdarg.h>

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -33,7 +33,7 @@
 #ifndef NCP_BASE_HPP_
 #define NCP_BASE_HPP_
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
 #include <openthread/ip6.h>

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -30,7 +30,6 @@
  *   This file implements full thread device specified Spinel interface to the OpenThread stack.
  */
 
-#include <openthread/config.h>
 #include "ncp_base.hpp"
 
 #include <openthread/diag.h>

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -30,7 +30,6 @@
  *   This file implements minimal thread device required Spinel interface to the OpenThread stack.
  */
 
-#include <openthread/config.h>
 #include "ncp_base.hpp"
 
 #if OPENTHREAD_ENABLE_BORDER_ROUTER

--- a/src/ncp/ncp_base_radio.cpp
+++ b/src/ncp/ncp_base_radio.cpp
@@ -30,8 +30,6 @@
  *   This file implements raw link required Spinel interface to the OpenThread stack.
  */
 
-#include <openthread/config.h>
-
 #include "ncp_base.hpp"
 
 #include <stdlib.h>

--- a/src/ncp/ncp_buffer.cpp
+++ b/src/ncp/ncp_buffer.cpp
@@ -30,9 +30,8 @@
  *   This file implements NCP frame buffer class.
  */
 
-#include <openthread/config.h>
-
 #include "ncp_buffer.hpp"
+
 #include "utils/wrap_string.h"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"

--- a/src/ncp/ncp_buffer.hpp
+++ b/src/ncp/ncp_buffer.hpp
@@ -33,7 +33,8 @@
 #ifndef NCP_FRAME_BUFFER_HPP_
 #define NCP_FRAME_BUFFER_HPP_
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
+
 #include <openthread/message.h>
 #include <openthread/types.h>
 

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -30,8 +30,6 @@
  *   This file implements a SPI interface to the OpenThread stack.
  */
 
-#include <openthread/config.h>
-
 #include "ncp_spi.hpp"
 
 #include <openthread/ncp.h>

--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -33,7 +33,7 @@
 #ifndef NCP_SPI_HPP_
 #define NCP_SPI_HPP_
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include "ncp/ncp_base.hpp"
 

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -30,8 +30,6 @@
  *   This file contains definitions for a UART based NCP interface to the OpenThread stack.
  */
 
-#include <openthread/config.h>
-
 #include "ncp_uart.hpp"
 
 #include <stdio.h>
@@ -166,7 +164,7 @@ void NcpUart::EncodeAndSendToUart(void)
                 SuccessOrExit(mFrameEncoder.Encode(mByte, mUartBuffer));
             }
 
-            // track the change of mHostPowerStateInProgress by the 
+            // track the change of mHostPowerStateInProgress by the
             // call to OutFrameRemove.
             prevHostPowerState = mHostPowerStateInProgress;
 

--- a/src/ncp/ncp_uart.hpp
+++ b/src/ncp/ncp_uart.hpp
@@ -33,7 +33,7 @@
 #ifndef NCP_UART_HPP_
 #define NCP_UART_HPP_
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include "ncp/hdlc.hpp"
 #include "ncp/ncp_base.hpp"

--- a/src/ncp/spinel_encoder.cpp
+++ b/src/ncp/spinel_encoder.cpp
@@ -30,8 +30,6 @@
  *   This file implements a spinel encoder.
  */
 
-#include <openthread/config.h>
-
 #include "spinel_encoder.hpp"
 
 #include "common/code_utils.hpp"

--- a/src/ncp/spinel_encoder.hpp
+++ b/src/ncp/spinel_encoder.hpp
@@ -33,7 +33,7 @@
 #ifndef SPINEL_ENCODER_HPP_
 #define SPINEL_ENCODER_HPP_
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <openthread/message.h>
 #include <openthread/ncp.h>

--- a/src/ncp/spinel_platform.h
+++ b/src/ncp/spinel_platform.h
@@ -49,7 +49,7 @@
  *
  */
 
-#include <openthread/config.h>
+#include "openthread-core-config.h"
 
 #include <stdarg.h>
 #include "utils/wrap_stdbool.h"


### PR DESCRIPTION
This commit simplifies the config header files includes in
OpenThread core and non-public source files. With this change the
`"openthread-core-config.h"` becomes the main config header file. This
header file includes all other config ones:
- The `configure` generated `<openthread/config.h>;
- The project specific one by `OPENTHREAD_PROJECT_CORE_CONFIG_FILE`;
- The "openthread-core-default-config.h" defining default settings.

With the change in this commit, all header files include "openthread-
core-config.h" as the first `#include`, and in `.cpp` files, the first
`#include` continues to be the unit's corresponding header file. The
new model ensures that the configuration settings are visible and
consistent in all the source files. This commit also updates the
style guide document accordingly.