### PR TITLE
[harness-automation] support RF-shield test cases

### DIFF
--- a/tools/harness-automation/autothreadharness/harness_case.py
+++ b/tools/harness-automation/autothreadharness/harness_case.py
@@ -163,7 +163,7 @@ class HarnessCase(unittest.TestCase):
     case_need_shield = False
     """bool: whether needs RF-box"""
 
-    device_order = ''
+    device_order = []
     """list: device drag order in TestHarness TestBed page"""
 
     def __init__(self, *args, **kwargs):
@@ -562,9 +562,11 @@ class HarnessCase(unittest.TestCase):
             if not settings.DUT2_DEVICE:
                 logger.info('Must set DUT2_DEVICE')
                 raise FailError('DUT2_DEVICE must be set in settings.py')
-            if isinstance(self.device_order, list):
+            if isinstance(self.device_order, list) and self.device_order:
                 shield_order = self.device_order
                 logger.info('case %s devices ordered by %s ', self.case, shield_order)
+            else:
+                logger.info('case %s uses %s as DUT', self.case, settings.DUT2_DEVICE)
 
         # for test bed with multi-vendor devices
         if settings.MIXED_DEVICE_TYPE:

--- a/tools/harness-automation/autothreadharness/harness_case.py
+++ b/tools/harness-automation/autothreadharness/harness_case.py
@@ -617,7 +617,10 @@ class HarnessCase(unittest.TestCase):
                                 matched = True
                                 break
                             for device_item in shield_devices:
-                                if device_order_item[0] == mixed_device_item[0] and mixed_device_item[1] == device_item[1]:
+                                if (
+                                    device_order_item[0] == mixed_device_item[0]
+                                    and mixed_device_item[1] == device_item[1]
+                                ):
                                     golden_device_candidates.append(device_item)
                                     shield_devices.remove(device_item)
                                     matched = True
@@ -630,7 +633,10 @@ class HarnessCase(unittest.TestCase):
                                 matched = True
                                 break
                             for device_item in devices:
-                                if device_order_item[0] == mixed_device_item[0] and mixed_device_item[1] == device_item[1]:
+                                if (
+                                    device_order_item[0] == mixed_device_item[0]
+                                    and mixed_device_item[1] == device_item[1]
+                                ):
                                     golden_device_candidates.append(device_item)
                                     devices.remove(device_item)
                                     matched = True

--- a/tools/harness-automation/autothreadharness/harness_case.py
+++ b/tools/harness-automation/autothreadharness/harness_case.py
@@ -533,7 +533,7 @@ class HarnessCase(unittest.TestCase):
         if settings.DUT_DEVICE:
             dut_device = settings.DUT_DEVICE
 
-        """check if test case need to use RF-shield box and its device order in Testbed page
+        """check if test case needs to use RF-shield box and its device order in Testbed page
         Two parameters case_need_shield & device_order should be set in the case script
         according to the requires: https://openthread.io/certification/test-cases#rf_shielding
         Example:
@@ -553,8 +553,8 @@ class HarnessCase(unittest.TestCase):
 
          In case script med_6_3_2.py:
          case_need_shield = True
