### PR TITLE
[examples] Introducing pseudo resets

### DIFF
--- a/examples/apps/cli/main.c
+++ b/examples/apps/cli/main.c
@@ -63,6 +63,8 @@ int main(int argc, char *argv[])
     uint8_t *otInstanceBuffer       = NULL;
 #endif
 
+pseudo_reset:
+
     PlatformInit(argc, argv);
 
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
@@ -86,16 +88,18 @@ int main(int argc, char *argv[])
     otDiagInit(sInstance);
 #endif
 
-    while (1)
+    while (!PlatformPseudoResetWasRequested())
     {
         otTaskletsProcess(sInstance);
         PlatformProcessDrivers(sInstance);
     }
 
-        // otInstanceFinalize(sInstance);
+    otInstanceFinalize(sInstance);
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-        // free(otInstanceBuffer);
+    free(otInstanceBuffer);
 #endif
+
+    goto pseudo_reset;
 
     return 0;
 }

--- a/examples/apps/ncp/main.c
+++ b/examples/apps/ncp/main.c
@@ -62,6 +62,8 @@ int main(int argc, char *argv[])
     uint8_t *otInstanceBuffer       = NULL;
 #endif
 
+pseudo_reset:
+
     PlatformInit(argc, argv);
 
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
@@ -85,16 +87,18 @@ int main(int argc, char *argv[])
     otDiagInit(sInstance);
 #endif
 
-    while (1)
+    while (!PlatformPseudoResetWasRequested())
     {
         otTaskletsProcess(sInstance);
         PlatformProcessDrivers(sInstance);
     }
 
-        // otInstanceFinalize(sInstance);
+    otInstanceFinalize(sInstance);
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-        // free(otInstanceBuffer);
+    free(otInstanceBuffer);
 #endif
+
+    goto pseudo_reset;
 
     return 0;
 }

--- a/examples/platforms/cc2538/platform.c
+++ b/examples/platforms/cc2538/platform.c
@@ -49,6 +49,11 @@ void PlatformInit(int argc, char *argv[])
     (void)argv;
 }
 
+bool PlatformPseudoResetWasRequested(void)
+{
+    return false;
+}
+
 void PlatformProcessDrivers(otInstance *aInstance)
 {
     sInstance = aInstance;

--- a/examples/platforms/cc2650/platform.c
+++ b/examples/platforms/cc2650/platform.c
@@ -57,6 +57,11 @@ void PlatformInit(int argc, char *argv[])
     cc2650RadioInit();
 }
 
+bool PlatformPseudoResetWasRequested(void)
+{
+    return false;
+}
+
 /**
  * Function documented in platform-cc2650.h
  */

--- a/examples/platforms/cc2652/platform.c
+++ b/examples/platforms/cc2652/platform.c
@@ -71,6 +71,11 @@ void PlatformInit(int argc, char *argv[])
     cc2652RadioInit();
 }
 
+bool PlatformPseudoResetWasRequested(void)
+{
+    return false;
+}
+
 /**
  * Function documented in platform-cc2652.h
  */

--- a/examples/platforms/da15000/platform.c
+++ b/examples/platforms/da15000/platform.c
@@ -138,6 +138,11 @@ void PlatformInit(int argc, char *argv[])
     (void)argv;
 }
 
+bool PlatformPseudoResetWasRequested(void)
+{
+    return false;
+}
+
 static sys_clk_t ClkGet(void)
 {
     sys_clk_t clk    = sysclk_RC16;

--- a/examples/platforms/efr32/platform.c
+++ b/examples/platforms/efr32/platform.c
@@ -66,6 +66,11 @@ void PlatformInit(int argc, char *argv[])
     efr32RandomInit();
 }
 
+bool PlatformPseudoResetWasRequested(void)
+{
+    return false;
+}
+
 void PlatformDeinit(void)
 {
     efr32RadioDeinit();

--- a/examples/platforms/emsk/platform.c
+++ b/examples/platforms/emsk/platform.c
@@ -53,6 +53,11 @@ void PlatformInit(int argc, char *argv[])
     (void)argv;
 }
 
