### PR TITLE
[mle] skip saving NetworkInfo before device is attached (for first time)

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -442,8 +442,10 @@ otError Mle::Store(void)
 
     if (IsAttached())
     {
-        // only update network information while we are attached to avoid losing information when a reboot occurs after
-        // a message is sent but before attaching
+        // Only update network information while we are attached to
+        // avoid losing/overwriting previous information when a reboot
+        // occurs after a message is sent but before attaching.
+
         networkInfo.mDeviceMode          = mDeviceMode;
         networkInfo.mRole                = mRole;
         networkInfo.mRloc16              = GetRloc16();
@@ -463,11 +465,17 @@ otError Mle::Store(void)
     }
     else
     {
-        // when not attached, read out any existing values so that we do not change them
-        IgnoreReturnValue(Get<Settings>().ReadNetworkInfo(networkInfo));
+        // When not attached, read out any previous saved `NetworkInfo`.
+        // If there is none, it indicates that device was never attached
+        // before. In that case, no need to save any info (note that on
+        // a device reset the MLE/MAC frame counters would reset but
+        // device also starts with a new randomly generated extended
+        // address. If there is a previously saved `NetworkInfo`, we
+        // just update the key sequence and MAC and MLE frame counters.
+
+        SuccessOrExit(Get<Settings>().ReadNetworkInfo(networkInfo));
     }
 
-    // update MAC and MLE Frame Counters even when we are not attached MLE messages are sent before a device attached
     networkInfo.mKeySequence     = Get<KeyManager>().GetCurrentKeySequence();
     networkInfo.mMleFrameCounter = Get<KeyManager>().GetMleFrameCounter() + OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD;
     networkInfo.mMacFrameCounter = Get<KeyManager>().GetMacFrameCounter() + OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD;


### PR DESCRIPTION
This commit changes the `Mle::Store()` behavior such that if a device
is not attached and there is no previously saved `NetworkInfo`
(indicating that the device has never been attached before) we skip
saving/updating the `NetworkInfo`. Note that on a device reset the
MLE/MAC frame counters (which are part of `NetworkInfo`) would reset
but device would also start with a new randomly generated extended
address (so the security nonces would not be repeated).