### PR TITLE
[mac] use ot::Instance reference in scan callback handlers

### DIFF
--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -39,8 +39,8 @@
 
 using namespace ot;
 
-static void HandleActiveScanResult(void *aContext, Mac::Frame *aFrame);
-static void HandleEnergyScanResult(void *aContext, otEnergyScanResult *aResult);
+static void HandleActiveScanResult(Instance &aInstance, Mac::Frame *aFrame);
+static void HandleEnergyScanResult(Instance &aInstance, otEnergyScanResult *aResult);
 
 uint8_t otLinkGetChannel(otInstance *aInstance)
 {
@@ -367,8 +367,7 @@ otError otLinkActiveScan(otInstance *             aInstance,
     Instance &instance = *static_cast<Instance *>(aInstance);
 
     instance.RegisterActiveScanCallback(aCallback, aCallbackContext);
-    return instance.GetThreadNetif().GetMac().ActiveScan(aScanChannels, aScanDuration, &HandleActiveScanResult,
-                                                         aInstance);
+    return instance.GetThreadNetif().GetMac().ActiveScan(aScanChannels, aScanDuration, &HandleActiveScanResult);
 }
 
 bool otLinkIsActiveScanInProgress(otInstance *aInstance)
@@ -378,20 +377,18 @@ bool otLinkIsActiveScanInProgress(otInstance *aInstance)
     return instance.GetThreadNetif().GetMac().IsActiveScanInProgress();
 }
 
-void HandleActiveScanResult(void *aContext, Mac::Frame *aFrame)
+void HandleActiveScanResult(Instance &aInstance, Mac::Frame *aFrame)
 {
-    Instance &instance = *static_cast<Instance *>(aContext);
-
     if (aFrame == NULL)
     {
-        instance.InvokeActiveScanCallback(NULL);
+        aInstance.InvokeActiveScanCallback(NULL);
     }
     else
     {
         otActiveScanResult result;
 
-        instance.GetThreadNetif().GetMac().ConvertBeaconToActiveScanResult(aFrame, result);
-        instance.InvokeActiveScanCallback(&result);
+        aInstance.GetThreadNetif().GetMac().ConvertBeaconToActiveScanResult(aFrame, result);
+        aInstance.InvokeActiveScanCallback(&result);
     }
 }
 
@@ -404,15 +401,12 @@ otError otLinkEnergyScan(otInstance *             aInstance,
     Instance &instance = *static_cast<Instance *>(aInstance);
 
     instance.RegisterEnergyScanCallback(aCallback, aCallbackContext);
-    return instance.GetThreadNetif().GetMac().EnergyScan(aScanChannels, aScanDuration, &HandleEnergyScanResult,
-                                                         aInstance);
+    return instance.GetThreadNetif().GetMac().EnergyScan(aScanChannels, aScanDuration, &HandleEnergyScanResult);
 }
 
-void HandleEnergyScanResult(void *aContext, otEnergyScanResult *aResult)
+void HandleEnergyScanResult(Instance &aInstance, otEnergyScanResult *aResult)
 {
-    Instance &instance = *static_cast<Instance *>(aContext);
-
-    instance.InvokeEnergyScanCallback(aResult);
+    aInstance.InvokeEnergyScanCallback(aResult);
 }
 
 bool otLinkIsEnergyScanInProgress(otInstance *aInstance)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -115,11 +115,11 @@ public:
     /**
      * This function pointer is called on receiving an IEEE 802.15.4 Beacon during an Active Scan.
      *
-     * @param[in]  aContext       A pointer to arbitrary context information.
+     * @param[in]  aInstance      A reference to the OpenThread instance.
      * @param[in]  aBeaconFrame   A pointer to the Beacon frame or NULL to indicate end of Active Scan operation.
      *
      */
