### PR TITLE
[mac] use link layer sequnece number to detect duplicate frames

### DIFF
--- a/include/openthread/types.h
+++ b/include/openthread/types.h
@@ -1159,6 +1159,7 @@ typedef struct otThreadLinkInfo
     uint8_t  mChannel;      ///< 802.15.4 Channel
     int8_t   mRss;          ///< Received Signal Strength in dBm.
     uint8_t  mLqi;          ///< Link Quality Indicator for a received message.
+    uint8_t  mSequence;     ///< The link sequence number of the received message.
     bool     mLinkSecurity; ///< Indicates whether or not link security is enabled.
 } otThreadLinkInfo;
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1602,7 +1602,7 @@ otError Mac::ProcessFrameSequence(Frame &aFrame, const Address &aSrcAddr)
 
     VerifyOrExit(linkNeighbor != NULL);
 
-    if (aFrame.GetSequence() + 1 <= linkNeighbor->GetLinkFrameSequence())
+    if (aFrame.GetSequence() + 1 == linkNeighbor->GetLinkFrameSequence())
     {
         ExitNow(error = OT_ERROR_DUPLICATED);
     }

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -908,6 +908,7 @@ private:
     void    GenerateNonce(const ExtAddress &aAddress, uint32_t aFrameCounter, uint8_t aSecurityLevel, uint8_t *aNonce);
     void    ProcessTransmitSecurity(Frame &aFrame);
     otError ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, Neighbor *aNeighbor);
+    otError ProcessFrameSequence(Frame &aFrame, const Address &aSrcAddr);
     void    UpdateIdleMode(void);
     void    StartOperation(Operation aOperation);
     void    FinishOperation(void);
@@ -915,7 +916,7 @@ private:
     void    SendBeacon(Frame &aFrame);
     void    StartBackoff(void);
     void    BeginTransmit(void);
-    otError HandleMacCommand(Frame &aFrame);
+    otError HandleMacCommand(Frame &aFrame, const Address &aSrcAddr);
     Frame * GetOperationFrame(void);
 
     static void HandleMacTimer(Timer &aTimer);

--- a/src/core/thread/child_table.cpp
+++ b/src/core/thread/child_table.cpp
@@ -265,8 +265,12 @@ bool ChildTable::MatchesFilter(const Child &aChild, StateFilter aFilter)
         rval = (aChild.GetState() != Child::kStateInvalid);
         break;
 
-    case kInStateAnyExceptValidOrRestoing:
+    case kInStateAnyExceptValidOrRestoring:
         rval = !aChild.IsStateValidOrRestoring();
+        break;
+
+    case kInStateAnyExceptInvalidOrRestoring:
+        rval = !aChild.IsStateInvalidOrRestoring();
         break;
     }
 

