### PR TITLE
[mbedtls] disable debug by default

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -45,6 +45,8 @@ python --version || die
 [ $BUILD_TARGET != scan-build ] || {
     ./bootstrap || die
 
+    export CPPFLAGS="-DMBEDTLS_DEBUG_C"
+
     scan-build ./configure                \
         --enable-application-coap         \
         --enable-application-coap-secure  \

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -162,8 +162,11 @@ otError Dtls::Start(bool             aClient,
                                       MBEDTLS_ENTROPY_SOURCE_STRONG);
     VerifyOrExit(rval == 0);
 
+#ifdef MBEDTLS_DEBUG_C
     // mbedTLS's debug level is almost the same as OpenThread's
     mbedtls_debug_set_threshold(OPENTHREAD_CONFIG_LOG_LEVEL);
+#endif
+
     otPlatRadioGetIeeeEui64(&GetInstance(), eui64.m8);
     rval = mbedtls_ctr_drbg_seed(&mCtrDrbg, mbedtls_entropy_func, &mEntropy, eui64.m8, sizeof(eui64));
     VerifyOrExit(rval == 0);

--- a/third_party/mbedtls/mbedtls-config.h
+++ b/third_party/mbedtls/mbedtls-config.h
@@ -70,7 +70,6 @@ __inline int windows_kernel_snprintf(char * s, size_t n, const char * format, ..
 #define MBEDTLS_CIPHER_C
 #define MBEDTLS_CMAC_C
 #define MBEDTLS_CTR_DRBG_C
-#define MBEDTLS_DEBUG_C
 #define MBEDTLS_ECJPAKE_C
 #define MBEDTLS_ECP_C
 #define MBEDTLS_ECP_DP_SECP256R1_ENABLED


### PR DESCRIPTION
Reduces code size by **20,756 bytes** when DTLS is enabled.

```
$ arm-none-eabi-size output/cc2538/bin/ot-cli-ftd 
   text	   data	    bss	    dec	    hex	filename
 218360	   4588	  21648	 244596	  3bb74	output/cc2538/bin/ot-cli-ftd (before)
 197604	   4588	  21644	 223836	  36a5c	output/cc2538/bin/ot-cli-ftd (after)
```
