### PR TITLE
Notifier changes. 

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -251,13 +251,19 @@ enum
 };
 
 /**
+ * This type represents the bit-field indicating specific state that has changed. See `OT_CHANGED_*` definitions.
+ *
+ */
+typedef uint32_t otChangedFlags;
+
+/**
  * This function pointer is called to notify certain configuration or state changes within OpenThread.
  *
  * @param[in]  aFlags    A bit-field indicating specific state that has changed.  See `OT_CHANGED_*` definitions.
  * @param[in]  aContext  A pointer to application-specific context.
  *
  */
-typedef void(OTCALL *otStateChangedCallback)(uint32_t aFlags, void *aContext);
+typedef void(OTCALL *otStateChangedCallback)(otChangedFlags aFlags, void *aContext);
 
 /**
  * This function registers a callback to indicate when certain configuration or state changes within OpenThread.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3478,7 +3478,7 @@ exit:
     return;
 }
 
-void OTCALL Interpreter::s_HandleNetifStateChanged(uint32_t aFlags, void *aContext)
+void OTCALL Interpreter::s_HandleNetifStateChanged(otChangedFlags aFlags, void *aContext)
 {
 #ifdef OTDLL
     otCliContext *cliContext = static_cast<otCliContext *>(aContext);
@@ -3489,9 +3489,9 @@ void OTCALL Interpreter::s_HandleNetifStateChanged(uint32_t aFlags, void *aConte
 }
 
 #ifdef OTDLL
-void Interpreter::HandleNetifStateChanged(otInstance *mInstance, uint32_t aFlags)
+void Interpreter::HandleNetifStateChanged(otInstance *mInstance, otChangedFlags aFlags)
 #else
-void Interpreter::HandleNetifStateChanged(uint32_t aFlags)
+void Interpreter::HandleNetifStateChanged(otChangedFlags aFlags)
 #endif
 {
     VerifyOrExit((aFlags & OT_CHANGED_THREAD_NETDATA) != 0);

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -330,7 +330,7 @@ private:
     static void s_HandlePingTimer(Timer &aTimer);
 #endif
     static void OTCALL s_HandleActiveScanResult(otActiveScanResult *aResult, void *aContext);
-    static void OTCALL s_HandleNetifStateChanged(uint32_t aFlags, void *aContext);
+    static void OTCALL s_HandleNetifStateChanged(otChangedFlags aFlags, void *aContext);
 #ifndef OTDLL
     static void s_HandleLinkPcapReceive(const otRadioFrame *aFrame, void *aContext);
 #endif
@@ -360,9 +360,9 @@ private:
 #endif
     void HandleActiveScanResult(otActiveScanResult *aResult);
 #ifdef OTDLL
-    void HandleNetifStateChanged(otInstance *aInstance, uint32_t aFlags);
+    void HandleNetifStateChanged(otInstance *aInstance, otChangedFlags aFlags);
 #else
-    void HandleNetifStateChanged(uint32_t aFlags);
+    void HandleNetifStateChanged(otChangedFlags aFlags);
 #endif
 #ifndef OTDLL
     void HandleLinkPcapReceive(const otRadioFrame *aFrame);

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -196,11 +196,9 @@ exit:
 
 void Notifier::LogChangedFlags(Flags aFlags) const
 {
-    Flags flags = aFlags;
-    char  stringBuffer[kFlagsStringBufferSize];
-    char *buf = stringBuffer;
-    int   len = sizeof(stringBuffer) - 1;
-    int   charsWritten;
+    Flags                          flags   = aFlags;
+    bool                           isFirst = true;
+    String<kFlagsStringBufferSize> string;
 
     for (uint8_t bit = 0; bit < sizeof(Flags) * CHAR_BIT; bit++)
     {
@@ -208,18 +206,14 @@ void Notifier::LogChangedFlags(Flags aFlags) const
 
         if (flags & (1 << bit))
         {
-            charsWritten = snprintf(buf, static_cast<size_t>(len), "%s ", FlagToString(1 << bit));
-            VerifyOrExit(charsWritten >= 0 && charsWritten < len);
-            buf += charsWritten;
-            len -= charsWritten;
-
+            SuccessOrExit(string.Append("%s%s", isFirst ? "" : " ", FlagToString(1 << bit)));
+            isFirst = false;
             flags ^= (1 << bit);
         }
     }
 
 exit:
-    stringBuffer[sizeof(stringBuffer) - 1] = 0;
-    otLogInfoCore(GetInstance(), "Notifier: StateChanged (0x%04x) [ %s] ", aFlags, stringBuffer);
+    otLogInfoCore(GetInstance(), "Notifier: StateChanged (0x%04x) [%s] ", aFlags, string.AsCString());
 }
 
 const char *Notifier::FlagToString(Flags aFlag) const

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -149,7 +149,7 @@ exit:
     return;
 }
 
-void Notifier::SetFlags(uint32_t aFlags)
+void Notifier::SetFlags(Flags aFlags)
 {
     mFlags |= aFlags;
     mTask.Post();
@@ -162,7 +162,7 @@ void Notifier::HandleStateChanged(Tasklet &aTasklet)
 
 void Notifier::HandleStateChanged(void)
 {
-    uint32_t flags = mFlags;
+    Flags flags = mFlags;
 
     VerifyOrExit(flags != 0);
 
@@ -194,15 +194,15 @@ exit:
 
 #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MAC == 1)
 
-void Notifier::LogChangedFlags(uint32_t aFlags) const
+void Notifier::LogChangedFlags(Flags aFlags) const
 {
-    uint32_t flags = aFlags;
-    char     stringBuffer[kFlagsStringBufferSize];
-    char *   buf = stringBuffer;
-    int      len = sizeof(stringBuffer) - 1;
-    int      charsWritten;
+    Flags flags = aFlags;
+    char  stringBuffer[kFlagsStringBufferSize];
+    char *buf = stringBuffer;
+    int   len = sizeof(stringBuffer) - 1;
+    int   charsWritten;
 
-    for (uint8_t bit = 0; bit < 32; bit++)
+    for (uint8_t bit = 0; bit < sizeof(Flags) * CHAR_BIT; bit++)
     {
         VerifyOrExit(flags != 0);
 
@@ -222,7 +222,7 @@ exit:
     otLogInfoCore(GetInstance(), "Notifier: StateChanged (0x%04x) [ %s] ", aFlags, stringBuffer);
 }
 
-const char *Notifier::FlagToString(uint32_t aFlag) const
+const char *Notifier::FlagToString(Flags aFlag) const
 {
     const char *retval = "(unknown)";
 
@@ -333,15 +333,13 @@ const char *Notifier::FlagToString(uint32_t aFlag) const
 
 #else // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MAC == 1)
 
-void Notifier::LogChangedFlags(uint32_t aFlags) const
+void Notifier::LogChangedFlags(Flags) const
 {
-    OT_UNUSED_VARIABLE(aFlags);
 }
 
-const char *Notifier::FlagToString(uint32_t aFlag) const
+const char *Notifier::FlagToString(Flags) const
 {
-    OT_UNUSED_VARIABLE(aFlag);
-    return NULL;
+    return "";
 }
 
 #endif // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MAC == 1)

--- a/src/core/common/notifier.hpp
+++ b/src/core/common/notifier.hpp
@@ -67,6 +67,13 @@ class Notifier : public InstanceLocator
 {
 public:
     /**
+     * This type defines the a bit-field indicating specific state that has changed. See `OT_CHANGED_<STATE>`
+     * definitions in `instance.h`.
+     *
+     */
+    typedef otChangedFlags Flags;
+
+    /**
      * This class defines a callback instance that can be registered with the `Notifier`.
      *
      */
