### PR TITLE
[tlv] simplify searching for a TLV or an Extended TLV within a message

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -407,6 +407,11 @@ otError Message::AppendTlv(const Tlv &aTlv)
     return Append(&aTlv, aTlv.GetSize());
 }
 
+otError Message::AppendTlv(const ExtendedTlv &aExtendedTlv)
+{
+    return Append(&aExtendedTlv, aExtendedTlv.GetSize());
+}
+
 otError Message::Prepend(const void *aBuf, uint16_t aLength)
 {
     otError error     = OT_ERROR_NONE;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -415,6 +415,19 @@ public:
     otError AppendTlv(const Tlv &aTlv);
 
     /**
+     * This method appends an Extended TLV to the end of the message.
+     *
+     * On success, this method grows the message by the size of the Extended TLV.
+     *
+     * @param[in]  aExtendedTlv  A reference to an Extended TLV.
+     *
+     * @retval OT_ERROR_NONE     Successfully appended the Extended TLV to the message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
+     *
+     */
+    otError AppendTlv(const ExtendedTlv &aExtendedTlv);
+
+    /**
      * This method reads bytes from the message.
      *
      * @param[in]  aOffset  Byte offset within the message to begin reading.

--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -38,20 +38,20 @@
 
 namespace ot {
 
-otError Tlv::Get(const Message &aMessage, uint8_t aType, uint16_t aMaxLength, Tlv &aTlv)
+otError Tlv::Get(const Message &aMessage, uint8_t aType, uint16_t aMaxSize, Tlv &aTlv)
 {
-    otError  error = OT_ERROR_NOT_FOUND;
+    otError  error;
     uint16_t offset;
+    uint16_t size;
 
-    SuccessOrExit(error = GetOffset(aMessage, aType, offset));
-    aMessage.Read(offset, sizeof(Tlv), &aTlv);
+    SuccessOrExit(error = Find(aMessage, aType, &offset, &size, NULL));
 
-    if (aMaxLength > sizeof(aTlv) + aTlv.GetLength())
+    if (aMaxSize > size)
     {
-        aMaxLength = sizeof(aTlv) + aTlv.GetLength();
+        aMaxSize = size;
     }
 
-    aMessage.Read(offset, aMaxLength, &aTlv);
+    aMessage.Read(offset, aMaxSize, &aTlv);
 
 exit:
     return error;
@@ -59,77 +59,83 @@ exit:
 
 otError Tlv::GetOffset(const Message &aMessage, uint8_t aType, uint16_t &aOffset)
 {
-    otError  error  = OT_ERROR_NOT_FOUND;
-    uint16_t offset = aMessage.GetOffset();
-    uint16_t end    = aMessage.GetLength();
-    Tlv      tlv;
+    return Find(aMessage, aType, &aOffset, NULL, NULL);
+}
 
-    while (offset + sizeof(tlv) <= end)
+otError Tlv::GetValueOffset(const Message &aMessage, uint8_t aType, uint16_t &aValueOffset, uint16_t &aLength)
+{
+    otError  error;
+    uint16_t offset;
+    uint16_t size;
+    bool     isExtendedTlv;
+
+    SuccessOrExit(error = Find(aMessage, aType, &offset, &size, &isExtendedTlv));
+
+    if (!isExtendedTlv)
     {
-        uint32_t length = sizeof(tlv);
-
-        aMessage.Read(offset, sizeof(tlv), &tlv);
-
-        if (tlv.GetLength() != kExtendedLength)
-        {
-            length += tlv.GetLength();
-        }
-        else
-        {
-            uint16_t extLength;
-
-            VerifyOrExit(sizeof(extLength) == aMessage.Read(offset + sizeof(tlv), sizeof(extLength), &extLength));
-            length += sizeof(extLength) + HostSwap16(extLength);
-        }
-
-        VerifyOrExit(offset + length <= end);
-
-        if (tlv.GetType() == aType)
-        {
-            aOffset = offset;
-            ExitNow(error = OT_ERROR_NONE);
-        }
-
-        offset += static_cast<uint16_t>(length);
+        aValueOffset = offset + sizeof(Tlv);
+        aLength      = size - sizeof(Tlv);
+    }
+    else
+    {
+        aValueOffset = offset + sizeof(ExtendedTlv);
+        aLength      = size - sizeof(ExtendedTlv);
     }
 
 exit:
     return error;
 }
 
-otError Tlv::GetValueOffset(const Message &aMessage, uint8_t aType, uint16_t &aOffset, uint16_t &aLength)
+otError Tlv::Find(const Message &aMessage, uint8_t aType, uint16_t *aOffset, uint16_t *aSize, bool *aIsExtendedTlv)
 {
     otError  error  = OT_ERROR_NOT_FOUND;
     uint16_t offset = aMessage.GetOffset();
     uint16_t end    = aMessage.GetLength();
     Tlv      tlv;
+    uint16_t size;
 
-    while (offset + sizeof(tlv) <= end)
+    while (true)
     {
-        uint16_t length;
+        VerifyOrExit(offset + sizeof(Tlv) <= end);
+        aMessage.Read(offset, sizeof(Tlv), &tlv);
 
-        aMessage.Read(offset, sizeof(tlv), &tlv);
-        offset += sizeof(tlv);
-        length = tlv.GetLength();
-
-        if (length == kExtendedLength)
+        if (tlv.mLength != kExtendedLength)
         {
-            VerifyOrExit(offset + sizeof(length) <= end);
-            aMessage.Read(offset, sizeof(length), &length);
-            offset += sizeof(length);
-            length = HostSwap16(length);
+            size = tlv.GetSize();
+        }
+        else
+        {
+            ExtendedTlv extTlv;
+
+            VerifyOrExit(offset + sizeof(ExtendedTlv) <= end);
+            aMessage.Read(offset, sizeof(ExtendedTlv), &extTlv);
+            size = extTlv.GetSize();
         }
 
-        VerifyOrExit(length <= end - offset);
+        VerifyOrExit(offset + size <= end);
 
         if (tlv.GetType() == aType)
         {
-            aOffset = offset;
-            aLength = length;
-            ExitNow(error = OT_ERROR_NONE);
+            if (aOffset != NULL)
+            {
+                *aOffset = offset;
+            }
+
+            if (aSize != NULL)
+            {
+                *aSize = size;
+            }
+
+            if (aIsExtendedTlv != NULL)
+            {
+                *aIsExtendedTlv = (tlv.mLength == kExtendedLength);
+            }
+
+            error = OT_ERROR_NONE;
+            ExitNow();
         }
 
-        offset += length;
+        offset += size;
     }
 
 exit:

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -120,7 +120,7 @@ public:
      * @returns A pointer to the next TLV.
      *
      */
-    Tlv *GetNext(void) { return reinterpret_cast<Tlv *>(reinterpret_cast<uint8_t *>(this) + sizeof(*this) + mLength); }
+    Tlv *GetNext(void) { return reinterpret_cast<Tlv *>(reinterpret_cast<uint8_t *>(this) + GetSize()); }
 
     /**
      * This method returns a pointer to the next TLV.
@@ -130,7 +130,7 @@ public:
      */
     const Tlv *GetNext(void) const
     {
-        return reinterpret_cast<const Tlv *>(reinterpret_cast<const uint8_t *>(this) + sizeof(*this) + mLength);
+        return reinterpret_cast<const Tlv *>(reinterpret_cast<const uint8_t *>(this) + GetSize());
     }
 
     /**
@@ -138,14 +138,14 @@ public:
      *
      * @param[in]   aMessage    A reference to the message.
      * @param[in]   aType       The Type value to search for.
-     * @param[in]   aMaxLength  Maximum number of bytes to read.
+     * @param[in]   aMaxSize    Maximum number of bytes to read.
      * @param[out]  aTlv        A reference to the TLV that will be copied to.
      *
      * @retval OT_ERROR_NONE       Successfully copied the TLV.
      * @retval OT_ERROR_NOT_FOUND  Could not find the TLV with Type @p aType.
      *
      */
-    static otError Get(const Message &aMessage, uint8_t aType, uint16_t aMaxLength, Tlv &aTlv);
+    static otError Get(const Message &aMessage, uint8_t aType, uint16_t aMaxSize, Tlv &aTlv);
 
     /**
      * This static method obtains the offset of a TLV within @p aMessage.
@@ -175,16 +175,35 @@ public:
     static otError GetValueOffset(const Message &aMessage, uint8_t aType, uint16_t &aOffset, uint16_t &aLength);
 
 protected:
-    /**
-     * Length values.
-     *
-     */
     enum
     {
         kExtendedLength = 255, ///< Extended Length value
     };
 
 private:
+    /**
+     * This private static method searches within a given message for TLV type and outputs the TLV offset, size and
+     * whether it is an Extended TLV.
+     *
+     * A NULL pointer can be used for output parameters @p aOffset, @p aSize, or @p aIsExtendedTlv if the parameter
+     * is not required.
+     *
+     * @param[in]   aMessage       A reference to the message to search within.
+     * @param[in]   aType          The TLV type to search for.
+     * @param[out]  aOffset        A pointer to a variable to output the offset to the start of the TLV.
+     * @param[out]  aSize          A pointer to a variable to output the size (total number of bytes) of the TLV.
+     * @param[out]  aIsExtendedTlv A pointer to a boolean variable to output whether the found TLV is extended or not.
+     *
+     * @retval OT_ERROR_NONE       Successfully found the TLV.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the TLV with Type @p aType.
+     *
+     */
+    static otError Find(const Message &aMessage,
+                        uint8_t        aType,
+                        uint16_t *     aOffset,
+                        uint16_t *     aSize,
+                        bool *         aIsExtendedTlv);
+
     uint8_t mType;
     uint8_t mLength;
 } OT_TOOL_PACKED_END;
