### PR TITLE
[toranj] reduce number of routers/children in test-016-neighbor-table

### DIFF
--- a/tests/toranj/test-016-neighbor-table.py
+++ b/tests/toranj/test-016-neighbor-table.py
@@ -33,8 +33,8 @@ from wpan import verify
 #-----------------------------------------------------------------------------------------------------------------------
 # Test description: Neighbor table
 #
-# - Network with NUM_ROUTERS(= 5) routers, all within range of each other.
-# - The first router has NUM_CHILDREN(= 4) sleepy children attached to it.
+# - Network with NUM_ROUTERS(= 2) routers, all within range of each other.
+# - The first router has NUM_CHILDREN(= 1) sleepy children attached to it.
 # - The test verifies that all children and routers are observed in the "Thread:NeighborTable" of the first router.
 #
 
@@ -48,8 +48,8 @@ print 'Starting \'{}\''.format(test_name)
 speedup = 4
 wpan.Node.set_time_speedup_factor(speedup)
 
-NUM_ROUTERS = 5
-NUM_CHILDREN = 4
+NUM_ROUTERS = 2
+NUM_CHILDREN = 1
 
 routers = []
 for num in range(NUM_ROUTERS):


### PR DESCRIPTION
---

Reason for this change: Noticed occasional travis CI `toranj` test failures which seem to be due to large number of `wpantund` instances running in parallel . This change should help make such failures less frequent. 