### PR TITLE
[ci] test with time sync and header ie

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,10 @@ matrix:
       os: linux
       compiler: gcc
       python: "2.7"
+    - env: BUILD_TARGET="posix-32-bit" VERBOSE=1 VIRTUAL_TIME=1 TIME_SYNC=1
+      os: linux
+      compiler: gcc
+      python: "2.7"
     - env: BUILD_TARGET="posix-ncp" VERBOSE=1 VIRTUAL_TIME=1
       os: linux
       compiler: gcc

--- a/examples/common-switches.mk
+++ b/examples/common-switches.mk
@@ -123,6 +123,10 @@ ifeq ($(SNTP_CLIENT),1)
 configure_OPTIONS              += --enable-sntp-client
 endif
 
+ifeq ($(TIME_SYNC),1)
+COMMONCFLAGS                   += -DPENTHREAD_CONFIG_ENABLE_TIME_SYNC=1
+endif
+
 ifeq ($(UDP_FORWARD),1)
 configure_OPTIONS              += --enable-udp-forward
 endif

--- a/examples/platforms/posix/Makefile.am
+++ b/examples/platforms/posix/Makefile.am
@@ -54,7 +54,7 @@ PLATFORM_SOURCES                          = \
     $(NULL)
 
 libopenthread_posix_a_SOURCES             = \
-     $(PLATFORM_SOURCES)                    \
+    $(PLATFORM_SOURCES)                     \
     $(NULL)
 
 noinst_HEADERS                            = \

--- a/examples/platforms/posix/sim/alarm-sim.c
+++ b/examples/platforms/posix/sim/alarm-sim.c
@@ -181,4 +181,16 @@ void platformAlarmProcess(otInstance *aInstance)
 #endif // OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER
 }
 
+#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+uint64_t otPlatTimeGet(void)
+{
+    return platformAlarmGetNow();
+}
+
+uint16_t otPlatTimeGetXtalAccuracy(void)
+{
+    return 0;
+}
+#endif // OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+
 #endif // OPENTHREAD_POSIX_VIRTUAL_TIME

--- a/include/openthread/platform/time.h
+++ b/include/openthread/platform/time.h
@@ -32,8 +32,8 @@
  *   This file includes the platform abstraction for the time service.
  */
 
-#ifndef TIME_H_
-#define TIME_H_
+#ifndef OPENTHREAD_PLATFORM_TIME_H_
+#define OPENTHREAD_PLATFORM_TIME_H_
 
 #include <stdint.h>
 
@@ -76,4 +76,4 @@ uint16_t otPlatTimeGetXtalAccuracy(void);
 } // extern "C"
 #endif
 
-#endif // TIME_H_
+#endif // OPENTHREAD_PLATFORM_TIME_H_

--- a/tests/scripts/thread-cert/config.py
+++ b/tests/scripts/thread-cert/config.py
@@ -177,7 +177,9 @@ def create_default_mle_tlvs_factories():
         mle.TlvType.PENDING_TIMESTAMP: mle.PendingTimestampFactory(),
         mle.TlvType.ACTIVE_OPERATIONAL_DATASET: mle.ActiveOperationalDatasetFactory(),
         mle.TlvType.PENDING_OPERATIONAL_DATASET: mle.PendingOperationalDatasetFactory(),
-        mle.TlvType.THREAD_DISCOVERY: mle.ThreadDiscoveryFactory()
+        mle.TlvType.THREAD_DISCOVERY: mle.ThreadDiscoveryFactory(),
+        mle.TlvType.TIME_REQUEST: mle.TimeRequestFactory(),
+        mle.TlvType.TIME_PARAMETER: mle.TimeParameterFactory(),
     }
 
 
@@ -205,6 +207,7 @@ def create_deafult_network_tlvs_factories():
         network_layer.TlvType.ND_OPTION: network_layer.NdOptionFactory(),
         network_layer.TlvType.ND_DATA: network_layer.NdDataFactory(),
         network_layer.TlvType.THREAD_NETWORK_DATA: network_layer.ThreadNetworkDataFactory(create_default_network_data_tlvs_factory()),
+        network_layer.TlvType.XTAL_ACCURACY: network_layer.XtalAccuracyFactory(),
 
         # Routing information are distributed in a Thread network by MLE Routing TLV
         # which is in fact MLE Route64 TLV. Thread specificaton v1.1. - Chapter 5.20

