### PR TITLE
[core] rename UDP proxy to UDP forward

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -76,7 +76,7 @@ python --version || die
         --enable-raw-link-api             \
         --enable-service                  \
         --enable-sntp-client              \
-        --enable-udp-proxy                \
+        --enable-udp-forward              \
         --with-examples=posix || die
 
     scan-build --status-bugs -analyze-headers -v make || die

--- a/configure.ac
+++ b/configure.ac
@@ -674,36 +674,36 @@ AC_MSG_CHECKING([should NCP support UART])
 AC_MSG_RESULT([${OPENTHREAD_ENABLE_UART}])
 
 #
-# Thread UDP Proxy
+# Thread UDP forward
 #
 
-AC_MSG_CHECKING([whether to enable UDP proxy])
-AC_ARG_ENABLE(udp_proxy,
-    [AS_HELP_STRING([--enable-udp-proxy], [Enable UDP proxy support @<:@default=no@:>@.])],
+AC_MSG_CHECKING([whether to enable UDP forward])
+AC_ARG_ENABLE(udp_forward,
+    [AS_HELP_STRING([--enable-udp-forward], [Enable UDP forward support @<:@default=no@:>@.])],
     [
         case "${enableval}" in
 
         no|yes)
-            enable_udp_proxy=${enableval}
+            enable_udp_forward=${enableval}
             ;;
 
         *)
-            AC_MSG_ERROR([Invalid value ${enable_udp_proxy} for --enable-udp-proxy])
+            AC_MSG_ERROR([Invalid value ${enable_udp_forward} for --enable-udp-forward])
             ;;
         esac
     ],
-    [enable_udp_proxy=no])
+    [enable_udp_forward=no])
 
-if test "$enable_udp_proxy" = "yes"; then
-    OPENTHREAD_ENABLE_UDP_PROXY=1
+if test "$enable_udp_forward" = "yes"; then
+    OPENTHREAD_ENABLE_UDP_FORWARD=1
 else
-    OPENTHREAD_ENABLE_UDP_PROXY=0
+    OPENTHREAD_ENABLE_UDP_FORWARD=0
 fi
 
-AC_MSG_RESULT(${enable_udp_proxy})
-AC_SUBST(OPENTHREAD_ENABLE_UDP_PROXY)
-AM_CONDITIONAL([OPENTHREAD_ENABLE_UDP_PROXY], [test "${enable_udp_proxy}" = "yes"])
-AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_UDP_PROXY], [${OPENTHREAD_ENABLE_UDP_PROXY}], [Define to 1 to enable the UDP proxy feature.])
+AC_MSG_RESULT(${enable_udp_forward})
+AC_SUBST(OPENTHREAD_ENABLE_UDP_FORWARD)
+AM_CONDITIONAL([OPENTHREAD_ENABLE_UDP_FORWARD], [test "${enable_udp_forward}" = "yes"])
+AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_UDP_FORWARD], [${OPENTHREAD_ENABLE_UDP_FORWARD}], [Define to 1 to enable the UDP forward feature.])
 
 #
 # Thread Border Agent