-         device_order = ''
-         means no device drag order. DUT2_DEVICE should be applied as DUT and the other gold devices
+         device_order = [] # or not defined
+         means no device drag order. DUT2_DEVICE should be applied as DUT and the other golden devices
          are from GOLDEN_DEVICES.
         """
         if self.case_need_shield:
@@ -608,7 +608,7 @@ class HarnessCase(unittest.TestCase):
                 for device_order_item in self.device_order:
                     matched = False
                     for mixed_device_item in topo_mixed_devices:
-                        # mapping device in device_order which need to be shielded
+                        # mapping device in device_order which needs to be shielded
                         if device_order_item[1]:
                             if 'DUT' in device_order_item[0]:
                                 golden_device_candidates.append(settings.DUT2_DEVICE)
@@ -625,7 +625,7 @@ class HarnessCase(unittest.TestCase):
                                     shield_devices.remove(device_item)
                                     matched = True
                                     break
-                        # mapping device in device_order which do not need to be shielded
+                        # mapping device in device_order which does not need to be shielded
                         else:
                             if 'DUT' in device_order_item[0]:
                                 golden_device_candidates.append(settings.DUT_DEVICE)
@@ -677,7 +677,7 @@ class HarnessCase(unittest.TestCase):
                 matched_dut = False
                 for device_order_item in self.device_order:
                     matched = False
-                    # choose device which need to be shielded
+                    # choose device which needs to be shielded
                     if device_order_item[1]:
                         if 'DUT' in device_order_item[0]:
                             golden_device_candidates.append(settings.DUT2_DEVICE)
@@ -690,7 +690,7 @@ class HarnessCase(unittest.TestCase):
                                 shield_devices.remove(device_item)
                                 matched = True
                                 break
-                    # choose device which do not need to be shielded
+                    # choose device which does not need to be shielded
                     else:
                         if 'DUT' in device_order_item[0]:
                             golden_device_candidates.append(settings.DUT_DEVICE)

--- a/tools/harness-automation/autothreadharness/harness_case.py
+++ b/tools/harness-automation/autothreadharness/harness_case.py
@@ -384,11 +384,6 @@ class HarnessCase(unittest.TestCase):
         if not self.started:
             self.started = time.time()
 
-        if time.time() - self.started > 5 * len(settings.GOLDEN_DEVICES):
-            # self._browser.refresh()
-            time.sleep(1)
-            return
-
         # Detect Sniffer
         try:
             dialog = self._browser.find_element_by_id('capture-Setup-modal')

--- a/tools/harness-automation/autothreadharness/harness_case.py
+++ b/tools/harness-automation/autothreadharness/harness_case.py
@@ -535,7 +535,7 @@ class HarnessCase(unittest.TestCase):
 
         """check if case need to use shield box and its device order in Testbed page
         Example:
-         In case script leader_9_2_9.py: 
+         In case script leader_9_2_9.py:
           case_need_shield = True
           device_order = [('Router_2', False), ('Commissioner', True), ('Router_1', False), ('DUT', True)]
          On the TestBed page of the Test Harness, the device sort order for Leader_9_2_9

--- a/tools/harness-automation/autothreadharness/settings_sample.py
+++ b/tools/harness-automation/autothreadharness/settings_sample.py
@@ -101,33 +101,6 @@ OUTPUT_PATH = '.\\output'
 SHIELD_SIMULATION = False
 """bool: whether to simulate RF shield by changing channel"""
 
-SHIELD_CASE_ORDER = {
-    'Leader_9_2_9': [('Router_2', False), ('Commissioner', True), ('Router_1', False), ('DUT', True)],
-    'Router_9_2_9': [('Router_2', False), ('Commissioner', True), ('DUT', False), ('Leader', True)],
-    'Router_9_2_10': [('SED_1', False), ('MED_1', False), ('DUT', False), ('Commissioner', True), ('Leader', True)],
-    'MED_9_2_10': [('SED_1', False), ('DUT', False), ('Router_1', False), ('Commissioner', True), ('Leader', True)],
-    'SED_9_2_10': [('DUT', False), ('MED_1', False), ('Router_1', False), ('Commissioner', True), ('Leader', True)],
-    'MED_6_3_2': '',
-    'REED_5_6_7': '',
-}
-"""dict: RF-shield needed scenarios and corresponding orders.
-Example:
- 'Leader_9_2_9': [('Router_2', False), ('Commissioner', True), ('Router_1', False), ('DUT', True)]:
-   For scenario Leader_9_2_9, on the Configure Test Bed page of the Test Harness, the device sort order
-   should be like:
-     Router_2
-     Commissioner
-     Router_1
-     DUT
-   And the ('Commissioner', True) and ('DUT', True) indicate Commissioner device and DUT2 device should
-   be in the RF-box and choose from SHIELD_GOLDEN_DEVICES and DUT2_DEVICE. Otherwise ('DUT', False) means
-   DUT device is not in RF-box and use DUT_DEVICE. The other roles devices with False should be selected
-   from GOLDEN_DEVICES.
-
- ‘MED_6_3_2’: ’’ means no device drag order. DUT2_DEVICE should be applied as DUT and the other gold devices
- are from GOLDEN_DEVICES.
-"""
-
 PDU_CONTROLLER_TYPE = None
 """str: Type of connected PDU controller.
 

--- a/tools/harness-automation/autothreadharness/settings_sample.py
+++ b/tools/harness-automation/autothreadharness/settings_sample.py
@@ -113,18 +113,18 @@ SHIELD_CASE_ORDER = {
 """dict: RF-shield needed scenarios and corresponding orders.
 Example:
  'Leader_9_2_9': [('Router_2', False), ('Commissioner', True), ('Router_1', False), ('DUT', True)]:
