### PR TITLE
[cli] add performance tool support

### DIFF
--- a/examples/common-switches.mk
+++ b/examples/common-switches.mk
@@ -31,6 +31,7 @@
 BIG_ENDIAN          ?= 0
 BORDER_AGENT        ?= 0
 BORDER_ROUTER       ?= 0
+CLI_PERF            ?= 0
 COAP                ?= 0
 COAPS               ?= 0
 COMMISSIONER        ?= 0
@@ -76,6 +77,10 @@ endif
 
 ifeq ($(BORDER_ROUTER),1)
 COMMONCFLAGS                   += -DOPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE=1
+endif
+
+ifeq ($(CLI_PERF),1)
+COMMONCFLAGS                   += -DOPENTHREAD_CONFIG_CLI_PERF_ENABLE=1
 endif
 
 ifeq ($(COAP),1)

--- a/src/cli/Makefile.am
+++ b/src/cli/Makefile.am
@@ -149,6 +149,7 @@ SOURCES_COMMON =                      \
     cli_console.cpp                   \
     cli_dataset.cpp                   \
     cli_joiner.cpp                    \
+    cli_perf.cpp                      \
     cli_server.cpp                    \
     cli_uart.cpp                      \
     cli_udp.cpp                       \
@@ -171,6 +172,7 @@ noinst_HEADERS                      = \
     cli_console.hpp                   \
     cli_dataset.hpp                   \
     cli_joiner.hpp                    \
+    cli_perf.hpp                      \
     cli_server.hpp                    \
     cli_uart.hpp                      \
     cli_udp.hpp                       \

--- a/src/cli/README_PERF.md
+++ b/src/cli/README_PERF.md
@@ -11,11 +11,12 @@ Cli Perf is a performance tool used to test throughput, latency, jitter, out of 
 Use the `TIME_SYNC=1` build switch to enable Time Sync API support.
 Use the `CLI_PERF=1` build switch to enable Cli Perf support.
 
-Note: Latency measurement is based on Time Sync feature.
+Note: Latency measurement is based on Time Sync feature. If user doesn't want to test latency or
+the dev board doesn't support Time Sync feature, just remove the 'TIME_SYNC=1' build switch.
 
 ```bash
-> ./bootstrap
-> make -f examples/Makefile-nrf52840 TIME_SYNC=1 CLI_PERF=1 
+ ./bootstrap
+ make -f examples/Makefile-nrf52840 TIME_SYNC=1 CLI_PERF=1
 ```
 
 ### Example 1: Test Unicast Traffic
