### PR TITLE
[posix-app] check RCP capabilities and add support for stream log

### DIFF
--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -445,8 +445,12 @@ private:
         kMaxSpinelFrame    = 2048, ///< Max size in bytes for transferring spinel frames.
         kMaxWaitTime       = 2000, ///< Max time to wait for response in milliseconds.
         kVersionStringSize = 128,  ///< Max size of version string.
+        kCapsBufferSize    = 100,  ///< Max buffer size used to store `SPINEL_PROP_CAPS` value.
     };
 
+    otError CheckSpinelVersion(void);
+    otError CheckCapabilities(void);
+    otError CheckRadioCapabilities(void);
     void    DecodeHdlc(const uint8_t *aData, uint16_t aLength);
     void    ReadAll(void);
     otError WriteAll(const uint8_t *aBuffer, uint16_t aLength);
@@ -591,10 +595,11 @@ private:
 
     int          mSockFd;
     otRadioState mState;
-    bool         mIsAckRequested : 1; ///< Ack requested.
-    bool         mIsDecoding : 1;     ///< Decoding hdlc frames.
-    bool         mIsPromiscuous : 1;  ///< Promiscuous mode.
-    bool         mIsReady : 1;        ///< NCP ready.
+    bool         mIsAckRequested : 1;    ///< Ack requested.
+    bool         mIsDecoding : 1;        ///< Decoding hdlc frames.
+    bool         mIsPromiscuous : 1;     ///< Promiscuous mode.
+    bool         mIsReady : 1;           ///< NCP ready.
+    bool         mSupportsLogStream : 1; ///< RCP supports `LOG_STREAM` property with OpenThread log meta-data format.
 
 #if OPENTHREAD_ENABLE_DIAG
     bool   mDiagMode;

--- a/tests/toranj/openthread-core-toranj-config.h
+++ b/tests/toranj/openthread-core-toranj-config.h
@@ -171,6 +171,14 @@
 #define OPENTHREAD_CONFIG_LOG_SUFFIX                            ""
 
 /**
+ * @def OPENTHREAD_CONFIG_LOG_PLATFORM
+ *
+ * Define to enable platform region logging.
+ *
+ */
+#define OPENTHREAD_CONFIG_LOG_PLATFORM                          1
+
+/**
  * @def OPENTHREAD_CONFIG_NCP_TX_BUFFER_SIZE
  *
  *  The size of NCP message buffer in bytes


### PR DESCRIPTION
This commit contains the following changes:

- It adds code to `RadioSpinel::Init()` to get and check the RCP
  capabilities (`SPINEL_PROP_CAPS`) ensuring RCP supports radio/raw
  mode (`SPINEL_CAP_MAC_RAW`).

- It adds support for handling stream log `SPINEL_PROP_STREAM_LOG`
  property from RCP.

- It moves the existing code checking spinel version and radio
  capabilities of RCP into helper methods `CheckSpinelVersion()`
  and `CheckRadioCapabilities()`.