### PR TITLE
[link-raw] retransmit frames on any error

### DIFF
--- a/src/core/mac/link_raw.cpp
+++ b/src/core/mac/link_raw.cpp
@@ -291,7 +291,7 @@ void LinkRaw::InvokeTransmitDone(otRadioFrame *aFrame, otRadioFrame *aAckFrame, 
         mCsmaBackoffs = 0;
     }
 
-    if (aError == OT_ERROR_NO_ACK)
+    if (aError != OT_ERROR_NONE)
     {
         if (mTransmitRetries < aFrame->mInfo.mTxInfo.mMaxFrameRetries)
         {


### PR DESCRIPTION
----

This makes the `link-raw` behavior similar to how `mac.cpp` behaves.