### PR TITLE
[child-info] add mIsStateRestoring to otChildInfo 

### DIFF
--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -963,6 +963,7 @@ typedef struct
     bool           mSecureDataRequest : 1; ///< Secure Data Requests
     bool           mFullFunction : 1;      ///< Full Function Device
     bool           mFullNetworkData : 1;   ///< Full Network Data
+    bool           mIsStateRestoring : 1;  ///< Is in restoring state
     uint8_t        mIp6AddressesLength;    ///< Number of entries in IPv6 address array.
     const otIp6Address *mIp6Addresses;     ///< Array of IPv6 addresses (unused entries contain unspecified address).
 } otChildInfo;

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3766,6 +3766,7 @@ otError MleRouter::GetChildInfo(Child &aChild, otChildInfo &aChildInfo)
     aChildInfo.mSecureDataRequest = aChild.IsSecureDataRequest();
     aChildInfo.mFullFunction      = aChild.IsFullThreadDevice();
     aChildInfo.mFullNetworkData   = aChild.IsFullNetworkData();
+    aChildInfo.mIsStateRestoring  = aChild.IsStateRestoring();
 
     aChildInfo.mIp6AddressesLength = Child::kMaxIp6AddressPerChild;
     aChildInfo.mIp6Addresses       = aChild.GetIp6Addresses();

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -100,6 +100,8 @@ void NcpBase::HandleChildTableChanged(otThreadChildTableEvent aEvent, const otCh
 
     VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(SPINEL_PROP_THREAD_CHILD_TABLE));
 
+    VerifyOrExit(!aChildInfo.mIsStateRestoring);
+
     switch (aEvent)
     {
     case OT_THREAD_CHILD_TABLE_EVENT_CHILD_ADDED:
@@ -159,7 +161,8 @@ otError NcpBase::GetPropertyHandler_THREAD_CHILD_TABLE(void)
 
     for (uint8_t index = 0; index < maxChildren; index++)
     {
-        if (otThreadGetChildInfoByIndex(mInstance, index, &childInfo) != OT_ERROR_NONE)
+        if ((otThreadGetChildInfoByIndex(mInstance, index, &childInfo) != OT_ERROR_NONE) ||
+            childInfo.mIsStateRestoring)
         {
             continue;
         }


### PR DESCRIPTION
This commit adds a new field `mIsStateRestoring` to `otChildInfo`
struct to inform the if the child is being restored. This field is
used in `NcpBase` to filter child entries in restoring state.

---------------------
The fix from https://github.com/openthread/openthread/pull/2353 changes the behavior of `SPINEL_PROP_THREAD_CHILD_TABLE` property (to now include children in "restoring" state). The change in this PR adds logic to filter children in restoring state in `NcpBase` (this is to ensure compatibility with earlier drivers and keeping behavior same).. 

As a possible future improvement it may be good to expose the full child table (all child entries in valid and/or restoring states) from a separate Spinel property. 