### PR TITLE
[mac] remove redundant checks

### DIFF
--- a/src/core/mac/channel_mask.hpp
+++ b/src/core/mac/channel_mask.hpp
@@ -36,6 +36,7 @@
 
 #include "openthread-core-config.h"
 
+#include <limits.h>
 #include <openthread/platform/radio.h>
 
 #include "common/string.hpp"
@@ -140,7 +141,10 @@ public:
      * @returns TRUE if the channel @p aChannel is included in the mask, FALSE otherwise.
      *
      */
-    bool ContainsChannel(uint8_t aChannel) const { return ((1UL << aChannel) & mMask) != 0; }
+    bool ContainsChannel(uint8_t aChannel) const
+    {
+        return (aChannel < sizeof(mMask) * CHAR_BIT) ? ((1U << aChannel) & mMask) != 0 : false;
+    }
 
     /**
      * This method adds a channel to the channel mask.
@@ -148,7 +152,13 @@ public:
      * @param[in]  aChannel  A channel
      *
      */
-    void AddChannel(uint8_t aChannel) { mMask |= (1UL << aChannel); }
+    void AddChannel(uint8_t aChannel)
+    {
+        if (aChannel < sizeof(mMask) * CHAR_BIT)
+        {
+            mMask |= (1UL << aChannel); }
+        }
+    }
 
     /**
      * This method removes a channel from the channel mask.
@@ -156,7 +166,13 @@ public:
      * @param[in]  aChannel  A channel
      *
      */
-    void RemoveChannel(uint8_t aChannel) { mMask &= ~(1UL << aChannel); }
+    void RemoveChannel(uint8_t aChannel)
+    {
+       if (aChannel < sizeof(mMask) * CHAR_BIT)
+       {
+          mMask &= ~(1UL << aChannel);
+       }
+    }
 
     /**
      * This method updates the channel mask by intersecting it with another mask.

--- a/src/core/mac/channel_mask.hpp
+++ b/src/core/mac/channel_mask.hpp
@@ -143,7 +143,7 @@ public:
      */
     bool ContainsChannel(uint8_t aChannel) const
     {
-        return (aChannel < sizeof(mMask) * CHAR_BIT) ? ((1U << aChannel) & mMask) != 0 : false;
+        return (aChannel < sizeof(mMask) * CHAR_BIT) ? ((1UL << aChannel) & mMask) != 0 : false;
     }
 
     /**
@@ -156,7 +156,7 @@ public:
     {
         if (aChannel < sizeof(mMask) * CHAR_BIT)
         {
-            mMask |= (1UL << aChannel); }
+            mMask |= (1UL << aChannel);
         }
     }
 
@@ -168,10 +168,10 @@ public:
      */
     void RemoveChannel(uint8_t aChannel)
     {
-       if (aChannel < sizeof(mMask) * CHAR_BIT)
-       {
-          mMask &= ~(1UL << aChannel);
-       }
+        if (aChannel < sizeof(mMask) * CHAR_BIT)
+        {
+            mMask &= ~(1UL << aChannel);
+        }
     }
 
     /**

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -355,7 +355,6 @@ otError Mac::SetPanChannel(uint8_t aChannel)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(OT_RADIO_CHANNEL_MIN <= aChannel && aChannel <= OT_RADIO_CHANNEL_MAX, error = OT_ERROR_INVALID_ARGS);
     VerifyOrExit(mSupportedChannelMask.ContainsChannel(aChannel), error = OT_ERROR_INVALID_ARGS);
 
     VerifyOrExit(mPanChannel != aChannel, GetNotifier().SignalIfFirst(OT_CHANGED_THREAD_CHANNEL));
@@ -379,7 +378,6 @@ otError Mac::SetRadioChannel(uint16_t aAcquisitionId, uint8_t aChannel)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(OT_RADIO_CHANNEL_MIN <= aChannel && aChannel <= OT_RADIO_CHANNEL_MAX, error = OT_ERROR_INVALID_ARGS);
     VerifyOrExit(mSupportedChannelMask.ContainsChannel(aChannel), error = OT_ERROR_INVALID_ARGS);
 
     VerifyOrExit(mRadioChannelAcquisitionId && aAcquisitionId == mRadioChannelAcquisitionId,


### PR DESCRIPTION
The range of `mSupportedChannelMask` is less than or equal to the range between `OT_RADIO_CHANNEL_MIN` and `OT_RADIO_CHANNEL_MAX`. There is no need to do double checks.