### PR TITLE
[spi-hdlc-adapter] reset NCP/RCP on exit

### DIFF
--- a/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
+++ b/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
@@ -1983,6 +1983,9 @@ int main(int argc, char *argv[])
 bail:
     syslog(LOG_NOTICE, "Shutdown. (sRet = %d)", sRet);
 
+    syslog(LOG_NOTICE, "Reset NCP/RCP");
+    trigger_reset();
+
     if (sRet == EXIT_QUIT)
     {
         sRet = EXIT_SUCCESS;


### PR DESCRIPTION
This PR triggers resetting NCP/RCP on exit, which ensures NCP/RCP get
back to uninitialized state so that they will not respond to 15.4
messages.

Note, host should disable soft reset by passing `--no-reset` for RCP.
Thus OpenThread POSIX app doesn't need to reset RCP when it exits.