-   For scenario Leader_9_2_9, on the Configure Test Bed page of the Test Harness, the device sort order 
+   For scenario Leader_9_2_9, on the Configure Test Bed page of the Test Harness, the device sort order
    should be like:
-   Router_2
-   Commissioner
-   Router_1
-   DUT
-   And the ('Commissioner', True) and ('DUT', True) indicate Commissioner device and DUT2 device should 
-   be in the RF-box and choose from SHIELD_GOLDEN_DEVICES and DUT2_DEVICE. Otherwise ('DUT', False) means 
-   DUT device is not in RF-box and use DUT_DEVICE. The other roles devices with False should be selected 
+     Router_2
+     Commissioner
+     Router_1
+     DUT
+   And the ('Commissioner', True) and ('DUT', True) indicate Commissioner device and DUT2 device should
+   be in the RF-box and choose from SHIELD_GOLDEN_DEVICES and DUT2_DEVICE. Otherwise ('DUT', False) means
+   DUT device is not in RF-box and use DUT_DEVICE. The other roles devices with False should be selected
    from GOLDEN_DEVICES.
 
- ‘MED_6_3_2’: ’’ means no device drag order. DUT2_DEVICE should be applied as DUT and the other gold devices 
+ ‘MED_6_3_2’: ’’ means no device drag order. DUT2_DEVICE should be applied as DUT and the other gold devices
  are from GOLDEN_DEVICES.
 """
 

--- a/tools/harness-automation/autothreadharness/settings_sample.py
+++ b/tools/harness-automation/autothreadharness/settings_sample.py
@@ -93,7 +93,7 @@ into the RF-box besides DUT2_DEVICE.
 
 Example for CV testbed, 2 conformance devices should be put into the RF-box and listed here.
 
-Example for IV testbed using TopologyConfig_20180907b.txt, 1 OpenThread, 1 ARM and 1 SiLabs devices should be 
+Example for IV testbed using TopologyConfig_20180907b.txt, 1 OpenThread, 1 ARM and 1 SiLabs devices should be
 put into the RF-box and listed here.
 
 Example for IV testbed using TopologyConfig_20180907cK.txt, 1 OpenThread and 2 ARM devices should be put into

--- a/tools/harness-automation/autothreadharness/settings_sample.py
+++ b/tools/harness-automation/autothreadharness/settings_sample.py
@@ -33,14 +33,14 @@ AUTO_DUT = True
 
 DUT_DEVICE = ('COM16', 'OpenThread')
 """(str, str): The first element is serial port of the DUT, and the second is
