### PR TITLE
[mac] add Mac::NetworkName class

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -185,7 +185,7 @@ const char *otThreadGetNetworkName(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<Mac::Mac>().GetNetworkName();
+    return instance.Get<Mac::Mac>().GetNetworkName().GetAsCString();
 }
 
 otError otThreadSetNetworkName(otInstance *aInstance, const char *aNetworkName)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -366,36 +366,32 @@ public:
     /**
      * This method returns the IEEE 802.15.4 Network Name.
      *
-     * @returns A pointer to the IEEE 802.15.4 Network Name.
+     * @returns The IEEE 802.15.4 Network Name.
      *
      */
-    const char *GetNetworkName(void) const { return mNetworkName.m8; }
+    const NetworkName &GetNetworkName(void) const { return mNetworkName; }
 
     /**
      * This method sets the IEEE 802.15.4 Network Name.
      *
-     * @param[in]  aNetworkName  A pointer to the string. Must be null terminated.
+     * @param[in]  aNameString   A pointer to a string character array. Must be null terminated.
      *
      * @retval OT_ERROR_NONE           Successfully set the IEEE 802.15.4 Network Name.
      * @retval OT_ERROR_INVALID_ARGS   Given name is too long.
      *
      */
-    otError SetNetworkName(const char *aNetworkName)
-    {
-        return SetNetworkName(aNetworkName, OT_NETWORK_NAME_MAX_SIZE + 1);
-    }
+    otError SetNetworkName(const char *aNameString);
 
     /**
      * This method sets the IEEE 802.15.4 Network Name.
      *
-     * @param[in]  aBuffer  A pointer to the char buffer containing the name. Does not need to be null terminated.
-     * @param[in]  aLength  Number of chars in the buffer.
+     * @param[in]  aNameData     A name data (pointer to char buffer and length).
      *
      * @retval OT_ERROR_NONE           Successfully set the IEEE 802.15.4 Network Name.
      * @retval OT_ERROR_INVALID_ARGS   Given name is too long.
      *
      */
