### PR TITLE
[network-data] optimize network data update via MLE

### DIFF
--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -865,15 +865,6 @@ public:
     }
 
     /**
-     * This method indicates whether or not the TLV appears to be well-formed.
-     *
-     * @retval TRUE   If the TLV appears to be well-formed.
-     * @retval FALSE  If the TLV does not appear to be well-formed.
-     *
-     */
-    bool IsValid(void) const { return GetLength() < sizeof(*this) - sizeof(Tlv); }
-
-    /**
      * This method returns a pointer to the Network Data.
      *
      * @returns A pointer to the Network Data.

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -153,15 +153,18 @@ public:
      * @param[in]  aVersion        The Version value.
      * @param[in]  aStableVersion  The Stable Version value.
      * @param[in]  aStableOnly     TRUE if storing only the stable data, FALSE otherwise.
-     * @param[in]  aData           A pointer to the Network Data.
-     * @param[in]  aDataLength     The length of the Network Data in bytes.
+     * @param[in]  aMessage        A reference to the MLE message.
+     * @param[in]  aMessageOffset  The offset in @p aMessage for the Network Data TLV.
+     *
+     * @retval OT_ERROR_NONE   Successfully set the network data.
+     * @retval OT_ERROR_PARSE  Network Data TLV in @p aMessage is not valid.
      *
      */
-    void SetNetworkData(uint8_t        aVersion,
-                        uint8_t        aStableVersion,
-                        bool           aStableOnly,
-                        const uint8_t *aData,
-                        uint8_t        aDataLength);
+    otError SetNetworkData(uint8_t        aVersion,
+                           uint8_t        aStableVersion,
+                           bool           aStableOnly,
+                           const Message &aMessage,
+                           uint16_t       aMessageOffset);
 
     /**
      * This method sends a Server Data Notification message to the Leader indicating an invalid RLOC16.

--- a/tests/unit/test_lowpan.cpp
+++ b/tests/unit/test_lowpan.cpp
@@ -114,6 +114,9 @@ static void Init()
 
     // Emulate global prefixes with contextes.
     uint8_t mockNetworkData[] = {
+        0x0c, // MLE Network Data Type
+        0x20, // MLE Network Data Length
+
         // Prefix 2001:2:0:1::/64
         0x03, 0x0e,                                                             // Prefix TLV
         0x00, 0x40, 0x20, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x07, 0x02, // 6LoWPAN Context ID TLV
@@ -125,7 +128,12 @@ static void Init()
         0x02, 0x40                                                              // Context ID = 2, C = FALSE
     };
 
-    sThreadNetif->GetNetworkDataLeader().SetNetworkData(0, 0, true, mockNetworkData, sizeof(mockNetworkData));
+    Message *message = sInstance->GetMessagePool().New(Message::kTypeIp6, 0);
+    VerifyOrQuit(message != NULL, "6lo: Ip6::NewMessage failed");
+
+    SuccessOrQuit(message->Append(mockNetworkData, sizeof(mockNetworkData)), "6lo: Message::Append failed");
+
+    sThreadNetif->GetNetworkDataLeader().SetNetworkData(0, 0, true, *message, 0);
 }
 
 /**


### PR DESCRIPTION
This commit reduces stack usage when receiving/updating network data via MLE
by copying the network data directly out of the message and skipping the TLV
read.