### PR TITLE
[core] use free timer to simplify CoAP

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1838,7 +1838,7 @@ exit:
 
 void Interpreter::s_HandlePingTimer(Timer &aTimer)
 {
-    GetOwner(aTimer).HandlePingTimer();
+    GetOwner(*static_cast<OwnerTimer *>(&aTimer)).HandlePingTimer();
 }
 
 void Interpreter::HandlePingTimer()

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -47,14 +47,14 @@
 namespace ot {
 namespace Coap {
 
-CoapSecure::CoapSecure(Instance &aInstance, bool aLinkSecurity)
+CoapSecure::CoapSecure(Instance &aInstance, Tasklet::Handler aTransmitHandler, bool aLinkSecurity)
     : CoapBase(aInstance)
     , mConnectedCallback(NULL)
     , mConnectedContext(NULL)
     , mTransportCallback(NULL)
     , mTransportContext(NULL)
     , mTransmitQueue()
-    , mTransmitTask(aInstance, &CoapSecure::HandleTransmit, this)
+    , mTransmitTask(aInstance, aTransmitHandler, this)
     , mLayerTwoSecurity(aLinkSecurity)
 {
 }
@@ -381,6 +381,19 @@ exit:
     }
 }
 
+#if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
+
+ApplicationCoapSecure::ApplicationCoapSecure(Instance &aInstance)
+    : CoapSecure(aInstance, &ApplicationCoapSecure::HandleTransmit, true)
+{
+}
+
+void ApplicationCoapSecure::HandleTransmit(Tasklet &aTasklet)
+{
+    aTasklet.GetOwner<ApplicationCoapSecure>().CoapSecure::HandleTransmit();
+}
+
+#endif // OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
 } // namespace Coap
 } // namespace ot
 

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -47,34 +47,17 @@
 namespace ot {
 namespace Coap {
 
-CoapSecure::CoapSecure(Instance &aInstance)
-    : CoapBase(aInstance, &CoapSecure::HandleRetransmissionTimer, &CoapSecure::HandleResponsesQueueTimer)
+CoapSecure::CoapSecure(Instance &aInstance, bool aLinkSecurity)
+    : CoapBase(aInstance)
     , mConnectedCallback(NULL)
     , mConnectedContext(NULL)
     , mTransportCallback(NULL)
     , mTransportContext(NULL)
     , mTransmitQueue()
     , mTransmitTask(aInstance, &CoapSecure::HandleTransmit, this)
-    , mLayerTwoSecurity(false)
+    , mLayerTwoSecurity(aLinkSecurity)
 {
 }
-
-#if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-CoapSecure::CoapSecure(Instance &       aInstance,
-                       Tasklet::Handler aHandleTransmit,
-                       Timer::Handler   aRetransmissionTimer,
-                       Timer::Handler   aResponsesQueueTimer)
-    : CoapBase(aInstance, aRetransmissionTimer, aResponsesQueueTimer)
-    , mConnectedCallback(NULL)
-    , mConnectedContext(NULL)
-    , mTransportCallback(NULL)
-    , mTransportContext(NULL)
-    , mTransmitQueue()
-    , mTransmitTask(aInstance, aHandleTransmit, this)
-    , mLayerTwoSecurity(true)
-{
-}
-#endif // OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
 
 otError CoapSecure::Start(uint16_t aPort, TransportCallback aCallback, void *aContext)
 {
@@ -397,43 +380,6 @@ exit:
         otLogDebgMeshCoP("CoapSecure Transmit: %s", otThreadErrorToString(error));
     }
 }
