### PR TITLE
 [mle] update address registration (SPEC-712, SPEC-721)

### DIFF
--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -113,6 +113,7 @@ struct ChildInfo
     uint32_t         mTimeout;       ///< Timeout
     uint16_t         mRloc16;        ///< RLOC16
     uint8_t          mMode;          ///< The MLE device mode
+    uint8_t          mMlIid[8];      ///< Mesh Local IID
 };
 
 }  // namespace Settings

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1150,13 +1150,14 @@ protected:
     /**
      * This method appends an Address Registration TLV to a message.
      *
-     * @param[in]  aMessage  A reference to the message.
+     * @param[in]  aMessage    A reference to the message.
+     * @param[in]  aWithMlEid  A boolean indicates whether to append Mesh Local EID.
      *
      * @retval OT_ERROR_NONE     Successfully appended the Address Registration TLV.
      * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Address Registration TLV.
      *
      */
-    otError AppendAddressRegistration(Message &aMessage);
+    otError AppendAddressRegistration(Message &aMessage, bool aWithMlEid);
 
     /**
      * This method appends a Active Timestamp TLV to a message.

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -78,6 +78,21 @@ exit:
     return retval;
 }
 
+otError Child::GetMeshLocalIp6Address(Instance &aInstance, Ip6::Address &aAddress) const
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(!IsAllZero(mMeshLocalIid, sizeof(mMeshLocalIid)), error = OT_ERROR_NOT_FOUND);
+
+    memcpy(aAddress.mFields.m8, aInstance.GetThreadNetif().GetMle().GetMeshLocalPrefix(),
+           Ip6::Address::kMeshLocalPrefixSize);
+
+    aAddress.SetIid(mMeshLocalIid);
+
+exit:
+    return error;
+}
+
 otError Child::GetNextIp6Address(Instance &aInstance, Ip6AddressIterator &aIterator, Ip6::Address &aAddress) const
 {
     otError error = OT_ERROR_NONE;
@@ -88,14 +103,7 @@ otError Child::GetNextIp6Address(Instance &aInstance, Ip6AddressIterator &aItera
     if (aIterator.Get() == 0)
     {
         aIterator.Increment();
-
-        if (!IsAllZero(mMeshLocalIid, sizeof(mMeshLocalIid)))
-        {
-            memcpy(aAddress.mFields.m8, aInstance.GetThreadNetif().GetMle().GetMeshLocalPrefix(),
-                   Ip6::Address::kMeshLocalPrefixSize);
-            aAddress.SetIid(mMeshLocalIid);
-            ExitNow();
-        }
+        VerifyOrExit(GetMeshLocalIp6Address(aInstance, aAddress) == OT_ERROR_NOT_FOUND);
     }
 
     index = aIterator.Get() - 1;

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -421,6 +421,18 @@ public:
     void ClearIp6Addresses(void);
 
     /**
+     * This method gets the mesh-local IPv6 address.
+     *
+     * @param[in]    aInstance           A reference to the OpenThread instance.
+     * @param[out]   aAddress            A reference to an IPv6 address to provide address (if any).
+     *
+     * @retval       OT_ERROR_NONE       Successfully found the mesh-local address and updated @p aAddress.
+     * @retval       OT_ERROR_NOT_FOUND  No mesh-local IPv6 address in the IPv6 address list.
+     *
+     */
+    otError GetMeshLocalIp6Address(Instance &aInstance, Ip6::Address &aAddress) const;
+
+    /**
      * This method gets the next IPv6 address in the list.
      *
      * @param[in]    aInstance           A reference to the OpenThread instance.


### PR DESCRIPTION
In Thread 1.1.1 Specification
Section 4.7.1
>   If the Child ID Request included an Address Registration TLV, the Parent echoes back any addresses other than the ML-EID that it has stored.
>   The ML-EID address is always registered and does not need to be acknowledged in this fashion.

Section 4.7.5 when introducing keep-alive messages
>   The Address Registration TLVs are a complete list of any non-link-local, non-mesh-local addresses that the Child has configured.

Without this update, some issues would be raised with interop with ARM Testbed.