### PR TITLE
[nrf52840] support aes usage in interrupt context

### DIFF
--- a/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
+++ b/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
@@ -158,6 +158,18 @@
  */
 #define OPENTHREAD_CONFIG_HEAP_SIZE_NO_DTLS                     2048
 
+/**
+ * @def OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
+ *
+ * Define as 1 to enable AES usage in interrupt context.
+ *
+ * @note If this feature is enabled, a software AES under platform layer must be implemented when:
+ *       1. The platform's hardware AES only supports single AES engine;
+ *       2. The platform's hardware AES doesn't support interrupt context.
+ *
+ */
+#define OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES 0
+
 /*
  * Suppress the ARMCC warning on unreachable statement,
  * e.g. break after assert(false) or ExitNow() macro.

--- a/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
+++ b/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
@@ -158,18 +158,6 @@
  */
 #define OPENTHREAD_CONFIG_HEAP_SIZE_NO_DTLS                     2048
 
-/**
- * @def OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
- *
- * Define as 1 to enable AES usage in interrupt context.
- *
- * @note If this feature is enabled, a software AES under platform layer must be implemented when:
- *       1. The platform's hardware AES only supports single AES engine;
- *       2. The platform's hardware AES doesn't support interrupt context.
- *
- */
-#define OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES 0
-
 /*
  * Suppress the ARMCC warning on unreachable statement,
  * e.g. break after assert(false) or ExitNow() macro.

--- a/examples/platforms/nrf52840/platform-config.h
+++ b/examples/platforms/nrf52840/platform-config.h
@@ -494,4 +494,16 @@
 #define TEMP_MEASUREMENT_INTERVAL 30
 #endif
 
+/**
+ * @def NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT
+ *
+ * Define as 1 to enable AES usage in interrupt context.
+ *
+ * @note A software AES is enabled to support AES usage in interrupt context.
+ *
+ */
+#ifndef NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT
+#define NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT 0
+#endif
+
 #endif // PLATFORM_CONFIG_H_

--- a/third_party/NordicSemiconductor/libraries/crypto/aes_alt.c
+++ b/third_party/NordicSemiconductor/libraries/crypto/aes_alt.c
@@ -51,14 +51,14 @@
 
 #include "aes_alt_cc310.h"
 
