### PR TITLE
[tests] fix the unstable test case Cert_5_5_08_SplitRoutersLostLeader

### DIFF
--- a/tests/scripts/thread-cert/Cert_5_5_08_SplitRoutersLostLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_5_08_SplitRoutersLostLeader.py
@@ -48,6 +48,7 @@ class Cert_5_5_8_SplitRoutersLostLeader(unittest.TestCase):
         self.nodes[LEADER1].set_mode('rsdn')
         self.nodes[LEADER1].add_whitelist(self.nodes[ROUTER3].get_addr64())
         self.nodes[LEADER1].enable_whitelist()
+        self.nodes[LEADER1].set_router_selection_jitter(1)
 
         self.nodes[ROUTER3].set_panid(0xface)
         self.nodes[ROUTER3].set_mode('rsdn')


### PR DESCRIPTION
The unstable failing lies in when Leader has lower partition id and switches to better partition
formed by original routers.  The default RouterSelectionJitter of Leader is 120s, however the
migration waiting time in script is 60s, thus there are chances that the ping happens when the
Leader just becomes router in the new partition but before link sychronization, causing the ping
packet dropped on ROUTER3.

Two options to resolve this: 1) increase the waiting time for migration to a value > 120s or
2) configure router selection jitter to a small value to relax the waiting time requirements.
The second option reduces test time which is selected to resolve this issue.
  