### PR TITLE
[mle] request network data on child reattach after reboot

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1807,14 +1807,18 @@ otError Mle::SendChildUpdateRequest(void)
     switch (mRole)
     {
     case OT_DEVICE_ROLE_DETACHED:
+    {
+        static const uint8_t tlvs[] = {Tlv::kNetworkData};
+
         for (uint8_t i = 0; i < sizeof(mParentRequest.mChallenge); i++)
         {
             mParentRequest.mChallenge[i] = static_cast<uint8_t>(otPlatRandomGet());
         }
 
-        SuccessOrExit(error = AppendChallenge(*message, mParentRequest.mChallenge,
-                                              sizeof(mParentRequest.mChallenge)));
+        SuccessOrExit(error = AppendChallenge(*message, mParentRequest.mChallenge, sizeof(mParentRequest.mChallenge)));
+        SuccessOrExit(error = AppendTlvRequest(*message, tlvs, sizeof(tlvs)));
         break;
+    }
 
     case OT_DEVICE_ROLE_CHILD:
         SuccessOrExit(error = AppendSourceAddress(*message));


### PR DESCRIPTION
This commit adds a Network Data TLV request to the MLE Child Update Request
message when trying to resynchronize with a parent after reset.  This
eliminates the need for an MLE Data Request/Response exchange following the
MLE Child Update Request/Response exchange.