### PR TITLE
[mac] process security for neighbors on FFD Children

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1586,26 +1586,12 @@ void Mac::ReceiveDoneTask(Frame *aFrame, otError aError)
                      ((mRxOnWhenIdle && dstaddr.mShortAddress == kShortAddrBroadcast) ||
                       dstaddr.mShortAddress == mShortAddress), error = OT_ERROR_DESTINATION_ADDRESS_FILTERED);
 
-#if OPENTHREAD_FTD
-
-        // Allow non link-local multicasts from neighbor routers if FFD
+        // Allow  multicasts from neighbor routers if FFD
         if (neighbor == NULL && dstaddr.mShortAddress == kShortAddrBroadcast &&
-            srcaddr.mLength == sizeof(ShortAddress) &&
-            GetNetif().GetMle().IsActiveRouter(srcaddr.mShortAddress) &&
             (GetNetif().GetMle().GetDeviceMode() & Mle::ModeTlv::kModeFFD))
         {
-            uint8_t routerid;
-
-            routerid = GetNetif().GetMle().GetRouterId(srcaddr.mShortAddress);
-            neighbor = static_cast<Neighbor *>(GetNetif().GetMle().GetRouter(routerid));
-
-            if (neighbor != NULL && (neighbor->GetState() != Neighbor::kStateValid))
-            {
-                neighbor = NULL;
-            }
+            neighbor = GetNetif().GetMle().GetRxOnlyNeighborRouter(srcaddr);
         }
-
-#endif
 
         break;
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1586,6 +1586,7 @@ void Mac::ReceiveDoneTask(Frame *aFrame, otError aError)
                      ((mRxOnWhenIdle && dstaddr.mShortAddress == kShortAddrBroadcast) ||
                       dstaddr.mShortAddress == mShortAddress), error = OT_ERROR_DESTINATION_ADDRESS_FILTERED);
 
+#ifdef OPENTHREAD_FTD
         // Allow multicasts from neighbor routers if FFD
         if (neighbor == NULL && dstaddr.mShortAddress == kShortAddrBroadcast &&
             (GetNetif().GetMle().GetDeviceMode() & Mle::ModeTlv::kModeFFD))
@@ -1600,6 +1601,7 @@ void Mac::ReceiveDoneTask(Frame *aFrame, otError aError)
             	neighbor = NULL;
             }
         }
+#endif
 
         break;
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1586,7 +1586,8 @@ void Mac::ReceiveDoneTask(Frame *aFrame, otError aError)
                      ((mRxOnWhenIdle && dstaddr.mShortAddress == kShortAddrBroadcast) ||
                       dstaddr.mShortAddress == mShortAddress), error = OT_ERROR_DESTINATION_ADDRESS_FILTERED);
 
-#ifdef OPENTHREAD_FTD
+#if OPENTHREAD_FTD
+
         // Allow multicasts from neighbor routers if FFD
         if (neighbor == NULL && dstaddr.mShortAddress == kShortAddrBroadcast &&
             (GetNetif().GetMle().GetDeviceMode() & Mle::ModeTlv::kModeFFD))
@@ -1596,11 +1597,12 @@ void Mac::ReceiveDoneTask(Frame *aFrame, otError aError)
             routerid = GetNetif().GetMle().GetRouterId(srcaddr.mShortAddress);
             neighbor = static_cast<Neighbor *>(GetNetif().GetMle().GetRouter(routerid));
 
-            if(neighbor->GetState() != Neighbor::kStateValid)
+            if (neighbor->GetState() != Neighbor::kStateValid)
             {
-            	neighbor = NULL;
+                neighbor = NULL;
             }
         }
+
 #endif
 
         break;

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1597,7 +1597,7 @@ void Mac::ReceiveDoneTask(Frame *aFrame, otError aError)
             routerid = GetNetif().GetMle().GetRouterId(srcaddr.mShortAddress);
             neighbor = static_cast<Neighbor *>(GetNetif().GetMle().GetRouter(routerid));
 
-            if (neighbor->GetState() != Neighbor::kStateValid)
+            if (neighbor != NULL && (neighbor->GetState() != Neighbor::kStateValid))
             {
                 neighbor = NULL;
             }

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1588,8 +1588,10 @@ void Mac::ReceiveDoneTask(Frame *aFrame, otError aError)
 
 #if OPENTHREAD_FTD
 
