### PR TITLE
[posix-app] log filename when die

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -233,7 +233,7 @@ AC_PATH_PROG(CMP, cmp)
 #
 
 PROSPECTIVE_CFLAGS="-Wall -Wextra -Wshadow -Werror -std=c99 -pedantic-errors -Wno-gnu-zero-variadic-macro-arguments"
-PROSPECTIVE_CXXFLAGS="-Wall -Wextra -Wshadow -Werror -std=gnu++98 -Wno-c++14-compat -fno-exceptions -Wno-gnu-zero-variadic-macro-arguments"
+PROSPECTIVE_CXXFLAGS="-Wall -Wextra -Wshadow -Werror -std=gnu++98 -Wno-c++14-compat -fno-exceptions"
 
 AC_CACHE_CHECK([whether $CC is Clang],
     [nl_cv_clang],

--- a/configure.ac
+++ b/configure.ac
@@ -232,8 +232,8 @@ AC_PATH_PROG(CMP, cmp)
 #   -Wall                        CC, CXX
 #
 
-PROSPECTIVE_CFLAGS="-Wall -Wextra -Wshadow -Werror -std=c99 -pedantic-errors"
-PROSPECTIVE_CXXFLAGS="-Wall -Wextra -Wshadow -Werror -std=gnu++98 -Wno-c++14-compat -fno-exceptions"
+PROSPECTIVE_CFLAGS="-Wall -Wextra -Wshadow -Werror -std=c99 -pedantic-errors -Wno-gnu-zero-variadic-macro-arguments"
+PROSPECTIVE_CXXFLAGS="-Wall -Wextra -Wshadow -Werror -std=gnu++98 -Wno-c++14-compat -fno-exceptions -Wno-gnu-zero-variadic-macro-arguments"
 
 AC_CACHE_CHECK([whether $CC is Clang],
     [nl_cv_clang],

--- a/src/posix/platform/Makefile.am
+++ b/src/posix/platform/Makefile.am
@@ -81,6 +81,7 @@ check_PROGRAMS = test-settings
 test_settings_CPPFLAGS                    = \
     -I$(top_srcdir)/include                 \
     -I$(top_srcdir)/src/core                \
+    -DOPENTHREAD_CONFIG_LOG_PLATFORM=0      \
     -DSELF_TEST                             \
     $(NULL)
 

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -138,7 +138,7 @@ otError HdlcInterface::Init(const char *aRadioFile, const char *aRadioConfig)
 
     VerifyOrExit(mSockFd == -1, error = OT_ERROR_ALREADY);
 
-    VerifyOrExit(stat(aRadioFile, &st) == 0, perror("stat ncp file failed"); error = OT_ERROR_INVALID_ARGS);
+    VerifyOrDie(stat(aRadioFile, &st) == 0, OT_EXIT_INVALID_ARGUMENTS);
 
     if (S_ISCHR(st.st_mode))
     {
@@ -277,11 +277,11 @@ otError HdlcInterface::WaitForWritable(void)
             }
             else if (FD_ISSET(mSockFd, &errorFds))
             {
-                DieNowWithMessage("socket error", OT_EXIT_FAILURE);
+                DieNow(OT_EXIT_FAILURE);
             }
             else
             {
-                DieNowWithMessage("select error", OT_EXIT_FAILURE);
+                assert(false);
             }
         }
         else if ((rval < 0) && (errno != EINTR))

--- a/src/posix/platform/openthread-core-posix-config.h
+++ b/src/posix/platform/openthread-core-posix-config.h
@@ -35,6 +35,16 @@
 #define OPENTHREAD_CORE_POSIX_CONFIG_H_
 
 /**
+ * @def OPENTHREAD_CONFIG_LOG_PLATFORM
+ *
+ * Define to enable platform region logging.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_LOG_PLATFORM
+#define OPENTHREAD_CONFIG_LOG_PLATFORM 1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_PLATFORM_INFO
  *
  * The platform-specific string to insert into the OpenThread version string.

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -94,16 +94,14 @@ const char *otExitCodeToString(uint8_t aExitCode);
  * @param[in]   aExitCode   The exit code.
  *
  */
-#define VerifyOrDie(aCondition, aExitCode)                                                                           \
-    do                                                                                                               \
-    {                                                                                                                \
-        if (!(aCondition))                                                                                           \
-        {                                                                                                            \
-            fprintf(stderr, "exit(%d): %s line %d, %s\r\n", aExitCode, __func__, __LINE__,                           \
-                    otExitCodeToString(aExitCode));                                                                  \
-            otLogCritPlat("exit(%d): %s line %d, %s", aExitCode, __func__, __LINE__, otExitCodeToString(aExitCode)); \
-            exit(aExitCode);                                                                                         \
-        }                                                                                                            \
+#define VerifyOrDie(aCondition, aExitCode)                                                                   \
+    do                                                                                                       \
+    {                                                                                                        \
+        if (!(aCondition))                                                                                   \
+        {                                                                                                    \
+            otLogCritPlat("%s() at %s:%d: %s", __func__, __FILE__, __LINE__, otExitCodeToString(aExitCode)); \
+            exit(aExitCode);                                                                                 \
+        }                                                                                                    \
     } while (false)
 
 /**
@@ -113,19 +111,9 @@ const char *otExitCodeToString(uint8_t aExitCode);
  * @param[in]  aError  An error code to be evaluated against OT_ERROR_NONE.
  *
  */
-#define SuccessOrDie(aError)                                                                                        \
-    do                                                                                                              \
-    {                                                                                                               \
-        if (aError != OT_ERROR_NONE)                                                                                \
-        {                                                                                                           \
-            uint8_t exitCode;                                                                                       \
-            exitCode = (aError == OT_ERROR_INVALID_ARGS) ? OT_EXIT_INVALID_ARGUMENTS : OT_EXIT_FAILURE;             \
-            fprintf(stderr, "exit(%d): %s line %d, %s\r\n", exitCode, __func__, __LINE__,                           \
-                    otThreadErrorToString(aError));                                                                 \
-            otLogCritPlat("exit(%d): %s line %d, %s", exitCode, __func__, __LINE__, otThreadErrorToString(aError)); \
-            exit(exitCode);                                                                                         \
-        }                                                                                                           \
-    } while (false)
+#define SuccessOrDie(aError)             \
+    VerifyOrDie(aError == OT_ERROR_NONE, \
+                (aError == OT_ERROR_INVALID_ARGS ? OT_EXIT_INVALID_ARGUMENTS : OT_EXIT_FAILURE))
 
 /**
  * This macro unconditionally both records exit status and terminates the program.

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -527,11 +527,11 @@ void RadioSpinel::HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, 
 
         if (status >= SPINEL_STATUS_RESET__BEGIN && status <= SPINEL_STATUS_RESET__END)
         {
-            otLogCritPlat("RCP reset: %s", spinel_status_to_cstr(status));
-            mIsReady = true;
-
             // If RCP crashes/resets while radio was enabled, posix app exits.
             VerifyOrDie(!IsEnabled(), OT_EXIT_RADIO_SPINEL_RESET);
+
+            otLogInfoPlat("RCP reset: %s", spinel_status_to_cstr(status));
+            mIsReady = true;
         }
         else
         {

--- a/src/posix/platform/settings.cpp
+++ b/src/posix/platform/settings.cpp
@@ -349,18 +349,12 @@ void otPlatSettingsWipe(otInstance *aInstance)
 
 uint64_t gNodeId = 1;
 
-const char *otExitCodeToString(uint8_t aExitCode)
-{
-    OT_UNUSED_VARIABLE(aExitCode);
-    return "SELF_TEST";
-}
-
 int main()
 {
     otInstance *instance = NULL;
     uint8_t     data[60];
 
-    for (size_t i = 0; i < sizeof(data); ++i)
+    for (uint8_t i = 0; i < sizeof(data); ++i)
     {
         data[i] = i;
     }

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -51,6 +51,7 @@ if OPENTHREAD_BUILD_TESTS
 
 AM_CPPFLAGS                                                         = \
     -DOPENTHREAD_FTD=1                                                \
+    -DOPENTHREAD_CONFIG_LOG_PLATFORM=0                                \
     -I$(top_srcdir)/include                                           \
     -I$(top_srcdir)/src                                               \
     -I$(top_srcdir)/src/core                                          \

--- a/tests/unit/test_hdlc.cpp
+++ b/tests/unit/test_hdlc.cpp
@@ -517,7 +517,7 @@ void TestEncoderDecoder(void)
 
 uint32_t GetRandom(uint32_t max)
 {
-    return rand() % max;
+    return static_cast<uint32_t>(rand()) % max;
 }
 
 void TestFuzzEncoderDecoder(void)


### PR DESCRIPTION
This PR aims at adding the filename when die. Other enhancements:

* Enable PLATFORM region by default for posix-app
* Disable warning for zero variadic macro arguments
* Use VerifyOrExit to implement other assert utilities
* Do not call fprintf() and print exit code in assert utility

To print dying message to stderr, add `-v` when launching the app.
To get the exit code, use `echo $?` just after the app died.