### PR TITLE
[nrf52840] only enable ecdsa when OpenThread configures

### DIFF
--- a/third_party/NordicSemiconductor/libraries/crypto/nrf52840-mbedtls-config.h
+++ b/third_party/NordicSemiconductor/libraries/crypto/nrf52840-mbedtls-config.h
@@ -32,9 +32,6 @@
 #define MBEDTLS_SHA256_ALT
 #endif // DISABLE_CC310
 
-#define MBEDTLS_ECDH_C
-#define MBEDTLS_ECDSA_C
-
 #if defined(__ICCARM__)
     _Pragma("diag_suppress=Pe550")
 #endif


### PR DESCRIPTION
ECDSA is already enabled in
https://github.com/openthread/openthread/blob/master/third_party/mbedtls/mbedtls-config.h#L137