--- a/tests/scripts/thread-cert/mle.py
+++ b/tests/scripts/thread-cert/mle.py
@@ -58,6 +58,7 @@ class CommandType(IntEnum):
     ANNOUNCE = 15
     DISCOVERY_REQUEST = 16
     DISCOVERY_RESPONSE = 17
+    TIME_SYNC = 99
 
 
 class TlvType(IntEnum):
@@ -86,6 +87,8 @@ class TlvType(IntEnum):
     ACTIVE_OPERATIONAL_DATASET = 24
     PENDING_OPERATIONAL_DATASET = 25
     THREAD_DISCOVERY = 26
+    TIME_REQUEST = 252
+    TIME_PARAMETER = 253
 
 
 class SourceAddress(object):
@@ -1018,6 +1021,28 @@ class ThreadDiscoveryFactory:
     def parse(self, data, message_info):
         return ThreadDiscovery()
 
+class TimeRequest:
+    # TODO: Not implemented yet
+
+    def __init__(self):
+        print("TimeRequest is not implemented yet.")
+
+class TimeRequestFactory:
+
+    def parse(self, data, message_info):
+        return TimeRequest()
+
+class TimeParameter:
+    # TODO: Not implemented yet
+
+    def __init__(self):
+        print("TimeParameter is not implemented yet.")
+
+
+class TimeParameterFactory:
+
+    def parse(self, data, message_info):
+        return TimeParameter()
 
 class MleCommand(object):
 

--- a/tests/scripts/thread-cert/network_layer.py
+++ b/tests/scripts/thread-cert/network_layer.py
@@ -48,6 +48,7 @@ class TlvType(IntEnum):
     ND_DATA = 9
     THREAD_NETWORK_DATA = 10
     MLE_ROUTING = 11
+    XTAL_ACCURACY = 254
 
 
 class StatusValues(IntEnum):
@@ -274,6 +275,18 @@ class NdDataFactory(object):
     def parse(self, data, message_info):
         raise NotImplementedError("TODO: Not implemented yet")
 
+class XtalAccuracy:
+    # TODO: Not implemented yet
+
+    def __init__(self):
+        print("XtalAccuracy is not implemented yet.")
+
+
+class XtalAccuracyFactory:
+
+    def parse(self, data, message_info):
+        return XtalAccuracy()
+
 
 class ThreadNetworkData(object):
 
@@ -314,6 +327,8 @@ class NetworkLayerTlvsFactory(object):
             _type = ord(data.read(1))
             length = ord(data.read(1))
 
+            #if _type not in self._tlvs_factories:
+            #    continue
             factory = self._tlvs_factories[_type]
             tlv = factory.parse(io.BytesIO(data.read(length)), message_info)
 

--- a/tests/scripts/thread-cert/network_layer.py
+++ b/tests/scripts/thread-cert/network_layer.py
@@ -327,8 +327,6 @@ class NetworkLayerTlvsFactory(object):
             _type = ord(data.read(1))
             length = ord(data.read(1))
 
-            #if _type not in self._tlvs_factories:
-            #    continue
             factory = self._tlvs_factories[_type]
             tlv = factory.parse(io.BytesIO(data.read(length)), message_info)
 

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -571,4 +571,20 @@ void otPlatSettingsWipe(otInstance *aInstance)
     (void)aInstance;
 }
 
+#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+uint64_t otPlatTimeGet(void)
+{
+    struct timeval tv;
+
+    gettimeofday(&tv, NULL);
+
+    return (uint64_t)tv.tv_sec * 1000000 + (uint64_t)tv.tv_usec;
+}
+
+uint16_t otPlatTimeGetXtalAccuracy(void)
+{
+    return 0;
+}
+#endif // OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+
 } // extern "C"


### PR DESCRIPTION
This PR adds the missing test with ie present by enabling `TIME_SYNC`
feature, so that IE code are covered.

* [x] Add time sync in virtual time mode POSIX simulation
* [x] Add time sync TLV definition in test scripts
* [x] Skip parsing header ie in mac layer
* [x] Add common switch for time sync feature
* [x] Add missing functions to support unit test