### PR TITLE
[tests] fix the wrong port of dtls

### DIFF
--- a/tests/scripts/thread-cert/config.py
+++ b/tests/scripts/thread-cert/config.py
@@ -373,6 +373,7 @@ def create_default_based_on_src_dst_ports_udp_payload_factory(master_key):
         src_dst_port_based_payload_factories={
             19788: mle_message_factory,
             61631: coap_message_factory,
+            1000: dtls_message_factory,
             5684: dtls_message_factory,
         }
     )

--- a/tests/scripts/thread-cert/config.py
+++ b/tests/scripts/thread-cert/config.py
@@ -373,7 +373,7 @@ def create_default_based_on_src_dst_ports_udp_payload_factory(master_key):
         src_dst_port_based_payload_factories={
             19788: mle_message_factory,
             61631: coap_message_factory,
-            1000: dtls_message_factory,
+            5684: dtls_message_factory,
         }
     )
 


### PR DESCRIPTION
When running test scripts related with DTLS, we would get some exceptions. For example, `test_coaps.py`:
```
EXCEPTION: Could not find factory to build UDP payload.
Traceback (most recent call last):
  File "/usr/local/google/home/irvingcl/Documents/git/openthread/tests/scripts/thread-cert/sniffer.py", line 89, in _sniffer_main_loop
    messages = self._message_factory.create(io.BytesIO(data))
  File "/usr/local/google/home/irvingcl/Documents/git/openthread/tests/scripts/thread-cert/message.py", line 625, in create
    ipv6_packet = self._lowpan_parser.parse(lowpan_payload, message_info)
  File "/usr/local/google/home/irvingcl/Documents/git/openthread/tests/scripts/thread-cert/lowpan.py", line 1247, in parse
    return self._handle_iphc_header(data, message_info)
  File "/usr/local/google/home/irvingcl/Documents/git/openthread/tests/scripts/thread-cert/lowpan.py", line 1213, in _handle_iphc_header
    io.BytesIO(decompressed_data), message_info
  File "/usr/local/google/home/irvingcl/Documents/git/openthread/tests/scripts/thread-cert/ipv6.py", line 998, in parse
    data, next_header, message_info
  File "/usr/local/google/home/irvingcl/Documents/git/openthread/tests/scripts/thread-cert/ipv6.py", line 985, in _parse_upper_layer_protocol
    return factory.parse(data, message_info)
  File "/usr/local/google/home/irvingcl/Documents/git/openthread/tests/scripts/thread-cert/ipv6.py", line 1155, in parse
    payload = self._udp_payload_factory.parse(data, message_info)
  File "/usr/local/google/home/irvingcl/Documents/git/openthread/tests/scripts/thread-cert/ipv6.py", line 1129, in parse
    raise RuntimeError("Could not find factory to build UDP payload.")
```
I found that the problem is that the DTLS port in `config.py` is not correct, the actual port is defined in `coap_secure.h` as:
```
#define OT_DEFAULT_COAP_SECURE_PORT 5684 ///< Default CoAP Secure port, as specified in RFC 7252
```