### PR TITLE
[tests] Update toranj test script to retry failed tests

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -116,7 +116,8 @@ cd /tmp || die
         cd wpantund || die
         ./bootstrap.sh || die
         ./configure || die
-        sudo make install -j 8 || die
+        sudo make -j 8 || die
+        sudo make install || die
         cd .. || die
     }
 

--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -404,7 +404,7 @@ class Node(object):
     # class methods
 
     @classmethod
-    def init_all_nodes(cls, wait_time=20):
+    def init_all_nodes(cls, wait_time=15):
         """Issues a `wpanctl.leave` on all `Node` objects and waits for them to be ready"""
         random.seed(12345)
         time.sleep(0.5)
@@ -422,7 +422,7 @@ class Node(object):
                     raise
                 else:
                     break
-                time.sleep(0.1)
+                time.sleep(0.4)
 
     #------------------------------------------------------------------------------------------------------------------
     # IPv6 message Sender and Receiver class


### PR DESCRIPTION
This commit updates the `start.sh` script under `toranj` test
framework so that failed tested are tried again up to 3 times.
It also modifed how wpantund project is build and installed
under `toranj`.

