### PR TITLE
[core] EID-to-RLOC cache map optimization

### DIFF
--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -212,8 +212,10 @@ void AddressResolver::InvalidateCacheEntry(Cache &aEntry, InvalidationReason aRe
     aEntry.mState = Cache::kStateInvalid;
 }
 
-void AddressResolver::UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16, bool aApplyOptimization)
+otError AddressResolver::UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16)
 {
+    otError error = OT_ERROR_NOT_FOUND;
+
     for (int i = 0; i < kCacheEntries; i++)
     {
         if (mCache[i].mState == Cache::kStateInvalid || mCache[i].mTarget != aEid)
@@ -240,25 +242,29 @@ void AddressResolver::UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddre
             otLogNoteArp("Cache entry updated (snoop): %s, 0x%04x", aEid.ToString().AsCString(), aRloc16);
         }
 
-        ExitNow();
+        error = OT_ERROR_NONE;
     }
 
-    if (aApplyOptimization)
-    {
-        Cache *entry = NewCacheEntry();
-        VerifyOrExit(entry != NULL);
+    return error;
+}
 
-        entry->mTarget   = aEid;
-        entry->mRloc16   = aRloc16;
-        entry->mTimeout  = 0;
-        entry->mFailures = 0;
-        entry->mState    = Cache::kStateCached;
+otError AddressResolver::AddCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16)
+{
+    otError error = OT_ERROR_NONE;
+    Cache * entry = NewCacheEntry();
 
-        MarkCacheEntryAsUsed(*entry);
-    }
+    VerifyOrExit(entry != NULL, error = OT_ERROR_NO_BUFS);
+
+    entry->mTarget   = aEid;
+    entry->mRloc16   = aRloc16;
+    entry->mTimeout  = 0;
+    entry->mFailures = 0;
+    entry->mState    = Cache::kStateCached;
+
+    MarkCacheEntryAsUsed(*entry);
 
 exit:
-    return;
+    return error;
 }
 
 void AddressResolver::RestartAddressQueries(void)

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -212,7 +212,7 @@ void AddressResolver::InvalidateCacheEntry(Cache &aEntry, InvalidationReason aRe
     aEntry.mState = Cache::kStateInvalid;
 }
 
-void AddressResolver::UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16)
+void AddressResolver::UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16, bool aApplyOptimization)
 {
     for (int i = 0; i < kCacheEntries; i++)
     {
@@ -241,6 +241,20 @@ void AddressResolver::UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddre
         }
 
         ExitNow();
+    }
+
+    if (aApplyOptimization)
+    {
+        Cache *entry = NewCacheEntry();
+        VerifyOrExit(entry != NULL);
+
+        entry->mTarget   = aEid;
+        entry->mRloc16   = aRloc16;
+        entry->mTimeout  = 0;
+        entry->mFailures = 0;
+        entry->mState    = Cache::kStateCached;
+
+        MarkCacheEntryAsUsed(*entry);
     }
 
 exit:

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -103,11 +103,12 @@ public:
     void Remove(uint8_t aRouterId);
 
     /**
-     * This method updates an existing cache entry for the EID, if one exists.
+     * This method updates an existing cache entry for the EID, if one exists, or
+     * adds one cache entry if optimization should be applied.
      *
      * @param[in]  aEid               A reference to the EID.
      * @param[in]  aRloc16            The RLOC16 corresponding to @p aEid.
-     * @param[in]  aApplyOptimization Boolean indicates whether or not apply EID-to-RLOC map cache optimization.
+     * @param[in]  aApplyOptimization Boolean indicates whether or not adds one EID-to-RLOC for map cache optimization.
      *
      */
     void UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16, bool aApplyOptimization = false);

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -103,15 +103,28 @@ public:
     void Remove(uint8_t aRouterId);
 
     /**
-     * This method updates an existing cache entry for the EID, if one exists, or
-     * adds one cache entry if optimization should be applied.
+     * This method updates an existing cache entry for the EID.
      *
      * @param[in]  aEid               A reference to the EID.
      * @param[in]  aRloc16            The RLOC16 corresponding to @p aEid.
-     * @param[in]  aApplyOptimization Boolean indicates whether or not adds one EID-to-RLOC for map cache optimization.
+     *
+     * @retval OT_ERROR_NONE           Successfully updates an existing cache entry.
+     * @retval OT_ERROR_NOT_FOUND      No cache entry with @p aEid.
      *
      */
