### PR TITLE
[mpl] fix inserting mechanism and timer handling

### DIFF
--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -209,7 +209,7 @@ otError Mpl::UpdateSeedSet(uint16_t aSeedId, uint8_t aSequence)
     if (evict > insert)
     {
         assert(insert >= mSeedSet);
-        memmove(insert, insert + 1, static_cast<size_t>(evict - insert) * sizeof(MplSeedEntry));
+        memmove(insert + 1, insert, static_cast<size_t>(evict - insert) * sizeof(MplSeedEntry));
     }
     else if (evict < insert)
     {
@@ -221,7 +221,11 @@ otError Mpl::UpdateSeedSet(uint16_t aSeedId, uint8_t aSequence)
     insert->SetSeedId(aSeedId);
     insert->SetSequence(aSequence);
     insert->SetLifetime(kSeedEntryLifetime);
-    mSeedSetTimer.Start(kSeedEntryLifetimeDt);
+
+    if (!mSeedSetTimer.IsRunning())
+    {
+        mSeedSetTimer.Start(kSeedEntryLifetimeDt);
+    }
 
 exit:
     return error;


### PR DESCRIPTION
The #3557 greatly improved the MPL performance. However, while looking at logs from our stress tests where multiple nodes ping each other using ff03::1 address I spotted that nodes very rarely receive more Echo Responses for single Echo Request that they should. In short, something is wrong with de-duplication mechanism.

I think i found three problems, however, this PR tries to address only two.

1. With hundreds of MPL messages sent over the air, I spotted that the default timeout of 5 seconds for removing the MPL entry does not work as it should. The issue was related to not checking the `mSeedSetTimer` status and starting it again before it has a chance to fire. This code is inherited from the last implementation, although it leads to different behavior now.

2. While debugging de-duplication algorithm, I found out this scenario (below prints from `mSeedSet`):

```
ID | SeedID  | Seq
---|---------|-----
0  | 0xe800  | 34
1  | 0xe800  | 35
2  | 0xe800  | 36
3  | 0x8c00  | 26
4  | 0x8c00  | 29
5  | 0x8c00  | 38
6  | 0xc800  | 33
7  | 0xc800  | 44
8  | 0xc00   | 27
```

After receiving MPL message from Seed 0xc800 the last entry has been removed.

```
ID | SeedID | Seq
---|--------|-----
0  | 0xe800 | 34
1  | 0xe800 | 35
2  | 0xe800 | 36
3  | 0x8c00 | 26
4  | 0x8c00 | 29
5  | 0x8c00 | 38
6  | 0xc800 | 33
7  | 0xc800 | 44
8  | 0xc800 | 46
```

If I didn't miss any special case this PR should fix this issue too.

3. There is one strange behaviour which I'm not sure how to address (maybe its a valid behaviour). But there is some problem when sequence number wrapping around from 255 to 0+. In dense network where multiple MPL entries are stored in `mSeedSet` it sometimes causes block of MPL messages for up to 5 seconds or some strange `mSeedSet` modification that leads to incorect de-duplication mechanism (i have feeling that bad entries are evicted - the newer ones but with smaller sequence - but I don't have hard proof :smile:).