### PR TITLE
[mle] fix partition merging with REEDs

### DIFF
--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -813,6 +813,8 @@ private:
 
     static uint8_t LinkQualityToCost(uint8_t aLinkQuality);
 
+    static bool IsSingleton(const RouteTlv &aRouteTlv);
+
     Child *NewChild(void);
     Child *FindChild(uint16_t aChildId);
     Child *FindChild(const Mac::ExtAddress &aMacAddr);


### PR DESCRIPTION
REEDs periodically transmit MLE Advertisement messages to support merging
partitions.  However, REEDs do not include Route64 TLVs in their MLE
Advertisement messages.

This commit removes the strict requirement check when handling MLE
Advertisement messages, allowing such messages sent by REEDs to trigger
the partition merging process.