### PR TITLE
[core] use `1UL` instead of `1U` when working with `uint32_t`

### DIFF
--- a/src/core/mac/channel_mask.hpp
+++ b/src/core/mac/channel_mask.hpp
@@ -140,7 +140,7 @@ public:
      * @returns TRUE if the channel @p aChannel is included in the mask, FALSE otherwise.
      *
      */
-    bool ContainsChannel(uint8_t aChannel) const { return ((1U << aChannel) & mMask) != 0; }
+    bool ContainsChannel(uint8_t aChannel) const { return ((1UL << aChannel) & mMask) != 0; }
 
     /**
      * This method adds a channel to the channel mask.
@@ -148,7 +148,7 @@ public:
      * @param[in]  aChannel  A channel
      *
      */
-    void AddChannel(uint8_t aChannel) { mMask |= (1U << aChannel); }
+    void AddChannel(uint8_t aChannel) { mMask |= (1UL << aChannel); }
 
     /**
      * This method removes a channel from the channel mask.
@@ -156,7 +156,7 @@ public:
      * @param[in]  aChannel  A channel
      *
      */
-    void RemoveChannel(uint8_t aChannel) { mMask &= ~(1U << aChannel); }
+    void RemoveChannel(uint8_t aChannel) { mMask &= ~(1UL << aChannel); }
 
     /**
      * This method updates the channel mask by intersecting it with another mask.

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -246,7 +246,7 @@ void SubMac::StartCsmaBackoff(void)
         backoffExponent = kMaxBE;
     }
 
-    backoff = Random::GetUint32InRange(0, 1U << backoffExponent);
+    backoff = Random::GetUint32InRange(0, static_cast<uint32_t>(1UL << backoffExponent));
     backoff *= (static_cast<uint32_t>(kUnitBackoffPeriod) * OT_RADIO_SYMBOL_TIME);
 
     if (mRxOnWhenBackoff)

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1471,7 +1471,7 @@ otError NcpBase::DecodeChannelMask(uint32_t &aChannelMask)
     {
         SuccessOrExit(error = mDecoder.ReadUint8(channel));
         VerifyOrExit(channel <= 31, error = OT_ERROR_INVALID_ARGS);
-        aChannelMask |= (1U << channel);
+        aChannelMask |= (1UL << channel);
     }
 
 exit:

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -1171,7 +1171,7 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,
                 {
                     SuccessOrExit(error = mDecoder.ReadUint8(channel));
                     VerifyOrExit(channel <= 31, error = OT_ERROR_INVALID_ARGS);
-                    aDataset.mChannelMaskPage0 |= (1U << channel);
+                    aDataset.mChannelMaskPage0 |= (1UL << channel);
                 }
             }
 


### PR DESCRIPTION
This commit replaces `1U` constants with `1UL` in bit shift
statements like `1U << shift` when dealing with a variable shift
value that can be larger than 15. This helps make it explicit to the
compiler that the constant should be considered as a `uint32_t`.

-----

I think practically all compilers will correctly use `uint32_t` bitshift in all usages in OT code (i.e, determine the size from the statement context) but it's better/safer to be explicit about it. 

`1U` constant can be treated as `unsigned int` and C++ standard [requires minimum of 16 bits](https://en.cppreference.com/w/cpp/language/types) for `unsigned int` type 

