### PR TITLE
[mac] add Mac::ExtendedPanId type (wrapping otExtendedPanId)

### DIFF
--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -314,7 +314,8 @@ otError otCommissionerGeneratePSKc(otInstance *           aInstance,
     otError error = OT_ERROR_DISABLED_FEATURE;
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
-    error = MeshCoP::Commissioner::GeneratePSKc(aPassPhrase, aNetworkName, *aExtPanId, aPSKc);
+    error = MeshCoP::Commissioner::GeneratePSKc(aPassPhrase, aNetworkName,
+                                                *static_cast<const Mac::ExtendedPanId *>(aExtPanId), aPSKc);
 #else
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aPassPhrase);

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -71,7 +71,7 @@ otError otThreadSetExtendedPanId(otInstance *aInstance, const otExtendedPanId *a
 
     VerifyOrExit(instance.Get<Mle::MleRouter>().GetRole() == OT_DEVICE_ROLE_DISABLED, error = OT_ERROR_INVALID_STATE);
 
-    instance.Get<Mac::Mac>().SetExtendedPanId(*aExtendedPanId);
+    instance.Get<Mac::Mac>().SetExtendedPanId(*static_cast<const Mac::ExtendedPanId *>(aExtendedPanId));
 
     prefix.m8[0] = 0xfd;
     memcpy(&prefix.m8[1], aExtendedPanId->m8, 5);

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -414,20 +414,20 @@ public:
     void SetPanId(PanId aPanId);
 
     /**
-     * This method returns the IEEE 802.15.4 Extended PAN ID.
+     * This method returns the IEEE 802.15.4 Extended PAN Identifier.
      *
-     * @returns A pointer to the IEEE 802.15.4 Extended PAN ID.
+     * @returns The IEEE 802.15.4 Extended PAN Identifier.
      *
      */
-    const otExtendedPanId &GetExtendedPanId(void) const { return mExtendedPanId; }
+    const ExtendedPanId &GetExtendedPanId(void) const { return mExtendedPanId; }
 
     /**
-     * This method sets the IEEE 802.15.4 Extended PAN ID.
+     * This method sets the IEEE 802.15.4 Extended PAN Identifier.
      *
-     * @param[in]  aExtendedPanId  The IEEE 802.15.4 Extended PAN ID.
+     * @param[in]  aExtendedPanId  The IEEE 802.15.4 Extended PAN Identifier.
      *
      */
-    void SetExtendedPanId(const otExtendedPanId &aExtendedPanId);
+    void SetExtendedPanId(const ExtendedPanId &aExtendedPanId);
 
     /**
      * This method is called to handle a received frame.
@@ -703,20 +703,20 @@ private:
     bool mDelayingSleep : 1;
 #endif
 
-    Operation       mOperation;
-    uint8_t         mBeaconSequence;
-    uint8_t         mDataSequence;
-    uint8_t         mBroadcastTransmitCount;
-    PanId           mPanId;
-    uint8_t         mPanChannel;
-    uint8_t         mRadioChannel;
-    uint16_t        mRadioChannelAcquisitionId;
-    ChannelMask     mSupportedChannelMask;
-    otExtendedPanId mExtendedPanId;
-    otNetworkName   mNetworkName;
-    uint8_t         mScanChannel;
-    uint16_t        mScanDuration;
-    ChannelMask     mScanChannelMask;
+    Operation     mOperation;
+    uint8_t       mBeaconSequence;
+    uint8_t       mDataSequence;
+    uint8_t       mBroadcastTransmitCount;
+    PanId         mPanId;
+    uint8_t       mPanChannel;
+    uint8_t       mRadioChannel;
+    uint16_t      mRadioChannelAcquisitionId;
+    ChannelMask   mSupportedChannelMask;
+    ExtendedPanId mExtendedPanId;
+    otNetworkName mNetworkName;
+    uint8_t       mScanChannel;
+    uint16_t      mScanDuration;
+    ChannelMask   mScanChannelMask;
     union
     {
         ActiveScanHandler mActiveScanHandler;

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -89,6 +89,21 @@ Address::InfoString Address::ToString(void) const
                                     : (mType == kTypeNone ? InfoString("None") : InfoString("0x%04x", GetShort()));
 }
 
+bool ExtendedPanId::operator==(const ExtendedPanId &aOther) const
+{
+    return memcmp(m8, aOther.m8, sizeof(ExtendedPanId)) == 0;
+}
+
+bool ExtendedPanId::operator!=(const ExtendedPanId &aOther) const
+{
+    return memcmp(m8, aOther.m8, sizeof(ExtendedPanId)) != 0;
+}
+
+ExtendedPanId::InfoString ExtendedPanId::ToString(void) const
+{
+    return InfoString("%02x%02x%02x%02x%02x%02x%02x%02x", m8[0], m8[1], m8[2], m8[3], m8[4], m8[5], m8[6], m8[7]);
+}
+
 void Frame::InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl)
 {
     uint8_t *bytes  = GetPsdu();
@@ -1131,15 +1146,13 @@ Frame::InfoString Frame::ToInfoString(void) const
 
 BeaconPayload::InfoString BeaconPayload::ToInfoString(void) const
 {
-    const uint8_t *xpanid = GetExtendedPanId();
-    otNetworkName  networkname;
+    otNetworkName networkname;
 
     strlcpy(networkname.m8, GetNetworkName(), sizeof(networkname.m8));
 
-    return InfoString("name:%s, xpanid:%02x%02x%02x%02x%02x%02x%02x%02x, id:%d ver:%d, joinable:%s, native:%s",
-                      networkname.m8, xpanid[0], xpanid[1], xpanid[2], xpanid[3], xpanid[4], xpanid[5], xpanid[6],
-                      xpanid[7], GetProtocolId(), GetProtocolVersion(), IsJoiningPermitted() ? "yes" : "no",
-                      IsNative() ? "yes" : "no");
+    return InfoString("name:%s, xpanid:%s, id:%d, ver:%d, joinable:%s, native:%s", networkname.m8,
+                      mExtendedPanId.ToString().AsCString(), GetProtocolId(), GetProtocolVersion(),
+                      IsJoiningPermitted() ? "yes" : "no", IsNative() ? "yes" : "no");
 }
 
 #endif // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE) && (OPENTHREAD_CONFIG_LOG_MAC == 1)

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -385,6 +385,57 @@ private:
 };
 
 /**
+ * This structure represents an IEEE 802.15.4 Extended PAN Identifier.
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+class ExtendedPanId : public otExtendedPanId
+{
+public:
+    enum
+    {
+        kInfoStringSize = 17, // Max chars for the info string (`ToString()`).
+    };
+
+    /**
+     * This type defines the fixed-length `String` object returned from `ToString()`.
+     *
+     */
+    typedef String<kInfoStringSize> InfoString;
+
+    /**
+     * This method evaluates whether or not the Extended PAN Identifiers match.
+     *
+     * @param[in]  aOther  The Extended PAN Id to compare.
+     *
+     * @retval TRUE   If the Extended PAN Identifiers match.
+     * @retval FALSE  If the Extended PAN Identifiers do not match.
+     *
+     */
+    bool operator==(const ExtendedPanId &aOther) const;
+
+    /**
+     * This method evaluates whether or not the Extended PAN Identifiers match.
+     *
+     * @param[in]  aOther  The Extended PAN Id to compare.
+     *
+     * @retval TRUE   If the Extended Addresses do not match.
+     * @retval FALSE  If the Extended Addresses match.
+     *
+     */
+    bool operator!=(const ExtendedPanId &aOther) const;
+
+    /**
+     * This method converts an address to a string.
+     *
+     * @returns An `InfoString` containing the string representation of the Extended PAN Identifier.
+     *
+     */
+    InfoString ToString(void) const;
+
+} OT_TOOL_PACKED_END;
+
+/**
  * This class implements IEEE 802.15.4 IE (Information Element) generation and parsing.
  *
  */
