### PR TITLE
[mbedtls] free mbedtls on initialization failure

### DIFF
--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -316,6 +316,14 @@ public:
     ProvisioningUrlTlv mProvisioningUrl;
 
 private:
+    enum MbedtlsFreeStage
+    {
+        kFreeNone   = 0, // Nonthing to free
+        kFreeCommon = 1, // Free data used by both server and client
+        kFreeClient = 2, // Free data used by client
+    };
+    void FreeMbedtls(MbedtlsFreeStage aType);
+
     static otError MapError(int rval);
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -316,13 +316,7 @@ public:
     ProvisioningUrlTlv mProvisioningUrl;
 
 private:
-    enum MbedtlsFreeStage
-    {
-        kFreeNone   = 0, // Nonthing to free
-        kFreeCommon = 1, // Free data used by both server and client
-        kFreeClient = 2, // Free data used by client
-    };
-    void FreeMbedtls(MbedtlsFreeStage aType);
+    void FreeMbedtls(void);
 
     static otError MapError(int rval);
 


### PR DESCRIPTION
`Dtls::Start` might fails for various reasons, data allocated when trying
initializing mbedtls are not freed. This PR addresses this issue.

This PR also moves initialization of pk and x509 certificate which is freed in `Dtls::Close()` from constructor to `Dtls::Start()`.