### PR TITLE
[dataset] do not use Channel Mask TLV as MAC supported channel mask

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -553,18 +553,6 @@ otError Dataset::ApplyConfiguration(Instance &aInstance, bool *aIsMasterKeyUpdat
             break;
         }
 
-        case Tlv::kChannelMask:
-        {
-            const ChannelMask0Entry *mask0Entry = static_cast<const ChannelMaskTlv *>(cur)->GetMask0Entry();
-
-            if (mask0Entry != NULL)
-            {
-                mac.SetSupportedChannelMask(mask0Entry->GetMask());
-            }
-
-            break;
-        }
-
         case Tlv::kPanId:
             mac.SetPanId(static_cast<const PanIdTlv *>(cur)->GetPanId());
             break;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2308,8 +2308,9 @@ otError Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce, const Ip6::Add
     ChannelTlv         channel;
     PanIdTlv           panid;
     ActiveTimestampTlv activeTimestamp;
-    Message *          message;
+    Message *          message = NULL;
 
+    VerifyOrExit(netif.GetMac().GetSupportedChannelMask().ContainsChannel(aChannel), error = OT_ERROR_INVALID_ARGS);
     VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     message->SetLinkSecurityEnabled(true);
     message->SetSubType(Message::kSubTypeMleAnnounce);


### PR DESCRIPTION
This commit changes the code to treat Channel Mask TLV from
Operational Dataset and the MAC layer supported channel mask as
two different (unrelated) network parameters. In particular:
- With this commit, the Channel Mask TLV value is ignored when
  applying a Dataset from `Dataset:ApplyConfiguration()`.
- However, when we create an Active Operational Dataset as leader in
  `ActiveDataset::GenerateLocal()` method, the MAC layer's supported
  channel mask is still used for the Dataset Channel Mask TLV value.
- This commit also adds a check in `Mle::SendAnnounce()` to ensure
  that MLE Announcements are not sent on channels that are are not
  included in the MAC layer's supported channel mask.
-----------
Should help address Issue  https://github.com/openthread/openthread/issues/3056.

