### PR TITLE
[sub-mac] relax the requirement for TxDone callback

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -286,15 +286,15 @@ void SubMac::BeginTransmit(void)
     error = Get<Radio>().Receive(mTransmitFrame.GetChannel());
     assert(error == OT_ERROR_NONE);
 
-    error = Get<Radio>().Transmit(mTransmitFrame);
-    assert(error == OT_ERROR_NONE);
-
     SetState(kStateTransmit);
 
     if (mPcapCallback)
     {
         mPcapCallback(&mTransmitFrame, true, mPcapCallbackContext);
     }
+
+    error = Get<Radio>().Transmit(mTransmitFrame);
+    assert(error == OT_ERROR_NONE);
 
 exit:
     return;


### PR DESCRIPTION
This commit changes the `SubMac::BeginTrasnmit()` by moving the call
to `Transmit()` on radio platform after the state change to
`kStateTransmit` (and pcap callback). This relaxes the requirement for
radio platform implementation and allow it to invoke `TxDone` callback
directly from the `Transmit()` call itself (instead of requiring
`TxDone` to be called only after the `Transmit()` call returns).