### PR TITLE
[toolchain] define __COUNTER__ macro for keil compiler

### DIFF
--- a/src/core/utils/static_assert.hpp
+++ b/src/core/utils/static_assert.hpp
@@ -36,6 +36,13 @@
 
 #ifdef __cplusplus
 
+/**
+ * Some compilers such as Keil MDK-ARM does not support __COUNTER__ macro.
+ */
+#ifndef __COUNTER__
+#define __COUNTER__ __LINE__
+#endif
+
 namespace ot {
 
 template <int> struct StaticAssertError;


### PR DESCRIPTION
In #3541, the `__COUNTER__` macro has been introduced. This however causes Keil MDK-ARM compiler to fail due to undeclared `__COUNTER__` macro (it's fine however for GCC, SES and IAR).
 
This PR introduces not ideal workaround since there is no equivalent for `__COUNTER__` macro. Currently on this PR, Keil is able to compile all OpenThread libraries.