### PR TITLE
[nrf528xx] use nrfx_spis driver

### DIFF
--- a/examples/platforms/nrf52811/platform-config.h
+++ b/examples/platforms/nrf52811/platform-config.h
@@ -256,7 +256,7 @@
  * @def SPIS Instance.
  */
 #ifndef SPIS_INSTANCE
-#define SPIS_INSTANCE NRF_SPIS0
+#define SPIS_INSTANCE 0
 #endif
 
 /**
@@ -281,13 +281,6 @@
  */
 #ifndef SPIS_BIT_ORDER
 #define SPIS_BIT_ORDER NRF_SPIS_BIT_ORDER_MSB_FIRST
-#endif
-
-/**
- * @def SPIS Interrupt number.
- */
-#ifndef SPIS_IRQN
-#define SPIS_IRQN SPIM0_SPIS0_SPI0_IRQn
 #endif
 
 /**

--- a/examples/platforms/nrf52811/spi-slave.c
+++ b/examples/platforms/nrf52811/spi-slave.c
@@ -31,12 +31,14 @@
  *   This file implements the OpenThread platform abstraction for SPIS communication.
  *
  */
+#include <assert.h>
 
 #include <utils/code_utils.h>
 #include <openthread/platform/spi-slave.h>
 
 #include <hal/nrf_gpio.h>
-#include <hal/nrf_spis.h>
+#include <nrfx.h>
+#include <nrfx_spis.h>
 #include <platform-nrf5.h>
 
 #include "openthread-system.h"
@@ -55,10 +57,45 @@ static bool                                      sRequestTransactionFlag = false
 static bool                                      sFurtherProcessingFlag  = false;
 static otPlatSpiSlaveTransactionProcessCallback  sProcessCallback        = NULL;
 static otPlatSpiSlaveTransactionCompleteCallback sCompleteCallback       = NULL;
+static const nrfx_spis_t                         sSpiSlaveInstance       = NRFX_SPIS_INSTANCE(SPIS_INSTANCE);
+
+static void spisEventHandler(nrfx_spis_evt_t const *aEvent, void *aContext)
+{
+    OT_UNUSED_VARIABLE(aContext);
+
+    switch (aEvent->evt_type)
+    {
+    case NRFX_SPIS_BUFFERS_SET_DONE:
+        if (sRequestTransactionFlag)
+        {
+            // Host IRQ pin is active low.
+            nrf_gpio_pin_clear(SPIS_PIN_HOST_IRQ);
+        }
+        break;
+
+    case NRFX_SPIS_XFER_DONE:
+        // Ensure Host IRQ pin is set.
+        nrf_gpio_pin_set(SPIS_PIN_HOST_IRQ);
+
+        // Execute application callback.
+        if (sCompleteCallback(sContext, sOutputBuf, sOutputBufLen, sInputBuf, sInputBufLen, aEvent->rx_amount))
+        {
+            // Further processing is required.
+            sFurtherProcessingFlag = true;
+
+            otSysEventSignalPending();
+        }
+        break;
+
+    default:
+        assert(false);
+        break;
+    }
+}
 
 void nrf5SpiSlaveInit(void)
 {
-    /* Intentionally empty. */
+    // Intentionally empty.
 }
 
 void nrf5SpiSlaveDeinit(void)
