### PR TITLE
[nrf52840] custom EUI-64 get

### DIFF
--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -171,6 +171,7 @@ static inline void clearPendingEvents(void)
     } while (__STREXW(pendingEvents, (unsigned long volatile *)&sPendingEvents));
 }
 
+#if !OPENTHREAD_CONFIG_ENABLE_PLATFORM_EUI64_CUSTOM_SOURCE
 void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeeeEui64)
 {
     (void)aInstance;
@@ -180,6 +181,7 @@ void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeeeEui64)
 
     memcpy(aIeeeEui64, &factoryAddress, sizeof(factoryAddress));
 }
+#endif // OPENTHREAD_CONFIG_ENABLE_PLATFORM_EUI64_CUSTOM_SOURCE
 
 void otPlatRadioSetPanId(otInstance *aInstance, uint16_t aPanId)
 {

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -922,6 +922,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_ENABLE_PLATFORM_EUI64_CUSTOM_SOURCE
+ *
+ * Allows to define custom otPlatRadioGetIeeeEui64 function to retrieve EUI-64.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ENABLE_PLATFORM_EUI64_CUSTOM_SOURCE
+#define OPENTHREAD_CONFIG_ENABLE_PLATFORM_EUI64_CUSTOM_SOURCE 0
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_ENABLE_AUTO_START_SUPPORT
  *
  * Define to 1 if you want to enable auto start logic.


### PR DESCRIPTION
This change allows to define custom otPlatRadioGetIeeeEui64 function on nrf52840 platform.