### PR TITLE
[ncp] add SLAAC related spinel capability and property

### DIFF
--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -523,6 +523,17 @@ bool otIp6IsAddressUnspecified(const otIp6Address *aAddress);
 otError otIp6SelectSourceAddress(otInstance *aInstance, otMessageInfo *aMessageInfo);
 
 /**
+ * This function indicates whether the SLAAC module is enabled or not.
+ *
+ * This function requires the build-time feature `OPENTHREAD_CONFIG_ENABLE_SLAAC` to be enabled.
+ *
+ * @retval TRUE    SLAAC module is enabled.
+ * @retval FALSE   SLAAC module is disabled.
+ *
+ */
+bool otIp6IsSlaacEnabled(otInstance *aInstance);
+
+/**
  * This function enables/disables the SLAAC module.
  *
  * This function requires the build-time feature `OPENTHREAD_CONFIG_ENABLE_SLAAC` to be enabled.

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -272,6 +272,11 @@ exit:
 
 #if OPENTHREAD_CONFIG_ENABLE_SLAAC
 
+bool otIp6IsSlaacEnabled(otInstance *aInstance)
+{
+    return static_cast<Instance *>(aInstance)->Get<Utils::Slaac>().IsEnabled();
+}
+
 void otIp6SetSlaacEnabled(otInstance *aInstance, bool aEnabled)
 {
     Instance &    instance = *static_cast<Instance *>(aInstance);

--- a/src/core/utils/slaac_address.hpp
+++ b/src/core/utils/slaac_address.hpp
@@ -86,7 +86,7 @@ public:
     /**
      * This method enables the SLAAC module.
      *
-     * When enabled, new SLAAC addresses are generated and added fron on-mesh prefixes in network data.
+     * When enabled, new SLAAC addresses are generated and added from on-mesh prefixes in network data.
      *
      */
     void Enable(void);
@@ -98,6 +98,15 @@ public:
      *
      */
     void Disable(void);
