### PR TITLE
[mac] remove mDidTx from otRadioFrame

### DIFF
--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -722,10 +722,11 @@ OTAPI const otMacCounters *OTCALL otLinkGetCounters(otInstance *aInstance);
  * @note This callback is called before IEEE 802.15.4 security processing.
  *
  * @param[in]  aFrame    A pointer to the received IEEE 802.15.4 frame.
+ * @param[in]  aIsTx     Whether this frame is transmitted, not received.
  * @param[in]  aContext  A pointer to application-specific context.
  *
  */
-typedef void (*otLinkPcapCallback)(const otRadioFrame *aFrame, void *aContext);
+typedef void (*otLinkPcapCallback)(const otRadioFrame *aFrame, bool aIsTx, void *aContext);
 
 /**
  * This function registers a callback to provide received raw IEEE 802.15.4 frames.

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -153,11 +153,10 @@ typedef struct otRadioIeInfo
  */
 typedef struct otRadioFrame
 {
-    uint8_t *      mPsdu;      ///< The PSDU.
-    uint8_t        mLength;    ///< Length of the PSDU.
-    uint8_t        mChannel;   ///< Channel used to transmit/receive the frame.
-    bool           mDidTx : 1; ///< Set to true if this frame sent from the radio. Ignored by radio driver.
-    otRadioIeInfo *mIeInfo;    ///< The pointer to the Header IE(s) related information.
+    uint8_t *      mPsdu;    ///< The PSDU.
+    uint8_t        mLength;  ///< Length of the PSDU.
+    uint8_t        mChannel; ///< Channel used to transmit/receive the frame.
+    otRadioIeInfo *mIeInfo;  ///< The pointer to the Header IE(s) related information.
 
     /**
      * The union of transmit and receive information for a radio frame.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2049,13 +2049,15 @@ exit:
     AppendResult(error);
 }
 
-void Interpreter::s_HandleLinkPcapReceive(const otRadioFrame *aFrame, void *aContext)
+void Interpreter::s_HandleLinkPcapReceive(const otRadioFrame *aFrame, bool aIsTx, void *aContext)
 {
-    static_cast<Interpreter *>(aContext)->HandleLinkPcapReceive(aFrame);
+    static_cast<Interpreter *>(aContext)->HandleLinkPcapReceive(aFrame, aIsTx);
 }
 
-void Interpreter::HandleLinkPcapReceive(const otRadioFrame *aFrame)
+void Interpreter::HandleLinkPcapReceive(const otRadioFrame *aFrame, bool aIsTx)
 {
+    OT_UNUSED_VARIABLE(aIsTx);
+
     mServer->OutputFormat("\r\n");
 
     for (size_t i = 0; i < 44; i++)

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -348,7 +348,7 @@ private:
     static void OTCALL s_HandleActiveScanResult(otActiveScanResult *aResult, void *aContext);
     static void OTCALL s_HandleEnergyScanResult(otEnergyScanResult *aResult, void *aContext);
 #ifndef OTDLL
-    static void s_HandleLinkPcapReceive(const otRadioFrame *aFrame, void *aContext);
+    static void s_HandleLinkPcapReceive(const otRadioFrame *aFrame, bool aIsTx, void *aContext);
 #endif
     static void OTCALL s_HandleEnergyReport(uint32_t       aChannelMask,
                                             const uint8_t *aEnergyList,
@@ -381,7 +381,7 @@ private:
     void HandleActiveScanResult(otActiveScanResult *aResult);
     void HandleEnergyScanResult(otEnergyScanResult *aResult);
 #ifndef OTDLL
-    void HandleLinkPcapReceive(const otRadioFrame *aFrame);
+    void HandleLinkPcapReceive(const otRadioFrame *aFrame, bool aIsTx);
 #endif
     void HandleEnergyReport(uint32_t aChannelMask, const uint8_t *aEnergyList, uint8_t aEnergyListLength);
     void HandlePanIdConflict(uint16_t aPanId, uint32_t aChannelMask);

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -1056,14 +1056,6 @@ public:
     void SetIsARetransmission(bool aIsARetx) { mInfo.mTxInfo.mIsARetx = aIsARetx; }
 
     /**
-     * This method sets the did Tx attribute.
-     *
-     * @param[in]  aDidTx  TRUE if frame is sent from the radio, FALSE otherwise.
-     *
-     */
-    void SetDidTx(bool aDidTx) { mDidTx = aDidTx; }
-
-    /**
      * This method indicates whether or not CSMA-CA is enabled.
      *
      * @retval TRUE  CSMA-CA is enabled.

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -191,8 +191,7 @@ void SubMac::HandleReceiveDone(Frame *aFrame, otError aError)
 {
     if (mPcapCallback && (aFrame != NULL) && (aError == OT_ERROR_NONE))
     {
-        aFrame->SetDidTx(false);
-        mPcapCallback(aFrame, mPcapCallbackContext);
+        mPcapCallback(aFrame, false, mPcapCallbackContext);
     }
 
     mCallbacks.ReceiveDone(aFrame, aError);
@@ -295,8 +294,7 @@ void SubMac::BeginTransmit(void)
 
     if (mPcapCallback)
     {
-        mTransmitFrame.SetDidTx(true);
-        mPcapCallback(&mTransmitFrame, mPcapCallbackContext);
+        mPcapCallback(&mTransmitFrame, true, mPcapCallbackContext);
     }
 
 exit:

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -268,8 +268,8 @@ protected:
     static void HandleStateChanged(otChangedFlags aFlags, void *aContext);
     void        ProcessThreadChangedFlags(void);
 
-    static void HandlePcapFrame(const otRadioFrame *aFrame, void *aContext);
-    void        HandlePcapFrame(const otRadioFrame *aFrame);
+    static void HandlePcapFrame(const otRadioFrame *aFrame, bool aIsTx, void *aContext);
+    void        HandlePcapFrame(const otRadioFrame *aFrame, bool aIsTx);
 
     static void HandleTimeSyncUpdate(void *aContext);
     void        HandleTimeSyncUpdate(void);

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -3247,19 +3247,19 @@ exit:
 // MARK: Pcap frame handling
 // ----------------------------------------------------------------------------
 
-void NcpBase::HandlePcapFrame(const otRadioFrame *aFrame, void *aContext)
+void NcpBase::HandlePcapFrame(const otRadioFrame *aFrame, bool aIsTx, void *aContext)
 {
-    static_cast<NcpBase *>(aContext)->HandlePcapFrame(aFrame);
+    static_cast<NcpBase *>(aContext)->HandlePcapFrame(aFrame, aIsTx);
 }
 
-void NcpBase::HandlePcapFrame(const otRadioFrame *aFrame)
+void NcpBase::HandlePcapFrame(const otRadioFrame *aFrame, bool aIsTx)
 {
     uint16_t flags  = 0;
     uint8_t  header = SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0;
 
     VerifyOrExit(mPcapEnabled);
 
-    if (aFrame->mDidTx)
+    if (aIsTx)
     {
         flags |= SPINEL_MD_FLAG_TX;
     }

--- a/src/ncp/ncp_base_radio.cpp
+++ b/src/ncp/ncp_base_radio.cpp
@@ -61,11 +61,6 @@ void NcpBase::LinkRawReceiveDone(otRadioFrame *aFrame, otError aError)
     uint16_t flags  = 0;
     uint8_t  header = SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0;
 
-    if (aFrame->mDidTx)
-    {
-        flags |= SPINEL_MD_FLAG_TX;
-    }
-
     // Append frame header and frame length
     SuccessOrExit(mEncoder.BeginFrame(header, SPINEL_CMD_PROP_VALUE_IS, SPINEL_PROP_STREAM_RAW));
     SuccessOrExit(mEncoder.WriteUint16((aError == OT_ERROR_NONE) ? aFrame->mLength : 0));


### PR DESCRIPTION
mDidTx indicates whether a frame is received or transmitted, which is
only useful for capturing packets. This PR removes this field, and make
this flag a temporary argument to the pcap callback.