### PR TITLE
[coap] remove payload marker correctly and add payload marker check

### DIFF
--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -267,8 +267,7 @@ const otCoapOption *Message::GetNextOption(void)
 
         // The presence of a marker followed by a zero-length payload MUST be processed
         // as a message format error.
-        VerifyOrExit((GetHelpData().mNextOptionOffset - GetHelpData().mHeaderOffset) < GetLength(),
-                     error = OT_ERROR_PARSE);
+        VerifyOrExit(GetHelpData().mNextOptionOffset < GetLength(), error = OT_ERROR_PARSE);
 
         ExitNow(error = OT_ERROR_NOT_FOUND);
     }

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -261,7 +261,15 @@ const otCoapOption *Message::GetNextOption(void)
     }
     else
     {
+        // RFC7252 (Section 3):
+        // Reserved for payload marker.
         VerifyOrExit(optionLength == 0xf, error = OT_ERROR_PARSE);
+
+        // The presence of a marker followed by a zero-length payload MUST be processed
+        // as a message format error.
+        VerifyOrExit((GetHelpData().mNextOptionOffset - GetHelpData().mHeaderOffset) < GetLength(),
+                     error = OT_ERROR_PARSE);
+
         ExitNow(error = OT_ERROR_NOT_FOUND);
     }
 
@@ -323,6 +331,9 @@ otError Message::SetPayloadMarker(void)
     VerifyOrExit(GetLength() < kMaxHeaderLength, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = Append(&marker, sizeof(marker)));
     GetHelpData().mHeaderLength = GetLength();
+
+    // Set offset to the start of payload.
+    SetOffset(GetHelpData().mHeaderLength);
 
 exit:
     return error;

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -589,7 +589,7 @@ private:
         otCoapOption mOption;
         uint16_t     mNextOptionOffset; ///< The byte offset for the next CoAP Option
         uint16_t     mOptionLast;
-        uint16_t     mHeaderOffset;
+        uint16_t     mHeaderOffset; ///< The byte offset for the CoAP Header
         uint16_t     mHeaderLength;
     };
 

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -286,6 +286,12 @@ otError Message::SetLength(uint16_t aLength)
     SuccessOrExit(error = ResizeMessage(totalLengthRequest));
     mBuffer.mHead.mInfo.mLength = aLength;
 
+    // Correct offset in case shorter length is set.
+    if (GetOffset() > aLength)
+    {
+        SetOffset(aLength);
+    }
+
 exit:
     return error;
 }


### PR DESCRIPTION
#3419 introduced some setback about payload marker.

> RFC7252:  The presence of a marker followed by a zero-length payload MUST be processed as a message format error.