### PR TITLE
[mac-frame] update Mac::Address to track its type (Short vs Extended)

### DIFF
--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -170,7 +170,13 @@ void Address::SetIid(const Mac::ExtAddress &aEui64)
 void Address::ToExtAddress(Mac::ExtAddress &aExtAddress) const
 {
     memcpy(aExtAddress.m8, mFields.m8 + kInterfaceIdentifierOffset, sizeof(aExtAddress.m8));
-    aExtAddress.m8[0] ^= 0x02;
+    aExtAddress.ToggleLocal();
+}
+
+void Address::ToExtAddress(Mac::Address &aMacAddress) const
+{
+    aMacAddress.SetExtended(mFields.m8 + kInterfaceIdentifierOffset, /* reverse */ false);
+    aMacAddress.GetExtended().ToggleLocal();
 }
 
 uint8_t Address::GetScope(void) const

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -306,6 +306,14 @@ public:
     void ToExtAddress(Mac::ExtAddress &aExtAddress) const;
 
     /**
+     * This method converts the IPv6 Interface Identifier to an IEEE 802.15.4 MAC Address.
+     *
+     * @param[out]  aMacAddress  A reference to the MAC address.
+     *
+     */
+    void ToExtAddress(Mac::Address &aMacAddress) const;
+
+    /**
      * This method returns the IPv6 address scope.
      *
      * @returns The IPv6 address scope.

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -69,17 +69,17 @@ otError Lowpan::ComputeIid(const Mac::Address &aMacAddr, const Context &aContext
 {
     otError error = OT_ERROR_NONE;
 
-    switch (aMacAddr.mLength)
+    switch (aMacAddr.GetType())
     {
-    case 2:
+    case Mac::Address::kTypeShort:
         aIpAddress.mFields.m16[4] = HostSwap16(0x0000);
         aIpAddress.mFields.m16[5] = HostSwap16(0x00ff);
         aIpAddress.mFields.m16[6] = HostSwap16(0xfe00);
-        aIpAddress.mFields.m16[7] = HostSwap16(aMacAddr.mShortAddress);
+        aIpAddress.mFields.m16[7] = HostSwap16(aMacAddr.GetShort());
         break;
 
-    case Ip6::Address::kInterfaceIdentifierSize:
-        aIpAddress.SetIid(aMacAddr.mExtAddress);
+    case Mac::Address::kTypeExtended:
+        aIpAddress.SetIid(aMacAddr.GetExtended());
         break;
 
     default:
@@ -114,8 +114,7 @@ int Lowpan::CompressSourceIid(const Mac::Address &aMacAddr, const Ip6::Address &
     }
     else
     {
-        tmp.mLength = sizeof(tmp.mShortAddress);
-        tmp.mShortAddress = HostSwap16(aIpAddr.mFields.m16[7]);
+        tmp.SetShort(HostSwap16(aIpAddr.mFields.m16[7]));
         ComputeIid(tmp, aContext, ipaddr);
 
         if (memcmp(ipaddr.GetIid(), aIpAddr.GetIid(), Ip6::Address::kInterfaceIdentifierSize) == 0)
@@ -151,8 +150,7 @@ int Lowpan::CompressDestinationIid(const Mac::Address &aMacAddr, const Ip6::Addr
     }
     else
     {
-        tmp.mLength = sizeof(tmp.mShortAddress);
-        tmp.mShortAddress = HostSwap16(aIpAddr.mFields.m16[7]);
+        tmp.SetShort(HostSwap16(aIpAddr.mFields.m16[7]));
         ComputeIid(tmp, aContext, ipaddr);
 
         if (memcmp(ipaddr.GetIid(), aIpAddr.GetIid(), Ip6::Address::kInterfaceIdentifierSize) == 0)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3427,14 +3427,17 @@ Neighbor *Mle::GetNeighbor(const Mac::Address &aAddress)
 {
     Neighbor *neighbor = NULL;
 
-    switch (aAddress.mLength)
+    switch (aAddress.GetType())
     {
-    case 2:
-        neighbor = GetNeighbor(aAddress.mShortAddress);
+    case Mac::Address::kTypeShort:
+        neighbor = GetNeighbor(aAddress.GetShort());
         break;
 
-    case 8:
-        neighbor = GetNeighbor(aAddress.mExtAddress);
+    case Mac::Address::kTypeExtended:
+        neighbor = GetNeighbor(aAddress.GetExtended());
+        break;
+
+    default:
         break;
     }
 

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -228,13 +228,11 @@ const Mac::Address &Child::GetMacAddress(Mac::Address &aMacAddress) const
 {
     if (mUseShortAddress)
     {
-        aMacAddress.mShortAddress = GetRloc16();
-        aMacAddress.mLength = sizeof(aMacAddress.mShortAddress);
+        aMacAddress.SetShort(GetRloc16());
     }
     else
     {
-        aMacAddress.mExtAddress = GetExtAddress();
-        aMacAddress.mLength = sizeof(aMacAddress.mExtAddress);
+        aMacAddress.SetExtended(GetExtAddress());
     }
 
     return aMacAddress;

--- a/tests/unit/test_lowpan.hpp
+++ b/tests/unit/test_lowpan.hpp
@@ -74,8 +74,7 @@ public:
      *
      */
     void SetMacSource(const uint8_t *aAddress) {
-        mMacSource.mLength = OT_EXT_ADDRESS_SIZE;
-        memcpy(&mMacSource.mExtAddress, aAddress, mMacSource.mLength);
+        mMacSource.SetExtended(aAddress, /* reverse */ false);
     }
 
     /**
@@ -85,8 +84,7 @@ public:
      *
      */
     void SetMacSource(uint16_t aAddress) {
-        mMacSource.mLength = 2;
-        mMacSource.mShortAddress = aAddress;
+        mMacSource.SetShort(aAddress);
     }
 
     /**
@@ -96,8 +94,7 @@ public:
      *
      */
     void SetMacDestination(const uint8_t *aAddress) {
-        mMacDestination.mLength = OT_EXT_ADDRESS_SIZE;
-        memcpy(&mMacDestination.mExtAddress, aAddress, mMacDestination.mLength);
+        mMacDestination.SetExtended(aAddress, /* reverse */ false);
     }
 
     /**
@@ -107,8 +104,7 @@ public:
      *
      */
     void SetMacDestination(uint16_t aAddress) {
-        mMacDestination.mLength = 2;
-        mMacDestination.mShortAddress = aAddress;
+        mMacDestination.SetShort(aAddress);
     }
 
     /**


### PR DESCRIPTION
This commit updates the implementation of `Mac::Address` class by
adding getter and setter and other helper methods. When the address
is updated using the setter methods (`SetShort()` or `SetExtended()`
the `Address` class itself will update its type (remembering whether
it is an IEEE 802.15.4 Short Address or an Extended Address). This
helps simplify how this class is used in other modules.