### PR TITLE
[mle] send a unicast MLE Announce in response to a received Announce

### DIFF
--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -1328,6 +1328,19 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_SEND_UNICAST_ANNOUNCE_RESPONSE
+ *
+ * Define as 1 to enable sending of a unicast MLE Announce message in response to a received Announce message from
+ * a device.
+ *
+ * @note The unicast MLE announce message is sent in addition to (and after) the multicast MLE Announce.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_SEND_UNICAST_ANNOUNCE_RESPONSE
+#define OPENTHREAD_CONFIG_SEND_UNICAST_ANNOUNCE_RESPONSE 1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_NCP_ENABLE_PEEK_POKE
  *
  * Define as 1 to enable peek/poke functionality on NCP.

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1483,6 +1483,7 @@ private:
     otError SendParentRequest(void);
     otError SendChildIdRequest(void);
     void    SendOrphanAnnounce(void);
+    otError SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce, const Ip6::Address &aDestination);
 
     bool IsBetterParent(uint16_t aRloc16, uint8_t aLinkQuality, uint8_t aLinkMargin, ConnectivityTlv &aConnectivityTlv);
     void ResetParentCandidate(void);


### PR DESCRIPTION
This commit changes how MLE Announce messages are sent in response to
a received MLE Announce. In addition to a multicast MLE Announce
message, a unicast MLE Announce is also sent. This behavior can be
controlled using `OPENTHREAD_CONFIG_SEND_UNICAST_ANNOUNCE_RESPONSE`
config option. By default this is enabled.

This commit also changes actions taken after receiving an MLE Announce
in `Mle::HandleAnnounce()` to handle the situation where a device may
receive multiple MLE Announce messages with same info. No action is
taken if the device is detached, and current channel and panid match
the values from the received MLE Announce message.