### PR TITLE
[notifier] always signal changed state/config for the first time

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -251,13 +251,20 @@ enum
 };
 
 /**
+ * This type represents a bit-field indicating specific state/configuration that has changed. See `OT_CHANGED_*`
+ * definitions.
+ *
+ */
+typedef uint32_t otChangedFlags;
+
+/**
  * This function pointer is called to notify certain configuration or state changes within OpenThread.
  *
  * @param[in]  aFlags    A bit-field indicating specific state that has changed.  See `OT_CHANGED_*` definitions.
  * @param[in]  aContext  A pointer to application-specific context.
  *
  */
-typedef void(OTCALL *otStateChangedCallback)(uint32_t aFlags, void *aContext);
+typedef void(OTCALL *otStateChangedCallback)(otChangedFlags aFlags, void *aContext);
 
 /**
  * This function registers a callback to indicate when certain configuration or state changes within OpenThread.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3478,7 +3478,7 @@ exit:
     return;
 }
 
-void OTCALL Interpreter::s_HandleNetifStateChanged(uint32_t aFlags, void *aContext)
+void OTCALL Interpreter::s_HandleNetifStateChanged(otChangedFlags aFlags, void *aContext)
 {
 #ifdef OTDLL
     otCliContext *cliContext = static_cast<otCliContext *>(aContext);
@@ -3489,9 +3489,9 @@ void OTCALL Interpreter::s_HandleNetifStateChanged(uint32_t aFlags, void *aConte
 }
 
 #ifdef OTDLL
-void Interpreter::HandleNetifStateChanged(otInstance *mInstance, uint32_t aFlags)
+void Interpreter::HandleNetifStateChanged(otInstance *mInstance, otChangedFlags aFlags)
 #else
-void Interpreter::HandleNetifStateChanged(uint32_t aFlags)
+void Interpreter::HandleNetifStateChanged(otChangedFlags aFlags)
 #endif
 {
     VerifyOrExit((aFlags & OT_CHANGED_THREAD_NETDATA) != 0);

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -330,7 +330,7 @@ private:
     static void s_HandlePingTimer(Timer &aTimer);
 #endif
     static void OTCALL s_HandleActiveScanResult(otActiveScanResult *aResult, void *aContext);
-    static void OTCALL s_HandleNetifStateChanged(uint32_t aFlags, void *aContext);
+    static void OTCALL s_HandleNetifStateChanged(otChangedFlags aFlags, void *aContext);
 #ifndef OTDLL
     static void s_HandleLinkPcapReceive(const otRadioFrame *aFrame, void *aContext);
 #endif
@@ -360,9 +360,9 @@ private:
 #endif
     void HandleActiveScanResult(otActiveScanResult *aResult);
 #ifdef OTDLL
-    void HandleNetifStateChanged(otInstance *aInstance, uint32_t aFlags);
+    void HandleNetifStateChanged(otInstance *aInstance, otChangedFlags aFlags);
 #else
-    void HandleNetifStateChanged(uint32_t aFlags);
+    void HandleNetifStateChanged(otChangedFlags aFlags);
 #endif
 #ifndef OTDLL
     void HandleLinkPcapReceive(const otRadioFrame *aFrame);

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -653,12 +653,25 @@ public:
     /**
      * This method sets the IEEE 802.15.4 Network Name.
      *
-     * @param[in]  aNetworkName  A pointer to the IEEE 802.15.4 Network Name.
+     * @param[in]  aNetworkName  A pointer to the string. Must be null terminated.
      *
-     * @retval OT_ERROR_NONE  Successfully set the IEEE 802.15.4 Network Name.
+     * @retval OT_ERROR_NONE           Successfully set the IEEE 802.15.4 Network Name.
+     * @retval OT_ERROR_INVALID_ARGS   Given name is too long.
      *
      */
     otError SetNetworkName(const char *aNetworkName);
