### PR TITLE
[coap] optimize call to GetMatchedResponseCopy

### DIFF
--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -403,7 +403,7 @@ private:
      * @param[in]  aRequest      The CoAP message containing Message ID.
      * @param[in]  aMessageInfo  The message info containing source endpoint address and port.
      *
-     * @returns Matching cached response or NULL if not found
+     * @returns Matching cached response or NULL if not found.
      *
      */
     const Message *FindMatchedResponse(const Message &aRequest, const Ip6::MessageInfo &aMessageInfo) const;

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -397,6 +397,17 @@ private:
         kMaxCachedResponses = OPENTHREAD_CONFIG_COAP_SERVER_MAX_CACHED_RESPONSES,
     };
 
+    /**
+     * Check if CoAP response exists in the cache that matches given Message ID and source endpoint.
+     *
+     * @param[in]  aRequest      The CoAP message containing Message ID.
+     * @param[in]  aMessageInfo  The message info containing source endpoint address and port.
+     *
+     * @returns Matching cached response or NULL if not found
+     *
+     */
+    const Message *FindMatchedResponse(const Message &aRequest, const Ip6::MessageInfo &aMessageInfo) const;
+
     void DequeueResponse(Message &aMessage)
     {
         mQueue.Dequeue(aMessage);


### PR DESCRIPTION
Method `ResponsesQueue::EnqueueResponse` was using `GetMatchedResponseCopy` to check if matched response already exists in the cache. The code might clone message only to release it right away, which is not efficient. 

The commits ...
1. Add a new method `ResponsesQueue::FindMatchedResponse` which try to find and return the matched response in the queue, without cloning the message
2. Optimize `EnqueueResponse` by using `FindMatchedResponse`
3. Re-implement `GetMatchedResponseCopy` using `FindMatchedResponse` to  to reduce code redundancy.