### PR TITLE
[mle] avoid "1U << 32" when calculating attach start delay backoff

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -669,7 +669,7 @@ uint32_t Mle::GetAttachStartDelay(void) const
         uint16_t       counter = mAttachCounter - 1;
         const uint32_t ratio   = kAttachBackoffMaxInterval / kAttachBackoffMinInterval;
 
-        if ((counter <= sizeof(ratio) * CHAR_BIT) && ((1U << counter) <= ratio))
+        if ((counter < sizeof(ratio) * CHAR_BIT) && ((1UL << counter) <= ratio))
         {
             delay = kAttachBackoffMinInterval;
             delay <<= counter;


### PR DESCRIPTION
This change avoids the use of (potentially) undefined "1U << 32"
when calculating the backoff delay for attach re-attempt in MLE.
Credit for this bug goes to Coverity.