### PR TITLE
[travis] add gcc-arm-none-eabi-6-2017-q2-update to build check

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -79,6 +79,12 @@ cd /tmp || die
     }
 
     [ $BUILD_TARGET != arm-gcc63 ] || {
+        sudo apt-get install lib32z1 || die
+        wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 || die
+        tar xjf gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 || die
+        export PATH=/tmp/gcc-arm-none-eabi-6-2017-q2-update/bin:$PATH || die
+        arm-none-eabi-gcc --version || die
+
         wget https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2017.03-rc2/arc_gnu_2017.03-rc2_prebuilt_elf32_le_linux_install.tar.gz || die
         tar xzf arc_gnu_2017.03-rc2_prebuilt_elf32_le_linux_install.tar.gz
         export PATH=/tmp/arc_gnu_2017.03-rc2_prebuilt_elf32_le_linux_install/bin:$PATH || die

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -180,6 +180,60 @@ set -x
 }
 
 [ $BUILD_TARGET != arm-gcc63 ] || {
+    export PATH=/tmp/gcc-arm-none-eabi-6-2017-q2-update/bin:$PATH || die
+
+    git checkout -- . || die
+    git clean -xfd || die
+    ./bootstrap || die
+    COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-cc2538 || die
+    arm-none-eabi-size  output/cc2538/bin/ot-cli-ftd || die
+    arm-none-eabi-size  output/cc2538/bin/ot-cli-mtd || die
+    arm-none-eabi-size  output/cc2538/bin/ot-ncp-ftd || die
+    arm-none-eabi-size  output/cc2538/bin/ot-ncp-mtd || die
+
+    # git checkout -- . || die
+    # git clean -xfd || die
+    # ./bootstrap || die
+    # COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-da15000 || die
+    # arm-none-eabi-size  output/da15000/bin/ot-cli-ftd || die
+    # arm-none-eabi-size  output/da15000/bin/ot-cli-mtd || die
+    # arm-none-eabi-size  output/da15000/bin/ot-ncp-ftd || die
+    # arm-none-eabi-size  output/da15000/bin/ot-ncp-mtd || die
+
+    git checkout -- . || die
+    git clean -xfd || die
+    ./bootstrap || die
+    COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-kw41z || die
+    arm-none-eabi-size  output/kw41z/bin/ot-cli-ftd || die
+    arm-none-eabi-size  output/kw41z/bin/ot-cli-mtd || die
+    arm-none-eabi-size  output/kw41z/bin/ot-ncp-ftd || die
+    arm-none-eabi-size  output/kw41z/bin/ot-ncp-mtd || die
+
+    git checkout -- . || die
+    git clean -xfd || die
+    ./bootstrap || die
+    COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-nrf52840 || die
+    arm-none-eabi-size  output/nrf52840/bin/ot-cli-ftd || die
+    arm-none-eabi-size  output/nrf52840/bin/ot-cli-mtd || die
+    arm-none-eabi-size  output/nrf52840/bin/ot-ncp-ftd || die
+    arm-none-eabi-size  output/nrf52840/bin/ot-ncp-mtd || die
+
+    # git checkout -- . || die
+    # git clean -xfd || die
+    # ./bootstrap || die
+    # make -f examples/Makefile-cc2650 || die
+    # arm-none-eabi-size  output/cc2650/bin/ot-cli-mtd || die
+    # arm-none-eabi-size  output/cc2650/bin/ot-ncp-mtd || die
+
+    # git checkout -- . || die
+    # git clean -xfd || die
+    # ./bootstrap || die
+    # COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-cc2652 || die
+    # arm-none-eabi-size  output/cc2652/bin/ot-cli-ftd || die
+    # arm-none-eabi-size  output/cc2652/bin/ot-cli-mtd || die
+    # arm-none-eabi-size  output/cc2652/bin/ot-ncp-ftd || die
+    # arm-none-eabi-size  output/cc2652/bin/ot-ncp-mtd || die
+
     export PATH=/tmp/arc_gnu_2017.03-rc2_prebuilt_elf32_le_linux_install/bin:$PATH || die
 
     git checkout -- . || die


### PR DESCRIPTION
- Note: not all example platforms are included in this check because their third-party code generates compiler warnings.