### PR TITLE
[nrf528xx] update platforms README.md

### DIFF
--- a/examples/platforms/nrf52811/README.md
+++ b/examples/platforms/nrf52811/README.md
@@ -1,54 +1,50 @@
 # OpenThread on nRF52811 Example
 
+This directory contains example platform drivers for [Nordic Semiconductor nRF52811 SoC][nRF52811].
+
+[nRF52811]: https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF52811
+
 This SoC is meant to be used in the configuration that involves the Host Processor and the IEEE 802.15.4 radio.
 In this configuration, the full OpenThread stack is running on the Host Processor and the nRF52811 SoC acts as an IEEE 802.15.4 radio.
-The radio is running a minimal OpenThread implementation that allows for communication between the Host Processor and the nRF52811. In this architecture the nRF52811 SoC device is called NCP radio or RCP (Radio Co-Processor).
+The radio is running a minimal OpenThread implementation that allows for communication between the Host Processor and the nRF52811.
+In this architecture, the nRF52811 SoC device is called NCP radio or RCP (Radio Co-Processor).
 
 The nRF52811 platform is currently under development.
 
-For the SoC capable to a run full OpenThread stack please check the [nRF52840 platform][nRF52840-page].
+For the SoC capable to a run full OpenThread stack, see the [nRF52840 platform][nRF52840-page].
 
 [nRF52840-page]: ./../nrf52840/README.md
 
-## Toolchain
+## Prerequisites
+
+Before you start building the examples, you must download and install the toolchain and the tools required for flashing and debugging.
+
+### Toolchain
 
 Download and install the [GNU toolchain for ARM Cortex-M][gnu-toolchain].
 
 [gnu-toolchain]: https://launchpad.net/gcc-arm-embedded
 
-To install the GNU toolchain and its dependencies,
-run the following commands in Bash:
+To install the GNU toolchain and its dependencies, run the following commands in Bash:
 
 ```bash
 $ cd <path-to-openthread>
 $ ./script/bootstrap
 ```
 
+### Flashing and debugging tools
+
+[nRF5-Command-Line-Tools]: https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF5-Command-Line-Tools
+
+Install the [nRF5 Command Line Tools][nRF5-Command-Line-Tools] to flash, debug, and make use of logging features on the nRF52811 DK with SEGGER J-Link.
+
 ## Building the examples
 
-With this platform you can build:
+With this platform, you can build:
  - Limited version of CLI example (e.g. without Thread commissioning functionality)
  - NCP radio-only example that consists of two parts:
     - firmware that is flashed to the nRF52811 SoC
     - host executables to be executed on a POSIX platform in case of the RCP usage
-
-### Building the firmware
-
-To build the firmware using default UART RCP transport, run the following make commands:
-
-```bash
-$ cd <path-to-openthread>
-$ ./bootstrap
-$ make -f examples/Makefile-nrf52811
-```
-
-After a successful build, the `elf` files can be found in
-`<path-to-openthread>/output/nrf52811/bin`.  
-You can convert them to hex using arm-none-eabi-objcopy`:
-```bash
-$ arm-none-eabi-objcopy -O ihex ot-cli-mtd ot-cli-mtd.hex
-$ arm-none-eabi-objcopy -O ihex ot-ncp-radio ot-ncp-radio.hex
-```
 
 ### Building host executables
 ```bash
@@ -61,7 +57,25 @@ After a successful build, executables can be found in
 `<path-to-openthread>/openthread/output/posix/<system-architecture>/bin`.
 It is recommended to copy them to `/usr/bin` for easier access.
 
-## Building the examples with native SPI Slave support
+### Building the firmware with UART support
+
+To build the firmware using default UART RCP transport, run the following make commands:
+
+```bash
+$ cd <path-to-openthread>
+$ ./bootstrap
+$ make -f examples/Makefile-nrf52811
+```
+
+After a successful build, the `elf` files can be found in
+`<path-to-openthread>/output/nrf52811/bin`.  
+You can convert them to hex using `arm-none-eabi-objcopy`:
+```bash
+$ arm-none-eabi-objcopy -O ihex ot-cli-mtd ot-cli-mtd.hex
+$ arm-none-eabi-objcopy -O ihex ot-ncp-radio ot-ncp-radio.hex
+```
+
+### Building the firmware with native SPI support
 
 You can build the libraries with support for the native SPI Slave.
 To do so, build the libraries with the following parameter:
