### PR TITLE
[mle] stop attach timer from SetStateChild()

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -739,6 +739,7 @@ otError Mle::SetStateChild(uint16_t aRloc16)
     SetRloc16(aRloc16);
     SetRole(OT_DEVICE_ROLE_CHILD);
     SetAttachState(kAttachStateIdle);
+    mAttachTimer.Stop();
     mAttachCounter       = 0;
     mReattachState       = kReattachStop;
     mChildUpdateAttempts = 0;


### PR DESCRIPTION
This commit changes `SetStateChild()` to stop `mAttachTimer`. This
ensures that as the `mAttachState` is set to idle, the attach timer is
also stopped (note that the attach timer callback asserts on idle
attach state). This addresses a rare issue where an inopportune device
mode change request on an already attached device while it is
performing periodic parent search (or possibly delaying processing of
a received announce) could cause an assert; `SetDeviceMode()` would
call `SetStateChild()` setting the attach state to idle while attach
timer would continue to run.