### PR TITLE
[network-data] check and validate received network data before registering

### DIFF
--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -196,7 +196,8 @@ private:
                        bool &   aStable,
                        uint8_t *aTlvs,
                        uint8_t  aTlvsLength,
-                       bool     aExactMatch);
+                       bool     aExactMatch,
+                       bool     aAllowOtherEntries = true);
 
     bool IsStableUpdated(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aTlvsBase, uint8_t aTlvsBaseLength);
 


### PR DESCRIPTION
This commit adds check in `Leader::RegisterNetworkData()`to validate
the received network data and ensure it only contains entries matching
the RLOC16 of the device registering the network data. It updates
`RlocLookup()` method to add a new mode to allow or not allow any
entries that do not match the given RLOC16. 