### PR TITLE
[ncp] update JAM_DETECT_HISTORY_BITMAP to spinel uint64_t

### DIFF
--- a/doc/spinel-protocol-src/spinel-feature-jam-detect.md
+++ b/doc/spinel-protocol-src/spinel-feature-jam-detect.md
@@ -85,7 +85,7 @@ is larger than `PROP_JAM_DETECT_WINDOW` is undefined.
 ### PROP 4613: PROP_JAM_DETECT_HISTORY_BITMAP
 
 * Type: Read-Only
-* Packed-Encoding: `LL`
+* Packed-Encoding: `X`
 * Default Value: Implementation-specific
 * RECOMMENDED for `CAP_JAM_DETECT`
 
@@ -95,6 +95,3 @@ each bit corresponds to one second interval starting with bit 0 for the
 most recent interval and bit 63 for the oldest intervals (63 sec earlier).
 The bit is set to 1 if the jamming detection module observed/detected
 high signal level during the corresponding one second interval.
-The value is read-only and is encoded as two `L` (uint32) values in
-little-endian format (first `L` (uint32) value gives the lower bits
-corresponding to more recent history).

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -1396,17 +1396,7 @@ otError NcpBase::GetPropertyHandler_JAM_DETECT_BUSY(void)
 
 otError NcpBase::GetPropertyHandler_JAM_DETECT_HISTORY_BITMAP(void)
 {
-    otError error = OT_ERROR_NONE;
-    uint64_t historyBitmap = otJamDetectionGetHistoryBitmap(mInstance);
-
-    // History bitmap - bits 0-31
-    SuccessOrExit(error = mEncoder.WriteUint32(static_cast<uint32_t>(historyBitmap & 0xffffffff)));
-
-    // // History bitmap - bits 32-63
-    SuccessOrExit(error = mEncoder.WriteUint32(static_cast<uint32_t>(historyBitmap >> 32)));
-
-exit:
-    return error;
+    return mEncoder.WriteUint64(otJamDetectionGetHistoryBitmap(mInstance));
 }
 
 otError NcpBase::SetPropertyHandler_JAM_DETECT_ENABLE(void)

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -654,7 +654,7 @@ typedef enum
     SPINEL_PROP_JAM_DETECT_BUSY         = SPINEL_PROP_PHY_EXT__BEGIN + 4,
 
     /// Jamming detection history bitmap (for debugging)
-    /** Format: `LL` (read-only)
+    /** Format: `X` (read-only)
      *
      * This value provides information about current state of jamming detection
      * module for monitoring/debugging purpose. It returns a 64-bit value where
@@ -663,9 +663,6 @@ typedef enum
      * The bit is set to 1 if the jamming detection module observed/detected
      * high signal level during the corresponding one second interval.
      *
-     * The value is read-only and is encoded as two uint32 values in
-     * little-endian format (first uint32 gives the lower bits corresponding to
-     * more recent history).
      */
     SPINEL_PROP_JAM_DETECT_HISTORY_BITMAP
                                         = SPINEL_PROP_PHY_EXT__BEGIN + 5,


### PR DESCRIPTION
This commit changes the `JAM_DETECT_HISTORY_BITMAP` format to use spinel primitive type of `uint64_t` added in #2309 instead of two `uint32_t`.

----

Please note that this does not change the (over-the-wire) encoding of this property (instead of `LL` we use `X` (all using little-endian)).