### PR TITLE
[nrf528xx] remove default value for BuildJobs

### DIFF
--- a/examples/Makefile-nrf52811
+++ b/examples/Makefile-nrf52811
@@ -39,7 +39,6 @@ NM                              = arm-none-eabi-nm
 RANLIB                          = arm-none-eabi-ranlib
 OBJCOPY                         = arm-none-eabi-objcopy
 
-BuildJobs                      ?= 10
 GCCVersion                      = $(shell expr `$(CC) -dumpversion | cut -f1 -d.`)
 
 configure_OPTIONS                                 = \

--- a/examples/Makefile-nrf52840
+++ b/examples/Makefile-nrf52840
@@ -39,7 +39,6 @@ NM                              = arm-none-eabi-nm
 RANLIB                          = arm-none-eabi-ranlib
 OBJCOPY                         = arm-none-eabi-objcopy
 
-BuildJobs                      ?= 10
 GCCVersion                      = $(shell expr `$(CC) -dumpversion | cut -f1 -d.`)
 
 configure_OPTIONS                                 = \


### PR DESCRIPTION
Later in Makefile we set BuildJobs to the number of threads supported by CPU (only if this value is not set). Assigning default value of 10 limits performance on high performance PCs.