### PR TITLE
[build] fix IAR and Keil build warnings

### DIFF
--- a/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
+++ b/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
@@ -162,6 +162,7 @@
  */
 #if defined(__CC_ARM)
     _Pragma("diag_suppress=111")
+    _Pragma("diag_suppress=128")
 #endif
 
 #endif  // OPENTHREAD_CORE_NRF52840_CONFIG_H_

--- a/include/openthread/platform/toolchain.h
+++ b/include/openthread/platform/toolchain.h
@@ -243,8 +243,10 @@ extern "C" {
 
 #define OT_UNREACHABLE_CODE(CODE)       \
     _Pragma("diag_suppress=Pe111")      \
+    _Pragma("diag_suppress=Pe128")      \
     CODE                                \
-    _Pragma("diag_default=Pe111")
+    _Pragma("diag_default=Pe111")       \
+    _Pragma("diag_default=Pe128")
 
 #elif defined(__CC_ARM)
 

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -392,4 +392,4 @@ template<> Utils::SupervisionListener &Instance::Get(void)
     return GetThreadNetif().GetSupervisionListener();
 }
 
-} // namespance ot
+} // namespace ot

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1042,7 +1042,7 @@ void Mac::HandleTransmitDone(otRadioFrame *aFrame, otRadioFrame *aAckFrame, otEr
 
     default:
         assert(false);
-        ExitNow();
+        OT_UNREACHABLE_CODE(ExitNow());
     }
 
     // Determine whether a CSMA retry is required.

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -161,7 +161,7 @@ private:
  * This class implements Extended MAC Address TLV generation and parsing.
  *
  */
-OT_TOOL_PACKED_BEGIN;
+OT_TOOL_PACKED_BEGIN
 class ThreadExtMacAddressTlv: public ThreadTlv
 {
 public:


### PR DESCRIPTION
This PR provides some minor fixes to restore warningless build of OpenThread libraries in IAR and Keil compilers.