### PR TITLE
[jam-detector] pause jam detection when thread is disabled

### DIFF
--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #include "common/locator.hpp"
+#include "common/notifier.hpp"
 #include "common/timer.hpp"
 #include "utils/wrap_stdint.h"
 
@@ -173,12 +174,6 @@ public:
     uint64_t GetHistoryBitmap(void) const { return mHistoryBitmap; }
 
 private:
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
-    void        UpdateHistory(bool aThresholdExceeded);
-    void        UpdateJamState(void);
-
-private:
     enum
     {
         kMaxWindow            = 63, // Max window size
@@ -188,21 +183,30 @@ private:
         kMinSampleInterval = 2,   // in ms
         kMaxRandomDelay    = 4,   // in ms
         kOneSecondInterval = 1000 // in ms
-
     };
 
-    Handler    mHandler;                  // Handler/callback to inform about jamming state
-    void *     mContext;                  // Context for handler/callback
-    int8_t     mRssiThreshold;            // RSSI threshold for jam detection
-    TimerMilli mTimer;                    // RSSI sample timer
-    uint64_t   mHistoryBitmap;            // History bitmap, each bit correspond to 1 sec interval
-    uint32_t   mCurSecondStartTime;       // Start time for current 1 sec interval
-    uint16_t   mSampleInterval;           // Current sample interval
-    uint8_t    mWindow : 6;               // Window (in sec) to monitor jamming
-    uint8_t    mBusyPeriod : 6;           // BusyPeriod (in sec) with mWindow to alert jamming
-    bool       mEnabled : 1;              // If jam detection is enabled
-    bool       mAlwaysAboveThreshold : 1; // State for current 1 sec interval
-    bool       mJamState : 1;             // Current jam state
+    void        CheckState(void);
+    void        SetJamState(bool aNewState);
+    static void HandleTimer(Timer &aTimer);
+    void        HandleTimer(void);
+    void        UpdateHistory(bool aThresholdExceeded);
+    void        UpdateJamState(void);
+    static void HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags);
+    void        HandleStateChanged(uint32_t aFlags);
+
+    Handler            mHandler;                  // Handler/callback to inform about jamming state
+    void *             mContext;                  // Context for handler/callback
+    Notifier::Callback mNotifierCallback;         // Notifier callback
+    TimerMilli         mTimer;                    // RSSI sample timer
+    uint64_t           mHistoryBitmap;            // History bitmap, each bit correspond to 1 sec interval
+    uint32_t           mCurSecondStartTime;       // Start time for current 1 sec interval
+    uint16_t           mSampleInterval;           // Current sample interval
+    uint8_t            mWindow : 6;               // Window (in sec) to monitor jamming
+    uint8_t            mBusyPeriod : 6;           // BusyPeriod (in sec) with mWindow to alert jamming
+    bool               mEnabled : 1;              // If jam detection is enabled
+    bool               mAlwaysAboveThreshold : 1; // State for current 1 sec interval
+    bool               mJamState : 1;             // Current jam state
+    int8_t             mRssiThreshold;            // RSSI threshold for jam detection
 };
 
 /**


### PR DESCRIPTION
Once jamming detection is enabled/started, `JamDetector`  will also
monitor the Thread device role. RSSI sampling is stopped if the device
role changes to `DISABLED` and is resumed if the role changes. This
commit also adds new logs to this class to indicate when jamming is
detected or cleared and/or when any of the parameters get changed.