### PR TITLE
[spi-hdlc-adapter] add cast to unsigned int on call to usleep

### DIFF
--- a/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
+++ b/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
@@ -1826,7 +1826,7 @@ int main(int argc, char *argv[])
 
     trigger_reset();
 
-    usleep(sSpiResetDelay * USEC_PER_MSEC);
+    usleep((useconds_t)sSpiResetDelay * USEC_PER_MSEC);
 
     // ========================================================================
     // MAIN LOOP


### PR DESCRIPTION
Resolve build failure:
```
spi-hdlc-adapter.c:1829:27: error: implicit conversion changes signedness: 'int' to '__useconds_t' (aka 'unsigned int') [-Werror,-Wsign-conversion]
    usleep(sSpiResetDelay * USEC_PER_MSEC);
    ~~~~~~ ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
```