### PR TITLE
[radio-spinel] always be ready to read from socket

### DIFF
--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -670,24 +670,16 @@ void RadioSpinel::UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, int &aMax
 {
     int sockFd = mHdlcInterface.GetSocket();
 
-    if ((mState != OT_RADIO_STATE_TRANSMIT || mTxState == kSent))
-    {
-        FD_SET(sockFd, &aReadFdSet);
+    FD_SET(sockFd, &aReadFdSet);
 
-        if (aMaxFd < sockFd)
-        {
-            aMaxFd = sockFd;
-        }
+    if (aMaxFd < sockFd)
+    {
+        aMaxFd = sockFd;
     }
 
     if (mState == OT_RADIO_STATE_TRANSMIT && mTxState == kIdle)
     {
         FD_SET(sockFd, &aWriteFdSet);
-
-        if (aMaxFd < sockFd)
-        {
-            aMaxFd = sockFd;
-        }
     }
 
     if (!mFrameQueue.IsEmpty() || (mState == OT_RADIO_STATE_TRANSMIT && mTxState == kDone))


### PR DESCRIPTION
This commit changes the logic in `RadioSpinel` such that the HDLC
socket is always added to read fd set in `UpdateFdSet()` replacing
the existing code where read was not allowed during an ongoing 15.4
frame transmission. Note that during a frame transmission, radio can
potentially receive a frame (e.g. during CSMA backoffs). Also other
spinel frames such as logs can be received during tx.