### PR TITLE
[coap] remove otCoapMessageSetMessageId()

### DIFF
--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -343,6 +343,19 @@ typedef struct otCoapResource
 void otCoapMessageInit(otMessage *aMessage, otCoapType aType, otCoapCode aCode);
 
 /**
+ * This function initializes a response message.
+ *
+ * @note Both message ID and token are set according to @p aRequest.
+ *
+ * @param[inout] aResponse  A pointer to the CoAP response message.
+ * @param[in]    aRequest   A pointer to the CoAP request message.
+ * @param[in]    aType      CoAP message type.
+ * @param[in]    aCode      CoAP message code.
+ *
+ */
+otError otCoapMessageInitResponse(otMessage *aResponse, const otMessage *aRequest, otCoapType aType, otCoapCode aCode);
+
+/**
  * This function sets the Token value and length in a header.
  *
  * @param[inout]  aMessage          A pointer to the CoAP message.
@@ -489,15 +502,6 @@ otError otCoapMessageAppendUriQueryOption(otMessage *aMessage, const char *aUriQ
  *
  */
 otError otCoapMessageSetPayloadMarker(otMessage *aMessage);
-
-/**
- * This function sets the Message ID value.
- *
- * @param[in]  aMessage     A pointer to the CoAP message.
- * @param[in]  aMessageId   The Message ID value.
- *
- */
-void otCoapMessageSetMessageId(otMessage *aMessage, uint16_t aMessageId);
 
 /**
  * This function returns the Type value.

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -352,6 +352,9 @@ void otCoapMessageInit(otMessage *aMessage, otCoapType aType, otCoapCode aCode);
  * @param[in]    aType      CoAP message type.
  * @param[in]    aCode      CoAP message code.
  *
+ * @retval OT_ERROR_NONE     Successfully initialized the response message.
+ * @retval OT_ERROR_NO_BUFS  Insufficient message buffers available to initialize the response message.
+ *
  */
 otError otCoapMessageInitResponse(otMessage *aResponse, const otMessage *aRequest, otCoapType aType, otCoapCode aCode);
 

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -330,10 +330,7 @@ void Coap::HandleRequest(otMessage *aMessage, const otMessageInfo *aMessageInfo)
         responseMessage = otCoapNewMessage(mInterpreter.mInstance, NULL);
         VerifyOrExit(responseMessage != NULL, error = OT_ERROR_NO_BUFS);
 
