### PR TITLE
[code-style] enhance clang-format.sh

### DIFF
--- a/script/clang-format.sh
+++ b/script/clang-format.sh
@@ -34,7 +34,9 @@ die() {
     exit 1
 }
 
-if which clang-format > /dev/null; then
+if which clang-format-5.0 > /dev/null; then
+    alias clang-format=clang-format-5.0
+elif which clang-format > /dev/null; then
     case "$(clang-format --version)" in
         "$CLANG_FORMAT_VERSION"*)
             ;;
@@ -42,8 +44,6 @@ if which clang-format > /dev/null; then
             die "clang-format 5.0 required"
             ;;
     esac
-elif which clang-format-5.0 > /dev/null; then
-    alias clang-format=clang-format-5.0
 else
     die "clang-format 5.0 required"
 fi


### PR DESCRIPTION
This PR prefers `clang-format-5.0` to `clang-format`.