### PR TITLE
[cli] separate the result and child list in different lines for THCI

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -469,7 +469,6 @@ void Interpreter::ProcessChild(int argc, char *argv[])
 {
     otError error = OT_ERROR_NONE;
     otChildInfo childInfo;
-    uint8_t maxChildren;
     long value;
     bool isTable = false;
 
@@ -483,11 +482,11 @@ void Interpreter::ProcessChild(int argc, char *argv[])
             mServer->OutputFormat("+-----+--------+------------+------------+-------+------+-+-+-+-+------------------+\r\n");
         }
 
-        maxChildren = otThreadGetMaxAllowedChildren(mInstance);
-
-        for (uint8_t i = 0; i < maxChildren ; i++)
+        // For certifcation: here intentionally not limits the upperbound for the index,
+        // giving the chance to exit from below default case as OpenThread THCI expects
+        // the content of "child list" and the result "Done" in seperate lines.
+        for (uint8_t i = 0; ; i++)
         {
-
             switch (otThreadGetChildInfoByIndex(mInstance, i, &childInfo))
             {
             case OT_ERROR_NONE:
@@ -530,8 +529,6 @@ void Interpreter::ProcessChild(int argc, char *argv[])
                 }
             }
         }
-
-        ExitNow();
     }
 
     SuccessOrExit(error = ParseLong(argv[0], value));


### PR DESCRIPTION
Fix one hidden issue newly found:
Since #1321,  cli "child list" would return as below if children exist.
```
> child list
1 Done
```
However OpenThread THCI expects 'Done' in a separate line as the termination for this command, otherwise warning "failed to find end of response".  It causes Test Harness failing to compute DUT MAC address for some scenarios when test manually and prompting for user input (TH is trying to reduce user input). 
We didn't notice it because we have been testing with automation tool or enabling AUTO_DUT which use different mechanisms for DUT_MAC.