### PR TITLE
[commissioner]  update how Provisioning URL is stored

### DIFF
--- a/include/openthread/commissioner.h
+++ b/include/openthread/commissioner.h
@@ -81,6 +81,8 @@ typedef enum otCommissionerJoinerEvent
 #define OT_COMMISSIONING_PASSPHRASE_MIN_SIZE 6   ///< Minimum size of the Commissioning Passphrase
 #define OT_COMMISSIONING_PASSPHRASE_MAX_SIZE 255 ///< Maximum size of the Commissioning Passphrase
 
+#define OT_PROVISIONING_URL_MAX_SIZE 64 ///< Max size (number of chars) in Provisioning URL string (excludes null char).
+
 #define OT_STEERING_DATA_MAX_LENGTH 16 ///< Max steering data length (bytes)
 
 /**
@@ -230,23 +232,20 @@ otError otCommissionerRemoveJoiner(otInstance *aInstance, const otExtAddress *aE
  * This function gets the Provisioning URL.
  *
  * @param[in]    aInstance       A pointer to an OpenThread instance.
- * @param[out]   aLength         A pointer to `uint16_t` to return the length (number of chars) in the URL string.
  *
- * Note that the returned URL string buffer is not necessarily null-terminated.
- *
- * @returns A pointer to char buffer containing the URL string, or NULL if @p aLength is NULL.
+ * @returns A pointer to the URL string.
  *
  */
-const char *otCommissionerGetProvisioningUrl(otInstance *aInstance, uint16_t *aLength);
+const char *otCommissionerGetProvisioningUrl(otInstance *aInstance);
 
 /**
  * This function sets the Provisioning URL.
  *
  * @param[in]  aInstance             A pointer to an OpenThread instance.
- * @param[in]  aProvisioningUrl      A pointer to the Provisioning URL (may be NULL).
+ * @param[in]  aProvisioningUrl      A pointer to the Provisioning URL (may be NULL to set as empty string).
  *
  * @retval OT_ERROR_NONE          Successfully set the Provisioning URL.
- * @retval OT_ERROR_INVALID_ARGS  @p aProvisioningUrl is invalid.
+ * @retval OT_ERROR_INVALID_ARGS  @p aProvisioningUrl is invalid (too long).
  *
  */
 otError otCommissionerSetProvisioningUrl(otInstance *aInstance, const char *aProvisioningUrl);

--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -102,18 +102,11 @@ otError otCommissionerSetProvisioningUrl(otInstance *aInstance, const char *aPro
     return instance.Get<MeshCoP::Commissioner>().SetProvisioningUrl(aProvisioningUrl);
 }
 
-const char *otCommissionerGetProvisioningUrl(otInstance *aInstance, uint16_t *aLength)
+const char *otCommissionerGetProvisioningUrl(otInstance *aInstance)
 {
-    const char *url = NULL;
-
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    if (aLength != NULL)
-    {
-        url = instance.Get<MeshCoP::Commissioner>().GetProvisioningUrl(*aLength);
-    }
-
-    return url;
+    return instance.Get<MeshCoP::Commissioner>().GetProvisioningUrl();
 }
 
 otError otCommissionerAnnounceBegin(otInstance *        aInstance,

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -374,11 +374,6 @@ exit:
     return error;
 }
 
-const char *Commissioner::GetProvisioningUrl(void) const
-{
-    return mProvisioningUrl;
-}
-
 otError Commissioner::SetProvisioningUrl(const char *aProvisioningUrl)
 {
     otError error = OT_ERROR_NONE;
@@ -399,16 +394,6 @@ otError Commissioner::SetProvisioningUrl(const char *aProvisioningUrl)
 
 exit:
     return error;
-}
-
-uint16_t Commissioner::GetSessionId(void) const
-{
-    return mSessionId;
-}
-
-otCommissionerState Commissioner::GetState(void) const
-{
-    return mState;
 }
 
 void Commissioner::HandleTimer(Timer &aTimer)

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -89,6 +89,8 @@ void Commissioner::SetState(otCommissionerState aState)
 {
     VerifyOrExit(mState != aState);
 
+    otLogInfoMeshCoP("Commissioner State: %s -> %s", StateToString(mState), StateToString(aState));
+
     mState = aState;
 
     if (mStateCallback)
@@ -1124,6 +1126,36 @@ otError Commissioner::GeneratePskc(const char *              aPassPhrase,
 exit:
     return error;
 }
+
+// LCOV_EXCL_START
+
+#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MLE == 1)
+
+const char *Commissioner::StateToString(otCommissionerState aState)
+{
+    const char *str = "Unknown";
+
+    switch (aState)
+    {
+    case OT_COMMISSIONER_STATE_DISABLED:
+        str = "disabled";
+        break;
+    case OT_COMMISSIONER_STATE_PETITION:
+        str = "petition";
+        break;
+    case OT_COMMISSIONER_STATE_ACTIVE:
+        str = "active";
+        break;
+    default:
+        break;
+    }
+
+    return str;
+}
+
+#endif // (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MLE == 1)
+
+// LCOV_EXCL_STOP
 
 } // namespace MeshCoP
 } // namespace ot

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -137,22 +137,18 @@ public:
     /**
      * This method gets the Provisioning URL.
      *
-     * @param[out]   aLength     A reference to `uint16_t` to return the length (number of chars) in the URL string.
-     *
-     * Note that the returned URL string buffer is not necessarily null-terminated.
-     *
      * @returns A pointer to char buffer containing the URL string.
      *
      */
