### PR TITLE
[mle] implement hysteresis for establishing links and merging

### DIFF
--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -273,6 +273,11 @@ typedef enum otError
     OT_ERROR_DISABLED_FEATURE = 33,
 
     /**
+     * The link margin was too low.
+     */
+    OT_ERROR_LINK_MARGIN_LOW = 34,
+
+    /**
      * Generic error (should not use).
      */
     OT_ERROR_GENERIC = 255,

--- a/src/core/common/logging.cpp
+++ b/src/core/common/logging.cpp
@@ -410,6 +410,10 @@ const char *otThreadErrorToString(otError aError)
         retval = "GenericError";
         break;
 
+    case OT_ERROR_LINK_MARGIN_LOW:
+        retval = "LinkMarginLow";
+        break;
+
     default:
         retval = "UnknownErrorType";
         break;

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -1079,7 +1079,27 @@
 #define OPENTHREAD_CONFIG_MLE_SEND_LINK_REQUEST_ON_ADV_TIMEOUT  0
 #endif
 
-/*
+/**
+ * @def OPENTHREAD_CONFIG_MLE_LINK_REQUEST_MARGIN_MIN
+ *
+ * Specifies the minimum link margin in dBm required before attempting to establish a link with a neighboring router.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MLE_LINK_REQUEST_MARGIN_MIN
+#define OPENTHREAD_CONFIG_MLE_LINK_REQUEST_MARGIN_MIN           10
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_MLE_PARTITION_MERGE_MARGIN_MIN
+ *
+ * Specifies the minimum link margin in dBm required before attempting to merge to a different partition.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MLE_PARTITION_MERGE_MARGIN_MIN
+#define OPENTHREAD_CONFIG_MLE_PARTITION_MERGE_MARGIN_MIN        10
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_ENABLE_DEBUG_UART
  *
  * Enable the "Debug Uart" platform feature.


### PR DESCRIPTION
This commit applies a hysteresis to establishing new links or merging
partitions.  In particular, this commit introduces new minimum link
margin thresholds that must be met before attempting to establish a
new link or merging to a different partition.  Enforcing a mininmum
link margin threshold before establishing new links helps avoid links
that will quickly become invalid due to normal time-varying link
qualities.