### PR TITLE
[border-agent] fix appending extended UDP Encapsulation TLV

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -424,7 +424,7 @@ bool BorderAgent::HandleUdpReceive(const Message &aMessage, const Ip6::MessageIn
         tlv.SetSourcePort(aMessageInfo.GetPeerPort());
         tlv.SetDestinationPort(aMessageInfo.GetSockPort());
         tlv.SetUdpLength(udpLength);
-        SuccessOrExit(error = message->AppendTlv(tlv));
+        SuccessOrExit(error = message->Append(&tlv, sizeof(tlv)));
 
         offset = message->GetLength();
         SuccessOrExit(error = message->SetLength(offset + udpLength));


### PR DESCRIPTION
This PR fix the bug that border agent incorrectly appends the UDP Encapsulation TLV:
- _AppendTlv_ does not accept an Extended TLV;
- _AppendTlv_ expects a complete TLV object which includes the _value_ just behind the _length_.