### PR TITLE
[indirect-sender] new design for indirect tx and handling of data polls

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -191,6 +191,7 @@ LOCAL_SRC_FILES                                          := \
     src/core/thread/announce_sender.cpp                     \
     src/core/thread/child_table.cpp                         \
     src/core/thread/energy_scan_server.cpp                  \
+    src/core/thread/indirect_sender.cpp                     \
     src/core/thread/key_manager.cpp                         \
     src/core/thread/link_quality.cpp                        \
     src/core/thread/lowpan.cpp                              \

--- a/Android.mk
+++ b/Android.mk
@@ -152,6 +152,7 @@ LOCAL_SRC_FILES                                          := \
     src/core/crypto/pbkdf2_cmac.cpp                         \
     src/core/crypto/sha256.cpp                              \
     src/core/mac/channel_mask.cpp                           \
+    src/core/mac/data_poll_handler.cpp                      \
     src/core/mac/data_poll_sender.cpp                       \
     src/core/mac/mac.cpp                                    \
     src/core/mac/mac_filter.cpp                             \

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -197,6 +197,7 @@ SOURCES_COMMON                      = \
     thread/announce_sender.cpp        \
     thread/child_table.cpp            \
     thread/energy_scan_server.cpp     \
+    thread/indirect_sender.cpp        \
     thread/key_manager.cpp            \
     thread/link_quality.cpp           \
     thread/lowpan.cpp                 \
@@ -364,6 +365,7 @@ HEADERS_COMMON                      = \
     thread/announce_sender.hpp        \
     thread/child_table.hpp            \
     thread/energy_scan_server.hpp     \
+    thread/indirect_sender.hpp        \
     thread/key_manager.hpp            \
     thread/link_quality.hpp           \
     thread/lowpan.hpp                 \

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -156,6 +156,7 @@ SOURCES_COMMON                      = \
     crypto/pbkdf2_cmac.cpp            \
     crypto/sha256.cpp                 \
     mac/channel_mask.cpp              \
+    mac/data_poll_handler.cpp         \
     mac/data_poll_sender.cpp          \
     mac/link_raw.cpp                  \
     mac/mac.cpp                       \
@@ -322,6 +323,7 @@ HEADERS_COMMON                      = \
     crypto/pbkdf2_cmac.h              \
     crypto/sha256.hpp                 \
     mac/channel_mask.hpp              \
+    mac/data_poll_handler.hpp         \
     mac/data_poll_sender.hpp          \
     mac/link_raw.hpp                  \
     mac/mac.hpp                       \

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -35,6 +35,7 @@
 
 #include <string.h>
 #include <openthread/diag.h>
+#include <openthread/thread.h>
 #include <openthread/platform/diag.h>
 
 #include "common/debug.hpp"

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -458,9 +458,14 @@ template <> inline Ip6::Filter &Instance::Get(void)
 }
 
 #if OPENTHREAD_FTD
+template <> inline IndirectSender &Instance::Get(void)
+{
+    return mThreadNetif.mMeshForwarder.mIndirectSender;
+}
+
 template <> inline SourceMatchController &Instance::Get(void)
 {
-    return mThreadNetif.mMeshForwarder.mSourceMatchController;
+    return mThreadNetif.mMeshForwarder.mIndirectSender.mSourceMatchController;
 }
 
 template <> inline AddressResolver &Instance::Get(void)

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -458,6 +458,7 @@ template <> inline Ip6::Filter &Instance::Get(void)
 }
 
 #if OPENTHREAD_FTD
+
 template <> inline IndirectSender &Instance::Get(void)
 {
     return mThreadNetif.mMeshForwarder.mIndirectSender;
@@ -466,6 +467,11 @@ template <> inline IndirectSender &Instance::Get(void)
 template <> inline SourceMatchController &Instance::Get(void)
 {
     return mThreadNetif.mMeshForwarder.mIndirectSender.mSourceMatchController;
+}
+
+template <> inline DataPollHandler &Instance::Get(void)
+{
+    return mThreadNetif.mMeshForwarder.mIndirectSender.mDataPollHandler;
 }
 
 template <> inline AddressResolver &Instance::Get(void)

--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -1,0 +1,315 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes the implementation for handling of data polls and indirect frame transmission.
+ */
+
+#if OPENTHREAD_FTD
+
+#include "data_poll_handler.hpp"
+
+#include "common/code_utils.hpp"
+#include "common/instance.hpp"
+#include "common/locator-getters.hpp"
+#include "common/logging.hpp"
+
+namespace ot {
+
+DataPollHandler::Callbacks::Callbacks(Instance &aInstance)
+    : InstanceLocator(aInstance)
+{
+}
+
+inline otError DataPollHandler::Callbacks::PrepareFrameForChild(Mac::Frame &aFrame, Child &aChild)
+{
+    return Get<IndirectSender>().PrepareFrameForChild(aFrame, aChild);
+}
+
+inline void DataPollHandler::Callbacks::HandleSentFrameToChild(const Mac::Frame &aFrame, otError aError, Child &aChild)
+{
+    Get<IndirectSender>().HandleSentFrameToChild(aFrame, aError, aChild);
+}
+
+inline void DataPollHandler::Callbacks::HandleFrameChangeDone(Child &aChild)
+{
+    Get<IndirectSender>().HandleFrameChangeDone(aChild);
+}
+
+//---------------------------------------------------------
+
+DataPollHandler::DataPollHandler(Instance &aInstance)
+    : InstanceLocator(aInstance)
+    , mIndirectTxChild(NULL)
+    , mCallbacks(aInstance)
+{
+}
+
+void DataPollHandler::Clear(void)
+{
+    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
+    {
+        Child &child = *iter.GetChild();
+        child.SetDataPollPending(false);
+        child.SetFrameReplacePending(false);
+        child.SetFramePurgePending(false);
+        child.ResetIndirectTxAttempts();
+    }
+
+    mIndirectTxChild = NULL;
+}
+
+void DataPollHandler::HandleNewFrame(Child &aChild)
+{
+    OT_UNUSED_VARIABLE(aChild);
+
+    // There is no need to take any action with current data poll
+    // handler implementation, since the preparation of the frame
+    // happens after receiving of a data poll from the child. This
+    // method is included for use by other data poll handler models
+    // (e.g., in RCP/host model if the handling of data polls is
+    // delegated to RCP).
+}
+
+void DataPollHandler::RequestFrameChange(FrameChange aChange, Child &aChild)
+{
+    if ((mIndirectTxChild == &aChild) && Get<Mac::Mac>().IsPerformingIndirectTransmit())
+    {
+        switch (aChange)
+        {
+        case kReplaceFrame:
+            aChild.SetFrameReplacePending(true);
+            break;
+
+        case kPurgeFrame:
+            aChild.SetFramePurgePending(true);
+            break;
+        }
+    }
+    else
+    {
+        mCallbacks.HandleFrameChangeDone(aChild);
+    }
+}
+
+void DataPollHandler::HandleDataPoll(Mac::Frame &aFrame)
+{
+    Mac::Address macSource;
+    Child *      child;
+    uint16_t     indirectMsgCount;
+
+    VerifyOrExit(aFrame.GetSecurityEnabled());
+    VerifyOrExit(Get<Mle::MleRouter>().GetRole() != OT_DEVICE_ROLE_DETACHED);
+
+    SuccessOrExit(aFrame.GetSrcAddr(macSource));
+    child = Get<ChildTable>().FindChild(macSource, ChildTable::kInStateValidOrRestoring);
+    VerifyOrExit(child != NULL);
+
+    child->SetLastHeard(TimerMilli::GetNow());
+    child->ResetLinkFailures();
+    indirectMsgCount = child->GetIndirectMessageCount();
+
+    otLogInfoMac("Rx data poll, src:0x%04x, qed_msgs:%d, rss:%d, ack-fp:%d", child->GetRloc16(), indirectMsgCount,
+                 aFrame.GetRssi(), aFrame.IsAckedWithFramePending());
+
+    if (!aFrame.IsAckedWithFramePending())
+    {
+        if ((indirectMsgCount > 0) && macSource.IsShort())
+        {
+            Get<SourceMatchController>().SetSrcMatchAsShort(*child, true);
+        }
+
+        ExitNow();
+    }
+
+    VerifyOrExit(!Get<SourceMatchController>().IsEnabled() || (indirectMsgCount > 0));
+
+    if (mIndirectTxChild == NULL)
+    {
+        mIndirectTxChild = child;
+        Get<Mac::Mac>().RequestIndirectFrameTransmission();
+    }
+    else
+    {
+        child->SetDataPollPending(true);
+    }
+
+exit:
+    return;
+}
+
+otError DataPollHandler::HandleFrameRequest(Mac::Frame &aFrame)
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(mIndirectTxChild != NULL, error = OT_ERROR_ABORT);
+
+    SuccessOrExit(error = mCallbacks.PrepareFrameForChild(aFrame, *mIndirectTxChild));
+
+    if (mIndirectTxChild->GetIndirectTxAttempts() > 0)
+    {
+        // For a re-transmission of an indirect frame to a sleepy
+        // child, we ensure to use the same frame counter, key id, and
+        // data sequence number as the previous attempt.
+
+        aFrame.SetIsARetransmission(true);
+        aFrame.SetSequence(mIndirectTxChild->GetIndirectDataSequenceNumber());
+
+        if (aFrame.GetSecurityEnabled())
+        {
+            aFrame.SetFrameCounter(mIndirectTxChild->GetIndirectFrameCounter());
+            aFrame.SetKeyId(mIndirectTxChild->GetIndirectKeyId());
+        }
+    }
+    else
+    {
+        aFrame.SetIsARetransmission(false);
+    }
+
+exit:
+    return error;
+}
+
+void DataPollHandler::HandleSentFrame(const Mac::Frame &aFrame, otError aError)
+{
+    Child *child = mIndirectTxChild;
+
+    VerifyOrExit(child != NULL);
+
+    mIndirectTxChild = NULL;
+    HandleSentFrame(aFrame, aError, *child);
+
+exit:
+    ProcessPendingPolls();
+}
+
+void DataPollHandler::HandleSentFrame(const Mac::Frame &aFrame, otError aError, Child &aChild)
+{
+    if (aChild.IsFramePurgePending())
+    {
+        aChild.SetFramePurgePending(false);
+        aChild.SetFrameReplacePending(false);
+        aChild.ResetIndirectTxAttempts();
+        mCallbacks.HandleFrameChangeDone(aChild);
+        ExitNow();
+    }
+
+    switch (aError)
+    {
+    case OT_ERROR_NONE:
+        aChild.ResetIndirectTxAttempts();
+        aChild.SetFrameReplacePending(false);
+        break;
+
+    case OT_ERROR_NO_ACK:
+        aChild.IncrementIndirectTxAttempts();
+
+        // Fall through
+
+    case OT_ERROR_CHANNEL_ACCESS_FAILURE:
+    case OT_ERROR_ABORT:
+
+        if (aChild.IsFrameReplacePending())
+        {
+            aChild.SetFrameReplacePending(false);
+            aChild.ResetIndirectTxAttempts();
+            mCallbacks.HandleFrameChangeDone(aChild);
+            ExitNow();
+        }
+
+        otLogInfoMac("Indirect tx to child %04x failed, attempt %d/%d, error:%s", aChild.GetRloc16(),
+                     aChild.GetIndirectTxAttempts(), kMaxPollTriggeredTxAttempts, otThreadErrorToString(aError));
+
+        if (aChild.GetIndirectTxAttempts() < kMaxPollTriggeredTxAttempts)
+        {
+            // We save the frame counter, key id, and data sequence number of
+            // current frame so we use the same values for the retransmission
+            // of the frame following the receipt of the next data poll.
+
+            aChild.SetIndirectDataSequenceNumber(aFrame.GetSequence());
+
+            if (aFrame.GetSecurityEnabled())
+            {
+                uint32_t frameCounter;
+                uint8_t  keyId;
+
+                aFrame.GetFrameCounter(frameCounter);
+                aChild.SetIndirectFrameCounter(frameCounter);
+
+                aFrame.GetKeyId(keyId);
+                aChild.SetIndirectKeyId(keyId);
+            }
+
+            ExitNow();
+        }
+
+        aChild.ResetIndirectTxAttempts();
+        break;
+
+    default:
+        assert(false);
+        break;
+    }
+
+    mCallbacks.HandleSentFrameToChild(aFrame, aError, aChild);
+
+exit:
+    return;
+}
+
+void DataPollHandler::ProcessPendingPolls(void)
+{
+    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValidOrRestoring); !iter.IsDone(); iter++)
+    {
+        Child *child = iter.GetChild();
+
+        if (!child->IsDataPollPending())
+        {
+            continue;
+        }
+
+        // Find the child with earliest poll receive time.
+
+        if ((mIndirectTxChild == NULL) ||
+            TimerScheduler::IsStrictlyBefore(child->GetLastHeard(), mIndirectTxChild->GetLastHeard()))
+        {
+            mIndirectTxChild = child;
+        }
+    }
+
+    if (mIndirectTxChild != NULL)
+    {
+        mIndirectTxChild->SetDataPollPending(false);
+        Get<Mac::Mac>().RequestIndirectFrameTransmission();
+    }
+}
+
+} // namespace ot
+
+#endif // #if OPENTHREAD_FTD

