### PR TITLE
[link-raw] fix radio with multiple transmit buffers

### DIFF
--- a/examples/platforms/posix/platform-posix.h
+++ b/examples/platforms/posix/platform-posix.h
@@ -244,4 +244,12 @@ void otSimSendEvent(const struct Event *aEvent);
  */
 void otSimSendUartWriteEvent(const uint8_t *aData, uint16_t aLength);
 
+/**
+ * This function checks if radio transmitting is pending.
+ *
+ * @returns Whether radio transmitting is pending.
+ *
+ */
+bool platformRadioIsTransmitPending(void);
+
 #endif // PLATFORM_POSIX_H_

--- a/examples/platforms/posix/sim/platform-sim.c
+++ b/examples/platforms/posix/sim/platform-sim.c
@@ -281,7 +281,7 @@ void otSysProcessDrivers(otInstance *aInstance)
     platformUartUpdateFdSet(&read_fds, &write_fds, &error_fds, &max_fd);
 #endif
 
-    if (!otTaskletsArePending(aInstance) && platformAlarmGetNext() > 0)
+    if (!otTaskletsArePending(aInstance) && platformAlarmGetNext() > 0 && !platformRadioIsTransmitPending())
     {
         platformSendSleepEvent();
 

--- a/examples/platforms/posix/sim/radio-sim.c
+++ b/examples/platforms/posix/sim/radio-sim.c
@@ -540,9 +540,14 @@ void radioSendMessage(otInstance *aInstance)
     sAckWait = true;
 }
 
