### PR TITLE
[mle] reset the attach counter and restart backoff on "mode" change

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -770,7 +770,12 @@ otError Mle::SetDeviceMode(uint8_t aDeviceMode)
     switch (mRole)
     {
     case OT_DEVICE_ROLE_DISABLED:
+        break;
+
     case OT_DEVICE_ROLE_DETACHED:
+        mAttachCounter = 0;
+        SetStateDetached();
+        BecomeChild(kAttachAny);
         break;
 
     case OT_DEVICE_ROLE_CHILD:


### PR DESCRIPTION
This changes addresses the situation where we have a single device
in network configured as sleepy end-device going through attach
backoff intervals and then user changes the device mode to be
non-sleepy and FTD. This change ensures that device become leader
quickly.