### PR TITLE
[locator] adding OwnerLocator

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3536,13 +3536,13 @@ void Interpreter::SetUserCommands(const otCliCommand *aCommands, uint8_t aLength
     mUserCommandsLength = aLength;
 }
 
-Interpreter &Interpreter::GetOwner(const Context &aContext)
+Interpreter &Interpreter::GetOwner(OwnerLocator &aOwnerLocator)
 {
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    Interpreter &interpreter = *static_cast<Interpreter *>(aContext.GetContext());
+    Interpreter &interpreter = (aOwnerLocator.GetOwner<Interpreter>());
 #else
     Interpreter &interpreter = Uart::sUartServer->GetInterpreter();
-    OT_UNUSED_VARIABLE(aContext);
+    OT_UNUSED_VARIABLE(aOwnerLocator);
 #endif
     return interpreter;
 }

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -52,7 +52,6 @@
 #endif
 
 #include "common/code_utils.hpp"
-#include "common/context.hpp"
 #include "common/instance.hpp"
 
 #ifndef OTDLL
@@ -373,7 +372,7 @@ private:
     void HandleDnsResponse(const char *aHostname, Ip6::Address &aAddress, uint32_t aTtl, otError aResult);
 #endif
 
-    static Interpreter &GetOwner(const Context &aContext);
+    static Interpreter &GetOwner(OwnerLocator &aOwnerLocator);
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
 

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -206,7 +206,6 @@ HEADERS_COMMON                      = \
     coap/coap_header.hpp              \
     coap/coap_secure.hpp              \
     common/code_utils.hpp             \
-    common/context.hpp                \
     common/crc16.hpp                  \
     common/debug.hpp                  \
     common/encoding.hpp               \
@@ -214,6 +213,7 @@ HEADERS_COMMON                      = \
     common/locator.hpp                \
     common/logging.hpp                \
     common/message.hpp                \
+    common/owner-locator.hpp          \
     common/settings.hpp               \
     common/new.hpp                    \
     common/tasklet.hpp                \

--- a/src/core/api/link_raw.hpp
+++ b/src/core/api/link_raw.hpp
@@ -113,7 +113,6 @@ public:
 
 private:
     otError DoTransmit(otRadioFrame *aFrame);
-    static LinkRaw &GetOwner(const Context &aContext);
 
     otInstance             &mInstance;
     bool                    mEnabled;

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -38,6 +38,7 @@
 #include "common/debug.hpp"
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/owner-locator.hpp"
 
 using namespace ot;
 
@@ -509,7 +510,7 @@ void LinkRaw::InvokeEnergyScanDone(int8_t aEnergyScanMaxRssi)
 
 void LinkRaw::HandleTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleTimer();
+    aTimer.GetOwner<LinkRaw>().HandleTimer();
 }
 
 void LinkRaw::HandleTimer(void)
@@ -601,7 +602,7 @@ void LinkRaw::StartCsmaBackoff(void)
 
 void LinkRaw::HandleEnergyScanTask(Tasklet &aTasklet)
 {
-    GetOwner(aTasklet).HandleEnergyScanTask();
+    aTasklet.GetOwner<LinkRaw>().HandleEnergyScanTask();
 }
 
 void LinkRaw::HandleEnergyScanTask(void)
@@ -627,17 +628,6 @@ void LinkRaw::HandleEnergyScanTask(void)
 }
 
 #endif // OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ENERGY_SCAN
-
-LinkRaw &LinkRaw::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    LinkRaw &link = *static_cast<LinkRaw *>(aContext.GetContext());
-#else
-    LinkRaw &link = Instance::Get().GetLinkRaw();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return link;
-}
 
 } // namespace ot
 

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -36,6 +36,7 @@
 #include "common/debug.hpp"
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/owner-locator.hpp"
 #include "net/ip6.hpp"
 #include "net/udp6.hpp"
 #include "thread/thread_netif.hpp"
@@ -917,25 +918,14 @@ Coap::Coap(Instance &aInstance):
 {
 }
 
-Coap &Coap::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    Coap &coap = *static_cast<Coap *>(aContext.GetContext());
-#else
-    Coap &coap = Instance::Get().GetThreadNetif().GetCoap();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return coap;
-}
-
 void Coap::HandleRetransmissionTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).CoapBase::HandleRetransmissionTimer();
+    aTimer.GetOwner<Coap>().CoapBase::HandleRetransmissionTimer();
 }
 
 void Coap::HandleResponsesQueueTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).CoapBase::HandleResponsesQueueTimer();
+    aTimer.GetOwner<Coap>().CoapBase::HandleResponsesQueueTimer();
 }
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
@@ -945,25 +935,14 @@ ApplicationCoap::ApplicationCoap(Instance &aInstance):
 {
 }
 
-ApplicationCoap &ApplicationCoap::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    ApplicationCoap &coap = *static_cast<ApplicationCoap *>(aContext.GetContext());
-#else
-    ApplicationCoap &coap = Instance::Get().GetApplicationCoap();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return coap;
-}
-
 void ApplicationCoap::HandleRetransmissionTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).CoapBase::HandleRetransmissionTimer();
+    aTimer.GetOwner<ApplicationCoap>().CoapBase::HandleRetransmissionTimer();
 }
 
 void ApplicationCoap::HandleResponsesQueueTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).CoapBase::HandleResponsesQueueTimer();
+    aTimer.GetOwner<ApplicationCoap>().CoapBase::HandleResponsesQueueTimer();
 }
 
 #endif // OPENTHREAD_ENABLE_APPLICATION_COAP

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -750,7 +750,6 @@ public:
     Coap(Instance &aInstance);
 
 private:
-    static Coap &GetOwner(const Context &aContext);
     static void HandleRetransmissionTimer(Timer &aTimer);
     static void HandleResponsesQueueTimer(Timer &aTimer);
 };
@@ -773,7 +772,6 @@ public:
     ApplicationCoap(Instance &aInstance);
 
 private:
-    static ApplicationCoap &GetOwner(const Context &aContext);
     static void HandleRetransmissionTimer(Timer &aTimer);
     static void HandleResponsesQueueTimer(Timer &aTimer);
 };

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -32,6 +32,7 @@
 
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/owner-locator.hpp"
 #include "meshcop/dtls.hpp"
 #include "thread/thread_netif.hpp"
 
@@ -277,7 +278,7 @@ exit:
 
 void CoapSecure::HandleUdpTransmit(Tasklet &aTasklet)
 {
-    GetOwner(aTasklet).HandleUdpTransmit();
+    aTasklet.GetOwner<CoapSecure>().HandleUdpTransmit();
 }
 
 void CoapSecure::HandleUdpTransmit(void)
@@ -309,25 +310,14 @@ exit:
     otLogFuncExit();
 }
 
-CoapSecure &CoapSecure::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    CoapSecure &coap = *static_cast<CoapSecure *>(aContext.GetContext());
-#else
-    CoapSecure &coap = Instance::Get().GetThreadNetif().GetCoapSecure();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return coap;
-}
-
 void CoapSecure::HandleRetransmissionTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).CoapBase::HandleRetransmissionTimer();
+    aTimer.GetOwner<CoapSecure>().CoapBase::HandleRetransmissionTimer();
 }
 
 void CoapSecure::HandleResponsesQueueTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).CoapBase::HandleResponsesQueueTimer();
+    aTimer.GetOwner<CoapSecure>().CoapBase::HandleResponsesQueueTimer();
 }
 
 }  // namespace Coap

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -219,8 +219,6 @@ private:
     static void HandleRetransmissionTimer(Timer &aTimer);
     static void HandleResponsesQueueTimer(Timer &aTimer);
 
-    static CoapSecure &GetOwner(const Context &aContext);
-
     Ip6::MessageInfo mPeerAddress;
     ConnectedCallback mConnectedCallback;
     void *mConnectedContext;

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -241,4 +241,179 @@ void Instance::InvokeEnergyScanCallback(otEnergyScanResult *aResult) const
     }
 }
 
