### PR TITLE
[mle] clear previous rloc16 before parent switch attempt

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1673,6 +1673,7 @@ otError Mle::SendChildIdRequest(void)
     SuccessOrExit(error = AppendPendingTimestamp(*message));
 
     mParentCandidate.SetState(Neighbor::kStateValid);
+    SetRloc16(Mac::kShortAddrInvalid);
 
     memset(&destination, 0, sizeof(destination));
     destination.mFields.m16[0] = HostSwap16(0xfe80);


### PR DESCRIPTION
This commit adds code to explicitly set the RLOC16 to invalid from
within  `Mle::SendChildIdRequest()`. This ensures that during a parent
switch attempt on a sleepy-end-device, the data polls use the
extended address as the source MAC address.