### PR TITLE
[spinel] add a section for MeshCop properties and update documentation

### DIFF
--- a/doc/spinel-protocol-src/spinel-prop.md
+++ b/doc/spinel-protocol-src/spinel-prop.md
@@ -14,9 +14,9 @@ following allocation plan:
 Property ID Range     | Description
 :---------------------|:-----------------
 0 - 127               | Reserved for frequently-used properties
-128 - 15,359          | Unallocated
+128 - 15,359          | Technology-specific
 15,360 - 16,383       | Vendor-specific
-16,384 - 1,999,999    | Unallocated
+16,384 - 1,999,999    | Technology-specific
 2,000,000 - 2,097,151 | Experimental use only
 
 For an explanation of the data format encoding shorthand used
@@ -28,16 +28,24 @@ The currently assigned properties are broken up into several
 sections, each with reserved ranges of property identifiers.
 These ranges are:
 
-Name   | Range (Inclusive)            | Documentation
--------|------------------------------|--------------
-Core   | 0x00 - 0x1F, 0x1000 - 0x11FF | (#prop-core)
-PHY    | 0x20 - 0x2F, 0x1200 - 0x12FF | (#prop-phy)
-MAC    | 0x30 - 0x3F, 0x1300 - 0x13FF | (#prop-mac)
-NET    | 0x40 - 0x4F, 0x1400 - 0x14FF | (#prop-net)
-Tech   | 0x50 - 0x5F, 0x1500 - 0x15FF | Technology-specific
-IPv6   | 0x60 - 0x6F, 0x1600 - 0x16FF | (#prop-ipv6)
-Stream | 0x70 - 0x7F, 0x1700 - 0x17FF | (#prop-core)
-Debug  |              0x4000 - 0x4400 | (#prop-debug)
+Name         | Range (Inclusive)              | Description
+-------------|--------------------------------|------------------------
+Core         | 0x000 - 0x01F, 0x1000 - 0x11FF | Spinel core
+PHY          | 0x020 - 0x02F, 0x1200 - 0x12FF | Radio PHY layer
+MAC          | 0x030 - 0x03F, 0x1300 - 0x13FF | MAC layer
+NET          | 0x040 - 0x04F, 0x1400 - 0x14FF | Network
+Thread       | 0x050 - 0x05F, 0x1500 - 0x15FF | Thread
+IPv6         | 0x060 - 0x06F, 0x1600 - 0x16FF | IPv6
+Stream       | 0x070 - 0x07F, 0x1700 - 0x17FF | Stream
+MeshCop      | 0x080 - 0x08F, 0x1800 - 0x18FF | Thread Mesh Commissioning
+OpenThread   |                0x1900 - 0x19FF | OpenThread specific
+Interface    | 0x100 - 0x1FF                  | Interface (e.g., UART)
+PIB          | 0x400 - 0x4FF                  | 802.15.4 PIB
+Counter      | 0x500 - 0x7FF                  | Counters (MAC, IP, etc).
+Nest         |                0x3BC0 - 0x3BFF | Nest (legacy)
+Vendor       |                0x3C00 - 0x3FFF | Vendor specific
+Debug        |                0x4000 - 0x43FF | Debug related
+Experimental |          2,000,000 - 2,097,151 | Experimental use only
 
 Note that some of the property sections have two reserved
 ranges: a primary range (which is encoded as a single byte)

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -474,6 +474,32 @@ enum
     SPINEL_CAP_EXPERIMENTAL__END   = 2097152,
 };
 
+/**
+ * Property Keys
+ *
+ * The properties are broken up into several sections, each with a
+ * reserved ranges of property identifiers:
+ *
+ *    Name         | Range (Inclusive)              | Description
+ *    -------------|--------------------------------|------------------------
+ *    Core         | 0x000 - 0x01F, 0x1000 - 0x11FF | Spinel core
+ *    PHY          | 0x020 - 0x02F, 0x1200 - 0x12FF | Radio PHY layer
+ *    MAC          | 0x030 - 0x03F, 0x1300 - 0x13FF | MAC layer
+ *    NET          | 0x040 - 0x04F, 0x1400 - 0x14FF | Network
+ *    Thread       | 0x050 - 0x05F, 0x1500 - 0x15FF | Thread
+ *    IPv6         | 0x060 - 0x06F, 0x1600 - 0x16FF | IPv6
+ *    Stream       | 0x070 - 0x07F, 0x1700 - 0x17FF | Stream
+ *    MeshCop      | 0x080 - 0x08F, 0x1800 - 0x18FF | Thread Mesh Commissioning
+ *    OpenThread   |                0x1900 - 0x19FF | OpenThread specific
+ *    Interface    | 0x100 - 0x1FF                  | Interface (e.g., UART)
+ *    PIB          | 0x400 - 0x4FF                  | 802.15.4 PIB
+ *    Counter      | 0x500 - 0x7FF                  | Counters (MAC, IP, etc).
+ *    Nest         |                0x3BC0 - 0x3BFF | Nest (legacy)
+ *    Vendor       |                0x3C00 - 0x3FFF | Vendor specific
+ *    Debug        |                0x4000 - 0x43FF | Debug related
+ *    Experimental |          2,000,000 - 2,097,151 | Experimental use only
+ *
+ */
 typedef enum {
     SPINEL_PROP_LAST_STATUS      = 0,  ///< status [i]
     SPINEL_PROP_PROTOCOL_VERSION = 1,  ///< major, minor [i,i]
@@ -921,6 +947,9 @@ typedef enum {
     SPINEL_PROP_NET_PSKC = SPINEL_PROP_NET__BEGIN + 11, ///< [D]
 
     SPINEL_PROP_NET__END = 0x50,
+
+    SPINEL_PROP_NET_EXT__BEGIN = 0x1400,
+    SPINEL_PROP_NET_EXT__END   = 0x1500,
 
     SPINEL_PROP_THREAD__BEGIN      = 0x50,
     SPINEL_PROP_THREAD_LEADER_ADDR = SPINEL_PROP_THREAD__BEGIN + 0, ///< [6]
@@ -1468,6 +1497,9 @@ typedef enum {
 
     SPINEL_PROP_IPV6__END = 0x70,
 
+    SPINEL_PROP_IPV6_EXT__BEGIN = 0x1600,
+    SPINEL_PROP_IPV6_EXT__END   = 0x1700,
+
     SPINEL_PROP_STREAM__BEGIN       = 0x70,
     SPINEL_PROP_STREAM_DEBUG        = SPINEL_PROP_STREAM__BEGIN + 0, ///< [U]
     SPINEL_PROP_STREAM_RAW          = SPINEL_PROP_STREAM__BEGIN + 1, ///< [dD]
@@ -1498,6 +1530,15 @@ typedef enum {
      */
     SPINEL_PROP_STREAM_LOG  = SPINEL_PROP_STREAM__BEGIN + 4,
     SPINEL_PROP_STREAM__END = 0x80,
+
+    SPINEL_PROP_STREAM_EXT__BEGIN = 0x1700,
+    SPINEL_PROP_STREAM_EXT__END   = 0x1800,
+
+    SPINEL_PROP_MESHCOP__BEGIN = 0x80,
+    SPINEL_PROP_MESHCOP__END   = 0x90,
+
+    SPINEL_PROP_MESHCOP_EXT__BEGIN = 0x1800,
+    SPINEL_PROP_MESHCOP_EXT__END   = 0x1900,
 
     SPINEL_PROP_OPENTHREAD__BEGIN = 0x1900,
 
@@ -1635,6 +1676,8 @@ typedef enum {
 
     SPINEL_PROP_OPENTHREAD__END = 0x2000,
 
+    SPINEL_PROP_INTERFACE__BEGIN = 0x100,
+
     /// UART Bitrate
     /** Format: `L`
      *
@@ -1657,7 +1700,7 @@ typedef enum {
      *  the host, all further frames will be transmitted at the new
      *  bitrate.
      */
-    SPINEL_PROP_UART_BITRATE = 0x100,
+    SPINEL_PROP_UART_BITRATE = SPINEL_PROP_INTERFACE__BEGIN + 0,
 
     /// UART Software Flow Control
     /** Format: `b`
@@ -1670,9 +1713,11 @@ typedef enum {
      *  This property is only implemented when a UART is being
      *  used for Spinel. This property is optional.
      */
-    SPINEL_PROP_UART_XON_XOFF = 0x101,
+    SPINEL_PROP_UART_XON_XOFF = SPINEL_PROP_INTERFACE__BEGIN + 1,
 
-    SPINEL_PROP_15_4_PIB__BEGIN = 1024,
+    SPINEL_PROP_INTERFACE__END = 0x200,
+
+    SPINEL_PROP_15_4_PIB__BEGIN = 0x400,
     // For direct access to the 802.15.4 PID.
     // Individual registers are fetched using
     // `SPINEL_PROP_15_4_PIB__BEGIN+[PIB_IDENTIFIER]`
@@ -1684,9 +1729,9 @@ typedef enum {
     SPINEL_PROP_15_4_PIB_PHY_CHANNELS_SUPPORTED = SPINEL_PROP_15_4_PIB__BEGIN + 0x01, ///< [A(L)]
     SPINEL_PROP_15_4_PIB_MAC_PROMISCUOUS_MODE   = SPINEL_PROP_15_4_PIB__BEGIN + 0x51, ///< [b]
     SPINEL_PROP_15_4_PIB_MAC_SECURITY_ENABLED   = SPINEL_PROP_15_4_PIB__BEGIN + 0x5d, ///< [b]
-    SPINEL_PROP_15_4_PIB__END                   = 1280,
+    SPINEL_PROP_15_4_PIB__END                   = 0x500,
 
-    SPINEL_PROP_CNTR__BEGIN = 1280,
+    SPINEL_PROP_CNTR__BEGIN = 0x500,
 
     /// Counter reset behavior
     /** Format: `C`
@@ -1942,9 +1987,10 @@ typedef enum {
      */
     SPINEL_PROP_CNTR_ALL_MAC_COUNTERS = SPINEL_PROP_CNTR__BEGIN + 401,
 
-    SPINEL_PROP_CNTR__END = 2048,
+    SPINEL_PROP_CNTR__END = 0x800,
 
-    SPINEL_PROP_NEST__BEGIN     = 15296,
+    SPINEL_PROP_NEST__BEGIN = 0x3BC0,
+
     SPINEL_PROP_NEST_STREAM_MFG = SPINEL_PROP_NEST__BEGIN + 0,
 
     /// The legacy network ULA prefix (8 bytes)
@@ -1955,12 +2001,12 @@ typedef enum {
     /** Format: 'E' */
     SPINEL_PROP_NEST_LEGACY_LAST_NODE_JOINED = SPINEL_PROP_NEST__BEGIN + 2,
 
-    SPINEL_PROP_NEST__END = 15360,
+    SPINEL_PROP_NEST__END = 0x3C00,
 
-    SPINEL_PROP_VENDOR__BEGIN = 15360,
-    SPINEL_PROP_VENDOR__END   = 16384,
+    SPINEL_PROP_VENDOR__BEGIN = 0x3C00,
+    SPINEL_PROP_VENDOR__END   = 0x4000,
 
-    SPINEL_PROP_DEBUG__BEGIN = 16384,
+    SPINEL_PROP_DEBUG__BEGIN = 0x4000,
 
     /// Testing platform assert
     /** Format: 'b' (read-only)
@@ -1986,7 +2032,7 @@ typedef enum {
      */
     SPINEL_PROP_DEBUG_TEST_WATCHDOG = SPINEL_PROP_DEBUG__BEGIN + 2,
 
-    SPINEL_PROP_DEBUG__END = 17408,
+    SPINEL_PROP_DEBUG__END = 0x4400,
 
     SPINEL_PROP_EXPERIMENTAL__BEGIN = 2000000,
     SPINEL_PROP_EXPERIMENTAL__END   = 2097152,


### PR DESCRIPTION
This commit updates the documentation of spinel property sections
and also adds a new range `0x080 - 0x08F, 0x1800 - 0x18FF` 
for MeshCop related properties.
