### PR TITLE
[diags] make diag output & cmd line buffer params configurable

### DIFF
--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -1538,7 +1538,7 @@
 /**
  * @def OPENTHREAD_CONFIG_DIAG_OUTPUT_BUFFER_SIZE
  *
- * Define OpenThread diagnostic mode output buffer size.
+ * Define OpenThread diagnostic mode output buffer size in bytes
  *
  */
 #ifndef OPENTHREAD_CONFIG_DIAG_OUTPUT_BUFFER_SIZE
@@ -1558,7 +1558,7 @@
 /**
  * @def OPENTHREAD_CONFIG_DIAG_CMD_LINE_BUFFER_SIZE
  *
- * Define OpenThread diagnostic mode command line buffer size
+ * Define OpenThread diagnostic mode command line buffer size in bytes.
  *
  */
 #ifndef OPENTHREAD_CONFIG_DIAG_CMD_LINE_BUFFER_SIZE

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -1535,4 +1535,34 @@
 #define OPENTHREAD_CONFIG_DISABLE_CCA_ON_LAST_ATTEMPT 0
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_DIAG_OUTPUT_BUFFER_SIZE
+ *
+ * Define OpenThread diagnostic mode output buffer size.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_DIAG_OUTPUT_BUFFER_SIZE
+#define OPENTHREAD_CONFIG_DIAG_OUTPUT_BUFFER_SIZE 256
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_DIAG_CMD_LINE_ARGS_MAX
+ *
+ * Define OpenThread diagnostic mode max command line arguments.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_DIAG_CMD_LINE_ARGS_MAX
+#define OPENTHREAD_CONFIG_DIAG_CMD_LINE_ARGS_MAX 32
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_DIAG_CMD_LINE_BUFFER_SIZE
+ *
+ * Define OpenThread diagnostic mode command line buffer size
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_DIAG_CMD_LINE_BUFFER_SIZE
+#define OPENTHREAD_CONFIG_DIAG_CMD_LINE_BUFFER_SIZE 256
+#endif
+
 #endif // OPENTHREAD_CORE_DEFAULT_CONFIG_H_

--- a/src/diag/diag_process.hpp
+++ b/src/diag/diag_process.hpp
@@ -62,7 +62,7 @@ private:
 
     enum
     {
-        kMaxOutputSize = 256,
+        kMaxOutputSize = OPENTHREAD_CONFIG_DIAG_OUTPUT_BUFFER_SIZE,
     };
 
     struct DiagStats

--- a/src/diag/openthread-diag.cpp
+++ b/src/diag/openthread-diag.cpp
@@ -68,8 +68,8 @@ const char *otDiagProcessCmdLine(const char *aInput)
 {
     enum
     {
-        kMaxArgs = 32,
-        kMaxCommandBuffer = 256,
+        kMaxArgs = OPENTHREAD_CONFIG_DIAG_CMD_LINE_ARGS_MAX,
+        kMaxCommandBuffer = OPENTHREAD_CONFIG_DIAG_CMD_LINE_BUFFER_SIZE,
     };
 
     otError error = OT_ERROR_NONE;


### PR DESCRIPTION
Make ot diag output buffer size configurable.
Make ot diag command line max argument number and buffer size configurable.