### PR TITLE
[slaac] add config option to enable/disable SLAAC support

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -90,7 +90,7 @@ build_cc1352() {
     git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
-    COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-cc1352 || die
+    COMMISSIONER=1 JOINER=1 SLAAC=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-cc1352 || die
     arm-none-eabi-size  output/cc1352/bin/ot-cli-ftd || die
     arm-none-eabi-size  output/cc1352/bin/ot-cli-mtd || die
     arm-none-eabi-size  output/cc1352/bin/ot-ncp-ftd || die
@@ -101,7 +101,7 @@ build_cc2538() {
     git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
-    COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-cc2538 || die
+    COMMISSIONER=1 JOINER=1 SLAAC=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-cc2538 || die
     arm-none-eabi-size  output/cc2538/bin/ot-cli-ftd || die
     arm-none-eabi-size  output/cc2538/bin/ot-cli-mtd || die
     arm-none-eabi-size  output/cc2538/bin/ot-ncp-ftd || die
@@ -121,7 +121,7 @@ build_cc2652() {
     git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
-    COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-cc2652 || die
+    COMMISSIONER=1 JOINER=1 SLAAC=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-cc2652 || die
     arm-none-eabi-size  output/cc2652/bin/ot-cli-ftd || die
     arm-none-eabi-size  output/cc2652/bin/ot-cli-mtd || die
     arm-none-eabi-size  output/cc2652/bin/ot-ncp-ftd || die
@@ -132,7 +132,7 @@ build_da15000() {
     git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
-    COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-da15000 || die
+    COMMISSIONER=1 JOINER=1 SLAAC=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-da15000 || die
     arm-none-eabi-size  output/da15000/bin/ot-cli-ftd || die
     arm-none-eabi-size  output/da15000/bin/ot-cli-mtd || die
     arm-none-eabi-size  output/da15000/bin/ot-ncp-ftd || die
@@ -145,7 +145,7 @@ build_emsk() {
     git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
-    COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-emsk || die
+    COMMISSIONER=1 JOINER=1 SLAAC=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-emsk || die
     arc-elf32-size  output/emsk/bin/ot-cli-ftd || die
     arc-elf32-size  output/emsk/bin/ot-cli-mtd || die
     arc-elf32-size  output/emsk/bin/ot-ncp-ftd || die
@@ -156,7 +156,7 @@ build_kw41z() {
     git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
-    COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-kw41z || die
+    COMMISSIONER=1 JOINER=1 SLAAC=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-kw41z || die
     arm-none-eabi-size  output/kw41z/bin/ot-cli-ftd || die
     arm-none-eabi-size  output/kw41z/bin/ot-cli-mtd || die
     arm-none-eabi-size  output/kw41z/bin/ot-ncp-ftd || die
@@ -193,7 +193,7 @@ build_nrf52811() {
 
 build_nrf52840() {
     # Default OpenThread switches for nRF52840 platform
-    OPENTHREAD_FLAGS="BORDER_AGENT=1 BORDER_ROUTER=1 COAP=1 COAPS=1 COMMISSIONER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 ECDSA=1 FULL_LOGS=1 JOINER=1 LINK_RAW=1 MAC_FILTER=1 MTD_NETDIAG=1 SERVICE=1 SNTP_CLIENT=1 UDP_FORWARD=1"
+    OPENTHREAD_FLAGS="BORDER_AGENT=1 BORDER_ROUTER=1 COAP=1 COAPS=1 COMMISSIONER=1 SLAAC=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 ECDSA=1 FULL_LOGS=1 JOINER=1 LINK_RAW=1 MAC_FILTER=1 MTD_NETDIAG=1 SERVICE=1 SNTP_CLIENT=1 UDP_FORWARD=1"
 
     # UART transport
     git checkout -- . || die
@@ -237,7 +237,7 @@ build_qpg6095() {
     git checkout -- . || die
     git clean -xfd || die
     ./bootstrap || die
-    COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-qpg6095 || die
+    COMMISSIONER=1 JOINER=1 SLAAC=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-qpg6095 || die
     arm-none-eabi-size  output/qpg6095/bin/ot-cli-ftd || die
     arm-none-eabi-size  output/qpg6095/bin/ot-cli-mtd || die
     arm-none-eabi-size  output/qpg6095/bin/ot-ncp-ftd || die
@@ -251,7 +251,7 @@ build_samr21() {
     unzip -qq asf-standalone-archive-3.45.0.85.zip || die
     mv xdk-asf-3.45.0 third_party/microchip/asf || die
     ./bootstrap || die
-    COMMISSIONER=1 JOINER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-samr21 || die
+    COMMISSIONER=1 JOINER=1 SLAAC=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DNS_CLIENT=1 make -f examples/Makefile-samr21 || die
     arm-none-eabi-size  output/samr21/bin/ot-cli-ftd || die
     arm-none-eabi-size  output/samr21/bin/ot-cli-mtd || die
     arm-none-eabi-size  output/samr21/bin/ot-ncp-ftd || die

--- a/examples/common-switches.mk
+++ b/examples/common-switches.mk
@@ -26,6 +26,39 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+# OpenThread Features (Makefile default configuration).
+
+BORDER_AGENT        ?= 0
+BORDER_ROUTER       ?= 0
+CERT_LOG            ?= 0
+COAP                ?= 0
+COAPS               ?= 0
+COMMISSIONER        ?= 0
+COVERAGE            ?= 0
+CHANNEL_MANAGER     ?= 0
+CHANNEL_MONITOR     ?= 0
+CHILD_SUPERVISION   ?= 0
+DEBUG               ?= 0
+DHCP6_CLIENT        ?= 0
+DHCP6_SERVER        ?= 0
+DIAGNOSTIC          ?= 0
+DISABLE_DOC         ?= 0
+DNS_CLIENT          ?= 0
+ECDSA               ?= 0
+JAM_DETECTION       ?= 0
+JOINER              ?= 0
+LEGACY              ?= 0
+LINK_RAW            ?= 0
+MAC_FILTER          ?= 0
+MTD_NETDIAG         ?= 0
+PLATFORM_UDP        ?= 0
+SERVICE             ?= 0
+SLAAC               ?= 1  # SLAAC is enabled by default
+SNTP_CLIENT         ?= 0
+TIME_SYNC           ?= 0
+UDP_FORWARD         ?= 0
+
+
 ifeq ($(BORDER_AGENT),1)
 configure_OPTIONS              += --enable-border-agent
 endif
@@ -125,6 +158,10 @@ endif
 
 ifeq ($(SERVICE),1)
 configure_OPTIONS              += --enable-service
+endif
+
+ifeq ($(SLAAC),1)
+COMMONCFLAGS                   += -DOPENTHREAD_CONFIG_ENABLE_SLAAC=1
 endif
 
 ifeq ($(SNTP_CLIENT),1)

--- a/examples/platforms/posix/openthread-core-posix-config.h
+++ b/examples/platforms/posix/openthread-core-posix-config.h
@@ -53,6 +53,16 @@
 #define OPENTHREAD_CONFIG_LOG_OUTPUT OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_ENABLE_SLAAC
+ *
+ * Define as 1 to enable support for adding of auto-configured SLAAC addresses by OpenThread.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ENABLE_SLAAC /* allows command line override */
+#define OPENTHREAD_CONFIG_ENABLE_SLAAC 1
+#endif
+
 #if OPENTHREAD_RADIO
 /**
  * @def OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ACK_TIMEOUT

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -915,9 +915,19 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_ENABLE_SLAAC
+ *
+ * Define as 1 to enable support for adding of auto-configured SLAAC addresses by OpenThread.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ENABLE_SLAAC
+#define OPENTHREAD_CONFIG_ENABLE_SLAAC 0
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_NUM_SLAAC_ADDRESSES
  *
- * The number of auto-configured SLAAC addresses.
+ * The number of auto-configured SLAAC addresses. Applicable only if OPENTHREAD_CONFIG_ENABLE_SLAAC is enabled.
  *
  */
 #ifndef OPENTHREAD_CONFIG_NUM_SLAAC_ADDRESSES

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1506,7 +1506,9 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
 #endif
 #endif
 
+#if OPENTHREAD_CONFIG_ENABLE_SLAAC
         GetNetif().UpdateSlaac();
+#endif
 
 #if OPENTHREAD_ENABLE_DHCP6_SERVER
         GetNetif().GetDhcp6Server().UpdateService();

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -43,7 +43,9 @@
 #include "thread/mle.hpp"
 #include "thread/thread_tlvs.hpp"
 #include "thread/thread_uri_paths.hpp"
+#if OPENTHREAD_CONFIG_ENABLE_SLAAC
 #include "utils/slaac_address.hpp"
+#endif
 
 using ot::Encoding::BigEndian::HostSwap16;
 
@@ -110,7 +112,9 @@ ThreadNetif::ThreadNetif(Instance &aInstance)
 #endif
 {
     mCoap.SetInterceptor(&ThreadNetif::TmfFilter, this);
+#if OPENTHREAD_CONFIG_ENABLE_SLAAC
     memset(mSlaacAddresses, 0, sizeof(mSlaacAddresses));
+#endif
 }
 
 void ThreadNetif::Up(void)
@@ -224,10 +228,12 @@ exit:
     return rval;
 }
 
+#if OPENTHREAD_CONFIG_ENABLE_SLAAC
 void ThreadNetif::UpdateSlaac(void)
 {
     Utils::Slaac::UpdateAddresses(&GetInstance(), mSlaacAddresses, OT_ARRAY_LENGTH(mSlaacAddresses),
                                   otIp6CreateRandomIid, NULL);
 }
+#endif
 
 } // namespace ot

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -439,11 +439,13 @@ public:
      */
     bool IsTmfMessage(const Ip6::MessageInfo &aMessageInfo);
 
+#if OPENTHREAD_CONFIG_ENABLE_SLAAC
     /**
      * This method updates addresses that shall be automatically created using SLAAC.
      *
      */
     void UpdateSlaac(void);
+#endif
 
 private:
     static otError TmfFilter(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo, void *aContext);
@@ -455,7 +457,9 @@ private:
 #if OPENTHREAD_ENABLE_DHCP6_SERVER
     Dhcp6::Dhcp6Server mDhcp6Server;
 #endif // OPENTHREAD_ENABLE_DHCP6_SERVER
+#if OPENTHREAD_CONFIG_ENABLE_SLAAC
     Ip6::NetifUnicastAddress mSlaacAddresses[OPENTHREAD_CONFIG_NUM_SLAAC_ADDRESSES];
+#endif
 #if OPENTHREAD_ENABLE_DNS_CLIENT
     Dns::Client mDnsClient;
 #endif // OPENTHREAD_ENABLE_DNS_CLIENT

--- a/src/posix/platform/openthread-core-posix-config.h
+++ b/src/posix/platform/openthread-core-posix-config.h
@@ -42,4 +42,14 @@
  */
 #define OPENTHREAD_CONFIG_PLATFORM_INFO "POSIX-APP"
 
+/**
+ * @def OPENTHREAD_CONFIG_ENABLE_SLAAC
+ *
+ * Define as 1 to enable support for adding of auto-configured SLAAC addresses by OpenThread.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ENABLE_SLAAC /* allows command line override */
+#define OPENTHREAD_CONFIG_ENABLE_SLAAC 1
+#endif
+
 #endif // OPENTHREAD_CORE_POSIX_CONFIG_H_


### PR DESCRIPTION
This commit adds `OPENTHREAD_CONFIG_ENABLE_SLAAC` as a build
configuration option to enable/disable SLAAC support within
OpenThread.