### PR TITLE
[commissioner-dataset] initialize mSessionId to a random value

### DIFF
--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -61,7 +61,7 @@ Leader::Leader(Instance &aInstance)
     , mKeepAlive(OT_URI_PATH_LEADER_KEEP_ALIVE, Leader::HandleKeepAlive, this)
     , mTimer(aInstance, HandleTimer, this)
     , mDelayTimerMinimal(DelayTimerTlv::kDelayTimerMinimal)
-    , mSessionId(0xffff)
+    , mSessionId(Random::GetUint16())
 {
     GetNetif().GetCoap().AddResource(mPetition);
     GetNetif().GetCoap().AddResource(mKeepAlive);


### PR DESCRIPTION
This commit fixes Leader's accepting more than one on-mesh commissioners.
For the scenario that two thread network with individual on-mesh commissioner,
both session ids may be 1. When network migrates, the Leader should reject the /c/la
from the commissioner which has just migrated.

This issue is noticed when looking into the traffic of 9.2.7 - after migration, the Leader would accept both /c/la and BA Rloc in commissioning data frequently changes the between the two original on-mesh commissioners.
I don't think it is an expecting behavior.

For this fix, I am not quite sure if it is the best option. Randomizing the session id might be another option.

@jwhui , looking forward to hear your thoughts. Thanks.