-the device type. This must be set if AUTO_DUT=False."""
+the device type."""
 
 DUT2_DEVICE = ('COM18', 'OpenThread')
 """(str, str): The first element is serial port of the DUT, and the second is
-the device type. DUT in RF-box for RF-shield needed cases and this must be set if AUTO_DUT=False."""
+the device type. DUT in RF-box for RF-shield needed cases."""
 
 DUT_VERSION = 'g12345'
-"""str: Version of DUT, must be set if AUTO_DUT=False."""
+"""str: Version of DUT"""
 
 DUT_MANUFACTURER = 'Open Thread'
 """str: Manufacturer of the DUT"""
@@ -76,17 +76,29 @@ TESTER_REMARKS = 'OpenThread is great'
 """str: Any comments in the final PDF"""
 
 GOLDEN_DEVICES = []
-"""[(str, str)]: devices list.
-It should be something like [('COM1', 'OpenThread'), ('COM2', 'ARM')] for devices connected to Windows.
-For OpenThread golden devices, ser2net is also supported, just use IP:PORT for the name. For example,
-('192.168.1.2:5001', 'OpenThread').
+"""[(str, str)]: golden device list.
+It is a port and vendor pair list like [('COM1', 'OpenThread'), ('COM2', 'ARM')] for over-the-air golden devices
+connected to Windows. For OpenThread golden devices, ser2net is also supported by using IP:PORT as the port
+like ('192.168.1.2:5001', 'OpenThread').
 """
 
 SHIELD_GOLDEN_DEVICES = []
-"""[(str, str)]: devices list in RF-box.
-It should be something like [('COM1', 'OpenThread'), ('COM2', 'ARM')] for devices connected to Windows.
-For OpenThread golden devices, ser2net is also supported, just use IP:PORT for the name. For example,
-('192.168.1.2:5001', 'OpenThread').
+"""[(str, str)]: shielded golden device list.
+It is a port and vendor pair list like [('COM1', 'OpenThread'), ('COM2', 'ARM')] for shielded golden devices
+connected to Windows. For OpenThread golden devices, ser2net is also supported by using IP:PORT as the port
+like ('192.168.1.2:5001', 'OpenThread').
+
+For current topology, maximal common Leader and Commissioner devices for case 9.2.9 and 9.2.10 should be put
+into the RF-box besides DUT2_DEVICE.
+
+Example for CV testbed, 2 conformance devices should be put into the RF-box and listed here.
+
+Example for IV testbed using TopologyConfig_20180907b.txt, 1 OpenThread, 1 ARM and 1 SiLabs devices should be 
+put into the RF-box and listed here.
+
+Example for IV testbed using TopologyConfig_20180907cK.txt, 1 OpenThread and 2 ARM devices should be put into
+the RF-box and listed here.
+
 """
 
 MIXED_DEVICE_TYPE = True

--- a/tools/harness-automation/autothreadharness/settings_sample.py
+++ b/tools/harness-automation/autothreadharness/settings_sample.py
@@ -35,6 +35,10 @@ DUT_DEVICE = ('COM16', 'OpenThread')
 """(str, str): The first element is serial port of the DUT, and the second is
 the device type. This must be set if AUTO_DUT=False."""
 
+DUT2_DEVICE = ('COM18', 'OpenThread')
+"""(str, str): The first element is serial port of the DUT, and the second is
+the device type. DUT in RF-box for RF-shield needed cases and this must be set if AUTO_DUT=False."""
+
 DUT_VERSION = 'g12345'
 """str: Version of DUT, must be set if AUTO_DUT=False."""
 
@@ -73,9 +77,14 @@ TESTER_REMARKS = 'OpenThread is great'
 
 GOLDEN_DEVICES = []
 """[(str, str)]: devices list.
-
 It should be something like [('COM1', 'OpenThread'), ('COM2', 'ARM')] for devices connected to Windows.
