### PR TITLE
[key-manager] add Pskc class

### DIFF
--- a/include/openthread/commissioner.h
+++ b/include/openthread/commissioner.h
@@ -181,12 +181,12 @@ otError otCommissionerStop(otInstance *aInstance);
  *
  * @param[in]  aInstance          A pointer to an OpenThread instance.
  * @param[in]  aEui64             A pointer to the Joiner's IEEE EUI-64 or NULL for any Joiner.
- * @param[in]  aPSKd              A pointer to the PSKd.
+ * @param[in]  aPskd              A pointer to the PSKd.
  * @param[in]  aTimeout           A time after which a Joiner is automatically removed, in seconds.
  *
  * @retval OT_ERROR_NONE          Successfully added the Joiner.
  * @retval OT_ERROR_NO_BUFS       No buffers available to add the Joiner.
- * @retval OT_ERROR_INVALID_ARGS  @p aEui64 or @p aPSKd is invalid.
+ * @retval OT_ERROR_INVALID_ARGS  @p aEui64 or @p aPskd is invalid.
  * @retval OT_ERROR_INVALID_STATE The commissioner is not active.
  *
  * @note Only use this after successfully starting the Commissioner role with otCommissionerStart().
@@ -194,7 +194,7 @@ otError otCommissionerStop(otInstance *aInstance);
  */
 otError otCommissionerAddJoiner(otInstance *        aInstance,
                                 const otExtAddress *aEui64,
-                                const char *        aPSKd,
+                                const char *        aPskd,
                                 uint32_t            aTimeout);
 
 /**
@@ -412,17 +412,17 @@ otCommissionerState otCommissionerGetState(otInstance *aInstance);
  * @param[in]  aPassPhrase   The commissioning passphrase.
  * @param[in]  aNetworkName  The network name for PSKc computation.
  * @param[in]  aExtPanId     The extended pan id for PSKc computation.
- * @param[out] aPSKc         A pointer to the generated PSKc.
+ * @param[out] aPskc         A pointer to the generated PSKc.
  *
  * @retval OT_ERROR_NONE          Successfully generate PSKc.
  * @retval OT_ERROR_INVALID_ARGS  If any of the input arguments is invalid.
  *
  */
-otError otCommissionerGeneratePSKc(otInstance *           aInstance,
+otError otCommissionerGeneratePskc(otInstance *           aInstance,
                                    const char *           aPassPhrase,
                                    const char *           aNetworkName,
                                    const otExtendedPanId *aExtPanId,
-                                   uint8_t *              aPSKc);
+                                   uint8_t *              aPskc);
 
 /**
  * @}

--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -124,7 +124,7 @@ typedef struct otMeshLocalPrefix otMeshLocalPrefix;
  *
  */
 OT_TOOL_PACKED_BEGIN
-struct otPSKc
+struct otPskc
 {
     uint8_t m8[OT_PSKC_MAX_SIZE]; ///< Byte values
 } OT_TOOL_PACKED_END;
@@ -133,7 +133,7 @@ struct otPSKc
  * This structure represents a PSKc.
  *
  */
