### PR TITLE
[build] separate Header IE feature from time sync code

### DIFF
--- a/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
+++ b/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
@@ -171,10 +171,22 @@
  *
  * Define as 1 to enable the time synchronization service feature.
  *
+ */
+#define OPENTHREAD_CONFIG_ENABLE_TIME_SYNC                      0
+
+/**
+ * @def OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
+ *
+ * Define as 1 to support IEEE 802.15.4-2015 Header IE (Information Element) generation and parsing, it must be set
+ * to support following features:
+ *    1. Time synchronization service feature (i.e., OPENTHREAD_CONFIG_ENABLE_TIME_SYNC is set).
+ *
  * @note If it's enabled, plaforms must support interrupt context and concurrent access AES.
  *
  */
-#define OPENTHREAD_CONFIG_ENABLE_TIME_SYNC                      0
+#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#define OPENTHREAD_CONFIG_HEADER_IE_SUPPORT                     1
+#endif
 
 /**
  * @def NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT
@@ -182,10 +194,10 @@
  * Define as 1 to enable AES usage in interrupt context and AES-256, by introducing a software AES under platform layer.
  *
  * @note This feature must be enabled to support AES-256 used by Commissioner and Joiner, and AES usage in interrupt context
- *       used by time synchronization service.
+ *       used by Header IE related features.
  *
  */
-#if OPENTHREAD_ENABLE_COMMISSIONER || OPENTHREAD_ENABLE_JOINER || OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_ENABLE_COMMISSIONER || OPENTHREAD_ENABLE_JOINER || OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
 #define NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT                   1
 #else
 #define NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT                   0

--- a/examples/platforms/nrf52840/platform-config.h
+++ b/examples/platforms/nrf52840/platform-config.h
@@ -499,11 +499,11 @@
  *
  * If notification of started transmission should be enabled in the driver.
  *
- * @note This feature is enabled by default if OpenThread time synchronization service is enabled.
+ * @note This feature must be enabled to support Header IE related features.
  *
  */
 #ifndef NRF_802154_TX_STARTED_NOTIFY_ENABLED
-#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
 #define NRF_802154_TX_STARTED_NOTIFY_ENABLED 1
 #endif
 #endif

--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -80,7 +80,7 @@ static otRadioFrame sReceivedFrames[NRF_802154_RX_BUFFERS];
 static otRadioFrame sTransmitFrame;
 static uint8_t      sTransmitPsdu[OT_RADIO_FRAME_MAX_SIZE + 1];
 
-#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
 static otRadioIeInfo sTransmitIeInfo;
 static otRadioIeInfo sReceivedIeInfos[NRF_802154_RX_BUFFERS];
 static otInstance *  sInstance = NULL;
@@ -111,7 +111,7 @@ static void dataInit(void)
     sDisabled = true;
 
     sTransmitFrame.mPsdu = sTransmitPsdu + 1;
-#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
     sTransmitFrame.mIeInfo = &sTransmitIeInfo;
 #endif
 
@@ -335,7 +335,7 @@ otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 
 otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
 {
-#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
     sInstance = aInstance;
 #endif
 
@@ -676,7 +676,7 @@ void nrf5RadioProcess(otInstance *aInstance)
     }
 }
 
-#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
 void nrf_802154_received_timestamp_raw(uint8_t *p_data, int8_t power, uint8_t lqi, uint32_t time)
 #else
 void nrf_802154_received_raw(uint8_t *p_data, int8_t power, uint8_t lqi)
@@ -691,7 +691,7 @@ void nrf_802154_received_raw(uint8_t *p_data, int8_t power, uint8_t lqi)
             receivedFrame = &sReceivedFrames[i];
 
             memset(receivedFrame, 0, sizeof(*receivedFrame));
-#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
             receivedFrame->mIeInfo = &sReceivedIeInfos[i];
 #endif
             break;
@@ -804,11 +804,13 @@ int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)
     return NRF52840_RECEIVE_SENSITIVITY;
 }
 