@@ -69,44 +83,23 @@ To do so, build the libraries with the following parameter:
 $ make -f examples/Makefile-nrf52811 NCP_SPI=1
 ```
 
-With the `NCP_SPI` option enabled, SPI communication between the RCP example and wpantund is possible
-(provided that the wpantund host supports SPI Master).
-To achieve the communication between the RCP example and wpantund,
-choose an appropriate SPI device in the wpantund configuration file,
-`/etc/wpantund.conf`. See the following example.
+With this option enabled, the RCP example can communicate through SPI with wpantund (provided that the wpantund host supports SPI Master). To achieve this communication, choose the right SPI device in the wpantund configuration file, `/etc/wpantund.conf`. See the following example.
+
 
 ```
 Config:NCP:SocketPath "system:/usr/bin/ot-ncp /usr/bin/spi-hdlc-adapter -- '--stdio -i /sys/class/gpio/gpio25 /dev/spidev0.1'"
 ```
 
-[spi-hdlc-adapter][spi-hdlc-adapter]
-is a tool that can be used to perform communication between RCP and wpantund over SPI.
-In this example, `spi-hdlc-adapter` is installed in `/usr/bin`.
+In this example, [spi-hdlc-adapter][spi-hdlc-adapter] is a tool that you can use to communicate between RCP and wpantund over SPI. For this example, `spi-hdlc-adapter` is installed in `/usr/bin`.
 
 The default SPI Slave pin configuration for nRF52811 is defined in `examples/platforms/nrf52811/platform-config.h`.
 
 [spi-hdlc-adapter]: https://github.com/openthread/openthread/tree/master/tools/spi-hdlc-adapter
 
-### Building the host executables
-
-To build the host executables, run the following make commands:
-
-```bash
-$ cd <path-to-openthread>
-$ ./bootstrap
-$ make -f src/posix/Makefile-posix
-```
-
-After a successful build, executables can be found in
-`<path-to-openthread>/openthread/output/posix/<system-architecture>/bin`.
-Copy the files to /usr/bin for easier access.
-
 ## Flashing binaries
 
 Once the examples and libraries are built, flash the compiled binaries onto nRF52811
-using `nrfjprog` that is part of the [nRF5x Command Line Tools][nRF5x-Command-Line-Tools].
-
-[nRF5x-Command-Line-Tools]: https://www.nordicsemi.com/eng/Products/nRF52840#Downloads
+using `nrfjprog` that is part of the [nRFx Command Line Tools][nRF5-Command-Line-Tools].
 
 Run the following command:
 
@@ -127,124 +120,193 @@ To test the example:
 4. Connect the RCP to the PC.
 
 5. Start the ot-cli host application and connect with the RCP.
-   It is assumed that the default UART version of RCP is being used (make executed without the NCP=SPI=1 flag).
-   On Linux system, call a port name, for example `/dev/ttyACM0` for the first connected development kit,
-   and `/dev/ttyACM1` for the second one.
+   It is assumed that the default UART version of RCP is being used (make executed without the NCP-SPI=1 flag).
+   On Linux system, call a port name, for example `/dev/ttyACM0` for the first connected development kit, and `/dev/ttyACM1` for the second one.
 
-```bash
-$ /usr/bin/ot-cli /dev/ttyACM0 115200
-```
+   ```bash
+   $ /usr/bin/ot-cli /dev/ttyACM0 115200
+   ```
 
-Now you are connected with the CLI.
+   You are now connected with the CLI on the first board
 
 6. Use the following commands to form a network:
 
-```bash
- > panid 0xabcd
- Done
- > ifconfig up
- Done
- > thread start
- Done
-```
+   ```bash
+    > panid 0xabcd
+    Done
+    > ifconfig up
+    Done
+    > thread start
+    Done
+   ```
+   
+   After a couple of seconds the node will become a Leader of the network.
+   
+    ```bash
+    > state
+    Leader
+    ```
 
-7. Open a terminal connection on the first board and start a new Thread network:
+7. Open a terminal connection on the second board and attach a node to the network:
 
- ```bash
- > panid 0xabcd
- Done
- > ifconfig up
- Done
- > thread start
- Done
- ```
+   a. Start a terminal emulator like screen.
 
-After a couple of seconds the node will become a Leader of the network.
+   b. Connect to the used COM port with the following direct UART settings:
 
- ```bash
- > state
- Leader
- ```
+   * Baud rate: 115200
+   * 8 data bits
+   * 1 stop bit
+   * No parity
+   * HW flow control: RTS/CTS
+     This allows you to view the raw UART output.
 
-8. Open a terminal connection on the second board and attach a node to the network.
-   The CLI MTD example uses the direct UART connection. To view raw UART output, start a terminal
-   emulator like screen and connect to the used COM port with the following UART settings:
-    - Baud rate: 115200
-    - 8 data bits
-    - 1 stop bit
-    - No parity
-    - HW flow control: RTS/CTS
+   c. Run the following command to connect to the second board.
 
-Run the following to connect to the second board.
+      ```shell
+      screen /dev/ttyACM1 115200
+      ```
+      
+      You are now connected with the CLI on the second board
 
- ```bash
- screen /dev/ttyACM1 115200
- ```
+8. Use the following commands to attach to the network on the second board:
 
-Now you are connected with the CLI.
+   ```bash
+   > panid 0xabcd
+   Done
+   > ifconfig up
+   Done
+   > thread start
+   Done
+   ```
 
-9. Use the following commands to form a network:
+   After a couple of seconds the second node will attach and become a Child.
 
- ```bash
- > panid 0xabcd
- Done
- > ifconfig up
- Done
- > thread start
- Done
- ```
+   ```bash
+   > state
+   Child
+   ```
 
-After a couple of seconds the second node will attach and become a Child.
+9. List all IPv6 addresses of the first board.
 
- ```bash
- > state
- Child
- ```
+   ```bash
+   > ipaddr
+   fdde:ad00:beef:0:0:ff:fe00:fc00
+   fdde:ad00:beef:0:0:ff:fe00:9c00
+   fdde:ad00:beef:0:4bcb:73a5:7c28:318e
+   fe80:0:0:0:5c91:c61:b67c:271c
+   ```
 
-10. List all IPv6 addresses of the first board.
+10. Choose one of them and send an ICMPv6 ping from the second board.
 
- ```bash
- > ipaddr
- fdde:ad00:beef:0:0:ff:fe00:fc00
- fdde:ad00:beef:0:0:ff:fe00:9c00
- fdde:ad00:beef:0:4bcb:73a5:7c28:318e
- fe80:0:0:0:5c91:c61:b67c:271c
- ```
-
-11. Choose one of them and send an ICMPv6 ping from the second board.
-
- ```bash
- > ping fdde:ad00:beef:0:0:ff:fe00:fc00
- 16 bytes from fdde:ad00:beef:0:0:ff:fe00:fc00: icmp_seq=1 hlim=64 time=8ms
- ```
+    ```bash
+    > ping fdde:ad00:beef:0:0:ff:fe00:fc00
+    16 bytes from fdde:ad00:beef:0:0:ff:fe00:fc00: icmp_seq=1 hlim=64 time=8ms
+    ```
 
 For a list of all available commands, visit [OpenThread CLI Reference README.md][CLI].
 
 [CLI]: ./../../../src/cli/README.md
 
-## Working with the logging module
+## SEGGER J-Link tools
+
+SEGGER J-Link tools allow to debug and flash generated firmware using on-board debugger or external one.
+
+### Working with RTT logging
 
 By default, the OpenThread's logging module provides functions to output logging
 information over SEGGER's Real Time Transfer (RTT).
 
-The RTT output can be viewed in the J-Link RTT Viewer, which is available from SEGGER.
+You can set the desired log level by using the `OPENTHREAD_CONFIG_LOG_LEVEL` define.
 
-The viewer is also included in the nRF Tools. 
-To read or write messages over RTT:
+To enable the highest verbosity level, append `FULL_LOGS` flag to the `make` command:
+```
+$ make -f examples/Makefile-nrf52811 FULL_LOGS=1
+```
 
-1. Connect an nRF5 development board via with a USB cable. 
-2. Run the J-Link RTT Viewer.
-3. In the Specify Target Device dropdown menu, select the nRF52 device.
-4. In the Target Interface & Speed dropdown menu, select the SWD interface.
+#### Enable logging on Windows
 
-The intended log level can be set using `OPENTHREAD_CONFIG_LOG_LEVEL` define.
+1. Connect the DK to your machine with a USB cable.
+2. Run `J-Link RTT Viewer`. The configuration window appears.
+3. From the Specify Target Device dropdown menu, select `NRF52810_XXAA`.
+4. From the Target Interface & Speed dropdown menu, select `SWD`.
 
-## Disabling the Mass Storage Device
+#### Enable logging on Linux
 
-Depending on your software version, a known issue in SEGGER's J-Link firmware can cause data corruption or data drops if you use the serial port. You can avoid this issue by disabling the Mass Storage Device:
+1. Connect the DK to your machine with a USB cable.
+2. Run `JLinkExe` to connect to the target. For example:
+```
+JLinkExe -device NRF52810_XXAA -if SWD -speed 4000 -autoconnect 1 -SelectEmuBySN <SEGGER_ID> -RTTTelnetPort 19021
+```
+3. Run `JLinkRTTTelnet` to obtain the RTT logs from the connected device in a separate console. For example:
+```
+JLinkRTTClient -RTTTelnetPort 19021
+```
 
- - On Linux or macOS (OS X), open JLinkExe from the terminal and run the command `MSDDisable`.
- - On Microsoft Windows, open the J-Link Commander application and run the command `MSDDisable`.
+### Mass Storage Device known issue
+
+Depending on your version, due to a known issue in SEGGER's J-Link firmware, you might experience data corruption or data drops if you use the serial port. You can avoid this issue by disabling the Mass Storage Device.
+
+#### Disabling the Mass Storage Device on Windows
+
+1. Connect the DK to your machine with a USB cable.
+2. Run `J-Link Commander`. The configuration window appears.
+3. From the Specify Target Device dropdown menu, select `NRF52810_XXAA`.
+4. From the Target Interface & Speed dropdown menu, select `SWD`.
+5. Run the following command:
+```
+MSDDisable
+```
+6. Power cycle the DK.
+
+#### Disabling the Mass Storage Device on Linux
+
+1. Connect the DK to your machine with a USB cable.
+2. Run `JLinkExe` to connect to the target. For example:
+```
+JLinkExe -device NRF52810_XXAA -if SWD -speed 4000 -autoconnect 1 -SelectEmuBySN <SEGGER_ID>
+```
+3. Run the following command:
+```
+MSDDisable
+```
+4. Power cycle the DK.
+
+### Hardware Flow Control detection
+
+By default, SEGGER J-Link automatically detects at runtime whether the target is using Hardware Flow Control (HWFC).
+
+The automatic HWFC detection is done by driving P0.07 (Clear to Send - CTS) from the interface MCU and evaluating the state of P0.05 (Request to Send - RTS) when the first data is sent or received. If the state of P0.05 (RTS) is high, it is assumed that HWFC is not used.
+
+To avoid potential race conditions, you can force HWFC and bypass the runtime auto-detection.
+
+#### Disabling the HWFC detection on Windows
+
+1. Connect the DK to your machine with a USB cable.
+2. Run `J-Link Commander`. The configuration window appears.
+3. From the Specify Target Device dropdown menu, select `NRF52810_XXAA`.
+4. From the Target Interface & Speed dropdown menu, select `SWD`.
+5. Run the following command:
+```
+SetHWFC Force
+```
+6. Power cycle the DK.
+
+#### Disabling the HWFC detection on Linux
+
+1. Connect the DK to your machine with a USB cable.
+2. Run `JLinkExe` to connect to the target. For example:
+```
+JLinkExe -device NRF52810_XXAA -if SWD -speed 4000 -autoconnect 1 -SelectEmuBySN <SEGGER_ID>
+```
+3. Run the following command:
+```
+SetHWFC Force
+```
+4. Power cycle the DK.
+
+You can find more details [here][J-Link-OB].
+
+[J-Link-OB]: https://wiki.segger.com/J-Link_OB_SAM3U_NordicSemi#Hardware_flow_control_support
 
 ## Diagnostic module
 

--- a/examples/platforms/nrf52840/README.md
+++ b/examples/platforms/nrf52840/README.md
@@ -1,26 +1,39 @@
 # OpenThread on nRF52840 Example
 
-This directory contains example platform drivers for [Nordic Semiconductor nRF52840 SoC][nRF52840].
+<a href="http://threadgroup.org/technology/ourtechnology#certifiedproducts">
+<img src="https://cdn.rawgit.com/openthread/openthread/ab4c4e1e/doc/images/certified.svg" alt="Thread Certified Component" width="150px" align="right">
+</a>
 
-[nRF52840]: https://www.nordicsemi.com/eng/Products/nRF52840
+This directory contains example platform drivers for [Nordic Semiconductor nRF52840 SoC][nRF52840]. The OpenThread stack has been officially certified as a *Thread Certified Component* on this platform.
+
+[nRF52840]: https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF52840
 
 To facilitate Thread products development with the nRF52840 platform, Nordic Semiconductor provides <i>nRF5 SDK for Thread and Zigbee</i>. See [Nordic Semiconductor's nRF5 SDK for Thread and Zigbee][nRF5-SDK-section] section for more details.
 
 [nRF5-SDK-section]: #nordic-semiconductors-nrf5-sdk-for-thread-and-zigbee
 
-## Toolchain
+## Prerequisites
+
+Before you start building the examples, you must download and install the toolchain and the tools required for flashing and debugging.
+
+### Toolchain
 
 Download and install the [GNU toolchain for ARM Cortex-M][gnu-toolchain].
 
 [gnu-toolchain]: https://launchpad.net/gcc-arm-embedded
 
-To install the GNU toolchain and its dependencies,
-run the following commands in Bash:
+To install the GNU toolchain and its dependencies, run the following commands in Bash:
 
 ```bash
 $ cd <path-to-openthread>
 $ ./script/bootstrap
 ```
+
+### Flashing and debugging tools
+
+[nRF5-Command-Line-Tools]: https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF5-Command-Line-Tools
+
+Install the [nRF5 Command Line Tools][nRF5-Command-Line-Tools] to flash, debug, and make use of logging features on the nRF52840 DK with SEGGER J-Link.
 
 ## Building the examples
 
@@ -33,9 +46,8 @@ $ make -f examples/Makefile-nrf52840
 ```
 
 After a successful build, the `elf` files can be found in
