### PR TITLE
[mesh-forwarder] fix double logging msg tx to non-sleepy child

### DIFF
--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -723,17 +723,20 @@ void MeshForwarder::HandleSentFrameToChild(const Mac::Frame &aFrame, otError aEr
             mSourceMatchController.DecrementMessageCount(*child);
         }
 
-        LogMessage(kMessageTransmit, *mSendMessage, &aMacDest, txError);
-
-        if (mSendMessage->GetType() == Message::kTypeIp6)
+        if (!mSendMessage->GetDirectTransmission())
         {
-            if (mSendMessage->GetTxSuccess())
+            LogMessage(kMessageTransmit, *mSendMessage, &aMacDest, txError);
+
+            if (mSendMessage->GetType() == Message::kTypeIp6)
             {
-                mIpCounters.mTxSuccess++;
-            }
-            else
-            {
-                mIpCounters.mTxFailure++;
+                if (mSendMessage->GetTxSuccess())
+                {
+                    mIpCounters.mTxSuccess++;
+                }
+                else
+                {
+                    mIpCounters.mTxFailure++;
+                }
             }
         }
     }


### PR DESCRIPTION
This commit moves the logging of a message transmission status and
updating of the counters in `MeshForwarder::HandleSentFrameToChild()`
inside the `if` block checking for the message to be indirect. This
change addresses an issue where message transmissions to a non-sleepy
child could be logged and counted twice from both `HandleSentFrame()`
and `HandleSentFrameToChild()`.