+
+    /**
+     * This method indicates whether SLAAC module is enabled or not.
+     *
+     * @retval TRUE    SLAAC module is enabled.
+     * @retval FALSE   SLAAC module is disabled.
+     *
+     */
+    bool IsEnabled(void) const { return mEnabled; }
 
     /**
      * This methods sets a SLAAC prefix filter handler.

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1787,6 +1787,10 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_CAPS>(void)
     SuccessOrExit(error = mEncoder.WriteUintPacked(SPINEL_CAP_OOB_STEERING_DATA));
 #endif
 
+#if OPENTHREAD_CONFIG_ENABLE_SLAAC
+    SuccessOrExit(error = mEncoder.WriteUintPacked(SPINEL_CAP_SLAAC));
+#endif
+
 #if OPENTHREAD_CONFIG_NCP_ENABLE_PEEK_POKE
     SuccessOrExit(error = mEncoder.WriteUintPacked(SPINEL_CAP_PEEK_POKE));
 #endif

--- a/src/ncp/ncp_base_dispatcher.cpp
+++ b/src/ncp/ncp_base_dispatcher.cpp
@@ -511,6 +511,11 @@ NcpBase::PropertyHandler NcpBase::FindGetPropertyHandler(spinel_prop_key_t aKey)
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_RCP_VERSION>;
         break;
 #endif
+#if OPENTHREAD_CONFIG_ENABLE_SLAAC
+    case SPINEL_PROP_SLAAC_ENABLED:
+        handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_SLAAC_ENABLED>;
+        break;
+#endif
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 
         // --------------------------------------------------------------------------
@@ -840,6 +845,11 @@ NcpBase::PropertyHandler NcpBase::FindSetPropertyHandler(spinel_prop_key_t aKey)
 #if OPENTHREAD_ENABLE_CHILD_SUPERVISION
     case SPINEL_PROP_CHILD_SUPERVISION_CHECK_TIMEOUT:
         handler = &NcpBase::HandlePropertySet<SPINEL_PROP_CHILD_SUPERVISION_CHECK_TIMEOUT>;
+        break;
+#endif
+#if OPENTHREAD_CONFIG_ENABLE_SLAAC
+    case SPINEL_PROP_SLAAC_ENABLED:
+        handler = &NcpBase::HandlePropertySet<SPINEL_PROP_SLAAC_ENABLED>;
         break;
 #endif
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -2833,6 +2833,27 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_RCP_VERSION>(void)
 
 #endif // OPENTHREAD_ENABLE_POSIX_APP
 
+#if OPENTHREAD_CONFIG_ENABLE_SLAAC
+
+template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_SLAAC_ENABLED>(void)
+{
+    return mEncoder.WriteBool(otIp6IsSlaacEnabled(mInstance));
+}
+
+template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_SLAAC_ENABLED>(void)
+{
+    otError error = OT_ERROR_NONE;
+    bool    enabled;
+
+    SuccessOrExit(error = mDecoder.ReadBool(enabled));
+    otIp6SetSlaacEnabled(mInstance, enabled);
+
+exit:
+    return error;
+}
+
+#endif // OPENTHREAD_CONFIG_ENABLE_SLAAC
+
 #if OPENTHREAD_ENABLE_LEGACY
 
 void NcpBase::RegisterLegacyHandlers(const otNcpLegacyHandlers *aHandlers)

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1851,6 +1851,10 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PARENT_RESPONSE_INFO";
         break;
 
+    case SPINEL_PROP_SLAAC_ENABLED:
+        ret = "SLAAC_ENABLED";
+        break;
+
     case SPINEL_PROP_UART_BITRATE:
         ret = "UART_BITRATE";
         break;
@@ -2478,6 +2482,10 @@ const char *spinel_capability_to_cstr(unsigned int capability)
 
     case SPINEL_CAP_POSIX_APP:
         ret = "POSIX_APP";
+        break;
+
+    case SPINEL_CAP_SLAAC:
+        ret = "SLAAC";
         break;
 
     case SPINEL_CAP_ERROR_RATE_TRACKING:

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -778,6 +778,7 @@ enum
     SPINEL_CAP_TIME_SYNC               = (SPINEL_CAP_OPENTHREAD__BEGIN + 7),
     SPINEL_CAP_CHILD_SUPERVISION       = (SPINEL_CAP_OPENTHREAD__BEGIN + 8),
     SPINEL_CAP_POSIX_APP               = (SPINEL_CAP_OPENTHREAD__BEGIN + 9),
+    SPINEL_CAP_SLAAC                   = (SPINEL_CAP_OPENTHREAD__BEGIN + 10),
     SPINEL_CAP_OPENTHREAD__END         = 640,
 
     SPINEL_CAP_THREAD__BEGIN        = 1024,
@@ -3024,6 +3025,17 @@ typedef enum
      *
      */
     SPINEL_PROP_PARENT_RESPONSE_INFO = SPINEL_PROP_OPENTHREAD__BEGIN + 13,
+
+    /// SLAAC enabled
+    /** Format `b` - Read-Write
+     *  Required capability: `SPINEL_CAP_SLAAC`
+     *
+     * This property allows the host to enable/disable SLAAC module on NCP at run-time. When SLAAC module is enabled,
+     * SLAAC addresses (based on on-mesh prefixes in Network Data) are added to the interface. When SLAAC module is
+     * disabled any previously added SLAAC address is removed.
+     *
+     */
+    SPINEL_PROP_SLAAC_ENABLED = SPINEL_PROP_OPENTHREAD__BEGIN + 14,
 
     SPINEL_PROP_OPENTHREAD__END = 0x2000,
 


### PR DESCRIPTION
This PR contains two related commits: 

**[ncp] add SLAAC related spinel capability and property**

 This commit adds `SPINEL_CAP_SLAAC` which indicates to host whether
 SLAAC feature is supported. It also adds `SPINEL_PROP_SLAAC_ENABLED`
 spinel property to let host enable/disable SLAAC module at run-time.

------

**[slaac] add IsEnabled() method and public API otIp6IsSlaacEnabled**