+// Specializations of the `Get<Type>()` method.
+
+template<> TaskletScheduler &Instance::Get(void)
+{
+    return GetTaskletScheduler();
+}
+
+template<> MeshForwarder &Instance::Get(void)
+{
+    return GetThreadNetif().GetMeshForwarder();
+}
+
+template<> Mle::Mle &Instance::Get(void)
+{
+    return GetThreadNetif().GetMle();
+}
+
+template<> Mle::MleRouter &Instance::Get(void)
+{
+    return GetThreadNetif().GetMle();
+}
+
+template<> Ip6::Netif &Instance::Get(void)
+{
+    return GetThreadNetif();
+}
+
+template<> Ip6::Ip6 &Instance::Get(void)
+{
+    return GetIp6();
+}
+
+template<> Mac::Mac &Instance::Get(void)
+{
+    return GetThreadNetif().GetMac();
+}
+
+template<> KeyManager &Instance::Get(void)
+{
+    return GetThreadNetif().GetKeyManager();
+}
+
+#if OPENTHREAD_FTD
+template<> AddressResolver &Instance::Get(void)
+{
+    return GetThreadNetif().GetAddressResolver();
+}
+
+template<> MeshCoP::Leader &Instance::Get(void)
+{
+    return GetThreadNetif().GetLeader();
+}
+
+template<> MeshCoP::JoinerRouter &Instance::Get(void)
+{
+    return GetThreadNetif().GetJoinerRouter();
+}
+#endif // OPENTHREAD_FTD
+
+template<> AnnounceBeginServer &Instance::Get(void)
+{
+    return GetThreadNetif().GetAnnounceBeginServer();
+}
+
+template<> DataPollManager &Instance::Get(void)
+{
+    return GetThreadNetif().GetMeshForwarder().GetDataPollManager();
+}
+
+template<> EnergyScanServer &Instance::Get(void)
+{
+    return GetThreadNetif().GetEnergyScanServer();
+}
+
+template<> PanIdQueryServer &Instance::Get(void)
+{
+    return GetThreadNetif().GetPanIdQueryServer();
+}
+
+template<> NetworkData::Leader &Instance::Get(void)
+{
+    return GetThreadNetif().GetNetworkDataLeader();
+}
+
+template<> Ip6::Mpl &Instance::Get(void)
+{
+    return GetIp6().GetMpl();
+}
+
+template<> Coap::Coap &Instance::Get(void)
+{
+    return GetThreadNetif().GetCoap();
+}
+
+template<> MeshCoP::ActiveDatasetBase &Instance::Get(void)
+{
+    return GetThreadNetif().GetActiveDataset();
+}
+
+template<> MeshCoP::PendingDatasetBase &Instance::Get(void)
+{
+    return GetThreadNetif().GetPendingDataset();
+}
+
+#if OPENTHREAD_ENABLE_APPLICATION_COAP
+template<> Coap::ApplicationCoap &Instance::Get(void)
+{
+    return GetApplicationCoap();
+}
+#endif
+
+#if OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
+template<> MeshCoP::Commissioner &Instance::Get(void)
+{
+    return GetThreadNetif().GetCommissioner();
+}
+#endif
+
+#if OPENTHREAD_ENABLE_JOINER
+template<> MeshCoP::Joiner &Instance::Get(void)
+{
+    return GetThreadNetif().GetJoiner();
+}
+#endif
+
+#if OPENTHREAD_ENABLE_DNS_CLIENT
+template<> Dns::Client &Instance::Get(void)
+{
+    return GetThreadNetif().GetDnsClient();
+}
+#endif
+
+#if OPENTHREAD_ENABLE_DTLS
+template<> MeshCoP::Dtls &Instance::Get(void)
+{
+    return GetThreadNetif().GetDtls();
+}
+
+template<> Coap::CoapSecure &Instance::Get(void)
+{
+    return GetThreadNetif().GetCoapSecure();
+}
+#endif
+
+#if OPENTHREAD_ENABLE_RAW_LINK_API
+template<> LinkRaw &Instance::Get(void)
+{
+    return GetLinkRaw();
+}
+#endif
+
+#if OPENTHREAD_ENABLE_DHCP6_CLIENT
+template<> Dhcp6::Dhcp6Client &Instance::Get(void)
+{
+    return GetThreadNetif().GetDhcp6Client();
+}
+#endif
+
+#if OPENTHREAD_ENABLE_JAM_DETECTION
+template<> Utils::JamDetector &Instance::Get(void)
+{
+    return GetThreadNetif().GetJamDetector();
+}
+#endif
+
+template<> Utils::ChildSupervisor &Instance::Get(void)
+{
+    return GetThreadNetif().GetChildSupervisor();
+}
+
+template<> Utils::SupervisionListener &Instance::Get(void)
+{
+    return GetThreadNetif().GetSupervisionListener();
+}
+
 } // namespance ot

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -321,6 +321,24 @@ public:
      */
     MessagePool &GetMessagePool(void) { return mMessagePool; }
 
+    /**
+     * This template method returns a reference to a given `Type` object belonging to the OpenThread instance.
+     *
+     * For example, `Get<MeshForwarder>()` returns a reference to the `MeshForwarder` object of the instance.
+     *
+     * Note that any `Type` for which the `Get<Type>` is defined MUST be uniquely accessible from the OpenThread
+     * `Instance` through the member variable property hierarchy.
+     *
+     * Specializations of the `Get<Type>()` method are defined in the `instance.cpp`. The specializations are defined
+     * for any class (type) which can use `GetOwner<Type>` method, i.e., any class that is an owner of a callback
+     * providing object such as a `Timer`,`Tasklet`, or any sub-class of `OwnerLocator`.
+     *
+     * @returns A reference to the `Type` object of the instance.
+     *
+     */
+    template <typename Type>
+    Type &Get(void);
+
 private:
     Instance(void);
     void AfterInit(void);

--- a/src/core/common/locator.hpp
+++ b/src/core/common/locator.hpp
@@ -55,7 +55,6 @@ namespace Ip6 { class Ip6; }
  *
  */
 
-
 /**
  * This class implements a locator for an OpenThread Instance object.
  *
@@ -116,6 +115,54 @@ protected:
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
 private:
     Instance &mInstance;
+#endif
+};
+
+/**
+ * This class implements a locator for owner of an object.
+ *
+ * This is used as the base class for objects that provide a callback (e.g., `Timer` or `Tasklet`).
+ *
+ */
+class OwnerLocator
+{
+public:
+
+    /**
+     * This template method returns a reference to the owner object.
+     *
+     * The caller needs to provide the `OwnerType` as part of the template type.
+     *
+     * @returns A reference to the owner of this object.
+     *
+     */
+    template <typename OwnerType>
+    OwnerType &GetOwner(void)
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    { return *static_cast<OwnerType *>(mOwner); }
+#else
+    // Implemented in `owner-locator.hpp`
+    ;
+#endif
+
+protected:
+    /**
+     * This constructor initializes the object
+     *
+     * @param[in]  aOwner   A pointer to the owner object (as `void *`).
+     *
+     */
+    OwnerLocator(void *aOwner)
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+        : mOwner(aOwner)
+#endif
+    {
+        OT_UNUSED_VARIABLE(aOwner);
+    }
+
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+private:
+    void *mOwner;
 #endif
 };
 

--- a/src/core/common/owner-locator.hpp
+++ b/src/core/common/owner-locator.hpp
@@ -28,76 +28,40 @@
 
 /**
  * @file
- *   This file includes definitions for maintaining a pointer to arbitrary context information.
+ *   This file includes definitions for owner locator.
  */
 
-#ifndef CONTEXT_HPP_
-#define CONTEXT_HPP_
+#ifndef OWNER_LOCATOR_HPP_
+#define OWNER_LOCATOR_HPP_
 
 #include "openthread-core-config.h"
 
