### PR TITLE
[platform] add a UART flush operation

### DIFF
--- a/examples/platforms/cc1352/uart.c
+++ b/examples/platforms/cc1352/uart.c
@@ -192,10 +192,7 @@ static void processReceive(void)
     }
 }
 
-/**
- * @brief process the transmit side of the buffers
- */
-static void processTransmit(void)
+otError otPlatUartFlush(void)
 {
     otEXPECT(sSendBuffer != NULL);
 
@@ -207,10 +204,20 @@ static void processTransmit(void)
 
     sSendBuffer = NULL;
     sSendLen    = 0;
-    otPlatUartSendDone();
 
+    return OT_ERROR_NONE;
 exit:
-    return;
+    // Nothing to flush?
+    return OT_ERROR_INVALID_STATE;
+}
+
+/**
+ * @brief process the transmit side of the buffers
+ */
+static void processTransmit(void)
+{
+    otPlatUartFlush();
+    otPlatUartSendDone();
 }
 
 /**

--- a/examples/platforms/cc1352/uart.c
+++ b/examples/platforms/cc1352/uart.c
@@ -206,8 +206,8 @@ otError otPlatUartFlush(void)
     sSendLen    = 0;
 
     return OT_ERROR_NONE;
+
 exit:
-    // Nothing to flush?
     return OT_ERROR_INVALID_STATE;
 }
 

--- a/examples/platforms/cc2538/uart.c
+++ b/examples/platforms/cc2538/uart.c
@@ -195,7 +195,6 @@ otError otPlatUartFlush(void)
     return OT_ERROR_NONE;
 
 exit:
-    // Nothing to flush?
     return OT_ERROR_INVALID_STATE;
 }
 

--- a/examples/platforms/cc2538/uart.c
+++ b/examples/platforms/cc2538/uart.c
@@ -179,7 +179,7 @@ void processReceive(void)
     }
 }
 
-void processTransmit(void)
+otError otPlatUartFlush(void)
 {
     otEXPECT(sTransmitBuffer != NULL);
 
@@ -192,10 +192,17 @@ void processTransmit(void)
     }
 
     sTransmitBuffer = NULL;
-    otPlatUartSendDone();
+    return OT_ERROR_NONE;
 
 exit:
-    return;
+    // Nothing to flush?
+    return OT_ERROR_INVALID_STATE;
+}
+
+void processTransmit(void)
+{
+    otPlatUartFlush();
+    otPlatUartSendDone();
 }
 
 void cc2538UartProcess(void)

--- a/examples/platforms/cc2650/uart.c
+++ b/examples/platforms/cc2650/uart.c
@@ -147,10 +147,7 @@ static void processReceive(void)
     }
 }
 
-/**
- * @brief process the transmit side of the buffers
- */
-static void processTransmit(void)
+otError otPlatUartFlush(void)
 {
     otEXPECT(sSendBuffer != NULL);
 
@@ -162,10 +159,20 @@ static void processTransmit(void)
 
     sSendBuffer = NULL;
     sSendLen    = 0;
-    otPlatUartSendDone();
 
+    return OT_ERROR_NONE;
 exit:
-    return;
+    // Nothing to flush?
+    return OT_ERROR_INVALID_STATE;
+}
+
+/**
+ * @brief process the transmit side of the buffers
+ */
+static void processTransmit(void)
+{
+    otPlatUartFlush();
+    otPlatUartSendDone();
 }
 
 /**

--- a/examples/platforms/cc2650/uart.c
+++ b/examples/platforms/cc2650/uart.c
@@ -161,8 +161,8 @@ otError otPlatUartFlush(void)
     sSendLen    = 0;
 
     return OT_ERROR_NONE;
+
 exit:
-    // Nothing to flush?
     return OT_ERROR_INVALID_STATE;
 }
 

--- a/examples/platforms/cc2652/uart.c
+++ b/examples/platforms/cc2652/uart.c
@@ -192,10 +192,7 @@ static void processReceive(void)
     }
 }
 
-/**
- * @brief process the transmit side of the buffers
- */
-static void processTransmit(void)
+otError otPlatUartFlush(void)
 {
     otEXPECT(sSendBuffer != NULL);
 
@@ -207,10 +204,20 @@ static void processTransmit(void)
 
     sSendBuffer = NULL;
     sSendLen    = 0;
-    otPlatUartSendDone();
+
+    return OT_ERROR_NONE;
 
 exit:
-    return;
+    return OT_ERROR_INVALID_STATE;
+}
+
+/**
+ * @brief process the transmit side of the buffers
+ */
+static void processTransmit(void)
+{
+    otPlatUartFlush();
+    otPlatUartSendDone();
 }
 
 /**

--- a/examples/platforms/efr32mg12/uart.c
+++ b/examples/platforms/efr32mg12/uart.c
@@ -251,7 +251,7 @@ static void processReceive(void)
 
 otError otPlatUartFlush(void)
 {
-	return OT_ERROR_NOT_IMPLEMENTED;
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
 static void processTransmit(void)

--- a/examples/platforms/efr32mg12/uart.c
+++ b/examples/platforms/efr32mg12/uart.c
@@ -249,6 +249,11 @@ static void processReceive(void)
     CORE_EXIT_NVIC();
 }
 
+otError otPlatUartFlush(void)
+{
+	return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 static void processTransmit(void)
 {
     if (sTransmitBuffer != NULL && sTransmitLength == 0)

--- a/examples/platforms/efr32mg21/uart.c
+++ b/examples/platforms/efr32mg21/uart.c
@@ -250,6 +250,11 @@ static void processReceive(void)
     CORE_EXIT_NVIC();
 }
 
+otError otPlatUartFlush(void)
+{
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 static void processTransmit(void)
 {
     if (sTransmitBuffer != NULL && sTransmitLength == 0)

--- a/examples/platforms/gp712/uart-posix.c
+++ b/examples/platforms/gp712/uart-posix.c
@@ -207,6 +207,11 @@ exit:
     return error;
 }
 
+otError otPlatUartFlush(void)
+{
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 void platformUartProcess(void)
 {
     ssize_t       rval;

--- a/examples/platforms/gp712/uart-socket.c
+++ b/examples/platforms/gp712/uart-socket.c
@@ -149,6 +149,11 @@ otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
     return error;
 }
 
+otError otPlatUartFlush(void)
+{
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 void platformUartInit(void)
 {
 }

--- a/examples/platforms/kw41z/uart.c
+++ b/examples/platforms/kw41z/uart.c
@@ -120,6 +120,11 @@ exit:
     return error;
 }
 
+otError otPlatUartFlush(void)
+{
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 static void processTransmit(void)
 {
     if (sTransmitBuffer && sTransmitDone)

--- a/examples/platforms/nrf52811/uart.c
+++ b/examples/platforms/nrf52811/uart.c
@@ -119,6 +119,11 @@ exit:
     return;
 }
 
+otError otPlatUartFlush(void)
+{
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 /**
  * Function for notifying application about transmission being done.
  */

