### PR TITLE
[notifier] add OT_CHANGED_THREAD_MODE

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -284,6 +284,7 @@ enum
     OT_CHANGED_SECURITY_POLICY             = 1 << 22, ///< Security Policy changed
     OT_CHANGED_CHANNEL_MANAGER_NEW_CHANNEL = 1 << 23, ///< Channel Manager new pending Thread channel changed
     OT_CHANGED_SUPPORTED_CHANNEL_MASK      = 1 << 24, ///< Supported channel mask changed
+    OT_CHANGED_THREAD_MODE                 = 1 << 25, ///< Thread mode changed
 };
 
 /**

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -332,6 +332,10 @@ const char *Notifier::FlagToString(otChangedFlags aFlag) const
         retval = "ChanMask";
         break;
 
+    case OT_CHANGED_THREAD_MODE:
+        retval = "Mode";
+        break;
+
     default:
         break;
     }

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -782,9 +782,17 @@ otError Mle::SetDeviceMode(uint8_t aDeviceMode)
 
     VerifyOrExit((aDeviceMode & ModeTlv::kModeFFD) == 0 || (aDeviceMode & ModeTlv::kModeRxOnWhenIdle) != 0,
                  error = OT_ERROR_INVALID_ARGS);
-    VerifyOrExit(mDeviceMode != aDeviceMode);
+
+    VerifyOrExit(mDeviceMode != aDeviceMode, GetNotifier().SignalIfFirst(OT_CHANGED_THREAD_MODE));
+
+    otLogNoteMle(GetInstance(), "Mode 0x%02x -> 0x%02x [rx-on:%s, sec-data-req:%s, ffd:%s, full-netdata:%s]",
+                 mDeviceMode, aDeviceMode, (aDeviceMode & ModeTlv::kModeRxOnWhenIdle) ? "yes" : " no",
+                 (aDeviceMode & ModeTlv::kModeSecureDataRequest) ? "yes" : " no",
+                 (aDeviceMode & ModeTlv::kModeFFD) ? "yes" : "no",
+                 (aDeviceMode & ModeTlv::kModeFullNetworkData) ? "yes" : "no");
 
     mDeviceMode = aDeviceMode;
+    GetNotifier().Signal(OT_CHANGED_THREAD_MODE);
 
     switch (mRole)
     {


### PR DESCRIPTION
This commit adds a new flag `OT_CHANGED_THREAD_MODE` to indicate
when Thread mode changes. This commit also adds a log (at log level
`OT_LOG_LEVEL_NOTE`) indicating the mode change and the new mode
value.