### PR TITLE
[logging] remove otLogFunc<Entry/Exit> macros

### DIFF
--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -50,10 +50,8 @@ otInstance *otInstanceInit(void *aInstanceBuffer, size_t *aInstanceBufferSize)
 {
     Instance *instance;
 
-    otLogFuncEntry();
     instance = Instance::Init(aInstanceBuffer, aInstanceBufferSize);
     otLogInfoApi(*instance, "otInstance Initialized");
-    otLogFuncExit();
 
     return instance;
 }
@@ -76,9 +74,7 @@ void otInstanceFinalize(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    otLogFuncEntry();
     instance.Finalize();
-    otLogFuncExit();
 }
 
 otError otSetStateChangedCallback(otInstance *aInstance, otStateChangedCallback aCallback, void *aContext)

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -48,8 +48,6 @@ otError otIp6SetEnabled(otInstance *aInstance, bool aEnabled)
     otError error = OT_ERROR_NONE;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    otLogFuncEntry();
-
     if (aEnabled)
     {
 #if OPENTHREAD_ENABLE_RAW_LINK_API
@@ -68,7 +66,6 @@ otError otIp6SetEnabled(otInstance *aInstance, bool aEnabled)
 #if OPENTHREAD_ENABLE_RAW_LINK_API
 exit:
 #endif // OPENTHREAD_ENABLE_RAW_LINK_API
-    otLogFuncExitErr(error);
     return error;
 }
 
@@ -189,12 +186,8 @@ otError otIp6Send(otInstance *aInstance, otMessage *aMessage)
     otError error;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    otLogFuncEntry();
-
     error = instance.GetIp6().SendRaw(*static_cast<Message *>(aMessage),
                                       instance.GetThreadNetif().GetInterfaceId());
-
-    otLogFuncExitErr(error);
 
     return error;
 }
@@ -203,7 +196,6 @@ otMessage *otIp6NewMessage(otInstance *aInstance, bool aLinkSecurityEnabled)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
     Message *message = instance.GetMessagePool().New(Message::kTypeIp6, 0);
