### PR TITLE
[udp] suppress warning of unused parameter

### DIFF
--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -54,6 +54,7 @@ static bool IsMle(Instance &aInstance, uint16_t aPort)
 #if OPENTHREAD_FTD
     return aPort == ot::Mle::kUdpPort || aPort == aInstance.Get<MeshCoP::JoinerRouter>().GetJoinerUdpPort();
 #else
+    OT_UNUSED_VARIABLE(aInstance);
     return aPort == ot::Mle::kUdpPort;
 #endif
 }


### PR DESCRIPTION
This PR suppresses warning of unused parameter `aInstance` when `OPENTHREAD_FTD` is not set.