### PR TITLE
[operational-dataset] cache Active/Pending Timestamp value

### DIFF
--- a/src/core/meshcop/dataset_local.hpp
+++ b/src/core/meshcop/dataset_local.hpp
@@ -72,6 +72,19 @@ public:
     void Clear(void);
 
     /**
+     * This method restores and retrieves the dataset from non-volatile memory.
+     *
+     * This method also sets the memory-cached timestamp for subsequent calls to `Compare()`.
+     *
+     * @param[out]  aDataset  Where to place the dataset.
+     *
+     * @retval OT_ERROR_NONE       Successfully retrieved the dataset.
+     * @retval OT_ERROR_NOT_FOUND  There is no corresponding dataset stored in non-volatile memory.
+     *
+     */
+    otError Restore(Dataset &aDataset);
+
+    /**
      * This method retrieves the dataset from non-volatile memory.
      *
      * @param[out]  aDataset  Where to place the dataset.
@@ -135,8 +148,10 @@ private:
     uint16_t GetSettingsKey(void) const;
     void     SetTimestamp(const Dataset &aDataset);
 
-    uint32_t  mUpdateTime; ///< Local time last updated
-    Tlv::Type mType;       ///< Active or Pending
+    Timestamp mTimestamp;            ///< Active or Pending Timestamp
+    uint32_t  mUpdateTime;           ///< Local time last updated
+    Tlv::Type mType;                 ///< Active or Pending
+    bool      mTimestampPresent : 1; ///< Whether or not timestamp is present
 };
 
 } // namespace MeshCoP

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -111,7 +111,7 @@ otError DatasetManager::Restore(void)
 
     mTimer.Stop();
 
-    SuccessOrExit(error = mLocal.Get(dataset));
+    SuccessOrExit(error = mLocal.Restore(dataset));
 
     timestamp = dataset.GetTimestamp();
 


### PR DESCRIPTION
This commit caches the Active/Pending Timestamp value in memory so that
subsequent calls to `DatasetLocal::Compare()` does not require reading
from non-volatile settings and allocating another dataset buffer on the
stack to do so.