### PR TITLE
[spinel] do not use glibc-internal header sys/cdefs.h

### DIFF
--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -51,16 +51,6 @@
 #define SPINEL_API_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 #endif // ifdef __GNUC__
 
-#if !defined(__BEGIN_DECLS) || !defined(__END_DECLS)
-#if defined(__cplusplus)
-#define __BEGIN_DECLS extern "C" {
-#define __END_DECLS }
-#else // if defined(__cplusplus)
-#define __BEGIN_DECLS
-#define __END_DECLS
-#endif // else defined(__cplusplus)
-#endif // if !defined(__BEGIN_DECLS) || !defined(__END_DECLS)
-
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #ifndef SPINEL_API_EXTERN
@@ -105,7 +95,9 @@
 
 // ----------------------------------------------------------------------------
 
-__BEGIN_DECLS
+#if defined(__cplusplus)
+extern "C" {
+#endif
 
 typedef enum {
     SPINEL_STATUS_OK      = 0, ///< Operation has completed successfully.
@@ -2587,6 +2579,8 @@ SPINEL_API_EXTERN const char *spinel_capability_to_cstr(unsigned int capability)
 
 // ----------------------------------------------------------------------------
 
-__END_DECLS
+#if defined(__cplusplus)
+}
+#endif
 
 #endif /* defined(SPINEL_HEADER_INCLUDED) */


### PR DESCRIPTION
The `sys/cdefs.h` is an internal header of `glibc` and is not meant to
be used by user code.  The macros needed from it can be trivially
implemented where required, relying on this header being present
excludes OpenThread from being used on systems where `glibc` is not the
used C library (e.g. OpenWRT, where `uclibc` or `musl` is standard).

https://wiki.musl-libc.org/faq.html#Q:-When-compiling-something-against-musl,-I-get-error-messages-about-%3Ccode%3Esys/cdefs.h%3C/code%3E