### PR TITLE
[network-data] use enumeration Type for local vs leader

### DIFF
--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -50,9 +50,9 @@
 namespace ot {
 namespace NetworkData {
 
-NetworkData::NetworkData(Instance &aInstance, bool aLocal)
+NetworkData::NetworkData(Instance &aInstance, Type aType)
     : InstanceLocator(aInstance)
-    , mLocal(aLocal)
+    , mType(aType)
     , mLastAttemptWait(false)
     , mLastAttempt(0)
 {
@@ -1013,7 +1013,7 @@ otError NetworkData::SendServerDataNotification(uint16_t aRloc16)
 
     VerifyOrExit((message = netif.GetCoap().NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
 
-    if (mLocal)
+    if (mType == kTypeLocal)
     {
         ThreadTlv tlv;
         tlv.SetType(ThreadTlv::kThreadNetworkData);
@@ -1035,7 +1035,7 @@ otError NetworkData::SendServerDataNotification(uint16_t aRloc16)
     messageInfo.SetPeerPort(kCoapUdpPort);
     SuccessOrExit(error = netif.GetCoap().SendMessage(*message, messageInfo));
 
-    if (mLocal)
+    if (mType == kTypeLocal)
     {
         mLastAttempt     = TimerMilli::GetNow();
         mLastAttemptWait = true;

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -96,13 +96,23 @@ public:
     };
 
     /**
+     * This enumeration specifies the type of Network Data (local or leader).
+     *
+     */
+    enum Type
+    {
+        kTypeLocal,  ///< Local Network Data.
+        kTypeLeader, ///< Leader Network Data.
+    };
+
+    /**
      * This constructor initializes the object.
      *
      * @param[in]  aInstance     A reference to the OpenThread instance.
-     * @param[in]  aLocal        TRUE if this represents local network data, FALSE otherwise.
+     * @param[in]  aType         Network data type
      *
      */
-    NetworkData(Instance &aInstance, bool aLocal);
+    NetworkData(Instance &aInstance, Type aType);
 
     /**
      * This method clears the network data.
@@ -510,7 +520,7 @@ private:
         uint8_t *mIteratorBuffer;
     };
 
-    const bool mLocal;
+    const Type mType;
     bool       mLastAttemptWait;
     uint32_t   mLastAttempt;
 };

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -58,7 +58,7 @@ namespace ot {
 namespace NetworkData {
 
 LeaderBase::LeaderBase(Instance &aInstance)
-    : NetworkData(aInstance, false)
+    : NetworkData(aInstance, kTypeLeader)
 {
     Reset();
 }

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -46,7 +46,7 @@ namespace ot {
 namespace NetworkData {
 
 Local::Local(Instance &aInstance)
-    : NetworkData(aInstance, true)
+    : NetworkData(aInstance, kTypeLocal)
     , mOldRloc(Mac::kShortAddrInvalid)
 {
 }

--- a/tests/unit/test_network_data.cpp
+++ b/tests/unit/test_network_data.cpp
@@ -41,7 +41,7 @@ class TestNetworkData : public NetworkData::NetworkData
 {
 public:
     TestNetworkData(ot::Instance *aInstance, const uint8_t *aTlvs, uint8_t aTlvsLength)
-        : NetworkData::NetworkData(*aInstance, false)
+        : NetworkData::NetworkData(*aInstance, kTypeLeader)
     {
         memcpy(mTlvs, aTlvs, aTlvsLength);
         mLength = aTlvsLength;


### PR DESCRIPTION
This commit changes `NetworkData` to use an enumeration `Type` to
specify whether a `NetworkData` instance represents local network
data or leader network data.