### PR TITLE
[mesh-forwarder] add logs for forwarded MeshHeader messages

### DIFF
--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -326,7 +326,7 @@ private:
 
     otError GetDestinationRlocByServiceAloc(uint16_t aServiceAloc, uint16_t &aMeshDest);
 
-    void LogIp6Message(MessageAction aAction, const Message &aMessage, const Mac::Address *aMacAddress, otError aError);
+    void LogMessage(MessageAction aAction, const Message &aMessage, const Mac::Address *aAddress, otError aError);
     void LogFrame(const char *aActionText, const Mac::Frame &aFrame, otError aError);
     void LogFragmentFrameDrop(otError                       aError,
                               uint8_t                       aFrameLength,
@@ -339,6 +339,40 @@ private:
                               const Mac::Address &aMacSource,
                               const Mac::Address &aMacDest,
                               bool                aIsSecure);
+
+#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MAC == 1)
+    const char *MessageActionToString(MessageAction aAction, otError aError);
+    const char *MessagePriorityToString(const Message &aMessage);
+
+    otError ParseIp6UdpTcpHeader(const Message &aMessage,
+                                 Ip6::Header &  aIp6Header,
+                                 uint16_t &     aChecksum,
+                                 uint16_t &     aSourcePort,
+                                 uint16_t &     aDestPort);
+    otError DecompressIp6UdpTcpHeader(const Message &     aMessage,
+                                      uint16_t            aOffset,
+                                      const Mac::Address &aMeshSource,
+                                      const Mac::Address &aMeshDest,
+                                      Ip6::Header &       aIp6Header,
+                                      uint16_t &          aChecksum,
+                                      uint16_t &          aSourcePort,
+                                      uint16_t &          aDestPort);
+    otError LogMeshFragmentHeader(MessageAction       aAction,
+                                  const Message &     aMessage,
+                                  const Mac::Address *aMacAddress,
+                                  otError             aError,
+                                  uint16_t &          aOffset,
+                                  Mac::Address &      aMeshSource,
+                                  Mac::Address &      aMeshDest);
+
+    void LogIp6SourceDestAddresses(Ip6::Header &aIp6Header, uint16_t aSourcePort, uint16_t aDestPort);
+    void LogMeshIpHeader(const Message &     aMessage,
+                         uint16_t            aOffset,
+                         const Mac::Address &aMeshSource,
+                         const Mac::Address &aMeshDest);
+    void LogMeshMessage(MessageAction aAction, const Message &aMessage, const Mac::Address *aAddress, otError aError);
+    void LogIp6Message(MessageAction aAction, const Message &aMessage, const Mac::Address *aAddress, otError aError);
+#endif
 
     Mac::Receiver mMacReceiver;
     Mac::Sender   mMacSender;


### PR DESCRIPTION
This commit adds a new method `MeshForwarder::LogMeshMessage()` to log
info about messages with `MeshHeader` (messages that are forwarded by
device). The new logs indicate  when a message is received/sent or
possibly dropped. The immediate source and destination for the
received or sent frame is logged. The new logs include info from
`MeshHeader` such as mesh source, mesh destination, number of hops
left. If the message is fragmented, info from fragment header such as
datagram tag and offset is included in the logs. For a non-fragmented
or a  first fragment `LogMeshMessage()` will also decompress the IPv6
and transport (UDP/TCP) headers and  provide info from them such as
IPv6 payload length, UDP/TCP checksum and IPv6 source/destination
addresses in the logs.

In addition to the new logs, this commit makes the following small changes:
- Adds `\t` to log lines which are grouped (make it easier to read).
- Adds `const` qualifiers to some methods in `Lowpan::MeshHeader`.
- Adds new method in `FragmentHeader` to init it from a `Message`.

-----------

Here is sample of new logs for a mesh frame (non-fragmented):

