### PR TITLE
[ncp] spinel prop to get a new dataset (use when forming new network)

### DIFF
--- a/src/ncp/ncp_base_dispatcher.cpp
+++ b/src/ncp/ncp_base_dispatcher.cpp
@@ -581,6 +581,9 @@ NcpBase::PropertyHandler NcpBase::FindGetPropertyHandler(spinel_prop_key_t aKey)
     case SPINEL_PROP_THREAD_ADDRESS_CACHE_TABLE:
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_ADDRESS_CACHE_TABLE>;
         break;
+    case SPINEL_PROP_THREAD_NEW_DATASET:
+        handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_NEW_DATASET>;
+        break;
 #if OPENTHREAD_ENABLE_JOINER
     case SPINEL_PROP_MESHCOP_JOINER_STATE:
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_MESHCOP_JOINER_STATE>;

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -40,6 +40,7 @@
 #include <openthread/child_supervision.h>
 #endif
 #include <openthread/dataset.h>
+#include <openthread/dataset_ftd.h>
 #include <openthread/diag.h>
 #include <openthread/icmp6.h>
 #include <openthread/ncp.h>
@@ -435,6 +436,25 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_NETWORK_ID_TIM
     otThreadSetNetworkIdTimeout(mInstance, timeout);
 
 exit:
+    return error;
+}
+
+template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_NEW_DATASET>(void)
+{
+    otError              error;
+    otOperationalDataset dataset;
+
+    error = otDatasetCreateNewNetwork(mInstance, &dataset);
+
+    if (error == OT_ERROR_NONE)
+    {
+        error = EncodeOperationalDataset(dataset);
+    }
+    else
+    {
+        error = mEncoder.OverwriteWithLastStatusError(ThreadErrorToSpinelStatus(error));
+    }
+
     return error;
 }
 

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1689,6 +1689,10 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "DATASET_DEST_ADDRESS";
         break;
 
+    case SPINEL_PROP_THREAD_NEW_DATASET:
+        ret = "THREAD_NEW_DATASET";
+        break;
+
     case SPINEL_PROP_MESHCOP_JOINER_STATE:
         ret = "MESHCOP_JOINER_STATE";
         break;

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -2383,6 +2383,34 @@ typedef enum
      */
     SPINEL_PROP_DATASET_DEST_ADDRESS = SPINEL_PROP_THREAD_EXT__BEGIN + 39,
 
+    /// Thread New Operational Dataset
+    /** Format: `A(t(iD))` - Read only - FTD build only
+     *
+     * This property allows host to request NCP to create and return a new Operation Dataset to use when forming a new
+     * network.
+     *
+     * Operational Dataset consists of a set of supported properties (e.g., channel, master key, network name, PAN id,
+     * etc). Note that not all supported properties may be present (have a value) in a Dataset.
+     *
+     * The Dataset value is encoded as an array of structs containing pairs of property key (as `i`) followed by the
+     * property value (as `D`). The property value must follow the format associated with the corresponding property.
+     *
+     * The following properties can be included in a Dataset list:
+     *
+     *   SPINEL_PROP_DATASET_ACTIVE_TIMESTAMP
+     *   SPINEL_PROP_PHY_CHAN
+     *   SPINEL_PROP_PHY_CHAN_SUPPORTED (Channel Mask Page 0)
+     *   SPINEL_PROP_NET_MASTER_KEY
+     *   SPINEL_PROP_NET_NETWORK_NAME
+     *   SPINEL_PROP_NET_XPANID
+     *   SPINEL_PROP_MAC_15_4_PANID
+     *   SPINEL_PROP_IPV6_ML_PREFIX
+     *   SPINEL_PROP_NET_PSKC
+     *   SPINEL_PROP_DATASET_SECURITY_POLICY
+     *
+     */
+    SPINEL_PROP_THREAD_NEW_DATASET = SPINEL_PROP_THREAD_EXT__BEGIN + 40,
+
     SPINEL_PROP_THREAD_EXT__END = 0x1600,
 
     SPINEL_PROP_IPV6__BEGIN = 0x60,


### PR DESCRIPTION
This commit adds a new property `SPINEL_PROP_THREAD_NEW_DATASET` in
spinel to create a new Operational Dataset to use when forming a new
network. This property maps to `otDatasetCreateNewNetwork()`