### PR TITLE
[meshcop] border agent of native commissioner

### DIFF
--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -238,6 +238,7 @@ typedef enum otMeshcopTlvType
     OT_MESHCOP_TLV_SECURITYPOLICY           = 12,  ///< meshcop Security Policy TLV
     OT_MESHCOP_TLV_GET                      = 13,  ///< meshcop Get TLV
     OT_MESHCOP_TLV_ACTIVETIMESTAMP          = 14,  ///< meshcop Active Timestamp TLV
+    OT_MESHCOP_TLV_COMMISSIONER_UDP_PORT    = 15,  ///< meshcop Commissioner UDP Port TLV
     OT_MESHCOP_TLV_STATE                    = 16,  ///< meshcop State TLV
     OT_MESHCOP_TLV_JOINER_DTLS              = 17,  ///< meshcop Joiner DTLS Encapsulation TLV
     OT_MESHCOP_TLV_JOINER_UDP_PORT          = 18,  ///< meshcop Joiner UDP Port TLV

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -127,9 +127,8 @@ private:
 
     enum
     {
-        kBorderAgentUdpPort = 49191,     ///< UDP port of border agent service.
-        kKeepAliveTimeout   = 50 * 1000, ///< Timeout to reject a commissioner.
-        kRestartDelay       = 1 * 1000,  ///< Delay to restart border agent service.
+        kKeepAliveTimeout = 50 * 1000, ///< Timeout to reject a commissioner.
+        kRestartDelay     = 1 * 1000,  ///< Delay to restart border agent service.
     };
 
     Ip6::MessageInfo mMessageInfo;

--- a/src/core/meshcop/meshcop.hpp
+++ b/src/core/meshcop/meshcop.hpp
@@ -49,6 +49,7 @@ namespace MeshCoP {
 enum
 {
     kMeshCoPMessagePriority = Message::kPriorityNet, ///< The priority for MeshCoP message
+    kBorderAgentUdpPort     = 49191,                 ///< UDP port of border agent service.
 };
 
 /**

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -85,6 +85,7 @@ public:
         kSecurityPolicy          = OT_MESHCOP_TLV_SECURITYPOLICY,           ///< Security Policy TLV
         kGet                     = OT_MESHCOP_TLV_GET,                      ///< Get TLV
         kActiveTimestamp         = OT_MESHCOP_TLV_ACTIVETIMESTAMP,          ///< Active Timestamp TLV
+        kCommissionerUdpPort     = OT_MESHCOP_TLV_COMMISSIONER_UDP_PORT,    ///< Commissioner UDP Port TLV
         kState                   = OT_MESHCOP_TLV_STATE,                    ///< State TLV
         kJoinerDtlsEncapsulation = OT_MESHCOP_TLV_JOINER_DTLS,              ///< Joiner DTLS Encapsulation TLV
         kJoinerUdpPort           = OT_MESHCOP_TLV_JOINER_UDP_PORT,          ///< Joiner UDP Port TLV
@@ -975,6 +976,53 @@ public:
      *
      */
     bool IsValid(void) const { return GetLength() == sizeof(*this) - sizeof(Tlv); }
+} OT_TOOL_PACKED_END;
+
+/**
+ * This class implements Commissioner UDP Port TLV generation and parsing.
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+class CommissionerUdpPortTlv : public Tlv
+{
+public:
+    /**
+     * This method initializes the TLV.
+     *
+     */
+    void Init(void)
+    {
+        SetType(kCommissionerUdpPort);
+        SetLength(sizeof(*this) - sizeof(Tlv));
+    }
+
+    /**
+     * This method indicates whether or not the TLV appears to be well-formed.
+     *
+     * @retval TRUE   If the TLV appears to be well-formed.
+     * @retval FALSE  If the TLV does not appear to be well-formed.
+     *
+     */
+    bool IsValid(void) const { return GetLength() == sizeof(*this) - sizeof(Tlv); }
+
+    /**
+     * This method returns the UDP Port value.
+     *
+     * @returns The UDP Port value.
+     *
+     */
+    uint16_t GetUdpPort(void) const { return HostSwap16(mUdpPort); }
+
+    /**
+     * This method sets the UDP Port value.
+     *
+     * @param[in]  aUdpPort  The UDP Port value.
+     *
+     */
+    void SetUdpPort(uint16_t aUdpPort) { mUdpPort = HostSwap16(aUdpPort); }
+
+private:
+    uint16_t mUdpPort;
 } OT_TOOL_PACKED_END;
 
 /**

--- a/src/core/net/ip6_filter.cpp
+++ b/src/core/net/ip6_filter.cpp
@@ -37,6 +37,7 @@
 
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
+#include "meshcop/meshcop.hpp"
 #include "net/ip6.hpp"
 #include "net/tcp.hpp"
 #include "net/udp6.hpp"
@@ -46,6 +47,7 @@ namespace ot {
 namespace Ip6 {
 
 Filter::Filter(void)
+    : mAllowNativeCommissioner(true)
 {
     memset(mUnsecurePorts, 0, sizeof(mUnsecurePorts));
 }
@@ -84,6 +86,11 @@ bool Filter::Accept(Message &aMessage) const
             ExitNow(rval = true);
         }
 
+        // Allow native commissioner traffic
+        if (mAllowNativeCommissioner && dstport == MeshCoP::kBorderAgentUdpPort)
+        {
+            ExitNow(rval = true);
+        }
         break;
 
     case kProtoTcp:

--- a/src/core/net/ip6_filter.hpp
+++ b/src/core/net/ip6_filter.hpp
@@ -115,12 +115,21 @@ public:
      */
     const uint16_t *GetUnsecurePorts(uint8_t &aNumEntries) const;
 
