### PR TITLE
[core] add Set class

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -116,6 +116,7 @@ LOCAL_SRC_FILES                                          := \
     src/core/common/locator.cpp                             \
     src/core/common/message.cpp                             \
     src/core/common/notifier.cpp                            \
+    src/core/common/set.cpp                                 \
     src/core/common/settings.cpp                            \
     src/core/common/string.cpp                              \
     src/core/common/tasklet.cpp                             \

--- a/etc/visual-studio/libopenthread.vcxproj
+++ b/etc/visual-studio/libopenthread.vcxproj
@@ -82,6 +82,7 @@
     <ClCompile Include="..\..\src\core\common\logging.cpp" />
     <ClCompile Include="..\..\src\core\common\message.cpp" />
     <ClCompile Include="..\..\src\core\common\notifier.cpp" />
+    <ClCompile Include="..\..\src\core\common\set.cpp" />
     <ClCompile Include="..\..\src\core\common\settings.cpp" />
     <ClCompile Include="..\..\src\core\common\string.cpp" />
     <ClCompile Include="..\..\src\core\common\tasklet.cpp" />
@@ -175,6 +176,7 @@
     <ClInclude Include="..\..\src\core\common\message.hpp" />
     <ClInclude Include="..\..\src\core\common\notifier.hpp" />
     <ClInclude Include="..\..\src\core\common\new.hpp" />
+    <ClInclude Include="..\..\src\core\common\set.hpp" />
     <ClInclude Include="..\..\src\core\common\string.hpp" />
     <ClInclude Include="..\..\src\core\common\tasklet.hpp" />
     <ClInclude Include="..\..\src\core\common\timer.hpp" />

--- a/etc/visual-studio/libopenthread.vcxproj.filters
+++ b/etc/visual-studio/libopenthread.vcxproj.filters
@@ -144,6 +144,9 @@
     <ClCompile Include="..\..\src\core\common\notifier.cpp">
       <Filter>Source Files\common</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\core\common\set.cpp">
+      <Filter>Source Files\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\core\common\settings.cpp">
       <Filter>Source Files\common</Filter>
     </ClCompile>
@@ -411,6 +414,9 @@
       <Filter>Header Files\common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\core\common\new.hpp">
+      <Filter>Header Files\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\common\set.hpp">
       <Filter>Header Files\common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\core\common\string.hpp">

--- a/etc/visual-studio/libopenthread_k.vcxproj
+++ b/etc/visual-studio/libopenthread_k.vcxproj
@@ -91,6 +91,7 @@
     <ClCompile Include="..\..\src\core\common\logging.cpp" />
     <ClCompile Include="..\..\src\core\common\message.cpp" />
     <ClCompile Include="..\..\src\core\common\notifier.cpp" />
+    <ClCompile Include="..\..\src\core\common\set.cpp" />
     <ClCompile Include="..\..\src\core\common\settings.cpp" />
     <ClCompile Include="..\..\src\core\common\string.cpp" />
     <ClCompile Include="..\..\src\core\common\tasklet.cpp" />
@@ -202,6 +203,7 @@
     <ClInclude Include="..\..\src\core\common\message.hpp" />
     <ClInclude Include="..\..\src\core\common\notifier.hpp" />
     <ClInclude Include="..\..\src\core\common\new.hpp" />
+    <ClInclude Include="..\..\src\core\common\set.hpp" />
     <ClInclude Include="..\..\src\core\common\string.hpp" />
     <ClInclude Include="..\..\src\core\common\tasklet.hpp" />
     <ClInclude Include="..\..\src\core\common\timer.hpp" />

--- a/etc/visual-studio/libopenthread_k.vcxproj.filters
+++ b/etc/visual-studio/libopenthread_k.vcxproj.filters
@@ -141,6 +141,9 @@
     <ClCompile Include="..\..\src\core\common\notifier.cpp">
       <Filter>Source Files\common</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\core\common\set.cpp">
+      <Filter>Source Files\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\core\common\settings.cpp">
       <Filter>Source Files\common</Filter>
     </ClCompile>
@@ -405,6 +408,9 @@
       <Filter>Header Files\common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\core\common\new.hpp">
+      <Filter>Header Files\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\common\set.hpp">
       <Filter>Header Files\common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\core\common\string.hpp">

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -139,6 +139,7 @@ SOURCES_COMMON                      = \
     common/logging.cpp                \
     common/message.cpp                \
     common/notifier.cpp               \
+    common/set.cpp                    \
     common/settings.cpp               \
     common/string.cpp                 \
     common/tasklet.cpp                \
@@ -239,6 +240,7 @@ libopenthread_radio_a_SOURCES       = \
     common/locator.cpp                \
     common/logging.cpp                \
     common/message.cpp                \
+    common/set.cpp                    \
     common/string.cpp                 \
     common/tasklet.cpp                \
     common/timer.cpp                  \
@@ -303,6 +305,7 @@ HEADERS_COMMON                      = \
     common/notifier.hpp               \
     common/owner-locator.hpp          \
     common/random.hpp                 \
+    common/set.hpp                    \
     common/settings.hpp               \
     common/string.hpp                 \
     common/tasklet.hpp                \

