### PR TITLE
[mle] do not delete the ParentInfo settings

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1661,7 +1661,6 @@ otError Mle::SendChildIdRequest(void)
             // attach to a better partition, invalidating old parent state (especially when in kStateRestored) ensures
             // that GetNeighbor() returns mParentCandidate when processing the Child ID Response.
             mParent.SetState(Neighbor::kStateInvalid);
-            otPlatSettingsDelete(&GetInstance(), Settings::kKeyParentInfo, -1);
         }
     }
 


### PR DESCRIPTION
This is related to this PR https://github.com/openthread/openthread/pull/2492 and the issue notcied during re-attach process.