### PR TITLE
[posix-app] discard received HDLC frame on error

### DIFF
--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -499,6 +499,7 @@ void HdlcInterface::HandleHdlcFrame(otError aError)
     }
     else
     {
+        mRxFrameBuffer.DiscardFrame();
         otLogWarnPlat("Error decoding hdlc frame: %s", otThreadErrorToString(aError));
     }
 }


### PR DESCRIPTION
This commit changes the `HdlcInterface::HandleHdlcFrame()` callback
which handles a received and decoded HDLC frame such that it
discards a bad/incorrect frame from the multi frame buffer (i.e,
discard the frame on any error).