### PR TITLE
[ip6] clean up ip6 address usage

### DIFF
--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -172,7 +172,7 @@ bool Netif::IsMulticastSubscribed(const Address &aAddress) const
 
     for (NetifMulticastAddress *cur = mMulticastAddresses; cur; cur = cur->GetNext())
     {
-        if (memcmp(&cur->mAddress, &aAddress, sizeof(cur->mAddress)) == 0)
+        if (cur->GetAddress() == aAddress)
         {
             ExitNow(rval = true);
         }
@@ -342,7 +342,7 @@ otError Netif::UnsubscribeExternalMulticast(const Address &aAddress)
 
     for (entry = mMulticastAddresses; entry; entry = entry->GetNext())
     {
-        if (memcmp(&entry->mAddress, &aAddress, sizeof(otIp6Address)) == 0)
+        if (entry->GetAddress() == aAddress)
         {
             VerifyOrExit((entry >= &mExtMulticastAddresses[0]) && (entry < &mExtMulticastAddresses[num]),
                          error = OT_ERROR_INVALID_ARGS);
@@ -382,7 +382,7 @@ void Netif::UnsubscribeAllExternalMulticastAddresses(void)
         // In unused entries, the `mNext` points back to the entry itself.
         if (entry->mNext != entry)
         {
-            UnsubscribeExternalMulticast(*static_cast<Address *>(&entry->mAddress));
+            UnsubscribeExternalMulticast(entry->GetAddress());
         }
     }
 }
@@ -449,7 +449,7 @@ otError Netif::AddExternalUnicastAddress(const NetifUnicastAddress &aAddress)
 
     for (entry = mUnicastAddresses; entry; entry = entry->GetNext())
     {
-        if (memcmp(&entry->mAddress, &aAddress.mAddress, sizeof(otIp6Address)) == 0)
+        if (entry->GetAddress() == aAddress.GetAddress())
         {
             VerifyOrExit((entry >= &mExtUnicastAddresses[0]) && (entry < &mExtUnicastAddresses[num]),
                          error = OT_ERROR_INVALID_ARGS);
@@ -493,7 +493,7 @@ otError Netif::RemoveExternalUnicastAddress(const Address &aAddress)
 
     for (entry = mUnicastAddresses; entry; entry = entry->GetNext())
     {
-        if (memcmp(&entry->mAddress, &aAddress, sizeof(otIp6Address)) == 0)
+        if (entry->GetAddress() == aAddress)
         {
             VerifyOrExit((entry >= &mExtUnicastAddresses[0]) && (entry < &mExtUnicastAddresses[num]),
                          error = OT_ERROR_INVALID_ARGS);
@@ -533,7 +533,7 @@ void Netif::RemoveAllExternalUnicastAddresses(void)
         // In unused entries, the `mNext` points back to the entry itself.
         if (entry->mNext != entry)
         {
-            RemoveExternalUnicastAddress(*static_cast<Address *>(&entry->mAddress));
+            RemoveExternalUnicastAddress(entry->GetAddress());
         }
     }
 }

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -93,7 +93,7 @@ public:
      * @returns The unicast address.
      *
      */
-    const Address &GetAddress(void) const { return *static_cast<const Address *>(&mAddress); }
+    const Address &GetAddress(void) const { return static_cast<const Address &>(mAddress); }
 
     /**
      * This method returns the unicast address.
@@ -101,7 +101,7 @@ public:
      * @returns The unicast address.
      *
      */
-    Address &GetAddress(void) { return *static_cast<Address *>(&mAddress); }
+    Address &GetAddress(void) { return static_cast<Address &>(mAddress); }
 
     /**
      * This method returns the IPv6 scope value.
@@ -145,7 +145,7 @@ public:
      * @returns The multicast address.
      *
      */
-    const Address &GetAddress(void) const { return *static_cast<const Address *>(&mAddress); }
+    const Address &GetAddress(void) const { return static_cast<const Address &>(mAddress); }
 
     /**
      * This method returns the multicast address.
@@ -153,7 +153,7 @@ public:
      * @returns The multicast address.
      *
      */
-    Address &GetAddress(void) { return *static_cast<Address *>(&mAddress); }
+    Address &GetAddress(void) { return static_cast<Address &>(mAddress); }
 
     /**
      * This method returns the next multicast address subscribed to the interface.

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -399,11 +399,11 @@ void AddressResolver::HandleAddressNotification(Coap::Header &aHeader, Message &
 
     otLogInfoArp(GetInstance(), "Received address notification from 0x%04x for %s to 0x%04x",
                  HostSwap16(aMessageInfo.GetPeerAddr().mFields.m16[7]),
-                 targetTlv.GetTarget()->ToString(stringBuffer, sizeof(stringBuffer)), rloc16Tlv.GetRloc16());
+                 targetTlv.GetTarget().ToString(stringBuffer, sizeof(stringBuffer)), rloc16Tlv.GetRloc16());
 
     for (int i = 0; i < kCacheEntries; i++)
     {
-        if (mCache[i].mTarget != *targetTlv.GetTarget())
+        if (mCache[i].mTarget != targetTlv.GetTarget())
         {
             continue;
         }
@@ -448,7 +448,7 @@ void AddressResolver::HandleAddressNotification(Coap::Header &aHeader, Message &
                 otLogInfoArp(GetInstance(), "Sending address notification acknowledgment");
             }
 
-            netif.GetMeshForwarder().HandleResolved(*targetTlv.GetTarget(), OT_ERROR_NONE);
+            netif.GetMeshForwarder().HandleResolved(targetTlv.GetTarget(), OT_ERROR_NONE);
             break;
         }
     }
@@ -496,7 +496,7 @@ otError AddressResolver::SendAddressError(const ThreadTargetTlv &aTarget, const 
     SuccessOrExit(error = netif.GetCoap().SendMessage(*message, messageInfo));
 
     otLogInfoArp(GetInstance(), "Sending address error for target %s",
-                 aTarget.GetTarget()->ToString(stringBuffer, sizeof(stringBuffer)));
+                 aTarget.GetTarget().ToString(stringBuffer, sizeof(stringBuffer)));
 
     OT_UNUSED_VARIABLE(stringBuffer);
 
@@ -550,7 +550,7 @@ void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessag
 
     for (const Ip6::NetifUnicastAddress *address = netif.GetUnicastAddresses(); address; address = address->GetNext())
     {
-        if (memcmp(&address->mAddress, targetTlv.GetTarget(), sizeof(address->mAddress)) == 0 &&
+        if (address->GetAddress() == targetTlv.GetTarget() &&
             memcmp(netif.GetMle().GetMeshLocal64().GetIid(), mlIidTlv.GetIid(), 8))
         {
             // Target EID matches address and Mesh Local EID differs
@@ -573,7 +573,7 @@ void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessag
 
         for (uint8_t j = 0; j < Child::kMaxIp6AddressPerChild; j++)
         {
-            if (children[i].GetIp6Address(j) == *targetTlv.GetTarget() &&
+            if (children[i].GetIp6Address(j) == targetTlv.GetTarget() &&
                 children[i].GetExtAddress() != macAddr)
             {
                 // Target EID matches child address and Mesh Local EID differs on child
@@ -631,9 +631,9 @@ void AddressResolver::HandleAddressQuery(Coap::Header &aHeader, Message &aMessag
 
     otLogInfoArp(GetInstance(), "Received address query from 0x%04x for target %s",
                  HostSwap16(aMessageInfo.GetPeerAddr().mFields.m16[7]),
-                 targetTlv.GetTarget()->ToString(stringBuffer, sizeof(stringBuffer)));
+                 targetTlv.GetTarget().ToString(stringBuffer, sizeof(stringBuffer)));
 
-    if (netif.IsUnicastAddress(*targetTlv.GetTarget()))
+    if (netif.IsUnicastAddress(targetTlv.GetTarget()))
     {
         mlIidTlv.SetIid(netif.GetMle().GetMeshLocal64().GetIid());
         SendAddressQueryResponse(targetTlv, mlIidTlv, NULL, aMessageInfo.GetPeerAddr());
@@ -653,7 +653,7 @@ void AddressResolver::HandleAddressQuery(Coap::Header &aHeader, Message &aMessag
 
         for (uint8_t j = 0; j < Child::kMaxIp6AddressPerChild; j++)
         {
-            if (children[i].GetIp6Address(j) != *targetTlv.GetTarget())
+            if (children[i].GetIp6Address(j) != targetTlv.GetTarget())
             {
                 continue;
             }
@@ -709,7 +709,7 @@ void AddressResolver::SendAddressQueryResponse(const ThreadTargetTlv &aTargetTlv
     SuccessOrExit(error = netif.GetCoap().SendMessage(*message, messageInfo));
 
     otLogInfoArp(GetInstance(), "Sending address notification for target %s",
-                 aTargetTlv.GetTarget()->ToString(stringBuffer, sizeof(stringBuffer)));
+                 aTargetTlv.GetTarget().ToString(stringBuffer, sizeof(stringBuffer)));
 
     OT_UNUSED_VARIABLE(stringBuffer);
 

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -164,7 +164,7 @@ void MeshForwarder::HandleResolved(const Ip6::Address &aEid, otError aError)
 
         cur->Read(Ip6::Header::GetDestinationOffset(), sizeof(ip6Dst), &ip6Dst);
 
-        if (memcmp(&ip6Dst, &aEid, sizeof(ip6Dst)) == 0)
+        if (ip6Dst == aEid)
         {
             mResolvingQueue.Dequeue(*cur);
 
@@ -469,10 +469,8 @@ otError MeshForwarder::SendMessage(Message &aMessage)
 
         aMessage.Read(0, sizeof(ip6Header), &ip6Header);
 
-        if (!memcmp(&ip6Header.GetDestination(), netif.GetMle().GetLinkLocalAllThreadNodesAddress(),
-                    sizeof(ip6Header.GetDestination())) ||
-            !memcmp(&ip6Header.GetDestination(), netif.GetMle().GetRealmLocalAllThreadNodesAddress(),
-                    sizeof(ip6Header.GetDestination())))
+        if (ip6Header.GetDestination() == netif.GetMle().GetLinkLocalAllThreadNodesAddress() ||
+            ip6Header.GetDestination() == netif.GetMle().GetRealmLocalAllThreadNodesAddress())
         {
             // schedule direct transmission
             aMessage.SetDirectTransmission();

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -808,14 +808,14 @@ exit:
     return OT_ERROR_NONE;
 }
 
-const Ip6::Address *Mle::GetLinkLocalAllThreadNodesAddress(void) const
+const Ip6::Address &Mle::GetLinkLocalAllThreadNodesAddress(void) const
 {
-    return &mLinkLocalAllThreadNodes.GetAddress();
+    return mLinkLocalAllThreadNodes.GetAddress();
 }
 
-const Ip6::Address *Mle::GetRealmLocalAllThreadNodesAddress(void) const
+const Ip6::Address &Mle::GetRealmLocalAllThreadNodesAddress(void) const
 {
-    return &mRealmLocalAllThreadNodes.GetAddress();
+    return mRealmLocalAllThreadNodes.GetAddress();
 }
 
 uint16_t Mle::GetRloc16(void) const

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -687,20 +687,20 @@ public:
     otError UpdateLinkLocalAddress(void);
 
     /**
-     * This method returns a pointer to the link-local all Thread nodes multicast address.
+     * This method returns a reference to the link-local all Thread nodes multicast address.
      *
-     * @returns A pointer to the link-local all Thread nodes multicast address.
+     * @returns A reference to the link-local all Thread nodes multicast address.
      *
      */
-    const Ip6::Address *GetLinkLocalAllThreadNodesAddress(void) const;
+    const Ip6::Address &GetLinkLocalAllThreadNodesAddress(void) const;
 
     /**
-     * This method returns a pointer to the realm-local all Thread nodes multicast address.
+     * This method returns a reference to the realm-local all Thread nodes multicast address.
      *
-     * @returns A pointer to the realm-local all Thread nodes multicast address.
+     * @returns A reference to the realm-local all Thread nodes multicast address.
      *
      */
-    const Ip6::Address *GetRealmLocalAllThreadNodesAddress(void) const;
+    const Ip6::Address &GetRealmLocalAllThreadNodesAddress(void) const;
 
     /**
      * This method returns a pointer to the parent when operating in End Device mode.

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -138,12 +138,12 @@ public:
     bool IsValid(void) const { return GetLength() == sizeof(*this) - sizeof(ThreadTlv); }
 
     /**
-     * This method returns a pointer to the Target EID.
+     * This method returns a reference to the Target EID.
      *
      * @returns A pointer to the Target EID.
      *
      */
-    const Ip6::Address *GetTarget(void) const { return &mTarget; }
+    const Ip6::Address &GetTarget(void) const { return mTarget; }
 
     /**
      * This method sets the Target EID.


### PR DESCRIPTION
- Replace `memcmp` with `==` and `!=` operators.
- Change pointers to reference where applicable.