### PR TITLE
[posix-app] fix daemon uart send done

### DIFF
--- a/src/posix/platform/uart.c
+++ b/src/posix/platform/uart.c
@@ -237,6 +237,7 @@ void platformUartProcess(const fd_set *aReadFdSet, const fd_set *aWriteFdSet, co
         IgnoreReturnValue(write(STDERR_FILENO, sWriteBuffer, sWriteLength));
         sWriteBuffer = NULL;
         sWriteLength = 0;
+        otPlatUartSendDone();
     }
 
     otEXPECT(sSessionSocket != -1);


### PR DESCRIPTION
This PR address an issue in daemon mode that the `otPlatUartSendDone()` is not properly called when no client is connected.