### PR TITLE
[mac] separate aes ccm process from ProcessTransmitSecurity() method

### DIFF
--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -109,6 +109,7 @@ typedef struct otRadioFrame
             uint8_t mMaxTxAttempts; ///< Max number of transmit attempts for an outbound frame.
             bool    mIsARetx : 1; ///< Set to true if this frame is a retransmission. Should be ignored by radio driver.
             bool    mIsCcaEnabled : 1; ///< Set to true if CCA must be enabled for this packet. False otherwise.
+            const uint8_t *mAesKey;    ///< The key used for frame encryption and authentication (AES CCM).
         } mTxInfo;
 
         struct

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -884,7 +884,7 @@ public:
      *                          for AES CCM computation.
      *
      */
-    void ProcessTransmitAesCcm(Frame &aFrame, const ExtAddress *aExtAddress);
+    static void ProcessTransmitAesCcm(Frame &aFrame, const ExtAddress *aExtAddress);
 
 private:
     enum
@@ -931,7 +931,11 @@ private:
      */
     void ProcessTransmitSecurity(Frame &aFrame, bool aProcessAesCcm);
 
-    void    GenerateNonce(const ExtAddress &aAddress, uint32_t aFrameCounter, uint8_t aSecurityLevel, uint8_t *aNonce);
+    static void GenerateNonce(const ExtAddress &aAddress,
+                              uint32_t          aFrameCounter,
+                              uint8_t           aSecurityLevel,
+                              uint8_t *         aNonce);
+
     otError ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, Neighbor *aNeighbor);
     void    UpdateIdleMode(void);
     void    StartOperation(Operation aOperation);

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -876,6 +876,16 @@ public:
      */
     bool IsEnabled(void) { return mEnabled; }
 
+    /**
+     * This method performs AES CCM on the frame which is going to be sent.
+     *
+     * @param[in]  aFrame       A reference to the MAC frame buffer that is going to be sent.
+     * @param[in]  aExtAddress  A pointer to the extended address, which will be used to generate nonce
+     *                          for AES CCM computation.
+     *
+     */
+    void ProcessTransmitAesCcm(Frame &aFrame, const ExtAddress *aExtAddress);
+
 private:
     enum
     {
@@ -908,8 +918,20 @@ private:
         kOperationTransmitOutOfBandFrame,
     };
 
+    /**
+     * This method processes transmit security on the frame which is going to be sent.
+     *
+     * This method prepares the frame, fills Mac auxiliary header, and perform AES CCM immediately in most cases
+     * (depends on @p aProcessAesCcm). If aProcessAesCcm is False, it probably means that some content in the frame
+     * will be updated just before transmission, so AES CCM will be performed after that (before transmission).
+     *
+     * @param[in]  aFrame          A reference to the MAC frame buffer which is going to be sent.
+     * @param[in]  aProcessAesCcm  TRUE to perform AES CCM immediately, FALSE otherwise.
+     *
+     */
+    void ProcessTransmitSecurity(Frame &aFrame, bool aProcessAesCcm);
+
     void    GenerateNonce(const ExtAddress &aAddress, uint32_t aFrameCounter, uint8_t aSecurityLevel, uint8_t *aNonce);
-    void    ProcessTransmitSecurity(Frame &aFrame);
     otError ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, Neighbor *aNeighbor);
     void    UpdateIdleMode(void);
     void    StartOperation(Operation aOperation);

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -935,6 +935,22 @@ public:
     void SetIsCcaEnabled(bool aIsCcaEnabled) { mInfo.mTxInfo.mIsCcaEnabled = aIsCcaEnabled; }
 
     /**
+     * This method returns the key used for frame encryption and authentication (AES CCM).
+     *
+     * @returns The pointer to the key.
+     *
+     */
+    const uint8_t *GetAesKey(void) const { return mInfo.mTxInfo.mAesKey; }
+
+    /**
+     * This method sets the key used for frame encryption and authentication (AES CCM).
+     *
+     * @param[in]  aAesKey  The pointer to the key.
+     *
+     */
+    void SetAesKey(const uint8_t *aAesKey) { mInfo.mTxInfo.mAesKey = aAesKey; }
+
+    /**
      * This method returns the IEEE 802.15.4 PSDU length.
      *
      * @returns The IEEE 802.15.4 PSDU length.


### PR DESCRIPTION
Create a new ProcessTransmitAesCcm() method, which is safe to be called in
interrupt context.