--- a/src/core/mac/data_poll_handler.hpp
+++ b/src/core/mac/data_poll_handler.hpp
@@ -1,0 +1,263 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for handling of data polls and indirect frame transmission.
+ */
+
+#ifndef DATA_POLL_HANDLER_HPP_
+#define DATA_POLL_HANDLER_HPP_
+
+#include "openthread-core-config.h"
+
+#include "common/code_utils.hpp"
+#include "common/locator.hpp"
+#include "common/timer.hpp"
+#include "mac/mac.hpp"
+#include "mac/mac_frame.hpp"
+
+namespace ot {
+
+/**
+ * @addtogroup core-data-poll-handler
+ *
+ * @brief
+ *   This module includes definitions for data poll handler.
+ *
+ * @{
+ */
+
+class Child;
+
+/**
+ * This class implements the data poll (mac data request command) handler.
+ *
+ */
+class DataPollHandler : public InstanceLocator
+{
+    friend class Mac::Mac;
+
+public:
+    enum
+    {
+        kMaxPollTriggeredTxAttempts = OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_POLLS,
+    };
+
+    /**
+     * This enumeration defines frame change request types used as input to `RequestFrameChange()`.
+     *
+     */
+    enum FrameChange
+    {
+        kPurgeFrame,   ///< Indicates that previous frame should be purged. Any ongoing indirect tx should be aborted.
+        kReplaceFrame, ///< Indicates that previous frame needs to be replaced with a new higher priority one.
+    };
+
+    /**
+     * This class defines all the child info required for handling of data polls and indirect frame transmissions.
+     *
+     * `Child` class publicly inherits from this class.
+     *
+     */
+    class ChildInfo
+    {
+        friend class DataPollHandler;
+
+    private:
+        bool IsDataPollPending(void) const { return mDataPollPending; }
+        void SetDataPollPending(bool aPending) { mDataPollPending = aPending; }
+
+        uint32_t GetIndirectFrameCounter(void) const { return mIndirectFrameCounter; }
+        void     SetIndirectFrameCounter(uint32_t aFrameCounter) { mIndirectFrameCounter = aFrameCounter; }
+
+        uint8_t GetIndirectKeyId(void) const { return mIndirectKeyId; }
+        void    SetIndirectKeyId(uint8_t aKeyId) { mIndirectKeyId = aKeyId; }
+
+        uint8_t GetIndirectTxAttempts(void) const { return mIndirectTxAttempts; }
+        void    SetIndirectTxAttemptsToMax(void) { mIndirectTxAttempts = kMaxPollTriggeredTxAttempts; }
+        void    ResetIndirectTxAttempts(void) { mIndirectTxAttempts = 0; }
+        void    IncrementIndirectTxAttempts(void) { mIndirectTxAttempts++; }
+
+        uint8_t GetIndirectDataSequenceNumber(void) const { return mIndirectDsn; }
+        void    SetIndirectDataSequenceNumber(uint8_t aDsn) { mIndirectDsn = aDsn; }
+
+        bool IsFramePurgePending(void) const { return mFramePurgePending; }
+        void SetFramePurgePending(bool aPurgePending) { mFramePurgePending = aPurgePending; }
+
+        bool IsFrameReplacePending(void) const { return mFrameReplacePending; }
+        void SetFrameReplacePending(bool aReplacePending) { mFrameReplacePending = aReplacePending; }
+
+        uint32_t mIndirectFrameCounter;    // Frame counter for current indirect frame (used for retx).
+        uint8_t  mIndirectKeyId;           // Key Id for current indirect frame (used for retx).
+        uint8_t  mIndirectDsn;             // MAC level Data Sequence Number (DSN) for retx attempts.
+        uint8_t  mIndirectTxAttempts : 5;  // Number of data poll triggered tx attempts.
+        bool     mDataPollPending : 1;     // Indicates whether or not a Data Poll was received.
+        bool     mFramePurgePending : 1;   // Indicates a pending purge request for the current indirect frame.
+        bool     mFrameReplacePending : 1; // Indicates a pending replace request for the current indirect frame.
+
+        OT_STATIC_ASSERT(kMaxPollTriggeredTxAttempts < (1 << 5), "mIndirectTxAttempts cannot fit max!");
+    };
+
+    /**
+     * This class defines the callbacks used by the `DataPollHandler`.
+     *
+     */
+    class Callbacks : public InstanceLocator
+    {
+        friend class DataPollHandler;
+
+    private:
+        /**
+         * This constructor initializes the data poll handler object.
+         *
+         * @param[in]  aInstance   A reference to the OpenThread instance.
+         *
+         */
+        explicit Callbacks(Instance &aInstance);
+
+        /**
+         * This callback method requests a frame to be prepared for indirect transmission to a given sleepy child.
+         *
+         * @param[in] aFrame  A reference to a MAC frame where the new frame would be placed.
+         * @param[in] aChild  The child for which to prepare the frame.
+         *
+         * @retval OT_ERROR_NONE   Frame was prepared successfully
+         * @retval OT_ERROR_ABORT  Indirect transmission to child should be aborted (no frame for the child).
+         *
+         */
+        otError PrepareFrameForChild(Mac::Frame &aFrame, Child &aChild);
+
+        /**
+         * This callback method notifies the end of indirect frame transmission to a child.
+         *
+         * @param[in]  aFrame     The transmitted frame.
+         * @param[in]  aError     OT_ERROR_NONE when the frame was transmitted successfully,
+         *                        OT_ERROR_NO_ACK when the frame was transmitted but no ACK was received,
+         *                        OT_ERROR_CHANNEL_ACCESS_FAILURE tx failed due to activity on the channel,
+         *                        OT_ERROR_ABORT when transmission was aborted for other reasons.
+         * @param[in]  aChild     The child to which the frame was transmitted.
+         *
+         */
+        void HandleSentFrameToChild(const Mac::Frame &aFrame, otError aError, Child &aChild);
+
+        /**
+         * This callback method notifies that a requested frame change from `RequestFrameChange()` is processed.
+         *
+         * This callback indicates to the next layer that the indirect frame/message for the child can be safely
+         * updated.
+         *
+         * @param[in]  aChild     The child to update.
+         *
+         */
+        void HandleFrameChangeDone(Child &aChild);
+    };
+
+    /**
+     * This constructor initializes the data poll handler object.
+     *
+     * @param[in]  aInstance   A reference to the OpenThread instance.
+     *
+     */
+    explicit DataPollHandler(Instance &aInstance);
+
+    /**
+     * This method clears any state/info saved per child for indirect frame transmission.
+     *
+     */
+    void Clear(void);
+
+    /**
+     * This method informs data poll handler that there is a new frame for a given child.
+     *
+     * After this call, the data poll handler can use the `Callbacks::PrepareFrameForChild()` method to request the
+     * frame to be prepared. A subsequent call to `Callbacks::PrepareFrameForChild()` should ensure to prepare the same
+     * frame (this is used for retransmissions of frame by data poll handler). If/When the frame transmission is
+     * finished, the data poll handler will invoke the `Callbacks::HandleSentFrameToChild()` to indicate the status of
+     * the frame transmission.
+     *
+     * @param[in]  aChild     The child which has a new frame.
+     *
+     */
+    void HandleNewFrame(Child &aChild);
+
+    /**
+     * This method requests a frame change for a given child.
+     *
+     * Two types of frame change requests are supported:
+     *
+     * 1) "Purge Frame" which indicates that the previous frame should be purged and any ongoing indirect tx aborted.
+     * 2) "Replace Frame" which indicates that the previous frame needs to be replaced with a new higher priority one.
+     *
+     * If there is no ongoing indirect frame transmission to the child, the request will be handled immediately and the
+     * callback `HandleFrameChangeDone()` is called directly from this method itself. This callback notifies the next
+     * layer that the indirect frame/message for the child can be safely updated.
+     *
+     * If there is an ongoing indirect frame transmission to this child, the request can not be handled immediately.
+     * The following options can happen based on the request type:
+     *
+     * 1) In case of "purge" request, the ongoing indirect transmission is aborted and upon completion of the abort the
+     *    callback `HandleFrameChangeDone()` is invoked.
+     *
+     * 2) In case of "replace" request, the ongoing indirect transmission is allowed to finish (current tx attempt).
+     *    2.a) If the tx attempt is successful, the `Callbacks::HandleSentFrameToChild()` in invoked which indicates
+     *         the "replace" could not happen (in this case the `HandleFrameChangeDone()` is no longer called).
+     *    2.b) If the ongoing tx attempt is unsuccessful, then callback `HandleFrameChangeDone()` is invoked to allow
+     *         the next layer to update the frame/message for the child.
+     *
+     * If there is a pending request, a subsequent call to this method is ignored except for the case where pending
+     * request is for "replace frame" and new one is for "purge frame" where the "purge" overrides the "replace"
+     * request.
+     *
+     * @param[in]  aChange    The frame change type.
+     * @param[in]  aChild     The child to process its frame change.
+     *
+     */
+    void RequestFrameChange(FrameChange aChange, Child &aChild);
+
+private:
+    // Callbacks from MAC
+    void    HandleDataPoll(Mac::Frame &aFrame);
+    otError HandleFrameRequest(Mac::Frame &aFrame);
+    void    HandleSentFrame(const Mac::Frame &aFrame, otError aError);
+
+    void HandleSentFrame(const Mac::Frame &aFrame, otError aError, Child &aChild);
+    void ProcessPendingPolls(void);
+
+    Child *   mIndirectTxChild;
+    Callbacks mCallbacks;
+};
+
+/**
+ * @}
+ *
+ */
+
+} // namespace ot
+
+#endif // DATA_POLL_HANDLER_HPP_

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -48,9 +48,10 @@
 #include "mac/sub_mac.hpp"
 #include "thread/key_manager.hpp"
 #include "thread/link_quality.hpp"
