### PR TITLE
[style] harmonize boolean checks

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1023,7 +1023,7 @@ void Interpreter::ProcessEidCache(int argc, char *argv[])
     {
         SuccessOrExit(otThreadGetEidCacheEntry(mInstance, i, &entry));
 
-        if (entry.mValid == false)
+        if (!entry.mValid)
         {
             continue;
         }

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -317,7 +317,7 @@ otError otLinkSetPromiscuous(otInstance *aInstance, bool aPromiscuous)
     Instance &instance = *static_cast<Instance *>(aInstance);
 
     // cannot enable IEEE 802.15.4 promiscuous mode if the Thread interface is enabled
-    VerifyOrExit(instance.Get<ThreadNetif>().IsUp() == false, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(!instance.Get<ThreadNetif>().IsUp(), error = OT_ERROR_INVALID_STATE);
 
     instance.Get<Mac::Mac>().SetPromiscuous(aPromiscuous);
 
@@ -331,7 +331,7 @@ otError otLinkSetEnabled(otInstance *aInstance, bool aEnable)
     Instance &instance = *static_cast<Instance *>(aInstance);
 
     // cannot disable the link layer if the Thread interface is enabled
-    VerifyOrExit(instance.Get<ThreadNetif>().IsUp() == false, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(!instance.Get<ThreadNetif>().IsUp(), error = OT_ERROR_INVALID_STATE);
 
     instance.Get<Mac::Mac>().SetEnabled(aEnable);
 

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -109,7 +109,7 @@ Instance &Instance::InitSingle(void)
 {
     Instance *instance = &Get();
 
-    VerifyOrExit(instance->mIsInitialized == false);
+    VerifyOrExit(!instance->mIsInitialized);
 
     instance = new (&gInstanceRaw) Instance();
 
@@ -173,7 +173,7 @@ void Instance::AfterInit(void)
 
 void Instance::Finalize(void)
 {
-    VerifyOrExit(mIsInitialized == true);
+    VerifyOrExit(mIsInitialized);
 
     mIsInitialized = false;
 

--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -228,7 +228,7 @@ void DataPollSender::HandlePollSent(Mac::Frame &aFrame, otError aError)
             }
         }
 
-        if (mRetxMode == true)
+        if (mRetxMode)
         {
             mRetxMode                   = false;
             mPollTxFailureCounter       = 0;
@@ -251,7 +251,7 @@ void DataPollSender::HandlePollSent(Mac::Frame &aFrame, otError aError)
 
         if (mPollTxFailureCounter < kMaxPollRetxAttempts)
         {
-            if (mRetxMode == false)
+            if (!mRetxMode)
             {
                 mRetxMode                   = true;
                 shouldRecalculatePollPeriod = true;
@@ -307,7 +307,7 @@ void DataPollSender::CheckFramePending(Mac::Frame &aFrame)
 
     mPollTimeoutCounter = 0;
 
-    if (aFrame.GetFramePending() == true)
+    if (aFrame.GetFramePending())
     {
         SendDataPoll();
     }
@@ -434,12 +434,12 @@ uint32_t DataPollSender::CalculatePollPeriod(void) const
 {
     uint32_t period = 0;
 
-    if (mAttachMode == true)
+    if (mAttachMode)
     {
         period = kAttachDataPollPeriod;
     }
 
-    if (mRetxMode == true)
+    if (mRetxMode)
     {
         if ((period == 0) || (period > kRetxPollPeriod))
         {

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -940,10 +940,7 @@ void Mac::ProcessTransmitSecurity(Frame &aFrame, bool aProcessAesCcm)
     uint8_t           keyIdMode;
     const ExtAddress *extAddress = NULL;
 
-    if (aFrame.GetSecurityEnabled() == false)
-    {
-        ExitNow();
-    }
+    VerifyOrExit(aFrame.GetSecurityEnabled());
 
     aFrame.GetKeyIdMode(keyIdMode);
 
@@ -1392,10 +1389,7 @@ otError Mac::ProcessReceiveSecurity(Frame &aFrame, const Address &aSrcAddr, Neig
     const ExtAddress *extAddress;
     Crypto::AesCcm    aesCcm;
 
-    if (aFrame.GetSecurityEnabled() == false)
-    {
-        ExitNow();
-    }
+    VerifyOrExit(aFrame.GetSecurityEnabled());
 
     aFrame.GetSecurityLevel(securityLevel);
     aFrame.GetFrameCounter(frameCounter);
@@ -1673,7 +1667,7 @@ void Mac::HandleReceivedFrame(Frame *aFrame, otError aError)
 
         neighbor->GetLinkInfo().AddRss(GetNoiseFloor(), aFrame->GetRssi());
 
-        if (aFrame->GetSecurityEnabled() == true)
+        if (aFrame->GetSecurityEnabled())
         {
             switch (neighbor->GetState())
             {

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -477,7 +477,7 @@ void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
     VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(responseHeader), &responseHeader) ==
                  sizeof(responseHeader));
     VerifyOrExit(responseHeader.GetType() == Header::kTypeResponse && responseHeader.GetQuestionCount() == 1 &&
-                 responseHeader.IsTruncationFlagSet() == false);
+                 !responseHeader.IsTruncationFlagSet());
 
     aMessage.MoveOffset(sizeof(responseHeader));
     offset = aMessage.GetOffset();

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -611,7 +611,7 @@ otError Ip6::HandleFragment(Message &aMessage)
     VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(fragmentHeader), &fragmentHeader) == sizeof(fragmentHeader),
                  error = OT_ERROR_PARSE);
 
-    VerifyOrExit(fragmentHeader.GetOffset() == 0 && fragmentHeader.IsMoreFlagSet() == false, error = OT_ERROR_DROP);
+    VerifyOrExit(fragmentHeader.GetOffset() == 0 && !fragmentHeader.IsMoreFlagSet(), error = OT_ERROR_DROP);
 
     aMessage.MoveOffset(sizeof(fragmentHeader));
 
@@ -628,7 +628,7 @@ otError Ip6::HandleExtensionHeaders(Message &aMessage,
     otError         error = OT_ERROR_NONE;
     ExtensionHeader extHeader;
 
-    while (aReceive == true || aNextHeader == kProtoHopOpts)
+    while (aReceive || aNextHeader == kProtoHopOpts)
     {
         VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(extHeader), &extHeader) == sizeof(extHeader),
                      error = OT_ERROR_PARSE);
@@ -690,7 +690,7 @@ otError Ip6::ProcessReceiveCallback(const Message &    aMessage,
     otError  error       = OT_ERROR_NONE;
     Message *messageCopy = NULL;
 
-    VerifyOrExit(aFromNcpHost == false, error = OT_ERROR_NO_ROUTE);
+    VerifyOrExit(!aFromNcpHost, error = OT_ERROR_NO_ROUTE);
     VerifyOrExit(mReceiveIp6DatagramCallback != NULL, error = OT_ERROR_NO_ROUTE);
 
     if (mIsReceiveIp6FilterEnabled)

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -340,7 +340,7 @@ otError AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
 
 exit:
 
-    if (mTimer.IsRunning() == false)
+    if (!mTimer.IsRunning())
     {
         mTimer.Start(kStateUpdatePeriod);
     }

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -91,7 +91,7 @@ MeshForwarder::MeshForwarder(Instance &aInstance)
 
 void MeshForwarder::Start(void)
 {
-    if (mEnabled == false)
+    if (!mEnabled)
     {
         Get<Mac::Mac>().SetRxOnWhenIdle(true);
 #if OPENTHREAD_FTD
@@ -106,7 +106,7 @@ void MeshForwarder::Stop(void)
 {
     Message *message;
 
-    VerifyOrExit(mEnabled == true);
+    VerifyOrExit(mEnabled);
 
     mDataPollSender.StopPolling();
     mUpdateTimer.Stop();
@@ -167,7 +167,7 @@ void MeshForwarder::ScheduleTransmissionTask(Tasklet &aTasklet)
 
 void MeshForwarder::ScheduleTransmissionTask(void)
 {
-    VerifyOrExit(mSendBusy == false);
+    VerifyOrExit(!mSendBusy);
 
     mSendMessage = GetDirectTransmission();
     VerifyOrExit(mSendMessage != NULL);
@@ -213,7 +213,7 @@ Message *MeshForwarder::GetDirectTransmission(void)
 
     for (curMessage = mSendQueue.GetHead(); curMessage; curMessage = nextMessage)
     {
-        if (curMessage->GetDirectTransmission() == false)
+        if (!curMessage->GetDirectTransmission())
         {
             nextMessage = curMessage->GetNext();
             continue;
@@ -973,7 +973,7 @@ void MeshForwarder::HandleSentFrame(Mac::Frame &aFrame, otError aError)
         ExitNow();
     }
 
-    if (mSendMessage->GetDirectTransmission() == false && mSendMessage->IsChildPending() == false)
+    if (!mSendMessage->GetDirectTransmission() && !mSendMessage->IsChildPending())
     {
         if (mSendMessage->GetSubType() == Message::kSubTypeMleChildIdRequest && mSendMessage->IsLinkSecurityEnabled())
         {
@@ -1184,7 +1184,7 @@ void MeshForwarder::HandleFragment(uint8_t *               aFrame,
         // any remaining fragments in reassembly list upon receiving of a new
         // (secure) first fragment.
 
-        if ((GetRxOnWhenIdle() == false) && message->IsLinkSecurityEnabled())
+        if (!GetRxOnWhenIdle() && message->IsLinkSecurityEnabled())
         {
             ClearReassemblyList();
         }
@@ -1217,7 +1217,7 @@ void MeshForwarder::HandleFragment(uint8_t *               aFrame,
         // message with a new tag. In either case, we can safely clear any
         // remaining fragments stored in the reassembly list.
 
-        if (GetRxOnWhenIdle() == false)
+        if (!GetRxOnWhenIdle())
         {
             if ((message == NULL) && (aLinkInfo.mLinkSecurity))
             {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -240,7 +240,7 @@ otError Mle::Start(bool aAnnounceAttach)
     otError error = OT_ERROR_NONE;
 
     // cannot bring up the interface if IEEE 802.15.4 promiscuous mode is enabled
-    VerifyOrExit(otPlatRadioGetPromiscuous(&GetInstance()) == false, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(!otPlatRadioGetPromiscuous(&GetInstance()), error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(Get<ThreadNetif>().IsUp(), error = OT_ERROR_INVALID_STATE);
 
     SetStateDetached();

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1312,7 +1312,7 @@ otError MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::Messa
                 {
                     for (uint8_t i = 0, routeCount = 0; i <= kMaxRouterId; i++)
                     {
-                        if (route.IsRouterIdSet(i) == false)
+                        if (!route.IsRouterIdSet(i))
                         {
                             continue;
                         }
@@ -3785,7 +3785,7 @@ otError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
     Ip6::MessageInfo       messageInfo;
     Coap::Message *        message = NULL;
 
-    VerifyOrExit(mAddressSolicitPending == false);
+    VerifyOrExit(!mAddressSolicitPending);
 
     VerifyOrExit((message = Get<Coap::Coap>().NewMessage()) != NULL, error = OT_ERROR_NO_BUFS);
 
@@ -4497,7 +4497,7 @@ bool MleRouter::HasOneNeighborWithComparableConnectivity(const RouteTlv &aRoute,
             if (localLinkQuality >= 2)
             {
                 // check if this neighbor router is in peer Route64 TLV
-                if (aRoute.IsRouterIdSet(router.GetRouterId()) == false)
+                if (!aRoute.IsRouterIdSet(router.GetRouterId()))
                 {
                     ExitNow(rval = false);
                 }

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -369,7 +369,7 @@ otError LeaderBase::DefaultRouteLookup(PrefixTlv &aPrefix, uint16_t *aRloc16)
         {
             entry = borderRouter->GetEntry(i);
 
-            if (entry->IsDefaultRoute() == false)
+            if (!entry->IsDefaultRoute())
             {
                 continue;
             }

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -126,7 +126,7 @@ void ChildSupervisor::HandleTimer(void)
 
         child.IncrementSecondsSinceLastSupervision();
 
-        if ((child.GetSecondsSinceLastSupervision() >= mSupervisionInterval) && (child.IsRxOnWhenIdle() == false))
+        if ((child.GetSecondsSinceLastSupervision() >= mSupervisionInterval) && !child.IsRxOnWhenIdle())
         {
             SendMessage(child);
         }
@@ -220,7 +220,7 @@ exit:
 void SupervisionListener::RestartTimer(void)
 {
     if ((mTimeout != 0) && (Get<Mle::MleRouter>().GetRole() != OT_DEVICE_ROLE_DISABLED) &&
-        (Get<MeshForwarder>().GetRxOnWhenIdle() == false))
+        !Get<MeshForwarder>().GetRxOnWhenIdle())
     {
         mTimer.Start(TimerMilli::SecToMsec(mTimeout));
     }
@@ -237,8 +237,7 @@ void SupervisionListener::HandleTimer(Timer &aTimer)
 
 void SupervisionListener::HandleTimer(void)
 {
-    VerifyOrExit((Get<Mle::MleRouter>().GetRole() == OT_DEVICE_ROLE_CHILD) &&
-                 (Get<MeshForwarder>().GetRxOnWhenIdle() == false));
+    VerifyOrExit((Get<Mle::MleRouter>().GetRole() == OT_DEVICE_ROLE_CHILD) && !Get<MeshForwarder>().GetRxOnWhenIdle());
 
     otLogWarnUtil("Supervision timeout. No frame from parent in %d sec", mTimeout);
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -385,7 +385,7 @@ void NcpBase::HandleFrameRemovedFromNcpBuffer(void *                   aContext,
 
 void NcpBase::HandleFrameRemovedFromNcpBuffer(NcpFrameBuffer::FrameTag aFrameTag)
 {
-    if (mHostPowerStateInProgress == true)
+    if (mHostPowerStateInProgress)
     {
         if (aFrameTag == mHostPowerReplyFrameTag)
         {

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -769,7 +769,7 @@ otError NcpBase::HandlePropertySet_SPINEL_PROP_THREAD_COMMISSIONER_ENABLED(uint8
 
     SuccessOrExit(error = mDecoder.ReadBool(enabled));
 
-    if (enabled == false)
+    if (!enabled)
     {
         error = otCommissionerStop(mInstance);
     }

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -773,7 +773,7 @@ template <> otError NcpBase::HandlePropertyInsert<SPINEL_PROP_THREAD_ON_MESH_NET
 
     memset(&borderRouterConfig, 0, sizeof(otBorderRouterConfig));
 
-    VerifyOrExit(mAllowLocalNetworkDataChange == true, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(mAllowLocalNetworkDataChange, error = OT_ERROR_INVALID_STATE);
 
     SuccessOrExit(error = mDecoder.ReadIp6Address(borderRouterConfig.mPrefix.mPrefix));
     SuccessOrExit(error = mDecoder.ReadUint8(prefixLength));
@@ -804,7 +804,7 @@ template <> otError NcpBase::HandlePropertyRemove<SPINEL_PROP_THREAD_ON_MESH_NET
 
     memset(&ip6Prefix, 0, sizeof(otIp6Prefix));
 
-    VerifyOrExit(mAllowLocalNetworkDataChange == true, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(mAllowLocalNetworkDataChange, error = OT_ERROR_INVALID_STATE);
 
     SuccessOrExit(error = mDecoder.ReadIp6Address(ip6Prefix.mPrefix));
     SuccessOrExit(error = mDecoder.ReadUint8(prefixLength));
@@ -864,7 +864,7 @@ template <> otError NcpBase::HandlePropertyInsert<SPINEL_PROP_SERVER_SERVICES>(v
     const uint8_t * data;
     uint16_t        dataLen;
 
-    VerifyOrExit(mAllowLocalServerDataChange == true, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(mAllowLocalServerDataChange, error = OT_ERROR_INVALID_STATE);
 
     SuccessOrExit(error = mDecoder.ReadUint32(cfg.mEnterpriseNumber));
     SuccessOrExit(error = mDecoder.ReadDataWithLen(data, dataLen));
@@ -898,7 +898,7 @@ template <> otError NcpBase::HandlePropertyRemove<SPINEL_PROP_SERVER_SERVICES>(v
     const uint8_t *serviceData;
     uint16_t       serviceDataLength;
 
-    VerifyOrExit(mAllowLocalServerDataChange == true, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(mAllowLocalServerDataChange, error = OT_ERROR_INVALID_STATE);
 
     SuccessOrExit(error = mDecoder.ReadUint32(enterpriseNumber));
     SuccessOrExit(error = mDecoder.ReadDataWithLen(serviceData, serviceDataLength));
@@ -1902,7 +1902,7 @@ template <> otError NcpBase::HandlePropertyInsert<SPINEL_PROP_THREAD_OFF_MESH_RO
 
     memset(&routeConfig, 0, sizeof(otExternalRouteConfig));
 
-    VerifyOrExit(mAllowLocalNetworkDataChange == true, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(mAllowLocalNetworkDataChange, error = OT_ERROR_INVALID_STATE);
 
     SuccessOrExit(error = mDecoder.ReadIp6Address(routeConfig.mPrefix.mPrefix));
     SuccessOrExit(error = mDecoder.ReadUint8(prefixLength));
@@ -1927,7 +1927,7 @@ template <> otError NcpBase::HandlePropertyRemove<SPINEL_PROP_THREAD_OFF_MESH_RO
 
     memset(&ip6Prefix, 0, sizeof(otIp6Prefix));
 
-    VerifyOrExit(mAllowLocalNetworkDataChange == true, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(mAllowLocalNetworkDataChange, error = OT_ERROR_INVALID_STATE);
 
     SuccessOrExit(error = mDecoder.ReadIp6Address(ip6Prefix.mPrefix));
     SuccessOrExit(error = mDecoder.ReadUint8(prefixLength));

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -150,7 +150,7 @@ void NcpUart::EncodeAndSendToUart(void)
                 otPlatWakeHost();
             }
 
-            VerifyOrExit(super_t::ShouldDeferHostSend() == false);
+            VerifyOrExit(!super_t::ShouldDeferHostSend());
             SuccessOrExit(mFrameEncoder.BeginFrame());
 
             txFrameBuffer.OutFrameBegin();


### PR DESCRIPTION
This commit simplifies boolean checks containing `== false` to use the
`!` operator instead, and removes redundant `== true` checks. This
commit aims to harmonize the boolean check style across core modules.