-    void UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16, bool aApplyOptimization = false);
+    otError UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16);
+
+    /**
+     * This method adds one cache entry for the EID.
+     *
+     * @param[in]  aEid               A reference to the EID.
+     * @param[in]  aRloc16            The RLOC16 corresponding to @p aEid.
+     *
+     * @retval OT_ERROR_NONE           Successfully adds one cache entry.
+     * @retval OT_ERROR_NO_BUFS        Insufficient buffer space available to add one cache entry.
+     *
+     */
+    otError AddCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16);
 
     /**
      * This method returns the RLOC16 for a given EID, or initiates an Address Query if the mapping is not known.

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -105,11 +105,12 @@ public:
     /**
      * This method updates an existing cache entry for the EID, if one exists.
      *
-     * @param[in]  aEid     A reference to the EID.
-     * @param[in]  aRloc16  The RLOC16 corresponding to @p aEid.
+     * @param[in]  aEid               A reference to the EID.
+     * @param[in]  aRloc16            The RLOC16 corresponding to @p aEid.
+     * @param[in]  aApplyOptimization Boolean indicates whether or not apply EID-to-RLOC map cache optimization.
      *
      */
-    void UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16);
+    void UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16, bool aApplyOptimization = false);
 
     /**
      * This method returns the RLOC16 for a given EID, or initiates an Address Query if the mapping is not known.

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -594,7 +594,8 @@ void MeshForwarder::UpdateRoutes(uint8_t *           aFrame,
     VerifyOrExit(!aMeshDest.IsBroadcast() && aMeshSource.IsShort());
     SuccessOrExit(GetIp6Header(aFrame, aFrameLength, aMeshSource, aMeshDest, ip6Header));
 
-    if (!ip6Header.GetSource().IsRoutingLocator() && !ip6Header.GetSource().IsAnycastRoutingLocator())
+    if (!ip6Header.GetSource().IsRoutingLocator() && !ip6Header.GetSource().IsAnycastRoutingLocator() &&
+        Get<NetworkData::Leader>().IsOnMesh(ip6Header.GetSource()) /* only for on mesh address which may require AQ */)
     {
         // Thread 1.1 Specification 5.5.2.2:
         // An FTDs MAY add/update EID-to-RLOC Map Cache entries by inspecting packets being received.

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -607,7 +607,12 @@ void MeshForwarder::UpdateRoutes(uint8_t *           aFrame,
             applyOptimization = true;
         }
 
-        Get<AddressResolver>().UpdateCacheEntry(ip6Header.GetSource(), aMeshSource.GetShort(), applyOptimization);
+        if (Get<AddressResolver>().UpdateCacheEntry(ip6Header.GetSource(), aMeshSource.GetShort()) ==
+                OT_ERROR_NOT_FOUND &&
+            applyOptimization)
+        {
+            Get<AddressResolver>().AddCacheEntry(ip6Header.GetSource(), aMeshSource.GetShort());
+        }
     }
 
     neighbor = Get<Mle::MleRouter>().GetNeighbor(ip6Header.GetSource());


### PR DESCRIPTION
Thread 1.1 Spec 5.5.2.2:
```
FTDs MAY update EID-to-RLOC Map Cache entries by inspecting packets being sent/received
via a Thread Interface.
```

This PR would add EID-to-RLOC map cache entry by inspecting packets received, aiming to reduce  
RealmLocal multicast AQ when response is expected.