### PR TITLE
[mle] add address outside of constructor

### DIFF
--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -423,7 +423,7 @@ OTAPI const otMeshLocalPrefix *OTCALL otThreadGetMeshLocalPrefix(otInstance *aIn
  * @param[in]  aMeshLocalPrefix  A pointer to the Mesh Local Prefix.
  *
  * @retval OT_ERROR_NONE           Successfully set the Mesh Local Prefix.
- * @retval OT_ERROR_INVALID_STATE  Thread protocols are enabled.
+ * @retval OT_ERROR_INVALID_STATE  Thread protocols are not enabled.
  *
  */
 OTAPI otError OTCALL otThreadSetMeshLocalPrefix(otInstance *aInstance, const otMeshLocalPrefix *aMeshLocalPrefix);

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -423,7 +423,7 @@ OTAPI const otMeshLocalPrefix *OTCALL otThreadGetMeshLocalPrefix(otInstance *aIn
  * @param[in]  aMeshLocalPrefix  A pointer to the Mesh Local Prefix.
  *
  * @retval OT_ERROR_NONE           Successfully set the Mesh Local Prefix.
- * @retval OT_ERROR_INVALID_STATE  Thread protocols are not enabled.
+ * @retval OT_ERROR_INVALID_STATE  Thread protocols are enabled.
  *
  */
 OTAPI otError OTCALL otThreadSetMeshLocalPrefix(otInstance *aInstance, const otMeshLocalPrefix *aMeshLocalPrefix);

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -206,7 +206,7 @@ otError otThreadSetMeshLocalPrefix(otInstance *aInstance, const otMeshLocalPrefi
     VerifyOrExit(instance.GetThreadNetif().GetMle().GetRole() == OT_DEVICE_ROLE_DISABLED,
                  error = OT_ERROR_INVALID_STATE);
 
-    error = instance.GetThreadNetif().GetMle().SetMeshLocalPrefix(*aMeshLocalPrefix);
+    instance.GetThreadNetif().GetMle().SetMeshLocalPrefix(*aMeshLocalPrefix);
     instance.GetThreadNetif().GetActiveDataset().Clear();
     instance.GetThreadNetif().GetPendingDataset().Clear();
 

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -99,9 +99,6 @@ Netif::Netif(Instance &aInstance, int8_t aInterfaceId)
         // To mark the address as unused/available, set the `mNext` to point back to itself.
         mExtMulticastAddresses[i].mNext = &mExtMulticastAddresses[i];
     }
-
-    mMulticastAddresses = static_cast<NetifMulticastAddress *>(
-        const_cast<otNetifMulticastAddress *>(&kLinkLocalAllNodesMulticastAddress));
 }
 
 bool Netif::IsMulticastSubscribed(const Address &aAddress) const
@@ -118,6 +115,25 @@ bool Netif::IsMulticastSubscribed(const Address &aAddress) const
 
 exit:
     return rval;
+}
+
+void Netif::SubscribeAllNodesMulticast(void)
+{
+    assert(mMulticastAddresses == NULL);
+
+    mMulticastAddresses = static_cast<NetifMulticastAddress *>(
+        const_cast<otNetifMulticastAddress *>(&kLinkLocalAllNodesMulticastAddress));
+
+    GetNotifier().Signal(OT_CHANGED_IP6_MULTICAST_SUBSRCRIBED);
+}
+
+void Netif::UnsubscribeAllNodesMulticast(void)
+{
+    assert(mMulticastAddresses == NULL || mMulticastAddresses == &kLinkLocalAllNodesMulticastAddress);
+
+    mMulticastAddresses = NULL;
+
+    GetNotifier().Signal(OT_CHANGED_IP6_MULTICAST_UNSUBSRCRIBED);
 }
 
 otError Netif::SubscribeAllRoutersMulticast(void)

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -447,6 +447,21 @@ public:
         return OT_ERROR_NOT_IMPLEMENTED;
     }
 
