### PR TITLE
[toranj] disable OT/NCP logs (by default) during initialization of nodes

### DIFF
--- a/tests/toranj/test-007-traffic-router-sleepy.py
+++ b/tests/toranj/test-007-traffic-router-sleepy.py
@@ -61,8 +61,6 @@ verify(node2.get(wpan.WPAN_NAME) == node1.get(wpan.WPAN_NAME))
 verify(node2.get(wpan.WPAN_PANID) == node1.get(wpan.WPAN_PANID))
 verify(node2.get(wpan.WPAN_XPANID) == node1.get(wpan.WPAN_XPANID))
 
-
-
 #-----------------------------------------------------------------------------------------------------------------------
 # Test implementation
 

--- a/tests/toranj/test-010-on-mesh-prefix-config-gateway.py
+++ b/tests/toranj/test-010-on-mesh-prefix-config-gateway.py
@@ -98,9 +98,6 @@ all_nodes = [r1, r2, sc1, sc2]
 
 wpan.Node.init_all_nodes()
 
-for node in all_nodes:
-    node.set(wpan.WPAN_OT_LOG_LEVEL, '0')
-
 #-----------------------------------------------------------------------------------------------------------------------
 # Build network topology
 
@@ -174,7 +171,7 @@ verify_prefix([r1], prefix4, 48, priority="high", stable=False, on_mesh=True, sl
 # Remove prefix and verify that it is removed from list
 r1.remove_prefix(prefix4, 48)
 time.sleep(0.5)
-verify(node.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES).find(prefix4) < 0)
+verify(r1.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES).find(prefix4) < 0)
 
 r1.add_prefix(prefix4, 48, priority="-1", stable=True, on_mesh=False, slaac=True, dhcp=False, configure=True,
     default_route=False, preferred=True)

--- a/tests/toranj/test-011-child-table.py
+++ b/tests/toranj/test-011-child-table.py
@@ -58,8 +58,6 @@ all_nodes = [router] + children
 # Init all nodes
 
 wpan.Node.init_all_nodes()
-for node in all_nodes:
-    node.set(wpan.WPAN_OT_LOG_LEVEL, '0')
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Build network topology

--- a/tests/toranj/test-012-multi-hop-traffic.py
+++ b/tests/toranj/test-012-multi-hop-traffic.py
@@ -81,8 +81,6 @@ all_nodes = routers + sed_children + fed_children
 # Init all nodes
 
 wpan.Node.init_all_nodes()
-for node in all_nodes:
-    node.set(wpan.WPAN_OT_LOG_LEVEL, '0')
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Build network topology

--- a/tests/toranj/test-013-off-mesh-route-traffic.py
+++ b/tests/toranj/test-013-off-mesh-route-traffic.py
@@ -79,7 +79,6 @@ for node in all_nodes:
     # interface) are not pushed to NCP (and therefore are not
     # on-mesh).
     node.set("Daemon:IPv6:AutoUpdateInterfaceAddrsOnNCP", '0')
-    node.set(wpan.WPAN_OT_LOG_LEVEL, '0')
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Build network topology

--- a/tests/toranj/test-014-ip6-address-add.py
+++ b/tests/toranj/test-014-ip6-address-add.py
@@ -74,8 +74,6 @@ all_nodes = [r1, fed1, r2, sed2]
 # Init all nodes
 
 wpan.Node.init_all_nodes()
-for node in all_nodes:
-    node.set(wpan.WPAN_OT_LOG_LEVEL, '0')
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Build network topology

--- a/tests/toranj/test-602-channel-manager-channel-select.py
+++ b/tests/toranj/test-602-channel-manager-channel-select.py
@@ -64,8 +64,6 @@ node = wpan.Node()
 
 wpan.Node.init_all_nodes()
 
-node.set(wpan.WPAN_OT_LOG_LEVEL, '0')
-
 #-----------------------------------------------------------------------------------------------------------------------
 # Build network topology
 

--- a/tests/toranj/test-603-channel-manager-announce-recovery.py
+++ b/tests/toranj/test-603-channel-manager-announce-recovery.py
@@ -68,12 +68,6 @@ wpan.Node.init_all_nodes()
 #-----------------------------------------------------------------------------------------------------------------------
 # Build network topology
 
-for node in all_nodes:
-    node.set(wpan.WPAN_OT_LOG_LEVEL, '0')
-
-#-----------------------------------------------------------------------------------------------------------------------
-# Test implementation
-
 router.form('announce-tst', channel=11)
 
 c1.join_node(router, node_type=wpan.JOIN_TYPE_SLEEPY_END_DEVICE)
@@ -84,6 +78,9 @@ c2.set(wpan.WPAN_POLL_INTERVAL, '500')
 
 c1.set(wpan.WPAN_THREAD_DEVICE_MODE,'5')
 c2.set(wpan.WPAN_THREAD_DEVICE_MODE,'5')
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Test implementation
 
 # Reset c2 and keep it in detached state
 c2.set('Daemon:AutoAssociateAfterReset', 'false')

--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -483,12 +483,14 @@ class Node(object):
     # class methods
 
     @classmethod
-    def init_all_nodes(cls, wait_time=15):
+    def init_all_nodes(cls, disable_logs=True, wait_time=15):
         """Issues a `wpanctl.leave` on all `Node` objects and waits for them to be ready"""
         random.seed(12345)
         time.sleep(0.5)
         start_time = time.time()
         for node in Node._all_nodes:
+            if disable_logs:
+                node.set(WPAN_OT_LOG_LEVEL, '0')
             while True:
                 try:
                     node.leave()


### PR DESCRIPTION
This commit changes `wpan.init_all_nodes()` to disable OT/logs on
all nodes as the default behavior.