### PR TITLE
[mac-filter] hide the mFiltered in public filter APIs

### DIFF
--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -99,7 +99,6 @@ typedef struct otMacFilterEntry
 {
     otExtAddress mExtAddress; ///< IEEE 802.15.4 Extended Address
     int8_t       mRssIn;      ///< Received signal strength
-    bool         mFiltered;   ///< Indicates whether or not this entry is filtered.
 } otMacFilterEntry;
 
 /**

--- a/src/core/common/code_utils.hpp
+++ b/src/core/common/code_utils.hpp
@@ -50,6 +50,19 @@
 #define OT_ARRAY_LENGTH(aArray) (sizeof(aArray) / sizeof(aArray[0]))
 
 /**
+ * This macro returns a pointer to end of a given array (pointing to the past-the-end element).
+ *
+ * Note that the past-the-end element is a theoretical element that would follow the last element in the array. It does
+ * not point to an actual element in array, and thus should not be dereferenced.
+ *
+ * @param[in]    Name of the array variable
+ *
+ * @returns Pointer to the past-the-end element.
+ *
+ */
+#define OT_ARRAY_END(aArray) (&aArray[OT_ARRAY_LENGTH(aArray)])
+
+/**
  * This macro returns a pointer aligned by @p aAlignment.
  *
  * @param[in] aPointer      A pointer to contiguous space.


### PR DESCRIPTION
This commit improves the `Mac::Filter` implementation. It mainly
removes the internally used `mFiltered` variable from the public
`otMacFilterEntry` definition and moves it inside `Mac::Filter`
private definitions.

---
Added a second (seperate) commit in the same PR:

**[code-utils] add OT_ARRAY_END() macro**

This commit adds `OT_ARRAY_END(aArray)` macro which returns a
pointer to the end of a given array (pointing to the past-the-end
element).