### PR TITLE
[ncp] added support for external NCP vendor hook

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -861,36 +861,33 @@ AM_CONDITIONAL([OPENTHREAD_ENABLE_LEGACY], [test "${enable_legacy}" = "yes"])
 AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_LEGACY],[${OPENTHREAD_ENABLE_LEGACY}],[Define to 1 if you want to use legacy network support])
 
 #
-# Vendor Specific Spinel Command Handler
+# NCP Vendor Hook Source - Specify a C++ file that implements the NCP vendor hook.
 #
 
-AC_ARG_ENABLE(spinelvendor,
-    [AS_HELP_STRING([--enable-spinelvendor],[Enable Spinel vendor command support @<:@default=no@:>@.])],
+AC_ARG_WITH(
+    [ncp-vendor-hook-source],
+    [AS_HELP_STRING([--with-ncp-vendor-hook-source=<VENDOR_HOOK.CPP>],[Specify a C++ file that implements the NCP vendor hook. @<:@default=none@:>@.])],
     [
-        case "${enableval}" in
+        if test "${withval}" = "no"
+        then OPENTHREAD_ENABLE_NCP_VENDOR_HOOK=0
+        elif test '!' -f "${withval}"
+        then AC_MSG_ERROR([Can't open ${withval} for --with-ncp-vendor-hook-source])
+        else
+            OPENTHREAD_ENABLE_NCP_VENDOR_HOOK=1
 
-        no|yes)
-            enable_vendor=${enableval}
-            ;;
-
-        *)
-            AC_MSG_ERROR([Invalid value ${enable_vendor} for --enable-spinelvendor])
-            ;;
-        esac
+            # Get the absolute path.
+            OPENTHREAD_NCP_VENDOR_HOOK_SOURCE=$(cd `dirname ${withval}` && pwd)/$(basename ${withval})
+        fi
     ],
-    [enable_vendor=no])
+    [
+        OPENTHREAD_ENABLE_NCP_VENDOR_HOOK=0
+    ])
 
-if test "$enable_vendor" = "yes"; then
-    OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT=1
-else
-    OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT=0
-fi
-
-AC_MSG_CHECKING([whether to enable spinel vendor command support])
-AC_MSG_RESULT(${enable_vendor})
-AC_SUBST(OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT)
-AM_CONDITIONAL([OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT], [test "${enable_vendor}" = "yes"])
-AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT],[${OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT}],[Define to 1 if you want to implement Spinel vendor command support])
+AC_MSG_CHECKING([for NCP vendor hook source])
+AC_MSG_RESULT(${OPENTHREAD_NCP_VENDOR_HOOK_SOURCE-none})
+AC_SUBST(OPENTHREAD_NCP_VENDOR_HOOK_SOURCE)
+AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_NCP_VENDOR_HOOK],[${OPENTHREAD_ENABLE_NCP_VENDOR_HOOK}],[Define to 1 if using NCP vendor hook])
+AM_CONDITIONAL([OPENTHREAD_ENABLE_NCP_VENDOR_HOOK], [test "${OPENTHREAD_ENABLE_NCP_VENDOR_HOOK}" = "1"])
 
 #
 # Child Supervision
