### PR TITLE
[message] add and use AppendTlv

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -458,6 +458,11 @@ exit:
     return error;
 }
 
+otError Message::AppendTlv(const Tlv &aTlv)
+{
+    return Append(&aTlv, aTlv.GetSize());
+}
+
 otError Message::Prepend(const void *aBuf, uint16_t aLength)
 {
     otError error     = OT_ERROR_NONE;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -44,6 +44,7 @@
 
 #include "common/code_utils.hpp"
 #include "common/locator.hpp"
+#include "common/tlvs.hpp"
 #include "mac/mac_frame.hpp"
 #include "thread/link_quality.hpp"
 
@@ -404,6 +405,19 @@ public:
      *
      */
     otError Append(const void *aBuf, uint16_t aLength);
+
+    /**
+     * This method appends a TLV to the end of the message.
+     *
+     * On success, this method grows the message by the size of the TLV.
+     *
+     * @param[in]  aTlv     A reference to a TLV.
+     *
+     * @retval OT_ERROR_NONE     Successfully appended the TLV to the message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
+     *
+     */
+    otError AppendTlv(const Tlv &aTlv);
 
     /**
      * This method reads bytes from the message.

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -38,13 +38,17 @@
 
 #include "utils/wrap_string.h"
 
+#include <openthread/error.h>
+#include <openthread/platform/toolchain.h>
+
 #include "common/encoding.hpp"
-#include "common/message.hpp"
 
 namespace ot {
 
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;
+
+class Message;
 
 /**
  * This class implements TLV generation and parsing.

--- a/src/core/meshcop/announce_begin_client.cpp
+++ b/src/core/meshcop/announce_begin_client.cpp
@@ -81,19 +81,19 @@ otError AnnounceBeginClient::SendRequest(uint32_t            aChannelMask,
 
     sessionId.Init();
     sessionId.SetCommissionerSessionId(Get<MeshCoP::Commissioner>().GetSessionId());
-    SuccessOrExit(error = message->Append(&sessionId, sizeof(sessionId)));
+    SuccessOrExit(error = message->AppendTlv(sessionId));
 
     channelMask.Init();
     channelMask.SetChannelMask(aChannelMask);
-    SuccessOrExit(error = message->Append(&channelMask, channelMask.GetSize()));
+    SuccessOrExit(error = message->AppendTlv(channelMask));
 
     count.Init();
     count.SetCount(aCount);
-    SuccessOrExit(error = message->Append(&count, sizeof(count)));
+    SuccessOrExit(error = message->AppendTlv(count));
 
     period.Init();
     period.SetPeriod(aPeriod);
-    SuccessOrExit(error = message->Append(&period, sizeof(period)));
+    SuccessOrExit(error = message->AppendTlv(period));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetPeerAddr(aAddress);

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -419,7 +419,7 @@ bool BorderAgent::HandleUdpReceive(const Message &aMessage, const Ip6::MessageIn
         tlv.SetSourcePort(aMessageInfo.GetPeerPort());
         tlv.SetDestinationPort(aMessageInfo.GetSockPort());
         tlv.SetUdpLength(udpLength);
-        SuccessOrExit(error = message->Append(&tlv, sizeof(tlv)));
+        SuccessOrExit(error = message->AppendTlv(tlv));
 
         offset = message->GetLength();
         SuccessOrExit(error = message->SetLength(offset + udpLength));
@@ -431,7 +431,7 @@ bool BorderAgent::HandleUdpReceive(const Message &aMessage, const Ip6::MessageIn
 
         tlv.Init();
         tlv.SetAddress(aMessageInfo.GetPeerAddr());
-        SuccessOrExit(error = message->Append(&tlv, sizeof(tlv)));
+        SuccessOrExit(error = message->AppendTlv(tlv));
     }
 
     SuccessOrExit(error = Get<Coap::CoapSecure>().SendMessage(*message, Get<Coap::CoapSecure>().GetPeerAddress()));

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -504,7 +504,7 @@ otError Commissioner::SendMgmtCommissionerSetRequest(const otCommissioningDatase
         MeshCoP::BorderAgentLocatorTlv locator;
         locator.Init();
         locator.SetBorderAgentLocator(aDataset.mLocator);
-        SuccessOrExit(error = message->Append(&locator, sizeof(locator)));
+        SuccessOrExit(error = message->AppendTlv(locator));
     }
 
     if (aDataset.mIsSessionIdSet)
@@ -512,7 +512,7 @@ otError Commissioner::SendMgmtCommissionerSetRequest(const otCommissioningDatase
         MeshCoP::CommissionerSessionIdTlv sessionId;
         sessionId.Init();
         sessionId.SetCommissionerSessionId(aDataset.mSessionId);
-        SuccessOrExit(error = message->Append(&sessionId, sizeof(sessionId)));
+        SuccessOrExit(error = message->AppendTlv(sessionId));
     }
 
     if (aDataset.mIsSteeringDataSet)
@@ -529,7 +529,7 @@ otError Commissioner::SendMgmtCommissionerSetRequest(const otCommissioningDatase
         MeshCoP::JoinerUdpPortTlv joinerUdpPort;
         joinerUdpPort.Init();
         joinerUdpPort.SetUdpPort(aDataset.mJoinerUdpPort);
-        SuccessOrExit(error = message->Append(&joinerUdpPort, sizeof(joinerUdpPort)));
+        SuccessOrExit(error = message->AppendTlv(joinerUdpPort));
     }
 
     if (aLength > 0)
@@ -602,7 +602,7 @@ otError Commissioner::SendPetition(void)
     commissionerId.Init();
     commissionerId.SetCommissionerId("OpenThread Commissioner");
 
-    SuccessOrExit(error = message->Append(&commissionerId, sizeof(Tlv) + commissionerId.GetLength()));
+    SuccessOrExit(error = message->AppendTlv(commissionerId));
 
     Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr());
     messageInfo.SetPeerPort(kCoapUdpPort);
@@ -698,11 +698,11 @@ otError Commissioner::SendKeepAlive(void)
 
     state.Init();
     state.SetState(mState == OT_COMMISSIONER_STATE_ACTIVE ? StateTlv::kAccept : StateTlv::kReject);
-    SuccessOrExit(error = message->Append(&state, sizeof(state)));
+    SuccessOrExit(error = message->AppendTlv(state));
 
     sessionId.Init();
     sessionId.SetCommissionerSessionId(mSessionId);
-    SuccessOrExit(error = message->Append(&sessionId, sizeof(sessionId)));
+    SuccessOrExit(error = message->AppendTlv(sessionId));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr());
@@ -928,7 +928,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Message &aRequest, State
 
     stateTlv.Init();
     stateTlv.SetState(aState);
-    SuccessOrExit(error = message->Append(&stateTlv, sizeof(stateTlv)));
+    SuccessOrExit(error = message->AppendTlv(stateTlv));
 
     joinerMessageInfo.SetPeerAddr(Get<Mle::MleRouter>().GetMeshLocal64());
     joinerMessageInfo.GetPeerAddr().SetIid(mJoinerIid);
@@ -984,22 +984,22 @@ otError Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::MessageInf
 
     udpPort.Init();
     udpPort.SetUdpPort(mJoinerPort);
-    SuccessOrExit(error = message->Append(&udpPort, sizeof(udpPort)));
+    SuccessOrExit(error = message->AppendTlv(udpPort));
 
     iid.Init();
     iid.SetIid(mJoinerIid);
-    SuccessOrExit(error = message->Append(&iid, sizeof(iid)));
+    SuccessOrExit(error = message->AppendTlv(iid));
 
     rloc.Init();
     rloc.SetJoinerRouterLocator(mJoinerRloc);
-    SuccessOrExit(error = message->Append(&rloc, sizeof(rloc)));
+    SuccessOrExit(error = message->AppendTlv(rloc));
 
     if (aMessage.GetSubType() == Message::kSubTypeJoinerFinalizeResponse)
     {
         JoinerRouterKekTlv kek;
         kek.Init();
         kek.SetKek(Get<KeyManager>().GetKek());
-        SuccessOrExit(error = message->Append(&kek, sizeof(kek)));
+        SuccessOrExit(error = message->AppendTlv(kek));
     }
 
     tlv.SetType(Tlv::kJoinerDtlsEncapsulation);

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -494,11 +494,11 @@ otError Dataset::AppendMleDatasetTlv(Message &aMessage) const
                 delayTimer.SetDelayTimer(0);
             }
 
-            SuccessOrExit(error = aMessage.Append(&delayTimer, sizeof(delayTimer)));
+            SuccessOrExit(error = aMessage.AppendTlv(delayTimer));
         }
         else
         {
-            SuccessOrExit(error = aMessage.Append(cur, sizeof(Tlv) + cur->GetLength()));
+            SuccessOrExit(error = aMessage.AppendTlv(*cur));
         }
 
         cur = cur->GetNext();

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -366,7 +366,7 @@ void DatasetManager::SendGetResponse(const Coap::Message &   aRequest,
             if (cur->GetType() != Tlv::kNetworkMasterKey ||
                 (Get<KeyManager>().GetSecurityPolicyFlags() & OT_SECURITY_POLICY_OBTAIN_MASTER_KEY))
             {
-                SuccessOrExit(error = message->Append(cur, sizeof(Tlv) + cur->GetLength()));
+                SuccessOrExit(error = message->AppendTlv(*cur));
             }
 
             cur = cur->GetNext();
@@ -386,7 +386,7 @@ void DatasetManager::SendGetResponse(const Coap::Message &   aRequest,
 
             if ((tlv = dataset.Get(static_cast<Tlv::Type>(aTlvs[index]))) != NULL)
             {
-                SuccessOrExit(error = message->Append(tlv, sizeof(Tlv) + tlv->GetLength()));
+                SuccessOrExit(error = message->AppendTlv(*tlv));
             }
         }
     }
@@ -446,7 +446,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
             CommissionerSessionIdTlv sessionId;
             sessionId.Init();
             sessionId.SetCommissionerSessionId(Get<Commissioner>().GetSessionId());
-            SuccessOrExit(error = message->Append(&sessionId, sizeof(sessionId)));
+            SuccessOrExit(error = message->AppendTlv(sessionId));
         }
     }
 
@@ -458,7 +458,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         timestamp.Init();
         static_cast<Timestamp *>(&timestamp)->SetSeconds(aDataset.mActiveTimestamp);
         static_cast<Timestamp *>(&timestamp)->SetTicks(0);
-        SuccessOrExit(error = message->Append(&timestamp, sizeof(timestamp)));
+        SuccessOrExit(error = message->AppendTlv(timestamp));
     }
 
     if (aDataset.mComponents.mIsPendingTimestampPresent)
@@ -467,7 +467,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         timestamp.Init();
         static_cast<Timestamp *>(&timestamp)->SetSeconds(aDataset.mPendingTimestamp);
         static_cast<Timestamp *>(&timestamp)->SetTicks(0);
-        SuccessOrExit(error = message->Append(&timestamp, sizeof(timestamp)));
+        SuccessOrExit(error = message->AppendTlv(timestamp));
     }
 
     if (aDataset.mComponents.mIsMasterKeyPresent)
@@ -475,7 +475,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         NetworkMasterKeyTlv masterkey;
         masterkey.Init();
         masterkey.SetNetworkMasterKey(aDataset.mMasterKey);
-        SuccessOrExit(error = message->Append(&masterkey, sizeof(masterkey)));
+        SuccessOrExit(error = message->AppendTlv(masterkey));
     }
 
     if (aDataset.mComponents.mIsNetworkNamePresent)
@@ -483,7 +483,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         NetworkNameTlv networkname;
         networkname.Init();
         networkname.SetNetworkName(aDataset.mNetworkName.m8);
-        SuccessOrExit(error = message->Append(&networkname, sizeof(Tlv) + networkname.GetLength()));
+        SuccessOrExit(error = message->AppendTlv(networkname));
     }
 
     if (aDataset.mComponents.mIsExtendedPanIdPresent)
@@ -491,7 +491,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         ExtendedPanIdTlv extpanid;
         extpanid.Init();
         extpanid.SetExtendedPanId(aDataset.mExtendedPanId);
-        SuccessOrExit(error = message->Append(&extpanid, sizeof(extpanid)));
+        SuccessOrExit(error = message->AppendTlv(extpanid));
     }
 
     if (aDataset.mComponents.mIsMeshLocalPrefixPresent)
@@ -499,7 +499,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         MeshLocalPrefixTlv localprefix;
         localprefix.Init();
         localprefix.SetMeshLocalPrefix(aDataset.mMeshLocalPrefix);
-        SuccessOrExit(error = message->Append(&localprefix, sizeof(localprefix)));
+        SuccessOrExit(error = message->AppendTlv(localprefix));
     }
 
     if (aDataset.mComponents.mIsDelayPresent)
@@ -507,7 +507,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         DelayTimerTlv delaytimer;
         delaytimer.Init();
         delaytimer.SetDelayTimer(aDataset.mDelay);
-        SuccessOrExit(error = message->Append(&delaytimer, sizeof(delaytimer)));
+        SuccessOrExit(error = message->AppendTlv(delaytimer));
     }
 
     if (aDataset.mComponents.mIsPanIdPresent)
@@ -515,7 +515,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         PanIdTlv panid;
         panid.Init();
         panid.SetPanId(aDataset.mPanId);
-        SuccessOrExit(error = message->Append(&panid, sizeof(panid)));
+        SuccessOrExit(error = message->AppendTlv(panid));
     }
 
     if (aDataset.mComponents.mIsChannelPresent)
@@ -523,7 +523,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         ChannelTlv channel;
         channel.Init();
         channel.SetChannel(aDataset.mChannel);
-        SuccessOrExit(error = message->Append(&channel, sizeof(channel)));
+        SuccessOrExit(error = message->AppendTlv(channel));
     }
 
     if (aDataset.mComponents.mIsChannelMaskPresent)
@@ -531,7 +531,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         ChannelMaskTlv channelMask;
         channelMask.Init();
         channelMask.SetChannelMask(aDataset.mChannelMask);
-        SuccessOrExit(error = message->Append(&channelMask, sizeof(channelMask)));
+        SuccessOrExit(error = message->AppendTlv(channelMask));
     }
 
     if (aLength > 0)

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -303,7 +303,7 @@ void DatasetManager::SendSetResponse(const Coap::Message &   aRequest,
 
     state.Init();
     state.SetState(aState);
-    SuccessOrExit(error = message->Append(&state, sizeof(state)));
+    SuccessOrExit(error = message->AppendTlv(state));
 
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, aMessageInfo));
 

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -89,23 +89,23 @@ otError EnergyScanClient::SendQuery(uint32_t                           aChannelM
 
     sessionId.Init();
     sessionId.SetCommissionerSessionId(Get<MeshCoP::Commissioner>().GetSessionId());
-    SuccessOrExit(error = message->Append(&sessionId, sizeof(sessionId)));
+    SuccessOrExit(error = message->AppendTlv(sessionId));
 
     channelMask.Init();
     channelMask.SetChannelMask(aChannelMask);
-    SuccessOrExit(error = message->Append(&channelMask, channelMask.GetSize()));
+    SuccessOrExit(error = message->AppendTlv(channelMask));
 
     count.Init();
     count.SetCount(aCount);
-    SuccessOrExit(error = message->Append(&count, sizeof(count)));
+    SuccessOrExit(error = message->AppendTlv(count));
 
     period.Init();
     period.SetPeriod(aPeriod);
-    SuccessOrExit(error = message->Append(&period, sizeof(period)));
+    SuccessOrExit(error = message->AppendTlv(period));
 
     scanDuration.Init();
     scanDuration.SetScanDuration(aScanDuration);
-    SuccessOrExit(error = message->Append(&scanDuration, sizeof(scanDuration)));
+    SuccessOrExit(error = message->AppendTlv(scanDuration));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetPeerAddr(aAddress);

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -408,33 +408,33 @@ otError Joiner::PrepareJoinerFinalizeMessage(const char *aProvisioningUrl,
 
     stateTlv.Init();
     stateTlv.SetState(MeshCoP::StateTlv::kAccept);
-    SuccessOrExit(error = mFinalizeMessage->Append(&stateTlv, sizeof(stateTlv)));
+    SuccessOrExit(error = mFinalizeMessage->AppendTlv(stateTlv));
 
     vendorNameTlv.Init();
     vendorNameTlv.SetVendorName(aVendorName);
-    SuccessOrExit(error = mFinalizeMessage->Append(&vendorNameTlv, vendorNameTlv.GetSize()));
+    SuccessOrExit(error = mFinalizeMessage->AppendTlv(vendorNameTlv));
 
     vendorModelTlv.Init();
     vendorModelTlv.SetVendorModel(aVendorModel);
-    SuccessOrExit(error = mFinalizeMessage->Append(&vendorModelTlv, vendorModelTlv.GetSize()));
+    SuccessOrExit(error = mFinalizeMessage->AppendTlv(vendorModelTlv));
 
     vendorSwVersionTlv.Init();
     vendorSwVersionTlv.SetVendorSwVersion(aVendorSwVersion);
-    SuccessOrExit(error = mFinalizeMessage->Append(&vendorSwVersionTlv, vendorSwVersionTlv.GetSize()));
+    SuccessOrExit(error = mFinalizeMessage->AppendTlv(vendorSwVersionTlv));
 
     vendorStackVersionTlv.Init();
     vendorStackVersionTlv.SetOui(OPENTHREAD_CONFIG_STACK_VENDOR_OUI);
     vendorStackVersionTlv.SetMajor(OPENTHREAD_CONFIG_STACK_VERSION_MAJOR);
     vendorStackVersionTlv.SetMinor(OPENTHREAD_CONFIG_STACK_VERSION_MINOR);
     vendorStackVersionTlv.SetRevision(OPENTHREAD_CONFIG_STACK_VERSION_REV);
-    SuccessOrExit(error = mFinalizeMessage->Append(&vendorStackVersionTlv, vendorStackVersionTlv.GetSize()));
+    SuccessOrExit(error = mFinalizeMessage->AppendTlv(vendorStackVersionTlv));
 
     if (aVendorData != NULL)
     {
         VendorDataTlv vendorDataTlv;
         vendorDataTlv.Init();
         vendorDataTlv.SetVendorData(aVendorData);
-        SuccessOrExit(error = mFinalizeMessage->Append(&vendorDataTlv, vendorDataTlv.GetSize()));
+        SuccessOrExit(error = mFinalizeMessage->AppendTlv(vendorDataTlv));
     }
 
     provisioningUrlTlv.Init();
@@ -442,7 +442,7 @@ otError Joiner::PrepareJoinerFinalizeMessage(const char *aProvisioningUrl,
 
     if (provisioningUrlTlv.GetLength() > 0)
     {
-        SuccessOrExit(error = mFinalizeMessage->Append(&provisioningUrlTlv, provisioningUrlTlv.GetSize()));
+        SuccessOrExit(error = mFinalizeMessage->AppendTlv(provisioningUrlTlv));
     }
 
 exit:

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -155,15 +155,15 @@ void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &a
 
     udpPort.Init();
     udpPort.SetUdpPort(aMessageInfo.GetPeerPort());
-    SuccessOrExit(error = message->Append(&udpPort, sizeof(udpPort)));
+    SuccessOrExit(error = message->AppendTlv(udpPort));
 
     iid.Init();
     iid.SetIid(aMessageInfo.GetPeerAddr().mFields.m8 + 8);
-    SuccessOrExit(error = message->Append(&iid, sizeof(iid)));
+    SuccessOrExit(error = message->AppendTlv(iid));
 
     rloc.Init();
     rloc.SetJoinerRouterLocator(Get<Mle::MleRouter>().GetRloc16());
-    SuccessOrExit(error = message->Append(&rloc, sizeof(rloc)));
+    SuccessOrExit(error = message->AppendTlv(rloc));
 
     tlv.SetType(Tlv::kJoinerDtlsEncapsulation);
     tlv.SetLength(aMessage.GetLength() - aMessage.GetOffset());
@@ -289,69 +289,69 @@ otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessage
 
     masterKey.Init();
     masterKey.SetNetworkMasterKey(Get<KeyManager>().GetMasterKey());
-    SuccessOrExit(error = message->Append(&masterKey, sizeof(masterKey)));
+    SuccessOrExit(error = message->AppendTlv(masterKey));
 
     meshLocalPrefix.Init();
     meshLocalPrefix.SetMeshLocalPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
-    SuccessOrExit(error = message->Append(&meshLocalPrefix, sizeof(meshLocalPrefix)));
+    SuccessOrExit(error = message->AppendTlv(meshLocalPrefix));
 
     extendedPanId.Init();
     extendedPanId.SetExtendedPanId(Get<Mac::Mac>().GetExtendedPanId());
-    SuccessOrExit(error = message->Append(&extendedPanId, sizeof(extendedPanId)));
+    SuccessOrExit(error = message->AppendTlv(extendedPanId));
 
     networkName.Init();
     networkName.SetNetworkName(Get<Mac::Mac>().GetNetworkName());
-    SuccessOrExit(error = message->Append(&networkName, sizeof(Tlv) + networkName.GetLength()));
+    SuccessOrExit(error = message->AppendTlv(networkName));
 
     Get<ActiveDataset>().Read(dataset);
 
     if ((tlv = dataset.Get(Tlv::kActiveTimestamp)) != NULL)
     {
-        SuccessOrExit(error = message->Append(tlv, sizeof(Tlv) + tlv->GetLength()));
+        SuccessOrExit(error = message->AppendTlv(*tlv));
     }
     else
     {
         ActiveTimestampTlv activeTimestamp;
         activeTimestamp.Init();
-        SuccessOrExit(error = message->Append(&activeTimestamp, sizeof(activeTimestamp)));
+        SuccessOrExit(error = message->AppendTlv(activeTimestamp));
     }
 
     if ((tlv = dataset.Get(Tlv::kChannelMask)) != NULL)
     {
-        SuccessOrExit(error = message->Append(tlv, sizeof(Tlv) + tlv->GetLength()));
+        SuccessOrExit(error = message->AppendTlv(*tlv));
     }
     else
     {
         ChannelMaskBaseTlv channelMask;
         channelMask.Init();
-        SuccessOrExit(error = message->Append(&channelMask, sizeof(channelMask)));
+        SuccessOrExit(error = message->AppendTlv(channelMask));
     }
 
     if ((tlv = dataset.Get(Tlv::kPSKc)) != NULL)
     {
-        SuccessOrExit(error = message->Append(tlv, sizeof(Tlv) + tlv->GetLength()));
+        SuccessOrExit(error = message->AppendTlv(*tlv));
     }
     else
     {
         PSKcTlv pskc;
         pskc.Init();
-        SuccessOrExit(error = message->Append(&pskc, sizeof(pskc)));
+        SuccessOrExit(error = message->AppendTlv(pskc));
     }
 
     if ((tlv = dataset.Get(Tlv::kSecurityPolicy)) != NULL)
     {
-        SuccessOrExit(error = message->Append(tlv, sizeof(Tlv) + tlv->GetLength()));
+        SuccessOrExit(error = message->AppendTlv(*tlv));
     }
     else
     {
         SecurityPolicyTlv securityPolicy;
         securityPolicy.Init();
-        SuccessOrExit(error = message->Append(&securityPolicy, sizeof(securityPolicy)));
+        SuccessOrExit(error = message->AppendTlv(securityPolicy));
     }
 
     networkKeySequence.Init();
     networkKeySequence.SetNetworkKeySequence(Get<KeyManager>().GetCurrentKeySequence());
-    SuccessOrExit(error = message->Append(&networkKeySequence, networkKeySequence.GetSize()));
+    SuccessOrExit(error = message->AppendTlv(networkKeySequence));
 
     messageInfo = aMessageInfo;
     messageInfo.SetPeerPort(kCoapUdpPort);

--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -134,19 +134,18 @@ otError Leader::SendPetitionResponse(const Coap::Message &   aRequest,
 
     state.Init();
     state.SetState(aState);
-    SuccessOrExit(error = message->Append(&state, sizeof(state)));
+    SuccessOrExit(error = message->AppendTlv(state));
 
     if (mTimer.IsRunning())
     {
-        uint16_t len = sizeof(Tlv) + mCommissionerId.GetLength();
-        SuccessOrExit(error = message->Append(&mCommissionerId, len));
+        SuccessOrExit(error = message->AppendTlv(mCommissionerId));
     }
 
     if (aState == StateTlv::kAccept)
     {
         sessionId.Init();
         sessionId.SetCommissionerSessionId(mSessionId);
-        SuccessOrExit(error = message->Append(&sessionId, sizeof(sessionId)));
+        SuccessOrExit(error = message->AppendTlv(sessionId));
     }
 
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, aMessageInfo));
@@ -231,7 +230,7 @@ otError Leader::SendKeepAliveResponse(const Coap::Message &   aRequest,
 
     state.Init();
     state.SetState(aState);
-    SuccessOrExit(error = message->Append(&state, sizeof(state)));
+    SuccessOrExit(error = message->AppendTlv(state));
 
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, aMessageInfo));
 

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -84,15 +84,15 @@ otError PanIdQueryClient::SendQuery(uint16_t                            aPanId,
 
     sessionId.Init();
     sessionId.SetCommissionerSessionId(Get<MeshCoP::Commissioner>().GetSessionId());
-    SuccessOrExit(error = message->Append(&sessionId, sizeof(sessionId)));
+    SuccessOrExit(error = message->AppendTlv(sessionId));
 
     channelMask.Init();
     channelMask.SetChannelMask(aChannelMask);
-    SuccessOrExit(error = message->Append(&channelMask, channelMask.GetSize()));
+    SuccessOrExit(error = message->AppendTlv(channelMask));
 
     panId.Init();
     panId.SetPanId(aPanId);
-    SuccessOrExit(error = message->Append(&panId, sizeof(panId)));
+    SuccessOrExit(error = message->AppendTlv(panId));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetPeerAddr(aAddress);

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -331,7 +331,7 @@ otError AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
 
     targetTlv.Init();
     targetTlv.SetTarget(aEid);
-    SuccessOrExit(error = message->Append(&targetTlv, sizeof(targetTlv)));
+    SuccessOrExit(error = message->AppendTlv(targetTlv));
 
     messageInfo.GetPeerAddr().mFields.m16[0] = HostSwap16(0xff03);
     messageInfo.GetPeerAddr().mFields.m16[7] = HostSwap16(0x0002);
@@ -466,8 +466,8 @@ otError AddressResolver::SendAddressError(const ThreadTargetTlv &      aTarget,
     message->AppendUriPathOptions(OT_URI_PATH_ADDRESS_ERROR);
     message->SetPayloadMarker();
 
-    SuccessOrExit(error = message->Append(&aTarget, sizeof(aTarget)));
-    SuccessOrExit(error = message->Append(&aEid, sizeof(aEid)));
+    SuccessOrExit(error = message->AppendTlv(aTarget));
+    SuccessOrExit(error = message->AppendTlv(aEid));
 
     if (aDestination == NULL)
     {
@@ -648,16 +648,16 @@ void AddressResolver::SendAddressQueryResponse(const ThreadTargetTlv &          
     message->AppendUriPathOptions(OT_URI_PATH_ADDRESS_NOTIFY);
     message->SetPayloadMarker();
 
-    SuccessOrExit(error = message->Append(&aTargetTlv, sizeof(aTargetTlv)));
-    SuccessOrExit(error = message->Append(&aMlEidTlv, sizeof(aMlEidTlv)));
+    SuccessOrExit(error = message->AppendTlv(aTargetTlv));
+    SuccessOrExit(error = message->AppendTlv(aMlEidTlv));
 
     rloc16Tlv.Init();
     rloc16Tlv.SetRloc16(Get<Mle::MleRouter>().GetRloc16());
-    SuccessOrExit(error = message->Append(&rloc16Tlv, sizeof(rloc16Tlv)));
+    SuccessOrExit(error = message->AppendTlv(rloc16Tlv));
 
     if (aLastTransactionTimeTlv != NULL)
     {
-        SuccessOrExit(error = message->Append(aLastTransactionTimeTlv, sizeof(*aLastTransactionTimeTlv)));
+        SuccessOrExit(error = message->AppendTlv(*aLastTransactionTimeTlv));
     }
 
     messageInfo.SetPeerAddr(aDestination);

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -193,7 +193,7 @@ otError EnergyScanServer::SendReport(void)
 
     channelMask.Init();
     channelMask.SetChannelMask(mChannelMask);
-    SuccessOrExit(error = message->Append(&channelMask, channelMask.GetSize()));
+    SuccessOrExit(error = message->AppendTlv(channelMask));
 
     energyList.Init();
     energyList.SetLength(mScanResultsLength);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -539,7 +539,7 @@ otError Mle::Discover(const Mac::ChannelMask &aScanChannels,
     discoveryRequest.Init();
     discoveryRequest.SetVersion(kThreadVersion);
     discoveryRequest.SetJoiner(aJoiner);
-    SuccessOrExit(error = message->Append(&discoveryRequest, sizeof(discoveryRequest)));
+    SuccessOrExit(error = message->AppendTlv(discoveryRequest));
 
     tlv.SetLength(static_cast<uint8_t>(message->GetLength() - startOffset));
     message->Write(startOffset - sizeof(tlv), sizeof(tlv), &tlv);
@@ -1131,7 +1131,7 @@ otError Mle::AppendSourceAddress(Message &aMessage)
     tlv.Init();
     tlv.SetRloc16(GetRloc16());
 
-    return aMessage.Append(&tlv, sizeof(tlv));
+    return aMessage.AppendTlv(tlv);
 }
 
 otError Mle::AppendStatus(Message &aMessage, StatusTlv::Status aStatus)
@@ -1141,7 +1141,7 @@ otError Mle::AppendStatus(Message &aMessage, StatusTlv::Status aStatus)
     tlv.Init();
     tlv.SetStatus(aStatus);
 
-    return aMessage.Append(&tlv, sizeof(tlv));
+    return aMessage.AppendTlv(tlv);
 }
 
 otError Mle::AppendMode(Message &aMessage, uint8_t aMode)
@@ -1151,7 +1151,7 @@ otError Mle::AppendMode(Message &aMessage, uint8_t aMode)
     tlv.Init();
     tlv.SetMode(aMode);
 
-    return aMessage.Append(&tlv, sizeof(tlv));
+    return aMessage.AppendTlv(tlv);
 }
 
 otError Mle::AppendTimeout(Message &aMessage, uint32_t aTimeout)
@@ -1161,7 +1161,7 @@ otError Mle::AppendTimeout(Message &aMessage, uint32_t aTimeout)
     tlv.Init();
     tlv.SetTimeout(aTimeout);
 
-    return aMessage.Append(&tlv, sizeof(tlv));
+    return aMessage.AppendTlv(tlv);
 }
 
 otError Mle::AppendChallenge(Message &aMessage, const uint8_t *aChallenge, uint8_t aChallengeLength)
@@ -1200,7 +1200,7 @@ otError Mle::AppendLinkFrameCounter(Message &aMessage)
     tlv.Init();
     tlv.SetFrameCounter(Get<KeyManager>().GetMacFrameCounter());
 
-    return aMessage.Append(&tlv, sizeof(tlv));
+    return aMessage.AppendTlv(tlv);
 }
 
 otError Mle::AppendMleFrameCounter(Message &aMessage)
@@ -1210,7 +1210,7 @@ otError Mle::AppendMleFrameCounter(Message &aMessage)
     tlv.Init();
     tlv.SetFrameCounter(Get<KeyManager>().GetMleFrameCounter());
 
-    return aMessage.Append(&tlv, sizeof(tlv));
+    return aMessage.AppendTlv(tlv);
 }
 
 otError Mle::AppendAddress16(Message &aMessage, uint16_t aRloc16)
@@ -1220,7 +1220,7 @@ otError Mle::AppendAddress16(Message &aMessage, uint16_t aRloc16)
     tlv.Init();
     tlv.SetRloc16(aRloc16);
 
-    return aMessage.Append(&tlv, sizeof(tlv));
+    return aMessage.AppendTlv(tlv);
 }
 
 otError Mle::AppendLeaderData(Message &aMessage)
@@ -1229,7 +1229,7 @@ otError Mle::AppendLeaderData(Message &aMessage)
     mLeaderData.SetDataVersion(Get<NetworkData::Leader>().GetVersion());
     mLeaderData.SetStableDataVersion(Get<NetworkData::Leader>().GetStableVersion());
 
-    return aMessage.Append(&mLeaderData, sizeof(mLeaderData));
+    return aMessage.AppendTlv(mLeaderData);
 }
 
 void Mle::FillNetworkDataTlv(NetworkDataTlv &aTlv, bool aStableOnly)
@@ -1251,7 +1251,7 @@ otError Mle::AppendNetworkData(Message &aMessage, bool aStableOnly)
     tlv.Init();
     FillNetworkDataTlv(tlv, aStableOnly);
 
-    SuccessOrExit(error = aMessage.Append(&tlv, sizeof(Tlv) + tlv.GetLength()));
+    error = aMessage.AppendTlv(tlv);
 
 exit:
     return error;
@@ -1279,7 +1279,7 @@ otError Mle::AppendScanMask(Message &aMessage, uint8_t aScanMask)
     tlv.Init();
     tlv.SetMask(aScanMask);
 
-    return aMessage.Append(&tlv, sizeof(tlv));
+    return aMessage.AppendTlv(tlv);
 }
 
 otError Mle::AppendLinkMargin(Message &aMessage, uint8_t aLinkMargin)
@@ -1289,7 +1289,7 @@ otError Mle::AppendLinkMargin(Message &aMessage, uint8_t aLinkMargin)
     tlv.Init();
     tlv.SetLinkMargin(aLinkMargin);
 
-    return aMessage.Append(&tlv, sizeof(tlv));
+    return aMessage.AppendTlv(tlv);
 }
 
 otError Mle::AppendVersion(Message &aMessage)
@@ -1299,7 +1299,7 @@ otError Mle::AppendVersion(Message &aMessage)
     tlv.Init();
     tlv.SetVersion(kThreadVersion);
 
-    return aMessage.Append(&tlv, sizeof(tlv));
+    return aMessage.AppendTlv(tlv);
 }
 
 otError Mle::AppendAddressRegistration(Message &aMessage)
@@ -1382,7 +1382,7 @@ otError Mle::AppendTimeRequest(Message &aMessage)
 
     tlv.Init();
 
-    return aMessage.Append(&tlv, sizeof(tlv));
+    return aMessage.AppendTlv(tlv);
 }
 
 otError Mle::AppendTimeParameter(Message &aMessage)
@@ -1393,7 +1393,7 @@ otError Mle::AppendTimeParameter(Message &aMessage)
     tlv.SetTimeSyncPeriod(Get<TimeSync>().GetTimeSyncPeriod());
     tlv.SetXtalThreshold(Get<TimeSync>().GetXtalThreshold());
 
-    return aMessage.Append(&tlv, sizeof(tlv));
+    return aMessage.AppendTlv(tlv);
 }
 
 otError Mle::AppendXtalAccuracy(Message &aMessage)
@@ -1403,7 +1403,7 @@ otError Mle::AppendXtalAccuracy(Message &aMessage)
     tlv.Init();
     tlv.SetXtalAccuracy(otPlatTimeGetXtalAccuracy());
 
-    return aMessage.Append(&tlv, sizeof(tlv));
+    return aMessage.AppendTlv(tlv);
 }
 #endif // OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
 
@@ -1418,7 +1418,7 @@ otError Mle::AppendActiveTimestamp(Message &aMessage)
 
     timestampTlv.Init();
     *static_cast<MeshCoP::Timestamp *>(&timestampTlv) = *timestamp;
-    error                                             = aMessage.Append(&timestampTlv, sizeof(timestampTlv));
+    error                                             = aMessage.AppendTlv(timestampTlv);
 
 exit:
     return error;
@@ -1435,7 +1435,7 @@ otError Mle::AppendPendingTimestamp(Message &aMessage)
 
     timestampTlv.Init();
     *static_cast<MeshCoP::Timestamp *>(&timestampTlv) = *timestamp;
-    error                                             = aMessage.Append(&timestampTlv, sizeof(timestampTlv));
+    error                                             = aMessage.AppendTlv(timestampTlv);
 
 exit:
     return error;
@@ -2326,7 +2326,7 @@ otError Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce, const Ip6::Add
 
     channel.Init();
     channel.SetChannel(Get<Mac::Mac>().GetPanChannel());
-    SuccessOrExit(error = message->Append(&channel, sizeof(channel)));
+    SuccessOrExit(error = message->AppendTlv(channel));
 
     if (aOrphanAnnounce)
     {
@@ -2335,7 +2335,7 @@ otError Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce, const Ip6::Add
         activeTimestamp.SetTicks(0);
         activeTimestamp.SetAuthoritative(true);
 
-        SuccessOrExit(error = message->Append(&activeTimestamp, sizeof(activeTimestamp)));
+        SuccessOrExit(error = message->AppendTlv(activeTimestamp));
     }
     else
     {
@@ -2344,7 +2344,7 @@ otError Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce, const Ip6::Add
 
     panid.Init();
     panid.SetPanId(Get<Mac::Mac>().GetPanId());
-    SuccessOrExit(error = message->Append(&panid, sizeof(panid)));
+    SuccessOrExit(error = message->AppendTlv(panid));
     SuccessOrExit(error = SendMessage(*message, aDestination));
 
     otLogInfoMle("Send Announce on channel %d", aChannel);

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -1024,7 +1024,7 @@ otError NetworkData::SendServerDataNotification(uint16_t aRloc16)
         ThreadRloc16Tlv rloc16Tlv;
         rloc16Tlv.Init();
         rloc16Tlv.SetRloc16(aRloc16);
-        SuccessOrExit(error = message->Append(&rloc16Tlv, sizeof(rloc16Tlv)));
+        SuccessOrExit(error = message->AppendTlv(rloc16Tlv));
     }
 
     Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr());

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -354,7 +354,7 @@ void Leader::SendCommissioningGetResponse(const Coap::Message &   aRequest,
             {
                 if (cur->GetType() == aTlvs[index])
                 {
-                    SuccessOrExit(error = message->Append(cur, sizeof(NetworkDataTlv) + cur->GetLength()));
+                    SuccessOrExit(error = message->AppendTlv(*cur));
                     break;
                 }
             }
@@ -394,7 +394,7 @@ void Leader::SendCommissioningSetResponse(const Coap::Message &    aRequest,
 
     state.Init();
     state.SetState(aState);
-    SuccessOrExit(error = message->Append(&state, sizeof(state)));
+    SuccessOrExit(error = message->AppendTlv(state));
 
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, aMessageInfo));
 

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -301,7 +301,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             ExtMacAddressTlv tlv;
             tlv.Init();
             tlv.SetMacAddr(Get<Mac::Mac>().GetExtAddress());
-            SuccessOrExit(error = aResponse.Append(&tlv, sizeof(tlv)));
+            SuccessOrExit(error = aResponse.AppendTlv(tlv));
             break;
         }
 
@@ -310,7 +310,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             Address16Tlv tlv;
             tlv.Init();
             tlv.SetRloc16(Get<Mle::MleRouter>().GetRloc16());
-            SuccessOrExit(error = aResponse.Append(&tlv, sizeof(tlv)));
+            SuccessOrExit(error = aResponse.AppendTlv(tlv));
             break;
         }
 
@@ -319,7 +319,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             ModeTlv tlv;
             tlv.Init();
             tlv.SetMode(Get<Mle::MleRouter>().GetDeviceMode());
-            SuccessOrExit(error = aResponse.Append(&tlv, sizeof(tlv)));
+            SuccessOrExit(error = aResponse.AppendTlv(tlv));
             break;
         }
 
@@ -330,7 +330,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
                 TimeoutTlv tlv;
                 tlv.Init();
                 tlv.SetTimeout(TimerMilli::MsecToSec(Get<DataPollManager>().GetKeepAlivePollPeriod()));
-                SuccessOrExit(error = aResponse.Append(&tlv, sizeof(tlv)));
+                SuccessOrExit(error = aResponse.AppendTlv(tlv));
             }
 
             break;
@@ -341,7 +341,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             ConnectivityTlv tlv;
             tlv.Init();
             Get<Mle::MleRouter>().FillConnectivityTlv(reinterpret_cast<Mle::ConnectivityTlv &>(tlv));
-            SuccessOrExit(error = aResponse.Append(&tlv, sizeof(tlv)));
+            SuccessOrExit(error = aResponse.AppendTlv(tlv));
             break;
         }
 
@@ -351,7 +351,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             RouteTlv tlv;
             tlv.Init();
             Get<Mle::MleRouter>().FillRouteTlv(reinterpret_cast<Mle::RouteTlv &>(tlv));
-            SuccessOrExit(error = aResponse.Append(&tlv, tlv.GetSize()));
+            SuccessOrExit(error = aResponse.AppendTlv(tlv));
             break;
         }
 #endif
@@ -360,7 +360,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
         {
             LeaderDataTlv tlv(reinterpret_cast<const LeaderDataTlv &>(Get<Mle::MleRouter>().GetLeaderDataTlv()));
             tlv.Init();
-            SuccessOrExit(error = aResponse.Append(&tlv, tlv.GetSize()));
+            SuccessOrExit(error = aResponse.AppendTlv(tlv));
             break;
         }
 
@@ -370,7 +370,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             tlv.Init();
 
             Get<Mle::MleRouter>().FillNetworkDataTlv((reinterpret_cast<Mle::NetworkDataTlv &>(tlv)), false);
-            SuccessOrExit(error = aResponse.Append(&tlv, tlv.GetSize()));
+            SuccessOrExit(error = aResponse.AppendTlv(tlv));
             break;
         }
 
@@ -386,7 +386,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             memset(&tlv, 0, sizeof(tlv));
             tlv.Init();
             FillMacCountersTlv(tlv);
-            SuccessOrExit(error = aResponse.Append(&tlv, tlv.GetSize()));
+            SuccessOrExit(error = aResponse.AppendTlv(tlv));
             break;
         }
 
@@ -434,7 +434,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             }
 
             tlv.SetLength(length);
-            SuccessOrExit(error = aResponse.Append(&tlv, tlv.GetSize()));
+            SuccessOrExit(error = aResponse.AppendTlv(tlv));
             break;
         }
 
@@ -447,7 +447,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
                 MaxChildTimeoutTlv tlv;
                 tlv.Init();
                 tlv.SetTimeout(maxTimeout);
-                SuccessOrExit(error = aResponse.Append(&tlv, sizeof(tlv)));
+                SuccessOrExit(error = aResponse.AppendTlv(tlv));
             }
 
             break;

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -134,11 +134,11 @@ otError PanIdQueryServer::SendConflict(void)
 
     channelMask.Init();
     channelMask.SetChannelMask(mChannelMask);
-    SuccessOrExit(error = message->Append(&channelMask, channelMask.GetSize()));
+    SuccessOrExit(error = message->AppendTlv(channelMask));
 
     panId.Init();
     panId.SetPanId(mPanId);
-    SuccessOrExit(error = message->Append(&panId, sizeof(panId)));
+    SuccessOrExit(error = message->AppendTlv(panId));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetPeerAddr(mCommissioner);


### PR DESCRIPTION
This commit adds a new method `AppendTlv` to `Message` class which
appends a fully formed TLV to the message. This commit also changes
the core modules to use the new method when appending a TLV.

------------

In existing code, we have 2 different ways of appending TLVs:
- Two patterns to add a fully formed TLV  (the new API covers both cases and simplifies the code)
  - The TLV size is fixed, 
    - e.g. `Append(&stateTlv, sizeof(stateTlv))` -> `AppendTlv(stateTlv)`
  - The TLV size can vary, e.g., 
    - `Append(cur, sizeof(Tlv) + cur->GetLength())` -> `AppendTlv(*cur)`
    - `Append(&vendorNameTlv, vendorNameTlv.GetSize())` -> `AppentTlv(vendorNameTlv)`
  
- The TLV is added in pieces (this remains as is and unchanged).