### PR TITLE
[mac-frame] helper methods to copy ExtAddress in normal/reverse byte order

### DIFF
--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -156,14 +156,14 @@ exit:
 
 otError otLinkRawSrcMatchAddExtEntry(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
-    Mac::Address address;
-    otError      error    = OT_ERROR_NONE;
-    Instance &   instance = *static_cast<Instance *>(aInstance);
+    Mac::ExtAddress address;
+    otError         error    = OT_ERROR_NONE;
+    Instance &      instance = *static_cast<Instance *>(aInstance);
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = OT_ERROR_INVALID_STATE);
 
-    address.SetExtended(aExtAddress->m8, /* aReverse */ true);
-    error = instance.Get<Radio>().AddSrcMatchExtEntry(address.GetExtended());
+    address.Set(aExtAddress->m8, Mac::ExtAddress::kReverseByteOrder);
+    error = instance.Get<Radio>().AddSrcMatchExtEntry(address);
 
 exit:
     return error;
@@ -183,14 +183,14 @@ exit:
 
 otError otLinkRawSrcMatchClearExtEntry(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
-    Mac::Address address;
-    otError      error    = OT_ERROR_NONE;
-    Instance &   instance = *static_cast<Instance *>(aInstance);
+    Mac::ExtAddress address;
+    otError         error    = OT_ERROR_NONE;
+    Instance &      instance = *static_cast<Instance *>(aInstance);
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = OT_ERROR_INVALID_STATE);
 
-    address.SetExtended(aExtAddress->m8, /* aReverse */ true);
-    error = instance.Get<Radio>().ClearSrcMatchExtEntry(address.GetExtended());
+    address.Set(aExtAddress->m8, Mac::ExtAddress::kReverseByteOrder);
+    error = instance.Get<Radio>().ClearSrcMatchExtEntry(address);
 
 exit:
     return error;

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -66,20 +66,21 @@ ExtAddress::InfoString ExtAddress::ToString(void) const
     return InfoString("%02x%02x%02x%02x%02x%02x%02x%02x", m8[0], m8[1], m8[2], m8[3], m8[4], m8[5], m8[6], m8[7]);
 }
 