--- a/src/core/common/set.cpp
+++ b/src/core/common/set.cpp
@@ -1,0 +1,160 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *  This file implements OpenThread Set class.
+ */
+
+#include "set.hpp"
+
+namespace ot {
+
+bool SetApi::IsEmpty(const uint8_t *aMask, uint16_t aMaskLength)
+{
+    bool isEmpty = true;
+
+    for (; aMaskLength > 0; aMaskLength--, aMask++)
+    {
+        VerifyOrExit(*aMask == 0, isEmpty = false);
+    }
+
+exit:
+    return isEmpty;
+}
+
+void SetApi::Itersect(uint8_t *aMask, const uint8_t *aOtherMask, uint16_t aMaskLength)
+{
+    for (; aMaskLength > 0; aMaskLength--, aMask++, aOtherMask++)
+    {
+        *aMask &= *aOtherMask;
+    }
+}
+
+void SetApi::Union(uint8_t *aMask, const uint8_t *aOtherMask, uint16_t aMaskLength)
+{
+    for (; aMaskLength > 0; aMaskLength--, aMask++, aOtherMask++)
+    {
+        *aMask |= *aOtherMask;
+    }
+}
+
+uint16_t SetApi::GetNumberOfElements(const uint8_t *aMask, uint16_t aMaskLength)
+{
+    // Number of `1` bits in binary representation of 0x0 to 0xF
+    static const uint8_t kBitCount[16] = {
+        0, // 0x0 -> 0000
+        1, // 0x1 -> 0001
+        1, // 0x2 -> 0010
+        2, // 0x3 -> 0011
+        1, // 0x4 -> 0100
+        2, // 0x5 -> 0101
+        2, // 0x6 -> 0110
+        3, // 0x7 -> 0111
+        1, // 0x8 -> 1000
+        2, // 0x9 -> 1001
+        2, // 0xa -> 1010
+        3, // 0xb -> 1011
+        2, // 0xc -> 1100
+        3, // 0xd -> 1101
+        3, // 0xe -> 1110
+        4, // 0xf -> 1111
+    };
+
+    uint16_t count = 0;
+
+    for (; aMaskLength > 0; aMaskLength--, aMask++)
+    {
+        uint8_t byte = *aMask;
+
+        count += kBitCount[byte & 0xf];
+        count += kBitCount[byte >> 4];
+    }
+
+    return count;
+}
+
+otError SetApi::GetNextElement(const uint8_t *aMaskArray, uint16_t &aElement, uint16_t aMaxSize)
+{
+    otError error = OT_ERROR_NOT_FOUND;
+
+    for (uint16_t element = (aElement == kSetIteratorFirst) ? 0 : (aElement + 1); element < aMaxSize; element++)
+    {
+        if (aMaskArray[element >> 3] & (1U << (element & 0x7)))
+        {
+            aElement = element;
+            error    = OT_ERROR_NONE;
+            break;
+        }
+    }
+
+    return error;
+}
+
+SetApi::InfoString SetApi::ToString(const uint8_t *aMaskArray, uint16_t aMaxSize)
+{
+    InfoString string;
+    uint16_t   element  = SetApi::kSetIteratorFirst;
+    bool       addComma = false;
+    otError    error;
+
+    SuccessOrExit(string.Append("{"));
+
+    error = GetNextElement(aMaskArray, element, aMaxSize);
+
+    while (error == OT_ERROR_NONE)
+    {
+        uint16_t rangeStart = element;
+        uint16_t rangeEnd   = element;
+
+        while ((error = GetNextElement(aMaskArray, element, aMaxSize)) == OT_ERROR_NONE)
+        {
+            if (element != rangeEnd + 1)
+            {
+                break;
+            }
+
+            rangeEnd = element;
+        }
+
+        SuccessOrExit(string.Append("%s%d", addComma ? ", " : " ", rangeStart));
+        addComma = true;
+
+        if (rangeStart < rangeEnd)
+        {
+            SuccessOrExit(string.Append("%s%d", rangeEnd == rangeStart + 1 ? ", " : "-", rangeEnd));
+        }
+    }
+
+    string.Append(" }");
+
+exit:
+    return string;
+}
+
+} // namespace ot

