### PR TITLE
[posix-sim] add method route_list & route_table to Node

### DIFF
--- a/tests/scripts/thread-cert/test_route_table.py
+++ b/tests/scripts/thread-cert/test_route_table.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import unittest
+
+import node
+import config
+
+LEADER = 1
+ROUTER1 = 2
+ROUTER2 = 3
+
+# Topology:
+# LEADER -- ROUTER1 -- ROUTER2
+#
+
+
+class TestRouteTable(unittest.TestCase):
+    def setUp(self):
+        self.simulator = config.create_default_simulator()
+
+        self.nodes = {}
+        for i in range(1, 4):
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
+
+        self.nodes[LEADER].set_panid(0xface)
+        self.nodes[LEADER].set_mode('rsdn')
+        self.nodes[LEADER].add_whitelist(self.nodes[ROUTER1].get_addr64())
+        self.nodes[LEADER].enable_whitelist()
+
+        self.nodes[ROUTER1].set_panid(0xface)
+        self.nodes[ROUTER1].set_mode('rsdn')
+        self.nodes[ROUTER1].add_whitelist(self.nodes[LEADER].get_addr64())
+        self.nodes[ROUTER1].add_whitelist(self.nodes[ROUTER2].get_addr64())
+        self.nodes[ROUTER1].enable_whitelist()
+        self.nodes[ROUTER1].set_router_selection_jitter(1)
+
+        self.nodes[ROUTER2].set_panid(0xface)
+        self.nodes[ROUTER2].set_mode('rsdn')
+        self.nodes[ROUTER2].add_whitelist(self.nodes[ROUTER1].get_addr64())
+        self.nodes[ROUTER2].enable_whitelist()
+        self.nodes[ROUTER2].set_router_selection_jitter(1)
+
+    def tearDown(self):
+        for n in list(self.nodes.values()):
+            n.stop()
+            n.destroy()
+        self.simulator.stop()
+
+    def test(self):
+        self.nodes[LEADER].start()
+        self.simulator.go(5)
+        self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+
+        self.nodes[ROUTER1].start()
+        self.nodes[ROUTER2].start()
+        self.simulator.go(5)
+        self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
+        self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
+
+        self.simulator.go(100)
+
+        router_ids = set(_node.get_router_id() for _node in self.nodes.values())
+        for _node in self.nodes.values():
+            self.assertEqual(set(_node.router_list()), router_ids)
+
+        for _node in self.nodes.values():
+            router_table = _node.router_table()
+            self.assertEqual(set(router_table.keys()), router_ids)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/scripts/thread-cert/test_route_table.py
+++ b/tests/scripts/thread-cert/test_route_table.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-#  Copyright (c) 2017, The OpenThread Authors.
+#  Copyright (c) 2019, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
The commits implement the `router_list` and `router_table` methods for Node in simulator. The methods should be useful someday. 
The commits also include a simple test to verify correctness. 