### PR TITLE
[nRF52840] remove __aeabi_assert definition from platform

### DIFF
--- a/examples/platforms/nrf52840/platform.c
+++ b/examples/platforms/nrf52840/platform.c
@@ -94,14 +94,3 @@ __WEAK void PlatformEventSignalPending(void)
 {
     // Intentionally empty
 }
-
-#if defined(__CC_ARM)
-__WEAK void __aeabi_assert(const char *aExpr, const char *aFile, int aLine)
-{
-    (void) aExpr;
-    (void) aFile;
-    (void) aLine;
-
-    while (1);
-}
-#endif


### PR DESCRIPTION
We've decided not to keep assert definition for Keil within platform library.