-`<path-to-openthread>/output/nrf52840/bin`.  You can convert them to `hex`
-files using `arm-none-eabi-objcopy`:
-
+`<path-to-openthread>/output/nrf52840/bin`.
+You can convert them to hex using `arm-none-eabi-objcopy`:
 ```bash
 $ arm-none-eabi-objcopy -O ihex ot-cli-ftd ot-cli-ftd.hex
 ```
@@ -51,9 +63,9 @@ The driver can be found in `third_party/NordicSemiconductor/libraries/usb/nordic
 
 ### nRF52840 dongle support (PCA10059)
 
-You can build the libraries with support for USB bootloader with automatic USB DFU trigger support in PCA10059. As this dongle uses the native USB support, you must enable it as well.
+You can build the libraries with support for the USB bootloader with USB DFU trigger support in PCA10059. As this dongle uses the native USB support, you must enable it as well.
 
-To build the libraries, run make with the following parameter:
+To build the libraries, run make with the following parameters:
 
 ```
 $ make -f examples/Makefile-nrf52840 USB=1 BOOTLOADER=1
@@ -61,9 +73,9 @@ $ make -f examples/Makefile-nrf52840 USB=1 BOOTLOADER=1
 
 See [nRF52840 Dongle Programming][nrf52840-dongle-programming] for more details about how to use the USB bootloader.
 
