### PR TITLE
[mac] change frame length type from uint8_t to uint16_t

### DIFF
--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -176,7 +176,7 @@ typedef struct otRadioIeInfo
 typedef struct otRadioFrame
 {
     uint8_t *      mPsdu;    ///< The PSDU.
-    uint8_t        mLength;  ///< Length of the PSDU.
+    uint16_t       mLength;  ///< Length of the PSDU.
     uint8_t        mChannel; ///< Channel used to transmit/receive the frame.
     otRadioIeInfo *mIeInfo;  ///< The pointer to the Header IE(s) related information.
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -204,7 +204,7 @@ otError Mac::ConvertBeaconToActiveScanResult(Frame *aBeaconFrame, otActiveScanRe
     Address        address;
     Beacon *       beacon        = NULL;
     BeaconPayload *beaconPayload = NULL;
-    uint8_t        payloadLength;
+    uint16_t       payloadLength;
 
     memset(&aResult, 0, sizeof(otActiveScanResult));
 

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -763,22 +763,22 @@ uint8_t Frame::GetFooterLength(void) const
 
 exit:
     // Frame Check Sequence
-    footerLength += kFcsSize;
+    footerLength += GetFcsSize();
 
     return footerLength;
 }
 
-uint8_t Frame::GetMaxPayloadLength(void) const
+uint16_t Frame::GetMaxPayloadLength(void) const
 {
-    return kMTU - (GetHeaderLength() + GetFooterLength());
+    return GetMtu() - (GetHeaderLength() + GetFooterLength());
 }
 
-uint8_t Frame::GetPayloadLength(void) const
+uint16_t Frame::GetPayloadLength(void) const
 {
     return GetPsduLength() - (GetHeaderLength() + GetFooterLength());
 }
 
-void Frame::SetPayloadLength(uint8_t aLength)
+void Frame::SetPayloadLength(uint16_t aLength)
 {
     SetPsduLength(GetHeaderLength() + GetFooterLength() + aLength);
 }
@@ -793,7 +793,7 @@ uint8_t Frame::SkipSecurityHeaderIndex(void) const
     // Sequence Number
     index += kDsnSize;
 
-    VerifyOrExit((index + kFcsSize) <= GetPsduLength(), index = kInvalidIndex);
+    VerifyOrExit((index + GetFcsSize()) <= GetPsduLength(), index = kInvalidIndex);
 
     fcf = GetFrameControlField();
 
@@ -839,7 +839,7 @@ uint8_t Frame::SkipSecurityHeaderIndex(void) const
         ExitNow(index = kInvalidIndex);
     }
 
-    VerifyOrExit((index + kFcsSize) <= GetPsduLength(), index = kInvalidIndex);
+    VerifyOrExit((index + GetFcsSize()) <= GetPsduLength(), index = kInvalidIndex);
 
     // Security Control + Frame Counter + Key Identifier
     if ((fcf & kFcfSecurityEnabled) != 0)
@@ -1046,6 +1046,18 @@ void Frame::CopyFrom(const Frame &aFromFrame)
 
     memcpy(mPsdu, aFromFrame.mPsdu, aFromFrame.GetPsduLength());
     memcpy(mIeInfo, aFromFrame.mIeInfo, sizeof(otRadioIeInfo));
+}
+
+uint16_t Frame::GetMtu(void) const
+{
+    uint16_t mtu = kMTU;
+    return mtu;
+}
+
+uint16_t Frame::GetFcsSize(void) const
+{
+    uint16_t fcsSize = kFcsSize;
+    return fcsSize;
 }
 
 Frame::InfoString Frame::ToInfoString(void) const

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1050,14 +1050,12 @@ void Frame::CopyFrom(const Frame &aFromFrame)
 
 uint16_t Frame::GetMtu(void) const
 {
-    uint16_t mtu = kMTU;
-    return mtu;
+    return kMTU;
 }
 
 uint16_t Frame::GetFcsSize(void) const
 {
-    uint16_t fcsSize = kFcsSize;
-    return fcsSize;
+    return kFcsSize;
 }
 
 Frame::InfoString Frame::ToInfoString(void) const

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -869,7 +869,7 @@ public:
      * @returns The MAC Frame Length.
      *
      */
-    uint8_t GetLength(void) const { return GetPsduLength(); }
+    uint16_t GetLength(void) const { return GetPsduLength(); }
 
     /**
      * This method sets the MAC Frame Length.
@@ -877,7 +877,7 @@ public:
      * @param[in]  aLength  The MAC Frame Length.
      *
      */
