### PR TITLE
[network-data] remove all matching entries from `RemoveRloc` methods

### DIFF
--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -433,6 +433,12 @@ exit:
     }
 }
 
+bool Leader::RlocMatch(uint16_t aFirstRloc16, uint16_t aSecondRloc16, bool aExactMatch)
+{
+    return ((aExactMatch && aFirstRloc16 == aSecondRloc16) ||
+            (!aExactMatch && Mle::Mle::RouterIdMatch(aFirstRloc16, aSecondRloc16)));
+}
+
 otError Leader::RlocLookup(uint16_t aRloc16,
                            bool &   aIn,
                            bool &   aStable,
@@ -484,8 +490,7 @@ otError Leader::RlocLookup(uint16_t aRloc16,
                     {
                         borderRouterEntry = borderRouter->GetEntry(i);
 
-                        if ((aExactMatch && borderRouterEntry->GetRloc() == aRloc16) ||
-                            (!aExactMatch && (Mle::Mle::RouterIdMatch(borderRouterEntry->GetRloc(), aRloc16))))
+                        if (RlocMatch(borderRouterEntry->GetRloc(), aRloc16, aExactMatch))
                         {
                             aIn = true;
 
@@ -505,8 +510,7 @@ otError Leader::RlocLookup(uint16_t aRloc16,
                     {
                         hasRouteEntry = hasRoute->GetEntry(i);
 
-                        if ((aExactMatch && hasRouteEntry->GetRloc() == aRloc16) ||
-                            (!aExactMatch && (Mle::Mle::RouterIdMatch(hasRouteEntry->GetRloc(), aRloc16))))
+                        if (RlocMatch(hasRouteEntry->GetRloc(), aRloc16, aExactMatch))
                         {
                             aIn = true;
 
@@ -555,8 +559,7 @@ otError Leader::RlocLookup(uint16_t aRloc16,
                     server = static_cast<ServerTlv *>(subCur);
                     VerifyOrExit(server->IsValid(), error = OT_ERROR_PARSE);
 
-                    if ((aExactMatch && server->GetServer16() == aRloc16) ||
-                        (!aExactMatch && (Mle::Mle::RouterIdMatch(server->GetServer16(), aRloc16))))
+                    if (RlocMatch(server->GetServer16(), aRloc16, aExactMatch))
                     {
                         aIn = true;
 
@@ -1372,8 +1375,7 @@ otError Leader::RemoveRloc(ServiceTlv &service, uint16_t aRloc16, bool aExactMat
         case NetworkDataTlv::kTypeServer:
             server = static_cast<ServerTlv *>(cur);
 
-            if ((aExactMatch && server->GetServer16() == aRloc16) ||
-                (!aExactMatch && (Mle::Mle::RouterIdMatch(server->GetServer16(), aRloc16))))
+            if (RlocMatch(server->GetServer16(), aRloc16, aExactMatch))
             {
                 removeLength = sizeof(ServerTlv) + server->GetServerDataLength();
                 service.SetSubTlvsLength(service.GetSubTlvsLength() - removeLength);
@@ -1396,23 +1398,19 @@ otError Leader::RemoveRloc(ServiceTlv &service, uint16_t aRloc16, bool aExactMat
 
 otError Leader::RemoveRloc(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute, uint16_t aRloc16, bool aExactMatch)
 {
-    HasRouteEntry *entry;
+    HasRouteEntry *entry = aHasRoute.GetFirstEntry();
 
-    // remove rloc from has route tlv
-    for (uint8_t i = 0; i < aHasRoute.GetNumEntries(); i++)
+    while (entry <= aHasRoute.GetLastEntry())
     {
-        entry = aHasRoute.GetEntry(i);
-
-        if ((aExactMatch && entry->GetRloc() != aRloc16) ||
-            (!aExactMatch && !(Mle::Mle::RouterIdMatch(entry->GetRloc(), aRloc16))))
+        if (RlocMatch(entry->GetRloc(), aRloc16, aExactMatch))
         {
+            aHasRoute.SetLength(aHasRoute.GetLength() - sizeof(HasRouteEntry));
+            aPrefix.SetSubTlvsLength(aPrefix.GetSubTlvsLength() - sizeof(HasRouteEntry));
+            Remove(reinterpret_cast<uint8_t *>(entry), sizeof(HasRouteEntry));
             continue;
         }
 
-        aHasRoute.SetLength(aHasRoute.GetLength() - sizeof(HasRouteEntry));
-        aPrefix.SetSubTlvsLength(aPrefix.GetSubTlvsLength() - sizeof(HasRouteEntry));
-        Remove(reinterpret_cast<uint8_t *>(entry), sizeof(*entry));
-        break;
+        entry = entry->GetNext();
     }
 
     return OT_ERROR_NONE;
@@ -1420,23 +1418,19 @@ otError Leader::RemoveRloc(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute, uint16_t 
 
 otError Leader::RemoveRloc(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter, uint16_t aRloc16, bool aExactMatch)
 {
-    BorderRouterEntry *entry;
+    BorderRouterEntry *entry = aBorderRouter.GetFirstEntry();
 
-    // remove rloc from border router tlv
-    for (uint8_t i = 0; i < aBorderRouter.GetNumEntries(); i++)
+    while (entry <= aBorderRouter.GetLastEntry())
     {
-        entry = aBorderRouter.GetEntry(i);
-
-        if ((aExactMatch && entry->GetRloc() != aRloc16) ||
-            (!aExactMatch && !(Mle::Mle::RouterIdMatch(entry->GetRloc(), aRloc16))))
+        if (RlocMatch(entry->GetRloc(), aRloc16, aExactMatch))
         {
+            aBorderRouter.SetLength(aBorderRouter.GetLength() - sizeof(BorderRouterEntry));
+            aPrefix.SetSubTlvsLength(aPrefix.GetSubTlvsLength() - sizeof(BorderRouterEntry));
+            Remove(reinterpret_cast<uint8_t *>(entry), sizeof(*entry));
             continue;
         }
 
-        aBorderRouter.SetLength(aBorderRouter.GetLength() - sizeof(BorderRouterEntry));
-        aPrefix.SetSubTlvsLength(aPrefix.GetSubTlvsLength() - sizeof(BorderRouterEntry));
-        Remove(reinterpret_cast<uint8_t *>(entry), sizeof(*entry));
-        break;
+        entry = entry->GetNext();
     }
 
     return OT_ERROR_NONE;

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -191,6 +191,8 @@ private:
     otError RemoveRloc(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute, uint16_t aRloc16, bool aExactMatch);
     otError RemoveRloc(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter, uint16_t aRloc16, bool aExactMatch);
 
+    static bool RlocMatch(uint16_t aFirstRloc16, uint16_t aSecondRloc16, bool aExactMatch);
+
     otError RlocLookup(uint16_t aRloc16,
                        bool &   aIn,
                        bool &   aStable,

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -226,6 +226,14 @@ public:
         mFlags = (mFlags & ~kPreferenceMask) | ((aPrf << kPreferenceOffset) & kPreferenceMask);
     }
 
+    /**
+     * This method returns a pointer to the next HasRouteEntry.
+     *
+     * @returns A pointer to the next HasRouteEntry.
+     *
+     */
+    HasRouteEntry *GetNext(void) { return (this + 1); }
+
 private:
     enum
     {
@@ -275,6 +283,27 @@ public:
     HasRouteEntry *GetEntry(uint8_t i)
     {
         return reinterpret_cast<HasRouteEntry *>(GetValue() + (i * sizeof(HasRouteEntry)));
+    }
+
+    /**
+     * This method returns a pointer to the first HasRouteEntry (at index 0'th).
+     *
+     * @returns A pointer to the first HasRouteEntry.
+     *
+     */
+    HasRouteEntry *GetFirstEntry(void) { return reinterpret_cast<HasRouteEntry *>(GetValue()); }
+
+    /**
+     * This method returns a pointer to the last HasRouteEntry.
+     *
+     * If there are no entries the pointer will be invalid but guaranteed to be before the `GetFirstEntry()` pointer.
+     *
+     * @returns A pointer to the last HasRouteEntry.
+     *
+     */
+    HasRouteEntry *GetLastEntry(void)
+    {
+        return reinterpret_cast<HasRouteEntry *>(GetValue() + GetLength() - sizeof(HasRouteEntry));
     }
 } OT_TOOL_PACKED_END;
 
@@ -586,6 +615,14 @@ public:
      */
     void SetOnMesh(void) { mFlags |= kOnMeshFlag; }
 
+    /**
+     * This method returns a pointer to the next BorderRouterEntry
+     *
+     * @returns A pointer to the next BorderRouterEntry.
+     *
+     */
+    BorderRouterEntry *GetNext(void) { return (this + 1); }
+
 private:
     uint16_t mRloc;
     uint8_t  mFlags;
@@ -630,6 +667,27 @@ public:
     BorderRouterEntry *GetEntry(uint8_t i)
     {
         return reinterpret_cast<BorderRouterEntry *>(GetValue() + (i * sizeof(BorderRouterEntry)));
+    }
+
+    /**
+     * This method returns a pointer to the first BorderRouterEntry (at index 0'th).
+     *
+     * @returns A pointer to the first BorderRouterEntry.
+     *
+     */
+    BorderRouterEntry *GetFirstEntry(void) { return reinterpret_cast<BorderRouterEntry *>(GetValue()); }
+
+    /**
+     * This method returns a pointer to the last BorderRouterEntry.
+     *
+     * If there are no entries the pointer will be invalid but guaranteed to be before the `GetFirstEntry()` pointer.
+     *
+     * @returns A pointer to the last BorderRouterEntry.
+     *
+     */
+    BorderRouterEntry *GetLastEntry(void)
+    {
+        return reinterpret_cast<BorderRouterEntry *>(GetValue() + GetLength() - sizeof(BorderRouterEntry));
     }
 } OT_TOOL_PACKED_END;
 

--- a/tests/toranj/start.sh
+++ b/tests/toranj/start.sh
@@ -139,6 +139,7 @@ run test-021-address-cache-table.py
 run test-022-multicast-ip6-address.py
 run test-023-multicast-traffic.py
 run test-024-partition-merge.py
+run test-025-network-data-timeout.py
 run test-100-mcu-power-state.py
 run test-600-channel-manager-properties.py
 run test-601-channel-manager-channel-change.py

--- a/tests/toranj/test-025-network-data-timeout.py
+++ b/tests/toranj/test-025-network-data-timeout.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+#
+#  Copyright (c) 2018, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+
+import time
+import wpan
+from wpan import verify
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Test description: Network Data (on-mesh prefix) timeout and entry removal
+#
+# Network topology
+#
+#   r1 ----- r2
+#            |
+#            |
+#            c2 (sleepy)
+#
+#
+# Test covers the following steps:
+#
+# - Every node adds a unique on-mesh prefix.
+# - Every node also adds a common on-mesh prefix (with different flags).
+# - Verify that all the unique and common prefixes are present on all nodes are associated with correct RLOC16.
+# - Remove `r2` from network (which removes `c2` as well) from Thread partition created by `r1`.
+# - Verify that all on-mesh prefixes added by `r2` or `c2` (unique and common) are removed on `r1`.
+#
+
+test_name = __file__[:-3] if __file__.endswith('.py') else __file__
+print '-' * 120
+print 'Starting \'{}\''.format(test_name)
+
+
+def verify_prefix(node_list, prefix, rloc16, prefix_len=64, stable=True, priority='med', on_mesh=False, slaac=False, dhcp=False,
+        configure=False, default_route=False, preferred=True):
+    """
+    This function verifies that the `prefix` is present on all the nodes in the `node_list`. It also verifies that the
+    `prefix` is associated with the given `rloc16` (as an integer).
+    """
+    for node in node_list:
+        prefixes = wpan.parse_on_mesh_prefix_result(node.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES))
+        for p in prefixes:
+            if p.prefix == prefix and p.origin == "ncp" and int(p.rloc16(), 0) == rloc16:
+                verify(int(p.prefix_len) == prefix_len)
+                verify(p.is_stable() == stable)
+                verify(p.is_on_mesh() == on_mesh)
+                verify(p.is_def_route() == default_route)
+                verify(p.is_slaac() == slaac)
+                verify(p.is_dhcp() == dhcp)
+                verify(p.is_config() == configure)
+                verify(p.is_preferred() == preferred)
+                verify(p.priority == priority)
+                break
+        else:
+            raise wpan.VerifyError("Did not find prefix {} on node {}".format(prefix, node))
+
+def verify_no_prefix(node_list, prefix, rloc16):
+    """
+    This function verifies that none of the nodes in `node_list` contains the on-mesh `prefix` associated with the
+    given `rloc16`.
+    """
+    for node in node_list:
+        prefixes = wpan.parse_on_mesh_prefix_result(node.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES))
+        for p in prefixes:
+            if p.prefix == prefix and p.origin == "ncp" and int(p.rloc16(), 0) == rloc16:
+                raise wpan.VerifyError("Did find prefix {} with rloc {} on node {}".format(prefix, hex(rloc16), node))
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Creating `wpan.Nodes` instances
+
+speedup = 25
+wpan.Node.set_time_speedup_factor(speedup)
+
+r1 = wpan.Node()
+r2 = wpan.Node()
+c2 = wpan.Node()
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Init all nodes
+
+wpan.Node.init_all_nodes()
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Build network topology
+#
+# Test topology:
+#
+#   r1 ----- r2
+#            |
+#            |
+#            c2
+
+r1.form("net-data")
+
+r1.whitelist_node(r2)
+r2.whitelist_node(r1)
+r2.join_node(r1, wpan.JOIN_TYPE_ROUTER)
+
+r2.whitelist_node(c2)
+c2.whitelist_node(r2)
+c2.join_node(r2, wpan.JOIN_TYPE_SLEEPY_END_DEVICE)
+c2.set(wpan.WPAN_POLL_INTERVAL, '400')
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Test implementation
+
+common_prefix = "fd00:cafe::"
+prefix1 = "fd00:1::"
+prefix2 = "fd00:2::"
+prefix3 = "fd00:3::"
+
+wait_time = 15
+
+# Each node adds its own prefix.
+r1.add_prefix(prefix1, on_mesh=True, preferred=True, stable=True)
+r2.add_prefix(prefix2, on_mesh=True, preferred=True, stable=True)
+c2.add_prefix(prefix3, on_mesh=True, preferred=True, stable=True)
+
+# `common_prefix` is added by all three nodes (with different flags)
+r1.add_prefix(common_prefix, on_mesh=True, preferred=True, stable=False)
+r2.add_prefix(common_prefix, on_mesh=True, preferred=True, stable=True)
+c2.add_prefix(common_prefix, on_mesh=True, preferred=False, stable=True)
+
+r1_rloc = int(r1.get(wpan.WPAN_THREAD_RLOC16), 0)
+r2_rloc = int(r2.get(wpan.WPAN_THREAD_RLOC16), 0)
+c2_rloc = int(c2.get(wpan.WPAN_THREAD_RLOC16), 0)
+
+def check_prefixes():
+    # Verify that all three `prefix1`, 'prefix2', and `prefix3` are present on all nodes
+    # and respectively associated with `r1`, r2, and `r3` nodes.
+    verify_prefix([r1, r2, c2], prefix1, r1_rloc, on_mesh=True, preferred=True, stable=True)
+    verify_prefix([r1, r2, c2], prefix2, r2_rloc, on_mesh=True, preferred=True, stable=True)
+    verify_prefix([r1, r2, c2], prefix3, c2_rloc, on_mesh=True, preferred=True, stable=True)
+
+    # Verify the presence of `common_prefix` associated with each node (with correct flags).
+    verify_prefix([r1, r2, c2], common_prefix, r1_rloc, on_mesh=True, preferred=True, stable=False)
+    verify_prefix([r1, r2, c2], common_prefix, r2_rloc, on_mesh=True, preferred=True, stable=True)
+    verify_prefix([r1, r2, c2], common_prefix, c2_rloc, on_mesh=True, preferred=False, stable=True)
+
+wpan.verify_within(check_prefixes, wait_time)
+
+# Remove `r2`. This should trigger all the prefixes added by it or its child to timeout and be removed.
+r2.leave()
+
+def check_prefixes_on_r1_after_r2_leave():
+    # Verify that entries added by r1 are still present
+    verify_prefix([r1], prefix1, r1_rloc, on_mesh=True, preferred=True, stable=True)
+    verify_prefix([r1], common_prefix, r1_rloc, on_mesh=True, preferred=True, stable=False)
+
+    # Verify all entries added by `r2` or `c2` are removed
+    verify_no_prefix([r1], prefix2, r2_rloc)
+    verify_no_prefix([r1], prefix3, c2_rloc)
+    verify_no_prefix([r1], common_prefix, r2_rloc)
+    verify_no_prefix([r1], common_prefix, c2_rloc)
+
+wpan.verify_within(check_prefixes_on_r1_after_r2_leave, wait_time)
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Test finished
+
+wpan.Node.finalize_all_nodes()
+
+print '\'{}\' passed.'.format(test_name)

--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -1015,10 +1015,11 @@ class OnMeshPrefix(object):
         # Example of expected text:
         #
         # '\t"fd00:abba:cafe::       prefix_len:64   origin:user     stable:yes flags:0x31'
-        # ' [on-mesh:1 def-route:0 config:0 dhcp:0 slaac:1 pref:1 prio:med]"'
+        # ' [on-mesh:1 def-route:0 config:0 dhcp:0 slaac:1 pref:1 prio:med] rloc:0x0000"'
 
-        m = re.match('\t"([0-9a-fA-F:]+)\s*prefix_len:(\d+)\s+origin:(\w*)\s+stable:(\w*).*' +
-                    '\[on-mesh:(\d)\s+def-route:(\d)\s+config:(\d)\s+dhcp:(\d)\s+slaac:(\d)\s+pref:(\d)\s+prio:(\w*)\]',
+        m = re.match('\t"([0-9a-fA-F:]+)\s*prefix_len:(\d+)\s+origin:(\w*)\s+stable:(\w*).* \[' +
+                    'on-mesh:(\d)\s+def-route:(\d)\s+config:(\d)\s+dhcp:(\d)\s+slaac:(\d)\s+pref:(\d)\s+prio:(\w*)\]' +
+                    '\s+rloc:(0x[0-9a-fA-F]+)',
                      text)
         verify(m is not None)
         data = m.groups()
@@ -1034,6 +1035,7 @@ class OnMeshPrefix(object):
         self._slaac      = (data[8] == '1')
         self._preferred  = (data[9] == '1')
         self._priority   = (data[10])
+        self._rloc16     = (data[11])
 
     @property
     def prefix(self):
@@ -1071,6 +1073,9 @@ class OnMeshPrefix(object):
 
     def is_preferred(self):
         return self._preferred
+
+    def rloc16(self):
+        return self._rloc16
 
     def __repr__(self):
         return 'OnMeshPrefix({})'.format(self.__dict__)


### PR DESCRIPTION
This commit makes changes to ensure the `Leader::RemoveRloc` methods
remove all matching entries from a `BorderRouterTlv` or `HasRouteTlv`
It adds new methods to `BorderRouterTlv` and `HasRouteTlv` to get the
first entry or last entry and allow an easier way to iterate over all
the entries.
This commit also adds a new helper method `RlocMatch()` to simplify
the comparison of RLOC16 values (exact match vs router id match).

----
PR https://github.com/openthread/openthread/pull/2905 helped fix the issue to clean a child-added network data when its parent is removed. This PR address a related issue where if there were multiple matching entries, only the first one would have been removed (we would `break` from the loop going over entries upon finding a match). 



