### PR TITLE
[mac] on ack timeout switch the radio to receive mode

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1455,6 +1455,7 @@ void Mac::HandleMacTimer(void)
 
     case kOperationTransmitData:
         otLogDebgMac(GetInstance(), "Ack timer fired");
+        RadioReceive(mTxFrame->mChannel);
         HandleTransmitDone(mTxFrame, NULL, OT_ERROR_NO_ACK);
         break;
 


### PR DESCRIPTION
This commit changes the `Mac` logic for handling ack timeout to put
the radio in receive mode before invoking the `HandleTransmitDone()`
callback with the `OT_ERROR_NO_ACK` status. This ensures that the
radio can be put to sleep after a no-ack error.

-------
Noticed this in posix simulation mode (when joining as sleepy). This only applies if the radio platform implementation does not implement the ack timeout (and OT `Mac` is used to handle the ack timeout). 