### PR TITLE
[mesh-forwarder] do not log dropping of received beacon frames

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1169,6 +1169,9 @@ void MeshForwarder::HandleReceivedFrame(Mac::Frame &aFrame)
 
 #endif
 
+    case Mac::Frame::kFcfFrameBeacon:
+        break;
+
     default:
         error = OT_ERROR_DROP;
         break;


### PR DESCRIPTION
This change removes the log message indicating dropping of a
received beacon frame.

----
This change helps reduce the not-so-useful log message  (which is observed a lot in busy test environment). 