### PR TITLE
[android] disable some optional features

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -42,11 +42,24 @@ OPENTHREAD_COMMON_FLAGS                                          := \
     -DPACKAGE_URL=\"http://github.com/openthread/openthread\"       \
     $(NULL)
 
+# Enable required features for on-device tests.
 ifeq ($(TARGET_BUILD_VARIANT),eng)
 OPENTHREAD_COMMON_FLAGS                                          += \
-    -DOPENTHREAD_ENABLE_CERT_LOG=1                                  \
     -DOPENTHREAD_ENABLE_DIAG=1                                      \
     -DOPENTHREAD_ENABLE_MAC_FILTER=1                                \
+    $(NULL)
+endif
+
+# Enable all optional features for CI tests.
+ifeq ($(TARGET_PRODUCT),generic)
+OPENTHREAD_COMMON_FLAGS                                          += \
+    -DOPENTHREAD_ENABLE_APPLICATION_COAP=1                          \
+    -DOPENTHREAD_ENABLE_CERT_LOG=1                                  \
+    -DOPENTHREAD_ENABLE_COMMISSIONER=1                              \
+    -DOPENTHREAD_ENABLE_DHCP6_CLIENT=1                              \
+    -DOPENTHREAD_ENABLE_DHCP6_SERVER=1                              \
+    -DOPENTHREAD_ENABLE_DNS_CLIENT=1                                \
+    -DOPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC=1                    \
     $(NULL)
 endif
 

--- a/Android.mk
+++ b/Android.mk
@@ -42,6 +42,14 @@ OPENTHREAD_COMMON_FLAGS                                          := \
     -DPACKAGE_URL=\"http://github.com/openthread/openthread\"       \
     $(NULL)
 
+ifeq ($(TARGET_BUILD_VARIANT),eng)
+OPENTHREAD_COMMON_FLAGS                                          += \
+    -DOPENTHREAD_ENABLE_CERT_LOG=1                                  \
+    -DOPENTHREAD_ENABLE_DIAG=1                                      \
+    -DOPENTHREAD_ENABLE_MAC_FILTER=1                                \
+    $(NULL)
+endif
+
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := spi-hdlc-adapter
@@ -68,14 +76,12 @@ LOCAL_C_INCLUDES                                         := \
     $(NULL)
 
 LOCAL_CFLAGS                                                                := \
-    -D_GNU_SOURCE                                                              \
     -DMBEDTLS_CONFIG_FILE=\"mbedtls-config.h\"                                 \
     -DOPENTHREAD_CONFIG_FILE=\<openthread-config-android.h\>                   \
     $(OPENTHREAD_COMMON_FLAGS)                                                 \
     -DOPENTHREAD_CONFIG_POSIX_APP_ENABLE_PTY_DEVICE=1                          \
     -DOPENTHREAD_FTD=1                                                         \
     -DOPENTHREAD_POSIX=1                                                       \
-    -DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"openthread-core-posix-config.h\"   \
     -DSPINEL_PLATFORM_HEADER=\"spinel_platform.h\"                             \
     $(NULL)
 
@@ -242,6 +248,12 @@ LOCAL_SRC_FILES                                          := \
 
 include $(OT_EXTRA_BUILD_CONFIG)
 
