### PR TITLE
[efr32] fix otPlatRadioTxDone sometimes not being called

### DIFF
--- a/examples/platforms/efr32/radio.c
+++ b/examples/platforms/efr32/radio.c
@@ -656,13 +656,12 @@ static void processNextRxPacket(otInstance *aInstance, RAIL_Handle_t aRailHandle
     RAIL_Status_t status;
     uint16_t length;
 
-    otEXPECT(sState == OT_RADIO_STATE_RECEIVE);
-
     packetHandle = RAIL_GetRxPacketInfo(aRailHandle, RAIL_RX_PACKET_HANDLE_OLDEST, &packetInfo);
     otEXPECT_ACTION(packetInfo.packetStatus == RAIL_RX_PACKET_READY_SUCCESS,
                     packetHandle = RAIL_RX_PACKET_HANDLE_INVALID);
 
     status = RAIL_GetRxPacketDetails(aRailHandle, packetHandle, &packetDetails);
+    otEXPECT(status != RAIL_STATUS_INVALID_STATE);
     assert(status == RAIL_STATUS_NO_ERROR);
     length = packetInfo.packetBytes + 1;
 


### PR DESCRIPTION
Sometimes when transmission is started RAIL_EVENT_RX_OVERFLOW
happens and then otPlatRadioTxDone is never called ( see #2530 ).

This commit makes sure the RX FIFO is always drained, even when
transmitting so RAIL_EVENT_RX_OVERFLOW never happens.