### PR TITLE
[ncp] add missing break statement

### DIFF
--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -731,6 +731,7 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset, const 
             }
 
             aDataset.mIsChannelMaskPage0Set = true;
+            break;
         }
 
         case SPINEL_PROP_DATASET_RAW_TLVS:


### PR DESCRIPTION
GCC 7.2.0 throws: `ncp_base_ftd.cpp:733: error: this statement may fall through.`

I did not analyze the code in great detail, but it seems, that `break` is missing.