### PR TITLE
[mac] stop timer on pending WaitingForData operation on rx-on-idle change

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -323,7 +323,11 @@ void Mac::SetRxOnWhenIdle(bool aRxOnWhenIdle)
 
     if (mRxOnWhenIdle)
     {
-        mPendingWaitingForData = false;
+        if (mPendingWaitingForData)
+        {
+            mTimer.Stop();
+            mPendingWaitingForData = false;
+        }
 
         if (mOperation == kOperationWaitingForData)
         {


### PR DESCRIPTION
This commit changes `SetRxOnWhenIdle()` to stop the timer (data poll
timeout) if there is a pending `kOperationWaitingForData` when rx-on-
when-idle is being enabled. This addresses an issue where the timer
could remain active if the `SetRxOnwhenIdle(true)` is called before
the operation `kOperationWaitingForData` actually starts. Note that
the data poll timeout timer gets started while current operation is
`kOperationTransmitData` (from `HandleTransmitDone()` on a successful
data request frame transmission with a received ack indicating a
pending frame).