-#include <openthread/platform/toolchain.h>
-
-#include "openthread-core-config.h"
+#include <openthread/types.h>
+#include "common/instance.hpp"
+#include "common/locator.hpp"
 
 namespace ot {
 
-/**
- * @addtogroup core-context
- *
- * @brief
- *   This module includes definitions for maintaining a pointer to arbitrary context information.
- *
- * @{
- *
- */
+#if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
 
-/**
- * This class implements definitions for maintaining a pointer to arbitrary context information.
- *
- * This is used as base class for objects that provide a callback or handler (e.g., Timer or Tasklet).
- *
- */
-class Context
+template <typename OwnerType>
+OwnerType &OwnerLocator::GetOwner(void)
 {
-public:
+    // This method uses the `Instance` template method `Get<Type>`
+    // to get to the given `Type` from the single OpenThread
+    // instance.
+    //
+    // The specializations of `Instance::Get<Type>` should be defined
+    // for any class (type) which would use `GetOwner<Type>` method
+    // (i.e., any class that is an owner of a callback providing object
+    // such as a `Timer`, `Tasklet`, or in general any sub-class of
+    // `OwnerLocator`).
 
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    /**
-     * This method returns the pointer to the arbitrary context information.
-     *
-     * @returns The pointer to the context information.
-     *
-     */
-    void *GetContext(void) const { return mContext; }
+    return Instance::Get().Get<OwnerType>();
+}
+
 #endif
-
-protected:
-    /**
-     * This constructor initializes the context object.
-     *
-     * @param[in]  aContext    A pointer to arbitrary context information.
-     *
-     */
-    Context(void *aContext)
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-        : mContext(aContext)
-#endif
-    {
-        OT_UNUSED_VARIABLE(aContext);
-    }
-
-private:
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    void *mContext;
-#endif
-};
-
-/**
- * @}
- *
- */
 
 }  // namespace ot
 
-#endif  // CONTEXT_HPP_
+#endif  // OWNER_LOCATOR_HPP_

