### PR TITLE
[mac] simplify the check for frame pending in data request ack

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1166,14 +1166,8 @@ void Mac::HandleTransmitDone(Frame &aFrame, Frame *aAckFrame, otError aError)
     case kOperationTransmitData:
         if (aFrame.IsDataRequestCommand())
         {
-            bool framePending = false;
-
-            if ((aError == OT_ERROR_NONE) && aFrame.GetAckRequest() && (aAckFrame != NULL))
-            {
-                framePending = aAckFrame->GetFramePending();
-            }
-
-            if (mEnabled && framePending)
+            if (mEnabled && (aError == OT_ERROR_NONE) && aFrame.GetAckRequest() && (aAckFrame != NULL) &&
+                aAckFrame->GetFramePending())
             {
                 mTimer.Start(kDataPollTimeout);
                 StartOperation(kOperationWaitingForData);


### PR DESCRIPTION
---
This commit contains no logic change. It removes the `bool framePending` variable (which is used only once in subsequent `if`) and combines the two `if`s into a single one.