@@ -1930,7 +1930,7 @@ AC_MSG_NOTICE([
   OpenThread Multiple Instances support     : ${enable_multiple_instances}
   OpenThread MTD Network Diagnostic support : ${enable_mtd_network_diagnostic}
   OpenThread builtin mbedtls support        : ${enable_builtin_mbedtls}
-  OpenThread UDP Proxy support              : ${enable_udp_proxy}
+  OpenThread UDP forward support            : ${enable_udp_forward}
   OpenThread Commissioner support           : ${enable_commissioner}
   OpenThread Joiner support                 : ${enable_joiner}
   OpenThread DTLS support                   : ${enable_dtls}

--- a/examples/Makefile-posix
+++ b/examples/Makefile-posix
@@ -69,7 +69,7 @@ configure_OPTIONS                   = \
     --enable-radio-only               \
     --enable-raw-link-api             \
     --enable-service                  \
-    --enable-udp-proxy                \
+    --enable-udp-forward              \
     --with-examples=posix             \
     $(NULL)
 

--- a/examples/common-switches.mk
+++ b/examples/common-switches.mk
@@ -123,8 +123,8 @@ ifeq ($(SNTP_CLIENT),1)
 configure_OPTIONS              += --enable-sntp-client
 endif
 
-ifeq ($(UDP_PROXY),1)
-configure_OPTIONS              += --enable-udp-proxy
+ifeq ($(UDP_FORWARD),1)
+configure_OPTIONS              += --enable-udp-forward
 endif
 
 ifeq ($(DEBUG_UART),1)

--- a/include/openthread-config-android.h
+++ b/include/openthread-config-android.h
@@ -78,7 +78,7 @@
 #define HAVE__BOOL 1
 
 /* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+ */
 #define LT_OBJDIR ".libs/"
 
 /* Define to 1 if your C compiler doesn't accept -c and -o together. */
@@ -160,8 +160,8 @@
 /* Define to 1 if you want to enable Service */
 #define OPENTHREAD_ENABLE_SERVICE 1
 
-/* Define to 1 to enable the UDP proxy feature. */
-#define OPENTHREAD_ENABLE_UDP_PROXY 1
+/* Define to 1 to enable the UDP forward feature. */
+#define OPENTHREAD_ENABLE_UDP_FORWARD 1
 
 /* OpenThread examples */
 #define OPENTHREAD_EXAMPLES none

--- a/include/openthread/udp.h
+++ b/include/openthread/udp.h
@@ -206,12 +206,12 @@ otError otUdpSend(otUdpSocket *aSocket, otMessage *aMessage, const otMessageInfo
  */
 
 /**
- * @addtogroup api-udp-proxy
+ * @addtogroup api-udp-forward
  *
  * @brief
- *   This module includes functions for UDP proxy feature.
+ *   This module includes functions for UDP forward feature.
  *
- *   The functions in this module are available when udp-proxy feature (`OPENTHREAD_ENABLE_UDP_PROXY`) is enabled.
+ *   The functions in this module are available when udp-forward feature (`OPENTHREAD_ENABLE_UDP_FORWARD`) is enabled.
  *
  * @{
  *
@@ -227,21 +227,21 @@ otError otUdpSend(otUdpSocket *aSocket, otMessage *aMessage, const otMessageInfo
  * @param[in]  aContext   A pointer to application-specific context.
  *
  */
-typedef void (*otUdpProxySender)(otMessage *   aMessage,
-                                 uint16_t      aPeerPort,
-                                 otIp6Address *aPeerAddr,
-                                 uint16_t      aSockPort,
-                                 void *        aContext);
+typedef void (*otUdpForwarder)(otMessage *   aMessage,
+                               uint16_t      aPeerPort,
+                               otIp6Address *aPeerAddr,
+                               uint16_t      aSockPort,
+                               void *        aContext);
 
 /**
- * Set UDP proxy callback to deliever UDP packets to host.
+ * Set UDP forward callback to deliever UDP packets to host.
  *
  * @param[in]  aInstance            A pointer to an OpenThread instance.
- * @param[in]  aSender              A pointer to a function called to deliver UDP packet to host.
+ * @param[in]  aForwarder           A pointer to a function called to forward UDP packet to host.
  * @param[in]  aContext             A pointer to application-specific context.
  *
  */
-void otUdpProxySetSender(otInstance *aInstance, otUdpProxySender aSender, void *aContext);
+void otUdpForwardSetForwarder(otInstance *aInstance, otUdpForwarder aForwarder, void *aContext);
 
 /**
  * Handle a UDP packet received from host.
@@ -255,11 +255,11 @@ void otUdpProxySetSender(otInstance *aInstance, otUdpProxySender aSender, void *
  * @warning No matter the call success or fail, the message is freed.
  *
  */
-void otUdpProxyReceive(otInstance *        aInstance,
-                       otMessage *         aMessage,
-                       uint16_t            aPeerPort,
-                       const otIp6Address *aPeerAddr,
-                       uint16_t            aSockPort);
+void otUdpForwardReceive(otInstance *        aInstance,
+                         otMessage *         aMessage,
+                         uint16_t            aPeerPort,
+                         const otIp6Address *aPeerAddr,
+                         uint16_t            aSockPort);
 
 /**
  * This function gets the existing UDP Sockets.

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -92,20 +92,20 @@ otError otUdpSend(otUdpSocket *aSocket, otMessage *aMessage, const otMessageInfo
     return socket.SendTo(*static_cast<Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
-#if OPENTHREAD_ENABLE_UDP_PROXY
-void otUdpProxySetSender(otInstance *aInstance, otUdpProxySender aSender, void *aContext)
+#if OPENTHREAD_ENABLE_UDP_FORWARD
+void otUdpForwardSetForwarder(otInstance *aInstance, otUdpForwarder aForwarder, void *aContext)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
     Ip6::Ip6 &ip6      = instance.Get<Ip6::Ip6>();
 
-    ip6.GetUdp().SetProxySender(aSender, aContext);
+    ip6.GetUdp().SetUdpForwarder(aForwarder, aContext);
 }
 
-void otUdpProxyReceive(otInstance *        aInstance,
-                       otMessage *         aMessage,
-                       uint16_t            aPeerPort,
-                       const otIp6Address *aPeerAddr,
-                       uint16_t            aSockPort)
+void otUdpForwardReceive(otInstance *        aInstance,
+                         otMessage *         aMessage,
+                         uint16_t            aPeerPort,
+                         const otIp6Address *aPeerAddr,
+                         uint16_t            aSockPort)
 {
     Ip6::MessageInfo messageInfo;
     Instance &       instance = *static_cast<Instance *>(aInstance);
@@ -123,7 +123,7 @@ void otUdpProxyReceive(otInstance *        aInstance,
 
     static_cast<ot::Message *>(aMessage)->Free();
 }
-#endif // OPENTHREAD_ENABLE_UDP_PROXY
+#endif // OPENTHREAD_ENABLE_UDP_FORWARD
 
 #if OPENTHREAD_ENABLE_PLATFORM_UDP
 otUdpSocket *otUdpGetSockets(otInstance *aInstance)

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -214,7 +214,7 @@ void BorderAgent::HandleCoapResponse(void *               aContext,
             netif.GetMle().GetCommissionerAloc(borderAgent.mCommissionerAloc.GetAddress(),
                                                sessionIdTlv.GetCommissionerSessionId());
             netif.AddUnicastAddress(borderAgent.mCommissionerAloc);
-            netif.GetIp6().GetUdp().AddReceiver(borderAgent.mProxyReceiver);
+            netif.GetIp6().GetUdp().AddReceiver(borderAgent.mUdpReceiver);
         }
     }
 
@@ -311,7 +311,7 @@ BorderAgent::BorderAgent(Instance &aInstance)
     , mPendingGet(OT_URI_PATH_PENDING_GET, BorderAgent::HandleRequest<&BorderAgent::mPendingGet>, this)
     , mPendingSet(OT_URI_PATH_PENDING_SET, BorderAgent::HandleRequest<&BorderAgent::mPendingSet>, this)
     , mProxyTransmit(OT_URI_PATH_PROXY_TX, BorderAgent::HandleRequest<&BorderAgent::mProxyTransmit>, this)
-    , mProxyReceiver(BorderAgent::HandleProxyReceive, this)
+    , mUdpReceiver(BorderAgent::HandleUdpReceive, this)
     , mTimer(aInstance, HandleTimeout, this)
     , mState(OT_BORDER_AGENT_STATE_STOPPED)
 {
@@ -364,7 +364,7 @@ exit:
     }
 }
 
-bool BorderAgent::HandleProxyReceive(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+bool BorderAgent::HandleUdpReceive(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     Coap::Header header;
     otError      error;
@@ -633,7 +633,7 @@ void BorderAgent::HandleConnected(bool aConnected)
         Coap::CoapSecure &coaps = netif.GetCoapSecure();
 
         otLogInfoMeshCoP("Commissioner disconnected");
-        netif.GetIp6().GetUdp().RemoveReceiver(mProxyReceiver);
+        netif.GetIp6().GetUdp().RemoveReceiver(mUdpReceiver);
         netif.RemoveUnicastAddress(mCommissionerAloc);
         coaps.Stop();
         SetState(OT_BORDER_AGENT_STATE_STARTED);

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -124,12 +124,12 @@ private:
     void    HandleRelayTransmit(const Coap::Header &aHeader, const Message &aMessage);
     void    HandleRelayReceive(const Coap::Header &aHeader, const Message &aMessage);
     void    HandleProxyTransmit(const Coap::Header &aHeader, const Message &aMessage);
-    static bool HandleProxyReceive(void *aContext, const otMessage *aMessage, const otMessageInfo *aMessageInfo)
+    static bool HandleUdpReceive(void *aContext, const otMessage *aMessage, const otMessageInfo *aMessageInfo)
     {
-        return static_cast<BorderAgent *>(aContext)->HandleProxyReceive(
+        return static_cast<BorderAgent *>(aContext)->HandleUdpReceive(
             *static_cast<const Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
     }
-    bool HandleProxyReceive(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    bool HandleUdpReceive(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     void SetState(otBorderAgentState aState);
 
@@ -154,7 +154,7 @@ private:
     Coap::Resource mPendingSet;
     Coap::Resource mProxyTransmit;
 
-    Ip6::UdpReceiver         mProxyReceiver; ///< The UDP receiver to handle proxy packets to Commissioner
+    Ip6::UdpReceiver         mUdpReceiver; ///< The UDP receiver to receive packets from external commissioner
     Ip6::NetifUnicastAddress mCommissionerAloc;
 
     TimerMilli         mTimer;

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -308,12 +308,12 @@ otError Udp::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, IpProto 
 {
     otError error = OT_ERROR_NONE;
 
-#if OPENTHREAD_ENABLE_UDP_PROXY
+#if OPENTHREAD_ENABLE_UDP_FORWARD
     if (aMessageInfo.GetInterfaceId() == OT_NETIF_INTERFACE_ID_HOST)
     {
-        VerifyOrExit(mProxySender != NULL, error = OT_ERROR_NO_ROUTE);
-        mProxySender(&aMessage, aMessageInfo.mPeerPort, &aMessageInfo.GetPeerAddr(), aMessageInfo.mSockPort,
-                     mProxySenderContext);
+        VerifyOrExit(mUdpForwarder != NULL, error = OT_ERROR_NO_ROUTE);
+        mUdpForwarder(&aMessage, aMessageInfo.mPeerPort, &aMessageInfo.GetPeerAddr(), aMessageInfo.mSockPort,
+                      mUdpForwarderContext);
         // message is consumed by the callback
     }
     else

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -328,20 +328,20 @@ public:
     otUdpSocket *GetUdpSockets(void) { return mSockets; }
 #endif
 
-#if OPENTHREAD_ENABLE_UDP_PROXY
+#if OPENTHREAD_ENABLE_UDP_FORWARD
     /**
-     * This method sets the proxy sender.
+     * This method sets the forward sender.
      *
-     * @param[in]   aSender     A function pointer to send the proxy UDP packet.
+     * @param[in]   aForwarder  A function pointer to forward UDP packets.
      * @param[in]   aContext    A pointer to arbitrary context information.
      *
      */
-    void SetProxySender(otUdpProxySender aSender, void *aContext)
+    void SetUdpForwarder(otUdpForwarder aForwarder, void *aContext)
     {
-        mProxySender        = aSender;
-        mProxySenderContext = aContext;
+        mUdpForwarder        = aForwarder;
+        mUdpForwarderContext = aContext;
     }
-#endif // OPENTHREAD_ENABLE_UDP_PROXY
+#endif // OPENTHREAD_ENABLE_UDP_FORWARD
 
 private:
     enum
@@ -358,9 +358,9 @@ private:
     uint16_t     mEphemeralPort;
     UdpReceiver *mReceivers;
     UdpSocket *  mSockets;
-#if OPENTHREAD_ENABLE_UDP_PROXY
-    void *           mProxySenderContext;
-    otUdpProxySender mProxySender;
+#if OPENTHREAD_ENABLE_UDP_FORWARD
+    void *         mUdpForwarderContext;
+    otUdpForwarder mUdpForwarder;
 #endif
 };
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -270,8 +270,8 @@ NcpBase::NcpBase(Instance *aInstance)
     otSetStateChangedCallback(mInstance, &NcpBase::HandleStateChanged, this);
     otIp6SetReceiveCallback(mInstance, &NcpBase::HandleDatagramFromStack, this);
     otIp6SetReceiveFilterEnabled(mInstance, true);
-#if OPENTHREAD_ENABLE_UDP_PROXY
-    otUdpProxySetSender(mInstance, &NcpBase::HandleUdpProxyStream, this);
+#if OPENTHREAD_ENABLE_UDP_FORWARD
+    otUdpForwardSetForwarder(mInstance, &NcpBase::HandleUdpForwardStream, this);
 #endif
     otLinkSetPcapCallback(mInstance, &NcpBase::HandleRawFrame, static_cast<void *>(this));
     otIcmp6SetEchoMode(mInstance, OT_ICMP6_ECHO_HANDLER_DISABLED);
@@ -1848,8 +1848,8 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_CAPS>(void)
     SuccessOrExit(error = mEncoder.WriteUintPacked(SPINEL_CAP_THREAD_JOINER));
 #endif
 
-#if OPENTHREAD_ENABLE_UDP_PROXY
-    SuccessOrExit(error = mEncoder.WriteUintPacked(SPINEL_CAP_THREAD_UDP_PROXY));
+#if OPENTHREAD_ENABLE_UDP_FORWARD
+    SuccessOrExit(error = mEncoder.WriteUintPacked(SPINEL_CAP_THREAD_UDP_FORWARD));
 #endif
 
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -316,14 +316,14 @@ protected:
                                      bool                  aAllowEmptyValues = false);
 #endif
 
-#if OPENTHREAD_ENABLE_UDP_PROXY
-    static void HandleUdpProxyStream(otMessage *   aMessage,
-                                     uint16_t      aPeerPort,
-                                     otIp6Address *aPeerAddr,
-                                     uint16_t      aSockPort,
-                                     void *        aContext);
-    void        HandleUdpProxyStream(otMessage *aMessage, uint16_t aPeerPort, otIp6Address &aPeerAddr, uint16_t aPort);
-#endif // OPENTHREAD_ENABLE_UDP_PROXY
+#if OPENTHREAD_ENABLE_UDP_FORWARD
+    static void HandleUdpForwardStream(otMessage *   aMessage,
+                                       uint16_t      aPeerPort,
+                                       otIp6Address *aPeerAddr,
+                                       uint16_t      aSockPort,
+                                       void *        aContext);
+    void HandleUdpForwardStream(otMessage *aMessage, uint16_t aPeerPort, otIp6Address &aPeerAddr, uint16_t aPort);
+#endif // OPENTHREAD_ENABLE_UDP_FORWARD
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 
     otError CommandHandler_NOOP(uint8_t aHeader);

--- a/src/ncp/ncp_base_dispatcher.cpp
+++ b/src/ncp/ncp_base_dispatcher.cpp
@@ -854,9 +854,9 @@ NcpBase::PropertyHandler NcpBase::FindSetPropertyHandler(spinel_prop_key_t aKey)
         handler = &NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_STEERING_DATA>;
         break;
 #endif
-#if OPENTHREAD_ENABLE_UDP_PROXY
-    case SPINEL_PROP_THREAD_UDP_PROXY_STREAM:
-        handler = &NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_UDP_PROXY_STREAM>;
+#if OPENTHREAD_ENABLE_UDP_FORWARD
+    case SPINEL_PROP_THREAD_UDP_FORWARD_STREAM:
+        handler = &NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_UDP_FORWARD_STREAM>;
         break;
 #endif
     case SPINEL_PROP_THREAD_ACTIVE_DATASET:

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -2841,8 +2841,8 @@ exit:
     return error;
 }
 
