### PR TITLE
[thci] match meshlocalprefix accurately to classify the addresses correctly

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -1877,7 +1877,6 @@ class OpenThread(IThci):
         try:
             cmd = 'dataset meshlocalprefix %s' % sMeshLocalPrefix
             self.hasActiveDatasetToCommit = True
-            self.meshLocalPrefix = sMeshLocalPrefix
             return self.__sendCommand(cmd)[0] == 'Done'
         except Exception, e:
             ModuleHelper.WriteIntoDebugLogger("setMLPrefix() Error: " + str(e))

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -254,7 +254,7 @@ class OpenThread(IThci):
                 # link local address
                 if ip6Addr.split(':')[4] != '0':
                     linkLocal64Addr = ip6Addr
-            elif ip6AddrPrefix == 'fd00':
+            elif ip6Addr.startswith(self.meshLocalPrefix)
                 # mesh local address
                 if ip6Addr.split(':')[4] == '0':
                     # rloc
@@ -1877,6 +1877,7 @@ class OpenThread(IThci):
         try:
             cmd = 'dataset meshlocalprefix %s' % sMeshLocalPrefix
             self.hasActiveDatasetToCommit = True
+            self.meshLocalPrefix = sMeshLocalPrefix
             return self.__sendCommand(cmd)[0] == 'Done'
         except Exception, e:
             ModuleHelper.WriteIntoDebugLogger("setMLPrefix() Error: " + str(e))

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -254,7 +254,7 @@ class OpenThread(IThci):
                 # link local address
                 if ip6Addr.split(':')[4] != '0':
                     linkLocal64Addr = ip6Addr
-            elif ip6Addr.startswith(self.meshLocalPrefix)
+            elif ip6Addr.startswith(self.meshLocalPrefix):
                 # mesh local address
                 if ip6Addr.split(':')[4] == '0':
                     # rloc

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -1257,7 +1257,7 @@ class OpenThread(IThci):
         self.channelMask = "0x7fff800" #(0xffff << 11)
         self.panId = ModuleHelper.Default_PanId
         self.xpanId = ModuleHelper.Default_XpanId
-        self.localprefix = ModuleHelper.Default_MLPrefix
+        self.meshLocalPrefix = ModuleHelper.Default_MLPrefix
         self.pskc = "00000000000000000000000000000000"  # OT only accept hex format PSKc for now
         self.securityPolicySecs = ModuleHelper.Default_SecurityPolicy
         self.securityPolicyFlags = "onrcb"
@@ -1287,7 +1287,7 @@ class OpenThread(IThci):
             self.setXpanId(self.xpanId)
             self.setNetworkName(self.networkName)
             self.setNetworkKey(self.networkKey)
-            self.setMLPrefix(self.localprefix)
+            self.setMLPrefix(self.meshLocalPrefix)
             self.setPSKc(self.pskc)
             self.setActiveTimestamp(self.activetimestamp)
         except Exception, e:

--- a/tools/harness-thci/OpenThread_WpanCtl.py
+++ b/tools/harness-thci/OpenThread_WpanCtl.py
@@ -332,7 +332,7 @@ class OpenThread_WpanCtl(IThci):
                 # link local address
                 if ip6Addr.split(':')[4] != '0':
                     linkLocal64Addr = ip6Addr
-            elif ip6AddrPrefix == 'fd00':
+            elif ip6Addr.startswith(self.meshLocalPrefix)
                 # mesh local address
                 if ip6Addr.split(':')[4] == '0':
                     # rloc
@@ -1940,6 +1940,7 @@ class OpenThread_WpanCtl(IThci):
             cmd = WPANCTL_CMD + 'setprop IPv6:MeshLocalPrefix %s' % sMeshLocalPrefix
             datasetCmd = WPANCTL_CMD + 'setprop Dataset:MeshLocalPrefix %s' % sMeshLocalPrefix
             self.hasActiveDatasetToCommit = True
+            self.meshLocalPrefix = sMeshLocalPrefix
             return self.__sendCommand(cmd)[0] != 'Fail' and self.__sendCommand(datasetCmd)[0] != 'Fail'
         except Exception, e:
             ModuleHelper.WriteIntoDebugLogger('setMLPrefix() Error: ' + str(e))

