### PR TITLE
[mesh-forwarder] clear child's indirect message pointer when message is removed

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -255,6 +255,25 @@ exit:
     return error;
 }
 
+otError MeshForwarder::RemoveMessageFromSleepyChild(Message &aMessage, Child &aChild)
+{
+    otError error = OT_ERROR_NONE;
+    uint8_t childIndex = GetNetif().GetMle().GetChildIndex(aChild);
+
+    VerifyOrExit(aMessage.GetChildMask(childIndex) == true, error = OT_ERROR_NOT_FOUND);
+
+    aMessage.ClearChildMask(childIndex);
+    mSourceMatchController.DecrementMessageCount(aChild);
+
+    if (aChild.GetIndirectMessage() == &aMessage)
+    {
+        aChild.SetIndirectMessage(NULL);
+    }
+
+exit:
+    return error;
+}
+
 void MeshForwarder::RemoveMessage(Message &aMessage)
 {
     Child *children;
@@ -264,16 +283,7 @@ void MeshForwarder::RemoveMessage(Message &aMessage)
 
     for (uint8_t i = 0; i < numChildren; i++)
     {
-        if (aMessage.GetChildMask(i))
-        {
-            aMessage.ClearChildMask(i);
-            mSourceMatchController.DecrementMessageCount(children[i]);
-
-            if (children[i].GetIndirectMessage() == &aMessage)
-            {
-                children[i].SetIndirectMessage(NULL);
-            }
-        }
+        IgnoreReturnValue(RemoveMessageFromSleepyChild(aMessage, children[i]));
     }
 
     if (mSendMessage == &aMessage)
@@ -293,8 +303,6 @@ void MeshForwarder::RemoveMessages(Child &aChild, uint8_t aSubType)
 
     for (Message *message = mSendQueue.GetHead(); message; message = nextMessage)
     {
-        uint8_t childIndex = netif.GetMle().GetChildIndex(aChild);
-
         nextMessage = message->GetNext();
 
         if ((aSubType != Message::kSubTypeNone) && (aSubType != message->GetSubType()))
@@ -302,12 +310,7 @@ void MeshForwarder::RemoveMessages(Child &aChild, uint8_t aSubType)
             continue;
         }
 
-        if (message->GetChildMask(childIndex))
-        {
-            message->ClearChildMask(childIndex);
-            mSourceMatchController.DecrementMessageCount(aChild);
-        }
-        else
+        if (RemoveMessageFromSleepyChild(*message, aChild) != OT_ERROR_NONE)
         {
             switch (message->GetType())
             {
@@ -340,9 +343,7 @@ void MeshForwarder::RemoveMessages(Child &aChild, uint8_t aSubType)
             }
 
             default:
-            {
                 break;
-            }
             }
         }
 

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -293,6 +293,7 @@ private:
     otError HandleDatagram(Message &aMessage, const otThreadLinkInfo &aLinkInfo,
                            const Mac::Address &aMacSource);
     void ClearReassemblyList(void);
+    otError RemoveMessageFromSleepyChild(Message &aMessage, Child &aChild);
     void RemoveMessage(Message &aMessage);
 
     static void HandleReceivedFrame(Mac::Receiver &aReceiver, Mac::Frame &aFrame);


### PR DESCRIPTION
This commit changes/fixes the `MeshForwarder::RemoveMessages()`
where we check if the message being removed is the current
indirect message stored in child entry and if so, ensure to clear
the pointer in the child.