-#if OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
+#if NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT
 #include <nrf.h>
 #include "aes_alt_soft.h"
 #endif
 
 void mbedtls_aes_init(mbedtls_aes_context * ctx)
 {
-#if OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
+#if NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT
     uint32_t  active_vector_id = (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) >> SCB_ICSR_VECTACTIVE_Pos;
 
     // Check if this function is called from main thread.
@@ -66,7 +66,7 @@ void mbedtls_aes_init(mbedtls_aes_context * ctx)
     {
 #endif
         aes_cc310_init(ctx);
-#if OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
+#if NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT
         ctx->using_cc310 = true;
     }
     else
@@ -79,12 +79,12 @@ void mbedtls_aes_init(mbedtls_aes_context * ctx)
 
 void mbedtls_aes_free(mbedtls_aes_context * ctx)
 {
-#if OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
+#if NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT
     if (ctx->using_cc310)
     {
 #endif
         aes_cc310_free(ctx);
-#if OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
+#if NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT
     }
     else
     {
@@ -99,12 +99,12 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context * ctx,
 {
     int result;
 
-#if OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
+#if NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT
     if (ctx->using_cc310)
     {
 #endif        
         result = aes_cc310_setkey_enc(ctx, key, keybits);
-#if OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
+#if NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT
     }
     else
     {
@@ -129,12 +129,12 @@ int mbedtls_aes_crypt_ecb(mbedtls_aes_context * ctx,
 {
     int result;
 
-#if OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
+#if NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT
     if (ctx->using_cc310)
     {
 #endif
         result = aes_cc310_crypt_ecb(ctx, mode, input, output);
-#if OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
+#if NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT
     }
     else
     {

--- a/third_party/NordicSemiconductor/libraries/crypto/aes_alt.h
+++ b/third_party/NordicSemiconductor/libraries/crypto/aes_alt.h
@@ -73,7 +73,7 @@ extern "C" {
  */
 typedef struct
 {
-#if OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
+#if NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT
     bool using_cc310;                               ///< Indicate whether it's using cc310 or not.
 #endif
 

--- a/third_party/NordicSemiconductor/libraries/crypto/aes_alt_cc310.h
+++ b/third_party/NordicSemiconductor/libraries/crypto/aes_alt_cc310.h
@@ -42,16 +42,8 @@
  *  limitations under the License.
  */
 
-#ifndef MBEDTLS_AES_ALT_H
-#define MBEDTLS_AES_ALT_H
-
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
-
-#include <openthread-core-config.h>
+#ifndef AES_ALT_CC310_H
+#define AES_ALT_CC310_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -59,45 +51,10 @@
 #ifdef MBEDTLS_AES_ALT
 
 #include "ssi_aes.h"
+#include "aes_alt.h"
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#if defined(__CC_ARM)
-#pragma anon_unions
-#endif
-
-/**
- * @brief AES context structure
- */
-typedef struct
-{
-#if OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
-    bool using_cc310;                               ///< Indicate whether it's using cc310 or not.
-#endif
-
-    union
-    {
-        struct
-        {
-            SaSiAesUserContext_t user_context;      ///< User context for CC310 AES.
-            uint8_t              key_buffer[32];    ///< Buffer for an encryption key.
-            SaSiAesUserKeyData_t key;               ///< CC310 AES key structure.
-            SaSiAesEncryptMode_t mode;              ///< Current context operation mode (encrypt/decrypt).
-        };
-        struct
-        {
-            int       nr;                           ///<  number of rounds  */
-            uint32_t *rk;                           ///<  AES round keys    */
-            uint32_t  buf[68];                      ///<  unaligned data    */
-       };
-    };
-}
-mbedtls_aes_context;
-
-#if defined(__CC_ARM)
-#pragma no_anon_unions
 #endif
 
 /**
@@ -105,14 +62,14 @@ mbedtls_aes_context;
  *
  * @param[in,out] ctx AES context to be initialized
  */
-void mbedtls_aes_init(mbedtls_aes_context * ctx);
+void aes_cc310_init(mbedtls_aes_context * ctx);
 
 /**
  * @brief Clear AES context
  *
  * @param[in,out] ctx AES context to be cleared
  */
-void mbedtls_aes_free(mbedtls_aes_context * ctx);
+void aes_cc310_free(mbedtls_aes_context * ctx);
 
 /**
  * @brief AES key schedule (encryption)
@@ -123,22 +80,9 @@ void mbedtls_aes_free(mbedtls_aes_context * ctx);
  *
  * @return 0 if successful
  */
-int mbedtls_aes_setkey_enc(mbedtls_aes_context * ctx,
-                           const unsigned char * key,
-                           unsigned int          keybits);
-
-/**
- * @brief AES key schedule (decryption)
- *
- * @param[in,out] ctx     AES context to be initialized
- * @param[in]     key     decryption key
- * @param[in]     keybits must be 128, 192 or 256
- *
- * @return 0 if successful
- */
-int mbedtls_aes_setkey_dec(mbedtls_aes_context * ctx,
-                           const unsigned char * key,
-                           unsigned int          keybits);
+int aes_cc310_setkey_enc(mbedtls_aes_context * ctx,
+                         const unsigned char * key,
+                         unsigned int          keybits);
 
 /**
  * @brief AES-ECB block encryption/decryption
@@ -150,10 +94,10 @@ int mbedtls_aes_setkey_dec(mbedtls_aes_context * ctx,
  *
  * @return 0 if successful
  */
-int mbedtls_aes_crypt_ecb(mbedtls_aes_context * ctx,
-                          int                   mode,
-                          const unsigned char   input[16],
-                          unsigned char         output[16]);
+int aes_cc310_crypt_ecb(mbedtls_aes_context * ctx,
+                        int                   mode,
+                        const unsigned char   input[16],
+                        unsigned char         output[16]);
 
 #ifdef __cplusplus
 }
@@ -161,4 +105,4 @@ int mbedtls_aes_crypt_ecb(mbedtls_aes_context * ctx,
 
 #endif /* MBEDTLS_AES_ALT */
 
-#endif /* MBEDTLS_AES_ALT_H */
+#endif /* AES_ALT_CC310_H */

--- a/third_party/NordicSemiconductor/libraries/crypto/aes_alt_soft.c
+++ b/third_party/NordicSemiconductor/libraries/crypto/aes_alt_soft.c
@@ -50,7 +50,7 @@
 
 #ifdef MBEDTLS_AES_ALT
 
-#if OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
+#if NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT
 
 /*
  * 32-bit integer manipulation macros (little endian)
@@ -399,6 +399,6 @@ int aes_soft_crypt_ecb( mbedtls_aes_context *ctx,
     return aes_encrypt( ctx, input, output );
 }
 
-#endif /* OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES */
+#endif /* NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT */
 
 #endif /* MBEDTLS_AES_ALT */

--- a/third_party/NordicSemiconductor/libraries/crypto/aes_alt_soft.c
+++ b/third_party/NordicSemiconductor/libraries/crypto/aes_alt_soft.c
@@ -1,0 +1,404 @@
+/*
+ *  Copyright (c) 2018, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+/*
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "mbedtls/aes.h"
+
+#include "aes_alt_soft.h"
+
+#include <string.h>
+
+#ifdef MBEDTLS_AES_ALT
+
+#if OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
+
+/*
+ * 32-bit integer manipulation macros (little endian)
+ */
+#define GET_UINT32_LE(n,b,i)                            \
+{                                                       \
+    (n) = ( (uint32_t) (b)[(i)    ]       )             \
+        | ( (uint32_t) (b)[(i) + 1] <<  8 )             \
+        | ( (uint32_t) (b)[(i) + 2] << 16 )             \
+        | ( (uint32_t) (b)[(i) + 3] << 24 );            \
+}
+
+#define PUT_UINT32_LE(n,b,i)                                    \
+{                                                               \
+    (b)[(i)    ] = (unsigned char) ( ( (n)       ) & 0xFF );    \
+    (b)[(i) + 1] = (unsigned char) ( ( (n) >>  8 ) & 0xFF );    \
+    (b)[(i) + 2] = (unsigned char) ( ( (n) >> 16 ) & 0xFF );    \
+    (b)[(i) + 3] = (unsigned char) ( ( (n) >> 24 ) & 0xFF );    \
+}
+
+/*
+ * Forward S-box
+ */
+static const unsigned char FSb[256] =
+{
+    0x63, 0x7C, 0x77, 0x7B, 0xF2, 0x6B, 0x6F, 0xC5,
+    0x30, 0x01, 0x67, 0x2B, 0xFE, 0xD7, 0xAB, 0x76,
+    0xCA, 0x82, 0xC9, 0x7D, 0xFA, 0x59, 0x47, 0xF0,
+    0xAD, 0xD4, 0xA2, 0xAF, 0x9C, 0xA4, 0x72, 0xC0,
+    0xB7, 0xFD, 0x93, 0x26, 0x36, 0x3F, 0xF7, 0xCC,
+    0x34, 0xA5, 0xE5, 0xF1, 0x71, 0xD8, 0x31, 0x15,
+    0x04, 0xC7, 0x23, 0xC3, 0x18, 0x96, 0x05, 0x9A,
+    0x07, 0x12, 0x80, 0xE2, 0xEB, 0x27, 0xB2, 0x75,
+    0x09, 0x83, 0x2C, 0x1A, 0x1B, 0x6E, 0x5A, 0xA0,
+    0x52, 0x3B, 0xD6, 0xB3, 0x29, 0xE3, 0x2F, 0x84,
+    0x53, 0xD1, 0x00, 0xED, 0x20, 0xFC, 0xB1, 0x5B,
+    0x6A, 0xCB, 0xBE, 0x39, 0x4A, 0x4C, 0x58, 0xCF,
+    0xD0, 0xEF, 0xAA, 0xFB, 0x43, 0x4D, 0x33, 0x85,
+    0x45, 0xF9, 0x02, 0x7F, 0x50, 0x3C, 0x9F, 0xA8,
+    0x51, 0xA3, 0x40, 0x8F, 0x92, 0x9D, 0x38, 0xF5,
+    0xBC, 0xB6, 0xDA, 0x21, 0x10, 0xFF, 0xF3, 0xD2,
+    0xCD, 0x0C, 0x13, 0xEC, 0x5F, 0x97, 0x44, 0x17,
+    0xC4, 0xA7, 0x7E, 0x3D, 0x64, 0x5D, 0x19, 0x73,
+    0x60, 0x81, 0x4F, 0xDC, 0x22, 0x2A, 0x90, 0x88,
+    0x46, 0xEE, 0xB8, 0x14, 0xDE, 0x5E, 0x0B, 0xDB,
+    0xE0, 0x32, 0x3A, 0x0A, 0x49, 0x06, 0x24, 0x5C,
+    0xC2, 0xD3, 0xAC, 0x62, 0x91, 0x95, 0xE4, 0x79,
+    0xE7, 0xC8, 0x37, 0x6D, 0x8D, 0xD5, 0x4E, 0xA9,
+    0x6C, 0x56, 0xF4, 0xEA, 0x65, 0x7A, 0xAE, 0x08,
+    0xBA, 0x78, 0x25, 0x2E, 0x1C, 0xA6, 0xB4, 0xC6,
+    0xE8, 0xDD, 0x74, 0x1F, 0x4B, 0xBD, 0x8B, 0x8A,
+    0x70, 0x3E, 0xB5, 0x66, 0x48, 0x03, 0xF6, 0x0E,
+    0x61, 0x35, 0x57, 0xB9, 0x86, 0xC1, 0x1D, 0x9E,
+    0xE1, 0xF8, 0x98, 0x11, 0x69, 0xD9, 0x8E, 0x94,
+    0x9B, 0x1E, 0x87, 0xE9, 0xCE, 0x55, 0x28, 0xDF,
+    0x8C, 0xA1, 0x89, 0x0D, 0xBF, 0xE6, 0x42, 0x68,
+    0x41, 0x99, 0x2D, 0x0F, 0xB0, 0x54, 0xBB, 0x16
+};
+
+/*
+ * Forward tables
+ */
+#define FT \
+\
+    V(A5,63,63,C6), V(84,7C,7C,F8), V(99,77,77,EE), V(8D,7B,7B,F6), \
+    V(0D,F2,F2,FF), V(BD,6B,6B,D6), V(B1,6F,6F,DE), V(54,C5,C5,91), \
+    V(50,30,30,60), V(03,01,01,02), V(A9,67,67,CE), V(7D,2B,2B,56), \
+    V(19,FE,FE,E7), V(62,D7,D7,B5), V(E6,AB,AB,4D), V(9A,76,76,EC), \
+    V(45,CA,CA,8F), V(9D,82,82,1F), V(40,C9,C9,89), V(87,7D,7D,FA), \
+    V(15,FA,FA,EF), V(EB,59,59,B2), V(C9,47,47,8E), V(0B,F0,F0,FB), \
+    V(EC,AD,AD,41), V(67,D4,D4,B3), V(FD,A2,A2,5F), V(EA,AF,AF,45), \
+    V(BF,9C,9C,23), V(F7,A4,A4,53), V(96,72,72,E4), V(5B,C0,C0,9B), \
+    V(C2,B7,B7,75), V(1C,FD,FD,E1), V(AE,93,93,3D), V(6A,26,26,4C), \
+    V(5A,36,36,6C), V(41,3F,3F,7E), V(02,F7,F7,F5), V(4F,CC,CC,83), \
+    V(5C,34,34,68), V(F4,A5,A5,51), V(34,E5,E5,D1), V(08,F1,F1,F9), \
+    V(93,71,71,E2), V(73,D8,D8,AB), V(53,31,31,62), V(3F,15,15,2A), \
+    V(0C,04,04,08), V(52,C7,C7,95), V(65,23,23,46), V(5E,C3,C3,9D), \
+    V(28,18,18,30), V(A1,96,96,37), V(0F,05,05,0A), V(B5,9A,9A,2F), \
+    V(09,07,07,0E), V(36,12,12,24), V(9B,80,80,1B), V(3D,E2,E2,DF), \
+    V(26,EB,EB,CD), V(69,27,27,4E), V(CD,B2,B2,7F), V(9F,75,75,EA), \
+    V(1B,09,09,12), V(9E,83,83,1D), V(74,2C,2C,58), V(2E,1A,1A,34), \
+    V(2D,1B,1B,36), V(B2,6E,6E,DC), V(EE,5A,5A,B4), V(FB,A0,A0,5B), \
+    V(F6,52,52,A4), V(4D,3B,3B,76), V(61,D6,D6,B7), V(CE,B3,B3,7D), \
+    V(7B,29,29,52), V(3E,E3,E3,DD), V(71,2F,2F,5E), V(97,84,84,13), \
+    V(F5,53,53,A6), V(68,D1,D1,B9), V(00,00,00,00), V(2C,ED,ED,C1), \
+    V(60,20,20,40), V(1F,FC,FC,E3), V(C8,B1,B1,79), V(ED,5B,5B,B6), \
+    V(BE,6A,6A,D4), V(46,CB,CB,8D), V(D9,BE,BE,67), V(4B,39,39,72), \
+    V(DE,4A,4A,94), V(D4,4C,4C,98), V(E8,58,58,B0), V(4A,CF,CF,85), \
+    V(6B,D0,D0,BB), V(2A,EF,EF,C5), V(E5,AA,AA,4F), V(16,FB,FB,ED), \
+    V(C5,43,43,86), V(D7,4D,4D,9A), V(55,33,33,66), V(94,85,85,11), \
+    V(CF,45,45,8A), V(10,F9,F9,E9), V(06,02,02,04), V(81,7F,7F,FE), \
+    V(F0,50,50,A0), V(44,3C,3C,78), V(BA,9F,9F,25), V(E3,A8,A8,4B), \
+    V(F3,51,51,A2), V(FE,A3,A3,5D), V(C0,40,40,80), V(8A,8F,8F,05), \
+    V(AD,92,92,3F), V(BC,9D,9D,21), V(48,38,38,70), V(04,F5,F5,F1), \
+    V(DF,BC,BC,63), V(C1,B6,B6,77), V(75,DA,DA,AF), V(63,21,21,42), \
+    V(30,10,10,20), V(1A,FF,FF,E5), V(0E,F3,F3,FD), V(6D,D2,D2,BF), \
+    V(4C,CD,CD,81), V(14,0C,0C,18), V(35,13,13,26), V(2F,EC,EC,C3), \
+    V(E1,5F,5F,BE), V(A2,97,97,35), V(CC,44,44,88), V(39,17,17,2E), \
+    V(57,C4,C4,93), V(F2,A7,A7,55), V(82,7E,7E,FC), V(47,3D,3D,7A), \
+    V(AC,64,64,C8), V(E7,5D,5D,BA), V(2B,19,19,32), V(95,73,73,E6), \
+    V(A0,60,60,C0), V(98,81,81,19), V(D1,4F,4F,9E), V(7F,DC,DC,A3), \
+    V(66,22,22,44), V(7E,2A,2A,54), V(AB,90,90,3B), V(83,88,88,0B), \
+    V(CA,46,46,8C), V(29,EE,EE,C7), V(D3,B8,B8,6B), V(3C,14,14,28), \
+    V(79,DE,DE,A7), V(E2,5E,5E,BC), V(1D,0B,0B,16), V(76,DB,DB,AD), \
+    V(3B,E0,E0,DB), V(56,32,32,64), V(4E,3A,3A,74), V(1E,0A,0A,14), \
+    V(DB,49,49,92), V(0A,06,06,0C), V(6C,24,24,48), V(E4,5C,5C,B8), \
+    V(5D,C2,C2,9F), V(6E,D3,D3,BD), V(EF,AC,AC,43), V(A6,62,62,C4), \
+    V(A8,91,91,39), V(A4,95,95,31), V(37,E4,E4,D3), V(8B,79,79,F2), \
+    V(32,E7,E7,D5), V(43,C8,C8,8B), V(59,37,37,6E), V(B7,6D,6D,DA), \
+    V(8C,8D,8D,01), V(64,D5,D5,B1), V(D2,4E,4E,9C), V(E0,A9,A9,49), \
+    V(B4,6C,6C,D8), V(FA,56,56,AC), V(07,F4,F4,F3), V(25,EA,EA,CF), \
+    V(AF,65,65,CA), V(8E,7A,7A,F4), V(E9,AE,AE,47), V(18,08,08,10), \
+    V(D5,BA,BA,6F), V(88,78,78,F0), V(6F,25,25,4A), V(72,2E,2E,5C), \
+    V(24,1C,1C,38), V(F1,A6,A6,57), V(C7,B4,B4,73), V(51,C6,C6,97), \
+    V(23,E8,E8,CB), V(7C,DD,DD,A1), V(9C,74,74,E8), V(21,1F,1F,3E), \
+    V(DD,4B,4B,96), V(DC,BD,BD,61), V(86,8B,8B,0D), V(85,8A,8A,0F), \
+    V(90,70,70,E0), V(42,3E,3E,7C), V(C4,B5,B5,71), V(AA,66,66,CC), \
+    V(D8,48,48,90), V(05,03,03,06), V(01,F6,F6,F7), V(12,0E,0E,1C), \
+    V(A3,61,61,C2), V(5F,35,35,6A), V(F9,57,57,AE), V(D0,B9,B9,69), \
+    V(91,86,86,17), V(58,C1,C1,99), V(27,1D,1D,3A), V(B9,9E,9E,27), \
+    V(38,E1,E1,D9), V(13,F8,F8,EB), V(B3,98,98,2B), V(33,11,11,22), \
+    V(BB,69,69,D2), V(70,D9,D9,A9), V(89,8E,8E,07), V(A7,94,94,33), \
+    V(B6,9B,9B,2D), V(22,1E,1E,3C), V(92,87,87,15), V(20,E9,E9,C9), \
+    V(49,CE,CE,87), V(FF,55,55,AA), V(78,28,28,50), V(7A,DF,DF,A5), \
+    V(8F,8C,8C,03), V(F8,A1,A1,59), V(80,89,89,09), V(17,0D,0D,1A), \
+    V(DA,BF,BF,65), V(31,E6,E6,D7), V(C6,42,42,84), V(B8,68,68,D0), \
+    V(C3,41,41,82), V(B0,99,99,29), V(77,2D,2D,5A), V(11,0F,0F,1E), \
+    V(CB,B0,B0,7B), V(FC,54,54,A8), V(D6,BB,BB,6D), V(3A,16,16,2C)
+
+#define V(a,b,c,d) 0x##a##b##c##d
+static const uint32_t FT0[256] = { FT };
+#undef V
+
+#define V(a,b,c,d) 0x##b##c##d##a
+static const uint32_t FT1[256] = { FT };
+#undef V
+
+#define V(a,b,c,d) 0x##c##d##a##b
+static const uint32_t FT2[256] = { FT };
+#undef V
+
+#define V(a,b,c,d) 0x##d##a##b##c
+static const uint32_t FT3[256] = { FT };
+#undef V
+
+#undef FT
+
+/*
+ * Round constants
+ */
+static const uint32_t RCON[10] =
+{
+    0x00000001, 0x00000002, 0x00000004, 0x00000008,
+    0x00000010, 0x00000020, 0x00000040, 0x00000080,
+    0x0000001B, 0x00000036
+};
+
+#define AES_FROUND(X0,X1,X2,X3,Y0,Y1,Y2,Y3)     \
+{                                               \
+    X0 = *RK++ ^ FT0[ ( Y0       ) & 0xFF ] ^   \
+                 FT1[ ( Y1 >>  8 ) & 0xFF ] ^   \
+                 FT2[ ( Y2 >> 16 ) & 0xFF ] ^   \
+                 FT3[ ( Y3 >> 24 ) & 0xFF ];    \
+                                                \
+    X1 = *RK++ ^ FT0[ ( Y1       ) & 0xFF ] ^   \
+                 FT1[ ( Y2 >>  8 ) & 0xFF ] ^   \
+                 FT2[ ( Y3 >> 16 ) & 0xFF ] ^   \
+                 FT3[ ( Y0 >> 24 ) & 0xFF ];    \
+                                                \
+    X2 = *RK++ ^ FT0[ ( Y2       ) & 0xFF ] ^   \
+                 FT1[ ( Y3 >>  8 ) & 0xFF ] ^   \
+                 FT2[ ( Y0 >> 16 ) & 0xFF ] ^   \
+                 FT3[ ( Y1 >> 24 ) & 0xFF ];    \
+                                                \
+    X3 = *RK++ ^ FT0[ ( Y3       ) & 0xFF ] ^   \
+                 FT1[ ( Y0 >>  8 ) & 0xFF ] ^   \
+                 FT2[ ( Y1 >> 16 ) & 0xFF ] ^   \
+                 FT3[ ( Y2 >> 24 ) & 0xFF ];    \
+}
+
+void aes_soft_init( mbedtls_aes_context *ctx )
+{
+    memset( ctx, 0, sizeof( mbedtls_aes_context ) );
+}
+
+void aes_soft_free( mbedtls_aes_context *ctx )
+{
+    memset( ctx, 0, sizeof( mbedtls_aes_context ) );
+}
+
+/*
+ * AES key schedule (encryption)
+ */
+int aes_soft_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
+                    unsigned int keybits )
+{
+    unsigned int i;
+    uint32_t *RK;
+
+    switch( keybits )
+    {
+        case 128: ctx->nr = 10; break;
+        case 192: ctx->nr = 12; break;
+        case 256: ctx->nr = 14; break;
+        default : return( MBEDTLS_ERR_AES_INVALID_KEY_LENGTH );
+    }
+
+    ctx->rk = RK = ctx->buf;
+
+    for( i = 0; i < ( keybits >> 5 ); i++ )
+    {
+        GET_UINT32_LE( RK[i], key, i << 2 );
+    }
+
+    switch( ctx->nr )
+    {
+        case 10:
+
+            for( i = 0; i < 10; i++, RK += 4 )
+            {
+                RK[4]  = RK[0] ^ RCON[i] ^
+                ( (uint32_t) FSb[ ( RK[3] >>  8 ) & 0xFF ]       ) ^
+                ( (uint32_t) FSb[ ( RK[3] >> 16 ) & 0xFF ] <<  8 ) ^
+                ( (uint32_t) FSb[ ( RK[3] >> 24 ) & 0xFF ] << 16 ) ^
+                ( (uint32_t) FSb[ ( RK[3]       ) & 0xFF ] << 24 );
+
+                RK[5]  = RK[1] ^ RK[4];
+                RK[6]  = RK[2] ^ RK[5];
+                RK[7]  = RK[3] ^ RK[6];
+            }
+            break;
+
+        case 12:
+
+            for( i = 0; i < 8; i++, RK += 6 )
+            {
+                RK[6]  = RK[0] ^ RCON[i] ^
+                ( (uint32_t) FSb[ ( RK[5] >>  8 ) & 0xFF ]       ) ^
+                ( (uint32_t) FSb[ ( RK[5] >> 16 ) & 0xFF ] <<  8 ) ^
+                ( (uint32_t) FSb[ ( RK[5] >> 24 ) & 0xFF ] << 16 ) ^
+                ( (uint32_t) FSb[ ( RK[5]       ) & 0xFF ] << 24 );
+
+                RK[7]  = RK[1] ^ RK[6];
+                RK[8]  = RK[2] ^ RK[7];
+                RK[9]  = RK[3] ^ RK[8];
+                RK[10] = RK[4] ^ RK[9];
+                RK[11] = RK[5] ^ RK[10];
+            }
+            break;
+
+        case 14:
+
+            for( i = 0; i < 7; i++, RK += 8 )
+            {
+                RK[8]  = RK[0] ^ RCON[i] ^
+                ( (uint32_t) FSb[ ( RK[7] >>  8 ) & 0xFF ]       ) ^
+                ( (uint32_t) FSb[ ( RK[7] >> 16 ) & 0xFF ] <<  8 ) ^
+                ( (uint32_t) FSb[ ( RK[7] >> 24 ) & 0xFF ] << 16 ) ^
+                ( (uint32_t) FSb[ ( RK[7]       ) & 0xFF ] << 24 );
+
+                RK[9]  = RK[1] ^ RK[8];
+                RK[10] = RK[2] ^ RK[9];
+                RK[11] = RK[3] ^ RK[10];
+
+                RK[12] = RK[4] ^
+                ( (uint32_t) FSb[ ( RK[11]       ) & 0xFF ]       ) ^
+                ( (uint32_t) FSb[ ( RK[11] >>  8 ) & 0xFF ] <<  8 ) ^
+                ( (uint32_t) FSb[ ( RK[11] >> 16 ) & 0xFF ] << 16 ) ^
+                ( (uint32_t) FSb[ ( RK[11] >> 24 ) & 0xFF ] << 24 );
+
+                RK[13] = RK[5] ^ RK[12];
+                RK[14] = RK[6] ^ RK[13];
+                RK[15] = RK[7] ^ RK[14];
+            }
+            break;
+    }
+
+    return( 0 );
+}
+
+/*
+ * AES-ECB block encryption
+ */
+int aes_encrypt( mbedtls_aes_context *ctx,
+                 const unsigned char input[16],
+                 unsigned char output[16] )
+{
+    int i;
+    uint32_t *RK, X0, X1, X2, X3, Y0, Y1, Y2, Y3;
+
+    RK = ctx->rk;
+
+    GET_UINT32_LE( X0, input,  0 ); X0 ^= *RK++;
+    GET_UINT32_LE( X1, input,  4 ); X1 ^= *RK++;
+    GET_UINT32_LE( X2, input,  8 ); X2 ^= *RK++;
+    GET_UINT32_LE( X3, input, 12 ); X3 ^= *RK++;
+
+    for( i = ( ctx->nr >> 1 ) - 1; i > 0; i-- )
+    {
+        AES_FROUND( Y0, Y1, Y2, Y3, X0, X1, X2, X3 );
+        AES_FROUND( X0, X1, X2, X3, Y0, Y1, Y2, Y3 );
+    }
+
+    AES_FROUND( Y0, Y1, Y2, Y3, X0, X1, X2, X3 );
+
+    X0 = *RK++ ^ \
+            ( (uint32_t) FSb[ ( Y0       ) & 0xFF ]       ) ^
+            ( (uint32_t) FSb[ ( Y1 >>  8 ) & 0xFF ] <<  8 ) ^
+            ( (uint32_t) FSb[ ( Y2 >> 16 ) & 0xFF ] << 16 ) ^
+            ( (uint32_t) FSb[ ( Y3 >> 24 ) & 0xFF ] << 24 );
+
+    X1 = *RK++ ^ \
+            ( (uint32_t) FSb[ ( Y1       ) & 0xFF ]       ) ^
+            ( (uint32_t) FSb[ ( Y2 >>  8 ) & 0xFF ] <<  8 ) ^
+            ( (uint32_t) FSb[ ( Y3 >> 16 ) & 0xFF ] << 16 ) ^
+            ( (uint32_t) FSb[ ( Y0 >> 24 ) & 0xFF ] << 24 );
+
+    X2 = *RK++ ^ \
+            ( (uint32_t) FSb[ ( Y2       ) & 0xFF ]       ) ^
+            ( (uint32_t) FSb[ ( Y3 >>  8 ) & 0xFF ] <<  8 ) ^
+            ( (uint32_t) FSb[ ( Y0 >> 16 ) & 0xFF ] << 16 ) ^
+            ( (uint32_t) FSb[ ( Y1 >> 24 ) & 0xFF ] << 24 );
+
+    X3 = *RK++ ^ \
+            ( (uint32_t) FSb[ ( Y3       ) & 0xFF ]       ) ^
+            ( (uint32_t) FSb[ ( Y0 >>  8 ) & 0xFF ] <<  8 ) ^
+            ( (uint32_t) FSb[ ( Y1 >> 16 ) & 0xFF ] << 16 ) ^
+            ( (uint32_t) FSb[ ( Y2 >> 24 ) & 0xFF ] << 24 );
+
+    PUT_UINT32_LE( X0, output,  0 );
+    PUT_UINT32_LE( X1, output,  4 );
+    PUT_UINT32_LE( X2, output,  8 );
+    PUT_UINT32_LE( X3, output, 12 );
+
+    return( 0 );
+}
+
+int aes_soft_crypt_ecb( mbedtls_aes_context *ctx,
+                    int mode,
+                    const unsigned char input[16],
+                    unsigned char output[16] )
+{
+    // OpenThread uses MBEDTLS_AES_ENCRYPT mode only
+    (void)mode;
+
+    return aes_encrypt( ctx, input, output );
+}
+
+#endif /* OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES */
+
+#endif /* MBEDTLS_AES_ALT */

--- a/third_party/NordicSemiconductor/libraries/crypto/aes_alt_soft.h
+++ b/third_party/NordicSemiconductor/libraries/crypto/aes_alt_soft.h
@@ -52,7 +52,7 @@
 
 #ifdef MBEDTLS_AES_ALT
 
-#if OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
+#if NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT
 
 #include "aes_alt.h"
 
@@ -106,7 +106,7 @@ int aes_soft_crypt_ecb(mbedtls_aes_context * ctx,
 }
 #endif
 
-#endif /* OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES */
+#endif /* NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT */
 
 #endif /* MBEDTLS_AES_ALT */
 

--- a/third_party/NordicSemiconductor/libraries/crypto/aes_alt_soft.h
+++ b/third_party/NordicSemiconductor/libraries/crypto/aes_alt_soft.h
@@ -42,14 +42,8 @@
  *  limitations under the License.
  */
 
-#ifndef MBEDTLS_AES_ALT_H
-#define MBEDTLS_AES_ALT_H
-
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
+#ifndef AES_ALT_SOFT_H
+#define AES_ALT_SOFT_H
 
 #include <openthread-core-config.h>
 
@@ -58,46 +52,12 @@
 
 #ifdef MBEDTLS_AES_ALT
 
-#include "ssi_aes.h"
+#if OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
+
+#include "aes_alt.h"
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#if defined(__CC_ARM)
-#pragma anon_unions
-#endif
-
-/**
- * @brief AES context structure
- */
-typedef struct
-{
-#if OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES
-    bool using_cc310;                               ///< Indicate whether it's using cc310 or not.
-#endif
-
-    union
-    {
-        struct
-        {
-            SaSiAesUserContext_t user_context;      ///< User context for CC310 AES.
-            uint8_t              key_buffer[32];    ///< Buffer for an encryption key.
-            SaSiAesUserKeyData_t key;               ///< CC310 AES key structure.
-            SaSiAesEncryptMode_t mode;              ///< Current context operation mode (encrypt/decrypt).
-        };
-        struct
-        {
-            int       nr;                           ///<  number of rounds  */
-            uint32_t *rk;                           ///<  AES round keys    */
-            uint32_t  buf[68];                      ///<  unaligned data    */
-       };
-    };
-}
-mbedtls_aes_context;
-
-#if defined(__CC_ARM)
-#pragma no_anon_unions
 #endif
 
 /**
@@ -105,14 +65,14 @@ mbedtls_aes_context;
  *
  * @param[in,out] ctx AES context to be initialized
  */
-void mbedtls_aes_init(mbedtls_aes_context * ctx);
+void aes_soft_init(mbedtls_aes_context * ctx);
 
 /**
  * @brief Clear AES context
  *
  * @param[in,out] ctx AES context to be cleared
  */
-void mbedtls_aes_free(mbedtls_aes_context * ctx);
+void aes_soft_free(mbedtls_aes_context * ctx);
 
 /**
  * @brief AES key schedule (encryption)
@@ -123,22 +83,9 @@ void mbedtls_aes_free(mbedtls_aes_context * ctx);
  *
  * @return 0 if successful
  */
-int mbedtls_aes_setkey_enc(mbedtls_aes_context * ctx,
-                           const unsigned char * key,
-                           unsigned int          keybits);
-
-/**
- * @brief AES key schedule (decryption)
- *
- * @param[in,out] ctx     AES context to be initialized
- * @param[in]     key     decryption key
- * @param[in]     keybits must be 128, 192 or 256
- *
- * @return 0 if successful
- */
-int mbedtls_aes_setkey_dec(mbedtls_aes_context * ctx,
-                           const unsigned char * key,
-                           unsigned int          keybits);
+int aes_soft_setkey_enc(mbedtls_aes_context * ctx,
+                         const unsigned char * key,
+                         unsigned int          keybits);
 
 /**
  * @brief AES-ECB block encryption/decryption
@@ -150,15 +97,17 @@ int mbedtls_aes_setkey_dec(mbedtls_aes_context * ctx,
  *
  * @return 0 if successful
  */
-int mbedtls_aes_crypt_ecb(mbedtls_aes_context * ctx,
-                          int                   mode,
-                          const unsigned char   input[16],
-                          unsigned char         output[16]);
+int aes_soft_crypt_ecb(mbedtls_aes_context * ctx,
+                        int                   mode,
+                        const unsigned char   input[16],
+                        unsigned char         output[16]);
 
 #ifdef __cplusplus
 }
 #endif
 
+#endif /* OPENTHREAD_CONFIG_INTERRUPT_CONTEXT_AES */
+
 #endif /* MBEDTLS_AES_ALT */
 
-#endif /* MBEDTLS_AES_ALT_H */
+#endif /* AES_ALT_SOFT_H */

--- a/third_party/mbedtls/Makefile.am
+++ b/third_party/mbedtls/Makefile.am
@@ -61,7 +61,9 @@ endif  # OPENTHREAD_EXAMPLES_EFR32
 
 if OPENTHREAD_EXAMPLES_NRF52840
 nodist_libmbedcrypto_a_SOURCES                                                       = \
+    @top_builddir@/third_party/NordicSemiconductor/libraries/crypto/aes_alt.c          \
     @top_builddir@/third_party/NordicSemiconductor/libraries/crypto/aes_alt_cc310.c    \
+    @top_builddir@/third_party/NordicSemiconductor/libraries/crypto/aes_alt_soft.c     \
     @top_builddir@/third_party/NordicSemiconductor/libraries/crypto/sha256_alt_cc310.c \
     @top_builddir@/third_party/NordicSemiconductor/libraries/crypto/cc310_mbedtls.c    \
     $(NULL)


### PR DESCRIPTION
These are some use cases to do AES in interrupt context in some new features (for example: #2618 network-wide time sync service), it works well with software AES provided by mbedtls, but there are some problems when hardware acceleration is enabled: 
- Some platform's hardware AES has only one AES engine, so it doesn't support concurrent access;
- Some platform's hardware AES doesn't support interrupt context (for example, nRF52840).

This PR resolves the issue by introducing a simple software AES under platform layer:
* Enhance AesCcm to indicate whether it is used in interrupt context
* Introduce a simple software AES under nRF52840 platform layer for AES usage in interrupt context