### PR TITLE
[coaps] fix disconnected

### DIFF
--- a/include/openthread/coap_secure.h
+++ b/include/openthread/coap_secure.h
@@ -206,10 +206,8 @@ otError otCoapSecureConnect(otInstance *                    aInstance,
  *
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  *
- * @retval OT_ERROR_NONE  Successfully stopped the DTLS connection.
- *
  */
-otError otCoapSecureDisconnect(otInstance *aInstance);
+void otCoapSecureDisconnect(otInstance *aInstance);
 
 /**
  * This method indicates whether or not the DTLS session is connected.

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -263,13 +263,13 @@ otError CoapSecure::Process(int argc, char *argv[])
     }
     else if (strcmp(argv[0], "disconnect") == 0)
     {
-        SuccessOrExit(error = otCoapSecureDisconnect(mInterpreter.mInstance));
+        otCoapSecureDisconnect(mInterpreter.mInstance);
     }
     else if (strcmp(argv[0], "stop") == 0)
     {
         if (otCoapSecureIsConnectionActive(mInterpreter.mInstance))
         {
-            error         = otCoapSecureDisconnect(mInterpreter.mInstance);
+            otCoapSecureDisconnect(mInterpreter.mInstance);
             mShutdownFlag = true;
         }
         else

--- a/src/core/api/coap_secure_api.cpp
+++ b/src/core/api/coap_secure_api.cpp
@@ -163,11 +163,11 @@ otError otCoapSecureConnect(otInstance *                    aInstance,
                                                        aContext);
 }
 
-otError otCoapSecureDisconnect(otInstance *aInstance)
+void otCoapSecureDisconnect(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.GetApplicationCoapSecure().Disconnect();
+    instance.GetApplicationCoapSecure().Disconnect();
 }
 
 bool otCoapSecureIsConnected(otInstance *aInstance)

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -146,18 +146,16 @@ bool CoapSecure::IsConnected(void)
     return GetNetif().GetDtls().GetState() == MeshCoP::Dtls::kStateConnected;
 }
 
-otError CoapSecure::Disconnect(void)
+void CoapSecure::Disconnect(void)
 {
-    Ip6::SockAddr sockAddr;
-    otError       error = OT_ERROR_NONE;
-
     GetNetif().GetDtls().Stop();
 
     // Disconnect from previous peer by connecting to any address
-    SuccessOrExit(error = mSocket.Connect(sockAddr));
+    {
+        otError error = mSocket.Connect(Ip6::SockAddr());
 
-exit:
-    return error;
+        assert(error == OT_ERROR_NONE);
+    }
 }
 
 MeshCoP::Dtls &CoapSecure::GetDtls(void)
@@ -307,6 +305,14 @@ void CoapSecure::HandleDtlsConnected(void *aContext, bool aConnected)
 
 void CoapSecure::HandleDtlsConnected(bool aConnected)
 {
+    if (!aConnected)
+    {
+        // Disconnect from previous peer by connecting to any address
+        otError error = mSocket.Connect(Ip6::SockAddr());
+
+        assert(error == OT_ERROR_NONE);
+    }
+
     if (mConnectedCallback != NULL)
     {
         mConnectedCallback(aConnected, mConnectedContext);

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -140,10 +140,8 @@ public:
     /**
      * This method stops the DTLS connection.
      *
-     * @retval OT_ERROR_NONE  Successfully stopped the DTLS connection.
-     *
      */
-    otError Disconnect(void);
+    void Disconnect(void);
 
     /**
      * This method returns a reference to the DTLS object.

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -691,11 +691,8 @@ void BorderAgent::HandleTimeout(void)
 
     if (coaps.IsConnected())
     {
-        otError error;
-
-        error = coaps.Disconnect();
-        otLogWarnMeshCoP("Reset commissioner session: %s", otThreadErrorToString(error));
-        OT_UNUSED_VARIABLE(error);
+        coaps.Disconnect();
+        otLogWarnMeshCoP("Reset commissioner session");
     }
 }
 


### PR DESCRIPTION
When DTLS is disconnected, the socket should also be disconnected from
the previous peer.

This fixes openthread/borderrouter#254.