### PR TITLE
[nrf52811] add support for nRF52811 platform

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -163,6 +163,23 @@ build_kw41z() {
     arm-none-eabi-size  output/kw41z/bin/ot-ncp-mtd || die
 }
 
+build_nrf52811() {
+    git checkout -- . || die
+    git clean -xfd || die
+    ./bootstrap || die
+    BORDER_ROUTER=1 COAP=1 DNS_CLIENT=1 LINK_RAW=1 MAC_FILTER=1 MTD_NETDIAG=1 make -f examples/Makefile-nrf52811 || die
+    arm-none-eabi-size  output/nrf52811/bin/ot-cli-mtd || die
+    arm-none-eabi-size  output/nrf52811/bin/ot-ncp-mtd || die
+    arm-none-eabi-size  output/nrf52811/bin/ot-ncp-radio || die
+
+    git checkout -- . || die
+    git clean -xfd || die
+    ./bootstrap || die
+    BORDER_ROUTER=1 COAP=1 DNS_CLIENT=1 LINK_RAW=1 MAC_FILTER=1 MTD_NETDIAG=1 NCP_SPI=1 make -f examples/Makefile-nrf52811 || die
+    arm-none-eabi-size  output/nrf52811/bin/ot-ncp-mtd || die
+    arm-none-eabi-size  output/nrf52811/bin/ot-ncp-radio || die
+}
+
 build_nrf52840() {
     git checkout -- . || die
     git clean -xfd || die
@@ -198,6 +215,7 @@ build_samr21() {
     build_cc2652
     build_da15000
     build_kw41z
+    build_nrf52811
     build_nrf52840
     build_samr21
 }
@@ -211,6 +229,7 @@ build_samr21() {
     build_cc2652
     build_da15000
     build_kw41z
+    build_nrf52811
     build_nrf52840
     build_samr21
 }
@@ -224,6 +243,7 @@ build_samr21() {
     build_cc2652
     build_da15000
     build_kw41z
+    build_nrf52811
     build_nrf52840
     build_samr21
 
@@ -239,6 +259,7 @@ build_samr21() {
     build_cc2652
     build_da15000
     build_kw41z
+    build_nrf52811
     build_nrf52840
     build_samr21
 }
@@ -251,6 +272,7 @@ build_samr21() {
     build_cc2650
     build_cc2652
     build_kw41z
+    build_nrf52811
     build_nrf52840
     build_samr21
 

--- a/configure.ac
+++ b/configure.ac
@@ -1660,12 +1660,12 @@ AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_ECDSA], [${OPENTHREAD_ENABLE_ECDSA}], [Def
 
 AC_ARG_WITH(examples,
     [AS_HELP_STRING([--with-examples=TARGET],
-        [Specify the examples from one of: none, posix, cc1352, cc2538, cc2650, cc2652, da15000, efr32, emsk, gp712, kw41z, nrf52840, qpg6095, samr21 @<:@default=none@:>@.])],
+        [Specify the examples from one of: none, posix, cc1352, cc2538, cc2650, cc2652, da15000, efr32, emsk, gp712, kw41z, nrf52811, nrf52840, qpg6095, samr21 @<:@default=none@:>@.])],
     [
         case "${with_examples}" in
         none)
             ;;
-        posix|cc1352|cc2538|cc2650|cc2652|da15000|efr32|emsk|gp712|kw41z|nrf52840|qpg6095|samr21)
+        posix|cc1352|cc2538|cc2650|cc2652|da15000|efr32|emsk|gp712|kw41z|nrf52811|nrf52840|qpg6095|samr21)
             if test ${enable_posix_app} = "yes"; then
                 AC_MSG_ERROR([--with-examples must be none when POSIX apps are enabled by --enable-posix-app])
             fi
@@ -1731,6 +1731,11 @@ case ${with_examples} in
         AC_DEFINE_UNQUOTED([OPENTHREAD_EXAMPLES_KW41Z],[${OPENTHREAD_EXAMPLES_KW41Z}],[Define to 1 if you want to use kw41z examples])
         ;;
 
+    nrf52811)
+        OPENTHREAD_EXAMPLES_NRF52811=1
+        AC_DEFINE_UNQUOTED([OPENTHREAD_EXAMPLES_NRF52811],[${OPENTHREAD_EXAMPLES_NRF52811}],[Define to 1 if you want to use nrf52811 examples])
+        ;;
+
     nrf52840)
         OPENTHREAD_EXAMPLES_NRF52840=1
         AC_DEFINE_UNQUOTED([OPENTHREAD_EXAMPLES_NRF52840],[${OPENTHREAD_EXAMPLES_NRF52840}],[Define to 1 if you want to use nrf52840 examples])
@@ -1784,6 +1789,9 @@ AM_CONDITIONAL([OPENTHREAD_EXAMPLES_GP712], [test "${with_examples}" = "gp712"])
 
 AC_SUBST(OPENTHREAD_EXAMPLES_KW41Z)
 AM_CONDITIONAL([OPENTHREAD_EXAMPLES_KW41Z], [test "${with_examples}" = "kw41z"])
+
+AC_SUBST(OPENTHREAD_EXAMPLES_NRF52811)
+AM_CONDITIONAL([OPENTHREAD_EXAMPLES_NRF52811], [test "${with_examples}" = "nrf52811"])
 
 AC_SUBST(OPENTHREAD_EXAMPLES_NRF52840)
 AM_CONDITIONAL([OPENTHREAD_EXAMPLES_NRF52840], [test "${with_examples}" = "nrf52840"])
@@ -1932,6 +1940,7 @@ src/posix/platform/Makefile
 third_party/Makefile
 third_party/jlink/Makefile
 third_party/mbedtls/Makefile
+third_party/NordicSemiconductor/Makefile
 examples/Makefile
 examples/apps/Makefile
 examples/apps/cli/Makefile
@@ -1946,6 +1955,7 @@ examples/platforms/efr32/Makefile
 examples/platforms/emsk/Makefile
 examples/platforms/gp712/Makefile
 examples/platforms/kw41z/Makefile
+examples/platforms/nrf52811/Makefile
 examples/platforms/nrf52840/Makefile
 examples/platforms/qpg6095/Makefile
 examples/platforms/samr21/Makefile

--- a/examples/Makefile-nrf52811
+++ b/examples/Makefile-nrf52811
@@ -1,0 +1,317 @@
+#
+#  Copyright (c) 2019, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+.NOTPARALLEL:
+
+AR                              = arm-none-eabi-ar
+CCAS                            = $(CCPREFIX) arm-none-eabi-gcc
+CPP                             = arm-none-eabi-cpp
+CC                              = $(CCPREFIX) arm-none-eabi-gcc
+CXX                             = $(CCPREFIX) arm-none-eabi-g++
+LD                              = arm-none-eabi-ld
+STRIP                           = arm-none-eabi-strip
+NM                              = arm-none-eabi-nm
+RANLIB                          = arm-none-eabi-ranlib
+OBJCOPY                         = arm-none-eabi-objcopy
+
+BuildJobs                      ?= 10
+GCCVersion                      = $(shell expr `$(CC) -dumpversion | cut -f1 -d.`)
+
+configure_OPTIONS                                 = \
+    --enable-mtd                                    \
+    --enable-linker-map                             \
+    --with-examples=nrf52811                        \
+    MBEDTLS_CPPFLAGS="$(NRF52811_MBEDTLS_CPPFLAGS)" \
+    $(NULL)
+
+ifdef SRC_PATH
+configure_OPTIONS              += --srcdir="$(SRC_PATH)"
+endif
+
+TopSourceDir                    := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..
+AbsTopSourceDir                 := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))..
+
+NRF52811_MBEDTLS_CPPFLAGS  = -DMBEDTLS_CONFIG_FILE='\"mbedtls-config.h\"'
+NRF52811_MBEDTLS_CPPFLAGS += -DMBEDTLS_USER_CONFIG_FILE='\"nrf52811-mbedtls-config.h\"'
+NRF52811_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls
+NRF52811_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls/repo/include
+NRF52811_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls/repo/include/mbedtls
+NRF52811_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/NordicSemiconductor/libraries/crypto
+NRF52811_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/NordicSemiconductor/libraries/nrf_cc310/include
+NRF52811_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/NordicSemiconductor/nrfx/mdk
+NRF52811_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/NordicSemiconductor/cmsis
+NRF52811_MBEDTLS_CPPFLAGS += -DNRF52811_XXAA
+
+CONFIG_FILE      = OPENTHREAD_PROJECT_CORE_CONFIG_FILE='\"openthread-core-nrf52811-config.h\"'
+CONFIG_FILE_PATH = $(AbsTopSourceDir)/examples/platforms/nrf52811/
+
+COMMONCFLAGS                   := \
+    -fdata-sections               \
+    -ffunction-sections           \
+    -Os                           \
+    -g                            \
+    -D$(CONFIG_FILE)              \
+    -I$(CONFIG_FILE_PATH)         \
+    $(NULL)
+
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
+
+ifeq ($(DCDC),1)
+COMMONCFLAGS += -DDCDC_ENABLE
+endif
+
+ifneq ($(CERT_LOG),1)
+COMMONCFLAGS += -DOPENTHREAD_CONFIG_LOG_OUTPUT=OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED
+endif
+
+#
+# Select transport which CLI, NCP and NCP-Radio examples will use to communicate.
+# To disable all transports use the DISABLE_TRANSPORTS switch. This will disable
+# the build of all above examples.
+# If NCP_SPI switch is set, only NCP and NCP-Radio examples will be built.
+# Otherwise, the default serial transport is UART.
+#
+ifndef DISABLE_TRANSPORTS
+configure_OPTIONS              += --enable-ncp
+configure_OPTIONS              += --enable-radio-only
+ifeq ($(NCP_SPI),1)
+COMMONCFLAGS                   += -DSPIS_AS_SERIAL_TRANSPORT=1
+configure_OPTIONS              += --with-ncp-bus=spi
+else
+COMMONCFLAGS                   += -DUART_AS_SERIAL_TRANSPORT=1
+configure_OPTIONS              += --with-ncp-bus=uart
+configure_OPTIONS              += --enable-diag
+configure_OPTIONS              += --enable-cli
+endif # NCP_SPI == 1
+endif # DISABLE_TRANSPORTS
+
+NRF52811_MBEDTLS_CPPFLAGS += -DDISABLE_CC310=1
+
+ifeq ($(shell expr $(GCCVersion) \>= 7), 1)
+    COMMONCFLAGS += -Wno-expansion-to-defined
+endif
+
+CPPFLAGS                       += \
+    $(COMMONCFLAGS)               \
+    $(target_CPPFLAGS)            \
+    $(NULL)
+
+CFLAGS                         += \
+    $(COMMONCFLAGS)               \
+    $(target_CFLAGS)              \
+    $(NULL)
+
+CXXFLAGS                       += \
+    $(COMMONCFLAGS)               \
+    $(target_CXXFLAGS)            \
+    -fno-exceptions               \
+    -fno-rtti                     \
+    $(NULL)
+
+LDFLAGS                        += \
+    $(COMMONCFLAGS)               \
+    $(target_LDFLAGS)             \
+    -specs=nano.specs             \
+    -specs=nosys.specs            \
+    -Wl,--gc-sections             \
+    $(NULL)
+
+CCASFLAGS                       += \
+    $(COMMONCCASFLAGS)             \
+    $(target_CCASFLAGS)            \
+    -x                             \
+    assembler-with-cpp             \
+    $(NULL)
+
+ECHO                            := @echo
+MAKE                            := make
+MKDIR_P                         := mkdir -p
+LN_S                            := ln -s
+RM_F                            := rm -f
+
+INSTALL                         := /usr/bin/install
+INSTALLFLAGS                    := -p
+
+BuildPath                       = build
+TopBuildDir                     = $(BuildPath)
+AbsTopBuildDir                  = $(PWD)/$(TopBuildDir)
+
+ResultPath                      = output
+TopResultDir                    = $(ResultPath)
+AbsTopResultDir                 = $(PWD)/$(TopResultDir)
+
+TargetTuple                     = nrf52811
+
+ARCHS                           = cortex-m4
+
+TopTargetLibDir                 = $(TopResultDir)/$(TargetTuple)/lib
+
+ifndef BuildJobs
+BuildJobs := $(shell getconf _NPROCESSORS_ONLN)
+endif
+JOBSFLAG := -j$(BuildJobs)
+
+#
+# configure-arch <arch>
+#
+# Configure OpenThread for the specified architecture.
+#
+#   arch - The architecture to configure.
+#
+define configure-arch
+$(ECHO) "  CONFIG   $(TargetTuple)..."
+(cd $(BuildPath)/$(TargetTuple) && $(AbsTopSourceDir)/configure \
+INSTALL="$(INSTALL) $(INSTALLFLAGS)" \
+CPP="$(CPP)" CC="$(CC)" CXX="$(CXX)" CCAS="$(CCAS)" OBJC="$(OBJC)" OBJCXX="$(OBJCXX)" AR="$(AR)" RANLIB="$(RANLIB)" NM="$(NM)" STRIP="$(STRIP)" CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CCASFLAGS="$(CCASFLAGS)" LDFLAGS="$(LDFLAGS)" \
+--host=arm-none-eabi \
+--prefix=/ \
+--exec-prefix=/$(TargetTuple) \
+$(configure_OPTIONS))
+endef # configure-arch
+
+#
+# build-arch <arch>
+#
+# Build the OpenThread intermediate build products for the specified
+# architecture.
+#
+#   arch - The architecture to build.
+#
+define build-arch
+$(ECHO) "  BUILD    $(TargetTuple)"
+$(MAKE) $(JOBSFLAG) -C $(BuildPath)/$(TargetTuple) --no-print-directory \
+all
+endef # build-arch
+
+#
+# stage-arch <arch>
+#
+# Stage (install) the OpenThread final build products for the specified
+# architecture.
+#
+#   arch - The architecture to stage.
+#
+define stage-arch
+$(ECHO) "  STAGE    $(TargetTuple)"
+$(MAKE) $(JOBSFLAG) -C $(BuildPath)/$(TargetTuple) --no-print-directory \
+DESTDIR=$(AbsTopResultDir) \
+install
+endef # stage-arch
+
+#
+# ARCH_template <arch>
+#
+# Define macros, targets and rules to configure, build, and stage the
+# OpenThread for a single architecture.
+#
+#   arch - The architecture to instantiate the template for.
+#
+define ARCH_template
+CONFIGURE_TARGETS += configure-$(1)
+BUILD_TARGETS     += do-build-$(1)
+STAGE_TARGETS     += stage-$(1)
+BUILD_DIRS        += $(BuildPath)/$(TargetTuple)
+DIRECTORIES       += $(BuildPath)/$(TargetTuple)
+
+configure-$(1): target_CPPFLAGS=$($(1)_target_CPPFLAGS)
+configure-$(1): target_CFLAGS=$($(1)_target_CFLAGS)
+configure-$(1): target_CXXFLAGS=$($(1)_target_CXXFLAGS)
+configure-$(1): target_LDFLAGS=$($(1)_target_LDFLAGS)
+configure-$(1): target_CCASFLAGS=$($(1)_target_CCASFLAGS)
+
+configure-$(1): $(BuildPath)/$(TargetTuple)/config.status
+
+$(BuildPath)/$(TargetTuple)/config.status: | $(BuildPath)/$(TargetTuple)
+	$$(call configure-arch,$(1))
+
+do-build-$(1): configure-$(1)
+
+do-build-$(1):
+	+$$(call build-arch,$(1))
+
+stage-$(1): do-build-$(1)
+
+stage-$(1): | $(TopResultDir)
+	$$(call stage-arch,$(1))
+
+$(1): stage-$(1)
+endef # ARCH_template
+
+.DEFAULT_GOAL := all
+
+all: stage
+
+#
+# Cortex-m4
+#
+
+cortex-m4_target_ABI                  = cortex-m4
+cortex-m4_target_CPPFLAGS             = -mcpu=cortex-m4 -mfloat-abi=soft -mthumb -mabi=aapcs
+cortex-m4_target_CFLAGS               = -mcpu=cortex-m4 -mfloat-abi=soft -mthumb -mabi=aapcs
+cortex-m4_target_CXXFLAGS             = -mcpu=cortex-m4 -mfloat-abi=soft -mthumb -mabi=aapcs
+cortex-m4_target_LDFLAGS              = -mcpu=cortex-m4 -mfloat-abi=soft -mthumb -mabi=aapcs
+
+# Instantiate an architecture-specific build template for each target
+# architecture.
+
+$(foreach arch,$(ARCHS),$(eval $(call ARCH_template,$(arch))))
+
+#
+# Common / Finalization
+#
+
+configure: $(CONFIGURE_TARGETS)
+
+build: $(BUILD_TARGETS)
+
+stage: $(STAGE_TARGETS)
+
+DIRECTORIES     = $(TopResultDir) $(TopResultDir)/$(TargetTuple)/lib $(BUILD_DIRS)
+
+CLEAN_DIRS      = $(TopResultDir) $(BUILD_DIRS)
+
+all: stage
+
+$(DIRECTORIES):
+	$(ECHO) "  MKDIR    $@"
+	@$(MKDIR_P) "$@"
+
+clean:
+	$(ECHO) "  CLEAN"
+	@$(RM_F) -r $(CLEAN_DIRS)
+
+help:
+	$(ECHO) "Simply type 'make -f $(firstword $(MAKEFILE_LIST))' to build OpenThread for the following "
+	$(ECHO) "architectures: "
+	$(ECHO) ""
+	$(ECHO) "    $(ARCHS)"
+	$(ECHO) ""
+	$(ECHO) "To build only a particular architecture, specify: "
+	$(ECHO) ""
+	$(ECHO) "    make -f $(firstword $(MAKEFILE_LIST)) <architecture>"
+	$(ECHO) ""

--- a/examples/platforms/Makefile.am
+++ b/examples/platforms/Makefile.am
@@ -40,6 +40,7 @@ DIST_SUBDIRS                            = \
     emsk                                  \
     gp712                                 \
     kw41z                                 \
+    nrf52811                              \
     nrf52840                              \
     posix                                 \
     qpg6095                               \
@@ -89,6 +90,10 @@ if OPENTHREAD_EXAMPLES_KW41Z
 SUBDIRS                                += kw41z
 endif
 
+if OPENTHREAD_EXAMPLES_NRF52811
+SUBDIRS                                += nrf52811
+endif
+
 if OPENTHREAD_EXAMPLES_NRF52840
 SUBDIRS                                += nrf52840
 endif
@@ -121,6 +126,7 @@ PRETTY_SUBDIRS                          = \
     emsk                                  \
     gp712                                 \
     kw41z                                 \
+    nrf52811                              \
     nrf52840                              \
     posix                                 \
     qpg6095                               \

--- a/examples/platforms/Makefile.platform.am
+++ b/examples/platforms/Makefile.platform.am
@@ -77,6 +77,10 @@ if OPENTHREAD_EXAMPLES_KW41Z
 include $(top_srcdir)/examples/platforms/kw41z/Makefile.platform.am
 endif
 
+if OPENTHREAD_EXAMPLES_NRF52811
+include $(top_srcdir)/examples/platforms/nrf52811/Makefile.platform.am
+endif
+
 if OPENTHREAD_EXAMPLES_NRF52840
 include $(top_srcdir)/examples/platforms/nrf52840/Makefile.platform.am
 endif

--- a/examples/platforms/nrf52811/DIAG.md
+++ b/examples/platforms/nrf52811/DIAG.md
@@ -1,6 +1,6 @@
 ## Diagnostic module
 
-nRF52840 port extends [OpenThread Diagnostics Module][DIAG].
+nRF52811 port extends [OpenThread Diagnostics Module][DIAG].
 
 New commands allow for more accurate low level radio testing.
 

--- a/examples/platforms/nrf52811/Makefile.am
+++ b/examples/platforms/nrf52811/Makefile.am
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2016-2017, The OpenThread Authors.
+#  Copyright (c) 2019, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -29,18 +29,17 @@
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 lib_LIBRARIES                                                                                              = \
-    libopenthread-nrf52840.a                                                                                 \
-    libopenthread-nrf52840-sdk.a                                                                             \
-    libopenthread-nrf52840-softdevice-sdk.a                                                                  \
+    libopenthread-nrf52811.a                                                                                 \
+    libopenthread-nrf52811-sdk.a                                                                             \
     $(NULL)
 
-# Do not enable -pedantic-errors for nRF52840 driver library
+# Do not enable -pedantic-errors for nRF52811 driver library
 override CFLAGS                                      := $(filter-out -pedantic-errors,$(CFLAGS))
 override CXXFLAGS                                    := $(filter-out -pedantic-errors,$(CXXFLAGS))
 
 COMMONCPPFLAGS                                                                                             = \
     -DCONFIG_GPIO_AS_PINRESET                                                                                \
-    -DNRF52840_XXAA                                                                                          \
+    -DNRF52811_XXAA                                                                                          \
     -I$(top_srcdir)/include                                                                                  \
     -I$(top_srcdir)/examples/platforms                                                                       \
     -I$(top_srcdir)/src/core                                                                                 \
@@ -56,15 +55,10 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/raal                                  \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/power                                            \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/systick                                          \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/usbd                                             \
     -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/app_error                                      \
     -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/atfifo                                         \
     -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/atomic                                         \
     -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/delay                                          \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/usb                                            \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/config                                     \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/class/cdc                                  \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/class/cdc/acm                              \
     -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/utf_converter                                  \
     -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx                                                     \
     -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx/hal                                                 \
@@ -72,8 +66,6 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx/drivers/include                                     \
     -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk                                                 \
     -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx/soc                                                 \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers                                  \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/nrf52                            \
     $(NULL)
 
 PLATFORM_COMMON_SOURCES                                                                                    = \
@@ -91,34 +83,14 @@ PLATFORM_COMMON_SOURCES                                                         
     spi-slave.c                                                                                              \
     system.c                                                                                                 \
     uart.c                                                                                                   \
-    usb-cdc-uart.c                                                                                           \
     $(NULL)
 
 SINGLEPHY_SOURCES                                                                                          = \
     flash_nosd.c                                                                                             \
     $(NULL)
 
-SOFTDEVICE_SOURCES                                                                                         = \
-    flash_sd.c                                                                                               \
-    softdevice.c                                                                                             \
-    softdevice.h                                                                                             \
-    $(NULL)
-
-SOFTDEVICE_CPPFLAGS                                                                                        = \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/raal/softdevice                       \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers                                  \
-    -DSOFTDEVICE_PRESENT                                                                                     \
-    -DS140                                                                                                   \
-    $(NULL)
-
-HWCRYPTO_SOURCES                                                                                           = \
-    @top_builddir@/third_party/NordicSemiconductor/libraries/crypto/aes_alt.c                                \
-    @top_builddir@/third_party/NordicSemiconductor/libraries/crypto/aes_alt_cc310.c                          \
-    @top_builddir@/third_party/NordicSemiconductor/libraries/crypto/aes_alt_soft.c                           \
-    @top_builddir@/third_party/NordicSemiconductor/libraries/crypto/cc310_mbedtls.c                          \
-    @top_builddir@/third_party/NordicSemiconductor/libraries/crypto/ecp_alt_cc310.c                          \
-    @top_builddir@/third_party/NordicSemiconductor/libraries/crypto/ecp_curves_alt.c                         \
-    @top_builddir@/third_party/NordicSemiconductor/libraries/crypto/sha256_alt_cc310.c                       \
+SINGLEPHY_CPPFLAGS                                                                                         = \
+    -DRAAL_SINGLE_PHY=1                                                                                      \
     $(NULL)
 
 PLATFORM_DIAG_SOURCES                                                                                      = \
@@ -135,53 +107,37 @@ PLATFORM_SOURCES                                                                
     $(NULL)
 endif
 
-libopenthread_nrf52840_a_CPPFLAGS                                                                          = \
+libopenthread_nrf52811_a_CPPFLAGS                                                                          = \
     $(COMMONCPPFLAGS)                                                                                        \
     $(SINGLEPHY_CPPFLAGS)                                                                                    \
     $(NULL)
 
-libopenthread_nrf52840_a_SOURCES                                                                           = \
+libopenthread_nrf52811_a_SOURCES                                                                           = \
     $(PLATFORM_SOURCES)                                                                                      \
     $(SINGLEPHY_SOURCES)                                                                                     \
-    $(HWCRYPTO_SOURCES)                                                                                      \
     $(NULL)
 
