### PR TITLE
[mac] add "Mac::ExtAddress::GenerateRandom()" to create random address

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -197,7 +197,7 @@ Mac::Mac(Instance &aInstance)
     , mCcaSampleCount(0)
     , mEnabled(true)
 {
-    GenerateExtAddress(&mExtAddress);
+    mExtAddress.GenerateRandom();
     mCcaSuccessRateTracker.Reset();
     memset(&mCounters, 0, sizeof(otMacCounters));
 
@@ -466,14 +466,6 @@ void Mac::SetRxOnWhenIdle(bool aRxOnWhenIdle)
 
 exit:
     return;
-}
-
-void Mac::GenerateExtAddress(ExtAddress *aExtAddress)
-{
-    Random::FillBuffer(aExtAddress->m8, sizeof(ExtAddress));
-
-    aExtAddress->SetGroup(false);
-    aExtAddress->SetLocal(true);
 }
 
 void Mac::SetExtAddress(const ExtAddress &aExtAddress)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -419,14 +419,6 @@ public:
     otError SendOutOfBandFrameRequest(otRadioFrame *aOobFrame);
 
     /**
-     * This method generates a random IEEE 802.15.4 Extended Address.
-     *
-     * @param[out]  aExtAddress  A pointer to where the generated Extended Address is placed.
-     *
-     */
-    void GenerateExtAddress(ExtAddress *aExtAddress);
-
-    /**
      * This method returns a reference to the IEEE 802.15.4 Extended Address.
      *
      * @returns A pointer to the IEEE 802.15.4 Extended Address.

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -39,9 +39,17 @@
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
+#include "common/random.hpp"
 
 namespace ot {
 namespace Mac {
+
+void ExtAddress::GenerateRandom(void)
+{
+    Random::FillBuffer(m8, sizeof(ExtAddress));
+    SetGroup(false);
+    SetLocal(true);
+}
 
 bool ExtAddress::operator==(const ExtAddress &aOther) const
 {

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -96,6 +96,12 @@ public:
     typedef String<kInfoStringSize> InfoString;
 
     /**
+     * This method generates a random IEEE 802.15.4 Extended Address.
+     *
+     */
+    void GenerateRandom(void);
+
+    /**
      * This method indicates whether or not the Group bit is set.
      *
      * @retval TRUE   If the group bit is set.
@@ -107,7 +113,7 @@ public:
     /**
      * This method sets the Group bit.
      *
-     * @param[in]  aLocal  TRUE if group address, FALSE otherwise.
+     * @param[in]  aGroup  TRUE if group address, FALSE otherwise.
      *
      */
     void SetGroup(bool aGroup)

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -582,7 +582,7 @@ void Joiner::HandleTimer(void)
     case OT_JOINER_STATE_JOINED:
         Mac::ExtAddress extAddress;
 
-        netif.GetMac().GenerateExtAddress(&extAddress);
+        extAddress.GenerateRandom();
         netif.GetMac().SetExtAddress(extAddress);
         netif.GetMle().UpdateLinkLocalAddress();
 


### PR DESCRIPTION
This commit adds method `GenerateRandom()` to `Mac::ExtAddress` to
generate a random IEEE 802.15.4 Extended Address with either a given
or default Group and Local bit settings. This method replaces the
`Mac` class `GenerateExtAddress()` method.