-typedef struct otPSKc otPSKc;
+typedef struct otPskc otPskc;
 
 /**
  * This structure represent Security Policy.
@@ -206,7 +206,7 @@ typedef struct otOperationalDatasetComponents
     bool mIsDelayPresent : 1;            ///< TRUE if Delay Timer is present, FALSE otherwise.
     bool mIsPanIdPresent : 1;            ///< TRUE if PAN ID is present, FALSE otherwise.
     bool mIsChannelPresent : 1;          ///< TRUE if Channel is present, FALSE otherwise.
-    bool mIsPSKcPresent : 1;             ///< TRUE if PSKc is present, FALSE otherwise.
+    bool mIsPskcPresent : 1;             ///< TRUE if PSKc is present, FALSE otherwise.
     bool mIsSecurityPolicyPresent : 1;   ///< TRUE if Security Policy is present, FALSE otherwise.
     bool mIsChannelMaskPresent : 1;      ///< TRUE if Channel Mask is present, FALSE otherwise.
 } otOperationalDatasetComponents;
@@ -228,7 +228,7 @@ typedef struct otOperationalDataset
     uint32_t                       mDelay;            ///< Delay Timer
     otPanId                        mPanId;            ///< PAN ID
     uint16_t                       mChannel;          ///< Channel
-    otPSKc                         mPSKc;             ///< PSKc
+    otPskc                         mPskc;             ///< PSKc
     otSecurityPolicy               mSecurityPolicy;   ///< Security Policy
     otChannelMask                  mChannelMask;      ///< Channel Mask
     otOperationalDatasetComponents mComponents;       ///< Specifies which components are set in the Dataset.

--- a/include/openthread/joiner.h
+++ b/include/openthread/joiner.h
@@ -85,7 +85,7 @@ typedef void (*otJoinerCallback)(otError aError, void *aContext);
  * This function enables the Thread Joiner role.
  *
  * @param[in]  aInstance         A pointer to an OpenThread instance.
- * @param[in]  aPSKd             A pointer to the PSKd.
+ * @param[in]  aPskd             A pointer to the PSKd.
  * @param[in]  aProvisioningUrl  A pointer to the Provisioning URL (may be NULL).
  * @param[in]  aVendorName       A pointer to the Vendor Name (may be NULL).
  * @param[in]  aVendorModel      A pointer to the Vendor Model (may be NULL).
@@ -95,11 +95,11 @@ typedef void (*otJoinerCallback)(otError aError, void *aContext);
  * @param[in]  aContext          A pointer to application-specific context.
  *
  * @retval OT_ERROR_NONE              Successfully started the Commissioner role.
- * @retval OT_ERROR_INVALID_ARGS      @p aPSKd or @p aProvisioningUrl is invalid.
+ * @retval OT_ERROR_INVALID_ARGS      @p aPskd or @p aProvisioningUrl is invalid.
  *
  */
 otError otJoinerStart(otInstance *     aInstance,
-                      const char *     aPSKd,
+                      const char *     aPskd,
                       const char *     aProvisioningUrl,
                       const char *     aVendorName,
                       const char *     aVendorModel,

--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -517,34 +517,34 @@ otError otThreadGetRouterInfo(otInstance *aInstance, uint16_t aRouterId, otRoute
 otError otThreadGetEidCacheEntry(otInstance *aInstance, uint8_t aIndex, otEidCacheEntry *aEntry);
 
 /**
- * Get the thrPSKc.
+ * Get the Thread PSKc
  *
  * @param[in]   aInstance   A pointer to an OpenThread instance.
  *
- * @returns A pointer to a buffer containing the thrPSKc.
+ * @returns A pointer to Thread PSKc
  *
- * @sa otThreadSetPSKc
+ * @sa otThreadSetPskc
  *
  */
-const otPSKc *otThreadGetPSKc(otInstance *aInstance);
+const otPskc *otThreadGetPskc(otInstance *aInstance);
 
 /**
- * Set the thrPSKc.
+ * Set the Thread PSKc
  *
  * This function will only succeed when Thread protocols are disabled.  A successful
  * call to this function will also invalidate the Active and Pending Operational Datasets in
  * non-volatile memory.
  *
  * @param[in]  aInstance   A pointer to an OpenThread instance.
- * @param[in]  aPSKc       A pointer to a buffer containing the thrPSKc.
+ * @param[in]  aPskc       A pointer to the new Thread PSKc.
  *
- * @retval OT_ERROR_NONE           Successfully set the thrPSKc.
+ * @retval OT_ERROR_NONE           Successfully set the Thread PSKc.
  * @retval OT_ERROR_INVALID_STATE  Thread protocols are enabled.
  *
- * @sa otThreadGetPSKc
+ * @sa otThreadGetPskc
  *
  */
-otError otThreadSetPSKc(otInstance *aInstance, const otPSKc *aPSKc);
+otError otThreadSetPskc(otInstance *aInstance, const otPskc *aPskc);
 
 /**
  * Get the assigned parent priority.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -191,7 +191,7 @@ const struct Command Interpreter::sCommands[] = {
     {"prefix", &Interpreter::ProcessPrefix},
 #endif
 #if OPENTHREAD_FTD
-    {"pskc", &Interpreter::ProcessPSKc},
+    {"pskc", &Interpreter::ProcessPskc},
     {"releaserouterid", &Interpreter::ProcessReleaseRouterId},
 #endif
     {"reset", &Interpreter::ProcessReset},
@@ -1507,13 +1507,13 @@ exit:
 #endif // OPENTHREAD_FTD
 
 #if OPENTHREAD_FTD
-void Interpreter::ProcessPSKc(int argc, char *argv[])
+void Interpreter::ProcessPskc(int argc, char *argv[])
 {
     otError error = OT_ERROR_NONE;
 
     if (argc == 0)
     {
-        const otPSKc *pskc = otThreadGetPSKc(mInstance);
+        const otPskc *pskc = otThreadGetPskc(mInstance);
 
         for (int i = 0; i < OT_PSKC_MAX_SIZE; i++)
         {
@@ -1524,10 +1524,10 @@ void Interpreter::ProcessPSKc(int argc, char *argv[])
     }
     else
     {
-        otPSKc pskc;
+        otPskc pskc;
 
         VerifyOrExit(Hex2Bin(argv[0], pskc.m8, sizeof(pskc)) == OT_PSKC_MAX_SIZE, error = OT_ERROR_PARSE);
-        SuccessOrExit(error = otThreadSetPSKc(mInstance, &pskc));
+        SuccessOrExit(error = otThreadSetPskc(mInstance, &pskc));
     }
 
 exit:

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -298,7 +298,7 @@ private:
 #endif
     void ProcessPromiscuous(int argc, char *argv[]);
 #if OPENTHREAD_FTD
-    void ProcessPSKc(int argc, char *argv[]);
+    void ProcessPskc(int argc, char *argv[]);
     void ProcessReleaseRouterId(int argc, char *argv[]);
 #endif
     void ProcessReset(int argc, char *argv[]);

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -65,7 +65,7 @@ const Dataset::Command Dataset::sCommands[] = {
     {"panid", &Dataset::ProcessPanId},
     {"pending", &Dataset::ProcessPending},
     {"pendingtimestamp", &Dataset::ProcessPendingTimestamp},
-    {"pskc", &Dataset::ProcessPSKc},
+    {"pskc", &Dataset::ProcessPskc},
     {"securitypolicy", &Dataset::ProcessSecurityPolicy},
 };
 
@@ -141,10 +141,10 @@ otError Dataset::Print(otOperationalDataset &aDataset)
         mInterpreter.mServer->OutputFormat("PAN ID: 0x%04x\r\n", aDataset.mPanId);
     }
 
-    if (aDataset.mComponents.mIsPSKcPresent)
+    if (aDataset.mComponents.mIsPskcPresent)
     {
         mInterpreter.mServer->OutputFormat("PSKc: ");
-        OutputBytes(aDataset.mPSKc.m8, sizeof(aDataset.mPSKc.m8));
+        OutputBytes(aDataset.mPskc.m8, sizeof(aDataset.mPskc.m8));
         mInterpreter.mServer->OutputFormat("\r\n");
     }
 
@@ -675,7 +675,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessPSKc(int argc, char *argv[])
+otError Dataset::ProcessPskc(int argc, char *argv[])
 {
     otError  error = OT_ERROR_NONE;
     uint16_t length;
@@ -683,10 +683,10 @@ otError Dataset::ProcessPSKc(int argc, char *argv[])
     VerifyOrExit(argc > 0, error = OT_ERROR_INVALID_ARGS);
     length = static_cast<uint16_t>((strlen(argv[0]) + 1) / 2);
     VerifyOrExit(length <= OT_PSKC_MAX_SIZE, error = OT_ERROR_NO_BUFS);
-    VerifyOrExit(Interpreter::Hex2Bin(argv[0], sDataset.mPSKc.m8 + OT_PSKC_MAX_SIZE - length, length) == length,
+    VerifyOrExit(Interpreter::Hex2Bin(argv[0], sDataset.mPskc.m8 + OT_PSKC_MAX_SIZE - length, length) == length,
                  error = OT_ERROR_PARSE);
 
-    sDataset.mComponents.mIsPSKcPresent = true;
+    sDataset.mComponents.mIsPskcPresent = true;
 
 exit:
     return error;

--- a/src/cli/cli_dataset.hpp
+++ b/src/cli/cli_dataset.hpp
@@ -94,7 +94,7 @@ private:
     otError ProcessPendingTimestamp(int argc, char *argv[]);
     otError ProcessMgmtSetCommand(int argc, char *argv[]);
     otError ProcessMgmtGetCommand(int argc, char *argv[]);
-    otError ProcessPSKc(int argc, char *argv[]);
+    otError ProcessPskc(int argc, char *argv[]);
     otError ProcessSecurityPolicy(int argc, char *argv[]);
 
     Interpreter &mInterpreter;

--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -73,11 +73,11 @@ exit:
     return error;
 }
 
-otError otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *aEui64, const char *aPSKd, uint32_t aTimeout)
+otError otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *aEui64, const char *aPskd, uint32_t aTimeout)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<MeshCoP::Commissioner>().AddJoiner(static_cast<const Mac::ExtAddress *>(aEui64), aPSKd,
+    return instance.Get<MeshCoP::Commissioner>().AddJoiner(static_cast<const Mac::ExtAddress *>(aEui64), aPskd,
                                                            aTimeout);
 }
 
@@ -188,15 +188,15 @@ otCommissionerState otCommissionerGetState(otInstance *aInstance)
     return instance.Get<MeshCoP::Commissioner>().GetState();
 }
 
-otError otCommissionerGeneratePSKc(otInstance *           aInstance,
+otError otCommissionerGeneratePskc(otInstance *           aInstance,
                                    const char *           aPassPhrase,
                                    const char *           aNetworkName,
                                    const otExtendedPanId *aExtPanId,
-                                   uint8_t *              aPSKc)
+                                   uint8_t *              aPskc)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    return MeshCoP::Commissioner::GeneratePSKc(aPassPhrase, aNetworkName,
-                                               *static_cast<const Mac::ExtendedPanId *>(aExtPanId), aPSKc);
+    return MeshCoP::Commissioner::GeneratePskc(aPassPhrase, aNetworkName,
+                                               *static_cast<const Mac::ExtendedPanId *>(aExtPanId), aPskc);
 }
 #endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE

--- a/src/core/api/joiner_api.cpp
+++ b/src/core/api/joiner_api.cpp
@@ -42,7 +42,7 @@ using namespace ot;
 
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
 otError otJoinerStart(otInstance *     aInstance,
-                      const char *     aPSKd,
+                      const char *     aPskd,
                       const char *     aProvisioningUrl,
                       const char *     aVendorName,
                       const char *     aVendorModel,
@@ -53,7 +53,7 @@ otError otJoinerStart(otInstance *     aInstance,
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<MeshCoP::Joiner>().Start(aPSKd, aProvisioningUrl, aVendorName, aVendorModel, aVendorSwVersion,
+    return instance.Get<MeshCoP::Joiner>().Start(aPskd, aProvisioningUrl, aVendorName, aVendorModel, aVendorSwVersion,
                                                  aVendorData, aCallback, aContext);
 }
 

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -317,21 +317,21 @@ void otThreadSetSteeringData(otInstance *aInstance, const otExtAddress *aExtAddr
 }
 #endif
 
-const otPSKc *otThreadGetPSKc(otInstance *aInstance)
+const otPskc *otThreadGetPskc(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return &instance.Get<KeyManager>().GetPSKc();
+    return &instance.Get<KeyManager>().GetPskc();
 }
 
-otError otThreadSetPSKc(otInstance *aInstance, const otPSKc *aPSKc)
+otError otThreadSetPskc(otInstance *aInstance, const otPskc *aPskc)
 {
     otError   error    = OT_ERROR_NONE;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
     VerifyOrExit(instance.Get<Mle::MleRouter>().GetRole() == OT_DEVICE_ROLE_DISABLED, error = OT_ERROR_INVALID_STATE);
 
-    instance.Get<KeyManager>().SetPSKc(*aPSKc);
+    instance.Get<KeyManager>().SetPskc(*static_cast<const Pskc *>(aPskc));
     instance.Get<MeshCoP::ActiveDataset>().Clear();
     instance.Get<MeshCoP::PendingDataset>().Clear();
 

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -151,7 +151,7 @@ public:
     /**
      * This method sets the PSK.
      *
-     * @param[in]  aPSK        A pointer to the PSK.
+     * @param[in]  aPsk        A pointer to the PSK.
      * @param[in]  aPskLength  The PSK length.
      *
      * @retval OT_ERROR_NONE          Successfully set the PSK.

--- a/src/core/common/random.hpp
+++ b/src/core/common/random.hpp
@@ -160,7 +160,7 @@ inline uint32_t AddJitter(uint32_t aValue, uint16_t aJitter)
 
 } // namespace NonCrypto
 
-#ifndef OPENTHREAD_RADIO
+#if !OPENTHREAD_RADIO
 
 namespace Crypto {
 

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -652,7 +652,7 @@ otError BorderAgent::Start(void)
     VerifyOrExit(mState == OT_BORDER_AGENT_STATE_STOPPED, error = OT_ERROR_ALREADY);
 
     SuccessOrExit(error = coaps.Start(kBorderAgentUdpPort));
-    SuccessOrExit(error = coaps.SetPsk(Get<KeyManager>().GetPSKc().m8, OT_PSKC_MAX_SIZE));
+    SuccessOrExit(error = coaps.SetPsk(Get<KeyManager>().GetPskc().m8, OT_PSKC_MAX_SIZE));
     coaps.SetConnectedCallback(HandleConnected, this);
 
     coaps.AddResource(mActiveGet);

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -244,13 +244,13 @@ void Commissioner::ClearJoiners(void)
     SendCommissionerSet();
 }
 
-otError Commissioner::AddJoiner(const Mac::ExtAddress *aEui64, const char *aPSKd, uint32_t aTimeout)
+otError Commissioner::AddJoiner(const Mac::ExtAddress *aEui64, const char *aPskd, uint32_t aTimeout)
 {
     otError error = OT_ERROR_NO_BUFS;
 
     VerifyOrExit(mState == OT_COMMISSIONER_STATE_ACTIVE, error = OT_ERROR_INVALID_STATE);
 
-    VerifyOrExit(strlen(aPSKd) <= Dtls::kPskMaxLength, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(strlen(aPskd) <= Dtls::kPskMaxLength, error = OT_ERROR_INVALID_ARGS);
     RemoveJoiner(aEui64, 0); // remove immediately
 
     for (size_t i = 0; i < OT_ARRAY_LENGTH(mJoiners); i++)
@@ -270,7 +270,7 @@ otError Commissioner::AddJoiner(const Mac::ExtAddress *aEui64, const char *aPSKd
             mJoiners[i].mAny = true;
         }
 
-        (void)strlcpy(mJoiners[i].mPsk, aPSKd, sizeof(mJoiners[i].mPsk));
+        (void)strlcpy(mJoiners[i].mPsk, aPskd, sizeof(mJoiners[i].mPsk));
         mJoiners[i].mValid          = true;
         mJoiners[i].mExpirationTime = TimerMilli::GetNow() + TimerMilli::SecToMsec(aTimeout);
 
@@ -286,11 +286,11 @@ exit:
     {
         if (aEui64)
         {
-            otLogInfoMeshCoP("Added Joiner (%s, %s)", aEui64->ToString().AsCString(), aPSKd);
+            otLogInfoMeshCoP("Added Joiner (%s, %s)", aEui64->ToString().AsCString(), aPskd);
         }
         else
         {
-            otLogInfoMeshCoP("Added Joiner (*, %s)", aPSKd);
+            otLogInfoMeshCoP("Added Joiner (*, %s)", aPskd);
         }
     }
 
@@ -1118,10 +1118,10 @@ exit:
     return error;
 }
 
-otError Commissioner::GeneratePSKc(const char *              aPassPhrase,
+otError Commissioner::GeneratePskc(const char *              aPassPhrase,
                                    const char *              aNetworkName,
                                    const Mac::ExtendedPanId &aExtPanId,
-                                   uint8_t *                 aPSKc)
+                                   uint8_t *                 aPskc)
 {
     otError     error      = OT_ERROR_NONE;
     const char *saltPrefix = "Thread";
@@ -1143,7 +1143,7 @@ otError Commissioner::GeneratePSKc(const char *              aPassPhrase,
     saltLen += static_cast<uint16_t>(strlen(aNetworkName));
 
     otPbkdf2Cmac(reinterpret_cast<const uint8_t *>(aPassPhrase), static_cast<uint16_t>(strlen(aPassPhrase)),
-                 reinterpret_cast<const uint8_t *>(salt), saltLen, 16384, OT_PSKC_MAX_SIZE, aPSKc);
+                 reinterpret_cast<const uint8_t *>(salt), saltLen, 16384, OT_PSKC_MAX_SIZE, aPskc);
 
 exit:
     return error;

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -99,7 +99,7 @@ public:
      * This method adds a Joiner entry.
      *
      * @param[in]  aEui64        A pointer to the Joiner's IEEE EUI-64 or NULL for any Joiner.
-     * @param[in]  aPSKd         A pointer to the PSKd.
+     * @param[in]  aPskd         A pointer to the PSKd.
      * @param[in]  aTimeout      A time after which a Joiner is automatically removed, in seconds.
      *
      * @retval OT_ERROR_NONE           Successfully added the Joiner.
@@ -107,7 +107,7 @@ public:
      * @retval OT_ERROR_INVALID_STATE  Commissioner service is not started.
      *
      */
-    otError AddJoiner(const Mac::ExtAddress *aEui64, const char *aPSKd, uint32_t aTimeout);
+    otError AddJoiner(const Mac::ExtAddress *aEui64, const char *aPskd, uint32_t aTimeout);
 
     /**
      * This method get joiner info at aIterator position.
@@ -222,16 +222,16 @@ public:
      * @param[in]  aPassPhrase   The commissioning passphrase.
      * @param[in]  aNetworkName  The network name for PSKc computation.
      * @param[in]  aExtPanId     The extended pan id for PSKc computation.
-     * @param[out] aPSKc         A pointer to where the generated PSKc will be placed.
+     * @param[out] aPskc         A pointer to where the generated PSKc will be placed.
      *
      * @retval OT_ERROR_NONE          Successfully generate PSKc.
      * @retval OT_ERROR_INVALID_ARGS  If the length of passphrase is out of range.
      *
      */
-    static otError GeneratePSKc(const char *              aPassPhrase,
+    static otError GeneratePskc(const char *              aPassPhrase,
                                 const char *              aNetworkName,
                                 const Mac::ExtendedPanId &aExtPanId,
-                                uint8_t *                 aPSKc);
+                                uint8_t *                 aPskc);
 
     /**
      * This method returns a reference to the AnnounceBeginClient instance.

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -213,11 +213,11 @@ void Dataset::Get(otOperationalDataset &aDataset) const
             break;
         }
 
-        case Tlv::kPSKc:
+        case Tlv::kPskc:
         {
-            const PSKcTlv *tlv                  = static_cast<const PSKcTlv *>(cur);
-            aDataset.mPSKc                      = tlv->GetPSKc();
-            aDataset.mComponents.mIsPSKcPresent = true;
+            const PskcTlv *tlv                  = static_cast<const PskcTlv *>(cur);
+            aDataset.mPskc                      = tlv->GetPskc();
+            aDataset.mComponents.mIsPskcPresent = true;
             break;
         }
 
@@ -340,11 +340,11 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         Set(tlv);
     }
 
-    if (aDataset.mComponents.mIsPSKcPresent)
+    if (aDataset.mComponents.mIsPskcPresent)
     {
-        MeshCoP::PSKcTlv tlv;
+        MeshCoP::PskcTlv tlv;
         tlv.Init();
-        tlv.SetPSKc(aDataset.mPSKc);
+        tlv.SetPskc(static_cast<const Pskc &>(aDataset.mPskc));
         Set(tlv);
     }
 
@@ -575,10 +575,10 @@ otError Dataset::ApplyConfiguration(Instance &aInstance, bool *aIsMasterKeyUpdat
 
 #if OPENTHREAD_FTD
 
-        case Tlv::kPSKc:
+        case Tlv::kPskc:
         {
-            const PSKcTlv *pskc = static_cast<const PSKcTlv *>(cur);
-            keyManager.SetPSKc(pskc->GetPSKc());
+            const PskcTlv *pskc = static_cast<const PskcTlv *>(cur);
+            keyManager.SetPskc(pskc->GetPskc());
             break;
         }
 

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -617,9 +617,9 @@ otError DatasetManager::SendGetRequest(const otOperationalDatasetComponents &aDa
         datasetTlvs[length++] = Tlv::kChannel;
     }
 
-    if (aDatasetComponents.mIsPSKcPresent)
+    if (aDatasetComponents.mIsPskcPresent)
     {
-        datasetTlvs[length++] = Tlv::kPSKc;
+        datasetTlvs[length++] = Tlv::kPskc;
     }
 
     if (aDatasetComponents.mIsSecurityPolicyPresent)

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -323,7 +323,7 @@ otError ActiveDataset::CreateNewNetwork(otOperationalDataset &aDataset)
     aDataset.mActiveTimestamp = 1;
 
     SuccessOrExit(error = Random::Crypto::FillBuffer(aDataset.mMasterKey.m8, sizeof(aDataset.mMasterKey)));
-    SuccessOrExit(error = Random::Crypto::FillBuffer(aDataset.mPSKc.m8, sizeof(aDataset.mPSKc)));
+    SuccessOrExit(error = static_cast<Pskc &>(aDataset.mPskc).GenerateRandom());
     SuccessOrExit(error = Random::Crypto::FillBuffer(aDataset.mExtendedPanId.m8, sizeof(aDataset.mExtendedPanId)));
 
     aDataset.mMeshLocalPrefix.m8[0] = 0xfd;
@@ -359,7 +359,7 @@ otError ActiveDataset::CreateNewNetwork(otOperationalDataset &aDataset)
     aDataset.mComponents.mIsMeshLocalPrefixPresent = true;
     aDataset.mComponents.mIsPanIdPresent           = true;
     aDataset.mComponents.mIsChannelPresent         = true;
-    aDataset.mComponents.mIsPSKcPresent            = true;
+    aDataset.mComponents.mIsPskcPresent            = true;
     aDataset.mComponents.mIsSecurityPolicyPresent  = true;
     aDataset.mComponents.mIsChannelMaskPresent     = true;
 
@@ -450,24 +450,24 @@ otError ActiveDataset::GenerateLocal(void)
     }
 
     // PSKc
-    if (dataset.Get(Tlv::kPSKc) == NULL)
+    if (dataset.Get(Tlv::kPskc) == NULL)
     {
-        PSKcTlv tlv;
+        PskcTlv tlv;
 
         tlv.Init();
 
-        if (Get<KeyManager>().IsPSKcSet())
+        if (Get<KeyManager>().IsPskcSet())
         {
             // use configured PSKc
-            tlv.SetPSKc(Get<KeyManager>().GetPSKc());
+            tlv.SetPskc(Get<KeyManager>().GetPskc());
         }
         else
         {
             // PSKc has not yet been configured, generate new PSKc at random
-            otPSKc pskc;
+            Pskc pskc;
 
-            SuccessOrExit(error = Random::Crypto::FillBuffer(pskc.m8, sizeof(pskc)));
-            tlv.SetPSKc(pskc);
+            SuccessOrExit(error = pskc.GenerateRandom());
+            tlv.SetPskc(pskc);
         }
 
         dataset.Set(tlv);

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -239,7 +239,7 @@ public:
     /**
      * This method sets the PSK.
      *
-     * @param[in]  aPSK  A pointer to the PSK.
+     * @param[in]  aPsk  A pointer to the PSK.
      *
      * @retval OT_ERROR_NONE          Successfully set the PSK.
      * @retval OT_ERROR_INVALID_ARGS  The PSK is invalid.

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -85,7 +85,7 @@ exit:
     return;
 }
 
-otError Joiner::Start(const char *     aPSKd,
+otError Joiner::Start(const char *     aPskd,
                       const char *     aProvisioningUrl,
                       const char *     aVendorName,
                       const char *     aVendorModel,
@@ -107,8 +107,8 @@ otError Joiner::Start(const char *     aPSKd,
     Get<Mle::MleRouter>().UpdateLinkLocalAddress();
 
     SuccessOrExit(error = Get<Coap::CoapSecure>().Start(kJoinerUdpPort));
-    SuccessOrExit(error = Get<Coap::CoapSecure>().SetPsk(reinterpret_cast<const uint8_t *>(aPSKd),
-                                                         static_cast<uint8_t>(strlen(aPSKd))));
+    SuccessOrExit(error = Get<Coap::CoapSecure>().SetPsk(reinterpret_cast<const uint8_t *>(aPskd),
+                                                         static_cast<uint8_t>(strlen(aPskd))));
 
     for (JoinerRouter *router = &mJoinerRouters[0]; router < OT_ARRAY_END(mJoinerRouters); router++)
     {

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -66,7 +66,7 @@ public:
     /**
      * This method starts the Joiner service.
      *
-     * @param[in]  aPSKd             A pointer to the PSKd.
+     * @param[in]  aPskd             A pointer to the PSKd.
      * @param[in]  aProvisioningUrl  A pointer to the Provisioning URL (may be NULL).
      * @param[in]  aVendorName       A pointer to the Vendor Name (may be NULL).
      * @param[in]  aVendorModel      A pointer to the Vendor Model (may be NULL).
@@ -78,7 +78,7 @@ public:
      * @retval OT_ERROR_NONE  Successfully started the Joiner service.
      *
      */
-    otError Start(const char *     aPSKd,
+    otError Start(const char *     aPskd,
                   const char *     aProvisioningUrl,
                   const char *     aVendorName,
                   const char *     aVendorModel,

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -324,13 +324,13 @@ otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessage
         SuccessOrExit(error = message->AppendTlv(channelMask));
     }
 
-    if ((tlv = dataset.Get(Tlv::kPSKc)) != NULL)
+    if ((tlv = dataset.Get(Tlv::kPskc)) != NULL)
     {
         SuccessOrExit(error = message->AppendTlv(*tlv));
     }
     else
     {
-        PSKcTlv pskc;
+        PskcTlv pskc;
         pskc.Init();
         SuccessOrExit(error = message->AppendTlv(pskc));
     }

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -64,8 +64,8 @@ bool Tlv::IsValid(const Tlv &aTlv)
         rval = static_cast<const NetworkMasterKeyTlv &>(aTlv).IsValid();
         break;
 
-    case Tlv::kPSKc:
-        rval = static_cast<const PSKcTlv &>(aTlv).IsValid();
+    case Tlv::kPskc:
+        rval = static_cast<const PskcTlv &>(aTlv).IsValid();
         break;
 
     case Tlv::kMeshLocalPrefix:

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -78,7 +78,7 @@ public:
         kPanId                   = OT_MESHCOP_TLV_PANID,                    ///< PAN ID TLV
         kExtendedPanId           = OT_MESHCOP_TLV_EXTPANID,                 ///< Extended PAN ID TLV
         kNetworkName             = OT_MESHCOP_TLV_NETWORKNAME,              ///< Network Name TLV
-        kPSKc                    = OT_MESHCOP_TLV_PSKC,                     ///< PSKc TLV
+        kPskc                    = OT_MESHCOP_TLV_PSKC,                     ///< PSKc TLV
         kNetworkMasterKey        = OT_MESHCOP_TLV_MASTERKEY,                ///< Network Master Key TLV
         kNetworkKeySequence      = OT_MESHCOP_TLV_NETWORK_KEY_SEQUENCE,     ///< Network Key Sequence TLV
         kMeshLocalPrefix         = OT_MESHCOP_TLV_MESHLOCALPREFIX,          ///< Mesh Local Prefix TLV
@@ -445,7 +445,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class PSKcTlv : public Tlv
+class PskcTlv : public Tlv
 {
 public:
     /**
@@ -454,7 +454,7 @@ public:
      */
     void Init(void)
     {
-        SetType(kPSKc);
+        SetType(kPskc);
         SetLength(sizeof(*this) - sizeof(Tlv));
     }
 
@@ -473,18 +473,18 @@ public:
      * @returns The PSKc value.
      *
      */
-    const otPSKc &GetPSKc(void) const { return mPSKc; }
+    const Pskc &GetPskc(void) const { return mPskc; }
 
     /**
      * This method sets the PSKc value.
      *
-     * @param[in]  aPSKc  A pointer to the PSKc value.
+     * @param[in]  aPskc  A pointer to the PSKc value.
      *
      */
-    void SetPSKc(const otPSKc &aPSKc) { mPSKc = aPSKc; }
+    void SetPskc(const Pskc &aPskc) { mPskc = aPskc; }
 
 private:
-    otPSKc mPSKc;
+    Pskc mPskc;
 } OT_TOOL_PACKED_END;
 
 /**

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -81,10 +81,10 @@ KeyManager::KeyManager(Instance &aInstance)
     , mKeyRotationTimer(aInstance, &KeyManager::HandleKeyRotationTimer, this)
     , mKekFrameCounter(0)
     , mSecurityPolicyFlags(0xff)
-    , mIsPSKcSet(false)
+    , mIsPskcSet(false)
 {
     mMasterKey = static_cast<const MasterKey &>(kDefaultMasterKey);
-    memset(&mPSKc, 0, sizeof(mPSKc));
+    memset(&mPskc, 0, sizeof(mPskc));
     ComputeKey(mKeySequence, mKey);
 }
 
@@ -100,14 +100,14 @@ void KeyManager::Stop(void)
 }
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
-void KeyManager::SetPSKc(const otPSKc &aPSKc)
+void KeyManager::SetPskc(const Pskc &aPskc)
 {
-    VerifyOrExit(memcmp(&mPSKc, &aPSKc, sizeof(mPSKc)) != 0, Get<Notifier>().SignalIfFirst(OT_CHANGED_PSKC));
-    mPSKc = aPSKc;
+    VerifyOrExit(mPskc != aPskc, Get<Notifier>().SignalIfFirst(OT_CHANGED_PSKC));
+    mPskc = aPskc;
     Get<Notifier>().Signal(OT_CHANGED_PSKC);
 
 exit:
-    mIsPSKcSet = true;
+    mIsPskcSet = true;
 }
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -41,6 +41,7 @@
 #include <openthread/dataset.h>
 
 #include "common/locator.hpp"
+#include "common/random.hpp"
 #include "common/timer.hpp"
 #include "crypto/hmac_sha256.hpp"
 #include "mac/mac_frame.hpp"
@@ -85,6 +86,48 @@ public:
      *
      */
     bool operator!=(const MasterKey &aOther) const { return memcmp(m8, aOther.m8, sizeof(MasterKey)) != 0; }
+
+} OT_TOOL_PACKED_END;
+
+/**
+ * This class represents a Thread Pre-Shared Key for the Commissioner (PSKc).
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+class Pskc : public otPskc
+{
+public:
+    /**
+     * This method evaluates whether or not the Thread PSKc values match.
+     *
+     * @param[in]  aOther  The Thread PSKc to compare.
+     *
+     * @retval TRUE   If the Thread PSKc values match.
+     * @retval FALSE  If the Thread PSKc values do not match.
+     *
+     */
+    bool operator==(const Pskc &aOther) const { return memcmp(m8, aOther.m8, sizeof(Pskc)) == 0; }
+
+    /**
+     * This method evaluates whether or not the Thread PSKc values match.
+     *
+     * @param[in]  aOther  The Thread PSKc to compare.
+     *
+     * @retval TRUE   If the Thread PSKc values do not match.
+     * @retval FALSE  If the Thread PSKc values match.
+     *
+     */
+    bool operator!=(const Pskc &aOther) const { return !(*this == aOther); }
+
+#if !OPENTHREAD_RADIO
+    /**
+     * This method generates a cryptographically secure random sequence to populate the Thread PSKc.
+     *
+     * @retval OT_ERROR_NONE  Successfully generated a random Thread PSKc.
+     *
+     */
+    otError GenerateRandom(void) { return Random::Crypto::FillBuffer(m8, sizeof(Pskc)); }
+#endif
 
 } OT_TOOL_PACKED_END;
 
@@ -150,7 +193,7 @@ public:
      * @retval FALSE if the PSKc is not not configured.
      *
      */
-    bool IsPSKcSet(void) const { return mIsPSKcSet; }
+    bool IsPskcSet(void) const { return mIsPskcSet; }
 
     /**
      * This method returns a pointer to the PSKc.
@@ -158,15 +201,15 @@ public:
      * @returns A reference to the PSKc.
      *
      */
-    const otPSKc &GetPSKc(void) const { return mPSKc; }
+    const Pskc &GetPskc(void) const { return mPskc; }
 
     /**
      * This method sets the PSKc.
      *
-     * @param[in]  aPSKc    A reference to the PSKc.
+     * @param[in]  aPskc    A reference to the PSKc.
      *
      */
-    void SetPSKc(const otPSKc &aPSKc);
+    void SetPskc(const Pskc &aPskc);
 #endif
 
     /**
@@ -428,13 +471,13 @@ private:
     TimerMilli mKeyRotationTimer;
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
-    otPSKc mPSKc;
+    Pskc mPskc;
 #endif
     uint8_t  mKek[kMaxKeyLength];
     uint32_t mKekFrameCounter;
 
     uint8_t mSecurityPolicyFlags;
-    bool    mIsPSKcSet : 1;
+    bool    mIsPskcSet : 1;
 };
 
 /**

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -312,7 +312,7 @@ exit:
 
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_NET_PSKC>(void)
 {
-    return mEncoder.WriteData(otThreadGetPSKc(mInstance)->m8, sizeof(spinel_net_pskc_t));
+    return mEncoder.WriteData(otThreadGetPskc(mInstance)->m8, sizeof(spinel_net_pskc_t));
 }
 
 template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_NET_PSKC>(void)
@@ -325,7 +325,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_NET_PSKC>(void)
 
     VerifyOrExit(len == sizeof(spinel_net_pskc_t), error = OT_ERROR_PARSE);
 
-    error = otThreadSetPSKc(mInstance, reinterpret_cast<const otPSKc *>(ptr));
+    error = otThreadSetPskc(mInstance, reinterpret_cast<const otPskc *>(ptr));
 
 exit:
     return error;
@@ -789,10 +789,10 @@ template <> otError NcpBase::HandlePropertyInsert<SPINEL_PROP_THREAD_JOINERS>(vo
 {
     otError             error         = OT_ERROR_NONE;
     const otExtAddress *eui64         = NULL;
-    const char *        aPSKd         = NULL;
+    const char *        pskd          = NULL;
     uint32_t            joinerTimeout = 0;
 
-    SuccessOrExit(error = mDecoder.ReadUtf8(aPSKd));
+    SuccessOrExit(error = mDecoder.ReadUtf8(pskd));
     SuccessOrExit(error = mDecoder.ReadUint32(joinerTimeout));
 
     if (mDecoder.ReadEui64(eui64) != OT_ERROR_NONE)
@@ -800,7 +800,7 @@ template <> otError NcpBase::HandlePropertyInsert<SPINEL_PROP_THREAD_JOINERS>(vo
         eui64 = NULL;
     }
 
-    error = otCommissionerAddJoiner(mInstance, eui64, aPSKd, joinerTimeout);
+    error = otCommissionerAddJoiner(mInstance, eui64, pskd, joinerTimeout);
 
 exit:
     return error;

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -1078,11 +1078,11 @@ otError NcpBase::EncodeOperationalDataset(const otOperationalDataset &aDataset)
         SuccessOrExit(mEncoder.CloseStruct());
     }
 
-    if (aDataset.mComponents.mIsPSKcPresent)
+    if (aDataset.mComponents.mIsPskcPresent)
     {
         SuccessOrExit(mEncoder.OpenStruct());
         SuccessOrExit(mEncoder.WriteUintPacked(SPINEL_PROP_NET_PSKC));
-        SuccessOrExit(mEncoder.WriteData(aDataset.mPSKc.m8, sizeof(spinel_net_pskc_t)));
+        SuccessOrExit(mEncoder.WriteData(aDataset.mPskc.m8, sizeof(spinel_net_pskc_t)));
         SuccessOrExit(mEncoder.CloseStruct());
     }
 
@@ -1281,10 +1281,10 @@ otError NcpBase::DecodeOperationalDataset(otOperationalDataset &aDataset,
 
                 SuccessOrExit(error = mDecoder.ReadData(psk, len));
                 VerifyOrExit(len == OT_PSKC_MAX_SIZE, error = OT_ERROR_INVALID_ARGS);
-                memcpy(aDataset.mPSKc.m8, psk, OT_PSKC_MAX_SIZE);
+                memcpy(aDataset.mPskc.m8, psk, OT_PSKC_MAX_SIZE);
             }
 
-            aDataset.mComponents.mIsPSKcPresent = true;
+            aDataset.mComponents.mIsPskcPresent = true;
             break;
 
         case SPINEL_PROP_DATASET_SECURITY_POLICY:

--- a/tests/unit/test_pskc.cpp
+++ b/tests/unit/test_pskc.cpp
@@ -45,7 +45,7 @@ void TestMinimumPassphrase(void)
                                     0xcc, 0xd1, 0xe4, 0xc0, 0x1d, 0x01, 0x54, 0xf8};
     const char    passphrase[]   = "123456";
     otInstance *  instance       = testInitInstance();
-    SuccessOrQuit(ot::MeshCoP::Commissioner::GeneratePSKc(passphrase, "OpenThread",
+    SuccessOrQuit(ot::MeshCoP::Commissioner::GeneratePskc(passphrase, "OpenThread",
                                                           static_cast<const ot::Mac::ExtendedPanId &>(sXPanId), pskc),
                   "TestMinimumPassphrase failed to generate PSKc");
     VerifyOrQuit(memcmp(pskc, expectedPskc, sizeof(pskc)) == 0, "TestMinimumPassphrase got wrong pskc");
@@ -75,7 +75,7 @@ void TestMaximumPassphrase(void)
                               "123456781234567";
 
     otInstance *instance = testInitInstance();
-    SuccessOrQuit(ot::MeshCoP::Commissioner::GeneratePSKc(passphrase, "OpenThread",
+    SuccessOrQuit(ot::MeshCoP::Commissioner::GeneratePskc(passphrase, "OpenThread",
                                                           static_cast<const ot::Mac::ExtendedPanId &>(sXPanId), pskc),
                   "TestMaximumPassphrase failed to generate PSKc");
     VerifyOrQuit(memcmp(pskc, expectedPskc, sizeof(pskc)) == 0, "TestMaximumPassphrase got wrong pskc");


### PR DESCRIPTION
 This commit adds a `Pskc` as a wrapper over `otPskc` and also
  renames all the uses of `PSK` into `Psk` to follow our variable
  and type naming convention which treats an acronym as a whole
  word.
