### PR TITLE
[mle] fixes to restoring children

### DIFF
--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -850,7 +850,6 @@ private:
     uint8_t mLeaderWeight;
     uint32_t mFixedLeaderPartitionId;  ///< only for certification testing
     bool mRouterRoleEnabled : 1;
-    bool mIsRouterRestoringChildren : 1;
     bool mAddressSolicitPending : 1;
 
     uint8_t mRouterId;


### PR DESCRIPTION
This commit makes the following fixes:
- Relax the length check in `RemoveStoredChild()`
- Remove children that do not match router ID
- Simplify restoring logic and remove `mIsRouterrestoringChildren` state var