### PR TITLE
[ble] Update GATT db registration api to use single call.

### DIFF
--- a/include/openthread/platform/ble.h
+++ b/include/openthread/platform/ble.h
@@ -199,6 +199,9 @@ enum
 
 };
 
+/// Convert the advertising interval from [ms] to [ble symbol times].
+#define OT_BLE_MS_TO_TICKS(x)  (((x) * 1000) / OT_BLE_ADV_INTERVAL_UNIT)
+
 /**
  * This enum represents BLE Device Address types.
  *
@@ -322,9 +325,10 @@ typedef struct otPlatBleGapConnParams
  *
  */
 typedef enum otPlatBleUuidType {
-    OT_BLE_UUID_TYPE_16  = 0, ///< UUID represented by 16-bit value.
-    OT_BLE_UUID_TYPE_32  = 1, ///< UUID represented by 32-bit value.
-    OT_BLE_UUID_TYPE_128 = 2, ///< UUID represented by 128-bit value.
+    OT_BLE_UUID_TYPE_NONE = 0, ///< UUID uninitialized value.
+    OT_BLE_UUID_TYPE_16   = 1, ///< UUID represented by 16-bit value.
+    OT_BLE_UUID_TYPE_32   = 2, ///< UUID represented by 32-bit value.
+    OT_BLE_UUID_TYPE_128  = 3, ///< UUID represented by 128-bit value.
 } otPlatBleUuidType;
 
 /**
@@ -369,6 +373,25 @@ typedef struct otPlatBleGattDescriptor
     otPlatBleUuid mUuid;   ///< A UUID value of descriptor.
     uint16_t      mHandle; ///< Descriptor handle.
 } otPlatBleGattDescriptor;
+
+/**
+ * Registration descriptor for a GATT service.
+ *
+ */
+typedef struct otPlatBleGattService
+{
+    /**
+     * Pointer to service UUID; use BLE_UUIDxx_DECLARE macros to declare
+     * proper UUID; NULL if there are no more characteristics in the service.
+     */
+    const otPlatBleUuid mUuid;
+
+    /**
+     * Array of characteristic definitions corresponding to characteristics
+     * belonging to this service.
+     */
+    otPlatBleGattCharacteristic *mCharacteristics;
+} otPlatBleGattService;
 
 /**
  * This structure represents an BLE packet.
@@ -956,6 +979,26 @@ extern void otPlatBleGattClientOnMtuExchangeResponse(otInstance *aInstance, uint
 otError otPlatBleGattServerServiceRegister(otInstance *aInstance, const otPlatBleUuid *aUuid, uint16_t *aHandle);
 
 /**
+ * Registers a list of GATT Services and their enclosed Characteristics.
+ * The generated handles will be written back into this structure when the
+ * BLE stack is enabled.
+ *
+ * @note This function shall be used only for GATT Server.
+ *
+ * @param[in]   aInstance  The OpenThread instance structure.
+ * @param[in]   aServices  Null terminated array of service structures to register.
+ * @param[out]  aHandle    The start handle of a service.
+ *
+ * @retval ::OT_ERROR_NONE           Service has been successfully registered.
+ * @retval ::OT_ERROR_INVALID_STATE  BLE Device is in invalid state.
+ * @retval ::OT_ERROR_INVALID_ARGS   Invalid service UUID has been provided.
+ * @retval ::OT_ERROR_NO_BUFS        No available internal buffer found.
+ */
+otError otPlatBleGattServerServicesRegister(otInstance *          aInstance, 
+                                            otPlatBleGattService *aServices, 
+                                            uint16_t *            aHandle);
+
+/**
  * Registers GATT Characteristic with maximum length of 128 octets.
  *
  * @note This function shall be used only for GATT Server.
@@ -1019,6 +1062,19 @@ extern void otPlatBleGattServerOnIndicationConfirmation(otInstance *aInstance, u
  *
  */
 extern void otPlatBleGattServerOnWriteRequest(otInstance *aInstance, uint16_t aHandle, otBleRadioPacket *aPacket);