+bool PlatformPseudoResetWasRequested(void)
+{
+    return false;
+}
+
 void PlatformProcessDrivers(otInstance *aInstance)
 {
     emskUartProcess();

--- a/examples/platforms/gp712/platform.c
+++ b/examples/platforms/gp712/platform.c
@@ -76,6 +76,11 @@ void PlatformInit(int argc, char *argv[])
     qorvoRadioInit();
 }
 
+bool PlatformPseudoResetWasRequested(void)
+{
+    return false;
+}
+
 void PlatformProcessDrivers(otInstance *aInstance)
 {
     if (localInstance == NULL)

--- a/examples/platforms/kw41z/platform.c
+++ b/examples/platforms/kw41z/platform.c
@@ -100,6 +100,11 @@ void PlatformInit(int argc, char *argv[])
     (void)argv;
 }
 
+bool PlatformPseudoResetWasRequested(void)
+{
+    return false;
+}
+
 void PlatformDeinit(void)
 {
 }

--- a/examples/platforms/nrf52840/alarm.c
+++ b/examples/platforms/nrf52840/alarm.c
@@ -339,6 +339,9 @@ static void AlarmStop(AlarmIndex aIndex)
 void nrf5AlarmInit(void)
 {
     memset(sTimerData, 0, sizeof(sTimerData));
+    sOverflowCounter = 0;
+    sMutex           = 0;
+    sTimeOffset      = 0;
 
     // Setup low frequency clock.
     nrf_drv_clock_lfclk_request(NULL);

--- a/examples/platforms/nrf52840/misc.c
+++ b/examples/platforms/nrf52840/misc.c
@@ -40,6 +40,8 @@
 
 static uint32_t sResetReason;
 
+bool gPlatformPseudoResetWasRequested;
+
 __WEAK void nrf5CryptoInit(void)
 {
     // This function is defined as weak so it could be overridden with external implementation.
@@ -69,8 +71,12 @@ void nrf5MiscDeinit(void)
 void otPlatReset(otInstance *aInstance)
 {
     (void)aInstance;
-
+#if OPENTHREAD_PLATFORM_USE_PSEUDO_RESET
+    gPlatformPseudoResetWasRequested = true;
+    sResetReason                     = POWER_RESETREAS_SREQ_Msk;
+#else  // if OPENTHREAD_PLATFORM_USE_PSEUDO_RESET
     NVIC_SystemReset();
+#endif // else OPENTHREAD_PLATFORM_USE_PSEUDO_RESET
 }
 
 otPlatResetReason otPlatGetResetReason(otInstance *aInstance)

--- a/examples/platforms/nrf52840/platform-config.h
+++ b/examples/platforms/nrf52840/platform-config.h
@@ -347,6 +347,16 @@
 #define USB_CDC_AS_SERIAL_TRANSPORT 0
 #endif
 
+/**
+ * @def OPENTHREAD_PLATFORM_USE_PSEUDO_RESET
+ *
+ * Reset the application, not the chip, when a software reset is requested.
+ * via `otPlatReset()`.
+ */
+#ifndef OPENTHREAD_PLATFORM_USE_PSEUDO_RESET
+#define OPENTHREAD_PLATFORM_USE_PSEUDO_RESET USB_CDC_AS_SERIAL_TRANSPORT
+#endif
+
 /*******************************************************************************
  * @section Radio driver configuration.
  ******************************************************************************/

--- a/examples/platforms/nrf52840/platform.c
+++ b/examples/platforms/nrf52840/platform.c
@@ -51,6 +51,18 @@ void __cxa_pure_virtual(void)
 
 void PlatformInit(int argc, char *argv[])
 {
+    extern bool gPlatformPseudoResetWasRequested;
+
+    if (gPlatformPseudoResetWasRequested)
+    {
+        nrf5AlarmDeinit();
+        nrf5AlarmInit();
+
+        gPlatformPseudoResetWasRequested = false;
+
+        return;
+    }
+
     (void)argc;
     (void)argv;
 
@@ -85,6 +97,12 @@ void PlatformDeinit(void)
 #if (OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED)
     nrf5LogDeinit();
 #endif
+}
+
+bool PlatformPseudoResetWasRequested(void)
+{
+    extern bool gPlatformPseudoResetWasRequested;
+    return gPlatformPseudoResetWasRequested;
 }
 
 void PlatformProcessDrivers(otInstance *aInstance)

--- a/examples/platforms/platform.h
+++ b/examples/platforms/platform.h
@@ -54,6 +54,14 @@ void PlatformInit(int argc, char *argv[]);
 void PlatformDeinit(void);
 
 /**
+ * This function returns true is a pseudo-reset was requested.
+ * In such a case, the main loop should shut down and re-initialize
+ * the OpenThread instance.
+ *
+ */
+bool PlatformPseudoResetWasRequested(void);
+
+/**
  * This function performs all platform-specific processing.
  *
  * @param[in]  aInstance  The OpenThread instance structure.

--- a/examples/platforms/posix/platform.c
+++ b/examples/platforms/posix/platform.c
@@ -55,6 +55,8 @@
 uint32_t NODE_ID           = 1;
 uint32_t WELLKNOWN_NODE_ID = 34;
 
+extern bool gPlatformPseudoResetWasRequested;
+
 #ifndef _WIN32
 int    gArgumentsCount = 0;
 char **gArguments      = NULL;
@@ -63,6 +65,12 @@ char **gArguments      = NULL;
 void PlatformInit(int argc, char *argv[])
 {
     char *endptr;
+
+    if (gPlatformPseudoResetWasRequested)
+    {
+        gPlatformPseudoResetWasRequested = false;
+        return;
+    }
 
     if (argc != 2)
     {
@@ -88,6 +96,11 @@ void PlatformInit(int argc, char *argv[])
     platformAlarmInit();
     platformRadioInit();
     platformRandomInit();
+}
+
+bool PlatformPseudoResetWasRequested(void)
+{
+    return gPlatformPseudoResetWasRequested;
 }
 
 void PlatformDeinit(void)

--- a/examples/platforms/posix/sim/platform-sim.c
+++ b/examples/platforms/posix/sim/platform-sim.c
@@ -52,6 +52,8 @@
 uint32_t NODE_ID           = 1;
 uint32_t WELLKNOWN_NODE_ID = 34;
 
+extern bool gPlatformPseudoResetWasRequested;
+
 int    gArgumentsCount = 0;
 char **gArguments      = NULL;
 
@@ -170,6 +172,12 @@ void PlatformInit(int argc, char *argv[])
 {
     char *endptr;
 
+    if (gPlatformPseudoResetWasRequested)
+    {
+        gPlatformPseudoResetWasRequested = false;
+        return;
+    }
+
     if (argc != 2)
     {
         exit(EXIT_FAILURE);
@@ -194,6 +202,11 @@ void PlatformInit(int argc, char *argv[])
     platformAlarmInit();
     platformRadioInit();
     platformRandomInit();
+}
+
+bool PlatformPseudoResetWasRequested(void)
+{
+    return gPlatformPseudoResetWasRequested;
 }
 
 void PlatformDeinit(void)

--- a/examples/platforms/samr21/platform.c
+++ b/examples/platforms/samr21/platform.c
@@ -175,6 +175,11 @@ void PlatformInit(int argc, char *argv[])
     samr21RadioInit();
 }
 
+bool PlatformPseudoResetWasRequested(void)
+{
+    return false;
+}
+
 void PlatformDeinit(void)
 {
 }


### PR DESCRIPTION
Pseudo resets allow for `otPlatReset()` to reset the OpenThread state without resetting the chip. This is important if the SoC is presenting itself as a USB device.

The build option `OPENTHREAD_PLATFORM_USE_PSEUDO_RESET` can be used to force this feature to be enabled or disabled by setting it to `1` or `0` accordingly. Otherwise it will be set to a platform-specified default value.