--- a/tools/harness-thci/OpenThread_WpanCtl.py
+++ b/tools/harness-thci/OpenThread_WpanCtl.py
@@ -1451,7 +1451,7 @@ class OpenThread_WpanCtl(IThci):
         self.channelMask = "0x7fff800" #(0xffff << 11)
         self.panId = ModuleHelper.Default_PanId
         self.xpanId = ModuleHelper.Default_XpanId
-        self.localprefix = ModuleHelper.Default_MLPrefix
+        self.meshLocalPrefix = ModuleHelper.Default_MLPrefix
         self.pskc = "00000000000000000000000000000000"  # OT only accept hex format PSKc for now
         self.securityPolicySecs = ModuleHelper.Default_SecurityPolicy
         self.securityPolicyFlags = "onrcb"
@@ -1480,7 +1480,7 @@ class OpenThread_WpanCtl(IThci):
             self.setXpanId(self.xpanId)
             self.setNetworkName(self.networkName)
             self.setNetworkKey(self.networkKey)
-            self.setMLPrefix(self.localprefix)
+            self.setMLPrefix(self.meshLocalPrefix)
             self.setPSKc(self.pskc)
             self.setActiveTimestamp(self.activetimestamp)
         except Exception, e:

--- a/tools/harness-thci/OpenThread_WpanCtl.py
+++ b/tools/harness-thci/OpenThread_WpanCtl.py
@@ -1940,7 +1940,6 @@ class OpenThread_WpanCtl(IThci):
             cmd = WPANCTL_CMD + 'setprop IPv6:MeshLocalPrefix %s' % sMeshLocalPrefix
             datasetCmd = WPANCTL_CMD + 'setprop Dataset:MeshLocalPrefix %s' % sMeshLocalPrefix
             self.hasActiveDatasetToCommit = True
-            self.meshLocalPrefix = sMeshLocalPrefix
             return self.__sendCommand(cmd)[0] != 'Fail' and self.__sendCommand(datasetCmd)[0] != 'Fail'
         except Exception, e:
             ModuleHelper.WriteIntoDebugLogger('setMLPrefix() Error: ' + str(e))

--- a/tools/harness-thci/OpenThread_WpanCtl.py
+++ b/tools/harness-thci/OpenThread_WpanCtl.py
@@ -332,7 +332,7 @@ class OpenThread_WpanCtl(IThci):
                 # link local address
                 if ip6Addr.split(':')[4] != '0':
                     linkLocal64Addr = ip6Addr
-            elif ip6Addr.startswith(self.meshLocalPrefix)
+            elif ip6Addr.startswith(self.meshLocalPrefix):
                 # mesh local address
                 if ip6Addr.split(':')[4] == '0':
                     # rloc


### PR DESCRIPTION
We met some errors running Test Harness for 1.2 features when calling `getDUA`. The `getDUA` function in our THCI is implemented using `getGUA`. And the critical code that cause the problem in `OpenThread.py` is as below:
```
    def __getIp6Address(self, addressType):
        # ......
            ip6AddrPrefix = ip6Addr.split(':')[0]
            if ip6AddrPrefix == 'fe80':
                # link local address
                if ip6Addr.split(':')[4] != '0':
                    linkLocal64Addr = ip6Addr
            elif ip6AddrPrefix == 'fd00':
                # mesh local address
                if ip6Addr.split(':')[4] == '0':
                    # rloc
                    rlocAddr = ip6Addr
                else:
                    # mesh EID
                    meshEIDAddr = ip6Addr
         # ......


    def getGlobal(self):
        #......
        return self.__getIp6Address('global')

    def getGUA(self, filterByPrefix=None):
        """get expected global unicast IPv6 address of Thread device
        Args:
            filterByPrefix: a given expected global IPv6 prefix to be matched
        Returns:
            a global IPv6 address
        """
        print '%s call getGUA' % self.port
        print filterByPrefix
        globalAddrs = []
        try:
            # get global addrs set if multiple
            globalAddrs = self.getGlobal()

            if filterByPrefix is None:
                return globalAddrs[0]
            else:
                for line in globalAddrs:
                    fullIp = ModuleHelper.GetFullIpv6Address(line)
                    if fullIp.startswith(filterByPrefix):
                        return fullIp
                print 'no global address matched'
                return str(globalAddrs[0])
        except Exception, e:
            ModuleHelper.WriteIntoDebugLogger("getGUA() Error: " + str(e))
```
When calling `getGlobal`, current code simply remove all the addresses that start with `fd00` and `fe80`, but a **DUA** in 1.2 could start with `fd00`. So I changed it so that it remove all the link local addresses and mesh local addresses.
