### PR TITLE
[posix-sim] remove unused variable

### DIFF
--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -465,11 +465,7 @@ exit:
 void platformRadioInit(void)
 {
 #if OPENTHREAD_POSIX_VIRTUAL_TIME == 0
-    struct sockaddr_in sockaddr;
-    char *             offset;
-
-    memset(&sockaddr, 0, sizeof(sockaddr));
-    sockaddr.sin_family = AF_INET;
+    char *offset;
 
     offset = getenv("PORT_OFFSET");
 


### PR DESCRIPTION
---
Variable `socketaddr`  no longer needed/used after #3993 moving the socket creation to `initFds()`.