-#include "thread/topology.hpp"
 
 namespace ot {
+
+class Neighbor;
 
 /**
  * @addtogroup core-mac
@@ -496,6 +497,16 @@ public:
      */
     bool IsEnergyScanInProgress(void) const { return (mOperation == kOperationEnergyScan) || (mPendingEnergyScan); }
 
+#if OPENTHREAD_FTD
+    /**
+     * This method indicates whether the MAC layer is performing an indirect transmission (in middle of a tx).
+     *
+     * @returns TRUE if in middle of an indirect transmission, FALSE otherwise.
+     *
+     */
+    bool IsPerformingIndirectTransmit(void) const { return (mOperation == kOperationTransmitDataIndirect); }
+#endif
+
     /**
      * This method returns if the MAC layer is in transmit state.
      *
@@ -649,7 +660,7 @@ private:
     void    PrepareBeacon(Frame &aFrame);
     bool    ShouldSendBeacon(void) const;
     void    BeginTransmit(void);
-    otError HandleMacCommand(Frame &aFrame);
+    bool    HandleMacCommand(Frame &aFrame);
     Frame * GetOperationFrame(void);
 
     static void HandleTimer(Timer &aTimer);

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -208,14 +208,26 @@ public:
     void SetRxOnWhenIdle(bool aRxOnWhenIdle);
 
     /**
-     * This method requests a new MAC frame transmission.
+     * This method requests a direct data frame transmission.
      *
      * @retval OT_ERROR_NONE           Frame transmission request is scheduled successfully.
      * @retval OT_ERROR_ALREADY        MAC is busy sending earlier transmission request.
      * @retval OT_ERROR_INVALID_STATE  The MAC layer is not enabled.
      *
      */
-    otError RequestFrameTransmission(void);
+    otError RequestDirectFrameTransmission(void);
+
+#if OPENTHREAD_FTD
+    /**
+     * This method requests an indirect data frame transmission.
+     *
+     * @retval OT_ERROR_NONE           Frame transmission request is scheduled successfully.
+     * @retval OT_ERROR_ALREADY        MAC is busy sending earlier transmission request.
+     * @retval OT_ERROR_INVALID_STATE  The MAC layer is not enabled.
+     *
+     */
+    otError RequestIndirectFrameTransmission(void);
+#endif
 
     /**
      * This method requests an Out of Band frame for MAC Transmission.
@@ -600,7 +612,10 @@ private:
         kOperationActiveScan,
         kOperationEnergyScan,
         kOperationTransmitBeacon,
-        kOperationTransmitData,
+        kOperationTransmitDataDirect,
+#if OPENTHREAD_FTD
+        kOperationTransmitDataIndirect,
+#endif
         kOperationTransmitPoll,
         kOperationWaitingForData,
         kOperationTransmitOutOfBandFrame,
@@ -662,7 +677,10 @@ private:
     bool mPendingActiveScan : 1;
     bool mPendingEnergyScan : 1;
     bool mPendingTransmitBeacon : 1;
-    bool mPendingTransmitData : 1;
+    bool mPendingTransmitDataDirect : 1;
+#if OPENTHREAD_FTD
+    bool mPendingTransmitDataIndirect : 1;
+#endif
     bool mPendingTransmitPoll : 1;
     bool mPendingTransmitOobFrame : 1;
     bool mPendingWaitingForData : 1;

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -45,6 +45,20 @@
 
 namespace ot {
 
+const Mac::Address &IndirectSender::ChildInfo::GetMacAddress(Mac::Address &aMacAddress) const
+{
+    if (mUseShortAddress)
+    {
+        aMacAddress.SetShort(static_cast<const Child *>(this)->GetRloc16());
+    }
+    else
+    {
+        aMacAddress.SetExtended(static_cast<const Child *>(this)->GetExtAddress());
+    }
+
+    return aMacAddress;
+}
+
 IndirectSender::IndirectSender(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mEnabled(false)

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -150,6 +150,16 @@ exit:
     return;
 }
 
+otError IndirectSender::HandleFrameRequest(Mac::Frame &aFrame)
+{
+    return Get<MeshForwarder>().HandleFrameRequest(aFrame);
+}
+
+void IndirectSender::HandleSentFrame(Mac::Frame &aFrame, otError aError)
+{
+    Get<MeshForwarder>().HandleSentFrame(aFrame, aError);
+}
+
 void IndirectSender::HandleDataPoll(const Mac::Frame &      aFrame,
                                     const Mac::Address &    aMacSource,
                                     const otThreadLinkInfo &aLinkInfo)
@@ -200,9 +210,7 @@ otError IndirectSender::GetIndirectTransmission(void)
             continue;
         }
 
-        Get<MeshForwarder>().mSendMessage                = child.GetIndirectMessage();
-        Get<MeshForwarder>().mSendMessageMaxCsmaBackoffs = Mac::kMaxCsmaBackoffsIndirect;
-        Get<MeshForwarder>().mSendMessageMaxFrameRetries = Mac::kMaxFrameRetriesIndirect;
+        Get<MeshForwarder>().mSendMessage = child.GetIndirectMessage();
 
         if (Get<MeshForwarder>().mSendMessage == NULL)
         {
@@ -234,7 +242,7 @@ otError IndirectSender::GetIndirectTransmission(void)
 
         mIndirectStartingChild = &child;
 
-        Get<Mac::Mac>().RequestFrameTransmission();
+        Get<Mac::Mac>().RequestIndirectFrameTransmission();
         ExitNow(error = OT_ERROR_NONE);
     }
 

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -1,0 +1,500 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for handling indirect transmission.
+ */
+
+#if OPENTHREAD_FTD
+
+#include "indirect_sender.hpp"
+
+#include "common/code_utils.hpp"
+#include "common/instance.hpp"
+#include "common/locator-getters.hpp"
+#include "common/logging.hpp"
+#include "common/message.hpp"
+#include "thread/mesh_forwarder.hpp"
+#include "thread/topology.hpp"
+
+namespace ot {
+
+IndirectSender::IndirectSender(Instance &aInstance)
+    : InstanceLocator(aInstance)
+    , mEnabled(false)
+    , mSourceMatchController(aInstance)
+    , mIndirectStartingChild(NULL)
+{
+}
+
+void IndirectSender::Stop(void)
+{
+    VerifyOrExit(mEnabled);
+
+    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
+    {
+        iter.GetChild()->SetIndirectMessage(NULL);
+        mSourceMatchController.ResetMessageCount(*iter.GetChild());
+    }
+
+    mIndirectStartingChild = NULL;
+
+exit:
+    mEnabled = false;
+}
+
+otError IndirectSender::AddMessageForSleepyChild(Message &aMessage, Child &aChild)
+{
+    otError error = OT_ERROR_NONE;
+    uint8_t childIndex;
+
+    VerifyOrExit(!aChild.IsRxOnWhenIdle(), error = OT_ERROR_INVALID_STATE);
+
+    childIndex = Get<ChildTable>().GetChildIndex(aChild);
+    VerifyOrExit(!aMessage.GetChildMask(childIndex), error = OT_ERROR_ALREADY);
+
+    aMessage.SetChildMask(childIndex);
+    mSourceMatchController.IncrementMessageCount(aChild);
+
+exit:
+    return error;
+}
+
+otError IndirectSender::RemoveMessageFromSleepyChild(Message &aMessage, Child &aChild)
+{
+    otError error      = OT_ERROR_NONE;
+    uint8_t childIndex = Get<ChildTable>().GetChildIndex(aChild);
+
+    VerifyOrExit(aMessage.GetChildMask(childIndex), error = OT_ERROR_NOT_FOUND);
+
+    aMessage.ClearChildMask(childIndex);
+    mSourceMatchController.DecrementMessageCount(aChild);
+
+    if (aChild.GetIndirectMessage() == &aMessage)
+    {
+        aChild.SetIndirectMessage(NULL);
+    }
+
+exit:
+    return error;
+}
+
+void IndirectSender::ClearAllMessagesForSleepyChild(Child &aChild)
+{
+    Message *nextMessage;
+
+    VerifyOrExit(aChild.GetIndirectMessageCount() > 0);
+
+    for (Message *message = Get<MeshForwarder>().mSendQueue.GetHead(); message; message = nextMessage)
+    {
+        nextMessage = message->GetNext();
+
+        message->ClearChildMask(Get<ChildTable>().GetChildIndex(aChild));
+
+        if (!message->IsChildPending() && !message->GetDirectTransmission())
+        {
+            if (Get<MeshForwarder>().mSendMessage == message)
+            {
+                Get<MeshForwarder>().mSendMessage = NULL;
+            }
+
+            Get<MeshForwarder>().mSendQueue.Dequeue(*message);
+            message->Free();
+        }
+    }
+
+    aChild.SetIndirectMessage(NULL);
+    mSourceMatchController.ResetMessageCount(aChild);
+
+exit:
+    return;
+}
+
+void IndirectSender::HandleDataPoll(const Mac::Frame &      aFrame,
+                                    const Mac::Address &    aMacSource,
+                                    const otThreadLinkInfo &aLinkInfo)
+{
+    Child *  child;
+    uint16_t indirectMsgCount;
+
+    // Security Check: only process secure Data Poll frames.
+    VerifyOrExit(aLinkInfo.mLinkSecurity);
+
+    VerifyOrExit(Get<Mle::MleRouter>().GetRole() != OT_DEVICE_ROLE_DETACHED);
+
+    child = Get<ChildTable>().FindChild(aMacSource, ChildTable::kInStateValidOrRestoring);
+    VerifyOrExit(child != NULL);
+
+    child->SetLastHeard(TimerMilli::GetNow());
+    child->ResetLinkFailures();
+    indirectMsgCount = child->GetIndirectMessageCount();
+
+    otLogInfoMac("Rx data poll, src:0x%04x, qed_msgs:%d, rss:%d, ack-fp:%d", child->GetRloc16(), indirectMsgCount,
+                 aLinkInfo.mRss, aFrame.IsAckedWithFramePending());
+    VerifyOrExit(aFrame.IsAckedWithFramePending());
+
+    if (!mSourceMatchController.IsEnabled() || (indirectMsgCount > 0))
+    {
+        child->SetDataRequestPending(true);
+    }
+
+    Get<MeshForwarder>().mScheduleTransmissionTask.Post();
+
+exit:
+    return;
+}
+
+otError IndirectSender::GetIndirectTransmission(void)
+{
+    otError error = OT_ERROR_NOT_FOUND;
+
+    UpdateIndirectMessages();
+
+    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValidOrRestoring, mIndirectStartingChild);
+         !iter.IsDone(); iter++)
+    {
+        Child &child = *iter.GetChild();
+
+        if (!child.IsDataRequestPending())
+        {
+            continue;
+        }
+
+        Get<MeshForwarder>().mSendMessage                = child.GetIndirectMessage();
+        Get<MeshForwarder>().mSendMessageMaxCsmaBackoffs = Mac::kMaxCsmaBackoffsIndirect;
+        Get<MeshForwarder>().mSendMessageMaxFrameRetries = Mac::kMaxFrameRetriesIndirect;
+
+        if (Get<MeshForwarder>().mSendMessage == NULL)
+        {
+            Get<MeshForwarder>().mSendMessage = GetIndirectTransmission(child);
+        }
+
+        if (Get<MeshForwarder>().mSendMessage != NULL)
+        {
+            PrepareIndirectTransmission(*Get<MeshForwarder>().mSendMessage, child);
+        }
+        else
+        {
+            // A NULL `mSendMessage` triggers an empty frame to be sent to the child.
+
+            if (child.IsIndirectSourceMatchShort())
+            {
+                Get<MeshForwarder>().mMacSource.SetShort(Get<Mac::Mac>().GetShortAddress());
+            }
+            else
+            {
+                Get<MeshForwarder>().mMacSource.SetExtended(Get<Mac::Mac>().GetExtAddress());
+            }
+
+            child.GetMacAddress(Get<MeshForwarder>().mMacDest);
+        }
+
+        // Remember the current child and move it to next one in the
+        // list after the indirect transmission has completed.
+
+        mIndirectStartingChild = &child;
+
+        Get<Mac::Mac>().RequestFrameTransmission();
+        ExitNow(error = OT_ERROR_NONE);
+    }
+
+exit:
+    return error;
+}
+
+Message *IndirectSender::GetIndirectTransmission(Child &aChild)
+{
+    Message *message = NULL;
+    Message *next;
+    uint8_t  childIndex = Get<ChildTable>().GetChildIndex(aChild);
+
+    for (message = Get<MeshForwarder>().mSendQueue.GetHead(); message; message = next)
+    {
+        next = message->GetNext();
+
+        if (message->GetChildMask(childIndex))
+        {
+            // Skip and remove the supervision message if there are other messages queued for the child.
+
+            if ((message->GetType() == Message::kTypeSupervision) && (aChild.GetIndirectMessageCount() > 1))
+            {
+                message->ClearChildMask(childIndex);
+                mSourceMatchController.DecrementMessageCount(aChild);
+                Get<MeshForwarder>().mSendQueue.Dequeue(*message);
+                message->Free();
+                continue;
+            }
+
+            break;
+        }
+    }
+
+    aChild.SetIndirectMessage(message);
+    aChild.SetIndirectFragmentOffset(0);
+    aChild.ResetIndirectTxAttempts();
+    aChild.SetIndirectTxSuccess(true);
+
+    if (message != NULL)
+    {
+        Mac::Address macAddr;
+
+        Get<MeshForwarder>().LogMessage(MeshForwarder::kMessagePrepareIndirect, *message,
+                                        &aChild.GetMacAddress(macAddr), OT_ERROR_NONE);
+    }
+
+    return message;
+}
+
+void IndirectSender::PrepareIndirectTransmission(Message &aMessage, const Child &aChild)
+{
+    if (aChild.GetIndirectTxAttempts() > 0)
+    {
+        Get<MeshForwarder>().mSendMessageIsARetransmission  = true;
+        Get<MeshForwarder>().mSendMessageFrameCounter       = aChild.GetIndirectFrameCounter();
+        Get<MeshForwarder>().mSendMessageKeyId              = aChild.GetIndirectKeyId();
+        Get<MeshForwarder>().mSendMessageDataSequenceNumber = aChild.GetIndirectDataSequenceNumber();
+    }
+
+    aMessage.SetOffset(aChild.GetIndirectFragmentOffset());
+
+    switch (aMessage.GetType())
+    {
+    case Message::kTypeIp6:
+    {
+        Ip6::Header ip6Header;
+
+        aMessage.Read(0, sizeof(ip6Header), &ip6Header);
+
+        Get<MeshForwarder>().mAddMeshHeader = false;
+        Get<MeshForwarder>().GetMacSourceAddress(ip6Header.GetSource(), Get<MeshForwarder>().mMacSource);
+
+        if (ip6Header.GetDestination().IsLinkLocal())
+        {
+            Get<MeshForwarder>().GetMacDestinationAddress(ip6Header.GetDestination(), Get<MeshForwarder>().mMacDest);
+        }
+        else
+        {
+            aChild.GetMacAddress(Get<MeshForwarder>().mMacDest);
+        }
+
+        break;
+    }
+
+    case Message::kTypeSupervision:
+        aChild.GetMacAddress(Get<MeshForwarder>().mMacDest);
+        break;
+
+    default:
+        assert(false);
+        break;
+    }
+}
+
+void IndirectSender::UpdateIndirectMessages(void)
+{
+    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateAnyExceptValidOrRestoring); !iter.IsDone();
+         iter++)
+    {
+        if (iter.GetChild()->GetIndirectMessageCount() == 0)
+        {
+            continue;
+        }
+
+        ClearAllMessagesForSleepyChild(*iter.GetChild());
+    }
+}
+
+void IndirectSender::HandleSentFrameToChild(const Mac::Frame &aFrame, otError aError, const Mac::Address &aMacDest)
+{
+    Child *child;
+
+    child = Get<ChildTable>().FindChild(aMacDest, ChildTable::kInStateValidOrRestoring);
+    VerifyOrExit(child != NULL);
+
+    child->SetDataRequestPending(false);
+
+    VerifyOrExit(Get<MeshForwarder>().mSendMessage != NULL);
+
+    if (Get<MeshForwarder>().mSendMessage == child->GetIndirectMessage())
+    {
+        // To ensure fairness in handling of data requests from sleepy
+        // children, once a message is completed for indirect transmission to a
+        // child (on both success or failure), the `mIndirectStartingChild` is
+        // updated to the next `Child` entry after the current one. Subsequent
+        // call to `ScheduleTransmissionTask()` will begin the iteration
+        // through the children list from this child.
+
+        ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValidOrRestoring, mIndirectStartingChild);
+        iter++;
+        mIndirectStartingChild = iter.GetChild();
+
+        switch (aError)
+        {
+        case OT_ERROR_NONE:
+            child->ResetIndirectTxAttempts();
+            break;
+
+        case OT_ERROR_NO_ACK:
+            child->IncrementIndirectTxAttempts();
+            // fall through
+
+        case OT_ERROR_CHANNEL_ACCESS_FAILURE:
+        case OT_ERROR_ABORT:
+
+            otLogInfoMac("Indirect tx to child %04x failed, attempt %d/%d, error:%s", child->GetRloc16(),
+                         child->GetIndirectTxAttempts(), kMaxPollTriggeredTxAttempts, otThreadErrorToString(aError));
+
+            if (child->GetIndirectTxAttempts() < kMaxPollTriggeredTxAttempts)
+            {
+                // We save the frame counter, key id, and data sequence number of
+                // current frame so we use the same values for the retransmission
+                // of the frame following the receipt of a data request command (data
+                // poll) from the sleepy child.
+
+                child->SetIndirectDataSequenceNumber(aFrame.GetSequence());
+
+                if (aFrame.GetSecurityEnabled())
+                {
+                    uint32_t frameCounter;
+                    uint8_t  keyId;
+
+                    aFrame.GetFrameCounter(frameCounter);
+                    child->SetIndirectFrameCounter(frameCounter);
+
+                    aFrame.GetKeyId(keyId);
+                    child->SetIndirectKeyId(keyId);
+                }
+
+                ExitNow();
+            }
+
+            child->ResetIndirectTxAttempts();
+            child->SetIndirectTxSuccess(false);
+
+#if OPENTHREAD_CONFIG_DROP_MESSAGE_ON_FRAGMENT_TX_FAILURE
+            // We set the NextOffset to end of message, since there is no need to
+            // send any remaining fragments in the message to the child, if all tx
+            // attempts of current frame already failed.
+
+            Get<MeshForwarder>().mMessageNextOffset = Get<MeshForwarder>().mSendMessage->GetLength();
+#endif
+
+            break;
+
+        default:
+            assert(false);
+            break;
+        }
+    }
+
+    if (Get<MeshForwarder>().mMessageNextOffset < Get<MeshForwarder>().mSendMessage->GetLength())
+    {
+        if (Get<MeshForwarder>().mSendMessage == child->GetIndirectMessage())
+        {
+            child->SetIndirectFragmentOffset(Get<MeshForwarder>().mMessageNextOffset);
+        }
+    }
+    else
+    {
+        otError txError = aError;
+        uint8_t childIndex;
+
+        if (Get<MeshForwarder>().mSendMessage == child->GetIndirectMessage())
+        {
+            child->SetIndirectFragmentOffset(0);
+            child->SetIndirectMessage(NULL);
+            child->GetLinkInfo().AddMessageTxStatus(child->GetIndirectTxSuccess());
+
+            // Enable short source address matching after the first indirect
+            // message transmission attempt to the child. We intentionally do
+            // not check for successful tx here to address the scenario where
+            // the child does receive "Child ID Response" but parent misses the
+            // 15.4 ack from child. If the "Child ID Response" does not make it
+            // to the child, then the child will need to send a new "Child ID
+            // Request" which will cause the parent to switch to using long
+            // address mode for source address matching.
+
+            mSourceMatchController.SetSrcMatchAsShort(*child, true);
+
+#if !OPENTHREAD_CONFIG_DROP_MESSAGE_ON_FRAGMENT_TX_FAILURE
+
+            // When `CONFIG_DROP_MESSAGE_ON_FRAGMENT_TX_FAILURE` is
+            // disabled, all fragment frames of a larger message are
+            // sent even if the transmission of an earlier fragment fail.
+            // Note that `GetIndirectTxSuccess() tracks the tx success of
+            // the entire message to the child, while `txError = aError`
+            // represents the error status of the last fragment frame
+            // transmission.
+
+            if (!child->GetIndirectTxSuccess() && (txError == OT_ERROR_NONE))
+            {
+                txError = OT_ERROR_FAILED;
+            }
+#endif
+        }
+
+        childIndex = Get<ChildTable>().GetChildIndex(*child);
+
+        if (Get<MeshForwarder>().mSendMessage->GetChildMask(childIndex))
+        {
+            Get<MeshForwarder>().mSendMessage->ClearChildMask(childIndex);
+            mSourceMatchController.DecrementMessageCount(*child);
+        }
+
+        if (!Get<MeshForwarder>().mSendMessage->GetDirectTransmission())
+        {
+            Get<MeshForwarder>().LogMessage(MeshForwarder::kMessageTransmit, *Get<MeshForwarder>().mSendMessage,
+                                            &aMacDest, txError);
+
+            if (Get<MeshForwarder>().mSendMessage->GetType() == Message::kTypeIp6)
+            {
+                if (Get<MeshForwarder>().mSendMessage->GetTxSuccess())
+                {
+                    Get<MeshForwarder>().mIpCounters.mTxSuccess++;
+                }
+                else
+                {
+                    Get<MeshForwarder>().mIpCounters.mTxFailure++;
+                }
+            }
+        }
+    }
+
+    if (aError == OT_ERROR_NONE)
+    {
+        Get<Utils::ChildSupervisor>().UpdateOnSend(*child);
+    }
+
+exit:
+    return;
+}
+
+} // namespace ot
+
+#endif // #if OPENTHREAD_FTD

