### PR TITLE
[code-utils] fix wrong pointer size in otALIGN

### DIFF
--- a/src/core/common/code_utils.hpp
+++ b/src/core/common/code_utils.hpp
@@ -57,7 +57,8 @@
  * @returns The aligned pointer.
  *
  */
-#define otALIGN(aPointer, aAlignment) ((void *)(((uintptr_t)(aPointer) + (aAlignment)-1U) & ~((aAlignment)-1U)))
+#define otALIGN(aPointer, aAlignment) \
+    ((void *)(((uintptr_t)(aPointer) + (aAlignment)-1UL) & ~((uintptr_t)(aAlignment)-1UL)))
 
 // Calculates the aligned variable size.
 #define otALIGNED_VAR_SIZE(size, align_type) (((size) + (sizeof(align_type) - 1)) / sizeof(align_type))


### PR DESCRIPTION
On macOS and my docker environment, otALIGN() does not behave as
expected, because `~(aAlignment - 1)` is not of the pointer size.
This PR force converts it to pointer size.

This bug is introduced in #3419 