### PR TITLE
[router-table] add check in ProcessTlv() before removing neighbor

### DIFF
--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -556,11 +556,14 @@ void RouterTable::ProcessTlv(const Mle::RouteTlv &aTlv)
         }
         else
         {
-            Router *router = GetRouter(i);
+            if (IsAllocated(i))
+            {
+                Router *router = GetRouter(i);
 
-            assert(router != NULL);
-            router->SetNextHop(Mle::kInvalidRouterId);
-            RemoveNeighbor(*router);
+                assert(router != NULL);
+                router->SetNextHop(Mle::kInvalidRouterId);
+                RemoveNeighbor(*router);
+            }
 
             mAllocatedRouterIds[i / 8] &= ~(1 << (i % 8));
         }


### PR DESCRIPTION
This commit avoids triggering an assert when a router is removed by the
leader.