### PR TITLE
[slaac] no second address for a single prefix

### DIFF
--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -106,20 +106,12 @@ void Slaac::UpdateAddresses(otInstance *    aInstance,
             continue;
         }
 
-        for (size_t i = 0; i < aNumAddresses; i++)
+        for (const otNetifAddress *address = otIp6GetUnicastAddresses(aInstance); address != NULL;
+             address                       = address->mNext)
         {
-            otNetifAddress *address = &aAddresses[i];
-
-            if (!address->mValid)
-            {
-                continue;
-            }
-
             if (otIp6PrefixMatch(&config.mPrefix.mPrefix, &address->mAddress) >= config.mPrefix.mLength &&
                 config.mPrefix.mLength == address->mPrefixLength)
             {
-                static_cast<Instance *>(aInstance)->GetThreadNetif().AddUnicastAddress(
-                    *static_cast<Ip6::NetifUnicastAddress *>(address));
                 found = true;
                 break;
             }


### PR DESCRIPTION
This PR changes the SLAAC policy so that if there is an existing address
with of a prefix, no new address will be created for this SLAAC enabled
prefix.