### PR TITLE
[mesh-forwarder] do not allow eviction of message being processed

### DIFF
--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -114,6 +114,7 @@ struct MessageInfo
     uint8_t mPriority : 2;     ///< Identifies the message priority level (lower value is higher priority).
     bool    mInPriorityQ : 1;  ///< Indicates whether the message is queued in normal or priority queue.
     bool    mTxSuccess : 1;    ///< Indicates whether the direct tx of the message was successful.
+    bool    mDoNotEvict : 1;   ///< Indicates whether or not this message may be evicted.
 #if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
     bool    mTimeSync : 1;      ///< Indicates whether the message is also used for time sync purpose.
     uint8_t mTimeSyncSeq;       ///< The time sync sequence.
@@ -619,7 +620,7 @@ public:
     void SetDirectTransmission(void) { mBuffer.mHead.mInfo.mDirectTx = true; }
 
     /**
-     * This methods indicates whether the direct transmission of message was successful.
+     * This method indicates whether the direct transmission of message was successful.
      *
      * @retval TRUE   If direct transmission of message was successful (all fragments were delivered and acked).
      * @retval FALSE  If direct transmission of message failed (at least one fragment failed).
@@ -628,13 +629,30 @@ public:
     bool GetTxSuccess(void) const { return mBuffer.mHead.mInfo.mTxSuccess; }
 
     /**
-     * This methods sets whether the direct transmission of message was successful.
+     * This method sets whether the direct transmission of message was successful.
      *
      * @param[in] aTxSuccess   TRUE if the direct transmission is successful, FALSE otherwise (i.e., at least one
      *                         fragment transmission failed).
      *
      */
     void SetTxSuccess(bool aTxSuccess) { mBuffer.mHead.mInfo.mTxSuccess = aTxSuccess; }
+
+    /**
+     * This method indicates whether the message may be evicted.
+     *
+     * @retval TRUE   If the message must not be evicted.
+     * @retval FALSE  If the message may be evicted.
+     *
+     */
+    bool GetDoNotEvict(void) const { return mBuffer.mHead.mInfo.mDoNotEvict; }
+
+    /**
+     * This method sets whether the message may be evicted.
+     *
+     * @param[in]  aDoNotEvict  TRUE if the message may not be evicted, FALSE otherwise.
+     *
+     */
+    void SetDoNotEvict(bool aDoNotEvict) { mBuffer.mHead.mInfo.mDoNotEvict = aDoNotEvict; }
 
     /**
      * This method indicates whether or not link security is enabled for the message.

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -230,12 +230,13 @@ Message *MeshForwarder::GetDirectTransmission(void)
 
     for (curMessage = mSendQueue.GetHead(); curMessage; curMessage = nextMessage)
     {
-        nextMessage = curMessage->GetNext();
-
         if (curMessage->GetDirectTransmission() == false)
         {
+            nextMessage = curMessage->GetNext();
             continue;
         }
+
+        curMessage->SetDoNotEvict(true);
 
         switch (curMessage->GetType())
         {
@@ -265,6 +266,11 @@ Message *MeshForwarder::GetDirectTransmission(void)
             error = OT_ERROR_DROP;
             break;
         }
+
+        curMessage->SetDoNotEvict(false);
+
+        // the next message may have been evicted during processing (e.g. due to Address Solicit)
+        nextMessage = curMessage->GetNext();
 
         switch (error)
         {

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -244,6 +244,7 @@ otError MeshForwarder::EvictMessage(uint8_t aPriority)
 
     if (message->GetPriority() < aPriority)
     {
+        VerifyOrExit(!message->GetDoNotEvict());
         RemoveMessage(*message);
         ExitNow(error = OT_ERROR_NONE);
     }


### PR DESCRIPTION
#3015 introduced the ability to evict messages queued in MeshForwarder.

Processing a message may trigger an Address Solicit message to be sent.
Because Thread control messages have higher priority, it is possible for the
Address Solicit message to evict the data message that caused the generation
of the Address Solicit message.

This commit present a message that's being processed from being evicted.