### PR TITLE
[mac] post operation task on rx-on-idle mode change

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -329,7 +329,7 @@ void Mac::SetRxOnWhenIdle(bool aRxOnWhenIdle)
         {
             mTimer.Stop();
             FinishOperation();
-            PerformNextOperation();
+            mOperationTask.Post();
         }
 
 #if OPENTHREAD_CONFIG_STAY_AWAKE_BETWEEN_FRAGMENTS
@@ -1234,14 +1234,20 @@ void Mac::HandleTimer(void)
         PerformNextOperation();
         break;
 
-    default:
 #if OPENTHREAD_CONFIG_STAY_AWAKE_BETWEEN_FRAGMENTS
-        otLogDebgMac("Sleep delay timeout expired");
-        mDelayingSleep = false;
-        UpdateIdleMode();
-#else
-        assert(false);
+    case kOperationIdle:
+        if (mDelayingSleep)
+        {
+            otLogDebgMac("Sleep delay timeout expired");
+            mDelayingSleep = false;
+            UpdateIdleMode();
+        }
+
+        break;
 #endif
+
+    default:
+        assert(false);
         break;
     }
 }


### PR DESCRIPTION
The `SetRxOnWhenIdle()` is changed such that if it needs to stop
operation `WaitingForData`, the next operation gets started from
the `mOperationTask` tasklet. This change makes the behavior of
the `SetRxOnWhenIdle()`  consistent with other MAC APIs (i.e.,
new operations are started only from tasklet or from a radio/timer
callback and not from any MAC APIs). This commit also updates the
`HandleTimer()` to check for operation being `kOperationIdle` when
timer is used for delaying sleep.