@@ -79,11 +86,10 @@ public:
          * This type defines the function pointer which is called to notify of state or configuration changes.
          *
          * @param[in] aCallback    A reference to callback instance.
-         * @param[in] aFlags       A bit-field indicating specific state that has changed. See `OT_CHANGED_<STATE>`
-         *                         definitions in `instance.h`.
+         * @param[in] aFlags       A flags bit-field indicating specific state that has changed.
          *
          */
-        typedef void (*Handler)(Callback &aCallback, uint32_t aFlags);
+        typedef void (*Handler)(Callback &aCallback, Notifier::Flags aFlags);
 
         /**
          * This constructor initializes a `Callback` instance
@@ -156,7 +162,7 @@ public:
      * @param[in]  aFlags       A bit-field indicating what configuration or state has changed.
      *
      */
-    void SetFlags(uint32_t aFlags);
+    void SetFlags(Flags aFlags);
 
     /**
      * This method indicates whether or not a state changed callback is pending.
@@ -182,10 +188,10 @@ private:
     static void HandleStateChanged(Tasklet &aTasklet);
     void        HandleStateChanged(void);
 
-    void        LogChangedFlags(uint32_t aFlags) const;
-    const char *FlagToString(uint32_t aFlag) const;
+    void        LogChangedFlags(Flags aFlags) const;
+    const char *FlagToString(Flags aFlag) const;
 
-    uint32_t         mFlags;
+    Flags            mFlags;
     Tasklet          mTask;
     Callback *       mCallbacks;
     ExternalCallback mExternalCallbacks[kMaxExternalHandlers];

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -71,12 +71,12 @@ JoinerRouter::JoinerRouter(Instance &aInstance)
     aInstance.GetNotifier().RegisterCallback(mNotifierCallback);
 }
 
-void JoinerRouter::HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags)
+void JoinerRouter::HandleStateChanged(Notifier::Callback &aCallback, Notifier::Flags aFlags)
 {
     aCallback.GetOwner<JoinerRouter>().HandleStateChanged(aFlags);
 }
 
-void JoinerRouter::HandleStateChanged(uint32_t aFlags)
+void JoinerRouter::HandleStateChanged(Notifier::Flags aFlags)
 {
     ThreadNetif &netif = GetNetif();
 

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -88,8 +88,8 @@ private:
         kDelayJoinEnt = 50, ///< milliseconds
     };
 
-    static void HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags);
-    void        HandleStateChanged(uint32_t aFlags);
+    static void HandleStateChanged(Notifier::Callback &aCallback, Notifier::Flags aFlags);
+    void        HandleStateChanged(Notifier::Flags aFlags);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/thread/announce_sender.cpp
+++ b/src/core/thread/announce_sender.cpp
@@ -196,12 +196,12 @@ void AnnounceSender::Stop(void)
     otLogInfoMle(GetInstance(), "Stopping periodic MLE Announcements tx");
 }
 
-void AnnounceSender::HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags)
+void AnnounceSender::HandleStateChanged(Notifier::Callback &aCallback, Notifier::Flags aFlags)
 {
     aCallback.GetOwner<AnnounceSender>().HandleStateChanged(aFlags);
 }
 
-void AnnounceSender::HandleStateChanged(uint32_t aFlags)
+void AnnounceSender::HandleStateChanged(Notifier::Flags aFlags)
 {
     if ((aFlags & OT_CHANGED_THREAD_ROLE) != 0)
     {

--- a/src/core/thread/announce_sender.hpp
+++ b/src/core/thread/announce_sender.hpp
@@ -162,8 +162,8 @@ private:
     void        CheckState(void);
     void        Stop(void);
     static void HandleTimer(Timer &aTimer);
-    static void HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags);
-    void        HandleStateChanged(uint32_t aFlags);
+    static void HandleStateChanged(Notifier::Callback &aCallback, Notifier::Flags aFlags);
+    void        HandleStateChanged(Notifier::Flags aFlags);
 
     Notifier::Callback mNotifierCallback;
 };

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -227,12 +227,12 @@ exit:
     return error;
 }
 
-void EnergyScanServer::HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags)
+void EnergyScanServer::HandleStateChanged(Notifier::Callback &aCallback, Notifier::Flags aFlags)
 {
     aCallback.GetOwner<EnergyScanServer>().HandleStateChanged(aFlags);
 }
 
-void EnergyScanServer::HandleStateChanged(uint32_t aFlags)
+void EnergyScanServer::HandleStateChanged(Notifier::Flags aFlags)
 {
     if ((aFlags & OT_CHANGED_THREAD_NETDATA) != 0 && !mActive &&
         GetNetif().GetNetworkDataLeader().GetCommissioningData() == NULL)

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -80,8 +80,8 @@ private:
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
 
-    static void HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags);
-    void        HandleStateChanged(uint32_t aFlags);
+    static void HandleStateChanged(Notifier::Callback &aCallback, Notifier::Flags aFlags);
+    void        HandleStateChanged(Notifier::Flags aFlags);
 
     otError SendReport(void);
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1374,12 +1374,12 @@ exit:
     return error;
 }
 
-void Mle::HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags)
+void Mle::HandleStateChanged(Notifier::Callback &aCallback, Notifier::Flags aFlags)
 {
     aCallback.GetOwner<Mle>().HandleStateChanged(aFlags);
 }
 
-void Mle::HandleStateChanged(uint32_t aFlags)
+void Mle::HandleStateChanged(Notifier::Flags aFlags)
 {
     ThreadNetif &netif = GetNetif();
     VerifyOrExit(mRole != OT_DEVICE_ROLE_DISABLED);

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1545,8 +1545,8 @@ private:
                        uint8_t                aSecurityLevel,
                        uint8_t *              aNonce);
 
-    static void HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags);
-    void        HandleStateChanged(uint32_t aFlags);
+    static void HandleStateChanged(Notifier::Callback &aCallback, Notifier::Flags aFlags);
+    void        HandleStateChanged(Notifier::Flags aFlags);
     static void HandleAttachTimer(Timer &aTimer);
     void        HandleAttachTimer(void);
     static void HandleDelayedResponseTimer(Timer &aTimer);

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -256,12 +256,12 @@ void ChannelManager::HandleTimer(void)
     }
 }
 
-void ChannelManager::HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags)
+void ChannelManager::HandleStateChanged(Notifier::Callback &aCallback, Notifier::Flags aFlags)
 {
     aCallback.GetOwner<ChannelManager>().HandleStateChanged(aFlags);
 }
 
-void ChannelManager::HandleStateChanged(uint32_t aFlags)
+void ChannelManager::HandleStateChanged(Notifier::Flags aFlags)
 {
     VerifyOrExit((aFlags & OT_CHANGED_THREAD_CHANNEL) != 0);
     VerifyOrExit(mChannel == GetInstance().Get<Mac::Mac>().GetPanChannel());

--- a/src/core/utils/channel_manager.hpp
+++ b/src/core/utils/channel_manager.hpp
@@ -273,8 +273,8 @@ private:
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
-    static void HandleStateChanged(Notifier::Callback &aCallback, uint32_t aChangedFlags);
-    void        HandleStateChanged(uint32_t aChangedFlags);
+    static void HandleStateChanged(Notifier::Callback &aCallback, Notifier::Flags aChangedFlags);
+    void        HandleStateChanged(Notifier::Flags aChangedFlags);
     void        PreparePendingDataset(void);
     void        StartAutoSelectTimer(void);
 

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -167,12 +167,12 @@ void ChildSupervisor::CheckState(void)
     }
 }
 
-void ChildSupervisor::HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags)
+void ChildSupervisor::HandleStateChanged(Notifier::Callback &aCallback, Notifier::Flags aFlags)
 {
     aCallback.GetOwner<ChildSupervisor>().HandleStateChanged(aFlags);
 }
 
-void ChildSupervisor::HandleStateChanged(uint32_t aFlags)
+void ChildSupervisor::HandleStateChanged(Notifier::Flags aFlags)
 {
     if ((aFlags & (OT_CHANGED_THREAD_ROLE | OT_CHANGED_THREAD_CHILD_ADDED | OT_CHANGED_THREAD_CHILD_REMOVED)) != 0)
     {

--- a/src/core/utils/child_supervision.hpp
+++ b/src/core/utils/child_supervision.hpp
@@ -159,8 +159,8 @@ private:
     void        CheckState(void);
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
-    static void HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags);
-    void        HandleStateChanged(uint32_t aFlags);
+    static void HandleStateChanged(Notifier::Callback &aCallback, Notifier::Flags aFlags);
+    void        HandleStateChanged(Notifier::Flags aFlags);
 
     uint16_t           mSupervisionInterval;
     TimerMilli         mTimer;

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -278,12 +278,12 @@ void JamDetector::SetJamState(bool aNewState)
     }
 }
 
-void JamDetector::HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags)
+void JamDetector::HandleStateChanged(Notifier::Callback &aCallback, Notifier::Flags aFlags)
 {
     aCallback.GetOwner<JamDetector>().HandleStateChanged(aFlags);
 }
 
-void JamDetector::HandleStateChanged(uint32_t aFlags)
+void JamDetector::HandleStateChanged(Notifier::Flags aFlags)
 {
     if (aFlags & OT_CHANGED_THREAD_ROLE)
     {

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -191,8 +191,8 @@ private:
     void        HandleTimer(void);
     void        UpdateHistory(bool aThresholdExceeded);
     void        UpdateJamState(void);
-    static void HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags);
-    void        HandleStateChanged(uint32_t aFlags);
+    static void HandleStateChanged(Notifier::Callback &aCallback, Notifier::Flags aFlags);
+    void        HandleStateChanged(Notifier::Flags aFlags);
 
     Handler            mHandler;                  // Handler/callback to inform about jamming state
     void *             mContext;                  // Context for handler/callback

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -261,7 +261,7 @@ protected:
 #endif // OPENTHREAD_RADIO || OPENTHREAD_ENABLE_RAW_LINK_API
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
-    static void HandleStateChanged(uint32_t aFlags, void *aContext);
+    static void HandleStateChanged(otChangedFlags aFlags, void *aContext);
     void ProcessThreadChangedFlags(void);
 
 #if OPENTHREAD_FTD

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -2935,7 +2935,7 @@ exit:
 // MARK: Property/Status Changed
 // ----------------------------------------------------------------------------
 
-void NcpBase::HandleStateChanged(uint32_t aFlags, void *aContext)
+void NcpBase::HandleStateChanged(otChangedFlags aFlags, void *aContext)
 {
     NcpBase *ncp = static_cast<NcpBase *>(aContext);
 
@@ -2947,7 +2947,7 @@ void NcpBase::ProcessThreadChangedFlags(void)
 {
     static const struct
     {
-        uint32_t mThreadFlag;
+        otChangedFlags mThreadFlag;
         spinel_prop_key_t mPropKey;
     } kFlags[] =
     {


### PR DESCRIPTION
This PR contains two commits:
-  [notifier] define otChangedFlags and Notifier::Flags types
- [notifier] update the logging to use `String` class

The first commit defines new types `otChangedFlags` and `Notifier::Flags` to abstract the flag variable size.
The second commit updated the logging method in `Notifier` to use the `String` helper methods. 

