### PR TITLE
[channel-manager] allow channel manager feature without channel-monitor

### DIFF
--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -369,16 +369,6 @@ exit:
     return error;
 }
 
-#else // OPENTHREAD_ENABLE_CHANNEL_MONITOR
-
-otError ChannelManager::FindBetterChannel(uint8_t &, uint16_t &)
-{
-    otLogInfoUtil(GetInstance(), "ChannelManager: ChannelMonitor feature is disabled - cannot select channel");
-    return OT_ERROR_DISABLED_FEATURE;
-}
-
-#endif // OPENTHREAD_ENABLE_CHANNEL_MONITOR
-
 bool ChannelManager::ShouldAttamptChannelChange(void)
 {
     uint16_t ccaFailureRate = GetInstance().Get<Mac::Mac>().GetCcaFailureRate();
@@ -439,6 +429,16 @@ exit:
 
     return error;
 }
+
+#else // OPENTHREAD_ENABLE_CHANNEL_MONITOR
+
+otError ChannelManager::RequestChannelSelect(bool)
+{
+    otLogInfoUtil(GetInstance(), "ChannelManager: ChannelMonitor feature is disabled - cannot select channel");
+    return OT_ERROR_DISABLED_FEATURE;
+}
+
+#endif // OPENTHREAD_ENABLE_CHANNEL_MONITOR
 
 void ChannelManager::StartAutoSelectTimer(void)
 {

--- a/src/core/utils/channel_manager.hpp
+++ b/src/core/utils/channel_manager.hpp
@@ -276,9 +276,12 @@ private:
     static void HandleStateChanged(Notifier::Callback &aCallback, uint32_t aChangedFlags);
     void        HandleStateChanged(uint32_t aChangedFlags);
     void        PreparePendingDataset(void);
-    otError     FindBetterChannel(uint8_t &aNewChannel, uint16_t &aOccupancy);
-    bool        ShouldAttamptChannelChange(void);
     void        StartAutoSelectTimer(void);
+
+#if OPENTHREAD_ENABLE_CHANNEL_MONITOR
+    otError FindBetterChannel(uint8_t &aNewChannel, uint16_t &aOccupancy);
+    bool    ShouldAttamptChannelChange(void);
+#endif
 
     Mac::ChannelMask   mSupportedChannelMask;
     Mac::ChannelMask   mFavoredChannelMask;


### PR DESCRIPTION
This commit fixes an issue to allow "channel manager" feature to be
enabled without requiring the channel-monitor feature.