### PR TITLE
[nrf52840] fix mbedtls define names in openthread-core-nrf52840-config.h

### DIFF
--- a/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
+++ b/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
@@ -141,20 +141,20 @@
 #define SETTINGS_CONFIG_PAGE_NUM                                4
 
 /**
- * @def OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE
+ * @def OPENTHREAD_CONFIG_HEAP_SIZE
  *
- * The size of mbedTLS heap buffer when DTLS is enabled.
+ * The size of heap buffer when DTLS is enabled.
  *
  */
-#define OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE                     (4096 * sizeof(void *))
+#define OPENTHREAD_CONFIG_HEAP_SIZE                             (4096 * sizeof(void *))
 
 /**
- * @def OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE_NO_DTLS
+ * @def OPENTHREAD_CONFIG_HEAP_SIZE_NO_DTLS
  *
- * The size of mbedTLS heap buffer when DTLS is disabled.
+ * The size of heap buffer when DTLS is disabled.
  *
  */
-#define OPENTHREAD_CONFIG_MBEDTLS_HEAP_SIZE_NO_DTLS             2048
+#define OPENTHREAD_CONFIG_HEAP_SIZE_NO_DTLS                     2048
 
 /*
  * Suppress the ARMCC warning on unreachable statement,


### PR DESCRIPTION
This PR alignes openthread-core-nrf52840-config.h to the latest heap related define changes introduced in openthread-core-default-config.h.

Signed-off-by: Piotr Szkotak <piotr.szkotak@nordicsemi.no>