### PR TITLE
[api] expose API to select source address

### DIFF
--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -538,6 +538,17 @@ OTAPI uint8_t OTCALL otIp6PrefixMatch(const otIp6Address *aFirst, const otIp6Add
 bool otIp6IsAddressUnspecified(const otIp6Address *aAddress);
 
 /**
+ * This function perform OpenThread source address selection.
+ *
+ * @param[inout]  aMessageInfo  A pointer to the message information.
+ *
+ * @retval  OT_ERROR_NONE       Found a source address and is filled into mSockAddr of @p aMessageInfo.
+ * @retval  OT_ERROR_NOT_FOUND  No source address was found and @p aMessageInfo is unchanged.
+ *
+ */
+otError otIp6SelectSourceAddress(otInstance *aInstance, otMessageInfo *aMessageInfo);
+
+/**
  * @}
  *
  */

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -264,3 +264,17 @@ bool otIp6IsAddressUnspecified(const otIp6Address *aAddress)
 {
     return static_cast<const Ip6::Address *>(aAddress)->IsUnspecified();
 }
+
+otError otIp6SelectSourceAddress(otInstance *aInstance, otMessageInfo *aMessageInfo)
+{
+    otError                         error    = OT_ERROR_NONE;
+    Instance &                      instance = *static_cast<Instance *>(aInstance);
+    const Ip6::NetifUnicastAddress *netifAddr;
+
+    netifAddr = instance.GetIp6().SelectSourceAddress(*static_cast<Ip6::MessageInfo *>(aMessageInfo));
+    VerifyOrExit(netifAddr != NULL, error = OT_ERROR_NOT_FOUND);
+    memcpy(&aMessageInfo->mSockAddr, &netifAddr->mAddress, sizeof(aMessageInfo->mSockAddr));
+
+exit:
+    return error;
+}


### PR DESCRIPTION
This PR exposes the API to select a proper source address so that upper layer can easily choose a source address when it wants to send a packet through OpenThread but the source address is unspecified.