### PR TITLE
[posix] clear pending alarms in posix platform which could persist execve call

### DIFF
--- a/examples/platforms/posix/misc.c
+++ b/examples/platforms/posix/misc.c
@@ -55,6 +55,8 @@ void otPlatReset(otInstance *aInstance)
     platformRadioDeinit();
     platformUartRestore();
 
+    alarm(0);
+
     execvp(argv[0], argv);
     perror("reset failed");
     exit(EXIT_FAILURE);


### PR DESCRIPTION
When embedding OpenThread CLI in more complex application, it is possible that the application will do utilize `alarm()` or `setitimer()` calls, which cause `SIGALRM` to be delivered to the application with specified delay. For example, linux port of FreeRTOS uses that to implement kernel ticks. Calling `execve` in `otPlatReset()` breaks/conflicts with this behavior: `SIGALRM` handler is being cleared, but the timer itself is not.

So, the resulting situation is that the signal will be delivered to the new application, which might have not set up its own `SIGALRM` handler yet (specifically FreeRTOS sets 1 millisecond ticks) - resulting in the whole process to be killed by system due to unhandled signal.

That accumulates into bigger problems with `wpantund`, which in such situation does break as well, when `reset` is being called from `wpanctl`.

This fix makes `otPlatReset` to perform more thorough and clean reset. 