### PR TITLE
[nRF52840] Fix NCP radio not working on USB CDC UART

### DIFF
--- a/examples/platforms/nrf52840/platform-nrf5.h
+++ b/examples/platforms/nrf52840/platform-nrf5.h
@@ -54,6 +54,12 @@ void nrf5UartInit(void);
 void nrf5UartDeinit(void);
 
 /**
+ * Clear pending UART data.
+ *
+ */
+void nrf5UartClearPendingData(void);
+
+/**
  * This function performs UART driver processing.
  *
  */

--- a/examples/platforms/nrf52840/system.c
+++ b/examples/platforms/nrf52840/system.c
@@ -81,6 +81,11 @@ void otSysInit(int argc, char *argv[])
         nrf5UartInit();
         nrf5CryptoInit();
     }
+    else
+    {
+        nrf5UartClearPendingData();
+    }
+
 #ifndef SPIS_TRANSPORT_DISABLE
     nrf5SpiSlaveInit();
 #endif

--- a/examples/platforms/nrf52840/uart.c
+++ b/examples/platforms/nrf52840/uart.c
@@ -150,6 +150,11 @@ void nrf5UartInit(void)
     // Intentionally empty.
 }
 
+void nrf5UartClearPendingData(void)
+{
+    // Intentionally empty.
+}
+
 void nrf5UartDeinit(void)
 {
     if (sUartEnabled)

--- a/examples/platforms/nrf52840/usb-cdc-uart.c
+++ b/examples/platforms/nrf52840/usb-cdc-uart.c
@@ -290,6 +290,13 @@ void nrf5UartDeinit(void)
     app_usbd_uninit();
 }
 
+void nrf5UartClearPendingData(void)
+{
+    sUsbState.mTransferInProgress = false;
+    sUsbState.mTxBuffer           = NULL;
+    sUsbState.mTxSize             = 0;
+}
+
 void nrf5UartProcess(void)
 {
     while (app_usbd_event_queue_process())


### PR DESCRIPTION
Connecting posix ot-cli and ot-ncp to NCP radio device triggered an assertion on nRF52840 Development Kit due to USB returning OT_ERROR_BUSY. USB-CDC-UART TX buffer was not cleared after pseudo reset.