### PR TITLE
[posix-app] platform UDP

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -63,7 +63,29 @@ cd /tmp || die
     }
 
     [ $BUILD_TARGET != posix-app-pty ] || {
-        sudo apt-get install socat expect || die
+        sudo apt-get install socat expect libdbus-1-dev autoconf-archive || die
+        JOBS=$(getconf _NPROCESSORS_ONLN)
+        (
+        WPANTUND_TMPDIR=/tmp/wpantund
+        git clone --depth 1 https://github.com/openthread/wpantund.git $WPANTUND_TMPDIR
+        cd $WPANTUND_TMPDIR
+        ./bootstrap.sh
+        ./configure --prefix= --exec-prefix=/usr --disable-ncp-dummy --enable-static-link-ncp-plugin=spinel
+        make -j $JOBS
+        sudo make install
+        ) || die
+        (
+        LIBCOAP_TMPDIR=/tmp/libcoap
+        mkdir $LIBCOAP_TMPDIR
+        cd $LIBCOAP_TMPDIR
+        wget https://github.com/obgm/libcoap/archive/bsd-licensed.tar.gz
+        tar xvf bsd-licensed.tar.gz
+        cd libcoap-bsd-licensed
+        ./autogen.sh
+        ./configure --prefix= --exec-prefix=/usr --with-boost=internal --disable-tests --disable-documentation
+        make -j $JOBS
+        sudo make install
+        ) || die
     }
 
     [ $BUILD_TARGET != scan-build ] || {

--- a/.travis/check-posix-app-pty
+++ b/.travis/check-posix-app-pty
@@ -68,7 +68,7 @@ check() {
     RADIO_NCP_PATH="$(pwd)/$(ls output/*linux*/bin/ot-ncp-radio)"
     $RADIO_NCP_PATH 1 > $RADIO_PTY < $RADIO_PTY &
     OT_NCP_PATH="$(pwd)/$(ls output/posix/*linux*/bin/ot-ncp)"
-    PLATFORM_NETIF=wpan0 sudo -E wpantund -I wpan0 -o Thread:Config:FilterRLOCAddresses 0 -s "system:${OT_NCP_PATH} ${CORE_PTY} -echo" &
+    PLATFORM_NETIF=wpan0 sudo -E wpantund -I wpan0 -o Thread:Config:FilterRLOCAddresses 0 -s "system:${OT_NCP_PATH} ${CORE_PTY}" &
 
     while true; do
         sleep 5

--- a/.travis/posix-app-pty
+++ b/.travis/posix-app-pty
@@ -1,0 +1,93 @@
+#!/bin/bash
+#
+#  Copyright (c) 2018, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e
+set -x
+
+die() {
+	echo " *** ERROR: " $*
+	exit 1
+}
+
+at_exit() {
+    sudo killall wpantund
+    killall socat
+}
+
+main() {
+    ./bootstrap
+    COVERAGE=1 make -f examples/Makefile-posix
+    COVERAGE=1 make -f src/posix/Makefile-posix PLATFORM_UDP=1
+    trap at_exit INT TERM EXIT
+
+    SOCAT_OUTPUT=/tmp/ot-socat
+    socat -d -d pty,raw,b115200,echo=0 pty,raw,b115200,echo=0 > /dev/null 2> $SOCAT_OUTPUT &
+    while true; do
+        if test $(head -n2 $SOCAT_OUTPUT | wc -l) = 2; then
+            RADIO_PTY=$(head -n1 $SOCAT_OUTPUT | grep -o '/dev/.\+')
+            CORE_PTY=$(head -n2 $SOCAT_OUTPUT | tail -n1 | grep -o '/dev/.\+')
+            break
+        fi
+        echo 'Waiting for socat ready...'
+        sleep 1
+    done
+    echo 'RADIO_PTY' $DEVICE_PTY
+    echo 'CORE_PTY' $CORE_PTY
+
+    RADIO_NCP_PATH="$(pwd)/$(ls output/*linux*/bin/ot-ncp-radio)"
+    $RADIO_NCP_PATH 1 > $RADIO_PTY < $RADIO_PTY &
+    OT_NCP_PATH="$(pwd)/$(ls output/posix/*linux*/bin/ot-ncp)"
+    PLATFORM_NETIF=wpan0 sudo -E wpantund -I wpan0 -o Thread:Config:FilterRLOCAddresses 0 -s "system:${OT_NCP_PATH} ${CORE_PTY} -echo" &
+
+    while true; do
+        sleep 5
+        if sudo wpanctl status; then
+            break
+        else
+            echo 'Still waiting for wpantund'
+        fi
+    done
+
+    sudo wpanctl leave || true
+    sudo wpanctl form -c 18 OpenThreadTest
+
+    mleid=$(sudo wpanctl status | grep MeshLocalAddress | cut -d'"' -f4)
+    echo "ML-EID is: ${mleid}"
+
+    netstat -an | grep -q 61631 || die 'TMF port is not available!'
+    xaddress=$(sudo wpanctl get 'NCP:ExtendedAddress' | cut -d= -f2 | tr -d ' []')
+    echo "Extended address is: ${xaddress}"
+    # Try retrieving extended address
+    coap_response=$(echo -n '120100' | xxd -r -p | coap-client -m POST coap://[${mleid}]:61631/d/dg -f- | xxd -p -u | grep 0008)
+    echo "CoAP response is: ${coap_response}"
+    # Verify CoAP response contains the extended address
+    [[ "${coap_response}" = *${xaddress}* ]] || die 'failed to get extended address through TMF'
+}
+
+main "$@"

--- a/.travis/posix-app-pty
+++ b/.travis/posix-app-pty
@@ -40,10 +40,13 @@ at_exit() {
     killall socat
 }
 
-main() {
+build() {
     ./bootstrap
     COVERAGE=1 make -f examples/Makefile-posix
     COVERAGE=1 make -f src/posix/Makefile-posix PLATFORM_UDP=1
+}
+
+check() {
     trap at_exit INT TERM EXIT
 
     SOCAT_OUTPUT=/tmp/ot-socat
@@ -93,6 +96,18 @@ main() {
 
     # Leave so that code coverage will be flushed
     sudo wpanctl leave || true
+}
+
+main() {
+    case $1 in
+        check)
+            check
+            ;;
+        *)
+            build
+            check
+            ;;
+    esac
 }
 
 main "$@"

--- a/.travis/posix-app-pty
+++ b/.travis/posix-app-pty
@@ -83,11 +83,16 @@ main() {
     netstat -an | grep -q 61631 || die 'TMF port is not available!'
     xaddress=$(sudo wpanctl get 'NCP:ExtendedAddress' | cut -d= -f2 | tr -d ' []')
     echo "Extended address is: ${xaddress}"
-    # Try retrieving extended address
+
+    # Retrievie extended address through network diagnostic get
     coap_response=$(echo -n '120100' | xxd -r -p | coap-client -m POST coap://[${mleid}]:61631/d/dg -f- | xxd -p -u | grep 0008)
     echo "CoAP response is: ${coap_response}"
+
     # Verify CoAP response contains the extended address
-    [[ "${coap_response}" = *${xaddress}* ]] || die 'failed to get extended address through TMF'
+    [[ "${coap_response}" = *${xaddress}* ]] || die 'failed to get extended address'
+
+    # Leave so that code coverage will be flushed
+    sudo wpanctl leave || true
 }
 
 main "$@"

--- a/.travis/posix-app-pty
+++ b/.travis/posix-app-pty
@@ -36,8 +36,10 @@ die() {
 }
 
 at_exit() {
-    sudo killall wpantund
-    killall socat
+    EXIT_CODE=$?
+    sudo killall wpantund || true
+    killall socat || true
+    exit $EXIT_CODE
 }
 
 build() {

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -490,49 +490,7 @@ python --version || die
 }
 
 [ $BUILD_TARGET != posix-app-pty ] || {
-    ./bootstrap
-    COVERAGE=1 make -f examples/Makefile-posix
-    COVERAGE=1 make -f src/posix/Makefile-posix
-
-    SOCAT_OUTPUT=/tmp/ot-socat
-    socat -d -d pty,raw,echo=0 pty,raw,echo=0 > /dev/null 2> $SOCAT_OUTPUT &
-    while true; do
-        if test $(head -n2 $SOCAT_OUTPUT | wc -l) = 2; then
-            RADIO_PTY=$(head -n1 $SOCAT_OUTPUT | grep -o '/dev/.\+')
-            CORE_PTY=$(head -n2 $SOCAT_OUTPUT | tail -n1 | grep -o '/dev/.\+')
-            break
-        fi
-        echo 'Waiting for socat ready...'
-        sleep 1
-    done
-    echo 'RADIO_PTY' $DEVICE_PTY
-    echo 'CORE_PTY' $CORE_PTY
-
-    RADIO_NCP_PATH="$(pwd)/$(ls output/*linux*/bin/ot-ncp-radio)"
-    $RADIO_NCP_PATH 1 > $RADIO_PTY < $RADIO_PTY &
-    OT_CLI_PATH="$(pwd)/$(ls output/posix/*linux*/bin/ot-cli)"
-
-    expect <<EOF || die
-spawn $OT_CLI_PATH $CORE_PTY
-set timeout 2
-send "panid 0xface\r\n"
-expect "Done"
-send "ifconfig up\r\n"
-expect "Done"
-send "thread start\r\n"
-expect "Done"
-sleep 5
-send "state\r\n"
-expect {
-    "leader" {
-        send "exit\r\n"
-        expect eof
-    }
-    timeout abort
-}
-send_user "Success"
-EOF
-    killall socat
+    .travis/posix-app-pty || die
 }
 
 [ $BUILD_TARGET != posix-mtd ] || {

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -490,7 +490,7 @@ python --version || die
 }
 
 [ $BUILD_TARGET != posix-app-pty ] || {
-    .travis/posix-app-pty || die
+    .travis/check-posix-app-pty || die
 }
 
 [ $BUILD_TARGET != posix-mtd ] || {

--- a/configure.ac
+++ b/configure.ac
@@ -796,6 +796,35 @@ AM_CONDITIONAL([OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE], [test "${enable_appl
 AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE],[${OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE}],[Define to 1 if you want to enable CoAP Secure to an application.])
 
 #
+# Platform UDP
+#
+
+AC_ARG_ENABLE(platform_udp,
+    [AS_HELP_STRING([--enable-platform-udp],[Enable platform UDP support @<:@default=no@:>@.])],
+    [
+        case "${enableval}" in
+        no|yes)
+            enable_platform_udp=${enableval}
+            ;;
+        *)
+            AC_MSG_ERROR([Invalid value ${enable_platform_udp} for --enable-platform-udp])
+            ;;
+        esac
+    ],
+    [enable_platform_udp=no])
+
+if test "$enable_platform_udp" = "yes"; then
+    OPENTHREAD_ENABLE_PLATFORM_UDP=1
+else
+    OPENTHREAD_ENABLE_PLATFORM_UDP=0
+fi
+
+AC_MSG_RESULT(${enable_platform_udp})
+AC_SUBST(OPENTHREAD_ENABLE_PLATFORM_UDP)
+AM_CONDITIONAL([OPENTHREAD_ENABLE_PLATFORM_UDP], [test "${enable_platform_udp}" = "yes"])
+AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_PLATFORM_UDP], [${OPENTHREAD_ENABLE_PLATFORM_UDP}], [Define to 1 to enable platform UDP.])
+
+#
 # Thread Commissioner
 #
 

--- a/include/openthread/platform/Makefile.am
+++ b/include/openthread/platform/Makefile.am
@@ -40,6 +40,7 @@ ot_platform_headers                     = \
     random.h                              \
     time.h                                \
     uart.h                                \
+    udp.h                                 \
     spi-slave.h                           \
     settings.h                            \
     messagepool.h                         \

--- a/include/openthread/platform/udp.h
+++ b/include/openthread/platform/udp.h
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (c) 2018, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * @brief
+ *   This file includes the abstraction for the platform UDP service.
+ */
+
+#ifndef OPENTHREAD_PLATFORM_UDP_H_
+#define OPENTHREAD_PLATFORM_UDP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * This function initializes the UDP socket by platform.
+ *
+ * @param[in]   aUdpSocket  A pointer to the UDP socket.
+ *
+ * @retval  OT_ERROR_NONE   Successfully initialized UDP socket by platform.
+ * @retval  OT_ERROR_FAILED Failed to initializ UDP Socket.
+ *
+ */
+otError otPlatUdpSocket(otUdpSocket *aUdpSocket);
+
+/**
+ * This function closes the UDP socket by platform.
+ *
+ * @param[in]   aUdpSocket  A pointer to the UDP socket.
+ *
+ * @retval  OT_ERROR_NONE   Successfully closed UDP socket by platform.
+ * @retval  OT_ERROR_FAILED Failed to clos UDP Socket.
+ *
+ */
+otError otPlatUdpClose(otUdpSocket *aUdpSocket);
+
+/**
+ * This function binds the UDP socket by platform.
+ *
+ * @param[in]   aUdpSocket  A pointer to the UDP socket.
+ *
+ * @retval  OT_ERROR_NONE   Successfully binded UDP socket by platform.
+ * @retval  OT_ERROR_FAILED Failed to bind UDP socket.
+ *
+ */
+otError otPlatUdpBind(otUdpSocket *aUdpSocket);
+
+/**
+ * This function connects UDP socket by platform.
+ *
+ * @param[in]   aUdpSocket  A pointer to the UDP socket.
+ *
+ * @retval  OT_ERROR_NONE   Successfully connected by platform.
+ * @retval  OT_ERROR_FAILED Failed to connect UDP socket.
+ *
+ */
+otError otPlatUdpConnect(otUdpSocket *aUdpSocket);
+
+/**
+ * This function sends UDP payload by platform.
+ *
+ * @param[in]   aUdpSocket      A pointer to the UDP socket.
+ * @param[in]   aMessage        A pointer to the message to send.
+ * @param[in]   aMessageInfo    A pointer to the message info associated with @p aMessage.
+ *
+ * @retval  OT_ERROR_NONE   Successfully sent by platform, and @p aMessage is freed.
+ * @retval  OT_ERROR_FAILED Failed to binded UDP socket.
+ *
+ */
+otError otPlatUdpSend(otUdpSocket *aUdpSocket, otMessage *aMessage, const otMessageInfo *aMessageInfo);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // OPENTHREAD_PLATFORM_UDP_H_

--- a/include/openthread/platform/udp.h
+++ b/include/openthread/platform/udp.h
@@ -45,7 +45,7 @@ extern "C" {
  * @param[in]   aUdpSocket  A pointer to the UDP socket.
  *
  * @retval  OT_ERROR_NONE   Successfully initialized UDP socket by platform.
- * @retval  OT_ERROR_FAILED Failed to initializ UDP Socket.
+ * @retval  OT_ERROR_FAILED Failed to initialize UDP Socket.
  *
  */
 otError otPlatUdpSocket(otUdpSocket *aUdpSocket);
@@ -56,7 +56,7 @@ otError otPlatUdpSocket(otUdpSocket *aUdpSocket);
  * @param[in]   aUdpSocket  A pointer to the UDP socket.
  *
  * @retval  OT_ERROR_NONE   Successfully closed UDP socket by platform.
- * @retval  OT_ERROR_FAILED Failed to clos UDP Socket.
+ * @retval  OT_ERROR_FAILED Failed to close UDP Socket.
  *
  */
 otError otPlatUdpClose(otUdpSocket *aUdpSocket);

--- a/include/openthread/udp.h
+++ b/include/openthread/udp.h
@@ -89,6 +89,7 @@ typedef struct otUdpSocket
     otSockAddr          mPeerName; ///< The peer IPv6 socket address.
     otUdpReceive        mHandler;  ///< A function pointer to the application callback.
     void *              mContext;  ///< A pointer to application-specific context.
+    void *              mHandle;   ///< A handle to platform's UDP
     struct otUdpSocket *mNext;     ///< A pointer to the next UDP socket (internal use only).
 } otUdpSocket;
 
@@ -252,6 +253,16 @@ void otUdpProxyReceive(otInstance *        aInstance,
                        uint16_t            aPeerPort,
                        const otIp6Address *aPeerAddr,
                        uint16_t            aSockPort);
+
+/**
+ * This function gets the existing UDP Sockets.
+ *
+ * @param[in]  aInstance            A pointer to an OpenThread instance.
+ *
+ * @returns A pointer to the first UDP Socket.
+ *
+ */
+otUdpSocket *otUdpGetSockets(otInstance *aInstance);
 
 /**
  * @}

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -124,3 +124,12 @@ void otUdpProxyReceive(otInstance *        aInstance,
     static_cast<ot::Message *>(aMessage)->Free();
 }
 #endif // OPENTHREAD_ENABLE_UDP_PROXY
+
+#if OPENTHREAD_ENABLE_PLATFORM_UDP
+otUdpSocket *otUdpGetSockets(otInstance *aInstance)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.Get<Ip6::Ip6>().GetUdp().GetUdpSockets();
+}
+#endif

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -644,6 +644,7 @@ otError Ip6::ProcessReceiveCallback(const Message &    aMessage,
 
                 break;
 
+#if OPENTHREAD_ENABLE_PLATFORM_UDP == 0
             case kCoapUdpPort:
 
                 // do not pass TMF messages
@@ -653,8 +654,15 @@ otError Ip6::ProcessReceiveCallback(const Message &    aMessage,
                 }
 
                 break;
+#endif // OPENTHREAD_ENABLE_PLATFORM_UDP
 
             default:
+#if OPENTHREAD_FTD
+                if (udp.GetDestinationPort() == GetInstance().Get<MeshCoP::JoinerRouter>().GetJoinerUdpPort())
+                {
+                    ExitNow(error = OT_ERROR_NO_ROUTE);
+                }
+#endif
                 break;
             }
 

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -132,10 +132,7 @@ otError UdpSocket::Close(void)
     otError error = OT_ERROR_NONE;
 
 #if OPENTHREAD_ENABLE_PLATFORM_UDP
-    if (!IsMle(GetInstance(), mSockName.mPort))
-    {
-        SuccessOrExit(error = otPlatUdpClose(this));
-    }
+    SuccessOrExit(error = otPlatUdpClose(this));
 #endif
     SuccessOrExit(error = GetUdp().RemoveSocket(*this));
     memset(&mSockName, 0, sizeof(mSockName));

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -324,6 +324,10 @@ public:
      */
     otError UpdateChecksum(Message &aMessage, uint16_t aPseudoHeaderChecksum);
 
+#if OPENTHREAD_ENABLE_PLATFORM_UDP
+    otUdpSocket *GetUdpSockets(void) { return mSockets; }
+#endif
+
 #if OPENTHREAD_ENABLE_UDP_PROXY
     /**
      * This method sets the proxy sender.

--- a/src/posix/Makefile-posix
+++ b/src/posix/Makefile-posix
@@ -90,6 +90,12 @@ ifeq ($(VIRTUAL_TIME),1)
 COMMONCFLAGS                   += -DOPENTHREAD_POSIX_VIRTUAL_TIME=1
 endif
 
+ifeq ($(PLATFORM_UDP),1)
+configure_OPTIONS              += \
+    --enable-platform-udp         \
+    $(NULL)
+endif
+
 CPPFLAGS                       += \
     $(COMMONCFLAGS)               \
     $(NULL)

--- a/src/posix/platform/Makefile.am
+++ b/src/posix/platform/Makefile.am
@@ -65,6 +65,12 @@ nodist_libopenthread_posix_a_SOURCES      = \
 inc_%: ../../ncp/%
 	echo '#include "$<"' > $@
 
+if OPENTHREAD_ENABLE_PLATFORM_UDP
+libopenthread_posix_a_SOURCES            += \
+    udp.cpp                                 \
+    $(NULL)
+endif
+
 noinst_HEADERS                            = \
     frame_queue.hpp                         \
     openthread-system.h                     \

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -315,6 +315,24 @@ void otSimRadioSpinelProcess(otInstance *aInstance, const struct Event *aEvent);
 #define otSysGetTime(aTime) gettimeofday(aTime, NULL)
 #endif
 
+/**
+ * This function performs platform UDP driver processing.
+ *
+ * @param[in]   aInstance   The OpenThread instance structure.
+ * @param[in]   aReadFdSet  A pointer to the read file descriptors.
+ *
+ */
+void platformUdpProcess(otInstance *aInstance, const fd_set *aReadSet);
+
+/**
+ * This function updates the file descriptor sets with file descriptors used by the platform UDP driver.
+ *
+ * @param[in]     aInstance    The OpenThread instance structure.
+ * @param[inout]  aReadFdSet   A pointer to the read file descriptors.
+ * @param[inout]  aMaxFd       A pointer to the max file descriptor.
+ */
+void platformUdpUpdateFdSet(otInstance *aInstance, fd_set *aReadFdSet, int *aMaxFd);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -316,6 +316,12 @@ void otSimRadioSpinelProcess(otInstance *aInstance, const struct Event *aEvent);
 #endif
 
 /**
+ * This function initializes platform UDP driver.
+ *
+ */
+void platformUdpInit(void);
+
+/**
  * This function performs platform UDP driver processing.
  *
  * @param[in]   aInstance   The OpenThread instance structure.

--- a/src/posix/platform/system.c
+++ b/src/posix/platform/system.c
@@ -107,6 +107,9 @@ void otSysInit(int aArgCount, char *aArgVector[])
     platformAlarmInit(speedUpFactor);
     platformRadioInit(radioFile, radioConfig);
     platformRandomInit();
+#if OPENTHREAD_ENABLE_PLATFORM_UDP
+    platformUdpInit();
+#endif
 }
 
 bool otSysPseudoResetWasRequested(void)

--- a/src/posix/platform/system.c
+++ b/src/posix/platform/system.c
@@ -170,6 +170,9 @@ void otSysProcessDrivers(otInstance *aInstance)
 
     platformAlarmUpdateTimeout(&timeout);
     platformUartUpdateFdSet(&readFdSet, &writeFdSet, &errorFdSet, &maxFd);
+#if OPENTHREAD_ENABLE_PLATFORM_UDP
+    platformUdpUpdateFdSet(aInstance, &readFdSet, &maxFd);
+#endif
 #if OPENTHREAD_POSIX_VIRTUAL_TIME
     otSimUpdateFdSet(&readFdSet, &writeFdSet, &errorFdSet, &maxFd, &timeout);
 #else
@@ -230,4 +233,7 @@ void otSysProcessDrivers(otInstance *aInstance)
 #endif
     platformUartProcess(&readFdSet, &writeFdSet, &errorFdSet);
     platformAlarmProcess(aInstance);
+#if OPENTHREAD_ENABLE_PLATFORM_UDP
+    platformUdpProcess(aInstance, &readFdSet);
+#endif
 }

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -106,7 +106,9 @@ otError otPlatUdpBind(otUdpSocket *aUdpSocket)
     otError error = OT_ERROR_NONE;
     int     fd    = GetFdFromHandle(aUdpSocket->mHandle);
 
+    assert(sPlatNetifIndex != 0);
     assert(fd == -1);
+    VerifyOrExit(sPlatNetifIndex != 0, error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(fd == -1, error = OT_ERROR_ALREADY);
 
     fd = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
@@ -234,6 +236,8 @@ exit:
 
 void platformUdpUpdateFdSet(otInstance *aInstance, fd_set *aReadFdSet, int *aMaxFd)
 {
+    VerifyOrExit(sPlatNetifIndex != 0);
+
     for (otUdpSocket *socket = otUdpGetSockets(aInstance); socket != NULL; socket = socket->mNext)
     {
         int fd = GetFdFromHandle(socket->mHandle);
@@ -250,6 +254,9 @@ void platformUdpUpdateFdSet(otInstance *aInstance, fd_set *aReadFdSet, int *aMax
             *aMaxFd = fd;
         }
     }
+
+exit:
+    return;
 }
 
 void platformUdpInit(void)
@@ -314,6 +321,8 @@ exit:
 
 void platformUdpProcess(otInstance *aInstance, const fd_set *aReadFdSet)
 {
+    VerifyOrExit(sPlatNetifIndex != 0);
+
     for (otUdpSocket *socket = otUdpGetSockets(aInstance); socket != NULL; socket = socket->mNext)
     {
         int fd = GetFdFromHandle(socket->mHandle);
@@ -353,4 +362,7 @@ void platformUdpProcess(otInstance *aInstance, const fd_set *aReadFdSet)
             break;
         }
     }
+
+exit:
+    return;
 }

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -1,0 +1,352 @@
+/*
+ *  Copyright (c) 2018, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * @brief
+ *   This file includes the platform UDP driver.
+ */
+
+#include "platform-posix.h"
+
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <stdlib.h>
+#include <sys/select.h>
+
+#include <openthread/instance.h>
+#include <openthread/thread.h>
+#include <openthread/udp.h>
+#include <openthread/platform/udp.h>
+
+#include "common/code_utils.hpp"
+
+static int         sPlatNetifIndex = 0;
+static otInstance *sInstance       = NULL;
+
+static const void * kInvalidHandle = reinterpret_cast<void *>(-1);
+static const size_t kMaxUdpSize    = 1280;
+
+static void *GetHandleFromFd(int aFd)
+{
+    return reinterpret_cast<void *>(aFd);
+}
+
+static int GetFdFromHandle(void *aHandle)
+{
+    return reinterpret_cast<long>(aHandle);
+}
+
+static void closeFd(int aFd)
+{
+    VerifyOrExit(aFd != -1);
+
+    if (close(aFd))
+    {
+        perror("close");
+    }
+
+exit:
+    return;
+}
+
+static bool isLinkLocal(const struct in6_addr &aAddress)
+{
+    return aAddress.s6_addr[0] == 0xfe && aAddress.s6_addr[1] == 0x80;
+}
+
+otError otPlatUdpSocket(otUdpSocket *aUdpSocket)
+{
+    aUdpSocket->mHandle = kInvalidHandle;
+    return OT_ERROR_NONE;
+}
+
+otError otPlatUdpClose(otUdpSocket *aUdpSocket)
+{
+    otError error = OT_ERROR_NONE;
+    int     fd    = GetFdFromHandle(aUdpSocket->mHandle);
+
+    VerifyOrExit(fd > 0);
+    closeFd(fd);
+
+exit:
+    aUdpSocket->mHandle = kInvalidHandle;
+    return error;
+}
+
+otError otPlatUdpBind(otUdpSocket *aUdpSocket)
+{
+    otError error = OT_ERROR_NONE;
+    int     fd    = GetFdFromHandle(aUdpSocket->mHandle);
+
+    assert(fd == -1);
+    VerifyOrExit(fd == -1, error = OT_ERROR_ALREADY);
+
+    fd = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+    assert(fd > 0);
+    VerifyOrExit(fd > 0, error = OT_ERROR_FAILED);
+
+    {
+        struct sockaddr_in6 sin6;
+
+        memset(&sin6, 0, sizeof(struct sockaddr_in6));
+        sin6.sin6_port   = htons(aUdpSocket->mSockName.mPort);
+        sin6.sin6_family = AF_INET6;
+        memcpy(&sin6.sin6_addr, &aUdpSocket->mSockName.mAddress, sizeof(sin6.sin6_addr));
+        VerifyOrExit(0 == bind(fd, reinterpret_cast<struct sockaddr *>(&sin6), sizeof(sin6)), error = OT_ERROR_FAILED);
+    }
+
+    {
+        unsigned int hops = 255;
+        VerifyOrExit(0 == setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &hops, sizeof(hops)),
+                     error = OT_ERROR_FAILED);
+        int on = 1;
+        VerifyOrExit(0 == setsockopt(fd, IPPROTO_IPV6, IPV6_RECVHOPLIMIT, &on, sizeof(on)), error = OT_ERROR_FAILED);
+        VerifyOrExit(0 == setsockopt(fd, IPPROTO_IPV6, IPV6_RECVPKTINFO, &on, sizeof(on)), error = OT_ERROR_FAILED);
+    }
+
+    VerifyOrExit(0 == setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_IF, &sPlatNetifIndex, sizeof(sPlatNetifIndex)),
+                 error = OT_ERROR_FAILED);
+
+    if (aUdpSocket->mSockName.mPort == 0)
+    {
+        struct sockaddr_in6 sin6;
+        socklen_t           len = sizeof(sin6);
+
+        VerifyOrExit(0 == getsockname(fd, reinterpret_cast<struct sockaddr *>(&sin6), &len), error = OT_ERROR_FAILED);
+        aUdpSocket->mSockName.mPort = ntohs(sin6.sin6_port);
+    }
+
+    aUdpSocket->mHandle = GetHandleFromFd(fd);
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        if (error == OT_ERROR_FAILED)
+        {
+            perror("otUdpBind");
+            closeFd(fd);
+        }
+    }
+
+    return error;
+}
+
+otError otPlatUdpConnect(otUdpSocket *aUdpSocket)
+{
+    otError             error = OT_ERROR_NONE;
+    struct sockaddr_in6 sin6;
+    int                 fd = GetFdFromHandle(aUdpSocket->mHandle);
+
+    VerifyOrExit(fd > 0, error = OT_ERROR_INVALID_ARGS);
+
+    memset(&sin6, 0, sizeof(struct sockaddr_in6));
+    sin6.sin6_port   = htons(aUdpSocket->mPeerName.mPort);
+    sin6.sin6_family = AF_INET6;
+    memcpy(&sin6.sin6_addr, &aUdpSocket->mPeerName.mAddress, sizeof(sin6.sin6_addr));
+
+    VerifyOrExit(0 == connect(fd, reinterpret_cast<struct sockaddr *>(&sin6), sizeof(sin6)), error = OT_ERROR_FAILED);
+
+exit:
+    return error;
+}
+
+otError otPlatUdpSend(otUdpSocket *aUdpSocket, otMessage *aMessage, const otMessageInfo *aMessageInfo)
+{
+    otError             error = OT_ERROR_NONE;
+    int                 fd    = GetFdFromHandle(aUdpSocket->mHandle);
+    struct sockaddr_in6 peerAddr;
+    uint8_t             payload[kMaxUdpSize];
+    uint16_t            len;
+
+    if (fd == -1)
+    {
+        SuccessOrExit(error = otPlatUdpBind(aUdpSocket));
+    }
+
+    assert(fd != -1);
+    assert(aMessageInfo->mHopLimit > 0);
+
+    memset(&peerAddr, 0, sizeof(peerAddr));
+    peerAddr.sin6_port   = htons(aMessageInfo->mPeerPort);
+    peerAddr.sin6_family = AF_INET6;
+    memcpy(&peerAddr.sin6_addr, &aMessageInfo->mPeerAddr, sizeof(peerAddr.sin6_addr));
+
+    if (isLinkLocal(peerAddr.sin6_addr))
+    {
+        peerAddr.sin6_scope_id = sPlatNetifIndex;
+    }
+
+    len = otMessageGetLength(aMessage);
+    otMessageRead(aMessage, 0, payload, len);
+    VerifyOrExit(len == sendto(fd, payload, len, 0, reinterpret_cast<struct sockaddr *>(&peerAddr), sizeof(peerAddr)),
+                 error = OT_ERROR_FAILED);
+
+exit:
+    if (error == OT_ERROR_NONE)
+    {
+        otMessageFree(aMessage);
+    }
+    else
+    {
+        perror("sendto");
+    }
+
+    return error;
+}
+
+void platformUdpUpdateFdSet(otInstance *aInstance, fd_set *aReadFdSet, int *aMaxFd)
+{
+    for (otUdpSocket *socket = otUdpGetSockets(aInstance); socket != NULL; socket = socket->mNext)
+    {
+        int fd = GetFdFromHandle(socket->mHandle);
+
+        if (fd == -1)
+        {
+            continue;
+        }
+
+        FD_SET(fd, aReadFdSet);
+
+        if (aMaxFd != NULL && *aMaxFd < fd)
+        {
+            *aMaxFd = fd;
+        }
+    }
+}
+
+void platformUdpInit(otInstance *aInstance)
+{
+    const char *platformNetif = getenv("PLATFORM_NETIF");
+    sPlatNetifIndex           = if_nametoindex(platformNetif);
+
+    if (sPlatNetifIndex == 0)
+    {
+        perror("if_nametoindex");
+    }
+
+    OT_UNUSED_VARIABLE(aInstance);
+}
+
+static otError readSocket(int aFd, uint8_t *aPayload, uint16_t &aLength, otMessageInfo &aMessageInfo)
+{
+    struct sockaddr_in6 peerAddr;
+    uint8_t             control[kMaxUdpSize];
+    struct iovec        iov;
+    struct msghdr       msg;
+    ssize_t             rval;
+
+    iov.iov_base = aPayload;
+    iov.iov_len  = aLength;
+
+    msg.msg_name       = &peerAddr;
+    msg.msg_namelen    = sizeof(peerAddr);
+    msg.msg_control    = control;
+    msg.msg_controllen = sizeof(control);
+    msg.msg_iov        = &iov;
+    msg.msg_iovlen     = 1;
+    msg.msg_flags      = 0;
+
+    rval = recvmsg(aFd, &msg, 0);
+    VerifyOrExit(rval > 0, perror("recvmsg"));
+    aLength = static_cast<uint16_t>(rval);
+
+    for (struct cmsghdr *hdr = CMSG_FIRSTHDR(&msg); hdr != NULL; hdr = CMSG_NXTHDR(&msg, hdr))
+    {
+        if (hdr->cmsg_level == IPPROTO_IPV6)
+        {
+            if (hdr->cmsg_type == IPV6_HOPLIMIT)
+            {
+                int hoplimit           = *reinterpret_cast<int *>(CMSG_DATA(hdr));
+                aMessageInfo.mHopLimit = hoplimit;
+            }
+            else if (hdr->cmsg_type == IPV6_PKTINFO)
+            {
+                struct in6_pktinfo *pktinfo;
+
+                pktinfo = reinterpret_cast<in6_pktinfo *>(CMSG_DATA(hdr));
+                memcpy(&aMessageInfo.mSockAddr, &pktinfo->ipi6_addr, sizeof(aMessageInfo.mSockAddr));
+            }
+        }
+    }
+
+    aMessageInfo.mPeerPort = ntohs(peerAddr.sin6_port);
+    memcpy(&aMessageInfo.mPeerAddr, &peerAddr.sin6_addr, sizeof(aMessageInfo.mPeerAddr));
+
+exit:
+    return rval > 0 ? OT_ERROR_NONE : OT_ERROR_FAILED;
+}
+
+void platformUdpProcess(otInstance *aInstance, const fd_set *aReadFdSet)
+{
+    if (sInstance == NULL)
+    {
+        sInstance = aInstance;
+        platformUdpInit(aInstance);
+    }
+
+    for (otUdpSocket *socket = otUdpGetSockets(aInstance); socket != NULL; socket = socket->mNext)
+    {
+        int fd = GetFdFromHandle(socket->mHandle);
+
+        if (FD_ISSET(fd, aReadFdSet))
+        {
+            otMessageInfo messageInfo;
+            otMessage *   message = NULL;
+            uint8_t       payload[kMaxUdpSize];
+            uint16_t      length = sizeof(payload);
+
+            memset(&messageInfo, 0, sizeof(messageInfo));
+            messageInfo.mSockPort    = socket->mSockName.mPort;
+            messageInfo.mInterfaceId = OT_NETIF_INTERFACE_ID_HOST;
+
+            if (OT_ERROR_NONE != readSocket(fd, payload, length, messageInfo))
+            {
+                continue;
+            }
+
+            message = otUdpNewMessage(aInstance, false);
+
+            if (message == NULL)
+            {
+                continue;
+            }
+
+            if (otMessageAppend(message, payload, length) != OT_ERROR_NONE)
+            {
+                otMessageFree(message);
+                continue;
+            }
+
+            socket->mHandler(socket->mContext, message, &messageInfo);
+            otMessageFree(message);
+            // only process one socket a time
+            break;
+        }
+    }
+}

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -39,15 +39,12 @@
 #include <stdlib.h>
 #include <sys/select.h>
 
