### PR TITLE
[mle] attach backoff feature

### DIFF
--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -1343,6 +1343,71 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_ENABLE_ATTACH_BACKOFF
+ *
+ * Define as 1 to enable attach backoff feature
+ *
+ * When this feature is enabled, an exponentially increasing backoff wait time is added between attach attempts.
+ * If device is sleepy, the radio will be put to sleep during the wait time. This ensures that a battery-powered sleepy
+ * end-device does not drain its battery by continuously searching for a parent to attach to (when there is no
+ * router/parent for it to attach).
+ *
+ * The backoff time starts from a minimum interval specified by `OPENTHREAD_CONFIG_ATTACH_BACKOFF_MINIMUM_INTERVAL`,
+ * and every attach attempt the wait time is doubled up to `OPENTHREAD_CONFIG_ATTACH_BACKOFF_MAXIMUM_INTERVAL` which
+ * specifies the maximum wait time.
+ *
+ * Once the wait time reaches the maximum, a random jitter interval is added to it. The maximum value for jitter is
+ * specified by `OPENTHREAD_CONFIG_ATTACH_BACKOFF_JITTER_INTERVAL`. The random jitter is selected uniformly within
+ * range `[-JITTER, +JITTER]`. It is only added when the backoff wait interval is at maximum value.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ENABLE_ATTACH_BACKOFF
+#define OPENTHREAD_CONFIG_ENABLE_ATTACH_BACKOFF 1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_ATTACH_BACKOFF_MINIMUM_INTERVAL
+ *
+ * Specifies the minimum backoff wait interval (in milliseconds) used by attach backoff feature.
+ *
+ * Applicable only if attach backoff feature is enabled (see `OPENTHREAD_CONFIG_ENABLE_ATTACH_BACKOFF`).
+ *
+ * Please see `OPENTHREAD_CONFIG_ENABLE_ATTACH_BACKOFF` description for more details.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ATTACH_BACKOFF_MINIMUM_INTERVAL
+#define OPENTHREAD_CONFIG_ATTACH_BACKOFF_MINIMUM_INTERVAL 251
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_ATTACH_BACKOFF_MAXIMUM_INTERVAL
+ *
+ * Specifies the maximum backoff wait interval (in milliseconds) used by attach backoff feature.
+ *
+ * Applicable only if attach backoff feature is enabled (see `OPENTHREAD_CONFIG_ENABLE_ATTACH_BACKOFF`).
+ *
+ * Please see `OPENTHREAD_CONFIG_ENABLE_ATTACH_BACKOFF` description for more details.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ATTACH_BACKOFF_MAXIMUM_INTERVAL
+#define OPENTHREAD_CONFIG_ATTACH_BACKOFF_MAXIMUM_INTERVAL 1200000 // 1200 seconds = 20 minutes
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_ATTACH_BACKOFF_JITTER_INTERVAL
+ *
+ * Specifies the maximum jitter interval (in milliseconds) used by attach backoff feature.
+ *
+ * Applicable only if attach backoff feature is enabled (see `OPENTHREAD_CONFIG_ENABLE_ATTACH_BACKOFF`).
+ *
+ * Please see `OPENTHREAD_CONFIG_ENABLE_ATTACH_BACKOFF` description for more details.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ATTACH_BACKOFF_JITTER_INTERVAL
+#define OPENTHREAD_CONFIG_ATTACH_BACKOFF_JITTER_INTERVAL 2000
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_SEND_UNICAST_ANNOUNCE_RESPONSE
  *
  * Define as 1 to enable sending of a unicast MLE Announce message in response to a received Announce message from

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1520,6 +1520,18 @@ private:
     {
         kMleMessagePriority = Message::kPriorityHigh,
         kMleHopLimit        = 255,
+
+        // Parameters related to "periodic parent search" feature (CONFIG_ENABLE_PERIODIC_PARENT_SEARCH).
+        // All timer intervals are converted to milliseconds.
+        kParentSearchCheckInterval   = (OPENTHREAD_CONFIG_PARENT_SEARCH_CHECK_INTERVAL * 1000u),
+        kParentSearchBackoffInterval = (OPENTHREAD_CONFIG_PARENT_SEARCH_BACKOFF_INTERVAL * 1000u),
+        kParentSearchJitterInterval  = (15 * 1000u),
+        kParentSearchRssThreadhold   = OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_THRESHOLD,
+
+        // Parameters for "attach backoff" feature (CONFIG_ENABLE_ATTACH_BACKOFF) - Intervals are in milliseconds.
+        kAttachBackoffMinInterval = OPENTHREAD_CONFIG_ATTACH_BACKOFF_MINIMUM_INTERVAL,
+        kAttachBackoffMaxInterval = OPENTHREAD_CONFIG_ATTACH_BACKOFF_MAXIMUM_INTERVAL,
+        kAttachBackoffJitter      = OPENTHREAD_CONFIG_ATTACH_BACKOFF_JITTER_INTERVAL,
     };
 
     enum ParentRequestType
@@ -1527,17 +1539,6 @@ private:
         kParentRequestTypeRouters,         ///< Parent Request to all routers.
         kParentRequestTypeRoutersAndReeds, ///< Parent Request to all routers and REEDs.
     };
-
-#if OPENTHREAD_CONFIG_ENABLE_PERIODIC_PARENT_SEARCH
-    enum
-    {
-        // All timer intervals are converted to milliseconds
-        kParentSearchCheckInterval   = (OPENTHREAD_CONFIG_PARENT_SEARCH_CHECK_INTERVAL * 1000u),
-        kParentSearchBackoffInterval = (OPENTHREAD_CONFIG_PARENT_SEARCH_BACKOFF_INTERVAL * 1000u),
-        kParentSearchJitterInterval  = (15 * 1000u),
-        kParentSearchRssThreadhold   = OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_THRESHOLD,
-    };
-#endif
 
     void GenerateNonce(const Mac::ExtAddress &aMacAddr,
                        uint32_t               aFrameCounter,
@@ -1568,6 +1569,7 @@ private:
     otError HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     void    ProcessAnnounce(void);
 
+    uint32_t GetAttachStartDelay(void) const;
     otError  SendParentRequest(ParentRequestType aType);
     otError  SendChildIdRequest(void);
     otError  SendOrphanAnnounce(void);

--- a/src/core/thread/mle_constants.hpp
+++ b/src/core/thread/mle_constants.hpp
@@ -61,7 +61,7 @@ enum
     kUdpPort                       = 19788, ///< MLE UDP Port
     kParentRequestRouterTimeout    = 750,   ///< Router Parent Request timeout
     kParentRequestReedTimeout      = 1250,  ///< Router and REEDs Parent Request timeout
-    kParentRequestJitter           = 50,    ///< Maximum jitter time added to Parent Request timeout
+    kAttachStartJitter             = 50,    ///< Maximum jitter time added to start of attach.
     kAnnounceProcessTimeout        = 250,   ///< Timeout after receiving Announcement before channel/pan-id change
     kAnnounceTimeout               = 1400,  ///< Total timeout used for sending Announcement messages
     kMinAnnounceDelay              = 80,    ///< Minimum delay between Announcement messages


### PR DESCRIPTION
This commit adds "attach backoff" feature in MLE. When enabled, an
exponentially increasing backoff wait time is added between attach
attempts. If device is sleepy, the radio will be put to sleep during
the wait time. This ensures that a battery-powered sleepy end-device
does not drain its battery by continuously searching for a parent to
attach to (when there is no router/parent for it to attach).

`OPENTHREAD_CONFIG_ENABLE_ATTACH_BACKOFF` configuration option can be
used to enable/disable this feature. It is enabled by default.