### PR TITLE
[logs] compile Mac::Frame::ToInfoString at NOTE log level

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1060,7 +1060,7 @@ uint16_t Frame::GetFcsSize(void) const
 
 // LCOV_EXCL_START
 
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MAC == 1)
+#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE) && (OPENTHREAD_CONFIG_LOG_MAC == 1)
 
 Frame::InfoString Frame::ToInfoString(void) const
 {
@@ -1136,7 +1136,7 @@ BeaconPayload::InfoString BeaconPayload::ToInfoString(void) const
                       IsNative() ? "yes" : "no");
 }
 
-#endif // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MAC == 1)
+#endif // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE) && (OPENTHREAD_CONFIG_LOG_MAC == 1)
 
 // LCOV_EXCL_STOP
 


### PR DESCRIPTION
This fixes a linker error when buiding with OT_LOG_LEVEL_NOTE.

MeshForwarder depends on Mac::Frame::ToInfoString at the NOTE level.

Resolves #3961.