### PR TITLE
[mbedtls] guard allocator with accurate macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -434,8 +434,16 @@ if test "$enable_builtin_mbedtls" = "yes" -a ! "${MBEDTLS_CPPFLAGS}"; then
     MBEDTLS_CPPFLAGS="${MBEDTLS_CPPFLAGS} -I\${abs_top_srcdir}/third_party/mbedtls/repo/include"
     MBEDTLS_CPPFLAGS="${MBEDTLS_CPPFLAGS} -DMBEDTLS_CONFIG_FILE=\\\"mbedtls-config.h\\\""
 fi
+
+if test "$enable_builtin_mbedtls" = "yes"; then
+    OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS=1
+else
+    OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS=0
+fi
+
 AC_MSG_CHECKING([whether mbed TLS should be enabled])
 AC_MSG_RESULT(${enable_builtin_mbedtls})
+AC_DEFINE_UNQUOTED([OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS], [${OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS}], [Define to 1 if you want to enable support for bultin-mbedtls.])
 AM_CONDITIONAL([OPENTHREAD_ENABLE_BUILTIN_MBEDTLS], [test "${enable_builtin_mbedtls}" = "yes"])
 
 #

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -430,7 +430,7 @@ private:
     Settings mSettings;
 
 #if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-#if !OPENTHREAD_CONFIG_DISABLE_MBEDTLS_MEMORY_ALLOCATOR
+#if OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS
     Crypto::MbedTls mMbedTls;
 #endif
     Utils::Heap mHeap;

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -430,8 +430,10 @@ private:
     Settings mSettings;
 
 #if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+#if !OPENTHREAD_CONFIG_DISABLE_MBEDTLS_MEMORY_ALLOCATOR
     Crypto::MbedTls mMbedTls;
-    Utils::Heap     mHeap;
+#endif
+    Utils::Heap mHeap;
 #endif
 
     Ip6::Ip6    mIp6;

--- a/src/core/crypto/mbedtls.cpp
+++ b/src/core/crypto/mbedtls.cpp
@@ -42,6 +42,7 @@
 namespace ot {
 namespace Crypto {
 
+#ifdef MBEDTLS_MEMORY_BUFFER_ALLOC_C
 static void *CAlloc(size_t aCount, size_t aSize)
 {
     return Instance::Get().GetHeap().CAlloc(aCount, aSize);
@@ -51,10 +52,13 @@ static void Free(void *aPointer)
 {
     Instance::Get().GetHeap().Free(aPointer);
 }
+#endif // MBEDTLS_MEMORY_BUFFER_ALLOC_C
 
 MbedTls::MbedTls(void)
 {
+#ifdef MBEDTLS_MEMORY_BUFFER_ALLOC_C
     mbedtls_platform_set_calloc_free(CAlloc, Free);
+#endif
 }
 
 } // namespace Crypto

--- a/src/core/crypto/mbedtls.cpp
+++ b/src/core/crypto/mbedtls.cpp
@@ -37,7 +37,7 @@
 
 #include "common/instance.hpp"
 
-#if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES && !OPENTHREAD_CONFIG_DISABLE_MBEDTLS_MEMORY_ALLOCATOR
+#if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES && OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS
 
 namespace ot {
 namespace Crypto {
@@ -54,10 +54,14 @@ static void Free(void *aPointer)
 
 MbedTls::MbedTls(void)
 {
+#ifdef MBEDTLS_DEBUG_C
+    // mbedTLS's debug level is almost the same as OpenThread's
+    mbedtls_debug_set_threshold(OPENTHREAD_CONFIG_LOG_LEVEL);
+#endif
     mbedtls_platform_set_calloc_free(CAlloc, Free);
 }
 
 } // namespace Crypto
 } // namespace ot
 
-#endif // #if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES && !OPENTHREAD_CONFIG_DISABLE_MBEDTLS_MEMORY_ALLOCATOR
+#endif // !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES && OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS

--- a/src/core/crypto/mbedtls.cpp
+++ b/src/core/crypto/mbedtls.cpp
@@ -37,12 +37,11 @@
 
 #include "common/instance.hpp"
 
-#if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+#if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES && !OPENTHREAD_CONFIG_DISABLE_MBEDTLS_MEMORY_ALLOCATOR
 
 namespace ot {
 namespace Crypto {
 
-#ifdef MBEDTLS_MEMORY_BUFFER_ALLOC_C
 static void *CAlloc(size_t aCount, size_t aSize)
 {
     return Instance::Get().GetHeap().CAlloc(aCount, aSize);
@@ -52,16 +51,13 @@ static void Free(void *aPointer)
 {
     Instance::Get().GetHeap().Free(aPointer);
 }
-#endif // MBEDTLS_MEMORY_BUFFER_ALLOC_C
 
 MbedTls::MbedTls(void)
 {
-#ifdef MBEDTLS_MEMORY_BUFFER_ALLOC_C
     mbedtls_platform_set_calloc_free(CAlloc, Free);
-#endif
 }
 
 } // namespace Crypto
 } // namespace ot
 
-#endif // #if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+#endif // #if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES && !OPENTHREAD_CONFIG_DISABLE_MBEDTLS_MEMORY_ALLOCATOR

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -176,11 +176,6 @@ otError Dtls::Start(bool             aClient,
                                       MBEDTLS_ENTROPY_SOURCE_STRONG);
     VerifyOrExit(rval == 0);
 
-#ifdef MBEDTLS_DEBUG_C
-    // mbedTLS's debug level is almost the same as OpenThread's
-    mbedtls_debug_set_threshold(OPENTHREAD_CONFIG_LOG_LEVEL);
-#endif
-
     {
         otExtAddress eui64;
         otPlatRadioGetIeeeEui64(&GetInstance(), eui64.m8);

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -340,16 +340,6 @@
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_DISABLE_MBEDTLS_MEMORY_ALLOCATOR
- *
- * Whether to disable the OpenThread's memory allocator for mbedTLS.
- *
- */
-#ifndef OPENTHREAD_CONFIG_DISABLE_MBEDTLS_MEMORY_ALLOCATOR
-#define OPENTHREAD_CONFIG_DISABLE_MBEDTLS_MEMORY_ALLOCATOR 0
-#endif
-
-/**
  * @def OPENTHREAD_CONFIG_IP_ADDRS_PER_CHILD
  *
  * The maximum number of supported IPv6 address registrations per child.
@@ -687,6 +677,19 @@
  */
 #ifndef OPENTHREAD_CONFIG_LOG_LEVEL
 #define OPENTHREAD_CONFIG_LOG_LEVEL OT_LOG_LEVEL_CRIT
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS
+ *
+ * Define as 1 to enable bultin-mbedtls.
+ *
+ * Note that the OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS determines whether to use bultin-mbedtls as well as
+ * whether to manage mbedTLS internally, such as memory allocation and debug.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS
+#define OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS 1
 #endif
 
 /**

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -340,6 +340,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_DISABLE_MBEDTLS_MEMORY_ALLOCATOR
+ *
+ * Whether to disable the OpenThread's memory allocator for mbedTLS.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_DISABLE_MBEDTLS_MEMORY_ALLOCATOR
+#define OPENTHREAD_CONFIG_DISABLE_MBEDTLS_MEMORY_ALLOCATOR 0
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_IP_ADDRS_PER_CHILD
  *
  * The maximum number of supported IPv6 address registrations per child.


### PR DESCRIPTION
This PR guard using mbedTLS's buffer allocator API with a more accurate
macro, so that even in single instance mode, we can use other memory
allocator.