### PR TITLE
[mle] fix mChildUpdateRequestTimer use for retranmission of Data Reqeust

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -298,7 +298,7 @@ otError MleRouter::SetStateRouter(uint16_t aRloc16)
     SetAttachState(kAttachStateIdle);
     mAttachCounter = 0;
     mAttachTimer.Stop();
-    mChildUpdateRequestTimer.Stop();
+    mMessageTransmissionTimer.Stop();
     mAdvertiseTimer.Stop();
     ResetAdvertiseInterval();
 
@@ -333,7 +333,7 @@ otError MleRouter::SetStateLeader(uint16_t aRloc16)
     SetAttachState(kAttachStateIdle);
     mAttachCounter = 0;
     mAttachTimer.Stop();
-    mChildUpdateRequestTimer.Stop();
+    mMessageTransmissionTimer.Stop();
     mAdvertiseTimer.Stop();
     ResetAdvertiseInterval();
     AddLeaderAloc();


### PR DESCRIPTION
This commit ensures that the `mChildUpdateRequestTimer` timer is used
for retranmission of Data Request messages when there is no pending or
active Child Update Request. It also adds logic to ensure device gets
detached after some number of Data Request attempts with no response.