-#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
 void nrf_802154_tx_started(const uint8_t *aFrame)
 {
+    bool notifyFrameUpdated = false;
     assert(aFrame == sTransmitPsdu);
 
+#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
     if (sTransmitFrame.mIeInfo->mTimeIeOffset != 0)
     {
         uint8_t *timeIe = sTransmitFrame.mPsdu + sTransmitFrame.mIeInfo->mTimeIeOffset;
@@ -823,6 +825,12 @@ void nrf_802154_tx_started(const uint8_t *aFrame)
             *(++timeIe) = (uint8_t)(time & 0xff);
         }
 
+        notifyFrameUpdated = true;
+    }
+#endif // OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+
+    if (notifyFrameUpdated)
+    {
         otPlatRadioFrameUpdated(sInstance, &sTransmitFrame);
     }
 }

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -111,7 +111,7 @@ static otRadioFrame        sReceiveFrame;
 static otRadioFrame        sTransmitFrame;
 static otRadioFrame        sAckFrame;
 
-#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
 static otRadioIeInfo sTransmitIeInfo;
 static otRadioIeInfo sReceivedIeInfo;
 #endif
@@ -431,7 +431,7 @@ void platformRadioInit(void)
     sTransmitFrame.mPsdu = sTransmitMessage.mPsdu;
     sAckFrame.mPsdu      = sAckMessage.mPsdu;
 
-#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
     sTransmitFrame.mIeInfo = &sTransmitIeInfo;
     sReceiveFrame.mIeInfo  = &sReceivedIeInfo;
 #else
@@ -598,6 +598,9 @@ void radioReceive(otInstance *aInstance)
 
 void radioSendMessage(otInstance *aInstance)
 {
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
+    bool notifyFrameUpdated = false;
+
 #if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
     if (sTransmitFrame.mIeInfo->mTimeIeOffset != 0)
     {
@@ -613,9 +616,15 @@ void radioSendMessage(otInstance *aInstance)
             *(++timeIe) = (uint8_t)(time & 0xff);
         }
 
+        notifyFrameUpdated = true;
+    }
+#endif // OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+
+    if (notifyFrameUpdated)
+    {
         otPlatRadioFrameUpdated(aInstance, &sTransmitFrame);
     }
-#endif
+#endif // OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
 
     sTransmitMessage.mChannel = sTransmitFrame.mChannel;
 

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -758,7 +758,7 @@ uint16_t otLinkGetShortAddress(otInstance *aInstance)
     return static_cast<Instance *>(aInstance)->GetLinkRaw().GetShortAddress();
 }
 
