### PR TITLE
[mle] revert request network data on child reattach after reboot (#2466)

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1806,18 +1806,14 @@ otError Mle::SendChildUpdateRequest(void)
     switch (mRole)
     {
     case OT_DEVICE_ROLE_DETACHED:
-    {
-        static const uint8_t tlvs[] = {Tlv::kNetworkData};
-
         for (uint8_t i = 0; i < sizeof(mParentRequest.mChallenge); i++)
         {
             mParentRequest.mChallenge[i] = static_cast<uint8_t>(otPlatRandomGet());
         }
 
-        SuccessOrExit(error = AppendChallenge(*message, mParentRequest.mChallenge, sizeof(mParentRequest.mChallenge)));
-        SuccessOrExit(error = AppendTlvRequest(*message, tlvs, sizeof(tlvs)));
+        SuccessOrExit(error = AppendChallenge(*message, mParentRequest.mChallenge,
+                                              sizeof(mParentRequest.mChallenge)));
         break;
-    }
 
     case OT_DEVICE_ROLE_CHILD:
         SuccessOrExit(error = AppendSourceAddress(*message));


### PR DESCRIPTION
This reverts commit 87d8940abfc379c0748055fc0bf6f4870d5e73ce.

Adding Network Data to the MLE Child Update Response message increases the
message size beyond what can fit in a single IEEE 802.15.4 frame.  The
Thread specification requires all fragmented MLE message to have MAC
security enabled.