### PR TITLE
[spi-hdlc-adapter] increase max spi-align-allowance from 6 to 16

### DIFF
--- a/tools/spi-hdlc-adapter/README.md
+++ b/tools/spi-hdlc-adapter/README.md
@@ -40,9 +40,9 @@ protocol document.
     set to zero for spi-hdlc-adapter to work with some SPI drivers.
 *   `--spi-align-allowance[=n]`: Specify the maximum number of 0xFF
     bytes to clip from start of MISO frame. This makes this tool usable
-    with SPI slaves which have buggy SPI blocks that prepend up to
-    three 0xFF bytes to the start of MISO frame. Default value is `0`.
-    Maximum value is `6`. *This must be set to `4` for chips in the
+    with SPI slaves which have buggy SPI blocks that prepend a variable
+    number of 0xFF bytes to the start of MISO frame. Default value is `0`.
+    Maximum value is `16`. *This should be set to `7` for chips in the
     SiLabs EM35x family.*
 *   `--spi-small-packet=[n]`: Specify the smallest packet we can receive
     in a single SPI transaction. Packets sent by the slave which are smaller

--- a/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
+++ b/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
@@ -95,7 +95,7 @@
 #define GPIO_INT_ASSERT_STATE           0 // I̅N̅T̅ is asserted low
 #define GPIO_RES_ASSERT_STATE           0 // R̅E̅S̅ is asserted low
 
-#define SPI_RX_ALIGN_ALLOWANCE_MAX      6
+#define SPI_RX_ALIGN_ALLOWANCE_MAX      16
 
 #define SOCKET_DEBUG_BYTES_PER_LINE     16
 
@@ -1457,8 +1457,8 @@ static void print_help(void)
     "    --spi-mode[=mode] ............ Specify the SPI mode to use (0-3).\n"
     "    --spi-speed[=hertz] .......... Specify the SPI speed in hertz.\n"
     "    --spi-cs-delay[=usec] ........ Specify the delay after C̅S̅ assertion, in µsec\n"
-    "    --spi-align-allowance[=n] .... Specify the maximum number of FF bytes to\n"
-    "                                   clip from start of MISO frame. Max value is 3.\n"
+    "    --spi-align-allowance[=n] .... Specify the maximum number of 0xFF bytes to\n"
+    "                                   clip from start of MISO frame. Max value is 16.\n"
     "    --spi-small-packet=[n] ....... Specify the smallest packet we can receive\n"
     "                                   in a single transaction(larger packets will\n"
     "                                   require two transactions). Default value is 32.\n"

--- a/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
+++ b/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
@@ -67,7 +67,7 @@
 /* ------------------------------------------------------------------------- */
 /* MARK: Macros and Constants */
 
-#define SPI_HDLC_VERSION                "0.06"
+#define SPI_HDLC_VERSION                "0.07"
 
 #define MAX_FRAME_SIZE                  2048
 #define HEADER_LEN                      5


### PR DESCRIPTION
Testing has determined that some SPI slave interfaces sometimes emit
even more than 6 0xFF bytes before sending the first header byte. Upping
this value to 16 in order to provide some future proofing.