### PR TITLE
[meshcop] use IEEE EUI-64 rather than Joiner ID on user input

### DIFF
--- a/doc/spinel-protocol-src/spinel-tech-thread.md
+++ b/doc/spinel-protocol-src/spinel-tech-thread.md
@@ -256,7 +256,7 @@ Data per item is:
 
 * `U`: PSKd
 * `L`: Timeout in seconds
-* `E`: Extended/long address (optional)
+* `E`: IEEE EUI-64 (optional)
 
 Passess Pre-Shared Key for the Device to the NCP in the commissioning process.
 When the Extended address is ommited all Devices which provided a valid PSKd

--- a/etc/visual-studio/libopenthread.vcxproj
+++ b/etc/visual-studio/libopenthread.vcxproj
@@ -104,9 +104,10 @@
     <ClCompile Include="..\..\src\core\meshcop\joiner.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\joiner_router.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\leader.cpp" />
+    <ClCompile Include="..\..\src\core\meshcop\meshcop.cpp" />
+    <ClCompile Include="..\..\src\core\meshcop\meshcop_tlvs.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\panid_query_client.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\timestamp.cpp" />
-    <ClCompile Include="..\..\src\core\meshcop\meshcop_tlvs.cpp" />
     <ClCompile Include="..\..\src\core\net\dhcp6_client.cpp" />
     <ClCompile Include="..\..\src\core\net\dhcp6_server.cpp" />
     <ClCompile Include="..\..\src\core\net\icmp6.cpp" />
@@ -181,9 +182,10 @@
     <ClInclude Include="..\..\src\core\meshcop\joiner.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\joiner_router.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\leader.hpp" />
+    <ClInclude Include="..\..\src\core\meshcop\meshcop.hpp" />
+    <ClInclude Include="..\..\src\core\meshcop\meshcop_tlvs.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\panid_query_client.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\timestamp.hpp" />
-    <ClInclude Include="..\..\src\core\meshcop\tlvs.hpp" />
     <ClInclude Include="..\..\src\core\net\icmp6.hpp" />
     <ClInclude Include="..\..\src\core\net\ip6.hpp" />
     <ClInclude Include="..\..\src\core\net\ip6_address.hpp" />

--- a/etc/visual-studio/libopenthread_k.vcxproj
+++ b/etc/visual-studio/libopenthread_k.vcxproj
@@ -112,9 +112,10 @@
     <ClCompile Include="..\..\src\core\meshcop\joiner.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\joiner_router.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\leader.cpp" />
+    <ClCompile Include="..\..\src\core\meshcop\meshcop.cpp" />
+    <ClCompile Include="..\..\src\core\meshcop\meshcop_tlvs.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\panid_query_client.cpp" />
     <ClCompile Include="..\..\src\core\meshcop\timestamp.cpp" />
-    <ClCompile Include="..\..\src\core\meshcop\meshcop_tlvs.cpp" />
     <ClCompile Include="..\..\src\core\net\dhcp6_client.cpp" />
     <ClCompile Include="..\..\src\core\net\dhcp6_server.cpp" />
     <ClCompile Include="..\..\src\core\net\icmp6.cpp" />
@@ -213,9 +214,10 @@
     <ClInclude Include="..\..\src\core\meshcop\joiner.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\joiner_router.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\leader.hpp" />
+    <ClInclude Include="..\..\src\core\meshcop\meshcop.hpp" />
+    <ClInclude Include="..\..\src\core\meshcop\meshcop_tlvs.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\panid_query_client.hpp" />
     <ClInclude Include="..\..\src\core\meshcop\timestamp.hpp" />
-    <ClInclude Include="..\..\src\core\meshcop\tlvs.hpp" />
     <ClInclude Include="..\..\src\core\net\dhcp6.hpp" />
     <ClInclude Include="..\..\src\core\net\dhcp6_client.hpp" />
     <ClInclude Include="..\..\src\core\net\dhcp6_server.hpp" />

--- a/examples/apps/windows/otAdapter.h
+++ b/examples/apps/windows/otAdapter.h
@@ -211,7 +211,7 @@ public:
         uint64_t get()
         {
             uint64_t addr;
-            otLinkGetJoinerId(DeviceInstance, (otExtAddress*)&addr);
+            otJoinerGetId(DeviceInstance, (otExtAddress*)&addr);
             return addr;
         }
     }

--- a/examples/drivers/windows/include/otLwfIoctl.h
+++ b/examples/drivers/windows/include/otLwfIoctl.h
@@ -542,7 +542,7 @@ typedef struct otCommissionConfig
     // GUID - InterfaceGuid
     // otExtAddress - aEui64
 
-#define IOCTL_OTLWF_OT_HASH_MAC_ADDRESS \
+#define IOCTL_OTLWF_OT_JOINER_ID \
     OTLWF_CTL_CODE(172, METHOD_BUFFERED, FILE_READ_DATA)
     // GUID - InterfaceGuid
     // otExtAddress - aEui64

--- a/examples/drivers/windows/include/otNode.h
+++ b/examples/drivers/windows/include/otNode.h
@@ -146,9 +146,14 @@ OTNODEAPI uint16_t OTCALL otNodeGetAddr16(otNode* aNode);
 OTNODEAPI const char* OTCALL otNodeGetAddr64(otNode* aNode);
 
 /**
- * Gets the node's hash mac address
+ * Gets the node's eui-64 address
  */
