### PR TITLE
[mac] use direct callbacks into mesh forwarder for send/recv

### DIFF
--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -277,119 +277,6 @@ private:
 };
 
 /**
- * This class implements a MAC receiver client.
- *
- */
-class Receiver : public OwnerLocator
-{
-    friend class Mac;
-
-public:
-    /**
-     * This function pointer is called when a MAC frame is received.
-     *
-     * @param[in]  aReceiver A reference to the MAC receiver client object.
-     * @param[in]  aFrame    A reference to the MAC frame.
-     *
-     */
-    typedef void (*ReceiveFrameHandler)(Receiver &aReceiver, Frame &aFrame);
-
-    /**
-     * This function pointer is called on a data request command (data poll) timeout, i.e., when the ack in response to
-     * a data request command indicated a frame is pending, but no frame was received after `kDataPollTimeout` interval.
-     *
-     * @param[in]  aReceiver  A reference to the MAC receiver client object.
-     *
-     */
-    typedef void (*DataPollTimeoutHandler)(Receiver &aReceiver);
-
-    /**
-     * This constructor creates a MAC receiver client.
-     *
-     * @param[in]  aReceiveFrameHandler  A pointer to a function that is called on MAC frame reception.
-     * @param[in]  aPollTimeoutHandler   A pointer to a function called on data poll timeout (may be set to NULL).
-     * @param[in]  aOwner                A pointer to owner of this object.
-     *
-     */
-    Receiver(ReceiveFrameHandler aReceiveFrameHandler, DataPollTimeoutHandler aPollTimeoutHandler, void *aOwner)
-        : OwnerLocator(aOwner)
-        , mReceiveFrameHandler(aReceiveFrameHandler)
-        , mPollTimeoutHandler(aPollTimeoutHandler)
-        , mNext(NULL)
-    {
-    }
-
-private:
-    void HandleReceivedFrame(Frame &aFrame) { mReceiveFrameHandler(*this, aFrame); }
-
-    void HandleDataPollTimeout(void)
-    {
-        if (mPollTimeoutHandler != NULL)
-        {
-            mPollTimeoutHandler(*this);
-        }
-    }
-
-    ReceiveFrameHandler    mReceiveFrameHandler;
-    DataPollTimeoutHandler mPollTimeoutHandler;
-    Receiver *             mNext;
-};
-
-/**
- * This class implements a MAC sender client.
- *
- */
-class Sender : public OwnerLocator
-{
-    friend class Mac;
-
-public:
-    /**
-     * This function pointer is called when the MAC is about to transmit the frame asking MAC sender client to provide
-     * the frame.
-     *
-     * @param[in]  aSender   A reference to the MAC sender client object.
-     * @param[in]  aFrame    A reference to the MAC frame buffer.
-     *
-     */
-    typedef otError (*FrameRequestHandler)(Sender &aSender, Frame &aFrame);
-
-    /**
-     * This function pointer is called when the MAC is done sending the frame.
-     *
-     * @param[in]  aSender   A reference to the MAC sender client object.
-     * @param[in]  aFrame    A reference to the MAC frame buffer that was sent.
-     * @param[in]  aError    The status of the last MSDU transmission.
-     *
-     */
-    typedef void (*SentFrameHandler)(Sender &aSender, Frame &aFrame, otError aError);
-
-    /**
-     * This constructor creates a MAC sender client.
-     *
-     * @param[in]  aFrameRequestHandler  A pointer to a function that is called when about to send a MAC frame.
-     * @param[in]  aSentFrameHandler     A pointer to a function that is called when done sending the frame.
-     * @param[in]  aOwner                A pointer to owner of this object.
-     *
-     */
-    Sender(FrameRequestHandler aFrameRequestHandler, SentFrameHandler aSentFrameHandler, void *aOwner)
-        : OwnerLocator(aOwner)
-        , mFrameRequestHandler(aFrameRequestHandler)
-        , mSentFrameHandler(aSentFrameHandler)
-        , mNext(NULL)
-    {
-    }
-
-private:
-    otError HandleFrameRequest(Frame &aFrame) { return mFrameRequestHandler(*this, aFrame); }
-    void    HandleSentFrame(Frame &aFrame, otError aError) { mSentFrameHandler(*this, aFrame, aError); }
-
-    FrameRequestHandler mFrameRequestHandler;
-    SentFrameHandler    mSentFrameHandler;
-    Sender *            mNext;
-};
-
-/**
  * This class implements the IEEE 802.15.4 MAC.
  *
  */
@@ -508,35 +395,25 @@ public:
     void SetRxOnWhenIdle(bool aRxOnWhenIdle);
 
     /**
-     * This method registers a new MAC receiver client.
+     * This method requests a new MAC frame transmission.
      *
-     * @param[in]  aReceiver  A reference to the MAC receiver client.
-     *
-     * @retval OT_ERROR_NONE     Successfully registered the receiver.
-     * @retval OT_ERROR_ALREADY  The receiver was already registered.
-     *
-     */
-    otError RegisterReceiver(Receiver &aReceiver);
-
-    /**
-     * This method registers a new MAC sender client.
-     *
-     * @param[in]  aSender  A reference to the MAC sender client.
-     *
-     * @retval OT_ERROR_NONE     Successfully registered the sender.
-     * @retval OT_ERROR_ALREADY  The sender was already registered.
+     * @retval OT_ERROR_NONE           Frame transmission request is scheduled successfully.
+     * @retval OT_ERROR_ALREADY        MAC is busy sending earlier transmission request.
+     * @retval OT_ERROR_INVALID_STATE  The MAC layer is not enabled.
      *
      */
