### PR TITLE
[ncp-base] add IgnoreReturnValue when error should be ignored

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1651,7 +1651,8 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
-        WritePropertyValueIsFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_PROP_UNSOL_UPDATE_FILTER);
+        IgnoreReturnValue(
+            WritePropertyValueIsFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_PROP_UNSOL_UPDATE_FILTER));
     }
 
     return error;


### PR DESCRIPTION
This change adds `IgnoreReturnValue` when the returned error can be
safely ignored. This should help address a Coverity warning.