### PR TITLE
[radio-spinel] remove extra log on tx done failure

### DIFF
--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -1257,7 +1257,6 @@ void RadioSpinel::HandleTransmitDone(uint32_t          aCommand,
     }
     else
     {
-        otLogWarnPlat("Spinel status: %d.", status);
         error = SpinelStatusToOtError(status);
     }
 


### PR DESCRIPTION
This commit removes the extra logging of spinel error status on
tx done callback. The error will be logged from `LogIfFail()` at
the exit of the `HandleTransmitDone()`.