+For OpenThread golden devices, ser2net is also supported, just use IP:PORT for the name. For example,
+('192.168.1.2:5001', 'OpenThread').
+"""
 
+SHIELD_GOLDEN_DEVICES = []
+"""[(str, str)]: devices list in RF-box.
+It should be something like [('COM1', 'OpenThread'), ('COM2', 'ARM')] for devices connected to Windows.
 For OpenThread golden devices, ser2net is also supported, just use IP:PORT for the name. For example,
 ('192.168.1.2:5001', 'OpenThread').
 """
@@ -91,6 +100,33 @@ OUTPUT_PATH = '.\\output'
 
 SHIELD_SIMULATION = False
 """bool: whether to simulate RF shield by changing channel"""
+
+SHIELD_CASE_ORDER = {
+    'Leader_9_2_9': [('Router_2', False), ('Commissioner', True), ('Router_1', False), ('DUT', True)],
+    'Router_9_2_9': [('Router_2', False), ('Commissioner', True), ('DUT', False), ('Leader', True)],
+    'Router_9_2_10': [('SED_1', False), ('MED_1', False), ('DUT', False), ('Commissioner', True), ('Leader', True)],
+    'MED_9_2_10': [('SED_1', False), ('DUT', False), ('Router_1', False), ('Commissioner', True), ('Leader', True)],
+    'SED_9_2_10': [('DUT', False), ('MED_1', False), ('Router_1', False), ('Commissioner', True), ('Leader', True)],
+    'MED_6_3_2': '',
+    'REED_5_6_7': '',
+}
+"""dict: RF-shield needed scenarios and corresponding orders.
+Example:
+ 'Leader_9_2_9': [('Router_2', False), ('Commissioner', True), ('Router_1', False), ('DUT', True)]:
+   For scenario Leader_9_2_9, on the Configure Test Bed page of the Test Harness, the device sort order 
+   should be like:
+   Router_2
+   Commissioner
+   Router_1
+   DUT
+   And the ('Commissioner', True) and ('DUT', True) indicate Commissioner device and DUT2 device should 
+   be in the RF-box and choose from SHIELD_GOLDEN_DEVICES and DUT2_DEVICE. Otherwise ('DUT', False) means 
+   DUT device is not in RF-box and use DUT_DEVICE. The other roles devices with False should be selected 
+   from GOLDEN_DEVICES.
+
+ ‘MED_6_3_2’: ’’ means no device drag order. DUT2_DEVICE should be applied as DUT and the other gold devices 
+ are from GOLDEN_DEVICES.
+"""
 
 PDU_CONTROLLER_TYPE = None
 """str: Type of connected PDU controller.

--- a/tools/harness-automation/cases/leader_9_2_9.py
+++ b/tools/harness-automation/cases/leader_9_2_9.py
@@ -37,6 +37,8 @@ class Leader_9_2_9(HarnessCase):
     role = HarnessCase.ROLE_LEADER
     case = '9 2 9'
     golden_devices_required = 3
+    case_need_shield = True
+    device_order = [('Router_2', False), ('Commissioner', True), ('Router_1', False), ('DUT', True)]
 
     def on_dialog(self, dialog, title):
         pass

--- a/tools/harness-automation/cases/med_6_3_2.py
+++ b/tools/harness-automation/cases/med_6_3_2.py
@@ -37,6 +37,8 @@ class MED_6_3_2(HarnessCase):
     role = HarnessCase.ROLE_MED
     case = '6 3 2'
     golden_devices_required = 1
+    case_need_shield = True
+    device_order = ''
 
     def on_dialog(self, dialog, title):
         pass

--- a/tools/harness-automation/cases/med_6_3_2.py
+++ b/tools/harness-automation/cases/med_6_3_2.py
@@ -38,7 +38,6 @@ class MED_6_3_2(HarnessCase):
     case = '6 3 2'
     golden_devices_required = 1
     case_need_shield = True
-    device_order = ''
 
     def on_dialog(self, dialog, title):
         pass

--- a/tools/harness-automation/cases/med_9_2_10.py
+++ b/tools/harness-automation/cases/med_9_2_10.py
@@ -37,6 +37,8 @@ class MED_9_2_10(HarnessCase):
     role = HarnessCase.ROLE_MED
     case = '9 2 10'
     golden_devices_required = 4
+    case_need_shield = True
+    device_order = [('SED_1', False), ('DUT', False), ('Router_1', False), ('Commissioner', True), ('Leader', True)]
 
     def on_dialog(self, dialog, title):
         pass

