### PR TITLE
[mle] suppress Data Response when trying to update network data

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3075,9 +3075,15 @@ otError MleRouter::SendDataResponse(const Ip6::Address &aDestination, const uint
                                     uint16_t aDelay)
 {
     otError error = OT_ERROR_NONE;
-    Message *message;
+    Message *message = NULL;
     Neighbor *neighbor;
     bool stableOnly;
+
+    if (mRetrieveNewNetworkData)
+    {
+        otLogInfoMle(GetInstance(), "Suppressing Data Response - waiting for new network data");
+        ExitNow();
+    }
 
     VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandDataResponse));


### PR DESCRIPTION
There may be short windows where a device does not have the proper Thread
Network Data.  For example, when a device is coming out of reset and
resynchronizing with the rest of the network.

This commit suppresses MLE Data Response transmissions while the device is
trying to receive the latest Thread Network Data from a neighbor.  This
eliminates the possibility that the device may propagate inconsistent
Thread Network Data.

This commit fixes spurious failures in Cert_9_2_15_PendingPartition.py.