### PR TITLE
[efr32] fix brd4304a build error of duplicate define

### DIFF
--- a/examples/platforms/efr32mg12/brd4161a/hal-config.h
+++ b/examples/platforms/efr32mg12/brd4161a/hal-config.h
@@ -33,6 +33,18 @@
 // [BULBPWM_COLOR]$
 
 // $[BUTTON]
+#define BSP_BUTTON_PRESENT                            (1)
+
+#define BSP_BUTTON0_PIN                               (6U)
+#define BSP_BUTTON0_PORT                              (gpioPortF)
+
+#define BSP_BUTTON1_PIN                               (7U)
+#define BSP_BUTTON1_PORT                              (gpioPortF)
+
+#define BSP_BUTTON_COUNT                              (2U)
+#define BSP_BUTTON_INIT                               { { BSP_BUTTON0_PORT, BSP_BUTTON0_PIN }, { BSP_BUTTON1_PORT, BSP_BUTTON1_PIN } }
+#define BSP_BUTTON_GPIO_DOUT                          (HAL_GPIO_DOUT_LOW)
+#define BSP_BUTTON_GPIO_MODE                          (HAL_GPIO_MODE_INPUT)
 // [BUTTON]$
 
 // $[CMU]

--- a/examples/platforms/efr32mg12/brd4166a/hal-config.h
+++ b/examples/platforms/efr32mg12/brd4166a/hal-config.h
@@ -33,6 +33,18 @@
 // [BULBPWM_COLOR]$
 
 // $[BUTTON]
+#define BSP_BUTTON_PRESENT                   (1)
+
+#define BSP_BUTTON0_PIN                      (14U)
+#define BSP_BUTTON0_PORT                     (gpioPortD)
+
+#define BSP_BUTTON1_PIN                      (15U)
+#define BSP_BUTTON1_PORT                     (gpioPortD)
+
+#define BSP_BUTTON_COUNT                     (2U)
+#define BSP_BUTTON_INIT                      { { BSP_BUTTON0_PORT, BSP_BUTTON0_PIN }, { BSP_BUTTON1_PORT, BSP_BUTTON1_PIN } }
+#define BSP_BUTTON_GPIO_DOUT                 (HAL_GPIO_DOUT_LOW)
+#define BSP_BUTTON_GPIO_MODE                 (HAL_GPIO_MODE_INPUT)
 // [BUTTON]$
 
 // $[CMU]

--- a/examples/platforms/efr32mg12/brd4304a/hal-config.h
+++ b/examples/platforms/efr32mg12/brd4304a/hal-config.h
@@ -33,6 +33,18 @@
 // [BULBPWM_COLOR]$
 
 // $[BUTTON]
+#define BSP_BUTTON_PRESENT                            (1)
+
+#define BSP_BUTTON0_PIN                               (6U)
+#define BSP_BUTTON0_PORT                              (gpioPortF)
+
+#define BSP_BUTTON1_PIN                               (7U)
+#define BSP_BUTTON1_PORT                              (gpioPortF)
+
+#define BSP_BUTTON_COUNT                              (2U)
+#define BSP_BUTTON_INIT                               { { BSP_BUTTON0_PORT, BSP_BUTTON0_PIN }, { BSP_BUTTON1_PORT, BSP_BUTTON1_PIN } }
+#define BSP_BUTTON_GPIO_DOUT                          (HAL_GPIO_DOUT_LOW)
+#define BSP_BUTTON_GPIO_MODE                          (HAL_GPIO_MODE_INPUT)
 // [BUTTON]$
 
 // $[CMU]

--- a/examples/platforms/efr32mg12/sleepy-demo/sleepy-demo-ftd/main.c
+++ b/examples/platforms/efr32mg12/sleepy-demo/sleepy-demo-ftd/main.c
@@ -30,7 +30,7 @@
 #include "em_cmu.h"
 #include "em_emu.h"
 #include "gpiointerrupt.h"
-#include "hal-config-board.h"
+#include "hal-config.h"
 #include "hal_common.h"
 #include "openthread-system.h"
 #include "rtcdriver.h"

--- a/examples/platforms/efr32mg12/sleepy-demo/sleepy-demo-mtd/main.c
+++ b/examples/platforms/efr32mg12/sleepy-demo/sleepy-demo-mtd/main.c
@@ -33,7 +33,7 @@
 #include "em_cmu.h"
 #include "em_emu.h"
 #include "gpiointerrupt.h"
-#include "hal-config-board.h"
+#include "hal-config.h"
 #include "hal_common.h"
 #include "openthread-system.h"
 #include "platform-efr32.h"


### PR DESCRIPTION
Fixes build error on efr32mg12/brd4304a that resulted in a conflicting define of BSP_LED_POLARITY.
Removed hal-config-board.h from sleepy demo and moved some definitions into each hal-config.h in order to build.