--- a/src/core/common/tasklet.cpp
+++ b/src/core/common/tasklet.cpp
@@ -42,9 +42,9 @@
 
 namespace ot {
 
-Tasklet::Tasklet(Instance &aInstance, Handler aHandler, void *aContext):
+Tasklet::Tasklet(Instance &aInstance, Handler aHandler, void *aOwner):
     InstanceLocator(aInstance),
-    Context(aContext),
+    OwnerLocator(aOwner),
     mHandler(aHandler),
     mNext(NULL)
 {
@@ -66,6 +66,8 @@ otError TaskletScheduler::Post(Tasklet &aTasklet)
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(mTail != &aTasklet && aTasklet.mNext == NULL, error = OT_ERROR_ALREADY);
+
+    VerifyOrExit(&aTasklet.GetInstance().Get<TaskletScheduler>() == this);
 
     if (mTail == NULL)
     {

--- a/src/core/common/tasklet.hpp
+++ b/src/core/common/tasklet.hpp
@@ -40,7 +40,6 @@
 
 #include <openthread/tasklet.h>
 
-#include "common/context.hpp"
 #include "common/locator.hpp"
 
 namespace ot {
@@ -61,7 +60,7 @@ class TaskletScheduler;
  * This class is used to represent a tasklet.
  *
  */
-class Tasklet: public InstanceLocator, public Context
+class Tasklet: public InstanceLocator, public OwnerLocator
 {
     friend class TaskletScheduler;
 
@@ -79,10 +78,10 @@ public:
      *
      * @param[in]  aInstance   A reference to the instance object.
      * @param[in]  aHandler    A pointer to a function that is called when the tasklet is run.
-     * @param[in]  aContext    A pointer to arbitrary context information.
+     * @param[in]  aOwner      A pointer to owner of this `Tasklet` object.
      *
      */
-    Tasklet(Instance &aInstance, Handler aHandler, void *aContext);
+    Tasklet(Instance &aInstance, Handler aHandler, void *aOwner);
 
     /**
      * This method puts the tasklet on the run queue.

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -43,7 +43,6 @@
 #include <openthread/platform/alarm-micro.h>
 #include <openthread/platform/alarm-milli.h>
 
-#include "common/context.hpp"
 #include "common/debug.hpp"
 #include "common/locator.hpp"
 #include "common/tasklet.hpp"
@@ -66,7 +65,7 @@ class TimerMilliScheduler;
  * This class implements a timer.
  *
  */
-class Timer: public InstanceLocator, public Context
+class Timer: public InstanceLocator, public OwnerLocator
 {
     friend class TimerScheduler;
 
@@ -88,14 +87,14 @@ public:
     /**
      * This constructor creates a timer instance.
      *
-     * @param[in]  aInstance   A reference to the instance.
+     * @param[in]  aInstance   A reference to the OpenThread instance.
      * @param[in]  aHandler    A pointer to a function that is called when the timer expires.
-     * @param[in]  aContext    A pointer to arbitrary context information.
+     * @param[in]  aOwner      A pointer to owner of the `Timer` object.
      *
      */
-    Timer(Instance &aInstance, Handler aHandler, void *aContext):
+    Timer(Instance &aInstance, Handler aHandler, void *aOwner):
         InstanceLocator(aInstance),
-        Context(aContext),
+        OwnerLocator(aOwner),
         mHandler(aHandler),
         mFireTime(0),
         mNext(this) {
@@ -148,13 +147,13 @@ public:
     /**
      * This constructor creates a millisecond timer instance.
      *
-     * @param[in]  aInstance   A reference to the instance.
+     * @param[in]  aInstance   A reference to the OpenThread instance.
      * @param[in]  aHandler    A pointer to a function that is called when the timer expires.
-     * @param[in]  aContext    A pointer to arbitrary context information.
+     * @param[in]  aOwner      A pointer to the owner of the `TimerMilli` object.
      *
      */
-    TimerMilli(Instance &aInstance, Handler aHandler, void *aContext):
-        Timer(aInstance, aHandler, aContext) {
+    TimerMilli(Instance &aInstance, Handler aHandler, void *aOwner):
+        Timer(aInstance, aHandler, aOwner) {
     }
 
     /**
@@ -356,13 +355,13 @@ public:
     /**
      * This constructor creates a timer instance.
      *
-     * @param[in]  aInstance   A reference to the instance object.
+     * @param[in]  aInstance   A reference to the OpenThread instance.
      * @param[in]  aHandler    A pointer to a function that is called when the timer expires.
-     * @param[in]  aContext    A pointer to arbitrary context information.
+     * @param[in]  aOwner      A pointer to owner of the `TimerMicro` object.
      *
      */
-    TimerMicro(Instance &aInstance, Handler aHandler, void *aContext):
-        Timer(aInstance, aHandler, aContext) {
+    TimerMicro(Instance &aInstance, Handler aHandler, void *aOwner):
+        Timer(aInstance, aHandler, aOwner) {
     }
 
     /**

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -45,9 +45,9 @@ TrickleTimer::TrickleTimer(
 #ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
     uint32_t aRedundancyConstant,
 #endif
-    Handler aTransmitHandler, Handler aIntervalExpiredHandler, void *aContext)
+    Handler aTransmitHandler, Handler aIntervalExpiredHandler, void *aOwner)
     :
-    TimerMilli(aInstance, HandleTimerFired, aContext),
+    TimerMilli(aInstance, HandleTimerFired, aOwner),
 #ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
     k(aRedundancyConstant),
     c(0),

--- a/src/core/common/trickle_timer.hpp
+++ b/src/core/common/trickle_timer.hpp
@@ -36,7 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include "common/context.hpp"
 #include "common/timer.hpp"
 
 namespace ot {
@@ -86,14 +85,14 @@ public:
      * @param[in]  aRedundancyConstant      The redundancy constant for the timer, k.
      * @param[in]  aTransmitHandler         A pointer to a function that is called when transmission should occur.
      * @param[in]  aIntervalExpiredHandler  An optional pointer to a function that is called when the interval expires.
-     * @param[in]  aContext                 A pointer to arbitrary context information.
+     * @param[in]  aOwner                   A pointer to owner of the `TrickleTimer` object.
      *
      */
     TrickleTimer(Instance &aInstance,
 #ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
                  uint32_t aRedundancyConstant,
 #endif
-                 Handler aTransmitHandler, Handler aIntervalExpiredHandler, void *aContext);
+                 Handler aTransmitHandler, Handler aIntervalExpiredHandler, void *aOwner);
 
     /**
      * This method indicates whether or not the trickle timer instance is running.

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -44,6 +44,7 @@
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/owner-locator.hpp"
 #include "crypto/aes_ccm.hpp"
 #include "crypto/sha256.hpp"
 #include "mac/mac_frame.hpp"
@@ -392,7 +393,7 @@ exit:
 
 void Mac::HandleEnergyScanSampleRssi(Tasklet &aTasklet)
 {
-    GetOwner(aTasklet).HandleEnergyScanSampleRssi();
+    aTasklet.GetOwner<Mac>().HandleEnergyScanSampleRssi();
 }
 
 void Mac::HandleEnergyScanSampleRssi(void)
@@ -859,7 +860,7 @@ exit:
 
 void Mac::HandleBeginTransmit(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleBeginTransmit();
+    aTimer.GetOwner<Mac>().HandleBeginTransmit();
 }
 
 void Mac::HandleBeginTransmit(void)
@@ -1156,7 +1157,7 @@ exit:
 
 void Mac::HandleMacTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleMacTimer();
+    aTimer.GetOwner<Mac>().HandleMacTimer();
 }
 
 void Mac::HandleMacTimer(void)
@@ -1202,7 +1203,7 @@ exit:
 
 void Mac::HandleReceiveTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleReceiveTimer();
+    aTimer.GetOwner<Mac>().HandleReceiveTimer();
 }
 
 void Mac::HandleReceiveTimer(void)
@@ -1934,17 +1935,6 @@ bool Mac::IsBeaconJoinable(void)
     return joinable;
 }
 #endif // OPENTHREAD_CONFIG_ENABLE_BEACON_RSP_WHEN_JOINABLE
-
-Mac &Mac::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    Mac &mac = *static_cast<Mac *>(aContext.GetContext());
-#else
-    Mac &mac = Instance::Get().GetThreadNetif().GetMac();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return mac;
-}
 
 const char *Mac::OperationToString(Operation aOperation)
 {

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -38,7 +38,6 @@
 
 #include <openthread/platform/radio.h>
 
-#include "common/context.hpp"
 #include "common/locator.hpp"
 #include "common/tasklet.hpp"
 #include "common/timer.hpp"
@@ -103,7 +102,7 @@ enum
  * This class implements a MAC receiver client.
  *
  */
-class Receiver: public Context
+class Receiver: public OwnerLocator
 {
     friend class Mac;
 
@@ -131,11 +130,11 @@ public:
      *
      * @param[in]  aReceiveFrameHandler  A pointer to a function that is called on MAC frame reception.
      * @param[in]  aPollTimeoutHandler   A pointer to a function called on data poll timeout (may be set to NULL).
-     * @param[in]  aContext              A pointer to arbitrary context information.
+     * @param[in]  aOwner                A pointer to owner of this object.
      *
      */
-    Receiver(ReceiveFrameHandler aReceiveFrameHandler, DataPollTimeoutHandler aPollTimeoutHandler, void *aContext):
-        Context(aContext),
+    Receiver(ReceiveFrameHandler aReceiveFrameHandler, DataPollTimeoutHandler aPollTimeoutHandler, void *aOwner):
+        OwnerLocator(aOwner),
         mReceiveFrameHandler(aReceiveFrameHandler),
         mPollTimeoutHandler(aPollTimeoutHandler),
         mNext(NULL) {
@@ -159,7 +158,7 @@ private:
  * This class implements a MAC sender client.
  *
  */
-class Sender: public Context
+class Sender: public OwnerLocator
 {
     friend class Mac;
 
@@ -188,11 +187,11 @@ public:
      *
      * @param[in]  aFrameRequestHandler  A pointer to a function that is called when about to send a MAC frame.
      * @param[in]  aSentFrameHandler     A pointer to a function that is called when done sending the frame.
-     * @param[in]  aContext              A pointer to arbitrary context information.
+     * @param[in]  aOwner                A pointer to owner of this object.
      *
      */
-    Sender(FrameRequestHandler aFrameRequestHandler, SentFrameHandler aSentFrameHandler, void *aContext):
-        Context(aContext),
+    Sender(FrameRequestHandler aFrameRequestHandler, SentFrameHandler aSentFrameHandler, void *aOwner):
+        OwnerLocator(aOwner),
         mFrameRequestHandler(aFrameRequestHandler),
         mSentFrameHandler(aSentFrameHandler),
         mNext(NULL) {
@@ -650,8 +649,6 @@ private:
     otError RadioTransmit(Frame *aSendFrame);
     otError RadioReceive(uint8_t aChannel);
     otError RadioSleep(void);
-
-    static Mac &GetOwner(const Context &aContext);
 
     static const char *OperationToString(Operation aOperation);
 

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -45,6 +45,7 @@
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/owner-locator.hpp"
 #include "crypto/pbkdf2_cmac.h"
 #include "meshcop/joiner_router.hpp"
 #include "meshcop/meshcop.hpp"
@@ -321,7 +322,7 @@ otCommissionerState Commissioner::GetState(void) const
 
 void Commissioner::HandleTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleTimer();
+    aTimer.GetOwner<Commissioner>().HandleTimer();
 }
 
 void Commissioner::HandleTimer(void)
@@ -343,7 +344,7 @@ void Commissioner::HandleTimer(void)
 
 void Commissioner::HandleJoinerExpirationTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleJoinerExpirationTimer();
+    aTimer.GetOwner<Commissioner>().HandleJoinerExpirationTimer();
 }
 
 void Commissioner::HandleJoinerExpirationTimer(void)
@@ -1081,17 +1082,6 @@ otError Commissioner::GeneratePSKc(const char *aPassPhrase, const char *aNetwork
 
 exit:
     return error;
-}
-
-Commissioner &Commissioner::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    Commissioner &commissioner = *static_cast<Commissioner *>(aContext.GetContext());
-#else
-    Commissioner &commissioner = Instance::Get().GetThreadNetif().GetCommissioner();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return commissioner;
 }
 
 }  // namespace MeshCoP

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -279,8 +279,6 @@ private:
     otError SendPetition(void);
     otError SendKeepAlive(void);
 
-    static Commissioner &GetOwner(const Context &aContext);
-
     otCommissionerState mState;
 
     struct Joiner

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -43,6 +43,7 @@
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/owner-locator.hpp"
 #include "common/timer.hpp"
 #include "crypto/sha256.hpp"
 #include "thread/thread_netif.hpp"
@@ -376,7 +377,7 @@ int Dtls::HandleMbedtlsExportKeys(const unsigned char *aMasterSecret, const unsi
 
 void Dtls::HandleTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleTimer();
+    aTimer.GetOwner<Dtls>().HandleTimer();
 }
 
 void Dtls::HandleTimer(void)
@@ -513,17 +514,6 @@ void Dtls::HandleMbedtlsDebug(void *ctx, int level, const char *, int, const cha
         otLogDebgMbedTls(pThis->GetInstance(), "%s", str);
         break;
     }
-}
-
-Dtls &Dtls::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    Dtls &dtls = *static_cast<Dtls *>(aContext.GetContext());
-#else
-    Dtls &dtls = Instance::Get().GetThreadNetif().GetDtls();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return dtls;
 }
 
 }  // namespace MeshCoP

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -234,8 +234,6 @@ private:
     void Close(void);
     void Process(void);
 
-    static Dtls &GetOwner(const Context &aContext);
-
     uint8_t mPsk[kPskMaxLength];
     uint8_t mPskLength;
 

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -46,6 +46,7 @@
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/owner-locator.hpp"
 #include "mac/mac_frame.hpp"
 #include "meshcop/meshcop.hpp"
 #include "thread/thread_netif.hpp"
@@ -578,7 +579,7 @@ exit:
 
 void Joiner::HandleTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleTimer();
+    aTimer.GetOwner<Joiner>().HandleTimer();
 }
 
 void Joiner::HandleTimer(void)
@@ -612,17 +613,6 @@ void Joiner::HandleTimer(void)
     }
 
     Complete(error);
-}
-
-Joiner &Joiner::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    Joiner &joiner = *static_cast<Joiner *>(aContext.GetContext());
-#else
-    Joiner &joiner = Instance::Get().GetThreadNetif().GetJoiner();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return joiner;
 }
 
 }  // namespace MeshCoP

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -157,8 +157,6 @@ private:
     void HandleJoinerEntrust(Coap::Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     void SendJoinerEntrustResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aRequestInfo);
 
