### PR TITLE
[efr32] update to Silicon Labs Flex SDK v2.5

### DIFF
--- a/examples/Makefile-efr32
+++ b/examples/Makefile-efr32
@@ -91,11 +91,12 @@ EFR32_MBEDTLS_CPPFLAGS  = -DMBEDTLS_CONFIG_FILE='\"mbedtls-config.h\"'
 EFR32_MBEDTLS_CPPFLAGS += -DMBEDTLS_USER_CONFIG_FILE='\"efr32-mbedtls-config.h\"'
 EFR32_MBEDTLS_CPPFLAGS += -D$(MCU)
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/examples/platforms/efr32/crypto
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.3/util/third_party/mbedtls/configs
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.3/platform/CMSIS/Include
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.3/util/third_party/mbedtls/sl_crypto/include
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.3/platform/Device/SiliconLabs/EFR32MG12P/Include
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.3/platform/emlib/inc
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.5/util/third_party/mbedtls/configs
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.5/platform/CMSIS/Include
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.5/util/third_party/mbedtls/sl_crypto/include
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.5/platform/Device/SiliconLabs/EFR32MG12P/Include
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.5/platform/emlib/inc
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.5/platform/radio/rail_lib/chip/efr32/efr32xg1x
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls/repo/include
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls/repo/include/mbedtls

