### PR TITLE
[link-raw] log frame tx attempt failures

### DIFF
--- a/src/core/mac/link_raw.cpp
+++ b/src/core/mac/link_raw.cpp
@@ -205,6 +205,24 @@ void LinkRaw::InvokeEnergyScanDone(int8_t aEnergyScanMaxRssi)
     }
 }
 
+#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MAC == 1)
+void LinkRaw::RecordFrameTransmitStatus(const Frame &aFrame,
+                                        const Frame *aAckFrame,
+                                        otError      aError,
+                                        uint8_t      aRetryCount,
+                                        bool         aWillRetx)
+{
+    OT_UNUSED_VARIABLE(aAckFrame);
+    OT_UNUSED_VARIABLE(aWillRetx);
+
+    if (aError != OT_ERROR_NONE)
+    {
+        otLogInfoMac("Frame tx failed, error:%s, retries:%d/%d, %s", otThreadErrorToString(aError), aRetryCount,
+                     aFrame.GetMaxFrameRetries(), aFrame.ToInfoString().AsCString());
+    }
+}
+#endif
+
 } // namespace Mac
 } // namespace ot
 

--- a/src/core/mac/link_raw.hpp
+++ b/src/core/mac/link_raw.hpp
@@ -253,6 +253,33 @@ public:
      */
     otError SetExtAddress(const ExtAddress &aExtAddress);
 
+    /**
+     * This method records the status of a frame transmission attempt and is mainly used for logging failures.
+     *
+     * Unlike `HandleTransmitDone` which is called after all transmission attempts of frame to indicate final status
+     * of a frame transmission request, this method is invoked on all frame transmission attempts.
+     *
+     * @param[in] aFrame      The transmitted frame.
+     * @param[in] aAckFrame   A pointer to the ACK frame, or NULL if no ACK was received.
+     * @param[in] aError      OT_ERROR_NONE when the frame was transmitted successfully,
+     *                        OT_ERROR_NO_ACK when the frame was transmitted but no ACK was received,
+     *                        OT_ERROR_CHANNEL_ACCESS_FAILURE tx failed due to activity on the channel,
+     *                        OT_ERROR_ABORT when transmission was aborted for other reasons.
+     * @param[in] aRetryCount Indicates number of transmission retries for this frame.
+     * @param[in] aWillRetx   Indicates whether frame will be retransmitted or not. This is applicable only
+     *                        when there was an error in transmission (i.e., `aError` is not NONE).
+     *
+     */
+#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MAC == 1)
+    void RecordFrameTransmitStatus(const Frame &aFrame,
+                                   const Frame *aAckFrame,
+                                   otError      aError,
+                                   uint8_t      aRetryCount,
+                                   bool         aWillRetx);
+#else
+    void    RecordFrameTransmitStatus(const Frame &, const Frame *, otError, uint8_t, bool) {}
+#endif
+
 private:
     bool                    mEnabled;
     uint8_t                 mReceiveChannel;

--- a/src/core/mac/sub_mac_callbacks.cpp
+++ b/src/core/mac/sub_mac_callbacks.cpp
@@ -143,8 +143,13 @@ void SubMac::Callbacks::RecordCcaStatus(bool, uint8_t)
 {
 }
 
-void SubMac::Callbacks::RecordFrameTransmitStatus(const Frame &, const Frame *, otError, uint8_t, bool)
+void SubMac::Callbacks::RecordFrameTransmitStatus(const Frame &aFrame,
+                                                  const Frame *aAckFrame,
+                                                  otError      aError,
+                                                  uint8_t      aRetryCount,
+                                                  bool         aWillRetx)
 {
+    static_cast<LinkRaw *>(this)->RecordFrameTransmitStatus(aFrame, aAckFrame, aError, aRetryCount, aWillRetx);
 }
 
 void SubMac::Callbacks::TransmitDone(Frame &aFrame, Frame *aAckFrame, otError aError)


### PR DESCRIPTION
This commit adds logs to indicate frame tx attempt failures on
`LinkRaw` class for RCP model.