@@ -76,10 +113,10 @@ void nrf5SpiSlaveProcess(void)
 {
     otEXPECT(sFurtherProcessingFlag == true);
 
-    /* Clear further processing flag. */
+    // Clear further processing flag.
     sFurtherProcessingFlag = false;
 
-    /* Perform any further processing if necessary. */
+    // Perform any further processing if necessary.
     sProcessCallback(sContext);
 
 exit:
@@ -90,67 +127,43 @@ otError otPlatSpiSlaveEnable(otPlatSpiSlaveTransactionCompleteCallback aComplete
                              otPlatSpiSlaveTransactionProcessCallback  aProcessCallback,
                              void *                                    aContext)
 {
-    otError error = OT_ERROR_NONE;
+    otError            result = OT_ERROR_NONE;
+    nrfx_err_t         error  = NRFX_SUCCESS;
+    nrfx_spis_config_t config = NRFX_SPIS_DEFAULT_CONFIG;
 
-    /* Check if SPI Slave interface is already enabled. */
+    assert(aCompleteCallback != NULL);
+    assert(aProcessCallback != NULL);
+
+    // Check if SPI Slave interface is already enabled.
     otEXPECT_ACTION(sCompleteCallback == NULL, error = OT_ERROR_ALREADY);
 
-    /* Set up MISO/MOSI/SCK/CSN and Host IRQ. */
-    nrf_gpio_cfg_input(SPIS_PIN_MISO, NRF_GPIO_PIN_NOPULL);
-    nrf_gpio_cfg_input(SPIS_PIN_MOSI, NRF_GPIO_PIN_NOPULL);
-    nrf_gpio_cfg_input(SPIS_PIN_SCK, NRF_GPIO_PIN_NOPULL);
-    nrf_gpio_cfg_input(SPIS_PIN_CSN, NRF_GPIO_PIN_NOPULL);
+    config.csn_pin      = SPIS_PIN_CSN;
+    config.miso_pin     = SPIS_PIN_MISO;
+    config.mosi_pin     = SPIS_PIN_MOSI;
+    config.sck_pin      = SPIS_PIN_SCK;
+    config.mode         = SPIS_MODE;
+    config.bit_order    = SPIS_BIT_ORDER;
+    config.irq_priority = SPIS_IRQ_PRIORITY;
+
+    error = nrfx_spis_init(&sSpiSlaveInstance, &config, spisEventHandler, NULL);
+    assert(error == NRFX_SUCCESS);
+
+    // Set up Host IRQ pin.
     nrf_gpio_pin_set(SPIS_PIN_HOST_IRQ);
     nrf_gpio_cfg_output(SPIS_PIN_HOST_IRQ);
 
-    nrf_spis_pins_set(SPIS_INSTANCE, SPIS_PIN_SCK, SPIS_PIN_MOSI, SPIS_PIN_MISO, SPIS_PIN_CSN);
-
-    /* Set buffer pointers. */
-    nrf_spis_rx_buffer_set(SPIS_INSTANCE, NULL, 0);
-    nrf_spis_tx_buffer_set(SPIS_INSTANCE, NULL, 0);
-
-    /* Configure SPIS Mode and Bit order. */
-    nrf_spis_configure(SPIS_INSTANCE, SPIS_MODE, SPIS_BIT_ORDER);
-
-    /* Use 0xFF character to indicate that there is no transmit buffer set up or overflow occured
-       as described in API documentation. */
-    nrf_spis_def_set(SPIS_INSTANCE, 0xFF);
-    nrf_spis_orc_set(SPIS_INSTANCE, 0xFF);
-
-    /* Clear SPIS specific events. */
-    nrf_spis_event_clear(SPIS_INSTANCE, NRF_SPIS_EVENT_END);
-    nrf_spis_event_clear(SPIS_INSTANCE, NRF_SPIS_EVENT_ACQUIRED);
-
-    /* Enable interrupts for ACQUIRED and END events. */
-    nrf_spis_int_enable(SPIS_INSTANCE, (NRF_SPIS_INT_ACQUIRED_MASK | NRF_SPIS_INT_END_MASK));
-
-    /* Configure NVIC to handle SPIS interrupts. */
-    NVIC_SetPriority(SPIS_IRQN, SPIS_IRQ_PRIORITY);
-    NVIC_ClearPendingIRQ(SPIS_IRQN);
-    NVIC_EnableIRQ(SPIS_IRQN);
-
-    /* Enable SPI slave device. */
-    nrf_spis_enable(SPIS_INSTANCE);
-
-    /* Set proper callback and context. */
+    // Set proper callback and context.
     sProcessCallback  = aProcessCallback;
     sCompleteCallback = aCompleteCallback;
     sContext          = aContext;
 
 exit:
-    return error;
+    return result;
 }
 
 void otPlatSpiSlaveDisable(void)
 {
-    /* Disable interrupts for ACQUIRED and END events. */
-    nrf_spis_int_disable(SPIS_INSTANCE, (NRF_SPIS_INT_ACQUIRED_MASK | NRF_SPIS_INT_END_MASK));
-
-    /* Disable NVIC interrupt. */
-    NVIC_DisableIRQ(SPIS_IRQN);
-
-    /* Disable SPIS instance. */
-    nrf_spis_disable(SPIS_INSTANCE);
+    nrfx_spis_uninit(&sSpiSlaveInstance);
 }
 
 otError otPlatSpiSlavePrepareTransaction(uint8_t *aOutputBuf,
@@ -159,10 +172,11 @@ otError otPlatSpiSlavePrepareTransaction(uint8_t *aOutputBuf,
                                          uint16_t aInputBufLen,
                                          bool     aRequestTransactionFlag)
 {
-    otError            error            = OT_ERROR_NONE;
-    nrf_spis_semstat_t semaphore_status = nrf_spis_semaphore_status_get(SPIS_INSTANCE);
+    otError            result           = OT_ERROR_NONE;
+    nrfx_err_t         error            = NRFX_SUCCESS;
+    nrf_spis_semstat_t semaphore_status = nrf_spis_semaphore_status_get(sSpiSlaveInstance.p_reg);
 
-    otEXPECT_ACTION(sCompleteCallback != NULL, error = OT_ERROR_INVALID_STATE);
+    assert(sCompleteCallback != NULL);
 
     otEXPECT_ACTION(((semaphore_status != NRF_SPIS_SEMSTAT_SPIS) && (semaphore_status != NRF_SPIS_SEMSTAT_CPUPENDING)),
                     error = OT_ERROR_BUSY);
@@ -181,61 +195,11 @@ otError otPlatSpiSlavePrepareTransaction(uint8_t *aOutputBuf,
 
     sRequestTransactionFlag = aRequestTransactionFlag;
 
-    /* Trigger acquired event. */
-    nrf_spis_task_trigger(SPIS_INSTANCE, NRF_SPIS_TASK_ACQUIRE);
+    error = nrfx_spis_buffers_set(&sSpiSlaveInstance, sOutputBuf, sOutputBufLen, sInputBuf, sInputBufLen);
+    assert(error == NRFX_SUCCESS);
 
 exit:
-    return error;
-}
-
-/**
- * Interrupt handler of SPIS peripherial.
- */
-void SPIM0_SPIS0_SPI0_IRQHandler(void)
-{
-    /* Check for SPI semaphore acquired event. */
-    if (nrf_spis_event_check(SPIS_INSTANCE, NRF_SPIS_EVENT_ACQUIRED))
-    {
-        nrf_spis_event_clear(SPIS_INSTANCE, NRF_SPIS_EVENT_ACQUIRED);
-
-        /* Set actual TX/RX buffers. */
-        nrf_spis_tx_buffer_set(SPIS_INSTANCE, sOutputBuf, sOutputBufLen);
-        nrf_spis_rx_buffer_set(SPIS_INSTANCE, sInputBuf, sInputBufLen);
-
-        if (sRequestTransactionFlag)
-        {
-            /* Interrupt pin is active low. */
-            nrf_gpio_pin_clear(SPIS_PIN_HOST_IRQ);
-        }
-
-        /* Trigger RELEASE event immediately. */
-        nrf_spis_task_trigger(SPIS_INSTANCE, NRF_SPIS_TASK_RELEASE);
-    }
-
-    /* Check for SPI transaction complete event. */
-    if (nrf_spis_event_check(SPIS_INSTANCE, NRF_SPIS_EVENT_END))
-    {
-        nrf_spis_event_clear(SPIS_INSTANCE, NRF_SPIS_EVENT_END);
-
-        if (sRequestTransactionFlag)
-        {
-            nrf_gpio_pin_set(SPIS_PIN_HOST_IRQ);
-        }
-
-        /* Discard all transactions until buffers are updated. */
-        nrf_spis_tx_buffer_set(SPIS_INSTANCE, sOutputBuf, 0);
-        nrf_spis_rx_buffer_set(SPIS_INSTANCE, sInputBuf, 0);
-
-        /* Execute application callback. */
-        if (sCompleteCallback(sContext, sOutputBuf, sOutputBufLen, sInputBuf, sInputBufLen,
-                              nrf_spis_rx_amount_get(SPIS_INSTANCE)))
-        {
-            /* Further processing is required. */
-            sFurtherProcessingFlag = true;
-
-            otSysEventSignalPending();
-        }
-    }
+    return result;
 }
 
 #endif // SPIS_AS_SERIAL_TRANSPORT == 1

--- a/examples/platforms/nrf52840/platform-config.h
+++ b/examples/platforms/nrf52840/platform-config.h
@@ -256,7 +256,7 @@
  * @def SPIS Instance.
  */
 #ifndef SPIS_INSTANCE
-#define SPIS_INSTANCE NRF_SPIS0
+#define SPIS_INSTANCE 0
 #endif
 
 /**
@@ -281,13 +281,6 @@
  */
 #ifndef SPIS_BIT_ORDER
 #define SPIS_BIT_ORDER NRF_SPIS_BIT_ORDER_MSB_FIRST
-#endif
-
-/**
- * @def SPIS Interrupt number.
- */
-#ifndef SPIS_IRQN
-#define SPIS_IRQN SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQn
 #endif
 
 /**

--- a/examples/platforms/nrf52840/spi-slave.c
+++ b/examples/platforms/nrf52840/spi-slave.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2018, The OpenThread Authors.
+ *  Copyright (c) 2019, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -31,12 +31,14 @@
  *   This file implements the OpenThread platform abstraction for SPIS communication.
  *
  */
+#include <assert.h>
 
 #include <utils/code_utils.h>
 #include <openthread/platform/spi-slave.h>
 
 #include <hal/nrf_gpio.h>
-#include <hal/nrf_spis.h>
+#include <nrfx.h>
+#include <nrfx_spis.h>
 #include <platform-nrf5.h>
 
 #include "openthread-system.h"
@@ -55,10 +57,45 @@ static bool                                      sRequestTransactionFlag = false
 static bool                                      sFurtherProcessingFlag  = false;
 static otPlatSpiSlaveTransactionProcessCallback  sProcessCallback        = NULL;
 static otPlatSpiSlaveTransactionCompleteCallback sCompleteCallback       = NULL;
+static const nrfx_spis_t                         sSpiSlaveInstance       = NRFX_SPIS_INSTANCE(SPIS_INSTANCE);
+
+static void spisEventHandler(nrfx_spis_evt_t const *aEvent, void *aContext)
+{
+    OT_UNUSED_VARIABLE(aContext);
+
+    switch (aEvent->evt_type)
+    {
+    case NRFX_SPIS_BUFFERS_SET_DONE:
+        if (sRequestTransactionFlag)
+        {
+            // Host IRQ pin is active low.
+            nrf_gpio_pin_clear(SPIS_PIN_HOST_IRQ);
+        }
+        break;
+
+    case NRFX_SPIS_XFER_DONE:
+        // Ensure Host IRQ pin is set.
+        nrf_gpio_pin_set(SPIS_PIN_HOST_IRQ);
+
+        // Execute application callback.
+        if (sCompleteCallback(sContext, sOutputBuf, sOutputBufLen, sInputBuf, sInputBufLen, aEvent->rx_amount))
+        {
+            // Further processing is required.
+            sFurtherProcessingFlag = true;
+
+            otSysEventSignalPending();
+        }
+        break;
+
+    default:
+        assert(false);
+        break;
+    }
+}
 
 void nrf5SpiSlaveInit(void)
 {
-    /* Intentionally empty. */
+    // Intentionally empty.
 }
 
 void nrf5SpiSlaveDeinit(void)
@@ -76,10 +113,10 @@ void nrf5SpiSlaveProcess(void)
 {
     otEXPECT(sFurtherProcessingFlag == true);
 
-    /* Clear further processing flag. */
+    // Clear further processing flag.
     sFurtherProcessingFlag = false;
 
-    /* Perform any further processing if necessary. */
+    // Perform any further processing if necessary.
     sProcessCallback(sContext);
 
 exit:
@@ -90,67 +127,43 @@ otError otPlatSpiSlaveEnable(otPlatSpiSlaveTransactionCompleteCallback aComplete
                              otPlatSpiSlaveTransactionProcessCallback  aProcessCallback,
                              void *                                    aContext)
 {
-    otError error = OT_ERROR_NONE;
+    otError            result = OT_ERROR_NONE;
+    nrfx_err_t         error  = NRFX_SUCCESS;
+    nrfx_spis_config_t config = NRFX_SPIS_DEFAULT_CONFIG;
 
-    /* Check if SPI Slave interface is already enabled. */
+    assert(aCompleteCallback != NULL);
+    assert(aProcessCallback != NULL);
+
+    // Check if SPI Slave interface is already enabled.
     otEXPECT_ACTION(sCompleteCallback == NULL, error = OT_ERROR_ALREADY);
 
-    /* Set up MISO/MOSI/SCK/CSN and Host IRQ. */
-    nrf_gpio_cfg_input(SPIS_PIN_MISO, NRF_GPIO_PIN_NOPULL);
-    nrf_gpio_cfg_input(SPIS_PIN_MOSI, NRF_GPIO_PIN_NOPULL);
-    nrf_gpio_cfg_input(SPIS_PIN_SCK, NRF_GPIO_PIN_NOPULL);
-    nrf_gpio_cfg_input(SPIS_PIN_CSN, NRF_GPIO_PIN_NOPULL);
+    config.csn_pin      = SPIS_PIN_CSN;
+    config.miso_pin     = SPIS_PIN_MISO;
+    config.mosi_pin     = SPIS_PIN_MOSI;
+    config.sck_pin      = SPIS_PIN_SCK;
+    config.mode         = SPIS_MODE;
+    config.bit_order    = SPIS_BIT_ORDER;
+    config.irq_priority = SPIS_IRQ_PRIORITY;
+
+    error = nrfx_spis_init(&sSpiSlaveInstance, &config, spisEventHandler, NULL);
+    assert(error == NRFX_SUCCESS);
+
+    // Set up Host IRQ pin.
     nrf_gpio_pin_set(SPIS_PIN_HOST_IRQ);
     nrf_gpio_cfg_output(SPIS_PIN_HOST_IRQ);
 
-    nrf_spis_pins_set(SPIS_INSTANCE, SPIS_PIN_SCK, SPIS_PIN_MOSI, SPIS_PIN_MISO, SPIS_PIN_CSN);
-
-    /* Set buffer pointers. */
-    nrf_spis_rx_buffer_set(SPIS_INSTANCE, NULL, 0);
-    nrf_spis_tx_buffer_set(SPIS_INSTANCE, NULL, 0);
-
-    /* Configure SPIS Mode and Bit order. */
-    nrf_spis_configure(SPIS_INSTANCE, SPIS_MODE, SPIS_BIT_ORDER);
-
-    /* Use 0xFF character to indicate that there is no transmit buffer set up or overflow occured
-       as described in API documentation. */
-    nrf_spis_def_set(SPIS_INSTANCE, 0xFF);
-    nrf_spis_orc_set(SPIS_INSTANCE, 0xFF);
-
-    /* Clear SPIS specific events. */
-    nrf_spis_event_clear(SPIS_INSTANCE, NRF_SPIS_EVENT_END);
-    nrf_spis_event_clear(SPIS_INSTANCE, NRF_SPIS_EVENT_ACQUIRED);
-
-    /* Enable interrupts for ACQUIRED and END events. */
-    nrf_spis_int_enable(SPIS_INSTANCE, (NRF_SPIS_INT_ACQUIRED_MASK | NRF_SPIS_INT_END_MASK));
-
-    /* Configure NVIC to handle SPIS interrupts. */
-    NVIC_SetPriority(SPIS_IRQN, SPIS_IRQ_PRIORITY);
-    NVIC_ClearPendingIRQ(SPIS_IRQN);
-    NVIC_EnableIRQ(SPIS_IRQN);
-
-    /* Enable SPI slave device. */
-    nrf_spis_enable(SPIS_INSTANCE);
-
-    /* Set proper callback and context. */
+    // Set proper callback and context.
     sProcessCallback  = aProcessCallback;
     sCompleteCallback = aCompleteCallback;
     sContext          = aContext;
 
 exit:
-    return error;
+    return result;
 }
 
 void otPlatSpiSlaveDisable(void)
 {
-    /* Disable interrupts for ACQUIRED and END events. */
-    nrf_spis_int_disable(SPIS_INSTANCE, (NRF_SPIS_INT_ACQUIRED_MASK | NRF_SPIS_INT_END_MASK));
-
-    /* Disable NVIC interrupt. */
-    NVIC_DisableIRQ(SPIS_IRQN);
-
-    /* Disable SPIS instance. */
-    nrf_spis_disable(SPIS_INSTANCE);
+    nrfx_spis_uninit(&sSpiSlaveInstance);
 }
 
 otError otPlatSpiSlavePrepareTransaction(uint8_t *aOutputBuf,
@@ -159,10 +172,11 @@ otError otPlatSpiSlavePrepareTransaction(uint8_t *aOutputBuf,
                                          uint16_t aInputBufLen,
                                          bool     aRequestTransactionFlag)
 {
-    otError            error            = OT_ERROR_NONE;
-    nrf_spis_semstat_t semaphore_status = nrf_spis_semaphore_status_get(SPIS_INSTANCE);
+    otError            result           = OT_ERROR_NONE;
+    nrfx_err_t         error            = NRFX_SUCCESS;
+    nrf_spis_semstat_t semaphore_status = nrf_spis_semaphore_status_get(sSpiSlaveInstance.p_reg);
 
-    otEXPECT_ACTION(sCompleteCallback != NULL, error = OT_ERROR_INVALID_STATE);
+    assert(sCompleteCallback != NULL);
 
     otEXPECT_ACTION(((semaphore_status != NRF_SPIS_SEMSTAT_SPIS) && (semaphore_status != NRF_SPIS_SEMSTAT_CPUPENDING)),
                     error = OT_ERROR_BUSY);
@@ -181,61 +195,11 @@ otError otPlatSpiSlavePrepareTransaction(uint8_t *aOutputBuf,
 
     sRequestTransactionFlag = aRequestTransactionFlag;
 
-    /* Trigger acquired event. */
-    nrf_spis_task_trigger(SPIS_INSTANCE, NRF_SPIS_TASK_ACQUIRE);
+    error = nrfx_spis_buffers_set(&sSpiSlaveInstance, sOutputBuf, sOutputBufLen, sInputBuf, sInputBufLen);
+    assert(error == NRFX_SUCCESS);
 
 exit:
-    return error;
-}
-
-/**
- * Interrupt handler of SPIS peripherial.
- */
-void SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQHandler(void)
-{
-    /* Check for SPI semaphore acquired event. */
-    if (nrf_spis_event_check(SPIS_INSTANCE, NRF_SPIS_EVENT_ACQUIRED))
-    {
-        nrf_spis_event_clear(SPIS_INSTANCE, NRF_SPIS_EVENT_ACQUIRED);
-
-        /* Set actual TX/RX buffers. */
-        nrf_spis_tx_buffer_set(SPIS_INSTANCE, sOutputBuf, sOutputBufLen);
-        nrf_spis_rx_buffer_set(SPIS_INSTANCE, sInputBuf, sInputBufLen);
-
-        if (sRequestTransactionFlag)
-        {
-            /* Interrupt pin is active low. */
-            nrf_gpio_pin_clear(SPIS_PIN_HOST_IRQ);
-        }
-
-        /* Trigger RELEASE event immediately. */
-        nrf_spis_task_trigger(SPIS_INSTANCE, NRF_SPIS_TASK_RELEASE);
-    }
-
-    /* Check for SPI transaction complete event. */
-    if (nrf_spis_event_check(SPIS_INSTANCE, NRF_SPIS_EVENT_END))
-    {
-        nrf_spis_event_clear(SPIS_INSTANCE, NRF_SPIS_EVENT_END);
-
-        if (sRequestTransactionFlag)
-        {
-            nrf_gpio_pin_set(SPIS_PIN_HOST_IRQ);
-        }
-
-        /* Discard all transactions until buffers are updated. */
-        nrf_spis_tx_buffer_set(SPIS_INSTANCE, sOutputBuf, 0);
-        nrf_spis_rx_buffer_set(SPIS_INSTANCE, sInputBuf, 0);
-
-        /* Execute application callback. */
-        if (sCompleteCallback(sContext, sOutputBuf, sOutputBufLen, sInputBuf, sInputBufLen,
-                              nrf_spis_rx_amount_get(SPIS_INSTANCE)))
-        {
-            /* Further processing is required. */
-            sFurtherProcessingFlag = true;
-
-            otSysEventSignalPending();
-        }
-    }
+    return result;
 }
 
 #endif // SPIS_AS_SERIAL_TRANSPORT == 1

--- a/third_party/NordicSemiconductor/Makefile.am
+++ b/third_party/NordicSemiconductor/Makefile.am
@@ -110,7 +110,7 @@ NORDICSEMI_COMMON_SOURCES                                                       
     libraries/utf_converter/utf.c                                                                                         \
     nrfx/drivers/src/nrfx_clock.c                                                                                         \
     nrfx/drivers/src/nrfx_power.c                                                                                         \
-    nrfx/drivers/src/nrfx_spis.c                                                                                       \
+    nrfx/drivers/src/nrfx_spis.c                                                                                          \
     nrfx/drivers/src/nrfx_systick.c                                                                                       \
     nrfx/hal/nrf_nvmc.c                                                                                                   \
     nrfx/soc/nrfx_atomic.c                                                                                                \

--- a/third_party/NordicSemiconductor/Makefile.am
+++ b/third_party/NordicSemiconductor/Makefile.am
@@ -110,6 +110,7 @@ NORDICSEMI_COMMON_SOURCES                                                       
     libraries/utf_converter/utf.c                                                                                         \
     nrfx/drivers/src/nrfx_clock.c                                                                                         \
     nrfx/drivers/src/nrfx_power.c                                                                                         \
+    nrfx/drivers/src/nrfx_spis.c                                                                                       \
     nrfx/drivers/src/nrfx_systick.c                                                                                       \
     nrfx/hal/nrf_nvmc.c                                                                                                   \
     nrfx/soc/nrfx_atomic.c                                                                                                \
@@ -363,6 +364,7 @@ noinst_HEADERS                                                                  
     $(top_srcdir)/third_party/NordicSemiconductor/nrfx/drivers/include/nrfx_clock.h                                       \
     $(top_srcdir)/third_party/NordicSemiconductor/nrfx/drivers/include/nrfx_power_clock.h                                 \
     $(top_srcdir)/third_party/NordicSemiconductor/nrfx/drivers/include/nrfx_power.h                                       \
+    $(top_srcdir)/third_party/NordicSemiconductor/nrfx/drivers/include/nrfx_spis.h                                        \
     $(top_srcdir)/third_party/NordicSemiconductor/nrfx/drivers/include/nrfx_systick.h                                     \
     $(top_srcdir)/third_party/NordicSemiconductor/nrfx/drivers/include/nrfx_usbd.h                                        \
     $(top_srcdir)/third_party/NordicSemiconductor/nrfx/drivers/src/nrfx_usbd_errata.h                                     \

--- a/third_party/NordicSemiconductor/dependencies/sdk_config.h
+++ b/third_party/NordicSemiconductor/dependencies/sdk_config.h
@@ -651,6 +651,121 @@
 
 // </e>
 
+
+// <e> NRFX_SPIS_ENABLED - nrfx_spis - SPIS peripheral driver
+//==========================================================
+#if (SPIS_AS_SERIAL_TRANSPORT == 1)
+#ifndef NRFX_SPIS_ENABLED
+#define NRFX_SPIS_ENABLED 1
+#endif
+#else  // SPIS_AS_SERIAL_TRANSPORT == 1
+#ifndef NRFX_SPIS_ENABLED
+#define NRFX_SPIS_ENABLED 0
+#endif
+#endif // SPIS_AS_SERIAL_TRANSPORT == 1
+
+// <q> NRFX_SPIS0_ENABLED  - Enable SPIS0 instance
+
+#ifndef NRFX_SPIS0_ENABLED
+#define NRFX_SPIS0_ENABLED 1
+#endif
+
+// <q> NRFX_SPIS1_ENABLED  - Enable SPIS1 instance
+
+
+#ifndef NRFX_SPIS1_ENABLED
+#define NRFX_SPIS1_ENABLED 0
+#endif
+
+// <q> NRFX_SPIS2_ENABLED  - Enable SPIS2 instance
+
+
+#ifndef NRFX_SPIS2_ENABLED
+#define NRFX_SPIS2_ENABLED 0
+#endif
+
+// <o> NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY
+#define NRFX_SPIS_DEFAULT_CONFIG_IRQ_PRIORITY 7
+#endif
+
+// <o> NRFX_SPIS_DEFAULT_DEF - SPIS default DEF character  <0-255>
+
+
+#ifndef NRFX_SPIS_DEFAULT_DEF
+#define NRFX_SPIS_DEFAULT_DEF 255
+#endif
+
+// <o> NRFX_SPIS_DEFAULT_ORC - SPIS default ORC character  <0-255>
+
+
+#ifndef NRFX_SPIS_DEFAULT_ORC
+#define NRFX_SPIS_DEFAULT_ORC 255
+#endif
+
+// <e> NRFX_SPIS_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_SPIS_CONFIG_LOG_ENABLED
+#define NRFX_SPIS_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_SPIS_CONFIG_LOG_LEVEL  - Default Severity level
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_SPIS_CONFIG_LOG_LEVEL
+#define NRFX_SPIS_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_SPIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_SPIS_CONFIG_INFO_COLOR
+#define NRFX_SPIS_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_SPIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_SPIS_CONFIG_DEBUG_COLOR
+#define NRFX_SPIS_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
 // <q> SYSTICK_ENABLED  - nrf_drv_systick - SysTick driver
 
 #if (USB_CDC_AS_SERIAL_TRANSPORT == 1)


### PR DESCRIPTION
This PR modifies SPI Slave implementation to use the driver from the [nrfx](https://github.com/NordicSemiconductor/nrfx).

Additionally, a very rare race condition has been fixed.