### PR TITLE
[core] update Child Update Request aggregation feature

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -82,12 +82,12 @@ Mle::Mle(Instance &aInstance)
     , mParentLinkQuality2(0)
     , mParentLinkQuality1(0)
     , mChildUpdateAttempts(0)
+    , mChildUpdateRequestPendingStatus(kChildUpdateRequestPendingNo)
     , mParentLinkMargin(0)
     , mParentIsSingleton(false)
     , mReceivedResponseFromParent(false)
     , mSocket(aInstance.GetThreadNetif().GetIp6().GetUdp())
     , mTimeout(kMleEndDeviceTimeout)
-    , mSendChildUpdateRequest(aInstance, &Mle::HandleSendChildUpdateRequest, this)
     , mDiscoverHandler(NULL)
     , mDiscoverContext(NULL)
     , mIsDiscoverInProgress(false)
@@ -1437,6 +1437,7 @@ void Mle::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlag
 void Mle::HandleStateChanged(otChangedFlags aFlags)
 {
     ThreadNetif &netif = GetNetif();
+
     VerifyOrExit(mRole != OT_DEVICE_ROLE_DISABLED);
 
     if ((aFlags & (OT_CHANGED_IP6_ADDRESS_ADDED | OT_CHANGED_IP6_ADDRESS_REMOVED)) != 0)
@@ -1453,7 +1454,7 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
 
         if (mRole == OT_DEVICE_ROLE_CHILD && !IsFullThreadDevice())
         {
-            mSendChildUpdateRequest.Post();
+            mChildUpdateRequestPendingStatus = kChildUpdateRequestPendingInit;
         }
     }
 
@@ -1461,7 +1462,7 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
     {
         if (mRole == OT_DEVICE_ROLE_CHILD && !IsFullThreadDevice() && !IsRxOnWhenIdle())
         {
-            mSendChildUpdateRequest.Post();
+            mChildUpdateRequestPendingStatus = kChildUpdateRequestPendingInit;
         }
     }
 
@@ -1473,7 +1474,7 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
         }
         else if ((aFlags & OT_CHANGED_THREAD_ROLE) == 0)
         {
-            mSendChildUpdateRequest.Post();
+            mChildUpdateRequestPendingStatus = kChildUpdateRequestPendingInit;
         }
 
 #if OPENTHREAD_ENABLE_BORDER_ROUTER || OPENTHREAD_ENABLE_SERVICE
@@ -1482,6 +1483,11 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
         this->UpdateServiceAlocs();
 #endif
 #endif
+    }
+
+    if (mChildUpdateRequestPendingStatus == kChildUpdateRequestPendingInit)
+    {
+        mChildUpdateRequestTimer.Start(kChildUpdateRequestPendingDelay);
     }
 
     if (aFlags & (OT_CHANGED_THREAD_ROLE | OT_CHANGED_THREAD_KEY_SEQUENCE_COUNTER))
@@ -2037,25 +2043,6 @@ exit:
     return error;
 }
 
-void Mle::HandleSendChildUpdateRequest(Tasklet &aTasklet)
-{
-    aTasklet.GetOwner<Mle>().HandleSendChildUpdateRequest();
-}
-
-void Mle::HandleSendChildUpdateRequest(void)
-{
-    // a Network Data update can cause a change to the IPv6 address configuration
-    // only send a Child Update Request after we know there are no more pending changes
-    if (GetNotifier().IsPending())
-    {
-        mSendChildUpdateRequest.Post();
-    }
-    else
-    {
-        SendChildUpdateRequest();
-    }
-}
-
 void Mle::HandleChildUpdateRequestTimer(Timer &aTimer)
 {
     aTimer.GetOwner<Mle>().HandleChildUpdateRequestTimer();
@@ -2063,7 +2050,25 @@ void Mle::HandleChildUpdateRequestTimer(Timer &aTimer)
 
 void Mle::HandleChildUpdateRequestTimer(void)
 {
-    if (mParent.IsStateRestoring() || IsRxOnWhenIdle())
+    // a Network Data update can cause a change to the IPv6 address configuration
+    // only send a Child Update Request after we know there are no more pending changes
+    if (GetNotifier().IsPending())
+    {
+        mChildUpdateRequestTimer.Start(kChildUpdateRequestPendingDelay);
+        ExitNow();
+    }
+
+    if (mChildUpdateRequestPendingStatus == kChildUpdateRequestPendingInit)
+    {
+        mChildUpdateAttempts             = 0;
+        mChildUpdateRequestPendingStatus = kChildUpdateRequestPendingInProgress;
+    }
+
+    if (mChildUpdateRequestPendingStatus == kChildUpdateRequestPendingInProgress)
+    {
+        SendChildUpdateRequest();
+    }
+    else if (mParent.IsStateRestoring() || IsRxOnWhenIdle())
     {
         SendChildUpdateRequest();
     }
@@ -2078,6 +2083,9 @@ void Mle::HandleChildUpdateRequestTimer(void)
 
         SendDataRequest(destination, tlvs, sizeof(tlvs), 0);
     }
+
+exit:
+    return;
 }
 
 otError Mle::SendChildUpdateRequest(void)