-    otError SendFrameRequest(Sender &aSender);
+    otError SendFrameRequest(void);
 
     /**
-     * This method registers a Out of Band frame for MAC Transmission.
+     * This method requests an Out of Band frame for MAC Transmission.
+     *
      * An Out of Band frame is one that was generated outside of OpenThread.
      *
      * @param[in]  aOobFrame  A pointer to the frame.
      *
-     * @retval OT_ERROR_NONE     Successfully registered the frame.
-     * @retval OT_ERROR_ALREADY  MAC layer is busy sending a previously registered frame.
+     * @retval OT_ERROR_NONE           Successfully scheduled the frame transmission.
+     * @retval OT_ERROR_ALREADY        MAC layer is busy sending a previously requested frame.
+     * @retval OT_ERROR_INVALID_STATE  The MAC layer is not enabled.
      *
      */
     otError SendOutOfBandFrameRequest(otRadioFrame *aOobFrame);
@@ -1037,9 +914,6 @@ private:
 
     otNetworkName   mNetworkName;
     otExtendedPanId mExtendedPanId;
-
-    Sender *  mSendHead, *mSendTail;
-    Receiver *mReceiveHead, *mReceiveTail;
 
     uint8_t mBeaconSequence;
     uint8_t mDataSequence;

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -69,6 +69,8 @@ enum
  */
 class MeshForwarder : public InstanceLocator
 {
+    friend class Mac::Mac;
+
 public:
     /**
      * This constructor initializes the object.
@@ -322,20 +324,17 @@ private:
     void     RemoveMessage(Message &aMessage);
     void     HandleDiscoverComplete(void);
 
-    static void    HandleReceivedFrame(Mac::Receiver &aReceiver, Mac::Frame &aFrame);
-    void           HandleReceivedFrame(Mac::Frame &aFrame);
-    static otError HandleFrameRequest(Mac::Sender &aSender, Mac::Frame &aFrame);
-    otError        HandleFrameRequest(Mac::Frame &aFrame);
-    static void    HandleSentFrame(Mac::Sender &aSender, Mac::Frame &aFrame, otError aError);
-    void           HandleSentFrame(Mac::Frame &aFrame, otError aError);
-    void           HandleSentFrameToChild(const Mac::Frame &aFrame, otError aError, const Mac::Address &macDest);
-    static void    HandleDiscoverTimer(Timer &aTimer);
-    void           HandleDiscoverTimer(void);
-    static void    HandleReassemblyTimer(Timer &aTimer);
-    void           HandleReassemblyTimer(void);
-    static void    ScheduleTransmissionTask(Tasklet &aTasklet);
-    void           ScheduleTransmissionTask(void);
-    static void    HandleDataPollTimeout(Mac::Receiver &aReceiver);
+    void    HandleReceivedFrame(Mac::Frame &aFrame);
+    otError HandleFrameRequest(Mac::Frame &aFrame);
+    void    HandleSentFrame(Mac::Frame &aFrame, otError aError);
+    void    HandleSentFrameToChild(const Mac::Frame &aFrame, otError aError, const Mac::Address &macDest);
+
+    static void HandleDiscoverTimer(Timer &aTimer);
+    void        HandleDiscoverTimer(void);
+    static void HandleReassemblyTimer(Timer &aTimer);
+    void        HandleReassemblyTimer(void);
+    static void ScheduleTransmissionTask(Tasklet &aTasklet);
+    void        ScheduleTransmissionTask(void);
 
     otError GetDestinationRlocByServiceAloc(uint16_t aServiceAloc, uint16_t &aMeshDest);
 
@@ -401,10 +400,8 @@ private:
                        otLogLevel          aLogLevel);
 #endif // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE) && (OPENTHREAD_CONFIG_LOG_MAC == 1)
 
-    Mac::Receiver mMacReceiver;
-    Mac::Sender   mMacSender;
-    TimerMilli    mDiscoverTimer;
-    TimerMilli    mReassemblyTimer;
+    TimerMilli mDiscoverTimer;
+    TimerMilli mReassemblyTimer;
 
     PriorityQueue mSendQueue;
     MessageQueue  mReassemblyList;

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -434,7 +434,7 @@ otError MeshForwarder::GetIndirectTransmission(void)
 
         mIndirectStartingChild = &child;
 
-        netif.GetMac().SendFrameRequest(mMacSender);
+        netif.GetMac().SendFrameRequest();
         ExitNow(error = OT_ERROR_NONE);
     }
 


### PR DESCRIPTION
This commit changes `Mac` implementation to use direct callbacks into
`MeshForwarder` to inform it of a frame reception or status of a
requested frame transmission. This changes replaces the `Mac::Sender`
and `Mac::Receiver` model.