### PR TITLE
[efr32] remove duplicated uart initialization

### DIFF
--- a/examples/platforms/efr32/platform.c
+++ b/examples/platforms/efr32/platform.c
@@ -62,8 +62,6 @@ void PlatformInit(int argc, char *argv[])
     HAL_Init();
     BSP_Init(BSP_INIT_BCC);
 
-    otPlatUartEnable();
-
     RAIL_Init_t railInitParams =
     {
         128, // maxPacketLength: UNUSED


### PR DESCRIPTION
otPlatUartEnable() will be called in cli uart or ncp uart component initialization, so remove the duplicated call from platform layer.