### PR TITLE
[mbedtls] include debug.h

### DIFF
--- a/src/core/crypto/mbedtls.cpp
+++ b/src/core/crypto/mbedtls.cpp
@@ -33,6 +33,7 @@
 
 #include "mbedtls.hpp"
 
+#include <mbedtls/debug.h>
 #include <mbedtls/platform.h>
 
 #include "common/instance.hpp"


### PR DESCRIPTION
The `<mbedtls/debug.h>` is included in `mbedtls.cpp` file which is
needed for `mbedtls_debug_set_threshold()`.