### PR TITLE
[mesh-forwarder] retransmit on CCA errors

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -951,11 +951,6 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, otError aError)
 
     VerifyOrExit(mEnabled);
 
-    if (mSendMessage != NULL)
-    {
-        mSendMessage->SetOffset(mMessageNextOffset);
-    }
-
     aFrame.GetDstAddr(macDest);
 
     if ((neighbor = netif.GetMle().GetNeighbor(macDest)) != NULL)
@@ -995,7 +990,7 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, otError aError)
 
     HandleSentFrameToChild(aFrame, aError, macDest);
 
-    VerifyOrExit(mSendMessage != NULL);
+    VerifyOrExit((mSendMessage != NULL) && ((aError == OT_ERROR_NONE) || (aError == OT_ERROR_NO_ACK)));
 
     if (mSendMessage->GetDirectTransmission())
     {

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -649,6 +649,8 @@ void MeshForwarder::HandleSentFrameToChild(const Mac::Frame &aFrame, otError aEr
         }
     }
 
+    VerifyOrExit((aError == OT_ERROR_NONE) || (aError == OT_ERROR_NO_ACK));
+
     if (mMessageNextOffset < mSendMessage->GetLength())
     {
         if (mSendMessage == child->GetIndirectMessage())


### PR DESCRIPTION
This commit changes the way the mesh forwarder layer handles transmit
attempt failures due to CCA failures.  Prior to this commit, the mesh
forwarder layer would simply drop the packet.  This commit keeps the
packet in the queue so that it can be retransmitted at a later time.  This
applies to both direct and indirect transmissions.