### PR TITLE
[network-diagnostic] limit number of entries in Child Table TLV

### DIFF
--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -59,6 +59,15 @@ class Tlv
 {
 public:
     /**
+     * Length values.
+     *
+     */
+    enum
+    {
+        kBaseTlvMaxLength = 254, ///< The maximum length of the Base TLV format.
+    };
+
+    /**
      * This method returns the Type value.
      *
      * @returns The Type value.


### PR DESCRIPTION
This PR fixes Thread Certification Test Case Router_5_7_3 where Child Table TLV was damaged.

Additionally this PR ensures only Base TLV format is used (#4118),
 Thread Group Jira: [SPEC-894](https://threadgroup.atlassian.net/browse/SPEC-894)