--- a/src/core/thread/indirect_sender.hpp
+++ b/src/core/thread/indirect_sender.hpp
@@ -194,6 +194,10 @@ public:
     otError GetIndirectTransmission(void);
     void    HandleSentFrameToChild(const Mac::Frame &aFrame, otError aError, const Mac::Address &aMacDest);
 
+    // Callbacks from MAC layer
+    void    HandleSentFrame(Mac::Frame &aFrame, otError aError);
+    otError HandleFrameRequest(Mac::Frame &aFrame);
+
 private:
     enum
     {

--- a/src/core/thread/indirect_sender.hpp
+++ b/src/core/thread/indirect_sender.hpp
@@ -64,6 +64,78 @@ class IndirectSender : public InstanceLocator
 
 public:
     /**
+     * This class defines all the child info required for indirect transmission.
+     *
+     * `Child` class publicly inherits from this class.
+     */
+    class ChildInfo
+    {
+        friend class IndirectSender;
+        friend class SourceMatchController;
+
+    public:
+        /**
+         * This method returns the number of queued messages for the child.
+         *
+         * @returns Number of queued messages for the child.
+         *
+         */
+        uint16_t GetIndirectMessageCount(void) const { return mQueuedMessageCount; }
+
+    private:
+        bool IsDataRequestPending(void) const { return mDataRequestPendig; }
+        void SetDataRequestPending(bool aPending) { mDataRequestPendig = aPending; }
+
+        Message *GetIndirectMessage(void) { return mIndirectMessage; }
+        void     SetIndirectMessage(Message *aMessage) { mIndirectMessage = aMessage; }
+
+        uint16_t GetIndirectFragmentOffset(void) const { return mIndirectFragmentOffset; }
+        void     SetIndirectFragmentOffset(uint16_t aFragmentOffset) { mIndirectFragmentOffset = aFragmentOffset; }
+
+        bool GetIndirectTxSuccess(void) const { return mIndirectTxSuccess; }
+        void SetIndirectTxSuccess(bool aTxStatus) { mIndirectTxSuccess = aTxStatus; }
+
+        uint32_t GetIndirectFrameCounter(void) const { return mIndirectFrameCounter; }
+        void     SetIndirectFrameCounter(uint32_t aFrameCounter) { mIndirectFrameCounter = aFrameCounter; }
+
+        uint8_t GetIndirectKeyId(void) const { return mIndirectKeyId; }
+        void    SetIndirectKeyId(uint8_t aKeyId) { mIndirectKeyId = aKeyId; }
+
+        uint8_t GetIndirectTxAttempts(void) const { return mIndirectTxAttempts; }
+        void    ResetIndirectTxAttempts(void) { mIndirectTxAttempts = 0; }
+        void    IncrementIndirectTxAttempts(void) { mIndirectTxAttempts++; }
+
+        uint8_t GetIndirectDataSequenceNumber(void) const { return mIndirectDsn; }
+        void    SetIndirectDataSequenceNumber(uint8_t aDsn) { mIndirectDsn = aDsn; }
+
+        bool IsIndirectSourceMatchShort(void) const { return mUseShortAddress; }
+        void SetIndirectSourceMatchShort(bool aShort) { mUseShortAddress = aShort; }
+
+        bool IsIndirectSourceMatchPending(void) const { return mSourceMatchPending; }
+        void SetIndirectSourceMatchPending(bool aPending) { mSourceMatchPending = aPending; }
+
+        void IncrementIndirectMessageCount(void) { mQueuedMessageCount++; }
+        void DecrementIndirectMessageCount(void) { mQueuedMessageCount--; }
+        void ResetIndirectMessageCount(void) { mQueuedMessageCount = 0; }
+
+        const Mac::Address &GetMacAddress(Mac::Address &aMacAddress) const;
+
+        Message *mIndirectMessage;             // Current indirect message.
+        uint16_t mIndirectFragmentOffset : 15; // 6LoWPAN fragment offset for the indirect message.
+        bool     mIndirectTxSuccess : 1;       // Indicates tx success/failure of current indirect message.
+        uint16_t mQueuedMessageCount : 13;     // Number of queued indirect messages for the child.
+        bool     mUseShortAddress : 1;         // Indicates whether to use short or extended address.
+        bool     mSourceMatchPending : 1;      // Indicates whether or not pending to add to src match table.
+        bool     mDataRequestPendig : 1;       // Indicates whether or not a Data Poll was received,
+        uint32_t mIndirectFrameCounter;        // Frame counter for current indirect message (used fore retx).
+        uint8_t  mIndirectKeyId;               // Key Id for current indirect message (used for retx).
+        uint8_t  mIndirectTxAttempts;          // Number of data poll triggered tx attempts.
+        uint8_t  mIndirectDsn;                 // MAC level Data Sequence Number (DSN) for retx attempts.
+
+        OT_STATIC_ASSERT(OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS < 8192, "mQueuedMessageCount cannot fit max required!");
+    };
+
+    /**
      * This constructor initializes the object.
      *
      * @param[in]  aInstance  A reference to the OpenThread instance.

--- a/src/core/thread/indirect_sender.hpp
+++ b/src/core/thread/indirect_sender.hpp
@@ -1,0 +1,154 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for handling indirect transmission.
+ */
+
+#ifndef INDIRECT_SENDER_HPP_
+#define INDIRECT_SENDER_HPP_
+
+#include "openthread-core-config.h"
+
+#include "common/locator.hpp"
+#include "common/message.hpp"
+#include "mac/mac_frame.hpp"
+#include "thread/src_match_controller.hpp"
+
+namespace ot {
+
+/**
+ * @addtogroup core-mesh-forwarding
+ *
+ * @brief
+ *   This module includes definitions for handling indirect transmissions.
+ *
+ * @{
+ */
+
+class Child;
+
+/**
+ * This class implements indirect transmission.
+ *
+ */
+class IndirectSender : public InstanceLocator
+{
+    friend class Instance;
+
+public:
+    /**
+     * This constructor initializes the object.
+     *
+     * @param[in]  aInstance  A reference to the OpenThread instance.
+     *
+     */
+    explicit IndirectSender(Instance &aInstance);
+
+    /**
+     * This method enables indirect transmissions.
+     *
+     */
+    void Start(void) { mEnabled = true; }
+
+    /**
+     * This method disables indirect transmission.
+     *
+     * Any previously scheduled indirect transmission is canceled.
+     *
+     */
+    void Stop(void);
+
+    /**
+     * This method adds a message for indirect transmission to a sleepy child.
+     *
+     * @param[in] aMessage  The message to add.
+     * @param[in] aChild    The (sleepy) child for indirect transmission.
+     *
+     * @retval OT_ERROR_NONE           Successfully added the message for indirect transmission.
+     * @retval OT_ERROR_ALREADY        The message was already added for indirect transmission to same child.
+     * @retval OT_ERROR_INVALID_STATE  The child is not sleepy.
+     *
+     */
+    otError AddMessageForSleepyChild(Message &aMessage, Child &aChild);
+
+    /**
+     * This method removes a message for indirect transmission to a sleepy child.
+     *
+     * @param[in] aMessage  The message to update.
+     * @param[in] aChild    The (sleepy) child for indirect transmission.
+     *
+     * @retval OT_ERROR_NONE           Successfully removed the message for indirect transmission.
+     * @retval OT_ERROR_NOT_FOUND      The message was not scheduled for indirect transmission to the child.
+     *
+     */
+    otError RemoveMessageFromSleepyChild(Message &aMessage, Child &aChild);
+
+    /**
+     * This method removes all added messages for a specific child and frees message (with no indirect/direct tx).
+     *
+     * @param[in]  aChild  A reference to a child whose messages shall be removed.
+     *
+     */
+    void ClearAllMessagesForSleepyChild(Child &aChild);
+
+    void    HandleDataPoll(const Mac::Frame &aFrame, const Mac::Address &aMacSource, const otThreadLinkInfo &aLinkInfo);
+    otError GetIndirectTransmission(void);
+    void    HandleSentFrameToChild(const Mac::Frame &aFrame, otError aError, const Mac::Address &aMacDest);
+
+private:
+    enum
+    {
+        /**
+         * Maximum number of tx attempts by `MeshForwarder` for an outbound indirect frame (for a sleepy child). The
+         * `MeshForwader` attempts occur following the reception of a new data request command (a new data poll) from
+         * the sleepy child.
+         *
+         */
+        kMaxPollTriggeredTxAttempts = OPENTHREAD_CONFIG_MAX_TX_ATTEMPTS_INDIRECT_POLLS,
+    };
+
+    Message *GetIndirectTransmission(Child &aChild);
+    void     PrepareIndirectTransmission(Message &aMessage, const Child &aChild);
+    void     UpdateIndirectMessages(void);
+
+    bool mEnabled;
+
+    SourceMatchController mSourceMatchController;
+    Child *               mIndirectStartingChild;
+};
+
+/**
+ * @}
+ *
+ */
+
+} // namespace ot
+
+#endif // INDIRECT_SENDER_HPP_

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -62,8 +62,6 @@ MeshForwarder::MeshForwarder(Instance &aInstance)
     , mMessageNextOffset(0)
     , mSendMessage(NULL)
     , mSendMessageIsARetransmission(false)
-    , mSendMessageMaxCsmaBackoffs(Mac::kMaxCsmaBackoffsDirect)
-    , mSendMessageMaxFrameRetries(Mac::kMaxFrameRetriesDirect)
     , mMeshSource()
     , mMeshDest()
     , mAddMeshHeader(false)
@@ -80,7 +78,6 @@ MeshForwarder::MeshForwarder(Instance &aInstance)
     , mSendMessageFrameCounter(0)
     , mSendMessageKeyId(0)
     , mSendMessageDataSequenceNumber(0)
-    , mIndirectStartingChild(NULL)
 #endif
     , mDataPollSender(aInstance)
 {
@@ -192,9 +189,7 @@ void MeshForwarder::ScheduleTransmissionTask(void)
             mSendMessage->SetTxSuccess(true);
         }
 
-        mSendMessageMaxCsmaBackoffs = Mac::kMaxCsmaBackoffsDirect;
-        mSendMessageMaxFrameRetries = Mac::kMaxFrameRetriesDirect;
-        Get<Mac::Mac>().RequestFrameTransmission();
+        Get<Mac::Mac>().RequestDirectFrameTransmission();
         ExitNow();
     }
 
