### PR TITLE
[ncp] add new fields (age, rssi, etc) to PARENT spinel property

### DIFF
--- a/doc/spinel-protocol-src/spinel-tech-thread.md
+++ b/doc/spinel-protocol-src/spinel-tech-thread.md
@@ -32,10 +32,17 @@ The IPv6 address of the leader. (Note: May change to long and short address of l
 
 ### PROP 81: PROP_THREAD_PARENT
 * Type: Read-Only
-* Packed-Encoding: `ES`
-* LADDR, SADDR
+* Packed-Encoding: `ESLccCC`
 
-The long address and short address of the parent of this node.
+Information about parent of this node.
+
+*  `E`: Extended address
+*  `S`: RLOC16
+*  `L`: Age (seconds since last heard from)
+*  `c`: Average RSS (in dBm)
+*  `c`: Last RSSI (in dBm)
+*  `C`: Link Quality In
+*  `C`: Link Quality Out
 
 ### PROP 82: PROP_THREAD_CHILD_TABLE
 * Type: Read-Only

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -568,8 +568,26 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_PARENT>(void)
 
     if (error == OT_ERROR_NONE)
     {
-        SuccessOrExit(error = mEncoder.WriteEui64(parentInfo.mExtAddress)); // Parent's extended address
-        SuccessOrExit(error = mEncoder.WriteUint16(parentInfo.mRloc16));
+        if (parentInfo.mLinkEstablished)
+        {
+            int8_t averageRssi;
+            int8_t lastRssi;
+
+            otThreadGetParentAverageRssi(mInstance, &averageRssi);
+            otThreadGetParentLastRssi(mInstance, &lastRssi);
+
+            SuccessOrExit(error = mEncoder.WriteEui64(parentInfo.mExtAddress));
+            SuccessOrExit(error = mEncoder.WriteUint16(parentInfo.mRloc16));
+            SuccessOrExit(error = mEncoder.WriteUint32(parentInfo.mAge));
+            SuccessOrExit(error = mEncoder.WriteInt8(averageRssi));
+            SuccessOrExit(error = mEncoder.WriteInt8(lastRssi));
+            SuccessOrExit(error = mEncoder.WriteUint8(parentInfo.mLinkQualityIn));
+            SuccessOrExit(error = mEncoder.WriteUint8(parentInfo.mLinkQualityOut));
+        }
+        else
+        {
+            SuccessOrExit(error = mEncoder.OverwriteWithLastStatusError(SPINEL_STATUS_ITEM_NOT_FOUND));
+        }
     }
     else
     {

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -923,7 +923,20 @@ typedef enum {
 
     SPINEL_PROP_THREAD__BEGIN      = 0x50,
     SPINEL_PROP_THREAD_LEADER_ADDR = SPINEL_PROP_THREAD__BEGIN + 0, ///< [6]
-    SPINEL_PROP_THREAD_PARENT      = SPINEL_PROP_THREAD__BEGIN + 1, ///< LADDR, SADDR [ES]
+
+    /// Thread Parent Info
+    /** Format: `ESLccCC` - Read only
+     *
+     *  `E`: Extended address
+     *  `S`: RLOC16
+     *  `L`: Age (seconds since last heard from)
+     *  `c`: Average RSS (in dBm)
+     *  `c`: Last RSSI (in dBm)
+     *  `C`: Link Quality In
+     *  `C`: Link Quality Out
+     *
+     */
+    SPINEL_PROP_THREAD_PARENT = SPINEL_PROP_THREAD__BEGIN + 1,
 
     /// Thread Child Table
     /** Format: [A(t(ESLLCCcCc)] - Read only


### PR DESCRIPTION
This commit appends new fields to format of `PROP_THREAD_PARENT`
spinel property. The new fields provide age, avrerage RSSI and
last RSSI, etc. This commit also updates the spinel documentation.

Related PR in wpantund: https://github.com/openthread/wpantund/pull/326