### PR TITLE
[ip6] use mesh local prefix length as ALOC prefix length

### DIFF
--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -159,7 +159,7 @@ otError Dhcp6Server::UpdateService(void)
                 address->mFields.m16[6]      = HostSwap16(0xfe00);
                 address->mFields.m8[14]      = Ip6::Address::kAloc16Mask;
                 address->mFields.m8[15]      = lowpanContext.mContextId;
-                mAgentsAloc[i].mPrefixLength = 128;
+                mAgentsAloc[i].mPrefixLength = 64;
                 mAgentsAloc[i].mPreferred    = true;
                 mAgentsAloc[i].mValid        = true;
                 netif.AddUnicastAddress(mAgentsAloc[i]);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -135,7 +135,7 @@ Mle::Mle(Instance &aInstance)
     mLinkLocal64.mValid        = true;
 
     // Leader Aloc
-    mLeaderAloc.mPrefixLength       = 128;
+    mLeaderAloc.mPrefixLength       = 64;
     mLeaderAloc.mPreferred          = true;
     mLeaderAloc.mValid              = true;
     mLeaderAloc.mScopeOverride      = Ip6::Address::kRealmLocalScope;
@@ -148,7 +148,7 @@ Mle::Mle(Instance &aInstance)
     {
         memset(&mServiceAlocs[i], 0, sizeof(mServiceAlocs[i]));
 
-        mServiceAlocs[i].mPrefixLength               = 128;
+        mServiceAlocs[i].mPrefixLength               = 64;
         mServiceAlocs[i].mPreferred                  = true;
         mServiceAlocs[i].mValid                      = true;
         mServiceAlocs[i].mScopeOverride              = Ip6::Address::kRealmLocalScope;


### PR DESCRIPTION
This change is made so that address callback can use prefix length to determine if the changed address is multicast or not.