### PR TITLE
[efr32] add otSysEventSignalPending calls to efr32mg12

### DIFF
--- a/examples/platforms/efr32mg12/Makefile.am
+++ b/examples/platforms/efr32mg12/Makefile.am
@@ -46,6 +46,7 @@ libopenthread_efr32mg12_a_CPPFLAGS                                            = 
     -D__START=main                                                              \
     -D__STARTUP_CLEAR_BSS                                                       \
     -DPLATFORM_HEADER=\"@top_builddir@/third_party/silabs/gecko_sdk_suite/v2.6/platform/base/hal/micro/cortexm3/compiler/gcc.h\" \
+    -DNVIC_CONFIG=\"platform/base/hal/micro/cortexm3/efm32/nvic-config.h\"      \
     -Wno-sign-compare                                                           \
     -DCORTEXM3                                                                  \
     -DPHY=EMBER_PHY_RAIL                                                        \

--- a/examples/platforms/efr32mg12/alarm.c
+++ b/examples/platforms/efr32mg12/alarm.c
@@ -36,6 +36,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "openthread-system.h"
 #include <openthread/config.h>
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
@@ -67,6 +68,7 @@ static bool     sIsRunning = false;
 
 static void RAILCb_TimerExpired(RAIL_Handle_t aHandle)
 {
+    otSysEventSignalPending();
 }
 
 void efr32AlarmInit(void)

--- a/examples/platforms/efr32mg12/system.c
+++ b/examples/platforms/efr32mg12/system.c
@@ -34,6 +34,7 @@
 
 #include <string.h>
 
+#include "openthread-system.h"
 #include <openthread/tasklet.h>
 #include <openthread/platform/uart.h>
 
@@ -70,16 +71,27 @@ void otSysInit(int argc, char *argv[])
     OT_UNUSED_VARIABLE(argc);
     OT_UNUSED_VARIABLE(argv);
 
+    __disable_irq();
+
+#undef FIXED_EXCEPTION
+#define FIXED_EXCEPTION(vectorNumber, functionName, deviceIrqn, deviceIrqHandler)
+#define EXCEPTION(vectorNumber, functionName, deviceIrqn, deviceIrqHandler, priorityLevel, subpriority) \
+    NVIC_SetPriority(deviceIrqn, NVIC_EncodePriority(PRIGROUP_POSITION, priorityLevel, subpriority));
+#include NVIC_CONFIG
+#undef EXCEPTION
+
+    NVIC_SetPriorityGrouping(PRIGROUP_POSITION);
     CHIP_Init();
-
     halInitChipSpecific();
-
     BSP_Init(BSP_INIT_BCC);
+    RTCDRV_Init();
 
 #if (HAL_FEM_ENABLE)
     initFem();
     wakeupFem();
 #endif
+
+    __enable_irq();
 
 #if USE_EFR32_LOG
     efr32LogInit();
@@ -152,4 +164,9 @@ void otSysProcessDrivers(otInstance *aInstance)
     efr32UartProcess();
     efr32RadioProcess(aInstance);
     efr32AlarmProcess(aInstance);
+}
+
+__WEAK void otSysEventSignalPending(void)
+{
+    // Intentionally empty
 }

--- a/examples/platforms/efr32mg12/uart.c
+++ b/examples/platforms/efr32mg12/uart.c
@@ -34,6 +34,7 @@
 
 #include <stddef.h>
 
+#include "openthread-system.h"
 #include <openthread/platform/uart.h>
 
 #include "utils/code_utils.h"
@@ -132,6 +133,8 @@ static void receiveDone(UARTDRV_Handle_t aHandle, Ecode_t aStatus, uint8_t *aDat
         assert(sReceiveDeferred == false);
         sReceiveDeferred = true;
     }
+
+    otSysEventSignalPending();
 }
 
 static inline bool isBufferEmpty(uint16_t unwrappedReadStart, uint16_t unwrappedReadEnd)
@@ -180,6 +183,7 @@ exit:
 static void transmitDone(UARTDRV_Handle_t aHandle, Ecode_t aStatus, uint8_t *aData, UARTDRV_Count_t aCount)
 {
     sTransmitLength = 0;
+    otSysEventSignalPending();
 }
 
 static void processReceive(void)


### PR DESCRIPTION
Added otSysEventSignalPending calls and defined as a weak function to efr32mg12.  This is for the porting of OpenWeave to run on top of OpenThread on the EFR32 and is used as a way to wake up the Thread task to execute otSysProcessDrivers in response to uart, alarm and radio events. 

Added configuration of NVIC and interrupt priorities.
Moved RTCDRV Initialization from radio.c into system.c

Note that uart.c only calls otSysEventSignalPending when a transfer (currently 64-bytes) is complete.  This doesn't affect bare-metal CLI and NCP apps.   However we may modify this in a later commit to call otSysEventSignalPending on every byte received.