-    void SetLength(uint8_t aLength) { SetPsduLength(aLength); }
+    void SetLength(uint16_t aLength) { SetPsduLength(aLength); }
 
     /**
      * This method returns the MAC header size.
@@ -901,7 +901,7 @@ public:
      * @returns The current MAC Payload length.
      *
      */
-    uint8_t GetPayloadLength(void) const;
+    uint16_t GetPayloadLength(void) const;
 
     /**
      * This method returns the maximum MAC Payload length for the given MAC header and footer.
@@ -909,13 +909,13 @@ public:
      * @returns The maximum MAC Payload length for the given MAC header and footer.
      *
      */
-    uint8_t GetMaxPayloadLength(void) const;
+    uint16_t GetMaxPayloadLength(void) const;
 
     /**
      * This method sets the MAC Payload length.
      *
      */
-    void SetPayloadLength(uint8_t aLength);
+    void SetPayloadLength(uint16_t aLength);
 
     /**
      * This method returns the IEEE 802.15.4 channel used for transmission or reception.
@@ -1074,7 +1074,7 @@ public:
      * @returns The IEEE 802.15.4 PSDU length.
      *
      */
-    uint8_t GetPsduLength(void) const { return mLength; }
+    uint16_t GetPsduLength(void) const { return mLength; }
 
     /**
      * This method sets the IEEE 802.15.4 PSDU length.
@@ -1082,7 +1082,7 @@ public:
      * @param[in]  aLength  The IEEE 802.15.4 PSDU length.
      *
      */
-    void SetPsduLength(uint8_t aLength) { mLength = aLength; }
+    void SetPsduLength(uint16_t aLength) { mLength = aLength; }
 
     /**
      * This method returns a pointer to the PSDU.
@@ -1261,6 +1261,22 @@ public:
      *
      */
     void CopyFrom(const Frame &aFromFrame);
+
+    /**
+     * This method returns the maximum transmission unit size (MTU).
+     *
+     * @returns The maximum transmission unit (MTU).
+     *
+     */
+    uint16_t GetMtu(void) const;
+
+    /**
+     * This method returns the FCS size.
+     *
+     * @returns This method returns the FCS size.
+     *
+     */
+    uint16_t GetFcsSize(void) const;
 
     /**
      * This method returns information about the frame object as an `InfoString` object.

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -1206,7 +1206,7 @@ exit:
     return (error == OT_ERROR_NONE) ? static_cast<int>(compressedLength) : -1;
 }
 
-otError MeshHeader::Init(const uint8_t *aFrame, uint8_t aFrameLength)
+otError MeshHeader::Init(const uint8_t *aFrame, uint16_t aFrameLength)
 {
     otError error = OT_ERROR_NONE;
 
@@ -1260,7 +1260,7 @@ exit:
     return error;
 }
 
-otError FragmentHeader::Init(const uint8_t *aFrame, uint8_t aFrameLength)
+otError FragmentHeader::Init(const uint8_t *aFrame, uint16_t aFrameLength)
 {
     otError error = OT_ERROR_PARSE;
 

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -91,7 +91,7 @@ public:
      * @param[in]  aLength  The size of the write buffer.
      *
      */
-    BufferWriter(uint8_t *aBuf, uint8_t aLength)
+    BufferWriter(uint8_t *aBuf, uint16_t aLength)
     {
         mWritePointer    = aBuf;
         mRemainingLength = aLength;
@@ -215,7 +215,7 @@ public:
 
 private:
     uint8_t *mWritePointer;
-    uint8_t  mRemainingLength;
+    uint16_t mRemainingLength;
 };
 
 /**
@@ -420,7 +420,7 @@ public:
      * @retval OT_ERROR_PARSE    Mesh Header could not be parsed from @p aFrame.
      *
      */
-    otError Init(const uint8_t *aFrame, uint8_t aFrameLength);
+    otError Init(const uint8_t *aFrame, uint16_t aFrameLength);
 
     /**
      * This method initializes the mesh header from a message object @p aMessage.
@@ -609,7 +609,7 @@ public:
      * @retval OT_ERROR_PARSE    Fragment header could not be parsed from @p aFrame.
      *
      */
