### PR TITLE
[mle] increase Route TLV length to avoid buffer overflow

### DIFF
--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -603,7 +603,7 @@ private:
     };
     uint8_t mRouterIdSequence;
     uint8_t mRouterIdMask[BitVectorBytes(kMaxRouterId + 1)];
-    uint8_t mRouteData[kMaxRouters];
+    uint8_t mRouteData[kMaxRouterId + 1];
 } OT_TOOL_PACKED_END;
 
 /**


### PR DESCRIPTION
Properly formed Route TLVs should never have more than 32 route entries.
This fix follows a "be liberal in what you accept" approach.