### PR TITLE
[mle-router] stop mStateUpdateTimer on mode change

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1689,6 +1689,8 @@ void MleRouter::HandleStateUpdateTimer(void)
 {
     bool routerStateUpdate = false;
 
+    VerifyOrExit(IsRouterRoleEnabled());
+
     mStateUpdateTimer.Start(kStateUpdatePeriod);
 
     if (mChallengeTimeout > 0)


### PR DESCRIPTION
This commit ensures to not re-start the `mStateUpdateTimer` from its
callback, when router role is disabled. This addresses the issue where
a mode change (disabling router role) could cause the timer to
continue to fire indefinitely, further causing device to attempt to
reattach from each timer callback.

Thanks to Conor O'Neill (@conormoneill) for discovering and debugging
this issue.

----
This should help address Issue https://github.com/openthread/openthread/issues/3372