### PR TITLE
[mle] maintain best parent candidate during router-only search

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1607,7 +1607,8 @@ void Mle::HandleAttachTimer(void)
         // new parent candidate is compared with the current parent
         // and that it is indeed preferred over the current one.
 
-        if (mParentCandidate.GetState() == Neighbor::kStateParentResponse &&
+        if ((mParentCandidate.GetLinkInfo().GetLinkQuality() == 3 || mAttachState != kAttachStateParentRequestRouter) &&
+            mParentCandidate.GetState() == Neighbor::kStateParentResponse &&
             (mRole != OT_DEVICE_ROLE_CHILD || mReceivedResponseFromParent || mParentRequestMode == kAttachBetter) &&
             SendChildIdRequest() == OT_ERROR_NONE)
         {
@@ -3132,8 +3133,6 @@ otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInf
     }
 
     linkQuality = LinkQualityInfo::ConvertLinkMarginToLinkQuality(linkMargin);
-
-    VerifyOrExit(mAttachState != kAttachStateParentRequestRouter || linkQuality == 3);
 
     // Connectivity
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kConnectivity, sizeof(connectivity), connectivity));

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1606,6 +1606,10 @@ void Mle::HandleAttachTimer(void)
         // to which the device is attached. This ensures that the
         // new parent candidate is compared with the current parent
         // and that it is indeed preferred over the current one.
+        // If we are in kAttachStateParentRequestRouter and cannot
+        // find a parent with best link quality(3), we will keep
+        // the candidate and forward to REED stage to find a better
+        // parent.
 
         if ((mParentCandidate.GetLinkInfo().GetLinkQuality() == 3 || mAttachState != kAttachStateParentRequestRouter) &&
             mParentCandidate.GetState() == Neighbor::kStateParentResponse &&

--- a/src/core/thread/mle_constants.hpp
+++ b/src/core/thread/mle_constants.hpp
@@ -60,6 +60,7 @@ enum
     kThreadVersion                  = 2,     ///< Thread Version
     kUdpPort                        = 19788, ///< MLE UDP Port
     kParentRequestRouterTimeout     = 750,   ///< Router Parent Request timeout
+    kParentRequestDuplicateMargin   = 50,    ///< Margin for duplicate parent request
     kParentRequestReedTimeout       = 1250,  ///< Router and REEDs Parent Request timeout
     kAttachStartJitter              = 50,    ///< Maximum jitter time added to start of attach.
     kAnnounceProcessTimeout         = 250,   ///< Timeout after receiving Announcement before channel/pan-id change

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1649,7 +1649,7 @@ otError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::Messa
         }
 #endif
     }
-    else if (TimerMilli::Elapsed(child->GetLastHeard()) < kParentRequestRouterTimeout)
+    else if (TimerMilli::Elapsed(child->GetLastHeard()) < kParentRequestRouterTimeout - kParentRequestDuplicateMargin)
     {
         ExitNow(error = OT_ERROR_DUPLICATED);
     }


### PR DESCRIPTION
When testing devices in crowded radio environment and with less capable radio functionalities, the filtered parent response will cause the parent request to be sent again but filtered by parent because the parent view the request as duplicated. The devices thus becomes the network leader rather than join the existing partition.

According to the specification, there is no requirement for link quality to be 3 so the filter is removed and the best parent can still be selected in the following comparison.