--- a/src/core/thread/child_table.hpp
+++ b/src/core/thread/child_table.hpp
@@ -58,12 +58,13 @@ public:
      */
     enum StateFilter
     {
-        kInStateValid,                    ///< Accept child only in `Child::kStateValid`.
-        kInStateValidOrRestoring,         ///< Accept child with `Child::IsStateValidOrRestoring()` being `true`.
-        kInStateChildIdRequest,           ///< Accept child only in `Child:kStateChildIdRequest`.
-        kInStateValidOrAttaching,         ///< Accept child with `Child::IsStateValidOrAttaching()` being `true`.
-        kInStateAnyExceptInvalid,         ///< Accept child in any state except `Child:kStateInvalid`.
-        kInStateAnyExceptValidOrRestoing, ///< Accept child in any state except `Child::IsStateValidOrRestoring()`.
+        kInStateValid,                       ///< Accept child only in `Child::kStateValid`.
+        kInStateValidOrRestoring,            ///< Accept child with `Child::IsStateValidOrRestoring()` being `true`.
+        kInStateChildIdRequest,              ///< Accept child only in `Child:kStateChildIdRequest`.
+        kInStateValidOrAttaching,            ///< Accept child with `Child::IsStateValidOrAttaching()` being `true`.
+        kInStateAnyExceptInvalid,            ///< Accept child in any state except `Child:kStateInvalid`.
+        kInStateAnyExceptValidOrRestoring,   ///< Accept child in any state except `Child::IsStateValidOrRestoring()`.
+        kInStateAnyExceptInvalidOrRestoring, ///< Accept child in any state except `Child::IsStateInvalidOrRestoring()`.
     };
 
     /**

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1115,6 +1115,7 @@ void MeshForwarder::HandleReceivedFrame(Mac::Frame &aFrame)
     linkInfo.mRss          = aFrame.GetRssi();
     linkInfo.mLqi          = aFrame.GetLqi();
     linkInfo.mLinkSecurity = aFrame.GetSecurityEnabled();
+    linkInfo.mSequence     = aFrame.GetSequence();
 
     payload       = aFrame.GetPayload();
     payloadLength = aFrame.GetPayloadLength();

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -219,7 +219,7 @@ exit:
 
 void MeshForwarder::UpdateIndirectMessages(void)
 {
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateAnyExceptValidOrRestoing); !iter.IsDone();
+    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateAnyExceptValidOrRestoring); !iter.IsDone();
          iter.Advance())
     {
         if (iter.GetChild()->GetIndirectMessageCount() == 0)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3221,11 +3221,16 @@ otError Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::Messag
     // Challenge
     if (Tlv::GetTlv(aMessage, Tlv::kChallenge, sizeof(challenge), challenge) == OT_ERROR_NONE)
     {
+        const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
+
         VerifyOrExit(challenge.IsValid(), error = OT_ERROR_PARSE);
         VerifyOrExit(static_cast<size_t>(numTlvs + 3) <= sizeof(tlvs), error = OT_ERROR_NO_BUFS);
         tlvs[numTlvs++] = Tlv::kResponse;
         tlvs[numTlvs++] = Tlv::kMleFrameCounter;
         tlvs[numTlvs++] = Tlv::kLinkFrameCounter;
+
+        // Challenge TLV indicates parent coming out of reset
+        mParent.SetLinkFrameSequence(linkInfo->mSequence + 1);
     }
 
     SuccessOrExit(error = SendChildUpdateResponse(tlvs, numTlvs, challenge));

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1328,6 +1328,16 @@ protected:
     }
 
     /**
+     * This method returns a pointer to the neighbor object.
+     *
+     * @param[in]  aAddress  A reference to the MAC address.
+     *
+     * @returns A pointer to the neighbor object.
+     *
+     */
+    Neighbor *GetLinkNeighbor(const Mac::Address &aAddress);
+
+    /**
      * This method returns the next hop towards an RLOC16 destination.
      *
      * @param[in]  aDestination  The RLOC16 of the destination.

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -413,6 +413,16 @@ public:
     Neighbor *GetNeighbor(const Ip6::Address &aAddress);
 
     /**
+     * This method returns a pointer to a Neighbor object.
+     *
+     * @param[in]  aAddress  The address of the Neighbor.
+     *
+     * @returns A pointer to the Neighbor corresponding to @p aAddress, NULL otherwise.
+     *
+     */
+    Neighbor *GetLinkNeighbor(const Mac::Address &aAddress);
+
+    /**
      * This method returns a pointer to a Neighbor object if a one-way link is maintained
      * as in the instance of an FFD child with neighbor routers.
      *
@@ -771,6 +781,9 @@ private:
     bool HasMinDowngradeNeighborRouters(void);
     bool HasOneNeighborWithComparableConnectivity(const RouteTlv &aRoute, uint8_t aRouterId);
     bool HasSmallNumberOfChildren(void);
+
+    Neighbor *GetNeighbor(uint16_t aAddress, ChildTable::StateFilter aFilter);
+    Neighbor *GetNeighbor(const Mac::ExtAddress &aAddress, ChildTable::StateFilter aFilter);
 
     static bool HandleAdvertiseTimer(TrickleTimer &aTimer);
     bool        HandleAdvertiseTimer(void);

--- a/src/core/thread/mle_router_mtd.hpp
+++ b/src/core/thread/mle_router_mtd.hpp
@@ -96,6 +96,7 @@ public:
     Neighbor *GetNeighbor(const Mac::ExtAddress &aAddress) { return Mle::GetNeighbor(aAddress); }
     Neighbor *GetNeighbor(const Mac::Address &aAddress) { return Mle::GetNeighbor(aAddress); }
     Neighbor *GetNeighbor(const Ip6::Address &aAddress) { return Mle::GetNeighbor(aAddress); }
+    Neighbor *GetLinkNeighbor(const Mac::Address &aAddress) { return Mle::GetLinkNeighbor(aAddress); }
     Neighbor *GetRxOnlyNeighborRouter(const Mac::Address &aAddress)
     {
         OT_UNUSED_VARIABLE(aAddress);

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -105,6 +105,16 @@ public:
     bool IsStateValidOrRestoring(void) const { return (mState == kStateValid) || IsStateRestoring(); }
 
     /**
+     * This method indicates whether the neighbor/child is in invalid state or if it is being restored.
+     *
+     * When in these states messages never be received from the neighbor/child.
+     *
+     * @returns TRUE if the neighbor is in invalid, restored, or being restored states, FALSE otherwise.
+     *
+     */
+    bool IsStateInvalidOrRestoring(void) const { return (mState == kStateInvalid) || IsStateRestoring(); };
+
+    /**
      * This method gets the device mode flags.
      *
      * @returns The device mode flags.
@@ -336,6 +346,22 @@ public:
      */
     uint8_t GetChallengeSize(void) const { return sizeof(mValidPending.mPending.mChallenge); }
 
