### PR TITLE
[toranj] update form/join tests to cover new wpanctl capabilities

### DIFF
--- a/tests/toranj/test-002-form.py
+++ b/tests/toranj/test-002-form.py
@@ -40,6 +40,9 @@ print 'Starting \'{}\''.format(test_name)
 #-----------------------------------------------------------------------------------------------------------------------
 # Creating `wpan.Nodes` instances
 
+speedup = 4
+wpan.Node.set_time_speedup_factor(speedup)
+
 node = wpan.Node()
 
 #-----------------------------------------------------------------------------------------------------------------------
@@ -89,7 +92,7 @@ verify(node.get(wpan.WPAN_XPANID) != DEFAULT_XPANID)
 node.leave()
 verify(node.get(wpan.WPAN_STATE) == wpan.STATE_OFFLINE)
 
-# Form a network with a specific panid, xpanid and key.
+# Form a network with a specific panid, xpanid and key specified separately
 
 node.set(wpan.WPAN_PANID, '0x1977')
 node.set(wpan.WPAN_XPANID, '1020031510006016', binary_data=True)
@@ -103,6 +106,23 @@ verify(node.get(wpan.WPAN_KEY) == '[0123456789ABCDEFFECDBA9876543210]')
 verify(node.get(wpan.WPAN_PANID) == '0x1977')
 verify(node.get(wpan.WPAN_XPANID) == '0x1020031510006016')
 
+node.leave()
+verify(node.get(wpan.WPAN_STATE) == wpan.STATE_OFFLINE)
+
+# Form a network with all parameters given as part of `form` command itself
+
+node.form('vahman', channel_mask='15,20-24', panid='0x1977', xpanid='1020031510006016',
+	key='0123456789abcdeffecdba9876543210', key_index='1', mesh_local_prefix='fd00:cafe::')
+
+verify(node.get(wpan.WPAN_STATE) == wpan.STATE_ASSOCIATED)
+verify(node.get(wpan.WPAN_NAME) == '"vahman"')
+channel = int(node.get(wpan.WPAN_CHANNEL), 0)
+verify(channel == 15 or (20 <= channel <= 24))
+verify(node.get(wpan.WPAN_KEY) == '[0123456789ABCDEFFECDBA9876543210]')
+verify(node.get(wpan.WPAN_KEY_INDEX) == '1')
+verify(node.get(wpan.WPAN_PANID) == '0x1977')
+verify(node.get(wpan.WPAN_XPANID) == '0x1020031510006016')
+verify(node.get(wpan.WPAN_IP6_MESH_LOCAL_PREFIX) == '"fd00:cafe::/64"')
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished

--- a/tests/toranj/test-003-join.py
+++ b/tests/toranj/test-003-join.py
@@ -40,6 +40,9 @@ print 'Starting \'{}\''.format(test_name)
 #-----------------------------------------------------------------------------------------------------------------------
 # Creating `wpan.Nodes` instances
 
+speedup = 4
+wpan.Node.set_time_speedup_factor(speedup)
+
 node1 = wpan.Node()
 node2 = wpan.Node()
 

--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -45,6 +45,7 @@ WPAN_NAME                                      = 'Network:Name'
 WPAN_PANID                                     = 'Network:PANID'
 WPAN_XPANID                                    = 'Network:XPANID'
 WPAN_KEY                                       = 'Network:Key'
+WPAN_KEY_INDEX                                 = 'Network:KeyIndex'
 WPAN_CHANNEL                                   = 'NCP:Channel'
 WPAN_HW_ADDRESS                                = 'NCP:HardwareAddress'
 WPAN_EXT_ADDRESS                               = 'NCP:ExtendedAddress'
@@ -319,17 +320,28 @@ class Node(object):
     def leave(self):
         return self.wpanctl('leave')
 
-    def form(self, name, channel=None, node_type=None):
+    def form(self, name, channel=None, channel_mask=None, panid=None, xpanid=None, key=None, key_index=None,
+            node_type=None, mesh_local_prefix=None, legacy_prefix=None):
         return self.wpanctl('form \"' + name + '\"' +
                             (' -c {}'.format(channel) if channel is not None else '') +
-                            (' -T {}'.format(node_type) if node_type is not None else ''))
+                            (' -m {}'.format(channel_mask) if channel_mask is not None else '') +
+                            (' -p {}'.format(panid) if panid is not None else '') +
+                            (' -x {}'.format(xpanid) if xpanid is not None else '') +
+                            (' -k {}'.format(key) if key is not None else '') +
+                            (' -i {}'.format(key_index) if key_index is not None else '') +
+                            (' -T {}'.format(node_type) if node_type is not None else '') +
+                            (' -M {}'.format(mesh_local_prefix) if mesh_local_prefix is not None else '') +
+                            (' -L {}'.format(legacy_prefix) if legacy_prefix is not None else ''))
 
-    def join(self, name, channel=None, node_type=None, panid=None, xpanid=None):
+
+    def join(self, name, channel=None, node_type=None, panid=None, xpanid=None, key=None):
         return self.wpanctl('join \"' + name + '\"' +
                             (' -c {}'.format(channel) if channel is not None else '') +
                             (' -T {}'.format(node_type) if node_type is not None else '') +
                             (' -p {}'.format(panid) if panid is not None else '') +
-                            (' -x {}'.format(xpanid) if xpanid is not None else ''))
+                            (' -x {}'.format(xpanid) if xpanid is not None else '') +
+                            (' -k {}'.format(key) if key is not None else '') +
+                            (' -n'))
 
     def active_scan(self, channel=None):
         return self.wpanctl('scan' +
@@ -409,16 +421,13 @@ class Node(object):
         if not node.is_associated():
             return "{} is not associated".format(node)
 
-        name = node.get(WPAN_NAME)
-        panid = node.get(WPAN_PANID)
-        xpanid = node.get(WPAN_XPANID)
-        channel = node.get(WPAN_CHANNEL)
-
-        if should_set_key:
-            netkey = node.get(WPAN_KEY)
-            self.set(WPAN_KEY, netkey[1:-1], binary_data=True)
-
-        return self.join(name[1:-1], channel=channel, node_type=node_type, panid=panid, xpanid=xpanid)
+        return self.join(
+            node.get(WPAN_NAME)[1:-1],
+            channel=node.get(WPAN_CHANNEL),
+            node_type=node_type,
+            panid=node.get(WPAN_PANID),
+            xpanid=node.get(WPAN_XPANID),
+            key=node.get(WPAN_KEY)[1:-1] if should_set_key else None)
 
     def whitelist_node(self, node):
         """Adds a given node (of type `Node`) to the whitelist of `self` and enables whitelisting on `self`"""


### PR DESCRIPTION
This commit updates the `toranj` tests related to forming/joining
a network to cover newly added capabilities to wpanctl `form`/`join`
commands (allowing all parameters to be given as part of the
command itself).

--------

PR  in wpantund adding new capability to `form` and `join` commands: https://github.com/openthread/wpantund/pull/340  (merged)