@@ -503,8 +498,6 @@ otError MeshForwarder::HandleFrameRequest(Mac::Frame &aFrame)
     {
         SendEmptyFrame(aFrame, false);
         aFrame.SetIsARetransmission(false);
-        aFrame.SetMaxCsmaBackoffs(Mac::kMaxCsmaBackoffsDirect);
-        aFrame.SetMaxFrameRetries(Mac::kMaxFrameRetriesDirect);
         ExitNow();
     }
 
@@ -574,8 +567,6 @@ otError MeshForwarder::HandleFrameRequest(Mac::Frame &aFrame)
     assert(error == OT_ERROR_NONE);
 
     aFrame.SetIsARetransmission(mSendMessageIsARetransmission);
-    aFrame.SetMaxCsmaBackoffs(mSendMessageMaxCsmaBackoffs);
-    aFrame.SetMaxFrameRetries(mSendMessageMaxFrameRetries);
 
 #if OPENTHREAD_FTD
 

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -385,8 +385,15 @@ private:
                                      uint16_t                aFrameLength,
                                      Lowpan::FragmentHeader &aFragmentHeader);
 
+    uint16_t PrepareDataFrame(Mac::Frame &        aFrame,
+                              Message &           aMessage,
+                              const Mac::Address &aMacSource,
+                              const Mac::Address &aMacDest,
+                              bool                aAddMeshHeader = false,
+                              uint16_t            aMeshSource    = 0xffff,
+                              uint16_t            aMeshDest      = 0xffff);
+
     void    SendMesh(Message &aMessage, Mac::Frame &aFrame);
