### PR TITLE
[udp] call at most one handler

### DIFF
--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -415,6 +415,7 @@ void Udp::HandlePayload(Message &aMessage, MessageInfo &aMessageInfo)
         }
 
         socket->HandleUdpReceive(aMessage, aMessageInfo);
+        break;
     }
 }
 


### PR DESCRIPTION
I'm not sure if we are allowing a UDP packet to be handled by multiple handlers.
Currently otUdpSocket::mHandler is of the following prototype:
```cpp
typedef void (*otUdpReceive)(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
```
which means the handler can modify the message. This PR makes it clear that a packet will have at most one handler.

I came up with this concern because a message's offset is modified by UDP handlers, if we allow a second handler, this modified offset may result in parse errors.