### PR TITLE
[radio-spinel] parse frame rx timestamp

### DIFF
--- a/include/openthread/error.h
+++ b/include/openthread/error.h
@@ -348,6 +348,11 @@ typedef enum otError
     OT_ERROR_LINK_MARGIN_LOW = 34,
 
     /**
+     * The number of defined errors.
+     */
+    OT_NUM_ERRORS,
+
+    /**
      * Generic error (should not use).
      */
     OT_ERROR_GENERIC = 255,

--- a/src/ncp/ncp_base_radio.cpp
+++ b/src/ncp/ncp_base_radio.cpp
@@ -66,10 +66,8 @@ void NcpBase::LinkRawReceiveDone(otRadioFrame *aFrame, otError aError)
 
     if (aError == OT_ERROR_NONE)
     {
-        // Append length
-        SuccessOrExit(mEncoder.WriteUint16(aFrame->mLength));
         // Append the frame contents
-        SuccessOrExit(mEncoder.WriteData(aFrame->mPsdu, aFrame->mLength));
+        SuccessOrExit(mEncoder.WriteDataWithLen(aFrame->mPsdu, aFrame->mLength));
     }
     else
     {

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -525,21 +525,17 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
 
             require_action((spinel_ssize_t)data_len >= (block_len + pui_len), bail, (ret = -1, errno = EOVERFLOW));
 
-            if (block_len > 0)
+            if (in_place)
             {
-                if (in_place)
+                require_action(NULL != block_len_ptr && *block_len_ptr >= block_len, bail, (ret = -1, errno = EINVAL));
+                memcpy(arg_ptr, block_ptr, block_len);
+            }
+            else
+            {
+                const uint8_t **block_ptr_ptr = (const uint8_t **)arg_ptr;
+                if (NULL != block_ptr_ptr)
                 {
-                    require_action(NULL != block_len_ptr && *block_len_ptr >= block_len, bail,
-                                   (ret = -1, errno = EINVAL));
-                    memcpy(arg_ptr, block_ptr, block_len);
-                }
-                else
-                {
-                    const uint8_t **block_ptr_ptr = (const uint8_t **)arg_ptr;
-                    if (NULL != block_ptr_ptr)
-                    {
-                        *block_ptr_ptr = block_ptr;
-                    }
+                    *block_ptr_ptr = block_ptr;
                 }
             }
 

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -525,17 +525,21 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
 
             require_action((spinel_ssize_t)data_len >= (block_len + pui_len), bail, (ret = -1, errno = EOVERFLOW));
 
-            if (in_place)
+            if (block_len > 0)
             {
-                require_action(NULL != block_len_ptr && *block_len_ptr >= block_len, bail, (ret = -1, errno = EINVAL));
-                memcpy(arg_ptr, block_ptr, block_len);
-            }
-            else
-            {
-                const uint8_t **block_ptr_ptr = (const uint8_t **)arg_ptr;
-                if (NULL != block_ptr_ptr)
+                if (in_place)
                 {
-                    *block_ptr_ptr = block_ptr;
+                    require_action(NULL != block_len_ptr && *block_len_ptr >= block_len, bail,
+                                   (ret = -1, errno = EINVAL));
+                    memcpy(arg_ptr, block_ptr, block_len);
+                }
+                else
+                {
+                    const uint8_t **block_ptr_ptr = (const uint8_t **)arg_ptr;
+                    if (NULL != block_ptr_ptr)
+                    {
+                        *block_ptr_ptr = block_ptr;
+                    }
                 }
             }
 

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -601,26 +601,44 @@ exit:
 otError RadioSpinel::ParseRadioFrame(otRadioFrame &aFrame, const uint8_t *aBuffer, uint16_t aLength)
 {
     otError        error        = OT_ERROR_NONE;
-    uint16_t       packetLength = 0;
+    uint16_t       flags        = 0;
+    int8_t         noiseFloor   = -128;
+    spinel_size_t  size         = OT_RADIO_FRAME_MAX_SIZE;
+    unsigned int   receiveError = 0;
     spinel_ssize_t unpacked;
-    uint16_t       flags      = 0;
-    int8_t         noiseFloor = -128;
-    spinel_size_t  size       = OT_RADIO_FRAME_MAX_SIZE;
 
-    unpacked = spinel_datatype_unpack(aBuffer, aLength, SPINEL_DATATYPE_UINT16_S, &packetLength);
-    VerifyOrExit(unpacked > 0 && packetLength <= OT_RADIO_FRAME_MAX_SIZE, error = OT_ERROR_PARSE);
+    // Timestamp is ms + us.
+    unpacked = spinel_datatype_unpack_in_place(
+        aBuffer, aLength,
+        SPINEL_DATATYPE_DATA_WLEN_S                              // Frame
+                        SPINEL_DATATYPE_INT8_S                   // RSSI
+                        SPINEL_DATATYPE_INT8_S                   // Noise Floor
+                        SPINEL_DATATYPE_UINT16_S                 // Flags
+                        SPINEL_DATATYPE_STRUCT_S(                // PHY-data
+                            SPINEL_DATATYPE_UINT8_S              // 802.15.4 channel
+                                        SPINEL_DATATYPE_UINT8_S  // 802.15.4 LQI
+                                        SPINEL_DATATYPE_UINT32_S // Timestamp (ms).
+                                        SPINEL_DATATYPE_UINT16_S // Timestamp (us).
+                            ) SPINEL_DATATYPE_STRUCT_S(          // Vendor-data
+                            SPINEL_DATATYPE_UINT_PACKED_S        // Receive error
+                            ),
+        aFrame.mPsdu, &size, &aFrame.mInfo.mRxInfo.mRssi, &noiseFloor, &flags, &aFrame.mChannel,
+        &aFrame.mInfo.mRxInfo.mLqi, &aFrame.mInfo.mRxInfo.mMsec, &aFrame.mInfo.mRxInfo.mUsec, &receiveError);
 
-    aFrame.mLength = static_cast<uint8_t>(packetLength);
-
-    unpacked = spinel_datatype_unpack_in_place(aBuffer, aLength,
-                                               SPINEL_DATATYPE_DATA_WLEN_S SPINEL_DATATYPE_INT8_S SPINEL_DATATYPE_INT8_S
-                                                   SPINEL_DATATYPE_UINT16_S SPINEL_DATATYPE_STRUCT_S( // PHY-data
-                                                       SPINEL_DATATYPE_UINT8_S     // 802.15.4 channel
-                                                           SPINEL_DATATYPE_UINT8_S // 802.15.4 LQI
-                                                       ),
-                                               aFrame.mPsdu, &size, &aFrame.mInfo.mRxInfo.mRssi, &noiseFloor, &flags,
-                                               &aFrame.mChannel, &aFrame.mInfo.mRxInfo.mLqi);
     VerifyOrExit(unpacked > 0, error = OT_ERROR_PARSE);
+
+    if (receiveError == 0)
+    {
+        aFrame.mLength = static_cast<uint8_t>(size);
+    }
+    else if (receiveError < OT_NUM_ERRORS)
+    {
+        error = static_cast<otError>(receiveError);
+    }
+    else
+    {
+        error = OT_ERROR_PARSE;
+    }
 
 exit:
     LogIfFail("Handle radio frame failed", error);

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -627,7 +627,7 @@ otError RadioSpinel::ParseRadioFrame(otRadioFrame &aFrame, const uint8_t *aBuffe
 
     VerifyOrExit(unpacked > 0, error = OT_ERROR_PARSE);
 
-    if (receiveError == 0)
+    if (receiveError == OT_ERROR_NONE)
     {
         aFrame.mLength = static_cast<uint8_t>(size);
     }


### PR DESCRIPTION
This PR parses rx timestamp of radio frame received by RCP, no matter data
frames or ACK frames.

* add OT_NUM_ERRORS as number of defined errors.
* allow empty SPINEL_DATATYPE_DATA and SPINEL_DATATYPE_DATA_WLEN when parsing spinel packets.