-[nrf52840-dongle-programming]: https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.nrf52%2Fdita%2Fnrf52%2Fdevelopment%2Fnrf52840_dongle%2Fprogramming.html&cp=2_0_4_4
+[nrf52840-dongle-programming]: https://www.nordicsemi.com/DocLib/Content/User_Guides/nrf52840_dongle/latest/UG/nrf52840_Dongle/programming
 
-### Native SPI Slave support
+### Native SPI support
 
 You can build the libraries with support for native SPI Slave.
 To build the libraries, run make with the following parameter:
@@ -79,9 +91,7 @@ should be chosen in wpantund configuration file, `/etc/wpantund.conf`. You can f
 Config:NCP:SocketPath "system:/usr/bin/spi-hdlc-adapter --gpio-int /sys/class/gpio/gpio25 /dev/spidev0.0"
 ```
 
-[spi-hdlc-adapter][spi-hdlc-adapter]
-is a tool that can be used to perform communication between NCP and wpantund over SPI.
-In the above example it is assumed that `spi-hdlc-adapter` is installed in `/usr/bin`.
+In this example, [spi-hdlc-adapter][spi-hdlc-adapter] is a tool that you can use to communicate between NCP and wpantund over SPI. For this example, `spi-hdlc-adapter` is installed in `/usr/bin`.
 
 The default SPI Slave pin configuration for nRF52840 is defined in `examples/platforms/nrf52840/platform-config.h`.
 
@@ -100,7 +110,7 @@ You can prefix the compiler command using the CCPREFIX parameter. This speeds up
 $ make -f examples/Makefile-nrf52840 USB=1 CCPREFIX=ccache
 ```
 
