### PR TITLE
[code-style] remove multiple return statements per free function or method

### DIFF
--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -127,7 +127,7 @@ void Coap::HandleServerResponse(otCoapHeader *aHeader, otMessage *aMessage, cons
 {
     otError      error = OT_ERROR_NONE;
     otCoapHeader responseHeader;
-    otMessage *  responseMessage;
+    otMessage *  responseMessage = NULL;
     otCoapCode   responseCode    = OT_COAP_CODE_EMPTY;
     char         responseContent = '0';
 
@@ -158,7 +158,7 @@ void Coap::HandleServerResponse(otCoapHeader *aHeader, otMessage *aMessage, cons
 
     default:
         mInterpreter.mServer->OutputFormat("Undefined\r\n");
-        return;
+        ExitNow(error = OT_ERROR_PARSE);
     }
 
     PrintPayload(aMessage);
@@ -196,11 +196,14 @@ void Coap::HandleServerResponse(otCoapHeader *aHeader, otMessage *aMessage, cons
 
 exit:
 
-    if (error != OT_ERROR_NONE && responseMessage != NULL)
+    if (error != OT_ERROR_NONE)
     {
-        mInterpreter.mServer->OutputFormat("Cannot send coap response message: Error %d: %s\r\n", error,
-                                           otThreadErrorToString(error));
-        otMessageFree(responseMessage);
+        if (responseMessage != NULL)
+        {
+            mInterpreter.mServer->OutputFormat("Cannot send coap response message: Error %d: %s\r\n", error,
+                                               otThreadErrorToString(error));
+            otMessageFree(responseMessage);
+        }
     }
     else if (responseCode >= OT_COAP_CODE_RESPONSE_MIN)
     {

--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -295,16 +295,16 @@ void Uart::SendDoneTask(void)
 
 extern "C" void otCliPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, va_list aArgs)
 {
-    if (NULL == Uart::sUartServer)
-    {
-        return;
-    }
+    VerifyOrExit(Uart::sUartServer != NULL);
 
     Uart::sUartServer->OutputFormatV(aFormat, aArgs);
     Uart::sUartServer->OutputFormat("\r\n");
 
     OT_UNUSED_VARIABLE(aLogLevel);
     OT_UNUSED_VARIABLE(aLogRegion);
+
+exit:
+    return;
 }
 
 } // namespace Cli

--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -45,14 +45,9 @@ bool otDatasetIsCommissioned(otInstance *aInstance)
 
     otDatasetGetActive(aInstance, &dataset);
 
-    if (dataset.mComponents.mIsMasterKeyPresent && dataset.mComponents.mIsNetworkNamePresent &&
-        dataset.mComponents.mIsExtendedPanIdPresent && dataset.mComponents.mIsPanIdPresent &&
-        dataset.mComponents.mIsChannelPresent)
-    {
-        return true;
-    }
-
-    return false;
+    return ((dataset.mComponents.mIsMasterKeyPresent) && (dataset.mComponents.mIsNetworkNamePresent) &&
+            (dataset.mComponents.mIsExtendedPanIdPresent) && (dataset.mComponents.mIsPanIdPresent) &&
+            (dataset.mComponents.mIsChannelPresent));
 }
 
 otError otDatasetGetActive(otInstance *aInstance, otOperationalDataset *aDataset)

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -158,14 +158,7 @@ exit:
     // First comparison is to get around issues with comparing
     // signed and unsigned numbers, if aNumBuffers is negative then
     // the second comparison wont be attempted.
-    if (aNumBuffers < 0 || aNumBuffers <= GetFreeBufferCount())
-    {
-        return OT_ERROR_NONE;
-    }
-    else
-    {
-        return OT_ERROR_NO_BUFS;
-    }
+    return (aNumBuffers < 0 || aNumBuffers <= GetFreeBufferCount()) ? OT_ERROR_NONE : OT_ERROR_NO_BUFS;
 }
 
 #if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -114,17 +114,24 @@ private:
 
 static Coap::Header::Code CoapCodeFromError(otError aError)
 {
+    Coap::Header::Code code;
+
     switch (aError)
     {
     case OT_ERROR_NONE:
-        return OT_COAP_CODE_CHANGED;
+        code = OT_COAP_CODE_CHANGED;
+        break;
 
     case OT_ERROR_PARSE:
-        return OT_COAP_CODE_BAD_REQUEST;
+        code = OT_COAP_CODE_BAD_REQUEST;
+        break;
 
     default:
-        return OT_COAP_CODE_INTERNAL_ERROR;
+        code = OT_COAP_CODE_INTERNAL_ERROR;
+        break;
     }
+
+    return code;
 }
 
 void BorderAgent::SendErrorMessage(const Coap::Header &aHeader)

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -565,7 +565,8 @@ exit:
 
 uint16_t Dhcp6Client::FindOption(Message &aMessage, uint16_t aOffset, uint16_t aLength, Dhcp6::Code aCode)
 {
-    uint16_t end = aOffset + aLength;
+    uint16_t end  = aOffset + aLength;
+    uint16_t rval = 0;
 
     while (aOffset <= end)
     {
@@ -574,14 +575,14 @@ uint16_t Dhcp6Client::FindOption(Message &aMessage, uint16_t aOffset, uint16_t a
 
         if (option.GetCode() == (aCode))
         {
-            return aOffset;
+            ExitNow(rval = aOffset);
         }
 
         aOffset += sizeof(option) + option.GetLength();
     }
 
 exit:
-    return 0;
+    return rval;
 }
 
 otError Dhcp6Client::ProcessServerIdentifier(Message &aMessage, uint16_t aOffset)

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -312,7 +312,8 @@ exit:
 
 uint16_t Dhcp6Server::FindOption(Message &aMessage, uint16_t aOffset, uint16_t aLength, Code aCode)
 {
-    uint16_t end = aOffset + aLength;
+    uint16_t end  = aOffset + aLength;
+    uint16_t rval = 0;
 
     while (aOffset <= end)
     {
@@ -321,14 +322,14 @@ uint16_t Dhcp6Server::FindOption(Message &aMessage, uint16_t aOffset, uint16_t a
 
         if (option.GetCode() == aCode)
         {
-            return aOffset;
+            ExitNow(rval = aOffset);
         }
 
         aOffset += sizeof(option) + option.GetLength();
     }
 
 exit:
-    return 0;
+    return rval;
 }
 otError Dhcp6Server::ProcessClientIdentifier(Message &aMessage, uint16_t aOffset, ClientIdentifier &aClient)
 {

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -181,20 +181,26 @@ void Address::ToExtAddress(Mac::Address &aMacAddress) const
 
 uint8_t Address::GetScope(void) const
 {
+    uint8_t rval;
+
     if (IsMulticast())
     {
-        return mFields.m8[1] & 0xf;
+        rval = mFields.m8[1] & 0xf;
     }
     else if (IsLinkLocal())
     {
-        return kLinkLocalScope;
+        rval = kLinkLocalScope;
     }
     else if (IsLoopback())
     {
-        return kNodeLocalScope;
+        rval = kNodeLocalScope;
+    }
+    else
+    {
+        rval = kGlobalScope;
     }
 
-    return kGlobalScope;
+    return rval;
 }
 
 uint8_t Address::PrefixMatch(const uint8_t *aPrefixA, const uint8_t *aPrefixB, uint8_t aMaxLength)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3684,32 +3684,34 @@ exit:
 
 Neighbor *Mle::GetNeighbor(uint16_t aAddress)
 {
+    Neighbor *rval = NULL;
+
     if ((mParent.IsStateValidOrRestoring()) && (mParent.GetRloc16() == aAddress))
     {
-        return &mParent;
+        rval = &mParent;
     }
-
-    if ((mParentCandidate.GetState() == Neighbor::kStateValid) && (mParentCandidate.GetRloc16() == aAddress))
+    else if ((mParentCandidate.GetState() == Neighbor::kStateValid) && (mParentCandidate.GetRloc16() == aAddress))
     {
-        return &mParentCandidate;
+        rval = &mParentCandidate;
     }
 
-    return NULL;
+    return rval;
 }
 
 Neighbor *Mle::GetNeighbor(const Mac::ExtAddress &aAddress)
 {
+    Neighbor *rval = NULL;
+
     if ((mParent.IsStateValidOrRestoring()) && (mParent.GetExtAddress() == aAddress))
     {
-        return &mParent;
+        rval = &mParent;
     }
-
-    if ((mParentCandidate.GetState() == Neighbor::kStateValid) && (mParentCandidate.GetExtAddress() == aAddress))
+    else if ((mParentCandidate.GetState() == Neighbor::kStateValid) && (mParentCandidate.GetExtAddress() == aAddress))
     {
-        return &mParentCandidate;
+        rval = &mParentCandidate;
     }
 
-    return NULL;
+    return rval;
 }
 
 Neighbor *Mle::GetNeighbor(const Mac::Address &aAddress)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -373,14 +373,17 @@ bool MleRouter::HandleAdvertiseTimer(TrickleTimer &aTimer)
 
 bool MleRouter::HandleAdvertiseTimer(void)
 {
+    bool continueTrickle = true;
+
     if (!IsFullThreadDevice())
     {
-        return false;
+        ExitNow(continueTrickle = false);
     }
 
     SendAdvertisement();
 
-    return true;
+exit:
+    return continueTrickle;
 }
 
 void MleRouter::StopAdvertiseTimer(void)
@@ -1006,20 +1009,28 @@ exit:
 
 uint8_t MleRouter::LinkQualityToCost(uint8_t aLinkQuality)
 {
+    uint8_t rval;
+
     switch (aLinkQuality)
     {
     case 1:
-        return kLinkQuality1LinkCost;
+        rval = kLinkQuality1LinkCost;
+        break;
 
     case 2:
-        return kLinkQuality2LinkCost;
+        rval = kLinkQuality2LinkCost;
+        break;
 
     case 3:
-        return kLinkQuality3LinkCost;
+        rval = kLinkQuality3LinkCost;
+        break;
 
     default:
-        return kLinkQuality0LinkCost;
+        rval = kLinkQuality0LinkCost;
+        break;
     }
+
+    return rval;
 }
 
 uint8_t MleRouter::GetLinkCost(uint8_t aRouterId)
@@ -3699,10 +3710,12 @@ otError MleRouter::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, I
 {
     ThreadNetif &    netif = GetNetif();
     Ip6::MessageInfo messageInfo;
+    otError          error = OT_ERROR_NONE;
 
     if (mRole == OT_DEVICE_ROLE_CHILD)
     {
-        return Mle::CheckReachability(aMeshSource, aMeshDest, aIp6Header);
+        error = Mle::CheckReachability(aMeshSource, aMeshDest, aIp6Header);
+        ExitNow();
     }
 
     if (aMeshDest == netif.GetMac().GetShortAddress())
@@ -3711,12 +3724,12 @@ otError MleRouter::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, I
         if (netif.IsUnicastAddress(aIp6Header.GetDestination()))
         {
             // IPv6 destination is this device
-            return OT_ERROR_NONE;
+            ExitNow();
         }
         else if (GetNeighbor(aIp6Header.GetDestination()) != NULL)
         {
             // IPv6 destination is an RFD child
-            return OT_ERROR_NONE;
+            ExitNow();
         }
     }
     else if (GetRouterId(aMeshDest) == mRouterId)
@@ -3724,13 +3737,13 @@ otError MleRouter::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, I
         // mesh destination is a child of this device
         if (GetChildTable().FindChild(aMeshDest, ChildTable::kInStateValidOrRestoring))
         {
-            return OT_ERROR_NONE;
+            ExitNow();
         }
     }
     else if (GetNextHop(aMeshDest) != Mac::kShortAddrInvalid)
     {
         // forwarding to another router and route is known
-        return OT_ERROR_NONE;
+        ExitNow();
     }
 
     messageInfo.GetPeerAddr()                = GetMeshLocal16();
@@ -3740,7 +3753,10 @@ otError MleRouter::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, I
     netif.GetIp6().GetIcmp().SendError(Ip6::IcmpHeader::kTypeDstUnreach, Ip6::IcmpHeader::kCodeDstUnreachNoRoute,
                                        messageInfo, aIp6Header);
 
-    return OT_ERROR_DROP;
+    error = OT_ERROR_DROP;
+
+exit:
+    return error;
 }
 
 otError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -878,9 +878,9 @@ PrefixTlv *NetworkData::FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength
 
 PrefixTlv *NetworkData::FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, uint8_t *aTlvs, uint8_t aTlvsLength)
 {
-    NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(aTlvs);
-    NetworkDataTlv *end = reinterpret_cast<NetworkDataTlv *>(aTlvs + aTlvsLength);
-    PrefixTlv *     compare;
+    NetworkDataTlv *cur     = reinterpret_cast<NetworkDataTlv *>(aTlvs);
+    NetworkDataTlv *end     = reinterpret_cast<NetworkDataTlv *>(aTlvs + aTlvsLength);
+    PrefixTlv *     compare = NULL;
 
     while (cur < end)
     {
@@ -893,15 +893,17 @@ PrefixTlv *NetworkData::FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength
             if (compare->GetPrefixLength() == aPrefixLength &&
                 PrefixMatch(compare->GetPrefix(), aPrefix, aPrefixLength) >= aPrefixLength)
             {
-                return compare;
+                ExitNow();
             }
         }
 
         cur = cur->GetNext();
     }
 