+    /**
+     * This method gets the link sequence value.
+     *
+     * @returns The link sequence value.
+     *
+     */
+    uint8_t GetLinkFrameSequence() { return mLinkFrameSequence; }
+
+    /**
+     * This method sets the link sequence value.
+     *
+     * @param[in]  aLinkSequence  The link sequence value.
+     *
+     */
+    void SetLinkFrameSequence(uint8_t aFrameSequence) { mLinkFrameSequence = aFrameSequence; }
+
 private:
     Mac::ExtAddress mMacAddr;   ///< The IEEE 802.15.4 Extended Address
     uint32_t        mLastHeard; ///< Time when last heard.
@@ -352,13 +378,14 @@ private:
         } mPending;
     } mValidPending;
 
-    uint32_t        mKeySequence;     ///< Current key sequence
-    uint16_t        mRloc16;          ///< The RLOC16
-    uint8_t         mState : 3;       ///< The link state
-    uint8_t         mMode : 4;        ///< The MLE device mode
-    bool            mDataRequest : 1; ///< Indicates whether or not a Data Poll was received
-    uint8_t         mLinkFailures;    ///< Consecutive link failure count
-    LinkQualityInfo mLinkInfo;        ///< Link quality info (contains average RSS, link margin and link quality)
+    uint32_t        mKeySequence;       ///< Current key sequence
+    uint16_t        mRloc16;            ///< The RLOC16
+    uint8_t         mState : 3;         ///< The link state
+    uint8_t         mMode : 4;          ///< The MLE device mode
+    bool            mDataRequest : 1;   ///< Indicates whether or not a Data Poll was received
+    uint8_t         mLinkFailures;      ///< Consecutive link failure count
+    uint8_t         mLinkFrameSequence; ///< The sequence number of link frame
+    LinkQualityInfo mLinkInfo;          ///< Link quality info (contains average RSS, link margin and link quality)
 };
 
 /**

--- a/tests/unit/test_child_table.cpp
+++ b/tests/unit/test_child_table.cpp
@@ -58,6 +58,7 @@ const ChildTable::StateFilter kAllFilters[] = {
     ChildTable::kInStateChildIdRequest,
     ChildTable::kInStateValidOrAttaching,
     ChildTable::kInStateAnyExceptInvalid,
+    ChildTable::kInStateAnyExceptInvalidOrRestoring,
 };
 
 // Checks whether a `Child` matches the `TestChild` struct.
@@ -97,8 +98,12 @@ static bool StateMatchesFilter(Child::State aState, ChildTable::StateFilter aFil
         rval = child.IsStateValidOrAttaching();
         break;
 
-    case ChildTable::kInStateAnyExceptValidOrRestoing:
+    case ChildTable::kInStateAnyExceptValidOrRestoring:
         rval = !child.IsStateValidOrRestoring();
+        break;
+
+    case ChildTable::kInStateAnyExceptInvalidOrRestoring:
+        rval = !child.IsStateInvalidOrRestoring();
         break;
     }
 


### PR DESCRIPTION
Openthread is using the frame counter in security header to detect
duplicate frames and it also provides API to enable/disable link layer
security. If link layer security is disabled, the MAC layer can't detect
duplicate frames any more. This patch resolves this issue by using the
link layer sequence number to detect duplicate frames.