### PR TITLE
[radio] only allow disable in sleep state

### DIFF
--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -422,7 +422,8 @@ otError otPlatRadioEnable(otInstance *aInstance);
  *
  * @param[in] aInstance  The OpenThread instance structure.
  *
- * @retval OT_ERROR_NONE  Successfully transitioned to Disabled.
+ * @retval OT_ERROR_NONE            Successfully transitioned to Disabled.
+ * @retval OT_ERROR_INVALID_STATE   The radio was not in sleep state.
  *
  */
 otError otPlatRadioDisable(otInstance *aInstance);

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -148,10 +148,11 @@ otError SubMac::Disable(void)
     otError error;
 
     mTimer.Stop();
-    error = otPlatRadioDisable(&GetInstance());
-    assert(error == OT_ERROR_NONE);
+    SuccessOrExit(error = otPlatRadioSleep(&GetInstance()));
+    SuccessOrExit(error = otPlatRadioDisable(&GetInstance()));
     SetState(kStateDisabled);
 
+exit:
     return error;
 }
 


### PR DESCRIPTION
There's missing error definition for otPlatRadioDisable(). This PR adds
an error case OT_ERROR_INVALID_STATE to make sure this is only called
when the radio is in sleep mode.