### PR TITLE
[efr32mg12] update the channel range of channel config entry

### DIFF
--- a/third_party/silabs/rail_config/rail_config.c
+++ b/third_party/silabs/rail_config/rail_config.c
@@ -159,8 +159,8 @@ const RAIL_ChannelConfigEntry_t generated_channels[] = {
     .baseFrequency = 904000000,
     .channelSpacing = 2000000,
     .physicalChannelOffset = 0,
-    .channelNumberStart = 0,
-    .channelNumberEnd = 20,
+    .channelNumberStart = 1,
+    .channelNumberEnd = 10,
     .maxPower = RAIL_TX_POWER_MAX,
     .attr = &generated_entryAttr
   },


### PR DESCRIPTION
The PR [#3922](https://github.com/openthread/openthread/commit/0bb0b7424#diff-e9cef7a8ce52bf573877847ae819d53dR212) checks if the first channel equals to the minimum channel for the sub-GHz. The minimum channel of sub-GHz is set to 1, the first channel in the channel config entry also should be set to 1 to match the minimum channel of sub-GHz.