### PR TITLE
[mle-router] signal a child/router neighbor entry being added or removed

### DIFF
--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -580,47 +580,55 @@ OTAPI int8_t OTCALL otThreadGetParentPriority(otInstance *aInstance);
 OTAPI otError OTCALL otThreadSetParentPriority(otInstance *aInstance, int8_t aParentPriority);
 
 /**
- * This enumeration defines the constants used in `otThreadChildTableCallback` to indicate whether a child is added or
- * removed.
+ * This enumeration defines the constants used in `otNeighborTableCallback` to indicate whether a child or router
+ * neighbor is being added or removed.
  *
  */
-typedef enum otThreadChildTableEvent
+typedef enum
 {
-    OT_THREAD_CHILD_TABLE_EVENT_CHILD_ADDED,   ///< A child is being added.
-    OT_THREAD_CHILD_TABLE_EVENT_CHILD_REMOVED, ///< A child is being removed.
-} otThreadChildTableEvent;
+    OT_NEIGHBOR_TABLE_EVENT_CHILD_ADDED,    ///< A child is being added.
+    OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED,  ///< A child is being removed.
+    OT_NEIGHBOR_TABLE_EVENT_ROUTER_ADDED,   ///< A router is being added.
+    OT_NEIGHBOR_TABLE_EVENT_ROUTER_REMOVED, ///< A router is being removed.
+} otNeighborTableEvent;
 
 /**
- * This function pointer is called to notify that a child is being added to or removed from child table.
- *
- * @param[in]  aEvent      A event flag indicating whether a child is being added or removed.
- * @param[in]  aChildInfo  A pointer to child information structure.
+ * This type represent a neighbor table entry info (child or router) and is used as a parameter in the neighbor table
+ * callback `otNeighborTableCallback`.
  *
  */
-typedef void (*otThreadChildTableCallback)(otThreadChildTableEvent aEvent, const otChildInfo *aChildInfo);
+typedef struct
+{
+    otInstance *mInstance; ///< The OpenThread instance.
+    union
+    {
+        otChildInfo    mChild;  ///< The child neighbor info.
+        otNeighborInfo mRouter; ///< The router neighbor info.
+    } mInfo;
+} otNeighborTableEntryInfo;
 
 /**
- * This function gets the child table callback function.
+ * This function pointer is called to notify that a child or router neighbor is being added to or removed from neighbor
+ * table.
  *
- * @param[in] aInstance  A pointer to an OpenThread instance.
- *
- * @returns  The callback function pointer.
+ * @param[in]  aEvent      A event flag.
+ * @param[in]  aEntryInfo  A pointer to table entry info.
  *
  */
-otThreadChildTableCallback otThreadGetChildTableCallback(otInstance *aInstance);
+typedef void (*otNeighborTableCallback)(otNeighborTableEvent aEvent, const otNeighborTableEntryInfo *aEntryInfo);
 
 /**
- * This function sets the child table callback function.
+ * This function registers a neighbor table callback function.
  *
- * The provided callback (if non-NULL) will be invoked when a child entry is being added/removed to/from the child
- * table. Subsequent calls to this method will overwrite the previous callback. Note that this callback in invoked
- * while the child table is being updated and always before the `otStateChangedCallback`.
+ * The provided callback (if non-NULL) will be invoked when a child or router neighbor entry is being added/removed
+ * to/from the neighbor table. Subsequent calls to this method will overwrite the previous callback.  Note that this
+ * callback in invoked while the neighbor/child table is being updated and always before the `otStateChangedCallback`.
  *
  * @param[in] aInstance  A pointer to an OpenThread instance.
  * @param[in] aCallback  A pointer to callback handler function.
  *
  */
