### PR TITLE
[radio] remove unused mSecurityValid from otRadioFrame structure

### DIFF
--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -577,8 +577,7 @@ OTAPI const otMacCounters *OTCALL otLinkGetCounters(otInstance *aInstance);
  *
  * @note This callback is called after FCS processing and @p aFrame may not contain the actual FCS that was received.
  *
- * @note This callback is called before IEEE 802.15.4 security processing and mSecurityValid in @p aFrame will
- * always be false.
+ * @note This callback is called before IEEE 802.15.4 security processing.
  *
  * @param[in]  aFrame    A pointer to the received IEEE 802.15.4 frame.
  * @param[in]  aContext  A pointer to application-specific context.

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -97,16 +97,15 @@ typedef enum otRadioCaps {
  */
 typedef struct otRadioFrame
 {
-    uint8_t *mPsdu;              ///< The PSDU.
-    uint8_t  mLength;            ///< Length of the PSDU.
-    uint8_t  mChannel;           ///< Channel used to transmit/receive the frame.
-    int8_t   mRssi;              ///< Received signal strength indicator in dBm for received frames.
-    uint8_t  mLqi;               ///< Link Quality Indicator for received frames.
-    uint8_t  mMaxTxAttempts;     ///< Max number of transmit attempts for an outbound frame.
-    bool     mSecurityValid : 1; ///< Security Enabled flag is set and frame passes security checks.
-    bool     mDidTX : 1;         ///< Set to true if this frame sent from the radio. Ignored by radio driver.
-    bool     mIsARetx : 1;       ///< Set to true if this frame is a retransmission. Should be ignored by radio driver.
-    bool     mIsCcaEnabled : 1;  ///< Set to true if CCA must be enabled for this packet. False otherwise.
+    uint8_t *mPsdu;             ///< The PSDU.
+    uint8_t  mLength;           ///< Length of the PSDU.
+    uint8_t  mChannel;          ///< Channel used to transmit/receive the frame.
+    int8_t   mRssi;             ///< Received signal strength indicator in dBm for received frames.
+    uint8_t  mLqi;              ///< Link Quality Indicator for received frames.
+    uint8_t  mMaxTxAttempts;    ///< Max number of transmit attempts for an outbound frame.
+    bool     mDidTX : 1;        ///< Set to true if this frame sent from the radio. Ignored by radio driver.
+    bool     mIsARetx : 1;      ///< Set to true if this frame is a retransmission. Should be ignored by radio driver.
+    bool     mIsCcaEnabled : 1; ///< Set to true if CCA must be enabled for this packet. False otherwise.
 
     /**
      * The timestamp when the frame was received (milliseconds).

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1597,8 +1597,6 @@ otError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, Neig
     const ExtAddress *extAddress;
     Crypto::AesCcm    aesCcm;
 
-    aFrame.SetSecurityValid(false);
-
     if (aFrame.GetSecurityEnabled() == false)
     {
         ExitNow();
@@ -1723,8 +1721,6 @@ otError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, Neig
         }
     }
 
-    aFrame.SetSecurityValid(true);
-
 exit:
     return error;
 }
@@ -1769,8 +1765,6 @@ void Mac::HandleReceivedFrame(Frame *aFrame, otError aError)
     VerifyOrExit(error == OT_ERROR_NONE);
     VerifyOrExit(aFrame != NULL, error = OT_ERROR_NO_FRAME_RECEIVED);
     VerifyOrExit(mEnabled, error = OT_ERROR_INVALID_STATE);
-
-    aFrame->SetSecurityValid(false);
 
     if (mPcapCallback)
     {

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -902,23 +902,6 @@ public:
     void SetMaxTxAttempts(uint8_t aMaxTxAttempts) { mMaxTxAttempts = aMaxTxAttempts; }
 
     /**
-     * This method indicates whether or not frame security was enabled and passed security validation.
-     *
-     * @retval TRUE   Frame security was enabled and passed security validation.
-     * @retval FALSE  Frame security was not enabled or did not pass security validation.
-     *
-     */
-    bool GetSecurityValid(void) const { return mSecurityValid; }
-
-    /**
-     * This method sets the security valid attribute.
-     *
-     * @param[in]  aSecurityValid  TRUE if frame security was enabled and passed security validation, FALSE otherwise.
-     *
-     */
-    void SetSecurityValid(bool aSecurityValid) { mSecurityValid = aSecurityValid; }
-
-    /**
      * This method indicates whether or not the frame is a retransmission.
      *
      * @retval TRUE   Frame is a retransmission


### PR DESCRIPTION
The mSecurityValid in otRadioFrame structure is not in use, its functionality was replaced by GetSecurityEnabled() since the change: [link](https://github.com/openthread/openthread/pull/111/files#diff-475cd0819c812a3145866a316ae19af6R1009).