### PR TITLE
[efr32] random number generation fix

### DIFF
--- a/examples/platforms/efr32/random.c
+++ b/examples/platforms/efr32/random.c
@@ -71,11 +71,13 @@ void efr32RandomInit(void)
 
 uint32_t otPlatRandomGet(void)
 {
-    uint8_t  tmp    = 0;
+    uint8_t  tmp;
     uint32_t random = 0;
 
     for (int i = 0; i < 4; i++)
     {
+        tmp = 0;
+
         for (int j = 0; j < 3; j++)
         {
             ADC_Start(ADC0, adcStartSingle);


### PR DESCRIPTION
Random numbers in EFR32 example where artificially large because a variable wasn't being cleared between iterations of a for-loop.