### PR TITLE
[nrf52840] prevent linker from dicarding strong nrf5CryptoInit implementation

### DIFF
--- a/third_party/NordicSemiconductor/libraries/crypto/cc310_mbedtls.c
+++ b/third_party/NordicSemiconductor/libraries/crypto/cc310_mbedtls.c
@@ -41,6 +41,19 @@ CRYS_RND_WorkBuff_t  m_rndWorkBuff;
 CRYS_RND_State_t    * pRndState    = &m_rndState;
 CRYS_RND_WorkBuff_t * pRndWorkBuff = &m_rndWorkBuff;
 
+void cc310_enable(void)
+{
+    NRF_CRYPTOCELL->ENABLE = 1;
+    NVIC_EnableIRQ(CRYPTOCELL_IRQn);
+}
+
+void cc310_disable(void)
+{
+    NRF_CRYPTOCELL->ENABLE = 0;
+    NVIC_DisableIRQ(CRYPTOCELL_IRQn);
+    NVIC_ClearPendingIRQ(CRYPTOCELL_IRQn);
+}
+
 void nrf5CryptoInit(void)
 {
     SA_SilibRetCode_t sa_result;

--- a/third_party/NordicSemiconductor/libraries/crypto/cc310_mbedtls.h
+++ b/third_party/NordicSemiconductor/libraries/crypto/cc310_mbedtls.h
@@ -33,19 +33,10 @@
 #include "nrf.h"
 
 /** @brief Enable CC310 hardware. */
-static inline void cc310_enable(void)
-{
-    NRF_CRYPTOCELL->ENABLE = 1;
-    NVIC_EnableIRQ(CRYPTOCELL_IRQn);
-}
+void cc310_enable(void);
 
 /** @brief Disable CC310 hardware. */
-static inline void cc310_disable(void)
-{
-    NRF_CRYPTOCELL->ENABLE = 0;
-    NVIC_DisableIRQ(CRYPTOCELL_IRQn);
-    NVIC_ClearPendingIRQ(CRYPTOCELL_IRQn);
-}
+void cc310_disable(void);
 
 /** @brief Wrapper for CC310 operations which ignores result.
  *


### PR DESCRIPTION
Fixes #2896

Linker will discard libmbedcrypto_a-cc310_mbedtls.o when searching mbedTLS library, if it finds weak implementation of nrf5CryptoInit/Deinit before strong ones. Adding additional symbols to this file will prevent this behavior and make linker search libmbedcrypto_a-cc310_mbedtls.o even after weak implementations are found.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>