### PR TITLE
[mac] move data poll tx into Mac and DataPollManager

### DIFF
--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -206,8 +206,7 @@ public:
     {
         kTypeIp6         = 0, ///< A full uncompressed IPv6 packet
         kType6lowpan     = 1, ///< A 6lowpan frame
-        kTypeMacDataPoll = 2, ///< A MAC data poll message
-        kTypeSupervision = 3, ///< A child supervision frame.
+        kTypeSupervision = 2, ///< A child supervision frame.
     };
 
     enum

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -233,6 +233,16 @@ public:
     otError RequestOutOfBandFrameTransmission(otRadioFrame *aOobFrame);
 
     /**
+     * This method requests transmission of a data poll (MAC Data Request) frame.
+     *
+     * @retval OT_ERROR_NONE           Data poll transmission request is scheduled successfully.
+     * @retval OT_ERROR_ALREADY        MAC is busy sending earlier poll transmission request.
+     * @retval OT_ERROR_INVALID_STATE  The MAC layer is not enabled.
+     *
+     */
+    otError RequestDataPollTransmission(void);
+
+    /**
      * This method returns a reference to the IEEE 802.15.4 Extended Address.
      *
      * @returns A pointer to the IEEE 802.15.4 Extended Address.
@@ -591,6 +601,7 @@ private:
         kOperationEnergyScan,
         kOperationTransmitBeacon,
         kOperationTransmitData,
+        kOperationTransmitPoll,
         kOperationWaitingForData,
         kOperationTransmitOutOfBandFrame,
     };
@@ -618,6 +629,7 @@ private:
     void    StartOperation(Operation aOperation);
     void    FinishOperation(void);
     void    PerformNextOperation(void);
+    otError PrepareDataRequest(Frame &aFrame);
     void    PrepareBeaconRequest(Frame &aFrame);
     void    PrepareBeacon(Frame &aFrame);
     bool    ShouldSendBeacon(void) const;
@@ -651,8 +663,10 @@ private:
     bool mPendingEnergyScan : 1;
     bool mPendingTransmitBeacon : 1;
     bool mPendingTransmitData : 1;
+    bool mPendingTransmitPoll : 1;
     bool mPendingTransmitOobFrame : 1;
     bool mPendingWaitingForData : 1;
+    bool mShouldTxPollBeforeData : 1;
     bool mRxOnWhenIdle : 1;
     bool mPromiscuous : 1;
     bool mBeaconsEnabled : 1;

--- a/src/core/thread/data_poll_manager.hpp
+++ b/src/core/thread/data_poll_manager.hpp
@@ -132,16 +132,17 @@ public:
     uint32_t GetExternalPollPeriod(void) const { return mExternalPollPeriod; }
 
     /**
-     * This method informs the data poll manager of success/error status of a previously requested poll message
+     * This method informs the data poll manager of success/error status of a previously requested poll frame
      * transmission.
      *
      * In case of transmit failure, the data poll manager may choose to send the next data poll more quickly (up to
      * some fixed number of attempts).
      *
-     * @param[in] aError   Error status of a data poll message transmission.
+     * @param[in] aFrame     The data poll frame.
+     * @param[in] aError     Error status of a data poll message transmission.
      *
      */
-    void HandlePollSent(otError aError);
+    void HandlePollSent(Mac::Frame &aFrame, otError aError);
 
     /**
      * This method informs the data poll manager that a data poll timeout happened, i.e., when the ack in response to

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -169,6 +169,7 @@ class MeshForwarder : public InstanceLocator
 {
     friend class Mac::Mac;
     friend class Instance;
+    friend class DataPollManager;
 
 public:
     /**
@@ -383,7 +384,6 @@ private:
     Message *GetIndirectTransmission(Child &aChild);
     otError  PrepareDiscoverRequest(void);
     void     PrepareIndirectTransmission(Message &aMessage, const Child &aChild);
-    otError  PrepareDataPoll(void);
     void     HandleMesh(uint8_t *               aFrame,
                         uint8_t                 aFrameLength,
                         const Mac::Address &    aMacSource,
@@ -404,7 +404,6 @@ private:
                                      uint8_t                 aFrameLength,
                                      Lowpan::FragmentHeader &aFragmentHeader);
 
-    void    SendPoll(Message &aMessage, Mac::Frame &aFrame);
     void    SendMesh(Message &aMessage, Mac::Frame &aFrame);
     otError SendFragment(Message &aMessage, Mac::Frame &aFrame);
     void    SendEmptyFrame(Mac::Frame &aFrame, bool aAckRequest);
@@ -423,10 +422,11 @@ private:
     void    RemoveMessage(Message &aMessage);
     void    HandleDiscoverComplete(void);
 
-    void    HandleReceivedFrame(Mac::Frame &aFrame);
-    otError HandleFrameRequest(Mac::Frame &aFrame);
-    void    HandleSentFrame(Mac::Frame &aFrame, otError aError);
-    void    HandleSentFrameToChild(const Mac::Frame &aFrame, otError aError, const Mac::Address &aMacDest);
+    void      HandleReceivedFrame(Mac::Frame &aFrame);
+    otError   HandleFrameRequest(Mac::Frame &aFrame);
+    Neighbor *UpdateNeighborOnSentFrame(Mac::Frame &aFrame, otError aError, const Mac::Address &aMacDest);
+    void      HandleSentFrame(Mac::Frame &aFrame, otError aError);
+    void      HandleSentFrameToChild(const Mac::Frame &aFrame, otError aError, const Mac::Address &aMacDest);
 
     static void HandleDiscoverTimer(Timer &aTimer);
     void        HandleDiscoverTimer(void);


### PR DESCRIPTION
This commit moves the implementation of data poll transmission
related logic into `Mac` and `DataPollManagr` from `MeshForwarder`.