--- a/src/core/common/set.hpp
+++ b/src/core/common/set.hpp
@@ -1,0 +1,407 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *  This file defines OpenThread String class.
+ */
+
+#ifndef SET_HPP_
+#define SET_HPP_
+
+#include "openthread-core-config.h"
+
+#include "common/encoding.hpp"
+#include "common/string.hpp"
+
+namespace ot {
+
+/**
+ * @addtogroup core-set
+ *
+ * @brief
+ *   This module includes definitions for OpenThread Set (of integers).
+ *
+ * @{
+ *
+ */
+
+/**
+ * This class defines the common (non-template) APIs and types inherited by `Set` class.
+ *
+ */
+class SetApi
+{
+public:
+    enum
+    {
+        kSetIteratorFirst = 0xffff, ///< Element value passed to `GetNextElement()` to get the first element of the set.
+        kInfoStringSize   = 100,    ///< Max chars for the info string (`ToString()`).
+    };
+
+    /**
+     * This type defines the fixed-length `String` object returned from `ToString()`.
+     *
+     */
+    typedef String<kInfoStringSize> InfoString;
+
+protected:
+    SetApi(void) {}
+    static bool       IsEmpty(const uint8_t *aMaskArray, uint16_t aMaskArrayLength);
+    static void       Itersect(uint8_t *aMaskArray, const uint8_t *aOtherMaskArray, uint16_t aMaskArrayLength);
+    static void       Union(uint8_t *aMaskArray, const uint8_t *aOtherMaskArray, uint16_t aMaskArrayLength);
+    static uint16_t   GetNumberOfElements(const uint8_t *aMaskArray, uint16_t aMaskArrayLength);
+    static otError    GetNextElement(const uint8_t *aMaskArray, uint16_t &aElement, uint16_t aMaxSize);
+    static InfoString ToString(const uint8_t *aMaskArray, uint16_t aMaxSize);
+};
+
+/**
+ * This class defines a `Set` of integers capable of storing elements from `0` up to but not including `kMaxSize`.
+ *
+ * The template parameter `kMaxSize` specifies the maximum set size (maximum number of elements) and valid range of
+ * values that can stored in the set.
+ *
+ * This is base template class for `Set` providing all common methods.
+ *
+ */
+template <uint16_t kMaxSize> class SetBase : public SetApi
+{
+public:
+    /**
+     * This method clears the set.
+     *
+     */
+    void Clear(void) { memset(mMaskArray, 0, kMaskArrayLength); }
+
+    /**
+     * This method indicates whether the set is empty or not.
+     *
+     * @retval TRUE     Set is empty.
+     * @retval FALSE    Set is not empty.
+     *
+     */
+    bool IsEmpty(void) const { return SetApi::IsEmpty(mMaskArray, kMaskArrayLength); }
+
+    /**
+     * This method indicates whether or not the set contains a given element.
+     *
+     * @note The given element @p aElement MUST be within valid range of `0` up to but not including `kMaxSize`.
+     * Otherwise, the behavior of this method is undefined.
+     *
+     * @param[in] aElement   Element to check.
+     *
+     * @retval TRUE   The element is contained in the set.
+     * @retval FALSE  The element is not contained in the set.
+     *
+     */
+    bool Contains(uint16_t aElement) const { return (Mask(aElement) & Bit(aElement)) != 0; }
+
+    /**
+     * This method adds an element to the set.
+     *
+     * @note The given element @p aElement MUST be within valid range of `0` up to but not including `kMaxSize`.
+     * Otherwise, the behavior of this method is undefined.
+     *
+     * @param[in] aElement   Element to add.
+     *
+     */
+    void Add(uint16_t aElement) { Mask(aElement) |= Bit(aElement); }
+
+    /**
+     * This method removes an element from the set.
+     *
+     * @note The given element @p aElement MUST be within valid range of `0` up to but not including `kMaxSize`.
+     * Otherwise, the behavior of this method is undefined.
+     *
+     * @param[in] aElement   Element to remove.
+     *
+     */
+    void Remove(uint16_t aElement) { Mask(aElement) &= ~Bit(aElement); }
+
+    /**
+     * This method flips an element in the set (i.e. it is added if not in set, removed if in the set).
+     *
+     * @note The given element @p aElement MUST be within valid range of `0` up to but not including `kMaxSize`.
+     * Otherwise, the behavior of this method is undefined.
+     *
+     * @param[in] aElement   Element to flip.
+     *
+     */
+    void Flip(uint16_t aElement) { Mask(aElement) ^= Bit(aElement); }
+
+    /**
+     * This method updates the set to be intersection of the current set with another given set.
+     *
+     * @param[in] aAnother   Another set to perform intersect operation.
+     *
+     */
+    void Intersect(const SetBase &aAnother) { SetApi::Itersect(mMaskArray, aAnother.mMaskArray, kMaskArrayLength); }
+
+    /**
+     * This method updates the set to be the union of the current set and another given set.
+     *
+     * @param[in] aAnother   Another set to perform union operation.
+     *
+     */
+    void Union(const SetBase &aAnother) { SetApi::Union(mMaskArray, aAnother.mMaskArray, kMaskArrayLength); }
+
+    /**
+     * This method gets the number of elements in the set.
+     *
+     * @returns  Number of elements in the set.
+     *
+     */
+    uint16_t GetNumberOfElements(void) const { return SetApi::GetNumberOfElements(mMaskArray, kMaskArrayLength); }
+
+    /**
+     * This method gets the next element in the set given a previous one.
+     *
+     * This method is used to iterate over all elements in the set.
+     *
+     * @param[inout] aElement   Reference to an element variable.
+     *                          On entry it can be `kSetIteratorFirst` to get the first element of the set, or
+     *                          a previous element. On exit, the next element in set is returned in this variable.
+     *
+     * @retval OT_ERROR_NONE       Successfully iterated to next element in set, @p aElement is updated.
+     * @retval OT_ERROR_NOT_FOUND  No more element in the set.
+     *
+     */
+    otError GetNextElement(uint16_t &aElement) const { return SetApi::GetNextElement(mMaskArray, aElement, kMaxSize); }
+
+    /**
+     * This method overloads `==` operator to indicate whether two sets are equal.
+     *
+     * @param[in] aAnother   A reference to another set to compare with the current one.
+     *
+     * @returns TRUE if the two set are equal, FALSE otherwise.
+     *
+     */
+    bool operator==(const SetBase &aAnother) const
+    {
+        return memcmp(mMaskArray, aAnother.mMaskArray, kMaskArrayLength) == 0;
+    }
+
+    /**
+     * This method overloads `!=` operator to indicate whether two sets are not equal.
+     *
+     * @param[in] aAnother   A reference to another set to compare with the current one.
+     *
+     * @returns TRUE if the two set are not equal, FALSE otherwise.
+     *
+     */
+    bool operator!=(const SetBase &aAnother) const
+    {
+        return memcmp(mMaskArray, aAnother.mMaskArray, kMaskArrayLength) != 0;
+    }
+
+    /**
+     * This method returns the maximum set size (maximum number of elements in the set).
+     *
+     * @note The elements in the set must be within range of `0` up to but not including `kMaxSize`.
+     *
+     * @returns The maximum set size.
+     *
+     */
+    uint16_t GetMaxSize(void) const { return kMaxSize; }
+
+    /**
+     * This method converts the set into a human-readable string.
+     *
+     * Examples of possible output:
+     *  -  empty set       ->  "{ }"
+     *  -  ranges          ->  "{ 11-26 }"
+     *  -  single element  ->  "{ 20 }"
+     *  -  multiple ranges ->  "{ 11, 14-17, 20-22, 24, 25 }"
+     *  -  no range        ->  "{ 14, 21, 26 }"
+     *
+     * @returns  An `InfoString` object representing the set.
+     *
+     */
+    InfoString ToString(void) const { return SetApi::ToString(mMaskArray, kMaxSize); }
+
+protected:
+    enum
+    {
+        kMaskArrayLength = BitVectorBytes(kMaxSize), ///< Length of bitmask array (number of bytes)
+    };
+
+    /**
+     * This constructor initializes the object
+     *
+     * Protected constructor to ensure only sub-classes can be instantiated.
+     *
+     */
+    SetBase(void)
+        : SetApi()
+    {
+        Clear();
+    }
+
+    // Returns a bitmask corresponding to a given element.
+    uint8_t Bit(uint16_t aElement) const { return static_cast<uint8_t>(1U << (aElement & 7)); }
+
+    // Returns a reference to the byte in the mask array corresponding to the given element in set.
+    uint8_t &Mask(uint16_t aElement) { return mMaskArray[aElement >> 3]; }
+
+    // Returns a const reference to the byte in the mask array corresponding to the given element in set.
+    const uint8_t &Mask(uint16_t aElement) const { return mMaskArray[aElement >> 3]; }
+
+    uint8_t mMaskArray[kMaskArrayLength];
+};
+
+/**
+ * This class defines a set of integers (capable of storing elements from `0` up to but not including `kMaxSize`).
+ *
+ * The template parameter `kMaxSize` specifies the range of valid values that can stored in the set.
+ *
+ */
+template <uint16_t kMaxSize> class Set : public SetBase<kMaxSize>
+{
+public:
+    /**
+     * This constructor initializes the set object
+     *
+     * Set starts as empty.
+     *
+     */
+    Set(void)
+        : SetBase<kMaxSize>()
+    {
+    }
+};
+
+/**
+ * This definition is a template customization of `Set<>` class for size 16.
+ *
+ */
+template <> class Set<16> : public SetBase<16>
+{
+public:
+    /**
+     * This constructor initializes the set object
+     *
+     * The set starts as empty.
+     *
+     */
+    Set(void)
+        : SetBase<16>()
+    {
+    }
+
+    /**
+     * This constructor initializes the set object from a given `uint16_t` bit-vector mask (little endian order).
+     *
+     * Bit 0 (LSB) in the bit-vector mask corresponds to element 0, bit 1 to element 1, and so on.
+     *
+     * @param[in] aBitMask   A `uint16_t` bit-vector mask.
+     *
+     */
+    explicit Set(uint16_t aBitMask)
+        : SetBase<16>()
+    {
+        SetFromMask(aBitMask);
+    }
+
+    /**
+     * This method converts the set into `uint16_t` bit-vector mask (little endian order).
+     *
+     * Bit 0 (LSB) in the bit-vector mask corresponds to element 0, bit 1 to element 1, and so on.
+     *
+     * @returns A bit-vector mask corresponding to elements in the set.
+     *
+     */
+    uint16_t GetAsMask(void) const { return Encoding::LittleEndian::ReadUint16(mMaskArray); }
+
+    /**
+     * This method populates the set from a given `uint16_t` bit-vector mask (little endian order).
+     *
+     * Bit 0 (LSB) in the bit-vector mask corresponds to element 0, bit 1 to element 1, and so on.
+     *
+     */
+    void SetFromMask(uint16_t aBitMask) { Encoding::LittleEndian::WriteUint16(aBitMask, mMaskArray); }
+};
+
+/**
+ * This definition is a template customization of `Set<>` class for size 32.
+ *
+ */
+template <> class Set<32> : public SetBase<32>
+{
+public:
+    /**
+     * This constructor initializes the set object
+     *
+     * The set starts as empty.
+     *
+     */
+    Set(void)
+        : SetBase<32>()
+    {
+    }
+
+    /**
+     * This constructor initializes the set object from a given `uint32_t` bit-vector mask (little endian order).
+     *
+     * Bit 0 (LSB) in the bit-vector mask corresponds to element 0, bit 1 to element 1, and so on.
+     *
+     * @param[in] aBitMask   A `uint32_t` bit-vector mask.
+     *
+     */
+    explicit Set(uint32_t mBitMask)
+        : SetBase<32>()
+    {
+        SetFromMask(mBitMask);
+    }
+
+    /**
+     * This method converts the set into `uint32_t` bit-vector mask (little endian order).
+     *
+     * Bit 0 (LSB) in the bit-vector mask corresponds to element 0, bit 1 to element 1, and so on.
+     *
+     * @returns A bit-vector mask corresponding to elements in the set.
+     *
+     */
+    uint32_t GetAsMask(void) const { return Encoding::LittleEndian::ReadUint32(mMaskArray); }
+
+    /**
+     * This method populates the set from a given `uint32_t` bit-vector mask (little endian order).
+     *
+     * Bit 0 (LSB) in the bit-vector mask corresponds to element 0, bit 1 to element 1, and so on.
+     *
+     */
+    void SetFromMask(uint32_t aBitMask) { Encoding::LittleEndian::WriteUint32(aBitMask, mMaskArray); }
+};
+
+/**
+ * @}
+ *
+ */
+
+} // namespace ot
+
+#endif // OT_SET_HPP_