+    compare = NULL;
+
 exit:
-    return NULL;
+    return compare;
 }
 
 int8_t NetworkData::PrefixMatch(const uint8_t *a, const uint8_t *b, uint8_t aLength)
@@ -947,9 +949,9 @@ ServiceTlv *NetworkData::FindService(uint32_t       aEnterpriseNumber,
                                      uint8_t *      aTlvs,
                                      uint8_t        aTlvsLength)
 {
-    NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(aTlvs);
-    NetworkDataTlv *end = reinterpret_cast<NetworkDataTlv *>(aTlvs + aTlvsLength);
-    ServiceTlv *    compare;
+    NetworkDataTlv *cur     = reinterpret_cast<NetworkDataTlv *>(aTlvs);
+    NetworkDataTlv *end     = reinterpret_cast<NetworkDataTlv *>(aTlvs + aTlvsLength);
+    ServiceTlv *    compare = NULL;
 
     while (cur < end)
     {
@@ -963,15 +965,17 @@ ServiceTlv *NetworkData::FindService(uint32_t       aEnterpriseNumber,
                 (compare->GetServiceDataLength() == aServiceDataLength) &&
                 (memcmp(compare->GetServiceData(), aServiceData, aServiceDataLength) == 0))
             {
-                return compare;
+                ExitNow();
             }
         }
 
         cur = cur->GetNext();
     }
 
