### PR TITLE
[build] don't define UINT32_MAX for C

### DIFF
--- a/include/openthread/platform/toolchain.h
+++ b/include/openthread/platform/toolchain.h
@@ -303,12 +303,14 @@ extern "C" {
 /*
  * Keil and IAR compiler doesn't provide type limits for C++.
  */
+#ifdef __cplusplus
 #if defined(__CC_ARM) || defined(__ICCARM__)
 
 #ifndef UINT32_MAX
 #define UINT32_MAX 0xffffffff
 #endif
 
+#endif
 #endif
 
 /**


### PR DESCRIPTION
As comment suggests we should define UINT32_MAX here only for C++.