--- a/examples/platforms/nrf52840/uart.c
+++ b/examples/platforms/nrf52840/uart.c
@@ -119,6 +119,11 @@ exit:
     return;
 }
 
+otError otPlatUartFlush(void)
+{
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 /**
  * Function for notifying application about transmission being done.
  */

--- a/examples/platforms/nrf52840/usb-cdc-uart.c
+++ b/examples/platforms/nrf52840/usb-cdc-uart.c
@@ -362,4 +362,9 @@ exit:
     return error;
 }
 
+otError otPlatUartFlush(void)
+{
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 #endif // USB_CDC_AS_SERIAL_TRANSPORT == 1

--- a/examples/platforms/posix/sim/platform-sim.c
+++ b/examples/platforms/posix/sim/platform-sim.c
@@ -165,6 +165,11 @@ otError otPlatUartSend(const uint8_t *aData, uint16_t aLength)
 
     return error;
 }
+
+otError otPlatUartFlush(void)
+{
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
 #endif // OPENTHREAD_POSIX_VIRTUAL_TIME_UART
 
 static void socket_init(void)

--- a/examples/platforms/posix/spi-stubs.c
+++ b/examples/platforms/posix/spi-stubs.c
@@ -78,11 +78,6 @@ void otPlatUartSendDone(void)
 {
 }
 
-otError otPlatUartFlush(void)
-{
-    return OT_ERROR_NOT_IMPLEMENTED;
-}
-
 void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength)
 {
     OT_UNUSED_VARIABLE(aBuf);

--- a/examples/platforms/posix/spi-stubs.c
+++ b/examples/platforms/posix/spi-stubs.c
@@ -78,6 +78,11 @@ void otPlatUartSendDone(void)
 {
 }
 
+otError otPlatUartFlush(void)
+{
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength)
 {
     OT_UNUSED_VARIABLE(aBuf);

--- a/examples/platforms/posix/uart-posix.c
+++ b/examples/platforms/posix/uart-posix.c
@@ -222,6 +222,11 @@ void platformUartUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, fd_set *aE
     }
 }
 
