### PR TITLE
[ip6] messages sent to Service Locator will not be filtered out

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -701,9 +701,10 @@ otError Ip6::ProcessReceiveCallback(const Message &    aMessage,
 
     if (mIsReceiveIp6FilterEnabled)
     {
-        // do not pass messages sent to an RLOC/ALOC
-        VerifyOrExit(!aMessageInfo.GetSockAddr().IsRoutingLocator() &&
-                         !aMessageInfo.GetSockAddr().IsAnycastRoutingLocator(),
+        // do not pass messages sent to an RLOC/ALOC, except Service Locator
+        VerifyOrExit((!aMessageInfo.GetSockAddr().IsRoutingLocator() &&
+                      !aMessageInfo.GetSockAddr().IsAnycastRoutingLocator()) ||
+                     aMessageInfo.GetSockAddr().IsAnycastServiceLocator(),
                      error = OT_ERROR_NO_ROUTE);
 
         switch (aIpProto)

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -702,10 +702,10 @@ otError Ip6::ProcessReceiveCallback(const Message &    aMessage,
     if (mIsReceiveIp6FilterEnabled)
     {
         // do not pass messages sent to an RLOC/ALOC, except Service Locator
-        VerifyOrExit((!aMessageInfo.GetSockAddr().IsRoutingLocator() &&
-                      !aMessageInfo.GetSockAddr().IsAnycastRoutingLocator()) ||
-                     aMessageInfo.GetSockAddr().IsAnycastServiceLocator(),
-                     error = OT_ERROR_NO_ROUTE);
+        VerifyOrExit(
+            (!aMessageInfo.GetSockAddr().IsRoutingLocator() && !aMessageInfo.GetSockAddr().IsAnycastRoutingLocator()) ||
+                aMessageInfo.GetSockAddr().IsAnycastServiceLocator(),
+            error = OT_ERROR_NO_ROUTE);
 
         switch (aIpProto)
         {

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -130,6 +130,11 @@ bool Address::IsAnycastRoutingLocator(void) const
             mFields.m16[6] == HostSwap16(0xfe00) && mFields.m8[14] == kAloc16Mask);
 }
 
+bool Address::IsAnycastServiceLocator(void) const
+{
+    return IsAnycastRoutingLocator() && (mFields.m16[7] >= HostSwap16(Mle::kAloc16ServiceStart)) && (mFields.m16[7] <= HostSwap16(Mle::kAloc16ServiceEnd));
+}
+
 bool Address::IsSubnetRouterAnycast(void) const
 {
     return (mFields.m32[2] == 0 && mFields.m32[3] == 0);

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -132,7 +132,8 @@ bool Address::IsAnycastRoutingLocator(void) const
 
 bool Address::IsAnycastServiceLocator(void) const
 {
-    return IsAnycastRoutingLocator() && (mFields.m16[7] >= HostSwap16(Mle::kAloc16ServiceStart)) && (mFields.m16[7] <= HostSwap16(Mle::kAloc16ServiceEnd));
+    return IsAnycastRoutingLocator() && (mFields.m16[7] >= HostSwap16(Mle::kAloc16ServiceStart)) &&
+           (mFields.m16[7] <= HostSwap16(Mle::kAloc16ServiceEnd));
 }
 
 bool Address::IsSubnetRouterAnycast(void) const

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -244,6 +244,15 @@ public:
     bool IsAnycastRoutingLocator(void) const;
 
     /**
+     * This method indicates whether or not the IPv6 address is an Anycast Service Locator.
+     *
+     * @retval TRUE   If the IPv6 address is an Anycast Service Locator.
+     * @retval FALSE  If the IPv6 address is not an Anycast Service Locator.
+     *
+     */
+    bool IsAnycastServiceLocator(void) const;
+
+    /**
      * This method indicates whether or not the IPv6 address is Subnet-Router Anycast (RFC 4291),
      *
      * @retval TRUE   If the IPv6 address is a Subnet-Router Anycast address.


### PR DESCRIPTION
Messages sent to Service Locator will not be filtered out, when thread
control traffic filtering is enabled via SetReceiveIp6FilterEnabled().

This PR is related to issue:
https://github.com/openthread/openthread/issues/3582