-#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
 void otPlatRadioFrameUpdated(otInstance *aInstance, otRadioFrame *aFrame)
 {
     // Note: For now this functionality is not supported in Radio Only mode.

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1981,14 +1981,16 @@ void Mac::HandleReceivedFrame(Frame *aFrame, otError aError)
 
     netif.GetMeshForwarder().GetDataPollManager().CheckFramePending(*aFrame);
 
-#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
 
     if (aFrame->GetVersion() == Frame::kFcfFrameVersion2015)
     {
+#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
         ProcessTimeIe(*aFrame);
+#endif
     }
 
-#endif
+#endif // OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
 
     if (neighbor != NULL)
     {
@@ -2383,11 +2385,13 @@ uint8_t Mac::GetTimeIeOffset(Frame &aFrame)
 exit:
     return offset;
 }
+#endif // OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
 
 /**
  * This function will be called from interrupt context, it should only read/write data passed in
  * via @p aFrame, but should not read/write any state within OpenThread.
  */
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
 extern "C" void otPlatRadioFrameUpdated(otInstance *aInstance, otRadioFrame *aFrame)
 {
     Instance *        instance   = static_cast<Instance *>(aInstance);
@@ -2405,7 +2409,7 @@ extern "C" void otPlatRadioFrameUpdated(otInstance *aInstance, otRadioFrame *aFr
 exit:
     return;
 }
-#endif // OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#endif // OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
 
 } // namespace Mac
 } // namespace ot

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -365,7 +365,7 @@ bool Frame::IsSrcPanIdPresent(uint16_t aFcf) const
 
     if ((aFcf & kFcfSrcAddrMask) != kFcfSrcAddrNone && (aFcf & kFcfPanidCompression) == 0)
     {
-#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
         // Handle a special case in IEEE 802.15.4-2015, when Pan ID Compression is 0, but Src Pan ID is not present:
         //  Dest Address:       Extended
         //  Source Address:     Extended
@@ -892,14 +892,14 @@ exit:
 uint8_t Frame::FindPayloadIndex(void) const
 {
     uint8_t index = SkipSecurityHeaderIndex();
-#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
     uint8_t *cur    = NULL;
     uint8_t *footer = GetFooter();
 #endif
 
     VerifyOrExit(index != kInvalidIndex);
 
-#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
     cur = GetPsdu() + index;
 
     if (IsIePresent())
@@ -969,7 +969,7 @@ uint8_t *Frame::GetFooter(void) const
     return GetPsdu() + GetPsduLength() - GetFooterLength();
 }
 
-#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
 uint8_t Frame::FindHeaderIeIndex(void) const
 {
     uint8_t index;
@@ -1041,7 +1041,9 @@ uint8_t *Frame::GetHeaderIe(uint8_t aIeId) const
 exit:
     return cur;
 }
+#endif // OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
 
+#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
 uint8_t *Frame::GetTimeIe(void) const
 {
     TimeIe * timeIe              = NULL;

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -1183,6 +1183,16 @@ public:
     uint64_t GetTimestamp(void) const { return mIeInfo->mTimestamp; }
 
     /**
+     * This method returns a pointer to the vendor specific Time IE.
+     *
+     * @returns A pointer to the Time IE, NULL if not found.
+     *
+     */
+    uint8_t *GetTimeIe(void) const;
+#endif // OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
+    /**
      * This method appends Header IEs to MAC header.
      *
      * @param[in]   aIeList  The pointer to the Header IEs array.
@@ -1203,16 +1213,7 @@ public:
      *
      */
     uint8_t *GetHeaderIe(uint8_t aIeId) const;
-
-    /**
-     * This method returns a pointer to the vendor specific Time IE.
-     *
-     * @returns A pointer to the Time IE, NULL if not found.
-     *
-     */
-    uint8_t *GetTimeIe(void) const;
-
-#endif // OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#endif // OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
 
     /**
      * This method returns information about the frame object as an `InfoString` object.
@@ -1237,7 +1238,7 @@ private:
     uint8_t  FindSecurityHeaderIndex(void) const;
     uint8_t  SkipSecurityHeaderIndex(void) const;
     uint8_t  FindPayloadIndex(void) const;
-#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
     uint8_t FindHeaderIeIndex(void) const;
 #endif
 

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -1662,8 +1662,6 @@
  *
  * Define as 1 to enable the time synchronization service feature.
  *
- * @note If it's enabled, plaforms must support interrupt context and concurrent access AES.
- *
  */
 #ifndef OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
 #define OPENTHREAD_CONFIG_ENABLE_TIME_SYNC 0
@@ -1705,6 +1703,24 @@
  */
 #ifndef OPENTHREAD_CONFIG_TIME_SYNC_XTAL_THRESHOLD
 #define OPENTHREAD_CONFIG_TIME_SYNC_XTAL_THRESHOLD 300
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
+ *
+ * Define as 1 to support IEEE 802.15.4-2015 Header IE (Information Element) generation and parsing, it must be set
+ * to support following features:
+ *    1. Time synchronization service feature (i.e., OPENTHREAD_CONFIG_ENABLE_TIME_SYNC is set).
+ *
+ * @note If it's enabled, plaforms must support interrupt context and concurrent access AES.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
+#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#define OPENTHREAD_CONFIG_HEADER_IE_SUPPORT 1
+#else
+#define OPENTHREAD_CONFIG_HEADER_IE_SUPPORT 0
+#endif
 #endif
 
 #endif // OPENTHREAD_CORE_DEFAULT_CONFIG_H_

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -703,7 +703,7 @@ otError MeshForwarder::SendFragment(Message &aMessage, Mac::Frame &aFrame)
 
     if (dstpan == netif.GetMac().GetPanId())
     {
-#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
         // Handle a special case in IEEE 802.15.4-2015, when Pan ID Compression is 0, but Src Pan ID is not present:
         //  Dest Address:       Extended
         //  Src Address:        Extended


### PR DESCRIPTION
Add a configure option to enable/disable Header IE support: OPENTHREAD_CONFIG_HEADER_IE_SUPPORT

So then the Header IE generation and parsing feature could be enabled separately.