### PR TITLE
[nrf52840] do not include libjlinkrtt in the SDK version of OT libs

### DIFF
--- a/examples/platforms/nrf52840/Makefile.am
+++ b/examples/platforms/nrf52840/Makefile.am
@@ -394,11 +394,8 @@ libopenthread_nrf52840_a_LIBADD                                                 
     $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o")
 
 libopenthread_nrf52840_sdk_a_LIBADD                                                                        = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")                   \
-    $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o")
+    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
 
 libopenthread_nrf52840_softdevice_sdk_a_LIBADD                                                             = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")                   \
-    $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o")
-
+    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am


### PR DESCRIPTION
This PR fixes the issue with multiple jlink RTT libs being linked by the SDK examples.

Signed-off-by: Szkotak, Piotr <Piotr.Szkotak@nordicsemi.no>