### PR TITLE
[mac] refactor frame rx/tx logging logic into methods

### DIFF
--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -852,6 +852,10 @@ private:
     otError RadioReceive(uint8_t aChannel);
     otError RadioSleep(void);
 
+    void LogFrameRxFailure(const Frame *aFrame, otError aError) const;
+    void LogFrameTxFailure(const Frame &aFrame, otError aError) const;
+    void LogBeacon(const char *aActionText, const BeaconPayload &aBeaconPayload) const;
+
     static const char *OperationToString(Operation aOperation);
 
     Operation mOperation;

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -998,7 +998,7 @@ const char *Frame::ToInfoString(char *aBuf, uint16_t aSize) const
     return aBuf;
 }
 
-const char *BeaconPayload::ToInfoString(char *aBuf, uint16_t aSize)
+const char *BeaconPayload::ToInfoString(char *aBuf, uint16_t aSize) const
 {
     const uint8_t *xpanid = GetExtendedPanId();
 

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -1234,7 +1234,7 @@ public:
      * @returns A pointer to the char string buffer.
      *
      */
-    const char *ToInfoString(char *aBuf, uint16_t aSize);
+    const char *ToInfoString(char *aBuf, uint16_t aSize) const;
 
 private:
     uint8_t mProtocolId;


### PR DESCRIPTION
This commit helps reduce stack usage by refactoring logging related
code for frame rx/tx failure and beacon rx/tx into separate methods.