### PR TITLE
[cli] fix network time format specifier

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1624,7 +1624,7 @@ void Interpreter::ProcessNetworkTime(int argc, char *argv[])
 
         networkTimeStatus = otNetworkTimeGet(mInstance, time);
 
-        mServer->OutputFormat("Network Time:     %dus", time);
+        mServer->OutputFormat("Network Time:     %luus", time);
 
         switch (networkTimeStatus)
         {


### PR DESCRIPTION
Network time is a uint64 aka unsigned long `%lu`