### PR TITLE
[mac-frame] set kMtu from config param and inline simple getters

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1092,16 +1092,6 @@ void TxFrame::CopyFrom(const TxFrame &aFromFrame)
 #endif
 }
 
-uint16_t Frame::GetMtu(void) const
-{
-    return kMTU;
-}
-
-uint16_t Frame::GetFcsSize(void) const
-{
-    return kFcsSize;
-}
-
 // LCOV_EXCL_START
 
 #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE) && (OPENTHREAD_CONFIG_LOG_MAC == 1)

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -770,7 +770,7 @@ class Frame : public otRadioFrame
 public:
     enum
     {
-        kMTU                 = 127,
+        kMtu                 = OT_RADIO_FRAME_MAX_SIZE,
         kFcfSize             = sizeof(uint16_t),
         kDsnSize             = sizeof(uint8_t),
         kSecurityControlSize = sizeof(uint8_t),
@@ -1379,7 +1379,7 @@ public:
      * @returns The maximum transmission unit (MTU).
      *
      */
-    uint16_t GetMtu(void) const;
+    uint16_t GetMtu(void) const { return kMtu; }
 
     /**
      * This method returns the FCS size.
@@ -1387,7 +1387,7 @@ public:
      * @returns This method returns the FCS size.
      *
      */
-    uint16_t GetFcsSize(void) const;
+    uint16_t GetFcsSize(void) const { return kFcsSize; }
 
     /**
      * This method returns information about the frame object as an `InfoString` object.

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -272,7 +272,7 @@ void TestMacHeader(void)
 
     for (unsigned i = 0; i < OT_ARRAY_LENGTH(tests); i++)
     {
-        uint8_t      psdu[Mac::Frame::kMTU];
+        uint8_t      psdu[Mac::Frame::kMtu];
         Mac::TxFrame frame;
 
         frame.mPsdu = psdu;


### PR DESCRIPTION
---
Also renamed `kMTU` -> `kMtu` to be consistent with code style.