### PR TITLE
[nrf52840] set initialized state to false in nrf_drv_clock_uninit()

### DIFF
--- a/third_party/NordicSemiconductor/drivers/clock/nrf_drv_clock.c
+++ b/third_party/NordicSemiconductor/drivers/clock/nrf_drv_clock.c
@@ -190,6 +190,7 @@ void nrf_drv_clock_uninit(void)
     ASSERT(m_clock_cb.module_initialized);
     nrfx_clock_disable();
     nrfx_clock_uninit();
+    m_clock_cb.module_initialized = false;
 }
 
 static void item_enqueue(nrf_drv_clock_handler_item_t ** p_head,


### PR DESCRIPTION
Fix an issue that application could not reinitialize the clock again after nrf_drv_clock_uninit().