-
-void CoapSecure::HandleRetransmissionTimer(Timer &aTimer)
-{
-    aTimer.GetOwner<CoapSecure>().CoapBase::HandleRetransmissionTimer();
-}
-
-void CoapSecure::HandleResponsesQueueTimer(Timer &aTimer)
-{
-    aTimer.GetOwner<CoapSecure>().CoapBase::HandleResponsesQueueTimer();
-}
-
-#if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-
-ApplicationCoapSecure::ApplicationCoapSecure(Instance &aInstance)
-    : CoapSecure(aInstance,
-                 &ApplicationCoapSecure::HandleTransmit,
-                 &ApplicationCoapSecure::HandleRetransmissionTimer,
-                 &ApplicationCoapSecure::HandleResponsesQueueTimer)
-{
-}
-
-void ApplicationCoapSecure::HandleTransmit(Tasklet &aTasklet)
-{
-    aTasklet.GetOwner<ApplicationCoapSecure>().CoapSecure::HandleTransmit();
-}
-
-void ApplicationCoapSecure::HandleRetransmissionTimer(Timer &aTimer)
-{
-    aTimer.GetOwner<ApplicationCoapSecure>().CoapBase::HandleRetransmissionTimer();
-}
-
-void ApplicationCoapSecure::HandleResponsesQueueTimer(Timer &aTimer)
-{
-    aTimer.GetOwner<ApplicationCoapSecure>().CoapBase::HandleResponsesQueueTimer();
-}
-
-#endif // OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
 
 } // namespace Coap
 } // namespace ot

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -69,27 +69,14 @@ public:
 
     /**
      * This constructor initializes the object.
-     *
-     * @param[in]  aInstance  A reference to the OpenThread instance.
-     *
-     */
-    explicit CoapSecure(Instance &aInstance);
-
-#if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-    /**
-     * This constructor initializes the object.
      * (Used for Application CoAPS)
      *
-     * @param[in]  aInstance             A reference to the OpenThread instance.
-     * @param[in]  aUdpTransmitHandle    Handler for udp transmit.
-     * @param[in]  aRetransmissionTimer  Handler for retransmission.
-     * @param[in]  aResponsesQueueTimer  Handler for Queue Responses.
+     * @param[in]  aInstance            A reference to the OpenThread instance.
+     * @param[in]  aUdpTransmitHandle   Handler for udp transmit.
+     * @param[in]  aLinkSecurity        Whether to enable link security.
      *
      */
