### PR TITLE
[logging] check for non-null instance in otLog<level>Plat macros

### DIFF
--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -1360,19 +1360,55 @@ extern "C" {
  *
  */
 #if OPENTHREAD_CONFIG_LOG_PLATFORM == 1
-#define otLogCritPlat(aInstance, aFormat, ...) \
-    otLogCrit(aInstance, OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnPlat(aInstance, aFormat, ...) \
-    otLogWarn(aInstance, OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNotePlat(aInstance, aFormat, ...) \
-    otLogNote(aInstance, OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoPlat(aInstance, aFormat, ...) \
-    otLogInfo(aInstance, OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgPlat(aInstance, aFormat, ...) \
-    otLogDebg(aInstance, OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritPlat(aInstance, aFormat, ...)                                                               \
+    do                                                                                                       \
+    {                                                                                                        \
+        if (aInstance != NULL)                                                                               \
+        {                                                                                                    \
+            otLogCrit(aInstance, OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__); \
+        }                                                                                                    \
+    } while (false)
+
+#define otLogWarnPlat(aInstance, aFormat, ...)                                                               \
+    do                                                                                                       \
+    {                                                                                                        \
+        if (aInstance != NULL)                                                                               \
+        {                                                                                                    \
+            otLogWarn(aInstance, OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__); \
+        }                                                                                                    \
+    } while (false)
+
+#define otLogNotePlat(aInstance, aFormat, ...)                                                               \
+    do                                                                                                       \
+    {                                                                                                        \
+        if (aInstance != NULL)                                                                               \
+        {                                                                                                    \
+            otLogNote(aInstance, OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__); \
+        }                                                                                                    \
+    } while (false)
+
+#define otLogInfoPlat(aInstance, aFormat, ...)                                                               \
+    do                                                                                                       \
+    {                                                                                                        \
+        if (aInstance != NULL)                                                                               \
+        {                                                                                                    \
+            otLogInfo(aInstance, OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__); \
+        }                                                                                                    \
+    } while (false)
+
+#define otLogDebgPlat(aInstance, aFormat, ...)                                                               \
+    do                                                                                                       \
+    {                                                                                                        \
+        if (aInstance != NULL)                                                                               \
+        {                                                                                                    \
+            otLogDebg(aInstance, OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__); \
+        }                                                                                                    \
+    } while (false)
+
 #else
 #define otLogCritPlat(aInstance, aFormat, ...)
 #define otLogWarnPlat(aInstance, aFormat, ...)
+#define otLogNotePlat(aInstance, aFormat, ...)
 #define otLogInfoPlat(aInstance, aFormat, ...)
 #define otLogDebgPlat(aInstance, aFormat, ...)
 #endif

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -283,7 +283,7 @@ static int ForkPty(const char *aCommand, const char *aArguments)
 
         rval = snprintf(cmd, sizeof(cmd), "exec %s %s", aCommand, aArguments);
         VerifyOrExit(rval > 0 && static_cast<size_t>(rval) < sizeof(cmd),
-                     otLogCritPlat(mInstance, "NCP file and configuration is too long!"));
+                     fprintf(stderr, "NCP file and configuration is too long!"));
 
         execl(getenv("SHELL"), getenv("SHELL"), "-c", cmd, NULL);
         perror("open pty failed");
@@ -560,9 +560,8 @@ void RadioSpinel::Init(const char *aRadioFile, const char *aRadioConfig)
         if ((versionMajor != SPINEL_PROTOCOL_VERSION_THREAD_MAJOR) ||
             (versionMinor != SPINEL_PROTOCOL_VERSION_THREAD_MINOR))
         {
-            otLogCritPlat(mInstance, "Spinel version mismatch - PosixApp:%d.%d, RCP:%d.%d",
-                          SPINEL_PROTOCOL_VERSION_THREAD_MAJOR, SPINEL_PROTOCOL_VERSION_THREAD_MINOR, versionMajor,
-                          versionMinor);
+            fprintf(stderr, "Spinel version mismatch - PosixApp:%d.%d, RCP:%d.%d", SPINEL_PROTOCOL_VERSION_THREAD_MAJOR,
+                    SPINEL_PROTOCOL_VERSION_THREAD_MINOR, versionMajor, versionMinor);
             ExitNow(error = OT_ERROR_FAILED);
         }
     }


### PR DESCRIPTION
This commit contains the following changes
- It updates the `otLog<Levl>Plat` macros to verify that passed in
  `aInstance` pointer is not NULL.
- It updates the `RadioSpinel` implementation to use `fprint`
  in functions/methods where `mInstance` is not available or
  is known to be `NULL` (e.g., during radio initialization).

--------

This will help allow us to enable logging in "Posix App". The radio is initialized before OT instance is available and we do receive from RCP during initialization which may trigger a `otLogPlat` calls with a  `NULL` instance. 