### PR TITLE
[mle] send shorter "Child ID Request" if full version requires fragmentation

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -393,15 +393,23 @@ exit:
 
 bool Message::IsSubTypeMle(void) const
 {
-    bool rval = false;
+    bool rval;
 
-    if (mBuffer.mHead.mInfo.mSubType == kSubTypeMleAnnounce ||
-        mBuffer.mHead.mInfo.mSubType == kSubTypeMleDiscoverRequest ||
-        mBuffer.mHead.mInfo.mSubType == kSubTypeMleDiscoverResponse ||
-        mBuffer.mHead.mInfo.mSubType == kSubTypeMleChildUpdateRequest ||
-        mBuffer.mHead.mInfo.mSubType == kSubTypeMleDataResponse || mBuffer.mHead.mInfo.mSubType == kSubTypeMleGeneral)
+    switch (mBuffer.mHead.mInfo.mSubType)
     {
+    case kSubTypeMleGeneral:
+    case kSubTypeMleAnnounce:
+    case kSubTypeMleDiscoverRequest:
+    case kSubTypeMleDiscoverResponse:
+    case kSubTypeMleChildUpdateRequest:
+    case kSubTypeMleDataResponse:
+    case kSubTypeMleChildIdRequest:
         rval = true;
+        break;
+
+    default:
+        rval = false;
+        break;
     }
 
     return rval;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -218,16 +218,17 @@ public:
 
     enum
     {
-        kSubTypeNone                   = 0, ///< None
-        kSubTypeMleAnnounce            = 1, ///< MLE Announce
-        kSubTypeMleDiscoverRequest     = 2, ///< MLE Discover Request
-        kSubTypeMleDiscoverResponse    = 3, ///< MLE Discover Response
-        kSubTypeJoinerEntrust          = 4, ///< Joiner Entrust
-        kSubTypeMplRetransmission      = 5, ///< MPL next retransmission message
-        kSubTypeMleGeneral             = 6, ///< General MLE
-        kSubTypeJoinerFinalizeResponse = 7, ///< Joiner Finalize Response
-        kSubTypeMleChildUpdateRequest  = 8, ///< MLE Child Update Request
-        kSubTypeMleDataResponse        = 9, ///< MLE Data Response
+        kSubTypeNone                   = 0,  ///< None
+        kSubTypeMleAnnounce            = 1,  ///< MLE Announce
+        kSubTypeMleDiscoverRequest     = 2,  ///< MLE Discover Request
+        kSubTypeMleDiscoverResponse    = 3,  ///< MLE Discover Response
+        kSubTypeJoinerEntrust          = 4,  ///< Joiner Entrust
+        kSubTypeMplRetransmission      = 5,  ///< MPL next retransmission message
+        kSubTypeMleGeneral             = 6,  ///< General MLE
+        kSubTypeJoinerFinalizeResponse = 7,  ///< Joiner Finalize Response
+        kSubTypeMleChildUpdateRequest  = 8,  ///< MLE Child Update Request
+        kSubTypeMleDataResponse        = 9,  ///< MLE Data Response
+        kSubTypeMleChildIdRequest      = 10, ///< MLE Child ID Request
     };
 
     enum

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -568,6 +568,15 @@ otError MeshForwarder::HandleFrameRequest(Mac::Frame &aFrame)
         {
             // Enable security and try again.
             mSendMessage->SetLinkSecurityEnabled(true);
+
+            if (mSendMessage->GetSubType() == Message::kSubTypeMleChildIdRequest)
+            {
+                otLogNoteMac("Child ID Request requires fragmentation, aborting tx");
+                mMessageNextOffset = mSendMessage->GetLength();
+                error              = OT_ERROR_ABORT;
+                ExitNow();
+            }
+
             error = SendFragment(*mSendMessage, aFrame);
         }
 
@@ -1136,6 +1145,18 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, otError aError)
 
     if (mSendMessage->GetDirectTransmission() == false && mSendMessage->IsChildPending() == false)
     {
+        if (mSendMessage->GetSubType() == Message::kSubTypeMleChildIdRequest && mSendMessage->IsLinkSecurityEnabled())
+        {
+            // If the Child ID Request requires fragmentation and therefore
+            // link layer security, the frame transmission will be aborted.
+            // When the message is being freed, we signal to MLE to prepare a
+            // shorter Child ID Request message (by only including mesh-local
+            // address in the Address Registration TLV).
+
+            otLogInfoMac("Requesting shorter `Child ID Request`");
+            Get<Mle::Mle>().RequestShorterChildIdRequest();
+        }
+
         mSendQueue.Dequeue(*mSendMessage);
         mSendMessage->Free();
         mSendMessage       = NULL;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1072,6 +1072,16 @@ public:
      */
     void RegisterParentResponseStatsCallback(otThreadParentResponseCallback aCallback, void *aContext);
 
+    /**
+     * This method requests MLE layer to prepare and send a shorter version of Child ID Request message by only
+     * including the mesh-local IPv6 address in the Address Registration TLV.
+     *
+     * This method should be called when a previous MLE Child ID Request message would require fragmentation at 6LoWPAN
+     * layer.
+     *
+     */
+    void RequestShorterChildIdRequest(void);
+
 protected:
     /**
      * States during attach (when searching for a parent).
@@ -1103,6 +1113,17 @@ protected:
     enum
     {
         kMleMaxResponseDelay = 1000u, ///< Maximum delay before responding to a multicast request.
+    };
+
+    /**
+     * This enumeration type is used in `AppendAddressRegistration()` to determine which addresses to include in the
+     * appended Address Registration TLV.
+     *
+     */
+    enum AddressRegistrationMode
+    {
+        kAppendAllAddresses,  ///< Append all addresses (unicast/multicast) in Address Registration TLV.
+        kAppendMeshLocalOnly, ///< Only append the Mesh Local (ML-EID) address in Address Registration TLV.
     };
 
     /**
@@ -1323,12 +1344,13 @@ protected:
      * This method appends an Address Registration TLV to a message.
      *
      * @param[in]  aMessage  A reference to the message.
+     * @param[in]  aMode     Determines which addresses to include in the TLV (see `AddressRegistrationMode`).
      *
      * @retval OT_ERROR_NONE     Successfully appended the Address Registration TLV.
      * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Address Registration TLV.
      *
      */
-    otError AppendAddressRegistration(Message &aMessage);
+    otError AppendAddressRegistration(Message &aMessage, AddressRegistrationMode aMode = kAppendAllAddresses);
 
 #if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
     /**
@@ -1754,6 +1776,8 @@ private:
     ChildUpdateRequestState mChildUpdateRequestState;
     uint8_t                 mDataRequestAttempts;
     DataRequestState        mDataRequestState;
+
+    AddressRegistrationMode mAddressRegistrationMode;
 
     uint8_t       mParentLinkMargin;
     bool          mParentIsSingleton;

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2089,6 +2089,7 @@ otError MleRouter::HandleChildIdRequest(const Message &         aMessage,
 
     // Remove existing MLE messages
     Get<MeshForwarder>().RemoveMessages(*child, Message::kSubTypeMleGeneral);
+    Get<MeshForwarder>().RemoveMessages(*child, Message::kSubTypeMleChildIdRequest);
     Get<MeshForwarder>().RemoveMessages(*child, Message::kSubTypeMleChildUpdateRequest);
     Get<MeshForwarder>().RemoveMessages(*child, Message::kSubTypeMleDataResponse);
 

--- a/tests/toranj/start.sh
+++ b/tests/toranj/start.sh
@@ -134,6 +134,7 @@ run test-028-router-leader-reset-recovery.py
 run test-029-data-poll-interval.py
 run test-030-slaac-address-ncp.py
 run test-031-meshcop-joiner-commissioner.py
+run test-032-child-attach-with-multiple-ip-addresses.py
 run test-100-mcu-power-state.py
 run test-600-channel-manager-properties.py
 run test-601-channel-manager-channel-change.py

--- a/tests/toranj/test-032-child-attach-with-multiple-ip-addresses.py
+++ b/tests/toranj/test-032-child-attach-with-multiple-ip-addresses.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+#
+#  Copyright (c) 2019, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+
+import time
+import wpan
+from wpan import verify
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Test description:
+#
+# This test covers the situation for SED child (re)attaching to a parent with multiple IPv6 addresses present on the
+# child.
+
+test_name = __file__[:-3] if __file__.endswith('.py') else __file__
+print '-' * 120
+print 'Starting \'{}\''.format(test_name)
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Utility functions
+
+def verify_address(node_list, prefix):
+    """
+    This function verifies that all nodes in the `node_list` contain an IPv6 address with the given `prefix`.
+    """
+    for node in node_list:
+        all_addrs = wpan.parse_list(node.get(wpan.WPAN_IP6_ALL_ADDRESSES))
+        verify(any([addr.startswith(prefix[:-1]) for addr in all_addrs]))
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Creating `wpan.Nodes` instances
+
+speedup = 4
+wpan.Node.set_time_speedup_factor(speedup)
+
+parent = wpan.Node()
+child = wpan.Node()
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Init all nodes
+
+wpan.Node.init_all_nodes()
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Build network topology
+
+parent.form('addr-test')
+child.join_node(parent, node_type=wpan.JOIN_TYPE_SLEEPY_END_DEVICE)
+child.set(wpan.WPAN_POLL_INTERVAL, '200')
+
+all_nodes = [parent, child]
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Test implementation
+
+WAIT_TIME = 5
+CHILD_SUPERVISION_CHECK_TIMEOUT = 1
+
+prefix1 = 'fd00:1::'
+prefix2 = 'fd00:2::'
+prefix3 = 'fd00:3::'
+prefix4 = 'fd00:4::'
+
+# Add 4 prefixes (all with SLAAC bit set).
+parent.add_prefix(prefix1, on_mesh=True, slaac=True, configure=True)
+parent.add_prefix(prefix2, on_mesh=True, slaac=True, configure=True)
+parent.add_prefix(prefix3, on_mesh=True, slaac=True, configure=True)
+parent.add_prefix(prefix4, on_mesh=True, slaac=True, configure=True)
+
+# Verify that the sleepy child gets all 4 SLAAC addresses.
+def check_addresses_on_child():
+    verify_address([child], prefix1)
+    verify_address([child], prefix2)
+    verify_address([child], prefix3)
+    verify_address([child], prefix4)
+
+wpan.verify_within(check_addresses_on_child, WAIT_TIME)
+
+# Enable white-listing on parent.
+parent.set(wpan.WPAN_MAC_WHITELIST_ENABLED, '1')
+
+# Enable supervision check on child, this ensures that child is detached soon.
+child.set(wpan.WPAN_CHILD_SUPERVISION_CHECK_TIMEOUT, str(CHILD_SUPERVISION_CHECK_TIMEOUT))
+
+# Wait for child to get detached.
+def check_child_is_detached():
+    verify(not child.is_associated())
+
+wpan.verify_within(check_child_is_detached, WAIT_TIME)
+
+# Now reset parent and wait for it to be associated.
+parent.reset()
+
+def check_parent_is_associated():
+    verify(parent.is_associated())
+
+wpan.verify_within(check_parent_is_associated, WAIT_TIME)
+
+# Now verify that child is indeed getting attached back.
+def check_child_is_associated():
+    verify(child.is_associated())
+
+wpan.verify_within(check_child_is_associated, WAIT_TIME)
+
+# Any finally check that we see all the child addresses on the parent's child table.
+def check_child_addressses_on_parent():
+    child_addrs = parent.get(wpan.WPAN_THREAD_CHILD_TABLE_ADDRESSES)
+    verify(child_addrs.find(prefix1) > 0)
+    verify(child_addrs.find(prefix2) > 0)
+    verify(child_addrs.find(prefix3) > 0)
+    verify(child_addrs.find(prefix4) > 0)
+
+wpan.verify_within(check_child_addressses_on_parent, WAIT_TIME)
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Test finished
+
+wpan.Node.finalize_all_nodes()
+
+print '\'{}\' passed.'.format(test_name)


### PR DESCRIPTION
This commit addresses the attach failure issue by an SED child trying
to register multiple IPv6 addresses in MLE "Child ID Request" message.
If the MLE "Child ID Request" requires fragmentation at 6LoWPAN layer,
this commit changes the code to abort the transmission and drop the
message and instead signal to MLE layer to prepare a shorter "Child ID
Request" by only including the mesh-local address in the `Address
Registration TLV`. After the child attaches, the new code will ensure
to trigger a "Child Update Request" exchange for the child to register
the remaining IPv6 addresses with its parents.

---------------
This PR also includes a separate commit adding a test-case covering this scenario.

[toranj] adding test-case for a SED child attaching with multiple IP addresses

This should address issue https://github.com/openthread/openthread/issues/3807.