### PR TITLE
[spinel] use 64bit timestamp for rx frames

### DIFF
--- a/src/ncp/ncp_base_radio.cpp
+++ b/src/ncp/ncp_base_radio.cpp
@@ -90,10 +90,7 @@ void NcpBase::LinkRawReceiveDone(otRadioFrame *aFrame, otError aError)
     SuccessOrExit(mEncoder.WriteUint8(aFrame->mChannel));           // 802.15.4 channel (Receive channel)
     SuccessOrExit(mEncoder.WriteUint8(aFrame->mInfo.mRxInfo.mLqi)); // 802.15.4 LQI
 
-    SuccessOrExit(mEncoder.WriteUint32(
-        static_cast<uint32_t>(aFrame->mInfo.mRxInfo.mTimestamp / 1000))); // The timestamp milliseconds
-    SuccessOrExit(
-        mEncoder.WriteUint16(aFrame->mInfo.mRxInfo.mTimestamp % 1000)); // The timestamp microseconds, offset to mMsec
+    SuccessOrExit(mEncoder.WriteUint64(aFrame->mInfo.mRxInfo.mTimestamp)); // The timestamp in microseconds
 
     SuccessOrExit(mEncoder.CloseStruct());
 
@@ -137,13 +134,10 @@ void NcpBase::LinkRawTransmitDone(otRadioFrame *aFrame, otRadioFrame *aAckFrame,
             SuccessOrExit(mEncoder.WriteInt8(-128));                           // Noise Floor (Currently unused)
             SuccessOrExit(mEncoder.WriteUint16(0));                            // Flags
 
-            SuccessOrExit(mEncoder.OpenStruct());                              // PHY-data
-            SuccessOrExit(mEncoder.WriteUint8(aAckFrame->mChannel));           // Receive channel
-            SuccessOrExit(mEncoder.WriteUint8(aAckFrame->mInfo.mRxInfo.mLqi)); // Link Quality Indicator
-            SuccessOrExit(mEncoder.WriteUint32(
-                static_cast<uint32_t>(aAckFrame->mInfo.mRxInfo.mTimestamp / 1000))); // The timestamp milliseconds
-            SuccessOrExit(mEncoder.WriteUint16(aAckFrame->mInfo.mRxInfo.mTimestamp %
-                                               1000)); // The timestamp microseconds, offset to mMsec
+            SuccessOrExit(mEncoder.OpenStruct());                                     // PHY-data
+            SuccessOrExit(mEncoder.WriteUint8(aAckFrame->mChannel));                  // Receive channel
+            SuccessOrExit(mEncoder.WriteUint8(aAckFrame->mInfo.mRxInfo.mLqi));        // Link Quality Indicator
+            SuccessOrExit(mEncoder.WriteUint64(aAckFrame->mInfo.mRxInfo.mTimestamp)); // The timestamp in microseconds
 
             SuccessOrExit(mEncoder.CloseStruct());
 

--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -617,11 +617,21 @@ private:
     bool  mIsPromiscuous : 1;     ///< Promiscuous mode.
     bool  mIsReady : 1;           ///< NCP ready.
     bool  mSupportsLogStream : 1; ///< RCP supports `LOG_STREAM` property with OpenThread log meta-data format.
-
 #if OPENTHREAD_ENABLE_DIAG
     bool   mDiagMode;
     char * mDiagOutput;
     size_t mDiagOutputMaxLen;
+#endif
+
+#if OPENTHREAD_CONFIG_48BIT_TIMESTAMP_SUPPORT_ENABLE
+    enum TimestampType
+    {
+        kTimestampTypeUnknown = 0,
+        kTimestampType48      = 1,
+        kTimestampType64      = 2,
+    };
+
+    TimestampType mTimestampType; ///< STREAM_RAW timestamp type.
 #endif
 
     uint64_t mTxRadioEndUs;

--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -617,21 +617,11 @@ private:
     bool  mIsPromiscuous : 1;     ///< Promiscuous mode.
     bool  mIsReady : 1;           ///< NCP ready.
     bool  mSupportsLogStream : 1; ///< RCP supports `LOG_STREAM` property with OpenThread log meta-data format.
+
 #if OPENTHREAD_ENABLE_DIAG
     bool   mDiagMode;
     char * mDiagOutput;
     size_t mDiagOutputMaxLen;
-#endif
-
-#if OPENTHREAD_CONFIG_48BIT_TIMESTAMP_SUPPORT_ENABLE
-    enum TimestampType
-    {
-        kTimestampTypeUnknown = 0,
-        kTimestampType48      = 1,
-        kTimestampType64      = 2,
-    };
-
-    TimestampType mTimestampType; ///< STREAM_RAW timestamp type.
 #endif
 
     uint64_t mTxRadioEndUs;


### PR DESCRIPTION
This PR changes the default timestamp of rx frames to be 64bit, which is
aimed to ensure the timestamp never wraps. This PR changes the protocol
of spinel.

**NOTE** Changing spinel protocol is not allowed normally, however, since the
timestamp is only used by sniffer, we exceptionally changed this for efficiency
consideration. Pyspinel is also updated accordingly.