### PR TITLE
fixed trivial typographical error

### DIFF
--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -678,7 +678,7 @@ void radioTransmit(struct RadioMessage *aMessage, const struct otRadioFrame *aFr
 
         if (rval < 0)
         {
-            perror("recvfrom");
+            perror("sendto");
             exit(EXIT_FAILURE);
         }
     }


### PR DESCRIPTION
The last system call was _sendto_, so I think the error message prefix should reflect this.