### PR TITLE
[posix] use multicast to simulate radio

### DIFF
--- a/examples/platforms/posix/platform-posix.h
+++ b/examples/platforms/posix/platform-posix.h
@@ -170,10 +170,12 @@ void platformRadioUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, int *aMax
 /**
  * This function performs radio driver processing.
  *
- * @param[in]  aInstance  The OpenThread instance structure.
+ * @param[in]  aInstance    The OpenThread instance structure.
+ * @param[in]  aReadFdSet   A pointer to the read file descriptors.
+ * @param[in]  aWriteFdSet  A pointer to the write file descriptors.
  *
  */
-void platformRadioProcess(otInstance *aInstance);
+void platformRadioProcess(otInstance *aInstance, const fd_set *aReadFdSet, const fd_set *aWriteFdSet);
 
 /**
  * This function initializes the random number service used by OpenThread.

--- a/examples/platforms/posix/sim/platform-sim.c
+++ b/examples/platforms/posix/sim/platform-sim.c
@@ -301,7 +301,7 @@ void otSysProcessDrivers(otInstance *aInstance)
     }
 
     platformAlarmProcess(aInstance);
-    platformRadioProcess(aInstance);
+    platformRadioProcess(aInstance, &read_fds, &write_fds);
 #if OPENTHREAD_POSIX_VIRTUAL_TIME_UART == 0
     platformUartProcess();
 #endif

--- a/tests/scripts/thread-cert/config.py
+++ b/tests/scripts/thread-cert/config.py
@@ -459,8 +459,8 @@ def create_default_thread_message_factory(master_key=DEFAULT_MASTER_KEY):
     return message.MessageFactory(lowpan_parser=lowpan_parser)
 
 
-def create_default_thread_sniffer(nodeid=SNIFFER_ID):
-    return sniffer.Sniffer(nodeid, create_default_thread_message_factory())
+def create_default_thread_sniffer():
+    return sniffer.Sniffer(create_default_thread_message_factory())
 
 
 def create_default_simulator():

--- a/tests/scripts/thread-cert/sniffer.py
+++ b/tests/scripts/thread-cert/sniffer.py
@@ -54,21 +54,19 @@ class Sniffer:
 
     RECV_BUFFER_SIZE = 4096
 
-    def __init__(self, nodeid, message_factory):
+    def __init__(self, message_factory):
         """
         Args:
-            nodeid (int): Node identifier
             message_factory (MessageFactory): Class producing messages from data bytes.
         """
 
-        self.nodeid = nodeid
         self._message_factory = message_factory
 
         self._pcap = pcap.PcapCodec(os.getenv('TEST_NAME', 'current'))
 
         # Create transport
         transport_factory = sniffer_transport.SnifferTransportFactory()
-        self._transport = transport_factory.create_transport(nodeid)
+        self._transport = transport_factory.create_transport()
 
         self._thread = None
         self._thread_alive = threading.Event()


### PR DESCRIPTION
This PR changes to use multicast to simulate radio transmission. This
avoids sending a frame multiple times, and also avoid duplicated packets
in captures which is annoying when analyzing traffic.

This implementation uses two separate sockets for tx and rx. This is
because the current implementation of thread-cert requires sniffer
reports the exact sender of each packet. This issue can be addressed by
stateful tracking state of each node, but I don't have the cycles for
now.