### PR TITLE
[mle] properly handle cases where router table is not populated

### DIFF
--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -474,7 +474,8 @@ Router *RouterTable::GetLeader(void)
 
 uint32_t RouterTable::GetLeaderAge(void) const
 {
-    return TimerMilli::MsecToSec(TimerMilli::GetNow() - mRouterIdSequenceLastUpdated);
+    return (mActiveRouterCount > 0) ? TimerMilli::MsecToSec(TimerMilli::GetNow() - mRouterIdSequenceLastUpdated)
+                                    : 0xffffffff;
 }
 
 uint8_t RouterTable::GetNeighborCount(void) const


### PR DESCRIPTION
After attaching to a network, a device may need to wait until receiving the
next MLE Advertisement before populating the router table.

This commit makes the following changes:

- When receiving an MLE Advertisement, always process the Route TLV when the
  router table is not yet populated.

- Have RouterTable::GetLeaderAge() return max value when the router table
  is not yet populated.

- When generating a Connectivity TLV, populate the max routing cost when
  no leader information is available.

Resolves #2748.