### PR TITLE
[posix] skip calling RadioReceiveDone with OT_ERROR_ABORT

### DIFF
--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -748,16 +748,18 @@ void radioProcessFrame(otInstance *aInstance)
 
 exit:
 
+    if (error != OT_ERROR_ABORT)
+    {
 #if OPENTHREAD_ENABLE_DIAG
-
-    if (otPlatDiagModeGet())
-    {
-        otPlatDiagRadioReceiveDone(aInstance, error == OT_ERROR_NONE ? &sReceiveFrame : NULL, error);
-    }
-    else
+        if (otPlatDiagModeGet())
+        {
+            otPlatDiagRadioReceiveDone(aInstance, error == OT_ERROR_NONE ? &sReceiveFrame : NULL, error);
+        }
+        else
 #endif
-    {
-        otPlatRadioReceiveDone(aInstance, error == OT_ERROR_NONE ? &sReceiveFrame : NULL, error);
+        {
+            otPlatRadioReceiveDone(aInstance, error == OT_ERROR_NONE ? &sReceiveFrame : NULL, error);
+        }
     }
 }
 


### PR DESCRIPTION
This commit changes the posix platform radio implementation by not
invoking the `RadioReceiveDone` callback with error `OT_ERROR_ABORT`.
This is added to help remove extra logs when simulating OpenThread in
posix mode.