### PR TITLE
[tlv] remove unnecessary user-specified constructor

### DIFF
--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -57,16 +57,6 @@ class Tlv
 {
 public:
     /**
-     * Default constructor.
-     *
-     */
-    Tlv(void)
-        : mType(0)
-        , mLength(0)
-    {
-    }
-
-    /**
      * This method returns the Type value.
      *
      * @returns The Type value.


### PR DESCRIPTION
Reduces code size by 1616 bytes.

Before:
```
$ arm-none-eabi-size output/nrf52840/bin/ot-cli-ftd  
   text	   data	    bss	    dec	    hex	filename
 175688	    548	  37536	 213772	  3430c	output/nrf52840/bin/ot-cli-ftd
```

After:
```
$ arm-none-eabi-size output/nrf52840/bin/ot-cli-ftd 
   text	   data	    bss	    dec	    hex	filename
 174072	    548	  37536	 212156	  33cbc	output/nrf52840/bin/ot-cli-ftd
```