### PR TITLE
[mesh-forwarder] do not forward mesh headers to MTD

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1981,7 +1981,8 @@ void MeshForwarder::HandleMesh(uint8_t *aFrame, uint8_t aFrameLength, const Mac:
     UpdateRoutes(aFrame, aFrameLength, meshSource, meshDest);
 #endif // OPENTHREAD_FTD
 
-    if (meshDest.mShortAddress == netif.GetMac().GetShortAddress())
+    if (meshDest.mShortAddress == netif.GetMac().GetShortAddress() ||
+        netif.GetMle().IsMinimalChild(meshDest.mShortAddress))
     {
         aFrame += meshHeader.GetHeaderLength();
         aFrameLength -= meshHeader.GetHeaderLength();

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3183,6 +3183,23 @@ Child *MleRouter::GetChildren(uint8_t *aNumChildren)
     return mChildren;
 }
 
+bool MleRouter::IsMinimalChild(uint16_t aRloc16)
+{
+    ThreadNetif &netif = GetNetif();
+    bool rval = false;
+
+    if (GetRouterId(aRloc16) == GetRouterId(netif.GetMac().GetShortAddress()))
+    {
+        Neighbor *neighbor;
+
+        neighbor = netif.GetMle().GetNeighbor(aRloc16);
+
+        rval = (neighbor != NULL) && (!neighbor->IsFullThreadDevice());
+    }
+
+    return rval;
+}
+
 otError MleRouter::SetMaxAllowedChildren(uint8_t aMaxChildren)
 {
     otError error = OT_ERROR_NONE;

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -533,6 +533,17 @@ public:
     otError GetChildInfoByIndex(uint8_t aChildIndex, otChildInfo &aChildInfo);
 
     /**
+     * This method indicates whether or not the RLOC16 is an MTD child of this device.
+     *
+     * @param[in]  aRloc16  The RLOC16.
+     *
+     * @retval TRUE if @p aRloc16 is an MTD child of this device.
+     * @retval FALSE if @p aRloc16 is not an MTD child of this device.
+     *
+     */
+    bool IsMinimalChild(uint16_t aRloc16);
+
+    /**
      * This method gets the next neighbor information. It is used to iterate through the entries of
      * the neighbor table.
      *

--- a/src/core/thread/mle_router_mtd.hpp
+++ b/src/core/thread/mle_router_mtd.hpp
@@ -93,6 +93,8 @@ public:
         return NULL;
     }
 
+    bool IsMinimalChild(uint16_t) { return false; }
+
     void RestoreChildren(void) { }
     otError RemoveStoredChild(uint16_t) {return OT_ERROR_NOT_IMPLEMENTED; }
     otError StoreChild(uint16_t) {return OT_ERROR_NOT_IMPLEMENTED; }


### PR DESCRIPTION
Thread 1.1.1 Section 5.10.1.3 states:
```
MEDs do not receive or process mesh headers and do not have a link-layer routing table.
```

This PR helps ensure that mesh headers are never sent to MTD children.