### PR TITLE
[posix-app] simplify UART on POSIX app

### DIFF
--- a/src/posix/Makefile-posix
+++ b/src/posix/Makefile-posix
@@ -79,11 +79,12 @@ AbsTopSourceDir                := $(dir $(realpath $(firstword $(MAKEFILE_LIST))
 CONFIG_FILE      = OPENTHREAD_PROJECT_CORE_CONFIG_FILE='\"openthread-core-posix-config.h\"'
 CONFIG_FILE_PATH = $(AbsTopSourceDir)/src/posix/platform
 
-COMMONCFLAGS                   := \
-    -O0                           \
-    -g                            \
-    -D$(CONFIG_FILE)              \
-    -I$(CONFIG_FILE_PATH)         \
+COMMONCFLAGS                         := \
+    -O2                                 \
+    -g                                  \
+    -D$(CONFIG_FILE)                    \
+    -I$(CONFIG_FILE_PATH)               \
+    -DOPENTHREAD_CONFIG_UART_CLI_RAW=1  \
     $(NULL)
 
 ifeq ($(VIRTUAL_TIME),1)

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -30,8 +30,11 @@
 
 #include <openthread-core-config.h>
 #include <setjmp.h>
+#include <signal.h>
 #include <unistd.h>
-#include <openthread/config.h>
+#ifdef __linux__
+#include <sys/prctl.h>
+#endif
 
 #define OPENTHREAD_POSIX_APP_NCP 1
 #define OPENTHREAD_POSIX_APP_CLI 2
@@ -61,6 +64,12 @@ void otTaskletsSignalPending(otInstance *aInstance)
 int main(int argc, char *argv[])
 {
     otInstance *instance;
+
+#ifdef __linux__
+    // Ensure we terminate this process if the
+    // parent process dies.
+    prctl(PR_SET_PDEATHSIG, SIGHUP);
+#endif
 
     if (setjmp(gResetJump))
     {

--- a/src/posix/platform/uart.c
+++ b/src/posix/platform/uart.c
@@ -28,157 +28,40 @@
 
 #include "platform-posix.h"
 
-#include <assert.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#ifdef OPENTHREAD_TARGET_LINUX
-#include <sys/prctl.h>
-#endif
-#include <termios.h>
 #include <unistd.h>
 
 #include <openthread/platform/uart.h>
 
 #include "code_utils.h"
 
-int   posix_openpt(int oflag);
-int   grantpt(int fildes);
-int   unlockpt(int fd);
-char *ptsname(int fd);
-
-static uint8_t        s_receive_buffer[128];
-static const uint8_t *s_write_buffer;
-static uint16_t       s_write_length;
-static int            s_in_fd;
-static int            s_out_fd;
-
-static struct termios original_stdin_termios;
-static struct termios original_stdout_termios;
-
-static void restore_stdin_termios(void)
-{
-    tcsetattr(s_in_fd, TCSAFLUSH, &original_stdin_termios);
-}
-
-static void restore_stdout_termios(void)
-{
-    tcsetattr(s_out_fd, TCSAFLUSH, &original_stdout_termios);
-}
+static uint8_t        sReceiveBuffer[128];
+static const uint8_t *sWriteBuffer;
+static uint16_t       sWriteLength;
 
 void platformUartRestore(void)
 {
-    restore_stdin_termios();
-    restore_stdout_termios();
-    dup2(s_out_fd, STDOUT_FILENO);
 }
 
 otError otPlatUartEnable(void)
 {
-    otError        error = OT_ERROR_NONE;
-    struct termios termios;
-
-#ifdef OPENTHREAD_TARGET_LINUX
-    // Ensure we terminate this process if the
-    // parent process dies.
-    prctl(PR_SET_PDEATHSIG, SIGHUP);
-#endif
-
-    s_in_fd  = dup(STDIN_FILENO);
-    s_out_fd = dup(STDOUT_FILENO);
-    dup2(STDERR_FILENO, STDOUT_FILENO);
-
-    // We need this signal to make sure that this
-    // process terminates properly.
-    signal(SIGPIPE, SIG_DFL);
-
-    if (isatty(s_in_fd))
-    {
-        tcgetattr(s_in_fd, &original_stdin_termios);
-        atexit(&restore_stdin_termios);
-    }
-
-    if (isatty(s_out_fd))
-    {
-        tcgetattr(s_out_fd, &original_stdout_termios);
-        atexit(&restore_stdout_termios);
-    }
-
-    if (isatty(s_in_fd))
-    {
-        // get current configuration
-        otEXPECT_ACTION(tcgetattr(s_in_fd, &termios) == 0, perror("tcgetattr"); error = OT_ERROR_GENERIC);
-
-        // Set up the termios settings for raw mode. This turns
-        // off input/output processing, line processing, and character processing.
-        cfmakeraw(&termios);
-
-        // Set up our cflags for local use. Turn on hangup-on-close.
-        termios.c_cflag |= HUPCL | CREAD | CLOCAL;
-
-        // "Minimum number of characters for noncanonical read"
-        termios.c_cc[VMIN] = 1;
-
-        // "Timeout in deciseconds for noncanonical read"
-        termios.c_cc[VTIME] = 0;
-
-        // configure baud rate
-        otEXPECT_ACTION(cfsetispeed(&termios, B115200) == 0, perror("cfsetispeed"); error = OT_ERROR_GENERIC);
-
-        // set configuration
-        otEXPECT_ACTION(tcsetattr(s_in_fd, TCSANOW, &termios) == 0, perror("tcsetattr"); error = OT_ERROR_GENERIC);
-    }
-
-    if (isatty(s_out_fd))
-    {
-        // get current configuration
-        otEXPECT_ACTION(tcgetattr(s_out_fd, &termios) == 0, perror("tcgetattr"); error = OT_ERROR_GENERIC);
-
-        // Set up the termios settings for raw mode. This turns
-        // off input/output processing, line processing, and character processing.
-        cfmakeraw(&termios);
-
-        // Absolutely obliterate all output processing.
-        termios.c_oflag = 0;
-
-        // Set up our cflags for local use. Turn on hangup-on-close.
-        termios.c_cflag |= HUPCL | CREAD | CLOCAL;
-
-        // configure baud rate
-        otEXPECT_ACTION(cfsetospeed(&termios, B115200) == 0, perror("cfsetospeed"); error = OT_ERROR_GENERIC);
-
-        // set configuration
-        otEXPECT_ACTION(tcsetattr(s_out_fd, TCSANOW, &termios) == 0, perror("tcsetattr"); error = OT_ERROR_GENERIC);
-    }
-
-    return error;
-
-exit:
-    close(s_in_fd);
-    close(s_out_fd);
-    return error;
+    return OT_ERROR_NONE;
 }
 
 otError otPlatUartDisable(void)
 {
-    otError error = OT_ERROR_NONE;
-
-    close(s_in_fd);
-    close(s_out_fd);
-
-    return error;
+    return OT_ERROR_NONE;
 }
 
 otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
     otError error = OT_ERROR_NONE;
 
-    otEXPECT_ACTION(s_write_length == 0, error = OT_ERROR_BUSY);
+    otEXPECT_ACTION(sWriteLength == 0, error = OT_ERROR_BUSY);
 
-    s_write_buffer = aBuf;
-    s_write_length = aBufLength;
+    sWriteBuffer = aBuf;
+    sWriteLength = aBufLength;
 
 exit:
     return error;
@@ -188,31 +71,31 @@ void platformUartUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, fd_set *aE
 {
     if (aReadFdSet != NULL)
     {
-        FD_SET(s_in_fd, aReadFdSet);
+        FD_SET(STDIN_FILENO, aReadFdSet);
 
         if (aErrorFdSet != NULL)
         {
-            FD_SET(s_in_fd, aErrorFdSet);
+            FD_SET(STDIN_FILENO, aErrorFdSet);
         }
 
-        if (aMaxFd != NULL && *aMaxFd < s_in_fd)
+        if (aMaxFd != NULL && *aMaxFd < STDIN_FILENO)
         {
-            *aMaxFd = s_in_fd;
+            *aMaxFd = STDIN_FILENO;
         }
     }
 
-    if ((aWriteFdSet != NULL) && (s_write_length > 0))
+    if ((aWriteFdSet != NULL) && (sWriteLength > 0))
     {
-        FD_SET(s_out_fd, aWriteFdSet);
+        FD_SET(STDOUT_FILENO, aWriteFdSet);
 
         if (aErrorFdSet != NULL)
         {
-            FD_SET(s_out_fd, aErrorFdSet);
+            FD_SET(STDOUT_FILENO, aErrorFdSet);
         }
 
-        if (aMaxFd != NULL && *aMaxFd < s_out_fd)
+        if (aMaxFd != NULL && *aMaxFd < STDOUT_FILENO)
         {
-            *aMaxFd = s_out_fd;
+            *aMaxFd = STDOUT_FILENO;
         }
     }
 }
@@ -220,27 +103,26 @@ void platformUartUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, fd_set *aE
 void platformUartProcess(const fd_set *aReadFdSet, const fd_set *aWriteFdSet, const fd_set *aErrorFdSet)
 {
     ssize_t rval;
-    errno = 0;
 
-    if (FD_ISSET(s_in_fd, aErrorFdSet))
+    if (FD_ISSET(STDIN_FILENO, aErrorFdSet))
     {
-        perror("s_in_fd");
+        perror("stdin");
         exit(OT_EXIT_FAILURE);
     }
 
-    if (FD_ISSET(s_out_fd, aErrorFdSet))
+    if (FD_ISSET(STDOUT_FILENO, aErrorFdSet))
     {
-        perror("s_out_fd");
+        perror("stdout");
         exit(OT_EXIT_FAILURE);
     }
 
-    if (FD_ISSET(s_in_fd, aReadFdSet))
+    if (FD_ISSET(STDIN_FILENO, aReadFdSet))
     {
-        rval = read(s_in_fd, s_receive_buffer, sizeof(s_receive_buffer));
+        rval = read(STDIN_FILENO, sReceiveBuffer, sizeof(sReceiveBuffer));
 
         if (rval > 0)
         {
-            otPlatUartReceived(s_receive_buffer, (uint16_t)rval);
+            otPlatUartReceived(sReceiveBuffer, (uint16_t)rval);
         }
         else if (rval < 0)
         {
@@ -254,9 +136,9 @@ void platformUartProcess(const fd_set *aReadFdSet, const fd_set *aWriteFdSet, co
         }
     }
 
-    if ((s_write_length > 0) && (FD_ISSET(s_out_fd, aWriteFdSet)))
+    if ((sWriteLength > 0) && (FD_ISSET(STDOUT_FILENO, aWriteFdSet)))
     {
-        rval = write(s_out_fd, s_write_buffer, s_write_length);
+        rval = write(STDOUT_FILENO, sWriteBuffer, sWriteLength);
 
         if (rval <= 0)
         {
@@ -264,10 +146,10 @@ void platformUartProcess(const fd_set *aReadFdSet, const fd_set *aWriteFdSet, co
             exit(OT_EXIT_FAILURE);
         }
 
-        s_write_buffer += (uint16_t)rval;
-        s_write_length -= (uint16_t)rval;
+        sWriteBuffer += (uint16_t)rval;
+        sWriteLength -= (uint16_t)rval;
 
-        if (s_write_length == 0)
+        if (sWriteLength == 0)
         {
             otPlatUartSendDone();
         }

--- a/tests/scripts/thread-cert/node_api.py
+++ b/tests/scripts/thread-cert/node_api.py
@@ -59,7 +59,7 @@ class otApi:
     def thread_stop(self):
         if self.Api.otNodeThreadStop(self.otNode) != 0:
             raise OSError("otNodeThreadStop failed!")
-            
+
     def commissioner_start(self):
         if self.Api.otNodeCommissionerStart(self.otNode) != 0:
             raise OSError("otNodeCommissionerStart failed!")
@@ -317,15 +317,15 @@ class otApi:
         if binary == None:
             binary = ""
         if self.Api.otNodeSendActiveSet(
-                self.otNode, 
-                ctypes.c_ulonglong(active_timestamp), 
-                ctypes.c_ushort(panid), 
-                ctypes.c_ushort(channel), 
-                ctypes.c_uint(channel_mask), 
-                extended_panid.encode('utf-8'), 
-                master_key.encode('utf-8'), 
-                mesh_local.encode('utf-8'), 
-                network_name.encode('utf-8'), 
+                self.otNode,
+                ctypes.c_ulonglong(active_timestamp),
+                ctypes.c_ushort(panid),
+                ctypes.c_ushort(channel),
+                ctypes.c_uint(channel_mask),
+                extended_panid.encode('utf-8'),
+                master_key.encode('utf-8'),
+                mesh_local.encode('utf-8'),
+                network_name.encode('utf-8'),
                 binary.encode('utf-8')
             ) != 0:
             raise OSError("otNodeSendActiveSet failed!")
@@ -371,7 +371,7 @@ class otApi:
         self.Api = ctypes.WinDLL("otnodeapi.dll")
         if self.Api == None:
             raise OSError("Failed to load otnodeapi.dll!")
-        
+
         # Define the functions
         self.Api.otNodeLog.argtypes = [ctypes.c_char_p]
 
@@ -380,7 +380,7 @@ class otApi:
 
         self.Api.otNodeFinalize.argtypes = [ctypes.c_void_p]
 
-        self.Api.otNodeSetMode.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeSetMode.argtypes = [ctypes.c_void_p,
                                            ctypes.c_char_p]
 
         self.Api.otNodeInterfaceUp.argtypes = [ctypes.c_void_p]
@@ -393,13 +393,13 @@ class otApi:
 
         self.Api.otNodeCommissionerStart.argtypes = [ctypes.c_void_p]
 
-        self.Api.otNodeCommissionerJoinerAdd.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeCommissionerJoinerAdd.argtypes = [ctypes.c_void_p,
                                                          ctypes.c_char_p,
                                                          ctypes.c_char_p]
 
         self.Api.otNodeCommissionerStop.argtypes = [ctypes.c_void_p]
 
-        self.Api.otNodeJoinerStart.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeJoinerStart.argtypes = [ctypes.c_void_p,
                                                ctypes.c_char_p,
                                                ctypes.c_char_p]
 
@@ -411,16 +411,16 @@ class otApi:
 
         self.Api.otNodeDisableWhitelist.argtypes = [ctypes.c_void_p]
 
-        self.Api.otNodeAddWhitelist.argtypes = [ctypes.c_void_p, 
-                                                ctypes.c_char_p, 
+        self.Api.otNodeAddWhitelist.argtypes = [ctypes.c_void_p,
+                                                ctypes.c_char_p,
                                                 ctypes.c_byte]
 
-        self.Api.otNodeRemoveWhitelist.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeRemoveWhitelist.argtypes = [ctypes.c_void_p,
                                                    ctypes.c_char_p]
-        
+
         self.Api.otNodeGetAddr16.argtypes = [ctypes.c_void_p]
         self.Api.otNodeGetAddr16.restype = ctypes.c_ushort
-        
+
         self.Api.otNodeGetAddr64.argtypes = [ctypes.c_void_p]
         self.Api.otNodeGetAddr64.restype = ctypes.c_char_p
 
@@ -429,128 +429,128 @@ class otApi:
 
         self.Api.otNodeGetJoinerId.argtypes = [ctypes.c_void_p]
         self.Api.otNodeGetJoinerId.restype = ctypes.c_char_p
-        
-        self.Api.otNodeSetChannel.argtypes = [ctypes.c_void_p, 
+
+        self.Api.otNodeSetChannel.argtypes = [ctypes.c_void_p,
                                               ctypes.c_ubyte]
-        
+
         self.Api.otNodeGetChannel.argtypes = [ctypes.c_void_p]
         self.Api.otNodeGetChannel.restype = ctypes.c_ubyte
 
-        self.Api.otNodeSetMasterkey.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeSetMasterkey.argtypes = [ctypes.c_void_p,
                                                 ctypes.c_char_p]
-        
+
         self.Api.otNodeGetMasterkey.argtypes = [ctypes.c_void_p]
         self.Api.otNodeGetMasterkey.restype = ctypes.c_char_p
-        
+
         self.Api.otNodeGetKeySequenceCounter.argtypes = [ctypes.c_void_p]
         self.Api.otNodeGetKeySequenceCounter.restype = ctypes.c_uint
 
-        self.Api.otNodeSetKeySequenceCounter.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeSetKeySequenceCounter.argtypes = [ctypes.c_void_p,
                                                          ctypes.c_uint]
 
-        self.Api.otNodeSetKeySwitchGuardTime.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeSetKeySwitchGuardTime.argtypes = [ctypes.c_void_p,
                                                          ctypes.c_uint]
 
-        self.Api.otNodeSetNetworkIdTimeout.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeSetNetworkIdTimeout.argtypes = [ctypes.c_void_p,
                                                        ctypes.c_ubyte]
-        
+
         self.Api.otNodeGetNetworkName.argtypes = [ctypes.c_void_p]
         self.Api.otNodeGetNetworkName.restype = ctypes.c_char_p
 
-        self.Api.otNodeSetNetworkName.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeSetNetworkName.argtypes = [ctypes.c_void_p,
                                                   ctypes.c_char_p]
-        
+
         self.Api.otNodeGetPanId.argtypes = [ctypes.c_void_p]
         self.Api.otNodeGetPanId.restype = ctypes.c_ushort
 
-        self.Api.otNodeSetPanId.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeSetPanId.argtypes = [ctypes.c_void_p,
                                             ctypes.c_ushort]
-        
+
         self.Api.otNodeGetPartitionId.argtypes = [ctypes.c_void_p]
         self.Api.otNodeGetPartitionId.restype = ctypes.c_uint
 
-        self.Api.otNodeSetPartitionId.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeSetPartitionId.argtypes = [ctypes.c_void_p,
                                                   ctypes.c_uint]
 
-        self.Api.otNodeSetRouterUpgradeThreshold.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeSetRouterUpgradeThreshold.argtypes = [ctypes.c_void_p,
                                                              ctypes.c_ubyte]
 
-        self.Api.otNodeSetRouterDowngradeThreshold.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeSetRouterDowngradeThreshold.argtypes = [ctypes.c_void_p,
                                                                ctypes.c_ubyte]
 
-        self.Api.otNodeReleaseRouterId.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeReleaseRouterId.argtypes = [ctypes.c_void_p,
                                                    ctypes.c_ubyte]
-        
+
         self.Api.otNodeGetState.argtypes = [ctypes.c_void_p]
         self.Api.otNodeGetState.restype = ctypes.c_char_p
 
-        self.Api.otNodeSetState.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeSetState.argtypes = [ctypes.c_void_p,
                                             ctypes.c_char_p]
-        
+
         self.Api.otNodeGetTimeout.argtypes = [ctypes.c_void_p]
         self.Api.otNodeGetTimeout.restype = ctypes.c_uint
 
-        self.Api.otNodeSetTimeout.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeSetTimeout.argtypes = [ctypes.c_void_p,
                                             ctypes.c_uint]
-        
+
         self.Api.otNodeGetWeight.argtypes = [ctypes.c_void_p]
         self.Api.otNodeGetWeight.restype = ctypes.c_ubyte
 
-        self.Api.otNodeSetWeight.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeSetWeight.argtypes = [ctypes.c_void_p,
                                              ctypes.c_ubyte]
 
-        self.Api.otNodeAddIpAddr.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeAddIpAddr.argtypes = [ctypes.c_void_p,
                                              ctypes.c_char_p]
-        
+
         self.Api.otNodeGetAddrs.argtypes = [ctypes.c_void_p]
         self.Api.otNodeGetAddrs.restype = ctypes.c_char_p
-        
+
         self.Api.otNodeGetContextReuseDelay.argtypes = [ctypes.c_void_p]
         self.Api.otNodeGetContextReuseDelay.restype = ctypes.c_uint
 
-        self.Api.otNodeSetContextReuseDelay.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeSetContextReuseDelay.argtypes = [ctypes.c_void_p,
                                                         ctypes.c_uint]
 
-        self.Api.otNodeAddPrefix.argtypes = [ctypes.c_void_p, 
-                                             ctypes.c_char_p, 
-                                             ctypes.c_char_p, 
+        self.Api.otNodeAddPrefix.argtypes = [ctypes.c_void_p,
+                                             ctypes.c_char_p,
+                                             ctypes.c_char_p,
                                              ctypes.c_char_p]
 
-        self.Api.otNodeRemovePrefix.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeRemovePrefix.argtypes = [ctypes.c_void_p,
                                                 ctypes.c_char_p]
 
-        self.Api.otNodeAddRoute.argtypes = [ctypes.c_void_p, 
-                                            ctypes.c_char_p, 
+        self.Api.otNodeAddRoute.argtypes = [ctypes.c_void_p,
+                                            ctypes.c_char_p,
                                             ctypes.c_char_p]
 
-        self.Api.otNodeRemoveRoute.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeRemoveRoute.argtypes = [ctypes.c_void_p,
                                                ctypes.c_char_p]
 
         self.Api.otNodeRegisterNetdata.argtypes = [ctypes.c_void_p]
 
-        self.Api.otNodeEnergyScan.argtypes = [ctypes.c_void_p, 
-                                              ctypes.c_uint, 
-                                              ctypes.c_ubyte, 
-                                              ctypes.c_ushort, 
-                                              ctypes.c_ushort, 
+        self.Api.otNodeEnergyScan.argtypes = [ctypes.c_void_p,
+                                              ctypes.c_uint,
+                                              ctypes.c_ubyte,
+                                              ctypes.c_ushort,
+                                              ctypes.c_ushort,
                                               ctypes.c_char_p]
 
-        self.Api.otNodePanIdQuery.argtypes = [ctypes.c_void_p, 
-                                              ctypes.c_ushort, 
-                                              ctypes.c_uint, 
+        self.Api.otNodePanIdQuery.argtypes = [ctypes.c_void_p,
+                                              ctypes.c_ushort,
+                                              ctypes.c_uint,
                                               ctypes.c_char_p]
 
         self.Api.otNodeScan.argtypes = [ctypes.c_void_p]
         self.Api.otNodeScan.restype = ctypes.c_char_p
 
-        self.Api.otNodePing.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodePing.argtypes = [ctypes.c_void_p,
                                         ctypes.c_char_p,
                                         ctypes.c_ushort,
                                         ctypes.c_uint,
                                         ctypes.c_uint16]
         self.Api.otNodePing.restype = ctypes.c_uint
 
-        self.Api.otNodeSetRouterSelectionJitter.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeSetRouterSelectionJitter.argtypes = [ctypes.c_void_p,
                                                             ctypes.c_ubyte]
 
         self.Api.otNodeCommissionerAnnounceBegin.argtypes = [ctypes.c_void_p,
@@ -593,9 +593,9 @@ class otApi:
                                                  ctypes.c_char_p,
                                                  ctypes.c_char_p]
 
-        self.Api.otNodeSetMaxChildren.argtypes = [ctypes.c_void_p, 
+        self.Api.otNodeSetMaxChildren.argtypes = [ctypes.c_void_p,
                                                   ctypes.c_ubyte]
-        
+
         # Initialize a new node
         self.otNode = self.Api.otNodeInit(ctypes.c_uint(nodeid))
         if self.otNode == None:

--- a/tests/scripts/thread-cert/node_cli.py
+++ b/tests/scripts/thread-cert/node_cli.py
@@ -31,6 +31,7 @@ import os
 import sys
 import time
 import pexpect
+import pexpect.popen_spawn
 import re
 import socket
 import ipaddress
@@ -78,7 +79,7 @@ class otCli:
         cmd += ' %d' % nodeid
         print ("%s" % cmd)
 
-        self.pexpect = pexpect.spawn(cmd, timeout=4)
+        self.pexpect = pexpect.popen_spawn.PopenSpawn(cmd, timeout=4)
 
         # Add delay to ensure that the process is ready to receive commands.
         timeout = 0.4
@@ -141,11 +142,14 @@ class otCli:
         self.destroy()
 
     def destroy(self):
-        if self.pexpect and self.pexpect.isalive():
+        if not self.pexpect:
+            return
+
+        if hasattr(self.pexpect, 'proc') and self.pexpect.proc.poll() is None or \
+                not hasattr(self.pexpect, 'proc') and self.pexpect.isalive():
             print("%d: exit" % self.nodeid)
             self.pexpect.send('exit\n')
             self.pexpect.expect(pexpect.EOF)
-            self.pexpect.terminate()
             self.pexpect = None
 
     def send_command(self, cmd, go=True):


### PR DESCRIPTION
OpenThread UART configures stdin and stdout if it's tty device. However this may cause issues when use OpenThread working as a component together with other components which also uses stdin and stdout. For example, other components may print newline with single `\n`.

This PR leaves stdin and stdout as is and provides a configure option so that UART CLI does not echo inputs.