--- a/tools/harness-automation/cases/reed_5_6_7.py
+++ b/tools/harness-automation/cases/reed_5_6_7.py
@@ -38,7 +38,6 @@ class REED_5_6_7(HarnessCase):
     case = '5 6 7'
     golden_devices_required = 16
     case_need_shield = True
-    device_order = ''
 
     def on_dialog(self, dialog, title):
         pass

--- a/tools/harness-automation/cases/reed_5_6_7.py
+++ b/tools/harness-automation/cases/reed_5_6_7.py
@@ -37,6 +37,8 @@ class REED_5_6_7(HarnessCase):
     role = HarnessCase.ROLE_REED
     case = '5 6 7'
     golden_devices_required = 16
+    case_need_shield = True
+    device_order = ''
 
     def on_dialog(self, dialog, title):
         pass

--- a/tools/harness-automation/cases/router_9_2_10.py
+++ b/tools/harness-automation/cases/router_9_2_10.py
@@ -37,6 +37,8 @@ class Router_9_2_10(HarnessCase):
     role = HarnessCase.ROLE_ROUTER
     case = '9 2 10'
     golden_devices_required = 4
+    case_need_shield = True
+    device_order = [('SED_1', False), ('MED_1', False), ('DUT', False), ('Commissioner', True), ('Leader', True)]
 
     def on_dialog(self, dialog, title):
         pass

--- a/tools/harness-automation/cases/router_9_2_9.py
+++ b/tools/harness-automation/cases/router_9_2_9.py
@@ -37,6 +37,8 @@ class Router_9_2_9(HarnessCase):
     role = HarnessCase.ROLE_ROUTER
     case = '9 2 9'
     golden_devices_required = 3
+    case_need_shield = True
+    device_order = [('Router_2', False), ('Commissioner', True), ('DUT', False), ('Leader', True)]
 
     def on_dialog(self, dialog, title):
         pass

--- a/tools/harness-automation/cases/sed_9_2_10.py
+++ b/tools/harness-automation/cases/sed_9_2_10.py
@@ -37,6 +37,8 @@ class SED_9_2_10(HarnessCase):
     role = HarnessCase.ROLE_SED
     case = '9 2 10'
     golden_devices_required = 4
+    case_need_shield = True
+    device_order = [('DUT', False), ('MED_1', False), ('Router_1', False), ('Commissioner', True), ('Leader', True)]
 
     def on_dialog(self, dialog, title):
         pass

--- a/tools/harness-automation/cases_R140/leader_9_2_9.py
+++ b/tools/harness-automation/cases_R140/leader_9_2_9.py
@@ -37,6 +37,8 @@ class Leader_9_2_9(HarnessCase):
     role = HarnessCase.ROLE_LEADER
     case = '9 2 9'
     golden_devices_required = 3
+    case_need_shield = True
+    device_order = [('Router_2', False), ('Commissioner', True), ('Router_1', False), ('DUT', True)]
 
     def on_dialog(self, dialog, title):
         pass

--- a/tools/harness-automation/cases_R140/med_6_3_2.py
+++ b/tools/harness-automation/cases_R140/med_6_3_2.py
@@ -37,6 +37,8 @@ class MED_6_3_2(HarnessCase):
     role = HarnessCase.ROLE_MED
     case = '6 3 2'
     golden_devices_required = 1
+    case_need_shield = True
+    device_order = ''
 
     def on_dialog(self, dialog, title):
         pass

--- a/tools/harness-automation/cases_R140/med_6_3_2.py
+++ b/tools/harness-automation/cases_R140/med_6_3_2.py
@@ -38,7 +38,6 @@ class MED_6_3_2(HarnessCase):
     case = '6 3 2'
     golden_devices_required = 1
     case_need_shield = True
-    device_order = ''
 
     def on_dialog(self, dialog, title):
         pass

