### PR TITLE
[nrf52840] add support for the USB DFU software trigger

### DIFF
--- a/examples/Makefile-nrf52840
+++ b/examples/Makefile-nrf52840
@@ -64,10 +64,6 @@ else
 configure_OPTIONS              += --with-ncp-bus=uart
 endif
 
-ifeq ($(BOOTLOADER),1)
-configure_OPTIONS += --with-custom-linker-file=$(AbsTopSourceDir)/examples/platforms/nrf52840/nrf52840_bootloader.ld
-endif
-
 TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..
 AbsTopSourceDir                 := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))..
 
@@ -102,6 +98,11 @@ endif
 
 ifeq ($(USB),1)
 COMMONCFLAGS += -DUSB_CDC_AS_SERIAL_TRANSPORT=1
+endif
+
+ifeq ($(BOOTLOADER),1)
+configure_OPTIONS += --with-custom-linker-file=$(AbsTopSourceDir)/examples/platforms/nrf52840/nrf52840_bootloader.ld
+COMMONCFLAGS += -DAPP_USBD_NRF_DFU_TRIGGER_ENABLED=1
 endif
 
 ifeq ($(DISABLE_CC310), 1)

--- a/examples/platforms/nrf52840/Makefile.am
+++ b/examples/platforms/nrf52840/Makefile.am
@@ -176,6 +176,8 @@ NORDICSEMI_SOURCES                                                              
     @top_builddir@/third_party/NordicSemiconductor/libraries/usb/app_usbd_core.c                             \
     @top_builddir@/third_party/NordicSemiconductor/libraries/usb/app_usbd_string_desc.c                      \
     @top_builddir@/third_party/NordicSemiconductor/libraries/usb/app_usbd_serial_num.c                       \
+    @top_builddir@/third_party/NordicSemiconductor/libraries/usb/app_usbd_nrf_dfu_trigger.c                  \
+    @top_builddir@/third_party/NordicSemiconductor/libraries/usb/nrf_dfu_trigger_usb.c                       \
     @top_builddir@/third_party/NordicSemiconductor/libraries/usb/class/cdc/acm/app_usbd_cdc_acm.c            \
     @top_builddir@/third_party/NordicSemiconductor/libraries/utf_converter/utf.c                             \
     @top_builddir@/third_party/NordicSemiconductor/nrfx/drivers/src/nrfx_clock.c                             \
@@ -253,6 +255,8 @@ noinst_HEADERS                                                                  
     $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrf_log_internal.h                              \
     $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrf_log_types.h                                 \
     $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrf_log.h                                       \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrf_log_ctrl.h                                  \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrf_log_ctrl_internal.h                         \
     $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrf_section.h                                   \
     $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrfx_config.h                                   \
     $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrfx_glue.h                                     \
@@ -319,6 +323,9 @@ noinst_HEADERS                                                                  
     $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd_string_desc.h                         \
     $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd_types.h                               \
     $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd.h                                     \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd_nrf_dfu_trigger.h                     \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd_nrf_dfu_trigger_types.h               \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd_nrf_dfu_trigger_internal.h            \
     $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/class/cdc/app_usbd_cdc_desc.h                  \
     $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/class/cdc/app_usbd_cdc_types.h                 \
     $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/class/cdc/acm/app_usbd_cdc_acm_internal.h      \

--- a/examples/platforms/nrf52840/README.md
+++ b/examples/platforms/nrf52840/README.md
@@ -49,8 +49,7 @@ Note, that if Windows 7 or earlier is used, an additional USB CDC driver has to 
 It can be found in third_party/NordicSemiconductor/libraries/usb/nordic_cdc_acm_example.inf
 
 ## nRF52840 dongle support (PCA10059)
-
-You can build the libraries with support for USB bootloader present in PCA10059. As this dongle uses native USB support we have to enable it as well. To do so, build the libraries with the following parameter:
+You can build the libraries with support for USB bootloader with automatic USB DFU trigger suppoted by the PCA10059. As this dongle uses native USB support we have to enable it as well. To do so, build the libraries with the following parameter:
 ```
 $ make -f examples/Makefile-nrf52840 USB=1 BOOTLOADER=1
 ```

--- a/examples/platforms/nrf52840/README.md
+++ b/examples/platforms/nrf52840/README.md
@@ -49,7 +49,7 @@ Note, that if Windows 7 or earlier is used, an additional USB CDC driver has to 
 It can be found in third_party/NordicSemiconductor/libraries/usb/nordic_cdc_acm_example.inf
 
 ## nRF52840 dongle support (PCA10059)
-You can build the libraries with support for USB bootloader with automatic USB DFU trigger suppoted by the PCA10059. As this dongle uses native USB support we have to enable it as well. To do so, build the libraries with the following parameter:
+You can build the libraries with support for USB bootloader with automatic USB DFU trigger support in PCA10059. As this dongle uses native USB support we have to enable it as well. To do so, build the libraries with the following parameter:
 ```
 $ make -f examples/Makefile-nrf52840 USB=1 BOOTLOADER=1
 ```

--- a/examples/platforms/nrf52840/platform-config.h
+++ b/examples/platforms/nrf52840/platform-config.h
@@ -425,7 +425,7 @@
  * @def The USB interface to use for CDC ACM COMM.
  *
  * According to the USB Specification, interface numbers cannot have gaps. Tailor this value to adhere to this
- * limitation. Takes values between 0-255
+ * limitation. Takes values between 0-255.
  */
 #ifndef USB_CDC_ACM_COMM_INTERFACE
 #define USB_CDC_ACM_COMM_INTERFACE 1
@@ -435,7 +435,7 @@
  * @def The USB interface to use for CDC ACM DATA.
  *
  * According to the USB Specification, interface numbers cannot have gaps. Tailor this value to adhere to this
- * limitation. Takes values between 0-255
+ * limitation. Takes values between 0-255.
  */
 #ifndef USB_CDC_ACM_DATA_INTERFACE
 #define USB_CDC_ACM_DATA_INTERFACE 2
@@ -537,4 +537,5 @@
 #define NRF_802154_TX_STARTED_NOTIFY_ENABLED 1
 #endif
 #endif
+
 #endif // PLATFORM_CONFIG_H_