-OTNODEAPI const char* OTCALL otNodeGetHashMacAddress(otNode* aNode);
+OTNODEAPI const char* OTCALL otNodeGetEui64(otNode* aNode);
+
+/**
+ * Gets the node's joiner id
+ */
+OTNODEAPI const char* OTCALL otNodeGetJoinerId(otNode* aNode);
 
 /**
  * Sets the channel for the node

--- a/examples/drivers/windows/otApi/otApi.cpp
+++ b/examples/drivers/windows/otApi/otApi.cpp
@@ -1548,18 +1548,6 @@ otLinkGetFactoryAssignedIeeeEui64(
 }
 
 OTAPI 
-void 
-OTCALL
-otLinkGetJoinerId(
-    _In_ otInstance *aInstance, 
-    _Out_ otExtAddress *aHashMacAddress
-    )
-{
-    if (aInstance == nullptr) return;
-    (void)QueryIOCTL(aInstance, IOCTL_OTLWF_OT_HASH_MAC_ADDRESS, aHashMacAddress);
-}
-
-OTAPI 
 otError 
 OTCALL
 otThreadGetLeaderRloc(
@@ -3917,6 +3905,18 @@ otJoinerStop(
 {
     if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_JOINER_STOP));
+}
+
+OTAPI 
+otError 
+OTCALL
+otJoinerGetId(
+    _In_ otInstance *aInstance, 
+    _Out_ otExtAddress *aJoinerId
+    )
+{
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
+    return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_JOINER_ID, aJoinerId));
 }
 
 OTAPI

--- a/examples/drivers/windows/otLwf/iocontrol.c
+++ b/examples/drivers/windows/otLwf/iocontrol.c
@@ -116,7 +116,7 @@ OTLWF_IOCTL_HANDLER IoCtls[] =
     { "IOCTL_OTLWF_OT_JOINER_START",                REF_IOCTL_FUNC(otJoinerStart) },
     { "IOCTL_OTLWF_OT_JOINER_STOP",                 REF_IOCTL_FUNC(otJoinerStop) },
     { "IOCTL_OTLWF_OT_FACTORY_EUI64",               REF_IOCTL_FUNC(otFactoryAssignedIeeeEui64) },
-    { "IOCTL_OTLWF_OT_HASH_MAC_ADDRESS",            REF_IOCTL_FUNC(otHashMacAddress) },
+    { "IOCTL_OTLWF_OT_JOINER_ID",                   REF_IOCTL_FUNC(otJoinerId) },
     { "IOCTL_OTLWF_OT_ROUTER_DOWNGRADE_THRESHOLD",  REF_IOCTL_FUNC_WITH_TUN(otRouterDowngradeThreshold) },
     { "IOCTL_OTLWF_OT_COMMISSIONER_PANID_QUERY",    REF_IOCTL_FUNC(otCommissionerPanIdQuery) },
     { "IOCTL_OTLWF_OT_COMMISSIONER_ENERGY_SCAN",    REF_IOCTL_FUNC(otCommissionerEnergyScan) },
@@ -1374,7 +1374,7 @@ otLwfIoCtl_otFactoryAssignedIeeeEui64(
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
-otLwfIoCtl_otHashMacAddress(
+otLwfIoCtl_otJoinerId(
     _In_ PMS_FILTER         pFilter,
     _In_reads_bytes_(InBufferLength)
             PUCHAR          InBuffer,
@@ -1391,9 +1391,8 @@ otLwfIoCtl_otHashMacAddress(
 
     if (*OutBufferLength >= sizeof(otExtAddress))
     {
-        otLinkGetJoinerId(pFilter->otCtx, (otExtAddress*)OutBuffer);
+        status = ThreadErrorToNtstatus(otJoinerGetId(pFilter->otCtx, (otExtAddress*)OutBuffer));
         *OutBufferLength = sizeof(otExtAddress);
-        status = STATUS_SUCCESS;
     }
     else
     {

--- a/examples/drivers/windows/otLwf/iocontrol.h
+++ b/examples/drivers/windows/otLwf/iocontrol.h
@@ -202,7 +202,7 @@ DECL_IOCTL_FUNC(otCommissionerStop);
 DECL_IOCTL_FUNC(otJoinerStart);
 DECL_IOCTL_FUNC(otJoinerStop);
 DECL_IOCTL_FUNC(otFactoryAssignedIeeeEui64);
-DECL_IOCTL_FUNC(otHashMacAddress);
+DECL_IOCTL_FUNC(otJoinerId);
 DECL_IOCTL_FUNC_WITH_TUN2(otRouterDowngradeThreshold);
 DECL_IOCTL_FUNC(otCommissionerPanIdQuery);
 DECL_IOCTL_FUNC(otCommissionerEnergyScan);

--- a/examples/drivers/windows/otNodeApi/otNodeApi.cpp
+++ b/examples/drivers/windows/otNodeApi/otNodeApi.cpp
@@ -1146,23 +1146,6 @@ OTNODEAPI uint16_t OTCALL otNodeGetAddr16(otNode* aNode)
     return result;
 }
 
-OTNODEAPI const char* OTCALL otNodeGetHashMacAddress(otNode* aNode)
-{
-    otLogFuncEntryMsg("[%d]", aNode->mId);
-    otExtAddress aHashMacAddress = {};
-    otLinkGetJoinerId(aNode->mInstance, &aHashMacAddress);
-    char* str = (char*)malloc(18);
-    if (str != nullptr)
-    {
-        aNode->mMemoryToFree.push_back(str);
-        for (int i = 0; i < 8; i++)
-            sprintf_s(str + i * 2, 18 - (2 * i), "%02x", aHashMacAddress.m8[i]);
-        printf("%d: hashmacaddr\r\n%s\r\n", aNode->mId, str);
-    }
-    otLogFuncExit();
-    return str;
-}
-
 OTNODEAPI const char* OTCALL otNodeGetAddr64(otNode* aNode)
 {
     otLogFuncEntryMsg("[%d]", aNode->mId);
@@ -1176,6 +1159,40 @@ OTNODEAPI const char* OTCALL otNodeGetAddr64(otNode* aNode)
         printf("%d: extaddr\r\n%s\r\n", aNode->mId, str);
     }
     otFreeMemory(extAddr);
+    otLogFuncExit();
+    return str;
+}
+
+OTNODEAPI const char* OTCALL otNodeGetEui64(otNode* aNode)
+{
+    otLogFuncEntryMsg("[%d]", aNode->mId);
+    otExtAddress aEui64 = {};
+    otLinkGetFactoryAssignedIeeeEui64(aNode->mInstance, &aEui64);
+    char* str = (char*)malloc(18);
+    if (str != nullptr)
+    {
+        aNode->mMemoryToFree.push_back(str);
+        for (int i = 0; i < 8; i++)
+            sprintf_s(str + i * 2, 18 - (2 * i), "%02x", aEui64.m8[i]);
+        printf("%d: eui64\r\n%s\r\n", aNode->mId, str);
+    }
+    otLogFuncExit();
+    return str;
+}
+
+OTNODEAPI const char* OTCALL otNodeGetJoinerId(otNode* aNode)
+{
+    otLogFuncEntryMsg("[%d]", aNode->mId);
+    otExtAddress aJoinerId = {};
+    otJoinerGetId(aNode->mInstance, &aJoinerId);
+    char* str = (char*)malloc(18);
+    if (str != nullptr)
+    {
+        aNode->mMemoryToFree.push_back(str);
+        for (int i = 0; i < 8; i++)
+            sprintf_s(str + i * 2, 18 - (2 * i), "%02x", aJoinerId.m8[i]);
+        printf("%d: joinerid\r\n%s\r\n", aNode->mId, str);
+    }
     otLogFuncExit();
     return str;
 }

--- a/include/openthread/commissioner.h
+++ b/include/openthread/commissioner.h
@@ -86,37 +86,37 @@ OTAPI otError OTCALL otCommissionerStop(otInstance *aInstance);
 /**
  * This function adds a Joiner entry.
  *
- * @param[in]  aInstance             A pointer to an OpenThread instance.
- * @param[in]  aExtAddress           A pointer to the Joiner's extended address or NULL for any Joiner.
- * @param[in]  aPSKd                 A pointer to the PSKd.
- * @param[in]  aTimeout              A time after which a Joiner is automatically removed, in seconds.
+ * @param[in]  aInstance          A pointer to an OpenThread instance.
+ * @param[in]  aEui64             A pointer to the Joiner's IEEE EUI-64 or NULL for any Joiner.
+ * @param[in]  aPSKd              A pointer to the PSKd.
+ * @param[in]  aTimeout           A time after which a Joiner is automatically removed, in seconds.
  *
  * @retval OT_ERROR_NONE          Successfully added the Joiner.
  * @retval OT_ERROR_NO_BUFS       No buffers available to add the Joiner.
- * @retval OT_ERROR_INVALID_ARGS  @p aExtAddress or @p aPSKd is invalid.
+ * @retval OT_ERROR_INVALID_ARGS  @p aEui64 or @p aPSKd is invalid.
  * @retval OT_ERROR_INVALID_STATE The commissioner is not active.
  *
  * @note Only use this after successfully starting the Commissioner role with otCommissionerStart().
  *
  */
