### PR TITLE
[mle] do not clear address query cache when switching to the router role

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -441,7 +441,6 @@ otError MleRouter::SetStateRouter(uint16_t aRloc16)
     netif.GetIp6().SetForwardingEnabled(true);
     netif.GetIp6().GetMpl().SetTimerExpirations(kMplRouterDataMessageTimerExpirations);
     netif.GetMac().SetBeaconEnabled(true);
-    netif.GetAddressResolver().Clear();
 
     // clear router table
     for (int i = 0; i <= kMaxRouterId; i++)


### PR DESCRIPTION
Is it necessary to clear Address Query Cache while transition to the router role? I have already submitted [patch](https://github.com/openthread/openthread/commit/41e4b3202bf60388020287eff6880a360d2332c9) for Parent<->Child interaction with Address Query mechanism so personally i don't see any other potential issues.

There is a problem with current approach:

Use case: Streaming application, that floods data packets to the ML-EID address of other node in the network, blocks and drains message buffers when stack switches role from Child to Router. All in all, the problem is caused by sending Address Query before any Routers reply with Link Accept.

Simplified visualization of the problem:

![plantuml](https://user-images.githubusercontent.com/5144764/35709682-f4c353c2-07b3-11e8-821c-2dbc0ea34456.png)

Important note: I have observed some random Travis fails (maybe it is caused by the new virtual time mechanism, but it might be that there is something wrong with this PR).

I guess this PR does not completely eliminate above sceario, but it helps to minimalize it.
As an alternative we can somehow postpone initial Address Query if let's say we became Router xxx ms before, however this PR anyway looks like improvement to me.