-#if OPENTHREAD_ENABLE_UDP_PROXY
-template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_UDP_PROXY_STREAM>(void)
+#if OPENTHREAD_ENABLE_UDP_FORWARD
+template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_UDP_FORWARD_STREAM>(void)
 {
     const uint8_t *     framePtr = NULL;
     uint16_t            frameLen = 0;
@@ -2862,9 +2862,9 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_UDP_PROXY_STRE
 
     SuccessOrExit(error = otMessageAppend(message, framePtr, static_cast<uint16_t>(frameLen)));
 
-    otUdpProxyReceive(mInstance, message, peerPort, peerAddr, sockPort);
+    otUdpForwardReceive(mInstance, message, peerPort, peerAddr, sockPort);
 
-    // `otUdpProxyReceive()` takes ownership of `message` (in both success
+    // `otUdpForwardReceive()` takes ownership of `message` (in both success
     // or failure cases). `message` is set to NULL so it is not freed at
     // exit.
     message = NULL;
@@ -2878,21 +2878,21 @@ exit:
     return error;
 }
 
-void NcpBase::HandleUdpProxyStream(otMessage *   aMessage,
-                                   uint16_t      aPeerPort,
-                                   otIp6Address *aPeerAddr,
-                                   uint16_t      aSockPort,
-                                   void *        aContext)
+void NcpBase::HandleUdpForwardStream(otMessage *   aMessage,
+                                     uint16_t      aPeerPort,
+                                     otIp6Address *aPeerAddr,
+                                     uint16_t      aSockPort,
+                                     void *        aContext)
 {
-    static_cast<NcpBase *>(aContext)->HandleUdpProxyStream(aMessage, aPeerPort, *aPeerAddr, aSockPort);
+    static_cast<NcpBase *>(aContext)->HandleUdpForwardStream(aMessage, aPeerPort, *aPeerAddr, aSockPort);
 }
 