-    static Joiner &GetOwner(const Context &aContext);
-
     otJoinerState mState;
 
     otJoinerCallback mCallback;

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -43,6 +43,7 @@
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/owner-locator.hpp"
 #include "meshcop/meshcop.hpp"
 #include "meshcop/meshcop_tlvs.hpp"
 #include "thread/mle.hpp"
@@ -427,7 +428,7 @@ exit:
 
 void JoinerRouter::HandleTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleTimer();
+    aTimer.GetOwner<JoinerRouter>().HandleTimer();
 }
 
 void JoinerRouter::HandleTimer(void)
@@ -527,17 +528,6 @@ void JoinerRouter::HandleJoinerEntrustResponse(Coap::Header *aHeader, Message *a
 
 exit:
     return ;
-}
-
-JoinerRouter &JoinerRouter::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    JoinerRouter &joiner = *static_cast<JoinerRouter *>(aContext.GetContext());
-#else
-    JoinerRouter &joiner = Instance::Get().GetThreadNetif().GetJoinerRouter();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return joiner;
 }
 
 }  // namespace Dtls

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -113,8 +113,6 @@ private:
 
     otError GetBorderAgentRloc(uint16_t &aRloc);
 
-    static JoinerRouter &GetOwner(const Context &aContext);
-
     Ip6::NetifCallback mNetifCallback;
 
     Ip6::UdpSocket mSocket;

--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -45,6 +45,7 @@
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/owner-locator.hpp"
 #include "meshcop/meshcop.hpp"
 #include "meshcop/meshcop_tlvs.hpp"
 #include "thread/thread_netif.hpp"
@@ -286,7 +287,7 @@ uint32_t Leader::GetDelayTimerMinimal(void) const
 
 void Leader::HandleTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleTimer();
+    aTimer.GetOwner<Leader>().HandleTimer();
 }
 
 void Leader::HandleTimer(void)
@@ -316,17 +317,6 @@ void Leader::ResignCommissioner(void)
     SetEmptyCommissionerData();
 
     otLogInfoMeshCoP(GetInstance(), "commissioner inactive");
-}
-
-Leader &Leader::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    Leader &leader = *static_cast<Leader *>(aContext.GetContext());
-#else
-    Leader &leader = Instance::Get().GetThreadNetif().GetLeader();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return leader;
 }
 
 }  // namespace MeshCoP

--- a/src/core/meshcop/leader.hpp
+++ b/src/core/meshcop/leader.hpp
@@ -133,8 +133,6 @@ private:
 
     void ResignCommissioner(void);
 
-    static Leader &GetOwner(const Context &aContext);
-
     Coap::Resource mPetition;
     Coap::Resource mKeepAlive;
     TimerMilli mTimer;

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -42,6 +42,7 @@
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/owner-locator.hpp"
 #include "mac/mac.hpp"
 #include "net/dhcp6.hpp"
 #include "thread/thread_netif.hpp"
@@ -332,7 +333,7 @@ exit:
 
 bool Dhcp6Client::HandleTrickleTimer(TrickleTimer &aTrickleTimer)
 {
-    return GetOwner(aTrickleTimer).HandleTrickleTimer();
+    return aTrickleTimer.GetOwner<Dhcp6Client>().HandleTrickleTimer();
 }
 
 bool Dhcp6Client::HandleTrickleTimer(void)
@@ -714,17 +715,6 @@ otError Dhcp6Client::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
 
 exit:
     return error;
-}
-
-Dhcp6Client &Dhcp6Client::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    Dhcp6Client &client = *static_cast<Dhcp6Client *>(aContext.GetContext());
-#else
-    Dhcp6Client &client = Instance::Get().GetThreadNetif().GetDhcp6Client();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return client;
 }
 
 }  // namespace Dhcp6

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -224,8 +224,6 @@ private:
     static bool HandleTrickleTimer(TrickleTimer &aTrickleTimer);
     bool HandleTrickleTimer(void);
 
-    static Dhcp6Client &GetOwner(const Context &aContext);
-
     Ip6::UdpSocket mSocket;
 
     TrickleTimer mTrickleTimer;

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -33,6 +33,7 @@
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
+#include "common/owner-locator.hpp"
 #include "net/udp6.hpp"
 #include "thread/thread_netif.hpp"
 
@@ -384,7 +385,7 @@ void Client::FinalizeDnsTransaction(Message &aQuery, const QueryMetadata &aQuery
 
 void Client::HandleRetransmissionTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleRetransmissionTimer();
+    aTimer.GetOwner<Client>().HandleRetransmissionTimer();
 }
 
 void Client::HandleRetransmissionTimer(void)
@@ -517,17 +518,6 @@ exit:
     }
 
     return;
-}
-
-Client &Client::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    Client &client = *static_cast<Client *>(aContext.GetContext());
-#else
-    Client &client = Instance::Get().GetThreadNetif().GetDnsClient();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return client;
 }
 
 }  // namespace Coap

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -252,8 +252,6 @@ private:
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static Client &GetOwner(const Context &aContext);
-
     Ip6::UdpSocket mSocket;
 
     uint16_t mMessageId;

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -40,6 +40,7 @@
 #include "common/instance.hpp"
 #include "common/logging.hpp"
 #include "common/message.hpp"
+#include "common/owner-locator.hpp"
 #include "net/icmp6.hpp"
 #include "net/ip6_address.hpp"
 #include "net/ip6_routes.hpp"
@@ -407,7 +408,7 @@ exit:
 
 void Ip6::HandleSendQueue(Tasklet &aTasklet)
 {
-    GetOwner(aTasklet).HandleSendQueue();
+    aTasklet.GetOwner<Ip6>().HandleSendQueue();
 }
 
 void Ip6::HandleSendQueue(void)
@@ -1113,17 +1114,6 @@ int8_t Ip6::GetOnLinkNetif(const Address &aAddress)
 
 exit:
     return rval;
-}
-
-Ip6 &Ip6::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    Ip6 &ip6 = *static_cast<Ip6 *>(aContext.GetContext());
-#else
-    Ip6 &ip6 = Instance::Get().GetIp6();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return ip6;
 }
 
 const char *Ip6::IpProtoToString(IpProto aIpProto)

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -391,8 +391,6 @@ private:
     otError HandlePayload(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aIpProto);
     int8_t FindForwardInterfaceId(const MessageInfo &aMessageInfo);
 
-    static Ip6 &GetOwner(const Context &aContext);
-
     bool mForwardingEnabled;
     bool mIsReceiveIp6FilterEnabled;
     otIp6ReceiveCallback mReceiveIp6DatagramCallback;

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -38,6 +38,7 @@
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/message.hpp"
+#include "common/owner-locator.hpp"
 #include "net/ip6.hpp"
 
 namespace ot {
@@ -259,7 +260,7 @@ exit:
 
 void Mpl::HandleRetransmissionTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleRetransmissionTimer();
+    aTimer.GetOwner<Mpl>().HandleRetransmissionTimer();
 }
 
 void Mpl::HandleRetransmissionTimer(void)
@@ -346,7 +347,7 @@ void Mpl::HandleRetransmissionTimer(void)
 
 void Mpl::HandleSeedSetTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleSeedSetTimer();
+    aTimer.GetOwner<Mpl>().HandleSeedSetTimer();
 }
 
 void Mpl::HandleSeedSetTimer(void)
@@ -366,17 +367,6 @@ void Mpl::HandleSeedSetTimer(void)
     {
         mSeedSetTimer.Start(kSeedEntryLifetimeDt);
     }
