### PR TITLE
[core] update first parent request with only R flag during downgrade

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1622,11 +1622,15 @@ void Mle::HandleAttachTimer(void)
         mReceivedResponseFromParent = false;
         GetNetif().GetMeshForwarder().SetRxOnWhenIdle(true);
 
+        // initial MLE Parent Request has both E and R flags set in Scan Mask TLV
+        // during reattach when losing connectivity.
         if (mParentRequestMode == kAttachSame1 || mParentRequestMode == kAttachSame2)
         {
             SendParentRequest(kParentRequestTypeRoutersAndReeds);
             delay = kParentRequestReedTimeout;
         }
+        // initial MLE Parent Request has only R flag set in Scan Mask TLV for
+        // during initial attach or downgrade process
         else
         {
             SendParentRequest(kParentRequestTypeRouters);
@@ -1783,6 +1787,7 @@ uint32_t Mle::Reattach(void)
         break;
 
     case kAttachSame2:
+    case kAttachSameDowngrade:
         BecomeChild(kAttachAny);
         break;
 
@@ -3141,8 +3146,12 @@ otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInf
         case kAttachSame1:
         case kAttachSame2:
             VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId());
-            VerifyOrExit(diff > 0 || (diff == 0 && netif.GetMle().GetRouterTable().GetLeaderAge() <
-                                                       netif.GetMle().GetNetworkIdTimeout()));
+            VerifyOrExit(diff > 0);
+            break;
+
+        case kAttachSameDowngrade:
+            VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId());
+            VerifyOrExit(diff >= 0);
             break;
 
         case kAttachBetter:
@@ -4101,6 +4110,10 @@ const char *Mle::AttachModeToString(AttachMode aMode)
 
     case kAttachBetter:
         str = "better-partition";
+        break;
+
+    case kAttachSameDowngrade:
+        str = "same-partition-downgrade";
         break;
     }
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -88,10 +88,11 @@ namespace Mle {
  */
 enum AttachMode
 {
-    kAttachAny    = 0, ///< Attach to any Thread partition.
-    kAttachSame1  = 1, ///< Attach to the same Thread partition (attempt 1).
-    kAttachSame2  = 2, ///< Attach to the same Thread partition (attempt 2).
-    kAttachBetter = 3, ///< Attach to a better (i.e. higher weight/partition id) Thread partition.
+    kAttachAny           = 0, ///< Attach to any Thread partition.
+    kAttachSame1         = 1, ///< Attach to the same Thread partition (attempt 1 when losing connectivity).
+    kAttachSame2         = 2, ///< Attach to the same Thread partition (attempt 2 when losing connectivity).
+    kAttachBetter        = 3, ///< Attach to a better (i.e. higher weight/partition id) Thread partition.
+    kAttachSameDowngrade = 4, ///< Attach to the same Thread partition during downgrade process.
 };
 
 /**

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -243,24 +243,22 @@ otError MleRouter::HandleChildStart(AttachMode aMode)
 
     switch (aMode)
     {
+    case kAttachSameDowngrade:
+        SendAddressRelease();
+
+        // reset children info if any
+        if (HasChildren())
+        {
+            RemoveChildren();
+        }
+
+        // reset routerId info
+        SetRouterId(kInvalidRouterId);
+        break;
+
     case kAttachSame1:
     case kAttachSame2:
-
-        // downgrade
-        if (mRouterTable.GetActiveRouterCount() > mRouterDowngradeThreshold)
-        {
-            SendAddressRelease();
-
-            // reset children info if any
-            if (HasChildren())
-            {
-                RemoveChildren();
-            }
-
-            // reset routerId info
-            SetRouterId(kInvalidRouterId);
-        }
-        else if (HasChildren())
+        if (HasChildren())
         {
             BecomeRouter(ThreadStatusTlv::kHaveChildIdRequest);
         }
@@ -1753,7 +1751,7 @@ void MleRouter::HandleStateUpdateTimer(void)
         {
             // downgrade to REED
             otLogNoteMle(GetInstance(), "Downgrade to REED");
-            BecomeChild(kAttachSame1);
+            BecomeChild(kAttachSameDowngrade);
         }
 
         break;


### PR DESCRIPTION
This commit distinguishes the attach same process during downgrade from
the one caused by losing connectivity as for the former downgrade
scenario, there must be enough active routers to provide connectivity,
and additional benefits is to avoid the impact of possible flooding parent
responses if there are lots of REEDs in large scale thread network.