### PR TITLE
[posix] make posix settings path configurable

### DIFF
--- a/examples/platforms/posix/flash.c
+++ b/examples/platforms/posix/flash.c
@@ -53,16 +53,17 @@ enum
 otError utilsFlashInit(void)
 {
     otError     error = OT_ERROR_NONE;
-    char        fileName[20];
+    const char *path  = OPENTHREAD_CONFIG_POSIX_SETTINGS_PATH;
+    char        fileName[sizeof(OPENTHREAD_CONFIG_POSIX_SETTINGS_PATH) + 32];
     struct stat st;
     bool        create = false;
     const char *offset = getenv("PORT_OFFSET");
 
     memset(&st, 0, sizeof(st));
 
-    if (stat("tmp", &st) == -1)
+    if (stat(path, &st) == -1)
     {
-        mkdir("tmp", 0777);
+        mkdir(path, 0777);
     }
 
     if (offset == NULL)
@@ -70,7 +71,7 @@ otError utilsFlashInit(void)
         offset = "0";
     }
 
-    snprintf(fileName, sizeof(fileName), "tmp/%s_%d.flash", offset, NODE_ID);
+    snprintf(fileName, sizeof(fileName), "%s/%s_%d.flash", path, offset, NODE_ID);
 
     if (access(fileName, 0))
     {

--- a/include/openthread-config-android.h
+++ b/include/openthread-config-android.h
@@ -272,3 +272,6 @@
 /* Define to the type of an unsigned integer type of width exactly 8 bits if
    such a type exists and the standard includes do not define it. */
 /* #undef uint8_t */
+
+/* The settings storage path on android. */
+#define OPENTHREAD_CONFIG_POSIX_SETTINGS_PATH "/data/thread"

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -1766,4 +1766,14 @@
 #define OPENTHREAD_CONFIG_ENABLE_LONG_ROUTES 0
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_POSIX_SETTINGS_PATH
+ *
+ * The settings storage path on posix platform.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_POSIX_SETTINGS_PATH
+#define OPENTHREAD_CONFIG_POSIX_SETTINGS_PATH "tmp"
+#endif
+
 #endif // OPENTHREAD_CORE_DEFAULT_CONFIG_H_

--- a/src/posix/platform/flash.c
+++ b/src/posix/platform/flash.c
@@ -54,7 +54,8 @@ enum
 otError utilsFlashInit(void)
 {
     otError     error = OT_ERROR_NONE;
-    char        fileName[32];
+    const char *path  = OPENTHREAD_CONFIG_POSIX_SETTINGS_PATH;
+    char        fileName[sizeof(OPENTHREAD_CONFIG_POSIX_SETTINGS_PATH) + 32];
     struct stat st;
     bool        create = false;
     const char *offset = getenv("PORT_OFFSET");
@@ -62,9 +63,9 @@ otError utilsFlashInit(void)
 
     memset(&st, 0, sizeof(st));
 
-    if (stat("tmp", &st) == -1)
+    if (stat(path, &st) == -1)
     {
-        mkdir("tmp", 0777);
+        mkdir(path, 0777);
     }
 
     if (offset == NULL)
@@ -72,7 +73,7 @@ otError utilsFlashInit(void)
         offset = "0";
     }
 
-    snprintf(fileName, sizeof(fileName), "tmp/%s_%" PRIx64 ".flash", offset, NODE_ID);
+    snprintf(fileName, sizeof(fileName), "%s/%s_%" PRIx64 ".flash", path, offset, NODE_ID);
 
     if (access(fileName, 0))
     {


### PR DESCRIPTION
configure settings path on andriod to "/data/thread" as default, which will persist after reboot.