### PR TITLE
[coaps] refine definition of CoapSecure::Connect

### DIFF
--- a/include/openthread/coap_secure.h
+++ b/include/openthread/coap_secure.h
@@ -188,7 +188,7 @@ otError otCoapSecureSetCaCertificateChain(otInstance *   aInstance,
  * This method initializes DTLS session with a peer.
  *
  * @param[in]  aInstance               A pointer to an OpenThread instance.
- * @param[in]  aMessageInfo            A pointer to a message info structure.
+ * @param[in]  aSockAddr               A pointer to the remote sockaddr.
  * @param[in]  aCallback               A pointer to a function that will be called when the DTLS connection
  *                                     state changes.
  * @param[in]  aContext                A pointer to arbitrary context information.
@@ -197,7 +197,7 @@ otError otCoapSecureSetCaCertificateChain(otInstance *   aInstance,
  *
  */
 otError otCoapSecureConnect(otInstance *                    aInstance,
-                            const otMessageInfo *           aMessageInfo,
+                            const otSockAddr *              aSockAddr,
                             otHandleCoapSecureClientConnect aHandler,
                             void *                          aContext);
 

--- a/src/core/api/coap_secure_api.cpp
+++ b/src/core/api/coap_secure_api.cpp
@@ -34,6 +34,7 @@
 #include "openthread-core-config.h"
 
 #include <openthread/coap_secure.h>
+#include <openthread/ip6.h>
 
 #include "coap/coap_header.hpp"
 #include "coap/coap_secure.hpp"
@@ -152,13 +153,13 @@ void otCoapSecureSetSslAuthMode(otInstance *aInstance, bool aVerifyPeerCertifica
 }
 
 otError otCoapSecureConnect(otInstance *                    aInstance,
-                            const otMessageInfo *           aMessageInfo,
+                            const otSockAddr *              aSockAddr,
                             otHandleCoapSecureClientConnect aHandler,
                             void *                          aContext)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.GetApplicationCoapSecure().Connect(*static_cast<const Ip6::MessageInfo *>(aMessageInfo), aHandler,
+    return instance.GetApplicationCoapSecure().Connect(*static_cast<const Ip6::SockAddr *>(aSockAddr), aHandler,
                                                        aContext);
 }
 

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -118,9 +118,20 @@ otError CoapSecure::Stop(void)
     return CoapBase::Stop();
 }
 
-otError CoapSecure::Connect(const Ip6::MessageInfo &aMessageInfo, ConnectedCallback aCallback, void *aContext)
+otError CoapSecure::Connect(const Ip6::SockAddr &aSockAddr, ConnectedCallback aCallback, void *aContext)
 {
-    mPeerAddress       = aMessageInfo;
+    memcpy(&mPeerAddress.mPeerAddr, &aSockAddr.mAddress, sizeof(mPeerAddress.mPeerAddr));
+    mPeerAddress.mPeerPort = aSockAddr.mPort;
+
+    if (aSockAddr.GetAddress().IsLinkLocal() || aSockAddr.GetAddress().IsMulticast())
+    {
+        mPeerAddress.mInterfaceId = aSockAddr.mScopeId;
+    }
+    else
+    {
+        mPeerAddress.mInterfaceId = 0;
+    }
+
     mConnectedCallback = aCallback;
     mConnectedContext  = aContext;
 

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -125,14 +125,14 @@ public:
     /**
      * This method initializes DTLS session with a peer.
      *
-     * @param[in]  aMessageInfo            A pointer to a message info structure.
+     * @param[in]  aSockAddr               A reference to the remote sockaddr.
      * @param[in]  aCallback               A pointer to a function that will be called once DTLS connection is
      * established.
      *
      * @retval OT_ERROR_NONE  Successfully started DTLS connection.
      *
      */
-    otError Connect(const Ip6::MessageInfo &aMessageInfo, ConnectedCallback aCallback, void *aContext);
+    otError Connect(const Ip6::SockAddr &aSockAddr, ConnectedCallback aCallback, void *aContext);
 
     /**
      * This method indicates whether or not the DTLS session is active.

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -284,7 +284,7 @@ otError Joiner::TryNextJoin()
 
     if (joinerRouter->mPriority > 0)
     {
-        Ip6::MessageInfo messageInfo;
+        Ip6::SockAddr sockaddr;
 
         joinerRouter->mPriority = 0;
 
@@ -292,12 +292,12 @@ otError Joiner::TryNextJoin()
         netif.GetMac().SetPanChannel(joinerRouter->mChannel);
         netif.GetIp6Filter().AddUnsecurePort(netif.GetCoapSecure().GetPort());
 
-        messageInfo.GetPeerAddr().mFields.m16[0] = HostSwap16(0xfe80);
-        messageInfo.GetPeerAddr().SetIid(joinerRouter->mExtAddr);
-        messageInfo.mPeerPort    = joinerRouter->mJoinerUdpPort;
-        messageInfo.mInterfaceId = OT_NETIF_INTERFACE_ID_THREAD;
+        sockaddr.GetAddress().mFields.m16[0] = HostSwap16(0xfe80);
+        sockaddr.GetAddress().SetIid(joinerRouter->mExtAddr);
+        sockaddr.mPort    = joinerRouter->mJoinerUdpPort;
+        sockaddr.mScopeId = OT_NETIF_INTERFACE_ID_THREAD;
 
-        netif.GetCoapSecure().Connect(messageInfo, Joiner::HandleSecureCoapClientConnect, this);
+        netif.GetCoapSecure().Connect(sockaddr, Joiner::HandleSecureCoapClientConnect, this);
         mState = OT_JOINER_STATE_CONNECT;
         error  = OT_ERROR_NONE;
     }

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -193,7 +193,7 @@ public:
      * This constructor initializes the object.
      *
      */
-    SockAddr(void) { memset(&mAddress, 0, sizeof(mAddress)), mPort = 0, mScopeId = 0; }
+    SockAddr(void) { memset(&mAddress, 0, sizeof(*this)); }
 
     /**
      * This method returns a reference to the IPv6 address.


### PR DESCRIPTION
This PR make the CoAP connect API consistent to the UDP's connect API.