### PR TITLE
 [data-poll-sender] always honor the default child timeout based poll interval

### DIFF
--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -431,7 +431,7 @@ uint32_t otLinkGetPollPeriod(otInstance *aInstance);
  *       Or zero to clear user-specified poll period.
  *
  * @note User-specified value should be no more than the maximal value 0x3FFFFFF ((1 << 26) - 1) allowed,
- * otherwise it would be cilpped by the maximal value.
+ * otherwise it would be clipped by the maximal value.
  *
  * @param[in]  aInstance    A pointer to an OpenThread instance.
  * @param[in]  aPollPeriod  data poll period in milliseconds.

--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -182,15 +182,11 @@ exit:
 
 uint32_t DataPollSender::GetKeepAlivePollPeriod(void) const
 {
-    uint32_t period = 0;
+    uint32_t period = GetDefaultPollPeriod();
 
     if (mExternalPollPeriod != 0)
     {
-        period = mExternalPollPeriod;
-    }
-    else
-    {
-        period = GetDefaultPollPeriod();
+        UpdateIfLarger(period, mExternalPollPeriod);
     }
 
     return period;
@@ -430,47 +426,41 @@ void DataPollSender::ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector)
     }
 }
 
+void DataPollSender::UpdateIfLarger(uint32_t &aPreiod, uint32_t aNewPeriod)
+{
+    if (aPreiod > aNewPeriod)
+    {
+        aPreiod = aNewPeriod;
+    }
+}
+
 uint32_t DataPollSender::CalculatePollPeriod(void) const
 {
-    uint32_t period = 0;
+    uint32_t period = GetDefaultPollPeriod();
 
     if (mAttachMode)
     {
-        period = kAttachDataPollPeriod;
+        UpdateIfLarger(period, kAttachDataPollPeriod);
     }
 
     if (mRetxMode)
     {
-        if ((period == 0) || (period > kRetxPollPeriod))
-        {
-            period = kRetxPollPeriod;
-        }
+        UpdateIfLarger(period, kRetxPollPeriod);
     }
 
     if (mRemainingFastPolls != 0)
     {
-        if ((period == 0) || (period > kFastPollPeriod))
-        {
-            period = kFastPollPeriod;
-        }
+        UpdateIfLarger(period, kFastPollPeriod);
     }
 
     if (mExternalPollPeriod != 0)
     {
-        if ((period == 0) || (period > mExternalPollPeriod))
-        {
-            period = mExternalPollPeriod;
-        }
+        UpdateIfLarger(period, mExternalPollPeriod);
     }
 
     if (period == 0)
     {
-        period = GetDefaultPollPeriod();
-
-        if (period == 0)
-        {
-            period = kMinPollPeriod;
-        }
+        period = kMinPollPeriod;
     }
 
     return period;

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -336,7 +336,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             {
                 TimeoutTlv tlv;
                 tlv.Init();
-                tlv.SetTimeout(TimerMilli::MsecToSec(Get<DataPollSender>().GetKeepAlivePollPeriod()));
+                tlv.SetTimeout(Get<Mle::MleRouter>().GetTimeout());
                 SuccessOrExit(error = aResponse.AppendTlv(tlv));
             }
 

--- a/tests/toranj/start.sh
+++ b/tests/toranj/start.sh
@@ -137,6 +137,7 @@ run test-031-meshcop-joiner-commissioner.py
 run test-032-child-attach-with-multiple-ip-addresses.py
 run test-033-mesh-local-prefix-change.py
 run test-034-poor-link-parent-child-attach.py
+run test-035-child-timeout-large-data-poll.py
 run test-100-mcu-power-state.py
 run test-600-channel-manager-properties.py
 run test-601-channel-manager-channel-change.py

--- a/tests/toranj/test-035-child-timeout-large-data-poll.py
+++ b/tests/toranj/test-035-child-timeout-large-data-poll.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+#  Copyright (c) 2019, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+
+import wpan
+import time
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test description:
+#
+# This test covers the situation where the data poll interval is set to a value larger than child's timeout interval.
+# The test verifies that the sleepy child would send a data poll within its timeout interval (ensuring hat child stays
+# in parent's child table).
+
+test_name = __file__[:-3] if __file__.endswith('.py') else __file__
+print('-' * 120)
+print('Starting \'{}\''.format(test_name))
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Creating `wpan.Nodes` instances
+
+speedup = 4
+wpan.Node.set_time_speedup_factor(speedup)
+
+parent = wpan.Node()
+child = wpan.Node()
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Init all nodes
+
+wpan.Node.init_all_nodes()
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test implementation
+
+parent.form("poll-timeout")
+
+TIMEOUT = 5   # Child timeout in seconds
+
+child.set(wpan.WPAN_THREAD_CHILD_TIMEOUT, str(TIMEOUT))
+
+child.set(wpan.WPAN_POLL_INTERVAL, str(5 * TIMEOUT * 1000))
+
+child.join_node(parent, node_type=wpan.JOIN_TYPE_SLEEPY_END_DEVICE)
+
+poll_count_before = int(child.get(wpan.WPAN_NCP_COUNTER_TX_PKT_DATA_POLL), 0)
+
+time.sleep(TIMEOUT * 1.1 / speedup)
+
+poll_count_after = int(child.get(wpan.WPAN_NCP_COUNTER_TX_PKT_DATA_POLL), 0)
+
+wpan.verify(poll_count_after > poll_count_before)
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test finished
+
+wpan.Node.finalize_all_nodes()
+
+print('\'{}\' passed.'.format(test_name))


### PR DESCRIPTION
This PR contains three related changes/commits.

It addresses an issue with child timing out on parent (kicked out of child table) if the data poll period is set (by user) to a value larger than the child's timeout.

    [network-diagnostics] use the child timeout directly
    
    This commit changes the `NetworkDiagnostic::FillRequestedTlvs()` to
    directly use the child timeout value in appended `TimeoutTlv`. This
    addresses an issue where a user-specified long data poll interval
    could cause the timeout TLV in diags response to be set higher than
    actual child's timeout value.

---------------

    [data-poll-sender] always honor the default child timeout based poll interval
    
    This commit changes the `DataPollSender` to ensure that a child device
    will always send a data poll within its timeout interval. This
    addresses an issue where a large user-specified poll period could
    cause the device to adopt a poll period longer than the default child
    timeout (causing parent to kick the child out of its child table).
    
    This commit also simplifies the selection code for a new poll period
    by adding a helper `UpdateIfLarger()` method to update the period only
    if it's larger than a given new value.

---------

    [toranj] add test to verify child sending data poll within its timeout
    
    This commit adds a `toranj` test-case. This test covers the situation
    where the data poll interval is set to a value larger than child's
    timeout interval. The test verifies that the sleepy child would send a
    data poll within its timeout interval (ensuring that child stays in
    parent's child table).

The new test does indeed fail without the change/fix from the second commit.