### PR TITLE
[mac] clean up extended address usage

### DIFF
--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -399,10 +399,13 @@ typedef uint16_t otShortAddress;
  * This type represents the IEEE 802.15.4 Extended Address.
  *
  */
-typedef struct otExtAddress
+OT_TOOL_PACKED_BEGIN
+struct otExtAddress
 {
     uint8_t m8[OT_EXT_ADDRESS_SIZE];  ///< IEEE 802.15.4 Extended Address bytes
-} otExtAddress;
+} OT_TOOL_PACKED_END;
+
+typedef struct otExtAddress otExtAddress;
 
 #define OT_IP6_PREFIX_SIZE         8   ///< Size of an IPv6 prefix (bytes)
 #define OT_IP6_ADDRESS_SIZE        16  ///< Size of an IPv6 address (bytes)

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -151,7 +151,7 @@ otError otIp6CreateMacIid(otInstance *aInstance, otNetifAddress *aAddress, void 
     Instance &instance = *static_cast<Instance *>(aInstance);
 
     memcpy(&aAddress->mAddress.mFields.m8[OT_IP6_ADDRESS_SIZE - OT_IP6_IID_SIZE],
-           instance.GetThreadNetif().GetMac().GetExtAddress(), OT_IP6_IID_SIZE);
+           &instance.GetThreadNetif().GetMac().GetExtAddress(), OT_IP6_IID_SIZE);
     aAddress->mAddress.mFields.m8[OT_IP6_ADDRESS_SIZE - OT_IP6_IID_SIZE] ^= 0x02;
 
     return OT_ERROR_NONE;

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -69,7 +69,7 @@ const otExtAddress *otLinkGetExtendedAddress(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return reinterpret_cast<const otExtAddress *>(instance.GetThreadNetif().GetMac().GetExtAddress());
+    return &instance.GetThreadNetif().GetMac().GetExtAddress();
 }
 
 otError otLinkSetExtendedAddress(otInstance *aInstance, const otExtAddress *aExtAddress)

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -357,8 +357,7 @@ otError otThreadGetParentInfo(otInstance *aInstance, otRouterInfo *aParentInfo)
     VerifyOrExit(aParentInfo != NULL, error = OT_ERROR_INVALID_ARGS);
 
     parent = instance.GetThreadNetif().GetMle().GetParent();
-    memcpy(aParentInfo->mExtAddress.m8, &parent->GetExtAddress(), sizeof(aParentInfo->mExtAddress));
-
+    aParentInfo->mExtAddress      = parent->GetExtAddress();
     aParentInfo->mRloc16          = parent->GetRloc16();
     aParentInfo->mRouterId        = Mle::Mle::GetRouterId(parent->GetRloc16());
     aParentInfo->mNextHop         = parent->GetNextHop();

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -221,7 +221,7 @@ otError Mac::ConvertBeaconToActiveScanResult(Frame *aBeaconFrame, otActiveScanRe
     VerifyOrExit(aBeaconFrame->GetType() == Frame::kFcfFrameBeacon, error = OT_ERROR_PARSE);
     SuccessOrExit(error = aBeaconFrame->GetSrcAddr(address));
     VerifyOrExit(address.mLength == sizeof(address.mExtAddress), error = OT_ERROR_PARSE);
-    memcpy(&aResult.mExtAddress, &address.mExtAddress, sizeof(aResult.mExtAddress));
+    aResult.mExtAddress = address.mExtAddress;
 
     aBeaconFrame->GetSrcPanId(aResult.mPanId);
     aResult.mChannel = aBeaconFrame->GetChannel();
@@ -1590,8 +1590,7 @@ void Mac::ReceiveDoneTask(Frame *aFrame, otError aError)
 
     case sizeof(ExtAddress):
         aFrame->GetDstPanId(panid);
-        VerifyOrExit(panid == mPanId &&
-                     memcmp(&dstaddr.mExtAddress, &mExtAddress, sizeof(dstaddr.mExtAddress)) == 0,
+        VerifyOrExit(panid == mPanId && dstaddr.mExtAddress == mExtAddress,
                      error = OT_ERROR_DESTINATION_ADDRESS_FILTERED);
         break;
     }
@@ -1622,7 +1621,7 @@ void Mac::ReceiveDoneTask(Frame *aFrame, otError aError)
     }
 
     // Duplicate Address Protection