-void Address::SetExtended(const uint8_t *aBuffer, bool aReverse)
+void ExtAddress::CopyAddress(uint8_t *aDst, const uint8_t *aSrc, CopyByteOrder aByteOrder)
 {
-    mType = kTypeExtended;
+    switch (aByteOrder)
+    {
+    case kNormalByteOrder:
+        memcpy(aDst, aSrc, sizeof(ExtAddress));
+        break;
 
-    if (aReverse)
-    {
-        for (unsigned int i = 0; i < sizeof(ExtAddress); i++)
+    case kReverseByteOrder:
+        aSrc += sizeof(ExtAddress) - 1;
+        for (uint8_t len = sizeof(ExtAddress); len > 0; len--)
         {
-            mShared.mExtAddress.m8[i] = aBuffer[sizeof(ExtAddress) - 1 - i];
+            *aDst++ = *aSrc--;
         }
-    }
-    else
-    {
-        memcpy(mShared.mExtAddress.m8, aBuffer, sizeof(ExtAddress));
+        break;
     }
 }
 
@@ -275,7 +276,7 @@ otError Frame::GetDstAddr(Address &aAddress) const
         break;
 
     case kFcfDstAddrExt:
-        aAddress.SetExtended(GetPsdu() + index, /* reverse */ true);
+        aAddress.SetExtended(GetPsdu() + index, ExtAddress::kReverseByteOrder);
         break;
 
     default:
@@ -295,16 +296,12 @@ void Frame::SetDstAddr(ShortAddress aShortAddress)
 
 void Frame::SetDstAddr(const ExtAddress &aExtAddress)
 {
-    uint8_t  index = FindDstAddrIndex();
-    uint8_t *buf   = GetPsdu() + index;
+    uint8_t index = FindDstAddrIndex();
 
     assert((GetFrameControlField() & kFcfDstAddrMask) == kFcfDstAddrExt);
     assert(index != kInvalidIndex);
 
-    for (unsigned int i = 0; i < sizeof(ExtAddress); i++)
-    {
-        buf[i] = aExtAddress.m8[sizeof(ExtAddress) - 1 - i];
-    }
+    aExtAddress.CopyTo(GetPsdu() + index, ExtAddress::kReverseByteOrder);
 }
 
 void Frame::SetDstAddr(const Address &aAddress)
@@ -447,7 +444,7 @@ otError Frame::GetSrcAddr(Address &aAddress) const
         break;
 
     case kFcfSrcAddrExt:
-        aAddress.SetExtended(GetPsdu() + index, /* reverse */ true);
+        aAddress.SetExtended(GetPsdu() + index, ExtAddress::kReverseByteOrder);
         break;
 
     default:
@@ -471,16 +468,12 @@ void Frame::SetSrcAddr(ShortAddress aShortAddress)
 
 void Frame::SetSrcAddr(const ExtAddress &aExtAddress)
 {
-    uint8_t  index = FindSrcAddrIndex();
-    uint8_t *buf   = GetPsdu() + index;
+    uint8_t index = FindSrcAddrIndex();
 
     assert((GetFrameControlField() & kFcfSrcAddrMask) == kFcfSrcAddrExt);
     assert(index != kInvalidIndex);
 
-    for (unsigned int i = 0; i < sizeof(aExtAddress); i++)
-    {
-        buf[i] = aExtAddress.m8[sizeof(aExtAddress) - 1 - i];
-    }
+    aExtAddress.CopyTo(GetPsdu() + index, ExtAddress::kReverseByteOrder);
 }
 
 void Frame::SetSrcAddr(const Address &aAddress)

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -97,10 +97,33 @@ public:
     typedef String<kInfoStringSize> InfoString;
 
     /**
+     * This enumeration type specifies the copy byte order when Extended Address is being copied to/from a buffer.
+     *
+     */
+    enum CopyByteOrder
+    {
+        kNormalByteOrder,  // Copy address bytes in normal order (as provided in array buffer).
+        kReverseByteOrder, // Copy address bytes in reverse byte order.
+    };
+
+    /**
      * This method generates a random IEEE 802.15.4 Extended Address.
      *
      */
     void GenerateRandom(void);
+
+    /**
+     * This method sets the Extended Address from a given byte array.
+     *
+     * @param[in] aBuffer    Pointer to an array containing the Extended Address. `OT_EXT_ADDRESS_SIZE` bytes from
+     *                       buffer are copied to form the Extended Address.
+     * @param[in] aByteOrder The byte order to use when copying the address.
+     *
+     */
+    void Set(const uint8_t *aBuffer, CopyByteOrder aByteOrder = kNormalByteOrder)
+    {
+        CopyAddress(m8, aBuffer, aByteOrder);
+    }
 
     /**
      * This method indicates whether or not the Group bit is set.
@@ -169,6 +192,18 @@ public:
     void ToggleLocal(void) { m8[0] ^= kLocalFlag; }
 
     /**
+     * This method copies the Extended Address into a given buffer.
+     *
+     * @param[out] aBuffer     A pointer to a buffer to copy the Extended Address into.
+     * @param[in]  aByteOrder  The byte order to copy the address.
+     *
+     */
+    void CopyTo(uint8_t *aBuffer, CopyByteOrder aByteOrder = kNormalByteOrder) const
+    {
+        CopyAddress(aBuffer, m8, aByteOrder);
+    }
+
+    /**
      * This method evaluates whether or not the Extended Addresses match.
      *
      * @param[in]  aOther  The Extended Address to compare.
@@ -199,6 +234,8 @@ public:
     InfoString ToString(void) const;
 
 private:
+    static void CopyAddress(uint8_t *aDst, const uint8_t *aSrc, CopyByteOrder aByteOrder);
+
     enum
     {
         kGroupFlag = 1 << 0,
@@ -338,17 +375,20 @@ public:
     }
 
     /**
-     * This method sets the address with an Extended Address given as byte array.
+     * This method sets the address with an Extended Address given as a byte array.
      *
      * The type is also updated to indicate that the address is Extended.
      *
-     * @param[in]  aBuffer   Pointer to a array containing the Extended Address. `OT_EXT_ADDRESS_SIZE` bytes from buffer
-     *                       are copied to form the Extended Address.
-     * @param[in]  aReverse  If `true` then `OT_EXT_ADDRESS_SIZE` bytes from @p aBuffer are copied in reverse order,
-     *                       otherwise they are copied as provided.
+     * @param[in] aBuffer    Pointer to an array containing the Extended Address. `OT_EXT_ADDRESS_SIZE` bytes from
+     *                       buffer are copied to form the Extended Address.
+     * @param[in] aByteOrder The byte order to copy the address from @p aBuffer.
      *
      */
-    void SetExtended(const uint8_t *aBuffer, bool aReverse);
+    void SetExtended(const uint8_t *aBuffer, ExtAddress::CopyByteOrder aByteOrder = ExtAddress::kNormalByteOrder)
+    {
+        mShared.mExtAddress.Set(aBuffer, aByteOrder);
+        mType = kTypeExtended;
+    }
 
     /**
      * This method indicates whether or not the address is a Short Broadcast Address.

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -109,13 +109,13 @@ void SubMac::SetShortAddress(ShortAddress aShortAddress)
 
 void SubMac::SetExtAddress(const ExtAddress &aExtAddress)
 {
-    Address address;
+    ExtAddress address;
 
     mExtAddress = aExtAddress;
 
     // Reverse the byte order before setting on radio.
-    address.SetExtended(aExtAddress.m8, /* aReverse */ true);
-    Get<Radio>().SetExtendedAddress(address.GetExtended());
+    address.Set(aExtAddress.m8, ExtAddress::kReverseByteOrder);
+    Get<Radio>().SetExtendedAddress(address);
 
     otLogDebgMac("RadioExtAddress: %s", mExtAddress.ToString().AsCString());
 }

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -181,7 +181,7 @@ void Address::ToExtAddress(Mac::ExtAddress &aExtAddress) const
 
 void Address::ToExtAddress(Mac::Address &aMacAddress) const
 {
-    aMacAddress.SetExtended(mFields.m8 + kInterfaceIdentifierOffset, /* reverse */ false);
+    aMacAddress.SetExtended(mFields.m8 + kInterfaceIdentifierOffset);
     aMacAddress.GetExtended().ToggleLocal();
 }
 