--- a/examples/platforms/nrf52840/platform-config.h
+++ b/examples/platforms/nrf52840/platform-config.h
@@ -422,6 +422,26 @@
 #endif
 
 /**
+ * @def The USB interface to use for CDC ACM COMM.
+ *
+ * According to the USB Specification, interface numbers cannot have gaps. Tailor this value to adhere to this
+ * limitation. Takes values between 0-255
+ */
+#ifndef USB_CDC_ACM_COMM_INTERFACE
+#define USB_CDC_ACM_COMM_INTERFACE 1
+#endif
+
+/**
+ * @def The USB interface to use for CDC ACM DATA.
+ *
+ * According to the USB Specification, interface numbers cannot have gaps. Tailor this value to adhere to this
+ * limitation. Takes values between 0-255
+ */
+#ifndef USB_CDC_ACM_DATA_INTERFACE
+#define USB_CDC_ACM_DATA_INTERFACE 2
+#endif
+
+/**
  * @def OPENTHREAD_PLATFORM_USE_PSEUDO_RESET
  *
  * Reset the application, not the chip, when a software reset is requested.
@@ -517,5 +537,4 @@
 #define NRF_802154_TX_STARTED_NOTIFY_ENABLED 1
 #endif
 #endif
-
 #endif // PLATFORM_CONFIG_H_

--- a/examples/platforms/nrf52840/usb-cdc-uart.c
+++ b/examples/platforms/nrf52840/usb-cdc-uart.c
@@ -57,22 +57,21 @@
 #include "libraries/usb/app_usbd.h"
 #include "libraries/usb/app_usbd_serial_num.h"
 #include "libraries/usb/class/cdc/acm/app_usbd_cdc_acm.h"
+#include "libraries/usb/nrf_dfu_trigger_usb.h"
 
 #if (USB_CDC_AS_SERIAL_TRANSPORT == 1)
 
 static void cdcAcmUserEventHandler(app_usbd_class_inst_t const *aInstance, app_usbd_cdc_acm_user_event_t aEvent);
 
-#define CDC_ACM_COMM_INTERFACE 0
 #define CDC_ACM_COMM_EPIN NRF_DRV_USBD_EPIN2
 
-#define CDC_ACM_DATA_INTERFACE 1
 #define CDC_ACM_DATA_EPIN NRF_DRV_USBD_EPIN1
 #define CDC_ACM_DATA_EPOUT NRF_DRV_USBD_EPOUT1
 
 APP_USBD_CDC_ACM_GLOBAL_DEF(sAppCdcAcm,
                             cdcAcmUserEventHandler,
-                            CDC_ACM_COMM_INTERFACE,
-                            CDC_ACM_DATA_INTERFACE,
+                            USB_CDC_ACM_COMM_INTERFACE,
+                            USB_CDC_ACM_DATA_INTERFACE,
                             CDC_ACM_COMM_EPIN,
                             CDC_ACM_DATA_EPIN,
                             CDC_ACM_DATA_EPOUT,
@@ -262,6 +261,11 @@ void nrf5UartInit(void)
 
     ret_code_t ret = app_usbd_init(&usbdConfig);
     assert(ret == NRF_SUCCESS);
+
+#if NRF_MODULE_ENABLED(APP_USBD_NRF_DFU_TRIGGER)
+    ret = nrf_dfu_trigger_usb_init();
+    assert(ret == NRF_SUCCESS);
+#endif // NRF_MODULE_ENABLED(APP_USBD_NRF_DFU_TRIGGER)
 
     app_usbd_class_inst_t const *cdcAcmInstance = app_usbd_cdc_acm_class_inst_get(&sAppCdcAcm);
     ret                                         = app_usbd_class_append(cdcAcmInstance);

--- a/third_party/NordicSemiconductor/README.md
+++ b/third_party/NordicSemiconductor/README.md
@@ -10,3 +10,6 @@ Directory consists of following folders:
  - /nrfx         - Standalone drivers for peripherals present in Nordic SoCs (https://github.com/NordicSemiconductor/nrfx)
  - /segger_rtt   - Library for the RTT communication
  - /softdevice   - SoftDevice s140 headers
+
+ The following changes comparing to the nRF5 SDK 15.2 have been incorporated:
+- modified nrf_log_ctrl.h file in order to remove unused backend logging functions

--- a/third_party/NordicSemiconductor/dependencies/nrf_log_ctrl.h
+++ b/third_party/NordicSemiconductor/dependencies/nrf_log_ctrl.h
@@ -1,0 +1,252 @@
+/**
+ * Copyright (c) 2016 - 2018, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef NRF_LOG_CTRL_H
+#define NRF_LOG_CTRL_H
+
+/**@file
+ * @addtogroup nrf_log Logger module
+ * @ingroup    app_common
+ *
+ * @defgroup nrf_log_ctrl Functions for controlling nrf_log
+ * @{
+ * @ingroup  nrf_log
+ * @brief    The nrf_log control interface.
+ */
+
+#include "sdk_config.h"
+#include "sdk_errors.h"
+#include <stdint.h>
+#include <stdbool.h>
+#include "nrf_log_types.h"
+#include "nrf_log_ctrl_internal.h"
+
+/* Different backends currently not supported. */
+#define LOG_BACKEND 0
+
+#if LOG_BACKEND
+#include "nrf_log_backend_interface.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Timestamp function prototype.
+ *
+ * @return Timestamp value.
+ */
+typedef uint32_t (*nrf_log_timestamp_func_t)(void);
+
+
+/**@brief Macro for initializing the logs.
+ *
+ * Macro has one or two parameters. First parameter (obligatory) is the timestamp function (@ref nrf_log_timestamp_func_t).
+ * Additionally, as the second parameter timestamp frequency in Hz can be provided. If not provided then default
+ * frequency is used (@ref  NRF_LOG_TIMESTAMP_DEFAULT_FREQUENCY). Frequency is used to format timestamp prefix if
+ * @ref NRF_LOG_STR_FORMATTER_TIMESTAMP_FORMAT_ENABLED is set.
+ *
+ * @return  NRF_SUCCESS after successful initialization, otherwise an error code.
+ */
+#define NRF_LOG_INIT(...) NRF_LOG_INTERNAL_INIT(__VA_ARGS__)
+
+
+/**@brief Macro for processing a single log entry from a queue of deferred logs.
+ *
+ * You can call this macro from the main context or from the error handler to process
+ * log entries one by one.
+ *
+ * @note If logs are not deferred, this call has no use and is defined as 'false'.
+ *
+ * @retval true    There are more logs to process in the buffer.
+ * @retval false   No more logs in the buffer.
+ */
+#define NRF_LOG_PROCESS()    NRF_LOG_INTERNAL_PROCESS()
+
+/** @brief Macro for processing all log entries from the buffer.
+ * It blocks until all buffered entries are processed by the backend.
+ *
+ * @note If logs are not deferred, this call has no use and is empty.
+ */
+#define NRF_LOG_FLUSH()      NRF_LOG_INTERNAL_FLUSH()
+
+/** @brief Macro for flushing log data before reset.
+ *
+ * @note If logs are not deferred, this call has no use and is empty.
+ *
+ * @note If RTT is used, then a breakpoint is hit once flushed.
+ */
+#define NRF_LOG_FINAL_FLUSH() NRF_LOG_INTERNAL_FINAL_FLUSH()
+
+/**
+ * @brief Function for initializing the frontend and the default backend.
+ *
+ * @ref NRF_LOG_INIT calls this function to initialize the frontend and the backend.
+ * If custom backend is used, then @ref NRF_LOG_INIT should not be called.
+ * Instead, frontend and user backend should be verbosely initialized.
+ *
+ * @param timestamp_func Function for getting a 32-bit timestamp.
+ * @param timestamp_freq Frequency of the timestamp.
+ *
+ * @return Error status.
+ *
+ */
+ret_code_t nrf_log_init(nrf_log_timestamp_func_t timestamp_func, uint32_t timestamp_freq);
+
+#if LOG_BACKEND
+/**
+ * @brief Function for adding new backend interface to the logger.
+ *
+ * @param p_backend Pointer to the backend interface.
+ * @param severity  Initial value of severity level for each module forwarded to the backend. This
+ *                  option is only applicable if @ref NRF_LOG_FILTERS_ENABLED is set.
+ * @return -1 if backend cannot be added or positive number (backend ID).
+ */
+int32_t nrf_log_backend_add(nrf_log_backend_t const * p_backend, nrf_log_severity_t severity);
+
+/**
+ * @brief Function for removing backend from the logger.
+ *
+ * @param p_backend Pointer to the backend interface.
+ *
+ */
+void nrf_log_backend_remove(nrf_log_backend_t const * p_backend);
+#endif /* LOG_BACKEND */
+
+/**
+ * @brief Function for setting logger backends into panic mode.
+ *
+ * When this function is called all attached backends are informed about panic state of the system.
+ * It is up to the backend to react properly (hold or process logs in blocking mode, etc.)
+ */
+void nrf_log_panic(void);
+
+/**
+ * @brief Function for handling a single log entry.
+ *
+ * Use this function only if the logs are buffered. It takes a single entry from the
+ * buffer and attempts to process it.
+ *
+ * @retval true  If there are more entries to process.
+ * @retval false If there are no more entries to process.
+ */
+bool nrf_log_frontend_dequeue(void);
+
+/**
+ * @brief Function for getting number of independent log modules registered into the logger.
+ *
+ * @return Number of registered modules.
+ */
+uint32_t nrf_log_module_cnt_get(void);
+
+/**
+ * @brief Function for getting module name.
+ *
+ * @param module_id      Module ID.
+ * @param is_ordered_idx Module ID is given is index in alphabetically sorted list of modules.
+ * @return Pointer to string with module name.
+ */
+const char * nrf_log_module_name_get(uint32_t module_id, bool is_ordered_idx);
+
+/**
+ * @brief Function for getting coloring of specific logs.
+ *
+ * @param module_id Module ID.
+ * @param severity  Log severity.
+ *
+ * @return ID of the color.
+ */
+uint8_t nrf_log_color_id_get(uint32_t module_id, nrf_log_severity_t severity);
+
+/**
+ * @brief Function for configuring filtering ofs logs in the module.
+ *
+ * Filtering of logs in modules is independent for each backend.
+ *
+ * @param backend_id Backend ID which want to chenge its configuration.
+ * @param module_id  Module ID which logs will be reconfigured.
+ * @param severity   New severity filter.
+ */
+void nrf_log_module_filter_set(uint32_t backend_id,
+                               uint32_t module_id,
+                               nrf_log_severity_t severity);
+
+/**
+ * @brief Function for getting module severity level.
+ *
+ * @param backend_id     Backend ID.
+ * @param module_id      Module ID.
+ * @param is_ordered_idx Module ID is given is index in alphabetically sorted list of modules.
+ * @param dynamic        It true current filter for given backend is returned. If false then
+ *                       compiled-in level is returned (maximum available). If this parameter is
+ *                       false then backend_id parameter is not used.
+ *
+ * @return Severity.
+ */
+nrf_log_severity_t nrf_log_module_filter_get(uint32_t backend_id,
+                                             uint32_t module_id,
+                                             bool     is_ordered_idx,
+                                             bool     dynamic);
+
+/**
+ * @brief Function stores current filtering configuration into non-volatile memory using @ref fds module.
+ *
+ * @return NRF_SUCCESS or @ref fds error code.
+ */
+ret_code_t nrf_log_config_store(void);
+
+/**
+ * @brief Function loads configuration from non-volatile memory using @ref fds module.
+ *
+ * @retval NRF_SUCCESS         On successful loading.
+ * @retval NRF_ERROR_NOT_FOUND Configuration file not found.
+ * @retval NRF_ERROR_INTERNAL  Other @ref fds error on reading configuration file.
+ */
+ret_code_t nrf_log_config_load(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRF_LOG_CTRL_H
+
+/**
+ *@}
+ **/

--- a/third_party/NordicSemiconductor/dependencies/nrf_log_ctrl_internal.h
+++ b/third_party/NordicSemiconductor/dependencies/nrf_log_ctrl_internal.h
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016 - 2018, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef NRF_LOG_CTRL_INTERNAL_H
+#define NRF_LOG_CTRL_INTERNAL_H
+/**
+ * @cond (NODOX)
+ * @defgroup nrf_log_ctrl_internal Auxiliary internal types declarations
+ * @{
+ * @internal
+ */
+
+#include "sdk_common.h"
+#if NRF_MODULE_ENABLED(NRF_LOG)
+
+#define NRF_LOG_LFCLK_FREQ 32768
+
+#ifdef APP_TIMER_CONFIG_RTC_FREQUENCY
+#define LOG_TIMESTAMP_DEFAULT_FREQUENCY ((NRF_LOG_TIMESTAMP_DEFAULT_FREQUENCY == 0) ?              \
+                                       (NRF_LOG_LFCLK_FREQ/(APP_TIMER_CONFIG_RTC_FREQUENCY + 1)) : \
+                                        NRF_LOG_TIMESTAMP_DEFAULT_FREQUENCY)
+#else
+#define LOG_TIMESTAMP_DEFAULT_FREQUENCY NRF_LOG_TIMESTAMP_DEFAULT_FREQUENCY
+#endif
+
+#define NRF_LOG_INTERNAL_INIT(...)               \
+        nrf_log_init(GET_VA_ARG_1(__VA_ARGS__),  \
+                     GET_VA_ARG_1(GET_ARGS_AFTER_1(__VA_ARGS__, LOG_TIMESTAMP_DEFAULT_FREQUENCY)))
+
+#define NRF_LOG_INTERNAL_PROCESS() nrf_log_frontend_dequeue()
+#define NRF_LOG_INTERNAL_FLUSH()            \
+    do {                                    \
+        while (NRF_LOG_INTERNAL_PROCESS()); \
+    } while (0)
+
+#define NRF_LOG_INTERNAL_FINAL_FLUSH()      \
+    do {                                    \
+        nrf_log_panic();                    \
+        NRF_LOG_INTERNAL_FLUSH();           \
+    } while (0)
+
+
+#else // NRF_MODULE_ENABLED(NRF_LOG)
+#define NRF_LOG_INTERNAL_PROCESS()            false
+#define NRF_LOG_INTERNAL_FLUSH()
+#define NRF_LOG_INTERNAL_INIT(timestamp_func) NRF_SUCCESS
+#define NRF_LOG_INTERNAL_HANDLERS_SET(default_handler, bytes_handler) \
+    UNUSED_PARAMETER(default_handler); UNUSED_PARAMETER(bytes_handler)
+#define NRF_LOG_INTERNAL_FINAL_FLUSH()
+#endif // NRF_MODULE_ENABLED(NRF_LOG)
+
+/** @}
+ * @endcond
+ */
+#endif // NRF_LOG_CTRL_INTERNAL_H