-void otThreadSetChildTableCallback(otInstance *aInstance, otThreadChildTableCallback aCallback);
+void otThreadRegisterNeighborTableCallback(otInstance *aInstance, otNeighborTableCallback aCallback);
 
 /**
  * @}

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -380,18 +380,11 @@ otError otThreadSetParentPriority(otInstance *aInstance, const int8_t aParentPri
     return instance.Get<Mle::MleRouter>().SetAssignParentPriority(aParentPriority);
 }
 
-otThreadChildTableCallback otThreadGetChildTableCallback(otInstance *aInstance)
+void otThreadRegisterNeighborTableCallback(otInstance *aInstance, otNeighborTableCallback aCallback)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<Mle::MleRouter>().GetChildTableChangedCallback();
-}
-
-void otThreadSetChildTableCallback(otInstance *aInstance, otThreadChildTableCallback aCallback)
-{
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mle::MleRouter>().SetChildTableChangedCallback(aCallback);
+    instance.Get<Mle::MleRouter>().RegisterNeighborTableChangedCallback(aCallback);
 }
 
 #endif // OPENTHREAD_FTD

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -597,23 +597,27 @@ public:
     otError GetMaxChildTimeout(uint32_t &aTimeout) const;
 
     /**
-     * This method sets the "child table changed" callback function.
+     * This method register the "neighbor table changed" callback function.
      *
-     * The provided callback (if non-NULL) will be invoked when a child entry is being added/remove to/from the child
-     * table. Subsequent calls to this method will overwrite the previous callback.
+     * The provided callback (if non-NULL) will be invoked when a child/router entry is being added/remove to/from the
+     * neighbor table. Subsequent calls to this method will overwrite the previous callback.
      *
      * @param[in] aCallback    A pointer to callback handler function.
      *
      */
-    void SetChildTableChangedCallback(otThreadChildTableCallback aCallback) { mChildTableChangedCallback = aCallback; }
+    void RegisterNeighborTableChangedCallback(otNeighborTableCallback aCallback)
+    {
+        mNeighborTableChangedCallback = aCallback;
+    }
 
     /**
-     * This method gets the "child table changed" callback function.
+     * This method signals a "neighbor table changed" events (invoking the registered callback function).
      *
-     * @returns  The callback function pointer.
+     * @param[in] aEvent     The event to emit (child/router added/removed).
+     * @param[in] aNeighbor  The neighbor that is being added/removed.
      *
      */
