### PR TITLE
[spi-hdlc-adapter] fix compilation on Alpine Linux with musl libc

### DIFF
--- a/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
+++ b/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
@@ -50,6 +50,7 @@
 #include <sys/ioctl.h>
 #include <sys/file.h>
 
+#include <linux/ioctl.h>
 #include <linux/spi/spidev.h>
 
 #if HAVE_EXECINFO_H


### PR DESCRIPTION
Without linux/ioctl.h compilation fails on this platform, because _IOC_SIZEBITS will not be defined.

resolves #2711 