```
wpantund[226515]: NCP => [INFO]-MAC-----: Received mesh frame, len:53, from:0x8800, msrc:0x8800, mdst:0xd000, hops:3, frag:no, sec:yes, rss:-20.0
wpantund[226515]: NCP => [INFO]-MAC-----:       IPv6 UDP msg, plen:50, chksum:bbe8, prio:low
wpantund[226515]: NCP => [INFO]-MAC-----:       src: fd88:feef:f677:0:0:ff:fe00:8800
wpantund[226515]: NCP => [INFO]-MAC-----:       dst: fd88:feef:f677:0:0:ff:fe00:d000
wpantund[226515]: NCP => [INFO]-MAC-----: Sent mesh frame, len:53, to:0xd000, msrc:0x8800, mdst:0xd000, hops:2, frag:no, sec:yes
wpantund[226515]: NCP => [INFO]-MAC-----: Received mesh frame, len:73, from:0xd000, msrc:0xd000, mdst:0x8800, hops:3, frag:no, sec:yes, rss:-20.0
wpantund[226515]: NCP => [INFO]-MAC-----:       IPv6 UDP msg, plen:40, chksum:e391, prio:low
wpantund[226515]: NCP => [INFO]-MAC-----:       src: fd88:feef:f677:0:70ea:b020:c04f:68df
wpantund[226515]: NCP => [INFO]-MAC-----:       dst: fd88:feef:f677:0:fd54:569d:56e1:59d1
wpantund[226515]: NCP => [INFO]-MAC-----: Received mesh frame, len:73, from:0xd000, msrc:0xd000, mdst:0x8800, hops:3, frag:no, sec:yes, rss:-20.0
wpantund[226515]: NCP => [INFO]-MAC-----:       IPv6 UDP msg, plen:40, chksum:e391, prio:low
wpantund[226515]: NCP => [INFO]-MAC-----:       src: fd88:feef:f677:0:70ea:b020:c04f:68df
wpantund[226515]: NCP => [INFO]-MAC-----:       dst: fd88:feef:f677:0:fd54:569d:56e1:59d1
wpantund[226515]: NCP => [INFO]-MAC-----: Sent mesh frame, len:73, to:0x8800, msrc:0xd000, mdst:0x8800, hops:2, frag:no, sec:yes
```

For fragmented mesh header frames:

```
wpantund[233247]: NCP => [INFO]-MAC-----: Received mesh frame, len:101, from:0xf400, msrc:0xf400, mdst:0x0400, hops:3, frag:yes, sec:yes, rss:-20.0
wpantund[233247]: NCP => [INFO]-MAC-----:       Frag tag:c1a0, offset:0
wpantund[233247]: NCP => [INFO]-MAC-----:       IPv6 UDP msg, plen:108, chksum:a459, prio:low
wpantund[233247]: NCP => [INFO]-MAC-----:       src: fd6b:4c48:3cc7:0:1907:f415:ea68:9115
wpantund[233247]: NCP => [INFO]-MAC-----:       dst: fd6b:4c48:3cc7:0:2468:50c1:8b0a:eac
wpantund[233247]: NCP => [INFO]-MAC-----: Received mesh frame, len:46, from:0xf400, msrc:0xf400, mdst:0x0400, hops:3, frag:yes, sec:yes, rss:-20.0
wpantund[233247]: NCP => [INFO]-MAC-----:       Frag tag:c1a0, offset:112
wpantund[233247]: NCP => [INFO]-MAC-----: Sent mesh frame, len:101, to:0x0400, msrc:0xf400, mdst:0x0400, hops:2, frag:yes, sec:yes
wpantund[233247]: NCP => [INFO]-MAC-----:       Frag tag:c1a0, offset:0
wpantund[233247]: NCP => [INFO]-MAC-----: Sent mesh frame, len:46, to:0x0400, msrc:0xf400, mdst:0x0400, hops:2, frag:yes, sec:yes
wpantund[233247]: NCP => [INFO]-MAC-----:       Frag tag:c1a0, offset:112
```



