### PR TITLE
[harness-automation] update to ED device category

### DIFF
--- a/tools/harness-automation/cases/ed_9_2_18.py
+++ b/tools/harness-automation/cases/ed_9_2_18.py
@@ -33,7 +33,7 @@ import unittest
 from autothreadharness.harness_case import HarnessCase
 
 class ED_9_2_18(HarnessCase):
-    role = HarnessCase.ROLE_ED
+    role = HarnessCase.ROLE_MED
     case = '9 2 18'
     golden_devices_required = 5
     def on_dialog(self, dialog, title):

--- a/tools/harness-automation/cases/ed_9_2_6.py
+++ b/tools/harness-automation/cases/ed_9_2_6.py
@@ -33,7 +33,7 @@ import unittest
 from autothreadharness.harness_case import HarnessCase
 
 class ED_9_2_6(HarnessCase):
-    role = HarnessCase.ROLE_ED
+    role = HarnessCase.ROLE_MED
     case = '9 2 6'
     golden_devices_required = 4
     def on_dialog(self, dialog, title):


### PR DESCRIPTION
I'm unable to run the test cases ed_9_2_6 and ed_9_2_18 using the test harness automation. It look like the python code is trying to find these test cases under the "ED" menu of the Thread Test Harness. Instead they are located under the MED category.

Updating the "role" in the python code for the test harness automation fixes the issue.

I think this relates to the confusing way how test cases are categorized in the Thread Test Harness. It looks like a fix is on it's way as mentioned here:
https://threadgroup.atlassian.net/projects/TESTPLAN/issues/TESTPLAN-57?filter=allopenissues

But in the mean time, the harness automation needs an updated as included here.