### PR TITLE
[coap] have AbortTransaction() call the associated response handler

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -369,15 +369,17 @@ otError CoapBase::AbortTransaction(otCoapResponseHandler aHandler, void *aContex
 {
     otError error = OT_ERROR_NOT_FOUND;
     Message *message;
+    Message *nextMessage;
     CoapMetadata coapMetadata;
 
-    for (message = mPendingRequests.GetHead(); message != NULL; message = message->GetNext())
+    for (message = mPendingRequests.GetHead(); message != NULL; message = nextMessage)
     {
+        nextMessage = message->GetNext();
         coapMetadata.ReadFrom(*message);
 
         if (coapMetadata.mResponseHandler == aHandler && coapMetadata.mResponseContext == aContext)
         {
-            DequeueMessage(*message);
+            FinalizeCoapTransaction(*message, coapMetadata, NULL, NULL, NULL, OT_ERROR_ABORT);
             error = OT_ERROR_NONE;
         }
     }

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -610,6 +610,8 @@ public:
     /**
      * This method aborts CoAP transactions associated with given handler and context.
      *
+     * The associated response handler will be called with OT_ERROR_ABORT.
+     *
      * @param[in]  aHandler  A function pointer that should be called when the transaction ends.
      * @param[in]  aContext  A pointer to arbitrary context information.
      *


### PR DESCRIPTION
Calling the associated response handler simplifies the client's handling of
CoAP transactions.

This commit also fixes a bug in aborting multiple pending transactions.