### PR TITLE
[time-sync] fix incorrect status after boot

### DIFF
--- a/src/core/thread/time_sync_service.cpp
+++ b/src/core/thread/time_sync_service.cpp
@@ -195,7 +195,12 @@ void TimeSync::CheckAndHandleChanges(bool aTimeUpdated)
 
     case OT_DEVICE_ROLE_CHILD:
     case OT_DEVICE_ROLE_ROUTER:
-        if (timeSyncLastSyncMs > resyncNeededThresholdMs)
+        if (mLastTimeSyncReceived == 0)
+        {
+            // Haven't yet received any time sync
+            networkTimeStatus = OT_NETWORK_TIME_UNSYNCHRONIZED;
+        }
+        else if (timeSyncLastSyncMs > resyncNeededThresholdMs)
         {
             // The device hasn’t received time sync for more than two periods time.
             networkTimeStatus = OT_NETWORK_TIME_RESYNC_NEEDED;


### PR DESCRIPTION
After a reboot, `TimerMilli::GetNow()` begins counting from 0 (at least on the efr32). This has the effect that when `mLastTimeSyncReceived` is 0 (its initialised value), the check for
`timeSyncLastSyncMs > resyncNeededThresholdMs` returns false within the first 60 seconds of uptime, and the status of `OT_NETWORK_TIME_SYNCHRONIZED` is inadvertently taken.

Add a check to prevent this and return `OT_NETWORK_TIME_UNSYNCHRONIZED` when `mLastTimeSyncReceived` is 0