-        // Allow multicasts from neighbor routers if FFD
+        // Allow non link-local multicasts from neighbor routers if FFD
         if (neighbor == NULL && dstaddr.mShortAddress == kShortAddrBroadcast &&
+            srcaddr.mLength == sizeof(ShortAddress) &&
+            GetNetif().GetMle().IsActiveRouter(srcaddr.mShortAddress) &&
             (GetNetif().GetMle().GetDeviceMode() & Mle::ModeTlv::kModeFFD))
         {
             uint8_t routerid;

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1514,7 +1514,7 @@ otError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::Messa
             mRouterSelectionJitterTimeout = (otPlatRandomGet() % mRouterSelectionJitter) + 1;
         }
 
-        // fall through
+    // fall through
 
     case OT_DEVICE_ROLE_LEADER:
 
@@ -1833,7 +1833,7 @@ void MleRouter::HandleStateUpdateTimer(void)
             ExitNow();
         }
 
-        // fall through
+    // fall through
 
     case OT_DEVICE_ROLE_ROUTER:
         // verify path to leader
@@ -4805,7 +4805,7 @@ void MleRouter::RemoveChildren(void)
         case Neighbor::kStateValid:
             SignalChildUpdated(OT_THREAD_CHILD_TABLE_EVENT_CHILD_REMOVED, mChildren[i]);
 
-            // fall-through
+        // fall-through
 
         case Neighbor::kStateChildUpdateRequest:
         case Neighbor::kStateRestored:

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3313,16 +3313,14 @@ Neighbor *MleRouter::GetNeighbor(uint16_t aAddress)
             }
         }
 
-        for (int i = 0; i <= kMaxRouterId; i++)
+        if (IsActiveRouter(aAddress))
         {
-            if (i == mRouterId)
-            {
-                continue;
-            }
+            uint8_t routerId = GetRouterId(aAddress);
+            Router *router = &mRouters[routerId];
 
-            if (mRouters[i].GetState() == Neighbor::kStateValid && mRouters[i].GetRloc16() == aAddress)
+            if (router->GetState() == Neighbor::kStateValid && router->GetRloc16() == aAddress)
             {
-                ExitNow(rval = &mRouters[i]);
+                ExitNow(rval = router);
             }
         }
 

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -518,6 +518,17 @@ public:
     Neighbor *GetNeighbor(const Ip6::Address &aAddress);
 
     /**
+     * This method returns a pointer to a Neighbor object if a one-way link is maintained
+     * as in the instance of an FFD child with neighbor routers.
+     *
+     * @param[in]  aAddress  The address of the Neighbor.
+     *
+     * @returns A pointer to the Neighbor corresponding to @p aAddress, NULL otherwise.
+     *
+     */
+    Neighbor *GetRxOnlyNeighborRouter(const Mac::Address &aAddress);
+
+    /**
      * This method retains diagnostic information for an attached child by Child ID or RLOC16.
      *
      * @param[in]   aChildId    The Child ID or RLOC16 for an attached child.

--- a/src/core/thread/mle_router_mtd.hpp
+++ b/src/core/thread/mle_router_mtd.hpp
@@ -102,6 +102,7 @@ public:
     Neighbor *GetNeighbor(const Mac::ExtAddress &aAddress) { return Mle::GetNeighbor(aAddress); }
     Neighbor *GetNeighbor(const Mac::Address &aAddress) { return Mle::GetNeighbor(aAddress); }
     Neighbor *GetNeighbor(const Ip6::Address &aAddress) { return Mle::GetNeighbor(aAddress); }
+    Neighbor *GetRxOnlyNeighborRouter(const Mac::Address &aAddress) { OT_UNUSED_VARIABLE(aAddress); return NULL; }
 
     otError GetNextNeighborInfo(otNeighborInfoIterator &, otNeighborInfo &) { return OT_ERROR_NOT_IMPLEMENTED; }
 


### PR DESCRIPTION
Fixes #2364 

Also simplified the existing MleRouter::GetNeighbor() slightly