### PR TITLE
[mle] do not apply active dataset from settings after attaching

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3360,8 +3360,6 @@ otError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::MessageIn
     Get<NetworkData::Leader>().SetNetworkData(leaderData.GetDataVersion(), leaderData.GetStableDataVersion(),
                                               !IsFullNetworkData(), aMessage, networkDataOffset);
 
-    Get<MeshCoP::ActiveDataset>().ApplyConfiguration();
-
     SetStateChild(shortAddress.GetRloc16());
 
 exit:


### PR DESCRIPTION
A device should use the Active Dataset in use by the partition that it is
attached to, not the one stored locally in non-volatile.