### PR TITLE
[efr32] initialise timeReceived as required by Rail

### DIFF
--- a/examples/platforms/efr32/radio.c
+++ b/examples/platforms/efr32/radio.c
@@ -609,6 +609,8 @@ static void checkForAck(RAIL_Handle_t aRailHandle)
     packetHandle = RAIL_GetRxPacketInfo(aRailHandle, RAIL_RX_PACKET_HANDLE_NEWEST, &packetInfo);
     assert(packetInfo.packetStatus == RAIL_RX_PACKET_READY_SUCCESS);
 
+    packetDetails.timeReceived.timePosition = RAIL_PACKET_TIME_INVALID;
+    packetDetails.timeReceived.totalPacketBytes = 0;
     status = RAIL_GetRxPacketDetails(aRailHandle, packetHandle, &packetDetails);
     assert(status == RAIL_STATUS_NO_ERROR);
     otEXPECT(packetDetails.isAck);
@@ -662,6 +664,8 @@ static void processNextRxPacket(otInstance *aInstance, RAIL_Handle_t aRailHandle
     otEXPECT_ACTION(packetInfo.packetStatus == RAIL_RX_PACKET_READY_SUCCESS,
                     packetHandle = RAIL_RX_PACKET_HANDLE_INVALID);
 
+    packetDetails.timeReceived.timePosition = RAIL_PACKET_TIME_INVALID;
+    packetDetails.timeReceived.totalPacketBytes = 0;
     status = RAIL_GetRxPacketDetails(aRailHandle, packetHandle, &packetDetails);
     assert(status == RAIL_STATUS_NO_ERROR);
     length = packetInfo.packetBytes + 1;


### PR DESCRIPTION
Worked fine without this but just to be safe.