### PR TITLE
[posix-app] fix missing sentinel in execl()

### DIFF
--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -504,7 +504,8 @@ int HdlcInterface::ForkPty(const char *aCommand, const char *aArguments)
                      fprintf(stderr, "NCP file and configuration is too long!");
                      rval = -1);
 
-        VerifyOrExit((rval = execl(SOCKET_UTILS_DEFAULT_SHELL, SOCKET_UTILS_DEFAULT_SHELL, "-c", cmd, static_cast<char*>(NULL))) != -1,
+        VerifyOrExit((rval = execl(SOCKET_UTILS_DEFAULT_SHELL, SOCKET_UTILS_DEFAULT_SHELL, "-c", cmd,
+                        static_cast<char *>(NULL))) != -1,
                      perror("execl(OT_RCP)"));
     }
     else

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -505,7 +505,7 @@ int HdlcInterface::ForkPty(const char *aCommand, const char *aArguments)
                      rval = -1);
 
         VerifyOrExit((rval = execl(SOCKET_UTILS_DEFAULT_SHELL, SOCKET_UTILS_DEFAULT_SHELL, "-c", cmd,
-                                    static_cast<char *>(NULL))) != -1,
+                                   static_cast<char *>(NULL))) != -1,
                      perror("execl(OT_RCP)"));
     }
     else

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -504,7 +504,7 @@ int HdlcInterface::ForkPty(const char *aCommand, const char *aArguments)
                      fprintf(stderr, "NCP file and configuration is too long!");
                      rval = -1);
 
-        VerifyOrExit((rval = execl(SOCKET_UTILS_DEFAULT_SHELL, SOCKET_UTILS_DEFAULT_SHELL, "-c", cmd, NULL)) != -1,
+        VerifyOrExit((rval = execl(SOCKET_UTILS_DEFAULT_SHELL, SOCKET_UTILS_DEFAULT_SHELL, "-c", cmd, static_cast<char*>(NULL))) != -1,
                      perror("execl(OT_RCP)"));
     }
     else

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -505,7 +505,7 @@ int HdlcInterface::ForkPty(const char *aCommand, const char *aArguments)
                      rval = -1);
 
         VerifyOrExit((rval = execl(SOCKET_UTILS_DEFAULT_SHELL, SOCKET_UTILS_DEFAULT_SHELL, "-c", cmd,
-                        static_cast<char *>(NULL))) != -1,
+                                    static_cast<char *>(NULL))) != -1,
                      perror("execl(OT_RCP)"));
     }
     else


### PR DESCRIPTION
This commit fix error that when using OpenWRT package otbr project,
there will be an error: missing sentinel in function execl.