### PR TITLE
[logging] fix build with OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL=1

### DIFF
--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -201,7 +201,7 @@ otError Uart::ProcessCommand(void)
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
         /* TODO: how exactly do we get the instance here? */
 #else
-    otLogInfoCli(&Instance::Get(), "execute command: %s", mRxBuffer);
+    otLogInfoCli(Instance::Get(), "execute command: %s", mRxBuffer);
 #endif
 #endif
     mInterpreter.ProcessLine(mRxBuffer, mRxLength, *this);

--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -993,10 +993,10 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_PLATFORM == 1
-#define otLogCritPlat(aInstance, aFormat, ...) otLogCrit(aInstance, OT_LOG_REGION_PLATFORM, aFormat, ##__VA_ARGS__)
-#define otLogWarnPlat(aInstance, aFormat, ...) otLogWarn(aInstance, OT_LOG_REGION_PLATFORM, aFormat, ##__VA_ARGS__)
-#define otLogInfoPlat(aInstance, aFormat, ...) otLogInfo(aInstance, OT_LOG_REGION_PLATFORM, aFormat, ##__VA_ARGS__)
-#define otLogDebgPlat(aInstance, aFormat, ...) otLogDebg(aInstance, OT_LOG_REGION_PLATFORM, aFormat, ##__VA_ARGS__)
+#define otLogCritPlat(aInstance, aFormat, ...) otLogCrit(&aInstance, OT_LOG_REGION_PLATFORM, aFormat, ##__VA_ARGS__)
+#define otLogWarnPlat(aInstance, aFormat, ...) otLogWarn(&aInstance, OT_LOG_REGION_PLATFORM, aFormat, ##__VA_ARGS__)
+#define otLogInfoPlat(aInstance, aFormat, ...) otLogInfo(&aInstance, OT_LOG_REGION_PLATFORM, aFormat, ##__VA_ARGS__)
+#define otLogDebgPlat(aInstance, aFormat, ...) otLogDebg(&aInstance, OT_LOG_REGION_PLATFORM, aFormat, ##__VA_ARGS__)
 #else
 #define otLogCritPlat(aInstance, aFormat, ...)
 #define otLogWarnPlat(aInstance, aFormat, ...)

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -41,6 +41,7 @@
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/encoding.hpp"
+#include "common/instance.hpp"
 #include "common/logging.hpp"
 #include "meshcop/meshcop.hpp"
 #include "meshcop/meshcop_tlvs.hpp"


### PR DESCRIPTION
Dynamic logging builds seem to have been broken for a couple months; this fixes them.

Enabling dynamic logging simultaneously with certification log support (OPENTHREAD_ENABLE_CERT_LOG==1)  remains broken, because otLogCertMeshCoP() logs at OT_LOG_LEVEL_NONE, which causes _otDynamicLog() to error out with a type-limit error since otGetDynamicLogLevel() >= OT_LOG_LEVEL_NONE can never be false. I'm not sure of the best way to fix this. My gut says to add a new level OT_LOG_LEVEL_SILENT but that would be an API change, and I'm not sure that's appropriate material for my first pull request here. :-)