### PR TITLE
[icmp6] pass Echo Request messages to user-defined callback

### DIFF
--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -159,7 +159,7 @@ otError Icmp::HandleMessage(Message &aMessage, MessageInfo &aMessageInfo)
 
     if (icmp6Header.GetType() == IcmpHeader::kTypeEchoRequest)
     {
-        ExitNow(error = HandleEchoRequest(aMessage, aMessageInfo));
+        SuccessOrExit(error = HandleEchoRequest(aMessage, aMessageInfo));
     }
 
     aMessage.MoveOffset(sizeof(icmp6Header));


### PR DESCRIPTION
I believe the idea behind [this change](https://github.com/openthread/openthread/pull/3016/files#diff-4eeb1f333894faf7f7e14d1c228b453bL162) in #3016 was too check if `HandleEchoRequest` is not failing.

The result is that ICMPv6 Echo Requests are not passed to user-defined ICMPv6 callback registered via `otIcmp6RegisterHandler` function (see couple line below my change).

This feature is very important for us.