### PR TITLE
[child] update how IPv6 addresses of a child are managed

### DIFF
--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -366,6 +366,26 @@ OTAPI otError OTCALL otThreadGetChildInfoById(otInstance *aInstance, uint16_t aC
 OTAPI otError OTCALL otThreadGetChildInfoByIndex(otInstance *aInstance, uint8_t aChildIndex, otChildInfo *aChildInfo);
 
 /**
+ * This function gets the next IPv6 address (using an iterator) for a given child.
+ *
+ * @param[in]     aInstance    A pointer to an OpenThread instance.
+ * @param[in]     aChildIndex  The child index.
+ * @param[inout]  aIterator    A pointer to the iterator. On success the iterator will be updated to point to next
+ *                             entry in the list. To get the first IPv6 address the iterator should be set to
+ *                             OT_CHILD_IP6_ADDRESS_ITERATOR_INIT.
+ * @param[out]    aAddress     A pointer to an IPv6 address where the child's next address is placed (on success).
+ *
+ * @retval OT_ERROR_NONE          Successfully found the next IPv6 address (@p aAddress was successfully updated).
+ * @retval OT_ERROR_NOT_FOUND     The child has no subsequent IPv6 address entry.
+ * @retval OT_ERROR_INVALID_ARGS  @p aIterator or @p aAddress are NULL, or child at @p aChildIndex is not valid.
+ *
+ * @sa otThreadGetChildInfoByIndex
+ *
+ */
+otError otThreadGetChildNextIp6Address(otInstance *aInstance, uint8_t aChildIndex, otChildIp6AddressIterator *aIterator,
+                                       otIp6Address *aAddress);
+
+/**
  * Get the current Router ID Sequence.
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.

--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -937,9 +937,11 @@ typedef struct
     bool           mFullFunction : 1;      ///< Full Function Device
     bool           mFullNetworkData : 1;   ///< Full Network Data
     bool           mIsStateRestoring : 1;  ///< Is in restoring state
-    uint8_t        mIp6AddressesLength;    ///< Number of entries in IPv6 address array.
-    const otIp6Address *mIp6Addresses;     ///< Array of IPv6 addresses (unused entries contain unspecified address).
 } otChildInfo;
+
+#define OT_CHILD_IP6_ADDRESS_ITERATOR_INIT  0   ///< Initializer for otChildIP6AddressIterator
+
+typedef uint16_t otChildIp6AddressIterator;     ///< Used to iterate through IPv6 addresses of a Thread Child entry.
 
 /**
  * This structure holds diagnostic information for a Thread Router

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -41,6 +41,7 @@
 
 #include "common/instance.hpp"
 #include "thread/mle_constants.hpp"
+#include "thread/topology.hpp"
 
 using namespace ot;
 
@@ -253,6 +254,27 @@ otError otThreadGetChildInfoByIndex(otInstance *aInstance, uint8_t aChildIndex, 
     VerifyOrExit(aChildInfo != NULL, error = OT_ERROR_INVALID_ARGS);
 
     error = instance.GetThreadNetif().GetMle().GetChildInfoByIndex(aChildIndex, *aChildInfo);
+
+exit:
+    return error;
+}
+
+otError otThreadGetChildNextIp6Address(otInstance *aInstance, uint8_t aChildIndex, otChildIp6AddressIterator *aIterator,
+                                       otIp6Address *aAddress)
+{
+    otError error = OT_ERROR_NONE;
+    Instance &instance = *static_cast<Instance *>(aInstance);
+    Child::Ip6AddressIterator iterator;
+    Ip6::Address *address;
+
+    VerifyOrExit(aIterator != NULL && aAddress != NULL, error = OT_ERROR_INVALID_ARGS);
+
+    address = static_cast<Ip6::Address *>(aAddress);
+    iterator.Set(*aIterator);
+
+    SuccessOrExit(error = instance.GetThreadNetif().GetMle().GetChildNextIp6Address(aChildIndex, iterator, *address));
+
+    *aIterator = iterator.Get();
 
 exit:
     return error;

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -47,6 +47,11 @@ using ot::Encoding::BigEndian::HostSwap32;
 namespace ot {
 namespace Ip6 {
 
+void Address::Clear(void)
+{
+    memset(mFields.m8, 0, sizeof(mFields));
+}
+
 bool Address::IsUnspecified(void) const
 {
     return (mFields.m32[0] == 0 && mFields.m32[1] == 0 && mFields.m32[2] == 0 && mFields.m32[3] == 0);

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -97,6 +97,12 @@ public:
     };
 
     /**
+     * This method clears the IPv6 address by setting it to the Unspecified Address "::".
+     *
+     */
+    void Clear(void);
+
+    /**
      * This method indicates whether or not the IPv6 address is the Unspecified Address.
      *
      * @retval TRUE   If the IPv6 address is the Unspecified Address.

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -581,22 +581,23 @@ void AddressResolver::HandleAddressError(Coap::Header &aHeader, Message &aMessag
 
     for (int i = 0; i < numChildren; i++)
     {
-        if (children[i].GetState() != Neighbor::kStateValid || children[i].IsFullThreadDevice())
+        Child &child = children[i];
+
+        if (child.GetState() != Neighbor::kStateValid || child.IsFullThreadDevice())
         {
             continue;
         }
 
-        for (uint8_t j = 0; j < Child::kMaxIp6AddressPerChild; j++)
+        if (child.GetExtAddress() != macAddr)
         {
-            if (children[i].GetIp6Address(j) == targetTlv.GetTarget() &&
-                children[i].GetExtAddress() != macAddr)
-            {
-                // Target EID matches child address and Mesh Local EID differs on child
-                memset(&children[i].GetIp6Address(j), 0, sizeof(children[i].GetIp6Address(j)));
+            // Mesh Local EID differs, so check whether Target EID
+            // matches a child address and if so remove it.
 
+            if (child.RemoveIp6Address(targetTlv.GetTarget()) == OT_ERROR_NONE)
+            {
                 memset(&destination, 0, sizeof(destination));
                 destination.mFields.m16[0] = HostSwap16(0xfe80);
-                destination.SetIid(children[i].GetExtAddress());
+                destination.SetIid(child.GetExtAddress());
 
                 SendAddressError(targetTlv, mlIidTlv, &destination);
                 ExitNow();
@@ -659,22 +660,19 @@ void AddressResolver::HandleAddressQuery(Coap::Header &aHeader, Message &aMessag
 
     for (int i = 0; i < numChildren; i++)
     {
-        if (children[i].GetState() != Neighbor::kStateValid ||
-            children[i].IsFullThreadDevice() ||
-            children[i].GetLinkFailures() >= Mle::kFailedChildTransmissions)
+        Child &child = children[i];
+
+        if (child.GetState() != Neighbor::kStateValid ||
+            child.IsFullThreadDevice() ||
+            child.GetLinkFailures() >= Mle::kFailedChildTransmissions)
         {
             continue;
         }
 
-        for (uint8_t j = 0; j < Child::kMaxIp6AddressPerChild; j++)
+        if (child.HasIp6Address(targetTlv.GetTarget()))
         {
-            if (children[i].GetIp6Address(j) != targetTlv.GetTarget())
-            {
-                continue;
-            }
-
-            mlIidTlv.SetIid(children[i].GetExtAddress());
-            lastTransactionTimeTlv.SetTime(TimerMilli::GetNow() - children[i].GetLastHeard());
+            mlIidTlv.SetIid(child.GetExtAddress());
+            lastTransactionTimeTlv.SetTime(TimerMilli::GetNow() - child.GetLastHeard());
             SendAddressQueryResponse(targetTlv, mlIidTlv, &lastTransactionTimeTlv, aMessageInfo.GetPeerAddr());
             ExitNow();
         }

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -533,6 +533,21 @@ public:
     otError GetChildInfoByIndex(uint8_t aChildIndex, otChildInfo &aChildInfo);
 
     /**
+     * This methods gets the next IPv6 address (using an iterator) for a given child.
+     *
+     * @param[in]     aChildIndex  The child index.
+     * @param[inout]  aIterator    A reference to iterator. On success the iterator will be updated to point to next
+     *                             entry in the list.
+     * @param[out]    aAddress     A reference to an IPv6 address where the child's next address is placed (on success).
+     *
+     * @retval OT_ERROR_NONE          Successfully found the next address (@p aAddress and @ aIterator are updated).
+     * @retval OT_ERROR_NOT_FOUND     The child has no subsequent IPv6 address entry.
+     * @retval OT_ERROR_INVALID_ARGS  Child at @p aChildIndex is not valid.
+     *
+     */
+    otError GetChildNextIp6Address(uint8_t aChildIndex, Child::Ip6AddressIterator &aIterator, Ip6::Address &aAddress);
+
+    /**
      * This method indicates whether or not the RLOC16 is an MTD child of this device.
      *
      * @param[in]  aRloc16  The RLOC16.

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -215,7 +215,8 @@ otError NcpBase::GetPropertyHandler_THREAD_CHILD_TABLE_ADDRESSES(void)
     otError error = OT_ERROR_NONE;
     otChildInfo childInfo;
     uint8_t maxChildren;
-    const otIp6Address *ip6Address;
+    otIp6Address ip6Address;
+    otChildIp6AddressIterator iterator = OT_CHILD_IP6_ADDRESS_ITERATOR_INIT;
 
     maxChildren = otThreadGetMaxAllowedChildren(mInstance);
 
@@ -232,14 +233,11 @@ otError NcpBase::GetPropertyHandler_THREAD_CHILD_TABLE_ADDRESSES(void)
         SuccessOrExit(error = mEncoder.WriteEui64(childInfo.mExtAddress));
         SuccessOrExit(error = mEncoder.WriteUint16(childInfo.mRloc16));
 
-        ip6Address = childInfo.mIp6Addresses;
+        iterator = OT_CHILD_IP6_ADDRESS_ITERATOR_INIT;
 
-        for (uint8_t num = childInfo.mIp6AddressesLength; num > 0; num--, ip6Address++)
+        while (otThreadGetChildNextIp6Address(mInstance, childIndex, &iterator, &ip6Address) == OT_ERROR_NONE)
         {
-            if (!otIp6IsAddressUnspecified(ip6Address))
-            {
-                SuccessOrExit(error = mEncoder.WriteIp6Address(*ip6Address));
-            }
+            SuccessOrExit(error = mEncoder.WriteIp6Address(ip6Address));
         }
 
         SuccessOrExit(error = mEncoder.CloseStruct());

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -83,6 +83,7 @@ endif # OPENTHREAD_ENABLE_BUILTIN_MBEDTLS
 
 check_PROGRAMS                                                      = \
     test-aes                                                          \
+    test-child                                                        \
     test-fuzz                                                         \
     test-heap                                                         \
     test-hmac-sha256                                                  \
@@ -142,6 +143,9 @@ TESTS_ENVIRONMENT                                                   = \
 
 test_aes_LDADD               = $(COMMON_LDADD)
 test_aes_SOURCES             = test_platform.cpp test_aes.cpp
+
+test_child_LDADD             = $(COMMON_LDADD)
+test_child_SOURCES           = test_platform.cpp test_child.cpp
 
 test_fuzz_LDADD              = $(COMMON_LDADD)
 test_fuzz_SOURCES            = test_platform.cpp test_fuzz.cpp

--- a/tests/unit/test_child.cpp
+++ b/tests/unit/test_child.cpp
@@ -1,0 +1,237 @@
+/*
+ *  Copyright (c) 2018, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test_platform.h"
+
+#include <openthread/config.h>
+#include <openthread/openthread.h>
+
+#include "common/instance.hpp"
+#include "test_util.h"
+#include "thread/topology.hpp"
+
+namespace ot {
+
+static ot::Instance *sInstance;
+
+enum
+{
+    kMaxChildIp6Addresses = OPENTHREAD_CONFIG_IP_ADDRS_PER_CHILD
+};
+
+void VerifyChildIp6Addresses(const Child &aChild, uint8_t aAddressListLength, const Ip6::Address aAddressList[])
+{
+    Child::Ip6AddressIterator iterator;
+    Ip6::Address address;
+    bool addressObserved[kMaxChildIp6Addresses];
+
+    for (uint8_t index = 0; index < aAddressListLength; index++)
+    {
+        VerifyOrQuit(aChild.HasIp6Address(aAddressList[index]), "HasIp6Address() failed\n");
+    }
+
+    memset(addressObserved, 0, sizeof(addressObserved));
+
+    while (aChild.GetNextIp6Address(iterator, address) == OT_ERROR_NONE)
+    {
+        bool addressIsInList = false;
+
+        for (uint8_t index = 0; index < aAddressListLength; index++)
+        {
+            if (address == aAddressList[index])
+            {
+                addressIsInList = true;
+                addressObserved[index] = true;
+                break;
+            }
+        }
+
+        VerifyOrQuit(addressIsInList, "Child::GetNextIp6Address() returned an address not in the expected list\n");
+    }
+
+    for (uint8_t index = 0; index < aAddressListLength; index++)
+    {
+        VerifyOrQuit(addressObserved[index], "Child::GetNextIp6Address() missed an entry from the expected list\n");
+    }
+}
+
+void TestChildIp6Address(void)
+{
+    Child child;
+    Ip6::Address addresses[kMaxChildIp6Addresses];
+    const char *ip6Addresses[] =
+    {
+        "fe80::1234",
+        "fd6b:e251:52fb:0:12e6:b94c:1c28:c56a",
+        "fd00:1234::204c:3d7c:98f6:9a1b",
+        "fd00:cafe::204c:3d7c:98f6:9a1b",
+    };
+
+    uint8_t numAddresses = static_cast<uint8_t>(sizeof(ip6Addresses) / sizeof(ip6Addresses[0]));
+
+    sInstance = testInitInstance();
+    VerifyOrQuit(sInstance != NULL, "Null instance");
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    printf("\nConverting IPv6 addresses from string");
+
+    for (uint8_t index = 0; index < numAddresses; index++)
+    {
+        VerifyOrQuit(index < kMaxChildIp6Addresses, "Too many IPv6 addresses in the unit test");
+        SuccessOrQuit(addresses[index].FromString(ip6Addresses[index]),
+                      "could not convert IPv6 address from string");
+    }
+
+    printf(" -- PASS\n");
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    printf("Child state after init");
+    memset(&child, 0, sizeof(child));
+    VerifyChildIp6Addresses(child, 0, NULL);
+    printf(" -- PASS\n");
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    printf("Adding a single IPv6 address");
+
+    for (uint8_t index = 0; index < numAddresses; index++)
+    {
+        SuccessOrQuit(child.AddIp6Address(addresses[index]), "AddIp6Address() failed");
+        VerifyChildIp6Addresses(child, 1, &addresses[index]);
+
+        child.ClearIp6Addresses();
+        VerifyChildIp6Addresses(child, 0, NULL);
+    }
+
+    printf(" -- PASS\n");
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    printf("Adding multiple IPv6 addresses");
+
+    for (uint8_t index = 0; index < numAddresses; index++)
+    {
+        SuccessOrQuit(child.AddIp6Address(addresses[index]), "AddIp6Address() failed");
+        VerifyChildIp6Addresses(child, index + 1, addresses);
+    }
+
+    printf(" -- PASS\n");
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    printf("Checking for failure when adding an address already in list");
+
+    for (uint8_t index = 0; index < numAddresses; index++)
+    {
+        VerifyOrQuit(child.AddIp6Address(addresses[index]) == OT_ERROR_ALREADY,
+                     "AddIp6Address() did not fail when adding same address");
+        VerifyChildIp6Addresses(child, numAddresses, addresses);
+    }
+
+    printf(" -- PASS\n");
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    printf("Removing addresses from list starting from front of the list");
+
+    for (uint8_t index = 0; index < numAddresses; index++)
+    {
+        SuccessOrQuit(child.RemoveIp6Address(addresses[index]), "RemoveIp6Address() failed");
+        VerifyChildIp6Addresses(child, numAddresses - 1 - index, &addresses[index + 1]);
+
+        VerifyOrQuit(child.RemoveIp6Address(addresses[index]) == OT_ERROR_NOT_FOUND,
+                     "RemoveIp6Address() did not fail when removing an address not on the list");
+    }
+
+    VerifyChildIp6Addresses(child, 0, NULL);
+    printf(" -- PASS\n");
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    printf("Removing addresses from list starting from back of the list");
+
+    for (uint8_t index = 0; index < numAddresses; index++)
+    {
+        SuccessOrQuit(child.AddIp6Address(addresses[index]), "AddIp6Address() failed");
+    }
+
+    for (uint8_t index = numAddresses - 1; index > 0; index--)
+    {
+        SuccessOrQuit(child.RemoveIp6Address(addresses[index]), "RemoveIp6Address() failed");
+        VerifyChildIp6Addresses(child, index, &addresses[0]);
+
+        VerifyOrQuit(child.RemoveIp6Address(addresses[index]) == OT_ERROR_NOT_FOUND,
+                     "RemoveIp6Address() did not fail when removing an address not on the list");
+    }
+
+    printf(" -- PASS\n");
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    printf("Removing address entries from middle of the list");
+
+    for (uint8_t indexToRemove = 1; indexToRemove < numAddresses - 1; indexToRemove++)
+    {
+        child.ClearIp6Addresses();
+
+        for (uint8_t index = 0; index < numAddresses; index++)
+        {
+            SuccessOrQuit(child.AddIp6Address(addresses[index]), "AddIp6Address() failed");
+        }
+
+        SuccessOrQuit(child.RemoveIp6Address(addresses[indexToRemove]), "RemoveIp6Address() failed");
+
+        VerifyOrQuit(child.RemoveIp6Address(addresses[indexToRemove]) == OT_ERROR_NOT_FOUND,
+                     "RemoveIp6Address() did not fail when removing an address not on the list");
+
+        {
+            Ip6::Address updatedAddressList[kMaxChildIp6Addresses];
+            uint8_t updatedListIndex = 0;
+
+            for (uint8_t index = 0; index < numAddresses; index++)
+            {
+                if (index != indexToRemove)
+                {
+                    updatedAddressList[updatedListIndex++] = addresses[index];
+                }
+            }
+
+            VerifyChildIp6Addresses(child, updatedListIndex, updatedAddressList);
+        }
+    }
+
+    printf(" -- PASS\n");
+
+    testFreeInstance(sInstance);
+}
+
+}  // namespace ot
+
+#ifdef ENABLE_TEST_MAIN
+int main(void)
+{
+    ot::TestChildIp6Address();
+    printf("\nAll tests passed.\n");
+    return 0;
+}
+#endif


### PR DESCRIPTION
This commit updates/enhances the `Child` class methods related to
managing of the list of IPv6 addresses associated with a child. The
new model provides APIs to add or remove an IPv6 address, check if the
list contains an address, and a method to iterate through all IPv6
addresses of a child. The `mle_router` and `address_resolver` and NCP
implementations are updated to use the new APIs.

This commit also adds a unit test `test_child` to verify  the newly
added methods.