### PR TITLE
[mac] prioritize a pending poll tx after handling of frame tx

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -738,6 +738,13 @@ void Mac::PerformNextOperation(void)
     {
         mPendingTransmitDataDirect = false;
         mOperation                 = kOperationTransmitDataDirect;
+
+        if (mPendingTransmitPoll)
+        {
+            // Ensure that a pending "transmit poll" operation request
+            // is prioritized over any future "transmit data" requests.
+            mShouldTxPollBeforeData = true;
+        }
     }
 
     if (mOperation != kOperationIdle)


### PR DESCRIPTION
This commit ensures to prioritize a pending poll tx request after
handling a (direct) frame tx request. This addresses the situation
where back-to-back frame tx requests could have delayed a data poll
tx request.

--------
Note  that the back-to-back frame tx requests should not happen in current implementation (`MeshForwarder` would issue next frame tx request from a posted tasklet). However, the fix/change would ensure such a pattern of use behaves correctly.
