### PR TITLE
[core] use OT_ARRAY_END and iterate using pointers

### DIFF
--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -152,7 +152,7 @@ void Slaac::Update(UpdateMode aMode)
         // If enabled, remove any SLAAC addresses with no matching on-mesh prefix,
         // otherwise (when disabled) remove all previously added SLAAC addresses.
 
-        for (slaacAddr = &mAddresses[0]; slaacAddr < &mAddresses[OT_ARRAY_LENGTH(mAddresses)]; slaacAddr++)
+        for (slaacAddr = &mAddresses[0]; slaacAddr < OT_ARRAY_END(mAddresses); slaacAddr++)
         {
             if (!slaacAddr->mValid)
             {
@@ -220,7 +220,7 @@ void Slaac::Update(UpdateMode aMode)
             {
                 bool added = false;
 
-                for (slaacAddr = &mAddresses[0]; slaacAddr < &mAddresses[OT_ARRAY_LENGTH(mAddresses)]; slaacAddr++)
+                for (slaacAddr = &mAddresses[0]; slaacAddr < OT_ARRAY_END(mAddresses); slaacAddr++)
                 {
                     if (slaacAddr->mValid)
                     {


### PR DESCRIPTION
This PR contains a couple of smaller changes (each their own small commit) in different modules, all around using `OT_ARRAY_END()` macro and/or changing how we iterate over array elements (using pointer).

- [slaac-address] use OT_ARRAY_END macro
- [netif] use OT_ARRAY_END() when iterating over external address arrays
