### PR TITLE
[nrf52840] remove startup delay after software reset in USB driver

### DIFF
--- a/examples/platforms/nrf52840/platform-config.h
+++ b/examples/platforms/nrf52840/platform-config.h
@@ -318,16 +318,6 @@
 #endif
 
 /**
- * @def USB_INITIAL_DELAY_MS
- *
- * Init delay for USB driver, used when software reset was detected to help OS to re-enumerate the device.
- *
- */
-#ifndef USB_INITIAL_DELAY_MS
-#define USB_INITIAL_DELAY_MS 600
-#endif
-
-/**
  * @def USB_HOST_UART_CONFIG_DELAY_MS
  *
  * Delay after DTR gets asserted that we start send any queued data. This allows slow

--- a/examples/platforms/nrf52840/usb-cdc-uart.c
+++ b/examples/platforms/nrf52840/usb-cdc-uart.c
@@ -205,13 +205,6 @@ static void processConnection(void)
     // Provide some delay so the OS can re-enumerate the device in case of reset.
     if (sUsbState.mReadyToStart)
     {
-        if (((otPlatGetResetReason(NULL) == OT_PLAT_RESET_REASON_EXTERNAL) ||
-             (otPlatGetResetReason(NULL) == OT_PLAT_RESET_REASON_SOFTWARE)) &&
-            (otPlatAlarmMilliGetNow() < USB_INITIAL_DELAY_MS))
-        {
-            return;
-        }
-
         sUsbState.mReadyToStart = false;
 
         if (nrf_drv_usbd_is_enabled())


### PR DESCRIPTION
Remove initial delay for USB driver, as it is unnecessary after pseudo reset was introduced.

Additionaly, after USB driver was updated, it behave incorrectly in applications using WFE (for example CLI with WFE enabled got stuck after being flashed, until USB cable was plugged out and in).

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>