### PR TITLE
[nrf528xx] fix undefined behavior warning in IAR

### DIFF
--- a/examples/platforms/nrf52811/README.md
+++ b/examples/platforms/nrf52811/README.md
@@ -105,8 +105,8 @@ The default SPI Slave pin configuration for nRF52811 is defined in `examples/pla
 When the Thread device is configured to obtain the Thread Network security credentials with either Thread Commissioning or an out-of-band method, the extended MAC address should be constructed out of the globally unique IEEE EUI-64.
 
 The IEEE EUI-64 address consists of two parts:
- - 24-bits of MA-L (MAC Address Block Large), formerly called OUI (Organizationally Unique Identifier)
- - 40-bits device unique identifier
+ - 24 bits of MA-L (MAC Address Block Large), formerly called OUI (Organizationally Unique Identifier)
+ - 40-bit device unique identifier
 
 By default, the device uses Nordic Semiconductor's MA-L (f4-ce-36). You can modify it by overwriting the `OPENTHREAD_CONFIG_STACK_VENDOR_OUI` define, located in the `openthread-core-nrf52811-config.h` file. This value must be publicly registered by the IEEE Registration Authority.
 

--- a/examples/platforms/nrf52811/radio.c
+++ b/examples/platforms/nrf52811/radio.c
@@ -183,6 +183,7 @@ void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeeeEui64)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
+    uint64_t factoryAddress;
     uint32_t index = 0;
 
     // Set the MAC Address Block Larger (MA-L) formerly called OUI.
@@ -191,7 +192,8 @@ void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeeeEui64)
     aIeeeEui64[index++] = OPENTHREAD_CONFIG_STACK_VENDOR_OUI & 0xff;
 
     // Use device identifier assigned during the production.
-    uint64_t factoryAddress = (uint64_t)NRF_FICR->DEVICEID[0] << 32 | NRF_FICR->DEVICEID[1];
+    factoryAddress = (uint64_t)NRF_FICR->DEVICEID[0] << 32;
+    factoryAddress |= NRF_FICR->DEVICEID[1];
     memcpy(aIeeeEui64 + index, &factoryAddress, sizeof(factoryAddress) - index);
 }
 #endif // OPENTHREAD_CONFIG_ENABLE_PLATFORM_EUI64_CUSTOM_SOURCE

--- a/examples/platforms/nrf52840/README.md
+++ b/examples/platforms/nrf52840/README.md
@@ -126,8 +126,8 @@ $ make -f examples/Makefile-nrf52840 DISABLE_CC310=1
 When the Thread device is configured to obtain the Thread Network security credentials with either Thread Commissioning or an out-of-band method, the extended MAC address should be constructed out of the globally unique IEEE EUI-64.
 
 The IEEE EUI-64 address consists of two parts:
- - 24-bits of MA-L (MAC Address Block Large), formerly called OUI (Organizationally Unique Identifier)
- - 40-bits device unique identifier
+ - 24 bits of MA-L (MAC Address Block Large), formerly called OUI (Organizationally Unique Identifier)
+ - 40-bit device unique identifier
 
 By default, the device uses Nordic Semiconductor's MA-L (f4-ce-36). You can modify it by overwriting the `OPENTHREAD_CONFIG_STACK_VENDOR_OUI` define, located in the `openthread-core-nrf52840-config.h` file. This value must be publicly registered by the IEEE Registration Authority.
 

--- a/examples/platforms/nrf52840/radio.c
+++ b/examples/platforms/nrf52840/radio.c
@@ -183,6 +183,7 @@ void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeeeEui64)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
+    uint64_t factoryAddress;
     uint32_t index = 0;
 
     // Set the MAC Address Block Larger (MA-L) formerly called OUI.
@@ -191,7 +192,8 @@ void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeeeEui64)
     aIeeeEui64[index++] = OPENTHREAD_CONFIG_STACK_VENDOR_OUI & 0xff;
 
     // Use device identifier assigned during the production.
-    uint64_t factoryAddress = (uint64_t)NRF_FICR->DEVICEID[0] << 32 | NRF_FICR->DEVICEID[1];
+    factoryAddress = (uint64_t)NRF_FICR->DEVICEID[0] << 32;
+    factoryAddress |= NRF_FICR->DEVICEID[1];
     memcpy(aIeeeEui64 + index, &factoryAddress, sizeof(factoryAddress) - index);
 }
 #endif // OPENTHREAD_CONFIG_ENABLE_PLATFORM_EUI64_CUSTOM_SOURCE


### PR DESCRIPTION
FYI.. This PR fixes IAR warning: `undefined behavior: the order of volatile accesses is undefined in this statement`