### PR TITLE
[mle] skip saving network info on role change to detached

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1519,7 +1519,13 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
 
     if (aFlags & (OT_CHANGED_THREAD_ROLE | OT_CHANGED_THREAD_KEY_SEQUENCE_COUNTER))
     {
-        Store();
+        // Store the settings on a key seq change, or when role changes and device
+        // is attached (i.e., skip `Store()` on role change to detached).
+
+        if ((aFlags & OT_CHANGED_THREAD_KEY_SEQUENCE_COUNTER) || IsAttached())
+        {
+            Store();
+        }
     }
 
     if (aFlags & OT_CHANGED_SECURITY_POLICY)


### PR DESCRIPTION
This commit changes the behavior of `Mle` to skip the saving of
network info (to non-volatile memory) on role change to detached. Note
that `Store()` does only update the MAC/MLE counters if device is not
attached. The MAC/MLE counters update is tracked already by
`KeyManager`.