-    typedef void (*ActiveScanHandler)(void *aContext, Frame *aBeaconFrame);
+    typedef void (*ActiveScanHandler)(Instance &aInstance, Frame *aBeaconFrame);
 
     /**
      * This method starts an IEEE 802.15.4 Active Scan.
@@ -128,13 +128,12 @@ public:
      * @param[in]  aScanDuration  The time in milliseconds to spend scanning each channel. Zero duration maps to
      *                            default value `kScanDurationDefault` = 300 ms.
      * @param[in]  aHandler       A pointer to a function that is called on receiving an IEEE 802.15.4 Beacon.
-     * @param[in]  aContext       A pointer to arbitrary context information.
      *
      * @retval OT_ERROR_NONE  Successfully scheduled the Active Scan request.
      * @retval OT_ERROR_BUSY  Could not schedule the scan (a scan is ongoing or scheduled).
      *
      */
-    otError ActiveScan(uint32_t aScanChannels, uint16_t aScanDuration, ActiveScanHandler aHandler, void *aContext);
+    otError ActiveScan(uint32_t aScanChannels, uint16_t aScanDuration, ActiveScanHandler aHandler);
 
     /**
      * This method converts a beacon frame to an active scan result of type `otActiveScanResult`.
@@ -153,12 +152,12 @@ public:
      * This function pointer is called during an Energy Scan when the result for a channel is ready or the scan
      * completes.
      *
-     * @param[in]  aContext  A pointer to arbitrary context information.
+     * @param[in]  aInstance A reference to the OpenThread instance.
      * @param[in]  aResult   A valid pointer to the energy scan result information or NULL when the energy scan
      *                       completes.
      *
      */
-    typedef void (*EnergyScanHandler)(void *aContext, otEnergyScanResult *aResult);
+    typedef void (*EnergyScanHandler)(Instance &aInstance, otEnergyScanResult *aResult);
 
     /**
      * This method starts an IEEE 802.15.4 Energy Scan.
@@ -167,13 +166,12 @@ public:
      * @param[in]  aScanDuration     The time in milliseconds to spend scanning each channel. If the duration is set to
      *                               zero, a single RSSI sample will be taken per channel.
      * @param[in]  aHandler          A pointer to a function called to pass on scan result or indicate scan completion.
-     * @param[in]  aContext          A pointer to arbitrary context information.
      *
      * @retval OT_ERROR_NONE  Accepted the Energy Scan request.
      * @retval OT_ERROR_BUSY  Could not start the energy scan.
      *
      */
