### PR TITLE
Joiner: Allow EUI64 (to derive Joiner ID) to be specified during Joiner Commissioning.

### DIFF
--- a/examples/drivers/windows/otApi/otApi.cpp
+++ b/examples/drivers/windows/otApi/otApi.cpp
@@ -3876,6 +3876,7 @@ otJoinerStart(
     _Null_terminated_ const char *aVendorModel,
     _Null_terminated_ const char *aVendorSwVersion,
     _Null_terminated_ const char *aVendorData,
+    _In_ const otExtAddress *aEui64,
     _In_ otJoinerCallback aCallback,
     _In_ void *aCallbackContext
     )
@@ -3890,6 +3891,7 @@ otJoinerStart(
     size_t aVendorModelLength = aVendorModel == nullptr ? 0 : strlen(aVendorModel);
     size_t aVendorSwVersionLength = aVendorSwVersion == nullptr ? 0 : strlen(aVendorSwVersion);
     size_t aVendorDataLength = aVendorData == nullptr ? 0 : strlen(aVendorData);
+    size_t aEui64Length = aEui64 == nullptr ? 0 : sizeof(aEui64);
 
     if (aPSKdLength > OPENTHREAD_PSK_MAX_LENGTH ||
         aProvisioningUrlLength > OPENTHREAD_PROV_URL_MAX_LENGTH ||

--- a/examples/drivers/windows/otLwf/iocontrol.c
+++ b/examples/drivers/windows/otLwf/iocontrol.c
@@ -5442,6 +5442,7 @@ otLwfIoCtl_otJoinerStart(
                     pFilter->otVendorModel,
                     pFilter->otVendorSwVersion,
                     pFilter->otVendorData[0] == '\0' ? NULL : pFilter->otVendorData,
+                    NULL,
                     otLwfJoinerCallback,
                     pFilter)
                 );

--- a/examples/drivers/windows/otNodeApi/otNodeApi.cpp
+++ b/examples/drivers/windows/otNodeApi/otNodeApi.cpp
@@ -1047,7 +1047,7 @@ OTNODEAPI int32_t OTCALL otNodeJoinerStart(otNode* aNode, const char *aPSKd, con
     printf("%d: joiner start %s %s\r\n", aNode->mId, aPSKd, aProvisioningUrl);
 
     // TODO: handle the joiner completion callback
-    auto error = otJoinerStart(aNode->mInstance, aPSKd, aProvisioningUrl, NULL, NULL, NULL, NULL, NULL, NULL);
+    auto error = otJoinerStart(aNode->mInstance, aPSKd, aProvisioningUrl, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     
     otLogFuncExit();
     return error;

--- a/include/openthread/joiner.h
+++ b/include/openthread/joiner.h
@@ -88,6 +88,8 @@ typedef void(OTCALL *otJoinerCallback)(otError aError, void *aContext);
  * @param[in]  aVendorModel      A pointer to the Vendor Model (may be NULL).
  * @param[in]  aVendorSwVersion  A pointer to the Vendor SW Version (may be NULL).
  * @param[in]  aVendorData       A pointer to the Vendor Data (may be NULL).
+ * @param[in]  aEui64            A pointer to the EUI64 to use as extended address during join. If NULL the
+ *                               factory-assigned one will be used instead.
  * @param[in]  aCallback         A pointer to a function that is called when the join operation completes.
  * @param[in]  aContext          A pointer to application-specific context.
  *
@@ -96,15 +98,16 @@ typedef void(OTCALL *otJoinerCallback)(otError aError, void *aContext);
  * @retval OT_ERROR_DISABLED_FEATURE  The Joiner feature is not enabled in this build.
  *
  */
-OTAPI otError OTCALL otJoinerStart(otInstance *     aInstance,
-                                   const char *     aPSKd,
-                                   const char *     aProvisioningUrl,
-                                   const char *     aVendorName,
-                                   const char *     aVendorModel,
-                                   const char *     aVendorSwVersion,
-                                   const char *     aVendorData,
-                                   otJoinerCallback aCallback,
-                                   void *           aContext);
+OTAPI otError OTCALL otJoinerStart(otInstance *        aInstance,
+                                   const char *        aPSKd,
+                                   const char *        aProvisioningUrl,
+                                   const char *        aVendorName,
+                                   const char *        aVendorModel,
+                                   const char *        aVendorSwVersion,
+                                   const char *        aVendorData,
+                                   const otExtAddress *aEui64,
+                                   otJoinerCallback    aCallback,
+                                   void *              aContext);
 
 /**
  * This function disables the Thread Joiner role.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3447,7 +3447,7 @@ void Interpreter::ProcessJoiner(int argc, char *argv[])
         VerifyOrExit(argc > 1, error = OT_ERROR_INVALID_ARGS);
         provisioningUrl = (argc > 2) ? argv[2] : NULL;
         otJoinerStart(mInstance, argv[1], provisioningUrl, PACKAGE_NAME, OPENTHREAD_CONFIG_PLATFORM_INFO,
-                      PACKAGE_VERSION, NULL, &Interpreter::s_HandleJoinerCallback, this);
+                      PACKAGE_VERSION, NULL, NULL, &Interpreter::s_HandleJoinerCallback, this);
     }
     else if (strcmp(argv[0], "stop") == 0)
     {

--- a/src/core/api/joiner_api.cpp
+++ b/src/core/api/joiner_api.cpp
@@ -40,22 +40,24 @@
 
 using namespace ot;
 
-otError otJoinerStart(otInstance *     aInstance,
-                      const char *     aPSKd,
-                      const char *     aProvisioningUrl,
-                      const char *     aVendorName,
-                      const char *     aVendorModel,
-                      const char *     aVendorSwVersion,
-                      const char *     aVendorData,
-                      otJoinerCallback aCallback,
-                      void *           aContext)
+otError otJoinerStart(otInstance *        aInstance,
+                      const char *        aPSKd,
+                      const char *        aProvisioningUrl,
+                      const char *        aVendorName,
+                      const char *        aVendorModel,
+                      const char *        aVendorSwVersion,
+                      const char *        aVendorData,
+                      const otExtAddress *aEui64,
+                      otJoinerCallback    aCallback,
+                      void *              aContext)
 {
     otError error = OT_ERROR_DISABLED_FEATURE;
 #if OPENTHREAD_ENABLE_JOINER
     Instance &instance = *static_cast<Instance *>(aInstance);
 
     error = instance.Get<MeshCoP::Joiner>().Start(aPSKd, aProvisioningUrl, aVendorName, aVendorModel, aVendorSwVersion,
-                                                  aVendorData, aCallback, aContext);
+                                                  aVendorData, static_cast<const Mac::ExtAddress *>(aEui64), aCallback,
+                                                  aContext);
 #else
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aPSKd);
@@ -64,6 +66,7 @@ otError otJoinerStart(otInstance *     aInstance,
     OT_UNUSED_VARIABLE(aVendorModel);
     OT_UNUSED_VARIABLE(aVendorSwVersion);
     OT_UNUSED_VARIABLE(aVendorData);
+    OT_UNUSED_VARIABLE(aEui64);
     OT_UNUSED_VARIABLE(aCallback);
     OT_UNUSED_VARIABLE(aContext);
 #endif

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -501,10 +501,16 @@ otError otThreadDiscover(otInstance *             aInstance,
                          otHandleActiveScanResult aCallback,
                          void *                   aCallbackContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &      instance = *static_cast<Instance *>(aInstance);
+    Mac::ExtAddress eui64;
+
+    if (aEnableEui64Filtering)
+    {
+        otPlatRadioGetIeeeEui64(aInstance, eui64.m8);
+    }
 
     return instance.Get<Mle::MleRouter>().Discover(static_cast<Mac::ChannelMask>(aScanChannels), aPanId, aJoiner,
-                                                   aEnableEui64Filtering, aCallback, aCallbackContext);
+                                                   aEnableEui64Filtering ? &eui64 : NULL, aCallback, aCallbackContext);
 }
 
 bool otThreadIsDiscoverInProgress(otInstance *aInstance)

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -99,6 +99,7 @@ otError Joiner::Start(const char *     aPSKd,
                       void *           aContext)
 {
     otError         error;
+    Mac::ExtAddress eui64;
     Mac::ExtAddress joinerId;
 
     otLogInfoMeshCoP("Joiner starting");
@@ -106,7 +107,8 @@ otError Joiner::Start(const char *     aPSKd,
     VerifyOrExit(mState == OT_JOINER_STATE_IDLE, error = OT_ERROR_BUSY);
 
     // Use extended address based on factory-assigned IEEE EUI-64
-    GetJoinerId(joinerId);
+    otPlatRadioGetIeeeEui64(&GetInstance(), eui64.m8);
+    ComputeJoinerId(eui64, joinerId);
     Get<Mac::Mac>().SetExtAddress(joinerId);
     Get<Mle::MleRouter>().UpdateLinkLocalAddress();
 
@@ -123,8 +125,7 @@ otError Joiner::Start(const char *     aPSKd,
                                                        aVendorData));
 
     SuccessOrExit(error = Get<Mle::MleRouter>().Discover(Mac::ChannelMask(0), Get<Mac::Mac>().GetPanId(),
-                                                         /* aJoiner */ true, /* aEnableFiltering */ true,
-                                                         HandleDiscoverResult, this));
+                                                         /* aJoiner */ true, &eui64, HandleDiscoverResult, this));
     mCallback = aCallback;
     mContext  = aContext;
 

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -89,14 +89,15 @@ exit:
     return;
 }
 
