### PR TITLE
[style] minor code style fixups

### DIFF
--- a/include/openthread/coap_secure.h
+++ b/include/openthread/coap_secure.h
@@ -128,8 +128,8 @@ otError otCoapSecureSetPsk(otInstance *   aInstance,
  */
 otError otCoapSecureGetPeerCertificateBase64(otInstance *   aInstance,
                                              unsigned char *aPeerCert,
-                                             uint64_t *     aCertLength,
-                                             uint64_t       aCertBufferSize);
+                                             size_t *       aCertLength,
+                                             size_t         aCertBufferSize);
 
 /**
  * This method sets the authentication mode for the coap secure connection.

--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -407,31 +407,6 @@ OTAPI otError OTCALL otDatasetSendMgmtPendingSet(otInstance *                aIn
                                                  uint8_t                     aLength);
 
 /**
- * Get minimal delay timer.
- *
- * @param[in]  aInstance A pointer to an OpenThread instance.
- *
- * @retval the value of minimal delay timer (in ms).
- *
- */
-OTAPI uint32_t OTCALL otDatasetGetDelayTimerMinimal(otInstance *aInstance);
-
-/**
- * Set minimal delay timer.
- *
- * @note This API is reserved for testing and demo purposes only. Changing settings with
- * this API will render a production application non-compliant with the Thread Specification.
- *
- * @param[in]  aInstance           A pointer to an OpenThread instance.
- * @param[in]  aDelayTimerMinimal  The value of minimal delay timer (in ms).
- *
- * @retval  OT_ERROR_NONE          Successfully set minimal delay timer.
- * @retval  OT_ERROR_INVALID_ARGS  If @p aDelayTimerMinimal is not valid.
- *
- */
-OTAPI otError OTCALL otDatasetSetDelayTimerMinimal(otInstance *aInstance, uint32_t aDelayTimerMinimal);
-
-/**
  * @}
  *
  */

--- a/include/openthread/link_raw.h
+++ b/include/openthread/link_raw.h
@@ -267,7 +267,7 @@ otError otLinkRawSrcMatchEnable(otInstance *aInstance, bool aEnable);
  * @retval OT_ERROR_INVALID_STATE    If the raw link-layer isn't enabled.
  *
  */
-otError otLinkRawSrcMatchAddShortEntry(otInstance *aInstance, const uint16_t aShortAddress);
+otError otLinkRawSrcMatchAddShortEntry(otInstance *aInstance, uint16_t aShortAddress);
 
 /**
  * Adding extended address to the source match table.
@@ -293,7 +293,7 @@ otError otLinkRawSrcMatchAddExtEntry(otInstance *aInstance, const otExtAddress *
  * @retval OT_ERROR_INVALID_STATE    If the raw link-layer isn't enabled.
  *
  */
-otError otLinkRawSrcMatchClearShortEntry(otInstance *aInstance, const uint16_t aShortAddress);
+otError otLinkRawSrcMatchClearShortEntry(otInstance *aInstance, uint16_t aShortAddress);
 
 /**
  * Removing extended address to the source match table of the radio.

--- a/include/openthread/platform/debug_uart.h
+++ b/include/openthread/platform/debug_uart.h
@@ -106,9 +106,9 @@ void otPlatDebugUart_vprintf(const char *fmt, va_list ap);
  *
  * This function MUST be implemented by the platform
  *
- * @param[in] the_byte   what to transmit
+ * @param[in] c   what to transmit
  */
-void otPlatDebugUart_putchar_raw(int the_byte);
+void otPlatDebugUart_putchar_raw(int c);
 
 /**
  * Poll/test debug uart if a key has been pressed.
@@ -138,9 +138,9 @@ int otPlatDebugUart_getc(void);
  * A WEAK default implementation is provided
  * that can be overridden as needed.
  *
- * @param[in] the_byte   the byte to transmit
+ * @param[in] c   the byte to transmit
  */
-void otPlatDebugUart_putchar(int the_byte);
+void otPlatDebugUart_putchar(int c);
 
 /**
  * identical to "man 3 puts" - terminates with lf

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -404,17 +404,17 @@ void Interpreter::OutputBytes(const uint8_t *aBytes, uint8_t aLength) const
     }
 }
 
-otError Interpreter::ParseLong(char *argv, long &value)
+otError Interpreter::ParseLong(char *aString, long &aLong)
 {
     char *endptr;
-    value = strtol(argv, &endptr, 0);
+    aLong = strtol(aString, &endptr, 0);
     return (*endptr == '\0') ? OT_ERROR_NONE : OT_ERROR_PARSE;
 }
 
-otError Interpreter::ParseUnsignedLong(char *argv, unsigned long &value)
+otError Interpreter::ParseUnsignedLong(char *aString, unsigned long &aUnsignedLong)
 {
     char *endptr;
-    value = strtoul(argv, &endptr, 0);
+    aUnsignedLong = strtoul(aString, &endptr, 0);
     return (*endptr == '\0') ? OT_ERROR_NONE : OT_ERROR_PARSE;
 }
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -263,7 +263,7 @@ template <class T> class otPtr
     T *ptr;
 
 public:
-    otPtr(T *_ptr)
+    explicit otPtr(T *_ptr)
         : ptr(_ptr)
     {
     }

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1799,7 +1799,7 @@ void Interpreter::ProcessNetworkName(int argc, char *argv[])
     if (argc == 0)
     {
         otStringPtr networkName(otThreadGetNetworkName(mInstance));
-        mServer->OutputFormat("%.*s\r\n", OT_NETWORK_NAME_MAX_SIZE, (const char *)networkName);
+        mServer->OutputFormat("%.*s\r\n", OT_NETWORK_NAME_MAX_SIZE, static_cast<const char *>(networkName));
     }
     else
     {
@@ -3135,7 +3135,7 @@ void Interpreter::ProcessVersion(int argc, char *argv[])
     OT_UNUSED_VARIABLE(argv);
 
     otStringPtr version(otGetVersionString());
-    mServer->OutputFormat("%s\r\n", (const char *)version);
+    mServer->OutputFormat("%s\r\n", static_cast<const char *>(version));
     AppendResult(OT_ERROR_NONE);
 }
 

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -162,7 +162,7 @@ public:
      *
      * @param[in]  aError Error code value.
      */
-    void AppendResult(otError error) const;
+    void AppendResult(otError aError) const;
 
     /**
      * Write a number of bytes to the CLI console as a hex string.

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -110,7 +110,7 @@ public:
      *
      * @param[in]  aInstance  The OpenThread instance structure.
      */
-    Interpreter(Instance *aInstance);
+    explicit Interpreter(Instance *aInstance);
 
     /**
      * This method interprets a CLI command.

--- a/src/cli/cli_coap.hpp
+++ b/src/cli/cli_coap.hpp
@@ -58,7 +58,7 @@ public:
      * @param[in]  aInterpreter  The CLI interpreter.
      *
      */
-    Coap(Interpreter &aInterpreter);
+    explicit Coap(Interpreter &aInterpreter);
 
     /**
      * This method interprets a list of CLI arguments.

--- a/src/cli/cli_coap_secure.hpp
+++ b/src/cli/cli_coap_secure.hpp
@@ -64,7 +64,7 @@ public:
      * @param[in]  aInterpreter  The CLI interpreter.
      *
      */
-    CoapSecure(Interpreter &aInterpreter);
+    explicit CoapSecure(Interpreter &aInterpreter);
 
     /**
      * This method interprets a list of CLI arguments.

--- a/src/cli/cli_console.hpp
+++ b/src/cli/cli_console.hpp
@@ -57,7 +57,7 @@ public:
      * @param[in]  aInstance  The OpenThread instance structure.
      *
      */
-    Console(Instance *aInstance);
+    explicit Console(Instance *aInstance);
 
     /**
      * This method delivers raw characters to the client.

--- a/src/cli/cli_dataset.hpp
+++ b/src/cli/cli_dataset.hpp
@@ -52,7 +52,7 @@ class Interpreter;
 class Dataset
 {
 public:
-    Dataset(Interpreter &aInterpreter)
+    explicit Dataset(Interpreter &aInterpreter)
         : mInterpreter(aInterpreter)
     {
     }

--- a/src/cli/cli_server.hpp
+++ b/src/cli/cli_server.hpp
@@ -48,7 +48,7 @@ namespace Cli {
 class Server
 {
 public:
-    Server(Instance *aInstance)
+    explicit Server(Instance *aInstance)
         : mInterpreter(aInstance)
     {
     }

--- a/src/cli/cli_uart.hpp
+++ b/src/cli/cli_uart.hpp
@@ -57,7 +57,7 @@ public:
      * @param[in]  aInstance  The OpenThread instance structure.
      *
      */
-    Uart(Instance *aInstance);
+    explicit Uart(Instance *aInstance);
 
     /**
      * This method delivers raw characters to the client.

--- a/src/cli/cli_udp.hpp
+++ b/src/cli/cli_udp.hpp
@@ -56,7 +56,7 @@ public:
      * @param[in]  aInterpreter  The CLI interpreter.
      *
      */
-    UdpExample(Interpreter &aInterpreter);
+    explicit UdpExample(Interpreter &aInterpreter);
 
     /**
      * This method interprets a list of CLI arguments.

--- a/src/core/api/channel_manager_api.cpp
+++ b/src/core/api/channel_manager_api.cpp
@@ -62,11 +62,11 @@ uint16_t otChannelManagerGetDelay(otInstance *aInstance)
     return instance.GetChannelManager().GetDelay();
 }
 
-otError otChannelManagerSetDelay(otInstance *aInstance, uint16_t aMinDelay)
+otError otChannelManagerSetDelay(otInstance *aInstance, uint16_t aDelay)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.GetChannelManager().SetDelay(aMinDelay);
+    return instance.GetChannelManager().SetDelay(aDelay);
 }
 
 otError otChannelManagerRequestChannelSelect(otInstance *aInstance, bool aSkipQualityCheck)

--- a/src/core/api/coap_secure_api.cpp
+++ b/src/core/api/coap_secure_api.cpp
@@ -127,14 +127,13 @@ otError otCoapSecureSetPsk(otInstance *   aInstance,
 
 otError otCoapSecureGetPeerCertificateBase64(otInstance *   aInstance,
                                              unsigned char *aPeerCert,
-                                             uint64_t *     aCertLength,
-                                             uint64_t       aCertBufferSize)
+                                             size_t *       aCertLength,
+                                             size_t         aCertBufferSize)
 {
 #ifdef MBEDTLS_BASE64_C
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.GetApplicationCoapSecure().GetPeerCertificateBase64(aPeerCert, (size_t *)aCertLength,
-                                                                        (size_t)aCertBufferSize);
+    return instance.GetApplicationCoapSecure().GetPeerCertificateBase64(aPeerCert, aCertLength, aCertBufferSize);
 #else
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aPeerCert);

--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -299,12 +299,12 @@ otError otCommissionerGeneratePSKc(otInstance *           aInstance,
                                    const otExtendedPanId *aExtPanId,
                                    uint8_t *              aPSKc)
 {
+    OT_UNUSED_VARIABLE(aInstance);
+
     otError error = OT_ERROR_DISABLED_FEATURE;
 
 #if OPENTHREAD_FTD && OPENTHREAD_ENABLE_COMMISSIONER
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    error = instance.GetThreadNetif().GetCommissioner().GeneratePSKc(aPassPhrase, aNetworkName, *aExtPanId, aPSKc);
+    error = MeshCoP::Commissioner::GeneratePSKc(aPassPhrase, aNetworkName, *aExtPanId, aPSKc);
 #else
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aPassPhrase);

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -36,6 +36,7 @@
 #include <openthread/link.h>
 
 #include "common/instance.hpp"
+#include "mac/mac.hpp"
 #include "phy/phy.hpp"
 
 using namespace ot;
@@ -101,7 +102,7 @@ otError otLinkSetSupportedChannelMask(otInstance *aInstance, uint32_t aChannelMa
     VerifyOrExit(instance.GetThreadNetif().GetMle().GetRole() == OT_DEVICE_ROLE_DISABLED,
                  error = OT_ERROR_INVALID_STATE);
 
-    instance.GetThreadNetif().GetMac().SetSupportedChannelMask(aChannelMask);
+    instance.GetThreadNetif().GetMac().SetSupportedChannelMask(static_cast<Mac::ChannelMask>(aChannelMask));
 
 exit:
     return error;

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -88,14 +88,14 @@ exit:
     return error;
 }
 
-otError otThreadGetLeaderRloc(otInstance *aInstance, otIp6Address *aAddress)
+otError otThreadGetLeaderRloc(otInstance *aInstance, otIp6Address *aLeaderRloc)
 {
     otError   error;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    VerifyOrExit(aAddress != NULL, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aLeaderRloc != NULL, error = OT_ERROR_INVALID_ARGS);
 
-    error = instance.GetThreadNetif().GetMle().GetLeaderAddress(*static_cast<Ip6::Address *>(aAddress));
+    error = instance.GetThreadNetif().GetMle().GetLeaderAddress(*static_cast<Ip6::Address *>(aLeaderRloc));
 
 exit:
     return error;

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -507,8 +507,8 @@ otError otThreadDiscover(otInstance *             aInstance,
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.GetThreadNetif().GetMle().Discover(aScanChannels, aPanId, aJoiner, aEnableEui64Filtering, aCallback,
-                                                       aCallbackContext);
+    return instance.GetThreadNetif().GetMle().Discover(static_cast<Mac::ChannelMask>(aScanChannels), aPanId, aJoiner,
+                                                       aEnableEui64Filtering, aCallback, aCallbackContext);
 }
 
 bool otThreadIsDiscoverInProgress(otInstance *aInstance)

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -149,7 +149,7 @@ void otThreadSetNetworkIdTimeout(otInstance *aInstance, uint8_t aTimeout)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    instance.GetThreadNetif().GetMle().SetNetworkIdTimeout((uint8_t)aTimeout);
+    instance.GetThreadNetif().GetMle().SetNetworkIdTimeout(aTimeout);
 }
 
 uint8_t otThreadGetRouterUpgradeThreshold(otInstance *aInstance)

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -57,13 +57,13 @@ exit:
     return message;
 }
 
-otError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aCallbackContext)
+otError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aContext)
 {
     otError         error    = OT_ERROR_INVALID_ARGS;
     Instance &      instance = *static_cast<Instance *>(aInstance);
     Ip6::UdpSocket &socket   = *new (aSocket) Ip6::UdpSocket(instance.GetIp6().GetUdp());
 
-    error = socket.Open(aCallback, aCallbackContext);
+    error = socket.Open(aCallback, aContext);
 
     return error;
 }

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -661,8 +661,6 @@ exit:
             cachedResponse->Free();
         }
     }
-
-    return;
 }
 
 CoapMetadata::CoapMetadata(bool                    aConfirmable,

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -267,7 +267,7 @@ public:
      * @param[in]  aMessageInfo  The message info containing source endpoint identification.
      *
      */
