### PR TITLE
[mesh-forwarder] do not treat CCA failures the same as no-ack

### DIFF
--- a/src/core/thread/data_poll_manager.cpp
+++ b/src/core/thread/data_poll_manager.cpp
@@ -217,6 +217,12 @@ void DataPollManager::HandlePollSent(otError aError)
 
         break;
 
+    case OT_ERROR_CHANNEL_ACCESS_FAILURE:
+    case OT_ERROR_ABORT:
+        mRetxMode                   = true;
+        shouldRecalculatePollPeriod = true;
+        break;
+
     default:
         mPollTxFailureCounter++;
 

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -957,7 +957,7 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, otError aError)
 
     if (mSendMessage->GetDirectTransmission())
     {
-        if (aError != OT_ERROR_NONE)
+        if (aError == OT_ERROR_NO_ACK)
         {
             // If the transmission of any fragment frame fails,
             // the overall message transmission is considered

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -592,14 +592,18 @@ void MeshForwarder::HandleSentFrameToChild(const Mac::Frame &aFrame, otError aEr
         iter.Advance();
         mIndirectStartingChild = iter.GetChild();
 
-        if (aError == OT_ERROR_NONE)
+        switch (aError)
         {
+        case OT_ERROR_NONE:
             child->ResetIndirectTxAttempts();
-        }
-        else
-        {
-            child->IncrementIndirectTxAttempts();
+            break;
 
+        case OT_ERROR_NO_ACK:
+            child->IncrementIndirectTxAttempts();
+            // fall through
+
+        case OT_ERROR_CHANNEL_ACCESS_FAILURE:
+        case OT_ERROR_ABORT:
             if (child->GetIndirectTxAttempts() < kMaxPollTriggeredTxAttempts)
             {
                 // We save the frame counter, key id, and data sequence number of
@@ -634,6 +638,12 @@ void MeshForwarder::HandleSentFrameToChild(const Mac::Frame &aFrame, otError aEr
 
             mMessageNextOffset = mSendMessage->GetLength();
 #endif
+
+            break;
+
+        default:
+            assert(false);
+            break;
         }
     }
 


### PR DESCRIPTION
Thread 1.1.1 Section 5.9.4 states: "Note that failures to transmit due to
failed clear channel assessments do not count as a failure to receive an
ACK."