### PR TITLE
[efr32] add missing volatile qualifiers

### DIFF
--- a/examples/platforms/efr32/radio.c
+++ b/examples/platforms/efr32/radio.c
@@ -67,19 +67,19 @@ enum
     EFR32_RECEIVE_SENSITIVITY = -100, // dBm
 };
 
-static uint16_t     sPanId             = 0;
-static bool         sTransmitBusy      = false;
-static bool         sPromiscuous       = false;
-static bool         sIsSrcMatchEnabled = false;
-static otRadioState sState             = OT_RADIO_STATE_DISABLED;
+static uint16_t      sPanId             = 0;
+static volatile bool sTransmitBusy      = false;
+static bool          sPromiscuous       = false;
+static bool          sIsSrcMatchEnabled = false;
+static otRadioState  sState             = OT_RADIO_STATE_DISABLED;
 
 static uint8_t      sReceivePsdu[IEEE802154_MAX_LENGTH];
 static otRadioFrame sReceiveFrame;
 static otError      sReceiveError;
 
-static otRadioFrame sTransmitFrame;
-static uint8_t      sTransmitPsdu[IEEE802154_MAX_LENGTH];
-static otError      sTransmitError;
+static otRadioFrame     sTransmitFrame;
+static uint8_t          sTransmitPsdu[IEEE802154_MAX_LENGTH];
+static volatile otError sTransmitError;
 
 typedef struct srcMatchEntry
 {

--- a/examples/platforms/efr32/uart.c
+++ b/examples/platforms/efr32/uart.c
@@ -153,7 +153,7 @@ otError otPlatUartEnable(void)
 
     for (uint8_t i = 0; i < sizeof(sReceiveBuffer); i++)
     {
-        UARTDRV_Receive(sUartHandle, (uint8_t *)&sReceiveBuffer[i], sizeof(sReceiveBuffer[i]), receiveDone);
+        UARTDRV_Receive(sUartHandle, &sReceiveBuffer[i], sizeof(sReceiveBuffer[i]), receiveDone);
     }
 
     return OT_ERROR_NONE;

--- a/examples/platforms/efr32/uart.c
+++ b/examples/platforms/efr32/uart.c
@@ -74,7 +74,7 @@ DEFINE_BUF_QUEUE(EMDRV_UARTDRV_MAX_CONCURRENT_TX_BUFS, sUartTxQueue);
 
 static UARTDRV_HandleData_t sUartHandleData;
 static UARTDRV_Handle_t     sUartHandle = &sUartHandleData;
-static volatile uint8_t     sReceiveBuffer[2];
+static uint8_t              sReceiveBuffer[2];
 static const uint8_t *      sTransmitBuffer = NULL;
 static volatile uint16_t    sTransmitLength = 0;
 
@@ -83,12 +83,12 @@ typedef struct ReceiveFifo_t
     // The data buffer
     uint8_t mBuffer[kReceiveFifoSize];
     // The offset of the first item written to the list.
-    uint16_t mHead;
+    volatile uint16_t mHead;
     // The offset of the next item to be written to the list.
-    uint16_t mTail;
+    volatile uint16_t mTail;
 } ReceiveFifo_t;
 
-static volatile ReceiveFifo_t sReceiveFifo;
+static ReceiveFifo_t sReceiveFifo;
 
 static void processReceive(void);
 
@@ -117,7 +117,7 @@ static void processReceive(void)
     // If the data wraps around, process the first part
     if (sReceiveFifo.mHead > tail)
     {
-        otPlatUartReceived((uint8_t *)sReceiveFifo.mBuffer + sReceiveFifo.mHead, kReceiveFifoSize - sReceiveFifo.mHead);
+        otPlatUartReceived(sReceiveFifo.mBuffer + sReceiveFifo.mHead, kReceiveFifoSize - sReceiveFifo.mHead);
 
         // Reset the buffer mHead back to zero.
         sReceiveFifo.mHead = 0;
@@ -126,7 +126,7 @@ static void processReceive(void)
     // For any data remaining, process it
     if (sReceiveFifo.mHead != tail)
     {
-        otPlatUartReceived((uint8_t *)sReceiveFifo.mBuffer + sReceiveFifo.mHead, tail - sReceiveFifo.mHead);
+        otPlatUartReceived(sReceiveFifo.mBuffer + sReceiveFifo.mHead, tail - sReceiveFifo.mHead);
 
         // Set mHead to the local tail we have cached
         sReceiveFifo.mHead = tail;


### PR DESCRIPTION
These variables are modified from interrupt context and therefore should be marked as volatile