### PR TITLE
[posix] implement virtual time and update tests to utilize virtual time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,16 +42,16 @@ after_success:
 
 matrix:
   include:
-    - env: BUILD_TARGET="posix-distcheck" VERBOSE=1
+    - env: BUILD_TARGET="posix-distcheck" VERBOSE=1 VIRTUAL_TIME=1
       os: linux
       compiler: clang
-    - env: BUILD_TARGET="posix-32-bit" VERBOSE=1
+    - env: BUILD_TARGET="posix-32-bit" VERBOSE=1 VIRTUAL_TIME=1
       os: linux
       compiler: gcc
-    - env: BUILD_TARGET="posix-ncp" VERBOSE=1
+    - env: BUILD_TARGET="posix-ncp" VERBOSE=1 VIRTUAL_TIME=1
       os: linux
       compiler: gcc
-    - env: BUILD_TARGET="posix-mtd" VERBOSE=1
+    - env: BUILD_TARGET="posix-mtd" VERBOSE=1 VIRTUAL_TIME=1
       os: linux
       compiler: gcc
     - env: BUILD_TARGET="pretty-check"

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -346,6 +346,7 @@ set -x
 [ $BUILD_TARGET != posix-distcheck ] || {
     export ASAN_SYMBOLIZER_PATH=`which llvm-symbolizer-3.4` || die
     export ASAN_OPTIONS=symbolize=1 || die
+    export DISTCHECK_CONFIGURE_FLAGS= CPPFLAGS=-DOPENTHREAD_POSIX_VIRTUAL_TIME=1 || die
     ./bootstrap || die
     make -f examples/Makefile-posix distcheck || die
 }

--- a/examples/Makefile-posix
+++ b/examples/Makefile-posix
@@ -83,6 +83,10 @@ COMMONCFLAGS                   := \
 
 include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
+ifeq ($(VIRTUAL_TIME),1)
+COMMONCFLAGS                   += -DOPENTHREAD_POSIX_VIRTUAL_TIME=1
+endif
+
 CPPFLAGS                       += \
     $(COMMONCFLAGS)               \
     $(NULL)

--- a/examples/platforms/posix/Makefile.am
+++ b/examples/platforms/posix/Makefile.am
@@ -46,6 +46,9 @@ libopenthread_posix_a_SOURCES             = \
     random.c                                \
     uart-posix.c                            \
     flash.c                                 \
+    sim/alarm-sim.c                         \
+    sim/platform-sim.c                      \
+    sim/radio-sim.c                         \
     $(NULL)
 
 if OPENTHREAD_ENABLE_DIAG

--- a/examples/platforms/posix/misc.c
+++ b/examples/platforms/posix/misc.c
@@ -34,6 +34,7 @@
 
 #include <openthread/types.h>
 #include <openthread/platform/misc.h>
+#include <openthread/platform/platform.h>
 
 #ifndef _WIN32
 extern int      gArgumentsCount;
@@ -52,7 +53,7 @@ void otPlatReset(otInstance *aInstance)
 
     argv[gArgumentsCount] = NULL;
 
-    platformRadioDeinit();
+    PlatformDeinit();
     platformUartRestore();
 
     alarm(0);

--- a/examples/platforms/posix/platform-posix.h
+++ b/examples/platforms/posix/platform-posix.h
@@ -82,6 +82,22 @@ __forceinline void timersub(struct timeval *a, struct timeval *b, struct timeval
 
 #include "openthread-core-config.h"
 
+enum
+{
+    OT_SIM_EVENT_ALARM_FIRED    = 0,
+    OT_SIM_EVENT_RADIO_RECEIVED = 1,
+    OT_EVENT_DATA_MAX_SIZE      = 1024,
+};
+
+OT_TOOL_PACKED_BEGIN
+struct Event
+{
+    uint64_t mDelay;
+    uint8_t mEvent;
+    uint16_t mDataLength;
+    uint8_t mData[OT_EVENT_DATA_MAX_SIZE];
+} OT_TOOL_PACKED_END;
+
 /**
  * Unique node ID.
  *
@@ -117,16 +133,50 @@ void platformAlarmUpdateTimeout(struct timeval *tv);
 void platformAlarmProcess(otInstance *aInstance);
 
 /**
+ * This function returns the next alarm event time.
+ *
+ * @returns The next alarm fire time.
+ *
+ */
+int32_t platformAlarmGetNext(void);
+
+/**
+ * This function returns the current alarm time.
+ *
+ * @returns The current alarm time.
+ *
+ */
+uint64_t platformAlarmGetNow(void);
+
+/**
+ * This function advances the alarm time by @p aDelta.
+ *
+ * @param[in]  aDelta  The amount of time to advance.
+ *
+ */
+void platformAlarmAdvanceNow(uint64_t aDelta);
+
+/**
  * This function initializes the radio service used by OpenThread.
  *
  */
 void platformRadioInit(void);
 
 /**
- * This function deinitializes the radio service used by OpenThread.
+ * This function shuts down the radio service used by OpenThread.
  *
  */
 void platformRadioDeinit(void);
+
+/**
+ * This function inputs a received radio frame.
+ *
+ * @param[in]  aInstance   A pointer to the OpenThread instance.
+ * @param[in]  aBuf        A pointer to the received radio frame.
+ * @param[in]  aBufLength  The size of the received radio frame.
+ *
+ */
+void platformRadioReceive(otInstance *aInstance, uint8_t *aBuf, uint16_t aBufLength);
 
 /**
  * This function updates the file descriptor sets with file descriptors used by the radio driver.

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -168,7 +168,7 @@ public:
      * @retval TRUE   If the message shall be sent before the given time.
      * @retval FALSE  Otherwise.
      */
-    bool IsEarlier(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mNextTimerShot) > 0); };
+    bool IsEarlier(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mNextTimerShot) >= 0); };
 
     /**
      * This method checks if the message shall be sent after the given time.
@@ -299,7 +299,7 @@ public:
      * @retval FALSE  Otherwise.
      *
      */