-### CryptoCell 310 support
+### Optional disabling of CryptoCell 310 support
 
 By default, mbedTLS library is built with support for CryptoCell 310 hardware acceleration of cryptographic operations used in OpenThread. You can disable CryptoCell 310 and use software cryptography instead by building OpenThread with the following parameter:
 ```
@@ -110,9 +120,7 @@ $ make -f examples/Makefile-nrf52840 DISABLE_CC310=1
 ## Flashing the binaries
 
 Flash the compiled binaries onto nRF52840 using `nrfjprog` which is
-part of the [nRF5x Command Line Tools][nRF5x-Command-Line-Tools].
-
-[nRF5x-Command-Line-Tools]: https://www.nordicsemi.com/eng/Products/nRF52840#Downloads
+part of the [nRF5 Command Line Tools][nRF5-Command-Line-Tools].
 
 ```bash
 $ nrfjprog -f nrf52 --chiperase --program output/nrf52840/bin/ot-cli-ftd.hex --reset
@@ -120,129 +128,190 @@ $ nrfjprog -f nrf52 --chiperase --program output/nrf52840/bin/ot-cli-ftd.hex --r
 
 ## Running the example
 
-1. Prepare two boards with the flashed `CLI Example` (as shown above).
-2. The CLI example uses UART connection. To view raw UART output, start a terminal
-   emulator like PuTTY and connect to the used COM port with the following UART settings:
-    - Baud rate: 115200
-    - 8 data bits
-    - 1 stop bit
-    - No parity
-    - HW flow control: RTS/CTS
+To test the example:
 
