### PR TITLE
[ncp] set NCP instance pointer to NULL during pseudo reset

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -604,7 +604,7 @@ void NcpBase::Log(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aLog
     otError error  = OT_ERROR_NONE;
     uint8_t header = SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0;
 
-    VerifyOrExit(!mDisableStreamWrite);
+    VerifyOrExit(!mDisableStreamWrite, error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(SPINEL_PROP_STREAM_LOG));
 
     // If there is a pending queued response we do not allow any new log
@@ -1171,6 +1171,8 @@ otError NcpBase::CommandHandler_RESET(uint8_t aHeader)
         mChangedPropsSet.AddLastStatus(SPINEL_STATUS_RESET_UNKNOWN);
         mUpdateChangedPropsTask.Post();
     }
+
+    sNcpInstance = NULL;
 
     return error;
 }


### PR DESCRIPTION
This PR fixes the problem with initializing the NCP with wpantund. The bug was apparent when the NCP image was built with the `FULL_LOGS` switch set.
The reason for the bug was that after the pseudo reset the OpenThread stack wrote logs to NCP's `otPlatLog` implementation that used the not yet initialized NCP object. This put the `mUartSendTask` and `mUpdateChangedPropsTask` to the `TaskletScheduler` linked list. 
Later when the NCP itself was initialized, the `mNext` pointer in the tasklets `mUartSendTask` and `mUpdateChangedPropsTask` was set to null, causing all tasklets scheduled after the `mUartSendTask` to be lost. The NCP reset status could not be in such case sent to the wpantund. The wpantund then retried resetting the NCP, which repeated the process until the wpantund gave up.