### PR TITLE
[ncp] include prop set support for THREAD_CHILD_TIMEOUT in MTD build

### DIFF
--- a/src/ncp/ncp_base_dispatcher.cpp
+++ b/src/ncp/ncp_base_dispatcher.cpp
@@ -703,6 +703,9 @@ NcpBase::PropertyHandler NcpBase::FindSetPropertyHandler(spinel_prop_key_t aKey)
     case SPINEL_PROP_IPV6_ICMP_PING_OFFLOAD_MODE:
         handler = &NcpBase::HandlePropertySet<SPINEL_PROP_IPV6_ICMP_PING_OFFLOAD_MODE>;
         break;
+    case SPINEL_PROP_THREAD_CHILD_TIMEOUT:
+        handler = &NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_CHILD_TIMEOUT>;
+        break;
     case SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU:
         handler = &NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU>;
         break;
@@ -776,9 +779,6 @@ NcpBase::PropertyHandler NcpBase::FindSetPropertyHandler(spinel_prop_key_t aKey)
 #if OPENTHREAD_FTD
     case SPINEL_PROP_NET_PSKC:
         handler = &NcpBase::HandlePropertySet<SPINEL_PROP_NET_PSKC>;
-        break;
-    case SPINEL_PROP_THREAD_CHILD_TIMEOUT:
-        handler = &NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_CHILD_TIMEOUT>;
         break;
     case SPINEL_PROP_THREAD_NETWORK_ID_TIMEOUT:
         handler = &NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_NETWORK_ID_TIMEOUT>;

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -468,19 +468,6 @@ exit:
 }
 #endif // #if OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
 
-template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_CHILD_TIMEOUT>(void)
-{
-    uint32_t timeout = 0;
-    otError  error   = OT_ERROR_NONE;
-
-    SuccessOrExit(error = mDecoder.ReadUint32(timeout));
-
-    otThreadSetChildTimeout(mInstance, timeout);
-
-exit:
-    return error;
-}
-
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_PREFERRED_ROUTER_ID>(void)
 {
     return mEncoder.WriteUint8(mPreferredRouteId);

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -2199,6 +2199,19 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_CHILD_TIMEOUT>
     return mEncoder.WriteUint32(otThreadGetChildTimeout(mInstance));
 }
 
+template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_CHILD_TIMEOUT>(void)
+{
+    uint32_t timeout = 0;
+    otError  error   = OT_ERROR_NONE;
+
+    SuccessOrExit(error = mDecoder.ReadUint32(timeout));
+
+    otThreadSetChildTimeout(mInstance, timeout);
+
+exit:
+    return error;
+}
+
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_RLOC16>(void)
 {
     return mEncoder.WriteUint16(otThreadGetRloc16(mInstance));


### PR DESCRIPTION
-----
Setting `SPINEL_PROP_THREAD_CHILD_TIMEOUT` property is (and should be) supported on MTD build.