### PR TITLE
[spinel] change parsing of boolean

### DIFF
--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -277,7 +277,7 @@ spinel_datatype_vunpack_(bool in_place, const uint8_t *data_ptr, spinel_size_t d
 
             if (arg_ptr)
             {
-                *arg_ptr = data_ptr[0];
+                *arg_ptr = data_ptr[0] != 0;
             }
 
             ret += sizeof(uint8_t);


### PR DESCRIPTION
This commit brings/syncs the change in `spinel.c` from wpantund. This change was done as part of wpantund commit https://github.com/openthread/wpantund/commit/d77e7cbf23a942a65dd8078405240e5fe3b67b8d which addressed some of the fuzzer test issues.

