### PR TITLE
[mle] Periodic Parent Search feature

### DIFF
--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -856,7 +856,7 @@
  *
  */
 #ifndef OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER
-#define OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER    0
+#define OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER            0
 #endif
 
 /**
@@ -968,6 +968,64 @@
  */
 #ifndef OPENTHREAD_CONFIG_INFORM_PREVIOUS_PARENT_ON_REATTACH
 #define OPENTHREAD_CONFIG_INFORM_PREVIOUS_PARENT_ON_REATTACH    0
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_ENABLE_PERIODIC_PARENT_SEARCH
+ *
+ * Define as 1 to enable periodic parent search feature.
+ *
+ * When this feature is enabled an end-device/child (while staying attached) will periodically search for a possible
+ * better parent and will switch parent if a better one is found.
+ *
+ * The child will periodically check the average RSS value for the current parent, and only if it is below a specific
+ * threshold, a parent search is performed. The `OPENTHREAD_CONFIG_PARENT_SEARCH_CHECK_INTERVAL` specifies the the
+ * check interval (in seconds) and `OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_THRESHOLD` gives the RSS threshold.
+ *
+ * Since the parent search process can be power consuming (child needs to stays in RX mode to collect parent response)
+ * and to limit its impact on battery-powered devices, after a parent search is triggered, the child will not trigger
+ * another one before a specified backoff interval specified by `OPENTHREAD_CONFIG_PARENT_SEARCH_BACKOFF_INTERVAL`
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ENABLE_PERIODIC_PARENT_SEARCH
+#define OPENTHREAD_CONFIG_ENABLE_PERIODIC_PARENT_SEARCH         0
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_PARENT_SEARCH_CHECK_INTERVAL
+ *
+ * Specifies the interval in seconds for a child to check the trigger condition to perform a parent search.
+ *
+ * Applicable only if periodic parent search feature is enabled (see `OPENTHREAD_CONFIG_ENABLE_PERIODIC_PARENT_SEARCH`).
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_PARENT_SEARCH_CHECK_INTERVAL
+#define OPENTHREAD_CONFIG_PARENT_SEARCH_CHECK_INTERVAL          (9 * 60)
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_PARENT_SEARCH_BACKOFF_INTERVAL
+ *
+ * Specifies the backoff interval in seconds for a child to not perform a parent search after triggering one.
+ *
+ * Applicable only if periodic parent search feature is enabled (see `OPENTHREAD_CONFIG_ENABLE_PERIODIC_PARENT_SEARCH`).
+ *
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_PARENT_SEARCH_BACKOFF_INTERVAL
+#define OPENTHREAD_CONFIG_PARENT_SEARCH_BACKOFF_INTERVAL        (10* 60 * 60)
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_THRESHOLD
+ *
+ * Specifies the RSS threshold used to trigger a parent search.
+ *
+ * Applicable only if periodic parent search feature is enabled (see `OPENTHREAD_CONFIG_ENABLE_PERIODIC_PARENT_SEARCH`).
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_THRESHOLD
+#define OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_THRESHOLD           -65
 #endif
 
 /**

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1394,6 +1394,17 @@ private:
         kMleHopLimit        = 255,
     };
 
+#if OPENTHREAD_CONFIG_ENABLE_PERIODIC_PARENT_SEARCH
+    enum
+    {
+        // All timer intervals are converted to milliseconds
+        kParentSearchCheckInterval   = (OPENTHREAD_CONFIG_PARENT_SEARCH_CHECK_INTERVAL * 1000u),
+        kParentSearchBackoffInterval = (OPENTHREAD_CONFIG_PARENT_SEARCH_BACKOFF_INTERVAL * 1000u),
+        kParentSearchJitterInterval  = (15 * 1000u),
+        kParentSearchRssThreadhold   = OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_THRESHOLD,
+    };
+#endif
+
     void GenerateNonce(const Mac::ExtAddress &aMacAddr, uint32_t aFrameCounter, uint8_t aSecurityLevel,
                        uint8_t *aNonce);
 
@@ -1441,6 +1452,13 @@ private:
     otError InformPreviousParent(void);
 #endif
 
+#if OPENTHREAD_CONFIG_ENABLE_PERIODIC_PARENT_SEARCH
+    static void HandleParentSearchTimer(Timer &aTimer);
+    void HandleParentSearchTimer(void);
+    void StartParentSearchTimer(void);
+    void UpdateParentSearchState(void);
+#endif
+
     MessageQueue mDelayedResponses;
 
     struct
@@ -1478,6 +1496,14 @@ private:
 
 #if OPENTHREAD_CONFIG_INFORM_PREVIOUS_PARENT_ON_REATTACH
     uint16_t mPreviousParentRloc;
+#endif
+
+#if OPENTHREAD_CONFIG_ENABLE_PERIODIC_PARENT_SEARCH
+    bool mParentSearchIsInBackoff        : 1;
+    bool mParentSearchBackoffWasCanceled : 1;
+    bool mParentSearchRecentlyDetached   : 1;
+    uint32_t mParentSearchBackoffCancelTime;
+    TimerMilli mParentSearchTimer;
 #endif
 
     uint8_t mAnnounceChannel;


### PR DESCRIPTION
This commit implements a "Periodic Parent Search" feature in MLE.
This feature is disabled by default and can be enabled through
`OPENTHREAD_CONFIG_ENABLE_PERIODIC_PARENT_SEARCH` configuration
option.

When enabled, an end-device/child (while staying attached) will
periodically search for a possible better parent and will switch
if it finds a better one.

The child will periodically check the average RSS value for the
current parent, and only if it is below a specific threshold, a
parent search is performed. Since the parent search process can be
power consuming (child needs to stays in RX mode to collect parent
response) and to limit its impact on battery-powered devices, after a
parent search is triggered, the child will not trigger another one
before a specified longer backoff interval. The check and backoff
intervals along with the RSS threshold used to trigger the parent
search can be set from a set of configuration options.