-void NcpBase::HandleUdpProxyStream(otMessage *aMessage, uint16_t aPeerPort, otIp6Address &aPeerAddr, uint16_t aPort)
+void NcpBase::HandleUdpForwardStream(otMessage *aMessage, uint16_t aPeerPort, otIp6Address &aPeerAddr, uint16_t aPort)
 {
     uint16_t length = otMessageGetLength(aMessage);
     uint8_t  header = SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0;
 
-    SuccessOrExit(mEncoder.BeginFrame(header, SPINEL_CMD_PROP_VALUE_IS, SPINEL_PROP_THREAD_UDP_PROXY_STREAM));
+    SuccessOrExit(mEncoder.BeginFrame(header, SPINEL_CMD_PROP_VALUE_IS, SPINEL_PROP_THREAD_UDP_FORWARD_STREAM));
     SuccessOrExit(mEncoder.WriteUint16(length));
     SuccessOrExit(mEncoder.WriteMessage(aMessage));
 
@@ -2914,7 +2914,7 @@ exit:
         otMessageFree(aMessage);
     }
 }
-#endif // OPENTHREAD_ENABLE_UDP_PROXY
+#endif // OPENTHREAD_ENABLE_UDP_FORWARD
 
 // ----------------------------------------------------------------------------
 // MARK: Property/Status Changed

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1602,8 +1602,8 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "THREAD_TMF_PROXY_STREAM";
         break;
 
