### PR TITLE
[platform] attach timestamp in promiscuous mode

### DIFF
--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -497,7 +497,7 @@ void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable)
     }
 }
 
-void readFrame(void)
+void readFrame(otInstance *aInstance)
 {
     uint8_t length;
     uint8_t crcCorr;
@@ -510,7 +510,7 @@ void readFrame(void)
     length = HWREG(RFCORE_SFR_RFDATA);
     otEXPECT(IEEE802154_MIN_LENGTH <= length && length <= IEEE802154_MAX_LENGTH);
 
-    if (otPlatRadioGetPromiscuous(NULL))
+    if (otPlatRadioGetPromiscuous(aInstance))
     {
         // Timestamp
         sReceiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
@@ -554,7 +554,7 @@ exit:
 
 void cc2538RadioProcess(otInstance *aInstance)
 {
-    readFrame();
+    readFrame(aInstance);
 
     if ((sState == OT_RADIO_STATE_RECEIVE && sReceiveFrame.mLength > 0) ||
         (sState == OT_RADIO_STATE_TRANSMIT && sReceiveFrame.mLength > IEEE802154_ACK_LENGTH))

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -510,11 +510,12 @@ void readFrame(void)
     length = HWREG(RFCORE_SFR_RFDATA);
     otEXPECT(IEEE802154_MIN_LENGTH <= length && length <= IEEE802154_MAX_LENGTH);
 
-#if OPENTHREAD_ENABLE_RAW_LINK_API
-    // Timestamp
-    sReceiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
-    sReceiveFrame.mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
-#endif
+    if (otPlatRadioGetPromiscuous(NULL))
+    {
+        // Timestamp
+        sReceiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
+        sReceiveFrame.mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
+    }
 
     // read psdu
     for (i = 0; i < length - 2; i++)

--- a/examples/platforms/cc2650/radio.c
+++ b/examples/platforms/cc2650/radio.c
@@ -1824,7 +1824,7 @@ static void cc2650RadioProcessReceiveQueue(otInstance *aInstance)
 
             if (crcCorr->status.bCrcErr == 0 && (len - 2) < OT_RADIO_FRAME_MAX_SIZE)
             {
-                if (otPlatRadioGetPromiscuous(NULL))
+                if (otPlatRadioGetPromiscuous(aInstance))
                 {
                     // TODO: Propagate CM0 timestamp
                     receiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();

--- a/examples/platforms/cc2650/radio.c
+++ b/examples/platforms/cc2650/radio.c
@@ -1824,11 +1824,12 @@ static void cc2650RadioProcessReceiveQueue(otInstance *aInstance)
 
             if (crcCorr->status.bCrcErr == 0 && (len - 2) < OT_RADIO_FRAME_MAX_SIZE)
             {
-#if OPENTHREAD_ENABLE_RAW_LINK_API
-                // TODO: Propagate CM0 timestamp
-                receiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
-                receiveFrame.mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
-#endif
+                if (otPlatRadioGetPromiscuous(NULL))
+                {
+                    // TODO: Propagate CM0 timestamp
+                    receiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
+                    receiveFrame.mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
+                }
 
                 receiveFrame.mLength             = len;
                 receiveFrame.mPsdu               = &(payload[1]);

--- a/examples/platforms/cc2652/radio.c
+++ b/examples/platforms/cc2652/radio.c
@@ -1860,7 +1860,7 @@ static void cc2652RadioProcessReceiveQueue(otInstance *aInstance)
 
             if (crcCorr->status.bCrcErr == 0 && (len - 2) < OT_RADIO_FRAME_MAX_SIZE)
             {
-                if (otPlatRadioGetPromiscuous(NULL))
+                if (otPlatRadioGetPromiscuous(aInstance))
                 {
                     // TODO: Propagate CM0 timestamp
                     receiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();

--- a/examples/platforms/cc2652/radio.c
+++ b/examples/platforms/cc2652/radio.c
@@ -1860,11 +1860,12 @@ static void cc2652RadioProcessReceiveQueue(otInstance *aInstance)
 
             if (crcCorr->status.bCrcErr == 0 && (len - 2) < OT_RADIO_FRAME_MAX_SIZE)
             {
-#if OPENTHREAD_ENABLE_RAW_LINK_API
-                // TODO: Propagate CM0 timestamp
-                receiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
-                receiveFrame.mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
-#endif
+                if (otPlatRadioGetPromiscuous(NULL))
+                {
+                    // TODO: Propagate CM0 timestamp
+                    receiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
+                    receiveFrame.mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
+                }
 
                 receiveFrame.mLength             = len;
                 receiveFrame.mPsdu               = &(payload[1]);

--- a/examples/platforms/da15000/radio.c
+++ b/examples/platforms/da15000/radio.c
@@ -587,11 +587,13 @@ void ftdf_rcv_frame_transparent(ftdf_data_length_t  frame_length,
     {
         radioRssiCalc(link_quality);
 
-#if OPENTHREAD_ENABLE_RAW_LINK_API
-        // Timestamp
-        sReceiveFrame[sWriteFrame].mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
-        sReceiveFrame[sWriteFrame].mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
-#endif
+        if (otPlatRadioGetPromiscuous(NULL))
+        {
+            // Timestamp
+            sReceiveFrame[sWriteFrame].mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
+            sReceiveFrame[sWriteFrame].mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
+        }
+
         sReceiveFrame[sWriteFrame].mChannel            = sChannel;
         sReceiveFrame[sWriteFrame].mLength             = frame_length;
         sReceiveFrame[sWriteFrame].mInfo.mRxInfo.mLqi  = OT_RADIO_LQI_NONE;

--- a/examples/platforms/da15000/radio.c
+++ b/examples/platforms/da15000/radio.c
@@ -140,7 +140,7 @@ void da15000RadioInit(void)
         sReceiveFrame[ptr].mPsdu = &sReceivePsdu[ptr][0];
     }
 
-    otLogInfoPlat(sInstance, "Radio initialized", NULL);
+    otLogInfoPlat(sThreadInstance, "Radio initialized", NULL);
 }
 
 void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeeeEui64)
@@ -587,7 +587,7 @@ void ftdf_rcv_frame_transparent(ftdf_data_length_t  frame_length,
     {
         radioRssiCalc(link_quality);
 
-        if (otPlatRadioGetPromiscuous(sInstance))
+        if (otPlatRadioGetPromiscuous(sThreadInstance))
         {
             // Timestamp
             sReceiveFrame[sWriteFrame].mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();

--- a/examples/platforms/da15000/radio.c
+++ b/examples/platforms/da15000/radio.c
@@ -587,7 +587,7 @@ void ftdf_rcv_frame_transparent(ftdf_data_length_t  frame_length,
     {
         radioRssiCalc(link_quality);
 
-        if (otPlatRadioGetPromiscuous(NULL))
+        if (otPlatRadioGetPromiscuous(sInstance))
         {
             // Timestamp
             sReceiveFrame[sWriteFrame].mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();

--- a/examples/platforms/emsk/radio.c
+++ b/examples/platforms/emsk/radio.c
@@ -462,11 +462,12 @@ void readFrame(void)
 
     otEXPECT_ACTION(IEEE802154_MIN_LENGTH <= length && length <= IEEE802154_MAX_LENGTH, ;);
 
-#if OPENTHREAD_ENABLE_RAW_LINK_API
-    // Timestamp
-    sReceiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
-    sReceiveFrame.mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
-#endif
+    if (otPlatRadioGetPromiscuous(NULL))
+    {
+        // Timestamp
+        sReceiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
+        sReceiveFrame.mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
+    }
 
     /* Read PSDU */
     memcpy(sReceiveFrame.mPsdu, readBuffer, length - 2);

--- a/examples/platforms/emsk/radio.c
+++ b/examples/platforms/emsk/radio.c
@@ -429,7 +429,7 @@ void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable)
     mrf24j40_set_promiscuous(~aEnable);
 }
 
-void readFrame(void)
+void readFrame(otInstance *aInstance)
 {
     /* readBuffer
      * 1 bit -- 5 to 127 bits -- 1 bit -- 1bit
@@ -462,7 +462,7 @@ void readFrame(void)
 
     otEXPECT_ACTION(IEEE802154_MIN_LENGTH <= length && length <= IEEE802154_MAX_LENGTH, ;);
 
-    if (otPlatRadioGetPromiscuous(NULL))
+    if (otPlatRadioGetPromiscuous(aInstance))
     {
         // Timestamp
         sReceiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
@@ -536,7 +536,7 @@ void emskRadioProcess(otInstance *aInstance)
 {
     numRadioProcess++;
 
-    readFrame();
+    readFrame(aInstance);
     uint8_t reg = mrf24j40_read_short_ctrl_reg(MRF24J40_TXSTAT);
 
     if (reg & MRF24J40_TXNSTAT)

--- a/examples/platforms/kw41z/radio.c
+++ b/examples/platforms/kw41z/radio.c
@@ -105,6 +105,7 @@ static uint8_t      sTxData[OT_RADIO_FRAME_MAX_SIZE];
 #if DOUBLE_BUFFERING
 static uint8_t sRxData[OT_RADIO_FRAME_MAX_SIZE];
 #endif
+static otInstance *sInstance = NULL;
 
 /* Private functions */
 static void         rf_abort(void);
@@ -182,6 +183,7 @@ otError otPlatRadioEnable(otInstance *aInstance)
 {
     otEXPECT(!otPlatRadioIsEnabled(aInstance));
 
+    sInstance = aInstance;
     ZLL->PHY_CTRL &= ~ZLL_PHY_CTRL_TRCV_MSK_MASK;
     NVIC_ClearPendingIRQ(Radio_1_IRQn);
     NVIC_EnableIRQ(Radio_1_IRQn);
@@ -749,7 +751,7 @@ static bool rf_process_rx_frame(void)
     /* Check if frame is valid */
     otEXPECT_ACTION((IEEE802154_MIN_LENGTH <= temp) && (temp <= IEEE802154_MAX_LENGTH), status = false);
 
-    if (otPlatRadioGetPromiscuous(NULL))
+    if (otPlatRadioGetPromiscuous(sInstance))
     {
         // Timestamp
         sRxFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();

--- a/examples/platforms/kw41z/radio.c
+++ b/examples/platforms/kw41z/radio.c
@@ -749,11 +749,12 @@ static bool rf_process_rx_frame(void)
     /* Check if frame is valid */
     otEXPECT_ACTION((IEEE802154_MIN_LENGTH <= temp) && (temp <= IEEE802154_MAX_LENGTH), status = false);
 
-#if OPENTHREAD_ENABLE_RAW_LINK_API
-    // Timestamp
-    sRxFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
-    sRxFrame.mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
-#endif
+    if (otPlatRadioGetPromiscuous(NULL))
+    {
+        // Timestamp
+        sRxFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
+        sRxFrame.mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
+    }
 
     sRxFrame.mLength = temp;
     temp             = (ZLL->LQI_AND_RSSI & ZLL_LQI_AND_RSSI_LQI_VALUE_MASK) >> ZLL_LQI_AND_RSSI_LQI_VALUE_SHIFT;

--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -82,8 +82,8 @@ static uint8_t      sTransmitPsdu[OT_RADIO_FRAME_MAX_SIZE + 1];
 #if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
 static otRadioIeInfo sTransmitIeInfo;
 static otRadioIeInfo sReceivedIeInfos[NRF_802154_RX_BUFFERS];
-static otInstance *  sInstance = NULL;
 #endif
+static otInstance *sInstance = NULL;
 
 static otRadioFrame sAckFrame;
 
@@ -258,7 +258,7 @@ otRadioState otPlatRadioGetState(otInstance *aInstance)
 
 otError otPlatRadioEnable(otInstance *aInstance)
 {
-    (void)aInstance;
+    sInstance = aInstance;
 
     otError error;
 
@@ -334,10 +334,6 @@ otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 
 otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
 {
-#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
-    sInstance = aInstance;
-#endif
-
     otError result = OT_ERROR_NONE;
 
     aFrame->mPsdu[-1] = aFrame->mLength;

--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -704,7 +704,7 @@ void nrf_802154_received_raw(uint8_t *p_data, int8_t power, uint8_t lqi)
     receivedFrame->mInfo.mRxInfo.mRssi = power;
     receivedFrame->mInfo.mRxInfo.mLqi  = lqi;
     receivedFrame->mChannel            = nrf_802154_channel_get();
-    if (otPlatRadioGetPromiscuous(NULL))
+    if (otPlatRadioGetPromiscuous(sInstance))
     {
         uint64_t timestamp                 = nrf5AlarmGetCurrentTime();
         receivedFrame->mInfo.mRxInfo.mMsec = timestamp / US_PER_MS;

--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -704,11 +704,12 @@ void nrf_802154_received_raw(uint8_t *p_data, int8_t power, uint8_t lqi)
     receivedFrame->mInfo.mRxInfo.mRssi = power;
     receivedFrame->mInfo.mRxInfo.mLqi  = lqi;
     receivedFrame->mChannel            = nrf_802154_channel_get();
-#if OPENTHREAD_ENABLE_RAW_LINK_API
-    uint64_t timestamp                 = nrf5AlarmGetCurrentTime();
-    receivedFrame->mInfo.mRxInfo.mMsec = timestamp / US_PER_MS;
-    receivedFrame->mInfo.mRxInfo.mUsec = timestamp - receivedFrame->mInfo.mRxInfo.mMsec * US_PER_MS;
-#endif
+    if (otPlatRadioGetPromiscuous(NULL))
+    {
+        uint64_t timestamp                 = nrf5AlarmGetCurrentTime();
+        receivedFrame->mInfo.mRxInfo.mMsec = timestamp / US_PER_MS;
+        receivedFrame->mInfo.mRxInfo.mUsec = timestamp - receivedFrame->mInfo.mRxInfo.mMsec * US_PER_MS;
+    }
 #if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
     // Get the timestamp when the SFD was received.
     uint32_t offset =

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -571,11 +571,12 @@ void radioReceive(otInstance *aInstance)
         exit(EXIT_FAILURE);
     }
 
-#if OPENTHREAD_ENABLE_RAW_LINK_API
-    // Timestamp
-    sReceiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
-    sReceiveFrame.mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
-#endif
+    if (otPlatRadioGetPromiscuous(NULL))
+    {
+        // Timestamp
+        sReceiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
+        sReceiveFrame.mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
+    }
 
 #if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
     sReceiveFrame.mIeInfo->mTimestamp = otPlatTimeGet();

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -571,7 +571,7 @@ void radioReceive(otInstance *aInstance)
         exit(EXIT_FAILURE);
     }
 
-    if (otPlatRadioGetPromiscuous(NULL))
+    if (otPlatRadioGetPromiscuous(aInstance))
     {
         // Timestamp
         sReceiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();

--- a/examples/platforms/posix/sim/radio-sim.c
+++ b/examples/platforms/posix/sim/radio-sim.c
@@ -475,7 +475,7 @@ void platformRadioReceive(otInstance *aInstance, uint8_t *aBuf, uint16_t aBufLen
 
     memcpy(&sReceiveMessage, aBuf, aBufLength);
 
-    if (otPlatRadioGetPromiscuous(NULL))
+    if (otPlatRadioGetPromiscuous(aInstance))
     {
         // Timestamp
         sReceiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();

--- a/examples/platforms/posix/sim/radio-sim.c
+++ b/examples/platforms/posix/sim/radio-sim.c
@@ -475,11 +475,12 @@ void platformRadioReceive(otInstance *aInstance, uint8_t *aBuf, uint16_t aBufLen
 
     memcpy(&sReceiveMessage, aBuf, aBufLength);
 
-#if OPENTHREAD_ENABLE_RAW_LINK_API
-    // Timestamp
-    sReceiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
-    sReceiveFrame.mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
-#endif
+    if (otPlatRadioGetPromiscuous(NULL))
+    {
+        // Timestamp
+        sReceiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
+        sReceiveFrame.mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
+    }
 
     sReceiveFrame.mLength = (uint8_t)(aBufLength - 1);
 

--- a/examples/platforms/samr21/radio.c
+++ b/examples/platforms/samr21/radio.c
@@ -214,7 +214,7 @@ static void handleRx(void)
     {
         sRxDone = false;
 
-        if (otPlatRadioGetPromiscuous(NULL))
+        if (otPlatRadioGetPromiscuous(sInstance))
         {
             // Timestamp
             sReceiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();

--- a/examples/platforms/samr21/radio.c
+++ b/examples/platforms/samr21/radio.c
@@ -214,11 +214,12 @@ static void handleRx(void)
     {
         sRxDone = false;
 
-#if OPENTHREAD_ENABLE_RAW_LINK_API
-        // Timestamp
-        sReceiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
-        sReceiveFrame.mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
-#endif
+        if (otPlatRadioGetPromiscuous(NULL))
+        {
+            // Timestamp
+            sReceiveFrame.mInfo.mRxInfo.mMsec = otPlatAlarmMilliGetNow();
+            sReceiveFrame.mInfo.mRxInfo.mUsec = 0; // Don't support microsecond timer for now.
+        }
 
 #if OPENTHREAD_ENABLE_DIAG
 


### PR DESCRIPTION
Sniffing using radio only mode firmware results in packets without timestamp information. This PR attaches timestamp info when in promiscuous mode.