### PR TITLE
[commissioner] add provisioning URL member variable

### DIFF
--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -79,6 +79,7 @@ Commissioner::Commissioner(Instance &aInstance)
     mCommissionerAloc.mValid              = true;
     mCommissionerAloc.mScopeOverride      = Ip6::Address::kRealmLocalScope;
     mCommissionerAloc.mScopeOverrideValid = true;
+    mProvisioningUrl.Init();
 }
 
 void Commissioner::AddCoapResources(void)
@@ -312,11 +313,9 @@ exit:
 
 const char *Commissioner::GetProvisioningUrl(uint16_t &aLength) const
 {
-    ProvisioningUrlTlv &provisioningUrl = Get<Coap::CoapSecure>().GetDtls().mProvisioningUrl;
+    aLength = mProvisioningUrl.GetLength();
 
-    aLength = provisioningUrl.GetLength();
-
-    return provisioningUrl.GetProvisioningUrl();
+    return mProvisioningUrl.GetProvisioningUrl();
 }
 
 otError Commissioner::SetProvisioningUrl(const char *aProvisioningUrl)
@@ -329,7 +328,7 @@ otError Commissioner::SetProvisioningUrl(const char *aProvisioningUrl)
         VerifyOrExit(len <= MeshCoP::ProvisioningUrlTlv::kMaxLength, error = OT_ERROR_INVALID_ARGS);
     }
 
-    Get<Coap::CoapSecure>().GetDtls().mProvisioningUrl.SetProvisioningUrl(aProvisioningUrl);
+    mProvisioningUrl.SetProvisioningUrl(aProvisioningUrl);
 
 exit:
     return error;
@@ -903,9 +902,8 @@ void Commissioner::HandleJoinerFinalize(Coap::Message &aMessage, const Ip6::Mess
 
     if (Tlv::GetTlv(aMessage, Tlv::kProvisioningUrl, sizeof(provisioningUrl), provisioningUrl) == OT_ERROR_NONE)
     {
-        if (provisioningUrl.GetLength() != Get<Coap::CoapSecure>().GetDtls().mProvisioningUrl.GetLength() ||
-            memcmp(provisioningUrl.GetProvisioningUrl(),
-                   Get<Coap::CoapSecure>().GetDtls().mProvisioningUrl.GetProvisioningUrl(),
+        if (provisioningUrl.GetLength() != mProvisioningUrl.GetLength() ||
+            memcmp(provisioningUrl.GetProvisioningUrl(), mProvisioningUrl.GetProvisioningUrl(),
                    provisioningUrl.GetLength()) != 0)
         {
             state = StateTlv::kReject;

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -332,6 +332,8 @@ private:
 
     Ip6::NetifUnicastAddress mCommissionerAloc;
 
+    ProvisioningUrlTlv mProvisioningUrl;
+
     otCommissionerState mState;
 };
 

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -109,8 +109,6 @@ Dtls::Dtls(Instance &aInstance, bool aLayerTwoSecurity)
 #ifdef MBEDTLS_SSL_COOKIE_C
     memset(&mCookieCtx, 0, sizeof(mCookieCtx));
 #endif
-
-    mProvisioningUrl.Init();
 }
 
 void Dtls::FreeMbedtls(void)

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -387,12 +387,6 @@ public:
      */
     const Ip6::MessageInfo &GetPeerAddress(void) const { return mPeerAddress; }
 
-    /**
-     * The provisioning URL is placed here so that both the Commissioner and Joiner can share the same object.
-     *
-     */
-    ProvisioningUrlTlv mProvisioningUrl;
-
     void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
 private:


### PR DESCRIPTION
This commit moves the definition of provisioning URL TLV member
variable to `Commissioner` class (from `Dtls` class).

--------

It was originally defined in `Dtls` so that it can be shared between `Joiner` and `Commissioner` but with recent changes  `Joiner` does not use/need the `Dtls`  variable. 