@@ -1502,7 +1553,6 @@ public:
     {
         kProtocolId      = 3,  ///< Thread Protocol ID.
         kNetworkNameSize = 16, ///< Size of Thread Network Name (bytes).
-        kExtPanIdSize    = 8,  ///< Size of Thread Extended PAN ID.
         kInfoStringSize  = 92, ///< Max chars for the info string (@sa ToInfoString()).
     };
 
@@ -1628,20 +1678,20 @@ public:
     }
 
     /**
-     * This method returns a pointer to the Extended PAN ID field.
+     * This method returns the Extended PAN ID field.
      *
-     * @returns A pointer to the Extended PAN ID field.
+     * @returns The Extended PAN ID field.
      *
      */
-    const uint8_t *GetExtendedPanId(void) const { return mExtendedPanId; }
+    const ExtendedPanId &GetExtendedPanId(void) const { return mExtendedPanId; }
 
     /**
      * This method sets the Extended PAN ID field.
      *
-     * @param[in]  aExtPanId  A pointer to the Extended PAN ID.
+     * @param[in]  aExtPanId  An Extended PAN ID.
      *
      */
-    void SetExtendedPanId(const uint8_t *aExtPanId) { memcpy(mExtendedPanId, aExtPanId, sizeof(mExtendedPanId)); }
+    void SetExtendedPanId(const ExtendedPanId &aExtPanId) { mExtendedPanId = aExtPanId; }
 
     /**
      * This method returns information about the Beacon as a `InfoString`.
@@ -1652,10 +1702,10 @@ public:
     InfoString ToInfoString(void) const;
 
 private:
-    uint8_t mProtocolId;
-    uint8_t mFlags;
-    char    mNetworkName[kNetworkNameSize];
-    uint8_t mExtendedPanId[kExtPanIdSize];
+    uint8_t       mProtocolId;
+    uint8_t       mFlags;
+    char          mNetworkName[kNetworkNameSize];
+    ExtendedPanId mExtendedPanId;
 } OT_TOOL_PACKED_END;
 
 /**

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -1090,10 +1090,10 @@ exit:
     return error;
 }
 
-otError Commissioner::GeneratePSKc(const char *           aPassPhrase,
-                                   const char *           aNetworkName,
-                                   const otExtendedPanId &aExtPanId,
-                                   uint8_t *              aPSKc)
+otError Commissioner::GeneratePSKc(const char *              aPassPhrase,
+                                   const char *              aNetworkName,
+                                   const Mac::ExtendedPanId &aExtPanId,
+                                   uint8_t *                 aPSKc)
 {
     otError     error      = OT_ERROR_NONE;
     const char *saltPrefix = "Thread";

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -216,10 +216,10 @@ public:
      * @retval OT_ERROR_INVALID_ARGS  If the length of passphrase is out of range.
      *
      */
