### PR TITLE
[posix-app] simplify makefiles

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3643,17 +3643,17 @@ exit:
 } // namespace ot
 
 #if OPENTHREAD_ENABLE_LEGACY
-extern "C" void otNcpRegisterLegacyHandlers(const otNcpLegacyHandlers *aHandlers)
+OT_TOOL_WEAK void otNcpRegisterLegacyHandlers(const otNcpLegacyHandlers *aHandlers)
 {
     OT_UNUSED_VARIABLE(aHandlers);
 }
 
-extern "C" void otNcpHandleDidReceiveNewLegacyUlaPrefix(const uint8_t *aUlaPrefix)
+OT_TOOL_WEAK void otNcpHandleDidReceiveNewLegacyUlaPrefix(const uint8_t *aUlaPrefix)
 {
     OT_UNUSED_VARIABLE(aUlaPrefix);
 }
 
-extern "C" void otNcpHandleLegacyNodeDidJoin(const otExtAddress *aExtAddr)
+OT_TOOL_WEAK void otNcpHandleLegacyNodeDidJoin(const otExtAddress *aExtAddr)
 {
     OT_UNUSED_VARIABLE(aExtAddr);
 }

--- a/src/posix/Makefile.am
+++ b/src/posix/Makefile.am
@@ -140,9 +140,11 @@ ot_daemon_SOURCES                                                      = \
 
 ot_daemon_LDADD                                                        = \
     $(top_builddir)/src/cli/libopenthread-cli-ftd.a                      \
+    $(top_builddir)/src/ncp/libopenthread-ncp-ftd.a                      \
     $(top_builddir)/src/core/libopenthread-ftd.a                         \
     $(LDADD_COMMON)                                                      \
     $(top_builddir)/src/cli/libopenthread-cli-ftd.a                      \
+    $(top_builddir)/src/ncp/libopenthread-ncp-ftd.a                      \
     $(top_builddir)/src/core/libopenthread-ftd.a                         \
     $(LDADD_COMMON)                                                      \
     $(NULL)
@@ -167,9 +169,11 @@ ot_cli_SOURCES                                                         = \
 
 ot_cli_LDADD                                                           = \
     $(top_builddir)/src/cli/libopenthread-cli-ftd.a                      \
+    $(top_builddir)/src/ncp/libopenthread-ncp-ftd.a                      \
     $(top_builddir)/src/core/libopenthread-ftd.a                         \
     $(LDADD_COMMON)                                                      \
     $(top_builddir)/src/cli/libopenthread-cli-ftd.a                      \
+    $(top_builddir)/src/ncp/libopenthread-ncp-ftd.a                      \
     $(top_builddir)/src/core/libopenthread-ftd.a                         \
     $(LDADD_COMMON)                                                      \
     $(NULL)

--- a/src/posix/platform/Makefile.am
+++ b/src/posix/platform/Makefile.am
@@ -32,8 +32,8 @@ lib_LIBRARIES                             = libopenthread-posix.a
 
 libopenthread_posix_a_CPPFLAGS            = \
     -I$(top_srcdir)/include                 \
+    -I$(top_srcdir)/src                     \
     -I$(top_srcdir)/src/core                \
-    -I$(top_srcdir)/src/ncp                 \
     -I$(top_srcdir)/src/posix/platform      \
     -D_GNU_SOURCE                           \
     $(OPENTHREAD_TARGET_DEFINES)            \

--- a/src/posix/platform/Makefile.am
+++ b/src/posix/platform/Makefile.am
@@ -53,18 +53,6 @@ libopenthread_posix_a_SOURCES             = \
     uart.c                                  \
     $(NULL)
 
-INC_NCP_SOURCES                           = \
-    inc_spinel.c                            \
-    inc_hdlc.cpp                            \
-    $(NULL)
-
-nodist_libopenthread_posix_a_SOURCES      = \
-    $(INC_NCP_SOURCES)                      \
-    $(NULL)
-
-inc_%: ../../ncp/%
-	echo '#include "$<"' > $@
-
 if OPENTHREAD_ENABLE_PLATFORM_UDP
 libopenthread_posix_a_SOURCES            += \
     udp.cpp                                 \

--- a/src/posix/platform/hdlc_interface.hpp
+++ b/src/posix/platform/hdlc_interface.hpp
@@ -36,7 +36,7 @@
 
 #include "platform-config.h"
 
-#include "hdlc.hpp"
+#include "ncp/hdlc.hpp"
 
 namespace ot {
 namespace PosixApp {

--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -37,7 +37,7 @@
 #include <openthread/platform/radio.h>
 
 #include "hdlc_interface.hpp"
-#include "spinel.h"
+#include "ncp/spinel.h"
 
 namespace ot {
 namespace PosixApp {


### PR DESCRIPTION
This PR aims to simplify the posix-app makefiles (remove the use `inc_hdlc.cpp` and `inc_spine.c` trick). The idea is to instead include the library `libopenthread-ncp-ftd.a` when linking the final posix-app executable `ot-ncp`,  `ot-cli` and/or, `o-daemon`.

The PR contains 3 separate (small) commits: 
-  [cli] ensure legacy callback APIs are defined as `OT_TOOL_WEAK`
-  [posix-app] simplify the makefile (link in ncp lib).
-  [posix-app] ensure header files from ncp folder have "ncp/" prefix


