### PR TITLE
[posix] enable time speed up feature

### DIFF
--- a/examples/platforms/posix/alarm.c
+++ b/examples/platforms/posix/alarm.c
@@ -50,10 +50,13 @@ static uint32_t sMsAlarm     = 0;
 static bool     sIsUsRunning = false;
 static uint32_t sUsAlarm     = 0;
 
+static uint32_t sSpeedUpFactor = 1;
+
 static struct timeval sStart;
 
-void platformAlarmInit(void)
+void platformAlarmInit(uint32_t aSpeedUpFactor)
 {
+    sSpeedUpFactor = aSpeedUpFactor;
     gettimeofday(&sStart, NULL);
 }
 
@@ -64,7 +67,7 @@ uint32_t otPlatAlarmMilliGetNow(void)
     gettimeofday(&tv, NULL);
     timersub(&tv, &sStart, &tv);
 
-    return (uint32_t)((tv.tv_sec * MS_PER_S) + (tv.tv_usec / US_PER_MS));
+    return (uint32_t)((tv.tv_sec * sSpeedUpFactor * MS_PER_S) + (tv.tv_usec * sSpeedUpFactor / US_PER_MS));
 }
 
 void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
@@ -87,7 +90,7 @@ uint32_t otPlatAlarmMicroGetNow(void)
     gettimeofday(&tv, NULL);
     timersub(&tv, &sStart, &tv);
 
-    return (uint32_t)(tv.tv_sec * US_PER_S + tv.tv_usec);
+    return (uint32_t)(tv.tv_sec * US_PER_S + tv.tv_usec) * sSpeedUpFactor;
 }
 
 void otPlatAlarmMicroStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
@@ -128,15 +131,24 @@ void platformAlarmUpdateTimeout(struct timeval *aTimeout)
         aTimeout->tv_sec  = 0;
         aTimeout->tv_usec = 0;
     }
-    else if (msRemaining * US_PER_MS < usRemaining)
-    {
-        aTimeout->tv_sec  = msRemaining / MS_PER_S;
-        aTimeout->tv_usec = (msRemaining % MS_PER_S) * US_PER_MS;
-    }
     else
     {
-        aTimeout->tv_sec  = usRemaining / US_PER_S;
-        aTimeout->tv_usec = usRemaining % US_PER_S;
+        int64_t remaining = ((int64_t)msRemaining) * US_PER_MS;
+
+        if (usRemaining < remaining)
+        {
+            remaining = usRemaining;
+        }
+
+        remaining /= sSpeedUpFactor;
+
+        if (remaining == 0)
+        {
+            remaining = 1;
+        }
+
+        aTimeout->tv_sec  = remaining / US_PER_S;
+        aTimeout->tv_usec = remaining % US_PER_S;
     }
 }
 

--- a/examples/platforms/posix/platform-posix.h
+++ b/examples/platforms/posix/platform-posix.h
@@ -114,7 +114,7 @@ extern uint32_t WELLKNOWN_NODE_ID;
  * This function initializes the alarm service used by OpenThread.
  *
  */
-void platformAlarmInit(void);
+void platformAlarmInit(uint32_t aSpeedUpFactor);
 
 /**
  * This function retrieves the time remaining until the alarm fires.

--- a/examples/platforms/posix/sim/alarm-sim.c
+++ b/examples/platforms/posix/sim/alarm-sim.c
@@ -48,8 +48,9 @@ static uint32_t sMsAlarm     = 0;
 static bool     sIsUsRunning = false;
 static uint32_t sUsAlarm     = 0;
 
-void platformAlarmInit(void)
+void platformAlarmInit(uint32_t aSpeedUpFactor)
 {
+    (void)aSpeedUpFactor;
     sNow = 0;
 }
 

--- a/examples/platforms/posix/sim/platform-sim.c
+++ b/examples/platforms/posix/sim/platform-sim.c
@@ -199,7 +199,7 @@ void PlatformInit(int argc, char *argv[])
 
     socket_init();
 
-    platformAlarmInit();
+    platformAlarmInit(1);
     platformRadioInit();
     platformRandomInit();
 }

--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -173,7 +173,8 @@ def _log(text, new_line=True, flush=True):
 class Node(object):
     """ A wpantund OT NCP instance """
 
-    _VERBOSE = False     # defines the default verbosity setting (can be changed per `Node`)
+    _VERBOSE = False        # defines the default verbosity setting (can be changed per `Node`)
+    _SPEED_UP_FACTOR = 1    # defines the default time speed up factor
 
     # path to `wpantund`, `wpanctl` and `ot-ncp-ftd` code
     _WPANTUND = '/usr/local/sbin/wpantund'
@@ -200,8 +201,10 @@ class Node(object):
         self._interface_name = self._INTFC_NAME_PREFIX + str(index)
         self._verbose = verbose
 
+        ncp_socket_path = 'system:{} {} {}'.format(self._OT_NCP_FTD, index, self._SPEED_UP_FACTOR)
+
         cmd = self._WPANTUND + \
-               ' -o Config:NCP:SocketPath \"system:{} {}\"'.format(self._OT_NCP_FTD, index) + \
+               ' -o Config:NCP:SocketPath \"{}\"'.format(ncp_socket_path) + \
                ' -o Config:TUN:InterfaceName {}'.format(self._interface_name) + \
                ' -o Config:NCP:DriverName spinel' + \
                ' -o Daemon:SyslogMask \"all -debug\"'
@@ -423,6 +426,13 @@ class Node(object):
                 else:
                     break
                 time.sleep(0.4)
+
+    @classmethod
+    def set_time_speedup_factor(cls, factor):
+        """Sets up the time speed up factor - should be set before creating any `Node` objects"""
+        if len(Node._all_nodes) != 0:
+            raise Node._NodeError('set_time_speedup_factor() cannot be called after creating a `Node`')
+        Node._SPEED_UP_FACTOR = factor
 
     #------------------------------------------------------------------------------------------------------------------
     # IPv6 message Sender and Receiver class


### PR DESCRIPTION
This commit adds a new feature under posix platform to emulate
time (platform Alarm APIs) with a given speed up factor (i.e., as
if time runs `x` times faster). The speed up factor can be given
when running the NCP app as an input argument (default is 1).