-    const char *GetProvisioningUrl(uint16_t &aLength) const;
+    const char *GetProvisioningUrl(void) const;
 
     /**
      * This method sets the Provisioning URL.
      *
-     * @param[in]  aProvisioningUrl  A pointer to the Provisioning URL (may be NULL).
+     * @param[in]  aProvisioningUrl  A pointer to the Provisioning URL (may be NULL to set URL to empty string).
      *
-     * @retval OT_ERROR_NONE          Successfully added the Joiner.
-     * @retval OT_ERROR_INVALID_ARGS  @p aProvisioningUrl is invalid.
+     * @retval OT_ERROR_NONE          Successfully set the Provisioning URL.
+     * @retval OT_ERROR_INVALID_ARGS  @p aProvisioningUrl is invalid (too long).
      *
      */
     otError SetProvisioningUrl(const char *aProvisioningUrl);
@@ -356,7 +352,7 @@ private:
 
     Ip6::NetifUnicastAddress mCommissionerAloc;
 
-    ProvisioningUrlTlv mProvisioningUrl;
+    char mProvisioningUrl[OT_PROVISIONING_URL_MAX_SIZE + 1]; // + 1 is for null char at end of string.
 
     otCommissionerStateCallback  mStateCallback;
     otCommissionerJoinerCallback mJoinerCallback;

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -340,12 +340,11 @@ private:
     uint8_t    mJoinerIid[Ip6::Address::kInterfaceIdentifierSize];
     uint16_t   mJoinerPort;
     uint16_t   mJoinerRloc;
-    uint8_t    mJoinerIndex;
-    TimerMilli mJoinerExpirationTimer;
-
-    TimerMilli mTimer;
     uint16_t   mSessionId;
+    uint8_t    mJoinerIndex;
     uint8_t    mTransmitAttempts;
+    TimerMilli mJoinerExpirationTimer;
+    TimerMilli mTimer;
 
     Coap::Resource mRelayReceive;
     Coap::Resource mDatasetChanged;

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -140,7 +140,7 @@ public:
      * @returns A pointer to char buffer containing the URL string.
      *
      */
-    const char *GetProvisioningUrl(void) const;
+    const char *GetProvisioningUrl(void) const { return mProvisioningUrl; }
 
     /**
      * This method sets the Provisioning URL.
@@ -159,7 +159,7 @@ public:
      * @returns The Commissioner Session ID.
      *
      */
-    uint16_t GetSessionId(void) const;
+    uint16_t GetSessionId(void) const { return mSessionId; }
 
     /**
      * This method indicates whether or not the Commissioner role is active.
@@ -179,7 +179,7 @@ public:
      * @retval OT_COMMISSIONER_STATE_ACTIVE    Commissioner enabled.
      *
      */
-    otCommissionerState GetState(void) const;
+    otCommissionerState GetState(void) const { return mState; }
 
     /**
      * This method sends MGMT_COMMISSIONER_GET.

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -323,6 +323,8 @@ private:
     void SetState(otCommissionerState aState);
     void SignalJoinerEvent(otCommissionerJoinerEvent aEvent, const Mac::ExtAddress &aJoinerId);
 
+    static const char *StateToString(otCommissionerState aState);
+
     struct Joiner
     {
         Mac::ExtAddress mEui64;

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -1832,7 +1832,7 @@ class ProvisioningUrlTlv : public Tlv
 public:
     enum
     {
-        kMaxLength = 64, // Maximum number of chars in the Provisioning URL string.
+        kMaxLength = OT_PROVISIONING_URL_MAX_SIZE, // Maximum number of chars in the Provisioning URL string.
     };
 
     /**

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -578,19 +578,7 @@ exit:
 
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_MESHCOP_COMMISSIONER_PROVISIONING_URL>(void)
 {
-    otError     error  = OT_ERROR_NONE;
-    uint16_t    length = 0;
-    const char *url    = otCommissionerGetProvisioningUrl(mInstance, &length);
-
-    if (url != NULL && length > 0)
-    {
-        SuccessOrExit(error = mEncoder.WriteData(reinterpret_cast<const uint8_t *>(url), length));
-    }
-
-    SuccessOrExit(error = mEncoder.WriteUint8(0));
-
-exit:
-    return error;
+    return mEncoder.WriteUtf8(otCommissionerGetProvisioningUrl(mInstance));
 }
 
 template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_MESHCOP_COMMISSIONER_PROVISIONING_URL>(void)


### PR DESCRIPTION
This PR contains a collection of smaller commit changes/improvements in `Commissioner`.

_[commissioner] update how Provisioning URL is stored_
    
This commit updates how the `Commissioner` stores the Provisioning URL
(now saved as null terminated string). It also updates the related
APIs (including the public `otCommissionerGetProvisioningUrl`) and its
use in `NcpBase`.

_[commissioner] iterate over joiners using pointer
[commissioner] make simple getter methods inline
[commissioner] log commissioner state changes_


