### PR TITLE
[nrf52840] Improvements to USB-CDC-UART

### DIFF
--- a/examples/platforms/nrf52840/platform-config.h
+++ b/examples/platforms/nrf52840/platform-config.h
@@ -328,6 +328,17 @@
 #endif
 
 /**
+ * @def USB_HOST_UART_CONFIG_DELAY_MS
+ *
+ * Delay after DTR gets asserted that we start send any queued data. This allows slow
+ * Linux-based hosts to have enough time to configure their port for raw mode.
+ *
+ */
+#ifndef USB_HOST_UART_CONFIG_DELAY_MS
+#define USB_HOST_UART_CONFIG_DELAY_MS 10
+#endif
+
+/**
  * @def USB_CDC_AS_SERIAL_TRANSPORT
  *
  * Use USB CDC driver for serial communication.


### PR DESCRIPTION
This change addresses some issues that was noticed while working to bring up the OpenThread NCP on the nRF52840. The most important change is the introduction of the macro `USB_HOST_UART_CONFIG_DELAY_MS`, which will slightly delay the output of queued data once the fake UART is opened. On some slow Linux systems, the USB-CDC-UART driver sends the data so quickly after the port opens that the application hasn't had time to get the TTY properly configured using tcsetattr(). While this is technically a host-side problem, fixing this problem host-side is architecturally infeasible in many cases. Ensuring the reliable delivery of the first bytes of the HDLC stream from the NCP after a reset is critical to the host driver being able to identify that a reset has indeed occurred. Waiting a few milliseconds after the port is opened allows the reset reason frame to be reliably transmitted.