-    otError EnergyScan(uint32_t aScanChannels, uint16_t aScanDuration, EnergyScanHandler aHandler, void *aContext);
+    otError EnergyScan(uint32_t aScanChannels, uint16_t aScanDuration, EnergyScanHandler aHandler);
 
     /**
      * This method indicates the energy scan for the current channel is complete.
@@ -641,7 +639,7 @@ private:
     void        HandleTimer(void);
     static void HandleOperationTask(Tasklet &aTasklet);
 
-    void    Scan(Operation aScanOperation, uint32_t aScanChannels, uint16_t aScanDuration, void *aContext);
+    void    Scan(Operation aScanOperation, uint32_t aScanChannels, uint16_t aScanDuration);
     otError UpdateScanChannel(void);
     void    PerformActiveScan(void);
     void    PerformEnergyScan(void);
@@ -687,7 +685,6 @@ private:
     uint8_t         mScanChannel;
     uint16_t        mScanDuration;
     ChannelMask     mScanChannelMask;
-    void *          mScanContext;
     union
     {
         ActiveScanHandler mActiveScanHandler;

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -128,7 +128,7 @@ void EnergyScanServer::HandleTimer(void)
     {
         // grab the lowest channel to scan
         uint32_t channelMask = mChannelMaskCurrent & ~(mChannelMaskCurrent - 1);
-        GetNetif().GetMac().EnergyScan(channelMask, mScanDuration, HandleScanResult, this);
+        GetNetif().GetMac().EnergyScan(channelMask, mScanDuration, HandleScanResult);
     }
     else
     {
@@ -139,9 +139,9 @@ exit:
     return;
 }
 
-void EnergyScanServer::HandleScanResult(void *aContext, otEnergyScanResult *aResult)
+void EnergyScanServer::HandleScanResult(Instance &aInstance, otEnergyScanResult *aResult)
 {
-    static_cast<EnergyScanServer *>(aContext)->HandleScanResult(aResult);
+    aInstance.Get<EnergyScanServer>().HandleScanResult(aResult);
 }
 
 void EnergyScanServer::HandleScanResult(otEnergyScanResult *aResult)

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -69,7 +69,7 @@ private:
     static void HandleRequest(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleRequest(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleScanResult(void *aContext, otEnergyScanResult *aResult);
+    static void HandleScanResult(Instance &aInstance, otEnergyScanResult *aResult);
     void        HandleScanResult(otEnergyScanResult *aResult);
 
     static void HandleTimer(Timer &aTimer);

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -95,9 +95,9 @@ exit:
     return;
 }
 
-void PanIdQueryServer::HandleScanResult(void *aContext, Mac::Frame *aFrame)
+void PanIdQueryServer::HandleScanResult(Instance &aInstance, Mac::Frame *aFrame)
 {
-    static_cast<PanIdQueryServer *>(aContext)->HandleScanResult(aFrame);
+    aInstance.Get<PanIdQueryServer>().HandleScanResult(aFrame);
 }
 
 void PanIdQueryServer::HandleScanResult(Mac::Frame *aFrame)
@@ -168,7 +168,7 @@ void PanIdQueryServer::HandleTimer(Timer &aTimer)
 
 void PanIdQueryServer::HandleTimer(void)
 {
-    GetNetif().GetMac().ActiveScan(mChannelMask, 0, HandleScanResult, this);
+    GetNetif().GetMac().ActiveScan(mChannelMask, 0, HandleScanResult);
     mChannelMask = 0;
 }
 

--- a/src/core/thread/panid_query_server.hpp
+++ b/src/core/thread/panid_query_server.hpp
@@ -66,7 +66,7 @@ private:
     static void HandleQuery(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleQuery(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleScanResult(void *aContext, Mac::Frame *aFrame);
+    static void HandleScanResult(Instance &aInstance, Mac::Frame *aFrame);
     void        HandleScanResult(Mac::Frame *aFrame);
 
     static void HandleTimer(Timer &aTimer);

--- a/src/core/utils/channel_monitor.cpp
+++ b/src/core/utils/channel_monitor.cpp
@@ -112,14 +112,14 @@ void ChannelMonitor::HandleTimer(Timer &aTimer)
 void ChannelMonitor::HandleTimer(void)
 {
     GetInstance().Get<Mac::Mac>().EnergyScan(mScanChannelMasks[mChannelMaskIndex], 0,
-                                             &ChannelMonitor::HandleEnergyScanResult, this);
+                                             &ChannelMonitor::HandleEnergyScanResult);
 
     mTimer.StartAt(mTimer.GetFireTime(), Random::AddJitter(kTimerInterval, kMaxJitterInterval));
 }
 
-void ChannelMonitor::HandleEnergyScanResult(void *aContext, otEnergyScanResult *aResult)
+void ChannelMonitor::HandleEnergyScanResult(Instance &aInstance, otEnergyScanResult *aResult)
 {
-    static_cast<ChannelMonitor *>(aContext)->HandleEnergyScanResult(aResult);
+    aInstance.Get<ChannelMonitor>().HandleEnergyScanResult(aResult);
 }
 
 void ChannelMonitor::HandleEnergyScanResult(otEnergyScanResult *aResult)

--- a/src/core/utils/channel_monitor.hpp
+++ b/src/core/utils/channel_monitor.hpp
@@ -195,7 +195,7 @@ private:
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
-    static void HandleEnergyScanResult(void *aContext, otEnergyScanResult *aResult);
+    static void HandleEnergyScanResult(Instance &aInstance, otEnergyScanResult *aResult);
     void        HandleEnergyScanResult(otEnergyScanResult *aResult);
     void        LogResults(void);
 


### PR DESCRIPTION
This commit changes the scan callback handlers to use `ot::Instance`
as a parameter replacing a given `void *` context.