### PR TITLE
[mle] fix REED's failing to become router due to the invalid soliciting state

### DIFF
--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -208,6 +208,18 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_ADDRESS_SOLICIT_RETRY_DELAY
+ *
+ * Minimum delay for next address solicit attempt (in seconds).
+ *
+ * Default: 10 seconds
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ADDRESS_SOLICIT_RETRY_DELAY
+#define OPENTHREAD_CONFIG_ADDRESS_SOLICIT_RETRY_DELAY          10
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_ADDRESS_QUERY_INITIAL_RETRY_DELAY
  *
  * Initial retry delay for address query (in seconds).

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -878,12 +878,12 @@ private:
     uint8_t mLeaderWeight;
     uint32_t mFixedLeaderPartitionId;  ///< only for certification testing
     bool mRouterRoleEnabled : 1;
-    bool mAddressSolicitPending : 1;
 
     uint8_t mRouterId;
     uint8_t mPreviousRouterId;
     uint32_t mPreviousPartitionId;
 
+    uint8_t mAddressSolicitDelayTimer;
     uint8_t mRouterSelectionJitter;         ///< The variable to save the assigned jitter value.
     uint8_t mRouterSelectionJitterTimeout;  ///< The Timeout prior to request/release Router ID.
 


### PR DESCRIPTION
It would take some time for the Leader to establish the routing to the new router in linear
topology, which may happenly cause following FTD trapped in REED state because Leader
would drop the address reply as it thinks the REED's parent is not reachable in this
time window. And the REED would not retry any further as the flag mAddressSolicitPending is
only be cleared when receiving the address reply.

This commit allows further address solicit attempt under proper condition and restricts the interval
between two sucessive address solicit attempts as well.