### PR TITLE
[mle] adding SetRole() method to change device role

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -972,6 +972,14 @@ protected:
     Message *NewMleMessage(void);
 
     /**
+     * This method sets the device role.
+     *
+     * @param[in] aRole A device role.
+     *
+     */
+    void SetRole(otDeviceRole aRole);
+
+    /**
      * This method appends an MLE header to a message.
      *
      * @param[in]  aMessage  A reference to the message.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -416,13 +416,8 @@ otError MleRouter::SetStateRouter(uint16_t aRloc16)
 {
     ThreadNetif &netif = GetNetif();
 
-    if (mRole != OT_DEVICE_ROLE_ROUTER)
-    {
-        GetNotifier().SetFlags(OT_CHANGED_THREAD_ROLE);
-    }
-
     SetRloc16(aRloc16);
-    mRole               = OT_DEVICE_ROLE_ROUTER;
+    SetRole(OT_DEVICE_ROLE_ROUTER);
     mParentRequestState = kParentIdle;
     mParentRequestTimer.Stop();
     mChildUpdateRequestTimer.Stop();
@@ -455,7 +450,6 @@ otError MleRouter::SetStateRouter(uint16_t aRloc16)
         }
     }
 
-    otLogInfoMle(GetInstance(), "Role -> Router");
     return OT_ERROR_NONE;
 }
 
@@ -463,13 +457,8 @@ otError MleRouter::SetStateLeader(uint16_t aRloc16)
 {
     ThreadNetif &netif = GetNetif();
 
-    if (mRole != OT_DEVICE_ROLE_LEADER)
-    {
-        GetNotifier().SetFlags(OT_CHANGED_THREAD_ROLE);
-    }
-
     SetRloc16(aRloc16);
-    mRole               = OT_DEVICE_ROLE_LEADER;
+    SetRole(OT_DEVICE_ROLE_LEADER);
     mParentRequestState = kParentIdle;
     mParentRequestTimer.Stop();
     mChildUpdateRequestTimer.Stop();
@@ -502,7 +491,8 @@ otError MleRouter::SetStateLeader(uint16_t aRloc16)
         }
     }
 
-    otLogInfoMle(GetInstance(), "Role -> Leader %d", mLeaderData.GetPartitionId());
+    otLogInfoMle(GetInstance(), "Leader partition id 0x%x", mLeaderData.GetPartitionId());
+
     return OT_ERROR_NONE;
 }
 


### PR DESCRIPTION
This commit adds a new method `Mle::SetRole()` to update the device
role. This method is used in MLE class instead of direct assignment to
`mRole` variable. The `SetRole()` will ensure to set flag on
`Notifier` (when there is a role change) and also log the role change.
This change simplifies the code and addresses a (rare) issue where
notifier callback would not be invoked on transition from "detached"
to "disabled" role.