### PR TITLE
[mle] allow to use GetChildInfo method on restored children

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3748,7 +3748,7 @@ otError MleRouter::GetChildInfo(Child &aChild, otChildInfo &aChildInfo)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aChild.GetState() == Neighbor::kStateValid, error = OT_ERROR_NOT_FOUND);
+    VerifyOrExit(aChild.IsStateValidOrRestoring(), error = OT_ERROR_NOT_FOUND);
 
     memset(&aChildInfo, 0, sizeof(aChildInfo));
     memcpy(&aChildInfo.mExtAddress, &aChild.GetExtAddress(), sizeof(aChildInfo.mExtAddress));


### PR DESCRIPTION
Recently we have seen a random crashing of NCP.

After debugging I see that there is a problem with assert: 
`mle_router.cpp:4892: void ot::Mle::MleRouter::SignalChildUpdated(..): Assertion error == OT_ERROR_NONE failed.`

This was introduced in #2280 

So basically, whenever Router/Leader (NCP) has stored child in persistent storage, and after reboot previous child does not exist anymore, node tries to remove the child after stored child timeout.
This results in following calls: `MleRouter::RemoveNeighbor -> MleRouter::SignalChildUpdated -> MleRouter::GetChildInfo`

Currently `GetChildInfo `method returns `OT_ERROR_NOT_FOUND `for children with other than valid state. However in the scenario described above, the state of a child is either `kStateRestored `(rx-off) or `kStateChildUpdateRequest `(rx-on). This finally leads to assert.

To reproduce, just use spinel-cli to create the network. Then join one end-device (preferable with short child timeout e.g. 10s). Then turn-off NCP, turn-off ED and turn-on NCP again. After child timeout of the node, assert will be caught.
