### PR TITLE
[cc2538] adjust receiver sensitivity

### DIFF
--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -64,7 +64,7 @@ enum
 
 enum
 {
-    CC2538_RECEIVE_SENSITIVITY = -100, // dBm
+    CC2538_RECEIVE_SENSITIVITY = -88, // dBm
 };
 
 typedef struct TxPowerTable


### PR DESCRIPTION
CC2538 data sheet indicates -88 dBm across entire operating conditions.