### PR TITLE
[key-manager] set default key from KeyManager

### DIFF
--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -47,8 +47,28 @@ static const uint8_t kThreadString[] = {
     'T', 'h', 'r', 'e', 'a', 'd',
 };
 
+static const otMasterKey kDefaultMasterKey = {{
+    0x00,
+    0x11,
+    0x22,
+    0x33,
+    0x44,
+    0x55,
+    0x66,
+    0x77,
+    0x88,
+    0x99,
+    0xaa,
+    0xbb,
+    0xcc,
+    0xdd,
+    0xee,
+    0xff,
+}};
+
 KeyManager::KeyManager(Instance &aInstance)
     : InstanceLocator(aInstance)
+    , mMasterKey(kDefaultMasterKey)
     , mKeySequence(0)
     , mMacFrameCounter(0)
     , mMleFrameCounter(0)
@@ -62,6 +82,7 @@ KeyManager::KeyManager(Instance &aInstance)
     , mKekFrameCounter(0)
     , mSecurityPolicyFlags(0xff)
 {
+    ComputeKey(mKeySequence, mKey);
 }
 
 void KeyManager::Start(void)

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -49,25 +49,6 @@ using ot::Encoding::BigEndian::HostSwap16;
 
 namespace ot {
 
-static const otMasterKey kThreadMasterKey = {{
-    0x00,
-    0x11,
-    0x22,
-    0x33,
-    0x44,
-    0x55,
-    0x66,
-    0x77,
-    0x88,
-    0x99,
-    0xaa,
-    0xbb,
-    0xcc,
-    0xdd,
-    0xee,
-    0xff,
-}};
-
 ThreadNetif::ThreadNetif(Instance &aInstance)
     : Netif(aInstance, OT_NETIF_INTERFACE_ID_THREAD)
     , mCoap(aInstance)
@@ -123,7 +104,6 @@ ThreadNetif::ThreadNetif(Instance &aInstance)
     , mEnergyScan(aInstance)
 
 {
-    mKeyManager.SetMasterKey(kThreadMasterKey);
     mCoap.SetInterceptor(&ThreadNetif::TmfFilter, this);
 }
 


### PR DESCRIPTION
This commit moves the setting/initialization of default key from
`ThreadNetif` to `KeyManager` class.

