### PR TITLE
[netif] do not allow external link-local unicast addresses

### DIFF
--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -410,6 +410,8 @@ otError Netif::AddExternalUnicastAddress(const NetifUnicastAddress &aAddress)
     NetifUnicastAddress *entry;
     size_t               num = sizeof(mExtUnicastAddresses) / sizeof(mExtUnicastAddresses[0]);
 
+    VerifyOrExit(!aAddress.GetAddress().IsLinkLocal(), error = OT_ERROR_INVALID_ARGS);
+
     for (entry = mUnicastAddresses; entry; entry = entry->GetNext())
     {
         if (entry->GetAddress() == aAddress.GetAddress())


### PR DESCRIPTION
Thread does not support address resolution for link-local unicast addresses.
As a result, any link-local unicast address other than the one based on the
IEEE 802.15.4 Extended Address is not useful.

Helps avoid the issued identified in #2571.