### PR TITLE
[crypto] don't add entropy source if it's done by mbedTLS

### DIFF
--- a/src/core/common/random_manager.cpp
+++ b/src/core/common/random_manager.cpp
@@ -149,14 +149,19 @@ uint32_t RandomManager::NonCryptoPrng::GetNext(void)
 void RandomManager::Entropy::Init(void)
 {
     mbedtls_entropy_init(&mEntropyContext);
+
+#ifndef OT_MBEDTLS_STRONG_DEFAULT_ENTROPY_PRESENT
     mbedtls_entropy_add_source(&mEntropyContext, &RandomManager::Entropy::HandleMbedtlsEntropyPoll, NULL,
                                MBEDTLS_ENTROPY_MIN_HARDWARE, MBEDTLS_ENTROPY_SOURCE_STRONG);
+#endif // OT_MBEDTLS_STRONG_DEFAULT_ENTROPY_PRESENT
 }
 
 void RandomManager::Entropy::Deinit(void)
 {
     mbedtls_entropy_free(&mEntropyContext);
 }
+
+#ifndef OT_MBEDTLS_STRONG_DEFAULT_ENTROPY_PRESENT
 
 int RandomManager::Entropy::HandleMbedtlsEntropyPoll(void *         aData,
                                                      unsigned char *aOutput,
@@ -175,6 +180,8 @@ exit:
     OT_UNUSED_VARIABLE(aData);
     return rval;
 }
+
+#endif // OT_MBEDTLS_STRONG_DEFAULT_ENTROPY_PRESENT
 
 //-------------------------------------------------------------------
 // CryptoCtrDrbg

--- a/src/core/common/random_manager.hpp
+++ b/src/core/common/random_manager.hpp
@@ -45,6 +45,11 @@
 
 #include "utils/wrap_stdint.h"
 
+#if (!defined(MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES) && \
+     (!defined(MBEDTLS_NO_PLATFORM_ENTROPY) || defined(MBEDTLS_HAVEGE_C) || defined(MBEDTLS_ENTROPY_HARDWARE_ALT)))
+#define OT_MBEDTLS_STRONG_DEFAULT_ENTROPY_PRESENT
+#endif
+
 namespace ot {
 
 /**
@@ -123,7 +128,9 @@ private:
         mbedtls_entropy_context *GetContext(void) { return &mEntropyContext; }
 
     private:
+#ifndef OT_MBEDTLS_STRONG_DEFAULT_ENTROPY_PRESENT
         static int HandleMbedtlsEntropyPoll(void *aData, unsigned char *aOutput, size_t aInLen, size_t *aOutLen);
+#endif // OT_MBEDTLS_STRONG_DEFAULT_ENTROPY_PRESENT
 
         mbedtls_entropy_context mEntropyContext;
     };

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -438,8 +438,6 @@ private:
     static void HandleUdpTransmit(Tasklet &aTasklet);
     void        HandleUdpTransmit(void);
 
-    static int HandleMbedtlsEntropyPoll(void *aData, unsigned char *aOutput, size_t aInLen, size_t *aOutLen);
-
     void Process(void);
 
     State mState;


### PR DESCRIPTION
If platform uses MbedTLS feature to add entropy source during context init (by platform entropy, HAVEGE or `MBEDTLS_ENTROPY_HARDWARE_ALT`) we shouldn't add second entropy source. This saves time and power as we don't have to poll two different entropy sources/poll same entropy source twice.