### PR TITLE
[ncp] do not check local network data lock when adding a joiner

### DIFF
--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -429,8 +429,6 @@ otError NcpBase::InsertPropertyHandler_THREAD_JOINERS(void)
     const char *aPSKd = NULL;
     uint32_t joinerTimeout = 0;
 
-    VerifyOrExit(mAllowLocalNetworkDataChange == true, error = OT_ERROR_INVALID_STATE);
-
     SuccessOrExit(error = mDecoder.ReadUtf8(aPSKd));
     SuccessOrExit(error = mDecoder.ReadUint32(joinerTimeout));
 
@@ -439,13 +437,11 @@ otError NcpBase::InsertPropertyHandler_THREAD_JOINERS(void)
         eui64 = NULL;
     }
 
-
     error = otCommissionerAddJoiner(mInstance, eui64, aPSKd, joinerTimeout);
 
 exit:
     return error;
 }
-
 #endif // OPENTHREAD_ENABLE_COMMISSIONER
 
 otError NcpBase::SetPropertyHandler_THREAD_LOCAL_LEADER_WEIGHT(void)


### PR DESCRIPTION
Due to issue #2110 there was a conclusion to not set lock on local network data when a new joiner is added. As a result the openthread/wpantund#256 pull request has been created.

However despite removing following [lines](https://github.com/openthread/wpantund/pull/256/files#diff-816a041f7db348e0472f042be4dab42fL329) from wpantund, the OpenThread code still checks if mLocalNetworkDataChange variable is set before joiner can be added.

This PR removes the check, allowing to add a new Joiner from the Host side again.