-    if (memcmp(&srcaddr.mExtAddress, &mExtAddress, sizeof(srcaddr.mExtAddress)) == 0)
+    if (srcaddr.mExtAddress == mExtAddress)
     {
         ExitNow(error = OT_ERROR_INVALID_SOURCE_ADDRESS);
     }

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -350,12 +350,12 @@ public:
     void GenerateExtAddress(ExtAddress *aExtAddress);
 
     /**
-     * This method returns a pointer to the IEEE 802.15.4 Extended Address.
+     * This method returns a reference to the IEEE 802.15.4 Extended Address.
      *
      * @returns A pointer to the IEEE 802.15.4 Extended Address.
      *
      */
-    const ExtAddress *GetExtAddress(void) const { return &mExtAddress; }
+    const ExtAddress &GetExtAddress(void) const { return mExtAddress; }
 
     /**
      * This method sets the IEEE 802.15.4 Extended Address

--- a/src/core/mac/mac_filter.cpp
+++ b/src/core/mac/mac_filter.cpp
@@ -63,7 +63,7 @@ Filter::Entry *Filter::FindEntry(const ExtAddress &aExtAddress)
     for (uint8_t i = 0; i < GetMaxEntries(); i++)
     {
         if ((mEntries[i].mFiltered || mEntries[i].mRssIn != OT_MAC_FILTER_FIXED_RSS_DISABLED) &&
-            memcmp(&aExtAddress, &mEntries[i].mExtAddress, OT_EXT_ADDRESS_SIZE) == 0)
+            (aExtAddress == static_cast<const ExtAddress &>(mEntries[i].mExtAddress)))
         {
             ExitNow(entry = &mEntries[i]);
         }
@@ -112,7 +112,7 @@ otError Filter::AddAddress(const ExtAddress &aExtAddress)
     if (entry == NULL)
     {
         VerifyOrExit((entry = FindAvailEntry()) != NULL, error = OT_ERROR_NO_BUFS);
-        memcpy(&entry->mExtAddress, &aExtAddress, OT_EXT_ADDRESS_SIZE);
+        entry->mExtAddress = aExtAddress;
     }
 
     if (entry->mFiltered)
@@ -187,7 +187,7 @@ otError Filter::AddRssIn(const ExtAddress *aExtAddress, int8_t aRss)
         if (entry == NULL)
         {
             VerifyOrExit((entry = FindAvailEntry()) != NULL, error = OT_ERROR_NO_BUFS);
-            memcpy(&entry->mExtAddress, aExtAddress, OT_EXT_ADDRESS_SIZE);
+            entry->mExtAddress = static_cast<const otExtAddress &>(*aExtAddress);
         }
 
         entry->mRssIn = aRss;

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -43,6 +43,16 @@
 namespace ot {
 namespace Mac {
 
+bool ExtAddress::operator==(const ExtAddress &aOther) const
+{
+    return memcmp(m8, aOther.m8, sizeof(ExtAddress)) == 0;
+}
+
+bool ExtAddress::operator!=(const ExtAddress &aOther) const
+{
+    return memcmp(m8, aOther.m8, sizeof(ExtAddress)) != 0;
+}
+
 const char *Address::ToString(char *aBuf, uint16_t aSize) const
 {
     switch (mLength)

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -81,6 +81,7 @@ typedef otShortAddress ShortAddress;
  * This structure represents an IEEE 802.15.4 Extended Address.
  *
  */
+OT_TOOL_PACKED_BEGIN
 class ExtAddress: public otExtAddress
 {
 public:
@@ -132,13 +133,35 @@ public:
         }
     }
 
+    /**
+     * This method evaluates whether or not the Extended Addresses match.
+     *
+     * @param[in]  aOther  The Extended Address to compare.
+     *
+     * @retval TRUE   If the Extended Addresses match.
+     * @retval FALSE  If the Extended Addresses do not match.
+     *
+     */
+    bool operator==(const ExtAddress &aOther) const;
+
+    /**
+     * This method evaluates whether or not the Extended Addresses match.
+     *
+     * @param[in]  aOther  The Extended Address to compare.
+     *
+     * @retval TRUE   If the Extended Addresses do not match.
+     * @retval FALSE  If the Extended Addresses match.
+     *
+     */
+    bool operator!=(const ExtAddress &aOther) const;
+
 private:
     enum
     {
         kGroupFlag = 1 << 0,
         kLocalFlag = 1 << 1,
     };
