### PR TITLE
[mle] detect duplicate/invalid child info in non-volatile

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -347,23 +347,7 @@ otError Mle::Restore(void)
     {
         netif.GetMle().SetRouterId(GetRouterId(GetRloc16()));
         netif.GetMle().SetPreviousPartitionId(networkInfo.mPreviousPartitionId);
-
-        switch (netif.GetMle().RestoreChildren())
-        {
-        // If there are more saved children in non-volatile settings
-        // than could be restored or the values in the settings are
-        // invalid, erase all the children info in the settings and
-        // refresh the info to ensure that the non-volatile settings
-        // stay in sync with the child table.
-
-        case OT_ERROR_FAILED:
-        case OT_ERROR_NO_BUFS:
-            netif.GetMle().RefreshStoredChildren();
-            break;
-
-        default:
-            break;
-        }
+        netif.GetMle().RestoreChildren();
     }
 
 exit:

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3642,19 +3642,21 @@ exit:
     return error;
 }
 
-otError MleRouter::RestoreChildren(void)
+void MleRouter::RestoreChildren(void)
 {
     otError error = OT_ERROR_NONE;
+    bool foundDuplicate = false;
+    uint8_t index;
 
-    for (uint8_t i = 0; ; i++)
+    for (index = 0; ; index++)
     {
         Child *child;
         Settings::ChildInfo childInfo;
         uint16_t length;
 
         length = sizeof(childInfo);
-        SuccessOrExit(error = otPlatSettingsGet(&GetInstance(), Settings::kKeyChildInfo, i,
-                                                reinterpret_cast<uint8_t *>(&childInfo), &length));
+        SuccessOrExit(otPlatSettingsGet(&GetInstance(), Settings::kKeyChildInfo, index,
+                                        reinterpret_cast<uint8_t *>(&childInfo), &length));
         VerifyOrExit(length >= sizeof(childInfo), error = OT_ERROR_PARSE);
 
         child = FindChild(*static_cast<Mac::ExtAddress *>(&childInfo.mExtAddress));
@@ -3662,6 +3664,10 @@ otError MleRouter::RestoreChildren(void)
         if (child == NULL)
         {
             VerifyOrExit((child = NewChild()) != NULL, error = OT_ERROR_NO_BUFS);
+        }
+        else
+        {
+            foundDuplicate = true;
         }
 
         memset(child, 0, sizeof(*child));
@@ -3676,7 +3682,17 @@ otError MleRouter::RestoreChildren(void)
     }
 
 exit:
-    return error;
+
+    if (foundDuplicate || (index > kMaxChildren) || (error != OT_ERROR_NONE))
+    {
+        // If there is any error, e.g., there are more saved children
+        // in non-volatile settings than could be restored or there are
+        // duplicate entries with same extended address, refresh the stored
+        // children info to ensure that the non-volatile settings remain
+        // consistent with the child table.
+
+        RefreshStoredChildren();
+    }
 }
 
 otError MleRouter::RemoveStoredChild(uint16_t aChildRloc16)

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -438,12 +438,8 @@ public:
     /**
      * This method restores children information from non-volatile memory.
      *
-     * @retval  OT_ERROR_NONE     Successfully restored children information.
-     * @retval  OT_ERROR_FAILED   The saved child info in non-volatile memory is invalid.
-     * @retval  OT_ERROR_NO_BUFS  More children in settings than max children.
-     *
      */
-    otError RestoreChildren(void);
+    void RestoreChildren(void);
 
     /**
      * This method remove a stored child information from non-volatile memory.
@@ -466,16 +462,6 @@ public:
      *
      */
     otError StoreChild(uint16_t aChildRloc16);
-
-    /**
-     * This method refreshes all the saved children information in non-volatile memory by first erasing any saved
-     * child information in non-volatile memory and then saving all children info.
-     *
-     * @retval  OT_ERROR_NONE      Successfully refreshed all children info in non-volatile memory
-     * @retval  OT_ERROR_NO_BUFS   Insufficient available buffers to store child.
-     *
-     */
-    otError RefreshStoredChildren(void);
 
     /**
      * This method returns a pointer to a Neighbor object.
@@ -744,6 +730,7 @@ private:
     otError AppendActiveDataset(Message &aMessage);
     otError AppendPendingDataset(Message &aMessage);
     otError GetChildInfo(Child &aChild, otChildInfo &aChildInfo);
+    otError RefreshStoredChildren(void);
     otError HandleDetachStart(void);
     otError HandleChildStart(AttachMode aMode);
     otError HandleLinkRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/thread/mle_router_mtd.hpp
+++ b/src/core/thread/mle_router_mtd.hpp
@@ -93,10 +93,9 @@ public:
         return NULL;
     }
 
-    otError RestoreChildren(void) {return OT_ERROR_NOT_IMPLEMENTED; }
+    void RestoreChildren(void) { }
     otError RemoveStoredChild(uint16_t) {return OT_ERROR_NOT_IMPLEMENTED; }
     otError StoreChild(uint16_t) {return OT_ERROR_NOT_IMPLEMENTED; }
-    otError RefreshStoredChildren(void) { return OT_ERROR_NOT_IMPLEMENTED; }
 
     Neighbor *GetNeighbor(uint16_t aAddress) { return Mle::GetNeighbor(aAddress); }
     Neighbor *GetNeighbor(const Mac::ExtAddress &aAddress) { return Mle::GetNeighbor(aAddress); }


### PR DESCRIPTION
This commit changes the `MleRouter::RestoreChildren()` such that it
can detect invalid child info in non-volatile settings (i.e., if there
are more entries than max allowed/supported children, or if there are
duplicate entries with same ext address in the list). If an invalid
settings is detected, the non-volatile child info is refreshed
(erased and re-written).