### PR TITLE
[logging] add two new regions for core and utility modules

### DIFF
--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -1182,6 +1182,8 @@ typedef enum otLogRegion
     OT_LOG_REGION_PLATFORM = 12, ///< Platform
     OT_LOG_REGION_COAP     = 13, ///< CoAP
     OT_LOG_REGION_CLI      = 14, ///< CLI
+    OT_LOG_REGION_CORE     = 15, ///< OpenThread Core
+    OT_LOG_REGION_UTIL     = 16, ///< Utility module
 } otLogRegion;
 
 /**

--- a/src/core/common/logging.cpp
+++ b/src/core/common/logging.cpp
@@ -259,6 +259,14 @@ const char *otLogRegionToString(otLogRegion aRegion)
         retval = "-PLAT----";
         break;
 
+    case OT_LOG_REGION_CORE:
+        retval = "-CORE----";
+        break;
+
+    case OT_LOG_REGION_UTIL:
+        retval = "-UTIL----";
+        break;
+
     default:
         retval = "---------";
         break;

--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -596,6 +596,64 @@ extern "C" {
 #endif
 
 /**
+ * @def otLogCritCore
+ *
+ * This method generates a log with level critical for the Core region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogWarnCore
+ *
+ * This method generates a log with level warning for the Core region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogInfoCore
+ *
+ * This method generates a log with level info for the Core region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogDebgCore
+ *
+ * This method generates a log with level debug for the Core region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+#if OPENTHREAD_CONFIG_LOG_CORE == 1
+#define otLogCritCore(aInstance, aFormat, ...) otLogCrit(&aInstance, OT_LOG_REGION_CORE, aFormat, ## __VA_ARGS__)
+#define otLogWarnCore(aInstance, aFormat, ...) otLogWarn(&aInstance, OT_LOG_REGION_CORE, aFormat, ## __VA_ARGS__)
+#define otLogInfoCore(aInstance, aFormat, ...) otLogInfo(&aInstance, OT_LOG_REGION_CORE, aFormat, ## __VA_ARGS__)
+#define otLogDebgCore(aInstance, aFormat, ...) otLogDebg(&aInstance, OT_LOG_REGION_CORE, aFormat, ## __VA_ARGS__)
+#define otLogDebgCoreErr(aInstance, aError, aFormat, ...)                 \
+    otLogWarn(aInstance, OT_LOG_REGION_CORE, "Error %s: " aFormat, otThreadErrorToString(aError), ## __VA_ARGS__)
+#else
+#define otLogCritCore(aInstance, aFormat, ...)
+#define otLogWarnCore(aInstance, aFormat, ...)
+#define otLogInfoCore(aInstance, aFormat, ...)
+#define otLogDebgCore(aInstance, aFormat, ...)
+#define otLogDebgCoreErr(aInstance, aError, aFormat, ...)
+#endif
+
+/**
  * @def otLogCritMem
  *
  * This method generates a log with level critical for the memory region.
@@ -650,6 +708,64 @@ extern "C" {
 #define otLogWarnMem(aInstance, aFormat, ...)
 #define otLogInfoMem(aInstance, aFormat, ...)
 #define otLogDebgMem(aInstance, aFormat, ...)
+#endif
+
+/**
+ * @def otLogCritUtil
+ *
+ * This method generates a log with level critical for the Util region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogWarnUtil
+ *
+ * This method generates a log with level warning for the Util region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogInfoUtil
+ *
+ * This method generates a log with level info for the Util region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogDebgUtil
+ *
+ * This method generates a log with level debug for the Util region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+#if OPENTHREAD_CONFIG_LOG_UTIL == 1
+#define otLogCritUtil(aInstance, aFormat, ...) otLogCrit(&aInstance, OT_LOG_REGION_UTIL, aFormat, ## __VA_ARGS__)
+#define otLogWarnUtil(aInstance, aFormat, ...) otLogWarn(&aInstance, OT_LOG_REGION_UTIL, aFormat, ## __VA_ARGS__)
+#define otLogInfoUtil(aInstance, aFormat, ...) otLogInfo(&aInstance, OT_LOG_REGION_UTIL, aFormat, ## __VA_ARGS__)
+#define otLogInfoUtilErr(aInstance, aError, aFormat, ...)                \
+    otLogInfo(&aInstance, OT_LOG_REGION_UTIL, "Error %s: " aFormat, otThreadErrorToString(aError), ## __VA_ARGS__)
+#define otLogDebgUtil(aInstance, aFormat, ...) otLogDebg(&aInstance, OT_LOG_REGION_UTIL, aFormat, ## __VA_ARGS__)
+#else
+#define otLogCritUtil(aInstance, aFormat, ...)
+#define otLogWarnUtil(aInstance, aFormat, ...)
+#define otLogInfoUtil(aInstance, aFormat, ...)
+#define otLogInfoUtilErr(aInstance, aError, aFormat, ...)
+#define otLogDebgUtil(aInstance, aFormat, ...)
 #endif
 
 /**
@@ -1335,6 +1451,66 @@ extern "C" {
 #define otDumpWarnMac(aInstance, aId, aBuf, aLength)
 #define otDumpInfoMac(aInstance, aId, aBuf, aLength)
 #define otDumpDebgMac(aInstance, aId, aBuf, aLength)
+#endif
+
+
+/**
+ * @def otDumpCritCore
+ *
+ * This method generates a memory dump with log level debug and region Core.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+
+/**
+ * @def otDumpWarnCore
+ *
+ * This method generates a memory dump with log level warning and region Core.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+
+/**
+ * @def otDumpInfoCore
+ *
+ * This method generates a memory dump with log level info and region Core.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+
+/**
+ * @def otDumpDebgCore
+ *
+ * This method generates a memory dump with log level debug and region Core.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+#if OPENTHREAD_CONFIG_LOG_CORE == 1
+#define otDumpCritCore(aInstance, aId, aBuf, aLength) otDumpCrit(aInstance, OT_LOG_REGION_CORE, aId, aBuf, aLength)
+#define otDumpWarnCore(aInstance, aId, aBuf, aLength) otDumpWarn(aInstance, OT_LOG_REGION_CORE, aId, aBuf, aLength)
+#define otDumpInfoCore(aInstance, aId, aBuf, aLength) otDumpInfo(aInstance, OT_LOG_REGION_CORE, aId, aBuf, aLength)
+#define otDumpDebgCore(aInstance, aId, aBuf, aLength) otDumpDebg(aInstance, OT_LOG_REGION_CORE, aId, aBuf, aLength)
+#else
+#define otDumpCritCore(aInstance, aId, aBuf, aLength)
+#define otDumpWarnCore(aInstance, aId, aBuf, aLength)
+#define otDumpInfoCore(aInstance, aId, aBuf, aLength)
+#define otDumpDebgCore(aInstance, aId, aBuf, aLength)
 #endif
 
 /**

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -714,6 +714,26 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_LOG_CORE
+ *
+ * Define to enable OpenThread Core logging.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_LOG_CORE
+#define OPENTHREAD_CONFIG_LOG_CORE                              1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_LOG_UTIL
+ *
+ * Define to enable OpenThread Utility module logging.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_LOG_UTIL
+#define OPENTHREAD_CONFIG_LOG_UTIL                              1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_LOG_PREPEND_LEVEL
  *
  * Define to prepend the log level to all log messages

--- a/src/core/utils/channel_monitor.cpp
+++ b/src/core/utils/channel_monitor.cpp
@@ -63,13 +63,13 @@ void ChannelMonitor::Start(void)
 {
     Clear();
     mTimer.Start(kTimerInterval);
-    otLogDebgMac(GetInstance(), "ChannelMonitor: Starting");
+    otLogDebgUtil(GetInstance(), "ChannelMonitor: Starting");
 }
 
 void ChannelMonitor::Stop(void)
 {
     mTimer.Stop();
-    otLogDebgMac(GetInstance(), "ChannelMonitor: Stopping");
+    otLogDebgUtil(GetInstance(), "ChannelMonitor: Stopping");
 }
 
 void ChannelMonitor::Clear(void)
@@ -78,7 +78,7 @@ void ChannelMonitor::Clear(void)
     mSampleCount = 0;
     memset(mChannelQuality, 0, sizeof(mChannelQuality));
 
-    otLogDebgMac(GetInstance(), "ChannelMonitor: Clearing data");
+    otLogDebgUtil(GetInstance(), "ChannelMonitor: Clearing data");
 }
 
 uint16_t ChannelMonitor::GetChannelQuality(uint8_t aChannel) const
@@ -112,7 +112,7 @@ void ChannelMonitor::RestartTimer(void)
     interval += jitter;
     mTimer.StartAt(mTimer.GetFireTime(), interval);
 
-    otLogDebgMac(GetInstance(), "ChannelMonitor: Timer interval %u, jitter %d", interval, jitter);
+    otLogDebgUtil(GetInstance(), "ChannelMonitor: Timer interval %u, jitter %d", interval, jitter);
 }
 
 void ChannelMonitor::HandleTimer(Timer &aTimer)
@@ -156,7 +156,7 @@ void ChannelMonitor::HandleEnergyScanResult(otEnergyScanResult *aResult)
 
         assert(channelIndex < kNumChannels);
 
-        otLogDebgMac(GetInstance(), "ChannelMonitor: channel: %d, rssi:%d", aResult->mChannel, aResult->mMaxRssi);
+        otLogDebgUtil(GetInstance(), "ChannelMonitor: channel: %d, rssi:%d", aResult->mChannel, aResult->mMaxRssi);
 
         if (aResult->mMaxRssi != OT_RADIO_RSSI_INVALID)
         {
@@ -191,7 +191,7 @@ void ChannelMonitor::HandleEnergyScanResult(otEnergyScanResult *aResult)
 
 void ChannelMonitor::LogResults(void)
 {
-    otLogInfoMac(
+    otLogInfoUtil(
         GetInstance(),
         "ChannelMonitor: %u [%02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x]",
         mSampleCount,


### PR DESCRIPTION
This commit adds `OT_LOG_REGION_CORE` and `OT_LOG_REGION_UTIL` as
two new log regions. The Core is intended for any core module that
does not fit any other category. The `UTIL` is intended for all
modules under `/core/util` folder.