--- a/third_party/NordicSemiconductor/dependencies/sdk_config.h
+++ b/third_party/NordicSemiconductor/dependencies/sdk_config.h
@@ -297,6 +297,15 @@
 #define USBD_ENABLED 0
 #endif
 #endif // USB_CDC_AS_SERIAL_TRANSPORT == 1
+
+// <q> Enable power USB detection.
+
+// <i> Configure if the example supports USB port connection.
+
+#ifndef USBD_POWER_DETECTION
+#define USBD_POWER_DETECTION 1
+#endif
+
 // <o> USBD_CONFIG_IRQ_PRIORITY  - Interrupt priority
 
 // <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
@@ -347,6 +356,77 @@
 
 // </e>
 
+
+// <h> Application info used by the USB DFU.
+ 
+// <q> @def APP_NAME
+
+// <i> Application name in a human readable string.
+
+
+#ifndef APP_NAME
+#define APP_NAME "OpenThread App"
+#endif
+
+
+// <q> APP_VERSION_MAJOR
+
+// <i> Application version major version.
+
+#ifndef APP_VERSION_MAJOR
+#define APP_VERSION_MAJOR 1
+#endif
+
+
+// <q> APP_VERSION_MINOR
+
+// <i> Application version minor version.
+
+
+#ifndef APP_VERSION_MINOR
+#define APP_VERSION_MINOR 0
+#endif
+
+
+// <q> APP_VERSION_PATCH
+
+// <i> Application version patch version.
+
+
+#ifndef APP_VERSION_PATCH
+#define APP_VERSION_PATCH 0
+#endif
+
+
+// <q> @def APP_ID
+
+// <i> Application ID.
+
+
+#ifndef APP_ID
+#define APP_ID 1
+#endif
+
+
+// <q> APP_VERSION_PRERELEASE
+
+// <i> Application prerelease tag.
+
+
+#ifndef APP_VERSION_PRERELEASE
+#define APP_VERSION_PRERELEASE ""
+#endif
+
+
+// <q> APP_VERSION_METADATA
+
+// <i> Application metadata.
+
+
+#ifndef APP_VERSION_METADATA
+#define APP_VERSION_METADATA ""
+#endif
+
 // <h> app_usbd_cdc_acm - USB CDC ACM class
 
 //==========================================================
@@ -368,6 +448,52 @@
 #endif
 
 // </h>
+
+// <h> app_usbd_nrf_dfu_trigger - USB Trigger library
+
+//==========================================================
+// <q> APP_USBD_NRF_DFU_TRIGGER_ENABLED
+
+
+// <i> Enable possibility to enter the bootloader from the application via a software trigger send over USB.
+// <i> Requires configured BSP_SELF_PINRESET_PIN which is a GPIO pin connected to the reset pin.
+
+#ifndef APP_USBD_NRF_DFU_TRIGGER_ENABLED
+#define APP_USBD_NRF_DFU_TRIGGER_ENABLED 0
+#endif
+
+// <q> BSP_SELF_PINRESET_PIN
+
+
+// <i> Enable possibility to enter the bootloader from the application via a software trigger send over USB.
+// <i> Requires configured BSP_SELF_PINRESET_PIN which is a GPIO pin connected to the reset pin.
+// <i> NRF_GPIO_PIN_MAP(0,19) is a pin used on Nordic PCA10059 Dongle.
+
+#ifndef BSP_SELF_PINRESET_PIN
+#define BSP_SELF_PINRESET_PIN NRF_GPIO_PIN_MAP(0, 19)
+#endif
+
+// <q> NRF_DFU_TRIGGER_USB_USB_SHARED
+
+// <i> Flag indicating whether USB is used for other purposes in the application.
+
+#ifndef NRF_DFU_TRIGGER_USB_USB_SHARED
+#define NRF_DFU_TRIGGER_USB_USB_SHARED 1
+#endif
+
+
+// <q> NRF_DFU_TRIGGER_USB_INTERFACE_NUM
+
+// <i> The USB interface to use for the DFU Trigger library.
+// <i> According to the USB Specification, interface numbers cannot have gaps. Tailor this value to adhere to this
+// <i> limitation. Takes values between 0-255
+
+#ifndef NRF_DFU_TRIGGER_USB_INTERFACE_NUM
+#define NRF_DFU_TRIGGER_USB_INTERFACE_NUM 0
+#endif
+
+// </h>
+
 //==========================================================
 
 // <h> nrf_log - Logging

