### PR TITLE
[ncp] Supress all output except PROP_LAST_STATUS at startup.

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -564,7 +564,8 @@ NcpBase::NcpBase(Instance *aInstance):
     mFramingErrorCounter(0),
     mRxSpinelFrameCounter(0),
     mRxSpinelOutOfOrderTidCounter(0),
-    mTxSpinelFrameCounter(0)
+    mTxSpinelFrameCounter(0),
+    mDidInitialUpdates(false)
 {
     assert(mInstance != NULL);
 
@@ -1028,7 +1029,7 @@ void NcpBase::UpdateChangedProps(void)
 
             SuccessOrExit(WriteLastStatusFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, status));
         }
-        else
+        else if (mDidInitialUpdates)
         {
             SuccessOrExit(WritePropertyValueIsFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, propKey));
         }
@@ -1038,6 +1039,7 @@ void NcpBase::UpdateChangedProps(void)
     }
 
 exit:
+    mDidInitialUpdates = true;
     return;
 }
 

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -759,6 +759,7 @@ private:
     bool mLegacyNodeDidJoin;
 #endif
 
+    bool mDidInitialUpdates;
 };
 
 }  // namespace Ncp


### PR DESCRIPTION
When an OpenThread NCP starts up, the only thing it should emit is a `CMD_PROP_VALUE_IS` for `PROP_LAST_STATUS`, with a reset reason as the status code.

However, up until this point we have been also dumping out lots of other details which happen to be triggrered by OpenThread's start-up code. This is effectively noise, since a properly implemented host driver would be explicitly fetching the values of properties it needs to know at startup.

This change fixes this by supressing all property updates at startup except `PROP_LAST_STATUS`.