### PR TITLE
[time] adding Time class

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1966,7 +1966,7 @@ void Interpreter::HandleIcmpReceive(Message &               aMessage,
 
     if (aMessage.Read(aMessage.GetOffset(), sizeof(uint32_t), &timestamp) >= static_cast<int>(sizeof(uint32_t)))
     {
-        mServer->OutputFormat(" time=%dms", TimerMilli::Elapsed(HostSwap32(timestamp)));
+        mServer->OutputFormat(" time=%dms", TimerMilli::GetNow().GetValue() - HostSwap32(timestamp));
     }
 
     mServer->OutputFormat("\r\n");
@@ -2022,7 +2022,7 @@ void Interpreter::ProcessPing(int argc, char *argv[])
 
         case 3:
             SuccessOrExit(error = ParsePingInterval(argv[index], interval));
-            VerifyOrExit(0 < interval && interval <= Timer::kMaxDt, error = OT_ERROR_INVALID_ARGS);
+            VerifyOrExit(0 < interval && interval <= Timer::kMaxDelay, error = OT_ERROR_INVALID_ARGS);
             mInterval = interval;
             break;
 
@@ -2049,7 +2049,7 @@ void Interpreter::HandlePingTimer(Timer &aTimer)
 void Interpreter::HandlePingTimer()
 {
     otError  error     = OT_ERROR_NONE;
-    uint32_t timestamp = HostSwap32(TimerMilli::GetNow());
+    uint32_t timestamp = HostSwap32(TimerMilli::GetNow().GetValue());
 
     otMessage *          message;
     const otMessageInfo *messageInfo = static_cast<const otMessageInfo *>(&mMessageInfo);

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -318,6 +318,7 @@ HEADERS_COMMON                             = \
     common/settings.hpp                      \
     common/string.hpp                        \
     common/tasklet.hpp                       \
+    common/time.hpp                          \
     common/timer.hpp                         \
     common/tlvs.hpp                          \
     common/trickle_timer.hpp                 \

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -320,8 +320,8 @@ otError otThreadGetParentInfo(otInstance *aInstance, otRouterInfo *aParentInfo)
     aParentInfo->mPathCost       = parent->GetCost();
     aParentInfo->mLinkQualityIn  = parent->GetLinkInfo().GetLinkQuality();
     aParentInfo->mLinkQualityOut = parent->GetLinkQualityOut();
-    aParentInfo->mAge       = static_cast<uint8_t>(TimerMilli::MsecToSec(TimerMilli::Elapsed(parent->GetLastHeard())));
-    aParentInfo->mAllocated = true;
+    aParentInfo->mAge            = static_cast<uint8_t>(Time::MsecToSec(TimerMilli::GetNow() - parent->GetLastHeard()));
+    aParentInfo->mAllocated      = true;
     aParentInfo->mLinkEstablished = parent->GetState() == Neighbor::kStateValid;
 
 #if !OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -166,8 +166,9 @@ public:
      *
      * @retval TRUE   If the message shall be sent before the given time.
      * @retval FALSE  Otherwise.
+     *
      */
-    bool IsEarlier(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mNextTimerShot) >= 0); }
+    bool IsEarlier(TimeMilli aTime) const { return aTime >= mNextTimerShot; }
 
     /**
      * This method checks if the message shall be sent after the given time.
@@ -176,8 +177,9 @@ public:
      *
      * @retval TRUE   If the message shall be sent after the given time.
      * @retval FALSE  Otherwise.
+     *
      */
-    bool IsLater(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mNextTimerShot) < 0); }
+    bool IsLater(TimeMilli aTime) const { return aTime < mNextTimerShot; }
 
 private:
     Ip6::Address          mSourceAddress;         ///< IPv6 address of the message source.
@@ -185,7 +187,7 @@ private:
     uint16_t              mDestinationPort;       ///< UDP port of the message destination.
     otCoapResponseHandler mResponseHandler;       ///< A function pointer that is called on response reception.
     void *                mResponseContext;       ///< A pointer to arbitrary context information.
-    uint32_t              mNextTimerShot;         ///< Time when the timer should shoot for this message.
+    TimeMilli             mNextTimerShot;         ///< Time when the timer should shoot for this message.
     uint32_t              mRetransmissionTimeout; ///< Delay that is applied to next retransmission.
     uint8_t               mRetransmissionCount;   ///< Number of retransmissions.
     bool                  mAcknowledged : 1;      ///< Information that request was acknowledged.
@@ -268,7 +270,7 @@ public:
      *
      */
     explicit EnqueuedResponseHeader(const Ip6::MessageInfo &aMessageInfo)
-        : mDequeueTime(TimerMilli::GetNow() + TimerMilli::SecToMsec(kExchangeLifetime))
+        : mDequeueTime(TimerMilli::GetNow() + Time::SecToMsec(kExchangeLifetime))
         , mMessageInfo(aMessageInfo)
     {
     }
@@ -305,7 +307,7 @@ public:
      * @retval FALSE  Otherwise.
      *
      */
-    bool IsEarlier(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mDequeueTime) >= 0); }
+    bool IsEarlier(TimeMilli aTime) const { return aTime >= mDequeueTime; }
 
     /**
      * This method returns number of milliseconds in which the message should be sent.
@@ -324,7 +326,7 @@ public:
     const Ip6::MessageInfo &GetMessageInfo(void) const { return mMessageInfo; }
 
 private:
-    uint32_t               mDequeueTime;
+    TimeMilli              mDequeueTime;
     const Ip6::MessageInfo mMessageInfo;
 };
 

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -88,7 +88,6 @@ enum
  * This class implements metadata required for CoAP retransmission.
  *
  */
-OT_TOOL_PACKED_BEGIN
 class CoapMetadata
 {
     friend class CoapBase;
@@ -192,7 +191,7 @@ private:
     uint8_t               mRetransmissionCount;   ///< Number of retransmissions.
     bool                  mAcknowledged : 1;      ///< Information that request was acknowledged.
     bool                  mConfirmable : 1;       ///< Information that message is confirmable.
-} OT_TOOL_PACKED_END;
+};
 
 /**
  * This class implements CoAP resource handling.

--- a/src/core/common/time.hpp
+++ b/src/core/common/time.hpp
@@ -1,0 +1,263 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for time instance.
+ */
+
+#ifndef TIME_HPP_
+#define TIME_HPP_
+
+#include "openthread-core-config.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace ot {
+
+/**
+ * @addtogroup core-timer
+ *
+ * @brief
+ *   This module includes definitions for the time instance.
+ *
+ * @{
+ *
+ */
+
+/**
+ * This class represents a time instance.
+ *
+ */
+class Time
+{
+public:
+    /**
+     * This constant defines a maximum time duration ensured to be longer than any other duration.
+     *
+     */
+    static const uint32_t kMaxDuration = ~static_cast<uint32_t>(0UL);
+
+    /**
+     * This is the default constructor for a `Time` object.
+     *
+     */
+    Time(void) {}
+
+    /**
+     * This constructor initializes a `Time` object with a given value.
+     *
+     * @param[in] aValue   The numeric time value to initialize the `Time` object.
+     *
+     */
+    explicit Time(uint32_t aValue) { SetValue(aValue); }
+
+    /**
+     * This method gets the numeric time value associated with the `Time` object.
+     *
+     * @returns The numeric `Time` value.
+     *
+     */
+    uint32_t GetValue(void) const { return mValue; }
+
+    /**
+     * This method sets the numeric time value.
+     *
+     * @param[in] aValue   The numeric time value.
+     *
+     */
+    void SetValue(uint32_t aValue) { mValue = aValue; }
+
+    /**
+     * This method calculates the time duration between two `Time` instances.
+     *
+     * @note Expression `(t1 - t2)` returns the duration of the interval starting from `t2` and ending at `t1`. When
+     * calculating the duration, `t2 is assumed to be in the past relative to `t1`. The duration calculation correctly
+     * takes into account the wrapping of numeric value of `Time` instances. The returned value can span the entire
+     * range of the `uint32_t` type.
+     *
+     * @param[in]   aOther  A `Time` instance to subtract from.
+     *
+     * @returns The duration of interval from @p aOther to this `Time` object.
+     *
+     */
+    uint32_t operator-(const Time &aOther) const { return mValue - aOther.mValue; }
+
+    /**
+     * This method returns a new `Time` which is ahead of this `Time` object by a given duration.
+     *
+     * @param[in]   aDuration  A duration.
+     *
+     * @returns A new `Time` which is ahead of this object by @aDuration.
+     *
+     */
+    Time operator+(uint32_t aDuration) const { return Time(mValue + aDuration); }
+
+    /**
+     * This method returns a new `Time` which is behind this `Time` object by a given duration.
+     *
+     * @param[in]   aDuration  A duration.
+     *
+     * @returns A new `Time` which is behind this object by @aDuration.
+     *
+     */
+    Time operator-(uint32_t aDuration) const { return Time(mValue - aDuration); }
+
+    /**
+     * This method moves this `Time` object forward by a given duration.
+     *
+     * @param[in]   aDuration  A duration.
+     *
+     */
+    void operator+=(uint32_t aDuration) { mValue += aDuration; }
+
+    /**
+     * This method moves this `Time` object backward by a given duration.
+     *
+     * @param[in]   aDuration  A duration.
+     *
+     */
+    void operator-=(uint32_t aDuration) { mValue -= aDuration; }
+
+    /**
+     * This method indicates whether two `Time` instances are equal.
+     *
+     * @param[in]   aOther   A `Time` instance to compare with.
+     *
+     * @retval TRUE    The two `Time` instances are equal.
+     * @retval FALSE   The two `Time` instances are not equal.
+     *
+     */
+    bool operator==(const Time &aOther) const { return mValue == aOther.mValue; }
+
+    /**
+     * This method indicates whether two `Time` instance are not equal.
+     *
+     * @param[in]   aOther   A `Time` instance to compare with.
+     *
+     * @retval TRUE    The two `Time` instances are not equal.
+     * @retval FALSE   The two `Time` instances are equal.
+     *
+     */
+    bool operator!=(const Time &aOther) const { return !(*this == aOther); }
+
+    /**
+     * This method indicates whether this `Time` instance is strictly before another one.
+     *
+     * @note The comparison operators correctly take into account the wrapping of `Time` numeric value. For a given
+     * `Time` instance `t0`, any `Time` instance `t` where `(t - t0)` is less than half the range of `uint32_t` type
+     * is considered to be after `t0`, otherwise it is considered to be before 't0' (or equal to it). As an example
+     * to illustrate this model we can use clock hours: If we are at hour 12, hours 1 to 5 are considered to be
+     * after 12, and hours 6 to 11 are considered to be before 12.
+     *
+     * @param[in]   aOther   A `Time` instance to compare with.
+     *
+     * @retval TRUE    This `Time` instance is strictly before @p aOther.
+     * @retval FALSE   This `Time` instance is not strictly before @p aOther.
+     *
+     */
+    bool operator<(const Time &aOther) const { return ((mValue - aOther.mValue) & (1UL << 31)) != 0; }
+
+    /**
+     * This method indicates whether this `Time` instance is after or equal to another one.
+     *
+     * @param[in]   aOther   A `Time` instance to compare with.
+     *
+     * @retval TRUE    This `Time` instance is after or equal to @p aOther.
+     * @retval FALSE   This `Time` instance is not after or equal to @p aOther.
+     *
+     */
+    bool operator>=(const Time &aOther) const { return !(*this < aOther); }
+
+    /**
+     * This method indicates whether this `Time` instance is before or equal to another one.
+     *
+     * @param[in]   aOther   A `Time` instance to compare with.
+     *
+     * @retval TRUE    This `Time` instance is before or equal to @p aOther.
+     * @retval FALSE   This `Time` instance is not before or equal to @p aOther.
+     *
+     */
+    bool operator<=(const Time &aOther) const { return (aOther >= *this); }
+
+    /**
+     * This method indicates whether this `Time` instance is strictly after another one.
+     *
+     * @param[in]   aOther   A `Time` instance to compare with.
+     *
+     * @retval TRUE    This `Time` instance is strictly after @p aOther.
+     * @retval FALSE   This `Time` instance is not strictly after @p aOther.
+     *
+     */
+    bool operator>(const Time &aOther) const { return (aOther < *this); }
+
+    /**
+     * This static method converts a given number of seconds to milliseconds.
+     *
+     * @returns The number of milliseconds.
+     *
+     */
+    static uint32_t SecToMsec(uint32_t aSeconds) { return aSeconds * 1000u; }
+
+    /**
+     * This static method converts a given number of milliseconds to seconds.
+     *
+     * @returns The number of seconds.
+     *
+     */
+    static uint32_t MsecToSec(uint32_t aMilliseconds) { return aMilliseconds / 1000u; }
+
+private:
+    uint32_t mValue;
+};
+
+/**
+ * This type represents a time instance (millisecond time).
+ *
+ */
+typedef Time TimeMilli;
+
+#if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
+
+/**
+ * This type represents a time instance (microsecond time).
+ *
+ */
+typedef Time TimeMicro;
+
+#endif // OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
+
+/**
+ * @}
+ *
+ */
+
+} // namespace ot
+
+#endif // TIME_HPP_

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -45,6 +45,7 @@
 #include "common/debug.hpp"
 #include "common/locator.hpp"
 #include "common/tasklet.hpp"
