### PR TITLE
[mle] only include mesh-local address in "Child Update Response"

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1721,6 +1721,7 @@ private:
     otError HandleDiscoveryResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     otError HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     void    ProcessAnnounce(void);
+    bool    HasUnregisteredAddress(void);
 
     uint32_t GetAttachStartDelay(void) const;
     otError  SendParentRequest(ParentRequestType aType);


### PR DESCRIPTION
This commit changes preparation of "Child Update Response" (on a
child) such that only the mesh-local address is included in Address
Registration TLV. If the child has more addresses to register it
follows up with its own "Child Update Request".

------------

It also updates `toranj` test-032 to cover the address registration behavior by child after parent reset.