### PR TITLE
[toranj] add test for joining without key

### DIFF
--- a/tests/toranj/test-003-join.py
+++ b/tests/toranj/test-003-join.py
@@ -84,6 +84,18 @@ verify(node2.get(wpan.WPAN_PANID) == node1.get(wpan.WPAN_PANID))
 verify(node2.get(wpan.WPAN_XPANID) == node1.get(wpan.WPAN_XPANID))
 verify(node2.get(wpan.WPAN_KEY) == node1.get(wpan.WPAN_KEY))
 
+node2.leave()
+
+# Join from node2 without setting network key
+node2.join_node(node1, should_set_key=False)
+verify(node2.get(wpan.WPAN_STATE) == wpan.STATE_CREDENTIALS_NEEDED)
+verify(node2.get(wpan.WPAN_NAME) == node1.get(wpan.WPAN_NAME))
+verify(node2.get(wpan.WPAN_PANID) == node1.get(wpan.WPAN_PANID))
+verify(node2.get(wpan.WPAN_XPANID) == node1.get(wpan.WPAN_XPANID))
+node2.set(wpan.WPAN_KEY, node1.get(wpan.WPAN_KEY)[1:-1], binary_data=True)
+verify(node2.get(wpan.WPAN_KEY) == node1.get(wpan.WPAN_KEY))
+verify(node2.get(wpan.WPAN_STATE) == wpan.STATE_ASSOCIATED)
+
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 

--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -377,7 +377,7 @@ class Node(object):
     def is_associated(self):
         return self.get(WPAN_STATE) == STATE_ASSOCIATED
 
-    def join_node(self, node, node_type=JOIN_TYPE_ROUTER):
+    def join_node(self, node, node_type=JOIN_TYPE_ROUTER, should_set_key=True):
         """Join a network specified by another node, `node` should be a Node"""
 
         if not node.is_associated():
@@ -386,10 +386,12 @@ class Node(object):
         name = node.get(WPAN_NAME)
         panid = node.get(WPAN_PANID)
         xpanid = node.get(WPAN_XPANID)
-        netkey = node.get(WPAN_KEY)
         channel = node.get(WPAN_CHANNEL)
 
-        self.set(WPAN_KEY, netkey[1:-1], binary_data=True)
+        if should_set_key:
+            netkey = node.get(WPAN_KEY)
+            self.set(WPAN_KEY, netkey[1:-1], binary_data=True)
+
         return self.join(name[1:-1], channel=channel, node_type=node_type, panid=panid, xpanid=xpanid)
 
     def whitelist_node(self, node):


### PR DESCRIPTION
This PR updates the `test-003-join` test script to add a case
for joining without first setting network key and checking the
wpantund state "associating:credentials-needed".