+#include "common/time.hpp"
 
 namespace ot {
 
@@ -69,9 +70,11 @@ class Timer : public InstanceLocator, public OwnerLocator
     friend class TimerScheduler;
 
 public:
-    static const uint32_t kMaxDt =
-        (1UL << 31) - 1; ///< Maximum permitted value for parameter `aDt` in `Start` and `StartAt` method.
-    static const uint32_t kForeverDt = 0xffffffff; ///< The special forever `aDt` value.
+    /**
+     * This constant defines maximum delay allowed when starting a timer.
+     *
+     */
+    static const uint32_t kMaxDelay = (Time::kMaxDuration >> 1);
 
     /**
      * This function pointer is called when the timer expires.
@@ -93,7 +96,7 @@ public:
         : InstanceLocator(aInstance)
         , OwnerLocator(aOwner)
         , mHandler(aHandler)
-        , mFireTime(0)
+        , mFireTime()
         , mNext(this)
     {
     }
@@ -101,10 +104,10 @@ public:
     /**
      * This method returns the fire time of the timer.
      *
-     * @returns The fire time in milliseconds.
+     * @returns The fire time.
      *
      */
-    uint32_t GetFireTime(void) const { return mFireTime; }
+    Time GetFireTime(void) const { return mFireTime; }
 
     /**
      * This method indicates whether or not the timer instance is running.
@@ -126,13 +129,13 @@ protected:
      * @retval FALSE If the fire time of this timer object is the same or after aTimer's fire time.
      *
      */
-    bool DoesFireBefore(const Timer &aSecondTimer, uint32_t aNow);
+    bool DoesFireBefore(const Timer &aSecondTimer, Time aNow);
 
     void Fired(void) { mHandler(*this); }
 
-    Handler  mHandler;
-    uint32_t mFireTime;
-    Timer *  mNext;
+    Handler mHandler;
+    Time    mFireTime;
+    Timer * mNext;
 };
 
 /**
@@ -156,23 +159,21 @@ public:
     }
 
     /**
-     * This method schedules the timer to fire a @p dt milliseconds from now.
+     * This method schedules the timer to fire after a given delay (in milliseconds) from now.
      *
-     * @param[in]  aDt  The expire time in milliseconds from now.
-     *                  (aDt must be smaller than or equal to kMaxDt).
+     * @param[in]  aDelay   The delay in milliseconds. It must not be longer than `kMaxDelay`.
      *
      */
-    void Start(uint32_t aDt) { StartAt(GetNow(), aDt); }
+    void Start(uint32_t aDelay);
 
     /**
-     * This method schedules the timer to fire at @p aDt milliseconds from @p aT0.
+     * This method schedules the timer to fire after a given delay (in milliseconds) from a given start time.
      *
-     * @param[in]  aT0  The start time in milliseconds.
-     * @param[in]  aDt  The expire time in milliseconds from @p aT0.
-     *                  (aDt must be smaller than or equal to kMaxDt).
+     * @param[in]  aStartTime  The start time.
+     * @param[in]  aDelay      The delay in milliseconds. It must not be longer than `kMaxDelay`.
      *
      */
-    void StartAt(uint32_t aT0, uint32_t aDt);
+    void StartAt(TimeMilli sStartTime, uint32_t aDelay);
 
     /**
      * This method stops the timer.
@@ -181,68 +182,12 @@ public:
     void Stop(void);
 
     /**
-     * This static method returns the time diff in milliseconds between @p aStart and @p aEnd.
-     *
-     * @param[in]   aStart  The start time.
-     * @param[in]   aEnd    The end time.
-     *
-     * @returns The time diff in milliseconds.
-     *
-     */
-    static int32_t Diff(uint32_t aStart, uint32_t aEnd)
-    {
-        uint32_t diff = aEnd - aStart;
-        return reinterpret_cast<int32_t &>(diff);
-    }
-
-    /**
-     * This static method returns the time elapsed in milliseconds from @p aStart to @p aEnd.
-     *
-     * @note This method assumes @p aEnd is after @p aStart.
-     *
-     * @param[in]   aStart  The start time.
-     * @param[in]   aEnd    The end time.
-     *
-     * @returns The elapsed time in milliseconds.
-     *
-     */
-    static uint32_t Elapsed(uint32_t aStart, uint32_t aEnd) { return aEnd - aStart; }
-
-    /**
-     * This static method returns the time passed in milliseconds since @p aStart.
-     *
-     * @note This method assumes now is after @p aStart.
-     *
-     * @param[in]   aStart  The start time.
-     *
-     * @returns The elapsed time in milliseconds.
-     *
-     */
-    static uint32_t Elapsed(uint32_t aStart) { return Elapsed(aStart, GetNow()); }
-
-    /**
      * This static method returns the current time in milliseconds.
      *
      * @returns The current time in milliseconds.
      *
      */
-    static uint32_t GetNow(void) { return otPlatAlarmMilliGetNow(); }
-
-    /**
-     * This static method returns the number of milliseconds given seconds.
-     *
-     * @returns The number of milliseconds.
-     *
-     */
-    static uint32_t SecToMsec(uint32_t aSeconds) { return aSeconds * 1000u; }
-
-    /**
-     * This static method returns the number of seconds given milliseconds.
-     *
-     * @returns The number of seconds.
-     *
-     */
-    static uint32_t MsecToSec(uint32_t aMilliseconds) { return aMilliseconds / 1000u; }
+    static TimeMilli GetNow(void) { return TimeMilli(otPlatAlarmMilliGetNow()); }
 };
 
 /**
@@ -290,22 +235,6 @@ private:
 class TimerScheduler : public InstanceLocator
 {
     friend class Timer;
-
-public:
-    /**
-     * This static method compares two times and indicates if the first time is strictly before (earlier) than the
-     * second time.
-     *
-     * This method requires that the difference between the two given times to be smaller than kMaxDt.
-     *
-     * @param[in] aTimerA   The first time for comparison.
-     * @param[in] aTimerB   The second time for comparison.
-     *
-     * @returns TRUE  if aTimeA is before aTimeB.
-     * @returns FALSE if aTimeA is same time or after aTimeB.
-     *
-     */
-    static bool IsStrictlyBefore(uint32_t aTimeA, uint32_t aTimeB);
 
 protected:
     /**
@@ -436,23 +365,21 @@ public:
     }
 
     /**
-     * This method schedules the timer to fire a @p aDt microseconds from now.
+     * This method schedules the timer to fire after a given delay (in microseconds) from now.
      *
-     * @param[in]  aDt  The expire time in microseconds from now.
-     *                  (aDt must be smaller than or equal to kMaxDt).
+     * @param[in]  aDelay   The delay in microseconds. It must not be be longer than `kMaxDelay`.
      *
      */
