### PR TITLE
[coap] remove otCoapMessage from CoapSecure::DefaultHandler()

### DIFF
--- a/examples/platforms/posix/openthread-core-posix-config.h
+++ b/examples/platforms/posix/openthread-core-posix-config.h
@@ -119,4 +119,11 @@
  */
 #define OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER 1
 
+/**
+ * @def CLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER
+ *
+ * Define to 1 to use DefaultHandler for unhandled requests
+ *
+ */
+#define CLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER 1
 #endif // OPENTHREAD_CORE_POSIX_CONFIG_H_

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -586,30 +586,26 @@ void CoapSecure::HandleClientResponse(otMessage *aMessage, const otMessageInfo *
 }
 
 #if CLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER
-void OTCALL CoapSecure::DefaultHandle(void *               aContext,
-                                      otCoapMessage *      aHeader,
-                                      otMessage *          aMessage,
-                                      const otMessageInfo *aMessageInfo)
+void OTCALL CoapSecure::DefaultHandler(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<CoapSecure *>(aContext)->DefaultHandle(aHeader, aMessage, aMessageInfo);
+    static_cast<CoapSecure *>(aContext)->DefaultHandler(aMessage, aMessageInfo);
 }
 
-void CoapSecure::DefaultHandle(otCoapMessage *aHeader, otMessage *aMessage, const otMessageInfo *aMessageInfo)
+void CoapSecure::DefaultHandler(otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    OT_UNUSED_VARIABLE(aMessage);
+    otError    error = OT_ERROR_NONE;
+    otMessage *responseMessage;
 
-    otError       error = OT_ERROR_NONE;
-    otCoapMessage responseHeader;
-    otMessage *   responseMessage;
-
-    if (otCoapMessageGetType(aHeader) == OT_COAP_TYPE_CONFIRMABLE || otCoapMessageGetCode(aHeader) == OT_COAP_CODE_GET)
+    if ((otCoapMessageGetType(aMessage) == OT_COAP_TYPE_CONFIRMABLE) ||
+        (otCoapMessageGetCode(aMessage) == OT_COAP_CODE_GET))
     {
-        otCoapMessageInit(&responseHeader, OT_COAP_TYPE_NON_CONFIRMABLE, OT_COAP_CODE_NOT_FOUND);
-        otCoapMessageSetMessageId(&responseHeader, otCoapMessageGetMessageId(aHeader));
-        otCoapMessageSetToken(&responseHeader, otCoapMessageGetToken(aHeader), otCoapMessageGetTokenLength(aHeader));
-
         responseMessage = otCoapNewMessage(mInterpreter.mInstance, NULL);
         VerifyOrExit(responseMessage != NULL, error = OT_ERROR_NO_BUFS);
+
+        otCoapMessageInit(responseMessage, OT_COAP_TYPE_NON_CONFIRMABLE, OT_COAP_CODE_NOT_FOUND);
+        otCoapMessageSetMessageId(responseMessage, otCoapMessageGetMessageId(aMessage));
+        otCoapMessageSetToken(responseMessage, otCoapMessageGetToken(aMessage), otCoapMessageGetTokenLength(aMessage));
+
         SuccessOrExit(error = otCoapSecureSendResponse(mInterpreter.mInstance, responseMessage, aMessageInfo));
     }
 

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -150,7 +150,7 @@ otError CoapSecure::Process(int argc, char *argv[])
         SuccessOrExit(error = otCoapSecureStart(mInterpreter.mInstance, OT_DEFAULT_COAP_SECURE_PORT));
         otCoapSecureSetClientConnectedCallback(mInterpreter.mInstance, &CoapSecure::HandleClientConnect, this);
 #if CLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER
-        otCoapSecureSetDefaultHandler(mInterpreter.mInstance, &CoapSecure::DefaultHandle, this);
+        otCoapSecureSetDefaultHandler(mInterpreter.mInstance, &CoapSecure::DefaultHandler, this);
 #endif // CLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER
 #ifdef MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
         if (mUseCertificate)

--- a/src/cli/cli_coap_secure.hpp
+++ b/src/cli/cli_coap_secure.hpp
@@ -97,8 +97,8 @@ private:
     void               HandleClientResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo, otError aError);
 
 #if CLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER
-    static void OTCALL DefaultHandle(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
-    void               DefaultHandle(otMessage *aMessage, const otMessageInfo *aMessageInfo);
+    static void OTCALL DefaultHandler(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
+    void               DefaultHandler(otMessage *aMessage, const otMessageInfo *aMessageInfo);
 #endif // CLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER
 
     static void OTCALL HandleClientConnect(bool aConnected, void *aContext);

--- a/src/cli/cli_coap_secure.hpp
+++ b/src/cli/cli_coap_secure.hpp
@@ -41,11 +41,6 @@
 #include "coap/coap_message.hpp"
 #include "coap/coap_secure.hpp"
 
-/**
- * to test the default handler for not handled requests set to 1.
- */
-#define CLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER 0
-
 namespace ot {
 namespace Cli {
 


### PR DESCRIPTION
replaces PR of https://github.com/openthread/openthread/pull/3686 