### PR TITLE
[udp] expose an API to send UDP datagram

### DIFF
--- a/include/openthread/udp.h
+++ b/include/openthread/udp.h
@@ -98,7 +98,7 @@ otError otUdpAddReceiver(otInstance *aInstance, otUdpReceiver *aUdpReceiver);
 otError otUdpRemoveReceiver(otInstance *aInstance, otUdpReceiver *aUdpReceiver);
 
 /**
- * This function sends a raw UDP message.
+ * This function sends a UDP message without socket.
  *
  * @param[in]  aInstance     A pointer to an OpenThread instance.
  * @param[in]  aMessage      A pointer to a message without UDP header.

--- a/include/openthread/udp.h
+++ b/include/openthread/udp.h
@@ -98,6 +98,19 @@ otError otUdpAddReceiver(otInstance *aInstance, otUdpReceiver *aUdpReceiver);
 otError otUdpRemoveReceiver(otInstance *aInstance, otUdpReceiver *aUdpReceiver);
 
 /**
+ * This function sends a raw UDP message.
+ *
+ * @param[in]  aInstance     A pointer to an OpenThread instance.
+ * @param[in]  aMessage      A pointer to a message without UDP header.
+ * @param[in]  aMessageInfo  A pointer to a message info associated with @p aMessage.
+ *
+ * @retval OT_ERROR_NONE     Successfully enqueued the message into an output interface.
+ * @retval OT_ERROR_NO_BUFS  Insufficient available buffer to add the IPv6 headers.
+ *
+ */
+otError otUdpSendDatagram(otInstance *aInstance, otMessage *aMessage, otMessageInfo *aMessageInfo);
+
+/**
  * This callback allows OpenThread to inform the application of a received UDP message.
  *
  */

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -150,3 +150,11 @@ otError otUdpRemoveReceiver(otInstance *aInstance, otUdpReceiver *aUdpReceiver)
 
     return instance.Get<Ip6::Udp>().RemoveReceiver(*static_cast<Ip6::UdpReceiver *>(aUdpReceiver));
 }
+
+otError otUdpSendDatagram(otInstance *aInstance, otMessage *aMessage, otMessageInfo *aMessageInfo)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.Get<Ip6::Udp>().SendDatagram(*static_cast<ot::Message *>(aMessage),
+                                                 *static_cast<Ip6::MessageInfo *>(aMessageInfo), Ip6::kProtoUdp);
+}


### PR DESCRIPTION
This PR exposes an API to send UDP datagram, this is usefully when the
udp receiver handler needs to send messages.