### PR TITLE
[child-supervision] relax the check for starting the supervision timeout timer

### DIFF
--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -214,9 +214,7 @@ void SupervisionListener::RestartTimer(void)
 {
     ThreadNetif &netif = GetNetif();
 
-    // Restart the timer, if the timeout value is non-zero and the device is a sleepy child.
-
-    if ((mTimeout != 0) && (netif.GetMle().GetRole() == OT_DEVICE_ROLE_CHILD) &&
+    if ((mTimeout != 0) && (netif.GetMle().GetRole() != OT_DEVICE_ROLE_DISABLED) &&
         (netif.GetMeshForwarder().GetRxOnWhenIdle() == false))
     {
         mTimer.Start(TimerMilli::SecToMsec(mTimeout));


### PR DESCRIPTION
This commit changes the `SupervisionListener` implementation by
relaxing the checks for when to start the supervision listener timeout
timer, in particular removing the check for role to be `ROLE_CHILD`.
This addresses an issue where timer may not start during (re-)attach
process after a "Child Id Request" transmission where the device
becomes sleepy but its role is not yet set to child.