### PR TITLE
[logging] change some log messages from INFO level to NOTE level

### DIFF
--- a/include/openthread/platform/logging-windows.h
+++ b/include/openthread/platform/logging-windows.h
@@ -168,6 +168,11 @@
 // end_wpp
 
 // begin_wpp config
+// USEPREFIX (otLogNoteApi, "[%p]API%!SPACE!", &CTX);
+// otLogNoteApi{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_API}(CTX, MSG, ...);
+// end_wpp
+
+// begin_wpp config
 // USEPREFIX (otLogInfoApi, "[%p]API%!SPACE!", &CTX);
 // otLogInfoApi{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_API}(CTX, MSG, ...);
 // end_wpp
@@ -190,6 +195,11 @@
 // end_wpp
 
 // begin_wpp config
+// USEPREFIX (otLogNoteNcp, "[%p]NCP%!SPACE!", &CTX);
+// otLogNoteNcp{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_NCP}(CTX, MSG, ...);
+// end_wpp
+
+// begin_wpp config
 // USEPREFIX (otLogInfoNcp, "[%p]NCP%!SPACE!", &CTX);
 // otLogInfoNcp{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_NCP}(CTX, MSG, ...);
 // end_wpp
@@ -209,6 +219,11 @@
 // begin_wpp config
 // USEPREFIX (otLogWarnMeshCoP, "[%p]MESHCOP%!SPACE!", &CTX);
 // otLogWarnMeshCoP{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_MESHCOP}(CTX, MSG, ...);
+// end_wpp
+
+// begin_wpp config
+// USEPREFIX (otLogNoteMeshCoP, "[%p]MESHCOP%!SPACE!", &CTX);
+// otLogNoteMeshCoP{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_MESHCOP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
@@ -236,6 +251,11 @@
 // begin_wpp config
 // USEPREFIX (otLogWarnMbedTls, "[%p]MBED%!SPACE!", &CTX);
 // otLogWarnMbedTls{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_MBEDTLS}(CTX, MSG, ...);
+// end_wpp
+
+// begin_wpp config
+// USEPREFIX (otLogNoteMbedTls, "[%p]MBED%!SPACE!", &CTX);
+// otLogNoteMbedTls{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_MBEDTLS}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
@@ -267,6 +287,11 @@
 // end_wpp
 
 // begin_wpp config
+// USEPREFIX (otLogNoteMle, "[%p]MLE%!SPACE!", &CTX);
+// otLogNoteMle{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_MLE}(CTX, MSG, ...);
+// end_wpp
+
+// begin_wpp config
 // USEPREFIX (otLogInfoMle, "[%p]MLE%!SPACE!", &CTX);
 // otLogInfoMle{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_MLE}(CTX, MSG, ...);
 // end_wpp
@@ -286,6 +311,11 @@
 // begin_wpp config
 // USEPREFIX (otLogWarnArp, "[%p]ARP%!SPACE!", &CTX);
 // otLogWarnArp{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_ARP}(CTX, MSG, ...);
+// end_wpp
+
+// begin_wpp config
+// USEPREFIX (otLogNoteArp, "[%p]ARP%!SPACE!", &CTX);
+// otLogNoteArp{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_ARP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
@@ -311,6 +341,11 @@
 // end_wpp
 
 // begin_wpp config
+// USEPREFIX (otLogNoteNetData, "[%p]NETD%!SPACE!", &CTX);
+// otLogNoteNetData{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_NETD}(CTX, MSG, ...);
+// end_wpp
+
+// begin_wpp config
 // USEPREFIX (otLogInfoNetData, "[%p]NETD%!SPACE!", &CTX);
 // otLogInfoNetData{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_NETD}(CTX, MSG, ...);
 // end_wpp
@@ -330,6 +365,11 @@
 // begin_wpp config
 // USEPREFIX (otLogWarnIcmp, "[%p]ICMP%!SPACE!", &CTX);
 // otLogWarnIcmp{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_ICMP}(CTX, MSG, ...);
+// end_wpp
+
+// begin_wpp config
+// USEPREFIX (otLogNoteIcmp, "[%p]ICMP%!SPACE!", &CTX);
+// otLogNoteIcmp{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_ICMP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
@@ -355,6 +395,11 @@
 // end_wpp
 
 // begin_wpp config
