### PR TITLE
[coap] make CoapBase::Send() private

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -191,12 +191,6 @@ exit:
     return error;
 }
 
-otError CoapBase::Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
-{
-    static_cast<Message &>(aMessage).Finish();
-    return mSender(*this, aMessage, aMessageInfo);
-}
-
 otError CoapBase::SendEmptyMessage(Message::Type aType, const Message &aRequest, const Ip6::MessageInfo &aMessageInfo)
 {
     otError  error   = OT_ERROR_NONE;
@@ -209,6 +203,7 @@ otError CoapBase::SendEmptyMessage(Message::Type aType, const Message &aRequest,
     message->Init(aType, OT_COAP_CODE_EMPTY);
     message->SetMessageId(aRequest.GetMessageId());
 
+    message->Finish();
     SuccessOrExit(error = Send(*message, aMessageInfo));
 
 exit:
@@ -369,7 +364,6 @@ Message *CoapBase::CopyAndEnqueueMessage(const Message &     aMessage,
 {
     otError  error       = OT_ERROR_NONE;
     Message *messageCopy = NULL;
-    uint32_t alarmFireTime;
 
     // Create a message copy of requested size.
     VerifyOrExit((messageCopy = aMessage.Clone(aCopyLength)) != NULL, error = OT_ERROR_NO_BUFS);
@@ -380,6 +374,8 @@ Message *CoapBase::CopyAndEnqueueMessage(const Message &     aMessage,
     // Setup the timer.
     if (mRetransmissionTimer.IsRunning())
     {
+        uint32_t alarmFireTime;
+
         // If timer is already running, check if it should be restarted with earlier fire time.
         alarmFireTime = mRetransmissionTimer.GetFireTime();
 
@@ -883,7 +879,7 @@ void Coap::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessage
                                            *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
-otError Coap::Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError Coap::Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     return mSocket.SendTo(aMessage, aMessageInfo);
 }

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -442,7 +442,7 @@ public:
      * @retval OT_ERROR_NO_BUFS  Failed to allocate retransmission data.
      *
      */
-    typedef otError (*Sender)(CoapBase &aCoapBase, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    typedef otError (*Sender)(CoapBase &aCoapBase, ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     /**
      * This function pointer is called before CoAP server processing a CoAP packets.
@@ -659,18 +659,6 @@ protected:
     explicit CoapBase(Instance &aInstance, Sender aSender);
 
     /**
-     * This method sends a CoAP message.
-     *
-     * @param[in]  aMessage      A reference to the message to send.
-     * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
-     *
-     * @retval OT_ERROR_NONE     Successfully sent CoAP message.
-     * @retval OT_ERROR_NO_BUFS  Failed to allocate retransmission data.
-     *
-     */
-    otError Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-
-    /**
      * This method receives a CoAP message.
      *
      * @param[in]  aMessage      A reference to the received message.
@@ -699,6 +687,21 @@ private:
 
     otError SendCopy(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     otError SendEmptyMessage(Message::Type aType, const Message &aRequest, const Ip6::MessageInfo &aMessageInfo);
+
+    /**
+     * This method sends a message.
+     *
+     * @param[in]  aMessage      A reference to the message to send.
+     * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.
+     *
+     * @retval OT_ERROR_NONE     Successfully sent CoAP message.
+     * @retval OT_ERROR_NO_BUFS  Failed to allocate retransmission data.
+     *
+     */
+    otError Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+    {
+        return mSender(*this, aMessage, aMessageInfo);
+    }
 
     MessageQueue      mPendingRequests;
     uint16_t          mMessageId;
@@ -752,11 +755,11 @@ public:
     otError Stop(void);
 
 private:
-    static otError Send(CoapBase &aCoapBase, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+    static otError Send(CoapBase &aCoapBase, ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
     {
         return static_cast<Coap &>(aCoapBase).Send(aMessage, aMessageInfo);
     }
-    otError Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -236,14 +236,16 @@ otError CoapSecure::SendMessage(Message &               aMessage,
     return CoapBase::SendMessage(aMessage, aMessageInfo, aHandler, aContext);
 }
 
-otError CoapSecure::Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+otError CoapSecure::Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
+    otError error;
 
-    static_cast<Message &>(aMessage).Finish();
-    mTransmitQueue.Enqueue(aMessage);
+    SuccessOrExit(error = mTransmitQueue.Enqueue(aMessage));
     mTransmitTask.Post();
-    return OT_ERROR_NONE;
+
+exit:
+    return error;
 }
 
 void CoapSecure::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -319,11 +319,11 @@ public:
     const Ip6::MessageInfo &GetPeerMessageInfo(void) const { return mPeerAddress; }
 
 private:
-    static otError Send(CoapBase &aCoapBase, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+    static otError Send(CoapBase &aCoapBase, ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
     {
         return static_cast<CoapSecure &>(aCoapBase).Send(aMessage, aMessageInfo);
     }
-    otError Send(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     static void HandleDtlsConnected(void *aContext, bool aConnected);
     void        HandleDtlsConnected(bool aConnected);


### PR DESCRIPTION
This PR makes CoapBase::Send() private so that only safe methods
are exposed, such as SendMessage(), SendEmptyMessage(), SendAck().