### PR TITLE
[thci] correct conversion of IPv6 prefix

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -500,7 +500,7 @@ class OpenThread(IThci):
         finalMac = ':'.join(a + b + c + d for a,b,c,d in zip(hexIter, hexIter,hexIter,hexIter))
         prefix = str(finalMac)
         strIp6Prefix = prefix[:20]
-        return strIp6Prefix +':'
+        return strIp6Prefix +'::'
 
     def __convertLongToString(self, iValue):
         """convert a long hex integer to string


### PR DESCRIPTION
The #3830 introduced additional parse validation to `otIp6AddressFromString`.

Probably due to this PR (or less likely this #3819), the following certification test cases fail with AutoDUT:

- `Leader_7_1_1`
- `Leader_7_1_3`
- `Router_7_1_2`
- `Router_7_1_4`
- `Router_7_1_5`

The reason for this is that prefix `2001:0000:0000:0000:` (one colon at the end) is no longer valid.

This PR updates `OpenThread.py` THCI file to construct valid prefix. Note that OpenThread_wpanctl.py has the correct version of this functionality already implemented.