### PR TITLE
[thci] pass the channel mask as a comma separated channel string

### DIFF
--- a/tools/harness-thci/OpenThread_WpanCtl.py
+++ b/tools/harness-thci/OpenThread_WpanCtl.py
@@ -657,16 +657,16 @@ class OpenThread_WpanCtl(IThci):
             channelList: channel list (i.e. [21, 22, 23])
 
         Returns:
-            a string with range-like format (i.e. '21-23')
+            a comma separated channel string (i.e. '21, 22, 23')
         """
         chan_mask_range = ''
         if isinstance(channelList, list):
-            if len(channelList) == 1:
-                chan_mask_range = str(channelList[0])
-            elif len(channelList) > 1:
-                chan_mask_range = str(channelList[0]) + '-' + str(channelList[-1])
+            if len(channelList):
+                chan_mask_range = ",".join(str(chan) for chan in channelList)
+            else:
+                print 'empty list'
         else:
-            print 'not a list:', channelList
+            print 'not a valid channel list:', channelList
 
         return chan_mask_range
 
@@ -777,7 +777,7 @@ class OpenThread_WpanCtl(IThci):
                         print 'login success (serial)'
                         time.sleep(0.3)
                         self.deviceConnected = True
-                        self.handle.write('stty cols 128\n')
+                        self.handle.write('stty cols 256\n')
                         time.sleep(1)
                         break
                 if self.deviceConnected == False:
@@ -796,7 +796,7 @@ class OpenThread_WpanCtl(IThci):
                 self.handle.connect(self.dutIpv4, port=self.dutPort, username=WPAN_CARRIER_USER, password=WPAN_CARRIER_PASSWD)
                 print 'login success (ssh)'
                 self.deviceConnected = True
-                self.handle.exec_command('stty cols 128\n')
+                self.handle.exec_command('stty cols 256\n')
                 time.sleep(1)
                 self._is_net = True
             except Exception as e:


### PR DESCRIPTION
Test log of certification test case 9.2.14:

COM39 call MGMT_PANID_QUERY
sudo wpanctl -I wpan0 commissioner pan-id-query 0xface 11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26 fd00:db8:0:0:46e7:955e:c25f:c2af
sending [sudo wpanctl -I wpan0 commissioner pan-id-query 0xface 11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26 fd00:db8:0:0:46e7:955e:c25f:c2af]
[COM39] Expecting [sudo wpanctl -I wpan0 commissioner pan-id-query 0xface 11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26 fd00:db8:0:0:46e7:955e:c25f:c2af]
[COM39] Got line [sudo wpanctl -I wpan0 commissioner pan-id-query 0xface 11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26 fd00:db8:0:0:46e7:955e:c25f:c2af]
[COM39] Expected [sudo wpanctl -I wpan0 commissioner pan-id-query 0xface 11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26 fd00:db8:0:0:46e7:955e:c25f:c2af]
read line: Successfully sent PAN ID Query, pan-id:0xface, channel-mask:0x7fff800, dest:"fd00:db8::46e7:955e:c25f:c2af"
read line: Use property "Commissioner:PanIdConflictResult" to get received PAN ID Conflict results
read line: pi@raspberrypi:~$
