### PR TITLE
[docs] fix instances of "the the" in comments

### DIFF
--- a/include/openthread/coap_secure.h
+++ b/include/openthread/coap_secure.h
@@ -175,7 +175,7 @@ otError otCoapSecureSetCertificate(otInstance *   aInstance,
  * @param[in]  aX509CaCertificateChain  A pointer to the PEM formatted X509 CA chain.
  * @param[in]  aX509CaCertChainLength   The length of chain.
  *
- * @retval OT_ERROR_NONE  Successfully set the the trusted top level CAs.
+ * @retval OT_ERROR_NONE  Successfully set the trusted top level CAs.
  *
  */
 otError otCoapSecureSetCaCertificateChain(otInstance *   aInstance,

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -210,7 +210,7 @@ public:
      * @param[in]  aX509CaCertificateChain  A pointer to the PEM formatted X509 CA chain.
      * @param[in]  aX509CaCertChainLength   The length of chain.
      *
-     * @retval OT_ERROR_NONE  Successfully set the the trusted top level CAs.
+     * @retval OT_ERROR_NONE  Successfully set the trusted top level CAs.
      *
      */
     otError SetCaCertificateChain(const uint8_t *aX509CaCertificateChain, uint32_t aX509CaCertChainLength);

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -79,7 +79,7 @@ public:
     /**
      * This method gets the state of the Border Agent service.
      *
-     * @returns The state of the the Border Agent service.
+     * @returns The state of the Border Agent service.
      *
      */
     otBorderAgentState GetState(void) const { return mState; }

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -302,7 +302,7 @@ public:
      * @param[in]  aX509CaCertificateChain  A pointer to the PEM formatted X509 CA chain.
      * @param[in]  aX509CaCertChainLength   The length of chain.
      *
-     * @retval OT_ERROR_NONE  Successfully set the the trusted top level CAs.
+     * @retval OT_ERROR_NONE  Successfully set the trusted top level CAs.
      *
      */
     otError SetCaCertificateChain(const uint8_t *aX509CaCertificateChain, uint32_t aX509CaCertChainLength);

--- a/src/core/net/sntp_client.hpp
+++ b/src/core/net/sntp_client.hpp
@@ -162,15 +162,15 @@ public:
     /**
      * This method returns the root delay field value.
      *
-     * @returns Value of the the root delay field.
+     * @returns Value of the root delay field.
      *
      */
     uint32_t GetRootDelay(void) const { return HostSwap32(mRootDelay); }
 
     /**
-     * This method sets the the root delay field.
+     * This method sets the root delay field.
      *
-     * @param[in]  aRootDelay  The value of the the root delay field.
+     * @param[in]  aRootDelay  The value of the root delay field.
      *
      */
     void SetRootDelay(uint32_t aRootDelay) { mRootDelay = HostSwap32(aRootDelay); }
@@ -178,15 +178,15 @@ public:
     /**
      * This method returns the root dispersion field value.
      *
-     * @returns Value of the the root dispersion field.
+     * @returns Value of the root dispersion field.
      *
      */
     uint32_t GetRootDispersion(void) const { return HostSwap32(mRootDispersion); }
 
     /**
-     * This method sets the the root dispersion field.
+     * This method sets the root dispersion field.
      *
-     * @param[in]  aRootDispersion  The value of the the root dispersion field.
+     * @param[in]  aRootDispersion  The value of the root dispersion field.
      *
      */
     void SetRootDispersion(uint32_t aRootDispersion) { mRootDispersion = HostSwap32(aRootDispersion); }
@@ -194,15 +194,15 @@ public:
     /**
      * This method returns the reference identifier field value.
      *
-     * @returns Value of the the reference identifier field.
+     * @returns Value of the reference identifier field.
      *
      */
     uint32_t GetReferenceId(void) const { return HostSwap32(mReferenceId); }
 
     /**
-     * This method sets the the reference identifier field.
+     * This method sets the reference identifier field.
      *
-     * @param[in]  aReferenceId  The value of the the reference identifier field.
+     * @param[in]  aReferenceId  The value of the reference identifier field.
      *
      */
     void SetReferenceId(uint32_t aReferenceId) { mReferenceId = HostSwap32(aReferenceId); }
@@ -210,7 +210,7 @@ public:
     /**
      * This method returns the kiss code in ASCII format.
      *
-     * @returns Value of the the reference identifier field in ASCII format.
+     * @returns Value of the reference identifier field in ASCII format.
      *
      */
     char *GetKissCode(void) { return reinterpret_cast<char *>(&mReferenceId); }

--- a/src/core/openthread-core-default-config.h
+++ b/src/core/openthread-core-default-config.h
@@ -1411,7 +1411,7 @@
  * better parent and will switch parent if a better one is found.
  *
  * The child will periodically check the average RSS value for the current parent, and only if it is below a specific
- * threshold, a parent search is performed. The `OPENTHREAD_CONFIG_PARENT_SEARCH_CHECK_INTERVAL` specifies the the
+ * threshold, a parent search is performed. The `OPENTHREAD_CONFIG_PARENT_SEARCH_CHECK_INTERVAL` specifies the
  * check interval (in seconds) and `OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_THRESHOLD` gives the RSS threshold.
  *
  * Since the parent search process can be power consuming (child needs to stays in RX mode to collect parent response)

--- a/src/ncp/ncp_base_radio.cpp
+++ b/src/ncp/ncp_base_radio.cpp
@@ -180,7 +180,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_RADIO_CAPS>(void)
 
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_MAC_SRC_MATCH_ENABLED>(void)
 {
-    // TODO: Would be good to add an `otLinkRaw` API to give the the status of source match.
+    // TODO: Would be good to add an `otLinkRaw` API to give the status of source match.
     return mEncoder.WriteBool(mSrcMatchEnabled);
 }
 

--- a/src/ncp/ncp_buffer.hpp
+++ b/src/ncp/ncp_buffer.hpp
@@ -447,7 +447,7 @@ private:
      * -------------------------------
      *
      * `NcpFrameBuffer` internally stores a frame as a sequence of data segments. Each segment stores a portion of
-     * frame. The data segments are stored in the the main buffer `mBuffer`. `mBuffer` is utilized as a circular buffer.
+     * frame. The data segments are stored in the main buffer `mBuffer`. `mBuffer` is utilized as a circular buffer.
 
      * The content of messages (which are added using `InFrameFeedMessage()`) are not directly copied in the `mBuffer`
      * but instead they are enqueued in a message queue `mMessageQueue`.
@@ -617,7 +617,7 @@ private:
 
     uint8_t *const mBuffer;       // Pointer to the buffer used to store the data.
     uint8_t *const mBufferEnd;    // Points to after the end of buffer.
-    const uint16_t mBufferLength; // Length of the the buffer.
+    const uint16_t mBufferLength; // Length of the buffer.
 
     BufferCallback mFrameAddedCallback;   // Callback to signal when a new frame is added
     void *         mFrameAddedContext;    // Context passed to `mFrameAddedCallback`.


### PR DESCRIPTION
One of these flagged in the recent openthread.io reference update, so I fixed that and all other instances that aren't in third party or the Spinel docs.