### PR TITLE
[posix-sim] always set timestamp

### DIFF
--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -634,13 +634,8 @@ static void radioReceive(otInstance *aInstance)
     otEXPECT(sReceiveFrame.mChannel == sReceiveMessage.mChannel);
     otEXPECT(sState == OT_RADIO_STATE_RECEIVE || sState == OT_RADIO_STATE_TRANSMIT);
 
-#if !OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    if (otPlatRadioGetPromiscuous(aInstance))
-#endif
-    {
-        // Unable to simulate SFD, so use the rx done timestamp instead.
-        sReceiveFrame.mInfo.mRxInfo.mTimestamp = otPlatTimeGet();
-    }
+    // Unable to simulate SFD, so use the rx done timestamp instead.
+    sReceiveFrame.mInfo.mRxInfo.mTimestamp = otPlatTimeGet();
 
     if (sTxWait)
     {


### PR DESCRIPTION
This sets frame rx timestamp no matter in promiscuous mode or not. This is useful for debugging time related issues.