-   On Linux system a port name should be called e.g. `/dev/ttyACM0` or `/dev/ttyACM1`.
-3. Open a terminal connection on the first board and start a new Thread network.
+1. Prepare two boards with the flashed `CLI Example` (as shown above). The CLI FTD example uses the direct UART connection.
 
- ```bash
- > panid 0xabcd
- Done
- > ifconfig up
- Done
- > thread start
- Done
- ```
+2. Open a terminal connection on two boards:
 
-4. After a couple of seconds the node will become a Leader of the network.
+   a. Start a terminal emulator like screen.
 
- ```bash
- > state
- Leader
- ```
+   b. Connect to the used COM port with the following direct UART settings:
 
-5. Open a terminal connection on the second board and attach a node to the network.
+   * Baud rate: 115200
+   * 8 data bits
+   * 1 stop bit
+   * No parity
+   * HW flow control: RTS/CTS
+     This allows you to view the raw UART output.
 
- ```bash
- > panid 0xabcd
- Done
- > ifconfig up
- Done
- > thread start
- Done
- ```
+     On Linux system a port name should be called e.g. `/dev/ttyACM0` or `/dev/ttyACM1`.
 
-6. After a couple of seconds the second node will attach and become a Child.
+   c. Run the following command to connect to a board.
 
- ```bash
- > state
- Child
- ```
+   ```shell
+   screen /dev/ttyACM0 115200
+   ```
 
-7. List all IPv6 addresses of the first board.
+   Now you are connected with the CLI.
 
- ```bash
- > ipaddr
- fdde:ad00:beef:0:0:ff:fe00:fc00
- fdde:ad00:beef:0:0:ff:fe00:9c00
- fdde:ad00:beef:0:4bcb:73a5:7c28:318e
- fe80:0:0:0:5c91:c61:b67c:271c
- ```
+3. Use the following commands to form a network on the first board.
 
-8. Choose one of them and send an ICMPv6 ping from the second board.
+   ```bash
+   > panid 0xabcd
+   Done
+   > ifconfig up
+   Done
+   > thread start
+   Done
+   ```
 