-    otError SendFragment(Message &aMessage, Mac::Frame &aFrame);
     void    SendEmptyFrame(Mac::Frame &aFrame, bool aAckRequest);
     otError UpdateIp6Route(Message &aMessage);
     otError UpdateIp6RouteFtd(Ip6::Header &ip6Header);

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -503,8 +503,6 @@ private:
 
     Message *mSendMessage;
     bool     mSendMessageIsARetransmission;
-    uint8_t  mSendMessageMaxCsmaBackoffs;
-    uint8_t  mSendMessageMaxFrameRetries;
 
     Mac::Address mMacSource;
     Mac::Address mMacDest;
@@ -532,7 +530,6 @@ private:
     uint32_t              mSendMessageFrameCounter;
     uint8_t               mSendMessageKeyId;
     uint8_t               mSendMessageDataSequenceNumber;
-    Child *               mIndirectStartingChild;
 #endif
 
     DataPollSender mDataPollSender;

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -509,7 +509,6 @@ private:
     uint16_t      mMessageNextOffset;
 
     Message *mSendMessage;
-    bool     mSendMessageIsARetransmission;
 
     Mac::Address mMacSource;
     Mac::Address mMacDest;
@@ -534,9 +533,6 @@ private:
     FragmentPriorityEntry mFragmentEntries[kNumFragmentPriorityEntries];
     MessageQueue          mResolvingQueue;
     IndirectSender        mIndirectSender;
