### PR TITLE
[style] change style guide for use of goto keyword

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -33,7 +33,7 @@
 - Non-local Goto
   - There should be no calls to the functions `setjmp` or `longjmp`.
 - Local Goto
-  - There should be no calls to the C/C++ keyword goto.  Exception: The use of local gotos for the purposes of common error handling blocks and single points of function return at the bottom of a function.
+  - The use of C/C++ keyword goto should be avoided.  Exception: The use of local gotos for the purposes of common error handling blocks and single points of function return at the bottom of a function.
 - C Preprocessor
   - Use of the C preprocessor should be limited to file inclusion and simple macros.
   - Macros shall not be defined within a function or a block and should be defined at the top of a file.


### PR DESCRIPTION
This commit changes the style guide related to the use of `goto`
keyword (change from "should not use " to "should be avoided") in
order to allow its use selectively.

------------

This is follow up from discussion in https://github.com/openthread/openthread/pull/3952#discussion_r300161922 to let us selectively allow  the use `goto` (e.g., in [`Lowpan::Compress`](https://github.com/openthread/openthread/blob/master/src/core/thread/lowpan.cpp#L250) to jump to the start of method).