### PR TITLE
[joiner] fail on bad string args for vendor name, mode, sw version, etc.

### DIFF
--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -411,15 +411,15 @@ otError Joiner::PrepareJoinerFinalizeMessage(const char *aProvisioningUrl,
     SuccessOrExit(error = mFinalizeMessage->AppendTlv(stateTlv));
 
     vendorNameTlv.Init();
-    vendorNameTlv.SetVendorName(aVendorName);
+    SuccessOrExit(error = vendorNameTlv.SetVendorName(aVendorName));
     SuccessOrExit(error = mFinalizeMessage->AppendTlv(vendorNameTlv));
 
     vendorModelTlv.Init();
-    vendorModelTlv.SetVendorModel(aVendorModel);
+    SuccessOrExit(error = vendorModelTlv.SetVendorModel(aVendorModel));
     SuccessOrExit(error = mFinalizeMessage->AppendTlv(vendorModelTlv));
 
     vendorSwVersionTlv.Init();
-    vendorSwVersionTlv.SetVendorSwVersion(aVendorSwVersion);
+    SuccessOrExit(error = vendorSwVersionTlv.SetVendorSwVersion(aVendorSwVersion));
     SuccessOrExit(error = mFinalizeMessage->AppendTlv(vendorSwVersionTlv));
 
     vendorStackVersionTlv.Init();
@@ -433,12 +433,12 @@ otError Joiner::PrepareJoinerFinalizeMessage(const char *aProvisioningUrl,
     {
         VendorDataTlv vendorDataTlv;
         vendorDataTlv.Init();
-        vendorDataTlv.SetVendorData(aVendorData);
+        SuccessOrExit(error = vendorDataTlv.SetVendorData(aVendorData));
         SuccessOrExit(error = mFinalizeMessage->AppendTlv(vendorDataTlv));
     }
 
     provisioningUrlTlv.Init();
-    provisioningUrlTlv.SetProvisioningUrl(aProvisioningUrl);
+    SuccessOrExit(error = provisioningUrlTlv.SetProvisioningUrl(aProvisioningUrl));
 
     if (provisioningUrlTlv.GetLength() > 0)
     {


### PR DESCRIPTION
This commit ensures that the `Joiner::Start()` fails and returns an
error if the passed-in string args (vendor name, model, sw version,
data or provisioning URL) are incorrect and cannot be added to the
corresponding TLVs (e.g., string is too long).