-};
+} OT_TOOL_PACKED_END;
 
 /**
  * This structure represents an IEEE 802.15.4 Short or Extended Address.

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -234,7 +234,7 @@ void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
         joinerRouter.mJoinerUdpPort = aResult->mJoinerUdpPort;
         joinerRouter.mPanId = aResult->mPanId;
         joinerRouter.mChannel = aResult->mChannel;
-        memcpy(joinerRouter.mExtAddr.m8, &aResult->mExtAddress, sizeof(joinerRouter.mExtAddr));
+        joinerRouter.mExtAddr = static_cast<Mac::ExtAddress &>(aResult->mExtAddress);
         AddJoinerRouter(joinerRouter);
     }
     else

--- a/src/core/net/dhcp6.hpp
+++ b/src/core/net/dhcp6.hpp
@@ -292,7 +292,7 @@ public:
      * @param[in]  aLinkLayerAddress The client LinkLayerAddress.
      *
      */
-    void SetDuidLinkLayerAddress(const Mac::ExtAddress *aDuidLinkLayerAddress) { memcpy(mDuidLinkLayerAddress, aDuidLinkLayerAddress, sizeof(Mac::ExtAddress)); }
+    void SetDuidLinkLayerAddress(const Mac::ExtAddress &aDuidLinkLayerAddress) { memcpy(mDuidLinkLayerAddress, &aDuidLinkLayerAddress, sizeof(Mac::ExtAddress)); }
 
 private:
     uint16_t mDuidType;                                         ///< Duid Type
@@ -356,7 +356,7 @@ public:
      * @param[in]  aLinkLayerAddress The server LinkLayerAddress.
      *
      */
-    void SetDuidLinkLayerAddress(const Mac::ExtAddress *aDuidLinkLayerAddress) { memcpy(mDuidLinkLayerAddress, aDuidLinkLayerAddress, sizeof(Mac::ExtAddress)); }
+    void SetDuidLinkLayerAddress(const Mac::ExtAddress &aDuidLinkLayerAddress) { memcpy(mDuidLinkLayerAddress, &aDuidLinkLayerAddress, sizeof(Mac::ExtAddress)); }
 
 private:
     uint16_t mDuidType;                                         ///< Duid Type

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -609,7 +609,7 @@ otError Dhcp6Client::ProcessClientIdentifier(Message &aMessage, uint16_t aOffset
                    (option.GetLength() == (sizeof(option) - sizeof(Dhcp6Option))) &&
                    (option.GetDuidType() == kDuidLL) &&
                    (option.GetDuidHardwareType() == kHardwareTypeEui64)) &&
-                  (!memcmp(option.GetDuidLinkLayerAddress(), GetNetif().GetMac().GetExtAddress(),
+                  (!memcmp(option.GetDuidLinkLayerAddress(), &GetNetif().GetMac().GetExtAddress(),
                            sizeof(Mac::ExtAddress)))),
                  error = OT_ERROR_PARSE);
 exit:

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -574,7 +574,7 @@ void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessag
         for (uint8_t j = 0; j < Child::kMaxIp6AddressPerChild; j++)
         {
             if (children[i].GetIp6Address(j) == *targetTlv.GetTarget() &&
-                memcmp(&children[i].GetExtAddress(), &macAddr, sizeof(macAddr)))
+                children[i].GetExtAddress() != macAddr)
             {
                 // Target EID matches child address and Mesh Local EID differs on child
                 memset(&children[i].GetIp6Address(j), 0, sizeof(children[i].GetIp6Address(j)));

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -427,7 +427,7 @@ void MeshForwarder::ScheduleTransmissionTask(void)
             else
             {
                 mMacSource.mLength = sizeof(mMacSource.mExtAddress);
-                memcpy(mMacSource.mExtAddress.m8, netif.GetMac().GetExtAddress(), sizeof(mMacDest.mExtAddress));
+                mMacSource.mExtAddress = netif.GetMac().GetExtAddress();
             }
 
             child.GetMacAddress(mMacDest);
@@ -634,9 +634,9 @@ Message *MeshForwarder::GetDirectTransmission(void)
                 else
                 {
                     mMacSource.mLength = sizeof(mMacSource.mExtAddress);
-                    memcpy(mMacSource.mExtAddress.m8, netif.GetMac().GetExtAddress(), sizeof(mMacSource.mExtAddress));
+                    mMacSource.mExtAddress = netif.GetMac().GetExtAddress();
                     mMacDest.mLength = sizeof(mMacDest.mExtAddress);
-                    memcpy(mMacDest.mExtAddress.m8, &parent->GetExtAddress(), sizeof(mMacDest.mExtAddress));
+                    mMacDest.mExtAddress = parent->GetExtAddress();
                 }
             }
             else
