### PR TITLE
[nrf52840] reinitialize all peripherals except uart for pseudo reset

### DIFF
--- a/examples/platforms/nrf52840/platform.c
+++ b/examples/platforms/nrf52840/platform.c
@@ -38,10 +38,13 @@
 #include <openthread/platform/logging.h>
 
 #include "platform-nrf5.h"
+#include "platform.h"
 #include <drivers/clock/nrf_drv_clock.h>
 #include <nrf.h>
 
 #include <openthread/config.h>
+
+extern bool gPlatformPseudoResetWasRequested;
 
 void __cxa_pure_virtual(void)
 {
@@ -51,16 +54,9 @@ void __cxa_pure_virtual(void)
 
 void PlatformInit(int argc, char *argv[])
 {
-    extern bool gPlatformPseudoResetWasRequested;
-
     if (gPlatformPseudoResetWasRequested)
     {
-        nrf5AlarmDeinit();
-        nrf5AlarmInit();
-
-        gPlatformPseudoResetWasRequested = false;
-
-        return;
+        PlatformDeinit();
     }
 
     (void)argc;
@@ -79,7 +75,10 @@ void PlatformInit(int argc, char *argv[])
 #endif
     nrf5AlarmInit();
     nrf5RandomInit();
-    nrf5UartInit();
+    if (!gPlatformPseudoResetWasRequested)
+    {
+        nrf5UartInit();
+    }
 #ifndef SPIS_TRANSPORT_DISABLE
     nrf5SpiSlaveInit();
 #endif
@@ -87,10 +86,13 @@ void PlatformInit(int argc, char *argv[])
     nrf5CryptoInit();
     nrf5RadioInit();
     nrf5TempInit();
+
+    gPlatformPseudoResetWasRequested = false;
 }
 
 void PlatformDeinit(void)
 {
+    nrf5AlarmDeinit();
     nrf5TempDeinit();
     nrf5RadioDeinit();
     nrf5CryptoDeinit();
@@ -98,9 +100,11 @@ void PlatformDeinit(void)
 #ifndef SPIS_TRANSPORT_DISABLE
     nrf5SpiSlaveDeinit();
 #endif
-    nrf5UartDeinit();
+    if (!gPlatformPseudoResetWasRequested)
+    {
+        nrf5UartDeinit();
+    }
     nrf5RandomDeinit();
-    nrf5AlarmDeinit();
 #if (OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED) || \
     (OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_NCP_SPINEL)
     nrf5LogDeinit();
@@ -109,7 +113,6 @@ void PlatformDeinit(void)
 
 bool PlatformPseudoResetWasRequested(void)
 {
-    extern bool gPlatformPseudoResetWasRequested;
     return gPlatformPseudoResetWasRequested;
 }
 

--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -225,6 +225,7 @@ void nrf5RadioInit(void)
 void nrf5RadioDeinit(void)
 {
     nrf_802154_deinit();
+    sPendingEvents = 0;
 }
 
 otRadioState otPlatRadioGetState(otInstance *aInstance)


### PR DESCRIPTION
In current code, if usb-cdc is enabled, the ```factoryreset``` is based on pseudo reset, and only alarm will be reinitialized.

But if the radio is not reinitialized during pseudo reset, it may trigger unexpected ```otPlatRadioTxDone()```, and cause the device to hang. This PR fixes such issue by reinitializing all peripherals (except uart).

The issue is exposed during performance test in large scale testbed.