-    uint32_t              mSendMessageFrameCounter;
-    uint8_t               mSendMessageKeyId;
-    uint8_t               mSendMessageDataSequenceNumber;
 #endif
 
     DataPollSender mDataPollSender;

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -50,6 +50,10 @@ otError MeshForwarder::SendMessage(Message &aMessage)
     otError         error = OT_ERROR_NONE;
     Neighbor *      neighbor;
 
+    aMessage.SetOffset(0);
+    aMessage.SetDatagramTag(0);
+    SuccessOrExit(error = mSendQueue.Enqueue(aMessage));
+
     switch (aMessage.GetType())
     {
     case Message::kTypeIp6:
@@ -122,9 +126,7 @@ otError MeshForwarder::SendMessage(Message &aMessage)
     case Message::kTypeSupervision:
     {
         Child *child = Get<Utils::ChildSupervisor>().GetDestination(aMessage);
-        VerifyOrExit(child != NULL, error = OT_ERROR_DROP);
-        VerifyOrExit(!child->IsRxOnWhenIdle(), error = OT_ERROR_DROP);
-
+        assert((child != NULL) && !child->IsRxOnWhenIdle());
         mIndirectSender.AddMessageForSleepyChild(aMessage, *child);
         break;
     }
@@ -134,9 +136,6 @@ otError MeshForwarder::SendMessage(Message &aMessage)
         break;
     }
 
-    aMessage.SetOffset(0);
-    aMessage.SetDatagramTag(0);
-    SuccessOrExit(error = mSendQueue.Enqueue(aMessage));
     mScheduleTransmissionTask.Post();
 
 exit:

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3150,7 +3150,7 @@ void MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
 
             aNeighbor.SetState(Neighbor::kStateInvalid);
 
-            Get<MeshForwarder>().ClearChildIndirectMessages(static_cast<Child &>(aNeighbor));
+            Get<IndirectSender>().ClearAllMessagesForSleepyChild(static_cast<Child &>(aNeighbor));
             Get<NetworkData::Leader>().SendServerDataNotification(aNeighbor.GetRloc16());
 
             if (aNeighbor.GetDeviceMode() & ModeTlv::kModeFullThreadDevice)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1394,7 +1394,6 @@ otError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::Messa
             router->ResetLinkFailures();
             router->SetLastHeard(TimerMilli::GetNow());
             router->SetState(Neighbor::kStateLinkRequest);
-            router->SetDataRequestPending(false);
             SendLinkRequest(router);
             ExitNow(error = OT_ERROR_NO_ROUTE);
         }
@@ -1638,7 +1637,6 @@ otError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::Messa
         child->GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
         child->ResetLinkFailures();
         child->SetState(Neighbor::kStateParentRequest);
-        child->SetDataRequestPending(false);
 #if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
         if (Tlv::GetTlv(aMessage, Tlv::kTimeRequest, sizeof(timeRequest), timeRequest) == OT_ERROR_NONE)
         {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2271,7 +2271,7 @@ otError MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
 
         if (!(mode.GetMode() & ModeTlv::kModeRxOnWhenIdle) && (child->GetState() == Neighbor::kStateValid))
         {
-            Get<SourceMatchController>().SetSrcMatchAsShort(*child, true);
+            Get<IndirectSender>().SetChildUseShortAddress(*child, true);
         }
     }
 
@@ -2860,7 +2860,7 @@ otError MleRouter::SendChildIdResponse(Child &aChild)
 
     if (!aChild.IsRxOnWhenIdle())
     {
-        Get<SourceMatchController>().SetSrcMatchAsShort(aChild, false);
+        Get<IndirectSender>().SetChildUseShortAddress(aChild, false);
     }
 
 #if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
@@ -3522,7 +3522,7 @@ void MleRouter::RestoreChildren(void)
         child->SetDeviceMode(childInfo.mMode);
         child->SetState(Neighbor::kStateRestored);
         child->SetLastHeard(TimerMilli::GetNow());
-        Get<SourceMatchController>().SetSrcMatchAsShort(*child, true);
+        Get<IndirectSender>().SetChildUseShortAddress(*child, true);
         numChildren++;
     }
 

--- a/src/core/thread/src_match_controller.cpp
+++ b/src/core/thread/src_match_controller.cpp
@@ -40,6 +40,7 @@
 #include "mac/mac_frame.hpp"
 #include "thread/mesh_forwarder.hpp"
 #include "thread/thread_netif.hpp"
