### PR TITLE
[efr32] configurable board

### DIFF
--- a/examples/Makefile-efr32
+++ b/examples/Makefile-efr32
@@ -56,7 +56,7 @@ AbsTopSourceDir                 := $(dir $(realpath $(firstword $(MAKEFILE_LIST)
 
 EFR32_MBEDTLS_CPPFLAGS  = -DMBEDTLS_CONFIG_FILE='\"mbedtls-config.h\"'
 EFR32_MBEDTLS_CPPFLAGS += -DMBEDTLS_USER_CONFIG_FILE='\"efr32-mbedtls-config.h\"'
-EFR32_MBEDTLS_CPPFLAGS += -DEFR32MG12P432F1024GL125
+EFR32_MBEDTLS_CPPFLAGS += -D$(MCU)
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/examples/platforms/efr32/crypto
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.0/util/third_party/mbedtls/configs
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.0/platform/CMSIS/Include

--- a/examples/Makefile-efr32
+++ b/examples/Makefile-efr32
@@ -54,6 +54,22 @@ configure_OPTIONS               = \
 TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..
 AbsTopSourceDir                 := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))..
 
+
+#
+# Differentiate between boards
+# - BRD4161A / SLWSTK6000B / Wireless Starter Kit
+# - BRD4166A / SLTB004A / Thunderboard Sense 2
+#
+ifeq ($(BOARD),BRD4161A)
+MCU = EFR32MG12P432F1024GL125
+else
+ifeq ($(BOARD),BRD4166A)
+MCU = EFR32MG12P332F1024GL125
+else
+$(error Please provide a value for BOARD variable e.g BOARD=BRD4161A (currently supported BRD4161A or BRD4166A) )
+endif
+endif
+
 EFR32_MBEDTLS_CPPFLAGS  = -DMBEDTLS_CONFIG_FILE='\"mbedtls-config.h\"'
 EFR32_MBEDTLS_CPPFLAGS += -DMBEDTLS_USER_CONFIG_FILE='\"efr32-mbedtls-config.h\"'
 EFR32_MBEDTLS_CPPFLAGS += -D$(MCU)
@@ -77,6 +93,7 @@ COMMONCFLAGS                   := \
     -g                            \
     -D$(CONFIG_FILE)              \
     -I$(CONFIG_FILE_PATH)         \
+    -D$(MCU)                      \
     $(NULL)
 
 include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk

--- a/examples/platforms/efr32/Makefile.am
+++ b/examples/platforms/efr32/Makefile.am
@@ -41,7 +41,7 @@ override CXXFLAGS                            := $(filter-out -pedantic-errors,$(
 EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.0
 
 libopenthread_efr32_a_CPPFLAGS                                                = \
-    -DEFR32MG12P432F1024GL125                                                   \
+    -D$(MCU)                                                  \
     -D__START=main                                                              \
     -D__STARTUP_CLEAR_BSS                                                       \
     -I$(top_srcdir)/include                                                     \
@@ -55,7 +55,7 @@ libopenthread_efr32_a_CPPFLAGS                                                = 
     -I$(EFR32MG_SDK_SRCDIR)/platform/radio/rail_lib/hal/efr32                   \
     -I$(EFR32MG_SDK_SRCDIR)/platform/radio/rail_lib/plugin/pa-conversions       \
     -I$(EFR32MG_SDK_SRCDIR)/hardware/kit/common/bsp                             \
-    -I$(EFR32MG_SDK_SRCDIR)/hardware/kit/EFR32MG12_BRD4161A/config              \
+    -I$(EFR32MG_SDK_SRCDIR)/hardware/kit/EFR32MG12_$(BOARD)/config              \
     -I$(EFR32MG_SDK_SRCDIR)/platform/CMSIS/Include                              \
     -I$(EFR32MG_SDK_SRCDIR)/platform/Device/SiliconLabs/EFR32MG12P/Include      \
     -I$(EFR32MG_SDK_SRCDIR)/platform/emdrv/common/inc                           \

--- a/examples/platforms/efr32/Makefile.am
+++ b/examples/platforms/efr32/Makefile.am
@@ -41,7 +41,6 @@ override CXXFLAGS                            := $(filter-out -pedantic-errors,$(
 EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.0
 
 libopenthread_efr32_a_CPPFLAGS                                                = \
-    -D$(MCU)                                                  \
     -D__START=main                                                              \
     -D__STARTUP_CLEAR_BSS                                                       \
     -I$(top_srcdir)/include                                                     \

--- a/examples/platforms/efr32/README.md
+++ b/examples/platforms/efr32/README.md
@@ -1,10 +1,11 @@
 # OpenThread on EFR32 Example
 
 This directory contains example platform drivers for the [Silicon Labs EFR32][efr32mg]
-based on [EFR32™ Mighty Gecko Wireless Starter Kit][SLWSTK6000B].
+based on [EFR32™ Mighty Gecko Wireless Starter Kit][SLWSTK6000B] or [Thunderboard™ Sense 2 Sensor-to-Cloud Advanced IoT Development Kit][SLTB004A].
 
 [efr32mg]: http://www.silabs.com/products/wireless/mesh-networking/efr32mg-mighty-gecko-zigbee-thread-soc
 [SLWSTK6000B]: http://www.silabs.com/products/development-tools/wireless/mesh-networking/mighty-gecko-starter-kit
+[SLTB004A]: https://www.silabs.com/products/development-tools/thunderboard/thunderboard-sense-two-kit
 
 The example platform drivers are intended to present the minimal code
 necessary to support OpenThread. [EFR32MG12P SoC][efr32mg12p]
@@ -58,7 +59,15 @@ $ cp -rf gecko_sdk_suite <path-to-openthread>/third_party/silabs/
 ```bash
 $ cd <path-to-openthread>
 $ ./bootstrap
-$ make -f examples/Makefile-efr32
+```
+For EFR32™ Mighty Gecko Wireless Starter Kit:
+```bash
+$ make -f examples/Makefile-efr32 BOARD=BRD4161A
+```
+or alternatively for the Thunderboard™ Sense 2:
+
+```bash
+$ make -f examples/Makefile-efr32 BOARD=BRD4166A
 ```
 
 After a successful build, the `elf` files are found in


### PR DESCRIPTION
As discussed in issue #2324, the support for Silabs Thunderboard Sense 2 will be added through this pull request.
The user can now  provide the board, for example for WSTK:
```
make -f examples/Makefile-efr32 COMMISSIONER=1 BOARD=BRD4161A
```
or for Thunderboard Sense 2
```
make -f examples/Makefile-efr32 COMMISSIONER=1 BOARD=BRD4166A
```