@@ -1534,6 +1531,7 @@ AC_MSG_NOTICE([
   OpenThread NCP-MTD support                : ${enable_ncp_app_mtd}
   OpenThread NCP-FTD support                : ${enable_ncp_app_ftd}
   OpenThread NCP-BUS Configuration          : ${with_ncp_bus}
+  OpenThread NCP Vendor Hook Source         : ${with_ncp_vendor_hook_source}
   OpenThread Multiple Instances support     : ${enable_multiple_instances}
   OpenThread MTD Network Diagnostic support : ${enable_mtd_network_diagnostic}
   OpenThread builtin mbedtls support        : ${enable_builtin_mbedtls}

--- a/src/ncp/Makefile.am
+++ b/src/ncp/Makefile.am
@@ -29,6 +29,7 @@
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 EXTRA_DIST                                        = \
+    example_vendor_hook.cpp                         \
     $(NULL)
 
 # Pull in the sources that comprise the OpenThread NCP library.
@@ -83,6 +84,24 @@ COMMON_SOURCES                                    = \
     ncp_uart.cpp                                    \
     ncp_uart.hpp                                    \
     $(NULL)
+
+if OPENTHREAD_ENABLE_NCP_VENDOR_HOOK
+
+.INTERMEDIATE: ncp_vendor_hook_temp.cpp
+ncp_vendor_hook_temp.cpp: ${OPENTHREAD_NCP_VENDOR_HOOK_SOURCE}
+	$(AM_V_GEN)cp $< $@
+
+# "nodist_" prefix tells automake not to include in 'make dist'
+nodist_libopenthread_ncp_mtd_a_SOURCES            = \
+    ncp_vendor_hook_temp.cpp                        \
+    $(NULL)
+
+# "nodist_" prefix tells automake not to include in 'make dist'
+nodist_libopenthread_ncp_ftd_a_SOURCES            = \
+    ncp_vendor_hook_temp.cpp                        \
+    $(NULL)
+
+endif # if OPENTHREAD_ENABLE_NCP_VENDOR_HOOK
 
 libopenthread_ncp_mtd_a_SOURCES                   = \
    $(COMMON_SOURCES)                                \

--- a/src/ncp/example_vendor_hook.cpp
+++ b/src/ncp/example_vendor_hook.cpp
@@ -1,0 +1,54 @@
+/*
+ *    Copyright (c) 2016-2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+ *    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file shows how to implement the NCP vendor hook.
+ */
+
+#include "ncp_base.hpp"
+
+namespace ot {
+namespace Ncp {
+
+otError NcpBase::VendorCommandHandler(uint8_t aHeader, unsigned int aCommand)
+{
+    otError error = OT_ERROR_NONE;
+
+    switch (aCommand) {
+
+    // TODO: Implement your command handlers here.
+
+    default:
+        error = SendLastStatus(aHeader, SPINEL_STATUS_INVALID_COMMAND);
+    }
+
+    return error;
+}
+
+}  // namespace Ncp
+}  // namespace ot

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -950,7 +950,7 @@ otError NcpBase::HandleCommand(uint8_t aHeader, unsigned int aCommand)
 
     default:
 
-#if OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT
+#if OPENTHREAD_ENABLE_NCP_VENDOR_HOOK
         if (aCommand >= SPINEL_CMD_VENDOR__BEGIN && aCommand < SPINEL_CMD_VENDOR__END)
         {
             error = VendorCommandHandler(aHeader, aCommand);

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -256,9 +256,9 @@ private:
     void HandleTmfProxyStream(otMessage *aMessage, uint16_t aLocator, uint16_t aPort);
 #endif // OPENTHREAD_FTD && OPENTHREAD_ENABLE_TMF_PROXY
 
-#if OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT
+#if OPENTHREAD_ENABLE_NCP_VENDOR_HOOK
     otError VendorCommandHandler(uint8_t aHeader, unsigned int aCommand);
-#endif // OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT
+#endif // OPENTHREAD_ENABLE_NCP_VENDOR_HOOK
 
     otError CommandHandler_NOOP(uint8_t aHeader);
     otError CommandHandler_RESET(uint8_t aHeader);


### PR DESCRIPTION
This change (requested by @pvanhorn) allows developers to add a hook source file to the NCP build that contains hook for implementing vendor-specific commands. This is done via a new configure script argument, `--with-ncp-vendor-hook-source=<C++FILE>`, with the argument being a single C++ source file containing the hook.

This isn't a terribly elegant solution to this sort of problem, so long-term we should consider major refactoring of the NCP codebase to enable the flexibility of allowing the vendor to implement a library that can be linked in, instead of a file which must be compiled in.