-#include <openthread/instance.h>
-#include <openthread/thread.h>
 #include <openthread/udp.h>
 #include <openthread/platform/udp.h>
 
 #include "common/code_utils.hpp"
 
-static int         sPlatNetifIndex = 0;
-static otInstance *sInstance       = NULL;
+static int sPlatNetifIndex = 0;
 
 static void *const  kInvalidHandle = reinterpret_cast<void *const>(-1);
 static const size_t kMaxUdpSize    = 1280;
@@ -151,7 +148,7 @@ exit:
     {
         if (error == OT_ERROR_FAILED)
         {
-            perror("otUdpBind");
+            perror("otPlatUdpBind");
             closeFd(fd);
         }
     }
@@ -255,7 +252,7 @@ void platformUdpUpdateFdSet(otInstance *aInstance, fd_set *aReadFdSet, int *aMax
     }
 }
 
-void platformUdpInit(otInstance *aInstance)
+void platformUdpInit(void)
 {
     const char *platformNetif = getenv("PLATFORM_NETIF");
     sPlatNetifIndex           = if_nametoindex(platformNetif);
@@ -264,8 +261,6 @@ void platformUdpInit(otInstance *aInstance)
     {
         perror("if_nametoindex");
     }
-
-    OT_UNUSED_VARIABLE(aInstance);
 }
 
 static otError readSocket(int aFd, uint8_t *aPayload, uint16_t &aLength, otMessageInfo &aMessageInfo)
