### PR TITLE
[cc2538] fix entropy.c

### DIFF
--- a/examples/platforms/cc2538/entropy.c
+++ b/examples/platforms/cc2538/entropy.c
@@ -87,7 +87,7 @@ otError otPlatEntropyGet(uint8_t *aOutput, uint16_t aOutputLength)
 
     otEXPECT_ACTION(aOutput, error = OT_ERROR_INVALID_ARGS);
 
-    if (otPlatRadioIsEnabled(sInstance))
+    if (sInstance && otPlatRadioIsEnabled(sInstance))
     {
         channel = 11 + (HWREG(RFCORE_XREG_FREQCTRL) - 11) / 5;
         otPlatRadioSleep(sInstance);


### PR DESCRIPTION
otPlatEntropyGet is called before OT instance is available. This PR adds check if sInstance is initialized. Should fix #3859 

Note:
entropy.c implementation should be OT instance independent but this one is...