### PR TITLE
[dataset] use Read/Save method names instead of Get/Set

### DIFF
--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -57,7 +57,7 @@ otError otDatasetGetActive(otInstance *aInstance, otOperationalDataset *aDataset
 
     VerifyOrExit(aDataset != NULL, error = OT_ERROR_INVALID_ARGS);
 
-    error = instance.GetThreadNetif().GetActiveDataset().Get(*aDataset);
+    error = instance.GetThreadNetif().GetActiveDataset().Read(*aDataset);
 
 exit:
     return error;
@@ -70,7 +70,7 @@ otError otDatasetSetActive(otInstance *aInstance, const otOperationalDataset *aD
 
     VerifyOrExit(aDataset != NULL, error = OT_ERROR_INVALID_ARGS);
 
-    error = instance.GetThreadNetif().GetActiveDataset().Set(*aDataset);
+    error = instance.GetThreadNetif().GetActiveDataset().Save(*aDataset);
 
 exit:
     return error;
@@ -83,7 +83,7 @@ otError otDatasetGetPending(otInstance *aInstance, otOperationalDataset *aDatase
 
     VerifyOrExit(aDataset != NULL, error = OT_ERROR_INVALID_ARGS);
 
-    error = instance.GetThreadNetif().GetPendingDataset().Get(*aDataset);
+    error = instance.GetThreadNetif().GetPendingDataset().Read(*aDataset);
 
 exit:
     return error;
@@ -96,7 +96,7 @@ otError otDatasetSetPending(otInstance *aInstance, const otOperationalDataset *a
 
     VerifyOrExit(aDataset != NULL, error = OT_ERROR_INVALID_ARGS);
 
-    error = instance.GetThreadNetif().GetPendingDataset().Set(*aDataset);
+    error = instance.GetThreadNetif().GetPendingDataset().Save(*aDataset);
 
 exit:
     return error;

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -70,7 +70,7 @@ otError DatasetLocal::Restore(Dataset &aDataset)
     const Timestamp *timestamp;
     otError          error;
 
-    error = Get(aDataset);
+    error = Read(aDataset);
     SuccessOrExit(error);
 
     timestamp = aDataset.GetTimestamp();
@@ -89,7 +89,7 @@ exit:
     return error;
 }
 
-otError DatasetLocal::Get(Dataset &aDataset) const
+otError DatasetLocal::Read(Dataset &aDataset) const
 {
     DelayTimerTlv *delayTimer;
     uint32_t       elapsed;
@@ -126,14 +126,14 @@ exit:
     return error;
 }
 
-otError DatasetLocal::Get(otOperationalDataset &aDataset) const
+otError DatasetLocal::Read(otOperationalDataset &aDataset) const
 {
     Dataset dataset(mType);
     otError error;
 
     memset(&aDataset, 0, sizeof(aDataset));
 
-    error = Get(dataset);
+    error = Read(dataset);
     SuccessOrExit(error);
 
     dataset.Get(aDataset);
@@ -142,7 +142,7 @@ exit:
     return error;
 }
 
-otError DatasetLocal::Set(const otOperationalDataset &aDataset)
+otError DatasetLocal::Save(const otOperationalDataset &aDataset)
 {
     otError error = OT_ERROR_NONE;
     Dataset dataset(mType);
@@ -150,14 +150,14 @@ otError DatasetLocal::Set(const otOperationalDataset &aDataset)
     error = dataset.Set(aDataset);
     SuccessOrExit(error);
 
-    error = Set(dataset);
+    error = Save(dataset);
     SuccessOrExit(error);
 
 exit:
     return error;
 }
 
-otError DatasetLocal::Set(const Dataset &aDataset)
+otError DatasetLocal::Save(const Dataset &aDataset)
 {
     const Timestamp *timestamp;
     otError          error;

--- a/src/core/meshcop/dataset_local.hpp
+++ b/src/core/meshcop/dataset_local.hpp
@@ -93,7 +93,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND  There is no corresponding dataset stored in non-volatile memory.
      *
      */
-    otError Get(Dataset &aDataset) const;
+    otError Read(Dataset &aDataset) const;
 
     /**
      * This method retrieves the dataset from non-volatile memory.
@@ -104,7 +104,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND  There is no corresponding dataset stored in non-volatile memory.
      *
      */
-    otError Get(otOperationalDataset &aDataset) const;
+    otError Read(otOperationalDataset &aDataset) const;
 
     /**
      * This method returns the local time this dataset was last updated or restored.
@@ -120,7 +120,7 @@ public:
      * @retval OT_ERROR_NONE  Successfully stored the dataset.
      *
      */
-    otError Set(const otOperationalDataset &aDataset);
+    otError Save(const otOperationalDataset &aDataset);
 
     /**
      * This method stores the dataset into non-volatile memory.
@@ -128,7 +128,7 @@ public:
      * @retval OT_ERROR_NONE  Successfully stored the dataset.
      *
      */
-    otError Set(const Dataset &aDataset);
+    otError Save(const Dataset &aDataset);
 
     /**
      * This method compares this dataset to another based on the timestamp.

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -90,7 +90,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND  There is no corresponding dataset stored in non-volatile memory.
      *
      */
-    otError Get(Dataset &aDataset) const { return mLocal.Get(aDataset); }
+    otError Read(Dataset &aDataset) const { return mLocal.Read(aDataset); }
 
     /**
      * This method retrieves the dataset from non-volatile memory.
@@ -101,7 +101,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND  There is no corresponding dataset stored in non-volatile memory.
      *
      */
-    otError Get(otOperationalDataset &aDataset) const { return mLocal.Get(aDataset); }
+    otError Read(otOperationalDataset &aDataset) const { return mLocal.Read(aDataset); }
 
     /**
      * This method retrieves the channel mask from local dataset.
@@ -185,7 +185,7 @@ protected:
     void Clear(void);
 
     /**
-     * This method sets the Operational Dataset in non-volatile memory.
+     * This method saves the Operational Dataset in non-volatile memory.
      *
      * @param[in]  aDataset  The Operational Dataset.
      *
@@ -193,15 +193,15 @@ protected:
      * @retval OT_ERROR_PARSE  The dataset has at least one TLV with invalid format.
      *
      */
-    otError Set(const Dataset &aDataset);
+    otError Save(const Dataset &aDataset);
 
     /**
-     * This method sets the Operational Dataset in non-volatile memory.
+     * This method saves the Operational Dataset in non-volatile memory.
      *
      * @param[in]  aDataset  The Operational Dataset.
      *
      */
-    otError Set(const otOperationalDataset &aDataset);
+    otError Save(const otOperationalDataset &aDataset);
 
     /**
      * This method sets the Operational Dataset for the partition.
@@ -214,7 +214,7 @@ protected:
      * @param[in]  aLength     The length of the Operational Dataset.
      *
      */
-    otError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
+    otError Save(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
 
     /**
      * This method handles a MGMT_GET request message.
@@ -224,7 +224,7 @@ protected:
      * @param[in]  aMessageInfo  The message info.
      *
      */
-    void Get(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo) const;
+    void HandleGet(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo) const;
 
     /**
      * This method compares the partition's Operational Dataset with that stored in non-volatile memory.
@@ -288,7 +288,7 @@ protected:
      * @retval OT_ERROR_DROP  The MGMT_SET request message was dropped.
      *
      */
-    otError Set(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError HandleSet(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
 private:
     void SendSetResponse(const Coap::Message &aRequest, const Ip6::MessageInfo &aMessageInfo, StateTlv::State aState);
@@ -310,17 +310,17 @@ public:
      * This method clears the Active Operational Dataset.
      *
      */
-    void Clear(void);
+    void Clear(void) { DatasetManager::Clear(); }
 
     /**
-     * This method sets the Operational Dataset in non-volatile memory.
+     * This method saves the Operational Dataset in non-volatile memory.
      *
      * This method also reconfigures the Thread interface.
      *
      * @param[in]  aDataset  The Operational Dataset.
      *
      */
-    void Set(const Dataset &aDataset);
+    void Save(const Dataset &aDataset) { DatasetManager::Save(aDataset); }
 
     /**
      * This method sets the Operational Dataset for the partition.
@@ -334,7 +334,7 @@ public:
      * @param[in]  aLength     The length of the Operational Dataset.
      *
      */
-    otError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
+    otError Save(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
 
     /**
      * This method sets the Operational Dataset in non-volatile memory.
@@ -342,7 +342,7 @@ public:
      * @param[in]  aDataset  The Operational Dataset.
      *
      */
-    otError Set(const otOperationalDataset &aDataset);
+    otError Save(const otOperationalDataset &aDataset) { return DatasetManager::Save(aDataset); }
 
 #if OPENTHREAD_FTD
 
@@ -417,14 +417,14 @@ public:
     void ClearNetwork(void);
 
     /**
-     * This method sets the Operational Dataset in non-volatile memory.
+     * This method saves the Operational Dataset in non-volatile memory.
      *
      * This method also starts the Delay Timer.
      *
      * @param[in]  aDataset  The Operational Dataset.
      *
      */
-    otError Set(const otOperationalDataset &aDataset);
+    otError Save(const otOperationalDataset &aDataset);
 
     /**
      * This method sets the Operational Dataset for the partition.
@@ -439,7 +439,7 @@ public:
      * @param[in]  aLength     The length of the Operational Dataset.
      *
      */
-    otError Set(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
+    otError Save(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
 
 #if OPENTHREAD_FTD
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -307,7 +307,7 @@ otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessage
     networkName.SetNetworkName(netif.GetMac().GetNetworkName());
     SuccessOrExit(error = message->Append(&networkName, sizeof(Tlv) + networkName.GetLength()));
 
-    netif.GetActiveDataset().Get(dataset);
+    netif.GetActiveDataset().Read(dataset);
     if ((tlv = dataset.Get(Tlv::kActiveTimestamp)) != NULL)
     {
         SuccessOrExit(error = message->Append(tlv, sizeof(Tlv) + tlv->GetLength()));

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2964,7 +2964,8 @@ otError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &a
         if (activeDatasetOffset > 0)
         {
             aMessage.Read(activeDatasetOffset, sizeof(tlv), &tlv);
-            netif.GetActiveDataset().Set(activeTimestamp, aMessage, activeDatasetOffset + sizeof(tlv), tlv.GetLength());
+            netif.GetActiveDataset().Save(activeTimestamp, aMessage, activeDatasetOffset + sizeof(tlv),
+                                          tlv.GetLength());
         }
     }
 
@@ -2974,8 +2975,8 @@ otError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &a
         if (pendingDatasetOffset > 0)
         {
             aMessage.Read(pendingDatasetOffset, sizeof(tlv), &tlv);
-            netif.GetPendingDataset().Set(pendingTimestamp, aMessage, pendingDatasetOffset + sizeof(tlv),
-                                          tlv.GetLength());
+            netif.GetPendingDataset().Save(pendingTimestamp, aMessage, pendingDatasetOffset + sizeof(tlv),
+                                           tlv.GetLength());
         }
     }
 
@@ -3316,7 +3317,7 @@ otError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::MessageIn
         if (Tlv::GetOffset(aMessage, Tlv::kActiveDataset, offset) == OT_ERROR_NONE)
         {
             aMessage.Read(offset, sizeof(tlv), &tlv);
-            netif.GetActiveDataset().Set(activeTimestamp, aMessage, offset + sizeof(tlv), tlv.GetLength());
+            netif.GetActiveDataset().Save(activeTimestamp, aMessage, offset + sizeof(tlv), tlv.GetLength());
         }
     }
 
@@ -3335,7 +3336,7 @@ otError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::MessageIn
         if (Tlv::GetOffset(aMessage, Tlv::kPendingDataset, offset) == OT_ERROR_NONE)
         {
             aMessage.Read(offset, sizeof(tlv), &tlv);
-            netif.GetPendingDataset().Set(pendingTimestamp, aMessage, offset + sizeof(tlv), tlv.GetLength());
+            netif.GetPendingDataset().Save(pendingTimestamp, aMessage, offset + sizeof(tlv), tlv.GetLength());
         }
     }
     else

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -109,7 +109,7 @@ void ChannelManager::PreparePendingDataset(void)
 
     VerifyOrExit(mChannel != GetInstance().Get<Mac::Mac>().GetPanChannel());
 
-    if (netif.GetPendingDataset().Get(dataset) == OT_ERROR_NONE)
+    if (netif.GetPendingDataset().Read(dataset) == OT_ERROR_NONE)
     {
         if (dataset.mComponents.mIsPendingTimestampPresent)
         {
@@ -134,7 +134,7 @@ void ChannelManager::PreparePendingDataset(void)
 
     pendingTimestamp += 1 + Random::GetUint32InRange(0, kMaxTimestampIncrease);
 
-    error = netif.GetActiveDataset().Get(dataset);
+    error = netif.GetActiveDataset().Read(dataset);
 
     if (error != OT_ERROR_NONE)
     {


### PR DESCRIPTION
This commit renames methods in `DatasetLocal`, `DatasetManager`,
'ActiveDataset' and `PendingDataset` to use `Read()` and `Save()`
in place of `Get()` and `Set()` respectively. This aligns the
names with `Setting` class indicating that these method do
read/save Dataset info in non-volatile memory.