### PR TITLE
[mac] avoid data poll timeout when a duplicate frame is received

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1730,7 +1730,35 @@ void Mac::HandleReceivedFrame(Frame *aFrame, otError aError)
     }
 
     // Security Processing
-    SuccessOrExit(error = ProcessReceiveSecurity(*aFrame, srcaddr, neighbor));
+    error = ProcessReceiveSecurity(*aFrame, srcaddr, neighbor);
+
+    switch (error)
+    {
+    case OT_ERROR_DUPLICATED:
+
+        // Allow a duplicate received frame pass, only if the
+        // current operation is `kOperationWaitingForData` (i.e.,
+        // the sleepy device is waiting to receive a frame after
+        // a data poll ack from parent indicating there is a
+        // pending frame for it). This ensures that the sleepy
+        // device goes to sleep faster and avoids a data poll
+        // timeout.
+        //
+        // Note that `error` is checked again later after the
+        // operation `kOperationWaitingForData` is processed
+        // so the duplicate frame will not be passed to any
+        // registered `Receiver`.
+
+        VerifyOrExit(mOperation == kOperationWaitingForData);
+
+        // Fall through
+
+    case OT_ERROR_NONE:
+        break;
+
+    default:
+        ExitNow();
+    }
 
     if (neighbor != NULL)
     {
@@ -1799,6 +1827,8 @@ void Mac::HandleReceivedFrame(Frame *aFrame, otError aError)
 #endif
             FinishOperation();
         }
+
+        SuccessOrExit(error);
 
         break;
 


### PR DESCRIPTION
This commit changes how `Mac::HandleReceivedFrame()` handles duplicate
received frame when a sleepy device is waiting for data after a data
poll ack from parent indicating a pending frame. This change ensures
that the sleepy device can go to sleep faster and avoid a data poll
timeout.