--- a/src/core/mac/channel_mask.cpp
+++ b/src/core/mac/channel_mask.cpp
@@ -40,78 +40,25 @@
 namespace ot {
 namespace Mac {
 
-uint8_t ChannelMask::GetNumberOfChannels(void) const
-{
-    uint8_t num     = 0;
-    uint8_t channel = kChannelIteratorFirst;
-
-    while (GetNextChannel(channel) == OT_ERROR_NONE)
-    {
-        num++;
-    }
-
-    return num;
-}
-
 otError ChannelMask::GetNextChannel(uint8_t &aChannel) const
 {
-    otError error = OT_ERROR_NOT_FOUND;
+    otError  error;
+    uint16_t element;
 
     if (aChannel == kChannelIteratorFirst)
     {
-        aChannel = (OT_RADIO_CHANNEL_MIN - 1);
+        element = Set<32>::kSetIteratorFirst;
+    }
+    else
+    {
+        element = aChannel;
     }
 
-    for (aChannel++; aChannel <= OT_RADIO_CHANNEL_MAX; aChannel++)
-    {
-        if (ContainsChannel(aChannel))
-        {
-            ExitNow(error = OT_ERROR_NONE);
-        }
-    }
+    SuccessOrExit(error = mChannels.GetNextElement(element));
+    aChannel = static_cast<uint8_t>(element);
 
 exit:
     return error;
-}
-
-ChannelMask::InfoString ChannelMask::ToString(void) const
-{
-    InfoString string;
-    uint8_t    channel  = kChannelIteratorFirst;
-    bool       addComma = false;
-    otError    error;
-
-    string.Append("{");
-
-    error = GetNextChannel(channel);
-
-    while (error == OT_ERROR_NONE)
-    {
-        uint8_t rangeStart = channel;
-        uint8_t rangeEnd   = channel;
-
-        while ((error = GetNextChannel(channel)) == OT_ERROR_NONE)
-        {
-            if (channel != rangeEnd + 1)
-            {
-                break;
-            }
-
-            rangeEnd = channel;
-        }
-
-        string.Append("%s%d", addComma ? ", " : " ", rangeStart);
-        addComma = true;
-
-        if (rangeStart < rangeEnd)
-        {
-            string.Append("%s%d", rangeEnd == rangeStart + 1 ? ", " : "-", rangeEnd);
-        }
-    }
-
-    string.Append("}");
-
-    return string;
 }
 
 } // namespace Mac

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -31,6 +31,7 @@
 
 #include "common/encoding.hpp"
 #include "common/locator.hpp"
+#include "common/set.hpp"
 #include "mac/mac_frame.hpp"
 #include "thread/mle_constants.hpp"
 #include "thread/thread_tlvs.hpp"
@@ -341,12 +342,12 @@ private:
         return const_cast<Router *>(const_cast<const RouterTable *>(this)->GetNextEntry(aRouter));
     }
 
