### PR TITLE
[data-poll-sender] add logic to select poll destination

### DIFF
--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -131,6 +131,26 @@ exit:
     return error;
 }
 
+otError DataPollSender::GetPollDestinationAddress(Mac::Address &aDest) const
+{
+    otError   error  = OT_ERROR_NONE;
+    Neighbor *parent = Get<Mle::MleRouter>().GetParentCandidate();
+
+    VerifyOrExit((parent != NULL) && parent->IsStateValidOrRestoring(), error = OT_ERROR_ABORT);
+
+    if ((Get<Mac::Mac>().GetShortAddress() == Mac::kShortAddrInvalid) || (parent != Get<Mle::MleRouter>().GetParent()))
+    {
+        aDest.SetExtended(parent->GetExtAddress());
+    }
+    else
+    {
+        aDest.SetShort(parent->GetRloc16());
+    }
+
+exit:
+    return error;
+}
+
 otError DataPollSender::SetExternalPollPeriod(uint32_t aPeriod)
 {
     otError error = OT_ERROR_NONE;

--- a/src/core/mac/data_poll_sender.hpp
+++ b/src/core/mac/data_poll_sender.hpp
@@ -132,6 +132,17 @@ public:
     uint32_t GetExternalPollPeriod(void) const { return mExternalPollPeriod; }
 
     /**
+     * This method gets the destination MAC address for a data poll frame.
+     *
+     * @param[out] aDest       Reference to a `MAC::Address` to output the poll destination address (on success).
+     *
+     * @retval OT_ERROR_NONE   @p aDest was updated successfully.
+     * @retval OT_ERROR_ABORT  Abort the data poll transmission (not currently attached to any parent).
+     *
+     */
+    otError GetPollDestinationAddress(Mac::Address &aDest) const;
+
+    /**
      * This method informs the data poll sender of success/error status of a previously requested poll frame
      * transmission.
      *


### PR DESCRIPTION
This commit changes the interaction of `Mac` and `DataPollSender` such
that the selection of a data poll destination MAC address is delegated
to `DataPollSender` (related code is moved into `DataPollSender` from
`Mac`).