### PR TITLE
[toranj] update test-002 to verify immediate command after a reset

### DIFF
--- a/tests/toranj/test-002-form.py
+++ b/tests/toranj/test-002-form.py
@@ -130,6 +130,14 @@ verify(node.get(wpan.WPAN_PANID) == '0x1977')
 verify(node.get(wpan.WPAN_XPANID) == '0x1020031510006016')
 verify(node.get(wpan.WPAN_IP6_MESH_LOCAL_PREFIX) == '"fd00:cafe::/64"')
 
+# Verify behavior when commands are issued immediately after a `reset`
+
+node.reset()
+node.leave()
+
+node.reset()
+node.form('net-after-reset')
+
 # -----------------------------------------------------------------------------------------------------------------------
 # Test finished
 


### PR DESCRIPTION
This commit updates toranj `test-002` to verify behavior of `wpantund`
when a command is issued immediately after a `reset`.

----
This is tied to https://github.com/openthread/wpantund/pull/428 and expected to fail until the `wpantund` change is merged.
