### PR TITLE
[travis] fix cert 5-2-05 address query

### DIFF
--- a/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
@@ -27,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-import time
 import unittest
 
 import node
@@ -126,8 +125,11 @@ class Cert_5_2_5_AddressQuery(unittest.TestCase):
         mleid = self.nodes[DUT_REED].get_ip6_address(config.ADDRESS_TYPE.ML_EID)
         self.assertTrue(self.nodes[ED1].ping(mleid))
 
+        # Wait for sniffer collecting packets
+        self.simulator.go(1)
+
         reed_messages = self.simulator.get_messages_sent_by(DUT_REED)
-        msg = reed_messages.next_coap_message('0.02')
+        msg = reed_messages.next_coap_message('0.02', '/a/an')
         command.check_address_notification(msg, self.nodes[DUT_REED], self.nodes[LEADER])
 
         # 7 & 8. Verify DUT_REED would send Address Notification when ping to its 2001::EID and 2002::EID.
@@ -142,8 +144,11 @@ class Cert_5_2_5_AddressQuery(unittest.TestCase):
                 raise "Error: Address is unexpected."
             self.assertTrue(self.nodes[ED1].ping(global_address))
 
+            # Wait for sniffer collecting packets
+            self.simulator.go(1)
+
             reed_messages = self.simulator.get_messages_sent_by(DUT_REED)
-            msg = reed_messages.next_coap_message('0.02')
+            msg = reed_messages.next_coap_message('0.02', '/a/an')
             command.check_address_notification(msg, self.nodes[DUT_REED], self.nodes[LEADER])
 
         assert flag2001 == 1 , "Error: Expecting address 2001::EID not appear."


### PR DESCRIPTION
The check posix-app-cli fails from time to time. The cause is finding the message before the sniffer actual collected that message. This PR adds a little delay after ping so that sniffer have enough time to collect the wanted packet.