### PR TITLE
[dataset] emit OT_CHANGED_* events when applying Dataset for first time

### DIFF
--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -63,6 +63,7 @@ ThreadNetif::ThreadNetif(Instance &aInstance)
 #endif // OPENTHREAD_ENABLE_DNS_CLIENT
     , mActiveDataset(aInstance)
     , mPendingDataset(aInstance)
+    , mDatasetEmittedFlags(0)
     , mKeyManager(aInstance)
     , mLowpan(aInstance)
     , mMac(aInstance)

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -288,6 +288,17 @@ public:
      */
     MeshCoP::PendingDataset &GetPendingDataset(void) { return mPendingDataset; }
 
+    /**
+     * This method returns a reference to flag variable tracking a bit-field indicating which network state/parameter
+     * changes has been emitted by applying an Active/Pending Dataset.
+     *
+     * The bit-field uses the `OT_CHANGED_*` definitions from `Notifier` class.
+     *
+     * @returns A reference to the Dataset change flags variable.
+     *
+     */
+    uint32_t &GetDatasetEmittedFlags(void) { return mDatasetEmittedFlags; }
+
 #if OPENTHREAD_FTD
     /**
      * This method returns a reference to the joiner router object.
@@ -436,6 +447,7 @@ private:
 #endif // OPENTHREAD_ENABLE_DNS_CLIENT
     MeshCoP::ActiveDataset  mActiveDataset;
     MeshCoP::PendingDataset mPendingDataset;
+    uint32_t                mDatasetEmittedFlags;
     Ip6::Filter             mIp6Filter;
     KeyManager              mKeyManager;
     Lowpan::Lowpan          mLowpan;


### PR DESCRIPTION
This commit adds new logic in `Dataset::ApplyConfiguration()` to
ensure when a Dataset configuration is applied, each of the
`OT_CHANGED_*` events (for channel, network name, PAN id, or extended
PAN id) is emitted for the first time it is applied. Afterwards only
if the value is changed the corresponding `OT_CHANGED_*` is  emitted.

This change addresses an issue where if user sets any of these
parameters (using OpenThread public APIs) before starting Thread
operation, the event indicating the change would not be emitted.