### PR TITLE
[ncp] send Parent Response info on NCP FTD configuration

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -279,6 +279,7 @@ NcpBase::NcpBase(Instance *aInstance)
 #if OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
     memset(&mSteeringDataAddress, 0, sizeof(mSteeringDataAddress));
 #endif
+    otThreadRegisterParentResponseCallback(mInstance, &NcpBase::HandleParentResponseInfo, static_cast<void *>(this));
 #endif // OPENTHREAD_FTD
 #if OPENTHREAD_ENABLE_LEGACY
     mLegacyNodeDidJoin = false;

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -266,6 +266,9 @@ protected:
 #if OPENTHREAD_FTD
     static void HandleChildTableChanged(otThreadChildTableEvent aEvent, const otChildInfo *aChildInfo);
     void        HandleChildTableChanged(otThreadChildTableEvent aEvent, const otChildInfo &aChildInfo);
+
+    static void HandleParentResponseInfo(otThreadParentResponseInfo *aInfo, void *aContext);
+    void        HandleParentResponseInfo(const otThreadParentResponseInfo *aInfo);
 #endif
 
     static void HandleDatagramFromStack(otMessage *aMessage, void *aContext);

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -83,6 +83,38 @@ exit:
 // MARK: Property/Status Changed
 // ----------------------------------------------------------------------------
 
+void NcpBase::HandleParentResponseInfo(otThreadParentResponseInfo *aInfo, void *aContext)
+{
+    VerifyOrExit(aInfo && aContext);
+
+    static_cast<NcpBase *>(aContext)->HandleParentResponseInfo(aInfo);
+
+exit:
+    return;
+}
+
+void NcpBase::HandleParentResponseInfo(const otThreadParentResponseInfo *aInfo)
+{
+    VerifyOrExit(aInfo);
+
+    SuccessOrExit(mEncoder.BeginFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_CMD_PROP_VALUE_IS,
+                                      SPINEL_PROP_PARENT_RESPONSE_INFO));
+
+    SuccessOrExit(mEncoder.WriteEui64(aInfo->mExtAddr));
+    SuccessOrExit(mEncoder.WriteUint16(aInfo->mRloc16));
+    SuccessOrExit(mEncoder.WriteInt8(aInfo->mRssi));
+    SuccessOrExit(mEncoder.WriteInt8(aInfo->mPriority));
+    SuccessOrExit(mEncoder.WriteUint8(aInfo->mLinkQuality3));
+    SuccessOrExit(mEncoder.WriteUint8(aInfo->mLinkQuality2));
+    SuccessOrExit(mEncoder.WriteUint8(aInfo->mLinkQuality1));
+    SuccessOrExit(mEncoder.WriteBool(aInfo->mIsAttached));
+
+    SuccessOrExit(mEncoder.EndFrame());
+
+exit:
+    return;
+}
+
 void NcpBase::HandleChildTableChanged(otThreadChildTableEvent aEvent, const otChildInfo *aChildInfo)
 {
     GetNcpInstance()->HandleChildTableChanged(aEvent, *aChildInfo);

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1842,6 +1842,10 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "RCP_VERSION";
         break;
 
+    case SPINEL_PROP_PARENT_RESPONSE_INFO:
+        ret = "PARENT_RESPONSE_INFO";
+        break;
+
     case SPINEL_PROP_UART_BITRATE:
         ret = "UART_BITRATE";
         break;

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -2016,6 +2016,24 @@ typedef enum {
      */
     SPINEL_PROP_RCP_VERSION = SPINEL_PROP_OPENTHREAD__BEGIN + 12,
 
+    /// Thread Parent Response info
+    /** Format: `ESccCCCb` - Asynchronous event only
+     *
+     *  `E`: Extended address
+     *  `S`: RLOC16
+     *  `c`: Instant RSSI
+     *  'c': Parent Priority
+     *  `C`: Link Quality3
+     *  `C`: Link Quality2
+     *  `C`: Link Quality1
+     *  'b': Is the node receiving parent response frame attached
+     *
+     * This property sends Parent Response frame information to the Host.
+     * This property is available for FTD build only.
+     *
+     */
+    SPINEL_PROP_PARENT_RESPONSE_INFO = SPINEL_PROP_OPENTHREAD__BEGIN + 13,
+
     SPINEL_PROP_OPENTHREAD__END = 0x2000,
 
     SPINEL_PROP_INTERFACE__BEGIN = 0x100,


### PR DESCRIPTION
- Register a callback API to receive parent response info in "ncp_base" class constructor.
- Added a new Spinel key to send the parent response info data to host.
