### PR TITLE
[diag] remove unnecessary receive operation in DiagReceiveDone()

### DIFF
--- a/src/diag/diag_process.cpp
+++ b/src/diag/diag_process.cpp
@@ -375,7 +375,6 @@ void Diag::DiagReceiveDone(otInstance *aInstance, otRadioFrame *aFrame, otError 
         sStats.received_packets++;
     }
     otPlatDiagRadioReceived(aInstance, aFrame, aError);
-    otPlatRadioReceive(aInstance, sChannel);
 
 exit:
     return;


### PR DESCRIPTION
The extra receive operation may abort the process of transmit.