### PR TITLE
[config] remove duplicate unused definitions and fix comments

### DIFF
--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -172,8 +172,8 @@ typedef struct otMleCounters
     /**
      * Number of times device changed its parents.
      *
-     * Support for this counter requires the feature option OPENTHREAD_CONFIG_INFORM_PREVIOUS_PARENT_ON_REATTACH to be
-     * enabled.
+     * Support for this counter requires the feature option OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH to
+     * be enabled.
      *
      * A parent change can happen if device detaches from its current parent and attaches to a different one, or even
      * while device is attached when the periodic parent search feature is enabled  (please see option

--- a/src/core/config/dhcp6_server.h
+++ b/src/core/config/dhcp6_server.h
@@ -46,7 +46,7 @@
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_NUM_DHCP_PREFIXES
+ * @def OPENTHREAD_CONFIG_DHCP6_SERVER_NUM_PREFIXES
  *
  * The number of dhcp prefixes.
  *

--- a/src/core/config/joiner.h
+++ b/src/core/config/joiner.h
@@ -46,7 +46,7 @@
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_MAX_JOINER_ENTRIES
+ * @def OPENTHREAD_CONFIG_JOINER_MAX_CANDIDATES
  *
  * The maximum number of Joiner Router entries that can be queued by the Joiner.
  *

--- a/src/core/config/tmf.h
+++ b/src/core/config/tmf.h
@@ -147,17 +147,4 @@
 #define OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE 0
 #endif
 
-/**
- * @def OPENTHREAD_CONFIG_INFORM_PREVIOUS_PARENT_ON_REATTACH
- *
- * Define as 1 for a child to inform its previous parent when it attaches to a new parent.
- *
- * If this feature is enabled, when a device attaches to a new parent, it will send an IP message (with empty payload
- * and mesh-local IP address as the source address) to its previous parent.
- *
- */
-#ifndef OPENTHREAD_CONFIG_INFORM_PREVIOUS_PARENT_ON_REATTACH
-#define OPENTHREAD_CONFIG_INFORM_PREVIOUS_PARENT_ON_REATTACH 0
-#endif
-
 #endif // CONFIG_TMF_H_


### PR DESCRIPTION
This commit removes the unused duplicate definition in `tmf.h` for
`OPENTHREAD_CONFIG_INFORM_PREVIOUS_PARENT_ON_REATTACH` (this is
defined in `config/mle.h`). Also updates the comment/documentation
for `DHCP6_SERVER_NUM_PREFIXES` and `JOINER_MAX_CANDIDATES`.