### PR TITLE
[mesh-forwarder] fix bug when stopping discover request

### DIFF
--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -307,6 +307,7 @@ private:
     void     ClearReassemblyList(void);
     otError  RemoveMessageFromSleepyChild(Message &aMessage, Child &aChild);
     void     RemoveMessage(Message &aMessage);
+    void     HandleDiscoverComplete(void);
 
     static void    HandleReceivedFrame(Mac::Receiver &aReceiver, Mac::Frame &aFrame);
     void           HandleReceivedFrame(Mac::Frame &aFrame);


### PR DESCRIPTION
This commit fixes a bug when calling `MeshForwarder::Stop()` while the
discover operation is ongoing.  In particular, while the send queue is
flushed, `mDiscoverTimer` is not stopped, resulting in a NULL pointer
dereference in the timer handler.

This commit also moves common cleanup code for the discover operation into
a single method.