### PR TITLE
[nrf52840] reinitialize all peripherals except uart for pseudo reset

### DIFF
--- a/examples/platforms/nrf52840/platform-nrf5.h
+++ b/examples/platforms/nrf52840/platform-nrf5.h
@@ -149,12 +149,6 @@ void nrf5RadioInit(void);
 void nrf5RadioDeinit(void);
 
 /**
- * Pseudo reset Radio driver.
- *
- */
-void nrf5RadioPseudoReset(void);
-
-/**
  * Function for processing Radio.
  *
  */

--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -224,12 +224,8 @@ void nrf5RadioInit(void)
 
 void nrf5RadioDeinit(void)
 {
-    nrf_802154_deinit();
-}
-
-void nrf5RadioPseudoReset(void)
-{
     nrf_802154_sleep();
+    nrf_802154_deinit();
     sPendingEvents = 0;
 }
 

--- a/third_party/NordicSemiconductor/drivers/radio/platform/clock/nrf_802154_clock_sdk.c
+++ b/third_party/NordicSemiconductor/drivers/radio/platform/clock/nrf_802154_clock_sdk.c
@@ -65,12 +65,12 @@ static void clock_handler(nrf_drv_clock_evt_type_t event)
 
 void nrf_802154_clock_init(void)
 {
-    nrf_drv_clock_init();
+    // Intentionally empty.
 }
 
 void nrf_802154_clock_deinit(void)
 {
-    nrf_drv_clock_uninit();
+    // Intentionally empty.
 }
 
 void nrf_802154_clock_hfclk_start(void)


### PR DESCRIPTION
There are some problems if radio is not reinitialized during pseudo reset:
* It may trigger unexpected otPlatRadioTxDone(), and cause the device to hang;
* The uncleared radio timer queue is invalid, it may block the new added timer which has a larger targer time.

Note: The clock init/deinit is disabled during radio init/deinit.