### PR TITLE
[travis] enable "channel monitor" feature in posix ftd (router) build

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -311,6 +311,7 @@ set -x
         --enable-legacy                     \
         --enable-mac-filter                 \
         --enable-service                    \
+        --enable-channel-monitor            \
         --disable-docs                      \
         --disable-test || die
     make -j 8 || die


### PR DESCRIPTION
This commit enables the "channel monitor" feature in the posix FTD build representing a common router Thread device.