--- a/third_party/NordicSemiconductor/libraries/usb/app_usbd_nrf_dfu_trigger.c
+++ b/third_party/NordicSemiconductor/libraries/usb/app_usbd_nrf_dfu_trigger.c
@@ -1,0 +1,373 @@
+/**
+ * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include "sdk_common.h"
+#if NRF_MODULE_ENABLED(APP_USBD_NRF_DFU_TRIGGER)
+
+#include <string.h>
+#include <ctype.h>
+#include "app_usbd.h"
+#include "app_usbd_nrf_dfu_trigger.h"
+#include "app_usbd_string_desc.h"
+#include "nrf_gpio.h"
+
+/**
+ * @defgroup app_usbd_nrf_dfu_trigger_internal USBD Nordic DFU Trigger internals
+ * @{
+ * @ingroup app_usbd_nrf_dfu_trigger
+ * @internal
+ */
+
+#define NRF_LOG_MODULE_NAME usbd_nrf_dfu_trigger
+
+#if APP_USBD_NRF_DFU_TRIGGER_CONFIG_LOG_ENABLED
+#define NRF_LOG_LEVEL       APP_USBD_NRF_DFU_TRIGGER_CONFIG_LOG_LEVEL
+#define NRF_LOG_INFO_COLOR  APP_USBD_NRF_DFU_TRIGGER_CONFIG_INFO_COLOR
+#define NRF_LOG_DEBUG_COLOR APP_USBD_NRF_DFU_TRIGGER_CONFIG_DEBUG_COLOR
+#else //APP_USBD_NRF_DFU_TRIGGER_CONFIG_LOG_ENABLED
+#define NRF_LOG_LEVEL       0
+#endif //APP_USBD_NRF_DFU_TRIGGER_CONFIG_LOG_ENABLED
+#include "nrf_log.h"
+NRF_LOG_MODULE_REGISTER();
+
+/**
+ * @brief Auxiliary function to access DFU Trigger instance data.
+ *
+ * @param[in] p_inst Class instance data.
+ *
+ * @return DFU Trigger instance data @ref app_usbd_nrf_dfu_trigger_t
+ */
+static inline app_usbd_nrf_dfu_trigger_t const * nrf_dfu_trigger_get(app_usbd_class_inst_t const * p_inst)
+{
+    ASSERT(p_inst != NULL);
+    return (app_usbd_nrf_dfu_trigger_t const *)p_inst;
+}
+
+/**
+ * @brief Auxiliary function to access DFU Trigger context data.
+ *
+ * @param[in] p_dfu    DFU Trigger instance data.
+ *
+ * @return DFU Trigger context data @ref app_usbd_nrf_dfu_trigger_ctx_t
+ */
+static inline app_usbd_nrf_dfu_trigger_ctx_t * nrf_dfu_trigger_ctx_get(
+        app_usbd_nrf_dfu_trigger_t const * p_dfu)
+{
+    ASSERT(p_dfu != NULL);
+    ASSERT(p_dfu->specific.p_data != NULL);
+    return &p_dfu->specific.p_data->ctx;
+}
+
+/**
+ * @brief Internal SETUP standard IN request handler.
+ *
+ * @param[in] p_inst        Generic class instance.
+ * @param[in] p_setup_ev    Setup event.
+ *
+ * @return Standard error code.
+ * @retval NRF_SUCCESS if request handled correctly.
+ * @retval NRF_ERROR_NOT_SUPPORTED if request is not supported.
+ */
+static ret_code_t setup_req_std_in(app_usbd_class_inst_t const * p_inst,
+                                   app_usbd_setup_evt_t const *  p_setup_ev)
+{
+    /* Only Get Descriptor standard IN request is supported by DFU class */
+    if ((app_usbd_setup_req_rec(p_setup_ev->setup.bmRequestType) == APP_USBD_SETUP_REQREC_INTERFACE)
+        &&
+        (p_setup_ev->setup.bmRequest == APP_USBD_SETUP_STDREQ_GET_DESCRIPTOR))
+    {
+        size_t dsc_len = 0;
+        size_t max_size;
+
+        uint8_t * p_trans_buff = app_usbd_core_setup_transfer_buff_get(&max_size);
+        /* Try to find descriptor in class internals*/
+        ret_code_t ret = app_usbd_class_descriptor_find(p_inst,
+                                                        p_setup_ev->setup.wValue.hb,
+                                                        p_setup_ev->setup.wValue.lb,
+                                                        p_trans_buff,
+                                                        &dsc_len);
+        if (ret != NRF_ERROR_NOT_FOUND)
+        {
+            ASSERT(dsc_len < NRF_DRV_USBD_EPSIZE);
+            return app_usbd_core_setup_rsp(&(p_setup_ev->setup), p_trans_buff, dsc_len);
+        }
+    }
+    return NRF_ERROR_NOT_SUPPORTED;
+}
+
+/**
+ * @brief Internal SETUP standard OUT request handler.
+ *
+ * @param[in] p_inst        Generic class instance.
+ * @param[in] p_setup_ev    Setup event.
+ *
+ * @return Standard error code.
+ * @retval NRF_SUCCESS if request handled correctly.
+ * @retval NRF_ERROR_NOT_SUPPORTED if request is not supported.
+ * @retval NRF_ERROR_FORBIDDEN if endpoint stall cannot be cleared because of internal state.
+ */
+static ret_code_t setup_req_std_out(app_usbd_class_inst_t const * p_inst,
+                                    app_usbd_setup_evt_t const *  p_setup_ev)
+{
+
+    switch (p_setup_ev->setup.bmRequest)
+    {
+    default:
+        break;
+    }
+    return NRF_ERROR_NOT_SUPPORTED;
+}
+
+/**
+ * @brief User event handler.
+ *
+ * @param[in] p_inst        Class instance.
+ * @param[in] event user    Event type.
+ */
+static inline void user_event_handler(app_usbd_class_inst_t const *         p_inst,
+                                      app_usbd_nrf_dfu_trigger_user_event_t event)
+{
+    app_usbd_nrf_dfu_trigger_t const * p_dfu = nrf_dfu_trigger_get(p_inst);
+    if (p_dfu->specific.inst.user_ev_handler != NULL)
+    {
+        p_dfu->specific.inst.user_ev_handler(p_inst, event);
+    }
+}
+
+/**
+ * @brief Internal SETUP class IN request handler.
+ *
+ * @param[in] p_inst        Generic class instance.
+ * @param[in] p_setup_ev    Setup event.
+ *
+ * @return Standard error code.
+ * @retval NRF_SUCCESS if request handled correctly.
+ * @retval NRF_ERROR_NOT_SUPPORTED if request is not supported.
+ */
+static ret_code_t setup_req_class_in(app_usbd_class_inst_t const * p_inst,
+                                     app_usbd_setup_evt_t const *  p_setup_ev)
+{
+    app_usbd_nrf_dfu_trigger_t const * p_dfu = nrf_dfu_trigger_get(p_inst);
+
+    switch (p_setup_ev->setup.bmRequest)
+    {
+        case APP_USBD_NRF_DFU_TRIGGER_REQ_NORDIC_INFO:
+            if (p_setup_ev->setup.wLength.w != sizeof(app_usbd_nrf_dfu_trigger_nordic_info_t))
+            {
+                return NRF_ERROR_NOT_SUPPORTED;
+            }
+            return app_usbd_core_setup_rsp(&p_setup_ev->setup,
+                                           p_dfu->specific.inst.p_dfu_info,
+                                           sizeof(app_usbd_nrf_dfu_trigger_nordic_info_t));
+
+        case APP_USBD_NRF_DFU_TRIGGER_REQ_SEM_VER:
+            return app_usbd_core_setup_rsp(&p_setup_ev->setup,
+                                           p_dfu->specific.inst.p_sem_ver,
+                                           p_dfu->specific.inst.sem_ver_size);
+
+        default:
+            break;
+    }
+
+    return NRF_ERROR_NOT_SUPPORTED;
+}
+
+/**
+ * @brief Internal SETUP class OUT request handler.
+ *
+ * @param[in] p_inst        Generic class instance.
+ * @param[in] p_setup_ev    Setup event.
+ *
+ * @return Standard error code.
+ * @retval NRF_SUCCESS if request handled correctly.
+ * @retval NRF_ERROR_NOT_SUPPORTED if request is not supported.
+ */
+static ret_code_t setup_req_class_out(app_usbd_class_inst_t const * p_inst,
+                                      app_usbd_setup_evt_t const *  p_setup_ev)
+{
+    app_usbd_nrf_dfu_trigger_t const * p_dfu     = nrf_dfu_trigger_get(p_inst);
+    app_usbd_nrf_dfu_trigger_ctx_t *   p_dfu_ctx = nrf_dfu_trigger_ctx_get(p_dfu);
+
+    switch (p_setup_ev->setup.bmRequest)
+    {
+        case APP_USBD_NRF_DFU_TRIGGER_REQ_DETACH:
+        {
+            NRF_LOG_DEBUG("Entering DFU Mode");
+            p_dfu_ctx->state = APP_USBD_NRF_DFU_TRIGGER_STATE_DETACH;
+            user_event_handler(p_inst, APP_USBD_NRF_DFU_TRIGGER_USER_EVT_DETACH);
+            return NRF_SUCCESS;
+        }
+        default:
+            break;
+    }
+
+    return NRF_ERROR_NOT_SUPPORTED;
+}
+
+/**
+ * @brief Control endpoint handle.
+ *
+ * @param[in] p_inst        Generic class instance.
+ * @param[in] p_setup_ev    Setup event.
+ *
+ * @return Standard error code.
+ * @retval NRF_SUCCESS if request handled correctly.
+ * @retval NRF_ERROR_NOT_SUPPORTED if request is not supported.
+ */
+static ret_code_t setup_event_handler(app_usbd_class_inst_t const * p_inst,
+                                      app_usbd_setup_evt_t const *  p_setup_ev)
+{
+    ASSERT(p_inst     != NULL);
+    ASSERT(p_setup_ev != NULL);
+
+    if (app_usbd_setup_req_dir(p_setup_ev->setup.bmRequestType) == APP_USBD_SETUP_REQDIR_IN)
+    {
+        switch (app_usbd_setup_req_typ(p_setup_ev->setup.bmRequestType))
+        {
+            case APP_USBD_SETUP_REQTYPE_STD:
+                return setup_req_std_in(p_inst, p_setup_ev);
+            case APP_USBD_SETUP_REQTYPE_CLASS:
+                return setup_req_class_in(p_inst, p_setup_ev);
+            default:
+                break;
+        }
+    }
+    else /* APP_USBD_SETUP_REQDIR_OUT */
+    {
+        switch (app_usbd_setup_req_typ(p_setup_ev->setup.bmRequestType))
+        {
+            case APP_USBD_SETUP_REQTYPE_STD:
+                return setup_req_std_out(p_inst, p_setup_ev);
+            case APP_USBD_SETUP_REQTYPE_CLASS:
+                return setup_req_class_out(p_inst, p_setup_ev);
+            default:
+                break;
+        }
+    }
+
+    return NRF_ERROR_NOT_SUPPORTED;
+}
+
+/**
+ * @brief @ref app_usbd_class_methods_t::event_handler
+ */
+static ret_code_t nrf_dfu_trigger_event_handler(app_usbd_class_inst_t const *  p_inst,
+                                                app_usbd_complex_evt_t const * p_event)
+{
+    ASSERT(p_inst  != NULL);
+    ASSERT(p_event != NULL);
+
+    ret_code_t ret = NRF_SUCCESS;
+    switch (p_event->app_evt.type)
+    {
+        case APP_USBD_EVT_DRV_SOF:
+            break;
+        case APP_USBD_EVT_DRV_RESET:
+            break;
+        case APP_USBD_EVT_DRV_SETUP:
+            ret  = setup_event_handler(p_inst, (app_usbd_setup_evt_t const *) p_event);
+            break;
+        case APP_USBD_EVT_DRV_EPTRANSFER:
+            break;
+        case APP_USBD_EVT_DRV_SUSPEND:
+            break;
+        case APP_USBD_EVT_DRV_RESUME:
+            break;
+        case APP_USBD_EVT_INST_APPEND:
+            break;
+        case APP_USBD_EVT_INST_REMOVE:
+            break;
+        case APP_USBD_EVT_STARTED:
+            break;
+        case APP_USBD_EVT_STOPPED:
+            break;
+        default:
+            ret = NRF_ERROR_NOT_SUPPORTED;
+            break;
+    }
+
+    return ret;
+}
+
+/**
+ * @brief @ref app_usbd_class_methods_t::feed_descriptors
+ */
+static bool nrf_dfu_trigger_feed_descriptors(app_usbd_class_descriptor_ctx_t * p_ctx,
+                                             app_usbd_class_inst_t const     * p_inst,
+                                             uint8_t                         * p_buff,
+                                             size_t                            max_size)
+{
+    static app_usbd_class_iface_conf_t const * p_cur_iface = NULL;
+    p_cur_iface = app_usbd_class_iface_get(p_inst, 0);
+    app_usbd_nrf_dfu_trigger_t const * p_dfu = nrf_dfu_trigger_get(p_inst);
+
+    APP_USBD_CLASS_DESCRIPTOR_BEGIN(p_ctx, p_buff, max_size)
+
+    /* INTERFACE DESCRIPTOR */
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(sizeof(app_usbd_descriptor_iface_t)); // bLength
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(APP_USBD_DESCRIPTOR_INTERFACE); // bDescriptorType
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(app_usbd_class_iface_number_get(p_cur_iface)); // bInterfaceNumber
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(0x00); // bAlternateSetting
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(0); // bNumEndpoints
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(APP_USBD_NRF_DFU_TRIGGER_CLASS); // bInterfaceClass
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(APP_USBD_NRF_DFU_TRIGGER_SUBCLASS); // bInterfaceSubClass
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(APP_USBD_NRF_DFU_TRIGGER_PROTOCOL_RUNTIME); // bInterfaceProtocol
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(0x00); // iInterface
+
+    /* FUNCTIONAL DESCRIPTOR */
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(sizeof(app_usbd_nrf_dfu_trigger_desc_func_t)); // bFunctionLength
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(APP_USBD_NRF_DFU_TRIGGER_CS_FUNCTIONAL); // bDescriptorType
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(APP_USBD_NRF_DFU_TRIGGER_BIT_CAN_DNLOAD |
+                                    APP_USBD_NRF_DFU_TRIGGER_BIT_WILL_DETACH); // bmAttribute
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(LSB_16(p_dfu->specific.inst.detach_timeout)); // wDetachTimeOut LSB
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(MSB_16(p_dfu->specific.inst.detach_timeout)); // wDetachTimeOut MSB
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(LSB_16(p_dfu->specific.inst.transfer_size)); // wTransferSize LSB
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(MSB_16(p_dfu->specific.inst.transfer_size)); // wTransferSize MSB
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(LSB_16(p_dfu->specific.inst.bcd_dfu)); // bcdDFUVersion LSB
+    APP_USBD_CLASS_DESCRIPTOR_WRITE(MSB_16(p_dfu->specific.inst.bcd_dfu)); // bcdDFUVersion MSB
+
+    APP_USBD_CLASS_DESCRIPTOR_END();
+}
+
+const app_usbd_class_methods_t app_usbd_nrf_dfu_trigger_class_methods = {
+        .event_handler    = nrf_dfu_trigger_event_handler,
+        .feed_descriptors = nrf_dfu_trigger_feed_descriptors,
+};
+
+#endif /* NRF_MODULE_ENABLED(APP_USBD_NRF_DFU_TRIGGER) */

