### PR TITLE
[meshcop] improve logging of adding/removing joiners

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -53,6 +53,12 @@ bool ExtAddress::operator!=(const ExtAddress &aOther) const
     return memcmp(m8, aOther.m8, sizeof(ExtAddress)) != 0;
 }
 
+const char *ExtAddress::ToString(char *aBuf, uint16_t aSize) const
+{
+    snprintf(aBuf, aSize, "%02x%02x%02x%02x%02x%02x%02x%02x", m8[0], m8[1], m8[2], m8[3], m8[4], m8[5], m8[6], m8[7]);
+    return aBuf;
+}
+
 void Address::SetExtended(const uint8_t *aBuffer, bool aReverse)
 {
     mType = kTypeExtended;
@@ -72,6 +78,8 @@ void Address::SetExtended(const uint8_t *aBuffer, bool aReverse)
 
 const char *Address::ToString(char *aBuf, uint16_t aSize) const
 {
+    const char *rval = aBuf;
+
     switch (mType)
     {
     case kTypeNone:
@@ -83,13 +91,11 @@ const char *Address::ToString(char *aBuf, uint16_t aSize) const
         break;
 
     case kTypeExtended:
-        snprintf(aBuf, aSize, "%02x%02x%02x%02x%02x%02x%02x%02x", GetExtended().m8[0], GetExtended().m8[1],
-                 GetExtended().m8[2], GetExtended().m8[3], GetExtended().m8[4], GetExtended().m8[5],
-                 GetExtended().m8[6], GetExtended().m8[7]);
+        rval = GetExtended().ToString(aBuf, aSize);
         break;
     }
 
-    return aBuf;
+    return rval;
 }
 
 otError Frame::InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl)

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -171,6 +171,17 @@ public:
      */
     bool operator!=(const ExtAddress &aOther) const;
 
+    /**
+     * This method converts an address to a NULL-terminated string.
+     *
+     * @param[out]  aBuf   A pointer to a character buffer.
+     * @param[in]   aSize  The maximum size of the buffer.
+     *
+     * @returns A pointer to the character string buffer.
+     *
+     */
+    const char *ToString(char *aBuf, uint16_t aSize) const;
+
 private:
     enum
     {

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -318,11 +318,7 @@ private:
     };
     Joiner mJoiners[OPENTHREAD_CONFIG_MAX_JOINER_ENTRIES];
 
-    union
-    {
-        uint8_t  mJoinerIid[8];
-        uint64_t mJoinerIid64;
-    };
+    uint8_t    mJoinerIid[8];
     uint16_t   mJoinerPort;
     uint16_t   mJoinerRloc;
     TimerMilli mJoinerExpirationTimer;

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -55,7 +55,6 @@
 #if OPENTHREAD_ENABLE_JOINER
 
 using ot::Encoding::BigEndian::HostSwap16;
-using ot::Encoding::BigEndian::HostSwap64;
 
 namespace ot {
 namespace MeshCoP {
@@ -197,9 +196,11 @@ void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
     if (aResult != NULL)
     {
         JoinerRouter joinerRouter;
+        char         logString[Mac::Address::kAddressStringSize];
 
-        otLogDebgMeshCoP(GetInstance(), "HandleDiscoverResult() aResult = %llX",
-                         HostSwap64(*reinterpret_cast<uint64_t *>(&aResult->mExtAddress)));
+        otLogDebgMeshCoP(GetInstance(), "Received Discovery Response (%s)",
+                         static_cast<Mac::ExtAddress &>(aResult->mExtAddress).ToString(logString, sizeof(logString)));
+        OT_UNUSED_VARIABLE(logString);
 
         // Joining is disabled if the Steering Data is not included
         if (aResult->mSteeringData.mLength == 0)


### PR DESCRIPTION
This commit makes the following changes:
- Only print logs on success.
- Remove use of `HostSwap64()`, which can cause hard faults.
- Add `ExtAddress::ToString()` method.