### PR TITLE
[test] fix PRETTY_FILES definition in unit test makefile

### DIFF
--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -245,7 +245,7 @@ PRETTY_FILES                                                        = \
     $(test_pskc_SOURCES)                                              \
     $(test_spinel_decoder_SOURCES)                                    \
     $(test_spinel_encoder_SOURCES)                                    \
-    $(test_string)                                                    \
+    $(test_string_SOURCES)                                            \
     $(test_strlcat_SOURCES)                                           \
     $(test_strlcpy_SOURCES)                                           \
     $(test_strnlen_SOURCES)                                           \

--- a/tests/unit/test_string.cpp
+++ b/tests/unit/test_string.cpp
@@ -41,15 +41,14 @@ enum
     kStringSize = 10,
 };
 
-template <uint16_t kSize>
-void PrintString(const char *aName, const String<kSize> aString)
+template <uint16_t kSize> void PrintString(const char *aName, const String<kSize> aString)
 {
     printf("\t%s = [%d] \"%s\"\n", aName, aString.GetLength(), aString.AsCString());
 }
 
 void TestString(void)
 {
-    otError error;
+    otError             error;
     String<kStringSize> str1;
     String<kStringSize> str2("abc");
     String<kStringSize> str3("%d", 12);


### PR DESCRIPTION
The `test_string` source is also made "pretty".