--- a/third_party/NordicSemiconductor/libraries/usb/app_usbd_nrf_dfu_trigger.h
+++ b/third_party/NordicSemiconductor/libraries/usb/app_usbd_nrf_dfu_trigger.h
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef APP_USBD_NRF_DFU_TRIGGER_H__
+#define APP_USBD_NRF_DFU_TRIGGER_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "nrf_drv_usbd.h"
+#include "app_usbd_class_base.h"
+#include "app_usbd.h"
+#include "app_usbd_core.h"
+#include "app_usbd_descriptor.h"
+
+#include "app_usbd_nrf_dfu_trigger_types.h"
+#include "app_usbd_nrf_dfu_trigger_internal.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup app_usbd_nrf_dfu_trigger USB Nordic DFU Trigger class
+ * @ingroup app_usbd
+ *
+ * @brief @tagAPI52840 Module with types, definitions,
+ *                     and API used by the USB Nordic DFU Trigger class.
+ *
+ * @{
+ */
+
+#ifdef DOXYGEN
+/**
+ * @brief Nordic DFU Trigger class instance type.
+ *
+ * @ref APP_USBD_CLASS_TYPEDEF
+ */
+typedef struct { } app_usbd_nrf_dfu_trigger_t;
+#else
+/*lint -save -e10 -e26 -e123 -e505 */
+APP_USBD_CLASS_NO_EP_TYPEDEF(app_usbd_nrf_dfu_trigger,                                             \
+                             APP_USBD_NRF_DFU_TRIGGER_CONFIG(0),                                   \
+                             APP_USBD_NRF_DFU_TRIGGER_INSTANCE_SPECIFIC_DEC,                       \
+                             APP_USBD_NRF_DFU_TRIGGER_DATA_SPECIFIC_DEC                            \
+);
+#endif
+
+/*lint -restore*/
+
+
+/*lint -save -e407 */
+
+/**
+ * @brief Events passed to user event handler.
+ *
+ * @note Example prototype of user event handler:
+ *
+ * void dfu_user_ev_handler(app_usbd_class_inst_t const *         p_inst,
+ *                          app_usbd_nrf_dfu_trigger_user_event_t event);
+ */
+typedef enum app_usbd_nrf_dfu_trigger_user_event_e {
+    APP_USBD_NRF_DFU_TRIGGER_USER_EVT_DETACH,
+} app_usbd_nrf_dfu_trigger_user_event_t;
+
+/*lint -restore*/
+
+/**
+ * @brief Global definition of app_usbd_nrf_dfu_trigger_t class.
+ *
+ * @param instance_name         Name of global instance.
+ * @param interface_number      Unique interface number.
+ * @param p_nordic_dfu          Pointer to @ref app_usbd_nrf_dfu_trigger_nordic_info_t structure.
+ * @param sem_ver_str           Semantic version string.
+ * @param user_ev_handler       User event handler (optional).
+ *
+ * @note This macro is just simplified version of @ref APP_USBD_NRF_DFU_TRIGGER_GLOBAL_DEF_INTERNAL
+ *
+ */
+/*lint -save -emacro(26 64 123 505 651, APP_USBD_NRF_DFU_TRIGGER_GLOBAL_DEF)*/
+#define APP_USBD_NRF_DFU_TRIGGER_GLOBAL_DEF(instance_name,                                         \
+                                            interface_number,                                      \
+                                            p_nordic_dfu,                                          \
+                                            sem_ver_str,                                           \
+                                            user_ev_handler)                                       \
+        APP_USBD_NRF_DFU_TRIGGER_GLOBAL_DEF_INTERNAL(instance_name,                                \
+                                                     interface_number,                             \
+                                                     0,                                            \
+                                                     0,                                            \
+                                                     p_nordic_dfu,                                 \
+                                                     sem_ver_str,                                  \
+                                                     user_ev_handler)
+/*lint -restore*/
+
+/**
+ * @brief Helper function to get class instance from Nordic DFU Trigger.
+ *
+ * @param[in] p_dfu Nordic DFU Trigger instance
+ *                  (declared by @ref APP_USBD_NRF_DFU_TRIGGER_GLOBAL_DEF)
+ *
+ * @return Base class instance
+ */
+static inline app_usbd_class_inst_t const *
+app_usbd_nrf_dfu_trigger_class_inst_get(app_usbd_nrf_dfu_trigger_t const * p_dfu)
+{
+    return &p_dfu->base;
+}
+
+/**
+ * @brief Helper function to get DFU from base class instance.
+ *
+ * @param[in] p_inst Base class instance.
+ *
+ * @return DFU class handle.
+ */
+static inline app_usbd_nrf_dfu_trigger_t const *
+app_usbd_nrf_dfu_trigger_class_get( app_usbd_class_inst_t const * p_inst)
+{
+    return (app_usbd_nrf_dfu_trigger_t const *)p_inst;
+}
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* APP_USBD_NRF_DFU_TRIGGER_H__ */