-    explicit CoapSecure(Instance &       aInstance,
-                        Tasklet::Handler aUdpTransmitHandle,
-                        Timer::Handler   aRetransmissionTimer,
-                        Timer::Handler   aResponsesQueueTimer);
+    explicit CoapSecure(Instance &aInstance, Tasklet::Handler aUdpTransmitHandle, bool aLinkSecurity = false);
 #endif // OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
 
     /**
@@ -348,8 +335,6 @@ private:
     static otError HandleDtlsSend(void *aContext, const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
     otError        HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
 
-    static void HandleRetransmissionTimer(Timer &aTimer);
-    static void HandleResponsesQueueTimer(Timer &aTimer);
     static void HandleTransmit(Tasklet &aTasklet);
 
     Ip6::MessageInfo  mPeerAddress;
@@ -363,13 +348,14 @@ private:
     bool mLayerTwoSecurity : 1;
 };
 
+<<<<<<< HEAD
 #if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
 
-/**
- * This class implements the application CoAP Secure client and server.
- *
- */
-class ApplicationCoapSecure : public CoapSecure
+    /**
+     * This class implements the application CoAP Secure client and server.
+     *
+     */
+    class ApplicationCoapSecure : public CoapSecure
 {
 public:
     /**
@@ -388,6 +374,8 @@ private:
 
 #endif // OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
 
+=======
+>>>>>>> [core] use free timer to simplify CoAP
 } // namespace Coap
 } // namespace ot
 

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -69,15 +69,15 @@ public:
 
     /**
      * This constructor initializes the object.
-     * (Used for Application CoAPS)
      *
      * @param[in]  aInstance            A reference to the OpenThread instance.
      * @param[in]  aUdpTransmitHandle   Handler for udp transmit.
      * @param[in]  aLinkSecurity        Whether to enable link security.
      *
      */
-    explicit CoapSecure(Instance &aInstance, Tasklet::Handler aUdpTransmitHandle, bool aLinkSecurity = false);
-#endif // OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
+    explicit CoapSecure(Instance &       aInstance,
+                        Tasklet::Handler aUdpTransmitHandle = &CoapSecure::HandleTransmit,
+                        bool             aLinkSecurity      = false);
 
     /**
      * This method starts the secure CoAP agent.
@@ -348,14 +348,13 @@ private:
     bool mLayerTwoSecurity : 1;
 };
 
-<<<<<<< HEAD
 #if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
 
-    /**
-     * This class implements the application CoAP Secure client and server.
-     *
-     */
-    class ApplicationCoapSecure : public CoapSecure
+/**
+ * This class implements the application CoAP Secure client and server.
+ *
+ */
+class ApplicationCoapSecure : public CoapSecure
 {
 public:
     /**
@@ -367,15 +366,11 @@ public:
     explicit ApplicationCoapSecure(Instance &aInstance);
 
 private:
-    static void HandleRetransmissionTimer(Timer &aTimer);
-    static void HandleResponsesQueueTimer(Timer &aTimer);
     static void HandleTransmit(Tasklet &aTasklet);
 };
 
 #endif // OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
 
-=======
->>>>>>> [core] use free timer to simplify CoAP
 } // namespace Coap
 } // namespace ot
 

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -68,7 +68,7 @@ Instance::Instance(void)
     , mApplicationCoap(*this)
 #endif
 #if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-    , mApplicationCoapSecure(*this)
+    , mApplicationCoapSecure(*this, true)
 #endif
 #if OPENTHREAD_ENABLE_CHANNEL_MONITOR
     , mChannelMonitor(*this)

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -68,7 +68,7 @@ Instance::Instance(void)
     , mApplicationCoap(*this)
 #endif
 #if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-    , mApplicationCoapSecure(*this, true)
+    , mApplicationCoapSecure(*this)
 #endif
 #if OPENTHREAD_ENABLE_CHANNEL_MONITOR
     , mChannelMonitor(*this)

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -330,7 +330,7 @@ public:
      * @returns A reference to the application COAP Secure object.
      *
      */
-    Coap::CoapSecure &GetApplicationCoapSecure(void) { return mApplicationCoapSecure; }
+    Coap::ApplicationCoapSecure &GetApplicationCoapSecure(void) { return mApplicationCoapSecure; }
 #endif
 
 #if OPENTHREAD_ENABLE_CHANNEL_MONITOR
@@ -442,7 +442,7 @@ private:
 #endif
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-    Coap::CoapSecure mApplicationCoapSecure;
+    Coap::ApplicationCoapSecure mApplicationCoapSecure;
 #endif
 
 #if OPENTHREAD_ENABLE_CHANNEL_MONITOR
@@ -591,6 +591,13 @@ template <> inline MeshCoP::PendingDataset &Instance::Get(void)
 template <> inline TimeSync &Instance::Get(void)
 {
     return GetThreadNetif().GetTimeSync();
+}
+#endif
+
+#if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
+template <> inline Coap::ApplicationCoapSecure &Instance::Get(void)
+{
+    return GetApplicationCoapSecure();
 }
 #endif
 

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -320,7 +320,7 @@ public:
      * @returns A reference to the application COAP object.
      *
      */
-    Coap::ApplicationCoap &GetApplicationCoap(void) { return mApplicationCoap; }
+    Coap::Coap &GetApplicationCoap(void) { return mApplicationCoap; }
 #endif
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
@@ -330,7 +330,7 @@ public:
      * @returns A reference to the application COAP Secure object.
      *
      */
-    Coap::ApplicationCoapSecure &GetApplicationCoapSecure(void) { return mApplicationCoapSecure; }
+    Coap::CoapSecure &GetApplicationCoapSecure(void) { return mApplicationCoapSecure; }
 #endif
 
 #if OPENTHREAD_ENABLE_CHANNEL_MONITOR
@@ -438,11 +438,11 @@ private:
     ThreadNetif mThreadNetif;
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
-    Coap::ApplicationCoap mApplicationCoap;
+    Coap::Coap mApplicationCoap;
 #endif
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-    Coap::ApplicationCoapSecure mApplicationCoapSecure;
+    Coap::CoapSecure mApplicationCoapSecure;
 #endif
 
 #if OPENTHREAD_ENABLE_CHANNEL_MONITOR
@@ -591,20 +591,6 @@ template <> inline MeshCoP::PendingDataset &Instance::Get(void)
 template <> inline TimeSync &Instance::Get(void)
 {
     return GetThreadNetif().GetTimeSync();
-}
-#endif
-
-#if OPENTHREAD_ENABLE_APPLICATION_COAP
-template <> inline Coap::ApplicationCoap &Instance::Get(void)
-{
-    return GetApplicationCoap();
-}
-#endif
-
-#if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-template <> inline Coap::ApplicationCoapSecure &Instance::Get(void)
-{
-    return GetApplicationCoapSecure();
 }
 #endif
 

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -69,6 +69,18 @@ bool Timer::DoesFireBefore(const Timer &aSecondTimer, uint32_t aNow)
     return retval;
 }
 
+void FreeMilliTimer::StartAt(uint32_t aT0, uint32_t aDt)
+{
+    assert(aDt <= kMaxDt);
+    mFireTime = aT0 + aDt;
+    GetTimerMilliScheduler().Add(*this);
+}
+
+void FreeMilliTimer::Stop(void)
+{
+    GetTimerMilliScheduler().Remove(*this);
+}
+
 void TimerMilli::StartAt(uint32_t aT0, uint32_t aDt)
 {
     assert(aDt <= kMaxDt);
@@ -81,7 +93,7 @@ void TimerMilli::Stop(void)
     GetTimerMilliScheduler().Remove(*this);
 }
 
-TimerMilliScheduler &TimerMilli::GetTimerMilliScheduler(void) const
+TimerMilliScheduler &MilliTimerBase::GetTimerMilliScheduler(void) const
 {
     return GetInstance().GetTimerMilliScheduler();
 }

--- a/src/core/mac/link_raw.cpp
+++ b/src/core/mac/link_raw.cpp
@@ -430,7 +430,7 @@ void LinkRaw::TransmitStarted(otRadioFrame *aFrame)
 
 void LinkRaw::HandleTimer(Timer &aTimer)
 {
-    LinkRaw &linkRaw = aTimer.GetOwner<LinkRaw>();
+    LinkRaw &linkRaw = static_cast<OwnerTimer *>(&aTimer)->GetOwner<LinkRaw>();
 
 #if OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ENERGY_SCAN
     // Energy scan uses a different timer for adding delay between RSSI samples.

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1022,7 +1022,7 @@ exit:
 
 void Mac::HandleBackoffTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<Mac>().HandleBackoffTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<Mac>().HandleBackoffTimer();
 }
 
 void Mac::HandleBackoffTimer(void)
@@ -1536,7 +1536,7 @@ exit:
 
 void Mac::HandleMacTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<Mac>().HandleMacTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<Mac>().HandleMacTimer();
 }
 
 void Mac::HandleMacTimer(void)