+
+    /**
+     * This method sets the IEEE 802.15.4 Network Name.
+     *
+     * @param[in]  aBuffer  A pointer to the char buffer containing the name. Does not need to be null terminated.
+     * @param[in]  aLength  Number of chars in the buffer.
+     *
+     * @retval OT_ERROR_NONE           Successfully set the IEEE 802.15.4 Network Name.
+     * @retval OT_ERROR_INVALID_ARGS   Given name is too long.
+     *
+     */
+    otError SetNetworkName(const char *aBuffer, uint8_t aLength);
 
     /**
      * This method returns the IEEE 802.15.4 PAN ID.

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -122,7 +122,7 @@ otError Commissioner::Stop(void)
     GetNetif().GetCoapSecure().Stop();
 
     mState = OT_COMMISSIONER_STATE_DISABLED;
-    GetNotifier().SetFlags(OT_CHANGED_COMMISSIONER_STATE);
+    GetNotifier().Signal(OT_CHANGED_COMMISSIONER_STATE);
     RemoveCoapResources();
     ClearJoiners();
     mTransmitAttempts = 0;
@@ -681,7 +681,7 @@ exit:
         }
     }
 
-    GetNotifier().SetFlags(OT_CHANGED_COMMISSIONER_STATE);
+    GetNotifier().Signal(OT_CHANGED_COMMISSIONER_STATE);
 }
 
 otError Commissioner::SendKeepAlive(void)

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -100,7 +100,7 @@ otError Joiner::Start(const char *     aPSKd,
 
     VerifyOrExit(mState == OT_JOINER_STATE_IDLE, error = OT_ERROR_BUSY);
 
-    GetNotifier().SetFlags(OT_CHANGED_JOINER_STATE);
+    GetNotifier().Signal(OT_CHANGED_JOINER_STATE);
 
     // use extended address based on factory-assigned IEEE EUI-64
     GetJoinerId(joinerId);
@@ -168,7 +168,7 @@ void Joiner::Complete(otError aError)
     ThreadNetif &netif = GetNetif();
     mState             = OT_JOINER_STATE_IDLE;
     otError error      = OT_ERROR_NOT_FOUND;
-    GetNotifier().SetFlags(OT_CHANGED_JOINER_STATE);
+    GetNotifier().Signal(OT_CHANGED_JOINER_STATE);
 
     netif.GetCoapSecure().Disconnect();
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -71,12 +71,12 @@ JoinerRouter::JoinerRouter(Instance &aInstance)
     aInstance.GetNotifier().RegisterCallback(mNotifierCallback);
 }
 
-void JoinerRouter::HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags)
+void JoinerRouter::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)
 {
     aCallback.GetOwner<JoinerRouter>().HandleStateChanged(aFlags);
 }
 
-void JoinerRouter::HandleStateChanged(uint32_t aFlags)
+void JoinerRouter::HandleStateChanged(otChangedFlags aFlags)
 {
     ThreadNetif &netif = GetNetif();
 

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -88,8 +88,8 @@ private:
         kDelayJoinEnt = 50, ///< milliseconds
     };
 
-    static void HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags);
-    void        HandleStateChanged(uint32_t aFlags);
+    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
+    void        HandleStateChanged(otChangedFlags aFlags);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -146,7 +146,7 @@ otError Netif::SubscribeAllRoutersMulticast(void)
         }
     }
 
-    GetNotifier().SetFlags(OT_CHANGED_IP6_MULTICAST_SUBSRCRIBED);
+    GetNotifier().Signal(OT_CHANGED_IP6_MULTICAST_SUBSRCRIBED);
 
 exit:
     return error;
@@ -178,7 +178,7 @@ exit:
 
     if (error != OT_ERROR_NOT_FOUND)
     {
-        GetNotifier().SetFlags(OT_CHANGED_IP6_MULTICAST_UNSUBSRCRIBED);
+        GetNotifier().Signal(OT_CHANGED_IP6_MULTICAST_UNSUBSRCRIBED);
     }
 
     return error;
@@ -198,7 +198,7 @@ otError Netif::SubscribeMulticast(NetifMulticastAddress &aAddress)
 
     aAddress.mNext      = mMulticastAddresses;
     mMulticastAddresses = &aAddress;
-    GetNotifier().SetFlags(OT_CHANGED_IP6_MULTICAST_SUBSRCRIBED);
+    GetNotifier().Signal(OT_CHANGED_IP6_MULTICAST_SUBSRCRIBED);
 
 exit:
     return error;
@@ -231,7 +231,7 @@ exit:
 
     if (error != OT_ERROR_NOT_FOUND)
     {
-        GetNotifier().SetFlags(OT_CHANGED_IP6_MULTICAST_UNSUBSRCRIBED);
+        GetNotifier().Signal(OT_CHANGED_IP6_MULTICAST_UNSUBSRCRIBED);
     }
 
     return error;
@@ -290,7 +290,7 @@ otError Netif::SubscribeExternalMulticast(const Address &aAddress)
     entry->mAddress     = aAddress;
     entry->mNext        = mMulticastAddresses;
     mMulticastAddresses = entry;
-    GetNotifier().SetFlags(OT_CHANGED_IP6_MULTICAST_SUBSRCRIBED);
+    GetNotifier().Signal(OT_CHANGED_IP6_MULTICAST_SUBSRCRIBED);
 
 exit:
     return error;
@@ -330,7 +330,7 @@ otError Netif::UnsubscribeExternalMulticast(const Address &aAddress)
     // To mark the address entry as unused/available, set the `mNext` pointer back to the entry itself.
     entry->mNext = entry;
 
-    GetNotifier().SetFlags(OT_CHANGED_IP6_MULTICAST_UNSUBSRCRIBED);
+    GetNotifier().Signal(OT_CHANGED_IP6_MULTICAST_UNSUBSRCRIBED);
 
 exit:
     return error;
@@ -365,7 +365,7 @@ otError Netif::AddUnicastAddress(NetifUnicastAddress &aAddress)
     aAddress.mNext    = mUnicastAddresses;
     mUnicastAddresses = &aAddress;
 
-    GetNotifier().SetFlags(aAddress.mRloc ? OT_CHANGED_THREAD_RLOC_ADDED : OT_CHANGED_IP6_ADDRESS_ADDED);
+    GetNotifier().Signal(aAddress.mRloc ? OT_CHANGED_THREAD_RLOC_ADDED : OT_CHANGED_IP6_ADDRESS_ADDED);
 
 exit:
     return error;
@@ -398,7 +398,7 @@ exit:
 
     if (error != OT_ERROR_NOT_FOUND)
     {
-        GetNotifier().SetFlags(aAddress.mRloc ? OT_CHANGED_THREAD_RLOC_REMOVED : OT_CHANGED_IP6_ADDRESS_REMOVED);
+        GetNotifier().Signal(aAddress.mRloc ? OT_CHANGED_THREAD_RLOC_REMOVED : OT_CHANGED_IP6_ADDRESS_REMOVED);
     }
 
     return error;
@@ -443,7 +443,7 @@ otError Netif::AddExternalUnicastAddress(const NetifUnicastAddress &aAddress)
     entry->mNext      = mUnicastAddresses;
     mUnicastAddresses = entry;
 
-    GetNotifier().SetFlags(OT_CHANGED_IP6_ADDRESS_ADDED);
+    GetNotifier().Signal(OT_CHANGED_IP6_ADDRESS_ADDED);
 
 exit:
     return error;
@@ -483,7 +483,7 @@ otError Netif::RemoveExternalUnicastAddress(const Address &aAddress)
     // To mark the address entry as unused/available, set the `mNext` pointer back to the entry itself.
     entry->mNext = entry;
 
-    GetNotifier().SetFlags(OT_CHANGED_IP6_ADDRESS_REMOVED);
+    GetNotifier().Signal(OT_CHANGED_IP6_ADDRESS_REMOVED);
 
 exit:
     return error;

--- a/src/core/thread/announce_sender.cpp
+++ b/src/core/thread/announce_sender.cpp
@@ -196,12 +196,12 @@ void AnnounceSender::Stop(void)
     otLogInfoMle(GetInstance(), "Stopping periodic MLE Announcements tx");
 }
 
-void AnnounceSender::HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags)
+void AnnounceSender::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)
 {
     aCallback.GetOwner<AnnounceSender>().HandleStateChanged(aFlags);
 }
 
-void AnnounceSender::HandleStateChanged(uint32_t aFlags)
+void AnnounceSender::HandleStateChanged(otChangedFlags aFlags)
 {
     if ((aFlags & OT_CHANGED_THREAD_ROLE) != 0)
     {

--- a/src/core/thread/announce_sender.hpp
+++ b/src/core/thread/announce_sender.hpp
@@ -162,8 +162,8 @@ private:
     void        CheckState(void);
     void        Stop(void);
     static void HandleTimer(Timer &aTimer);
-    static void HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags);
-    void        HandleStateChanged(uint32_t aFlags);
+    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
+    void        HandleStateChanged(otChangedFlags aFlags);
 
     Notifier::Callback mNotifierCallback;
 };

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -227,12 +227,12 @@ exit:
     return error;
 }
 
-void EnergyScanServer::HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags)
+void EnergyScanServer::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)
 {
     aCallback.GetOwner<EnergyScanServer>().HandleStateChanged(aFlags);
 }
 
-void EnergyScanServer::HandleStateChanged(uint32_t aFlags)
+void EnergyScanServer::HandleStateChanged(otChangedFlags aFlags)
 {
     if ((aFlags & OT_CHANGED_THREAD_NETDATA) != 0 && !mActive &&
         GetNetif().GetNetworkDataLeader().GetCommissioningData() == NULL)

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -80,8 +80,8 @@ private:
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
 
-    static void HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags);
-    void        HandleStateChanged(uint32_t aFlags);
+    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
+    void        HandleStateChanged(otChangedFlags aFlags);
 
     otError SendReport(void);
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1545,8 +1545,8 @@ private:
                        uint8_t                aSecurityLevel,
                        uint8_t *              aNonce);
 
-    static void HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags);
-    void        HandleStateChanged(uint32_t aFlags);
+    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
+    void        HandleStateChanged(otChangedFlags aFlags);
     static void HandleAttachTimer(Timer &aTimer);
     void        HandleAttachTimer(void);
     static void HandleDelayedResponseTimer(Timer &aTimer);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -4517,11 +4517,11 @@ void MleRouter::SignalChildUpdated(otThreadChildTableEvent aEvent, Child &aChild
     switch (aEvent)
     {
     case OT_THREAD_CHILD_TABLE_EVENT_CHILD_ADDED:
-        GetNotifier().SetFlags(OT_CHANGED_THREAD_CHILD_ADDED);
+        GetNotifier().Signal(OT_CHANGED_THREAD_CHILD_ADDED);
         break;
 
     case OT_THREAD_CHILD_TABLE_EVENT_CHILD_REMOVED:
-        GetNotifier().SetFlags(OT_CHANGED_THREAD_CHILD_REMOVED);
+        GetNotifier().Signal(OT_CHANGED_THREAD_CHILD_REMOVED);
         break;
     }
 }

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -68,7 +68,7 @@ void LeaderBase::Reset(void)
     mVersion       = static_cast<uint8_t>(otPlatRandomGet());
     mStableVersion = static_cast<uint8_t>(otPlatRandomGet());
     mLength        = 0;
-    GetNotifier().SetFlags(OT_CHANGED_THREAD_NETDATA);
+    GetNotifier().Signal(OT_CHANGED_THREAD_NETDATA);
 }
 
 otError LeaderBase::GetContext(const Ip6::Address &aAddress, Lowpan::Context &aContext)
@@ -431,7 +431,7 @@ otError LeaderBase::SetNetworkData(uint8_t        aVersion,
 
     otDumpDebgNetData(GetInstance(), "set network data", mTlvs, mLength);
 
-    GetNotifier().SetFlags(OT_CHANGED_THREAD_NETDATA);
+    GetNotifier().Signal(OT_CHANGED_THREAD_NETDATA);
 
 exit:
     return error;
@@ -457,7 +457,7 @@ otError LeaderBase::SetCommissioningData(const uint8_t *aValue, uint8_t aValueLe
     }
 
     mVersion++;
-    GetNotifier().SetFlags(OT_CHANGED_THREAD_NETDATA);
+    GetNotifier().Signal(OT_CHANGED_THREAD_NETDATA);
 
 exit:
     return error;

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -103,7 +103,7 @@ void Leader::IncrementVersion(void)
     if (GetNetif().GetMle().GetRole() == OT_DEVICE_ROLE_LEADER)
     {
         mVersion++;
-        GetNotifier().SetFlags(OT_CHANGED_THREAD_NETDATA);
+        GetNotifier().Signal(OT_CHANGED_THREAD_NETDATA);
     }
 }
 
@@ -142,7 +142,7 @@ void Leader::RemoveBorderRouter(uint16_t aRloc16)
         mStableVersion++;
     }
 
-    GetNotifier().SetFlags(OT_CHANGED_THREAD_NETDATA);
+    GetNotifier().Signal(OT_CHANGED_THREAD_NETDATA);
 
 exit:
     return;
@@ -772,7 +772,7 @@ otError Leader::RegisterNetworkData(uint16_t aRloc16, uint8_t *aTlvs, uint8_t aT
         }
     }
 
-    GetNotifier().SetFlags(OT_CHANGED_THREAD_NETDATA);
+    GetNotifier().Signal(OT_CHANGED_THREAD_NETDATA);
 
 exit:
     return error;
@@ -1179,7 +1179,7 @@ otError Leader::FreeContext(uint8_t aContextId)
     mContextUsed &= ~(1 << aContextId);
     mVersion++;
     mStableVersion++;
-    GetNotifier().SetFlags(OT_CHANGED_THREAD_NETDATA);
+    GetNotifier().Signal(OT_CHANGED_THREAD_NETDATA);
     return OT_ERROR_NONE;
 }
 

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -79,7 +79,7 @@ void ChannelManager::RequestChannelChange(uint8_t aChannel)
 
     mTimer.Start(1 + Random::GetUint32InRange(0, kRequestStartJitterInterval));
 
-    GetNotifier().SetFlags(OT_CHANGED_CHANNEL_MANAGER_NEW_CHANNEL);
+    GetNotifier().Signal(OT_CHANGED_CHANNEL_MANAGER_NEW_CHANNEL);
 
 exit:
     return;
@@ -256,12 +256,12 @@ void ChannelManager::HandleTimer(void)
     }
 }
 
-void ChannelManager::HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags)
+void ChannelManager::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)
 {
     aCallback.GetOwner<ChannelManager>().HandleStateChanged(aFlags);
 }
 
-void ChannelManager::HandleStateChanged(uint32_t aFlags)
+void ChannelManager::HandleStateChanged(otChangedFlags aFlags)
 {
     VerifyOrExit((aFlags & OT_CHANGED_THREAD_CHANNEL) != 0);
     VerifyOrExit(mChannel == GetInstance().Get<Mac::Mac>().GetPanChannel());

--- a/src/core/utils/channel_manager.hpp
+++ b/src/core/utils/channel_manager.hpp
@@ -273,8 +273,8 @@ private:
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
-    static void HandleStateChanged(Notifier::Callback &aCallback, uint32_t aChangedFlags);
-    void        HandleStateChanged(uint32_t aChangedFlags);
+    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aChangedFlags);
+    void        HandleStateChanged(otChangedFlags aChangedFlags);
     void        PreparePendingDataset(void);
     void        StartAutoSelectTimer(void);
 

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -167,12 +167,12 @@ void ChildSupervisor::CheckState(void)
     }
 }
 
-void ChildSupervisor::HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags)
+void ChildSupervisor::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)
 {
     aCallback.GetOwner<ChildSupervisor>().HandleStateChanged(aFlags);
 }
 
-void ChildSupervisor::HandleStateChanged(uint32_t aFlags)
+void ChildSupervisor::HandleStateChanged(otChangedFlags aFlags)
 {
     if ((aFlags & (OT_CHANGED_THREAD_ROLE | OT_CHANGED_THREAD_CHILD_ADDED | OT_CHANGED_THREAD_CHILD_REMOVED)) != 0)
     {

--- a/src/core/utils/child_supervision.hpp
+++ b/src/core/utils/child_supervision.hpp
@@ -159,8 +159,8 @@ private:
     void        CheckState(void);
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
-    static void HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags);
-    void        HandleStateChanged(uint32_t aFlags);
+    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
+    void        HandleStateChanged(otChangedFlags aFlags);
 
     uint16_t           mSupervisionInterval;
     TimerMilli         mTimer;

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -278,12 +278,12 @@ void JamDetector::SetJamState(bool aNewState)
     }
 }
 
-void JamDetector::HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags)
+void JamDetector::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)
 {
     aCallback.GetOwner<JamDetector>().HandleStateChanged(aFlags);
 }
 
-void JamDetector::HandleStateChanged(uint32_t aFlags)
+void JamDetector::HandleStateChanged(otChangedFlags aFlags)
 {
     if (aFlags & OT_CHANGED_THREAD_ROLE)
     {

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -191,8 +191,8 @@ private:
     void        HandleTimer(void);
     void        UpdateHistory(bool aThresholdExceeded);
     void        UpdateJamState(void);
-    static void HandleStateChanged(Notifier::Callback &aCallback, uint32_t aFlags);
-    void        HandleStateChanged(uint32_t aFlags);
+    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
+    void        HandleStateChanged(otChangedFlags aFlags);
 
     Handler            mHandler;                  // Handler/callback to inform about jamming state
     void *             mContext;                  // Context for handler/callback

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -269,7 +269,7 @@ protected:
 #endif // OPENTHREAD_RADIO || OPENTHREAD_ENABLE_RAW_LINK_API
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
-    static void HandleStateChanged(uint32_t aFlags, void *aContext);
+    static void HandleStateChanged(otChangedFlags aFlags, void *aContext);
     void        ProcessThreadChangedFlags(void);
 
 #if OPENTHREAD_FTD

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -2884,7 +2884,7 @@ exit:
 // MARK: Property/Status Changed
 // ----------------------------------------------------------------------------
 
-void NcpBase::HandleStateChanged(uint32_t aFlags, void *aContext)
+void NcpBase::HandleStateChanged(otChangedFlags aFlags, void *aContext)
 {
     NcpBase *ncp = static_cast<NcpBase *>(aContext);
 
@@ -2896,7 +2896,7 @@ void NcpBase::ProcessThreadChangedFlags(void)
 {
     static const struct
     {
-        uint32_t          mThreadFlag;
+        otChangedFlags    mThreadFlag;
         spinel_prop_key_t mPropKey;
     } kFlags[] = {
         {OT_CHANGED_IP6_ADDRESS_ADDED, SPINEL_PROP_IPV6_ADDRESS_TABLE},


### PR DESCRIPTION
This commit adds new logic in `Notifier` class (and how it is used) to
ensure when state/configuration is changed, each of the OT_CHANGED_*
events (e.g., channel, network name) is signaled for the first time
(even in case new set value is same as before).

This change addresses an issue where if user sets a parameter (using
OpenThread public APIs) before starting Thread operation the event
indicating the change would not be emitted.

This commit also defines `otChangedFlags` and `Notifier::Flags`
types, and updates the logging in `Notifier` to use `String` class.