### PR TITLE
[nrf52840] clear radio timer queue during pseudo reset

### DIFF
--- a/examples/platforms/nrf52840/alarm.c
+++ b/examples/platforms/nrf52840/alarm.c
@@ -53,6 +53,7 @@
 
 #include <drivers/clock/nrf_drv_clock.h>
 #include <drivers/radio/platform/timer/nrf_802154_timer.h>
+#include <drivers/radio/timer_scheduler/nrf_802154_timer_sched.h>
 
 #include <hal/nrf_rtc.h>
 
@@ -373,10 +374,14 @@ void nrf5AlarmInit(void)
     }
 
     nrf_rtc_task_trigger(RTC_INSTANCE, NRF_RTC_TASK_START);
+
+    nrf_802154_timer_sched_init();
 }
 
 void nrf5AlarmDeinit(void)
 {
+    nrf_802154_timer_sched_deinit();
+
     nrf_rtc_task_trigger(RTC_INSTANCE, NRF_RTC_TASK_STOP);
 
     for (uint32_t i = 0; i < kNumTimers; i++)


### PR DESCRIPTION
After pseudo reset, the system time will start over, the uncleared radio timer queue is invalid
since the hardware timer(RTC CMP) is already stopped, the new added timer will be blocked if it
has a larger target time.