### PR TITLE
[meshcop] partially updates Commissioner Dataset

### DIFF
--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -261,6 +261,16 @@ void Leader::HandleCommissioningSet(Coap::Message &aMessage, const Ip6::MessageI
                     VerifyOrExit(length + cur->GetSize() <= sizeof(tlvs));
                     memcpy(tlvs + length, reinterpret_cast<uint8_t *>(cur), cur->GetSize());
                     length += cur->GetSize();
+                } else {
+                    MeshCoP::Tlv tlv;
+                    // If there is no valid TLV with the type in incoming request,
+                    // merge the TLV in local Commissioning Dataset.
+                    if (MeshCoP::Tlv::GetTlv(aMessage, cur->GetType(), sizeof(tlv), tlv) != OT_ERROR_NONE)
+                    {
+                        VerifyOrExit(length + cur->GetSize() <= sizeof(tlvs));
+                        memcpy(tlvs + length, reinterpret_cast<uint8_t *>(cur), cur->GetSize());
+                        length += cur->GetSize();
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR fix the problem that the leader always override local Commissioner Dataset with incoming `MGMT_COMMISSIONER_SET.req` message while the message can only include a subset of the Commissioner Dataset. This will result in losing all TLVs that is not present in current message.

This PR fix this by merge all TLVs in local Commissioner Dataset, if it is not present in current message.

## Discussion
https://threadgroup.atlassian.net/browse/SPEC-889?atlOrigin=eyJpIjoiYzQ5OTQzYjM5OWVkNDkyNzg2ODU4YzAxNWEwZDllNzkiLCJwIjoiaiJ9

## Test
This is manually tested with [ot-commissioner](https://github.com/openthread/ot-commissioner) with following command sequence:
```bash
> start :: 49191 # petition with border agent at [::]:49191
> joiner getport meshcop # this should result in Error::NotFound
> joiner setport meshcop 1002 # set the MeshCoP Joiner UDP Port to 1002
> joiner enableall meshcop # enable all MeshCoP joiners by setting Steering Data TLV
> network pull # pull commissioner dataset to local
> joiner getport meshcop # make sure the previous set MeshCoP Joiner UDP Port is not overridden by subsequent joiner steering command
```

## Review
Please see [the first commit](https://github.com/openthread/openthread/commit/a92345f4644c2957cfe8212e25ab9af3867718e0) for logic changes. The second commit is just for reusing the `GetCommissioningData()` method.
