### PR TITLE
[mac] remove unused method definitions

### DIFF
--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -556,24 +556,6 @@ public:
     int8_t GetNoiseFloor(void);
 
     /**
-     * This method indicates whether or not CSMA backoff is supported by the radio layer.
-     *
-     * @retval true   CSMA backoff is supported by the radio.
-     * @retval false  CSMA backoff is not supported by the radio.
-     *
-     */
-    bool RadioSupportsCsmaBackoff(void);
-
-    /**
-     * This method indicates whether or not transmit retries is supported by the radio layer.
-     *
-     * @retval true   Retries (and CSMA) are supported by the radio.
-     * @retval false  Retries (and CSMA) are not supported by the radio.
-     *
-     */
-    bool RadioSupportsRetries(void);
-
-    /**
      * This method returns the current CCA (Clear Channel Assessment) failure rate.
      *
      * The rate is maintained over a window of (roughly) last `OPENTHREAD_CONFIG_CCA_FAILURE_RATE_AVERAGING_WINDOW`


### PR DESCRIPTION
This class removes unused method definitions in `Mac` class. Note
that these methods are now provided and used in `SubMac`.