### PR TITLE
[ncp] config option for max log string size in otNcpPlatLogv()

### DIFF
--- a/include/openthread/ncp.h
+++ b/include/openthread/ncp.h
@@ -84,6 +84,16 @@ void otNcpInit(otInstance *aInstance);
  */
 otError otNcpStreamWrite(int aStreamId, const uint8_t *aDataPtr, int aDataLen);
 
+/**
+ * Writes OpenThread Log using `otNcpStreamWrite`.
+ *
+ * @param[in]  aLogLevel   The log level.
+ * @param[in]  aLogRegion  The log region.
+ * @param[in]  aFormat     A pointer to the format string.
+ * @param[in]  aArgs       va_list matching aFormat.
+ */
+void otNcpPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, va_list aArgs);
+
 //-----------------------------------------------------------------------------------------
 // Peek/Poke memory access control delegates
 
@@ -201,16 +211,6 @@ void otNcpHandleDidReceiveNewLegacyUlaPrefix(const uint8_t *aUlaPrefix);
  *
  */
 void otNcpRegisterLegacyHandlers(const otNcpLegacyHandlers *aHandlers);
-
-/**
- * Callback to write the OpenThread Log to the NCP Spinel Tunnel.
- *
- * @param[in]  aLogLevel   The log level.
- * @param[in]  aLogRegion  The log region.
- * @param[in]  aFormat     A pointer to the format string.
- * @param[in]  aArgs       va_list matching aFormat.
- */
-void otNcpPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, va_list aArgs);
 
 /**
  * @}

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -856,6 +856,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_NCP_SPINEL_LOG_MAX_SIZE
+ *
+ * The maximum OpenThread log string size (number of chars) supported by NCP using Spinel `StreamWrite`.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_NCP_SPINEL_LOG_MAX_SIZE
+#define OPENTHREAD_CONFIG_NCP_SPINEL_LOG_MAX_SIZE 150
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT
  *
  * The assert is managed by platform defined logic when this flag is set.

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -2163,7 +2163,7 @@ otError otNcpStreamWrite(int aStreamId, const uint8_t *aDataPtr, int aDataLen)
 
 extern "C" void otNcpPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, va_list aArgs)
 {
-    char logString[128];
+    char logString[OPENTHREAD_CONFIG_NCP_SPINEL_LOG_MAX_SIZE];
     int charsWritten;
 
     if ((charsWritten = vsnprintf(logString, sizeof(logString), aFormat, aArgs)) > 0)


### PR DESCRIPTION
This commit adds `OPENTHREAD_CONFIG_NCP_SPINEL_LOG_MAX_SIZE` as
a config option to set the max log string size supported by NCP
`otNcpPlatLogv()`. This commit also increases the default to 150
characters.