-        otCoapMessageInit(responseMessage, OT_COAP_TYPE_ACKNOWLEDGMENT, responseCode);
-        otCoapMessageSetMessageId(responseMessage, otCoapMessageGetMessageId(aMessage));
-        SuccessOrExit(error = otCoapMessageSetToken(responseMessage, otCoapMessageGetToken(aMessage),
-                                                    otCoapMessageGetTokenLength(aMessage)));
+        otCoapMessageInitResponse(responseMessage, aMessage, OT_COAP_TYPE_ACKNOWLEDGMENT, responseCode);
 
         if (otCoapMessageGetCode(aMessage) == OT_COAP_CODE_GET)
         {

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -330,7 +330,8 @@ void Coap::HandleRequest(otMessage *aMessage, const otMessageInfo *aMessageInfo)
         responseMessage = otCoapNewMessage(mInterpreter.mInstance, NULL);
         VerifyOrExit(responseMessage != NULL, error = OT_ERROR_NO_BUFS);
 
-        otCoapMessageInitResponse(responseMessage, aMessage, OT_COAP_TYPE_ACKNOWLEDGMENT, responseCode);
+        SuccessOrExit(
+            error = otCoapMessageInitResponse(responseMessage, aMessage, OT_COAP_TYPE_ACKNOWLEDGMENT, responseCode));
 
         if (otCoapMessageGetCode(aMessage) == OT_COAP_CODE_GET)
         {

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -496,7 +496,8 @@ void CoapSecure::HandleRequest(otMessage *aMessage, const otMessageInfo *aMessag
         responseMessage = otCoapNewMessage(mInterpreter.mInstance, NULL);
         VerifyOrExit(responseMessage != NULL, error = OT_ERROR_NO_BUFS);
 
-        otCoapMessageInitResponse(responseMessage, aMessage, OT_COAP_TYPE_ACKNOWLEDGMENT, responseCode);
+        SuccessOrExit(
+            error = otCoapMessageInitResponse(responseMessage, aMessage, OT_COAP_TYPE_ACKNOWLEDGMENT, responseCode));
 
         if (otCoapMessageGetCode(aMessage) == OT_COAP_CODE_GET)
         {
@@ -568,7 +569,8 @@ void CoapSecure::DefaultHandler(otMessage *aMessage, const otMessageInfo *aMessa
         responseMessage = otCoapNewMessage(mInterpreter.mInstance, NULL);
         VerifyOrExit(responseMessage != NULL, error = OT_ERROR_NO_BUFS);
 
-        otCoapMessageInitResponse(responseMessage, aMessage, OT_COAP_TYPE_NON_CONFIRMABLE, OT_COAP_CODE_NOT_FOUND);
+        SuccessOrExit(error = otCoapMessageInitResponse(responseMessage, aMessage, OT_COAP_TYPE_NON_CONFIRMABLE,
+                                                        OT_COAP_CODE_NOT_FOUND));
 
         SuccessOrExit(error = otCoapSecureSendResponse(mInterpreter.mInstance, responseMessage, aMessageInfo));
     }

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -496,10 +496,7 @@ void CoapSecure::HandleRequest(otMessage *aMessage, const otMessageInfo *aMessag
         responseMessage = otCoapNewMessage(mInterpreter.mInstance, NULL);
         VerifyOrExit(responseMessage != NULL, error = OT_ERROR_NO_BUFS);
 
-        otCoapMessageInit(responseMessage, OT_COAP_TYPE_ACKNOWLEDGMENT, responseCode);
-        otCoapMessageSetMessageId(responseMessage, otCoapMessageGetMessageId(aMessage));
-        SuccessOrExit(error = otCoapMessageSetToken(responseMessage, otCoapMessageGetToken(aMessage),
-                                                    otCoapMessageGetTokenLength(aMessage)));
+        otCoapMessageInitResponse(responseMessage, aMessage, OT_COAP_TYPE_ACKNOWLEDGMENT, responseCode);
 
         if (otCoapMessageGetCode(aMessage) == OT_COAP_CODE_GET)
         {
@@ -571,10 +568,7 @@ void CoapSecure::DefaultHandler(otMessage *aMessage, const otMessageInfo *aMessa
         responseMessage = otCoapNewMessage(mInterpreter.mInstance, NULL);
         VerifyOrExit(responseMessage != NULL, error = OT_ERROR_NO_BUFS);
 
-        otCoapMessageInit(responseMessage, OT_COAP_TYPE_NON_CONFIRMABLE, OT_COAP_CODE_NOT_FOUND);
-        otCoapMessageSetMessageId(responseMessage, otCoapMessageGetMessageId(aMessage));
-        SuccessOrExit(error = otCoapMessageSetToken(responseMessage, otCoapMessageGetToken(aMessage),
-                                                    otCoapMessageGetTokenLength(aMessage)));
+        otCoapMessageInitResponse(responseMessage, aMessage, OT_COAP_TYPE_NON_CONFIRMABLE, OT_COAP_CODE_NOT_FOUND);
 
         SuccessOrExit(error = otCoapSecureSendResponse(mInterpreter.mInstance, responseMessage, aMessageInfo));
     }

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -64,6 +64,16 @@ void otCoapMessageInit(otMessage *aMessage, otCoapType aType, otCoapCode aCode)
     static_cast<Coap::Message *>(aMessage)->Init(aType, aCode);
 }
 
+otError otCoapMessageInitResponse(otMessage *aResponse, const otMessage *aRequest, otCoapType aType, otCoapCode aCode)
+{
+    Coap::Message &      response = *static_cast<Coap::Message *>(aResponse);
+    const Coap::Message &request  = *static_cast<const Coap::Message *>(aRequest);
+
+    response.Init(aType, aCode);
+
+    return response.SetToken(request.GetToken(), request.GetTokenLength());
+}
+
 otError otCoapMessageSetToken(otMessage *aMessage, const uint8_t *aToken, uint8_t aTokenLength)
 {
     return static_cast<Coap::Message *>(aMessage)->SetToken(aToken, aTokenLength);
@@ -117,11 +127,6 @@ otError otCoapMessageAppendUriQueryOption(otMessage *aMessage, const char *aUriQ
 otError otCoapMessageSetPayloadMarker(otMessage *aMessage)
 {
     return static_cast<Coap::Message *>(aMessage)->SetPayloadMarker();
-}
-
-void otCoapMessageSetMessageId(otMessage *aMessage, uint16_t aMessageId)
-{
-    return static_cast<Coap::Message *>(aMessage)->SetMessageId(aMessageId);
 }
 
 otCoapType otCoapMessageGetType(const otMessage *aMessage)

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -70,6 +70,7 @@ otError otCoapMessageInitResponse(otMessage *aResponse, const otMessage *aReques
     const Coap::Message &request  = *static_cast<const Coap::Message *>(aRequest);
 
     response.Init(aType, aCode);
+    response.SetMessageId(request.GetMessageId());
 
     return response.SetToken(request.GetToken(), request.GetTokenLength());
 }


### PR DESCRIPTION
Message ID is managed by CoAP agent. Allowing user setting it may result
in invalid usage. This PR removes this API and adds a new API to
initialize CoAP response message.