### PR TITLE
[ncp] allow a vendor defined subclass of ncp_uart or ncp_spi to access ncp_base members

### DIFF
--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -167,7 +167,7 @@ public:
      */
     bool ShouldDeferHostSend(void);
 
-private:
+protected:
     typedef otError (NcpBase::*PropertyHandler)(void);
 
     struct PropertyHandlerEntry
@@ -674,7 +674,6 @@ protected:
     SpinelDecoder mDecoder;
     bool mHostPowerStateInProgress;
 
-private:
     enum
     {
         kTxBufferSize = OPENTHREAD_CONFIG_NCP_TX_BUFFER_SIZE,  // Tx Buffer size (used by mTxFrameBuffer).

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -53,6 +53,8 @@
 namespace ot {
 namespace Ncp {
 
+#if OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT == 0
+
 static otDEFINE_ALIGNED_VAR(sNcpRaw, sizeof(NcpSpi), uint64_t);
 
 extern "C" void otNcpInit(otInstance *aInstance)
@@ -67,6 +69,8 @@ extern "C" void otNcpInit(otInstance *aInstance)
         assert(false);
     }
 }
+
+#endif // OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT == 0
 
 static void spi_header_set_flag_byte(uint8_t *header, uint8_t value)
 {

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -51,6 +51,8 @@
 namespace ot {
 namespace Ncp {
 
+#if OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT == 0
+
 static otDEFINE_ALIGNED_VAR(sNcpRaw, sizeof(NcpUart), uint64_t);
 
 extern "C" void otNcpInit(otInstance *aInstance)
@@ -65,6 +67,8 @@ extern "C" void otNcpInit(otInstance *aInstance)
         assert(false);
     }
 }
+
+#endif // OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT == 0
 
 NcpUart::UartTxBuffer::UartTxBuffer(void)
     : Hdlc::Encoder::BufferWriteIterator()


### PR DESCRIPTION
This change satisfies issue #2410.  The strategy for a vendor that desires to extend the Spinel responses can subclass either the ncp_uart or ncp_spi class with a new ncp_vendor class to which the vendor may add new API's to be called by vendor specific code for the purpose of sending vendor specific messages to a host.  The members of class ncp_base have all been designated as protected rather than private to allow the new subclass full access to all the facilities necessary for constructing and sending spinel messages.

The instantiation of an ncp_spi object or ncp_uart object has been conditionally compiled out when OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT is enabled. The expectation is that the vendor will implement similar code to instantiate a vendor specific subclass which will serve the same role as ncp_uart or ncp_spi.