### PR TITLE
[mle] clear last received Leader Data TLV on Mle::Stop

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -283,6 +283,7 @@ otError Mle::Stop(bool aClearNetworkDatasets)
     netif.GetNetworkDataLocal().Clear();
 #endif
     netif.GetNetworkDataLeader().Clear();
+    memset(&mLeaderData, 0, sizeof(mLeaderData));
 
     if (aClearNetworkDatasets)
     {


### PR DESCRIPTION
This commit clears the `mLeaderData` which is last received Leader
Data TLV from `Mle::Stop()` after network data is cleared.

This addresses an issue where if `Mle::Stop()` is called after an
attach (on MTD device) and then afterwards Thread is started again. The
device may assume it still has the correct network data and will not
request it from parent.