@@ -1566,7 +1566,7 @@ void Mac::HandleMacTimer(void)
 
 void Mac::HandleReceiveTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<Mac>().HandleReceiveTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<Mac>().HandleReceiveTimer();
 }
 
 void Mac::HandleReceiveTimer(void)

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -687,7 +687,7 @@ exit:
 
 void BorderAgent::HandleTimeout(Timer &aTimer)
 {
-    aTimer.GetOwner<BorderAgent>().HandleTimeout();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<BorderAgent>().HandleTimeout();
 }
 
 void BorderAgent::HandleTimeout(void)

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -336,7 +336,7 @@ otCommissionerState Commissioner::GetState(void) const
 
 void Commissioner::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<Commissioner>().HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<Commissioner>().HandleTimer();
 }
 
 void Commissioner::HandleTimer(void)
@@ -358,7 +358,7 @@ void Commissioner::HandleTimer(void)
 
 void Commissioner::HandleJoinerExpirationTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<Commissioner>().HandleJoinerExpirationTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<Commissioner>().HandleJoinerExpirationTimer();
 }
 
 void Commissioner::HandleJoinerExpirationTimer(void)

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -423,7 +423,7 @@ void ActiveDataset::HandleGet(Coap::Header &aHeader, Message &aMessage, const Ip
 
 void ActiveDataset::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<ActiveDataset>().HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<ActiveDataset>().HandleTimer();
 }
 
 PendingDataset::PendingDataset(Instance &aInstance)
