### PR TITLE
[coap] add IsBound() check in Coap::Send

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -895,7 +895,7 @@ void Coap::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessage
 
 otError Coap::Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    return mSocket.SendTo(aMessage, aMessageInfo);
+    return mSocket.IsBound() ? mSocket.SendTo(aMessage, aMessageInfo) : OT_ERROR_INVALID_STATE;
 }
 
 } // namespace Coap


### PR DESCRIPTION
This commit add IsBound() judge before send message. Otherwise, it might
crash on Send() when the ifconfig is down.