-    static otError GeneratePSKc(const char *           aPassPhrase,
-                                const char *           aNetworkName,
-                                const otExtendedPanId &aExtPanId,
-                                uint8_t *              aPSKc);
+    static otError GeneratePSKc(const char *              aPassPhrase,
+                                const char *              aNetworkName,
+                                const Mac::ExtendedPanId &aExtPanId,
+                                uint8_t *                 aPSKc);
 
     /**
      * This method returns a reference to the AnnounceBeginClient instance.

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -40,6 +40,7 @@
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
 #include "common/logging.hpp"
+#include "mac/mac_frame.hpp"
 #include "meshcop/meshcop_tlvs.hpp"
 #include "thread/mle_tlvs.hpp"
 
@@ -303,7 +304,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
     {
         MeshCoP::ExtendedPanIdTlv tlv;
         tlv.Init();
-        tlv.SetExtendedPanId(aDataset.mExtendedPanId);
+        tlv.SetExtendedPanId(static_cast<const Mac::ExtendedPanId &>(aDataset.mExtendedPanId));
         Set(tlv);
     }
 

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -486,7 +486,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
     {
         ExtendedPanIdTlv extpanid;
         extpanid.Init();
-        extpanid.SetExtendedPanId(aDataset.mExtendedPanId);
+        extpanid.SetExtendedPanId(static_cast<const Mac::ExtendedPanId &>(aDataset.mExtendedPanId));
         SuccessOrExit(error = message->AppendTlv(extpanid));
     }
 

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -47,6 +47,7 @@
 #include "common/encoding.hpp"
 #include "common/message.hpp"
 #include "common/tlvs.hpp"
+#include "mac/mac_frame.hpp"
 #include "meshcop/timestamp.hpp"
 #include "net/ip6_address.hpp"
 #include "radio/radio.hpp"
@@ -361,18 +362,18 @@ public:
      * @returns The Extended PAN ID value.
      *
      */