- ```bash
- > ping fdde:ad00:beef:0:0:ff:fe00:fc00
- 16 bytes from fdde:ad00:beef:0:0:ff:fe00:fc00: icmp_seq=1 hlim=64 time=8ms
- ```
+   After a couple of seconds the node will become a Leader of the network.
+
+   ```bash
+   > state
+   Leader
+   ```
+
+4. Use the following commands to attach to the network on the second board.
+
+   ```bash
+   > panid 0xabcd
+   Done
+   > ifconfig up
+   Done
+   > thread start
+   Done
+   ```
+
+   After a couple of seconds the second node will attach and become a Child.
+
+   ```bash
+   > state
+   Child
+   ```
+
+5. List all IPv6 addresses of the first board.
+
+   ```bash
+   > ipaddr
+   fdde:ad00:beef:0:0:ff:fe00:fc00
+   fdde:ad00:beef:0:0:ff:fe00:9c00
+   fdde:ad00:beef:0:4bcb:73a5:7c28:318e
+   fe80:0:0:0:5c91:c61:b67c:271c
+   ```
+
+6. Choose one of them and send an ICMPv6 ping from the second board.
+
+   ```bash
+   > ping fdde:ad00:beef:0:0:ff:fe00:fc00
+   16 bytes from fdde:ad00:beef:0:0:ff:fe00:fc00: icmp_seq=1 hlim=64 time=8ms
+   ```
 
 For a list of all available commands, visit [OpenThread CLI Reference README.md][CLI].
 
 [CLI]: ./../../../src/cli/README.md
 
-## Logging module
+## SEGGER J-Link tools
+
+SEGGER J-Link tools allow to debug and flash generated firmware using on-board debugger or external one.
+
+### Working with RTT logging
 
 By default, the OpenThread's logging module provides functions to output logging
 information over SEGGER's Real Time Transfer (RTT).
 
-RTT output can be viewed in the J-Link RTT Viewer, which is available from SEGGER.
-The viewer is also included in the nRF Tools. To read or write messages over RTT,
-connect an nRF5 development board via USB and run the J-Link RTT Viewer.
+You can set the desired log level by using the `OPENTHREAD_CONFIG_LOG_LEVEL` define.
 
-Select the correct target device (nRF52) and the target interface "SWD".
-
-The intended log level can be set using `OPENTHREAD_CONFIG_LOG_LEVEL` define.
-
-## Segger J-Link configuration
-
-### Disabling the Mass Storage Device
-
-Due to a known issue in Segger’s J-Link firmware, depending on your version, you might experience data corruption or drops if you use the serial port. You can avoid this issue by disabling the Mass Storage Device:
-
- - On Linux or macOS (OS X), open JLinkExe from the terminal.
- - On Microsoft Windows, open the J-Link Commander application.
-
-Run the following command:
-
-```bash
-MSDDisable
+To enable the highest verbosity level, append `FULL_LOGS` flag to the `make` command:
+```
+$ make -f examples/Makefile-nrf52840 FULL_LOGS=1
 ```
 
-This command takes effect after a power cycle of the development kit and stay this way until changed again.
+#### Enable logging on Windows
+
+1. Connect the DK to your machine with a USB cable.
+2. Run `J-Link RTT Viewer`. The configuration window appears.
+3. From the Specify Target Device dropdown menu, select `NRF52840_XXAA`.
+4. From the Target Interface & Speed dropdown menu, select `SWD`.
+
+#### Enable logging on Linux
+
+1. Connect the DK to your machine with a USB cable.
+2. Run `JLinkExe` to connect to the target. For example:
+```
+JLinkExe -device NRF52840_XXAA -if SWD -speed 4000 -autoconnect 1 -SelectEmuBySN <SEGGER_ID> -RTTTelnetPort 19021
+```
+3. Run `JLinkRTTTelnet` to obtain the RTT logs from the connected device in a separate console. For example:
+```
+JLinkRTTClient -RTTTelnetPort 19021
+```
+
+### Mass Storage Device known issue
+
+Depending on your version, due to a known issue in SEGGER's J-Link firmware, you might experience data corruption or data drops if you use the serial port. You can avoid this issue by disabling the Mass Storage Device.
+
+#### Disabling the Mass Storage Device on Windows
+
+1. Connect the DK to your machine with a USB cable.
+2. Run `J-Link Commander`. The configuration window appears.
+3. From the Specify Target Device dropdown menu, select `NRF52840_XXAA`.
+4. From the Target Interface & Speed dropdown menu, select `SWD`.
+5. Run the following command:
+```
+MSDDisable
+```
+6. Power cycle the DK.
+
+#### Disabling the Mass Storage Device on Linux
+
+1. Connect the DK to your machine with a USB cable.
+2. Run `JLinkExe` to connect to the target. For example:
+```
+JLinkExe -device NRF52840_XXAA -if SWD -speed 4000 -autoconnect 1 -SelectEmuBySN <SEGGER_ID>
+```
+3. Run the following command:
+```
+MSDDisable
+```
+4. Power cycle the DK.
 
 ### Hardware Flow Control detection
 
-By default, J-Link detects at runtime if the target uses flow control or not.
+By default, SEGGER J-Link automatically detects at runtime whether the target is using Hardware Flow Control (HWFC).
 
-Automatic HWFC detection is done by driving P0.07 (Clear to Send (CTS)) from the interface MCU and evaluating the state of P0.05 (Request to Send (RTS)) when the first data is sent or received. If the state of P0.05 (RTS) is high, HWFC is assumed not to be used.
+The automatic HWFC detection is done by driving P0.07 (Clear to Send - CTS) from the interface MCU and evaluating the state of P0.05 (Request to Send - RTS) when the first data is sent or received. If the state of P0.05 (RTS) is high, it is assumed that HWFC is not used.
 
-To avoid potential race conditions, it is possible to force hardware flow control and bypass runtime auto-detection.
+To avoid potential race conditions, you can force HWFC and bypass the runtime auto-detection.
 
- - On Linux or macOS (OS X), open JLinkExe from the terminal.
- - On Microsoft Windows, open the J-Link Commander application.
+#### Disabling the HWFC detection on Windows
 
-Run the following command:
-
-```bash
+1. Connect the DK to your machine with a USB cable.
+2. Run `J-Link Commander`. The configuration window appears.
+3. From the Specify Target Device dropdown menu, select `NRF52840_XXAA`.
+4. From the Target Interface & Speed dropdown menu, select `SWD`.
+5. Run the following command:
+```
 SetHWFC Force
 ```
