### PR TITLE
[cli] recover default behavior of ctrl-c

### DIFF
--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -135,7 +135,6 @@ void Uart::ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength)
 #ifdef OPENTHREAD_EXAMPLES_POSIX
 
         case 0x04: // ASCII for Ctrl-D
-        case 0x03: // ASCII for Ctrl-C
             exit(EXIT_SUCCESS);
             break;
 #endif


### PR DESCRIPTION
This could better support gdb debugging. Use ctrl-d as the only elegant way to exit OpenThread.