### PR TITLE
[build] fix missing definitions in configure.ac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ jobs:
     - env: BUILD_TARGET="android-build" VERBOSE=1
       os: linux
       dist: trusty
+      python: "2.7" # The old Android build system only supports python2
       script: .travis/script.sh
     - env: BUILD_TARGET="posix-distcheck" VERBOSE=1 VIRTUAL_TIME=1
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,6 @@ jobs:
     - env: BUILD_TARGET="android-build" VERBOSE=1
       os: linux
       dist: trusty
-      python: "2.7"
       script: .travis/script.sh
     - env: BUILD_TARGET="posix-distcheck" VERBOSE=1 VIRTUAL_TIME=1
       os: linux
@@ -73,12 +72,10 @@ jobs:
     - env: BUILD_TARGET="posix-32-bit" VERBOSE=1 VIRTUAL_TIME=1
       os: linux
       compiler: gcc
-      python: "2.7"
       script: .travis/script.sh
     - env: BUILD_TARGET="posix-32-bit" VERBOSE=1 VIRTUAL_TIME=1 TIME_SYNC=1
       os: linux
       compiler: gcc
-      python: "2.7"
       script: .travis/script.sh
     - env: BUILD_TARGET="posix-ncp" VERBOSE=1 VIRTUAL_TIME=1
       os: linux
@@ -178,7 +175,6 @@ jobs:
     - env: BUILD_TARGET="toranj-test-framework" VERBOSE=1 TORANJ_POSIX_APP_RCP_MODEL=1
       os: linux
       compiler: gcc
-      python: "2.7"
       script: .travis/script.sh
     - env: BUILD_TARGET="osx" VERBOSE=1
       os: osx

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -47,7 +47,7 @@ cd /tmp || die
         pip install -r $TRAVIS_BUILD_DIR/tests/scripts/thread-cert/requirements.txt || die
         [ $BUILD_TARGET != posix-ncp -a $BUILD_TARGET != posix-app-ncp ] || {
             # Packages used by ncp tools.
-            pip install git+https://github.com/openthread/pyspinel.git@style/remove-python2 || die
+            pip install git+https://github.com/bukepo/pyspinel.git@style/remove-python2 || die
         }
     }
 

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -47,7 +47,7 @@ cd /tmp || die
         pip install -r $TRAVIS_BUILD_DIR/tests/scripts/thread-cert/requirements.txt || die
         [ $BUILD_TARGET != posix-ncp -a $BUILD_TARGET != posix-app-ncp ] || {
             # Packages used by ncp tools.
-            pip install git+https://github.com/bukepo/pyspinel.git@style/remove-python2 || die
+            pip install git+https://github.com/openthread/pyspinel.git@style/remove-python2 || die
         }
     }
 

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -47,7 +47,7 @@ cd /tmp || die
         pip install -r $TRAVIS_BUILD_DIR/tests/scripts/thread-cert/requirements.txt || die
         [ $BUILD_TARGET != posix-ncp -a $BUILD_TARGET != posix-app-ncp ] || {
             # Packages used by ncp tools.
-            pip install git+https://github.com/openthread/pyspinel.git@style/remove-python2 || die
+            pip install git+https://github.com/openthread/pyspinel || die
         }
     }
 

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -47,7 +47,7 @@ cd /tmp || die
         pip install -r $TRAVIS_BUILD_DIR/tests/scripts/thread-cert/requirements.txt || die
         [ $BUILD_TARGET != posix-ncp -a $BUILD_TARGET != posix-app-ncp ] || {
             # Packages used by ncp tools.
-            pip install git+https://github.com/openthread/pyspinel || die
+            pip install git+https://github.com/openthread/pyspinel.git@style/remove-python2 || die
         }
     }
 

--- a/configure.ac
+++ b/configure.ac
@@ -406,6 +406,8 @@ fi
 
 if test "$enable_builtin_mbedtls" = "yes"; then
     CPPFLAGS="${CPPFLAGS} -DOPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS=1"
+else
+    CPPFLAGS="${CPPFLAGS} -DOPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS=0"
 fi
 
 AC_MSG_CHECKING([whether mbed TLS should be enabled])