--- a/tools/harness-automation/cases_R140/med_9_2_10.py
+++ b/tools/harness-automation/cases_R140/med_9_2_10.py
@@ -33,10 +33,12 @@ import unittest
 from autothreadharness.harness_case import HarnessCase
 
 
-class ED_9_2_10(HarnessCase):
-    role = HarnessCase.ROLE_ED
+class MED_9_2_10(HarnessCase):
+    role = HarnessCase.ROLE_MED
     case = '9 2 10'
     golden_devices_required = 4
+    case_need_shield = True
+    device_order = [('SED_1', False), ('DUT', False), ('Router_1', False), ('Commissioner', True), ('Leader', True)]
 
     def on_dialog(self, dialog, title):
         pass

--- a/tools/harness-automation/cases_R140/reed_5_6_7.py
+++ b/tools/harness-automation/cases_R140/reed_5_6_7.py
@@ -38,7 +38,6 @@ class REED_5_6_7(HarnessCase):
     case = '5 6 7'
     golden_devices_required = 16
     case_need_shield = True
-    device_order = ''
 
     def on_dialog(self, dialog, title):
         pass

--- a/tools/harness-automation/cases_R140/reed_5_6_7.py
+++ b/tools/harness-automation/cases_R140/reed_5_6_7.py
@@ -37,6 +37,8 @@ class REED_5_6_7(HarnessCase):
     role = HarnessCase.ROLE_REED
     case = '5 6 7'
     golden_devices_required = 16
+    case_need_shield = True
+    device_order = ''
 
     def on_dialog(self, dialog, title):
         pass

--- a/tools/harness-automation/cases_R140/router_9_2_10.py
+++ b/tools/harness-automation/cases_R140/router_9_2_10.py
@@ -37,6 +37,8 @@ class Router_9_2_10(HarnessCase):
     role = HarnessCase.ROLE_ROUTER
     case = '9 2 10'
     golden_devices_required = 4
+    case_need_shield = True
+    device_order = [('SED_1', False), ('MED_1', False), ('DUT', False), ('Commissioner', True), ('Leader', True)]
 
     def on_dialog(self, dialog, title):
         pass

--- a/tools/harness-automation/cases_R140/router_9_2_9.py
+++ b/tools/harness-automation/cases_R140/router_9_2_9.py
@@ -37,6 +37,8 @@ class Router_9_2_9(HarnessCase):
     role = HarnessCase.ROLE_ROUTER
     case = '9 2 9'
     golden_devices_required = 3
+    case_need_shield = True
+    device_order = [('Router_2', False), ('Commissioner', True), ('DUT', False), ('Leader', True)]
 
     def on_dialog(self, dialog, title):
         pass

--- a/tools/harness-automation/cases_R140/sed_9_2_10.py
+++ b/tools/harness-automation/cases_R140/sed_9_2_10.py
@@ -37,6 +37,8 @@ class SED_9_2_10(HarnessCase):
     role = HarnessCase.ROLE_SED
     case = '9 2 10'
     golden_devices_required = 4
+    case_need_shield = True
+    device_order = [('DUT', False), ('MED_1', False), ('Router_1', False), ('Commissioner', True), ('Leader', True)]
 
     def on_dialog(self, dialog, title):
         pass


### PR DESCRIPTION
1. RF-shield needed cases 6.3.2, 5.6.7, 9.2.9, 9.2.10 automation both on CV and IV testbed
2. Added DUT2_DEVICE and SHIELD_GOLDEN_DEVICES in settings file which list the second DUT and golden devices in RF-box. The emulation of the required shielding/unshielding test environment is achieved by controlling the programmable RF-switch ( example: Agilent 3499B + HP 44476A microwave switch module) via scripts (configure SHIELD_CONTROLLER_TYPE and  SHIELD_CONTROLLER_PARAMS in settings file ) and final impacting the IN/OUT signal of the devices in the box.
3. Added case_need_shield and device_order parameters in RF-shield needed case scripts for checking if test case needs to use RF-shield box and its device order on the Test Harness Testbed page.