### PR TITLE
[mle] delay to send announce for FTD

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -649,13 +649,8 @@ otError Mle::SetStateChild(uint16_t aRloc16)
     netif.GetIp6().SetForwardingEnabled(false);
     netif.GetIp6().GetMpl().SetTimerExpirations(kMplChildDataMessageTimerExpirations);
 
-    // Once the Thread device receives the new Active Commissioning Dataset, the device MUST
-    // transmit its own Announce messages on the channel it was on prior to the attachment.
-    if (mPreviousPanId != Mac::kPanIdBroadcast)
-    {
-        mPreviousPanId = Mac::kPanIdBroadcast;
-        netif.GetAnnounceBeginServer().SendAnnounce(1 << mPreviousChannel);
-    }
+    // send announce after attached if needed
+    InformPreviousChannel();
 
 #if OPENTHREAD_CONFIG_ENABLE_PERIODIC_PARENT_SEARCH
     UpdateParentSearchState();
@@ -668,6 +663,22 @@ otError Mle::SetStateChild(uint16_t aRloc16)
 
     otLogInfoMle(GetInstance(), "Role -> Child");
     return OT_ERROR_NONE;
+}
+
+void Mle::InformPreviousChannel(void)
+{
+    VerifyOrExit(mPreviousPanId != Mac::kPanIdBroadcast);
+
+    if ((mDeviceMode & ModeTlv::kModeFFD) == 0 ||
+        mRole == OT_DEVICE_ROLE_ROUTER ||
+        GetNetif().GetMle().GetRouterSelectionJitterTimeout() == 0)
+    {
+        mPreviousPanId = Mac::kPanIdBroadcast;
+        GetNetif().GetAnnounceBeginServer().SendAnnounce(1 << mPreviousChannel);
+    }
+
+exit:
+    return;
 }
 
 otError Mle::SetTimeout(uint32_t aTimeout)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -668,6 +668,7 @@ otError Mle::SetStateChild(uint16_t aRloc16)
 void Mle::InformPreviousChannel(void)
 {
     VerifyOrExit(mPreviousPanId != Mac::kPanIdBroadcast);
+    VerifyOrExit(mRole == OT_DEVICE_ROLE_CHILD || mRole == OT_DEVICE_ROLE_ROUTER);
 
     if ((mDeviceMode & ModeTlv::kModeFFD) == 0 ||
         mRole == OT_DEVICE_ROLE_ROUTER ||

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1360,6 +1360,16 @@ protected:
      */
     void LogMleMessage(const char *aLogMessage, const Ip6::Address &aAddress, uint16_t aRloc) const;
 
+    /**
+     * This method triggers MLE Announce on previous channel after the Thread device successfully
+     * attaches and receives the new Active Commissioning Dataset if needed.
+     *
+     * MTD would send Announce immediately after attached.
+     * FTD would delay to send Announce after it has become Router or it decided to stay in REED role.
+     *
+     */
+    void InformPreviousChannel(void);
+
     LeaderDataTlv mLeaderData;              ///< Last received Leader Data TLV.
     bool mRetrieveNewNetworkData;           ///< Indicating new Network Data is needed if set.
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1365,7 +1365,7 @@ protected:
      * attaches and receives the new Active Commissioning Dataset if needed.
      *
      * MTD would send Announce immediately after attached.
-     * FTD would delay to send Announce after it has become Router or it decided to stay in REED role.
+     * FTD would delay to send Announce after tried to become Router or decided to stay in REED role.
      *
      */
     void InformPreviousChannel(void);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1872,6 +1872,11 @@ void MleRouter::HandleStateUpdateTimer(void)
                 // upgrade to Router
                 BecomeRouter(ThreadStatusTlv::kTooFewRouters);
             }
+            else
+            {
+                // send announce after decided to stay in REED if needed
+                InformPreviousChannel();
+            }
 
             if (!mAdvertiseTimer.IsRunning())
             {
@@ -4310,6 +4315,9 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Header *aHeader, Message *aMe
         mRouters[GetLeaderId()].SetAllocated(true);
         mRouters[GetLeaderId()].SetNextHop(GetRouterId(mParent.GetRloc16()));
     }
+
+    // send announce after become Router if needed
+    InformPreviousChannel();
 
     // send link request
     SendLinkRequest(NULL);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -4316,9 +4316,6 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Header *aHeader, Message *aMe
         mRouters[GetLeaderId()].SetNextHop(GetRouterId(mParent.GetRloc16()));
     }
 
-    // send announce after become Router if needed
-    InformPreviousChannel();
-
     // send link request
     SendLinkRequest(NULL);
 
@@ -4346,6 +4343,10 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Header *aHeader, Message *aMe
     }
 
 exit:
+
+    // send announce after received address solicit reply if needed
+    InformPreviousChannel();
+
     return;
 }
 

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -302,6 +302,14 @@ public:
     otError SetRouterSelectionJitter(uint8_t aRouterJitter);
 
     /**
+     * This method returns the current router selection jitter timeout value.
+     *
+     * @returns The current router selection jitter timeout value.
+     *
+     */
+    uint8_t GetRouterSelectionJitterTimeout(void) { return mRouterSelectionJitterTimeout; }
+
+    /**
      * This method returns the current Router ID Sequence value.
      *
      * @returns The current Router ID Sequence value.

--- a/src/core/thread/mle_router_mtd.hpp
+++ b/src/core/thread/mle_router_mtd.hpp
@@ -59,6 +59,7 @@ public:
 
     uint8_t GetActiveRouterCount(void) const { return 0; }
     uint8_t GetActiveNeighborRouterCount(void) const { return 0; }
+    uint8_t GetRouterSelectionJitterTimeout(void) { return 0; }
 
     uint32_t GetLeaderAge(void) const { return 0; }
 


### PR DESCRIPTION
This commit delays sending Announce for FTD after it has become Router and decided to stay in REED on the safe side:
OT device would try to attach on the announced channel only once, and if it fails, the device would switch back to old channel. However the FTD may get a different router id, or it will take longer for REED to become router especially in linear topology, causing the attaching device fail to attach and may no chance to attach again on the announced channel.