-libopenthread_nrf52840_sdk_a_CPPFLAGS                                                                      = \
+libopenthread_nrf52811_sdk_a_CPPFLAGS                                                                      = \
     $(COMMONCPPFLAGS)                                                                                        \
     $(SINGLEPHY_CPPFLAGS)                                                                                    \
     $(NULL)
 
-libopenthread_nrf52840_sdk_a_SOURCES                                                                       = \
+libopenthread_nrf52811_sdk_a_SOURCES                                                                       = \
     $(PLATFORM_SOURCES)                                                                                      \
     $(SINGLEPHY_SOURCES)                                                                                     \
-    $(HWCRYPTO_SOURCES)                                                                                      \
-    $(NULL)
-
-libopenthread_nrf52840_softdevice_sdk_a_CPPFLAGS                                                           = \
-    $(COMMONCPPFLAGS)                                                                                        \
-    $(SOFTDEVICE_CPPFLAGS)                                                                                   \
-    $(NULL)
-
-libopenthread_nrf52840_softdevice_sdk_a_SOURCES                                                            = \
-    $(PLATFORM_SOURCES)                                                                                      \
-    $(SOFTDEVICE_SOURCES)                                                                                    \
-    $(HWCRYPTO_SOURCES)                                                                                      \
     $(NULL)
 
 PRETTY_FILES                                                                                               = \
     $(PLATFORM_COMMON_SOURCES)                                                                               \
     $(PLATFORM_DIAG_SOURCES)                                                                                 \
     $(NULL)
-
 Dash                                                                                                       = -
 
-libopenthread_nrf52840_a_LIBADD                                                                            = \
+libopenthread_nrf52811_a_LIBADD                                                                            = \
     $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")                   \
     $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o")
 
-libopenthread_nrf52840_sdk_a_LIBADD                                                                        = \
+libopenthread_nrf52811_sdk_a_LIBADD                                                                        = \
     $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
 
-libopenthread_nrf52840_softdevice_sdk_a_LIBADD                                                             = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/nrf52811/Makefile.platform.am
+++ b/examples/platforms/nrf52811/Makefile.platform.am
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2017, The OpenThread Authors.
+#  Copyright (c) 2019, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -27,14 +27,13 @@
 #
 
 #
-# nrf52840 platform-specific Makefile
+# nrf52811 platform-specific Makefile
 #
 
 LDADD_COMMON                                                                                 += \
-    $(top_builddir)/examples/platforms/nrf52840/libopenthread-nrf52840.a                        \
-    $(top_builddir)/third_party/NordicSemiconductor/libnordicsemi-nrf52840-sdk.a                \
-    $(top_builddir)/third_party/NordicSemiconductor/libnordicsemi-nrf52840-radio-driver.a       \
-    $(top_srcdir)/third_party/NordicSemiconductor/libraries/nrf_cc310/lib/libnrf_cc310_0.9.10.a \
+    $(top_builddir)/examples/platforms/nrf52811/libopenthread-nrf52811.a                        \
+    $(top_builddir)/third_party/NordicSemiconductor/libnordicsemi-nrf52811-sdk.a                \
+    $(top_builddir)/third_party/NordicSemiconductor/libnordicsemi-nrf52811-radio-driver.a       \
     $(NULL)
 
 if OPENTHREAD_ENABLE_CUSTOM_LINKER_FILE
@@ -43,6 +42,6 @@ LDFLAGS_COMMON                                                                  
     $(NULL)
 else
 LDFLAGS_COMMON                                                                               += \
-    -T $(top_srcdir)/examples/platforms/nrf52840/nrf52840.ld                                    \
+    -T $(top_srcdir)/examples/platforms/nrf52811/nrf52811.ld                                    \
     $(NULL)
 endif

