### PR TITLE
[ncp] remove diags module from radio only ncp

### DIFF
--- a/examples/apps/ncp/Makefile.am
+++ b/examples/apps/ncp/Makefile.am
@@ -54,6 +54,9 @@ SOURCES_COMMON                                                        += \
 LDADD_MBEDTLS                                                          = \
     $(NULL)
 
+LDADD_DIAG                                                             = \
+    $(NULL)
+
 if OPENTHREAD_ENABLE_BUILTIN_MBEDTLS
 LDADD_MBEDTLS                                                         += \
     $(top_builddir)/third_party/mbedtls/libmbedcrypto.a                  \
@@ -61,7 +64,7 @@ LDADD_MBEDTLS                                                         += \
 endif # OPENTHREAD_ENABLE_BUILTIN_MBEDTLS
 
 if OPENTHREAD_ENABLE_DIAG
-LDADD_COMMON                                                          += \
+LDADD_DIAG                                                            += \
     $(top_builddir)/src/diag/libopenthread-diag.a                        \
     $(NULL)
 endif
@@ -87,9 +90,11 @@ ot_ncp_ftd_LDADD                                                       = \
     $(top_builddir)/src/core/libopenthread-ftd.a                         \
     $(LDADD_COMMON)                                                      \
     $(LDADD_MBEDTLS)                                                     \
+    $(LDADD_DIAG)                                                        \
     $(top_builddir)/src/core/libopenthread-ftd.a                         \
     $(LDADD_COMMON)                                                      \
     $(LDADD_MBEDTLS)                                                     \
+    $(LDADD_DIAG)                                                        \
     $(NULL)
 
 ot_ncp_ftd_LDFLAGS                                                     = \
@@ -119,9 +124,11 @@ ot_ncp_mtd_LDADD                                                       = \
     $(top_builddir)/src/core/libopenthread-mtd.a                         \
     $(LDADD_COMMON)                                                      \
     $(LDADD_MBEDTLS)                                                     \
+    $(LDADD_DIAG)                                                        \
     $(top_builddir)/src/core/libopenthread-mtd.a                         \
     $(LDADD_COMMON)                                                      \
     $(LDADD_MBEDTLS)                                                     \
+    $(LDADD_DIAG)                                                        \
     $(NULL)
 
 ot_ncp_mtd_LDFLAGS                                                     = \

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -33,6 +33,8 @@
 
 #include "openthread-core-config.h"
 
+#include <openthread/diag.h>
+
 #include "common/debug.hpp"
 #include "common/instance.hpp"
 #include "common/logging.hpp"
@@ -763,8 +765,40 @@ uint16_t otLinkGetShortAddress(otInstance *aInstance)
     return static_cast<Instance *>(aInstance)->GetLinkRaw().GetShortAddress();
 }
 
+#if OPENTHREAD_ENABLE_DIAG
+void otDiagInit(otInstance *aInstance)
+{
+    (void)aInstance;
+}
+
+const char *otDiagProcessCmdLine(const char *aInput)
+{
+    (void)aInput;
+    return NULL;
+}
+
+extern "C" void otPlatDiagAlarmFired(otInstance *aInstance)
+{
+    (void)aInstance;
+}
+
+extern "C" void otPlatDiagRadioTransmitDone(otInstance *aInstance, otRadioFrame *aFrame, otError aError)
+{
+    (void)aInstance;
+    (void)aFrame;
+    (void)aError;
+}
+
+extern "C" void otPlatDiagRadioReceiveDone(otInstance *aInstance, otRadioFrame *aFrame, otError aError)
+{
+    (void)aInstance;
+    (void)aFrame;
+    (void)aError;
+}
+#endif // OPENTHREAD_ENABLE_DIAG
+
 #if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
-void otPlatRadioFrameUpdated(otInstance *aInstance, otRadioFrame *aFrame)
+extern "C" void otPlatRadioFrameUpdated(otInstance *aInstance, otRadioFrame *aFrame)
 {
     // Note: For now this functionality is not supported in Radio Only mode.
     (void)aInstance;


### PR DESCRIPTION
The main diags module is built together with OT core, which runs on host side, radio only ncp will only act as transceiver and support platform specific diags features. It helps to reduce code size of radio-only NCP.