### PR TITLE
[meshcop] do not set joiner port in constructor

### DIFF
--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -66,7 +66,6 @@ JoinerRouter::JoinerRouter(Instance &aInstance)
     , mIsJoinerPortConfigured(false)
     , mExpectJoinEntRsp(false)
 {
-    mSocket.GetSockName().mPort = OPENTHREAD_CONFIG_JOINER_UDP_PORT;
     GetNetif().GetCoap().AddResource(mRelayTransmit);
     aInstance.GetNotifier().RegisterCallback(mNotifierCallback);
 }


### PR DESCRIPTION
Port should only be set with `UdpSocket::Bind()`.