### PR TITLE
[trickle-timer] improve/simplify the implementation

### DIFF
--- a/src/core/common/trickle_timer.hpp
+++ b/src/core/common/trickle_timer.hpp
@@ -58,29 +58,32 @@ class TrickleTimer : public TimerMilli
 {
 public:
     /**
-     * Represents the modes of operation for the TrickleTimer
+     * This enumeration defines the modes of operation for the `TrickleTimer`.
+     *
      */
-    typedef enum Mode {
-        kModeNormal     = 0, ///< Runs the normal trickle logic.
-        kModePlainTimer = 1, ///< Runs a normal timer between Imin and Imax.
-        kModeMPL        = 2, ///< Runs the trickle logic modified for MPL.
-    } Mode;
+    enum Mode
+    {
+        kModeNormal,     ///< Runs the normal trickle logic (as per RFC6206).
+        kModePlainTimer, ///< Runs a plain timer with random interval selected between min/max intervals.
+        kModeMPL,        ///< Runs the trickle logic modified for MPL.
+    };
 
     /**
      * This function pointer is called when the timer expires.
      *
-     * @param[in]  aTimer  A reference to the expired timer.
+     * @param[in]  aTimer  A reference to the trickle timer.
      *
      * @retval TRUE   If the trickle timer should continue running.
      * @retval FALSE  If the trickle timer should stop running.
+     *
      */
     typedef bool (*Handler)(TrickleTimer &aTimer);
 
     /**
-     * This constructor creates a trickle timer instance.
+     * This constructor initializes a `TrickleTimer` instance.
      *
-     * @param[in]  aInstance                A reference to the instance.
-     * @param[in]  aRedundancyConstant      The redundancy constant for the timer, k.
+     * @param[in]  aInstance                A reference to the OpenThread instance.
+     * @param[in]  aRedundancyConstant      The redundancy constant for the timer, also known as `k`.
      * @param[in]  aTransmitHandler         A pointer to a function that is called when transmission should occur.
      * @param[in]  aIntervalExpiredHandler  An optional pointer to a function that is called when the interval expires.
      * @param[in]  aOwner                   A pointer to owner of the `TrickleTimer` object.
@@ -99,29 +102,22 @@ public:
      *
      * @retval TRUE   If the trickle timer is running.
      * @retval FALSE  If the trickle timer is not running.
+     *
      */
-    bool IsRunning(void) const;
+    bool IsRunning(void) const { return mIsRunning; }
 
     /**
-     * This method start the trickle timer.
+     * This method starts the trickle timer.
      *
-     * @param[in]  aIntervalMin  The minimum interval for the timer, Imin.
-     * @param[in]  aIntervalMax  The maximum interval for the timer, Imax.
+     * @param[in]  aIntervalMin  The minimum interval for the timer in milliseconds.
+     * @param[in]  aIntervalMax  The maximum interval for the timer in milliseconds.
      * @param[in]  aMode         The operating mode for the timer.
      *
-     */
-    void Start(uint32_t aIntervalMin, uint32_t aIntervalMax, Mode aMode);
-
-    /**
-     * This method start the trickle timer.
-     *
-     * @param[in]  aStartTime    The start time.
-     * @param[in]  aIntervalMin  The minimum interval for the timer, Imin.
-     * @param[in]  aIntervalMax  The maximum interval for the timer, Imax.
-     * @param[in]  aMode         The operating mode for the timer.
+     * @retval OT_ERROR_NONE           The timer started successfully.
+     * @retval OT_ERROR_INVALID_ARGS   The given parameters are invalid (i.e., max interval is smaller than min).
      *
      */
-    void StartAt(uint32_t aStartTime, uint32_t aIntervalMin, uint32_t aIntervalMax, Mode aMode);
+    otError Start(uint32_t aIntervalMin, uint32_t aIntervalMax, Mode aMode);
 
     /**
      * This method stops the trickle timer.
@@ -134,7 +130,7 @@ public:
      * This method indicates to the trickle timer a 'consistent' state.
      *
      */
-    void IndicateConsistent(void);
+    void IndicateConsistent(void) { mCounter++; }
 #endif
 
     /**
@@ -144,52 +140,27 @@ public:
     void IndicateInconsistent(void);
 
 private:
-    bool TransmitFired(void) { return mTransmitHandler(*this); }
-    bool IntervalExpiredFired(void) { return mIntervalExpiredHandler ? mIntervalExpiredHandler(*this) : true; }
-
-    void StartNewInterval(void);
-
-    static void HandleTimerFired(Timer &aTimer);
-    void        HandleTimerFired(void);
-
-    // Shadow base class method to ensure it is hidden.
-    void StartAt(void) {}
-
-    typedef enum Phase {
-        ///< Indicates we are currently not running
-        kPhaseDormant = 1,
-        ///< Indicates that when the timer expires, it should evaluate for transmit callbacks
-        kPhaseTransmit = 2,
-        ///< Indicates that when the timer expires, it should process interval expiration callbacks
-        kPhaseInterval = 3,
-    } Phase;
+    void        StartNewInterval(void);
+    static void HandleTimer(Timer &aTimer);
+    void        HandleTimer(void);
+    void        HandleEndOfTimeInInterval(void);
+    void        HandleEndOfInterval(void);
+    void        StartAt(void) {} // Shadow base class `TimerMilli` method to ensure it is hidden.
 
 #ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
-    // Redundancy constant
-    const uint32_t k;
-
-    // A counter, keeping track of the number of "consistent" transmissions received
-    uint32_t c;
+    const uint32_t mRedundancyConstant; // Redundancy constant (aka 'k').
+    uint32_t       mCounter;            // A counter for number of "consistent" transmissions (aka 'c').
 #endif
 
-    // Minimum interval size
-    uint32_t Imin;
-    // Maximum interval size
-    uint32_t Imax;
-    // The mode of operation
-    Mode mMode;
-
-    // The current interval size (in milliseconds)
-    uint32_t I;
-    // The time (in milliseconds) into the interval at which we should transmit
-    uint32_t t;
-
-    // The current trickle phase for the timer
-    Phase mPhase;
-
-    // Callback variables
-    Handler mTransmitHandler;
-    Handler mIntervalExpiredHandler;
+    uint32_t mIntervalMin;            // Minimum interval (aka `Imin`).
+    uint32_t mIntervalMax;            // Maximum interval (aka `Imax`).
+    uint32_t mInterval;               // Current interval (aka `I`).
+    uint32_t mTimeInInterval;         // Time in interval (aka `t`).
+    Handler  mTransmitHandler;        // Transmit handler callback.
+    Handler  mIntervalExpiredHandler; // Interval expired handler callback.
+    Mode     mMode;                   // Trickle timer mode.
+    bool     mIsRunning : 1;          // Indicates if the trickle timer is running.
+    bool     mInTransmitPhase : 1;    // Indicates if in transmit phase (before time `t` in current interval `I`).
 };
 
 /**


### PR DESCRIPTION
This commit makes the following changes in `TrickleTimer` class:

- Member variable are renamed to follow the code style guideline.
- New methods added for handling of "end of interval" vs. "middle
  of interval" timer fired callbacks.
- The random range selections for mode `kModeNormal` are updated
  to follow RFC6206 (closed vs. open range).