### PR TITLE
[data-poll-sender] rename DataPollManager as DataPollSender

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -154,6 +154,7 @@ LOCAL_SRC_FILES                                          := \
     src/core/crypto/pbkdf2_cmac.cpp                         \
     src/core/crypto/sha256.cpp                              \
     src/core/mac/channel_mask.cpp                           \
+    src/core/mac/data_poll_sender.cpp                       \
     src/core/mac/mac.cpp                                    \
     src/core/mac/mac_filter.cpp                             \
     src/core/mac/mac_frame.cpp                              \
@@ -191,7 +192,6 @@ LOCAL_SRC_FILES                                          := \
     src/core/thread/announce_begin_server.cpp               \
     src/core/thread/announce_sender.cpp                     \
     src/core/thread/child_table.cpp                         \
-    src/core/thread/data_poll_manager.cpp                   \
     src/core/thread/energy_scan_server.cpp                  \
     src/core/thread/key_manager.cpp                         \
     src/core/thread/link_quality.cpp                        \

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -159,6 +159,7 @@ SOURCES_COMMON                      = \
     crypto/pbkdf2_cmac.cpp            \
     crypto/sha256.cpp                 \
     mac/channel_mask.cpp              \
+    mac/data_poll_sender.cpp          \
     mac/link_raw.cpp                  \
     mac/mac.cpp                       \
     mac/mac_filter.cpp                \
@@ -198,7 +199,6 @@ SOURCES_COMMON                      = \
     thread/announce_begin_server.cpp  \
     thread/announce_sender.cpp        \
     thread/child_table.cpp            \
-    thread/data_poll_manager.cpp      \
     thread/energy_scan_server.cpp     \
     thread/key_manager.cpp            \
     thread/link_quality.cpp           \
@@ -327,6 +327,7 @@ HEADERS_COMMON                      = \
     crypto/pbkdf2_cmac.h              \
     crypto/sha256.hpp                 \
     mac/channel_mask.hpp              \
+    mac/data_poll_sender.hpp          \
     mac/link_raw.hpp                  \
     mac/mac.hpp                       \
     mac/mac_filter.hpp                \
@@ -368,7 +369,6 @@ HEADERS_COMMON                      = \
     thread/announce_begin_server.hpp  \
     thread/announce_sender.hpp        \
     thread/child_table.hpp            \
-    thread/data_poll_manager.hpp      \
     thread/energy_scan_server.hpp     \
     thread/key_manager.hpp            \
     thread/link_quality.hpp           \

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -161,21 +161,21 @@ uint32_t otLinkGetPollPeriod(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<DataPollManager>().GetKeepAlivePollPeriod();
+    return instance.Get<DataPollSender>().GetKeepAlivePollPeriod();
 }
 
 otError otLinkSetPollPeriod(otInstance *aInstance, uint32_t aPollPeriod)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<DataPollManager>().SetExternalPollPeriod(aPollPeriod);
+    return instance.Get<DataPollSender>().SetExternalPollPeriod(aPollPeriod);
 }
 
 otError otLinkSendDataRequest(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<DataPollManager>().SendDataPoll();
+    return instance.Get<DataPollSender>().SendDataPoll();
 }
 
 otShortAddress otLinkGetShortAddress(otInstance *aInstance)

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -484,9 +484,9 @@ template <> inline AnnounceBeginServer &Instance::Get(void)
     return mThreadNetif.mAnnounceBegin;
 }
 
-template <> inline DataPollManager &Instance::Get(void)
+template <> inline DataPollSender &Instance::Get(void)
 {
-    return mThreadNetif.mMeshForwarder.mDataPollManager;
+    return mThreadNetif.mMeshForwarder.mDataPollSender;
 }
 
 template <> inline EnergyScanServer &Instance::Get(void)

--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -28,10 +28,10 @@
 
 /**
  * @file
- *   This file implements data poll (mac data request command) manager class.
+ *   This file implements data poll (mac data request command) sender class.
  */
 
