### PR TITLE
[channel-manager] handle simultaneous channel change requests

### DIFF
--- a/src/core/utils/channel_manager.hpp
+++ b/src/core/utils/channel_manager.hpp
@@ -142,11 +142,11 @@ public:
 private:
     enum
     {
-        kDefaultSupprotedChannelMask = OT_RADIO_SUPPORTED_CHANNELS,
-        kMaxTimestampIncrease = 128,
-
+        kDefaultSupprotedChannelMask   = OT_RADIO_SUPPORTED_CHANNELS,
+        kMaxTimestampIncrease          = 128,
         kPendingDatasetTxRetryInterval = 20000,    // in ms
-        kChangeCheckWaitInterval = 30000,          // in ms
+        kChangeCheckWaitInterval       = 30000,    // in ms
+        kRequestStartJitterInterval    = 10000,    // in ms
     };
 
     enum State


### PR DESCRIPTION
This commit adds new logic in `ChannelManager` to help handle
situations where multiple devices within network request channel
change around the same time. This simplifies how the channel change
can be triggered by users allowing them to request a channel change on
all routers/devices simultaneously (this would help with cases where
the Thread network contains multiple partitions).

In particular, this commit adds a jitter delay to start processing of
a channel change request (random delay before a Pending Dataset is
prepared and sent to leader). Also this commit changes how the Pending
Dataset is prepared and sent. The code now checks if there is a valid
Pending Dataset and if it is changing the channel to same one as the
current channel change request, then it skips updating the Pending
Dataset.