@@ -321,7 +322,7 @@ On node 1, it shows the test result.
 * [client](#client-destaddr-address-bandwidth-value-length-value-priority-value-time-value-count-value-id-value-findelay-value-echo-value-interval-value-format-value)
 * [start](#start)
 * [stop](#stop)
-* [show](#show)
+* [list](#list)
 * [clear](#clear)
 
 ## Command Details
@@ -335,7 +336,7 @@ client
 server
 start
 stop
-show
+list
 clear
 Done
 ```
@@ -458,11 +459,11 @@ Stop client transmiting packets.
 Done
 ```
 
-### show
-Show perf sessions.
+### list
+Show perf settings.
 
 ```bash
-> perf show
+> perf list
 perf client destaddr fdde:ad00:beef:0:0:ff:fe00:fc00 bandwidth 2000 length 64 priority 1 id 1
 perf client destaddr fdde:ad00:beef:0:0:ff:fe00:fc00 bandwidth 2000 length 64 priority 2 id 2
 Done

--- a/src/cli/README_PERF.md
+++ b/src/cli/README_PERF.md
@@ -1,0 +1,480 @@
+# OpenThread CLI - Perf Example
+
+## Overview
+
+Cli Perf is a performance tool used to test throughput, latency, jitter, out of order and loss rate of OpenThread Network.
+
+## Quick Start
+
+### Build with Time Sync and Cli Perf support
+
+Use the `TIME_SYNC=1` build switch to enable Time Sync API support.
+Use the `CLI_PERF=1` build switch to enable Cli Perf support.
+
+Note: Latency measurement is based on Time Sync feature.
+
+```bash
+> ./bootstrap
+> make -f examples/Makefile-nrf52840 TIME_SYNC=1 CLI_PERF=1 
+```
+
+### Example 1: Test Unicast Traffic
+
+#### Form Network and enable Time Sync
+
+Form a network with at least two devices. All devices are time synchronized with each other.
+
+#### Node 1
+
+On node 1, create a listening session and start it.
+
+```bash
+> perf server
+Done
+> perf start
+Server listening on UDP port 5001
+Done
+> 
+```
+
+#### Node 2
+
+On node 2, create a transmission session and start it.
+
+```bash
+> perf client destaddr fdde:ad00:beef:0:0:ff:fe00:fc00 bandwidth 2000 length 64
+Done
+> perf start
+Client connecting to  fdde:ad00:beef:0:0:ff:fe00:fc00 , UDP port 5001
+[ ID]  Interval              Transfer     Bandwidth
+Done
+> [  0]  0.000 -  1.280 sec     320 Bytes    2000 bits/sec  
+[  0]  1.280 -  2.304 sec     256 Bytes    2000 bits/sec  
+[  0]  2.304 -  3.328 sec     256 Bytes    2000 bits/sec  
+[  0]  3.328 -  4.352 sec     256 Bytes    2000 bits/sec  
+[  0]  4.352 -  5.376 sec     256 Bytes    2000 bits/sec  
+[  0]  5.376 -  6.400 sec     256 Bytes    2000 bits/sec  
+[  0]  6.400 -  7.424 sec     256 Bytes    2000 bits/sec  
+[  0]  7.424 -  8.448 sec     256 Bytes    2000 bits/sec  
+[  0]  8.448 -  9.472 sec     256 Bytes    2000 bits/sec  
+[  0]  0.000 - 10.240 sec    2560 Bytes    2000 bits/sec 
+```
+
+#### Node 1
+
+On node 1, it shows the test result.
+
+```bash
+> 
+[ ID] Interval             Transfer     Bandwidth         Jitter    Lost/Total LossRate Latency(min, avg, max)
+[  0] local fdde:ad00:beef:0:0:ff:fe00:fc00 port 5001 connected with fdde:ad00:beef:0:3307:2f7b:7426:af07 port 49156
+[  0]  0.000 -  1.282 sec     320 Bytes    1996 bits/sec   0.356ms     0/   5     ( 0%) (6.1ms, 7.3ms, 8.5ms)
+[  0]  1.282 -  2.306 sec     256 Bytes    2000 bits/sec   0.505ms     0/   4     ( 0%) (7.0ms, 7.7ms, 8.1ms)
+[  0]  2.306 -  3.329 sec     256 Bytes    2001 bits/sec   0.660ms     0/   4     ( 0%) (6.0ms, 7.2ms, 7.9ms)
+[  0]  3.329 -  4.353 sec     256 Bytes    2000 bits/sec   0.743ms     0/   4     ( 0%) (6.6ms, 7.3ms, 7.9ms)
+[  0]  4.353 -  5.377 sec     256 Bytes    2000 bits/sec   0.684ms     0/   4     ( 0%) (6.3ms, 7.1ms, 7.5ms)
+[  0]  5.377 -  6.401 sec     256 Bytes    2000 bits/sec   1.097ms     0/   4     ( 0%) (6.0ms, 8.2ms, 11.7ms)
+[  0]  6.401 -  7.425 sec     256 Bytes    2000 bits/sec   0.852ms     0/   4     ( 0%) (7.3ms, 7.6ms, 7.8ms)
+[  0]  7.425 -  8.449 sec     256 Bytes    2000 bits/sec   0.881ms     0/   4     ( 0%) (6.3ms, 7.5ms, 7.9ms)
+[  0]  8.449 -  9.472 sec     256 Bytes    2001 bits/sec   0.864ms     0/   4     ( 0%) (6.8ms, 7.3ms, 8.3ms)
+[  0]  9.472 - 10.246 sec     192 Bytes    1984 bits/sec   0.824ms     0/   3     ( 0%) (7.9ms, 8.3ms, 8.7ms)
+[  0]  0.000 - 10.246 sec    2560 Bytes    1998 bits/sec   0.824ms     0/  40     ( 0%) (6.0ms, 7.5ms, 11.7ms)
+```
+
+### Example 2: Test Multicast Traffic
+
+#### Form Network and enable Time Sync
+
+Form a network with at least three devices. All devices are time synchronized with each other.
+
+#### Node 1
+
+On node 1, create a listening session and start it.
+
+```bash
+> perf server
+Done
+> perf start
+Server listening on UDP port 5001
+Done
+```
+
+#### Node 2
+
+On node 2, create a listening session and start it.
+
+```bash
+> perf server
+Done
+> perf start
+Server listening on UDP port 5001
+Done
+```
+
+#### Node 3
+
+On node 3, create a transmission session and start to transmit multicast traffic.
+
+```bash
+> perf client destaddr ff33:40:fdde:ad00:beef:0:0:1 bandwidth 2000 length 64
+Done
+> 
+> perf start
+Client connecting to  ff33:40:fdde:ad00:beef:0:0:1 , UDP port 5001
+[ ID]  Interval              Transfer     Bandwidth
+Done
+> [  0] local 0:0:0:0:0:0:0:0 port 49152 connected with ff33:40:fdde:ad00:beef:0:0:1 port 5001
+[  0]  0.000 -  1.281 sec     320 Bytes    1998 bits/sec  
+[  0]  1.281 -  2.305 sec     256 Bytes    2000 bits/sec  
+[  0]  2.305 -  3.329 sec     256 Bytes    2000 bits/sec  
+[  0]  3.329 -  4.353 sec     256 Bytes    2000 bits/sec  
+[  0]  4.353 -  5.377 sec     256 Bytes    2000 bits/sec  
+[  0]  5.377 -  6.401 sec     256 Bytes    2000 bits/sec  
+[  0]  6.401 -  7.425 sec     256 Bytes    2000 bits/sec  
+[  0]  7.425 -  8.449 sec     256 Bytes    2000 bits/sec  
+[  0]  8.449 -  9.473 sec     256 Bytes    2000 bits/sec  
+[  0]  0.000 - 10.241 sec    2560 Bytes    1999 bits/sec 
+```
+
+#### Node 2
+
+On node 2, it shows the test result.
+
+```bash
+[ ID] Interval             Transfer     Bandwidth         Jitter    Lost/Total LossRate Latency(min, avg, max)
+[  0] local ff33:40:fdde:ad00:beef:0:0:1 port 5001 connected with fdde:ad00:beef:0:7cb:8ee3:2012:c99a port 49153
+[  0]  0.000 -  1.281 sec     320 Bytes    1998 bits/sec   0.290ms     0/   5     ( 0%) (6.6ms, 7.9ms, 9.0ms)
+[  0]  1.281 -  2.303 sec     256 Bytes    2003 bits/sec   0.442ms     0/   4     ( 0%) (6.6ms, 7.1ms, 7.3ms)
+[  0]  2.303 -  3.327 sec     256 Bytes    2000 bits/sec   0.691ms     0/   4     ( 0%) (6.6ms, 7.4ms, 8.9ms)
+[  0]  3.327 -  4.353 sec     256 Bytes    1996 bits/sec   0.880ms     0/   4     ( 0%) (7.0ms, 8.0ms, 8.7ms)
+[  0]  4.353 -  5.375 sec     256 Bytes    2003 bits/sec   1.014ms     0/   4     ( 0%) (6.7ms, 7.3ms, 8.5ms)
+[  0]  5.375 -  6.401 sec     256 Bytes    1996 bits/sec   0.910ms     0/   4     ( 0%) (7.0ms, 7.4ms, 8.1ms)
+[  0]  6.401 -  7.424 sec     256 Bytes    2001 bits/sec   0.980ms     0/   4     ( 0%) (6.7ms, 7.7ms, 8.9ms)
+[  0]  7.424 -  8.449 sec     256 Bytes    1998 bits/sec   0.932ms     0/   4     ( 0%) (7.6ms, 8.3ms, 9.1ms)
+[  0]  8.449 -  9.471 sec     256 Bytes    2003 bits/sec   0.849ms     0/   4     ( 0%) (6.8ms, 8.2ms, 8.8ms)
+[  0]  9.471 - 10.246 sec     192 Bytes    1981 bits/sec   0.879ms     0/   3     ( 0%) (6.9ms, 7.3ms, 7.7ms)
+[  0]  0.000 - 10.246 sec    2560 Bytes    1998 bits/sec   0.879ms     0/  40     ( 0%) (6.6ms, 7.7ms, 9.1ms)
+```
+
+#### Node 1
+
+On node 1, it shows the test result.
+
+```bash
+[ ID] Interval             Transfer     Bandwidth         Jitter    Lost/Total LossRate Latency(min, avg, max)
+[  0] local ff33:40:fdde:ad00:beef:0:0:1 port 5001 connected with fdde:ad00:beef:0:7cb:8ee3:2012:c99a port 49153
+[  0]  0.000 -  1.298 sec     320 Bytes    1972 bits/sec   4.260ms     0/   5     ( 0%) (40.5ms, 56.2ms, 71.4ms)
+[  0]  1.298 -  2.310 sec     256 Bytes    2023 bits/sec   9.429ms     0/   4     ( 0%) (29.5ms, 45.4ms, 58.8ms)
+[  0]  2.310 -  3.346 sec     256 Bytes    1976 bits/sec  13.060ms     0/   4     ( 0%) (15.9ms, 38.6ms, 71.1ms)
+[  0]  3.346 -  4.328 sec     256 Bytes    2085 bits/sec  15.465ms     0/   4     ( 0%) (19.1ms, 32.7ms, 46.5ms)
+[  0]  4.328 -  5.384 sec     256 Bytes    1939 bits/sec  15.834ms     0/   4     ( 0%) (60.8ms, 66.5ms, 73.8ms)
+[  0]  5.384 -  6.424 sec     256 Bytes    1969 bits/sec  16.967ms     0/   4     ( 0%) (32.5ms, 52.0ms, 77.1ms)
+[  0]  6.424 -  7.423 sec     256 Bytes    2050 bits/sec  20.179ms     0/   4     ( 0%) (18.7ms, 38.1ms, 51.7ms)
+[  0]  7.423 -  8.425 sec     256 Bytes    2043 bits/sec  19.913ms     0/   4     ( 0%) (30.5ms, 50.4ms, 72.4ms)
+[  0]  8.425 -  9.444 sec     256 Bytes    2009 bits/sec  16.449ms     0/   4     ( 0%) (22.4ms, 26.7ms, 32.4ms)
+[  0]  9.444 - 10.233 sec     192 Bytes    1946 bits/sec  17.720ms     0/   3     ( 0%) (18.1ms, 35.1ms, 56.4ms)
+[  0]  0.000 - 10.233 sec    2560 Bytes    2001 bits/sec  17.720ms     0/  40     ( 0%) (15.9ms, 44.7ms, 77.1ms)
+```
+
+### Example 3: Test Round Trip Traffic
+
+#### Form Network and enable Time Sync
+
+Form a network with at least two devices. All devices are time synchronized with each other.
+
+#### Node 1
+
+On node 1, create a listening session to receive the packets and send received packets back to the originator.
+
+```bash
+> perf server format quiet
+Done
+> perf start
+Done
+```
+
+#### Node 2
+On node 2, create a listening session to receive the packets, create a transmission session to send packets. When the listening session receives reply packets, it shows the round trip test result.
+
+```bash
+> perf server
+Done
+> 
+> perf client destaddr fdde:ad00:beef:0:0:ff:fe00:400 bandwidth 2000 length 64 echo 1 format quiet
+Done
+> perf start
+Server listening on UDP port 5001
+Done
+> 
+[ ID] Interval             Transfer     Bandwidth         Jitter    Lost/Total LossRate Latency(min, avg, max)
+[  1] local fdde:ad00:beef:0:7cb:8ee3:2012:c99a port 5001 connected with fdde:ad00:beef:0:2095:53c3:c345:30df port 49154
+[  1]  0.000 -  1.277 sec     320 Bytes    2004 bits/sec   0.413ms     0/   5     ( 0%) (16.5ms, 19.0ms, 20.9ms)
+[  1]  1.277 -  2.315 sec     256 Bytes    1973 bits/sec   1.541ms     0/   4     ( 0%) (14.6ms, 19.2ms, 30.9ms)
+[  1]  2.315 -  3.323 sec     256 Bytes    2031 bits/sec   2.826ms     0/   4     ( 0%) (13.0ms, 16.3ms, 21.4ms)
+[  1]  3.323 -  4.346 sec     256 Bytes    2001 bits/sec   2.593ms     0/   4     ( 0%) (13.9ms, 14.7ms, 16.8ms)
+[  1]  4.346 -  5.373 sec     256 Bytes    1994 bits/sec   2.412ms     0/   4     ( 0%) (14.2ms, 15.5ms, 16.8ms)
+[  1]  5.373 -  6.393 sec     256 Bytes    2007 bits/sec   2.424ms     0/   4     ( 0%) (12.7ms, 15.2ms, 18.0ms)
+[  1]  6.393 -  7.417 sec     256 Bytes    2000 bits/sec   2.211ms     0/   4     ( 0%) (13.3ms, 15.2ms, 16.2ms)
+[  1]  7.417 -  8.442 sec     256 Bytes    1998 bits/sec   2.092ms     0/   4     ( 0%) (14.0ms, 15.3ms, 17.0ms)
+[  1]  8.442 -  9.469 sec     256 Bytes    1994 bits/sec   2.597ms     0/   4     ( 0%) (14.5ms, 17.2ms, 21.4ms)
+[  1]  9.469 - 10.245 sec     192 Bytes    1979 bits/sec   2.754ms     0/   3     ( 0%) (14.0ms, 17.0ms, 20.9ms)
+[  1]  0.000 - 10.245 sec    2560 Bytes    1999 bits/sec   2.754ms     0/  40     ( 0%) (12.7ms, 16.5ms, 30.9ms)
+```
+
+### Example 4: Test Multiple Streams
+
+#### Form Network and enable Time Sync
+
+Form a network with at least two devices. All devices are time synchronized with each other.
+
+#### Node 1
+
+On node 1, create a listening session and start it.
+
+```bash
+> perf server
+Done
+> perf start
+Server listening on UDP port 5001
+Done
+>
+```
+
+#### Node 2
+
+On node 2, create two transmission sessions to send packets with different priorities.
+
+```bash
+> perf client destaddr fdde:ad00:beef:0:0:ff:fe00:fc00 bandwidth 40000 priority 0 id 0
+Done
+> 
+> perf client destaddr fdde:ad00:beef:0:0:ff:fe00:fc00 bandwidth 40000 priority 2 id 2
+Done
+> 
+> perf start
+Client connecting to  fdde:ad00:beef:0:0:ff:fe00:fc00 , UDP port 5001
+[ ID]  Interval              Transfer     Bandwidth
+Client connecting to  fdde:ad00:beef:0:0:ff:fe00:fc00 , UDP port 5001
+Done
+> [  0]  0.000 -  1.011 sec    5056 Bytes   40007 bits/sec
+[  2]  0.000 -  1.012 sec    5056 Bytes   39968 bits/sec
+[  0]  1.011 -  2.010 sec    4992 Bytes   39975 bits/sec
+[  2]  1.012 -  2.010 sec    4992 Bytes   40016 bits/sec
+[  0]  2.010 -  3.008 sec    4992 Bytes   40016 bits/sec
+[  2]  2.010 -  3.009 sec    4992 Bytes   39975 bits/sec
+[  0]  3.008 -  4.007 sec    4992 Bytes   39975 bits/sec
+[  2]  3.009 -  4.007 sec    4992 Bytes   40016 bits/sec
+[  0]  4.007 -  5.005 sec    4992 Bytes   40016 bits/sec
+[  2]  4.007 -  5.005 sec    4992 Bytes   40016 bits/sec
+[  0]  5.005 -  6.003 sec    4992 Bytes   40016 bits/sec
+[  2]  5.005 -  6.004 sec    4992 Bytes   39975 bits/sec
+[  0]  6.003 -  7.002 sec    4992 Bytes   39975 bits/sec
+[  2]  6.004 -  7.002 sec    4992 Bytes   40016 bits/sec
+[  0]  7.002 -  8.000 sec    4992 Bytes   40016 bits/sec
+[  2]  7.002 -  8.001 sec    4992 Bytes   39975 bits/sec
+[  0]  8.000 -  9.011 sec    5056 Bytes   40007 bits/sec
+[  2]  8.001 -  9.012 sec    5056 Bytes   40007 bits/sec
+[  0]  9.011 - 10.010 sec    4992 Bytes   39975 bits/sec
+[  0]  0.000 - 10.010 sec   50048 Bytes   39998 bits/sec
+[  2]  9.012 - 10.010 sec    4992 Bytes   40016 bits/sec
+[  2]  0.000 - 10.010 sec   50048 Bytes   39998 bits/sec
+```
+
+#### Node 1
+
+On node 1, it shows the test result.
+
+```bash
+>
+[ ID] Interval             Transfer     Bandwidth         Jitter    Lost/Total LossRate Latency(min, avg, max)
+[  2] local fdde:ad00:beef:0:0:ff:fe00:fc00 port 5001 connected with fdde:ad00:beef:0:d247:355f:a8fd:cd1d port 49160
+[  0] local fdde:ad00:beef:0:0:ff:fe00:fc00 port 5001 connected with fdde:ad00:beef:0:d247:355f:a8fd:cd1d port 49159
+[  2]  0.000 -  1.018 sec    5056 Bytes   39732 bits/sec   2.047ms     0/  79     ( 0%) (5.5ms, 9.3ms, 21.1ms)
+[  0]  0.000 -  1.024 sec    4864 Bytes   38000 bits/sec   2.697ms     0/  76     ( 0%) (11.7ms, 34.0ms, 66.9ms)
+[  0]  1.024 -  2.012 sec    4736 Bytes   38348 bits/sec   2.611ms     0/  74     ( 0%) (58.5ms, 82.5ms, 106.5ms)
+[  2]  1.018 -  2.023 sec    5056 Bytes   40246 bits/sec   2.354ms     0/  79     ( 0%) (5.7ms, 10.5ms, 26.4ms)
+[  2]  2.023 -  3.012 sec    4928 Bytes   39862 bits/sec   1.988ms     0/  77     ( 0%) (5.7ms, 10.3ms, 23.2ms)
+[  0]  2.012 -  3.013 sec    4800 Bytes   38361 bits/sec   2.299ms     0/  75     ( 0%) (93.7ms, 133.4ms, 159.1ms)
+[  2]  3.012 -  4.022 sec    5056 Bytes   40047 bits/sec   2.051ms     0/  79     ( 0%) (6.2ms, 9.9ms, 16.2ms)
+[  0]  3.013 -  4.023 sec    4992 Bytes   39540 bits/sec   1.767ms     0/  78     ( 0%) (131.5ms, 150.8ms, 167.2ms)
+[  2]  4.022 -  5.023 sec    4992 Bytes   39896 bits/sec   3.461ms     0/  78     ( 0%) (5.9ms, 10.1ms, 19.4ms)
+[  0]  4.023 -  5.023 sec    4672 Bytes   37376 bits/sec   4.169ms     0/  73     ( 0%) (145.5ms, 177.8ms, 223.5ms)
+[  2]  5.023 -  6.018 sec    4992 Bytes   40136 bits/sec   2.745ms     0/  78     ( 0%) (5.7ms, 10.4ms, 22.0ms)
+[  0]  5.023 -  6.019 sec    4544 Bytes   36497 bits/sec   3.522ms     0/  71     ( 0%) (222.3ms, 272.0ms, 321.7ms)
+[  2]  6.018 -  7.020 sec    4992 Bytes   39856 bits/sec   1.812ms     0/  78     ( 0%) (5.6ms, 9.4ms, 13.2ms)
+[  0]  6.019 -  7.021 sec    5184 Bytes   41389 bits/sec   1.753ms     0/  81     ( 0%) (273.9ms, 298.4ms, 314.2ms)
+[  2]  7.020 -  8.014 sec    4992 Bytes   40177 bits/sec   2.022ms     0/  78     ( 0%) (5.6ms, 10.6ms, 20.1ms)
+[  0]  7.021 -  8.013 sec    4608 Bytes   37161 bits/sec   2.210ms     0/  72     ( 0%) (271.8ms, 321.3ms, 359.5ms)
+[  2]  8.014 -  9.014 sec    4992 Bytes   39936 bits/sec   3.007ms     0/  78     ( 0%) (5.6ms, 10.5ms, 21.2ms)
+[  0]  8.013 -  9.015 sec    4480 Bytes   35768 bits/sec   3.767ms     0/  70     ( 0%) (335.3ms, 387.6ms, 459.9ms)
+[  2]  9.014 - 10.014 sec    4992 Bytes   39936 bits/sec   2.701ms     0/  78     ( 0%) (5.7ms, 9.9ms, 18.4ms)
+[  2]  0.000 - 10.017 sec   50048 Bytes   39970 bits/sec   2.701ms     0/ 782     ( 0%) (5.5ms, 10.1ms, 26.4ms)
+[  0]  9.015 - 10.019 sec    4928 Bytes   39266 bits/sec   3.018ms     0/  77     ( 0%) (449.2ms, 466.4ms, 487.7ms)
+[  0] 10.019 - 10.271 sec    2240 Bytes   71111 bits/sec   5.424ms     0/  35     ( 0%) (269.0ms, 362.9ms, 463.1ms)
+[  0]  0.000 - 10.271 sec   50048 Bytes   38981 bits/sec   5.424ms     0/ 782     ( 0%) (11.7ms, 237.6ms, 487.7ms)
+```
+
+## Command List
+
+* [help](#help)
+* [server](#server-interval-value-format-cvs-quiet)
+* [client](#client-destaddr-address-bandwidth-value-length-value-priority-value-time-value-count-value-id-value-findelay-value-echo-value-interval-value-format-value)
+* [start](#start)
+* [stop](#stop)
+* [show](#show)
+* [clear](#clear)
+
+## Command Details
+
+### help
+
+```bash
+> perf help 
+help
+client
+server
+start
+stop
+show
+clear
+Done
+```
+
+### server \[interval \<value\>\] \[format \<cvs | quiet\>\]
+Create a listening session.
+
+* interval: Seconds between periodic bandwidth reports (default: 1 second).
+* format: Formats of bandwidth reports (cvs: cvs format, quiet: output nothing).
+
+```bash
+> perf server
+Done
+```
+
+### client destaddr \<address\>  \[bandwidth \<value\>\] \[length \<value\>\] \[priority \<value\>\] \[time \<value\>\] \[count \<value\>\] \[id \<value>\] \[findelay \<value>\] \[echo \<value\>\] \[interval \<value\>\] \[format \<value\>\]
+Create a transmission session.
+
+* address: Destination address of server.
+* bandwidth: Bandwidth to send at in bits/sec (default: 2000 bits/sec). 
+* length: Length of the data packet in bytes (default: 64 bytes). 
+* priority: Priority of the data packet (0:LOW ,1: NORMAL ,2: HIGH. default: 1). 
+* time: Time in seconds to transmit for (default: 10 seconds. 0: infinite transmission).
+* count: Number of packets to transmit for.
+* id: Session identifier.
+* findelay: Delay between the last data packet and the first FIN packet in milliseconds (default: 250 ms).
+* echo: Set echo flag to request server send back packets to the originator, used to measure round trip time (0: enable 1: disable).
+* interval: Seconds between periodic bandwidth reports (default: 1 second).
+* format: Formats of bandwidth reports (cvs: cvs format, quiet: output nothing).
+
+```bash
+> perf client destaddr fdde:ad00:beef:0:0:ff:fe00:fc00 bandwidth 2000 length 64
+Done
+>
+```
+
+### start
+Enable all clients to transmit data packets and enable server to listen on the socket.
+
+```bash
+> perf start
+Client connecting to  fdde:ad00:beef:0:0:ff:fe00:fc00 , UDP port 5001
+[ ID]  Interval              Transfer     Bandwidth
+Done
+> [  0]  0.000 -  1.280 sec     320 Bytes    2000 bits/sec  
+[  0]  1.280 -  2.304 sec     256 Bytes    2000 bits/sec  
+[  0]  2.304 -  3.328 sec     256 Bytes    2000 bits/sec  
+[  0]  3.328 -  4.352 sec     256 Bytes    2000 bits/sec  
+[  0]  4.352 -  5.376 sec     256 Bytes    2000 bits/sec  
+[  0]  5.376 -  6.400 sec     256 Bytes    2000 bits/sec  
+[  0]  6.400 -  7.424 sec     256 Bytes    2000 bits/sec  
+[  0]  7.424 -  8.448 sec     256 Bytes    2000 bits/sec  
+[  0]  8.448 -  9.472 sec     256 Bytes    2000 bits/sec  
+[  0]  0.000 - 10.240 sec    2560 Bytes    2000 bits/sec
+```
+
+### start client
+Enable all clients to transmit data packets.
+
+```bash
+> perf start client
+Client connecting to  fdde:ad00:beef:0:0:ff:fe00:fc00 , UDP port 5001
+[ ID]  Interval              Transfer     Bandwidth
+Done
+> [  0]  0.000 -  1.280 sec     320 Bytes    2000 bits/sec  
+[  0]  1.280 -  2.304 sec     256 Bytes    2000 bits/sec  
+[  0]  2.304 -  3.328 sec     256 Bytes    2000 bits/sec  
+[  0]  3.328 -  4.352 sec     256 Bytes    2000 bits/sec  
+[  0]  4.352 -  5.376 sec     256 Bytes    2000 bits/sec  
+[  0]  5.376 -  6.400 sec     256 Bytes    2000 bits/sec  
+[  0]  6.400 -  7.424 sec     256 Bytes    2000 bits/sec  
+[  0]  7.424 -  8.448 sec     256 Bytes    2000 bits/sec  
+[  0]  8.448 -  9.472 sec     256 Bytes    2000 bits/sec  
+[  0]  0.000 - 10.240 sec    2560 Bytes    2000 bits/sec
+```
+
+### start server
+Enable server to listen on the socket.
+
+```bah
+> perf start server
+Server listening on UDP port 5001
+Done
+> 
+[ ID] Interval             Transfer     Bandwidth         Jitter    Lost/Total LossRate Latency(min, avg, max)
+[  0] local fdde:ad00:beef:0:0:ff:fe00:fc00 port 5001 connected with fdde:ad00:beef:0:3307:2f7b:7426:af07 port 49153
+[  0]  0.000 -  1.274 sec     320 Bytes    2009 bits/sec   1.519ms    39/  44     (88%) (6.2ms, 9.5ms, 16.7ms)
+[  0]  1.274 -  2.298 sec     256 Bytes    2000 bits/sec   1.831ms     0/   4     ( 0%) (6.0ms, 8.6ms, 11.4ms)
+[  0]  2.298 -  3.324 sec     256 Bytes    1996 bits/sec   1.534ms     0/   4     ( 0%) (6.0ms, 6.7ms, 7.8ms)
+[  0]  3.324 -  4.346 sec     256 Bytes    2003 bits/sec   2.329ms     0/   4     ( 0%) (6.2ms, 9.5ms, 16.9ms)
+[  0]  4.346 -  5.371 sec     256 Bytes    1998 bits/sec   1.959ms     0/   4     ( 0%) (6.5ms, 7.1ms, 7.9ms)
+[  0]  5.371 -  6.395 sec     256 Bytes    2000 bits/sec   1.518ms     0/   4     ( 0%) (6.3ms, 6.6ms, 7.0ms)
+[  0]  6.395 -  7.418 sec     256 Bytes    2001 bits/sec   1.465ms     0/   4     ( 0%) (6.2ms, 7.1ms, 8.3ms)
+[  0]  7.418 -  8.447 sec     256 Bytes    1990 bits/sec   1.651ms     0/   4     ( 0%) (7.3ms, 9.6ms, 12.3ms)
+[  0]  8.447 -  9.469 sec     256 Bytes    2003 bits/sec   1.605ms     0/   4     ( 0%) (6.7ms, 7.5ms, 8.3ms)
+[  0]  9.469 - 10.240 sec     192 Bytes    1992 bits/sec   1.981ms     0/   3     ( 0%) (7.4ms, 9.1ms, 12.3ms)
+[  0]  0.000 - 10.240 sec    2560 Bytes    2000 bits/sec   1.981ms    39/  79     (49%) (6.0ms, 8.1ms, 16.9ms)
+```
+
+### stop
+Stop server receiving packets and stop client transmitting packets.
+
+```bash
+> perf stop
+Done
+```
+
+### stop server
+Stop server receiving packets.
+
+```bash
+> perf stop server
+Done
+```
+### stop client
+Stop client transmiting packets.
+
+```bash
+> perf stop client
+Done
+```
+
+### show
+Show perf sessions.
+
+```bash
+> perf show
+perf client destaddr fdde:ad00:beef:0:0:ff:fe00:fc00 bandwidth 2000 length 64 priority 1 id 1
+perf client destaddr fdde:ad00:beef:0:0:ff:fe00:fc00 bandwidth 2000 length 64 priority 2 id 2
+Done
+```
+
+### clear
+Clear all sessions.
+
+```bash
+> perf clear
+Done
+> 
+```
+
+

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -181,6 +181,9 @@ const struct Command Interpreter::sCommands[] = {
 #if OPENTHREAD_FTD
     {"parentpriority", &Interpreter::ProcessParentPriority},
 #endif
+#if OPENTHREAD_CONFIG_CLI_PERF_ENABLE
+    {"perf", &Interpreter::ProcessPerf},
+#endif
     {"ping", &Interpreter::ProcessPing},
     {"pollperiod", &Interpreter::ProcessPollPeriod},
     {"promiscuous", &Interpreter::ProcessPromiscuous},
@@ -244,6 +247,9 @@ Interpreter::Interpreter(Instance *aInstance)
     , mJoiner(*this)
 #endif
     , mInstance(aInstance)
+#if OPENTHREAD_CONFIG_CLI_PERF_ENABLE
+    , mPerf(*this)
+#endif
 {
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
     otThreadSetReceiveDiagnosticGetCallback(mInstance, &Interpreter::HandleDiagnosticGetResponse, this);
@@ -3060,6 +3066,13 @@ void Interpreter::ProcessUdp(int argc, char *argv[])
     error = mUdp.Process(argc, argv);
     AppendResult(error);
 }
+
+#if OPENTHREAD_CONFIG_CLI_PERF_ENABLE
+void Interpreter::ProcessPerf(int argc, char *argv[])
+{
+    AppendResult(mPerf.Process(argc, argv));
+}
+#endif
 
 void Interpreter::ProcessVersion(int argc, char *argv[])
 {

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -48,6 +48,9 @@
 #include "cli/cli_dataset.hpp"
 #include "cli/cli_joiner.hpp"
 #include "cli/cli_udp.hpp"
+#if OPENTHREAD_CONFIG_CLI_PERF_ENABLE
+#include "cli/cli_perf.hpp"
+#endif
 
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
 #include "cli/cli_coap.hpp"
@@ -100,6 +103,7 @@ class Interpreter
     friend class Commissioner;
     friend class Dataset;
     friend class Joiner;
+    friend class Perf;
     friend class UdpExample;
 
 public:
@@ -285,6 +289,9 @@ private:
 #if OPENTHREAD_FTD
     void ProcessParentPriority(int argc, char *argv[]);
 #endif
+#if OPENTHREAD_CONFIG_CLI_PERF_ENABLE
+    void ProcessPerf(int argc, char *argv[]);
+#endif
     void ProcessPing(int argc, char *argv[]);
     void ProcessPollPeriod(int argc, char *argv[]);
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
@@ -406,6 +413,10 @@ private:
 #endif
 
     Instance *mInstance;
+
+#if OPENTHREAD_CONFIG_CLI_PERF_ENABLE
+    Perf mPerf;
+#endif
 };
 
 } // namespace Cli

--- a/src/cli/cli_config.h
+++ b/src/cli/cli_config.h
@@ -65,4 +65,14 @@
 #define OPENTHREAD_CONFIG_CLI_UART_TX_BUFFER_SIZE 1024
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_CLI_PERF_NUM_SESSIONS
+ *
+ * The number of CLI Perf sessions. The minimum value is 2.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CLI_PERF_NUM_SESSIONS
+#define OPENTHREAD_CONFIG_CLI_PERF_NUM_SESSIONS 3
+#endif
+
 #endif // CONFIG_CLI_H_

--- a/src/cli/cli_config.h
+++ b/src/cli/cli_config.h
@@ -65,14 +65,4 @@
 #define OPENTHREAD_CONFIG_CLI_UART_TX_BUFFER_SIZE 1024
 #endif
 
-/**
- * @def OPENTHREAD_CONFIG_CLI_PERF_NUM_SESSIONS
- *
- * The number of CLI Perf sessions. The minimum value is 2.
- *
- */
-#ifndef OPENTHREAD_CONFIG_CLI_PERF_NUM_SESSIONS
-#define OPENTHREAD_CONFIG_CLI_PERF_NUM_SESSIONS 3
-#endif
-
 #endif // CONFIG_CLI_H_

--- a/src/cli/cli_perf.cpp
+++ b/src/cli/cli_perf.cpp
@@ -1,0 +1,1790 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements a network performance tool.
+ */
+
+#include <openthread/coap.h>
+#include <openthread/message.h>
+#include <openthread/udp.h>
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+#include <openthread/network_time.h>
+#endif
+
+#include "cli/cli.hpp"
+#include "cli/cli_perf.hpp"
+#include "cli/cli_uart.hpp"
+
+#include "common/encoding.hpp"
+#include "common/new.hpp"
+#include "common/random.hpp"
+#include "net/ip6_address.hpp"
+
+#if OPENTHREAD_CONFIG_CLI_PERF_ENABLE
+
+using ot::Encoding::BigEndian::HostSwap16;
+using ot::Encoding::BigEndian::HostSwap32;
+
+namespace ot {
+namespace Cli {
+
+const struct Perf::Command Perf::sCommands[] = {{"help", &Perf::ProcessHelp},     {"client", &Perf::ProcessClient},
+                                                {"server", &Perf::ProcessServer}, {"start", &Perf::ProcessStart},
+                                                {"stop", &Perf::ProcessStop},     {"show", &Perf::ProcessShow},
+                                                {"clear", &Perf::ProcessClear}};
+
+Session::Session(Perf &aPerf, const Setting &aSetting, uint8_t aRole)
+    : mPerf(&aPerf)
+    , mSetting(&aSetting)
+    , mRole(aRole)
+    , mState(kStateIdle)
+{
+    InitStats();
+}
+
+void Session::InitStats(void)
+{
+    memset(&mStats, 0, sizeof(mStats));
+    mStats.mCurMinLatency   = UINT32_MAX;
+    mStats.mTotalMinLatency = UINT32_MAX;
+}
+
+void Session::InitCurrentStats(void)
+{
+    mStats.mCurBytes         = 0;
+    mStats.mCurCntError      = 0;
+    mStats.mCurCntDatagram   = 0;
+    mStats.mCurCntOutOfOrder = 0;
+    mStats.mCurMinLatency    = UINT32_MAX;
+    mStats.mCurMaxLatency    = 0;
+    mStats.mCurLatency       = 0;
+}
+
+otError Session::OpenSocket(void)
+{
+    otError    error       = OT_ERROR_NONE;
+    bool       closeSocket = false;
+    otSockAddr sockaddr;
+
+    VerifyOrExit(!mSocketValid, error = OT_ERROR_ALREADY);
+    SuccessOrExit(error = otUdpOpen(mPerf->mInstance, &mSocket, Perf::s_HandleUdpReceive, GetContext()));
+
+    SetContext(*mPerf, *this);
+
+    switch (mRole)
+    {
+    case kRoleClient:
+        memcpy(sockaddr.mAddress.mFields.m8, mPeerAddr.mFields.m8, sizeof(otIp6Address));
+        sockaddr.mPort = mPeerPort;
+
+        VerifyOrExit((error = otUdpConnect(&mSocket, &sockaddr)) == OT_ERROR_NONE, closeSocket = true);
+
+        if (!(mSetting->IsFlagSet(Setting::kFlagFormatCvs) || mSetting->IsFlagSet(Setting::kFlagFormatQuiet)))
+        {
+            Server::sServer->OutputFormat(
+                "Client connecting to  %x:%x:%x:%x:%x:%x:%x:%x , ", HostSwap16(sockaddr.mAddress.mFields.m16[0]),
+                HostSwap16(sockaddr.mAddress.mFields.m16[1]), HostSwap16(sockaddr.mAddress.mFields.m16[2]),
+                HostSwap16(sockaddr.mAddress.mFields.m16[3]), HostSwap16(sockaddr.mAddress.mFields.m16[4]),
+                HostSwap16(sockaddr.mAddress.mFields.m16[5]), HostSwap16(sockaddr.mAddress.mFields.m16[6]),
+                HostSwap16(sockaddr.mAddress.mFields.m16[7]));
+            Server::sServer->OutputFormat("UDP port %d\n\r", sockaddr.mPort);
+        }
+        break;
+
+    case kRoleListener:
+        memset(sockaddr.mAddress.mFields.m8, 0, sizeof(otIp6Address));
+        sockaddr.mPort = mLocalPort;
+
+        VerifyOrExit((error = otUdpBind(&mSocket, &sockaddr)) == OT_ERROR_NONE, closeSocket = true);
+
+        if (!(mSetting->IsFlagSet(Setting::kFlagFormatCvs) || mSetting->IsFlagSet(Setting::kFlagFormatQuiet)))
+        {
+            Server::sServer->OutputFormat("Server listening on UDP port %d\r\n", sockaddr.mPort);
+        }
+        break;
+
+    case kRoleServer:
+        memcpy(sockaddr.mAddress.mFields.m8, mLocalAddr.mFields.m8, sizeof(otIp6Address));
+        sockaddr.mPort = mLocalPort;
+
+        VerifyOrExit((error = otUdpBind(&mSocket, &sockaddr)) == OT_ERROR_NONE, closeSocket = true);
+        break;
+
+    default:
+        error = OT_ERROR_NOT_IMPLEMENTED;
+        break;
+    }
+
+exit:
+    if (error == OT_ERROR_NONE)
+    {
+        mSocketValid = true;
+    }
+    else if (closeSocket)
+    {
+        otUdpClose(&mSocket);
+    }
+
+    return error;
+}
+
+void Session::CloseSocket(void)
+{
+    if (mReplySocketValid)
+    {
+        otUdpClose(&mReplySocket);
+        mReplySocketValid = false;
+    }
+
+    if (mSocketValid)
+    {
+        otUdpClose(&mSocket);
+        mSocketValid = false;
+    }
+}
+
+otError Session::HandleFistMessage(otMessage &aMessage, const otMessageInfo &aMessageInfo)
+{
+    otError      error    = OT_ERROR_NONE;
+    uint32_t     milliNow = TimerMilli::GetNow();
+    otIp6Address sockAddr = aMessageInfo.mSockAddr;
+    otIp6Address peerAddr = aMessageInfo.mPeerAddr;
+    PerfHeader   perfHeader;
+    PacketInfo   packetInfo;
+
+    VerifyOrExit(mRole == kRoleServer, error = OT_ERROR_FAILED);
+    VerifyOrExit(mState == kStateIdle, error = OT_ERROR_FAILED);
+
+    packetInfo.mLength = otMessageGetLength(&aMessage) - otMessageGetOffset(&aMessage);
+    VerifyOrExit(otMessageRead(&aMessage, otMessageGetOffset(&aMessage), &perfHeader, sizeof(PerfHeader)) ==
+                     sizeof(PerfHeader),
+                 error = OT_ERROR_PARSE);
+    VerifyOrExit(!perfHeader.GetFinFlag(), error = OT_ERROR_PARSE);
+
+    memcpy(mLocalAddr.mFields.m8, sockAddr.mFields.m8, sizeof(otIp6Address));
+    memcpy(mPeerAddr.mFields.m8, peerAddr.mFields.m8, sizeof(otIp6Address));
+
+    mLocalPort    = aMessageInfo.mSockPort;
+    mPeerPort     = aMessageInfo.mPeerPort;
+    mSessionId    = perfHeader.GetSessionId();
+    mPrintEndTime = 0;
+
+    /* Perf uses the formula "NumOfPackets*PacketLength/Interval" to calculate throughput Periodically.
+     * The server in the first interval reveives one packet more than the subsequent intervals. Then the
+     * calculated throughput of first interval is larger than the throughput in subsequenct intervals. To
+     * resolve this issue, set the session start time ahead of one transmit interval to extend the first
+     * interval to adjust throughput of the first interval.
+     * This figure shows this case:
+     * |<------------------1st' Interval-------------->|
+     * |           |<----------1st Interval----------->|<----------2nd Interval----------->|
+     * ------------1-----------2-----------3-----------4-----------5-----------6-----------7
+     */
+    mSessionStartTime = milliNow - perfHeader.GetSendingInterval() / USEC_PER_MS;
+    mSessionEndTime   = milliNow + mSetting->GetInterval();
+
+    SuccessOrExit(error = OpenSocket());
+
+    GetPacketInfo(perfHeader, milliNow * USEC_PER_MS, packetInfo);
+    UpdatePacketStats(packetInfo);
+
+    if (mPerf->mPrintServerHeaderFlag == false)
+    {
+        mPerf->mPrintServerHeaderFlag = true;
+        PrintServerReportHeader();
+    }
+
+    PrintConnection();
+
+    if (perfHeader.GetEchoFlag() == true)
+    {
+        Message &         message  = *static_cast<Message *>(&aMessage);
+        otMessagePriority priority = static_cast<otMessagePriority>(message.GetPriority());
+
+        IgnoreReturnValue(SendReply(perfHeader, priority, packetInfo.mLength));
+    }
+
+    mState = kStateReceivingData;
+
+exit:
+    return error;
+}
+
+void Session::HandleSubsequentMessages(otMessage &aMessage, const otMessageInfo &aMessageInfo)
+{
+    uint32_t   milliNow = TimerMilli::GetNow();
+    PacketInfo packetInfo;
+    PerfHeader perfHeader;
+
+    if ((mPeerPort != aMessageInfo.mPeerPort) ||
+        (memcmp(mPeerAddr.mFields.m8, aMessageInfo.mPeerAddr.mFields.m8, sizeof(otIp6Address)) != 0))
+    {
+        return;
+    }
+
+    VerifyOrExit(mRole == kRoleServer);
+    VerifyOrExit(mState == kStateReceivingData || mState == kStateReceivingFin);
+
+    packetInfo.mLength = otMessageGetLength(&aMessage) - otMessageGetOffset(&aMessage);
+    VerifyOrExit(otMessageRead(&aMessage, otMessageGetOffset(&aMessage), &perfHeader, sizeof(PerfHeader)) ==
+                 sizeof(PerfHeader));
+
+    if (perfHeader.GetFinFlag())
+    {
+        if (mState == kStateReceivingData)
+        {
+            mState    = kStateReceivingFin;
+            mFireTime = mPerf->mTimer.GetNow();
+
+            if (perfHeader.GetEchoFlag())
+            {
+                // Waiting to close the session after all FIN packets are sent back to the originator.
+                mFireTime += UsToTimerTime(kMaxNumFin * kFinIntervalUs);
+            }
+
+            mPrintStartTime = mPrintEndTime;
+            mPrintEndTime   = milliNow - mSessionStartTime - perfHeader.GetFinDelay();
+            mFinCounter     = 0;
+
+            mPerf->StartTimer();
+
+            if (mStats.mCurCntDatagram != 0)
+            {
+                PrintServerReport();
+            }
+
+            PrintServerReportEnd();
+        }
+    }
+    else
+    {
+        GetPacketInfo(perfHeader, milliNow * USEC_PER_MS, packetInfo);
+        UpdatePacketStats(packetInfo);
+
+        if (TimeCompare(mSessionEndTime, milliNow) <= 0)
+        {
+            mPrintStartTime = mPrintEndTime;
+            mPrintEndTime   = milliNow - mSessionStartTime;
+
+            while (TimeCompare(mSessionEndTime, milliNow) <= 0)
+            {
+                mSessionEndTime += mSetting->GetInterval();
+            }
+
+            PrintServerReport();
+            InitCurrentStats();
+        }
+    }
+
+    if (perfHeader.GetEchoFlag() == true)
+    {
+        Message &         message  = *static_cast<Message *>(&aMessage);
+        otMessagePriority priority = static_cast<otMessagePriority>(message.GetPriority());
+
+        IgnoreReturnValue(SendReply(perfHeader, priority, packetInfo.mLength));
+    }
+
+exit:
+    return;
+}
+
+otError Session::SendReply(PerfHeader &aPerfHeader, otMessagePriority aPriority, uint16_t aLength)
+{
+    otError           error       = OT_ERROR_NONE;
+    otMessage *       message     = NULL;
+    otMessageSettings msgSettings = {true, aPriority};
+    otMessageInfo     messageInfo;
+
+    VerifyOrExit(aLength >= sizeof(PerfHeader), error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit((message = otUdpNewMessage(mPerf->mInstance, &msgSettings)) != NULL, error = OT_ERROR_NO_BUFS);
+
+    aPerfHeader.SetEchoFlag(false);
+    aPerfHeader.SetReplyFlag(true);
+    SuccessOrExit(error = otMessageAppend(message, &aPerfHeader, sizeof(PerfHeader)));
+    SuccessOrExit(error = otMessageSetLength(message, aLength));
+
+    if (!mReplySocketValid)
+    {
+        otSockAddr sockaddr;
+
+        memset(&mReplySocket, 0, sizeof(otUdpSocket));
+        SuccessOrExit(otUdpOpen(mPerf->mInstance, &mReplySocket, NULL, NULL));
+
+        memcpy(sockaddr.mAddress.mFields.m8, mPeerAddr.mFields.m8, sizeof(otIp6Address));
+        sockaddr.mPort = kUdpPort;
+
+        if ((error = otUdpConnect(&mReplySocket, &sockaddr)) != OT_ERROR_NONE)
+        {
+            otUdpClose(&mReplySocket);
+            ExitNow();
+        }
+
+        mReplySocketValid = true;
+    }
+
+    memset(&messageInfo, 0, sizeof(otMessageInfo));
+    memcpy(messageInfo.mPeerAddr.mFields.m8, mPeerAddr.mFields.m8, sizeof(otIp6Address));
+    messageInfo.mPeerPort = kUdpPort;
+
+    error = otUdpSend(&mReplySocket, message, &messageInfo);
+
+exit:
+    if (error != OT_ERROR_NONE && message != NULL)
+    {
+        otMessageFree(message);
+    }
+
+    return error;
+}
+
+otError Session::SendData(void)
+{
+    otError           error       = OT_ERROR_NONE;
+    uint32_t          milliNow    = TimerMilli::GetNow();
+    otMessage *       message     = NULL;
+    otMessageSettings msgSettings = {true, mSetting->GetPriority()};
+    otMessageInfo     messageInfo;
+    PerfHeader        perfHeader;
+    uint64_t          microNow;
+
+    VerifyOrExit(mState == kStateSendingData, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(mSetting->GetLength() >= sizeof(PerfHeader), error = OT_ERROR_INVALID_ARGS);
+
+    if (GetSynchronizedTime(microNow) == OT_ERROR_NONE)
+    {
+        perfHeader.SetSyncFlag(true);
+    }
+    else
+    {
+        microNow = milliNow * USEC_PER_MS;
+        perfHeader.SetSyncFlag(false);
+    }
+
+    perfHeader.SetSeqNumber(mSeqNumber++);
+    perfHeader.SetTime(microNow);
+    perfHeader.SetSessionId(mSessionId);
+    perfHeader.SetSendingInterval(mSendingIntervalUs);
+    perfHeader.SetEchoFlag(mSetting->IsFlagSet(Setting::kFlagEcho) ? true : false);
+    perfHeader.SetFinFlag(false);
+
+    VerifyOrExit((message = otUdpNewMessage(mPerf->mInstance, &msgSettings)) != NULL, error = OT_ERROR_NO_BUFS);
+    SuccessOrExit(error = otMessageAppend(message, &perfHeader, sizeof(PerfHeader)));
+    SuccessOrExit(error = otMessageSetLength(message, mSetting->GetLength()));
+
+    memset(&messageInfo, 0, sizeof(otMessageInfo));
+    memcpy(messageInfo.mPeerAddr.mFields.m8, mPeerAddr.mFields.m8, sizeof(otIp6Address));
+    messageInfo.mPeerPort = mPeerPort;
+
+    error = otUdpSend(&mSocket, message, &messageInfo);
+
+    if ((mLocalPort == 0) && (mSocket.mSockName.mPort != 0))
+    {
+        memcpy(mLocalAddr.mFields.m8, mSocket.mSockName.mAddress.mFields.m8, sizeof(otIp6Address));
+        mLocalPort = mSocket.mSockName.mPort;
+
+        PrintConnection();
+    }
+
+exit:
+    if (error == OT_ERROR_NONE)
+    {
+        mStats.mCurCntDatagram++;
+        mStats.mTotalCntDatagram++;
+        mStats.mCurBytes += mSetting->GetLength();
+        mStats.mTotalBytes += mSetting->GetLength();
+    }
+    else
+    {
+        mStats.mCurCntError++;
+        mStats.mTotalCntError++;
+        if (message != NULL)
+        {
+            otMessageFree(message);
+        }
+    }
+
+    if (TimeCompare(mSessionEndTime, milliNow) <= 0)
+    {
+        mPrintStartTime = mPrintEndTime;
+        mPrintEndTime   = milliNow - mSessionStartTime;
+
+        // If the throughput is very low, the sending intervel may larger than the setting interval. The session
+        // end time needs to be updated untill it is larger than the current time.
+        while (TimeCompare(mSessionEndTime, milliNow) <= 0)
+        {
+            mSessionEndTime += mSetting->GetInterval();
+        }
+
+        PrintClientReport();
+        InitCurrentStats();
+    }
+
+    return error;
+}
+
+otError Session::SendFin(void)
+{
+    otError           error       = OT_ERROR_NONE;
+    uint32_t          milliNow    = TimerMilli::GetNow();
+    otMessageSettings msgSettings = {true, mSetting->GetPriority()};
+    otMessage *       message     = NULL;
+    otMessageInfo     messageInfo;
+    PerfHeader        perfHeader;
+
+    VerifyOrExit(mState == kStateSendingFin, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(mSetting->GetLength() >= sizeof(PerfHeader), error = OT_ERROR_INVALID_ARGS);
+
+    perfHeader.SetSeqNumber(mSeqNumber);
+    perfHeader.SetTime(0);
+    perfHeader.SetFinDelay(static_cast<uint8_t>(milliNow - mSessionEndTime));
+    perfHeader.SetSessionId(mSessionId);
+    perfHeader.SetEchoFlag(mSetting->IsFlagSet(Setting::kFlagEcho));
+    perfHeader.SetFinFlag(true);
+
+    VerifyOrExit((message = otUdpNewMessage(mPerf->mInstance, &msgSettings)) != NULL, error = OT_ERROR_NO_BUFS);
+    SuccessOrExit(error = otMessageAppend(message, &perfHeader, sizeof(PerfHeader)));
+    SuccessOrExit(error = otMessageSetLength(message, sizeof(PerfHeader)));
+
+    memset(&messageInfo, 0, sizeof(otMessageInfo));
+    memcpy(messageInfo.mPeerAddr.mFields.m8, mPeerAddr.mFields.m8, sizeof(otIp6Address));
+    messageInfo.mPeerPort = mPeerPort;
+
+    error = otUdpSend(&mSocket, message, &messageInfo);
+
+exit:
+    if ((error != OT_ERROR_NONE) && message != NULL)
+    {
+        otMessageFree(message);
+    }
+
+    return error;
+}
+
+void Session::GetPacketInfo(PerfHeader &aPerfHeader, uint64_t aMicroNow, PacketInfo &aPacketInfo)
+{
+    uint64_t microNow;
+
+    aPacketInfo.mSeqNumber       = aPerfHeader.GetSeqNumber();
+    aPacketInfo.mRelativeLatency = static_cast<int64_t>(aMicroNow) - static_cast<int64_t>(aPerfHeader.GetTime());
+    aPacketInfo.mAbsoluteLatency = kInvalidTime;
+
+    if (aPerfHeader.GetReplyFlag())
+    {
+        if (GetSynchronizedTime(microNow) != OT_ERROR_NONE)
+        {
+            // The local time can be used to calculate the latency when user is testing round trip time.
+            microNow = aMicroNow;
+        }
+
+        aPacketInfo.mAbsoluteLatency =
+            microNow > aPerfHeader.GetTime() ? static_cast<uint32_t>(microNow - aPerfHeader.GetTime()) : 0;
+    }
+    else if ((GetSynchronizedTime(microNow) == OT_ERROR_NONE) && aPerfHeader.GetSyncFlag())
+    {
+        aPacketInfo.mAbsoluteLatency =
+            microNow > aPerfHeader.GetTime() ? static_cast<uint32_t>(microNow - aPerfHeader.GetTime()) : 0;
+    }
+}
+
+void Session::UpdatePacketStats(PacketInfo &aPacketInfo)
+{
+    int64_t deltaLatency = 0;
+
+    if ((aPacketInfo.mSeqNumber != 0) && (aPacketInfo.mSeqNumber != mSeqNumber + 1))
+    {
+        if (aPacketInfo.mSeqNumber < mSeqNumber + 1)
+        {
+            mStats.mCurCntOutOfOrder++;
+            mStats.mTotalCntOutOfOrder++;
+
+            if (mStats.mCurCntError > 0)
+            {
+                mStats.mCurCntError--;
+            }
+
+            if (mStats.mTotalCntError > 0)
+            {
+                mStats.mTotalCntError--;
+            }
+        }
+        else
+        {
+            mStats.mCurCntError += aPacketInfo.mSeqNumber - (mSeqNumber + 1);
+            mStats.mTotalCntError += aPacketInfo.mSeqNumber - (mSeqNumber + 1);
+        }
+    }
+
+    if (mStats.mTotalCntDatagram != 0)
+    {
+        // Caculate jitter, refer to sections 6.3.1 and A.8 of RFC 1889.
+        if (aPacketInfo.mRelativeLatency > mStats.mRelativeLatency)
+        {
+            deltaLatency = aPacketInfo.mRelativeLatency - mStats.mRelativeLatency;
+        }
+        else
+        {
+            deltaLatency = mStats.mRelativeLatency - aPacketInfo.mRelativeLatency;
+        }
+
+        mStats.mJitter += (deltaLatency - mStats.mJitter) / 16;
+    }
+
+    mStats.mRelativeLatency = aPacketInfo.mRelativeLatency;
+
+    if (aPacketInfo.mSeqNumber > mSeqNumber)
+    {
+        mSeqNumber = aPacketInfo.mSeqNumber;
+    }
+
+    mStats.mCurBytes += aPacketInfo.mLength;
+    mStats.mTotalBytes += aPacketInfo.mLength;
+    mStats.mCurCntDatagram++;
+    mStats.mTotalCntDatagram++;
+
+    if (aPacketInfo.mAbsoluteLatency == kInvalidTime)
+    {
+        mStats.mLatencyValid = false;
+    }
+    else
+    {
+        mStats.mLatencyValid = true;
+        if (aPacketInfo.mAbsoluteLatency < mStats.mCurMinLatency)
+        {
+            mStats.mCurMinLatency = aPacketInfo.mAbsoluteLatency;
+        }
+
+        if (aPacketInfo.mAbsoluteLatency > mStats.mCurMaxLatency)
+        {
+            mStats.mCurMaxLatency = aPacketInfo.mAbsoluteLatency;
+        }
+
+        if (aPacketInfo.mAbsoluteLatency < mStats.mTotalMinLatency)
+        {
+            mStats.mTotalMinLatency = aPacketInfo.mAbsoluteLatency;
+        }
+
+        if (aPacketInfo.mAbsoluteLatency > mStats.mTotalMaxLatency)
+        {
+            mStats.mTotalMaxLatency = aPacketInfo.mAbsoluteLatency;
+        }
+
+        mStats.mTotalLatency += aPacketInfo.mAbsoluteLatency;
+        mStats.mCurLatency += aPacketInfo.mAbsoluteLatency;
+    }
+}
+
+void Session::PrintReport(Report &aReport, bool aServer)
+{
+    uint32_t lossRate;
+    uint32_t interval  = aReport.mEndTime - aReport.mStartTime;
+    uint32_t bandwidth = static_cast<uint32_t>((interval == 0) ? 0 : (aReport.mNumBytes * 8000UL / interval));
+
+    if (aServer)
+    {
+        lossRate = (aReport.mCntDatagram == 0) ? 0 : 100 * aReport.mCntError / aReport.mCntDatagram;
+    }
+
+    if (aReport.mIsFormatCvs)
+    {
+        Server::sServer->OutputFormat("%u,", aReport.mReportType);
+        Server::sServer->OutputFormat("%u,%u.%03u,%u.%03u,", aReport.mSessionId, aReport.mStartTime / MS_PER_SEC,
+                                      aReport.mStartTime % MS_PER_SEC, aReport.mEndTime / MS_PER_SEC,
+                                      aReport.mEndTime % MS_PER_SEC);
+
+        Server::sServer->OutputFormat("%u,", aReport.mNumBytes);
+        Server::sServer->OutputFormat("%u,", bandwidth);
+
+        if (aServer)
+        {
+            Server::sServer->OutputFormat("%d.%03d,%u,%u,%u,", aReport.mJitter / USEC_PER_MS,
+                                          aReport.mJitter % USEC_PER_MS, aReport.mCntError, aReport.mCntDatagram,
+                                          lossRate);
+
+            if (aReport.mLatencyValid)
+            {
+                uint32_t avgLatency;
+
+                if (aReport.mCntDatagram == aReport.mCntError)
+                {
+                    avgLatency = 0;
+                }
+                else
+                {
+                    avgLatency = aReport.mLatency / (aReport.mCntDatagram - aReport.mCntError);
+                }
+
+                Server::sServer->OutputFormat("%u.%u,%u.%u,%u.%u", aReport.mMinLatency / USEC_PER_MS,
+                                              (aReport.mMinLatency % USEC_PER_MS) / 100, avgLatency / USEC_PER_MS,
+                                              (avgLatency % USEC_PER_MS) / 100, aReport.mMaxLatency / USEC_PER_MS,
+                                              (aReport.mMaxLatency % USEC_PER_MS) / 100);
+            }
+        }
+
+        Server::sServer->OutputFormat("\r\n");
+    }
+    else
+    {
+        Server::sServer->OutputFormat("[%3u] %2u.%03u - %2u.%03u sec  ", aReport.mSessionId,
+                                      aReport.mStartTime / MS_PER_SEC, aReport.mStartTime % MS_PER_SEC,
+                                      aReport.mEndTime / MS_PER_SEC, aReport.mEndTime % MS_PER_SEC);
+
+        Server::sServer->OutputFormat("%6u Bytes  ", aReport.mNumBytes);
+        Server::sServer->OutputFormat("%6u bits/sec  ", bandwidth);
+
+        if (aServer)
+        {
+            Server::sServer->OutputFormat("%2d.%03dms  ", aReport.mJitter / USEC_PER_MS, aReport.mJitter % USEC_PER_MS);
+            Server::sServer->OutputFormat("%4u/%4u     (%2u%%)", aReport.mCntError, aReport.mCntDatagram, lossRate);
+            if (aReport.mLatencyValid)
+            {
+                uint32_t avgLatency;
+
+                if (aReport.mCntDatagram == aReport.mCntError)
+                {
+                    avgLatency = 0;
+                }
+                else
+                {
+                    avgLatency = aReport.mLatency / (aReport.mCntDatagram - aReport.mCntError);
+                }
+
+                Server::sServer->OutputFormat(" (%u.%ums, %u.%ums, %u.%ums)", aReport.mMinLatency / USEC_PER_MS,
+                                              (aReport.mMinLatency % USEC_PER_MS) / 100, avgLatency / USEC_PER_MS,
+                                              (avgLatency % USEC_PER_MS) / 100, aReport.mMaxLatency / USEC_PER_MS,
+                                              (aReport.mMaxLatency % USEC_PER_MS) / 100);
+            }
+        }
+
+        Server::sServer->OutputFormat("\r\n");
+
+        if (aReport.mCntOutOfOrder != 0)
+        {
+            Server::sServer->OutputFormat("[%3u] %2u.%03u - %2u.%03u sec  ", aReport.mSessionId,
+                                          aReport.mStartTime / MS_PER_SEC, aReport.mStartTime % MS_PER_SEC,
+                                          aReport.mEndTime / MS_PER_SEC, aReport.mEndTime % MS_PER_SEC);
+            Server::sServer->OutputFormat("%u datagrams received out-of-order\r\n", aReport.mCntOutOfOrder);
+        }
+    }
+}
+
+void Session::PrintConnection(void)
+{
+    VerifyOrExit(!(mSetting->IsFlagSet(Setting::kFlagFormatQuiet) || mSetting->IsFlagSet(Setting::kFlagFormatCvs)));
+
+    Server::sServer->OutputFormat("[%3u] local ", mSessionId);
+    Server::sServer->OutputFormat("%x:%x:%x:%x:%x:%x:%x:%x ", HostSwap16(mLocalAddr.mFields.m16[0]),
+                                  HostSwap16(mLocalAddr.mFields.m16[1]), HostSwap16(mLocalAddr.mFields.m16[2]),
+                                  HostSwap16(mLocalAddr.mFields.m16[3]), HostSwap16(mLocalAddr.mFields.m16[4]),
+                                  HostSwap16(mLocalAddr.mFields.m16[5]), HostSwap16(mLocalAddr.mFields.m16[6]),
+                                  HostSwap16(mLocalAddr.mFields.m16[7]));
+    Server::sServer->OutputFormat("port %u ", mLocalPort);
+
+    Server::sServer->OutputFormat("connected with %x:%x:%x:%x:%x:%x:%x:%x ", HostSwap16(mPeerAddr.mFields.m16[0]),
+                                  HostSwap16(mPeerAddr.mFields.m16[1]), HostSwap16(mPeerAddr.mFields.m16[2]),
+                                  HostSwap16(mPeerAddr.mFields.m16[3]), HostSwap16(mPeerAddr.mFields.m16[4]),
+                                  HostSwap16(mPeerAddr.mFields.m16[5]), HostSwap16(mPeerAddr.mFields.m16[6]),
+                                  HostSwap16(mPeerAddr.mFields.m16[7]));
+    Server::sServer->OutputFormat("port %u\r\n", mPeerPort);
+
+exit:
+    return;
+}
+
+void Session::PrintClientReportHeader(void)
+{
+    VerifyOrExit(!(mSetting->IsFlagSet(Setting::kFlagFormatQuiet) || mSetting->IsFlagSet(Setting::kFlagFormatCvs)));
+    Server::sServer->OutputFormat("[ ID]  Interval              Transfer     Bandwidth\r\n");
+
+exit:
+    return;
+}
+
+void Session::PrintClientReport(void)
+{
+    Report report;
+
+    VerifyOrExit(!mSetting->IsFlagSet(Setting::kFlagFormatQuiet));
+
+    memset(&report, 0, sizeof(Report));
+
+    report.mIsFormatCvs = mSetting->IsFlagSet(Setting::kFlagFormatCvs);
+    report.mReportType  = kReportTypeClient;
+    report.mSessionId   = mSessionId;
+    report.mStartTime   = mPrintStartTime;
+    report.mEndTime     = mPrintEndTime;
+    report.mNumBytes    = mStats.mCurBytes;
+    report.mCntError    = mStats.mCurCntError;
+    report.mCntDatagram = mStats.mCurCntError + mStats.mCurCntDatagram;
+
+    PrintReport(report, false);
+
+exit:
+    return;
+}
+
+void Session::PrintClientReportEnd(void)
+{
+    Report report;
+
+    VerifyOrExit(!mSetting->IsFlagSet(Setting::kFlagFormatQuiet));
+
+    memset(&report, 0, sizeof(Report));
+
+    report.mIsFormatCvs = mSetting->IsFlagSet(Setting::kFlagFormatCvs);
+    report.mReportType  = kReportTypeClientEnd;
+    report.mSessionId   = mSessionId;
+    report.mStartTime   = mPrintStartTime;
+    report.mEndTime     = mPrintEndTime;
+    report.mNumBytes    = mStats.mTotalBytes;
+    report.mCntError    = mStats.mTotalCntError;
+    report.mCntDatagram = mStats.mTotalCntError + mStats.mTotalCntDatagram;
+
+    if (!mSetting->IsFlagSet(Setting::kFlagFormatCvs))
+    {
+        Server::sServer->OutputFormat("%s", COLOR_CODE_RED);
+    }
+
+    PrintReport(report, false);
+
+    if (!mSetting->IsFlagSet(Setting::kFlagFormatCvs))
+    {
+        Server::sServer->OutputFormat("%s", COLOR_CODE_END);
+    }
+
+exit:
+    return;
+}
+
+void Session::PrintServerReportHeader(void)
+{
+    uint64_t microNow;
+    VerifyOrExit(!(mSetting->IsFlagSet(Setting::kFlagFormatQuiet) || mSetting->IsFlagSet(Setting::kFlagFormatCvs)));
+
+    Server::sServer->OutputFormat("\r\n[ ID] Interval             Transfer     Bandwidth         "
+                                  "Jitter    Lost/Total LossRate ");
+
+    if (GetSynchronizedTime(microNow) == OT_ERROR_NONE)
+    {
+        Server::sServer->OutputFormat("Latency(min, avg, max)\r\n");
+    }
+    else
+    {
+        Server::sServer->OutputFormat("\r\n");
+    }
+
+exit:
+    return;
+}
+
+void Session::PrintServerReport(void)
+{
+    Report report;
+
+    VerifyOrExit(!mSetting->IsFlagSet(Setting::kFlagFormatQuiet));
+
+    memset(&report, 0, sizeof(Report));
+
+    report.mIsFormatCvs   = mSetting->IsFlagSet(Setting::kFlagFormatCvs);
+    report.mReportType    = kReportTypeServer;
+    report.mSessionId     = mSessionId;
+    report.mStartTime     = mPrintStartTime;
+    report.mEndTime       = mPrintEndTime;
+    report.mNumBytes      = mStats.mCurBytes;
+    report.mJitter        = mStats.mJitter;
+    report.mCntError      = mStats.mCurCntError;
+    report.mCntDatagram   = mStats.mCurCntError + mStats.mCurCntDatagram;
+    report.mCntOutOfOrder = mStats.mCurCntOutOfOrder;
+    report.mMinLatency    = mStats.mCurMinLatency;
+    report.mMaxLatency    = mStats.mCurMaxLatency;
+    report.mLatency       = mStats.mCurLatency;
+    report.mLatencyValid  = mStats.mLatencyValid;
+
+    PrintReport(report, true);
+
+exit:
+    return;
+}
+
+void Session::PrintServerReportEnd(void)
+{
+    Report report;
+
+    VerifyOrExit(!mSetting->IsFlagSet(Setting::kFlagFormatQuiet));
+
+    memset(&report, 0, sizeof(Report));
+
+    report.mIsFormatCvs   = mSetting->IsFlagSet(Setting::kFlagFormatCvs);
+    report.mReportType    = kReportTypeServerEnd;
+    report.mSessionId     = mSessionId;
+    report.mStartTime     = 0;
+    report.mEndTime       = mPrintEndTime;
+    report.mNumBytes      = mStats.mTotalBytes;
+    report.mJitter        = mStats.mJitter;
+    report.mCntError      = mStats.mTotalCntError;
+    report.mCntDatagram   = mStats.mTotalCntError + mStats.mTotalCntDatagram;
+    report.mCntOutOfOrder = mStats.mTotalCntOutOfOrder;
+    report.mMinLatency    = mStats.mTotalMinLatency;
+    report.mMaxLatency    = mStats.mTotalMaxLatency;
+    report.mLatency       = mStats.mTotalLatency;
+    report.mLatencyValid  = mStats.mLatencyValid;
+
+    if (!mSetting->IsFlagSet(Setting::kFlagFormatCvs))
+    {
+        Server::sServer->OutputFormat("%s", COLOR_CODE_RED);
+    }
+
+    PrintReport(report, true);
+
+    if (!mSetting->IsFlagSet(Setting::kFlagFormatCvs))
+    {
+        Server::sServer->OutputFormat("%s", COLOR_CODE_END);
+    }
+
+exit:
+    return;
+}
+
+void Session::TimerFired(void)
+{
+    uint32_t milliNow = TimerMilli::GetNow();
+
+    VerifyOrExit(mState == kStateSendingData || mState == kStateSendingFin || mState == kStateReceivingFin);
+    VerifyOrExit(TimeCompare(mFireTime, mPerf->mTimer.GetNow()) <= 0);
+
+    switch (mState)
+    {
+    case kStateSendingData:
+        SendData();
+
+        if (mSetting->GetTime() != 0)
+        {
+            if (mSetting->IsFlagSet(Setting::kFlagNumber))
+            {
+                if (mStats.mTotalCntDatagram >= mSetting->GetCount())
+                {
+                    mState = kStateSendingFin;
+                }
+            }
+            else if (milliNow - mSessionStartTime >= mSetting->GetTime())
+            {
+                mState = kStateSendingFin;
+            }
+        }
+
+        if (mState == kStateSendingData)
+        {
+            mFireTime += UsToTimerTime(mSendingIntervalUs);
+            break;
+        }
+
+        mPrintStartTime = 0;
+        mPrintEndTime   = milliNow - mSessionStartTime;
+        mSessionEndTime = milliNow;
+        mFinCounter     = 0;
+
+        PrintClientReportEnd();
+        if (mSetting->GetFinDelay() != 0)
+        {
+            mFireTime += UsToTimerTime(mSetting->GetFinDelay() * USEC_PER_SEC);
+        }
+        else
+        {
+            mFireTime += UsToTimerTime(kFinIntervalUs);
+        }
+
+        // fall through
+
+    case kStateSendingFin:
+        SendFin();
+        mFinCounter++;
+
+        if (mFinCounter >= kMaxNumFin)
+        {
+            CloseSocket();
+            mState = kStateInvalid;
+        }
+        else
+        {
+            mFireTime += UsToTimerTime(kFinIntervalUs);
+        }
+        break;
+
+    case kStateReceivingFin:
+        CloseSocket();
+        mState = kStateInvalid;
+        break;
+
+    default:
+        break;
+    }
+
+exit:
+    return;
+}
+
+bool Session::MatchMsgInfo(const otMessageInfo &aMessageInfo)
+{
+    bool ret = false;
+
+    if ((aMessageInfo.mPeerPort == mPeerPort) &&
+        (memcmp(aMessageInfo.mPeerAddr.mFields.m8, mPeerAddr.mFields.m8, sizeof(otIp6Address)) == 0) &&
+        (aMessageInfo.mSockPort == mLocalPort))
+    {
+        ret = true;
+    }
+
+    return ret;
+}
+
+otError Session::GetDelayInterval(uint32_t &aInterval)
+{
+    otError  error = OT_ERROR_NONE;
+    uint32_t now   = mPerf->mTimer.GetNow();
+
+    VerifyOrExit(mState == kStateSendingData || mState == kStateSendingFin || mState == kStateReceivingFin,
+                 error = OT_ERROR_INVALID_STATE);
+
+    if (TimeCompare(mFireTime, now) <= 0)
+    {
+        aInterval = 0;
+        ExitNow();
+    }
+
+    aInterval = mFireTime - now;
+
+exit:
+    return error;
+}
+
+otError Session::GetSynchronizedTime(uint64_t &aSyncTime)
+{
+    otError error = OT_ERROR_FAILED;
+
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    if (otNetworkTimeGet(mPerf->mInstance, &aSyncTime) == OT_NETWORK_TIME_SYNCHRONIZED)
+    {
+        error = OT_ERROR_NONE;
+    }
+#endif
+
+    OT_UNUSED_VARIABLE(aSyncTime);
+
+    return error;
+}
+
+otError Session::PrepareReceive(void)
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(mRole == kRoleListener, error = OT_ERROR_FAILED);
+    VerifyOrExit(mState == kStateIdle, error = OT_ERROR_FAILED);
+
+    mLocalPort = kUdpPort;
+    SuccessOrExit(error = OpenSocket());
+
+    mState = kStateListening;
+
+exit:
+    return error;
+}
+
+otError Session::PrepareTransmit(uint8_t aSessionId)
+{
+    otError  error    = OT_ERROR_NONE;
+    uint32_t milliNow = TimerMilli::GetNow();
+
+    VerifyOrExit(mRole == kRoleClient, error = OT_ERROR_FAILED);
+    VerifyOrExit(mState == kStateIdle, error = OT_ERROR_FAILED);
+
+    mSendingIntervalUs =
+        static_cast<uint32_t>((static_cast<uint64_t>(mSetting->GetLength()) * 8000000LL) / mSetting->GetBandwidth());
+    if (mSendingIntervalUs < kMinSendingIntervalUs)
+    {
+        mSendingIntervalUs = kMinSendingIntervalUs;
+    }
+
+    memcpy(mPeerAddr.mFields.m8, mSetting->GetDestAddr()->mFields.m8, sizeof(otIp6Address));
+
+    mFireTime         = mPerf->mTimer.GetNow() + UsToTimerTime(mSendingIntervalUs);
+    mSessionStartTime = milliNow;
+    mSessionEndTime   = milliNow + mSetting->GetInterval();
+    mSessionId        = (mSetting->IsFlagSet(Setting::kFlagSessionId)) ? mSetting->GetSessionId() : aSessionId;
+    mPeerPort         = kUdpPort;
+    mPrintEndTime     = 0;
+
+    SuccessOrExit(error = OpenSocket());
+
+    mState = kStateSendingData;
+
+exit:
+    return error;
+}
+
+uint32_t Session::UsToTimerTime(uint32_t aTime)
+{
+#if !OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
+    aTime = aTime / USEC_PER_MS;
+#endif
+
+    return aTime;
+}
+
+Perf::Perf(Interpreter &aInterpreter)
+    : mServerRunning(false)
+    , mClientRunning(false)
+    , mPrintServerHeaderFlag(false)
+    , mPrintClientHeaderFlag(false)
+    , mTimer(*aInterpreter.mInstance, &Perf::s_HandleTimer, this)
+    , mServerSetting(NULL)
+    , mInterpreter(aInterpreter)
+    , mInstance(aInterpreter.mInstance)
+{
+    memset(mSettings, 0, sizeof(mSettings));
+    memset(mSessions, 0, sizeof(mSessions));
+}
+
+otError Perf::Process(int argc, char *argv[])
+{
+    otError error = OT_ERROR_PARSE;
+
+    if (argc == 0)
+    {
+        ProcessHelp(0, NULL);
+        ExitNow(error = OT_ERROR_NONE);
+    }
+
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(sCommands); i++)
+    {
+        if (strcmp(argv[0], sCommands[i].mName) == 0)
+        {
+            error = (this->*sCommands[i].mCommand)(argc - 1, argv + 1);
+            break;
+        }
+    }
+
+exit:
+    return error;
+}
+
+otError Perf::ProcessHelp(int argc, char *argv[])
+{
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(sCommands); i++)
+    {
+        Server::sServer->OutputFormat("%s\r\n", sCommands[i].mName);
+    }
+
+    OT_UNUSED_VARIABLE(argc);
+    OT_UNUSED_VARIABLE(argv);
+
+    return OT_ERROR_NONE;
+}
+
+otError Perf::ProcessClient(int argc, char *argv[])
+{
+    otError  error   = OT_ERROR_NONE;
+    Setting *setting = NULL;
+
+    VerifyOrExit(argc >= 1, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(!(mServerRunning || mClientRunning), error = OT_ERROR_BUSY);
+    VerifyOrExit((setting = NewSetting()) != NULL, error = OT_ERROR_NO_BUFS);
+
+    SuccessOrExit(error = SetSetting(argc, argv, true, *setting));
+    VerifyOrExit(setting->IsFlagSet(Setting::kFlagDestAddr), error = OT_ERROR_INVALID_ARGS);
+
+exit:
+    if ((error != OT_ERROR_NONE) && (setting != NULL))
+    {
+        FreeSetting(*setting);
+    }
+
+    return error;
+}
+
+otError Perf::ProcessServer(int argc, char *argv[])
+{
+    otError  error   = OT_ERROR_NONE;
+    Setting *setting = NULL;
+
+    VerifyOrExit(!(mServerRunning || mClientRunning), error = OT_ERROR_BUSY);
+    VerifyOrExit(mServerSetting == NULL, error = OT_ERROR_ALREADY);
+    VerifyOrExit((setting = NewSetting()) != NULL, error = OT_ERROR_NO_BUFS);
+    SuccessOrExit(error = SetSetting(argc, argv, false, *setting));
+
+    mServerSetting = setting;
+
+exit:
+    if ((error != OT_ERROR_NONE) && (setting != NULL))
+    {
+        FreeSetting(*setting);
+    }
+
+    return error;
+}
+
+otError Perf::SetSetting(int argc, char *argv[], bool aClient, Setting &aSetting)
+{
+    otError error = OT_ERROR_NONE;
+    long    value;
+
+    for (int i = 0; i < argc; i += 2)
+    {
+        if (i == argc - 1)
+        {
+            ExitNow(error = OT_ERROR_INVALID_ARGS);
+        }
+        else if (strcmp(argv[i], "interval") == 0)
+        {
+            SuccessOrExit(error = Interpreter::ParseLong(argv[i + 1], value));
+            VerifyOrExit(value != 0, error = OT_ERROR_INVALID_ARGS);
+
+            aSetting.SetFlag(Setting::kFlagInterval);
+            aSetting.SetInterval(static_cast<uint32_t>(value) * MS_PER_SEC);
+        }
+        else if (strcmp(argv[i], "format") == 0)
+        {
+            if (strcmp(argv[i + 1], "cvs") == 0)
+            {
+                aSetting.SetFlag(Setting::kFlagFormatCvs);
+                aSetting.ClearFlag(Setting::kFlagFormatQuiet);
+            }
+            else if (strcmp(argv[i + 1], "quiet") == 0)
+            {
+                aSetting.SetFlag(Setting::kFlagFormatQuiet);
+                aSetting.ClearFlag(Setting::kFlagFormatCvs);
+            }
+            else
+            {
+                ExitNow(error = OT_ERROR_INVALID_ARGS);
+            }
+        }
+        else if (aClient)
+        {
+            if (strcmp(argv[i], "destaddr") == 0)
+            {
+                otIp6Address destAddr;
+                SuccessOrExit(error = otIp6AddressFromString(argv[i + 1], &destAddr));
+                aSetting.SetFlag(Setting::kFlagDestAddr);
+                aSetting.SetDestAddr(destAddr);
+            }
+            else if (strcmp(argv[i], "bandwidth") == 0)
+            {
+                SuccessOrExit(error = Interpreter::ParseLong(argv[i + 1], value));
+                VerifyOrExit(value != 0, error = OT_ERROR_INVALID_ARGS);
+
+                aSetting.SetFlag(Setting::kFlagBandwidth);
+                aSetting.SetBandwidth(static_cast<uint32_t>(value));
+            }
+            else if (strcmp(argv[i], "length") == 0)
+            {
+                SuccessOrExit(error = Interpreter::ParseLong(argv[i + 1], value));
+                VerifyOrExit(static_cast<uint16_t>(value) >= sizeof(PerfHeader), error = OT_ERROR_INVALID_ARGS);
+                VerifyOrExit(value <= kMaxPayloadLength, error = OT_ERROR_INVALID_ARGS);
+
+                aSetting.SetFlag(Setting::kFlagLength);
+                aSetting.SetLength(static_cast<uint16_t>(value));
+            }
+            else if (strcmp(argv[i], "priority") == 0)
+            {
+                SuccessOrExit(error = Interpreter::ParseLong(argv[i + 1], value));
+                VerifyOrExit(value <= OT_MESSAGE_PRIORITY_HIGH, error = OT_ERROR_INVALID_ARGS);
+
+                aSetting.SetFlag(Setting::kFlagPriority);
+                aSetting.SetPriority(static_cast<otMessagePriority>(value));
+            }
+            else if (strcmp(argv[i], "time") == 0)
+            {
+                SuccessOrExit(error = Interpreter::ParseLong(argv[i + 1], value));
+
+                aSetting.SetFlag(Setting::kFlagTime);
+                aSetting.SetTime(static_cast<uint32_t>(value) * MS_PER_SEC);
+            }
+            else if (strcmp(argv[i], "count") == 0)
+            {
+                SuccessOrExit(error = Interpreter::ParseLong(argv[i + 1], value));
+                VerifyOrExit(value != 0, error = OT_ERROR_INVALID_ARGS);
+
+                aSetting.SetFlag(Setting::kFlagNumber);
+                aSetting.SetCount(static_cast<uint32_t>(value));
+            }
+            else if (strcmp(argv[i], "id") == 0)
+            {
+                SuccessOrExit(error = Interpreter::ParseLong(argv[i + 1], value));
+                VerifyOrExit(value <= 0xff, error = OT_ERROR_INVALID_ARGS);
+
+                aSetting.SetFlag(Setting::kFlagSessionId);
+                aSetting.SetSessionId(static_cast<uint8_t>(value));
+            }
+            else if (strcmp(argv[i], "findelay") == 0)
+            {
+                SuccessOrExit(error = Interpreter::ParseLong(argv[i + 1], value));
+                VerifyOrExit(value <= Setting::kMaxFinDelayMs, error = OT_ERROR_INVALID_ARGS);
+
+                aSetting.SetFlag(Setting::kFlagFinDelay);
+                aSetting.SetFinDelay(static_cast<uint8_t>(value));
+            }
+            else if (strcmp(argv[i], "echo") == 0)
+            {
+                SuccessOrExit(error = Interpreter::ParseLong(argv[i + 1], value));
+
+                if (value == 0)
+                {
+                    aSetting.SetFlag(Setting::kFlagEcho);
+                    aSetting.SetEchoFlag(false);
+                }
+                else
+                {
+                    aSetting.SetFlag(Setting::kFlagEcho);
+                    aSetting.SetEchoFlag(true);
+                }
+            }
+            else
+            {
+                error = OT_ERROR_INVALID_ARGS;
+                break;
+            }
+        }
+        else
+        {
+            error = OT_ERROR_INVALID_ARGS;
+            break;
+        }
+    }
+
+exit:
+    if (error == OT_ERROR_NONE)
+    {
+        if (aClient)
+        {
+            aSetting.SetFlag(Setting::kFlagClient);
+        }
+        else
+        {
+            aSetting.ClearFlag(Setting::kFlagClient);
+        }
+    }
+
+    return error;
+}
+
+void Perf::PrintSetting(Setting &aSetting)
+{
+    const otIp6Address *destAddr = aSetting.GetDestAddr();
+
+    if (aSetting.IsFlagSet(Setting::kFlagClient))
+    {
+        Server::sServer->OutputFormat("perf client ");
+    }
+    else
+    {
+        Server::sServer->OutputFormat("perf server ");
+    }
+
+    if (aSetting.IsFlagSet(Setting::kFlagDestAddr))
+    {
+        Server::sServer->OutputFormat("destaddr %x:%x:%x:%x:%x:%x:%x:%x ", HostSwap16(destAddr->mFields.m16[0]),
+                                      HostSwap16(destAddr->mFields.m16[1]), HostSwap16(destAddr->mFields.m16[2]),
+                                      HostSwap16(destAddr->mFields.m16[3]), HostSwap16(destAddr->mFields.m16[4]),
+                                      HostSwap16(destAddr->mFields.m16[5]), HostSwap16(destAddr->mFields.m16[6]),
+                                      HostSwap16(destAddr->mFields.m16[7]));
+    }
+
+    if (aSetting.IsFlagSet(Setting::kFlagBandwidth))
+    {
+        Server::sServer->OutputFormat("bandwidth %u ", aSetting.GetBandwidth());
+    }
+
+    if (aSetting.IsFlagSet(Setting::kFlagLength))
+    {
+        Server::sServer->OutputFormat("length %u ", aSetting.GetLength());
+    }
+
+    if (aSetting.IsFlagSet(Setting::kFlagInterval))
+    {
+        Server::sServer->OutputFormat("interval %u ", aSetting.GetInterval() / MS_PER_SEC);
+    }
+
+    if (aSetting.IsFlagSet(Setting::kFlagFormatCvs))
+    {
+        Server::sServer->OutputFormat("format cvs ");
+    }
+    else if (aSetting.IsFlagSet(Setting::kFlagFormatQuiet))
+    {
+        Server::sServer->OutputFormat("format quiet ");
+    }
+
+    if (aSetting.IsFlagSet(Setting::kFlagTime))
+    {
+        Server::sServer->OutputFormat("time %u ", aSetting.GetTime() / MS_PER_SEC);
+    }
+
+    if (aSetting.IsFlagSet(Setting::kFlagNumber))
+    {
+        Server::sServer->OutputFormat("count %u ", aSetting.GetCount());
+    }
+
+    if (aSetting.IsFlagSet(Setting::kFlagPriority))
+    {
+        Server::sServer->OutputFormat("priority %u ", aSetting.GetPriority());
+    }
+
+    if (aSetting.IsFlagSet(Setting::kFlagSessionId))
+    {
+        Server::sServer->OutputFormat("id %u ", aSetting.GetSessionId());
+    }
+
+    if (aSetting.IsFlagSet(Setting::kFlagFinDelay))
+    {
+        Server::sServer->OutputFormat("findelay %u ", aSetting.GetFinDelay());
+    }
+
+    if (aSetting.IsFlagSet(Setting::kFlagEcho))
+    {
+        Server::sServer->OutputFormat("echo %d ", aSetting.GetEchoFlag());
+    }
+
+    Server::sServer->OutputFormat("\r\n");
+}
+
+void Perf::SessionStop(uint8_t aRole)
+{
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mSessions); i++)
+    {
+        if (!mSessions[i].IsStateValid())
+        {
+            continue;
+        }
+
+        if (mSessions[i].GetRole() == aRole)
+        {
+            mSessions[i].Free();
+        }
+    }
+}
+
+otError Perf::ServerStart()
+{
+    otError  error = OT_ERROR_NONE;
+    Session *session;
+
+    VerifyOrExit(mServerSetting != NULL);
+    VerifyOrExit(!mServerRunning, error = OT_ERROR_BUSY);
+    VerifyOrExit((session = NewSession(*mServerSetting, Session::kRoleListener)) != NULL, error = OT_ERROR_NO_BUFS);
+
+    if (session->PrepareReceive() != OT_ERROR_NONE)
+    {
+        session->Free();
+        ExitNow(error = OT_ERROR_FAILED);
+    }
+
+    mServerRunning = true;
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        SessionStop(Session::kRoleListener);
+    }
+
+    return error;
+}
+
+otError Perf::ClientStart()
+{
+    otError  error         = OT_ERROR_NONE;
+    bool     clientRunning = false;
+    Session *session;
+
+    VerifyOrExit(!mClientRunning);
+
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mSettings); i++)
+    {
+        if (!mSettings[i].IsFlagSet(Setting::kFlagValid) || !mSettings[i].IsFlagSet(Setting::kFlagClient))
+        {
+            continue;
+        }
+
+        VerifyOrExit((session = NewSession(mSettings[i], Session::kRoleClient)) != NULL, error = OT_ERROR_NO_BUFS);
+        SuccessOrExit(session->PrepareTransmit(static_cast<uint8_t>(i)));
+
+        if (mPrintClientHeaderFlag == false)
+        {
+            mPrintClientHeaderFlag = true;
+            session->PrintClientReportHeader();
+        }
+
+        clientRunning = true;
+    }
+
+    VerifyOrExit(clientRunning);
+
+    mClientRunning = true;
+    StartTimer();
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        SessionStop(Session::kRoleClient);
+    }
+
+    return error;
+}
+
+otError Perf::ProcessStart(int argc, char *argv[])
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(argc <= 1, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(otThreadGetDeviceRole(mInstance) != OT_DEVICE_ROLE_DISABLED, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(!(mServerRunning && mClientRunning), error = OT_ERROR_BUSY);
+
+    if (argc == 0)
+    {
+        SuccessOrExit(error = ServerStart());
+        if ((error = ClientStart()) != OT_ERROR_NONE)
+        {
+            ServerStop();
+        }
+    }
+    else if (strcmp(argv[0], "server") == 0)
+    {
+        SuccessOrExit(error = ServerStart());
+    }
+    else if (strcmp(argv[0], "client") == 0)
+    {
+        SuccessOrExit(error = ClientStart());
+    }
+    else
+    {
+        ExitNow(error = OT_ERROR_INVALID_ARGS);
+    }
+
+    VerifyOrExit(mServerRunning | mClientRunning, error = OT_ERROR_FAILED);
+
+exit:
+    return error;
+}
+
+void Perf::ServerStop()
+{
+    VerifyOrExit(mServerRunning);
+
+    SessionStop(Session::kRoleListener);
+    SessionStop(Session::kRoleServer);
+
+    mServerRunning         = false;
+    mPrintServerHeaderFlag = false;
+
+    if (mClientRunning == false && mTimer.IsRunning())
+    {
+        mTimer.Stop();
+    }
+
+exit:
+    return;
+}
+
+void Perf::ClientStop(void)
+{
+    VerifyOrExit(mClientRunning);
+
+    SessionStop(Session::kRoleClient);
+
+    mClientRunning         = false;
+    mPrintClientHeaderFlag = false;
+
+    if (mServerRunning == false && mTimer.IsRunning())
+    {
+        mTimer.Stop();
+    }
+
+exit:
+    return;
+}
+
+Session *Perf::FindValidSession(uint8_t aRole)
+{
+    Session *session = NULL;
+
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mSessions); i++)
+    {
+        if ((mSessions[i].IsStateValid()) && (mSessions[i].GetRole() == aRole))
+        {
+            session = &mSessions[i];
+            break;
+        }
+    }
+
+    return session;
+}
+
+void Perf::UpdateClientState(void)
+{
+    VerifyOrExit(mClientRunning);
+    VerifyOrExit(FindValidSession(Session::kRoleClient) == NULL);
+
+    mClientRunning         = false;
+    mPrintClientHeaderFlag = false;
+
+    if (mServerRunning == false && mTimer.IsRunning())
+    {
+        mTimer.Stop();
+    }
+
+exit:
+    return;
+}
+
+otError Perf::ProcessStop(int argc, char *argv[])
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(argc <= 1, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(mServerRunning || mClientRunning);
+
+    if (argc == 0)
+    {
+        ServerStop();
+        ClientStop();
+    }
+    else if (strcmp(argv[0], "server") == 0)
+    {
+        ServerStop();
+    }
+    else if (strcmp(argv[0], "client") == 0)
+    {
+        ClientStop();
+    }
+    else
+    {
+        ExitNow(error = OT_ERROR_INVALID_ARGS);
+    }
+
+exit:
+
+    return error;
+}
+
+otError Perf::ProcessShow(int argc, char *argv[])
+{
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mSettings); i++)
+    {
+        if (!mSettings[i].IsFlagSet(Setting::kFlagValid))
+        {
+            continue;
+        }
+
+        PrintSetting(mSettings[i]);
+    }
+
+    OT_UNUSED_VARIABLE(argc);
+    OT_UNUSED_VARIABLE(argv);
+
+    return OT_ERROR_NONE;
+}
+
+otError Perf::ProcessClear(int argc, char *argv[])
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(!(mServerRunning || mClientRunning), error = OT_ERROR_BUSY);
+
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mSettings); i++)
+    {
+        if (mSettings[i].IsFlagSet(Setting::kFlagValid))
+        {
+            FreeSetting(mSettings[i]);
+        }
+    }
+
+    OT_UNUSED_VARIABLE(argc);
+    OT_UNUSED_VARIABLE(argv);
+
+exit:
+    return error;
+}
+
+void Perf::s_HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
+{
+    otPerfContext *context = static_cast<otPerfContext *>(aContext);
+    context->mPerf->HandleUdpReceive(aMessage, aMessageInfo, *context->mSession);
+}
+
+void Perf::HandleUdpReceive(otMessage *aMessage, const otMessageInfo *aMessageInfo, Session &aSession)
+{
+    Session *session;
+
+    VerifyOrExit(mServerRunning);
+
+    if ((session = FindSession(*aMessageInfo)) == NULL)
+    {
+        VerifyOrExit((session = NewSession(aSession.GetSetting(), Session::kRoleServer)) != NULL);
+
+        if (session->HandleFistMessage(*aMessage, *aMessageInfo) != OT_ERROR_NONE)
+        {
+            session->Free();
+        }
+    }
+    else
+    {
+        session->HandleSubsequentMessages(*aMessage, *aMessageInfo);
+    }
+
+exit:
+    return;
+}
+
+Setting *Perf::NewSetting()
+{
+    Setting *setting = NULL;
+
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mSettings); i++)
+    {
+        if (!mSettings[i].IsFlagSet(Setting::kFlagValid))
+        {
+            setting = new (static_cast<void *>(&mSettings[i])) Setting();
+            setting->SetFlag(Setting::kFlagValid);
+            break;
+        }
+    }
+
+    return setting;
+}
+
+void Perf::FreeSetting(Setting &aSetting)
+{
+    if (!aSetting.IsFlagSet(Setting::kFlagClient))
+    {
+        mServerSetting = NULL;
+    }
+
+    aSetting.ClearFlag(Setting::kFlagValid);
+}
+
+Session *Perf::NewSession(const Setting &aSetting, uint8_t aRole)
+{
+    Session *session = NULL;
+
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mSessions); i++)
+    {
+        if (!mSessions[i].IsStateValid())
+        {
+            session = new (static_cast<void *>(&mSessions[i])) Session(*this, aSetting, aRole);
+            break;
+        }
+    }
+
+    return session;
+}
+
+Session *Perf::FindSession(const otMessageInfo &aMessageInfo)
+{
+    Session *session = NULL;
+
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mSessions); i++)
+    {
+        if ((mSessions[i].IsStateValid()) && mSessions[i].MatchMsgInfo(aMessageInfo))
+        {
+            session = &mSessions[i];
+            break;
+        }
+    }
+
+    return session;
+}
+
+Perf &Perf::GetOwner(OwnerLocator &aOwnerLocator)
+{
+#if OPENTHREAD_ENABLE_MULTIPLE_INSTANCES
+    Perf &perf = (aOwnerLocator.GetOwner<Perf>());
+#else
+    Perf &perf = Server::sServer->GetInterpreter().mPerf;
+    OT_UNUSED_VARIABLE(aOwnerLocator);
+#endif
+
+    return perf;
+}
+
+otError Perf::FindMinDelayInterval(uint32_t &aInterval)
+{
+    otError  error       = OT_ERROR_NONE;
+    uint32_t minInterval = UINT32_MAX;
+    uint32_t interval;
+
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mSessions); i++)
+    {
+        if (mSessions[i].GetDelayInterval(interval) == OT_ERROR_NONE)
+        {
+            if (interval < minInterval)
+            {
+                minInterval = interval;
+            }
+        }
+    }
+
+    VerifyOrExit(minInterval != UINT32_MAX, error = OT_ERROR_NOT_FOUND);
+    aInterval = minInterval;
+
+exit:
+    return error;
+}
+
+void Perf::StartTimer()
+{
+    uint32_t interval;
+
+    VerifyOrExit(FindMinDelayInterval(interval) == OT_ERROR_NONE);
+
+    if (mTimer.IsRunning())
+    {
+        mTimer.Stop();
+    }
+
+    mTimer.Start(interval);
+
+exit:
+    return;
+}
+
+void Perf::s_HandleTimer(Timer &aTimer)
+{
+    GetOwner(aTimer).HandleTimer();
+}
+
+void Perf::HandleTimer(void)
+{
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mSessions); i++)
+    {
+        mSessions[i].TimerFired();
+    }
+
+    UpdateClientState();
+    StartTimer();
+}
+} // namespace Cli
+} // namespace ot
+#endif // OPENTHREAD_CONFIG_CLI_PERF_ENABLE

--- a/src/cli/cli_perf.hpp
+++ b/src/cli/cli_perf.hpp
@@ -1,0 +1,923 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file contains definitions for the network performance tool.
+ */
+
+#ifndef CLI_PERF_HPP_
+#define CLI_PERF_HPP_
+
+#include "openthread-core-config.h"
+
+#include "cli_config.h"
+
+#include <stdio.h>
+#include <openthread/error.h>
+#include <openthread/udp.h>
+#include <openthread/platform/toolchain.h>
+
+#include "common/encoding.hpp"
+#include "common/instance.hpp"
+#include "common/timer.hpp"
+#include "net/ip6_headers.hpp"
+#include "net/udp6.hpp"
+
+#if OPENTHREAD_CONFIG_CLI_PERF_ENABLE
+
+using ot::Encoding::BigEndian::HostSwap32;
+namespace ot {
+namespace Cli {
+
+class Interpreter;
+class Perf;
+class Session;
+class Setting;
+
+#define USEC_PER_SEC 1000000UL
+#define MS_PER_SEC 1000
+#define USEC_PER_MS 1000
+#define COLOR_CODE_RED "\033[31m"
+#define COLOR_CODE_END "\033[0m"
+
+OT_TOOL_PACKED_BEGIN
+class PerfHeader
+{
+public:
+    /**
+     * This method sets the value of time.
+     *
+     * @param[in] aUsec  The value of time (in microseconds).
+     *
+     */
+    void SetTime(uint64_t aUsec)
+    {
+        mSec  = HostSwap32(static_cast<uint32_t>(aUsec / USEC_PER_SEC));
+        mUsec = HostSwap32(static_cast<uint32_t>(aUsec % USEC_PER_SEC));
+    }
+
+    /**
+     * This method gets the value of time.
+     *
+     * @returns The value time (in microseconds).
+     *
+     */
+    uint64_t GetTime(void) { return static_cast<uint64_t>(HostSwap32(mSec)) * USEC_PER_SEC + HostSwap32(mUsec); }
+
+    /**
+     * This method gets the sequence number.
+     *
+     * @returns The sequence number.
+     *
+     */
+    uint32_t GetSeqNumber(void) const { return HostSwap32(mSeqNumber); }
+
+    /**
+     * This method sets the sequence number.
+     *
+     * @param[in]  aSeqNumber  A sequence number.
+     *
+     */
+    void SetSeqNumber(uint32_t aSeqNumber) { mSeqNumber = HostSwap32(aSeqNumber); }
+
+    /**
+     * This method gets the sending interval.
+     *
+     * @returns The sending interval (in microseconds).
+     *
+     */
+    uint32_t GetSendingInterval(void) { return HostSwap32(mSendingIntervalUs); }
+
+    /**
+     * This method sets the sending interval.
+     *
+     * @param[in]  aInterval  A sending interval (in microseconds).
+     *
+     */
+    void SetSendingInterval(uint32_t aInterval) { mSendingIntervalUs = HostSwap32(aInterval); }
+
+    /**
+     * This method gets the fin delay.
+     *
+     * @returns The fin delay (in milliseconds).
+     *
+     */
+    uint8_t GetFinDelay(void) const { return mFinDelay; }
+
+    /**
+     * This method sets the fin delay.
+     *
+     * @param[in]  aFinDelay  The fin delay (in milliseconds).
+     *
+     */
+    void SetFinDelay(uint8_t aFinDelay) { mFinDelay = aFinDelay; }
+
+    /**
+     * This method gets the session identifier value.
+     *
+     * @returns The session identifier.
+     *
+     */
+    uint8_t GetSessionId(void) const { return mSessionId; }
+
+    /**
+     * This method sets the session identifier value.
+     *
+     * @param[in]  aSessionId  A session identifier.
+     *
+     */
+    void SetSessionId(uint8_t aSessionId) { mSessionId = aSessionId; }
+
+    /**
+     * This method gets the fin flag.
+     *
+     * @returns The fin flag.
+     *
+     */
+    bool GetFinFlag(void) const { return mFinFlag; }
+
+    /**
+     * This method sets the fin flag.
+     *
+     * @param[in]  aFin  The fin flag.
+     *
+     */
+    void SetFinFlag(bool aFinFlag) { mFinFlag = aFinFlag; }
+
+    /**
+     * This method gets the echo flag.
+     *
+     * @returns The echo flag.
+     *
+     */
+    bool GetEchoFlag(void) const { return mEchoFlag; }
+
+    /**
+     * This method sets the echo flag.
+     *
+     * @param[in]  aEchoFlag  The echo flag.
+     *
+     */
+    void SetEchoFlag(bool aEchoFlag) { mEchoFlag = aEchoFlag; }
+
+    /**
+     * This method sets the synchronization flag.
+     *
+     * @param[in]  aSyncFlag  The synchronization flag.
+     *
+     */
+    void SetSyncFlag(bool aSyncFlag) { mSyncFlag = aSyncFlag; }
+
+    /**
+     * This method gets the synchronization flag.
+     *
+     * @returns The synchronization flag.
+     *
+     */
+    bool GetSyncFlag(void) const { return mSyncFlag; }
+
+    /**
+     * This method sets the reply flag.
+     *
+     * @param[in]  aReplyFlag  The reply flag.
+     *
+     */
+    void SetReplyFlag(bool aReplyFlag) { mReplyFlag = aReplyFlag; }
+
+    /**
+     * This method gets the reply flag.
+     *
+     * @returns The reply flag.
+     *
+     */
+    bool GetReplyFlag(void) const { return mReplyFlag; }
+
+private:
+    uint32_t mSec;
+    uint32_t mUsec;
+    uint32_t mSeqNumber;
+    uint32_t mSendingIntervalUs;
+    uint8_t  mSessionId;
+    uint8_t  mFinDelay;
+    bool     mFinFlag : 1;
+    bool     mEchoFlag : 1;
+    bool     mReplyFlag : 1;
+    bool     mSyncFlag : 1;
+} OT_TOOL_PACKED_END;
+
+/**
+ * This class implements the Setting object.
+ *
+ */
+class Setting
+{
+public:
+    /**
+     * This enumeration defines the setting flags.
+     *
+     */
+    enum
+    {
+        kFlagValid       = 1,       ///< Indicates whether the Setting is valid.
+        kFlagClient      = 1 << 1,  ///< Indicates whether the type of the Setting is a client.
+        kFlagEcho        = 1 << 2,  ///< Indicates whether the echo flag is set.
+        kFlagBandwidth   = 1 << 3,  ///< Indicates whether the bandwidth is set.
+        kFlagLength      = 1 << 4,  ///< Indicates whether the length is set.
+        kFlagInterval    = 1 << 5,  ///< Indicates whether the display interval is set.
+        kFlagPriority    = 1 << 6,  ///< Indicates whether the priority is set.
+        kFlagTime        = 1 << 7,  ///< Indicates whether the testing time is set.
+        kFlagNumber      = 1 << 8,  ///< Indicates whether the number of packets is set.
+        kFlagSessionId   = 1 << 9,  ///< Indicates whether the session ID is set.
+        kFlagFormatCvs   = 1 << 10, ///< Indicates whether the display format is CVS.
+        kFlagFormatQuiet = 1 << 11, ///< Indicates whether the display is disabled.
+        kFlagFinDelay    = 1 << 12, ///< Indicates whether the fin delay is set.
+        kFlagDestAddr    = 1 << 13, ///< Indicates whether the destination address is set.
+    };
+
+    enum
+    {
+        kMaxFinDelayMs = 200, ///< Maximum Fin delay time (in milliseconds).
+    };
+
+    /**
+     * This constructor initializes the Setting object.
+     *
+     */
+    Setting(void)
+        : mFlags(0)
+        , mLength(kDefaultLength)
+        , mBandwidth(kDefaultBandwidth)
+        , mInterval(kDefaultInterval)
+        , mTime(kDefaultTime)
+        , mPriority(OT_MESSAGE_PRIORITY_LOW)
+        , mFinDelay(0)
+    {
+        memset(&mDestAddr, 0, sizeof(otIp6Address));
+    }
+
+    /**
+     * This method sets the flag.
+     *
+     * @param[in]  aFlag  The flag.
+     *
+     */
+    void SetFlag(uint32_t aFlag) { mFlags |= aFlag; }
+
+    /**
+     * This method clears the flag.
+     *
+     * @param[in]  aFlag  The flag.
+     *
+     */
+    void ClearFlag(uint32_t aFlag) { mFlags &= (~aFlag); }
+
+    /**
+     * This method indicates whether or not the flag is set.
+     *
+     * @param[in]  aFlag  The flag.
+     *
+     * @retval TRUE   If the flag is set.
+     * @retval FALSE  If the flag is not set.
+     *
+     */
+    bool IsFlagSet(uint32_t aFlag) const { return (mFlags & aFlag) ? true : false; }
+
+    /**
+     * This method returns a pointer to the IPv6 destination address.
+     *
+     * @returns A pointer to the IPv6 destination address.
+     *
+     */
+    const otIp6Address *GetDestAddr() const { return &mDestAddr; }
+
+    /**
+     * This method sets the IPv6 destination address.
+     *
+     * @param[in]  aAddr  A reference to the IPv6 destination address.
+     *
+     */
+    void SetDestAddr(otIp6Address &aAddr) { memcpy(mDestAddr.mFields.m8, aAddr.mFields.m8, sizeof(otIp6Address)); }
+
+    /**
+     * This method indicates whether the echo flag is set.
+     *
+     * @retval TRUE   If the echo flag is set.
+     * @retval FALSE  If the echo flag is not set.
+     *
+     */
+    bool GetEchoFlag(void) const { return IsFlagSet(kFlagEcho); }
+
+    /**
+     * This method sets the echo flag.
+     *
+     * @param[in]  aFlag  The echo flag.
+     *
+     */
+    void SetEchoFlag(bool aFlag) { aFlag ? SetFlag(kFlagEcho) : ClearFlag(kFlagEcho); }
+
+    /**
+     * This method returns the bandwidth value.
+     *
+     * @retval The bandwidth value (in bits/sec).
+     *
+     */
+    uint32_t GetBandwidth(void) const { return mBandwidth; }
+
+    /**
+     * This method sets the bandwidth value.
+     *
+     * @param[in]  aBandwidth  The bandwidth value (in bits/sec).
+     *
+     */
+    void SetBandwidth(uint32_t aBandwidth) { mBandwidth = aBandwidth; }
+
+    /**
+     * This method returns the length value.
+     *
+     * @retval The length value.
+     *
+     */
+    uint16_t GetLength(void) const { return mLength; }
+
+    /**
+     * This method sets the length value.
+     *
+     * @param[in]  aLength  The length value.
+     *
+     */
+    void SetLength(uint16_t aLength) { mLength = aLength; }
+
+    /**
+     * This method returns the report interval value.
+     *
+     * @retval The interval value (in milliseconds).
+     *
+     */
+    uint32_t GetInterval(void) const { return mInterval; }
+
+    /**
+     * This method sets the interval value.
+     *
+     * @param[in]  aLength  The interval value (in milliseconds).
+     *
+     */
+    void SetInterval(uint32_t aInterval) { mInterval = aInterval; }
+
+    /**
+     * This method returns the time value.
+     *
+     * @retval The time value (in milliseconds).
+     *
+     */
+    uint32_t GetTime(void) const { return mTime; }
+
+    /**
+     * This method sets the time value.
+     *
+     * @param[in]  aTime  The time value (in milliseconds).
+     *
+     */
+    void SetTime(uint32_t aTime) { mTime = aTime; }
+
+    /**
+     * This method returns the number value.
+     *
+     * @retval The number value.
+     *
+     */
+    uint32_t GetCount(void) const { return mCount; }
+
+    /**
+     * This method sets the count value.
+     *
+     * @param[in]  aCount  The count value.
+     *
+     */
+    void SetCount(uint32_t aCount) { mCount = aCount; }
+
+    /**
+     * This method returns the priority value.
+     *
+     * @retval The priority value.
+     *
+     */
+    otMessagePriority GetPriority(void) const { return mPriority; }
+
+    /**
+     * This method sets the priority value.
+     *
+     * @param[in]  aPriority  The priority value.
+     *
+     */
+    void SetPriority(otMessagePriority aPriority) { mPriority = aPriority; }
+
+    /**
+     * This method returns the session ID.
+     *
+     * @retval The session ID.
+     *
+     */
+    uint8_t GetSessionId(void) const { return mSessionId; }
+
+    /**
+     * This method sets the session ID.
+     *
+     * @param[in]  aSessionId  The session ID.
+     *
+     */
+    void SetSessionId(uint8_t aSessionId) { mSessionId = aSessionId; }
+
+    /**
+     * This method returns the fin delay value.
+     *
+     * @retval The fin delay value (in seconds).
+     *
+     */
+    uint8_t GetFinDelay(void) const { return mFinDelay; }
+
+    /**
+     * This method sets the fin delay value. The fin delay is the delay between the last sent data packet and the
+     * first sent FIN packet.
+     *
+     * @param[in]  aFinDelay  The fin delay value (in seconds).
+     *
+     */
+    void SetFinDelay(uint8_t aFinDelay) { mFinDelay = aFinDelay; }
+
+private:
+    enum
+    {
+        kDefaultBandwidth = 2000,  ///< Default bandwidth (in bits/sec).
+        kDefaultLength    = 64,    ///< Default length (in bytes).
+        kDefaultInterval  = 1000,  ///< Default interval of bandwidth reports (in milliseconds).
+        kDefaultTime      = 10000, ///< Default time to transmit for (in milliseconds).
+    };
+
+    uint16_t          mFlags;
+    uint16_t          mLength;
+    otIp6Address      mDestAddr;
+    uint32_t          mBandwidth;
+    uint32_t          mInterval;
+    uint32_t          mTime;
+    uint32_t          mCount;
+    otMessagePriority mPriority;
+    uint8_t           mSessionId;
+    uint8_t           mFinDelay;
+};
+
+/**
+ * This structure represents the context passed to UDP socket.
+ */
+struct otPerfContext
+{
+    Perf *   mPerf;    ///< A pointer to a Perf object.
+    Session *mSession; ///< A pointer to a Session object.
+};
+
+/**
+ * This class implements the session.
+ *
+ */
+class Session
+{
+public:
+    enum
+    {
+        kRoleClient,   ///< Client.
+        kRoleListener, ///< Listener.
+        kRoleServer,   ///< Server.
+    };
+
+    enum
+    {
+        kStateInvalid,       ///< Invalid.
+        kStateIdle,          ///< Idle.
+        kStateListening,     ///< Server is listening.
+        kStateSendingData,   ///< Client is sending data packets.
+        kStateReceivingData, ///< Server is receiving data packets.
+        kStateSendingFin,    ///< Client is sending Fin packets.
+        kStateReceivingFin,  ///< Server is receiving Fin packets.
+    };
+
+    /**
+     * This constructor initializes the Session object.
+     *
+     */
+    Session(void) {}
+
+    /**
+     * This constructor initializes the Session object.
+     *
+     * @param[in]  aPerf     A reference to a Perf object.
+     * @param[in]  aSetting  A reference to a Setting object.
+     * @param[in]  aRole     Session role.
+     *
+     */
+    Session(Perf &aPerf, const Setting &aSetting, uint8_t aRole);
+
+    /**
+     * This method gets the session role.
+     *
+     * @returns The session role.
+     *
+     */
+    uint8_t GetRole(void) const { return mRole; }
+
+    /**
+     * This method sets the session role.
+     *
+     * @param[in]  aRole   The session role.
+     *
+     */
+    void SetRole(uint8_t aRole) { mRole = aRole; }
+
+    /**
+     * This method indicates if the session is valid.
+     *
+     * @retval true   The session is valid.
+     * @retval false  The session is invalid.
+     *
+     */
+    bool IsStateValid(void) { return mState != kStateInvalid; }
+
+    /**
+     * This method closes the opened socket and set the session to invalid state.
+     *
+     */
+    void Free(void)
+    {
+        CloseSocket();
+        mState = kStateInvalid;
+    }
+
+    /**
+     * This method returns a reference to the setting object.
+     *
+     * @returns A reference to the setting object.
+     *
+     */
+    const Setting &GetSetting(void) { return *mSetting; }
+
+    /**
+     * This method returns a pointer to the socket context.
+     *
+     * @returns A pointer to the socket context.
+     *
+     */
+    otPerfContext *GetContext(void) { return &mContext; }
+
+    /**
+     * This method sets the socket context.
+     *
+     * @param[in]  aPerf     A reference to the Perf object.
+     * @param[in]  aSession  A reference to the Session object.
+     *
+     */
+    void SetContext(Perf &aPerf, Session &aSession)
+    {
+        mContext.mPerf    = &aPerf;
+        mContext.mSession = &aSession;
+    }
+
+    /**
+     * This method compares two timestamps.
+     *
+     * @param[in]  aTimeA  A reference to the first timestamp.
+     * @param[in]  aTimeB  A reference to the second timestamp.
+     *
+     * @retval -1  if @p aTimeA is less than @p aTimeB.
+     * @retval  0  if @p aTimeA is equal to @p aTimeB.
+     * @retval  1  if @p aTimeA is greater than @p aTimeB.
+     *
+     */
+    int TimeCompare(const uint32_t &aTimeA, const uint32_t &aTimeB)
+    {
+        uint32_t diff = aTimeA - aTimeB;
+
+        return (diff == 0) ? 0 : (((diff & (1UL << 31)) ? -1 : 1));
+    }
+
+    /**
+     * This method opens a socket and listens on the default port.
+     *
+     * @retval OT_ERROR_NONE    Successfully opened the socket and listened on the  default port.
+     * @retval OT_ERROR_FAILED  The role is not a listener or the state isn't idle.
+     * @retval OT_ERROR_ALREADY The socket has been opened.
+     */
+    otError PrepareReceive(void);
+
+    /**
+     * This method opens a socket and prepares to transmit packets.
+     *
+     * @param[in]  aSessionId  A default session ID. If user doesn't specify a session ID, the session will use it as
+     *                         the session ID.
+     *
+     * @retval OT_ERROR_NONE    Successfully opened the socket and prepared to transmit packets.
+     * @retval OT_ERROR_FAILED  Either the role is not a client, or the state isn't idle.
+     * @retval OT_ERROR_ALREADY The socket was already opened.
+     */
+    otError PrepareTransmit(uint8_t aSessionId);
+
+    /**
+     * This method processes the first received message.
+     *
+     * @param[in]  aMessage      A reference to the message.
+     * @param[in]  aMessageInfo  A reference to the message information.
+     *
+     * @retval OT_ERROR_NONE    Successfully processed the received message.
+     * @retval OT_ERROR_FAILED  Either the role is not a server, or the state isn't idle.
+     * @retval OT_ERROR_PARSE   The format of the received message is not correct.
+     */
+    otError HandleFistMessage(otMessage &aMessage, const otMessageInfo &aMessageInfo);
+
+    /**
+     * This method processes the subsequenct received messages.
+     *
+     * @param[in]  aMessage      A reference to the message.
+     * @param[in]  aMessageInfo  A reference to the message information.
+     */
+    void HandleSubsequentMessages(otMessage &aMessage, const otMessageInfo &aMessageInfo);
+
+    /**
+     * This method returns the timer delay interval.
+     *
+     * @param[out]  aInterval  A reference to the delay interval.
+     *
+     * @retval OT_ERROR_NONE           Successfully get delay interval.
+     * @retval OT_ERROR_INVALID_STATE  The session isn't in sending data, sending Fin or receiving Fin state.
+     */
+    otError GetDelayInterval(uint32_t &aInterval);
+
+    /**
+     * This method indicates if the message is sent to this session.
+     *
+     * @param[in]  aMessageInfo  A reference to the message information.
+     *
+     * @retval true  The message is sent to this session.
+     * @retval false The message isn't sent to this session.
+     */
+    bool MatchMsgInfo(const otMessageInfo &aMessageInfo);
+
+    /**
+     * This method handles the timer event.
+     *
+     */
+    void TimerFired(void);
+
+    /**
+     * This method prints the client report header.
+     *
+     */
+    void PrintClientReportHeader(void);
+
+private:
+    enum
+    {
+        kReportTypeInvalid   = 0, ///< Invalid report.
+        kReportTypeClient    = 1, ///< Client periodic report.
+        kReportTypeClientEnd = 2, ///< Client session end report.
+        kReportTypeServer    = 3, ///< Server periodic report.
+        kReportTypeServerEnd = 4, ///< Server session end report.
+    };
+
+    enum
+    {
+        kUdpPort              = 5001,       ///< Default listening port.
+        kMaxNumFin            = 20,         ///< Maximum number of FIN packets.
+        kFinIntervalUs        = 100000,     ///< Interval of sending FIN packets.
+        kMinSendingIntervalUs = 2000,       ///< Mimimum interval of sending data packets.
+        kInvalidTime          = UINT32_MAX, ///< Invalid time.
+    };
+
+    struct Stats
+    {
+        int32_t mJitter;          ///< The jitter value (in microseconds).
+        int64_t mRelativeLatency; ///< The relative latency (in microseconds) of the received packet.
+
+        uint64_t mCurBytes;         ///< Number of reveived bytes per reporting period.
+        uint32_t mCurCntDatagram;   ///< Number of received packets per reporting period.
+        uint32_t mCurCntOutOfOrder; ///< Number of out of order packets per reporting period.
+        uint32_t mCurCntError;      ///< Number of lost packets per reporting period.
+
+        uint32_t mCurMinLatency; ///< The minimum latency (in microseconds) per reporting period.
+        uint32_t mCurMaxLatency; ///< The maximum latency (in microseconds) per reporting period.
+        uint32_t mCurLatency;    ///< The sum of latency (in microseconds) per reporting period.
+
+        uint64_t mTotalBytes;         ///< Total number of received bytes.
+        uint32_t mTotalCntDatagram;   ///< Total number of received packets.
+        uint32_t mTotalCntOutOfOrder; ///< Total number of out of order packets.
+        uint32_t mTotalCntError;      ///< Total number of lost packets.
+
+        uint32_t mTotalMinLatency; ///< The minimum latency (in microseconds) for all received packets.
+        uint32_t mTotalMaxLatency; ///< The maximum latency (in microseconds) for all received packets.
+        uint32_t mTotalLatency;    ///< The sum of latency (in microseconds) for all received packets.
+
+        bool mLatencyValid; ///< Indicates whether the latency is valid.
+    };
+
+    struct Report
+    {
+        uint32_t mSessionId;        ///< Session ID.
+        uint32_t mStartTime;        ///< Start time of report.
+        uint32_t mEndTime;          ///< End time of report.
+        int32_t  mJitter;           ///< Jitter.
+        uint64_t mNumBytes;         ///< Total received bytes.
+        uint32_t mCntError;         ///< Number of lost packets.
+        uint32_t mCntDatagram;      ///< Total sent packets.
+        uint32_t mCntOutOfOrder;    ///< Number of out of order packets.
+        uint32_t mLatency;          ///< The sum of latency.
+        uint32_t mMinLatency;       ///< Minimum latency.
+        uint32_t mMaxLatency;       ///< Maximum latency.
+        uint8_t  mReportType : 3;   ///< Report type.
+        bool     mIsFormatCvs : 1;  ///< Indicates if the output format is CVS format.
+        bool     mLatencyValid : 1; ///< Indicates if the latency is valid.
+    };
+
+    struct PacketInfo
+    {
+        uint16_t mLength;          ///< Packet paylod length.
+        uint32_t mSeqNumber;       ///< Sequence number.
+        uint32_t mAbsoluteLatency; ///< Absolute latency.
+        int64_t  mRelativeLatency; ///< Relative latency.
+    };
+
+    void InitStats();
+    void InitCurrentStats();
+
+    otError  GetSynchronizedTime(uint64_t &aSyncTime);
+    void     GetPacketInfo(PerfHeader &aPerfHeader, uint64_t aMicroNow, PacketInfo &aPacketInfo);
+    void     UpdatePacketStats(PacketInfo &aPacketInfo);
+    uint32_t UsToTimerTime(uint32_t aTime);
+
+    otError OpenSocket(void);
+    void    CloseSocket(void);
+
+    otError SendData(void);
+    otError SendReply(PerfHeader &aPerfHeader, otMessagePriority aPriority, uint16_t aLength);
+    otError SendFin(void);
+
+    void PrintReport(Report &aReport, bool aServer);
+    void PrintConnection(void);
+    void PrintClientReport(void);
+    void PrintClientReportEnd(void);
+    void PrintServerReportHeader(void);
+    void PrintServerReport(void);
+    void PrintServerReportEnd(void);
+
+    otUdpSocket  mSocket;
+    otIp6Address mLocalAddr;
+    otIp6Address mPeerAddr;
+    uint16_t     mLocalPort;
+    uint16_t     mPeerPort;
+
+    uint32_t mFireTime;
+    uint32_t mSessionStartTime;
+    uint32_t mSessionEndTime;
+    uint32_t mPrintStartTime;
+    uint32_t mPrintEndTime;
+
+    uint32_t mSeqNumber;
+    uint32_t mSendingIntervalUs;
+    Stats    mStats;
+
+    otUdpSocket   mReplySocket;
+    otPerfContext mContext;
+
+    Perf *         mPerf;
+    const Setting *mSetting;
+
+    uint8_t mSessionId;
+    uint8_t mFinCounter;
+    uint8_t mRole : 2;
+    uint8_t mState : 3;
+    bool    mSocketValid : 1;
+    bool    mReplySocketValid : 1;
+};
+
+/**
+ * This class implements a CLI-based performance test tool.
+ *
+ */
+class Perf
+{
+    friend class Session;
+
+public:
+    /**
+     * Constructor
+     *
+     * @param[in]  aInterpreter  The CLI interpreter.
+     *
+     */
+    explicit Perf(Interpreter &aInterpreter);
+
+    /**
+     * This method interprets a list of CLI arguments.
+     *
+     * @param[in]  argc  The number of elements in argv.
+     * @param[in]  argv  A pointer to an array of command line arguments.
+     *
+     */
+    otError Process(int argc, char *argv[]);
+
+private:
+    struct Command
+    {
+        const char *mName;
+        otError (Perf::*mCommand)(int argc, char *argv[]);
+    };
+
+    enum
+    {
+        kNumSettings      = OPENTHREAD_CONFIG_CLI_PERF_NUM_SESSIONS,
+        kNumSessions      = OPENTHREAD_CONFIG_CLI_PERF_NUM_SESSIONS,
+        kMaxPayloadLength = Ip6::Ip6::kMaxDatagramLength - sizeof(Ip6::Header) - sizeof(Ip6::UdpHeader),
+    };
+
+    otError SetSetting(int argc, char *argv[], bool aClient, Setting &aSetting);
+    void    PrintSetting(Setting &aSetting);
+    otError ProcessHelp(int argc, char *argv[]);
+    otError ProcessClient(int argc, char *argv[]);
+    otError ProcessServer(int argc, char *argv[]);
+    otError ProcessStart(int argc, char *argv[]);
+    otError ProcessStop(int argc, char *argv[]);
+    otError ProcessSync(int argc, char *argv[]);
+    otError ProcessShow(int argc, char *argv[]);
+    otError ProcessClear(int argc, char *argv[]);
+
+    void    SessionStop(uint8_t aRole);
+    otError ServerStart(void);
+    otError ClientStart(void);
+    void    ServerStop(void);
+    void    ClientStop(void);
+
+    static void s_HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
+    void        HandleUdpReceive(otMessage *aMessage, const otMessageInfo *aMessageInfo, Session &aSession);
+
+    Session *NewSession(const Setting &aSetting, uint8_t aRole);
+    Session *FindSession(const otMessageInfo &aMessageInfo);
+    Session *FindValidSession(uint8_t aRole);
+    void     UpdateClientState(void);
+
+    Setting *NewSetting(void);
+    void     FreeSetting(Setting &aSetting);
+
+    static Perf &GetOwner(OwnerLocator &aOwnerLocator);
+
+    static void s_HandleTimer(Timer &aTimer);
+    void        HandleTimer(void);
+    otError     FindMinDelayInterval(uint32_t &aInterval);
+    void        StartTimer(void);
+
+    static const Command sCommands[];
+
+    bool mServerRunning : 1;
+    bool mClientRunning : 1;
+    bool mPrintServerHeaderFlag : 1;
+    bool mPrintClientHeaderFlag : 1;
+
+#if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
+    TimerMicro mTimer;
+#else
+    TimerMilli mTimer;
+#endif
+
+    Session  mSessions[kNumSessions];
+    Setting  mSettings[kNumSettings];
+    Setting *mServerSetting;
+
+    Interpreter &mInterpreter;
+    Instance *   mInstance;
+};
+
+} // namespace Cli
+} // namespace ot
+
+#endif // OPENTHREAD_CONFIG_CLI_PERF_ENABLE
+#endif // CLI_PERF_HPP_


### PR DESCRIPTION
This PR implements a performance tool for OpenThread. The performance
tool could be used to test throughput, loss rate, latency, jitter and
out of order for OpenThread. And the tool supports to test unicast,
multicast and echo streams. Besides, it has the ability to test multiple
streams simultaneously.