-
 
     if (message)
     {

--- a/src/core/api/tasklet_api.cpp
+++ b/src/core/api/tasklet_api.cpp
@@ -47,12 +47,11 @@ void otTaskletsProcess(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    otLogFuncEntry();
     VerifyOrExit(otInstanceIsInitialized(aInstance));
     instance.GetTaskletScheduler().ProcessQueuedTasklets();
 
 exit:
-    otLogFuncExit();
+    return;
 }
 
 bool otTaskletsArePending(otInstance *aInstance)

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -480,8 +480,6 @@ otError otThreadSetEnabled(otInstance *aInstance, bool aEnabled)
     otError error = OT_ERROR_NONE;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    otLogFuncEntry();
-
     if (aEnabled)
     {
         VerifyOrExit(instance.GetThreadNetif().GetMac().GetPanId() != Mac::kPanIdBroadcast,
@@ -494,7 +492,6 @@ otError otThreadSetEnabled(otInstance *aInstance, bool aEnabled)
     }
 
 exit:
-    otLogFuncExitErr(error);
     return error;
 }
 

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -131,14 +131,11 @@ otError CoapSecure::SendMessage(Message &aMessage, otCoapResponseHandler aHandle
 {
     otError error = OT_ERROR_NONE;
 
-    otLogFuncEntry();
-
     VerifyOrExit(IsConnected(), error = OT_ERROR_INVALID_STATE);
 
     error = CoapBase::SendMessage(aMessage, mPeerAddress, aHandler, aContext);
 
 exit:
-    otLogFuncExitErr(error);
     return error;
 }
 
@@ -157,8 +154,6 @@ otError CoapSecure::Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo
 void CoapSecure::Receive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     ThreadNetif &netif = GetNetif();
-
-    otLogFuncEntry();
 
     if (!netif.GetDtls().IsStarted())
     {
@@ -193,7 +188,7 @@ void CoapSecure::Receive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo
     netif.GetDtls().Receive(aMessage, aMessage.GetOffset(), aMessage.GetLength() - aMessage.GetOffset());
 
 exit:
-    otLogFuncExit();
+    return;
 }
 
 void CoapSecure::HandleDtlsConnected(void *aContext, bool aConnected)
@@ -218,8 +213,6 @@ void CoapSecure::HandleDtlsReceive(uint8_t *aBuf, uint16_t aLength)
 {
     Message *message = NULL;
 
-    otLogFuncEntry();
-
     VerifyOrExit((message = GetInstance().GetMessagePool().New(Message::kTypeIp6, 0)) != NULL);
     SuccessOrExit(message->Append(aBuf, aLength));
 
@@ -231,8 +224,6 @@ exit:
     {
         message->Free();
     }
-
-    otLogFuncExit();
 }
 
 otError CoapSecure::HandleDtlsSend(void *aContext, const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType)
@@ -243,8 +234,6 @@ otError CoapSecure::HandleDtlsSend(void *aContext, const uint8_t *aBuf, uint16_t
 otError CoapSecure::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType)
 {
     otError error = OT_ERROR_NONE;
-
-    otLogFuncEntry();
 
     if (mTransmitMessage == NULL)
     {
@@ -271,8 +260,6 @@ exit:
         mTransmitMessage = NULL;
     }
 
-    otLogFuncExitErr(error);
-
     return error;
 }
 
@@ -284,8 +271,6 @@ void CoapSecure::HandleUdpTransmit(Tasklet &aTasklet)
 void CoapSecure::HandleUdpTransmit(void)
 {
     otError error = OT_ERROR_NONE;
-
-    otLogFuncEntry();
 
     VerifyOrExit(mTransmitMessage != NULL, error = OT_ERROR_NO_BUFS);
 
@@ -306,8 +291,6 @@ exit:
     }
 
     mTransmitMessage = NULL;
-
-    otLogFuncExit();
 }
 
 void CoapSecure::HandleRetransmissionTimer(Timer &aTimer)

--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -58,14 +58,6 @@
 extern "C" {
 #endif
 
-#ifndef WINDOWS_LOGGING
-#define otLogFuncEntry()
-#define otLogFuncEntryMsg(aFormat, ...)
-#define otLogFuncExit()
-#define otLogFuncExitMsg(aFormat, ...)
-#define otLogFuncExitErr(error)
-#endif
-
 /**
  * @def otLogCrit
  *

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -215,13 +215,11 @@ extern "C" void otPlatAlarmMilliFired(otInstance *aInstance)
 {
     Instance *instance = static_cast<Instance *>(aInstance);
 
-    otLogFuncEntry();
-
     VerifyOrExit(otInstanceIsInitialized(aInstance));
     instance->GetTimerMilliScheduler().ProcessTimers();
 
 exit:
-    otLogFuncExit();
+    return;
 }
 
 #if OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER
@@ -253,13 +251,11 @@ extern "C" void otPlatAlarmMicroFired(otInstance *aInstance)
 {
     Instance *instance = static_cast<Instance *>(aInstance);
 
-    otLogFuncEntry();
-
     VerifyOrExit(otInstanceIsInitialized(aInstance));
     instance->GetTimerMicroScheduler().ProcessTimers();
 
 exit:
-    otLogFuncExit();
+    return;
 }
 #endif // OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -419,8 +419,6 @@ void Mac::SetExtAddress(const ExtAddress &aExtAddress)
 {
     otExtAddress address;
 
-    otLogFuncEntry();
-
     for (size_t i = 0; i < sizeof(address); i++)
     {
         address.m8[i] = aExtAddress.m8[7 - i];
@@ -428,16 +426,13 @@ void Mac::SetExtAddress(const ExtAddress &aExtAddress)
 
     otPlatRadioSetExtendedAddress(&GetInstance(), &address);
     mExtAddress = aExtAddress;
-
-    otLogFuncExit();
 }
 
 otError Mac::SetShortAddress(ShortAddress aShortAddress)
 {
-    otLogFuncEntryMsg("%d", aShortAddress);
     mShortAddress = aShortAddress;
     otPlatRadioSetShortAddress(&GetInstance(), aShortAddress);
-    otLogFuncExit();
+
     return OT_ERROR_NONE;
 }
 
@@ -445,15 +440,12 @@ otError Mac::SetChannel(uint8_t aChannel)
 {
     otError error = OT_ERROR_NONE;
 
-    otLogFuncEntryMsg("%d", aChannel);
-
     VerifyOrExit(OT_RADIO_CHANNEL_MIN <= aChannel && aChannel <= OT_RADIO_CHANNEL_MAX, error = OT_ERROR_INVALID_ARGS);
 
     mChannel = aChannel;
     UpdateIdleMode();
 
 exit:
-    otLogFuncExit();
     return error;
 }
 
@@ -461,23 +453,19 @@ otError Mac::SetNetworkName(const char *aNetworkName)
 {
     otError error = OT_ERROR_NONE;
 
-    otLogFuncEntryMsg("%s", aNetworkName);
-
     VerifyOrExit(strlen(aNetworkName) <= OT_NETWORK_NAME_MAX_SIZE, error = OT_ERROR_INVALID_ARGS);
 
     (void)strlcpy(mNetworkName.m8, aNetworkName, sizeof(mNetworkName));
 
 exit:
-    otLogFuncExitErr(error);
     return error;
 }
 
 otError Mac::SetPanId(PanId aPanId)
 {
-    otLogFuncEntryMsg("%d", aPanId);
     mPanId = aPanId;
     otPlatRadioSetPanId(&GetInstance(), mPanId);
-    otLogFuncExit();
+
     return OT_ERROR_NONE;
 }
 
@@ -977,11 +965,11 @@ extern "C" void otPlatRadioTxStarted(otInstance *aInstance, otRadioFrame *aFrame
 {
     Instance *instance = static_cast<Instance *>(aInstance);
 
-    otLogFuncEntry();
     VerifyOrExit(instance->IsInitialized());
     instance->GetThreadNetif().GetMac().HandleTransmitStarted(aFrame);
+
 exit:
-    otLogFuncExit();
+    return;
 }
 
 void Mac::HandleTransmitStarted(otRadioFrame *aFrame)
@@ -1000,7 +988,6 @@ extern "C" void otPlatRadioTxDone(otInstance *aInstance, otRadioFrame *aFrame, o
 {
     Instance *instance = static_cast<Instance *>(aInstance);
 
-    otLogFuncEntryMsg("%!otError!", aError);
     VerifyOrExit(instance->IsInitialized());
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
@@ -1016,7 +1003,7 @@ extern "C" void otPlatRadioTxDone(otInstance *aInstance, otRadioFrame *aFrame, o
     }
 
 exit:
-    otLogFuncExit();
+    return;
 }
 
 void Mac::HandleTransmitDone(otRadioFrame *aFrame, otRadioFrame *aAckFrame, otError aError)
@@ -1496,7 +1483,6 @@ extern "C" void otPlatRadioReceiveDone(otInstance *aInstance, otRadioFrame *aFra
 {
     Instance *instance = static_cast<Instance *>(aInstance);
 
-    otLogFuncEntryMsg("%!otError!", aError);
     VerifyOrExit(instance->IsInitialized());
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
@@ -1512,7 +1498,7 @@ extern "C" void otPlatRadioReceiveDone(otInstance *aInstance, otRadioFrame *aFra
     }
 
 exit:
-    otLogFuncExit();
+    return;
 }
 
 void Mac::HandleReceivedFrame(Frame *aFrame, otError aError)

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -94,8 +94,6 @@ otError Joiner::Start(const char *aPSKd, const char *aProvisioningUrl,
     Crc16 ccitt(Crc16::kCcitt);
     Crc16 ansi(Crc16::kAnsi);
 
-    otLogFuncEntry();
-
     VerifyOrExit(mState == OT_JOINER_STATE_IDLE, error = OT_ERROR_BUSY);
 
     GetNotifier().SetFlags(OT_CHANGED_JOINER_STATE);
@@ -138,17 +136,13 @@ otError Joiner::Start(const char *aPSKd, const char *aProvisioningUrl,
     mState = OT_JOINER_STATE_DISCOVER;
 
 exit:
-    otLogFuncExitErr(error);
     return error;
 }
 
 otError Joiner::Stop(void)
 {
-    otLogFuncEntry();
-
     Close();
 
-    otLogFuncExit();
     return OT_ERROR_NONE;
 }
 
@@ -160,12 +154,9 @@ otJoinerState Joiner::GetState(void) const
 void Joiner::Close(void)
 {
     ThreadNetif &netif = GetNetif();
-    otLogFuncEntry();
 
     netif.GetCoapSecure().Disconnect();
     netif.GetIp6Filter().RemoveUnsecurePort(netif.GetCoapSecure().GetPort());
-
-    otLogFuncExit();
 }
 
 void Joiner::Complete(otError aError)
@@ -198,13 +189,12 @@ void Joiner::HandleDiscoverResult(otActiveScanResult *aResult, void *aContext)
 
 void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
 {
-    otLogFuncEntry();
-
     if (aResult != NULL)
     {
         JoinerRouter joinerRouter;
 
-        otLogFuncEntryMsg("aResult = %llX", HostSwap64(*reinterpret_cast<uint64_t *>(&aResult->mExtAddress)));
+        otLogDebgMeshCoP(GetInstance(), "HandleDiscoverResult() aResult = %llX",
+                         HostSwap64(*reinterpret_cast<uint64_t *>(&aResult->mExtAddress)));
 
         // Joining is disabled if the Steering Data is not included
         if (aResult->mSteeringData.mLength == 0)
@@ -248,7 +238,7 @@ void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
     }
 
 exit:
-    otLogFuncExit();
+    return;
 }
 
 void Joiner::AddJoinerRouter(JoinerRouter &aJoinerRouter)
@@ -356,8 +346,6 @@ void Joiner::SendJoinerFinalize(void)
     VendorSwVersionTlv vendorSwVersionTlv;
     VendorStackVersionTlv vendorStackVersionTlv;
 
-    otLogFuncEntry();
-
     header.Init(OT_COAP_TYPE_CONFIRMABLE, OT_COAP_CODE_POST);
     header.AppendUriPathOptions(OT_URI_PATH_JOINER_FINALIZE);
     header.SetPayloadMarker();
@@ -419,8 +407,6 @@ exit:
     {
         message->Free();
     }
-
-    otLogFuncExit();
 }
 
 void Joiner::HandleJoinerFinalizeResponse(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
@@ -436,8 +422,6 @@ void Joiner::HandleJoinerFinalizeResponse(Coap::Header *aHeader, Message *aMessa
 {
     (void) aMessageInfo;
     StateTlv state;
-
-    otLogFuncEntry();
 
     VerifyOrExit(mState == OT_JOINER_STATE_CONNECTED &&
                  aResult == OT_ERROR_NONE &&
@@ -461,7 +445,6 @@ void Joiner::HandleJoinerFinalizeResponse(Coap::Header *aHeader, Message *aMessa
 
 exit:
     Close();
-    otLogFuncExit();
 }
 
 void Joiner::HandleJoinerEntrust(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
@@ -482,8 +465,6 @@ void Joiner::HandleJoinerEntrust(Coap::Header &aHeader, Message &aMessage, const
     NetworkNameTlv networkName;
     ActiveTimestampTlv activeTimestamp;
     NetworkKeySequenceTlv networkKeySeq;
-
-    otLogFuncEntry();
 
     VerifyOrExit(mState == OT_JOINER_STATE_ENTRUST &&
                  aHeader.GetType() == OT_COAP_TYPE_CONFIRMABLE &&
@@ -537,8 +518,6 @@ exit:
         otLogWarnMeshCoP(GetInstance(), "Error while processing joiner entrust: %s",
                          otThreadErrorToString(error));
     }
-
-    otLogFuncExit();
 }
 
 void Joiner::SendJoinerEntrustResponse(const Coap::Header &aRequestHeader,
@@ -549,8 +528,6 @@ void Joiner::SendJoinerEntrustResponse(const Coap::Header &aRequestHeader,
     Message *message;
     Coap::Header responseHeader;
     Ip6::MessageInfo responseInfo(aRequestInfo);
-
-    otLogFuncEntry();
 
     responseHeader.SetDefaultResponseHeader(aRequestHeader);
 
@@ -573,8 +550,6 @@ exit:
     {
         message->Free();
     }
-
-    otLogFuncExit();
 }
 
 void Joiner::HandleTimer(Timer &aTimer)

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -139,11 +139,10 @@ exit:
 
 otError JoinerRouter::SetJoinerUdpPort(uint16_t aJoinerUdpPort)
 {
-    otLogFuncEntry();
     mJoinerUdpPort = aJoinerUdpPort;
     mIsJoinerPortConfigured = true;
     HandleStateChanged(OT_CHANGED_THREAD_NETDATA);
-    otLogFuncExit();
+
     return OT_ERROR_NONE;
 }
 
@@ -166,8 +165,6 @@ void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &a
     ExtendedTlv tlv;
     uint16_t borderAgentRloc;
 
-    otLogFuncEntryMsg("from peer: %llX",
-                      HostSwap64(*reinterpret_cast<const uint64_t *>(aMessageInfo.GetPeerAddr().mFields.m8 + 8)));
     otLogInfoMeshCoP(GetInstance(), "JoinerRouter::HandleUdpReceive");
 
     SuccessOrExit(error = GetBorderAgentRloc(borderAgentRloc));
@@ -226,8 +223,6 @@ exit:
     {
         message->Free();
     }
-
-    otLogFuncExitErr(error);
 }
 
 void JoinerRouter::HandleRelayTransmit(void *aContext, otCoapHeader *aHeader, otMessage *aMessage,
@@ -249,7 +244,6 @@ void JoinerRouter::HandleRelayTransmit(Coap::Header &aHeader, Message &aMessage,
     Message *message = NULL;
     Ip6::MessageInfo messageInfo;
 
-    otLogFuncEntry();
     VerifyOrExit(aHeader.GetType() == OT_COAP_TYPE_NON_CONFIRMABLE &&
                  aHeader.GetCode() == OT_COAP_CODE_POST, error = OT_ERROR_DROP);
 
@@ -307,8 +301,6 @@ exit:
     {
         message->Free();
     }
-
-    otLogFuncExitErr(error);
 }
 
 
@@ -329,8 +321,6 @@ otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessage
     const Tlv *tlv;
 
     DelayedJoinEntHeader delayedMessage;
-
-    otLogFuncEntry();
 
     header.Init(OT_COAP_TYPE_CONFIRMABLE, OT_COAP_CODE_POST);
     header.AppendUriPathOptions(OT_URI_PATH_JOINER_ENTRUST);
@@ -422,7 +412,6 @@ exit:
         message->Free();
     }
 
-    otLogFuncExitErr(error);
     return error;
 }
 

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -706,7 +706,6 @@ otError Ip6::HandleDatagram(Message &aMessage, Netif *aNetif, int8_t aInterfaceI
     uint8_t hopLimit;
     int8_t forwardInterfaceId;
 
-    otLogFuncEntry();
 
 #if 0
     uint8_t buf[1024];
@@ -833,15 +832,12 @@ exit:
         aMessage.Free();
     }
 
-    otLogFuncExitErr(error);
     return error;
 }
 
 int8_t Ip6::FindForwardInterfaceId(const MessageInfo &aMessageInfo)
 {
     int8_t interfaceId;
-
-    otLogFuncEntry();
 
     if (aMessageInfo.GetSockAddr().IsMulticast())
     {
@@ -867,8 +863,6 @@ int8_t Ip6::FindForwardInterfaceId(const MessageInfo &aMessageInfo)
     {
         interfaceId = 0;
     }
-
-    otLogFuncExit();
 
     return interfaceId;
 }

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -238,8 +238,6 @@ otError Mle::Start(bool aEnableReattach, bool aAnnounceAttach)
     ThreadNetif &netif = GetNetif();
     otError error = OT_ERROR_NONE;
 
-    otLogFuncEntry();
-
     // cannot bring up the interface if IEEE 802.15.4 promiscuous mode is enabled
     VerifyOrExit(otPlatRadioGetPromiscuous(&netif.GetInstance()) == false, error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(netif.IsUp(), error = OT_ERROR_INVALID_STATE);
@@ -274,7 +272,6 @@ otError Mle::Start(bool aEnableReattach, bool aAnnounceAttach)
     }
 
 exit:
-    otLogFuncExitErr(error);
     return error;
 }
 
@@ -282,7 +279,6 @@ otError Mle::Stop(bool aClearNetworkDatasets)
 {
     ThreadNetif &netif = GetNetif();
 
-    otLogFuncEntry();
     netif.GetKeyManager().Stop();
     SetStateDetached();
     netif.RemoveUnicastAddress(mMeshLocal16);
@@ -298,7 +294,7 @@ otError Mle::Stop(bool aClearNetworkDatasets)
     }
 
     mRole = OT_DEVICE_ROLE_DISABLED;
-    otLogFuncExit();
+
     return OT_ERROR_NONE;
 }
 
@@ -503,8 +499,6 @@ otError Mle::BecomeDetached(void)
     ThreadNetif &netif = GetNetif();
     otError error = OT_ERROR_NONE;
 
-    otLogFuncEntry();
-
     VerifyOrExit(mRole != OT_DEVICE_ROLE_DISABLED, error = OT_ERROR_INVALID_STATE);
 
     // not in reattach stage after reset
@@ -523,7 +517,6 @@ otError Mle::BecomeDetached(void)
     BecomeChild(kAttachAny);
 
 exit:
-    otLogFuncExitErr(error);
     return error;
 }
 
@@ -531,8 +524,6 @@ otError Mle::BecomeChild(AttachMode aMode)
 {
     ThreadNetif &netif = GetNetif();
     otError error = OT_ERROR_NONE;
-
-    otLogFuncEntry();
 
     VerifyOrExit(mRole != OT_DEVICE_ROLE_DISABLED, error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(mParentRequestState == kParentIdle, error = OT_ERROR_BUSY);
@@ -568,7 +559,6 @@ otError Mle::BecomeChild(AttachMode aMode)
     mParentRequestTimer.Start((otPlatRandomGet() % kParentRequestRouterTimeout) + 1);
 
 exit:
-    otLogFuncExitErr(error);
     return error;
 }
 


### PR DESCRIPTION
This commit removes the `otLogFuncEntry` and `otLogFuncExit` (and other related) macros and their use within OT core.

These macros were currently unused on all platforms except for windows. They do not follow the model used by all other `otLog` APIs (there is no way to specify log region, or log level or to pass in `ot::Instance` to them). 
