### PR TITLE
[build] let COMMONCFLAGS defined in common-switches.mk take effect

### DIFF
--- a/examples/Makefile-cc2538
+++ b/examples/Makefile-cc2538
@@ -50,8 +50,6 @@ configure_OPTIONS               = \
     --enable-linker-map           \
     $(NULL)
 
-include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
-
 TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..
 AbsTopSourceDir                 := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))..
 
@@ -66,6 +64,8 @@ COMMONCFLAGS                   := \
     -D$(CONFIG_FILE)              \
     -I$(CONFIG_FILE_PATH)         \
     $(NULL)
+
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 CPPFLAGS                       += \
     $(COMMONCFLAGS)               \

--- a/examples/Makefile-cc2650
+++ b/examples/Makefile-cc2650
@@ -50,8 +50,6 @@ configure_OPTIONS               = \
     MBEDTLS_CPPFLAGS="$(CC2650_MBEDTLS_CPPFLAGS)" \
     $(NULL)
 
-include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
-
 CC2650_MBEDTLS_CPPFLAGS  = -DMBEDTLS_CONFIG_FILE='\"cc2650-mbedtls-config.h\"'
 CC2650_MBEDTLS_CPPFLAGS += -I$(PWD)/examples/platforms/cc2650/crypto
 CC2650_MBEDTLS_CPPFLAGS += -I$(PWD)/third_party/ti/devices/cc26x0
@@ -68,6 +66,8 @@ COMMONCFLAGS                   := \
     -g                            \
     $(CC2650_CONFIG_FILE_CPPFLAGS)\
     $(NULL)
+
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 CPPFLAGS                       += \
     $(COMMONCFLAGS)               \

--- a/examples/Makefile-cc2652
+++ b/examples/Makefile-cc2652
@@ -51,7 +51,6 @@ configure_OPTIONS                                          = \
     $(NULL)
 
 DEFAULT_LOGGING                                           ?= 1
-include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 CC2652_MBEDTLS_CPPFLAGS                                    = \
     -DMBEDTLS_CONFIG_FILE='\"cc2652-mbedtls-config.h\"'      \
@@ -73,6 +72,8 @@ COMMONCFLAGS                                              := \
     -g                                                       \
     $(CC2652_CONFIG_FILE_CPPFLAGS)                           \
     $(NULL)
+
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 CPPFLAGS                                                  += \
     $(COMMONCFLAGS)                                          \

--- a/examples/Makefile-da15000
+++ b/examples/Makefile-da15000
@@ -50,8 +50,6 @@ configure_OPTIONS               = \
     MBEDTLS_CPPFLAGS="$(DA15000_MBEDTLS_CPPFLAGS)" \
     $(NULL)
 
-include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
-
 TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..
 AbsTopSourceDir                 := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))..
 
@@ -80,6 +78,8 @@ COMMONCFLAGS                   := \
     -D$(CONFIG_FILE)              \
     -I$(CONFIG_FILE_PATH)         \
     $(NULL)
+
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 CPPFLAGS                       += \
     $(COMMONCFLAGS)               \

--- a/examples/Makefile-efr32
+++ b/examples/Makefile-efr32
@@ -51,8 +51,6 @@ configure_OPTIONS               = \
     MBEDTLS_CPPFLAGS="$(EFR32_MBEDTLS_CPPFLAGS)" \
     $(NULL)
 
-include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
-
 TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..
 AbsTopSourceDir                 := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))..
 
@@ -80,6 +78,8 @@ COMMONCFLAGS                   := \
     -D$(CONFIG_FILE)              \
     -I$(CONFIG_FILE_PATH)         \
     $(NULL)
+
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 CPPFLAGS                       += \
     $(COMMONCFLAGS)               \

--- a/examples/Makefile-emsk
+++ b/examples/Makefile-emsk
@@ -49,8 +49,6 @@ configure_OPTIONS               = \
     --enable-linker-map           \
     $(NULL)
 
