### PR TITLE
[mac] ensure MAC operations get started from a tasklet

### DIFF
--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -644,8 +644,8 @@ private:
     void HandleBeginTransmit(void);
     static void HandleReceiveTimer(Timer &aTimer);
     void HandleReceiveTimer(void);
-    static void HandleEnergyScanSampleRssi(Tasklet &aTasklet);
-    void HandleEnergyScanSampleRssi(void);
+    static void PerformOperation(Tasklet &aTasklet);
+    void PerformOperation(void);
 
     void StartCsmaBackoff(void);
 
@@ -654,6 +654,7 @@ private:
     void PerformActiveScan(void);
     void PerformEnergyScan(void);
     void ReportEnergyScanResult(int8_t aRssi);
+    void SampleRssi(void);
 
     otError RadioTransmit(Frame *aSendFrame);
     otError RadioReceive(uint8_t aChannel);
@@ -673,6 +674,8 @@ private:
 #if OPENTHREAD_CONFIG_STAY_AWAKE_BETWEEN_FRAGMENTS
     bool mDelaySleep              : 1;
 #endif
+
+    Tasklet mOperationTask;
 
     TimerMilli mMacTimer;
 #if OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER
@@ -708,7 +711,6 @@ private:
         ActiveScanHandler mActiveScanHandler;
         EnergyScanHandler mEnergyScanHandler;
     };
-    Tasklet mEnergyScanSampleRssiTask;
 
     otLinkPcapCallback mPcapCallback;
     void *mPcapCallbackContext;


### PR DESCRIPTION
This commit changes how MAC operations (frame tx, active/energy scan, etc.) get started by adding a new tasklet `mOperationTask` which is used to start/perform any pending operation. This ensures that callbacks related to an operation are invoked after the method which initiates the operation returns. For 
 example, when a new `Mac::Sender` is registered with a call to `Mac::SendFrameRequest()`, its callback `FrameRequestHandler` would be invoked after the `SendFrameRequest()` call itself returns.

The `mOperationTask` serves two purposes:
- It's mainly used for starting a new operation. 
- It is also used during Energy Scan to take an RSSI sample.