### PR TITLE
[nrf52480] Fix for buffer overrun in otPlatLog

### DIFF
--- a/examples/platforms/nrf52840/logging.c
+++ b/examples/platforms/nrf52840/logging.c
@@ -167,6 +167,12 @@ void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion,
     va_start(paramList, aFormat);
     length += vsnprintf(&logString[length], (LOG_PARSE_BUFFER_SIZE - length),
                         aFormat, paramList);
+
+    if (length > LOG_PARSE_BUFFER_SIZE)
+    {
+        length = LOG_PARSE_BUFFER_SIZE;
+    }
+
     logString[length++] = '\n';
     va_end(paramList);
 


### PR DESCRIPTION
This commit addresses a misunderstanding of what the return value of `vsnprintf()` means.

This fixes issue #2382.