### PR TITLE
[cert] THCI: only record commissioning log during 'joining' status

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -521,7 +521,11 @@ class OpenThread(IThci):
         t_end = time.time() + durationInSeconds
         while time.time() < t_end:
             time.sleep(0.3)
-            if self.logThreadStatus == self.logStatus['paused']:
+
+            if self.logThreadStatus == self.logStatus['pauseReq']:
+                self.logThreadStatus = self.logStatus['paused']
+
+            if self.logThreadStatus != self.logStatus['running']:
                 continue
 
             try:
@@ -532,14 +536,13 @@ class OpenThread(IThci):
 
                     if "Join success" in line:
                         self.joinCommissionedStatus = self.joinStatus['succeed']
+                        break
                     elif "Join failed" in line:
                         self.joinCommissionedStatus = self.joinStatus['failed']
+                        break
 
             except Exception:
                 pass
-
-            if self.logThreadStatus == self.logStatus['pauseReq']:
-                self.logThreadStatus = self.logStatus['paused']
 
         self.logThreadStatus = self.logStatus['stop']
         return logs


### PR DESCRIPTION
Fix the abnormal logging in Test Harness Command Window for 8.x tests when TH's resetting device with the default values after each run. It is caused by the competition of serial data reading by _readCommissioningLogs() and __sendCommand().

This issue doesn't impact the test, while this PR is just to ensure expecting logging in TH for 8.x.