### PR TITLE
[debug] Add make options for DEBUG=1.

### DIFF
--- a/examples/Makefile-nrf52840
+++ b/examples/Makefile-nrf52840
@@ -87,13 +87,26 @@ CONFIG_FILE_PATH = $(AbsTopSourceDir)/examples/platforms/nrf52840/
 COMMONCFLAGS                   := \
     -fdata-sections               \
     -ffunction-sections           \
-    -Os                           \
-    -g                            \
     -D$(CONFIG_FILE)              \
     -I$(CONFIG_FILE_PATH)         \
     $(NULL)
 
 include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
+
+ifeq ($(DEBUG),1)
+configure_OPTIONS += --enable-optimizations=no
+COMMONCFLAGS                   += \
+    -O0                           \
+    -ggdb3                        \
+    -DENABLE_DEBUG_LOG            \
+    $(NULL)
+else
+configure_OPTIONS += --enable-optimizations=yes
+COMMONCFLAGS                   += \
+    -Os                           \
+    -g                            \
+    $(NULL)
+endif
 
 ifneq ($(CERT_LOG),1)
 COMMONCFLAGS += -DOPENTHREAD_CONFIG_LOG_OUTPUT=OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED

--- a/examples/Makefile-posix
+++ b/examples/Makefile-posix
@@ -81,13 +81,26 @@ CONFIG_FILE      = OPENTHREAD_PROJECT_CORE_CONFIG_FILE='\"openthread-core-posix-
 CONFIG_FILE_PATH = $(AbsTopSourceDir)/examples/platforms/posix/
 
 COMMONCFLAGS                   := \
-    -O1                           \
-    -g                            \
     -D$(CONFIG_FILE)              \
     -I$(CONFIG_FILE_PATH)         \
     $(NULL)
 
 include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
+
+ifeq ($(DEBUG),1)
+configure_OPTIONS += --enable-optimizations=no
+COMMONCFLAGS                   += \
+    -O0                           \
+    -ggdb3                        \
+    -DENABLE_DEBUG_LOG            \
+    $(NULL)
+else
+configure_OPTIONS += --enable-optimizations=yes
+COMMONCFLAGS                   += \
+    -O1                           \
+    -g                            \
+    $(NULL)
+endif
 
 ifeq ($(VIRTUAL_TIME),1)
 COMMONCFLAGS                   += -DOPENTHREAD_POSIX_VIRTUAL_TIME=1

--- a/third_party/NordicSemiconductor/libraries/app_error/app_error_weak.c
+++ b/third_party/NordicSemiconductor/libraries/app_error/app_error_weak.c
@@ -37,6 +37,7 @@
  * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
+#include <assert.h>
 #include "app_error.h"
 
 /*lint -save -e14 */


### PR DESCRIPTION
Disables all optimizations when DEBUG=1 is passed to examples/Makefile.
The current proposal adds this support for posix and nRF.  
This PR could be expanded to all platforms if there is demand.