### PR TITLE
[mle] remove mtd's Child Update Request for OT_CHANGED_THREAD_NETDATA event

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1460,10 +1460,6 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
         {
             netif.GetMle().HandleNetworkDataUpdateRouter();
         }
-        else if ((aFlags & OT_CHANGED_THREAD_ROLE) == 0)
-        {
-            mSendChildUpdateRequest.Post();
-        }
 
 #if OPENTHREAD_ENABLE_BORDER_ROUTER || OPENTHREAD_ENABLE_SERVICE
         netif.GetNetworkDataLocal().SendServerDataNotification();


### PR DESCRIPTION
This update is motivated by the certification issue when running cert 6.3.2 for otbr.
In this test, TH expects that after configured the BR, the first Child Update Request from MTD would have the new SLAAC unicast address. 
No issue for cli version, because `OT_CHANGED_THREAD_NETDATA` and `OT_CHANGED_IP6_ADDRESS_ADDED` events are very close and only one Child Update Request is triggered.
However for otbr (ncp) version, the SLAAC address is added at wpan when new on-mesh prefixes is found, which introduce some more delay, thus causing two subsequent Child Update Request Messages with the second one has the new SLAAC address.

We may request GRL to improve its robustness. Meanwhile, I could not figure out the purpose of sending Child Update Request for MTD when `OT_CHANGED_THREAD_NETDATA`. This PR might be another option.

@jwhui , please correct me if anything I have missed. Thanks.