-}
-
-Mpl &Mpl::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    Mpl &mpl = *static_cast<Mpl *>(aContext.GetContext());
-#else
-    Mpl &mpl = Instance::Get().GetIp6().GetMpl();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return mpl;
 }
 
 }  // namespace Ip6

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -535,8 +535,6 @@ private:
     static void HandleRetransmissionTimer(Timer &aTimer);
     void HandleRetransmissionTimer(void);
 
-    static Mpl &GetOwner(const Context &aContext);
-
     uint8_t mTimerExpirations;
     uint8_t mSequence;
     uint16_t mSeedId;

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -37,6 +37,7 @@
 #include "common/debug.hpp"
 #include "common/instance.hpp"
 #include "common/message.hpp"
+#include "common/owner-locator.hpp"
 #include "net/ip6.hpp"
 
 namespace ot {
@@ -561,7 +562,7 @@ void Netif::SetStateChangedFlags(uint32_t aFlags)
 
 void Netif::HandleStateChangedTask(Tasklet &aTasklet)
 {
-    GetOwner(aTasklet).HandleStateChangedTask();
+    aTasklet.GetOwner<Netif>().HandleStateChangedTask();
 }
 
 void Netif::HandleStateChangedTask(void)
@@ -574,17 +575,6 @@ void Netif::HandleStateChangedTask(void)
     {
         callback->Callback(flags);
     }
-}
-
-Netif &Netif::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    Netif &netif = *static_cast<Netif *>(aContext.GetContext());
-#else
-    Netif &netif = Instance::Get().GetThreadNetif();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return netif;
 }
 
 }  // namespace Ip6

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -533,7 +533,6 @@ public:
 private:
     static void HandleStateChangedTask(Tasklet &aTasklet);
     void HandleStateChangedTask(void);
-    static Netif &GetOwner(const Context &aContext);
 
     NetifCallback *mCallbacks;
     NetifUnicastAddress *mUnicastAddresses;

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -45,6 +45,7 @@
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/owner-locator.hpp"
 #include "mac/mac_frame.hpp"
 #include "thread/mesh_forwarder.hpp"
 #include "thread/mle_router.hpp"
@@ -722,7 +723,7 @@ exit:
 
 void AddressResolver::HandleTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleTimer();
+    aTimer.GetOwner<AddressResolver>().HandleTimer();
 }
 
 void AddressResolver::HandleTimer(void)
@@ -807,17 +808,6 @@ void AddressResolver::HandleIcmpReceive(Message &aMessage, const Ip6::MessageInf
 
 exit:
     OT_UNUSED_VARIABLE(aMessageInfo);
-}
-
-AddressResolver &AddressResolver::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    AddressResolver &resolver = *static_cast<AddressResolver *>(aContext.GetContext());
-#else
-    AddressResolver &resolver = Instance::Get().GetThreadNetif().GetAddressResolver();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return resolver;
 }
 
 }  // namespace ot

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -207,8 +207,6 @@ private:
     static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
 
-    static AddressResolver &GetOwner(const Context &aContext);
-
     Coap::Resource mAddressError;
     Coap::Resource mAddressQuery;
     Coap::Resource mAddressNotification;

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -42,6 +42,7 @@
 #include "common/instance.hpp"
 #include "common/debug.hpp"
 #include "common/logging.hpp"
+#include "common/owner-locator.hpp"
 #include "meshcop/meshcop_tlvs.hpp"
 #include "thread/thread_netif.hpp"
 #include "thread/thread_uri_paths.hpp"
@@ -127,7 +128,7 @@ exit:
 
 void AnnounceBeginServer::HandleTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleTimer();
+    aTimer.GetOwner<AnnounceBeginServer>().HandleTimer();
 }
 
 void AnnounceBeginServer::HandleTimer(void)
@@ -150,17 +151,6 @@ void AnnounceBeginServer::HandleTimer(void)
             mCount--;
         }
     }
-}
-
-AnnounceBeginServer &AnnounceBeginServer::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    AnnounceBeginServer &server = *static_cast<AnnounceBeginServer *>(aContext.GetContext());
-#else
-    AnnounceBeginServer &server = Instance::Get().GetThreadNetif().GetAnnounceBeginServer();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return server;
 }
 
 }  // namespace ot

--- a/src/core/thread/announce_begin_server.hpp
+++ b/src/core/thread/announce_begin_server.hpp
@@ -94,8 +94,6 @@ private:
     static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
 
-    static AnnounceBeginServer &GetOwner(const Context &aContext);
-
     uint32_t mChannelMask;
     uint16_t mPeriod;
     uint8_t mCount;

--- a/src/core/thread/data_poll_manager.cpp
+++ b/src/core/thread/data_poll_manager.cpp
@@ -41,6 +41,7 @@
 #include "common/instance.hpp"
 #include "common/logging.hpp"
 #include "common/message.hpp"
+#include "common/owner-locator.hpp"
 #include "net/ip6.hpp"
 #include "net/netif.hpp"
 #include "thread/mesh_forwarder.hpp"
@@ -410,18 +411,7 @@ uint32_t DataPollManager::CalculatePollPeriod(void) const
 
 void DataPollManager::HandlePollTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).SendDataPoll();
-}
-
-DataPollManager &DataPollManager::GetOwner(Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    DataPollManager &manager = *static_cast<DataPollManager *>(aContext.GetContext());
-#else
-    DataPollManager &manager = Instance::Get().GetThreadNetif().GetMeshForwarder().GetDataPollManager();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return manager;
+    aTimer.GetOwner<DataPollManager>().SendDataPoll();
 }
 
 uint32_t DataPollManager::GetDefaultPollPeriod(void) const

--- a/src/core/thread/data_poll_manager.hpp
+++ b/src/core/thread/data_poll_manager.hpp
@@ -219,7 +219,6 @@ private:
     void ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector);
     uint32_t CalculatePollPeriod(void) const;
     static void HandlePollTimer(Timer &aTimer);
-    static DataPollManager &GetOwner(Context &aContext);
     uint32_t GetDefaultPollPeriod(void) const;
 
     uint32_t    mTimerStartTime;

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -42,6 +42,7 @@
 #include "common/debug.hpp"
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/owner-locator.hpp"
 #include "meshcop/meshcop.hpp"
 #include "meshcop/meshcop_tlvs.hpp"
 #include "thread/thread_netif.hpp"
@@ -120,7 +121,7 @@ exit:
 
 void EnergyScanServer::HandleTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleTimer();
+    aTimer.GetOwner<EnergyScanServer>().HandleTimer();
 }
 
 void EnergyScanServer::HandleTimer(void)
@@ -239,17 +240,6 @@ void EnergyScanServer::HandleNetifStateChanged(uint32_t aFlags)
         mActive = false;
         mTimer.Stop();
     }
-}
-
-EnergyScanServer &EnergyScanServer::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    EnergyScanServer &server = *static_cast<EnergyScanServer *>(aContext.GetContext());
-#else
-    EnergyScanServer &server = Instance::Get().GetThreadNetif().GetEnergyScanServer();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return server;
 }
 
 }  // namespace ot

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -87,8 +87,6 @@ private:
 
     otError SendReport(void);
 
-    static EnergyScanServer &GetOwner(const Context &aContext);
-
     Ip6::Address mCommissioner;
     uint32_t mChannelMask;
     uint32_t mChannelMaskCurrent;

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -36,6 +36,7 @@
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/timer.hpp"
+#include "common/owner-locator.hpp"
 #include "crypto/hmac_sha256.hpp"
 #include "thread/mle_router.hpp"
 #include "thread/thread_netif.hpp"
@@ -248,7 +249,7 @@ void KeyManager::StartKeyRotationTimer(void)
 
 void KeyManager::HandleKeyRotationTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleKeyRotationTimer();
+    aTimer.GetOwner<KeyManager>().HandleKeyRotationTimer();
 }
 
 void KeyManager::HandleKeyRotationTimer(void)
@@ -268,17 +269,6 @@ void KeyManager::HandleKeyRotationTimer(void)
     {
         SetCurrentKeySequence(mKeySequence + 1);
     }
