### PR TITLE
[cli] delete redundant and unnecessary includes

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -68,14 +68,6 @@
 
 #include "cli_dataset.hpp"
 
-#if OPENTHREAD_ENABLE_APPLICATION_COAP
-#include "cli_coap.hpp"
-#endif
-
-#if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-#include "cli_coap_secure.hpp"
-#endif
-
 #if OPENTHREAD_ENABLE_CHANNEL_MANAGER && OPENTHREAD_FTD
 #include <openthread/channel_manager.h>
 #endif

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -48,12 +48,10 @@
 #include "cli/cli_udp.hpp"
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP
-#include <coap/coap_message.hpp>
 #include "cli/cli_coap.hpp"
 #endif
 
 #if OPENTHREAD_ENABLE_APPLICATION_COAP_SECURE
-#include <coap/coap_message.hpp>
 #include "cli/cli_coap_secure.hpp"
 #endif
 


### PR DESCRIPTION
There are some unnecessary includes in the CLI. Maybe it makes sense to remove them. If not, this PR can also be closed again.

#### `cli.cpp`
 * `#include "cli_coap.hpp"` already in header
 * `#include "cli_coap_secure.hpp"` already in header

#### `cli.hpp`
 * first `#include <coap/coap_message.hpp>` already included by `cli_coap.hpp`
 * second  `#include <coap/coap_message.hpp>` already included by `cli_coap_secure.hpp`