-    void Start(uint32_t aDt) { StartAt(GetNow(), aDt); }
+    void Start(uint32_t aDelay);
 
     /**
-     * This method schedules the timer to fire at @p aDt microseconds from @p aT0.
+     * This method schedules the timer to fire after a given delay (in microseconds) from a given start time.
      *
-     * @param[in]  aT0  The start time in microseconds.
-     * @param[in]  aDt  The expire time in microseconds from @p aT0.
-     *                  (aDt must be smaller than or equal to kMaxDt).
+     * @param[in]  aStartTime  The start time.
+     * @param[in]  aDelay      The delay in microseconds. It must not be longer than `kMaxDelay`.
      *
      */
-    void StartAt(uint32_t aT0, uint32_t aDt);
+    void StartAt(TimeMicro aStartTime, uint32_t aDelay);
 
     /**
      * This method stops the timer.
@@ -466,7 +393,7 @@ public:
      * @returns The current time in microseconds.
      *
      */
-    static uint32_t GetNow(void) { return otPlatAlarmMicroGetNow(); }
+    static TimeMicro GetNow(void) { return Time(otPlatAlarmMicroGetNow()); }
 };
 
 /**

--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -300,8 +300,7 @@ void DataPollHandler::ProcessPendingPolls(void)
 
         // Find the child with earliest poll receive time.
 
-        if ((mIndirectTxChild == NULL) ||
-            TimerScheduler::IsStrictlyBefore(child->GetLastHeard(), mIndirectTxChild->GetLastHeard()))
+        if ((mIndirectTxChild == NULL) || (child->GetLastHeard() < mIndirectTxChild->GetLastHeard()))
         {
             mIndirectTxChild = child;
         }

--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -386,8 +386,8 @@ exit:
 
 void DataPollSender::ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector)
 {
-    uint32_t now;
-    uint32_t oldPeriod = mPollPeriod;
+    TimeMilli now;
+    uint32_t  oldPeriod = mPollPeriod;
 
     if (aPollPeriodSelector == kRecalculatePollPeriod)
     {
@@ -408,7 +408,8 @@ void DataPollSender::ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector)
             // a switch to a shorter poll interval, the first data poll
             // will not be sent too quickly (and possibly before the
             // response is available/prepared on the parent node).
-            if (TimerScheduler::IsStrictlyBefore(mTimerStartTime + mPollPeriod, now + kMinPollPeriod))
+
+            if (mTimerStartTime + mPollPeriod < now + kMinPollPeriod)
             {
                 mTimer.StartAt(now, kMinPollPeriod);
             }
@@ -473,7 +474,7 @@ void DataPollSender::HandlePollTimer(Timer &aTimer)
 
 uint32_t DataPollSender::GetDefaultPollPeriod(void) const
 {
-    return TimerMilli::SecToMsec(Get<Mle::MleRouter>().GetTimeout()) -
+    return Time::SecToMsec(Get<Mle::MleRouter>().GetTimeout()) -
            static_cast<uint32_t>(kRetxPollPeriod) * kMaxPollRetxAttempts;
 }
 

--- a/src/core/mac/data_poll_sender.hpp
+++ b/src/core/mac/data_poll_sender.hpp
@@ -271,10 +271,10 @@ private:
     static void HandlePollTimer(Timer &aTimer);
     static void UpdateIfLarger(uint32_t &aPreiod, uint32_t aNewPeriod);
 
-    uint32_t mTimerStartTime;
-    uint32_t mPollPeriod;
-    uint32_t mExternalPollPeriod : 26; //< In milliseconds.
-    uint8_t  mFastPollsUsers : 6;      //< Number of callers which request fast polls.
+    TimeMilli mTimerStartTime;
+    uint32_t  mPollPeriod;
+    uint32_t  mExternalPollPeriod : 26; //< In milliseconds.
+    uint8_t   mFastPollsUsers : 6;      //< Number of callers which request fast polls.
 
     TimerMilli mTimer;
 

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -418,7 +418,7 @@ otError SubMac::EnergyScan(uint8_t aScanChannel, uint16_t aScanDuration)
 
         SetState(kStateEnergyScan);
         mEnergyScanMaxRssi = kInvalidRssiValue;
-        mEnergyScanEndTime = TimerMilli::GetNow() + aScanDuration;
+        mEnergyScanEndTime = TimerMilli::GetNow() + static_cast<uint32_t>(aScanDuration);
         mTimer.Start(0);
     }
     else
@@ -442,7 +442,7 @@ void SubMac::SampleRssi(void)
         }
     }
 
-    if (TimerMilliScheduler::IsStrictlyBefore(TimerMilli::GetNow(), mEnergyScanEndTime))
+    if (TimerMilli::GetNow() < mEnergyScanEndTime)
     {
         mTimer.StartAt(mTimer.GetFireTime(), kEnergyScanRssiSampleInterval);
     }

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -411,7 +411,7 @@ private:
     ExtAddress         mExtAddress;
     bool               mRxOnWhenBackoff;
     int8_t             mEnergyScanMaxRssi;
-    uint32_t           mEnergyScanEndTime;
+    TimeMilli          mEnergyScanEndTime;
     TxFrame &          mTransmitFrame;
     Callbacks          mCallbacks;
     otLinkPcapCallback mPcapCallback;

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -328,7 +328,7 @@ private:
     struct Joiner
     {
         Mac::ExtAddress mEui64;
-        uint32_t        mExpirationTime;
+        TimeMilli       mExpirationTime;
         char            mPsk[Dtls::kPskMaxLength + 1];
         bool            mValid : 1;
         bool            mAny : 1;

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -477,7 +477,7 @@ otError Dataset::AppendMleDatasetTlv(Message &aMessage) const
         }
         else if (cur->GetType() == Tlv::kDelayTimer)
         {
-            uint32_t      elapsed = TimerMilli::Elapsed(mUpdateTime);
+            uint32_t      elapsed = TimerMilli::GetNow() - mUpdateTime;
             DelayTimerTlv delayTimer(static_cast<const DelayTimerTlv &>(*cur));
 
             if (delayTimer.GetDelayTimer() > elapsed)

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -41,6 +41,7 @@
 
 #include "common/locator.hpp"
 #include "common/message.hpp"
+#include "common/timer.hpp"
 #include "meshcop/meshcop_tlvs.hpp"
 
 namespace ot {
@@ -139,7 +140,7 @@ public:
      * @returns The local time the dataset was last updated.
      *
      */
-    uint32_t GetUpdateTime(void) const { return mUpdateTime; }
+    TimeMilli GetUpdateTime(void) const { return mUpdateTime; }
 
     /**
      * This method returns a reference to the Timestamp.
@@ -242,7 +243,7 @@ private:
     void Remove(uint8_t *aStart, uint8_t aLength);
 
     uint8_t   mTlvs[kMaxSize]; ///< The Dataset buffer
-    uint32_t  mUpdateTime;     ///< Local time last updated
+    TimeMilli mUpdateTime;     ///< Local time last updated
     uint16_t  mLength;         ///< The number of valid bytes in @var mTlvs
     Tlv::Type mType;           ///< Active or Pending
 };

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -107,7 +107,7 @@ otError DatasetLocal::Read(Dataset &aDataset) const
         delayTimer = static_cast<DelayTimerTlv *>(aDataset.Get(Tlv::kDelayTimer));
         VerifyOrExit(delayTimer);
 
-        elapsed = TimerMilli::Elapsed(mUpdateTime);
+        elapsed = TimerMilli::GetNow() - mUpdateTime;
 
         if (delayTimer->GetDelayTimer() > elapsed)
         {

--- a/src/core/meshcop/dataset_local.hpp
+++ b/src/core/meshcop/dataset_local.hpp
@@ -121,7 +121,7 @@ public:
      * @returns The local time this dataset was last updated or restored.
      *
      */
-    uint32_t GetUpdateTime(void) const { return mUpdateTime; }
+    TimeMilli GetUpdateTime(void) const { return mUpdateTime; }
 
     /**
      * This method stores the dataset into non-volatile memory.
@@ -156,7 +156,7 @@ private:
     void SetTimestamp(const Dataset &aDataset);
 
     Timestamp mTimestamp;            ///< Active or Pending Timestamp
-    uint32_t  mUpdateTime;           ///< Local time last updated
+    TimeMilli mUpdateTime;           ///< Local time last updated
     Tlv::Type mType;                 ///< Active or Pending
     bool      mTimestampPresent : 1; ///< Whether a timestamp is present
     bool      mSaved : 1;            ///< Whether a dataset is saved in non-volatile

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -808,9 +808,9 @@ void PendingDataset::StartDelayTimer(void)
         uint32_t delay = delayTimer->GetDelayTimer();
 
         // the Timer implementation does not support the full 32 bit range
-        if (delay > Timer::kMaxDt)
+        if (delay > Timer::kMaxDelay)
         {
-            delay = Timer::kMaxDt;
+            delay = Timer::kMaxDelay;
         }
 
         mDelayTimer.StartAt(dataset.GetUpdateTime(), delay);

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -668,7 +668,7 @@ int Dtls::HandleMbedtlsGetTimer(void)
     {
         rval = 2;
     }
-    else if (static_cast<int32_t>(mTimerIntermediate - TimerMilli::GetNow()) <= 0)
+    else if (mTimerIntermediate <= TimerMilli::GetNow())
     {
         rval = 1;
     }

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -471,8 +471,8 @@ private:
 
     TimerMilliContext mTimer;
 
-    uint32_t mTimerIntermediate;
-    bool     mTimerSet : 1;
+    TimeMilli mTimerIntermediate;
+    bool      mTimerSet : 1;
 
     bool mLayerTwoSecurity : 1;
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -387,7 +387,7 @@ void JoinerRouter::SendDelayedJoinerEntrust(void)
 {
     DelayedJoinEntHeader delayedJoinEnt;
     Coap::Message *      message = static_cast<Coap::Message *>(mDelayedJoinEnts.GetHead());
-    uint32_t             now     = TimerMilli::GetNow();
+    TimeMilli            now     = TimerMilli::GetNow();
     Ip6::MessageInfo     messageInfo;
 
     VerifyOrExit(message != NULL);

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -135,7 +135,7 @@ public:
      * @param[in]  aKek          A pointer to the KEK.
      *
      */