-#include "data_poll_manager.hpp"
+#include "data_poll_sender.hpp"
 
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
@@ -46,13 +46,13 @@
 
 namespace ot {
 
-DataPollManager::DataPollManager(Instance &aInstance)
+DataPollSender::DataPollSender(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mTimerStartTime(0)
     , mPollPeriod(0)
     , mExternalPollPeriod(0)
     , mFastPollsUsers(0)
-    , mTimer(aInstance, &DataPollManager::HandlePollTimer, this)
+    , mTimer(aInstance, &DataPollSender::HandlePollTimer, this)
     , mEnabled(false)
     , mAttachMode(false)
     , mRetxMode(false)
@@ -62,7 +62,7 @@ DataPollManager::DataPollManager(Instance &aInstance)
 {
 }
 
-otError DataPollManager::StartPolling(void)
+otError DataPollSender::StartPolling(void)
 {
     otError error = OT_ERROR_NONE;
 
@@ -76,7 +76,7 @@ exit:
     return error;
 }
 
-void DataPollManager::StopPolling(void)
+void DataPollSender::StopPolling(void)
 {
     mTimer.Stop();
     mAttachMode           = false;
@@ -88,7 +88,7 @@ void DataPollManager::StopPolling(void)
     mEnabled              = false;
 }
 
-otError DataPollManager::SendDataPoll(void)
+otError DataPollSender::SendDataPoll(void)
 {
     otError   error;
     Neighbor *parent;
@@ -131,7 +131,7 @@ exit:
     return error;
 }
 
-otError DataPollManager::SetExternalPollPeriod(uint32_t aPeriod)
+otError DataPollSender::SetExternalPollPeriod(uint32_t aPeriod)
 {
     otError error = OT_ERROR_NONE;
 
@@ -160,7 +160,7 @@ exit:
     return error;
 }
 
-uint32_t DataPollManager::GetKeepAlivePollPeriod(void) const
+uint32_t DataPollSender::GetKeepAlivePollPeriod(void) const
 {
     uint32_t period = 0;
 
@@ -176,7 +176,7 @@ uint32_t DataPollManager::GetKeepAlivePollPeriod(void) const
     return period;
 }
 
-void DataPollManager::HandlePollSent(Mac::Frame &aFrame, otError aError)
+void DataPollSender::HandlePollSent(Mac::Frame &aFrame, otError aError)
 {
     Mac::Address macDest;
     bool         shouldRecalculatePollPeriod = false;
@@ -256,7 +256,7 @@ exit:
     return;
 }
 
-void DataPollManager::HandlePollTimeout(void)
+void DataPollSender::HandlePollTimeout(void)
 {
     // A data poll timeout happened, i.e., the ack in response to
     // a data poll indicated that a frame was pending, but no frame
@@ -281,7 +281,7 @@ exit:
     return;
 }
 
-void DataPollManager::CheckFramePending(Mac::Frame &aFrame)
+void DataPollSender::CheckFramePending(Mac::Frame &aFrame)
 {
     VerifyOrExit(mEnabled);
 
@@ -296,7 +296,7 @@ exit:
     return;
 }
 
-void DataPollManager::RecalculatePollPeriod(void)
+void DataPollSender::RecalculatePollPeriod(void)
 {
     if (mEnabled)
     {
@@ -304,7 +304,7 @@ void DataPollManager::RecalculatePollPeriod(void)
     }
 }
 
-void DataPollManager::SetAttachMode(bool aMode)
+void DataPollSender::SetAttachMode(bool aMode)
 {
     if (mAttachMode != aMode)
     {
@@ -317,7 +317,7 @@ void DataPollManager::SetAttachMode(bool aMode)
     }
 }
 
-void DataPollManager::SendFastPolls(uint8_t aNumFastPolls)
+void DataPollSender::SendFastPolls(uint8_t aNumFastPolls)
 {
     bool shouldRecalculatePollPeriod = (mRemainingFastPolls == 0);
 
@@ -347,7 +347,7 @@ void DataPollManager::SendFastPolls(uint8_t aNumFastPolls)
     }
 }
 
-otError DataPollManager::StopFastPolls(void)
+otError DataPollSender::StopFastPolls(void)
 {
     otError error = OT_ERROR_NONE;
 
@@ -368,7 +368,7 @@ exit:
     return error;
 }
 
-void DataPollManager::ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector)
+void DataPollSender::ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector)
 {
     uint32_t now;
     uint32_t oldPeriod = mPollPeriod;
@@ -410,7 +410,7 @@ void DataPollManager::ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector)
     }
 }
 
-uint32_t DataPollManager::CalculatePollPeriod(void) const
+uint32_t DataPollSender::CalculatePollPeriod(void) const
 {
     uint32_t period = 0;
 
@@ -456,12 +456,12 @@ uint32_t DataPollManager::CalculatePollPeriod(void) const
     return period;
 }
 
-void DataPollManager::HandlePollTimer(Timer &aTimer)
+void DataPollSender::HandlePollTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<DataPollManager>().SendDataPoll();
+    aTimer.GetOwner<DataPollSender>().SendDataPoll();
 }
 
