### PR TITLE
[data-poll-manager] remove unneeded code handling NO_BUFS error

### DIFF
--- a/src/core/thread/data_poll_manager.hpp
+++ b/src/core/thread/data_poll_manager.hpp
@@ -219,13 +219,12 @@ public:
 private:
     enum // Poll period under different conditions (in milliseconds).
     {
-        kAttachDataPollPeriod   = OPENTHREAD_CONFIG_ATTACH_DATA_POLL_PERIOD, ///< Poll period during attach.
-        kRetxPollPeriod         = OPENTHREAD_CONFIG_RETX_POLL_PERIOD,        ///< Poll retx period due to tx failure.
-        kNoBufferRetxPollPeriod = 200,                                       ///< Poll retx due to no buffer space.
-        kFastPollPeriod         = 188,                                       ///< Period used for fast polls.
-        kMinPollPeriod          = OPENTHREAD_CONFIG_MINIMUM_POLL_PERIOD,     ///< Minimum allowed poll period.
-        kMaxExternalPeriod      = ((1 << 26) - 1),                           ///< Maximum allowed user-specified period.
-                                                                             ///< i.e. (0x3FFFFF)ms, about 18.64 hours.
+        kAttachDataPollPeriod = OPENTHREAD_CONFIG_ATTACH_DATA_POLL_PERIOD, ///< Poll period during attach.
+        kRetxPollPeriod       = OPENTHREAD_CONFIG_RETX_POLL_PERIOD,        ///< Poll retx period due to tx failure.
+        kFastPollPeriod       = 188,                                       ///< Period used for fast polls.
+        kMinPollPeriod        = OPENTHREAD_CONFIG_MINIMUM_POLL_PERIOD,     ///< Minimum allowed poll period.
+        kMaxExternalPeriod    = ((1 << 26) - 1),                           ///< Maximum allowed user-specified period.
+                                                                           ///< i.e. (0x3FFFFF)ms, about 18.64 hours.
     };
 
     enum
@@ -256,7 +255,6 @@ private:
     bool    mEnabled : 1;              //< Indicates whether data polling is enabled/started.
     bool    mAttachMode : 1;           //< Indicates whether in attach mode (to use attach poll period).
     bool    mRetxMode : 1;             //< Indicates whether last poll tx failed at mac/radio layer (poll retx mode).
-    bool    mNoBufferRetxMode : 1;     //< Indicates whether last poll tx failed due to insufficient buffer.
     uint8_t mPollTimeoutCounter : 4;   //< Poll timeouts counter (0 to `kQuickPollsAfterTimout`).
     uint8_t mPollTxFailureCounter : 4; //< Poll tx failure counter (0 to `kMaxPollRetxAttempts`).
     uint8_t mRemainingFastPolls : 4;   //< Number of remaining fast polls when in transient fast polling mode.


### PR DESCRIPTION
This commit remove the logic in `DataPollManager` related to handling
of the `NO_BUFS` error case when sending a data poll. This logic is no
longer needed since the data poll tx logic is now handled by `Mac`
layer directly and there is no need to allocate/use a `Message` instance
for data poll (which could earlier lead to `NO_BUFs` error situation).

-----------

This is PR/change that follows https://github.com/openthread/openthread/pull/3915 (and is on top of the commit from that PR). Submitted a seperate PR to keep https://github.com/openthread/openthread/pull/3915 easier to read/review.

The main change in this PR is in this commit: https://github.com/openthread/openthread/pull/3918/commits/781294b42dbf43a23b7de91e15ef646fadc28d78