### PR TITLE
[mac] inline shorter methods / rename frame preparing methods

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -717,18 +717,19 @@ void Mac::GenerateNonce(const ExtAddress &aAddress, uint32_t aFrameCounter, uint
     aNonce[0] = aSecurityLevel;
 }
 
-void Mac::SendBeaconRequest(Frame &aFrame)
+void Mac::PrepareBeaconRequest(Frame &aFrame)
 {
-    // initialize MAC header
     uint16_t fcf = Frame::kFcfFrameMacCmd | Frame::kFcfDstAddrShort | Frame::kFcfSrcAddrNone;
+
     aFrame.InitMacHeader(fcf, Frame::kSecNone);
     aFrame.SetDstPanId(kShortAddrBroadcast);
     aFrame.SetDstAddr(kShortAddrBroadcast);
     aFrame.SetCommandId(Frame::kMacCmdBeaconRequest);
+
     otLogInfoMac("Sending Beacon Request");
 }
 
-void Mac::SendBeacon(Frame &aFrame)
+void Mac::PrepareBeacon(Frame &aFrame)
 {
     uint8_t        numUnsecurePorts;
     uint8_t        beaconLength;
@@ -736,13 +737,11 @@ void Mac::SendBeacon(Frame &aFrame)
     Beacon *       beacon        = NULL;
     BeaconPayload *beaconPayload = NULL;
 
-    // initialize MAC header
     fcf = Frame::kFcfFrameBeacon | Frame::kFcfDstAddrNone | Frame::kFcfSrcAddrExt;
     aFrame.InitMacHeader(fcf, Frame::kSecNone);
     aFrame.SetSrcPanId(mPanId);
     aFrame.SetSrcAddr(GetExtAddress());
 
-    // write payload
     beacon = reinterpret_cast<Beacon *>(aFrame.GetPayload());
     beacon->Init();
     beaconLength = sizeof(*beacon);
@@ -919,7 +918,7 @@ void Mac::BeginTransmit(void)
     case kOperationActiveScan:
         mSubMac.SetPanId(kPanIdBroadcast);
         sendFrame.SetChannel(mScanChannel);
-        SendBeaconRequest(sendFrame);
+        PrepareBeaconRequest(sendFrame);
         sendFrame.SetSequence(0);
         sendFrame.SetMaxCsmaBackoffs(kMaxCsmaBackoffsDirect);
         sendFrame.SetMaxFrameRetries(kMaxFrameRetriesDirect);
@@ -927,7 +926,7 @@ void Mac::BeginTransmit(void)
 
     case kOperationTransmitBeacon:
         sendFrame.SetChannel(mRadioChannel);
-        SendBeacon(sendFrame);
+        PrepareBeacon(sendFrame);
         sendFrame.SetSequence(mBeaconSequence++);
         sendFrame.SetMaxCsmaBackoffs(kMaxCsmaBackoffsDirect);
         sendFrame.SetMaxFrameRetries(kMaxFrameRetriesDirect);

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -345,11 +345,6 @@ exit:
     return;
 }
 
-void Mac::SetShortAddress(ShortAddress aShortAddress)
-{
-    mSubMac.SetShortAddress(aShortAddress);
-}
-
 otError Mac::SetPanChannel(uint8_t aChannel)
 {
     otError error = OT_ERROR_NONE;
@@ -431,11 +426,6 @@ void Mac::SetSupportedChannelMask(const ChannelMask &aMask)
 
 exit:
     return;
-}
-
-otError Mac::SetNetworkName(const char *aNetworkName)
-{
-    return SetNetworkName(aNetworkName, OT_NETWORK_NAME_MAX_SIZE + 1);
 }
 
 otError Mac::SetNetworkName(const char *aBuffer, uint8_t aLength)
@@ -1729,11 +1719,6 @@ exit:
     return error;
 }
 
-void Mac::SetPcapCallback(otLinkPcapCallback aPcapCallback, void *aCallbackContext)
-{
-    mSubMac.SetPcapCallback(aPcapCallback, aCallbackContext);
-}
-
 void Mac::SetPromiscuous(bool aPromiscuous)
 {
     mPromiscuous = aPromiscuous;
@@ -1746,11 +1731,6 @@ void Mac::SetPromiscuous(bool aPromiscuous)
 
     mSubMac.SetRxOnWhenBackoff(mRxOnWhenIdle || mPromiscuous);
     UpdateIdleMode();
-}
-
-void Mac::SetEnabled(bool aEnable)
-{
-    mEnabled = aEnable;
 }
 
 void Mac::ResetCounters(void)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -612,8 +612,8 @@ private:
     void    StartOperation(Operation aOperation);
     void    FinishOperation(void);
     void    PerformNextOperation(void);
-    void    SendBeaconRequest(Frame &aFrame);
-    void    SendBeacon(Frame &aFrame);
+    void    PrepareBeaconRequest(Frame &aFrame);
+    void    PrepareBeacon(Frame &aFrame);
     bool    ShouldSendBeacon(void) const;
     void    BeginTransmit(void);
     otError HandleMacCommand(Frame &aFrame);

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -262,7 +262,7 @@ public:
      * @param[in]  aShortAddress  The IEEE 802.15.4 Short Address.
      *
      */
-    void SetShortAddress(ShortAddress aShortAddress);
+    void SetShortAddress(ShortAddress aShortAddress) { mSubMac.SetShortAddress(aShortAddress); }
 
     /**
      * This method returns the IEEE 802.15.4 PAN Channel.
@@ -358,7 +358,10 @@ public:
      * @retval OT_ERROR_INVALID_ARGS   Given name is too long.
      *
      */
-    otError SetNetworkName(const char *aNetworkName);
+    otError SetNetworkName(const char *aNetworkName)
+    {
+        return SetNetworkName(aNetworkName, OT_NETWORK_NAME_MAX_SIZE + 1);
+    }
 
     /**
      * This method sets the IEEE 802.15.4 Network Name.
@@ -489,7 +492,10 @@ public:
      * @param[in]  aCallbackContext  A pointer to application-specific context.
      *
      */
-    void SetPcapCallback(otLinkPcapCallback aPcapCallback, void *aCallbackContext);
+    void SetPcapCallback(otLinkPcapCallback aPcapCallback, void *aCallbackContext)
+    {
+        mSubMac.SetPcapCallback(aPcapCallback, aCallbackContext);
+    }
 
     /**
      * This method indicates whether or not promiscuous mode is enabled at the link layer.
@@ -549,7 +555,7 @@ public:
      * @param[in]  aEnable The requested State for the MAC layer. true - Start, false - Stop.
      *
      */
-    void SetEnabled(bool aEnable);
+    void SetEnabled(bool aEnable) { mEnabled = aEnable; }
 
     /**
      * This method indicates whether or not the link layer is enabled.


### PR DESCRIPTION
This PR contains two small changes/improvements in MAC (kept them seperate commits).

- [mac] rename methods preparing beacon and beacon request frames
- [mac] inline short/simple methods