### PR TITLE
[efr32] further UART driver refactoring

### DIFF
--- a/examples/platforms/efr32/uart.c
+++ b/examples/platforms/efr32/uart.c
@@ -230,9 +230,7 @@ static void processReceive(void)
         {
             // There is still data in the buffer (i.e. wrappedReadStart < wrappedReadEnd)
             readLength = wrappedReadEnd - wrappedReadStart;
-
             otPlatUartReceived(sReceiveFifo.mBuffer + wrappedReadStart, readLength);
-            assert(sReceiveFifo.mReadStart + readLength == readEnd);
 
             // All data has been read
             sReceiveFifo.mReadStart = readEnd;


### PR DESCRIPTION
- No longer queue 2x 32-byte buffers for UART receive. Upon investigation, the RAIL library switches these buffers in software (within the same ISR context as `receiveDone`), so it seems to be pointless from a performance perspective in queuing multiple buffers. Instead, now work with 64-byte buffers. 
- Refactored `updateReceiveProgress` so that extra variable `mLastCount` isn't required.
- Extensive testing at higher baud rates revealed race conditions and some issues with detecting buffer full conditions.
- Added comments to clarify the logic
- Removed asserts after returning from RAIL library functions. Contrary to my previous arguments, if the behaviour of the RAIL library functions changes in the future (with regards to the errors it returns), then somebody would have to remember to check these asserts were still appropriate.