### PR TITLE
[ncp] add `UDP_PROXY_STREAM` to dispatcher list and update documents

### DIFF
--- a/doc/spinel-protocol-src/spinel-tech-thread.md
+++ b/doc/spinel-protocol-src/spinel-tech-thread.md
@@ -295,13 +295,15 @@ Set to true to enable the native commissioner. It is mandatory before adding the
 * Packed-Encoding: `b`
 * Required capability: `CAP_THREAD_TMF_PROXY`
 
-Set to true to enable the TMF proxy.
+Set to true to enable the TMF proxy. This property is deprecated.
 
 ### PROP 5394: PROP_THREAD_TMF_PROXY_STREAM {#prop-thread-tmf-proxy-stream}
 
 * Type: Read-Write-Stream
 * Packed-Encoding: `dSS`
 * Required capability: `CAP_THREAD_TMF_PROXY`
+
+This property is deprecated. Please see `SPINEL_PROP_THREAD_UDP_PROXY_STREAM`.
 
 Data per item is:
 
@@ -315,7 +317,6 @@ Fields:  | Length | CoAP | locator | port
 
 This property allows the host to send and receive TMF messages from
 the NCP's RLOC address and support Thread-specific border router functions.
-
 
 ### PROP 5395: PROP_THREAD_DISOVERY_SCAN_JOINER_FLAG {#prop-thread-discovery-scan-joiner-flag}
 
@@ -570,7 +571,6 @@ Data per item is:
 * `c`: Average RSSI (in dBm)
 * `c`: Last RSSI (in dBm)
 
-
 ### PROP 5411: SPINEL_PROP_THREAD_ADDRESS_CACHE_TABLE (#prop-thread-address-cache-table)
 
 * Type: Read-Only
@@ -583,3 +583,16 @@ Data per item is:
 * `6` : Target IPv6 address
 * `S` : RLOC16 of target
 * `C` : Age (order of use, 0 indicates most recently used entry)
+
+### PROP 5412: SPINEL_PROP_THREAD_UDP_PROXY_STREAM (#prop-thread-udp-proxy-stream)
+
+* Type: Write-Stream
+* Packed-Encoding: `dS6S`
+* Required capability: `CAP_THREAD_UDP_PROXY`
+
+This property helps exchange UDP packets with host.
+
+  `d`: UDP payload
+  `S`: Remote UDP port
+  `6`: Remote IPv6 address
+  `S`: Local UDP port

--- a/src/ncp/ncp_base_dispatcher.cpp
+++ b/src/ncp/ncp_base_dispatcher.cpp
@@ -551,11 +551,6 @@ NcpBase::PropertyHandler NcpBase::FindGetPropertyHandler(spinel_prop_key_t aKey)
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_COMMISSIONER_ENABLED>;
         break;
 #endif
-#if OPENTHREAD_ENABLE_TMF_PROXY
-    case SPINEL_PROP_THREAD_TMF_PROXY_ENABLED:
-        handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_TMF_PROXY_ENABLED>;
-        break;
-#endif
 #if OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
     case SPINEL_PROP_THREAD_STEERING_DATA:
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_STEERING_DATA>;
@@ -817,12 +812,9 @@ NcpBase::PropertyHandler NcpBase::FindSetPropertyHandler(spinel_prop_key_t aKey)
         handler = &NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_STEERING_DATA>;
         break;
 #endif
-#if OPENTHREAD_ENABLE_TMF_PROXY
-    case SPINEL_PROP_THREAD_TMF_PROXY_ENABLED:
-        handler = &NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_TMF_PROXY_ENABLED>;
-        break;
-    case SPINEL_PROP_THREAD_TMF_PROXY_STREAM:
-        handler = &NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_TMF_PROXY_STREAM>;
+#if OPENTHREAD_ENABLE_UDP_PROXY
+    case SPINEL_PROP_THREAD_UDP_PROXY_STREAM:
+        handler = &NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_UDP_PROXY_STREAM>;
         break;
 #endif
     case SPINEL_PROP_THREAD_ACTIVE_DATASET:

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -1131,13 +1131,19 @@ typedef enum {
 
     /// Thread TMF proxy enable
     /** Format `b`
+     * Required capability: `SPINEL_CAP_THREAD_TMF_PROXY`
      *
-     * Default value is `false`.
+     * This property is deprecated.
+     *
      */
     SPINEL_PROP_THREAD_TMF_PROXY_ENABLED = SPINEL_PROP_THREAD_EXT__BEGIN + 17,
 
     /// Thread TMF proxy stream
     /** Format `dSS`
+     * Required capability: `SPINEL_CAP_THREAD_TMF_PROXY`
+     *
+     * This property is deprecated. Please see `SPINEL_PROP_THREAD_UDP_PROXY_STREAM`.
+     *
      */
     SPINEL_PROP_THREAD_TMF_PROXY_STREAM = SPINEL_PROP_THREAD_EXT__BEGIN + 18,
 
@@ -1397,6 +1403,7 @@ typedef enum {
 
     /// Thread UDP proxy stream
     /** Format `dS6S`
+     * Required capability: `SPINEL_CAP_THREAD_UDP_PROXY`
      *
      * This property helps exchange UDP packets with host.
      *


### PR DESCRIPTION
This commit 
- adds `UDP_PROXY_STREAM` in the NCP dispatcher
- removes the deleted/deprecated `TMF_<>` properties in NCP dispatcher
- updates spinel docs, header file and `spinel-tech-thread.md`

