### PR TITLE
[channel-manager] API to get the last requested channel

### DIFF
--- a/include/openthread/channel_manager.h
+++ b/include/openthread/channel_manager.h
@@ -73,6 +73,14 @@ extern "C" {
 otError otChannelManagerRequestChannelChange(otInstance *aInstance, uint8_t aChannel);
 
 /**
+ * This function gets the channel from the last successful call to `otChannelManagerRequestChannelChange()`
+ *
+ * @returns The last requested channel or zero if there has been no channel change request yet.
+ *
+ */
+uint8_t otChannelManagerGetRequestedChannel(otInstance *aInstance);
+
+/**
  * This function gets the delay (in seconds) used by Channel Manager for a channel change.
  *
  * @param[in]  aInstance          A pointer to an OpenThread instance.

--- a/src/core/api/channel_manager_api.cpp
+++ b/src/core/api/channel_manager_api.cpp
@@ -48,6 +48,13 @@ otError otChannelManagerRequestChannelChange(otInstance *aInstance, uint8_t aCha
     return instance.GetChannelManager().RequestChannelChange(aChannel);
 }
 
+uint8_t otChannelManagerGetRequestedChannel(otInstance *aInstance)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.GetChannelManager().GetRequestedChannel();
+}
+
 uint16_t otChannelManagerGetDelay(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);

--- a/src/core/utils/channel_manager.hpp
+++ b/src/core/utils/channel_manager.hpp
@@ -100,7 +100,15 @@ public:
     otError RequestChannelChange(uint8_t aChannel);
 
     /**
-     * This method gets the  delay (in seconds) used for a channel change.
+     * This method gets the channel from the last successful call to `RequestChannelChange()`.
+     *
+     * @returns The last requested channel, or zero if there has been no channel change request yet.
+     *
+     */
+    uint8_t GetRequestedChannel(void) const { return mChannel; }
+
+    /**
+     * This method gets the delay (in seconds) used for a channel change.
      *
      * @returns The delay (in seconds)
      *


### PR DESCRIPTION
This commits adds a new API to `ChannelManager` class (and a
a corresponding public OT API) to get the channel for the last
successfully requested channel change.