### PR TITLE
[logging] adding a new log level NOTE

### DIFF
--- a/include/openthread/platform/logging.h
+++ b/include/openthread/platform/logging.h
@@ -64,8 +64,9 @@ extern "C" {
 #define OT_LOG_LEVEL_NONE 0 ///< None
 #define OT_LOG_LEVEL_CRIT 1 ///< Critical
 #define OT_LOG_LEVEL_WARN 2 ///< Warning
-#define OT_LOG_LEVEL_INFO 3 ///< Info
-#define OT_LOG_LEVEL_DEBG 4 ///< Debug
+#define OT_LOG_LEVEL_NOTE 3 ///< Note
+#define OT_LOG_LEVEL_INFO 4 ///< Info
+#define OT_LOG_LEVEL_DEBG 5 ///< Debug
 
 /* note: The enum otLogRegion is found in 'openthread/types.h' */
 

--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -66,6 +66,7 @@ extern "C" {
 #define _OT_LEVEL_NONE_PREFIX "[NONE]"
 #define _OT_LEVEL_CRIT_PREFIX "[CRIT]"
 #define _OT_LEVEL_WARN_PREFIX "[WARN]"
+#define _OT_LEVEL_NOTE_PREFIX "[NOTE]"
 #define _OT_LEVEL_INFO_PREFIX "[INFO]"
 #define _OT_LEVEL_DEBG_PREFIX "[DEBG]"
 #define _OT_REGION_SUFFIX ": "
@@ -73,6 +74,7 @@ extern "C" {
 #define _OT_LEVEL_NONE_PREFIX
 #define _OT_LEVEL_CRIT_PREFIX
 #define _OT_LEVEL_WARN_PREFIX
+#define _OT_LEVEL_NOTE_PREFIX
 #define _OT_LEVEL_INFO_PREFIX
 #define _OT_LEVEL_DEBG_PREFIX
 #define _OT_REGION_SUFFIX
@@ -155,6 +157,24 @@ extern "C" {
 #endif
 
 /**
+ * @def otLogNote
+ *
+ * Logging at log level note
+ *
+ * @param[in]  aInstance A pointer to the OpenThread instance.
+ * @param[in]  aRegion   The log region.
+ * @param[in]  aFormat   A pointer to the format string.
+ * @param[in]  ...       Arguments for the format specification.
+ *
+ */
+#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#define otLogNote(aInstance, aRegion, aFormat, ...) \
+    _otLogFormatter(aInstance, OT_LOG_LEVEL_NOTE, aRegion, _OT_LEVEL_NOTE_PREFIX aFormat, ##__VA_ARGS__)
+#else
+#define otLogNote(aInstance, aRegion, aFormat, ...)
+#endif
+
+/**
  * @def otLogInfo
  *
  * Logging at log level info.
@@ -215,6 +235,17 @@ extern "C" {
  */
 
 /**
+ * @def otLogNoteApi
+ *
+ * This method generates a log with level note for the API region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
  * @def otLogInfoApi
  *
  * This method generates a log with level info for the API region.
@@ -240,6 +271,8 @@ extern "C" {
     otLogCrit(&aInstance, OT_LOG_REGION_API, _OT_REGION_API_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogWarnApi(aInstance, aFormat, ...) \
     otLogWarn(&aInstance, OT_LOG_REGION_API, _OT_REGION_API_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogNoteApi(aInstance, aFormat, ...) \
+    otLogNote(&aInstance, OT_LOG_REGION_API, _OT_REGION_API_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoApi(aInstance, aFormat, ...) \
     otLogInfo(&aInstance, OT_LOG_REGION_API, _OT_REGION_API_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogDebgApi(aInstance, aFormat, ...) \
@@ -247,6 +280,7 @@ extern "C" {
 #else
 #define otLogCritApi(aInstance, aFormat, ...)
 #define otLogWarnApi(aInstance, aFormat, ...)
+#define otLogNoteApi(aInstance, aFormat, ...)
 #define otLogInfoApi(aInstance, aFormat, ...)
 #define otLogDebgApi(aInstance, aFormat, ...)
 #endif
@@ -267,6 +301,17 @@ extern "C" {
  * @def otLogWarnMeshCoP
  *
  * This method generates a log with level warning for the MLE region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogNoteMeshCoP
+ *
+ * This method generates a log with level note for the MLE region.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aFormat      A pointer to the format string.
@@ -300,6 +345,8 @@ extern "C" {
     otLogCrit(&aInstance, OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogWarnMeshCoP(aInstance, aFormat, ...) \
     otLogWarn(&aInstance, OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogNoteMeshCoP(aInstance, aFormat, ...) \
+    otLogNote(&aInstance, OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoMeshCoP(aInstance, aFormat, ...) \
     otLogInfo(&aInstance, OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogDebgMeshCoP(aInstance, aFormat, ...) \
@@ -307,12 +354,14 @@ extern "C" {
 #else
 #define otLogCritMeshCoP(aInstance, aFormat, ...)
 #define otLogWarnMeshCoP(aInstance, aFormat, ...)
+#define otLogNoteMeshCoP(aInstance, aFormat, ...)
 #define otLogInfoMeshCoP(aInstance, aFormat, ...)
 #define otLogDebgMeshCoP(aInstance, aFormat, ...)
 #endif
 
 #define otLogCritMbedTls(aInstance, aFormat, ...) otLogCritMeshCoP(aInstance, aFormat, ##__VA_ARGS__)
 #define otLogWarnMbedTls(aInstance, aFormat, ...) otLogWarnMeshCoP(aInstance, aFormat, ##__VA_ARGS__)
+#define otLogNoteMbedTls(aInstance, aFormat, ...) otLogNoteMeshCoP(aInstance, aFormat, ##__VA_ARGS__)
 #define otLogInfoMbedTls(aInstance, aFormat, ...) otLogInfoMeshCoP(aInstance, aFormat, ##__VA_ARGS__)
 #define otLogDebgMbedTls(aInstance, aFormat, ...) otLogDebgMeshCoP(aInstance, aFormat, ##__VA_ARGS__)
 
@@ -335,7 +384,18 @@ extern "C" {
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aFormat      A pointer to the format string.
  * @param[in]  ...          Arguments for the format specification.
- * *
+ *
+ */
+
+/**
+ * @def otLogNoteMle
+ *
+ * This method generates a log with level note for the MLE region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
  */
 
 /**
@@ -346,7 +406,7 @@ extern "C" {
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aFormat      A pointer to the format string.
  * @param[in]  ...          Arguments for the format specification.
- * *
+ *
  */
 
 /**
@@ -368,6 +428,8 @@ extern "C" {
 #define otLogWarnMleErr(aInstance, aError, aFormat, ...)                                 \
     otLogWarn(&aInstance, OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX "Error %s: " aFormat, \
               otThreadErrorToString(aError), ##__VA_ARGS__)
+#define otLogNoteMle(aInstance, aFormat, ...) \
+    otLogNote(&aInstance, OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoMle(aInstance, aFormat, ...) \
     otLogInfo(&aInstance, OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogDebgMle(aInstance, aFormat, ...) \
@@ -376,6 +438,7 @@ extern "C" {
 #define otLogCritMle(aInstance, aFormat, ...)
 #define otLogWarnMle(aInstance, aFormat, ...)
 #define otLogWarnMleErr(aInstance, aError, aFormat, ...)
+#define otLogNoteMle(aInstance, aFormat, ...)
 #define otLogInfoMle(aInstance, aFormat, ...)
 #define otLogDebgMle(aInstance, aFormat, ...)
 #endif
@@ -389,13 +452,23 @@ extern "C" {
  * @param[in]  aFormat      A pointer to the format string.
  * @param[in]  ...          Arguments for the format specification.
  *
- *
  */
 
 /**
  * @def otLogWarnArp
  *
  * This method generates a log with level warning for the EID-to-RLOC mapping region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogInfoArp
+ *
+ * This method generates a log with level note for the EID-to-RLOC mapping region.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aFormat      A pointer to the format string.
@@ -429,6 +502,8 @@ extern "C" {
     otLogCrit(&aInstance, OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogWarnArp(aInstance, aFormat, ...) \
     otLogWarn(&aInstance, OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogNoteArp(aInstance, aFormat, ...) \
+    otLogNote(&aInstance, OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoArp(aInstance, aFormat, ...) \
     otLogInfo(&aInstance, OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogDebgArp(aInstance, aFormat, ...) \
@@ -436,6 +511,7 @@ extern "C" {
 #else
 #define otLogCritArp(aInstance, aFormat, ...)
 #define otLogWarnArp(aInstance, aFormat, ...)
+#define otLogNoteArp(aInstance, aFormat, ...)
 #define otLogInfoArp(aInstance, aFormat, ...)
 #define otLogDebgArp(aInstance, aFormat, ...)
 #endif
@@ -455,6 +531,17 @@ extern "C" {
  * @def otLogWarnNetData
  *
  * This method generates a log with level warning for the Network Data region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogInfoNetData
+ *
+ * This method generates a log with level note for the Network Data region.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aFormat      A pointer to the format string.
@@ -488,6 +575,8 @@ extern "C" {
     otLogCrit(&aInstance, OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogWarnNetData(aInstance, aFormat, ...) \
     otLogWarn(&aInstance, OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogNoteNetData(aInstance, aFormat, ...) \
+    otLogNote(&aInstance, OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoNetData(aInstance, aFormat, ...) \
     otLogInfo(&aInstance, OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogDebgNetData(aInstance, aFormat, ...) \
@@ -495,6 +584,7 @@ extern "C" {
 #else
 #define otLogCritNetData(aInstance, aFormat, ...)
 #define otLogWarnNetData(aInstance, aFormat, ...)
+#define otLogNoteNetData(aInstance, aFormat, ...)
 #define otLogInfoNetData(aInstance, aFormat, ...)
 #define otLogDebgNetData(aInstance, aFormat, ...)
 #endif
@@ -514,6 +604,17 @@ extern "C" {
  * @def otLogWarnIcmp
  *
  * This method generates a log with level warning for the ICMPv6 region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogNoteIcmp
+ *
+ * This method generates a log with level note for the ICMPv6 region.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aFormat      A pointer to the format string.
@@ -547,6 +648,8 @@ extern "C" {
     otLogCrit(&aInstance, OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogWarnIcmp(aInstance, aFormat, ...) \
     otLogWarn(&aInstance, OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogNoteIcmp(aInstance, aFormat, ...) \
+    otLogNote(&aInstance, OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoIcmp(aInstance, aFormat, ...) \
     otLogInfo(&aInstance, OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogDebgIcmp(aInstance, aFormat, ...) \
@@ -554,6 +657,7 @@ extern "C" {
 #else
 #define otLogCritIcmp(aInstance, aFormat, ...)
 #define otLogWarnIcmp(aInstance, aFormat, ...)
+#define otLogNoteIcmp(aInstance, aFormat, ...)
 #define otLogInfoIcmp(aInstance, aFormat, ...)
 #define otLogDebgIcmp(aInstance, aFormat, ...)
 #endif
@@ -573,6 +677,17 @@ extern "C" {
  * @def otLogWarnIp6
  *
  * This method generates a log with level warning for the IPv6 region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogNoteIp6
+ *
+ * This method generates a log with level note for the IPv6 region.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aFormat      A pointer to the format string.
@@ -606,6 +721,8 @@ extern "C" {
     otLogCrit(&aInstance, OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogWarnIp6(aInstance, aFormat, ...) \
     otLogWarn(&aInstance, OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogNoteIp6(aInstance, aFormat, ...) \
+    otLogNote(&aInstance, OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoIp6(aInstance, aFormat, ...) \
     otLogInfo(&aInstance, OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogDebgIp6(aInstance, aFormat, ...) \
@@ -613,6 +730,7 @@ extern "C" {
 #else
 #define otLogCritIp6(aInstance, aFormat, ...)
 #define otLogWarnIp6(aInstance, aFormat, ...)
+#define otLogNoteIp6(aInstance, aFormat, ...)
 #define otLogInfoIp6(aInstance, aFormat, ...)
 #define otLogDebgIp6(aInstance, aFormat, ...)
 #endif
@@ -626,13 +744,23 @@ extern "C" {
  * @param[in]  aFormat      A pointer to the format string.
  * @param[in]  ...          Arguments for the format specification.
  *
-
  */
 
 /**
  * @def otLogWarnMac
  *
  * This method generates a log with level warning for the MAC region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogNoteMac
+ *
+ * This method generates a log with level note for the MAC region.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aFormat      A pointer to the format string.
@@ -666,6 +794,8 @@ extern "C" {
     otLogCrit(&aInstance, OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogWarnMac(aInstance, aFormat, ...) \
     otLogWarn(&aInstance, OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogNoteMac(aInstance, aFormat, ...) \
+    otLogNote(&aInstance, OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoMac(aInstance, aFormat, ...) \
     otLogInfo(&aInstance, OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogDebgMac(aInstance, aFormat, ...) \
@@ -676,6 +806,7 @@ extern "C" {
 #else
 #define otLogCritMac(aInstance, aFormat, ...)
 #define otLogWarnMac(aInstance, aFormat, ...)
+#define otLogNoteMac(aInstance, aFormat, ...)
 #define otLogInfoMac(aInstance, aFormat, ...)
 #define otLogDebgMac(aInstance, aFormat, ...)
 #define otLogDebgMacErr(aInstance, aError, aFormat, ...)
@@ -696,6 +827,17 @@ extern "C" {
  * @def otLogWarnCore
  *
  * This method generates a log with level warning for the Core region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogNoteCore
+ *
+ * This method generates a log with level note for the Core region.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aFormat      A pointer to the format string.
@@ -729,6 +871,8 @@ extern "C" {
     otLogCrit(&aInstance, OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogWarnCore(aInstance, aFormat, ...) \
     otLogWarn(&aInstance, OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogNoteCore(aInstance, aFormat, ...) \
+    otLogNote(&aInstance, OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoCore(aInstance, aFormat, ...) \
     otLogInfo(&aInstance, OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogDebgCore(aInstance, aFormat, ...) \
@@ -753,7 +897,6 @@ extern "C" {
  * @param[in]  aFormat      A pointer to the format string.
  * @param[in]  ...          Arguments for the format specification.
  *
- *
  */
 
 /**
@@ -765,6 +908,16 @@ extern "C" {
  * @param[in]  aFormat      A pointer to the format string.
  * @param[in]  ...          Arguments for the format specification.
  *
+ */
+
+/**
+ * @def otLogNoteMem
+ *
+ * This method generates a log with level note for the memory region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
  *
  */
 
@@ -794,6 +947,8 @@ extern "C" {
     otLogCrit(&aInstance, OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogWarnMem(aInstance, aFormat, ...) \
     otLogWarn(&aInstance, OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogNoteMem(aInstance, aFormat, ...) \
+    otLogNote(&aInstance, OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoMem(aInstance, aFormat, ...) \
     otLogInfo(&aInstance, OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogDebgMem(aInstance, aFormat, ...) \
@@ -801,6 +956,7 @@ extern "C" {
 #else
 #define otLogCritMem(aInstance, aFormat, ...)
 #define otLogWarnMem(aInstance, aFormat, ...)
+#define otLogNoteMem(aInstance, aFormat, ...)
 #define otLogInfoMem(aInstance, aFormat, ...)
 #define otLogDebgMem(aInstance, aFormat, ...)
 #endif
@@ -820,6 +976,17 @@ extern "C" {
  * @def otLogWarnUtil
  *
  * This method generates a log with level warning for the Util region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogNoteUtil
+ *
+ * This method generates a log with level note for the Util region.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aFormat      A pointer to the format string.
@@ -853,6 +1020,8 @@ extern "C" {
     otLogCrit(&aInstance, OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogWarnUtil(aInstance, aFormat, ...) \
     otLogWarn(&aInstance, OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogNoteUtil(aInstance, aFormat, ...) \
+    otLogNote(&aInstance, OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoUtil(aInstance, aFormat, ...) \
     otLogInfo(&aInstance, OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoUtilErr(aInstance, aError, aFormat, ...)                                  \
@@ -863,6 +1032,7 @@ extern "C" {
 #else
 #define otLogCritUtil(aInstance, aFormat, ...)
 #define otLogWarnUtil(aInstance, aFormat, ...)
+#define otLogNoteUtil(aInstance, aFormat, ...)
 #define otLogInfoUtil(aInstance, aFormat, ...)
 #define otLogInfoUtilErr(aInstance, aError, aFormat, ...)
 #define otLogDebgUtil(aInstance, aFormat, ...)
@@ -883,6 +1053,17 @@ extern "C" {
  * @def otLogWarnNetDiag
  *
  * This method generates a log with level warning for the NETDIAG region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogNoteNetDiag
+ *
+ * This method generates a log with level note for the NETDIAG region.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aFormat      A pointer to the format string.
@@ -916,6 +1097,8 @@ extern "C" {
     otLogCrit(&aInstance, OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogWarnNetDiag(aInstance, aFormat, ...) \
     otLogWarn(&aInstance, OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogNoteNetDiag(aInstance, aFormat, ...) \
+    otLogNote(&aInstance, OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoNetDiag(aInstance, aFormat, ...) \
     otLogInfo(&aInstance, OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogDebgNetDiag(aInstance, aFormat, ...) \
@@ -923,6 +1106,7 @@ extern "C" {
 #else
 #define otLogCritNetDiag(aInstance, aFormat, ...)
 #define otLogWarnNetDiag(aInstance, aFormat, ...)
+#define otLogNoteNetDiag(aInstance, aFormat, ...)
 #define otLogInfoNetDiag(aInstance, aFormat, ...)
 #define otLogDebgNetDiag(aInstance, aFormat, ...)
 #endif
@@ -970,6 +1154,17 @@ extern "C" {
 /**
  * @def otLogInfoCli
  *
+ * This method generates a log with level note for the CLI region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogInfoCli
+ *
  * This method generates a log with level info for the CLI region.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
@@ -989,10 +1184,13 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_CLI == 1
+
 #define otLogCritCli(aInstance, aFormat, ...) \
     otLogCrit(&aInstance, OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogWarnCli(aInstance, aFormat, ...) \
     otLogWarn(&aInstance, OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogNoteCli(aInstance, aFormat, ...) \
+    otLogNote(&aInstance, OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoCli(aInstance, aFormat, ...) \
     otLogInfo(&aInstance, OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoCliErr(aInstance, aError, aFormat, ...) \
@@ -1002,6 +1200,7 @@ extern "C" {
 #else
 #define otLogCritCli(aInstance, aFormat, ...)
 #define otLogWarnCli(aInstance, aFormat, ...)
+#define otLogNoteCli(aInstance, aFormat, ...)
 #define otLogInfoCli(aInstance, aFormat, ...)
 #define otLogInfoCliErr(aInstance, aError, aFormat, ...)
 #define otLogDebgCli(aInstance, aFormat, ...)
@@ -1022,6 +1221,17 @@ extern "C" {
  * @def otLogWarnCoap
  *
  * This method generates a log with level warning for the CoAP region.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aFormat      A pointer to the format string.
+ * @param[in]  ...          Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogNoteCoap
+ *
+ * This method generates a log with level note for the CoAP region.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aFormat      A pointer to the format string.
@@ -1055,6 +1265,8 @@ extern "C" {
     otLogCrit(&aInstance, OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogWarnCoap(aInstance, aFormat, ...) \
     otLogWarn(&aInstance, OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogNoteCoap(aInstance, aFormat, ...) \
+    otLogNote(&aInstance, OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoCoap(aInstance, aFormat, ...) \
     otLogInfo(&aInstance, OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoCoapErr(aInstance, aError, aFormat, ...)                                  \
@@ -1065,6 +1277,7 @@ extern "C" {
 #else
 #define otLogCritCoap(aInstance, aFormat, ...)
 #define otLogWarnCoap(aInstance, aFormat, ...)
+#define otLogNoteCoap(aInstance, aFormat, ...)
 #define otLogInfoCoap(aInstance, aFormat, ...)
 #define otLogInfoCoapErr(aInstance, aError, aFormat, ...)
 #define otLogDebgCoap(aInstance, aFormat, ...)
@@ -1085,6 +1298,17 @@ extern "C" {
  * @def otLogWarnPlat
  *
  * This method generates a log with level warning for the Platform region.
+ *
+ * @param[in]  aInstance A pointer to the OpenThread instance.
+ * @param[in]  aFormat   A pointer to the format string.
+ * @param[in]  ...       Arguments for the format specification.
+ *
+ */
+
+/**
+ * @def otLogNotePlat
+ *
+ * This method generates a log with level note for the Platform region.
  *
  * @param[in]  aInstance A pointer to the OpenThread instance.
  * @param[in]  aFormat   A pointer to the format string.
@@ -1118,6 +1342,8 @@ extern "C" {
     otLogCrit(aInstance, OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogWarnPlat(aInstance, aFormat, ...) \
     otLogWarn(aInstance, OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogNotePlat(aInstance, aFormat, ...) \
+    otLogNote(aInstance, OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogInfoPlat(aInstance, aFormat, ...) \
     otLogInfo(aInstance, OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
 #define otLogDebgPlat(aInstance, aFormat, ...) \
@@ -1167,6 +1393,25 @@ extern "C" {
     otDump(&aInstance, OT_LOG_LEVEL_WARN, aRegion, aId, aBuf, aLength)
 #else
 #define otDumpWarn(aInstance, aRegion, aId, aBuf, aLength)
+#endif
+
+/**
+ * @def otDumpNote
+ *
+ * This method generates a memory dump with log level note.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aRegion      The log region.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#define otDumpNote(aInstance, aRegion, aId, aBuf, aLength) \
+    otDump(&aInstance, OT_LOG_LEVEL_NOTE, aRegion, aId, aBuf, aLength)
+#else
+#define otDumpInfo(aInstance, aRegion, aId, aBuf, aLength)
 #endif
 
 /**
@@ -1231,6 +1476,16 @@ extern "C" {
  */
 
 /**
+ * @def otDumpNoteNetData
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+
+/**
  * @def otDumpInfoNetData
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
@@ -1256,6 +1511,8 @@ extern "C" {
     otDumpCrit(aInstance, OT_LOG_REGION_NET_DATA, aId, aBuf, aLength)
 #define otDumpWarnNetData(aInstance, aId, aBuf, aLength) \
     otDumpWarn(aInstance, OT_LOG_REGION_NET_DATA, aId, aBuf, aLength)
+#define otDumpNoteNetData(aInstance, aId, aBuf, aLength) \
+    otDumpNote(aInstance, OT_LOG_REGION_NET_DATA, aId, aBuf, aLength)
 #define otDumpInfoNetData(aInstance, aId, aBuf, aLength) \
     otDumpInfo(aInstance, OT_LOG_REGION_NET_DATA, aId, aBuf, aLength)
 #define otDumpDebgNetData(aInstance, aId, aBuf, aLength) \
@@ -1263,6 +1520,7 @@ extern "C" {
 #else
 #define otDumpCritNetData(aInstance, aId, aBuf, aLength)
 #define otDumpWarnNetData(aInstance, aId, aBuf, aLength)
+#define otDumpNoteNetData(aInstance, aId, aBuf, aLength)
 #define otDumpInfoNetData(aInstance, aId, aBuf, aLength)
 #define otDumpDebgNetData(aInstance, aId, aBuf, aLength)
 #endif
@@ -1283,6 +1541,18 @@ extern "C" {
  * @def otDumpWarnMle
  *
  * This method generates a memory dump with log level warning and region MLE.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+
+/**
+ * @def otDumpNoteMle
+ *
+ * This method generates a memory dump with log level note and region MLE.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
@@ -1317,11 +1587,13 @@ extern "C" {
 #if OPENTHREAD_CONFIG_LOG_MLE == 1
 #define otDumpCritMle(aInstance, aId, aBuf, aLength) otDumpCrit(aInstance, OT_LOG_REGION_MLE, aId, aBuf, aLength)
 #define otDumpWarnMle(aInstance, aId, aBuf, aLength) otDumpWarn(aInstance, OT_LOG_REGION_MLE, aId, aBuf, aLength)
+#define otDumpNoteMle(aInstance, aId, aBuf, aLength) otDumpNote(aInstance, OT_LOG_REGION_MLE, aId, aBuf, aLength)
 #define otDumpInfoMle(aInstance, aId, aBuf, aLength) otDumpInfo(aInstance, OT_LOG_REGION_MLE, aId, aBuf, aLength)
 #define otDumpDebgMle(aInstance, aId, aBuf, aLength) otDumpDebg(aInstance, OT_LOG_REGION_MLE, aId, aBuf, aLength)
 #else
 #define otDumpCritMle(aInstance, aId, aBuf, aLength)
 #define otDumpWarnMle(aInstance, aId, aBuf, aLength)
+#define otDumpNoteMle(aInstance, aId, aBuf, aLength)
 #define otDumpInfoMle(aInstance, aId, aBuf, aLength)
 #define otDumpDebgMle(aInstance, aId, aBuf, aLength)
 #endif
@@ -1342,6 +1614,18 @@ extern "C" {
  * @def otDumpWarnArp
  *
  * This method generates a memory dump with log level warning and region EID-to-RLOC mapping.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+
+/**
+ * @def otDumpNoteArp
+ *
+ * This method generates a memory dump with log level note and region EID-to-RLOC mapping.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
@@ -1376,11 +1660,13 @@ extern "C" {
 #if OPENTHREAD_CONFIG_LOG_ARP == 1
 #define otDumpCritArp(aInstance, aId, aBuf, aLength) otDumpCrit(aInstance, OT_LOG_REGION_ARP, aId, aBuf, aLength)
 #define otDumpWarnArp(aInstance, aId, aBuf, aLength) otDumpWarn(aInstance, OT_LOG_REGION_ARP, aId, aBuf, aLength)
+#define otDumpNoteArp(aInstance, aId, aBuf, aLength) otDumpNote(aInstance, OT_LOG_REGION_ARP, aId, aBuf, aLength)
 #define otDumpInfoArp(aInstance, aId, aBuf, aLength) otDumpInfo(aInstance, OT_LOG_REGION_ARP, aId, aBuf, aLength)
 #define otDumpDebgArp(aInstance, aId, aBuf, aLength) otDumpDebg(aInstance, OT_LOG_REGION_ARP, aId, aBuf, aLength)
 #else
 #define otDumpCritArp(aInstance, aId, aBuf, aLength)
 #define otDumpWarnArp(aInstance, aId, aBuf, aLength)
+#define otDumpNoteArp(aInstance, aId, aBuf, aLength)
 #define otDumpInfoArp(aInstance, aId, aBuf, aLength)
 #define otDumpDebgArp(aInstance, aId, aBuf, aLength)
 #endif
@@ -1401,6 +1687,18 @@ extern "C" {
  * @def otDumpWarnIcmp
  *
  * This method generates a memory dump with log level warning and region ICMPv6.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+
+/**
+ * @def otDumpNoteIcmp
+ *
+ * This method generates a memory dump with log level note and region ICMPv6.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
@@ -1435,11 +1733,13 @@ extern "C" {
 #if OPENTHREAD_CONFIG_LOG_ICMP == 1
 #define otDumpCritIcmp(aInstance, aId, aBuf, aLength) otDumpCrit(aInstance, OT_LOG_REGION_ICMP, aId, aBuf, aLength)
 #define otDumpWarnIcmp(aInstance, aId, aBuf, aLength) otDumpWarn(aInstance, OT_LOG_REGION_ICMP, aId, aBuf, aLength)
+#define otDumpNoteIcmp(aInstance, aId, aBuf, aLength) otDumpNote(aInstance, OT_LOG_REGION_ICMP, aId, aBuf, aLength)
 #define otDumpInfoIcmp(aInstance, aId, aBuf, aLength) otDumpInfo(aInstance, OT_LOG_REGION_ICMP, aId, aBuf, aLength)
 #define otDumpDebgIcmp(aInstance, aId, aBuf, aLength) otDumpDebg(aInstance, OT_LOG_REGION_ICMP, aId, aBuf, aLength)
 #else
 #define otDumpCritIcmp(aInstance, aId, aBuf, aLength)
 #define otDumpWarnIcmp(aInstance, aId, aBuf, aLength)
+#define otDumpNoteIcmp(aInstance, aId, aBuf, aLength)
 #define otDumpInfoIcmp(aInstance, aId, aBuf, aLength)
 #define otDumpDebgIcmp(aInstance, aId, aBuf, aLength)
 #endif
@@ -1460,6 +1760,18 @@ extern "C" {
  * @def otDumpWarnIp6
  *
  * This method generates a memory dump with log level warning and region IPv6.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+
+/**
+ * @def otDumpNoteIp6
+ *
+ * This method generates a memory dump with log level note and region IPv6.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
@@ -1494,11 +1806,13 @@ extern "C" {
 #if OPENTHREAD_CONFIG_LOG_IP6 == 1
 #define otDumpCritIp6(aInstance, aId, aBuf, aLength) otDumpCrit(aInstance, OT_LOG_REGION_IP6, aId, aBuf, aLength)
 #define otDumpWarnIp6(aInstance, aId, aBuf, aLength) otDumpWarn(aInstance, OT_LOG_REGION_IP6, aId, aBuf, aLength)
+#define otDumpNoteIp6(aInstance, aId, aBuf, aLength) otDumpNote(aInstance, OT_LOG_REGION_IP6, aId, aBuf, aLength)
 #define otDumpInfoIp6(aInstance, aId, aBuf, aLength) otDumpInfo(aInstance, OT_LOG_REGION_IP6, aId, aBuf, aLength)
 #define otDumpDebgIp6(aInstance, aId, aBuf, aLength) otDumpDebg(aInstance, OT_LOG_REGION_IP6, aId, aBuf, aLength)
 #else
 #define otDumpCritIp6(aInstance, aId, aBuf, aLength)
 #define otDumpWarnIp6(aInstance, aId, aBuf, aLength)
+#define otDumpNoteIp6(aInstance, aId, aBuf, aLength)
 #define otDumpInfoIp6(aInstance, aId, aBuf, aLength)
 #define otDumpDebgIp6(aInstance, aId, aBuf, aLength)
 #endif
@@ -1519,6 +1833,18 @@ extern "C" {
  * @def otDumpWarnMac
  *
  * This method generates a memory dump with log level warning and region MAC.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+
+/**
+ * @def otDumpNoteMac
+ *
+ * This method generates a memory dump with log level note and region MAC.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
@@ -1553,11 +1879,13 @@ extern "C" {
 #if OPENTHREAD_CONFIG_LOG_MAC == 1
 #define otDumpCritMac(aInstance, aId, aBuf, aLength) otDumpCrit(aInstance, OT_LOG_REGION_MAC, aId, aBuf, aLength)
 #define otDumpWarnMac(aInstance, aId, aBuf, aLength) otDumpWarn(aInstance, OT_LOG_REGION_MAC, aId, aBuf, aLength)
+#define otDumpNoteMac(aInstance, aId, aBuf, aLength) otDumpNote(aInstance, OT_LOG_REGION_MAC, aId, aBuf, aLength)
 #define otDumpInfoMac(aInstance, aId, aBuf, aLength) otDumpInfo(aInstance, OT_LOG_REGION_MAC, aId, aBuf, aLength)
 #define otDumpDebgMac(aInstance, aId, aBuf, aLength) otDumpDebg(aInstance, OT_LOG_REGION_MAC, aId, aBuf, aLength)
 #else
 #define otDumpCritMac(aInstance, aId, aBuf, aLength)
 #define otDumpWarnMac(aInstance, aId, aBuf, aLength)
+#define otDumpNoteMac(aInstance, aId, aBuf, aLength)
 #define otDumpInfoMac(aInstance, aId, aBuf, aLength)
 #define otDumpDebgMac(aInstance, aId, aBuf, aLength)
 #endif
@@ -1578,6 +1906,18 @@ extern "C" {
  * @def otDumpWarnCore
  *
  * This method generates a memory dump with log level warning and region Core.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+
+/**
+ * @def otDumpNoteCore
+ *
+ * This method generates a memory dump with log level note and region Core.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
@@ -1612,11 +1952,13 @@ extern "C" {
 #if OPENTHREAD_CONFIG_LOG_CORE == 1
 #define otDumpCritCore(aInstance, aId, aBuf, aLength) otDumpCrit(aInstance, OT_LOG_REGION_CORE, aId, aBuf, aLength)
 #define otDumpWarnCore(aInstance, aId, aBuf, aLength) otDumpWarn(aInstance, OT_LOG_REGION_CORE, aId, aBuf, aLength)
+#define otDumpNoteCore(aInstance, aId, aBuf, aLength) otDumpNote(aInstance, OT_LOG_REGION_CORE, aId, aBuf, aLength)
 #define otDumpInfoCore(aInstance, aId, aBuf, aLength) otDumpInfo(aInstance, OT_LOG_REGION_CORE, aId, aBuf, aLength)
 #define otDumpDebgCore(aInstance, aId, aBuf, aLength) otDumpDebg(aInstance, OT_LOG_REGION_CORE, aId, aBuf, aLength)
 #else
 #define otDumpCritCore(aInstance, aId, aBuf, aLength)
 #define otDumpWarnCore(aInstance, aId, aBuf, aLength)
+#define otDumpNoteCore(aInstance, aId, aBuf, aLength)
 #define otDumpInfoCore(aInstance, aId, aBuf, aLength)
 #define otDumpDebgCore(aInstance, aId, aBuf, aLength)
 #endif
@@ -1637,6 +1979,18 @@ extern "C" {
  * @def otDumpWarnMem
  *
  * This method generates a memory dump with log level warning and region memory.
+ *
+ * @param[in]  aInstance    A reference to the OpenThread instance.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+
+/**
+ * @def otDumpNoteMem
+ *
+ * This method generates a memory dump with log level note and region memory.
  *
  * @param[in]  aInstance    A reference to the OpenThread instance.
  * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
@@ -1671,11 +2025,13 @@ extern "C" {
 #if OPENTHREAD_CONFIG_LOG_MEM == 1
 #define otDumpCritMem(aInstance, aId, aBuf, aLength) otDumpCrit(aInstance, OT_LOG_REGION_MEM, aId, aBuf, aLength)
 #define otDumpWarnMem(aInstance, aId, aBuf, aLength) otDumpWarn(aInstance, OT_LOG_REGION_MEM, aId, aBuf, aLength)
+#define otDumpNoteMem(aInstance, aId, aBuf, aLength) otDumpNote(aInstance, OT_LOG_REGION_MEM, aId, aBuf, aLength)
 #define otDumpInfoMem(aInstance, aId, aBuf, aLength) otDumpInfo(aInstance, OT_LOG_REGION_MEM, aId, aBuf, aLength)
 #define otDumpDebgMem(aInstance, aId, aBuf, aLength) otDumpDebg(aInstance, OT_LOG_REGION_MEM, aId, aBuf, aLength)
 #else
 #define otDumpCritMem(aInstance, aId, aBuf, aLength)
 #define otDumpWarnMem(aInstance, aId, aBuf, aLength)
+#define otDumpNoteMem(aInstance, aId, aBuf, aLength)
 #define otDumpInfoMem(aInstance, aId, aBuf, aLength)
 #define otDumpDebgMem(aInstance, aId, aBuf, aLength)
 #endif

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -842,6 +842,10 @@ uint8_t NcpBase::ConvertLogLevel(otLogLevel aLogLevel)
         spinelLogLevel = SPINEL_NCP_LOG_LEVEL_WARN;
         break;
 
+    case OT_LOG_LEVEL_NOTE:
+        spinelLogLevel = SPINEL_NCP_LOG_LEVEL_NOTICE;
+        break;
+
     case OT_LOG_LEVEL_INFO:
         spinelLogLevel = SPINEL_NCP_LOG_LEVEL_INFO;
         break;
@@ -2354,6 +2358,9 @@ otError NcpBase::SetPropertyHandler_DEBUG_NCP_LOG_LEVEL(void)
         break;
 
     case SPINEL_NCP_LOG_LEVEL_NOTICE:
+        logLevel = OT_LOG_LEVEL_NOTE;
+        break;
+
     case SPINEL_NCP_LOG_LEVEL_INFO:
         logLevel = OT_LOG_LEVEL_INFO;
         break;


### PR DESCRIPTION
This commit adds a new log level `NOTE` between `INFO` and `WARN`. The `INFO` level is intended for informational message about behavior of  the network (e.g., info about received/transmitted messages). `NOTE` level is intended for normal but significant events that require special handling (e.g., device getting detached) and are expected to be less frequent that `INFO` level events and logs.
