### PR TITLE
[meshcop] improve HandleCommissioningGet implementation

### DIFF
--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -225,9 +225,8 @@ private:
     void        HandleCommissioningGet(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     void SendCommissioningGetResponse(const Coap::Message &   aRequest,
-                                      const Ip6::MessageInfo &aMessageInfo,
-                                      const uint8_t *         aTlvs,
-                                      uint8_t                 aLength);
+                                      uint16_t                aLength,
+                                      const Ip6::MessageInfo &aMessageInfo);
     void SendCommissioningSetResponse(const Coap::Message &    aRequest,
                                       const Ip6::MessageInfo & aMessageInfo,
                                       MeshCoP::StateTlv::State aState);


### PR DESCRIPTION
- Fix insufficient length checks.
- Avoid using a large stack buffer.