### PR TITLE
[link-quality] explicitly clear link quality for new child/router

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -195,12 +195,11 @@ Mac::Mac(Instance &aInstance)
     , mTxFrame(static_cast<Frame *>(otPlatRadioGetTransmitBuffer(&aInstance)))
     , mOobFrame(NULL)
     , mKeyIdMode2FrameCounter(0)
-    , mCcaSuccessRateTracker()
     , mCcaSampleCount(0)
     , mEnabled(true)
 {
     GenerateExtAddress(&mExtAddress);
-
+    mCcaSuccessRateTracker.Reset();
     memset(&mCounters, 0, sizeof(otMacCounters));
 
     otPlatRadioEnable(&GetInstance());

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -140,18 +140,16 @@ exit:
     return string;
 }
 
-LinkQualityInfo::LinkQualityInfo(void)
-    : mLastRss(OT_RADIO_RSSI_INVALID)
-{
-    mRssAverager.Reset();
-    SetLinkQuality(0);
-}
-
 void LinkQualityInfo::Clear(void)
 {
     mRssAverager.Reset();
     SetLinkQuality(0);
     mLastRss = OT_RADIO_RSSI_INVALID;
+
+#if OPENTHREAD_CONFIG_ENABLE_TX_ERROR_RATE_TRACKING
+    mFrameErrorRate.Reset();
+    mMessageErrorRate.Reset();
+#endif
 }
 
 void LinkQualityInfo::AddRss(int8_t aNoiseFloor, int8_t aRss)

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -68,17 +68,6 @@ public:
     };
 
     /**
-     * This constructor initializes a `SuccessRateTracker` instance.
-     *
-     * After initialization the tracker starts with success rate 100% (failure rate 0%).
-     *
-     */
-    SuccessRateTracker(void)
-        : mFailureRate(0)
-    {
-    }
-
-    /**
      * This method resets the tracker to its initialized state, setting success rate to 100%.
      *
      */
@@ -240,12 +229,6 @@ public:
      *
      */
     typedef String<kInfoStringSize> InfoString;
-
-    /**
-     * This constructor initializes the object.
-     *
-     */
-    LinkQualityInfo(void);
 
     /**
      * This method clears the all the data in the object.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3504,6 +3504,7 @@ void MleRouter::RestoreChildren(void)
         memset(child, 0, sizeof(*child));
 
         child->SetExtAddress(*static_cast<const Mac::ExtAddress *>(&childInfo.mExtAddress));
+        child->GetLinkInfo().Clear();
         child->SetRloc16(childInfo.mRloc16);
         child->SetTimeout(childInfo.mTimeout);
         child->SetDeviceMode(childInfo.mMode);

--- a/tests/unit/test_link_quality.cpp
+++ b/tests/unit/test_link_quality.cpp
@@ -93,6 +93,7 @@ void TestLinkQualityData(RssTestData aRssData)
     size_t          i;
 
     printf("- - - - - - - - - - - - - - - - - -\n");
+    linkInfo.Clear();
     min = kMinRssValue;
     max = kMaxRssValue;
 
@@ -386,6 +387,8 @@ void TestSuccessRateTracker(void)
     const uint16_t kWeightLimit[] = {64, 128, 256, 300, 512, 810, 900};
 
     printf("\nTesting SuccessRateTracker\n");
+
+    rateTracker.Reset();
 
     VerifyOrQuit(rateTracker.GetSuccessRate() == kMaxRate, "SuccessRateTracker: Initial value incorrect");
     VerifyOrQuit(rateTracker.GetFailureRate() == 0, "SuccessRateTracker: Initial value incorrect");


### PR DESCRIPTION
The child/router entries are generally cleared using `memset()` to avoid
explicitly setting all fields to zero.  As a result, it is necessary to
explicitly clear the link quality state to properly initialize the last
RSSI reading.  The user-specific constructors are also removed.