-uint32_t DataPollManager::GetDefaultPollPeriod(void) const
+uint32_t DataPollSender::GetDefaultPollPeriod(void) const
 {
     return TimerMilli::SecToMsec(Get<Mle::MleRouter>().GetTimeout()) -
            static_cast<uint32_t>(kRetxPollPeriod) * kMaxPollRetxAttempts;

--- a/src/core/mac/data_poll_sender.hpp
+++ b/src/core/mac/data_poll_sender.hpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *   This file includes definitions for data poll (mac data request command) manager.
+ *   This file includes definitions for data poll (mac data request command) sender.
  */
 
 #ifndef DATA_POLL_MANAGER_HPP_
@@ -44,20 +44,20 @@
 namespace ot {
 
 /**
- * @addtogroup core-data-poll-manager
+ * @addtogroup core-data-poll-sender
  *
  * @brief
- *   This module includes definitions for data poll manager.
+ *   This module includes definitions for data poll sender.
  *
  * @{
  */
 
 /**
- * This class implements the data poll (mac data request command) manager.
+ * This class implements the data poll (mac data request command) sender.
  *
  */
 
-class DataPollManager : public InstanceLocator
+class DataPollSender : public InstanceLocator
 {
 public:
     enum
@@ -68,15 +68,15 @@ public:
     };
 
     /**
-     * This constructor initializes the data poll manager object.
+     * This constructor initializes the data poll sender object.
      *
      * @param[in]  aInstance   A reference to the OpenThread instance.
      *
      */
-    explicit DataPollManager(Instance &aInstance);
+    explicit DataPollSender(Instance &aInstance);
 
     /**
-     * This method instructs the data poll manager to start sending periodic data polls.
+     * This method instructs the data poll sender to start sending periodic data polls.
      *
      * @retval OT_ERROR_NONE            Successfully started sending periodic data polls.
      * @retval OT_ERROR_ALREADY         Periodic data poll transmission is already started/enabled.
@@ -86,7 +86,7 @@ public:
     otError StartPolling(void);
 
     /**
-     * This method instructs the data poll manager to stop sending periodic data polls.
+     * This method instructs the data poll sender to stop sending periodic data polls.
      *
      */
     void StopPolling(void);
@@ -132,10 +132,10 @@ public:
     uint32_t GetExternalPollPeriod(void) const { return mExternalPollPeriod; }
 
     /**
-     * This method informs the data poll manager of success/error status of a previously requested poll frame
+     * This method informs the data poll sender of success/error status of a previously requested poll frame
      * transmission.
      *
-     * In case of transmit failure, the data poll manager may choose to send the next data poll more quickly (up to
+     * In case of transmit failure, the data poll sender may choose to send the next data poll more quickly (up to
      * some fixed number of attempts).
      *
      * @param[in] aFrame     The data poll frame.
@@ -145,35 +145,35 @@ public:
     void HandlePollSent(Mac::Frame &aFrame, otError aError);
 
     /**
-     * This method informs the data poll manager that a data poll timeout happened, i.e., when the ack in response to
+     * This method informs the data poll sender that a data poll timeout happened, i.e., when the ack in response to
      * a data request command indicated that a frame was pending, but no frame was received after timeout interval.
      *
-     * Data poll manager may choose to transmit another data poll immediately (up to some fixed number of attempts).
+     * Data poll sender may choose to transmit another data poll immediately (up to some fixed number of attempts).
      *
      */
     void HandlePollTimeout(void);
 
     /**
-     * This method informs the data poll manager that a mac frame has been received. It checks the "frame pending" in
-     * the received frame header and if it is set, data poll manager will send an immediate data poll to retrieve the
+     * This method informs the data poll sender that a mac frame has been received. It checks the "frame pending" in
+     * the received frame header and if it is set, data poll sender will send an immediate data poll to retrieve the
      * pending frame.
      *
      */
     void CheckFramePending(Mac::Frame &aFrame);
 
     /**
-     * This method asks the data poll manager to recalculate the poll period.
+     * This method asks the data poll sender to recalculate the poll period.
      *
-     * This is mainly used to inform the poll manager that a parameter impacting the poll period (e.g., the child's
+     * This is mainly used to inform the poll sender that a parameter impacting the poll period (e.g., the child's
      * timeout value which is used to determine the default data poll period) is modified.
      *
      */
     void RecalculatePollPeriod(void);
 
     /**
-     * This method sets/clears the attach mode on data poll manager.
+     * This method sets/clears the attach mode on data poll sender.
      *
-     * When attach mode is enabled, the data poll manager will send data polls at a faster rate determined by
+     * When attach mode is enabled, the data poll sender will send data polls at a faster rate determined by
      * poll period configuration option `OPENTHREAD_CONFIG_ATTACH_DATA_POLL_PERIOD`.
      *
      * @param[in]  aMode  The mode value.
@@ -182,7 +182,7 @@ public:
     void SetAttachMode(bool aMode);
 
     /**
-     * This method asks data poll manager to send the next given number of polls at a faster rate (poll period defined
+     * This method asks data poll sender to send the next given number of polls at a faster rate (poll period defined
      * by `kFastPollPeriod`). This is used by OpenThread stack when it expects a response from the parent/sender.
      *
      * If @p aNumFastPolls is zero the default value specified by `kDefaultFastPolls` is used instead. The number of
@@ -200,7 +200,7 @@ public:
     void SendFastPolls(uint8_t aNumFastPolls);
 
     /**
-     * This method asks data poll manager to stop fast polls when the expecting response is received.
+     * This method asks data poll sender to stop fast polls when the expecting response is received.
      *
      * @retval OT_ERROR_NONE            Successfully stopped fast polls when no other responses are expected.
      * @retval OT_ERROR_BUSY            There are other callers who are waiting for responses.

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1260,7 +1260,7 @@ void Mac::HandleTransmitDone(Frame &aFrame, Frame *aAckFrame, otError aError)
 
         mCounters.mTxDataPoll++;
         FinishOperation();
-        Get<DataPollManager>().HandlePollSent(aFrame, aError);
+        Get<DataPollSender>().HandlePollSent(aFrame, aError);
         PerformNextOperation();
         break;
 
@@ -1308,7 +1308,7 @@ void Mac::HandleTimer(void)
     case kOperationWaitingForData:
         otLogDebgMac("Data poll timeout");
         FinishOperation();
-        Get<DataPollManager>().HandlePollTimeout();
+        Get<DataPollSender>().HandlePollTimeout();
         PerformNextOperation();
         break;
 
@@ -1612,7 +1612,7 @@ void Mac::HandleReceivedFrame(Frame *aFrame, otError aError)
         ExitNow();
     }
 
-    Get<DataPollManager>().CheckFramePending(*aFrame);
+    Get<DataPollSender>().CheckFramePending(*aFrame);
 
 #if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT
 

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -82,7 +82,7 @@ MeshForwarder::MeshForwarder(Instance &aInstance)
     , mSendMessageDataSequenceNumber(0)
     , mIndirectStartingChild(NULL)
 #endif
-    , mDataPollManager(aInstance)
+    , mDataPollSender(aInstance)
 {
     mFragTag = Random::NonCrypto::GetUint16();
 
@@ -111,7 +111,7 @@ void MeshForwarder::Stop(void)
 
     VerifyOrExit(mEnabled == true);
 
-    mDataPollManager.StopPolling();
+    mDataPollSender.StopPolling();
     mUpdateTimer.Stop();
 
     if (mScanning)
@@ -367,12 +367,12 @@ void MeshForwarder::SetRxOnWhenIdle(bool aRxOnWhenIdle)
 
     if (aRxOnWhenIdle)
     {
-        mDataPollManager.StopPolling();
+        mDataPollSender.StopPolling();
         Get<Utils::SupervisionListener>().Stop();
     }
     else
     {
-        mDataPollManager.StartPolling();
+        mDataPollSender.StartPolling();
         Get<Utils::SupervisionListener>().Start();
     }
 }

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -39,10 +39,10 @@
 #include "common/locator.hpp"
 #include "common/tasklet.hpp"
 #include "mac/channel_mask.hpp"
+#include "mac/data_poll_sender.hpp"
 #include "mac/mac.hpp"
 #include "net/ip6.hpp"
 #include "thread/address_resolver.hpp"
-#include "thread/data_poll_manager.hpp"
 #include "thread/lowpan.hpp"
 #include "thread/network_data_leader.hpp"
 #include "thread/src_match_controller.hpp"
@@ -169,7 +169,7 @@ class MeshForwarder : public InstanceLocator
 {
     friend class Mac::Mac;
     friend class Instance;
-    friend class DataPollManager;
+    friend class DataPollSender;
 
 public:
     /**
@@ -556,7 +556,7 @@ private:
     Child *               mIndirectStartingChild;
 #endif
 
-    DataPollManager mDataPollManager;
+    DataPollSender mDataPollSender;
 };
 
 /**

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -806,7 +806,7 @@ void Mle::SetTimeout(uint32_t aTimeout)
 
     mTimeout = aTimeout;
 
-    Get<DataPollManager>().RecalculatePollPeriod();
+    Get<DataPollSender>().RecalculatePollPeriod();
 
     if (mRole == OT_DEVICE_ROLE_CHILD)
     {
@@ -1862,7 +1862,7 @@ uint32_t Mle::Reattach(void)
         else if (!IsRxOnWhenIdle())
         {
             // return to sleepy operation
-            Get<DataPollManager>().SetAttachMode(false);
+            Get<DataPollSender>().SetAttachMode(false);
             Get<MeshForwarder>().SetRxOnWhenIdle(false);
         }
 
@@ -1930,7 +1930,7 @@ void Mle::HandleDelayedResponseTimer(void)
                 // for Rx-Off-when-idle device.
                 if (!IsRxOnWhenIdle())
                 {
-                    Get<DataPollManager>().SendFastPolls(DataPollManager::kDefaultFastPolls);
+                    Get<DataPollSender>().SendFastPolls(DataPollSender::kDefaultFastPolls);
                 }
             }
             else
@@ -2102,7 +2102,7 @@ otError Mle::SendChildIdRequest(void)
 
     if (!IsRxOnWhenIdle())
     {
-        Get<DataPollManager>().SetAttachMode(true);
+        Get<DataPollSender>().SetAttachMode(true);
         Get<MeshForwarder>().SetRxOnWhenIdle(false);
     }
 
@@ -2142,7 +2142,7 @@ otError Mle::SendDataRequest(const Ip6::Address &aDestination,
 
         if (!IsRxOnWhenIdle())
         {
-            Get<DataPollManager>().SendFastPolls(DataPollManager::kDefaultFastPolls);
+            Get<DataPollSender>().SendFastPolls(DataPollSender::kDefaultFastPolls);
         }
     }
 
@@ -2331,7 +2331,7 @@ otError Mle::SendChildUpdateRequest(void)
 
     if (!IsRxOnWhenIdle())
     {
-        Get<DataPollManager>().SetAttachMode(true);
+        Get<DataPollSender>().SetAttachMode(true);
         Get<MeshForwarder>().SetRxOnWhenIdle(false);
     }
     else
@@ -2967,7 +2967,7 @@ otError Mle::HandleDataResponse(const Message &aMessage, const Ip6::MessageInfo 
         // running out the specified number. E.g. other component also trigger fast poll, and
         // is waiting for response; or the corner case where multiple Mle Data Request attempts
         // happened due to the retransmission mechanism.
-        IgnoreReturnValue(Get<DataPollManager>().StopFastPolls());
+        IgnoreReturnValue(Get<DataPollSender>().StopFastPolls());
     }
 
     return error;
@@ -3471,7 +3471,7 @@ otError Mle::HandleChildIdResponse(const Message &aMessage, const Ip6::MessageIn
 
     if (!IsRxOnWhenIdle())
     {
-        Get<DataPollManager>().SetAttachMode(false);
+        Get<DataPollSender>().SetAttachMode(false);
         Get<MeshForwarder>().SetRxOnWhenIdle(false);
     }
     else
@@ -3655,7 +3655,7 @@ otError Mle::HandleChildUpdateResponse(const Message &aMessage, const Ip6::Messa
 
         if (!IsRxOnWhenIdle())
         {
-            Get<DataPollManager>().SetAttachMode(false);
+            Get<DataPollSender>().SetAttachMode(false);
             Get<MeshForwarder>().SetRxOnWhenIdle(false);
         }
         else

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -323,7 +323,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             {
                 TimeoutTlv tlv;
                 tlv.Init();
-                tlv.SetTimeout(TimerMilli::MsecToSec(Get<DataPollManager>().GetKeepAlivePollPeriod()));
+                tlv.SetTimeout(TimerMilli::MsecToSec(Get<DataPollSender>().GetKeepAlivePollPeriod()));
                 SuccessOrExit(error = aResponse.AppendTlv(tlv));
             }
 


### PR DESCRIPTION
This commit renames the `DataPollManager` to `DataPollSender` and
also moves the files in `src/core/mac` folder.

---------

This is in preparation for adding a new class `DataPollHandler` (to handle data polls and indirect tx by mac layer).