### PR TITLE
Simplify Coap (using context-tracking Timer and Tasklet)

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -48,10 +48,10 @@
 namespace ot {
 namespace Coap {
 
-CoapBase::CoapBase(Instance &aInstance)
+Coap::Coap(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mSocket(aInstance.GetThreadNetif().GetIp6().GetUdp())
-    , mRetransmissionTimer(aInstance, &CoapBase::HandleRetransmissionTimer, this)
+    , mRetransmissionTimer(aInstance, &Coap::HandleRetransmissionTimer, this)
     , mResources(NULL)
     , mContext(NULL)
     , mInterceptor(NULL)
@@ -62,20 +62,20 @@ CoapBase::CoapBase(Instance &aInstance)
     mMessageId = Random::GetUint16();
 }
 
-otError CoapBase::Start(uint16_t aPort)
+otError Coap::Start(uint16_t aPort)
 {
     otError       error;
     Ip6::SockAddr sockaddr;
     sockaddr.mPort = aPort;
 
-    SuccessOrExit(error = mSocket.Open(&CoapBase::HandleUdpReceive, this));
+    SuccessOrExit(error = mSocket.Open(&Coap::HandleUdpReceive, this));
     SuccessOrExit(error = mSocket.Bind(sockaddr));
 
 exit:
     return error;
 }
 
-otError CoapBase::Stop(void)
+otError Coap::Stop(void)
 {
     Message *    message = mPendingRequests.GetHead();
     Message *    messageToRemove;
@@ -96,7 +96,7 @@ otError CoapBase::Stop(void)
     return mSocket.Close();
 }
 
-otError CoapBase::AddResource(Resource &aResource)
+otError Coap::AddResource(Resource &aResource)
 {
     otError error = OT_ERROR_NONE;
 
@@ -112,7 +112,7 @@ exit:
     return error;
 }
 
-void CoapBase::RemoveResource(Resource &aResource)
+void Coap::RemoveResource(Resource &aResource)
 {
     if (mResources == &aResource)
     {
@@ -134,13 +134,13 @@ exit:
     aResource.mNext = NULL;
 }
 
-void CoapBase::SetDefaultHandler(otCoapRequestHandler aHandler, void *aContext)
+void Coap::SetDefaultHandler(otCoapRequestHandler aHandler, void *aContext)
 {
     mDefaultHandler        = aHandler;
     mDefaultHandlerContext = aContext;
 }
 
-Message *CoapBase::NewMessage(const Header &aHeader, const otMessageSettings *aSettings)
+Message *Coap::NewMessage(const Header &aHeader, const otMessageSettings *aSettings)
 {
     Message *message = NULL;
 
@@ -155,10 +155,10 @@ exit:
     return message;
 }
 
-otError CoapBase::SendMessage(Message &               aMessage,
-                              const Ip6::MessageInfo &aMessageInfo,
-                              otCoapResponseHandler   aHandler,
-                              void *                  aContext)
+otError Coap::SendMessage(Message &               aMessage,
+                          const Ip6::MessageInfo &aMessageInfo,
+                          otCoapResponseHandler   aHandler,
+                          void *                  aContext)
 {
     otError      error;
     Header       header;
@@ -212,14 +212,12 @@ exit:
     return error;
 }
 
-otError CoapBase::Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError Coap::Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     return mSocket.SendTo(aMessage, aMessageInfo);
 }
 
-otError CoapBase::SendEmptyMessage(Header::Type            aType,
-                                   const Header &          aRequestHeader,
-                                   const Ip6::MessageInfo &aMessageInfo)
+otError Coap::SendEmptyMessage(Header::Type aType, const Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo)
 {
     otError  error = OT_ERROR_NONE;
     Header   responseHeader;
@@ -244,9 +242,7 @@ exit:
     return error;
 }
 
-otError CoapBase::SendHeaderResponse(Header::Code            aCode,
-                                     const Header &          aRequestHeader,
-                                     const Ip6::MessageInfo &aMessageInfo)
+otError Coap::SendHeaderResponse(Header::Code aCode, const Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo)
 {
     otError      error = OT_ERROR_NONE;
     Header       responseHeader;
@@ -290,12 +286,12 @@ exit:
     return error;
 }
 
-void CoapBase::HandleRetransmissionTimer(Timer &aTimer)
+void Coap::HandleRetransmissionTimer(Timer &aTimer)
 {
-    static_cast<CoapBase *>(static_cast<TimerMilliContext &>(aTimer).GetContext())->HandleRetransmissionTimer();
+    static_cast<Coap *>(static_cast<TimerMilliContext &>(aTimer).GetContext())->HandleRetransmissionTimer();
 }
 
-void CoapBase::HandleRetransmissionTimer(void)
+void Coap::HandleRetransmissionTimer(void)
 {
     uint32_t         now       = TimerMilli::GetNow();
     uint32_t         nextDelta = 0xffffffff;
@@ -357,12 +353,12 @@ void CoapBase::HandleRetransmissionTimer(void)
     }
 }
 
-void CoapBase::FinalizeCoapTransaction(Message &               aRequest,
-                                       const CoapMetadata &    aCoapMetadata,
-                                       Header *                aResponseHeader,
-                                       Message *               aResponse,
-                                       const Ip6::MessageInfo *aMessageInfo,
-                                       otError                 aResult)
+void Coap::FinalizeCoapTransaction(Message &               aRequest,
+                                   const CoapMetadata &    aCoapMetadata,
+                                   Header *                aResponseHeader,
+                                   Message *               aResponse,
+                                   const Ip6::MessageInfo *aMessageInfo,
+                                   otError                 aResult)
 {
     DequeueMessage(aRequest);
 
@@ -373,7 +369,7 @@ void CoapBase::FinalizeCoapTransaction(Message &               aRequest,
     }
 }
 
-otError CoapBase::AbortTransaction(otCoapResponseHandler aHandler, void *aContext)
+otError Coap::AbortTransaction(otCoapResponseHandler aHandler, void *aContext)
 {
     otError      error = OT_ERROR_NOT_FOUND;
     Message *    message;
@@ -395,9 +391,7 @@ otError CoapBase::AbortTransaction(otCoapResponseHandler aHandler, void *aContex
     return error;
 }
 
-Message *CoapBase::CopyAndEnqueueMessage(const Message &     aMessage,
-                                         uint16_t            aCopyLength,
-                                         const CoapMetadata &aCoapMetadata)
+Message *Coap::CopyAndEnqueueMessage(const Message &aMessage, uint16_t aCopyLength, const CoapMetadata &aCoapMetadata)
 {
     otError  error       = OT_ERROR_NONE;
     Message *messageCopy = NULL;
@@ -439,7 +433,7 @@ exit:
     return messageCopy;
 }
 
-void CoapBase::DequeueMessage(Message &aMessage)
+void Coap::DequeueMessage(Message &aMessage)
 {
     mPendingRequests.Dequeue(aMessage);
 
@@ -456,7 +450,7 @@ void CoapBase::DequeueMessage(Message &aMessage)
     // the timer would just shoot earlier and then it'd be setup again.
 }
 
-otError CoapBase::SendCopy(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError Coap::SendCopy(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     otError  error;
     Message *messageCopy = NULL;
@@ -478,10 +472,10 @@ exit:
     return error;
 }
 
-Message *CoapBase::FindRelatedRequest(const Header &          aResponseHeader,
-                                      const Ip6::MessageInfo &aMessageInfo,
-                                      Header &                aRequestHeader,
-                                      CoapMetadata &          aCoapMetadata)
+Message *Coap::FindRelatedRequest(const Header &          aResponseHeader,
+                                  const Ip6::MessageInfo &aMessageInfo,
+                                  Header &                aRequestHeader,
+                                  CoapMetadata &          aCoapMetadata)
 {
     Message *message = mPendingRequests.GetHead();
 
@@ -527,13 +521,13 @@ exit:
     return message;
 }
 
-void CoapBase::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
+void Coap::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<CoapBase *>(aContext)->Receive(*static_cast<Message *>(aMessage),
-                                               *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Coap *>(aContext)->Receive(*static_cast<Message *>(aMessage),
+                                           *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
-void CoapBase::Receive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Coap::Receive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     otError error;
     Header  header;
@@ -557,7 +551,7 @@ exit:
     }
 }
 
-void CoapBase::ProcessReceivedResponse(Header &aResponseHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Coap::ProcessReceivedResponse(Header &aResponseHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     Header       requestHeader;
     CoapMetadata coapMetadata;
@@ -635,7 +629,7 @@ exit:
     }
 }
 
-void CoapBase::ProcessReceivedRequest(Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Coap::ProcessReceivedRequest(Header &aHeader, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     char                  uriPath[Resource::kMaxReceivedUriPath] = "";
     char *                curUriPath                             = uriPath;
@@ -930,20 +924,6 @@ uint32_t EnqueuedResponseHeader::GetRemainingTime(void) const
 
     return remainingTime >= 0 ? static_cast<uint32_t>(remainingTime) : 0;
 }
-
-Coap::Coap(Instance &aInstance)
-    : CoapBase(aInstance)
-{
-}
-
-#if OPENTHREAD_ENABLE_APPLICATION_COAP
-
-ApplicationCoap::ApplicationCoap(Instance &aInstance)
-    : CoapBase(aInstance)
-{
-}
-
-#endif // OPENTHREAD_ENABLE_APPLICATION_COAP
 
 } // namespace Coap
 } // namespace ot

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -352,11 +352,9 @@ public:
      * Default class constructor.
      *
      * @param[in]  aInstance  A reference to the OpenThread instance.
-     * @param[in]  aHandler   A timer handler provided by owner of `RespponseQueue`.
-     * @param[in]  aContext   A pointer to arbitrary context information (used along with timer handler).
      *
      */
-    ResponsesQueue(Instance &aInstance, Timer::Handler aHandler, void *aContext);
+    explicit ResponsesQueue(Instance &aInstance);
 
     /**
      * Add given response to the cache.
@@ -420,15 +418,6 @@ public:
      */
     const MessageQueue &GetResponses(void) const { return mQueue; }
 
-    /**
-     * Callback handler for timer.
-     *
-     * This method must be invoked by the owner of `ResponsesQueue` instance when the timer expires from the `aHandler`
-     * callback function provided in the constructor.
-     *
-     */
-    void HandleTimer(void);
-
 private:
     enum
     {
@@ -441,8 +430,11 @@ private:
         aMessage.Free();
     }
 
-    MessageQueue mQueue;
-    TimerMilli   mTimer;
+    static void HandleTimer(Timer &aTimer);
+    void        HandleTimer(void);
+
+    MessageQueue      mQueue;
+    TimerMilliContext mTimer;
 };
 
 /**
@@ -674,32 +666,10 @@ protected:
     /**
      * This constructor initializes the object.
      *
-     * @param[in]  aInstance                      A reference to the OpenThread instance.
-     * @param[in]  aRetransmissionTimerHandler    A timer handler provided by sub-class for `mRetranmissionTimer`.
-     * @param[in]  aResponsesQueueTimerHandler    A timer handler provided by sub-class for `mReponsesQueue` timer.
+     * @param[in]  aInstance    A reference to the OpenThread instance.
      *
      */
-    CoapBase(Instance &     aInstance,
-             Timer::Handler aRetransmissionTimerHandler,
-             Timer::Handler aResponsesQueueTimerHandler);
-
-    /**
-     * Retransmission timer handler.
-     *
-     * This method must be invoked by sub-class when the timer expires from the `aRetransmissionTimerHandler`
-     * callback function provided in the constructor.
-     *
-     */
-    void HandleRetransmissionTimer(void);
-
-    /**
-     * `ResponsesQueue` timer handler.
-     *
-     * This method must be invoked by sub-class when the timer expires from the `aResponsesQueueTimerHandler`
-     * callback function provided in the constructor.
-     *
-     */
-    void HandleResponsesQueueTimer(void) { mResponsesQueue.HandleTimer(); }
+    explicit CoapBase(Instance &aInstance);
 
     /**
      * This method sends a message.
@@ -722,6 +692,9 @@ protected:
     Ip6::UdpSocket mSocket;
 
 private:
+    static void HandleRetransmissionTimer(Timer &aTimer);
+    void        HandleRetransmissionTimer(void);
+
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 
     Message *CopyAndEnqueueMessage(const Message &aMessage, uint16_t aCopyLength, const CoapMetadata &aCoapMetadata);
@@ -743,9 +716,9 @@ private:
     otError SendCopy(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     otError SendEmptyMessage(Header::Type aType, const Header &aRequestHeader, const Ip6::MessageInfo &aMessageInfo);
 
-    MessageQueue mPendingRequests;
-    uint16_t     mMessageId;
-    TimerMilli   mRetransmissionTimer;
+    MessageQueue      mPendingRequests;
+    uint16_t          mMessageId;
+    TimerMilliContext mRetransmissionTimer;
 
     Resource *mResources;
 
@@ -771,10 +744,6 @@ public:
      *
      */
     explicit Coap(Instance &aInstance);
-
-private:
-    static void HandleRetransmissionTimer(Timer &aTimer);
-    static void HandleResponsesQueueTimer(Timer &aTimer);
 };
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
@@ -793,10 +762,6 @@ public:
      *
      */
     explicit ApplicationCoap(Instance &aInstance);