+
+/**
+ * The BLE driver calls this method to notify OpenThread that an ATT Read Request
+ * packet has been received.
+ *
+ * @note This function shall be used only for GATT Server.
+ *
+ * @param[in] aInstance   The OpenThread instance structure.
+ * @param[in] aHandle     The handle of the attribute to be read.
+ * @param[out] aPacket    A pointer to the packet to be filled with pointers to attribute data to be read.
+ *
+ */
+extern void otPlatBleGattServerOnReadRequest(otInstance *aInstance, uint16_t aHandle, otBleRadioPacket *aPacket);
 
 /**
  * The BLE driver calls this method to notify OpenThread that an ATT Subscription

--- a/include/openthread/platform/ble.h
+++ b/include/openthread/platform/ble.h
@@ -383,13 +383,14 @@ typedef struct otPlatBleGattService
 {
     /**
      * Pointer to service UUID; use BLE_UUIDxx_DECLARE macros to declare
-     * proper UUID; NULL if there are no more characteristics in the service.
+     * proper UUID; OT_BLE_UUID_TYPE_NONE if there are no more characteristics
+     * in the service.
      */
     const otPlatBleUuid mUuid;
 
     /**
-     * Array of characteristic definitions corresponding to characteristics
-     * belonging to this service.
+     * Null-terminated list of characteristic definitions corresponding to
+     * characteristics belonging to this service.
      */
     otPlatBleGattCharacteristic *mCharacteristics;
 } otPlatBleGattService;

--- a/include/openthread/platform/ble.h
+++ b/include/openthread/platform/ble.h
@@ -200,7 +200,7 @@ enum
 };
 
 /// Convert the advertising interval from [ms] to [ble symbol times].
-#define OT_BLE_MS_TO_TICKS(x)  (((x) * 1000) / OT_BLE_ADV_INTERVAL_UNIT)
+#define OT_BLE_MS_TO_TICKS(x) (((x)*1000) / OT_BLE_ADV_INTERVAL_UNIT)
 
 /**
  * This enum represents BLE Device Address types.
@@ -994,9 +994,7 @@ otError otPlatBleGattServerServiceRegister(otInstance *aInstance, const otPlatBl
  * @retval ::OT_ERROR_INVALID_ARGS   Invalid service UUID has been provided.
  * @retval ::OT_ERROR_NO_BUFS        No available internal buffer found.
  */
-otError otPlatBleGattServerServicesRegister(otInstance *          aInstance, 
-                                            otPlatBleGattService *aServices, 
-                                            uint16_t *            aHandle);
+otError otPlatBleGattServerServicesRegister(otInstance *aInstance, otPlatBleGattService *aServices, uint16_t *aHandle);
 
 /**
  * Registers GATT Characteristic with maximum length of 128 octets.

--- a/include/openthread/platform/ble.h
+++ b/include/openthread/platform/ble.h
@@ -389,6 +389,12 @@ typedef struct otPlatBleGattService
     const otPlatBleUuid mUuid;
 
     /**
+     * Handle of service; written to by stack after call to
+     * otPlatBleGattServerServicesRegister.
+     */
+    uint16_t mHandle;
+
+    /**
      * Null-terminated list of characteristic definitions corresponding to
      * characteristics belonging to this service.
      */
