### PR TITLE
[ncp] add support for SPINEL_PROP_PHY_RSSI property in radio only mode

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -2071,6 +2071,11 @@ exit:
     return error;
 }
 
+template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_PHY_RSSI>(void)
+{
+    return mEncoder.WriteInt8(otPlatRadioGetRssi(mInstance));
+}
+
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_PHY_RX_SENSITIVITY>(void)
 {
     return mEncoder.WriteInt8(otPlatRadioGetReceiveSensitivity(mInstance));

--- a/src/ncp/ncp_base_dispatcher.cpp
+++ b/src/ncp/ncp_base_dispatcher.cpp
@@ -80,6 +80,9 @@ NcpBase::PropertyHandler NcpBase::FindGetPropertyHandler(spinel_prop_key_t aKey)
     case SPINEL_PROP_PHY_CHAN:
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_PHY_CHAN>;
         break;
+    case SPINEL_PROP_PHY_RSSI:
+        handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_PHY_RSSI>;
+        break;
     case SPINEL_PROP_PHY_RX_SENSITIVITY:
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_PHY_RX_SENSITIVITY>;
         break;
@@ -170,9 +173,6 @@ NcpBase::PropertyHandler NcpBase::FindGetPropertyHandler(spinel_prop_key_t aKey)
         break;
     case SPINEL_PROP_PHY_FREQ:
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_PHY_FREQ>;
-        break;
-    case SPINEL_PROP_PHY_RSSI:
-        handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_PHY_RSSI>;
         break;
     case SPINEL_PROP_NET_IF_UP:
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_NET_IF_UP>;

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -221,11 +221,6 @@ exit:
     return error;
 }
 
-template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_PHY_RSSI>(void)
-{
-    return mEncoder.WriteInt8(otPlatRadioGetRssi(mInstance));
-}
-
 otError NcpBase::CommandHandler_NET_SAVE(uint8_t aHeader)
 {
     return PrepareLastStatusResponse(aHeader, SPINEL_STATUS_UNIMPLEMENTED);


### PR DESCRIPTION
-----
PR https://github.com/openthread/openthread/pull/3051 helped add support for getting (real) RSSI from the RCP (NCP in radio mode) using the `SPINEL_PROP_PHY_RSSI` property.
This PR chanages the this propery from MTD/FTD mode only to a common one (supported in all builds including radio mode RCP)