@@ -1090,7 +1090,7 @@ otError MeshForwarder::GetMacSourceAddress(const Ip6::Address &aIp6Addr, Mac::Ad
 
     aIp6Addr.ToExtAddress(aMacAddr.mExtAddress);
 
-    if (memcmp(&aMacAddr.mExtAddress, netif.GetMac().GetExtAddress(), sizeof(aMacAddr.mExtAddress)) != 0)
+    if (aMacAddr.mExtAddress != netif.GetMac().GetExtAddress())
     {
         aMacAddr.mLength = sizeof(aMacAddr.mShortAddress);
         aMacAddr.mShortAddress = netif.GetMac().GetShortAddress();
@@ -1553,7 +1553,7 @@ otError MeshForwarder::SendEmptyFrame(Mac::Frame &aFrame, bool aAckRequest)
     else
     {
         macSource.mLength = sizeof(macSource.mExtAddress);
-        memcpy(&macSource.mExtAddress, netif.GetMac().GetExtAddress(), sizeof(macSource.mExtAddress));
+        macSource.mExtAddress = netif.GetMac().GetExtAddress();
     }
 
     fcf = Mac::Frame::kFcfFrameData | Mac::Frame::kFcfFrameVersion2006;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -122,7 +122,7 @@ Mle::Mle(Instance &aInstance) :
 
     // link-local 64
     mLinkLocal64.GetAddress().mFields.m16[0] = HostSwap16(0xfe80);
-    mLinkLocal64.GetAddress().SetIid(*GetNetif().GetMac().GetExtAddress());
+    mLinkLocal64.GetAddress().SetIid(GetNetif().GetMac().GetExtAddress());
     mLinkLocal64.mPrefixLength = 64;
     mLinkLocal64.mPreferred = true;
     mLinkLocal64.mValid = true;
@@ -387,7 +387,7 @@ otError Mle::Store(void)
         networkInfo.mRole = mRole;
         networkInfo.mRloc16 = GetRloc16();
         networkInfo.mPreviousPartitionId = mLeaderData.GetPartitionId();
-        memcpy(networkInfo.mExtAddress.m8, netif.GetMac().GetExtAddress(), sizeof(networkInfo.mExtAddress));
+        networkInfo.mExtAddress = netif.GetMac().GetExtAddress();
         memcpy(networkInfo.mMlIid, &mMeshLocal64.GetAddress().mFields.m8[OT_IP6_PREFIX_SIZE], OT_IP6_IID_SIZE);
 
         if (mRole == OT_DEVICE_ROLE_CHILD)
@@ -395,7 +395,7 @@ otError Mle::Store(void)
             Settings::ParentInfo parentInfo;
 
             memset(&parentInfo, 0, sizeof(parentInfo));
-            memcpy(&parentInfo.mExtAddress, &mParent.GetExtAddress(), sizeof(parentInfo.mExtAddress));
+            parentInfo.mExtAddress = mParent.GetExtAddress();
 
             SuccessOrExit(error = otPlatSettingsSet(&netif.GetInstance(), Settings::kKeyParentInfo,
                                                     reinterpret_cast<uint8_t *>(&parentInfo), sizeof(parentInfo)));
@@ -732,7 +732,7 @@ otError Mle::UpdateLinkLocalAddress(void)
     ThreadNetif &netif = GetNetif();
 
     netif.RemoveUnicastAddress(mLinkLocal64);
-    mLinkLocal64.GetAddress().SetIid(*netif.GetMac().GetExtAddress());
+    mLinkLocal64.GetAddress().SetIid(netif.GetMac().GetExtAddress());
     netif.AddUnicastAddress(mLinkLocal64);
 
     netif.SetStateChangedFlags(OT_CHANGED_THREAD_LL_ADDR);
@@ -1657,7 +1657,7 @@ otError Mle::SendChildIdRequest(void)
     Ip6::Address destination;
 
     if (mRole == OT_DEVICE_ROLE_CHILD &&
-        memcmp(&mParent.GetExtAddress(), &mParentCandidate.GetExtAddress(), OT_EXT_ADDRESS_SIZE) == 0)
+        mParent.GetExtAddress() == mParentCandidate.GetExtAddress())
     {
         otLogInfoMle(GetInstance(), "Already attached to candidate parent");
         ExitNow(error = OT_ERROR_ALREADY);
@@ -2032,7 +2032,7 @@ otError Mle::SendMessage(Message &aMessage, const Ip6::Address &aDestination)
 
         aMessage.Write(0, header.GetLength(), &header);
 
-        GenerateNonce(*netif.GetMac().GetExtAddress(),
+        GenerateNonce(netif.GetMac().GetExtAddress(),
                       netif.GetKeyManager().GetMleFrameCounter(),
                       Mac::Frame::kSecEncMic32,
                       nonce);
@@ -2413,7 +2413,7 @@ otError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo
         break;
 
     case OT_DEVICE_ROLE_CHILD:
-        if (memcmp(&mParent.GetExtAddress(), &macAddr, sizeof(macAddr)))
+        if (mParent.GetExtAddress() != macAddr)
         {
             break;
         }
@@ -2717,7 +2717,7 @@ otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInf
     aMessageInfo.GetPeerAddr().ToExtAddress(extAddress);
 
     if (mRole == OT_DEVICE_ROLE_CHILD &&
-        memcmp(&mParent.GetExtAddress(), &extAddress, sizeof(extAddress)) == 0)
+        mParent.GetExtAddress() == extAddress)
     {
         mReceivedResponseFromParent = true;
     }
@@ -2988,8 +2988,7 @@ otError Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::Messag
         VerifyOrExit(status.IsValid(), error = OT_ERROR_PARSE);
 
         aMessageInfo.GetPeerAddr().ToExtAddress(srcAddr);
-        VerifyOrExit((memcmp(&mParent.GetExtAddress(), &srcAddr, sizeof(srcAddr)) == 0),
-                     error = OT_ERROR_DROP);
+        VerifyOrExit(mParent.GetExtAddress() == srcAddr, error = OT_ERROR_DROP);
 
         if (status.GetStatus() == StatusTlv::kError)
         {
@@ -3321,13 +3320,13 @@ Neighbor *Mle::GetNeighbor(uint16_t aAddress)
 Neighbor *Mle::GetNeighbor(const Mac::ExtAddress &aAddress)
 {
     if ((mParent.IsStateValidOrRestoring()) &&
-        (memcmp(&mParent.GetExtAddress(), &aAddress, sizeof(aAddress)) == 0))
+        (mParent.GetExtAddress() == aAddress))
     {
         return &mParent;
     }
 
     if ((mParentCandidate.GetState() == Neighbor::kStateValid) &&
-        (memcmp(&mParentCandidate.GetExtAddress(), &aAddress, sizeof(aAddress)) == 0))
+        (mParentCandidate.GetExtAddress() == aAddress))
     {
         return &mParentCandidate;
     }

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -300,7 +300,7 @@ otError MleRouter::BecomeLeader(void)
 
     SetRouterId(routerId);
 
-    router->SetExtAddress(*netif.GetMac().GetExtAddress());
+    router->SetExtAddress(netif.GetMac().GetExtAddress());
     mAdvertiseTimer.Stop();
     netif.GetAddressResolver().Clear();
 
@@ -757,7 +757,7 @@ otError MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::Message
             }
             else
             {
-                VerifyOrExit(memcmp(&neighbor->GetExtAddress(), &macAddr, sizeof(macAddr)) == 0);
+                VerifyOrExit(neighbor->GetExtAddress() == macAddr);
             }
         }
         else
