### PR TITLE
[travis-ci] merge pretty check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -185,11 +185,7 @@ jobs:
       language: generic
       script: .travis/script.sh
     - stage: lint
-      env: BUILD_TARGET="py-pretty-check"
-      os: linux
-      python: "2.7"
-      script: .travis/script.sh
-    - env: BUILD_TARGET="pretty-check"
+      name: "Pretty Check"
       os: linux
       addons:
         apt:
@@ -198,9 +194,9 @@ jobs:
             - ubuntu-toolchain-r-test
           packages:
             - clang-format-6.0
-      script: .travis/script.sh
-    - env: BUILD_TARGET="size-report"
+      script: .travis/check-pretty
+    - env:
+      name: "Size Report"
       os: linux
-      compiler: gcc
-      script: .travis/script.sh VERBOSE=1
+      script: .travis/check-size
       if: type = pull_request

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -27,6 +27,8 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+[ -n "$BUILD_TARGET" ] || exit 0
+
 die() {
 	echo " *** ERROR: " $*
 	exit 1
@@ -57,15 +59,6 @@ cd /tmp || die
         unzip android-ndk-r17c-linux-x86_64.zip > /dev/null
         mv android-ndk-r17c ndk-bundle
         ) || die
-    }
-
-    [ $BUILD_TARGET != pretty-check ] || {
-        clang-format --version || die
-    }
-
-    [ $BUILD_TARGET != py-pretty-check ] || {
-        pip install --upgrade pip || die
-        python -m pip install flake8 || die
     }
 
     [ $BUILD_TARGET != posix-app-pty ] || {
@@ -108,7 +101,7 @@ cd /tmp || die
         arm-none-eabi-gcc --version || die
     }
 
-    [ $BUILD_TARGET != arm-gcc-7 -a $BUILD_TARGET != size-report ] || {
+    [ $BUILD_TARGET != arm-gcc-7 ] || {
         wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2 || die
         tar xjf gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2 || die
         export PATH=/tmp/gcc-arm-none-eabi-7-2018-q2-update/bin:$PATH || die

--- a/.travis/check-pretty
+++ b/.travis/check-pretty
@@ -27,26 +27,48 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-[ -n "$BUILD_TARGET" ] || exit 0
+set -e -x -o pipefail
 
-set -e
-
-codecov_upload() {
-    curl -s https://codecov.io/bash > codecov
-    chmod a+x codecov
-
-    # Assume gcov by default, and llvm-cov if CC is clang
-    if [[ -z $CC ]]; then
-        ./codecov
-    elif  "$CC" --version | grep -q gcc; then
-        ./codecov
-    elif "$CC" --version | grep -q clang; then
-        ./codecov -x "llvm-cov gcov"
-    fi
+setup_python()
+{
+  python -m pip install flake8
 }
 
-main() {
-    codecov_upload
+check_python()
+{
+  flake8 --config=script/pystyle.cfg tests tools
+}
+
+check_clang()
+{
+  clang-format --version
+  ./bootstrap
+  ./configure
+  make pretty-check
+}
+
+main()
+{
+  case $1 in
+    setup)
+      setup_python
+      ;;
+    python)
+      check_python
+      ;;
+    clang)
+      check_cpp
+      ;;
+    '')
+      setup_python
+      check_python
+      check_clang
+      ;;
+    *)
+      echo "USAGE: $0 [setup|python|clang]"
+      exit 1
+      ;;
+  esac
 }
 
 main "$@"

--- a/.travis/check-size
+++ b/.travis/check-size
@@ -1,0 +1,107 @@
+#!/bin/bash
+#
+#  Copyright (c) 2019, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e -x -o pipefail
+
+setup_arm_gcc_7()
+{
+  if arm-none-eabi-gcc --version | grep -q 'Arm Embedded Processors 7'; then
+    return 0
+  fi
+
+  (cd /tmp/
+   wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2
+   tar xjf gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2)
+  export PATH=/tmp/gcc-arm-none-eabi-7-2018-q2-update/bin:$PATH
+
+  arm-none-eabi-gcc --version
+}
+
+size_nrf52840()
+{
+    [ ${TRAVIS_PULL_REQUEST} != false ]
+
+    mkdir ../output
+
+    export MERGE_BASE_SHA=$(git merge-base HEAD ${TRAVIS_BRANCH})
+
+    # pull request
+    OPENTHREAD_FLAGS="BORDER_AGENT=1 BORDER_ROUTER=1 CHANNEL_MANAGER=1 CHANNEL_MONITOR=1 CHILD_SUPERVISION=1 COAP=1 COAPS=1 COMMISSIONER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DIAGNOSTIC=1 DISABLE_DOC=1 DNS_CLIENT=1 ECDSA=1 FULL_LOGS=1 JAM_DETECTION=1 JOINER=1 LINK_RAW=1 MAC_FILTER=1 MTD_NETDIAG=1 SERVICE=1 SLAAC=1 SNTP_CLIENT=1 TIME_SYNC=1 UDP_FORWARD=1"
+
+    git checkout -- .
+    git clean -xfd
+    ./bootstrap
+    make -f examples/Makefile-nrf52840 ${OPENTHREAD_FLAGS}
+    mv output/nrf52840 ../output/nrf52840-b
+
+    git checkout ${MERGE_BASE_SHA}
+    git submodule update --init
+
+    # base branch
+    git checkout -- .
+    git clean -xfd
+    ./bootstrap
+    make -f examples/Makefile-nrf52840 ${OPENTHREAD_FLAGS}
+    mv output/nrf52840 ../output/nrf52840-a
+
+    curl -s "${SIZE_REPORT_URL}/bash" > size-report
+    chmod a+x size-report
+
+    ./size-report init OpenThread
+
+    ./size-report size ../output/nrf52840-a/bin/ot-cli-ftd ../output/nrf52840-b/bin/ot-cli-ftd
+    ./size-report size ../output/nrf52840-a/bin/ot-cli-mtd ../output/nrf52840-b/bin/ot-cli-mtd
+    ./size-report size ../output/nrf52840-a/bin/ot-ncp-ftd ../output/nrf52840-b/bin/ot-ncp-ftd
+    ./size-report size ../output/nrf52840-a/bin/ot-ncp-mtd ../output/nrf52840-b/bin/ot-ncp-mtd
+    ./size-report size ../output/nrf52840-a/bin/ot-rcp     ../output/nrf52840-b/bin/ot-rcp
+
+    ./size-report post
+}
+
+main()
+{
+  case $1 in
+    setup)
+      setup_arm_gcc_7
+      ;;
+    nrf52840)
+      size_nrf52840
+      ;;
+    '')
+      setup_arm_gcc_7
+      size_nrf52840
+      ;;
+    *)
+      echo "USAGE: $0 [setup|nrf52840]"
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -36,16 +36,6 @@ set -x
 
 python --version || die
 
