### PR TITLE
[cc26xx] remove -pedantic-errors from cc26xx driverlib build

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -243,21 +243,21 @@ set -x
     arm-none-eabi-size  output/nrf52840/bin/ot-ncp-ftd || die
     arm-none-eabi-size  output/nrf52840/bin/ot-ncp-mtd || die
 
-    # git checkout -- . || die
-    # git clean -xfd || die
-    # ./bootstrap || die
-    # make -f examples/Makefile-cc2650 || die
-    # arm-none-eabi-size  output/cc2650/bin/ot-cli-mtd || die
-    # arm-none-eabi-size  output/cc2650/bin/ot-ncp-mtd || die
+    git checkout -- . || die
+    git clean -xfd || die
+    ./bootstrap || die
+    make -f examples/Makefile-cc2650 || die
+    arm-none-eabi-size  output/cc2650/bin/ot-cli-mtd || die
+    arm-none-eabi-size  output/cc2650/bin/ot-ncp-mtd || die
 
-    # git checkout -- . || die
-    # git clean -xfd || die
-    # ./bootstrap || die
-    # COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-cc2652 || die
-    # arm-none-eabi-size  output/cc2652/bin/ot-cli-ftd || die
-    # arm-none-eabi-size  output/cc2652/bin/ot-cli-mtd || die
-    # arm-none-eabi-size  output/cc2652/bin/ot-ncp-ftd || die
-    # arm-none-eabi-size  output/cc2652/bin/ot-ncp-mtd || die
+    git checkout -- . || die
+    git clean -xfd || die
+    ./bootstrap || die
+    COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-cc2652 || die
+    arm-none-eabi-size  output/cc2652/bin/ot-cli-ftd || die
+    arm-none-eabi-size  output/cc2652/bin/ot-cli-mtd || die
+    arm-none-eabi-size  output/cc2652/bin/ot-ncp-ftd || die
+    arm-none-eabi-size  output/cc2652/bin/ot-ncp-mtd || die
 
     git checkout -- . || die
     git clean -xfd || die

--- a/examples/platforms/cc2650/Makefile.am
+++ b/examples/platforms/cc2650/Makefile.am
@@ -30,6 +30,11 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 lib_LIBRARIES                                         = libopenthread-cc2650.a
 
+# Do not enable -pedantic-errors for cc26xx driverlib
+override CFLAGS                                      := $(filter-out -pedantic-errors,$(CFLAGS))
+override CXXFLAGS                                    := $(filter-out -pedantic-errors,$(CXXFLAGS))
+
+
 libopenthread_cc2650_a_CPPFLAGS                       = \
     -I$(top_srcdir)/include                             \
     -I$(top_srcdir)/src                                 \

--- a/examples/platforms/cc2652/Makefile.am
+++ b/examples/platforms/cc2652/Makefile.am
@@ -30,6 +30,10 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 lib_LIBRARIES                                         = libopenthread-cc2652.a
 
+# Do not enable -pedantic-errors for cc26xx driverlib
+override CFLAGS                                      := $(filter-out -pedantic-errors,$(CFLAGS))
+override CXXFLAGS                                    := $(filter-out -pedantic-errors,$(CXXFLAGS))
+
 libopenthread_cc2652_a_CPPFLAGS                       = \
     -I$(top_srcdir)/include                             \
     -I$(top_srcdir)/src                                 \


### PR DESCRIPTION
Resolves #2362.