@@ -435,6 +437,8 @@ AC_ARG_ENABLE(posix-app,
 
 if test "$enable_posix_app" = "yes"; then
     CPPFLAGS="${CPPFLAGS} -DOPENTHREAD_PLATFORM_POSIX_APP=1"
+else
+    CPPFLAGS="${CPPFLAGS} -DOPENTHREAD_PLATFORM_POSIX_APP=0"
 fi
 
 AC_MSG_RESULT(${enable_posix_app})
@@ -463,6 +467,8 @@ AC_ARG_ENABLE(posix-app-daemon,
 
 if test "$enable_posix_app_daemon" = "yes"; then
     CPPFLAGS="${CPPFLAGS} -DOPENTHREAD_ENABLE_POSIX_APP_DAEMON=1"
+else
+    CPPFLAGS="${CPPFLAGS} -DOPENTHREAD_ENABLE_POSIX_APP_DAEMON=0"
 fi
 
 AC_MSG_RESULT(${enable_posix_app_daemon})
@@ -656,7 +662,6 @@ AC_ARG_WITH(
         then AC_MSG_ERROR([Can't open ${withval} for --with-vendor-extension])
         else
             OPENTHREAD_ENABLE_VENDOR_EXTENSION=1
-            CPPFLAGS="${CPPFLAGS} -DOPENTHREAD_ENABLE_VENDOR_EXTENSION=1"
 
             # Get the absolute path.
             OPENTHREAD_VENDOR_EXTENSION_SOURCE=$(cd `dirname ${withval}` && pwd)/$(basename ${withval})
@@ -667,6 +672,7 @@ AC_ARG_WITH(
         with_vendor_extension=none
     ])
 
+CPPFLAGS="${CPPFLAGS} -DOPENTHREAD_ENABLE_VENDOR_EXTENSION=${OPENTHREAD_ENABLE_VENDOR_EXTENSION}"
 AC_MSG_CHECKING([for vendor extension])
 AC_MSG_RESULT(${OPENTHREAD_VENDOR_EXTENSION_SOURCE-none})
 AC_SUBST(OPENTHREAD_VENDOR_EXTENSION_SOURCE)
@@ -714,7 +720,6 @@ AC_ARG_WITH(
         then OPENTHREAD_ENABLE_NCP_SPINEL_ENCRYPTER=0
         else
             OPENTHREAD_ENABLE_NCP_SPINEL_ENCRYPTER=1
-            CPPFLAGS="${CPPFLAGS} -DOPENTHREAD_ENABLE_NCP_SPINEL_ENCRYPTER=1"
             OPENTHREAD_NCP_SPINEL_ENCRYPTER_LIBS=${withval}
         fi
     ],
@@ -723,6 +728,7 @@ AC_ARG_WITH(
         with_ncp_spinel_encrypter_libs=none
     ])
 
+CPPFLAGS="${CPPFLAGS} -DOPENTHREAD_ENABLE_NCP_SPINEL_ENCRYPTER=${OPENTHREAD_ENABLE_NCP_SPINEL_ENCRYPTER}"
 AC_MSG_CHECKING([for NCP Spinel Encrypter])
 AC_MSG_RESULT(${OPENTHREAD_NCP_SPINEL_ENCRYPTER_LIBS-none})
 AC_SUBST(OPENTHREAD_NCP_SPINEL_ENCRYPTER_LIBS)
@@ -850,7 +856,7 @@ NL_ENABLE_DOCS([auto],[NO])
 
 AM_CONDITIONAL(OPENTHREAD_BUILD_DOCS, [test "${nl_cv_build_docs}" = "yes"])
 
-AM_CONDITIONAL(OPENTHREAD_POSIX, [test "${enable_posix_app}" = "yes" -o "${OPENTHREAD_EXAMPLES_POSIX}" = "1"])
+AM_CONDITIONAL(OPENTHREAD_POSIX, [test "${enable_posix_app}" = "yes" -o "${with_examples}" = "posix"])
 
 #
 # Checks for libraries and packages.

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -47,12 +47,14 @@ namespace ot {
 namespace Cli {
 
 const struct CoapSecure::Command CoapSecure::sCommands[] = {
-    {"help", &CoapSecure::ProcessHelp},         {"connect", &CoapSecure::ProcessConnect},
-    {"delete", &CoapSecure::ProcessRequest},    {"disconnect", &CoapSecure::ProcessDisconnect},
-    {"get", &CoapSecure::ProcessRequest},       {"post", &CoapSecure::ProcessRequest},
-    {"psk", &CoapSecure::ProcessPsk},           {"put", &CoapSecure::ProcessRequest},
-    {"resource", &CoapSecure::ProcessResource}, {"start", &CoapSecure::ProcessStart},
-    {"stop", &CoapSecure::ProcessStop},
+    {"help", &CoapSecure::ProcessHelp},      {"connect", &CoapSecure::ProcessConnect},
+    {"delete", &CoapSecure::ProcessRequest}, {"disconnect", &CoapSecure::ProcessDisconnect},
+    {"get", &CoapSecure::ProcessRequest},    {"post", &CoapSecure::ProcessRequest},
+    {"put", &CoapSecure::ProcessRequest},    {"resource", &CoapSecure::ProcessResource},
+    {"start", &CoapSecure::ProcessStart},    {"stop", &CoapSecure::ProcessStop},
+#ifdef MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
+    {"psk", &CoapSecure::ProcessPsk},
+#endif
 #ifdef MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
     {"x509", &CoapSecure::ProcessX509},
 #endif
@@ -341,6 +343,7 @@ otError CoapSecure::ProcessDisconnect(int argc, char *argv[])
     return OT_ERROR_NONE;
 }
 
+#ifdef MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
 otError CoapSecure::ProcessPsk(int argc, char *argv[])
 {
     otError error = OT_ERROR_NONE;
@@ -364,6 +367,7 @@ otError CoapSecure::ProcessPsk(int argc, char *argv[])
 exit:
     return error;
 }
+#endif // MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
 
 #ifdef MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 otError CoapSecure::ProcessX509(int argc, char *argv[])


### PR DESCRIPTION
This PR adds missing definitions in configure.ac to fix configure with
options like `--disable-FEATURE`. This is because some features are
enabled by default, if missing defining as `0`, the `--disable-FEATURE`
will not work.