### PR TITLE
[mac] add feature to transmit out of band 15.4 frames

### DIFF
--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -151,6 +151,18 @@ OTAPI otError OTCALL otLinkSendDataRequest(otInstance *aInstance);
 OTAPI bool OTCALL otLinkIsInTransmitState(otInstance *aInstance);
 
 /**
+ * This function enqueues an IEEE 802.15.4 out of band Frame for transmission.
+ *
+ * @param[in] aInstance  A pointer to an OpenThread instance.
+ * @parma[in] aOobFrame  A pointer to the frame to transmit.
+ *
+ * @retval OT_ERROR_NONE           Successfully enqueued an IEEE 802.15.4 Data Request message.
+ * @retval OT_ERROR_ALREADY        An IEEE 802.15.4 out of band frame is already enqueued.
+ *
+ */
+OTAPI otError OTCALL otLinkOutOfBandTransmitRequest(otInstance *aInstance, otRadioFrame *aOobFrame);
+
+/**
  * Get the IEEE 802.15.4 channel.
  *
  * @param[in] aInstance A pointer to an OpenThread instance.

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -358,3 +358,10 @@ bool otLinkIsInTransmitState(otInstance *aInstance)
 
     return instance.GetThreadNetif().GetMac().IsInTransmitState();
 }
+
+otError otLinkOutOfBandTransmitRequest(otInstance *aInstance, otRadioFrame *aOobFrame)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.GetThreadNetif().GetMac().SendOutOfBandFrameRequest(aOobFrame);
+}

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -186,7 +186,9 @@ bool Mac::IsEnergyScanInProgress(void)
 
 bool Mac::IsInTransmitState(void)
 {
-    return (mOperation == kOperationTransmitData) || (mOperation == kOperationTransmitBeacon) || (mOperation == kOperationTransmitOutOfBandFrame);
+    return (mOperation == kOperationTransmitData) || 
+           (mOperation == kOperationTransmitBeacon) || 
+           (mOperation == kOperationTransmitOutOfBandFrame);
 }
 
 otError Mac::ConvertBeaconToActiveScanResult(Frame *aBeaconFrame, otActiveScanResult &aResult)
@@ -910,26 +912,32 @@ void Mac::HandleBeginTransmit(Timer &aTimer)
     aTimer.GetOwner<Mac>().HandleBeginTransmit();
 }
 
-void Mac::HandleBeginTransmit(void)
+Frame *Mac::GetOperationFrame(void)
 {
-    Frame *theFrame = NULL;
-    otError error = OT_ERROR_NONE;
-    bool applyTransmitSecurity = true;
+    Frame *frame = NULL;
 
     switch (mOperation)
     {
     case kOperationTransmitOutOfBandFrame:
-        theFrame = mOobFrame;
+        frame = mOobFrame;
         break;
 
     default:
-        theFrame = mTxFrame;
+        frame = mTxFrame;
         break;
     }
 
-    assert(theFrame != NULL);
+    assert(frame != NULL);
 
-    Frame &sendFrame(*theFrame);
+    return frame;
+}
+
+void Mac::HandleBeginTransmit(void)
+{
+    otError error = OT_ERROR_NONE;
+    bool applyTransmitSecurity = true;
+    Frame *opFrame = GetOperationFrame();
+    Frame &sendFrame(*opFrame);
 
 #if OPENTHREAD_CONFIG_DISABLE_CCA_ON_LAST_ATTEMPT
 
@@ -1007,7 +1015,7 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
-        HandleTransmitDone(theFrame, NULL, OT_ERROR_ABORT);
+        HandleTransmitDone(opFrame, NULL, OT_ERROR_ABORT);
     }
 }
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -186,9 +186,8 @@ bool Mac::IsEnergyScanInProgress(void)
 
 bool Mac::IsInTransmitState(void)
 {
-    return (mOperation == kOperationTransmitData) || 
-           (mOperation == kOperationTransmitBeacon) || 
-           (mOperation == kOperationTransmitOutOfBandFrame);
+    return (mOperation == kOperationTransmitData) ||
+           (mOperation == kOperationTransmitBeacon) || (mOperation == kOperationTransmitOutOfBandFrame);
 }
 
 otError Mac::ConvertBeaconToActiveScanResult(Frame *aBeaconFrame, otActiveScanResult &aResult)

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -936,8 +936,7 @@ void Mac::HandleBeginTransmit(void)
 {
     otError error = OT_ERROR_NONE;
     bool applyTransmitSecurity = true;
-    Frame *opFrame = GetOperationFrame();
-    Frame &sendFrame(*opFrame);
+    Frame &sendFrame(*GetOperationFrame());
 
 #if OPENTHREAD_CONFIG_DISABLE_CCA_ON_LAST_ATTEMPT
 
@@ -1015,7 +1014,7 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
-        HandleTransmitDone(opFrame, NULL, OT_ERROR_ABORT);
+        HandleTransmitDone(&sendFrame, NULL, OT_ERROR_ABORT);
     }
 }
 

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -354,7 +354,7 @@ public:
      * @param[in]  aOobFrame  A pointer to the frame.
      *
      * @retval OT_ERROR_NONE     Successfully registered the frame.
-     * @retval OT_ERROR_ALREADY  The frame was already registered.
+     * @retval OT_ERROR_ALREADY  MAC layer is busy sending a previously registered frame.
      *
      */
     otError SendOutOfBandFrameRequest(otRadioFrame *aOobFrame);
