### PR TITLE
[toranj] add extra delay after node reset in test-014

### DIFF
--- a/tests/toranj/test-014-ip6-address-add.py
+++ b/tests/toranj/test-014-ip6-address-add.py
@@ -163,7 +163,7 @@ for iter in range(2):
         # Reset the nodes and verify that all addresses/prefixes are preserved.
         fed1.reset()
         sed2.reset()
-
+        time.sleep(5)
 
 # Remove address from `r2`
 


### PR DESCRIPTION
----
This is to make the `test-014` more robust. 

In this custom travis test/build, ran the same test 40 times (on Travis) with the change in this PR (adding delay after reset)... all passed:
https://travis-ci.com/abtink/openthread/jobs/133527688


