### PR TITLE
[mle] abort Address Solicit on partition change

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -842,6 +842,7 @@ void Mle::SetLeaderData(uint32_t aPartitionId, uint8_t aWeighting, uint8_t aLead
 {
     if (mLeaderData.GetPartitionId() != aPartitionId)
     {
+        GetNetif().GetMle().HandlePartitionChange();
         mLastPartitionId = mLeaderData.GetPartitionId();
         mLastPartitionRouterIdSequence = GetNetif().GetMle().GetRouterIdSequence();
         mLastPartitionIdTimeout = GetNetif().GetMle().GetNetworkIdTimeout();

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -90,6 +90,14 @@ MleRouter::MleRouter(Instance &aInstance):
     SetRouterId(kInvalidRouterId);
 }
 
+void MleRouter::HandlePartitionChange(void)
+{
+    ThreadNetif &netif = GetNetif();
+
+    netif.GetAddressResolver().Clear();
+    netif.GetCoap().AbortTransaction(&MleRouter::HandleAddressSolicitResponse, this);
+}
+
 bool MleRouter::IsRouterRoleEnabled(void) const
 {
     return mRouterRoleEnabled && (mDeviceMode & ModeTlv::kModeFFD);
@@ -324,6 +332,7 @@ void MleRouter::StopLeader(void)
     mAdvertiseTimer.Stop();
     netif.GetNetworkDataLeader().Stop();
     netif.UnsubscribeAllRoutersMulticast();
+    HandlePartitionChange();
 }
 
 otError MleRouter::HandleDetachStart(void)

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -815,6 +815,8 @@ private:
 
     static bool IsSingleton(const RouteTlv &aRouteTlv);
 
+    void HandlePartitionChange(void);
+
     Child *NewChild(void);
     Child *FindChild(uint16_t aChildId);
     Child *FindChild(const Mac::ExtAddress &aMacAddr);

--- a/src/core/thread/mle_router_mtd.hpp
+++ b/src/core/thread/mle_router_mtd.hpp
@@ -151,6 +151,7 @@ private:
     otError HandleDataRequest(const Message &, const Ip6::MessageInfo &) { return OT_ERROR_DROP; }
     otError HandleNetworkDataUpdateRouter(void) { return OT_ERROR_NONE; }
     otError HandleDiscoveryRequest(const Message &, const Ip6::MessageInfo &) { return OT_ERROR_DROP; }
+    void HandlePartitionChange(void) { }
 
     void StopAdvertiseTimer(void) { }
     otError ProcessRouteTlv(const RouteTlv &aRoute) { OT_UNUSED_VARIABLE(aRoute); return OT_ERROR_NONE; }


### PR DESCRIPTION
This commit aborts the Address Solicit transaction on a partition change.
Doing so avoids having Address Solicit messages being sent to the wrong
Leader address and delays caused by waiting for the previous Address Solicit
transaction to time out.