--- a/third_party/NordicSemiconductor/libraries/usb/app_usbd_nrf_dfu_trigger_internal.h
+++ b/third_party/NordicSemiconductor/libraries/usb/app_usbd_nrf_dfu_trigger_internal.h
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef APP_USBD_NRF_DFU_TRIGGER_INTERNAL_H__
+#define APP_USBD_NRF_DFU_TRIGGER_INTERNAL_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup app_usbd_nrf_dfu_trigger_internals USB Nordic DFU Trigger internals
+ * @ingroup app_usbd_nrf_dfu_trigger
+ *
+ * @brief @tagAPI52840 Internals of the USB Nordic DFU Trigger class.
+ * @{
+ */
+
+/**
+ * @brief Forward declaration of Nordic DFU Trigger Class type.
+ *
+ */
+APP_USBD_CLASS_FORWARD(app_usbd_nrf_dfu_trigger);
+
+/*lint -save -e165*/
+/**
+ * @brief Forward declaration of @ref app_usbd_nrf_dfu_trigger_user_event_e
+ *
+ */
+enum app_usbd_nrf_dfu_trigger_user_event_e;
+
+/*lint -restore*/
+
+/**
+ * @brief User event handler.
+ *
+ * @param[in] p_inst    Class instance.
+ * @param[in] event     User event.
+ *
+ * */
+typedef void (*app_usbd_nrf_dfu_trigger_user_ev_handler_t)(
+        app_usbd_class_inst_t const *              p_inst,
+        enum app_usbd_nrf_dfu_trigger_user_event_e event);
+
+/**
+ * @brief Nordic DFU Trigger part of class instance data.
+ */
+typedef struct {
+    size_t const    sem_ver_size;   //!< Semantic string size
+    uint16_t const  detach_timeout; //!< Detach timeout in ms - for compatibility with DFU spec.
+    uint16_t const  transfer_size;  //!< Transfer size - for compatibility with DFU spec.
+    uint16_t const  bcd_dfu;        //!< DFU spec version.
+    uint8_t const * p_sem_ver;      //!< Pointer to semantic version string
+
+    app_usbd_nrf_dfu_trigger_nordic_info_t const * p_dfu_info; //!< Pointer to Nordic DFU Info
+
+    app_usbd_nrf_dfu_trigger_user_ev_handler_t user_ev_handler; //!< User event handler
+} app_usbd_nrf_dfu_trigger_inst_t;
+
+/**
+ * @brief Internal module state.
+ *
+ * @note For future compatibility with DFU class.
+ */
+typedef enum {
+    APP_USBD_NRF_DFU_TRIGGER_STATE_IDLE,          /**< Internal module state IDLE          */
+    APP_USBD_NRF_DFU_TRIGGER_STATE_DETACH,        /**< Internal module state DETACH        */
+} app_usbd_nrf_dfu_trigger_state_t;
+
+/**
+ * @brief Nordic DFU Trigger context.
+ *
+ * */
+typedef struct {
+    app_usbd_nrf_dfu_trigger_state_t state; //!< Internal module state
+} app_usbd_nrf_dfu_trigger_ctx_t;
+
+
+/**
+ * @brief Nordic DFU Trigger configuration macro.
+ *
+ * Used by @ref APP_USBD_NRF_DFU_TRIGGER_GLOBAL_DEF
+ *
+ * @param iface Interface number.
+ * */
+#define APP_USBD_NRF_DFU_TRIGGER_CONFIG(iface) (iface)
+
+
+/**
+ * @brief Specific class constant data for Nordic DFU Trigger.
+ *
+ * @ref app_usbd_nrf_dfu_trigger_inst_t
+ */
+#define APP_USBD_NRF_DFU_TRIGGER_INSTANCE_SPECIFIC_DEC app_usbd_nrf_dfu_trigger_inst_t inst;
+
+
+/**
+ * @brief Configures Nordic DFU Trigger instance.
+ *
+ * @param user_event_handler    User event handler.
+ * @param p_nordic_dfu          Pointer to @ref app_usbd_nrf_dfu_trigger_nordic_info_t structure.
+ * @param sem_ver_str           Semantic version string.
+ * @param timeout               Detach timeout in ms - left for compatibility with USB DFU spec.
+ * @param size                  Transfer size in bytes - left for compatibility with USB DFU spec.
+ * @param bcd                   USB DFU specification version.
+ */
+#define APP_USBD_NRF_DFU_TRIGGER_INST_CONFIG(user_event_handler,                                   \
+                                             p_nordic_dfu,                                         \
+                                             sem_ver_str,                                          \
+                                             timeout,                                              \
+                                             size,                                                 \
+                                             bcd)                                                  \
+    .inst = {                                                                                      \
+         .user_ev_handler   = user_event_handler,                                                  \
+         .p_dfu_info        = p_nordic_dfu,                                                        \
+         .p_sem_ver         = sem_ver_str,                                                         \
+         .sem_ver_size      = sizeof(sem_ver_str),                                                 \
+         .transfer_size     = size,                                                                \
+         .detach_timeout    = timeout,                                                             \
+         .bcd_dfu           = bcd,                                                                 \
+    }
+
+/**
+ * @brief Specific class data for Nordic DFU Trigger.
+ *
+ * @ref app_usbd_nrf_dfu_trigger_ctx_t
+ * */
+#define APP_USBD_NRF_DFU_TRIGGER_DATA_SPECIFIC_DEC app_usbd_nrf_dfu_trigger_ctx_t ctx;
+
+
+/**
+ * @brief Public Nordic DFU Trigger class interface.
+ */
+extern const app_usbd_class_methods_t app_usbd_nrf_dfu_trigger_class_methods;
+
+/**
+ * @brief Global definition of Nordic DFU Trigger instance.
+ */
+#define APP_USBD_NRF_DFU_TRIGGER_GLOBAL_DEF_INTERNAL(instance_name,                                \
+                                                     interface_number,                             \
+                                                     detach_timeout,                               \
+                                                     transfer_size,                                \
+                                                     p_nordic_dfu,                                 \
+                                                     sem_ver_str,                                  \
+                                                     user_ev_handler)                              \
+    APP_USBD_CLASS_INST_NO_EP_GLOBAL_DEF(                                                          \
+        instance_name,                                                                             \
+        app_usbd_nrf_dfu_trigger,                                                                  \
+        &app_usbd_nrf_dfu_trigger_class_methods,                                                   \
+        APP_USBD_NRF_DFU_TRIGGER_CONFIG((interface_number)),                                       \
+        (APP_USBD_NRF_DFU_TRIGGER_INST_CONFIG(user_ev_handler,                                     \
+                                              p_nordic_dfu,                                        \
+                                              sem_ver_str,                                         \
+                                              detach_timeout,                                      \
+                                              transfer_size,                                       \
+                                              0x0110))                                             \
+    )
+
+
+/** @} */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* APP_USBD_NRF_DFU_TRIGGER_INTERNAL_H__ */

