### PR TITLE
[tests] fix occasional failures in Cert_5_1_08_RouterAttachConnectivity.py

### DIFF
--- a/tests/scripts/thread-cert/Cert_5_1_08_RouterAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_5_1_08_RouterAttachConnectivity.py
@@ -97,10 +97,19 @@ class Cert_5_1_08_RouterAttachConnectivity(unittest.TestCase):
         self.simulator.go(5)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
-        for i in range(2, 6):
+        for i in range(2, 5):
             self.nodes[i].start()
-            self.simulator.go(5)
+
+        self.simulator.go(5)
+
+        for i in range(2, 5):
             self.assertEqual(self.nodes[i].get_state(), 'router')
+
+        self.simulator.go(config.MAX_ADVERTISEMENT_INTERVAL)
+
+        self.nodes[ROUTER4].start()
+        self.simulator.go(5)
+        self.assertEqual(self.nodes[ROUTER4].get_state(), 'router')
 
         leader_messages = self.simulator.get_messages_sent_by(LEADER)
         router1_messages = self.simulator.get_messages_sent_by(ROUTER1)


### PR DESCRIPTION
This commit adds necessary delay to allow the router topology to establish
links with neighboring routers.