### PR TITLE
[dataset] fix dataset update issue

### DIFF
--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -204,7 +204,7 @@ void DatasetManager::HandleTimer(void)
         const ActiveTimestampTlv *tlv = static_cast<const ActiveTimestampTlv *>(dataset.Get(Tlv::kActiveTimestamp));
         const Timestamp *         pendingActiveTimestamp = static_cast<const Timestamp *>(tlv);
 
-        if (pendingActiveTimestamp != NULL && mLocal.Compare(pendingActiveTimestamp) >= 0)
+        if (pendingActiveTimestamp != NULL && mLocal.Compare(pendingActiveTimestamp) == 0)
         {
             // stop registration attempts during dataset transition
             ExitNow();

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -450,7 +450,11 @@ void PendingDataset::Clear(void)
 
 void PendingDataset::ClearNetwork(void)
 {
-    Restore();
+    Dataset dataset(mLocal.GetType());
+
+    mTimestamp.Init();
+    mTimestampValid = false;
+    DatasetManager::Set(dataset);
 }
 
 otError PendingDataset::Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength)


### PR DESCRIPTION
For 9.2.7, two partitions at the beginning,
(Leader + Commissioner): only have active dataset with lower timestamp value.
(Commissioner): lower partition id priority, have active and pending dataset with higher timestamp value.

Before this PR, when migrating
issue 1: for pending dataset, when ClearNetwork(), if simply restore from flash, there would be no chance to start the timer and trigger /c/ps

issue 2: When deciding whether to register /c/as in HandleTimer(), the active timestamp in Pending Dataset would always be larger than the active timestamp in Active Dataset. That is, when there is pending dataset, there would be no chance to update the active dataset to Leader (/c/as). 

For 9.2.9, the major difference is that (Leader + Commissioner) have both active/pending Dataset with lower timestamp. Affected by above issue 2 as well.

With this PR, 9.2.7 could pass and 9.2.9 traffic looks all right.