### PR TITLE
[coaps] fix disconnect in CoAP secure

### DIFF
--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -32,6 +32,7 @@
 
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/new.hpp"
 #include "common/owner-locator.hpp"
 #include "meshcop/dtls.hpp"
 #include "thread/thread_netif.hpp"
@@ -151,7 +152,15 @@ bool CoapSecure::IsConnected(void)
 
 otError CoapSecure::Disconnect(void)
 {
-    return GetNetif().GetDtls().Stop();
+    Ip6::SockAddr sockAddr;
+    otError       error = OT_ERROR_NONE;
+
+    SuccessOrExit(error = GetNetif().GetDtls().Stop());
+    // Disconnect from previous peer by connecting to any address
+    SuccessOrExit(error = mSocket.Connect(sockAddr));
+
+exit:
+    return error;
 }
 
 MeshCoP::Dtls &CoapSecure::GetDtls(void)

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -32,7 +32,6 @@
 
 #include "common/instance.hpp"
 #include "common/logging.hpp"
-#include "common/new.hpp"
 #include "common/owner-locator.hpp"
 #include "meshcop/dtls.hpp"
 #include "thread/thread_netif.hpp"


### PR DESCRIPTION
Disconnect socket in `CoapSecure::Disconnect()`

More Info:
[connect() on Linux]: https://linux.die.net/man/2/connect
[connect() on macOS]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/connect.2.html