### PR TITLE
[meshcop] clip long strings for vendor name, model, version, data

### DIFF
--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -323,7 +323,18 @@ const char *Commissioner::GetProvisioningUrl(uint16_t &aLength) const
 
 otError Commissioner::SetProvisioningUrl(const char *aProvisioningUrl)
 {
-    return Get<Coap::CoapSecure>().GetDtls().mProvisioningUrl.SetProvisioningUrl(aProvisioningUrl);
+    otError error = OT_ERROR_NONE;
+
+    if (aProvisioningUrl != NULL)
+    {
+        size_t len = strnlen(aProvisioningUrl, MeshCoP::ProvisioningUrlTlv::kMaxLength + 1);
+        VerifyOrExit(len <= MeshCoP::ProvisioningUrlTlv::kMaxLength, error = OT_ERROR_INVALID_ARGS);
+    }
+
+    Get<Coap::CoapSecure>().GetDtls().mProvisioningUrl.SetProvisioningUrl(aProvisioningUrl);
+
+exit:
+    return error;
 }
 
 uint16_t Commissioner::GetSessionId(void) const

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -1809,6 +1809,11 @@ OT_TOOL_PACKED_BEGIN
 class ProvisioningUrlTlv : public Tlv
 {
 public:
+    enum
+    {
+        kMaxLength = 64, // Maximum number of chars in the Provisioning URL string.
+    };
+
     /**
      * This method initializes the TLV.
      *
@@ -1842,29 +1847,19 @@ public:
      * @param[in]  aProvisioningUrl  A pointer to the Provisioning URL value.
      *
      */
-    otError SetProvisioningUrl(const char *aProvisioningUrl)
+    void SetProvisioningUrl(const char *aProvisioningUrl)
     {
-        otError error = OT_ERROR_NONE;
-        size_t  len   = aProvisioningUrl ? strnlen(aProvisioningUrl, kMaxLength + 1) : 0;
+        size_t len = aProvisioningUrl ? strnlen(aProvisioningUrl, kMaxLength) : 0;
 
-        VerifyOrExit(len <= kMaxLength, error = OT_ERROR_INVALID_ARGS);
         SetLength(static_cast<uint8_t>(len));
 
         if (len > 0)
         {
             memcpy(mProvisioningUrl, aProvisioningUrl, len);
         }
-
-    exit:
-        return error;
     }
 
 private:
-    enum
-    {
-        kMaxLength = 64,
-    };
-
     char mProvisioningUrl[kMaxLength];
 } OT_TOOL_PACKED_END;
 
@@ -1909,21 +1904,16 @@ public:
      * @param[in]  aVendorName  A pointer to the Vendor Name value.
      *
      */
-    otError SetVendorName(const char *aVendorName)
+    void SetVendorName(const char *aVendorName)
     {
-        otError error = OT_ERROR_NONE;
-        size_t  len   = (aVendorName == NULL) ? 0 : strnlen(aVendorName, sizeof(mVendorName) + 1);
+        size_t len = (aVendorName == NULL) ? 0 : strnlen(aVendorName, sizeof(mVendorName));
 
-        VerifyOrExit(len <= sizeof(mVendorName), error = OT_ERROR_INVALID_ARGS);
         SetLength(static_cast<uint8_t>(len));
 
         if (len > 0)
         {
             memcpy(mVendorName, aVendorName, len);
         }
-
-    exit:
-        return error;
     }
 
 private:
@@ -1976,21 +1966,16 @@ public:
      * @param[in]  aVendorModel  A pointer to the Vendor Model value.
      *
      */
-    otError SetVendorModel(const char *aVendorModel)
+    void SetVendorModel(const char *aVendorModel)
     {
-        otError error = OT_ERROR_NONE;
-        size_t  len   = (aVendorModel == NULL) ? 0 : strnlen(aVendorModel, sizeof(mVendorModel) + 1);
+        size_t len = (aVendorModel == NULL) ? 0 : strnlen(aVendorModel, sizeof(mVendorModel));
 
-        VerifyOrExit(len <= sizeof(mVendorModel), error = OT_ERROR_INVALID_ARGS);
         SetLength(static_cast<uint8_t>(len));
 
         if (len > 0)
         {
             memcpy(mVendorModel, aVendorModel, len);
         }
-
-    exit:
-        return error;
     }
 
 private:
@@ -2043,21 +2028,16 @@ public:
      * @param[in]  aVendorSwVersion  A pointer to the Vendor SW Version value.
      *
      */
-    otError SetVendorSwVersion(const char *aVendorSwVersion)
+    void SetVendorSwVersion(const char *aVendorSwVersion)
     {
-        otError error = OT_ERROR_NONE;
-        size_t  len   = (aVendorSwVersion == NULL) ? 0 : strnlen(aVendorSwVersion, sizeof(mVendorSwVersion) + 1);
+        size_t len = (aVendorSwVersion == NULL) ? 0 : strnlen(aVendorSwVersion, sizeof(mVendorSwVersion));
 
-        VerifyOrExit(len <= sizeof(mVendorSwVersion), error = OT_ERROR_INVALID_ARGS);
         SetLength(static_cast<uint8_t>(len));
 
         if (len > 0)
         {
             memcpy(mVendorSwVersion, aVendorSwVersion, len);
         }
-
-    exit:
-        return error;
     }
 
 private:
@@ -2110,21 +2090,16 @@ public:
      * @param[in]  aVendorData  A pointer to the Vendor Data value.
      *
      */
-    otError SetVendorData(const char *aVendorData)
+    void SetVendorData(const char *aVendorData)
     {
-        otError error = OT_ERROR_NONE;
-        size_t  len   = (aVendorData == NULL) ? 0 : strnlen(aVendorData, sizeof(mVendorData) + 1);
+        size_t len = (aVendorData == NULL) ? 0 : strnlen(aVendorData, sizeof(mVendorData));
 
-        VerifyOrExit(len <= sizeof(mVendorData), error = OT_ERROR_INVALID_ARGS);
         SetLength(static_cast<uint8_t>(len));
 
         if (len > 0)
         {
             memcpy(mVendorData, aVendorData, len);
         }
-
-    exit:
-        return error;
     }
 
 private:


### PR DESCRIPTION
This commit ensures that if the passed-in string args (vendor name,
model, sw version, data or provisioning URL) in `Joiner::Start()`
are too long, they are clipped to the max size defined by the
corresponding TLVs.