+bool platformRadioIsTransmitPending(void)
+{
+    return sState == OT_RADIO_STATE_TRANSMIT && !sAckWait;
+}
+
 void platformRadioProcess(otInstance *aInstance)
 {
-    if (sState == OT_RADIO_STATE_TRANSMIT && !sAckWait)
+    if (platformRadioIsTransmitPending())
     {
         radioSendMessage(aInstance);
     }

--- a/include/openthread/link_raw.h
+++ b/include/openthread/link_raw.h
@@ -177,14 +177,13 @@ typedef void (*otLinkRawTransmitDone)(otInstance *  aInstance,
  * 2. Transmits the PSDU on the given channel and at the given transmit power.
  *
  * @param[in]  aInstance    A pointer to an OpenThread instance.
- * @param[in]  aFrame       A pointer to the frame that was transmitted.
  * @param[in]  aCallback    A pointer to a function called on completion of the transmission.
  *
  * @retval OT_ERROR_NONE          Successfully transitioned to Transmit.
  * @retval OT_ERROR_INVALID_STATE The radio was not in the Receive state.
  *
  */
-otError otLinkRawTransmit(otInstance *aInstance, otRadioFrame *aFrame, otLinkRawTransmitDone aCallback);
+otError otLinkRawTransmit(otInstance *aInstance, otLinkRawTransmitDone aCallback);
 
 /**
  * Get the most recent RSSI measurement.

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -105,14 +105,7 @@ otError otLinkRawReceive(otInstance *aInstance, otLinkRawReceiveDone aCallback)
 
 otRadioFrame *otLinkRawGetTransmitBuffer(otInstance *aInstance)
 {
-    otRadioFrame *buffer = NULL;
-
-    VerifyOrExit(static_cast<Instance *>(aInstance)->GetLinkRaw().IsEnabled());
-
-    buffer = otPlatRadioGetTransmitBuffer(aInstance);
-
-exit:
-    return buffer;
+    return static_cast<Instance *>(aInstance)->GetLinkRaw().GetTransmitFrame();
 }
 
 otError otLinkRawTransmit(otInstance *aInstance, otRadioFrame *aFrame, otLinkRawTransmitDone aCallback)

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -108,10 +108,10 @@ otRadioFrame *otLinkRawGetTransmitBuffer(otInstance *aInstance)
     return static_cast<Instance *>(aInstance)->GetLinkRaw().GetTransmitFrame();
 }
 
-otError otLinkRawTransmit(otInstance *aInstance, otRadioFrame *aFrame, otLinkRawTransmitDone aCallback)
+otError otLinkRawTransmit(otInstance *aInstance, otLinkRawTransmitDone aCallback)
 {
-    otLogInfoPlat("LinkRaw Transmit (%d bytes on channel %d)", aFrame->mLength, aFrame->mChannel);
-    return static_cast<Instance *>(aInstance)->GetLinkRaw().Transmit(aFrame, aCallback);
+    otLogInfoPlat("LinkRaw Transmit");
+    return static_cast<Instance *>(aInstance)->GetLinkRaw().Transmit(aCallback);
 }
 
 int8_t otLinkRawGetRssi(otInstance *aInstance)

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -407,7 +407,7 @@ public:
      * @returns A reference to the LinkRaw object.
      *
      */
-    LinkRaw &GetLinkRaw(void) { return mLinkRaw; }
+    Mac::LinkRaw &GetLinkRaw(void) { return mLinkRaw; }
 #endif
 
 private:
@@ -460,7 +460,7 @@ private:
     MessagePool mMessagePool;
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 #if OPENTHREAD_RADIO || OPENTHREAD_ENABLE_RAW_LINK_API
-    LinkRaw mLinkRaw;
+    Mac::LinkRaw mLinkRaw;
 #endif // OPENTHREAD_RADIO || OPENTHREAD_ENABLE_RAW_LINK_API
 
 #if OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
@@ -689,7 +689,7 @@ template <> inline AnnounceSender &Instance::Get(void)
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 
 #if OPENTHREAD_RADIO || OPENTHREAD_ENABLE_RAW_LINK_API
-template <> inline LinkRaw &Instance::Get(void)
+template <> inline Mac::LinkRaw &Instance::Get(void)
 {
     return GetLinkRaw();
 }

--- a/src/core/mac/link_raw.cpp
+++ b/src/core/mac/link_raw.cpp
@@ -361,6 +361,18 @@ void LinkRaw::InvokeTransmitDone(otRadioFrame *aFrame, otRadioFrame *aAckFrame, 
 
     VerifyOrExit(mTransmitDoneCallback != NULL);
 
+    switch (aError)
+    {
+    case OT_ERROR_NONE:
+    case OT_ERROR_NO_ACK:
+    case OT_ERROR_CHANNEL_ACCESS_FAILURE:
+    case OT_ERROR_ABORT:
+        break;
+    default:
+        aError = OT_ERROR_ABORT;
+        break;
+    }
+
     mTransmitDoneCallback(&GetInstance(), aFrame, aAckFrame, aError);
 
 exit:

--- a/src/core/mac/link_raw.hpp
+++ b/src/core/mac/link_raw.hpp
@@ -40,6 +40,7 @@
 
 #include "common/locator.hpp"
 #include "common/timer.hpp"
+#include "mac/mac_frame.hpp"
 
 #if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ACK_TIMEOUT || OPENTHREAD_CONFIG_ENABLE_SOFTWARE_CSMA_BACKOFF || \
     OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ENERGY_SCAN
@@ -50,6 +51,7 @@
 
 namespace ot {
 
+namespace Mac {
 class LinkRaw : public InstanceLocator
 {
 public:
@@ -256,10 +258,10 @@ private:
 
     void        TransmitNow(void);
     void        StartTransmit(void);
-    Tasklet     mOperationTask;
     static void HandleOperationTask(Tasklet &aTasklet);
     void        HandleOperationTask();
 
+    Tasklet  mOperationTask;
     uint16_t mPendingOperations;
 
 #if OPENTHREAD_LINKRAW_TIMER_REQUIRED
@@ -284,18 +286,17 @@ private:
 
 #endif // OPENTHREAD_LINKRAW_TIMER_REQUIRED
 
+#if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_CSMA_BACKOFF
+    void StartCsmaBackoff(void);
+
+    uint8_t mCsmaBackoffs;
+#endif // OPENTHREAD_CONFIG_ENABLE_SOFTWARE_CSMA_BACKOFF
+
 #if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT
 
     uint8_t mTransmitRetries;
-    uint8_t mCsmaBackoffs;
 
 #endif // OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT
-
-#if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_CSMA_BACKOFF
-
-    void StartCsmaBackoff(void);
-
-#endif // OPENTHREAD_CONFIG_ENABLE_SOFTWARE_CSMA_BACKOFF
 
 #if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ENERGY_SCAN
 
@@ -331,10 +332,11 @@ private:
     otLinkRawReceiveDone    mReceiveDoneCallback;
     otLinkRawTransmitDone   mTransmitDoneCallback;
     otLinkRawEnergyScanDone mEnergyScanDoneCallback;
-    otRadioFrame *          mTransmitFrame;
+    Frame *                 mTransmitFrame;
     otRadioCaps             mRadioCaps;
 };
 
+} // namespace Mac
 } // namespace ot
 
 #endif // LINK_RAW_HPP_

--- a/src/core/mac/link_raw.hpp
+++ b/src/core/mac/link_raw.hpp
@@ -52,6 +52,7 @@
 namespace ot {
 
 namespace Mac {
+
 class LinkRaw : public InstanceLocator
 {
 public:
@@ -117,14 +118,13 @@ public:
      *
      * @note The callback @p aCallback will not be called if this call does not return OT_ERROR_NONE.
      *
-     * @param[in]  aFrame               A pointer to the frame that was transmitted.
      * @param[in]  aCallback            A pointer to a function called on completion of the transmission.
      *
      * @retval OT_ERROR_NONE            Successfully transitioned to Transmit.
      * @retval OT_ERROR_INVALID_STATE   The radio was not in the Receive state.
      *
      */
-    otError Transmit(otRadioFrame *aFrame, otLinkRawTransmitDone aCallback);
+    otError Transmit(otLinkRawTransmitDone aCallback);
 
     /**
      * This method invokes the mTransmitDoneCallback, if set.
@@ -251,28 +251,23 @@ public:
     otRadioFrame *GetTransmitFrame(void) { return mTransmitFrame; }
 
 private:
-    enum
-    {
-        kOperationTransmitData = 1 << 0,
-    };
-
     void        TransmitNow(void);
     void        StartTransmit(void);
     static void HandleOperationTask(Tasklet &aTasklet);
-    void        HandleOperationTask();
+    void        HandleOperationTask(void);
 
-    Tasklet  mOperationTask;
-    uint16_t mPendingOperations;
+    Tasklet mOperationTask;
+    bool    mPendingTransmitData : 1;
 
-#if OPENTHREAD_LINKRAW_TIMER_REQUIRED
-
-    enum TimerReason{
+    enum TimerReason
+    {
         kTimerReasonNone,
         kTimerReasonAckTimeout,
         kTimerReasonCsmaBackoffComplete,
         kTimerReasonEnergyScanComplete,
     };
 
+#if OPENTHREAD_LINKRAW_TIMER_REQUIRED
     TimerMilli  mTimer;
     TimerReason mTimerReason;
 #if OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -1072,6 +1072,14 @@ public:
     void SetCsmaCaEnabled(bool aCsmaCaEnabled) { mInfo.mTxInfo.mCsmaCaEnabled = aCsmaCaEnabled; }
 
     /**
+     * This method gets the CSMA-CA enabled attribute.
+     *
+     * @returns  TRUE if CSMA-CA must be enabled for this packet, FALSE otherwise.
+     *
+     */
+    bool IsCsmaCaEnabled(void) const { return mInfo.mTxInfo.mCsmaCaEnabled; }
+
+    /**
      * This method returns the key used for frame encryption and authentication (AES CCM).
      *
      * @returns The pointer to the key.

--- a/src/ncp/ncp_base_radio.cpp
+++ b/src/ncp/ncp_base_radio.cpp
@@ -369,7 +369,7 @@ otError NcpBase::HandlePropertySet_SPINEL_PROP_STREAM_RAW(uint8_t aHeader)
 
     // Pass frame to the radio layer. Note, this fails if we
     // haven't enabled raw stream or are already transmitting.
-    error = otLinkRawTransmit(mInstance, frame, &NcpBase::LinkRawTransmitDone);
+    error = otLinkRawTransmit(mInstance, &NcpBase::LinkRawTransmitDone);
 
 exit:
 


### PR DESCRIPTION
`otPlatRadioGetTransmitBuffer()` may return different values and even null on certain platform. This PR changed link raw so that this API is only called once. Otherwise, it may result in null pointer crash.
Besides,
* avoided reentrance issue of InvokeTransmitDone by deferring transmit in a tasklet.
* corrected how software retransmissions behavior when radio itself supports retransmission. 