@@ -650,6 +650,7 @@ private:
     void SendBeacon(Frame &aFrame);
     void StartBackoff(void);
     otError HandleMacCommand(Frame &aFrame);
+    Frame *GetOperationFrame(void);
 
     static void HandleMacTimer(Timer &aTimer);
     void HandleMacTimer(void);

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -348,6 +348,18 @@ public:
     otError SendFrameRequest(Sender &aSender);
 
     /**
+     * This method registers a Out of Band frame for MAC Transmission.
+     * An Out of Band frame is one that was generated outside of OpenThread.
+     *
+     * @param[in]  aOobFrame  A pointer to the frame.
+     *
+     * @retval OT_ERROR_NONE     Successfully registered the frame.
+     * @retval OT_ERROR_ALREADY  The frame was already registered.
+     *
+     */
+    otError SendOutOfBandFrameRequest(otRadioFrame *aOobFrame);
+
+    /**
      * This method generates a random IEEE 802.15.4 Extended Address.
      *
      * @param[out]  aExtAddress  A pointer to where the generated Extended Address is placed.
@@ -625,6 +637,7 @@ private:
         kOperationTransmitBeacon,
         kOperationTransmitData,
         kOperationWaitingForData,
+        kOperationTransmitOutOfBandFrame,
     };
 
     void GenerateNonce(const ExtAddress &aAddress, uint32_t aFrameCounter, uint8_t aSecurityLevel, uint8_t *aNonce);
@@ -668,6 +681,7 @@ private:
     bool mPendingEnergyScan       : 1;
     bool mPendingTransmitBeacon   : 1;
     bool mPendingTransmitData     : 1;
+    bool mPendingTransmitOobFrame : 1;
     bool mPendingWaitingForData   : 1;
     bool mRxOnWhenIdle            : 1;
     bool mBeaconsEnabled          : 1;
@@ -720,6 +734,7 @@ private:
 #endif  // OPENTHREAD_ENABLE_MAC_FILTER
 
     Frame *mTxFrame;
+    Frame *mOobFrame;
 
     otMacCounters mCounters;
     uint32_t mKeyIdMode2FrameCounter;


### PR DESCRIPTION
These changes allow for 3rd party code to provide a 15.4 frame that OpenThread will transmit in conjunction with its other operations.  The frame will be taken as-is, unmodified and transmitted by OpenThread at the earliest opportunity.  It is currently the job of the 3rd party code to know when the frame transmission has completed.