### PR TITLE
[settings] provide compile time option to disable writing of settings to flash

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1612,6 +1612,36 @@ AM_CONDITIONAL([OPENTHREAD_ENABLE_SERVICE], [test "${enable_service}" = "yes"])
 AC_DEFINE_UNQUOTED([OPENTHREAD_ENABLE_SERVICE],[${OPENTHREAD_ENABLE_SERVICE}],[Define to 1 if you want to enable Service])
 
 #
+# Settings stub
+#
+
+AC_ARG_ENABLE(settings-stub,
+    [AS_HELP_STRING([--enable-settings-stub], [Disables non-volatile storage of settings @<:@default=no@:>@.])],
+    [
+        case "${enableval}" in
+
+        no|yes)
+            settings-stub=${enableval}
+            ;;
+
+        *)
+            AC_MSG_ERROR([Invalid value ${settings-stub} for --settings-stub])
+            ;;
+        esac
+    ],
+    [settings-stub=no])
+
+if test "$enable_settings_stub" = "yes"; then
+    OPENTHREAD_SETTINGS_STUB=1
+else
+    OPENTHREAD_SETTINGS_STUB=0
+fi
+
+AC_SUBST(OPENTHREAD_SETTINGS_STUB)
+AM_CONDITIONAL([OPENTHREAD_SETTINGS_STUB], [test "${enable_settings_stub}" = "yes"])
+AC_DEFINE_UNQUOTED([OPENTHREAD_SETTINGS_STUB],[${OPENTHREAD_SETTINGS_STUB}],[Define to 1 if you want to enable settings stub])
+
+#
 # Linker Map Output
 #
 
@@ -2099,5 +2129,6 @@ AC_MSG_NOTICE([
   OpenThread ECDSA support                  : ${enable_ecdsa}
   OpenThread Examples                       : ${with_examples}
   OpenThread POSIX Application              : ${enable_posix_app}
+  OpenThread Settings Stub                  : $(enable_settings_stub)
 
 ])

--- a/examples/common-switches.mk
+++ b/examples/common-switches.mk
@@ -52,6 +52,7 @@ LINK_RAW            ?= 0
 MAC_FILTER          ?= 0
 MTD_NETDIAG         ?= 0
 PLATFORM_UDP        ?= 0
+SETTINGS_STUB       ?= 0
 SERVICE             ?= 0
 # SLAAC is enabled by default
 SLAAC               ?= 1
@@ -155,6 +156,10 @@ endif
 
 ifeq ($(PLATFORM_UDP),1)
 configure_OPTIONS              += --enable-platform-udp
+endif
+
+ifeq ($(SETTINGS_STUB),1)
+configure_OPTIONS              += --enable-settings-stub
 endif
 
 ifeq ($(SERVICE),1)

--- a/examples/platforms/utils/Makefile.am
+++ b/examples/platforms/utils/Makefile.am
@@ -44,6 +44,16 @@ libopenthread_platform_utils_a_SOURCES  = \
     soft_source_match_table.c             \
     $(NULL)
 
+if OPENTHREAD_SETTINGS_STUB
+    libopenthread_platform_utils_a_SOURCES += \
+        settings_stub.c \
+        $(NULL)
+else
+    libopenthread_platform_utils_a_SOURCES += \
+        settings_flash.c \
+        $(NULL)
+endif
+
 noinst_HEADERS                          = \
     code_utils.h                          \
     flash.h                               \

--- a/examples/platforms/utils/settings_stub.c
+++ b/examples/platforms/utils/settings_stub.c
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (c) 2016, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file stubs the OpenThread platform abstraction for non-volatile storage of settings.
+ *
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+#include <openthread-core-config.h>
+
+#include <openthread/instance.h>
+#include <openthread/platform/settings.h>
+
+// settings API
+void otPlatSettingsInit(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+}
+
+otError otPlatSettingsBeginChange(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    return OT_ERROR_NONE;
+}
+
+otError otPlatSettingsCommitChange(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    return OT_ERROR_NONE;
+}
+
+otError otPlatSettingsAbandonChange(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    return OT_ERROR_NONE;
+}
+
+otError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aKey);
+    OT_UNUSED_VARIABLE(aIndex);
+    OT_UNUSED_VARIABLE(aValue);
+    OT_UNUSED_VARIABLE(aValueLength);
+    
+    return OT_ERROR_NOT_FOUND;
+}
+
+otError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aKey);
+    OT_UNUSED_VARIABLE(aValue);
+    OT_UNUSED_VARIABLE(aValueLength);
+    
+    return OT_ERROR_NONE;
+}
+
+otError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aKey);
+    OT_UNUSED_VARIABLE(aValue);
+    OT_UNUSED_VARIABLE(aValueLength);
+
+    return OT_ERROR_NONE;
+}
+
+otError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aKey);
+    OT_UNUSED_VARIABLE(aIndex);
+
+    return OT_ERROR_NONE;
+}
+
+void otPlatSettingsWipe(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+}


### PR DESCRIPTION
Currently, we have a supervisor program that talks to wpantund via dbus. It monitors the state of the NCP and the correct properties are set on the NCP at startup or reset (after completely clearing them, via `SPINEL_CMD_NET_CLEAR`), including network key, PANID, etc. Doing this every time in flash places an unnecessary burden on the lifespan of the flash because we want to ensure that settings are completely cleared first to avoid any potential issues caused if the flash layout changes between 2 different NCP firmware versions, for example.

In our case, storing settings in non-volatile storage is not necessary because we don't need auto-connect functionality (our supervisor application handles it).