### PR TITLE
[mle] do not clear network data on MLE stop

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -279,10 +279,6 @@ otError Mle::Stop(bool aClearNetworkDatasets)
     netif.GetKeyManager().Stop();
     SetStateDetached();
     netif.RemoveUnicastAddress(mMeshLocal16);
-#if OPENTHREAD_ENABLE_BORDER_ROUTER || OPENTHREAD_ENABLE_SERVICE
-    netif.GetNetworkDataLocal().Clear();
-#endif
-    netif.GetNetworkDataLeader().Clear();
 
     if (aClearNetworkDatasets)
     {


### PR DESCRIPTION
This commit changes `Mle:Stop()` so that leader and local network data
are not cleared.

This is related to https://github.com/openthread/openthread/pull/2589