+#include "thread/topology.hpp"
 
 namespace ot {
 

--- a/src/core/thread/src_match_controller.hpp
+++ b/src/core/thread/src_match_controller.hpp
@@ -36,10 +36,12 @@
 
 #include "openthread-core-config.h"
 
+#include <openthread/error.h>
 #include "common/locator.hpp"
-#include "thread/topology.hpp"
 
 namespace ot {
+
+class Child;
 
 /**
  * @addtogroup core-source-match-controller

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -240,18 +240,4 @@ void Child::GenerateChallenge(void)
     Random::NonCrypto::FillBuffer(mAttachChallenge, sizeof(mAttachChallenge));
 }
 
-const Mac::Address &Child::GetMacAddress(Mac::Address &aMacAddress) const
-{
-    if (mUseShortAddress)
-    {
-        aMacAddress.SetShort(GetRloc16());
-    }
-    else
-    {
-        aMacAddress.SetExtended(GetExtAddress());
-    }
-
-    return aMacAddress;
-}
-
 } // namespace ot

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -42,6 +42,7 @@
 #include "common/random.hpp"
 #include "mac/mac_frame.hpp"
 #include "net/ip6.hpp"
+#include "thread/indirect_sender.hpp"
 #include "thread/link_quality.hpp"
 #include "thread/mle_tlvs.hpp"
 
@@ -273,22 +274,6 @@ public:
     void SetRloc16(uint16_t aRloc16) { mRloc16 = aRloc16; }
 
     /**
-     * This method indicates whether an IEEE 802.15.4 Data Request message was received.
-     *
-     * @returns TRUE if an IEEE 802.15.4 Data Request message was received, FALSE otherwise.
-     *
-     */
-    bool IsDataRequestPending(void) const { return mDataRequest; }
-
-    /**
-     * This method sets the indicator for whether an IEEE 802.15.4 Data Request message was received.
-     *
-     * @param[in]  aPending  TRUE if an IEEE 802.15.4 Data Request message was received, FALSE otherwise.
-     *
-     */
-    void SetDataRequestPending(bool aPending) { mDataRequest = aPending; }
-
-    /**
      * This method gets the number of consecutive link failures.
      *
      * @returns The number of consecutive link failures.
@@ -372,11 +357,10 @@ private:
         } mPending;
     } mValidPending;
 
-    uint32_t mKeySequence;     ///< Current key sequence
-    uint16_t mRloc16;          ///< The RLOC16
-    uint8_t  mState : 3;       ///< The link state
-    uint8_t  mMode : 4;        ///< The MLE device mode
-    bool     mDataRequest : 1; ///< Indicates whether or not a Data Poll was received
+    uint32_t mKeySequence; ///< Current key sequence
+    uint16_t mRloc16;      ///< The RLOC16
+    uint8_t  mState : 4;   ///< The link state
+    uint8_t  mMode : 4;    ///< The MLE device mode
 #if OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
     uint8_t mLinkFailures : 7;    ///< Consecutive link failure count
     bool    mTimeSyncEnabled : 1; ///< Indicates whether or not time sync feature is enabled.
@@ -390,7 +374,7 @@ private:
  * This class represents a Thread Child.
  *
  */
-class Child : public Neighbor
+class Child : public Neighbor, public IndirectSender::ChildInfo
 {
 public:
     enum
@@ -584,180 +568,6 @@ public:
     uint8_t GetChallengeSize(void) const { return sizeof(mAttachChallenge); }
 
     /**
-     * This method gets the IEEE 802.15.4 Frame Counter used during indirect retransmissions.
-     *
-     * @returns The IEEE 802.15.4 Frame Counter value.
-     *
-     */
-    uint32_t GetIndirectFrameCounter(void) const { return mIndirectFrameCounter; }
-
-    /**
-     * This method sets the IEEE 802.15.4 Frame Counter to use during indirect retransmissions.
-     *
-     * @param[in]  aFrameCounter  The IEEE 802.15.4 Frame Counter value.
-     *
-     */
-    void SetIndirectFrameCounter(uint32_t aFrameCounter) { mIndirectFrameCounter = aFrameCounter; }
-
-    /**
-     * This method gets the message buffer to use for indirect transmissions.
-     *
-     * @returns The message buffer.
-     *
-     */
-    Message *GetIndirectMessage(void) { return mIndirectMessage; }
-
-    /**
-     * This method sets the message buffer to use for indirect transmissions.
-     *
-     * @param[in]  aMessage  The message buffer.
-     *
-     */
-    void SetIndirectMessage(Message *aMessage) { mIndirectMessage = aMessage; }
-
-    /**
-     * This method gets the 6LoWPAN Fragment Offset to use for indirect transmissions.
-     *
-     * @returns The 6LoWPAN Fragment Offset value.
-     *
-     */
-    uint16_t GetIndirectFragmentOffset(void) const { return mIndirectFragmentOffset; }
-
-    /**
-     * This method sets the 6LoWPAN Fragment Offset to use for indirect transmissions.
-     *
-     * @param[in]  aFragmentOffset  The 6LoWPAN Fragment Offset value to use.
-     *
-     */
-    void SetIndirectFragmentOffset(uint16_t aFragmentOffset) { mIndirectFragmentOffset = aFragmentOffset; }
-
-    /**
-     * This method gets the transmission status (success/failure) of the indirect transmission.
-     *
-     * @returns The transmission status of indirect transmission, `true` indicating success, `false` indicating failure.
-     *
-     */
-    bool GetIndirectTxSuccess(void) const { return mIndirectTxSuccess; }
-
-    /**
-     * This method sets the transmission status (success/failure) of the indirect transmission.
-     *
-     * @param[in]  aTxStatus    The transmission status, `true` indicating success, `false` indicating failure.
-     *
-     */
-    void SetIndirectTxSuccess(bool aTxStatus) { mIndirectTxSuccess = aTxStatus; }
-
-    /**
-     * This method gets the IEEE 802.15.4 Key ID to use for indirect retransmissions.
-     *
-     * @returns The IEEE 802.15.4 Key ID value.
-     *
-     */
-    uint8_t GetIndirectKeyId(void) const { return mIndirectKeyId; }
-
-    /**
-     * This method sets the IEEE 802.15.4 Key ID value to use for indirect retransmissions.
-     *
-     * @param[in]  aKeyId  The IEEE 802.15.4 Key ID value.
-     *
-     */
-    void SetIndirectKeyId(uint8_t aKeyId) { mIndirectKeyId = aKeyId; }
-
-    /**
-     * This method gets the number of indirect transmission attempts for the current message.
-     *
-     * @returns The number of indirect transmission attempts.
-     *
-     */
-    uint8_t GetIndirectTxAttempts(void) const { return mIndirectTxAttempts; }
-
-    /**
-     * This method resets the number of indirect transmission attempts to zero.
-     *
-     */
-    void ResetIndirectTxAttempts(void) { mIndirectTxAttempts = 0; }
-
-    /**
-     * This method increments the number of indirect transmission attempts.
-     *
-     */
-    void IncrementIndirectTxAttempts(void) { mIndirectTxAttempts++; }
-
-    /**
-     * This method gets the IEEE 802.15.4 Data Sequence Number to use during indirect retransmissions.
-     *
-     * @returns The IEEE 802.15.4 Data Sequence Number value.
-     *
-     */
-    uint8_t GetIndirectDataSequenceNumber(void) const { return mIndirectDsn; }
-
-    /**
-     * This method sets the IEEE 802.15.4 Data Sequence Number to use during indirect retransmissions.
-     *
-     * @param[in]  aDsn  The IEEE 802.15.4 Data Sequence Number value.
-     *
-     */
-    void SetIndirectDataSequenceNumber(uint8_t aDsn) { mIndirectDsn = aDsn; }
-
-    /**
-     * This method indicates whether or not to source match on the short address.
-     *
-     * @returns TRUE if using the short address, FALSE if using the extended address.
-     *
-     */
-    bool IsIndirectSourceMatchShort(void) const { return mUseShortAddress; }
-
-    /**
-     * This method sets whether or not to source match on the short address.
-     *
-     * @param[in]  aShort  TRUE if using the short address, FALSE if using the extended address.
-     *
-     */
-    void SetIndirectSourceMatchShort(bool aShort) { mUseShortAddress = aShort; }
-
-    /**
-     * This method indicates whether or not the child needs to be added to the source match table.
-     *
-     * @returns TRUE if the child needs to be added to the source match table, FALSE otherwise.
-     *
-     */
-    bool IsIndirectSourceMatchPending(void) const { return mSourceMatchPending; }
-
-    /**
-     * This method sets whether or not the child needs to be added to the source match table.
-     *
-     * @param[in]  aPending  TRUE if the child needs to be added to the source match table, FALSE otherwise.
-     *
-     */
-    void SetIndirectSourceMatchPending(bool aPending) { mSourceMatchPending = aPending; }
-
-    /**
-     * This method returns the number of queued message(s) for the child
-     *
-     * @returns Number of queues message(s).
-     *
-     */
-    uint16_t GetIndirectMessageCount(void) const { return mQueuedMessageCount; }
-
-    /**
-     * This method increments the indirect message count.
-     *
-     */
-    void IncrementIndirectMessageCount(void) { mQueuedMessageCount++; }
-
-    /**
-     * This method decrements the indirect message count.
-     *
-     */
-    void DecrementIndirectMessageCount(void) { mQueuedMessageCount--; }
-
-    /**
-     * This method resets the indirect message count to zero.
-     *
-     */
-    void ResetIndirectMessageCount(void) { mQueuedMessageCount = 0; }
-
-    /**
      * This method clears the requested TLV list.
      *
      */
@@ -781,17 +591,6 @@ public:
      *
      */
     void SetRequestTlv(uint8_t aIndex, uint8_t aType) { mRequestTlvs[aIndex] = aType; }
-
-    /**
-     * This method gets the mac address of child (either rloc16 or extended address depending on `UseShortAddress`
-     * flag).
-     *
-     * @param[out] aMacAddress A reference to a mac address object to which the child's address is copied.
-     *
-     * @returns A (const) reference to the mac address @a aMacAddress.
-     *
-     */
-    const Mac::Address &GetMacAddress(Mac::Address &aMacAddress) const;
 
 #if OPENTHREAD_ENABLE_CHILD_SUPERVISION
 
@@ -827,6 +626,7 @@ private:
         kNumIp6Addresses = OPENTHREAD_CONFIG_IP_ADDRS_PER_CHILD - 1,
     };
 
+    uint8_t      mNetworkDataVersion;                                   ///< Current Network Data version
     uint8_t      mMeshLocalIid[Ip6::Address::kInterfaceIdentifierSize]; ///< IPv6 address IID for mesh-local address
     Ip6::Address mIp6Address[kNumIp6Addresses];                         ///< Registered IPv6 addresses
 
@@ -837,18 +637,6 @@ private:
         uint8_t mRequestTlvs[kMaxRequestTlvs];                 ///< Requested MLE TLVs
         uint8_t mAttachChallenge[Mle::ChallengeTlv::kMaxSize]; ///< The challenge value
     };
-
-    uint32_t mIndirectFrameCounter;        ///< Frame counter for current indirect message (used fore retx).
-    Message *mIndirectMessage;             ///< Current indirect message.
-    uint16_t mIndirectFragmentOffset : 15; ///< 6LoWPAN fragment offset for the indirect message.
-    bool     mIndirectTxSuccess : 1;       ///< Indicates tx success/failure of current indirect message.
-    uint8_t  mIndirectKeyId;               ///< Key Id for current indirect message (used for retx).
-    uint8_t  mIndirectTxAttempts;          ///< Number of data poll triggered tx attempts.
-    uint8_t  mIndirectDsn;                 ///< MAC level Data Sequence Number (DSN) for retx attempts.
-    uint8_t  mNetworkDataVersion;          ///< Current Network Data version
-    uint16_t mQueuedMessageCount : 13;     ///< Number of queued indirect messages for the child.
-    bool     mUseShortAddress : 1;         ///< Indicates whether to use short or extended address.
-    bool     mSourceMatchPending : 1;      ///< Indicates whether or not pending to add to src match table.
 
 #if OPENTHREAD_ENABLE_CHILD_SUPERVISION
     uint16_t mSecondsSinceSupervision; ///< Number of seconds since last supervision of the child.

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -374,7 +374,7 @@ private:
  * This class represents a Thread Child.
  *
  */
-class Child : public Neighbor, public IndirectSender::ChildInfo
+class Child : public Neighbor, public IndirectSender::ChildInfo, public DataPollHandler::ChildInfo
 {
 public:
     enum


### PR DESCRIPTION
This PR changes the design of indirect frame tx in OpenThread core. The primary objective is move the handling of data polls and indirect tx closer to MAC layer. 
- This enables future enhancements to have RCP handle data polls and indirect tx (including retx of indirect frame tx).
- Also helps get the MAC layer definition closer (but not a 100% match) to 802.15.4 MCPS/MLME  style primitive definitions. 
- Helps simplify the code and reduce complexity and responsibility  of `MeshForwarder` module.
- Allows each module to define its own state/info it requires to be saved per child/neighbor in the `Child` class.

The PR contains multiple related commits each containing relatively smaller changes in the hope to structure the overall design and make it easier to review/read the code. Each commit is run through travis to ensure it builds correctly and that it passes all the tests on travis.

**[indirect-sender] adding new class IndirectSender**   
This commit adds a new module/class `IndirectSender` for handling
of the indirect transmission to sleepy children. The commit just
moves the existing code form `MeshForwarder` into the new class.

**[indirect-sender] define ChildInfo for child indirect tx related info**
This commit defines `IndirectSender::ChildInfo` class in child sender
module which contains all the info needed to store (per child) for
handling of indirect transmissions to the child. The `Child` class
inherits from the new class. This helps keep the indirect tx info in
the same file.

**[mac] add new operation for indirect data frame transmission**
This commit adds a new operation for indirect data frame transmission
in `Mac` class (only available on FTD build). The indirect tx request
is handled before a direct tx request. This commit also changes how
the number of retries and CMSA attempts (for a frame) are determined
`Mac` class itself now sets these according to request type.

**[mesh-forwarder] add PrepareDataFrame()**
This commit refactors and updates the existing code to add a generic
method `MeshForwarder::PrepareDataFrame()`. This method constructs a
MAC data from from a given IPv6 message at the offset set in the
message. This method enables link security when message is MLE type
and requires fragmentation.

**[data-poll-handler] adding DataPollHandler class**
This commit adds a new class `DataPollHandler` which sits between
`Mac` layer and `IndirectSender`. It interfaces to `Mac` to handle any
received data poll and perform indirect frame transmission including
the re-transmission logic of frames (per poll). All state info (per
child) for handling of indirect frame retransmission is now defined
and managed by the `DataPollHanlder` class itself. This commit updates
the `IndiretSender` to interface with the `DataPollHandler` class and
handle preparation of frames from `Message` for indirect transmission.

