### PR TITLE
[mac] change the sub-mac callback model

### DIFF
--- a/src/core/mac/link_raw.cpp
+++ b/src/core/mac/link_raw.cpp
@@ -59,7 +59,7 @@ LinkRaw::LinkRaw(Instance &aInstance)
     , mTransmitDoneCallback(NULL)
     , mEnergyScanDoneCallback(NULL)
 #if OPENTHREAD_RADIO
-    , mSubMac(aInstance, *this)
+    , mSubMac(aInstance)
 #elif OPENTHREAD_ENABLE_RAW_LINK_API
     , mSubMac(aInstance.Get<SubMac>())
 #endif

--- a/src/core/mac/link_raw.hpp
+++ b/src/core/mac/link_raw.hpp
@@ -52,10 +52,6 @@ namespace Mac {
  *
  */
 class LinkRaw : public InstanceLocator
-#if OPENTHREAD_RADIO
-    ,
-                public SubMac::Callbacks
-#endif
 {
     friend class ot::Instance;
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -96,7 +96,7 @@ Mac::Mac(Instance &aInstance)
     , mScanDuration(0)
     , mScanChannelMask()
     , mActiveScanHandler(NULL) /* Initialize `mActiveScanHandler` and `mEnergyScanHandler` union */
-    , mSubMac(aInstance, *this)
+    , mSubMac(aInstance)
     , mOperationTask(aInstance, &Mac::HandleOperationTask, this)
     , mTimer(aInstance, &Mac::HandleTimer, this)
     , mOobFrame(NULL)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -93,7 +93,7 @@ enum
  * This class implements the IEEE 802.15.4 MAC.
  *
  */
-class Mac : public InstanceLocator, public SubMac::Callbacks
+class Mac : public InstanceLocator
 {
     friend class ot::Instance;
 

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -45,7 +45,7 @@
 namespace ot {
 namespace Mac {
 
-SubMac::SubMac(Instance &aInstance, Callbacks &aCallbacks)
+SubMac::SubMac(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mRadioCaps(otPlatRadioGetCaps(&aInstance))
     , mState(kStateDisabled)
@@ -56,7 +56,7 @@ SubMac::SubMac(Instance &aInstance, Callbacks &aCallbacks)
     , mEnergyScanMaxRssi(kInvalidRssiValue)
     , mEnergyScanEndTime(0)
     , mTransmitFrame(*static_cast<Frame *>(otPlatRadioGetTransmitBuffer(&aInstance)))
-    , mCallbacks(aCallbacks)
+    , mCallbacks(aInstance)
     , mPcapCallback(NULL)
     , mPcapCallbackContext(NULL)
     , mTimer(aInstance, &SubMac::HandleTimer, this)

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -86,11 +86,17 @@ public:
      * This class defines the callbacks notifying `SubMac` user of changes and events.
      *
      */
-    class Callbacks
+    class Callbacks : public InstanceLocator
     {
-        friend class SubMac;
+    public:
+        /**
+         * This constructor initializes the `Callbacks` object.
+         *
+         * @param[in]  aInstance  A reference to the OpenThread instance.
+         *
+         */
+        explicit Callbacks(Instance &aInstance);
 
-    protected:
         /**
          * This method notifies user of `SubMac` of a received frame.
          *
@@ -173,22 +179,15 @@ public:
          */
         void FrameUpdated(Frame &aFrame);
 #endif
-
-        /**
-         * This constructor initializes the `Callbacks` object.
-         *
-         */
-        Callbacks(void) {}
     };
 
     /**
      * This constructor initializes the `SubMac` object.
      *
      * @param[in]  aInstance  A reference to the OpenThread instance.
-     * @param[in]  aCallbacks A reference to the `Callbacks` object.
      *
      */
-    SubMac(Instance &aInstance, Callbacks &aCallbacks);
+    explicit SubMac(Instance &aInstance);
 
     /**
      * This method gets the capabilities provided by platform radio.
@@ -465,7 +464,7 @@ private:
     int8_t             mEnergyScanMaxRssi;
     uint32_t           mEnergyScanEndTime;
     Frame &            mTransmitFrame;
-    Callbacks &        mCallbacks;
+    Callbacks          mCallbacks;
     otLinkPcapCallback mPcapCallback;
     void *             mPcapCallbackContext;
 #if OPENTHREAD_CONFIG_ENABLE_PLATFORM_USEC_TIMER

--- a/src/core/mac/sub_mac_callbacks.cpp
+++ b/src/core/mac/sub_mac_callbacks.cpp
@@ -41,29 +41,30 @@
 namespace ot {
 namespace Mac {
 
+SubMac::Callbacks::Callbacks(Instance &aInstance)
+    : InstanceLocator(aInstance)
+{
+}
+
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
 
 void SubMac::Callbacks::ReceiveDone(Frame *aFrame, otError aError)
 {
-    Mac &mac = *static_cast<Mac *>(this);
-
 #if OPENTHREAD_ENABLE_RAW_LINK_API
-    LinkRaw &linkRaw = mac.Get<LinkRaw>();
-
-    if (linkRaw.IsEnabled())
+    if (Get<LinkRaw>().IsEnabled())
     {
-        linkRaw.InvokeReceiveDone(aFrame, aError);
+        Get<LinkRaw>().InvokeReceiveDone(aFrame, aError);
     }
     else
 #endif
     {
-        mac.HandleReceivedFrame(aFrame, aError);
+        Get<Mac>().HandleReceivedFrame(aFrame, aError);
     }
 }
 
 void SubMac::Callbacks::RecordCcaStatus(bool aCcaSuccess, uint8_t aChannel)
 {
-    static_cast<Mac *>(this)->RecordCcaStatus(aCcaSuccess, aChannel);
+    Get<Mac>().RecordCcaStatus(aCcaSuccess, aChannel);
 }
 
 void SubMac::Callbacks::RecordFrameTransmitStatus(const Frame &aFrame,
@@ -72,42 +73,34 @@ void SubMac::Callbacks::RecordFrameTransmitStatus(const Frame &aFrame,
                                                   uint8_t      aRetryCount,
                                                   bool         aWillRetx)
 {
-    static_cast<Mac *>(this)->RecordFrameTransmitStatus(aFrame, aAckFrame, aError, aRetryCount, aWillRetx);
+    Get<Mac>().RecordFrameTransmitStatus(aFrame, aAckFrame, aError, aRetryCount, aWillRetx);
 }
 
 void SubMac::Callbacks::TransmitDone(Frame &aFrame, Frame *aAckFrame, otError aError)
 {
-    Mac &mac = *static_cast<Mac *>(this);
-
 #if OPENTHREAD_ENABLE_RAW_LINK_API
-    LinkRaw &linkRaw = mac.Get<LinkRaw>();
-
-    if (linkRaw.IsEnabled())
+    if (Get<LinkRaw>().IsEnabled())
     {
-        linkRaw.InvokeTransmitDone(aFrame, aAckFrame, aError);
+        Get<LinkRaw>().InvokeTransmitDone(aFrame, aAckFrame, aError);
     }
     else
 #endif
     {
-        mac.HandleTransmitDone(aFrame, aAckFrame, aError);
+        Get<Mac>().HandleTransmitDone(aFrame, aAckFrame, aError);
     }
 }
 
 void SubMac::Callbacks::EnergyScanDone(int8_t aMaxRssi)
 {
-    Mac &mac = *static_cast<Mac *>(this);
-
 #if OPENTHREAD_ENABLE_RAW_LINK_API
-    LinkRaw &linkRaw = mac.Get<LinkRaw>();
-
-    if (linkRaw.IsEnabled())
+    if (Get<LinkRaw>().IsEnabled())
     {
-        linkRaw.InvokeEnergyScanDone(aMaxRssi);
+        Get<LinkRaw>().InvokeEnergyScanDone(aMaxRssi);
     }
     else
 #endif
     {
-        mac.EnergyScanDone(aMaxRssi);
+        Get<Mac>().EnergyScanDone(aMaxRssi);
     }
 }
 
@@ -120,13 +113,9 @@ void SubMac::Callbacks::FrameUpdated(Frame &aFrame)
      *
      */
 
-    Mac &mac = *static_cast<Mac *>(this);
-
     if (aFrame.GetSecurityEnabled())
     {
-        const ExtAddress &extAddress = mac.GetExtAddress();
-
-        mac.ProcessTransmitAesCcm(aFrame, &extAddress);
+        Get<Mac>().ProcessTransmitAesCcm(aFrame, &Get<Mac>().GetExtAddress());
     }
 }
 #endif
@@ -135,7 +124,7 @@ void SubMac::Callbacks::FrameUpdated(Frame &aFrame)
 
 void SubMac::Callbacks::ReceiveDone(Frame *aFrame, otError aError)
 {
-    static_cast<LinkRaw *>(this)->InvokeReceiveDone(aFrame, aError);
+    Get<LinkRaw>().InvokeReceiveDone(aFrame, aError);
 }
 
 void SubMac::Callbacks::RecordCcaStatus(bool, uint8_t)
@@ -148,17 +137,17 @@ void SubMac::Callbacks::RecordFrameTransmitStatus(const Frame &aFrame,
                                                   uint8_t      aRetryCount,
                                                   bool         aWillRetx)
 {
-    static_cast<LinkRaw *>(this)->RecordFrameTransmitStatus(aFrame, aAckFrame, aError, aRetryCount, aWillRetx);
+    Get<LinkRaw>().RecordFrameTransmitStatus(aFrame, aAckFrame, aError, aRetryCount, aWillRetx);
 }
 
 void SubMac::Callbacks::TransmitDone(Frame &aFrame, Frame *aAckFrame, otError aError)
 {
-    static_cast<LinkRaw *>(this)->InvokeTransmitDone(aFrame, aAckFrame, aError);
+    Get<LinkRaw>().InvokeTransmitDone(aFrame, aAckFrame, aError);
 }
 
 void SubMac::Callbacks::EnergyScanDone(int8_t aMaxRssi)
 {
-    static_cast<LinkRaw *>(this)->InvokeEnergyScanDone(aMaxRssi);
+    Get<LinkRaw>().InvokeEnergyScanDone(aMaxRssi);
 }
 
 #if OPENTHREAD_CONFIG_HEADER_IE_SUPPORT


### PR DESCRIPTION
This commit changes the sub-mac callback model to simplify it such
that `SubMac::Callback` is itself an `InstanceLocator` and directly
calls into the correct next layers (`Mac` or `LinkRaw`). This model
relaxes the need for the other classes to sub-class the `Callback`
and will have `SubMac` itself define a `mCallbacks` instance (which
is an empty class) instead of tracking a reference to a callback
object.