+    /**
+     * This method sets whether to allow native commissioner traffic.
+     *
+     * @param[in]   aAllow  Whether to allow native commissioner traffic.
+     *
+     */
+    void AllowNativeCommissioner(bool aAllow) { mAllowNativeCommissioner = aAllow; }
+
 private:
     enum
     {
         kMaxUnsecurePorts = 2,
     };
     uint16_t mUnsecurePorts[kMaxUnsecurePorts];
+    bool     mAllowNativeCommissioner;
 };
 
 } // namespace Ip6

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1530,6 +1530,12 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
         Store();
     }
 
+    if (aFlags & OT_CHANGED_SECURITY_POLICY)
+    {
+        GetNetif().GetIp6Filter().AllowNativeCommissioner(GetNetif().GetKeyManager().GetSecurityPolicyFlags() &
+                                                          OT_SECURITY_POLICY_NATIVE_COMMISSIONING);
+    }
+
 exit:
     return;
 }

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1532,8 +1532,8 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
 
     if (aFlags & OT_CHANGED_SECURITY_POLICY)
     {
-        GetNetif().GetIp6Filter().AllowNativeCommissioner(GetNetif().GetKeyManager().GetSecurityPolicyFlags() &
-                                                          OT_SECURITY_POLICY_NATIVE_COMMISSIONING);
+        GetNetif().GetIp6Filter().AllowNativeCommissioner(
+            (GetNetif().GetKeyManager().GetSecurityPolicyFlags() & OT_SECURITY_POLICY_NATIVE_COMMISSIONING) != 0);
     }
 
 exit:

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2742,6 +2742,12 @@ otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint1
 
     if (netif.GetKeyManager().GetSecurityPolicyFlags() & OT_SECURITY_POLICY_NATIVE_COMMISSIONING)
     {
+        MeshCoP::CommissionerUdpPortTlv commissionerUdpPort;
+
+        commissionerUdpPort.Init();
+        commissionerUdpPort.SetUdpPort(MeshCoP::kBorderAgentUdpPort);
+        SuccessOrExit(error = message->Append(&commissionerUdpPort, sizeof(commissionerUdpPort)));
+
         discoveryResponse.SetNativeCommissioner(true);
     }
     else


### PR DESCRIPTION
This PR enables a node serve as the border agent of native commissioner
by adding the border agent UDP port to unsecure port when the security
policy allows.

To fully test verify this PR, we need a native commissioner, which I
will submit a separate PR to enable that.