--- a/examples/platforms/nrf52811/README.md
+++ b/examples/platforms/nrf52811/README.md
@@ -1,0 +1,262 @@
+# OpenThread on nRF52811 Example
+
+This SoC is meant to be used in the configuration that involves the Host Processor and the IEEE 802.15.4 radio.
+In this configuration, the full OpenThread stack is running on the Host Processor and the nRF52811 SoC acts as an IEEE 802.15.4 radio.
+The radio is running a minimal OpenThread implementation that allows for communication between the Host Processor and the nRF52811. In this architecture the nRF52811 SoC device is called NCP radio or RCP (Radio Co-Processor).
+
+The nRF52811 platform is currently under development.
+
+For the SoC capable to a run full OpenThread stack please check the [nRF52840 platform][nRF52840-page].
+
+[nRF52840-page]: ./../nrf52840/README.md
+
+## Toolchain
+
+Download and install the [GNU toolchain for ARM Cortex-M][gnu-toolchain].
+
+[gnu-toolchain]: https://launchpad.net/gcc-arm-embedded
+
+To install the GNU toolchain and its dependencies,
+run the following commands in Bash:
+
+```bash
+$ cd <path-to-openthread>
+$ ./script/bootstrap
+```
+
+## Building the examples
+
+With this platform you can build:
+ - Limited version of CLI example (e.g. without Thread commissioning functionality)
+ - NCP radio-only example that consists of two parts:
+    - firmware that is flashed to the nRF52811 SoC
+    - host executables to be executed on a POSIX platform in case of the RCP usage
+
+### Building the firmware
+
+To build the firmware using default UART RCP transport, run the following make commands:
+
+```bash
+$ cd <path-to-openthread>
+$ ./bootstrap
+$ make -f examples/Makefile-nrf52811
+```
+
+After a successful build, the `elf` files can be found in
+`<path-to-openthread>/output/nrf52811/bin`.  
+You can convert them to hex using arm-none-eabi-objcopy`:
+```bash
+$ arm-none-eabi-objcopy -O ihex ot-cli-mtd ot-cli-mtd.hex
+$ arm-none-eabi-objcopy -O ihex ot-ncp-radio ot-ncp-radio.hex
+```
+
+### Building host executables
+```bash
+$ cd <path-to-openthread>
+$ ./bootstrap
+$ make -f src/posix/Makefile-posix
+```
+
+After a successful build, executables can be found in
+`<path-to-openthread>/openthread/output/posix/<system-architecture>/bin`.
+It is recommended to copy them to `/usr/bin` for easier access.
+
+## Building the examples with native SPI Slave support
+
+You can build the libraries with support for the native SPI Slave.
+To do so, build the libraries with the following parameter:
+```
+$ make -f examples/Makefile-nrf52811 NCP_SPI=1
+```
+
+With the `NCP_SPI` option enabled, SPI communication between the RCP example and wpantund is possible
+(provided that the wpantund host supports SPI Master).
+To achieve the communication between the RCP example and wpantund,
+choose an appropriate SPI device in the wpantund configuration file,
+`/etc/wpantund.conf`. See the following example.
+
+```
+Config:NCP:SocketPath "system:/usr/bin/ot-ncp /usr/bin/spi-hdlc-adapter -- '--stdio -i /sys/class/gpio/gpio25 /dev/spidev0.1'"
+```
+
+[spi-hdlc-adapter][spi-hdlc-adapter]
+is a tool that can be used to perform communication between RCP and wpantund over SPI.
+In this example, `spi-hdlc-adapter` is installed in `/usr/bin`.
+
+The default SPI Slave pin configuration for nRF52811 is defined in `examples/platforms/nrf52811/platform-config.h`.
+
+[spi-hdlc-adapter]: https://github.com/openthread/openthread/tree/master/tools/spi-hdlc-adapter
+
+### Building the host executables
+
+To build the host executables, run the following make commands:
+
+```bash
+$ cd <path-to-openthread>
+$ ./bootstrap
+$ make -f src/posix/Makefile-posix
+```
+
+After a successful build, executables can be found in
+`<path-to-openthread>/openthread/output/posix/<system-architecture>/bin`.
+Copy the files to /usr/bin for easier access.
+
+## Flashing binaries
+
+Once the examples and libraries are built, flash the compiled binaries onto nRF52811
+using `nrfjprog` that is part of the [nRF5x Command Line Tools][nRF5x-Command-Line-Tools].
+
+[nRF5x-Command-Line-Tools]: https://www.nordicsemi.com/eng/Products/nRF52840#Downloads
+
+Run the following command:
+
+```bash
+$ nrfjprog -f nrf52 --chiperase --program output/nrf52811/bin/ot-cli-mtd.hex --reset
+```
+
+## Running the example
+
+To test the example:
+
+1. Prepare two boards.
+
+2. Flash one with the `CLI MTD Example` (ot-cli-mtd.hex, as shown above).
+
+3. Flash `RCP Example` (ot-ncp-radio.hex) to the other board.
+
+4. Connect the RCP to the PC.
+
+5. Start the ot-cli host application and connect with the RCP.
+   It is assumed that the default UART version of RCP is being used (make executed without the NCP=SPI=1 flag).
+   On Linux system, call a port name, for example `/dev/ttyACM0` for the first connected development kit,
+   and `/dev/ttyACM1` for the second one.
+
+```bash
+$ /usr/bin/ot-cli /dev/ttyACM0 115200
+```
+
+Now you are connected with the CLI.
+
+6. Use the following commands to form a network:
+
+```bash
+ > panid 0xabcd
+ Done
+ > ifconfig up
+ Done
+ > thread start
+ Done
+```
+
+7. Open a terminal connection on the first board and start a new Thread network:
+
+ ```bash
+ > panid 0xabcd
+ Done
+ > ifconfig up
+ Done
+ > thread start
+ Done
+ ```
+
+After a couple of seconds the node will become a Leader of the network.
+
+ ```bash
+ > state
+ Leader
+ ```
+
+8. Open a terminal connection on the second board and attach a node to the network.
+   The CLI MTD example uses the direct UART connection. To view raw UART output, start a terminal
+   emulator like screen and connect to the used COM port with the following UART settings:
+    - Baud rate: 115200
+    - 8 data bits
+    - 1 stop bit
+    - No parity
+    - HW flow control: RTS/CTS
+
+Run the following to connect to the second board.
+
+ ```bash
+ screen /dev/ttyACM1 115200
+ ```
+
+Now you are connected with the CLI.
+
+9. Use the following commands to form a network:
+
+ ```bash
+ > panid 0xabcd
+ Done
+ > ifconfig up
+ Done
+ > thread start
+ Done
+ ```
+
+After a couple of seconds the second node will attach and become a Child.
+
+ ```bash
+ > state
+ Child
+ ```
+
+10. List all IPv6 addresses of the first board.
+
+ ```bash
+ > ipaddr
+ fdde:ad00:beef:0:0:ff:fe00:fc00
+ fdde:ad00:beef:0:0:ff:fe00:9c00
+ fdde:ad00:beef:0:4bcb:73a5:7c28:318e
+ fe80:0:0:0:5c91:c61:b67c:271c
+ ```
+
+11. Choose one of them and send an ICMPv6 ping from the second board.
+
+ ```bash
+ > ping fdde:ad00:beef:0:0:ff:fe00:fc00
+ 16 bytes from fdde:ad00:beef:0:0:ff:fe00:fc00: icmp_seq=1 hlim=64 time=8ms
+ ```
+
+For a list of all available commands, visit [OpenThread CLI Reference README.md][CLI].
+
+[CLI]: ./../../../src/cli/README.md
+
+## Working with the logging module
+
+By default, the OpenThread's logging module provides functions to output logging
+information over SEGGER's Real Time Transfer (RTT).
+
+The RTT output can be viewed in the J-Link RTT Viewer, which is available from SEGGER.
+
+The viewer is also included in the nRF Tools. 
+To read or write messages over RTT:
+
+1. Connect an nRF5 development board via with a USB cable. 
+2. Run the J-Link RTT Viewer.
+3. In the Specify Target Device dropdown menu, select the nRF52 device.
+4. In the Target Interface & Speed dropdown menu, select the SWD interface.
+
+The intended log level can be set using `OPENTHREAD_CONFIG_LOG_LEVEL` define.
+
+## Disabling the Mass Storage Device
+
+Depending on your software version, a known issue in SEGGER's J-Link firmware can cause data corruption or data drops if you use the serial port. You can avoid this issue by disabling the Mass Storage Device:
+
+ - On Linux or macOS (OS X), open JLinkExe from the terminal and run the command `MSDDisable`.
+ - On Microsoft Windows, open the J-Link Commander application and run the command `MSDDisable`.
+
+## Diagnostic module
+
+nRF52811 supports [OpenThread Diagnostics Module][DIAG], with some additional features.
+
+For more information, see [nRF Diag command reference][nRFDIAG].
+
+[DIAG]: ./../../../src/diag/README.md
+[nRFDIAG]: DIAG.md
+
+## Radio driver documentation
+
+The radio driver documentation includes *.uml state machines sequence diagrams that can be opened with [PlantUML][PlantUML-url].
+
+[PlantUML-url]: http://plantuml.com/

--- a/examples/platforms/nrf52811/alarm.c
+++ b/examples/platforms/nrf52811/alarm.c
@@ -1,0 +1,690 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the OpenThread platform abstraction for the alarm.
+ *
+ */
+
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <openthread/platform/alarm-micro.h>
+#include <openthread/platform/alarm-milli.h>
+#include <openthread/platform/diag.h>
+#include <openthread/platform/time.h>
+
+#include "openthread-system.h"
+
+#include "platform-config.h"
+#include "platform-nrf5.h"
+#include "cmsis/core_cmFunc.h"
+
+#include <drivers/clock/nrf_drv_clock.h>
+#include <drivers/radio/nrf_802154_utils.h>
+#include <drivers/radio/platform/lp_timer/nrf_802154_lp_timer.h>
+
+#include <hal/nrf_rtc.h>
+
+#include <openthread/config.h>
+
+// clang-format off
+#define RTC_FREQUENCY       NRF_802154_RTC_FREQUENCY
+
+#define US_PER_MS           1000ULL
+#define US_PER_S            NRF_802154_US_PER_S
+#define US_PER_OVERFLOW     (512UL * NRF_802154_US_PER_S)  ///< Time that has passed between overflow events. On full RTC speed, it occurs every 512 s.
+
+#define MS_PER_S            1000UL
+
+#define MIN_RTC_COMPARE_EVENT_TICKS  2                                                        ///< Minimum number of RTC ticks delay that guarantees that RTC compare event will fire.
+#define MIN_RTC_COMPARE_EVENT_DT     (MIN_RTC_COMPARE_EVENT_TICKS * NRF_802154_US_PER_TICK)   ///< Minimum time delta from now before RTC compare event is guaranteed to fire.
+#define EPOCH_32BIT_US               (1ULL << 32)
+#define EPOCH_FROM_TIME(time)        ((time) & ((uint64_t)UINT32_MAX << 32))
+
+#define XTAL_ACCURACY       40 // The crystal used on nRF52840PDK has ±20ppm accuracy.
+// clang-format on
+
+typedef enum
+{
+    kMsTimer,
+    kUsTimer,
+    k802154Timer,
+    k802154Sync,
+    kNumTimers
+} AlarmIndex;
+
+typedef struct
+{
+    volatile bool mFireAlarm;  ///< Information for processing function, that alarm should fire.
+    uint64_t      mTargetTime; ///< Alarm fire time (in millisecond for MsTimer, in microsecond for UsTimer)
+} AlarmData;
+
+typedef struct
+{
+    uint32_t        mChannelNumber;
+    uint32_t        mCompareEventMask;
+    nrf_rtc_event_t mCompareEvent;
+    nrf_rtc_int_t   mCompareInt;
+} AlarmChannelData;
+
+static volatile uint32_t sOverflowCounter; ///< Counter of RTC overflowCounter, incremented by 2 on each OVERFLOW event.
+static volatile uint8_t  sMutex;           ///< Mutex for write access to @ref sOverflowCounter.
+static volatile uint64_t sTimeOffset = 0;  ///< Time overflowCounter to keep track of current time (in millisecond).
+static volatile bool     sEventPending;    ///< Timer fired and upper layer should be notified.
+static AlarmData         sTimerData[kNumTimers]; ///< Data of the timers.
+
+static const AlarmChannelData sChannelData[kNumTimers] = //
+    {                                                    //
+        [kMsTimer] =
+            {
+                .mChannelNumber    = 0,
+                .mCompareEventMask = RTC_EVTEN_COMPARE0_Msk,
+                .mCompareEvent     = NRF_RTC_EVENT_COMPARE_0,
+                .mCompareInt       = NRF_RTC_INT_COMPARE0_MASK,
+            },
+        [kUsTimer] =
+            {
+                .mChannelNumber    = 1,
+                .mCompareEventMask = RTC_EVTEN_COMPARE1_Msk,
+                .mCompareEvent     = NRF_RTC_EVENT_COMPARE_1,
+                .mCompareInt       = NRF_RTC_INT_COMPARE1_MASK,
+            },
+        [k802154Timer] =
+            {
+                .mChannelNumber    = 2,
+                .mCompareEventMask = RTC_EVTEN_COMPARE2_Msk,
+                .mCompareEvent     = NRF_RTC_EVENT_COMPARE_2,
+                .mCompareInt       = NRF_RTC_INT_COMPARE2_MASK,
+            },
+        [k802154Sync] = {
+            .mChannelNumber    = 3,
+            .mCompareEventMask = RTC_EVTEN_COMPARE3_Msk,
+            .mCompareEvent     = NRF_RTC_EVENT_COMPARE_3,
+            .mCompareInt       = NRF_RTC_INT_COMPARE3_MASK,
+        }};
+
+static inline bool MutexGet(void)
+{
+    do
+    {
+        volatile uint8_t mutexValue = __LDREXB(&sMutex);
+
+        if (mutexValue)
+        {
+            __CLREX();
+            return false;
+        }
+    } while (__STREXB(1, &sMutex));
+
+    // Disable OVERFLOW interrupt to prevent lock-up in interrupt context while mutex is locked from lower priority
+    // context and OVERFLOW event flag is stil up.
+    nrf_rtc_int_disable(RTC_INSTANCE, NRF_RTC_INT_OVERFLOW_MASK);
+
+    __DMB();
+
+    return true;
+}
+
+static inline void MutexRelease(void)
+{
+    // Re-enable OVERFLOW interrupt.
+    nrf_rtc_int_enable(RTC_INSTANCE, NRF_RTC_INT_OVERFLOW_MASK);
+
+    __DMB();
+    sMutex = 0;
+}
+
+static inline uint64_t TimeToTicks(uint64_t aTime, AlarmIndex aIndex)
+{
+    if (aIndex == kMsTimer)
+    {
+        aTime *= US_PER_MS;
+    }
+
+    return NRF_802154_US_TO_RTC_TICKS(aTime);
+}
+
+static inline uint64_t TicksToTime(uint64_t aTicks, AlarmIndex aIndex)
+{
+    uint64_t result = NRF_802154_RTC_TICKS_TO_US(aTicks);
+
+    if (aIndex == kMsTimer)
+    {
+        result /= US_PER_MS;
+    }
+
+    return result;
+}
+
+static inline bool AlarmShallStrike(uint64_t aNow, AlarmIndex aIndex)
+{
+    return aNow >= sTimerData[aIndex].mTargetTime;
+}
+
+static uint32_t GetOverflowCounter(void)
+{
+    uint32_t overflowCounter;
+
+    // Get mutual access for writing to sOverflowCounter variable.
+    if (MutexGet())
+    {
+        bool increasing = false;
+
+        // Check if interrupt was handled already.
+        if (nrf_rtc_event_pending(RTC_INSTANCE, NRF_RTC_EVENT_OVERFLOW))
+        {
+            sOverflowCounter++;
+            increasing = true;
+
+            __DMB();
+
+            // Mark that interrupt was handled.
+            nrf_rtc_event_clear(RTC_INSTANCE, NRF_RTC_EVENT_OVERFLOW);
+
+            // Result should be incremented. sOverflowCounter will be incremented after mutex is released.
+        }
+        else
+        {
+            // Either overflow handling is not needed OR we acquired the mutex just after it was released.
+            // Overflow is handled after mutex is released, but it cannot be assured that sOverflowCounter
+            // was incremented for the second time, so we increment the result here.
+        }
+
+        overflowCounter = (sOverflowCounter + 1) / 2;
+
+        MutexRelease();
+
+        if (increasing)
+        {
+            // It's virtually impossible that overflow event is pending again before next instruction is performed. It
+            // is an error condition.
+            assert(sOverflowCounter & 0x01);
+
+            // Increment the counter for the second time, to allow instructions from other context get correct value of
+            // the counter.
+            sOverflowCounter++;
+        }
+    }
+    else
+    {
+        // Failed to acquire mutex.
+        if (nrf_rtc_event_pending(RTC_INSTANCE, NRF_RTC_EVENT_OVERFLOW) || (sOverflowCounter & 0x01))
+        {
+            // Lower priority context is currently incrementing sOverflowCounter variable.
+            overflowCounter = (sOverflowCounter + 2) / 2;
+        }
+        else
+        {
+            // Lower priority context has already incremented sOverflowCounter variable or incrementing is not needed
+            // now.
+            overflowCounter = sOverflowCounter / 2;
+        }
+    }
+
+    return overflowCounter;
+}
+
+static uint32_t GetRtcCounter(void)
+{
+    return nrf_rtc_counter_get(RTC_INSTANCE);
+}
+
+static void GetOffsetAndCounter(uint32_t *aOffset, uint32_t *aCounter)
+{
+    uint32_t offset1 = GetOverflowCounter();
+
+    __DMB();
+
+    uint32_t rtcValue1 = GetRtcCounter();
+
+    __DMB();
+
+    uint32_t offset2 = GetOverflowCounter();
+
+    *aOffset  = offset2;
+    *aCounter = (offset1 == offset2) ? rtcValue1 : GetRtcCounter();
+}
+
+static uint64_t GetTime(uint32_t aOffset, uint32_t aCounter, AlarmIndex aIndex)
+{
+    uint64_t result = (uint64_t)aOffset * US_PER_OVERFLOW + TicksToTime(aCounter, kUsTimer);
+
+    if (aIndex == kMsTimer)
+    {
+        result /= US_PER_MS;
+    }
+
+    return result;
+}
+
+static uint64_t GetCurrentTime(AlarmIndex aIndex)
+{
+    uint32_t offset;
+    uint32_t rtc_counter;
+
+    GetOffsetAndCounter(&offset, &rtc_counter);
+
+    return GetTime(offset, rtc_counter, aIndex);
+}
+
+static void HandleCompareMatch(AlarmIndex aIndex, bool aSkipCheck)
+{
+    nrf_rtc_event_clear(RTC_INSTANCE, sChannelData[aIndex].mCompareEvent);
+
+    uint64_t now = GetCurrentTime(aIndex);
+
+    // In case the target time was larger than single overflow,
+    // we should only strike the timer on final compare event.
+    if (aSkipCheck || AlarmShallStrike(now, aIndex))
+    {
+        nrf_rtc_event_disable(RTC_INSTANCE, sChannelData[aIndex].mCompareEventMask);
+        nrf_rtc_int_disable(RTC_INSTANCE, sChannelData[aIndex].mCompareInt);
+
+        switch (aIndex)
+        {
+        case k802154Timer:
+            nrf_802154_lp_timer_fired();
+            break;
+
+        case k802154Sync:
+            nrf_802154_lp_timer_synchronized();
+            break;
+
+        case kMsTimer:
+        case kUsTimer:
+            sTimerData[aIndex].mFireAlarm = true;
+            sEventPending                 = true;
+            otSysEventSignalPending();
+            break;
+
+        default:
+            assert(false);
+        }
+    }
+}
+
+static uint64_t ConvertT0AndDtTo64BitTime(uint32_t aT0, uint32_t aDt, const uint64_t *aNow)
+{
+    uint64_t now;
+    now = *aNow;
+
+    if (((uint32_t)now < aT0) && ((aT0 - (uint32_t)now) > (UINT32_MAX / 2)))
+    {
+        now -= EPOCH_32BIT_US;
+    }
+    else if (((uint32_t)now > aT0) && (((uint32_t)now) - aT0 > (UINT32_MAX / 2)))
+    {
+        now += EPOCH_32BIT_US;
+    }
+
+    return (EPOCH_FROM_TIME(now)) + aT0 + aDt;
+}
+
+static uint64_t RoundUpTimeToTimerTicksMultiply(uint64_t aTime, AlarmIndex aIndex)
+{
+    uint64_t ticks  = TimeToTicks(aTime, aIndex);
+    uint64_t result = TicksToTime(ticks, aIndex);
+    return result;
+}
+
+static void TimerStartAt(uint32_t aT0, uint32_t aDt, AlarmIndex aIndex, const uint64_t *aNow)
+{
+    uint64_t targetCounter;
+    uint64_t targetTime;
+
+    nrf_rtc_int_disable(RTC_INSTANCE, sChannelData[aIndex].mCompareInt);
+    nrf_rtc_event_enable(RTC_INSTANCE, sChannelData[aIndex].mCompareEventMask);
+
+    targetTime    = ConvertT0AndDtTo64BitTime(aT0, aDt, aNow);
+    targetCounter = TimeToTicks(targetTime, aIndex) & RTC_CC_COMPARE_Msk;
+
+    sTimerData[aIndex].mTargetTime = RoundUpTimeToTimerTicksMultiply(targetTime, aIndex);
+
+    nrf_rtc_cc_set(RTC_INSTANCE, sChannelData[aIndex].mChannelNumber, targetCounter);
+}
+
+static void AlarmStartAt(uint32_t aT0, uint32_t aDt, AlarmIndex aIndex)
+{
+    uint32_t offset;
+    uint32_t rtc_value;
+    uint64_t now;
+    uint64_t now_rtc_protected;
+
+    GetOffsetAndCounter(&offset, &rtc_value);
+    now = GetTime(offset, rtc_value, aIndex);
+
+    TimerStartAt(aT0, aDt, aIndex, &now);
+
+    if (rtc_value != GetRtcCounter())
+    {
+        GetOffsetAndCounter(&offset, &rtc_value);
+    }
+
+    now_rtc_protected = GetTime(offset, rtc_value + MIN_RTC_COMPARE_EVENT_TICKS, aIndex);
+
+    if (AlarmShallStrike(now_rtc_protected, aIndex))
+    {
+        HandleCompareMatch(aIndex, true);
+
+        /**
+         * Normally ISR sets event flag automatically.
+         * Here we are calling HandleCompareMatch explicitly and no ISR will be fired.
+         * To prevent possible permanent sleep on next WFE we have to set event flag.
+         */
+        __SEV();
+    }
+    else
+    {
+        nrf_rtc_int_enable(RTC_INSTANCE, sChannelData[aIndex].mCompareInt);
+    }
+}
+
+static void TimerSyncStartAt(uint32_t aT0, uint32_t aDt, const uint64_t *aNow)
+{
+    TimerStartAt(aT0, aDt, k802154Sync, aNow);
+
+    nrf_rtc_int_enable(RTC_INSTANCE, sChannelData[k802154Sync].mCompareInt);
+}
+
+static void AlarmStop(AlarmIndex aIndex)
+{
+    nrf_rtc_event_disable(RTC_INSTANCE, sChannelData[aIndex].mCompareEventMask);
+    nrf_rtc_int_disable(RTC_INSTANCE, sChannelData[aIndex].mCompareInt);
+    nrf_rtc_event_clear(RTC_INSTANCE, sChannelData[aIndex].mCompareEvent);
+
+    sTimerData[aIndex].mFireAlarm = false;
+}
+
+void nrf5AlarmInit(void)
+{
+    memset(sTimerData, 0, sizeof(sTimerData));
+    sOverflowCounter = 0;
+    sMutex           = 0;
+    sTimeOffset      = 0;
+
+    // Setup low frequency clock.
+    nrf_drv_clock_lfclk_request(NULL);
+
+    while (!nrf_drv_clock_lfclk_is_running())
+    {
+    }
+
+    // Setup RTC timer.
+    NVIC_SetPriority(RTC_IRQN, RTC_IRQ_PRIORITY);
+    NVIC_ClearPendingIRQ(RTC_IRQN);
+    NVIC_EnableIRQ(RTC_IRQN);
+
+    nrf_rtc_prescaler_set(RTC_INSTANCE, 0);
+
+    nrf_rtc_event_clear(RTC_INSTANCE, NRF_RTC_EVENT_OVERFLOW);
+    nrf_rtc_event_enable(RTC_INSTANCE, RTC_EVTEN_OVRFLW_Msk);
+    nrf_rtc_int_enable(RTC_INSTANCE, NRF_RTC_INT_OVERFLOW_MASK);
+
+    for (uint32_t i = 0; i < kNumTimers; i++)
+    {
+        nrf_rtc_event_clear(RTC_INSTANCE, sChannelData[i].mCompareEvent);
+        nrf_rtc_event_disable(RTC_INSTANCE, sChannelData[i].mCompareEventMask);
+        nrf_rtc_int_disable(RTC_INSTANCE, sChannelData[i].mCompareInt);
+    }
+
+    nrf_rtc_task_trigger(RTC_INSTANCE, NRF_RTC_TASK_START);
+}
+
+void nrf5AlarmDeinit(void)
+{
+    nrf_rtc_task_trigger(RTC_INSTANCE, NRF_RTC_TASK_STOP);
+
+    for (uint32_t i = 0; i < kNumTimers; i++)
+    {
+        nrf_rtc_event_clear(RTC_INSTANCE, sChannelData[i].mCompareEvent);
+        nrf_rtc_event_disable(RTC_INSTANCE, sChannelData[i].mCompareEventMask);
+        nrf_rtc_int_disable(RTC_INSTANCE, sChannelData[i].mCompareInt);
+    }
+
+    nrf_rtc_int_disable(RTC_INSTANCE, NRF_RTC_INT_OVERFLOW_MASK);
+    nrf_rtc_event_disable(RTC_INSTANCE, RTC_EVTEN_OVRFLW_Msk);
+    nrf_rtc_event_clear(RTC_INSTANCE, NRF_RTC_EVENT_OVERFLOW);
+
+    nrf_802154_lp_timer_sync_stop();
+
+    NVIC_DisableIRQ(RTC_IRQN);
+    NVIC_ClearPendingIRQ(RTC_IRQN);
+    NVIC_SetPriority(RTC_IRQN, 0);
+
+    nrf_drv_clock_lfclk_release();
+}
+
+void nrf5AlarmProcess(otInstance *aInstance)
+{
+    do
+    {
+        sEventPending = false;
+
+        if (sTimerData[kMsTimer].mFireAlarm)
+        {
+            sTimerData[kMsTimer].mFireAlarm = false;
+
+#if OPENTHREAD_ENABLE_DIAG
+
+            if (otPlatDiagModeGet())
+            {
+                otPlatDiagAlarmFired(aInstance);
+            }
+            else
+#endif
+            {
+                otPlatAlarmMilliFired(aInstance);
+            }
+        }
+
+        if (sTimerData[kUsTimer].mFireAlarm)
+        {
+            sTimerData[kUsTimer].mFireAlarm = false;
+
+            otPlatAlarmMicroFired(aInstance);
+        }
+    } while (sEventPending);
+}
+
+inline uint64_t nrf5AlarmGetCurrentTime(void)
+{
+    return GetCurrentTime(kUsTimer);
+}
+
+uint32_t otPlatAlarmMilliGetNow(void)
+{
+    return (uint32_t)(nrf5AlarmGetCurrentTime() / US_PER_MS);
+}
+
+void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
+{
+    (void)aInstance;
+
+    AlarmStartAt(aT0, aDt, kMsTimer);
+}
+
+void otPlatAlarmMilliStop(otInstance *aInstance)
+{
+    (void)aInstance;
+
+    AlarmStop(kMsTimer);
+}
+
+uint32_t otPlatAlarmMicroGetNow(void)
+{
+    return (uint32_t)nrf5AlarmGetCurrentTime();
+}
+
+void otPlatAlarmMicroStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
+{
+    (void)aInstance;
+
+    AlarmStartAt(aT0, aDt, kUsTimer);
+}
+
+void otPlatAlarmMicroStop(otInstance *aInstance)
+{
+    (void)aInstance;
+
+    AlarmStop(kUsTimer);
+}
+
+/**
+ * Radio driver timer abstraction API
+ */
+
+void nrf_802154_lp_timer_init(void)
+{
+    // Intentionally empty
+}
+
+void nrf_802154_lp_timer_deinit(void)
+{
+    // Intentionally empty
+}
+
+void nrf_802154_lp_timer_critical_section_enter(void)
+{
+    nrf_rtc_int_disable(RTC_INSTANCE, sChannelData[k802154Timer].mCompareInt);
+    __DSB();
+    __ISB();
+}
+
+void nrf_802154_lp_timer_critical_section_exit(void)
+{
+    nrf_rtc_int_enable(RTC_INSTANCE, sChannelData[k802154Timer].mCompareInt);
+}
+
+uint32_t nrf_802154_lp_timer_time_get(void)
+{
+    return (uint32_t)nrf5AlarmGetCurrentTime();
+}
+
+uint32_t nrf_802154_lp_timer_granularity_get(void)
+{
+    return NRF_802154_US_PER_TICK;
+}
+
+void nrf_802154_lp_timer_start(uint32_t t0, uint32_t dt)
+{
+    AlarmStartAt(t0, dt, k802154Timer);
+}
+
+bool nrf_802154_lp_timer_is_running(void)
+{
+    return nrf_rtc_int_is_enabled(RTC_INSTANCE, sChannelData[k802154Timer].mCompareInt);
+}
+
+void nrf_802154_lp_timer_stop(void)
+{
+    AlarmStop(k802154Timer);
+}
+
+void nrf_802154_lp_timer_sync_start_now(void)
+{
+    uint32_t counter;
+    uint32_t offset;
+    uint64_t now;
+
+    do
+    {
+        GetOffsetAndCounter(&offset, &counter);
+        now = GetTime(offset, counter, k802154Sync);
+        TimerSyncStartAt((uint32_t)now, MIN_RTC_COMPARE_EVENT_DT, &now);
+    } while (GetRtcCounter() != counter);
+}
+
+void nrf_802154_lp_timer_sync_start_at(uint32_t t0, uint32_t dt)
+{
+    uint64_t now = GetCurrentTime(k802154Sync);
+
+    TimerSyncStartAt(t0, dt, &now);
+}
+
+void nrf_802154_lp_timer_sync_stop(void)
+{
+    AlarmStop(k802154Sync);
+}
+
+uint32_t nrf_802154_lp_timer_sync_event_get(void)
+{
+    return (uint32_t)nrf_rtc_event_address_get(RTC_INSTANCE, sChannelData[k802154Sync].mCompareEvent);
+}
+
+uint32_t nrf_802154_lp_timer_sync_time_get(void)
+{
+    return (uint32_t)sTimerData[k802154Sync].mTargetTime;
+}
+
+/**
+ * RTC IRQ handler
+ */
+
+void RTC_IRQ_HANDLER(void)
+{
+    // Handle overflow.
+    if (nrf_rtc_event_pending(RTC_INSTANCE, NRF_RTC_EVENT_OVERFLOW))
+    {
+        // Disable OVERFLOW interrupt to prevent lock-up in interrupt context while mutex is locked from lower priority
+        // context and OVERFLOW event flag is stil up. OVERFLOW interrupt will be re-enabled when mutex is released -
+        // either from this handler, or from lower priority context, that locked the mutex.
+        nrf_rtc_int_disable(RTC_INSTANCE, NRF_RTC_INT_OVERFLOW_MASK);
+
+        // Handle OVERFLOW event by reading current value of overflow counter.
+        (void)GetOverflowCounter();
+    }
+
+    // Handle compare match.
+    for (uint32_t i = 0; i < kNumTimers; i++)
+    {
+        if (nrf_rtc_int_is_enabled(RTC_INSTANCE, sChannelData[i].mCompareInt) &&
+            nrf_rtc_event_pending(RTC_INSTANCE, sChannelData[i].mCompareEvent))
+        {
+            HandleCompareMatch((AlarmIndex)i, false);
+        }
+    }
+}
+
+#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+uint64_t otPlatTimeGet(void)
+{
+    return nrf5AlarmGetCurrentTime();
+}
+
+uint16_t otPlatTimeGetXtalAccuracy(void)
+{
+    return XTAL_ACCURACY;
+}
+#endif // OPENTHREAD_CONFIG_ENABLE_TIME_SYNC

--- a/examples/platforms/nrf52811/diag.c
+++ b/examples/platforms/nrf52811/diag.c
@@ -1,0 +1,492 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "platform-nrf5.h"
+
+#include <hal/nrf_gpio.h>
+
+#include <openthread/cli.h>
+#include <openthread/platform/alarm-milli.h>
+#include <openthread/platform/diag.h>
+#include <openthread/platform/radio.h>
+#include <openthread/platform/toolchain.h>
+
+#include <common/logging.hpp>
+#include <drivers/radio/nrf_802154.h>
+#include <utils/code_utils.h>
+
+typedef enum
+{
+    kDiagTransmitModeIdle,
+    kDiagTransmitModePackets,
+    kDiagTransmitModeCarrier
+} DiagTrasmitMode;
+
+struct PlatformDiagCommand
+{
+    const char *mName;
+    void (*mCommand)(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
+};
+
+struct PlatformDiagMessage
+{
+    const char mMessageDescriptor[11];
+    uint8_t    mChannel;
+    int16_t    mID;
+    uint32_t   mCnt;
+};
+
+/**
+ * Diagnostics mode variables.
+ *
+ */
+static bool                       sDiagMode         = false;
+static bool                       sListen           = false;
+static DiagTrasmitMode            sTransmitMode     = kDiagTransmitModeIdle;
+static uint8_t                    sChannel          = 20;
+static int8_t                     sTxPower          = 0;
+static uint32_t                   sTxPeriod         = 1;
+static int32_t                    sTxCount          = 0;
+static int32_t                    sTxRequestedCount = 1;
+static int16_t                    sID               = -1;
+static struct PlatformDiagMessage sDiagMessage      = {.mMessageDescriptor = "DiagMessage",
+                                                  .mChannel           = 0,
+                                                  .mID                = 0,
+                                                  .mCnt               = 0};
+
+static otError parseLong(char *argv, long *aValue)
+{
+    char *endptr;
+    *aValue = strtol(argv, &endptr, 0);
+    return (*endptr == '\0') ? OT_ERROR_NONE : OT_ERROR_PARSE;
+}
+
+static void appendErrorResult(otError aError, char *aOutput, size_t aOutputMaxLen)
+{
+    if (aError != OT_ERROR_NONE)
+    {
+        snprintf(aOutput, aOutputMaxLen, "failed\r\nstatus %#x\r\n", aError);
+    }
+}
+
+static bool startCarrierTransmision(void)
+{
+    nrf_802154_channel_set(sChannel);
+    nrf_802154_tx_power_set(sTxPower);
+
+    return nrf_802154_continuous_carrier();
+}
+
+static void processListen(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+{
+    (void)aInstance;
+    otError error = OT_ERROR_NONE;
+
+    otEXPECT_ACTION(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
+
+    if (argc == 0)
+    {
+        snprintf(aOutput, aOutputMaxLen, "listen: %s\r\n", sListen == true ? "yes" : "no");
+    }
+    else
+    {
+        long value;
+
+        error = parseLong(argv[0], &value);
+        otEXPECT(error == OT_ERROR_NONE);
+        sListen = (bool)(value);
+        snprintf(aOutput, aOutputMaxLen, "set listen to %s\r\nstatus 0x%02x\r\n", sListen == true ? "yes" : "no",
+                 error);
+    }
+
+exit:
+    appendErrorResult(error, aOutput, aOutputMaxLen);
+}
+
+static void processID(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+{
+    (void)aInstance;
+
+    otError error = OT_ERROR_NONE;
+
+    otEXPECT_ACTION(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
+
+    if (argc == 0)
+    {
+        snprintf(aOutput, aOutputMaxLen, "ID: %" PRId16 "\r\n", sID);
+    }
+    else
+    {
+        long value;
+
+        error = parseLong(argv[0], &value);
+        otEXPECT(error == OT_ERROR_NONE);
+        otEXPECT_ACTION(value >= 0, error = OT_ERROR_INVALID_ARGS);
+        sID = (int16_t)(value);
+        snprintf(aOutput, aOutputMaxLen, "set ID to %" PRId16 "\r\nstatus 0x%02x\r\n", sID, error);
+    }
+
+exit:
+    appendErrorResult(error, aOutput, aOutputMaxLen);
+}
+
+static void processTransmit(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+{
+    otError error = OT_ERROR_NONE;
+
+    otEXPECT_ACTION(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
+
+    if (argc == 0)
+    {
+        snprintf(aOutput, aOutputMaxLen,
+                 "transmit will send %" PRId32 " diagnostic messages with %" PRIu32 " ms interval\r\nstatus 0x%02x\r\n",
+                 sTxRequestedCount, sTxPeriod, error);
+    }
+    else if (strcmp(argv[0], "stop") == 0)
+    {
+        otEXPECT_ACTION(sTransmitMode != kDiagTransmitModeIdle, error = OT_ERROR_INVALID_STATE);
+
+        otPlatAlarmMilliStop(aInstance);
+        snprintf(aOutput, aOutputMaxLen, "diagnostic message transmission is stopped\r\nstatus 0x%02x\r\n", error);
+        sTransmitMode = kDiagTransmitModeIdle;
+        otPlatRadioReceive(aInstance, sChannel);
+    }
+    else if (strcmp(argv[0], "start") == 0)
+    {
+        otEXPECT_ACTION(sTransmitMode == kDiagTransmitModeIdle, error = OT_ERROR_INVALID_STATE);
+
+        otPlatAlarmMilliStop(aInstance);
+        sTransmitMode = kDiagTransmitModePackets;
+        sTxCount      = sTxRequestedCount;
+        uint32_t now  = otPlatAlarmMilliGetNow();
+        otPlatAlarmMilliStartAt(aInstance, now, sTxPeriod);
+        snprintf(aOutput, aOutputMaxLen,
+                 "sending %" PRId32 " diagnostic messages with %" PRIu32 " ms interval\r\nstatus 0x%02x\r\n",
+                 sTxRequestedCount, sTxPeriod, error);
+    }
+    else if (strcmp(argv[0], "carrier") == 0)
+    {
+        otEXPECT_ACTION(sTransmitMode == kDiagTransmitModeIdle, error = OT_ERROR_INVALID_STATE);
+
+        otEXPECT_ACTION(startCarrierTransmision(), error = OT_ERROR_FAILED);
+
+        sTransmitMode = kDiagTransmitModeCarrier;
+
+        snprintf(aOutput, aOutputMaxLen, "sending carrier on channel %d with tx power %d\r\nstatus 0x%02x\r\n",
+                 sChannel, sTxPower, error);
+    }
+    else if (strcmp(argv[0], "interval") == 0)
+    {
+        long value;
+
+        otEXPECT_ACTION(argc == 2, error = OT_ERROR_INVALID_ARGS);
+
+        error = parseLong(argv[1], &value);
+        otEXPECT(error == OT_ERROR_NONE);
+        otEXPECT_ACTION(value > 0, error = OT_ERROR_INVALID_ARGS);
+        sTxPeriod = (uint32_t)(value);
+        snprintf(aOutput, aOutputMaxLen, "set diagnostic messages interval to %" PRIu32 " ms\r\nstatus 0x%02x\r\n",
+                 sTxPeriod, error);
+    }
+    else if (strcmp(argv[0], "count") == 0)
+    {
+        long value;
+
+        otEXPECT_ACTION(argc == 2, error = OT_ERROR_INVALID_ARGS);
+
+        error = parseLong(argv[1], &value);
+        otEXPECT(error == OT_ERROR_NONE);
+        otEXPECT_ACTION((value > 0) || (value == -1), error = OT_ERROR_INVALID_ARGS);
+        sTxRequestedCount = (uint32_t)(value);
+        snprintf(aOutput, aOutputMaxLen, "set diagnostic messages count to %" PRId32 "\r\nstatus 0x%02x\r\n",
+                 sTxRequestedCount, error);
+    }
+    else
+    {
+        error = OT_ERROR_INVALID_ARGS;
+    }
+
+exit:
+    appendErrorResult(error, aOutput, aOutputMaxLen);
+}
+
+static void processGpio(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    long    pinnum;
+    otError error = OT_ERROR_NONE;
+
+    otEXPECT_ACTION(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
+
+    if (argc == 1)
+    {
+        uint32_t value;
+
+        error = parseLong(argv[0], &pinnum);
+        otEXPECT(error == OT_ERROR_NONE);
+
+        value = nrf_gpio_pin_read(pinnum);
+
+        snprintf(aOutput, aOutputMaxLen, "gpio %d = %d\r\n", (uint8_t)pinnum, (uint8_t)value);
+    }
+    else if (strcmp(argv[0], "set") == 0)
+    {
+        otEXPECT_ACTION(argc == 2, error = OT_ERROR_INVALID_ARGS);
+        error = parseLong(argv[1], &pinnum);
+        otEXPECT(error == OT_ERROR_NONE);
+
+        nrf_gpio_pin_set(pinnum);
+
+        snprintf(aOutput, aOutputMaxLen, "gpio %d = 1\r\n", (uint8_t)pinnum);
+    }
+    else if (strcmp(argv[0], "clr") == 0)
+    {
+        otEXPECT_ACTION(argc == 2, error = OT_ERROR_INVALID_ARGS);
+        error = parseLong(argv[1], &pinnum);
+        otEXPECT(error == OT_ERROR_NONE);
+
+        nrf_gpio_pin_clear(pinnum);
+
+        snprintf(aOutput, aOutputMaxLen, "gpio %d = 0\r\n", (uint8_t)pinnum);
+    }
+    else if (strcmp(argv[0], "out") == 0)
+    {
+        otEXPECT_ACTION(argc == 2, error = OT_ERROR_INVALID_ARGS);
+        error = parseLong(argv[1], &pinnum);
+        otEXPECT(error == OT_ERROR_NONE);
+
+        nrf_gpio_cfg_output(pinnum);
+
+        snprintf(aOutput, aOutputMaxLen, "gpio %d: out\r\n", (uint8_t)pinnum);
+    }
+    else if (strcmp(argv[0], "in") == 0)
+    {
+        otEXPECT_ACTION(argc == 2, error = OT_ERROR_INVALID_ARGS);
+        error = parseLong(argv[1], &pinnum);
+        otEXPECT(error == OT_ERROR_NONE);
+
+        nrf_gpio_cfg_input(pinnum, NRF_GPIO_PIN_NOPULL);
+
+        snprintf(aOutput, aOutputMaxLen, "gpio %d: in no pull\r\n", (uint8_t)pinnum);
+    }
+    else
+    {
+        error = OT_ERROR_INVALID_ARGS;
+    }
+
+exit:
+    appendErrorResult(error, aOutput, aOutputMaxLen);
+}
+
+static void processTemp(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(argv);
+
+    otError error = OT_ERROR_NONE;
+    int32_t temperature;
+
+    otEXPECT_ACTION(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
+    otEXPECT_ACTION(argc == 0, error = OT_ERROR_INVALID_ARGS);
+
+    temperature = nrf5TempGet();
+
+    // Measurement resolution is 0.25 degrees Celsius
+    // Convert the temperature measurement to a decimal value, in degrees Celsius
+    snprintf(aOutput, aOutputMaxLen, "%" PRId32 ".%02" PRId32 "\r\n", temperature / 4, 25 * (temperature % 4));
+
+exit:
+    appendErrorResult(error, aOutput, aOutputMaxLen);
+}
+
+static void processCcaThreshold(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+{
+    (void)aInstance;
+
+    otError              error = OT_ERROR_NONE;
+    nrf_802154_cca_cfg_t ccaConfig;
+
+    otEXPECT_ACTION(otPlatDiagModeGet(), error = OT_ERROR_INVALID_STATE);
+
+    if (argc == 0)
+    {
+        nrf_802154_cca_cfg_get(&ccaConfig);
+
+        snprintf(aOutput, aOutputMaxLen, "cca threshold: %u\r\n", ccaConfig.ed_threshold);
+    }
+    else
+    {
+        long value;
+        error = parseLong(argv[0], &value);
+        otEXPECT(error == OT_ERROR_NONE);
+        otEXPECT_ACTION(value >= 0 && value <= 0xFF, error = OT_ERROR_INVALID_ARGS);
+
+        memset(&ccaConfig, 0, sizeof(ccaConfig));
+        ccaConfig.mode         = NRF_RADIO_CCA_MODE_ED;
+        ccaConfig.ed_threshold = (uint8_t)value;
+
+        nrf_802154_cca_cfg_set(&ccaConfig);
+        snprintf(aOutput, aOutputMaxLen, "set cca threshold to %u\r\nstatus 0x%02x\r\n", ccaConfig.ed_threshold, error);
+    }
+
+exit:
+    appendErrorResult(error, aOutput, aOutputMaxLen);
+}
+
+const struct PlatformDiagCommand sCommands[] = {
+    {"ccathreshold", &processCcaThreshold},
+    {"gpio", &processGpio},
+    {"id", &processID},
+    {"listen", &processListen},
+    {"temp", &processTemp},
+    {"transmit", &processTransmit},
+};
+
+void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+{
+    uint32_t i;
+
+    for (i = 0; i < sizeof(sCommands) / sizeof(sCommands[0]); i++)
+    {
+        if (strcmp(argv[0], sCommands[i].mName) == 0)
+        {
+            sCommands[i].mCommand(aInstance, argc - 1, argc > 1 ? &argv[1] : NULL, aOutput, aOutputMaxLen);
+            break;
+        }
+    }
+
+    if (i == sizeof(sCommands) / sizeof(sCommands[0]))
+    {
+        snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", argv[0]);
+    }
+}
+
+void otPlatDiagModeSet(bool aMode)
+{
+    sDiagMode = aMode;
+
+    if (!sDiagMode)
+    {
+        otPlatRadioReceive(NULL, sChannel);
+        otPlatRadioSleep(NULL);
+    }
+    else
+    {
+        // Reinit
+        sTransmitMode = kDiagTransmitModeIdle;
+    }
+}
+
+bool otPlatDiagModeGet()
+{
+    return sDiagMode;
+}
+
+void otPlatDiagChannelSet(uint8_t aChannel)
+{
+    sChannel = aChannel;
+}
+
+void otPlatDiagTxPowerSet(int8_t aTxPower)
+{
+    sTxPower = aTxPower;
+}
+
+void otPlatDiagRadioReceived(otInstance *aInstance, otRadioFrame *aFrame, otError aError)
+{
+    (void)aInstance;
+
+    if (sListen && (aError == OT_ERROR_NONE))
+    {
+        if (aFrame->mLength == sizeof(struct PlatformDiagMessage))
+        {
+            struct PlatformDiagMessage *message = (struct PlatformDiagMessage *)aFrame->mPsdu;
+
+            if (strncmp(message->mMessageDescriptor, "DiagMessage", 11) == 0)
+            {
+                otPlatLog(OT_LOG_LEVEL_DEBG, OT_LOG_REGION_PLATFORM,
+                          "{\"Frame\":{"
+                          "\"LocalChannel\":%u ,"
+                          "\"RemoteChannel\":%u,"
+                          "\"CNT\":%" PRIu32 ","
+                          "\"LocalID\":%" PRId16 ","
+                          "\"RemoteID\":%" PRId16 ","
+                          "\"RSSI\":%d"
+                          "}}\r\n",
+                          aFrame->mChannel, message->mChannel, message->mCnt, sID, message->mID,
+                          aFrame->mInfo.mRxInfo.mRssi);
+            }
+        }
+    }
+}
+
+void otPlatDiagAlarmCallback(otInstance *aInstance)
+{
+    if (sTransmitMode == kDiagTransmitModePackets)
+    {
+        if ((sTxCount > 0) || (sTxCount == -1))
+        {
+            otRadioFrame *sTxPacket = otPlatRadioGetTransmitBuffer(aInstance);
+
+            sTxPacket->mLength  = sizeof(struct PlatformDiagMessage);
+            sTxPacket->mChannel = sChannel;
+
+            sDiagMessage.mChannel = sTxPacket->mChannel;
+            sDiagMessage.mID      = sID;
+
+            memcpy(sTxPacket->mPsdu, &sDiagMessage, sizeof(struct PlatformDiagMessage));
+            otPlatRadioTransmit(aInstance, sTxPacket);
+
+            sDiagMessage.mCnt++;
+
+            if (sTxCount != -1)
+            {
+                sTxCount--;
+            }
+
+            uint32_t now = otPlatAlarmMilliGetNow();
+            otPlatAlarmMilliStartAt(aInstance, now, sTxPeriod);
+        }
+        else
+        {
+            sTransmitMode = kDiagTransmitModeIdle;
+            otPlatAlarmMilliStop(aInstance);
+            otPlatLog(OT_LOG_LEVEL_DEBG, OT_LOG_REGION_PLATFORM, "Transmit done");
+        }
+    }
+}

--- a/examples/platforms/nrf52811/fem.c
+++ b/examples/platforms/nrf52811/fem.c
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the OpenThread FEM helper functions.
+ *
+ */
+
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
+#include <stdint.h>
+#include <string.h>
+
+#include "platform-fem.h"
+
+#define ENABLE_FEM 1
+#include <nrf_802154.h>
+
+void PlatformFemSetConfigParams(const PlatformFemConfigParams *aConfig)
+{
+    nrf_802154_fem_control_cfg_t cfg;
+
+    memset(&cfg, 0, sizeof(cfg));
+
+    cfg.pa_cfg.enable       = aConfig->mPaCfg.mEnable;
+    cfg.pa_cfg.active_high  = aConfig->mPaCfg.mActiveHigh;
+    cfg.pa_cfg.gpio_pin     = aConfig->mPaCfg.mGpioPin;
+    cfg.lna_cfg.enable      = aConfig->mLnaCfg.mEnable;
+    cfg.lna_cfg.active_high = aConfig->mLnaCfg.mActiveHigh;
+    cfg.lna_cfg.gpio_pin    = aConfig->mLnaCfg.mGpioPin;
+    cfg.ppi_ch_id_clr       = aConfig->mPpiChIdClr;
+    cfg.ppi_ch_id_set       = aConfig->mPpiChIdSet;
+    cfg.pa_gpiote_ch_id     = aConfig->mGpiotePaChId;
+    cfg.lna_gpiote_ch_id    = aConfig->mGpioteLnaChId;
+
+    nrf_802154_fem_control_cfg_set(&cfg);
+}

--- a/examples/platforms/nrf52811/flash.c
+++ b/examples/platforms/nrf52811/flash.c
@@ -1,0 +1,156 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <utils/code_utils.h>
+#include <utils/flash.h>
+#include <openthread/platform/alarm-milli.h>
+
+#include "platform-nrf5.h"
+
+#define FLASH_PAGE_ADDR_MASK 0xFFFFF000
+#define FLASH_PAGE_SIZE 4096
+
+static uint32_t sFlashDataStart;
+static uint32_t sFlashDataEnd;
+
+static inline uint32_t mapAddress(uint32_t aAddress)
+{
+    return aAddress + sFlashDataStart;
+}
+
+otError utilsFlashInit(void)
+{
+#if defined(__CC_ARM)
+    // Temporary solution for Keil compiler.
+    uint32_t const bootloaderAddr = NRF_UICR->NRFFW[0];
+    uint32_t const pageSize       = NRF_FICR->CODEPAGESIZE;
+    uint32_t const codeSize       = NRF_FICR->CODESIZE;
+
+    if (bootloaderAddr != 0xFFFFFFFF)
+    {
+        sFlashDataEnd = bootloaderAddr;
+    }
+    else
+    {
+        sFlashDataEnd = pageSize * codeSize;
+    }
+
+    sFlashDataStart = sFlashDataEnd - (pageSize * SETTINGS_CONFIG_PAGE_NUM);
+
+#elif defined(__GNUC__) || defined(__ICCARM__)
+    extern uint32_t __start_ot_flash_data;
+    extern uint32_t __stop_ot_flash_data;
+
+    sFlashDataStart = (uint32_t)&__start_ot_flash_data;
+    sFlashDataEnd   = (uint32_t)&__stop_ot_flash_data;
+
+#endif
+
+    // Just ensure that the start and end addresses are page-aligned.
+    assert((sFlashDataStart % FLASH_PAGE_SIZE) == 0);
+    assert((sFlashDataEnd % FLASH_PAGE_SIZE) == 0);
+
+    return OT_ERROR_NONE;
+}
+
+uint32_t utilsFlashGetSize(void)
+{
+    return sFlashDataEnd - sFlashDataStart;
+}
+
+otError utilsFlashErasePage(uint32_t aAddress)
+{
+    otError error = OT_ERROR_NONE;
+    otEXPECT_ACTION(aAddress < utilsFlashGetSize(), error = OT_ERROR_INVALID_ARGS);
+
+    error = nrf5FlashPageErase(mapAddress(aAddress & FLASH_PAGE_ADDR_MASK));
+
+exit:
+    return error;
+}
+
+otError utilsFlashStatusWait(uint32_t aTimeout)
+{
+    otError error = OT_ERROR_BUSY;
+
+    if (aTimeout == 0)
+    {
+        if (!nrf5FlashIsBusy())
+        {
+            error = OT_ERROR_NONE;
+        }
+    }
+    else
+    {
+        uint32_t startTime = otPlatAlarmMilliGetNow();
+
+        do
+        {
+            if (!nrf5FlashIsBusy())
+            {
+                error = OT_ERROR_NONE;
+                break;
+            }
+        } while (otPlatAlarmMilliGetNow() - startTime < aTimeout);
+    }
+
+    return error;
+}
+
+uint32_t utilsFlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
+{
+    uint32_t result = 0;
+    otEXPECT(aData);
+    otEXPECT(aAddress < utilsFlashGetSize());
+    otEXPECT(aSize);
+
+    result = nrf5FlashWrite(mapAddress(aAddress), aData, aSize);
+
+exit:
+    return result;
+}
+
+uint32_t utilsFlashRead(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
+{
+    uint32_t result = 0;
+    otEXPECT(aData);
+    otEXPECT(aAddress < utilsFlashGetSize());
+
+    memcpy(aData, (uint8_t *)mapAddress(aAddress), aSize);
+    result = aSize;
+
+exit:
+    return result;
+}

--- a/examples/platforms/nrf52811/flash_nosd.c
+++ b/examples/platforms/nrf52811/flash_nosd.c
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <openthread/config.h>
+#include <openthread-core-config.h>
+
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+
+#include <utils/code_utils.h>
+#include <utils/flash.h>
+
+#include "hal/nrf_nvmc.h"
+#include "platform-nrf5.h"
+
+otError nrf5FlashPageErase(uint32_t aAddress)
+{
+    nrf_nvmc_page_erase(aAddress);
+
+    return OT_ERROR_NONE;
+}
+
+bool nrf5FlashIsBusy(void)
+{
+    return NRF_NVMC->READY != NVMC_READY_READY_Ready;
+}
+
+uint32_t nrf5FlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize)
+{
+    nrf_nvmc_write_bytes(aAddress, aData, aSize);
+    return aSize;
+}

--- a/examples/platforms/nrf52811/logging.c
+++ b/examples/platforms/nrf52811/logging.c
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2018, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the OpenThread platform abstraction for logging.
+ *
+ */
+
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+#include <openthread/platform/alarm-milli.h>
+#include <openthread/platform/logging.h>
+
+#include <utils/logging_rtt.h>
+
+#if (OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED) || \
+    (OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_NCP_SPINEL)
+void nrf5LogInit(void)
+{
+    utilsLogRttInit();
+}
+
+void nrf5LogDeinit(void)
+{
+    utilsLogRttDeinit();
+}
+
+OT_TOOL_WEAK void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
+{
+    va_list ap;
+
+    va_start(ap, aFormat);
+
+    utilsLogRttOutput(aLogLevel, aLogRegion, aFormat, ap);
+
+    va_end(ap);
+}
+#endif

--- a/examples/platforms/nrf52811/misc.c
+++ b/examples/platforms/nrf52811/misc.c
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+#include <openthread/platform/misc.h>
+
+#include <nrf.h>
+
+#include "platform-nrf5.h"
+
+static uint32_t sResetReason;
+
+bool gPlatformPseudoResetWasRequested;
+
+void nrf5MiscInit(void)
+{
+    sResetReason         = NRF_POWER->RESETREAS;
+    NRF_POWER->RESETREAS = 0xFFFFFFFF;
+}
+
+void nrf5MiscDeinit(void)
+{
+    // Intentionally empty.
+}
+
+void otPlatReset(otInstance *aInstance)
+{
+    (void)aInstance;
+#if OPENTHREAD_PLATFORM_USE_PSEUDO_RESET
+    gPlatformPseudoResetWasRequested = true;
+    sResetReason                     = POWER_RESETREAS_SREQ_Msk;
+#else  // if OPENTHREAD_PLATFORM_USE_PSEUDO_RESET
+    NVIC_SystemReset();
+#endif // else OPENTHREAD_PLATFORM_USE_PSEUDO_RESET
+}
+
+otPlatResetReason otPlatGetResetReason(otInstance *aInstance)
+{
+    (void)aInstance;
+    otPlatResetReason reason;
+
+    if (sResetReason & POWER_RESETREAS_RESETPIN_Msk)
+    {
+        reason = OT_PLAT_RESET_REASON_EXTERNAL;
+    }
+    else if (sResetReason & POWER_RESETREAS_DOG_Msk)
+    {
+        reason = OT_PLAT_RESET_REASON_WATCHDOG;
+    }
+    else if (sResetReason & POWER_RESETREAS_SREQ_Msk)
+    {
+        reason = OT_PLAT_RESET_REASON_SOFTWARE;
+    }
+    else if (sResetReason & POWER_RESETREAS_LOCKUP_Msk)
+    {
+        reason = OT_PLAT_RESET_REASON_FAULT;
+    }
+    else if ((sResetReason & POWER_RESETREAS_OFF_Msk) || (sResetReason & POWER_RESETREAS_DIF_Msk))
+    {
+        reason = OT_PLAT_RESET_REASON_OTHER;
+    }
+    else
+    {
+        reason = OT_PLAT_RESET_REASON_POWER_ON;
+    }
+
+    return reason;
+}
+
+void otPlatWakeHost(void)
+{
+    // TODO: implement an operation to wake the host from sleep state.
+}

--- a/examples/platforms/nrf52811/nrf52811.ld
+++ b/examples/platforms/nrf52811/nrf52811.ld
@@ -1,0 +1,168 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   GCC linker script for nRF52811.
+ */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x30000
+  RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x6000
+}
+
+OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+
+ENTRY(Reset_Handler)
+
+FLASH_PAGE_SIZE       = 4096;
+FLASH_DATA_PAGES_USED = 2;
+
+SECTIONS
+{
+    .text :
+    {
+        KEEP(*(.isr_vector))
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.rodata*)
+
+        KEEP(*(.eh_frame*))
+    } > FLASH
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > FLASH
+    __exidx_end = .;
+
+    __etext = .;
+
+    .data : AT (__etext)
+    {
+        __data_start__ = .;
+        *(vtable)
+        *(.data*)
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        KEEP(*(.jcr*))
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+
+    } > RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+
+    .heap (COPY):
+    {
+        __HeapBase = .;
+        __end__ = .;
+        PROVIDE(end = .);
+        KEEP(*(.heap*))
+        __HeapLimit = .;
+    } > RAM
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy (COPY):
+    {
+        KEEP(*(.stack*))
+    } > RAM
+
+    __stop_ot_flash_data = (ORIGIN(FLASH) + LENGTH(FLASH));
+    __start_ot_flash_data = (__stop_ot_flash_data - (FLASH_PAGE_SIZE * FLASH_DATA_PAGES_USED));
+
+    /* Assure that code does not overlap flash data area.*/
+    ASSERT((__start_ot_flash_data >= __etext + SIZEOF(.data)), "Error: Code overlaps flash data area.")
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/examples/platforms/nrf52811/openthread-core-nrf52811-config.h
+++ b/examples/platforms/nrf52811/openthread-core-nrf52811-config.h
@@ -1,0 +1,215 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes nrf52811 compile-time configuration constants
+ *   for OpenThread.
+ */
+
+#ifndef OPENTHREAD_CORE_NRF52811_CONFIG_H_
+#define OPENTHREAD_CORE_NRF52811_CONFIG_H_
+
+/*
+ * The GNU Autoconf system defines a PACKAGE macro which is the name
+ * of the software package. This name collides with PACKAGE field in
+ * the nRF52 Factory Information Configuration Registers (FICR)
+ * structure.
+ */
+#undef PACKAGE
+
+/**
+ * @def OPENTHREAD_CONFIG_LOG_OUTPUT
+ *
+ * The nrf52811 platform provides an otPlatLog() function.
+ */
+#ifndef OPENTHREAD_CONFIG_LOG_OUTPUT /* allow command line override */
+#define OPENTHREAD_CONFIG_LOG_OUTPUT  OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_PLATFORM_INFO
+ *
+ * The platform-specific string to insert into the OpenThread version string.
+ *
+ */
+#define OPENTHREAD_CONFIG_PLATFORM_INFO                         "NRF52811"
+
+/**
+ * @def OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS
+ *
+ * The number of message buffers in the buffer pool.
+ *
+ */
+#define OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS                   64
+
+/**
+ * @def OPENTHREAD_CONFIG_MAX_STATECHANGE_HANDLERS
+ *
+ * The maximum number of state-changed callback handlers (set using `otSetStateChangedCallback()`).
+ *
+ */
+#define OPENTHREAD_CONFIG_MAX_STATECHANGE_HANDLERS              3
+
+/**
+ * @def OPENTHREAD_CONFIG_ADDRESS_CACHE_ENTRIES
+ *
+ * The number of EID-to-RLOC cache entries.
+ *
+ */
+#define OPENTHREAD_CONFIG_ADDRESS_CACHE_ENTRIES                 20
+
+/**
+ * @def OPENTHREAD_CONFIG_LOG_PREPREND_LEVEL
+ *
+ * Define to prepend the log level to all log messages
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_LOG_PREPEND_LEVEL
+#define OPENTHREAD_CONFIG_LOG_PREPEND_LEVEL                     0
+#endif
+
+ /**
+  * @def OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ACK_TIMEOUT
+  *
+  * Define to 1 if you want to enable software ACK timeout logic.
+  *
+  */
+#define OPENTHREAD_CONFIG_ENABLE_SOFTWARE_ACK_TIMEOUT           0
+
+ /**
+  * @def OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT
+  *
+  * Define to 1 if you want to enable software retransmission logic.
+  *
+  */
+#define OPENTHREAD_CONFIG_ENABLE_SOFTWARE_RETRANSMIT            1
+
+/**
+ * @def OPENTHREAD_CONFIG_ENABLE_SOFTWARE_CSMA_BACKOFF
+ *
+ * Define to 1 if you want to enable software CSMA-CA backoff logic.
+ *
+ */
+#define OPENTHREAD_CONFIG_ENABLE_SOFTWARE_CSMA_BACKOFF          0
+
+/**
+ * @def OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER
+ *
+ * Define to 1 if you want to support microsecond timer in platform.
+ *
+ */
+#define OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER            1
+
+/**
+ * @def SETTINGS_CONFIG_BASE_ADDRESS
+ *
+ * The base address of settings.
+ *
+ */
+#define SETTINGS_CONFIG_BASE_ADDRESS                            0
+
+/**
+ * @def SETTINGS_CONFIG_PAGE_SIZE
+ *
+ * The page size of settings.
+ *
+ */
+#define SETTINGS_CONFIG_PAGE_SIZE                               4096
+
+/**
+ * @def SETTINGS_CONFIG_PAGE_NUM
+ *
+ * The page number of settings.
+ *
+ */
+#define SETTINGS_CONFIG_PAGE_NUM                                2
+
+/**
+ * @def OPENTHREAD_CONFIG_HEAP_SIZE
+ *
+ * The size of heap buffer when DTLS is enabled.
+ *
+ */
+#define OPENTHREAD_CONFIG_HEAP_SIZE                             (4096 * sizeof(void *))
+
+/**
+ * @def OPENTHREAD_CONFIG_HEAP_SIZE_NO_DTLS
+ *
+ * The size of heap buffer when DTLS is disabled.
+ *
+ */
+#define OPENTHREAD_CONFIG_HEAP_SIZE_NO_DTLS                     2048
+
+/**
+ * @def OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+ *
+ * Define as 1 to enable the time synchronization service feature.
+ *
+ */
+#define OPENTHREAD_CONFIG_ENABLE_TIME_SYNC                      0
+
+/**
+ * @def OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
+ *
+ * Define as 1 to support IEEE 802.15.4-2015 Header IE (Information Element) generation and parsing, it must be set
+ * to support following features:
+ *    1. Time synchronization service feature (i.e., OPENTHREAD_CONFIG_ENABLE_TIME_SYNC is set).
+ *
+ * @note If it's enabled, plaforms must support interrupt context and concurrent access AES.
+ *
+ */
+#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+#define OPENTHREAD_CONFIG_HEADER_IE_SUPPORT                     1
+#endif
+
+/**
+ * @def NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT
+ *
+ * Define as 1 to enable AES usage in interrupt context and AES-256, by introducing a software AES under platform layer.
+ *
+ * @note This feature must be enabled to support AES-256 used by Commissioner and Joiner, and AES usage in interrupt context
+ *       used by Header IE related features.
+ *
+ */
+#if OPENTHREAD_ENABLE_COMMISSIONER || OPENTHREAD_ENABLE_JOINER || OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
+#define NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT                   1
+#else
+#define NRF_MBEDTLS_AES_ALT_INTERRUPT_CONTEXT                   0
+#endif
+
+/*
+ * Suppress the ARMCC warning on unreachable statement,
+ * e.g. break after assert(false) or ExitNow() macro.
+ */
+#if defined(__CC_ARM)
+    _Pragma("diag_suppress=111")
+    _Pragma("diag_suppress=128")
+#endif
+
+#endif  // OPENTHREAD_CORE_NRF52811_CONFIG_H_

--- a/examples/platforms/nrf52811/platform-config.h
+++ b/examples/platforms/nrf52811/platform-config.h
@@ -1,0 +1,463 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes the platform-specific configuration.
+ *
+ */
+
+#ifndef PLATFORM_CONFIG_H_
+#define PLATFORM_CONFIG_H_
+
+#include "nrf.h"
+#include "nrf_peripherals.h"
+#include "drivers/clock/nrf_drv_clock.h"
+#include "hal/nrf_radio.h"
+#include "hal/nrf_uart.h"
+
+#include "openthread-core-config.h"
+#include <openthread/config.h>
+
+/*******************************************************************************
+ * @section UART Driver Configuration.
+ ******************************************************************************/
+
+/**
+ * @def UART_INSTANCE
+ *
+ * UART Instance.
+ *
+ */
+#ifndef UART_INSTANCE
+#define UART_INSTANCE NRF_UART0
+#endif
+
+/**
+ * @def UART_PARITY
+ *
+ * UART Parity configuration.
+ *
+ * @brief Possible values:
+ *         \ref NRF_UART_PARITY_EXCLUDED - Parity bit is not present.
+ *         \ref NRF_UART_PARITY_INCLUDED - Parity bit is present.
+ *
+ */
+#ifndef UART_PARITY
+#define UART_PARITY NRF_UART_PARITY_EXCLUDED
+#endif
+
+/**
+ * @def UART_HWFC
+ *
+ * UART Hardware Flow Control.
+ *
+ * @brief Possible values:
+ *         \ref NRF_UART_HWFC_ENABLED - HW Flow control enabled.
+ *         \ref NRF_UART_HWFC_DISABLED - HW Flow control disabled.
+ *
+ */
+#ifndef UART_HWFC
+#define UART_HWFC NRF_UART_HWFC_ENABLED
+#endif
+
+/**
+ * @def UART_BAUDRATE
+ *
+ * UART Baudrate.
+ *
+ * @brief Possible values:
+ *         \ref NRF_UART_BAUDRATE_1200 - 1200 baud.
+ *         \ref NRF_UART_BAUDRATE_2400 - 2400 baud.
+ *         \ref NRF_UART_BAUDRATE_4800 - 4800 baud.
+ *         \ref NRF_UART_BAUDRATE_9600 - 9600 baud.
+ *         \ref NRF_UART_BAUDRATE_14400 - 14400 baud.
+ *         \ref NRF_UART_BAUDRATE_19200 - 19200 baud.
+ *         \ref NRF_UART_BAUDRATE_28800 - 28800 baud.
+ *         \ref NRF_UART_BAUDRATE_38400 - 38400 baud.
+ *         \ref NRF_UART_BAUDRATE_57600 - 57600 baud.
+ *         \ref NRF_UART_BAUDRATE_76800 - 76800 baud.
+ *         \ref NRF_UART_BAUDRATE_115200 - 115200 baud.
+ *         \ref NRF_UART_BAUDRATE_230400 - 230400 baud.
+ *         \ref NRF_UART_BAUDRATE_250000 - 250000 baud.
+ *         \ref NRF_UART_BAUDRATE_460800 - 460800 baud.
+ *         \ref NRF_UART_BAUDRATE_921600 - 921600 baud.
+ *         \ref NRF_UART_BAUDRATE_1000000 - 1000000 baud.
+ *
+ */
+#ifndef UART_BAUDRATE
+#define UART_BAUDRATE NRF_UART_BAUDRATE_115200
+#endif
+
+/**
+ *  @def UART_IRQN
+ *
+ * UART Interrupt number.
+ *
+ */
+#ifndef UART_IRQN
+#define UART_IRQN UARTE0_UART0_IRQn
+#endif
+
+/**
+ * @def UART_IRQ_PRIORITY
+ *
+ * UART Interrupt priority.
+ *
+ */
+#ifndef UART_IRQ_PRIORITY
+#define UART_IRQ_PRIORITY 6
+#endif
+
+/**
+ * @def UART_RX_BUFFER_SIZE
+ *
+ * UART Receive buffer size.
+ *
+ */
+#ifndef UART_RX_BUFFER_SIZE
+#define UART_RX_BUFFER_SIZE 256
+#endif
+
+/**
+ * @def UART_PIN_TX
+ *
+ * UART TX Pin.
+ *
+ */
+#ifndef UART_PIN_TX
+#define UART_PIN_TX 6
+#endif
+
+/**
+ * @def UART_PIN_RX
+ *
+ * UART RX Pin.
+ *
+ */
+#ifndef UART_PIN_RX
+#define UART_PIN_RX 8
+#endif
+
+/**
+ * @def UART_PIN_CTS
+ *
+ * UART CTS Pin.
+ *
+ */
+#ifndef UART_PIN_CTS
+#define UART_PIN_CTS 7
+#endif
+
+/**
+ * @def UART_PIN_RTS
+ *
+ * UART RTS Pin.
+ *
+ */
+#ifndef UART_PIN_RTS
+#define UART_PIN_RTS 5
+#endif
+
+/*******************************************************************************
+ * @section Alarm Driver Configuration.
+ ******************************************************************************/
+
+/**
+ * @def RTC_INSTANCE
+ *
+ * RTC Instance.
+ *
+ */
+#ifndef RTC_INSTANCE
+#define RTC_INSTANCE NRF_RTC0
+#endif
+
+/**
+ * @def RTC_IRQ_HANDLER
+ *
+ * RTC interrupt handler name
+ *
+ */
+#ifndef RTC_IRQ_HANDLER
+#define RTC_IRQ_HANDLER RTC0_IRQHandler
+#endif
+
+/**
+ * @def RTC_IRQN
+ *
+ * RTC Interrupt number.
+ *
+ */
+#ifndef RTC_IRQN
+#define RTC_IRQN RTC0_IRQn
+#endif
+
+/**
+ * @def RTC_IRQ_PRIORITY
+ *
+ * RTC Interrupt priority.
+ *
+ */
+#ifndef RTC_IRQ_PRIORITY
+#define RTC_IRQ_PRIORITY 6
+#endif
+
+/*******************************************************************************
+ * @section Random Number Generator Driver Configuration.
+ ******************************************************************************/
+
+/**
+ * @def RNG_BUFFER_SIZE
+ *
+ * True Random Number Generator buffer size.
+ *
+ */
+#ifndef RNG_BUFFER_SIZE
+#define RNG_BUFFER_SIZE 64
+#endif
+
+/**
+ * @def RNG_IRQ_PRIORITY
+ *
+ * RNG Interrupt priority.
+ *
+ */
+#ifndef RNG_IRQ_PRIORITY
+#define RNG_IRQ_PRIORITY 6
+#endif
+
+/*******************************************************************************
+ * @section SPI Slave configuration.
+ ******************************************************************************/
+
+/**
+ * @def SPIS Instance.
+ */
+#ifndef SPIS_INSTANCE
+#define SPIS_INSTANCE NRF_SPIS0
+#endif
+
+/**
+ * @def SPIS mode.
+ *
+ * @brief Possible values:
+ *         \ref NRF_SPIS_MODE_0 - SCK active high, sample on leading edge of clock.
+ *         \ref NRF_SPIS_MODE_1 - SCK active high, sample on trailing edge of clock.
+ *         \ref NRF_SPIS_MODE_2 - SCK active low, sample on leading edge of clock.
+ *         \ref NRF_SPIS_MODE_3 - SCK active low, sample on trailing edge of clock.
+ */
+#ifndef SPIS_MODE
+#define SPIS_MODE NRF_SPIS_MODE_0
+#endif
+
+/**
+ * @def SPIS bit orders.
+ *
+ * @brief Possible values:
+ *         \ref NRF_SPIS_BIT_ORDER_MSB_FIRST - Most significant bit shifted out first.
+ *         \ref NRF_SPIS_BIT_ORDER_LSB_FIRST - Least significant bit shifted out first.
+ */
+#ifndef SPIS_BIT_ORDER
+#define SPIS_BIT_ORDER NRF_SPIS_BIT_ORDER_MSB_FIRST
+#endif
+
+/**
+ * @def SPIS Interrupt number.
+ */
+#ifndef SPIS_IRQN
+#define SPIS_IRQN SPIM0_SPIS0_SPI0_IRQn
+#endif
+
+/**
+ * @def SPIS Interrupt priority.
+ */
+#ifndef SPIS_IRQ_PRIORITY
+#define SPIS_IRQ_PRIORITY 6
+#endif
+
+/**
+ * @def SPIS MOSI Pin.
+ */
+#ifndef SPIS_PIN_MOSI
+#define SPIS_PIN_MOSI 4
+#endif
+
+/**
+ * @def SPIS MISO Pin.
+ */
+#ifndef SPIS_PIN_MISO
+#define SPIS_PIN_MISO 28
+#endif
+
+/**
+ * @def SPIS SCK Pin.
+ */
+#ifndef SPIS_PIN_SCK
+#define SPIS_PIN_SCK 3
+#endif
+
+/**
+ * @def SPIS CSN Pin.
+ */
+#ifndef SPIS_PIN_CSN
+#define SPIS_PIN_CSN 29
+#endif
+
+/**
+ * @def SPIS Host IRQ Pin.
+ */
+#ifndef SPIS_PIN_HOST_IRQ
+#define SPIS_PIN_HOST_IRQ 30
+#endif
+
+/*******************************************************************************
+ * @section Platform FEM Configuration
+ ******************************************************************************/
+
+/**
+ * @def PLATFORM_FEM_ENABLE_DEFAULT_CONFIG
+ *
+ * Enable default front end module configuration.
+ *
+ */
+#ifndef PLATFORM_FEM_ENABLE_DEFAULT_CONFIG
+#define PLATFORM_FEM_ENABLE_DEFAULT_CONFIG 0
+#endif
+
+/*******************************************************************************
+ * @section Radio driver configuration.
+ ******************************************************************************/
+
+/**
+ * @def NRF_802154_PENDING_SHORT_ADDRESSES
+ *
+ * Number of slots containing short addresses of nodes for which pending data is stored.
+ *
+ */
+#ifndef NRF_802154_PENDING_SHORT_ADDRESSES
+#define NRF_802154_PENDING_SHORT_ADDRESSES OPENTHREAD_CONFIG_MAX_CHILDREN
+#endif
+
+/**
+ * @def NRF_802154_PENDING_EXTENDED_ADDRESSES
+ *
+ * Number of slots containing extended addresses of nodes for which pending data is stored.
+ *
+ */
+#ifndef NRF_802154_PENDING_EXTENDED_ADDRESSES
+#define NRF_802154_PENDING_EXTENDED_ADDRESSES OPENTHREAD_CONFIG_MAX_CHILDREN
+#endif
+
+/**
+ * @def NRF_802154_CSMA_CA_ENABLED
+ *
+ * If CSMA-CA procedure should be enabled by the driver. Disabling CSMA-CA procedure improves
+ * driver performance.
+ *
+ */
+#ifndef NRF_802154_CSMA_CA_ENABLED
+#define NRF_802154_CSMA_CA_ENABLED 1
+#endif
+
+/**
+ * @def NRF_802154_ACK_TIMEOUT_ENABLED
+ *
+ * If ACK timeout feature should be enabled in the driver.
+ *
+ */
+#ifndef NRF_802154_ACK_TIMEOUT_ENABLED
+#define NRF_802154_ACK_TIMEOUT_ENABLED 1
+#endif
+
+/**
+ * @def NRF_802154_SWI_EGU_INSTANCE
+ *
+ * SWI EGU instance used by the driver to synchronize PPIs and for requests and notifications if
+ * SWI is in use.
+ *
+ * @note This option is used by the core module regardless of the driver configuration.
+ *
+ */
+#ifndef NRF_802154_SWI_EGU_INSTANCE
+#define NRF_802154_SWI_EGU_INSTANCE NRF_EGU0
+#endif
+
+/**
+ * @def NRF_802154_SWI_IRQ_HANDLER
+ *
+ * SWI EGU IRQ handler used by the driver for requests and notifications if SWI is in use.
+ *
+ * @note This option is used when the driver uses SWI to process requests and notifications.
+ *
+ */
+#ifndef NRF_802154_SWI_IRQ_HANDLER
+#define NRF_802154_SWI_IRQ_HANDLER SWI0_EGU0_IRQHandler
+#endif
+
+/**
+ * @def NRF_802154_SWI_IRQN
+ *
+ * SWI EGU IRQ number used by the driver for requests and notifications if SWI is in use.
+ *
+ * @note This option is used when the driver uses SWI to process requests and notifications.
+ *
+ */
+#ifndef NRF_802154_SWI_IRQN
+#define NRF_802154_SWI_IRQN SWI0_EGU0_IRQn
+#endif
+
+/*******************************************************************************
+ * @section Temperature sensor driver configuration.
+ ******************************************************************************/
+
+/**
+ * @def TEMP_MEASUREMENT_INTERVAL
+ *
+ * Interval of consecutive temperature measurements [s].
+ *
+ */
+#ifndef TEMP_MEASUREMENT_INTERVAL
+#define TEMP_MEASUREMENT_INTERVAL 30
+#endif
+
+/**
+ * @def NRF_802154_TX_STARTED_NOTIFY_ENABLED
+ *
+ * If notification of started transmission should be enabled in the driver.
+ *
+ * @note This feature must be enabled to support Header IE related features.
+ *
+ */
+#ifndef NRF_802154_TX_STARTED_NOTIFY_ENABLED
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
+#define NRF_802154_TX_STARTED_NOTIFY_ENABLED 1
+#endif
+#endif
+
+#endif // PLATFORM_CONFIG_H_

--- a/examples/platforms/nrf52811/platform-fem.h
+++ b/examples/platforms/nrf52811/platform-fem.h
@@ -1,0 +1,111 @@
+/*
+ *  Copyright (c) 2017, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes front end module platform-specific functions.
+ *
+ */
+
+#ifndef PLATFORM_FEM_H_
+#define PLATFORM_FEM_H_
+
+#include <stdint.h>
+
+// clang-format off
+
+#define PLATFORM_FEM_DEFAULT_PA_PIN                      26  /**< Default Power Amplifier pin. */
+#define PLATFORM_FEM_DEFAULT_LNA_PIN                     27  /**< Default Low Noise Amplifier pin. */
+#define PLATFORM_FEM_DEFAULT_SET_PPI_CHANNEL             15  /**< Default PPI channel for pin setting. */
+#define PLATFORM_FEM_DEFAULT_CLR_PPI_CHANNEL             16  /**< Default PPI channel for pin clearing. */
+#define PLATFORM_FEM_DEFAULT_TIMER_MATCH_PPI_GROUP       4   /**< Default PPI channel group used to disable timer match PPI. */
+#define PLATFORM_FEM_DEFAULT_RADIO_DISABLED_PPI_GROUP    5   /**< Default PPI channel group used to disable radio disabled PPI. */
+#define PLATFORM_FEM_DEFAULT_LNA_GPIOTE_CHANNEL          6   /**< Default LNA GPIOTE channel for FEM control. */
+#define PLATFORM_FEM_DEFAULT_PA_GPIOTE_CHANNEL           7   /**< Default PA GPIOTE channel for FEM control. */
+
+// clang-format on
+
+#define PLATFORM_FEM_DEFAULT_CONFIG                                \
+    ((PlatformFemConfigParams){                                    \
+        .mPaCfg =                                                  \
+            {                                                      \
+                .mEnable     = 1,                                  \
+                .mActiveHigh = 1,                                  \
+                .mGpioPin    = PLATFORM_FEM_DEFAULT_PA_PIN,        \
+            },                                                     \
+        .mLnaCfg =                                                 \
+            {                                                      \
+                .mEnable     = 1,                                  \
+                .mActiveHigh = 1,                                  \
+                .mGpioPin    = PLATFORM_FEM_DEFAULT_LNA_PIN,       \
+            },                                                     \
+        .mPpiChIdClr    = PLATFORM_FEM_DEFAULT_CLR_PPI_CHANNEL,    \
+        .mPpiChIdSet    = PLATFORM_FEM_DEFAULT_SET_PPI_CHANNEL,    \
+        .mGpiotePaChId  = PLATFORM_FEM_DEFAULT_PA_GPIOTE_CHANNEL,  \
+        .mGpioteLnaChId = PLATFORM_FEM_DEFAULT_LNA_GPIOTE_CHANNEL, \
+    })
+
+/**
+ * @brief Configuration parameters for the PA and LNA.
+ */
+typedef struct
+{
+    uint8_t mEnable : 1;     /**< Enable toggling for this amplifier */
+    uint8_t mActiveHigh : 1; /**< Set the pin to be active high */
+    uint8_t mGpioPin : 6;    /**< The GPIO pin to toggle for this amplifier */
+} PlatformFemConfigPaLna;
+
+/**
+ * @brief PA & LNA GPIO toggle configuration
+ *
+ * This option configures the nRF 802.15.4 radio driver to toggle pins when the radio
+ * is active for use with a power amplifier and/or a low noise amplifier.
+ *
+ * Toggling the pins is achieved by using two PPI channels and a GPIOTE channel. The hardware channel IDs are provided
+ * by the application and should be regarded as reserved as long as any PA/LNA toggling is enabled.
+ *
+ * @note Changing this configuration while the radio is in use may have undefined
+ *       consequences and must be avoided by the application.
+ */
+typedef struct
+{
+    PlatformFemConfigPaLna mPaCfg;         /**< Power Amplifier configuration */
+    PlatformFemConfigPaLna mLnaCfg;        /**< Low Noise Amplifier configuration */
+    uint8_t                mPpiChIdSet;    /**< PPI channel used for radio pin setting */
+    uint8_t                mPpiChIdClr;    /**< PPI channel used for radio pin clearing */
+    uint8_t                mGpiotePaChId;  /**< GPIOTE channel used for radio PA pin toggling */
+    uint8_t                mGpioteLnaChId; /**< GPIOTE channel used for radio LNA pin toggling */
+} PlatformFemConfigParams;
+
+/**
+ * Function used to set parameters of FEM.
+ *
+ */
+void PlatformFemSetConfigParams(const PlatformFemConfigParams *aConfig);
+
+#endif // PLATFORM_FEM_H_

--- a/examples/platforms/nrf52811/platform-nrf5.h
+++ b/examples/platforms/nrf52811/platform-nrf5.h
@@ -1,0 +1,201 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes the platform-specific initializers.
+ *
+ */
+
+#ifndef PLATFORM_NRF5_H_
+#define PLATFORM_NRF5_H_
+
+#include <stdint.h>
+
+#include <openthread/instance.h>
+
+#include "platform-config.h"
+
+/**
+ * Initialization of UART driver.
+ *
+ */
+void nrf5UartInit(void);
+
+/**
+ * Deinitialization of UART driver.
+ *
+ */
+void nrf5UartDeinit(void);
+
+/**
+ * This function performs UART driver processing.
+ *
+ */
+void nrf5UartProcess(void);
+
+/**
+ * Initialization of Alarm driver.
+ *
+ */
+void nrf5AlarmInit(void);
+
+/**
+ * Deinitialization of Alarm driver.
+ *
+ */
+void nrf5AlarmDeinit(void);
+
+/**
+ * Function for processing Alarm.
+ *
+ */
+void nrf5AlarmProcess(otInstance *aInstance);
+
+/**
+ * Function for geting current time in mircosecond.
+ *
+ */
+uint64_t nrf5AlarmGetCurrentTime(void);
+
+/**
+ * Initialization of Random Number Generator.
+ *
+ */
+void nrf5RandomInit(void);
+
+/**
+ * Deinitialization of Random Number Generator.
+ *
+ */
+void nrf5RandomDeinit(void);
+
+/**
+ * Initialization of Logger driver.
+ *
+ */
+void nrf5LogInit(void);
+
+/**
+ * Deinitialization of Logger driver.
+ *
+ */
+void nrf5LogDeinit(void);
+
+/**
+ * Initialization of SPI Slave driver.
+ *
+ */
+void nrf5SpiSlaveInit(void);
+
+/**
+ * Deinitialization of SPI Slave driver.
+ *
+ */
+void nrf5SpiSlaveDeinit(void);
+
+/**
+ * Function for processing SPI Slave driver.
+ */
+void nrf5SpiSlaveProcess(void);
+
+/**
+ * Initialization of Misc module.
+ *
+ */
+void nrf5MiscInit(void);
+
+/**
+ * Deinitialization of Misc module.
+ *
+ */
+void nrf5MiscDeinit(void);
+
+/**
+ * Initialization of Radio driver.
+ *
+ */
+void nrf5RadioInit(void);
+
+/**
+ * Deinitialization of Radio driver.
+ *
+ */
+void nrf5RadioDeinit(void);
+
+/**
+ * Function for processing Radio.
+ *
+ */
+void nrf5RadioProcess(otInstance *aInstance);
+
+/**
+ * Function for erasing page in flash.
+ *
+ */
+otError nrf5FlashPageErase(uint32_t aAddress);
+
+/**
+ * Function for checking state of flash driver.
+ *
+ */
+bool nrf5FlashIsBusy(void);
+
+/**
+ * Function for writing data into flash.
+ *
+ */
+uint32_t nrf5FlashWrite(uint32_t aAddress, uint8_t *aData, uint32_t aSize);
+
+/**
+ * Initialization of temperature controller.
+ *
+ */
+void nrf5TempInit(void);
+
+/**
+ * Deinitialization of temperature controller.
+ *
+ */
+void nrf5TempDeinit(void);
+
+/**
+ * Function for processing temperature controller.
+ *
+ */
+void nrf5TempProcess(void);
+
+/**
+ * Function for measuring internal temperature.
+ *
+ * @return Temperature value measured.
+ *
+ */
+int32_t nrf5TempGet(void);
+
+#endif // PLATFORM_NRF5_H_

--- a/examples/platforms/nrf52811/radio.c
+++ b/examples/platforms/nrf52811/radio.c
@@ -1,0 +1,834 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the OpenThread platform abstraction for radio communication.
+ *
+ */
+
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <common/code_utils.hpp>
+#include <platform-config.h>
+#include <openthread/platform/alarm-micro.h>
+#include <openthread/platform/diag.h>
+#include <openthread/platform/logging.h>
+#include <openthread/platform/radio.h>
+#include <openthread/platform/time.h>
+
+#include "openthread-system.h"
+#include "platform-nrf5.h"
+
+#include <nrf.h>
+#include <nrf_802154.h>
+
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
+// clang-format off
+
+#define SHORT_ADDRESS_SIZE    2
+#define EXTENDED_ADDRESS_SIZE 8
+#define PENDING_BIT           0x10
+#define US_PER_MS             1000ULL
+
+// clang-format on
+
+enum
+{
+    NRF52811_RECEIVE_SENSITIVITY = -100, // dBm
+};
+
+static bool sDisabled;
+
+static otError      sReceiveError = OT_ERROR_NONE;
+static otRadioFrame sReceivedFrames[NRF_802154_RX_BUFFERS];
+static otRadioFrame sTransmitFrame;
+static uint8_t      sTransmitPsdu[OT_RADIO_FRAME_MAX_SIZE + 1];
+
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
+static otRadioIeInfo sTransmitIeInfo;
+static otRadioIeInfo sReceivedIeInfos[NRF_802154_RX_BUFFERS];
+#endif
+static otInstance *sInstance = NULL;
+
+static otRadioFrame sAckFrame;
+
+static int8_t sDefaultTxPower;
+
+static uint32_t sEnergyDetectionTime;
+static uint8_t  sEnergyDetectionChannel;
+static int8_t   sEnergyDetected;
+
+typedef enum
+{
+    kPendingEventSleep,                // Requested to enter Sleep state.
+    kPendingEventFrameTransmitted,     // Transmitted frame and received ACK (if requested).
+    kPendingEventChannelAccessFailure, // Failed to transmit frame (channel busy).
+    kPendingEventInvalidOrNoAck,       // Failed to transmit frame (received invalid or no ACK).
+    kPendingEventReceiveFailed,        // Failed to receive a valid frame.
+    kPendingEventEnergyDetectionStart, // Requested to start Energy Detection procedure.
+    kPendingEventEnergyDetected,       // Energy Detection finished.
+} RadioPendingEvents;
+
+static uint32_t sPendingEvents;
+
+static void dataInit(void)
+{
+    sDisabled = true;
+
+    sTransmitFrame.mPsdu = sTransmitPsdu + 1;
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
+    sTransmitFrame.mIeInfo = &sTransmitIeInfo;
+#endif
+
+    sReceiveError = OT_ERROR_NONE;
+
+    for (uint32_t i = 0; i < NRF_802154_RX_BUFFERS; i++)
+    {
+        sReceivedFrames[i].mPsdu = NULL;
+    }
+
+    memset(&sAckFrame, 0, sizeof(sAckFrame));
+}
+
+static void convertShortAddress(uint8_t *aTo, uint16_t aFrom)
+{
+    aTo[0] = (uint8_t)aFrom;
+    aTo[1] = (uint8_t)(aFrom >> 8);
+}
+
+static inline bool isPendingEventSet(RadioPendingEvents aEvent)
+{
+    return sPendingEvents & (1UL << aEvent);
+}
+
+static void setPendingEvent(RadioPendingEvents aEvent)
+{
+    volatile uint32_t pendingEvents;
+    uint32_t          bitToSet = 1UL << aEvent;
+
+    do
+    {
+        pendingEvents = __LDREXW((unsigned long volatile *)&sPendingEvents);
+        pendingEvents |= bitToSet;
+    } while (__STREXW(pendingEvents, (unsigned long volatile *)&sPendingEvents));
+
+    otSysEventSignalPending();
+}
+
+static void resetPendingEvent(RadioPendingEvents aEvent)
+{
+    volatile uint32_t pendingEvents;
+    uint32_t          bitsToRemain = ~(1UL << aEvent);
+
+    do
+    {
+        pendingEvents = __LDREXW((unsigned long volatile *)&sPendingEvents);
+        pendingEvents &= bitsToRemain;
+    } while (__STREXW(pendingEvents, (unsigned long volatile *)&sPendingEvents));
+}
+
+static inline void clearPendingEvents(void)
+{
+    // Clear pending events that could cause race in the MAC layer.
+    volatile uint32_t pendingEvents;
+    uint32_t          bitsToRemain = ~(0UL);
+
+    bitsToRemain &= ~(1UL << kPendingEventSleep);
+
+    do
+    {
+        pendingEvents = __LDREXW((unsigned long volatile *)&sPendingEvents);
+        pendingEvents &= bitsToRemain;
+    } while (__STREXW(pendingEvents, (unsigned long volatile *)&sPendingEvents));
+}
+
+#if !OPENTHREAD_CONFIG_ENABLE_PLATFORM_EUI64_CUSTOM_SOURCE
+void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeeeEui64)
+{
+    (void)aInstance;
+
+    uint64_t factoryAddress = (uint64_t)NRF_FICR->DEVICEID[0] << 32;
+    factoryAddress |= NRF_FICR->DEVICEID[1];
+
+    memcpy(aIeeeEui64, &factoryAddress, sizeof(factoryAddress));
+}
+#endif // OPENTHREAD_CONFIG_ENABLE_PLATFORM_EUI64_CUSTOM_SOURCE
+
+void otPlatRadioSetPanId(otInstance *aInstance, uint16_t aPanId)
+{
+    (void)aInstance;
+
+    uint8_t address[SHORT_ADDRESS_SIZE];
+    convertShortAddress(address, aPanId);
+
+    nrf_802154_pan_id_set(address);
+}
+
+void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aExtAddress)
+{
+    (void)aInstance;
+
+    nrf_802154_extended_address_set(aExtAddress->m8);
+}
+
+void otPlatRadioSetShortAddress(otInstance *aInstance, uint16_t aShortAddress)
+{
+    (void)aInstance;
+
+    uint8_t address[SHORT_ADDRESS_SIZE];
+    convertShortAddress(address, aShortAddress);
+
+    nrf_802154_short_address_set(address);
+}
+
+void nrf5RadioInit(void)
+{
+    dataInit();
+    nrf_802154_init();
+}
+
+void nrf5RadioDeinit(void)
+{
+    nrf_802154_sleep();
+    nrf_802154_deinit();
+    sPendingEvents = 0;
+}
+
+otRadioState otPlatRadioGetState(otInstance *aInstance)
+{
+    (void)aInstance;
+
+    if (sDisabled)
+    {
+        return OT_RADIO_STATE_DISABLED;
+    }
+
+    switch (nrf_802154_state_get())
+    {
+    case NRF_802154_STATE_SLEEP:
+        return OT_RADIO_STATE_SLEEP;
+
+    case NRF_802154_STATE_RECEIVE:
+    case NRF_802154_STATE_ENERGY_DETECTION:
+        return OT_RADIO_STATE_RECEIVE;
+
+    case NRF_802154_STATE_TRANSMIT:
+        return OT_RADIO_STATE_TRANSMIT;
+
+    default:
+        assert(false); // Make sure driver returned valid state.
+    }
+
+    return OT_RADIO_STATE_RECEIVE; // It is the default state. Return it in case of unknown.
+}
+
+otError otPlatRadioEnable(otInstance *aInstance)
+{
+    sInstance = aInstance;
+
+    otError error;
+
+    if (sDisabled)
+    {
+        sDisabled = false;
+        error     = OT_ERROR_NONE;
+    }
+    else
+    {
+        error = OT_ERROR_INVALID_STATE;
+    }
+
+    return error;
+}
+
+otError otPlatRadioDisable(otInstance *aInstance)
+{
+    (void)aInstance;
+
+    otError error;
+
+    if (!sDisabled)
+    {
+        sDisabled = true;
+        error     = OT_ERROR_NONE;
+    }
+    else
+    {
+        error = OT_ERROR_INVALID_STATE;
+    }
+
+    return error;
+}
+
+bool otPlatRadioIsEnabled(otInstance *aInstance)
+{
+    (void)aInstance;
+
+    return !sDisabled;
+}
+
+otError otPlatRadioSleep(otInstance *aInstance)
+{
+    (void)aInstance;
+
+    if (nrf_802154_sleep())
+    {
+        clearPendingEvents();
+    }
+    else
+    {
+        clearPendingEvents();
+        setPendingEvent(kPendingEventSleep);
+    }
+
+    return OT_ERROR_NONE;
+}
+
+otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
+{
+    (void)aInstance;
+
+    bool result;
+
+    nrf_802154_channel_set(aChannel);
+    nrf_802154_tx_power_set(sDefaultTxPower);
+    result = nrf_802154_receive();
+    clearPendingEvents();
+
+    return result ? OT_ERROR_NONE : OT_ERROR_INVALID_STATE;
+}
+
+otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
+{
+    otError result = OT_ERROR_NONE;
+
+    aFrame->mPsdu[-1] = aFrame->mLength;
+
+    nrf_802154_channel_set(aFrame->mChannel);
+
+    if (aFrame->mInfo.mTxInfo.mCsmaCaEnabled)
+    {
+        nrf_802154_transmit_csma_ca_raw(&aFrame->mPsdu[-1]);
+    }
+    else
+    {
+        if (!nrf_802154_transmit_raw(&aFrame->mPsdu[-1], false))
+        {
+            result = OT_ERROR_FAILED;
+        }
+    }
+
+    clearPendingEvents();
+
+    if (result == OT_ERROR_NONE)
+    {
+        otPlatRadioTxStarted(aInstance, aFrame);
+    }
+
+    return result;
+}
+
+otRadioFrame *otPlatRadioGetTransmitBuffer(otInstance *aInstance)
+{
+    (void)aInstance;
+
+    return &sTransmitFrame;
+}
+
+int8_t otPlatRadioGetRssi(otInstance *aInstance)
+{
+    (void)aInstance;
+
+    return nrf_802154_rssi_last_get();
+}
+
+otRadioCaps otPlatRadioGetCaps(otInstance *aInstance)
+{
+    (void)aInstance;
+
+    return (otRadioCaps)(OT_RADIO_CAPS_ENERGY_SCAN | OT_RADIO_CAPS_ACK_TIMEOUT | OT_RADIO_CAPS_CSMA_BACKOFF);
+}
+
+bool otPlatRadioGetPromiscuous(otInstance *aInstance)
+{
+    (void)aInstance;
+
+    return nrf_802154_promiscuous_get();
+}
+
+void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable)
+{
+    (void)aInstance;
+
+    nrf_802154_promiscuous_set(aEnable);
+}
+
+void otPlatRadioEnableSrcMatch(otInstance *aInstance, bool aEnable)
+{
+    (void)aInstance;
+
+    nrf_802154_auto_pending_bit_set(aEnable);
+}
+
+otError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
+{
+    (void)aInstance;
+
+    otError error;
+
+    uint8_t shortAddress[SHORT_ADDRESS_SIZE];
+    convertShortAddress(shortAddress, aShortAddress);
+
+    if (nrf_802154_pending_bit_for_addr_set(shortAddress, false))
+    {
+        error = OT_ERROR_NONE;
+    }
+    else
+    {
+        error = OT_ERROR_NO_BUFS;
+    }
+
+    return error;
+}
+
+otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const otExtAddress *aExtAddress)
+{
+    (void)aInstance;
+
+    otError error;
+
+    if (nrf_802154_pending_bit_for_addr_set(aExtAddress->m8, true))
+    {
+        error = OT_ERROR_NONE;
+    }
+    else
+    {
+        error = OT_ERROR_NO_BUFS;
+    }
+
+    return error;
+}
+
+otError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, const uint16_t aShortAddress)
+{
+    (void)aInstance;
+
+    otError error;
+
+    uint8_t shortAddress[SHORT_ADDRESS_SIZE];
+    convertShortAddress(shortAddress, aShortAddress);
+
+    if (nrf_802154_pending_bit_for_addr_clear(shortAddress, false))
+    {
+        error = OT_ERROR_NONE;
+    }
+    else
+    {
+        error = OT_ERROR_NO_ADDRESS;
+    }
+
+    return error;
+}
+
+otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const otExtAddress *aExtAddress)
+{
+    (void)aInstance;
+
+    otError error;
+
+    if (nrf_802154_pending_bit_for_addr_clear(aExtAddress->m8, true))
+    {
+        error = OT_ERROR_NONE;
+    }
+    else
+    {
+        error = OT_ERROR_NO_ADDRESS;
+    }
+
+    return error;
+}
+
+void otPlatRadioClearSrcMatchShortEntries(otInstance *aInstance)
+{
+    (void)aInstance;
+
+    nrf_802154_pending_bit_for_addr_reset(false);
+}
+
+void otPlatRadioClearSrcMatchExtEntries(otInstance *aInstance)
+{
+    (void)aInstance;
+
+    nrf_802154_pending_bit_for_addr_reset(true);
+}
+
+otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration)
+{
+    (void)aInstance;
+
+    sEnergyDetectionTime    = (uint32_t)aScanDuration * 1000UL;
+    sEnergyDetectionChannel = aScanChannel;
+
+    clearPendingEvents();
+
+    nrf_802154_channel_set(aScanChannel);
+
+    if (nrf_802154_energy_detection(sEnergyDetectionTime))
+    {
+        resetPendingEvent(kPendingEventEnergyDetectionStart);
+    }
+    else
+    {
+        setPendingEvent(kPendingEventEnergyDetectionStart);
+    }
+
+    return OT_ERROR_NONE;
+}
+
+otError otPlatRadioGetTransmitPower(otInstance *aInstance, int8_t *aPower)
+{
+    otError error = OT_ERROR_NONE;
+    (void)aInstance;
+
+    if (aPower == NULL)
+    {
+        error = OT_ERROR_INVALID_ARGS;
+    }
+    else
+    {
+        *aPower = sDefaultTxPower;
+    }
+
+    return error;
+}
+
+otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
+{
+    (void)aInstance;
+
+    sDefaultTxPower = aPower;
+    nrf_802154_tx_power_set(aPower);
+
+    return OT_ERROR_NONE;
+}
+
+void nrf5RadioProcess(otInstance *aInstance)
+{
+    for (uint32_t i = 0; i < NRF_802154_RX_BUFFERS; i++)
+    {
+        if (sReceivedFrames[i].mPsdu != NULL)
+        {
+#if OPENTHREAD_ENABLE_DIAG
+
+            if (otPlatDiagModeGet())
+            {
+                otPlatDiagRadioReceiveDone(aInstance, &sReceivedFrames[i], OT_ERROR_NONE);
+            }
+            else
+#endif
+            {
+                otPlatRadioReceiveDone(aInstance, &sReceivedFrames[i], OT_ERROR_NONE);
+            }
+
+            uint8_t *bufferAddress   = &sReceivedFrames[i].mPsdu[-1];
+            sReceivedFrames[i].mPsdu = NULL;
+            nrf_802154_buffer_free_raw(bufferAddress);
+        }
+    }
+
+    if (isPendingEventSet(kPendingEventFrameTransmitted))
+    {
+        resetPendingEvent(kPendingEventFrameTransmitted);
+
+#if OPENTHREAD_ENABLE_DIAG
+
+        if (otPlatDiagModeGet())
+        {
+            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, OT_ERROR_NONE);
+        }
+        else
+#endif
+        {
+            otRadioFrame *ackPtr = (sAckFrame.mPsdu == NULL) ? NULL : &sAckFrame;
+            otPlatRadioTxDone(aInstance, &sTransmitFrame, ackPtr, OT_ERROR_NONE);
+        }
+
+        if (sAckFrame.mPsdu != NULL)
+        {
+            nrf_802154_buffer_free_raw(sAckFrame.mPsdu - 1);
+            sAckFrame.mPsdu = NULL;
+        }
+    }
+
+    if (isPendingEventSet(kPendingEventChannelAccessFailure))
+    {
+        resetPendingEvent(kPendingEventChannelAccessFailure);
+
+#if OPENTHREAD_ENABLE_DIAG
+
+        if (otPlatDiagModeGet())
+        {
+            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, OT_ERROR_CHANNEL_ACCESS_FAILURE);
+        }
+        else
+#endif
+        {
+            otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_CHANNEL_ACCESS_FAILURE);
+        }
+    }
+
+    if (isPendingEventSet(kPendingEventInvalidOrNoAck))
+    {
+        resetPendingEvent(kPendingEventInvalidOrNoAck);
+
+#if OPENTHREAD_ENABLE_DIAG
+
+        if (otPlatDiagModeGet())
+        {
+            otPlatDiagRadioTransmitDone(aInstance, &sTransmitFrame, OT_ERROR_NO_ACK);
+        }
+        else
+#endif
+        {
+            otPlatRadioTxDone(aInstance, &sTransmitFrame, NULL, OT_ERROR_NO_ACK);
+        }
+    }
+
+    if (isPendingEventSet(kPendingEventReceiveFailed))
+    {
+        resetPendingEvent(kPendingEventReceiveFailed);
+
+#if OPENTHREAD_ENABLE_DIAG
+
+        if (otPlatDiagModeGet())
+        {
+            otPlatDiagRadioReceiveDone(aInstance, NULL, sReceiveError);
+        }
+        else
+#endif
+        {
+            otPlatRadioReceiveDone(aInstance, NULL, sReceiveError);
+        }
+    }
+
+    if (isPendingEventSet(kPendingEventEnergyDetected))
+    {
+        resetPendingEvent(kPendingEventEnergyDetected);
+
+        otPlatRadioEnergyScanDone(aInstance, sEnergyDetected);
+    }
+
+    if (isPendingEventSet(kPendingEventSleep))
+    {
+        if (nrf_802154_sleep())
+        {
+            resetPendingEvent(kPendingEventSleep);
+        }
+    }
+
+    if (isPendingEventSet(kPendingEventEnergyDetectionStart))
+    {
+        nrf_802154_channel_set(sEnergyDetectionChannel);
+
+        if (nrf_802154_energy_detection(sEnergyDetectionTime))
+        {
+            resetPendingEvent(kPendingEventEnergyDetectionStart);
+        }
+    }
+}
+
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
+void nrf_802154_received_timestamp_raw(uint8_t *p_data, int8_t power, uint8_t lqi, uint32_t time)
+#else
+void nrf_802154_received_raw(uint8_t *p_data, int8_t power, uint8_t lqi)
+#endif
+{
+    otRadioFrame *receivedFrame = NULL;
+
+    for (uint32_t i = 0; i < NRF_802154_RX_BUFFERS; i++)
+    {
+        if (sReceivedFrames[i].mPsdu == NULL)
+        {
+            receivedFrame = &sReceivedFrames[i];
+
+            memset(receivedFrame, 0, sizeof(*receivedFrame));
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
+            receivedFrame->mIeInfo = &sReceivedIeInfos[i];
+#endif
+            break;
+        }
+    }
+
+    assert(receivedFrame != NULL);
+
+    receivedFrame->mPsdu               = &p_data[1];
+    receivedFrame->mLength             = p_data[0];
+    receivedFrame->mInfo.mRxInfo.mRssi = power;
+    receivedFrame->mInfo.mRxInfo.mLqi  = lqi;
+    receivedFrame->mChannel            = nrf_802154_channel_get();
+    if (otPlatRadioGetPromiscuous(sInstance))
+    {
+        uint64_t timestamp                 = nrf5AlarmGetCurrentTime();
+        receivedFrame->mInfo.mRxInfo.mMsec = timestamp / US_PER_MS;
+        receivedFrame->mInfo.mRxInfo.mUsec = timestamp - receivedFrame->mInfo.mRxInfo.mMsec * US_PER_MS;
+    }
+#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+    // Get the timestamp when the SFD was received.
+    uint32_t offset =
+        (int32_t)otPlatAlarmMicroGetNow() - (int32_t)nrf_802154_first_symbol_timestamp_get(time, p_data[0]);
+    receivedFrame->mIeInfo->mTimestamp = otPlatTimeGet() - offset;
+#endif
+
+    otSysEventSignalPending();
+}
+
+void nrf_802154_receive_failed(nrf_802154_rx_error_t error)
+{
+    switch (error)
+    {
+    case NRF_802154_RX_ERROR_INVALID_FRAME:
+        sReceiveError = OT_ERROR_NO_FRAME_RECEIVED;
+        break;
+
+    case NRF_802154_RX_ERROR_INVALID_FCS:
+        sReceiveError = OT_ERROR_FCS;
+        break;
+
+    case NRF_802154_RX_ERROR_INVALID_DEST_ADDR:
+        sReceiveError = OT_ERROR_DESTINATION_ADDRESS_FILTERED;
+        break;
+
+    case NRF_802154_RX_ERROR_RUNTIME:
+    case NRF_802154_RX_ERROR_TIMESLOT_ENDED:
+    case NRF_802154_RX_ERROR_ABORTED:
+        sReceiveError = OT_ERROR_FAILED;
+        break;
+
+    default:
+        assert(false);
+    }
+
+    setPendingEvent(kPendingEventReceiveFailed);
+}
+
+void nrf_802154_transmitted_raw(const uint8_t *aFrame, uint8_t *aAckPsdu, int8_t aPower, uint8_t aLqi)
+{
+    assert(aFrame == sTransmitPsdu);
+
+    if (aAckPsdu == NULL)
+    {
+        sAckFrame.mPsdu = NULL;
+    }
+    else
+    {
+        sAckFrame.mPsdu               = &aAckPsdu[1];
+        sAckFrame.mLength             = aAckPsdu[0];
+        sAckFrame.mInfo.mRxInfo.mRssi = aPower;
+        sAckFrame.mInfo.mRxInfo.mLqi  = aLqi;
+        sAckFrame.mChannel            = nrf_802154_channel_get();
+    }
+
+    setPendingEvent(kPendingEventFrameTransmitted);
+}
+
+void nrf_802154_transmit_failed(const uint8_t *aFrame, nrf_802154_tx_error_t error)
+{
+    assert(aFrame == sTransmitPsdu);
+
+    switch (error)
+    {
+    case NRF_802154_TX_ERROR_BUSY_CHANNEL:
+    case NRF_802154_TX_ERROR_TIMESLOT_ENDED:
+        setPendingEvent(kPendingEventChannelAccessFailure);
+        break;
+
+    case NRF_802154_TX_ERROR_INVALID_ACK:
+    case NRF_802154_TX_ERROR_NO_ACK:
+    case NRF_802154_TX_ERROR_NO_MEM:
+        setPendingEvent(kPendingEventInvalidOrNoAck);
+        break;
+
+    default:
+        assert(false);
+    }
+}
+
+void nrf_802154_energy_detected(uint8_t result)
+{
+    sEnergyDetected = nrf_802154_dbm_from_energy_level_calculate(result);
+
+    setPendingEvent(kPendingEventEnergyDetected);
+}
+
+int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)
+{
+    (void)aInstance;
+    return NRF52811_RECEIVE_SENSITIVITY;
+}
+
+#if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
+void nrf_802154_tx_started(const uint8_t *aFrame)
+{
+    bool notifyFrameUpdated = false;
+    assert(aFrame == sTransmitPsdu);
+
+#if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+    if (sTransmitFrame.mIeInfo->mTimeIeOffset != 0)
+    {
+        uint8_t *timeIe = sTransmitFrame.mPsdu + sTransmitFrame.mIeInfo->mTimeIeOffset;
+        uint64_t time   = otPlatTimeGet() + sTransmitFrame.mIeInfo->mNetworkTimeOffset;
+
+        *timeIe = sTransmitFrame.mIeInfo->mTimeSyncSeq;
+
+        *(++timeIe) = (uint8_t)(time & 0xff);
+        for (uint8_t i = 1; i < sizeof(uint64_t); i++)
+        {
+            time        = time >> 8;
+            *(++timeIe) = (uint8_t)(time & 0xff);
+        }
+
+        notifyFrameUpdated = true;
+    }
+#endif // OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
+
+    if (notifyFrameUpdated)
+    {
+        otPlatRadioFrameUpdated(sInstance, &sTransmitFrame);
+    }
+}
+#endif

--- a/examples/platforms/nrf52811/random.c
+++ b/examples/platforms/nrf52811/random.c
@@ -1,0 +1,205 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements a random number generator.
+ *
+ */
+
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <utils/code_utils.h>
+#include <openthread/platform/random.h>
+
+#include "platform-nrf5.h"
+
+#include <hal/nrf_rng.h>
+
+static uint8_t           sBuffer[RNG_BUFFER_SIZE];
+static volatile uint32_t sReadPosition;
+static volatile uint32_t sWritePosition;
+
+static inline uint32_t bufferCount(void)
+{
+    uint32_t writePos = sWritePosition;
+    return writePos - sReadPosition;
+}
+
+static inline bool bufferIsEmpty(void)
+{
+    return (bufferCount() == 0);
+}
+
+static inline bool bufferIsUint32Ready(void)
+{
+    return (bufferCount() >= 4);
+}
+
+static inline bool bufferIsFull(void)
+{
+    return (bufferCount() >= RNG_BUFFER_SIZE);
+}
+
+static inline void bufferPut(uint8_t val)
+{
+    if (!bufferIsFull())
+    {
+        sBuffer[(sWritePosition++) % RNG_BUFFER_SIZE] = val;
+    }
+}
+
+static inline uint8_t bufferGet()
+{
+    uint8_t retVal = 0;
+
+    if (!bufferIsEmpty())
+    {
+        retVal = sBuffer[sReadPosition++ % RNG_BUFFER_SIZE];
+    }
+
+    return retVal;
+}
+
+static inline uint32_t bufferGetUint32()
+{
+    uint32_t retVal = 0;
+
+    if (bufferIsUint32Ready())
+    {
+        for (uint32_t i = 0; i < 4; i++)
+        {
+            retVal <<= 8;
+            retVal |= bufferGet();
+        }
+    }
+
+    return retVal;
+}
+
+static void generatorStart(void)
+{
+    nrf_rng_event_clear(NRF_RNG_EVENT_VALRDY);
+    nrf_rng_int_enable(NRF_RNG_INT_VALRDY_MASK);
+    nrf_rng_task_trigger(NRF_RNG_TASK_START);
+}
+
+static void generatorStop(void)
+{
+    nrf_rng_int_disable(NRF_RNG_INT_VALRDY_MASK);
+    nrf_rng_task_trigger(NRF_RNG_TASK_STOP);
+}
+
+void RNG_IRQHandler(void)
+{
+    if (nrf_rng_event_get(NRF_RNG_EVENT_VALRDY) && nrf_rng_int_get(NRF_RNG_INT_VALRDY_MASK))
+    {
+        nrf_rng_event_clear(NRF_RNG_EVENT_VALRDY);
+
+        bufferPut(nrf_rng_random_value_get());
+
+        if (bufferIsFull())
+        {
+            generatorStop();
+        }
+    }
+}
+
+void nrf5RandomInit(void)
+{
+    uint32_t seed = 0;
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    sReadPosition  = 0;
+    sWritePosition = 0;
+
+    NVIC_SetPriority(RNG_IRQn, RNG_IRQ_PRIORITY);
+    NVIC_ClearPendingIRQ(RNG_IRQn);
+    NVIC_EnableIRQ(RNG_IRQn);
+
+    nrf_rng_error_correction_enable();
+    nrf_rng_shorts_disable(NRF_RNG_SHORT_VALRDY_STOP_MASK);
+    generatorStart();
+
+    // Wait for the first randomized 4 bytes, to randomize software generator seed.
+    while (!bufferIsUint32Ready())
+        ;
+
+    seed = bufferGetUint32();
+
+    srand(seed);
+}
+
+void nrf5RandomDeinit(void)
+{
+    // Intentionally empty.
+}
+
+uint32_t otPlatRandomGet(void)
+{
+    return (uint32_t)rand();
+}
+
+otError otPlatRandomGetTrue(uint8_t *aOutput, uint16_t aOutputLength)
+{
+    otError  error = OT_ERROR_NONE;
+    uint8_t  copyLength;
+    uint16_t index = 0;
+
+    otEXPECT_ACTION(aOutput && aOutputLength, error = OT_ERROR_INVALID_ARGS);
+
+    do
+    {
+        copyLength = (uint8_t)bufferCount();
+
+        if (copyLength > aOutputLength - index)
+        {
+            copyLength = aOutputLength - index;
+        }
+
+        if (copyLength > 0)
+        {
+            for (uint32_t i = 0; i < copyLength; i++)
+            {
+                aOutput[i + index] = bufferGet();
+            }
+
+            generatorStart();
+
+            index += copyLength;
+        }
+    } while (index < aOutputLength);
+
+exit:
+    return error;
+}

--- a/examples/platforms/nrf52811/spi-slave.c
+++ b/examples/platforms/nrf52811/spi-slave.c
@@ -1,0 +1,237 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the OpenThread platform abstraction for SPIS communication.
+ *
+ */
+
+#include <utils/code_utils.h>
+#include <openthread/platform/spi-slave.h>
+
+#include <hal/nrf_gpio.h>
+#include <hal/nrf_spis.h>
+#include <platform-nrf5.h>
+
+#if (SPIS_AS_SERIAL_TRANSPORT == 1)
+
+/**
+ *  SPI Slave transaction variables.
+ */
+static void *                                    sContext                = NULL;
+static uint8_t *                                 sOutputBuf              = NULL;
+static uint16_t                                  sOutputBufLen           = 0;
+static uint8_t *                                 sInputBuf               = NULL;
+static uint16_t                                  sInputBufLen            = 0;
+static bool                                      sRequestTransactionFlag = false;
+static bool                                      sFurtherProcessingFlag  = false;
+static otPlatSpiSlaveTransactionProcessCallback  sProcessCallback        = NULL;
+static otPlatSpiSlaveTransactionCompleteCallback sCompleteCallback       = NULL;
+
+void nrf5SpiSlaveInit(void)
+{
+    /* Intentionally empty. */
+}
+
+void nrf5SpiSlaveDeinit(void)
+{
+    sOutputBuf              = NULL;
+    sOutputBufLen           = 0;
+    sInputBuf               = NULL;
+    sInputBufLen            = 0;
+    sRequestTransactionFlag = false;
+
+    otPlatSpiSlaveDisable();
+}
+
+void nrf5SpiSlaveProcess(void)
+{
+    otEXPECT(sFurtherProcessingFlag == true);
+
+    /* Clear further processing flag. */
+    sFurtherProcessingFlag = false;
+
+    /* Perform any further processing if necessary. */
+    sProcessCallback(sContext);
+
+exit:
+    return;
+}
+
+otError otPlatSpiSlaveEnable(otPlatSpiSlaveTransactionCompleteCallback aCompleteCallback,
+                             otPlatSpiSlaveTransactionProcessCallback  aProcessCallback,
+                             void *                                    aContext)
+{
+    otError error = OT_ERROR_NONE;
+
+    /* Check if SPI Slave interface is already enabled. */
+    otEXPECT_ACTION(sCompleteCallback == NULL, error = OT_ERROR_ALREADY);
+
+    /* Set up MISO/MOSI/SCK/CSN and Host IRQ. */
+    nrf_gpio_cfg_input(SPIS_PIN_MISO, NRF_GPIO_PIN_NOPULL);
+    nrf_gpio_cfg_input(SPIS_PIN_MOSI, NRF_GPIO_PIN_NOPULL);
+    nrf_gpio_cfg_input(SPIS_PIN_SCK, NRF_GPIO_PIN_NOPULL);
+    nrf_gpio_cfg_input(SPIS_PIN_CSN, NRF_GPIO_PIN_NOPULL);
+    nrf_gpio_pin_set(SPIS_PIN_HOST_IRQ);
+    nrf_gpio_cfg_output(SPIS_PIN_HOST_IRQ);
+
+    nrf_spis_pins_set(SPIS_INSTANCE, SPIS_PIN_SCK, SPIS_PIN_MOSI, SPIS_PIN_MISO, SPIS_PIN_CSN);
+
+    /* Set buffer pointers. */
+    nrf_spis_rx_buffer_set(SPIS_INSTANCE, NULL, 0);
+    nrf_spis_tx_buffer_set(SPIS_INSTANCE, NULL, 0);
+
+    /* Configure SPIS Mode and Bit order. */
+    nrf_spis_configure(SPIS_INSTANCE, SPIS_MODE, SPIS_BIT_ORDER);
+
+    /* Use 0xFF character to indicate that there is no transmit buffer set up or overflow occured
+       as described in API documentation. */
+    nrf_spis_def_set(SPIS_INSTANCE, 0xFF);
+    nrf_spis_orc_set(SPIS_INSTANCE, 0xFF);
+
+    /* Clear SPIS specific events. */
+    nrf_spis_event_clear(SPIS_INSTANCE, NRF_SPIS_EVENT_END);
+    nrf_spis_event_clear(SPIS_INSTANCE, NRF_SPIS_EVENT_ACQUIRED);
+
+    /* Enable interrupts for ACQUIRED and END events. */
+    nrf_spis_int_enable(SPIS_INSTANCE, (NRF_SPIS_INT_ACQUIRED_MASK | NRF_SPIS_INT_END_MASK));
+
+    /* Configure NVIC to handle SPIS interrupts. */
+    NVIC_SetPriority(SPIS_IRQN, SPIS_IRQ_PRIORITY);
+    NVIC_ClearPendingIRQ(SPIS_IRQN);
+    NVIC_EnableIRQ(SPIS_IRQN);
+
+    /* Enable SPI slave device. */
+    nrf_spis_enable(SPIS_INSTANCE);
+
+    /* Set proper callback and context. */
+    sProcessCallback  = aProcessCallback;
+    sCompleteCallback = aCompleteCallback;
+    sContext          = aContext;
+
+exit:
+    return error;
+}
+
+void otPlatSpiSlaveDisable(void)
+{
+    /* Disable interrupts for ACQUIRED and END events. */
+    nrf_spis_int_disable(SPIS_INSTANCE, (NRF_SPIS_INT_ACQUIRED_MASK | NRF_SPIS_INT_END_MASK));
+
+    /* Disable NVIC interrupt. */
+    NVIC_DisableIRQ(SPIS_IRQN);
+
+    /* Disable SPIS instance. */
+    nrf_spis_disable(SPIS_INSTANCE);
+}
+
+otError otPlatSpiSlavePrepareTransaction(uint8_t *aOutputBuf,
+                                         uint16_t aOutputBufLen,
+                                         uint8_t *aInputBuf,
+                                         uint16_t aInputBufLen,
+                                         bool     aRequestTransactionFlag)
+{
+    otError            error            = OT_ERROR_NONE;
+    nrf_spis_semstat_t semaphore_status = nrf_spis_semaphore_status_get(SPIS_INSTANCE);
+
+    otEXPECT_ACTION(sCompleteCallback != NULL, error = OT_ERROR_INVALID_STATE);
+
+    otEXPECT_ACTION(((semaphore_status != NRF_SPIS_SEMSTAT_SPIS) && (semaphore_status != NRF_SPIS_SEMSTAT_CPUPENDING)),
+                    error = OT_ERROR_BUSY);
+
+    if (aOutputBuf != NULL)
+    {
+        sOutputBuf    = aOutputBuf;
+        sOutputBufLen = aOutputBufLen;
+    }
+
+    if (aInputBuf != NULL)
+    {
+        sInputBuf    = aInputBuf;
+        sInputBufLen = aInputBufLen;
+    }
+
+    sRequestTransactionFlag = aRequestTransactionFlag;
+
+    /* Trigger acquired event. */
+    nrf_spis_task_trigger(SPIS_INSTANCE, NRF_SPIS_TASK_ACQUIRE);
+
+exit:
+    return error;
+}
+
+/**
+ * Interrupt handler of SPIS peripherial.
+ */
+void SPIM0_SPIS0_SPI0_IRQHandler(void)
+{
+    /* Check for SPI semaphore acquired event. */
+    if (nrf_spis_event_check(SPIS_INSTANCE, NRF_SPIS_EVENT_ACQUIRED))
+    {
+        nrf_spis_event_clear(SPIS_INSTANCE, NRF_SPIS_EVENT_ACQUIRED);
+
+        /* Set actual TX/RX buffers. */
+        nrf_spis_tx_buffer_set(SPIS_INSTANCE, sOutputBuf, sOutputBufLen);
+        nrf_spis_rx_buffer_set(SPIS_INSTANCE, sInputBuf, sInputBufLen);
+
+        if (sRequestTransactionFlag)
+        {
+            /* Interrupt pin is active low. */
+            nrf_gpio_pin_clear(SPIS_PIN_HOST_IRQ);
+        }
+
+        /* Trigger RELEASE event immediately. */
+        nrf_spis_task_trigger(SPIS_INSTANCE, NRF_SPIS_TASK_RELEASE);
+    }
+
+    /* Check for SPI transaction complete event. */
+    if (nrf_spis_event_check(SPIS_INSTANCE, NRF_SPIS_EVENT_END))
+    {
+        nrf_spis_event_clear(SPIS_INSTANCE, NRF_SPIS_EVENT_END);
+
+        if (sRequestTransactionFlag)
+        {
+            nrf_gpio_pin_set(SPIS_PIN_HOST_IRQ);
+        }
+
+        /* Discard all transactions until buffers are updated. */
+        nrf_spis_tx_buffer_set(SPIS_INSTANCE, sOutputBuf, 0);
+        nrf_spis_rx_buffer_set(SPIS_INSTANCE, sInputBuf, 0);
+
+        /* Execute application callback. */
+        if (sCompleteCallback(sContext, sOutputBuf, sOutputBufLen, sInputBuf, sInputBufLen,
+                              nrf_spis_rx_amount_get(SPIS_INSTANCE)))
+        {
+            /* Further processing is required. */
+            sFurtherProcessingFlag = true;
+        }
+    }
+}
+
+#endif // SPIS_AS_SERIAL_TRANSPORT == 1

--- a/examples/platforms/nrf52811/system.c
+++ b/examples/platforms/nrf52811/system.c
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes the platform-specific initializers.
+ *
+ */
+
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
+#include <openthread/platform/logging.h>
+
+#include "openthread-system.h"
+#include "platform-fem.h"
+#include "platform-nrf5.h"
+#include <drivers/clock/nrf_drv_clock.h>
+#include <nrf.h>
+
+#include <openthread/config.h>
+
+extern bool gPlatformPseudoResetWasRequested;
+
+void __cxa_pure_virtual(void)
+{
+    while (1)
+        ;
+}
+
+void otSysInit(int argc, char *argv[])
+{
+    if (gPlatformPseudoResetWasRequested)
+    {
+        otSysDeinit();
+    }
+
+    (void)argc;
+    (void)argv;
+
+#if DCDC_ENABLE
+    NRF_POWER->DCDCEN = 1;
+#endif
+
+    nrf_drv_clock_init();
+
+#if (OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED) || \
+    (OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_NCP_SPINEL)
+    nrf5LogInit();
+#endif
+    nrf5AlarmInit();
+    nrf5RandomInit();
+    if (!gPlatformPseudoResetWasRequested)
+    {
+#if (UART_AS_SERIAL_TRANSPORT == 1)
+        nrf5UartInit();
+#endif
+    }
+
+#if (SPIS_AS_SERIAL_TRANSPORT == 1)
+    nrf5SpiSlaveInit();
+#endif
+    nrf5MiscInit();
+    nrf5RadioInit();
+    nrf5TempInit();
+
+#if PLATFORM_FEM_ENABLE_DEFAULT_CONFIG
+    PlatformFemSetConfigParams(&PLATFORM_FEM_DEFAULT_CONFIG);
+#endif
+
+    gPlatformPseudoResetWasRequested = false;
+}
+
+void otSysDeinit(void)
+{
+    nrf5TempDeinit();
+    nrf5RadioDeinit();
+    nrf5MiscDeinit();
+#if (SPIS_AS_SERIAL_TRANSPORT == 1)
+    nrf5SpiSlaveDeinit();
+#endif
+    if (!gPlatformPseudoResetWasRequested)
+    {
+#if (UART_AS_SERIAL_TRANSPORT == 1)
+        nrf5UartDeinit();
+#endif
+    }
+    nrf5RandomDeinit();
+    nrf5AlarmDeinit();
+#if (OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED) || \
+    (OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_NCP_SPINEL)
+    nrf5LogDeinit();
+#endif
+}
+
+bool otSysPseudoResetWasRequested(void)
+{
+    return gPlatformPseudoResetWasRequested;
+}
+
+void otSysProcessDrivers(otInstance *aInstance)
+{
+    nrf5RadioProcess(aInstance);
+#if (UART_AS_SERIAL_TRANSPORT == 1)
+    nrf5UartProcess();
+#endif
+#if (SPIS_AS_SERIAL_TRANSPORT == 1)
+    nrf5SpiSlaveProcess();
+#endif
+    nrf5TempProcess();
+    nrf5AlarmProcess(aInstance);
+}
+
+__WEAK void otSysEventSignalPending(void)
+{
+    // Intentionally empty
+}

--- a/examples/platforms/nrf52811/temp.c
+++ b/examples/platforms/nrf52811/temp.c
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <limits.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <hal/nrf_temp.h>
+#include <utils/code_utils.h>
+
+#include "platform-nrf5.h"
+#include <drivers/radio/platform/temperature/nrf_802154_temperature.h>
+
+#define US_PER_S 1000000ULL
+
+static uint64_t sLastReadTimestamp;
+static int32_t  sTemperature;
+
+__STATIC_INLINE void dataReadyEventClear(void)
+{
+    NRF_TEMP->EVENTS_DATARDY = 0;
+    volatile uint32_t dummy  = NRF_TEMP->EVENTS_DATARDY;
+    (void)dummy;
+}
+
+void nrf5TempInit(void)
+{
+    nrf_temp_init();
+
+    NRF_TEMP->TASKS_START = 1;
+}
+
+void nrf5TempDeinit(void)
+{
+    NRF_TEMP->TASKS_STOP = 1;
+}
+
+void nrf5TempProcess(void)
+{
+    int32_t  prevTemperature = sTemperature;
+    uint64_t now;
+
+    if (NRF_TEMP->EVENTS_DATARDY)
+    {
+        dataReadyEventClear();
+
+        sTemperature = nrf_temp_read();
+    }
+
+    now = nrf5AlarmGetCurrentTime();
+
+    if (now - sLastReadTimestamp > (TEMP_MEASUREMENT_INTERVAL * US_PER_S))
+    {
+        NRF_TEMP->TASKS_START = 1;
+        sLastReadTimestamp    = now;
+    }
+
+    if (prevTemperature != sTemperature)
+    {
+        nrf_802154_temperature_changed();
+    }
+}
+
+int32_t nrf5TempGet(void)
+{
+    // Provide temperature value in [0.25 C] unit.
+    return sTemperature;
+}
+
+void nrf_802154_temperature_init(void)
+{
+    // Intentionally empty
+}
+
+void nrf_802154_temperature_deinit(void)
+{
+    // Intentionally empty
+}
+
+int8_t nrf_802154_temperature_get(void)
+{
+    // Provide temperature value in [C].
+    return (int8_t)(sTemperature / 4);
+}

--- a/examples/platforms/nrf52811/uart.c
+++ b/examples/platforms/nrf52811/uart.c
@@ -1,0 +1,331 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the OpenThread platform abstraction for UART communication.
+ *
+ */
+
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <utils/code_utils.h>
+#include <openthread/platform/toolchain.h>
+#include <openthread/platform/uart.h>
+
+#include "openthread-system.h"
+
+#include "platform-nrf5.h"
+#include <drivers/clock/nrf_drv_clock.h>
+#include <hal/nrf_gpio.h>
+#include <hal/nrf_uart.h>
+
+#if (UART_AS_SERIAL_TRANSPORT == 1)
+
+bool sUartEnabled = false;
+
+/**
+ *  UART TX buffer variables.
+ */
+static const uint8_t *sTransmitBuffer = NULL;
+static uint16_t       sTransmitLength = 0;
+static bool           sTransmitDone   = 0;
+
+/**
+ *  UART RX ring buffer variables.
+ */
+static uint8_t  sReceiveBuffer[UART_RX_BUFFER_SIZE];
+static uint16_t sReceiveHead = 0;
+static uint16_t sReceiveTail = 0;
+
+/**
+ * Function for checking if RX buffer is full.
+ *
+ * @retval true  RX buffer is full.
+ * @retval false RX buffer is not full.
+ */
+static __INLINE bool isRxBufferFull()
+{
+    uint16_t next = (sReceiveHead + 1) % UART_RX_BUFFER_SIZE;
+    return (next == sReceiveTail);
+}
+
+/**
+ * Function for checking if RX buffer is empty.
+ *
+ * @retval true  RX buffer is empty.
+ * @retval false RX buffer is not empty.
+ */
+static __INLINE bool isRxBufferEmpty()
+{
+    return (sReceiveHead == sReceiveTail);
+}
+
+/**
+ * Function for notifying application about new bytes received.
+ */
+static void processReceive(void)
+{
+    // Set head position to not be changed during read procedure.
+    uint16_t head = sReceiveHead;
+
+    otEXPECT(isRxBufferEmpty() == false);
+
+    // In case head roll back to the beginning of the buffer, notify about left
+    // bytes from the end of the buffer.
+    if (head < sReceiveTail)
+    {
+        otPlatUartReceived(&sReceiveBuffer[sReceiveTail], (UART_RX_BUFFER_SIZE - sReceiveTail));
+        sReceiveTail = 0;
+    }
+
+    // Notify about received bytes.
+    if (head > sReceiveTail)
+    {
+        otPlatUartReceived(&sReceiveBuffer[sReceiveTail], (head - sReceiveTail));
+        sReceiveTail = head;
+    }
+
+exit:
+    return;
+}
+
+/**
+ * Function for notifying application about transmission being done.
+ */
+static void processTransmit(void)
+{
+    otEXPECT(sTransmitBuffer != NULL);
+
+    if (sTransmitDone)
+    {
+        // Clear Transmition transaction and notify application.
+        sTransmitBuffer = NULL;
+        sTransmitLength = 0;
+        sTransmitDone   = false;
+        otPlatUartSendDone();
+    }
+
+exit:
+    return;
+}
+
+void nrf5UartProcess(void)
+{
+    processReceive();
+    processTransmit();
+}
+
+void nrf5UartInit(void)
+{
+    // Intentionally empty.
+}
+
+void nrf5UartDeinit(void)
+{
+    if (sUartEnabled)
+    {
+        otPlatUartDisable();
+    }
+}
+
+otError otPlatUartEnable(void)
+{
+    otError error = OT_ERROR_NONE;
+
+    otEXPECT_ACTION(sUartEnabled == false, error = OT_ERROR_ALREADY);
+
+    // Set up TX and RX pins.
+    nrf_gpio_pin_set(UART_PIN_TX);
+    nrf_gpio_cfg_output(UART_PIN_TX);
+    nrf_gpio_cfg_input(UART_PIN_RX, NRF_GPIO_PIN_NOPULL);
+    nrf_uart_txrx_pins_set(UART_INSTANCE, UART_PIN_TX, UART_PIN_RX);
+
+#if (UART_HWFC_ENABLED == 1)
+    // Set up CTS and RTS pins.
+    nrf_gpio_cfg_input(UART_PIN_CTS, NRF_GPIO_PIN_NOPULL);
+    nrf_gpio_pin_set(UART_PIN_RTS);
+    nrf_gpio_cfg_output(UART_PIN_RTS);
+    nrf_uart_hwfc_pins_set(UART_INSTANCE, UART_PIN_RTS, UART_PIN_CTS);
+
+    nrf_uart_configure(UART_INSTANCE, UART_PARITY, NRF_UART_HWFC_ENABLED);
+#else
+    nrf_uart_configure(UART_INSTANCE, UART_PARITY, NRF_UART_HWFC_DISABLED);
+#endif
+
+    // Configure baudrate.
+    nrf_uart_baudrate_set(UART_INSTANCE, UART_BAUDRATE);
+
+    // Clear UART specific events.
+    nrf_uart_event_clear(UART_INSTANCE, NRF_UART_EVENT_TXDRDY);
+    nrf_uart_event_clear(UART_INSTANCE, NRF_UART_EVENT_ERROR);
+    nrf_uart_event_clear(UART_INSTANCE, NRF_UART_EVENT_RXDRDY);
+
+    // Enable interrupts for TX.
+    nrf_uart_int_enable(UART_INSTANCE, NRF_UART_INT_MASK_TXDRDY);
+
+    // Enable interrupts for RX.
+    nrf_uart_int_enable(UART_INSTANCE, NRF_UART_INT_MASK_RXDRDY | NRF_UART_INT_MASK_ERROR);
+
+    // Configure NVIC to handle UART interrupts.
+    NVIC_SetPriority(UART_IRQN, UART_IRQ_PRIORITY);
+    NVIC_ClearPendingIRQ(UART_IRQN);
+    NVIC_EnableIRQ(UART_IRQN);
+
+    // Start HFCLK
+    nrf_drv_clock_hfclk_request(NULL);
+
+    while (!nrf_drv_clock_hfclk_is_running())
+    {
+    }
+
+    // Enable UART instance, and start RX on it.
+    nrf_uart_enable(UART_INSTANCE);
+    nrf_uart_task_trigger(UART_INSTANCE, NRF_UART_TASK_STARTRX);
+
+    sUartEnabled = true;
+
+exit:
+    return error;
+}
+
+otError otPlatUartDisable(void)
+{
+    otError error = OT_ERROR_NONE;
+
+    otEXPECT_ACTION(sUartEnabled == true, error = OT_ERROR_ALREADY);
+
+    // Disable NVIC interrupt.
+    NVIC_DisableIRQ(UART_IRQN);
+    NVIC_ClearPendingIRQ(UART_IRQN);
+    NVIC_SetPriority(UART_IRQN, 0);
+
+    // Disable interrupts for TX.
+    nrf_uart_int_disable(UART_INSTANCE, NRF_UART_INT_MASK_TXDRDY);
+
+    // Disable interrupts for RX.
+    nrf_uart_int_disable(UART_INSTANCE, NRF_UART_INT_MASK_RXDRDY | NRF_UART_INT_MASK_ERROR);
+
+    // Disable UART instance.
+    nrf_uart_disable(UART_INSTANCE);
+
+    // Release HF clock.
+    nrf_drv_clock_hfclk_release();
+
+    sUartEnabled = false;
+
+exit:
+    return error;
+}
+
+otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
+{
+    otError error = OT_ERROR_NONE;
+
+    otEXPECT_ACTION(sTransmitBuffer == NULL, error = OT_ERROR_BUSY);
+
+    // Set up transmit buffer and its size without counting first triggered byte.
+    sTransmitBuffer = aBuf;
+    sTransmitLength = aBufLength - 1;
+
+    // Initiate Transmission process.
+    nrf_uart_event_clear(UART_INSTANCE, NRF_UART_EVENT_TXDRDY);
+    nrf_uart_txd_set(UART_INSTANCE, *sTransmitBuffer++);
+    nrf_uart_task_trigger(UART_INSTANCE, NRF_UART_TASK_STARTTX);
+
+exit:
+    return error;
+}
+
+/**
+ * Interrupt handler of UART0 peripherial.
+ */
+void UARTE0_UART0_IRQHandler(void)
+{
+    // Check if any error has been detected.
+    if (nrf_uart_event_check(UART_INSTANCE, NRF_UART_EVENT_ERROR))
+    {
+        // Clear error event and ignore erronous byte in RXD register.
+        nrf_uart_event_clear(UART_INSTANCE, NRF_UART_EVENT_ERROR);
+        nrf_uart_event_clear(UART_INSTANCE, NRF_UART_EVENT_RXDRDY);
+    }
+    else if (nrf_uart_event_check(UART_INSTANCE, NRF_UART_EVENT_RXDRDY))
+    {
+        // Clear RXDRDY event.
+        nrf_uart_event_clear(UART_INSTANCE, NRF_UART_EVENT_RXDRDY);
+
+        // Read byte from the UART buffer.
+        uint8_t byte = nrf_uart_rxd_get(UART_INSTANCE);
+
+        if (!isRxBufferFull())
+        {
+            sReceiveBuffer[sReceiveHead] = byte;
+            sReceiveHead                 = (sReceiveHead + 1) % UART_RX_BUFFER_SIZE;
+            otSysEventSignalPending();
+        }
+    }
+
+    if (nrf_uart_event_check(UART_INSTANCE, NRF_UART_EVENT_TXDRDY))
+    {
+        // Clear TXDRDY event.
+        nrf_uart_event_clear(UART_INSTANCE, NRF_UART_EVENT_TXDRDY);
+
+        // Send any more bytes if available or call application about TX done.
+        if (sTransmitLength)
+        {
+            nrf_uart_txd_set(UART_INSTANCE, *sTransmitBuffer++);
+            sTransmitLength--;
+        }
+        else
+        {
+            sTransmitDone = true;
+            nrf_uart_task_trigger(UART_INSTANCE, NRF_UART_TASK_STOPTX);
+            otSysEventSignalPending();
+        }
+    }
+}
+
+#endif // UART_AS_SERIAL_TRANSPORT == 1
+
+/**
+ * The UART driver weak functions definition.
+ *
+ */
+OT_TOOL_WEAK void otPlatUartSendDone(void)
+{
+}
+
+OT_TOOL_WEAK void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength)
+{
+    OT_UNUSED_VARIABLE(aBuf);
+    OT_UNUSED_VARIABLE(aBufLength);
+}

--- a/examples/platforms/nrf52840/README.md
+++ b/examples/platforms/nrf52840/README.md
@@ -10,12 +10,12 @@ To facilitate Thread products development with the nRF52840 platform, Nordic Sem
 
 ## Toolchain
 
-Download and install [GNU toolchain for ARM Cortex-M][gnu-toolchain].
+Download and install the [GNU toolchain for ARM Cortex-M][gnu-toolchain].
 
 [gnu-toolchain]: https://launchpad.net/gcc-arm-embedded
 
-In a Bash terminal, follow these instructions to install the GNU toolchain and
-other dependencies.
+To install the GNU toolchain and its dependencies,
+run the following commands in Bash:
 
 ```bash
 $ cd <path-to-openthread>
