### PR TITLE
[nrf52840] Fix HF clock stop procedure in radio driver

### DIFF
--- a/examples/platforms/nrf52840/Makefile.am
+++ b/examples/platforms/nrf52840/Makefile.am
@@ -38,6 +38,7 @@ COMMONCPPFLAGS                                                                  
     -DCONFIG_GPIO_AS_PINRESET                                                                                \
     -DNRF52840_XXAA                                                                                          \
     -DENABLE_FEM=1                                                                                           \
+    -DNRF_DRV_RADIO802154_PROJECT_CONFIG=\"platform-config.h\"                                               \
     -I$(top_srcdir)/include                                                                                  \
     -I$(top_srcdir)/examples/platforms                                                                       \
     -I$(top_srcdir)/src/core                                                                                 \

--- a/examples/platforms/nrf52840/flash_sd.c
+++ b/examples/platforms/nrf52840/flash_sd.c
@@ -42,7 +42,6 @@
 #include "platform-nrf5.h"
 #include "softdevice.h"
 
-#define MIN(a, b)        (((a) < (b)) ? (a) : (b))
 #define FLASH_PAGE_SIZE  4096
 #define FLASH_TIMEOUT    1000
 

--- a/examples/platforms/nrf52840/platform-config.h
+++ b/examples/platforms/nrf52840/platform-config.h
@@ -36,10 +36,12 @@
 #define PLATFORM_CONFIG_H_
 
 #include "device/nrf.h"
-#include "hal/nrf_uart.h"
+#include "drivers/clock/nrf_drv_clock.h"
 #include "hal/nrf_peripherals.h"
 #include "hal/nrf_radio.h"
+#include "hal/nrf_uart.h"
 
+#include "openthread-core-config.h"
 #include <openthread/config.h>
 
 /*******************************************************************************
@@ -332,6 +334,58 @@
  */
 #ifndef USB_CDC_AS_SERIAL_TRANSPORT
 #define USB_CDC_AS_SERIAL_TRANSPORT  0
+#endif
+
+/*******************************************************************************
+ * @section Radio driver configuration.
+ ******************************************************************************/
+
+/**
+ * @def NRF_DRV_RADIO802154_PENDING_SHORT_ADDRESSES
+ *
+ * Number of slots containing short addresses of nodes for which pending data is stored.
+ *
+ */
+#ifndef NRF_DRV_RADIO802154_PENDING_SHORT_ADDRESSES
+#define NRF_DRV_RADIO802154_PENDING_SHORT_ADDRESSES  OPENTHREAD_CONFIG_MAX_CHILDREN
+#endif
+
+/**
+ * @def NRF_DRV_RADIO802154_PENDING_EXTENDED_ADDRESSES
+ *
+ * Number of slots containing extended addresses of nodes for which pending data is stored.
+ *
+ */
+#ifndef NRF_DRV_RADIO802154_PENDING_EXTENDED_ADDRESSES
+#define NRF_DRV_RADIO802154_PENDING_EXTENDED_ADDRESSES  OPENTHREAD_CONFIG_MAX_CHILDREN
+#endif
+
+/**
+ * @def NRF_RAAL_HFCLK_START
+ *
+ * Macro to request High Frequency Clock start. It may use external driver or OS function.
+ *
+ */
+#ifndef NRF_RAAL_HFCLK_START
+#define NRF_RAAL_HFCLK_START()                                                                     \
+    do {                                                                                           \
+        nrf_drv_clock_hfclk_request(NULL);                                                         \
+                                                                                                   \
+        while(NRF_CLOCK->HFCLKSTAT != (CLOCK_HFCLKSTAT_SRC_Msk | CLOCK_HFCLKSTAT_STATE_Msk)) {}    \
+    } while(0);
+#endif
+
+/**
+ * @def NRF_RAAL_HFCLK_STOP
+ *
+ * Macro to release High Frequency Clock. It may use external driver or OS function.
+ *
+ */
+#ifndef NRF_RAAL_HFCLK_STOP
+#define NRF_RAAL_HFCLK_STOP()                                                                      \
+    do {                                                                                           \
+        nrf_drv_clock_hfclk_release();                                                             \
+    } while(0);
 #endif
 
 #endif  // PLATFORM_CONFIG_H_

--- a/third_party/NordicSemiconductor/drivers/radio/raal/nrf_raal_config.h
+++ b/third_party/NordicSemiconductor/drivers/radio/raal/nrf_raal_config.h
@@ -31,6 +31,10 @@
 #ifndef NRF_RAAL_CONFIG_H__
 #define NRF_RAAL_CONFIG_H__
 
+#ifdef NRF_DRV_RADIO802154_PROJECT_CONFIG
+#include NRF_DRV_RADIO802154_PROJECT_CONFIG
+#endif
+
 #include <nrf.h>
 
 #ifdef __cplusplus
@@ -61,12 +65,14 @@ extern "C" {
  * Macro to request High Frequency Clock start. It may use external driver or OS function.
  *
  */
+#ifndef NRF_RAAL_HFCLK_START
 #define NRF_RAAL_HFCLK_START()                                                                     \
     do {                                                                                           \
         NRF_CLOCK->TASKS_HFCLKSTART = 1;                                                           \
                                                                                                    \
         while(NRF_CLOCK->HFCLKSTAT != (CLOCK_HFCLKSTAT_SRC_Msk | CLOCK_HFCLKSTAT_STATE_Msk)) {}    \
     } while(0);
+#endif
 
 /**
  * @def NRF_RAAL_HFCLK_STOP
@@ -74,10 +80,12 @@ extern "C" {
  * Macro to release High Frequency Clock. It may use external driver or OS function.
  *
  */
+#ifndef NRF_RAAL_HFCLK_STOP
 #define NRF_RAAL_HFCLK_STOP()                                                                      \
     do {                                                                                           \
         NRF_CLOCK->TASKS_HFCLKSTOP = 1;                                                            \
     } while(0);
+#endif
 
 /**
  *@}

--- a/third_party/NordicSemiconductor/hal/nrf_egu.h
+++ b/third_party/NordicSemiconductor/hal/nrf_egu.h
@@ -45,8 +45,6 @@
 #include "nrf.h"
 #include "nrf_peripherals.h"
 
-#define ASSERT assert
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Should fix #2380 . I don't have NCP USB setup to test it, but I've verified that now radio driver uses clock driver to enable and disable HF clock.