### PR TITLE
[mesh-forwarder] clear children's indirect msg and src match table on stop

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -132,6 +132,12 @@ void MeshForwarder::Stop(void)
     }
 
 #if OPENTHREAD_FTD
+    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
+    {
+        iter.GetChild()->SetIndirectMessage(NULL);
+        Get<SourceMatchController>().ResetMessageCount(*iter.GetChild());
+    }
+
     memset(mFragmentEntries, 0, sizeof(mFragmentEntries));
 #endif
 


### PR DESCRIPTION
This commit ensures to clear the indirect message pointer on all
children and reset the indirect message count (which in turn clear the
source match table) from `MeshForwarder::Stop()`. This addresses the
issue where on an `Stop()`/`Start()` call the source match table can
become out of sync with the send queue and/or a child may hold on to
an already freed `Message`.