### PR TITLE
[mle] simplify Start()

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -447,7 +447,7 @@ otError otThreadSetEnabled(otInstance *aInstance, bool aEnabled)
     {
         VerifyOrExit(instance.GetThreadNetif().GetMac().GetPanId() != Mac::kPanIdBroadcast,
                      error = OT_ERROR_INVALID_STATE);
-        error = instance.GetThreadNetif().GetMle().Start(true, false);
+        error = instance.GetThreadNetif().GetMle().Start(/* aAnnounceAttach */ false);
     }
     else
     {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -236,7 +236,7 @@ exit:
     return error;
 }
 
-otError Mle::Start(bool aEnableReattach, bool aAnnounceAttach)
+otError Mle::Start(bool aAnnounceAttach)
 {
     ThreadNetif &netif = GetNetif();
     otError      error = OT_ERROR_NONE;
@@ -253,7 +253,7 @@ otError Mle::Start(bool aEnableReattach, bool aAnnounceAttach)
 
     netif.GetKeyManager().Start();
 
-    if (aEnableReattach)
+    if (!aAnnounceAttach)
     {
         mReattachState = kReattachStart;
     }
@@ -3654,7 +3654,7 @@ void Mle::ProcessAnnounce(void)
     mac.SetPanChannel(newChannel);
     mac.SetPanId(newPanId);
 
-    Start(/* aEnableReattach */ false, /* aAnnounceAttach */ true);
+    Start(/* aAnnounceAttach */ true);
 }
 
 otError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -495,7 +495,6 @@ public:
     /**
      * This method starts the MLE protocol operation.
      *
-     * @param[in]  aEnableReattach True if reattach using stored dataset, or False if not.
      * @param[in]  aAnnounceAttach True if attach on the announced thread network with newer active timestamp,
      *                             or False if not.
      *
@@ -503,7 +502,7 @@ public:
      * @retval OT_ERROR_ALREADY  The protocol operation was already started.
      *
      */
-    otError Start(bool aEnableReattach, bool aAnnounceAttach);
+    otError Start(bool aAnnounceAttach);
 
     /**
      * This method stops the MLE protocol operation.


### PR DESCRIPTION
This commit simplifies the `Mle::Start()` by combining its parameters.
With the new definition `Start()` would always try to reattach using
any saved active/pending dataset unless it is asked to attach on an
announced network (i.e., `aAnnounceAttach` is `true`).

----

In current code `Start()`  has two `bool` parameters: `Start(bool aEnableReattach, bool aAnnounceAttach)`.  But in our usage of this API the two parameters seems to be related (and always opposite of each other). This API is used from two places in code. 
- From `otThreadSetEnabled` used as `Start(true, false)`
- From `ProcessAnnounce()` used as `Start(false, true`).
