### PR TITLE
[mle] delete stale EID-to-RLOC entries of removed neighbors

### DIFF
--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -97,13 +97,24 @@ exit:
     return error;
 }
 
-void AddressResolver::Remove(uint8_t routerId)
+void AddressResolver::Remove(uint8_t aRouterId)
 {
     for (int i = 0; i < kCacheEntries; i++)
     {
-        if (Mle::Mle::GetRouterId(mCache[i].mRloc16) == routerId)
+        if (Mle::Mle::GetRouterId(mCache[i].mRloc16) == aRouterId)
         {
             InvalidateCacheEntry(mCache[i], kReasonRemovingRouterId);
+        }
+    }
+}
+
+void AddressResolver::Remove(uint16_t aRloc16)
+{
+    for (int i = 0; i < kCacheEntries; i++)
+    {
+        if (mCache[i].mRloc16 == aRloc16)
+        {
+            InvalidateCacheEntry(mCache[i], kReasonRemovingRloc16);
         }
     }
 }
@@ -154,6 +165,10 @@ const char *AddressResolver::ConvertInvalidationReasonToString(InvalidationReaso
     {
     case kReasonRemovingRouterId:
         str = "removing router id";
+        break;
+
+    case kReasonRemovingRloc16:
+        str = "removing rloc16";
         break;
 
     case kReasonReceivedIcmpDstUnreachNoRoute:

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -94,7 +94,15 @@ public:
     otError GetEntry(uint8_t aIndex, otEidCacheEntry &aEntry) const;
 
     /**
-     * This method removes a Router ID from the EID-to-RLOC cache.
+     * This method removes the EID-to-RLOC cache entries corresponding to an RLOC16.
+     *
+     * @param[in]  aRloc16  The RLOC16 address.
+     *
+     */
+    void Remove(uint16_t aRloc16);
+
+    /**
+     * This method removes all EID-to-RLOC cache entries assossiated with a Router ID.
      *
      * @param[in]  aRouterId  The Router ID.
      *
@@ -169,6 +177,7 @@ private:
     enum InvalidationReason
     {
         kReasonRemovingRouterId,
+        kReasonRemovingRloc16,
         kReasonReceivedIcmpDstUnreachNoRoute,
         kReasonEvictingForNewEntry,
     };

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3244,6 +3244,13 @@ otError MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
             aNeighbor.SetState(Neighbor::kStateInvalid);
             netif.GetMeshForwarder().UpdateIndirectMessages();
             netif.GetNetworkDataLeader().SendServerDataNotification(aNeighbor.GetRloc16());
+
+            if (aNeighbor.GetDeviceMode() & ModeTlv::kModeFFD)
+            {
+                // Clear all EID-to-RLOC entries assossiated with the child.
+                netif.GetAddressResolver().Remove(aNeighbor.GetRloc16());
+            }
+
             RemoveStoredChild(aNeighbor.GetRloc16());
         }
         else if ((aNeighbor.GetState() == Neighbor::kStateValid) && IsActiveRouter(aNeighbor.GetRloc16()))
@@ -3270,6 +3277,9 @@ otError MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
             if (routerToRemove.GetNextHop() == kInvalidRouterId)
             {
                 ResetAdvertiseInterval();
+
+                // Clear all EID-to-RLOC entries assossiated with the router.
+                netif.GetAddressResolver().Remove(GetRouterId(aNeighbor.GetRloc16()));
             }
         }
 


### PR DESCRIPTION
Currently, OpenThread detects several situations where RLOC16 of our neighbor is stale (based on extended MAC address).
For example, when our child sends Link Request from different RLOC16, we remove him from the child list.
	
Unfortunately in many such places, EID-to-RLOC cache is not cleared, which may lead to single packet drop.

You can reproduce this situation for example like that:
	
```
1. Node A:
panid 0
ifconfig up
thread start

2. Node B:
panid 0
routerrole disable
ifconfig up
thread start

3. Node A:
ping Node B ML-EID (new Address Query is generated)
Reply from Node B SUCCESS

4. Node B:
routerrole enable
state router

5. Node A:
ping Node B ML-EID (internal ICMPv6 Dest Unreachable message is sent to ourself, and EID-to-RLOC cache entries are removed)
**No Reply**

ping Node B ML-EID (new Address Query is generated)
Reply from Node B SUCCESS
```

This PR:
 - removes the stale EID-to-RLOC entries in such cases (child promotes to router, router downgrades to child etc.), which basically replaces the step 5 from above interaction with the step 3).
 - additionally cleans up (unifying) child removal procedure (please review it carefully, i don't see a reason why previously child could be removed in several ways, but i may have missed sth)
 
 If this PR could be accepted, i would like to merge two commits separately (without squashing them), else i can create two PRs separately.