### PR TITLE
[posix] always set ACK FP for data requests when SrcMatch is disabled

### DIFF
--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -177,7 +177,7 @@ static inline bool isDataRequestAndHasFramePending(const uint8_t *aFrame)
     const uint8_t *cur = aFrame;
     uint8_t        securityControl;
     bool           isDataRequest   = false;
-    bool           hasFramePending = false;
+    bool           hasFramePending = true;
 
     // FCF + DSN
     cur += 2 + 1;


### PR DESCRIPTION
The commits fix the issue that when Src Match is disabled, ACK FramePending is never set for data requests , which on the contrary should always be set for data requests. 