### PR TITLE
[mpl] fix bug in comparing sequence numbers

### DIFF
--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -158,12 +158,14 @@ otError Mpl::UpdateSeedSet(uint16_t aSeedId, uint8_t aSequence)
         {
             // have existing entries for aSeedId
 
-            if (aSequence == mSeedSet[i].GetSequence())
+            int8_t diff = static_cast<int8_t>(aSequence - mSeedSet[i].GetSequence());
+
+            if (diff == 0)
             {
                 // already received, drop message
                 ExitNow(error = OT_ERROR_DROP);
             }
-            else if (insert == NULL && aSequence < mSeedSet[i].GetSequence())
+            else if (insert == NULL && diff < 0)
             {
                 // insert in order of sequence
                 insert = &mSeedSet[i];


### PR DESCRIPTION
Fix serial number arithmetic due to value wrap.

Credit to @LuDuda for finding the issue (see #3587).