### PR TITLE
[style] advance C++ language standard to C++11

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -105,7 +105,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp03
+Standard:        Cpp11
 TabWidth:        4
 UseTab:          Never
 ...

--- a/Android.mk
+++ b/Android.mk
@@ -99,6 +99,8 @@ LOCAL_CFLAGS                                                                := \
     $(NULL)
 
 LOCAL_CPPFLAGS                                                              := \
+    -std=c++11                                                                 \
+    -pedantic-errors                                                           \
     -Wno-non-virtual-dtor                                                      \
     $(NULL)
 
@@ -299,6 +301,8 @@ LOCAL_CFLAGS                                                                := \
     $(NULL)
 
 LOCAL_CPPFLAGS                                                              := \
+    -std=c++11                                                                 \
+    -pedantic-errors                                                           \
     -Wno-non-virtual-dtor                                                      \
     $(NULL)
 
@@ -356,6 +360,8 @@ LOCAL_CFLAGS                                                                := \
     $(NULL)
 
 LOCAL_CPPFLAGS                                                              := \
+    -std=c++11                                                                 \
+    -pedantic-errors                                                           \
     -Wno-non-virtual-dtor                                                      \
     $(NULL)
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -18,7 +18,7 @@
 - C
   - OpenThread uses and enforces the ISO9899:1999 (aka ISO C99, C99) C language standard as the minimum.
 - C++
-  - OpenThread uses and enforces the ISO14882:2003 (aka ISO C++03, C++03) C++ language standard as the minimum.
+  - OpenThread uses and enforces the ISO14882:2011 (aka ISO C++11, C++11) C++ language standard as the minimum.
 - Extensions
   - Wherever possible, toolchain-specific (e.g GCC/GNU) extensions or the use of later standards shall be avoided or shall be leveraged through toolchain-compatibility preprocessor macros.
 

--- a/configure.ac
+++ b/configure.ac
@@ -233,7 +233,7 @@ AC_PATH_PROG(CMP, cmp)
 #
 
 PROSPECTIVE_CFLAGS="-Wall -Wextra -Wshadow -Werror -std=c99 -pedantic-errors"
