### PR TITLE
[ncp] fix missing "RCPVersion" property under POSIX-app

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1744,7 +1744,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_CAPS>(void)
     SuccessOrExit(error = mEncoder.WriteUintPacked(SPINEL_CAP_MAC_RAW));
 #endif
 
-#if OPENTHREAD_ENABLE_POSIX_APP
+#if OPENTHREAD_PLATFORM_POSIX_APP
     SuccessOrExit(error = mEncoder.WriteUintPacked(SPINEL_CAP_POSIX_APP));
 #endif
 

--- a/src/ncp/ncp_base_dispatcher.cpp
+++ b/src/ncp/ncp_base_dispatcher.cpp
@@ -506,7 +506,7 @@ NcpBase::PropertyHandler NcpBase::FindGetPropertyHandler(spinel_prop_key_t aKey)
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_CHILD_SUPERVISION_CHECK_TIMEOUT>;
         break;
 #endif
-#if OPENTHREAD_ENABLE_POSIX_APP
+#if OPENTHREAD_PLATFORM_POSIX_APP
     case SPINEL_PROP_RCP_VERSION:
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_RCP_VERSION>;
         break;

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -2961,14 +2961,14 @@ exit:
 
 #endif // OPENTHREAD_ENABLE_MAC_FILTER
 
-#if OPENTHREAD_ENABLE_POSIX_APP
+#if OPENTHREAD_PLATFORM_POSIX_APP
 
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_RCP_VERSION>(void)
 {
     return mEncoder.WriteUtf8(otGetRadioVersionString(mInstance));
 }
 
-#endif // OPENTHREAD_ENABLE_POSIX_APP
+#endif
 
 #if OPENTHREAD_CONFIG_ENABLE_SLAAC
 

--- a/tests/toranj/test-001-get-set.py
+++ b/tests/toranj/test-001-get-set.py
@@ -174,10 +174,18 @@ all_gettable_props = [
     wpan.WPAN_THREAD_STABLE_LEADER_NETWORK_DATA
 ]
 
+all_posix_app_gettable_props = [
+    wpan.WPAN_RCP_VERSION
+]
+
 node.form('get-set')
 
 for prop in all_gettable_props:
     node.get(prop)
+
+if node.using_posix_app_with_rcp:
+    for prop in all_posix_app_gettable_props:
+        node.get(prop)
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Test finished

--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -58,6 +58,7 @@ WPAN_NCP_VERSION                               = 'NCP:Version'
 WPAN_NCP_MCU_POWER_STATE                       = "NCP:MCUPowerState"
 WPAN_NETWORK_ALLOW_JOIN                        = 'com.nestlabs.internal:Network:AllowingJoin'
 WPAN_NETWORK_PASSTHRU_PORT                     = 'com.nestlabs.internal:Network:PassthruPort'
+WPAN_RCP_VERSION                               = "POSIXApp:RCPVersion"
 
 WPAN_IP6_LINK_LOCAL_ADDRESS                    = "IPv6:LinkLocalAddress"
 WPAN_IP6_MESH_LOCAL_ADDRESS                    = "IPv6:MeshLocalAddress"
@@ -298,11 +299,11 @@ class Node(object):
         # Check if env variable `TORANJ_POSIX_APP_RCP_MODEL` is defined
         # and use it to determine if to use operate in "posix-ncp-app".
         if self._POSIX_APP_ENV_VAR in os.environ:
-            use_posix_app_with_rcp = (os.environ[self._POSIX_APP_ENV_VAR] in ['1', 'yes'])
+            self._use_posix_app_with_rcp = (os.environ[self._POSIX_APP_ENV_VAR] in ['1', 'yes'])
         else:
-            use_posix_app_with_rcp = False
+            self._use_posix_app_with_rcp = False
 
-        if use_posix_app_with_rcp:
+        if self._use_posix_app_with_rcp:
             ncp_socket_path = 'system:{} -s {} {} {}'.format(self._OT_NCP_FTD_POSIX_APP, self._SPEED_UP_FACTOR,
                 self._OT_NCP_RADIO, index)
         else:
@@ -349,6 +350,10 @@ class Node(object):
     @property
     def tund_log_file(self):
         return self._tund_log_file
+
+    @property
+    def using_posix_app_with_rcp(self):
+        return self._use_posix_app_with_rcp
 
     #------------------------------------------------------------------------------------------------------------------
     # Executing a `wpanctl` command


### PR DESCRIPTION
This PR contains two related commits: 

 **[ncp-base] fix the `#if` check for posix-app**

------

 **[toranj] verify "RCPVersion" is gettable on posix-app mode**
    
This commit updates the `test-001` to allow extra properties to
be verified when running under posix-app model. The new test
ensures "POSIXApp:RCPVersion" is gettable.

------

This PR addresses an issue where the "RCP Version" property (through spinel/wpantund) is disabled (not supported) on posix-app build. It seems to be caused due to a rename of the build option `OPENTHREAD_ENABLE_POSIX_APP` to `OPENTHREAD_PLATFORM_POSIX_APP` from https://github.com/openthread/openthread/pull/3611. 

