### PR TITLE
[mle] remove existing MLE Data Response in queues when there is newer Network Data

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -366,6 +366,7 @@ bool Message::IsSubTypeMle(void) const
         mBuffer.mHead.mInfo.mSubType == kSubTypeMleDiscoverRequest ||
         mBuffer.mHead.mInfo.mSubType == kSubTypeMleDiscoverResponse ||
         mBuffer.mHead.mInfo.mSubType == kSubTypeMleChildUpdateRequest ||
+        mBuffer.mHead.mInfo.mSubType == kSubTypeMleDataResponse ||
         mBuffer.mHead.mInfo.mSubType == kSubTypeMleGeneral)
     {
         rval = true;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -218,6 +218,7 @@ public:
         kSubTypeMleGeneral             = 6,  ///< General MLE
         kSubTypeJoinerFinalizeResponse = 7,  ///< Joiner Finalize Response
         kSubTypeMleChildUpdateRequest  = 8,  ///< MLE Child Update Request
+        kSubTypeMleDataResponse        = 9,  ///< MLE Data Response
     };
 
     enum

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -175,6 +175,12 @@ public:
     void RemoveMessages(Child &aChild, uint8_t aSubType);
 
     /**
+     * This method frees unicast/multicast MLE Data Responses from Send Message Queue if any.
+     *
+     */
+    void RemoveDataResponseMessages(void);
+
+    /**
      * This method evicts the first indirect message in the indirect send queue.
      *
      * @retval OT_ERROR_NONE       Successfully evicted an indirect message.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1565,6 +1565,29 @@ void Mle::HandleDelayedResponseTimer(void)
     }
 }
 
+void Mle::RemoveDelayedDataResponseMessage(void)
+{
+    Message *message = mDelayedResponses.GetHead();
+    DelayedResponseHeader delayedResponse;
+
+    while (message != NULL)
+    {
+        delayedResponse.ReadFrom(*message);
+
+        if (message->GetSubType() == Message::kSubTypeMleDataResponse)
+        {
+            mDelayedResponses.Dequeue(*message);
+            message->Free();
+            LogMleMessage("Remove Delayed Data Response", delayedResponse.GetDestination());
+
+            // no more than one multicast MLE Data Response in Delayed Message Queue.
+            break;
+        }
+
+        message = message->GetNext();
+    }
+}
+
 otError Mle::SendParentRequest(void)
 {
     otError error = OT_ERROR_NONE;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -937,6 +937,12 @@ public:
      */
     const MessageQueue &GetMessageQueue(void) const { return mDelayedResponses; }
 
+    /**
+     * This method frees multicast MLE Data Response from Delayed Message Queue if any.
+     *
+     */
+    void RemoveDelayedDataResponseMessage(void);
+
 protected:
     enum
     {


### PR DESCRIPTION
This commit helps to reduce additional message exchanges when multiple network data updates in short time.