-    void Init(uint32_t aSendTime, Ip6::MessageInfo &aMessageInfo, const uint8_t *aKek)
+    void Init(TimeMilli aSendTime, Ip6::MessageInfo &aMessageInfo, const uint8_t *aKek)
     {
         mSendTime    = aSendTime;
         mMessageInfo = aMessageInfo;
@@ -185,7 +185,7 @@ public:
      * @returns  A time when the message shall be sent.
      *
      */
-    uint32_t GetSendTime(void) const { return mSendTime; }
+    TimeMilli GetSendTime(void) const { return mSendTime; }
 
     /**
      * This method returns a destination of the delayed message.
@@ -211,7 +211,7 @@ public:
      * @retval TRUE   If the message shall be sent before the given time.
      * @retval FALSE  Otherwise.
      */
-    bool IsEarlier(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mSendTime) > 0); }
+    bool IsEarlier(TimeMilli aTime) const { return aTime > mSendTime; }
 
     /**
      * This method checks if the message shall be sent after the given time.
@@ -221,11 +221,11 @@ public:
      * @retval TRUE   If the message shall be sent after the given time.
      * @retval FALSE  Otherwise.
      */
-    bool IsLater(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mSendTime) < 0); }
+    bool IsLater(TimeMilli aTime) const { return aTime < mSendTime; }
 
 private:
     Ip6::MessageInfo mMessageInfo;                    ///< Message info of the message to send.
-    uint32_t         mSendTime;                       ///< Time when the message shall be sent.
+    TimeMilli        mSendTime;                       ///< Time when the message shall be sent.
     uint8_t          mKek[KeyManager::kMaxKeyLength]; ///< KEK used by MAC layer to encode this message.
 };
 

--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -113,7 +113,7 @@ void Leader::HandlePetition(Coap::Message &aMessage, const Ip6::MessageInfo &aMe
     }
 
     state = StateTlv::kAccept;
-    mTimer.Start(TimerMilli::SecToMsec(kTimeoutLeaderPetition));
+    mTimer.Start(Time::SecToMsec(kTimeoutLeaderPetition));
 
 exit:
     SendPetitionResponse(aMessage, aMessageInfo, state);
@@ -207,7 +207,7 @@ void Leader::HandleKeepAlive(Coap::Message &aMessage, const Ip6::MessageInfo &aM
         }
 
         responseState = StateTlv::kAccept;
-        mTimer.Start(TimerMilli::SecToMsec(kTimeoutLeaderPetition));
+        mTimer.Start(Time::SecToMsec(kTimeoutLeaderPetition));
     }
 
     SendKeepAliveResponse(aMessage, aMessageInfo, responseState);

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -204,7 +204,7 @@ bool Dhcp6Client::ProcessNextIdentityAssociation()
 
         mIdentityAssociationCurrent = &mIdentityAssociations[i];
 
-        mTrickleTimer.Start(TimerMilli::SecToMsec(kTrickleTimerImin), TimerMilli::SecToMsec(kTrickleTimerImax),
+        mTrickleTimer.Start(Time::SecToMsec(kTrickleTimerImin), Time::SecToMsec(kTrickleTimerImax),
                             TrickleTimer::kModeNormal);
 
         mTrickleTimer.IndicateInconsistent();
@@ -317,7 +317,7 @@ otError Dhcp6Client::AppendElapsedTime(Message &aMessage)
     ElapsedTime option;
 
     option.Init();
-    option.SetElapsedTime(static_cast<uint16_t>(TimerMilli::MsecToSec(TimerMilli::Elapsed(mStartTime))));
+    option.SetElapsedTime(static_cast<uint16_t>(Time::MsecToSec(TimerMilli::GetNow() - mStartTime)));
     return aMessage.Append(&option, sizeof(option));
 }
 

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -154,8 +154,8 @@ private:
 
     TrickleTimer mTrickleTimer;
 
-    uint8_t  mTransactionId[kTransactionIdSize];
-    uint32_t mStartTime;
+    uint8_t   mTransactionId[kTransactionIdSize];
+    TimeMilli mStartTime;
 
     IdentityAssociation  mIdentityAssociations[OPENTHREAD_CONFIG_DHCP6_CLIENT_NUM_PREFIXES];
     IdentityAssociation *mIdentityAssociationCurrent;

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -159,10 +159,10 @@ exit:
 
 Message *Client::CopyAndEnqueueMessage(const Message &aMessage, const QueryMetadata &aQueryMetadata)
 {
-    otError  error       = OT_ERROR_NONE;
-    uint32_t now         = TimerMilli::GetNow();
-    Message *messageCopy = NULL;
-    uint32_t nextTransmissionTime;
+    otError   error       = OT_ERROR_NONE;
+    TimeMilli now         = TimerMilli::GetNow();
+    Message * messageCopy = NULL;
+    TimeMilli nextTransmissionTime;
 
     // Create a message copy for further retransmissions.
     VerifyOrExit((messageCopy = aMessage.Clone()) != NULL, error = OT_ERROR_NO_BUFS);
@@ -394,8 +394,8 @@ void Client::HandleRetransmissionTimer(Timer &aTimer)
 
 void Client::HandleRetransmissionTimer(void)
 {
-    uint32_t         now       = TimerMilli::GetNow();
-    uint32_t         nextDelta = TimerMilli::kForeverDt;
+    TimeMilli        now       = TimerMilli::GetNow();
+    uint32_t         nextDelta = TimeMilli::kMaxDuration;
     QueryMetadata    queryMetadata;
     Message *        message     = mPendingQueries.GetHead();
     Message *        nextMessage = NULL;
@@ -408,7 +408,7 @@ void Client::HandleRetransmissionTimer(void)
 
         if (queryMetadata.IsLater(now))
         {
-            uint32_t diff = TimerMilli::Elapsed(now, queryMetadata.mTransmissionTime);
+            uint32_t diff = queryMetadata.mTransmissionTime - TimerMilli::GetNow();
 
             // Calculate the next delay and choose the lowest.
             if (diff < nextDelta)
@@ -425,12 +425,12 @@ void Client::HandleRetransmissionTimer(void)
             queryMetadata.mTransmissionTime = now + kResponseTimeout;
             queryMetadata.UpdateIn(*message);
 
-            diff = TimerMilli::Elapsed(now, queryMetadata.mTransmissionTime);
+            diff = kResponseTimeout;
 
             // Check if retransmission time is lower than current lowest.
             if (diff < nextDelta)
             {
-                nextDelta = queryMetadata.mTransmissionTime - now;
+                nextDelta = kResponseTimeout;
             }
 
             // Retransmit
@@ -449,7 +449,7 @@ void Client::HandleRetransmissionTimer(void)
         message = nextMessage;
     }
 
-    if (nextDelta != TimerMilli::kForeverDt)
+    if (nextDelta != TimeMilli::kMaxDuration)
     {
         mRetransmissionTimer.Start(nextDelta);
     }

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -49,6 +49,30 @@ using ot::Encoding::BigEndian::HostSwap16;
 namespace ot {
 namespace Dns {
 
+QueryMetadata::QueryMetadata(void)
+    : mHostname(NULL)
+    , mResponseHandler(NULL)
+    , mResponseContext(NULL)
+    , mTransmissionTime()
+    , mDestinationPort(0)
+    , mRetransmissionCount(0)
+{
+    mSourceAddress.Clear();
+    mDestinationAddress.Clear();
+}
+
+QueryMetadata::QueryMetadata(otDnsResponseHandler aHandler, void *aContext)
+    : mHostname(NULL)
+    , mResponseHandler(aHandler)
+    , mResponseContext(aContext)
+    , mTransmissionTime()
+    , mDestinationPort(0)
+    , mRetransmissionCount(0)
+{
+    mSourceAddress.Clear();
+    mDestinationAddress.Clear();
+}
+
 Client::Client(Ip6::Netif &aNetif)
     : mSocket(aNetif.Get<Ip6::Udp>())
     , mMessageId(0)

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -60,7 +60,7 @@ public:
      * Default constructor for the object.
      *
      */
-    QueryMetadata(void) { memset(this, 0, sizeof(*this)); }
+    QueryMetadata(void);
 
     /**
      * This constructor initializes the object with specific values.
@@ -69,12 +69,7 @@ public:
      * @param[in]  aContext  Context for the handler function.
      *
      */
-    QueryMetadata(otDnsResponseHandler aHandler, void *aContext)
-    {
-        memset(this, 0, sizeof(*this));
-        mResponseHandler = aHandler;
-        mResponseContext = aContext;
-    }
+    QueryMetadata(otDnsResponseHandler aHandler, void *aContext);
 
     /**
      * This method appends request data to the message.

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -122,7 +122,7 @@ public:
      * @retval TRUE   If the message shall be sent before the given time.
      * @retval FALSE  Otherwise.
      */
-    bool IsEarlier(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mTransmissionTime) > 0); }
+    bool IsEarlier(TimeMilli aTime) const { return aTime > mTransmissionTime; }
 
     /**
      * This method checks if the message shall be sent after the given time.
@@ -132,13 +132,13 @@ public:
      * @retval TRUE   If the message shall be sent after the given time.
      * @retval FALSE  Otherwise.
      */
-    bool IsLater(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mTransmissionTime) < 0); }
+    bool IsLater(TimeMilli aTime) const { return aTime < mTransmissionTime; }
 
 private:
     const char *         mHostname;            ///< A hostname to be find.
     otDnsResponseHandler mResponseHandler;     ///< A function pointer that is called on response reception.
     void *               mResponseContext;     ///< A pointer to arbitrary context information.
