### PR TITLE
[radio-spinel] remove unused method HandleHdlcError

### DIFF
--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -391,15 +391,6 @@ exit:
     LogIfFail("Error handling hdlc frame", error);
 }
 
-void RadioSpinel::HandleHdlcError(void *aContext, otError aError, uint8_t *aBuffer, uint16_t aLength)
-{
-    otLogWarnPlat("Error decoding hdlc frame: %s", otThreadErrorToString(aError));
-    OT_UNUSED_VARIABLE(aContext);
-    OT_UNUSED_VARIABLE(aError);
-    OT_UNUSED_VARIABLE(aBuffer);
-    OT_UNUSED_VARIABLE(aLength);
-}
-
 void RadioSpinel::HandleNotification(const uint8_t *aBuffer, uint16_t aLength)
 {
     spinel_prop_key_t key;

--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -533,7 +533,6 @@ private:
                         va_list           args);
     otError ParseRadioFrame(otRadioFrame &aFrame, const uint8_t *aBuffer, uint16_t aLength);
 
-    static void HandleHdlcError(void *aContext, otError aError, uint8_t *aBuffer, uint16_t aLength);
     static void HandleSpinelFrame(void *aContext, uint8_t *aBuffer, uint16_t aLength)
     {
         static_cast<RadioSpinel *>(aContext)->HandleSpinelFrame(aBuffer, aLength);


### PR DESCRIPTION
---
Quick follow-up on https://github.com/openthread/openthread/pull/3293. `HandleHdlcError` is moved to `HdlcInterface` class (from `RadioSpinel`) so removing it from `RadioSpinel`.