### PR TITLE
[message] allocate message with corresponding component

### DIFF
--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -211,7 +211,7 @@ otMessage *otIp6NewMessage(otInstance *aInstance, const otMessageSettings *aSett
         VerifyOrExit(aSettings->mPriority <= OT_MESSAGE_PRIORITY_HIGH, message = NULL);
     }
 
-    message = instance.GetMessagePool().New(Message::kTypeIp6, 0, aSettings);
+    message = instance.GetIp6().NewMessage(0, aSettings);
 
 exit:
     return message;

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -50,7 +50,7 @@ otMessage *otUdpNewMessage(otInstance *aInstance, const otMessageSettings *aSett
         VerifyOrExit(aSettings->mPriority <= OT_MESSAGE_PRIORITY_HIGH, message = NULL);
     }
 
-    message = instance.GetMessagePool().New(Message::kTypeIp6, 0, aSettings);
+    message = instance.GetIp6().GetUdp().NewMessage(0, aSettings);
 
 exit:
     return message;


### PR DESCRIPTION
This PR changes the API of allocating messages, so that a allocated message will have properly reserved memory for headers. This can help reduce memory copy in `Message::Prepend()` for adding UDP and IP headers.