### PR TITLE
[tests] fix occasional failures in Cert_6_1_03_RouterAttachConnectivity.py

### DIFF
--- a/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
@@ -95,8 +95,13 @@ class Cert_6_1_3_RouterAttachConnectivity(unittest.TestCase):
 
         for i in range(2, 5):
             self.nodes[i].start()
-            self.simulator.go(5)
+
+        self.simulator.go(5)
+
+        for i in range(2, 5):
             self.assertEqual(self.nodes[i].get_state(), 'router')
+
+        self.simulator.go(config.MAX_ADVERTISEMENT_INTERVAL)
 
         self.nodes[ED].start()
         self.simulator.go(5)


### PR DESCRIPTION
This commit adds necessary delay to allow the router topology to establish
links with neighboring routers.