### PR TITLE
[nrf52840] suppress warning in mbedtls in Keil and IAR compiler

### DIFF
--- a/third_party/NordicSemiconductor/libraries/crypto/nrf52840-mbedtls-config.h
+++ b/third_party/NordicSemiconductor/libraries/crypto/nrf52840-mbedtls-config.h
@@ -36,7 +36,9 @@
 #define MBEDTLS_ECDSA_C
 
 #if defined(__ICCARM__)
-    _Pragma("diag_suppress=Pe549")
-    _Pragma("diag_suppress=Pa082")
-    _Pragma("diag_suppress=Pa084")
+    _Pragma("diag_suppress=Pe550")
+#endif
+
+#if defined(__CC_ARM)
+    _Pragma("diag_suppress=550")
 #endif


### PR DESCRIPTION
This PR suppresses warning on Keil and IAR introduced with new mbedtls:
`openthread\third_party\mbedtls\repo\library\pkparse.c(1146) : Error[Pe550]: variable "ret" was set but never used`

The other IAR warnings have been fixed and so workarounds are removed.