@@ -2089,7 +2097,8 @@ otError Mle::SendChildUpdateRequest(void)
 
     if (mChildUpdateAttempts >= kMaxChildKeepAliveAttempts)
     {
-        mChildUpdateAttempts = 0;
+        mChildUpdateAttempts             = 0;
+        mChildUpdateRequestPendingStatus = kChildUpdateRequestPendingNo;
         BecomeDetached();
         ExitNow();
     }
@@ -3444,8 +3453,8 @@ otError Mle::HandleChildUpdateResponse(const Message &aMessage, const Ip6::Messa
             netif.GetMeshForwarder().SetRxOnWhenIdle(true);
         }
 
-        mChildUpdateAttempts = 0;
-
+        mChildUpdateAttempts             = 0;
+        mChildUpdateRequestPendingStatus = kChildUpdateRequestPendingNo;
         break;
 
     default:

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1582,11 +1582,11 @@ private:
         kParentRequestTypeRoutersAndReeds, ///< Parent Request to all routers and REEDs.
     };
 
-    enum ChildUpdateRequestPendingStatus
+    enum ChildUpdateRequestState
     {
-        kChildUpdateRequestPendingNo,
-        kChildUpdateRequestPendingInProgress,
-        kChildUpdateRequestPendingInit,
+        kChildUpdateRequestNone,
+        kChildUpdateRequestPending,
+        kChildUpdateRequestActive
     };
 
     void GenerateNonce(const Mac::ExtAddress &aMacAddr,
@@ -1665,7 +1665,7 @@ private:
     uint8_t       mParentLinkQuality2;
     uint8_t       mParentLinkQuality1;
     uint8_t       mChildUpdateAttempts;
-    uint8_t       mChildUpdateRequestPendingStatus;
+    uint8_t       mChildUpdateRequestState;
     uint8_t       mParentLinkMargin;
     bool          mParentIsSingleton;
     bool          mReceivedResponseFromParent;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1584,9 +1584,9 @@ private:
 
     enum ChildUpdateRequestState
     {
-        kChildUpdateRequestNone,
-        kChildUpdateRequestPending,
-        kChildUpdateRequestActive
+        kChildUpdateRequestNone,    ///< No pending or active Child Update Request.
+        kChildUpdateRequestPending, ///< Pending Child Update Request due to relative OT_CHANGED event.
+        kChildUpdateRequestActive,  ///< Child Update Request has been sent and Child Update Response is expected.
     };
 
     void GenerateNonce(const Mac::ExtAddress &aMacAddr,

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1582,6 +1582,13 @@ private:
         kParentRequestTypeRoutersAndReeds, ///< Parent Request to all routers and REEDs.
     };
 
+    enum ChildUpdateRequestPendingStatus
+    {
+        kChildUpdateRequestPendingNo,
+        kChildUpdateRequestPendingInProgress,
+        kChildUpdateRequestPendingInit,
+    };
+
     void GenerateNonce(const Mac::ExtAddress &aMacAddr,
                        uint32_t               aFrameCounter,
                        uint8_t                aSecurityLevel,
@@ -1597,8 +1604,6 @@ private:
     void        HandleChildUpdateRequestTimer(void);
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    static void HandleSendChildUpdateRequest(Tasklet &aTasklet);
-    void        HandleSendChildUpdateRequest(void);
 
     otError HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     otError HandleChildIdResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
@@ -1660,17 +1665,16 @@ private:
     uint8_t       mParentLinkQuality2;
     uint8_t       mParentLinkQuality1;
     uint8_t       mChildUpdateAttempts;
-    LeaderDataTlv mParentLeaderData;
+    uint8_t       mChildUpdateRequestPendingStatus;
     uint8_t       mParentLinkMargin;
     bool          mParentIsSingleton;
     bool          mReceivedResponseFromParent;
+    LeaderDataTlv mParentLeaderData;
 
     Router mParentCandidate;
 
     Ip6::UdpSocket mSocket;
     uint32_t       mTimeout;
-
-    Tasklet mSendChildUpdateRequest;
 
     DiscoverHandler mDiscoverHandler;
     void *          mDiscoverContext;

--- a/src/core/thread/mle_constants.hpp
+++ b/src/core/thread/mle_constants.hpp
@@ -68,7 +68,7 @@ enum
     kParentResponseMaxDelayRouters  = 500,   ///< Maximum delay for response for Parent Request sent to routers only
     kParentResponseMaxDelayAll      = 1000,  ///< Maximum delay for response for Parent Request sent to all devices
     kUnicastRetransmissionDelay     = 1000,  ///< Base delay before retransmitting an MLE unicast.
-    kChildUpdateRequestPendingDelay = 1000,  ///< Delay (in ms) for aggregating Child Update Request.
+    kChildUpdateRequestPendingDelay = 100,   ///< Delay (in ms) for aggregating Child Update Request.
     kMaxTransmissionCount           = 3,     ///< Maximum number of times an MLE message may be transmitted.
     kMaxResponseDelay               = 1000,  ///< Maximum delay before responding to a multicast request
     kMaxChildIdRequestTimeout       = 5000,  ///< Maximum delay for receiving a Child ID Request

--- a/src/core/thread/mle_constants.hpp
+++ b/src/core/thread/mle_constants.hpp
@@ -57,22 +57,23 @@ enum
  */
 enum
 {
-    kVersion                       = 2,     ///< MLE Version
-    kUdpPort                       = 19788, ///< MLE UDP Port
-    kParentRequestRouterTimeout    = 750,   ///< Router Parent Request timeout
-    kParentRequestReedTimeout      = 1250,  ///< Router and REEDs Parent Request timeout
-    kAttachStartJitter             = 50,    ///< Maximum jitter time added to start of attach.
-    kAnnounceProcessTimeout        = 250,   ///< Timeout after receiving Announcement before channel/pan-id change
-    kAnnounceTimeout               = 1400,  ///< Total timeout used for sending Announcement messages
-    kMinAnnounceDelay              = 80,    ///< Minimum delay between Announcement messages
-    kParentResponseMaxDelayRouters = 500,   ///< Maximum delay for response for Parent Request sent to routers only
-    kParentResponseMaxDelayAll     = 1000,  ///< Maximum delay for response for Parent Request sent to all devices
-    kUnicastRetransmissionDelay    = 1000,  ///< Base delay before retransmitting an MLE unicast.
-    kMaxTransmissionCount          = 3,     ///< Maximum number of times an MLE message may be transmitted.
-    kMaxResponseDelay              = 1000,  ///< Maximum delay before responding to a multicast request
-    kMaxChildIdRequestTimeout      = 5000,  ///< Maximum delay for receiving a Child ID Request
-    kMaxChildUpdateResponseTimeout = 2000,  ///< Maximum delay for receiving a Child Update Response
-    kMaxLinkRequestTimeout         = 2000,  ///< Maximum delay for receiving a Link Accept
+    kVersion                        = 2,     ///< MLE Version
+    kUdpPort                        = 19788, ///< MLE UDP Port
+    kParentRequestRouterTimeout     = 750,   ///< Router Parent Request timeout
+    kParentRequestReedTimeout       = 1250,  ///< Router and REEDs Parent Request timeout
+    kAttachStartJitter              = 50,    ///< Maximum jitter time added to start of attach.
+    kAnnounceProcessTimeout         = 250,   ///< Timeout after receiving Announcement before channel/pan-id change
+    kAnnounceTimeout                = 1400,  ///< Total timeout used for sending Announcement messages
+    kMinAnnounceDelay               = 80,    ///< Minimum delay between Announcement messages
+    kParentResponseMaxDelayRouters  = 500,   ///< Maximum delay for response for Parent Request sent to routers only
+    kParentResponseMaxDelayAll      = 1000,  ///< Maximum delay for response for Parent Request sent to all devices
+    kUnicastRetransmissionDelay     = 1000,  ///< Base delay before retransmitting an MLE unicast.
+    kChildUpdateRequestPendingDelay = 1000,  ///< Delay (in ms) for aggregating Child Update Request.
+    kMaxTransmissionCount           = 3,     ///< Maximum number of times an MLE message may be transmitted.
+    kMaxResponseDelay               = 1000,  ///< Maximum delay before responding to a multicast request
+    kMaxChildIdRequestTimeout       = 5000,  ///< Maximum delay for receiving a Child ID Request
+    kMaxChildUpdateResponseTimeout  = 2000,  ///< Maximum delay for receiving a Child Update Response
+    kMaxLinkRequestTimeout          = 2000,  ///< Maximum delay for receiving a Link Accept
     kMinTimeout = (((kMaxChildKeepAliveAttempts + 1) * kUnicastRetransmissionDelay) / 1000), ///< Minimum timeout(s)
 };
 


### PR DESCRIPTION
To introduce additional time delay for aggregating Child Update Request Messages as discussed in #2858, this commit replaces the task with a timer which has a fixed aggregation delay (1s).
