### PR TITLE
[harness-automation] add option to add all devices to the test bed

### DIFF
--- a/tools/harness-automation/autothreadharness/harness_case.py
+++ b/tools/harness-automation/autothreadharness/harness_case.py
@@ -162,6 +162,7 @@ class HarnessCase(unittest.TestCase):
         self._hc = None
         self.result_dir = '%s\\%s' % (settings.OUTPUT_PATH, self.__class__.__name__)
         self.history = HistoryHelper()
+        self.add_all_devices = False
 
         super(HarnessCase, self).__init__(*args, **kwargs)
 
@@ -485,10 +486,11 @@ class HarnessCase(unittest.TestCase):
         if len(devices) < golden_devices_required:
             raise GoldenDeviceNotEnoughError()
 
+
         # add golden devices
-        while golden_devices_required:
+        number_of_devices_to_add = len(devices) if self.add_all_devices else golden_devices_required
+        for i in range(number_of_devices_to_add):
             self._add_device(*devices.pop())
-            golden_devices_required = golden_devices_required - 1
 
         # add DUT
         if settings.DUT_DEVICE:
@@ -511,7 +513,7 @@ class HarnessCase(unittest.TestCase):
                 self._connect_devices()
                 button_next = browser.find_element_by_id('nextBtn')
                 if not wait_until(lambda: 'disabled' not in button_next.get_attribute('class'),
-                                  times=(30 + 4 * self.golden_devices_required)):
+                                  times=(30 + 4 * number_of_devices_to_add)):
                     bad_ones = []
                     selected_hw_set = test_bed.find_elements_by_class_name('selected-hw')
                     for selected_hw in selected_hw_set:


### PR DESCRIPTION
I added new option which allows to add all golden devices listed in the settings.py file to the test bed. It is mainly to allow the use of the TopologyConfig.txt file. When the EnableDeviceSelection option is set to 'True', Harness chooses devices used in a given test case based on the requirements from the TopologyConfig.txt file. If those requirements are not met by the test bed, it is not possible to run this test case. By adding all golden devices we make sure that it will be possible to run a particular test case, as long as there is enough devices of each type listed in the settings.py file.