### PR TITLE
[MAC] Provide a mechanism to start/stop the MAC according to the state of the Interface.

### DIFF
--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -786,6 +786,17 @@ public:
      */
     uint16_t GetCcaFailureRate(void) const { return mCcaSuccessRateTracker.GetFailureRate(); }
 
+    /**
+     * This method Starts/Stops the MAC layer. It is used when the Interface State changes Up/Down.
+     *
+     * @param[in]  aEnable The requested State for the MAC layer. true - Start, false - Stop.
+     *
+     * @retval true   The operation succeeded or the new State equals the current State.
+     * @retval false  The operation failed.
+     *
+     */
+    bool SetEnabled(bool aEnable);
+
 private:
     enum
     {
@@ -924,6 +935,7 @@ private:
 
     SuccessRateTracker mCcaSuccessRateTracker;
     uint16_t           mCcaSampleCount;
+    bool               mEnabled;
 };
 
 /**

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -111,6 +111,7 @@ otError ThreadNetif::Up(void)
 {
     if (!mIsUp)
     {
+        mMac.SetEnabled(true);
         GetIp6().AddNetif(*this);
         mMeshForwarder.Start();
         mCoap.Start(kCoapUdpPort);
@@ -129,6 +130,7 @@ otError ThreadNetif::Up(void)
 
 otError ThreadNetif::Down(void)
 {
+    mMac.SetEnabled(false);
     mCoap.Stop();
 #if OPENTHREAD_ENABLE_DNS_CLIENT
     mDnsClient.Stop();


### PR DESCRIPTION
To ensure proper and expedient shutdown of Openthread when the Interface is brought down, this change provides a mechanism to gracefully stop the MAC layer operations.  Scans are stopped by preventing any new channel change.  New Transmissions are stopped. Existing transmissions are allowed to complete. Any pending operations are cleared.