### PR TITLE
[radio-spinel] determine presence of Ack from spinel TxDone frame

### DIFF
--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -600,7 +600,6 @@ private:
     char         mVersion[kVersionStringSize];
 
     otRadioState mState;
-    bool         mIsAckRequested : 1;    ///< Ack requested.
     bool         mIsPromiscuous : 1;     ///< Promiscuous mode.
     bool         mIsReady : 1;           ///< NCP ready.
     bool         mSupportsLogStream : 1; ///< RCP supports `LOG_STREAM` property with OpenThread log meta-data format.


### PR DESCRIPTION
This commit changes `RadioSpinel` to determine if Ack is present
directly from the received spinel TxDone frame (i.e. check the
remaining unparsed length of spinel frame to determine if ack frame is
included by Radio Co-Processor (RCP)). This change helps simplify the
code by removing the requirement for `RadioSpinel` as the layer
between OpenThread core and RCP to parse the 15.4 frame.