-
-private:
-    static void HandleRetransmissionTimer(Timer &aTimer);
-    static void HandleResponsesQueueTimer(Timer &aTimer);
 };
 
 #endif

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -91,7 +91,7 @@ enum
 OT_TOOL_PACKED_BEGIN
 class CoapMetadata
 {
-    friend class CoapBase;
+    friend class Coap;
 
 public:
     /**
@@ -198,7 +198,7 @@ private:
  */
 class Resource : public otCoapResource
 {
-    friend class CoapBase;
+    friend class Coap;
 
 public:
     enum
@@ -438,10 +438,10 @@ private:
 };
 
 /**
- * This class implements the common base for CoAP client and server.
+ * This class implements the CoAP client and server.
  *
  */
-class CoapBase : public InstanceLocator
+class Coap : public InstanceLocator
 {
     friend class ResponsesQueue;
 
@@ -460,6 +460,14 @@ public:
      *
      */
     typedef otError (*Interceptor)(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, void *aContext);
+
+    /**
+     * This constructor initializes the object.
+     *
+     * @param[in]  aInstance    A reference to the OpenThread instance.
+     *
+     */
+    explicit Coap(Instance &aInstance);
 
     /**
      * This method starts the CoAP service.
@@ -664,14 +672,6 @@ public:
 
 protected:
     /**
-     * This constructor initializes the object.
-     *
-     * @param[in]  aInstance    A reference to the OpenThread instance.
-     *
-     */
-    explicit CoapBase(Instance &aInstance);
-
-    /**
      * This method sends a message.
      *
      * @param[in]  aMessage      A reference to the message to send.
@@ -729,42 +729,6 @@ private:
     otCoapRequestHandler mDefaultHandler;
     void *               mDefaultHandlerContext;
 };
-
-/**
- * This class implements the CoAP client and server.
- *
- */
-class Coap : public CoapBase
-{
-public:
-    /**
-     * This constructor initializes the object.
-     *
-     * @param[in] aInstance      A reference to the OpenThread instance.
-     *
-     */
-    explicit Coap(Instance &aInstance);
-};
-
-#if OPENTHREAD_ENABLE_APPLICATION_COAP
-
-/**
- * This class implements the application CoAP client and server.
- *
- */
-class ApplicationCoap : public CoapBase
-{
-public:
-    /**
-     * This constructor initializes the object.
-     *
-     * @param[in] aInstance      A reference to the OpenThread instance.
-     *
-     */
-    explicit ApplicationCoap(Instance &aInstance);
-};
-
-#endif
 
 } // namespace Coap
 } // namespace ot

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -47,34 +47,17 @@
 namespace ot {
 namespace Coap {
 
-CoapSecure::CoapSecure(Instance &aInstance)
-    : CoapBase(aInstance, &CoapSecure::HandleRetransmissionTimer, &CoapSecure::HandleResponsesQueueTimer)
+CoapSecure::CoapSecure(Instance &aInstance, bool aLayerTwoSecurity)
+    : CoapBase(aInstance)
     , mConnectedCallback(NULL)
     , mConnectedContext(NULL)
     , mTransportCallback(NULL)
     , mTransportContext(NULL)
     , mTransmitQueue()
     , mTransmitTask(aInstance, &CoapSecure::HandleTransmit, this)
-    , mLayerTwoSecurity(false)
+    , mLayerTwoSecurity(aLayerTwoSecurity)
 {
 }
-
-#if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-CoapSecure::CoapSecure(Instance &       aInstance,
-                       Tasklet::Handler aHandleTransmit,
-                       Timer::Handler   aRetransmissionTimer,
-                       Timer::Handler   aResponsesQueueTimer)
-    : CoapBase(aInstance, aRetransmissionTimer, aResponsesQueueTimer)
-    , mConnectedCallback(NULL)
-    , mConnectedContext(NULL)
-    , mTransportCallback(NULL)
-    , mTransportContext(NULL)
-    , mTransmitQueue()
-    , mTransmitTask(aInstance, aHandleTransmit, this)
-    , mLayerTwoSecurity(true)
-{
-}
-#endif // OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
 
 otError CoapSecure::Start(uint16_t aPort, TransportCallback aCallback, void *aContext)
 {
@@ -369,7 +352,7 @@ exit:
 
 void CoapSecure::HandleTransmit(Tasklet &aTasklet)
 {
-    aTasklet.GetOwner<CoapSecure>().HandleTransmit();
+    static_cast<CoapSecure *>(static_cast<TaskletContext &>(aTasklet).GetContext())->HandleTransmit();
 }
 
 void CoapSecure::HandleTransmit(void)
@@ -399,39 +382,11 @@ exit:
     }
 }
 
