### PR TITLE
[border-agent] check read UdpEncapsulationTlv length

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -335,7 +335,7 @@ void BorderAgent::HandleProxyTransmit(const Coap::Header &aHeader, const Message
         UdpEncapsulationTlv tlv;
 
         SuccessOrExit(error = Tlv::GetOffset(aMessage, Tlv::kUdpEncapsulation, offset));
-        aMessage.Read(offset, sizeof(tlv), &tlv);
+        VerifyOrExit(aMessage.Read(offset, sizeof(tlv), &tlv) == sizeof(tlv), error = OT_ERROR_PARSE);
 
         VerifyOrExit((message = GetInstance().GetIp6().GetUdp().NewMessage(0)) != NULL, error = OT_ERROR_NO_BUFS);
         SuccessOrExit(error = message->SetLength(tlv.GetUdpLength()));


### PR DESCRIPTION
This commit verifies that the read length of `UdpEncapsulationTlv`
from a message is valid before processing it. Credit to Coverity.