### PR TITLE
[mac] process frame pending bit at the MAC layer

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1106,8 +1106,6 @@ void MeshForwarder::HandleReceivedFrame(Mac::Frame &aFrame)
 
     netif.GetSupervisionListener().UpdateOnReceive(macSource, linkInfo.mLinkSecurity);
 
-    mDataPollManager.CheckFramePending(aFrame);
-
     switch (aFrame.GetType())
     {
     case Mac::Frame::kFcfFrameData:


### PR DESCRIPTION
This commit allows processing of the frame pending bit to occur even if the
received frame is a duplicate.