### PR TITLE
[posix-sim] enhance microsecond alarm implementation

### DIFF
--- a/examples/platforms/posix/Makefile.platform.am
+++ b/examples/platforms/posix/Makefile.platform.am
@@ -33,3 +33,9 @@
 LDADD_COMMON                                                          += \
     $(top_builddir)/examples/platforms/posix/libopenthread-posix.a       \
     $(NULL)
+
+if OPENTHREAD_TARGET_LINUX
+LDADD_COMMON                                                          += \
+    -lrt                                                                 \
+    $(NULL)
+endif


### PR DESCRIPTION
This PR enhances the microsecond timer implementation with POSIX timer
API. This only enhances simulation on Linux because the API is not
supported on macOS.

The idea is call `timer_settime()` when schedule a microsecond procision alarm.
Linux will notify the process with the configured signal
`OPENTHREAD_CONFIG_MICRO_TIMER_SIGNAL`. The signal handler does
nothing, but the process will be waken up and the existing micro timer process
can be performed on time.