-    otError SetNetworkName(const char *aBuffer, uint8_t aLength);
+    otError SetNetworkName(const NetworkName::Data &aNameData);
 
     /**
      * This method returns the IEEE 802.15.4 PAN ID.
@@ -713,7 +709,7 @@ private:
     uint16_t      mRadioChannelAcquisitionId;
     ChannelMask   mSupportedChannelMask;
     ExtendedPanId mExtendedPanId;
-    otNetworkName mNetworkName;
+    NetworkName   mNetworkName;
     uint8_t       mScanChannel;
     uint16_t      mScanDuration;
     ChannelMask   mScanChannelMask;

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -95,6 +95,46 @@ ExtendedPanId::InfoString ExtendedPanId::ToString(void) const
     return InfoString("%02x%02x%02x%02x%02x%02x%02x%02x", m8[0], m8[1], m8[2], m8[3], m8[4], m8[5], m8[6], m8[7]);
 }
 
+uint8_t NetworkName::Data::CopyTo(char *aBuffer, uint8_t aMaxSize) const
+{
+    uint8_t len = GetLength();
+
+    memset(aBuffer, 0, aMaxSize);
+
+    if (len > aMaxSize)
+    {
+        len = aMaxSize;
+    }
+
+    memcpy(aBuffer, GetBuffer(), len);
+
+    return len;
+}
+
+NetworkName::Data NetworkName::GetAsData(void) const
+{
+    uint8_t len = static_cast<uint8_t>(strnlen(m8, kMaxSize + 1));
+
+    return Data(m8, len);
+}
+
+otError NetworkName::Set(const Data &aNameData)
+{
+    otError error  = OT_ERROR_NONE;
+    uint8_t newLen = static_cast<uint8_t>(strnlen(aNameData.GetBuffer(), aNameData.GetLength()));
+
+    VerifyOrExit(newLen <= kMaxSize, error = OT_ERROR_INVALID_ARGS);
+
+    // Ensure the new name does not match the current one.
+    VerifyOrExit(memcmp(m8, aNameData.GetBuffer(), newLen) || (m8[newLen] != '\0'), error = OT_ERROR_ALREADY);
+
+    memcpy(m8, aNameData.GetBuffer(), newLen);
+    m8[newLen] = '\0';
+
+exit:
+    return error;
+}
+
 void Frame::InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl)
 {
     uint8_t *bytes  = GetPsdu();
@@ -1129,11 +1169,11 @@ Frame::InfoString Frame::ToInfoString(void) const
 
 BeaconPayload::InfoString BeaconPayload::ToInfoString(void) const
 {
-    otNetworkName networkname;
+    NetworkName name;
 
-    strlcpy(networkname.m8, GetNetworkName(), sizeof(networkname.m8));
+    name.Set(GetNetworkName());
 
-    return InfoString("name:%s, xpanid:%s, id:%d, ver:%d, joinable:%s, native:%s", networkname.m8,
+    return InfoString("name:%s, xpanid:%s, id:%d, ver:%d, joinable:%s, native:%s", name.GetAsCString(),
                       mExtendedPanId.ToString().AsCString(), GetProtocolId(), GetProtocolVersion(),
                       IsJoiningPermitted() ? "yes" : "no", IsNative() ? "yes" : "no");
 }

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -191,8 +191,7 @@ void Dataset::Get(otOperationalDataset &aDataset) const
         case Tlv::kNetworkName:
         {
             const NetworkNameTlv *tlv = static_cast<const NetworkNameTlv *>(cur);
-            memcpy(aDataset.mNetworkName.m8, tlv->GetNetworkName(), tlv->GetLength());
-            aDataset.mNetworkName.m8[tlv->GetLength()] = '\0';
+            static_cast<Mac::NetworkName &>(aDataset.mNetworkName).Set(tlv->GetNetworkName());
             aDataset.mComponents.mIsNetworkNamePresent = true;
             break;
         }
@@ -328,7 +327,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
     {
         MeshCoP::NetworkNameTlv tlv;
         tlv.Init();
-        tlv.SetNetworkName(aDataset.mNetworkName.m8);
+        tlv.SetNetworkName(static_cast<const Mac::NetworkName &>(aDataset.mNetworkName).GetAsData());
         Set(tlv);
     }
 
@@ -556,7 +555,7 @@ otError Dataset::ApplyConfiguration(Instance &aInstance, bool *aIsMasterKeyUpdat
         case Tlv::kNetworkName:
         {
             const NetworkNameTlv *name = static_cast<const NetworkNameTlv *>(cur);
-            mac.SetNetworkName(name->GetNetworkName(), name->GetLength());
+            mac.SetNetworkName(name->GetNetworkName());
             break;
         }
 

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -478,7 +478,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
     {
         NetworkNameTlv networkname;
         networkname.Init();
-        networkname.SetNetworkName(aDataset.mNetworkName.m8);
+        networkname.SetNetworkName(static_cast<const Mac::NetworkName &>(aDataset.mNetworkName).GetAsData());
         SuccessOrExit(error = message->AppendTlv(networkname));
     }
 

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -436,7 +436,7 @@ otError ActiveDataset::GenerateLocal(void)
     {
         NetworkNameTlv tlv;
         tlv.Init();
-        tlv.SetNetworkName(Get<Mac::Mac>().GetNetworkName());
+        tlv.SetNetworkName(Get<Mac::Mac>().GetNetworkName().GetAsData());
         dataset.Set(tlv);
     }
 

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -557,7 +557,7 @@ void Joiner::HandleJoinerEntrust(Coap::Message &aMessage, const Ip6::MessageInfo
     Get<Mle::MleRouter>().SetMeshLocalPrefix(meshLocalPrefix.GetMeshLocalPrefix());
     Get<Mac::Mac>().SetExtendedPanId(extendedPanId.GetExtendedPanId());
 
-    Get<Mac::Mac>().SetNetworkName(networkName.GetNetworkName(), networkName.GetNetworkNameLength());
+    Get<Mac::Mac>().SetNetworkName(networkName.GetNetworkName());
 
     otLogInfoMeshCoP("Joiner successful!");
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -297,7 +297,7 @@ otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessage
     SuccessOrExit(error = message->AppendTlv(extendedPanId));
 
     networkName.Init();
-    networkName.SetNetworkName(Get<Mac::Mac>().GetNetworkName());
+    networkName.SetNetworkName(Get<Mac::Mac>().GetNetworkName().GetAsData());
     SuccessOrExit(error = message->AppendTlv(networkName));
 
     Get<ActiveDataset>().Read(dataset);

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -83,6 +83,26 @@ bool Tlv::IsValid(const Tlv &aTlv)
     return rval;
 }
 
+Mac::NetworkName::Data NetworkNameTlv::GetNetworkName(void) const
+{
+    uint8_t len = GetLength();
+
+    if (len > sizeof(mNetworkName))
+    {
+        len = sizeof(mNetworkName);
+    }
+
+    return Mac::NetworkName::Data(mNetworkName, len);
+}
+
+void NetworkNameTlv::SetNetworkName(const Mac::NetworkName::Data &aNameData)
+{
+    uint8_t len;
+
+    len = aNameData.CopyTo(mNetworkName, sizeof(mNetworkName));
+    SetLength(len);
+}
+
 bool SteeringDataTlv::IsCleared(void) const
 {
     bool rval = true;

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -405,39 +405,23 @@ public:
     bool IsValid(void) const { return true; }
 
     /**
-     * This method returns the Network Name length.
+     * This method gets the Network Name value.
      *
-     * @returns The Network Name length.
-     *
-     */
-    uint8_t GetNetworkNameLength(void) const
-    {
-        return GetLength() <= sizeof(mNetworkName) ? GetLength() : sizeof(mNetworkName);
-    }
-
-    /**
-     * This method returns the Network Name value.
-     *
-     * @returns The Network Name value.
+     * @returns The Network Name value (as `NetworkName::Data`).
      *
      */