@@ -1134,7 +1134,7 @@ Child *MleRouter::FindChild(const Mac::ExtAddress &aAddress)
     for (int i = 0; i < mMaxChildrenAllowed; i++)
     {
         if (mChildren[i].GetState() != Neighbor::kStateInvalid &&
-            memcmp(&mChildren[i].GetExtAddress(), &aAddress, sizeof(mChildren[i].GetExtAddress())) == 0)
+            mChildren[i].GetExtAddress() == aAddress)
         {
             ExitNow(rval = &mChildren[i]);
         }
@@ -1352,7 +1352,7 @@ otError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::Messa
         }
 
         if (mRole == OT_DEVICE_ROLE_CHILD &&
-            (memcmp(&mParent.GetExtAddress(), &macAddr, sizeof(macAddr)) == 0 || !(mDeviceMode & ModeTlv::kModeFFD)))
+            (mParent.GetExtAddress() == macAddr || !(mDeviceMode & ModeTlv::kModeFFD)))
         {
             ExitNow();
         }
@@ -1439,7 +1439,7 @@ otError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::Messa
             ExitNow();
         }
 
-        if (memcmp(&mParent.GetExtAddress(), &macAddr, sizeof(mParent.GetExtAddress())) == 0)
+        if (mParent.GetExtAddress() == macAddr)
         {
             router = &mParent;
 
@@ -2208,7 +2208,7 @@ otError MleRouter::HandleChildIdRequest(const Message &aMessage, const Ip6::Mess
     for (int i = 0; i <= kMaxRouterId; i++)
     {
         if (mRouters[i].GetState() != Neighbor::kStateInvalid &&
-            memcmp(&mRouters[i].GetExtAddress(), &macAddr, sizeof(macAddr)) == 0)
+            mRouters[i].GetExtAddress() == macAddr)
         {
             RemoveNeighbor(mRouters[i]);
             break;
@@ -2633,20 +2633,20 @@ exit:
 otError MleRouter::SetSteeringData(const otExtAddress *aExtAddress)
 {
     otError error = OT_ERROR_NONE;
-    uint8_t nullExtAddr[OT_EXT_ADDRESS_SIZE];
-    uint8_t allowAnyExtAddr[OT_EXT_ADDRESS_SIZE];
+    ExtAddress nullExtAddr;
+    ExtAddress allowAnyExtAddr;
 
-    memset(nullExtAddr, 0, sizeof(nullExtAddr));
-    memset(allowAnyExtAddr, 0xFF, sizeof(allowAnyExtAddr));
+    memset(nullExtAddr.m8, 0, sizeof(nullExtAddr.m8));
+    memset(allowAnyExtAddr.m8, 0xFF, sizeof(allowAnyExtAddr.m8));
 
     mSteeringData.Init();
 
-    if ((aExtAddress == NULL) || (memcmp(aExtAddress, &nullExtAddr, sizeof(nullExtAddr)) == 0))
+    if ((aExtAddress == NULL) || (*aExtAddress == nullExtAddr))
     {
         // Clear steering data
         mSteeringData.Clear();
     }
-    else if (memcmp(aExtAddress, &allowAnyExtAddr, sizeof(allowAnyExtAddr)) == 0)
+    else if (*aExtAddress == allowAnyExtAddr)
     {
         // Set steering data to 0xFF
         mSteeringData.SetLength(1);
@@ -3141,7 +3141,7 @@ Child *MleRouter::GetChild(const Mac::ExtAddress &aAddress)
     for (int i = 0; i < mMaxChildrenAllowed; i++)
     {
         if (mChildren[i].IsStateValidOrRestoring() &&
-            memcmp(&mChildren[i].GetExtAddress(), &aAddress, sizeof(aAddress)) == 0)
+            mChildren[i].GetExtAddress() == aAddress)
         {
             return &mChildren[i];
         }
@@ -3338,7 +3338,7 @@ Neighbor *MleRouter::GetNeighbor(const Mac::ExtAddress &aAddress)
         for (int i = 0; i < mMaxChildrenAllowed; i++)
         {
             if (mChildren[i].IsStateValidOrRestoring() &&
-                memcmp(&mChildren[i].GetExtAddress(), &aAddress, sizeof(aAddress)) == 0)
+                mChildren[i].GetExtAddress() == aAddress)
             {
                 ExitNow(rval = &mChildren[i]);
             }
@@ -3352,7 +3352,7 @@ Neighbor *MleRouter::GetNeighbor(const Mac::ExtAddress &aAddress)
             }
 
             if (mRouters[i].GetState() == Neighbor::kStateValid &&
-                memcmp(&mRouters[i].GetExtAddress(), &aAddress, sizeof(aAddress)) == 0)
+                mRouters[i].GetExtAddress() == aAddress)
             {
                 ExitNow(rval = &mRouters[i]);
             }
@@ -3502,7 +3502,7 @@ Neighbor *MleRouter::GetRxOnlyNeighborRouter(const Mac::Address &aAddress)
             }
 
             if (mRouters[i].GetState() == Neighbor::kStateValid &&
-                memcmp(&mRouters[i].GetExtAddress(), &aAddress.mExtAddress, sizeof(aAddress.mExtAddress)) == 0)
+                mRouters[i].GetExtAddress() == aAddress.mExtAddress)
             {
                 ExitNow(rval = &mRouters[i]);
             }
@@ -3763,8 +3763,7 @@ otError MleRouter::StoreChild(uint16_t aChildRloc16)
     IgnoreReturnValue(RemoveStoredChild(aChildRloc16));
 
     memset(&childInfo, 0, sizeof(childInfo));
-    memcpy(&childInfo.mExtAddress, &child->GetExtAddress(), sizeof(childInfo.mExtAddress));
-
+    childInfo.mExtAddress = child->GetExtAddress();
     childInfo.mTimeout = child->GetTimeout();
     childInfo.mRloc16  = child->GetRloc16();
     childInfo.mMode    = child->GetDeviceMode();
@@ -3801,8 +3800,7 @@ otError MleRouter::GetChildInfo(Child &aChild, otChildInfo &aChildInfo)
     VerifyOrExit(aChild.IsStateValidOrRestoring(), error = OT_ERROR_NOT_FOUND);
 
     memset(&aChildInfo, 0, sizeof(aChildInfo));
-    memcpy(&aChildInfo.mExtAddress, &aChild.GetExtAddress(), sizeof(aChildInfo.mExtAddress));
-
+    aChildInfo.mExtAddress         = aChild.GetExtAddress();
     aChildInfo.mTimeout            = aChild.GetTimeout();
     aChildInfo.mRloc16             = aChild.GetRloc16();
     aChildInfo.mChildId            = GetChildId(aChild.GetRloc16());
@@ -3843,8 +3841,7 @@ otError MleRouter::GetRouterInfo(uint16_t aRouterId, otRouterInfo &aRouterInfo)
     router = GetRouter(routerId);
     VerifyOrExit(router != NULL, error = OT_ERROR_NOT_FOUND);
 
-    memcpy(&aRouterInfo.mExtAddress, &router->GetExtAddress(), sizeof(aRouterInfo.mExtAddress));
-
+    aRouterInfo.mExtAddress      = router->GetExtAddress();
     aRouterInfo.mAllocated       = router->IsAllocated();
     aRouterInfo.mRouterId        = routerId;
     aRouterInfo.mRloc16          = GetRloc16(routerId);
@@ -3908,7 +3905,7 @@ exit:
 
     if (neighbor != NULL)
     {
-        memcpy(&aNeighInfo.mExtAddress, &neighbor->GetExtAddress(), sizeof(aNeighInfo.mExtAddress));
+        aNeighInfo.mExtAddress = neighbor->GetExtAddress();
         aNeighInfo.mAge = TimerMilli::MsecToSec(TimerMilli::GetNow() - neighbor->GetLastHeard());
         aNeighInfo.mRloc16 = neighbor->GetRloc16();
         aNeighInfo.mLinkFrameCounter = neighbor->GetLinkFrameCounter();
@@ -4016,7 +4013,7 @@ otError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
     VerifyOrExit((message = netif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     macAddr64Tlv.Init();
-    macAddr64Tlv.SetMacAddr(*netif.GetMac().GetExtAddress());
+    macAddr64Tlv.SetMacAddr(netif.GetMac().GetExtAddress());
     SuccessOrExit(error = message->Append(&macAddr64Tlv, sizeof(macAddr64Tlv)));
 
     if (IsRouterIdValid(mPreviousRouterId))
@@ -4072,7 +4069,7 @@ otError MleRouter::SendAddressRelease(void)
     SuccessOrExit(error = message->Append(&rlocTlv, sizeof(rlocTlv)));
 
     macAddr64Tlv.Init();
-    macAddr64Tlv.SetMacAddr(*netif.GetMac().GetExtAddress());
+    macAddr64Tlv.SetMacAddr(netif.GetMac().GetExtAddress());
     SuccessOrExit(error = message->Append(&macAddr64Tlv, sizeof(macAddr64Tlv)));
 
     messageInfo.SetSockAddr(GetMeshLocal16());
@@ -4162,7 +4159,7 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Header *aHeader, Message *aMe
     SetRouterId(routerId);
 
     // fill in its own extended address.
-    router->SetExtAddress(*GetNetif().GetMac().GetExtAddress());
+    router->SetExtAddress(GetNetif().GetMac().GetExtAddress());
 
     SuccessOrExit(SetStateRouter(GetRloc16(mRouterId)));
 
@@ -4261,7 +4258,7 @@ void MleRouter::HandleAddressSolicit(Coap::Header &aHeader, Message &aMessage, c
     for (uint8_t i = 0; i <= kMaxRouterId; i++)
     {
         if (mRouters[i].IsAllocated() &&
-            memcmp(&mRouters[i].GetExtAddress(), macAddr64Tlv.GetMacAddr(), sizeof(mRouters[i].GetExtAddress())) == 0)
+            mRouters[i].GetExtAddress() == macAddr64Tlv.GetMacAddr())
         {
             ExitNow(routerId = i);
         }
@@ -4293,7 +4290,7 @@ void MleRouter::HandleAddressSolicit(Coap::Header &aHeader, Message &aMessage, c
         if (router != NULL)
         {
             if (router->IsAllocated() &&
-                memcmp(&router->GetExtAddress(), macAddr64Tlv.GetMacAddr(), sizeof(router->GetExtAddress())))
+                router->GetExtAddress() != macAddr64Tlv.GetMacAddr())
             {
                 // requested Router ID is allocated to another device
                 routerId = kInvalidRouterId;
@@ -4324,7 +4321,7 @@ void MleRouter::HandleAddressSolicit(Coap::Header &aHeader, Message &aMessage, c
 
     if (router != NULL)
     {
-        router->SetExtAddress(*macAddr64Tlv.GetMacAddr());
+        router->SetExtAddress(macAddr64Tlv.GetMacAddr());
     }
     else
     {
@@ -4422,8 +4419,7 @@ void MleRouter::HandleAddressRelease(Coap::Header &aHeader, Message &aMessage,
     routerId = GetRouterId(rlocTlv.GetRloc16());
     router = GetRouter(routerId);
 
-    VerifyOrExit(router != NULL &&
-                 memcmp(&router->GetExtAddress(), macAddr64Tlv.GetMacAddr(), sizeof(router->GetExtAddress())) == 0);
+    VerifyOrExit(router != NULL && router->GetExtAddress() == macAddr64Tlv.GetMacAddr());
 
     ReleaseRouterId(routerId);
 

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -293,7 +293,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &aRequest, Message &aRespon
         {
             ExtMacAddressTlv tlv;
             tlv.Init();
-            tlv.SetMacAddr(*netif.GetMac().GetExtAddress());
+            tlv.SetMacAddr(netif.GetMac().GetExtAddress());
             SuccessOrExit(error = aResponse.Append(&tlv, sizeof(tlv)));
             break;
         }

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -159,7 +159,7 @@ otError ThreadNetif::GetLinkAddress(Ip6::LinkAddress &address) const
 {
     address.mType = Ip6::LinkAddress::kEui64;
     address.mLength = sizeof(address.mExtAddress);
-    memcpy(&address.mExtAddress, mMac.GetExtAddress(), address.mLength);
+    address.mExtAddress = mMac.GetExtAddress();
     return OT_ERROR_NONE;
 }
 

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -161,6 +161,7 @@ private:
  * This class implements Extended MAC Address TLV generation and parsing.
  *
  */
+OT_TOOL_PACKED_BEGIN;
 class ThreadExtMacAddressTlv: public ThreadTlv
 {
 public:
@@ -180,12 +181,12 @@ public:
     bool IsValid(void) const { return GetLength() == sizeof(*this) - sizeof(ThreadTlv); }
 
     /**
-     * This method returns a pointer to the Extended MAC Address.
+     * This method returns a reference to the Extended MAC Address.
      *
      * @returns A pointer to the Extended MAC Address.
      *
      */
-    const Mac::ExtAddress *GetMacAddr(void) const { return &mMacAddr; }
+    const Mac::ExtAddress &GetMacAddr(void) const { return mMacAddr; }
 
     /**
      * This method sets the Extended MAC Address.
@@ -197,7 +198,7 @@ public:
 
 private:
     Mac::ExtAddress mMacAddr;
-};
+} OT_TOOL_PACKED_END;
 
 /**
  * This class implements RLOC16 TLV generation and parsing.


### PR DESCRIPTION
- Replace `memcmp` with `==` and `!=` operators.
- Replace `memcpy` with `=` assignment.
- Change pointers to reference where applicable.