### PR TITLE
[mac] separate configs for macMaxCSMABackoffs and macMaxFrameRetries

### DIFF
--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -124,7 +124,8 @@ typedef struct otRadioFrame
          */
         struct
         {
-            uint8_t        mMaxTxAttempts;     ///< Max number of transmit attempts for an outbound frame.
+            uint8_t        mMaxCsmaBackoffs;   ///< Maximum number of backoffs attempts before declaring CCA failure.
+            uint8_t        mMaxFrameRetries;   ///< Maximum number of retries allowed after a transmission failure.
             bool           mIsARetx : 1;       ///< True if this frame is a retransmission (ignored by radio driver).
             bool           mCsmaCaEnabled : 1; ///< Set to true to enable CSMA-CA for this packet, false otherwise.
             const uint8_t *mAesKey;            ///< The key used for AES-CCM frame security.

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -233,6 +233,7 @@ libopenthread_ftd_a_SOURCES         = \
     $(NULL)
 
 HEADERS_COMMON                      = \
+    openthread-core-config-check.h    \
     openthread-core-config.h          \
     openthread-core-default-config.h  \
     api/link_raw.hpp                  \

--- a/src/core/api/link_raw.hpp
+++ b/src/core/api/link_raw.hpp
@@ -263,8 +263,8 @@ private:
 
 #if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT
 
-    uint8_t mTransmitAttempts;
-    uint8_t mCsmaAttempts;
+    uint8_t mTransmitRetries;
+    uint8_t mCsmaBackoffs;
 
 #endif // OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT
 

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -53,6 +53,10 @@ LinkRaw::LinkRaw(Instance &aInstance)
     , mTimerMicro(aInstance, &LinkRaw::HandleTimer, this)
 #endif // OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER
 #endif // OPENTHREAD_LINKRAW_TIMER_REQUIRED
+#if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT
+    , mTransmitRetries(0)
+    , mCsmaBackoffs(0)
+#endif // OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT
 #if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ENERGY_SCAN
     , mEnergyScanTask(aInstance, &LinkRaw::HandleEnergyScanTask, this)
 #endif // OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ENERGY_SCAN
@@ -225,8 +229,8 @@ otError LinkRaw::Transmit(otRadioFrame *aFrame, otLinkRawTransmitDone aCallback)
         mTransmitDoneCallback = aCallback;
 
 #if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT
-        mTransmitAttempts = 0;
-        mCsmaAttempts     = 0;
+        mTransmitRetries = 0;
+        mCsmaBackoffs    = 0;
 #endif // OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT
 
 #if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_CSMA_BACKOFF
@@ -260,9 +264,10 @@ void LinkRaw::InvokeTransmitDone(otRadioFrame *aFrame, otRadioFrame *aAckFrame, 
 
     if (aError == OT_ERROR_CHANNEL_ACCESS_FAILURE)
     {
-        if (mCsmaAttempts < Mac::kMaxCSMABackoffs)
+        mCsmaBackoffs++;
+
+        if (mCsmaBackoffs < aFrame->mInfo.mTxInfo.mMaxCsmaBackoffs)
         {
-            mCsmaAttempts++;
 #if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_CSMA_BACKOFF
             StartCsmaBackoff();
 #else
@@ -279,14 +284,14 @@ void LinkRaw::InvokeTransmitDone(otRadioFrame *aFrame, otRadioFrame *aAckFrame, 
     }
     else
     {
-        mCsmaAttempts = 0;
+        mCsmaBackoffs = 0;
     }
 
     if (aError == OT_ERROR_NO_ACK)
     {
-        if (mTransmitAttempts < aFrame->mInfo.mTxInfo.mMaxTxAttempts)
+        if (mTransmitRetries < aFrame->mInfo.mTxInfo.mMaxFrameRetries)
         {
-            mTransmitAttempts++;
+            mTransmitRetries++;
 #if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_CSMA_BACKOFF
             StartCsmaBackoff();
 #else
@@ -451,7 +456,7 @@ void LinkRaw::HandleTimer(void)
 
 void LinkRaw::StartCsmaBackoff(void)
 {
-    uint32_t backoffExponent = Mac::kMinBE + mTransmitAttempts + mCsmaAttempts;
+    uint32_t backoffExponent = Mac::kMinBE + mTransmitRetries + mCsmaBackoffs;
     uint32_t backoff;
 
     if (backoffExponent > Mac::kMaxBE)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -71,7 +71,6 @@ enum
 {
     kMinBE             = 3,  ///< macMinBE (IEEE 802.15.4-2006).
     kMaxBE             = 5,  ///< macMaxBE (IEEE 802.15.4-2006).
-    kMaxCSMABackoffs   = 4,  ///< macMaxCSMABackoffs (IEEE 802.15.4-2006).
     kUnitBackoffPeriod = 20, ///< Number of symbols (IEEE 802.15.4-2006).
 
     kMinBackoff = 1, ///< Minimum backoff (milliseconds).
@@ -84,24 +83,17 @@ enum
     kScanChannelsAll     = OT_CHANNEL_ALL, ///< All channels.
     kScanDurationDefault = 300,            ///< Default interval between channels (milliseconds).
 
-    /**
-     * Maximum number of MAC layer tx attempts for an outbound direct frame.
-     *
-     */
-    kDirectFrameMacTxAttempts = OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_DIRECT,
+    kMaxCsmaBackoffsDirect =
+        OPENTHREAD_CONFIG_MAC_MAX_CSMA_BACKOFFS_DIRECT, ///< macMaxCsmaBackoffs for direct transmissions
+    kMaxCsmaBackoffsIndirect =
+        OPENTHREAD_CONFIG_MAC_MAX_CSMA_BACKOFFS_INDIRECT, ///< macMaxCsmaBackoffs for indirect transmissions
 
-    /**
-     * Maximum number of MAC layer tx attempts for an outbound indirect frame (for a sleepy child) after receiving
-     * a data request command (data poll) from the child.
-     *
-     */
-    kIndirectFrameMacTxAttempts = OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_PER_POLL,
+    kMaxFrameRetriesDirect =
+        OPENTHREAD_CONFIG_MAC_MAX_FRAME_RETRIES_DIRECT, ///< macMaxFrameRetries for direct transmissions
+    kMaxFrameRetriesIndirect =
+        OPENTHREAD_CONFIG_MAC_MAX_FRAME_RETRIES_INDIRECT, ///< macMaxFrameRetries for indirect transmissions
 
-    /**
-     * The transmit number of a broadcast frame in MAC layer.
-     *
-     */
-    kTxNumBcast = OPENTHREAD_CONFIG_TX_NUM_BCAST,
+    kTxNumBcast = OPENTHREAD_CONFIG_TX_NUM_BCAST ///< Number of times each broadcast frame is transmitted
 };
 
 /**
@@ -1059,8 +1051,8 @@ private:
 
     uint8_t mBeaconSequence;
     uint8_t mDataSequence;
-    uint8_t mCsmaAttempts;
-    uint8_t mTransmitAttempts;
+    uint8_t mCsmaBackoffs;
+    uint8_t mTransmitRetries;
     uint8_t mBroadcastTransmitCount;
 
     ChannelMask mScanChannelMask;

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -989,20 +989,48 @@ public:
     void SetLqi(uint8_t aLqi) { mInfo.mRxInfo.mLqi = aLqi; }
 
     /**
-     * This method returns the maximum number of transmit attempts for the frame.
+     * This method returns the maximum number of backoffs the CSMA-CA algorithm will attempt before declaring a channel
+     * access failure.
      *
-     * @returns The maximum number of transmit attempts.
+     * Equivalent to macMaxCSMABackoffs in IEEE 802.15.4-2006.
+     *
+     * @returns The maximum number of backoffs the CSMA-CA algorithm will attempt before declaring a channel access
+     *          failure.
      *
      */
-    uint8_t GetMaxTxAttempts(void) const { return mInfo.mTxInfo.mMaxTxAttempts; }
+    uint8_t GetMaxCsmaBackoffs(void) const { return mInfo.mTxInfo.mMaxCsmaBackoffs; }
 
     /**
-     * This method set the maximum number of transmit attempts for frame.
+     * This method sets the maximum number of backoffs the CSMA-CA algorithm will attempt before declaring a channel
+     * access failure.
      *
-     * @returns The maximum number of transmit attempts.
+     * Equivalent to macMaxCSMABackoffs in IEEE 802.15.4-2006.
+     *
+     * @param[in]  aMaxCsmaBackoffs  The maximum number of backoffs the CSMA-CA algorithm will attempt before declaring
+     *                               a channel access failure.
      *
      */
-    void SetMaxTxAttempts(uint8_t aMaxTxAttempts) { mInfo.mTxInfo.mMaxTxAttempts = aMaxTxAttempts; }
+    void SetMaxCsmaBackoffs(uint8_t aMaxCsmaBackoffs) { mInfo.mTxInfo.mMaxCsmaBackoffs = aMaxCsmaBackoffs; }
+
+    /**
+     * This method returns the maximum number of retries allowed after a transmission failure.
+     *
+     * Equivalent to macMaxFrameRetries in IEEE 802.15.4-2006.
+     *
+     * @returns The maximum number of retries allowed after a transmission failure.
+     *
+     */
+    uint8_t GetMaxFrameRetries(void) const { return mInfo.mTxInfo.mMaxFrameRetries; }
+
+    /**
+     * This method sets the maximum number of retries allowed after a transmission failure.
+     *
+     * Equivalent to macMaxFrameRetries in IEEE 802.15.4-2006.
+     *
+     * @param[in]  aMaxFrameRetries  The maximum number of retries allowed after a transmission failure.
+     *
+     */
+    void SetMaxFrameRetries(uint8_t aMaxFrameRetries) { mInfo.mTxInfo.mMaxFrameRetries = aMaxFrameRetries; }
 
     /**
      * This method indicates whether or not the frame is a retransmission.

--- a/src/core/openthread-core-config-check.h
+++ b/src/core/openthread-core-config-check.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2016, The OpenThread Authors.
+ *  Copyright (c) 2018, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -28,24 +28,15 @@
 
 /**
  * @file
- *   This file includes compile-time configuration constants for OpenThread.
+ *   Sanity checking for configuration options.
  */
 
-#ifndef OPENTHREAD_CORE_CONFIG_H_
-#define OPENTHREAD_CORE_CONFIG_H_
+#ifndef OPENTHREAD_CORE_CONFIG_CHECK_H_
+#define OPENTHREAD_CORE_CONFIG_CHECK_H_
 
-#include <openthread/config.h>
-
-#define OPENTHREAD_CORE_CONFIG_H_IN
-
-#ifdef OPENTHREAD_PROJECT_CORE_CONFIG_FILE
-#include OPENTHREAD_PROJECT_CORE_CONFIG_FILE
+#ifdef OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_PER_POLL
+#error \
+    "OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_PER_POLL was replaced by OPENTHREAD_CONFIG_MAC_MAX_FRAME_RETRIES_INDIRECT."
 #endif
 
-#include "openthread-core-default-config.h"
-
-#undef OPENTHREAD_CORE_CONFIG_H_IN
-
-#include "openthread-core-config-check.h"
-
-#endif // OPENTHREAD_CORE_CONFIG_H_
+#endif // OPENTHREAD_CORE_CONFIG_CHECK_H_

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -126,25 +126,51 @@
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_DIRECT
+ * @def OPENTHREAD_CONFIG_MAC_MAX_CSMA_BACKOFFS_DIRECT
  *
- * Maximum number of MAC layer transmit attempts for an outbound direct frame.
- * Per IEEE 802.15.4-2006, default value is set to (macMaxFrameRetries + 1) with macMaxFrameRetries = 3.
+ * The maximum number of backoffs the CSMA-CA algorithm will attempt before declaring a channel access failure.
+ *
+ * Equivalent to macMaxCSMABackoffs in IEEE 802.15.4-2006, default value is 4.
  *
  */
-#ifndef OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_DIRECT
-#define OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_DIRECT 4
+#ifndef OPENTHREAD_CONFIG_MAC_MAX_CSMA_BACKOFFS_DIRECT
+#define OPENTHREAD_CONFIG_MAC_MAX_CSMA_BACKOFFS_DIRECT 32
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_PER_POLL
+ * @def OPENTHREAD_CONFIG_MAC_MAX_CSMA_BACKOFFS_INDIRECT
  *
- * Maximum number of MAC layer transmit attempts for an outbound indirect frame (to a sleepy child) after receiving
- * a data request command (data poll) from the child.
+ * The maximum number of backoffs the CSMA-CA algorithm will attempt before declaring a channel access failure.
+ *
+ * Equivalent to macMaxCSMABackoffs in IEEE 802.15.4-2006, default value is 4.
  *
  */
-#ifndef OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_PER_POLL
-#define OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_PER_POLL 1
+#ifndef OPENTHREAD_CONFIG_MAC_MAX_CSMA_BACKOFFS_INDIRECT
+#define OPENTHREAD_CONFIG_MAC_MAX_CSMA_BACKOFFS_INDIRECT 4
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_MAC_MAX_FRAME_RETRIES_DIRECT
+ *
+ * The maximum number of retries allowed after a transmission failure for direct transmissions.
+ *
+ * Equivalent to macMaxFrameRetries, default value is 3.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MAC_MAX_FRAME_RETRIES_DIRECT
+#define OPENTHREAD_CONFIG_MAC_MAX_FRAME_RETRIES_DIRECT 3
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_MAC_MAX_FRAME_RETRIES_INDIRECT
+ *
+ * The maximum number of retries allowed after a transmission failure for indirect transmissions.
+ *
+ * Equivalent to macMaxFrameRetries, default value is 0.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MAC_MAX_FRAME_RETRIES_INDIRECT
+#define OPENTHREAD_CONFIG_MAC_MAX_FRAME_RETRIES_INDIRECT 0
 #endif
 
 /**

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -400,7 +400,8 @@ private:
 
     Message *mSendMessage;
     bool     mSendMessageIsARetransmission;
-    uint8_t  mSendMessageMaxMacTxAttempts;
+    uint8_t  mSendMessageMaxCsmaBackoffs;
+    uint8_t  mSendMessageMaxFrameRetries;
 
     Mac::Address mMacSource;
     Mac::Address mMacDest;

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -385,8 +385,9 @@ otError MeshForwarder::GetIndirectTransmission(void)
             continue;
         }
 
-        mSendMessage                 = child.GetIndirectMessage();
-        mSendMessageMaxMacTxAttempts = Mac::kIndirectFrameMacTxAttempts;
+        mSendMessage                = child.GetIndirectMessage();
+        mSendMessageMaxCsmaBackoffs = Mac::kMaxCsmaBackoffsIndirect;
+        mSendMessageMaxFrameRetries = Mac::kMaxFrameRetriesIndirect;
 
         if (mSendMessage == NULL)
         {
@@ -648,8 +649,6 @@ void MeshForwarder::HandleSentFrameToChild(const Mac::Frame &aFrame, otError aEr
             break;
         }
     }
-
-    VerifyOrExit((aError == OT_ERROR_NONE) || (aError == OT_ERROR_NO_ACK));
 
     if (mMessageNextOffset < mSendMessage->GetLength())
     {

--- a/src/ncp/ncp_base_radio.cpp
+++ b/src/ncp/ncp_base_radio.cpp
@@ -360,7 +360,8 @@ otError NcpBase::HandlePropertySet_SPINEL_PROP_STREAM_RAW(uint8_t aHeader)
     memcpy(frame->mPsdu, frameBuffer, frame->mLength);
 
     // TODO: This should be later added in the STREAM_RAW argument to allow user to directly specify it.
-    frame->mInfo.mTxInfo.mMaxTxAttempts = OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_DIRECT;
+    frame->mInfo.mTxInfo.mMaxCsmaBackoffs = OPENTHREAD_CONFIG_MAC_MAX_CSMA_BACKOFFS_DIRECT;
+    frame->mInfo.mTxInfo.mMaxFrameRetries = OPENTHREAD_CONFIG_MAC_MAX_FRAME_RETRIES_DIRECT;
 
     // Pass frame to the radio layer. Note, this fails if we
     // haven't enabled raw stream or are already transmitting.


### PR DESCRIPTION
This commit aligns the MAC CSMA backoff and retransmit configuration more
closely with IEEE 802.15.4-2006.

This PR also reverts #2846.