### PR TITLE
[logging] change log strings in LogIp6Message

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -2490,7 +2490,7 @@ void MeshForwarder::LogIp6Message(MessageAction aAction, const Message &aMessage
         break;
 
     case kMessagePrepareIndirect:
-        actionText = "Preping indir tx";
+        actionText = "Prepping indir tx";
         shouldLogSrcDstAddresses = false;
         break;
 
@@ -2499,7 +2499,7 @@ void MeshForwarder::LogIp6Message(MessageAction aAction, const Message &aMessage
         break;
 
     case kMessageReassemblyDrop:
-        actionText = "Dropping (reassembly timeout)";
+        actionText = "Dropping (reassembly queue)";
         shouldLogRss = true;
         break;
 


### PR DESCRIPTION
Changing the string for `kMessageReassemblyDrop` from `"Dropping (reassembly timeout)"` to `"Dropping (reassembly queue)"` to note that message is not necessarily being dropped due to timeout. For example,  message in reassembly queue may be dropped on SED if a fragment is missed or a fragment for a new message (different tag) is received. 