-    const otExtendedPanId &GetExtendedPanId(void) const { return mExtendedPanId; }
+    const Mac::ExtendedPanId &GetExtendedPanId(void) const { return mExtendedPanId; }
 
     /**
      * This method sets the Extended PAN ID value.
      *
-     * @param[in]  aExtendedPanId  A pointer to the Extended PAN ID value.
+     * @param[in]  aExtendedPanId  An Extended PAN ID value.
      *
      */
-    void SetExtendedPanId(const otExtendedPanId &aExtendedPanId) { mExtendedPanId = aExtendedPanId; }
+    void SetExtendedPanId(const Mac::ExtendedPanId &aExtendedPanId) { mExtendedPanId = aExtendedPanId; }
 
 private:
-    otExtendedPanId mExtendedPanId;
+    Mac::ExtendedPanId mExtendedPanId;
 } OT_TOOL_PACKED_END;
 
 /**

--- a/tests/unit/test_pskc.cpp
+++ b/tests/unit/test_pskc.cpp
@@ -45,7 +45,8 @@ void TestMinimumPassphrase(void)
                                     0xcc, 0xd1, 0xe4, 0xc0, 0x1d, 0x01, 0x54, 0xf8};
     const char    passphrase[]   = "123456";
     otInstance *  instance       = testInitInstance();
-    SuccessOrQuit(ot::MeshCoP::Commissioner::GeneratePSKc(passphrase, "OpenThread", sXPanId, pskc),
+    SuccessOrQuit(ot::MeshCoP::Commissioner::GeneratePSKc(passphrase, "OpenThread",
+                                                          static_cast<const ot::Mac::ExtendedPanId &>(sXPanId), pskc),
                   "TestMinimumPassphrase failed to generate PSKc");
     VerifyOrQuit(memcmp(pskc, expectedPskc, sizeof(pskc)) == 0, "TestMinimumPassphrase got wrong pskc");
     testFreeInstance(instance);
@@ -74,7 +75,8 @@ void TestMaximumPassphrase(void)
                               "123456781234567";
 
     otInstance *instance = testInitInstance();
-    SuccessOrQuit(ot::MeshCoP::Commissioner::GeneratePSKc(passphrase, "OpenThread", sXPanId, pskc),
+    SuccessOrQuit(ot::MeshCoP::Commissioner::GeneratePSKc(passphrase, "OpenThread",
+                                                          static_cast<const ot::Mac::ExtendedPanId &>(sXPanId), pskc),
                   "TestMaximumPassphrase failed to generate PSKc");
     VerifyOrQuit(memcmp(pskc, expectedPskc, sizeof(pskc)) == 0, "TestMaximumPassphrase got wrong pskc");
     testFreeInstance(instance);


### PR DESCRIPTION
The wrapper class `Mac::ExtendedPanId` mainly defines overloads of operators `==` and `!=` and `ToString()` method.