### PR TITLE
[cli] rename sources to reduce confusion

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -281,10 +281,10 @@ LOCAL_LDLIBS                               := \
 LOCAL_SRC_FILES                            := \
     src/cli/cli.cpp                           \
     src/cli/cli_coap.cpp                      \
-    src/cli/cli_console.cpp                   \
     src/cli/cli_dataset.cpp                   \
-    src/cli/cli_uart.cpp                      \
     src/cli/cli_udp_example.cpp               \
+    src/cli/console.cpp                       \
+    src/cli/uart.cpp                          \
     src/posix/main.c                          \
     $(NULL)
 

--- a/etc/visual-studio/libopenthread-cli-windows.vcxproj
+++ b/etc/visual-studio/libopenthread-cli-windows.vcxproj
@@ -60,7 +60,7 @@
     <ClCompile Include="..\..\src\cli\cli.cpp" />
     <ClCompile Include="..\..\src\cli\cli_dataset.cpp" />
     <ClCompile Include="..\..\src\cli\cli_instance.cpp" />
-    <ClCompile Include="..\..\src\cli\cli_uart.cpp" />
+    <ClCompile Include="..\..\src\cli\uart.cpp" />
     <ClCompile Include="..\..\src\core\utils\missing_strnlen.c" />
     <ClCompile Include="..\..\src\core\utils\parse_cmdline.cpp" />
   </ItemGroup>

--- a/etc/visual-studio/libopenthread-cli-windows.vcxproj.filters
+++ b/etc/visual-studio/libopenthread-cli-windows.vcxproj.filters
@@ -16,7 +16,7 @@
     <ClCompile Include="..\..\src\cli\cli_instance.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\cli\cli_uart.cpp">
+    <ClCompile Include="..\..\src\cli\uart.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/etc/visual-studio/libopenthread-cli.vcxproj
+++ b/etc/visual-studio/libopenthread-cli.vcxproj
@@ -58,7 +58,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\src\cli\cli.cpp" />
     <ClCompile Include="..\..\src\cli\cli_dataset.cpp" />
-    <ClCompile Include="..\..\src\cli\cli_uart.cpp" />
+    <ClCompile Include="..\..\src\cli\uart.cpp" />
     <ClCompile Include="..\..\src\cli\cli_udp_example.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/etc/visual-studio/libopenthread-cli.vcxproj.filters
+++ b/etc/visual-studio/libopenthread-cli.vcxproj.filters
@@ -13,7 +13,7 @@
     <ClCompile Include="..\..\src\cli\cli_dataset.cpp">
       <Filter>Source Files</Filter>
     </ClCompile> 
-    <ClCompile Include="..\..\src\cli\cli_uart.cpp">
+    <ClCompile Include="..\..\src\cli\uart.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\cli\cli_udp_example.cpp">

--- a/src/cli/Makefile.am
+++ b/src/cli/Makefile.am
@@ -145,10 +145,10 @@ SOURCES_COMMON =                      \
     cli.cpp                           \
     cli_coap.cpp                      \
     cli_coap_secure.cpp               \
-    cli_console.cpp                   \
     cli_dataset.cpp                   \
-    cli_uart.cpp                      \
     cli_udp_example.cpp               \
+    uart.cpp                          \
+    console.cpp                       \
     $(NULL)
 
 libopenthread_cli_ftd_a_SOURCES =     \
@@ -163,11 +163,11 @@ noinst_HEADERS                      = \
     cli.hpp                           \
     cli_coap.hpp                      \
     cli_coap_secure.hpp               \
-    cli_console.hpp                   \
     cli_dataset.hpp                   \
     cli_server.hpp                    \
-    cli_uart.hpp                      \
     cli_udp_example.hpp               \
+    console.hpp                       \
+    uart.hpp                          \
     x509_cert_key.hpp                 \
     $(NULL)
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -74,7 +74,7 @@
 #endif
 
 #include "cli_dataset.hpp"
-#include "cli_uart.hpp"
+#include "uart.hpp"
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
 #include "cli_coap.hpp"

