### PR TITLE
[posix-app] add HdlcInterface class

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -180,15 +180,16 @@ LOCAL_SRC_FILES                                          := \
     src/ncp/spinel_decoder.cpp                              \
     src/ncp/spinel_encoder.cpp                              \
     src/posix/platform/alarm.c                              \
-    src/posix/platform/misc.c                               \
+    src/posix/platform/frame_queue.cpp                      \
+    src/posix/platform/hdlc_interface.cpp                   \
     src/posix/platform/logging.c                            \
+    src/posix/platform/misc.c                               \
+    src/posix/platform/radio_spinel.cpp                     \
     src/posix/platform/random.c                             \
+    src/posix/platform/settings.cpp                         \
+    src/posix/platform/spi-stubs.c                          \
     src/posix/platform/system.c                             \
     src/posix/platform/uart.c                               \
-    src/posix/platform/spi-stubs.c                          \
-    src/posix/platform/frame_queue.cpp                      \
-    src/posix/platform/radio_spinel.cpp                     \
-    src/posix/platform/settings.cpp                         \
     third_party/mbedtls/repo/library/md.c                   \
     third_party/mbedtls/repo/library/md_wrap.c              \
     third_party/mbedtls/repo/library/memory_buffer_alloc.c  \

--- a/src/posix/platform/Makefile.am
+++ b/src/posix/platform/Makefile.am
@@ -42,6 +42,7 @@ libopenthread_posix_a_CPPFLAGS            = \
 libopenthread_posix_a_SOURCES             = \
     alarm.c                                 \
     frame_queue.cpp                         \
+    hdlc_interface.cpp                      \
     logging.c                               \
     misc.c                                  \
     radio_spinel.cpp                        \
@@ -75,6 +76,7 @@ noinst_HEADERS                            = \
     frame_queue.hpp                         \
     openthread-system.h                     \
     platform-posix.h                        \
