### PR TITLE
[mle] enter fast poll mode when dequeue delayed MLE Data Request

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1840,6 +1840,16 @@ void Mle::HandleDelayedResponseTimer(void)
             if (SendMessage(*message, delayedResponse.GetDestination()) == OT_ERROR_NONE)
             {
                 LogMleMessage("Send delayed message", delayedResponse.GetDestination());
+
+                // Here enters fast poll mode, as for Rx-Off-when-idle device, the enqueued msg should
+                // be Mle Data Reqeuest.
+                // Note: Finer-grade check (e.g. message subtype) might be required when deciding whether
+                // or not enters fast poll mode fast poll mode if there are other type of delayed message
+                // for Rx-Off-when-idle device.
+                if (!IsRxOnWhenIdle())
+                {
+                    Get<DataPollManager>().SendFastPolls(DataPollManager::kDefaultFastPolls);
+                }
             }
             else
             {


### PR DESCRIPTION
Mle Data Request would be always delayed except the retransmitted ones. For sleepy device, it should enter fast poll mode after the delayed Mle Data Request is dequeued to send.  Besides, after received Mle Data Response, it should stop fast poll mode.