### PR TITLE
[mesh-forwarder] use extended address for data poll during parent switch attempt

### DIFF
--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -275,6 +275,7 @@ private:
     Message *GetIndirectTransmission(Child &aChild);
     otError PrepareDiscoverRequest(void);
     void PrepareIndirectTransmission(Message &aMessage, const Child &aChild);
+    otError PrepareDataPoll(void);
     void HandleMesh(uint8_t *aFrame, uint8_t aPayloadLength, const Mac::Address &aMacSource,
                     const otThreadLinkInfo &aLinkInfo);
     void HandleFragment(uint8_t *aFrame, uint8_t aPayloadLength,


### PR DESCRIPTION
This commit changes the logic for preparing a data poll (802.15.4 MAC
Data Request) frame and selecting short/extended address. It ensures
that during a parent switch attempt on a sleepy-end-device, the data
polls use the extended address as the source MAC address.