### PR TITLE
[pskc] set random PSKc when generating a new Active Dataset

### DIFF
--- a/examples/drivers/windows/otApi/otApi.cpp
+++ b/examples/drivers/windows/otApi/otApi.cpp
@@ -1619,7 +1619,7 @@ otThreadSetMasterKey(
 }
 
 OTAPI 
-const uint8_t *
+const otPSKc *
 OTCALL
 otThreadGetPSKc(
     _In_ otInstance *aInstance 
@@ -1627,7 +1627,7 @@ otThreadGetPSKc(
 {
     if (aInstance == nullptr) return nullptr;
 
-    uint8_t *Result = (uint8_t*)malloc(sizeof(otPSKc));
+    otPSKc *Result = (otPSKc*)malloc(sizeof(otPSKc));
     if (Result == nullptr) return nullptr;
     if (QueryIOCTL(aInstance, IOCTL_OTLWF_OT_PSKC, Result) != ERROR_SUCCESS)
     {
@@ -1642,16 +1642,12 @@ otError
 OTCALL
 otThreadSetPSKc(
     _In_ otInstance *aInstance, 
-    const uint8_t *aPSKc 
+    const otPSKc *aPSKc 
     )
 {
     if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
     
-    BYTE Buffer[sizeof(GUID) + sizeof(otPSKc)];
-    memcpy_s(Buffer, sizeof(Buffer), &aInstance->InterfaceGuid, sizeof(GUID));
-    memcpy_s(Buffer + sizeof(GUID), sizeof(Buffer) - sizeof(GUID), aPSKc, sizeof(otPSKc));
-    
-    return DwordToThreadError(SendIOCTL(aInstance->ApiHandle, IOCTL_OTLWF_OT_PSKC, Buffer, sizeof(Buffer), nullptr, 0));
+    return DwordToThreadError(SetIOCTL(aInstance, IOCTL_OTLWF_OT_PSKC, aPSKc));
 }
 
 OTAPI

--- a/examples/drivers/windows/otLwf/iocontrol.c
+++ b/examples/drivers/windows/otLwf/iocontrol.c
@@ -1746,12 +1746,12 @@ otLwfIoCtl_otPSKc(
 
     if (InBufferLength >= sizeof(otPSKc))
     {
-        status = ThreadErrorToNtstatus(otThreadSetPSKc(pFilter->otCtx, InBuffer));
+        status = ThreadErrorToNtstatus(otThreadSetPSKc(pFilter->otCtx, (otPSKc*)InBuffer));
         *OutBufferLength = 0;
     }
     else if (*OutBufferLength >= sizeof(otPSKc))
     {
-        const uint8_t* aPSKc = otThreadGetPSKc(pFilter->otCtx);
+        const otPSKc* aPSKc = otThreadGetPSKc(pFilter->otCtx);
         memcpy(OutBuffer, aPSKc, sizeof(otPSKc));
         *OutBufferLength = sizeof(otPSKc);
         status = STATUS_SUCCESS;

--- a/examples/drivers/windows/otNodeApi/otNodeApi.cpp
+++ b/examples/drivers/windows/otNodeApi/otNodeApi.cpp
@@ -1256,14 +1256,15 @@ OTNODEAPI int32_t OTCALL otNodeSetPSKc(otNode* aNode, const char *aPSKc)
     otLogFuncEntryMsg("[%d] %s", aNode->mId, aPSKc);
     printf("%d: pskc %s\r\n", aNode->mId, aPSKc);
 
-    uint8_t pskc[OT_PSKC_MAX_SIZE];
-    if (Hex2Bin(aPSKc, pskc, sizeof(pskc)) != OT_PSKC_MAX_SIZE)
+    int pskcLength;
+    otPSKc pskc;
+    if ((pskcLength = Hex2Bin(aPSKc, pskc.m8, sizeof(aPSKc))) != OT_PSKC_MAX_SIZE)
     {
-        printf("invalid pskc %s\r\n", aPSKc);
+        printf("invalid length pskd %d\r\n", pskcLength);
         return OT_ERROR_PARSE;
     }
 
-    auto error = otThreadSetPSKc(aNode->mInstance, pskc);
+    auto error = otThreadSetPSKc(aNode->mInstance, &pskc);
     otLogFuncExit();
     return error;
 }
@@ -1278,7 +1279,7 @@ OTNODEAPI const char* OTCALL otNodeGetPSKc(otNode* aNode)
     {
         aNode->mMemoryToFree.push_back(str);
         for (int i = 0; i < OT_PSKC_MAX_SIZE; i++)
-            sprintf_s(str + i * 2, strLength - (2 * i), "%02x", aPSKc[i]);
+            sprintf_s(str + i * 2, strLength - (2 * i), "%02x", aPSKc->m8[i]);
         printf("%d: pskc\r\n%s\r\n", aNode->mId, str);
     }
     otFreeMemory(aPSKc);

--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -112,7 +112,7 @@ struct otMeshLocalPrefix
 } OT_TOOL_PACKED_END;
 
 /**
- * This structure represents a Mesh Local Prefix
+ * This structure represents a Mesh Local Prefix.
  *
  */
 typedef struct otMeshLocalPrefix otMeshLocalPrefix;
@@ -123,10 +123,17 @@ typedef struct otMeshLocalPrefix otMeshLocalPrefix;
  * This structure represents PSKc.
  *
  */
-typedef struct otPSKc
+OT_TOOL_PACKED_BEGIN
+struct otPSKc
 {
     uint8_t m8[OT_PSKC_MAX_SIZE]; ///< Byte values
-} otPSKc;
+} OT_TOOL_PACKED_END;
+
+/**
+ * This structure represents a PSKc.
+ *
+ */
+typedef struct otPSKc otPSKc;
 
 /**
  * This structure represent Security Policy.

--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -524,7 +524,7 @@ OTAPI otError OTCALL otThreadGetEidCacheEntry(otInstance *aInstance, uint8_t aIn
  * @sa otThreadSetPSKc
  *
  */
-OTAPI const uint8_t *OTCALL otThreadGetPSKc(otInstance *aInstance);
+OTAPI const otPSKc *OTCALL otThreadGetPSKc(otInstance *aInstance);
 
 /**
  * Set the thrPSKc.
@@ -542,7 +542,7 @@ OTAPI const uint8_t *OTCALL otThreadGetPSKc(otInstance *aInstance);
  * @sa otThreadGetPSKc
  *
  */
-OTAPI otError OTCALL otThreadSetPSKc(otInstance *aInstance, const uint8_t *aPSKc);
+OTAPI otError OTCALL otThreadSetPSKc(otInstance *aInstance, const otPSKc *aPSKc);
 
 /**
  * Get the assigned parent priority.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1515,21 +1515,21 @@ void Interpreter::ProcessPSKc(int argc, char *argv[])
 
     if (argc == 0)
     {
-        const uint8_t *currentPSKc = otThreadGetPSKc(mInstance);
+        const otPSKc *pskc = otThreadGetPSKc(mInstance);
 
         for (int i = 0; i < OT_PSKC_MAX_SIZE; i++)
         {
-            mServer->OutputFormat("%02x", currentPSKc[i]);
+            mServer->OutputFormat("%02x", pskc->m8[i]);
         }
 
         mServer->OutputFormat("\r\n");
     }
     else
     {
-        uint8_t newPSKc[OT_PSKC_MAX_SIZE];
+        otPSKc pskc;
 
-        VerifyOrExit(Hex2Bin(argv[0], newPSKc, sizeof(newPSKc)) == OT_PSKC_MAX_SIZE, error = OT_ERROR_PARSE);
-        SuccessOrExit(error = otThreadSetPSKc(mInstance, newPSKc));
+        VerifyOrExit(Hex2Bin(argv[0], pskc.m8, sizeof(pskc)) == OT_PSKC_MAX_SIZE, error = OT_ERROR_PARSE);
+        SuccessOrExit(error = otThreadSetPSKc(mInstance, &pskc));
     }
 
 exit:

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -344,21 +344,21 @@ otError otThreadSetSteeringData(otInstance *aInstance, const otExtAddress *aExtA
     return error;
 }
 
-const uint8_t *otThreadGetPSKc(otInstance *aInstance)
+const otPSKc *otThreadGetPSKc(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<KeyManager>().GetPSKc();
+    return &instance.Get<KeyManager>().GetPSKc();
 }
 
-otError otThreadSetPSKc(otInstance *aInstance, const uint8_t *aPSKc)
+otError otThreadSetPSKc(otInstance *aInstance, const otPSKc *aPSKc)
 {
     otError   error    = OT_ERROR_NONE;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
     VerifyOrExit(instance.Get<Mle::MleRouter>().GetRole() == OT_DEVICE_ROLE_DISABLED, error = OT_ERROR_INVALID_STATE);
 
-    instance.Get<KeyManager>().SetPSKc(aPSKc);
+    instance.Get<KeyManager>().SetPSKc(*aPSKc);
     instance.Get<MeshCoP::ActiveDataset>().Clear();
     instance.Get<MeshCoP::PendingDataset>().Clear();
 

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -651,7 +651,7 @@ otError BorderAgent::Start(void)
     VerifyOrExit(mState == OT_BORDER_AGENT_STATE_STOPPED, error = OT_ERROR_ALREADY);
 
     SuccessOrExit(error = coaps.Start(kBorderAgentUdpPort));
-    SuccessOrExit(error = coaps.SetPsk(Get<KeyManager>().GetPSKc(), OT_PSKC_MAX_SIZE));
+    SuccessOrExit(error = coaps.SetPsk(Get<KeyManager>().GetPSKc().m8, OT_PSKC_MAX_SIZE));
     coaps.SetConnectedCallback(HandleConnected, this);
 
     coaps.AddResource(mActiveGet);

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -216,8 +216,8 @@ void Dataset::Get(otOperationalDataset &aDataset) const
 
         case Tlv::kPSKc:
         {
-            const PSKcTlv *tlv = static_cast<const PSKcTlv *>(cur);
-            memcpy(aDataset.mPSKc.m8, tlv->GetPSKc(), tlv->GetLength());
+            const PSKcTlv *tlv                  = static_cast<const PSKcTlv *>(cur);
+            aDataset.mPSKc                      = tlv->GetPSKc();
             aDataset.mComponents.mIsPSKcPresent = true;
             break;
         }
@@ -347,7 +347,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
     {
         MeshCoP::PSKcTlv tlv;
         tlv.Init();
-        tlv.SetPSKc(aDataset.mPSKc.m8);
+        tlv.SetPSKc(aDataset.mPSKc);
         Set(tlv);
     }
 

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -403,8 +403,22 @@ otError ActiveDataset::GenerateLocal(void)
     if (dataset.Get(Tlv::kPSKc) == NULL)
     {
         PSKcTlv tlv;
+
         tlv.Init();
-        tlv.SetPSKc(Get<KeyManager>().GetPSKc());
+
+        if (Get<KeyManager>().IsPSKcSet())
+        {
+            // use configured PSKc
+            tlv.SetPSKc(Get<KeyManager>().GetPSKc());
+        }
+        else
+        {
+            // PSKc has not yet been configured, generate new PSKc at random
+            otPSKc pskc;
+            SuccessOrExit(error = otPlatRandomGetTrue(pskc.m8, sizeof(pskc)));
+            tlv.SetPSKc(pskc);
+        }
+
         dataset.Set(tlv);
     }
 

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -460,7 +460,7 @@ public:
      * @returns The PSKc value.
      *
      */
-    const uint8_t *GetPSKc(void) const { return mPSKc; }
+    const otPSKc &GetPSKc(void) const { return mPSKc; }
 
     /**
      * This method sets the PSKc value.
@@ -468,10 +468,10 @@ public:
      * @param[in]  aPSKc  A pointer to the PSKc value.
      *
      */
-    void SetPSKc(const uint8_t *aPSKc) { memcpy(mPSKc, aPSKc, sizeof(mPSKc)); }
+    void SetPSKc(const otPSKc &aPSKc) { mPSKc = aPSKc; }
 
 private:
-    uint8_t mPSKc[16];
+    otPSKc mPSKc;
 } OT_TOOL_PACKED_END;
 
 /**

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -81,7 +81,9 @@ KeyManager::KeyManager(Instance &aInstance)
     , mKeyRotationTimer(aInstance, &KeyManager::HandleKeyRotationTimer, this)
     , mKekFrameCounter(0)
     , mSecurityPolicyFlags(0xff)
+    , mIsPSKcSet(false)
 {
+    memset(&mPSKc, 0, sizeof(mPSKc));
     ComputeKey(mKeySequence, mKey);
 }
 
@@ -104,7 +106,7 @@ void KeyManager::SetPSKc(const otPSKc &aPSKc)
     Get<Notifier>().Signal(OT_CHANGED_PSKC);
 
 exit:
-    return;
+    mIsPSKcSet = true;
 }
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -97,15 +97,10 @@ void KeyManager::Stop(void)
 }
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
-const uint8_t *KeyManager::GetPSKc(void) const
+void KeyManager::SetPSKc(const otPSKc &aPSKc)
 {
-    return mPSKc;
-}
-
-void KeyManager::SetPSKc(const uint8_t *aPSKc)
-{
-    VerifyOrExit(memcmp(mPSKc, aPSKc, sizeof(mPSKc)) != 0, Get<Notifier>().SignalIfFirst(OT_CHANGED_PSKC));
-    memcpy(mPSKc, aPSKc, sizeof(mPSKc));
+    VerifyOrExit(memcmp(&mPSKc, &aPSKc, sizeof(mPSKc)) != 0, Get<Notifier>().SignalIfFirst(OT_CHANGED_PSKC));
+    mPSKc = aPSKc;
     Get<Notifier>().Signal(OT_CHANGED_PSKC);
 
 exit:

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -102,21 +102,23 @@ public:
      */
     otError SetMasterKey(const otMasterKey &aKey);
 
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
     /**
      * This method returns a pointer to the PSKc.
      *
-     * @returns A pointer to the PSKc.
+     * @returns A reference to the PSKc.
      *
      */
-    const uint8_t *GetPSKc(void) const;
+    const otPSKc &GetPSKc(void) const { return mPSKc; }
 
     /**
      * This method sets the PSKc.
      *
-     * @param[in]  aPSKc    A pointer to the PSKc.
+     * @param[in]  aPSKc    A reference to the PSKc.
      *
      */
-    void SetPSKc(const uint8_t *aPSKc);
+    void SetPSKc(const otPSKc &aPSKc);
+#endif
 
     /**
      * This method returns the current key sequence value.
@@ -360,7 +362,7 @@ private:
     TimerMilli mKeyRotationTimer;
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
-    uint8_t mPSKc[kMaxKeyLength];
+    otPSKc mPSKc;
 #endif
     uint8_t  mKek[kMaxKeyLength];
     uint32_t mKekFrameCounter;

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -104,6 +104,17 @@ public:
 
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
     /**
+     * This method indicates whether the PSKc is configured.
+     *
+     * A value of all zeros indicates that the PSKc is not configured.
+     *
+     * @retval TRUE  if the PSKc is configured.
+     * @retval FALSE if the PSKc is not not configured.
+     *
+     */
+    bool IsPSKcSet(void) const { return mIsPSKcSet; }
+
+    /**
      * This method returns a pointer to the PSKc.
      *
      * @returns A reference to the PSKc.
@@ -368,6 +379,7 @@ private:
     uint32_t mKekFrameCounter;
 
     uint8_t mSecurityPolicyFlags;
+    bool    mIsPSKcSet : 1;
 };
 
 /**

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -294,7 +294,7 @@ exit:
 
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_NET_PSKC>(void)
 {
-    return mEncoder.WriteData(otThreadGetPSKc(mInstance), sizeof(spinel_net_pskc_t));
+    return mEncoder.WriteData(otThreadGetPSKc(mInstance)->m8, sizeof(spinel_net_pskc_t));
 }
 
 template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_NET_PSKC>(void)
@@ -307,7 +307,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_NET_PSKC>(void)
 
     VerifyOrExit(len == sizeof(spinel_net_pskc_t), error = OT_ERROR_PARSE);
 
-    error = otThreadSetPSKc(mInstance, ptr);
+    error = otThreadSetPSKc(mInstance, reinterpret_cast<const otPSKc *>(ptr));
 
 exit:
     return error;


### PR DESCRIPTION
When generating a new Active Dataset, the current PSKc value is used. Because
the PSKc is initialized to all zeros, new Active Datasets have a default
PSKc value of all zeros.
    
This commit checks if the PSKc has been set (i.e. not all zeros) and, if not
set, generates a random PSKc when creating a new Active Dataset.

Also, this PR contains a commit to use `otPSKc` rather than byte arrays.