### PR TITLE
[thci] fix preferred flag when config border router for ncp device

### DIFF
--- a/tools/harness-thci/OpenThread_WpanCtl.py
+++ b/tools/harness-thci/OpenThread_WpanCtl.py
@@ -1595,7 +1595,7 @@ class OpenThread_WpanCtl(IThci):
             parameter = ''
 
             if P_slaac_preferred == 1:
-                parameter += ' -a'
+                parameter += ' -a -f'
 
             if P_stable == 1:
                 parameter += ' -s'


### PR DESCRIPTION
Fix 7.1.2,  some reference device looks requiring preferred flag