@@ -496,7 +496,7 @@ void PendingDataset::StartDelayTimer(void)
 
 void PendingDataset::HandleDelayTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<PendingDataset>().HandleDelayTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<PendingDataset>().HandleDelayTimer();
 }
 
 void PendingDataset::HandleDelayTimer(void)
@@ -548,7 +548,7 @@ void PendingDataset::HandleGet(Coap::Header &aHeader, Message &aMessage, const I
 
 void PendingDataset::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<PendingDataset>().HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<PendingDataset>().HandleTimer();
 }
 
 } // namespace MeshCoP

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -691,7 +691,7 @@ int Dtls::HandleMbedtlsExportKeys(const unsigned char *aMasterSecret,
 
 void Dtls::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<Dtls>().HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<Dtls>().HandleTimer();
 }
 
 void Dtls::HandleTimer(void)

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -558,7 +558,7 @@ exit:
 
 void Joiner::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<Joiner>().HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<Joiner>().HandleTimer();
 }
 
 void Joiner::HandleTimer(void)

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -402,7 +402,7 @@ exit:
 
 void JoinerRouter::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<JoinerRouter>().HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<JoinerRouter>().HandleTimer();
 }
 
 void JoinerRouter::HandleTimer(void)

--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -307,7 +307,7 @@ uint32_t Leader::GetDelayTimerMinimal(void) const
 
 void Leader::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<Leader>().HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<Leader>().HandleTimer();
 }
 
 void Leader::HandleTimer(void)

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -382,12 +382,12 @@ void Client::FinalizeDnsTransaction(Message &            aQuery,
 
 void Client::HandleRetransmissionTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<Client>().HandleRetransmissionTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<Client>().HandleRetransmissionTimer();
 }
 
 void Client::HandleRetransmissionTimer(void)
 {
-    uint32_t         now       = TimerMilli::GetNow();
+    uint32_t         now       = MilliTimerBase::GetNow();
     uint32_t         nextDelta = 0xffffffff;
     QueryMetadata    queryMetadata;
     Message *        message     = mPendingQueries.GetHead();

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -259,7 +259,7 @@ exit:
 
 void Mpl::HandleRetransmissionTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<Mpl>().HandleRetransmissionTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<Mpl>().HandleRetransmissionTimer();
 }
 
 void Mpl::HandleRetransmissionTimer(void)
@@ -346,7 +346,7 @@ void Mpl::HandleRetransmissionTimer(void)
 
 void Mpl::HandleSeedSetTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<Mpl>().HandleSeedSetTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<Mpl>().HandleSeedSetTimer();
 }
 
 void Mpl::HandleSeedSetTimer(void)

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -260,7 +260,7 @@ void Client::FinalizeSntpTransaction(Message &            aQuery,
 
 void Client::HandleRetransmissionTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<Client>().HandleRetransmissionTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<Client>().HandleRetransmissionTimer();
 }
 
 void Client::HandleRetransmissionTimer(void)

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -702,7 +702,7 @@ exit:
 
 void AddressResolver::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<AddressResolver>().HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<AddressResolver>().HandleTimer();
 }
 
 void AddressResolver::HandleTimer(void)

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -110,7 +110,7 @@ exit:
 
 void AnnounceBeginServer::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<AnnounceBeginServer>().AnnounceSenderBase::HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<AnnounceBeginServer>().AnnounceSenderBase::HandleTimer();
 }
 
 } // namespace ot

--- a/src/core/thread/announce_sender.cpp
+++ b/src/core/thread/announce_sender.cpp
@@ -119,7 +119,7 @@ AnnounceSender::AnnounceSender(Instance &aInstance)
 
 void AnnounceSender::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<AnnounceSender>().AnnounceSenderBase::HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<AnnounceSender>().AnnounceSenderBase::HandleTimer();
 }
 
 otError AnnounceSender::GetActiveDatasetChannelMask(Mac::ChannelMask &aMask) const