+// USEPREFIX (otLogNoteIp6, "[%p]IP6%!SPACE!", &CTX);
+// otLogNoteIp6{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_IPV6}(CTX, MSG, ...);
+// end_wpp
+
+// begin_wpp config
 // USEPREFIX (otLogInfoIp6, "[%p]IP6%!SPACE!", &CTX);
 // otLogInfoIp6{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_IPV6}(CTX, MSG, ...);
 // end_wpp
@@ -374,6 +419,11 @@
 // begin_wpp config
 // USEPREFIX (otLogWarnMac, "[%p]MAC%!SPACE!", &CTX);
 // otLogWarnMac{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_MAC}(CTX, MSG, ...);
+// end_wpp
+
+// begin_wpp config
+// USEPREFIX (otLogNoteMac, "[%p]MAC%!SPACE!", &CTX);
+// otLogNoteMac{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_MAC}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
@@ -405,6 +455,11 @@
 // end_wpp
 
 // begin_wpp config
+// USEPREFIX (otLogNoteCore, "[%p]CORE%!SPACE!", &CTX);
+// otLogNoteCore{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_MAC}(CTX, MSG, ...);
+// end_wpp
+
+// begin_wpp config
 // USEPREFIX (otLogInfoCore, "[%p]CORE%!SPACE!", &CTX);
 // otLogInfoCore{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_MAC}(CTX, MSG, ...);
 // end_wpp
@@ -430,6 +485,11 @@
 // begin_wpp config
 // USEPREFIX (otLogWarnUtil, "[%p]UTIL%!SPACE!", &CTX);
 // otLogWarnUtil{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_MAC}(CTX, MSG, ...);
+// end_wpp
+
+// begin_wpp config
+// USEPREFIX (otLogNoteUtil, "[%p]UTIL%!SPACE!", &CTX);
+// otLogNoteUtil{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_MAC}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
@@ -462,6 +522,11 @@
 // end_wpp
 
 // begin_wpp config
+// USEPREFIX (otLogNoteMem, "[%p]MEM%!SPACE!", &CTX);
+// otLogNoteMem{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_MEM}(CTX, MSG, ...);
+// end_wpp
+
+// begin_wpp config
 // USEPREFIX (otLogInfoMem, "[%p]MEM%!SPACE!", &CTX);
 // otLogInfoMem{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_MEM}(CTX, MSG, ...);
 // end_wpp
@@ -490,6 +555,11 @@
 // end_wpp
 
 // begin_wpp config
+// USEPREFIX (otLogNoteNetDiag, "[%p]NETD%!SPACE!", &CTX);
+// otLogNoteNetDiag{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_NDIAG}(CTX, MSG, ...);
+// end_wpp
+
+// begin_wpp config
 // USEPREFIX (otLogInfoNetDiag, "[%p]NETD%!SPACE!", &CTX);
 // otLogInfoNetDiag{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_NDIAG}(CTX, MSG, ...);
 // end_wpp
@@ -509,6 +579,11 @@
 // begin_wpp config
 // USEPREFIX (otLogWarnCoap, "[%p]COAP%!SPACE!", &CTX);
 // otLogWarnCoap{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_COAP}(CTX, MSG, ...);
+// end_wpp
+
+// begin_wpp config
+// USEPREFIX (otLogNoteCoap, "[%p]COAP%!SPACE!", &CTX);
+// otLogNoteCoap{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_COAP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config
@@ -537,6 +612,11 @@
 // begin_wpp config
 // USEPREFIX (otLogWarnCli, "[%p]COAP%!SPACE!", &CTX);
 // otLogWarnCli{LEVEL=TRACE_LEVEL_WARNING,FLAGS=OT_COAP}(CTX, MSG, ...);
