### PR TITLE
[nrf52840] avoid unexpected transmit done callback after pseudo reset

### DIFF
--- a/examples/platforms/nrf52840/platform-nrf5.h
+++ b/examples/platforms/nrf52840/platform-nrf5.h
@@ -149,6 +149,12 @@ void nrf5RadioInit(void);
 void nrf5RadioDeinit(void);
 
 /**
+ * Pseudo reset Radio driver.
+ *
+ */
+void nrf5RadioPseudoReset(void);
+
+/**
  * Function for processing Radio.
  *
  */

--- a/examples/platforms/nrf52840/platform.c
+++ b/examples/platforms/nrf52840/platform.c
@@ -55,6 +55,7 @@ void PlatformInit(int argc, char *argv[])
 
     if (gPlatformPseudoResetWasRequested)
     {
+        nrf5RadioPseudoReset();
         nrf5AlarmDeinit();
         nrf5AlarmInit();
 

--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -227,6 +227,12 @@ void nrf5RadioDeinit(void)
     nrf_802154_deinit();
 }
 
+void nrf5RadioPseudoReset(void)
+{
+    nrf_802154_sleep();
+    sPendingEvents = 0;
+}
+
 otRadioState otPlatRadioGetState(otInstance *aInstance)
 {
     (void)aInstance;


### PR DESCRIPTION
Introduce a nrf5RadioPseudoReset() method, it will put the radio to sleep mode, and clear the pending events during pseudo reset. So to avoid unexpected transmit done callback after pseudo reset, which may cause the device to hang.