### PR TITLE
[mle] remove unused attach state kAttachStateSynchronize

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -272,7 +272,6 @@ otError Mle::Start(bool aAnnounceAttach)
     }
     else
     {
-        SetAttachState(kAttachStateSynchronize);
         mChildUpdateAttempts = 0;
         SendChildUpdateRequest();
     }
@@ -1632,10 +1631,6 @@ void Mle::HandleAttachTimer(void)
     {
     case kAttachStateIdle:
         assert(false);
-        break;
-
-    case kAttachStateSynchronize:
-        SendChildUpdateRequest();
         break;
 
     case kAttachStateProcessAnnounce:
@@ -4150,10 +4145,6 @@ const char *Mle::AttachStateToString(AttachState aState)
     {
     case kAttachStateIdle:
         str = "Idle";
-        break;
-
-    case kAttachStateSynchronize:
-        str = "Sync";
         break;
 
     case kAttachStateProcessAnnounce:

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1082,7 +1082,6 @@ protected:
     enum AttachState
     {
         kAttachStateIdle,                ///< Not currently searching for a parent.
-        kAttachStateSynchronize,         ///< Looking to synchronize with a parent (after reset).
         kAttachStateProcessAnnounce,     ///< Waiting to process a received Announce (to switch channel/pan-id).
         kAttachStateStart,               ///< Starting to look for a parent.
         kAttachStateParentRequestRouter, ///< Searching for a Router to attach to.


### PR DESCRIPTION
The attach state `kAttachStateSynchronize` was intended for sending
"Child Update Requests" after a reset (if device was previously
attached) using the `mAttachTimer` for retransmissions. However,
"Child Update" transmissions use `mMessageTransmissionTimer`
instead.