### PR TITLE
[mle] enable state update timer when enabling router role

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -125,8 +125,8 @@ void MleRouter::SetRouterRoleEnabled(bool aEnabled)
 
         break;
     }
-	
-    if (aEnabled && !mStateUpdateTimer.IsRunning() && IsFullThreadDevice() && (mRole != OT_DEVICE_ROLE_DISABLED))
+
+    if (IsRouterRoleEnabled() && IsAttached() && !mStateUpdateTimer.IsRunning())
     {
         mStateUpdateTimer.Start(kStateUpdatePeriod);
     }

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -126,8 +126,7 @@ void MleRouter::SetRouterRoleEnabled(bool aEnabled)
         break;
     }
 	
-    if (aEnabled && !mStateUpdateTimer.IsRunning() && IsFullThreadDevice() 
-        && (mRole != OT_DEVICE_ROLE_DISABLED))
+    if (aEnabled && !mStateUpdateTimer.IsRunning() && IsFullThreadDevice() && (mRole != OT_DEVICE_ROLE_DISABLED))
     {
         mStateUpdateTimer.Start(kStateUpdatePeriod);
     }

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -125,6 +125,12 @@ void MleRouter::SetRouterRoleEnabled(bool aEnabled)
 
         break;
     }
+	
+    if (aEnabled && !mStateUpdateTimer.IsRunning() && IsFullThreadDevice() 
+        && (mRole != OT_DEVICE_ROLE_DISABLED))
+    {
+        mStateUpdateTimer.Start(kStateUpdatePeriod);
+    }
 }
 
 otError MleRouter::BecomeRouter(ThreadStatusTlv::Status aStatus)


### PR DESCRIPTION
If already connected as a child when enabling the routerrole, then the timer won't start.