-    bool IsEarlier(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mDequeueTime) > 0); }
+    bool IsEarlier(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mDequeueTime) >= 0); }
 
     /**
      * This method returns number of milliseconds in which the message should be sent.

--- a/tests/scripts/thread-cert/Cert_5_1_03_RouterAddressReallocation.py
+++ b/tests/scripts/thread-cert/Cert_5_1_03_RouterAddressReallocation.py
@@ -38,15 +38,16 @@ import node
 LEADER = 1
 ROUTER1 = 2
 ROUTER2 = 3
-SNIFFER = 4
 
 
 class Cert_5_1_03_RouterAddressReallocation(unittest.TestCase):
 
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1, 4):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -68,44 +69,38 @@ class Cert_5_1_03_RouterAddressReallocation(unittest.TestCase):
         self.nodes[ROUTER2].enable_whitelist()
         self.nodes[ROUTER2].set_router_selection_jitter(1)
 
-        self.sniffer = config.create_default_thread_sniffer(SNIFFER)
-        self.sniffer.start()
-
     def tearDown(self):
-        self.sniffer.stop()
-        del self.sniffer
-
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
-        time.sleep(4)
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         rloc16 = self.nodes[ROUTER1].get_addr16()
 
         self.nodes[ROUTER2].set_network_id_timeout(110)
         self.nodes[LEADER].stop()
-        time.sleep(140)
+        self.simulator.go(140)
 
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'leader')
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
         self.assertEqual(self.nodes[ROUTER1].get_addr16(), rloc16)
 
-        leader_messages = self.sniffer.get_messages_sent_by(LEADER)
-        router1_messages = self.sniffer.get_messages_sent_by(ROUTER1)
-        router2_messages = self.sniffer.get_messages_sent_by(ROUTER2)
+        leader_messages = self.simulator.get_messages_sent_by(LEADER)
+        router1_messages = self.simulator.get_messages_sent_by(ROUTER1)
+        router2_messages = self.simulator.get_messages_sent_by(ROUTER2)
 
         # 2 - All
         leader_messages.next_mle_message(mle.CommandType.ADVERTISEMENT)

--- a/tests/scripts/thread-cert/Cert_5_1_05_RouterAddressTimeout.py
+++ b/tests/scripts/thread-cert/Cert_5_1_05_RouterAddressTimeout.py
@@ -37,15 +37,16 @@ import node
 
 LEADER = 1
 ROUTER1 = 2
-SNIFFER = 3
 
 
 class Cert_5_1_05_RouterAddressTimeout(unittest.TestCase):
 
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1, 3):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -56,53 +57,47 @@ class Cert_5_1_05_RouterAddressTimeout(unittest.TestCase):
         self.nodes[ROUTER1].set_mode('rsdn')
         self._setUpRouter1()
 
-        self.sniffer = config.create_default_thread_sniffer(SNIFFER)
-        self.sniffer.start()
-
     def _setUpRouter1(self):
         self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
         self.nodes[ROUTER1].set_router_selection_jitter(1)
 
     def tearDown(self):
-        self.sniffer.stop()
-        del self.sniffer
-
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
-        time.sleep(4)
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         rloc16 = self.nodes[ROUTER1].get_addr16()
 
         self.nodes[ROUTER1].reset()
         self._setUpRouter1()
-        time.sleep(200)
+        self.simulator.go(200)
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
         self.assertNotEqual(self.nodes[ROUTER1].get_addr16(), rloc16)
 
         rloc16 = self.nodes[ROUTER1].get_addr16()
         self.nodes[ROUTER1].reset()
         self._setUpRouter1()
-        time.sleep(300)
+        self.simulator.go(300)
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
         self.assertEqual(self.nodes[ROUTER1].get_addr16(), rloc16)
 
-        leader_messages = self.sniffer.get_messages_sent_by(LEADER)
-        router1_messages = self.sniffer.get_messages_sent_by(ROUTER1)
+        leader_messages = self.simulator.get_messages_sent_by(LEADER)
+        router1_messages = self.simulator.get_messages_sent_by(ROUTER1)
 
         # 2 - All
         leader_messages.next_mle_message(mle.CommandType.ADVERTISEMENT)

--- a/tests/scripts/thread-cert/Cert_5_1_06_RemoveRouterId.py
+++ b/tests/scripts/thread-cert/Cert_5_1_06_RemoveRouterId.py
@@ -37,15 +37,16 @@ import node
 
 LEADER = 1
 ROUTER1 = 2
-SNIFFER = 3
 
 
 class Cert_5_1_06_RemoveRouterId(unittest.TestCase):
 
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1, 3):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -58,25 +59,19 @@ class Cert_5_1_06_RemoveRouterId(unittest.TestCase):
         self.nodes[ROUTER1].enable_whitelist()
         self.nodes[ROUTER1].set_router_selection_jitter(1)
 
-        self.sniffer = config.create_default_thread_sniffer(SNIFFER)
-        self.sniffer.start()
-
     def tearDown(self):
-        self.sniffer.stop()
-        del self.sniffer
-
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
-        time.sleep(4)
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
         rloc16 = self.nodes[ROUTER1].get_addr16()
 
@@ -84,14 +79,14 @@ class Cert_5_1_06_RemoveRouterId(unittest.TestCase):
             self.assertTrue(self.nodes[LEADER].ping(addr))
 
         self.nodes[LEADER].release_router_id(rloc16 >> 10)
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         for addr in self.nodes[ROUTER1].get_addrs():
             self.assertTrue(self.nodes[LEADER].ping(addr))
 
-        leader_messages = self.sniffer.get_messages_sent_by(LEADER)
-        router1_messages = self.sniffer.get_messages_sent_by(ROUTER1)
+        leader_messages = self.simulator.get_messages_sent_by(LEADER)
+        router1_messages = self.simulator.get_messages_sent_by(ROUTER1)
 
         # 1 - All
         leader_messages.next_mle_message(mle.CommandType.ADVERTISEMENT)

--- a/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
+++ b/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -38,9 +39,11 @@ SED1 = 7
 
 class Cert_5_1_07_MaxChildCount(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1, 13):
-            self.nodes[i] = node.Node(i, (i >= 3))
+            self.nodes[i] = node.Node(i, (i >= 3), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -69,20 +72,20 @@ class Cert_5_1_07_MaxChildCount(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
-        time.sleep(4)
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         for i in range(3, 13):
             self.nodes[i].start()
-            time.sleep(7)
+            self.simulator.go(7)
             self.assertEqual(self.nodes[i].get_state(), 'child')
 
         ipaddrs = self.nodes[SED1].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_1_11_REEDAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_5_1_11_REEDAttachLinkQuality.py
@@ -38,15 +38,16 @@ LEADER = 1
 REED = 2
 ROUTER2 = 3
 ROUTER1 = 4
-SNIFFER = 5
 
 
 class Cert_5_1_11_REEDAttachLinkQuality(unittest.TestCase):
 
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1, 5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -75,40 +76,34 @@ class Cert_5_1_11_REEDAttachLinkQuality(unittest.TestCase):
         self.nodes[ROUTER1].enable_whitelist()
         self.nodes[ROUTER1].set_router_selection_jitter(1)
 
-        self.sniffer = config.create_default_thread_sniffer(SNIFFER)
-        self.sniffer.start()
-
     def tearDown(self):
-        self.sniffer.stop()
-        del self.sniffer
-
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
-        time.sleep(4)
 
         self.nodes[REED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[REED].get_state(), 'child')
 
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER1].start()
-        time.sleep(10)
+        self.simulator.go(10)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
         self.assertEqual(self.nodes[REED].get_state(), 'router')
 
-        leader_messages = self.sniffer.get_messages_sent_by(LEADER)
-        reed_messages = self.sniffer.get_messages_sent_by(REED)
-        router1_messages = self.sniffer.get_messages_sent_by(ROUTER1)
-        router2_messages = self.sniffer.get_messages_sent_by(ROUTER2)
+        leader_messages = self.simulator.get_messages_sent_by(LEADER)
+        reed_messages = self.simulator.get_messages_sent_by(REED)
+        router1_messages = self.simulator.get_messages_sent_by(ROUTER1)
+        router2_messages = self.simulator.get_messages_sent_by(ROUTER2)
 
         # 1 - Leader. REED1, Router2
         leader_messages.next_mle_message(mle.CommandType.ADVERTISEMENT)

--- a/tests/scripts/thread-cert/Cert_5_2_03_LeaderReject2Hops.py
+++ b/tests/scripts/thread-cert/Cert_5_2_03_LeaderReject2Hops.py
@@ -39,13 +39,14 @@ DUT_LEADER = 1
 ROUTER_1 = 2
 ROUTER_31 = 32
 ROUTER_32 = 33
-SNIFFER = 34
 
 class Cert_5_2_3_LeaderReject2Hops(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
 
-        self.nodes[DUT_LEADER] = node.Node(DUT_LEADER)
+        self.nodes[DUT_LEADER] = node.Node(DUT_LEADER, simulator=self.simulator)
         self.nodes[DUT_LEADER].set_panid(0xface)
         self.nodes[DUT_LEADER].set_mode('rsdn')
         self.nodes[DUT_LEADER].enable_whitelist()
@@ -53,7 +54,7 @@ class Cert_5_2_3_LeaderReject2Hops(unittest.TestCase):
         self.nodes[DUT_LEADER].set_router_downgrade_threshold(33)
 
         for i in range(2, 33):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
             self.nodes[i].set_panid(0xface)
             self.nodes[i].set_mode('rsdn')
             self.nodes[i].add_whitelist(self.nodes[DUT_LEADER].get_addr64())
@@ -63,7 +64,7 @@ class Cert_5_2_3_LeaderReject2Hops(unittest.TestCase):
             self.nodes[i].set_router_downgrade_threshold(33)
             self.nodes[i].set_router_selection_jitter(1)
 
-        self.nodes[ROUTER_32] = node.Node(ROUTER_32)
+        self.nodes[ROUTER_32] = node.Node(ROUTER_32, simulator=self.simulator)
         self.nodes[ROUTER_32].set_panid(0xface)
         self.nodes[ROUTER_32].set_mode('rsdn')
         self.nodes[ROUTER_32].add_whitelist(self.nodes[ROUTER_1].get_addr64())
@@ -73,38 +74,33 @@ class Cert_5_2_3_LeaderReject2Hops(unittest.TestCase):
         self.nodes[ROUTER_32].set_router_downgrade_threshold(33)
         self.nodes[ROUTER_32].set_router_selection_jitter(1)
 
-        self.sniffer = config.create_default_thread_sniffer(SNIFFER)
-        self.sniffer.start()
-
     def tearDown(self):
-        self.sniffer.stop()
-        del self.sniffer
-
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         # 1
         self.nodes[DUT_LEADER].start()
-        self.nodes[DUT_LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[DUT_LEADER].get_state(), 'leader')
 
         for i in range(2, 32):
             self.nodes[i].start()
-            time.sleep(5)
+            self.simulator.go(5)
             self.assertEqual(self.nodes[i].get_state(), 'router')
 
-        leader_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+        leader_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
 
         # 2
         self.nodes[ROUTER_31].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER_31].get_state(), 'router')
 
         # 3 - DUT_LEADER
         # This method flushes the message queue so calling this method again will return only the newly logged messages.
-        leader_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+        leader_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
         msg = leader_messages.next_coap_message('2.04')
         msg.assertCoapMessageContainsTlv(network_layer.Status)
         msg.assertCoapMessageContainsTlv(network_layer.RouterMask)
@@ -119,10 +115,10 @@ class Cert_5_2_3_LeaderReject2Hops(unittest.TestCase):
 
         # 5 - Router_32
         self.nodes[ROUTER_32].start()
-        time.sleep(5)
+        self.simulator.go(5)
 
         # 6 - DUT_LEADER
-        leader_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+        leader_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
         msg = leader_messages.next_coap_message('2.04')
         msg.assertCoapMessageContainsTlv(network_layer.Status)
 

--- a/tests/scripts/thread-cert/Cert_5_2_07_REEDSynchronization.py
+++ b/tests/scripts/thread-cert/Cert_5_2_07_REEDSynchronization.py
@@ -42,33 +42,30 @@ DUT_REED = 17
 
 class Cert_5_2_7_REEDSynchronization(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1, 18):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
             self.nodes[i].set_panid(0xface)
             self.nodes[i].set_mode('rsdn')
             self.nodes[i].set_router_selection_jitter(1)
 
-        self.sniffer = config.create_default_thread_sniffer()
-        self.sniffer.start()
-
     def tearDown(self):
-        self.sniffer.stop()
-        del self.sniffer
-
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         # 1. Ensure topology is formed correctly without DUT_ROUTER1.
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         for i in range(2, 17):
             self.nodes[i].start()
-        time.sleep(5)
+        self.simulator.go(5)
 
         for i in range(2, 17):
             self.assertEqual(self.nodes[i].get_state(), 'router')
@@ -78,11 +75,11 @@ class Cert_5_2_7_REEDSynchronization(unittest.TestCase):
         self.nodes[DUT_REED].add_whitelist(self.nodes[DUT_ROUTER1].get_addr64(), config.RSSI['LINK_QULITY_1'])
 
         self.nodes[DUT_REED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[DUT_REED].get_state(), 'child')
 
         # The DUT_REED must not send a coap message here.
-        reed_messages = self.sniffer.get_messages_sent_by(DUT_REED)
+        reed_messages = self.simulator.get_messages_sent_by(DUT_REED)
         msg = reed_messages.does_not_contain_coap_message()
         assert msg is True, "Error: The DUT_REED sent an Address Solicit Request"
 
@@ -92,8 +89,8 @@ class Cert_5_2_7_REEDSynchronization(unittest.TestCase):
             command.check_link_request(msg)
 
         # 4. DUT_ROUTER1: Verify sent a Link Accept to DUT_REED.
-        time.sleep(30)
-        dut_messages = self.sniffer.get_messages_sent_by(DUT_ROUTER1)
+        self.simulator.go(30)
+        dut_messages = self.simulator.get_messages_sent_by(DUT_ROUTER1)
         flag_link_accept = False
         while True:
             msg = dut_messages.next_mle_message(mle.CommandType.LINK_ACCEPT, False)

--- a/tests/scripts/thread-cert/Cert_5_3_01_LinkLocal.py
+++ b/tests/scripts/thread-cert/Cert_5_3_01_LinkLocal.py
@@ -39,9 +39,11 @@ DUT_ROUTER1 = 2
 
 class Cert_5_3_1_LinkLocal(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -54,15 +56,16 @@ class Cert_5_3_1_LinkLocal(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         # 1
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[DUT_ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[DUT_ROUTER1].get_state(), 'router')
 
         # 2 & 3

--- a/tests/scripts/thread-cert/Cert_5_3_02_RealmLocal.py
+++ b/tests/scripts/thread-cert/Cert_5_3_02_RealmLocal.py
@@ -41,9 +41,11 @@ SED1 = 4
 
 class Cert_5_3_2_RealmLocal(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i, (i == SED1))
+            self.nodes[i] = node.Node(i, (i == SED1), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -70,33 +72,28 @@ class Cert_5_3_2_RealmLocal(unittest.TestCase):
         self.nodes[SED1].enable_whitelist()
         self.nodes[SED1].set_timeout(3)
 
-        self.sniffer = config.create_default_thread_sniffer()
-        self.sniffer.start()
-
     def tearDown(self):
-        self.sniffer.stop()
-        del self.sniffer
-
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         # 1
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[DUT_ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[DUT_ROUTER2].get_state(), 'router')
 
         self.nodes[SED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         # 2 & 3
@@ -106,31 +103,31 @@ class Cert_5_3_2_RealmLocal(unittest.TestCase):
 
         # 4 & 5
         self.assertTrue(self.nodes[LEADER].ping('ff03::1', num_responses=2, size=256))
-        sed_messages = self.sniffer.get_messages_sent_by(SED1)
+        sed_messages = self.simulator.get_messages_sent_by(SED1)
         self.assertFalse(sed_messages.contains_icmp_message())
 
         self.assertTrue(self.nodes[LEADER].ping('ff03::1', num_responses=2))
-        sed_messages = self.sniffer.get_messages_sent_by(SED1)
+        sed_messages = self.simulator.get_messages_sent_by(SED1)
         self.assertFalse(sed_messages.contains_icmp_message())
 
         # 6 & 7
         self.assertTrue(self.nodes[LEADER].ping('ff03::2', num_responses=2, size=256))
-        sed_messages = self.sniffer.get_messages_sent_by(SED1)
+        sed_messages = self.simulator.get_messages_sent_by(SED1)
         self.assertFalse(sed_messages.contains_icmp_message())
 
         self.assertTrue(self.nodes[LEADER].ping('ff03::2', num_responses=2))
-        sed_messages = self.sniffer.get_messages_sent_by(SED1)
+        sed_messages = self.simulator.get_messages_sent_by(SED1)
         self.assertFalse(sed_messages.contains_icmp_message())
 
         # 8
         self.assertTrue(self.nodes[LEADER].ping(config.REALM_LOCAL_All_THREAD_NODES_MULTICAST_ADDRESS, num_responses=3, size=256))
-        time.sleep(2)
-        sed_messages = self.sniffer.get_messages_sent_by(SED1)
+        self.simulator.go(2)
+        sed_messages = self.simulator.get_messages_sent_by(SED1)
         self.assertTrue(sed_messages.contains_icmp_message())
 
         self.assertTrue(self.nodes[LEADER].ping(config.REALM_LOCAL_All_THREAD_NODES_MULTICAST_ADDRESS, num_responses=3))
-        time.sleep(2)
-        sed_messages = self.sniffer.get_messages_sent_by(SED1)
+        self.simulator.go(2)
+        sed_messages = self.simulator.get_messages_sent_by(SED1)
         self.assertTrue(sed_messages.contains_icmp_message())
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_5_3_05_RoutingLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_5_3_05_RoutingLinkQuality.py
@@ -41,9 +41,11 @@ ROUTER3 = 4
 
 class Cert_5_3_5_RoutingLinkQuality(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -72,26 +74,21 @@ class Cert_5_3_5_RoutingLinkQuality(unittest.TestCase):
         self.nodes[ROUTER3].enable_whitelist()
         self.nodes[ROUTER3].set_router_selection_jitter(1)
 
-        self.sniffer = config.create_default_thread_sniffer()
-        self.sniffer.start()
-
     def tearDown(self):
-        self.sniffer.stop()
-        del self.sniffer
-
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         # 1
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         for router in range(DUT_ROUTER1, ROUTER3 + 1):
             self.nodes[router].start()
-        time.sleep(10)
+        self.simulator.go(10)
 
         for router in range(DUT_ROUTER1, ROUTER3 + 1):
             self.assertEqual(self.nodes[router].get_state(), 'router')
@@ -102,38 +99,38 @@ class Cert_5_3_5_RoutingLinkQuality(unittest.TestCase):
         # Verify the ICMPv6 Echo Request took the least cost path.
         self.assertTrue(self.nodes[ROUTER3].ping(leader_rloc))
         path = [ROUTER3, DUT_ROUTER1, LEADER]
-        command.check_icmp_path(self.sniffer, path, self.nodes)
+        command.check_icmp_path(self.simulator, path, self.nodes)
 
         # 4 & 5
         self.nodes[LEADER].add_whitelist(self.nodes[DUT_ROUTER1].get_addr64(), config.RSSI['LINK_QULITY_1'])
         self.nodes[DUT_ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64(), config.RSSI['LINK_QULITY_1'])
-        time.sleep(70)
+        self.simulator.go(70)
 
         # Verify the ICMPv6 Echo Request took the longer path because it cost less.
         self.assertTrue(self.nodes[ROUTER3].ping(leader_rloc))
         path = [ROUTER3, DUT_ROUTER1, ROUTER2, LEADER]
-        command.check_icmp_path(self.sniffer, path, self.nodes)
+        command.check_icmp_path(self.simulator, path, self.nodes)
 
         # 6 & 7
         self.nodes[LEADER].add_whitelist(self.nodes[DUT_ROUTER1].get_addr64(), config.RSSI['LINK_QULITY_2'])
         self.nodes[DUT_ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64(), config.RSSI['LINK_QULITY_2'])
-        time.sleep(70)
+        self.simulator.go(70)
 
         # Verify the direct neighbor would be prioritized when there are two paths with the same cost.
         self.assertTrue(self.nodes[ROUTER3].ping(leader_rloc))
         path = [ROUTER3, DUT_ROUTER1, LEADER]
-        command.check_icmp_path(self.sniffer, path, self.nodes)
+        command.check_icmp_path(self.simulator, path, self.nodes)
 
         # 8 & 9
         self.nodes[LEADER].add_whitelist(self.nodes[DUT_ROUTER1].get_addr64(), config.RSSI['LINK_QULITY_0'])
         self.nodes[DUT_ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64(), config.RSSI['LINK_QULITY_0'])
-        time.sleep(70)
+        self.simulator.go(70)
 
         # Verify the ICMPv6 Echo Request took the longer path.
         leader_rloc = self.nodes[LEADER].get_ip6_address(config.ADDRESS_TYPE.RLOC)
         self.assertTrue(self.nodes[ROUTER3].ping(leader_rloc))
         path = [ROUTER3, DUT_ROUTER1, ROUTER2, LEADER]
-        command.check_icmp_path(self.sniffer, path, self.nodes)
+        command.check_icmp_path(self.simulator, path, self.nodes)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_3_06_RouterIdMask.py
+++ b/tests/scripts/thread-cert/Cert_5_3_06_RouterIdMask.py
@@ -41,9 +41,11 @@ ROUTER2 = 3
 
 class Cert_5_3_6_RouterIdMask(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,4):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[DUT_LEADER].set_panid(0xface)
         self.nodes[DUT_LEADER].set_mode('rsdn')
@@ -61,39 +63,34 @@ class Cert_5_3_6_RouterIdMask(unittest.TestCase):
         self.nodes[ROUTER2].set_mode('rsdn')
         self._setUpRouter2()
 
-        self.sniffer = config.create_default_thread_sniffer()
-        self.sniffer.start()
-
     def _setUpRouter2(self):
         self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER2].enable_whitelist()
         self.nodes[ROUTER2].set_router_selection_jitter(1)
 
     def tearDown(self):
-        self.sniffer.stop()
-        del self.sniffer
-
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         # 1
         self.nodes[DUT_LEADER].start()
-        self.nodes[DUT_LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[DUT_LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
         router2_id = self.nodes[ROUTER2].get_router_id()
 
         # Wait DUT_LEADER to establish routing to ROUTER2 via ROUTER1's MLE advertisement.
-        time.sleep(config.MAX_ADVERTISEMENT_INTERVAL)
+        self.simulator.go(config.MAX_ADVERTISEMENT_INTERVAL)
 
         # 2
         self.nodes[ROUTER2].reset()
@@ -101,15 +98,15 @@ class Cert_5_3_6_RouterIdMask(unittest.TestCase):
 
         # 3 & 4
         # Flush the message queue to avoid possible impact on follow-up verification.
-        dut_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+        dut_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
 
         # Verify the cost from DUT_LEADER to ROUTER2 goes to infinity in 12 mins.
         routing_cost = 1
         for i in range(0, 24):
-            time.sleep(30)
+            self.simulator.go(30)
             print("%ss" %((i + 1) * 30))
 
-            leader_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+            leader_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
             msg = leader_messages.last_mle_message(mle.CommandType.ADVERTISEMENT, False)
             if msg == None:
                 continue
@@ -121,37 +118,37 @@ class Cert_5_3_6_RouterIdMask(unittest.TestCase):
                 break
         self.assertTrue(routing_cost == 0)
 
-        time.sleep(config.INFINITE_COST_TIMEOUT + config.MAX_ADVERTISEMENT_INTERVAL)
-        leader_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+        self.simulator.go(config.INFINITE_COST_TIMEOUT + config.MAX_ADVERTISEMENT_INTERVAL)
+        leader_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
         msg = leader_messages.last_mle_message(mle.CommandType.ADVERTISEMENT)
         self.assertFalse(command.check_id_set(msg, router2_id))
 
         # 5
         # Flush the message queue to avoid possible impact on follow-up verification.
-        dut_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+        dut_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
 
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
-        time.sleep(config.MAX_ADVERTISEMENT_INTERVAL)
-        leader_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+        self.simulator.go(config.MAX_ADVERTISEMENT_INTERVAL)
+        leader_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
         leader_messages.last_mle_message(mle.CommandType.ADVERTISEMENT)
 
         # 6
-        self.nodes[ROUTER1].stop()
-        self.nodes[ROUTER2].stop()
+        self.nodes[ROUTER1].reset()
+        self.nodes[ROUTER2].reset()
 
         router1_id = self.nodes[ROUTER1].get_router_id()
         router2_id = self.nodes[ROUTER2].get_router_id()
 
-        time.sleep(config.MAX_NEIGHBOR_AGE + config.MAX_ADVERTISEMENT_INTERVAL)
-        leader_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+        self.simulator.go(config.MAX_NEIGHBOR_AGE + config.MAX_ADVERTISEMENT_INTERVAL)
+        leader_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
         msg = leader_messages.last_mle_message(mle.CommandType.ADVERTISEMENT)
         self.assertEqual(command.get_routing_cost(msg, router1_id), 0)
 
-        time.sleep(config.INFINITE_COST_TIMEOUT + config.MAX_ADVERTISEMENT_INTERVAL)
-        leader_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+        self.simulator.go(config.INFINITE_COST_TIMEOUT + config.MAX_ADVERTISEMENT_INTERVAL)
+        leader_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
         msg = leader_messages.last_mle_message(mle.CommandType.ADVERTISEMENT)
         self.assertFalse(command.check_id_set(msg, router1_id))
         self.assertFalse(command.check_id_set(msg, router2_id))

--- a/tests/scripts/thread-cert/Cert_5_3_06b_RouterIdMask.py
+++ b/tests/scripts/thread-cert/Cert_5_3_06b_RouterIdMask.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -38,9 +39,11 @@ ROUTER2 = 3
 
 class Cert_5_3_6_RouterIdMask(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,4):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -64,24 +67,25 @@ class Cert_5_3_6_RouterIdMask(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER1].stop()
         self.nodes[ROUTER2].stop()
 
-        time.sleep(300)
+        self.simulator.go(300)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
+++ b/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
@@ -46,9 +46,11 @@ MTDS = [MED1, SED1, MED3]
 
 class Cert_5_3_7_DuplicateAddress(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,7):
-            self.nodes[i] = node.Node(i, (i in MTDS))
+            self.nodes[i] = node.Node(i, (i in MTDS), simulator=self.simulator)
 
         self.nodes[DUT_LEADER].set_panid(0xface)
         self.nodes[DUT_LEADER].set_mode('rsdn')
@@ -86,27 +88,22 @@ class Cert_5_3_7_DuplicateAddress(unittest.TestCase):
         self.nodes[MED3].add_whitelist(self.nodes[DUT_LEADER].get_addr64())
         self.nodes[MED3].enable_whitelist()
 
-        self.sniffer = config.create_default_thread_sniffer()
-        self.sniffer.start()
-
     def tearDown(self):
-        self.sniffer.stop()
-        del self.sniffer
-
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         # 1
         self.nodes[DUT_LEADER].start()
-        self.nodes[DUT_LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[DUT_LEADER].get_state(), 'leader')
 
         for i in range(ROUTER1, MED3 + 1):
             self.nodes[i].start()
 
-        time.sleep(5)
+        self.simulator.go(5)
 
         for i in [ROUTER1, ROUTER2]:
             self.assertEqual(self.nodes[i].get_state(), 'router')
@@ -115,7 +112,7 @@ class Cert_5_3_7_DuplicateAddress(unittest.TestCase):
             self.assertEqual(self.nodes[i].get_state(), 'child')
 
         # 2
-        leader_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+        leader_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
         msg = leader_messages.next_mle_message(mle.CommandType.ADVERTISEMENT)
         command.check_mle_advertisement(msg)
 
@@ -126,23 +123,23 @@ class Cert_5_3_7_DuplicateAddress(unittest.TestCase):
         self.nodes[MED1].add_ipaddr('2001:2:0:1::1234')
         self.nodes[SED1].add_ipaddr('2001:2:0:1::1234')
 
-        time.sleep(5)
+        self.simulator.go(5)
 
         # 4
         # Flush the message queue to avoid possible impact on follow-up verification.
-        self.sniffer.get_messages_sent_by(DUT_LEADER)
+        self.simulator.get_messages_sent_by(DUT_LEADER)
 
         self.nodes[MED3].ping('2001:2:0:1::1234')
 
         # Verify DUT_LEADER sent an Address Query Request to the Realm local address.
-        dut_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+        dut_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
         msg = dut_messages.next_coap_message('0.02', '/a/aq')
         command.check_address_query(msg, self.nodes[DUT_LEADER], config.REALM_LOCAL_ALL_ROUTERS_ADDRESS)
 
         # 5 & 6
         # Verify DUT_LEADER sent an Address Error Notification to the Realm local address.
-        time.sleep(5)
-        dut_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+        self.simulator.go(5)
+        dut_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
         msg = dut_messages.next_coap_message('0.02', '/a/ae')
         command.check_address_error_notification(msg, self.nodes[DUT_LEADER], config.REALM_LOCAL_ALL_ROUTERS_ADDRESS)
 

--- a/tests/scripts/thread-cert/Cert_5_3_08_ChildAddressSet.py
+++ b/tests/scripts/thread-cert/Cert_5_3_08_ChildAddressSet.py
@@ -45,10 +45,11 @@ MTDS = [MED1, MED2]
 
 class Cert_5_3_8_ChildAddressSet(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
 
         self.nodes = {}
         for i in range(1, 5):
-            self.nodes[i] = node.Node(i, (i in MTDS))
+            self.nodes[i] = node.Node(i, (i in MTDS), simulator=self.simulator)
 
         self.nodes[DUT_LEADER].set_panid(0xface)
         self.nodes[DUT_LEADER].set_mode('rsdn')
@@ -69,24 +70,19 @@ class Cert_5_3_8_ChildAddressSet(unittest.TestCase):
             self.nodes[i].add_whitelist(self.nodes[DUT_LEADER].get_addr64())
             self.nodes[i].enable_whitelist()
 
-        self.sniffer = config.create_default_thread_sniffer()
-        self.sniffer.start()
-
     def tearDown(self):
-        self.sniffer.stop()
-        del self.sniffer
-
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[DUT_LEADER].start()
-        self.nodes[DUT_LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[DUT_LEADER].get_state(), 'leader')
 
         self.nodes[BR].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[BR].get_state(), 'router')
 
         # 1 BR: Configure BR to be a DHCPv6 server
@@ -96,19 +92,19 @@ class Cert_5_3_8_ChildAddressSet(unittest.TestCase):
         self.nodes[BR].register_netdata()
 
         # Set lowpan context of sniffer
-        self.sniffer.set_lowpan_context(1, '2001::/64')
-        self.sniffer.set_lowpan_context(2, '2002::/64')
-        self.sniffer.set_lowpan_context(3, '2003::/64')
+        self.simulator.set_lowpan_context(1, '2001::/64')
+        self.simulator.set_lowpan_context(2, '2002::/64')
+        self.simulator.set_lowpan_context(3, '2003::/64')
 
         # 2 DUT_LEADER: Verify LEADER sent an Advertisement
-        leader_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+        leader_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
         msg = leader_messages.next_mle_message(mle.CommandType.ADVERTISEMENT)
         command.check_mle_advertisement(msg)
 
         # 3 MED1, MED2: MED1 and MED2 attach to DUT_LEADER
         for i in MTDS:
             self.nodes[i].start()
-            time.sleep(5)
+            self.simulator.go(5)
             self.assertEqual(self.nodes[i].get_state(), 'child')
 
         # 4 MED1: MED1 send an ICMPv6 Echo Request to the MED2 ML-EID
@@ -117,15 +113,15 @@ class Cert_5_3_8_ChildAddressSet(unittest.TestCase):
         self.assertTrue(self.nodes[MED1].ping(med2_ml_eid))
 
         # Verify DUT_LEADER didn't generate an Address Query Request
-        leader_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+        leader_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
         msg = leader_messages.next_coap_message('0.02', '/a/aq', False)
         assert msg is None, "Error: The DUT_LEADER sent an unexpected Address Query Request"
 
         # Wait for sniffer got packets
-        time.sleep(1)
+        self.simulator.go(1)
 
         # Verify MED2 sent an ICMPv6 Echo Reply
-        med2_messages = self.sniffer.get_messages_sent_by(MED2)
+        med2_messages = self.simulator.get_messages_sent_by(MED2)
         msg = med2_messages.get_icmp_message(ipv6.ICMP_ECHO_RESPONSE)
         assert msg is not None, "Error: The MED2 didn't send ICMPv6 Echo Reply to MED1"
 
@@ -135,15 +131,15 @@ class Cert_5_3_8_ChildAddressSet(unittest.TestCase):
         self.assertTrue(self.nodes[MED1].ping(addr))
 
         # Verify DUT_LEADER didn't generate an Address Query Request
-        leader_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+        leader_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
         msg = leader_messages.next_coap_message('0.02', '/a/aq', False)
         assert msg is None, "Error: The DUT_LEADER sent an unexpected Address Query Request"
 
         # Wait for sniffer got packets
-        time.sleep(1)
+        self.simulator.go(1)
 
         # Verify MED2 sent an ICMPv6 Echo Reply
-        med2_messages = self.sniffer.get_messages_sent_by(MED2)
+        med2_messages = self.simulator.get_messages_sent_by(MED2)
         msg = med2_messages.get_icmp_message(ipv6.ICMP_ECHO_RESPONSE)
         assert msg is not None, "Error: The MED2 didn't send ICMPv6 Echo Reply to MED1"
 
@@ -153,15 +149,15 @@ class Cert_5_3_8_ChildAddressSet(unittest.TestCase):
         self.assertTrue(self.nodes[MED1].ping(addr))
 
         # Verify DUT_LEADER didn't generate an Address Query Request
-        leader_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+        leader_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
         msg = leader_messages.next_coap_message('0.02', '/a/aq', False)
         assert msg is None, "Error: The DUT_LEADER sent an unexpected Address Query Request"
 
         # Wait for sniffer got packets
-        time.sleep(1)
+        self.simulator.go(1)
 
         # Verify MED2 sent an ICMPv6 Echo Reply
-        med2_messages = self.sniffer.get_messages_sent_by(MED2)
+        med2_messages = self.simulator.get_messages_sent_by(MED2)
         msg = med2_messages.get_icmp_message(ipv6.ICMP_ECHO_RESPONSE)
         assert msg is not None, "Error: The MED2 didn't send ICMPv6 Echo Reply to MED1"
 
@@ -171,15 +167,15 @@ class Cert_5_3_8_ChildAddressSet(unittest.TestCase):
         self.assertTrue(self.nodes[MED1].ping(addr))
 
         # Verify DUT_LEADER didn't generate an Address Query Request
-        leader_messages = self.sniffer.get_messages_sent_by(DUT_LEADER)
+        leader_messages = self.simulator.get_messages_sent_by(DUT_LEADER)
         msg = leader_messages.next_coap_message('0.02', '/a/aq', False)
         assert msg is None, "Error: The DUT_LEADER sent an unexpected Address Query Request"
 
         # Wait for sniffer got packets
-        time.sleep(1)
+        self.simulator.go(1)
 
         # Verify MED2 sent an ICMPv6 Echo Reply
-        med2_messages = self.sniffer.get_messages_sent_by(MED2)
+        med2_messages = self.simulator.get_messages_sent_by(MED2)
         msg = med2_messages.get_icmp_message(ipv6.ICMP_ECHO_RESPONSE)
         assert msg is not None, "Error: The MED2 didn't send ICMPv6 Echo Reply to MED1"
 

--- a/tests/scripts/thread-cert/Cert_5_3_09_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_09_AddressQuery.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -40,9 +41,11 @@ SED1 = 5
 
 class Cert_5_3_09_AddressQuery(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i, (i == SED1))
+            self.nodes[i] = node.Node(i, (i == SED1), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -81,34 +84,36 @@ class Cert_5_3_09_AddressQuery(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[LEADER].add_prefix('2001:2:0:1::/64', 'pdros')
         self.nodes[LEADER].add_prefix('2001:2:0:2::/64', 'pdro')
         self.nodes[LEADER].register_netdata()
+        self.simulator.go(5)
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER3].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER3].get_state(), 'router')
 
         self.nodes[SED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         # wait for sed got replied
-        time.sleep(10)
+        self.simulator.go(10)
 
         addrs = self.nodes[ROUTER3].get_addrs()
         self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))
@@ -130,7 +135,7 @@ class Cert_5_3_09_AddressQuery(unittest.TestCase):
                 self.assertTrue(self.nodes[SED1].ping(addr))
 
         self.nodes[ROUTER3].stop()
-        time.sleep(300)
+        self.simulator.go(300)
 
         addrs = self.nodes[ROUTER3].get_addrs()
         for addr in addrs:
@@ -138,7 +143,7 @@ class Cert_5_3_09_AddressQuery(unittest.TestCase):
                 self.assertFalse(self.nodes[SED1].ping(addr))
 
         self.nodes[SED1].stop()
-        time.sleep(10)
+        self.simulator.go(10)
 
         addrs = self.nodes[SED1].get_addrs()
         for addr in addrs:

--- a/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
@@ -46,9 +46,11 @@ MED1 = 5
 
 class Cert_5_3_10_AddressQuery(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1, 6):
-            self.nodes[i] = node.Node(i, (i == MED1))
+            self.nodes[i] = node.Node(i, (i == MED1), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -83,26 +85,21 @@ class Cert_5_3_10_AddressQuery(unittest.TestCase):
         self.nodes[MED1].add_whitelist(self.nodes[DUT_ROUTER2].get_addr64())
         self.nodes[MED1].enable_whitelist()
 
-        self.sniffer = config.create_default_thread_sniffer()
-        self.sniffer.start()
-
     def tearDown(self):
-        self.sniffer.stop()
-        del self.sniffer
-
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         # 1 & 2
         # Build and verify the topology
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[BR].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[BR].get_state(), 'router')
 
         # Configure two On-Mesh Prefixes on the BR
@@ -111,19 +108,19 @@ class Cert_5_3_10_AddressQuery(unittest.TestCase):
         self.nodes[BR].register_netdata()
 
         # Set lowpan context of sniffer
-        self.sniffer.set_lowpan_context(1, '2003::/64')
-        self.sniffer.set_lowpan_context(2, '2004::/64')
+        self.simulator.set_lowpan_context(1, '2003::/64')
+        self.simulator.set_lowpan_context(2, '2004::/64')
 
         self.nodes[DUT_ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[DUT_ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[MED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[MED1].get_state(), 'child')
 
         # 3 MED1: MED1 sends an ICMPv6 Echo Request to Router1 using GUA 2003:: address
@@ -132,10 +129,10 @@ class Cert_5_3_10_AddressQuery(unittest.TestCase):
         self.assertTrue(self.nodes[MED1].ping(router1_addr))
 
         # Wait for sniffer got Address Notification messages
-        time.sleep(1)
+        self.simulator.go(1)
 
         # Verify DUT_ROUTER2 sent an Address Query Request
-        dut_router2_messages = self.sniffer.get_messages_sent_by(DUT_ROUTER2)
+        dut_router2_messages = self.simulator.get_messages_sent_by(DUT_ROUTER2)
         msg = dut_router2_messages.next_coap_message('0.02', '/a/aq')
         command.check_address_query(msg, self.nodes[DUT_ROUTER2], config.REALM_LOCAL_ALL_ROUTERS_ADDRESS)
 
@@ -150,10 +147,10 @@ class Cert_5_3_10_AddressQuery(unittest.TestCase):
         self.assertTrue(self.nodes[BR].ping(med1_addr))
 
         # Wait for sniffer got Address Notification messages
-        time.sleep(1)
+        self.simulator.go(1)
 
         # Verify DUT_ROUTER2 sent an Address Notification message
-        dut_router2_messages = self.sniffer.get_messages_sent_by(DUT_ROUTER2)
+        dut_router2_messages = self.simulator.get_messages_sent_by(DUT_ROUTER2)
         msg = dut_router2_messages.next_coap_message('0.02', '/a/an')
         command.check_address_notification(msg, self.nodes[DUT_ROUTER2], self.nodes[BR])
 
@@ -163,10 +160,10 @@ class Cert_5_3_10_AddressQuery(unittest.TestCase):
         self.assertTrue(self.nodes[MED1].ping(addr))
 
         # Wait for sniffer got ICMPv6 Echo Reply
-        time.sleep(1)
+        self.simulator.go(1)
 
         # Verify DUT_ROUTER2 didn't generate an Address Query Request
-        dut_router2_messages = self.sniffer.get_messages_sent_by(DUT_ROUTER2)
+        dut_router2_messages = self.simulator.get_messages_sent_by(DUT_ROUTER2)
         dut_router2_messages_temp = copy.deepcopy(dut_router2_messages)
         msg = dut_router2_messages.next_coap_message('0.02', '/a/aq', False)
         assert msg is None, "Error: The DUT_ROUTER2 sent an unexpected Address Query Request"
@@ -179,7 +176,7 @@ class Cert_5_3_10_AddressQuery(unittest.TestCase):
         # 6 DUT_ROUTER2: Power off ROUTER1 and wait 580 seconds to allow the LEADER to expire its Router ID
         router1_id = self.nodes[ROUTER1].get_router_id()
         self.nodes[ROUTER1].stop()
-        time.sleep(580)
+        self.simulator.go(580)
 
         # Send an ICMPv6 Echo Request from MED1 to ROUTER1 GUA 2003:: address
         self.assertFalse(self.nodes[MED1].ping(router1_addr))
@@ -188,20 +185,20 @@ class Cert_5_3_10_AddressQuery(unittest.TestCase):
         command.check_router_id_cached(self.nodes[DUT_ROUTER2], router1_id, False)
 
         # Verify DUT_ROUTER2 sent an Address Query Request
-        dut_router2_messages = self.sniffer.get_messages_sent_by(DUT_ROUTER2)
+        dut_router2_messages = self.simulator.get_messages_sent_by(DUT_ROUTER2)
         msg = dut_router2_messages.next_coap_message('0.02', '/a/aq')
         msg.assertSentToDestinationAddress(config.REALM_LOCAL_ALL_ROUTERS_ADDRESS)
 
         # 7 MED1: Power off MED1 and wait to allow DUT_ROUTER2 to timeout the child
         self.nodes[MED1].stop()
-        time.sleep(config.MLE_END_DEVICE_TIMEOUT)
+        self.simulator.go(config.MLE_END_DEVICE_TIMEOUT)
 
         # BR sends two ICMPv6 Echo Requests to MED1 GUA 2003:: address
         self.assertFalse(self.nodes[BR].ping(med1_addr))
         self.assertFalse(self.nodes[BR].ping(med1_addr))
 
         # Verify DUT_ROUTER2 didn't generate an Address Notification message
-        dut_router2_messages = self.sniffer.get_messages_sent_by(DUT_ROUTER2)
+        dut_router2_messages = self.simulator.get_messages_sent_by(DUT_ROUTER2)
         msg = dut_router2_messages.next_coap_message('0.02', '/a/an/', False)
         assert msg is None, "Error: The DUT_ROUTER2 sent an unexpected Address Notification message"
 

--- a/tests/scripts/thread-cert/Cert_5_5_01_LeaderReset.py
+++ b/tests/scripts/thread-cert/Cert_5_5_01_LeaderReset.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -37,9 +38,11 @@ ROUTER = 2
 
 class Cert_5_5_1_LeaderReset(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -59,24 +62,25 @@ class Cert_5_5_1_LeaderReset(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         rloc16 = self.nodes[LEADER].get_addr16()
 
         self.nodes[LEADER].reset();
         self._setUpLeader()
-        time.sleep(5)
+        self.simulator.go(5)
 
         self.nodes[LEADER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
         self.assertEqual(self.nodes[LEADER].get_addr16(), rloc16)
 

--- a/tests/scripts/thread-cert/Cert_5_5_02_LeaderReboot.py
+++ b/tests/scripts/thread-cert/Cert_5_5_02_LeaderReboot.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -38,9 +39,11 @@ ED = 3
 
 class Cert_5_5_2_LeaderReboot(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,4):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -67,27 +70,28 @@ class Cert_5_5_2_LeaderReboot(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         self.nodes[LEADER].reset()
         self._setUpLeader()
-        time.sleep(140)
+        self.simulator.go(140)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'leader')
 
         self.nodes[LEADER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'router')
 
         addrs = self.nodes[ED].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_5_03_SplitMergeChildren.py
+++ b/tests/scripts/thread-cert/Cert_5_5_03_SplitMergeChildren.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -43,9 +44,11 @@ MTDS = [ED1, ED2, ED3]
 
 class Cert_5_5_3_SplitMergeChildren(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,7):
-            self.nodes[i] = node.Node(i, (i in MTDS))
+            self.nodes[i] = node.Node(i, (i in MTDS), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -91,30 +94,31 @@ class Cert_5_5_3_SplitMergeChildren(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[ED2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED2].get_state(), 'child')
 
         self.nodes[ED3].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED3].get_state(), 'child')
 
         self.nodes[LEADER].reset()
@@ -123,15 +127,15 @@ class Cert_5_5_3_SplitMergeChildren(unittest.TestCase):
         self.nodes[ED1].add_whitelist(self.nodes[ROUTER1].get_addr64())
         self.nodes[ROUTER1].add_whitelist(self.nodes[ED1].get_addr64())
 
-        time.sleep(140)
+        self.simulator.go(140)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'leader')
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'leader')
 
         self.nodes[LEADER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'router')
 
-        time.sleep(30)
+        self.simulator.go(30)
 
         addrs = self.nodes[ED1].get_addrs()
         for addr in addrs:

--- a/tests/scripts/thread-cert/Cert_5_5_04_SplitMergeRouters.py
+++ b/tests/scripts/thread-cert/Cert_5_5_04_SplitMergeRouters.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -40,9 +41,11 @@ ROUTER4 = 5
 
 class Cert_5_5_4_SplitMergeRouters(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -84,34 +87,35 @@ class Cert_5_5_4_SplitMergeRouters(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER3].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER3].get_state(), 'router')
 
         self.nodes[ROUTER4].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER4].get_state(), 'router')
 
         self.nodes[LEADER].reset()
         self._setUpLeader()
-        time.sleep(150)
+        self.simulator.go(150)
 
         self.nodes[LEADER].start()
-        time.sleep(50)
+        self.simulator.go(50)
 
         self.assertEqual(self.nodes[LEADER].get_state(), 'router')
 

--- a/tests/scripts/thread-cert/Cert_5_5_07_SplitMergeThreeWay.py
+++ b/tests/scripts/thread-cert/Cert_5_5_07_SplitMergeThreeWay.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER1 = 1
@@ -39,9 +40,11 @@ ROUTER3 = 4
 
 class Cert_5_5_7_SplitMergeThreeWay(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[LEADER1].set_panid(0xface)
         self.nodes[LEADER1].set_mode('rsdn')
@@ -76,30 +79,31 @@ class Cert_5_5_7_SplitMergeThreeWay(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER1].start()
-        self.nodes[LEADER1].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER1].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER3].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER3].get_state(), 'router')
 
         self.nodes[LEADER1].reset()
         self._setUpLeader1()
-        time.sleep(140)
+        self.simulator.go(140)
 
         self.nodes[LEADER1].start()
-        time.sleep(30)
+        self.simulator.go(30)
 
         addrs = self.nodes[LEADER1].get_addrs()
         for addr in addrs:

--- a/tests/scripts/thread-cert/Cert_5_5_08_SplitRoutersLostLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_5_08_SplitRoutersLostLeader.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER1 = 1
@@ -40,9 +41,11 @@ ED1 = 5
 
 class Cert_5_5_8_SplitRoutersLostLeader(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i, (i == ED1))
+            self.nodes[i] = node.Node(i, (i == ED1), simulator=self.simulator)
 
         self.nodes[LEADER1].set_panid(0xface)
         self.nodes[LEADER1].set_mode('rsdn')
@@ -88,23 +91,23 @@ class Cert_5_5_8_SplitRoutersLostLeader(unittest.TestCase):
 
     def test(self):
         self.nodes[LEADER1].start()
-        self.nodes[LEADER1].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER1].get_state(), 'leader')
 
         self.nodes[ROUTER3].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER3].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         addrs = self.nodes[ED1].get_addrs()
@@ -114,10 +117,10 @@ class Cert_5_5_8_SplitRoutersLostLeader(unittest.TestCase):
 
         self.nodes[ROUTER3].reset()
         self._setUpRouter3()
-        time.sleep(140)
+        self.simulator.go(140)
 
         self.nodes[ROUTER3].start()        
-        time.sleep(60)
+        self.simulator.go(60)
 
         addrs = self.nodes[ED1].get_addrs()
         for addr in addrs:

--- a/tests/scripts/thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -41,9 +42,11 @@ MTDS = [ED1, SED1]
 
 class Cert_5_6_1_NetworkDataLeaderAsBr(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i, (i in MTDS))
+            self.nodes[i] = node.Node(i, (i in MTDS), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -73,10 +76,11 @@ class Cert_5_6_1_NetworkDataLeaderAsBr(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(4)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[LEADER].add_prefix('2001:2:0:1::/64', 'paros')
@@ -84,15 +88,15 @@ class Cert_5_6_1_NetworkDataLeaderAsBr(unittest.TestCase):
         self.nodes[LEADER].register_netdata()
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[SED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         addrs = self.nodes[ED1].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -41,9 +42,11 @@ MTDS = [ED1, SED1]
 
 class Cert_5_6_2_NetworkDataRouterAsBr(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i, (i in MTDS))
+            self.nodes[i] = node.Node(i, (i in MTDS), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -73,14 +76,15 @@ class Cert_5_6_2_NetworkDataRouterAsBr(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(4)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ROUTER].add_prefix('2001:2:0:1::/64', 'paros')
@@ -88,11 +92,11 @@ class Cert_5_6_2_NetworkDataRouterAsBr(unittest.TestCase):
         self.nodes[ROUTER].register_netdata()
 
         self.nodes[ED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[SED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         addrs = self.nodes[ED1].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -41,9 +42,11 @@ MTDS = [ED1, SED1]
 
 class Cert_5_6_3_NetworkDataRegisterAfterAttachLeader(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i, (i in MTDS))
+            self.nodes[i] = node.Node(i, (i in MTDS), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -73,29 +76,30 @@ class Cert_5_6_3_NetworkDataRegisterAfterAttachLeader(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(4)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[SED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         self.nodes[LEADER].add_prefix('2001:2:0:1::/64', 'paros')
         self.nodes[LEADER].add_prefix('2001:2:0:2::/64', 'paro')
         self.nodes[LEADER].register_netdata()
 
-        time.sleep(10)
+        self.simulator.go(10)
 
         addrs = self.nodes[ED1].get_addrs()
         self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))

--- a/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -41,9 +42,11 @@ MTDS = [ED1, SED1]
 
 class Cert_5_6_4_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i, (i in MTDS))
+            self.nodes[i] = node.Node(i, (i in MTDS), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -73,29 +76,30 @@ class Cert_5_6_4_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(4)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[SED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         self.nodes[ROUTER].add_prefix('2001:2:0:1::/64', 'paros')
         self.nodes[ROUTER].add_prefix('2001:2:0:2::/64', 'paro')
         self.nodes[ROUTER].register_netdata()
 
-        time.sleep(10)
+        self.simulator.go(10)
 
         addrs = self.nodes[ED1].get_addrs()
         self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))

--- a/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -41,9 +42,11 @@ MTDS = [ED1, SED1]
 
 class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i, (i in MTDS))
+            self.nodes[i] = node.Node(i, (i in MTDS), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -73,29 +76,30 @@ class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(4)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[SED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         self.nodes[ROUTER].add_prefix('2001:2:0:1::/64', 'paros')
         self.nodes[ROUTER].add_prefix('2001:2:0:2::/64', 'paro')
         self.nodes[ROUTER].register_netdata()
 
-        time.sleep(10)
+        self.simulator.go(10)
 
         addrs = self.nodes[ED1].get_addrs()
         self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))
@@ -114,7 +118,7 @@ class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
         self.nodes[ROUTER].add_prefix('2001:2:0:3::/64', 'pacs')
         self.nodes[ROUTER].register_netdata()
 
-        time.sleep(10)
+        self.simulator.go(10)
 
         addrs = self.nodes[ED1].get_addrs()
         self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))

--- a/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
+++ b/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -41,9 +42,11 @@ MTDS = [ED1, SED1]
 
 class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i, (i in MTDS))
+            self.nodes[i] = node.Node(i, (i in MTDS), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -73,29 +76,30 @@ class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(4)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[SED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         self.nodes[ROUTER].add_prefix('2001:2:0:1::/64', 'paros')
         self.nodes[ROUTER].add_prefix('2001:2:0:2::/64', 'paro')
         self.nodes[ROUTER].register_netdata()
 
-        time.sleep(10)
+        self.simulator.go(10)
 
         addrs = self.nodes[ED1].get_addrs()
         self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))
@@ -114,7 +118,7 @@ class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
         self.nodes[ROUTER].add_prefix('2001:2:0:3::/64', 'pacs')
         self.nodes[ROUTER].register_netdata()
 
-        time.sleep(10)
+        self.simulator.go(10)
 
         addrs = self.nodes[ED1].get_addrs()
         self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))
@@ -134,7 +138,7 @@ class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
 
         self.nodes[ROUTER].remove_prefix('2001:2:0:3::/64')
         self.nodes[ROUTER].register_netdata()
-        time.sleep(10)
+        self.simulator.go(10)
 
         addrs = self.nodes[ED1].get_addrs()
         self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))

--- a/tests/scripts/thread-cert/Cert_5_8_01_KeySynchronization.py
+++ b/tests/scripts/thread-cert/Cert_5_8_01_KeySynchronization.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -37,9 +38,11 @@ ED = 2
 
 class Cert_5_8_1_KeySynchronization(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -57,14 +60,15 @@ class Cert_5_8_1_KeySynchronization(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(4)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         addrs = self.nodes[LEADER].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_8_02_KeyIncrement.py
+++ b/tests/scripts/thread-cert/Cert_5_8_02_KeyIncrement.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -37,9 +38,11 @@ ROUTER = 2
 
 class Cert_5_8_2_KeyIncrement(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -58,13 +61,15 @@ class Cert_5_8_2_KeyIncrement(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(4)
+        self.assertEqual(self.nodes[LEADER].get_state(), "leader")
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), "router")
 
         addrs = self.nodes[ROUTER].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_8_03_KeyIncrementRollOver.py
+++ b/tests/scripts/thread-cert/Cert_5_8_03_KeyIncrementRollOver.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -37,9 +38,11 @@ ROUTER = 2
 
 class Cert_5_8_3_KeyIncrementRollOver(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -59,14 +62,15 @@ class Cert_5_8_3_KeyIncrementRollOver(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(4)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         addrs = self.nodes[ROUTER].get_addrs()

--- a/tests/scripts/thread-cert/Cert_6_1_01_RouterAttach.py
+++ b/tests/scripts/thread-cert/Cert_6_1_01_RouterAttach.py
@@ -36,13 +36,14 @@ import node
 
 LEADER = 1
 ED = 2
-SNIFFER = 3
 
 class Cert_6_1_1_RouterAttach(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -54,28 +55,23 @@ class Cert_6_1_1_RouterAttach(unittest.TestCase):
         self.nodes[ED].add_whitelist(self.nodes[LEADER].get_addr64())
         self.nodes[ED].enable_whitelist()
 
-        self.sniffer = config.create_default_thread_sniffer(SNIFFER)
-        self.sniffer.start()
-
     def tearDown(self):
-        self.sniffer.stop()
-        del self.sniffer
-
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
-        leader_messages = self.sniffer.get_messages_sent_by(LEADER)
-        ed_messages = self.sniffer.get_messages_sent_by(ED)
+        leader_messages = self.simulator.get_messages_sent_by(LEADER)
+        ed_messages = self.simulator.get_messages_sent_by(ED)
 
         # 1 - leader
         msg = leader_messages.next_mle_message(mle.CommandType.ADVERTISEMENT)

--- a/tests/scripts/thread-cert/Cert_6_1_02_REEDAttach.py
+++ b/tests/scripts/thread-cert/Cert_6_1_02_REEDAttach.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -38,9 +39,11 @@ ED = 3
 
 class Cert_6_1_2_REEDAttach(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,4):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -63,18 +66,19 @@ class Cert_6_1_2_REEDAttach(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[REED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[REED].get_state(), 'child')
 
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
         self.assertEqual(self.nodes[REED].get_state(), 'router')
 

--- a/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -40,9 +41,11 @@ ED = 5
 
 class Cert_6_1_3_RouterAttachConnectivity(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -83,19 +86,20 @@ class Cert_6_1_3_RouterAttachConnectivity(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         for i in range(2, 5):
             self.nodes[i].start()
-            time.sleep(5)
+            self.simulator.go(5)
             self.assertEqual(self.nodes[i].get_state(), 'router')
 
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         addrs = self.nodes[ED].get_addrs()

--- a/tests/scripts/thread-cert/Cert_6_1_04_REEDAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_6_1_04_REEDAttachConnectivity.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -40,9 +41,11 @@ ED = 5
 
 class Cert_6_1_4_REEDAttachConnectivity(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -83,28 +86,29 @@ class Cert_6_1_4_REEDAttachConnectivity(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[REED0].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[REED0].get_state(), 'child')
 
         self.nodes[REED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[REED1].get_state(), 'child')
 
-        time.sleep(10)
+        self.simulator.go(10)
 
         self.nodes[ED].start()
-        time.sleep(10)
+        self.simulator.go(10)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
         self.assertEqual(self.nodes[REED1].get_state(), 'router')
 

--- a/tests/scripts/thread-cert/Cert_6_1_05_RouterAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_6_1_05_RouterAttachLinkQuality.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -39,9 +40,11 @@ ED = 4
 
 class Cert_6_1_5_RouterAttachLinkQuality(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -73,22 +76,23 @@ class Cert_6_1_5_RouterAttachLinkQuality(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_6_1_06_REEDAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_6_1_06_REEDAttachLinkQuality.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -39,9 +40,11 @@ ED = 4
 
 class Cert_6_1_6_REEDAttachLinkQuality(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -73,22 +76,23 @@ class Cert_6_1_6_REEDAttachLinkQuality(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[REED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[REED].get_state(), 'child')
 
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ED].start()
-        time.sleep(10)
+        self.simulator.go(10)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
         self.assertEqual(self.nodes[REED].get_state(), 'router')
 

--- a/tests/scripts/thread-cert/Cert_6_1_07_EDSynchronization.py
+++ b/tests/scripts/thread-cert/Cert_6_1_07_EDSynchronization.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -40,9 +41,11 @@ ROUTER3 = 5
 
 class Cert_6_1_7_EDSynchronization(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -87,26 +90,27 @@ class Cert_6_1_7_EDSynchronization(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER3].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER3].get_state(), 'router')
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_6_2_01_NewPartition.py
+++ b/tests/scripts/thread-cert/Cert_6_2_01_NewPartition.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -38,9 +39,11 @@ ED = 3
 
 class Cert_6_2_1_NewPartition(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,4):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -63,22 +66,23 @@ class Cert_6_2_1_NewPartition(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         self.nodes[LEADER].stop()
-        time.sleep(140)
+        self.simulator.go(140)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'leader')
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 

--- a/tests/scripts/thread-cert/Cert_6_2_02_NewPartition.py
+++ b/tests/scripts/thread-cert/Cert_6_2_02_NewPartition.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -39,9 +40,11 @@ ED = 4
 
 class Cert_6_2_2_NewPartition(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -74,26 +77,27 @@ class Cert_6_2_2_NewPartition(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         self.nodes[LEADER].stop()
-        time.sleep(140)
+        self.simulator.go(140)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'leader')
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
         self.assertEqual(self.nodes[ED].get_state(), 'child')

--- a/tests/scripts/thread-cert/Cert_6_3_02_NetworkDataUpdate.py
+++ b/tests/scripts/thread-cert/Cert_6_3_02_NetworkDataUpdate.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -37,9 +38,11 @@ ED = 2
 
 class Cert_5_6_2_NetworkDataUpdate(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -56,19 +59,20 @@ class Cert_5_6_2_NetworkDataUpdate(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         self.nodes[LEADER].add_prefix('2001:2:0:1::/64', 'paros')
         self.nodes[LEADER].register_netdata()
-        time.sleep(5)
+        self.simulator.go(5)
 
         addrs = self.nodes[ED].get_addrs()
         self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))
@@ -81,11 +85,11 @@ class Cert_5_6_2_NetworkDataUpdate(unittest.TestCase):
 
         self.nodes[LEADER].add_prefix('2001:2:0:2::/64', 'paros')
         self.nodes[LEADER].register_netdata()
-        time.sleep(5)
+        self.simulator.go(5)
 
         self.nodes[LEADER].add_whitelist(self.nodes[ED].get_addr64())
         self.nodes[ED].add_whitelist(self.nodes[LEADER].get_addr64())
-        time.sleep(10)
+        self.simulator.go(10)
 
         addrs = self.nodes[ED].get_addrs()
         self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))

--- a/tests/scripts/thread-cert/Cert_6_4_01_LinkLocal.py
+++ b/tests/scripts/thread-cert/Cert_6_4_01_LinkLocal.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -37,9 +38,11 @@ ED = 2
 
 class Cert_6_4_1_LinkLocal(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -55,14 +58,15 @@ class Cert_6_4_1_LinkLocal(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         addrs = self.nodes[ED].get_addrs()

--- a/tests/scripts/thread-cert/Cert_6_4_02_RealmLocal.py
+++ b/tests/scripts/thread-cert/Cert_6_4_02_RealmLocal.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -38,9 +39,11 @@ ED = 3
 
 class Cert_5_3_2_RealmLocal(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -63,18 +66,19 @@ class Cert_5_3_2_RealmLocal(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         addrs = self.nodes[ED].get_addrs()

--- a/tests/scripts/thread-cert/Cert_6_5_01_ChildResetSynchronize.py
+++ b/tests/scripts/thread-cert/Cert_6_5_01_ChildResetSynchronize.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -37,9 +38,11 @@ ED = 2
 
 class Cert_6_5_1_ChildResetSynchronize(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -59,31 +62,32 @@ class Cert_6_5_1_ChildResetSynchronize(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         self.nodes[ED].reset()
         self._setUpEd()
-        time.sleep(5)
+        self.simulator.go(5)
 
         self.nodes[ED].set_timeout(100)
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         self.nodes[ED].reset()
         self._setUpEd()
-        time.sleep(5)
+        self.simulator.go(5)
         self.nodes[ED].set_timeout(100)
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         addrs = self.nodes[ED].get_addrs()

--- a/tests/scripts/thread-cert/Cert_6_5_02_ChildResetReattach.py
+++ b/tests/scripts/thread-cert/Cert_6_5_02_ChildResetReattach.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -37,9 +38,11 @@ ED = 2
 
 class Cert_6_5_2_ChildResetReattach(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -58,14 +61,15 @@ class Cert_6_5_2_ChildResetReattach(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         self.nodes[LEADER].remove_whitelist(self.nodes[ED].get_addr64())
@@ -73,12 +77,12 @@ class Cert_6_5_2_ChildResetReattach(unittest.TestCase):
 
         self.nodes[ED].reset()
         self._setUpEd()
-        time.sleep(5)
+        self.simulator.go(5)
         self.nodes[ED].start()
 
-        time.sleep(5)
+        self.simulator.go(5)
         self.nodes[LEADER].add_whitelist(self.nodes[ED].get_addr64())
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         addrs = self.nodes[ED].get_addrs()

--- a/tests/scripts/thread-cert/Cert_6_6_01_KeyIncrement.py
+++ b/tests/scripts/thread-cert/Cert_6_6_01_KeyIncrement.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -37,9 +38,11 @@ ED = 2
 
 class Cert_6_6_1_KeyIncrement(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -57,13 +60,15 @@ class Cert_6_6_1_KeyIncrement(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
+        self.assertEqual(self.nodes[LEADER].get_state(), "leader")
 
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), "child")
 
         addrs = self.nodes[ED].get_addrs()

--- a/tests/scripts/thread-cert/Cert_6_6_02_KeyIncrementRollOver.py
+++ b/tests/scripts/thread-cert/Cert_6_6_02_KeyIncrementRollOver.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -37,9 +38,11 @@ ED = 2
 
 class Cert_6_6_2_KeyIncrement1(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i, (i == ED))
+            self.nodes[i] = node.Node(i, (i == ED), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -58,14 +61,15 @@ class Cert_6_6_2_KeyIncrement1(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ED].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED].get_state(), 'child')
 
         addrs = self.nodes[ED].get_addrs()

--- a/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -41,9 +42,11 @@ MTDS = [SED1, ED1]
 
 class Cert_7_1_1_BorderRouterAsLeader(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i, (i in MTDS))
+            self.nodes[i] = node.Node(i, (i in MTDS), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -73,10 +76,11 @@ class Cert_7_1_1_BorderRouterAsLeader(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[LEADER].add_prefix('2001:2:0:1::/64', 'paros')
@@ -84,15 +88,15 @@ class Cert_7_1_1_BorderRouterAsLeader(unittest.TestCase):
         self.nodes[LEADER].register_netdata()
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[SED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         self.nodes[ED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         addrs = self.nodes[SED1].get_addrs()

--- a/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -41,9 +42,11 @@ MTDS = [ED2, SED2]
 
 class Cert_7_1_2_BorderRouterAsRouter(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i, (i in MTDS))
+            self.nodes[i] = node.Node(i, (i in MTDS), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -73,14 +76,15 @@ class Cert_7_1_2_BorderRouterAsRouter(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ROUTER].add_prefix('2001:2:0:1::/64', 'paros')
@@ -88,11 +92,11 @@ class Cert_7_1_2_BorderRouterAsRouter(unittest.TestCase):
         self.nodes[ROUTER].register_netdata()
 
         self.nodes[ED2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED2].get_state(), 'child')
 
         self.nodes[SED2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[SED2].get_state(), 'child')
 
         addrs = self.nodes[ED2].get_addrs()

--- a/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -41,9 +42,11 @@ MTDS = [SED1, ED1]
 
 class Cert_7_1_3_BorderRouterAsLeader(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i, (i in MTDS))
+            self.nodes[i] = node.Node(i, (i in MTDS), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -73,28 +76,29 @@ class Cert_7_1_3_BorderRouterAsLeader(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[SED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         self.nodes[ED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[LEADER].add_prefix('2001:2:0:1::/64', 'paros')
         self.nodes[LEADER].add_prefix('2001:2:0:2::/64', 'paro')
         self.nodes[LEADER].register_netdata()
-        time.sleep(5)
+        self.simulator.go(5)
 
         addrs = self.nodes[SED1].get_addrs()
         self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))

--- a/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -41,9 +42,11 @@ MTDS = [SED2, ED2]
 
 class Cert_7_1_4_BorderRouterAsRouter(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i, (i in MTDS))
+            self.nodes[i] = node.Node(i, (i in MTDS), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -73,28 +76,29 @@ class Cert_7_1_4_BorderRouterAsRouter(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED2].get_state(), 'child')
 
         self.nodes[SED2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[SED2].get_state(), 'child')
 
         self.nodes[ROUTER].add_prefix('2001:2:0:1::/64', 'paros')
         self.nodes[ROUTER].add_prefix('2001:2:0:2::/64', 'paro')
         self.nodes[ROUTER].register_netdata()
-        time.sleep(5)
+        self.simulator.go(5)
 
         addrs = self.nodes[ED2].get_addrs()
         self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))

--- a/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 LEADER = 1
@@ -41,9 +42,11 @@ MTDS = [ED2, SED2]
 
 class Cert_7_1_5_BorderRouterAsRouter(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i, (i in MTDS))
+            self.nodes[i] = node.Node(i, (i in MTDS), simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -73,28 +76,29 @@ class Cert_7_1_5_BorderRouterAsRouter(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
 
         self.nodes[ED2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED2].get_state(), 'child')
 
         self.nodes[SED2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[SED2].get_state(), 'child')
 
         self.nodes[ROUTER].add_prefix('2001:2:0:1::/64', 'paros')
         self.nodes[ROUTER].add_prefix('2001:2:0:2::/64', 'paro')
         self.nodes[ROUTER].register_netdata()
-        time.sleep(5)
+        self.simulator.go(5)
 
         addrs = self.nodes[ED2].get_addrs()
         self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))
@@ -112,7 +116,7 @@ class Cert_7_1_5_BorderRouterAsRouter(unittest.TestCase):
 
         self.nodes[ROUTER].add_prefix('2001:2:0:3::/64', 'paros')
         self.nodes[ROUTER].register_netdata()
-        time.sleep(5)
+        self.simulator.go(5)
 
         addrs = self.nodes[ED2].get_addrs()
         self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))

--- a/tests/scripts/thread-cert/Cert_8_1_02_Commissioning.py
+++ b/tests/scripts/thread-cert/Cert_8_1_02_Commissioning.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 COMMISSIONER = 1
@@ -37,6 +38,8 @@ JOINER = 2
 
 class Cert_8_1_02_Commissioning(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,3):
             self.nodes[i] = node.Node(i)
@@ -53,19 +56,20 @@ class Cert_8_1_02_Commissioning(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[COMMISSIONER].interface_up()
         self.nodes[COMMISSIONER].thread_start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'leader')
         self.nodes[COMMISSIONER].commissioner_start()
-        time.sleep(3)
+        self.simulator.go(3)
         self.nodes[COMMISSIONER].commissioner_add_joiner(self.nodes[JOINER].get_eui64(), 'OPENTHREAD')
 
         self.nodes[JOINER].interface_up()
         self.nodes[JOINER].joiner_start('DAERHTNEPO')
-        time.sleep(10)
+        self.simulator.go(10)
         self.assertNotEqual(self.nodes[JOINER].get_masterkey(), self.nodes[COMMISSIONER].get_masterkey())
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_8_2_01_JoinerRouter.py
+++ b/tests/scripts/thread-cert/Cert_8_2_01_JoinerRouter.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 COMMISSIONER = 1
@@ -38,6 +39,8 @@ JOINER = 3
 
 class Cert_8_2_01_JoinerRouter(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,4):
             self.nodes[i] = node.Node(i)
@@ -62,31 +65,32 @@ class Cert_8_2_01_JoinerRouter(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[COMMISSIONER].interface_up()
         self.nodes[COMMISSIONER].thread_start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'leader')
 
         self.nodes[COMMISSIONER].commissioner_start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.nodes[COMMISSIONER].commissioner_add_joiner(self.nodes[JOINER_ROUTER].get_eui64(), 'OPENTHREAD')
         self.nodes[COMMISSIONER].commissioner_add_joiner(self.nodes[JOINER].get_eui64(), 'OPENTHREAD2')
-        time.sleep(5)
+        self.simulator.go(5)
 
         self.nodes[COMMISSIONER].add_whitelist(self.nodes[JOINER_ROUTER].get_joiner_id())
         self.nodes[JOINER_ROUTER].add_whitelist(self.nodes[COMMISSIONER].get_addr64())
 
         self.nodes[JOINER_ROUTER].interface_up()
         self.nodes[JOINER_ROUTER].joiner_start('OPENTHREAD')
-        time.sleep(10)
+        self.simulator.go(10)
         self.assertEqual(self.nodes[JOINER_ROUTER].get_masterkey(), self.nodes[COMMISSIONER].get_masterkey())
 
         self.nodes[COMMISSIONER].add_whitelist(self.nodes[JOINER_ROUTER].get_addr64())
 
         self.nodes[JOINER_ROUTER].thread_start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[JOINER_ROUTER].get_state(), 'router')
 
         self.nodes[JOINER_ROUTER].add_whitelist(self.nodes[JOINER].get_joiner_id())
@@ -94,13 +98,13 @@ class Cert_8_2_01_JoinerRouter(unittest.TestCase):
 
         self.nodes[JOINER].interface_up()
         self.nodes[JOINER].joiner_start('OPENTHREAD2')
-        time.sleep(10)
+        self.simulator.go(10)
         self.assertEqual(self.nodes[JOINER].get_masterkey(), self.nodes[COMMISSIONER].get_masterkey())
 
         self.nodes[JOINER_ROUTER].add_whitelist(self.nodes[JOINER].get_addr64())
 
         self.nodes[JOINER].thread_start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[JOINER].get_state(), 'router')
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_8_2_02_JoinerRouter.py
+++ b/tests/scripts/thread-cert/Cert_8_2_02_JoinerRouter.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 COMMISSIONER = 1
@@ -38,9 +39,11 @@ JOINER = 3
 
 class Cert_8_2_02_JoinerRouter(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,4):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[COMMISSIONER].set_panid(0xface)
         self.nodes[COMMISSIONER].set_mode('rsdn')
@@ -62,31 +65,32 @@ class Cert_8_2_02_JoinerRouter(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[COMMISSIONER].interface_up()
         self.nodes[COMMISSIONER].thread_start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'leader')
 
         self.nodes[COMMISSIONER].commissioner_start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.nodes[COMMISSIONER].commissioner_add_joiner(self.nodes[JOINER_ROUTER].get_eui64(), 'OPENTHREAD')
         self.nodes[COMMISSIONER].commissioner_add_joiner(self.nodes[JOINER].get_eui64(), 'OPENTHREAD2')
-        time.sleep(5)
+        self.simulator.go(5)
 
         self.nodes[COMMISSIONER].add_whitelist(self.nodes[JOINER_ROUTER].get_joiner_id())
         self.nodes[JOINER_ROUTER].add_whitelist(self.nodes[COMMISSIONER].get_addr64())
 
         self.nodes[JOINER_ROUTER].interface_up()
         self.nodes[JOINER_ROUTER].joiner_start('OPENTHREAD')
-        time.sleep(10)
+        self.simulator.go(10)
         self.assertEqual(self.nodes[JOINER_ROUTER].get_masterkey(), self.nodes[COMMISSIONER].get_masterkey())
 
         self.nodes[COMMISSIONER].add_whitelist(self.nodes[JOINER_ROUTER].get_addr64())
 
         self.nodes[JOINER_ROUTER].thread_start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[JOINER_ROUTER].get_state(), 'router')
 
         self.nodes[JOINER_ROUTER].add_whitelist(self.nodes[JOINER].get_joiner_id())
@@ -94,7 +98,7 @@ class Cert_8_2_02_JoinerRouter(unittest.TestCase):
 
         self.nodes[JOINER].interface_up()
         self.nodes[JOINER].joiner_start('2DAERHTNEPO')
-        time.sleep(10)
+        self.simulator.go(10)
         self.assertNotEqual(self.nodes[JOINER].get_masterkey(), self.nodes[COMMISSIONER].get_masterkey())
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_9_2_04_ActiveDataset.py
+++ b/tests/scripts/thread-cert/Cert_9_2_04_ActiveDataset.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 COMMISSIONER = 1
@@ -37,9 +38,11 @@ LEADER = 2
 
 class Cert_9_2_15_PendingPartition(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,3):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[COMMISSIONER].set_active_dataset(10, panid=0xface, master_key='000102030405060708090a0b0c0d0e0f')
         self.nodes[COMMISSIONER].set_mode('rsdn')
@@ -53,24 +56,25 @@ class Cert_9_2_15_PendingPartition(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[COMMISSIONER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'router')
 
         self.nodes[COMMISSIONER].commissioner_start()
-        time.sleep(3)
+        self.simulator.go(3)
 
         self.nodes[COMMISSIONER].send_mgmt_active_set(active_timestamp=101,
                                                       channel_mask=0x001fffe0,
                                                       extended_panid='000db70000000000',
                                                       network_name='GRL')
-        time.sleep(3)
+        self.simulator.go(3)
         self.assertEqual(self.nodes[LEADER].get_network_name(), 'GRL')
 
         # Step 6
@@ -80,7 +84,7 @@ class Cert_9_2_15_PendingPartition(unittest.TestCase):
                                                       channel_mask=0x001fffe0,
                                                       extended_panid='000db70000000001',
                                                       network_name='threadcert')
-        time.sleep(3)
+        self.simulator.go(3)
         self.assertEqual(self.nodes[LEADER].get_network_name(), 'GRL')
 
         # Step 8
@@ -90,7 +94,7 @@ class Cert_9_2_15_PendingPartition(unittest.TestCase):
                                                       extended_panid='000db70000000000',
                                                       mesh_local='fd00:0db7::',
                                                       network_name='UL')
-        time.sleep(3)
+        self.simulator.go(3)
         self.assertEqual(self.nodes[LEADER].get_network_name(), 'GRL')
 
         # Step 10
@@ -101,7 +105,7 @@ class Cert_9_2_15_PendingPartition(unittest.TestCase):
                                                       master_key='00112233445566778899aabbccddeeff',
                                                       mesh_local='fd00:0db7::',
                                                       network_name='UL')
-        time.sleep(3)
+        self.simulator.go(3)
         self.assertEqual(self.nodes[LEADER].get_network_name(), 'GRL')
 
         # Step 12
@@ -113,7 +117,7 @@ class Cert_9_2_15_PendingPartition(unittest.TestCase):
                                                       mesh_local='fd00:0db7::',
                                                       network_name='UL',
                                                       panid=0xafce)
-        time.sleep(3)
+        self.simulator.go(3)
         self.assertEqual(self.nodes[LEADER].get_network_name(), 'GRL')
 
         # Step 14
@@ -123,7 +127,7 @@ class Cert_9_2_15_PendingPartition(unittest.TestCase):
                                                       extended_panid='000db70000000000',
                                                       network_name='UL',
                                                       binary='0b02abcd')
-        time.sleep(3)
+        self.simulator.go(3)
         self.assertEqual(self.nodes[LEADER].get_network_name(), 'GRL')
 
         # Step 16
@@ -132,7 +136,7 @@ class Cert_9_2_15_PendingPartition(unittest.TestCase):
                                                       channel_mask=0x001fffe0,
                                                       extended_panid='000db70000000000',
                                                       network_name='UL')
-        time.sleep(3)
+        self.simulator.go(3)
         self.assertEqual(self.nodes[LEADER].get_network_name(), 'GRL')
 
         # Step 18
@@ -142,7 +146,7 @@ class Cert_9_2_15_PendingPartition(unittest.TestCase):
                                                       extended_panid='000db70000000000',
                                                       network_name='UL',
                                                       binary='0806113320440000')
-        time.sleep(3)
+        self.simulator.go(3)
         self.assertEqual(self.nodes[LEADER].get_network_name(), 'UL')
 
         # Step 20
@@ -152,7 +156,7 @@ class Cert_9_2_15_PendingPartition(unittest.TestCase):
                                                       extended_panid='000db70000000000',
                                                       network_name='GRL',
                                                       binary='8202aa55')
-        time.sleep(3)
+        self.simulator.go(3)
         self.assertEqual(self.nodes[LEADER].get_network_name(), 'GRL')
 
         ipaddrs = self.nodes[COMMISSIONER].get_addrs()

--- a/tests/scripts/thread-cert/Cert_9_2_11_MasterKey.py
+++ b/tests/scripts/thread-cert/Cert_9_2_11_MasterKey.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 KEY1 = '000102030405060708090a0b0c0d0e0f'
@@ -48,9 +49,11 @@ MTDS = [ED1, SED1]
 
 class Cert_9_2_11_MasterKey(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,6):
-            self.nodes[i] = node.Node(i, (i in MTDS))
+            self.nodes[i] = node.Node(i, (i in MTDS), simulator=self.simulator)
 
         self.nodes[COMMISSIONER].set_active_dataset(10, channel=CHANNEL_INIT, panid=PANID_INIT, master_key=KEY1)
         self.nodes[COMMISSIONER].set_mode('rsdn')
@@ -92,35 +95,36 @@ class Cert_9_2_11_MasterKey(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[COMMISSIONER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'router')
         self.nodes[COMMISSIONER].commissioner_start()
-        time.sleep(3)
+        self.simulator.go(3)
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[SED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         self.nodes[COMMISSIONER].send_mgmt_pending_set(pending_timestamp=10,
                                                        active_timestamp=70,
                                                        delay_timer=10000,
                                                        master_key=KEY2)
-        time.sleep(310)
+        self.simulator.go(310)
 
         print(self.nodes[COMMISSIONER].get_masterkey())
         print(self.nodes[LEADER].get_masterkey())
@@ -143,7 +147,7 @@ class Cert_9_2_11_MasterKey(unittest.TestCase):
                                                        active_timestamp=30,
                                                        delay_timer=10000,
                                                        master_key=KEY1)
-        time.sleep(310)
+        self.simulator.go(310)
 
         print(self.nodes[COMMISSIONER].get_masterkey())
         print(self.nodes[LEADER].get_masterkey())

--- a/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
+++ b/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 COMMISSIONER = 1
@@ -39,9 +40,11 @@ ED1 = 4
 
 class Cert_9_2_13_EnergyScan(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i, (i == ED1))
+            self.nodes[i] = node.Node(i, (i == ED1), simulator=self.simulator)
 
         self.nodes[COMMISSIONER].set_panid(0xface)
         self.nodes[COMMISSIONER].set_mode('rsdn')
@@ -71,24 +74,25 @@ class Cert_9_2_13_EnergyScan(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[COMMISSIONER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'router')
         self.nodes[COMMISSIONER].commissioner_start()
-        time.sleep(3)
+        self.simulator.go(3)
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         ipaddrs = self.nodes[ROUTER1].get_addrs()

--- a/tests/scripts/thread-cert/Cert_9_2_14_PanIdQuery.py
+++ b/tests/scripts/thread-cert/Cert_9_2_14_PanIdQuery.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 COMMISSIONER = 1
@@ -39,9 +40,11 @@ LEADER2 = 4
 
 class Cert_9_2_14_PanIdQuery(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[COMMISSIONER].set_panid(0xface)
         self.nodes[COMMISSIONER].set_mode('rsdn')
@@ -71,24 +74,25 @@ class Cert_9_2_14_PanIdQuery(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER1].start()
-        self.nodes[LEADER1].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER1].get_state(), 'leader')
 
         self.nodes[COMMISSIONER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'router')
         self.nodes[COMMISSIONER].commissioner_start()
-        time.sleep(3)
+        self.simulator.go(3)
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[LEADER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER2].get_state(), 'leader')
 
         ipaddrs = self.nodes[ROUTER1].get_addrs()

--- a/tests/scripts/thread-cert/Cert_9_2_15_PendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_15_PendingPartition.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 CHANNEL_INIT = 19
@@ -44,9 +45,11 @@ ROUTER2 = 4
 
 class Cert_9_2_15_PendingPartition(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,5):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[COMMISSIONER].set_active_dataset(15, channel=CHANNEL_INIT, panid=PANID_INIT)
         self.nodes[COMMISSIONER].set_mode('rsdn')
@@ -82,30 +85,31 @@ class Cert_9_2_15_PendingPartition(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[COMMISSIONER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'router')
         self.nodes[COMMISSIONER].commissioner_start()
-        time.sleep(3)
+        self.simulator.go(3)
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[COMMISSIONER].send_mgmt_pending_set(pending_timestamp=10,
                                                        active_timestamp=70,
                                                        delay_timer=600000,
                                                        mesh_local='fd00:0db9::')
-        time.sleep(5)
+        self.simulator.go(5)
 
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.nodes[ROUTER2].reset()
@@ -116,12 +120,12 @@ class Cert_9_2_15_PendingPartition(unittest.TestCase):
                                                        delay_timer=200000,
                                                        mesh_local='fd00:0db7::',
                                                        panid=PANID_FINAL)
-        time.sleep(100)
+        self.simulator.go(100)
 
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
-        time.sleep(100)
+        self.simulator.go(100)
 
         self.assertEqual(self.nodes[COMMISSIONER].get_panid(), PANID_FINAL)
         self.assertEqual(self.nodes[LEADER].get_panid(), PANID_FINAL)

--- a/tests/scripts/thread-cert/Cert_9_2_17_Orphan.py
+++ b/tests/scripts/thread-cert/Cert_9_2_17_Orphan.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 CHANNEL1 = 11
@@ -43,9 +44,11 @@ ED1 = 3
 
 class Cert_9_2_17_Orphan(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,4):
-            self.nodes[i] = node.Node(i, (i == ED1))
+            self.nodes[i] = node.Node(i, (i == ED1), simulator=self.simulator)
 
         self.nodes[LEADER1].set_active_dataset(10, channel=CHANNEL1, panid=PANID_INIT, channel_mask=CHANNEL_MASK)
         self.nodes[LEADER1].set_mode('rsdn')
@@ -69,10 +72,11 @@ class Cert_9_2_17_Orphan(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def test(self):
         self.nodes[LEADER1].start()
-        self.nodes[LEADER1].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER1].get_state(), 'leader')
 
         self.nodes[LEADER2].start()
@@ -80,13 +84,13 @@ class Cert_9_2_17_Orphan(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER2].get_state(), 'leader')
 
         self.nodes[ED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[LEADER1].stop()
         self.nodes[LEADER2].add_whitelist(self.nodes[ED1].get_addr64())
         self.nodes[ED1].add_whitelist(self.nodes[LEADER2].get_addr64())
-        time.sleep(20)
+        self.simulator.go(20)
 
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
         self.assertEqual(self.nodes[ED1].get_channel(), CHANNEL2)

--- a/tests/scripts/thread-cert/Cert_9_2_18_RollBackActiveTimestamp.py
+++ b/tests/scripts/thread-cert/Cert_9_2_18_RollBackActiveTimestamp.py
@@ -30,6 +30,7 @@
 import time
 import unittest
 
+import config
 import node
 
 KEY1 = '00112233445566778899aabbccddeeff'
@@ -49,9 +50,11 @@ MTDS = [ED1, SED1]
 
 class Cert_9_2_18_RollBackActiveTimestamp(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,7):
-            self.nodes[i] = node.Node(i, (i in MTDS))
+            self.nodes[i] = node.Node(i, (i in MTDS), simulator=self.simulator)
 
         self.nodes[COMMISSIONER].set_active_dataset(1, channel=CHANNEL_INIT, panid=PANID_INIT, master_key=KEY1)
         self.nodes[COMMISSIONER].set_mode('rsdn')
@@ -104,43 +107,43 @@ class Cert_9_2_18_RollBackActiveTimestamp(unittest.TestCase):
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[COMMISSIONER].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'router')
         self.nodes[COMMISSIONER].commissioner_start()
-        time.sleep(3)
+        self.simulator.go(3)
 
         self.nodes[ROUTER1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
 
         self.nodes[ED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')
 
         self.nodes[SED1].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[SED1].get_state(), 'child')
 
         self.nodes[COMMISSIONER].send_mgmt_active_set(active_timestamp=20000,
                                                       network_name='GRL')
-        time.sleep(5)
+        self.simulator.go(5)
 
         self.nodes[COMMISSIONER].send_mgmt_pending_set(pending_timestamp=20,
                                                        active_timestamp=20,
                                                        delay_timer=20000,
                                                        network_name='Shouldnotbe')
-        time.sleep(5)
+        self.simulator.go(5)
 
         self.nodes[COMMISSIONER].send_mgmt_pending_set(pending_timestamp=20,
                                                        active_timestamp=20,
                                                        delay_timer=20000,
                                                        network_name='MyHouse',
                                                        master_key=KEY2)
-        time.sleep(310)
+        self.simulator.go(310)
 
         self.assertEqual(self.nodes[COMMISSIONER].get_masterkey(), KEY2)
         self.assertEqual(self.nodes[LEADER].get_masterkey(), KEY2)
@@ -150,7 +153,7 @@ class Cert_9_2_18_RollBackActiveTimestamp(unittest.TestCase):
         self.assertEqual(self.nodes[ROUTER2].get_masterkey(), KEY1)
 
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'leader')
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Makefile.am
+++ b/tests/scripts/thread-cert/Makefile.am
@@ -133,6 +133,7 @@ EXTRA_DIST                                                         = \
     network_layer.py                                                 \
     node.py                                                          \
     node_cli.py                                                      \
+    simulator.py                                                     \
     sniffer.py                                                       \
     sniffer_transport.py                                             \
     test_coap.py                                                     \

--- a/tests/scripts/thread-cert/config.py
+++ b/tests/scripts/thread-cert/config.py
@@ -37,6 +37,7 @@ import mle
 import net_crypto
 import network_data
 import network_layer
+import simulator
 import sniffer
 
 MESH_LOCAL_PREFIX = 'fdde:ad00:beef::/64'
@@ -66,6 +67,8 @@ INFINITE_COST_TIMEOUT = 90
 
 MAX_ADVERTISEMENT_INTERVAL = 32
 MLE_END_DEVICE_TIMEOUT = 100
+
+VIRTUAL_TIME = bool(os.getenv('VIRTUAL_TIME', False))
 
 def create_default_network_data_prefix_sub_tlvs_factories():
     return {
@@ -331,3 +334,9 @@ def create_default_thread_message_factory(master_key=DEFAULT_MASTER_KEY):
 
 def create_default_thread_sniffer(nodeid=SNIFFER_ID):
     return sniffer.Sniffer(nodeid, create_default_thread_message_factory())
+
+
+def create_default_simulator():
+    if VIRTUAL_TIME:
+        return simulator.VirtualTime()
+    return simulator.RealTime()

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -38,9 +38,11 @@ import unittest
 import config
 
 class Node:
-    def __init__(self, nodeid, is_mtd=False):
+    def __init__(self, nodeid, is_mtd=False, simulator=None):
+        self.simulator = simulator
+
         if sys.platform != 'win32':
-            self.interface = node_cli.otCli(nodeid, is_mtd)
+            self.interface = node_cli.otCli(nodeid, is_mtd, simulator=simulator)
         else:
             self.interface = node_api.otApi(nodeid)
 
@@ -239,7 +241,7 @@ class Node:
     def scan(self):
         return self.interface.scan()
 
-    def ping(self, ipaddr, num_responses=1, size=None, timeout=5000):
+    def ping(self, ipaddr, num_responses=1, size=None, timeout=5):
         return self.interface.ping(ipaddr, num_responses, size, timeout)
 
     def reset(self):

--- a/tests/scripts/thread-cert/simulator.py
+++ b/tests/scripts/thread-cert/simulator.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python
+#
+#  Copyright (c) 2018, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import bisect
+import cmd
+import os
+import socket
+import struct
+import time
+import sys
+
+import io
+import config
+import message
+
+class RealTime:
+
+    def __init__(self):
+        self._sniffer = config.create_default_thread_sniffer()
+        self._sniffer.start()
+
+    def set_lowpan_context(self, cid, prefix):
+        self._sniffer.set_lowpan_context(cid, prefix)
+
+    def get_messages_sent_by(self, nodeid):
+        return self._sniffer.get_messages_sent_by(nodeid)
+
+    def go(self, duration):
+        time.sleep(duration)
+
+class VirtualTime:
+
+    BASE_PORT = 9000
+    MAX_NODES = 34
+    PORT_OFFSET = int(os.getenv('PORT_OFFSET', "0"))
+
+    def __init__(self):
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+        ip = '127.0.0.1'
+        self.port = self.BASE_PORT + (self.PORT_OFFSET * self.MAX_NODES)
+        self.sock.bind((ip, self.port))
+
+        self.devices = {}
+        self.event_queue = []
+        self.event_count = 0
+        self.current_time = 0
+        self.current_event = None;
+
+        self._message_factory = config.create_default_thread_message_factory()
+
+    def __del__(self):
+        self.sock.close()
+
+    def _add_message(self, nodeid, message):
+        addr = ('127.0.0.1', self.port + nodeid)
+
+        # Ignore any exceptions
+        try:
+            msg = self._message_factory.create(io.BytesIO(message))
+
+            if msg is not None:
+                self.devices[addr]['msgs'].append(msg)
+
+        except Exception as e:
+            # Just print the exception to the console
+            print("EXCEPTION: %s" % e)
+            pass
+
+    def set_lowpan_context(self, cid, prefix):
+        self._message_factory.set_lowpan_context(cid, prefix)
+
+    def get_messages_sent_by(self, nodeid):
+        """ Get sniffed messages.
+
+        Note! This method flushes the message queue so calling this method again will return only the newly logged messages.
+
+        Args:
+            nodeid (int): node id
+
+        Returns:
+            MessagesSet: a set with received messages.
+        """
+        addr = ('127.0.0.1', self.port + nodeid)
+
+        messages = self.devices[addr]['msgs']
+        self.devices[addr]['msgs'] = []
+
+        return message.MessagesSet(messages)
+
+    def receive_events(self):
+
+        if self.current_event is None:
+            self.sock.setblocking(0)
+        else:
+            self.sock.setblocking(1)
+
+        while True:
+            try:
+                msg, addr = self.sock.recvfrom(1024)
+            except socket.error:
+                break
+
+            if addr not in self.devices:
+                self.devices[addr] = {}
+                self.devices[addr]['alarm'] = None
+                self.devices[addr]['msgs'] = []
+                self.devices[addr]['time'] = self.current_time
+                #print "New device:", addr, self.devices
+
+            delay, type, datalen = struct.unpack('=QBH', msg[:11])
+            data = msg[11:]
+
+            event_time = self.current_time + delay
+
+            if type == 0:
+                # remove any existing alarm event for device
+                try:
+                    self.event_queue.remove(self.devices[addr]['alarm'])
+                    #print "-- Remove\t", self.devices[addr]['alarm']
+                    self.devices[addr]['alarm'] = None
+                except ValueError:
+                    pass
+
+                # add alarm event to event queue
+                event = (event_time, addr, type, datalen)
+                #print "-- Enqueue\t", event, delay, self.current_time
+                bisect.insort(self.event_queue, event)
+                self.devices[addr]['alarm'] = event
+
+                if self.current_event is not None and self.current_event[1] == addr:
+                    #print "Done\t", self.current_event
+                    self.current_event = None
+                    return
+
+            elif type == 1:
+                # add radio receive events event queue
+                for device in self.devices:
+                    if device != addr:
+                        event = (event_time, device, type, datalen, data)
+                        #print "-- Enqueue\t", event
+                        bisect.insort(self.event_queue, event)
+
+                self._add_message(addr[1] - self.port, data)
+
+                # add radio transmit done events to event queue
+                event = (event_time, addr, type, datalen, data)
+                bisect.insort(self.event_queue, event)
+
+    def process_next_event(self):
+
+        if self.current_event != None:
+            return
+
+        #print "Events", len(self.event_queue)
+        count = 0
+        for event in self.event_queue:
+            #print count, event
+            count += 1
+
+        # process next event
+        try:
+            event = self.event_queue.pop(0)
+        except IndexError:
+            return
+
+        #print "Pop\t", event
+
+        if len(event) == 4:
+            event_time, addr, type, datalen = event
+        else:
+            event_time, addr, type, datalen, data = event
+
+        self.event_count += 1
+        self.current_event = event
+
+        assert(event_time >= self.current_time)
+        self.current_time = event_time
+
+        elapsed = event_time - self.devices[addr]['time']
+        self.devices[addr]['time'] = event_time
+
+        message = struct.pack('=QBH', elapsed, type, datalen)
+
+        if type == 0:
+            self.devices[addr]['alarm'] = None
+            self.sock.sendto(message, addr)
+        elif type == 1:
+            message += data
+            self.sock.sendto(message, addr)
+
+    def sync_devices(self):
+        for addr in self.devices:
+            elapsed = self.current_time - self.devices[addr]['time']
+            self.devices[addr]['time'] = self.current_time
+            message = struct.pack('=QBH', elapsed, 0, 0)
+            self.sock.sendto(message, addr)
+
+    def go(self, duration):
+
+        duration = int(duration) * 1000000
+
+        start_time = self.current_time
+        self.current_event = None
+
+        print "running for %d us" % duration
+
+        self.receive_events()
+
+        while (self.current_time - start_time) < duration:
+            self.process_next_event()
+            self.receive_events()
+
+        self.sync_devices()

--- a/tests/scripts/thread-cert/test_service.py
+++ b/tests/scripts/thread-cert/test_service.py
@@ -50,9 +50,11 @@ SRV_1_SERVER_DATA = 'qux'
 
 class Test_Service(unittest.TestCase):
     def setUp(self):
+        self.simulator = config.create_default_simulator()
+
         self.nodes = {}
         for i in range(1,4):
-            self.nodes[i] = node.Node(i)
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
 
         self.nodes[LEADER].set_panid(0xface)
         self.nodes[LEADER].set_mode('rsdn')
@@ -84,6 +86,7 @@ class Test_Service(unittest.TestCase):
         for node in list(self.nodes.values()):
             node.stop()
         del self.nodes
+        del self.simulator
 
     def hasAloc(self, node_id, service_id):
         for addr in self.nodes[node_id].get_ip6_address(config.ADDRESS_TYPE.ALOC):
@@ -100,16 +103,16 @@ class Test_Service(unittest.TestCase):
 
     def failToPingFromAll(self, addr):
         for node in list(self.nodes.values()):
-            self.assertFalse(node.ping(addr, timeout=3000))
+            self.assertFalse(node.ping(addr, timeout=3))
 
     def test(self):
         self.nodes[LEADER].start()
-        self.nodes[LEADER].set_state('leader')
+        self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
         self.nodes[ROUTER2].start()
-        time.sleep(5)
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
@@ -122,7 +125,7 @@ class Test_Service(unittest.TestCase):
 
         self.nodes[ROUTER1].add_service(SRV_0_ENT_NUMBER, SRV_0_SERVICE_DATA, SRV_0_SERVER_DATA)
         self.nodes[ROUTER1].register_netdata()
-        time.sleep(2)
+        self.simulator.go(2)
 
         self.assertEqual(self.hasAloc(LEADER, SRV_0_ID), False)
         self.assertEqual(self.hasAloc(LEADER, SRV_1_ID), False)
@@ -136,7 +139,7 @@ class Test_Service(unittest.TestCase):
 
         self.nodes[LEADER].add_service(SRV_0_ENT_NUMBER, SRV_0_SERVICE_DATA, SRV_0_SERVER_DATA)
         self.nodes[LEADER].register_netdata()
-        time.sleep(2)
+        self.simulator.go(2)
 
         self.assertEqual(self.hasAloc(LEADER, SRV_0_ID), True)
         self.assertEqual(self.hasAloc(LEADER, SRV_1_ID), False)
@@ -149,7 +152,7 @@ class Test_Service(unittest.TestCase):
 
         self.nodes[ROUTER2].add_service(SRV_1_ENT_NUMBER, SRV_1_SERVICE_DATA, SRV_1_SERVER_DATA)
         self.nodes[ROUTER2].register_netdata()
-        time.sleep(2)
+        self.simulator.go(2)
 
         self.assertEqual(self.hasAloc(LEADER, SRV_0_ID), True)
         self.assertEqual(self.hasAloc(LEADER, SRV_1_ID), False)
@@ -164,7 +167,7 @@ class Test_Service(unittest.TestCase):
 
         self.nodes[ROUTER1].remove_service(SRV_0_ENT_NUMBER, SRV_0_SERVICE_DATA)
         self.nodes[ROUTER1].register_netdata()
-        time.sleep(2)
+        self.simulator.go(2)
 
         self.assertEqual(self.hasAloc(LEADER, SRV_0_ID), True)
         self.assertEqual(self.hasAloc(LEADER, SRV_1_ID), False)
@@ -178,7 +181,7 @@ class Test_Service(unittest.TestCase):
 
         self.nodes[LEADER].remove_service(SRV_0_ENT_NUMBER, SRV_0_SERVICE_DATA)
         self.nodes[LEADER].register_netdata()
-        time.sleep(2)
+        self.simulator.go(2)
 
         self.assertEqual(self.hasAloc(LEADER, SRV_0_ID), False)
         self.assertEqual(self.hasAloc(LEADER, SRV_1_ID), False)
@@ -192,7 +195,7 @@ class Test_Service(unittest.TestCase):
 
         self.nodes[ROUTER2].remove_service(SRV_1_ENT_NUMBER, SRV_1_SERVICE_DATA)
         self.nodes[ROUTER2].register_netdata()
-        time.sleep(2)
+        self.simulator.go(2)
 
         self.assertEqual(self.hasAloc(LEADER, SRV_0_ID), False)
         self.assertEqual(self.hasAloc(LEADER, SRV_1_ID), False)


### PR DESCRIPTION
Utilizing virtual time reduces Travis' test execution time by about 20 minutes.

This commit adds the following features:

- Example posix drivers to support virtual time simulation, allowing tests
  to run faster than real time.

- A python-based simulation driver that coordinates the virtual time
  simulations.  Each alarm event and message transmission across all nodes
  are scheduled in a single discrete time event queue.  As a result, only
  a single node is making forward progress at a time.

- Updated tests to utilize new virtual-time simulator, allowing them to run
  faster than real time.

- To enable virtual time feature, define VIRTUAL_TIME=1 env var and set
  CPPFLAGS=-DOPENTHREAD_POSIX_VIRTUAL_TIME=1.