### PR TITLE
[mac] allow same operation to start from done callback handler

### DIFF
--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -829,6 +829,7 @@ private:
     void    UpdateIdleMode(void);
     void    StartOperation(Operation aOperation);
     void    FinishOperation(void);
+    void    PerformNextOperation(void);
     void    SendBeaconRequest(Frame &aFrame);
     void    SendBeacon(Frame &aFrame);
     bool    ShouldSendBeacon(void) const;
@@ -836,7 +837,6 @@ private:
     void    BeginTransmit(void);
     otError HandleMacCommand(Frame &aFrame);
     Frame * GetOperationFrame(void);
-    void    PerformOperation(void);
 
     static void HandleMacTimer(Timer &aTimer);
     void        HandleMacTimer(void);


### PR DESCRIPTION
This commit changes the `Mac` operation scheduling to allow
users to start a new operation from the done callback handler of
a previous operation. For example, calling `Mac::ActiveScan()`
from a previous `mActiveScanHandler` callback handler should
succeed.

This is realized by ensuring to call `FinishOperation()` before
invoking the done callback and after the callback, perform any
pending next operation by calling `PeformNextOperation()`.