-    otThreadChildTableCallback GetChildTableChangedCallback(void) const { return mChildTableChangedCallback; }
+    void Signal(otNeighborTableEvent aEvent, Neighbor &aNeighbor);
 
     /**
      * This method returns whether the device has any sleepy children subscribed the address.
@@ -679,6 +683,7 @@ private:
     otError AppendActiveDataset(Message &aMessage);
     otError AppendPendingDataset(Message &aMessage);
     otError GetChildInfo(Child &aChild, otChildInfo &aChildInfo);
+    void    GetNeighborInfo(Neighbor &aNeighbor, otNeighborInfo &aNeighInfo);
     otError RefreshStoredChildren(void);
     void    HandleDetachStart(void);
     otError HandleChildStart(AttachMode aMode);
@@ -766,8 +771,6 @@ private:
     static void HandleStateUpdateTimer(Timer &aTimer);
     void        HandleStateUpdateTimer(void);
 
-    void SignalChildUpdated(otThreadChildTableEvent aEvent, Child &aChild);
-
     TrickleTimer mAdvertiseTimer;
     TimerMilli   mStateUpdateTimer;
 
@@ -777,7 +780,7 @@ private:
     ChildTable  mChildTable;
     RouterTable mRouterTable;
 
-    otThreadChildTableCallback mChildTableChangedCallback;
+    otNeighborTableCallback mNeighborTableChangedCallback;
 
     uint8_t  mChallengeTimeout;
     uint8_t  mChallenge[8];

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -101,7 +101,14 @@ void RouterTable::ClearNeighbors(void)
 {
     for (uint8_t index = 0; index < Mle::kMaxRouters; index++)
     {
-        mRouters[index].SetState(Neighbor::kStateInvalid);
+        Router &router = mRouters[index];
+
+        if (router.GetState() == Neighbor::kStateValid)
+        {
+            Get<Mle::MleRouter>().Signal(OT_NEIGHBOR_TABLE_EVENT_ROUTER_REMOVED, router);
+        }
+
+        router.SetState(Neighbor::kStateInvalid);
     }
 }
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -274,7 +274,7 @@ NcpBase::NcpBase(Instance *aInstance)
 #endif
     otIcmp6SetEchoMode(mInstance, OT_ICMP6_ECHO_HANDLER_DISABLED);
 #if OPENTHREAD_FTD
-    otThreadSetChildTableCallback(mInstance, &NcpBase::HandleChildTableChanged);
+    otThreadRegisterNeighborTableCallback(mInstance, &NcpBase::HandleNeighborTableChanged);
 #if OPENTHREAD_CONFIG_ENABLE_STEERING_DATA_SET_OOB
     memset(&mSteeringDataAddress, 0, sizeof(mSteeringDataAddress));
 #endif

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -322,6 +322,8 @@ protected:
                                      const otIp6Address ** aDestIpAddress    = NULL,
                                      bool                  aAllowEmptyValues = false);
 
+    otError EncodeNeighborInfo(const otNeighborInfo &aNeighborInfo);
+
 #if OPENTHREAD_FTD
     otError EncodeChildInfo(const otChildInfo &aChildInfo);
 #endif

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -276,8 +276,8 @@ protected:
     void        HandleTimeSyncUpdate(void);
 
 #if OPENTHREAD_FTD
-    static void HandleChildTableChanged(otThreadChildTableEvent aEvent, const otChildInfo *aChildInfo);
-    void        HandleChildTableChanged(otThreadChildTableEvent aEvent, const otChildInfo &aChildInfo);
+    static void HandleNeighborTableChanged(otNeighborTableEvent aEvent, const otNeighborTableEntryInfo *aEntry);
+    void        HandleNeighborTableChanged(otNeighborTableEvent aEvent, const otNeighborTableEntryInfo &aEntry);
 
     static void HandleParentResponseInfo(otThreadParentResponseInfo *aInfo, void *aContext);
     void        HandleParentResponseInfo(const otThreadParentResponseInfo &aInfo);

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -115,12 +115,12 @@ exit:
     return;
 }
 
-void NcpBase::HandleChildTableChanged(otThreadChildTableEvent aEvent, const otChildInfo *aChildInfo)
+void NcpBase::HandleNeighborTableChanged(otNeighborTableEvent aEvent, const otNeighborTableEntryInfo *aEntry)
 {
-    GetNcpInstance()->HandleChildTableChanged(aEvent, *aChildInfo);
+    GetNcpInstance()->HandleNeighborTableChanged(aEvent, *aEntry);
 }
 
-void NcpBase::HandleChildTableChanged(otThreadChildTableEvent aEvent, const otChildInfo &aChildInfo)
+void NcpBase::HandleNeighborTableChanged(otNeighborTableEvent aEvent, const otNeighborTableEntryInfo &aEntry)
 {
     otError      error   = OT_ERROR_NONE;
     uint8_t      header  = SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0;
@@ -128,15 +128,15 @@ void NcpBase::HandleChildTableChanged(otThreadChildTableEvent aEvent, const otCh
 
     VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(SPINEL_PROP_THREAD_CHILD_TABLE));
 
-    VerifyOrExit(!aChildInfo.mIsStateRestoring);
+    VerifyOrExit(!aEntry.mInfo.mChild.mIsStateRestoring);
 
     switch (aEvent)
     {
-    case OT_THREAD_CHILD_TABLE_EVENT_CHILD_ADDED:
+    case OT_NEIGHBOR_TABLE_EVENT_CHILD_ADDED:
         command = SPINEL_CMD_PROP_VALUE_INSERTED;
         break;
 
-    case OT_THREAD_CHILD_TABLE_EVENT_CHILD_REMOVED:
+    case OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED:
         command = SPINEL_CMD_PROP_VALUE_REMOVED;
         break;
 
@@ -145,7 +145,7 @@ void NcpBase::HandleChildTableChanged(otThreadChildTableEvent aEvent, const otCh
     }
 
     SuccessOrExit(error = mEncoder.BeginFrame(header, command, SPINEL_PROP_THREAD_CHILD_TABLE));
-    SuccessOrExit(error = EncodeChildInfo(aChildInfo));
+    SuccessOrExit(error = EncodeChildInfo(aEntry.mInfo.mChild));
     SuccessOrExit(error = mEncoder.EndFrame());
 
 exit:

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -163,6 +163,33 @@ uint8_t NcpBase::LinkFlagsToFlagByte(bool aRxOnWhenIdle, bool aSecureDataRequest
     return flags;
 }
 
+otError NcpBase::EncodeNeighborInfo(const otNeighborInfo &aNeighborInfo)
+{
+    otError error;
+    uint8_t modeFlags;
+
+    modeFlags = LinkFlagsToFlagByte(aNeighborInfo.mRxOnWhenIdle, aNeighborInfo.mSecureDataRequest,
+                                    aNeighborInfo.mFullThreadDevice, aNeighborInfo.mFullNetworkData);
+
+    SuccessOrExit(error = mEncoder.OpenStruct());
+
+    SuccessOrExit(error = mEncoder.WriteEui64(aNeighborInfo.mExtAddress));
+    SuccessOrExit(error = mEncoder.WriteUint16(aNeighborInfo.mRloc16));
+    SuccessOrExit(error = mEncoder.WriteUint32(aNeighborInfo.mAge));
+    SuccessOrExit(error = mEncoder.WriteUint8(aNeighborInfo.mLinkQualityIn));
+    SuccessOrExit(error = mEncoder.WriteInt8(aNeighborInfo.mAverageRssi));
+    SuccessOrExit(error = mEncoder.WriteUint8(modeFlags));
+    SuccessOrExit(error = mEncoder.WriteBool(aNeighborInfo.mIsChild));
+    SuccessOrExit(error = mEncoder.WriteUint32(aNeighborInfo.mLinkFrameCounter));
+    SuccessOrExit(error = mEncoder.WriteUint32(aNeighborInfo.mMleFrameCounter));
+    SuccessOrExit(error = mEncoder.WriteInt8(aNeighborInfo.mLastRssi));
+
+    SuccessOrExit(error = mEncoder.CloseStruct());
+
+exit:
+    return error;
+}
+
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_MAC_DATA_POLL_PERIOD>(void)
 {
     return mEncoder.WriteUint32(otLinkGetPollPeriod(mInstance));
@@ -577,27 +604,10 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_NEIGHBOR_TABLE
     otError                error = OT_ERROR_NONE;
     otNeighborInfoIterator iter  = OT_NEIGHBOR_INFO_ITERATOR_INIT;
     otNeighborInfo         neighInfo;
-    uint8_t                modeFlags;
 
     while (otThreadGetNextNeighborInfo(mInstance, &iter, &neighInfo) == OT_ERROR_NONE)
     {
-        modeFlags = LinkFlagsToFlagByte(neighInfo.mRxOnWhenIdle, neighInfo.mSecureDataRequest,
-                                        neighInfo.mFullThreadDevice, neighInfo.mFullNetworkData);
-
-        SuccessOrExit(error = mEncoder.OpenStruct());
-
-        SuccessOrExit(error = mEncoder.WriteEui64(neighInfo.mExtAddress));
-        SuccessOrExit(error = mEncoder.WriteUint16(neighInfo.mRloc16));
-        SuccessOrExit(error = mEncoder.WriteUint32(neighInfo.mAge));
-        SuccessOrExit(error = mEncoder.WriteUint8(neighInfo.mLinkQualityIn));
-        SuccessOrExit(error = mEncoder.WriteInt8(neighInfo.mAverageRssi));
-        SuccessOrExit(error = mEncoder.WriteUint8(modeFlags));
-        SuccessOrExit(error = mEncoder.WriteBool(neighInfo.mIsChild));
-        SuccessOrExit(error = mEncoder.WriteUint32(neighInfo.mLinkFrameCounter));
-        SuccessOrExit(error = mEncoder.WriteUint32(neighInfo.mMleFrameCounter));
-        SuccessOrExit(error = mEncoder.WriteInt8(neighInfo.mLastRssi));
-
-        SuccessOrExit(error = mEncoder.CloseStruct());
+        SuccessOrExit(error = EncodeNeighborInfo(neighInfo));
     }
 
 exit:


### PR DESCRIPTION
This PR contains two related commits:

**[mle-router] signal a child/router neighbor entry being added or removed**

This commit updates the neighbor table callback to signal when
either a child or a router neighbor entry is being added or removed.
This change replaces and enhances the previous APIs relalted to child
table callback.

------------

**[ncp] emit router entry addition/removal from neighbor table**
    
This commit updates `NcpBase` to emit `VALUE_INSERTED/REMOVED` spinel
message to host for `PROP_NEIGHBOR_TABLE` when a router neighbor entry
is added or removed.