### PR TITLE
[ncp] increase ChangedPropsSet max supported entries to 64

### DIFF
--- a/src/ncp/changed_props_set.cpp
+++ b/src/ncp/changed_props_set.cpp
@@ -41,8 +41,8 @@ namespace Ncp {
 // Note that {`SPINEL_PROP_LAST_STATUS`, `SPINEL_STATUS_RESET_UNKNOWN`} should be first entry to ensure that RESET is
 // reported before any other property update.
 //
-// Since a `uint32_t` is used as bit-mask to track which entries are in the changed set, we should ensure that the
-// number of entries in the list is always less than or equal to 32.
+// Since a `uint64_t` is used as bit-mask to track which entries are in the changed set, we should ensure that the
+// number of entries in the list is always less than or equal to 64.
 //
 const ChangedPropsSet::Entry ChangedPropsSet::mSupportedProps[] = {
     // Spinel property , Status (if prop is `LAST_STATUS`),  IsFilterable?
@@ -83,7 +83,6 @@ const ChangedPropsSet::Entry ChangedPropsSet::mSupportedProps[] = {
 #if OPENTHREAD_ENABLE_CHANNEL_MANAGER
     {SPINEL_PROP_CHANNEL_MANAGER_NEW_CHANNEL, SPINEL_STATUS_OK, true}, // 29
 #endif
-
 };
 
 uint8_t ChangedPropsSet::GetNumEntries(void) const

--- a/src/ncp/changed_props_set.hpp
+++ b/src/ncp/changed_props_set.hpp
@@ -196,14 +196,14 @@ private:
     uint8_t GetNumEntries(void) const;
     void    Add(spinel_prop_key_t aPropKey, spinel_status_t aStatus);
 
-    static void SetBit(uint32_t &aBitset, uint8_t aBitIndex) { aBitset |= (1U << aBitIndex); }
-    static void ClearBit(uint32_t &aBitset, uint8_t aBitIndex) { aBitset &= ~(1U << aBitIndex); }
-    static bool IsBitSet(uint32_t aBitset, uint8_t aBitIndex) { return (aBitset & (1U << aBitIndex)) != 0; }
+    static void SetBit(uint64_t &aBitset, uint8_t aBitIndex) { aBitset |= (1ULL << aBitIndex); }
+    static void ClearBit(uint64_t &aBitset, uint8_t aBitIndex) { aBitset &= ~(1ULL << aBitIndex); }
+    static bool IsBitSet(uint64_t aBitset, uint8_t aBitIndex) { return (aBitset & (1ULL << aBitIndex)) != 0; }
 
     static const Entry mSupportedProps[];
 
-    uint32_t mChangedSet;
-    uint32_t mFilterSet;
+    uint64_t mChangedSet;
+    uint64_t mFilterSet;
 };
 
 } // namespace Ncp


### PR DESCRIPTION
This commit increases the maximim number of entries that can be
supported by `Ncp::ChangePropsSet` to 64 by using `uint64_t` to
save the flags instead of `uint32_t`.