+    compare = NULL;
+
 exit:
-    return NULL;
+    return compare;
 }
 #endif
 

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -1053,15 +1053,17 @@ ServiceTlv *Leader::FindServiceById(uint8_t aServiceId)
 
             if (compare->GetServiceID() == aServiceId)
             {
-                return compare;
+                ExitNow();
             }
         }
 
         cur = cur->GetNext();
     }
 
+    compare = NULL;
+
 exit:
-    return NULL;
+    return compare;
 }
 #endif
 

--- a/src/ncp/hdlc.cpp
+++ b/src/ncp/hdlc.cpp
@@ -98,6 +98,8 @@ uint16_t UpdateFcs(uint16_t aFcs, uint8_t aByte)
 
 bool HdlcByteNeedsEscape(uint8_t aByte)
 {
+    bool rval;
+
     switch (aByte)
     {
     case kFlagXOn:
@@ -105,11 +107,15 @@ bool HdlcByteNeedsEscape(uint8_t aByte)
     case kEscapeSequence:
     case kFlagSequence:
     case kFlagSpecial:
-        return true;
+        rval = true;
+        break;
 
     default:
-        return false;
+        rval = false;
+        break;
     }
+
+    return rval;
 }
 
 Encoder::BufferWriteIterator::BufferWriteIterator(void)


### PR DESCRIPTION
There should be one return statement per free function or method at the end
of the free function or method.