### PR TITLE
[docs] adding missing parameter documentation

### DIFF
--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -488,6 +488,8 @@ typedef void (*otThreadChildTableCallback)(otThreadChildTableEvent aEvent, const
 /**
  * This function gets the child table callback function.
  *
+ * @param[in] aInstance  A pointer to an OpenThread instance.
+ *
  * @returns  The callback function pointer.
  *
  */
@@ -500,7 +502,8 @@ otThreadChildTableCallback otThreadGetChildTableCallback(otInstance *aInstance);
  * table. Subsequent calls to this method will overwrite the previous callback. Note that this callback in invoked
  * while the child table is being updated and always before the `otStateChangedCallback`.
  *
- * @param[in] aCallback                  A pointer to callback handler function.
+ * @param[in] aInstance  A pointer to an OpenThread instance.
+ * @param[in] aCallback  A pointer to callback handler function.
  *
  */
 void otThreadSetChildTableCallback(otInstance *aInstance, otThreadChildTableCallback aCallback);

--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -871,6 +871,9 @@ typedef struct otServiceConfig
      */
     uint8_t mServiceData[kMaxServiceDataSize];
 
+    /**
+     * The Server configuration.
+     */
     otServerConfig mServerConfig;
 } otServiceConfig;
 


### PR DESCRIPTION
Some missing parameter documentation was flagged when updating the reference on openthread.io