+    hdlc_interface.hpp                      \
     radio_spinel.hpp                        \
     $(NULL)
 

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -1,0 +1,457 @@
+/*
+ *  Copyright (c) 2018, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes the implementation for the HDLC interface to radio (RCP).
+ */
+
+#include "hdlc_interface.hpp"
+
+#include "platform-posix.h"
+#include "radio_spinel.hpp"
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#if OPENTHREAD_CONFIG_POSIX_APP_ENABLE_PTY_DEVICE
+#ifdef OPENTHREAD_TARGET_DARWIN
+#include <util.h>
+#else
+#include <pty.h>
+#endif
+#endif
+#include <stdarg.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/wait.h>
+#include <syslog.h>
+#include <termios.h>
+#include <unistd.h>
+
+#include <common/code_utils.hpp>
+#include <common/logging.hpp>
+
+#ifndef SOCKET_UTILS_DEFAULT_SHELL
+#define SOCKET_UTILS_DEFAULT_SHELL "/bin/sh"
+#endif
+
+namespace ot {
+namespace PosixApp {
+
+class EncoderBuffer : public Hdlc::Encoder::BufferWriteIterator
+{
+public:
+    EncoderBuffer(void)
+    {
+        mWritePointer    = mBuffer;
+        mRemainingLength = sizeof(mBuffer);
+    }
+
+    uint16_t       GetLength(void) const { return static_cast<uint16_t>(mWritePointer - mBuffer); }
+    const uint8_t *GetBuffer(void) const { return mBuffer; }
+
+private:
+    uint8_t mBuffer[HdlcInterface::kMaxFrameSize];
+};
+
+HdlcInterface::HdlcInterface(Callbacks &aCallbacks)
+    : mCallbacks(aCallbacks)
+    , mSockFd(-1)
+    , mIsDecoding(false)
+    , mHdlcDecoder(mDecoderBuffer, sizeof(mDecoderBuffer), HandleHdlcFrame, HandleHdlcError, this)
+{
+}
+
+otError HdlcInterface::Init(const char *aRadioFile, const char *aRadioConfig)
+{
+    otError     error = OT_ERROR_NONE;
+    struct stat st;
+
+    VerifyOrExit(mSockFd == -1, error = OT_ERROR_ALREADY);
+
+    VerifyOrExit(stat(aRadioFile, &st) == 0, perror("stat ncp file failed"); error = OT_ERROR_INVALID_ARGS);
+
+    if (S_ISCHR(st.st_mode))
+    {
+        mSockFd = OpenFile(aRadioFile, aRadioConfig);
+        VerifyOrExit(mSockFd != -1, error = OT_ERROR_INVALID_ARGS);
+    }
+#if OPENTHREAD_CONFIG_POSIX_APP_ENABLE_PTY_DEVICE
+    else if (S_ISREG(st.st_mode))
+    {
+        mSockFd = ForkPty(aRadioFile, aRadioConfig);
+        VerifyOrExit(mSockFd != -1, error = OT_ERROR_INVALID_ARGS);
+    }
+#endif // OPENTHREAD_CONFIG_POSIX_APP_ENABLE_PTY_DEVICE
+    else
+    {
+        otLogCritPlat("Radio file '%s' not supported", aRadioFile);
+        ExitNow(error = OT_ERROR_INVALID_ARGS);
+    }
+
+exit:
+    return error;
+}
+
+void HdlcInterface::Deinit(void)
+{
+    assert(mSockFd != -1);
+
+    VerifyOrExit(0 == close(mSockFd), perror("close NCP"));
+    VerifyOrExit(-1 != wait(NULL), perror("wait NCP"));
+
+    mSockFd = -1;
+
+exit:
+    return;
+}
+
+void HdlcInterface::Read(void)
+{
+    uint8_t buffer[kMaxFrameSize];
+    ssize_t rval;
+
+    rval = read(mSockFd, buffer, sizeof(buffer));
+
+    if (rval < 0)
+    {
+        perror("HdlcInterface::Read()");
+
+        if (errno != EAGAIN)
+        {
+            abort();
+        }
+    }
+
+    if (rval > 0)
+    {
+        Decode(buffer, static_cast<uint16_t>(rval));
+    }
+}
+
+void HdlcInterface::Decode(const uint8_t *aBuffer, uint16_t aLength)
+{
+    mIsDecoding = true;
+    mHdlcDecoder.Decode(aBuffer, aLength);
+    mIsDecoding = false;
+}
+
+otError HdlcInterface::SendFrame(const uint8_t *aFrame, uint16_t aLength)
+{
+    otError       error = OT_ERROR_NONE;
+    Hdlc::Encoder hdlcEncoder;
+    EncoderBuffer encoderBuffer;
+
+    SuccessOrExit(error = hdlcEncoder.Init(encoderBuffer));
+    SuccessOrExit(error = hdlcEncoder.Encode(aFrame, aLength, encoderBuffer));
+    SuccessOrExit(error = hdlcEncoder.Finalize(encoderBuffer));
+
+    SuccessOrExit(error = Write(encoderBuffer.GetBuffer(), encoderBuffer.GetLength()));
+
+exit:
+    return error;
+}
+
+otError HdlcInterface::Write(const uint8_t *aFrame, uint16_t aLength)
+{
+    otError error = OT_ERROR_NONE;
+
+#if OPENTHREAD_POSIX_VIRTUAL_TIME
+    otSimSendRadioSpinelWriteEvent(aFrame, aLength);
+#else
+    while (aLength)
+    {
+        ssize_t rval = write(mSockFd, aFrame, aLength);
+
+        if (rval > 0)
+        {
+            aLength -= static_cast<uint16_t>(rval);
+            aFrame += static_cast<uint16_t>(rval);
+        }
+        else if (rval < 0)
+        {
+            perror("HdlcInterface::Write");
+            ExitNow(error = OT_ERROR_FAILED);
+        }
+        else
+        {
+            ExitNow(error = OT_ERROR_FAILED);
+        }
+    }
+exit:
+#endif
+    return error;
+}
+
+int HdlcInterface::OpenFile(const char *aFile, const char *aConfig)
+{
+    int fd   = -1;
+    int rval = 0;
+
+    fd = open(aFile, O_RDWR | O_NOCTTY | O_NONBLOCK);
+    if (fd == -1)
+    {
+        perror("open uart failed");
+        ExitNow();
+    }
+
+    if (isatty(fd))
+    {
+        struct termios tios;
+
+        int  speed  = 115200;
+        int  cstopb = 1;
+        char parity = 'N';
+
+        VerifyOrExit((rval = tcgetattr(fd, &tios)) == 0);
+
+        cfmakeraw(&tios);
+
+        tios.c_cflag = CS8 | HUPCL | CREAD | CLOCAL;
+
+        // example: 115200N1
+        sscanf(aConfig, "%u%c%d", &speed, &parity, &cstopb);
+
+        switch (parity)
+        {
+        case 'N':
+            break;
+        case 'E':
+            tios.c_cflag |= PARENB;
+            break;
+        case 'O':
+            tios.c_cflag |= (PARENB | PARODD);
+            break;
+        default:
+            // not supported
+            assert(false);
+            exit(OT_EXIT_INVALID_ARGUMENTS);
+            break;
+        }
+
+        switch (cstopb)
+        {
+        case 1:
+            tios.c_cflag &= static_cast<unsigned long>(~CSTOPB);
+            break;
+        case 2:
+            tios.c_cflag |= CSTOPB;
+            break;
+        default:
+            assert(false);
+            exit(OT_EXIT_INVALID_ARGUMENTS);
+            break;
+        }
+
+        switch (speed)
+        {
+        case 9600:
+            speed = B9600;
+            break;
+        case 19200:
+            speed = B19200;
+            break;
+        case 38400:
+            speed = B38400;
+            break;
+        case 57600:
+            speed = B57600;
+            break;
+        case 115200:
+            speed = B115200;
+            break;
+#ifdef B230400
+        case 230400:
+            speed = B230400;
+            break;
+#endif
+#ifdef B460800
+        case 460800:
+            speed = B460800;
+            break;
+#endif
+#ifdef B500000
+        case 500000:
+            speed = B500000;
+            break;
+#endif
+#ifdef B576000
+        case 576000:
+            speed = B576000;
+            break;
+#endif
+#ifdef B921600
+        case 921600:
+            speed = B921600;
+            break;
+#endif
+#ifdef B1000000
+        case 1000000:
+            speed = B1000000;
+            break;
+#endif
+#ifdef B1152000
+        case 1152000:
+            speed = B1152000;
+            break;
+#endif
+#ifdef B1500000
+        case 1500000:
+            speed = B1500000;
+            break;
+#endif
+#ifdef B2000000
+        case 2000000:
+            speed = B2000000;
+            break;
+#endif
+#ifdef B2500000
+        case 2500000:
+            speed = B2500000;
+            break;
+#endif
+#ifdef B3000000
+        case 3000000:
+            speed = B3000000;
+            break;
+#endif
+#ifdef B3500000
+        case 3500000:
+            speed = B3500000;
+            break;
+#endif
+#ifdef B4000000
+        case 4000000:
+            speed = B4000000;
+            break;
+#endif
+        default:
+            assert(false);
+            exit(OT_EXIT_INVALID_ARGUMENTS);
+            break;
+        }
+
+        VerifyOrExit((rval = cfsetspeed(&tios, static_cast<speed_t>(speed))) == 0, perror("cfsetspeed"));
+        VerifyOrExit((rval = tcsetattr(fd, TCSANOW, &tios)) == 0, perror("tcsetattr"));
+        VerifyOrExit((rval = tcflush(fd, TCIOFLUSH)) == 0);
+    }
+
+exit:
+    if (rval != 0)
+    {
+        exit(OT_EXIT_FAILURE);
+    }
+
+    return fd;
+}
+
+#if OPENTHREAD_CONFIG_POSIX_APP_ENABLE_PTY_DEVICE
+int HdlcInterface::ForkPty(const char *aCommand, const char *aArguments)
+{
+    int fd  = -1;
+    int pid = -1;
+
+    {
+        struct termios tios;
+
+        memset(&tios, 0, sizeof(tios));
+        cfmakeraw(&tios);
+        tios.c_cflag = CS8 | HUPCL | CREAD | CLOCAL;
+
+        pid = forkpty(&fd, NULL, &tios, NULL);
+        VerifyOrExit(pid >= 0);
+    }
+
+    if (0 == pid)
+    {
+        const int     kMaxCommand = 255;
+        char          cmd[kMaxCommand];
+        int           rval;
+        struct rlimit limit;
+
+        rval = getrlimit(RLIMIT_NOFILE, &limit);
+        rval = setenv("SHELL", SOCKET_UTILS_DEFAULT_SHELL, 0);
+
+        VerifyOrExit(rval == 0, perror("setenv failed"));
+
+        // Close all file descriptors larger than STDERR_FILENO.
+        for (rlim_t i = (STDERR_FILENO + 1); i < limit.rlim_cur; i++)
+        {
+            close(static_cast<int>(i));
+        }
+
+        rval = snprintf(cmd, sizeof(cmd), "exec %s %s", aCommand, aArguments);
+        VerifyOrExit(rval > 0 && static_cast<size_t>(rval) < sizeof(cmd),
+                     otLogCritPlat("NCP file and configuration is too long!"));
+
+        execl(getenv("SHELL"), getenv("SHELL"), "-c", cmd, NULL);
+        perror("open pty failed");
+        exit(OT_EXIT_INVALID_ARGUMENTS);
+    }
+    else
+    {
+        int rval = fcntl(fd, F_GETFL);
+
+        if (rval != -1)
+        {
+            rval = fcntl(fd, F_SETFL, rval | O_NONBLOCK);
+        }
+
+        if (rval == -1)
+        {
+            perror("set nonblock failed");
+            close(fd);
+            fd = -1;
+        }
+    }
+
+exit:
+    return fd;
+}
+#endif // OPENTHREAD_CONFIG_POSIX_APP_ENABLE_PTY_DEVICE
+
+void HdlcInterface::HandleHdlcFrame(void *aContext, uint8_t *aFrame, uint16_t aFrameLength)
+{
+    static_cast<HdlcInterface *>(aContext)->mCallbacks.HandleReceivedFrame(aFrame, aFrameLength);
+}
+
+void HdlcInterface::HandleHdlcError(void *aContext, otError aError, uint8_t *aFrame, uint16_t aFrameLength)
+{
+    otLogWarnPlat("Error decoding hdlc frame: %s", otThreadErrorToString(aError));
+
+    OT_UNUSED_VARIABLE(aContext);
+    OT_UNUSED_VARIABLE(aError);
+    OT_UNUSED_VARIABLE(aFrame);
+    OT_UNUSED_VARIABLE(aFrameLength);
+}
+
+} // namespace PosixApp
+} // namespace ot

