### PR TITLE
[socket] use "this" pointer in memset while initialization SockAddr

### DIFF
--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -193,7 +193,7 @@ public:
      * This constructor initializes the object.
      *
      */
-    SockAddr(void) { memset(&mAddress, 0, sizeof(*this)); }
+    SockAddr(void) { memset(this, 0, sizeof(*this)); }
 
     /**
      * This method returns a reference to the IPv6 address.


### PR DESCRIPTION
This change helps address a coverity warning (about memory overrun).