### PR TITLE
[core] remove dependency on libstdc++

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1567,6 +1567,21 @@ AC_SUBST(OPENTHREAD_EXAMPLES_SAMR21)
 AM_CONDITIONAL([OPENTHREAD_EXAMPLES_SAMR21], [test "${with_examples}" = "samr21"])
 
 #
+# libstdc++
+#
+AC_ARG_WITH(
+    [libstdcxx],
+    [AS_HELP_STRING([--with-libstdcxx], [Specify the C++ standard library to link to @<:@default=none@:>@.])],
+    [],
+    [with_libstdcxx=none])
+
+if test "${with_libstdcxx}" = "none"; then
+    CXXFLAGS="${CXXFLAGS} -fno-exceptions -fno-rtti"
+else
+    AC_CHECK_LIB([${with_libstdcxx}], [__cxa_pure_virtual], , [AC_MSG_ERROR([Uanble to find standard C++ library])])
+fi
+
+#
 # Tools
 #
 

--- a/configure.ac
+++ b/configure.ac
@@ -233,7 +233,7 @@ AC_PATH_PROG(CMP, cmp)
 #
 
 PROSPECTIVE_CFLAGS="-Wall -Wextra -Wshadow -Werror -std=c99 -pedantic-errors"
-PROSPECTIVE_CXXFLAGS="-Wall -Wextra -Wshadow -Werror -std=gnu++98 -Wno-c++14-compat"
+PROSPECTIVE_CXXFLAGS="-Wall -Wextra -Wshadow -Werror -std=gnu++98 -Wno-c++14-compat -fno-exceptions -fno-rtti"
 
 AC_CACHE_CHECK([whether $CC is Clang],
     [nl_cv_clang],
@@ -1565,21 +1565,6 @@ AM_CONDITIONAL([OPENTHREAD_EXAMPLES_NRF52840], [test "${with_examples}" = "nrf52
 
 AC_SUBST(OPENTHREAD_EXAMPLES_SAMR21)
 AM_CONDITIONAL([OPENTHREAD_EXAMPLES_SAMR21], [test "${with_examples}" = "samr21"])
-
-#
-# libstdc++
-#
-AC_ARG_WITH(
-    [libstdcxx],
-    [AS_HELP_STRING([--with-libstdcxx], [Specify the C++ standard library to link to @<:@default=none@:>@.])],
-    [],
-    [with_libstdcxx=none])
-
-if test "${with_libstdcxx}" = "none"; then
-    CXXFLAGS="${CXXFLAGS} -fno-exceptions -fno-rtti"
-else
-    AC_CHECK_LIB([${with_libstdcxx}], [__cxa_pure_virtual], , [AC_MSG_ERROR([Uanble to find standard C++ library])])
-fi
 
 #
 # Tools

--- a/examples/platforms/posix/Makefile.platform.am
+++ b/examples/platforms/posix/Makefile.platform.am
@@ -32,5 +32,4 @@
 
 LDADD_COMMON                                                          += \
     $(top_builddir)/examples/platforms/posix/libopenthread-posix.a       \
-    -lstdc++                                                             \
     $(NULL)

--- a/src/cli/cli_server.hpp
+++ b/src/cli/cli_server.hpp
@@ -54,19 +54,32 @@ public:
      *
      * @returns The number of bytes placed in the output queue.
      *
+     * @retval  -1  Driver is broken.
+     *
      */
-    virtual int Output(const char *aBuf, uint16_t aBufLength) = 0;
+    virtual int Output(const char *aBuf, uint16_t aBufLength)
+    {
+        OT_UNUSED_VARIABLE(aBuf);
+        OT_UNUSED_VARIABLE(aBufLength);
+        return -1;
+    }
 
     /**
      * This method delivers formatted output to the client.
      *
-     * @param[in]  aFmt  A pointer to the format string.
-     * @param[in]  ...   A variable list of arguments to format.
+     * @param[in]  aFormat  A pointer to the format string.
+     * @param[in]  ...      A variable list of arguments to format.
      *
      * @returns The number of bytes placed in the output queue.
      *
+     * @retval  -1  Driver is broken.
+     *
      */
-    virtual int OutputFormat(const char *fmt, ...) = 0;
+    virtual int OutputFormat(const char *aFormat, ...)
+    {
+        OT_UNUSED_VARIABLE(aFormat);
+        return -1;
+    }
 };
 
 } // namespace Cli

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -408,7 +408,11 @@ public:
      * @retval OT_ERROR_NONE  Successfully enqueued the IPv6 message.
      *
      */
-    virtual otError SendMessage(Message &aMessage) = 0;
+    virtual otError SendMessage(Message &aMessage)
+    {
+        OT_UNUSED_VARIABLE(aMessage);
+        return OT_ERROR_NOT_IMPLEMENTED;
+    }
 
     /**
      * This virtual method fills out @p aAddress with the link address.
@@ -418,7 +422,11 @@ public:
      * @retval OT_ERROR_NONE  Successfully retrieved the link address.
      *
      */
-    virtual otError GetLinkAddress(LinkAddress &aAddress) const = 0;
+    virtual otError GetLinkAddress(LinkAddress &aAddress) const
+    {
+        OT_UNUSED_VARIABLE(aAddress);
+        return OT_ERROR_NOT_IMPLEMENTED;
+    }
 
     /**
      * This virtual method performs a source-destination route lookup.
@@ -431,7 +439,13 @@ public:
      * @retval OT_ERROR_NO_ROUTE  No route to destination.
      *
      */
-    virtual otError RouteLookup(const Address &aSource, const Address &aDestination, uint8_t *aPrefixMatch) = 0;
+    virtual otError RouteLookup(const Address &aSource, const Address &aDestination, uint8_t *aPrefixMatch)
+    {
+        OT_UNUSED_VARIABLE(aSource);
+        OT_UNUSED_VARIABLE(aDestination);
+        OT_UNUSED_VARIABLE(aPrefixMatch);
+        return OT_ERROR_NOT_IMPLEMENTED;
+    }
 
 private:
     NetifUnicastAddress *  mUnicastAddresses;

--- a/src/posix/Makefile.am
+++ b/src/posix/Makefile.am
@@ -58,7 +58,6 @@ LIBTOOLFLAGS_COMMON = --preserve-dup-deps
 
 LDADD_COMMON                                                           = \
     $(top_builddir)/src/posix/platform/libopenthread-posix.a             \
-    -lstdc++                                                             \
     -lutil                                                               \
     $(NULL)
 


### PR DESCRIPTION
Some platforms don't have libstdc++

* removed pure virtual function `__cxa_pure_virtual`
* added option use `-fno-exceptions -fno-rtti`