+// end_wpp
+
+// begin_wpp config
+// USEPREFIX (otLogNoteCli, "[%p]COAP%!SPACE!", &CTX);
+// otLogNoteCli{LEVEL=TRACE_LEVEL_INFORMATION,FLAGS=OT_COAP}(CTX, MSG, ...);
 // end_wpp
 
 // begin_wpp config

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -676,12 +676,12 @@ exit:
     switch (error)
     {
     case OT_ERROR_NO_BUFS:
-        otLogInfoIp6(GetInstance(), "Failed to pass up message (len: %d) to host - out of message buffer.",
+        otLogWarnIp6(GetInstance(), "Failed to pass up message (len: %d) to host - out of message buffer.",
                      aMessage.GetLength());
         break;
 
     case OT_ERROR_DROP:
-        otLogInfoIp6(GetInstance(), "Dropping message (len: %d) from local host since next hop is the host.",
+        otLogNoteIp6(GetInstance(), "Dropping message (len: %d) from local host since next hop is the host.",
                      aMessage.GetLength());
         break;
 

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -196,12 +196,12 @@ void AddressResolver::InvalidateCacheEntry(Cache &aEntry, InvalidationReason aRe
     switch (aEntry.mState)
     {
     case Cache::kStateCached:
-        otLogInfoArp(GetInstance(), "Cache entry removed: %s, 0x%04x - %s", aEntry.mTarget.ToString().AsCString(),
+        otLogNoteArp(GetInstance(), "Cache entry removed: %s, 0x%04x - %s", aEntry.mTarget.ToString().AsCString(),
                      aEntry.mRloc16, ConvertInvalidationReasonToString(aReason));
         break;
 
     case Cache::kStateQuery:
-        otLogInfoArp(GetInstance(), "Cache entry (query mode) removed: %s, timeout:%d, retry:%d - %s",
+        otLogNoteArp(GetInstance(), "Cache entry (query mode) removed: %s, timeout:%d, retry:%d - %s",
                      aEntry.mTarget.ToString().AsCString(), aEntry.mTimeout, aEntry.mRetryTimeout,
                      ConvertInvalidationReasonToString(aReason));
         break;
@@ -241,7 +241,7 @@ void AddressResolver::UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddre
                 GetNetif().GetMeshForwarder().HandleResolved(aEid, OT_ERROR_NONE);
             }
 
-            otLogInfoArp(GetInstance(), "Cache entry updated (snoop): %s, 0x%04x", aEid.ToString().AsCString(),
+            otLogNoteArp(GetInstance(), "Cache entry updated (snoop): %s, 0x%04x", aEid.ToString().AsCString(),
                          aRloc16);
         }
 
@@ -445,7 +445,7 @@ void AddressResolver::HandleAddressNotification(Coap::Header &          aHeader,
             mCache[i].mState               = Cache::kStateCached;
             MarkCacheEntryAsUsed(mCache[i]);
 
-            otLogInfoArp(GetInstance(), "Cache entry updated (notification): %s, 0x%04x, lastTrans:%d",
+            otLogNoteArp(GetInstance(), "Cache entry updated (notification): %s, 0x%04x, lastTrans:%d",
                          targetTlv.GetTarget().ToString().AsCString(), rloc16Tlv.GetRloc16(), lastTransactionTime);
 
             if (netif.GetCoap().SendEmptyAck(aHeader, aMessageInfo) == OT_ERROR_NONE)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -296,7 +296,7 @@ void Mle::SetRole(otDeviceRole aRole)
 {
     VerifyOrExit(aRole != mRole, GetNotifier().SignalIfFirst(OT_CHANGED_THREAD_ROLE));
 
-    otLogInfoMle(GetInstance(), "Role %s -> %s", RoleToString(mRole), RoleToString(aRole));
+    otLogNoteMle(GetInstance(), "Role %s -> %s", RoleToString(mRole), RoleToString(aRole));
 
     mRole = aRole;
     GetNotifier().Signal(OT_CHANGED_THREAD_ROLE);
@@ -635,7 +635,7 @@ uint32_t Mle::GetAttachStartDelay(void) const
         delay += jitter;
     }
 
-    otLogInfoMle(GetInstance(), "Attach attempt %d unsuccessful, will try again in %u.%03u seconds", mAttachCounter,
+    otLogNoteMle(GetInstance(), "Attach attempt %d unsuccessful, will try again in %u.%03u seconds", mAttachCounter,
                  delay / 1000, delay % 1000);
 
 exit:
@@ -1557,12 +1557,12 @@ void Mle::HandleAttachTimer(void)
     case kAttachStateStart:
         if (mAttachCounter > 0)
         {
-            otLogInfoMle(GetInstance(), "Attempt to attach - attempt %d, %s %s", mAttachCounter,
+            otLogNoteMle(GetInstance(), "Attempt to attach - attempt %d, %s %s", mAttachCounter,
                          AttachModeToString(mParentRequestMode), ReattachStateToString(mReattachState));
         }
         else
         {
-            otLogInfoMle(GetInstance(), "Attempt to attach - %s %s", AttachModeToString(mParentRequestMode),
+            otLogNoteMle(GetInstance(), "Attempt to attach - %s %s", AttachModeToString(mParentRequestMode),
                          ReattachStateToString(mReattachState));
         }
 
@@ -3424,7 +3424,7 @@ otError Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMe
         SetAttachState(kAttachStateProcessAnnounce);
         mAttachTimer.Start(kAnnounceProcessTimeout);
 
-        otLogInfoMle(GetInstance(), "Delay processing Announce - channel %d, panid 0x%02x", channel, panId);
+        otLogNoteMle(GetInstance(), "Delay processing Announce - channel %d, panid 0x%02x", channel, panId);
     }
     else if (localTimestamp->Compare(timestamp) < 0)
     {
@@ -3455,7 +3455,7 @@ void Mle::ProcessAnnounce(void)
 
     assert(mAttachState == kAttachStateProcessAnnounce);
 
-    otLogInfoMle(GetInstance(), "Processing Announce - channel %d, panid 0x%02x", newChannel, newPanId);
+    otLogNoteMle(GetInstance(), "Processing Announce - channel %d, panid 0x%02x", newChannel, newPanId);
 
     Stop(/* aClearNetworkDatasets */ false);
 
@@ -3736,7 +3736,7 @@ otError Mle::InformPreviousParent(void)
 
     SuccessOrExit(error = netif.GetIp6().SendDatagram(*message, messageInfo, Ip6::kProtoNone));
 
-    otLogInfoMle(GetInstance(), "Sending message to inform previous parent 0x%04x", mPreviousParentRloc);
+    otLogNoteMle(GetInstance(), "Sending message to inform previous parent 0x%04x", mPreviousParentRloc);
 
 exit:
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -360,7 +360,7 @@ otError MleRouter::SetStateLeader(uint16_t aRloc16)
         }
     }
 
-    otLogInfoMle(GetInstance(), "Leader partition id 0x%x", mLeaderData.GetPartitionId());
+    otLogNoteMle(GetInstance(), "Leader partition id 0x%x", mLeaderData.GetPartitionId());
 
     return OT_ERROR_NONE;
 }
@@ -1150,7 +1150,7 @@ otError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::Messa
 
     if (partitionId != mLeaderData.GetPartitionId())
     {
-        otLogInfoMle(GetInstance(), "Different partition (peer:%d, local:%d)", leaderData.GetPartitionId(),
+        otLogNoteMle(GetInstance(), "Different partition (peer:%d, local:%d)", leaderData.GetPartitionId(),
                      mLeaderData.GetPartitionId());
 
         VerifyOrExit(linkMargin >= OPENTHREAD_CONFIG_MLE_PARTITION_MERGE_MARGIN_MIN, error = OT_ERROR_LINK_MARGIN_LOW);
@@ -1678,7 +1678,7 @@ void MleRouter::HandleStateUpdateTimer(void)
         if (routerStateUpdate && mRouterTable.GetActiveRouterCount() > mRouterDowngradeThreshold)
         {
             // downgrade to REED
-            otLogInfoMle(GetInstance(), "Downgrade to REED");
+            otLogNoteMle(GetInstance(), "Downgrade to REED");
             BecomeChild(kAttachSame1);
         }
 

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -249,7 +249,7 @@ Router *RouterTable::Allocate(uint8_t aRouterId)
     mRouterIdSequenceLastUpdated = TimerMilli::GetNow();
     GetNetif().GetMle().ResetAdvertiseInterval();
 
-    otLogInfoMle(GetInstance(), "Allocate router id %d", aRouterId);
+    otLogNoteMle(GetInstance(), "Allocate router id %d", aRouterId);
 
 exit:
     return rval;
@@ -292,7 +292,7 @@ otError RouterTable::Release(uint8_t aRouterId)
     netif.GetNetworkDataLeader().RemoveBorderRouter(rloc16);
     netif.GetMle().ResetAdvertiseInterval();
 
-    otLogInfoMle(GetInstance(), "Release router id %d", aRouterId);
+    otLogNoteMle(GetInstance(), "Release router id %d", aRouterId);
 
 exit:
     return error;


### PR DESCRIPTION
This commit changes some of the log messages in `mle`, `ip6`,
`address_resolver` and `router_table` from INFO level to NOTE level.

It also adds missing `otLogNote<>` implementation for windows.