### PR TITLE
[mle] not echo back ML-EID registered by MTD

### DIFF
--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -295,7 +295,7 @@ compress:
     SuccessOrExit(error = buf.Advance(sizeof(hcCtl)));
 
     // Context Identifier
-    if (srcContext.mContextId != Mle::kRsvContextId || dstContext.mContextId != Mle::kRsvContextId)
+    if (srcContext.mContextId != 0 || dstContext.mContextId != 0)
     {
         hcCtl |= kHcContextId;
         SuccessOrExit(error = buf.Write(((srcContext.mContextId << 4) | dstContext.mContextId) & 0xff));

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -295,7 +295,7 @@ compress:
     SuccessOrExit(error = buf.Advance(sizeof(hcCtl)));
 
     // Context Identifier
-    if (srcContext.mContextId != 0 || dstContext.mContextId != 0)
+    if (srcContext.mContextId != Mle::kRsvContextId || dstContext.mContextId != Mle::kRsvContextId)
     {
         hcCtl |= kHcContextId;
         SuccessOrExit(error = buf.Write(((srcContext.mContextId << 4) | dstContext.mContextId) & 0xff));

--- a/src/core/thread/mle_constants.hpp
+++ b/src/core/thread/mle_constants.hpp
@@ -126,6 +126,7 @@ enum
     kReedAdvertiseJitter        = 60,                                      ///< REED_ADVERTISEMENT_JITTER (sec)
     kLeaderWeight               = 64,                                      ///< Default leader weight
     kMleEndDeviceTimeout        = OPENTHREAD_CONFIG_DEFAULT_CHILD_TIMEOUT, ///< MLE_END_DEVICE_TIMEOUT (sec)
+    kRsvContextId               = 0,                                       ///< 0 is reserved for Mesh Local Prefix
 };
 
 /**

--- a/src/core/thread/mle_constants.hpp
+++ b/src/core/thread/mle_constants.hpp
@@ -126,7 +126,7 @@ enum
     kReedAdvertiseJitter        = 60,                                      ///< REED_ADVERTISEMENT_JITTER (sec)
     kLeaderWeight               = 64,                                      ///< Default leader weight
     kMleEndDeviceTimeout        = OPENTHREAD_CONFIG_DEFAULT_CHILD_TIMEOUT, ///< MLE_END_DEVICE_TIMEOUT (sec)
-    kRsvContextId               = 0,                                       ///< 0 is reserved for Mesh Local Prefix
+    kMeshLocalPrefixContextId   = 0,                                       ///< 0 is reserved for Mesh Local Prefix
 };
 
 /**

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3327,7 +3327,7 @@ Neighbor *MleRouter::GetNeighbor(const Ip6::Address &aAddress)
     {
         child = iter.GetChild();
 
-        if (context.mContextId == kRsvContextId && aAddress.mFields.m16[4] == HostSwap16(0x0000) &&
+        if (context.mContextId == kMeshLocalPrefixContextId && aAddress.mFields.m16[4] == HostSwap16(0x0000) &&
             aAddress.mFields.m16[5] == HostSwap16(0x00ff) && aAddress.mFields.m16[6] == HostSwap16(0xfe00) &&
             aAddress.mFields.m16[7] == HostSwap16(child->GetRloc16()))
         {
@@ -3340,7 +3340,7 @@ Neighbor *MleRouter::GetNeighbor(const Ip6::Address &aAddress)
         }
     }
 
-    VerifyOrExit(context.mContextId == kRsvContextId, rval = NULL);
+    VerifyOrExit(context.mContextId == kMeshLocalPrefixContextId, rval = NULL);
 
     if (aAddress.mFields.m16[4] == HostSwap16(0x0000) && aAddress.mFields.m16[5] == HostSwap16(0x00ff) &&
         aAddress.mFields.m16[6] == HostSwap16(0xfe00))
@@ -4364,7 +4364,7 @@ otError MleRouter::AppendChildAddresses(Message &aMessage, Child &aChild)
             entry.SetUncompressed();
             entry.SetIp6Address(address);
         }
-        else if (context.mContextId != kRsvContextId)
+        else if (context.mContextId != kMeshLocalPrefixContextId)
         {
             // compressed entry
             entry.SetContextId(context.mContextId);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -4387,7 +4387,7 @@ otError MleRouter::AppendChildAddresses(Message &aMessage, Child &aChild)
     else
     {
         // remove AddressRegistrationTlv if no address to be echoed back
-        aMessage.SetLength(aMessage.GetLength() - sizeof(tlv));
+        aMessage.SetLength(startOffset);
     }
 
 exit:

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -83,7 +83,7 @@ otError LeaderBase::GetContext(const Ip6::Address &aAddress, Lowpan::Context &aC
     {
         aContext.mPrefix       = netif.GetMle().GetMeshLocalPrefix().m8;
         aContext.mPrefixLength = 64;
-        aContext.mContextId    = 0;
+        aContext.mContextId    = Mle::kRsvContextId;
         aContext.mCompressFlag = true;
     }
 
@@ -127,11 +127,11 @@ otError LeaderBase::GetContext(uint8_t aContextId, Lowpan::Context &aContext)
     PrefixTlv * prefix;
     ContextTlv *contextTlv;
 
-    if (aContextId == 0)
+    if (aContextId == Mle::kRsvContextId)
     {
         aContext.mPrefix       = GetNetif().GetMle().GetMeshLocalPrefix().m8;
         aContext.mPrefixLength = 64;
-        aContext.mContextId    = 0;
+        aContext.mContextId    = Mle::kRsvContextId;
         aContext.mCompressFlag = true;
         ExitNow(error = OT_ERROR_NONE);
     }

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -83,7 +83,7 @@ otError LeaderBase::GetContext(const Ip6::Address &aAddress, Lowpan::Context &aC
     {
         aContext.mPrefix       = netif.GetMle().GetMeshLocalPrefix().m8;
         aContext.mPrefixLength = 64;
-        aContext.mContextId    = Mle::kRsvContextId;
+        aContext.mContextId    = Mle::kMeshLocalPrefixContextId;
         aContext.mCompressFlag = true;
     }
 
@@ -127,11 +127,11 @@ otError LeaderBase::GetContext(uint8_t aContextId, Lowpan::Context &aContext)
     PrefixTlv * prefix;
     ContextTlv *contextTlv;
 
-    if (aContextId == Mle::kRsvContextId)
+    if (aContextId == Mle::kMeshLocalPrefixContextId)
     {
         aContext.mPrefix       = GetNetif().GetMle().GetMeshLocalPrefix().m8;
         aContext.mPrefixLength = 64;
-        aContext.mContextId    = Mle::kRsvContextId;
+        aContext.mContextId    = Mle::kMeshLocalPrefixContextId;
         aContext.mCompressFlag = true;
         ExitNow(error = OT_ERROR_NONE);
     }

--- a/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
@@ -86,6 +86,7 @@ class Cert_5_2_5_AddressQuery(unittest.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
         self.nodes[LEADER].add_prefix('2001::/64', 'pdros')
         self.nodes[LEADER].register_netdata()
+        self.simulator.set_lowpan_context(1, '2001::/64')
 
         # 2. BR: SLAAC Server for prefix 2002::/64.
         self.nodes[BR].start()
@@ -93,6 +94,7 @@ class Cert_5_2_5_AddressQuery(unittest.TestCase):
         self.assertEqual(self.nodes[BR].get_state(), 'router')
         self.nodes[BR].add_prefix('2002::/64', 'paros')
         self.nodes[BR].register_netdata()
+        self.simulator.set_lowpan_context(2, '2002::/64')
 
         # 3. Bring up remaining devices except DUT_REED.
         for i in range(2, 17):

--- a/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
+++ b/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
@@ -120,6 +120,9 @@ class Cert_5_3_7_DuplicateAddress(unittest.TestCase):
         self.nodes[ROUTER2].add_prefix('2001:2:0:1::/64', 'paros')
         self.nodes[ROUTER2].register_netdata()
 
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(1, '2001:2:0:1::/64')
+
         self.nodes[MED1].add_ipaddr('2001:2:0:1::1234')
         self.nodes[SED1].add_ipaddr('2001:2:0:1::1234')
 

--- a/tests/scripts/thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py
@@ -86,6 +86,11 @@ class Cert_5_6_1_NetworkDataLeaderAsBr(unittest.TestCase):
         self.nodes[LEADER].add_prefix('2001:2:0:1::/64', 'paros')
         self.nodes[LEADER].add_prefix('2001:2:0:2::/64', 'paro')
         self.nodes[LEADER].register_netdata()
+
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(1, '2001:2:0:1::/64')
+        self.simulator.set_lowpan_context(2, '2001:2:0:2::/64')
+
         self.simulator.go(5)
 
         self.nodes[ROUTER].start()

--- a/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
@@ -91,6 +91,10 @@ class Cert_5_6_2_NetworkDataRouterAsBr(unittest.TestCase):
         self.nodes[ROUTER].add_prefix('2001:2:0:2::/64', 'paro')
         self.nodes[ROUTER].register_netdata()
 
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(1, '2001:2:0:1::/64')
+        self.simulator.set_lowpan_context(2, '2001:2:0:2::/64')
+
         self.nodes[ED1].start()
         self.simulator.go(5)
         self.assertEqual(self.nodes[ED1].get_state(), 'child')

--- a/tests/scripts/thread-cert/Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py
@@ -99,6 +99,10 @@ class Cert_5_6_3_NetworkDataRegisterAfterAttachLeader(unittest.TestCase):
         self.nodes[LEADER].add_prefix('2001:2:0:2::/64', 'paro')
         self.nodes[LEADER].register_netdata()
 
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(1, '2001:2:0:1::/64')
+        self.simulator.set_lowpan_context(2, '2001:2:0:2::/64')
+
         self.simulator.go(10)
 
         addrs = self.nodes[ED1].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
@@ -99,6 +99,10 @@ class Cert_5_6_4_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
         self.nodes[ROUTER].add_prefix('2001:2:0:2::/64', 'paro')
         self.nodes[ROUTER].register_netdata()
 
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(1, '2001:2:0:1::/64')
+        self.simulator.set_lowpan_context(2, '2001:2:0:2::/64')
+
         self.simulator.go(10)
 
         addrs = self.nodes[ED1].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
@@ -99,6 +99,10 @@ class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
         self.nodes[ROUTER].add_prefix('2001:2:0:2::/64', 'paro')
         self.nodes[ROUTER].register_netdata()
 
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(1, '2001:2:0:1::/64')
+        self.simulator.set_lowpan_context(2, '2001:2:0:2::/64')
+
         self.simulator.go(10)
 
         addrs = self.nodes[ED1].get_addrs()
@@ -117,6 +121,9 @@ class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(unittest.TestCase):
 
         self.nodes[ROUTER].add_prefix('2001:2:0:3::/64', 'pacs')
         self.nodes[ROUTER].register_netdata()
+
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(3, '2001:2:0:3::/64')
 
         self.simulator.go(10)
 

--- a/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
+++ b/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
@@ -99,6 +99,10 @@ class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
         self.nodes[ROUTER].add_prefix('2001:2:0:2::/64', 'paro')
         self.nodes[ROUTER].register_netdata()
 
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(1, '2001:2:0:1::/64')
+        self.simulator.set_lowpan_context(2, '2001:2:0:2::/64')
+
         self.simulator.go(10)
 
         addrs = self.nodes[ED1].get_addrs()
@@ -117,6 +121,9 @@ class Cert_5_6_6_NetworkDataExpiration(unittest.TestCase):
 
         self.nodes[ROUTER].add_prefix('2001:2:0:3::/64', 'pacs')
         self.nodes[ROUTER].register_netdata()
+
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(3, '2001:2:0:3::/64')
 
         self.simulator.go(10)
 

--- a/tests/scripts/thread-cert/Cert_5_6_07_NetworkDataRequestREED.py
+++ b/tests/scripts/thread-cert/Cert_5_6_07_NetworkDataRequestREED.py
@@ -88,6 +88,9 @@ class Cert_5_6_7_NetworkDataRequestREED(unittest.TestCase):
         self.nodes[ROUTER].add_prefix('2001:2:0:3::/64', 'paros')
         self.nodes[ROUTER].register_netdata()
 
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(1, '2001:2:0:3::/64')
+
         self.simulator.go(2)
 
         self.nodes[LEADER].add_whitelist(self.nodes[REED].get_addr64())

--- a/tests/scripts/thread-cert/Cert_5_6_08_ContextManagement.py
+++ b/tests/scripts/thread-cert/Cert_5_6_08_ContextManagement.py
@@ -84,6 +84,10 @@ class Cert_5_6_8_ContextManagement(unittest.TestCase):
 
         self.nodes[ROUTER].add_prefix('2001:2:0:1::/64', 'paros')
         self.nodes[ROUTER].register_netdata()
+
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(1, '2001:2:0:1::/64')
+
         self.simulator.go(2)
 
         addrs = self.nodes[LEADER].get_addrs()
@@ -104,6 +108,10 @@ class Cert_5_6_8_ContextManagement(unittest.TestCase):
 
         self.nodes[ROUTER].add_prefix('2001:2:0:2::/64', 'paros')
         self.nodes[ROUTER].register_netdata()
+
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(2, '2001:2:0:2::/64')
+
         self.simulator.go(5)
 
         addrs = self.nodes[LEADER].get_addrs()
@@ -116,6 +124,10 @@ class Cert_5_6_8_ContextManagement(unittest.TestCase):
         self.simulator.go(5)
         self.nodes[ROUTER].add_prefix('2001:2:0:3::/64', 'paros')
         self.nodes[ROUTER].register_netdata()
+
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(3, '2001:2:0:3::/64')
+
         self.simulator.go(5)
 
         addrs = self.nodes[LEADER].get_addrs()

--- a/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
+++ b/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
@@ -110,6 +110,10 @@ class Cert_5_6_9_NetworkDataForwarding(unittest.TestCase):
         self.nodes[LEADER].add_prefix('2001:2:0:1::/64', 'paros', 'med')
         self.nodes[LEADER].add_route('2001:2:0:2::/64', 'med')
         self.nodes[LEADER].register_netdata()
+
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(1, '2001:2:0:1::/64')
+
         self.simulator.go(10)
 
         self.nodes[ROUTER2].add_prefix('2001:2:0:1::/64', 'paros', 'low')

--- a/tests/scripts/thread-cert/Cert_6_1_02_REEDAttach_MED.py
+++ b/tests/scripts/thread-cert/Cert_6_1_02_REEDAttach_MED.py
@@ -31,7 +31,7 @@ import unittest
 
 from command import check_parent_request
 from command import check_child_id_request
-from command import check_child_update_request_by_child
+from command import check_child_update_request_from_child
 from command import CheckType
 import config
 import mle
@@ -109,7 +109,7 @@ class Cert_6_1_2_REEDAttach_MED(unittest.TestCase):
         
         # Step 8 - DUT sends Child Update messages
         msg = med_messages.next_mle_message(mle.CommandType.CHILD_UPDATE_REQUEST)
-        check_child_update_request_by_child(msg)
+        check_child_update_request_from_child(msg, source_address=CheckType.CONTAIN, leader_data=CheckType.CONTAIN)
 
         # Step 10 - Leader sends ICMPv6 echo request, to DUT link local address
         med_addrs = self.nodes[MED].get_addrs()

--- a/tests/scripts/thread-cert/Cert_6_3_02_NetworkDataUpdate.py
+++ b/tests/scripts/thread-cert/Cert_6_3_02_NetworkDataUpdate.py
@@ -72,6 +72,10 @@ class Cert_6_3_2_NetworkDataUpdate(unittest.TestCase):
 
         self.nodes[LEADER].add_prefix('2001:2:0:1::/64', 'paros')
         self.nodes[LEADER].register_netdata()
+
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(1, '2001:2:0:1::/64')
+
         self.simulator.go(5)
 
         addrs = self.nodes[ED].get_addrs()
@@ -85,6 +89,10 @@ class Cert_6_3_2_NetworkDataUpdate(unittest.TestCase):
 
         self.nodes[LEADER].add_prefix('2001:2:0:2::/64', 'paros')
         self.nodes[LEADER].register_netdata()
+
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(2, '2001:2:0:2::/64')
+
         self.simulator.go(5)
 
         self.nodes[LEADER].add_whitelist(self.nodes[ED].get_addr64())

--- a/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
@@ -33,8 +33,8 @@ import unittest
 
 from command import check_child_id_response
 from command import check_child_update_response
+from command import check_child_update_request_from_child
 from command import check_data_response
-from command import check_message_address_registration_addr_set_equals
 from command import CheckType
 from command import NetworkDataCheckType
 import config
@@ -96,6 +96,10 @@ class Cert_7_1_1_BorderRouterAsLeader(unittest.TestCase):
         self.nodes[LEADER].add_prefix('2001:2:0:2::/64', 'paro')
         self.nodes[LEADER].register_netdata()
 
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(1, '2001:2:0:1::/64')
+        self.simulator.set_lowpan_context(2, '2001:2:0:2::/64')
+
         self.nodes[ROUTER].start()
         self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
@@ -150,13 +154,14 @@ class Cert_7_1_1_BorderRouterAsLeader(unittest.TestCase):
 
         # Step 10 - DUT sends Child Update Response
         msg_chd_upd_res_to_med = leader_messages.next_mle_message(mle.CommandType.CHILD_UPDATE_RESPONSE)
-        check_child_update_response(msg_chd_upd_res_to_med, address_registration=CheckType.CONTAIN)
         msg = med1_messages.next_mle_message(mle.CommandType.CHILD_UPDATE_REQUEST)
-        check_message_address_registration_addr_set_equals(msg, msg_chd_upd_res_to_med)
+        check_child_update_request_from_child(msg, address_registration=CheckType.CONTAIN, CIDs=[0, 1, 2])
 
-        check_child_update_response(msg_chd_upd_res_to_sed, address_registration=CheckType.CONTAIN)
+        check_child_update_response(msg_chd_upd_res_to_med, address_registration=CheckType.CONTAIN, CIDs=[1, 2])
+
         msg = sed1_messages.next_mle_message(mle.CommandType.CHILD_UPDATE_REQUEST)
-        check_message_address_registration_addr_set_equals(msg, msg_chd_upd_res_to_sed)
+        check_child_update_request_from_child(msg, address_registration=CheckType.CONTAIN, CIDs=[0, 1])
+        check_child_update_response(msg_chd_upd_res_to_sed, address_registration=CheckType.CONTAIN, CIDs=[1])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
@@ -91,6 +91,10 @@ class Cert_7_1_2_BorderRouterAsRouter(unittest.TestCase):
         self.nodes[ROUTER].add_prefix('2001:2:0:2::/64', 'paro')
         self.nodes[ROUTER].register_netdata()
 
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(1, '2001:2:0:1::/64')
+        self.simulator.set_lowpan_context(2, '2001:2:0:2::/64')
+
         self.nodes[ED2].start()
         self.simulator.go(5)
         self.assertEqual(self.nodes[ED2].get_state(), 'child')

--- a/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
@@ -112,6 +112,10 @@ class Cert_7_1_3_BorderRouterAsLeader(unittest.TestCase):
         self.nodes[LEADER].register_netdata()
         self.simulator.go(5)
 
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(1, '2001:2:0:1::/64')
+        self.simulator.set_lowpan_context(2, '2001:2:0:2::/64')
+
         leader_messages = self.simulator.get_messages_sent_by(LEADER)
         med1_messages = self.simulator.get_messages_sent_by(MED1)
         sed1_messages = self.simulator.get_messages_sent_by(SED1)
@@ -138,15 +142,13 @@ class Cert_7_1_3_BorderRouterAsLeader(unittest.TestCase):
         # 4 - N/A
         # Get addresses registered by MED1
         msg = med1_messages.next_mle_message(mle.CommandType.CHILD_UPDATE_REQUEST)
-        med1_addresses = msg.get_mle_message_tlv(mle.AddressRegistration).addresses
+        command.check_child_update_request_from_child(msg, address_registration=CheckType.CONTAIN, CIDs=[0, 1, 2])
 
         # 5 - Leader
         # Make a copy of leader's messages to ensure that we don't miss messages to SED1
         leader_messages_copy = leader_messages.clone()
         msg = leader_messages_copy.next_mle_message(mle.CommandType.CHILD_UPDATE_RESPONSE, sent_to_node=self.nodes[MED1])
-        command.check_child_update_response(msg, address_registration=CheckType.CONTAIN)
-        leader_addresses = msg.get_mle_message_tlv(mle.AddressRegistration).addresses
-        self.assertTrue(all(addr in leader_addresses for addr in med1_addresses))
+        command.check_child_update_response(msg, address_registration=CheckType.CONTAIN, CIDs=[1, 2])
 
         # 6A & 6B - Leader
         if config.LEADER_NOTIFY_SED_BY_CHILD_UPDATE_REQUEST:
@@ -160,13 +162,11 @@ class Cert_7_1_3_BorderRouterAsLeader(unittest.TestCase):
         # 7 - N/A
         # Get addresses registered by SED1
         msg = sed1_messages.next_mle_message(mle.CommandType.CHILD_UPDATE_REQUEST)
-        sed1_addresses = msg.get_mle_message_tlv(mle.AddressRegistration).addresses
+        command.check_child_update_request_from_child(msg, address_registration=CheckType.CONTAIN, CIDs=[0, 1])
 
         # 8 - Leader
         msg = leader_messages.next_mle_message(mle.CommandType.CHILD_UPDATE_RESPONSE, sent_to_node=self.nodes[SED1])
-        command.check_child_update_response(msg, address_registration=CheckType.CONTAIN)
-        leader_addresses = msg.get_mle_message_tlv(mle.AddressRegistration).addresses
-        self.assertTrue(all(addr in leader_addresses for addr in sed1_addresses))
+        command.check_child_update_response(msg, address_registration=CheckType.CONTAIN, CIDs=[1])
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
@@ -100,6 +100,10 @@ class Cert_7_1_4_BorderRouterAsRouter(unittest.TestCase):
         self.nodes[ROUTER].register_netdata()
         self.simulator.go(5)
 
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(1, '2001:2:0:1::/64')
+        self.simulator.set_lowpan_context(2, '2001:2:0:2::/64')
+
         addrs = self.nodes[ED2].get_addrs()
         self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))
         self.assertTrue(any('2001:2:0:2' in addr[0:10] for addr in addrs))

--- a/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
@@ -100,6 +100,10 @@ class Cert_7_1_5_BorderRouterAsRouter(unittest.TestCase):
         self.nodes[ROUTER].register_netdata()
         self.simulator.go(5)
 
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(1, '2001:2:0:1::/64')
+        self.simulator.set_lowpan_context(2, '2001:2:0:2::/64')
+
         addrs = self.nodes[ED2].get_addrs()
         self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))
         self.assertTrue(any('2001:2:0:2' in addr[0:10] for addr in addrs))


### PR DESCRIPTION
Thread 1.1 Spec 4.7.1 says
> The ML-EID address is always registered and does not need to be acknowledged