### PR TITLE
[docs] Doxygen updates for openthread.io reference documentation

### DIFF
--- a/include/openthread/openthread.h
+++ b/include/openthread/openthread.h
@@ -57,6 +57,8 @@ extern "C" {
  *
  * @{
  *
+ * @defgroup api-types Types
+ *
  * @defgroup api-execution Execution
  *
  * @{

--- a/include/openthread/platform/logging.h
+++ b/include/openthread/platform/logging.h
@@ -57,7 +57,7 @@ extern "C" {
 /**
  * Log levels.
  *
- * Implimentation note: These exist as defines (not enums) so that
+ * Implementation note: These exist as defines (not enums) so that
  * embedded code can remove code at compile time via if/else/endif
  */
 

--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -69,6 +69,16 @@ extern "C" {
 #endif /* _WIN32 */
 
 /**
+ * @addtogroup api-types
+ *
+ * @brief
+ *   This module includes API types
+ *
+ * @{
+ *
+ */
+
+/**
  * This type represents the OpenThread instance structure.
  */
 typedef struct otInstance otInstance;
@@ -1127,6 +1137,10 @@ typedef enum otLogRegion
     OT_LOG_REGION_CLI      = 14, ///< CLI
 } otLogRegion;
 
+/**
+ * @}
+ *
+ */
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
- Corrected spelling error
- Added a few Doxygen group tags so content can be properly generated in the openthread.io version of the API reference