-    uint32_t             mTransmissionTime;    ///< Time when the timer should shoot for this message.
+    TimeMilli            mTransmissionTime;    ///< Time when the timer should shoot for this message.
     Ip6::Address         mSourceAddress;       ///< IPv6 address of the message source.
     Ip6::Address         mDestinationAddress;  ///< IPv6 address of the message destination.
     uint16_t             mDestinationPort;     ///< UDP port of the message destination.

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -51,7 +51,6 @@ namespace Dns {
  * This class implements metadata required for DNS retransmission.
  *
  */
-OT_TOOL_PACKED_BEGIN
 class QueryMetadata
 {
     friend class Client;
@@ -143,7 +142,7 @@ private:
     Ip6::Address         mDestinationAddress;  ///< IPv6 address of the message destination.
     uint16_t             mDestinationPort;     ///< UDP port of the message destination.
     uint8_t              mRetransmissionCount; ///< Number of retransmissions.
-} OT_TOOL_PACKED_END;
+};
 
 /**
  * This class implements DNS client.

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -320,7 +320,7 @@ public:
      * @retval TRUE   If the message shall be sent before the given time.
      * @retval FALSE  Otherwise.
      */
-    bool IsEarlier(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mTransmissionTime) > 0); }
+    bool IsEarlier(TimeMilli aTime) const { return aTime > mTransmissionTime; }
 
     /**
      * This method checks if the message shall be sent after the given time.
@@ -330,7 +330,7 @@ public:
      * @retval TRUE   If the message shall be sent after the given time.
      * @retval FALSE  Otherwise.
      */
-    bool IsLater(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mTransmissionTime) < 0); }
+    bool IsLater(TimeMilli aTime) const { return aTime < mTransmissionTime; }
 
     /**
      * This method returns the MPL Seed Id value.
@@ -386,7 +386,7 @@ public:
      * @returns The transmission timestamp of the message.
      *
      */
-    uint32_t GetTransmissionTime(void) const { return mTransmissionTime; }
+    TimeMilli GetTransmissionTime(void) const { return mTransmissionTime; }
 
     /**
      * This method sets the transmission timestamp of the message.
@@ -394,7 +394,7 @@ public:
      * @param[in]  aTransmissionTime  The transmission timestamp of the message.
      *
      */
-    void SetTransmissionTime(uint32_t aTransmissionTime) { mTransmissionTime = aTransmissionTime; }
+    void SetTransmissionTime(TimeMilli aTransmissionTime) { mTransmissionTime = aTransmissionTime; }
 
     /**
      * This method returns the offset from the transmission time to the end of trickle interval.
@@ -418,14 +418,14 @@ public:
      * @param[in] aCurrentTime Current time (in milliseconds).
      * @param[in] aInterval    The current interval size (in milliseconds).
      */
-    void GenerateNextTransmissionTime(uint32_t aCurrentTime, uint8_t aInterval);
+    void GenerateNextTransmissionTime(TimeMilli aCurrentTime, uint8_t aInterval);
 
 private:
-    uint16_t mSeedId;
-    uint8_t  mSequence;
-    uint8_t  mTransmissionCount;
-    uint32_t mTransmissionTime;
-    uint8_t  mIntervalOffset;
+    uint16_t  mSeedId;
+    uint8_t   mSequence;
+    uint8_t   mTransmissionCount;
+    TimeMilli mTransmissionTime;
+    uint8_t   mIntervalOffset;
 } OT_TOOL_PACKED_END;
 
 /**

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -247,7 +247,6 @@ private:
  * This class represents metadata required for MPL retransmissions.
  *
  */
-OT_TOOL_PACKED_BEGIN
 class MplBufferedMessageMetadata
 {
 public:
@@ -426,7 +425,7 @@ private:
     uint8_t   mTransmissionCount;
     TimeMilli mTransmissionTime;
     uint8_t   mIntervalOffset;
-} OT_TOOL_PACKED_END;
+};
 
 /**
  * This class implements MPL message processing.

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -48,6 +48,49 @@
 namespace ot {
 namespace Sntp {
 
+Header::Header(void)
+    : mFlags(kNtpVersion << kVersionOffset | kModeClient << kModeOffset)
+    , mStratum(0)
+    , mPoll(0)
+    , mPrecision(0)
+    , mRootDelay(0)
+    , mRootDispersion(0)
+    , mReferenceId(0)
+    , mReferenceTimestampSeconds(0)
+    , mReferenceTimestampFraction(0)
+    , mOriginateTimestampSeconds(0)
+    , mOriginateTimestampFraction(0)
+    , mReceiveTimestampSeconds(0)
+    , mReceiveTimestampFraction(0)
+    , mTransmitTimestampSeconds(0)
+    , mTransmitTimestampFraction(0)
+{
+}
+
+QueryMetadata::QueryMetadata(void)
+    : mTransmitTimestamp(0)
+    , mResponseHandler(NULL)
+    , mResponseContext(NULL)
+    , mTransmissionTime(0)
+    , mDestinationPort(0)
+    , mRetransmissionCount(0)
+{
+    mSourceAddress.Clear();
+    mDestinationAddress.Clear();
+}
+
+QueryMetadata::QueryMetadata(otSntpResponseHandler aHandler, void *aContext)
+    : mTransmitTimestamp(0)
+    , mResponseHandler(aHandler)
+    , mResponseContext(aContext)
+    , mTransmissionTime(0)
+    , mDestinationPort(0)
+    , mRetransmissionCount(0)
+{
+    mSourceAddress.Clear();
+    mDestinationAddress.Clear();
+}
+
 Client::Client(Ip6::Netif &aNetif)
     : mSocket(aNetif.Get<Ip6::Udp>())
     , mRetransmissionTimer(aNetif.GetInstance(), &Client::HandleRetransmissionTimer, this)

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -98,14 +98,14 @@ otError Client::Query(const otSntpQuery *aQuery, otSntpResponseHandler aHandler,
     VerifyOrExit(aQuery->mMessageInfo != NULL, error = OT_ERROR_INVALID_ARGS);
 
     // Originate timestamp is used only as a unique token.
-    header.SetTransmitTimestampSeconds(TimerMilli::GetNow() / 1000 + kTimeAt1970);
+    header.SetTransmitTimestampSeconds(TimerMilli::GetNow().GetValue() / 1000 + kTimeAt1970);
 
     VerifyOrExit((message = NewMessage(header)) != NULL, error = OT_ERROR_NO_BUFS);
 
     messageInfo = static_cast<const Ip6::MessageInfo *>(aQuery->mMessageInfo);
 
     queryMetadata.mTransmitTimestamp   = header.GetTransmitTimestampSeconds();
-    queryMetadata.mTransmissionTime    = TimerMilli::GetNow() + kResponseTimeout;
+    queryMetadata.mTransmissionTime    = TimerMilli::GetNow() + static_cast<uint32_t>(kResponseTimeout);
     queryMetadata.mSourceAddress       = messageInfo->GetSockAddr();
     queryMetadata.mDestinationPort     = messageInfo->GetPeerPort();
     queryMetadata.mDestinationAddress  = messageInfo->GetPeerAddr();
@@ -146,10 +146,10 @@ exit:
 
 Message *Client::CopyAndEnqueueMessage(const Message &aMessage, const QueryMetadata &aQueryMetadata)
 {
-    otError  error       = OT_ERROR_NONE;
-    uint32_t now         = TimerMilli::GetNow();
-    Message *messageCopy = NULL;
-    uint32_t nextTransmissionTime;
+    otError   error       = OT_ERROR_NONE;
+    TimeMilli now         = TimerMilli::GetNow();
+    Message * messageCopy = NULL;
+    TimeMilli nextTransmissionTime;
 
     // Create a message copy for further retransmissions.
     VerifyOrExit((messageCopy = aMessage.Clone()) != NULL, error = OT_ERROR_NO_BUFS);
@@ -268,8 +268,8 @@ void Client::HandleRetransmissionTimer(Timer &aTimer)
 
 void Client::HandleRetransmissionTimer(void)
 {
-    uint32_t         now       = TimerMilli::GetNow();
-    uint32_t         nextDelta = TimerMilli::kForeverDt;
+    TimeMilli        now       = TimerMilli::GetNow();
+    uint32_t         nextDelta = TimeMilli::kMaxDuration;
     QueryMetadata    queryMetadata;
     Message *        message     = mPendingQueries.GetHead();
     Message *        nextMessage = NULL;
@@ -282,7 +282,7 @@ void Client::HandleRetransmissionTimer(void)
 
         if (queryMetadata.IsLater(now))
         {
-            uint32_t diff = TimerMilli::Elapsed(now, queryMetadata.mTransmissionTime);
+            uint32_t diff = queryMetadata.mTransmissionTime - now;
 
             // Calculate the next delay and choose the lowest.
             if (diff < nextDelta)
@@ -299,7 +299,7 @@ void Client::HandleRetransmissionTimer(void)
             queryMetadata.mTransmissionTime = now + kResponseTimeout;
             queryMetadata.UpdateIn(*message);
 
-            diff = TimerMilli::Elapsed(now, queryMetadata.mTransmissionTime);
+            diff = kResponseTimeout;
 
             // Check if retransmission time is lower than current lowest.
             if (diff < nextDelta)
@@ -323,7 +323,7 @@ void Client::HandleRetransmissionTimer(void)
         message = nextMessage;
     }
 
-    if (nextDelta != TimerMilli::kForeverDt)
+    if (nextDelta != TimeMilli::kMaxDuration)
     {
         mRetransmissionTimer.Start(nextDelta);
     }

--- a/src/core/net/sntp_client.hpp
+++ b/src/core/net/sntp_client.hpp
@@ -60,13 +60,7 @@ public:
      * Default constructor for SNTP Header.
      *
      */
