### PR TITLE
[posix-app] remove link file from posix-app

### DIFF
--- a/src/posix/platform/Makefile.am
+++ b/src/posix/platform/Makefile.am
@@ -43,18 +43,28 @@ libopenthread_posix_a_SOURCES             = \
     alarm.c                                 \
     flash.c                                 \
     frame_queue.cpp                         \
-    hdlc.cpp                                \
     logging.c                               \
     misc.c                                  \
     radio_spinel.cpp                        \
     random.c                                \
     settings.cpp                            \
     spi-stubs.c                             \
-    spinel.c                                \
     sim.c                                   \
     system.c                                \
     uart.c                                  \
     $(NULL)
+
+INC_NCP_SOURCES                           = \
+    inc_spinel.c                            \
+    inc_hdlc.cpp                            \
+    $(NULL)
+
+nodist_libopenthread_posix_a_SOURCES      = \
+    $(INC_NCP_SOURCES)                      \
+    $(NULL)
+
+inc_%: ../../ncp/%
+	echo '#include "$<"' > $@
 
 noinst_HEADERS                            = \
     flash.h                                 \

--- a/src/posix/platform/hdlc.cpp
+++ b/src/posix/platform/hdlc.cpp
@@ -1,1 +1,0 @@
-../../ncp/hdlc.cpp

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -1812,4 +1812,5 @@ void otPlatDiagAlarmCallback(otInstance *aInstance)
 {
     (void)aInstance;
 }
+
 #endif // OPENTHREAD_ENABLE_DIAG

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -1812,5 +1812,4 @@ void otPlatDiagAlarmCallback(otInstance *aInstance)
 {
     (void)aInstance;
 }
-
 #endif // OPENTHREAD_ENABLE_DIAG

--- a/src/posix/platform/spinel.c
+++ b/src/posix/platform/spinel.c
@@ -1,1 +1,0 @@
-../../ncp/spinel.c


### PR DESCRIPTION
The symbolic link file and the real file are treated as different files when performing code coverage tests. This PR removes link file and generate `inc_*` files to work around the `distcleancheck` issue(see [travis failure](https://travis-ci.org/bukepo/openthread/jobs/427109480)).