### PR TITLE
[nrf52480] Don't call PlatformDeinit() before NVIC_SystemReset()

### DIFF
--- a/examples/platforms/nrf52840/misc.c
+++ b/examples/platforms/nrf52840/misc.c
@@ -71,8 +71,6 @@ void otPlatReset(otInstance *aInstance)
 {
     (void)aInstance;
 
-    PlatformDeinit();
-
     NVIC_SystemReset();
 }
 


### PR DESCRIPTION
Calling `PlatformDeinit()` before calling `NVIC_SystemReset()` reduces the reliability of `otPlatReset()` to always work properly, and doing so seems superfluous if you are just going to reset the chip anyway.

This fixes issue #2383.