### PR TITLE
[commissioner] make start fail early if device role is invalid or detached

### DIFF
--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -144,6 +144,8 @@ otError Commissioner::Start(otCommissionerStateCallback  aStateCallback,
 {
     otError error = OT_ERROR_NONE;
 
+    otDeviceRole deviceRole = Get<Mle::MleRouter>().GetRole();
+    VerifyOrExit(deviceRole != OT_DEVICE_ROLE_DETACHED && deviceRole != OT_DEVICE_ROLE_DETACHED, error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(mState == OT_COMMISSIONER_STATE_DISABLED, error = OT_ERROR_INVALID_STATE);
 
     SuccessOrExit(error = Get<Coap::CoapSecure>().Start(SendRelayTransmit, this));


### PR DESCRIPTION
The commit fixed an issue that running "commissioner start" command when device role is detached cause commissioner to enter an invalid state. 