-void CoapSecure::HandleRetransmissionTimer(Timer &aTimer)
-{
-    aTimer.GetOwner<CoapSecure>().CoapBase::HandleRetransmissionTimer();
-}
-
-void CoapSecure::HandleResponsesQueueTimer(Timer &aTimer)
-{
-    aTimer.GetOwner<CoapSecure>().CoapBase::HandleResponsesQueueTimer();
-}
-
 #if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
 
 ApplicationCoapSecure::ApplicationCoapSecure(Instance &aInstance)
-    : CoapSecure(aInstance,
-                 &ApplicationCoapSecure::HandleTransmit,
-                 &ApplicationCoapSecure::HandleRetransmissionTimer,
-                 &ApplicationCoapSecure::HandleResponsesQueueTimer)
+    : CoapSecure(aInstance, /* aLayerTwoSecurity */ true)
 {
-}
-
-void ApplicationCoapSecure::HandleTransmit(Tasklet &aTasklet)
-{
-    aTasklet.GetOwner<ApplicationCoapSecure>().CoapSecure::HandleTransmit();
-}
-
-void ApplicationCoapSecure::HandleRetransmissionTimer(Timer &aTimer)
-{
-    aTimer.GetOwner<ApplicationCoapSecure>().CoapBase::HandleRetransmissionTimer();
-}
-
-void ApplicationCoapSecure::HandleResponsesQueueTimer(Timer &aTimer)
-{
-    aTimer.GetOwner<ApplicationCoapSecure>().CoapBase::HandleResponsesQueueTimer();
 }
 
 #endif // OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -48,7 +48,7 @@ namespace ot {
 namespace Coap {
 
 CoapSecure::CoapSecure(Instance &aInstance, bool aLayerTwoSecurity)
-    : CoapBase(aInstance)
+    : Coap(aInstance)
     , mConnectedCallback(NULL)
     , mConnectedContext(NULL)
     , mTransportCallback(NULL)
@@ -71,7 +71,7 @@ otError CoapSecure::Start(uint16_t aPort, TransportCallback aCallback, void *aCo
     // to transmit/receive messages, so do not open it in that case.
     if (mTransportCallback == NULL)
     {
-        error = CoapBase::Start(aPort);
+        error = Coap::Start(aPort);
     }
 
     return error;
@@ -99,7 +99,7 @@ otError CoapSecure::Stop(void)
     mTransportCallback = NULL;
     mTransportContext  = NULL;
 
-    return CoapBase::Stop();
+    return Coap::Stop();
 }
 
 otError CoapSecure::Connect(const Ip6::SockAddr &aSockAddr, ConnectedCallback aCallback, void *aContext)
@@ -209,7 +209,7 @@ otError CoapSecure::SendMessage(Message &aMessage, otCoapResponseHandler aHandle
 
     VerifyOrExit(IsConnected(), error = OT_ERROR_INVALID_STATE);
 
-    error = CoapBase::SendMessage(aMessage, mPeerAddress, aHandler, aContext);
+    error = Coap::SendMessage(aMessage, mPeerAddress, aHandler, aContext);
 
 exit:
     return error;
@@ -220,7 +220,7 @@ otError CoapSecure::SendMessage(Message &               aMessage,
                                 otCoapResponseHandler   aHandler,
                                 void *                  aContext)
 {
-    return CoapBase::SendMessage(aMessage, aMessageInfo, aHandler, aContext);
+    return Coap::SendMessage(aMessage, aMessageInfo, aHandler, aContext);
 }
 
 otError CoapSecure::Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -299,7 +299,7 @@ void CoapSecure::HandleDtlsReceive(uint8_t *aBuf, uint16_t aLength)
     VerifyOrExit((message = GetInstance().GetMessagePool().New(Message::kTypeIp6, 0)) != NULL);
     SuccessOrExit(message->Append(aBuf, aLength));
 
-    CoapBase::Receive(*message, mPeerAddress);
+    Coap::Receive(*message, mPeerAddress);
 
 exit:
 
@@ -381,15 +381,6 @@ exit:
         otLogDebgMeshCoP("CoapSecure Transmit: %s", otThreadErrorToString(error));
     }
 }
