### PR TITLE
[posix] fix diagnostics for missing diag alarm

### DIFF
--- a/src/posix/platform/alarm.c
+++ b/src/posix/platform/alarm.c
@@ -26,6 +26,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "openthread-core-config.h"
 #include "platform-posix.h"
 
 #include <assert.h>

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -31,10 +31,10 @@
  *   This file includes the implementation for the HDLC interface to radio (RCP).
  */
 
-#include "hdlc_interface.hpp"
-
+#include "openthread-core-config.h"
 #include "platform-posix.h"
-#include "radio_spinel.hpp"
+
+#include "hdlc_interface.hpp"
 
 #include <assert.h>
 #include <errno.h>

--- a/src/posix/platform/logging.c
+++ b/src/posix/platform/logging.c
@@ -26,8 +26,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "openthread-core-config.h"
 #include "platform-posix.h"
-#include <openthread-core-config.h>
 
 #include <assert.h>
 #include <inttypes.h>

--- a/src/posix/platform/misc.c
+++ b/src/posix/platform/misc.c
@@ -26,6 +26,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "openthread-core-config.h"
 #include "platform-posix.h"
 
 #include <assert.h>

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -30,7 +30,7 @@
  * @file
  *   This file implements the platform network on Linux.
  */
-
+#include "openthread-core-config.h"
 #include "platform-posix.h"
 
 #include <arpa/inet.h>

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -31,6 +31,7 @@
  *   This file implements the spinel based radio transceiver.
  */
 
+#include "openthread-core-config.h"
 #include "platform-posix.h"
 
 #include "radio_spinel.hpp"

--- a/src/posix/platform/random.c
+++ b/src/posix/platform/random.c
@@ -32,10 +32,11 @@
  *
  */
 
+#include "openthread-core-config.h"
+#include "platform-posix.h"
+
 #include <assert.h>
 #include <stdio.h>
-
-#include "platform-posix.h"
 
 #include <openthread/platform/random.h>
 

--- a/src/posix/platform/settings.cpp
+++ b/src/posix/platform/settings.cpp
@@ -32,6 +32,7 @@
  *
  */
 
+#include "openthread-core-config.h"
 #include "platform-posix.h"
 
 #include <assert.h>

--- a/src/posix/platform/sim.c
+++ b/src/posix/platform/sim.c
@@ -32,6 +32,7 @@
  *   This file implements the posix simulation.
  */
 
+#include "openthread-core-config.h"
 #include "platform-posix.h"
 
 #include <arpa/inet.h>

--- a/src/posix/platform/spi-stubs.c
+++ b/src/posix/platform/spi-stubs.c
@@ -32,6 +32,7 @@
  *
  */
 
+#include "openthread-core-config.h"
 #include "platform-posix.h"
 
 #include <stdio.h>

--- a/src/posix/platform/system.c
+++ b/src/posix/platform/system.c
@@ -32,6 +32,7 @@
  *   This file includes the platform-specific initializers.
  */
 
+#include "openthread-core-config.h"
 #include "platform-posix.h"
 
 #include <assert.h>

--- a/src/posix/platform/uart.c
+++ b/src/posix/platform/uart.c
@@ -26,6 +26,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "openthread-core-config.h"
 #include "platform-posix.h"
 
 #include <stdio.h>

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -36,6 +36,7 @@
 #define __APPLE_USE_RFC_3542
 #endif
 
+#include "openthread-core-config.h"
 #include "platform-posix.h"
 
 #include <arpa/inet.h>

--- a/tests/scripts/thread-cert/test_diag.py
+++ b/tests/scripts/thread-cert/test_diag.py
@@ -69,8 +69,10 @@ class TestDiag(unittest.TestCase):
              'sending 0x14 packet\(s\), length 0x64\r\nstatus 0x00\r\n'),
             ('diag repeat 100 100\n',
              'sending packets of length 0x64 at the delay of 0x64 ms\r\nstatus 0x00\r\n'),
+            ('diag repeat stop\n',
+             'repeated packet transmission is stopped\r\nstatus 0x00\r\n'),
             ('diag stop\n',
-             'received packets: 0\r\nsent packets: (\d+)\r\nfirst received packet: rssi=0, lqi=0\r\n\nstop diagnostics mode\r\nstatus 0x00\r\n'),
+             'received packets: 0\r\nsent packets: ([1-9]\d*)\r\nfirst received packet: rssi=0, lqi=0\r\n\nstop diagnostics mode\r\nstatus 0x00\r\n'),
             ('diag',
              'diagnostics mode is disabled\r\n'),
             ('diag 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32',
@@ -79,6 +81,7 @@ class TestDiag(unittest.TestCase):
 
         for case in cases:
             self.node_cli.send_command(case[0])
+            self.simulator.go(1)
             self.node_cli._expect(case[1])
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes a bug that `alarm.c` misses definition of
OPENTHREAD_ENABLE_DIAG for not including `openthread-core-config.h`.
This PR adds the `openthread-core-config.h` to every platform sources.

Besides, this PR enhances the test_diag.py to make sure diag can send
packets out.