### PR TITLE
[message] add callback handler to indicate final status of msg tx

### DIFF
--- a/include/openthread/error.h
+++ b/include/openthread/error.h
@@ -350,6 +350,14 @@ typedef enum otError
     OT_ERROR_LINK_MARGIN_LOW = 34,
 
     /**
+     * Message was evicted.
+     *
+     * This error indicates that message was dropped to make memory/buffer available for a higher priority message.
+     *
+     */
+    OT_ERROR_EVICTED = 35,
+
+    /**
      * The number of defined errors.
      */
     OT_NUM_ERRORS,

--- a/include/openthread/message.h
+++ b/include/openthread/message.h
@@ -110,6 +110,19 @@ typedef struct otMessageSettings
 } otMessageSettings;
 
 /**
+ * This type defines the callback for a message.
+ *
+ * The callback is invoked to indicate the status of an outbound message, whether it is sent successfully, dropped, or
+ * any failures during transmission over the air (e.g. no ACK is received or CSMA-CA failure).
+ *
+ * @param[in] aInstance  A pointer to the OpenThread instance.
+ * @param[in] aMessage   A pointer to the message.
+ * @param[in] aError     The error related to message transmission.
+ *
+ */
+typedef void (*otMessageCallback)(otInstance *aInstance, const otMessage *aMessage, otError aError);
+
+/**
  * Free an allocated message buffer.
  *
  * @param[in]  aMessage  A pointer to a message buffer.
@@ -294,6 +307,18 @@ uint16_t otMessageRead(const otMessage *aMessage, uint16_t aOffset, void *aBuf, 
  *
  */
 int otMessageWrite(otMessage *aMessage, uint16_t aOffset, const void *aBuf, uint16_t aLength);
+
+/**
+ * This function registers a callback on message. The callback is invoked to indicate the final status of message
+ * transmission.
+ *
+ * A subsequent call to this function will overwrite the previous callback handler.
+ *
+ * @param[in] aMessage   A pointer to a message buffer.
+ * @param[in] aCallback  A callback handler (can be NULL).
+ *
+ */
+void otMessageRegisterCallback(otMessage *aMessage, otMessageCallback aCallback);
 
 /**
  * This structure represents an OpenThread message queue.

--- a/src/core/api/message_api.cpp
+++ b/src/core/api/message_api.cpp
@@ -113,6 +113,12 @@ int otMessageWrite(otMessage *aMessage, uint16_t aOffset, const void *aBuf, uint
     return message.Write(aOffset, aLength, aBuf);
 }
 
+void otMessageRegisterCallback(otMessage *aMessage, otMessageCallback aCallback)
+{
+    Message &message = *static_cast<Message *>(aMessage);
+    message.RegisterCallback(aCallback);
+}
+
 void otMessageQueueInit(otMessageQueue *aQueue)
 {
     aQueue->mData = NULL;

--- a/src/core/common/logging.cpp
+++ b/src/core/common/logging.cpp
@@ -302,6 +302,10 @@ const char *otThreadErrorToString(otError aError)
         retval = "LinkMarginLow";
         break;
 
+    case OT_ERROR_EVICTED:
+        retval = "Evicted";
+        break;
+
     default:
         retval = "UnknownErrorType";
         break;

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -691,6 +691,14 @@ exit:
     return rval;
 }
 
+void Message::InvokeCallback(otError aError)
+{
+    if (mBuffer.mHead.mInfo.mCallback != NULL)
+    {
+        mBuffer.mHead.mInfo.mCallback(&GetMessagePool()->GetInstance(), this, aError);
+    }
+}
+
 uint16_t Message::UpdateChecksum(uint16_t aChecksum, uint16_t aValue)
 {
     uint16_t result = aChecksum + aValue;

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -158,7 +158,8 @@ void MeshForwarder::RemoveMessage(Message &aMessage)
     }
 
     mSendQueue.Dequeue(aMessage);
-    LogMessage(kMessageEvict, aMessage, NULL, OT_ERROR_NO_BUFS);
+    aMessage.InvokeCallback(OT_ERROR_EVICTED);
+    LogMessage(kMessageEvict, aMessage, NULL, OT_ERROR_EVICTED);
     aMessage.Free();
 }
 
@@ -285,6 +286,7 @@ Message *MeshForwarder::GetDirectTransmission(void)
 
         default:
             mSendQueue.Dequeue(*curMessage);
+            curMessage->InvokeCallback(error);
             LogMessage(kMessageDrop, *curMessage, NULL, error);
             curMessage->Free();
             continue;
@@ -1103,6 +1105,7 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, otError aError)
             }
 #endif
 
+            mSendMessage->InvokeCallback(txError);
             LogMessage(kMessageTransmit, *mSendMessage, &macDest, txError);
 
             if (mSendMessage->GetType() == Message::kTypeIp6)

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -176,6 +176,7 @@ void MeshForwarder::HandleResolved(const Ip6::Address &aEid, otError aError)
             }
             else
             {
+                cur->InvokeCallback(aError);
                 LogMessage(kMessageDrop, *cur, NULL, aError);
                 cur->Free();
             }
@@ -378,6 +379,7 @@ void MeshForwarder::RemoveDataResponseMessages(void)
         }
 
         mSendQueue.Dequeue(*message);
+        message->InvokeCallback(OT_ERROR_DROP);
         LogMessage(kMessageDrop, *message, NULL, OT_ERROR_NONE);
         message->Free();
     }
@@ -722,6 +724,7 @@ void MeshForwarder::HandleSentFrameToChild(const Mac::Frame &aFrame, otError aEr
 
         if (!mSendMessage->GetDirectTransmission())
         {
+            mSendMessage->InvokeCallback(txError);
             LogMessage(kMessageTransmit, *mSendMessage, &aMacDest, txError);
 
             if (mSendMessage->GetType() == Message::kTypeIp6)


### PR DESCRIPTION
This commit allows an optional callback handler to be registered with
a `Message` to indicate the status of an outbound message
transmission, whether the message was sent successfully, dropped,
evicted, or any failures during transmission over the air (e.g.,
no-ack or CSMA-CA failure). This commit also adds `OT_ERROR_EVICTED`
to `otError` enumeration to indicate when a message was evicted.