### PR TITLE
[posix-app] fix write in daemon mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,9 @@ matrix:
     - env: BUILD_TARGET="posix-app-pty" VERBOSE=1
       os: linux
       compiler: gcc
+    - env: BUILD_TARGET="posix-app-pty" VERBOSE=1 DAEMON=1
+      os: linux
+      compiler: gcc
     - env: BUILD_TARGET="android-build" VERBOSE=1
       os: linux
       python: "2.7"

--- a/.travis/check-posix-app-pty
+++ b/.travis/check-posix-app-pty
@@ -39,13 +39,14 @@ at_exit() {
     EXIT_CODE=$?
 
     sudo killall expect || true
+    killall ot-ctl || true
+    killall ot-daemon || true
     killall socat || true
 
     exit $EXIT_CODE
 }
 
 build() {
-    ./bootstrap
     COVERAGE=1 make -f examples/Makefile-posix
     COVERAGE=1 make -f src/posix/Makefile-posix PLATFORM_NETIF=1 PLATFORM_UDP=1
 }
@@ -70,9 +71,17 @@ check() {
 
     RADIO_NCP_PATH="$(pwd)/$(ls output/*linux*/bin/ot-ncp-radio)"
     $RADIO_NCP_PATH 1 > $RADIO_PTY < $RADIO_PTY &
-    OT_CLI_PATH="$(pwd)/$(ls output/posix/*linux*/bin/ot-cli)"
-    sudo expect <<EOF > $OT_OUTPUT &
-spawn $OT_CLI_PATH ${OT_NCP_PATH} ${CORE_PTY}
+
+    if [[ "${DAEMON}" = 1 ]]; then
+        sudo "$(pwd)/$(ls output/posix/*linux*/bin/ot-daemon)" ${OT_NCP_PATH} ${CORE_PTY} &
+        sleep 1
+        OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-ctl)"
+    else
+        OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-cli) ${OT_NCP_PATH} ${CORE_PTY}"
+    fi
+
+    sudo expect <<EOF > "${OT_OUTPUT}" &
+spawn ${OT_CLI_CMD}
 send "panid 0xface\r\n"
 expect "Done"
 send "ifconfig up\r\n"

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -596,6 +596,7 @@ python --version || die
 }
 
 [ $BUILD_TARGET != posix-app-pty ] || {
+    ./bootstrap
     .travis/check-posix-app-pty || die
 }
 

--- a/src/posix/platform/misc.c
+++ b/src/posix/platform/misc.c
@@ -48,7 +48,6 @@ void otPlatReset(otInstance *aInstance)
     OT_UNUSED_VARIABLE(aInstance);
 
     otSysDeinit();
-    platformUartRestore();
 
     longjmp(gResetJump, 1);
     assert(false);

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -264,12 +264,6 @@ void platformNetifUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, fd_set *a
 void platformNetifProcess(const fd_set *aReadFdSet, const fd_set *aWriteFdSet, const fd_set *aErrorFdSet);
 
 /**
- * This function restores the Uart.
- *
- */
-void platformUartRestore(void);
-
-/**
  * This function initialize simulation.
  *
  */


### PR DESCRIPTION
In daemon mode, UART write should be processed even when no client
is connected. This PR writes UART to STDERR in such situation.

* add test for daemon mode
* remove useless code for UART restore
* fix a typo of assert
* set FD_CLOEXEC flag to better support reset.