### PR TITLE
[hdlc-interface] ignore errno EINTR in socket read

### DIFF
--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -141,19 +141,14 @@ void HdlcInterface::Read(void)
 
     rval = read(mSockFd, buffer, sizeof(buffer));
 
-    if (rval < 0)
-    {
-        perror("HdlcInterface::Read()");
-
-        if (errno != EAGAIN)
-        {
-            abort();
-        }
-    }
-
     if (rval > 0)
     {
         Decode(buffer, static_cast<uint16_t>(rval));
+    }
+    else if ((rval < 0) && (errno != EAGAIN) && (errno != EINTR))
+    {
+        perror("HdlcInterface::Read()");
+        exit(OT_EXIT_FAILURE);
     }
 }
 


### PR DESCRIPTION
This commit changes `HdlcInterface::Read()` method to ignore `errno`
`EINTR` (interrupt by a signal) during socket `read()`. It also
uses `exit()` on error.