### PR TITLE
[coap] improve readability

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -527,8 +527,8 @@ exit:
 
 void CoapBase::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Coap *>(aContext)->Receive(*static_cast<Message *>(aMessage),
-                                           *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<CoapBase *>(aContext)->Receive(*static_cast<Message *>(aMessage),
+                                               *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
 void CoapBase::Receive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)


### PR DESCRIPTION
The current code make make people misunderstand that it will call the function CoapBase::Receive or Coap::Receive . In fact, when aContext is a CoapSecure object, it will call CoapSecure::Receive.