@@ -23,6 +23,8 @@ $ ./script/bootstrap
 ```
 
 ## Building the examples
+
+ To build the examples, run the following command in Bash:
 
 ```bash
 $ cd <path-to-openthread>
@@ -33,44 +35,39 @@ $ make -f examples/Makefile-nrf52840
 After a successful build, the `elf` files can be found in
 `<path-to-openthread>/output/nrf52840/bin`.  You can convert them to `hex`
 files using `arm-none-eabi-objcopy`:
+
 ```bash
 $ arm-none-eabi-objcopy -O ihex ot-cli-ftd ot-cli-ftd.hex
 ```
 
-## Native USB support
-
-You can build the libraries with support for native USB CDC ACM as a serial transport.
-To do so, build the libraries with the following parameter:
+You can build the libraries with support for the native USB CDC ACM as a serial transport.
+To do so, build the firmware with the following parameter:
 ```
 $ make -f examples/Makefile-nrf52840 USB=1
 ```
 
-Note, that if Windows 7 or earlier is used, an additional USB CDC driver has to be loaded.
-It can be found in third_party/NordicSemiconductor/libraries/usb/nordic_cdc_acm_example.inf
+If you are using Windows 7 or earlier, you must load an additional USB CDC driver.
+The driver can be found in `third_party/NordicSemiconductor/libraries/usb/nordic_cdc_acm_example.inf`.
 
