### PR TITLE
[toranj] add support for `add-prefix` and `remove-prefix`

### DIFF
--- a/tests/toranj/test-010-on-mesh-prefix-config-gateway.py
+++ b/tests/toranj/test-010-on-mesh-prefix-config-gateway.py
@@ -35,10 +35,10 @@ from wpan import verify
 #
 # Adding on-mesh prefix and `config-gateway` command
 #
-#  - Verifies adding an on-mesh prefix using wpantund/wpanctl `config-gateway` command.
+#  - Verifies adding an on-mesh prefix using `config-gateway`, `add-prefix` commands.
 #  - Verifies prefixes with different flags/priorities added on routers and/or end-devices.
 #  - Verifies `wpantund` adding SLAAC based IPv6 address based on prefix.
-#  - Verified `wpantund` retaining user-added prefixes and adding them back after an NCP reset.
+#  - Verifies `wpantund` retaining user-added prefixes and adding them back after an NCP reset.
 #
 
 test_name = __file__[:-3] if __file__.endswith('.py') else __file__
@@ -48,25 +48,36 @@ print 'Starting \'{}\''.format(test_name)
 #-----------------------------------------------------------------------------------------------------------------------
 # Utility functions
 
-def verify_prefix(node_list, prefix, on_mesh=True, slaac=True, def_route=False, priority='med'):
+def verify_address(node_list, prefix):
     """
-    This function verifies that all the nodes in the given `node_list` contain an IPv6 address with the given prefix,
-    and that the given prefix is present in the on-mesh prefixes list with the given flags (on-mesh, slaac, etc).
+    This function verifies that all nodes in the `node_list` contain an IPv6 address with the given `prefix`.
     """
     for node in node_list:
         all_addrs = wpan.parse_list(node.get(wpan.WPAN_IP6_ALL_ADDRESSES))
         verify(any([addr.startswith(prefix[:-1]) for addr in all_addrs]))
 
+def verify_prefix(node_list, prefix, prefix_len=64, stable=True, priority='med', on_mesh=False, slaac=False, dhcp=False,
+        configure=False, default_route=False, preferred=True):
+    """
+    This function verifies that the `prefix` is present on all the nodes in the `node_list`.
+    """
+    for node in node_list:
         prefixes = wpan.parse_on_mesh_prefix_result(node.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES))
         for p in prefixes:
             if p.prefix == prefix:
-                verify(p.prefix_len == '64')
-                verify(p.is_stable())
+                verify(int(p.prefix_len) == prefix_len)
+                verify(p.is_stable() == stable)
                 verify(p.is_on_mesh() == on_mesh)
-                verify(p.is_def_route() == def_route)
+                verify(p.is_def_route() == default_route)
                 verify(p.is_slaac() == slaac)
-                verify(p.is_dhcp() == False)
+                verify(p.is_dhcp() == dhcp)
+                verify(p.is_config() == configure)
+                verify(p.is_preferred() == preferred)
                 verify(p.priority == priority)
+                break
+        else:
+            print "Did not find prefix {} on node {}".format(prefix, node)
+            exit(1)
 
 
 #-----------------------------------------------------------------------------------------------------------------------
@@ -99,7 +110,7 @@ r2.whitelist_node(r1)
 r1.whitelist_node(sc1)
 r2.whitelist_node(sc2)
 
-r1.form('ipv6-address')
+r1.form('config-gtway')
 r2.join_node(r1, node_type=wpan.JOIN_TYPE_ROUTER)
 sc1.join_node(r1, node_type=wpan.JOIN_TYPE_SLEEPY_END_DEVICE)
 sc2.join_node(r2, node_type=wpan.JOIN_TYPE_SLEEPY_END_DEVICE)
@@ -113,23 +124,27 @@ sc2.set(wpan.WPAN_POLL_INTERVAL, '200')
 prefix1 = 'fd00:abba:cafe::'
 prefix2 = 'fd00:1234::'
 prefix3 = 'fd00:deed::'
+prefix4 = 'fd00:abcd::'
 
 # Add on-mesh prefix1 on router r1
 r1.config_gateway(prefix1)
 time.sleep(0.5)
 
 # Verify that the prefix1 and its corresponding address are present on all nodes
-verify_prefix(all_nodes, prefix1, def_route=False)
+verify_prefix(all_nodes, prefix1, stable=True, on_mesh=True, slaac=True)
+verify_address(all_nodes, prefix1)
 
 # Now add prefix2 with priority `high` on router r2 and check all nodes for the new prefix/address
 r2.config_gateway(prefix2, default_route=True, priority='1')
 time.sleep(0.5)
-verify_prefix(all_nodes, prefix2, def_route=True, priority='high')
+verify_prefix(all_nodes, prefix2, stable=True, on_mesh=True, slaac=True, default_route=True, priority='high')
+verify_address(all_nodes, prefix2)
 
 # Add prefix3 on sleepy end-device and check for it on all nodes
 sc1.config_gateway(prefix3, priority='-1')
 time.sleep(0.5)
