### PR TITLE
[posix-app] remove node id from logging

### DIFF
--- a/include/openthread/platform/logging.h
+++ b/include/openthread/platform/logging.h
@@ -110,7 +110,7 @@ extern "C" {
  * This type represents the log level.
  *
  */
-typedef uint8_t otLogLevel;
+typedef int otLogLevel;
 
 /**
  * This enumeration represents log regions.

--- a/src/posix/platform/logging.c
+++ b/src/posix/platform/logging.c
@@ -30,65 +30,46 @@
 #include "platform-posix.h"
 
 #include <assert.h>
-#include <inttypes.h>
 #include <stdarg.h>
-#include <stdio.h>
 #include <syslog.h>
 
 #include <openthread/platform/logging.h>
-
-#include "code_utils.h"
-
-#define LOGGING_MAX_LOG_STRING_SIZE 512
 
 #if OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED
 void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
 {
     OT_UNUSED_VARIABLE(aLogRegion);
 
-    char         logString[LOGGING_MAX_LOG_STRING_SIZE];
-    int          charsWritten;
-    va_list      args;
-    int          logLevel;
-    unsigned int offset = 0;
+    va_list args;
 
-    charsWritten = snprintf(&logString[offset], sizeof(logString), "[%" PRIx64 "] ", gNodeId);
-    otEXPECT_ACTION(charsWritten >= 0, logString[offset] = 0);
-    offset += (unsigned int)charsWritten;
-    otEXPECT_ACTION(offset < sizeof(logString), logString[sizeof(logString) - 1] = 0);
-
-    va_start(args, aFormat);
-    charsWritten = vsnprintf(&logString[offset], sizeof(logString) - offset, aFormat, args);
-    va_end(args);
-
-    otEXPECT_ACTION(charsWritten >= 0, logString[offset] = 0);
-
-exit:
     switch (aLogLevel)
     {
     case OT_LOG_LEVEL_NONE:
-        logLevel = LOG_ALERT;
+        aLogLevel = LOG_ALERT;
         break;
     case OT_LOG_LEVEL_CRIT:
-        logLevel = LOG_CRIT;
+        aLogLevel = LOG_CRIT;
         break;
     case OT_LOG_LEVEL_WARN:
-        logLevel = LOG_WARNING;
+        aLogLevel = LOG_WARNING;
         break;
     case OT_LOG_LEVEL_NOTE:
-        logLevel = LOG_NOTICE;
+        aLogLevel = LOG_NOTICE;
         break;
     case OT_LOG_LEVEL_INFO:
-        logLevel = LOG_INFO;
+        aLogLevel = LOG_INFO;
         break;
     case OT_LOG_LEVEL_DEBG:
-        logLevel = LOG_DEBUG;
+        aLogLevel = LOG_DEBUG;
         break;
     default:
         assert(false);
-        logLevel = LOG_DEBUG;
+        aLogLevel = LOG_DEBUG;
         break;
     }
-    syslog(logLevel, "%s", logString);
+
+    va_start(args, aFormat);
+    vsyslog(aLogLevel, aFormat, args);
+    va_end(args);
 }
 #endif // OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED


### PR DESCRIPTION
* Simplified posix-app logging
* typedef otLogLevel to signed int so that when dynamic logging and
  reference_device is enabled, there will not be always true error.