### PR TITLE
[diags] fix parsing command line and enhancements

### DIFF
--- a/include/openthread/diag.h
+++ b/include/openthread/diag.h
@@ -62,23 +62,23 @@ void otDiagInit(otInstance *aInstance);
 /**
  * This function processes a factory diagnostics command line.
  *
- * @param[in]  aArgc  The argument counter of diagnostics command line.
- * @param[in]  aArgv  The argument vector of diagnostics command line.
+ * @param[in]  aArgCount   The argument counter of diagnostics command line.
+ * @param[in]  aArgVector  The argument vector of diagnostics command line.
  *
  * @returns A pointer to the output string.
  *
  */
-char *otDiagProcessCmd(int aArgc, char *aArgv[]);
+const char *otDiagProcessCmd(int aArgCount, char *aArgVector[]);
 
 /**
  * This function processes a factory diagnostics command line.
  *
- * @param[in]  aString  A NULL-terminated string.
+ * @param[in]  aString  A NULL-terminated input string.
  *
  * @returns A pointer to the output string.
  *
  */
-char *otDiagProcessCmdLine(char *aString);
+const char *otDiagProcessCmdLine(const char *aString);
 
 /**
  * This function indicates whether or not the factory diagnostics mode is enabled.

--- a/src/diag/diag_process.hpp
+++ b/src/diag/diag_process.hpp
@@ -47,46 +47,50 @@ namespace ot {
 
 namespace Diagnostics {
 
-#define MAX_DIAG_OUTPUT 256
-
-struct Command
-{
-    const char *mName;                         ///< A pointer to the command string.
-    void (*mCommand)(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);  ///< A function pointer to process the command.
-};
-
-struct DiagStats
-{
-    uint32_t received_packets;
-    uint32_t sent_packets;
-    int8_t first_rssi;
-    uint8_t first_lqi;
-};
-
 class Diag
 {
 public:
     static void Init(otInstance *aInstance);
-    static char *ProcessCmd(int argc, char *argv[]);
-    static bool isEnabled(void);
+    static const char *ProcessCmd(int aArgCount, char *aArgVector[]);
+    static bool IsEnabled(void);
 
     static void DiagTransmitDone(otInstance *aInstance, otError aError);
     static void DiagReceiveDone(otInstance *aInstance, otRadioFrame *aFrame, otError aError);
     static void AlarmFired(otInstance *aInstance);
 
 private:
-    static void AppendErrorResult(otError error, char *aOutput, size_t aOutputMaxLen);
-    static void ProcessStart(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
-    static void ProcessStop(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
-    static void ProcessSend(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
-    static void ProcessRepeat(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
-    static void ProcessStats(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
-    static void ProcessChannel(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
-    static void ProcessPower(int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
+
+    enum
+    {
+        kMaxOutputSize = 256,
+    };
+
+    struct DiagStats
+    {
+        uint32_t mReceivedPackets;
+        uint32_t mSentPackets;
+        int8_t   mFirstRssi;
+        uint8_t  mFirstLqi;
+    };
+
+    struct Command
+    {
+        const char *mName;
+        void (*mHandler)(int aArgCount, char *aArgVector[]);
+    };
+
+    static void AppendErrorResult(otError aError);
+    static void ProcessStart(int aArgCount, char *aArgVector[]);
+    static void ProcessStop(int aArgCount, char *aArgVector[]);
+    static void ProcessSend(int aArgCount, char *aArgVector[]);
+    static void ProcessRepeat(int aArgCount, char *aArgVector[]);
+    static void ProcessStats(int aArgCount, char *aArgVector[]);
+    static void ProcessChannel(int aArgCount, char *aArgVector[]);
+    static void ProcessPower(int aArgCount, char *aArgVector[]);
     static void TxPacket(void);
     static otError ParseLong(char *aString, long &aLong);
 
-    static char sDiagOutput[];
+    static char sOutput[];
     static const struct Command sCommands[];
     static struct DiagStats sStats;
     static int8_t sTxPower;
@@ -95,7 +99,7 @@ private:
     static uint32_t sTxPeriod;
     static uint32_t sTxPackets;
     static otRadioFrame *sTxPacket;
-    static otInstance *sContext;
+    static otInstance *sInstance;
     static bool sRepeatActive;
 };
 

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -2145,15 +2145,14 @@ exit:
 otError NcpBase::SetPropertyHandler_NEST_STREAM_MFG(uint8_t aHeader)
 {
     const char *string = NULL;
-    char *output = NULL;
+    const char *output = NULL;
     otError error = OT_ERROR_NONE;
 
     error = mDecoder.ReadUtf8(string);
 
     VerifyOrExit(error == OT_ERROR_NONE, error = WriteLastStatusFrame(aHeader, ThreadErrorToSpinelStatus(error)));
 
-    // All diagnostics related features are processed within diagnostics module
-    output = otDiagProcessCmdLine(const_cast<char *>(string));
+    output = otDiagProcessCmdLine(string);
 
     // Prepare the response
     SuccessOrExit(error = mEncoder.BeginFrame(aHeader, SPINEL_CMD_PROP_VALUE_IS, SPINEL_PROP_NEST_STREAM_MFG));


### PR DESCRIPTION
This commit contains fixes and enchantments for diagnostics module
in OpenThread. In particular, the following changes are made to the
implementation of `otDiagProcessCmdLine()`:

- Fixes an issue with the parsing of command line input (where if
  more than 8 arguments were given, it could cause an out-of bound
  array access and a possible NCP crash). The new code will check for
  this and outputs an error if too many arguments are provided.
- Parsing logic is simplified and now allows for extra spaces between
  arguments.
- A local buffer is used to store the arguments to avoid modifying
  the passed-in input string.

This commit also simplifies and does a code clean-up of `Diag`
class (variable name changes, removing extra method paramters, and
minor style changes).

The `test_diag` unit test implementation is also updated:

- It includes new test commands.
- The test prints/logs the issued input commands and their
  corresponding output (as human-readable printable strings).