### PR TITLE
[coap] finish cached coap response before sending

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -601,6 +601,7 @@ void CoapBase::ProcessReceivedRequest(Message &aMessage, const Ip6::MessageInfo 
     switch (mResponsesQueue.GetMatchedResponseCopy(aMessage, aMessageInfo, &cachedResponse))
     {
     case OT_ERROR_NONE:
+        cachedResponse->Finish();
         error = Send(*cachedResponse, aMessageInfo);
         // fall through
         ;


### PR DESCRIPTION
The commits fixes the bug that Coap servers send invalid cached responses, specifically messages with Type=CONN, Code=0, MID=0. 
The cached responses should `Finish` before `Send`.

Please find the pcap traces regarding this issue in [pcap.zip](https://github.com/openthread/openthread/files/3619214/pcap.zip)
