### PR TITLE
[script] use python version specified in test script

### DIFF
--- a/script/test
+++ b/script/test
@@ -54,7 +54,7 @@ do_clean() {
 
 do_cert() {
     [[ ! -d tmp ]] || rm -rvf tmp
-    PYTHONUNBUFFERED=1 python "$1"
+    PYTHONUNBUFFERED=1 "$1"
 }
 
 print_usage() {


### PR DESCRIPTION
I verified all test scripts in `tests/scripts/thread-cert` have `x` permission.