### PR TITLE
[cli] make CLI buffer sizes configurable

### DIFF
--- a/src/cli/cli_uart.hpp
+++ b/src/cli/cli_uart.hpp
@@ -113,7 +113,7 @@ private:
     {
         kRxBufferSize = OPENTHREAD_CONFIG_CLI_UART_RX_BUFFER_SIZE,
         kTxBufferSize = OPENTHREAD_CONFIG_CLI_UART_TX_BUFFER_SIZE,
-        kMaxLineLength = OPENTHREAD_CONFIG_CLI_LINE_LENGTH,
+        kMaxLineLength = OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH,
     };
 
     otError ProcessCommand(void);

--- a/src/cli/cli_uart.hpp
+++ b/src/cli/cli_uart.hpp
@@ -111,9 +111,9 @@ public:
 private:
     enum
     {
-        kRxBufferSize = 512,
-        kTxBufferSize = 1024,
-        kMaxLineLength = 128,
+        kRxBufferSize = OPENTHREAD_CONFIG_CLI_UART_RX_BUFFER_SIZE,
+        kTxBufferSize = OPENTHREAD_CONFIG_CLI_UART_TX_BUFFER_SIZE,
+        kMaxLineLength = OPENTHREAD_CONFIG_CLI_LINE_LENGTH,
     };
 
     otError ProcessCommand(void);

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -232,6 +232,36 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_CLI_LINE_LENGTH
+ *
+ *  The maximum size of the CLI line in bytes
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CLI_LINE_LENGTH
+#define OPENTHREAD_CONFIG_CLI_LINE_LENGTH                       128
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_CLI_UART_RX_BUFFER_SIZE
+ *
+ *  The size of CLI UART RX buffer in bytes
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CLI_UART_RX_BUFFER_SIZE
+#define OPENTHREAD_CONFIG_CLI_UART_RX_BUFFER_SIZE               512
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_CLI_TX_BUFFER_SIZE
+ *
+ *  The size of CLI message buffer in bytes
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CLI_UART_TX_BUFFER_SIZE
+#define OPENTHREAD_CONFIG_CLI_UART_TX_BUFFER_SIZE               1024
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_MAX_CHILDREN
  *
  * The maximum number of children.

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -232,13 +232,13 @@
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_CLI_LINE_LENGTH
+ * @def OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH
  *
  *  The maximum size of the CLI line in bytes
  *
  */
-#ifndef OPENTHREAD_CONFIG_CLI_LINE_LENGTH
-#define OPENTHREAD_CONFIG_CLI_LINE_LENGTH                       128
+#ifndef OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH
+#define OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH                   128
 #endif
 
 /**


### PR DESCRIPTION
At present, the buffer sizes for the CLI are hard-coded, to 512 bytes for the receive buffer, 1kB for transmit, and a 128 byte line limit.  In tight memory scenarios, these figures can be unworkable.

The following commits add some configuration parameters to the `openthread-core-config-default.h` header to enable adjustment of these buffer sizes.