+otError otPlatUartFlush(void)
+{
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 void platformUartProcess(void)
 {
     ssize_t       rval;

--- a/examples/platforms/qpg6095/uart.c
+++ b/examples/platforms/qpg6095/uart.c
@@ -57,6 +57,11 @@ otError otPlatUartDisable(void)
     return error;
 }
 
+otError otPlatUartFlush(void)
+{
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 {
     otError error = OT_ERROR_NONE;

--- a/examples/platforms/samr21/uart.c
+++ b/examples/platforms/samr21/uart.c
@@ -97,6 +97,11 @@ static void processReceive(void)
     }
 }
 
+otError otPlatUartFlush(void)
+{
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 static void processTransmit(void)
 {
     if (sTransmitDone)

--- a/include/openthread/platform/uart.h
+++ b/include/openthread/platform/uart.h
@@ -88,9 +88,11 @@ otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength);
  * This is called when the CLI UART interface has a full buffer but still
  * wishes to send more data.
  *
- * @retval OT_ERROR_NONE    Flush succeeded, we can proceed to write more
- *                          data to the buffer.
- * @retval !OT_ERROR_NONE   Flush failed.  Following data will be truncated.
+ * @retval OT_ERROR_NONE                Flush succeeded, we can proceed to write more
+ *                                      data to the buffer.
+ *
+ * @retval OT_ERROR_NOT_IMPLEMENTED     Driver does not support synchronous flush.
+ * @retval OT_ERROR_INVALID_STATE       Driver has no data to flush.
  */
 otError otPlatUartFlush(void);
 

--- a/include/openthread/platform/uart.h
+++ b/include/openthread/platform/uart.h
@@ -84,6 +84,17 @@ otError otPlatUartDisable(void);
 otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength);
 
 /**
+ * Flush the outgoing transmit buffer and wait for the data to be sent.
+ * This is called when the CLI UART interface has a full buffer but still
+ * wishes to send more data.
+ *
+ * @retval OT_ERROR_NONE    Flush succeeded, we can proceed to write more
+ *                          data to the buffer.
+ * @retval !OT_ERROR_NONE   Flush failed.  Following data will be truncated.
+ */
+otError otPlatUartFlush(void);
+
+/**
  * The UART driver calls this method to notify OpenThread that the requested bytes have been sent.
  *
  */

--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -250,7 +250,7 @@ int Uart::Output(const char *aBuf, uint16_t aBufLength)
             sendLength = remaining;
         }
 
-        for (int i = 0; i < sendLength; i++)
+        for (uint16_t i = 0; i < sendLength; i++)
         {
             tail            = (mTxHead + mTxLength) % kTxBufferSize;
             mTxBuffer[tail] = *aBuf++;

--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -254,12 +254,12 @@ int Uart::Output(const char *aBuf, uint16_t aBufLength)
         {
             tail            = (mTxHead + mTxLength) % kTxBufferSize;
             mTxBuffer[tail] = *aBuf++;
+            aBufLength--;
             mTxLength++;
         }
 
         Send();
 
-        aBufLength -= sendLength;
         sent += sendLength;
 
         if (aBufLength > 0)

--- a/src/posix/platform/uart.c
+++ b/src/posix/platform/uart.c
@@ -161,6 +161,11 @@ exit:
     return error;
 }
 
+otError otPlatUartFlush(void)
+{
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 void platformUartUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, fd_set *aErrorFdSet, int *aMaxFd)
 {
     otEXPECT(sEnabled);


### PR DESCRIPTION
OpenThread's CLI relies on allocating a (by default) 1kB buffer into which it writes the text to be printed on the serial console so that the platform driver can organise for it to be transmitted to the terminal.

This may be done asynchronously via DMA (in the case of `nrf52840`, `efr32`, etc), or it may be done synchronously from the `otSysProcessDrivers` (e.g. `cc2538`, `emsk`, etc).

On memory-constrained devices like CC2538, it is helpful to reduce the size of this buffer, but this comes at a cost: output from commands such as `help` or `neighbor table` gets truncated as the buffer fills up.

This pull request introduces `otPlatUartFlush()` which when called, forces a blocking transmission of the pending data so that the buffer can be cleared to accept more data.  The buffer size can now be reduced to a mere 64 bytes or less.  The CLI UART TX buffer can then be reduced to a small value, with the only penalty being a small (~100ms) delay to the OpenThread process whilst the serial port is flushed when it fills up.

I have coded it so that if `otPlatUartFlush` returns something *other* than `OT_ERROR_NONE`, the data is discarded, preserving the old behaviour on platforms where it's not viable to implement a flush.  For Texas Instruments targets, the driver appeared to be essentially synchronous, so I've implemented it as such.  The others, I've just returned `OT_ERROR_NOT_IMPLEMENTED` so that the old behaviour remains.