### PR TITLE
[timer] support negative aDt for StartAt.

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -317,7 +317,7 @@ void CoapBase::HandleRetransmissionTimer(void)
         message = nextMessage;
     }
 
-    if (nextDelta != TimerMilli::kForeverDt)
+    if (nextDelta < TimerMilli::kForeverDt)
     {
         mRetransmissionTimer.Start(nextDelta);
     }

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -70,10 +70,10 @@ bool Timer::DoesFireBefore(const Timer &aSecondTimer, uint32_t aNow)
     return retval;
 }
 
-void TimerMilli::StartAt(uint32_t aT0, uint32_t aDt)
+void TimerMilli::StartAt(uint32_t aT0, int32_t aDt)
 {
-    assert(aDt <= kMaxDt);
-    mFireTime = aT0 + aDt;
+    assert(reinterpret_cast<const uint32_t &>(aDt) != kForeverDt);
+    mFireTime = aT0 + reinterpret_cast<const uint32_t &>(aDt);
     Get<TimerMilliScheduler>().Add(*this);
 }
 
@@ -218,10 +218,10 @@ exit:
 const TimerScheduler::AlarmApi TimerMicroScheduler::sAlarmMicroApi = {&otPlatAlarmMicroStartAt, &otPlatAlarmMicroStop,
                                                                       &otPlatAlarmMicroGetNow};
 
-void TimerMicro::StartAt(uint32_t aT0, uint32_t aDt)
+void TimerMicro::StartAt(uint32_t aT0, int32_t aDt)
 {
-    assert(aDt <= kMaxDt);
-    mFireTime = aT0 + aDt;
+    assert(reinterpret_cast<const uint32_t &>(aDt) != kForeverDt);
+    mFireTime = aT0 + reinterpret_cast<const uint32_t &>(aDt);
     Get<TimerMicroScheduler>().Add(*this);
 }
 

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -70,9 +70,9 @@ class Timer : public InstanceLocator, public OwnerLocator
     friend class TimerScheduler;
 
 public:
-    static const uint32_t kMaxDt =
+    static const int32_t kMaxDt =
         (1UL << 31) - 1; ///< Maximum permitted value for parameter `aDt` in `Start` and `StartAt` method.
-    static const uint32_t kForeverDt = 0xffffffff; ///< The special forever `aDt` value.
+    static const uint32_t kForeverDt = (1UL << 31); ///< The special forever `aDt` value.
 
     /**
      * This function pointer is called when the timer expires.
@@ -115,6 +115,24 @@ public:
      *
      */
     bool IsRunning(void) const { return (mNext != this); }
+
+    /**
+     * This method converts the @p aDt to a valid value.
+     *
+     * @note If @p aDt is bigger than kMaxDt, it will be reset to kMaxtDt.
+     *
+     * @param[in]   aDt     The diff time.
+     *
+     */
+    static int32_t NormalizeDt(uint32_t aDt)
+    {
+        if (aDt > Timer::kMaxDt)
+        {
+            aDt = Timer::kMaxDt;
+        }
+
+        return reinterpret_cast<const int32_t &>(aDt);
+    }
 
 protected:
     /**
@@ -163,7 +181,11 @@ public:
      *                  (aDt must be smaller than or equal to kMaxDt).
      *
      */
-    void Start(uint32_t aDt) { StartAt(GetNow(), aDt); }
+    void Start(uint32_t aDt)
+    {
+        assert(aDt <= kMaxDt);
+        StartAt(GetNow(), reinterpret_cast<const int32_t &>(aDt));
+    }
 
     /**
      * This method schedules the timer to fire at @p aDt milliseconds from @p aT0.
@@ -173,7 +195,21 @@ public:
      *                  (aDt must be smaller than or equal to kMaxDt).
      *
      */
