### PR TITLE
[dtls] invoke callback after DTLS disconnect timeout

### DIFF
--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -440,11 +440,6 @@ void Dtls::Disconnect(void)
     new (&mPeerAddress) Ip6::MessageInfo();
     mSocket.Connect(Ip6::SockAddr());
 
-    if (mConnectedHandler != NULL)
-    {
-        mConnectedHandler(mContext, false);
-    }
-
     FreeMbedtls();
 
 exit:
@@ -802,6 +797,11 @@ void Dtls::HandleTimer(void)
     case kStateCloseNotify:
         mState = kStateOpen;
         mTimer.Stop();
+
+        if (mConnectedHandler != NULL)
+        {
+            mConnectedHandler(mContext, false);
+        }
         break;
 
     default:


### PR DESCRIPTION
This PR fixes the DTLS bug that it returns to user before it is truly disconnected.

Previously, the DTLS implementation will call user's callback when it is in the `kStateCloseNotify` state. But this is not the true `DISCONNECTED` state because it doesn't allow user to start a new connection:

```c++
// Checked in Dtls::Connect
VerifyOrExit(mState == kStateOpen, error = OT_ERROR_INVALID_STATE);
```
Suppose the first connnection request failed and user reconnects in the callback, it would failed with `OT_ERROR_INVALID_STATE`. This is not reasonable.
