### PR TITLE
[toranj] add new method to finalize all nodes at end of each test

### DIFF
--- a/examples/platforms/posix/platform-posix.h
+++ b/examples/platforms/posix/platform-posix.h
@@ -70,6 +70,7 @@ __forceinline void timersub(struct timeval *a, struct timeval *b, struct timeval
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <poll.h>
+#include <signal.h>
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/stat.h>

--- a/tests/toranj/test-001-get-set.py
+++ b/tests/toranj/test-001-get-set.py
@@ -154,4 +154,6 @@ for prop in all_gettable_props:
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-002-form.py
+++ b/tests/toranj/test-002-form.py
@@ -107,5 +107,7 @@ verify(node.get(wpan.WPAN_XPANID) == '0x1020031510006016')
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)
 

--- a/tests/toranj/test-003-join.py
+++ b/tests/toranj/test-003-join.py
@@ -99,5 +99,7 @@ verify(node2.get(wpan.WPAN_STATE) == wpan.STATE_ASSOCIATED)
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)
 

--- a/tests/toranj/test-004-scan.py
+++ b/tests/toranj/test-004-scan.py
@@ -98,4 +98,6 @@ verify(nodes[0].is_in_scan_result(scan_result))
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-005-discover-scan.py
+++ b/tests/toranj/test-005-discover-scan.py
@@ -81,5 +81,7 @@ for node in nodes[1:]:
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)
 

--- a/tests/toranj/test-006-traffic-router-end-device.py
+++ b/tests/toranj/test-006-traffic-router-end-device.py
@@ -103,4 +103,6 @@ for src,dst in [ (ll1, ll2), (ll1, ml2), (ml1, ll2), (ml1, ml2) ]:
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-007-traffic-router-sleepy.py
+++ b/tests/toranj/test-007-traffic-router-sleepy.py
@@ -108,4 +108,6 @@ for poll_interval in [10, 100, 300]:
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-008-permit-join.py
+++ b/tests/toranj/test-008-permit-join.py
@@ -78,4 +78,6 @@ verify(node.get(wpan.WPAN_NETWORK_ALLOW_JOIN) == 'false')
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-009-insecure-traffic-join.py
+++ b/tests/toranj/test-009-insecure-traffic-join.py
@@ -119,4 +119,6 @@ verify(recver2.was_successful)
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-010-on-mesh-prefix-config-gateway.py
+++ b/tests/toranj/test-010-on-mesh-prefix-config-gateway.py
@@ -182,4 +182,6 @@ verify_prefix([r1], prefix4, 48, priority="low", stable=True, on_mesh=False, sla
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-011-child-table.py
+++ b/tests/toranj/test-011-child-table.py
@@ -94,4 +94,6 @@ for child in children:
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-012-multi-hop-traffic.py
+++ b/tests/toranj/test-012-multi-hop-traffic.py
@@ -168,4 +168,6 @@ for msg_length in MSG_LENS:
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-013-off-mesh-route-traffic.py
+++ b/tests/toranj/test-013-off-mesh-route-traffic.py
@@ -166,4 +166,6 @@ verify(recver.was_successful)
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-014-ip6-address-add.py
+++ b/tests/toranj/test-014-ip6-address-add.py
@@ -177,4 +177,6 @@ wpan.verify_within(check_address_prefix_removed, 15)
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-015-same-prefix-on-multiple-nodes.py
+++ b/tests/toranj/test-015-same-prefix-on-multiple-nodes.py
@@ -136,4 +136,6 @@ wpan.verify_within(check_prefix, 5)
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-016-neighbor-table.py
+++ b/tests/toranj/test-016-neighbor-table.py
@@ -146,4 +146,6 @@ for router in routers[1:]:
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-017-parent-reset-child-recovery.py
+++ b/tests/toranj/test-017-parent-reset-child-recovery.py
@@ -157,4 +157,6 @@ for i in range(len(all_children)):
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-100-mcu-power-state.py
+++ b/tests/toranj/test-100-mcu-power-state.py
@@ -208,4 +208,6 @@ verify(wpan_state == wpan.STATE_ASSOCIATED or wpan_state == wpan.STATE_ASSOCIATI
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-600-channel-manager-properties.py
+++ b/tests/toranj/test-600-channel-manager-properties.py
@@ -117,4 +117,6 @@ verify(int(node.get(wpan.WPAN_CHANNEL_MANAGER_DELAY), 0) == 180)
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-601-channel-manager-channel-change.py
+++ b/tests/toranj/test-601-channel-manager-channel-change.py
@@ -143,4 +143,6 @@ verify_channel(all_nodes, 18)
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-602-channel-manager-channel-select.py
+++ b/tests/toranj/test-602-channel-manager-channel-select.py
@@ -146,4 +146,6 @@ verify_channel([node], 12)
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/test-603-channel-manager-announce-recovery.py
+++ b/tests/toranj/test-603-channel-manager-announce-recovery.py
@@ -113,5 +113,7 @@ verify(int(c2.get(wpan.WPAN_CHANNEL), 0) == 26)
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)
 

--- a/tests/toranj/test-nnn-template.py
+++ b/tests/toranj/test-nnn-template.py
@@ -60,4 +60,6 @@ wpan.Node.init_all_nodes()
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished
 
+wpan.Node.finalize_all_nodes()
+
 print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -243,8 +243,10 @@ class Node(object):
         Node._all_nodes.add(self)
 
     def __del__(self):
-        self._wpantund_process.terminate()
-        self._tund_log_file.close()
+        self._wpantund_process.poll()
+        if self._wpantund_process.returncode is None:
+            self._wpantund_process.terminate()
+            self._wpantund_process.wait()
 
     def __repr__(self):
         return 'Node (index={}, interface_name={})'.format(self._index, self._interface_name)
@@ -509,6 +511,13 @@ class Node(object):
                 else:
                     break
                 time.sleep(0.4)
+
+    @classmethod
+    def finalize_all_nodes(cls):
+        """Finalizes all previously created `Node` instances (stops the wpantund process)"""
+        for node in Node._all_nodes:
+            node._wpantund_process.terminate()
+            node._wpantund_process.wait()
 
     @classmethod
     def set_time_speedup_factor(cls, factor):


### PR DESCRIPTION
This PR includes two commits:

**[toranj] add new method to finalize all nodes at end of each test**
The first commit adds a new method `finalize_all_nodes()` in `wpan.Node` class to finalize all previously created instances of `wpan.Node`. It terminates the associated `wpantund` process and waits. 

**[posix] handle signals SIGHUP or SIGTERM and exit**

----
The two changes together should help `toranj` test cases to be included in code coverage results. 