### PR TITLE
[docs] fix invalid TODO comment

### DIFF
--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -846,7 +846,7 @@ otError MeshForwarder::UpdateIp6RouteFtd(Ip6::Header &ip6Header)
 #endif
         else
         {
-            // TODO: support ALOC for Commissioner, Neighbor Discovery Agent
+            // TODO: support for Neighbor Discovery Agent ALOC
             ExitNow(error = OT_ERROR_DROP);
         }
     }


### PR DESCRIPTION
nit: This PR only removes invalid information about support of Commissioner ALOC. This support has been implemented in #2926 