### PR TITLE
[commissioner] add error checking to GetLeaderAloc and SendPetition in Start

### DIFF
--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -154,9 +154,8 @@ otError Commissioner::Start(otCommissionerStateCallback  aStateCallback,
     mCallbackContext  = aCallbackContext;
     mTransmitAttempts = 0;
 
+    SuccessOrExit(error = SendPetition());
     SetState(OT_COMMISSIONER_STATE_PETITION);
-
-    SendPetition();
 
 exit:
     return error;
@@ -507,7 +506,7 @@ otError Commissioner::SendMgmtCommissionerGetRequest(const uint8_t *aTlvs, uint8
     }
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
-    Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr());
+    SuccessOrExit(error = Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr()));
     messageInfo.SetPeerPort(kCoapUdpPort);
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, messageInfo,
                                                         Commissioner::HandleMgmtCommissionerGetResponse, this));
@@ -604,7 +603,7 @@ otError Commissioner::SendMgmtCommissionerSetRequest(const otCommissioningDatase
     }
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
-    Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr());
+    SuccessOrExit(error = Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr()));
     messageInfo.SetPeerPort(kCoapUdpPort);
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, messageInfo,
                                                         Commissioner::HandleMgmtCommissionerSetResponse, this));
@@ -662,7 +661,7 @@ otError Commissioner::SendPetition(void)
 
     SuccessOrExit(error = message->AppendTlv(commissionerId));
 
-    Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr());
+    SuccessOrExit(error = Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr()));
     messageInfo.SetPeerPort(kCoapUdpPort);
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     SuccessOrExit(
@@ -759,7 +758,7 @@ otError Commissioner::SendKeepAlive(void)
     SuccessOrExit(error = message->AppendTlv(sessionId));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
-    Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr());
+    SuccessOrExit(error = Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr()));
     messageInfo.SetPeerPort(kCoapUdpPort);
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, messageInfo,
                                                         Commissioner::HandleLeaderKeepAliveResponse, this));


### PR DESCRIPTION
Adding the SendPetition error handling in Start and moving it before updating the state fixes
the potential issue of locking up the commissioner in the OT_COMMISSIONER_STATE_PETITION
state without having actually sent the petition.