-## nRF52840 dongle support (PCA10059)
-You can build the libraries with support for USB bootloader with automatic USB DFU trigger support in PCA10059. As this dongle uses native USB support we have to enable it as well. To do so, build the libraries with the following parameter:
+### nRF52840 dongle support (PCA10059)
+
+You can build the libraries with support for USB bootloader with automatic USB DFU trigger support in PCA10059. As this dongle uses the native USB support, you must enable it as well.
+
+To build the libraries, run make with the following parameter:
+
 ```
 $ make -f examples/Makefile-nrf52840 USB=1 BOOTLOADER=1
 ```
-Please see [nRF52840 Dongle Programming][nrf52840-dongle-programming] for more details about how to use USB bootloader.
+
+See [nRF52840 Dongle Programming][nrf52840-dongle-programming] for more details about how to use the USB bootloader.
 
 [nrf52840-dongle-programming]: https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.nrf52%2Fdita%2Fnrf52%2Fdevelopment%2Fnrf52840_dongle%2Fprogramming.html&cp=2_0_4_4
 
-## Prefixing compiler command
-
-You can prefix compiler command using CCPREFIX parameter. This is useful when you utilize tools like [ccache][ccache-website] to speed up compilation. Example usage:
-
-[ccache-website]: https://ccache.samba.org/
-
-```
-$ make -f examples/Makefile-nrf52840 USB=1 CCPREFIX=ccache
-```
-
-## Native SPI Slave support
+### Native SPI Slave support
 
 You can build the libraries with support for native SPI Slave.
