### PR TITLE
[notifier] auto-register callback from its constructor

### DIFF
--- a/src/core/common/notifier.hpp
+++ b/src/core/common/notifier.hpp
@@ -87,13 +87,16 @@ public:
         /**
          * This constructor initializes a `Callback` instance
          *
+         * @param[in] aInstance   A reference to OpenThread instance.
          * @param[in] aHandler    A function pointer to the callback handler.
          * @param[in] aOwner      A pointer to the owner of the `Callback` instance.
          *
          */
-        Callback(Handler aHandler, void *aOwner);
+        Callback(Instance &aInstance, Handler aHandler, void *aOwner);
 
     private:
+        void Invoke(otChangedFlags aFlags) { mHandler(*this, aFlags); }
+
         Handler   mHandler;
         Callback *mNext;
     };
@@ -105,25 +108,6 @@ public:
      *
      */
     explicit Notifier(Instance &aInstance);
-
-    /**
-     * This method registers a callback.
-     *
-     * @param[in]  aCallback     A reference to the callback instance.
-     *
-     * @retval OT_ERROR_NONE     Successfully registered the callback.
-     * @retval OT_ERROR_ALREADY  The callback was already registered.
-     *
-     */
-    otError RegisterCallback(Callback &aCallback);
-
-    /**
-     * This method removes a previously registered callback.
-     *
-     * @param[in]  aCallback     A reference to the callback instance.
-     *
-     */
-    void RemoveCallback(Callback &aCallback);
 
     /**
      * This method registers an `otStateChangedCallback` handler.
@@ -198,6 +182,7 @@ private:
         void *                 mContext;
     };
 
+    void        RegisterCallback(Callback &aCallback);
     static void HandleStateChanged(Tasklet &aTasklet);
     void        HandleStateChanged(void);
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -61,13 +61,12 @@ JoinerRouter::JoinerRouter(Instance &aInstance)
     , mSocket(aInstance.GetThreadNetif().GetIp6().GetUdp())
     , mRelayTransmit(OT_URI_PATH_RELAY_TX, &JoinerRouter::HandleRelayTransmit, this)
     , mTimer(aInstance, &JoinerRouter::HandleTimer, this)
-    , mNotifierCallback(&JoinerRouter::HandleStateChanged, this)
+    , mNotifierCallback(aInstance, &JoinerRouter::HandleStateChanged, this)
     , mJoinerUdpPort(0)
     , mIsJoinerPortConfigured(false)
     , mExpectJoinEntRsp(false)
 {
     GetNetif().GetCoap().AddResource(mRelayTransmit);
-    aInstance.GetNotifier().RegisterCallback(mNotifierCallback);
 }
 
 void JoinerRouter::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)

--- a/src/core/thread/announce_sender.cpp
+++ b/src/core/thread/announce_sender.cpp
@@ -112,9 +112,8 @@ exit:
 
 AnnounceSender::AnnounceSender(Instance &aInstance)
     : AnnounceSenderBase(aInstance, &AnnounceSender::HandleTimer)
-    , mNotifierCallback(HandleStateChanged, this)
+    , mNotifierCallback(aInstance, HandleStateChanged, this)
 {
-    aInstance.GetNotifier().RegisterCallback(mNotifierCallback);
 }
 
 void AnnounceSender::HandleTimer(Timer &aTimer)

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -60,10 +60,9 @@ EnergyScanServer::EnergyScanServer(Instance &aInstance)
     , mActive(false)
     , mScanResultsLength(0)
     , mTimer(aInstance, &EnergyScanServer::HandleTimer, this)
-    , mNotifierCallback(&EnergyScanServer::HandleStateChanged, this)
+    , mNotifierCallback(aInstance, &EnergyScanServer::HandleStateChanged, this)
     , mEnergyScan(OT_URI_PATH_ENERGY_SCAN, &EnergyScanServer::HandleRequest, this)
 {
-    aInstance.GetNotifier().RegisterCallback(mNotifierCallback);
     GetNetif().GetCoap().AddResource(mEnergyScan);
 }
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -108,7 +108,7 @@ Mle::Mle(Instance &aInstance)
     , mAlternateChannel(0)
     , mAlternatePanId(Mac::kPanIdBroadcast)
     , mAlternateTimestamp(0)
-    , mNotifierCallback(&Mle::HandleStateChanged, this)
+    , mNotifierCallback(aInstance, &Mle::HandleStateChanged, this)
     , mParentResponseCb(NULL)
     , mParentResponseCbContext(NULL)
 {
@@ -202,8 +202,6 @@ Mle::Mle(Instance &aInstance)
 
     // `SetMeshLocalPrefix()` also adds the Mesh-Local EID and subscribes
     // to the Link- and Realm-Local All Thread Nodes multicast addresses.
-
-    aInstance.GetNotifier().RegisterCallback(mNotifierCallback);
 
 #if OPENTHREAD_CONFIG_ENABLE_PERIODIC_PARENT_SEARCH
     StartParentSearchTimer();

--- a/src/core/thread/time_sync_service.cpp
+++ b/src/core/thread/time_sync_service.cpp
@@ -62,12 +62,10 @@ TimeSync::TimeSync(Instance &aInstance)
     , mNetworkTimeOffset(0)
     , mTimeSyncCallback(NULL)
     , mTimeSyncCallbackContext(NULL)
-    , mNotifierCallback(&TimeSync::HandleStateChanged, this)
+    , mNotifierCallback(aInstance, &TimeSync::HandleStateChanged, this)
     , mTimer(aInstance, HandleTimeout, this)
     , mCurrentStatus(OT_NETWORK_TIME_UNSYNCHRONIZED)
 {
-    aInstance.GetNotifier().RegisterCallback(mNotifierCallback);
-
     CheckAndHandleChanges(false);
 }
 

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -52,7 +52,7 @@ ChannelManager::ChannelManager(Instance &aInstance)
     , mSupportedChannelMask(0)
     , mFavoredChannelMask(0)
     , mActiveTimestamp(0)
-    , mNotifierCallback(&ChannelManager::HandleStateChanged, this)
+    , mNotifierCallback(aInstance, &ChannelManager::HandleStateChanged, this)
     , mDelay(kMinimumDelay)
     , mChannel(0)
     , mState(kStateIdle)
@@ -60,7 +60,6 @@ ChannelManager::ChannelManager(Instance &aInstance)
     , mAutoSelectInterval(kDefaultAutoSelectInterval)
     , mAutoSelectEnabled(false)
 {
-    aInstance.GetNotifier().RegisterCallback(mNotifierCallback);
 }
 
 void ChannelManager::RequestChannelChange(uint8_t aChannel)

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -51,9 +51,8 @@ ChildSupervisor::ChildSupervisor(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mSupervisionInterval(kDefaultSupervisionInterval)
     , mTimer(aInstance, &ChildSupervisor::HandleTimer, this)
-    , mNotifierCallback(&ChildSupervisor::HandleStateChanged, this)
+    , mNotifierCallback(aInstance, &ChildSupervisor::HandleStateChanged, this)
 {
-    aInstance.GetNotifier().RegisterCallback(mNotifierCallback);
 }
 
 void ChildSupervisor::SetSupervisionInterval(uint16_t aInterval)

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -49,7 +49,7 @@ JamDetector::JamDetector(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mHandler(NULL)
     , mContext(NULL)
-    , mNotifierCallback(HandleStateChanged, this)
+    , mNotifierCallback(aInstance, HandleStateChanged, this)
     , mTimer(aInstance, &JamDetector::HandleTimer, this)
     , mHistoryBitmap(0)
     , mCurSecondStartTime(0)
@@ -61,7 +61,6 @@ JamDetector::JamDetector(Instance &aInstance)
     , mJamState(false)
     , mRssiThreshold(kDefaultRssiThreshold)
 {
-    aInstance.GetNotifier().RegisterCallback(mNotifierCallback);
 }
 
 otError JamDetector::Start(Handler aHandler, void *aContext)


### PR DESCRIPTION
This commit helps simplify the implementation and use of `Notifier`
by having the `Callback` constructor registering the callback with
the `Notifier`.