### PR TITLE
[ncp] Fix some issues with the spinel vendor hook.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1543,7 +1543,6 @@ AC_MSG_NOTICE([
   OpenThread MAC Filter support             : ${enable_mac_filter}
   OpenThread Diagnostics support            : ${enable_diag}
   OpenThread Child Supervision support      : ${enable_child_supervision}
-  OpenThread Spinel vendor specific support : ${enable_vendor}
   OpenThread Legacy network support         : ${enable_legacy}
   OpenThread Certification log support      : ${enable_cert_log}
   OpenThread DHCPv6 Server support          : ${enable_dhcp6_server}

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -53,7 +53,7 @@
 namespace ot {
 namespace Ncp {
 
-#if OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT == 0
+#if OPENTHREAD_ENABLE_NCP_VENDOR_HOOK == 0
 
 static otDEFINE_ALIGNED_VAR(sNcpRaw, sizeof(NcpSpi), uint64_t);
 

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -51,7 +51,7 @@
 namespace ot {
 namespace Ncp {
 
-#if OPENTHREAD_ENABLE_SPINEL_VENDOR_SUPPORT == 0
+#if OPENTHREAD_ENABLE_NCP_VENDOR_HOOK == 0
 
 static otDEFINE_ALIGNED_VAR(sNcpRaw, sizeof(NcpUart), uint64_t);
 


### PR DESCRIPTION
This fixes a couple issues related to the Spinel Vendor Hook feature.

1) otNcpInit in ncp_spi.cpp and ncp_uart.cpp was controlled by the wrong definition.
2) The enable_vendor variable no longer exists in configure.ac and so should be removed.