@@ -209,6 +228,49 @@ public:
     {
         Tlv::SetLength(kExtendedLength);
         mLength = HostSwap16(aLength);
+    }
+
+    /**
+     * This method returns the total size including Type, Length, and Value fields.
+     *
+     * @returns The total size include Type, Length, and Value fields.
+     *
+     */
+    uint16_t GetSize(void) const { return sizeof(ExtendedTlv) + GetLength(); }
+
+    /**
+     * This method returns a pointer to the Value.
+     *
+     * @returns A pointer to the value.
+     *
+     */
+    uint8_t *GetValue(void) { return reinterpret_cast<uint8_t *>(this) + sizeof(ExtendedTlv); }
+
+    /**
+     * This method returns a pointer to the Value.
+     *
+     * @returns A pointer to the value.
+     *
+     */
+    const uint8_t *GetValue(void) const { return reinterpret_cast<const uint8_t *>(this) + sizeof(ExtendedTlv); }
+
+    /**
+     * This method returns a pointer to the next TLV.
+     *
+     * @returns A pointer to the next TLV.
+     *
+     */
+    Tlv *GetNext(void) { return reinterpret_cast<Tlv *>(reinterpret_cast<uint8_t *>(this) + GetSize()); }
+
+    /**
+     * This method returns a pointer to the next TLV.
+     *
+     * @returns A pointer to the next TLV.
+     *
+     */
+    const Tlv *GetNext(void) const
+    {
+        return reinterpret_cast<const Tlv *>(reinterpret_cast<const uint8_t *>(this) + GetSize());
     }
 
 private:


### PR DESCRIPTION
This commit contains the following:

- Adds `GetSize()`, `GetValue()` and `GetNext()` to `ExtendedTlv`
  overriding the inherited ones from `Tlv` (which would be
  incorrect for an `ExtendedTlv`).
- Defines a new common private static method `Tlv::Find()` which
  is then used to simplify `Tlv::Get()` and `Tlv::GetOffset()` and
  `Tlv::GetValueOffset()` implementations.
- This change also ensures `Tlv::Get()` (which finds and reads a
  TLV of a given type within a message) work correctly for Extended
  TLVs.
- Adds `Message::AppendTlv()` method to handle `ExtendedTlv`.