--- a/src/posix/platform/hdlc_interface.hpp
+++ b/src/posix/platform/hdlc_interface.hpp
@@ -1,0 +1,178 @@
+/*
+ *  Copyright (c) 2018, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for the HDLC interface to radio (RCP).
+ */
+
+#ifndef POSIX_APP_HDLC_INTERFACE_HPP_
+#define POSIX_APP_HDLC_INTERFACE_HPP_
+
+#include "openthread-core-config.h"
+
+#include "hdlc.hpp"
+
+namespace ot {
+namespace PosixApp {
+
+/**
+ * This class defines an HDLC interface to the Radio Co-processor (RCP)
+ *
+ */
+class HdlcInterface
+{
+public:
+    enum
+    {
+        kMaxFrameSize = 2048, ///< Maximum frame size (number of bytes).
+    };
+
+    /**
+     * This class defines the callbacks provided by `HdlcInterfac` to its owner/user.
+     *
+     */
+    class Callbacks
+    {
+    public:
+        /**
+         * This callback is invoked to notify owner/user of `HdlcInterface` of a received (and decoded) frame.
+         *
+         * @param[in] aFrame   A pointer to buffer containing the received frame.
+         * @param[in] aLength  The length (number of bytes) of the received frame.
+         *
+         */
+        void HandleReceivedFrame(const uint8_t *aFrame, uint16_t aLength);
+    };
+
+    /**
+     * This constructor initializes the object.
+     *
+     * @param[in] aCallback   A reference to a `Callback` object.
+     *
+     */
+    explicit HdlcInterface(Callbacks &aCallbacks);
+
+    /**
+     * This method initializes the interface to the Radio Co-processor (RCP)
+     *
+     * @note This method should be called before reading and sending frames to the interface.
+     *
+     *
+     * @param[in]   aRadioFile    The path to either a UART device or an executable.
+     * @param[in]   aRadioConfig  Parameters to be given to the device or executable.
+     *
+     * @retval OT_ERROR_NONE          The interface is initialized successfully
+     * @retval OT_ERROR_ALREADY       The interface is already initialized.
+     * @retval OT_ERROR_INVALID_ARGS  The UART device or executable cannot be found or failed to open/run.
+     *
+     */
+    otError Init(const char *aRadioFile, const char *aRadioConfig);
+
+    /**
+     * This method deinitializes the interface to the RCP.
+     *
+     */
+    void Deinit(void);
+
+    /**
+     *
+     * This method returns the socket file descriptor associate with the interface
+     *
+     * @returns The associated socket file descriptor, or -1 if interface is not initializes.
+     *
+     */
+    int GetSocket(void) const { return mSockFd; }
+
+    /**
+     * This method indicates whether the `HdclInterface` is currently decoding a received frame or not.
+     *
+     * @returns  TRUE if currently decoding a received frame, FALSE otherwise.
+     *
+     */
+    bool IsDecoding(void) const { return mIsDecoding; }
+
+    /**
+     * This method instructs `HdlcInterface` to read and decode data from radio over the socket.
+     *
+     * If a full HDLC frame is decoded while reading data, this method invokes the `HandleReceivedFrame()` (on the
+     * `aCallback` object from constructor) to pass the received frame to be processed.
+     *
+     */
+    void Read(void);
+
+    /**
+     * This method encodes and sends a frame to Radio Co-processor (RCP) over the socket.
+     *
+     * @param[in] aFrame  A pointer to buffer containing the frame to send.
+     * @param[in] aLength The length (number of bytes) in the frame
+     *
+     * @retval OT_ERROR_NONE     Successfully encoded and sent the frame.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffer space available to encode the frame.
+     * @retval OT_ERROR_FAILED   Failed to send frame due to socket write failure.
+     *
+     */
+    otError SendFrame(const uint8_t *aFrame, uint16_t aLength);
+
+#if OPENTHREAD_POSIX_VIRTUAL_TIME
+    /**
+     * This method process read data (decode the data).
+     *
+     * This method is intended only for virtual time simulation. Its behavior is similar to `Read()` but instead of
+     * reading the data from the radio socket, it uses the given data in the buffer `aBuffer`.
+     *
+     * @param[in] aBuffer  A pointer to buffer containing data.
+     * @param[in] aLength  The length (number of bytes) in the buffer.
+     *
+     */
+    void ProcessReadData(const uint8_t *aBuffer, uint16_t aLength) { Decode(aBuffer, aLength); }
+#endif
+
+private:
+    otError Write(const uint8_t *aFrame, uint16_t aLength);
+    void    Decode(const uint8_t *aBuffer, uint16_t aLength);
+
+    static void HandleHdlcFrame(void *aContext, uint8_t *aFrame, uint16_t aFrameLength);
+    static void HandleHdlcError(void *aContext, otError aError, uint8_t *aFrame, uint16_t aFrameLength);
+
+    static int OpenFile(const char *aFile, const char *aConfig);
+#if OPENTHREAD_CONFIG_POSIX_APP_ENABLE_PTY_DEVICE
+    static int ForkPty(const char *aCommand, const char *aArguments);
+#endif
+
+    Callbacks &   mCallbacks;
+    int           mSockFd;
+    bool          mIsDecoding;
+    Hdlc::Decoder mHdlcDecoder;
+    uint8_t       mDecoderBuffer[kMaxFrameSize];
+};
+
+} // namespace PosixApp
+} // namespace ot
+
+#endif // POSIX_APP_HDLC_INTERFACE_HPP_


### PR DESCRIPTION
This commit adds a new class `HdlcInterface` under POSIX App which
performs HDLC encoding/decoding and read/write operations on the
interface to Radio Co-Processor (RCP). `RadioSpinel` is updated to
use the new class.

----------
This PR mainly moves existing logic related to RCP interface and HDLC encoding/decoding from `RadioSpinel` into a separate `HdlcInterface` class. 

**Motivation for this change:** The `RadioSpinel` class currently does 3 related tasks.
- It implements the interface to RCP and perform HDCL encoding and decoding
- It processes Spinel messages (providing blocking Spinel property `Set`, `Get`, `Insert`, `Remove` methods).
- It implements a radio platform abstraction (implementing `otPlatRadio<>` equivalent).

The idea is to break it into 3 components. This is the first PR which  takes care of first part. Next step, will try to separate the spinel frame processing logic.