-otError Joiner::Start(const char *     aPSKd,
-                      const char *     aProvisioningUrl,
-                      const char *     aVendorName,
-                      const char *     aVendorModel,
-                      const char *     aVendorSwVersion,
-                      const char *     aVendorData,
-                      otJoinerCallback aCallback,
-                      void *           aContext)
+otError Joiner::Start(const char *           aPSKd,
+                      const char *           aProvisioningUrl,
+                      const char *           aVendorName,
+                      const char *           aVendorModel,
+                      const char *           aVendorSwVersion,
+                      const char *           aVendorData,
+                      const Mac::ExtAddress *aEui64,
+                      otJoinerCallback       aCallback,
+                      void *                 aContext)
 {
     otError         error;
     Mac::ExtAddress eui64;
@@ -106,8 +107,15 @@ otError Joiner::Start(const char *     aPSKd,
 
     VerifyOrExit(mState == OT_JOINER_STATE_IDLE, error = OT_ERROR_BUSY);
 
-    // Use extended address based on factory-assigned IEEE EUI-64
-    otPlatRadioGetIeeeEui64(&GetInstance(), eui64.m8);
+    if (aEui64 != NULL)
+    {
+        eui64 = *aEui64;
+    }
+    else
+    {
+        otPlatRadioGetIeeeEui64(&GetInstance(), eui64.m8);
+    }
+
     ComputeJoinerId(eui64, joinerId);
     Get<Mac::Mac>().SetExtAddress(joinerId);
     Get<Mle::MleRouter>().UpdateLinkLocalAddress();

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -72,20 +72,23 @@ public:
      * @param[in]  aVendorModel      A pointer to the Vendor Model (may be NULL).
      * @param[in]  aVendorSwVersion  A pointer to the Vendor SW Version (may be NULL).
      * @param[in]  aVendorData       A pointer to the Vendor Data (may be NULL).
+     * @param[in]  aEui64            A pointer to the EUI64 to use as extended address during join. If NULL the
+     *                               factory-assigned one will be used instead.
      * @param[in]  aCallback         A pointer to a function that is called when the join operation completes.
      * @param[in]  aContext          A pointer to application-specific context.
      *
      * @retval OT_ERROR_NONE  Successfully started the Joiner service.
      *
      */
-    otError Start(const char *     aPSKd,
-                  const char *     aProvisioningUrl,
-                  const char *     aVendorName,
-                  const char *     aVendorModel,
-                  const char *     aVendorSwVersion,
-                  const char *     aVendorData,
-                  otJoinerCallback aCallback,
-                  void *           aContext);
+    otError Start(const char *           aPSKd,
+                  const char *           aProvisioningUrl,
+                  const char *           aVendorName,
+                  const char *           aVendorModel,
+                  const char *           aVendorSwVersion,
+                  const char *           aVendorData,
+                  const Mac::ExtAddress *aEui64,
+                  otJoinerCallback       aCallback,
+                  void *                 aContext);
 
     /**
      * This method stops the Joiner service.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -485,7 +485,7 @@ exit:
 otError Mle::Discover(const Mac::ChannelMask &aScanChannels,
                       uint16_t                aPanId,
                       bool                    aJoiner,
-                      bool                    aEnableFiltering,
+                      const Mac::ExtAddress * aEui64Filter,
                       DiscoverHandler         aCallback,
                       void *                  aContext)
 {
@@ -498,22 +498,21 @@ otError Mle::Discover(const Mac::ChannelMask &aScanChannels,
 
     VerifyOrExit(!mDiscoverInProgress, error = OT_ERROR_BUSY);
 
-    mDiscoverEnableFiltering = aEnableFiltering;
+    mDiscoverEnableFiltering = (aEui64Filter != NULL);
 
     if (mDiscoverEnableFiltering)
     {
-        Mac::ExtAddress extAddress;
+        Mac::ExtAddress joinerId;
         Crc16           ccitt(Crc16::kCcitt);
         Crc16           ansi(Crc16::kAnsi);
 
-        otPlatRadioGetIeeeEui64(&GetInstance(), extAddress.m8);
-        MeshCoP::ComputeJoinerId(extAddress, extAddress);
+        MeshCoP::ComputeJoinerId(*aEui64Filter, joinerId);
 
         // Compute bloom filter (for steering data)
-        for (size_t i = 0; i < sizeof(extAddress.m8); i++)
+        for (size_t i = 0; i < sizeof(joinerId.m8); i++)
         {
-            ccitt.Update(extAddress.m8[i]);
-            ansi.Update(extAddress.m8[i]);
+            ccitt.Update(joinerId.m8[i]);
+            ansi.Update(joinerId.m8[i]);
         }
 
         mDiscoverCcittIndex = ccitt.Get();

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -542,13 +542,13 @@ public:
     /**
      * This method initiates a Thread Discovery.
      *
-     * @param[in]  aScanChannels          A bit vector indicating which channels to scan.
-     * @param[in]  aPanId                 The PAN ID filter (set to Broadcast PAN to disable filter).
-     * @param[in]  aJoiner                Value of the Joiner Flag in the Discovery Request TLV.
-     * @param[in]  aEnableFiltering       Enable filtering out MLE discovery responses that don't match our factory
-     *                                    assigned EUI64.
-     * @param[in]  aHandler               A pointer to a function that is called on receiving an MLE Discovery Response.
-     * @param[in]  aContext               A pointer to arbitrary context information.
+     * @param[in]  aScanChannels        Channel mask providing channels to scan.
+     * @param[in]  aPanId               The PAN ID filter (set to Broadcast PAN to disable filter).
+     * @param[in]  aJoiner              Value of the Joiner Flag in the Discovery Request TLV.
+     * @param[in]  aEui64Filter         If not NULL, enables filtering of MLE discovery responses not matching the given
+     *                                  EUI64 (in steering data bloom filter). If NULL filtering is disabled.
+     * @param[in]  aHandler             A pointer to a function that is called on receiving an MLE Discovery Response.
+     * @param[in]  aContext             A pointer to arbitrary context information.
      *
      * @retval OT_ERROR_NONE  Successfully started a Thread Discovery.
      * @retval OT_ERROR_BUSY  Thread Discovery is already in progress.
@@ -557,7 +557,7 @@ public:
     otError Discover(const Mac::ChannelMask &aScanChannels,
                      uint16_t                aPanId,
                      bool                    aJoiner,
-                     bool                    aEnableFiltering,
+                     const Mac::ExtAddress * aEui64Filter,
                      DiscoverHandler         aCallback,
                      void *                  aContext);
 

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -1470,14 +1470,15 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_MESHCOP_JOINER_STATE>
 
 template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_MESHCOP_JOINER_COMMISSIONING>(void)
 {
-    otError     error           = OT_ERROR_NONE;
-    bool        action          = false;
-    const char *psk             = NULL;
-    const char *provisioningUrl = NULL;
-    const char *vendorName      = NULL;
-    const char *vendorModel     = NULL;
-    const char *vendorSwVersion = NULL;
-    const char *vendorData      = NULL;
+    otError             error           = OT_ERROR_NONE;
+    bool                action          = false;
+    const char *        psk             = NULL;
+    const char *        provisioningUrl = NULL;
+    const char *        vendorName      = NULL;
+    const char *        vendorModel     = NULL;
+    const char *        vendorSwVersion = NULL;
+    const char *        vendorData      = NULL;
+    const otExtAddress *eui64           = NULL;
 
     SuccessOrExit(error = mDecoder.ReadBool(action));
 
@@ -1516,6 +1517,11 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_MESHCOP_JOINER_COMMIS
         SuccessOrExit(error = mDecoder.ReadUtf8(vendorData));
     }
 
+    if (!mDecoder.IsAllReadInStruct())
+    {
+        SuccessOrExit(error = mDecoder.ReadEui64(eui64));
+    }
+
     // Use OpenThread default values for vendor name, mode, sw version if
     // not specified or an empty string is given.
 
@@ -1534,7 +1540,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_MESHCOP_JOINER_COMMIS
         vendorSwVersion = PACKAGE_VERSION;
     }
 
-    error = otJoinerStart(mInstance, psk, provisioningUrl, vendorName, vendorModel, vendorSwVersion, vendorData, NULL,
+    error = otJoinerStart(mInstance, psk, provisioningUrl, vendorName, vendorModel, vendorSwVersion, vendorData, eui64,
                           &NcpBase::HandleJoinerCallback_Jump, this);
 
 exit:

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -1534,7 +1534,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_MESHCOP_JOINER_COMMIS
         vendorSwVersion = PACKAGE_VERSION;
     }
 
-    error = otJoinerStart(mInstance, psk, provisioningUrl, vendorName, vendorModel, vendorSwVersion, vendorData,
+    error = otJoinerStart(mInstance, psk, provisioningUrl, vendorName, vendorModel, vendorSwVersion, vendorData, NULL,
                           &NcpBase::HandleJoinerCallback_Jump, this);
 
 exit:

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -2649,7 +2649,7 @@ typedef enum
     SPINEL_PROP_MESHCOP_JOINER_STATE = SPINEL_PROP_MESHCOP__BEGIN + 0, ///<[C]
 
     /// Thread Joiner Commissioning command and the parameters
-    /** Format `b` or `bU(UUUUU)` (fields in parenthesis are optional) - Write Only
+    /** Format `b` or `bU(UUUUUE)` (fields in parenthesis are optional) - Write Only
      *
      * This property starts or stops Joiner's commissioning process
      *
@@ -2683,6 +2683,7 @@ typedef enum
      *  `U` : Vendor Model. If not specified or empty string, use OpenThread default (OPENTHREAD_CONFIG_PLATFORM_INFO).
      *  `U` : Vendor Sw Version. If not specified or empty string, use OpenThread default (PACKAGE_VERSION).
      *  `U` : Vendor Data String. Will not be appended if not specified.
+     *  `E` : EUI64 address used to derive Joiner ID. Will use factory-assigned EUI64 (from radio) if not specified.
      *
      */
     SPINEL_PROP_MESHCOP_JOINER_COMMISSIONING = SPINEL_PROP_MESHCOP__BEGIN + 1,


### PR DESCRIPTION
This PR contains 3 related commits. 

---

**[mle] allow specifying the EUI64 for filtering in Mle::Discover()**
    
This commit updates the `Mle::Discover()` API allowing the EUI64
used during steering data bloom filtering to be specified as a
parameter.

----

**[joiner] allow EUI64 address to be specified from Joiner::Start()**
    
This commit extends the `Joiner::Start()` to allow a EUI64 address
to be (optionally) provided as an input parameter which is used to
derive the Joiner Id during the Joiner commissioning process. If a
`NULL` pointer is passed as the EUI64, the factory-assigned address
(from radio platform API `otPlatRadioGetIeeeEui64()`) will be used
instead. This commit also updates the public API `otJoninerStart()`
accordingly.

-----

**[ncp] allow EUI64 to be specified through spinel property**
    
This commit updates `SPINEL_PROP_MESHCOP_JOINER_COMMISSIONING` to
allow EUI64 to be (optionally) specified when Joiner commissioning
is started. The new change keeps the implementation backward
compatible with previous definition.