### PR TITLE
[instance] update order of member variables

### DIFF
--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -51,17 +51,26 @@ otDEFINE_ALIGNED_VAR(gInstanceRaw, sizeof(Instance), uint64_t);
 #endif
 
 Instance::Instance(void)
-    : mTimerMilliScheduler(*this)
+    : mTaskletScheduler()
+    , mTimerMilliScheduler(*this)
 #if OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER
     , mTimerMicroScheduler(*this)
 #endif
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
+#if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    , mHeap()
+#endif
+    , mMbedTls()
+#endif // #if OPENTHREAD_MTD || OPENTHREAD_FTD
+    , mRandomManager()
+#if OPENTHREAD_MTD || OPENTHREAD_FTD
+    , mNotifier(*this)
+    , mSettings(*this)
+    , mMessagePool(*this)
     , mActiveScanCallback(NULL)
     , mActiveScanCallbackContext(NULL)
     , mEnergyScanCallback(NULL)
     , mEnergyScanCallbackContext(NULL)
-    , mNotifier(*this)
-    , mSettings(*this)
     , mIp6(*this)
     , mThreadNetif(*this)
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
@@ -79,11 +88,10 @@ Instance::Instance(void)
 #if OPENTHREAD_CONFIG_ENABLE_ANNOUNCE_SENDER
     , mAnnounceSender(*this)
 #endif
-    , mMessagePool(*this)
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 #if OPENTHREAD_RADIO || OPENTHREAD_ENABLE_RAW_LINK_API
     , mLinkRaw(*this)
-#endif // OPENTHREAD_RADIO || OPENTHREAD_ENABLE_RAW_LINK_API
+#endif
 #if OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
     , mLogLevel(static_cast<otLogLevel>(OPENTHREAD_CONFIG_INITIAL_LOG_LEVEL))
 #endif

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -298,31 +298,41 @@ private:
     Instance(void);
     void AfterInit(void);
 
+    // Order of variables (their initialization in `Instance`)
+    // is important.
+    //
+    // Tasklet and Timer Schedulers are first to ensure other
+    // objects/classes can use them from their constructors.
+
+    TaskletScheduler    mTaskletScheduler;
     TimerMilliScheduler mTimerMilliScheduler;
 #if OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER
     TimerMicroScheduler mTimerMicroScheduler;
 #endif
-    TaskletScheduler mTaskletScheduler;
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
-    otHandleActiveScanResult mActiveScanCallback;
-    void *                   mActiveScanCallbackContext;
-    otHandleEnergyScanResult mEnergyScanCallback;
-    void *                   mEnergyScanCallbackContext;
-
-    Notifier mNotifier;
-    Settings mSettings;
-
+    // RandomManager is initialized before other objects. Note that it
+    // requires MbedTls which itself may use Heap.
+#if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    Utils::Heap mHeap;
+#endif
     Crypto::MbedTls mMbedTls;
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 
     RandomManager mRandomManager;
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
+    // Notifier, Settings, and MessagePool are initialized  before
+    // other member variables since other classes/objects from their
+    // constructor may use them.
+    Notifier    mNotifier;
+    Settings    mSettings;
+    MessagePool mMessagePool;
 
-#if !OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
-    Utils::Heap mHeap;
-#endif
+    otHandleActiveScanResult mActiveScanCallback;
+    void *                   mActiveScanCallbackContext;
+    otHandleEnergyScanResult mEnergyScanCallback;
+    void *                   mEnergyScanCallbackContext;
 
     Ip6::Ip6    mIp6;
     ThreadNetif mThreadNetif;
@@ -347,7 +357,6 @@ private:
     AnnounceSender mAnnounceSender;
 #endif
 
-    MessagePool mMessagePool;
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 #if OPENTHREAD_RADIO || OPENTHREAD_ENABLE_RAW_LINK_API
     Mac::LinkRaw mLinkRaw;


### PR DESCRIPTION
This commit updates order of member variable definitions in the
Instance class to ensure that objects that may be used by others are
initialized first. In particular, Tasklet and Timer Schedulers, and
RandomManager are initialized first. On FTD/MTD, this is followed by
Notifier, Settings, and MessagePool objects.