### PR TITLE
[cc2538] interrupt driven radio driver

### DIFF
--- a/examples/platforms/cc2538/openthread-core-cc2538-config.h
+++ b/examples/platforms/cc2538/openthread-core-cc2538-config.h
@@ -109,6 +109,20 @@
 #define OPENTHREAD_CONFIG_NCP_UART_ENABLE 1
 
 /**
+ * @def OPENTHREAD_CONFIG_CC2538_USE_RADIO_RX_INTERRUPT
+ *
+ * Enable support for using interrupt-driven radio reception.  This allows
+ * for a single frame to be received whilst the CPU is busy processing some
+ * other code.
+ *
+ * To disable interrupts and just rely on polling, set this to 0.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CC2538_USE_RADIO_RX_INTERRUPT
+#define OPENTHREAD_CONFIG_CC2538_USE_RADIO_RX_INTERRUPT 1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_CC2538_WITH_CC2592
  *
  * Enable support for the CC2592 range-extender front-end.

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -41,8 +41,6 @@
 #include "common/logging.hpp"
 #include "utils/code_utils.h"
 
-#define RFCORE_RXTX_INT (141)
-
 #define RFCORE_XREG_RFIRQM0 0x4008868C // RF interrupt masks
 #define RFCORE_XREG_RFIRQM1 0x40088690 // RF interrupt masks
 #define RFCORE_XREG_RFERRM 0x40088694  // RF error interrupt mask

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -661,7 +661,7 @@ void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable)
     }
 }
 
-void readFrame(otInstance *aInstance)
+static void readFrame(void)
 {
     uint8_t length;
     uint8_t crcCorr;
@@ -678,7 +678,7 @@ void readFrame(otInstance *aInstance)
 #error Time sync requires the timestamp of SFD rather than that of rx done!
 #else
     // Timestamp
-    if (otPlatRadioGetPromiscuous(aInstance))
+    if (cc2538RadioGetPromiscuous())
 #endif
     {
         // The current driver only supports milliseconds resolution.

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -743,11 +743,7 @@ void cc2538RadioProcess(otInstance *aInstance)
     HWREG(RFCORE_XREG_RFIRQM0) &= ~RFCORE_XREG_RFIRQM0_RXPKTDONE;
 #endif
 
-    if (sReceiveFrame.mLength == 0)
-    {
-        // sReceiveFrame is empty, so check for any received data.
-        readFrame();
-    }
+    readFrame();
 
 #if OPENTHREAD_CONFIG_LOG_PLATFORM && OPENTHREAD_CONFIG_CC2538_USE_RADIO_RX_INTERRUPT
     if (sDroppedFrameLength != 0)

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -667,6 +667,15 @@ static void readFrame(void)
     uint8_t crcCorr;
     int     i;
 
+    if (sReceiveFrame.mLength != 0)
+    {
+        /*
+         * There is already a frame present in the buffer, return early so
+         * we do not overwrite it (hopefully we'll catch it on the next run).
+         */
+        return;
+    }
+
     otEXPECT(sState == OT_RADIO_STATE_RECEIVE || sState == OT_RADIO_STATE_TRANSMIT);
     otEXPECT((HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_FIFOP) != 0);
 

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -667,14 +667,11 @@ static void readFrame(void)
     uint8_t crcCorr;
     int     i;
 
-    if (sReceiveFrame.mLength != 0)
-    {
-        /*
-         * There is already a frame present in the buffer, return early so
-         * we do not overwrite it (hopefully we'll catch it on the next run).
-         */
-        return;
-    }
+    /*
+     * There is already a frame present in the buffer, return early so
+     * we do not overwrite it (hopefully we'll catch it on the next run).
+     */
+    otEXPECT(sReceiveFrame.mLength == 0);
 
     otEXPECT(sState == OT_RADIO_STATE_RECEIVE || sState == OT_RADIO_STATE_TRANSMIT);
     otEXPECT((HWREG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_FIFOP) != 0);

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -818,7 +818,7 @@ void cc2538RadioProcess(otInstance *aInstance)
 void RFCoreRxTxIntHandler(void)
 {
 #if OPENTHREAD_CONFIG_CC2538_USE_RADIO_RX_INTERRUPT
-    if (RFCORE_SFR_RFIRQF0 & RFCORE_SFR_RFIRQF0_RXPKTDONE)
+    if (HWREG(RFCORE_SFR_RFIRQF0) & RFCORE_SFR_RFIRQF0_RXPKTDONE)
     {
         readFrame();
 

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -610,11 +610,16 @@ otRadioCaps otPlatRadioGetCaps(otInstance *aInstance)
     return OT_RADIO_CAPS_NONE;
 }
 
+static bool cc2538RadioGetPromiscuous(void)
+{
+    return (HWREG(RFCORE_XREG_FRMFILT0) & RFCORE_XREG_FRMFILT0_FRAME_FILTER_EN) == 0;
+}
+
 bool otPlatRadioGetPromiscuous(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    return (HWREG(RFCORE_XREG_FRMFILT0) & RFCORE_XREG_FRMFILT0_FRAME_FILTER_EN) == 0;
+    return cc2538RadioGetPromiscuous();
 }
 
 static int8_t cc2538RadioGetRssiOffset(void)

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -325,10 +325,12 @@ void cc2538RadioInit(void)
     sReceiveFrame.mLength  = 0;
     sReceiveFrame.mPsdu    = sReceivePsdu;
 
+#if OPENTHREAD_CONFIG_CC2538_USE_RADIO_RX_INTERRUPT
     // Enable interrupts for RX/TX, interrupt 141.
     // That's NVIC index 5 bit 13.
     HWREG(NVIC_EN0 + (5 * 4)) = (1 << 13);
     HWREG(RFCORE_XREG_RFIRQM0) |= RFCORE_XREG_RFIRQM0_RXPKTDONE;
+#endif
 
     // enable clock
     HWREG(SYS_CTRL_RCGCRFC) = SYS_CTRL_RCGCRFC_RFC0;

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -333,9 +333,9 @@ void cc2538RadioInit(void)
     sReceiveFrame.mPsdu    = sReceivePsdu;
 
 #if OPENTHREAD_CONFIG_CC2538_USE_RADIO_RX_INTERRUPT
-    // Enable interrupts for RX/TX, interrupt 141.
-    // That's NVIC index 5 bit 13.
-    HWREG(NVIC_EN0 + (5 * 4)) = (1 << 13);
+    // Enable interrupts for RX/TX, interrupt 26.
+    // That's NVIC index 0 (26 >> 5) bit 26 (26 & 0x1f).
+    HWREG(NVIC_EN0 + (0 * 4)) = (1 << 26);
     HWREG(RFCORE_XREG_RFIRQM0) |= RFCORE_XREG_RFIRQM0_RXPKTDONE;
 #endif
 


### PR DESCRIPTION
So, I have a confession to make… in PR#3609 I accidentally included some code that would have enabled the receive interrupt on the CC2538 in the NVIC.

Given the receive interrupt handler just blindly clears the interrupt flags, this is probably not a good plan.  So, a better option, implement the rest of it, with a compile-time switch to turn interrupt driven reception off if desired.  This allows for up to two frames to be stored until such time as they can be processed by OpenThread (one frame in the radio's buffer, and one in `sReceivedFrame`).

I'm doing some more thorough tests with the GRL test suite to ensure it hasn't broken anything but indications are it is working as expected (I'd be expecting failures left-right and centre if receive was broken by this).