### PR TITLE
[toolchain] add definition of UINT16_MAX

### DIFF
--- a/include/openthread/platform/toolchain.h
+++ b/include/openthread/platform/toolchain.h
@@ -239,6 +239,10 @@ extern "C" {
 #define UINT8_MAX 0xff
 #endif
 
+#ifndef UINT16_MAX
+#define UINT16_MAX 0xffff
+#endif
+
 #endif
 #endif
 


### PR DESCRIPTION
Fixes IAR build after #4216