### PR TITLE
[code-style] make pretty-check output something better

### DIFF
--- a/script/clang-format-check.sh
+++ b/script/clang-format-check.sh
@@ -40,4 +40,7 @@ die() {
 
 set -x
 
-[ -z "`clang-format -style=file -output-replacements-xml $@ | grep \"<replacement \"`" ] || die
+# from `man diff`:
+# Exit status is 0 if inputs are the same, 1 if different, 2 if trouble.
+
+clang-format -style=file $@  | diff $@ -

--- a/script/clang-format-check.sh
+++ b/script/clang-format-check.sh
@@ -43,4 +43,4 @@ set -x
 # from `man diff`:
 # Exit status is 0 if inputs are the same, 1 if different, 2 if trouble.
 
-clang-format -style=file $@  | diff $@ -
+clang-format -style=file $@  | diff -u $@ -


### PR DESCRIPTION
Like this:

```
PRETTY   cli.cpp
+clang-format -style=file ./cli.cpp
+diff ./cli.cpp -
1006,1009c1006,1009
<     int id;
<     const char *mgrName = otFIGetManagerName();
<     const char *faultName = NULL;
<     uint32_t faultCounter = 0;
---
>     int         id;
>     const char *mgrName      = otFIGetManagerName();
>     const char *faultName    = NULL;
>     uint32_t    faultCounter = 0;
make[2]: *** [pretty-check] Error 1
make[1]: *** [pretty-check-recursive] Error 1
make: *** [pretty-check-recursive] Error 1
+die
+echo  *** ERROR:
```