### PR TITLE
 [indirect-sender] convert queued child messages when mode changes

### DIFF
--- a/src/core/thread/indirect_sender.hpp
+++ b/src/core/thread/indirect_sender.hpp
@@ -186,6 +186,15 @@ public:
      */
     void SetChildUseShortAddress(Child &aChild, bool aUseShortAddress);
 
+    /**
+     * This method handles a child mode change and updates any queued messages for the child accordingly.
+     *
+     * @param[in]  aChild    The child whose device mode was changed.
+     * @param[in]  aOldMode  The old device mode of the child.
+     *
+     */
+    void HandleChildModeChange(Child &aChild, uint8_t aOldMode);
+
 private:
     enum
     {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2225,6 +2225,7 @@ otError MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
     LeaderDataTlv   leaderData;
     TimeoutTlv      timeout;
     Child *         child;
+    uint8_t         oldMode;
     TlvRequestTlv   tlvRequest;
     uint8_t         tlvs[kMaxResponseTlvs];
     uint8_t         tlvslength                = 0;
@@ -2257,23 +2258,8 @@ otError MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
         ExitNow();
     }
 
-    if (child->GetDeviceMode() != mode.GetMode())
-    {
-        otLogNoteMle("Child 0x%04x mode change 0x%02x -> 0x%02x [rx-on:%s, sec-data-req:%s, ftd:%s, full-netdata:%s]",
-                     child->GetRloc16(), child->GetDeviceMode(), mode.GetMode(),
-                     (mode.GetMode() & ModeTlv::kModeRxOnWhenIdle) ? "yes" : " no",
-                     (mode.GetMode() & ModeTlv::kModeSecureDataRequest) ? "yes" : " no",
-                     (mode.GetMode() & ModeTlv::kModeFullThreadDevice) ? "yes" : "no",
-                     (mode.GetMode() & ModeTlv::kModeFullNetworkData) ? "yes" : "no");
-
-        child->SetDeviceMode(mode.GetMode());
-        childDidChange = true;
-
-        if (!(mode.GetMode() & ModeTlv::kModeRxOnWhenIdle) && (child->GetState() == Neighbor::kStateValid))
-        {
-            Get<IndirectSender>().SetChildUseShortAddress(*child, true);
-        }
-    }
+    oldMode = child->GetDeviceMode();
+    child->SetDeviceMode(mode.GetMode());
 
     tlvs[tlvslength++] = Tlv::kMode;
 
@@ -2336,6 +2322,25 @@ otError MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
     }
 
     child->SetLastHeard(TimerMilli::GetNow());
+
+    if (oldMode != child->GetDeviceMode())
+    {
+        otLogNoteMle("Child 0x%04x mode change 0x%02x -> 0x%02x [rx-on:%s, sec-data-req:%s, ftd:%s, full-netdata:%s]",
+                     child->GetRloc16(), oldMode, mode.GetMode(),
+                     (mode.GetMode() & ModeTlv::kModeRxOnWhenIdle) ? "yes" : "no",
+                     (mode.GetMode() & ModeTlv::kModeSecureDataRequest) ? "yes" : "no",
+                     (mode.GetMode() & ModeTlv::kModeFullThreadDevice) ? "yes" : "no",
+                     (mode.GetMode() & ModeTlv::kModeFullNetworkData) ? "yes" : "no");
+
+        childDidChange = true;
+
+        // The `IndirectSender::HandleChildModeChange()` needs to happen
+        // after "Child Update" message is fully parsed to ensure that
+        // any registered IPv6 addresses included in the "Child Update"
+        // are added to the child.
+
+        Get<IndirectSender>().HandleChildModeChange(*child, oldMode);
+    }
 
     if (child->IsStateRestoring())
     {


### PR DESCRIPTION
This PR contains two related commits: 

**[indirect-sender] convert queued child messages when mode changes**
    
This commit ensures all queued messages for a child are accordingly
converted (direct vs. indirect transmission) when a child switches its
mode (from sleepy to non-sleepy or vice versa).

**[toranj] update child mode change test for msg direct/indirect conversion**
    
This commit updates `test-027-child-mode-change` to verify the
behavior of a parent node related to conversion of any queued messages
(direct vs indirect tx) upon the child's mode change. It ensures
unicaset and multicast messages are correctly received by the children
on a mode change (sleepy to non-sleep or vice versa).

It should help address issue https://github.com/openthread/openthread/issues/3988.

