### PR TITLE
[dtls] fix bug of cipher suites check

### DIFF
--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -295,6 +295,8 @@ otError Dtls::Setup(bool aClient)
     mbedtls_ssl_conf_rng(&mConf, mbedtls_ctr_drbg_random, Random::Crypto::MbedTlsContextGet());
     mbedtls_ssl_conf_min_version(&mConf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3);
     mbedtls_ssl_conf_max_version(&mConf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3);
+
+    assert(mCipherSuites[1] == 0);
     mbedtls_ssl_conf_ciphersuites(&mConf, mCipherSuites);
     mbedtls_ssl_conf_export_keys_cb(&mConf, HandleMbedtlsExportKeys, this);
     mbedtls_ssl_conf_handshake_timeout(&mConf, 8000, 60000);
@@ -363,8 +365,6 @@ exit:
 int Dtls::SetApplicationCoapSecureKeys(void)
 {
     int rval = 0;
-
-    VerifyOrExit(&mCipherSuites[0] != NULL, rval = MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
 
     switch (mCipherSuites[0])
     {


### PR DESCRIPTION
This commit fix a small bug of checking the cipher suites:

Below is wrong because it takes the address of the first cipher suite; this is also not necessary because the checking it done by the `switch` statement following
```c++
VerifyOrExit(&mCipherSuites[0] != NULL, rval = MBEDTLS_ERR_SSL_BAD_INPUT_DATA);
```

instead, we should check if `mCipherSuites[1] == 0`, as mbedtls will depends on it.

