### PR TITLE
[meshcop] fix dataset manager returning stack pointer

### DIFF
--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -94,15 +94,6 @@ otError DatasetManager::AppendMleDatasetTlv(Message &aMessage) const
     return dataset.AppendMleDatasetTlv(aMessage);
 }
 
-const Tlv *DatasetManager::GetTlv(Tlv::Type aType) const
-{
-    Dataset dataset(mLocal.GetType());
-
-    mLocal.Get(dataset);
-
-    return dataset.Get(aType);
-}
-
 otError DatasetManager::Restore(void)
 {
     otError          error;
@@ -203,9 +194,11 @@ void DatasetManager::HandleTimer(void)
 
     if (mLocal.GetType() == Tlv::kActiveTimestamp)
     {
-        const ActiveTimestampTlv *tlv =
-            static_cast<const ActiveTimestampTlv *>(netif.GetPendingDataset().GetTlv(Tlv::kActiveTimestamp));
-        const Timestamp *pendingActiveTimestamp = static_cast<const Timestamp *>(tlv);
+        Dataset dataset(Tlv::kPendingTimestamp);
+        netif.GetPendingDataset().Get(dataset);
+
+        const ActiveTimestampTlv *tlv = static_cast<const ActiveTimestampTlv *>(dataset.Get(Tlv::kActiveTimestamp));
+        const Timestamp *         pendingActiveTimestamp = static_cast<const Timestamp *>(tlv);
 
         if (pendingActiveTimestamp != NULL && mLocal.Compare(pendingActiveTimestamp) >= 0)
         {

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -92,14 +92,6 @@ public:
     otError AppendMleDatasetTlv(Message &aMessage) const;
 
     /**
-     * This method returns a pointer to the TLV.
-     *
-     * @returns A pointer to the TLV or NULL if none is found.
-     *
-     */
-    const Tlv *GetTlv(Tlv::Type aType) const;
-
-    /**
      * This method retrieves the dataset from non-volatile memory.
      *
      * @param[out]  aDataset  Where to place the dataset.

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -312,6 +312,7 @@ otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessage
     Message *        message = NULL;
     Coap::Header     header;
     Ip6::MessageInfo messageInfo;
+    Dataset          dataset(MeshCoP::Tlv::kActiveTimestamp);
 
     NetworkMasterKeyTlv   masterKey;
     MeshLocalPrefixTlv    meshLocalPrefix;
@@ -345,7 +346,8 @@ otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessage
     networkName.SetNetworkName(netif.GetMac().GetNetworkName());
     SuccessOrExit(error = message->Append(&networkName, sizeof(Tlv) + networkName.GetLength()));
 
-    if ((tlv = netif.GetActiveDataset().GetTlv(Tlv::kActiveTimestamp)) != NULL)
+    netif.GetActiveDataset().Get(dataset);
+    if ((tlv = dataset.Get(Tlv::kActiveTimestamp)) != NULL)
     {
         SuccessOrExit(error = message->Append(tlv, sizeof(Tlv) + tlv->GetLength()));
     }
@@ -356,7 +358,7 @@ otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessage
         SuccessOrExit(error = message->Append(&activeTimestamp, sizeof(activeTimestamp)));
     }
 
-    if ((tlv = netif.GetActiveDataset().GetTlv(Tlv::kChannelMask)) != NULL)
+    if ((tlv = dataset.Get(Tlv::kChannelMask)) != NULL)
     {
         SuccessOrExit(error = message->Append(tlv, sizeof(Tlv) + tlv->GetLength()));
     }
@@ -367,7 +369,7 @@ otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessage
         SuccessOrExit(error = message->Append(&channelMask, sizeof(channelMask)));
     }
 
-    if ((tlv = netif.GetActiveDataset().GetTlv(Tlv::kPSKc)) != NULL)
+    if ((tlv = dataset.Get(Tlv::kPSKc)) != NULL)
     {
         SuccessOrExit(error = message->Append(tlv, sizeof(Tlv) + tlv->GetLength()));
     }
@@ -378,7 +380,7 @@ otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessage
         SuccessOrExit(error = message->Append(&pskc, sizeof(pskc)));
     }
 
-    if ((tlv = netif.GetActiveDataset().GetTlv(Tlv::kSecurityPolicy)) != NULL)
+    if ((tlv = dataset.Get(Tlv::kSecurityPolicy)) != NULL)
     {
         SuccessOrExit(error = message->Append(tlv, sizeof(Tlv) + tlv->GetLength()));
     }

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2038,9 +2038,10 @@ void Mle::SendOrphanAnnounce(void)
 {
     const MeshCoP::ChannelMask0Tlv *channelMask;
     uint8_t                         channel;
+    MeshCoP::Dataset                dataset(MeshCoP::Tlv::kActiveTimestamp);
 
-    channelMask =
-        static_cast<const MeshCoP::ChannelMask0Tlv *>(GetNetif().GetActiveDataset().GetTlv(MeshCoP::Tlv::kChannelMask));
+    GetNetif().GetActiveDataset().Get(dataset);
+    channelMask = static_cast<const MeshCoP::ChannelMask0Tlv *>(dataset.Get(MeshCoP::Tlv::kChannelMask));
 
     VerifyOrExit(channelMask != NULL);
 


### PR DESCRIPTION
```cpp
const Tlv *DatasetManager::GetTlv(Tlv::Type aType) const
```
The above function returns pointer to stack memory, which could be overwritten before actually using it. I found this issue when debugging commissioning entrust process, which appends SecurityPolicy TLV.
However, the memory pointed by `tlv` returned by the above function was overwritten because the next call to `Message::Append()` will go very deep and the stack goes beyond the `tlv` pointed address.

This PR fixes this issue by removing this convenient function and let the caller provide memory for the wanted dataset.