### PR TITLE
[mle] add attach attempts with the network configuration in the received announce message

### DIFF
--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -1215,4 +1215,14 @@
 #define OPENTHREAD_CONFIG_DISABLE_CCA_ON_LAST_ATTEMPT           0
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_MAX_ANNOUNCE_ATTACH_ATTEMPTS
+ *
+ * Maximum number of attach attempts with the network configurations in the received announce message
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MAX_ANNOUNCE_ATTACH_ATTEMPTS
+#define OPENTHREAD_CONFIG_MAX_ANNOUNCE_ATTACH_ATTEMPTS              4
+#endif
+
 #endif  // OPENTHREAD_CORE_DEFAULT_CONFIG_H_

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1394,6 +1394,7 @@ protected:
         kReattachPending    = 3,   ///< Reattach using stored Pending Dataset
     };
     ReattachState mReattachState;
+    uint8_t mAnnounceAttachAttempts;
 
     TimerMilli mParentRequestTimer;          ///< The timer for driving the Parent Request process.
     TimerMilli mDelayedResponseTimer;        ///< The timer to delay MLE responses.


### PR DESCRIPTION
Fix the unstable Cert_9_2_12

The device would `SendAnnounce()` on its original channel after it attaches successfully on new channel, causing Its neighbor on original channel trying to attach on the new channel even before the device itself become router.  There are chances that the device could not retrieve its original router id (already in use by other devices), which would cause it to remove all its children, and drop following Child ID Request, fail to attach the neighbor.

This PR gives the neighbor more chances to attach on the new channel before switch back to its original channel.