### PR TITLE
[posix-app] add option to skip reset RCP

### DIFF
--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -154,7 +154,7 @@ void platformAlarmAdvanceNow(uint64_t aDelta);
 /**
  * This function initializes the radio service used by OpenThread.
  *
- * @note Even @p aReset is false, a reset event is still expected.
+ * @note Even when @p aReset is false, a reset event is still expected.
  *
  * @param[in]  aRadioFile       A pointer to the radio file.
  * @param[in]  aRadioConfig     A pointer to the radio config.

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -154,11 +154,12 @@ void platformAlarmAdvanceNow(uint64_t aDelta);
 /**
  * This function initializes the radio service used by OpenThread.
  *
- * @note Even when @p aReset is false, a reset event is still expected.
+ * @note Even when @p aReset is false, a reset event (i.e. a PROP_LAST_STATUS between
+ * [SPINEL_STATUS_RESET__BEGIN, SPINEL_STATUS_RESET__END]) is still expected from RCP.
  *
  * @param[in]  aRadioFile       A pointer to the radio file.
  * @param[in]  aRadioConfig     A pointer to the radio config.
- * @param[in]  aReset           Whether reset RCP when initializing.
+ * @param[in]  aReset           Whether to reset RCP when initializing.
  *
  */
 void platformRadioInit(const char *aRadioFile, const char *aRadioConfig, bool aReset);

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -154,11 +154,14 @@ void platformAlarmAdvanceNow(uint64_t aDelta);
 /**
  * This function initializes the radio service used by OpenThread.
  *
+ * @note Even @p aReset is false, a reset event is still expected.
+ *
  * @param[in]  aRadioFile       A pointer to the radio file.
  * @param[in]  aRadioConfig     A pointer to the radio config.
+ * @param[in]  aReset           Whether reset RCP when initializing.
  *
  */
-void platformRadioInit(const char *aRadioFile, const char *aRadioConfig);
+void platformRadioInit(const char *aRadioFile, const char *aRadioConfig, bool aReset);
 
 /**
  * This function shuts down the radio service used by OpenThread.

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -185,13 +185,17 @@ RadioSpinel::RadioSpinel(void)
     mVersion[0] = '\0';
 }
 
-void RadioSpinel::Init(const char *aRadioFile, const char *aRadioConfig)
+void RadioSpinel::Init(const char *aRadioFile, const char *aRadioConfig, bool aReset)
 {
     otError error = OT_ERROR_NONE;
 
     SuccessOrExit(error = mHdlcInterface.Init(aRadioFile, aRadioConfig));
 
-    SuccessOrExit(error = SendReset());
+    if (aReset)
+    {
+        SuccessOrExit(error = SendReset());
+    }
+
     SuccessOrExit(error = WaitResponse());
     VerifyOrExit(mIsReady, error = OT_ERROR_FAILED);
 
@@ -1465,9 +1469,9 @@ void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable)
     OT_UNUSED_VARIABLE(aInstance);
 }
 
-void platformRadioInit(const char *aRadioFile, const char *aRadioConfig)
+void platformRadioInit(const char *aRadioFile, const char *aRadioConfig, bool aReset)
 {
-    sRadioSpinel.Init(aRadioFile, aRadioConfig);
+    sRadioSpinel.Init(aRadioFile, aRadioConfig, aReset);
 }
 
 void platformRadioDeinit(void)

--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -56,9 +56,10 @@ public:
      *
      * @param[in]   aRadioFile    The path to either a uart device or an executable.
      * @param[in]   aRadioConfig  Parameters given to the device or executable.
+     * @param[in]   aReset        Whether reset RCP when initializing.
      *
      */
-    void Init(const char *aRadioFile, const char *aRadioConfig);
+    void Init(const char *aRadioFile, const char *aRadioConfig, bool aReset);
 
     /**
      * Deinitialize this radio transceiver.

--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -56,7 +56,7 @@ public:
      *
      * @param[in]   aRadioFile    The path to either a uart device or an executable.
      * @param[in]   aRadioConfig  Parameters given to the device or executable.
-     * @param[in]   aReset        Whether reset RCP when initializing.
+     * @param[in]   aReset        Whether to reset RCP when initializing.
      *
      */
     void Init(const char *aRadioFile, const char *aRadioConfig, bool aReset);

--- a/src/posix/platform/system.c
+++ b/src/posix/platform/system.c
@@ -51,11 +51,10 @@
 
 #include "openthread-system.h"
 
-static const struct option kOptions[] = {{"dry-run", no_argument, NULL, 'n'},
-                                         {"radio-version", no_argument, NULL, 0},
-                                         {"help", no_argument, NULL, 'h'},
-                                         {"time-speed", required_argument, NULL, 's'},
-                                         {0, 0, 0, 0}};
+static const struct option kOptions[] = {
+    {"dry-run", no_argument, NULL, 'n'},          {"no-reset", no_argument, NULL, 0},
+    {"radio-version", no_argument, NULL, 0},      {"help", no_argument, NULL, 'h'},
+    {"time-speed", required_argument, NULL, 's'}, {0, 0, 0, 0}};
 
 uint64_t gNodeId = 0;
 
@@ -66,6 +65,7 @@ static void PrintUsage(const char *aProgramName, FILE *aStream, int aExitCode)
             "    %s [Options] NodeId|Device|Command [DeviceConfig|CommandArgs]\n"
             "Options:\n"
             "    -n  --dry-run               Just verify if arguments is valid and radio spinel is compatible.\n"
+            "        --no-reset              Do not reset RCP on initialization\n"
             "        --radio-version         Print radio firmware version\n"
             "    -s  --time-speed factor     Time speed up factor.\n"
             "    -h  --help                  Display this usage information.\n",
@@ -80,6 +80,7 @@ otInstance *otSysInit(int aArgCount, char *aArgVector[])
     otInstance *instance          = NULL;
     uint32_t    speedUpFactor     = 1;
     bool        isDryRun          = false;
+    bool        reset             = true;
     bool        printRadioVersion = false;
 
     optind = 1;
@@ -119,6 +120,10 @@ otInstance *otSysInit(int aArgCount, char *aArgVector[])
             {
                 printRadioVersion = true;
             }
+            else if (!strcmp(kOptions[index].name, "no-reset"))
+            {
+                reset = false;
+            }
             break;
         case '?':
             PrintUsage(aArgVector[0], stderr, OT_EXIT_INVALID_ARGUMENTS);
@@ -146,7 +151,7 @@ otInstance *otSysInit(int aArgCount, char *aArgVector[])
     otSimInit();
 #endif
     platformAlarmInit(speedUpFactor);
-    platformRadioInit(radioFile, radioConfig);
+    platformRadioInit(radioFile, radioConfig, reset);
     platformRandomInit();
 #if OPENTHREAD_ENABLE_PLATFORM_UDP && OPENTHREAD_ENABLE_PLATFORM_NETIF == 0
     platformUdpInit(getenv("PLATFORM_NETIF"));


### PR DESCRIPTION
This PR adds a option `--no-reset` to OpenThread POSIX app to suppress
sending soft reset command when initializing OpenThread radio on host.
This is for NCP SPI bus scenario, where spi-hdlc-adapter is involved who
will trigger hardware reset at start.