### PR TITLE
[border-agent] reuse dtls restart

### DIFF
--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -88,8 +88,7 @@ private:
     {
         static_cast<BorderAgent *>(aContext)->HandleConnected(aConnected);
     }
-    void    HandleConnected(bool aConnected);
-    otError StartCoaps(void);
+    void HandleConnected(bool aConnected);
 
     template <Coap::Resource BorderAgent::*aResource>
     static void HandleRequest(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)


### PR DESCRIPTION
`MeshCoP::Dtls` session will restart listening by itself. It's not
necessary for border agent to restart `MeshCoP::Dtls`.