### PR TITLE
[ncp] add spinel_meshcop_joiner_state_t enumeration

### DIFF
--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -1441,7 +1441,31 @@ exit:
 #if OPENTHREAD_ENABLE_JOINER
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_MESHCOP_JOINER_STATE>(void)
 {
-    return mEncoder.WriteUint8(static_cast<uint8_t>(otJoinerGetState(mInstance)));
+    spinel_meshcop_joiner_state_t state = SPINEL_MESHCOP_JOINER_STATE_IDLE;
+
+    switch (otJoinerGetState(mInstance))
+    {
+    case OT_JOINER_STATE_IDLE:
+        state = SPINEL_MESHCOP_JOINER_STATE_IDLE;
+        break;
+    case OT_JOINER_STATE_DISCOVER:
+        state = SPINEL_MESHCOP_JOINER_STATE_DISCOVER;
+        break;
+    case OT_JOINER_STATE_CONNECT:
+        state = SPINEL_MESHCOP_JOINER_STATE_CONNECTING;
+        break;
+    case OT_JOINER_STATE_CONNECTED:
+        state = SPINEL_MESHCOP_JOINER_STATE_CONNECTED;
+        break;
+    case OT_JOINER_STATE_ENTRUST:
+        state = SPINEL_MESHCOP_JOINER_STATE_ENTRUST;
+        break;
+    case OT_JOINER_STATE_JOINED:
+        state = SPINEL_MESHCOP_JOINER_STATE_JOINED;
+        break;
+    }
+
+    return mEncoder.WriteUint8(state);
 }
 
 template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_MESHCOP_JOINER_COMMISSIONING>(void)

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -259,6 +259,16 @@ typedef enum
     SPINEL_HOST_POWER_STATE_ONLINE     = 4,
 } spinel_host_power_state_t;
 
+typedef enum
+{
+    SPINEL_MESHCOP_JOINER_STATE_IDLE       = 0,
+    SPINEL_MESHCOP_JOINER_STATE_DISCOVER   = 1,
+    SPINEL_MESHCOP_JOINER_STATE_CONNECTING = 2,
+    SPINEL_MESHCOP_JOINER_STATE_CONNECTED  = 3,
+    SPINEL_MESHCOP_JOINER_STATE_ENTRUST    = 4,
+    SPINEL_MESHCOP_JOINER_STATE_JOINED     = 5,
+} spinel_meshcop_joiner_state_t;
+
 enum
 {
     SPINEL_NET_FLAG_ON_MESH       = (1 << 0),
@@ -2632,7 +2642,8 @@ typedef enum
      *
      * Required capability: SPINEL_CAP_THREAD_JOINER
      *
-     * The valid values are specified by SPINEL_MESHCOP_COMMISIONER_STATE_<state> enumeration.
+     * The valid values are specified by `spinel_meshcop_joiner_state_t` (`SPINEL_MESHCOP_JOINER_STATE_<state>`)
+     * enumeration.
      *
      */
     SPINEL_PROP_MESHCOP_JOINER_STATE = SPINEL_PROP_MESHCOP__BEGIN + 0, ///<[C]


### PR DESCRIPTION
This commit defines an enumeration in spinel for Joiner state which
is related to property `SPINEL_PROP_MESHCOP_JOINER_STATE`.