### PR TITLE
[cert] add additional validation for Router_5_1_11 and ED_6_1_06 tests

### DIFF
--- a/tests/scripts/thread-cert/Cert_5_1_11_REEDAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_5_1_11_REEDAttachLinkQuality.py
@@ -72,7 +72,7 @@ class Cert_5_1_11_REEDAttachLinkQuality(unittest.TestCase):
         self.nodes[ROUTER1].set_panid(0xface)
         self.nodes[ROUTER1].set_mode('rsdn')
         self.nodes[ROUTER1].add_whitelist(self.nodes[REED].get_addr64())
-        self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER2].get_addr64(), rssi=-85)
+        self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[ROUTER1].enable_whitelist()
         self.nodes[ROUTER1].set_router_selection_jitter(1)
 
@@ -125,7 +125,6 @@ class Cert_5_1_11_REEDAttachLinkQuality(unittest.TestCase):
 
         msg = leader_messages.next_coap_message("2.04")
 
-        reed_messages.next_mle_message(mle.CommandType.ADVERTISEMENT)
         router2_messages.next_mle_message(mle.CommandType.ADVERTISEMENT)
 
         # 3 - Router1
@@ -158,6 +157,20 @@ class Cert_5_1_11_REEDAttachLinkQuality(unittest.TestCase):
         self.assertEqual(1, scan_mask_tlv.router)
         self.assertEqual(1, scan_mask_tlv.end_device)
 
+        # 6 - Router1
+        msg = router1_messages.next_mle_message(mle.CommandType.CHILD_ID_REQUEST)
+        msg.assertMleMessageContainsTlv(mle.LinkLayerFrameCounter)
+        msg.assertMleMessageContainsTlv(mle.Mode)
+        msg.assertMleMessageContainsTlv(mle.Response)
+        msg.assertMleMessageContainsTlv(mle.Timeout)
+        msg.assertMleMessageContainsTlv(mle.TlvRequest)
+        msg.assertMleMessageContainsTlv(mle.Version)
+        msg.assertMleMessageContainsOptionalTlv(mle.MleFrameCounter)
+        msg.assertMleMessageDoesNotContainTlv(mle.AddressRegistration)
+        msg.assertSentToNode(self.nodes[REED])
+
+        msg = reed_messages.next_mle_message(mle.CommandType.CHILD_ID_RESPONSE)
+        msg.assertSentToNode(self.nodes[ROUTER1])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scripts/thread-cert/Cert_6_1_05_RouterAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_6_1_05_RouterAttachLinkQuality.py
@@ -69,7 +69,7 @@ class Cert_6_1_5_RouterAttachLinkQuality(unittest.TestCase):
         self.nodes[ED].set_panid(0xface)
         self.nodes[ED].set_mode('rsn')
         self.nodes[ED].add_whitelist(self.nodes[ROUTER1].get_addr64())
-        self.nodes[ED].add_whitelist(self.nodes[ROUTER2].get_addr64(), rssi=-85)
+        self.nodes[ED].add_whitelist(self.nodes[ROUTER2].get_addr64())
         self.nodes[ED].enable_whitelist()
 
     def tearDown(self):

--- a/tests/scripts/thread-cert/Makefile.am
+++ b/tests/scripts/thread-cert/Makefile.am
@@ -87,7 +87,8 @@ EXTRA_DIST                                                         = \
     Cert_6_1_03_RouterAttachConnectivity.py                          \
     Cert_6_1_04_REEDAttachConnectivity.py                            \
     Cert_6_1_05_RouterAttachLinkQuality.py                           \
-    Cert_6_1_06_REEDAttachLinkQuality.py                             \
+    Cert_6_1_06_REEDAttachLinkQuality_ED.py                          \
+    Cert_6_1_06_REEDAttachLinkQuality_SED.py                         \
     Cert_6_1_07_EDSynchronization.py                                 \
     Cert_6_2_01_NewPartition.py                                      \
     Cert_6_2_02_NewPartition.py                                      \
@@ -227,7 +228,8 @@ check_SCRIPTS                                                      = \
     Cert_6_1_03_RouterAttachConnectivity.py                          \
     Cert_6_1_04_REEDAttachConnectivity.py                            \
     Cert_6_1_05_RouterAttachLinkQuality.py                           \
-    Cert_6_1_06_REEDAttachLinkQuality.py                             \
+    Cert_6_1_06_REEDAttachLinkQuality_ED.py                          \
+    Cert_6_1_06_REEDAttachLinkQuality_SED.py                         \
     Cert_6_1_07_EDSynchronization.py                                 \
     Cert_6_2_01_NewPartition.py                                      \
     Cert_6_2_02_NewPartition.py                                      \


### PR DESCRIPTION
This PR contains two separate but related commits:

---
**[cert] add additional validation for Router_5_1_11 test**

This commit adds an additional check for step 6 from Thread Certification Test Program.

---
**[cert] add additional validation for Cert_6_1_06 and fix link quality configuration**

This commit adds non-existing detailed checks for Cert_6_1_06. Additionally, two variants for MED and SED role have been added.

Despite the lack of the proper step checks, the above tests passed on #3803 because link-quality configuration was forced both on Golden Device and on DUT. However, it is not true in real certification, where only Golden Devices support this feature. Thus the configuration of link-quality on DUT has been removed.

---

This PR fails on the current master but passes with Jonathan's fix (#3850), and so after the fix is merged, rebase is needed.