-include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
-
 TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..
 AbsTopSourceDir                 := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))..
 
@@ -65,6 +63,8 @@ COMMONCFLAGS                   := \
     -D$(CONFIG_FILE)              \
     -I$(CONFIG_FILE_PATH)         \
     $(NULL)
+
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 CPPFLAGS                       += \
     $(COMMONCFLAGS)               \

--- a/examples/Makefile-gp712
+++ b/examples/Makefile-gp712
@@ -52,7 +52,6 @@ configure_OPTIONS               = \
     $(NULL)
 
 DEFAULT_LOGGING ?= 1
-include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 ifeq ($(CLI_LOGGING),1)
 configure_OPTIONS              += --enable-cli-logging
@@ -70,6 +69,8 @@ COMMONCFLAGS                   := \
     -W                            \
     -Wall                         \
     $(NULL)
+
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 CPPFLAGS                       += \
     $(COMMONCFLAGS)               \

--- a/examples/Makefile-kw41z
+++ b/examples/Makefile-kw41z
@@ -50,8 +50,6 @@ configure_OPTIONS               = \
     --enable-linker-map           \
     $(NULL)
 
-include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
-
 TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..
 AbsTopSourceDir                 := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))..
 
@@ -66,6 +64,8 @@ COMMONCFLAGS                   := \
     -D$(CONFIG_FILE)              \
     -I$(CONFIG_FILE_PATH)         \
     $(NULL)
+
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 CPPFLAGS                       += \
     $(COMMONCFLAGS)               \

--- a/examples/Makefile-nrf52840
+++ b/examples/Makefile-nrf52840
@@ -51,8 +51,6 @@ configure_OPTIONS                                 = \
     MBEDTLS_CPPFLAGS="$(NRF52840_MBEDTLS_CPPFLAGS)" \
     $(NULL)
 
-include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
-
 ifdef SRC_PATH
 configure_OPTIONS              += --srcdir="$(SRC_PATH)"
 endif
@@ -78,6 +76,8 @@ COMMONCFLAGS                   := \
     -D$(CONFIG_FILE)              \
     -I$(CONFIG_FILE_PATH)         \
     $(NULL)
+
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 ifneq ($(CERT_LOG),1)
 COMMONCFLAGS += -DOPENTHREAD_CONFIG_LOG_OUTPUT=OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED

--- a/examples/Makefile-posix
+++ b/examples/Makefile-posix
@@ -68,8 +68,6 @@ configure_OPTIONS                   = \
     --with-ncp-bus=uart               \
     $(NULL)
 
-include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
-
 TopSourceDir                   := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..
 AbsTopSourceDir                := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))..
 
@@ -82,6 +80,8 @@ COMMONCFLAGS                   := \
     -D$(CONFIG_FILE)              \
     -I$(CONFIG_FILE_PATH)         \
     $(NULL)
+
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 CPPFLAGS                       += \
     $(COMMONCFLAGS)               \

--- a/examples/Makefile-samr21
+++ b/examples/Makefile-samr21
@@ -50,8 +50,6 @@ configure_OPTIONS               = \
     --enable-linker-map           \
     $(NULL)
 
-include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
-
 TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..
 AbsTopSourceDir                 := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))..
 
@@ -66,6 +64,8 @@ COMMONCFLAGS                   := \
     -D$(CONFIG_FILE)              \
     -I$(CONFIG_FILE_PATH)         \
     $(NULL)
+
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 CPPFLAGS                       += \
     $(COMMONCFLAGS)               \


### PR DESCRIPTION
COMMONFLAGS in common-switches.mk #2315 would be override by COMMONFLAGS defined afterwards (as in https://github.com/openthread/openthread/blob/master/examples/Makefile-cc2538#L61)
Here adjusts the order to make COMMONCFLAGS defined in common-switches.mk take effect