### PR TITLE
[mle-router] fix issue with child info being saved in non-volatile settings

### DIFF
--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -364,13 +364,13 @@ public:
     /**
      * This method store a child information into non-volatile memory.
      *
-     * @param[in]  aChildRloc16   The child RLOC16 to store.
+     * @param[in]  aChild          A reference to the child to store.
      *
      * @retval  OT_ERROR_NONE      Successfully store child.
      * @retval  OT_ERROR_NO_BUFS   Insufficient available buffers to store child.
      *
      */
-    otError StoreChild(uint16_t aChildRloc16);
+    otError StoreChild(const Child &aChild);
 
     /**
      * This method returns a pointer to a Neighbor object.

--- a/src/core/thread/mle_router_mtd.hpp
+++ b/src/core/thread/mle_router_mtd.hpp
@@ -90,7 +90,7 @@ public:
 
     void    RestoreChildren(void) {}
     otError RemoveStoredChild(uint16_t) { return OT_ERROR_NOT_IMPLEMENTED; }
-    otError StoreChild(uint16_t) { return OT_ERROR_NOT_IMPLEMENTED; }
+    otError StoreChild(const Child &) { return OT_ERROR_NOT_IMPLEMENTED; }
 
     Neighbor *GetNeighbor(uint16_t aAddress) { return Mle::GetNeighbor(aAddress); }
     Neighbor *GetNeighbor(const Mac::ExtAddress &aAddress) { return Mle::GetNeighbor(aAddress); }


### PR DESCRIPTION
This commit addresses an bug where the child info was not being
saved in non-volatile settings. It fixes the following cases in
the code where a child id was used to search for a child (using
`FindChild()`) instead of the RLOC16 address:

- `StoreChild()` is changed to accept a `const Child &` as input
  parameter avoiding the need to look up the child by ID or RLOC16.
- `SendChildIdResponse()` and `GetChildInfoById()` are updated to
  perform the search for a child using its RLOC16.