### PR TITLE
[dataset] supplement full Operational Dataset for thread device

### DIFF
--- a/include/openthread/dataset_ftd.h
+++ b/include/openthread/dataset_ftd.h
@@ -165,6 +165,21 @@ OTAPI uint32_t OTCALL otDatasetGetDelayTimerMinimal(otInstance *aInstance);
 OTAPI otError OTCALL otDatasetSetDelayTimerMinimal(otInstance *aInstance, uint32_t aDelayTimerMinimal);
 
 /**
+ * This function updates the fields of existing Operational Dataset with new configuration.
+ *
+ * @param[in]     aInstance    A pointer to an OpenThread instance.
+ * @param[in]     aDatasetFrom A pointer to Operational Dataset with updated configuartion.
+ * @param[inout]  aDatasetTo   A pointer to existing Operational Dataset, which to be updated by @p aDatasetFrom.
+ *
+ * @retval OT_ERROR_NONE          Successfully retrieved the Pending Operational Dataset.
+ * @retval OT_ERROR_INVALID_ARGS  @p aDatasetFrom or @p aDatasetTo was NULL.
+ *
+ */
+otError otDatasetUpdate(otInstance *                aInstance,
+                        const otOperationalDataset *aDatasetFrom,
+                        otOperationalDataset *      aDatasetTo);
+
+/**
  * @}
  *
  */

--- a/src/core/api/dataset_ftd_api.cpp
+++ b/src/core/api/dataset_ftd_api.cpp
@@ -121,4 +121,91 @@ otError otDatasetSetDelayTimerMinimal(otInstance *aInstance, uint32_t aDelayTime
     return instance.GetThreadNetif().GetLeader().SetDelayTimerMinimal(aDelayTimerMinimal);
 }
 
+otError otDatasetUpdate(otInstance *                aInstance,
+                        const otOperationalDataset *aDatasetFrom,
+                        otOperationalDataset *      aDatasetTo)
+{
+    otError error = OT_ERROR_NONE;
+    OT_UNUSED_VARIABLE(aInstance);
+
+    VerifyOrExit(aDatasetFrom != NULL && aDatasetTo != NULL, error = OT_ERROR_INVALID_ARGS);
+
+    if (aDatasetFrom->mIsActiveTimestampSet)
+    {
+        aDatasetTo->mActiveTimestamp      = aDatasetFrom->mActiveTimestamp;
+        aDatasetTo->mIsActiveTimestampSet = true;
+    }
+
+    if (aDatasetFrom->mIsPendingTimestampSet)
+    {
+        aDatasetTo->mPendingTimestamp      = aDatasetFrom->mPendingTimestamp;
+        aDatasetTo->mIsPendingTimestampSet = true;
+    }
+
+    if (aDatasetFrom->mIsMasterKeySet)
+    {
+        memcpy(aDatasetTo->mMasterKey.m8, aDatasetFrom->mMasterKey.m8, sizeof(aDatasetTo->mMasterKey));
+        aDatasetTo->mIsMasterKeySet = true;
+    }
+
+    if (aDatasetFrom->mIsNetworkNameSet)
+    {
+        memcpy(aDatasetTo->mNetworkName.m8, aDatasetFrom->mNetworkName.m8, sizeof(aDatasetTo->mNetworkName));
+        aDatasetTo->mIsNetworkNameSet = true;
+    }
+
+    if (aDatasetFrom->mIsExtendedPanIdSet)
+    {
+        memcpy(aDatasetTo->mExtendedPanId.m8, aDatasetFrom->mExtendedPanId.m8, sizeof(aDatasetTo->mExtendedPanId));
+        aDatasetTo->mIsExtendedPanIdSet = true;
+    }
+
+    if (aDatasetFrom->mIsMeshLocalPrefixSet)
+    {
+        memcpy(aDatasetTo->mMeshLocalPrefix.m8, aDatasetFrom->mMeshLocalPrefix.m8,
+               sizeof(aDatasetTo->mMeshLocalPrefix));
+        aDatasetTo->mIsMeshLocalPrefixSet = true;
+    }
+
+    if (aDatasetFrom->mIsDelaySet)
+    {
+        aDatasetTo->mDelay      = aDatasetFrom->mDelay;
+        aDatasetTo->mIsDelaySet = true;
+    }
+
+    if (aDatasetFrom->mIsPanIdSet)
+    {
+        aDatasetTo->mPanId      = aDatasetFrom->mPanId;
+        aDatasetTo->mIsPanIdSet = true;
+    }
+
+    if (aDatasetFrom->mIsChannelSet)
+    {
+        aDatasetTo->mChannel      = aDatasetFrom->mChannel;
+        aDatasetTo->mIsChannelSet = true;
+    }
+
+    if (aDatasetFrom->mIsPSKcSet)
+    {
+        memcpy(aDatasetTo->mPSKc.m8, aDatasetFrom->mPSKc.m8, sizeof(aDatasetTo->mPSKc));
+        aDatasetTo->mIsPSKcSet = true;
+    }
+
+    if (aDatasetFrom->mIsSecurityPolicySet)
+    {
+        aDatasetTo->mSecurityPolicy.mRotationTime = aDatasetFrom->mSecurityPolicy.mRotationTime;
+        aDatasetTo->mSecurityPolicy.mFlags        = aDatasetFrom->mSecurityPolicy.mFlags;
+        aDatasetTo->mIsSecurityPolicySet          = true;
+    }
+
+    if (aDatasetFrom->mIsChannelMaskPage0Set)
+    {
+        aDatasetTo->mChannelMaskPage0      = aDatasetFrom->mChannelMaskPage0;
+        aDatasetTo->mIsChannelMaskPage0Set = true;
+    }
+
+exit:
+    return error;
+}
+
 #endif // OPENTHREAD_FTD

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -33,6 +33,8 @@
 #include "ncp_base.hpp"
 #include <openthread/config.h>
 