--- a/src/core/thread/data_poll_manager.cpp
+++ b/src/core/thread/data_poll_manager.cpp
@@ -416,12 +416,12 @@ uint32_t DataPollManager::CalculatePollPeriod(void) const
 
 void DataPollManager::HandlePollTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<DataPollManager>().SendDataPoll();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<DataPollManager>().SendDataPoll();
 }
 
 uint32_t DataPollManager::GetDefaultPollPeriod(void) const
 {
-    return TimerMilli::SecToMsec(GetNetif().GetMle().GetTimeout()) -
+    return MilliTimerBase::SecToMsec(GetNetif().GetMle().GetTimeout()) -
            static_cast<uint32_t>(kRetxPollPeriod) * kMaxPollRetxAttempts;
 }
 

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -122,7 +122,7 @@ exit:
 
 void EnergyScanServer::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<EnergyScanServer>().HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<EnergyScanServer>().HandleTimer();
 }
 
 void EnergyScanServer::HandleTimer(void)

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -276,7 +276,7 @@ void KeyManager::StartKeyRotationTimer(void)
 
 void KeyManager::HandleKeyRotationTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<KeyManager>().HandleKeyRotationTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<KeyManager>().HandleKeyRotationTimer();
 }
 
 void KeyManager::HandleKeyRotationTimer(void)

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1153,7 +1153,7 @@ void MeshForwarder::SetDiscoverParameters(uint32_t aScanChannels)
 
 void MeshForwarder::HandleDiscoverTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<MeshForwarder>().HandleDiscoverTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<MeshForwarder>().HandleDiscoverTimer();
 }
 
 void MeshForwarder::HandleDiscoverTimer(void)
@@ -1447,7 +1447,7 @@ void MeshForwarder::ClearReassemblyList(void)
 
 void MeshForwarder::HandleReassemblyTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<MeshForwarder>().HandleReassemblyTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<MeshForwarder>().HandleReassemblyTimer();
 }
 
 void MeshForwarder::HandleReassemblyTimer(void)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1582,7 +1582,7 @@ exit:
 
 void Mle::HandleAttachTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<Mle>().HandleAttachTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<Mle>().HandleAttachTimer();
 }
 
 void Mle::HandleAttachTimer(void)
@@ -1820,7 +1820,7 @@ exit:
 
 void Mle::HandleDelayedResponseTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<Mle>().HandleDelayedResponseTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<Mle>().HandleDelayedResponseTimer();
 }
 
 void Mle::HandleDelayedResponseTimer(void)
@@ -2116,7 +2116,7 @@ exit:
 
 void Mle::HandleMessageTransmissionTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<Mle>().HandleMessageTransmissionTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<Mle>().HandleMessageTransmissionTimer();
 }
 
 void Mle::HandleMessageTransmissionTimer(void)
@@ -3973,7 +3973,7 @@ exit:
 #if OPENTHREAD_CONFIG_ENABLE_PERIODIC_PARENT_SEARCH
 void Mle::HandleParentSearchTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<Mle>().HandleParentSearchTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<Mle>().HandleParentSearchTimer();
 }
 
 void Mle::HandleParentSearchTimer(void)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -381,7 +381,7 @@ otError MleRouter::SetStateLeader(uint16_t aRloc16)
 
 bool MleRouter::HandleAdvertiseTimer(TrickleTimer &aTimer)
 {
-    return aTimer.GetOwner<MleRouter>().HandleAdvertiseTimer();
+    return static_cast<OwnerTimer *>(&aTimer)->GetOwner<MleRouter>().HandleAdvertiseTimer();
 }
 
 bool MleRouter::HandleAdvertiseTimer(void)
@@ -1680,7 +1680,7 @@ exit:
 
 void MleRouter::HandleStateUpdateTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<MleRouter>().HandleStateUpdateTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<MleRouter>().HandleStateUpdateTimer();
 }
 
 void MleRouter::HandleStateUpdateTimer(void)

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -1554,7 +1554,7 @@ otError Leader::RemoveContext(PrefixTlv &aPrefix, uint8_t aContextId)
 
 void Leader::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<Leader>().HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<Leader>().HandleTimer();
 }
 
 void Leader::HandleTimer(void)

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -168,7 +168,7 @@ exit:
 
 void PanIdQueryServer::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<PanIdQueryServer>().HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<PanIdQueryServer>().HandleTimer();
 }
 
 void PanIdQueryServer::HandleTimer(void)

