### PR TITLE
[meshcop] set message offset when sending JOIN_FIN.rsp

### DIFF
--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -933,6 +933,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Message &aRequest, State
 
     message->SetDefaultResponseHeader(aRequest);
     message->SetPayloadMarker();
+    message->SetOffset(message->GetLength());
     message->SetSubType(Message::kSubTypeJoinerFinalizeResponse);
 
     stateTlv.Init();


### PR DESCRIPTION
Forgot to set message's offset when commissioner send JOIN_FIN.rsp message.
It results in unexpected prefix of outputted cert log.