### PR TITLE
[tools] add bash script git-squash-merge

### DIFF
--- a/tools/gerrit/README.md
+++ b/tools/gerrit/README.md
@@ -1,0 +1,67 @@
+git-squash-merge tool
+================
+
+`git-squash-merge` is a bash script to help squash merge a given branch
+into the current branch. This tool is helpful for synchronizing
+git repositories which work with `gerrit`.
+
+This command squash merges all commits from a given branch into the current branch.
+By default the changes are committed with a commit message containing the list
+of all squashed commits.
+
+## Syntax ##
+
+```
+git-squash-merge [--no-list] [--no-commit] <branch> [<commit msg>]"
+```
+
+## Parameters ##
+*  `<branch>` specifies the name of branch to merge into current branch.
+*  `<commit msg>` is an optional parameter specifying text to add to the commit message.
+
+## Options ##
+* `--no-list` when used the commit message will not include the list of squashed commits.
+* `--no-commit` when used, the tool squashes and stages the changes but does not commit"
+
+## Example of Use ##
+
+```
+~/sw/openthread $ ./tools/gerrit/git-squash-merge.sh github/master "OpenThread GitHub sync"
+commit 977287e73a3fcae297306b1e68da50d4bbee0d14 (HEAD)
+Author: Abtin Keshavarzian <abtink@google.com>
+Date:   Tue Aug 14 14:53:33 2018 -0700
+
+    Squash merge 'github/master' into 'HEAD'
+
+    OpenThread GitHub sync
+
+    3acd900bd [message] update comment/documentation (#2903)
+    2aa335144 [mle] fix logging at NOTE level (#2933)
+    a9932027f [toranj] test case for adding IPv6 addresses with same prefix on multiple nodes (#2915)
+    c097cd2d3 [mle] remove unused LeaderDataTlv from HandleChildUpdateRequest (#2936)
+    7be61df6e [message-info] remove unnecessary memset initialization (#2937)
+    bcfa7edff [ip6] ensure slaac addresses are added back after reset (#2938)
+    412f9740b [tlv] remove unnecessary user-specified constructor (#2940)
+    ba4b238a0 [link-quality] explicitly clear link quality for new child/router (#2941)
+    601b99b39 [android] use spi instead of uart (#2942)
+    d67c4e2f6 [ncp] include prop set support for THREAD_CHILD_TIMEOUT in MTD build (#2943)
+    44e583a55 [toranj] add new method to finalize all nodes at end of each test (#2930)
+    c551e3035 [posix] handle signals SIGHUP or SIGTERM and exit (#2930)
+    1ca81fbb1 [ncp] add support for child supervision in spinel/NcpBase (#2939)
+    f0bb0982e [examples] change example platform namespacing (#2927)
+    f089fc8e2 [gcc8] resolve compiler errors (#2944)
+    a9d32b7be [ncp] add support for Commissioner APIs in spinel and NCP (#2911)
+    8efb3c50e [meshcop] implement commissioning UDP proxy (#2926)
+    492f0c3b1 [harness-automation] update read method for TopologyConfig.txt format change (#2950)
+    e181f1f98 [posix-app] fix diag issues of radio only mode (#2948)
+    90ee0a4d6 [ncp] add joiner spinel support (#2877)
+    9d585edc4 [types] move types into specific headers (#2946)
+    101e24337 [nrf52840] fix default parameters of FEM (#2945)
+    c8d06c402 [efr32] fix em_system.h include (#2956)
+    d2e59fd64 [posix-app] fix getting tx power (#2957)
+    0c07c53ce [platform] attach timestamp in promiscuous mode (#2954)
+
+    Change-Id: I2fd7b537fc1e0251082f091cb897b9ac25e105dd
+
+Successfully squash merged branch 'github/master' into 'HEAD'
+```

--- a/tools/gerrit/git-squash-merge.sh
+++ b/tools/gerrit/git-squash-merge.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+#
+#  Copyright (c) 2018, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+die() {
+    echo " *** ERROR: " $*
+    exit 1
+}
+
+display_usage ()
+{
+    echo "Squash merge a given branch into the current branch"
+    echo ""
+    echo "This command squash merges all commits from a given branch into the current branch"
+    echo "By default, the changes are committed with a commit message which includes the list of all squashed commits"
+    echo "(use --no-commit and --no-list options to change default behavior)."
+    echo ""
+    echo "Usage: $(basename $0) [--no-list] [--no-commit] <branch> [<commit msg>]"
+    echo ""
+    echo "     <branch>       Specifies the name of branch to merge into current branch"
+    echo "     <commit msg>   An optional parameter specifying text to add to the commit message"
+    echo "Options:"
+    echo "     --no-list      The commit message will not include the list of squashed commits"
+    echo "     --no-commit    Squash and stage the changes but do not commit "
+    echo ""
+}
+
+SHOULD_ADD_LIST=true
+SHOULD_COMMIT=true
+
+while test $# != 0
+do
+    case "$1" in
+    --help|-h|-[?])
+        display_usage
+        exit 0
+        ;;
+
+    --no-list)
+        SHOULD_ADD_LIST=false
+        ;;
+    --no-commit)
+        SHOULD_COMMIT=false
+        ;;
+    --debug) set -x ;;
+    --*) die "Unknown argument $1" ;;
+    --)
+        shift
+        break
+        ;;
+    -*) die "Unknown argument $1" ;;
+    *)
+        break
+        ;;
+    esac
+    shift
+done
+
+if [ "$#" -eq 0 ]
+then
+    display_usage
+    die "No branch name"
+fi
+
+if [ "$#" -gt 2 ]
+then
+    display_usage
+    die "Extra argument"
+fi
+
+NEWLINE=$'\n'
+
+branch="$1"
+cur_branch=$(git rev-parse --abbrev-ref HEAD)
+
+# Get the list of commits (diff between current and new branch)
+# Note that the list starts with older commits
+
+if ${SHOULD_ADD_LIST}
+then
+    commit_list=$(git log HEAD..$branch --oneline --decorate=no --reverse)
+else
+    commit_list=""
+fi
+
+commit_msg_header="Squash merge '$branch' into '$cur_branch'"
+
+if [ -z "$2" ]; then
+    commit_msg="${commit_msg_header}${NEWLINE}${NEWLINE}${commit_list}"
+else
+    commit_msg="${commit_msg_header}${NEWLINE}${NEWLINE}$2${NEWLINE}${NEWLINE}${commit_list}"
+fi
+
+git merge --squash $branch  1> /dev/null 2> /dev/null || die "Failed to perform 'git merge -squash $branch'"
+
+# Check if there is anything staged
+git diff --cached --quiet
+if [ $? -eq 0 ]; then
+    echo "No changes to commit when squash merging branch '$branch' into '$cur_branch'"
+    exit 0
+fi
+
+if ${SHOULD_COMMIT}
+then
+    # Commit the staged changes
+    git commit -m "$commit_msg" 1> /dev/null 2> /dev/null || die "git commit failed${NEWLINE}${NEWLINE}$(cat $TMP)"
+
+    git log -1
+
+    echo "${NEWLINE}Successfully squash merged branch '$branch' into '$cur_branch'"
+else
+    echo "Successfully prepared squash merge of branch '$branch' into '$cur_branch' - ready to commit"
+fi
+


### PR DESCRIPTION
This commit adds a new script `git-squash-merg` which can help with
performing squash merge of a branch into another. The commit message
includes the list of squashed commits. This script is helpful for
synchronization of git repositories that work with gerrit.