### PR TITLE
slaac-utility: remove addresses properly

### DIFF
--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -85,7 +85,7 @@ void Slaac::UpdateAddresses(otInstance *    aInstance,
             }
         }
 
-        if (!found)
+        if (found)
         {
             otIp6RemoveUnicastAddress(aInstance, &address->mAddress);
             address->mValid = false;


### PR DESCRIPTION
This commit fixes the removeal of slaac-addresses in Slaac::UpdateAddresses.
When a address now matches a prefix, it is properly removed.