### PR TITLE
[nrf528xx] always enable diag module

### DIFF
--- a/examples/Makefile-nrf52811
+++ b/examples/Makefile-nrf52811
@@ -44,6 +44,7 @@ GCCVersion                      = $(shell expr `$(CC) -dumpversion | cut -f1 -d.
 
 configure_OPTIONS                                 = \
     --enable-mtd                                    \
+    --enable-diag                                   \
     --enable-linker-map                             \
     --with-examples=nrf52811                        \
     MBEDTLS_CPPFLAGS="$(NRF52811_MBEDTLS_CPPFLAGS)" \
@@ -105,7 +106,6 @@ configure_OPTIONS              += --with-ncp-bus=spi
 else
 COMMONCFLAGS                   += -DUART_AS_SERIAL_TRANSPORT=1
 configure_OPTIONS              += --with-ncp-bus=uart
-configure_OPTIONS              += --enable-diag
 configure_OPTIONS              += --enable-cli
 endif # NCP_SPI == 1
 endif # DISABLE_TRANSPORTS

--- a/examples/Makefile-nrf52840
+++ b/examples/Makefile-nrf52840
@@ -45,6 +45,7 @@ GCCVersion                      = $(shell expr `$(CC) -dumpversion | cut -f1 -d.
 configure_OPTIONS                                 = \
     --enable-ftd                                    \
     --enable-mtd                                    \
+    --enable-diag                                   \
     --enable-linker-map                             \
     --with-examples=nrf52840                        \
     $(NULL)
@@ -110,7 +111,6 @@ COMMONCFLAGS                   += -DSPIS_AS_SERIAL_TRANSPORT=1
 configure_OPTIONS              += --with-ncp-bus=spi
 else
 configure_OPTIONS              += --with-ncp-bus=uart
-configure_OPTIONS              += --enable-diag
 configure_OPTIONS              += --enable-cli
 ifeq ($(USB),1)
 COMMONCFLAGS                   += -DUSB_CDC_AS_SERIAL_TRANSPORT=1


### PR DESCRIPTION
Disabling diag module causes linker errors due to unresolved symbols when building NCP example with NCP_SPI flag set to 1 on some toolchains.