### PR TITLE
[posix-app] enhance RCP failure info

### DIFF
--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -171,8 +171,8 @@ void HdlcInterface::Deinit(void)
 {
     VerifyOrExit(mSockFd != -1);
 
-    VerifyOrExit(0 == close(mSockFd), perror("close NCP"));
-    VerifyOrExit(-1 != wait(NULL), perror("wait NCP"));
+    VerifyOrExit(0 == close(mSockFd), perror("close RCP"));
+    VerifyOrExit(-1 != wait(NULL) || errno == ECHILD, perror("wait RCP"));
 
     mSockFd = -1;
 

--- a/src/posix/platform/misc.c
+++ b/src/posix/platform/misc.c
@@ -112,6 +112,8 @@ void SuccessOrDie(otError aError)
     }
 
     otLogCritPlat("Error: %s", otThreadErrorToString(aError));
+    // For better user experience.
+    fprintf(stderr, "Error: %s\r\n", otThreadErrorToString(aError));
     exit(exitCode);
 }
 


### PR DESCRIPTION
POSIX-app by default disables logs to platform region and even enabled
logs are handled by syslog without printing to stderr. This PR prints
the error information to stderr at exit so that user may know what
happens.

This PR also eliminates the failure message of wait for no child
process exists.

