### PR TITLE
[ncp/radio-spinel] pass frame info (max CSMA/retry count) to RCP

### DIFF
--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -409,6 +409,7 @@ protected:
 #endif // OPENTHREAD_FTD
 
 #if OPENTHREAD_RADIO || OPENTHREAD_ENABLE_RAW_LINK_API
+    otError DecodeStreamRawTxRequest(otRadioFrame &aFrame);
     otError HandlePropertySet_SPINEL_PROP_STREAM_RAW(uint8_t aHeader);
 #endif
 

--- a/src/ncp/ncp_base_radio.cpp
+++ b/src/ncp/ncp_base_radio.cpp
@@ -336,32 +336,57 @@ exit:
     return error;
 }
 
+otError NcpBase::DecodeStreamRawTxRequest(otRadioFrame &aFrame)
+{
+    otError        error;
+    const uint8_t *payloadPtr;
+    uint16_t       payloadLen;
+    bool           csmaEnable;
+
+    SuccessOrExit(error = mDecoder.ReadDataWithLen(payloadPtr, payloadLen));
+    VerifyOrExit(payloadLen <= OT_RADIO_FRAME_MAX_SIZE, error = OT_ERROR_PARSE);
+
+    aFrame.mLength = static_cast<uint8_t>(payloadLen);
+    memcpy(aFrame.mPsdu, payloadPtr, aFrame.mLength);
+
+    // Parse the meta data
+
+    // Channel is a required parameter in meta data.
+    SuccessOrExit(error = mDecoder.ReadUint8(aFrame.mChannel));
+
+    // Set the default value for all optional parameters.
+    aFrame.mInfo.mTxInfo.mMaxCsmaBackoffs = OPENTHREAD_CONFIG_MAC_MAX_CSMA_BACKOFFS_DIRECT;
+    aFrame.mInfo.mTxInfo.mMaxFrameRetries = OPENTHREAD_CONFIG_MAC_MAX_FRAME_RETRIES_DIRECT;
+    aFrame.mInfo.mTxInfo.mCsmaCaEnabled   = true;
+
+    // All the next parameters are optional. Note that even if the
+    // decoder fails to parse any of optional parameters we still want to
+    // return `OT_ERROR_NONE` (so `error` is not updated after this
+    // point).
+
+    SuccessOrExit(mDecoder.ReadUint8(aFrame.mInfo.mTxInfo.mMaxCsmaBackoffs));
+    SuccessOrExit(mDecoder.ReadUint8(aFrame.mInfo.mTxInfo.mMaxFrameRetries));
+    SuccessOrExit(mDecoder.ReadBool(csmaEnable));
+    aFrame.mInfo.mTxInfo.mCsmaCaEnabled = csmaEnable;
+
+exit:
+    return error;
+}
+
 otError NcpBase::HandlePropertySet_SPINEL_PROP_STREAM_RAW(uint8_t aHeader)
 {
-    const uint8_t *frameBuffer = NULL;
-    otRadioFrame * frame;
-    uint16_t       frameLen = 0;
-    otError        error    = OT_ERROR_NONE;
+    otError       error = OT_ERROR_NONE;
+    otRadioFrame *frame;
 
     VerifyOrExit(otLinkRawIsEnabled(mInstance), error = OT_ERROR_INVALID_STATE);
 
     frame = otLinkRawGetTransmitBuffer(mInstance);
+    VerifyOrExit(frame != NULL, error = OT_ERROR_NO_BUFS);
 
-    SuccessOrExit(error = mDecoder.ReadDataWithLen(frameBuffer, frameLen));
-    SuccessOrExit(error = mDecoder.ReadUint8(frame->mChannel));
-
-    VerifyOrExit(frameLen <= OT_RADIO_FRAME_MAX_SIZE, error = OT_ERROR_PARSE);
+    SuccessOrExit(error = DecodeStreamRawTxRequest(*frame));
 
     // Cache the transaction ID for async response
     mCurTransmitTID = SPINEL_HEADER_GET_TID(aHeader);
-
-    // Update frame buffer and length
-    frame->mLength = static_cast<uint8_t>(frameLen);
-    memcpy(frame->mPsdu, frameBuffer, frame->mLength);
-
-    // TODO: This should be later added in the STREAM_RAW argument to allow user to directly specify it.
-    frame->mInfo.mTxInfo.mMaxCsmaBackoffs = OPENTHREAD_CONFIG_MAC_MAX_CSMA_BACKOFFS_DIRECT;
-    frame->mInfo.mTxInfo.mMaxFrameRetries = OPENTHREAD_CONFIG_MAC_MAX_FRAME_RETRIES_DIRECT;
 
     // Pass frame to the radio layer. Note, this fails if we
     // haven't enabled raw stream or are already transmitting.

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -1045,8 +1045,14 @@ void RadioSpinel::RadioTransmit(void)
     assert(mState == kStateTransmitPending);
 
     error = Request(true, SPINEL_CMD_PROP_VALUE_SET, SPINEL_PROP_STREAM_RAW,
-                    SPINEL_DATATYPE_DATA_WLEN_S SPINEL_DATATYPE_UINT8_S SPINEL_DATATYPE_INT8_S, mTransmitFrame->mPsdu,
-                    mTransmitFrame->mLength, mTransmitFrame->mChannel, mTransmitFrame->mInfo.mRxInfo.mRssi);
+                    SPINEL_DATATYPE_DATA_WLEN_S             // Frame data
+                                    SPINEL_DATATYPE_UINT8_S // Channel
+                                    SPINEL_DATATYPE_UINT8_S // MaxCsmaBackoffs
+                                    SPINEL_DATATYPE_UINT8_S // MaxFrameRetries
+                                    SPINEL_DATATYPE_BOOL_S, // CsmaCaEnabled
+                    mTransmitFrame->mPsdu, mTransmitFrame->mLength, mTransmitFrame->mChannel,
+                    mTransmitFrame->mInfo.mTxInfo.mMaxCsmaBackoffs, mTransmitFrame->mInfo.mTxInfo.mMaxFrameRetries,
+                    mTransmitFrame->mInfo.mTxInfo.mCsmaCaEnabled);
 
     if (error == OT_ERROR_NONE)
     {


### PR DESCRIPTION
This PR contains two related commits: 

**[ncp] decode meta-data (CSMA/retry counts) in STREAM_RAW property set**

This commit adds logic to decode and use the optional meta-data fields
in a `VALUE_SET` command (frame tx request) for `PROP_STREAM_RAW` in
raw-link or radio only (RCP) mode. The optional meta-data fields map
to definitions in `otRadioFrame` to specify number of CSMA backoffs
attempts, frame retry attempts, whether to enable CSMA-CA for this
frame or not. If any optional field is not included, default value
is used instead. This aligns the implementation with specification
of `PROP_STREAM_RAW` in `spinel.h`.

(please see [spinel.h#L2517](https://github.com/openthread/openthread/blob/master/src/ncp/spinel.h#L2517))

----

**[radio-spinel] add meta-data (CSMA/retry counts) in `STREAM_RAW` property set**

This commit updates `RadioSpinel::RadioTrasnmit()` to include the
`otRadioFrame` parameters (max CSMA backoffs, max frame retries, and
CSMA-CA enabled flag) as part of meta-data in `PROP_STREAM_RAW`
property `VALUE_SET` command.


