### PR TITLE
[data-poll-handler] always process data poll when acked with "frame pending"

### DIFF
--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -154,8 +154,6 @@ void DataPollHandler::HandleDataPoll(Mac::RxFrame &aFrame)
         ExitNow();
     }
 
-    VerifyOrExit(!Get<SourceMatchController>().IsEnabled() || (indirectMsgCount > 0));
-
     if (mIndirectTxChild == NULL)
     {
         mIndirectTxChild = child;


### PR DESCRIPTION
----
This PR removes the extra check remaining from before the change from https://github.com/openthread/openthread/pull/3785 and the related follow-ups. Before having the "Acked with FP" feature, we relied on  number of indirect msg in queue (for the child) or state of src-match-table to determine/guess if the data poll was acked with fp or not. That is now redundant and can be incorrect (e.g., if a message was removed/evicted after data poll was acked with fp set). 

If the data poll is acked with "frame pending" flag set, the child would stay in rx expecting a frame from parent. If we have no frame for the child, parent would send an empty frame to let the child know that it can go to sleep (and avoid the child having a data timeout and retx the data poll).

This change is required for new platform abstractions like Thread over BLE (ToBLE) where we may not have the ack or frame-pending notion at the link layer and rely on next layer to follow a "data poll" with empty frame (when there is no pending frame). 