+ifeq ($(filter -DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=%,$(LOCAL_CFLAGS)),)
+LOCAL_CFLAGS                                                                += \
+    -DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"openthread-core-posix-config.h\"   \
+    $(NULL)
+endif
+
 include $(BUILD_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
@@ -260,7 +272,6 @@ LOCAL_C_INCLUDES                                         := \
     $(NULL)
 
 LOCAL_CFLAGS                                                                := \
-    -D_GNU_SOURCE                                                              \
     -DMBEDTLS_CONFIG_FILE=\"mbedtls-config.h\"                                 \
     -DOPENTHREAD_CONFIG_FILE=\<openthread-config-android.h\>                   \
     $(OPENTHREAD_COMMON_FLAGS)                                                 \
@@ -269,7 +280,6 @@ LOCAL_CFLAGS                                                                := \
     -DOPENTHREAD_FTD=1                                                         \
     -DOPENTHREAD_POSIX=1                                                       \
     -DOPENTHREAD_POSIX_APP_TYPE=2                                              \
-    -DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"openthread-core-posix-config.h\"   \
     -DSPINEL_PLATFORM_HEADER=\"spinel_platform.h\"                             \
     $(NULL)
 
@@ -293,6 +303,12 @@ LOCAL_SRC_FILES                            := \
 
 include $(OT_EXTRA_BUILD_CONFIG)
 
+ifeq ($(filter -DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=%,$(LOCAL_CFLAGS)),)
+LOCAL_CFLAGS                                                                += \
+    -DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"openthread-core-posix-config.h\"   \
+    $(NULL)
+endif
+
 LOCAL_STATIC_LIBRARIES = ot-core
 include $(BUILD_EXECUTABLE)
 
@@ -312,7 +328,6 @@ LOCAL_C_INCLUDES                                         := \
     $(NULL)
 
 LOCAL_CFLAGS                                                                := \
-    -D_GNU_SOURCE                                                              \
     -DMBEDTLS_CONFIG_FILE=\"mbedtls-config.h\"                                 \
     -DOPENTHREAD_CONFIG_FILE=\<openthread-config-android.h\>                   \
     $(OPENTHREAD_COMMON_FLAGS)                                                 \
@@ -320,7 +335,6 @@ LOCAL_CFLAGS                                                                := \
     -DOPENTHREAD_FTD=1                                                         \
     -DOPENTHREAD_POSIX=1                                                       \
     -DOPENTHREAD_POSIX_APP_TYPE=1                                              \
-    -DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"openthread-core-posix-config.h\"   \
     -DSPINEL_PLATFORM_HEADER=\"spinel_platform.h\"                             \
     $(NULL)
 
@@ -343,6 +357,12 @@ LOCAL_SRC_FILES                            := \
     $(NULL)
 
 include $(OT_EXTRA_BUILD_CONFIG)
+
+ifeq ($(filter -DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=%,$(LOCAL_CFLAGS)),)
+LOCAL_CFLAGS                                                                += \
+    -DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"openthread-core-posix-config.h\"   \
+    $(NULL)
+endif
 
 LOCAL_STATIC_LIBRARIES = ot-core
 include $(BUILD_EXECUTABLE)

--- a/include/openthread-config-android.h
+++ b/include/openthread-config-android.h
@@ -26,17 +26,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Define to 1 if you want to enable CoAP to an application. */
-#define OPENTHREAD_ENABLE_APPLICATION_COAP 0
-
 /* Define to 1 to enable the border agent feature. */
 #define OPENTHREAD_ENABLE_BORDER_AGENT 1
 
 /* Define to 1 if you want to enable Border Router */
 #define OPENTHREAD_ENABLE_BORDER_ROUTER 1
-
-/* Define to 1 if you want to enable log for certification test */
-#define OPENTHREAD_ENABLE_CERT_LOG 1
 
 /* Define to 1 if you want to enable channel manager feature */
 #define OPENTHREAD_ENABLE_CHANNEL_MANAGER 0
@@ -46,21 +40,6 @@
 
 /* Define to 1 if you want to use child supervision feature */
 #define OPENTHREAD_ENABLE_CHILD_SUPERVISION 1
-
-/* Define to 1 to enable the commissioner role. */
-#define OPENTHREAD_ENABLE_COMMISSIONER 1
-
-/* Define to 1 if you want to enable DHCPv6 Client */
-#define OPENTHREAD_ENABLE_DHCP6_CLIENT 1
-
-/* Define to 1 if you want to enable DHCPv6 Server */
-#define OPENTHREAD_ENABLE_DHCP6_SERVER 1
-
-/* Define to 1 if you want to use diagnostics module */
-#define OPENTHREAD_ENABLE_DIAG 1
-
-/* Define to 1 if you want to enable DNS Client */
-#define OPENTHREAD_ENABLE_DNS_CLIENT 1
 
 /* Define to 1 to enable dtls support. */
 #define OPENTHREAD_ENABLE_DTLS 1
@@ -74,33 +53,11 @@
 /* Define to 1 if you want to use legacy network support */
 #define OPENTHREAD_ENABLE_LEGACY 1
 
-/* Define to 1 if you want to use MAC filter feature */
-#define OPENTHREAD_ENABLE_MAC_FILTER 1
-
-/* Define to 1 to enable network diagnostic for MTD. */
-#define OPENTHREAD_ENABLE_MTD_NETWORK_DIAGNOSTIC 0
-
-/* Define to 1 if you want to enable support for multiple OpenThread
-   instances. */
-#define OPENTHREAD_ENABLE_MULTIPLE_INSTANCES 0
-
-/* Define to 1 to enable the NCP SPI interface. */
-#define OPENTHREAD_ENABLE_NCP_SPI 0
-
-/* Define to 1 if using NCP Spinel Encrypter */
-#define OPENTHREAD_ENABLE_NCP_SPINEL_ENCRYPTER 0
-
 /* Define to 1 to enable the NCP UART interface. */
 #define OPENTHREAD_ENABLE_NCP_UART 1
 
-/* Define to 1 if using NCP vendor hook */
-#define OPENTHREAD_ENABLE_NCP_VENDOR_HOOK 0
-
 /* Define to 1 to build posix application. */
 #define OPENTHREAD_PLATFORM_POSIX_APP 1
-
-/* Define to 1 if you want to enable raw link-layer API */
-#define OPENTHREAD_ENABLE_RAW_LINK_API 0
 
 /* Define to 1 if you want to enable Service */
 #define OPENTHREAD_ENABLE_SERVICE 1


### PR DESCRIPTION
This PR remove unnecessary features of OpenThread on Android platform.
This PR also removes features disabled in openthread-config-android.h so
that these definitions can be overrided in Android.mk without warning.