### PR TITLE
[commissioner] only allow attached device to become commissioner

### DIFF
--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -144,6 +144,9 @@ otError Commissioner::Start(otCommissionerStateCallback  aStateCallback,
 {
     otError error = OT_ERROR_NONE;
 
+    otDeviceRole deviceRole = Get<Mle::MleRouter>().GetRole();
+    VerifyOrExit(deviceRole != OT_DEVICE_ROLE_DISABLED && deviceRole != OT_DEVICE_ROLE_DETACHED,
+            error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(mState == OT_COMMISSIONER_STATE_DISABLED, error = OT_ERROR_INVALID_STATE);
 
     SuccessOrExit(error = Get<Coap::CoapSecure>().Start(SendRelayTransmit, this));

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -144,9 +144,7 @@ otError Commissioner::Start(otCommissionerStateCallback  aStateCallback,
 {
     otError error = OT_ERROR_NONE;
 
-    otDeviceRole deviceRole = Get<Mle::MleRouter>().GetRole();
-    VerifyOrExit(deviceRole != OT_DEVICE_ROLE_DISABLED && deviceRole != OT_DEVICE_ROLE_DETACHED,
-                 error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(Get<Mle::MleRouter>().IsAttached(), error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(mState == OT_COMMISSIONER_STATE_DISABLED, error = OT_ERROR_INVALID_STATE);
 
     SuccessOrExit(error = Get<Coap::CoapSecure>().Start(SendRelayTransmit, this));

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -146,7 +146,7 @@ otError Commissioner::Start(otCommissionerStateCallback  aStateCallback,
 
     otDeviceRole deviceRole = Get<Mle::MleRouter>().GetRole();
     VerifyOrExit(deviceRole != OT_DEVICE_ROLE_DISABLED && deviceRole != OT_DEVICE_ROLE_DETACHED,
-            error = OT_ERROR_INVALID_STATE);
+                 error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(mState == OT_COMMISSIONER_STATE_DISABLED, error = OT_ERROR_INVALID_STATE);
 
     SuccessOrExit(error = Get<Coap::CoapSecure>().Start(SendRelayTransmit, this));


### PR DESCRIPTION
The PR fixes the issue that running "commissioner start" command when device role is detached will cause commissioner not be able to start or stop.