### PR TITLE
[toranj] perform a subprocess.poll() on wpantund instance during init

### DIFF
--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -491,6 +491,9 @@ class Node(object):
             start_time = time.time()
             while True:
                 try:
+                    node._wpantund_process.poll()
+                    if node._wpantund_process.returncode is not None:
+                        print 'Node {} wpantund instance has terminated unexpectedly'.format(node)
                     if disable_logs:
                         node.set(WPAN_OT_LOG_LEVEL, '0')
                     node.leave()


### PR DESCRIPTION
This allows the underlying wpantund process associated with a `Node`
instance to be executed while we are waiting for it to be initialized.
It also protects against any unexpected termination of an instance.
This change would help with the speed of initialization of all nodes,
mainly when there are many instances running in parallel.