### PR TITLE
[border-agent] handle error responses from leader

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -227,10 +227,17 @@ void BorderAgent::HandleCoapResponse(void *               aContext,
     Coap::Message *      message        = NULL;
     otError              error;
 
-    VerifyOrExit((message = NewMeshCoPMessage(instance.Get<Coap::CoapSecure>())) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = aResult);
+    VerifyOrExit((message = NewMeshCoPMessage(instance.Get<Coap::CoapSecure>())) != NULL, error = OT_ERROR_NO_BUFS);
 
-    if (forwardContext.IsPetition())
+    SuccessOrExit(error = forwardContext.ToHeader(*message, response->GetCode()));
+
+    if (response->GetLength() - response->GetOffset() > 0)
+    {
+        SuccessOrExit(error = message->SetPayloadMarker());
+    }
+
+    if (forwardContext.IsPetition() && response->GetCode() == OT_COAP_CODE_CHANGED)
     {
         StateTlv stateTlv;
 
@@ -250,13 +257,6 @@ void BorderAgent::HandleCoapResponse(void *               aContext,
             instance.Get<ThreadNetif>().AddUnicastAddress(borderAgent.mCommissionerAloc);
             instance.Get<Ip6::Udp>().AddReceiver(borderAgent.mUdpReceiver);
         }
-    }
-
-    SuccessOrExit(error = forwardContext.ToHeader(*message, response->GetCode()));
-
-    if (response->GetLength() - response->GetOffset() > 0)
-    {
-        SuccessOrExit(error = message->SetPayloadMarker());
     }
 
     SuccessOrExit(error = borderAgent.ForwardToCommissioner(*message, *response));

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -230,13 +230,6 @@ void BorderAgent::HandleCoapResponse(void *               aContext,
     SuccessOrExit(error = aResult);
     VerifyOrExit((message = NewMeshCoPMessage(instance.Get<Coap::CoapSecure>())) != NULL, error = OT_ERROR_NO_BUFS);
 
-    SuccessOrExit(error = forwardContext.ToHeader(*message, response->GetCode()));
-
-    if (response->GetLength() - response->GetOffset() > 0)
-    {
-        SuccessOrExit(error = message->SetPayloadMarker());
-    }
-
     if (forwardContext.IsPetition() && response->GetCode() == OT_COAP_CODE_CHANGED)
     {
         StateTlv stateTlv;
@@ -257,6 +250,13 @@ void BorderAgent::HandleCoapResponse(void *               aContext,
             instance.Get<ThreadNetif>().AddUnicastAddress(borderAgent.mCommissionerAloc);
             instance.Get<Ip6::Udp>().AddReceiver(borderAgent.mUdpReceiver);
         }
+    }
+
+    SuccessOrExit(error = forwardContext.ToHeader(*message, response->GetCode()));
+
+    if (response->GetLength() > response->GetOffset())
+    {
+        SuccessOrExit(error = message->SetPayloadMarker());
     }
 
     SuccessOrExit(error = borderAgent.ForwardToCommissioner(*message, *response));


### PR DESCRIPTION
This PR fix the bug in border agent that it assumes the _COM_PET.rsp_ from the leader is _CHANGED_. But it is possible for the leader to return a _4.XX_ error response. In that case, the border agent should forward that error response.