### PR TITLE
[mesh-forwarder] config option if to log src/dst IPv6 addresses

### DIFF
--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -764,6 +764,17 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_LOG_SRC_DST_IP_ADDRESSES
+ *
+ * If defined as 1 when IPv6 message info is logged in mesh-forwarder, the source and destination IPv6 addresses of
+ * messages are also included.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_LOG_SRC_DST_IP_ADDRESSES
+#define OPENTHREAD_CONFIG_LOG_SRC_DST_IP_ADDRESSES 1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION
  *
  * Defines the name of function/macro used for logging inside OpenThread, by default it is set to `otPlatLog()`.

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1443,7 +1443,7 @@ void MeshForwarder::LogIp6Message(MessageAction       aAction,
     const char * actionText;
     const char * priorityText;
     bool         shouldLogRss             = false;
-    bool         shouldLogSrcDstAddresses = true;
+    bool         shouldLogSrcDstAddresses = (OPENTHREAD_CONFIG_LOG_SRC_DST_IP_ADDRESSES != 0);
     char         stringBuffer[Ip6::Address::kIp6AddressStringSize];
     char         rssString[RssAverager::kStringSize];
 


### PR DESCRIPTION
This commit adds a new config option which determines if the source
and destination IPv6 addresses of received/sent messages are logged
from `MeshForwarder::LogIp6Message()`.


------

This is useful when NCP (with logs enabled) is being used with `wpantund` (with logs enabled). `wpantund` logs any inbound/outbound IP message from/to NCP (the logs contains the message  checksum and src/dst IPv6 address). So even with removing the src/dst address in OT logs, we can still map the message using the checksum and infer its src/dst from `wpantund` logs. 