### PR TITLE
[cc2538] fix wrong uart rx ioc config

### DIFF
--- a/examples/platforms/cc2538/cc2538-reg.h
+++ b/examples/platforms/cc2538/cc2538-reg.h
@@ -222,6 +222,11 @@
 #define IOC_OVERRIDE_OE                         0x00000008  // PAD Config Override Output Enable
 #define IOC_OVERRIDE_DIS                        0x00000000  // PAD Config Override Disabled
 
+#define IOC_PAD_IN_SEL_PA0                      0x00000000  // PA0
+#define IOC_PAD_IN_SEL_PA1                      0x00000001  // PA1
+#define IOC_PAD_IN_SEL_PA2                      0x00000002  // PA2
+#define IOC_PAD_IN_SEL_PA3                      0x00000003  // PA3
+
 #define UART0_BASE                              0x4000C000
 #define UART1_BASE                              0x4000D000
 #define GPIO_A_BASE                             0x400D9000  // GPIO

--- a/examples/platforms/cc2538/uart.c
+++ b/examples/platforms/cc2538/uart.c
@@ -113,8 +113,8 @@ otError otPlatUartEnable(void)
     HWREG(GPIO_A_BASE + GPIO_O_AFSEL) |= GPIO_PIN_1;
 
     // rx pin
-    HWREG(IOC_PA0_SEL)  = IOC_UARTRXD_UART0;
-    HWREG(IOC_PA0_OVER) = IOC_OVERRIDE_DIS;
+    HWREG(IOC_UARTRXD_UART0) = IOC_PAD_IN_SEL_PA0;
+    HWREG(IOC_PA0_OVER)      = IOC_OVERRIDE_DIS;
     HWREG(GPIO_A_BASE + GPIO_O_AFSEL) |= GPIO_PIN_0;
 
     HWREG(UART0_BASE + UART_O_CTL) = 0;
@@ -287,8 +287,8 @@ void cc2538DebugUartInit(void)
 
     // UART1 - rx pin we don't really use but we setup anyway
     // PA2 => is jumper position RF1.16
-    HWREG(IOC_PA2_SEL)  = IOC_UARTRXD_UART1;
-    HWREG(IOC_PA2_OVER) = IOC_OVERRIDE_DIS;
+    HWREG(IOC_UARTRXD_UART1) = IOC_PAD_IN_SEL_PA2;
+    HWREG(IOC_PA2_OVER)      = IOC_OVERRIDE_DIS;
     HWREG(GPIO_A_BASE + GPIO_O_AFSEL) |= GPIO_PIN_2;
 
     HWREG(UART1_BASE + UART_O_CC) = 0;


### PR DESCRIPTION
Fix a minor flaw in cc2538 uart initialization. This won't be a problem for default GPIO pin PA0 since it's the default value for the corresponding register. If a user wants to use a custom GPIO, however, the uart rx will not work as expected.