-OTAPI otError OTCALL otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *aExtAddress,
+OTAPI otError OTCALL otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *aEui64,
                                              const char *aPSKd, uint32_t aTimeout);
 
 /**
  * This function removes a Joiner entry.
  *
- * @param[in]  aInstance             A pointer to an OpenThread instance.
- * @param[in]  aExtAddress           A pointer to the Joiner's extended address or NULL for any Joiner.
+ * @param[in]  aInstance          A pointer to an OpenThread instance.
+ * @param[in]  aEui64             A pointer to the Joiner's IEEE EUI-64 or NULL for any Joiner.
  *
  * @retval OT_ERROR_NONE          Successfully removed the Joiner.
- * @retval OT_ERROR_NOT_FOUND     The Joiner specified by @p aExtAddress was not found.
- * @retval OT_ERROR_INVALID_ARGS  @p aExtAddress is invalid.
+ * @retval OT_ERROR_NOT_FOUND     The Joiner specified by @p aEui64 was not found.
+ * @retval OT_ERROR_INVALID_ARGS  @p aEui64 is invalid.
  * @retval OT_ERROR_INVALID_STATE The commissioner is not active.
  *
  * @note Only use this after successfully starting the Commissioner role with otCommissionerStart().
  *
  */
-OTAPI otError OTCALL otCommissionerRemoveJoiner(otInstance *aInstance, const otExtAddress *aExtAddress);
+OTAPI otError OTCALL otCommissionerRemoveJoiner(otInstance *aInstance, const otExtAddress *aEui64);
 
 /**
  * This function sets the Provisioning URL.

--- a/include/openthread/joiner.h
+++ b/include/openthread/joiner.h
@@ -91,8 +91,9 @@ typedef void (OTCALL *otJoinerCallback)(otError aError, void *aContext);
  * @param[in]  aCallback         A pointer to a function that is called when the join operation completes.
  * @param[in]  aContext          A pointer to application-specific context.
  *
- * @retval OT_ERROR_NONE          Successfully started the Commissioner role.
- * @retval OT_ERROR_INVALID_ARGS  @p aPSKd or @p aProvisioningUrl is invalid.
+ * @retval OT_ERROR_NONE              Successfully started the Commissioner role.
+ * @retval OT_ERROR_INVALID_ARGS      @p aPSKd or @p aProvisioningUrl is invalid.
+ * @retval OT_ERROR_DISABLED_FEATURE  The Joiner feature is not enabled in this build.
  *
  */
 OTAPI otError OTCALL otJoinerStart(otInstance *aInstance, const char *aPSKd, const char *aProvisioningUrl,
@@ -104,6 +105,9 @@ OTAPI otError OTCALL otJoinerStart(otInstance *aInstance, const char *aPSKd, con
  * This function disables the Thread Joiner role.
  *
  * @param[in]  aInstance  A pointer to an OpenThread instance.
+ *
+ * @retval OT_ERROR_NONE              Successfully disabled the Joiner role.
+ * @retval OT_ERROR_DISABLED_FEATURE  The Joiner feature is not enabled in this build.
  *
  */
 OTAPI otError OTCALL otJoinerStop(otInstance *aInstance);
@@ -122,6 +126,21 @@ OTAPI otError OTCALL otJoinerStop(otInstance *aInstance);
  *
  */
 OTAPI otJoinerState OTCALL otJoinerGetState(otInstance *aInstance);
+
+/**
+ * Get the Joiner ID.
+ *
+ * Joiner ID is the first 64 bits of the result of computing SHA-256 over factory-assigned
+ * IEEE EUI-64, which is used as IEEE 802.15.4 Extended Address during commissioning process.
+ *
+ * @param[in]   aInstance  A pointer to the OpenThread instance.
+ * @param[out]  aJoinerId  A pointer to where the Joiner ID is placed.
+ *
+ * @retval OT_ERROR_NONE              Successfully retrieved the Joiner ID.
+ * @retval OT_ERROR_DISABLED_FEATURE  The Joiner feature is not enabled in this build.
+ *
+ */
+OTAPI otError OTCALL otJoinerGetId(otInstance *aInstance, otExtAddress *aJoinerId);
 
 /**
  * @}

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -213,18 +213,6 @@ OTAPI otError OTCALL otLinkSetExtendedAddress(otInstance *aInstance, const otExt
 OTAPI void OTCALL otLinkGetFactoryAssignedIeeeEui64(otInstance *aInstance, otExtAddress *aEui64);
 
 /**
- * Get the Joiner ID.
- *
- * Joiner ID is the first 64 bits of the result of computing SHA-256 over factory-assigned
- * IEEE EUI-64, which is used as IEEE 802.15.4 Extended Address during commissioning process.
- *
- * @param[in]   aInstance          A pointer to the OpenThread instance.
- * @param[out]  aHashMacAddress    A pointer to where the Hash Mac Address is placed.
- *
- */
-OTAPI void OTCALL otLinkGetJoinerId(otInstance *aInstance, otExtAddress *aHashMacAddress);
-
-/**
  * This function returns the maximum transmit power setting in dBm.
  *
  * @param[in]  aInstance   A pointer to an OpenThread instance.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -26,11 +26,11 @@ OpenThread test scripts use the CLI to execute test cases.
 * [extaddr](#extaddr)
 * [extpanid](#extpanid)
 * [factoryreset](#factoryreset)
-* [hashmacaddr](#hashmacaddr)
 * [ifconfig](#ifconfig)
 * [ipaddr](#ipaddr)
 * [ipmaddr](#ipmaddr)
 * [joiner](#joiner-start-pskd-provisioningurl)
+* [joinerid](#joinerid)
 * [joinerport](#joinerport-port)
 * [keysequence](#keysequence-counter)
 * [leaderdata](#leaderdata)
@@ -295,11 +295,11 @@ This command will cause the device to send LEAD_KA[Reject] messages.
 Done
 ```
 
-### commissioner joiner add \<hashmacaddr\> \<psdk\>
+### commissioner joiner add \<eui64\> \<psdk\>
 
 Add a Joiner entry.
 
-* hashmacaddr: The Extended Address of the Joiner or '*' to match any Joiner.
+* eui64: The IEEE EUI-64 of the Joiner or '*' to match any Joiner.
 * pskd: Pre-Shared Key for the Joiner.
 
 ```bash
@@ -307,11 +307,11 @@ Add a Joiner entry.
 Done
 ```
 
-### commissioner joiner remove \<hashmacaddr\>
+### commissioner joiner remove \<eui64\>
 
 Remove a Joiner entry.
 
-* hashmacaddr: The Extended Address of the Joiner or '*' to match any Joiner.
+* eui64: The IEEE EUI-64 of the Joiner or '*' to match any Joiner.
 
 ```bash
 > commissioner joiner remove d45e64fa83f81cf7
@@ -768,16 +768,6 @@ Delete all stored settings, and signal a platform reset.
 > factoryreset
 ```
 
-### hashmacaddr
-
-Get the HashMac address.
-
-```bash
-> hashmacaddr
-e0b220eb7d8dda7e
-Done
-```
-
 ### ifconfig
 
 Show the status of the IPv6 interface.
@@ -915,6 +905,16 @@ Stop the Joiner role.
 
 ```bash
 > joiner stop
+Done
+```
+
+### joinerid
+
+Get the Joiner ID.
+
+```bash
+> joinerid
+e0b220eb7d8dda7e
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -136,7 +136,6 @@ const struct Command Interpreter::sCommands[] =
     { "extaddr", &Interpreter::ProcessExtAddress },
     { "extpanid", &Interpreter::ProcessExtPanId },
     { "factoryreset", &Interpreter::ProcessFactoryReset },
-    { "hashmacaddr", &Interpreter::ProcessHashMacAddress },
     { "ifconfig", &Interpreter::ProcessIfconfig },
 #ifdef OTDLL
     { "instance", &Interpreter::ProcessInstance },
@@ -148,6 +147,7 @@ const struct Command Interpreter::sCommands[] =
 #endif
 #if OPENTHREAD_ENABLE_JOINER
     { "joiner", &Interpreter::ProcessJoiner },
+    { "joinerid", &Interpreter::ProcessJoinerId },
 #endif
 #if OPENTHREAD_FTD
     { "joinerport", &Interpreter::ProcessJoinerPort },
@@ -982,22 +982,6 @@ void Interpreter::ProcessFactoryReset(int argc, char *argv[])
     otInstanceFactoryReset(mInstance);
     OT_UNUSED_VARIABLE(argc);
     OT_UNUSED_VARIABLE(argv);
-}
-
-void Interpreter::ProcessHashMacAddress(int argc, char *argv[])
-{
-    otError error = OT_ERROR_NONE;
-    otExtAddress hashMacAddress;
-
-    VerifyOrExit(argc == 0, error = OT_ERROR_PARSE);
-
-    otLinkGetJoinerId(mInstance, &hashMacAddress);
-    OutputBytes(hashMacAddress.m8, OT_EXT_ADDRESS_SIZE);
-    mServer->OutputFormat("\r\n");
-
-exit:
-    OT_UNUSED_VARIABLE(argv);
-    AppendResult(error);
 }
 
 void Interpreter::ProcessIfconfig(int argc, char *argv[])
@@ -2981,6 +2965,22 @@ void Interpreter::ProcessJoiner(int argc, char *argv[])
     }
 
 exit:
+    AppendResult(error);
+}
+
+void Interpreter::ProcessJoinerId(int argc, char *argv[])
+{
+    otError error = OT_ERROR_NONE;
+    otExtAddress joinerId;
+
+    VerifyOrExit(argc == 0, error = OT_ERROR_PARSE);
+
+    otJoinerGetId(mInstance, &joinerId);
+    OutputBytes(joinerId.m8, sizeof(joinerId));
+    mServer->OutputFormat("\r\n");
+
+exit:
+    OT_UNUSED_VARIABLE(argv);
     AppendResult(error);
 }
 

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -226,7 +226,6 @@ private:
     void ProcessExtAddress(int argc, char *argv[]);
     void ProcessExtPanId(int argc, char *argv[]);
     void ProcessFactoryReset(int argc, char *argv[]);
-    void ProcessHashMacAddress(int argc, char *argv[]);
     void ProcessIfconfig(int argc, char *argv[]);
     void ProcessIpAddr(int argc, char *argv[]);
     otError ProcessIpAddrAdd(int argc, char *argv[]);
@@ -239,6 +238,7 @@ private:
 #endif
 #if OPENTHREAD_ENABLE_JOINER
     void ProcessJoiner(int argc, char *argv[]);
+    void ProcessJoinerId(int argc, char *argv[]);
 #endif  // OPENTHREAD_ENABLE_JOINER
 #if OPENTHREAD_FTD
     void ProcessJoinerPort(int argc, char *argv[]);

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -144,9 +144,10 @@ SOURCES_COMMON                      = \
     meshcop/joiner.cpp                \
     meshcop/joiner_router.cpp         \
     meshcop/leader.cpp                \
+    meshcop/meshcop.cpp               \
+    meshcop/meshcop_tlvs.cpp          \
     meshcop/panid_query_client.cpp    \
     meshcop/timestamp.cpp             \
-    meshcop/meshcop_tlvs.cpp          \
     net/dhcp6_client.cpp              \
     net/dhcp6_server.cpp              \
     net/dns_client.cpp                \
@@ -242,9 +243,9 @@ HEADERS_COMMON                      = \
     meshcop/joiner_router.hpp         \
     meshcop/leader.hpp                \
     meshcop/meshcop.hpp               \
+    meshcop/meshcop_tlvs.hpp          \
     meshcop/panid_query_client.hpp    \
     meshcop/timestamp.hpp             \
-    meshcop/meshcop_tlvs.hpp          \
     net/dhcp6.hpp                     \
     net/dhcp6_client.hpp              \
     net/dhcp6_server.hpp              \

--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -65,17 +65,17 @@ otError otCommissionerStop(otInstance *aInstance)
     return error;
 }
 
-otError otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *aExtAddress, const char *aPSKd,
+otError otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *aEui64, const char *aPSKd,
                                 uint32_t aTimeout)
 {
     otError error = OT_ERROR_DISABLED_FEATURE;
 
 #if OPENTHREAD_FTD && OPENTHREAD_ENABLE_COMMISSIONER
-    error = aInstance->mThreadNetif.GetCommissioner().AddJoiner(static_cast<const Mac::ExtAddress *>(aExtAddress), aPSKd,
+    error = aInstance->mThreadNetif.GetCommissioner().AddJoiner(static_cast<const Mac::ExtAddress *>(aEui64), aPSKd,
                                                                 aTimeout);
 #else  // OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
     OT_UNUSED_VARIABLE(aInstance);
-    OT_UNUSED_VARIABLE(aExtAddress);
+    OT_UNUSED_VARIABLE(aEui64);
     OT_UNUSED_VARIABLE(aPSKd);
     OT_UNUSED_VARIABLE(aTimeout);
 #endif // OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
@@ -83,15 +83,15 @@ otError otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *aExtA
     return error;
 }
 
-otError otCommissionerRemoveJoiner(otInstance *aInstance, const otExtAddress *aExtAddress)
+otError otCommissionerRemoveJoiner(otInstance *aInstance, const otExtAddress *aEui64)
 {
     otError error = OT_ERROR_DISABLED_FEATURE;
 
 #if OPENTHREAD_FTD && OPENTHREAD_ENABLE_COMMISSIONER
-    error = aInstance->mThreadNetif.GetCommissioner().RemoveJoiner(static_cast<const Mac::ExtAddress *>(aExtAddress), 0);
+    error = aInstance->mThreadNetif.GetCommissioner().RemoveJoiner(static_cast<const Mac::ExtAddress *>(aEui64), 0);
 #else  // OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
     OT_UNUSED_VARIABLE(aInstance);
-    OT_UNUSED_VARIABLE(aExtAddress);
+    OT_UNUSED_VARIABLE(aEui64);
 #endif // OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
 
     return error;

--- a/src/core/api/joiner_api.cpp
+++ b/src/core/api/joiner_api.cpp
@@ -50,7 +50,7 @@ otError otJoinerStart(otInstance *aInstance, const char *aPSKd, const char *aPro
     error = aInstance->mThreadNetif.GetJoiner().Start(aPSKd, aProvisioningUrl,
                                                       aVendorName, aVendorModel, aVendorSwVersion, aVendorData,
                                                       aCallback, aContext);
-#else  // OPENTHREAD_ENABLE_JOINER
+#else
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aPSKd);
     OT_UNUSED_VARIABLE(aProvisioningUrl);
@@ -60,7 +60,7 @@ otError otJoinerStart(otInstance *aInstance, const char *aPSKd, const char *aPro
     OT_UNUSED_VARIABLE(aVendorData);
     OT_UNUSED_VARIABLE(aCallback);
     OT_UNUSED_VARIABLE(aContext);
-#endif // OPENTHREAD_ENABLE_JOINER
+#endif
 
     return error;
 }
@@ -71,9 +71,9 @@ otError otJoinerStop(otInstance *aInstance)
 
 #if OPENTHREAD_ENABLE_JOINER
     error = aInstance->mThreadNetif.GetJoiner().Stop();
-#else  // OPENTHREAD_ENABLE_JOINER
+#else
     OT_UNUSED_VARIABLE(aInstance);
-#endif // OPENTHREAD_ENABLE_JOINER
+#endif
 
     return error;
 }
@@ -84,9 +84,24 @@ otJoinerState otJoinerGetState(otInstance *aInstance)
 
 #if OPENTHREAD_ENABLE_JOINER
     state = aInstance->mThreadNetif.GetJoiner().GetState();
-#else  // OPENTHREAD_ENABLE_JOINER
+#else
     OT_UNUSED_VARIABLE(aInstance);
-#endif // OPENTHREAD_ENABLE_JOINER
+#endif
 
     return state;
+}
+
+otError otJoinerGetId(otInstance *aInstance, otExtAddress *aJoinerId)
+{
+    otError error = OT_ERROR_DISABLED_FEATURE;
+
+#if OPENTHREAD_ENABLE_JOINER
+    aInstance->mThreadNetif.GetJoiner().GetJoinerId(*static_cast<Mac::ExtAddress *>(aJoinerId));
+    error = OT_ERROR_NONE;
+#else
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aJoinerId);
+#endif
+
+    return error;
 }

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -88,11 +88,6 @@ void otLinkGetFactoryAssignedIeeeEui64(otInstance *aInstance, otExtAddress *aEui
     otPlatRadioGetIeeeEui64(aInstance, aEui64->m8);
 }
 
-void otLinkGetJoinerId(otInstance *aInstance, otExtAddress *aHashMacAddress)
-{
-    aInstance->mThreadNetif.GetMac().GetHashMacAddress(static_cast<Mac::ExtAddress *>(aHashMacAddress));
-}
-
 int8_t otLinkGetMaxTransmitPower(otInstance *aInstance)
 {
     return aInstance->mThreadNetif.GetMac().GetMaxTransmitPower();

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -489,24 +489,6 @@ void Mac::SetExtAddress(const ExtAddress &aExtAddress)
     otLogFuncExit();
 }
 
-void Mac::GetHashMacAddress(ExtAddress *aHashMacAddress)
-{
-    Crypto::Sha256 sha256;
-    uint8_t buf[Crypto::Sha256::kHashSize];
-
-    otLogFuncEntry();
-
-    otPlatRadioGetIeeeEui64(&GetInstance(), buf);
-    sha256.Start();
-    sha256.Update(buf, OT_EXT_ADDRESS_SIZE);
-    sha256.Finish(buf);
-
-    memcpy(aHashMacAddress->m8, buf, OT_EXT_ADDRESS_SIZE);
-    aHashMacAddress->SetLocal(true);
-
-    otLogFuncExitMsg("%llX", HostSwap64(*reinterpret_cast<uint64_t *>(aHashMacAddress)));
-}
-
 otError Mac::SetShortAddress(ShortAddress aShortAddress)
 {
     otLogFuncEntryMsg("%d", aShortAddress);

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -367,17 +367,6 @@ public:
     void SetExtAddress(const ExtAddress &aExtAddress);
 
     /**
-     * This method gets the Hash Mac Address.
-     *
-     * Hash Mac Address is the first 64 bits of the result of computing SHA-256 over factory-assigned
-     * IEEE EUI-64, which is used as IEEE 802.15.4 Extended Address during commissioning process.
-     *
-     * @param[out]  aHashMacAddress    A pointer to where the Hash Mac Address is placed.
-     *
-     */
-    void GetHashMacAddress(ExtAddress *aHashMacAddress);
-
-    /**
      * This method returns the IEEE 802.15.4 Short Address.
      *
      * @returns The IEEE 802.15.4 Short Address.

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -92,27 +92,27 @@ public:
     /**
      * This method adds a Joiner entry.
      *
-     * @param[in]  aExtAddress      A pointer to the Joiner's extended address or NULL for any Joiner.
-     * @param[in]  aPSKd            A pointer to the PSKd.
-     * @param[in]  aTimeout         A time after which a Joiner is automatically removed, in seconds.
+     * @param[in]  aEui64        A pointer to the Joiner's IEEE EUI-64 or NULL for any Joiner.
+     * @param[in]  aPSKd         A pointer to the PSKd.
+     * @param[in]  aTimeout      A time after which a Joiner is automatically removed, in seconds.
      *
      * @retval OT_ERROR_NONE     Successfully added the Joiner.
      * @retval OT_ERROR_NO_BUFS  No buffers available to add the Joiner.
      *
      */
-    otError AddJoiner(const Mac::ExtAddress *aExtAddress, const char *aPSKd, uint32_t aTimeout);
+    otError AddJoiner(const Mac::ExtAddress *aEui64, const char *aPSKd, uint32_t aTimeout);
 
     /**
      * This method removes a Joiner entry.
      *
-     * @param[in]  aExtAddress        A pointer to the Joiner's extended address or NULL for any Joiner.
-     * @param[in]  aDelay             The delay to remove Joiner (in seconds).
+     * @param[in]  aEui64          A pointer to the Joiner's IEEE EUI-64 or NULL for any Joiner.
+     * @param[in]  aDelay          The delay to remove Joiner (in seconds).
      *
      * @retval OT_ERROR_NONE       Successfully added the Joiner.
-     * @retval OT_ERROR_NOT_FOUND  The Joiner specified by @p aExtAddress was not found.
+     * @retval OT_ERROR_NOT_FOUND  The Joiner specified by @p aEui64 was not found.
      *
      */
-    otError RemoveJoiner(const Mac::ExtAddress *aExtAddress, uint32_t aDelay);
+    otError RemoveJoiner(const Mac::ExtAddress *aEui64, uint32_t aDelay);
 
     /**
      * This method sets the Provisioning URL.
@@ -285,7 +285,7 @@ private:
 
     struct Joiner
     {
-        Mac::ExtAddress mExtAddress;
+        Mac::ExtAddress mJoinerId;
         uint32_t mExpirationTime;
         char mPsk[Dtls::kPskMaxLength + 1];
         bool mValid : 1;

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -96,8 +96,6 @@ public:
     /**
      * This function returns the Joiner State.
      *
-     * @param[in]  aInstance  A pointer to an OpenThread instance.
-     *
      * @retval OT_JOINER_STATE_IDLE
      * @retval OT_JOINER_STATE_DISCOVER
      * @retval OT_JOINER_STATE_CONNECT
@@ -107,6 +105,14 @@ public:
      *
      */
     otJoinerState GetState(void) const;
+
+    /**
+     * This method retrieves the Joiner ID.
+     *
+     * @param[out]  aJoinerId  The Joiner ID.
+     *
+     */
+    void GetJoinerId(Mac::ExtAddress &aJoinerId) const;
 
 private:
     enum

--- a/src/core/meshcop/meshcop.cpp
+++ b/src/core/meshcop/meshcop.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2016, The OpenThread Authors.
+ *  Copyright (c) 2017, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -28,47 +28,27 @@
 
 /**
  * @file
- *   This file includes definitions for MeshCoP.
- *
+ *   This file implements common MeshCoP utility functions.
  */
 
-#ifndef MESHCOP_HPP_
-#define MESHCOP_HPP_
-
-#include "openthread-core-config.h"
-
-#include "coap/coap.hpp"
-#include "common/message.hpp"
+#include "crypto/sha256.hpp"
 #include "mac/mac_frame.hpp"
 
 namespace ot {
 namespace MeshCoP {
 
-enum
+void ComputeJoinerId(const Mac::ExtAddress &aEui64, Mac::ExtAddress &aJoinerId)
 {
-    kMeshCoPMessagePriority = Message::kPriorityHigh, // The priority for MeshCoP message
-};
+    Crypto::Sha256 sha256;
+    uint8_t hash[Crypto::Sha256::kHashSize];
 
-/**
- * This function create Message for MeshCoP
- *
- */
-inline Message *NewMeshCoPMessage(Coap::CoapBase &aCoap, const Coap::Header &aHeader)
-{
-    return aCoap.NewMessage(aHeader, kMeshCoPMessagePriority);
+    sha256.Start();
+    sha256.Update(aEui64.m8, sizeof(aEui64));
+    sha256.Finish(hash);
+
+    memcpy(&aJoinerId, hash, sizeof(aJoinerId));
+    aJoinerId.SetLocal(true);
 }
 
-/**
- * This function computes the Joiner ID from a factory-assigned IEEE EUI-64.
- *
- * @param[in]   aEui64     The factory-assigned IEEE EUI-64.
- * @param[out]  aJoinerId  The Joiner ID.
- *
- */
-void ComputeJoinerId(const Mac::ExtAddress &aEui64, Mac::ExtAddress &aJoinerId);
-
 }  // namespace MeshCoP
-
 }  // namespace ot
-
-#endif  // MESHCOP_HPP_

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -52,14 +52,14 @@ bool SteeringDataTlv::IsCleared(void) const
     return rval;
 }
 
-void SteeringDataTlv::ComputeBloomFilter(const otExtAddress *aExtAddress)
+void SteeringDataTlv::ComputeBloomFilter(const otExtAddress &aJoinerId)
 {
     Crc16 ccitt(Crc16::kCcitt);
     Crc16 ansi(Crc16::kAnsi);
 
     for (size_t j = 0; j < sizeof(otExtAddress); j++)
     {
-        uint8_t byte = aExtAddress->m8[j];
+        uint8_t byte = aJoinerId.m8[j];
         ccitt.Update(byte);
         ansi.Update(byte);
     }

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -645,10 +645,10 @@ public:
     /**
      * This method computes the Bloom Filter.
      *
-     * @param[in]  aExtAddress  Extended address
+     * @param[in]  aJoinerId  The Joiner ID.
      *
      */
-    void ComputeBloomFilter(const otExtAddress *aExtAddress);
+    void ComputeBloomFilter(const otExtAddress &aJoinerId);
 
 private:
     uint8_t mSteeringData[OT_STEERING_DATA_MAX_LENGTH];

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2663,7 +2663,7 @@ otError MleRouter::SetSteeringData(const otExtAddress *aExtAddress)
     else
     {
         // Set bloom filter with the extended address passed in
-        mSteeringData.ComputeBloomFilter(aExtAddress);
+        mSteeringData.ComputeBloomFilter(*aExtAddress);
     }
 
     return error;

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -381,7 +381,7 @@ exit:
 otError NcpBase::InsertPropertyHandler_THREAD_JOINERS(void)
 {
     otError error = OT_ERROR_NONE;
-    const otExtAddress *extAddress = NULL;
+    const otExtAddress *eui64 = NULL;
     const char *aPSKd = NULL;
     uint32_t joinerTimeout = 0;
 
@@ -390,13 +390,13 @@ otError NcpBase::InsertPropertyHandler_THREAD_JOINERS(void)
     SuccessOrExit(error = mDecoder.ReadUtf8(aPSKd));
     SuccessOrExit(error = mDecoder.ReadUint32(joinerTimeout));
 
-    if (mDecoder.ReadEui64(extAddress) != OT_ERROR_NONE)
+    if (mDecoder.ReadEui64(eui64) != OT_ERROR_NONE)
     {
-        extAddress = NULL;
+        eui64 = NULL;
     }
 
 
-    error = otCommissionerAddJoiner(mInstance, extAddress, aPSKd, joinerTimeout);
+    error = otCommissionerAddJoiner(mInstance, eui64, aPSKd, joinerTimeout);
 
 exit:
     return error;

--- a/tests/scripts/thread-cert/Cert_8_1_01_Commissioning.py
+++ b/tests/scripts/thread-cert/Cert_8_1_01_Commissioning.py
@@ -61,10 +61,10 @@ class Cert_8_1_01_Commissioning(unittest.TestCase):
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'leader')
         self.nodes[COMMISSIONER].commissioner_start()
         time.sleep(3)
-        self.nodes[COMMISSIONER].commissioner_add_joiner(self.nodes[JOINER].get_hashmacaddr(), 'openthread')
+        self.nodes[COMMISSIONER].commissioner_add_joiner(self.nodes[JOINER].get_eui64(), 'OPENTHREAD')
 
         self.nodes[JOINER].interface_up()
-        self.nodes[JOINER].joiner_start('openthread')
+        self.nodes[JOINER].joiner_start('OPENTHREAD')
         time.sleep(10)
         self.assertEqual(self.nodes[JOINER].get_masterkey(), self.nodes[COMMISSIONER].get_masterkey())
 

--- a/tests/scripts/thread-cert/Cert_8_1_02_Commissioning.py
+++ b/tests/scripts/thread-cert/Cert_8_1_02_Commissioning.py
@@ -61,10 +61,10 @@ class Cert_8_1_02_Commissioning(unittest.TestCase):
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'leader')
         self.nodes[COMMISSIONER].commissioner_start()
         time.sleep(3)
-        self.nodes[COMMISSIONER].commissioner_add_joiner(self.nodes[JOINER].get_hashmacaddr(), 'openthread')
+        self.nodes[COMMISSIONER].commissioner_add_joiner(self.nodes[JOINER].get_eui64(), 'OPENTHREAD')
 
         self.nodes[JOINER].interface_up()
-        self.nodes[JOINER].joiner_start('daerhtnepo')
+        self.nodes[JOINER].joiner_start('DAERHTNEPO')
         time.sleep(10)
         self.assertNotEqual(self.nodes[JOINER].get_masterkey(), self.nodes[COMMISSIONER].get_masterkey())
 

--- a/tests/scripts/thread-cert/Cert_8_2_01_JoinerRouter.py
+++ b/tests/scripts/thread-cert/Cert_8_2_01_JoinerRouter.py
@@ -71,15 +71,15 @@ class Cert_8_2_01_JoinerRouter(unittest.TestCase):
 
         self.nodes[COMMISSIONER].commissioner_start()
         time.sleep(5)
-        self.nodes[COMMISSIONER].commissioner_add_joiner(self.nodes[JOINER_ROUTER].get_hashmacaddr(), 'openthread')
-        self.nodes[COMMISSIONER].commissioner_add_joiner(self.nodes[JOINER].get_hashmacaddr(), 'openthread2')
+        self.nodes[COMMISSIONER].commissioner_add_joiner(self.nodes[JOINER_ROUTER].get_eui64(), 'OPENTHREAD')
+        self.nodes[COMMISSIONER].commissioner_add_joiner(self.nodes[JOINER].get_eui64(), 'OPENTHREAD2')
         time.sleep(5)
 
-        self.nodes[COMMISSIONER].add_whitelist(self.nodes[JOINER_ROUTER].get_hashmacaddr())
+        self.nodes[COMMISSIONER].add_whitelist(self.nodes[JOINER_ROUTER].get_joiner_id())
         self.nodes[JOINER_ROUTER].add_whitelist(self.nodes[COMMISSIONER].get_addr64())
 
         self.nodes[JOINER_ROUTER].interface_up()
-        self.nodes[JOINER_ROUTER].joiner_start('openthread')
+        self.nodes[JOINER_ROUTER].joiner_start('OPENTHREAD')
         time.sleep(10)
         self.assertEqual(self.nodes[JOINER_ROUTER].get_masterkey(), self.nodes[COMMISSIONER].get_masterkey())
 
@@ -89,11 +89,11 @@ class Cert_8_2_01_JoinerRouter(unittest.TestCase):
         time.sleep(5)
         self.assertEqual(self.nodes[JOINER_ROUTER].get_state(), 'router')
 
-        self.nodes[JOINER_ROUTER].add_whitelist(self.nodes[JOINER].get_hashmacaddr())
+        self.nodes[JOINER_ROUTER].add_whitelist(self.nodes[JOINER].get_joiner_id())
         self.nodes[JOINER].add_whitelist(self.nodes[JOINER_ROUTER].get_addr64())
 
         self.nodes[JOINER].interface_up()
-        self.nodes[JOINER].joiner_start('openthread2')
+        self.nodes[JOINER].joiner_start('OPENTHREAD2')
         time.sleep(10)
         self.assertEqual(self.nodes[JOINER].get_masterkey(), self.nodes[COMMISSIONER].get_masterkey())
 

--- a/tests/scripts/thread-cert/Cert_8_2_02_JoinerRouter.py
+++ b/tests/scripts/thread-cert/Cert_8_2_02_JoinerRouter.py
@@ -71,15 +71,15 @@ class Cert_8_2_02_JoinerRouter(unittest.TestCase):
 
         self.nodes[COMMISSIONER].commissioner_start()
         time.sleep(5)
-        self.nodes[COMMISSIONER].commissioner_add_joiner(self.nodes[JOINER_ROUTER].get_hashmacaddr(), 'openthread')
-        self.nodes[COMMISSIONER].commissioner_add_joiner(self.nodes[JOINER].get_hashmacaddr(), 'openthread2')
+        self.nodes[COMMISSIONER].commissioner_add_joiner(self.nodes[JOINER_ROUTER].get_eui64(), 'OPENTHREAD')
+        self.nodes[COMMISSIONER].commissioner_add_joiner(self.nodes[JOINER].get_eui64(), 'OPENTHREAD2')
         time.sleep(5)
 
-        self.nodes[COMMISSIONER].add_whitelist(self.nodes[JOINER_ROUTER].get_hashmacaddr())
+        self.nodes[COMMISSIONER].add_whitelist(self.nodes[JOINER_ROUTER].get_joiner_id())
         self.nodes[JOINER_ROUTER].add_whitelist(self.nodes[COMMISSIONER].get_addr64())
 
         self.nodes[JOINER_ROUTER].interface_up()
-        self.nodes[JOINER_ROUTER].joiner_start('openthread')
+        self.nodes[JOINER_ROUTER].joiner_start('OPENTHREAD')
         time.sleep(10)
         self.assertEqual(self.nodes[JOINER_ROUTER].get_masterkey(), self.nodes[COMMISSIONER].get_masterkey())
 
@@ -89,11 +89,11 @@ class Cert_8_2_02_JoinerRouter(unittest.TestCase):
         time.sleep(5)
         self.assertEqual(self.nodes[JOINER_ROUTER].get_state(), 'router')
 
-        self.nodes[JOINER_ROUTER].add_whitelist(self.nodes[JOINER].get_hashmacaddr())
+        self.nodes[JOINER_ROUTER].add_whitelist(self.nodes[JOINER].get_joiner_id())
         self.nodes[JOINER].add_whitelist(self.nodes[JOINER_ROUTER].get_addr64())
 
         self.nodes[JOINER].interface_up()
-        self.nodes[JOINER].joiner_start('2daerhtnepo')
+        self.nodes[JOINER].joiner_start('2DAERHTNEPO')
         time.sleep(10)
         self.assertNotEqual(self.nodes[JOINER].get_masterkey(), self.nodes[COMMISSIONER].get_masterkey())
 

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -107,8 +107,11 @@ class Node:
     def get_addr64(self):
         return self.interface.get_addr64()
 
-    def get_hashmacaddr(self):
-        return self.interface.get_hashmacaddr()
+    def get_eui64(self):
+        return self.interface.get_eui64()
+
+    def get_joiner_id(self):
+        return self.interface.get_joiner_id()
 
     def get_channel(self):
         return self.interface.get_channel()

--- a/tests/scripts/thread-cert/node_api.py
+++ b/tests/scripts/thread-cert/node_api.py
@@ -100,8 +100,11 @@ class otApi:
     def get_addr64(self):
         return self.Api.otNodeGetAddr64(self.otNode).decode('utf-8')
 
-    def get_hashmacaddr(self):
-        return self.Api.otNodeGetHashMacAddress(self.otNode).decode('utf-8')
+    def get_eui64(self):
+        return self.Api.otNodeGetEui64(self.otNode).decode('utf-8')
+
+    def get_joiner_id(self):
+        return self.Api.otNodeGetJoinerId(self.otNode).decode('utf-8')
 
     def get_channel(self):
         return self.Api.otNodeGetChannel(self.otNode)
@@ -420,10 +423,13 @@ class otApi:
         
         self.Api.otNodeGetAddr64.argtypes = [ctypes.c_void_p]
         self.Api.otNodeGetAddr64.restype = ctypes.c_char_p
-        
-        self.Api.otNodeGetHashMacAddress.argtypes = [ctypes.c_void_p]
-        self.Api.otNodeGetHashMacAddress.restype = ctypes.c_char_p
 
+        self.Api.otNodeGetEui64.argtypes = [ctypes.c_void_p]
+        self.Api.otNodeGetEui64.restype = ctypes.c_char_p
+
+        self.Api.otNodeGetJoinerId.argtypes = [ctypes.c_void_p]
+        self.Api.otNodeGetJoinerId.restype = ctypes.c_char_p
+        
         self.Api.otNodeSetChannel.argtypes = [ctypes.c_void_p, 
                                               ctypes.c_ubyte]
         

--- a/tests/scripts/thread-cert/node_cli.py
+++ b/tests/scripts/thread-cert/node_cli.py
@@ -201,8 +201,17 @@ class otCli:
         self.pexpect.expect('Done')
         return addr64
 
-    def get_hashmacaddr(self):
-        self.send_command('hashmacaddr')
+    def get_eui64(self):
+        self.send_command('eui64')
+        i = self.pexpect.expect('([0-9a-fA-F]{16})')
+        if i == 0:
+            addr64 = self.pexpect.match.groups()[0].decode("utf-8")
+
+        self.pexpect.expect('Done')
+        return addr64
+
+    def get_joiner_id(self):
+        self.send_command('joinerid')
         i = self.pexpect.expect('([0-9a-fA-F]{16})')
         if i == 0:
             addr = self.pexpect.match.groups()[0].decode("utf-8")

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -756,7 +756,7 @@ class OpenThread(IThci):
             if bType == MacType.FactoryMac:
                 macAddr64 = self.__sendCommand('eui64')[0]
             elif bType == MacType.HashMac:
-                macAddr64 = self.__sendCommand('hashmacaddr')[0]
+                macAddr64 = self.__sendCommand('joinerid')[0]
             else:
                 macAddr64 = self.__sendCommand('extaddr')[0]
         print macAddr64
@@ -1964,16 +1964,21 @@ class OpenThread(IThci):
             False: fail to add Joiner's steering data
         """
         print '%s call scanJoiner' % self.port
-        if xEUI == '*':
-            JoinerHashMac = '*'
-        else:
-            JoinerAddr = ModuleHelper.CalculateHashMac(xEUI)
-            JoinerHashMac = hex(int(JoinerAddr)).rstrip("L").lstrip("0x")
 
         # long timeout value to avoid automatic joiner removal (in seconds)
         timeout = 500
 
-        cmd = 'commissioner joiner add %s %s %s' % (JoinerHashMac, strPSKd, str(timeout))
+        if not isinstance(xEUI, str):
+            eui64 = self.__convertLongToString(xEUI)
+
+            # prepend 0 at the beginning
+            if len(eui64) < 16:
+                eui64 = eui64.zfill(16)
+                print eui64
+        else:
+            eui64 = xEUI
+
+        cmd = 'commissioner joiner add %s %s %s' % (eui64, strPSKd, str(timeout))
         print cmd
         if self.__sendCommand(cmd)[0] == 'Done':
             if self.logThreadStatus == self.logStatus['stop']:


### PR DESCRIPTION
Resolves #2254.