### PR TITLE
[mle] save network info on mle mode change

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -382,6 +382,7 @@ otError Mle::Restore(void)
     Get<KeyManager>().SetCurrentKeySequence(networkInfo.mKeySequence);
     Get<KeyManager>().SetMleFrameCounter(networkInfo.mMleFrameCounter);
     Get<KeyManager>().SetMacFrameCounter(networkInfo.mMacFrameCounter);
+    mDeviceMode.Set(networkInfo.mDeviceMode);
 
     switch (networkInfo.mRole)
     {
@@ -394,7 +395,6 @@ otError Mle::Restore(void)
         ExitNow();
     }
 
-    mDeviceMode.Set(networkInfo.mDeviceMode);
     Get<Mac::Mac>().SetShortAddress(networkInfo.mRloc16);
     Get<Mac::Mac>().SetExtAddress(networkInfo.mExtAddress);
 
@@ -458,7 +458,6 @@ otError Mle::Store(void)
         // avoid losing/overwriting previous information when a reboot
         // occurs after a message is sent but before attaching.
 
-        networkInfo.mDeviceMode          = mDeviceMode.Get();
         networkInfo.mRole                = mRole;
         networkInfo.mRloc16              = GetRloc16();
         networkInfo.mPreviousPartitionId = mLeaderData.GetPartitionId();
@@ -491,6 +490,7 @@ otError Mle::Store(void)
     networkInfo.mKeySequence     = Get<KeyManager>().GetCurrentKeySequence();
     networkInfo.mMleFrameCounter = Get<KeyManager>().GetMleFrameCounter() + OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD;
     networkInfo.mMacFrameCounter = Get<KeyManager>().GetMacFrameCounter() + OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD;
+    networkInfo.mDeviceMode      = mDeviceMode.Get();
 
     SuccessOrExit(error = Get<Settings>().SaveNetworkInfo(networkInfo));
 
@@ -841,6 +841,8 @@ otError Mle::SetDeviceMode(DeviceMode aDeviceMode)
     mDeviceMode = aDeviceMode;
 
     otLogNoteMle("Mode 0x%02x -> 0x%02x [%s]", oldMode.Get(), mDeviceMode.Get(), mDeviceMode.ToString().AsCString());
+
+    Store();
 
     switch (mRole)
     {


### PR DESCRIPTION
This commit ensures to save the network info in non-volatile settings
when the MLE device mode is changed (`Mle::SetDevcieMode()`)
independent of whether the device is currently attached or not. This
helps address the situation where there is a single router/leader
device in network and user changes the MLE thread mode to make it a
sleepy (where due to device being the only node in the network it
would not attach). Then, later upon device reset (without the change
in this commit) the device would have started again as router/leader.
Note that network info is saved/updated in non-volatile memory after a
successful attach.

---------------

More info related to this: This is not an issue on devices which use `wpantund` as host-side driver
since `"Thread:DeviceMode"` is one of the persisted parameters on `wpantund` (i.e., on an 
NCP reset `wpantund` ensures to restore the last requested value for this parameter back on NCP).