### PR TITLE
[mle] API to provide MLE Parent Response information

### DIFF
--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -183,8 +183,8 @@ typedef struct otMleCounters
 } otMleCounters;
 
 /**
- * This structure represents the parent response data which a client can request on each successful parent
- * response frame reception by ot stack.
+ * This structure represents the MLE Parent Response data that a client can receive on each successful Parent
+ * Response message received.
  *
  */
 typedef struct otThreadParentResponseInfo

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -735,8 +735,7 @@ const otMleCounters *otThreadGetMleCounters(otInstance *aInstance);
 void otThreadResetMleCounters(otInstance *aInstance);
 
 /**
- * This function pointer is called everytime a parent response frame is received to notify the caller about certain
- * stats.
+ * This function pointer is called every time an MLE Parent Response message is received.
  *
  * @param[in]  aStats    pointer to a location on stack holding the stats data.
  * @param[in]  aContext  A pointer to callback client-specific context.

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -744,10 +744,10 @@ void otThreadResetMleCounters(otInstance *aInstance);
 typedef void(OTCALL *otThreadParentResponseCallback)(otThreadParentResponseInfo *aInfo, void *aContext);
 
 /**
- * This function registers a callback to receive certain stats during a parent response frame handling
+ * This function registers a callback to receive MLE Parent Response data.
  *
  * @param[in]  aInstance  A pointer to an OpenThread instance.
- * @param[in]  aCallback  A pointer to a function that is called with certain parent response frame content.
+ * @param[in]  aCallback  A pointer to a function that is called when receiving an MLE Parent Response message.
  * @param[in]  aContext   A pointer to callback client-specific context.
  *
  * @retval OT_ERROR_NONE              On successful registration

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -183,6 +183,23 @@ typedef struct otMleCounters
 } otMleCounters;
 
 /**
+ * This structure represents the parent response data which a client can request on each successful parent
+ * response frame reception by ot stack.
+ *
+ */
+typedef struct otThreadParentResponseInfo
+{
+    otExtAddress mExtAddr;      ///< IEEE 802.15.4 Extended Address of the Parent
+    uint16_t     mRloc16;       ///< Short address of the Parent
+    int8_t       mRssi;         ///< Rssi of the Parent
+    int8_t       mPriority;     ///< Parent priority
+    uint8_t      mLinkQuality3; ///< Parent Link Quality 3
+    uint8_t      mLinkQuality2; ///< Parent Link Quality 2
+    uint8_t      mLinkQuality1; ///< Parent Link Quality 1
+    bool         mIsAttached;   ///< Is the node receiving parent response attached
+} otThreadParentResponseInfo;
+
+/**
  * This function starts Thread protocol operation.
  *
  * The interface must be up when calling this function.
@@ -716,6 +733,31 @@ const otMleCounters *otThreadGetMleCounters(otInstance *aInstance);
  *
  */
 void otThreadResetMleCounters(otInstance *aInstance);
+
+/**
+ * This function pointer is called everytime a parent response frame is received to notify the caller about certain
+ * stats.
+ *
+ * @param[in]  aStats    pointer to a location on stack holding the stats data.
+ * @param[in]  aContext  A pointer to callback client-specific context.
+ *
+ */
+typedef void(OTCALL *otThreadParentResponseCallback)(otThreadParentResponseInfo *aInfo, void *aContext);
+
+/**
+ * This function registers a callback to receive certain stats during a parent response frame handling
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ * @param[in]  aCallback  A pointer to a function that is called with certain parent response frame content.
+ * @param[in]  aContext   A pointer to callback client-specific context.
+ *
+ * @retval OT_ERROR_NONE              On successful registration
+ * @retval OT_ERROR_DISABLED_FEATURE  If the feature is not supported
+ *
+ */
+OTAPI otError OTCALL otThreadRegisterParentResponseCallback(otInstance *                   aInstance,
+                                                            otThreadParentResponseCallback aCallback,
+                                                            void *                         aContext);
 
 /**
  * @}

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -183,8 +183,7 @@ typedef struct otMleCounters
 } otMleCounters;
 
 /**
- * This structure represents the MLE Parent Response data that a client can receive on each successful Parent
- * Response message received.
+ * This structure represents the MLE Parent Response data.
  *
  */
 typedef struct otThreadParentResponseInfo
@@ -747,7 +746,7 @@ typedef void(OTCALL *otThreadParentResponseCallback)(otThreadParentResponseInfo 
  * This function registers a callback to receive MLE Parent Response data.
  *
  * @param[in]  aInstance  A pointer to an OpenThread instance.
- * @param[in]  aCallback  A pointer to a function that is called when receiving an MLE Parent Response message.
+ * @param[in]  aCallback  A pointer to a function that is called upon receiving an MLE Parent Response message.
  * @param[in]  aContext   A pointer to callback client-specific context.
  *
  * @retval OT_ERROR_NONE              On successful registration

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -538,3 +538,22 @@ void otThreadResetMleCounters(otInstance *aInstance)
 
     instance.GetThreadNetif().GetMle().ResetCounters();
 }
+
+otError otThreadRegisterParentResponseCallback(otInstance *                   aInstance,
+                                               otThreadParentResponseCallback aCallback,
+                                               void *                         aContext)
+{
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    instance.GetThreadNetif().GetMle().RegisterParentResponseStatsCallback(aCallback, aContext);
+
+    return OT_ERROR_NONE;
+#else
+    (void)aInstance;
+    (void)aCallback;
+    (void)aContext;
+
+    return OT_ERROR_DISABLED_FEATURE;
+#endif
+}

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1064,7 +1064,6 @@ public:
      * @param[in]  aCallback A pointer to a function that is called to deliver certain stats about Parents of a node.
      * @param[in]  aContext  A pointer to application-specific context.
      *
-     * @retval None
      */
     void RegisterParentResponseStatsCallback(otThreadParentResponseCallback aCallback, void *aContext);
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1057,6 +1057,17 @@ public:
      */
     void ResetCounters(void) { memset(&mCounters, 0, sizeof(mCounters)); }
 
+    /**
+     * This function registers the client callback which is called upon successfully processing a Parent response frame
+     * to deliver certain info about the Parent of a node.
+     *
+     * @param[in]  aCallback A pointer to a function that is called to deliver certain stats about Parents of a node.
+     * @param[in]  aContext  A pointer to application-specific context.
+     *
+     * @retval None
+     */
+    void RegisterParentResponseStatsCallback(otThreadParentResponseCallback aCallback, void *aContext);
+
 protected:
     /**
      * States during attach (when searching for a parent).
@@ -1786,6 +1797,9 @@ private:
     Ip6::NetifMulticastAddress mRealmLocalAllThreadNodes;
 
     Notifier::Callback mNotifierCallback;
+
+    otThreadParentResponseCallback mParentResponseCb;
+    void *                         mParentResponseCbContext;
 };
 
 } // namespace Mle

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1058,10 +1058,9 @@ public:
     void ResetCounters(void) { memset(&mCounters, 0, sizeof(mCounters)); }
 
     /**
-     * This function registers the client callback which is called upon successfully processing a Parent response frame
-     * to deliver certain info about the Parent of a node.
+     * This function registers the client callback that is called when processing an MLE Parent Response message.
      *
-     * @param[in]  aCallback A pointer to a function that is called to deliver certain stats about Parents of a node.
+     * @param[in]  aCallback A pointer to a function that is called to deliver MLE Parent Response data.
      * @param[in]  aContext  A pointer to application-specific context.
      *
      */


### PR DESCRIPTION
This Feature allows OT to share some of the parent response stats with application when a callback for the same is installed.