### PR TITLE
[link-quality] adding SuccessRateTracker and tracking CCA failure rate

### DIFF
--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -597,6 +597,18 @@ bool otLinkIsPromiscuous(otInstance *aInstance);
  */
 otError otLinkSetPromiscuous(otInstance *aInstance, bool aPromiscuous);
 
+
+/**
+ * This function returns the current CCA (Clear Channel Assessment) failure rate.
+ *
+ * The rate is maintained over a window of (roughly) last `OPENTHREAD_CONFIG_CCA_FAILURE_RATE_AVERAGING_WINDOW`
+ * frame transmissions.
+ *
+ * @returns The CCA failure rate with maximum value `0xffff` corresponding to 100% failure rate.
+ *
+ */
+uint16_t otLinkGetCcaFailureRate(otInstance *aInstance);
+
 /**
  * @}
  *

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -365,3 +365,10 @@ otError otLinkOutOfBandTransmitRequest(otInstance *aInstance, otRadioFrame *aOob
 
     return instance.GetThreadNetif().GetMac().SendOutOfBandFrameRequest(aOobFrame);
 }
+
+uint16_t otLinkGetCcaFailureRate(otInstance *aInstance)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.GetThreadNetif().GetMac().GetCcaFailureRate();
+}

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -44,6 +44,7 @@
 #include "mac/mac_frame.hpp"
 #include "mac/mac_filter.hpp"
 #include "thread/key_manager.hpp"
+#include "thread/link_quality.hpp"
 #include "thread/network_diagnostic_tlvs.hpp"
 #include "thread/topology.hpp"
 
@@ -623,10 +624,22 @@ public:
      */
     bool RadioSupportsRetries(void);
 
+    /**
+     * This method returns the current CCA (Clear Channel Assessment) failure rate.
+     *
+     * The rate is maintained over a window of (roughly) last `OPENTHREAD_CONFIG_CCA_FAILURE_RATE_AVERAGING_WINDOW`
+     * frame transmissions.
+     *
+     * @returns The CCA failure rate with maximum value `0xffff` corresponding to 100% failure rate.
+     *
+     */
+    uint16_t GetCcaFailureRate(void) const { return mCcaSuccessRateTracker.GetFailureRate(); }
+
 private:
     enum
     {
-        kInvalidRssiValue = 127
+        kInvalidRssiValue = 127,
+        kMaxCcaSampleCount = OPENTHREAD_CONFIG_CCA_FAILURE_RATE_AVERAGING_WINDOW,
     };
 
     enum Operation
@@ -739,6 +752,9 @@ private:
 
     otMacCounters mCounters;
     uint32_t mKeyIdMode2FrameCounter;
+
+    SuccessRateTracker mCcaSuccessRateTracker;
+    uint16_t mCcaSampleCount;
 };
 
 /**

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -924,6 +924,19 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_CCA_FAILURE_RATE_AVERAGING_WINDOW
+ *
+ * OpenThread's MAC implementation maintains the average failure rate of CCA (Clear Channel Assessment) operation on
+ * frame transmissions. This value specifies the window (in terms of number of transmissions or samples) over which the
+ * average rate is maintained. Practically, the average value can be considered as the percentage of CCA failures in
+ * (approximately) last AVERAGING_WINDOW frame transmissions.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CCA_FAILURE_RATE_AVERAGING_WINDOW
+#define OPENTHREAD_CONFIG_CCA_FAILURE_RATE_AVERAGING_WINDOW     512
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_CHANNEL_MONITOR_SAMPLE_INTERVAL
  *
  * The sample interval in milliseconds used by Channel Monitoring feature.

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -48,6 +48,18 @@ static const char *const kDigitsString[8] =
     "0",     "125", "25",  "375", "5",   "625", "75",  "875"
 };
 
+void SuccessRateTracker::AddSample(bool aSuccess, uint16_t aWeight)
+{
+    uint32_t oldAverage = mSuccessRate;
+    uint32_t newValue = (aSuccess) ? kMaxRateValue : 0;
+    uint32_t n = aWeight;
+
+    // `n/2` is added to the sum to ensure rounding the value to the nearest integer when dividing by `n`
+    // (e.g., 1.2 -> 1, 3.5 -> 4).
+
+    mSuccessRate = static_cast<uint16_t>(((oldAverage * (n - 1)) + newValue + (n / 2)) / n);
+}
+
 void RssAverager::Reset(void)
 {
     mAverage = 0;


### PR DESCRIPTION
This commit adds a new class `SuccessRateTracker` which can be used to
tracker success/failure rate of an operation. It uses an exponentially
moving average IIR filter to maintain the rate using  a `uint16_t` as
its storage. Unit test `test_link_quality` is updated to include a new
test case ``ot::TestSuccessRateTracker()` verifying the behavior of
the new class.

This commit uses the new class to track the CCA failure rate (over all
frame transmissions) at MAC layer.