### PR TITLE
[instance] co-locate OT_CHANGED_* flags with otStateChangedCallback

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -218,9 +218,40 @@ void otInstanceFinalize(otInstance *aInstance);
 #endif // OTDLL
 
 /**
+ * This enumeration defines flags that are passed as part of `otStateChangedCallback`.
+ *
+ */
+enum
+{
+    OT_CHANGED_IP6_ADDRESS_ADDED            = 1 << 0,   ///< IPv6 address was added
+    OT_CHANGED_IP6_ADDRESS_REMOVED          = 1 << 1,   ///< IPv6 address was removed
+    OT_CHANGED_THREAD_ROLE                  = 1 << 2,   ///< Role (disabled, detached, child, router, leader) changed
+    OT_CHANGED_THREAD_LL_ADDR               = 1 << 3,   ///< The link-local address changed
+    OT_CHANGED_THREAD_ML_ADDR               = 1 << 4,   ///< The mesh-local address changed
+    OT_CHANGED_THREAD_RLOC_ADDED            = 1 << 5,   ///< RLOC was added
+    OT_CHANGED_THREAD_RLOC_REMOVED          = 1 << 6,   ///< RLOC was removed
+    OT_CHANGED_THREAD_PARTITION_ID          = 1 << 7,   ///< Partition ID changed
+    OT_CHANGED_THREAD_KEY_SEQUENCE_COUNTER  = 1 << 8,   ///< Thread Key Sequence changed
+    OT_CHANGED_THREAD_NETDATA               = 1 << 9,   ///< Thread Network Data changed
+    OT_CHANGED_THREAD_CHILD_ADDED           = 1 << 10,  ///< Child was added
+    OT_CHANGED_THREAD_CHILD_REMOVED         = 1 << 11,  ///< Child was removed
+    OT_CHANGED_IP6_MULTICAST_SUBSRCRIBED    = 1 << 12,  ///< Subscribed to a IPv6 multicast address
+    OT_CHANGED_IP6_MULTICAST_UNSUBSRCRIBED  = 1 << 13,  ///< Unsubscribed from a IPv6 multicast address
+    OT_CHANGED_COMMISSIONER_STATE           = 1 << 14,  ///< Commissioner state changed
+    OT_CHANGED_JOINER_STATE                 = 1 << 15,  ///< Joiner state changed
+    OT_CHANGED_THREAD_CHANNEL               = 1 << 16,  ///< Thread network channel changed
+    OT_CHANGED_THREAD_PANID                 = 1 << 17,  ///< Thread network PAN Id changed
+    OT_CHANGED_THREAD_NETWORK_NAME          = 1 << 18,  ///< Thread network name changed
+    OT_CHANGED_THREAD_EXT_PANID             = 1 << 19,  ///< Thread network extended PAN ID changed
+    OT_CHANGED_MASTER_KEY                   = 1 << 20,  ///< Master key changed
+    OT_CHANGED_PSKC                         = 1 << 21,  ///< PSKc changed
+    OT_CHANGED_SECURITY_POLICY              = 1 << 22,  ///< Security Policy changed
+};
+
+/**
  * This function pointer is called to notify certain configuration or state changes within OpenThread.
  *
- * @param[in]  aFlags    A bit-field indicating specific state that has changed.
+ * @param[in]  aFlags    A bit-field indicating specific state that has changed.  See `OT_CHANGED_*` definitions.
  * @param[in]  aContext  A pointer to application-specific context.
  *
  */

--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -675,37 +675,6 @@ typedef struct otLinkModeConfig
 } otLinkModeConfig;
 
 /**
- * This enumeration represents flags that indicate what configuration or state has changed within OpenThread.
- *
- */
-enum
-{
-    OT_CHANGED_IP6_ADDRESS_ADDED            = 1 << 0,   ///< IPv6 address was added
-    OT_CHANGED_IP6_ADDRESS_REMOVED          = 1 << 1,   ///< IPv6 address was removed
-    OT_CHANGED_THREAD_ROLE                  = 1 << 2,   ///< Role (disabled, detached, child, router, leader) changed
-    OT_CHANGED_THREAD_LL_ADDR               = 1 << 3,   ///< The link-local address changed
-    OT_CHANGED_THREAD_ML_ADDR               = 1 << 4,   ///< The mesh-local address changed
-    OT_CHANGED_THREAD_RLOC_ADDED            = 1 << 5,   ///< RLOC was added
-    OT_CHANGED_THREAD_RLOC_REMOVED          = 1 << 6,   ///< RLOC was removed
-    OT_CHANGED_THREAD_PARTITION_ID          = 1 << 7,   ///< Partition ID changed
-    OT_CHANGED_THREAD_KEY_SEQUENCE_COUNTER  = 1 << 8,   ///< Thread Key Sequence changed
-    OT_CHANGED_THREAD_NETDATA               = 1 << 9,   ///< Thread Network Data changed
-    OT_CHANGED_THREAD_CHILD_ADDED           = 1 << 10,  ///< Child was added
-    OT_CHANGED_THREAD_CHILD_REMOVED         = 1 << 11,  ///< Child was removed
-    OT_CHANGED_IP6_MULTICAST_SUBSRCRIBED    = 1 << 12,  ///< Subscribed to a IPv6 multicast address
-    OT_CHANGED_IP6_MULTICAST_UNSUBSRCRIBED  = 1 << 13,  ///< Unsubscribed from a IPv6 multicast address
-    OT_CHANGED_COMMISSIONER_STATE           = 1 << 14,  ///< Commissioner state changed
-    OT_CHANGED_JOINER_STATE                 = 1 << 15,  ///< Joiner state changed
-    OT_CHANGED_THREAD_CHANNEL               = 1 << 16,  ///< Thread network channel changed
-    OT_CHANGED_THREAD_PANID                 = 1 << 17,  ///< Thread network PAN Id changed
-    OT_CHANGED_THREAD_NETWORK_NAME          = 1 << 18,  ///< Thread network name changed
-    OT_CHANGED_THREAD_EXT_PANID             = 1 << 19,  ///< Thread network extended PAN ID changed
-    OT_CHANGED_MASTER_KEY                   = 1 << 20,  ///< Master key changed
-    OT_CHANGED_PSKC                         = 1 << 21,  ///< PSKc changed
-    OT_CHANGED_SECURITY_POLICY              = 1 << 22,  ///< Security Policy changed
-};
-
-/**
  * This structure represents an IPv6 prefix.
  */
 OT_TOOL_PACKED_BEGIN


### PR DESCRIPTION
As suggested by @al1img [here](https://groups.google.com/forum/#!topic/openthread-users/a6504oYEgU8).