@@ -319,12 +314,6 @@ exit:
 
 void platformUdpProcess(otInstance *aInstance, const fd_set *aReadFdSet)
 {
-    if (sInstance == NULL)
-    {
-        sInstance = aInstance;
-        platformUdpInit(aInstance);
-    }
-
     for (otUdpSocket *socket = otUdpGetSockets(aInstance); socket != NULL; socket = socket->mNext)
     {
         int fd = GetFdFromHandle(socket->mHandle);

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -93,7 +93,7 @@ otError otPlatUdpClose(otUdpSocket *aUdpSocket)
     otError error = OT_ERROR_NONE;
     int     fd    = GetFdFromHandle(aUdpSocket->mHandle);
 
-    VerifyOrExit(fd > 0);
+    VerifyOrExit(fd != -1 && aUdpSocket->mSockName.mPort != 0);
     closeFd(fd);
 
 exit:
@@ -327,7 +327,7 @@ void platformUdpProcess(otInstance *aInstance, const fd_set *aReadFdSet)
     {
         int fd = GetFdFromHandle(socket->mHandle);
 
-        if (FD_ISSET(fd, aReadFdSet))
+        if (fd != -1 && FD_ISSET(fd, aReadFdSet))
         {
             otMessageInfo messageInfo;
             otMessage *   message = NULL;

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -240,7 +240,6 @@ otError otPlatUdpBind(otUdpSocket *aUdpSocket)
     VerifyOrExit(fd == -1, error = OT_ERROR_ALREADY);
 
     fd = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
-    assert(fd > 0);
     VerifyOrExit(fd > 0, error = OT_ERROR_FAILED);
 
     {
@@ -274,13 +273,10 @@ otError otPlatUdpBind(otUdpSocket *aUdpSocket)
     aUdpSocket->mHandle = GetHandleFromFd(fd);
 
 exit:
-    if (error != OT_ERROR_NONE)
+    if (error == OT_ERROR_FAILED)
     {
-        if (error == OT_ERROR_FAILED)
-        {
-            perror("otPlatUdpBind");
-            closeFd(fd);
-        }
+        perror("otPlatUdpBind");
+        closeFd(fd);
     }
 
     return error;
@@ -314,8 +310,6 @@ otError otPlatUdpSend(otUdpSocket *aUdpSocket, otMessage *aMessage, const otMess
     {
         SuccessOrExit(error = otPlatUdpBind(aUdpSocket));
     }
-
-    assert(fd != -1);
 
     {
         uint16_t len = otMessageGetLength(aMessage);


### PR DESCRIPTION
This PR defines a set of platform APIs to integrate UDP layer of OpenThread with that of platform.

With this PR, services or applications developed upon OpenThread can be also accessed through platform's own network interface, e.g. socket() on POSIX.

The following figure shows how this works.

```
                                        App
                                         |
+----------------------------------------+------+
|               OpenThread Core          |      |
|                                        |      |
|   MLE          TMF      BorderAgent    |      |
|    |            |           |          |      |
| ot Socket    ot Socket   ot Socket  ot Socket |
|    |            |           |          |      |
|    |   +--------+--------+  |          |      |
|    |   |Joiner Entrust   |  |          |      |
|    +-+-+                 +--+--+-------+      |
|      |                         |              |
|      V                         |              |
|    ot UDP                      |              |
|      |                         |              |
|      V                         |              |
|    ot Ip6                      |              |
|      |                         |              |
|      V                         |              |
|    ot Mac                      |              |
|      |                         |              |
+------+-------------------------+--------------+
       |                         |
       V                         V
 Platform Radio             Platform UDP
```