### PR TITLE
[mle] remove sleepy child in all roles

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3132,19 +3132,20 @@ bool MleRouter::IsMinimalChild(uint16_t aRloc16)
 
 void MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
 {
-    if (mRole == OT_DEVICE_ROLE_CHILD && &aNeighbor == &mParent)
+    if (&aNeighbor == &mParent)
     {
-        BecomeDetached();
+        if (mRole == OT_DEVICE_ROLE_CHILD)
+        {
+            BecomeDetached();
+        }
     }
-
-    if (!IsActiveRouter(aNeighbor.GetRloc16()))
+    else if (!IsActiveRouter(aNeighbor.GetRloc16()))
     {
         if (aNeighbor.IsStateValidOrRestoring())
         {
             Signal(OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED, aNeighbor);
         }
 
-        aNeighbor.SetState(Neighbor::kStateInvalid);
         Get<IndirectSender>().ClearAllMessagesForSleepyChild(static_cast<Child &>(aNeighbor));
         Get<NetworkData::Leader>().SendServerDataNotification(aNeighbor.GetRloc16());
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3132,14 +3132,12 @@ bool MleRouter::IsMinimalChild(uint16_t aRloc16)
 
 void MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
 {
-    bool isActiveRouter = IsActiveRouter(aNeighbor.GetRloc16());
-
     if (mRole == OT_DEVICE_ROLE_CHILD && &aNeighbor == &mParent)
     {
         BecomeDetached();
     }
 
-    if (!isActiveRouter)
+    if (!IsActiveRouter(aNeighbor.GetRloc16()))
     {
         if (aNeighbor.IsStateValidOrRestoring())
         {


### PR DESCRIPTION
The commits fix an issue that indirect messages for sleepy child are not correctly cleared in some case. 
In my posix-sim tests, this issue together with the issue fixed in PR #4232 can cause sleepy nodes unable to reattach for a long time, or even forever, as described in following steps:

1. Router R has a sleepy child S which has some indirect messages pending.
1. R changed role to Detached for any reason
2. R changed role to Child
3. R becomes router again with another Router ID
4. R removes the child S by calling `RemoveNeighbor`
    * because now R has `mRole == OT_DEVICE_ROLE_CHILD`, R does not call `ClearAllMessagesForSleepyChild`, failed to clear indirect messages
5. R got another child, which reused S's slot in ChildTable (thus having same ChildIndex)
6. S tries to reattach to R, sends Child ID Request, and get a different ChildIndex
7. S tries to send indirect message (Child ID Response) to S, calling `IndirectSender::AddMessageForSleepyChild -> SourceMatchController::IncrementMessageCount -> AddEntry`
8. In `SourceMatchController::AddEntry`, `AddAddress` returns `OT_ERROR_DUPLICATED` or `OT_ERROR_NO_BUFS`, because S's ext address already exists (was not correctly remove due to step 5). `AddEntry` calls `Enable(false)` to turn off src match in the code bellow.
    * `VerifyOrExit(AddAddress(aChild) == OT_ERROR_NONE, Enable(false));`
9. Since src match is turned off, issue #4232 causes all frame pending not to be set for data requests, causing sleepy child to go to sleep when ACK of Child ID Request is received, thus unable to receive Child ID Response.

Incorrect sleepy message removing also corrupts the data consistency of 
 `SourceMatchController`, causing its behavior unpredictable. 

I am still striving to have a better understanding of this issue and have many questions about removing neighbor. 
 * Beside `ClearAllMessagesForSleepyChild`, do we need to call other functions (listed bellow) too when role is not router/leader? 
    * `Signal(OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED, aNeighbor);`
    * `Get<NetworkData::Leader>().SendServerDataNotification(aNeighbor.GetRloc16());`
    * `Get<AddressResolver>().Remove(aNeighbor.GetRloc16());`
    * `RemoveStoredChild(aNeighbor.GetRloc16());`
 * Should children be removed when router is detached?

Thoughts?