### PR TITLE
[tests] fix wrong test class name of cert_9_2_04

### DIFF
--- a/tests/scripts/thread-cert/Cert_9_2_04_ActiveDataset.py
+++ b/tests/scripts/thread-cert/Cert_9_2_04_ActiveDataset.py
@@ -36,7 +36,7 @@ import node
 COMMISSIONER = 1
 LEADER = 2
 
-class Cert_9_2_15_PendingPartition(unittest.TestCase):
+class Cert_9_2_04_ActiveDataset(unittest.TestCase):
     def setUp(self):
         self.simulator = config.create_default_simulator()
 


### PR DESCRIPTION
This PR fix the wrong test class name of `cert_9_2_04_ActiveDataset`.