### PR TITLE
[toranj] limit the logs during init of all nodes

### DIFF
--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -438,7 +438,8 @@ class Node(object):
                 try:
                     node.leave()
                 except subprocess.CalledProcessError as e:
-                    _log(' -> \'{}\' exit code: {}'.format(e.output, e.returncode))
+                    if (node._verbose):
+                        _log(' -> \'{}\' exit code: {}'.format(e.output, e.returncode))
                     if time.time() - start_time > wait_time:
                         print 'Took too long to init all nodes ({}>{} sec)'.format(time.time() - start_time, wait_time)
                         raise


### PR DESCRIPTION


----
This should help get rid of logs like this in `travis` (the exit code is expected/normal when many wpantund instances are created at same time). 
```
Starting 'test-601-channel-manager-channel-change'
 -> '' exit code: 28
 -> '' exit code: 28
 -> '' exit code: 28
 -> '' exit code: 28
 -> '' exit code: 28
 -> '' exit code: 28
 -> '' exit code: 28
 -> '' exit code: 28
 -> '' exit code: 28
 -> '' exit code: 28
 -> '' exit code: 28
'test-601-channel-manager-channel-change' passed.
```