-    case SPINEL_PROP_THREAD_UDP_PROXY_STREAM:
-        ret = "THREAD_UDP_PROXY_STREAM";
+    case SPINEL_PROP_THREAD_UDP_FORWARD_STREAM:
+        ret = "THREAD_UDP_FORWARD_STREAM";
         break;
 
     case SPINEL_PROP_THREAD_DISCOVERY_SCAN_JOINER_FLAG:
@@ -2467,8 +2467,8 @@ const char *spinel_capability_to_cstr(unsigned int capability)
         ret = "THREAD_TMF_PROXY";
         break;
 
-    case SPINEL_CAP_THREAD_UDP_PROXY:
-        ret = "THREAD_UDP_PROXY";
+    case SPINEL_CAP_THREAD_UDP_FORWARD:
+        ret = "THREAD_UDP_FORWARD";
         break;
 
     case SPINEL_CAP_THREAD_JOINER:

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -765,7 +765,7 @@ enum
     SPINEL_CAP_THREAD__BEGIN       = 1024,
     SPINEL_CAP_THREAD_COMMISSIONER = (SPINEL_CAP_THREAD__BEGIN + 0),
     SPINEL_CAP_THREAD_TMF_PROXY    = (SPINEL_CAP_THREAD__BEGIN + 1),