-
-#if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-
-ApplicationCoapSecure::ApplicationCoapSecure(Instance &aInstance)
-    : CoapSecure(aInstance, /* aLayerTwoSecurity */ true)
-{
-}
-
-#endif // OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
 
 } // namespace Coap
 } // namespace ot

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -45,7 +45,7 @@ namespace ot {
 
 namespace Coap {
 
-class CoapSecure : public CoapBase
+class CoapSecure : public Coap
 {
 public:
     /**
@@ -342,31 +342,6 @@ private:
 
     bool mLayerTwoSecurity : 1;
 };
-
-#if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-
-/**
- * This class implements the application CoAP Secure client and server.
- *
- */
-class ApplicationCoapSecure : public CoapSecure
-{
-public:
-    /**
-     * This constructor initializes the object.
-     *
-     * @param[in] aInstance      A reference to the OpenThread instance.
-     *
-     */
-    explicit ApplicationCoapSecure(Instance &aInstance);
-
-private:
-    static void HandleRetransmissionTimer(Timer &aTimer);
-    static void HandleResponsesQueueTimer(Timer &aTimer);
-    static void HandleTransmit(Tasklet &aTasklet);
-};
-
-#endif // OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
 
 } // namespace Coap
 } // namespace ot

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -70,27 +70,11 @@ public:
     /**
      * This constructor initializes the object.
      *
-     * @param[in]  aInstance  A reference to the OpenThread instance.
+     * @param[in]  aInstance           A reference to the OpenThread instance.
+     * @param[in]  aLayerTwoSecurity   Specifies whether to use layer two security or not.
      *
      */
-    explicit CoapSecure(Instance &aInstance);
-
-#if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-    /**
-     * This constructor initializes the object.
-     * (Used for Application CoAPS)
-     *
-     * @param[in]  aInstance             A reference to the OpenThread instance.
-     * @param[in]  aUdpTransmitHandle    Handler for udp transmit.
-     * @param[in]  aRetransmissionTimer  Handler for retransmission.
-     * @param[in]  aResponsesQueueTimer  Handler for Queue Responses.
-     *
-     */
-    explicit CoapSecure(Instance &       aInstance,
-                        Tasklet::Handler aUdpTransmitHandle,
-                        Timer::Handler   aRetransmissionTimer,
-                        Timer::Handler   aResponsesQueueTimer);
-#endif // OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
+    explicit CoapSecure(Instance &aInstance, bool aLayerTwoSecurity = false);
 
     /**
      * This method starts the secure CoAP agent.
@@ -333,9 +317,6 @@ public:
      */
     const Ip6::MessageInfo &GetPeerMessageInfo(void) const { return mPeerAddress; }
 
-protected:
-    void HandleTransmit(void);
-
 private:
     virtual otError Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
@@ -348,9 +329,8 @@ private:
     static otError HandleDtlsSend(void *aContext, const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
     otError        HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
 
-    static void HandleRetransmissionTimer(Timer &aTimer);
-    static void HandleResponsesQueueTimer(Timer &aTimer);
     static void HandleTransmit(Tasklet &aTasklet);
+    void        HandleTransmit(void);
 
     Ip6::MessageInfo  mPeerAddress;
     ConnectedCallback mConnectedCallback;
@@ -358,7 +338,7 @@ private:
     TransportCallback mTransportCallback;
     void *            mTransportContext;
     MessageQueue      mTransmitQueue;
-    Tasklet           mTransmitTask;
+    TaskletContext    mTransmitTask;
 
     bool mLayerTwoSecurity : 1;
 };

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -68,7 +68,7 @@ Instance::Instance(void)
     , mApplicationCoap(*this)
 #endif
 #if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-    , mApplicationCoapSecure(*this)
+    , mApplicationCoapSecure(*this, /* aLayerTwoSecurity */ true)
 #endif
 #if OPENTHREAD_ENABLE_CHANNEL_MONITOR
     , mChannelMonitor(*this)

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -320,7 +320,7 @@ public:
      * @returns A reference to the application COAP object.
      *
      */
-    Coap::ApplicationCoap &GetApplicationCoap(void) { return mApplicationCoap; }
+    Coap::Coap &GetApplicationCoap(void) { return mApplicationCoap; }
 #endif
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
@@ -330,7 +330,7 @@ public:
      * @returns A reference to the application COAP Secure object.
      *
      */
-    Coap::ApplicationCoapSecure &GetApplicationCoapSecure(void) { return mApplicationCoapSecure; }
+    Coap::CoapSecure &GetApplicationCoapSecure(void) { return mApplicationCoapSecure; }
 #endif
 
 #if OPENTHREAD_ENABLE_CHANNEL_MONITOR
@@ -438,11 +438,11 @@ private:
     ThreadNetif mThreadNetif;
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
-    Coap::ApplicationCoap mApplicationCoap;
+    Coap::Coap mApplicationCoap;
 #endif
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-    Coap::ApplicationCoapSecure mApplicationCoapSecure;
+    Coap::CoapSecure mApplicationCoapSecure;
 #endif
 
 #if OPENTHREAD_ENABLE_CHANNEL_MONITOR
@@ -596,20 +596,6 @@ template <> inline MeshCoP::PendingDataset &Instance::Get(void)
 template <> inline TimeSync &Instance::Get(void)
 {
     return GetThreadNetif().GetTimeSync();
-}
-#endif
-
-#if OPENTHREAD_ENABLE_APPLICATION_COAP
-template <> inline Coap::ApplicationCoap &Instance::Get(void)
-{
-    return GetApplicationCoap();
-}
-#endif
-
-#if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-template <> inline Coap::ApplicationCoapSecure &Instance::Get(void)
-{
-    return GetApplicationCoapSecure();
 }
 #endif
 

--- a/src/core/common/tasklet.hpp
+++ b/src/core/common/tasklet.hpp
@@ -76,7 +76,7 @@ public:
     /**
      * This constructor creates a tasklet instance.
      *
-     * @param[in]  aInstance   A reference to the instance object.
+     * @param[in]  aInstance   A reference to the OpenThread instance object.
      * @param[in]  aHandler    A pointer to a function that is called when the tasklet is run.
      * @param[in]  aOwner      A pointer to owner of this `Tasklet` object.
      *
@@ -94,6 +94,44 @@ private:
 
     Handler  mHandler;
     Tasklet *mNext;
+};
+
+/**
+ * This class defines a tasklet that also maintains a user context pointer.
+ *
+ * In typical `Tasklet` use, in the handler callback, the owner of the tasklet is determined using `GetOwner<Type>`
+ * method. This method works if there is a single instance of `Type` within OpenThread instance hierarchy. The
+ * `TaskletContext` is intended for cases where there may be multiple instances of the same class/type using a `Tasklet`
+ * object. `TaskletContext` will store a context `void *` information.
+ *
+ */
+class TaskletContext : public Tasklet
+{
+public:
+    /**
+     * This constructor creates a tasklet instance.
+     *
+     * @param[in]  aInstance   A reference to the OpenThread instance.
+     * @param[in]  aHandler    A pointer to a function that is called when the tasklet is run.
+     * @param[in]  aContext    A pointer to an arbitrary context information.
+     *
+     */
+    TaskletContext(Instance &aInstance, Handler aHandler, void *aContext)
+        : Tasklet(aInstance, aHandler, aContext)
+        , mContext(aContext)
+    {
+    }
+
+    /**
+     * This method returns the pointer to the arbitrary context information.
+     *
+     * @returns Pointer to the arbitrary context information.
+     *
+     */
+    void *GetContext(void) { return mContext; }
+
+private:
+    void *mContext;
 };
 
 /**

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -216,6 +216,44 @@ private:
 };
 
 /**
+ * This class implements a millisecond timer that also maintains a user context pointer.
+ *
+ * In typical `TimerMilli`/`TimerMicro` use, in the timer callback handler, the owner of the timer is determined using
+ * `GetOwner<Type>` method. This method works if there is a single instance of `Type` within OpenThread instance
+ * hierarchy. The `TimerMilliContext` is intended for cases where there may be multiple instances of the same class/type
+ * using a timer object. `TimerMilliContext` will store a context `void *` information.
+ *
+ */
+class TimerMilliContext : public TimerMilli
+{
+public:
+    /**
+     * This constructor creates a millisecond timer that also maintains a user context pointer.
+     *
+     * @param[in]  aInstance   A reference to the OpenThread instance.
+     * @param[in]  aHandler    A pointer to a function that is called when the timer expires.
+     * @param[in]  aContext    A pointer to an arbitrary context information.
+     *
+     */
+    TimerMilliContext(Instance &aInstance, Handler aHandler, void *aContext)
+        : TimerMilli(aInstance, aHandler, aContext)
+        , mContext(aContext)
+    {
+    }
+
+    /**
+     * This method returns the pointer to the arbitrary context information.
+     *
+     * @returns Pointer to the arbitrary context information.
+     *
+     */
+    void *GetContext(void) { return mContext; }
+
+private:
+    void *mContext;
+};
+
+/**
  * This class implements the base timer scheduler.
  *
  */

--- a/src/core/meshcop/meshcop.hpp
+++ b/src/core/meshcop/meshcop.hpp
@@ -55,7 +55,7 @@ enum
  * This function create Message for MeshCoP
  *
  */
-inline Message *NewMeshCoPMessage(Coap::CoapBase &aCoap, const Coap::Header &aHeader)
+inline Message *NewMeshCoPMessage(Coap::Coap &aCoap, const Coap::Header &aHeader)
 {
     otMessageSettings settings = {true, static_cast<otMessagePriority>(kMeshCoPMessagePriority)};
     return aCoap.NewMessage(aHeader, &settings);


### PR DESCRIPTION
Goal of this PR is to simplify the COAP modules. 
It contains four related commits: 


>**[timer] adding ContextTimerMilli class**
>  
>This commit adds a new class `ContextTimerMilli` which is a
>millisecond timer also tracking an arbitrary context information
>provided by user in the object constructor.

>**[tasklet] adding ContextTasklet class**
>    
>This commit adds a new class `ContextTasklet` which is a `Taskelt`
>that is also tracking an arbitrary context information provided
>by user in the object constructor.

>**[coap] update Coap/CoapSecure to use Context tracking Timer/Tasklet**
>    
>This commit simplifies `ResponseQueue`, `CoapBase`, `CoapSecure` to
>use `ContextTimerMilli`/`ContextTaskelt`. This change removes the need
>for sub-classes to provide the timer and tasklet callback handlers.


>**[coap] remove Coap sub-classes**
>    
>This commit simplifies the COAP modules by renaming `CoapBase` to
>`Coap` and removing the now unnecessary sub-classes `ApplicationCoap`
>and `ApplicationCoapSecure`.