### PR TITLE
[ip6] ensure slaac addresses are added back after reset

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3492,6 +3492,8 @@ otError Mle::HandleChildUpdateResponse(const Message &aMessage, const Ip6::Messa
         mParent.SetState(Neighbor::kStateValid);
         SetStateChild(GetRloc16());
 
+        mRetrieveNewNetworkData = true;
+
         // fall through
 
     case OT_DEVICE_ROLE_CHILD:

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -115,6 +115,7 @@ void Slaac::UpdateAddresses(otInstance *    aInstance,
             if (otIp6PrefixMatch(&config.mPrefix.mPrefix, &address->mAddress) >= config.mPrefix.mLength &&
                 config.mPrefix.mLength == address->mPrefixLength)
             {
+                otIp6AddUnicastAddress(aInstance, address);
                 found = true;
                 break;
             }


### PR DESCRIPTION
This commit makes the following changes:

1. A child that is resynchronizing with its parent after reset always
   requests the network data to ensure that it has the latest version.

2. When autoconfiguring SLAAC addresses in response to a network data update
   always attempt to add the netif address buffer in case the netif
   structure was removed (e.g. due to reset).

Resolves #2932.