### PR TITLE
[gp712] fix typographical error causing an empty dependency

### DIFF
--- a/examples/platforms/gp712/Makefile.am
+++ b/examples/platforms/gp712/Makefile.am
@@ -58,7 +58,7 @@ libopenthread_gp712_a_LIBADD              = \
     $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
 
 libopenthread_gp712_a_SOURCES             = \
-    $(PLATFORM_SORUCES)                     \
+    $(PLATFORM_SOURCES)                     \
     $(NULL)
 
 PRETTY_FILES                              = \


### PR DESCRIPTION
Fixes the following warning:
```
❯ ./bootstrap
configure.ac:198: installing 'third_party/nlbuild-autotools/repo/autoconf/compile'
configure.ac:114: installing 'third_party/nlbuild-autotools/repo/autoconf/missing'
examples/apps/cli/Makefile.am: installing 'third_party/nlbuild-autotools/repo/autoconf/depcomp'
examples/platforms/gp712/Makefile.am:41: warning: variable 'PLATFORM_SOURCES' is defined but no program or
examples/platforms/gp712/Makefile.am:41: library has 'PLATFORM' as canonical name (possible typo)
```

With this change, the output becomes:
```
❯ ./bootstrap                                                                                                                                                                                                          openthread/git/master
configure.ac:198: installing 'third_party/nlbuild-autotools/repo/autoconf/compile'
configure.ac:114: installing 'third_party/nlbuild-autotools/repo/autoconf/missing'
examples/apps/cli/Makefile.am: installing 'third_party/nlbuild-autotools/repo/autoconf/depcomp'
```