### PR TITLE
[radio-spinel] use a dedicated mAckRadioFrame for acks

### DIFF
--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -266,8 +266,9 @@ void RadioSpinel::Init(const char *aRadioFile, const char *aRadioConfig)
     SuccessOrExit(error = Get(SPINEL_PROP_HWADDR, SPINEL_DATATYPE_UINT64_S, &gNodeId));
     gNodeId = ot::Encoding::BigEndian::HostSwap64(gNodeId);
 
-    mRxRadioFrame.mPsdu = mRxPsdu;
-    mTxRadioFrame.mPsdu = mTxPsdu;
+    mRxRadioFrame.mPsdu  = mRxPsdu;
+    mTxRadioFrame.mPsdu  = mTxPsdu;
+    mAckRadioFrame.mPsdu = mAckPsdu;
 
 exit:
     SuccessOrDie(error);
@@ -783,7 +784,7 @@ void RadioSpinel::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet)
         else
 #endif
         {
-            otPlatRadioTxDone(mInstance, mTransmitFrame, (mIsAckRequested ? &mRxRadioFrame : NULL), mTxError);
+            otPlatRadioTxDone(mInstance, mTransmitFrame, (mIsAckRequested ? &mAckRadioFrame : NULL), mTxError);
         }
 
         mTxState = kIdle;
@@ -1254,7 +1255,7 @@ void RadioSpinel::HandleTransmitDone(uint32_t          aCommand,
         if (mIsAckRequested)
         {
             VerifyOrExit(aLength > 0, error = OT_ERROR_FAILED);
-            SuccessOrExit(error = ParseRadioFrame(mRxRadioFrame, aBuffer, aLength));
+            SuccessOrExit(error = ParseRadioFrame(mAckRadioFrame, aBuffer, aLength));
         }
     }
     else
@@ -1630,7 +1631,7 @@ void ot::PosixApp::RadioSpinel::Process(const Event &aEvent)
         else
 #endif
         {
-            otPlatRadioTxDone(mInstance, mTransmitFrame, (mIsAckRequested ? &mRxRadioFrame : NULL), mTxError);
+            otPlatRadioTxDone(mInstance, mTransmitFrame, (mIsAckRequested ? &mAckRadioFrame : NULL), mTxError);
         }
 
         mTxState = kIdle;

--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -584,8 +584,10 @@ private:
 
     uint8_t       mRxPsdu[OT_RADIO_FRAME_MAX_SIZE];
     uint8_t       mTxPsdu[OT_RADIO_FRAME_MAX_SIZE];
+    uint8_t       mAckPsdu[OT_RADIO_FRAME_MAX_SIZE];
     otRadioFrame  mRxRadioFrame;
     otRadioFrame  mTxRadioFrame;
+    otRadioFrame  mAckRadioFrame;
     otRadioFrame *mTransmitFrame; ///< Points to the frame to send
 
     otExtAddress mExtendedAddress;


### PR DESCRIPTION
---
This commit uses a separate frame buffer (`mAckRadioFrame`) for saving acks instead of using `mRxRadioFrame` (which is used for received frames). 

**Why this change?**
This ensures that the ack frame won't be overwritten by a subsequently received frame. 

- Ack frame is read and saved in `HandleTransmitDone()` (which we get to from `HandleSpinelFrame() -> HandleResponse() -> HandleTransmitDone()`).
- But note that the saved ack frame is not immediately used, it is passed from `RadioSpinel::Process()` to next layer using `otPlatRadioTxDone()` callback.
- We can technically read and decode multiple spinel frames from a single call to `mHdlcInterface.Read()`:
  - So we can possibly get a TxDone spinel frame response where we read and save the ack frame;
  - And before getting the chance to get to `Process()`, from the same `mHdlcInterface.Read()` we can get a `VALUE_IS(STREAM_RAW)` spinel frame (i.e., receive a frame) which would then overwrite the ack frame (assuming we use `mRxRadioFrame` to save the ack)
- Using a separate ack frame (`mAckRadioFrame`) addresses this issue. 