-    Header(void)
-    {
-        memset(this, 0, sizeof(*this));
-
-        // Set default value of flags field.
-        SetFlags(kNtpVersion << kVersionOffset | kModeClient << kModeOffset);
-    }
+    Header(void);
 
     /**
      * Defines supported SNTP modes.
@@ -430,7 +424,7 @@ public:
      * Default constructor for the object.
      *
      */
-    QueryMetadata(void) { memset(this, 0, sizeof(*this)); }
+    QueryMetadata(void);
 
     /**
      * This constructor initializes the object with specific values.
@@ -439,12 +433,7 @@ public:
      * @param[in]  aContext  Context for the handler function.
      *
      */
-    QueryMetadata(otSntpResponseHandler aHandler, void *aContext)
-    {
-        memset(this, 0, sizeof(*this));
-        mResponseHandler = aHandler;
-        mResponseContext = aContext;
-    }
+    QueryMetadata(otSntpResponseHandler aHandler, void *aContext);
 
     /**
      * This method appends request data to the message.

--- a/src/core/net/sntp_client.hpp
+++ b/src/core/net/sntp_client.hpp
@@ -421,7 +421,6 @@ private:
  * This class implements metadata required for SNTP retransmission.
  *
  */
-OT_TOOL_PACKED_BEGIN
 class QueryMetadata
 {
     friend class Client;
@@ -513,7 +512,7 @@ private:
     Ip6::Address          mDestinationAddress;  ///< IPv6 address of the message destination.
     uint16_t              mDestinationPort;     ///< UDP port of the message destination.
     uint8_t               mRetransmissionCount; ///< Number of retransmissions.
-} OT_TOOL_PACKED_END;
+};
 
 /**
  * This class implements SNTP client.

--- a/src/core/net/sntp_client.hpp
+++ b/src/core/net/sntp_client.hpp
@@ -492,7 +492,7 @@ public:
      * @retval TRUE   If the message shall be sent before the given time.
      * @retval FALSE  Otherwise.
      */
-    bool IsEarlier(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mTransmissionTime) > 0); }
+    bool IsEarlier(TimeMilli aTime) const { return aTime > mTransmissionTime; }
 
     /**
      * This method checks if the message shall be sent after the given time.
@@ -502,13 +502,13 @@ public:
      * @retval TRUE   If the message shall be sent after the given time.
      * @retval FALSE  Otherwise.
      */
-    bool IsLater(uint32_t aTime) const { return (static_cast<int32_t>(aTime - mTransmissionTime) < 0); }
+    bool IsLater(TimeMilli aTime) const { return aTime < mTransmissionTime; }
 
 private:
     uint32_t              mTransmitTimestamp;   ///< Time at the client when the request departed for the server.
     otSntpResponseHandler mResponseHandler;     ///< A function pointer that is called on response reception.
     void *                mResponseContext;     ///< A pointer to arbitrary context information.
