### PR TITLE
[child] adding Child::GetMeshLocalIp6Address()

### DIFF
--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -78,6 +78,21 @@ exit:
     return retval;
 }
 
+otError Child::GetMeshLocalIp6Address(Instance &aInstance, Ip6::Address &aAddress) const
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(!IsAllZero(mMeshLocalIid, sizeof(mMeshLocalIid)), error = OT_ERROR_NOT_FOUND);
+
+    memcpy(aAddress.mFields.m8, aInstance.GetThreadNetif().GetMle().GetMeshLocalPrefix(),
+           Ip6::Address::kMeshLocalPrefixSize);
+
+    aAddress.SetIid(mMeshLocalIid);
+
+exit:
+    return error;
+}
+
 otError Child::GetNextIp6Address(Instance &aInstance, Ip6AddressIterator &aIterator, Ip6::Address &aAddress) const
 {
     otError error = OT_ERROR_NONE;
@@ -88,14 +103,7 @@ otError Child::GetNextIp6Address(Instance &aInstance, Ip6AddressIterator &aItera
     if (aIterator.Get() == 0)
     {
         aIterator.Increment();
-
-        if (!IsAllZero(mMeshLocalIid, sizeof(mMeshLocalIid)))
-        {
-            memcpy(aAddress.mFields.m8, aInstance.GetThreadNetif().GetMle().GetMeshLocalPrefix(),
-                   Ip6::Address::kMeshLocalPrefixSize);
-            aAddress.SetIid(mMeshLocalIid);
-            ExitNow();
-        }
+        VerifyOrExit(GetMeshLocalIp6Address(aInstance, aAddress) == OT_ERROR_NOT_FOUND);
     }
 
     index = aIterator.Get() - 1;

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -421,6 +421,18 @@ public:
     void ClearIp6Addresses(void);
 
     /**
+     * This method gets the mesh-local IPv6 address.
+     *
+     * @param[in]    aInstance           A reference to the OpenThread instance.
+     * @param[out]   aAddress            A reference to an IPv6 address to provide address (if any).
+     *
+     * @retval       OT_ERROR_NONE       Successfully found the mesh-local address and updated @p aAddress.
+     * @retval       OT_ERROR_NOT_FOUND  No mesh-local IPv6 address in the IPv6 address list.
+     *
+     */
+    otError GetMeshLocalIp6Address(Instance &aInstance, Ip6::Address &aAddress) const;
+
+    /**
      * This method gets the next IPv6 address in the list.
      *
      * @param[in]    aInstance           A reference to the OpenThread instance.


### PR DESCRIPTION
This commit adds a new method `Child::GetMeshLocalIp6Address()`
to get the mesh-local IPv6 address registered by a child. The
unit test `test_child` is also updated to verify the new method.