-To do so, build the libraries with the following parameter:
+To build the libraries, run make with the following parameter:
+
 ```
 $ make -f examples/Makefile-nrf52840 NCP_SPI=1
 ```
@@ -93,7 +90,17 @@ single transfer size limitation.
 
 [spi-hdlc-adapter]: https://github.com/openthread/openthread/tree/master/tools/spi-hdlc-adapter
 
-## CryptoCell 310 support
+### Optional prefix for compiler command
+
+You can prefix the compiler command using the CCPREFIX parameter. This speeds up the compilation when you use tools like [ccache][ccache-website]. Example usage:
+
+[ccache-website]: https://ccache.samba.org/
+
+```
+$ make -f examples/Makefile-nrf52840 USB=1 CCPREFIX=ccache
+```
+
+### CryptoCell 310 support
 
 By default, mbedTLS library is built with support for CryptoCell 310 hardware acceleration of cryptographic operations used in OpenThread. You can disable CryptoCell 310 and use software cryptography instead by building OpenThread with the following parameter:
 ```

--- a/third_party/Makefile.am
+++ b/third_party/Makefile.am
@@ -61,6 +61,14 @@ endif
 if OPENTHREAD_EXAMPLES_NRF52840
 SUBDIRS                                += \
     jlink                                 \
+    NordicSemiconductor                   \
+    $(NULL)
+endif
+
+if OPENTHREAD_EXAMPLES_NRF52811
+SUBDIRS                                += \
+    jlink                                 \
+    NordicSemiconductor                   \
     $(NULL)
 endif
 

--- a/third_party/NordicSemiconductor/Makefile.am
+++ b/third_party/NordicSemiconductor/Makefile.am
@@ -1,0 +1,397 @@
+#
+#  Copyright (c) 2016-2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
+
+if OPENTHREAD_EXAMPLES_NRF52811
+lib_LIBRARIES                                                                                              = \
+    libnordicsemi-nrf52811-sdk.a                                                                             \
+    libnordicsemi-nrf52811-radio-driver.a                                                                    \
+    $(NULL)
+endif
+
+if OPENTHREAD_EXAMPLES_NRF52840
+lib_LIBRARIES                                                                                              = \
+    libnordicsemi-nrf52840-sdk.a                                                                             \
+    libnordicsemi-nrf52840-radio-driver.a                                                                    \
+    libnordicsemi-nrf52840-radio-driver-softdevice.a                                                         \
+    $(NULL)
+endif
+
+# Do not enable -pedantic-errors for Nordic Semiconductor driver library
+override CFLAGS   := $(filter-out -pedantic-errors,$(CFLAGS))
+override CXXFLAGS := $(filter-out -pedantic-errors,$(CXXFLAGS))
+
+COMMONCPPFLAGS                                                                                             = \
+    -DCONFIG_GPIO_AS_PINRESET                                                                                \
+    -DENABLE_FEM=1                                                                                           \
+    -I$(srcdir)                                                                                              \
+    -I$(top_srcdir)/include                                                                                  \
+    -I$(top_srcdir)/src/core                                                                                 \
+    -I$(top_srcdir)/third_party/NordicSemiconductor                                                          \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/cmsis                                                    \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/dependencies                                             \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/clock                                            \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/common                                           \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio                                            \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/hal                                        \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch                                       \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/raal                                  \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/raal/softdevice                       \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/power                                            \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/systick                                          \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/usbd                                             \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/app_error                                      \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/atfifo                                         \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/atomic                                         \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/delay                                          \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/usb                                            \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/config                                     \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/class/cdc                                  \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/class/cdc/acm                              \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/utf_converter                                  \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx                                                     \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx/hal                                                 \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx/drivers                                             \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx/drivers/include                                     \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk                                                 \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx/soc                                                 \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers                                  \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/nrf52                            \
+    $(NULL)
+
+NRF52840_CPPFLAGS                                                                                          = \
+    -DNRF52840_XXAA                                                                                          \
+    -DNRF_802154_PROJECT_CONFIG=\"platform-config.h\"                                                        \
+    -I$(top_srcdir)/examples/platforms/nrf52840                                                              \
+    $(NULL)
+
+NRF52811_CPPFLAGS                                                                                          = \
+    -DNRF52811_XXAA                                                                                          \
+    -DNRF_802154_PROJECT_CONFIG=\"platform-config.h\"                                                        \
+    -D__HEAP_SIZE=0                                                                                          \
+    -D__STACK_SIZE=2048                                                                                      \
+    -I$(top_srcdir)/examples/platforms/nrf52811                                                              \
+    $(NULL)
+
+NORDICSEMI_COMMON_SOURCES                                                                                  = \
+    dependencies/app_util_platform.c                                                                         \
+    drivers/clock/nrf_drv_clock.c                                                                            \
+    drivers/power/nrf_drv_power.c                                                                            \
+    libraries/app_error/app_error.c                                                                          \
+    libraries/app_error/app_error_weak.c                                                                     \
+    libraries/utf_converter/utf.c                                                                            \
+    nrfx/drivers/src/nrfx_clock.c                                                                            \
+    nrfx/drivers/src/nrfx_power.c                                                                            \
+    nrfx/drivers/src/nrfx_systick.c                                                                          \
+    nrfx/hal/nrf_nvmc.c                                                                                      \
+    $(NULL)
+
+NORDICSEMI_USB_SOURCES                                                                                     = \
+    drivers/usbd/nrf_drv_usbd.c                                                                              \
+    libraries/atfifo/nrf_atfifo.c                                                                            \
+    libraries/atomic/nrf_atomic.c                                                                            \
+    libraries/usb/app_usbd.c                                                                                 \
+    libraries/usb/app_usbd_core.c                                                                            \
+    libraries/usb/app_usbd_string_desc.c                                                                     \
+    libraries/usb/app_usbd_serial_num.c                                                                      \
+    libraries/usb/app_usbd_nrf_dfu_trigger.c                                                                 \
+    libraries/usb/nrf_dfu_trigger_usb.c                                                                      \
+    libraries/usb/class/cdc/acm/app_usbd_cdc_acm.c                                                           \
+    $(NULL)
+
+NORDICSEMI_NRF52840_SOURCES                                                                                = \
+    nrfx/mdk/gcc_startup_nrf52840.S                                                                          \
+    nrfx/mdk/system_nrf52840.c                                                                               \
+    $(NULL)
+
+NORDICSEMI_NRF52811_SOURCES                                                                                = \
+    nrfx/mdk/gcc_startup_nrf52811.S                                                                          \
+    nrfx/mdk/system_nrf52811.c                                                                               \
+    $(NULL)
+
+RADIO_DRIVER_SOURCES                                                                                       = \
+    drivers/radio/nrf_802154.c                                                                               \
+    drivers/radio/nrf_802154_ack_pending_bit.c                                                               \
+    drivers/radio/nrf_802154_core.c                                                                          \
+    drivers/radio/nrf_802154_core_hooks.c                                                                    \
+    drivers/radio/nrf_802154_critical_section.c                                                              \
+    drivers/radio/nrf_802154_debug.c                                                                         \
+    drivers/radio/nrf_802154_pib.c                                                                           \
+    drivers/radio/nrf_802154_revision.c                                                                      \
+    drivers/radio/nrf_802154_rssi.c                                                                          \
+    drivers/radio/nrf_802154_rx_buffer.c                                                                     \
+    drivers/radio/nrf_802154_timer_coord.c                                                                   \
+    drivers/radio/fem/nrf_fem_control.c                                                                      \
+    drivers/radio/mac_features/nrf_802154_precise_ack_timeout.c                                              \
+    drivers/radio/mac_features/nrf_802154_csma_ca.c                                                          \
+    drivers/radio/mac_features/nrf_802154_delayed_trx.c                                                      \
+    drivers/radio/mac_features/nrf_802154_filter.c                                                           \
+    drivers/radio/platform/clock/nrf_802154_clock_sdk.c                                                      \
+    drivers/radio/platform/hp_timer/nrf_802154_hp_timer.c                                                    \
+    drivers/radio/rsch/nrf_802154_rsch.c                                                                     \
+    drivers/radio/rsch/nrf_802154_rsch_crit_sect.c                                                           \
+    drivers/radio/timer_scheduler/nrf_802154_timer_sched.c                                                   \
+    $(NULL)
+
+RADIO_DRIVER_SINGLE_PHY_SOURCES                                                                            = \
+    drivers/radio/nrf_802154_notification_direct.c                                                           \
+    drivers/radio/nrf_802154_priority_drop_direct.c                                                          \
+    drivers/radio/nrf_802154_request_direct.c                                                                \
+    drivers/radio/rsch/raal/single_phy/single_phy.c                                                          \
+    $(NULL)
+
+RADIO_DRIVER_SINGLE_PHY_CPPFLAGS                                                                           = \
+    -DRAAL_SINGLE_PHY=1                                                                                      \
+    $(NULL)
+
+RADIO_DRIVER_SOFTDEVICE_SOURCES                                                                            = \
+    drivers/radio/nrf_802154_notification_swi.c                                                              \
+    drivers/radio/nrf_802154_priority_drop_swi.c                                                             \
+    drivers/radio/nrf_802154_request_swi.c                                                                   \
+    drivers/radio/nrf_802154_swi.c                                                                           \
+    drivers/radio/rsch/raal/softdevice/nrf_raal_softdevice.c                                                 \
+    $(NULL)
+
+RADIO_DRIVER_SOFTDEVICE_CPPFLAGS                                                                           = \
+    -DRAAL_SOFTDEVICE=1                                                                                      \
+    $(NULL)
+
+SOFTDEVICE_CPPFLAGS                                                                                        = \
+    -DSOFTDEVICE_PRESENT                                                                                     \
+    -DS140                                                                                                   \
+    -DRAAL_SOFTDEVICE=1                                                                                      \
+    $(NULL)
+
+libnordicsemi_nrf52840_sdk_a_CPPFLAGS                                                                      = \
+    $(COMMONCPPFLAGS)                                                                                        \
+    $(NRF52840_CPPFLAGS)                                                                                     \
+    $(NULL)
+
+libnordicsemi_nrf52840_sdk_a_SOURCES                                                                       = \
+    $(NORDICSEMI_COMMON_SOURCES)                                                                             \
+    $(NORDICSEMI_USB_SOURCES)                                                                                \
+    $(NORDICSEMI_NRF52840_SOURCES)                                                                           \
+    $(NULL)
+
+libnordicsemi_nrf52840_radio_driver_a_CPPFLAGS                                                             = \
+    $(COMMONCPPFLAGS)                                                                                        \
+    $(NRF52840_CPPFLAGS)                                                                                     \
+    $(RADIO_DRIVER_SINGLE_PHY_CPPFLAGS)                                                                      \
+    $(NULL)
+
+libnordicsemi_nrf52840_radio_driver_a_SOURCES                                                              = \
+    $(RADIO_DRIVER_SOURCES)                                                                                  \
+    $(RADIO_DRIVER_SINGLE_PHY_SOURCES)                                                                       \
+    $(NULL)
+
+libnordicsemi_nrf52840_radio_driver_softdevice_a_CPPFLAGS                                                  = \
+    $(COMMONCPPFLAGS)                                                                                        \
+    $(NRF52840_CPPFLAGS)                                                                                     \
+    $(SOFTDEVICE_CPPFLAGS)                                                                                   \
+    $(RADIO_DRIVER_SOFTDEVICE_CPPFLAGS)                                                                      \
+    $(NULL)
+
+libnordicsemi_nrf52840_radio_driver_softdevice_a_SOURCES                                                   = \
+    $(RADIO_DRIVER_SOURCES)                                                                                  \
+    $(RADIO_DRIVER_SOFTDEVICE_SOURCES)                                                                       \
+    $(NULL)
+
+libnordicsemi_nrf52811_sdk_a_CPPFLAGS                                                                      = \
+    $(COMMONCPPFLAGS)                                                                                        \
+    $(NRF52811_CPPFLAGS)                                                                                     \
+    $(NULL)
+
+libnordicsemi_nrf52811_sdk_a_SOURCES                                                                       = \
+    $(NORDICSEMI_COMMON_SOURCES)                                                                             \
+    $(NORDICSEMI_NRF52811_SOURCES)                                                                           \
+    $(NULL)
+
+libnordicsemi_nrf52811_radio_driver_a_CPPFLAGS                                                             = \
+    $(COMMONCPPFLAGS)                                                                                        \
+    $(NRF52811_CPPFLAGS)                                                                                     \
+    $(RADIO_DRIVER_SINGLE_PHY_CPPFLAGS)                                                                      \
+    $(NULL)
+
+libnordicsemi_nrf52811_radio_driver_a_SOURCES                                                              = \
+    $(RADIO_DRIVER_SOURCES)                                                                                  \
+    $(RADIO_DRIVER_SINGLE_PHY_SOURCES)                                                                       \
+    $(NULL)
+
+noinst_HEADERS                                                                                               = \
+    $(top_srcdir)/third_party/NordicSemiconductor/cmsis/arm_math.h                                             \
+    $(top_srcdir)/third_party/NordicSemiconductor/cmsis/cmsis_armcc_V6.h                                       \
+    $(top_srcdir)/third_party/NordicSemiconductor/cmsis/cmsis_armcc.h                                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/cmsis/cmsis_gcc.h                                            \
+    $(top_srcdir)/third_party/NordicSemiconductor/cmsis/core_cm4.h                                             \
+    $(top_srcdir)/third_party/NordicSemiconductor/cmsis/core_cmFunc.h                                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/cmsis/core_cmInstr.h                                         \
+    $(top_srcdir)/third_party/NordicSemiconductor/cmsis/core_cmSimd.h                                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/app_util_platform.h                             \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/app_util.h                                      \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/apply_old_config.h                              \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nordic_common.h                                 \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrf_assert.h                                    \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrf_error.h                                     \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrf_log_instance.h                              \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrf_log_internal.h                              \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrf_log_types.h                                 \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrf_log.h                                       \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrf_log_ctrl.h                                  \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrf_log_ctrl_internal.h                         \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrf_section.h                                   \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrfx_config.h                                   \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrfx_glue.h                                     \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/nrfx_log.h                                      \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/sdk_common.h                                    \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/sdk_config.h                                    \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/sdk_errors.h                                    \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/sdk_macros.h                                    \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/sdk_os.h                                        \
+    $(top_srcdir)/third_party/NordicSemiconductor/dependencies/sdk_resources.h                                 \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/clock/nrf_drv_clock.h                                \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/common/nrf_drv_common.h                              \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/power/nrf_drv_power.h                                \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/systick/nrf_drv_systick.h                            \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/usbd/nrf_drv_usbd_errata.h                           \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/usbd/nrf_drv_usbd.h                                  \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154.h                                   \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_ack_pending_bit.h                   \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_core.h                              \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_core_hooks.h                        \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_config.h                            \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_const.h                             \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_critical_section.h                  \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_debug.h                             \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_notification.h                      \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_pib.h                               \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_priority_drop.h                     \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_procedures_duration.h               \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_request.h                           \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_revision.h                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_rssi.h                              \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_rx_buffer.h                         \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_timer_coord.h                       \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_swi.h                               \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/nrf_802154_utils.h                             \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/fem/nrf_fem_control_api.h                      \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/fem/nrf_fem_control_config.h                   \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/hal/nrf_radio.h                                \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/mac_features/nrf_802154_ack_timeout.h          \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/mac_features/nrf_802154_csma_ca.h              \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/mac_features/nrf_802154_filter.h               \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/platform/clock/nrf_802154_clock.h              \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/platform/temperature/nrf_802154_temperature.h  \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/platform/hp_timer/nrf_802154_hp_timer.h        \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/platform/lp_timer/nrf_802154_lp_timer.h        \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/nrf_802154_rsch.h                         \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/nrf_802154_wifi_coex.h                    \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/nrf_802154_rsch_crit_sect.h               \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/raal/nrf_raal_api.h                       \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/raal/nrf_raal_config.h                    \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/raal/softdevice/nrf_raal_softdevice.h     \
+    $(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/timer_scheduler/nrf_802154_timer_sched.h       \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/app_error/app_error_weak.h                         \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/app_error/app_error.h                              \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/atfifo/nrf_atfifo_internal.h                       \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/atfifo/nrf_atfifo.h                                \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/atomic/nrf_atomic_internal.h                       \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/atomic/nrf_atomic.h                                \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/delay/nrf_delay.h                                  \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd_class_base.h                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd_core.h                                \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd_descriptor.h                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd_langid.h                              \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd_request.h                             \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd_serial_num.h                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd_string_desc.h                         \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd_types.h                               \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd.h                                     \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd_nrf_dfu_trigger.h                     \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd_nrf_dfu_trigger_types.h               \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/app_usbd_nrf_dfu_trigger_internal.h            \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/class/cdc/app_usbd_cdc_desc.h                  \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/class/cdc/app_usbd_cdc_types.h                 \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/class/cdc/acm/app_usbd_cdc_acm_internal.h      \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/class/cdc/acm/app_usbd_cdc_acm.h               \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/usb/config/app_usbd_string_config.h                \
+    $(top_srcdir)/third_party/NordicSemiconductor/libraries/utf_converter/utf.h                                \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/drivers/nrfx_common.h                                   \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/drivers/nrfx_errors.h                                   \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/drivers/include/nrfx_clock.h                            \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/drivers/include/nrfx_power_clock.h                      \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/drivers/include/nrfx_power.h                            \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/drivers/include/nrfx_systick.h                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/hal/nrf_clock.h                                         \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/hal/nrf_gpio.h                                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/hal/nrf_gpiote.h                                        \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/hal/nrf_egu.h                                           \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/hal/nrf_nvmc.h                                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/hal/nrf_ppi.h                                           \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/hal/nrf_power.h                                         \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/hal/nrf_rng.h                                           \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/hal/nrf_spis.h                                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/hal/nrf_uart.h                                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/hal/nrf_usbd.h                                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk/compiler_abstraction.h                              \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk/nrf.h                                               \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk/nrf_peripherals.h                                   \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk/nrf51_to_nrf52.h                                    \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk/nrf51_to_nrf52810.h                                 \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk/nrf52_to_nrf52810.h                                 \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk/nrf51_to_nrf52840.h                                 \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk/nrf52_to_nrf52840.h                                 \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk/nrf52810_to_nrf52811.h                              \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk/nrf52811.h                                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk/nrf52811_bitfields.h                                \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk/nrf52811_peripherals.h                              \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk/nrf52840.h                                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk/nrf52840_bitfields.h                                \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk/nrf52840_peripherals.h                              \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk/system_nrf52840.h                                   \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/ble.h                                \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/ble_err.h                            \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/ble_gap.h                            \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/ble_gatt.h                           \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/ble_gattc.h                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/ble_gatts.h                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/ble_hci.h                            \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/ble_l2cap.h                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/ble_ranges.h                         \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/ble_types.h                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/nrf_error.h                          \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/nrf_error_sdm.h                      \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/nrf_error_soc.h                      \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/nrf_nvic.h                           \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/nrf_sdm.h                            \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/nrf_soc.h                            \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/nrf_svc.h                            \
+    $(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/nrf52/nrf_mbr.h                      \
+    $(NULL)
+
+include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/third_party/NordicSemiconductor/drivers/radio/fem/nrf_fem_control_config.h
+++ b/third_party/NordicSemiconductor/drivers/radio/fem/nrf_fem_control_config.h
@@ -53,6 +53,14 @@ extern "C" {
 /** Radio ramp-up time in RX mode, in us. */
 #define NRF_FEM_RADIO_RX_STARTUP_LATENCY_US 40
 
+#elif defined NRF52811_XXAA
+
+/** Radio ramp-up time in TX mode, in us. */
+#define NRF_FEM_RADIO_TX_STARTUP_LATENCY_US 40
+
+/** Radio ramp-up time in RX mode, in us. */
+#define NRF_FEM_RADIO_RX_STARTUP_LATENCY_US 40
+
 #else
 
 #error "Device not supported."

--- a/third_party/NordicSemiconductor/libraries/crypto/nrf52811-mbedtls-config.h
+++ b/third_party/NordicSemiconductor/libraries/crypto/nrf52811-mbedtls-config.h
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if defined(__ICCARM__)
+    _Pragma("diag_suppress=Pe550")
+#endif
+
+#if defined(__CC_ARM)
+    _Pragma("diag_suppress=550")
+    _Pragma("diag_suppress=68")
+#endif

--- a/third_party/jlink/Makefile.am
+++ b/third_party/jlink/Makefile.am
@@ -43,7 +43,7 @@ noinst_HEADERS                                            = \
     SEGGER_RTT_V640/RTT/SEGGER_RTT_Conf.h                   \
     $(NULL)
 
-if OPENTHREAD_EXAMPLES_NRF52840                                                           
+if OPENTHREAD_EXAMPLES_NRF52840
 libjlinkrtt_a_CPPFLAGS                                                                                 += \
     -DNRF52840_XXAA                                                                                       \
     -DSEGGER_RTT_CONFIG_H=\"$(top_srcdir)/third_party/NordicSemiconductor/segger_rtt/SEGGER_RTT_Conf.h\"  \
@@ -52,6 +52,16 @@ libjlinkrtt_a_CPPFLAGS                                                          
     -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/app_error                                   \
     -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk                                              \
     -I$(top_srcdir)/third_party/NordicSemiconductor/cmsis                                                 \
+    $(NULL)
+endif
+
+if OPENTHREAD_EXAMPLES_NRF52811
+libjlinkrtt_a_CPPFLAGS                                                                                 += \
+    -DNRF52811_XXAA                                                                                       \
+    -DSEGGER_RTT_CONFIG_H=\"$(top_srcdir)/third_party/NordicSemiconductor/segger_rtt/SEGGER_RTT_Conf.h\"  \
+    -I$(top_srcdir)/include                                                                               \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/dependencies                                          \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/app_error                                   \
     $(NULL)
 endif
 


### PR DESCRIPTION
This PR adds support for a new platform - nRF52811.

Additionally a small re-factorization of third party Nordic Semiconductor components have been made. It makes cleaner separation and also fixes `autotools` problem with `make distclean`. Funny fact, when two platforms include the same files (e.g. in third_party) in `Makefile.am`, `make distclean` removes *.Po files from them, when cleaning first platform and then it fails since it tries to remove the same *.Po files for the second platform.