### PR TITLE
[cli] add 'childip' command to cli for getting ip addresses of MTD children

### DIFF
--- a/examples/drivers/windows/otApi/otApi.cpp
+++ b/examples/drivers/windows/otApi/otApi.cpp
@@ -3089,6 +3089,22 @@ otThreadGetChildInfoByIndex(
 OTAPI
 otError
 OTCALL
+otThreadGetChildNextIp6Address(
+    _In_ otInstance *aInstance,
+    uint8_t aChildIndex,
+    _Inout_ otChildIp6AddressIterator *aIterator,
+    _Out_ otIp6Address *aAddress)
+{
+    if (aInstance == nullptr) return OT_ERROR_INVALID_ARGS;
+    UNREFERENCED_PARAMETER(aChildIndex);
+    UNREFERENCED_PARAMETER(aIterator);
+    UNREFERENCED_PARAMETER(aAddress);
+    return OT_ERROR_NOT_IMPLEMENTED; // TODO
+}
+
+OTAPI
+otError
+OTCALL
 otThreadGetNextNeighborInfo(
     _In_ otInstance *aInstance,
     _Inout_ otNeighborInfoIterator *aIterator,

--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -462,10 +462,10 @@ OTAPI otError OTCALL otThreadGetChildInfoByIndex(otInstance *aInstance, uint8_t 
  * @sa otThreadGetChildInfoByIndex
  *
  */
-otError otThreadGetChildNextIp6Address(otInstance *               aInstance,
-                                       uint8_t                    aChildIndex,
-                                       otChildIp6AddressIterator *aIterator,
-                                       otIp6Address *             aAddress);
+OTAPI otError OTCALL otThreadGetChildNextIp6Address(otInstance *               aInstance,
+                                                    uint8_t                    aChildIndex,
+                                                    otChildIp6AddressIterator *aIterator,
+                                                    otIp6Address *             aAddress);
 
 /**
  * Get the current Router ID Sequence.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -11,6 +11,7 @@ OpenThread test scripts use the CLI to execute test cases.
 * [bufferinfo](#bufferinfo)
 * [channel](#channel)
 * [child](#child-list)
+* [childip](#childip)
 * [childmax](#childmax)
 * [childtimeout](#childtimeout)
 * [coap](#coap-start)
@@ -183,6 +184,16 @@ RSSI: -20
 Done
 ```
 
+### childip
+
+Get the list of IP addresses stored for MTD children.
+
+```bash
+> childip
+3401: fdde:ad00:beef:0:3037:3e03:8c5f:bc0c
+Done
+```
+
 ### childmax
 
 Get the Thread maximum number of allowed children.
@@ -298,7 +309,7 @@ Coap Secure service stopped:  Done
 
 ### coaps set psk \<preSharedKey\> \<keyIdentity\>
 
-Set a pre-shared key with his identifier and the ciphersuite 
+Set a pre-shared key with his identifier and the ciphersuite
 "DTLS_PSK_WITH_AES_128_CCM_8" for the dtls session.
 
 * preSharedKey: The pre-shared key (PSK) for dtls session.
@@ -1315,7 +1326,7 @@ Done
 
 ### networkidtimeout
 
-Get the NETWORK_ID_TIMEOUT parameter used in the Router role.  
+Get the NETWORK_ID_TIMEOUT parameter used in the Router role.
 
 ```bash
 > networkidtimeout
@@ -1325,7 +1336,7 @@ Done
 
 ### networkidtimeout \<timeout\>
 
-Set the NETWORK_ID_TIMEOUT parameter used in the Router role.  
+Set the NETWORK_ID_TIMEOUT parameter used in the Router role.
 
 ```bash
 > networkidtimeout 120
@@ -1334,7 +1345,7 @@ Done
 
 ### networkname
 
-Get the Thread Network Name.  
+Get the Thread Network Name.
 
 ```bash
 > networkname
@@ -1344,7 +1355,7 @@ Done
 
 ### networkname \<name\>
 
-Set the Thread Network Name.  
+Set the Thread Network Name.
 
 ```bash
 > networkname OpenThread

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -195,6 +195,7 @@ private:
     void    ProcessChannel(int argc, char *argv[]);
 #if OPENTHREAD_FTD
     void ProcessChild(int argc, char *argv[]);
+    void ProcessChildIp(int argc, char *argv[]);
     void ProcessChildMax(int argc, char *argv[]);
 #endif
     void ProcessChildTimeout(int argc, char *argv[]);


### PR DESCRIPTION
Personally I find it useful for basic connection testing - eidcache already works for FTD children, but not MTDs.

Not entirely sure how the windows otApi works, but I copied the OT_ERROR_NOT_IMPLEMENTED pattern I saw in other places in the file. Let me know if it would be worth me looking into this in more detail.