### PR TITLE
[network-data] added support for iterating over services from leader data

### DIFF
--- a/include/openthread/server.h
+++ b/include/openthread/server.h
@@ -111,6 +111,21 @@ OTAPI otError OTCALL otServerGetNextService(otInstance *aInstance, otNetworkData
                                             otServiceConfig *aConfig);
 
 /**
+ * This function gets the next service in the leader Network Data.
+ *
+ * @param[in]     aInstance  A pointer to an OpenThread instance.
+ * @param[inout]  aIterator  A pointer to the Network Data iterator context. To get the first service entry
+                             it should be set to OT_NETWORK_DATA_ITERATOR_INIT.
+ * @param[out]    aConfig    A pointer to where the service information will be placed.
+ *
+ * @retval OT_ERROR_NONE       Successfully found the next service.
+ * @retval OT_ERROR_NOT_FOUND  No subsequent service exists in the leader Network Data.
+ *
+ */
+OTAPI otError OTCALL otServerGetNextLeaderService(otInstance *aInstance, otNetworkDataIterator *aIterator,
+                                                  otServiceConfig *aConfig);
+
+/**
  * Immediately register the local network data with the Leader.
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.

--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -857,6 +857,11 @@ typedef struct otServerConfig
 typedef struct otServiceConfig
 {
     /**
+     * Service ID. This field is used to return service ID when iterating over network data from leader.
+     */
+    uint8_t mServiceID;
+
+    /**
      * IANA Enterprise Number.
      */
     uint32_t mEnterpriseNumber;

--- a/src/core/api/server_api.cpp
+++ b/src/core/api/server_api.cpp
@@ -87,6 +87,20 @@ exit:
     return error;
 }
 
+otError otServerGetNextLeaderService(otInstance *aInstance, otNetworkDataIterator *aIterator,
+                                     otServiceConfig *aConfig)
+{
+    otError error = OT_ERROR_NONE;
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    VerifyOrExit(aIterator && aConfig, error = OT_ERROR_INVALID_ARGS);
+
+    error = instance.GetThreadNetif().GetNetworkDataLeader().GetNextService(aIterator, aConfig);
+
+exit:
+    return error;
+}
+
 otError otServerRegister(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -285,6 +285,7 @@ otError NetworkData::GetNextService(otNetworkDataIterator *aIterator, uint16_t a
             {
                 memset(aConfig, 0, sizeof(*aConfig));
 
+                aConfig->mServiceID = service->GetServiceID();
                 aConfig->mEnterpriseNumber = service->GetEnterpriseNumber();
                 aConfig->mServiceDataLength = service->GetServiceDataLength();
 


### PR DESCRIPTION
Current implementation doesn't allow to read service ID assigned by the leader after calling `otServiceAdd`+register. This PR adds support for iterating over leader data and retrieving the resulting ID.