-    const char *GetNetworkName(void) const { return mNetworkName; }
+    Mac::NetworkName::Data GetNetworkName(void) const;
 
     /**
      * This method sets the Network Name value.
      *
-     * @param[in]  aNetworkName  A pointer to the Network Name value.
+     * @param[in] aNameData   A Network Name value (as `NetworkName::Data`).
      *
      */
-    void SetNetworkName(const char *aNetworkName)
-    {
-        size_t length = strnlen(aNetworkName, sizeof(mNetworkName));
-        memcpy(mNetworkName, aNetworkName, length);
-        SetLength(static_cast<uint8_t>(length));
-    }
+    void SetNetworkName(const Mac::NetworkName::Data &aNameData);
 
 private:
-    char mNetworkName[OT_NETWORK_NAME_MAX_SIZE];
+    char mNetworkName[Mac::NetworkName::kMaxSize];
 } OT_TOOL_PACKED_END;
 
 /**

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3825,8 +3825,7 @@ otError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::Message
 
         case MeshCoP::Tlv::kNetworkName:
             aMessage.Read(offset, sizeof(networkName), &networkName);
-            memcpy(&result.mNetworkName, networkName.GetNetworkName(), networkName.GetNetworkNameLength());
-            result.mNetworkName.m8[networkName.GetNetworkNameLength()] = '\0';
+            static_cast<Mac::NetworkName &>(result.mNetworkName).Set(networkName.GetNetworkName());
             break;
 
         case MeshCoP::Tlv::kSteeringData:

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2761,7 +2761,7 @@ otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint1
 
     // Network Name TLV
     networkName.Init();
-    networkName.SetNetworkName(Get<Mac::Mac>().GetNetworkName());
+    networkName.SetNetworkName(Get<Mac::Mac>().GetNetworkName().GetAsData());
     SuccessOrExit(error = message->AppendTlv(networkName));
 
 #if OPENTHREAD_CONFIG_MLE_STEERING_DATA_SET_OOB_ENABLE


### PR DESCRIPTION
This commit adds `Mac::NetworkName` class as C++ wrapper over the
`otNetworkName`. It also adds `NetworkName::Data` to represent the
network name as a pointer to a char array buffer (not necessarily null
terminated) with a given length. This representation is used by
`Mac::BeaconPlayload` and `MeshCop::NetworkNameTlv`. This commit also
adds unit test for `Mac::NetworkName` class.