-[ $BUILD_TARGET != pretty-check ] || {
-    ./bootstrap || die
-    ./configure || die
-    make pretty-check || die
-}
-
-[ $BUILD_TARGET != py-pretty-check ] || {
-    flake8 --config=script/pystyle.cfg tests tools || die
-}
-
 [ $BUILD_TARGET != scan-build ] || {
     ./bootstrap || die
 
@@ -448,48 +438,6 @@ build_samr21() {
 
 [ $BUILD_TARGET != toranj-test-framework ] || {
     ./tests/toranj/start.sh || die
-}
-
-[ $BUILD_TARGET != size-report ] || {
-    [ ${TRAVIS_PULL_REQUEST} != false ] || die
-
-    export PATH=/tmp/gcc-arm-none-eabi-7-2018-q2-update/bin:$PATH || die
-
-    mkdir ../output
-
-    export MERGE_BASE_SHA=$(git merge-base HEAD ${TRAVIS_BRANCH})
-
-    # pull request
-    OPENTHREAD_FLAGS="BORDER_AGENT=1 BORDER_ROUTER=1 CHANNEL_MANAGER=1 CHANNEL_MONITOR=1 CHILD_SUPERVISION=1 COAP=1 COAPS=1 COMMISSIONER=1 DHCP6_CLIENT=1 DHCP6_SERVER=1 DIAGNOSTIC=1 DISABLE_DOC=1 DNS_CLIENT=1 ECDSA=1 FULL_LOGS=1 JAM_DETECTION=1 JOINER=1 LINK_RAW=1 MAC_FILTER=1 MTD_NETDIAG=1 SERVICE=1 SLAAC=1 SNTP_CLIENT=1 TIME_SYNC=1 UDP_FORWARD=1"
-
-    git checkout -- . || die
-    git clean -xfd || die
-    ./bootstrap || die
-    make -f examples/Makefile-nrf52840 ${OPENTHREAD_FLAGS} || die
-    mv output/nrf52840 ../output/nrf52840-b
-
-    git checkout ${MERGE_BASE_SHA}
-    git submodule update --init
-
-    # base branch
-    git checkout -- . || die
-    git clean -xfd || die
-    ./bootstrap || die
-    make -f examples/Makefile-nrf52840 ${OPENTHREAD_FLAGS} || die
-    mv output/nrf52840 ../output/nrf52840-a
-
-    curl -s "${SIZE_REPORT_URL}/bash" > size-report
-    chmod a+x size-report
-
-    ./size-report init OpenThread
-
-    ./size-report size ../output/nrf52840-a/bin/ot-cli-ftd ../output/nrf52840-b/bin/ot-cli-ftd
-    ./size-report size ../output/nrf52840-a/bin/ot-cli-mtd ../output/nrf52840-b/bin/ot-cli-mtd
-    ./size-report size ../output/nrf52840-a/bin/ot-ncp-ftd ../output/nrf52840-b/bin/ot-ncp-ftd
-    ./size-report size ../output/nrf52840-a/bin/ot-ncp-mtd ../output/nrf52840-b/bin/ot-ncp-mtd
-    ./size-report size ../output/nrf52840-a/bin/ot-rcp     ../output/nrf52840-b/bin/ot-rcp
-
-    ./size-report post
 }
 
 [ $BUILD_TARGET != osx ] || {


### PR DESCRIPTION
This PR merges the pretty checks into one to reduce the jobs and save time.

Besides, as many jobs were added, `.travis/before_script.sh` becomes very big. This PR removes pretty check and size report's dependency on that script. Since many job now differs much, it will be easier to maintain and use if each job itself manages its own prerequisites.