--- a/src/core/thread/time_sync_service.cpp
+++ b/src/core/thread/time_sync_service.cpp
@@ -174,7 +174,7 @@ void TimeSync::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags 
 
 void TimeSync::HandleTimeout(Timer &aTimer)
 {
-    aTimer.GetOwner<TimeSync>().HandleTimeout();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<TimeSync>().HandleTimeout();
 }
 
 void TimeSync::CheckAndHandleChanges(bool aTimeUpdated)

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -230,7 +230,7 @@ exit:
 
 void ChannelManager::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<ChannelManager>().HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<ChannelManager>().HandleTimer();
 }
 
 void ChannelManager::HandleTimer(void)

--- a/src/core/utils/channel_monitor.cpp
+++ b/src/core/utils/channel_monitor.cpp
@@ -106,7 +106,7 @@ exit:
 
 void ChannelMonitor::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<ChannelMonitor>().HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<ChannelMonitor>().HandleTimer();
 }
 
 void ChannelMonitor::HandleTimer(void)

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -115,7 +115,7 @@ void ChildSupervisor::UpdateOnSend(Child &aChild)
 
 void ChildSupervisor::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<ChildSupervisor>().HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<ChildSupervisor>().HandleTimer();
 }
 
 void ChildSupervisor::HandleTimer(void)
@@ -239,7 +239,7 @@ void SupervisionListener::RestartTimer(void)
 
 void SupervisionListener::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<SupervisionListener>().HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<SupervisionListener>().HandleTimer();
 }
 
 void SupervisionListener::HandleTimer(void)

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -165,7 +165,7 @@ exit:
 
 void JamDetector::HandleTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<JamDetector>().HandleTimer();
+    static_cast<OwnerTimer *>(&aTimer)->GetOwner<JamDetector>().HandleTimer();
 }
 
 void JamDetector::HandleTimer(void)


### PR DESCRIPTION
CoapSecure, ApplicationCoap and ApplicationCoapSecure must define several timer handlers for CoapBase class, because the handlers in the base class cannot find the right context with the OwnerLocator. This makes managing multiple instances of CoAP very annoying. This PR tries to solve this by introducing `FreeTimer`, which doesn't inherit `OwnerLocator`.

In order to alway find the right context, instead of asking context from instance, this PR makes the owner inherit `FreeTimer`, thus the handler can get the real context from the `FreeTimer`. In order to support owner owns multiple timers, `IndexedFreeTimer` is provided, owner may alias a `IndexFreeTimer` and inherit them all. This PR uses that way to provide `CoapBase` two timers.

```cpp
typedef IndexedFreeMilliTimer<CoapBase, 1> RetransmissionTimer;
typedef IndexedFreeMilliTimer<CoapBase, 2> ResponsesQueueTimer;

class CoapBase : public RetransmissionTimer, public ResponsesQueueTimer
{
}
```
Here's the code size changes
```sh
make -f examples/Makefile-nrf52840 COAP=1 COAPS=1 JOINER=1

git:(new-timer) ✗ arm-none-eabi-size output/nrf52840/bin/ot-cli-ftd
   text	   data	    bss	    dec	    hex	filename
 268808	    592	  54388	 323788	  4f0cc	output/nrf52840/bin/ot-cli-ftd

git:(master) arm-none-eabi-size output/nrf52840/bin/ot-cli-ftd
   text	   data	    bss	    dec	    hex	filename
 268976	    592	  54388	 323956	  4f174	output/nrf52840/bin/ot-cli-ftd
```

And the timer classes.
```
                     Timer
                      /\
                     /  \
           OwnerTimer FreeMilliTimer
              / \             \
             /   \     IndexedFreeMilliTimer
   TimerMilli TimerMicro
```