### PR TITLE
[nrf528xx] don't return OT_ERROR_FAILED from otPlatRadioTransmit

### DIFF
--- a/examples/platforms/nrf52811/radio.c
+++ b/examples/platforms/nrf52811/radio.c
@@ -335,7 +335,7 @@ otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 
 otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
 {
-    otError result = OT_ERROR_NONE;
+    bool result = true;
 
     aFrame->mPsdu[-1] = aFrame->mLength;
 
@@ -347,20 +347,18 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
     }
     else
     {
-        if (!nrf_802154_transmit_raw(&aFrame->mPsdu[-1], false))
-        {
-            result = OT_ERROR_FAILED;
-        }
+        result = nrf_802154_transmit_raw(&aFrame->mPsdu[-1], false);
     }
 
     clearPendingEvents();
+    otPlatRadioTxStarted(aInstance, aFrame);
 
-    if (result == OT_ERROR_NONE)
+    if (!result)
     {
-        otPlatRadioTxStarted(aInstance, aFrame);
+        setPendingEvent(kPendingEventChannelAccessFailure);
     }
 
-    return result;
+    return OT_ERROR_NONE;
 }
 
 otRadioFrame *otPlatRadioGetTransmitBuffer(otInstance *aInstance)

--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -335,7 +335,7 @@ otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 
 otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
 {
-    otError result = OT_ERROR_NONE;
+    bool result = true;
 
     aFrame->mPsdu[-1] = aFrame->mLength;
 
@@ -347,20 +347,18 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
     }
     else
     {
-        if (!nrf_802154_transmit_raw(&aFrame->mPsdu[-1], false))
-        {
-            result = OT_ERROR_FAILED;
-        }
+        result = nrf_802154_transmit_raw(&aFrame->mPsdu[-1], false);
     }
 
     clearPendingEvents();
+    otPlatRadioTxStarted(aInstance, aFrame);
 
-    if (result == OT_ERROR_NONE)
+    if (!result)
     {
-        otPlatRadioTxStarted(aInstance, aFrame);
+        setPendingEvent(kPendingEventChannelAccessFailure);
     }
 
-    return result;
+    return OT_ERROR_NONE;
 }
 
 otRadioFrame *otPlatRadioGetTransmitBuffer(otInstance *aInstance)


### PR DESCRIPTION
otPlatRadioTransmit can return OT_ERROR_INVALID_STATE or OT_ERROR_NONE so inform about failed TX later.
This fixes #3726 