+protected:
+    /**
+     * This method subscribes the network interface to the realm-local all MPL forwarders, link-local and
+     * realm-local all nodes address.
+     *
+     */
+    void SubscribeAllNodesMulticast(void);
+
+    /**
+     * This method unsubscribes the network interface from the realm-local all MPL forwarders, link-local and
+     * realm-local all nodes address.
+     *
+     */
+    void UnsubscribeAllNodesMulticast(void);
+
 private:
     NetifUnicastAddress *  mUnicastAddresses;
     NetifMulticastAddress *mMulticastAddresses;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -245,7 +245,7 @@ otError Mle::Start(bool aEnableReattach, bool aAnnounceAttach)
     VerifyOrExit(otPlatRadioGetPromiscuous(&netif.GetInstance()) == false, error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(netif.IsUp(), error = OT_ERROR_INVALID_STATE);
 
-    SetMeshLocalPrefix(GetMeshLocalPrefix());
+    ApplyMeshLocalPrefix();
     SetRloc16(GetRloc16());
 
     SetStateDetached();
@@ -894,10 +894,9 @@ void Mle::SetMeshLocalPrefix(const otMeshLocalPrefix &aMeshLocalPrefix)
     memcpy(mLeaderAloc.GetAddress().mFields.m8, aMeshLocalPrefix.m8, sizeof(aMeshLocalPrefix));
 
     // Just keep mesh local prefix if network interface is down
-    if (netif.IsUp())
-    {
-        ApplyMeshLocalPrefix();
-    }
+    VerifyOrExit(netif.IsUp());
+
+    ApplyMeshLocalPrefix();
 
 exit:
     return;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -705,10 +705,16 @@ public:
      *
      * @param[in]  aPrefix  A reference to the Mesh Local Prefix.
      *
-     * @retval OT_ERROR_NONE  Successfully set the Mesh Local Prefix.
+     */
+    void SetMeshLocalPrefix(const otMeshLocalPrefix &aPrefix);
+
+    /**
+     * This method applies the Mesh Local Prefix.
+     *
+     * @param[in]  aPrefix  A reference to the Mesh Local Prefix.
      *
      */
-    otError SetMeshLocalPrefix(const otMeshLocalPrefix &aPrefix);
+    void ApplyMeshLocalPrefix(void);
 
     /**
      * This method returns a reference to the Thread link-local address.

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -117,8 +117,16 @@ otError ThreadNetif::Up(void)
 
     // Enable the MAC just in case it was disabled while the Interface was down.
     mMac.SetEnabled(true);
-    GetIp6().AddNetif(*this);
+#if OPENTHREAD_ENABLE_CHANNEL_MONITOR
+    GetInstance().GetChannelMonitor().Start();
+#endif
     mMeshForwarder.Start();
+    GetIp6().AddNetif(*this);
+
+    mIsUp = true;
+
+    SubscribeAllNodesMulticast();
+    mMleRouter.Enable();
     mCoap.Start(kCoapUdpPort);
 #if OPENTHREAD_ENABLE_DNS_CLIENT
     mDnsClient.Start();
@@ -126,11 +134,6 @@ otError ThreadNetif::Up(void)
 #if OPENTHREAD_ENABLE_SNTP_CLIENT
     mSntpClient.Start();
 #endif
-#if OPENTHREAD_ENABLE_CHANNEL_MONITOR
-    GetInstance().GetChannelMonitor().Start();
-#endif
-    mMleRouter.Enable();
-    mIsUp = true;
     GetNotifier().Signal(OT_CHANGED_THREAD_NETIF_STATE);
 
 exit:
@@ -141,25 +144,27 @@ otError ThreadNetif::Down(void)
 {
     VerifyOrExit(mIsUp);
 
-    mCoap.Stop();
+#if OPENTHREAD_ENABLE_DTLS
+    mDtls.Stop();
+#endif
 #if OPENTHREAD_ENABLE_DNS_CLIENT
     mDnsClient.Stop();
 #endif
 #if OPENTHREAD_ENABLE_SNTP_CLIENT
     mSntpClient.Stop();
 #endif
-#if OPENTHREAD_ENABLE_CHANNEL_MONITOR
-    GetInstance().GetChannelMonitor().Stop();
-#endif
+    mCoap.Stop();
     mMleRouter.Disable();
-    mMeshForwarder.Stop();
-    GetIp6().RemoveNetif(*this);
     RemoveAllExternalUnicastAddresses();
     UnsubscribeAllExternalMulticastAddresses();
-    mIsUp = false;
+    UnsubscribeAllRoutersMulticast();
+    UnsubscribeAllNodesMulticast();
 
-#if OPENTHREAD_ENABLE_DTLS
-    mDtls.Stop();
+    mIsUp = false;
+    GetIp6().RemoveNetif(*this);
+    mMeshForwarder.Stop();
+#if OPENTHREAD_ENABLE_CHANNEL_MONITOR
+    GetInstance().GetChannelMonitor().Stop();
 #endif
     GetNotifier().Signal(OT_CHANGED_THREAD_NETIF_STATE);
 


### PR DESCRIPTION
This PR adds link local address when MLE is enabled. Adding address in constructor gives no chance to notify address change with address callback.