--- a/src/core/thread/src_match_controller.cpp
+++ b/src/core/thread/src_match_controller.cpp
@@ -153,10 +153,10 @@ otError SourceMatchController::AddAddress(const Child &aChild)
     }
     else
     {
-        Mac::Address address;
+        Mac::ExtAddress address;
 
-        address.SetExtended(aChild.GetExtAddress().m8, /* aReverse */ true);
-        error = Get<Radio>().AddSrcMatchExtEntry(address.GetExtended());
+        address.Set(aChild.GetExtAddress().m8, Mac::ExtAddress::kReverseByteOrder);
+        error = Get<Radio>().AddSrcMatchExtEntry(address);
 
         otLogDebgMac("SrcAddrMatch - Adding addr: %s -- %s (%d)", aChild.GetExtAddress().ToString().AsCString(),
                      otThreadErrorToString(error), error);
@@ -185,10 +185,10 @@ void SourceMatchController::ClearEntry(Child &aChild)
     }
     else
     {
-        Mac::Address address;
+        Mac::ExtAddress address;
 
-        address.SetExtended(aChild.GetExtAddress().m8, /* aReverse */ true);
-        error = Get<Radio>().ClearSrcMatchExtEntry(address.GetExtended());
+        address.Set(aChild.GetExtAddress().m8, Mac::ExtAddress::kReverseByteOrder);
+        error = Get<Radio>().ClearSrcMatchExtEntry(address);
 
         otLogDebgMac("SrcAddrMatch - Clearing addr: %s -- %s (%d)", aChild.GetExtAddress().ToString().AsCString(),
                      otThreadErrorToString(error), error);

--- a/tests/unit/test_lowpan.hpp
+++ b/tests/unit/test_lowpan.hpp
@@ -72,7 +72,7 @@ public:
      * @param aAddress Pointer to the long MAC address.
      *
      */
-    void SetMacSource(const uint8_t *aAddress) { mMacSource.SetExtended(aAddress, /* reverse */ false); }
+    void SetMacSource(const uint8_t *aAddress) { mMacSource.SetExtended(aAddress); }
 
     /**
      * This method sets short MAC source address.
@@ -88,7 +88,7 @@ public:
      * @param aAddress Pointer to the long MAC address.
      *
      */
-    void SetMacDestination(const uint8_t *aAddress) { mMacDestination.SetExtended(aAddress, /* reverse */ false); }
+    void SetMacDestination(const uint8_t *aAddress) { mMacDestination.SetExtended(aAddress); }
 
     /**
      * This method sets short MAC destination address.


### PR DESCRIPTION
This commit updates `Mac::ExtAddress` and `Mac::Address` to add
helper methods to copy address from/to a byte array in normal or
reverse bye order. This commit also adds a unit test for the two
Address classes.