### PR TITLE
[mesh-forwarder] Clear child's indirect message pointer when removing all its messages

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -211,6 +211,7 @@ void MeshForwarder::ClearChildIndirectMessages(Child &aChild)
         }
     }
 
+    aChild.SetIndirectMessage(NULL);
     mSourceMatchController.ResetMessageCount(aChild);
 
 exit:


### PR DESCRIPTION
This commit changes the `ClearChildIndirectMessages(aChild)` method in `MeshForwarder` to ensure that it also clears the indirect message pointer on the child entry.

This addresses a subtle bug in the code in the following situation: If we happen to receive a "Child Id Request" from an already valid child for which we are in the middle of an indirect transmission, from `MleRouter::HandleChildIdRequest()` all queued indirect messages for the child  are removed (through `MleRouter::RemoveNeighbor()` call). This would then free the indirect message while the child still kept a pointer to the freed message.