-    EnqueuedResponseHeader(const Ip6::MessageInfo &aMessageInfo)
+    explicit EnqueuedResponseHeader(const Ip6::MessageInfo &aMessageInfo)
         : mDequeueTime(TimerMilli::GetNow() + TimerMilli::SecToMsec(kExchangeLifetime))
         , mMessageInfo(aMessageInfo)
     {

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -45,8 +45,6 @@
 #include "common/message.hpp"
 #include "utils/static_assert.hpp"
 
-using ot::Encoding::BigEndian::HostSwap16;
-
 namespace ot {
 
 /**
@@ -56,6 +54,8 @@ namespace ot {
  *
  */
 namespace Coap {
+
+using ot::Encoding::BigEndian::HostSwap16;
 
 /**
  * @addtogroup core-coap

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -412,10 +412,10 @@ public:
     /**
      * This method sets a default response header based on request header.
      *
-     * @param[in]  aRequestHeader  Request header to base on.
+     * @param[in]  aRequest  The request message.
      *
      */
-    void SetDefaultResponseHeader(const Message &aRequestHeader);
+    void SetDefaultResponseHeader(const Message &aRequest);
 
     /**
      * This method checks if a header is an empty message header.

--- a/src/core/common/crc16.hpp
+++ b/src/core/common/crc16.hpp
@@ -59,7 +59,7 @@ public:
      * @param[in]  aPolynomial  The polynomial value.
      *
      */
-    Crc16(Polynomial aPolynomial);
+    explicit Crc16(Polynomial aPolynomial);
 
     /**
      * This method initializes the CRC16 computation.

--- a/src/core/common/locator.hpp
+++ b/src/core/common/locator.hpp
@@ -114,7 +114,7 @@ protected:
      * @param[in]  aInstance  A pointer to the otInstance.
      *
      */
-    InstanceLocator(Instance &aInstance)
+    explicit InstanceLocator(Instance &aInstance)
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
         : mInstance(aInstance)
 #endif
@@ -162,7 +162,7 @@ protected:
      * @param[in]  aOwner   A pointer to the owner object (as `void *`).
      *
      */
-    OwnerLocator(void *aOwner)
+    explicit OwnerLocator(void *aOwner)
 #if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
         : mOwner(aOwner)
 #endif

--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -1888,7 +1888,7 @@ extern "C" {
  * @param[in]  aLength   Number of bytes to print.
  *
  */
-void otDump(otLogLevel aLevel, otLogRegion aRegion, const char *aId, const void *aBuf, const size_t aLength);
+void otDump(otLogLevel aLevel, otLogRegion aRegion, const char *aId, const void *aBuf, size_t aLength);
 
 /**
  * This function converts a log level to a prefix string for appending to log message.

--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -1881,14 +1881,14 @@ extern "C" {
 /**
  * This method dumps bytes to the log in a human-readable fashion.
  *
- * @param[in]  aLevel    The log level.
- * @param[in]  aRegion   The log region.
- * @param[in]  aId       A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf      A pointer to the buffer.
- * @param[in]  aLength   Number of bytes to print.
+ * @param[in]  aLogLevel    The log level.
+ * @param[in]  aLogRegion   The log region.
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
  *
  */
-void otDump(otLogLevel aLevel, otLogRegion aRegion, const char *aId, const void *aBuf, size_t aLength);
+void otDump(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aId, const void *aBuf, size_t aLength);
 
 /**
  * This function converts a log level to a prefix string for appending to log message.

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -1244,7 +1244,7 @@ public:
         }
 
     private:
-        Iterator(Message *aMessage)
+        explicit Iterator(Message *aMessage)
             : mMessage(aMessage)
         {
         }

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -316,14 +316,14 @@ exit:
     return error;
 }
 
-otError Settings::Save(Key aKey, const void *aBuffer, uint16_t aSize)
+otError Settings::Save(Key aKey, const void *aValue, uint16_t aSize)
 {
-    return otPlatSettingsSet(&GetInstance(), aKey, reinterpret_cast<const uint8_t *>(aBuffer), aSize);
+    return otPlatSettingsSet(&GetInstance(), aKey, reinterpret_cast<const uint8_t *>(aValue), aSize);
 }
 
-otError Settings::Add(Key aKey, const void *aBuffer, uint16_t aSize)
+otError Settings::Add(Key aKey, const void *aValue, uint16_t aSize)
 {
-    return otPlatSettingsAdd(&GetInstance(), aKey, reinterpret_cast<const uint8_t *>(aBuffer), aSize);
+    return otPlatSettingsAdd(&GetInstance(), aKey, reinterpret_cast<const uint8_t *>(aValue), aSize);
 }
 
 otError Settings::Delete(Key aKey)

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -402,7 +402,7 @@ public:
          * @param[in]  aInstance  A reference to the OpenThread instance.
          *
          */
-        ChildInfoIterator(Instance &aInstance);
+        explicit ChildInfoIterator(Instance &aInstance);
 
         /**
          * This method resets the iterator to start from the first Child Info entry in the list.

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -470,7 +470,7 @@ public:
     };
 
 private:
-    otError ReadFixedSize(Key aKey, void *aBuffer, uint16_t aExpectedLength) const;
+    otError ReadFixedSize(Key aKey, void *aBuffer, uint16_t aExpectedSize) const;
     otError Read(Key aKey, void *aBuffer, uint16_t aMaxBufferSize, uint16_t &aReadSize) const;
     otError Save(Key aKey, const void *aValue, uint16_t aSize);
     otError Add(Key aKey, const void *aValue, uint16_t aSize);

--- a/src/core/common/string.hpp
+++ b/src/core/common/string.hpp
@@ -109,7 +109,7 @@ public:
      * @param[in] ...        Arguments for the format specification.
      *
      */
-    String(const char *aFormat, ...)
+    explicit String(const char *aFormat, ...)
         : mLength(0)
     {
         va_list args;

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -120,14 +120,14 @@ protected:
     /**
      * This method indicates if the fire time of this timer is strictly before the fire time of a second given timer.
      *
-     * @param[in]  aTimer   A reference to the second timer object.
-     * @param[in]  aNow     The current time (may in milliseconds or microsecond, which depends on the timer type).
+     * @param[in]  aSecondTimer   A reference to the second timer object.
+     * @param[in]  aNow           The current time (milliseconds or microsecond, depending on timer type).
      *
      * @retval TRUE  If the fire time of this timer object is strictly before aTimer's fire time
      * @retval FALSE If the fire time of this timer object is the same or after aTimer's fire time.
      *
      */
-    bool DoesFireBefore(const Timer &aTimer, uint32_t aNow);
+    bool DoesFireBefore(const Timer &aSecondTimer, uint32_t aNow);
 
     void Fired(void) { mHandler(*this); }
 

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -295,7 +295,7 @@ protected:
      * @param[in]  aInstance  A reference to the instance object.
      *
      */
-    TimerScheduler(Instance &aInstance)
+    explicit TimerScheduler(Instance &aInstance)
         : InstanceLocator(aInstance)
         , mHead(NULL)
     {
@@ -351,7 +351,7 @@ public:
      * @param[in]  aInstance  A reference to the instance object.
      *
      */
-    TimerMilliScheduler(Instance &aInstance)
+    explicit TimerMilliScheduler(Instance &aInstance)
         : TimerScheduler(aInstance)
     {
     }

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -41,10 +41,10 @@
 #include "common/encoding.hpp"
 #include "common/message.hpp"
 
+namespace ot {
+
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;
-
-namespace ot {
 
 /**
  * This class implements TLV generation and parsing.

--- a/src/core/crypto/aes_ccm.cpp
+++ b/src/core/crypto/aes_ccm.cpp
@@ -200,15 +200,15 @@ void AesCcm::Header(const void *aHeader, uint32_t aHeaderLength)
     }
 }
 
-void AesCcm::Payload(void *plaintext, void *ciphertext, uint32_t len, bool aEncrypt)
+void AesCcm::Payload(void *aPlainText, void *aCipherText, uint32_t aLength, bool aEncrypt)
 {
-    uint8_t *plaintextBytes  = reinterpret_cast<uint8_t *>(plaintext);
-    uint8_t *ciphertextBytes = reinterpret_cast<uint8_t *>(ciphertext);
+    uint8_t *plaintextBytes  = reinterpret_cast<uint8_t *>(aPlainText);
+    uint8_t *ciphertextBytes = reinterpret_cast<uint8_t *>(aCipherText);
     uint8_t  byte;
 
-    assert(mPlainTextCur + len <= mPlainTextLength);
+    assert(mPlainTextCur + aLength <= mPlainTextLength);
 
-    for (unsigned i = 0; i < len; i++)
+    for (unsigned i = 0; i < aLength; i++)
     {
         if (mCtrLength == 16)
         {
@@ -244,7 +244,7 @@ void AesCcm::Payload(void *plaintext, void *ciphertext, uint32_t len, bool aEncr
         mBlock[mBlockLength++] ^= byte;
     }
 
-    mPlainTextCur += len;
+    mPlainTextCur += aLength;
 
     if (mPlainTextCur >= mPlainTextLength)
     {
@@ -261,9 +261,9 @@ void AesCcm::Payload(void *plaintext, void *ciphertext, uint32_t len, bool aEncr
     }
 }
 
-void AesCcm::Finalize(void *tag, uint8_t *aTagLength)
+void AesCcm::Finalize(void *aTag, uint8_t *aTagLength)
 {
-    uint8_t *tagBytes = reinterpret_cast<uint8_t *>(tag);
+    uint8_t *tagBytes = reinterpret_cast<uint8_t *>(aTag);
 
     assert(mPlainTextCur == mPlainTextLength);
 

--- a/src/core/mac/channel_mask.hpp
+++ b/src/core/mac/channel_mask.hpp
@@ -92,7 +92,7 @@ public:
      * @param[in]  aMask   A channel mask (as a `uint32_t` bit-vector mask with bit 0 (lsb) -> channel 0, and so on).
      *
      */
-    ChannelMask(uint32_t aMask)
+    explicit ChannelMask(uint32_t aMask)
         : mMask(aMask)
     {
     }

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -303,9 +303,9 @@ void Mac::ReportEnergyScanResult(int8_t aRssi)
     }
 }
 
-void Mac::EnergyScanDone(int8_t aRssi)
+void Mac::EnergyScanDone(int8_t aEnergyScanMaxRssi)
 {
-    ReportEnergyScanResult(aRssi);
+    ReportEnergyScanResult(aEnergyScanMaxRssi);
     PerformEnergyScan();
 }
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -53,8 +53,6 @@
 #include "thread/mle_router.hpp"
 #include "thread/thread_netif.hpp"
 
-using ot::Encoding::BigEndian::HostSwap64;
-
 namespace ot {
 namespace Mac {
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -425,7 +425,7 @@ void Mac::SetSupportedChannelMask(const ChannelMask &aMask)
 {
     ChannelMask newMask = aMask;
 
-    newMask.Intersect(Phy::kSupportedChannels);
+    newMask.Intersect(ChannelMask(Phy::kSupportedChannels));
     VerifyOrExit(newMask != mSupportedChannelMask, GetNotifier().SignalIfFirst(OT_CHANGED_SUPPORTED_CHANNEL_MASK));
 
     mSupportedChannelMask = newMask;

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -432,7 +432,7 @@ uint8_t Frame::FindSrcAddrIndex(void) const
     return index;
 }
 
-otError Frame::GetSrcAddr(Address &address) const
+otError Frame::GetSrcAddr(Address &aAddress) const
 {
     otError  error = OT_ERROR_NONE;
     uint8_t  index = FindSrcAddrIndex();
@@ -443,15 +443,15 @@ otError Frame::GetSrcAddr(Address &address) const
     switch (fcf & kFcfSrcAddrMask)
     {
     case kFcfSrcAddrShort:
-        address.SetShort(Encoding::LittleEndian::ReadUint16(GetPsdu() + index));
+        aAddress.SetShort(Encoding::LittleEndian::ReadUint16(GetPsdu() + index));
         break;
 
     case kFcfSrcAddrExt:
-        address.SetExtended(GetPsdu() + index, /* reverse */ true);
+        aAddress.SetExtended(GetPsdu() + index, /* reverse */ true);
         break;
 
     default:
-        address.SetNone();
+        aAddress.SetNone();
         break;
     }
 
@@ -1031,12 +1031,12 @@ exit:
 }
 #endif // OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
 
-void Frame::CopyFrom(const Frame &aAnotherFrame)
+void Frame::CopyFrom(const Frame &aFromFrame)
 {
     uint8_t *      psduBuffer   = mPsdu;
     otRadioIeInfo *ieInfoBuffer = mIeInfo;
 
-    memcpy(this, &aAnotherFrame, sizeof(Frame));
+    memcpy(this, &aFromFrame, sizeof(Frame));
 
     // Set the original buffer pointers back on the frame
     // which were overwritten by above `memcpy()`.
@@ -1044,8 +1044,8 @@ void Frame::CopyFrom(const Frame &aAnotherFrame)
     mPsdu   = psduBuffer;
     mIeInfo = ieInfoBuffer;
 
-    memcpy(mPsdu, aAnotherFrame.mPsdu, aAnotherFrame.GetPsduLength());
-    memcpy(mIeInfo, aAnotherFrame.mIeInfo, sizeof(otRadioIeInfo));
+    memcpy(mPsdu, aFromFrame.mPsdu, aFromFrame.GetPsduLength());
+    memcpy(mIeInfo, aFromFrame.mIeInfo, sizeof(otRadioIeInfo));
 }
 
 Frame::InfoString Frame::ToInfoString(void) const

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -549,11 +549,11 @@ public:
     /**
      * This method initializes the MAC header.
      *
-     * @param[in]  aFcf     The Frame Control field.
-     * @param[in]  aSecCtl  The Security Control field.
+     * @param[in]  aFcf          The Frame Control field.
+     * @param[in]  aSecurityCtl  The Security Control field.
      *
      */
-    void InitMacHeader(uint16_t aFcf, uint8_t aSecCtl);
+    void InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl);
 
     /**
      * This method validates the frame.
@@ -1247,10 +1247,10 @@ public:
      * @note This method performs a deep copy meaning the content of PSDU buffer from the given frame is copied into
      * the PSDU buffer of the current frame.
 
-     * @param[in] aFrame   The frame to copy from.
+     * @param[in] aFromFrame  The frame to copy from.
      *
      */
-    void CopyFrom(const Frame &aFrame);
+    void CopyFrom(const Frame &aFromFrame);
 
     /**
      * This method returns information about the frame object as an `InfoString` object.

--- a/src/core/meshcop/announce_begin_client.hpp
+++ b/src/core/meshcop/announce_begin_client.hpp
@@ -62,12 +62,13 @@ public:
      * @param[in]  aChannelMask   The channel mask value.
      * @param[in]  aCount         The number of Announce messages sent per channel.
      * @param[in]  aPeriod        The time between two successive MLE Announce transmissions (in milliseconds).
+     * @param[in]  aAddress       The destination address.
      *
      * @retval OT_ERROR_NONE     Successfully enqueued the Announce Begin message.
      * @retval OT_ERROR_NO_BUFS  Insufficient buffers to generate a Announce Begin message.
      *
      */
-    otError SendRequest(uint32_t aChannelMask, uint8_t aCount, uint16_t mPeriod, const Ip6::Address &aAddress);
+    otError SendRequest(uint32_t aChannelMask, uint8_t aCount, uint16_t aPeriod, const Ip6::Address &aAddress);
 };
 
 /**

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -477,17 +477,17 @@ exit:
     }
 }
 
-otError BorderAgent::ForwardToCommissioner(Coap::Message &aNewMessage, const Message &aMessage)
+otError BorderAgent::ForwardToCommissioner(Coap::Message &aForwardMessage, const Message &aMessage)
 {
     ThreadNetif &netif  = GetNetif();
     otError      error  = OT_ERROR_NONE;
     uint16_t     offset = 0;
 
-    offset = aNewMessage.GetLength();
-    SuccessOrExit(error = aNewMessage.SetLength(offset + aMessage.GetLength() - aMessage.GetOffset()));
-    aMessage.CopyTo(aMessage.GetOffset(), offset, aMessage.GetLength() - aMessage.GetOffset(), aNewMessage);
+    offset = aForwardMessage.GetLength();
+    SuccessOrExit(error = aForwardMessage.SetLength(offset + aMessage.GetLength() - aMessage.GetOffset()));
+    aMessage.CopyTo(aMessage.GetOffset(), offset, aMessage.GetLength() - aMessage.GetOffset(), aForwardMessage);
 
-    SuccessOrExit(error = netif.GetCoapSecure().SendMessage(aNewMessage, netif.GetCoapSecure().GetPeerAddress()));
+    SuccessOrExit(error = netif.GetCoapSecure().SendMessage(aForwardMessage, netif.GetCoapSecure().GetPeerAddress()));
 
     otLogInfoMeshCoP("Sent to commissioner");
 

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -63,7 +63,7 @@ public:
      * @param[in]  aType       The type of the dataset, active or pending.
      *
      */
-    Dataset(const Tlv::Type aType);
+    explicit Dataset(const Tlv::Type aType);
 
     /**
      * This method clears the Dataset.

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -63,7 +63,7 @@ public:
      * @param[in]  aType       The type of the dataset, active or pending.
      *
      */
-    explicit Dataset(const Tlv::Type aType);
+    explicit Dataset(Tlv::Type aType);
 
     /**
      * This method clears the Dataset.

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -193,11 +193,11 @@ exit:
     return error;
 }
 
-int DatasetLocal::Compare(const Timestamp *aCompareTimestamp)
+int DatasetLocal::Compare(const Timestamp *aCompare)
 {
     int rval = 1;
 
-    if (aCompareTimestamp == NULL)
+    if (aCompare == NULL)
     {
         if (!mTimestampPresent)
         {
@@ -216,7 +216,7 @@ int DatasetLocal::Compare(const Timestamp *aCompareTimestamp)
         }
         else
         {
-            rval = mTimestamp.Compare(*aCompareTimestamp);
+            rval = mTimestamp.Compare(*aCompare);
         }
     }
 

--- a/src/core/meshcop/dataset_local.hpp
+++ b/src/core/meshcop/dataset_local.hpp
@@ -54,7 +54,7 @@ public:
      * @param[in]  aType      The type of the dataset, active or pending.
      *
      */
-    DatasetLocal(Instance &aInstance, const Tlv::Type aType);
+    DatasetLocal(Instance &aInstance, Tlv::Type aType);
 
     /**
      * This method indicates whether this is an Active or Pending Dataset.

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -173,7 +173,7 @@ protected:
      *
      */
     DatasetManager(Instance &          aInstance,
-                   const Tlv::Type     aType,
+                   Tlv::Type           aType,
                    const char *        aUriGet,
                    const char *        aUriSet,
                    TimerMilli::Handler aTimerHandler);

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -121,7 +121,7 @@ int Dtls::HandleMbedtlsEntropyPoll(void *aData, unsigned char *aOutput, size_t a
     otError error;
     int     rval = 0;
 
-    error = otPlatRandomGetTrue((uint8_t *)aOutput, (uint16_t)aInLen);
+    error = otPlatRandomGetTrue(static_cast<uint8_t *>(aOutput), static_cast<uint16_t>(aInLen));
     SuccessOrExit(error);
 
     if (aOutLen != NULL)
@@ -413,17 +413,19 @@ int Dtls::SetApplicationCoapSecureKeys(void)
 #ifdef MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
         if (mCaChainSrc != NULL)
         {
-            rval = mbedtls_x509_crt_parse(&mCaChain, (const unsigned char *)mCaChainSrc, (size_t)mCaChainLength);
+            rval = mbedtls_x509_crt_parse(&mCaChain, static_cast<const unsigned char *>(mCaChainSrc),
+                                          static_cast<size_t>(mCaChainLength));
             VerifyOrExit(rval == 0);
             mbedtls_ssl_conf_ca_chain(&mConf, &mCaChain, NULL);
         }
 
         if (mOwnCertSrc != NULL && mPrivateKeySrc != NULL)
         {
-            rval = mbedtls_x509_crt_parse(&mOwnCert, (const unsigned char *)mOwnCertSrc, (size_t)mOwnCertLength);
+            rval = mbedtls_x509_crt_parse(&mOwnCert, static_cast<const unsigned char *>(mOwnCertSrc),
+                                          static_cast<size_t>(mOwnCertLength));
             VerifyOrExit(rval == 0);
-            rval = mbedtls_pk_parse_key(&mPrivateKey, (const unsigned char *)mPrivateKeySrc, (size_t)mPrivateKeyLength,
-                                        NULL, 0);
+            rval = mbedtls_pk_parse_key(&mPrivateKey, static_cast<const unsigned char *>(mPrivateKeySrc),
+                                        static_cast<size_t>(mPrivateKeyLength), NULL, 0);
             VerifyOrExit(rval == 0);
             rval = mbedtls_ssl_conf_own_cert(&mConf, &mOwnCert, &mPrivateKey);
             VerifyOrExit(rval == 0);
@@ -433,8 +435,8 @@ int Dtls::SetApplicationCoapSecureKeys(void)
 
     case MBEDTLS_TLS_PSK_WITH_AES_128_CCM_8:
 #ifdef MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
-        rval = mbedtls_ssl_conf_psk(&mConf, (unsigned char *)mPreSharedKey, mPreSharedKeyLength,
-                                    (unsigned char *)mPreSharedKeyIdentity, mPreSharedKeyIdLength);
+        rval = mbedtls_ssl_conf_psk(&mConf, static_cast<const unsigned char *>(mPreSharedKey), mPreSharedKeyLength,
+                                    static_cast<const unsigned char *>(mPreSharedKeyIdentity), mPreSharedKeyIdLength);
         VerifyOrExit(rval == 0);
 #endif // MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
         break;
@@ -706,7 +708,7 @@ int Dtls::HandleMbedtlsReceive(unsigned char *aBuf, size_t aLength)
         aLength = mReceiveLength;
     }
 
-    rval = (int)mReceiveMessage->Read(mReceiveOffset, (uint16_t)aLength, aBuf);
+    rval = mReceiveMessage->Read(mReceiveOffset, static_cast<uint16_t>(aLength), aBuf);
     mReceiveOffset += static_cast<uint16_t>(rval);
     mReceiveLength -= static_cast<uint16_t>(rval);
 

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -50,9 +50,6 @@
 
 #if OPENTHREAD_ENABLE_COMMISSIONER && OPENTHREAD_FTD
 
-using ot::Encoding::BigEndian::HostSwap16;
-using ot::Encoding::BigEndian::HostSwap32;
-
 namespace ot {
 
 EnergyScanClient::EnergyScanClient(Instance &aInstance)

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -127,8 +127,8 @@ otError Joiner::Start(const char *     aPSKd,
 
     memset(mJoinerRouters, 0, sizeof(mJoinerRouters));
 
-    SuccessOrExit(error =
-                      netif.GetMle().Discover(0, netif.GetMac().GetPanId(), true, false, HandleDiscoverResult, this));
+    SuccessOrExit(error = netif.GetMle().Discover(Mac::ChannelMask(0), netif.GetMac().GetPanId(), true, false,
+                                                  HandleDiscoverResult, this));
 
     mVendorName      = aVendorName;
     mVendorModel     = aVendorModel;

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -51,7 +51,6 @@
 #include "thread/thread_uri_paths.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
-using ot::Encoding::BigEndian::HostSwap64;
 
 namespace ot {
 namespace MeshCoP {

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -96,8 +96,8 @@ private:
     static void HandleJoinerEntrustResponse(void *               aContext,
                                             otMessage *          aMessage,
                                             const otMessageInfo *aMessageInfo,
-                                            otError              result);
-    void HandleJoinerEntrustResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, otError result);
+                                            otError              aResult);
+    void HandleJoinerEntrustResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, otError aResult);
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -51,12 +51,12 @@
 #include "net/ip6_address.hpp"
 #include "phy/phy.hpp"
 
+namespace ot {
+namespace MeshCoP {
+
 using ot::Encoding::Reverse32;
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;
-
-namespace ot {
-namespace MeshCoP {
 
 /**
  * This class implements MeshCoP TLV generation and parsing.

--- a/src/core/meshcop/timestamp.hpp
+++ b/src/core/meshcop/timestamp.hpp
@@ -43,10 +43,10 @@
 
 #include "common/encoding.hpp"
 
-using ot::Encoding::BigEndian::HostSwap16;
-
 namespace ot {
 namespace MeshCoP {
+
+using ot::Encoding::BigEndian::HostSwap16;
 
 /**
  * This class implements Timestamp generation and parsing.

--- a/src/core/net/dhcp6.hpp
+++ b/src/core/net/dhcp6.hpp
@@ -39,11 +39,11 @@
 #include "common/message.hpp"
 #include "net/udp6.hpp"
 
-using ot::Encoding::BigEndian::HostSwap16;
-using ot::Encoding::BigEndian::HostSwap32;
-
 namespace ot {
 namespace Dhcp6 {
+
+using ot::Encoding::BigEndian::HostSwap16;
+using ot::Encoding::BigEndian::HostSwap32;
 
 /**
  * @addtogroup core-dhcp6

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -48,7 +48,6 @@
 #if OPENTHREAD_ENABLE_DHCP6_CLIENT
 
 using ot::Encoding::BigEndian::HostSwap16;
-using ot::Encoding::BigEndian::HostSwap32;
 
 namespace ot {
 

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -44,9 +44,6 @@
 
 #if OPENTHREAD_ENABLE_DHCP6_SERVER
 
-using ot::Encoding::BigEndian::HostSwap16;
-using ot::Encoding::BigEndian::HostSwap32;
-
 namespace ot {
 namespace Dhcp6 {
 

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -252,13 +252,13 @@ uint16_t Dhcp6Server::FindOption(Message &aMessage, uint16_t aOffset, uint16_t a
 exit:
     return rval;
 }
-otError Dhcp6Server::ProcessClientIdentifier(Message &aMessage, uint16_t aOffset, ClientIdentifier &aClient)
+otError Dhcp6Server::ProcessClientIdentifier(Message &aMessage, uint16_t aOffset, ClientIdentifier &aClientId)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(((aMessage.Read(aOffset, sizeof(aClient), &aClient) == sizeof(aClient)) &&
-                  (aClient.GetLength() == (sizeof(aClient) - sizeof(Dhcp6Option))) &&
-                  (aClient.GetDuidType() == kDuidLL) && (aClient.GetDuidHardwareType() == kHardwareTypeEui64)),
+    VerifyOrExit(((aMessage.Read(aOffset, sizeof(aClientId), &aClientId) == sizeof(aClientId)) &&
+                  (aClientId.GetLength() == (sizeof(aClientId) - sizeof(Dhcp6Option))) &&
+                  (aClientId.GetDuidType() == kDuidLL) && (aClientId.GetDuidHardwareType() == kHardwareTypeEui64)),
                  error = OT_ERROR_PARSE);
 exit:
     return error;
@@ -327,7 +327,7 @@ exit:
     return error;
 }
 
-otError Dhcp6Server::SendReply(otIp6Address &aDst, uint8_t *aTransactionId, ClientIdentifier &aClient, IaNa &aIaNa)
+otError Dhcp6Server::SendReply(otIp6Address &aDst, uint8_t *aTransactionId, ClientIdentifier &aClientId, IaNa &aIaNa)
 {
     otError          error = OT_ERROR_NONE;
     Ip6::MessageInfo messageInfo;
@@ -336,10 +336,10 @@ otError Dhcp6Server::SendReply(otIp6Address &aDst, uint8_t *aTransactionId, Clie
     VerifyOrExit((message = mSocket.NewMessage(0)) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, aTransactionId));
     SuccessOrExit(error = AppendServerIdentifier(*message));
-    SuccessOrExit(error = AppendClientIdentifier(*message, aClient));
+    SuccessOrExit(error = AppendClientIdentifier(*message, aClientId));
     SuccessOrExit(error = AppendIaNa(*message, aIaNa));
     SuccessOrExit(error = AppendStatusCode(*message, kStatusSuccess));
-    SuccessOrExit(error = AppendIaAddress(*message, aClient));
+    SuccessOrExit(error = AppendIaAddress(*message, aClientId));
     SuccessOrExit(error = AppendRapidCommit(*message));
 
     memcpy(messageInfo.GetPeerAddr().mFields.m8, &aDst, sizeof(otIp6Address));
@@ -366,9 +366,9 @@ otError Dhcp6Server::AppendHeader(Message &aMessage, uint8_t *aTransactionId)
     return aMessage.Append(&header, sizeof(header));
 }
 
-otError Dhcp6Server::AppendClientIdentifier(Message &aMessage, ClientIdentifier &aClient)
+otError Dhcp6Server::AppendClientIdentifier(Message &aMessage, ClientIdentifier &aClientId)
 {
-    return aMessage.Append(&aClient, sizeof(aClient));
+    return aMessage.Append(&aClientId, sizeof(aClientId));
 }
 
 otError Dhcp6Server::AppendServerIdentifier(Message &aMessage)
@@ -420,16 +420,16 @@ exit:
     return error;
 }
 
-otError Dhcp6Server::AppendStatusCode(Message &aMessage, Status aStatus)
+otError Dhcp6Server::AppendStatusCode(Message &aMessage, Status aStatusCode)
 {
     StatusCode option;
 
     option.Init();
-    option.SetStatusCode(aStatus);
+    option.SetStatusCode(aStatusCode);
     return aMessage.Append(&option, sizeof(option));
 }
 
-otError Dhcp6Server::AppendIaAddress(Message &aMessage, ClientIdentifier &aClient)
+otError Dhcp6Server::AppendIaAddress(Message &aMessage, ClientIdentifier &aClientId)
 {
     otError error = OT_ERROR_NONE;
 
@@ -440,7 +440,7 @@ otError Dhcp6Server::AppendIaAddress(Message &aMessage, ClientIdentifier &aClien
         {
             if (mPrefixAgentsMask & (1 << i))
             {
-                SuccessOrExit(error = AddIaAddress(aMessage, mPrefixAgents[i].GetPrefix(), aClient));
+                SuccessOrExit(error = AddIaAddress(aMessage, mPrefixAgents[i].GetPrefix(), aClientId));
             }
         }
     }
@@ -451,7 +451,7 @@ otError Dhcp6Server::AppendIaAddress(Message &aMessage, ClientIdentifier &aClien
         {
             if (mPrefixAgents[i].IsValid())
             {
-                SuccessOrExit(error = AddIaAddress(aMessage, mPrefixAgents[i].GetPrefix(), aClient));
+                SuccessOrExit(error = AddIaAddress(aMessage, mPrefixAgents[i].GetPrefix(), aClientId));
             }
         }
     }
@@ -460,14 +460,14 @@ exit:
     return error;
 }
 
-otError Dhcp6Server::AddIaAddress(Message &aMessage, const Ip6::Address &aPrefix, ClientIdentifier &aClient)
+otError Dhcp6Server::AddIaAddress(Message &aMessage, const Ip6::Address &aPrefix, ClientIdentifier &aClientId)
 {
     otError   error = OT_ERROR_NONE;
     IaAddress option;
 
     option.Init();
     memcpy(option.GetAddress().mFields.m8, &aPrefix, OT_IP6_PREFIX_SIZE);
-    option.GetAddress().SetIid(*reinterpret_cast<Mac::ExtAddress *>(aClient.GetDuidLinkLayerAddress()));
+    option.GetAddress().SetIid(*reinterpret_cast<Mac::ExtAddress *>(aClientId.GetDuidLinkLayerAddress()));
     option.SetPreferredLifetime(OT_DHCP6_DEFAULT_PREFERRED_LIFETIME);
     option.SetValidLifetime(OT_DHCP6_DEFAULT_VALID_LIFETIME);
     SuccessOrExit(error = aMessage.Append(&option, sizeof(option)));

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -189,15 +189,15 @@ private:
     otError AddPrefixAgent(const otIp6Prefix &aIp6Prefix, const Lowpan::Context &aContext);
 
     otError AppendHeader(Message &aMessage, uint8_t *aTransactionId);
-    otError AppendClientIdentifier(Message &aMessage, ClientIdentifier &aClient);
+    otError AppendClientIdentifier(Message &aMessage, ClientIdentifier &aClientId);
     otError AppendServerIdentifier(Message &aMessage);
     otError AppendIaNa(Message &aMessage, IaNa &aIaNa);
     otError AppendStatusCode(Message &aMessage, Status aStatusCode);
-    otError AppendIaAddress(Message &aMessage, ClientIdentifier &aClient);
+    otError AppendIaAddress(Message &aMessage, ClientIdentifier &aClientId);
     otError AppendRapidCommit(Message &aMessage);
     otError AppendVendorSpecificInformation(Message &aMessage);
 
-    otError AddIaAddress(Message &aMessage, const Ip6::Address &aPrefix, ClientIdentifier &aClient);
+    otError AddIaAddress(Message &aMessage, const Ip6::Address &aPrefix, ClientIdentifier &aClientId);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
@@ -205,12 +205,12 @@ private:
     void ProcessSolicit(Message &aMessage, otIp6Address &aDst, uint8_t *aTransactionId);
 
     uint16_t FindOption(Message &aMessage, uint16_t aOffset, uint16_t aLength, Code aCode);
-    otError  ProcessClientIdentifier(Message &aMessage, uint16_t aOffset, ClientIdentifier &aClient);
+    otError  ProcessClientIdentifier(Message &aMessage, uint16_t aOffset, ClientIdentifier &aClientId);
     otError  ProcessIaNa(Message &aMessage, uint16_t aOffset, IaNa &aIaNa);
     otError  ProcessIaAddress(Message &aMessage, uint16_t aOffset);
     otError  ProcessElapsedTime(Message &aMessage, uint16_t aOffset);
 
-    otError SendReply(otIp6Address &aDst, uint8_t *aTransactionId, ClientIdentifier &aClientIdentifier, IaNa &aIaNa);
+    otError SendReply(otIp6Address &aDst, uint8_t *aTransactionId, ClientIdentifier &aClientId, IaNa &aIaNa);
 
     Ip6::UdpSocket mSocket;
 

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -508,8 +508,6 @@ exit:
     {
         FinalizeDnsTransaction(*message, queryMetadata, NULL, 0, error);
     }
-
-    return;
 }
 
 } // namespace Dns

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -158,7 +158,7 @@ public:
      * @param[in]  aNetif    A reference to the network interface that DNS client should be assigned to.
      *
      */
-    Client(Ip6::Netif &aNetif)
+    explicit Client(Ip6::Netif &aNetif)
         : mSocket(aNetif.GetIp6().GetUdp())
         , mMessageId(0)
         , mRetransmissionTimer(aNetif.GetInstance(), &Client::HandleRetransmissionTimer, this){};

--- a/src/core/net/dns_headers.hpp
+++ b/src/core/net/dns_headers.hpp
@@ -41,9 +41,6 @@
 #include "common/encoding.hpp"
 #include "common/message.hpp"
 
-using ot::Encoding::BigEndian::HostSwap16;
-using ot::Encoding::BigEndian::HostSwap32;
-
 namespace ot {
 
 /**
@@ -53,6 +50,9 @@ namespace ot {
  *
  */
 namespace Dns {
+
+using ot::Encoding::BigEndian::HostSwap16;
+using ot::Encoding::BigEndian::HostSwap32;
 
 /**
  * @addtogroup core-dns

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -309,11 +309,11 @@ public:
     /**
      * This method updates the ICMPv6 checksum.
      *
-     * @param[in]  aMessage               A reference to the ICMPv6 message.
-     * @param[in]  aPseudoHeaderChecksum  The pseudo-header checksum value.
+     * @param[in]  aMessage   A reference to the ICMPv6 message.
+     * @param[in]  aChecksum  The pseudo-header checksum value.
      *
      */
-    void UpdateChecksum(Message &aMessage, uint16_t aPseudoHeaderChecksum);
+    void UpdateChecksum(Message &aMessage, uint16_t aChecksum);
 
     /**
      * This method indicates whether or not ICMPv6 Echo processing is enabled.
@@ -342,7 +342,7 @@ public:
     bool ShouldHandleEchoRequest(const MessageInfo &aMessageInfo);
 
 private:
-    otError HandleEchoRequest(Message &aMessage, const MessageInfo &aMessageInfo);
+    otError HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMessageInfo);
 
     IcmpHandler *mHandlers;
 

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -42,10 +42,10 @@
 #include "common/locator.hpp"
 #include "net/ip6_headers.hpp"
 
-using ot::Encoding::BigEndian::HostSwap16;
-
 namespace ot {
 namespace Ip6 {
+
+using ot::Encoding::BigEndian::HostSwap16;
 
 /**
  * @addtogroup core-ip6-icmp6

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -53,9 +53,6 @@
 #include "net/socket.hpp"
 #include "net/udp6.hpp"
 
-using ot::Encoding::BigEndian::HostSwap16;
-using ot::Encoding::BigEndian::HostSwap32;
-
 namespace ot {
 
 /**
@@ -66,6 +63,9 @@ namespace ot {
  *
  */
 namespace Ip6 {
+
+using ot::Encoding::BigEndian::HostSwap16;
+using ot::Encoding::BigEndian::HostSwap32;
 
 /**
  * @addtogroup core-ipv6

--- a/src/core/net/ip6_headers.hpp
+++ b/src/core/net/ip6_headers.hpp
@@ -44,9 +44,6 @@
 #include "net/netif.hpp"
 #include "net/socket.hpp"
 
-using ot::Encoding::BigEndian::HostSwap16;
-using ot::Encoding::BigEndian::HostSwap32;
-
 namespace ot {
 
 /**
@@ -57,6 +54,9 @@ namespace ot {
  *
  */
 namespace Ip6 {
+
+using ot::Encoding::BigEndian::HostSwap16;
+using ot::Encoding::BigEndian::HostSwap32;
 
 /**
  * @addtogroup core-ipv6

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -384,8 +384,6 @@ exit:
     {
         FinalizeSntpTransaction(*message, queryMetadata, 0, error);
     }
-
-    return;
 }
 
 } // namespace Sntp

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -45,8 +45,6 @@
  *   This file implements the SNTP client.
  */
 
-using ot::Encoding::BigEndian::HostSwap16;
-
 namespace ot {
 namespace Sntp {
 

--- a/src/core/net/sntp_client.hpp
+++ b/src/core/net/sntp_client.hpp
@@ -528,7 +528,7 @@ public:
      * @param[in]  aNetif    A reference to the network interface that SNTP client should be assigned to.
      *
      */
-    Client(Ip6::Netif &aNetif)
+    explicit Client(Ip6::Netif &aNetif)
         : mSocket(aNetif.GetIp6().GetUdp())
         , mRetransmissionTimer(aNetif.GetInstance(), &Client::HandleRetransmissionTimer, this)
         , mUnixEra(0){};

--- a/src/core/net/sntp_client.hpp
+++ b/src/core/net/sntp_client.hpp
@@ -46,6 +46,8 @@
 namespace ot {
 namespace Sntp {
 
+using ot::Encoding::BigEndian::HostSwap32;
+
 /**
  * This class implements SNTP header generation and parsing.
  *

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -315,11 +315,11 @@ public:
     /**
      * This method updates the UDP checksum.
      *
-     * @param[in]  aMessage               A reference to the UDP message.
-     * @param[in]  aPseudoHeaderChecksum  The pseudo-header checksum value.
+     * @param[in]  aMessage   A reference to the UDP message.
+     * @param[in]  aChecksum  The pseudo-header checksum value.
      *
      */
-    void UpdateChecksum(Message &aMessage, uint16_t aPseudoHeaderChecksum);
+    void UpdateChecksum(Message &aMessage, uint16_t aChecksum);
 
 #if OPENTHREAD_ENABLE_PLATFORM_UDP
     otUdpSocket *GetUdpSockets(void) { return mSockets; }

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -637,7 +637,7 @@ exit:
 }
 
 void AddressResolver::SendAddressQueryResponse(const ThreadTargetTlv &             aTargetTlv,
-                                               const ThreadMeshLocalEidTlv &       aMlIidTlv,
+                                               const ThreadMeshLocalEidTlv &       aMlEidTlv,
                                                const ThreadLastTransactionTimeTlv *aLastTransactionTimeTlv,
                                                const Ip6::Address &                aDestination)
 {
@@ -654,7 +654,7 @@ void AddressResolver::SendAddressQueryResponse(const ThreadTargetTlv &          
     message->SetPayloadMarker();
 
     SuccessOrExit(error = message->Append(&aTargetTlv, sizeof(aTargetTlv)));
-    SuccessOrExit(error = message->Append(&aMlIidTlv, sizeof(aMlIidTlv)));
+    SuccessOrExit(error = message->Append(&aMlEidTlv, sizeof(aMlEidTlv)));
 
     rloc16Tlv.Init();
     rloc16Tlv.SetRloc16(netif.GetMle().GetRloc16());

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -580,8 +580,6 @@ exit:
     {
         otLogWarnArp("Error while processing address error notification: %s", otThreadErrorToString(error));
     }
-
-    return;
 }
 
 void AddressResolver::HandleAddressQuery(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -47,8 +47,6 @@
 #include "thread/thread_netif.hpp"
 #include "thread/thread_uri_paths.hpp"
 
-using ot::Encoding::BigEndian::HostSwap32;
-
 namespace ot {
 
 AnnounceBeginServer::AnnounceBeginServer(Instance &aInstance)

--- a/src/core/thread/announce_sender.cpp
+++ b/src/core/thread/announce_sender.cpp
@@ -66,7 +66,7 @@ otError AnnounceSenderBase::SendAnnounce(Mac::ChannelMask aMask, uint8_t aCount,
     VerifyOrExit(aPeriod != 0, error = OT_ERROR_INVALID_ARGS);
     VerifyOrExit(aJitter < aPeriod, error = OT_ERROR_INVALID_ARGS);
 
-    aMask.Intersect(Phy::kSupportedChannels);
+    aMask.Intersect(Mac::ChannelMask(Phy::kSupportedChannels));
     VerifyOrExit(!aMask.IsEmpty(), error = OT_ERROR_INVALID_ARGS);
 
     mChannelMask = aMask;

--- a/src/core/thread/announce_sender.cpp
+++ b/src/core/thread/announce_sender.cpp
@@ -59,17 +59,20 @@ AnnounceSenderBase::AnnounceSenderBase(Instance &aInstance, Timer::Handler aHand
 {
 }
 
-otError AnnounceSenderBase::SendAnnounce(Mac::ChannelMask aMask, uint8_t aCount, uint32_t aPeriod, uint16_t aJitter)
+otError AnnounceSenderBase::SendAnnounce(Mac::ChannelMask aChannelMask,
+                                         uint8_t          aCount,
+                                         uint32_t         aPeriod,
+                                         uint16_t         aJitter)
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aPeriod != 0, error = OT_ERROR_INVALID_ARGS);
     VerifyOrExit(aJitter < aPeriod, error = OT_ERROR_INVALID_ARGS);
 
-    aMask.Intersect(Mac::ChannelMask(Phy::kSupportedChannels));
-    VerifyOrExit(!aMask.IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+    aChannelMask.Intersect(Mac::ChannelMask(Phy::kSupportedChannels));
+    VerifyOrExit(!aChannelMask.IsEmpty(), error = OT_ERROR_INVALID_ARGS);
 
-    mChannelMask = aMask;
+    mChannelMask = aChannelMask;
     mCount       = aCount;
     mPeriod      = aPeriod;
     mJitter      = aJitter;

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -63,6 +63,8 @@ namespace ot {
  */
 namespace Lowpan {
 
+using ot::Encoding::BigEndian::HostSwap16;
+
 /**
  * This structure represents a LOWPAN_IPHC Context.
  *

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -265,12 +265,12 @@ public:
     /**
      * This method decompresses a LOWPAN_IPHC header.
      *
-     * @param[out]  aMessage      A reference where the IPv6 header will be placed.
-     * @param[in]   aMacSource    The MAC source address.
-     * @param[in]   aMacDest      The MAC destination address.
-     * @param[in]   aBuf          A pointer to the LOWPAN_IPHC header.
-     * @param[in]   aBufLen       The number of bytes in @p aBuf.
-     * @param[in]   aDatagramLen  The IPv6 datagram length.
+     * @param[out]  aMessage         A reference where the IPv6 header will be placed.
+     * @param[in]   aMacSource       The MAC source address.
+     * @param[in]   aMacDest         The MAC destination address.
+     * @param[in]   aBuf             A pointer to the LOWPAN_IPHC header.
+     * @param[in]   aBufLength       The number of bytes in @p aBuf.
+     * @param[in]   aDatagramLength  The IPv6 datagram length.
      *
      * @returns The size of the compressed header in bytes.
      *
@@ -279,13 +279,13 @@ public:
                    const Mac::Address &aMacSource,
                    const Mac::Address &aMacDest,
                    const uint8_t *     aBuf,
-                   uint16_t            aBufLen,
-                   uint16_t            aDatagramLen);
+                   uint16_t            aBufLength,
+                   uint16_t            aDatagramLength);
 
     /**
      * This method decompresses a LOWPAN_IPHC header.
      *
-     * @param[out]  aHeader                 A reference where the IPv6 header will be placed.
+     * @param[out]  aIp6Header              A reference where the IPv6 header will be placed.
      * @param[out]  aCommpressedNextHeader  A boolean reference to output whether next header is compressed or not.
      * @param[in]   aMacSource              The MAC source address.
      * @param[in]   aMacDest                The MAC destination address.
@@ -295,7 +295,7 @@ public:
      * @returns The size of the compressed header in bytes or -1 if decompression fails.
      *
      */
-    int DecompressBaseHeader(Ip6::Header &       aHeader,
+    int DecompressBaseHeader(Ip6::Header &       aIp6Header,
                              bool &              aCompressedNextHeader,
                              const Mac::Address &aMacSource,
                              const Mac::Address &aMacDest,

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -840,19 +840,18 @@ otError MeshForwarder::SendFragment(Message &aMessage, Mac::Frame &aFrame)
 
             if (hopsLeft != Mle::kMaxRouteCost)
             {
-                hopsLeft +=
-                    netif.GetMle().GetLinkCost(netif.GetMle().GetRouterId(netif.GetMle().GetNextHop(mMeshDest)));
+                hopsLeft += netif.GetMle().GetLinkCost(Mle::Mle::GetRouterId(netif.GetMle().GetNextHop(mMeshDest)));
             }
             else
             {
                 // In case there is no route to the destination router (only link).
-                hopsLeft = netif.GetMle().GetLinkCost(netif.GetMle().GetRouterId(mMeshDest));
+                hopsLeft = netif.GetMle().GetLinkCost(Mle::Mle::GetRouterId(mMeshDest));
             }
         }
 
         // The hopsLft field MUST be incremented by one if the destination RLOC16
         // is not that of an active Router.
-        if (!netif.GetMle().IsActiveRouter(mMeshDest))
+        if (!Mle::Mle::IsActiveRouter(mMeshDest))
         {
             hopsLeft += 1;
         }
@@ -1036,7 +1035,7 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, otError aError)
         case OT_ERROR_NO_ACK:
             neighbor->IncrementLinkFailures();
 
-            if (netif.GetMle().IsActiveRouter(neighbor->GetRloc16()))
+            if (Mle::Mle::IsActiveRouter(neighbor->GetRloc16()))
             {
                 if (neighbor->GetLinkFailures() >= Mle::kFailedRouterTransmissions)
                 {
@@ -1593,7 +1592,7 @@ otError MeshForwarder::GetFramePriority(const uint8_t *     aFrame,
 
     SuccessOrExit(error = DecompressIp6Header(aFrame, aFrameLength, aMacSource, aMacDest, ip6Header, headerLength,
                                               nextHeaderCompressed));
-    aPriority = GetNetif().GetIp6().DscpToPriority(ip6Header.GetDscp());
+    aPriority = Ip6::Ip6::DscpToPriority(ip6Header.GetDscp());
     VerifyOrExit(ip6Header.GetNextHeader() == Ip6::kProtoUdp);
 
     aFrame += headerLength;

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -400,16 +400,16 @@ private:
     void     PrepareIndirectTransmission(Message &aMessage, const Child &aChild);
     otError  PrepareDataPoll(void);
     void     HandleMesh(uint8_t *               aFrame,
-                        uint8_t                 aPayloadLength,
+                        uint8_t                 aFrameLength,
                         const Mac::Address &    aMacSource,
                         const otThreadLinkInfo &aLinkInfo);
     void     HandleFragment(uint8_t *               aFrame,
-                            uint8_t                 aPayloadLength,
+                            uint8_t                 aFrameLength,
                             const Mac::Address &    aMacSource,
                             const Mac::Address &    aMacDest,
                             const otThreadLinkInfo &aLinkInfo);
     void     HandleLowpanHC(uint8_t *               aFrame,
-                            uint8_t                 aPayloadLength,
+                            uint8_t                 aFrameLength,
                             const Mac::Address &    aMacSource,
                             const Mac::Address &    aMacDest,
                             const otThreadLinkInfo &aLinkInfo);
@@ -441,7 +441,7 @@ private:
     void    HandleReceivedFrame(Mac::Frame &aFrame);
     otError HandleFrameRequest(Mac::Frame &aFrame);
     void    HandleSentFrame(Mac::Frame &aFrame, otError aError);
-    void    HandleSentFrameToChild(const Mac::Frame &aFrame, otError aError, const Mac::Address &macDest);
+    void    HandleSentFrameToChild(const Mac::Frame &aFrame, otError aError, const Mac::Address &aMacDest);
 
     static void HandleDiscoverTimer(Timer &aTimer);
     void        HandleDiscoverTimer(void);

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -804,7 +804,7 @@ otError MeshForwarder::UpdateIp6RouteFtd(Ip6::Header &ip6Header)
 
         if (aloc16 == Mle::kAloc16Leader)
         {
-            mMeshDest = netif.GetMle().GetRloc16(netif.GetMle().GetLeaderId());
+            mMeshDest = Mle::Mle::GetRloc16(netif.GetMle().GetLeaderId());
         }
         else if ((aloc16 >= Mle::kAloc16CommissionerStart) && (aloc16 <= Mle::kAloc16CommissionerEnd))
         {
@@ -820,18 +820,18 @@ otError MeshForwarder::UpdateIp6RouteFtd(Ip6::Header &ip6Header)
                               static_cast<uint8_t>(aloc16 & Mle::kAloc16DhcpAgentMask), agentRloc16) == OT_ERROR_NONE),
                          error = OT_ERROR_DROP);
 
-            routerId = netif.GetMle().GetRouterId(agentRloc16);
+            routerId = Mle::Mle::GetRouterId(agentRloc16);
 
             // if agent is active router or the child of the device
-            if ((netif.GetMle().IsActiveRouter(agentRloc16)) ||
-                (netif.GetMle().GetRloc16(routerId) == netif.GetMle().GetRloc16()))
+            if ((Mle::Mle::IsActiveRouter(agentRloc16)) ||
+                (Mle::Mle::GetRloc16(routerId) == netif.GetMle().GetRloc16()))
             {
                 mMeshDest = agentRloc16;
             }
             else
             {
                 // use the parent of the ED Agent as Dest
-                mMeshDest = netif.GetMle().GetRloc16(routerId);
+                mMeshDest = Mle::Mle::GetRloc16(routerId);
             }
         }
 
@@ -1179,7 +1179,7 @@ otError MeshForwarder::GetDestinationRlocByServiceAloc(uint16_t aServiceAloc, ui
 {
     otError                  error      = OT_ERROR_NONE;
     ThreadNetif &            netif      = GetNetif();
-    uint8_t                  serviceId  = netif.GetMle().GetServiceIdFromAloc(aServiceAloc);
+    uint8_t                  serviceId  = Mle::Mle::GetServiceIdFromAloc(aServiceAloc);
     NetworkData::ServiceTlv *serviceTlv = netif.GetNetworkDataLeader().FindServiceById(serviceId);
 
     if (serviceTlv != NULL)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3173,8 +3173,8 @@ otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInf
 
         case kAttachBetter:
             VerifyOrExit(leaderData.GetPartitionId() != mLeaderData.GetPartitionId());
-            VerifyOrExit(netif.GetMle().ComparePartitions(connectivity.GetActiveRouters() <= 1, leaderData,
-                                                          netif.GetMle().IsSingleton(), mLeaderData) > 0);
+            VerifyOrExit(MleRouter::ComparePartitions(connectivity.GetActiveRouters() <= 1, leaderData,
+                                                      netif.GetMle().IsSingleton(), mLeaderData) > 0);
             break;
         }
     }
@@ -3187,8 +3187,8 @@ otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInf
 
         if (IsFullThreadDevice())
         {
-            compare = netif.GetMle().ComparePartitions(connectivity.GetActiveRouters() <= 1, leaderData,
-                                                       mParentIsSingleton, mParentLeaderData);
+            compare = MleRouter::ComparePartitions(connectivity.GetActiveRouters() <= 1, leaderData, mParentIsSingleton,
+                                                   mParentLeaderData);
         }
 
         // only consider partitions that are the same or better

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -636,11 +636,13 @@ public:
     /**
      * This method sets the Device Mode as reported in the Mode TLV.
      *
+     * @param[in]  aDeviceMode  The device mode to set.
+     *
      * @retval OT_ERROR_NONE          Successfully set the Mode TLV.
      * @retval OT_ERROR_INVALID_ARGS  The mode combination specified in @p aMode is invalid.
      *
      */
-    otError SetDeviceMode(uint8_t aMode);
+    otError SetDeviceMode(uint8_t aDeviceMode);
 
     /**
      * This method indicates whether or not the device is rx-on-when-idle.
@@ -700,10 +702,10 @@ public:
     /**
      * This method sets the Mesh Local Prefix.
      *
-     * @param[in]  aPrefix  A reference to the Mesh Local Prefix.
+     * @param[in]  aMeshLocalPrefix  A reference to the Mesh Local Prefix.
      *
      */
-    void SetMeshLocalPrefix(const otMeshLocalPrefix &aPrefix);
+    void SetMeshLocalPrefix(const otMeshLocalPrefix &aMeshLocalPrefix);
 
     /**
      * This method applies the Mesh Local Prefix.
@@ -1549,21 +1551,21 @@ protected:
     /**
      * This method prints an MLE log message with an IPv6 address.
      *
-     * @param[in]  aLogMessage  The log message string.
-     * @param[in]  aAddress     The IPv6 address of the peer.
+     * @param[in]  aLogString  The log message string.
+     * @param[in]  aAddress    The IPv6 address of the peer.
      *
      */
-    void LogMleMessage(const char *aLogMessage, const Ip6::Address &aAddress) const;
+    void LogMleMessage(const char *aLogString, const Ip6::Address &aAddress) const;
 
     /**
      * This method prints an MLE log message with an IPv6 address and RLOC16.
      *
-     * @param[in]  aLogMessage  The log message string.
-     * @param[in]  aAddress     The IPv6 address of the peer.
-     * @param[in]  aRloc        The RLOC16.
+     * @param[in]  aLogString  The log message string.
+     * @param[in]  aAddress    The IPv6 address of the peer.
+     * @param[in]  aRloc       The RLOC16.
      *
      */
-    void LogMleMessage(const char *aLogMessage, const Ip6::Address &aAddress, uint16_t aRloc) const;
+    void LogMleMessage(const char *aLogString, const Ip6::Address &aAddress, uint16_t aRloc) const;
 
     /**
      * This method triggers MLE Announce on previous channel after the Thread device successfully

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2977,7 +2977,7 @@ exit:
 void MleRouter::SendChildUpdateResponse(Child *                 aChild,
                                         const Ip6::MessageInfo &aMessageInfo,
                                         const uint8_t *         aTlvs,
-                                        uint8_t                 aTlvslength,
+                                        uint8_t                 aTlvsLength,
                                         const ChallengeTlv *    aChallenge)
 {
     otError  error = OT_ERROR_NONE;
@@ -2986,7 +2986,7 @@ void MleRouter::SendChildUpdateResponse(Child *                 aChild,
     VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandChildUpdateResponse));
 
-    for (int i = 0; i < aTlvslength; i++)
+    for (int i = 0; i < aTlvsLength; i++)
     {
         switch (aTlvs[i])
         {
@@ -4108,7 +4108,7 @@ exit:
     }
 }
 
-void MleRouter::SendAddressSolicitResponse(const Coap::Message &   aRequestHeader,
+void MleRouter::SendAddressSolicitResponse(const Coap::Message &   aRequest,
                                            const Router *          aRouter,
                                            const Ip6::MessageInfo &aMessageInfo)
 {
@@ -4121,7 +4121,7 @@ void MleRouter::SendAddressSolicitResponse(const Coap::Message &   aRequestHeade
 
     VerifyOrExit((message = netif.GetCoap().NewMessage()) != NULL, error = OT_ERROR_NO_BUFS);
 
-    message->SetDefaultResponseHeader(aRequestHeader);
+    message->SetDefaultResponseHeader(aRequest);
     message->SetPayloadMarker();
 
     statusTlv.Init();

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -4012,8 +4012,6 @@ exit:
 
     // send announce after received address solicit reply if needed
     InformPreviousChannel();
-
-    return;
 }
 
 void MleRouter::HandleAddressSolicit(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -700,7 +700,7 @@ private:
     otError HandleLinkAccept(const Message &         aMessage,
                              const Ip6::MessageInfo &aMessageInfo,
                              uint32_t                aKeySequence,
-                             bool                    request);
+                             bool                    aRequest);
     otError HandleLinkAcceptAndRequest(const Message &         aMessage,
                                        const Ip6::MessageInfo &aMessageInfo,
                                        uint32_t                aKeySequence);
@@ -739,7 +739,7 @@ private:
                                     const Ip6::MessageInfo &aMessageInfo,
                                     const uint8_t *         aTlvs,
                                     uint8_t                 aTlvsLength,
-                                    const ChallengeTlv *    challenge);
+                                    const ChallengeTlv *    aChallenge);
     otError SendDataResponse(const Ip6::Address &aDestination,
                              const uint8_t *     aTlvs,
                              uint8_t             aTlvsLength,
@@ -751,13 +751,13 @@ private:
     void    StopLeader(void);
     void    SynchronizeChildNetworkData(void);
     otError UpdateChildAddresses(const Message &aMessage, uint16_t aOffset, Child &aChild);
-    void    UpdateRoutes(const RouteTlv &aTlv, uint8_t aRouterId);
+    void    UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId);
 
     static void HandleAddressSolicitResponse(void *               aContext,
                                              otMessage *          aMessage,
                                              const otMessageInfo *aMessageInfo,
-                                             otError              result);
-    void HandleAddressSolicitResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, otError result);
+                                             otError              aResult);
+    void HandleAddressSolicitResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, otError aResult);
     static void HandleAddressRelease(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleAddressRelease(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     static void HandleAddressSolicit(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -45,12 +45,12 @@
 #include "net/ip6_address.hpp"
 #include "thread/mle_constants.hpp"
 
-using ot::Encoding::BigEndian::HostSwap16;
-using ot::Encoding::BigEndian::HostSwap32;
-
 namespace ot {
 
 namespace Mle {
+
+using ot::Encoding::BigEndian::HostSwap16;
+using ot::Encoding::BigEndian::HostSwap32;
 
 #define TLVREQUESTTLV_ITERATOR_INIT 0 ///< Initializer for TlvRequestTlvIterator.
 

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -488,7 +488,7 @@ private:
         };
 
     public:
-        NetworkDataIterator(otNetworkDataIterator *aIterator)
+        explicit NetworkDataIterator(otNetworkDataIterator *aIterator)
             : mIteratorBuffer(reinterpret_cast<uint8_t *>(aIterator))
         {
         }

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -52,8 +52,6 @@
 #include "thread/thread_tlvs.hpp"
 #include "thread/thread_uri_paths.hpp"
 
-using ot::Encoding::BigEndian::HostSwap16;
-
 namespace ot {
 namespace NetworkData {
 

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -404,7 +404,7 @@ otError LeaderBase::DefaultRouteLookup(PrefixTlv &aPrefix, uint16_t *aRloc16)
 
 otError LeaderBase::SetNetworkData(uint8_t        aVersion,
                                    uint8_t        aStableVersion,
-                                   bool           aStable,
+                                   bool           aStableOnly,
                                    const Message &aMessage,
                                    uint16_t       aMessageOffset)
 {
@@ -422,7 +422,7 @@ otError LeaderBase::SetNetworkData(uint8_t        aVersion,
     mVersion       = aVersion;
     mStableVersion = aStableVersion;
 
-    if (aStable)
+    if (aStableOnly)
     {
         RemoveTemporaryData(mTlvs, mLength);
     }

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -1302,15 +1302,15 @@ void Leader::RemoveRloc(uint16_t aRloc16, MatchMode aMatchMode)
     otDumpDebgNetData("remove done", mTlvs, mLength);
 }
 
-void Leader::RemoveRloc(PrefixTlv &prefix, uint16_t aRloc16, MatchMode aMatchMode)
+void Leader::RemoveRloc(PrefixTlv &aPrefix, uint16_t aRloc16, MatchMode aMatchMode)
 {
-    NetworkDataTlv *cur = prefix.GetSubTlvs();
+    NetworkDataTlv *cur = aPrefix.GetSubTlvs();
     NetworkDataTlv *end;
     ContextTlv *    context;
 
     while (1)
     {
-        end = prefix.GetNext();
+        end = aPrefix.GetNext();
 
         if (cur >= end)
         {
@@ -1320,12 +1320,12 @@ void Leader::RemoveRloc(PrefixTlv &prefix, uint16_t aRloc16, MatchMode aMatchMod
         switch (cur->GetType())
         {
         case NetworkDataTlv::kTypeHasRoute:
-            RemoveRloc(prefix, *static_cast<HasRouteTlv *>(cur), aRloc16, aMatchMode);
+            RemoveRloc(aPrefix, *static_cast<HasRouteTlv *>(cur), aRloc16, aMatchMode);
 
             // remove has route tlv if empty
             if (cur->GetLength() == 0)
             {
-                prefix.SetSubTlvsLength(prefix.GetSubTlvsLength() - sizeof(HasRouteTlv));
+                aPrefix.SetSubTlvsLength(aPrefix.GetSubTlvsLength() - sizeof(HasRouteTlv));
                 Remove(reinterpret_cast<uint8_t *>(cur), sizeof(HasRouteTlv));
                 continue;
             }
@@ -1333,12 +1333,12 @@ void Leader::RemoveRloc(PrefixTlv &prefix, uint16_t aRloc16, MatchMode aMatchMod
             break;
 
         case NetworkDataTlv::kTypeBorderRouter:
-            RemoveRloc(prefix, *static_cast<BorderRouterTlv *>(cur), aRloc16, aMatchMode);
+            RemoveRloc(aPrefix, *static_cast<BorderRouterTlv *>(cur), aRloc16, aMatchMode);
 
             // remove border router tlv if empty
             if (cur->GetLength() == 0)
             {
-                prefix.SetSubTlvsLength(prefix.GetSubTlvsLength() - sizeof(BorderRouterTlv));
+                aPrefix.SetSubTlvsLength(aPrefix.GetSubTlvsLength() - sizeof(BorderRouterTlv));
                 Remove(reinterpret_cast<uint8_t *>(cur), sizeof(BorderRouterTlv));
                 continue;
             }
@@ -1352,9 +1352,9 @@ void Leader::RemoveRloc(PrefixTlv &prefix, uint16_t aRloc16, MatchMode aMatchMod
         cur = cur->GetNext();
     }
 
-    if ((context = FindContext(prefix)) != NULL)
+    if ((context = FindContext(aPrefix)) != NULL)
     {
-        if (prefix.GetSubTlvsLength() == sizeof(ContextTlv))
+        if (aPrefix.GetSubTlvsLength() == sizeof(ContextTlv))
         {
             context->ClearCompress();
             StartContextReuseTimer(context->GetContextId());
@@ -1368,16 +1368,16 @@ void Leader::RemoveRloc(PrefixTlv &prefix, uint16_t aRloc16, MatchMode aMatchMod
 }
 
 #if OPENTHREAD_ENABLE_SERVICE
-void Leader::RemoveRloc(ServiceTlv &service, uint16_t aRloc16, MatchMode aMatchMode)
+void Leader::RemoveRloc(ServiceTlv &aService, uint16_t aRloc16, MatchMode aMatchMode)
 {
-    NetworkDataTlv *cur = service.GetSubTlvs();
+    NetworkDataTlv *cur = aService.GetSubTlvs();
     NetworkDataTlv *end;
     ServerTlv *     server;
     uint8_t         removeLength;
 
     while (1)
     {
-        end = service.GetNext();
+        end = aService.GetNext();
 
         if (cur >= end)
         {
@@ -1392,7 +1392,7 @@ void Leader::RemoveRloc(ServiceTlv &service, uint16_t aRloc16, MatchMode aMatchM
             if (RlocMatch(server->GetServer16(), aRloc16, aMatchMode))
             {
                 removeLength = sizeof(ServerTlv) + server->GetServerDataLength();
-                service.SetSubTlvsLength(service.GetSubTlvsLength() - removeLength);
+                aService.SetSubTlvsLength(aService.GetSubTlvsLength() - removeLength);
                 Remove(reinterpret_cast<uint8_t *>(cur), removeLength);
                 continue;
             }

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -284,8 +284,6 @@ exit:
     {
         SendCommissioningSetResponse(aMessage, aMessageInfo, state);
     }
-
-    return;
 }
 
 void Leader::HandleCommissioningGet(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -320,7 +320,7 @@ void Leader::HandleCommissioningGet(Coap::Message &aMessage, const Ip6::MessageI
 
 void Leader::SendCommissioningGetResponse(const Coap::Message &   aRequest,
                                           const Ip6::MessageInfo &aMessageInfo,
-                                          uint8_t *               aTlvs,
+                                          const uint8_t *         aTlvs,
                                           uint8_t                 aLength)
 {
     ThreadNetif &  netif = GetNetif();

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -182,10 +182,10 @@ private:
     otError AddHasRoute(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute);
     otError AddBorderRouter(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter);
     otError AddNetworkData(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aOldTlvs, uint8_t aOldTlvsLength);
-    otError AddPrefix(PrefixTlv &aTlv);
+    otError AddPrefix(PrefixTlv &aPrefix);
 #if OPENTHREAD_ENABLE_SERVICE
     otError AddServer(ServiceTlv &aService, ServerTlv &aServer, uint8_t *aOldTlvs, uint8_t aOldTlvsLength);
-    otError AddService(ServiceTlv &aTlv, uint8_t *aOldTlvs, uint8_t aOldTlvsLength);
+    otError AddService(ServiceTlv &aService, uint8_t *aOldTlvs, uint8_t aOldTlvsLength);
 #endif
 
     int  AllocateContext(void);
@@ -201,7 +201,7 @@ private:
     void RemoveRloc(uint16_t aRloc16, MatchMode aMatchMode);
     void RemoveRloc(PrefixTlv &aPrefix, uint16_t aRloc16, MatchMode aMatchMode);
 #if OPENTHREAD_ENABLE_SERVICE
-    void RemoveRloc(ServiceTlv &service, uint16_t aRloc16, MatchMode aMatchMode);
+    void RemoveRloc(ServiceTlv &aService, uint16_t aRloc16, MatchMode aMatchMode);
 #endif
     void RemoveRloc(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute, uint16_t aRloc16, MatchMode aMatchMode);
     void RemoveRloc(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter, uint16_t aRloc16, MatchMode aMatchMode);

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -226,7 +226,7 @@ private:
 
     void SendCommissioningGetResponse(const Coap::Message &   aRequest,
                                       const Ip6::MessageInfo &aMessageInfo,
-                                      uint8_t *               aTlvs,
+                                      const uint8_t *         aTlvs,
                                       uint8_t                 aLength);
     void SendCommissioningSetResponse(const Coap::Message &    aRequest,
                                       const Ip6::MessageInfo & aMessageInfo,

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -172,7 +172,7 @@ private:
     void UpdateRloc(BorderRouterTlv &aBorderRouter);
 #if OPENTHREAD_ENABLE_SERVICE
     void UpdateRloc(ServiceTlv &aService);
-    void UpdateRloc(ServerTlv &aService);
+    void UpdateRloc(ServerTlv &aServer);
 #endif
 
     bool IsOnMeshPrefixConsistent(void);

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -41,12 +41,12 @@
 #include "common/encoding.hpp"
 #include "net/ip6_address.hpp"
 
-using ot::Encoding::BigEndian::HostSwap16;
-
 #define THREAD_ENTERPRISE_NUMBER 44970
 
 namespace ot {
 namespace NetworkData {
+
+using ot::Encoding::BigEndian::HostSwap16;
 
 /**
  * @addtogroup core-netdata-tlvs

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -250,7 +250,7 @@ otError NetworkDiagnostic::AppendChildTable(Message &aMessage)
 
         entry.SetReserved(0);
         entry.SetTimeout(timeout + 4);
-        entry.SetChildId(netif.GetMle().GetChildId(child.GetRloc16()));
+        entry.SetChildId(Mle::Mle::GetChildId(child.GetRloc16()));
         entry.SetMode(child.GetDeviceMode());
 
         SuccessOrExit(error = aMessage.Append(&entry, sizeof(ChildTableEntry)));

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -52,8 +52,6 @@
 #include "thread/thread_tlvs.hpp"
 #include "thread/thread_uri_paths.hpp"
 
-using ot::Encoding::BigEndian::HostSwap16;
-
 #if OPENTHREAD_FTD || OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC
 
 namespace ot {

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -48,12 +48,12 @@
 #include "phy/phy.hpp"
 #include "thread/mle_constants.hpp"
 
-using ot::Encoding::BigEndian::HostSwap16;
-using ot::Encoding::BigEndian::HostSwap32;
-
 namespace ot {
 
 namespace NetworkDiagnostic {
+
+using ot::Encoding::BigEndian::HostSwap16;
+using ot::Encoding::BigEndian::HostSwap32;
 
 /**
  * @addtogroup core-mle-tlvs

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -56,7 +56,7 @@ public:
          * @param[in] aInstance  A reference to the OpenThread instance.
          *
          */
-        Iterator(Instance &aInstance);
+        explicit Iterator(Instance &aInstance);
 
         /**
          * This method resets the iterator to start over.
@@ -118,7 +118,7 @@ public:
      * @param[in]  aInstance  A reference to the OpenThread instance.
      *
      */
-    RouterTable(Instance &aInstance);
+    explicit RouterTable(Instance &aInstance);
 
     /**
      * This method clears the router table.
@@ -371,7 +371,7 @@ public:
     class Iterator
     {
     public:
-        Iterator(Instance &) {}
+        explicit Iterator(Instance &) {}
         void    Reset(void) {}
         bool    IsDone(void) const { return true; }
         void    Advance(void) {}

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -312,10 +312,10 @@ public:
     /**
      * This method updates the router table with a received Route TLV.
      *
-     * @param[in]  aRoute  A reference to the Route TLV.
+     * @param[in]  aTlv  A reference to the Route TLV.
      *
      */
-    void ProcessTlv(const Mle::RouteTlv &aRoute);
+    void ProcessTlv(const Mle::RouteTlv &aTlv);
 
     /**
      * This method updates the router table with a received Router Mask TLV.
@@ -323,7 +323,7 @@ public:
      * @param[in]  aTlv  A reference to the Router Mask TLV.
      *
      */
-    void ProcessTlv(const ThreadRouterMaskTlv &Tlv);
+    void ProcessTlv(const ThreadRouterMaskTlv &aTlv);
 
     /**
      * This method updates the router table and must be called with a one second period.

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -44,8 +44,6 @@
 #include "thread/thread_tlvs.hpp"
 #include "thread/thread_uri_paths.hpp"
 
-using ot::Encoding::BigEndian::HostSwap16;
-
 namespace ot {
 
 ThreadNetif::ThreadNetif(Instance &aInstance)

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -172,11 +172,11 @@ exit:
     return;
 }
 
-otError ThreadNetif::GetLinkAddress(Ip6::LinkAddress &address) const
+otError ThreadNetif::GetLinkAddress(Ip6::LinkAddress &aAddress) const
 {
-    address.mType       = Ip6::LinkAddress::kEui64;
-    address.mLength     = sizeof(address.mExtAddress);
-    address.mExtAddress = mMac.GetExtAddress();
+    aAddress.mType       = Ip6::LinkAddress::kEui64;
+    aAddress.mLength     = sizeof(aAddress.mExtAddress);
+    aAddress.mExtAddress = mMac.GetExtAddress();
     return OT_ERROR_NONE;
 }
 

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -42,10 +42,10 @@
 #include "net/ip6_address.hpp"
 #include "thread/mle.hpp"
 
+namespace ot {
+
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;
-
-namespace ot {
 
 enum
 {

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -255,14 +255,14 @@ void ChannelManager::HandleTimer(void)
     }
 }
 
-void ChannelManager::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)
+void ChannelManager::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aChangedFlags)
 {
-    aCallback.GetOwner<ChannelManager>().HandleStateChanged(aFlags);
+    aCallback.GetOwner<ChannelManager>().HandleStateChanged(aChangedFlags);
 }
 
-void ChannelManager::HandleStateChanged(otChangedFlags aFlags)
+void ChannelManager::HandleStateChanged(otChangedFlags aChangedFlags)
 {
-    VerifyOrExit((aFlags & OT_CHANGED_THREAD_CHANNEL) != 0);
+    VerifyOrExit((aChangedFlags & OT_CHANGED_THREAD_CHANNEL) != 0);
     VerifyOrExit(mChannel == GetInstance().Get<Mac::Mac>().GetPanChannel());
 
     mState = kStateIdle;

--- a/src/core/utils/channel_monitor.hpp
+++ b/src/core/utils/channel_monitor.hpp
@@ -102,7 +102,7 @@ public:
      * @param[in]  aInstance     A reference to the OpenThread instance.
      *
      */
-    ChannelMonitor(Instance &aInstance);
+    explicit ChannelMonitor(Instance &aInstance);
 
     /**
      * This method starts the Channel Monitoring operation.

--- a/src/core/utils/child_supervision.hpp
+++ b/src/core/utils/child_supervision.hpp
@@ -238,11 +238,11 @@ public:
     /**
      * This method updates the supervision listener state. It informs the listener of a received frame.
      *
-     * @param[in]   aSource    The source MAC address of the received frame
-     * @param[in]   aIsSecure  TRUE to indicate that the received frame is secure, FALSE otherwise.
+     * @param[in]   aSourceAddress    The source MAC address of the received frame
+     * @param[in]   aIsSecure         TRUE to indicate that the received frame is secure, FALSE otherwise.
      *
      */
-    void UpdateOnReceive(const Mac::Address &aSource, bool aIsSecure);
+    void UpdateOnReceive(const Mac::Address &aSourceAddress, bool aIsSecure);
 
 private:
     enum

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -187,7 +187,7 @@ private:
     void        SetJamState(bool aNewState);
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
-    void        UpdateHistory(bool aThresholdExceeded);
+    void        UpdateHistory(bool aDidExceedThreshold);
     void        UpdateJamState(void);
     static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
     void        HandleStateChanged(otChangedFlags aFlags);

--- a/src/core/utils/missing_strlcat.c
+++ b/src/core/utils/missing_strlcat.c
@@ -27,13 +27,13 @@
 
 #include "utils/wrap_string.h"
 
-size_t missing_strlcat(char *dest, const char *src, size_t size)
+size_t missing_strlcat(char *dst, const char *src, size_t dstsize)
 {
-    size_t len = strlen(dest);
+    size_t len = strlen(dst);
 
-    if (len < size - 1)
+    if (len < dstsize - 1)
     {
-        return (len + strlcpy(dest + len, src, size - len));
+        return (len + strlcpy(dst + len, src, dstsize - len));
     }
 
     return len + strlen(src);

--- a/src/core/utils/missing_strlcpy.c
+++ b/src/core/utils/missing_strlcpy.c
@@ -27,25 +27,25 @@
 
 #include "utils/wrap_string.h"
 
-size_t missing_strlcpy(char *dest, const char *src, size_t size)
+size_t missing_strlcpy(char *dst, const char *src, size_t dstsize)
 {
     const size_t slen = strlen(src);
 
-    if (size != 0)
+    if (dstsize != 0)
     {
-        size--;
+        dstsize--;
 
-        if (slen < size)
+        if (slen < dstsize)
         {
-            size = slen;
+            dstsize = slen;
         }
 
-        if (size != 0)
+        if (dstsize != 0)
         {
-            memcpy(dest, src, size);
+            memcpy(dst, src, dstsize);
         }
 
-        dest[size] = 0;
+        dst[dstsize] = 0;
     }
 
     return slen;

--- a/src/diag/diag_process.cpp
+++ b/src/diag/diag_process.cpp
@@ -157,10 +157,10 @@ exit:
     AppendErrorResult(error, aOutput, aOutputMaxLen);
 }
 
-otError Diag::ParseLong(char *aArgVector, long &aValue)
+otError Diag::ParseLong(char *aString, long &aLong)
 {
     char *endptr;
-    aValue = strtol(aArgVector, &endptr, 0);
+    aLong = strtol(aString, &endptr, 0);
     return (*endptr == '\0') ? OT_ERROR_NONE : OT_ERROR_PARSE;
 }
 

--- a/src/diag/openthread-diag.cpp
+++ b/src/diag/openthread-diag.cpp
@@ -55,7 +55,7 @@ void otDiagProcessCmd(int aArgCount, char *aArgVector[], char *aOutput, size_t a
     Diag::ProcessCmd(aArgCount, aArgVector, aOutput, aOutputMaxLen);
 }
 
-void otDiagProcessCmdLine(const char *aInput, char *aOutput, size_t aOutputMaxLen)
+void otDiagProcessCmdLine(const char *aString, char *aOutput, size_t aOutputMaxLen)
 {
     enum
     {
@@ -68,9 +68,9 @@ void otDiagProcessCmdLine(const char *aInput, char *aOutput, size_t aOutputMaxLe
     char *  argVector[kMaxArgs];
     uint8_t argCount = 0;
 
-    VerifyOrExit(strnlen(aInput, kMaxCommandBuffer) < kMaxCommandBuffer, error = OT_ERROR_NO_BUFS);
+    VerifyOrExit(strnlen(aString, kMaxCommandBuffer) < kMaxCommandBuffer, error = OT_ERROR_NO_BUFS);
 
-    strcpy(buffer, aInput);
+    strcpy(buffer, aString);
     error = ot::Utils::CmdLineParser::ParseCmd(buffer, argCount, argVector, kMaxArgs);
 
 exit:

--- a/src/ncp/hdlc.cpp
+++ b/src/ncp/hdlc.cpp
@@ -201,9 +201,9 @@ exit:
     return error;
 }
 
-Decoder::Decoder(FrameWritePointer &aWritePointer, FrameHandler aFrameHandler, void *aContext)
+Decoder::Decoder(FrameWritePointer &aFrameWritePointer, FrameHandler aFrameHandler, void *aContext)
     : mState(kStateNoSync)
-    , mWritePointer(aWritePointer)
+    , mWritePointer(aFrameWritePointer)
     , mFrameHandler(aFrameHandler)
     , mContext(aContext)
     , mFcs(0)

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -650,7 +650,7 @@ uint8_t NcpBase::GetWrappedResponseQueueIndex(uint8_t aPosition)
     return aPosition;
 }
 
-otError NcpBase::EnqueueResponse(uint8_t aHeader, ResponseType aType, unsigned int aKeyOrStatus)
+otError NcpBase::EnqueueResponse(uint8_t aHeader, ResponseType aType, unsigned int aPropKeyOrStatus)
 {
     otError        error = OT_ERROR_NONE;
     spinel_tid_t   tid   = SPINEL_HEADER_GET_TID(aHeader);
@@ -664,7 +664,7 @@ otError NcpBase::EnqueueResponse(uint8_t aHeader, ResponseType aType, unsigned i
 
         if (aType == kResponseTypeLastStatus)
         {
-            mChangedPropsSet.AddLastStatus(static_cast<spinel_status_t>(aKeyOrStatus));
+            mChangedPropsSet.AddLastStatus(static_cast<spinel_status_t>(aPropKeyOrStatus));
         }
 
         ExitNow();
@@ -709,7 +709,7 @@ otError NcpBase::EnqueueResponse(uint8_t aHeader, ResponseType aType, unsigned i
     entry->mTid             = tid;
     entry->mIsInUse         = true;
     entry->mType            = aType;
-    entry->mPropKeyOrStatus = aKeyOrStatus;
+    entry->mPropKeyOrStatus = aPropKeyOrStatus;
 
     mResponseQueueTail++;
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -824,7 +824,6 @@ void NcpBase::UpdateChangedProps(void)
 
 exit:
     mDidInitialUpdates = true;
-    return;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1576,7 +1576,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_MAC_SCAN_STATE>(void)
             VerifyOrExit(HasOnly1BitSet(mScanChannelMask), error = OT_ERROR_INVALID_ARGS);
 
             scanChannel     = IndexOfMSB(mScanChannelMask);
-            mCurScanChannel = (int8_t)scanChannel;
+            mCurScanChannel = static_cast<int8_t>(scanChannel);
 
             error = otLinkRawEnergyScan(mInstance, scanChannel, mScanPeriod, LinkRawEnergyScanDone);
         }

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -68,7 +68,7 @@ public:
      * @param[in]  aInstance  The OpenThread instance structure.
      *
      */
-    NcpBase(Instance *aInstance);
+    explicit NcpBase(Instance *aInstance);
 
     /**
      * This static method returns the pointer to the single NCP instance.

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -985,7 +985,7 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,
                                           const uint8_t **      aTlvs,
                                           uint8_t *             aTlvsLength,
                                           const otIp6Address ** aDestIpAddress,
-                                          bool                  aAllowEmptyValue)
+                                          bool                  aAllowEmptyValues)
 {
     otError error = OT_ERROR_NONE;
 
@@ -1017,7 +1017,7 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,
         {
         case SPINEL_PROP_DATASET_ACTIVE_TIMESTAMP:
 
-            if (!aAllowEmptyValue || !mDecoder.IsAllReadInStruct())
+            if (!aAllowEmptyValues || !mDecoder.IsAllReadInStruct())
             {
                 SuccessOrExit(error = mDecoder.ReadUint64(aDataset.mActiveTimestamp));
             }
@@ -1027,7 +1027,7 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,
 
         case SPINEL_PROP_DATASET_PENDING_TIMESTAMP:
 
-            if (!aAllowEmptyValue || !mDecoder.IsAllReadInStruct())
+            if (!aAllowEmptyValues || !mDecoder.IsAllReadInStruct())
             {
                 SuccessOrExit(error = mDecoder.ReadUint64(aDataset.mPendingTimestamp));
             }
@@ -1037,7 +1037,7 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,
 
         case SPINEL_PROP_NET_MASTER_KEY:
 
-            if (!aAllowEmptyValue || !mDecoder.IsAllReadInStruct())
+            if (!aAllowEmptyValues || !mDecoder.IsAllReadInStruct())
             {
                 const uint8_t *key;
                 uint16_t       len;
@@ -1052,7 +1052,7 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,
 
         case SPINEL_PROP_NET_NETWORK_NAME:
 
-            if (!aAllowEmptyValue || !mDecoder.IsAllReadInStruct())
+            if (!aAllowEmptyValues || !mDecoder.IsAllReadInStruct())
             {
                 const char *name;
                 size_t      len;
@@ -1068,7 +1068,7 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,
 
         case SPINEL_PROP_NET_XPANID:
 
-            if (!aAllowEmptyValue || !mDecoder.IsAllReadInStruct())
+            if (!aAllowEmptyValues || !mDecoder.IsAllReadInStruct())
             {
                 const uint8_t *xpanid;
                 uint16_t       len;
@@ -1083,7 +1083,7 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,
 
         case SPINEL_PROP_IPV6_ML_PREFIX:
 
-            if (!aAllowEmptyValue || !mDecoder.IsAllReadInStruct())
+            if (!aAllowEmptyValues || !mDecoder.IsAllReadInStruct())
             {
                 const otIp6Address *addr;
                 uint8_t             prefixLen;
@@ -1099,7 +1099,7 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,
 
         case SPINEL_PROP_DATASET_DELAY_TIMER:
 
-            if (!aAllowEmptyValue || !mDecoder.IsAllReadInStruct())
+            if (!aAllowEmptyValues || !mDecoder.IsAllReadInStruct())
             {
                 SuccessOrExit(error = mDecoder.ReadUint32(aDataset.mDelay));
             }
@@ -1109,7 +1109,7 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,
 
         case SPINEL_PROP_MAC_15_4_PANID:
 
-            if (!aAllowEmptyValue || !mDecoder.IsAllReadInStruct())
+            if (!aAllowEmptyValues || !mDecoder.IsAllReadInStruct())
             {
                 SuccessOrExit(error = mDecoder.ReadUint16(aDataset.mPanId));
             }
@@ -1119,7 +1119,7 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,
 
         case SPINEL_PROP_PHY_CHAN:
 
-            if (!aAllowEmptyValue || !mDecoder.IsAllReadInStruct())
+            if (!aAllowEmptyValues || !mDecoder.IsAllReadInStruct())
             {
                 uint8_t channel;
 
@@ -1132,7 +1132,7 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,
 
         case SPINEL_PROP_NET_PSKC:
 
-            if (!aAllowEmptyValue || !mDecoder.IsAllReadInStruct())
+            if (!aAllowEmptyValues || !mDecoder.IsAllReadInStruct())
             {
                 const uint8_t *psk;
                 uint16_t       len;
@@ -1147,7 +1147,7 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,
 
         case SPINEL_PROP_DATASET_SECURITY_POLICY:
 
-            if (!aAllowEmptyValue || !mDecoder.IsAllReadInStruct())
+            if (!aAllowEmptyValues || !mDecoder.IsAllReadInStruct())
             {
                 SuccessOrExit(error = mDecoder.ReadUint16(aDataset.mSecurityPolicy.mRotationTime));
                 SuccessOrExit(error = mDecoder.ReadUint8(aDataset.mSecurityPolicy.mFlags));
@@ -1158,7 +1158,7 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,
 
         case SPINEL_PROP_PHY_CHAN_SUPPORTED:
 
-            if (!aAllowEmptyValue || !mDecoder.IsAllReadInStruct())
+            if (!aAllowEmptyValues || !mDecoder.IsAllReadInStruct())
             {
                 uint8_t channel;
 
@@ -1177,7 +1177,7 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,
 
         case SPINEL_PROP_DATASET_RAW_TLVS:
 
-            if (!aAllowEmptyValue || !mDecoder.IsAllReadInStruct())
+            if (!aAllowEmptyValues || !mDecoder.IsAllReadInStruct())
             {
                 const uint8_t *tlvs;
                 uint16_t       len;
@@ -1200,7 +1200,7 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,
 
         case SPINEL_PROP_DATASET_DEST_ADDRESS:
 
-            if (!aAllowEmptyValue || !mDecoder.IsAllReadInStruct())
+            if (!aAllowEmptyValues || !mDecoder.IsAllReadInStruct())
             {
                 const otIp6Address *addr;
 

--- a/src/ncp/ncp_buffer.cpp
+++ b/src/ncp/ncp_buffer.cpp
@@ -154,7 +154,7 @@ uint8_t *NcpFrameBuffer::GetUpdatedBufPtr(uint8_t *aBufPtr, uint16_t aOffset, Di
 }
 
 // Gets the distance between two buffer pointers (adjusts for the wrap-around) given a direction (forward or backward).
-uint16_t NcpFrameBuffer::GetDistance(uint8_t *aStartPtr, uint8_t *aEndPtr, Direction aDirection) const
+uint16_t NcpFrameBuffer::GetDistance(const uint8_t *aStartPtr, const uint8_t *aEndPtr, Direction aDirection) const
 {
     size_t distance = 0;
 

--- a/src/ncp/ncp_buffer.cpp
+++ b/src/ncp/ncp_buffer.cpp
@@ -41,10 +41,10 @@ namespace Ncp {
 
 const NcpFrameBuffer::FrameTag NcpFrameBuffer::kInvalidTag = NULL;
 
-NcpFrameBuffer::NcpFrameBuffer(uint8_t *aBuffer, uint16_t aBufferLen)
+NcpFrameBuffer::NcpFrameBuffer(uint8_t *aBuffer, uint16_t aBufferLength)
     : mBuffer(aBuffer)
-    , mBufferEnd(aBuffer + aBufferLen)
-    , mBufferLength(aBufferLen)
+    , mBufferEnd(aBuffer + aBufferLength)
+    , mBufferLength(aBufferLength)
 {
     for (uint8_t priority = 0; priority < kNumPrios; priority++)
     {
@@ -268,7 +268,7 @@ exit:
 }
 
 // This function closes/ends the current segment.
-void NcpFrameBuffer::InFrameEndSegment(uint16_t aHeaderFlags)
+void NcpFrameBuffer::InFrameEndSegment(uint16_t aSegmentHeaderFlags)
 {
     uint16_t segmentLength;
     uint16_t header;
@@ -283,7 +283,7 @@ void NcpFrameBuffer::InFrameEndSegment(uint16_t aHeaderFlags)
         // Update the length and the flags in segment header (at segment head pointer).
         header = ReadUint16At(mWriteSegmentHead, mWriteDirection);
         header |= (segmentLength & kSegmentHeaderLengthMask);
-        header |= aHeaderFlags;
+        header |= aSegmentHeaderFlags;
         WriteUint16At(mWriteSegmentHead, header, mWriteDirection);
 
         // Move the segment head to current tail (to be ready for a possible next segment).

--- a/src/ncp/ncp_buffer.hpp
+++ b/src/ncp/ncp_buffer.hpp
@@ -595,7 +595,7 @@ private:
     };
 
     uint8_t *GetUpdatedBufPtr(uint8_t *aBufPtr, uint16_t aOffset, Direction aDirection) const;
-    uint16_t GetDistance(uint8_t *aStartPtr, uint8_t *aEndPtr, Direction aDirection) const;
+    uint16_t GetDistance(const uint8_t *aStartPtr, const uint8_t *aEndPtr, Direction aDirection) const;
 
     uint16_t ReadUint16At(uint8_t *aBufPtr, Direction aDirection);
     void     WriteUint16At(uint8_t *aBufPtr, uint16_t aValue, Direction aDirection);

--- a/src/ncp/ncp_spi.hpp
+++ b/src/ncp/ncp_spi.hpp
@@ -58,7 +58,7 @@ public:
      * @param[in] aBuffer     Pointer to buffer containing the frame.
      *
      */
-    SpiFrame(uint8_t *aBuffer)
+    explicit SpiFrame(uint8_t *aBuffer)
         : mBuffer(aBuffer)
     {
     }
@@ -152,7 +152,7 @@ public:
      * @param[in]  aInstance  A pointer to the OpenThread instance structure.
      *
      */
-    NcpSpi(Instance *aInstance);
+    explicit NcpSpi(Instance *aInstance);
 
 private:
     enum

--- a/src/ncp/ncp_uart.hpp
+++ b/src/ncp/ncp_uart.hpp
@@ -56,7 +56,7 @@ public:
      * @param[in]  aInstance  The OpenThread instance structure.
      *
      */
-    NcpUart(Instance *aInstance);
+    explicit NcpUart(Instance *aInstance);
 
     /**
      * This method is called when uart tx is finished. It prepares and sends the next data chunk (if any) to uart.

--- a/src/ncp/ncp_uart.hpp
+++ b/src/ncp/ncp_uart.hpp
@@ -121,7 +121,7 @@ private:
     void HandleFrameAddedToNcpBuffer(void);
 
     static void EncodeAndSendToUart(Tasklet &aTasklet);
-    static void HandleFrame(void *aConext, otError aError);
+    static void HandleFrame(void *aContext, otError aError);
     static void HandleFrameAddedToNcpBuffer(void *                   aContext,
                                             NcpFrameBuffer::FrameTag aTag,
                                             NcpFrameBuffer::Priority aPriority,

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -253,7 +253,7 @@ const char *spinel_next_packed_datatype(const char *pack_format)
 }
 
 static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
-                                               const uint8_t *data_ptr,
+                                               const uint8_t *data_in,
                                                spinel_size_t  data_len,
                                                const char *   pack_format,
                                                va_list_obj *  args)
@@ -280,11 +280,11 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
 
             if (arg_ptr)
             {
-                *arg_ptr = data_ptr[0] != 0;
+                *arg_ptr = data_in[0] != 0;
             }
 
             ret += sizeof(uint8_t);
-            data_ptr += sizeof(uint8_t);
+            data_in += sizeof(uint8_t);
             data_len -= sizeof(uint8_t);
             break;
         }
@@ -297,11 +297,11 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
 
             if (arg_ptr)
             {
-                *arg_ptr = data_ptr[0];
+                *arg_ptr = data_in[0];
             }
 
             ret += sizeof(uint8_t);
-            data_ptr += sizeof(uint8_t);
+            data_in += sizeof(uint8_t);
             data_len -= sizeof(uint8_t);
             break;
         }
@@ -314,11 +314,11 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
 
             if (arg_ptr)
             {
-                *arg_ptr = (uint16_t)((data_ptr[1] << 8) | data_ptr[0]);
+                *arg_ptr = (uint16_t)((data_in[1] << 8) | data_in[0]);
             }
 
             ret += sizeof(uint16_t);
-            data_ptr += sizeof(uint16_t);
+            data_in += sizeof(uint16_t);
             data_len -= sizeof(uint16_t);
             break;
         }
@@ -331,11 +331,11 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
 
             if (arg_ptr)
             {
-                *arg_ptr = (uint32_t)((data_ptr[3] << 24) | (data_ptr[2] << 16) | (data_ptr[1] << 8) | data_ptr[0]);
+                *arg_ptr = (uint32_t)((data_in[3] << 24) | (data_in[2] << 16) | (data_in[1] << 8) | data_in[0]);
             }
 
             ret += sizeof(uint32_t);
-            data_ptr += sizeof(uint32_t);
+            data_in += sizeof(uint32_t);
             data_len -= sizeof(uint32_t);
             break;
         }
@@ -348,14 +348,14 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
 
             if (arg_ptr)
             {
-                uint32_t l32 = (uint32_t)((data_ptr[3] << 24) | (data_ptr[2] << 16) | (data_ptr[1] << 8) | data_ptr[0]);
-                uint32_t h32 = (uint32_t)((data_ptr[7] << 24) | (data_ptr[6] << 16) | (data_ptr[5] << 8) | data_ptr[4]);
+                uint32_t l32 = (uint32_t)((data_in[3] << 24) | (data_in[2] << 16) | (data_in[1] << 8) | data_in[0]);
+                uint32_t h32 = (uint32_t)((data_in[7] << 24) | (data_in[6] << 16) | (data_in[5] << 8) | data_in[4]);
 
                 *arg_ptr = ((uint64_t)l32) | (((uint64_t)h32) << 32);
             }
 
             ret += sizeof(uint64_t);
-            data_ptr += sizeof(uint64_t);
+            data_in += sizeof(uint64_t);
             data_len -= sizeof(uint64_t);
             break;
         }
@@ -369,7 +369,7 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
                 spinel_ipv6addr_t *arg = va_arg(args->obj, spinel_ipv6addr_t *);
                 if (arg)
                 {
-                    memcpy(arg, data_ptr, sizeof(spinel_ipv6addr_t));
+                    memcpy(arg, data_in, sizeof(spinel_ipv6addr_t));
                 }
             }
             else
@@ -377,12 +377,12 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
                 const spinel_ipv6addr_t **arg_ptr = va_arg(args->obj, const spinel_ipv6addr_t **);
                 if (arg_ptr)
                 {
-                    *arg_ptr = (const spinel_ipv6addr_t *)data_ptr;
+                    *arg_ptr = (const spinel_ipv6addr_t *)data_in;
                 }
             }
 
             ret += sizeof(spinel_ipv6addr_t);
-            data_ptr += sizeof(spinel_ipv6addr_t);
+            data_in += sizeof(spinel_ipv6addr_t);
             data_len -= sizeof(spinel_ipv6addr_t);
             break;
         }
@@ -396,7 +396,7 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
                 spinel_eui64_t *arg = va_arg(args->obj, spinel_eui64_t *);
                 if (arg)
                 {
-                    memcpy(arg, data_ptr, sizeof(spinel_eui64_t));
+                    memcpy(arg, data_in, sizeof(spinel_eui64_t));
                 }
             }
             else
@@ -404,12 +404,12 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
                 const spinel_eui64_t **arg_ptr = va_arg(args->obj, const spinel_eui64_t **);
                 if (arg_ptr)
                 {
-                    *arg_ptr = (const spinel_eui64_t *)data_ptr;
+                    *arg_ptr = (const spinel_eui64_t *)data_in;
                 }
             }
 
             ret += sizeof(spinel_eui64_t);
-            data_ptr += sizeof(spinel_eui64_t);
+            data_in += sizeof(spinel_eui64_t);
             data_len -= sizeof(spinel_eui64_t);
             break;
         }
@@ -423,7 +423,7 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
                 spinel_eui48_t *arg = va_arg(args->obj, spinel_eui48_t *);
                 if (arg)
                 {
-                    memcpy(arg, data_ptr, sizeof(spinel_eui48_t));
+                    memcpy(arg, data_in, sizeof(spinel_eui48_t));
                 }
             }
             else
@@ -431,12 +431,12 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
                 const spinel_eui48_t **arg_ptr = va_arg(args->obj, const spinel_eui48_t **);
                 if (arg_ptr)
                 {
-                    *arg_ptr = (const spinel_eui48_t *)data_ptr;
+                    *arg_ptr = (const spinel_eui48_t *)data_in;
                 }
             }
 
             ret += sizeof(spinel_eui48_t);
-            data_ptr += sizeof(spinel_eui48_t);
+            data_in += sizeof(spinel_eui48_t);
             data_len -= sizeof(spinel_eui48_t);
             break;
         }
@@ -444,7 +444,7 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
         case SPINEL_DATATYPE_UINT_PACKED_C:
         {
             unsigned int * arg_ptr = va_arg(args->obj, unsigned int *);
-            spinel_ssize_t pui_len = spinel_packed_uint_decode(data_ptr, data_len, arg_ptr);
+            spinel_ssize_t pui_len = spinel_packed_uint_decode(data_in, data_len, arg_ptr);
 
             // Range check
             require_action(NULL == arg_ptr || (*arg_ptr < SPINEL_MAX_UINT_PACKED), bail, (ret = -1, errno = ERANGE));
@@ -454,7 +454,7 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
             require(pui_len <= (spinel_ssize_t)data_len, bail);
 
             ret += pui_len;
-            data_ptr += pui_len;
+            data_in += pui_len;
             data_len -= (spinel_size_t)pui_len;
             break;
         }
@@ -469,7 +469,7 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
             // Add 1 for zero termination. If not zero terminated,
             // len will then be data_len+1, which we will detect
             // in the next check.
-            len = strnlen((const char *)data_ptr, data_len) + 1;
+            len = strnlen((const char *)data_in, data_len) + 1;
 
             // Verify that the string is zero terminated.
             require_action(len <= data_len, bail, (ret = -1, errno = EOVERFLOW));
@@ -481,7 +481,7 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
                 if (arg)
                 {
                     require_action(len_arg >= len, bail, (ret = -1, errno = ENOMEM));
-                    memcpy(arg, data_ptr, len);
+                    memcpy(arg, data_in, len);
                 }
             }
             else
@@ -489,12 +489,12 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
                 const char **arg_ptr = va_arg(args->obj, const char **);
                 if (arg_ptr)
                 {
-                    *arg_ptr = (const char *)data_ptr;
+                    *arg_ptr = (const char *)data_in;
                 }
             }
 
             ret += (spinel_size_t)len;
-            data_ptr += len;
+            data_in += len;
             data_len -= (spinel_size_t)len;
             break;
         }
@@ -504,14 +504,14 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
         {
             spinel_ssize_t pui_len       = 0;
             uint16_t       block_len     = 0;
-            const uint8_t *block_ptr     = data_ptr;
+            const uint8_t *block_ptr     = data_in;
             void *         arg_ptr       = va_arg(args->obj, void *);
             unsigned int * block_len_ptr = va_arg(args->obj, unsigned int *);
             char           nextformat    = *spinel_next_packed_datatype(pack_format);
 
             if ((pack_format[0] == SPINEL_DATATYPE_DATA_WLEN_C) || ((nextformat != 0) && (nextformat != ')')))
             {
-                pui_len = spinel_datatype_unpack(data_ptr, data_len, SPINEL_DATATYPE_UINT16_S, &block_len);
+                pui_len = spinel_datatype_unpack(data_in, data_len, SPINEL_DATATYPE_UINT16_S, &block_len);
                 block_ptr += pui_len;
 
                 require(pui_len > 0, bail);
@@ -546,7 +546,7 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
 
             block_len += (uint16_t)pui_len;
             ret += block_len;
-            data_ptr += block_len;
+            data_in += block_len;
             data_len -= block_len;
             break;
         }
@@ -557,12 +557,12 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
             spinel_ssize_t pui_len    = 0;
             uint16_t       block_len  = 0;
             spinel_ssize_t actual_len = 0;
-            const uint8_t *block_ptr  = data_ptr;
+            const uint8_t *block_ptr  = data_in;
             char           nextformat = *spinel_next_packed_datatype(pack_format);
 
             if ((pack_format[0] == SPINEL_DATATYPE_STRUCT_C) || ((nextformat != 0) && (nextformat != ')')))
             {
-                pui_len = spinel_datatype_unpack(data_ptr, data_len, SPINEL_DATATYPE_UINT16_S, &block_len);
+                pui_len = spinel_datatype_unpack(data_in, data_len, SPINEL_DATATYPE_UINT16_S, &block_len);
                 block_ptr += pui_len;
 
                 require(pui_len > 0, bail);
@@ -590,7 +590,7 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
             }
 
             ret += block_len;
-            data_ptr += block_len;
+            data_in += block_len;
             data_len -= block_len;
             break;
         }
@@ -614,7 +614,7 @@ bail:
     return ret;
 }
 
-spinel_ssize_t spinel_datatype_unpack_in_place(const uint8_t *data_ptr,
+spinel_ssize_t spinel_datatype_unpack_in_place(const uint8_t *data_in,
                                                spinel_size_t  data_len,
                                                const char *   pack_format,
                                                ...)
@@ -623,25 +623,25 @@ spinel_ssize_t spinel_datatype_unpack_in_place(const uint8_t *data_ptr,
     va_list_obj    args;
     va_start(args.obj, pack_format);
 
-    ret = spinel_datatype_vunpack_(true, data_ptr, data_len, pack_format, &args);
+    ret = spinel_datatype_vunpack_(true, data_in, data_len, pack_format, &args);
 
     va_end(args.obj);
     return ret;
 }
 
-spinel_ssize_t spinel_datatype_unpack(const uint8_t *data_ptr, spinel_size_t data_len, const char *pack_format, ...)
+spinel_ssize_t spinel_datatype_unpack(const uint8_t *data_in, spinel_size_t data_len, const char *pack_format, ...)
 {
     spinel_ssize_t ret;
     va_list_obj    args;
     va_start(args.obj, pack_format);
 
-    ret = spinel_datatype_vunpack_(false, data_ptr, data_len, pack_format, &args);
+    ret = spinel_datatype_vunpack_(false, data_in, data_len, pack_format, &args);
 
     va_end(args.obj);
     return ret;
 }
 
-spinel_ssize_t spinel_datatype_vunpack_in_place(const uint8_t *data_ptr,
+spinel_ssize_t spinel_datatype_vunpack_in_place(const uint8_t *data_in,
                                                 spinel_size_t  data_len,
                                                 const char *   pack_format,
                                                 va_list        args)
@@ -650,13 +650,13 @@ spinel_ssize_t spinel_datatype_vunpack_in_place(const uint8_t *data_ptr,
     va_list_obj    args_obj;
     va_copy(args_obj.obj, args);
 
-    ret = spinel_datatype_vunpack_(true, data_ptr, data_len, pack_format, &args_obj);
+    ret = spinel_datatype_vunpack_(true, data_in, data_len, pack_format, &args_obj);
 
     va_end(args_obj.obj);
     return ret;
 }
 
-spinel_ssize_t spinel_datatype_vunpack(const uint8_t *data_ptr,
+spinel_ssize_t spinel_datatype_vunpack(const uint8_t *data_in,
                                        spinel_size_t  data_len,
                                        const char *   pack_format,
                                        va_list        args)
@@ -665,13 +665,13 @@ spinel_ssize_t spinel_datatype_vunpack(const uint8_t *data_ptr,
     va_list_obj    args_obj;
     va_copy(args_obj.obj, args);
 
-    ret = spinel_datatype_vunpack_(false, data_ptr, data_len, pack_format, &args_obj);
+    ret = spinel_datatype_vunpack_(false, data_in, data_len, pack_format, &args_obj);
 
     va_end(args_obj.obj);
     return ret;
 }
 
-static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_ptr,
+static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_out,
                                              spinel_size_t data_len_max,
                                              const char *  pack_format,
                                              va_list_obj * args)
@@ -698,8 +698,8 @@ static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_ptr,
 
             if (data_len_max >= sizeof(uint8_t))
             {
-                data_ptr[0] = (arg != false);
-                data_ptr += sizeof(uint8_t);
+                data_out[0] = (arg != false);
+                data_out += sizeof(uint8_t);
                 data_len_max -= sizeof(uint8_t);
             }
             else
@@ -718,8 +718,8 @@ static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_ptr,
 
             if (data_len_max >= sizeof(uint8_t))
             {
-                data_ptr[0] = arg;
-                data_ptr += sizeof(uint8_t);
+                data_out[0] = arg;
+                data_out += sizeof(uint8_t);
                 data_len_max -= sizeof(uint8_t);
             }
             else
@@ -738,9 +738,9 @@ static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_ptr,
 
             if (data_len_max >= sizeof(uint16_t))
             {
-                data_ptr[1] = (arg >> 8) & 0xff;
-                data_ptr[0] = (arg >> 0) & 0xff;
-                data_ptr += sizeof(uint16_t);
+                data_out[1] = (arg >> 8) & 0xff;
+                data_out[0] = (arg >> 0) & 0xff;
+                data_out += sizeof(uint16_t);
                 data_len_max -= sizeof(uint16_t);
             }
             else
@@ -759,11 +759,11 @@ static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_ptr,
 
             if (data_len_max >= sizeof(uint32_t))
             {
-                data_ptr[3] = (arg >> 24) & 0xff;
-                data_ptr[2] = (arg >> 16) & 0xff;
-                data_ptr[1] = (arg >> 8) & 0xff;
-                data_ptr[0] = (arg >> 0) & 0xff;
-                data_ptr += sizeof(uint32_t);
+                data_out[3] = (arg >> 24) & 0xff;
+                data_out[2] = (arg >> 16) & 0xff;
+                data_out[1] = (arg >> 8) & 0xff;
+                data_out[0] = (arg >> 0) & 0xff;
+                data_out += sizeof(uint32_t);
                 data_len_max -= sizeof(uint32_t);
             }
             else
@@ -783,15 +783,15 @@ static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_ptr,
 
             if (data_len_max >= sizeof(uint64_t))
             {
-                data_ptr[7] = (arg >> 56) & 0xff;
-                data_ptr[6] = (arg >> 48) & 0xff;
-                data_ptr[5] = (arg >> 40) & 0xff;
-                data_ptr[4] = (arg >> 32) & 0xff;
-                data_ptr[3] = (arg >> 24) & 0xff;
-                data_ptr[2] = (arg >> 16) & 0xff;
-                data_ptr[1] = (arg >> 8) & 0xff;
-                data_ptr[0] = (arg >> 0) & 0xff;
-                data_ptr += sizeof(uint64_t);
+                data_out[7] = (arg >> 56) & 0xff;
+                data_out[6] = (arg >> 48) & 0xff;
+                data_out[5] = (arg >> 40) & 0xff;
+                data_out[4] = (arg >> 32) & 0xff;
+                data_out[3] = (arg >> 24) & 0xff;
+                data_out[2] = (arg >> 16) & 0xff;
+                data_out[1] = (arg >> 8) & 0xff;
+                data_out[0] = (arg >> 0) & 0xff;
+                data_out += sizeof(uint64_t);
                 data_len_max -= sizeof(uint64_t);
             }
             else
@@ -809,8 +809,8 @@ static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_ptr,
 
             if (data_len_max >= sizeof(spinel_ipv6addr_t))
             {
-                *(spinel_ipv6addr_t *)data_ptr = *arg;
-                data_ptr += sizeof(spinel_ipv6addr_t);
+                *(spinel_ipv6addr_t *)data_out = *arg;
+                data_out += sizeof(spinel_ipv6addr_t);
                 data_len_max -= sizeof(spinel_ipv6addr_t);
             }
             else
@@ -828,8 +828,8 @@ static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_ptr,
 
             if (data_len_max >= sizeof(spinel_eui48_t))
             {
-                *(spinel_eui48_t *)data_ptr = *arg;
-                data_ptr += sizeof(spinel_eui48_t);
+                *(spinel_eui48_t *)data_out = *arg;
+                data_out += sizeof(spinel_eui48_t);
                 data_len_max -= sizeof(spinel_eui48_t);
             }
             else
@@ -847,8 +847,8 @@ static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_ptr,
 
             if (data_len_max >= sizeof(spinel_eui64_t))
             {
-                *(spinel_eui64_t *)data_ptr = *arg;
-                data_ptr += sizeof(spinel_eui64_t);
+                *(spinel_eui64_t *)data_out = *arg;
+                data_out += sizeof(spinel_eui64_t);
                 data_len_max -= sizeof(spinel_eui64_t);
             }
             else
@@ -870,12 +870,12 @@ static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_ptr,
                 errno = EINVAL;
             });
 
-            encoded_size = spinel_packed_uint_encode(data_ptr, data_len_max, arg);
+            encoded_size = spinel_packed_uint_encode(data_out, data_len_max, arg);
             ret += encoded_size;
 
             if ((spinel_ssize_t)data_len_max >= encoded_size)
             {
-                data_ptr += encoded_size;
+                data_out += encoded_size;
                 data_len_max -= (spinel_size_t)encoded_size;
             }
             else
@@ -905,9 +905,9 @@ static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_ptr,
 
             if (data_len_max >= string_arg_len)
             {
-                memcpy(data_ptr, string_arg, string_arg_len);
+                memcpy(data_out, string_arg, string_arg_len);
 
-                data_ptr += string_arg_len;
+                data_out += string_arg_len;
                 data_len_max -= (spinel_size_t)string_arg_len;
             }
             else
@@ -928,7 +928,7 @@ static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_ptr,
 
             if ((pack_format[0] == SPINEL_DATATYPE_DATA_WLEN_C) || ((nextformat != 0) && (nextformat != ')')))
             {
-                size_len = spinel_datatype_pack(data_ptr, data_len_max, SPINEL_DATATYPE_UINT16_S, data_size_arg);
+                size_len = spinel_datatype_pack(data_out, data_len_max, SPINEL_DATATYPE_UINT16_S, data_size_arg);
                 require_action(size_len > 0, bail, {
                     ret   = -1;
                     errno = EINVAL;
@@ -939,12 +939,12 @@ static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_ptr,
 
             if (data_len_max >= (spinel_size_t)size_len + data_size_arg)
             {
-                data_ptr += size_len;
+                data_out += size_len;
                 data_len_max -= (spinel_size_t)size_len;
 
-                memcpy(data_ptr, arg, data_size_arg);
+                memcpy(data_out, arg, data_size_arg);
 
-                data_ptr += data_size_arg;
+                data_out += data_size_arg;
                 data_len_max -= data_size_arg;
             }
             else
@@ -977,7 +977,7 @@ static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_ptr,
 
             if ((pack_format[0] == SPINEL_DATATYPE_STRUCT_C) || ((nextformat != 0) && (nextformat != ')')))
             {
-                size_len = spinel_datatype_pack(data_ptr, data_len_max, SPINEL_DATATYPE_UINT16_S, struct_len);
+                size_len = spinel_datatype_pack(data_out, data_len_max, SPINEL_DATATYPE_UINT16_S, struct_len);
                 require_action(size_len > 0, bail, {
                     ret   = -1;
                     errno = EINVAL;
@@ -988,12 +988,12 @@ static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_ptr,
 
             if (struct_len + size_len <= (spinel_ssize_t)data_len_max)
             {
-                data_ptr += size_len;
+                data_out += size_len;
                 data_len_max -= (spinel_size_t)size_len;
 
-                struct_len = spinel_datatype_vpack_(data_ptr, data_len_max, pack_format + 2, args);
+                struct_len = spinel_datatype_vpack_(data_out, data_len_max, pack_format + 2, args);
 
-                data_ptr += struct_len;
+                data_out += struct_len;
                 data_len_max -= (spinel_size_t)struct_len;
             }
             else
@@ -1020,19 +1020,19 @@ bail:
     return ret;
 }
 
-spinel_ssize_t spinel_datatype_pack(uint8_t *data_ptr, spinel_size_t data_len_max, const char *pack_format, ...)
+spinel_ssize_t spinel_datatype_pack(uint8_t *data_out, spinel_size_t data_len_max, const char *pack_format, ...)
 {
     int         ret;
     va_list_obj args;
     va_start(args.obj, pack_format);
 
-    ret = spinel_datatype_vpack_(data_ptr, data_len_max, pack_format, &args);
+    ret = spinel_datatype_vpack_(data_out, data_len_max, pack_format, &args);
 
     va_end(args.obj);
     return ret;
 }
 
-spinel_ssize_t spinel_datatype_vpack(uint8_t *     data_ptr,
+spinel_ssize_t spinel_datatype_vpack(uint8_t *     data_out,
                                      spinel_size_t data_len_max,
                                      const char *  pack_format,
                                      va_list       args)
@@ -1041,7 +1041,7 @@ spinel_ssize_t spinel_datatype_vpack(uint8_t *     data_ptr,
     va_list_obj args_obj;
     va_copy(args_obj.obj, args);
 
-    ret = spinel_datatype_vpack_(data_ptr, data_len_max, pack_format, &args_obj);
+    ret = spinel_datatype_vpack_(data_out, data_len_max, pack_format, &args_obj);
 
     va_end(args_obj.obj);
     return ret;

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -777,7 +777,7 @@ static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_ptr,
         case SPINEL_DATATYPE_INT64_C:
         case SPINEL_DATATYPE_UINT64_C:
         {
-            uint64_t arg = (uint64_t)va_arg(args->obj, uint64_t);
+            uint64_t arg = va_arg(args->obj, uint64_t);
 
             ret += sizeof(uint64_t);
 

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -3530,11 +3530,11 @@ typedef char spinel_datatype_t;
 #define SPINEL_MAX_UINT_PACKED 2097151
 
 SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_pack(uint8_t *     data_out,
-                                                      spinel_size_t data_len,
+                                                      spinel_size_t data_len_max,
                                                       const char *  pack_format,
                                                       ...);
 SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_vpack(uint8_t *     data_out,
-                                                       spinel_size_t data_len,
+                                                       spinel_size_t data_len_max,
                                                        const char *  pack_format,
                                                        va_list       args);
 SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_unpack(const uint8_t *data_in,
@@ -3602,7 +3602,7 @@ SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_vunpack_in_place(const uint8_t 
 
 SPINEL_API_EXTERN spinel_ssize_t spinel_packed_uint_decode(const uint8_t *bytes,
                                                            spinel_size_t  len,
-                                                           unsigned int * value);
+                                                           unsigned int * value_ptr);
 SPINEL_API_EXTERN spinel_ssize_t spinel_packed_uint_encode(uint8_t *bytes, spinel_size_t len, unsigned int value);
 SPINEL_API_EXTERN spinel_ssize_t spinel_packed_uint_size(unsigned int value);
 

--- a/src/ncp/spinel_decoder.hpp
+++ b/src/ncp/spinel_decoder.hpp
@@ -456,14 +456,14 @@ public:
      *
      * On success, the read position gets updated.
      *
-     * @param[out] aUt8                 Reference to a `char` pointer to output the string.
+     * @param[out] aUtf8                Reference to a `char` pointer to output the string.
      *                                  On success, the pointer variable is updated.
      *
      * @retval OT_ERROR_NONE            Successfully read the value.
      * @retval OT_ERROR_PARSE           Failed to parse/decode the value.
      *
      */
-    otError ReadUtf8(const char *&aUt8);
+    otError ReadUtf8(const char *&aUtf8);
 
     /**
      * This method decodes and reads a data blob (sequence of bytes) form the frame.

--- a/src/ncp/spinel_encoder.hpp
+++ b/src/ncp/spinel_encoder.hpp
@@ -59,7 +59,7 @@ public:
      * @param[in] aNcpBuffer   A reference to a `NcpFrameBuffer` where the frames are written.
      *
      */
-    SpinelEncoder(NcpFrameBuffer &aNcpBuffer)
+    explicit SpinelEncoder(NcpFrameBuffer &aNcpBuffer)
         : mNcpBuffer(aNcpBuffer)
         , mNumOpenStructs(0)
         , mSavedNumOpenStructs(0)


### PR DESCRIPTION
- use C++-style casts
- remove unused using decls
- remove using decls from global namespace in headers
- mark single-arg constructors as explicit
- remove const values in declarations
- remove static member access through instances
- const-qualify pointer args where possible
- remove redundant declarations
- remove redundant control flow
- make parameter names consistent across decls and defs