### PR TITLE
[thci] update routerselectionjitter before start thread

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -401,6 +401,9 @@ class OpenThread(IThci):
                         for addr in self._addressfilterSet:
                             self.addBlockedMAC(addr)
 
+            if self.deviceRole in [Thread_Device_Role.Leader, Thread_Device_Role.Router, Thread_Device_Role.REED]:
+                self.__setRouterSelectionJitter(1)
+
             if self.__sendCommand('ifconfig up')[0] == 'Done':
                 if self.__sendCommand('thread start')[0] == 'Done':
                     self.isPowerDown = False
@@ -1007,14 +1010,12 @@ class OpenThread(IThci):
             if eRoleId == Thread_Device_Role.Leader:
                 print 'join as leader'
                 mode = 'rsdn'
-                self.__setRouterSelectionJitter(1)
                 if self.AutoDUTEnable is False:
                     # set ROUTER_DOWNGRADE_THRESHOLD
                     self.__setRouterDowngradeThreshold(33)
             elif eRoleId == Thread_Device_Role.Router:
                 print 'join as router'
                 mode = 'rsdn'
-                self.__setRouterSelectionJitter(1)
                 if self.AutoDUTEnable is False:
                     # set ROUTER_DOWNGRADE_THRESHOLD
                     self.__setRouterDowngradeThreshold(33)
@@ -1028,7 +1029,6 @@ class OpenThread(IThci):
             elif eRoleId == Thread_Device_Role.REED:
                 print 'join as REED'
                 mode = 'rsdn'
-                self.__setRouterSelectionJitter(1)
                 # set ROUTER_UPGRADE_THRESHOLD
                 self.__setRouterUpgradeThreshold(0)
             elif eRoleId == Thread_Device_Role.EndDevice_FED:

--- a/tools/harness-thci/OpenThread_WpanCtl.py
+++ b/tools/harness-thci/OpenThread_WpanCtl.py
@@ -500,6 +500,10 @@ class OpenThread_WpanCtl(IThci):
                 nodeType = 'end'
             else:
                 pass
+
+            if self.deviceRole in [Thread_Device_Role.Leader, Thread_Device_Role.Router, Thread_Device_Role.REED]:
+                self.__setRouterSelectionJitter(1)
+
             if startType == 'form':
                 startCmd = WPANCTL_CMD + '%s %s -c %s -T %s ' % (startType, self.networkName, str(self.channel), nodeType)
             else:
@@ -1183,7 +1187,6 @@ class OpenThread_WpanCtl(IThci):
                 print 'join as leader'
                 #rsdn
                 mode = 15
-                self.__setRouterSelectionJitter(1)
                 if self.AutoDUTEnable is False:
                     # set ROUTER_DOWNGRADE_THRESHOLD
                     self.__setRouterDowngradeThreshold(33)
@@ -1191,7 +1194,6 @@ class OpenThread_WpanCtl(IThci):
                 print 'join as router'
                 #rsdn
                 mode = 15
-                self.__setRouterSelectionJitter(1)
                 if self.AutoDUTEnable is False:
                     # set ROUTER_DOWNGRADE_THRESHOLD
                     self.__setRouterDowngradeThreshold(33)
@@ -1208,7 +1210,6 @@ class OpenThread_WpanCtl(IThci):
                 print 'join as REED'
                 #rsdn
                 mode = 15
-                self.__setRouterSelectionJitter(1)
                 # set ROUTER_UPGRADE_THRESHOLD
                 self.__setRouterUpgradeThreshold(0)
             elif eRoleId == Thread_Device_Role.EndDevice_FED:


### PR DESCRIPTION
This PR recovers the behavior for FTD(small routerselectionjitter setting after reset) changed when adding MTD cert support in #3339