### PR TITLE
[nrf528xx] use Nordic's OUI in factory assigned IEEE EUI-64

### DIFF
--- a/examples/platforms/nrf52811/README.md
+++ b/examples/platforms/nrf52811/README.md
@@ -100,6 +100,20 @@ The default SPI Slave pin configuration for nRF52811 is defined in `examples/pla
 
 [spi-hdlc-adapter]: https://github.com/openthread/openthread/tree/master/tools/spi-hdlc-adapter
 
+### IEEE EUI-64 address
+
+When the Thread device is configured to obtain the Thread Network security credentials with either Thread Commissioning or an out-of-band method, the extended MAC address should be constructed out of the globally unique IEEE EUI-64.
+
+The IEEE EUI-64 address consists of two parts:
+ - 24-bits of MA-L (MAC Address Block Large), formerly called OUI (Organizationally Unique Identifier)
+ - 40-bits device unique identifier
+
+By default, the device uses Nordic Semiconductor's MA-L (f4-ce-36). You can modify it by overwriting the `OPENTHREAD_CONFIG_STACK_VENDOR_OUI` define, located in the `openthread-core-nrf52811-config.h` file. This value must be publicly registered by the IEEE Registration Authority.
+
+You can also provide the full IEEE EUI-64 address by providing a custom `otPlatRadioGetIeeeEui64` function. To do this, define the flag `OPENTHREAD_CONFIG_ENABLE_PLATFORM_EUI64_CUSTOM_SOURCE`.
+
+After the Thread Network security credentials have been successfully obtained, the device uses randomly generated extended MAC address.
+
 ## Flashing binaries
 
 Once the examples and libraries are built, flash the compiled binaries onto nRF52811

--- a/examples/platforms/nrf52811/openthread-core-nrf52811-config.h
+++ b/examples/platforms/nrf52811/openthread-core-nrf52811-config.h
@@ -61,6 +61,16 @@
 #define OPENTHREAD_CONFIG_PLATFORM_INFO "NRF52811"
 
 /**
+ * @def OPENTHREAD_CONFIG_STACK_VENDOR_OUI
+ *
+ * The Organizationally Unique Identifier for the vendor.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_STACK_VENDOR_OUI
+#define OPENTHREAD_CONFIG_STACK_VENDOR_OUI 0xf4ce36
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS
  *
  * The number of message buffers in the buffer pool.

--- a/examples/platforms/nrf52811/radio.c
+++ b/examples/platforms/nrf52811/radio.c
@@ -183,10 +183,16 @@ void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeeeEui64)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    uint64_t factoryAddress = (uint64_t)NRF_FICR->DEVICEID[0] << 32;
-    factoryAddress |= NRF_FICR->DEVICEID[1];
+    uint32_t index = 0;
 
-    memcpy(aIeeeEui64, &factoryAddress, sizeof(factoryAddress));
+    // Set the MAC Address Block Larger (MA-L) formerly called OUI.
+    aIeeeEui64[index++] = (OPENTHREAD_CONFIG_STACK_VENDOR_OUI >> 16) & 0xff;
+    aIeeeEui64[index++] = (OPENTHREAD_CONFIG_STACK_VENDOR_OUI >> 8) & 0xff;
+    aIeeeEui64[index++] = OPENTHREAD_CONFIG_STACK_VENDOR_OUI & 0xff;
+
+    // Use device identifier assigned during the production.
+    uint64_t factoryAddress = (uint64_t)NRF_FICR->DEVICEID[0] << 32 | NRF_FICR->DEVICEID[1];
+    memcpy(aIeeeEui64 + index, &factoryAddress, sizeof(factoryAddress) - index);
 }
 #endif // OPENTHREAD_CONFIG_ENABLE_PLATFORM_EUI64_CUSTOM_SOURCE
 

--- a/examples/platforms/nrf52840/README.md
+++ b/examples/platforms/nrf52840/README.md
@@ -121,6 +121,20 @@ By default, mbedTLS library is built with support for CryptoCell 310 hardware ac
 $ make -f examples/Makefile-nrf52840 DISABLE_CC310=1
 ```
 
+### IEEE EUI-64 address
+
+When the Thread device is configured to obtain the Thread Network security credentials with either Thread Commissioning or an out-of-band method, the extended MAC address should be constructed out of the globally unique IEEE EUI-64.
+
+The IEEE EUI-64 address consists of two parts:
+ - 24-bits of MA-L (MAC Address Block Large), formerly called OUI (Organizationally Unique Identifier)
+ - 40-bits device unique identifier
+
+By default, the device uses Nordic Semiconductor's MA-L (f4-ce-36). You can modify it by overwriting the `OPENTHREAD_CONFIG_STACK_VENDOR_OUI` define, located in the `openthread-core-nrf52840-config.h` file. This value must be publicly registered by the IEEE Registration Authority.
+
+You can also provide the full IEEE EUI-64 address by providing a custom `otPlatRadioGetIeeeEui64` function. To do this, define the flag `OPENTHREAD_CONFIG_ENABLE_PLATFORM_EUI64_CUSTOM_SOURCE`.
+
+After the Thread Network security credentials have been successfully obtained, the device uses randomly generated extended MAC address.
+
 ## Flashing the binaries
 
 Flash the compiled binaries onto nRF52840 using `nrfjprog` which is

--- a/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
+++ b/examples/platforms/nrf52840/openthread-core-nrf52840-config.h
@@ -63,6 +63,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_STACK_VENDOR_OUI
+ *
+ * The Organizationally Unique Identifier for the vendor.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_STACK_VENDOR_OUI
+#define OPENTHREAD_CONFIG_STACK_VENDOR_OUI 0xf4ce36
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_MAX_CHILDREN
  *
  * The maximum number of children.

--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -183,10 +183,16 @@ void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeeeEui64)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    uint64_t factoryAddress = (uint64_t)NRF_FICR->DEVICEID[0] << 32;
-    factoryAddress |= NRF_FICR->DEVICEID[1];
+    uint32_t index = 0;
 
-    memcpy(aIeeeEui64, &factoryAddress, sizeof(factoryAddress));
+    // Set the MAC Address Block Larger (MA-L) formerly called OUI.
+    aIeeeEui64[index++] = (OPENTHREAD_CONFIG_STACK_VENDOR_OUI >> 16) & 0xff;
+    aIeeeEui64[index++] = (OPENTHREAD_CONFIG_STACK_VENDOR_OUI >> 8) & 0xff;
+    aIeeeEui64[index++] = OPENTHREAD_CONFIG_STACK_VENDOR_OUI & 0xff;
+
+    // Use device identifier assigned during the production.
+    uint64_t factoryAddress = (uint64_t)NRF_FICR->DEVICEID[0] << 32 | NRF_FICR->DEVICEID[1];
+    memcpy(aIeeeEui64 + index, &factoryAddress, sizeof(factoryAddress) - index);
 }
 #endif // OPENTHREAD_CONFIG_ENABLE_PLATFORM_EUI64_CUSTOM_SOURCE
 


### PR DESCRIPTION
This PR utilizes Nordic's MA-L (formerly called OUI).

It also addresses potential warning in wpantund due to M bit being set.
https://groups.google.com/forum/#!topic/openthread-users/tFcfhqjJiDc