### PR TITLE
[dataset] re-add the OT_CHANNEL_ALL definition in dataset.h

### DIFF
--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -174,6 +174,8 @@ typedef uint32_t otChannelMaskPage0;
 #define OT_CHANNEL_25_MASK (1 << 25) ///< Channel 25
 #define OT_CHANNEL_26_MASK (1 << 26) ///< Channel 26
 
+#define OT_CHANNEL_ALL 0xffffffff ///< All channels
+
 /**
  * This structure represents presence of different components in Active or Pending Operational Dataset.
  *


### PR DESCRIPTION
---
The `OT_CHANNEL_ALL` definition was removed from https://github.com/openthread/openthread/pull/3349 (probably since it was no longer used inside OT core), however note that this definition was included in the public header file `dataset.h` and intended for  application/users of OpenThread to use (along with other `OT_CHANNEL_<num>_MASK` definitions). 
For example, this definition is useful for OT users calling OpenThread APIs that expect a channel mask, say `otThreadDiscover()` or `otLinkActiveScan()`. 

This PR is re-adding this definition in `dataset.h`