### PR TITLE
[android] fix untracked pid

### DIFF
--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -121,9 +121,14 @@ exit:
     return error;
 }
 
+HdlcInterface::~HdlcInterface(void)
+{
+    Deinit();
+}
+
 void HdlcInterface::Deinit(void)
 {
-    assert(mSockFd != -1);
+    VerifyOrExit(mSockFd != -1);
 
     VerifyOrExit(0 == close(mSockFd), perror("close NCP"));
     VerifyOrExit(-1 != wait(NULL), perror("wait NCP"));

--- a/src/posix/platform/hdlc_interface.hpp
+++ b/src/posix/platform/hdlc_interface.hpp
@@ -80,6 +80,12 @@ public:
     explicit HdlcInterface(Callbacks &aCallbacks);
 
     /**
+     * This destructor deinitializes the object.
+     *
+     */
+    ~HdlcInterface(void);
+
+    /**
      * This method initializes the interface to the Radio Co-processor (RCP)
      *
      * @note This method should be called before reading and sending frames to the interface.


### PR DESCRIPTION
`HdlcInterface` doesn't wait for spi-hdlc-adapter exit when exit() is called. This PR adds destructor to wait such that there will not be untracked process warnings in android.
