### PR TITLE
[ncp-spi] improve callback implementation, change code style format

### DIFF
--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -40,6 +40,121 @@
 namespace ot {
 namespace Ncp {
 
+/**
+ * This class defines a SPI frame.
+ *
+ */
+class SpiFrame
+{
+public:
+    enum
+    {
+        kHeaderSize = 5,   ///< SPI header size (in bytes).
+    };
+
+    /**
+     * This constructor initializes an `SpiFrame` instance.
+     *
+     * @param[in] aBuffer     Pointer to buffer containing the frame.
+     *
+     */
+    SpiFrame(uint8_t *aBuffer) : mBuffer(aBuffer) { }
+
+    /**
+     * This method gets a pointer to data portion in the SPI frame skipping the header.
+     *
+     * @returns  A pointer to data in the SPI frame.
+     *
+     */
+    uint8_t *GetData(void) { return mBuffer + kHeaderSize; }
+
+    /**
+     * This method indicates whether or not the frame is valid.
+     *
+     * In a valid frame the flag byte should contain the pattern bits.
+     *
+     * @returns TRUE if the frame is valid, FALSE otherwise.
+     *
+     */
+    bool IsValid(void) const
+    {
+        return ((mBuffer[kIndexFlagByte] & kFlagPatternMask) == kFlagPattern);
+    }
+
+    /**
+     * This method sets the "flag byte" field in the SPI frame header.
+     *
+     * @param[in] aResetFalg     The status of reset flag (TRUE to set the flag, FALSE to clear flag).
+     *
+     */
+    void SetHeaderFlagByte(bool aResetFlag)
+    {
+        mBuffer[kIndexFlagByte] = kFlagPattern | (aResetFlag ? kFlagReset : 0);
+    }
+
+    /**
+     * This method sets the "accept len" field in the SPI frame header.
+     *
+     * "accept len" specifies number of bytes the sender of the SPI frame can receive.
+     *
+     * @param[in] aAcceptLen    The accept length in bytes.
+     *
+     */
+    void SetHeaderAcceptLen(uint16_t aAcceptLen)
+    {
+        Encoding::LittleEndian::WriteUint16(aAcceptLen, mBuffer + kIndexAcceptLen);
+    }
+
+    /**
+     * This method gets the "accept len" field in the SPI frame header.
+     *
+     * @returns  The accept length in bytes.
+     *
+     */
+    uint16_t GetHeaderAcceptLen(void) const
+    {
+        return Encoding::LittleEndian::ReadUint16(mBuffer + kIndexAcceptLen);
+    }
+
+    /**
+     * This method sets the "data len" field in the SPI frame header.
+     *
+     * "Data len" specifies number of data bytes in the transmitted SPI frame.
+     *
+     * @param[in] aDataLen    The data length in bytes.
+     *
+     */
+    void SetHeaderDataLen(uint16_t aDataLen)
+    {
+        Encoding::LittleEndian::WriteUint16(aDataLen, mBuffer + kIndexDataLen);
+    }
+
+    /**
+     * This method gets the "data len" field in the SPI frame header.
+     *
+     * @returns  The data length in bytes.
+     *
+     */
+    uint16_t GetHeaderDataLen(void) const
+    {
+        return Encoding::LittleEndian::ReadUint16(mBuffer + kIndexDataLen);
+    }
+
+private:
+    enum
+    {
+        kIndexFlagByte  = 0, // flag byte  (uint8_t).
+        kIndexAcceptLen = 1, // accept len (uint16_t little-endian encoding).
+        kIndexDataLen   = 3, // data len   (uint16_t little-endian encoding).
+
+        kFlagReset       = (1 << 7),  // Flag byte RESET bit.
+        kFlagPattern     = 0x02,      // Flag byte PATTERN bits.
+        kFlagPatternMask = 0x03,      // Flag byte PATTERN mask.
+    };
+
+    uint8_t *mBuffer;
+};
+
 class NcpSpi : public NcpBase
 {
 public:
@@ -58,55 +173,66 @@ private:
          * SPI tx and rx buffer size (should fit a max length frame + SPI header).
          *
          */
-        kSpiBufferSize   = OPENTHREAD_CONFIG_NCP_SPI_BUFFER_SIZE,
+        kSpiBufferSize = OPENTHREAD_CONFIG_NCP_SPI_BUFFER_SIZE,
 
         /**
-         * Size of SPI header in bytes.
+         * Size of the SPI header (in bytes).
          *
          */
-        kSpiHeaderLength = 5,
+        kSpiHeaderSize = SpiFrame::kHeaderSize,
     };
 
     enum TxState
     {
-        kTxStateIdle,               // No frame to send.
-        kTxStateSending,            // A frame is ready to be sent.
-        kTxStateHandlingSendDone    // The frame was sent successfully, waiting to prepare the next one (if any).
+        kTxStateIdle,            // No frame to send.
+        kTxStateSending,         // A frame is ready to be sent.
+        kTxStateHandlingSendDone // The frame was sent successfully, waiting to prepare the next one (if any).
     };
 
-    static bool SpiTransactionComplete(void *aContext, uint8_t *aOutputBuf, uint16_t aOutputBufLen, uint8_t *aInputBuf,
-                                       uint16_t aInputBufLen, uint16_t aTransactionLength);
-    bool SpiTransactionComplete(uint8_t *aOutputBuf, uint16_t aOutputBufLen, uint8_t *aInputBuf, uint16_t aInputBufLen,
-                                uint16_t aTransactionLength);
+    typedef uint8_t LargeFrameBuffer[kSpiBufferSize];
+    typedef uint8_t EmptyFrameBuffer[kSpiHeaderSize];
+
+    static bool SpiTransactionComplete(void *   aContext,
+                                       uint8_t *aOutputBuf,
+                                       uint16_t aOutputLen,
+                                       uint8_t *aInputBuf,
+                                       uint16_t aInputLen,
+                                       uint16_t aTransLen);
+    bool        SpiTransactionComplete(uint8_t *aOutputBuf,
+                                       uint16_t aOutputLen,
+                                       uint8_t *aInputBuf,
+                                       uint16_t aInputLen,
+                                       uint16_t aTransLen);
 
     static void SpiTransactionProcess(void *aContext);
-    void SpiTransactionProcess(void);
+    void        SpiTransactionProcess(void);
 
-    static void HandleFrameAddedToTxBuffer(void *aContext, NcpFrameBuffer::FrameTag aFrameTag,
-                                           NcpFrameBuffer::Priority aPriority, NcpFrameBuffer *aNcpFrameBuffer);
+    static void HandleFrameAddedToTxBuffer(void *                   aContext,
+                                           NcpFrameBuffer::FrameTag aFrameTag,
+                                           NcpFrameBuffer::Priority aPriority,
+                                           NcpFrameBuffer *         aNcpFrameBuffer);
 
     static void PrepareTxFrame(Tasklet &aTasklet);
-    void PrepareTxFrame(void);
-    void HandleRxFrame(void);
-
-    otError PrepareNextSpiSendFrame(void);
+    void        PrepareTxFrame(void);
+    void        HandleRxFrame(void);
+    void        PrepareNextSpiSendFrame(void);
 
     volatile TxState mTxState;
-    volatile bool mHandlingRxFrame;
-    volatile bool mResetFlag;
+    volatile bool    mHandlingRxFrame;
+    volatile bool    mResetFlag;
 
     Tasklet mPrepareTxFrameTask;
 
-    uint16_t mSendFrameLen;
-    uint8_t mSendFrame[kSpiBufferSize];
-    uint8_t mReceiveFrame[kSpiBufferSize];
+    uint16_t         mSendFrameLength;
+    LargeFrameBuffer mSendFrame;
+    EmptyFrameBuffer mEmptySendFrameFullAccept;
+    EmptyFrameBuffer mEmptySendFrameZeroAccept;
 
-    uint8_t mEmptySendFrameZeroAccept[kSpiHeaderLength];
-    uint8_t mEmptySendFrameFullAccept[kSpiHeaderLength];
-    uint8_t mEmptyReceiveFrame[kSpiHeaderLength];
+    LargeFrameBuffer mReceiveFrame;
+    EmptyFrameBuffer mEmptyReceiveFrame;
 };
 
-}  // namespace Ncp
-}  // namespace ot
+} // namespace Ncp
+} // namespace ot
 
-#endif  // NCP_SPI_HPP_
+#endif // NCP_SPI_HPP_


### PR DESCRIPTION
This commit makes the following changes in `NcpSpi` class:

- It adds a new class `NcpSpi::Header` which provide helper
  methods to parse and update the fields in the header of an SPI
  frame.
- It simplifies/enhances the `SpiTransactionComplete()` callback
  implementation by combining the parsing of input/output frame
  headers with the rx/tx frame processing.
- It adds a check for correct pattern bits in a received frame
  flag byte (frames with incorrect pattern bits are ignored).
- Code format is changed to follow the "pretty" style.