-    Router   mRouters[Mle::kMaxRouters];
-    uint8_t  mAllocatedRouterIds[BitVectorBytes(Mle::kMaxRouterId + 1)];
-    uint8_t  mRouterIdReuseDelay[Mle::kMaxRouterId + 1];
-    uint32_t mRouterIdSequenceLastUpdated;
-    uint8_t  mRouterIdSequence;
-    uint8_t  mActiveRouterCount;
+    Router                     mRouters[Mle::kMaxRouters];
+    uint32_t                   mRouterIdSequenceLastUpdated;
+    uint8_t                    mRouterIdSequence;
+    uint8_t                    mActiveRouterCount;
+    Set<Mle::kMaxRouterId + 1> mAllocatedRouterIds;
+    uint8_t                    mRouterIdReuseDelay[Mle::kMaxRouterId + 1];
 };
 
 #endif // OPENTHREAD_FTD

--- a/src/ncp/changed_props_set.hpp
+++ b/src/ncp/changed_props_set.hpp
@@ -38,6 +38,7 @@
 #include <stddef.h>
 
 #include <openthread/error.h>
+#include "common/set.hpp"
 
 #include "spinel.h"
 
@@ -53,6 +54,11 @@ namespace Ncp {
 class ChangedPropsSet
 {
 public:
+    enum
+    {
+        kMaxSize = 48, ///< Specifies the maximum number of entries (max set size).
+    };
+
     /**
      * Defines an entry in the set/list.
      *
@@ -69,8 +75,8 @@ public:
      *
      */
     ChangedPropsSet(void)
-        : mChangedSet(0)
-        , mFilterSet(0)
+        : mChangedSet()
+        , mFilterSet()
     {
     }
 
@@ -78,7 +84,7 @@ public:
      * This method clears the set.
      *
      */
-    void Clear(void) { mChangedSet = 0; }
+    void Clear(void) { mChangedSet.Clear(); }
 
     /**
      * This method indicates if the set is empty or not.
@@ -86,7 +92,7 @@ public:
      * @returns TRUE if the set if empty, FALSE otherwise.
      *
      */
-    bool IsEmpty(void) const { return (mChangedSet == 0); }
+    bool IsEmpty(void) const { return mChangedSet.IsEmpty(); }
 
     /**
      * This method adds a property to the set. The property added must be in the list of supported properties
@@ -141,7 +147,7 @@ public:
      * @returns TRUE if the entry is in the set, FALSE otherwise.
      *
      */
-    bool IsEntryChanged(uint8_t aIndex) const { return IsBitSet(mChangedSet, aIndex); }
+    bool IsEntryChanged(uint8_t aIndex) const { return mChangedSet.Contains(aIndex); }
 
     /**
      * This method removes an entry associated with an index in the set.
@@ -151,7 +157,7 @@ public:
      * @param[in] aIndex               Index of entry to be removed.
      *
      */
-    void RemoveEntry(uint8_t aIndex) { ClearBit(mChangedSet, aIndex); }
+    void RemoveEntry(uint8_t aIndex) { mChangedSet.Remove(aIndex); }
 
     /**
      * This method enables/disables filtering of a given property.
@@ -173,7 +179,7 @@ public:
      * @returns TRUE if the filter is enabled for the given entry, FALSE otherwise.
      *
      */
-    bool IsEntryFiltered(uint8_t aIndex) const { return IsBitSet(mFilterSet, aIndex); }
+    bool IsEntryFiltered(uint8_t aIndex) const { return mFilterSet.Contains(aIndex); }
 
     /**
      * This method determines whether filtering is enabled for a given property key.
@@ -190,20 +196,16 @@ public:
      * This method clears the filter.
      *
      */
-    void ClearFilter(void) { mFilterSet = 0; }
+    void ClearFilter(void) { mFilterSet.Clear(); }
 
 private:
     uint8_t GetNumEntries(void) const;
     void    Add(spinel_prop_key_t aPropKey, spinel_status_t aStatus);
 
-    static void SetBit(uint64_t &aBitset, uint8_t aBitIndex) { aBitset |= (1ULL << aBitIndex); }
-    static void ClearBit(uint64_t &aBitset, uint8_t aBitIndex) { aBitset &= ~(1ULL << aBitIndex); }
-    static bool IsBitSet(uint64_t aBitset, uint8_t aBitIndex) { return (aBitset & (1ULL << aBitIndex)) != 0; }
-
     static const Entry mSupportedProps[];
 
-    uint64_t mChangedSet;
-    uint64_t mFilterSet;
+    Set<kMaxSize> mChangedSet;
+    Set<kMaxSize> mFilterSet;
 };
 
 } // namespace Ncp

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -115,6 +115,7 @@ check_PROGRAMS                                                      = \
     test-network-data                                                 \
     test-priority-queue                                               \
     test-pskc                                                         \
