### PR TITLE
[nrf52840] do not compile spi-slave.c if NCP_SPI is not used

### DIFF
--- a/examples/Makefile-nrf52840
+++ b/examples/Makefile-nrf52840
@@ -43,12 +43,8 @@ BuildJobs                      ?= 10
 GCCVersion                      = $(shell expr `$(CC) -dumpversion | cut -f1 -d.`)
 
 configure_OPTIONS                                 = \
-    --enable-cli                                    \
-    --enable-diag                                   \
     --enable-ftd                                    \
     --enable-mtd                                    \
-    --enable-ncp                                    \
-    --enable-radio-only                             \
     --enable-linker-map                             \
     --with-examples=nrf52840                        \
     $(NULL)
@@ -59,12 +55,6 @@ endif
 
 ifdef SRC_PATH
 configure_OPTIONS              += --srcdir="$(SRC_PATH)"
-endif
-
-ifeq ($(NCP_SPI),1)
-configure_OPTIONS              += --with-ncp-bus=spi
-else
-configure_OPTIONS              += --with-ncp-bus=uart
 endif
 
 TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..
@@ -99,21 +89,39 @@ ifneq ($(CERT_LOG),1)
 COMMONCFLAGS += -DOPENTHREAD_CONFIG_LOG_OUTPUT=OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED
 endif
 
-ifeq ($(USB),1)
-COMMONCFLAGS += -DUSB_CDC_AS_SERIAL_TRANSPORT=1
-endif
-
 ifeq ($(BOOTLOADER),1)
 configure_OPTIONS += --with-custom-linker-file=$(AbsTopSourceDir)/examples/platforms/nrf52840/nrf52840_bootloader.ld
 COMMONCFLAGS += -DAPP_USBD_NRF_DFU_TRIGGER_ENABLED=1
 endif
 
+#
+# Select transport which CLI, NCP and NCP-Radio examples will use to communicate.
+# To disable all transports use the DISABLE_TRANSPORTS switch. This will disable
+# the build of all above examples.
+# If NCP_SPI switch is set, only NCP and NCP-Radio examples will be built.
+# Otherwise the user can select USB transport. If no transports were selected,
+# the default serial transport is UART.
+#
+ifndef DISABLE_TRANSPORTS
+configure_OPTIONS              += --enable-ncp
+configure_OPTIONS              += --enable-radio-only
+ifeq ($(NCP_SPI),1)
+COMMONCFLAGS                   += -DSPIS_AS_SERIAL_TRANSPORT=1
+configure_OPTIONS              += --with-ncp-bus=spi
+else
+configure_OPTIONS              += --with-ncp-bus=uart
+configure_OPTIONS              += --enable-diag
+configure_OPTIONS              += --enable-cli
+ifeq ($(USB),1)
+COMMONCFLAGS                   += -DUSB_CDC_AS_SERIAL_TRANSPORT=1
+else
+COMMONCFLAGS                   += -DUART_AS_SERIAL_TRANSPORT=1
+endif # USB     == 1
+endif # NCP_SPI == 1
+endif # DISABLE_TRANSPORTS
+
 ifeq ($(DISABLE_CC310), 1)
 NRF52840_MBEDTLS_CPPFLAGS += -DDISABLE_CC310=1
-endif
-
-ifeq ($(DISABLE_SPI),1)
-COMMONCFLAGS += -DSPIS_TRANSPORT_DISABLE=1
 endif
 
 ifeq ($(shell expr $(GCCVersion) \>= 7), 1)

--- a/examples/platforms/nrf52840/spi-slave.c
+++ b/examples/platforms/nrf52840/spi-slave.c
@@ -39,6 +39,8 @@
 #include <hal/nrf_spis.h>
 #include <platform-nrf5.h>
 
+#if (SPIS_AS_SERIAL_TRANSPORT == 1)
+
 /**
  *  SPI Slave transaction variables.
  */
@@ -231,3 +233,5 @@ void SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQHandler(void)
         }
     }
 }
+
+#endif // SPIS_AS_SERIAL_TRANSPORT == 1

--- a/examples/platforms/nrf52840/system.c
+++ b/examples/platforms/nrf52840/system.c
@@ -78,15 +78,19 @@ void otSysInit(int argc, char *argv[])
     nrf5RandomInit();
     if (!gPlatformPseudoResetWasRequested)
     {
+#if ((UART_AS_SERIAL_TRANSPORT == 1) || (USB_CDC_AS_SERIAL_TRANSPORT == 1))
         nrf5UartInit();
+#endif
         nrf5CryptoInit();
     }
     else
     {
+#if ((UART_AS_SERIAL_TRANSPORT == 1) || (USB_CDC_AS_SERIAL_TRANSPORT == 1))
         nrf5UartClearPendingData();
+#endif
     }
 
-#ifndef SPIS_TRANSPORT_DISABLE
+#if (SPIS_AS_SERIAL_TRANSPORT == 1)
     nrf5SpiSlaveInit();
 #endif
     nrf5MiscInit();
@@ -105,13 +109,15 @@ void otSysDeinit(void)
     nrf5TempDeinit();
     nrf5RadioDeinit();
     nrf5MiscDeinit();
-#ifndef SPIS_TRANSPORT_DISABLE
+#if (SPIS_AS_SERIAL_TRANSPORT == 1)
     nrf5SpiSlaveDeinit();
 #endif
     if (!gPlatformPseudoResetWasRequested)
     {
         nrf5CryptoDeinit();
+#if ((UART_AS_SERIAL_TRANSPORT == 1) || (USB_CDC_AS_SERIAL_TRANSPORT == 1))
         nrf5UartDeinit();
+#endif
     }
     nrf5RandomDeinit();
     nrf5AlarmDeinit();
@@ -129,9 +135,11 @@ bool otSysPseudoResetWasRequested(void)
 void otSysProcessDrivers(otInstance *aInstance)
 {
     nrf5RadioProcess(aInstance);
+#if ((UART_AS_SERIAL_TRANSPORT == 1) || (USB_CDC_AS_SERIAL_TRANSPORT == 1))
     nrf5UartProcess();
+#endif
     nrf5TempProcess();
-#ifndef SPIS_TRANSPORT_DISABLE
+#if (SPIS_AS_SERIAL_TRANSPORT == 1)
     nrf5SpiSlaveProcess();
 #endif
     nrf5AlarmProcess(aInstance);

--- a/examples/platforms/nrf52840/uart.c
+++ b/examples/platforms/nrf52840/uart.c
@@ -49,7 +49,7 @@
 #include <hal/nrf_gpio.h>
 #include <hal/nrf_uart.h>
 
-#if (USB_CDC_AS_SERIAL_TRANSPORT == 0)
+#if (UART_AS_SERIAL_TRANSPORT == 1)
 
 bool sUartEnabled = false;
 
@@ -319,7 +319,7 @@ void UARTE0_UART0_IRQHandler(void)
     }
 }
 
-#endif // USB_CDC_AS_SERIAL_TRANSPORT == 0
+#endif // UART_AS_SERIAL_TRANSPORT == 1
 
 /**
  * The UART driver weak functions definition.


### PR DESCRIPTION
This commit uses SPIS_TRANSPORT_DISABLE definition to disable compilation of spi-slave.c routines, if NCP_SPI flag is not set. This is done to avoid linker errors with SPI interrupt function if project uses SPI for other purposes.