### PR TITLE
[doc] fix incorrect SNTP comment

### DIFF
--- a/include/openthread/sntp.h
+++ b/include/openthread/sntp.h
@@ -69,7 +69,7 @@ typedef struct otSntpQuery
  * This function pointer is called when a SNTP response is received.
  *
  * @param[in]  aContext   A pointer to application-specific context.
- * @param[in]  aTime      Specifies the at the server when the response left for the client, in NTP timestamp format.
+ * @param[in]  aTime      Specifies the time at the server when the response left for the client, in UNIX time.
  * @param[in]  aResult    A result of the SNTP transaction.
  *
  * @retval  OT_ERROR_NONE              A response was received successfully and time is provided


### PR DESCRIPTION
The callback gets called with UNIX time, rather than NTP timestamp. See [sntp_client.cpp](https://github.com/openthread/openthread/blob/795a7e91972250539b7c2d0e0b74e95eca7798cf/src/core/net/sntp_client.cpp#L368).