+    test-set                                                          \
     test-spinel-decoder                                               \
     test-spinel-encoder                                               \
     test-string                                                       \
@@ -202,6 +203,9 @@ test_priority_queue_SOURCES  = test_platform.cpp test_priority_queue.cpp
 test_pskc_LDADD              = $(COMMON_LDADD)
 test_pskc_SOURCES            = test_platform.cpp test_pskc.cpp
 
+test_set_LDADD               = $(COMMON_LDADD)
+test_set_SOURCES             = test_platform.cpp test_set.cpp
+
 test_string_LDADD            = $(COMMON_LDADD)
 test_string_SOURCES          = test_platform.cpp test_string.cpp
 
@@ -243,6 +247,7 @@ PRETTY_FILES                                                        = \
     $(test_network_data_SOURCES)                                      \
     $(test_priority_queue_SOURCES)                                    \
     $(test_pskc_SOURCES)                                              \
+    $(test_set_SOURCES)                                               \
     $(test_spinel_decoder_SOURCES)                                    \
     $(test_spinel_encoder_SOURCES)                                    \
     $(test_string_SOURCES)                                            \

--- a/tests/unit/test_set.cpp
+++ b/tests/unit/test_set.cpp
@@ -1,0 +1,375 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test_platform.h"
+
+#include <openthread/config.h>
+
+#include "test_util.h"
+#include "common/code_utils.hpp"
+#include "common/set.hpp"
+
+namespace ot {
+
+// First 100 prime numbers.
+const uint16_t kPrimes[] = {2,   3,   5,   7,   11,  13,  17,  19,  23,  29,  31,  37,  41,  43,  47,  53,  59,
+                            61,  67,  71,  73,  79,  83,  89,  97,  101, 103, 107, 109, 113, 127, 131, 137, 139,
+                            149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233,
+                            239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311, 313, 317, 331, 337,
+                            347, 349, 353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419, 421, 431, 433, 439,
+                            443, 449, 457, 461, 463, 467, 479, 487, 491, 499, 503, 509, 521, 523, 541};
+
+template <uint16_t kMaxSize>
+void VerifySetContent(const Set<kMaxSize> &aSet, const uint16_t *aElements, uint16_t aLength)
+{
+    uint16_t index = 0;
+    uint16_t element;
+
+    // Verify that the set element matches with the entries in `aElements` list.
+
+    for (element = 0; element < aSet.GetMaxSize(); element++)
+    {
+        bool shouldContain = false;
+
+        if ((index < aLength) && (element == aElements[index]))
+        {
+            index++;
+            shouldContain = true;
+        }
+
+        VerifyOrQuit(aSet.Contains(element) == shouldContain, "Contains() does not match expected value");
+    }
+
+    // Iterate through set elements and verify that they match the `aElements` array (in same order).
+
+    index   = 0;
+    element = Set<kMaxSize>::kSetIteratorFirst;
+
+    while (aSet.GetNextElement(element) == OT_ERROR_NONE)
+    {
+        VerifyOrQuit(element == aElements[index++], "GetNextElement() failed\n");
+    }
+
+    VerifyOrQuit(index == aLength, "GetNextElement() did not return all expects elements\n");
+
+    // Check IsEmpty() and GetNumberOfElements().
+
+    VerifyOrQuit(aSet.IsEmpty() == (aLength == 0), "IsEmpty() failed");
+    VerifyOrQuit(aSet.GetNumberOfElements() == aLength, "GetNumberOfElements() failed");
+}
+
+template <uint16_t kMaxSize, typename MaskType> void VerifySetContent(const Set<kMaxSize> &aSet, MaskType aBitMask)
+{
+    // Verify that only the elements from `aBitMask` are contained the set.
+
+    printf("bitmask = 0x%x -- set = %s  \n", static_cast<uint32_t>(aBitMask), aSet.ToString().AsCString());
+
+    for (uint16_t element = 0; element < aSet.GetMaxSize(); element++)
+    {
+        bool shouldContain = ((aBitMask & (1UL << element)) != 0);
+
+        VerifyOrQuit(aSet.Contains(element) == shouldContain, "Contains() does not match expected value");
+    }
+}
+
+template <uint16_t kMaxSize> void PopulateSet(Set<kMaxSize> &aSet, const uint16_t *aList, uint16_t aListLength)
+{
+    aSet.Clear();
+
+    for (uint16_t i = 0; i < aListLength; i++)
+    {
+        aSet.Add(aList[i]);
+    }
+}
+
+template <uint16_t kMaxSize> void TestSetAddRemoveFlip(Set<kMaxSize> &aSet, const uint16_t *aList, uint16_t aListLength)
+{
+    for (uint16_t i = 0; i < aListLength; i++)
+    {
+        aSet.Add(aList[i]);
+        VerifySetContent(aSet, &aList[0], i + 1);
+    }
+
+    printf("  set = %s\n", aSet.ToString().AsCString());
+
+    for (uint16_t i = 0; i < aListLength; i++)
+    {
+        aSet.Remove(aList[i]);
+        VerifySetContent(aSet, &aList[i + 1], aListLength - i - 1);
+    }
+
+    for (uint16_t i = aListLength; i > 0; i--)
+    {
+        aSet.Flip(aList[i - 1]);
+        VerifySetContent(aSet, &aList[i - 1], aListLength - i + 1);
+    }
+
+    for (uint16_t i = aListLength; i > 0; i--)
+    {
+        aSet.Flip(aList[i - 1]);
+        VerifySetContent(aSet, &aList[0], i - 1);
+    }
+}
+
+template <uint16_t kMaxSize> void TestSet(void)
+{
+    Set<kMaxSize> set1;
+    Set<kMaxSize> set2;
+
+    uint16_t all[kMaxSize];
+    uint16_t odds[kMaxSize / 2];
+    uint16_t evens[(kMaxSize + 1) / 2];
+    uint16_t primesLength;
+
+    printf("\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - \n");
+    printf("Testing Set with size %d\n\n", kMaxSize);
+
+    for (uint16_t i = 0; i < kMaxSize; i++)
+    {
+        all[i] = i;
+    }
+
+    for (uint16_t i = 0; i < OT_ARRAY_LENGTH(odds); i++)
+    {
+        odds[i] = 2 * i + 1;
+    }
+
+    for (uint16_t i = 0; i < OT_ARRAY_LENGTH(evens); i++)
+    {
+        evens[i] = 2 * i;
+    }
+
+    for (primesLength = 0; kPrimes[primesLength] < kMaxSize; primesLength++)
+        ;
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // After constructor
+
+    VerifyOrQuit(set1.GetMaxSize() == kMaxSize, "GetMaxSize() failed");
+    VerifyOrQuit(set2.GetMaxSize() == kMaxSize, "GetMaxSize() failed");
+
+    VerifySetContent(set1, NULL, 0);
+    printf("Empty set = %s\n", set1.ToString().AsCString());
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Check Add/Remove/Flip
+
+    printf("all\n");
+    TestSetAddRemoveFlip(set1, all, OT_ARRAY_LENGTH(all));
+    printf("odds\n");
+    TestSetAddRemoveFlip(set1, odds, OT_ARRAY_LENGTH(odds));
+    printf("evens\n");
+    TestSetAddRemoveFlip(set1, evens, OT_ARRAY_LENGTH(evens));
+    printf("primes\n");
+    TestSetAddRemoveFlip(set1, kPrimes, primesLength);
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Verify Clear() behavior
+
+    PopulateSet(set1, all, OT_ARRAY_LENGTH(all));
+    VerifySetContent(set1, all, OT_ARRAY_LENGTH(all));
+    set1.Clear();
+    VerifySetContent(set1, all, 0);
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Verify Intersect() behavior
+
+    PopulateSet(set1, all, OT_ARRAY_LENGTH(all));
+    PopulateSet(set2, evens, OT_ARRAY_LENGTH(evens));
+
+    VerifySetContent(set1, all, OT_ARRAY_LENGTH(all));
+    VerifySetContent(set2, evens, OT_ARRAY_LENGTH(evens));
+
+    // Intersecting with itself
+    set1.Intersect(set1);
+    VerifySetContent(set1, all, OT_ARRAY_LENGTH(all));
+
+    // Intersecting all with evens should give us back evens.
+    printf("Intersecting %s with %s", set1.ToString().AsCString(), set2.ToString().AsCString());
+    set1.Intersect(set2);
+    printf(" gives %s\n", set1.ToString().AsCString());
+    VerifySetContent(set1, evens, OT_ARRAY_LENGTH(evens));
+
+    // Intersecting primes with evens should give us only {2}.
+    PopulateSet(set2, kPrimes, primesLength);
+    printf("Intersecting %s with %s", set1.ToString().AsCString(), set2.ToString().AsCString());
+    set1.Intersect(set2);
+    printf(" gives %s\n", set1.ToString().AsCString());
+    VerifyOrQuit(set1.GetNumberOfElements() == 1, "Intersect() failed");
+    VerifyOrQuit(set1.Contains(2) == true, "Intersect() failed");
+
+    // Intersecting primes with odds should gives all primes except 2.
+    PopulateSet(set1, odds, OT_ARRAY_LENGTH(odds));
+    printf("Intersecting %s with %s", set1.ToString().AsCString(), set2.ToString().AsCString());
+    set1.Intersect(set2);
+    printf(" gives %s\n", set1.ToString().AsCString());
+    VerifySetContent(set1, &kPrimes[1], primesLength - 1);
+
+    // Intersecting odd primes with evens should gives the empty set.
+    PopulateSet(set2, evens, OT_ARRAY_LENGTH(evens));
+    printf("Intersecting %s with %s", set1.ToString().AsCString(), set2.ToString().AsCString());
+    set1.Intersect(set2);
+    printf(" gives %s\n", set1.ToString().AsCString());
+    VerifySetContent(set1, NULL, 0);
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Verify Union() behavior
+
+    PopulateSet(set1, evens, OT_ARRAY_LENGTH(evens));
+    PopulateSet(set2, odds, OT_ARRAY_LENGTH(odds));
+
+    // Union with itself
+    set1.Union(set1);
+    VerifySetContent(set1, evens, OT_ARRAY_LENGTH(evens));
+
+    // Union of odds and evens should be all.
+    printf("Union of %s and %s", set1.ToString().AsCString(), set2.ToString().AsCString());
+    set1.Union(set2);
+    printf(" gives %s\n", set1.ToString().AsCString());
+    VerifySetContent(set1, all, OT_ARRAY_LENGTH(all));
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Verify operators ==, !=, and = (assignment)
+
+    PopulateSet(set1, evens, OT_ARRAY_LENGTH(evens));
+    PopulateSet(set2, odds, OT_ARRAY_LENGTH(odds));
+
+    VerifyOrQuit(set1 == set1, "operator== failed");
+    VerifyOrQuit(set2 == set2, "operator== failed");
+    VerifyOrQuit(set1 != set2, "operator!= failed");
+
+    set2 = set1;
+    VerifyOrQuit(set1 == set2, "operator== failed");
+
+    set1.Clear();
+    set2.Clear();
+    VerifyOrQuit(set1 == set2, "operator== failed");
+
+    for (uint16_t i = 0; i < kMaxSize; i++)
+    {
+        set1.Flip(i);
+        VerifyOrQuit(set1 != set2, "operator== failed");
+        set1.Flip(i);
+        VerifyOrQuit(set1 == set2, "operator== failed");
+    }
+
+    printf(" -- PASS\n");
+}
+
+void TestSet16(void)
+{
+    const uint16_t kMask1 = 0xba42;
+    const uint16_t kMask2 = 0xfedb;
+    const uint16_t kMask3 = 0xffff;
+    const uint16_t kMask4 = 0xa5a5;
+
+    Set<16> set1(kMask1);
+    Set<16> set2(kMask2);
+    Set<16> set3;
+
+    printf("\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - \n");
+    printf("Testing Set<16> specific methods\n\n");
+
+    VerifyOrQuit(set1.GetAsMask() == kMask1, "GetAsMask() failed");
+    VerifyOrQuit(set2.GetAsMask() == kMask2, "GetAsMask() failed");
+    VerifyOrQuit(set3.GetAsMask() == 0, "GetAsMask() failed");
+
+    VerifySetContent(set1, kMask1);
+    VerifySetContent(set2, kMask2);
+
+    set1.SetFromMask(kMask3);
+    VerifyOrQuit(set1.GetAsMask() == kMask3, "SetFromMask() failed");
+    VerifySetContent(set1, kMask3);
+
+    set2.SetFromMask(kMask4);
+    VerifyOrQuit(set2.GetAsMask() == kMask4, "SetFromMask() failed");
+    VerifySetContent(set2, kMask4);
+
+    set1.SetFromMask(0);
+    VerifyOrQuit(set1.GetAsMask() == 0, "SetFromMask() failed");
+    VerifyOrQuit(set1.IsEmpty(), "SetFromMask() failed");
+
+    printf(" -- PASS\n");
+}
+
+void TestSet32(void)
+{
+    const uint32_t kMask1 = 0xfedcba98;
+    const uint32_t kMask2 = 0x12345670;
+    const uint32_t kMask3 = 0xffffffff;
+    const uint32_t kMask4 = 0xa5a5a5a5;
+
+    Set<32> set1(kMask1);
+    Set<32> set2(kMask2);
+    Set<32> set3;
+
+    printf("\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - \n");
+    printf("Testing Set<32> specific methods\n\n");
+
+    VerifyOrQuit(set1.GetAsMask() == kMask1, "GetAsMask() failed");
+    VerifyOrQuit(set2.GetAsMask() == kMask2, "GetAsMask() failed");
+    VerifyOrQuit(set3.GetAsMask() == 0, "GetAsMask() failed");
+
+    VerifySetContent(set1, kMask1);
+    VerifySetContent(set2, kMask2);
+
+    set1.SetFromMask(kMask3);
+    VerifyOrQuit(set1.GetAsMask() == kMask3, "SetFromMask() failed");
+    VerifySetContent(set1, kMask3);
+
+    set2.SetFromMask(kMask4);
+    VerifyOrQuit(set2.GetAsMask() == kMask4, "SetFromMask() failed");
+    VerifySetContent(set2, kMask4);
+
+    set1.SetFromMask(0);
+    VerifyOrQuit(set1.GetAsMask() == 0, "SetFromMask() failed");
+    VerifyOrQuit(set1.IsEmpty(), "SetFromMask() failed");
+
+    printf(" -- PASS\n");
+}
+
+} // namespace ot
+
+#ifdef ENABLE_TEST_MAIN
+int main(void)
+{
+    ot::TestSet<3>();
+    ot::TestSet<9>();
+    ot::TestSet<16>();
+    ot::TestSet<20>();
+    ot::TestSet<32>();
+    ot::TestSet<77>();
+    ot::TestSet<500>();
+
+    ot::TestSet16();
+    ot::TestSet32();
+
+    printf("\nAll tests passed.\n");
+    return 0;
+}
+#endif


### PR DESCRIPTION
This commit adds a new common class `Set` which represents a set of
integers with a given (template) size parameter. The `Set` class is
implemented using a bit-vector mask array. This commit also adds a
unit test for the new `Set` class. The `ChannelMask`, `RouterTable`,
and `Ncp::ChangedPropsSet` classes are modified to use the new
`Set` class.