--- a/src/cli/console.cpp
+++ b/src/cli/console.cpp
@@ -31,7 +31,7 @@
  *   This file implements the CLI server on the CONSOLE service.
  */
 
-#include "cli_console.hpp"
+#include "console.hpp"
 
 #include <stdarg.h>
 #include <stdio.h>

--- a/src/cli/console.hpp
+++ b/src/cli/console.hpp
@@ -28,27 +28,27 @@
 
 /**
  * @file
- *   This file contains definitions for a CLI server on the UART service.
+ *   This file contains definitions for a CLI server on the CONSOLE service.
  */
 
-#ifndef CLI_UART_HPP_
-#define CLI_UART_HPP_
+#ifndef OPENTHREAD_CLI_CONSOLE_HPP_
+#define OPENTHREAD_CLI_CONSOLE_HPP_
 
 #include "openthread-core-config.h"
 
+#include <openthread/cli.h>
+
 #include "cli/cli.hpp"
 #include "cli/cli_server.hpp"
-#include "common/instance.hpp"
-#include "common/tasklet.hpp"
 
 namespace ot {
 namespace Cli {
 
 /**
- * This class implements the CLI server on top of the UART platform abstraction.
+ * This class implements the CLI server on top of the CONSOLE platform abstraction.
  *
  */
-class Uart : public Server
+class Console : public Server
 {
 public:
     /**
@@ -57,7 +57,7 @@ public:
      * @param[in]  aInstance  The OpenThread instance structure.
      *
      */
-    Uart(Instance *aInstance);
+    Console(Instance *aInstance);
 
     /**
      * This method delivers raw characters to the client.
@@ -82,55 +82,36 @@ public:
     virtual int OutputFormat(const char *fmt, ...);
 
     /**
-     * This method delivers formatted output to the client.
+     * This method sets a callback that is called when console has some output.
      *
-     * @param[in]  aFmt  A pointer to the format string.
-     * @param[in]  aAp   A variable list of arguments for format.
-     *
-     * @returns The number of bytes placed in the output queue.
+     * @param[in]  aCallback   A pointer to a callback method.
      *
      */
-    int OutputFormatV(const char *aFmt, va_list aAp);
+    void SetOutputCallback(otCliConsoleOutputCallback aCallback);
 
     /**
-     * This method returns a reference to the interpreter object.
+     * This method sets a context that is returned with the callback.
      *
-     * @returns A reference to the interpreter object.
+     * @param[in]  aContext   A pointer to a user context.
      *
      */
-    Interpreter &GetInterpreter(void) { return mInterpreter; }
+    void SetContext(void *aContext);
 
-    void ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength);
-    void SendDoneTask(void);
-
-    static Uart *sUartServer;
+    void ReceiveTask(char *aBuf, uint16_t aBufLength);
 
 private:
     enum
     {
-        kRxBufferSize  = OPENTHREAD_CONFIG_CLI_UART_RX_BUFFER_SIZE,
-        kTxBufferSize  = OPENTHREAD_CONFIG_CLI_UART_TX_BUFFER_SIZE,
-        kMaxLineLength = OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH,
+        kMaxLineLength = 128,
     };
 
-    otError ProcessCommand(void);
-    void    Send(void);
-
-    char     mRxBuffer[kRxBufferSize];
-    uint16_t mRxLength;
-
-    char     mTxBuffer[kTxBufferSize];
-    uint16_t mTxHead;
-    uint16_t mTxLength;
-
-    uint16_t mSendLength;
+    otCliConsoleOutputCallback mCallback;
+    void *                     mContext;
 
     Interpreter mInterpreter;
-
-    friend class Interpreter;
 };
 
 } // namespace Cli
 } // namespace ot
 
-#endif // CLI_UART_HPP_
+#endif // OPENTHREAD_CLI_CONSOLE_HPP_

--- a/src/cli/uart.cpp
+++ b/src/cli/uart.cpp
@@ -31,7 +31,7 @@
  *   This file implements the CLI server on the UART service.
  */
 
-#include "cli_uart.hpp"
+#include "uart.hpp"
 
 #include <stdarg.h>
 #include <stdio.h>


### PR DESCRIPTION
Leave `src/cli_*` sources implement sub-commands.