### PR TITLE
[mle] always echo back AR TLV in Child ID/Update Response

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -4358,16 +4358,8 @@ otError MleRouter::AppendChildAddresses(Message &aMessage, Child &aChild)
         length += entry.GetLength();
     }
 
-    if (length > 0)
-    {
-        tlv.SetLength(length);
-        aMessage.Write(startOffset, sizeof(tlv), &tlv);
-    }
-    else
-    {
-        // remove AddressRegistrationTlv if no address to be echoed back
-        aMessage.SetLength(startOffset);
-    }
+    tlv.SetLength(length);
+    aMessage.Write(startOffset, sizeof(tlv), &tlv);
 
 exit:
     return error;


### PR DESCRIPTION
The commits make sure AR TLV is always included in Child ID/Update Response if there is one in Request, according to [SPEC-888](https://threadgroup.atlassian.net/browse/SPEC-888) consensus.
The commits revert part of features introduced in PR #3640