-    void StartAt(uint32_t aT0, uint32_t aDt);
+    void StartAt(uint32_t aT0, uint32_t aDt)
+    {
+        assert(aDt <= Timer::kMaxDt);
+        StartAt(aT0, reinterpret_cast<const int32_t &>(aDt));
+    }
+
+    /**
+     * This method schedules the timer to fire at @p aDt milliseconds from @p aT0.
+     *
+     * @param[in]  aT0  The start time in milliseconds.
+     * @param[in]  aDt  The expire time in milliseconds from @p aT0.
+     *                  (aDt must not be equal to kForeverDt).
+     *
+     */
+    void StartAt(uint32_t aT0, int32_t aDt);
 
     /**
      * This method stops the timer.
@@ -193,7 +229,8 @@ public:
     static int32_t Diff(uint32_t aStart, uint32_t aEnd)
     {
         uint32_t diff = aEnd - aStart;
-        return reinterpret_cast<int32_t &>(diff);
+
+        return reinterpret_cast<const int32_t &>(diff);
     }
 
     /**
@@ -443,7 +480,11 @@ public:
      *                  (aDt must be smaller than or equal to kMaxDt).
      *
      */
-    void Start(uint32_t aDt) { StartAt(GetNow(), aDt); }
+    void Start(uint32_t aDt)
+    {
+        assert(aDt <= kMaxDt);
+        StartAt(GetNow(), reinterpret_cast<const int32_t &>(aDt));
+    }
 
     /**
      * This method schedules the timer to fire at @p aDt microseconds from @p aT0.
@@ -453,7 +494,21 @@ public:
      *                  (aDt must be smaller than or equal to kMaxDt).
      *
      */
