### PR TITLE
[udp6] init member variable from constructor

### DIFF
--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -200,6 +200,10 @@ Udp::Udp(Instance &aInstance)
     , mEphemeralPort(kDynamicPortMin)
     , mReceivers(NULL)
     , mSockets(NULL)
+#if OPENTHREAD_ENABLE_UDP_FORWARD
+    , mUdpForwarderContext(NULL)
+    , mUdpForwarder(NULL)
+#endif
 {
 }
 


### PR DESCRIPTION
This commit initializes `mUdpForwarder` and `mUdpForwarderContext`
from `Udp::Udp` class constructor. Credit to coverity