--- a/examples/platforms/efr32/Makefile.am
+++ b/examples/platforms/efr32/Makefile.am
@@ -40,7 +40,7 @@ override CXXFLAGS                            := $(filter-out -pedantic-errors,$(
 
 EFR32_BOARD_DIR                               = $(shell echo $(BOARD) | tr A-Z a-z)
 
-EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.3
+EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.5
 
 libopenthread_efr32_a_CPPFLAGS                                                = \
     -D__START=main                                                              \
@@ -73,6 +73,7 @@ libopenthread_efr32_a_CPPFLAGS                                                = 
     -I$(EFR32MG_SDK_SRCDIR)/platform/halconfig/inc/hal-config                   \
     -I$(EFR32MG_SDK_SRCDIR)/util/plugin/plugin-common/fem-control               \
     -Wno-unused-parameter                                                       \
+    -Wno-missing-field-initializers                                             \
     $(NULL)
 
 PLATFORM_SOURCES                                                              = \
@@ -91,37 +92,37 @@ PLATFORM_SOURCES                                                              = 
 
 nodist_libopenthread_efr32_a_SOURCES                                                                                           =  \
     @top_builddir@/third_party/silabs/rail_config/rail_config.c                                                                   \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/hardware/kit/common/bsp/bsp_bcc.c                                      \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/hardware/kit/common/bsp/bsp_init.c                                     \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/hardware/kit/common/bsp/bsp_stk.c                                      \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/hardware/kit/common/bsp/bsp_stk_leds.c                                 \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/Device/SiliconLabs/EFR32MG12P/Source/system_efr32mg12p.c      \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/Device/SiliconLabs/EFR32MG12P/Source/GCC/startup_efr32mg12p.c \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emdrv/dmadrv/src/dmadrv.c                                     \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emdrv/gpiointerrupt/src/gpiointerrupt.c                       \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emdrv/rtcdrv/src/rtcdriver.c                                  \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emdrv/uartdrv/src/uartdrv.c                                   \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emdrv/ustimer/src/ustimer.c                                   \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emlib/src/em_adc.c                                            \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emlib/src/em_cmu.c                                            \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emlib/src/em_core.c                                           \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emlib/src/em_crypto.c                                         \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emlib/src/em_emu.c                                            \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emlib/src/em_gpio.c                                           \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emlib/src/em_ldma.c                                           \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emlib/src/em_leuart.c                                         \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emlib/src/em_msc.c                                            \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emlib/src/em_rmu.c                                            \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emlib/src/em_rtcc.c                                           \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emlib/src/em_system.c                                         \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emlib/src/em_timer.c                                          \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/emlib/src/em_usart.c                                          \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/radio/rail_lib/hal/efr32/hal_efr.c                            \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/platform/radio/rail_lib/hal/hal_common.c                               \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/util/third_party/mbedtls/library/ecp.c                                 \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/util/third_party/mbedtls/sl_crypto/src/crypto_aes.c                    \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/util/third_party/mbedtls/sl_crypto/src/crypto_ecp.c                    \
-    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.3/util/third_party/mbedtls/sl_crypto/src/crypto_management.c             \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/hardware/kit/common/bsp/bsp_bcc.c                                      \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/hardware/kit/common/bsp/bsp_init.c                                     \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/hardware/kit/common/bsp/bsp_stk.c                                      \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/hardware/kit/common/bsp/bsp_stk_leds.c                                 \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/Device/SiliconLabs/EFR32MG12P/Source/system_efr32mg12p.c      \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/Device/SiliconLabs/EFR32MG12P/Source/GCC/startup_efr32mg12p.c \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emdrv/dmadrv/src/dmadrv.c                                     \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emdrv/gpiointerrupt/src/gpiointerrupt.c                       \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emdrv/rtcdrv/src/rtcdriver.c                                  \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emdrv/uartdrv/src/uartdrv.c                                   \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emdrv/ustimer/src/ustimer.c                                   \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emlib/src/em_adc.c                                            \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emlib/src/em_cmu.c                                            \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emlib/src/em_core.c                                           \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emlib/src/em_crypto.c                                         \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emlib/src/em_emu.c                                            \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emlib/src/em_gpio.c                                           \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emlib/src/em_ldma.c                                           \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emlib/src/em_leuart.c                                         \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emlib/src/em_msc.c                                            \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emlib/src/em_rmu.c                                            \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emlib/src/em_rtcc.c                                           \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emlib/src/em_system.c                                         \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emlib/src/em_timer.c                                          \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/emlib/src/em_usart.c                                          \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/radio/rail_lib/hal/efr32/hal_efr.c                            \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/platform/radio/rail_lib/hal/hal_common.c                               \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/util/third_party/mbedtls/library/ecp.c                                 \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/util/third_party/mbedtls/sl_crypto/src/crypto_aes.c                    \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/util/third_party/mbedtls/sl_crypto/src/crypto_ecp.c                    \
+    @top_builddir@/third_party/silabs/gecko_sdk_suite/v2.5/util/third_party/mbedtls/sl_crypto/src/crypto_management.c             \
     $(NULL)
 
 noinst_HEADERS                                                                = \

--- a/examples/platforms/efr32/Makefile.platform.am
+++ b/examples/platforms/efr32/Makefile.platform.am
@@ -32,9 +32,9 @@
 
 LDADD_COMMON                                                          += \
     $(top_builddir)/examples/platforms/efr32/libopenthread-efr32.a       \
-    $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.3/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg12_gcc_release.a \
+    $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.5/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg12_gcc_release.a \
     $(NULL)
 
 LDFLAGS_COMMON                                                        += \
-    -T $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.3/platform/Device/SiliconLabs/EFR32MG12P/Source/GCC/efr32mg12p.ld \
+    -T $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.5/platform/Device/SiliconLabs/EFR32MG12P/Source/GCC/efr32mg12p.ld \
     $(NULL)

--- a/examples/platforms/efr32/README.md
+++ b/examples/platforms/efr32/README.md
@@ -37,8 +37,8 @@ $ ./script/bootstrap
 
 2. Install Flex (Gecko) SDK including RAIL Library from Simplicity Studio.
    - Connect EFR32MG12P Wireless Starter Kit to Simplicity Studio.
-   - Find Flex SDK v2.3 in the Software Update page and click Install.
-   - Flex SDK v2.3 will be installed in the path: `/SimplicityStudio_v4/developer/sdks/gecko_sdk_suite`.
+   - Find Flex SDK v2.5 in the Software Update page and click Install.
+   - Flex SDK v2.5 will be installed in the path: `/SimplicityStudio_v4/developer/sdks/gecko_sdk_suite`.
 
 For more information on configuring, building, and installing applications for the Wireless Gecko (EFR32)
 portfolio using RAIL, see [Getting Started with RAIL Library quick start guide][QSG121]. For more information
@@ -53,6 +53,13 @@ $ cd <path-to-openthread>/third_party
 $ mkdir silabs
 $ cd <path-to-Simplicity-Studio>/developer/sdks
 $ cp -rf gecko_sdk_suite <path-to-openthread>/third_party/silabs/
+```
+
+Alternatively create a symbolic link to the Flex SDK source code.
+```bash
+$ cd <path-to-openthread>/third_party
+$ mkdir silabs
+$ ln -s <path-to-Simplicity-Studio>/developer/sdks/gecko_sdk_suite silabs/gecko_sdk_suite
 ```
 
 4. Build OpenThread Firmware (CLI example) on EFR32 platform.
@@ -93,9 +100,8 @@ $ (gdb) c
 
 Note: Support for the "EFR32MG12PxxxF1024" device was added to JLinkGDBServer V6.14d.
 
-Or
-
-Compiled binaries also may be flashed onto the specified EFR32 dev borad using [J-Link Commander][j-link-commander].
+Or 
+Compiled binaries also may be flashed onto the specified EFR32 dev board using [J-Link Commander][j-link-commander].
 
 [j-link-commander]: https://www.segger.com/products/debug-probes/j-link/tools/j-link-commander/
 
@@ -113,6 +119,20 @@ Note: SerialNo is J-Link serial number. Use the following command to get the ser
 ```bash
 $ JLinkExe
 ```
+
+Alternatively Simplicity Commander provides a graphical interface for J-Link Commander.
+
+```bash
+$ cd <path-to-openthread>/output/efr32/bin
+$ arm-none-eabi-objcopy -O ihex ot-cli-ftd ot-cli-ftd.ihex
+$ <path-to-simplicity-studio>/developer/adapter_packs/commander/commander
+```
+
+In the J-Link Device drop-down list select the serial number of the device to flash.  Click the Adapter Connect button.
+Esnure the Debug Interface drop-down list is set to SWD and click the Target Connect button.
+Click on the Flash icon on the left side of the window to switch to the flash page.
+In the Flash MCU pane enter the path of the ot-cli-ftd.s37 file or choose the file with the Browse... button.
+Click the Flash button located under the Browse... button.
 
 ## Run the example with EFR32 boards
 1. Flash two EFR32 boards with the `CLI example` firmware (as shown above).
@@ -220,8 +240,7 @@ For a list of all available commands, visit [OpenThread CLI Reference README.md]
 ## Verification
 
 The following toolchain has been used for testing and verification:
-   - gcc version 4.9.3
-   - gcc version 5.4.1
+   - gcc version 7.3.1
 
 The EFR32 example has been verified with following Flex SDK/RAIL Library version:
-   - Flex SDK version 2.0.0.0
+   - Flex SDK version 2.5.1.0

--- a/examples/platforms/efr32/fem-control.c
+++ b/examples/platforms/efr32/fem-control.c
@@ -29,5 +29,5 @@
 #include "hal-config.h"
 
 #if (HAL_FEM_ENABLE)
-#include "../../../third_party/silabs/gecko_sdk_suite/v2.3/util/plugin/plugin-common/fem-control/fem-control.c"
+#include "../../../third_party/silabs/gecko_sdk_suite/v2.5/util/plugin/plugin-common/fem-control/fem-control.c"
 #endif


### PR DESCRIPTION
Updated makefiles and sources for efr32 platform to use the v2.5 SDK from Silicon Labs released in January 2019.