-    uint32_t              mTransmissionTime;    ///< Time when the timer should shoot for this message.
+    TimeMilli             mTransmissionTime;    ///< Time when the timer should shoot for this message.
     Ip6::Address          mSourceAddress;       ///< IPv6 address of the message source.
     Ip6::Address          mDestinationAddress;  ///< IPv6 address of the message destination.
     uint16_t              mDestinationPort;     ///< UDP port of the message destination.

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -660,7 +660,7 @@ void AddressResolver::HandleAddressQuery(Coap::Message &aMessage, const Ip6::Mes
         if (child.HasIp6Address(GetInstance(), targetTlv.GetTarget()))
         {
             mlIidTlv.SetIid(child.GetExtAddress());
-            lastTransactionTimeTlv.SetTime(TimerMilli::Elapsed(child.GetLastHeard()));
+            lastTransactionTimeTlv.SetTime(TimerMilli::GetNow() - child.GetLastHeard());
             SendAddressQueryResponse(targetTlv, mlIidTlv, &lastTransactionTimeTlv, aMessageInfo.GetPeerAddr());
             ExitNow();
         }

--- a/src/core/thread/child_table.cpp
+++ b/src/core/thread/child_table.cpp
@@ -102,7 +102,15 @@ ChildTable::ChildTable(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mMaxChildrenAllowed(kMaxChildren)
 {
-    memset(mChildren, 0, sizeof(mChildren));
+    Clear();
+}
+
+void ChildTable::Clear(void)
+{
+    for (Child *child = &mChildren[0]; child < OT_ARRAY_END(mChildren); child++)
+    {
+        child->Clear();
+    }
 }
 
 Child *ChildTable::GetChildAtIndex(uint16_t aChildIndex)
@@ -124,7 +132,7 @@ Child *ChildTable::GetNewChild(void)
     {
         if (child->GetState() == Child::kStateInvalid)
         {
-            memset(child, 0, sizeof(Child));
+            child->Clear();
             ExitNow();
         }
     }

--- a/src/core/thread/child_table.hpp
+++ b/src/core/thread/child_table.hpp
@@ -170,7 +170,7 @@ public:
      * This method clears the child table.
      *
      */
-    void Clear(void) { memset(mChildren, 0, sizeof(mChildren)); }
+    void Clear(void);
 
     /**
      * This method returns the child table index for a given `Child` instance.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -117,7 +117,7 @@ Mle::Mle(Instance &aInstance)
 
     memset(&mLeaderData, 0, sizeof(mLeaderData));
     memset(&mParentLeaderData, 0, sizeof(mParentLeaderData));
-    memset(&mParent, 0, sizeof(mParent));
+    mParent.Clear();
     memset(&mChildIdRequest, 0, sizeof(mChildIdRequest));
     memset(&mLinkLocal64, 0, sizeof(mLinkLocal64));
     memset(&mMeshLocal64, 0, sizeof(mMeshLocal64));
@@ -125,7 +125,7 @@ Mle::Mle(Instance &aInstance)
     memset(&mLinkLocalAllThreadNodes, 0, sizeof(mLinkLocalAllThreadNodes));
     memset(&mRealmLocalAllThreadNodes, 0, sizeof(mRealmLocalAllThreadNodes));
     memset(&mLeaderAloc, 0, sizeof(mLeaderAloc));
-    memset(&mParentCandidate, 0, sizeof(mParentCandidate));
+    mParentCandidate.Clear();
     ResetCounters();
 
     // link-local 64
@@ -423,7 +423,7 @@ otError Mle::Restore(void)
             ExitNow();
         }
 
-        memset(&mParent, 0, sizeof(mParent));
+        mParent.Clear();
         mParent.SetExtAddress(*static_cast<Mac::ExtAddress *>(&parentInfo.mExtAddress));
         mParent.SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
                                          DeviceMode::kModeFullNetworkData | DeviceMode::kModeSecureDataRequest));
@@ -3175,8 +3175,7 @@ exit:
 
 void Mle::ResetParentCandidate(void)
 {
-    memset(&mParentCandidate, 0, sizeof(mParentCandidate));
-    mParentCandidate.SetState(Neighbor::kStateInvalid);
+    mParentCandidate.Clear();
 }
 
 otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, uint32_t aKeySequence)

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -360,7 +360,6 @@ private:
  * This class implements functionality required for delaying MLE responses.
  *
  */
-OT_TOOL_PACKED_BEGIN
 class DelayedResponseHeader
 {
 public:
@@ -461,7 +460,7 @@ public:
 private:
     Ip6::Address mDestination; ///< IPv6 address of the message destination.
     TimeMilli    mSendTime;    ///< Time when the message shall be sent.
-} OT_TOOL_PACKED_END;
+};
 
 /**
  * This class implements MLE functionality required by the Thread EndDevices, Router, and Leader roles.

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -367,7 +367,12 @@ public:
      * Default constructor for the object.
      *
      */
-    DelayedResponseHeader(void) { memset(this, 0, sizeof(*this)); }
+    DelayedResponseHeader(void)
+        : mDestination()
+        , mSendTime(0)
+    {
+        mDestination.Clear();
+    }
 
     /**
      * This constructor initializes the object with specific values.
@@ -377,9 +382,9 @@ public:
      *
      */
     DelayedResponseHeader(TimeMilli aSendTime, const Ip6::Address &aDestination)
+        : mDestination(aDestination)
+        , mSendTime(aSendTime)
     {
-        mSendTime    = aSendTime;
-        mDestination = aDestination;
     }
 
     /**

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -377,7 +377,7 @@ public:
      * @param[in]  aDestination  IPv6 address of the message destination.
      *
      */
-    DelayedResponseHeader(uint32_t aSendTime, const Ip6::Address &aDestination)
+    DelayedResponseHeader(TimeMilli aSendTime, const Ip6::Address &aDestination)
     {
         mSendTime    = aSendTime;
         mDestination = aDestination;
@@ -426,7 +426,7 @@ public:
      * @returns  A time when the message shall be sent.
      *
      */
-    uint32_t GetSendTime(void) const { return mSendTime; }
+    TimeMilli GetSendTime(void) const { return mSendTime; }
 
     /**
      * This method returns a destination of the delayed message.
@@ -443,8 +443,9 @@ public:
      *
      * @retval TRUE   If the message shall be sent before the given time.
      * @retval FALSE  Otherwise.
+     *
      */
-    bool IsEarlier(uint32_t aTime) { return (static_cast<int32_t>(aTime - mSendTime) > 0); }
+    bool IsEarlier(TimeMilli aTime) { return aTime > mSendTime; }
 
     /**
      * This method checks if the message shall be sent after the given time.
@@ -453,12 +454,13 @@ public:
      *
      * @retval TRUE   If the message shall be sent after the given time.
      * @retval FALSE  Otherwise.
+     *
      */
-    bool IsLater(uint32_t aTime) { return (static_cast<int32_t>(aTime - mSendTime) < 0); }
+    bool IsLater(TimeMilli aTime) { return aTime < mSendTime; }
 
 private:
     Ip6::Address mDestination; ///< IPv6 address of the message destination.
-    uint32_t     mSendTime;    ///< Time when the message shall be sent.
+    TimeMilli    mSendTime;    ///< Time when the message shall be sent.
 } OT_TOOL_PACKED_END;
 
 /**
@@ -1794,7 +1796,7 @@ private:
     bool       mParentSearchIsInBackoff : 1;
     bool       mParentSearchBackoffWasCanceled : 1;
     bool       mParentSearchRecentlyDetached : 1;
-    uint32_t   mParentSearchBackoffCancelTime;
+    TimeMilli  mParentSearchBackoffCancelTime;
     TimerMilli mParentSearchTimer;
 #endif
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1650,8 +1650,6 @@ otError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::Messa
     {
         VerifyOrExit((child = mChildTable.GetNewChild()) != NULL);
 
-        memset(child, 0, sizeof(*child));
-
         // MAC Address
         child->SetExtAddress(macAddr);
         child->GetLinkInfo().Clear();
@@ -3531,7 +3529,7 @@ void MleRouter::RestoreChildren(void)
             foundDuplicate = true;
         }
 
-        memset(child, 0, sizeof(*child));
+        child->Clear();
 
         child->SetExtAddress(*static_cast<const Mac::ExtAddress *>(&childInfo.mExtAddress));
         child->GetLinkInfo().Clear();

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -996,7 +996,8 @@ otError NetworkData::SendServerDataNotification(uint16_t aRloc16)
     Coap::Message *  message = NULL;
     Ip6::MessageInfo messageInfo;
 
-    VerifyOrExit(!mLastAttemptWait || TimerMilli::Elapsed(mLastAttempt) < kDataResubmitDelay, error = OT_ERROR_ALREADY);
+    VerifyOrExit(!mLastAttemptWait || (TimerMilli::GetNow() - mLastAttempt < kDataResubmitDelay),
+                 error = OT_ERROR_ALREADY);
 
     VerifyOrExit((message = Get<Coap::Coap>().NewMessage()) != NULL, error = OT_ERROR_NO_BUFS);
 

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -41,6 +41,7 @@
 
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
+#include "common/timer.hpp"
 #include "net/udp6.hpp"
 #include "thread/lowpan.hpp"
 #include "thread/mle_router.hpp"
@@ -517,7 +518,7 @@ private:
 
     const Type mType;
     bool       mLastAttemptWait;
-    uint32_t   mLastAttempt;
+    TimeMilli  mLastAttempt;
 };
 
 } // namespace NetworkData

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -1193,9 +1193,9 @@ void Leader::StartContextReuseTimer(uint8_t aContextId)
 {
     mContextLastUsed[aContextId - kMinContextId] = TimerMilli::GetNow();
 
-    if (mContextLastUsed[aContextId - kMinContextId] == 0)
+    if (mContextLastUsed[aContextId - kMinContextId].GetValue() == 0)
     {
-        mContextLastUsed[aContextId - kMinContextId] = 1;
+        mContextLastUsed[aContextId - kMinContextId].SetValue(1);
     }
 
     mTimer.Start(kStateUpdatePeriod);
@@ -1203,7 +1203,7 @@ void Leader::StartContextReuseTimer(uint8_t aContextId)
 
 void Leader::StopContextReuseTimer(uint8_t aContextId)
 {
-    mContextLastUsed[aContextId - kMinContextId] = 0;
+    mContextLastUsed[aContextId - kMinContextId].SetValue(0);
 }
 
 otError Leader::SendServerDataNotification(uint16_t aRloc16)
@@ -1559,12 +1559,12 @@ void Leader::HandleTimer(void)
 
     for (uint8_t i = 0; i < kNumContextIds; i++)
     {
-        if (mContextLastUsed[i] == 0)
+        if (mContextLastUsed[i].GetValue() == 0)
         {
             continue;
         }
 
-        if (TimerMilli::Elapsed(mContextLastUsed[i]) >= TimerMilli::SecToMsec(mContextIdReuseDelay))
+        if (TimerMilli::GetNow() - mContextLastUsed[i] >= Time::SecToMsec(mContextIdReuseDelay))
         {
             FreeContext(kMinContextId + i);
         }

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -244,7 +244,7 @@ private:
     };
 
     uint16_t   mContextUsed;
-    uint32_t   mContextLastUsed[kNumContextIds];
+    TimeMilli  mContextLastUsed[kNumContextIds];
     uint32_t   mContextIdReuseDelay;
     TimerMilli mTimer;
 

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -441,7 +441,7 @@ otError RouterTable::GetRouterInfo(uint16_t aRouterId, otRouterInfo &aRouterInfo
     aRouterInfo.mPathCost        = router->GetCost();
     aRouterInfo.mLinkQualityIn   = router->GetLinkInfo().GetLinkQuality();
     aRouterInfo.mLinkQualityOut  = router->GetLinkQualityOut();
-    aRouterInfo.mAge = static_cast<uint8_t>(TimerMilli::MsecToSec(TimerMilli::Elapsed(router->GetLastHeard())));
+    aRouterInfo.mAge             = static_cast<uint8_t>(Time::MsecToSec(TimerMilli::GetNow() - router->GetLastHeard()));
 
 exit:
     return error;
@@ -454,8 +454,7 @@ Router *RouterTable::GetLeader(void)
 
 uint32_t RouterTable::GetLeaderAge(void) const
 {
-    return (mActiveRouterCount > 0) ? TimerMilli::MsecToSec(TimerMilli::Elapsed(mRouterIdSequenceLastUpdated))
-                                    : 0xffffffff;
+    return (mActiveRouterCount > 0) ? Time::MsecToSec(TimerMilli::GetNow() - mRouterIdSequenceLastUpdated) : 0xffffffff;
 }
 
 uint8_t RouterTable::GetNeighborCount(void) const

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -183,7 +183,7 @@ void RouterTable::UpdateAllocation(void)
 
             if (router.GetRouterId() != routerId)
             {
-                memset(&router, 0, sizeof(router));
+                router.Clear();
                 router.SetRloc16(Mle::Mle::GetRloc16(routerId));
                 router.SetNextHop(Mle::kInvalidRouterId);
             }
@@ -194,7 +194,7 @@ void RouterTable::UpdateAllocation(void)
     for (uint8_t index = mActiveRouterCount; index < Mle::kMaxRouters; index++)
     {
         Router &router = mRouters[index];
-        memset(&router, 0, sizeof(router));
+        router.Clear();
         router.SetRloc16(0xffff);
     }
 }

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -290,7 +290,7 @@ public:
      * @returns The local time when the Router ID Sequence was last updated.
      *
      */
-    uint32_t GetRouterIdSequenceLastUpdated(void) const { return mRouterIdSequenceLastUpdated; }
+    TimeMilli GetRouterIdSequenceLastUpdated(void) const { return mRouterIdSequenceLastUpdated; }
 
     /**
      * This method returns the number of neighbor links.
@@ -356,7 +356,7 @@ private:
     Router      mRouters[Mle::kMaxRouters];
     RouterIdSet mAllocatedRouterIds;
     uint8_t     mRouterIdReuseDelay[Mle::kMaxRouterId + 1];
-    uint32_t    mRouterIdSequenceLastUpdated;
+    TimeMilli   mRouterIdSequenceLastUpdated;
     uint8_t     mRouterIdSequence;
     uint8_t     mActiveRouterCount;
 };

--- a/src/core/thread/time_sync_service.hpp
+++ b/src/core/thread/time_sync_service.hpp
@@ -209,10 +209,10 @@ private:
     uint16_t mTimeSyncPeriod;   ///< The time synchronization period.
     uint16_t mXtalThreshold;    ///< The XTAL accuracy threshold for a device to become a Router, in PPM.
 #if OPENTHREAD_FTD
-    uint32_t mLastTimeSyncSent; ///< The time when the last time synchronization message was sent.
+    TimeMilli mLastTimeSyncSent; ///< The time when the last time synchronization message was sent.
 #endif
-    uint32_t mLastTimeSyncReceived; ///< The time when the last time synchronization message was received.
-    int64_t  mNetworkTimeOffset;    ///< The time offset to the Thread Network time
+    TimeMilli mLastTimeSyncReceived; ///< The time when the last time synchronization message was received.
+    int64_t   mNetworkTimeOffset;    ///< The time offset to the Thread Network time
     otNetworkTimeSyncCallbackFn
                         mTimeSyncCallback; ///< The callback to be called when time sync is handled or status updated.
     void *              mTimeSyncCallbackContext; ///< The context to be passed to callback.

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -46,6 +46,12 @@ void Neighbor::GenerateChallenge(void)
     Random::NonCrypto::FillBuffer(mValidPending.mPending.mChallenge, sizeof(mValidPending.mPending.mChallenge));
 }
 
+void Child::Clear(void)
+{
+    memset(reinterpret_cast<void *>(this), 0, sizeof(Child));
+    SetState(kStateInvalid);
+}
+
 bool Child::IsStateValidOrAttaching(void) const
 {
     bool rval = false;
@@ -238,6 +244,12 @@ exit:
 void Child::GenerateChallenge(void)
 {
     Random::NonCrypto::FillBuffer(mAttachChallenge, sizeof(mAttachChallenge));
+}
+
+void Router::Clear(void)
+{
+    memset(reinterpret_cast<void *>(this), 0, sizeof(Router));
+    SetState(kStateInvalid);
 }
 
 } // namespace ot

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -435,6 +435,12 @@ public:
     };
 
     /**
+     * This method clears the child entry.
+     *
+     */
+    void Clear(void);
+
+    /**
      * This method indicates if the child state is valid or being attached or being restored.
      *
      * The states `kStateRestored`, `kStateChildIdRequest`, `kStateChildUpdateRequest`, `kStateValid`, (and
@@ -654,6 +660,12 @@ private:
 class Router : public Neighbor
 {
 public:
+    /**
+     * This method clears the router entry.
+     *
+     */
+    void Clear(void);
+
     /**
      * This method gets the router ID of the next hop to this router.
      *

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -40,6 +40,7 @@
 
 #include "common/message.hpp"
 #include "common/random.hpp"
+#include "common/timer.hpp"
 #include "mac/mac_frame.hpp"
 #include "net/ip6.hpp"
 #include "thread/device_mode.hpp"
@@ -208,7 +209,7 @@ public:
      * @returns The last heard time.
      *
      */
-    uint32_t GetLastHeard(void) const { return mLastHeard; }
+    TimeMilli GetLastHeard(void) const { return mLastHeard; }
 
     /**
      * This method sets the last heard time.
@@ -216,7 +217,7 @@ public:
      * @param[in]  aLastHeard  The last heard time.
      *
      */
-    void SetLastHeard(uint32_t aLastHeard) { mLastHeard = aLastHeard; }
+    void SetLastHeard(TimeMilli aLastHeard) { mLastHeard = aLastHeard; }
 
     /**
      * This method gets the link frame counter value.
@@ -344,7 +345,7 @@ public:
 
 private:
     Mac::ExtAddress mMacAddr;   ///< The IEEE 802.15.4 Extended Address
-    uint32_t        mLastHeard; ///< Time when last heard.
+    TimeMilli       mLastHeard; ///< Time when last heard.
     union
     {
         struct

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -98,7 +98,7 @@ void ChannelManager::PreparePendingDataset(void)
 {
     uint64_t             pendingTimestamp       = 0;
     uint64_t             pendingActiveTimestamp = 0;
-    uint32_t             delayInMs              = TimerMilli::SecToMsec(static_cast<uint32_t>(mDelay));
+    uint32_t             delayInMs              = Time::SecToMsec(static_cast<uint32_t>(mDelay));
     otOperationalDataset dataset;
     otError              error;
 
@@ -216,7 +216,7 @@ void ChannelManager::PreparePendingDataset(void)
     else
     {
         otLogInfoUtil("ChannelManager: %s error in dataset update (channel change %d), retry in %d sec",
-                      otThreadErrorToString(error), mChannel, TimerMilli::MsecToSec(kPendingDatasetTxRetryInterval));
+                      otThreadErrorToString(error), mChannel, Time::MsecToSec(kPendingDatasetTxRetryInterval));
 
         mTimer.Start(kPendingDatasetTxRetryInterval);
     }
@@ -393,7 +393,7 @@ void ChannelManager::StartAutoSelectTimer(void)
 
     if (mAutoSelectEnabled)
     {
-        mTimer.Start(TimerMilli::SecToMsec(mAutoSelectInterval));
+        mTimer.Start(Time::SecToMsec(mAutoSelectInterval));
     }
     else
     {
@@ -419,14 +419,13 @@ otError ChannelManager::SetAutoChannelSelectionInterval(uint32_t aInterval)
     otError  error        = OT_ERROR_NONE;
     uint32_t prevInterval = mAutoSelectInterval;
 
-    VerifyOrExit((aInterval != 0) && (aInterval <= TimerMilli::MsecToSec(Timer::kMaxDt)),
-                 error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit((aInterval != 0) && (aInterval <= Time::MsecToSec(Timer::kMaxDelay)), error = OT_ERROR_INVALID_ARGS);
 
     mAutoSelectInterval = aInterval;
 
     if (mAutoSelectEnabled && (mState == kStateIdle) && mTimer.IsRunning() && (prevInterval != aInterval))
     {
-        mTimer.StartAt(mTimer.GetFireTime() - TimerMilli::SecToMsec(prevInterval), TimerMilli::SecToMsec(aInterval));
+        mTimer.StartAt(mTimer.GetFireTime() - Time::SecToMsec(prevInterval), Time::SecToMsec(aInterval));
     }
 
 exit:

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -222,7 +222,7 @@ void SupervisionListener::RestartTimer(void)
     if ((mTimeout != 0) && (Get<Mle::MleRouter>().GetRole() != OT_DEVICE_ROLE_DISABLED) &&
         !Get<MeshForwarder>().GetRxOnWhenIdle())
     {
-        mTimer.Start(TimerMilli::SecToMsec(mTimeout));
+        mTimer.Start(Time::SecToMsec(mTimeout));
     }
     else
     {

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -208,7 +208,7 @@ exit:
 
 void JamDetector::UpdateHistory(bool aDidExceedThreshold)
 {
-    int32_t diff = TimerMilli::Diff(mCurSecondStartTime, TimerMilli::GetNow());
+    uint32_t interval = TimerMilli::GetNow() - mCurSecondStartTime;
 
     // If the RSSI is ever below the threshold, update mAlwaysAboveThreshold
     // for current second interval.
@@ -218,7 +218,8 @@ void JamDetector::UpdateHistory(bool aDidExceedThreshold)
     }
 
     // If we reached end of current one second interval, update the history bitmap
-    if (diff >= kOneSecondInterval)
+
+    if (interval >= kOneSecondInterval)
     {
         mHistoryBitmap <<= 1;
 
@@ -229,7 +230,7 @@ void JamDetector::UpdateHistory(bool aDidExceedThreshold)
 
         mAlwaysAboveThreshold = true;
 
-        mCurSecondStartTime += (static_cast<uint32_t>(diff) / kOneSecondInterval) * kOneSecondInterval;
+        mCurSecondStartTime += (interval / kOneSecondInterval) * kOneSecondInterval;
 
         UpdateJamState();
     }

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -198,7 +198,7 @@ private:
     Notifier::Callback mNotifierCallback;         // Notifier callback
     TimerMilli         mTimer;                    // RSSI sample timer
     uint64_t           mHistoryBitmap;            // History bitmap, each bit correspond to 1 sec interval
-    uint32_t           mCurSecondStartTime;       // Start time for current 1 sec interval
+    TimeMilli          mCurSecondStartTime;       // Start time for current 1 sec interval
     uint16_t           mSampleInterval;           // Current sample interval
     uint8_t            mWindow : 6;               // Window (in sec) to monitor jamming
     uint8_t            mBusyPeriod : 6;           // BusyPeriod (in sec) with mWindow to alert jamming


### PR DESCRIPTION
This commit adds `Time` class which represents an instance of time (it is a simple wrapper over a `uint32_t` corresponding to a numerical time value). The `Time` class provides helpful operator overloads:
- Operators `+` and `-` with a `Time` instance and a `Duration` to get a `Time` instance after or before.
- Operator `-` with two `Time` instances to calculate the `Duration` between two time instances.
 - Operators `<`, `<=`, `>`,`>=`, `==`, and `!=` to compare two `Time` instances. They correctly handle the wrapping of the numeric time value.
    
The core modules are updated to use the new `Time` and `Duration` types which help make the code simpler. This commit also updates the unit test `test_timer` to add test cases for newly
added types.

-----
The main reason for adding a `Time` class (which simply wraps over the `uint32_t` time tick count) is to ensure the comparison operators (`<`, `>`, `<=` and `>=`) are overloaded and behave correctly when the raw time tick count value is wrapped. 

This blocks a (common) wrong use pattern in the code where two raw time (`uint32_t`) values `t1` and `t2` are compared using `t1 < t2` to determine if time `t1` is before `t2`. 
- For example, if `t1 = 0xfffffffe` and `t2` is 5 ticks ahead at `t2 = 0x3`, the check `t1 < t2` would be `false` where as `t1` should be considered before `t2`.
- Such a use would be wrong only when the raw values wrap. For a millisecond `uint32_t` tick time, the wrap happens every ~50 days, so for a large span of time things would work fine leading to bugs that are tricky to find.

The new `Time` class allows this use pattern by overloading the operator to handle the warping correctly which in turn help us avoid such errors in future code.

-----

Another aspect addressed by this PR is the code pattern used to compare two raw `uint32_t` time tick values using `static_cast<int32_t>(t1 - t2) < 0` to determine if `t1` is before `t2` ([example](https://github.com/openthread/openthread/blob/7d423506932df0e1027e2c9d920ef8e9cfab080b/src/core/thread/mle.hpp#L457)). The type casting from an unsigned to a signed integer is (from C++ standard) an undefined behavior [https://en.cppreference.com/w/cpp/language/implicit_conversion]. How this is handled is left to the implementation of compiler/toolchain. While most toolchains do what we expect (i.e. convert a large `uint32_t` value to a negative `int32_t` value), this is not guaranteed (have been bitten by a toolchain not behaving like this in a previous project). This PR ensures that we don't need to use the `static_cast<int32_t>` thus making the code safer.

