### PR TITLE
[settings-flash] use #if to avoid unreachable code errors

### DIFF
--- a/examples/platforms/utils/settings_flash.c
+++ b/examples/platforms/utils/settings_flash.c
@@ -97,6 +97,10 @@ struct settingsBlock
 #define SETTINGS_CONFIG_PAGE_NUM 2
 #endif // SETTINGS_CONFIG_PAGE_NUM
 
+#if (SETTINGS_CONFIG_PAGE_NUM <= 1)
+#error "Invalid value for `SETTINGS_CONFIG_PAGE_NUM` (should be >= 2)"
+#endif
+
 static uint32_t sSettingsBaseAddress;
 static uint32_t sSettingsUsedSize;
 
@@ -113,8 +117,7 @@ static void setSettingsFlag(uint32_t aBase, uint32_t aFlag)
 static void initSettings(uint32_t aBase, uint32_t aFlag)
 {
     uint32_t address      = aBase;
-    uint32_t settingsSize = SETTINGS_CONFIG_PAGE_NUM > 1 ? SETTINGS_CONFIG_PAGE_SIZE * SETTINGS_CONFIG_PAGE_NUM / 2
-                                                         : SETTINGS_CONFIG_PAGE_SIZE;
+    uint32_t settingsSize = SETTINGS_CONFIG_PAGE_SIZE * SETTINGS_CONFIG_PAGE_NUM / 2;
 
     while (address < (aBase + settingsSize))
     {
@@ -133,10 +136,7 @@ static uint32_t swapSettingsBlock(otInstance *aInstance)
     uint32_t oldBase      = sSettingsBaseAddress;
     uint32_t swapAddress  = oldBase;
     uint32_t usedSize     = sSettingsUsedSize;
-    uint8_t  pageNum      = SETTINGS_CONFIG_PAGE_NUM;
-    uint32_t settingsSize = pageNum > 1 ? SETTINGS_CONFIG_PAGE_SIZE * pageNum / 2 : SETTINGS_CONFIG_PAGE_SIZE;
-
-    otEXPECT(pageNum > 1);
+    uint32_t settingsSize = SETTINGS_CONFIG_PAGE_SIZE * SETTINGS_CONFIG_PAGE_NUM / 2;
 
     sSettingsBaseAddress =
         (swapAddress == SETTINGS_CONFIG_BASE_ADDRESS) ? (swapAddress + settingsSize) : SETTINGS_CONFIG_BASE_ADDRESS;
@@ -198,7 +198,6 @@ static uint32_t swapSettingsBlock(otInstance *aInstance)
     setSettingsFlag(sSettingsBaseAddress, (uint32_t)OT_SETTINGS_IN_USE);
     setSettingsFlag(oldBase, (uint32_t)OT_SETTINGS_NOT_USED);
 
-exit:
     return settingsSize - sSettingsUsedSize;
 }
 
@@ -215,8 +214,7 @@ static otError addSetting(otInstance *   aInstance,
         struct settingsBlock block;
         uint8_t              data[OT_SETTINGS_BLOCK_DATA_SIZE];
     } OT_TOOL_PACKED_END addBlock;
-    uint32_t settingsSize = SETTINGS_CONFIG_PAGE_NUM > 1 ? SETTINGS_CONFIG_PAGE_SIZE * SETTINGS_CONFIG_PAGE_NUM / 2
-                                                         : SETTINGS_CONFIG_PAGE_SIZE;
+    uint32_t             settingsSize = SETTINGS_CONFIG_PAGE_SIZE * SETTINGS_CONFIG_PAGE_NUM / 2;
 
     addBlock.block.flag = 0xff;
     addBlock.block.key  = aKey;
@@ -260,8 +258,7 @@ void otPlatSettingsInit(otInstance *aInstance)
     OT_UNUSED_VARIABLE(aInstance);
 
     uint8_t  index;
-    uint32_t settingsSize = SETTINGS_CONFIG_PAGE_NUM > 1 ? SETTINGS_CONFIG_PAGE_SIZE * SETTINGS_CONFIG_PAGE_NUM / 2
-                                                         : SETTINGS_CONFIG_PAGE_SIZE;
+    uint32_t settingsSize = SETTINGS_CONFIG_PAGE_SIZE * SETTINGS_CONFIG_PAGE_NUM / 2;
 
     sSettingsBaseAddress = SETTINGS_CONFIG_BASE_ADDRESS;
 


### PR DESCRIPTION
This commit uses `#if (SETTINGS_CONFIG_PAGE_NUM > 1)` instead of
run-time check in `utils/settings_flash.c`. This helps simplify the
code and also address Coverity warnings for unreachable code.