### PR TITLE
[nRF52840] fix alarm problem on timer overflow

### DIFF
--- a/examples/platforms/nrf52840/platform-nrf5.h
+++ b/examples/platforms/nrf52840/platform-nrf5.h
@@ -81,7 +81,7 @@ void nrf5AlarmProcess(otInstance *aInstance);
  * Function for geting current time in mircosecond.
  *
  */
-uint64_t nrf5AlarmGetCurrentTime();
+uint64_t nrf5AlarmGetCurrentTime(void);
 
 /**
  * Initialization of Random Number Generator.


### PR DESCRIPTION
Millisecond and microsecond timers used by OpenThread can overflow during
application run. This commit sets RTC Compare Channel to correct value
after overflow.