-}
-
-KeyManager &KeyManager::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    KeyManager &keyManager = *static_cast<KeyManager *>(aContext.GetContext());
-#else
-    KeyManager &keyManager = Instance::Get().GetThreadNetif().GetKeyManager();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return keyManager;
 }
 
 }  // namespace ot

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -341,8 +341,6 @@ private:
     static void HandleKeyRotationTimer(Timer &aTimer);
     void HandleKeyRotationTimer(void);
 
-    static KeyManager &GetOwner(const Context &aContext);
-
     otMasterKey mMasterKey;
 
     uint32_t mKeySequence;

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -43,6 +43,7 @@
 #include "common/instance.hpp"
 #include "common/logging.hpp"
 #include "common/message.hpp"
+#include "common/owner-locator.hpp"
 #include "net/ip6.hpp"
 #include "net/ip6_filter.hpp"
 #include "net/netif.hpp"
@@ -362,7 +363,7 @@ void MeshForwarder::RemoveMessages(Child &aChild, uint8_t aSubType)
 
 void MeshForwarder::ScheduleTransmissionTask(Tasklet &aTasklet)
 {
-    GetOwner(aTasklet).ScheduleTransmissionTask();
+    aTasklet.GetOwner<MeshForwarder>().ScheduleTransmissionTask();
 }
 
 void MeshForwarder::ScheduleTransmissionTask(void)
@@ -1136,7 +1137,7 @@ otError MeshForwarder::GetMacDestinationAddress(const Ip6::Address &aIp6Addr, Ma
 
 otError MeshForwarder::HandleFrameRequest(Mac::Sender &aSender, Mac::Frame &aFrame)
 {
-    return GetOwner(aSender).HandleFrameRequest(aFrame);
+    return aSender.GetOwner<MeshForwarder>().HandleFrameRequest(aFrame);
 }
 
 otError MeshForwarder::HandleFrameRequest(Mac::Frame &aFrame)
@@ -1584,7 +1585,7 @@ otError MeshForwarder::SendEmptyFrame(Mac::Frame &aFrame, bool aAckRequest)
 
 void MeshForwarder::HandleSentFrame(Mac::Sender &aSender, Mac::Frame &aFrame, otError aError)
 {
-    GetOwner(aSender).HandleSentFrame(aFrame, aError);
+    aSender.GetOwner<MeshForwarder>().HandleSentFrame(aFrame, aError);
 }
 
 void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, otError aError)
@@ -1830,7 +1831,7 @@ void MeshForwarder::SetDiscoverParameters(uint32_t aScanChannels)
 
 void MeshForwarder::HandleDiscoverTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleDiscoverTimer();
+    aTimer.GetOwner<MeshForwarder>().HandleDiscoverTimer();
 }
 
 void MeshForwarder::HandleDiscoverTimer(void)
@@ -1865,7 +1866,7 @@ exit:
 
 void MeshForwarder::HandleReceivedFrame(Mac::Receiver &aReceiver, Mac::Frame &aFrame)
 {
-    GetOwner(aReceiver).HandleReceivedFrame(aFrame);
+    aReceiver.GetOwner<MeshForwarder>().HandleReceivedFrame(aFrame);
 }
 
 void MeshForwarder::HandleReceivedFrame(Mac::Frame &aFrame)
@@ -2281,7 +2282,7 @@ void MeshForwarder::ClearReassemblyList(void)
 
 void MeshForwarder::HandleReassemblyTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleReassemblyTimer();
+    aTimer.GetOwner<MeshForwarder>().HandleReassemblyTimer();
 }
 
 void MeshForwarder::HandleReassemblyTimer(void)
@@ -2416,18 +2417,7 @@ exit:
 
 void MeshForwarder::HandleDataPollTimeout(Mac::Receiver &aReceiver)
 {
-    GetOwner(aReceiver).GetDataPollManager().HandlePollTimeout();
-}
-
-MeshForwarder &MeshForwarder::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    MeshForwarder &meshForwader = *static_cast<MeshForwarder *>(aContext.GetContext());
-#else
-    MeshForwarder &meshForwader = Instance::Get().GetThreadNetif().GetMeshForwarder();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return meshForwader;
+    aReceiver.GetOwner<MeshForwarder>().GetDataPollManager().HandlePollTimeout();
 }
 
 #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MAC == 1)

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -316,8 +316,6 @@ private:
 #endif // OPENTHREAD_ENABLE_SERVICE
 #endif // OPENTHREAD_FTD
 
-    static MeshForwarder &GetOwner(const Context &aContext);
-
     void LogIp6Message(MessageAction aAction, const Message &aMessage, const Mac::Address *aMacAddress,
                        otError aError);
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -44,6 +44,7 @@
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/owner-locator.hpp"
 #include "common/settings.hpp"
 #include "crypto/aes_ccm.hpp"
 #include "mac/mac_frame.hpp"
@@ -1399,7 +1400,7 @@ exit:
 
 void Mle::HandleParentRequestTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleParentRequestTimer();
+    aTimer.GetOwner<Mle>().HandleParentRequestTimer();
 }
 
 void Mle::HandleParentRequestTimer(void)
@@ -1518,7 +1519,7 @@ void Mle::HandleParentRequestTimer(void)
 
 void Mle::HandleDelayedResponseTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleDelayedResponseTimer();
+    aTimer.GetOwner<Mle>().HandleDelayedResponseTimer();
 }
 
 void Mle::HandleDelayedResponseTimer(void)
@@ -1730,7 +1731,7 @@ exit:
 
 void Mle::HandleSendChildUpdateRequest(Tasklet &aTasklet)
 {
-    GetOwner(aTasklet).HandleSendChildUpdateRequest();
+    aTasklet.GetOwner<Mle>().HandleSendChildUpdateRequest();
 }
 
 void Mle::HandleSendChildUpdateRequest(void)
@@ -1749,7 +1750,7 @@ void Mle::HandleSendChildUpdateRequest(void)
 
 void Mle::HandleChildUpdateRequestTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleChildUpdateRequestTimer();
+    aTimer.GetOwner<Mle>().HandleChildUpdateRequestTimer();
 }
 
 void Mle::HandleChildUpdateRequestTimer(void)
@@ -3432,17 +3433,6 @@ exit:
     return error;
 }
 #endif // OPENTHREAD_CONFIG_INFORM_PREVIOUS_PARENT_ON_REATTACH
-
-Mle &Mle::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    Mle &mle = *static_cast<Mle *>(aContext.GetContext());
-#else
-    Mle &mle = Instance::Get().GetThreadNetif().GetMle();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return mle;
-}
 
 void Mle::LogMleMessage(const char *aLogString, const Ip6::Address &aAddress) const
 {

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1441,8 +1441,6 @@ private:
     otError InformPreviousParent(void);
 #endif
 
-    static Mle &GetOwner(const Context &aContext);
-
     MessageQueue mDelayedResponses;
 
     struct

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -44,6 +44,7 @@
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/owner-locator.hpp"
 #include "common/settings.hpp"
 #include "mac/mac_frame.hpp"
 #include "net/icmp6.hpp"
@@ -506,7 +507,7 @@ otError MleRouter::SetStateLeader(uint16_t aRloc16)
 
 bool MleRouter::HandleAdvertiseTimer(TrickleTimer &aTimer)
 {
-    return GetOwner(aTimer).HandleAdvertiseTimer();
+    return aTimer.GetOwner<MleRouter>().HandleAdvertiseTimer();
 }
 
 bool MleRouter::HandleAdvertiseTimer(void)
@@ -1770,7 +1771,7 @@ exit:
 
 void MleRouter::HandleStateUpdateTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleStateUpdateTimer();
+    aTimer.GetOwner<MleRouter>().HandleStateUpdateTimer();
 }
 
 void MleRouter::HandleStateUpdateTimer(void)
@@ -4839,17 +4840,6 @@ otError MleRouter::SetAssignParentPriority(int8_t aParentPriority)
 
 exit:
     return error;
-}
-
-MleRouter &MleRouter::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    MleRouter &mle = *static_cast<MleRouter *>(aContext.GetContext());
-#else
-    MleRouter &mle = Instance::Get().GetThreadNetif().GetMle();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return mle;
 }
 
 otError MleRouter::GetMaxChildTimeout(uint32_t &aTimeout) const

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -827,8 +827,6 @@ private:
 
     void SignalChildUpdated(otThreadChildTableEvent aEvent, Child &aChild);
 