-    void StartAt(uint32_t aT0, uint32_t aDt);
+    void StartAt(uint32_t aT0, uint32_t aDt)
+    {
+        assert(aDt <= Timer::kMaxDt);
+        StartAt(aT0, reinterpret_cast<const int32_t &>(aDt));
+    }
+
+    /**
+     * This method schedules the timer to fire at @p aDt microseconds from @p aT0.
+     *
+     * @param[in]  aT0  The start time in microseconds.
+     * @param[in]  aDt  The expire time in microseconds from @p aT0.
+     *                  (aDt must not be equal to kForeverDt).
+     *
+     */
+    void StartAt(uint32_t aT0, int32_t aDt);
 
     /**
      * This method stops the timer.

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -447,7 +447,7 @@ void SubMac::SampleRssi(void)
 
     if (TimerMilliScheduler::IsStrictlyBefore(TimerMilli::GetNow(), mEnergyScanEndTime))
     {
-        mTimer.StartAt(mTimer.GetFireTime(), kEnergyScanRssiSampleInterval);
+        mTimer.StartAt(mTimer.GetFireTime(), static_cast<int32_t>(kEnergyScanRssiSampleInterval));
     }
     else
     {

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -421,7 +421,7 @@ void Commissioner::UpdateJoinerExpirationTimer(void)
         }
     }
 
-    if (nextTimeout != TimerMilli::kForeverDt)
+    if (nextTimeout < TimerMilli::kForeverDt)
     {
         // Update the timer to the timeout of the next Joiner.
         mJoinerExpirationTimer.Start(nextTimeout);

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -805,13 +805,7 @@ void PendingDataset::StartDelayTimer(void)
 
     if ((delayTimer = static_cast<DelayTimerTlv *>(dataset.Get(Tlv::kDelayTimer))) != NULL)
     {
-        uint32_t delay = delayTimer->GetDelayTimer();
-
-        // the Timer implementation does not support the full 32 bit range
-        if (delay > Timer::kMaxDt)
-        {
-            delay = Timer::kMaxDt;
-        }
+        int32_t delay = Timer::NormalizeDt(delayTimer->GetDelayTimer());
 
         mDelayTimer.StartAt(dataset.GetUpdateTime(), delay);
         otLogInfoMeshCoP("delay timer started %d", delay);
@@ -839,7 +833,7 @@ void PendingDataset::HandleDelayTimer(void)
 
         if (elapsed < delay)
         {
-            mDelayTimer.StartAt(mDelayTimer.GetFireTime(), delay - elapsed);
+            mDelayTimer.StartAt(mDelayTimer.GetFireTime(), Timer::NormalizeDt(delay - elapsed));
             ExitNow();
         }
     }

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -449,7 +449,7 @@ void Client::HandleRetransmissionTimer(void)
         message = nextMessage;
     }
 
-    if (nextDelta != TimerMilli::kForeverDt)
+    if (nextDelta < TimerMilli::kForeverDt)
     {
         mRetransmissionTimer.Start(nextDelta);
     }

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -413,7 +413,7 @@ void Mpl::HandleRetransmissionTimer(void)
         message = nextMessage;
     }
 
-    if (nextDelta != TimerMilli::kForeverDt)
+    if (nextDelta < TimerMilli::kForeverDt)
     {
         mRetransmissionTimer.Start(nextDelta);
     }

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -323,7 +323,7 @@ void Client::HandleRetransmissionTimer(void)
         message = nextMessage;
     }
 
-    if (nextDelta != TimerMilli::kForeverDt)
+    if (nextDelta < TimerMilli::kForeverDt)
     {
         mRetransmissionTimer.Start(nextDelta);
     }

--- a/src/core/thread/data_poll_manager.cpp
+++ b/src/core/thread/data_poll_manager.cpp
@@ -414,11 +414,11 @@ void DataPollManager::ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector)
             // response is available/prepared on the parent node).
             if (TimerScheduler::IsStrictlyBefore(mTimerStartTime + mPollPeriod, now + kMinPollPeriod))
             {
-                mTimer.StartAt(now, kMinPollPeriod);
+                mTimer.StartAt(now, static_cast<int32_t>(kMinPollPeriod));
             }
             else
             {
-                mTimer.StartAt(mTimerStartTime, mPollPeriod);
+                mTimer.StartAt(mTimerStartTime, Timer::NormalizeDt(mPollPeriod));
             }
         }
         // Do nothing on the running poll timer if the poll interval doesn't change
@@ -426,7 +426,7 @@ void DataPollManager::ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector)
     else
     {
         mTimerStartTime = now;
-        mTimer.StartAt(mTimerStartTime, mPollPeriod);
+        mTimer.StartAt(mTimerStartTime, Timer::NormalizeDt(mPollPeriod));
     }
 }
 

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -284,7 +284,7 @@ void KeyManager::HandleKeyRotationTimer(void)
     // rotation timer (and the `mHoursSinceKeyRotation`) if it updates the key
     // sequence.
 
-    mKeyRotationTimer.StartAt(mKeyRotationTimer.GetFireTime(), kOneHourIntervalInMsec);
+    mKeyRotationTimer.StartAt(mKeyRotationTimer.GetFireTime(), static_cast<int32_t>(kOneHourIntervalInMsec));
 
     if (mHoursSinceKeyRotation >= mKeyRotationTime)
     {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1905,7 +1905,7 @@ void Mle::HandleDelayedResponseTimer(void)
         message = nextMessage;
     }
 
-    if (nextDelay != TimerMilli::kForeverDt)
+    if (nextDelay < TimerMilli::kForeverDt)
     {
         mDelayedResponseTimer.Start(nextDelay);
     }

--- a/tests/unit/test_timer.cpp
+++ b/tests/unit/test_timer.cpp
@@ -317,7 +317,8 @@ int TestTwoTimers(void)
 
     sNow += kTimerInterval;
 
-    timer2.StartAt(kTimeT0, kTimerInterval - 2); // Timer 2 is even before timer 1
+    // Test negative aDt support.
+    timer2.StartAt(timer1.GetFireTime(), -2); // Timer 2 is even before timer 1
 
     VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.\n");
     VerifyOrQuit(timer1.IsRunning() == true, "TestTwoTimers: Timer running Failed.\n");


### PR DESCRIPTION
This PR adds support for negative value `aDt`. This is useful when some
margin ahead is wanted when schedule a timer.

`kForeverDt` is adjusted to `(1UL<<31)` instead of `0xffffffff`(or `-1`)
which is valid negative value for `aDt`.

Unit test is also enhanced to cover negative `aDt`.