-    otError Init(const uint8_t *aFrame, uint8_t aFrameLength);
+    otError Init(const uint8_t *aFrame, uint16_t aFrameLength);
 
     /**
      * This method initializes the fragment header from a message @p aMessage.

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -410,7 +410,7 @@ void MeshForwarder::GetMacDestinationAddress(const Ip6::Address &aIp6Addr, Mac::
     }
 }
 
-otError MeshForwarder::GetMeshHeader(const uint8_t *&aFrame, uint8_t &aFrameLength, Lowpan::MeshHeader &aMeshHeader)
+otError MeshForwarder::GetMeshHeader(const uint8_t *&aFrame, uint16_t &aFrameLength, Lowpan::MeshHeader &aMeshHeader)
 {
     otError error;
 
@@ -422,7 +422,7 @@ exit:
     return error;
 }
 
-otError MeshForwarder::SkipMeshHeader(const uint8_t *&aFrame, uint8_t &aFrameLength)
+otError MeshForwarder::SkipMeshHeader(const uint8_t *&aFrame, uint16_t &aFrameLength)
 {
     otError            error = OT_ERROR_NONE;
     Lowpan::MeshHeader meshHeader;
@@ -438,7 +438,7 @@ exit:
 }
 
 otError MeshForwarder::GetFragmentHeader(const uint8_t *         aFrame,
-                                         uint8_t                 aFrameLength,
+                                         uint16_t                aFrameLength,
                                          Lowpan::FragmentHeader &aFragmentHeader)
 {
     otError error = OT_ERROR_NONE;
@@ -453,7 +453,7 @@ exit:
 }
 
 otError MeshForwarder::DecompressIp6Header(const uint8_t *     aFrame,
-                                           uint8_t             aFrameLength,
+                                           uint16_t            aFrameLength,
                                            const Mac::Address &aMacSource,
                                            const Mac::Address &aMacDest,
                                            Ip6::Header &       aIp6Header,
@@ -1147,7 +1147,7 @@ void MeshForwarder::HandleReceivedFrame(Mac::Frame &aFrame)
     Mac::Address     macDest;
     Mac::Address     macSource;
     uint8_t *        payload;
-    uint8_t          payloadLength;
+    uint16_t         payloadLength;
     otError          error = OT_ERROR_NONE;
 
     if (!mEnabled)
@@ -1240,7 +1240,7 @@ exit:
 }
 
 void MeshForwarder::HandleFragment(uint8_t *               aFrame,
-                                   uint8_t                 aFrameLength,
+                                   uint16_t                aFrameLength,
                                    const Mac::Address &    aMacSource,
                                    const Mac::Address &    aMacDest,
                                    const otThreadLinkInfo &aLinkInfo)
@@ -1274,7 +1274,7 @@ void MeshForwarder::HandleFragment(uint8_t *               aFrame,
         VerifyOrExit(headerLength > 0, error = OT_ERROR_PARSE);
 
         aFrame += headerLength;
-        aFrameLength -= static_cast<uint8_t>(headerLength);
+        aFrameLength -= static_cast<uint16_t>(headerLength);
 
         VerifyOrExit(fragmentHeader.GetDatagramSize() >= message->GetOffset() + aFrameLength, error = OT_ERROR_PARSE);
 
@@ -1435,7 +1435,7 @@ bool MeshForwarder::UpdateReassemblyList(void)
 }
 
 void MeshForwarder::HandleLowpanHC(uint8_t *               aFrame,
-                                   uint8_t                 aFrameLength,
+                                   uint16_t                aFrameLength,
                                    const Mac::Address &    aMacSource,
                                    const Mac::Address &    aMacDest,
                                    const otThreadLinkInfo &aLinkInfo)
@@ -1463,7 +1463,7 @@ void MeshForwarder::HandleLowpanHC(uint8_t *               aFrame,
     VerifyOrExit(headerLength > 0, error = OT_ERROR_PARSE);
 
     aFrame += headerLength;
-    aFrameLength -= static_cast<uint8_t>(headerLength);
+    aFrameLength -= static_cast<uint16_t>(headerLength);
 
     SuccessOrExit(error = message->SetLength(message->GetLength() + aFrameLength));
     message->Write(message->GetOffset(), aFrameLength, aFrame);
@@ -1505,7 +1505,7 @@ otError MeshForwarder::HandleDatagram(Message &               aMessage,
 }
 
 otError MeshForwarder::GetFramePriority(const uint8_t *     aFrame,
-                                        uint8_t             aFrameLength,
+                                        uint16_t            aFrameLength,
                                         const Mac::Address &aMacSource,
                                         const Mac::Address &aMacDest,
                                         uint8_t &           aPriority)
@@ -1773,7 +1773,7 @@ void MeshForwarder::LogFrame(const char *aActionText, const Mac::Frame &aFrame, 
 }
 
 void MeshForwarder::LogFragmentFrameDrop(otError                       aError,
-                                         uint8_t                       aFrameLength,
+                                         uint16_t                      aFrameLength,
                                          const Mac::Address &          aMacSource,
                                          const Mac::Address &          aMacDest,
                                          const Lowpan::FragmentHeader &aFragmentHeader,
@@ -1786,7 +1786,7 @@ void MeshForwarder::LogFragmentFrameDrop(otError                       aError,
 }
 
 void MeshForwarder::LogLowpanHcFrameDrop(otError             aError,
-                                         uint8_t             aFrameLength,
+                                         uint16_t            aFrameLength,
                                          const Mac::Address &aMacSource,
                                          const Mac::Address &aMacDest,
                                          bool                aIsSecure)
@@ -1807,7 +1807,7 @@ void MeshForwarder::LogFrame(const char *, const Mac::Frame &, otError)
 }
 
 void MeshForwarder::LogFragmentFrameDrop(otError,
-                                         uint8_t,
+                                         uint16_t,
                                          const Mac::Address &,
                                          const Mac::Address &,
                                          const Lowpan::FragmentHeader &,
@@ -1815,7 +1815,7 @@ void MeshForwarder::LogFragmentFrameDrop(otError,
 {
 }
 
-void MeshForwarder::LogLowpanHcFrameDrop(otError, uint8_t, const Mac::Address &, const Mac::Address &, bool)
+void MeshForwarder::LogLowpanHcFrameDrop(otError, uint16_t, const Mac::Address &, const Mac::Address &, bool)
 {
 }
 

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -355,25 +355,25 @@ private:
     };
 
     otError CheckReachability(uint8_t *           aFrame,
-                              uint8_t             aFrameLength,
+                              uint16_t            aFrameLength,
                               const Mac::Address &aMeshSource,
                               const Mac::Address &aMeshDest);
     void    UpdateRoutes(uint8_t *           aFrame,
-                         uint8_t             aFrameLength,
+                         uint16_t            aFrameLength,
                          const Mac::Address &aMeshSource,
                          const Mac::Address &aMeshDest);
 
-    otError  GetMeshHeader(const uint8_t *&aFrame, uint8_t &aFrameLength, Lowpan::MeshHeader &aMeshHeader);
-    otError  SkipMeshHeader(const uint8_t *&aFrame, uint8_t &aFrameLength);
+    otError  GetMeshHeader(const uint8_t *&aFrame, uint16_t &aFrameLength, Lowpan::MeshHeader &aMeshHeader);
+    otError  SkipMeshHeader(const uint8_t *&aFrame, uint16_t &aFrameLength);
     otError  DecompressIp6Header(const uint8_t *     aFrame,
-                                 uint8_t             aFrameLength,
+                                 uint16_t            aFrameLength,
                                  const Mac::Address &aMacSource,
                                  const Mac::Address &aMacDest,
                                  Ip6::Header &       aIp6Header,
                                  uint8_t &           aHeaderLength,
                                  bool &              aNextHeaderCompressed);
     otError  GetIp6Header(const uint8_t *     aFrame,
-                          uint8_t             aFrameLength,
+                          uint16_t            aFrameLength,
                           const Mac::Address &aMacSource,
                           const Mac::Address &aMacDest,
                           Ip6::Header &       aIp6Header);
@@ -385,23 +385,23 @@ private:
     otError  PrepareDiscoverRequest(void);
     void     PrepareIndirectTransmission(Message &aMessage, const Child &aChild);
     void     HandleMesh(uint8_t *               aFrame,
-                        uint8_t                 aFrameLength,
+                        uint16_t                aFrameLength,
                         const Mac::Address &    aMacSource,
                         const otThreadLinkInfo &aLinkInfo);
     void     HandleFragment(uint8_t *               aFrame,
-                            uint8_t                 aFrameLength,
+                            uint16_t                aFrameLength,
                             const Mac::Address &    aMacSource,
                             const Mac::Address &    aMacDest,
                             const otThreadLinkInfo &aLinkInfo);
     void     HandleLowpanHC(uint8_t *               aFrame,
-                            uint8_t                 aFrameLength,
+                            uint16_t                aFrameLength,
                             const Mac::Address &    aMacSource,
                             const Mac::Address &    aMacDest,
                             const otThreadLinkInfo &aLinkInfo);
     void HandleDataRequest(const Mac::Frame &aFrame, const Mac::Address &aMacSource, const otThreadLinkInfo &aLinkInfo);
 
     static otError GetFragmentHeader(const uint8_t *         aFrame,
-                                     uint8_t                 aFrameLength,
+                                     uint16_t                aFrameLength,
                                      Lowpan::FragmentHeader &aFragmentHeader);
 
     void    SendMesh(Message &aMessage, Mac::Frame &aFrame);
@@ -413,7 +413,7 @@ private:
     bool    UpdateReassemblyList(void);
     bool    UpdateFragmentLifetime(void);
     void    UpdateFragmentPriority(Lowpan::FragmentHeader &aFragmentHeader,
-                                   uint8_t                 aFragmentLength,
+                                   uint16_t                aFragmentLength,
                                    uint16_t                aSrcRloc16,
                                    uint8_t                 aPriority);
     otError HandleDatagram(Message &aMessage, const otThreadLinkInfo &aLinkInfo, const Mac::Address &aMacSource);
@@ -436,13 +436,13 @@ private:
     void        ScheduleTransmissionTask(void);
 
     otError GetFramePriority(const uint8_t *     aFrame,
-                             uint8_t             aFrameLength,
+                             uint16_t            aFrameLength,
                              const Mac::Address &aMacSource,
                              const Mac::Address &aMacDest,
                              uint8_t &           aPriority);
     otError GetFragmentPriority(Lowpan::FragmentHeader &aFragmentHeader, uint16_t aSrcRloc16, uint8_t &aPriority);
     otError GetForwardFramePriority(const uint8_t *     aFrame,
-                                    uint8_t             aFrameLength,
+                                    uint16_t            aFrameLength,
                                     const Mac::Address &aMacDest,
                                     const Mac::Address &aMacSource,
                                     uint8_t &           aPriority);
@@ -455,13 +455,13 @@ private:
     void LogMessage(MessageAction aAction, const Message &aMessage, const Mac::Address *aAddress, otError aError);
     void LogFrame(const char *aActionText, const Mac::Frame &aFrame, otError aError);
     void LogFragmentFrameDrop(otError                       aError,
-                              uint8_t                       aFrameLength,
+                              uint16_t                      aFrameLength,
                               const Mac::Address &          aMacSource,
                               const Mac::Address &          aMacDest,
                               const Lowpan::FragmentHeader &aFragmentHeader,
                               bool                          aIsSecure);
     void LogLowpanHcFrameDrop(otError             aError,
-                              uint8_t             aFrameLength,
+                              uint16_t            aFrameLength,
                               const Mac::Address &aMacSource,
                               const Mac::Address &aMacDest,
                               bool                aIsSecure);

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -877,7 +877,7 @@ exit:
 }
 
 otError MeshForwarder::GetIp6Header(const uint8_t *     aFrame,
-                                    uint8_t             aFrameLength,
+                                    uint16_t            aFrameLength,
                                     const Mac::Address &aMacSource,
                                     const Mac::Address &aMacDest,
                                     Ip6::Header &       aIp6Header)
@@ -890,7 +890,7 @@ otError MeshForwarder::GetIp6Header(const uint8_t *     aFrame,
 }
 
 otError MeshForwarder::CheckReachability(uint8_t *           aFrame,
-                                         uint8_t             aFrameLength,
+                                         uint16_t            aFrameLength,
                                          const Mac::Address &aMeshSource,
                                          const Mac::Address &aMeshDest)
 {
@@ -915,7 +915,7 @@ exit:
 }
 
 void MeshForwarder::HandleMesh(uint8_t *               aFrame,
-                               uint8_t                 aFrameLength,
+                               uint16_t                aFrameLength,
                                const Mac::Address &    aMacSource,
                                const otThreadLinkInfo &aLinkInfo)
 {
@@ -995,7 +995,7 @@ exit:
 }
 
 void MeshForwarder::UpdateRoutes(uint8_t *           aFrame,
-                                 uint8_t             aFrameLength,
+                                 uint16_t            aFrameLength,
                                  const Mac::Address &aMeshSource,
                                  const Mac::Address &aMeshDest)
 {
@@ -1040,7 +1040,7 @@ bool MeshForwarder::UpdateFragmentLifetime(void)
 }
 
 void MeshForwarder::UpdateFragmentPriority(Lowpan::FragmentHeader &aFragmentHeader,
-                                           uint8_t                 aFragmentLength,
+                                           uint16_t                aFragmentLength,
                                            uint16_t                aSrcRloc16,
                                            uint8_t                 aPriority)
 {
@@ -1123,7 +1123,7 @@ exit:
 }
 
 otError MeshForwarder::GetForwardFramePriority(const uint8_t *     aFrame,
-                                               uint8_t             aFrameLength,
+                                               uint16_t            aFrameLength,
                                                const Mac::Address &aMacDest,
                                                const Mac::Address &aMacSource,
                                                uint8_t &           aPriority)


### PR DESCRIPTION
This adds support for MAC frames greater than 255 bytes in preparation
for upcoming link layers which can support such long frames.