### PR TITLE
[mle] fix bug in forming Child ID Response message

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -4506,7 +4506,7 @@ otError MleRouter::AppendChildAddresses(Message &aMessage, Child &aChild)
     AddressRegistrationEntry entry;
     Lowpan::Context context;
     uint8_t length = 0;
-    uint8_t startOffset = static_cast<uint8_t>(aMessage.GetLength());
+    uint16_t startOffset = aMessage.GetLength();
 
     tlv.SetType(Tlv::kAddressRegistration);
     SuccessOrExit(error = aMessage.Append(&tlv, sizeof(tlv)));


### PR DESCRIPTION
This commit fixes an overflow issue when forming the Address Registration
TLV within an MLE Child ID Response message.  The overflow can cause the
resulting message to be malformed.