+#include <openthread/commissioner.h>
+
 #if OPENTHREAD_ENABLE_CHANNEL_MANAGER
 #include <openthread/channel_manager.h>
 #endif
@@ -826,7 +828,21 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_ACTIVE_DATASET
     otError              error = OT_ERROR_NONE;
     otOperationalDataset dataset;
 
+#ifndef OTDLL
+    otOperationalDataset newDataset;
+
+    SuccessOrExit(error = DecodeOperationalDataset(newDataset, NULL, NULL));
+
+    if (otCommissionerGetState(mInstance) == OT_COMMISSIONER_STATE_DISABLED &&
+        otDatasetGetActive(mInstance, &dataset) == OT_ERROR_NONE)
+    {
+        otDatasetUpdate(mInstance, &newDataset, &dataset);
+    }
+
+#else
     SuccessOrExit(error = DecodeOperationalDataset(dataset, NULL, NULL));
+#endif
+
     error = otDatasetSetActive(mInstance, &dataset);
 
 exit:
@@ -837,8 +853,21 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_PENDING_DATASE
 {
     otError              error = OT_ERROR_NONE;
     otOperationalDataset dataset;
+#ifndef OTDLL
+    otOperationalDataset newDataset;
 
+    SuccessOrExit(error = DecodeOperationalDataset(newDataset, NULL, NULL));
+
+    if (otCommissionerGetState(mInstance) == OT_COMMISSIONER_STATE_DISABLED &&
+        otDatasetGetPending(mInstance, &dataset) == OT_ERROR_NONE)
+    {
+        otDatasetUpdate(mInstance, &newDataset, &dataset);
+    }
+
+#else
     SuccessOrExit(error = DecodeOperationalDataset(dataset, NULL, NULL));
+#endif
+
     error = otDatasetSetPending(mInstance, &dataset);
 
 exit:
@@ -852,7 +881,20 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_MGMT_ACTIVE_DA
     const uint8_t *      extraTlvs;
     uint8_t              extraTlvsLength;
 
+#ifndef OTDLL
+    otOperationalDataset newDataset;
+
+    SuccessOrExit(error = DecodeOperationalDataset(newDataset, &extraTlvs, &extraTlvsLength));
+
+    if (otCommissionerGetState(mInstance) == OT_COMMISSIONER_STATE_DISABLED &&
+        otDatasetGetActive(mInstance, &dataset) == OT_ERROR_NONE)
+    {
+        otDatasetUpdate(mInstance, &newDataset, &dataset);
+    }
+#else
     SuccessOrExit(error = DecodeOperationalDataset(dataset, &extraTlvs, &extraTlvsLength));
+#endif
+
     error = otDatasetSendMgmtActiveSet(mInstance, &dataset, extraTlvs, extraTlvsLength);
 
 exit:
@@ -865,8 +907,20 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_MGMT_PENDING_D
     otOperationalDataset dataset;
     const uint8_t *      extraTlvs;
     uint8_t              extraTlvsLength;
+#ifndef OTDLL
+    otOperationalDataset newDataset;
 
+    SuccessOrExit(error = DecodeOperationalDataset(newDataset, &extraTlvs, &extraTlvsLength));
+
+    if (otCommissionerGetState(mInstance) == OT_COMMISSIONER_STATE_DISABLED &&
+        otDatasetGetPending(mInstance, &dataset) == OT_ERROR_NONE)
+    {
+        otDatasetUpdate(mInstance, &newDataset, &dataset);
+    }
+#else
     SuccessOrExit(error = DecodeOperationalDataset(dataset, &extraTlvs, &extraTlvsLength));
+#endif
+
     error = otDatasetSendMgmtPendingSet(mInstance, &dataset, extraTlvs, extraTlvsLength);
 
 exit:


### PR DESCRIPTION
This commit reduces the configuration burdens and ensures full Operational Dataset locally configured or MGMT_ACTIVE_SET or MGMT_PENDING_SET.
Thread Spec (section 8.7.4.2 and 8.7.5.2):
A MGMT_ACTIVE_SET.req message originated by a Thread Device MUST include the entire Active Operational Dataset as values encoded in appropriate TLVs.
A Thread Device that has a newer Pending Operational Dataset, as determined by the Pending Timestamp included in Thread Network Data, MUST provide its newer Pending Operational Dataset to the Leader by sending a MGMT_PENDING_SET.req to the Leader. The payload MUST include the entire Pending Operational Dataset as values encoded in appropriate TLVs