### PR TITLE
[efr32] fix building errors on boards without FEM

### DIFF
--- a/examples/platforms/efr32/Makefile.am
+++ b/examples/platforms/efr32/Makefile.am
@@ -67,7 +67,6 @@ libopenthread_efr32_a_CPPFLAGS                                                = 
     -I$(EFR32MG_SDK_SRCDIR)/platform/emdrv/rtcdrv/inc                           \
     -I$(EFR32MG_SDK_SRCDIR)/platform/emlib/inc                                  \
     -I$(EFR32MG_SDK_SRCDIR)/platform/halconfig/inc/hal-config                   \
-    -I$(EFR32MG_SDK_SRCDIR)/util/plugin/plugin-common/fem-control               \
     -Wno-unused-parameter                                                       \
     $(NULL)
 
@@ -112,7 +111,6 @@ nodist_libopenthread_efr32_a_SOURCES                                            
     @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.2/platform/emlib/src/em_usart.c                                          \
     @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.2/platform/radio/rail_lib/hal/efr32/hal_efr.c                            \
     @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.2/platform/radio/rail_lib/hal/hal_common.c                               \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.2/util/plugin/plugin-common/fem-control/fem-control.c                    \
     $(NULL)
 
 noinst_HEADERS                                                                = \

--- a/examples/platforms/efr32/Makefile.am
+++ b/examples/platforms/efr32/Makefile.am
@@ -67,6 +67,7 @@ libopenthread_efr32_a_CPPFLAGS                                                = 
     -I$(EFR32MG_SDK_SRCDIR)/platform/emdrv/rtcdrv/inc                           \
     -I$(EFR32MG_SDK_SRCDIR)/platform/emlib/inc                                  \
     -I$(EFR32MG_SDK_SRCDIR)/platform/halconfig/inc/hal-config                   \
+    -I$(EFR32MG_SDK_SRCDIR)/util/plugin/plugin-common/fem-control               \
     -Wno-unused-parameter                                                       \
     $(NULL)
 
@@ -81,6 +82,7 @@ PLATFORM_SOURCES                                                              = 
     random.c                                                                    \
     startup-gcc.c                                                               \
     uart.c                                                                      \
+    fem-control.c                                                               \
     $(NULL)
 
 nodist_libopenthread_efr32_a_SOURCES                                                                                           =  \

--- a/examples/platforms/efr32/Makefile.am
+++ b/examples/platforms/efr32/Makefile.am
@@ -74,6 +74,7 @@ libopenthread_efr32_a_CPPFLAGS                                                = 
 PLATFORM_SOURCES                                                              = \
     alarm.c                                                                     \
     diag.c                                                                      \
+    fem-control.c                                                               \
     flash.c                                                                     \
     logging.c                                                                   \
     misc.c                                                                      \
@@ -82,7 +83,6 @@ PLATFORM_SOURCES                                                              = 
     random.c                                                                    \
     startup-gcc.c                                                               \
     uart.c                                                                      \
-    fem-control.c                                                               \
     $(NULL)
 
 nodist_libopenthread_efr32_a_SOURCES                                                                                           =  \

--- a/examples/platforms/efr32/fem-control.c
+++ b/examples/platforms/efr32/fem-control.c
@@ -1,29 +1,29 @@
-/*                                                                                                                      
- *  Copyright (c) 2018, The OpenThread Authors.                                                                         
- *  All rights reserved.                                                                                                
- *                                                                                                                      
- *  Redistribution and use in source and binary forms, with or without                                                  
- *  modification, are permitted provided that the following conditions are met:                                         
- *  1. Redistributions of source code must retain the above copyright                                                   
- *     notice, this list of conditions and the following disclaimer.                                                    
- *  2. Redistributions in binary form must reproduce the above copyright                                                
- *     notice, this list of conditions and the following disclaimer in the                                              
- *     documentation and/or other materials provided with the distribution.                                             
- *  3. Neither the name of the copyright holder nor the                                                                 
- *     names of its contributors may be used to endorse or promote products                                             
- *     derived from this software without specific prior written permission.                                            
- *                                                                                                                      
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"                                         
- *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE                                           
- *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE                                          
- *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE                                           
- *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR                                                 
- *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF                                                
- *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS                                            
- *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN                                             
- *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)                                             
- *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE                                          
- *  POSSIBILITY OF SUCH DAMAGE.                                                                                         
+/*
+ *  Copyright (c) 2017, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "hal-config.h"

--- a/examples/platforms/efr32/fem-control.c
+++ b/examples/platforms/efr32/fem-control.c
@@ -1,0 +1,5 @@
+#include "hal-config.h"
+
+#if (HAL_FEM_ENABLE)
+#include "../../../third_party/silabs/gecko_sdk_suite/v2.2/util/plugin/plugin-common/fem-control/fem-control.c"
+#endif

--- a/examples/platforms/efr32/fem-control.c
+++ b/examples/platforms/efr32/fem-control.c
@@ -1,3 +1,31 @@
+/*                                                                                                                      
+ *  Copyright (c) 2018, The OpenThread Authors.                                                                         
+ *  All rights reserved.                                                                                                
+ *                                                                                                                      
+ *  Redistribution and use in source and binary forms, with or without                                                  
+ *  modification, are permitted provided that the following conditions are met:                                         
+ *  1. Redistributions of source code must retain the above copyright                                                   
+ *     notice, this list of conditions and the following disclaimer.                                                    
+ *  2. Redistributions in binary form must reproduce the above copyright                                                
+ *     notice, this list of conditions and the following disclaimer in the                                              
+ *     documentation and/or other materials provided with the distribution.                                             
+ *  3. Neither the name of the copyright holder nor the                                                                 
+ *     names of its contributors may be used to endorse or promote products                                             
+ *     derived from this software without specific prior written permission.                                            
+ *                                                                                                                      
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"                                         
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE                                           
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE                                          
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE                                           
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR                                                 
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF                                                
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS                                            
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN                                             
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)                                             
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE                                          
+ *  POSSIBILITY OF SUCH DAMAGE.                                                                                         
+ */
+
 #include "hal-config.h"
 
 #if (HAL_FEM_ENABLE)

--- a/examples/platforms/efr32/platform.c
+++ b/examples/platforms/efr32/platform.c
@@ -48,7 +48,7 @@
 #include "hal-config.h"
 
 #if (HAL_FEM_ENABLE)
-#include "fem-control.h"
+#include "../../../third_party/silabs/gecko_sdk_suite/v2.2/util/plugin/plugin-common/fem-control/fem-control.c"
 #endif
 
 void halInitChipSpecific(void);

--- a/examples/platforms/efr32/platform.c
+++ b/examples/platforms/efr32/platform.c
@@ -48,7 +48,7 @@
 #include "hal-config.h"
 
 #if (HAL_FEM_ENABLE)
-#include "../../../third_party/silabs/gecko_sdk_suite/v2.2/util/plugin/plugin-common/fem-control/fem-control.c"
+#include "fem-control.h"
 #endif
 
 void halInitChipSpecific(void);


### PR DESCRIPTION
On platforms that do not have or need FEM disabled the build is broken now. The solution is to only compile fem-control.c file on platforms that need it.