### PR TITLE
[dhcp] fix solicit request issue introduced in #3287

### DIFF
--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -345,7 +345,8 @@ otError Dhcp6Client::AppendIaNa(Message &aMessage, uint16_t aRloc16)
 
     for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mIdentityAssociations); ++i)
     {
-        if (mIdentityAssociations[i].mStatus == kIaStatusSolicitReplied)
+        if (mIdentityAssociations[i].mStatus == kIaStatusInvalid ||
+            mIdentityAssociations[i].mStatus == kIaStatusSolicitReplied)
         {
             continue;
         }
@@ -381,7 +382,8 @@ otError Dhcp6Client::AppendIaAddress(Message &aMessage, uint16_t aRloc16)
 
     for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mIdentityAssociations); ++i)
     {
-        if ((mIdentityAssociations[i].mStatus != kIaStatusSolicitReplied) &&
+        if ((mIdentityAssociations[i].mStatus == kIaStatusSolicit ||
+             mIdentityAssociations[i].mStatus == kIaStatusSoliciting) &&
             (mIdentityAssociations[i].mPrefixAgentRloc == aRloc16))
         {
             option.SetAddress(mIdentityAssociations[i].mNetifAddress.mAddress);


### PR DESCRIPTION
A pointer was used to point to the IdentityAssociation Linked List for the valid DHCP prefix information in Thread Network.
In #3287, the pointer was removed and whether or not one entry in the `mIdentityAssociations` array is one DHCP prefix configuration becomes to depend solely on the the entry's status. 
Stricter status conditions should be applied when solicit, otherwise there is chance that the Short Address of the DHCP Server is 0x0000, matches the default reset value (all 0) of one invalid `mIdentityAssociations entry`.  