### PR TITLE
[posix-app] add HOST flag for cross compiling

### DIFF
--- a/src/posix/Makefile-posix
+++ b/src/posix/Makefile-posix
@@ -78,8 +78,12 @@ configure_OPTIONS                   = \
 
 # Platform specific switches
 
-ifeq (${DAEMON},1)
+ifeq ($(DAEMON),1)
 configure_OPTIONS              += --enable-posix-app-daemon
+endif
+
+ifneq ($(HOST),)
+configure_OPTIONS              += --host=$(HOST)
 endif
 
 ifneq ($(DEBUG),1)

--- a/src/posix/Makefile-posix
+++ b/src/posix/Makefile-posix
@@ -82,14 +82,14 @@ ifeq ($(DAEMON),1)
 configure_OPTIONS              += --enable-posix-app-daemon
 endif
 
-ifneq ($(HOST),)
-configure_OPTIONS              += --host=$(HOST)
-endif
-
 ifneq ($(DEBUG),1)
 COMMONCFLAGS                   += \
     -O2                           \
     $(NULL)
+endif
+
+ifneq ($(HOST),)
+configure_OPTIONS              += --host=$(HOST)
 endif
 
 ifeq ($(PLATFORM_NETIF),1)


### PR DESCRIPTION
This commit add 'HOST' to provide the option for changing compile target host for cross compiling.