### PR TITLE
[toranj] update verify() to print line-no and test-name

### DIFF
--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -34,6 +34,7 @@ import weakref
 import subprocess
 import socket
 import asyncore
+import inspect
 
 #----------------------------------------------------------------------------------------------------------------------
 # wpantund properties
@@ -714,8 +715,10 @@ class AsyncReceiver(asyncore.dispatcher):
 #-----------------------------------------------------------------------------------------------------------------------
 
 def verify(condition):
+    """Verifies that a `condition` is true, otherwise exits"""
     if not condition:
-        print 'verify() failed'
+        calling_frame = inspect.currentframe().f_back
+        print 'verify() failed at line {} in "{}"'.format(calling_frame.f_lineno, calling_frame.f_code.co_filename)
         exit(1)
 
 


### PR DESCRIPTION
This commit updates the `verify()` definition in `toranj/wpan.py`
module to print the file-name and line number when the condition
fails.