+6. Power cycle the DK.
 
-The auto-detection feature may be enabled again by the following command:
+#### Disabling the HWFC detection on Linux
 
-```bash
-SetHWFC Enable
+1. Connect the DK to your machine with a USB cable.
+2. Run `JLinkExe` to connect to the target. For example:
 ```
+JLinkExe -device NRF52840_XXAA -if SWD -speed 4000 -autoconnect 1 -SelectEmuBySN <SEGGER_ID>
+```
+3. Run the following command:
+```
+SetHWFC Force
+```
+4. Power cycle the DK.
 
-You can find more details [here][J-Link_OB].
+You can find more details [here][J-Link-OB].
 
-[J-Link_OB]: https://wiki.segger.com/J-Link_OB_SAM3U_NordicSemi#Hardware_flow_control_support
+[J-Link-OB]: https://wiki.segger.com/J-Link_OB_SAM3U_NordicSemi#Hardware_flow_control_support
 
 ## Diagnostic module
 
@@ -267,7 +336,7 @@ The following toolchains have been used for testing and verification:
   - gcc version 6.2.0
 
  The following OpenThread commits have been verified with nRF52840 examples by Nordic Semiconductor:
-  - `704511c` - 18.09.2018 (the newest checked)
+  - `704511c` - 18.09.2018 (the latest checked)
   - `ec59d7e` - 06.04.2018
   - `a89eb88` - 16.11.2017
   - `6a15261` - 29.06.2017
@@ -289,8 +358,8 @@ The <i>nRF5 SDK for Thread and Zigbee</i> includes:
  - Border Router and cloud connectivity example,
  - Thread native commissioning with NFC example,
  - example applications demonstrating the use of FreeRTOS with OpenThread,
- - support for IAR, Keil MDK-ARM and Segger Embedded Studio (SES) IDEs for OpenThread stack and all example applications,
+ - support for IAR, Keil MDK-ARM and SEGGER Embedded Studio (SES) IDEs for OpenThread stack and all example applications,
  - range of PC tools including a Thread Topology Monitor,
  - software modules inherited from the nRF5 SDK e.g. peripheral drivers, NFC libraries, Bluetooth Low Energy libraries etc.
 
-[nRF5-SDK-Thread-Zigbee]: http://www.nordicsemi.com/eng/Products/nRF5-SDK-for-Thread
+[nRF5-SDK-Thread-Zigbee]: https://www.nordicsemi.com/Software-and-Tools/Software/nRF5-SDK-for-Thread-and-Zigbee


### PR DESCRIPTION
This PR enhances nRF52811 and nRF52840 documentation:

- add detailed documentation about Segger J-Link tools (@turon can you review it?) - mainly how to run it on Linux
- update links to point to the new website
- address tech writer review comments
