### PR TITLE
[operational-dataset] fix bug in getting the channel mask

### DIFF
--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -104,7 +104,7 @@ otError Dataset::Print(otOperationalDataset &aDataset)
 
     if (aDataset.mIsChannelMaskPage0Set)
     {
-        sServer->OutputFormat("Channel Mask Page 0: %x\r\n", aDataset.mChannelMaskPage0);
+        sServer->OutputFormat("Channel Mask Page 0: %08x\r\n", aDataset.mChannelMaskPage0);
     }
 
     if (aDataset.mIsDelaySet)

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -138,9 +138,8 @@ void Dataset::Get(otOperationalDataset &aDataset) const
             {
                 if (reinterpret_cast<const ChannelMaskEntry *>(entry)->GetChannelPage() == 0)
                 {
-                    uint8_t i                       = sizeof(ChannelMaskEntry);
-                    aDataset.mChannelMaskPage0      = static_cast<uint32_t>(entry[i] | (entry[i + 1] << 8) |
-                                                                       (entry[i + 2] << 16) | (entry[i + 3] << 24));
+                    const ChannelMask0Tlv *tlv      = static_cast<const ChannelMask0Tlv *>(cur);
+                    aDataset.mChannelMaskPage0      = tlv->GetMask();
                     aDataset.mIsChannelMaskPage0Set = true;
                     break;
                 }

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -139,9 +139,8 @@ otError DatasetLocal::Get(otOperationalDataset &aDataset) const
             {
                 if (reinterpret_cast<const ChannelMaskEntry *>(entry)->GetChannelPage() == 0)
                 {
-                    uint8_t i                       = sizeof(ChannelMaskEntry);
-                    aDataset.mChannelMaskPage0      = static_cast<uint32_t>(entry[i] | (entry[i + 1] << 8) |
-                                                                       (entry[i + 2] << 16) | (entry[i + 3] << 24));
+                    const ChannelMask0Tlv *tlv      = static_cast<const ChannelMask0Tlv *>(cur);
+                    aDataset.mChannelMaskPage0      = tlv->GetMask();
                     aDataset.mIsChannelMaskPage0Set = true;
                     break;
                 }


### PR DESCRIPTION
Resolves an issue reported [here](https://groups.google.com/d/msg/openthread-users/sS1WqMSbBFg/VSvBpftzBQAJ).