-    static MleRouter &GetOwner(const Context &aContext);
-
     TrickleTimer mAdvertiseTimer;
     TimerMilli mStateUpdateTimer;
 

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -47,6 +47,7 @@
 #include "common/instance.hpp"
 #include "common/logging.hpp"
 #include "common/message.hpp"
+#include "common/owner-locator.hpp"
 #include "common/timer.hpp"
 #include "mac/mac_frame.hpp"
 #include "meshcop/meshcop.hpp"
@@ -1516,7 +1517,7 @@ otError Leader::RemoveContext(PrefixTlv &aPrefix, uint8_t aContextId)
 
 void Leader::HandleTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleTimer();
+    aTimer.GetOwner<Leader>().HandleTimer();
 }
 
 void Leader::HandleTimer(void)
@@ -1544,17 +1545,6 @@ void Leader::HandleTimer(void)
     {
         mTimer.Start(kStateUpdatePeriod);
     }
-}
-
-Leader &Leader::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    Leader &leader = *static_cast<Leader *>(aContext.GetContext());
-#else
-    Leader &leader = Instance::Get().GetThreadNetif().GetNetworkDataLeader();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return leader;
 }
 
 }  // namespace NetworkData

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -203,7 +203,6 @@ private:
                                       uint8_t *aTlvs, uint8_t aLength);
     void SendCommissioningSetResponse(const Coap::Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo,
                                       MeshCoP::StateTlv::State aState);
-    static Leader &GetOwner(const Context &aContext);
 
     /**
      * Thread Specification Constants

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -26,6 +26,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+
 /**
  * @file
  *   This file implements the PAN ID Query Server.
@@ -42,6 +43,7 @@
 #include "common/debug.hpp"
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/owner-locator.hpp"
 #include "meshcop/meshcop.hpp"
 #include "meshcop/meshcop_tlvs.hpp"
 #include "thread/thread_netif.hpp"
@@ -164,24 +166,13 @@ exit:
 
 void PanIdQueryServer::HandleTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleTimer();
+    aTimer.GetOwner<PanIdQueryServer>().HandleTimer();
 }
 
 void PanIdQueryServer::HandleTimer(void)
 {
     GetNetif().GetMac().ActiveScan(mChannelMask, 0, HandleScanResult, this);
     mChannelMask = 0;
-}
-
-PanIdQueryServer &PanIdQueryServer::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    PanIdQueryServer &server = *static_cast<PanIdQueryServer *>(aContext.GetContext());
-#else
-    PanIdQueryServer &server = Instance::Get().GetThreadNetif().GetPanIdQueryServer();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return server;
 }
 
 }  // namespace ot

--- a/src/core/thread/panid_query_server.hpp
+++ b/src/core/thread/panid_query_server.hpp
@@ -84,8 +84,6 @@ private:
 
     otError SendConflict(void);
 
-    static PanIdQueryServer &GetOwner(const Context &aContext);
-
     Ip6::Address mCommissioner;
     uint32_t mChannelMask;
     uint16_t mPanId;

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -326,7 +326,7 @@ public:
     /**
      * This method returns a reference to the commissioner object.
      *
-     * @returns A reference to the commissioenr object.
+     * @returns A reference to the commissioner object.
      *
      */
     MeshCoP::Commissioner &GetCommissioner(void) { return mCommissioner; }

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -39,6 +39,7 @@
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/owner-locator.hpp"
 #include "thread/thread_netif.hpp"
 
 namespace ot {
@@ -132,7 +133,7 @@ void ChildSupervisor::UpdateOnSend(Child &aChild)
 
 void ChildSupervisor::HandleTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleTimer();
+    aTimer.GetOwner<ChildSupervisor>().HandleTimer();
 }
 
 void ChildSupervisor::HandleTimer(void)
@@ -163,17 +164,6 @@ void ChildSupervisor::HandleTimer(void)
 
 exit:
     return;
-}
-
-ChildSupervisor &ChildSupervisor::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    ChildSupervisor &supervisor = *static_cast<ChildSupervisor *>(aContext.GetContext());
-#else
-    ChildSupervisor &supervisor = Instance::Get().GetThreadNetif().GetChildSupervisor();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return supervisor;
 }
 
 #endif // #if OPENTHREAD_FTD
@@ -239,7 +229,7 @@ void SupervisionListener::RestartTimer(void)
 
 void SupervisionListener::HandleTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleTimer();
+    aTimer.GetOwner<SupervisionListener>().HandleTimer();
 }
 
 void SupervisionListener::HandleTimer(void)
@@ -255,17 +245,6 @@ void SupervisionListener::HandleTimer(void)
 
 exit:
     RestartTimer();
-}
-
-SupervisionListener &SupervisionListener::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    SupervisionListener &listener = *static_cast<SupervisionListener *>(aContext.GetContext());
-#else
-    SupervisionListener &listener = Instance::Get().GetThreadNetif().GetSupervisionListener();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return listener;
 }
 
 #endif // #if OPENTHREAD_ENABLE_CHILD_SUPERVISION

--- a/src/core/utils/child_supervision.hpp
+++ b/src/core/utils/child_supervision.hpp
@@ -157,7 +157,6 @@ private:
     void SendMessage(Child &aChild);
     static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
-    static ChildSupervisor &GetOwner(const Context &aContext);
 
     uint16_t     mSupervisionInterval;
     TimerMilli   mTimer;
@@ -249,7 +248,6 @@ private:
     void RestartTimer(void);
     static void HandleTimer(Timer &aTimer);
     void HandleTimer(void);
-    static SupervisionListener &GetOwner(const Context &aContext);
 
     uint16_t mTimeout;
     TimerMilli mTimer;

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -38,6 +38,7 @@
 
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
+#include "common/owner-locator.hpp"
 #include "thread/thread_netif.hpp"
 
 #if OPENTHREAD_ENABLE_JAM_DETECTION
@@ -136,7 +137,7 @@ exit:
 
 void JamDetector::HandleTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandleTimer();
+    aTimer.GetOwner<JamDetector>().HandleTimer();
 }
 
 void JamDetector::HandleTimer(void)
@@ -236,17 +237,6 @@ void JamDetector::UpdateJamState(void)
     {
         mHandler(mJamState, mContext);
     }
-}
-
-JamDetector &JamDetector::GetOwner(const Context &aContext)
-{
-#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    JamDetector &detector = *static_cast<JamDetector *>(aContext.GetContext());
-#else
-    JamDetector &detector = Instance::Get().GetThreadNetif().GetJamDetector();
-    OT_UNUSED_VARIABLE(aContext);
-#endif
-    return detector;
 }
 
 }  // namespace Utils

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -178,7 +178,6 @@ private:
     void HandleTimer(void);
     void UpdateHistory(bool aThresholdExceeded);
     void UpdateJamState(void);
-    static JamDetector &GetOwner(const Context &aContext);
 
 private:
     enum


### PR DESCRIPTION
This commit adds a new class `OwnerLocator` which is used by the
callback providing types (like `Timer` or `Tasklet`) to remember the
owner of the object. This change help simplify the handling of
callbacks from such objects. The object itself can be used to get
to its owner using `GetOwner<Type>()` method.  If support for multiple
OpenThread instances is enabled, an `OwnerLocator`  object maintains a
pointer to the owner. But for the single OpenThread instance scenario,
the owner is derived from the single `ot::Instance` object.

------
This change helps simplify the code:
- It removes the `Context` class and `context.hpp` file.
- It removes all the static `GetOwner(const Context &aContext)` methods from different classes and replaces them with a common definition in `OwnerLocator` instead. 
- The logic on how get to a specific `Type` object from `Instance` now resides in the `Instance` class implementation:
  -  e.g., to get to `DataPollManager` from instance we would use `intsance.GetThreadNetif().GetMeshForwarder().GetDataPollManager()` which is now defined as a specialization of a template `Instance` method `Instance::Get<DataPollManager>()`.

