### PR TITLE
[ncp] enable latency test feature

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1852,6 +1852,9 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_CAPS>(void)
     SuccessOrExit(error = mEncoder.WriteUintPacked(SPINEL_CAP_THREAD_UDP_PROXY));
 #endif
 
+#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC && OPENTHREAD_CONFIG_ENABLE_PERFORMANCE_TEST
+    SuccessOrExit(error = mEncoder.WriteUintPacked(SPINEL_CAP_PERFORMANCE_TEST));
+#endif
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 
 exit:

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -46,6 +46,7 @@
 #include <openthread/dhcp6_client.h>
 #include <openthread/message.h>
 #include <openthread/ncp.h>
+#include <openthread/udp.h>
 
 #include "changed_props_set.hpp"
 #include "common/instance.hpp"
@@ -488,6 +489,13 @@ protected:
     SpinelEncoder          mEncoder;
     SpinelDecoder          mDecoder;
     bool                   mHostPowerStateInProgress;
+#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC && OPENTHREAD_CONFIG_ENABLE_PERFORMANCE_TEST
+    uint32_t    mLatency;
+    uint8_t     mHopLimit;
+    otUdpSocket mSocket;
+    static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
+    void        HandleUdpReceive(otMessage *aMessage, const otMessageInfo *aMessageInfo);
+#endif
 
     enum
     {

--- a/src/ncp/ncp_base_dispatcher.cpp
+++ b/src/ncp/ncp_base_dispatcher.cpp
@@ -495,6 +495,14 @@ NcpBase::PropertyHandler NcpBase::FindGetPropertyHandler(spinel_prop_key_t aKey)
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_NETWORK_TIME>;
         break;
 #endif
+#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC && OPENTHREAD_CONFIG_ENABLE_PERFORMANCE_TEST
+    case SPINEL_PROP_PERFORMANCE_LATENCY:
+        handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_PERFORMANCE_LATENCY>;
+        break;
+    case SPINEL_PROP_PERFORMANCE_HOPLIMIT:
+        handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_PERFORMANCE_HOPLIMIT>;
+        break;
+#endif // OPENTHREAD_CONFIG_ENABLE_TIME_SYNC && OPENTHREAD_CONFIG_ENABLE_PERFORMANCE_TEST
 #if OPENTHREAD_ENABLE_CHILD_SUPERVISION
     case SPINEL_PROP_CHILD_SUPERVISION_CHECK_TIMEOUT:
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_CHILD_SUPERVISION_CHECK_TIMEOUT>;
@@ -813,6 +821,17 @@ NcpBase::PropertyHandler NcpBase::FindSetPropertyHandler(spinel_prop_key_t aKey)
         handler = &NcpBase::HandlePropertySet<SPINEL_PROP_CHILD_SUPERVISION_CHECK_TIMEOUT>;
         break;
 #endif
+#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC && OPENTHREAD_CONFIG_ENABLE_PERFORMANCE_TEST
+    case SPINEL_PROP_PERFORMANCE_LATENCY_TEST:
+        handler = &NcpBase::HandlePropertySet<SPINEL_PROP_PERFORMANCE_LATENCY_TEST>;
+        break;
+    case SPINEL_PROP_PERFORMANCE_LATENCY:
+        handler = &NcpBase::HandlePropertySet<SPINEL_PROP_PERFORMANCE_LATENCY>;
+        break;
+    case SPINEL_PROP_PERFORMANCE_HOPLIMIT:
+        handler = &NcpBase::HandlePropertySet<SPINEL_PROP_PERFORMANCE_HOPLIMIT>;
+        break;
+#endif // OPENTHREAD_CONFIG_ENABLE_TIME_SYNC && OPENTHREAD_CONFIG_ENABLE_PERFORMANCE_TEST
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 
         // --------------------------------------------------------------------------

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1846,6 +1846,18 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PARENT_RESPONSE_INFO";
         break;
 
+    case SPINEL_PROP_PERFORMANCE_LATENCY_TEST:
+        ret = "PERFORMANCE_LATENCY_TEST";
+        break;
+
+    case SPINEL_PROP_PERFORMANCE_LATENCY:
+        ret = "PERFORMANCE_LATENCY";
+        break;
+
+    case SPINEL_PROP_PERFORMANCE_HOPLIMIT:
+        ret = "PERFORMANCE_HOPLIMIT";
+        break;
+
     case SPINEL_PROP_UART_BITRATE:
         ret = "UART_BITRATE";
         break;
@@ -2453,6 +2465,10 @@ const char *spinel_capability_to_cstr(unsigned int capability)
 
     case SPINEL_CAP_POSIX_APP:
         ret = "POSIX_APP";
+        break;
+
+    case SPINEL_CAP_PERFORMANCE_TEST:
+        ret = "PERFORMANCE_TEST";
         break;
 
     case SPINEL_CAP_ERROR_RATE_TRACKING:

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -760,6 +760,7 @@ enum
     SPINEL_CAP_TIME_SYNC               = (SPINEL_CAP_OPENTHREAD__BEGIN + 7),
     SPINEL_CAP_CHILD_SUPERVISION       = (SPINEL_CAP_OPENTHREAD__BEGIN + 8),
     SPINEL_CAP_POSIX_APP               = (SPINEL_CAP_OPENTHREAD__BEGIN + 9),
+    SPINEL_CAP_PERFORMANCE_TEST        = (SPINEL_CAP_OPENTHREAD__BEGIN + 10),
     SPINEL_CAP_OPENTHREAD__END         = 640,
 
     SPINEL_CAP_THREAD__BEGIN       = 1024,
@@ -2317,6 +2318,45 @@ typedef enum
      *
      */
     SPINEL_PROP_PARENT_RESPONSE_INFO = SPINEL_PROP_OPENTHREAD__BEGIN + 13,
+
+    /// End-to-End Latency test
+    /** Format: `6Sb` - Write only
+     *
+     * Required capability SPINEL_CAP_PERFORMANCE_TEST_
+     *
+     *  `6`: Peer IPv6 address
+     *  `S`: UDP payload size
+     *  `b`: Role of node, True is sending node, False is receiving node.
+     *
+     * This property sets the role of node in latency test. Launch the receiving node by setting the default value in
+     * this property, and then launch the sending node to start the test.
+     *
+     */
+    SPINEL_PROP_PERFORMANCE_LATENCY_TEST = SPINEL_PROP_OPENTHREAD__BEGIN + 14,
+
+    /// Latency test result
+    /** Format: `L` - Read-Write
+     *
+     * Required capability SPINEL_CAP_PERFORMANCE_TEST
+     *
+     *  `L`: Latnecy value, in microseconds
+     *
+     * This property sends latency value from receiving node to the Host.
+     *
+     */
+    SPINEL_PROP_PERFORMANCE_LATENCY = SPINEL_PROP_OPENTHREAD__BEGIN + 15,
+
+    /// hoplimit value
+    /** Format: `C` - Read-Write
+     *
+     * Required capability SPINEL_CAP_PERFORMANCE_TEST
+     *
+     *  `C`: hoplimit value
+     *
+     * This property sends hoplimit value from receiving node to the Host.
+     *
+     */
+    SPINEL_PROP_PERFORMANCE_HOPLIMIT = SPINEL_PROP_OPENTHREAD__BEGIN + 16,
 
     SPINEL_PROP_OPENTHREAD__END = 0x2000,
 


### PR DESCRIPTION
This commit can be used to obtain the End-to-End one-way latency over UDP.