### PR TITLE
[coap] share the same coap secure object whether encrypt link layer or not

### DIFF
--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -47,7 +47,7 @@
 namespace ot {
 namespace Coap {
 
-CoapSecure::CoapSecure(Instance &aInstance, bool aLayerTwoSecurity)
+CoapSecure::CoapSecure(Instance &aInstance)
     : CoapBase(aInstance, &CoapSecure::Send)
     , mConnectedCallback(NULL)
     , mConnectedContext(NULL)
@@ -56,7 +56,7 @@ CoapSecure::CoapSecure(Instance &aInstance, bool aLayerTwoSecurity)
     , mTransmitQueue()
     , mTransmitTask(aInstance, &CoapSecure::HandleTransmit, this)
     , mSocket(aInstance.GetThreadNetif().GetIp6().GetUdp())
-    , mLayerTwoSecurity(aLayerTwoSecurity)
+    , mLinkSecurityEnabled(false)
 {
 }
 
@@ -348,7 +348,7 @@ otError CoapSecure::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, uint8_
 
     VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = OT_ERROR_NO_BUFS);
     message->SetSubType(aMessageSubType);
-    message->SetLinkSecurityEnabled(mLayerTwoSecurity);
+    message->SetLinkSecurityEnabled(mLinkSecurityEnabled);
 
     SuccessOrExit(error = message->Append(aBuf, aLength));
 

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -71,10 +71,9 @@ public:
      * This constructor initializes the object.
      *
      * @param[in]  aInstance           A reference to the OpenThread instance.
-     * @param[in]  aLayerTwoSecurity   Specifies whether to use layer two security or not.
      *
      */
-    explicit CoapSecure(Instance &aInstance, bool aLayerTwoSecurity = false);
+    explicit CoapSecure(Instance &aInstance);
 
     /**
      * This method starts the secure CoAP agent.
@@ -318,6 +317,14 @@ public:
      */
     const Ip6::MessageInfo &GetPeerMessageInfo(void) const { return mPeerAddress; }
 
+    /**
+     * This method sets whether or not link security is enabled for transmitting CoAP messages.
+     *
+     * @param[in]  aEnabled  TRUE if link security is enabled, FALSE otherwise.
+     *
+     */
+    void SetLinkSecurityEnabled(bool aEnabled) { mLinkSecurityEnabled = aEnabled; }
+
 private:
     static otError Send(CoapBase &aCoapBase, ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
     {
@@ -348,7 +355,7 @@ private:
     TaskletContext    mTransmitTask;
     Ip6::UdpSocket    mSocket;
 
-    bool mLayerTwoSecurity : 1;
+    bool mLinkSecurityEnabled : 1;
 };
 
 } // namespace Coap

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -67,9 +67,6 @@ Instance::Instance(void)
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
     , mApplicationCoap(*this)
 #endif
-#if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-    , mApplicationCoapSecure(*this, /* aLayerTwoSecurity */ true)
-#endif
 #if OPENTHREAD_ENABLE_CHANNEL_MONITOR
     , mChannelMonitor(*this)
 #endif
@@ -239,6 +236,16 @@ void Instance::InvokeEnergyScanCallback(otEnergyScanResult *aResult) const
         mEnergyScanCallback(aResult, mEnergyScanCallbackContext);
     }
 }
+
+#if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
+Coap::CoapSecure &Instance::GetApplicationCoapSecure()
+{
+    Coap::CoapSecure &coapSecure = mThreadNetif.GetCoapSecure();
+    coapSecure.SetLinkSecurityEnabled(true);
+    return coapSecure;
+}
+#endif
+
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 
 } // namespace ot

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -330,7 +330,7 @@ public:
      * @returns A reference to the application COAP Secure object.
      *
      */
-    Coap::CoapSecure &GetApplicationCoapSecure(void) { return mApplicationCoapSecure; }
+    Coap::CoapSecure &GetApplicationCoapSecure(void);
 #endif
 
 #if OPENTHREAD_ENABLE_CHANNEL_MONITOR
@@ -442,10 +442,6 @@ private:
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
     Coap::Coap mApplicationCoap;
-#endif
-
-#if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-    Coap::CoapSecure mApplicationCoapSecure;
 #endif
 
 #if OPENTHREAD_ENABLE_CHANNEL_MONITOR


### PR DESCRIPTION
In addition to the application layer, the NMKP feature of v1.2 also requires link-layer encryption when transmitting coap messages. As long as it is decided when establishing dtls session, this allows us to share a coap securiy object. We  also can change it at any time.