### PR TITLE
[platform] return error on incorrect otPlatRadioDisable usage

### DIFF
--- a/examples/platforms/nrf52811/radio.c
+++ b/examples/platforms/nrf52811/radio.c
@@ -41,7 +41,8 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <common/code_utils.hpp>
+#include "utils/code_utils.h"
+
 #include <platform-config.h>
 #include <openthread/platform/alarm-micro.h>
 #include <openthread/platform/diag.h>
@@ -248,6 +249,8 @@ otRadioState otPlatRadioGetState(otInstance *aInstance)
         return OT_RADIO_STATE_RECEIVE;
 
     case NRF_802154_STATE_TRANSMIT:
+    case NRF_802154_STATE_CCA:
+    case NRF_802154_STATE_CONTINUOUS_CARRIER:
         return OT_RADIO_STATE_TRANSMIT;
 
     default:
@@ -257,11 +260,18 @@ otRadioState otPlatRadioGetState(otInstance *aInstance)
     return OT_RADIO_STATE_RECEIVE; // It is the default state. Return it in case of unknown.
 }
 
+bool otPlatRadioIsEnabled(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    return !sDisabled;
+}
+
 otError otPlatRadioEnable(otInstance *aInstance)
 {
-    sInstance = aInstance;
-
     otError error;
+
+    sInstance = aInstance;
 
     if (sDisabled)
     {
@@ -278,28 +288,16 @@ otError otPlatRadioEnable(otInstance *aInstance)
 
 otError otPlatRadioDisable(otInstance *aInstance)
 {
-    OT_UNUSED_VARIABLE(aInstance);
+    otError error = OT_ERROR_NONE;
 
-    otError error;
+    otEXPECT(otPlatRadioIsEnabled(aInstance));
+    otEXPECT_ACTION(otPlatRadioGetState(aInstance) == OT_RADIO_STATE_SLEEP || isPendingEventSet(kPendingEventSleep),
+                    error = OT_ERROR_INVALID_STATE);
 
-    if (!sDisabled)
-    {
-        sDisabled = true;
-        error     = OT_ERROR_NONE;
-    }
-    else
-    {
-        error = OT_ERROR_INVALID_STATE;
-    }
+    sDisabled = true;
 
+exit:
     return error;
-}
-
-bool otPlatRadioIsEnabled(otInstance *aInstance)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-
-    return !sDisabled;
 }
 
 otError otPlatRadioSleep(otInstance *aInstance)
@@ -550,6 +548,8 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
 
 void nrf5RadioProcess(otInstance *aInstance)
 {
+    bool isEventPending = false;
+
     for (uint32_t i = 0; i < NRF_802154_RX_BUFFERS; i++)
     {
         if (sReceivedFrames[i].mPsdu != NULL)
@@ -660,6 +660,10 @@ void nrf5RadioProcess(otInstance *aInstance)
         {
             resetPendingEvent(kPendingEventSleep);
         }
+        else
+        {
+            isEventPending = true;
+        }
     }
 
     if (isPendingEventSet(kPendingEventEnergyDetectionStart))
@@ -670,6 +674,15 @@ void nrf5RadioProcess(otInstance *aInstance)
         {
             resetPendingEvent(kPendingEventEnergyDetectionStart);
         }
+        else
+        {
+            isEventPending = true;
+        }
+    }
+
+    if (isEventPending)
+    {
+        otSysEventSignalPending();
     }
 }
 

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -478,12 +478,15 @@ otError otPlatRadioEnable(otInstance *aInstance)
 
 otError otPlatRadioDisable(otInstance *aInstance)
 {
-    if (otPlatRadioIsEnabled(aInstance))
-    {
-        sState = OT_RADIO_STATE_DISABLED;
-    }
+    otError error = OT_ERROR_NONE;
 
-    return OT_ERROR_NONE;
+    otEXPECT(otPlatRadioIsEnabled(aInstance));
+    otEXPECT_ACTION(sState == OT_RADIO_STATE_SLEEP, error = OT_ERROR_INVALID_STATE);
+
+    sState = OT_RADIO_STATE_DISABLED;
+
+exit:
+    return error;
 }
 
 otError otPlatRadioSleep(otInstance *aInstance)

--- a/examples/platforms/posix/sim/radio-sim.c
+++ b/examples/platforms/posix/sim/radio-sim.c
@@ -410,12 +410,15 @@ otError otPlatRadioEnable(otInstance *aInstance)
 
 otError otPlatRadioDisable(otInstance *aInstance)
 {
-    if (otPlatRadioIsEnabled(aInstance))
-    {
-        sState = OT_RADIO_STATE_DISABLED;
-    }
+    otError error = OT_ERROR_NONE;
 
-    return OT_ERROR_NONE;
+    otEXPECT(otPlatRadioIsEnabled(aInstance));
+    otEXPECT_ACTION(sState == OT_RADIO_STATE_SLEEP, error = OT_ERROR_INVALID_STATE);
+
+    sState = OT_RADIO_STATE_DISABLED;
+
+exit:
+    return error;
 }
 
 otError otPlatRadioSleep(otInstance *aInstance)


### PR DESCRIPTION
This PR fixes #3656.

Additionally, a small inefficiency with the nRF5x platform using FreeRTOS and multiprotocol (Thread + BLE) has been fixed.