### PR TITLE
[tests] make pretty and update makefile

### DIFF
--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -134,7 +134,7 @@ check_PROGRAMS                                                     += \
     test-ncp-buffer                                                   \
     test-spinel-decoder                                               \
     test-spinel-encoder                                               \
-    $(NULL)   
+    $(NULL)
 
 if OPENTHREAD_ENABLE_NCP_UART
 check_PROGRAMS                                                     += \
@@ -243,6 +243,7 @@ test_toolchain_LDADD         = $(NULL)
 test_toolchain_SOURCES       = test_toolchain.cpp test_toolchain_c.c
 
 PRETTY_FILES                                                        = \
+    $(noinst_HEADERS)                                                 \
     $(test_address_sanitizer_SOURCES)                                 \
     $(test_aes_SOURCES)                                               \
     $(test_child_SOURCES)                                             \

--- a/tests/unit/test_platform.h
+++ b/tests/unit/test_platform.h
@@ -39,10 +39,10 @@
 
 #include <openthread/config.h>
 #include <openthread/platform/alarm-milli.h>
+#include <openthread/platform/entropy.h>
 #include <openthread/platform/logging.h>
 #include <openthread/platform/misc.h>
 #include <openthread/platform/radio.h>
-#include <openthread/platform/entropy.h>
 
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"


### PR DESCRIPTION
This PR contains two small commits:
- First one is the output of "make pretty" fixing order in the `tests/unit/test_platform.h`
- Second one is adding header file explicitly in `PRETTY_FILES` var in the unit test `Makefile` to ensure it's covered by `travis` pretty check build.

