### PR TITLE
[toranj] enable new mode "posix app and RCP"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -157,3 +157,6 @@ matrix:
     - env: BUILD_TARGET="toranj-test-framework" VERBOSE=1
       os: linux
       compiler: gcc
+    - env: BUILD_TARGET="toranj-test-framework" VERBOSE=1 TORANJ_POSIX_APP_RCP_MODEL=1
+      os: linux
+      compiler: gcc

--- a/tests/toranj/openthread-core-toranj-config.h
+++ b/tests/toranj/openthread-core-toranj-config.h
@@ -275,5 +275,31 @@
 #define OPENTHREAD_CONFIG_NCP_ENABLE_MCU_POWER_STATE_CONTROL 1
 
 
+#if OPENTHREAD_RADIO
+/**
+ * @def OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ACK_TIMEOUT
+ *
+ * Define to 1 if you want to enable software ACK timeout logic.
+ *
+ */
+#define OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ACK_TIMEOUT 1
+
+/**
+ * @def OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT
+ *
+ * Define to 1 if you want to enable software retransmission logic.
+ *
+ */
+#define OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT 1
+
+/**
+ * @def OPENTHREAD_CONFIG_ENABLE_SOFTWARE_CSMA_BACKOFF
+ *
+ * Define to 1 if you want to enable software CSMA-CA backoff logic.
+ *
+ */
+#define OPENTHREAD_CONFIG_ENABLE_SOFTWARE_CSMA_BACKOFF          1
+#endif // OPENTHREAD_RADIO
+
 #endif /* OPENTHREAD_CORE_TORANJ_CONFIG_H_ */
 

--- a/tests/toranj/start.sh
+++ b/tests/toranj/start.sh
@@ -53,7 +53,7 @@ run() {
     counter=0
     while true; do
 
-        if sudo python $1; then
+        if sudo -E python $1; then
             cleanup
             return
         fi
@@ -78,41 +78,91 @@ run() {
 cd $(dirname $0)
 cd ../..
 
-# Build OpenThread posix mode with required configuration
-
+# On Travis CI, the $BUILD_TARGET is defined as "toranj-test-framework".
 if [ "$BUILD_TARGET" = "toranj-test-framework" ]; then
     coverage=yes
 else
     coverage=no
 fi
 
-./bootstrap || die
-./configure                             \
-    CPPFLAGS='-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"../tests/toranj/openthread-core-toranj-config.h\"' \
-    --enable-coverage=${coverage}       \
-    --enable-ncp                        \
-    --with-ncp-bus=uart                 \
-    --enable-border-router              \
-    --enable-child-supervision          \
-    --enable-diag                       \
-    --enable-ftd                        \
-    --enable-jam-detection              \
-    --enable-legacy                     \
-    --enable-mac-filter                 \
-    --enable-service                    \
-    --enable-channel-monitor            \
-    --enable-channel-manager            \
-    --enable-commissioner               \
-    --with-examples=posix               \
-    --disable-docs                      \
-    --disable-tests || die
+case $TORANJ_POSIX_APP_RCP_MODEL in
+    1|yes)
+        use_posix_app_with_rcp=yes
+        ;;
+    *)
+        use_posix_app_with_rcp=no
+        ;;
+esac
 
-make -j 8 || die
+configure_options="                \
+    --disable-docs                 \
+    --disable-tests                \
+    --enable-border-router         \
+    --enable-channel-manager       \
+    --enable-channel-monitor       \
+    --enable-child-supervision     \
+    --enable-commissioner          \
+    --enable-coverage=$coverage    \
+    --enable-diag                  \
+    --enable-ftd                   \
+    --enable-jam-detection         \
+    --enable-legacy                \
+    --enable-mac-filter            \
+    --enable-ncp                   \
+    --enable-service               \
+    --with-ncp-bus=uart            \
+    "
 
-# Run all the tests
+cppflags_config='-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"../tests/toranj/openthread-core-toranj-config.h\"'
+
+if [ "$use_posix_app_with_rcp" = "no" ]; then
+
+    echo "==================================================================================================="
+    echo "Building OpenThread NCP FTD mode with POSIX platform"
+    echo "==================================================================================================="
+
+    ./bootstrap || die
+    ./configure                             \
+        CPPFLAGS="$cppflags_config"                \
+        --with-examples=posix               \
+        $configure_options || die           \
+
+    make -j 8 || die
+
+else
+
+    echo "===================================================================================================="
+    echo "Building OpenThread RCP (NCP in radio mode) with POSIX platform"
+    echo "===================================================================================================="
+
+    ./bootstrap || die
+    ./configure                             \
+        CPPFLAGS="$cppflags_config"                \
+        --enable-coverage=${coverage}       \
+        --enable-ncp                        \
+        --with-ncp-bus=uart                 \
+        --enable-radio-only                 \
+        --with-examples=posix               \
+        --disable-docs                      \
+        --disable-tests || die
+
+    make -j 8 || die
+
+    echo "===================================================================================================="
+    echo "Building OpenThread POSIX App NCP"
+    echo "===================================================================================================="
+
+    ./bootstrap || die
+    ./configure                             \
+        CPPFLAGS="$cppflags_config -DOPENTHREAD_CONFIG_POSIX_APP_ENABLE_PTY_DEVICE=1" \
+        --enable-posix-app                  \
+        $configure_options || die           \
+
+    make -j 8 || die
+
+fi
 
 cd tests/toranj
-
 cleanup
 
 run test-001-get-set.py

--- a/tests/toranj/start.sh
+++ b/tests/toranj/start.sh
@@ -123,7 +123,7 @@ if [ "$use_posix_app_with_rcp" = "no" ]; then
 
     ./bootstrap || die
     ./configure                             \
-        CPPFLAGS="$cppflags_config"                \
+        CPPFLAGS="$cppflags_config"         \
         --with-examples=posix               \
         $configure_options || die           \
 
@@ -137,7 +137,7 @@ else
 
     ./bootstrap || die
     ./configure                             \
-        CPPFLAGS="$cppflags_config"                \
+        CPPFLAGS="$cppflags_config"         \
         --enable-coverage=${coverage}       \
         --enable-ncp                        \
         --with-ncp-bus=uart                 \

--- a/tests/toranj/test-602-channel-manager-channel-select.py
+++ b/tests/toranj/test-602-channel-manager-channel-select.py
@@ -80,8 +80,8 @@ chan_15_to_17_mask = int('0x0038000', 0)
 node.set(wpan.WPAN_CHANNEL_MANAGER_SUPPORTED_CHANNEL_MASK, str(all_channls_mask))
 verify(int(node.get(wpan.WPAN_CHANNEL_MANAGER_SUPPORTED_CHANNEL_MASK), 0) == all_channls_mask)
 
-# Sleep for 4 second with speedup factor of 10,000 this is more than 11 hours.
-time.sleep(4)
+# Sleep for 4.5 second with speedup factor of 10,000 this is more than 12 hours.
+time.sleep(4.5)
 
 verify(int(node.get(wpan.WPAN_CHANNEL_MONITOR_SAMPLE_COUNT), 0) > 970)
 


### PR DESCRIPTION
This commit updates `toranj` framework to allow a different mode of
operation where tests are run using posix-app along with an RCP (NCP
in radio only mode) build. This commit also adds a new job for the
new model in travis CI build matrix.