### PR TITLE
[hdlc] report frames smaller than FCS size as error frame

### DIFF
--- a/src/ncp/hdlc.cpp
+++ b/src/ncp/hdlc.cpp
@@ -69,6 +69,7 @@ enum
 {
     kInitFcs = 0xffff, ///< Initial FCS value.
     kGoodFcs = 0xf0b8, ///< Good FCS value.
+    kFcsSize = 2,      ///< FCS size (number of bytes).
 };
 
 uint16_t UpdateFcs(uint16_t aFcs, uint8_t aByte)
@@ -237,19 +238,15 @@ void Decoder::Decode(const uint8_t *aData, uint16_t aLength)
 
             case kFlagSequence:
 
-                // Ignore frames which are smaller than the size of the FCS.
-                if (mDecodedLength > sizeof(uint16_t))
+                if (mDecodedLength > 0)
                 {
-                    otError error = OT_ERROR_NONE;
+                    otError error = OT_ERROR_PARSE;
 
-                    if (mFcs == kGoodFcs)
+                    if ((mDecodedLength >= kFcsSize) && (mFcs == kGoodFcs))
                     {
                         // Remove the FCS from the frame.
-                        mWritePointer.UndoLastWrites(sizeof(uint16_t));
-                    }
-                    else
-                    {
-                        error = OT_ERROR_PARSE;
+                        mWritePointer.UndoLastWrites(kFcsSize);
+                        error = OT_ERROR_NONE;
                     }
 
                     mFrameHandler(mContext, error);


### PR DESCRIPTION
This commit changes the `Hdlc::Decoder` implementation to report
non-zero length received frames shorter than FCS size as an error
`OT_ERROR_PARSE` (instead of ignoring such frames during decoding).
Since the recent changes in `Hdlc::Decoder` buffer model delegates
the management of the frame buffer to the user of `Decoder`,
clearing frame buffer after an error should be be performed by the
`Decoder` user from the `FrameHandler` callback. The change in this
commit addresses an issue where a small (single-byte) frame would
not have been cleared from the decoder buffer and included in the
next frame. This commit also updates the `test_hdlc` unit test to
cover small frame error.