### PR TITLE
[child-supervision] change how child supervision gets started/stopped

### DIFF
--- a/src/core/common/notifier.hpp
+++ b/src/core/common/notifier.hpp
@@ -80,7 +80,7 @@ public:
          *
          * @param[in] aCallback    A reference to callback instance.
          * @param[in] aFlags       A bit-field indicating specific state that has changed. See `OT_CHANGED_<STATE>`
-         *                         definitions in `types.h`.
+         *                         definitions in `instance.h`.
          *
          */
         typedef void (*Handler)(Callback &aCallback, uint32_t aFlags);

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -140,7 +140,6 @@ otError ThreadNetif::Up(void)
 #if OPENTHREAD_ENABLE_CHANNEL_MONITOR
         GetInstance().GetChannelMonitor().Start();
 #endif
-        mChildSupervisor.Start();
         mMleRouter.Enable();
         mIsUp = true;
     }
@@ -157,7 +156,6 @@ otError ThreadNetif::Down(void)
 #if OPENTHREAD_ENABLE_CHANNEL_MONITOR
     GetInstance().GetChannelMonitor().Stop();
 #endif
-    mChildSupervisor.Stop();
     mMleRouter.Disable();
     mMeshForwarder.Stop();
     GetIp6().RemoveNetif(*this);

--- a/src/core/utils/child_supervision.hpp
+++ b/src/core/utils/child_supervision.hpp
@@ -39,6 +39,7 @@
 
 #include "common/locator.hpp"
 #include "common/message.hpp"
+#include "common/notifier.hpp"
 #include "common/timer.hpp"
 #include "mac/mac_frame.hpp"
 #include "thread/topology.hpp"
@@ -155,11 +156,15 @@ private:
     };
 
     void        SendMessage(Child &aChild);
+    void        CheckState(void);
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
+    static void HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags);
+    void        HandleStateChanged(uint32_t aFlags);
 
-    uint16_t   mSupervisionInterval;
-    TimerMilli mTimer;
+    uint16_t           mSupervisionInterval;
+    TimerMilli         mTimer;
+    Notifier::Callback mNotifierCallback;
 };
 
 #else // #if OPENTHREAD_ENABLE_CHILD_SUPERVISION && OPENTHREAD_FTD


### PR DESCRIPTION
This commit removes the `Start()/Stop()` APIs from `ChildSupervisor`
class. Instead `ChildSupervisor` class itself would decide when to
start/stop. It registers a `Notifier` callback to be notified when the
Thread role changes and/or when a child is added or removed. If MLE
operation is enabled and there is at least one "valid" child in the
child table, child supervision starts, otherwise it is stopped.