-verify_prefix(all_nodes, prefix3, def_route=False, priority='low')
+verify_prefix(all_nodes, prefix3, stable=True, on_mesh=True, slaac=True, priority='low')
+verify_address(all_nodes, prefix3)
 
 # Verify that prefix1 is retained by `wpantund` and pushed to NCP after a reset
 r1.reset()
@@ -145,7 +160,27 @@ while not r1.is_associated():
 
 # Wait for on-mesh prefix to be updated
 time.sleep(0.5)
-verify_prefix(all_nodes, prefix1, def_route=False)
+verify_prefix(all_nodes, prefix1, stable=True, on_mesh=True, slaac=True)
+verify_address(all_nodes, prefix1)
+
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Test `add-prefix` and `remove-prefix`
+
+r1.add_prefix(prefix4, 48, priority="1", stable=False, on_mesh=True, slaac=False, dhcp=True, configure=False,
+    default_route=True, preferred=False)
+verify_prefix([r1], prefix4, 48, priority="high", stable=False, on_mesh=True, slaac=False, dhcp=True, configure=False,
+    default_route=True, preferred=False)
+
+# Remove prefix and verify that it is removed from list
+r1.remove_prefix(prefix4, 48)
+time.sleep(0.5)
+verify(node.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES).find(prefix4) < 0)
+
+r1.add_prefix(prefix4, 48, priority="-1", stable=True, on_mesh=False, slaac=True, dhcp=False, configure=True,
+    default_route=False, preferred=True)
+verify_prefix([r1], prefix4, 48, priority="low", stable=True, on_mesh=False, slaac=True, dhcp=False, configure=True,
+    default_route=False, preferred=True)
+
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished

--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -361,16 +361,34 @@ class Node(object):
                             (' -d' if default_route else '') +
                             (' -P {}'.format(priority) if priority is not None else ''))
 
-    def add_route(self, route_prefix, prefix_len_in_bytes=None, priority=None):
+    def add_prefix(self, prefix, prefix_len=None, priority=None, stable=True, on_mesh=False, slaac=False, dhcp=False,
+            configure=False, default_route=False, preferred=False):
+        return self.wpanctl('add-prefix ' + prefix +
+                            (' -l {}'.format(prefix_len) if prefix_len is not None else '') +
+                            (' -P {}'.format(priority) if priority is not None else '') +
+                            (' -s' if stable else '') +
+                            (' -f' if preferred else '') +
+                            (' -a' if slaac else '') +
+                            (' -d' if dhcp else '') +
+                            (' -c' if configure else '') +
+                            (' -r' if default_route else '') +
+                            (' -o' if on_mesh else ''))
+
+    def remove_prefix(self, prefix, prefix_len=None):
+        return self.wpanctl('remove-prefix ' + prefix +
+                            (' -l {}'.format(prefix_len) if prefix_len is not None else ''))
+
+    def add_route(self, route_prefix, prefix_len=None, priority=None, stable=True):
         """route priority [(>0 for high, 0 for medium, <0 for low)]"""
         return self.wpanctl('add-route ' + route_prefix +
-                            (' -l {}'.format(prefix_len_in_bytes) if prefix_len_in_bytes is not None else '') +
-                            (' -p {}'.format(priority) if priority is not None else ''))
+                            (' -l {}'.format(prefix_len) if prefix_len is not None else '') +
+                            (' -p {}'.format(priority) if priority is not None else '') +
+                            ('' if stable else '-n'))
 
-    def remove_route(self, route_prefix, prefix_len_in_bytes=None, priority=None):
+    def remove_route(self, route_prefix, prefix_len=None, priority=None, stable=True):
         """route priority [(>0 for high, 0 for medium, <0 for low)]"""
         return self.wpanctl('remove-route ' + route_prefix +
-                            (' -l {}'.format(prefix_len_in_bytes) if prefix_len_in_bytes is not None else '') +
+                            (' -l {}'.format(prefix_len) if prefix_len is not None else '') +
                             (' -p {}'.format(priority) if priority is not None else ''))
 
     #------------------------------------------------------------------------------------------------------------------
@@ -878,7 +896,7 @@ class OnMeshPrefix(object):
         self._config     = (data[6] == '1')
         self._dhcp       = (data[7] == '1')
         self._slaac      = (data[8] == '1')
-        self._preffered  = (data[9] == '1')
+        self._preferred  = (data[9] == '1')
         self._priority   = (data[10])
 
     @property
@@ -915,8 +933,8 @@ class OnMeshPrefix(object):
     def is_slaac(self):
         return self._slaac
 
-    def is_preffered(self):
-        return self._preffered
+    def is_preferred(self):
+        return self._preferred
 
     def __repr__(self):
         return 'OnMeshPrefix({})'.format(self.__dict__)


### PR DESCRIPTION
This commit updates `wpan.py` module to include newly added wpanctl
commands `add-prefix` and `remove-prefix` and include new `stable`
argument for `add-route`. It also updates `test-10` to test the
behavior of the new commands.