### PR TITLE
[radio] change radio API to support more advanced transmit power configs

### DIFF
--- a/doc/spinel-protocol-src/spinel-prop-core.md
+++ b/doc/spinel-protocol-src/spinel-prop-core.md
@@ -465,7 +465,7 @@ The frame metadata field consists of the following fields:
 
  Field   | Description                  | Type       | Len   | Default
 :--------|:-----------------------------|:-----------|-------|----------
-MD_POWER | (dBm) RSSI/TX-Power          | `c` int8   | 1     | -128
+MD_RSSI  | (dBm) RSSI                   | `c` int8   | 1     | -128
 MD_NOISE | (dBm) Noise floor            | `c` int8   | 1     | -128
 MD_FLAG  | Flags (defined below)        | `S` uint16 | 2     |
 MD_PHY   | PHY-specific data            | `d` data   | >=2   |
@@ -476,11 +476,6 @@ the host:
 
 * MD_NOISE
 * MD_FLAG
-
-When specifying `MD_POWER` for a packet to be transmitted, the actual
-transmit power is never larger than the current value of `PROP_PHY_TX_POWER`
-((#prop-phy-tx-power)). When left unspecified (or set to the value -128),
-an appropriate transmit power will be chosen by the NCP.
 
 The bit values in `MD_FLAG` are defined as follows:
 

--- a/doc/spinel-protocol-src/spinel-prop-phy.md
+++ b/doc/spinel-protocol-src/spinel-prop-phy.md
@@ -46,7 +46,7 @@ that is supported by the underlying radio hardware.
 
 ### PROP 37: PROP_PHY_TX_POWER {#prop-phy-tx-power}
 * Type: Read-Write
-* Packed-Encoding: `c` (int8)
+* Packed-Encoding: `L` (uint32)
 * Unit: dBm
 
 Value is the transmit power of the radio.

--- a/examples/drivers/windows/otApi/otApi.cpp
+++ b/examples/drivers/windows/otApi/otApi.cpp
@@ -1654,13 +1654,13 @@ otThreadSetPSKc(
 }
 
 OTAPI 
-int8_t 
+uint32_t 
 OTCALL
-otLinkGetMaxTransmitPower(
+otLinkGetTransmitPower(
     _In_ otInstance *aInstance
     )
 {
-    int8_t Result = 0;
+    uint32_t Result = 0;
     if (aInstance) (void)QueryIOCTL(aInstance, IOCTL_OTLWF_OT_MAX_TRANSMIT_POWER, &Result);
     return Result;
 }
@@ -1668,9 +1668,9 @@ otLinkGetMaxTransmitPower(
 OTAPI 
 void 
 OTCALL
-otLinkSetMaxTransmitPower(
+otLinkSetTransmitPower(
     _In_ otInstance *aInstance, 
-    int8_t aPower
+    uint32_t aPower
     )
 {
     if (aInstance) (void)SetIOCTL(aInstance, IOCTL_OTLWF_OT_MAX_TRANSMIT_POWER, aPower);

--- a/examples/drivers/windows/otLwf/command.c
+++ b/examples/drivers/windows/otLwf/command.c
@@ -956,7 +956,7 @@ otLwfCmdSendMacFrameAsync(
             Packet->mPsdu,
             (uint32_t)Packet->mLength,
             Packet->mChannel,
-            Packet->mPower
+            Packet->mRssi
             );
     if (!NT_SUCCESS(status))
     {

--- a/examples/drivers/windows/otLwf/eventprocessing.c
+++ b/examples/drivers/windows/otLwf/eventprocessing.c
@@ -1019,7 +1019,7 @@ otLwfEventWorkerThread(
                             SPINEL_DATATYPE_STRUCT_S( // Vendor-data
                                 SPINEL_DATATYPE_UINT_PACKED_S
                             ),
-                            &pFilter->otReceiveFrame.mPower,
+                            &pFilter->otReceiveFrame.mRssi,
                             &noiseFloor,
                             &flags,
                             &pFilter->otReceiveFrame.mChannel,

--- a/examples/drivers/windows/otLwf/iocontrol.c
+++ b/examples/drivers/windows/otLwf/iocontrol.c
@@ -4798,16 +4798,16 @@ otLwfIoCtl_otMaxTransmitPower(
 {
     NTSTATUS status = STATUS_INVALID_PARAMETER;
 
-    if (InBufferLength >= sizeof(int8_t))
+    if (InBufferLength >= sizeof(uint32_t))
     {
-        otLinkSetMaxTransmitPower(pFilter->otCtx, *(int8_t*)InBuffer);
+        otLinkSetTransmitPower(pFilter->otCtx, *(uint32_t*)InBuffer);
         status = STATUS_SUCCESS;
         *OutBufferLength = 0;
     }
-    else if (*OutBufferLength >= sizeof(int8_t))
+    else if (*OutBufferLength >= sizeof(uint32_t))
     {
-        *(int8_t*)OutBuffer = otLinkGetMaxTransmitPower(pFilter->otCtx);
-        *OutBufferLength = sizeof(int8_t);
+        *(uint32_t*)OutBuffer = otLinkGetTransmitPower(pFilter->otCtx);
+        *OutBufferLength = sizeof(uint32_t);
         status = STATUS_SUCCESS;
     }
     else

--- a/examples/drivers/windows/otLwf/radio.c
+++ b/examples/drivers/windows/otLwf/radio.c
@@ -802,7 +802,7 @@ error:
     return NT_SUCCESS(status) ? OT_ERROR_NONE : OT_ERROR_FAILED;
 }
 
-void otPlatRadioSetDefaultTxPower(_In_ otInstance *otCtx, int8_t aPower)
+void otPlatRadioSetTransmitPower(_In_ otInstance *otCtx, uint32_t aPower)
 {
     NT_ASSERT(otCtx);
     PMS_FILTER pFilter = otCtxToFilter(otCtx);
@@ -813,7 +813,7 @@ void otPlatRadioSetDefaultTxPower(_In_ otInstance *otCtx, int8_t aPower)
         otLwfCmdSetProp(
             pFilter,
             SPINEL_PROP_PHY_TX_POWER,
-            SPINEL_DATATYPE_INT8_S,
+            SPINEL_DATATYPE_UINT32_S,
             aPower
         );
     if (!NT_SUCCESS(status))

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -356,7 +356,7 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
         }
 
         setChannel(aFrame->mChannel);
-        setTxPower(aFrame->mPower);
+        setTxPower(aFrame->mRssi);
 
         while ((HWREG(RFCORE_XREG_FSMSTAT1) & 1) == 0);
 
@@ -446,7 +446,7 @@ void readFrame(void)
         sReceiveFrame.mPsdu[i] = HWREG(RFCORE_SFR_RFDATA);
     }
 
-    sReceiveFrame.mPower = (int8_t)HWREG(RFCORE_SFR_RFDATA) - CC2538_RSSI_OFFSET;
+    sReceiveFrame.mRssi = (int8_t)HWREG(RFCORE_SFR_RFDATA) - CC2538_RSSI_OFFSET;
     crcCorr = HWREG(RFCORE_SFR_RFDATA);
 
     if (crcCorr & CC2538_CRC_BIT_MASK)
@@ -840,7 +840,7 @@ otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint1
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+void otPlatRadioSetTransmitPower(otInstance *aInstance, uint32_t aPower)
 {
     // TODO: Create a proper implementation for this driver.
     (void)aInstance;

--- a/examples/platforms/cc2650/radio.c
+++ b/examples/platforms/cc2650/radio.c
@@ -1219,15 +1219,17 @@ exit:
 /**
  * Function documented in platform/radio.h
  */
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+void otPlatRadioSetTransmitPower(otInstance *aInstance, uint32_t aPower)
 {
     unsigned int i;
     output_config_t const *powerCfg = &(rgOutputPower[0]);
     (void)aInstance;
 
+    int8_t power = (int8_t)aPower;
+
     for (i = 1; i < OUTPUT_CONFIG_COUNT; i++)
     {
-        if (rgOutputPower[i].dbm >= aPower)
+        if (rgOutputPower[i].dbm >= power)
         {
             powerCfg = &(rgOutputPower[i]);
         }
@@ -1803,7 +1805,7 @@ static void cc2650RadioProcessReceiveQueue(otInstance *aInstance)
                 receiveFrame.mLength  = len;
                 receiveFrame.mPsdu    = &(payload[1]);
                 receiveFrame.mChannel = sReceiveCmd.channel;
-                receiveFrame.mPower   = rssi;
+                receiveFrame.mRssi    = rssi;
                 receiveFrame.mLqi     = crcCorr->status.corr;
 
                 receiveError = OT_ERROR_NONE;

--- a/examples/platforms/cc2652/radio.c
+++ b/examples/platforms/cc2652/radio.c
@@ -1228,15 +1228,17 @@ exit:
 /**
  * Function documented in platform/radio.h
  */
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+void otPlatRadioSetTransmitPower(otInstance *aInstance, uint32_t aPower)
 {
     unsigned int i;
     output_config_t const *powerCfg = &(rgOutputPower[0]);
     (void)aInstance;
 
+    int8_t power = (int8_t)aPower;
+
     for (i = 1; i < OUTPUT_CONFIG_COUNT; i++)
     {
-        if (rgOutputPower[i].dbm >= aPower)
+        if (rgOutputPower[i].dbm >= power)
         {
             powerCfg = &(rgOutputPower[i]);
         }
@@ -1815,7 +1817,7 @@ static void cc2652RadioProcessReceiveQueue(otInstance *aInstance)
                 receiveFrame.mLength  = len;
                 receiveFrame.mPsdu    = &(payload[1]);
                 receiveFrame.mChannel = sReceiveCmd.channel;
-                receiveFrame.mPower   = rssi;
+                receiveFrame.mRssi    = rssi;
                 receiveFrame.mLqi     = crcCorr->status.corr;
 
                 receiveError = OT_ERROR_NONE;

--- a/examples/platforms/da15000/radio.c
+++ b/examples/platforms/da15000/radio.c
@@ -531,13 +531,15 @@ otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint1
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+void otPlatRadioSetTransmitPower(otInstance *aInstance, uint32_t aPower)
 {
+    int8_t power = (int8_t)aPower;
+
     (void)aInstance;
 
-    otLogInfoPlat(sInstance, "Set DefaultTxPower: %d", aPower);
+    otLogInfoPlat(sInstance, "Set TransmitPower: %d", power);
 
-    FTDF_setValue(FTDF_PIB_TX_POWER, &aPower);
+    FTDF_setValue(FTDF_PIB_TX_POWER, &power);
 }
 
 void da15000RadioProcess(otInstance *aInstance)
@@ -656,7 +658,7 @@ void FTDF_rcvFrameTransparent(FTDF_DataLength frameLength,
         sReceiveFrame[sWriteFrame].mChannel   = sChannel;
         sReceiveFrame[sWriteFrame].mLength    = frameLength;
         sReceiveFrame[sWriteFrame].mLqi       = lqi;
-        sReceiveFrame[sWriteFrame].mPower     = otPlatRadioGetRssi(sThreadInstance);
+        sReceiveFrame[sWriteFrame].mRssi      = otPlatRadioGetRssi(sThreadInstance);
         memcpy(sReceiveFrame[sWriteFrame].mPsdu, frame, frameLength);
 
         sWriteFrame = (sWriteFrame + 1) % RADIO_FRAMES_BUFFER_SIZE;

--- a/examples/platforms/efr32/radio.c
+++ b/examples/platforms/efr32/radio.c
@@ -337,7 +337,7 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
     txOption.removeCrc  = false;
     txOption.syncWordId = 0;
 
-    RAIL_TxPowerSet(aFrame->mPower);
+    RAIL_TxPowerSet((int8_t)aFrame->mTxPowerConfig);
     setChannel(aFrame->mChannel);
     RAIL_RfIdleExt(RAIL_IDLE, true);
 
@@ -695,7 +695,7 @@ void RAILCb_RxPacketReceived(void *aRxPacketHandle)
 #endif
 
     memcpy(sReceiveFrame.mPsdu, rxPacketInfo->dataPtr + 1, rxPacketInfo->dataLength);
-    sReceiveFrame.mPower = rxPacketInfo->appendedInfo.rssiLatch;
+    sReceiveFrame.mRssi = rxPacketInfo->appendedInfo.rssiLatch;
     sReceiveFrame.mLqi = rxPacketInfo->appendedInfo.lqi;
     sReceiveFrame.mLength = length;
     sReceiveError = OT_ERROR_NONE;
@@ -844,10 +844,10 @@ void RAILCb_FreeMemory(void *aHandle)
     (void)aHandle;
 }
 
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+void otPlatRadioSetTransmitPower(otInstance *aInstance, uint32_t aPower)
 {
     (void)aInstance;
-    RAIL_TxPowerSet(aPower);
+    RAIL_TxPowerSet((int8_t)(aPower);
 }
 
 int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)

--- a/examples/platforms/emsk/radio.c
+++ b/examples/platforms/emsk/radio.c
@@ -472,7 +472,7 @@ void readFrame(void)
     /* Read PSDU */
     memcpy(sReceiveFrame.mPsdu, readBuffer, length - 2);
 
-    sReceiveFrame.mPower = (int8_t)(readRssi / MRF24J40_RSSI_SLOPE) - MRF24J40_RSSI_OFFSET;
+    sReceiveFrame.mRssi = (int8_t)(readRssi / MRF24J40_RSSI_SLOPE) - MRF24J40_RSSI_OFFSET;
     sReceiveFrame.mLength = (uint8_t) length;
     sReceiveFrame.mLqi = readPlqi;
 
@@ -675,7 +675,7 @@ otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint1
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+void otPlatRadioSetTransmitPower(otInstance *aInstance, uint32_t aPower)
 {
     // TODO: Create a proper implementation for this driver.
     (void)aInstance;

--- a/examples/platforms/gp712/radio.c
+++ b/examples/platforms/gp712/radio.c
@@ -219,7 +219,7 @@ void cbQorvoRadioReceiveDone(otRadioFrame *aPacket, otError aError)
 {
     if (aError == OT_ERROR_NONE)
     {
-        sLastReceivedPower = aPacket->mPower;
+        sLastReceivedPower = aPacket->mRssi;
     }
 
     otPlatRadioReceiveDone(pQorvoInstance, aPacket, aError);
@@ -314,7 +314,7 @@ void cbQorvoRadioEnergyScanDone(int8_t aEnergyScanMaxRssi)
 }
 
 
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+void otPlatRadioSetTransmitPower(otInstance *aInstance, uint32_t aPower)
 {
     // TODO: Create a proper implementation for this driver.
     (void)aInstance;

--- a/examples/platforms/kw41z/radio.c
+++ b/examples/platforms/kw41z/radio.c
@@ -346,7 +346,7 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
     }
 
     rf_set_channel(aFrame->mChannel);
-    rf_set_tx_power(aFrame->mPower);
+    rf_set_tx_power((int8_t)aFrame->mTxPowerConfig);
 
     *(uint8_t *)ZLL->PKT_BUFFER_TX = aFrame->mLength;
 
@@ -462,11 +462,11 @@ exit:
     return status;
 }
 
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+void otPlatRadioSetTransmitPower(otInstance *aInstance, uint32_t aPower)
 {
     (void)aInstance;
 
-    sAutoTxPwrLevel = aPower;
+    sAutoTxPwrLevel = (int8_t)aPower;
 }
 
 int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)
@@ -733,7 +733,7 @@ static bool rf_process_rx_frame(void)
     sRxFrame.mLength = temp;
     temp = (ZLL->LQI_AND_RSSI & ZLL_LQI_AND_RSSI_LQI_VALUE_MASK) >> ZLL_LQI_AND_RSSI_LQI_VALUE_SHIFT;
     sRxFrame.mLqi = rf_lqi_adjust(temp);
-    sRxFrame.mPower = rf_lqi_to_rssi(sRxFrame.mLqi);
+    sRxFrame.mRssi = rf_lqi_to_rssi(sRxFrame.mLqi);
 #if DOUBLE_BUFFERING
 
     for (temp = 0; temp < sRxFrame.mLength - 2; temp++)

--- a/examples/platforms/nrf52840/diag.c
+++ b/examples/platforms/nrf52840/diag.c
@@ -456,7 +456,7 @@ void otPlatDiagRadioReceived(otInstance *aInstance, otRadioFrame *aFrame, otErro
                           message->mCnt,
                           sID,
                           message->mID,
-                          aFrame->mPower
+                          aFrame->mRssi
                          );
             }
         }
@@ -474,7 +474,7 @@ void otPlatDiagAlarmCallback(otInstance *aInstance)
 
             sTxPacket->mLength = sizeof(struct PlatformDiagMessage);
             sTxPacket->mChannel = sChannel;
-            sTxPacket->mPower = sTxPower;
+            sTxPacket->mTxPowerConfig = (uint32_t)sTxPower;
 
             sDiagMessage.mChannel = sTxPacket->mChannel;
             sDiagMessage.mID = sID;

--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -329,7 +329,7 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
     aFrame->mPsdu[-1] = aFrame->mLength;
 
     nrf_drv_radio802154_channel_set(aFrame->mChannel);
-    nrf_drv_radio802154_tx_power_set(aFrame->mPower);
+    nrf_drv_radio802154_tx_power_set(aFrame->mTxPowerConfig);
 
     if (nrf_drv_radio802154_transmit_raw(&aFrame->mPsdu[-1], true))
     {
@@ -502,12 +502,12 @@ otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint1
     return OT_ERROR_NONE;
 }
 
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+void otPlatRadioSetTransmitPower(otInstance *aInstance, uint32_t aPower)
 {
     (void)aInstance;
 
-    sDefaultTxPower = aPower;
-    nrf_drv_radio802154_tx_power_set(aPower);
+    sDefaultTxPower = (int8_t)aPower;
+    nrf_drv_radio802154_tx_power_set((int8_t)aPower);
 }
 
 void nrf5RadioProcess(otInstance *aInstance)
@@ -537,7 +537,7 @@ void nrf5RadioProcess(otInstance *aInstance)
     if (isPendingEventSet(kPendingEventTransmit))
     {
         nrf_drv_radio802154_channel_set(sTransmitFrame.mChannel);
-        nrf_drv_radio802154_tx_power_set(sTransmitFrame.mPower);
+        nrf_drv_radio802154_tx_power_set(sTransmitFrame.mTxPowerConfig);
 
         if (nrf_drv_radio802154_transmit_raw(sTransmitPsdu, true))
         {
@@ -666,7 +666,7 @@ void nrf_drv_radio802154_received_raw(uint8_t *p_data, int8_t power, int8_t lqi)
 
     receivedFrame->mPsdu    = &p_data[1];
     receivedFrame->mLength  = p_data[0];
-    receivedFrame->mPower   = power;
+    receivedFrame->mRssi    = power;
     receivedFrame->mLqi     = lqi;
     receivedFrame->mChannel = nrf_drv_radio802154_channel_get();
 #if OPENTHREAD_ENABLE_RAW_LINK_API
@@ -714,7 +714,7 @@ void nrf_drv_radio802154_transmitted_raw(uint8_t *aAckPsdu, int8_t aPower, int8_
     {
         sAckFrame.mPsdu    = &aAckPsdu[1];
         sAckFrame.mLength  = aAckPsdu[0];
-        sAckFrame.mPower   = aPower;
+        sAckFrame.mRssi    = aPower;
         sAckFrame.mLqi     = aLqi;
         sAckFrame.mChannel = nrf_drv_radio802154_channel_get();
     }

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -728,7 +728,7 @@ void radioProcessFrame(otInstance *aInstance)
         goto exit;
     }
 
-    sReceiveFrame.mPower = -20;
+    sReceiveFrame.mRssi = -20;
     sReceiveFrame.mLqi = OT_RADIO_LQI_NONE;
 
     // generate acknowledgment
@@ -857,7 +857,7 @@ otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint1
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+void otPlatRadioSetTransmitPower(otInstance *aInstance, uint32_t aPower)
 {
     (void)aInstance;
     (void)aPower;

--- a/examples/platforms/samr21/radio.c
+++ b/examples/platforms/samr21/radio.c
@@ -252,7 +252,7 @@ static void handleRx(void)
             if (sPromiscuous || sReceiveFrame.mLength > IEEE802154_ACK_LENGTH)
             {
                 otLogDebgPlat(sInstance, "Radio receive done, rssi: %d",
-                              sReceiveFrame.mPower);
+                              sReceiveFrame.mRssi);
 
                 otPlatRadioReceiveDone(sInstance, &sReceiveFrame, OT_ERROR_NONE);
             }
@@ -291,7 +291,7 @@ void PHY_DataInd(PHY_DataInd_t *ind)
 {
     sReceiveFrame.mPsdu = ind->data;
     sReceiveFrame.mLength = ind->size + IEEE802154_FCS_SIZE;
-    sReceiveFrame.mPower = ind->rssi;
+    sReceiveFrame.mRssi = ind->rssi;
 
     sRxDone = true;
 }
@@ -518,7 +518,7 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
     uint8_t frame[OT_RADIO_FRAME_MAX_SIZE + 1];
 
     setChannel(aFrame->mChannel);
-    setTxPower(aFrame->mPower);
+    setTxPower((int8_t)aFrame->mTxPowerConfig);
 
     frame[0] = aFrame->mLength - IEEE802154_FCS_SIZE;
     memcpy(frame + 1, aFrame->mPsdu, aFrame->mLength);
@@ -616,13 +616,15 @@ otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint1
     return OT_ERROR_NONE;
 }
 
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+void otPlatRadioSetTransmitPower(otInstance *aInstance, uint32_t aPower)
 {
+    int8_t power = (int8_t)aPower;
+
     (void)aInstance;
 
-    otLogDebgPlat(sInstance, "Radio set default TX power: %d", aPower);
+    otLogDebgPlat(sInstance, "Radio set default TX power: %d", power);
 
-    setTxPower(aPower);
+    setTxPower(power);
 }
 
 int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -213,23 +213,27 @@ OTAPI otError OTCALL otLinkSetExtendedAddress(otInstance *aInstance, const otExt
 OTAPI void OTCALL otLinkGetFactoryAssignedIeeeEui64(otInstance *aInstance, otExtAddress *aEui64);
 
 /**
- * This function returns the maximum transmit power setting in dBm.
+ * This function returns the radio's transmit power configuration
+ *
+ * The 32-bit value's interpretation is radio-specific.
  *
  * @param[in]  aInstance   A pointer to an OpenThread instance.
  *
- * @returns  The maximum transmit power setting.
+ * @returns  The transmit power configuration.
  *
  */
-OTAPI int8_t OTCALL otLinkGetMaxTransmitPower(otInstance *aInstance);
+OTAPI uint32_t OTCALL otLinkGetTransmitPower(otInstance *aInstance);
 
 /**
- * This function sets the maximum transmit power in dBm.
+ * This function sets the transmit power configuration.
  *
- * @param[in]  aInstance A pointer to an OpenThread instance.
- * @param[in]  aPower    The maximum transmit power in dBm.
+ * The 32-bit value's interpretation is radio-specific.
+ *
+ * @param[in]  aInstance       A pointer to an OpenThread instance.
+ * @param[in]  aTransmitPower  The transmit power configuration.
  *
  */
-OTAPI void OTCALL otLinkSetMaxTransmitPower(otInstance *aInstance, int8_t aPower);
+OTAPI void OTCALL otLinkSetTransmitPower(otInstance *aInstance, uint32_t aTransmitPower);
 
 /**
  * Get the IEEE 802.15.4 PAN ID.

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -101,26 +101,15 @@ typedef struct otRadioFrame
     uint8_t  *mPsdu;            ///< The PSDU.
     uint8_t  mLength;           ///< Length of the PSDU.
     uint8_t  mChannel;          ///< Channel used to transmit/receive the frame.
-    int8_t   mPower;            ///< Transmit/receive power in dBm.
+    int8_t   mRssi;             ///< Received signal strengh indicator for received frames in dBm.
     uint8_t  mLqi;              ///< Link Quality Indicator for received frames.
+    uint32_t mTxPowerConfig;    ///< Transmit power configuration (interpretation is radio-specific).
+    uint32_t mMsec;             ///< The timestamp when the frame was received (milliseconds).
+    uint16_t mUsec;             ///< The timestamp when the frame was received (microseconds, the offset to mMsec).
     uint8_t  mMaxTxAttempts;    ///< Max number of transmit attempts for an outbound frame.
     bool     mSecurityValid: 1; ///< Security Enabled flag is set and frame passes security checks.
     bool     mDidTX: 1;         ///< Set to true if this frame sent from the radio. Ignored by radio driver.
     bool     mIsARetx: 1;       ///< Set to true if this frame is a retransmission. Should be ignored by radio driver.
-
-    /**
-     * The timestamp when the frame was received (milliseconds).
-     * Applicable/Required only when raw-link-api feature (`OPENTHREAD_ENABLE_RAW_LINK_API`) is enabled.
-     *
-     */
-    uint32_t mMsec;
-
-    /**
-     * The timestamp when the frame was received (microseconds, the offset to mMsec).
-     * Applicable/Required only when raw-link-api feature (`OPENTHREAD_ENABLE_RAW_LINK_API`) is enabled.
-     *
-     */
-    uint16_t mUsec;
 } otRadioFrame;
 
 /**
@@ -450,13 +439,15 @@ int8_t otPlatRadioGetRssi(otInstance *aInstance);
 otRadioCaps otPlatRadioGetCaps(otInstance *aInstance);
 
 /**
- * Set the radio Tx power used for auto-generated frames.
+ * Set the radio's transmit power configuration.
  *
- * @param[in] aInstance  The OpenThread instance structure.
- * @param[in] aPower     The Tx power to use in dBm.
+ * The 32-bit value interpretation is radio-specific.
+ *
+ * @param[in] aInstance       The OpenThread instance structure.
+ * @param[in] aTransmitPower  The Tx power configuration.
  *
  */
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower);
+void otPlatRadioSetTransmitPower(otInstance *aInstance, uint32_t aTransmitPower);
 
 /**
  * Get the status of promiscuous mode.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2625,12 +2625,12 @@ void Interpreter::ProcessTxPowerMax(int argc, char *argv[])
 
     if (argc == 0)
     {
-        mServer->OutputFormat("%d dBm\r\n", otLinkGetMaxTransmitPower(mInstance));
+        mServer->OutputFormat("%d dBm\r\n", otLinkGetTransmitPower(mInstance));
     }
     else
     {
         SuccessOrExit(error = ParseLong(argv[0], value));
-        otLinkSetMaxTransmitPower(mInstance, static_cast<int8_t>(value));
+        otLinkSetTransmitPower(mInstance, static_cast<uint32_t>(value));
     }
 
 exit:

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -94,19 +94,19 @@ void otLinkGetFactoryAssignedIeeeEui64(otInstance *aInstance, otExtAddress *aEui
     otPlatRadioGetIeeeEui64(aInstance, aEui64->m8);
 }
 
-int8_t otLinkGetMaxTransmitPower(otInstance *aInstance)
+uint32_t otLinkGetTransmitPower(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.GetThreadNetif().GetMac().GetMaxTransmitPower();
+    return instance.GetThreadNetif().GetMac().GetTransmitPower();
 }
 
-void otLinkSetMaxTransmitPower(otInstance *aInstance, int8_t aPower)
+void otLinkSetTransmitPower(otInstance *aInstance, uint32_t aTransmitPower)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    instance.GetThreadNetif().GetMac().SetMaxTransmitPower(aPower);
-    otPlatRadioSetDefaultTxPower(aInstance, aPower);
+    instance.GetThreadNetif().GetMac().SetTransmitPower(aTransmitPower);
+    otPlatRadioSetTransmitPower(aInstance, aTransmitPower);
 }
 
 otPanId otLinkGetPanId(otInstance *aInstance)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -403,20 +403,24 @@ public:
     otError SetChannel(uint8_t aChannel);
 
     /**
-     * This method returns the maximum transmit power in dBm.
+     * This method returns the transmit power configuration.
      *
-     * @returns  The maximum transmit power in dBm.
+     * The 32-bit value interpretation is radio-specific.
+     *
+     * @returns  The transmit power configuration.
      *
      */
-    int8_t GetMaxTransmitPower(void) const { return mMaxTransmitPower; }
+    uint32_t GetTransmitPower(void) const { return mTransmitPower; }
 
     /**
-     * This method sets the maximum transmit power in dBm.
+     * This method sets the transmit power configuration.
      *
-     * @param[in]  aPower  The maximum transmit power in dBm.
+     * The 32-bit value interpretation is radio-specific.
+     *
+     * @param[in]  aTransmitPower  The transmit power configuration.
      *
      */
-    void SetMaxTransmitPower(int8_t aPower) { mMaxTransmitPower = aPower; }
+    void SetTransmitPower(uint32_t aTransmitPower) { mTransmitPower = aTransmitPower; }
 
     /**
      * This method returns the IEEE 802.15.4 Network Name.
@@ -696,7 +700,7 @@ private:
     ShortAddress mShortAddress;
     PanId mPanId;
     uint8_t mChannel;
-    int8_t mMaxTransmitPower;
+    uint32_t mTransmitPower;
 
     otNetworkName mNetworkName;
     otExtendedPanId mExtendedPanId;

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -637,20 +637,20 @@ public:
     void SetChannel(uint8_t aChannel) { mChannel = aChannel; }
 
     /**
-     * This method returns the transmit/receive power in dBm used for transmission or reception.
+     * This method returns the receive signal strength indicator in dBm for received frames.
      *
-     * @returns The transmit/receive power in dBm used for transmission or reception.
+     * @returns The receive signal strength indicator in dBm for received frames.
      *
      */
-    int8_t GetPower(void) const { return mPower; }
+    int8_t GetRssi(void) const { return mRssi; }
 
     /**
-     * This method sets the transmit/receive power in dBm used for transmission or reception.
+     * This method sets the receive signal strength indicator in dBm for received frames.
      *
-     * @param[in]  aPower  The transmit/receive power in dBm used for transmission or reception.
+     * @param[in]  aRssi  The receive signal strength indicator in dBm for received frames.
      *
      */
-    void SetPower(int8_t aPower) { mPower = aPower; }
+    void SetRssi(int8_t aRssi) { mRssi = aRssi; }
 
     /**
      * This method returns the receive Link Quality Indicator.
@@ -667,6 +667,26 @@ public:
      *
      */
     void SetLqi(uint8_t aLqi) { mLqi = aLqi; }
+
+    /**
+     * This method gets the transmit power configuration for outgoing frames.
+     *
+     * The 32-bit value's interpretation is radio-specific.
+     *
+     * @returns The transmit power configuration.
+     *
+     */
+    uint32_t GetTransmitPower(void) const { return mTxPowerConfig; }
+
+    /**
+     * This method sets the transmit power configuration for outgoing frames.
+     *
+     * The 32-bit value's interpretation is radio-specific.
+     *
+     * @param[in]  aTxPowerConfig  The transmit power configuration.
+     *
+     */
+    void SetTransmitPower(uint32_t aTxPowerConfig) { mTxPowerConfig = aTxPowerConfig; }
 
     /**
      * This method returns the maximum number of transmit attempts for the frame.

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -118,11 +118,13 @@
 /**
  * @def OPENTHREAD_CONFIG_DEFAULT_MAX_TRANSMIT_POWER
  *
- * The default IEEE 802.15.4 maximum transmit power (dBm)
+ * The 32-bit value's interpretation is radio-specific.
+ *
+ * The default transmit power configuration.
  *
  */
-#ifndef OPENTHREAD_CONFIG_DEFAULT_MAX_TRANSMIT_POWER
-#define OPENTHREAD_CONFIG_DEFAULT_MAX_TRANSMIT_POWER            0
+#ifndef OPENTHREAD_CONFIG_DEFAULT_TRANSMIT_POWER
+#define OPENTHREAD_CONFIG_DEFAULT_TRANSMIT_POWER                0
 #endif
 
 /**

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1890,7 +1890,7 @@ void MeshForwarder::HandleReceivedFrame(Mac::Frame &aFrame)
 
     aFrame.GetSrcPanId(linkInfo.mPanId);
     linkInfo.mChannel = aFrame.GetChannel();
-    linkInfo.mRss = aFrame.GetPower();
+    linkInfo.mRss = aFrame.GetRssi();
     linkInfo.mLqi = aFrame.GetLqi();
     linkInfo.mLinkSecurity = aFrame.GetSecurityEnabled();
 

--- a/src/diag/diag_process.cpp
+++ b/src/diag/diag_process.cpp
@@ -186,7 +186,7 @@ void Diag::TxPacket()
 {
     sTxPacket->mLength = sTxLen;
     sTxPacket->mChannel = sChannel;
-    sTxPacket->mPower = sTxPower;
+    sTxPacket->mTxPowerConfig = (uint32_t)sTxPower;
 
     for (uint8_t i = 0; i < sTxLen; i++)
     {
@@ -368,7 +368,7 @@ void Diag::DiagReceiveDone(otInstance *aInstance, otRadioFrame *aFrame, otError 
         // for sensitivity test, only record the rssi and lqi for the first packet
         if (sStats.received_packets == 0)
         {
-            sStats.first_rssi = aFrame->mPower;
+            sStats.first_rssi = aFrame->mRssi;
             sStats.first_lqi = aFrame->mLqi;
         }
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -816,7 +816,7 @@ void NcpBase::HandleRawFrame(const otRadioFrame *aFrame)
     SuccessOrExit(mEncoder.WriteData(aFrame->mPsdu, aFrame->mLength));
 
     // Append metadata (rssi, etc)
-    SuccessOrExit(mEncoder.WriteInt8(aFrame->mPower)); // TX Power
+    SuccessOrExit(mEncoder.WriteInt8(aFrame->mRssi));  // RSSI
     SuccessOrExit(mEncoder.WriteInt8(-128));           // Noise floor (Currently unused)
     SuccessOrExit(mEncoder.WriteUint16(flags));        // Flags
 
@@ -1810,17 +1810,17 @@ otError NcpBase::GetPropertyHandler_PHY_RX_SENSITIVITY(void)
 
 otError NcpBase::GetPropertyHandler_PHY_TX_POWER(void)
 {
-    return mEncoder.WriteInt8(otLinkGetMaxTransmitPower(mInstance));
+    return mEncoder.WriteUint32(otLinkGetTransmitPower(mInstance));
 }
 
 otError NcpBase::SetPropertyHandler_PHY_TX_POWER(void)
 {
-    int8_t txPower = 0;
+    uint32_t txPower = 0;
     otError error = OT_ERROR_NONE;
 
-    SuccessOrExit(error = mDecoder.ReadInt8(txPower));
+    SuccessOrExit(error = mDecoder.ReadUint32(txPower));
 
-    otLinkSetMaxTransmitPower(mInstance, txPower);
+    otLinkSetTransmitPower(mInstance, txPower);
 
 exit:
     return error;

--- a/src/ncp/ncp_base_radio.cpp
+++ b/src/ncp/ncp_base_radio.cpp
@@ -82,7 +82,7 @@ void NcpBase::LinkRawReceiveDone(otRadioFrame *aFrame, otError aError)
     }
 
     // Append metadata (rssi, etc)
-    SuccessOrExit(mEncoder.WriteInt8(aFrame->mPower));      // TX Power
+    SuccessOrExit(mEncoder.WriteInt8(aFrame->mRssi));       // RSSI
     SuccessOrExit(mEncoder.WriteInt8(-128));                // Noise Floor (Currently unused)
     SuccessOrExit(mEncoder.WriteUint16(flags));             // Flags
 
@@ -128,7 +128,7 @@ void NcpBase::LinkRawTransmitDone(otRadioFrame *aFrame, otRadioFrame *aAckFrame,
             SuccessOrExit(mEncoder.WriteUint16(aAckFrame->mLength));
             SuccessOrExit(mEncoder.WriteData(aAckFrame->mPsdu, aAckFrame->mLength));
 
-            SuccessOrExit(mEncoder.WriteInt8(aAckFrame->mPower));    // RSSI
+            SuccessOrExit(mEncoder.WriteInt8(aAckFrame->mRssi));     // RSSI
             SuccessOrExit(mEncoder.WriteInt8(-128));                 // Noise Floor (Currently unused)
             SuccessOrExit(mEncoder.WriteUint16(0));                  // Flags
 
@@ -349,6 +349,7 @@ otError NcpBase::SetPropertyHandler_STREAM_RAW(uint8_t aHeader)
     otRadioFrame *frame;
     uint16_t frameLen = 0;
     otError error = OT_ERROR_NONE;
+    int8_t txpower;
 
     VerifyOrExit(otLinkRawIsEnabled(mInstance), error = OT_ERROR_INVALID_STATE);
 
@@ -356,7 +357,8 @@ otError NcpBase::SetPropertyHandler_STREAM_RAW(uint8_t aHeader)
 
     SuccessOrExit(error = mDecoder.ReadDataWithLen(frameBuffer, frameLen));
     SuccessOrExit(error = mDecoder.ReadUint8(frame->mChannel));
-    SuccessOrExit(error = mDecoder.ReadInt8(frame->mPower));
+    SuccessOrExit(error = mDecoder.ReadInt8(txpower));
+    frame->mTxPowerConfig = (uint32_t)txpower;  // TODO: support 32-bit tx power config
 
     VerifyOrExit(frameLen <= OT_RADIO_FRAME_MAX_SIZE, error = OT_ERROR_PARSE);
 

--- a/tests/fuzz/fuzzer_platform.c
+++ b/tests/fuzz/fuzzer_platform.c
@@ -238,7 +238,7 @@ otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint1
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+void otPlatRadioSetTransmitPower(otInstance *aInstance, uint32_t aPower)
 {
     (void)aInstance;
     (void)aPower;

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -392,7 +392,7 @@ extern "C" {
         return OT_ERROR_NOT_IMPLEMENTED;
     }
 
-    void otPlatRadioSetDefaultTxPower(otInstance *aInstance, int8_t aPower)
+    void otPlatRadioSetTransmitPower(otInstance *aInstance, uint32_t aPower)
     {
         (void)aInstance;
         (void)aPower;


### PR DESCRIPTION
The transmit power configuration in the existing radio API (i.e.
`otPlatRadioSetDefaultTxPower()` abstracted the radio power as an int8_t
in units of dBm.  This was overly constraining for platforms that had more
advanced ways of configuring the transmit power.

At the same time, Thread (and OpenThread), does not employ any form of
transmit power control.  As a result, while OpenThread provides APIs to
control the transmit power, it simply passes the transmit power value as
an opaque value.

This commit changes makes the following changes:

1. `otPlatRadioSetDefaultTxPower(int8_t)` has been changed to
   `otPlatRadioSetTransmitPower(uint32_t)`.

2. The transit power configuration increased to 32 bits, allowing for more
   advanced transmit power configurations.  The interpretation of this
   32-bit value is now radio-specific.

3. The `otRadioFrame` structure is now updated to separate the transmit and
   received power fields.  The transmit power field is now mTxPowerConfig.
   The received signal strengy field is now mRssi.