@@ -974,14 +980,13 @@ extern void otPlatBleGattClientOnMtuExchangeResponse(otInstance *aInstance, uint
  *
  * @param[in]   aInstance  The OpenThread instance structure.
  * @param[in]   aServices  Null-terminated array of service structures to register.
- * @param[out]  aHandle    The start handle of a service.
  *
  * @retval ::OT_ERROR_NONE           Service has been successfully registered.
  * @retval ::OT_ERROR_INVALID_STATE  BLE Device is in invalid state.
  * @retval ::OT_ERROR_INVALID_ARGS   Invalid service UUID has been provided.
  * @retval ::OT_ERROR_NO_BUFS        No available internal buffer found.
  */
-otError otPlatBleGattServerServicesRegister(otInstance *aInstance, otPlatBleGattService *aServices, uint16_t *aHandle);
+otError otPlatBleGattServerServicesRegister(otInstance *aInstance, otPlatBleGattService *aServices);
 
 /**
  * Sends ATT Handle Value Indication.

--- a/include/openthread/platform/ble.h
+++ b/include/openthread/platform/ble.h
@@ -481,7 +481,7 @@ otError otPlatBleGapAddressSet(otInstance *aInstance, const otPlatBleDeviceAddr 
  * those characteristics.
  *
  * @param[in] aInstance    The OpenThread instance structure.
- * @param[in] aDeviceName  A pointer to device name string (null terminated).
+ * @param[in] aDeviceName  A pointer to device name string (null-terminated).
  *                         Shall not exceed OT_BLE_DEV_NAME_MAX_LENGTH.
  * @param[in] aAppearance  The value of appearance characteristic.
  *
@@ -973,7 +973,7 @@ extern void otPlatBleGattClientOnMtuExchangeResponse(otInstance *aInstance, uint
  * @note This function shall be used only for GATT Server.
  *
  * @param[in]   aInstance  The OpenThread instance structure.
- * @param[in]   aServices  Null terminated array of service structures to register.
+ * @param[in]   aServices  Null-terminated array of service structures to register.
  * @param[out]  aHandle    The start handle of a service.
  *
  * @retval ::OT_ERROR_NONE           Service has been successfully registered.

--- a/include/openthread/platform/ble.h
+++ b/include/openthread/platform/ble.h
@@ -43,6 +43,7 @@ extern "C" {
 #include <stdint.h>
 
 #include <openthread/error.h>
+#include <openthread/instance.h>
 
 /**
  * @addtogroup plat-ble


### PR DESCRIPTION
Update the Bluetooth API for registration of all GATT services using a single call.

Here is an example service using the new API:

```
/**
 * Characteristic C1 UUID: 18EE2EF5-263D-4559-959F-4F9C429F9D11
 */
uint8_t sBtpUuidC1[] = {
    0x11, 0x9D, 0x9F, 0x42, 0x9C, 0x4F, 0x9F, 0x95,
    0x59, 0x45, 0x3D, 0x26, 0xF5, 0x2E, 0xEE, 0x18
};

/**
 * Characteristic C2 UUID: 18EE2EF5-263D-4559-959F-4F9C429F9D12
 */
uint8_t sBtpUuidC2[] = {
    0x12, 0x9D, 0x9F, 0x42, 0x9C, 0x4F, 0x9F, 0x95,
    0x59, 0x45, 0x3D, 0x26, 0xF5, 0x2E, 0xEE, 0x18
};

otPlatBleGattService sBtpServices[] =
{ 
  {
    .mUuid = {
        .mType = OT_BLE_UUID_TYPE_16,
        .mValue.mUuid16 = 0xFEAF
    },
    .mCharacteristics = (otPlatBleGattCharacteristic[]) { {
        .mUuid = {
            .mType = OT_BLE_UUID_TYPE_128,
            .mValue.mUuid128 = sBtpUuidC1
        },
        .mProperties = OT_BLE_CHAR_PROP_WRITE
    }, {
        .mUuid = {
            .mType = OT_BLE_UUID_TYPE_128,
            .mValue.mUuid128 = sBtpUuidC2
        },
        .mProperties = OT_BLE_CHAR_PROP_READ | OT_BLE_CHAR_PROP_INDICATE
    }, {
      {0}  /* No more characteristics in this service */
    }, }
  }, {
    {0} /* No more services. */
  }
};
```