-PROSPECTIVE_CXXFLAGS="-Wall -Wextra -Wshadow -Werror -std=gnu++98 -Wno-c++14-compat -fno-exceptions"
+PROSPECTIVE_CXXFLAGS="-Wall -Wextra -Wshadow -Werror -std=c++11 -pedantic-errors -fno-exceptions"
 
 AC_CACHE_CHECK([whether $CC is Clang],
     [nl_cv_clang],

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1893,7 +1893,7 @@ void Interpreter::HandleIcmpReceive(Message &               aMessage,
 {
     uint32_t timestamp = 0;
 
-    VerifyOrExit(aIcmpHeader.mType == OT_ICMP6_TYPE_ECHO_REPLY);
+    VerifyOrExit(aIcmpHeader.mType == OT_ICMP6_TYPE_ECHO_REPLY, OT_NO_ACTION);
 
     mServer->OutputFormat("%d bytes from ", aMessage.GetLength() - aMessage.GetOffset() + sizeof(otIcmp6Header));
 
@@ -3264,7 +3264,7 @@ otError Interpreter::ProcessMacFilterAddress(int argc, char *argv[])
 
             error = otLinkFilterAddAddress(mInstance, &extAddr);
 
-            VerifyOrExit(error == OT_ERROR_NONE || error == OT_ERROR_ALREADY);
+            VerifyOrExit(error == OT_ERROR_NONE || error == OT_ERROR_ALREADY, OT_NO_ACTION);
 
             if (argc > 2)
             {
@@ -3426,7 +3426,7 @@ void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength, Server &aServer)
 
     mServer = &aServer;
 
-    VerifyOrExit(aBuf != NULL && strnlen(aBuf, aBufLength + 1) <= aBufLength);
+    VerifyOrExit(aBuf != NULL && strnlen(aBuf, aBufLength + 1) <= aBufLength, OT_NO_ACTION);
 
     VerifyOrExit(Utils::CmdLineParser::ParseCmd(aBuf, argc, argv, kMaxArgs) == OT_ERROR_NONE,
                  mServer->OutputFormat("Error: too many args (max %d)\r\n", kMaxArgs));
@@ -3598,7 +3598,7 @@ extern "C" void otCliPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, cons
     OT_UNUSED_VARIABLE(aLogLevel);
     OT_UNUSED_VARIABLE(aLogRegion);
 
-    VerifyOrExit(Server::sServer != NULL);
+    VerifyOrExit(Server::sServer != NULL, OT_NO_ACTION);
 
     Server::sServer->OutputFormatV(aFormat, aArgs);
     Server::sServer->OutputFormat("\r\n");

--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -260,7 +260,7 @@ int Uart::Output(const char *aBuf, uint16_t aBufLength)
 
 void Uart::Send(void)
 {
-    VerifyOrExit(mSendLength == 0);
+    VerifyOrExit(mSendLength == 0, OT_NO_ACTION);
 
     if (mTxLength > kTxBufferSize - mTxHead)
     {

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -189,12 +189,8 @@ otMessage *otIp6NewMessageFromBuffer(otInstance *             aInstance,
                                      const otMessageSettings *aSettings)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
-    Message * message;
 
-    VerifyOrExit((message = instance.Get<Ip6::Ip6>().NewMessage(aData, aDataLength, aSettings)) != NULL);
-
-exit:
-    return message;
+    return instance.Get<Ip6::Ip6>().NewMessage(aData, aDataLength, aSettings);
 }
 
 otError otIp6AddUnsecurePort(otInstance *aInstance, uint16_t aPort)

--- a/src/core/api/tasklet_api.cpp
+++ b/src/core/api/tasklet_api.cpp
@@ -46,7 +46,7 @@ void otTaskletsProcess(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    VerifyOrExit(otInstanceIsInitialized(aInstance));
+    VerifyOrExit(otInstanceIsInitialized(aInstance), OT_NO_ACTION);
     instance.Get<TaskletScheduler>().ProcessQueuedTasklets();
 
 exit:
@@ -58,7 +58,7 @@ bool otTaskletsArePending(otInstance *aInstance)
     bool      retval   = false;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    VerifyOrExit(otInstanceIsInitialized(aInstance));
+    VerifyOrExit(otInstanceIsInitialized(aInstance), OT_NO_ACTION);
     retval = instance.Get<TaskletScheduler>().AreTaskletsPending();
 
 exit:

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -127,7 +127,7 @@ Message *CoapBase::NewMessage(const otMessageSettings *aSettings)
 {
     Message *message = NULL;
 
-    VerifyOrExit((message = static_cast<Message *>(Get<Ip6::Udp>().NewMessage(0, aSettings))) != NULL);
+    VerifyOrExit((message = static_cast<Message *>(Get<Ip6::Udp>().NewMessage(0, aSettings))) != NULL, OT_NO_ACTION);
     message->SetOffset(0);
 
 exit:
@@ -623,7 +623,8 @@ void CoapBase::ProcessReceivedRequest(Message &aMessage, const Ip6::MessageInfo 
                 *curUriPath++ = '/';
             }
 
-            VerifyOrExit(option->mLength < sizeof(uriPath) - static_cast<size_t>(curUriPath + 1 - uriPath));
+            VerifyOrExit(option->mLength < sizeof(uriPath) - static_cast<size_t>(curUriPath + 1 - uriPath),
+                         error = OT_ERROR_NOT_FOUND);
 
             aMessage.GetOptionValue(curUriPath);
             curUriPath += option->mLength;
@@ -782,7 +783,7 @@ void ResponsesQueue::EnqueueResponse(Message &aMessage, const Ip6::MessageInfo &
         DequeueOldestResponse();
     }
 
-    VerifyOrExit((responseCopy = aMessage.Clone()) != NULL);
+    VerifyOrExit((responseCopy = aMessage.Clone()) != NULL, OT_NO_ACTION);
 
     SuccessOrExit(error = enqueuedResponseHeader.AppendTo(*responseCopy));
     mQueue.Enqueue(*responseCopy);
@@ -806,7 +807,7 @@ void ResponsesQueue::DequeueOldestResponse(void)
 {
     Message *message;
 
-    VerifyOrExit((message = static_cast<Message *>(mQueue.GetHead())) != NULL);
+    VerifyOrExit((message = static_cast<Message *>(mQueue.GetHead())) != NULL, OT_NO_ACTION);
     DequeueResponse(*message);
 
 exit:

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -656,7 +656,7 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
-        otLogInfoCoapErr(error, "Failed to process request");
+        otLogInfoCoap("Failed to process request %s", otThreadErrorToString(error));
 
         if (error == OT_ERROR_NOT_FOUND && !aMessageInfo.GetSockAddr().IsMulticast())
         {

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -213,7 +213,7 @@ const otCoapOption *Message::GetFirstOption(void)
 
     memset(&GetHelpData().mOption, 0, sizeof(GetHelpData().mOption));
 
-    VerifyOrExit(GetLength() - GetHelpData().mHeaderOffset >= GetOptionStart());
+    VerifyOrExit(GetLength() - GetHelpData().mHeaderOffset >= GetOptionStart(), option = NULL);
 
     GetHelpData().mNextOptionOffset = GetHelpData().mHeaderOffset + GetOptionStart();
 
@@ -397,7 +397,7 @@ Message *Message::Clone(uint16_t aLength) const
 {
     Message *message = static_cast<Message *>(ot::Message::Clone(aLength));
 
-    VerifyOrExit(message != NULL);
+    VerifyOrExit(message != NULL, OT_NO_ACTION);
 
     memcpy(&message->GetHelpData(), &GetHelpData(), sizeof(GetHelpData()));
 

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -217,7 +217,8 @@ void CoapSecure::HandleDtlsReceive(uint8_t *aBuf, uint16_t aLength)
 {
     ot::Message *message = NULL;
 
-    VerifyOrExit((message = Get<MessagePool>().New(Message::kTypeIp6, Message::GetHelpDataReserved())) != NULL);
+    VerifyOrExit((message = Get<MessagePool>().New(Message::kTypeIp6, Message::GetHelpDataReserved())) != NULL,
+                 OT_NO_ACTION);
     SuccessOrExit(message->Append(aBuf, aLength));
 
     CoapBase::Receive(*message, mDtls.GetPeerAddress());
@@ -240,7 +241,7 @@ void CoapSecure::HandleTransmit(void)
     otError      error   = OT_ERROR_NONE;
     ot::Message *message = mTransmitQueue.GetHead();
 
-    VerifyOrExit(message != NULL);
+    VerifyOrExit(message != NULL, OT_NO_ACTION);
     mTransmitQueue.Dequeue(*message);
 
     if (mTransmitQueue.GetHead() != NULL)

--- a/src/core/common/code_utils.hpp
+++ b/src/core/common/code_utils.hpp
@@ -116,6 +116,14 @@
     } while (false)
 
 /**
+ * This macro allows use of `VerifyOrExit()` when there is no action to take.
+ *
+ * Example: `VerifyOrExit(condition, OT_NO_ACTION);`
+ *
+ */
+#define OT_NO_ACTION
+
+/**
  * This macro unconditionally executes @a ... and branches to the local label 'exit'.
  *
  * @note The use of this interface implies neither success nor failure for the overall exit status of the enclosing

--- a/src/core/common/extension_example.cpp
+++ b/src/core/common/extension_example.cpp
@@ -68,7 +68,7 @@ ExtensionBase &ExtensionBase::Init(Instance &aInstance)
 {
     ExtensionBase *ext = reinterpret_cast<ExtensionBase *>(&sExtensionRaw);
 
-    VerifyOrExit(!ext->mIsInitialized);
+    VerifyOrExit(!ext->mIsInitialized, OT_NO_ACTION);
 
     ext = new (&sExtensionRaw) Extension(aInstance);
 

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -106,7 +106,7 @@ Instance &Instance::InitSingle(void)
 {
     Instance *instance = &Get();
 
-    VerifyOrExit(instance->mIsInitialized == false);
+    VerifyOrExit(instance->mIsInitialized == false, OT_NO_ACTION);
 
     instance = new (&gInstanceRaw) Instance();
 
@@ -170,7 +170,7 @@ void Instance::AfterInit(void)
 
 void Instance::Finalize(void)
 {
-    VerifyOrExit(mIsInitialized == true);
+    VerifyOrExit(mIsInitialized, OT_NO_ACTION);
 
     mIsInitialized = false;
 

--- a/src/core/common/logging.cpp
+++ b/src/core/common/logging.cpp
@@ -44,8 +44,7 @@
 #error OPENTHREAD_CONFIG_ENABLE_DEBUG_UART_LOG requires OPENTHREAD_CONFIG_ENABLE_DEBUG_UART
 #endif
 
-#define otLogDump(aFormat, ...) \
-    _otDynamicLog(aLogLevel, aLogRegion, aFormat OPENTHREAD_CONFIG_LOG_SUFFIX, ##__VA_ARGS__)
+#define otLogDump(aFormat, ...) _otDynamicLog(aLogLevel, aLogRegion, aFormat OPENTHREAD_CONFIG_LOG_SUFFIX, __VA_ARGS__)
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/core/common/logging.cpp
+++ b/src/core/common/logging.cpp
@@ -355,5 +355,5 @@ void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat
 #endif
 
 #ifdef __cplusplus
-};
+} // extern "C"
 #endif

--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -114,16 +114,14 @@ extern "C" {
  *
  * Logging at log level critical.
  *
- * @param[in]  aRegion   The log region.
- * @param[in]  aFormat   A pointer to the format string.
- * @param[in]  ...       Arguments for the format specification.
+ * @param[in]  aRegion  The log region.
+ * @param[in]  ...      Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_CRIT
-#define otLogCrit(aRegion, aFormat, ...) \
-    _otLogFormatter(OT_LOG_LEVEL_CRIT, aRegion, _OT_LEVEL_CRIT_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCrit(aRegion, ...) _otLogFormatter(OT_LOG_LEVEL_CRIT, aRegion, _OT_LEVEL_CRIT_PREFIX __VA_ARGS__, NULL)
 #else
-#define otLogCrit(aRegion, aFormat, ...)
+#define otLogCrit(aRegion, ...)
 #endif
 
 /**
@@ -131,16 +129,14 @@ extern "C" {
  *
  * Logging at log level warning.
  *
- * @param[in]  aRegion   The log region.
- * @param[in]  aFormat   A pointer to the format string.
- * @param[in]  ...       Arguments for the format specification.
+ * @param[in]  aRegion  The log region.
+ * @param[in]  ...      Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
-#define otLogWarn(aRegion, aFormat, ...) \
-    _otLogFormatter(OT_LOG_LEVEL_WARN, aRegion, _OT_LEVEL_WARN_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogWarn(aRegion, ...) _otLogFormatter(OT_LOG_LEVEL_WARN, aRegion, _OT_LEVEL_WARN_PREFIX __VA_ARGS__, NULL)
 #else
-#define otLogWarn(aRegion, aFormat, ...)
+#define otLogWarn(aRegion, ...)
 #endif
 
 /**
@@ -148,16 +144,14 @@ extern "C" {
  *
  * Logging at log level note
  *
- * @param[in]  aRegion   The log region.
- * @param[in]  aFormat   A pointer to the format string.
- * @param[in]  ...       Arguments for the format specification.
+ * @param[in]  aRegion  The log region.
+ * @param[in]  ...      Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
-#define otLogNote(aRegion, aFormat, ...) \
-    _otLogFormatter(OT_LOG_LEVEL_NOTE, aRegion, _OT_LEVEL_NOTE_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogNote(aRegion, ...) _otLogFormatter(OT_LOG_LEVEL_NOTE, aRegion, _OT_LEVEL_NOTE_PREFIX __VA_ARGS__, NULL)
 #else
-#define otLogNote(aRegion, aFormat, ...)
+#define otLogNote(aRegion, ...)
 #endif
 
 /**
@@ -165,16 +159,14 @@ extern "C" {
  *
  * Logging at log level info.
  *
- * @param[in]  aRegion   The log region.
- * @param[in]  aFormat   A pointer to the format string.
- * @param[in]  ...       Arguments for the format specification.
+ * @param[in]  aRegion  The log region.
+ * @param[in]  ...      Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
-#define otLogInfo(aRegion, aFormat, ...) \
-    _otLogFormatter(OT_LOG_LEVEL_INFO, aRegion, _OT_LEVEL_INFO_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogInfo(aRegion, ...) _otLogFormatter(OT_LOG_LEVEL_INFO, aRegion, _OT_LEVEL_INFO_PREFIX __VA_ARGS__, NULL)
 #else
-#define otLogInfo(aRegion, aFormat, ...)
+#define otLogInfo(aRegion, ...)
 #endif
 
 /**
@@ -182,16 +174,14 @@ extern "C" {
  *
  * Logging at log level debug.
  *
- * @param[in]  aRegion   The log region.
- * @param[in]  aFormat   A pointer to the format string.
- * @param[in]  ...       Arguments for the format specification.
+ * @param[in]  aRegion  The log region.
+ * @param[in]  ...      Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG
-#define otLogDebg(aRegion, aFormat, ...) \
-    _otLogFormatter(OT_LOG_LEVEL_DEBG, aRegion, _OT_LEVEL_DEBG_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogDebg(aRegion, ...) _otLogFormatter(OT_LOG_LEVEL_DEBG, aRegion, _OT_LEVEL_DEBG_PREFIX __VA_ARGS__, NULL)
 #else
-#define otLogDebg(aRegion, aFormat, ...)
+#define otLogDebg(aRegion, ...)
 #endif
 
 /**
@@ -199,8 +189,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the API region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -209,8 +198,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the API region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -219,8 +207,7 @@ extern "C" {
  *
  * This method generates a log with level note for the API region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -229,8 +216,7 @@ extern "C" {
  *
  * This method generates a log with level info for the API region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -239,22 +225,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the API region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_API == 1
-#define otLogCritApi(aFormat, ...) otLogCrit(OT_LOG_REGION_API, _OT_REGION_API_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnApi(aFormat, ...) otLogWarn(OT_LOG_REGION_API, _OT_REGION_API_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteApi(aFormat, ...) otLogNote(OT_LOG_REGION_API, _OT_REGION_API_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoApi(aFormat, ...) otLogInfo(OT_LOG_REGION_API, _OT_REGION_API_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgApi(aFormat, ...) otLogDebg(OT_LOG_REGION_API, _OT_REGION_API_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritApi(...) otLogCrit(OT_LOG_REGION_API, _OT_REGION_API_PREFIX __VA_ARGS__)
+#define otLogWarnApi(...) otLogWarn(OT_LOG_REGION_API, _OT_REGION_API_PREFIX __VA_ARGS__)
+#define otLogNoteApi(...) otLogNote(OT_LOG_REGION_API, _OT_REGION_API_PREFIX __VA_ARGS__)
+#define otLogInfoApi(...) otLogInfo(OT_LOG_REGION_API, _OT_REGION_API_PREFIX __VA_ARGS__)
+#define otLogDebgApi(...) otLogDebg(OT_LOG_REGION_API, _OT_REGION_API_PREFIX __VA_ARGS__)
 #else
-#define otLogCritApi(aFormat, ...)
-#define otLogWarnApi(aFormat, ...)
-#define otLogNoteApi(aFormat, ...)
-#define otLogInfoApi(aFormat, ...)
-#define otLogDebgApi(aFormat, ...)
+#define otLogCritApi(...)
+#define otLogWarnApi(...)
+#define otLogNoteApi(...)
+#define otLogInfoApi(...)
+#define otLogDebgApi(...)
 #endif
 
 /**
@@ -262,8 +247,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  *
  */
@@ -273,8 +257,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -283,8 +266,7 @@ extern "C" {
  *
  * This method generates a log with level note for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -293,8 +275,7 @@ extern "C" {
  *
  * This method generates a log with level info for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -303,42 +284,29 @@ extern "C" {
  *
  * This method generates a log with level debug for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MLE == 1
-#define otLogCritMeshCoP(aFormat, ...) \
-    otLogCrit(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnMeshCoP(aFormat, ...) \
-    otLogWarn(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteMeshCoP(aFormat, ...) \
-    otLogNote(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoMeshCoP(aFormat, ...) \
-    otLogInfo(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgMeshCoP(aFormat, ...) \
-    otLogDebg(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritMeshCoP(...) otLogCrit(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX __VA_ARGS__)
+#define otLogWarnMeshCoP(...) otLogWarn(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX __VA_ARGS__)
+#define otLogNoteMeshCoP(...) otLogNote(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX __VA_ARGS__)
+#define otLogInfoMeshCoP(...) otLogInfo(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX __VA_ARGS__)
+#define otLogDebgMeshCoP(...) otLogDebg(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX __VA_ARGS__)
 #else
-#define otLogCritMeshCoP(aFormat, ...)
-#define otLogWarnMeshCoP(aFormat, ...)
-#define otLogNoteMeshCoP(aFormat, ...)
-#define otLogInfoMeshCoP(aFormat, ...)
-#define otLogDebgMeshCoP(aFormat, ...)
+#define otLogCritMeshCoP(...)
+#define otLogWarnMeshCoP(...)
+#define otLogNoteMeshCoP(...)
+#define otLogInfoMeshCoP(...)
+#define otLogDebgMeshCoP(...)
 #endif
-
-#define otLogCritMbedTls(aFormat, ...) otLogCritMeshCoP(aFormat, ##__VA_ARGS__)
-#define otLogWarnMbedTls(aFormat, ...) otLogWarnMeshCoP(aFormat, ##__VA_ARGS__)
-#define otLogNoteMbedTls(aFormat, ...) otLogNoteMeshCoP(aFormat, ##__VA_ARGS__)
-#define otLogInfoMbedTls(aFormat, ...) otLogInfoMeshCoP(aFormat, ##__VA_ARGS__)
-#define otLogDebgMbedTls(aFormat, ...) otLogDebgMeshCoP(aFormat, ##__VA_ARGS__)
 
 /**
  * @def otLogCritMle
  *
  * This method generates a log with level critical for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -347,8 +315,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -357,8 +324,7 @@ extern "C" {
  *
  * This method generates a log with level note for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -367,8 +333,7 @@ extern "C" {
  *
  * This method generates a log with level info for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -377,27 +342,22 @@ extern "C" {
  *
  * This method generates a log with level debug for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MLE == 1
-#define otLogCritMle(aFormat, ...) otLogCrit(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnMle(aFormat, ...) otLogWarn(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnMleErr(aError, aFormat, ...)                                                               \
-    otLogWarn(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX "Error %s: " aFormat, otThreadErrorToString(aError), \
-              ##__VA_ARGS__)
-#define otLogNoteMle(aFormat, ...) otLogNote(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoMle(aFormat, ...) otLogInfo(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgMle(aFormat, ...) otLogDebg(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritMle(...) otLogCrit(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX __VA_ARGS__)
+#define otLogWarnMle(...) otLogWarn(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX __VA_ARGS__)
+#define otLogNoteMle(...) otLogNote(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX __VA_ARGS__)
+#define otLogInfoMle(...) otLogInfo(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX __VA_ARGS__)
+#define otLogDebgMle(...) otLogDebg(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX __VA_ARGS__)
 #else
-#define otLogCritMle(aFormat, ...)
-#define otLogWarnMle(aFormat, ...)
-#define otLogWarnMleErr(aError, aFormat, ...)
-#define otLogNoteMle(aFormat, ...)
-#define otLogInfoMle(aFormat, ...)
-#define otLogDebgMle(aFormat, ...)
+#define otLogCritMle(...)
+#define otLogWarnMle(...)
+#define otLogNoteMle(...)
+#define otLogInfoMle(...)
+#define otLogDebgMle(...)
 #endif
 
 /**
@@ -405,8 +365,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the EID-to-RLOC mapping region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -415,8 +374,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the EID-to-RLOC mapping region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -425,8 +383,7 @@ extern "C" {
  *
  * This method generates a log with level note for the EID-to-RLOC mapping region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -435,8 +392,7 @@ extern "C" {
  *
  * This method generates a log with level info for the EID-to-RLOC mapping region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -445,22 +401,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the EID-to-RLOC mapping region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_ARP == 1
-#define otLogCritArp(aFormat, ...) otLogCrit(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnArp(aFormat, ...) otLogWarn(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteArp(aFormat, ...) otLogNote(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoArp(aFormat, ...) otLogInfo(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgArp(aFormat, ...) otLogDebg(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritArp(...) otLogCrit(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX __VA_ARGS__)
+#define otLogWarnArp(...) otLogWarn(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX __VA_ARGS__)
+#define otLogNoteArp(...) otLogNote(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX __VA_ARGS__)
+#define otLogInfoArp(...) otLogInfo(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX __VA_ARGS__)
+#define otLogDebgArp(...) otLogDebg(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX __VA_ARGS__)
 #else
-#define otLogCritArp(aFormat, ...)
-#define otLogWarnArp(aFormat, ...)
-#define otLogNoteArp(aFormat, ...)
-#define otLogInfoArp(aFormat, ...)
-#define otLogDebgArp(aFormat, ...)
+#define otLogCritArp(...)
+#define otLogWarnArp(...)
+#define otLogNoteArp(...)
+#define otLogInfoArp(...)
+#define otLogDebgArp(...)
 #endif
 
 /**
@@ -468,8 +423,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the Network Data region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -478,8 +432,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the Network Data region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -488,8 +441,7 @@ extern "C" {
  *
  * This method generates a log with level note for the Network Data region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -498,8 +450,7 @@ extern "C" {
  *
  * This method generates a log with level info for the Network Data region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -508,27 +459,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the Network Data region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_NETDATA == 1
-#define otLogCritNetData(aFormat, ...) \
-    otLogCrit(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnNetData(aFormat, ...) \
-    otLogWarn(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteNetData(aFormat, ...) \
-    otLogNote(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoNetData(aFormat, ...) \
-    otLogInfo(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgNetData(aFormat, ...) \
-    otLogDebg(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritNetData(...) otLogCrit(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX __VA_ARGS__)
+#define otLogWarnNetData(...) otLogWarn(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX __VA_ARGS__)
+#define otLogNoteNetData(...) otLogNote(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX __VA_ARGS__)
+#define otLogInfoNetData(...) otLogInfo(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX __VA_ARGS__)
+#define otLogDebgNetData(...) otLogDebg(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX __VA_ARGS__)
 #else
-#define otLogCritNetData(aFormat, ...)
-#define otLogWarnNetData(aFormat, ...)
-#define otLogNoteNetData(aFormat, ...)
-#define otLogInfoNetData(aFormat, ...)
-#define otLogDebgNetData(aFormat, ...)
+#define otLogCritNetData(...)
+#define otLogWarnNetData(...)
+#define otLogNoteNetData(...)
+#define otLogInfoNetData(...)
+#define otLogDebgNetData(...)
 #endif
 
 /**
@@ -536,8 +481,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the ICMPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -546,8 +490,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the ICMPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -556,8 +499,7 @@ extern "C" {
  *
  * This method generates a log with level note for the ICMPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -566,8 +508,7 @@ extern "C" {
  *
  * This method generates a log with level info for the ICMPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -576,22 +517,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the ICMPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_ICMP == 1
-#define otLogCritIcmp(aFormat, ...) otLogCrit(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnIcmp(aFormat, ...) otLogWarn(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteIcmp(aFormat, ...) otLogNote(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoIcmp(aFormat, ...) otLogInfo(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgIcmp(aFormat, ...) otLogDebg(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritIcmp(...) otLogCrit(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX __VA_ARGS__)
+#define otLogWarnIcmp(...) otLogWarn(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX __VA_ARGS__)
+#define otLogNoteIcmp(...) otLogNote(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX __VA_ARGS__)
+#define otLogInfoIcmp(...) otLogInfo(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX __VA_ARGS__)
+#define otLogDebgIcmp(...) otLogDebg(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX __VA_ARGS__)
 #else
-#define otLogCritIcmp(aFormat, ...)
-#define otLogWarnIcmp(aFormat, ...)
-#define otLogNoteIcmp(aFormat, ...)
-#define otLogInfoIcmp(aFormat, ...)
-#define otLogDebgIcmp(aFormat, ...)
+#define otLogCritIcmp(...)
+#define otLogWarnIcmp(...)
+#define otLogNoteIcmp(...)
+#define otLogInfoIcmp(...)
+#define otLogDebgIcmp(...)
 #endif
 
 /**
@@ -599,8 +539,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the IPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -609,8 +548,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the IPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -619,8 +557,7 @@ extern "C" {
  *
  * This method generates a log with level note for the IPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -629,8 +566,7 @@ extern "C" {
  *
  * This method generates a log with level info for the IPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -639,22 +575,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the IPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_IP6 == 1
-#define otLogCritIp6(aFormat, ...) otLogCrit(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnIp6(aFormat, ...) otLogWarn(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteIp6(aFormat, ...) otLogNote(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoIp6(aFormat, ...) otLogInfo(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgIp6(aFormat, ...) otLogDebg(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritIp6(...) otLogCrit(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX __VA_ARGS__)
+#define otLogWarnIp6(...) otLogWarn(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX __VA_ARGS__)
+#define otLogNoteIp6(...) otLogNote(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX __VA_ARGS__)
+#define otLogInfoIp6(...) otLogInfo(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX __VA_ARGS__)
+#define otLogDebgIp6(...) otLogDebg(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX __VA_ARGS__)
 #else
-#define otLogCritIp6(aFormat, ...)
-#define otLogWarnIp6(aFormat, ...)
-#define otLogNoteIp6(aFormat, ...)
-#define otLogInfoIp6(aFormat, ...)
-#define otLogDebgIp6(aFormat, ...)
+#define otLogCritIp6(...)
+#define otLogWarnIp6(...)
+#define otLogNoteIp6(...)
+#define otLogInfoIp6(...)
+#define otLogDebgIp6(...)
 #endif
 
 /**
@@ -662,8 +597,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the MAC region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -672,8 +606,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the MAC region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -682,8 +615,7 @@ extern "C" {
  *
  * This method generates a log with level note for the MAC region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -692,8 +624,7 @@ extern "C" {
  *
  * This method generates a log with level info for the MAC region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -702,8 +633,7 @@ extern "C" {
  *
  * This method generates a log with level debug for the MAC region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -712,38 +642,34 @@ extern "C" {
  *
  * This method generates a log with a given log level for the MAC region.
  *
- * @param[in]  aLogLevel    A log level.
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  aLogLevel  A log level.
+ * @param[in]  aFormat    A pointer to the format string.
+ * @param[in]  ...        Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MAC == 1
-#define otLogCritMac(aFormat, ...) otLogCrit(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnMac(aFormat, ...) otLogWarn(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteMac(aFormat, ...) otLogNote(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoMac(aFormat, ...) otLogInfo(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgMac(aFormat, ...) otLogDebg(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgMacErr(aError, aFormat, ...)                                                               \
-    otLogWarn(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX "Error %s: " aFormat, otThreadErrorToString(aError), \
-              ##__VA_ARGS__)
+#define otLogCritMac(...) otLogCrit(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX __VA_ARGS__)
+#define otLogWarnMac(...) otLogWarn(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX __VA_ARGS__)
+#define otLogNoteMac(...) otLogNote(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX __VA_ARGS__)
+#define otLogInfoMac(...) otLogInfo(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX __VA_ARGS__)
+#define otLogDebgMac(...) otLogDebg(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX __VA_ARGS__)
 #define otLogMac(aLogLevel, aFormat, ...)                                                     \
     do                                                                                        \
     {                                                                                         \
         if (otLoggingGetLevel() >= aLogLevel)                                                 \
         {                                                                                     \
             _otLogFormatter(aLogLevel, OT_LOG_REGION_MAC, "%s" _OT_REGION_MAC_PREFIX aFormat, \
-                            otLogLevelToPrefixString(aLogLevel), ##__VA_ARGS__);              \
+                            otLogLevelToPrefixString(aLogLevel), __VA_ARGS__);                \
         }                                                                                     \
     } while (false)
 
 #else
-#define otLogCritMac(aFormat, ...)
-#define otLogWarnMac(aFormat, ...)
-#define otLogNoteMac(aFormat, ...)
-#define otLogInfoMac(aFormat, ...)
-#define otLogDebgMac(aFormat, ...)
-#define otLogDebgMacErr(aError, aFormat, ...)
-#define otLogMac(aLogLevel, aFormat, ...)
+#define otLogCritMac(...)
+#define otLogWarnMac(...)
+#define otLogNoteMac(...)
+#define otLogInfoMac(...)
+#define otLogDebgMac(...)
+#define otLogMac(aLogLevel, ...)
 #endif
 
 /**
@@ -751,8 +677,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the Core region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -761,8 +686,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the Core region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -771,8 +695,7 @@ extern "C" {
  *
  * This method generates a log with level note for the Core region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -781,8 +704,7 @@ extern "C" {
  *
  * This method generates a log with level info for the Core region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -791,25 +713,20 @@ extern "C" {
  *
  * This method generates a log with level debug for the Core region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_CORE == 1
-#define otLogCritCore(aFormat, ...) otLogCrit(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnCore(aFormat, ...) otLogWarn(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteCore(aFormat, ...) otLogNote(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoCore(aFormat, ...) otLogInfo(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgCore(aFormat, ...) otLogDebg(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgCoreErr(aError, aFormat, ...)                                                                \
-    otLogWarn(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX "Error %s: " aFormat, otThreadErrorToString(aError), \
-              ##__VA_ARGS__)
+#define otLogCritCore(...) otLogCrit(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX __VA_ARGS__)
+#define otLogWarnCore(...) otLogWarn(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX __VA_ARGS__)
+#define otLogNoteCore(...) otLogNote(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX __VA_ARGS__)
+#define otLogInfoCore(...) otLogInfo(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX __VA_ARGS__)
+#define otLogDebgCore(...) otLogDebg(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX __VA_ARGS__)
 #else
-#define otLogCritCore(aFormat, ...)
-#define otLogWarnCore(aFormat, ...)
-#define otLogInfoCore(aFormat, ...)
-#define otLogDebgCore(aFormat, ...)
-#define otLogDebgCoreErr(aError, aFormat, ...)
+#define otLogCritCore(...)
+#define otLogWarnCore(...)
+#define otLogInfoCore(...)
+#define otLogDebgCore(...)
 #endif
 
 /**
@@ -817,8 +734,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the memory region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -827,8 +743,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the memory region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -837,8 +752,7 @@ extern "C" {
  *
  * This method generates a log with level note for the memory region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -847,8 +761,7 @@ extern "C" {
  *
  * This method generates a log with level info for the memory region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -857,22 +770,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the memory region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MEM == 1
-#define otLogCritMem(aFormat, ...) otLogCrit(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnMem(aFormat, ...) otLogWarn(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteMem(aFormat, ...) otLogNote(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoMem(aFormat, ...) otLogInfo(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgMem(aFormat, ...) otLogDebg(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritMem(...) otLogCrit(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX __VA_ARGS__)
+#define otLogWarnMem(...) otLogWarn(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX __VA_ARGS__)
+#define otLogNoteMem(...) otLogNote(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX __VA_ARGS__)
+#define otLogInfoMem(...) otLogInfo(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX __VA_ARGS__)
+#define otLogDebgMem(...) otLogDebg(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX __VA_ARGS__)
 #else
-#define otLogCritMem(aFormat, ...)
-#define otLogWarnMem(aFormat, ...)
-#define otLogNoteMem(aFormat, ...)
-#define otLogInfoMem(aFormat, ...)
-#define otLogDebgMem(aFormat, ...)
+#define otLogCritMem(...)
+#define otLogWarnMem(...)
+#define otLogNoteMem(...)
+#define otLogInfoMem(...)
+#define otLogDebgMem(...)
 #endif
 
 /**
@@ -880,8 +792,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the Util region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -890,8 +801,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the Util region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -900,8 +810,7 @@ extern "C" {
  *
  * This method generates a log with level note for the Util region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -910,8 +819,7 @@ extern "C" {
  *
  * This method generates a log with level info for the Util region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -920,26 +828,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the Util region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_UTIL == 1
-#define otLogCritUtil(aFormat, ...) otLogCrit(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnUtil(aFormat, ...) otLogWarn(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteUtil(aFormat, ...) otLogNote(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoUtil(aFormat, ...) otLogInfo(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoUtilErr(aError, aFormat, ...)                                                                \
-    otLogInfo(OT_LOG_REGION_UTIL, _OT_REGION_CORE_PREFIX "Error %s: " aFormat, otThreadErrorToString(aError), \
-              ##__VA_ARGS__)
-#define otLogDebgUtil(aFormat, ...) otLogDebg(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritUtil(...) otLogCrit(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX __VA_ARGS__)
+#define otLogWarnUtil(...) otLogWarn(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX __VA_ARGS__)
+#define otLogNoteUtil(...) otLogNote(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX __VA_ARGS__)
+#define otLogInfoUtil(...) otLogInfo(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX __VA_ARGS__)
+#define otLogDebgUtil(...) otLogDebg(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX __VA_ARGS__)
 #else
-#define otLogCritUtil(aFormat, ...)
-#define otLogWarnUtil(aFormat, ...)
-#define otLogNoteUtil(aFormat, ...)
-#define otLogInfoUtil(aFormat, ...)
-#define otLogInfoUtilErr(aError, aFormat, ...)
-#define otLogDebgUtil(aFormat, ...)
+#define otLogCritUtil(...)
+#define otLogWarnUtil(...)
+#define otLogNoteUtil(...)
+#define otLogInfoUtil(...)
+#define otLogDebgUtil(...)
 #endif
 
 /**
@@ -947,8 +850,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the NETDIAG region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -957,8 +859,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the NETDIAG region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -967,8 +868,7 @@ extern "C" {
  *
  * This method generates a log with level note for the NETDIAG region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -977,8 +877,7 @@ extern "C" {
  *
  * This method generates a log with level info for the NETDIAG region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -987,27 +886,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the NETDIAG region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_NETDIAG == 1
-#define otLogCritNetDiag(aFormat, ...) \
-    otLogCrit(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnNetDiag(aFormat, ...) \
-    otLogWarn(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteNetDiag(aFormat, ...) \
-    otLogNote(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoNetDiag(aFormat, ...) \
-    otLogInfo(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgNetDiag(aFormat, ...) \
-    otLogDebg(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritNetDiag(...) otLogCrit(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX __VA_ARGS__)
+#define otLogWarnNetDiag(...) otLogWarn(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX __VA_ARGS__)
+#define otLogNoteNetDiag(...) otLogNote(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX __VA_ARGS__)
+#define otLogInfoNetDiag(...) otLogInfo(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX __VA_ARGS__)
+#define otLogDebgNetDiag(...) otLogDebg(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX __VA_ARGS__)
 #else
-#define otLogCritNetDiag(aFormat, ...)
-#define otLogWarnNetDiag(aFormat, ...)
-#define otLogNoteNetDiag(aFormat, ...)
-#define otLogInfoNetDiag(aFormat, ...)
-#define otLogDebgNetDiag(aFormat, ...)
+#define otLogCritNetDiag(...)
+#define otLogWarnNetDiag(...)
+#define otLogNoteNetDiag(...)
+#define otLogInfoNetDiag(...)
+#define otLogDebgNetDiag(...)
 #endif
 
 /**
@@ -1015,16 +908,14 @@ extern "C" {
  *
  * This method generates a log with level none for the certification test.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  *
  */
 #if OPENTHREAD_ENABLE_REFERENCE_DEVICE
-#define otLogCertMeshCoP(aFormat, ...) \
-    _otLogFormatter(OT_LOG_LEVEL_NONE, OT_LOG_REGION_MESH_COP, aFormat, ##__VA_ARGS__)
+#define otLogCertMeshCoP(...) _otLogFormatter(OT_LOG_LEVEL_NONE, OT_LOG_REGION_MESH_COP, __VA_ARGS__, NULL)
 #else
-#define otLogCertMeshCoP(aFormat, ...)
+#define otLogCertMeshCoP(...)
 #endif
 
 /**
@@ -1032,8 +923,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the CLI region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1042,8 +932,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the CLI region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1052,8 +941,7 @@ extern "C" {
  *
  * This method generates a log with level note for the CLI region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1062,8 +950,7 @@ extern "C" {
  *
  * This method generates a log with level info for the CLI region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1072,26 +959,22 @@ extern "C" {
  *
  * This method generates a log with level debug for the CLI region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_CLI == 1
 
-#define otLogCritCli(aFormat, ...) otLogCrit(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnCli(aFormat, ...) otLogWarn(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteCli(aFormat, ...) otLogNote(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoCli(aFormat, ...) otLogInfo(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoCliErr(aError, aFormat, ...) \
-    otLogInfo(OT_LOG_REGION_CLI, "Error %s: " aFormat, otThreadErrorToString(aError), ##__VA_ARGS__)
-#define otLogDebgCli(aFormat, ...) otLogDebg(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritCli(...) otLogCrit(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX __VA_ARGS__)
+#define otLogWarnCli(...) otLogWarn(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX __VA_ARGS__)
+#define otLogNoteCli(...) otLogNote(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX __VA_ARGS__)
+#define otLogInfoCli(...) otLogInfo(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX __VA_ARGS__)
+#define otLogDebgCli(...) otLogDebg(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX __VA_ARGS__)
 #else
-#define otLogCritCli(aFormat, ...)
-#define otLogWarnCli(aFormat, ...)
-#define otLogNoteCli(aFormat, ...)
-#define otLogInfoCli(aFormat, ...)
-#define otLogInfoCliErr(aError, aFormat, ...)
-#define otLogDebgCli(aFormat, ...)
+#define otLogCritCli(...)
+#define otLogWarnCli(...)
+#define otLogNoteCli(...)
+#define otLogInfoCli(...)
+#define otLogDebgCli(...)
 #endif
 
 /**
@@ -1099,8 +982,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the CoAP region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1109,8 +991,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the CoAP region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1119,8 +1000,7 @@ extern "C" {
  *
  * This method generates a log with level note for the CoAP region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1129,8 +1009,7 @@ extern "C" {
  *
  * This method generates a log with level info for the CoAP region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1139,26 +1018,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the CoAP region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_COAP == 1
-#define otLogCritCoap(aFormat, ...) otLogCrit(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnCoap(aFormat, ...) otLogWarn(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteCoap(aFormat, ...) otLogNote(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoCoap(aFormat, ...) otLogInfo(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoCoapErr(aError, aFormat, ...)                                                                \
-    otLogInfo(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX "Error %s: " aFormat, otThreadErrorToString(aError), \
-              ##__VA_ARGS__)
-#define otLogDebgCoap(aFormat, ...) otLogDebg(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritCoap(...) otLogCrit(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX __VA_ARGS__)
+#define otLogWarnCoap(...) otLogWarn(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX __VA_ARGS__)
+#define otLogNoteCoap(...) otLogNote(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX __VA_ARGS__)
+#define otLogInfoCoap(...) otLogInfo(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX __VA_ARGS__)
+#define otLogDebgCoap(...) otLogDebg(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX __VA_ARGS__)
 #else
-#define otLogCritCoap(aFormat, ...)
-#define otLogWarnCoap(aFormat, ...)
-#define otLogNoteCoap(aFormat, ...)
-#define otLogInfoCoap(aFormat, ...)
-#define otLogInfoCoapErr(aError, aFormat, ...)
-#define otLogDebgCoap(aFormat, ...)
+#define otLogCritCoap(...)
+#define otLogWarnCoap(...)
+#define otLogNoteCoap(...)
+#define otLogInfoCoap(...)
+#define otLogDebgCoap(...)
 #endif
 
 /**
@@ -1166,8 +1040,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the Platform region.
  *
- * @param[in]  aFormat   A pointer to the format string.
- * @param[in]  ...       Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1176,8 +1049,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the Platform region.
  *
- * @param[in]  aFormat   A pointer to the format string.
- * @param[in]  ...       Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1186,8 +1058,7 @@ extern "C" {
  *
  * This method generates a log with level note for the Platform region.
  *
- * @param[in]  aFormat   A pointer to the format string.
- * @param[in]  ...       Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1196,8 +1067,7 @@ extern "C" {
  *
  * This method generates a log with level info for the Platform region.
  *
- * @param[in]  aFormat   A pointer to the format string.
- * @param[in]  ...       Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1206,22 +1076,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the Platform region.
  *
- * @param[in]  aFormat   A pointer to the format string.
- * @param[in]  ...       Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_PLATFORM == 1
-#define otLogCritPlat(aFormat, ...) otLogCrit(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnPlat(aFormat, ...) otLogWarn(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNotePlat(aFormat, ...) otLogNote(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoPlat(aFormat, ...) otLogInfo(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgPlat(aFormat, ...) otLogDebg(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritPlat(...) otLogCrit(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX __VA_ARGS__)
+#define otLogWarnPlat(...) otLogWarn(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX __VA_ARGS__)
+#define otLogNotePlat(...) otLogNote(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX __VA_ARGS__)
+#define otLogInfoPlat(...) otLogInfo(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX __VA_ARGS__)
+#define otLogDebgPlat(...) otLogDebg(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX __VA_ARGS__)
 #else
-#define otLogCritPlat(aFormat, ...)
-#define otLogWarnPlat(aFormat, ...)
-#define otLogNotePlat(aFormat, ...)
-#define otLogInfoPlat(aFormat, ...)
-#define otLogDebgPlat(aFormat, ...)
+#define otLogCritPlat(...)
+#define otLogWarnPlat(...)
+#define otLogNotePlat(...)
+#define otLogInfoPlat(...)
+#define otLogDebgPlat(...)
 #endif
 
 /**
@@ -1229,10 +1098,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level critical.
  *
- * @param[in]  aRegion      The log region.
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aRegion  The log region.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_CRIT
@@ -1246,10 +1115,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level warning.
  *
- * @param[in]  aRegion      The log region.
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aRegion  The log region.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
@@ -1263,10 +1132,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level note.
  *
- * @param[in]  aRegion      The log region.
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aRegion  The log region.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
@@ -1280,10 +1149,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level info.
  *
- * @param[in]  aRegion      The log region.
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aRegion  The log region.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
@@ -1297,10 +1166,10 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug.
  *
- * @param[in]  aRegion      The log region.
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aRegion  The log region.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG
@@ -1314,9 +1183,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region Network Data.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1325,26 +1194,26 @@ extern "C" {
  *
  * This method generates a memory dump with log level warning and region Network Data.
  *
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
 /**
  * @def otDumpNoteNetData
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
 /**
  * @def otDumpInfoNetData
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1353,9 +1222,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region Network Data.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_NETDATA == 1
@@ -1377,9 +1246,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region MLE.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1388,9 +1257,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level warning and region MLE.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1399,9 +1268,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level note and region MLE.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1410,9 +1279,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level info and region MLE.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1421,9 +1290,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region MLE.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MLE == 1
@@ -1445,9 +1314,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region EID-to-RLOC mapping.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1456,9 +1325,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level warning and region EID-to-RLOC mapping.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1467,9 +1336,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level note and region EID-to-RLOC mapping.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1478,9 +1347,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level info and region EID-to-RLOC mapping.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1489,9 +1358,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region EID-to-RLOC mapping.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_ARP == 1
@@ -1513,9 +1382,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region ICMPv6.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1524,9 +1393,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level warning and region ICMPv6.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1535,9 +1404,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level note and region ICMPv6.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1546,9 +1415,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level info and region ICMPv6.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1557,9 +1426,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region ICMPv6.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_ICMP == 1
@@ -1581,9 +1450,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region IPv6.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1592,9 +1461,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level warning and region IPv6.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1603,9 +1472,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level note and region IPv6.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1614,9 +1483,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level info and region IPv6.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1625,9 +1494,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region IPv6.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_IP6 == 1
@@ -1649,9 +1518,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region MAC.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1660,9 +1529,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level warning and region MAC.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1671,9 +1540,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level note and region MAC.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1682,9 +1551,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level info and region MAC.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1693,9 +1562,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region MAC.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MAC == 1
@@ -1717,9 +1586,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region Core.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1728,9 +1597,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level warning and region Core.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1739,9 +1608,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level note and region Core.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1750,9 +1619,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level info and region Core.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1761,9 +1630,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region Core.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_CORE == 1
@@ -1785,9 +1654,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region memory.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1796,9 +1665,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level warning and region memory.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1807,9 +1676,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level note and region memory.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1818,9 +1687,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level info and region memory.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 
@@ -1829,9 +1698,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level debug and region memory.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MEM == 1
@@ -1853,9 +1722,9 @@ extern "C" {
  *
  * This method generates a memory dump with log level none for the certification test.
  *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aId      A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf     A pointer to the buffer.
+ * @param[in]  aLength  Number of bytes to print.
  *
  */
 #if OPENTHREAD_ENABLE_REFERENCE_DEVICE
@@ -1867,11 +1736,11 @@ extern "C" {
 /**
  * This method dumps bytes to the log in a human-readable fashion.
  *
- * @param[in]  aLogLevel    The log level.
- * @param[in]  aLogRegion   The log region.
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
+ * @param[in]  aLogLevel   The log level.
+ * @param[in]  aLogRegion  The log region.
+ * @param[in]  aId         A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf        A pointer to the buffer.
+ * @param[in]  aLength     Number of bytes to print.
  *
  */
 void otDump(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aId, const void *aBuf, size_t aLength);
@@ -1879,7 +1748,7 @@ void otDump(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aId, const
 /**
  * This function converts a log level to a prefix string for appending to log message.
  *
- * @param[in]  aLogLevel    A log level.
+ * @param[in]  aLogLevel  A log level.
  *
  * @returns A C string representing the log level.
  *
@@ -1890,23 +1759,23 @@ const char *otLogLevelToPrefixString(otLogLevel aLogLevel);
  * Local/private macro to format the log message
  */
 #define _otLogFormatter(aLogLevel, aRegion, aFormat, ...) \
-    _otDynamicLog(aLogLevel, aRegion, aFormat OPENTHREAD_CONFIG_LOG_SUFFIX, ##__VA_ARGS__)
+    _otDynamicLog(aLogLevel, aRegion, aFormat OPENTHREAD_CONFIG_LOG_SUFFIX, __VA_ARGS__)
 
 #if OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL == 1
 
 /**
  * Local/private macro to dynamically filter log level.
  */
-#define _otDynamicLog(aLogLevel, aRegion, aFormat, ...)             \
-    do                                                              \
-    {                                                               \
-        if (otLoggingGetLevel() >= aLogLevel)                       \
-            _otPlatLog(aLogLevel, aRegion, aFormat, ##__VA_ARGS__); \
+#define _otDynamicLog(aLogLevel, aRegion, ...)           \
+    do                                                   \
+    {                                                    \
+        if (otLoggingGetLevel() >= aLogLevel)            \
+            _otPlatLog(aLogLevel, aRegion, __VA_ARGS__); \
     } while (false)
 
 #else // OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
 
-#define _otDynamicLog(aLogLevel, aRegion, aFormat, ...) _otPlatLog(aLogLevel, aRegion, aFormat, ##__VA_ARGS__)
+#define _otDynamicLog(aLogLevel, aRegion, ...) _otPlatLog(aLogLevel, aRegion, __VA_ARGS__)
 
 #endif // OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL
 
@@ -1914,8 +1783,7 @@ const char *otLogLevelToPrefixString(otLogLevel aLogLevel);
  * `OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION` is a configuration parameter (see `openthread-core-default-config.h`) which
  * specifies the function/macro to be used for logging in OpenThread. By default it is set to `otPlatLog()`.
  */
-#define _otPlatLog(aLogLevel, aRegion, aFormat, ...) \
-    OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION(aLogLevel, aRegion, aFormat, ##__VA_ARGS__)
+#define _otPlatLog(aLogLevel, aRegion, ...) OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION(aLogLevel, aRegion, __VA_ARGS__)
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -1918,7 +1918,7 @@ const char *otLogLevelToPrefixString(otLogLevel aLogLevel);
     OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION(aLogLevel, aRegion, aFormat, ##__VA_ARGS__)
 
 #ifdef __cplusplus
-};
+} // extern "C"
 #endif
 
 #endif // LOGGING_HPP_

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -68,7 +68,7 @@ Message *MessagePool::New(uint8_t aType, uint16_t aReserveHeader, uint8_t aPrior
     otError  error   = OT_ERROR_NONE;
     Message *message = NULL;
 
-    VerifyOrExit((message = static_cast<Message *>(NewBuffer(aPriority))) != NULL);
+    VerifyOrExit((message = static_cast<Message *>(NewBuffer(aPriority))) != NULL, OT_NO_ACTION);
 
     memset(message, 0, sizeof(*message));
     message->SetMessagePool(this);
@@ -367,7 +367,7 @@ otError Message::SetPriority(uint8_t aPriority)
     VerifyOrExit(aPriority < kNumPriorities, error = OT_ERROR_INVALID_ARGS);
 
     VerifyOrExit(IsInAQueue(), mBuffer.mHead.mInfo.mPriority = aPriority);
-    VerifyOrExit(mBuffer.mHead.mInfo.mPriority != aPriority);
+    VerifyOrExit(mBuffer.mHead.mInfo.mPriority != aPriority, OT_NO_ACTION);
 
     if (mBuffer.mHead.mInfo.mInPriorityQ)
     {

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -74,7 +74,7 @@ otError Notifier::RegisterCallback(otStateChangedCallback aCallback, void *aCont
     otError           error          = OT_ERROR_NONE;
     ExternalCallback *unusedCallback = NULL;
 
-    VerifyOrExit(aCallback != NULL);
+    VerifyOrExit(aCallback != NULL, OT_NO_ACTION);
 
     for (unsigned int i = 0; i < kMaxExternalHandlers; i++)
     {
@@ -104,7 +104,7 @@ exit:
 
 void Notifier::RemoveCallback(otStateChangedCallback aCallback, void *aContext)
 {
-    VerifyOrExit(aCallback != NULL);
+    VerifyOrExit(aCallback != NULL, OT_NO_ACTION);
 
     for (unsigned int i = 0; i < kMaxExternalHandlers; i++)
     {
@@ -145,7 +145,7 @@ void Notifier::HandleStateChanged(void)
 {
     otChangedFlags flags = mFlagsToSignal;
 
-    VerifyOrExit(flags != 0);
+    VerifyOrExit(flags != 0, OT_NO_ACTION);
 
     mFlagsToSignal = 0;
 
@@ -183,7 +183,7 @@ void Notifier::LogChangedFlags(otChangedFlags aFlags) const
 
     for (uint8_t bit = 0; bit < sizeof(otChangedFlags) * CHAR_BIT; bit++)
     {
-        VerifyOrExit(flags != 0);
+        VerifyOrExit(flags != 0, OT_NO_ACTION);
 
         if (flags & (1 << bit))
         {

--- a/src/core/common/random_manager.cpp
+++ b/src/core/common/random_manager.cpp
@@ -61,7 +61,7 @@ RandomManager::RandomManager(void)
 
     assert(sInitCount < 0xffff);
 
-    VerifyOrExit(sInitCount == 0);
+    VerifyOrExit(sInitCount == 0, OT_NO_ACTION);
 
 #ifndef OPENTHREAD_RADIO
     sEntropy.Init();
@@ -85,7 +85,7 @@ RandomManager::~RandomManager(void)
     assert(sInitCount > 0);
 
     sInitCount--;
-    VerifyOrExit(sInitCount == 0);
+    VerifyOrExit(sInitCount == 0, OT_NO_ACTION);
 
 #ifndef OPENTHREAD_RADIO
     sCtrDrbg.Deinit();
@@ -168,7 +168,7 @@ int RandomManager::Entropy::HandleMbedtlsEntropyPoll(void *         aData,
     SuccessOrExit(otPlatEntropyGet(reinterpret_cast<uint8_t *>(aOutput), static_cast<uint16_t>(aInLen)));
     rval = 0;
 
-    VerifyOrExit(aOutLen != NULL);
+    VerifyOrExit(aOutLen != NULL, OT_NO_ACTION);
     *aOutLen = aInLen;
 
 exit:

--- a/src/core/common/string.cpp
+++ b/src/core/common/string.cpp
@@ -59,6 +59,6 @@ otError StringBase::Write(char *aBuffer, uint16_t aSize, uint16_t &aLength, cons
     }
 
     return error;
-};
+}
 
 } // namespace ot

--- a/src/core/common/tasklet.cpp
+++ b/src/core/common/tasklet.cpp
@@ -66,7 +66,7 @@ otError TaskletScheduler::Post(Tasklet &aTasklet)
 
     VerifyOrExit(mTail != &aTasklet && aTasklet.mNext == NULL, error = OT_ERROR_ALREADY);
 
-    VerifyOrExit(&aTasklet.Get<TaskletScheduler>() == this);
+    VerifyOrExit(&aTasklet.Get<TaskletScheduler>() == this, error = OT_ERROR_NONE);
 
     if (mTail == NULL)
     {

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -127,7 +127,7 @@ void TimerScheduler::Add(Timer &aTimer, const AlarmApi &aAlarmApi)
 
 void TimerScheduler::Remove(Timer &aTimer, const AlarmApi &aAlarmApi)
 {
-    VerifyOrExit(aTimer.mNext != &aTimer);
+    VerifyOrExit(aTimer.mNext != &aTimer, OT_NO_ACTION);
 
     if (mHead == &aTimer)
     {
@@ -205,7 +205,7 @@ extern "C" void otPlatAlarmMilliFired(otInstance *aInstance)
 {
     Instance *instance = static_cast<Instance *>(aInstance);
 
-    VerifyOrExit(otInstanceIsInitialized(aInstance));
+    VerifyOrExit(otInstanceIsInitialized(aInstance), OT_NO_ACTION);
     instance->Get<TimerMilliScheduler>().ProcessTimers();
 
 exit:
@@ -232,7 +232,7 @@ extern "C" void otPlatAlarmMicroFired(otInstance *aInstance)
 {
     Instance *instance = static_cast<Instance *>(aInstance);
 
-    VerifyOrExit(otInstanceIsInitialized(aInstance));
+    VerifyOrExit(otInstanceIsInitialized(aInstance), OT_NO_ACTION);
     instance->Get<TimerMicroScheduler>().ProcessTimers();
 
 exit:

--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -78,11 +78,12 @@ otError Tlv::GetOffset(const Message &aMessage, uint8_t aType, uint16_t &aOffset
         {
             uint16_t extLength;
 
-            VerifyOrExit(sizeof(extLength) == aMessage.Read(offset + sizeof(tlv), sizeof(extLength), &extLength));
+            VerifyOrExit(sizeof(extLength) == aMessage.Read(offset + sizeof(tlv), sizeof(extLength), &extLength),
+                         error = OT_ERROR_NOT_FOUND);
             length += sizeof(extLength) + HostSwap16(extLength);
         }
 
-        VerifyOrExit(offset + length <= end);
+        VerifyOrExit(offset + length <= end, error = OT_ERROR_NOT_FOUND);
 
         if (tlv.GetType() == aType)
         {
@@ -114,13 +115,13 @@ otError Tlv::GetValueOffset(const Message &aMessage, uint8_t aType, uint16_t &aO
 
         if (length == kExtendedLength)
         {
-            VerifyOrExit(offset + sizeof(length) <= end);
+            VerifyOrExit(offset + sizeof(length) <= end, error = OT_ERROR_NOT_FOUND);
             aMessage.Read(offset, sizeof(length), &length);
             offset += sizeof(length);
             length = HostSwap16(length);
         }
 
-        VerifyOrExit(length <= end - offset);
+        VerifyOrExit(length <= end - offset, error = OT_ERROR_NOT_FOUND);
 
         if (tlv.GetType() == aType)
         {

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -95,7 +95,7 @@ void TrickleTimer::IndicateInconsistent(void)
 {
     // If interval is equal to minimum when an "inconsistent" event
     // is received, do nothing.
-    VerifyOrExit(mIsRunning && (mInterval != mIntervalMin));
+    VerifyOrExit(mIsRunning && (mInterval != mIntervalMin), OT_NO_ACTION);
 
     mInterval = mIntervalMin;
     StartNewInterval();

--- a/src/core/mac/channel_mask.cpp
+++ b/src/core/mac/channel_mask.cpp
@@ -78,7 +78,7 @@ uint8_t ChannelMask::ChooseRandomChannel(void) const
     uint8_t channel = kChannelIteratorFirst;
     uint8_t randomIndex;
 
-    VerifyOrExit(!IsEmpty());
+    VerifyOrExit(!IsEmpty(), OT_NO_ACTION);
 
     randomIndex = Random::NonCrypto::GetUint8InRange(0, GetNumberOfChannels());
 

--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -181,7 +181,7 @@ void DataPollSender::HandlePollSent(Mac::Frame &aFrame, otError aError)
     Mac::Address macDest;
     bool         shouldRecalculatePollPeriod = false;
 
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NO_ACTION);
 
     aFrame.GetDstAddr(macDest);
     Get<MeshForwarder>().UpdateNeighborOnSentFrame(aFrame, aError, macDest);
@@ -262,7 +262,7 @@ void DataPollSender::HandlePollTimeout(void)
     // a data poll indicated that a frame was pending, but no frame
     // was received after timeout interval.
 
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NO_ACTION);
 
     mPollTimeoutCounter++;
 
@@ -283,7 +283,7 @@ exit:
 
 void DataPollSender::CheckFramePending(Mac::Frame &aFrame)
 {
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NO_ACTION);
 
     mPollTimeoutCounter = 0;
 
@@ -351,11 +351,11 @@ otError DataPollSender::StopFastPolls(void)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mFastPollsUsers != 0);
+    VerifyOrExit(mFastPollsUsers != 0, OT_NO_ACTION);
 
     // If `mFastPollsUsers` hits the max, let it be cleared
     // from `HandlePollSent()` (after all fast polls are sent).
-    VerifyOrExit(mFastPollsUsers < kMaxFastPollsUsers);
+    VerifyOrExit(mFastPollsUsers < kMaxFastPollsUsers, OT_NO_ACTION);
 
     mFastPollsUsers--;
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -319,7 +319,7 @@ void Mac::EnergyScanDone(int8_t aEnergyScanMaxRssi)
 
 void Mac::SetRxOnWhenIdle(bool aRxOnWhenIdle)
 {
-    VerifyOrExit(mRxOnWhenIdle != aRxOnWhenIdle);
+    VerifyOrExit(mRxOnWhenIdle != aRxOnWhenIdle, OT_NO_ACTION);
 
     mRxOnWhenIdle = aRxOnWhenIdle;
 
@@ -367,7 +367,7 @@ otError Mac::SetPanChannel(uint8_t aChannel)
     mCcaSuccessRateTracker.Reset();
     Get<Notifier>().Signal(OT_CHANGED_THREAD_CHANNEL);
 
-    VerifyOrExit(!mRadioChannelAcquisitionId);
+    VerifyOrExit(!mRadioChannelAcquisitionId, OT_NO_ACTION);
 
     mRadioChannel = mPanChannel;
 
@@ -531,7 +531,7 @@ void Mac::UpdateIdleMode(void)
 {
     bool shouldSleep = !mRxOnWhenIdle && !mPromiscuous;
 
-    VerifyOrExit(mOperation == kOperationIdle);
+    VerifyOrExit(mOperation == kOperationIdle, OT_NO_ACTION);
 
 #if OPENTHREAD_CONFIG_STAY_AWAKE_BETWEEN_FRAGMENTS
     if (mShouldDelaySleep)
@@ -627,7 +627,7 @@ void Mac::HandleOperationTask(Tasklet &aTasklet)
 
 void Mac::PerformNextOperation(void)
 {
-    VerifyOrExit(mOperation == kOperationIdle);
+    VerifyOrExit(mOperation == kOperationIdle, OT_NO_ACTION);
 
     if (!mEnabled)
     {
@@ -852,7 +852,7 @@ bool Mac::ShouldSendBeacon(void) const
 {
     bool shouldSend = false;
 
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NO_ACTION);
 
     shouldSend = IsBeaconEnabled();
 
@@ -1487,7 +1487,7 @@ void Mac::HandleReceivedFrame(Frame *aFrame, otError aError)
 
     mCounters.mRxTotal++;
 
-    VerifyOrExit(error == OT_ERROR_NONE);
+    VerifyOrExit(error == OT_ERROR_NONE, OT_NO_ACTION);
     VerifyOrExit(aFrame != NULL, error = OT_ERROR_NO_FRAME_RECEIVED);
     VerifyOrExit(mEnabled, error = OT_ERROR_INVALID_STATE);
 
@@ -1600,7 +1600,7 @@ void Mac::HandleReceivedFrame(Frame *aFrame, otError aError)
         // so the duplicate frame will not be passed to next
         // layer (`MeshForwarder`).
 
-        VerifyOrExit(mOperation == kOperationWaitingForData);
+        VerifyOrExit(mOperation == kOperationWaitingForData, OT_NO_ACTION);
 
         // Fall through
 
@@ -1943,7 +1943,7 @@ void Mac::ProcessTimeIe(Frame &aFrame)
 {
     TimeIe *timeIe = reinterpret_cast<TimeIe *>(aFrame.GetTimeIe());
 
-    VerifyOrExit(timeIe != NULL);
+    VerifyOrExit(timeIe != NULL, OT_NO_ACTION);
 
     aFrame.SetNetworkTimeOffset(static_cast<int64_t>(timeIe->GetTime()) - static_cast<int64_t>(aFrame.GetTimestamp()));
     aFrame.SetTimeSyncSeq(timeIe->GetSequence());
@@ -1959,7 +1959,7 @@ uint8_t Mac::GetTimeIeOffset(Frame &aFrame)
     uint8_t *cur    = NULL;
 
     cur = aFrame.GetTimeIe();
-    VerifyOrExit(cur != NULL);
+    VerifyOrExit(cur != NULL, OT_NO_ACTION);
 
     cur += sizeof(VendorIeHeader);
     offset = static_cast<uint8_t>(cur - base);

--- a/src/core/mac/mac_filter.cpp
+++ b/src/core/mac/mac_filter.cpp
@@ -77,7 +77,7 @@ Filter::FilterEntry *Filter::FindAvailableEntry(void)
 
     for (entry = &mFilterEntries[0]; entry < OT_ARRAY_END(mFilterEntries); entry++)
     {
-        VerifyOrExit(entry->IsInUse());
+        VerifyOrExit(entry->IsInUse(), OT_NO_ACTION);
     }
 
     entry = NULL;

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -660,7 +660,7 @@ otError Frame::GetKeyId(uint8_t &aKeyId) const
     uint8_t        index = FindSecurityHeaderIndex();
     const uint8_t *buf   = GetPsdu() + index;
 
-    VerifyOrExit(index != kInvalidIndex);
+    VerifyOrExit(index != kInvalidIndex, OT_NO_ACTION);
 
     keySourceLength = GetKeySourceLength(buf[0] & kKeyIdModeMask);
 
@@ -718,7 +718,7 @@ bool Frame::IsDataRequestCommand(void) const
     bool    isDataRequest = false;
     uint8_t commandId     = 0;
 
-    VerifyOrExit(GetType() == kFcfFrameMacCmd);
+    VerifyOrExit(GetType() == kFcfFrameMacCmd, OT_NO_ACTION);
     SuccessOrExit(GetCommandId(commandId));
     isDataRequest = (commandId == kMacCmdDataRequest);
 
@@ -736,7 +736,7 @@ uint8_t Frame::GetFooterLength(void) const
     uint8_t footerLength = 0;
     uint8_t index        = FindSecurityHeaderIndex();
 
-    VerifyOrExit(index != kInvalidIndex);
+    VerifyOrExit(index != kInvalidIndex, OT_NO_ACTION);
 
     switch ((GetPsdu() + index)[0] & kSecLevelMask)
     {
@@ -880,7 +880,7 @@ uint8_t Frame::FindPayloadIndex(void) const
     const uint8_t *footer = GetFooter();
 #endif
 
-    VerifyOrExit(index != kInvalidIndex);
+    VerifyOrExit(index != kInvalidIndex, OT_NO_ACTION);
 
 #if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
     cur = GetPsdu() + index;
@@ -979,7 +979,7 @@ const uint8_t *Frame::GetHeaderIe(uint8_t aIeId) const
     const uint8_t *cur     = NULL;
     const uint8_t *payload = GetPayload();
 
-    VerifyOrExit(index != kInvalidIndex);
+    VerifyOrExit(index != kInvalidIndex, OT_NO_ACTION);
 
     cur = GetPsdu() + index;
 
@@ -1018,7 +1018,7 @@ const uint8_t *Frame::GetTimeIe(void) const
     uint8_t oui[kVendorOuiSize] = {kVendorOuiNest & 0xff, (kVendorOuiNest >> 8) & 0xff, (kVendorOuiNest >> 16) & 0xff};
 
     cur = GetHeaderIe(kHeaderIeVendor);
-    VerifyOrExit(cur != NULL);
+    VerifyOrExit(cur != NULL, OT_NO_ACTION);
 
     cur += sizeof(HeaderIe);
 

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -130,7 +130,7 @@ otError SubMac::Enable(void)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mState == kStateDisabled);
+    VerifyOrExit(mState == kStateDisabled, OT_NO_ACTION);
 
     SuccessOrExit(error = otPlatRadioEnable(&GetInstance()));
     SuccessOrExit(error = otPlatRadioSleep(&GetInstance()));
@@ -270,7 +270,7 @@ void SubMac::BeginTransmit(void)
 {
     otError error;
 
-    VerifyOrExit(mState == kStateCsmaBackoff);
+    VerifyOrExit(mState == kStateCsmaBackoff, OT_NO_ACTION);
 
 #if OPENTHREAD_CONFIG_DISABLE_CSMA_CA_ON_LAST_ATTEMPT
     if ((mTransmitRetries > 0) && (mTransmitRetries == mTransmitFrame.GetMaxFrameRetries()))
@@ -493,7 +493,7 @@ bool SubMac::ShouldHandleCsmaBackOff(void) const
     VerifyOrExit(!RadioSupportsCsmaBackoff(), swCsma = false);
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
-    VerifyOrExit(Get<LinkRaw>().IsEnabled());
+    VerifyOrExit(Get<LinkRaw>().IsEnabled(), OT_NO_ACTION);
 #endif
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API || OPENTHREAD_RADIO
@@ -511,7 +511,7 @@ bool SubMac::ShouldHandleAckTimeout(void) const
     VerifyOrExit(!RadioSupportsAckTimeout(), swAckTimeout = false);
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
-    VerifyOrExit(Get<LinkRaw>().IsEnabled());
+    VerifyOrExit(Get<LinkRaw>().IsEnabled(), OT_NO_ACTION);
 #endif
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API || OPENTHREAD_RADIO
@@ -529,7 +529,7 @@ bool SubMac::ShouldHandleRetries(void) const
     VerifyOrExit(!RadioSupportsRetries(), swRetries = false);
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
-    VerifyOrExit(Get<LinkRaw>().IsEnabled());
+    VerifyOrExit(Get<LinkRaw>().IsEnabled(), OT_NO_ACTION);
 #endif
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API || OPENTHREAD_RADIO
@@ -547,7 +547,7 @@ bool SubMac::ShouldHandleEnergyScan(void) const
     VerifyOrExit(!RadioSupportsEnergyScan(), swEnergyScan = false);
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API
-    VerifyOrExit(Get<LinkRaw>().IsEnabled());
+    VerifyOrExit(Get<LinkRaw>().IsEnabled(), OT_NO_ACTION);
 #endif
 
 #if OPENTHREAD_ENABLE_RAW_LINK_API || OPENTHREAD_RADIO

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -520,7 +520,8 @@ void BorderAgent::HandleRelayTransmit(const Coap::Message &aMessage)
     Ip6::MessageInfo       messageInfo;
     uint16_t               offset = 0;
 
-    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_NON_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_NON_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST,
+                 OT_NO_ACTION);
 
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kJoinerRouterLocator, sizeof(joinerRouterRloc), joinerRouterRloc));
     VerifyOrExit(joinerRouterRloc.IsValid(), error = OT_ERROR_PARSE);

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -85,7 +85,7 @@ Commissioner::Commissioner(Instance &aInstance)
 
 void Commissioner::SetState(otCommissionerState aState)
 {
-    VerifyOrExit(mState != aState);
+    VerifyOrExit(mState != aState, OT_NO_ACTION);
 
     mState = aState;
 
@@ -538,7 +538,7 @@ void Commissioner::HandleMgmtCommissionerGetResponse(Coap::Message *         aMe
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
 
-    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == OT_COAP_CODE_CHANGED);
+    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == OT_COAP_CODE_CHANGED, OT_NO_ACTION);
     otLogInfoMeshCoP("received MGMT_COMMISSIONER_GET response");
 
 exit:
@@ -635,7 +635,7 @@ void Commissioner::HandleMgmtCommissionerSetResponse(Coap::Message *         aMe
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
 
-    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == OT_COAP_CODE_CHANGED);
+    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == OT_COAP_CODE_CHANGED, OT_NO_ACTION);
     otLogInfoMeshCoP("received MGMT_COMMISSIONER_SET response");
 
 exit:
@@ -704,12 +704,12 @@ void Commissioner::HandleLeaderPetitionResponse(Coap::Message *         aMessage
     otLogInfoMeshCoP("received Leader Petition response");
 
     SuccessOrExit(Tlv::GetTlv(*aMessage, Tlv::kState, sizeof(state), state));
-    VerifyOrExit(state.IsValid());
+    VerifyOrExit(state.IsValid(), OT_NO_ACTION);
 
     VerifyOrExit(state.GetState() == StateTlv::kAccept, SetState(OT_COMMISSIONER_STATE_DISABLED));
 
     SuccessOrExit(Tlv::GetTlv(*aMessage, Tlv::kCommissionerSessionId, sizeof(sessionId), sessionId));
-    VerifyOrExit(sessionId.IsValid());
+    VerifyOrExit(sessionId.IsValid(), OT_NO_ACTION);
     mSessionId = sessionId.GetCommissionerSessionId();
 
     Get<Mle::MleRouter>().GetCommissionerAloc(mCommissionerAloc.GetAddress(), mSessionId);
@@ -799,7 +799,7 @@ void Commissioner::HandleLeaderKeepAliveResponse(Coap::Message *         aMessag
     otLogInfoMeshCoP("received Leader keep-alive response");
 
     SuccessOrExit(Tlv::GetTlv(*aMessage, Tlv::kState, sizeof(state), state));
-    VerifyOrExit(state.IsValid());
+    VerifyOrExit(state.IsValid(), OT_NO_ACTION);
 
     VerifyOrExit(state.GetState() == StateTlv::kAccept, SetState(OT_COMMISSIONER_STATE_DISABLED));
 
@@ -836,7 +836,8 @@ void Commissioner::HandleRelayReceive(Coap::Message &aMessage, const Ip6::Messag
 
     VerifyOrExit(mState == OT_COMMISSIONER_STATE_ACTIVE, error = OT_ERROR_INVALID_STATE);
 
-    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_NON_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_NON_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST,
+                 OT_NO_ACTION);
 
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kJoinerUdpPort, sizeof(joinerPort), joinerPort));
     VerifyOrExit(joinerPort.IsValid(), error = OT_ERROR_PARSE);
@@ -886,7 +887,7 @@ void Commissioner::HandleRelayReceive(Coap::Message &aMessage, const Ip6::Messag
         enableJoiner = (memcmp(mJoinerIid, joinerIid.GetIid(), sizeof(mJoinerIid)) == 0);
     }
 
-    VerifyOrExit(enableJoiner);
+    VerifyOrExit(enableJoiner, OT_NO_ACTION);
 
     mJoinerPort = joinerPort.GetUdpPort();
     mJoinerRloc = joinerRloc.GetJoinerRouterLocator();
@@ -916,7 +917,8 @@ void Commissioner::HandleDatasetChanged(void *aContext, otMessage *aMessage, con
 
 void Commissioner::HandleDatasetChanged(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST,
+                 OT_NO_ACTION);
 
     otLogInfoMeshCoP("received dataset changed");
 
@@ -993,7 +995,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Message &aRequest, State
 #if OPENTHREAD_ENABLE_REFERENCE_DEVICE
     uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
 
-    VerifyOrExit(message->GetLength() <= sizeof(buf));
+    VerifyOrExit(message->GetLength() <= sizeof(buf), OT_NO_ACTION);
     message->Read(message->GetOffset(), message->GetLength() - message->GetOffset(), buf);
     otDumpCertMeshCoP("[THCI] direction=send | type=JOIN_FIN.rsp |", buf, message->GetLength() - message->GetOffset());
 #endif

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -368,13 +368,13 @@ const Timestamp *Dataset::GetTimestamp(void) const
     if (mType == Tlv::kActiveTimestamp)
     {
         const ActiveTimestampTlv *tlv = static_cast<const ActiveTimestampTlv *>(Get(mType));
-        VerifyOrExit(tlv != NULL);
+        VerifyOrExit(tlv != NULL, OT_NO_ACTION);
         timestamp = static_cast<const Timestamp *>(tlv);
     }
     else
     {
         const PendingTimestampTlv *tlv = static_cast<const PendingTimestampTlv *>(Get(mType));
-        VerifyOrExit(tlv != NULL);
+        VerifyOrExit(tlv != NULL, OT_NO_ACTION);
         timestamp = static_cast<const Timestamp *>(tlv);
     }
 
@@ -446,7 +446,7 @@ void Dataset::Remove(Tlv::Type aType)
 {
     Tlv *tlv;
 
-    VerifyOrExit((tlv = Get(aType)) != NULL);
+    VerifyOrExit((tlv = Get(aType)) != NULL, OT_NO_ACTION);
     Remove(reinterpret_cast<uint8_t *>(tlv), sizeof(Tlv) + tlv->GetLength());
 
 exit:
@@ -461,7 +461,7 @@ otError Dataset::AppendMleDatasetTlv(Message &aMessage) const
     const Tlv *    cur = reinterpret_cast<const Tlv *>(mTlvs);
     const Tlv *    end = reinterpret_cast<const Tlv *>(mTlvs + mLength);
 
-    VerifyOrExit(mLength > 0);
+    VerifyOrExit(mLength > 0, OT_NO_ACTION);
 
     type = (mType == Tlv::kActiveTimestamp ? Mle::Tlv::kActiveDataset : Mle::Tlv::kPendingDataset);
 

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -105,7 +105,7 @@ otError DatasetLocal::Read(Dataset &aDataset) const
     else
     {
         delayTimer = static_cast<DelayTimerTlv *>(aDataset.Get(Tlv::kDelayTimer));
-        VerifyOrExit(delayTimer);
+        VerifyOrExit(delayTimer, OT_NO_ACTION);
 
         elapsed = TimerMilli::Elapsed(mUpdateTime);
 

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -225,7 +225,7 @@ otError DatasetManager::GetChannelMask(Mac::ChannelMask &aChannelMask) const
 
     channelMaskTlv = static_cast<const MeshCoP::ChannelMaskTlv *>(dataset.Get(MeshCoP::Tlv::kChannelMask));
     VerifyOrExit(channelMaskTlv != NULL, error = OT_ERROR_NOT_FOUND);
-    VerifyOrExit((mask = channelMaskTlv->GetChannelMask()) != 0);
+    VerifyOrExit((mask = channelMaskTlv->GetChannelMask()) != 0, OT_NO_ACTION);
 
     aChannelMask.SetMask(mask & Get<Mac::Mac>().GetSupportedChannelMask().GetMask());
 
@@ -237,9 +237,9 @@ exit:
 
 void DatasetManager::HandleTimer(void)
 {
-    VerifyOrExit(Get<Mle::MleRouter>().IsAttached());
+    VerifyOrExit(Get<Mle::MleRouter>().IsAttached(), OT_NO_ACTION);
 
-    VerifyOrExit(mLocal.Compare(GetTimestamp()) < 0);
+    VerifyOrExit(mLocal.Compare(GetTimestamp()) < 0, OT_NO_ACTION);
 
     if (mLocal.GetType() == Tlv::kActiveTimestamp)
     {

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -267,7 +267,7 @@ otError DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInf
 
         borderAgentLocator = static_cast<BorderAgentLocatorTlv *>(
             Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kBorderAgentLocator));
-        VerifyOrExit(borderAgentLocator != NULL);
+        VerifyOrExit(borderAgentLocator != NULL, OT_NO_ACTION);
 
         memset(&destination, 0, sizeof(destination));
         destination                = Get<Mle::MleRouter>().GetMeshLocal16();
@@ -553,7 +553,7 @@ void PendingDataset::ApplyActiveDataset(const Timestamp &aTimestamp, Coap::Messa
     Dataset       dataset(mLocal.GetType());
     DelayTimerTlv delayTimer;
 
-    VerifyOrExit(Get<Mle::MleRouter>().IsAttached());
+    VerifyOrExit(Get<Mle::MleRouter>().IsAttached(), OT_NO_ACTION);
 
     while (offset < aMessage.GetLength())
     {

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -195,7 +195,8 @@ void Dtls::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageI
     default:
         // Once DTLS session is started, communicate only with a peer.
         VerifyOrExit((mPeerAddress.GetPeerAddr() == aMessageInfo.GetPeerAddr()) &&
-                     (mPeerAddress.GetPeerPort() == aMessageInfo.GetPeerPort()));
+                         (mPeerAddress.GetPeerPort() == aMessageInfo.GetPeerPort()),
+                     OT_NO_ACTION);
         break;
     }
 
@@ -263,7 +264,7 @@ otError Dtls::Setup(bool aClient)
 
     rval = mbedtls_ssl_config_defaults(&mConf, aClient ? MBEDTLS_SSL_IS_CLIENT : MBEDTLS_SSL_IS_SERVER,
                                        MBEDTLS_SSL_TRANSPORT_DATAGRAM, MBEDTLS_SSL_PRESET_DEFAULT);
-    VerifyOrExit(rval == 0);
+    VerifyOrExit(rval == 0, OT_NO_ACTION);
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
     if (mVerifyPeerCertificate && mCipherSuites[0] == MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8)
@@ -296,14 +297,14 @@ otError Dtls::Setup(bool aClient)
         mbedtls_ssl_cookie_init(&mCookieCtx);
 
         rval = mbedtls_ssl_cookie_setup(&mCookieCtx, mbedtls_ctr_drbg_random, Random::Crypto::MbedTlsContextGet());
-        VerifyOrExit(rval == 0);
+        VerifyOrExit(rval == 0, OT_NO_ACTION);
 
         mbedtls_ssl_conf_dtls_cookies(&mConf, mbedtls_ssl_cookie_write, mbedtls_ssl_cookie_check, &mCookieCtx);
     }
 #endif // OPENTHREAD_ENABLE_BORDER_AGENT || OPENTHREAD_ENABLE_COMMISSIONER || OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
 
     rval = mbedtls_ssl_setup(&mSsl, &mConf);
-    VerifyOrExit(rval == 0);
+    VerifyOrExit(rval == 0, OT_NO_ACTION);
 
     mbedtls_ssl_set_bio(&mSsl, this, &Dtls::HandleMbedtlsTransmit, HandleMbedtlsReceive, NULL);
     mbedtls_ssl_set_timer_cb(&mSsl, this, &Dtls::HandleMbedtlsSetTimer, HandleMbedtlsGetTimer);
@@ -318,7 +319,7 @@ otError Dtls::Setup(bool aClient)
         rval = SetApplicationCoapSecureKeys();
     }
 #endif // OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-    VerifyOrExit(rval == 0);
+    VerifyOrExit(rval == 0, OT_NO_ACTION);
 
     mReceiveMessage = NULL;
     mMessageSubType = Message::kSubTypeNone;
@@ -362,7 +363,7 @@ int Dtls::SetApplicationCoapSecureKeys(void)
         {
             rval = mbedtls_x509_crt_parse(&mCaChain, static_cast<const unsigned char *>(mCaChainSrc),
                                           static_cast<size_t>(mCaChainLength));
-            VerifyOrExit(rval == 0);
+            VerifyOrExit(rval == 0, OT_NO_ACTION);
             mbedtls_ssl_conf_ca_chain(&mConf, &mCaChain, NULL);
         }
 
@@ -370,12 +371,12 @@ int Dtls::SetApplicationCoapSecureKeys(void)
         {
             rval = mbedtls_x509_crt_parse(&mOwnCert, static_cast<const unsigned char *>(mOwnCertSrc),
                                           static_cast<size_t>(mOwnCertLength));
-            VerifyOrExit(rval == 0);
+            VerifyOrExit(rval == 0, OT_NO_ACTION);
             rval = mbedtls_pk_parse_key(&mPrivateKey, static_cast<const unsigned char *>(mPrivateKeySrc),
                                         static_cast<size_t>(mPrivateKeyLength), NULL, 0);
-            VerifyOrExit(rval == 0);
+            VerifyOrExit(rval == 0, OT_NO_ACTION);
             rval = mbedtls_ssl_conf_own_cert(&mConf, &mOwnCert, &mPrivateKey);
-            VerifyOrExit(rval == 0);
+            VerifyOrExit(rval == 0, OT_NO_ACTION);
         }
 #endif // MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
         break;
@@ -384,7 +385,7 @@ int Dtls::SetApplicationCoapSecureKeys(void)
 #ifdef MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
         rval = mbedtls_ssl_conf_psk(&mConf, static_cast<const unsigned char *>(mPreSharedKey), mPreSharedKeyLength,
                                     static_cast<const unsigned char *>(mPreSharedKeyIdentity), mPreSharedKeyIdLength);
-        VerifyOrExit(rval == 0);
+        VerifyOrExit(rval == 0, OT_NO_ACTION);
 #endif // MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
         break;
 
@@ -421,7 +422,7 @@ void Dtls::Close(void)
 
 void Dtls::Disconnect(void)
 {
-    VerifyOrExit(mState == kStateConnecting || mState == kStateConnected);
+    VerifyOrExit(mState == kStateConnecting || mState == kStateConnected, OT_NO_ACTION);
 
     mbedtls_ssl_close_notify(&mSsl);
     mState = kStateCloseNotify;

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -286,7 +286,9 @@ otError Dtls::Setup(bool aClient)
     mbedtls_ssl_conf_ciphersuites(&mConf, mCipherSuites);
     mbedtls_ssl_conf_export_keys_cb(&mConf, HandleMbedtlsExportKeys, this);
     mbedtls_ssl_conf_handshake_timeout(&mConf, 8000, 60000);
+#if MBEDTLS_DEBUG_C
     mbedtls_ssl_conf_dbg(&mConf, HandleMbedtlsDebug, this);
+#endif
 
 #if OPENTHREAD_ENABLE_BORDER_AGENT || OPENTHREAD_ENABLE_COMMISSIONER || OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
     if (!aClient)
@@ -888,6 +890,7 @@ exit:
     }
 }
 
+#if MBEDTLS_DEBUG_C
 void Dtls::HandleMbedtlsDebug(void *ctx, int level, const char *, int, const char *str)
 {
     OT_UNUSED_VARIABLE(str);
@@ -898,23 +901,24 @@ void Dtls::HandleMbedtlsDebug(void *ctx, int level, const char *, int, const cha
     switch (level)
     {
     case 1:
-        otLogCritMbedTls("[%hu] %s", pThis->mSocket.GetSockName().mPort, str);
+        otLogCritMeshCoP("[%hu] %s", pThis->mSocket.GetSockName().mPort, str);
         break;
 
     case 2:
-        otLogWarnMbedTls("[%hu] %s", pThis->mSocket.GetSockName().mPort, str);
+        otLogWarnMeshCoP("[%hu] %s", pThis->mSocket.GetSockName().mPort, str);
         break;
 
     case 3:
-        otLogInfoMbedTls("[%hu] %s", pThis->mSocket.GetSockName().mPort, str);
+        otLogInfoMeshCoP("[%hu] %s", pThis->mSocket.GetSockName().mPort, str);
         break;
 
     case 4:
     default:
-        otLogDebgMbedTls("[%hu] %s", pThis->mSocket.GetSockName().mPort, str);
+        otLogDebgMeshCoP("[%hu] %s", pThis->mSocket.GetSockName().mPort, str);
         break;
     }
 }
+#endif // MBEDTLS_DEBUG_C
 
 otError Dtls::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType)
 {

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -403,7 +403,9 @@ private:
     int SetApplicationCoapSecureKeys(void);
 #endif // OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
 
+#if MBEDTLS_DEBUG_C
     static void HandleMbedtlsDebug(void *ctx, int level, const char *file, int line, const char *str);
+#endif
 
     static int HandleMbedtlsGetTimer(void *aContext);
     int        HandleMbedtlsGetTimer(void);

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -140,14 +140,15 @@ void EnergyScanClient::HandleReport(Coap::Message &aMessage, const Ip6::MessageI
         uint8_t                list[OPENTHREAD_CONFIG_MAX_ENERGY_RESULTS];
     } OT_TOOL_PACKED_END energyList;
 
-    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST,
+                 OT_NO_ACTION);
 
     otLogInfoMeshCoP("received energy scan report");
 
-    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
+    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0, OT_NO_ACTION);
 
     SuccessOrExit(MeshCoP::Tlv::GetTlv(aMessage, MeshCoP::Tlv::kEnergyList, sizeof(energyList), energyList.tlv));
-    VerifyOrExit(energyList.tlv.IsValid());
+    VerifyOrExit(energyList.tlv.IsValid(), OT_NO_ACTION);
 
     if (mCallback != NULL)
     {

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -77,7 +77,7 @@ void Joiner::GetJoinerId(Mac::ExtAddress &aJoinerId) const
 
 void Joiner::SetState(otJoinerState aState)
 {
-    VerifyOrExit(aState != mState);
+    VerifyOrExit(aState != mState, OT_NO_ACTION);
 
     otLogInfoMeshCoP("JoinerState: %s -> %s", JoinerStateToString(mState), JoinerStateToString(aState));
     mState = aState;
@@ -222,7 +222,7 @@ void Joiner::HandleDiscoverResult(otActiveScanResult *aResult, void *aContext)
 
 void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
 {
-    VerifyOrExit(mState == OT_JOINER_STATE_DISCOVER);
+    VerifyOrExit(mState == OT_JOINER_STATE_DISCOVER, OT_NO_ACTION);
 
     if (aResult != NULL)
     {
@@ -272,7 +272,7 @@ void Joiner::SaveDiscoveredJoinerRouter(const otActiveScanResult &aResult)
         }
     }
 
-    VerifyOrExit(entry < end);
+    VerifyOrExit(entry < end, OT_NO_ACTION);
 
     // Shift elements in array to make room for the new one.
     memmove(entry + 1, entry,
@@ -364,7 +364,7 @@ void Joiner::HandleSecureCoapClientConnect(bool aConnected, void *aContext)
 
 void Joiner::HandleSecureCoapClientConnect(bool aConnected)
 {
-    VerifyOrExit(mState == OT_JOINER_STATE_CONNECT);
+    VerifyOrExit(mState == OT_JOINER_STATE_CONNECT, OT_NO_ACTION);
 
     if (aConnected)
     {
@@ -494,10 +494,11 @@ void Joiner::HandleJoinerFinalizeResponse(Coap::Message &         aMessage,
     StateTlv state;
 
     VerifyOrExit(mState == OT_JOINER_STATE_CONNECTED && aResult == OT_ERROR_NONE &&
-                 aMessage.GetType() == OT_COAP_TYPE_ACKNOWLEDGMENT && aMessage.GetCode() == OT_COAP_CODE_CHANGED);
+                     aMessage.GetType() == OT_COAP_TYPE_ACKNOWLEDGMENT && aMessage.GetCode() == OT_COAP_CODE_CHANGED,
+                 OT_NO_ACTION);
 
     SuccessOrExit(Tlv::GetTlv(aMessage, Tlv::kState, sizeof(state), state));
-    VerifyOrExit(state.IsValid());
+    VerifyOrExit(state.IsValid(), OT_NO_ACTION);
 
     SetState(OT_JOINER_STATE_ENTRUST);
     mTimer.Start(kReponseTimeout);
@@ -673,7 +674,7 @@ void Joiner::LogCertMessage(const char *aText, const Coap::Message &aMessage) co
 {
     uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
 
-    VerifyOrExit(aMessage.GetLength() <= sizeof(buf));
+    VerifyOrExit(aMessage.GetLength() <= sizeof(buf), OT_NO_ACTION);
     aMessage.Read(aMessage.GetOffset(), aMessage.GetLength() - aMessage.GetOffset(), buf);
 
     otDumpCertMeshCoP(aText, buf, aMessage.GetLength() - aMessage.GetOffset());

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -73,8 +73,8 @@ void JoinerRouter::HandleStateChanged(Notifier::Callback &aCallback, otChangedFl
 
 void JoinerRouter::HandleStateChanged(otChangedFlags aFlags)
 {
-    VerifyOrExit(Get<Mle::MleRouter>().IsFullThreadDevice());
-    VerifyOrExit(aFlags & OT_CHANGED_THREAD_NETDATA);
+    VerifyOrExit(Get<Mle::MleRouter>().IsFullThreadDevice(), OT_NO_ACTION);
+    VerifyOrExit(aFlags & OT_CHANGED_THREAD_NETDATA, OT_NO_ACTION);
 
     Get<Ip6::Filter>().RemoveUnsecurePort(mSocket.GetSockName().mPort);
 
@@ -107,7 +107,7 @@ uint16_t JoinerRouter::GetJoinerUdpPort(void)
 
     joinerUdpPort =
         static_cast<JoinerUdpPortTlv *>(Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kJoinerUdpPort));
-    VerifyOrExit(joinerUdpPort != NULL);
+    VerifyOrExit(joinerUdpPort != NULL, OT_NO_ACTION);
 
     rval = joinerUdpPort->GetUdpPort();
 
@@ -388,14 +388,15 @@ void JoinerRouter::SendDelayedJoinerEntrust(void)
     uint32_t             now     = TimerMilli::GetNow();
     Ip6::MessageInfo     messageInfo;
 
-    VerifyOrExit(message != NULL);
-    VerifyOrExit(!mTimer.IsRunning());
+    VerifyOrExit(message != NULL, OT_NO_ACTION);
+    VerifyOrExit(!mTimer.IsRunning(), OT_NO_ACTION);
 
     delayedJoinEnt.ReadFrom(*message);
 
     // The message can be sent during CoAP transaction if KEK did not change (i.e. retransmission).
     VerifyOrExit(!mExpectJoinEntRsp ||
-                 memcmp(Get<KeyManager>().GetKek(), delayedJoinEnt.GetKek(), KeyManager::kMaxKeyLength) == 0);
+                     memcmp(Get<KeyManager>().GetKek(), delayedJoinEnt.GetKek(), KeyManager::kMaxKeyLength) == 0,
+                 OT_NO_ACTION);
 
     if (delayedJoinEnt.IsLater(now))
     {
@@ -462,9 +463,9 @@ void JoinerRouter::HandleJoinerEntrustResponse(Coap::Message *         aMessage,
     mExpectJoinEntRsp = false;
     SendDelayedJoinerEntrust();
 
-    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage != NULL);
+    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage != NULL, OT_NO_ACTION);
 
-    VerifyOrExit(aMessage->GetCode() == OT_COAP_CODE_CHANGED);
+    VerifyOrExit(aMessage->GetCode() == OT_COAP_CODE_CHANGED, OT_NO_ACTION);
 
     otLogInfoMeshCoP("Receive joiner entrust response");
     otLogCertMeshCoP("[THCI] direction=recv | type=JOIN_ENT.rsp");

--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -80,15 +80,15 @@ void Leader::HandlePetition(Coap::Message &aMessage, const Ip6::MessageInfo &aMe
 
     otLogInfoMeshCoP("received petition");
 
-    VerifyOrExit(Get<Mle::MleRouter>().IsRoutingLocator(aMessageInfo.GetPeerAddr()));
+    VerifyOrExit(Get<Mle::MleRouter>().IsRoutingLocator(aMessageInfo.GetPeerAddr()), OT_NO_ACTION);
     SuccessOrExit(Tlv::GetTlv(aMessage, Tlv::kCommissionerId, sizeof(commissionerId), commissionerId));
 
     if (mTimer.IsRunning())
     {
-        VerifyOrExit((commissionerId.GetCommissionerIdLength() == mCommissionerId.GetCommissionerIdLength()) &&
-                     (!strncmp(commissionerId.GetCommissionerId(), mCommissionerId.GetCommissionerId(),
-                               commissionerId.GetCommissionerIdLength())));
-
+        VerifyOrExit((commissionerId.GetLength() == mCommissionerId.GetLength()) &&
+                         (!strncmp(commissionerId.GetCommissionerId(), mCommissionerId.GetCommissionerId(),
+                                   commissionerId.GetLength())),
+                     OT_NO_ACTION);
         ResignCommissioner();
     }
 
@@ -174,10 +174,10 @@ void Leader::HandleKeepAlive(Coap::Message &aMessage, const Ip6::MessageInfo &aM
     otLogInfoMeshCoP("received keep alive");
 
     SuccessOrExit(Tlv::GetTlv(aMessage, Tlv::kState, sizeof(state), state));
-    VerifyOrExit(state.IsValid());
+    VerifyOrExit(state.IsValid(), OT_NO_ACTION);
 
     SuccessOrExit(Tlv::GetTlv(aMessage, Tlv::kCommissionerSessionId, sizeof(sessionId), sessionId));
-    VerifyOrExit(sessionId.IsValid());
+    VerifyOrExit(sessionId.IsValid(), OT_NO_ACTION);
 
     borderAgentLocator = static_cast<BorderAgentLocatorTlv *>(
         Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kBorderAgentLocator));
@@ -292,7 +292,7 @@ void Leader::HandleTimer(Timer &aTimer)
 
 void Leader::HandleTimer(void)
 {
-    VerifyOrExit(Get<Mle::MleRouter>().GetRole() == OT_DEVICE_ROLE_LEADER);
+    VerifyOrExit(Get<Mle::MleRouter>().GetRole() == OT_DEVICE_ROLE_LEADER, OT_NO_ACTION);
 
     ResignCommissioner();
 

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -119,10 +119,10 @@ bool ChannelTlv::IsValid(void) const
 {
     bool ret = false;
 
-    VerifyOrExit(GetLength() == sizeof(*this) - sizeof(Tlv));
-    VerifyOrExit(mChannelPage <= OT_RADIO_CHANNEL_PAGE_MAX);
-    VerifyOrExit((1U << mChannelPage) & Phy::kSupportedChannelPages);
-    VerifyOrExit(Phy::kChannelMin <= GetChannel() && GetChannel() <= Phy::kChannelMax);
+    VerifyOrExit(GetLength() == sizeof(*this) - sizeof(Tlv), OT_NO_ACTION);
+    VerifyOrExit(mChannelPage <= OT_RADIO_CHANNEL_PAGE_MAX, OT_NO_ACTION);
+    VerifyOrExit((1U << mChannelPage) & Phy::kSupportedChannelPages, OT_NO_ACTION);
+    VerifyOrExit(Phy::kChannelMin <= GetChannel() && GetChannel() <= Phy::kChannelMax, OT_NO_ACTION);
     ret = true;
 
 exit:
@@ -155,7 +155,7 @@ const ChannelMaskEntryBase *ChannelMaskBaseTlv::GetFirstEntry(void) const
 {
     const ChannelMaskEntryBase *entry = NULL;
 
-    VerifyOrExit(GetLength() >= sizeof(ChannelMaskEntryBase));
+    VerifyOrExit(GetLength() >= sizeof(ChannelMaskEntryBase), OT_NO_ACTION);
 
     entry = reinterpret_cast<const ChannelMaskEntryBase *>(GetValue());
     VerifyOrExit(GetLength() >= entry->GetEntrySize(), entry = NULL);
@@ -213,7 +213,7 @@ uint32_t ChannelMaskTlv::GetChannelMask(void) const
 
     for (; cur < end; cur = static_cast<const ChannelMaskEntry *>(cur->GetNext()))
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, OT_NO_ACTION);
 
 #if OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT
         if (cur->GetChannelPage() == OT_RADIO_CHANNEL_PAGE_2)
@@ -248,7 +248,7 @@ uint32_t ChannelMaskTlv::GetChannelMask(const Message &aMessage)
         ChannelMaskEntry entry;
 
         aMessage.Read(offset, sizeof(ChannelMaskEntryBase), &entry);
-        VerifyOrExit(offset + entry.GetEntrySize() <= end);
+        VerifyOrExit(offset + entry.GetEntrySize() <= end, OT_NO_ACTION);
 
         switch (entry.GetChannelPage())
         {

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -122,14 +122,15 @@ void PanIdQueryClient::HandleConflict(Coap::Message &aMessage, const Ip6::Messag
     Ip6::MessageInfo  responseInfo(aMessageInfo);
     uint32_t          mask;
 
-    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST,
+                 OT_NO_ACTION);
 
     otLogInfoMeshCoP("received panid conflict");
 
     SuccessOrExit(MeshCoP::Tlv::GetTlv(aMessage, MeshCoP::Tlv::kPanId, sizeof(panId), panId));
-    VerifyOrExit(panId.IsValid());
+    VerifyOrExit(panId.IsValid(), OT_NO_ACTION);
 
-    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
+    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0, OT_NO_ACTION);
 
     if (mCallback != NULL)
     {

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -188,7 +188,8 @@ bool Dhcp6Client::ProcessNextIdentityAssociation()
     bool rval = false;
 
     // not interrupt in-progress solicit
-    VerifyOrExit(mIdentityAssociationCurrent == NULL || mIdentityAssociationCurrent->mStatus != kIaStatusSoliciting);
+    VerifyOrExit(mIdentityAssociationCurrent == NULL || mIdentityAssociationCurrent->mStatus != kIaStatusSoliciting,
+                 OT_NO_ACTION);
 
     mTrickleTimer.Stop();
 
@@ -414,7 +415,7 @@ void Dhcp6Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aM
 
     Dhcp6Header header;
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(header), &header) == sizeof(header));
+    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(header), &header) == sizeof(header), OT_NO_ACTION);
     aMessage.MoveOffset(sizeof(header));
 
     if ((header.GetType() == kTypeReply) && (!memcmp(header.GetTransactionId(), mTransactionId, kTransactionIdSize)))
@@ -433,18 +434,18 @@ void Dhcp6Client::ProcessReply(Message &aMessage)
     uint16_t optionOffset;
 
     // Server Identifier
-    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionServerIdentifier)) > 0);
+    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionServerIdentifier)) > 0, OT_NO_ACTION);
     SuccessOrExit(ProcessServerIdentifier(aMessage, optionOffset));
 
     // Client Identifier
-    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionClientIdentifier)) > 0);
+    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionClientIdentifier)) > 0, OT_NO_ACTION);
     SuccessOrExit(ProcessClientIdentifier(aMessage, optionOffset));
 
     // Rapid Commit
-    VerifyOrExit(FindOption(aMessage, offset, length, kOptionRapidCommit) > 0);
+    VerifyOrExit(FindOption(aMessage, offset, length, kOptionRapidCommit) > 0, OT_NO_ACTION);
 
     // IA_NA
-    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionIaNa)) > 0);
+    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionIaNa)) > 0, OT_NO_ACTION);
     SuccessOrExit(ProcessIaNa(aMessage, optionOffset));
 
     HandleTrickleTimer();
@@ -461,7 +462,7 @@ uint16_t Dhcp6Client::FindOption(Message &aMessage, uint16_t aOffset, uint16_t a
     while (aOffset <= end)
     {
         Dhcp6Option option;
-        VerifyOrExit(aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option));
+        VerifyOrExit(aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option), OT_NO_ACTION);
 
         if (option.GetCode() == (aCode))
         {

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -183,11 +183,11 @@ void Dhcp6Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aM
     Dhcp6Header  header;
     otIp6Address dst = aMessageInfo.mPeerAddr;
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(header), &header) == sizeof(header));
+    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(header), &header) == sizeof(header), OT_NO_ACTION);
     aMessage.MoveOffset(sizeof(header));
 
     // discard if not solicit type
-    VerifyOrExit((header.GetType() == kTypeSolicit));
+    VerifyOrExit((header.GetType() == kTypeSolicit), OT_NO_ACTION);
 
     ProcessSolicit(aMessage, dst, header.GetTransactionId());
 
@@ -204,14 +204,14 @@ void Dhcp6Server::ProcessSolicit(Message &aMessage, otIp6Address &aDst, uint8_t 
     uint16_t         length = aMessage.GetLength() - aMessage.GetOffset();
 
     // Client Identifier (discard if not present)
-    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionClientIdentifier)) > 0);
+    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionClientIdentifier)) > 0, OT_NO_ACTION);
     SuccessOrExit(ProcessClientIdentifier(aMessage, optionOffset, clientIdentifier));
 
     // Server Identifier (assuming Rapid Commit, discard if present)
-    VerifyOrExit(FindOption(aMessage, offset, length, kOptionServerIdentifier) == 0);
+    VerifyOrExit(FindOption(aMessage, offset, length, kOptionServerIdentifier) == 0, OT_NO_ACTION);
 
     // Rapid Commit (assuming Rapid Commit, discard if not present)
-    VerifyOrExit(FindOption(aMessage, offset, length, kOptionRapidCommit) > 0);
+    VerifyOrExit(FindOption(aMessage, offset, length, kOptionRapidCommit) > 0, OT_NO_ACTION);
 
     // Elapsed Time if present
     if ((optionOffset = FindOption(aMessage, offset, length, kOptionElapsedTime)) > 0)
@@ -220,7 +220,7 @@ void Dhcp6Server::ProcessSolicit(Message &aMessage, otIp6Address &aDst, uint8_t 
     }
 
     // IA_NA (discard if not present)
-    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionIaNa)) > 0);
+    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionIaNa)) > 0, OT_NO_ACTION);
     SuccessOrExit(ProcessIaNa(aMessage, optionOffset, iana));
 
     SuccessOrExit(SendReply(aDst, aTransactionId, clientIdentifier, iana));
@@ -237,7 +237,7 @@ uint16_t Dhcp6Server::FindOption(Message &aMessage, uint16_t aOffset, uint16_t a
     while (aOffset <= end)
     {
         Dhcp6Option option;
-        VerifyOrExit(aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option));
+        VerifyOrExit(aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option), OT_NO_ACTION);
 
         if (option.GetCode() == aCode)
         {
@@ -291,7 +291,7 @@ otError Dhcp6Server::ProcessIaNa(Message &aMessage, uint16_t aOffset, IaNa &aIaN
 
     while (length > 0)
     {
-        VerifyOrExit((optionOffset = FindOption(aMessage, aOffset, length, kOptionIaAddress)) > 0);
+        VerifyOrExit((optionOffset = FindOption(aMessage, aOffset, length, kOptionIaAddress)) > 0, OT_NO_ACTION);
         SuccessOrExit(error = ProcessIaAddress(aMessage, optionOffset));
 
         length -= ((optionOffset - aOffset) + sizeof(IaAddress));

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -149,7 +149,7 @@ Message *Client::NewMessage(const Header &aHeader)
 {
     Message *message = NULL;
 
-    VerifyOrExit((message = mSocket.NewMessage(sizeof(aHeader))) != NULL);
+    VerifyOrExit((message = mSocket.NewMessage(sizeof(aHeader))) != NULL, OT_NO_ACTION);
     message->Prepend(&aHeader, sizeof(aHeader));
     message->SetOffset(0);
 
@@ -474,15 +474,16 @@ void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
     Message *          message = NULL;
     uint16_t           offset;
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(responseHeader), &responseHeader) ==
-                 sizeof(responseHeader));
+    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(responseHeader), &responseHeader) == sizeof(responseHeader),
+                 OT_NO_ACTION);
     VerifyOrExit(responseHeader.GetType() == Header::kTypeResponse && responseHeader.GetQuestionCount() == 1 &&
-                 responseHeader.IsTruncationFlagSet() == false);
+                     responseHeader.IsTruncationFlagSet() == false,
+                 OT_NO_ACTION);
 
     aMessage.MoveOffset(sizeof(responseHeader));
     offset = aMessage.GetOffset();
 
-    VerifyOrExit((message = FindRelatedQuery(responseHeader, queryMetadata)) != NULL);
+    VerifyOrExit((message = FindRelatedQuery(responseHeader, queryMetadata)) != NULL, OT_NO_ACTION);
 
     VerifyOrExit(responseHeader.GetResponseCode() == Header::kResponseSuccess, error = OT_ERROR_FAILED);
 

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -205,7 +205,8 @@ otError Icmp::HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMe
 
     // always handle Echo Request destined for RLOC or ALOC
     VerifyOrExit(ShouldHandleEchoRequest(aMessageInfo) || aMessageInfo.GetSockAddr().IsRoutingLocator() ||
-                 aMessageInfo.GetSockAddr().IsAnycastRoutingLocator());
+                     aMessageInfo.GetSockAddr().IsAnycastRoutingLocator(),
+                 OT_NO_ACTION);
 
     otLogInfoIcmp("Received Echo Request");
 

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -79,7 +79,7 @@ Message *Ip6::NewMessage(const uint8_t *aData, uint16_t aDataLength, const otMes
     }
 
     SuccessOrExit(GetDatagramPriority(aData, aDataLength, *reinterpret_cast<uint8_t *>(&settings.mPriority)));
-    VerifyOrExit((message = Get<MessagePool>().New(Message::kTypeIp6, 0, &settings)) != NULL);
+    VerifyOrExit((message = Get<MessagePool>().New(Message::kTypeIp6, 0, &settings)) != NULL, OT_NO_ACTION);
 
     if (message->Append(aData, aDataLength) != OT_ERROR_NONE)
     {
@@ -249,7 +249,8 @@ otError Ip6::InsertMplOption(Message &aMessage, Header &aHeader, MessageInfo &aM
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aHeader.GetDestination().IsMulticast() &&
-                 aHeader.GetDestination().GetScope() >= Address::kRealmLocalScope);
+                     aHeader.GetDestination().GetScope() >= Address::kRealmLocalScope,
+                 OT_NO_ACTION);
 
     if (aHeader.GetDestination().IsRealmLocalMulticast())
     {
@@ -336,7 +337,7 @@ otError Ip6::RemoveMplOption(Message &aMessage)
     offset = 0;
     aMessage.Read(offset, sizeof(ip6Header), &ip6Header);
     offset += sizeof(ip6Header);
-    VerifyOrExit(ip6Header.GetNextHeader() == kProtoHopOpts);
+    VerifyOrExit(ip6Header.GetNextHeader() == kProtoHopOpts, OT_NO_ACTION);
 
     aMessage.Read(offset, sizeof(hbh), &hbh);
     endOffset = offset + (hbh.GetLength() + 1) * 8;

--- a/src/core/net/ip6_filter.cpp
+++ b/src/core/net/ip6_filter.cpp
@@ -67,16 +67,16 @@ bool Filter::Accept(Message &aMessage) const
     }
 
     // Read IPv6 header
-    VerifyOrExit(sizeof(ip6) == aMessage.Read(0, sizeof(ip6), &ip6));
+    VerifyOrExit(sizeof(ip6) == aMessage.Read(0, sizeof(ip6), &ip6), OT_NO_ACTION);
 
     // Allow only link-local unicast or multicast
-    VerifyOrExit(ip6.GetDestination().IsLinkLocal() || ip6.GetDestination().IsLinkLocalMulticast());
+    VerifyOrExit(ip6.GetDestination().IsLinkLocal() || ip6.GetDestination().IsLinkLocalMulticast(), OT_NO_ACTION);
 
     switch (ip6.GetNextHeader())
     {
     case kProtoUdp:
         // Read the UDP header and get the dst port
-        VerifyOrExit(sizeof(udp) == aMessage.Read(sizeof(ip6), sizeof(udp), &udp));
+        VerifyOrExit(sizeof(udp) == aMessage.Read(sizeof(ip6), sizeof(udp), &udp), OT_NO_ACTION);
 
         dstport = udp.GetDestinationPort();
 
@@ -95,7 +95,7 @@ bool Filter::Accept(Message &aMessage) const
 
     case kProtoTcp:
         // Read the TCP header and get the dst port
-        VerifyOrExit(sizeof(tcp) == aMessage.Read(sizeof(ip6), sizeof(tcp), &tcp));
+        VerifyOrExit(sizeof(tcp) == aMessage.Read(sizeof(ip6), sizeof(tcp), &tcp), OT_NO_ACTION);
 
         dstport = tcp.GetDestinationPort();
 

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -249,7 +249,7 @@ void Mpl::AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSeque
     uint8_t interval = kDataMessageInterval;
 #endif
 
-    VerifyOrExit(GetTimerExpirations() > 0);
+    VerifyOrExit(GetTimerExpirations() > 0, OT_NO_ACTION);
     VerifyOrExit((messageCopy = aMessage.Clone()) != NULL, error = OT_ERROR_NO_BUFS);
 
     if (!aIsOutbound)

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -306,7 +306,7 @@ otError Netif::GetNextExternalMulticast(uint8_t &aIterator, Address &aAddress) c
     otError error = OT_ERROR_NOT_FOUND;
     size_t  num   = OT_ARRAY_LENGTH(mExtMulticastAddresses);
 
-    VerifyOrExit(aIterator < num);
+    VerifyOrExit(aIterator < num, OT_NO_ACTION);
 
     // Find an available entry in the `mExtMulticastAddresses` array.
     for (uint8_t i = aIterator; i < num; i++)

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -136,7 +136,7 @@ Message *Client::NewMessage(const Header &aHeader)
 {
     Message *message = NULL;
 
-    VerifyOrExit((message = mSocket.NewMessage(sizeof(aHeader))) != NULL);
+    VerifyOrExit((message = mSocket.NewMessage(sizeof(aHeader))) != NULL, OT_NO_ACTION);
     message->Prepend(&aHeader, sizeof(aHeader));
     message->SetOffset(0);
 
@@ -345,10 +345,10 @@ void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
     Message *     message  = NULL;
     uint64_t      unixTime = 0;
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(responseHeader), &responseHeader) ==
-                 sizeof(responseHeader));
+    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(responseHeader), &responseHeader) == sizeof(responseHeader),
+                 OT_NO_ACTION);
 
-    VerifyOrExit((message = FindRelatedQuery(responseHeader, queryMetadata)) != NULL);
+    VerifyOrExit((message = FindRelatedQuery(responseHeader, queryMetadata)) != NULL, OT_NO_ACTION);
 
     // Check if response came from the server.
     VerifyOrExit(responseHeader.GetMode() == Header::kModeServer, error = OT_ERROR_FAILED);

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -378,12 +378,12 @@ otError Udp::HandleMessage(Message &aMessage, MessageInfo &aMessageInfo)
     aMessageInfo.mSockPort = udpHeader.GetDestinationPort();
 
 #if OPENTHREAD_ENABLE_PLATFORM_UDP
-    VerifyOrExit(IsMle(GetInstance(), aMessageInfo.mSockPort));
+    VerifyOrExit(IsMle(GetInstance(), aMessageInfo.mSockPort), OT_NO_ACTION);
 #endif
 
     for (UdpReceiver *receiver = mReceivers; receiver; receiver = receiver->GetNext())
     {
-        VerifyOrExit(!receiver->HandleMessage(aMessage, aMessageInfo));
+        VerifyOrExit(!receiver->HandleMessage(aMessage, aMessageInfo), OT_NO_ACTION);
     }
 
     HandlePayload(aMessage, aMessageInfo);

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -367,25 +367,26 @@ void AddressResolver::HandleAddressNotification(Coap::Message &aMessage, const I
     ThreadLastTransactionTimeTlv lastTransactionTimeTlv;
     uint32_t                     lastTransactionTime;
 
-    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST,
+                 OT_NO_ACTION);
 
     SuccessOrExit(ThreadTlv::GetTlv(aMessage, ThreadTlv::kTarget, sizeof(targetTlv), targetTlv));
-    VerifyOrExit(targetTlv.IsValid());
+    VerifyOrExit(targetTlv.IsValid(), OT_NO_ACTION);
     targetTlv.Init(); // reset TLV length
 
     SuccessOrExit(ThreadTlv::GetTlv(aMessage, ThreadTlv::kMeshLocalEid, sizeof(mlIidTlv), mlIidTlv));
-    VerifyOrExit(mlIidTlv.IsValid());
+    VerifyOrExit(mlIidTlv.IsValid(), OT_NO_ACTION);
     mlIidTlv.Init(); // reset TLV length
 
     SuccessOrExit(ThreadTlv::GetTlv(aMessage, ThreadTlv::kRloc16, sizeof(rloc16Tlv), rloc16Tlv));
-    VerifyOrExit(rloc16Tlv.IsValid());
+    VerifyOrExit(rloc16Tlv.IsValid(), OT_NO_ACTION);
 
     lastTransactionTime = 0;
 
     if (ThreadTlv::GetTlv(aMessage, ThreadTlv::kLastTransactionTime, sizeof(lastTransactionTimeTlv),
                           lastTransactionTimeTlv) == OT_ERROR_NONE)
     {
-        VerifyOrExit(lastTransactionTimeTlv.IsValid());
+        VerifyOrExit(lastTransactionTimeTlv.IsValid(), OT_NO_ACTION);
         lastTransactionTime = lastTransactionTimeTlv.GetTime();
     }
 
@@ -589,10 +590,11 @@ void AddressResolver::HandleAddressQuery(Coap::Message &aMessage, const Ip6::Mes
     ThreadMeshLocalEidTlv        mlIidTlv;
     ThreadLastTransactionTimeTlv lastTransactionTimeTlv;
 
-    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_NON_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_NON_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST,
+                 OT_NO_ACTION);
 
     SuccessOrExit(ThreadTlv::GetTlv(aMessage, ThreadTlv::kTarget, sizeof(targetTlv), targetTlv));
-    VerifyOrExit(targetTlv.IsValid());
+    VerifyOrExit(targetTlv.IsValid(), OT_NO_ACTION);
     targetTlv.Init(); // reset TLV length
 
     mlIidTlv.Init();
@@ -749,9 +751,9 @@ void AddressResolver::HandleIcmpReceive(Message &               aMessage,
 
     Ip6::Header ip6Header;
 
-    VerifyOrExit(aIcmpHeader.GetType() == Ip6::IcmpHeader::kTypeDstUnreach);
-    VerifyOrExit(aIcmpHeader.GetCode() == Ip6::IcmpHeader::kCodeDstUnreachNoRoute);
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(ip6Header), &ip6Header) == sizeof(ip6Header));
+    VerifyOrExit(aIcmpHeader.GetType() == Ip6::IcmpHeader::kTypeDstUnreach, OT_NO_ACTION);
+    VerifyOrExit(aIcmpHeader.GetCode() == Ip6::IcmpHeader::kCodeDstUnreachNoRoute, OT_NO_ACTION);
+    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(ip6Header), &ip6Header) == sizeof(ip6Header), OT_NO_ACTION);
 
     for (int i = 0; i < kCacheEntries; i++)
     {

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -77,14 +77,14 @@ void AnnounceBeginServer::HandleRequest(Coap::Message &aMessage, const Ip6::Mess
     MeshCoP::PeriodTlv period;
     Ip6::MessageInfo   responseInfo(aMessageInfo);
 
-    VerifyOrExit(aMessage.GetCode() == OT_COAP_CODE_POST);
-    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
+    VerifyOrExit(aMessage.GetCode() == OT_COAP_CODE_POST, OT_NO_ACTION);
+    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0, OT_NO_ACTION);
 
     SuccessOrExit(MeshCoP::Tlv::GetTlv(aMessage, MeshCoP::Tlv::kCount, sizeof(count), count));
-    VerifyOrExit(count.IsValid());
+    VerifyOrExit(count.IsValid(), OT_NO_ACTION);
 
     SuccessOrExit(MeshCoP::Tlv::GetTlv(aMessage, MeshCoP::Tlv::kPeriod, sizeof(period), period));
-    VerifyOrExit(period.IsValid());
+    VerifyOrExit(period.IsValid(), OT_NO_ACTION);
 
     SendAnnounce(mask, count.GetCount(), period.GetPeriod());
 

--- a/src/core/thread/announce_sender.cpp
+++ b/src/core/thread/announce_sender.cpp
@@ -93,7 +93,7 @@ void AnnounceSenderBase::HandleTimer(void)
         if (mCount != 0)
         {
             mCount--;
-            VerifyOrExit(mCount != 0);
+            VerifyOrExit(mCount != 0, OT_NO_ACTION);
         }
 
         mChannel = Mac::ChannelMask::kChannelIteratorFirst;
@@ -161,7 +161,7 @@ void AnnounceSender::CheckState(void)
         period = kMinTxPeriod;
     }
 
-    VerifyOrExit(!IsRunning() || (period != GetPeriod()) || (GetChannelMask() != channelMask));
+    VerifyOrExit(!IsRunning() || (period != GetPeriod()) || (GetChannelMask() != channelMask), OT_NO_ACTION);
 
     SendAnnounce(channelMask, 0, period, kMaxJitter);
 

--- a/src/core/thread/child_table.cpp
+++ b/src/core/thread/child_table.cpp
@@ -80,7 +80,7 @@ void ChildTable::Iterator::Advance(void)
     Child *     listStart  = &childTable.mChildren[0];
     Child *     listEnd    = &childTable.mChildren[childTable.mMaxChildrenAllowed];
 
-    VerifyOrExit(mChild != NULL);
+    VerifyOrExit(mChild != NULL, OT_NO_ACTION);
 
     do
     {
@@ -109,7 +109,7 @@ Child *ChildTable::GetChildAtIndex(uint8_t aChildIndex)
 {
     Child *child = NULL;
 
-    VerifyOrExit(aChildIndex < mMaxChildrenAllowed);
+    VerifyOrExit(aChildIndex < mMaxChildrenAllowed, OT_NO_ACTION);
     child = &mChildren[aChildIndex];
 
 exit:

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -76,18 +76,18 @@ void EnergyScanServer::HandleRequest(Coap::Message &aMessage, const Ip6::Message
     Ip6::MessageInfo         responseInfo(aMessageInfo);
     uint32_t                 mask;
 
-    VerifyOrExit(aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.GetCode() == OT_COAP_CODE_POST, OT_NO_ACTION);
 
     SuccessOrExit(MeshCoP::Tlv::GetTlv(aMessage, MeshCoP::Tlv::kCount, sizeof(count), count));
-    VerifyOrExit(count.IsValid());
+    VerifyOrExit(count.IsValid(), OT_NO_ACTION);
 
     SuccessOrExit(MeshCoP::Tlv::GetTlv(aMessage, MeshCoP::Tlv::kPeriod, sizeof(period), period));
-    VerifyOrExit(period.IsValid());
+    VerifyOrExit(period.IsValid(), OT_NO_ACTION);
 
     SuccessOrExit(MeshCoP::Tlv::GetTlv(aMessage, MeshCoP::Tlv::kScanDuration, sizeof(scanDuration), scanDuration));
-    VerifyOrExit(scanDuration.IsValid());
+    VerifyOrExit(scanDuration.IsValid(), OT_NO_ACTION);
 
-    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
+    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0, OT_NO_ACTION);
 
     mChannelMask        = mask;
     mChannelMaskCurrent = mChannelMask;
@@ -117,7 +117,7 @@ void EnergyScanServer::HandleTimer(Timer &aTimer)
 
 void EnergyScanServer::HandleTimer(void)
 {
-    VerifyOrExit(mActive);
+    VerifyOrExit(mActive, OT_NO_ACTION);
 
     if (mCount)
     {
@@ -141,7 +141,7 @@ void EnergyScanServer::HandleScanResult(Instance &aInstance, otEnergyScanResult 
 
 void EnergyScanServer::HandleScanResult(otEnergyScanResult *aResult)
 {
-    VerifyOrExit(mActive);
+    VerifyOrExit(mActive, OT_NO_ACTION);
 
     if (aResult)
     {

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -180,7 +180,7 @@ void KeyManager::SetCurrentKeySequence(uint32_t aKeySequence)
     if ((aKeySequence == (mKeySequence + 1)) && (mKeySwitchGuardTime != 0) && mKeyRotationTimer.IsRunning() &&
         mKeySwitchGuardEnabled)
     {
-        VerifyOrExit(mHoursSinceKeyRotation >= mKeySwitchGuardTime);
+        VerifyOrExit(mHoursSinceKeyRotation >= mKeySwitchGuardTime, OT_NO_ACTION);
     }
 
     mKeySequence = aKeySequence;

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -133,7 +133,7 @@ RssAverager::InfoString RssAverager::ToString(void) const
 {
     InfoString string;
 
-    VerifyOrExit(mCount != 0);
+    VerifyOrExit(mCount != 0, OT_NO_ACTION);
     string.Set("%d.%s", -(mAverage >> kPrecisionBitShift), kDigitsString[mAverage & kPrecisionBitMask]);
 
 exit:
@@ -156,7 +156,7 @@ void LinkQualityInfo::AddRss(int8_t aNoiseFloor, int8_t aRss)
 {
     uint8_t oldLinkQuality = kNoLinkQuality;
 
-    VerifyOrExit(aRss != OT_RADIO_RSSI_INVALID);
+    VerifyOrExit(aRss != OT_RADIO_RSSI_INVALID, OT_NO_ACTION);
 
     mLastRss = aRss;
 

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -674,13 +674,13 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
     Ip6::IpProto         nextHeader;
     uint8_t *            bytes;
 
-    VerifyOrExit(remaining >= 2);
+    VerifyOrExit(remaining >= 2, OT_NO_ACTION);
     hcCtl = ReadUint16(cur);
     cur += 2;
     remaining -= 2;
 
     // check Dispatch bits
-    VerifyOrExit((hcCtl & kHcDispatchMask) == kHcDispatch);
+    VerifyOrExit((hcCtl & kHcDispatchMask) == kHcDispatch, OT_NO_ACTION);
 
     // Context Identifier
     srcContext.mPrefixLength = 0;
@@ -688,7 +688,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
 
     if ((hcCtl & kHcContextId) != 0)
     {
-        VerifyOrExit(remaining >= 1);
+        VerifyOrExit(remaining >= 1, OT_NO_ACTION);
 
         if (networkData.GetContext(cur[0] >> 4, srcContext) != OT_ERROR_NONE)
         {
@@ -715,7 +715,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
     // Traffic Class and Flow Label
     if ((hcCtl & kHcTrafficFlowMask) != kHcTrafficFlow)
     {
-        VerifyOrExit(remaining >= 1);
+        VerifyOrExit(remaining >= 1, OT_NO_ACTION);
 
         bytes = reinterpret_cast<uint8_t *>(&aIp6Header);
         bytes[1] |= (cur[0] & 0xc0) >> 2;
@@ -730,7 +730,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
 
         if ((hcCtl & kHcFlowLabel) == 0)
         {
-            VerifyOrExit(remaining >= 3);
+            VerifyOrExit(remaining >= 3, OT_NO_ACTION);
             bytes[1] |= cur[0] & 0x0f;
             bytes[2] |= cur[1];
             bytes[3] |= cur[2];
@@ -742,7 +742,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
     // Next Header
     if ((hcCtl & kHcNextHeader) == 0)
     {
-        VerifyOrExit(remaining >= 1);
+        VerifyOrExit(remaining >= 1, OT_NO_ACTION);
         aIp6Header.SetNextHeader(static_cast<Ip6::IpProto>(cur[0]));
         cur++;
         remaining--;
@@ -769,7 +769,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
         break;
 
     default:
-        VerifyOrExit(remaining >= 1);
+        VerifyOrExit(remaining >= 1, OT_NO_ACTION);
         aIp6Header.SetHopLimit(cur[0]);
         cur++;
         remaining--;
@@ -782,7 +782,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
     case kHcSrcAddrMode0:
         if ((hcCtl & kHcSrcAddrContext) == 0)
         {
-            VerifyOrExit(remaining >= sizeof(Ip6::Address));
+            VerifyOrExit(remaining >= sizeof(Ip6::Address), OT_NO_ACTION);
             memcpy(&aIp6Header.GetSource(), cur, sizeof(aIp6Header.GetSource()));
             cur += sizeof(Ip6::Address);
             remaining -= sizeof(Ip6::Address);
@@ -791,14 +791,14 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
         break;
 
     case kHcSrcAddrMode1:
-        VerifyOrExit(remaining >= Ip6::Address::kInterfaceIdentifierSize);
+        VerifyOrExit(remaining >= Ip6::Address::kInterfaceIdentifierSize, OT_NO_ACTION);
         aIp6Header.GetSource().SetIid(cur);
         cur += Ip6::Address::kInterfaceIdentifierSize;
         remaining -= Ip6::Address::kInterfaceIdentifierSize;
         break;
 
     case kHcSrcAddrMode2:
-        VerifyOrExit(remaining >= 2);
+        VerifyOrExit(remaining >= 2, OT_NO_ACTION);
         aIp6Header.GetSource().mFields.m8[11] = 0xff;
         aIp6Header.GetSource().mFields.m8[12] = 0xfe;
         memcpy(aIp6Header.GetSource().mFields.m8 + 14, cur, 2);
@@ -819,7 +819,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
         }
         else
         {
-            VerifyOrExit(srcContextValid);
+            VerifyOrExit(srcContextValid, OT_NO_ACTION);
             CopyContext(srcContext, aIp6Header.GetSource());
         }
     }
@@ -831,22 +831,22 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
         switch (hcCtl & kHcDstAddrModeMask)
         {
         case kHcDstAddrMode0:
-            VerifyOrExit((hcCtl & kHcDstAddrContext) == 0);
-            VerifyOrExit(remaining >= sizeof(Ip6::Address));
+            VerifyOrExit((hcCtl & kHcDstAddrContext) == 0, OT_NO_ACTION);
+            VerifyOrExit(remaining >= sizeof(Ip6::Address), OT_NO_ACTION);
             memcpy(&aIp6Header.GetDestination(), cur, sizeof(aIp6Header.GetDestination()));
             cur += sizeof(Ip6::Address);
             remaining -= sizeof(Ip6::Address);
             break;
 
         case kHcDstAddrMode1:
-            VerifyOrExit(remaining >= Ip6::Address::kInterfaceIdentifierSize);
+            VerifyOrExit(remaining >= Ip6::Address::kInterfaceIdentifierSize, OT_NO_ACTION);
             aIp6Header.GetDestination().SetIid(cur);
             cur += Ip6::Address::kInterfaceIdentifierSize;
             remaining -= Ip6::Address::kInterfaceIdentifierSize;
             break;
 
         case kHcDstAddrMode2:
-            VerifyOrExit(remaining >= 2);
+            VerifyOrExit(remaining >= 2, OT_NO_ACTION);
             aIp6Header.GetDestination().mFields.m8[11] = 0xff;
             aIp6Header.GetDestination().mFields.m8[12] = 0xfe;
             memcpy(aIp6Header.GetDestination().mFields.m8 + 14, cur, 2);
@@ -868,7 +868,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
         }
         else
         {
-            VerifyOrExit(dstContextValid);
+            VerifyOrExit(dstContextValid, OT_NO_ACTION);
             CopyContext(dstContext, aIp6Header.GetDestination());
         }
     }
@@ -883,14 +883,14 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
             switch (hcCtl & kHcDstAddrModeMask)
             {
             case kHcDstAddrMode0:
-                VerifyOrExit(remaining >= sizeof(Ip6::Address));
+                VerifyOrExit(remaining >= sizeof(Ip6::Address), OT_NO_ACTION);
                 memcpy(aIp6Header.GetDestination().mFields.m8, cur, sizeof(Ip6::Address));
                 cur += sizeof(Ip6::Address);
                 remaining -= sizeof(Ip6::Address);
                 break;
 
             case kHcDstAddrMode1:
-                VerifyOrExit(remaining >= 6);
+                VerifyOrExit(remaining >= 6, OT_NO_ACTION);
                 aIp6Header.GetDestination().mFields.m8[1] = cur[0];
                 memcpy(aIp6Header.GetDestination().mFields.m8 + 11, cur + 1, 5);
                 cur += 6;
@@ -898,7 +898,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
                 break;
 
             case kHcDstAddrMode2:
-                VerifyOrExit(remaining >= 4);
+                VerifyOrExit(remaining >= 4, OT_NO_ACTION);
                 aIp6Header.GetDestination().mFields.m8[1] = cur[0];
                 memcpy(aIp6Header.GetDestination().mFields.m8 + 13, cur + 1, 3);
                 cur += 4;
@@ -906,7 +906,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
                 break;
 
             case kHcDstAddrMode3:
-                VerifyOrExit(remaining >= 1);
+                VerifyOrExit(remaining >= 1, OT_NO_ACTION);
                 aIp6Header.GetDestination().mFields.m8[1]  = 0x02;
                 aIp6Header.GetDestination().mFields.m8[15] = cur[0];
                 cur++;
@@ -919,8 +919,8 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
             switch (hcCtl & kHcDstAddrModeMask)
             {
             case 0:
-                VerifyOrExit(remaining >= 6);
-                VerifyOrExit(dstContextValid);
+                VerifyOrExit(remaining >= 6, OT_NO_ACTION);
+                VerifyOrExit(dstContextValid, OT_NO_ACTION);
                 aIp6Header.GetDestination().mFields.m8[1] = cur[0];
                 aIp6Header.GetDestination().mFields.m8[2] = cur[1];
                 aIp6Header.GetDestination().mFields.m8[3] = dstContext.mPrefixLength;
@@ -938,7 +938,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
 
     if ((hcCtl & kHcNextHeader) != 0)
     {
-        VerifyOrExit(remaining >= 1);
+        VerifyOrExit(remaining >= 1, OT_NO_ACTION);
         SuccessOrExit(DispatchToNextHeader(cur[0], nextHeader));
         aIp6Header.SetNextHeader(nextHeader);
     }
@@ -962,33 +962,33 @@ int Lowpan::DecompressExtensionHeader(Message &aMessage, const uint8_t *aBuf, ui
     Ip6::OptionPad1 optionPad1;
     Ip6::OptionPadN optionPadN;
 
-    VerifyOrExit(remaining >= 1);
+    VerifyOrExit(remaining >= 1, OT_NO_ACTION);
     cur++;
     remaining--;
 
     // next header
     if (ctl & kExtHdrNextHeader)
     {
-        VerifyOrExit(remaining >= 1);
+        VerifyOrExit(remaining >= 1, OT_NO_ACTION);
 
         len = cur[0];
         cur++;
         remaining--;
 
-        VerifyOrExit(remaining >= len);
+        VerifyOrExit(remaining >= len, OT_NO_ACTION);
         SuccessOrExit(DispatchToNextHeader(cur[len], nextHeader));
         hdr[0] = static_cast<uint8_t>(nextHeader);
     }
     else
     {
-        VerifyOrExit(remaining >= 2);
+        VerifyOrExit(remaining >= 2, OT_NO_ACTION);
 
         hdr[0] = cur[0];
         len    = cur[1];
         cur += 2;
         remaining -= 2;
 
-        VerifyOrExit(remaining >= len);
+        VerifyOrExit(remaining >= len, OT_NO_ACTION);
     }
 
     // length
@@ -1036,12 +1036,12 @@ int Lowpan::DecompressUdpHeader(Ip6::UdpHeader &aUdpHeader, const uint8_t *aBuf,
     uint16_t       remaining = aBufLength;
     uint8_t        udpCtl;
 
-    VerifyOrExit(remaining >= 1);
+    VerifyOrExit(remaining >= 1, OT_NO_ACTION);
     udpCtl = cur[0];
     cur++;
     remaining--;
 
-    VerifyOrExit((udpCtl & kUdpDispatchMask) == kUdpDispatch);
+    VerifyOrExit((udpCtl & kUdpDispatchMask) == kUdpDispatch, OT_NO_ACTION);
 
     memset(&aUdpHeader, 0, sizeof(aUdpHeader));
 
@@ -1049,7 +1049,7 @@ int Lowpan::DecompressUdpHeader(Ip6::UdpHeader &aUdpHeader, const uint8_t *aBuf,
     switch (udpCtl & kUdpPortMask)
     {
     case 0:
-        VerifyOrExit(remaining >= 4);
+        VerifyOrExit(remaining >= 4, OT_NO_ACTION);
         aUdpHeader.SetSourcePort(ReadUint16(cur));
         aUdpHeader.SetDestinationPort(ReadUint16(cur + 2));
         cur += 4;
@@ -1057,7 +1057,7 @@ int Lowpan::DecompressUdpHeader(Ip6::UdpHeader &aUdpHeader, const uint8_t *aBuf,
         break;
 
     case 1:
-        VerifyOrExit(remaining >= 3);
+        VerifyOrExit(remaining >= 3, OT_NO_ACTION);
         aUdpHeader.SetSourcePort(ReadUint16(cur));
         aUdpHeader.SetDestinationPort(0xf000 | cur[2]);
         cur += 3;
@@ -1065,7 +1065,7 @@ int Lowpan::DecompressUdpHeader(Ip6::UdpHeader &aUdpHeader, const uint8_t *aBuf,
         break;
 
     case 2:
-        VerifyOrExit(remaining >= 3);
+        VerifyOrExit(remaining >= 3, OT_NO_ACTION);
         aUdpHeader.SetSourcePort(0xf000 | cur[0]);
         aUdpHeader.SetDestinationPort(ReadUint16(cur + 1));
         cur += 3;
@@ -1073,7 +1073,7 @@ int Lowpan::DecompressUdpHeader(Ip6::UdpHeader &aUdpHeader, const uint8_t *aBuf,
         break;
 
     case 3:
-        VerifyOrExit(remaining >= 1);
+        VerifyOrExit(remaining >= 1, OT_NO_ACTION);
         aUdpHeader.SetSourcePort(0xf0b0 | (cur[0] >> 4));
         aUdpHeader.SetDestinationPort(0xf0b0 | (cur[0] & 0xf));
         cur += 1;
@@ -1088,7 +1088,7 @@ int Lowpan::DecompressUdpHeader(Ip6::UdpHeader &aUdpHeader, const uint8_t *aBuf,
     }
     else
     {
-        VerifyOrExit(remaining >= 2);
+        VerifyOrExit(remaining >= 2, OT_NO_ACTION);
         aUdpHeader.SetChecksum(ReadUint16(cur));
         cur += 2;
     }
@@ -1105,7 +1105,7 @@ int Lowpan::DecompressUdpHeader(Message &aMessage, const uint8_t *aBuf, uint16_t
     int            headerLen = -1;
 
     headerLen = DecompressUdpHeader(udpHeader, aBuf, aBufLength);
-    VerifyOrExit(headerLen >= 0);
+    VerifyOrExit(headerLen >= 0, OT_NO_ACTION);
 
     // length
     if (aDatagramLength == 0)
@@ -1141,8 +1141,9 @@ int Lowpan::Decompress(Message &           aMessage,
     uint16_t       compressedLength = 0;
     uint16_t       currentOffset    = aMessage.GetOffset();
 
-    VerifyOrExit(remaining >= 2);
-    VerifyOrExit((rval = DecompressBaseHeader(ip6Header, compressed, aMacSource, aMacDest, cur, remaining)) >= 0);
+    VerifyOrExit(remaining >= 2, OT_NO_ACTION);
+    VerifyOrExit((rval = DecompressBaseHeader(ip6Header, compressed, aMacSource, aMacDest, cur, remaining)) >= 0,
+                 OT_NO_ACTION);
 
     cur += rval;
     remaining -= rval;
@@ -1152,7 +1153,7 @@ int Lowpan::Decompress(Message &           aMessage,
 
     while (compressed)
     {
-        VerifyOrExit(remaining >= 1);
+        VerifyOrExit(remaining >= 1, OT_NO_ACTION);
 
         if ((cur[0] & kExtHdrDispatchMask) == kExtHdrDispatch)
         {
@@ -1163,25 +1164,26 @@ int Lowpan::Decompress(Message &           aMessage,
                 cur++;
                 remaining--;
 
-                VerifyOrExit((rval = Decompress(aMessage, aMacSource, aMacDest, cur, remaining, aDatagramLength)) >= 0);
+                VerifyOrExit((rval = Decompress(aMessage, aMacSource, aMacDest, cur, remaining, aDatagramLength)) >= 0,
+                             OT_NO_ACTION);
             }
             else
             {
                 compressed = (cur[0] & kExtHdrNextHeader) != 0;
-                VerifyOrExit((rval = DecompressExtensionHeader(aMessage, cur, remaining)) >= 0);
+                VerifyOrExit((rval = DecompressExtensionHeader(aMessage, cur, remaining)) >= 0, OT_NO_ACTION);
             }
         }
         else if ((cur[0] & kUdpDispatchMask) == kUdpDispatch)
         {
             compressed = false;
-            VerifyOrExit((rval = DecompressUdpHeader(aMessage, cur, remaining, aDatagramLength)) >= 0);
+            VerifyOrExit((rval = DecompressUdpHeader(aMessage, cur, remaining, aDatagramLength)) >= 0, OT_NO_ACTION);
         }
         else
         {
             ExitNow();
         }
 
-        VerifyOrExit(remaining >= rval);
+        VerifyOrExit(remaining >= rval, OT_NO_ACTION);
         cur += rval;
         remaining -= rval;
     }
@@ -1264,14 +1266,14 @@ otError FragmentHeader::Init(const uint8_t *aFrame, uint16_t aFrameLength)
 {
     otError error = OT_ERROR_PARSE;
 
-    VerifyOrExit(aFrameLength >= sizeof(mDispatchSize) + sizeof(mTag));
+    VerifyOrExit(aFrameLength >= sizeof(mDispatchSize) + sizeof(mTag), OT_NO_ACTION);
     memcpy(reinterpret_cast<uint8_t *>(&mDispatchSize), aFrame, sizeof(mDispatchSize) + sizeof(mTag));
     aFrame += sizeof(mDispatchSize) + sizeof(mTag);
     aFrameLength -= sizeof(mDispatchSize) + sizeof(mTag);
 
     if (IsOffsetPresent())
     {
-        VerifyOrExit(aFrameLength >= sizeof(mOffset));
+        VerifyOrExit(aFrameLength >= sizeof(mOffset), OT_NO_ACTION);
         mOffset = *aFrame++;
     }
 

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -109,7 +109,7 @@ void MeshForwarder::Stop(void)
 {
     Message *message;
 
-    VerifyOrExit(mEnabled == true);
+    VerifyOrExit(mEnabled == true, OT_NO_ACTION);
 
     mDataPollSender.StopPolling();
     mUpdateTimer.Stop();
@@ -175,7 +175,7 @@ void MeshForwarder::ScheduleTransmissionTask(Tasklet &aTasklet)
 
 void MeshForwarder::ScheduleTransmissionTask(void)
 {
-    VerifyOrExit(mSendBusy == false);
+    VerifyOrExit(mSendBusy == false, OT_NO_ACTION);
 
     mSendMessageIsARetransmission = false;
 
@@ -207,7 +207,7 @@ otError MeshForwarder::PrepareDiscoverRequest(void)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(!mScanning);
+    VerifyOrExit(!mScanning, OT_NO_ACTION);
 
     mScanChannel  = Mac::ChannelMask::kChannelIteratorFirst;
     mRestorePanId = Get<Mac::Mac>().GetPanId();
@@ -433,7 +433,8 @@ otError MeshForwarder::SkipMeshHeader(const uint8_t *&aFrame, uint16_t &aFrameLe
     otError            error = OT_ERROR_NONE;
     Lowpan::MeshHeader meshHeader;
 
-    VerifyOrExit(aFrameLength >= 1 && reinterpret_cast<const Lowpan::MeshHeader *>(aFrame)->IsMeshHeader());
+    VerifyOrExit(aFrameLength >= 1 && reinterpret_cast<const Lowpan::MeshHeader *>(aFrame)->IsMeshHeader(),
+                 OT_NO_ACTION);
 
     SuccessOrExit(error = meshHeader.Init(aFrame, aFrameLength));
     aFrame += meshHeader.GetHeaderLength();
@@ -950,12 +951,12 @@ Neighbor *MeshForwarder::UpdateNeighborOnSentFrame(Mac::Frame &aFrame, otError a
 {
     Neighbor *neighbor = NULL;
 
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NO_ACTION);
 
     neighbor = Get<Mle::MleRouter>().GetNeighbor(aMacDest);
-    VerifyOrExit(neighbor != NULL);
+    VerifyOrExit(neighbor != NULL, OT_NO_ACTION);
 
-    VerifyOrExit(aFrame.GetAckRequest());
+    VerifyOrExit(aFrame.GetAckRequest(), OT_NO_ACTION);
 
     if (aError == OT_ERROR_NONE)
     {
@@ -964,7 +965,7 @@ Neighbor *MeshForwarder::UpdateNeighborOnSentFrame(Mac::Frame &aFrame, otError a
     else if (aError == OT_ERROR_NO_ACK)
     {
         neighbor->IncrementLinkFailures();
-        VerifyOrExit(Mle::Mle::IsActiveRouter(neighbor->GetRloc16()));
+        VerifyOrExit(Mle::Mle::IsActiveRouter(neighbor->GetRloc16()), OT_NO_ACTION);
 
         if (neighbor->GetLinkFailures() >= Mle::kFailedRouterTransmissions)
         {
@@ -986,7 +987,7 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, otError aError)
 
     mSendBusy = false;
 
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NO_ACTION);
 
     aFrame.GetDstAddr(macDest);
     neighbor = UpdateNeighborOnSentFrame(aFrame, aError, macDest);
@@ -995,7 +996,7 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, otError aError)
     HandleSentFrameToChild(aFrame, aError, macDest);
 #endif
 
-    VerifyOrExit(mSendMessage != NULL);
+    VerifyOrExit(mSendMessage != NULL, OT_NO_ACTION);
 
     if (mSendMessage->GetDirectTransmission())
     {
@@ -1525,14 +1526,14 @@ otError MeshForwarder::GetFramePriority(const uint8_t *     aFrame,
     SuccessOrExit(error = DecompressIp6Header(aFrame, aFrameLength, aMacSource, aMacDest, ip6Header, headerLength,
                                               nextHeaderCompressed));
     aPriority = Ip6::Ip6::DscpToPriority(ip6Header.GetDscp());
-    VerifyOrExit(ip6Header.GetNextHeader() == Ip6::kProtoUdp);
+    VerifyOrExit(ip6Header.GetNextHeader() == Ip6::kProtoUdp, OT_NO_ACTION);
 
     aFrame += headerLength;
     aFrameLength -= headerLength;
 
     if (nextHeaderCompressed)
     {
-        VerifyOrExit(Get<Lowpan::Lowpan>().DecompressUdpHeader(udpHeader, aFrame, aFrameLength) >= 0);
+        VerifyOrExit(Get<Lowpan::Lowpan>().DecompressUdpHeader(udpHeader, aFrame, aFrameLength) >= 0, OT_NO_ACTION);
     }
     else
     {
@@ -1570,20 +1571,22 @@ otError MeshForwarder::ParseIp6UdpTcpHeader(const Message &aMessage,
     aSourcePort = 0;
     aDestPort   = 0;
 
-    VerifyOrExit(sizeof(Ip6::Header) == aMessage.Read(0, sizeof(Ip6::Header), &aIp6Header));
-    VerifyOrExit(aIp6Header.IsVersion6());
+    VerifyOrExit(sizeof(Ip6::Header) == aMessage.Read(0, sizeof(Ip6::Header), &aIp6Header), OT_NO_ACTION);
+    VerifyOrExit(aIp6Header.IsVersion6(), OT_NO_ACTION);
 
     switch (aIp6Header.GetNextHeader())
     {
     case Ip6::kProtoUdp:
-        VerifyOrExit(sizeof(Ip6::UdpHeader) == aMessage.Read(sizeof(Ip6::Header), sizeof(Ip6::UdpHeader), &header.udp));
+        VerifyOrExit(sizeof(Ip6::UdpHeader) == aMessage.Read(sizeof(Ip6::Header), sizeof(Ip6::UdpHeader), &header.udp),
+                     OT_NO_ACTION);
         aChecksum   = header.udp.GetChecksum();
         aSourcePort = header.udp.GetSourcePort();
         aDestPort   = header.udp.GetDestinationPort();
         break;
 
     case Ip6::kProtoTcp:
-        VerifyOrExit(sizeof(Ip6::TcpHeader) == aMessage.Read(sizeof(Ip6::Header), sizeof(Ip6::TcpHeader), &header.tcp));
+        VerifyOrExit(sizeof(Ip6::TcpHeader) == aMessage.Read(sizeof(Ip6::Header), sizeof(Ip6::TcpHeader), &header.tcp),
+                     OT_NO_ACTION);
         aChecksum   = header.tcp.GetChecksum();
         aSourcePort = header.tcp.GetSourcePort();
         aDestPort   = header.tcp.GetDestinationPort();
@@ -1745,7 +1748,7 @@ void MeshForwarder::LogMessage(MessageAction       aAction,
         break;
     }
 
-    VerifyOrExit(GetInstance().GetLogLevel() >= logLevel);
+    VerifyOrExit(GetInstance().GetLogLevel() >= logLevel, OT_NO_ACTION);
 
     switch (aMessage.GetType())
     {

--- a/src/core/thread/mesh_forwarder_mtd.cpp
+++ b/src/core/thread/mesh_forwarder_mtd.cpp
@@ -57,7 +57,7 @@ otError MeshForwarder::EvictMessage(uint8_t aPriority)
     otError  error = OT_ERROR_NOT_FOUND;
     Message *message;
 
-    VerifyOrExit((message = mSendQueue.GetTail()) != NULL);
+    VerifyOrExit((message = mSendQueue.GetTail()) != NULL, OT_NO_ACTION);
 
     if (message->GetPriority() < aPriority)
     {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -286,7 +286,7 @@ void Mle::Stop(bool aClearNetworkDatasets)
         Get<MeshCoP::PendingDataset>().HandleDetach();
     }
 
-    VerifyOrExit(mRole != OT_DEVICE_ROLE_DISABLED);
+    VerifyOrExit(mRole != OT_DEVICE_ROLE_DISABLED, OT_NO_ACTION);
 
     Get<KeyManager>().Stop();
     SetStateDetached();
@@ -346,7 +346,7 @@ exit:
 
 void Mle::SetAttachState(AttachState aState)
 {
-    VerifyOrExit(aState != mAttachState);
+    VerifyOrExit(aState != mAttachState, OT_NO_ACTION);
     otLogInfoMle("AttachState %s -> %s", AttachStateToString(mAttachState), AttachStateToString(aState));
     mAttachState = aState;
 
@@ -587,7 +587,7 @@ otError Mle::BecomeDetached(void)
     // (i.e., waiting to start an attach attempt), there is no need to make any
     // changes.
 
-    VerifyOrExit(mRole != OT_DEVICE_ROLE_DETACHED || mAttachState != kAttachStateStart);
+    VerifyOrExit(mRole != OT_DEVICE_ROLE_DETACHED || mAttachState != kAttachStateStart, OT_NO_ACTION);
 
     // not in reattach stage after reset
     if (mReattachState == kReattachStop)
@@ -671,7 +671,7 @@ uint32_t Mle::GetAttachStartDelay(void) const
     uint32_t delay = 1;
     uint32_t jitter;
 
-    VerifyOrExit(mRole == OT_DEVICE_ROLE_DETACHED);
+    VerifyOrExit(mRole == OT_DEVICE_ROLE_DETACHED, OT_NO_ACTION);
 
     if (mAttachCounter == 0)
     {
@@ -781,8 +781,8 @@ void Mle::SetStateChild(uint16_t aRloc16)
 
 void Mle::InformPreviousChannel(void)
 {
-    VerifyOrExit(mAlternatePanId != Mac::kPanIdBroadcast);
-    VerifyOrExit(mRole == OT_DEVICE_ROLE_CHILD || mRole == OT_DEVICE_ROLE_ROUTER);
+    VerifyOrExit(mAlternatePanId != Mac::kPanIdBroadcast, OT_NO_ACTION);
+    VerifyOrExit(mRole == OT_DEVICE_ROLE_CHILD || mRole == OT_DEVICE_ROLE_ROUTER, OT_NO_ACTION);
 
     if (!IsFullThreadDevice() || mRole == OT_DEVICE_ROLE_ROUTER ||
         Get<MleRouter>().GetRouterSelectionJitterTimeout() == 0)
@@ -797,7 +797,7 @@ exit:
 
 void Mle::SetTimeout(uint32_t aTimeout)
 {
-    VerifyOrExit(mTimeout != aTimeout);
+    VerifyOrExit(mTimeout != aTimeout, OT_NO_ACTION);
 
     if (aTimeout < kMinTimeout)
     {
@@ -824,7 +824,7 @@ otError Mle::SetDeviceMode(uint8_t aDeviceMode)
 
     VerifyOrExit((aDeviceMode & ModeTlv::kModeFullThreadDevice) == 0 || (aDeviceMode & ModeTlv::kModeRxOnWhenIdle) != 0,
                  error = OT_ERROR_INVALID_ARGS);
-    VerifyOrExit(mDeviceMode != aDeviceMode);
+    VerifyOrExit(mDeviceMode != aDeviceMode, OT_NO_ACTION);
 
     otLogNoteMle("Mode 0x%02x -> 0x%02x [rx-on:%s, sec-data-req:%s, ftd:%s, full-netdata:%s]", mDeviceMode, aDeviceMode,
                  (aDeviceMode & ModeTlv::kModeRxOnWhenIdle) ? "yes" : " no",
@@ -896,7 +896,7 @@ void Mle::SetMeshLocalPrefix(const otMeshLocalPrefix &aMeshLocalPrefix)
     memcpy(mLeaderAloc.GetAddress().mFields.m8, aMeshLocalPrefix.m8, sizeof(aMeshLocalPrefix));
 
     // Just keep mesh local prefix if network interface is down
-    VerifyOrExit(Get<ThreadNetif>().IsUp());
+    VerifyOrExit(Get<ThreadNetif>().IsUp(), OT_NO_ACTION);
 
     ApplyMeshLocalPrefix();
 
@@ -926,7 +926,7 @@ void Mle::ApplyMeshLocalPrefix(void)
     mRealmLocalAllThreadNodes.GetAddress().mFields.m8[3] = 64;
     memcpy(mRealmLocalAllThreadNodes.GetAddress().mFields.m8 + 4, mMeshLocal64.GetAddress().mFields.m8, 8);
 
-    VerifyOrExit(mRole != OT_DEVICE_ROLE_DISABLED);
+    VerifyOrExit(mRole != OT_DEVICE_ROLE_DISABLED, OT_NO_ACTION);
 
     // Add the addresses back into the table.
     Get<ThreadNetif>().AddUnicastAddress(mMeshLocal64);
@@ -1099,7 +1099,7 @@ Message *Mle::NewMleMessage(void)
     otMessageSettings settings = {false, static_cast<otMessagePriority>(kMleMessagePriority)};
 
     message = mSocket.NewMessage(0, &settings);
-    VerifyOrExit(message != NULL);
+    VerifyOrExit(message != NULL, OT_NO_ACTION);
 
     message->SetSubType(Message::kSubTypeMleGeneral);
 
@@ -1390,7 +1390,7 @@ otError Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMod
         length += entry.GetLength();
         counter++;
         // only continue to append if there is available entry.
-        VerifyOrExit(!done && (counter < OPENTHREAD_CONFIG_IP_ADDRS_TO_REGISTER));
+        VerifyOrExit(!done && (counter < OPENTHREAD_CONFIG_IP_ADDRS_TO_REGISTER), OT_NO_ACTION);
     }
 
     // For sleepy end device, register external multicast addresses to the parent for indirect transmission
@@ -1409,7 +1409,7 @@ otError Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMod
 
             counter++;
             // only continue to append if there is available entry.
-            VerifyOrExit(counter < OPENTHREAD_CONFIG_IP_ADDRS_TO_REGISTER);
+            VerifyOrExit(counter < OPENTHREAD_CONFIG_IP_ADDRS_TO_REGISTER, OT_NO_ACTION);
         }
     }
 
@@ -1497,7 +1497,7 @@ void Mle::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlag
 
 void Mle::HandleStateChanged(otChangedFlags aFlags)
 {
-    VerifyOrExit(mRole != OT_DEVICE_ROLE_DISABLED);
+    VerifyOrExit(mRole != OT_DEVICE_ROLE_DISABLED, OT_NO_ACTION);
 
     if (aFlags & OT_CHANGED_THREAD_ROLE)
     {
@@ -1601,7 +1601,7 @@ void Mle::UpdateServiceAlocs(void)
     otNetworkDataIterator serviceIterator    = OT_NETWORK_DATA_ITERATOR_INIT;
     int                   serviceAlocsLength = OT_ARRAY_LENGTH(mServiceAlocs);
 
-    VerifyOrExit(mRole != OT_DEVICE_ROLE_DISABLED);
+    VerifyOrExit(mRole != OT_DEVICE_ROLE_DISABLED, OT_NO_ACTION);
 
     // First remove all alocs which are no longer necessary, to free up space in mServiceAlocs
     for (i = 0; i < serviceAlocsLength; i++)
@@ -1792,7 +1792,8 @@ bool Mle::PrepareAnnounceState(void)
     Mac::ChannelMask channelMask;
 
     VerifyOrExit((mRole != OT_DEVICE_ROLE_CHILD) && (mReattachState == kReattachStop) &&
-                 (Get<MeshCoP::ActiveDataset>().IsPartiallyComplete() || !IsFullThreadDevice()));
+                     (Get<MeshCoP::ActiveDataset>().IsPartiallyComplete() || !IsFullThreadDevice()),
+                 OT_NO_ACTION);
 
     if (Get<MeshCoP::ActiveDataset>().GetChannelMask(channelMask) != OT_ERROR_NONE)
     {
@@ -1836,7 +1837,7 @@ uint32_t Mle::Reattach(void)
         Get<MeshCoP::ActiveDataset>().Restore();
     }
 
-    VerifyOrExit(mReattachState == kReattachStop);
+    VerifyOrExit(mReattachState == kReattachStop, OT_NO_ACTION);
 
     switch (mParentRequestMode)
     {
@@ -2245,7 +2246,7 @@ void Mle::HandleMessageTransmissionTimer(void)
         }
 
         // Keep-alive "Child Update Request" only on a non-sleepy child
-        VerifyOrExit((mRole == OT_DEVICE_ROLE_CHILD) && IsRxOnWhenIdle());
+        VerifyOrExit((mRole == OT_DEVICE_ROLE_CHILD) && IsRxOnWhenIdle(), OT_NO_ACTION);
         break;
 
     case kChildUpdateRequestPending:
@@ -2617,11 +2618,11 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     uint8_t         command;
     Neighbor *      neighbor;
 
-    VerifyOrExit(aMessageInfo.GetLinkInfo() != NULL);
-    VerifyOrExit(aMessageInfo.GetHopLimit() == kMleHopLimit);
+    VerifyOrExit(aMessageInfo.GetLinkInfo() != NULL, OT_NO_ACTION);
+    VerifyOrExit(aMessageInfo.GetHopLimit() == kMleHopLimit, OT_NO_ACTION);
 
     length = aMessage.Read(aMessage.GetOffset(), sizeof(header), &header);
-    VerifyOrExit(header.IsValid() && header.GetLength() <= length);
+    VerifyOrExit(header.IsValid() && header.GetLength() <= length, OT_NO_ACTION);
 
     if (header.GetSecuritySuite() == Header::kNoSecurity)
     {
@@ -2644,7 +2645,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
         ExitNow();
     }
 
-    VerifyOrExit(mRole != OT_DEVICE_ROLE_DISABLED && header.GetSecuritySuite() == Header::k154Security);
+    VerifyOrExit(mRole != OT_DEVICE_ROLE_DISABLED && header.GetSecuritySuite() == Header::k154Security, OT_NO_ACTION);
 
     keySequence = header.GetKeyId();
 
@@ -2657,7 +2658,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
         mleKey = Get<KeyManager>().GetTemporaryMleKey(keySequence);
     }
 
-    VerifyOrExit(aMessage.GetOffset() + header.GetLength() + sizeof(messageTag) <= aMessage.GetLength());
+    VerifyOrExit(aMessage.GetOffset() + header.GetLength() + sizeof(messageTag) <= aMessage.GetLength(), OT_NO_ACTION);
     aMessage.MoveOffset(header.GetLength() - 1);
 
     aMessage.Read(aMessage.GetLength() - sizeof(messageTag), sizeof(messageTag), messageTag);
@@ -2691,7 +2692,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     tagLength = sizeof(tag);
     aesCcm.Finalize(tag, &tagLength);
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    VerifyOrExit(memcmp(messageTag, tag, sizeof(tag)) == 0);
+    VerifyOrExit(memcmp(messageTag, tag, sizeof(tag)) == 0, OT_NO_ACTION);
 #endif
 
     if (keySequence > Get<KeyManager>().GetCurrentKeySequence())
@@ -3015,7 +3016,7 @@ otError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &a
                 static_cast<int8_t>(leaderData.GetStableDataVersion() - Get<NetworkData::Leader>().GetStableVersion());
         }
 
-        VerifyOrExit(diff > 0);
+        VerifyOrExit(diff > 0, OT_NO_ACTION);
     }
 
     // Active Timestamp
@@ -3268,25 +3269,26 @@ otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInf
         switch (mParentRequestMode)
         {
         case kAttachAny:
-            VerifyOrExit(leaderData.GetPartitionId() != mLeaderData.GetPartitionId() || diff > 0);
+            VerifyOrExit(leaderData.GetPartitionId() != mLeaderData.GetPartitionId() || diff > 0, OT_NO_ACTION);
             break;
 
         case kAttachSame1:
         case kAttachSame2:
-            VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId());
-            VerifyOrExit(diff > 0);
+            VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId(), OT_NO_ACTION);
+            VerifyOrExit(diff > 0, OT_NO_ACTION);
             break;
 
         case kAttachSameDowngrade:
-            VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId());
-            VerifyOrExit(diff >= 0);
+            VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId(), OT_NO_ACTION);
+            VerifyOrExit(diff >= 0, OT_NO_ACTION);
             break;
 
         case kAttachBetter:
-            VerifyOrExit(leaderData.GetPartitionId() != mLeaderData.GetPartitionId());
+            VerifyOrExit(leaderData.GetPartitionId() != mLeaderData.GetPartitionId(), OT_NO_ACTION);
 
             VerifyOrExit(MleRouter::ComparePartitions(connectivity.GetActiveRouters() <= 1, leaderData,
-                                                      Get<MleRouter>().IsSingleton(), mLeaderData) > 0);
+                                                      Get<MleRouter>().IsSingleton(), mLeaderData) > 0,
+                         OT_NO_ACTION);
             break;
         }
     }
@@ -3304,10 +3306,11 @@ otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInf
         }
 
         // only consider partitions that are the same or better
-        VerifyOrExit(compare >= 0);
+        VerifyOrExit(compare >= 0, OT_NO_ACTION);
 
         // only consider better parents if the partitions are the same
-        VerifyOrExit(compare != 0 || IsBetterParent(sourceAddress.GetRloc16(), linkQuality, linkMargin, connectivity));
+        VerifyOrExit(compare != 0 || IsBetterParent(sourceAddress.GetRloc16(), linkQuality, linkMargin, connectivity),
+                     OT_NO_ACTION);
     }
 
     // Link Frame Counter
@@ -3317,7 +3320,7 @@ otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInf
     // Mle Frame Counter
     if (Tlv::GetTlv(aMessage, Tlv::kMleFrameCounter, sizeof(mleFrameCounter), mleFrameCounter) == OT_ERROR_NONE)
     {
-        VerifyOrExit(mleFrameCounter.IsValid());
+        VerifyOrExit(mleFrameCounter.IsValid(), OT_NO_ACTION);
     }
     else
     {
@@ -3329,7 +3332,7 @@ otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInf
     // Time Parameter
     if (Tlv::GetTlv(aMessage, Tlv::kTimeParameter, sizeof(timeParameter), timeParameter) == OT_ERROR_NONE)
     {
-        VerifyOrExit(timeParameter.IsValid());
+        VerifyOrExit(timeParameter.IsValid(), OT_NO_ACTION);
 
         Get<TimeSync>().SetTimeSyncPeriod(timeParameter.GetTimeSyncPeriod());
         Get<TimeSync>().SetXtalThreshold(timeParameter.GetXtalThreshold());
@@ -3404,7 +3407,7 @@ otError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::MessageIn
 
     LogMleMessage("Receive Child ID Response", aMessageInfo.GetPeerAddr(), sourceAddress.GetRloc16());
 
-    VerifyOrExit(mAttachState == kAttachStateChildIdRequest);
+    VerifyOrExit(mAttachState == kAttachStateChildIdRequest, OT_NO_ACTION);
 
     // Leader Data
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kLeaderData, sizeof(leaderData), leaderData));
@@ -3714,11 +3717,12 @@ otError Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMe
         // Announce message.
 
         VerifyOrExit((mRole != OT_DEVICE_ROLE_DETACHED) || (Get<Mac::Mac>().GetPanChannel() != channel) ||
-                     (Get<Mac::Mac>().GetPanId() != panId));
+                         (Get<Mac::Mac>().GetPanId() != panId),
+                     OT_NO_ACTION);
 
         if (mAttachState == kAttachStateProcessAnnounce)
         {
-            VerifyOrExit(mAlternateTimestamp < timestamp.GetSeconds());
+            VerifyOrExit(mAlternateTimestamp < timestamp.GetSeconds(), OT_NO_ACTION);
         }
 
         mAlternateTimestamp = timestamp.GetSeconds();
@@ -3838,7 +3842,8 @@ otError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::Message
             if (mDiscoverEnableFiltering)
             {
                 VerifyOrExit((steeringData.GetBit(mDiscoverCcittIndex % steeringData.GetNumBits()) &&
-                              steeringData.GetBit(mDiscoverAnsiIndex % steeringData.GetNumBits())));
+                              steeringData.GetBit(mDiscoverAnsiIndex % steeringData.GetNumBits())),
+                             OT_NO_ACTION);
             }
 
             didCheckSteeringData         = true;
@@ -3860,7 +3865,7 @@ otError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::Message
         offset += sizeof(meshcopTlv) + meshcopTlv.GetLength();
     }
 
-    VerifyOrExit(!mDiscoverEnableFiltering || didCheckSteeringData);
+    VerifyOrExit(!mDiscoverEnableFiltering || didCheckSteeringData, OT_NO_ACTION);
 
     mDiscoverHandler(&result, mDiscoverContext);
 
@@ -4005,7 +4010,8 @@ otError Mle::InformPreviousParent(void)
     Message *        message = NULL;
     Ip6::MessageInfo messageInfo;
 
-    VerifyOrExit((mPreviousParentRloc != Mac::kShortAddrInvalid) && (mPreviousParentRloc != mParent.GetRloc16()));
+    VerifyOrExit((mPreviousParentRloc != Mac::kShortAddrInvalid) && (mPreviousParentRloc != mParent.GetRloc16()),
+                 OT_NO_ACTION);
 
     mCounters.mParentChanges++;
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2956,7 +2956,7 @@ otError Mle::HandleDataResponse(const Message &aMessage, const Ip6::MessageInfo 
 
     if (error != OT_ERROR_NONE)
     {
-        otLogWarnMleErr(error, "Failed to process Data Response");
+        otLogWarnMle("Failed to process Data Response: %s", otThreadErrorToString(error));
     }
 
     if (mDataRequestState == kDataRequestNone && !IsRxOnWhenIdle())
@@ -3377,7 +3377,7 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
-        otLogWarnMleErr(error, "Failed to process Parent Response");
+        otLogWarnMle("Failed to process Parent Response: %s", otThreadErrorToString(error));
     }
 
     return error;
@@ -3498,7 +3498,7 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
-        otLogWarnMleErr(error, "Failed to process Child ID Response");
+        otLogWarnMle("Failed to process Child ID Response: %s", otThreadErrorToString(error));
     }
 
     return error;
@@ -3673,7 +3673,7 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
-        otLogWarnMleErr(error, "Failed to process Child Update Response");
+        otLogWarnMle("Failed to process Child Update Response: %s", otThreadErrorToString(error));
     }
 
     return error;
@@ -3868,7 +3868,7 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
-        otLogWarnMleErr(error, "Failed to process Discovery Response");
+        otLogWarnMle("Failed to process Discovery Response: %s", otThreadErrorToString(error));
     }
 
     return error;

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2686,7 +2686,7 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
-        otLogWarnMleErr(error, "Failed to process Discovery Request");
+        otLogWarnMle("Failed to process Discovery Request: %s", otThreadErrorToString(error));
     }
 
     return error;

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -485,7 +485,7 @@ bool NetworkData::ContainsService(uint8_t aServiceId, uint16_t aRloc16)
         NetworkDataTlv *subCur;
         NetworkDataTlv *subEnd;
 
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, OT_NO_ACTION);
 
         if (cur->GetType() != NetworkDataTlv::kTypeService)
         {
@@ -503,7 +503,7 @@ bool NetworkData::ContainsService(uint8_t aServiceId, uint16_t aRloc16)
             {
                 ServerTlv *server;
 
-                VerifyOrExit((subCur + 1) <= subEnd && subCur->GetNext() <= subEnd);
+                VerifyOrExit((subCur + 1) <= subEnd && subCur->GetNext() <= subEnd, OT_NO_ACTION);
 
                 if (subCur->GetType() != NetworkDataTlv::kTypeServer)
                 {
@@ -766,7 +766,7 @@ BorderRouterTlv *NetworkData::FindBorderRouter(PrefixTlv &aPrefix)
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, OT_NO_ACTION);
 
         if (cur->GetType() == NetworkDataTlv::kTypeBorderRouter)
         {
@@ -788,7 +788,7 @@ BorderRouterTlv *NetworkData::FindBorderRouter(PrefixTlv &aPrefix, bool aStable)
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, OT_NO_ACTION);
 
         if (cur->GetType() == NetworkDataTlv::kTypeBorderRouter && cur->IsStable() == aStable)
         {
@@ -810,7 +810,7 @@ HasRouteTlv *NetworkData::FindHasRoute(PrefixTlv &aPrefix)
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, OT_NO_ACTION);
 
         if (cur->GetType() == NetworkDataTlv::kTypeHasRoute)
         {
@@ -832,7 +832,7 @@ HasRouteTlv *NetworkData::FindHasRoute(PrefixTlv &aPrefix, bool aStable)
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, OT_NO_ACTION);
 
         if (cur->GetType() == NetworkDataTlv::kTypeHasRoute && cur->IsStable() == aStable)
         {
@@ -854,7 +854,7 @@ ContextTlv *NetworkData::FindContext(PrefixTlv &aPrefix)
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, OT_NO_ACTION);
 
         if (cur->GetType() == NetworkDataTlv::kTypeContext)
         {
@@ -881,7 +881,7 @@ PrefixTlv *NetworkData::FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, OT_NO_ACTION);
 
         if (cur->GetType() == NetworkDataTlv::kTypePrefix)
         {
@@ -952,7 +952,7 @@ ServiceTlv *NetworkData::FindService(uint32_t       aEnterpriseNumber,
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, OT_NO_ACTION);
 
         if (cur->GetType() == NetworkDataTlv::kTypeService)
         {

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -492,7 +492,7 @@ MeshCoP::Tlv *LeaderBase::GetCommissioningDataSubTlv(MeshCoP::Tlv::Type aType)
     MeshCoP::Tlv *  end;
 
     commissioningDataTlv = GetCommissioningData();
-    VerifyOrExit(commissioningDataTlv != NULL);
+    VerifyOrExit(commissioningDataTlv != NULL, OT_NO_ACTION);
 
     cur = reinterpret_cast<MeshCoP::Tlv *>(commissioningDataTlv->GetValue());
     end = reinterpret_cast<MeshCoP::Tlv *>(commissioningDataTlv->GetValue() + commissioningDataTlv->GetLength());
@@ -514,10 +514,10 @@ bool LeaderBase::IsJoiningEnabled(void)
     MeshCoP::Tlv *steeringData;
     bool          rval = false;
 
-    VerifyOrExit(GetCommissioningDataSubTlv(MeshCoP::Tlv::kBorderAgentLocator) != NULL);
+    VerifyOrExit(GetCommissioningDataSubTlv(MeshCoP::Tlv::kBorderAgentLocator) != NULL, OT_NO_ACTION);
 
     steeringData = GetCommissioningDataSubTlv(MeshCoP::Tlv::kSteeringData);
-    VerifyOrExit(steeringData != NULL);
+    VerifyOrExit(steeringData != NULL, OT_NO_ACTION);
 
     for (int i = 0; i < steeringData->GetLength(); i++)
     {

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -154,8 +154,8 @@ void NetworkDiagnostic::HandleDiagnosticGetResponse(Coap::Message &         aMes
                                                     const Ip6::MessageInfo &aMessageInfo,
                                                     otError                 aResult)
 {
-    VerifyOrExit(aResult == OT_ERROR_NONE);
-    VerifyOrExit(aMessage.GetCode() == OT_COAP_CODE_CHANGED);
+    VerifyOrExit(aResult == OT_ERROR_NONE, OT_NO_ACTION);
+    VerifyOrExit(aMessage.GetCode() == OT_COAP_CODE_CHANGED, OT_NO_ACTION);
 
     otLogInfoNetDiag("Received diagnostic get response");
 
@@ -178,7 +178,8 @@ void NetworkDiagnostic::HandleDiagnosticGetAnswer(void *               aContext,
 
 void NetworkDiagnostic::HandleDiagnosticGetAnswer(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST,
+                 OT_NO_ACTION);
 
     otLogInfoNetDiag("Diagnostic get answer received");
 
@@ -657,18 +658,20 @@ void NetworkDiagnostic::HandleDiagnosticReset(Coap::Message &aMessage, const Ip6
 
     otLogInfoNetDiag("Received diagnostic reset request");
 
-    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST,
+                 OT_NO_ACTION);
 
     VerifyOrExit((aMessage.Read(aMessage.GetOffset(), sizeof(NetworkDiagnosticTlv), &networkDiagnosticTlv) ==
-                  sizeof(NetworkDiagnosticTlv)));
+                  sizeof(NetworkDiagnosticTlv)),
+                 OT_NO_ACTION);
 
-    VerifyOrExit(networkDiagnosticTlv.GetType() == NetworkDiagnosticTlv::kTypeList);
+    VerifyOrExit(networkDiagnosticTlv.GetType() == NetworkDiagnosticTlv::kTypeList, OT_NO_ACTION);
 
     offset = aMessage.GetOffset() + sizeof(NetworkDiagnosticTlv);
 
     for (uint8_t i = 0; i < networkDiagnosticTlv.GetLength(); i++)
     {
-        VerifyOrExit(aMessage.Read(offset, sizeof(type), &type) == sizeof(type));
+        VerifyOrExit(aMessage.Read(offset, sizeof(type), &type) == sizeof(type), OT_NO_ACTION);
 
         switch (type)
         {

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -68,11 +68,11 @@ void PanIdQueryServer::HandleQuery(Coap::Message &aMessage, const Ip6::MessageIn
     Ip6::MessageInfo  responseInfo(aMessageInfo);
     uint32_t          mask;
 
-    VerifyOrExit(aMessage.GetCode() == OT_COAP_CODE_POST);
-    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
+    VerifyOrExit(aMessage.GetCode() == OT_COAP_CODE_POST, OT_NO_ACTION);
+    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0, OT_NO_ACTION);
 
     SuccessOrExit(MeshCoP::Tlv::GetTlv(aMessage, MeshCoP::Tlv::kPanId, sizeof(panId), panId));
-    VerifyOrExit(panId.IsValid());
+    VerifyOrExit(panId.IsValid(), OT_NO_ACTION);
 
     mChannelMask  = mask;
     mCommissioner = aMessageInfo.GetPeerAddr();

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -79,7 +79,7 @@ exit:
 
 const Router *RouterTable::GetNextEntry(const Router *aRouter) const
 {
-    VerifyOrExit(aRouter != NULL);
+    VerifyOrExit(aRouter != NULL, OT_NO_ACTION);
     aRouter++;
     VerifyOrExit(aRouter < &mRouters[Mle::kMaxRouters], aRouter = NULL);
     VerifyOrExit(aRouter->GetRloc16() != 0xffff, aRouter = NULL);
@@ -214,7 +214,7 @@ Router *RouterTable::Allocate(void)
         }
     }
 
-    VerifyOrExit(mActiveRouterCount < Mle::kMaxRouters && numAvailable > 0);
+    VerifyOrExit(mActiveRouterCount < Mle::kMaxRouters && numAvailable > 0, OT_NO_ACTION);
 
     // choose available router id at random
     freeBit = Random::NonCrypto::GetUint8InRange(0, numAvailable);
@@ -246,7 +246,8 @@ Router *RouterTable::Allocate(uint8_t aRouterId)
     Router *rval = NULL;
 
     VerifyOrExit(aRouterId <= Mle::kMaxRouterId && mActiveRouterCount < Mle::kMaxRouters && !IsAllocated(aRouterId) &&
-                 mRouterIdReuseDelay[aRouterId] == 0);
+                     mRouterIdReuseDelay[aRouterId] == 0,
+                 OT_NO_ACTION);
 
     mAllocatedRouterIds.Add(aRouterId);
     UpdateAllocation();
@@ -348,7 +349,7 @@ Router *RouterTable::GetNeighbor(uint16_t aRloc16)
 {
     Router *router = NULL;
 
-    VerifyOrExit(aRloc16 != Get<Mle::MleRouter>().GetRloc16());
+    VerifyOrExit(aRloc16 != Get<Mle::MleRouter>().GetRloc16(), OT_NO_ACTION);
 
     for (router = GetFirstEntry(); router != NULL; router = GetNextEntry(router))
     {
@@ -366,7 +367,7 @@ Router *RouterTable::GetNeighbor(const Mac::ExtAddress &aExtAddress)
 {
     Router *router = NULL;
 
-    VerifyOrExit(aExtAddress != Get<Mac::Mac>().GetExtAddress());
+    VerifyOrExit(aExtAddress != Get<Mac::Mac>().GetExtAddress(), OT_NO_ACTION);
 
     for (router = GetFirstEntry(); router != NULL; router = GetNextEntry(router))
     {
@@ -478,7 +479,8 @@ uint8_t RouterTable::GetLinkCost(Router &aRouter)
     uint8_t rval = Mle::kMaxRouteCost;
 
     VerifyOrExit(aRouter.GetRloc16() != Get<Mle::MleRouter>().GetRloc16() &&
-                 aRouter.GetState() == Neighbor::kStateValid);
+                     aRouter.GetState() == Neighbor::kStateValid,
+                 OT_NO_ACTION);
 
     rval = aRouter.GetLinkInfo().GetLinkQuality();
 

--- a/src/core/thread/src_match_controller.cpp
+++ b/src/core/thread/src_match_controller.cpp
@@ -87,7 +87,7 @@ void SourceMatchController::ResetMessageCount(Child &aChild)
 
 void SourceMatchController::SetSrcMatchAsShort(Child &aChild, bool aUseShortAddress)
 {
-    VerifyOrExit(aChild.IsIndirectSourceMatchShort() != aUseShortAddress);
+    VerifyOrExit(aChild.IsIndirectSourceMatchShort() != aUseShortAddress, OT_NO_ACTION);
 
     if (aChild.GetIndirectMessageCount() > 0)
     {

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -114,7 +114,7 @@ ThreadNetif::ThreadNetif(Instance &aInstance)
 
 void ThreadNetif::Up(void)
 {
-    VerifyOrExit(!mIsUp);
+    VerifyOrExit(!mIsUp, OT_NO_ACTION);
 
     // Enable the MAC just in case it was disabled while the Interface was down.
     Get<Mac::Mac>().SetEnabled(true);
@@ -142,7 +142,7 @@ exit:
 
 void ThreadNetif::Down(void)
 {
-    VerifyOrExit(mIsUp);
+    VerifyOrExit(mIsUp, OT_NO_ACTION);
 
 #if OPENTHREAD_ENABLE_DNS_CLIENT
     Get<Dns::Client>().Stop();

--- a/src/core/thread/time_sync_service.cpp
+++ b/src/core/thread/time_sync_service.cpp
@@ -81,7 +81,7 @@ void TimeSync::HandleTimeSyncMessage(const Message &aMessage)
     const int64_t origNetworkTimeOffset = mNetworkTimeOffset;
     int8_t        timeSyncSeqDelta;
 
-    VerifyOrExit(aMessage.GetTimeSyncSeq() != OT_TIME_SYNC_INVALID_SEQ);
+    VerifyOrExit(aMessage.GetTimeSyncSeq() != OT_TIME_SYNC_INVALID_SEQ, OT_NO_ACTION);
 
     timeSyncSeqDelta = static_cast<int8_t>(aMessage.GetTimeSyncSeq() - mTimeSyncSeq);
 
@@ -163,7 +163,7 @@ void TimeSync::ProcessTimeSync(void)
 
     if (mTimeSyncRequired)
     {
-        VerifyOrExit(Get<Mle::MleRouter>().SendTimeSync() == OT_ERROR_NONE);
+        VerifyOrExit(Get<Mle::MleRouter>().SendTimeSync() == OT_ERROR_NONE, OT_NO_ACTION);
 
         mLastTimeSyncSent = TimerMilli::GetNow();
         mTimeSyncRequired = false;

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -122,7 +122,7 @@ otError Child::GetNextIp6Address(Instance &aInstance, Ip6AddressIterator &aItera
     if (aIterator.Get() == 0)
     {
         aIterator.Increment();
-        VerifyOrExit(GetMeshLocalIp6Address(aInstance, aAddress) == OT_ERROR_NOT_FOUND);
+        VerifyOrExit(GetMeshLocalIp6Address(aInstance, aAddress) == OT_ERROR_NOT_FOUND, OT_NO_ACTION);
     }
 
     index = aIterator.Get() - 1;
@@ -187,7 +187,7 @@ otError Child::RemoveIp6Address(Instance &aInstance, const Ip6::Address &aAddres
 
     for (index = 0; index < kNumIp6Addresses; index++)
     {
-        VerifyOrExit(!mIp6Address[index].IsUnspecified());
+        VerifyOrExit(!mIp6Address[index].IsUnspecified(), OT_NO_ACTION);
 
         if (mIp6Address[index] == aAddress)
         {
@@ -213,7 +213,7 @@ bool Child::HasIp6Address(Instance &aInstance, const Ip6::Address &aAddress) con
 {
     bool retval = false;
 
-    VerifyOrExit(!aAddress.IsUnspecified());
+    VerifyOrExit(!aAddress.IsUnspecified(), OT_NO_ACTION);
 
     if (aInstance.Get<Mle::MleRouter>().IsMeshLocalAddress(aAddress))
     {
@@ -223,7 +223,7 @@ bool Child::HasIp6Address(Instance &aInstance, const Ip6::Address &aAddress) con
 
     for (uint16_t index = 0; index < kNumIp6Addresses; index++)
     {
-        VerifyOrExit(!mIp6Address[index].IsUnspecified());
+        VerifyOrExit(!mIp6Address[index].IsUnspecified(), OT_NO_ACTION);
 
         if (mIp6Address[index] == aAddress)
         {

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -102,9 +102,9 @@ void ChannelManager::PreparePendingDataset(void)
     otOperationalDataset dataset;
     otError              error;
 
-    VerifyOrExit(mState == kStateChangeRequested);
+    VerifyOrExit(mState == kStateChangeRequested, OT_NO_ACTION);
 
-    VerifyOrExit(mChannel != Get<Mac::Mac>().GetPanChannel());
+    VerifyOrExit(mChannel != Get<Mac::Mac>().GetPanChannel(), OT_NO_ACTION);
 
     if (Get<MeshCoP::PendingDataset>().Read(dataset) == OT_ERROR_NONE)
     {
@@ -259,8 +259,8 @@ void ChannelManager::HandleStateChanged(Notifier::Callback &aCallback, otChanged
 
 void ChannelManager::HandleStateChanged(otChangedFlags aChangedFlags)
 {
-    VerifyOrExit((aChangedFlags & OT_CHANGED_THREAD_CHANNEL) != 0);
-    VerifyOrExit(mChannel == Get<Mac::Mac>().GetPanChannel());
+    VerifyOrExit((aChangedFlags & OT_CHANGED_THREAD_CHANNEL) != 0, OT_NO_ACTION);
+    VerifyOrExit(mChannel == Get<Mac::Mac>().GetPanChannel(), OT_NO_ACTION);
 
     mState = kStateIdle;
     StartAutoSelectTimer();
@@ -347,7 +347,7 @@ otError ChannelManager::RequestChannelSelect(bool aSkipQualityCheck)
 
     VerifyOrExit(Get<Mle::Mle>().GetRole() != OT_DEVICE_ROLE_DISABLED, error = OT_ERROR_INVALID_STATE);
 
-    VerifyOrExit(aSkipQualityCheck || ShouldAttemptChannelChange());
+    VerifyOrExit(aSkipQualityCheck || ShouldAttemptChannelChange(), OT_NO_ACTION);
 
     SuccessOrExit(error = FindBetterChannel(newChannel, newOccupancy));
 
@@ -398,7 +398,7 @@ otError ChannelManager::RequestChannelSelect(bool)
 
 void ChannelManager::StartAutoSelectTimer(void)
 {
-    VerifyOrExit(mState == kStateIdle);
+    VerifyOrExit(mState == kStateIdle, OT_NO_ACTION);
 
     if (mAutoSelectEnabled)
     {

--- a/src/core/utils/channel_monitor.cpp
+++ b/src/core/utils/channel_monitor.cpp
@@ -105,7 +105,7 @@ uint16_t ChannelMonitor::GetChannelOccupancy(uint8_t aChannel) const
 {
     uint16_t occupancy = 0;
 
-    VerifyOrExit((Phy::kChannelMin <= aChannel) && (aChannel <= Phy::kChannelMax));
+    VerifyOrExit((Phy::kChannelMin <= aChannel) && (aChannel <= Phy::kChannelMax), OT_NO_ACTION);
     occupancy = mChannelOccupancy[aChannel - Phy::kChannelMin];
 
 exit:

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -66,7 +66,7 @@ Child *ChildSupervisor::GetDestination(const Message &aMessage) const
     Child * child = NULL;
     uint8_t childIndex;
 
-    VerifyOrExit(aMessage.GetType() == Message::kTypeSupervision);
+    VerifyOrExit(aMessage.GetType() == Message::kTypeSupervision, OT_NO_ACTION);
 
     aMessage.Read(0, sizeof(childIndex), &childIndex);
     child = Get<ChildTable>().GetChildAtIndex(childIndex);
@@ -80,10 +80,10 @@ void ChildSupervisor::SendMessage(Child &aChild)
     Message *message = NULL;
     uint8_t  childIndex;
 
-    VerifyOrExit(aChild.GetIndirectMessageCount() == 0);
+    VerifyOrExit(aChild.GetIndirectMessageCount() == 0, OT_NO_ACTION);
 
     message = Get<MessagePool>().New(Message::kTypeSupervision, sizeof(uint8_t));
-    VerifyOrExit(message != NULL);
+    VerifyOrExit(message != NULL, OT_NO_ACTION);
 
     // Supervision message is an empty payload 15.4 data frame.
     // The child index is stored here in the message content to allow
@@ -118,7 +118,7 @@ void ChildSupervisor::HandleTimer(Timer &aTimer)
 
 void ChildSupervisor::HandleTimer(void)
 {
-    VerifyOrExit(mSupervisionInterval != 0);
+    VerifyOrExit(mSupervisionInterval != 0, OT_NO_ACTION);
 
     for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValid); !iter.IsDone(); iter++)
     {
@@ -209,7 +209,8 @@ void SupervisionListener::UpdateOnReceive(const Mac::Address &aSourceAddress, bo
     // If listener is enabled and device is a child and it received a secure frame from its parent, restart the timer.
 
     VerifyOrExit(mTimer.IsRunning() && aIsSecure && (Get<Mle::MleRouter>().GetRole() == OT_DEVICE_ROLE_CHILD) &&
-                 (Get<Mle::MleRouter>().GetNeighbor(aSourceAddress) == Get<Mle::MleRouter>().GetParent()));
+                     (Get<Mle::MleRouter>().GetNeighbor(aSourceAddress) == Get<Mle::MleRouter>().GetParent()),
+                 OT_NO_ACTION);
 
     RestartTimer();
 
@@ -238,7 +239,8 @@ void SupervisionListener::HandleTimer(Timer &aTimer)
 void SupervisionListener::HandleTimer(void)
 {
     VerifyOrExit((Get<Mle::MleRouter>().GetRole() == OT_DEVICE_ROLE_CHILD) &&
-                 (Get<MeshForwarder>().GetRxOnWhenIdle() == false));
+                     (Get<MeshForwarder>().GetRxOnWhenIdle() == false),
+                 OT_NO_ACTION);
 
     otLogWarnUtil("Supervision timeout. No frame from parent in %d sec", mTimeout);
 

--- a/src/core/utils/heap.cpp
+++ b/src/core/utils/heap.cpp
@@ -66,7 +66,7 @@ void *Heap::CAlloc(size_t aCount, size_t aSize)
     Block *  curr = NULL;
     uint16_t size = static_cast<uint16_t>(aCount * aSize);
 
-    VerifyOrExit(size);
+    VerifyOrExit(size, OT_NO_ACTION);
 
     size += kAlignSize - 1 - kBlockRemainderSize;
     size &= ~(kAlignSize - 1);
@@ -81,7 +81,7 @@ void *Heap::CAlloc(size_t aCount, size_t aSize)
         curr = &BlockNext(*curr);
     }
 
-    VerifyOrExit(curr->IsFree());
+    VerifyOrExit(curr->IsFree(), OT_NO_ACTION);
 
     prev->SetNext(curr->GetNext());
 

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -101,18 +101,18 @@ exit:
 
 void JamDetector::CheckState(void)
 {
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NO_ACTION);
 
     switch (Get<Mle::MleRouter>().GetRole())
     {
     case OT_DEVICE_ROLE_DISABLED:
-        VerifyOrExit(mTimer.IsRunning());
+        VerifyOrExit(mTimer.IsRunning(), OT_NO_ACTION);
         mTimer.Stop();
         SetJamState(false);
         break;
 
     default:
-        VerifyOrExit(!mTimer.IsRunning());
+        VerifyOrExit(!mTimer.IsRunning(), OT_NO_ACTION);
         mCurSecondStartTime   = TimerMilli::GetNow();
         mAlwaysAboveThreshold = true;
         mHistoryBitmap        = 0;
@@ -170,7 +170,7 @@ void JamDetector::HandleTimer(void)
     int8_t rssi;
     bool   didExceedThreshold = true;
 
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NO_ACTION);
 
     rssi = otPlatRadioGetRssi(&GetInstance());
 

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -60,7 +60,7 @@ Slaac::Slaac(Instance &aInstance)
 
 void Slaac::Enable(void)
 {
-    VerifyOrExit(!mEnabled);
+    VerifyOrExit(!mEnabled, OT_NO_ACTION);
 
     otLogInfoUtil("SLAAC:: Enabling");
     mEnabled = true;
@@ -72,7 +72,7 @@ exit:
 
 void Slaac::Disable(void)
 {
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NO_ACTION);
 
     otLogInfoUtil("SLAAC:: Disabling");
     mEnabled = false;
@@ -84,12 +84,12 @@ exit:
 
 void Slaac::SetFilter(otIp6SlaacPrefixFilter aFilter)
 {
-    VerifyOrExit(aFilter != mFilter);
+    VerifyOrExit(aFilter != mFilter, OT_NO_ACTION);
 
     mFilter = aFilter;
     otLogInfoUtil("SLAAC: Filter %s", (mFilter != NULL) ? "updated" : "disabled");
 
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NO_ACTION);
     Update(kModeAdd | kModeRemove);
 
 exit:
@@ -110,7 +110,7 @@ void Slaac::HandleStateChanged(otChangedFlags aFlags)
 {
     UpdateMode mode = kModeNone;
 
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NO_ACTION);
 
     if (aFlags & OT_CHANGED_THREAD_NETDATA)
     {
@@ -296,7 +296,7 @@ void Slaac::GenerateIid(Ip6::NetifUnicastAddress &aAddress) const
         // Exit and return the address if the IID is not reserved,
         // otherwise, try again with a new dadCounter
 
-        VerifyOrExit(aAddress.GetAddress().IsIidReserved());
+        VerifyOrExit(aAddress.GetAddress().IsIidReserved(), OT_NO_ACTION);
     }
 
     otLogWarnUtil("SLAAC: Failed to generate a non-reserved IID after %d attempts", dadCounter);
@@ -312,7 +312,7 @@ void Slaac::GetIidSecretKey(IidSecretKey &aKey) const
     otError error;
 
     error = Get<Settings>().ReadSlaacIidSecretKey(aKey);
-    VerifyOrExit(error != OT_ERROR_NONE);
+    VerifyOrExit(error != OT_ERROR_NONE, OT_NO_ACTION);
 
     // If there is no previously saved secret key, generate
     // a random one and save it.

--- a/src/diag/diag_process.cpp
+++ b/src/diag/diag_process.cpp
@@ -336,7 +336,7 @@ exit:
 
 void Diag::DiagTransmitDone(otInstance *aInstance, otError aError)
 {
-    VerifyOrExit(aInstance == sInstance);
+    VerifyOrExit(aInstance == sInstance, OT_NO_ACTION);
 
     if (aError == OT_ERROR_NONE)
     {
@@ -359,7 +359,7 @@ exit:
 
 void Diag::DiagReceiveDone(otInstance *aInstance, otRadioFrame *aFrame, otError aError)
 {
-    VerifyOrExit(aInstance == sInstance);
+    VerifyOrExit(aInstance == sInstance, OT_NO_ACTION);
 
     if (aError == OT_ERROR_NONE)
     {
@@ -380,7 +380,7 @@ exit:
 
 void Diag::AlarmFired(otInstance *aInstance)
 {
-    VerifyOrExit(aInstance == sInstance);
+    VerifyOrExit(aInstance == sInstance, OT_NO_ACTION);
 
     if (sRepeatActive)
     {

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -327,7 +327,7 @@ void NcpBase::HandleReceive(const uint8_t *aBuf, uint16_t aBufLength)
     // Skip if there is no header byte to read or this isn't a spinel frame.
 
     SuccessOrExit(mDecoder.ReadUint8(header));
-    VerifyOrExit((SPINEL_HEADER_FLAG & header) == SPINEL_HEADER_FLAG);
+    VerifyOrExit((SPINEL_HEADER_FLAG & header) == SPINEL_HEADER_FLAG, OT_NO_ACTION);
 
     mRxSpinelFrameCounter++;
 
@@ -604,8 +604,8 @@ void NcpBase::Log(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aLog
     otError error  = OT_ERROR_NONE;
     uint8_t header = SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0;
 
-    VerifyOrExit(!mDisableStreamWrite);
-    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(SPINEL_PROP_STREAM_LOG));
+    VerifyOrExit(!mDisableStreamWrite, OT_NO_ACTION);
+    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(SPINEL_PROP_STREAM_LOG), OT_NO_ACTION);
 
     // If there is a pending queued response we do not allow any new log
     // stream writes. This is to ensure that log messages can not continue
@@ -792,7 +792,7 @@ void NcpBase::UpdateChangedProps(void)
     ProcessThreadChangedFlags();
 #endif
 
-    VerifyOrExit(!mChangedPropsSet.IsEmpty());
+    VerifyOrExit(!mChangedPropsSet.IsEmpty(), OT_NO_ACTION);
 
     entry = mChangedPropsSet.GetSupportedEntries(numEntries);
 
@@ -822,7 +822,7 @@ void NcpBase::UpdateChangedProps(void)
         }
 
         mChangedPropsSet.RemoveEntry(index);
-        VerifyOrExit(!mChangedPropsSet.IsEmpty());
+        VerifyOrExit(!mChangedPropsSet.IsEmpty(), OT_NO_ACTION);
     }
 
 exit:
@@ -959,7 +959,7 @@ otError NcpBase::HandleCommandPropertySet(uint8_t aHeader, spinel_prop_key_t aKe
 
         bool didHandle = HandlePropertySetForSpecialProperties(aHeader, aKey, error);
 
-        VerifyOrExit(!didHandle);
+        VerifyOrExit(!didHandle, OT_NO_ACTION);
 
 #if OPENTHREAD_ENABLE_NCP_VENDOR_HOOK
         if (aKey >= SPINEL_PROP_VENDOR__BEGIN && aKey < SPINEL_PROP_VENDOR__END)

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -86,7 +86,7 @@ exit:
 
 void NcpBase::HandleParentResponseInfo(otThreadParentResponseInfo *aInfo, void *aContext)
 {
-    VerifyOrExit(aInfo && aContext);
+    VerifyOrExit(aInfo && aContext, OT_NO_ACTION);
 
     static_cast<NcpBase *>(aContext)->HandleParentResponseInfo(*aInfo);
 
@@ -96,7 +96,7 @@ exit:
 
 void NcpBase::HandleParentResponseInfo(const otThreadParentResponseInfo &aInfo)
 {
-    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(SPINEL_PROP_PARENT_RESPONSE_INFO));
+    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(SPINEL_PROP_PARENT_RESPONSE_INFO), OT_NO_ACTION);
 
     SuccessOrExit(mEncoder.BeginFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_CMD_PROP_VALUE_IS,
                                       SPINEL_PROP_PARENT_RESPONSE_INFO));
@@ -134,7 +134,7 @@ void NcpBase::HandleNeighborTableChanged(otNeighborTableEvent aEvent, const otNe
         // Fall through
     case OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED:
         property = SPINEL_PROP_THREAD_CHILD_TABLE;
-        VerifyOrExit(!aEntry.mInfo.mChild.mIsStateRestoring);
+        VerifyOrExit(!aEntry.mInfo.mChild.mIsStateRestoring, OT_NO_ACTION);
         break;
 
     case OT_NEIGHBOR_TABLE_EVENT_ROUTER_ADDED:
@@ -148,7 +148,7 @@ void NcpBase::HandleNeighborTableChanged(otNeighborTableEvent aEvent, const otNe
         ExitNow();
     }
 
-    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(property));
+    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(property), OT_NO_ACTION);
 
     SuccessOrExit(error = mEncoder.BeginFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, command, property));
 

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -1559,7 +1559,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_IPV6_ML_PREFIX>(void)
     const otMeshLocalPrefix *mlPrefix = otThreadGetMeshLocalPrefix(mInstance);
     otIp6Address             addr;
 
-    VerifyOrExit(mlPrefix != NULL); // If `mlPrefix` is NULL send empty response.
+    VerifyOrExit(mlPrefix != NULL, OT_NO_ACTION); // If `mlPrefix` is NULL send empty response.
 
     memcpy(addr.mFields.m8, mlPrefix->m8, 8);
 
@@ -1594,7 +1594,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_IPV6_ML_ADDR>(void)
     otError             error = OT_ERROR_NONE;
     const otIp6Address *ml64  = otThreadGetMeshLocalEid(mInstance);
 
-    VerifyOrExit(ml64 != NULL);
+    VerifyOrExit(ml64 != NULL, OT_NO_ACTION);
     SuccessOrExit(error = mEncoder.WriteIp6Address(*ml64));
 
 exit:
@@ -1606,7 +1606,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_IPV6_LL_ADDR>(void)
     otError             error   = OT_ERROR_NONE;
     const otIp6Address *address = otThreadGetLinkLocalIp6Address(mInstance);
 
-    VerifyOrExit(address != NULL);
+    VerifyOrExit(address != NULL, OT_NO_ACTION);
     SuccessOrExit(error = mEncoder.WriteIp6Address(*address));
 
 exit:
@@ -3083,7 +3083,7 @@ void NcpBase::RegisterLegacyHandlers(const otNcpLegacyHandlers *aHandlers)
     mLegacyHandlers = aHandlers;
     bool isEnabled;
 
-    VerifyOrExit(mLegacyHandlers != NULL);
+    VerifyOrExit(mLegacyHandlers != NULL, OT_NO_ACTION);
 
     isEnabled = (otThreadGetDeviceRole(mInstance) != OT_DEVICE_ROLE_DISABLED);
 
@@ -3358,7 +3358,7 @@ void NcpBase::HandleDatagramFromStack(otMessage *aMessage, void *aContext)
 
 void NcpBase::HandleDatagramFromStack(otMessage *aMessage)
 {
-    VerifyOrExit(aMessage != NULL);
+    VerifyOrExit(aMessage != NULL, OT_NO_ACTION);
 
     SuccessOrExit(otMessageQueueEnqueue(&mMessageQueue, aMessage));
 
@@ -3525,7 +3525,7 @@ void NcpBase::HandlePcapFrame(const otRadioFrame *aFrame, bool aIsTx)
     uint16_t flags  = 0;
     uint8_t  header = SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0;
 
-    VerifyOrExit(mPcapEnabled);
+    VerifyOrExit(mPcapEnabled, OT_NO_ACTION);
 
     if (aIsTx)
     {
@@ -3567,7 +3567,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_PHY_PCAP_ENABLED>(voi
     bool    enabled;
 
     SuccessOrExit(error = mDecoder.ReadBool(enabled));
-    VerifyOrExit(enabled != mPcapEnabled);
+    VerifyOrExit(enabled != mPcapEnabled, OT_NO_ACTION);
 
     mPcapEnabled = enabled;
 
@@ -3625,7 +3625,7 @@ void NcpBase::ProcessThreadChangedFlags(void)
         {OT_CHANGED_SUPPORTED_CHANNEL_MASK, SPINEL_PROP_PHY_CHAN_SUPPORTED},
     };
 
-    VerifyOrExit(mThreadChangedFlags != 0);
+    VerifyOrExit(mThreadChangedFlags != 0, OT_NO_ACTION);
 
     // If thread role has changed, check for possible "join" error.
 
@@ -3696,7 +3696,7 @@ void NcpBase::ProcessThreadChangedFlags(void)
             }
 
             mThreadChangedFlags &= ~threadFlag;
-            VerifyOrExit(mThreadChangedFlags != 0);
+            VerifyOrExit(mThreadChangedFlags != 0, OT_NO_ACTION);
         }
     }
 

--- a/src/ncp/ncp_buffer.cpp
+++ b/src/ncp/ncp_buffer.cpp
@@ -253,7 +253,7 @@ otError NcpFrameBuffer::InFrameBeginSegment(void)
     uint16_t headerFlags = kSegmentHeaderNoFlag;
 
     // Verify that segment is not yet started (i.e., head and tail are the same).
-    VerifyOrExit(mWriteSegmentHead == mWriteSegmentTail);
+    VerifyOrExit(mWriteSegmentHead == mWriteSegmentTail, OT_NO_ACTION);
 
     // Check if this is the start of a new frame (i.e., frame start is same as segment head).
     if (mWriteFrameStart[mWriteDirection] == mWriteSegmentHead)
@@ -310,7 +310,7 @@ void NcpFrameBuffer::InFrameDiscard(void)
     otMessage *message;
 #endif
 
-    VerifyOrExit(mWriteDirection != kUnknown);
+    VerifyOrExit(mWriteDirection != kUnknown, OT_NO_ACTION);
 
     // Move the write segment head and tail pointers back to frame start.
     mWriteSegmentHead = mWriteSegmentTail = mWriteFrameStart[mWriteDirection];
@@ -469,12 +469,12 @@ uint16_t NcpFrameBuffer::InFrameGetDistance(const WritePosition &aPosition) cons
     uint16_t segmentLength;
     uint16_t offset;
 
-    VerifyOrExit(mWriteDirection != kUnknown);
-    VerifyOrExit(aPosition.mSegmentHead == mWriteSegmentHead);
+    VerifyOrExit(mWriteDirection != kUnknown, OT_NO_ACTION);
+    VerifyOrExit(aPosition.mSegmentHead == mWriteSegmentHead, OT_NO_ACTION);
 
     segmentLength = GetDistance(mWriteSegmentHead, mWriteSegmentTail, mWriteDirection);
     offset        = GetDistance(mWriteSegmentHead, aPosition.mPosition, mWriteDirection);
-    VerifyOrExit(offset < segmentLength);
+    VerifyOrExit(offset < segmentLength, OT_NO_ACTION);
 
     distance = GetDistance(aPosition.mPosition, mWriteSegmentTail, mWriteDirection);
 

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -144,8 +144,9 @@ bool NcpSpi::SpiTransactionComplete(uint8_t *aOutputBuf,
     SpiFrame inputFrame(aInputBuf);
     SpiFrame sendFrame(mSendFrame);
 
-    VerifyOrExit((aTransLen >= kSpiHeaderSize) && (aInputLen >= kSpiHeaderSize) && (aOutputLen >= kSpiHeaderSize));
-    VerifyOrExit(inputFrame.IsValid() && outputFrame.IsValid());
+    VerifyOrExit((aTransLen >= kSpiHeaderSize) && (aInputLen >= kSpiHeaderSize) && (aOutputLen >= kSpiHeaderSize),
+                 OT_NO_ACTION);
+    VerifyOrExit(inputFrame.IsValid() && outputFrame.IsValid(), OT_NO_ACTION);
 
     transDataLen = aTransLen - kSpiHeaderSize;
 
@@ -259,7 +260,7 @@ void NcpSpi::PrepareNextSpiSendFrame(void)
     uint16_t readLength;
     SpiFrame sendFrame(mSendFrame);
 
-    VerifyOrExit(!mTxFrameBuffer.IsEmpty());
+    VerifyOrExit(!mTxFrameBuffer.IsEmpty(), OT_NO_ACTION);
 
     if (ShouldWakeHost())
     {

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -150,7 +150,7 @@ void NcpUart::EncodeAndSendToUart(void)
                 otPlatWakeHost();
             }
 
-            VerifyOrExit(super_t::ShouldDeferHostSend() == false);
+            VerifyOrExit(super_t::ShouldDeferHostSend() == false, OT_NO_ACTION);
             SuccessOrExit(mFrameEncoder.BeginFrame());
 
             txFrameBuffer.OutFrameBegin();

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -169,7 +169,7 @@ HdlcInterface::~HdlcInterface(void)
 
 void HdlcInterface::Deinit(void)
 {
-    VerifyOrExit(mSockFd != -1);
+    VerifyOrExit(mSockFd != -1, OT_NO_ACTION);
 
     VerifyOrExit(0 == close(mSockFd), perror("close RCP"));
     VerifyOrExit(-1 != wait(NULL) || errno == ECHILD, perror("wait RCP"));
@@ -335,14 +335,14 @@ int HdlcInterface::OpenFile(const char *aFile, const char *aConfig)
         int  cstopb = 1;
         char parity = 'N';
 
-        VerifyOrExit((rval = tcgetattr(fd, &tios)) == 0);
+        VerifyOrExit((rval = tcgetattr(fd, &tios)) == 0, OT_NO_ACTION);
 
         cfmakeraw(&tios);
 
         tios.c_cflag = CS8 | HUPCL | CREAD | CLOCAL;
 
         // example: 115200N1
-        sscanf(aConfig, "%u%c%d", &speed, &parity, &cstopb);
+        sscanf(aConfig, "%d%c%d", &speed, &parity, &cstopb);
 
         switch (parity)
         {
@@ -465,7 +465,7 @@ int HdlcInterface::OpenFile(const char *aFile, const char *aConfig)
 
         VerifyOrExit((rval = cfsetspeed(&tios, static_cast<speed_t>(speed))) == 0, perror("cfsetspeed"));
         VerifyOrExit((rval = tcsetattr(fd, TCSANOW, &tios)) == 0, perror("tcsetattr"));
-        VerifyOrExit((rval = tcflush(fd, TCIOFLUSH)) == 0);
+        VerifyOrExit((rval = tcflush(fd, TCIOFLUSH)) == 0, OT_NO_ACTION);
     }
 
 exit:

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -406,7 +406,7 @@ void RadioSpinel::HandleNotification(const uint8_t *aFrame, uint16_t aLength)
     unpacked = spinel_datatype_unpack(aFrame, aLength, "CiiD", &header, &cmd, &key, &data, &len);
     VerifyOrExit(unpacked > 0, error = OT_ERROR_PARSE);
     VerifyOrExit(SPINEL_HEADER_GET_TID(header) == 0, error = OT_ERROR_PARSE);
-    VerifyOrExit(cmd == SPINEL_CMD_PROP_VALUE_IS);
+    VerifyOrExit(cmd == SPINEL_CMD_PROP_VALUE_IS, OT_NO_ACTION);
     HandleValueIs(key, data, static_cast<uint16_t>(len));
 
 exit:
@@ -471,7 +471,7 @@ void RadioSpinel::HandleWaitingResponse(uint32_t          aCommand,
     {
         spinel_ssize_t unpacked;
 
-        VerifyOrExit(mDiagOutput != NULL);
+        VerifyOrExit(mDiagOutput != NULL, OT_NO_ACTION);
         unpacked =
             spinel_datatype_unpack_in_place(aBuffer, aLength, SPINEL_DATATYPE_UTF8_S, mDiagOutput, &mDiagOutputMaxLen);
         VerifyOrExit(unpacked > 0, mError = OT_ERROR_PARSE);
@@ -807,7 +807,7 @@ otError RadioSpinel::SetShortAddress(uint16_t aAddress)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mShortAddress != aAddress);
+    VerifyOrExit(mShortAddress != aAddress, OT_NO_ACTION);
     SuccessOrExit(error = sRadioSpinel.Set(SPINEL_PROP_MAC_15_4_SADDR, SPINEL_DATATYPE_UINT16_S, aAddress));
     mShortAddress = aAddress;
 
@@ -835,7 +835,7 @@ otError RadioSpinel::SetPanId(uint16_t aPanId)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mPanId != aPanId);
+    VerifyOrExit(mPanId != aPanId, OT_NO_ACTION);
     SuccessOrExit(error = Set(SPINEL_PROP_MAC_15_4_PANID, SPINEL_DATATYPE_UINT16_S, aPanId));
     mPanId = aPanId;
 
@@ -1195,7 +1195,7 @@ otError RadioSpinel::RequestV(bool aWait, uint32_t command, spinel_prop_key_t aK
     VerifyOrExit(!aWait || tid > 0, error = OT_ERROR_BUSY);
 
     error = SendCommand(command, aKey, tid, aFormat, aArgs);
-    VerifyOrExit(error == OT_ERROR_NONE);
+    VerifyOrExit(error == OT_ERROR_NONE, OT_NO_ACTION);
 
     if (aKey == SPINEL_PROP_STREAM_RAW)
     {
@@ -1276,7 +1276,7 @@ otError RadioSpinel::Transmit(otRadioFrame &aFrame)
 {
     otError error = OT_ERROR_INVALID_STATE;
 
-    VerifyOrExit(mState == kStateReceive);
+    VerifyOrExit(mState == kStateReceive, OT_NO_ACTION);
     mState         = kStateTransmitPending;
     error          = OT_ERROR_NONE;
     mTransmitFrame = &aFrame;
@@ -1294,14 +1294,14 @@ otError RadioSpinel::Receive(uint8_t aChannel)
     if (mChannel != aChannel)
     {
         error = Set(SPINEL_PROP_PHY_CHAN, SPINEL_DATATYPE_UINT8_S, aChannel);
-        VerifyOrExit(error == OT_ERROR_NONE);
+        VerifyOrExit(error == OT_ERROR_NONE, OT_NO_ACTION);
         mChannel = aChannel;
     }
 
     if (mState == kStateSleep)
     {
         error = Set(SPINEL_PROP_MAC_RAW_STREAM_ENABLED, SPINEL_DATATYPE_BOOL_S, true);
-        VerifyOrExit(error == OT_ERROR_NONE);
+        VerifyOrExit(error == OT_ERROR_NONE, OT_NO_ACTION);
     }
 
     if (mTxRadioTid != 0)
@@ -1325,7 +1325,7 @@ otError RadioSpinel::Sleep(void)
     {
     case kStateReceive:
         error = sRadioSpinel.Set(SPINEL_PROP_MAC_RAW_STREAM_ENABLED, SPINEL_DATATYPE_BOOL_S, false);
-        VerifyOrExit(error == OT_ERROR_NONE);
+        VerifyOrExit(error == OT_ERROR_NONE, OT_NO_ACTION);
 
         mState = kStateSleep;
         break;
@@ -1346,7 +1346,7 @@ otError RadioSpinel::Enable(otInstance *aInstance)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(!IsEnabled());
+    VerifyOrExit(!IsEnabled(), OT_NO_ACTION);
 
     mInstance = aInstance;
 
@@ -1371,7 +1371,7 @@ otError RadioSpinel::Disable(void)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(IsEnabled());
+    VerifyOrExit(IsEnabled(), OT_NO_ACTION);
     VerifyOrExit(mState == kStateSleep, error = OT_ERROR_INVALID_STATE);
 
     SuccessOrDie(sRadioSpinel.Set(SPINEL_PROP_PHY_ENABLED, SPINEL_DATATYPE_BOOL_S, false));

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -360,7 +360,7 @@ exit:
 
 void platformUdpUpdateFdSet(otInstance *aInstance, fd_set *aReadFdSet, int *aMaxFd)
 {
-    VerifyOrExit(sPlatNetifIndex != 0);
+    VerifyOrExit(sPlatNetifIndex != 0, OT_NO_ACTION);
 
     for (otUdpSocket *socket = otUdpGetSockets(aInstance); socket != NULL; socket = socket->mNext)
     {
@@ -403,7 +403,7 @@ void platformUdpProcess(otInstance *aInstance, const fd_set *aReadFdSet)
 {
     otMessageSettings msgSettings = {false, OT_MESSAGE_PRIORITY_NORMAL};
 
-    VerifyOrExit(sPlatNetifIndex != 0);
+    VerifyOrExit(sPlatNetifIndex != 0, OT_NO_ACTION);
 
     for (otUdpSocket *socket = otUdpGetSockets(aInstance); socket != NULL; socket = socket->mNext)
     {


### PR DESCRIPTION
This PR makes the following changes:
- Update `-std` to `c++11`.
- Add `-pedantic-errors` to avoid use of gcc extensions.
- Update STYLE_GUIDE.md.
- Remove use of zero-length args for variadic macro (a gcc extension).

Resolves #3880.