### PR TITLE
[posix-app] fix crash on os ifconfig down

### DIFF
--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -98,12 +98,24 @@ static void UpdateUnicast(otInstance *aInstance, const otIp6Address &aAddress, u
     ifr6.ifr6_ifindex   = static_cast<int>(sTunIndex);
     ifr6.ifr6_prefixlen = aPrefixLength;
 
-    VerifyOrExit(ioctl(sIpFd, (aIsAdded ? SIOCSIFADDR : SIOCDIFADDR), &ifr6) == 0, perror("ioctl");
-                 error = OT_ERROR_FAILED);
+    if (aIsAdded)
+    {
+        VerifyOrDie(ioctl(sIpFd, SIOCSIFADDR, &ifr6) == 0, OT_EXIT_ERROR_ERRNO);
+    }
+    else
+    {
+        VerifyOrExit(ioctl(sIpFd, SIOCDIFADDR, &ifr6) == 0, perror("ioctl"); error = OT_ERROR_FAILED);
+    }
 
 exit:
-    SuccessOrDie(error);
-    otLogInfoPlat("%s: %s", __func__, otThreadErrorToString(error));
+    if (error != OT_ERROR_NONE)
+    {
+        otLogWarnPlat("%s: %s", __func__, otThreadErrorToString(error));
+    }
+    else
+    {
+        otLogInfoPlat("%s: %s", __func__, otThreadErrorToString(error));
+    }
 }
 
 static void UpdateMulticast(otInstance *aInstance, const otIp6Address &aAddress, bool aIsAdded)


### PR DESCRIPTION
This PR fixes a crash issue triggered by system command ifconfig down.
This is because OpenThread's tries removing addresses when the platform
network interface is already down.