### PR TITLE
[kw41z] radio driver fix to allow channel change

### DIFF
--- a/examples/platforms/kw41z/radio.c
+++ b/examples/platforms/kw41z/radio.c
@@ -234,24 +234,26 @@ otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 
     sState = OT_RADIO_STATE_RECEIVE;
 
-    otEXPECT(rf_get_state() != XCVR_RX_c);
-
     rf_abort();
 
-    /* Set Power level for auto TX */
-    rf_set_tx_power(sAutoTxPwrLevel);
-    rf_set_channel(aChannel);
-    sRxFrame.mChannel = aChannel;
+    /* Check if the channel needs to be changed */
+    if (sChannel != aChannel)
+    {
+        /* Set Power level for auto TX */
+        rf_set_tx_power(sAutoTxPwrLevel);
+        rf_set_channel(aChannel);
+        sRxFrame.mChannel = aChannel;
 
-    /* Filter ACK frames during RX sequence */
-    ZLL->RX_FRAME_FILTER &= ~(ZLL_RX_FRAME_FILTER_ACK_FT_MASK);
-    /* Clear all IRQ flags */
-    ZLL->IRQSTS = ZLL->IRQSTS;
-    /* Start the RX sequence */
-    ZLL->PHY_CTRL |= XCVR_RX_c;
+        /* Filter ACK frames during RX sequence */
+        ZLL->RX_FRAME_FILTER &= ~(ZLL_RX_FRAME_FILTER_ACK_FT_MASK);
+        /* Clear all IRQ flags */
+        ZLL->IRQSTS = ZLL->IRQSTS;
+        /* Start the RX sequence */
+        ZLL->PHY_CTRL |= XCVR_RX_c;
 
-    /* Unmask SEQ interrupt */
-    ZLL->PHY_CTRL &= ~ZLL_PHY_CTRL_SEQMSK_MASK;
+        /* Unmask SEQ interrupt */
+        ZLL->PHY_CTRL &= ~ZLL_PHY_CTRL_SEQMSK_MASK;
+    }
 
 exit:
     return status;

--- a/examples/platforms/kw41z/radio.c
+++ b/examples/platforms/kw41z/radio.c
@@ -242,17 +242,17 @@ otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
         rf_set_tx_power(sAutoTxPwrLevel);
         rf_set_channel(aChannel);
         sRxFrame.mChannel = aChannel;
-
-        /* Filter ACK frames during RX sequence */
-        ZLL->RX_FRAME_FILTER &= ~(ZLL_RX_FRAME_FILTER_ACK_FT_MASK);
-        /* Clear all IRQ flags */
-        ZLL->IRQSTS = ZLL->IRQSTS;
-        /* Start the RX sequence */
-        ZLL->PHY_CTRL |= XCVR_RX_c;
-
-        /* Unmask SEQ interrupt */
-        ZLL->PHY_CTRL &= ~ZLL_PHY_CTRL_SEQMSK_MASK;
     }
+
+    /* Filter ACK frames during RX sequence */
+    ZLL->RX_FRAME_FILTER &= ~(ZLL_RX_FRAME_FILTER_ACK_FT_MASK);
+    /* Clear all IRQ flags */
+    ZLL->IRQSTS = ZLL->IRQSTS;
+    /* Start the RX sequence */
+    ZLL->PHY_CTRL |= XCVR_RX_c;
+
+    /* Unmask SEQ interrupt */
+    ZLL->PHY_CTRL &= ~ZLL_PHY_CTRL_SEQMSK_MASK;
 
 exit:
     return status;

--- a/examples/platforms/kw41z/radio.c
+++ b/examples/platforms/kw41z/radio.c
@@ -234,11 +234,10 @@ otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 
     sState = OT_RADIO_STATE_RECEIVE;
 
-    rf_abort();
-
     /* Check if the channel needs to be changed */
     if (sChannel != aChannel)
     {
+        rf_abort();
         /* Set Power level for auto TX */
         rf_set_tx_power(sAutoTxPwrLevel);
         rf_set_channel(aChannel);


### PR DESCRIPTION
The NXP KW41Z radio driver prohibited changing channels while in receive mode; this prevented the leader properly responding to MLE Announces from orphaned child devices. With this fix, the leader will correctly jump to the child's channel (if the child's active timestamp is less than the leader's active timestamp) and perform the proper sequence of announces. Please reference ["ParentRequest/ParentResponse and MLE Announce Timing issue"](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/openthread-users/EGlHwc0Rtbs) for more detailed information.