### PR TITLE
[efr32] Remove UART retargeting

### DIFF
--- a/examples/platforms/efr32/Makefile.am
+++ b/examples/platforms/efr32/Makefile.am
@@ -55,8 +55,6 @@ libopenthread_efr32_a_CPPFLAGS                                                = 
     -I$(EFR32MG_SDK_SRCDIR)/platform/radio/rail_lib/hal/efr32                   \
     -I$(EFR32MG_SDK_SRCDIR)/platform/radio/rail_lib/plugin/pa-conversions       \
     -I$(EFR32MG_SDK_SRCDIR)/hardware/kit/common/bsp                             \
-    -I$(EFR32MG_SDK_SRCDIR)/hardware/kit/common/drivers                         \
-    -I$(EFR32MG_SDK_SRCDIR)/hardware/kit/common/halconfig                       \
     -I$(EFR32MG_SDK_SRCDIR)/hardware/kit/EFR32MG12_BRD4161A/config              \
     -I$(EFR32MG_SDK_SRCDIR)/platform/CMSIS/Include                              \
     -I$(EFR32MG_SDK_SRCDIR)/platform/Device/SiliconLabs/EFR32MG12P/Include      \
@@ -96,7 +94,6 @@ nodist_libopenthread_efr32_a_SOURCES                                            
     @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.0/hardware/kit/common/bsp/bsp_init.c                                     \
     @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.0/hardware/kit/common/bsp/bsp_stk.c                                      \
     @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.0/hardware/kit/common/bsp/bsp_stk_leds.c                                 \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.0/hardware/kit/common/drivers/retargetserial.c                           \
     @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.0/platform/Device/SiliconLabs/EFR32MG12P/Source/system_efr32mg12p.c      \
     @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.0/platform/Device/SiliconLabs/EFR32MG12P/Source/GCC/startup_efr32mg12p.c \
     @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.0/platform/emdrv/dmadrv/src/dmadrv.c                                     \

--- a/examples/platforms/efr32/hal-config.h
+++ b/examples/platforms/efr32/hal-config.h
@@ -221,7 +221,6 @@
 
 // $[SERIAL]
 #define HAL_SERIAL_USART0_ENABLE              (0)
-#define BSP_SERIAL_APP_PORT                   (HAL_SERIAL_PORT_USART0)
 #define HAL_SERIAL_LEUART0_ENABLE             (0)
 #define HAL_SERIAL_USART1_ENABLE              (0)
 #define HAL_SERIAL_USART2_ENABLE              (0)

--- a/examples/platforms/efr32/uart.c
+++ b/examples/platforms/efr32/uart.c
@@ -42,7 +42,7 @@
 #include "em_core.h"
 #include "uartdrv.h"
 
-#include "retargetserialhalconfig.h"
+#include "hal-config.h"
 
 enum
 {
@@ -51,23 +51,23 @@ enum
 
 #define USART_INIT                                                                           \
     {                                                                                        \
-        RETARGET_UART,                                    /* USART port */                   \
+        USART0,                                           /* USART port */                   \
         115200,                                           /* Baud rate */                    \
-        RETARGET_TX_LOCATION,                             /* USART Tx pin location number */ \
-        RETARGET_RX_LOCATION,                             /* USART Rx pin location number */ \
+        BSP_SERIAL_APP_TX_LOC,                            /* USART Tx pin location number */ \
+        BSP_SERIAL_APP_RX_LOC,                            /* USART Rx pin location number */ \
         (USART_Stopbits_TypeDef)USART_FRAME_STOPBITS_ONE, /* Stop bits */                    \
         (USART_Parity_TypeDef)USART_FRAME_PARITY_NONE,    /* Parity */                       \
         (USART_OVS_TypeDef)USART_CTRL_OVS_X16,            /* Oversampling mode*/             \
         false,                                            /* Majority vote disable */        \
         uartdrvFlowControlHwUart,                         /* Flow control */                 \
-        RETARGET_CTSPORT,                                 /* CTS port number */              \
-        RETARGET_CTSPIN,                                  /* CTS pin number */               \
-        RETARGET_RTSPORT,                                 /* RTS port number */              \
-        RETARGET_RTSPIN,                                  /* RTS pin number */               \
+        BSP_SERIAL_APP_CTS_PORT,                          /* CTS port number */              \
+        BSP_SERIAL_APP_CTS_PIN,                           /* CTS pin number */               \
+        BSP_SERIAL_APP_RTS_PORT,                          /* RTS port number */              \
+        BSP_SERIAL_APP_RTS_PIN,                           /* RTS pin number */               \
         (UARTDRV_Buffer_FifoQueue_t *)&sUartRxQueue,      /* RX operation queue */           \
         (UARTDRV_Buffer_FifoQueue_t *)&sUartTxQueue,      /* TX operation queue */           \
-        RETARGET_CTS_LOCATION,                            /* CTS location */                 \
-        RETARGET_RTS_LOCATION                             /* RTS location */                 \
+        BSP_SERIAL_APP_CTS_LOC,                           /* CTS location */                 \
+        BSP_SERIAL_APP_RTS_LOC                            /* RTS location */                 \
     }
 
 DEFINE_BUF_QUEUE(EMDRV_UARTDRV_MAX_CONCURRENT_RX_BUFS, sUartRxQueue);


### PR DESCRIPTION
Remove redundant retargetserial.c as retargeting may
conflict with OT UART. Also retargeting doesn't work
without retargetio.c and just consumes flash and RAM.

Signed-off-by: Oleksandr Grytsov <al1img@gmail.com>