--- a/third_party/NordicSemiconductor/libraries/usb/app_usbd_nrf_dfu_trigger_types.h
+++ b/third_party/NordicSemiconductor/libraries/usb/app_usbd_nrf_dfu_trigger_types.h
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef APP_USBD_NRF_DFU_TRIGGER_TYPES_H__
+#define APP_USBD_NRF_DFU_TRIGGER_TYPES_H__
+
+#include "app_util.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup app_usbd_nrf_dfu_trigger_types USB Nordic DFU Trigger types
+ * @ingroup app_usbd_nrf_dfu_trigger
+ *
+ * @brief @tagAPI52840 Types used in the USB Nordic DFU Trigger class.
+ * @{
+ */
+
+/** @brief Nordic DFU Trigger class definition in interface descriptor.
+ *
+ *  @ref app_usbd_descriptor_iface_t::bInterfaceClass
+ * */
+#define APP_USBD_NRF_DFU_TRIGGER_CLASS 0xFF
+
+/**
+ * @brief Nordic DFU Trigger subclass possible value.
+ */
+typedef enum {
+    APP_USBD_NRF_DFU_TRIGGER_SUBCLASS          = 0x01,    /**< Device Firmware Upgrade Code */
+} app_usbd_nrf_dfu_trigger_subclass_t;
+
+/**
+ * @brief Nordic DFU Trigger protocol possible value.
+ *
+ * @note Only Run-time protocol is implemented, as DFU mode is covered by Nordic DFU.
+ */
+typedef enum {
+    APP_USBD_NRF_DFU_TRIGGER_PROTOCOL_RUNTIME  = 0x01,    /**< Run-time Protocol */
+} app_usbd_nrf_dfu_trigger_protocol_t;
+
+/**
+ * @brief Nordic DFU Trigger USB requests @ref nrf_drv_usbd_setup_t::bmRequestType
+ *
+ * @note Requests are limited only to @ref APP_USBD_NRF_DFU_TRIGGER_PROTOCOL_RUNTIME protocol type.
+ */
+typedef enum {
+    APP_USBD_NRF_DFU_TRIGGER_REQ_DETACH      = 0x00, /**< Switch to DFU mode */
+    APP_USBD_NRF_DFU_TRIGGER_REQ_NORDIC_INFO = 0x07, /**< Request Nordic DFU information */
+    APP_USBD_NRF_DFU_TRIGGER_REQ_SEM_VER     = 0x08, /**< Request semantic version information */
+} app_usbd_nrf_dfu_trigger_req_t;
+
+/**
+ * @brief Nordic DFU Trigger Functional Descriptor types.
+ */
+typedef enum {
+    APP_USBD_NRF_DFU_TRIGGER_CS_FUNCTIONAL = 0x21, /**< Functional descriptor type.*/
+} app_usbd_nrf_dfu_trigger_func_type_t;
+
+/**
+ * @brief Nordic DFU Trigger functional descriptor bmAttributes bit masks.
+ *
+ * @note For future compatibility with DFU class.
+ */
+typedef enum {
+    APP_USBD_NRF_DFU_TRIGGER_BIT_CAN_DNLOAD    = 0x01, /**< bitCanDnload */
+    APP_USBD_NRF_DFU_TRIGGER_BIT_CAB_UPLOAD    = 0x02, /**< bitCanUpload */
+    APP_USBD_NRF_DFU_TRIGGER_BIT_MANI_TOLERANT = 0x04, /**< bitManifestationTolerant */
+    APP_USBD_NRF_DFU_TRIGGER_BIT_WILL_DETACH   = 0x08, /**< bitWillDetach */
+} app_usbd_nrf_dfu_trigger_bm_attributes_t;
+
+#pragma pack(push, 1)
+
+/**
+ * @brief Nordic DFU Trigger Functional Descriptor.
+ */
+typedef struct {
+    uint8_t  bFunctionLength; //!< Size of this descriptor in bytes.
+    uint8_t  bDescriptorType; //!< Descriptor type.
+    uint8_t  bmAttributes;    //!< Attributes bits.
+    uint16_t wDetachTimeOut;  //!< Device detach timeout - left for compatibility with USB DFU spec.
+    uint16_t wTransferSize;   //!< Transfer size - left for compatibility with USB DFU spec.
+    uint16_t bcdDFUVersion;   //!< DFU version.
+} app_usbd_nrf_dfu_trigger_desc_func_t;
+
+/**
+ * @brief Nordic custom DFU information.
+ */
+typedef struct {
+    uint32_t wAddress;          //!< Firmware start address.
+    uint32_t wFirmwareSize;     //!< Firmware size.
+    uint16_t wVersionMajor;     //!< Firmware version major.
+    uint16_t wVersionMinor;     //!< Firmware version minor.
+    uint32_t wFirmwareID;       //!< Firmware ID.
+    uint32_t wFlashSize;        //!< Flash size.
+    uint32_t wFlashPageSize;    //!< Flash page size.
+} app_usbd_nrf_dfu_trigger_nordic_info_t;
+
+#pragma pack(pop)
+
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* APP_USBD_NRF_DFU_TRIGGER_TYPES_H__ */

--- a/third_party/NordicSemiconductor/libraries/usb/nrf_dfu_trigger_usb.c
+++ b/third_party/NordicSemiconductor/libraries/usb/nrf_dfu_trigger_usb.c
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+ 
+#include "nordic_common.h"
+
+#if NRF_MODULE_ENABLED(APP_USBD_NRF_DFU_TRIGGER)
+#include "nrf_dfu_trigger_usb.h"
+#include "app_usbd.h"
+#include "app_usbd_nrf_dfu_trigger.h"
+#include "nrf_drv_clock.h"
+#include "nrf_log_ctrl.h"
+#include "nrf_gpio.h"
+#include "app_util.h"
+#include "app_usbd_serial_num.h"
+#define NRF_LOG_MODULE_NAME nrf_dfu_trigger_usb
+#include "nrf_log.h"
+NRF_LOG_MODULE_REGISTER();
+
+
+#ifndef BSP_SELF_PINRESET_PIN
+#error "This module is intended to be used with boards that have the GP pin shortened with the RESET pin."
+#endif
+
+#define DFU_FLASH_PAGE_SIZE  (NRF_FICR->CODEPAGESIZE)
+#define DFU_FLASH_PAGE_COUNT (NRF_FICR->CODESIZE)
+
+// Semantic versioning string.
+#define VERSION_STRING STRINGIFY(APP_VERSION_MAJOR) "." STRINGIFY(APP_VERSION_MINOR) "." STRINGIFY(APP_VERSION_PATCH) APP_VERSION_PRERELEASE APP_VERSION_METADATA
+
+static uint8_t                                m_version_string[] = APP_NAME " " VERSION_STRING; ///< Human-readable version string.
+static app_usbd_nrf_dfu_trigger_nordic_info_t m_dfu_info;                                       ///< Struct with various information about the current firmware.
+
+static void dfu_trigger_evt_handler(app_usbd_class_inst_t        const *  p_inst,
+                                    app_usbd_nrf_dfu_trigger_user_event_t event)
+{
+    UNUSED_PARAMETER(p_inst);
+
+    switch (event)
+    {
+        case APP_USBD_NRF_DFU_TRIGGER_USER_EVT_DETACH:
+            NRF_LOG_INFO("DFU Detach request received. Triggering a pin reset.");
+            NRF_LOG_FINAL_FLUSH();
+            nrf_gpio_cfg_output(BSP_SELF_PINRESET_PIN);
+            nrf_gpio_pin_clear(BSP_SELF_PINRESET_PIN);
+            break;
+        default:
+            break;
+    }
+}
+
+
+APP_USBD_NRF_DFU_TRIGGER_GLOBAL_DEF(m_app_dfu,
+                                    NRF_DFU_TRIGGER_USB_INTERFACE_NUM,
+                                    &m_dfu_info,
+                                    m_version_string,
+                                    dfu_trigger_evt_handler);
+
+
+static void usbd_user_evt_handler(app_usbd_event_type_t event)
+{
+    switch (event)
+    {
+        case APP_USBD_EVT_DRV_SUSPEND:
+            break;
+        case APP_USBD_EVT_DRV_RESUME:
+            break;
+        case APP_USBD_EVT_STARTED:
+            break;
+        case APP_USBD_EVT_STOPPED:
+            app_usbd_disable();
+            break;
+        case APP_USBD_EVT_POWER_DETECTED:
+            NRF_LOG_INFO("USB power detected");
+
+            if (!nrf_drv_usbd_is_enabled())
+            {
+                app_usbd_enable();
+            }
+            break;
+        case APP_USBD_EVT_POWER_REMOVED:
+            NRF_LOG_INFO("USB power removed");
+            app_usbd_stop();
+            break;
+        case APP_USBD_EVT_POWER_READY:
+            NRF_LOG_INFO("USB ready");
+            app_usbd_start();
+            break;
+        default:
+            break;
+    }
+}
+
+
+static void strings_create(void)
+{
+    uint8_t prev_char = 'a'; // Arbitrary valid char, not '-'.
+
+    // Remove characters that are not supported in semantic version strings.
+    for (size_t i = strlen(APP_NAME) + 1; i < strlen((char*)m_version_string); i++)
+    {
+        if (((m_version_string[i] >= 'a') && (m_version_string[i] <= 'z'))
+         || ((m_version_string[i] >= 'A') && (m_version_string[i] <= 'Z'))
+         || ((m_version_string[i] >= '0') && (m_version_string[i] <= '9'))
+         ||  (m_version_string[i] == '+')
+         ||  (m_version_string[i] == '.')
+         ||  (m_version_string[i] == '-'))
+        {
+            // Valid semantic version character.
+        }
+        else if (prev_char == '-')
+        {
+            m_version_string[i] = '0';
+        }
+        else
+        {
+            m_version_string[i] = '-';
+        }
+
+        prev_char = m_version_string[i];
+    }
+
+#if !NRF_DFU_TRIGGER_USB_USB_SHARED
+    app_usbd_serial_num_generate();
+#endif
+}
+
+#if !(APP_USBD_CONFIG_EVENT_QUEUE_ENABLE)
+static void usbd_evt_handler(app_usbd_internal_evt_t const * const p_event)
+{
+    app_usbd_event_execute(p_event);
+}
+#endif
+
+ret_code_t nrf_dfu_trigger_usb_init(void)
+{
+    ret_code_t  ret;
+    static bool initialized = false;
+
+    if (initialized)
+    {
+        return NRF_SUCCESS;
+    }
+
+    m_dfu_info.wAddress       = CODE_START;
+    m_dfu_info.wFirmwareSize  = CODE_SIZE;
+    m_dfu_info.wVersionMajor  = APP_VERSION_MAJOR;
+    m_dfu_info.wVersionMinor  = APP_VERSION_MINOR;
+    m_dfu_info.wFirmwareID    = APP_ID;
+    m_dfu_info.wFlashPageSize = DFU_FLASH_PAGE_SIZE;
+    m_dfu_info.wFlashSize     = m_dfu_info.wFlashPageSize * DFU_FLASH_PAGE_COUNT;
+
+    strings_create();
+
+    if (!NRF_DFU_TRIGGER_USB_USB_SHARED)
+    {
+        static const app_usbd_config_t usbd_config = {
+
+#if !(APP_USBD_CONFIG_EVENT_QUEUE_ENABLE)
+            .ev_handler = usbd_evt_handler,
+#endif
+            .ev_state_proc = usbd_user_evt_handler
+        };
+
+        ret = nrf_drv_clock_init();
+        if ((ret != NRF_SUCCESS) && (ret != NRF_ERROR_MODULE_ALREADY_INITIALIZED))
+        {
+            return ret;
+        }
+
+        ret = app_usbd_init(&usbd_config);
+        if (ret != NRF_SUCCESS)
+        {
+            return ret;
+        }
+    }
+
+    app_usbd_class_inst_t const * class_dfu = app_usbd_nrf_dfu_trigger_class_inst_get(&m_app_dfu);
+    ret = app_usbd_class_append(class_dfu);
+
+    if (!NRF_DFU_TRIGGER_USB_USB_SHARED)
+    {
+        if (USBD_POWER_DETECTION)
+        {
+            ret = app_usbd_power_events_enable();
+            APP_ERROR_CHECK(ret);
+        }
+        else
+        {
+            NRF_LOG_INFO("No USB power detection enabled\r\nStarting USB now");
+
+            app_usbd_enable();
+            app_usbd_start();
+        }
+    }
+
+    if (ret == NRF_SUCCESS)
+    {
+        initialized = true;
+    }
+
+    return ret;
+}
+
+#endif /* NRF_MODULE_ENABLED(APP_USBD_NRF_DFU_TRIGGER) */
+

--- a/third_party/NordicSemiconductor/libraries/usb/nrf_dfu_trigger_usb.h
+++ b/third_party/NordicSemiconductor/libraries/usb/nrf_dfu_trigger_usb.h
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef NRF_DFU_TRIGGER_USB_H
+#define NRF_DFU_TRIGGER_USB_H
+
+#include "sdk_errors.h"
+
+/**
+ * @defgroup nrf_dfu_trigger_usb USB DFU trigger library
+ * @ingroup app_common
+ *
+ * @brief @tagAPI52840 USB DFU trigger library is used to enter the bootloader and read the firmware version.
+ *
+ * @details See @ref lib_dfu_trigger_usb for additional documentation.
+ * @{
+ */
+
+/**
+ * @brief Function for initializing the USB DFU trigger library.
+ *
+ * @note  If the USB is also used for other purposes, then this function must be called after USB is
+ *        initialized but before it is enabled. In this case, the configuration flag @ref
+ *        NRF_DFU_TRIGGER_USB_USB_SHARED must be set to 1.
+ *
+ * @note  Calling this again after the first success has no effect and returns @ref NRF_SUCCESS.
+ *
+ * @note  If @ref APP_USBD_CONFIG_EVENT_QUEUE_ENABLE is on (1), USB events must be handled manually.
+ *        See @ref app_usbd_event_queue_process.
+ *
+ * @retval NRF_SUCCESS  On successful initialization.
+ * @return An error code on failure, for example if called at a wrong time.
+ */
+ret_code_t nrf_dfu_trigger_usb_init(void);
+
+/** @} */
+
+#endif //NRF_DFU_TRIGGER_USB_H


### PR DESCRIPTION
This PR adds support for the USB DFU trigger used to enter the bootloader from the application in order to flash it on compatible platforms (requires a device with a GPIO connected to the RESET pin).
PCA10059 is an example of the compatible hardware.
The feature has been requested in #3271.

To enable the support, compile the OpenThread with the following flags:
openthread$ make -j -f examples/Makefile-nrf52840 USB=1 BOOTLOADER=1

It has been tested with the latest nrfconnect 2.6.1 with programmer 1.0.0 app.
