### PR TITLE
[dhcp6] use EUI-64 in Client and Server Identifier

### DIFF
--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -460,11 +460,14 @@ otError Dhcp6Server::AppendServerIdentifier(Message &aMessage)
 {
     otError          error = OT_ERROR_NONE;
     ServerIdentifier option;
+    Mac::ExtAddress  eui64;
+
+    otPlatRadioGetIeeeEui64(&GetInstance(), eui64.m8);
 
     option.Init();
     option.SetDuidType(kDuidLL);
     option.SetDuidHardwareType(kHardwareTypeEui64);
-    option.SetDuidLinkLayerAddress(GetNetif().GetMac().GetExtAddress());
+    option.SetDuidLinkLayerAddress(eui64);
     SuccessOrExit(error = aMessage.Append(&option, sizeof(option)));
 
 exit:


### PR DESCRIPTION
Resolves #3442.