-    SPINEL_CAP_THREAD_UDP_PROXY    = (SPINEL_CAP_THREAD__BEGIN + 2),
+    SPINEL_CAP_THREAD_UDP_FORWARD  = (SPINEL_CAP_THREAD__BEGIN + 2),
     SPINEL_CAP_THREAD_JOINER       = (SPINEL_CAP_THREAD__BEGIN + 3),
     SPINEL_CAP_THREAD__END         = 1152,
 
@@ -1497,7 +1497,7 @@ typedef enum
     /** Format `dSS`
      * Required capability: `SPINEL_CAP_THREAD_TMF_PROXY`
      *
-     * This property is deprecated. Please see `SPINEL_PROP_THREAD_UDP_PROXY_STREAM`.
+     * This property is deprecated. Please see `SPINEL_PROP_THREAD_UDP_FORWARD_STREAM`.
      *
      */
     SPINEL_PROP_THREAD_TMF_PROXY_STREAM = SPINEL_PROP_THREAD_EXT__BEGIN + 18,
@@ -1764,9 +1764,9 @@ typedef enum
      */
     SPINEL_PROP_THREAD_ADDRESS_CACHE_TABLE = SPINEL_PROP_THREAD_EXT__BEGIN + 35,
 
-    /// Thread UDP proxy stream
+    /// Thread UDP forward stream
     /** Format `dS6S`
-     * Required capability: `SPINEL_CAP_THREAD_UDP_PROXY`
+     * Required capability: `SPINEL_CAP_THREAD_UDP_FORWARD`
      *
      * This property helps exchange UDP packets with host.
      *
@@ -1776,7 +1776,7 @@ typedef enum
      *  `S`: Local UDP port
      *
      */
-    SPINEL_PROP_THREAD_UDP_PROXY_STREAM = SPINEL_PROP_THREAD_EXT__BEGIN + 36,
+    SPINEL_PROP_THREAD_UDP_FORWARD_STREAM = SPINEL_PROP_THREAD_EXT__BEGIN + 36,
 
     /// Send MGMT_GET Thread Active Operational Dataset
     /** Format: `A(t(iD))` - Write only

--- a/src/posix/Makefile-posix
+++ b/src/posix/Makefile-posix
@@ -65,7 +65,7 @@ configure_OPTIONS                   = \
     --enable-mac-filter               \
     --enable-posix-app                \
     --enable-service                  \
-    --enable-udp-proxy                \
+    --enable-udp-forward              \
     --with-ncp-bus=uart               \
     $(NULL)
 


### PR DESCRIPTION
Thread defines UDP proxy as a feature to allow secure, two-way
communication of Thread Management Commands between the Commissioner
and any Thread Device in the Thread Network via the Border Agent.

This PR renames the existing UDP proxy feature which forwards UDP
packets back and forth between Host and NCP to UDP forward.