### PR TITLE
[tests] fix the unstable Cert_5_6_07

### DIFF
--- a/tests/scripts/thread-cert/Cert_5_6_07_NetworkDataRequestREED.py
+++ b/tests/scripts/thread-cert/Cert_5_6_07_NetworkDataRequestREED.py
@@ -89,7 +89,7 @@ class Cert_5_6_7_NetworkDataRequestREED(unittest.TestCase):
         self.nodes[LEADER].add_whitelist(self.nodes[REED].get_addr64())
         self.nodes[REED].add_whitelist(self.nodes[LEADER].get_addr64())
 
-        time.sleep(10)
+        time.sleep(35)
 
         addrs = self.nodes[REED].get_addrs()
         self.assertTrue(any('2001:2:0:3' in addr[0:10] for addr in addrs))


### PR DESCRIPTION
Multicast Network Data Response might already have finished in 2s after prefix register. So after restoring the link between Leader and REED, the only way for REED to know there is new Network Data is from the MLE advertisement from Leader. Extending waiting time here may help to stabilize this test.