### PR TITLE
[gcc8] resolve compiler errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,6 +142,16 @@ matrix:
           packages:
             - gcc-7
             - g++-7
+    - env: BUILD_TARGET="posix" CC="gcc-8" CXX="g++-8"
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-8
+            - g++-8
     - env: BUILD_TARGET="posix-ncp-spi" VERBOSE=1
       os: linux
       compiler: gcc

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -487,9 +487,7 @@ otError Dataset::AppendMleDatasetTlv(Message &aMessage) const
         else if (cur->GetType() == Tlv::kDelayTimer)
         {
             uint32_t      elapsed = TimerMilli::GetNow() - mUpdateTime;
-            DelayTimerTlv delayTimer;
-
-            memcpy(&delayTimer, cur, sizeof(delayTimer));
+            DelayTimerTlv delayTimer(static_cast<const DelayTimerTlv &>(*cur));
 
             if (delayTimer.GetDelayTimer() > elapsed)
             {

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -351,8 +351,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
 
         case NetworkDiagnosticTlv::kLeaderData:
         {
-            LeaderDataTlv tlv;
-            memcpy(&tlv, &netif.GetMle().GetLeaderDataTlv(), sizeof(tlv));
+            LeaderDataTlv tlv(reinterpret_cast<const LeaderDataTlv &>(netif.GetMle().GetLeaderDataTlv()));
             tlv.Init();
             SuccessOrExit(error = aResponse.Append(&tlv, tlv.GetSize()));
             break;


### PR DESCRIPTION
This commit resolves compiler errors generated by gcc8.

This commit also adds gcc8 build checks to travis.

Resolves #2931.