### PR TITLE
[radio] handle CCA ED threshold property configuration

### DIFF
--- a/examples/platforms/cc1352/radio.c
+++ b/examples/platforms/cc1352/radio.c
@@ -1330,7 +1330,7 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
 /**
  * Function documented in platform/radio.h
  */
-otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+otError otPlatRadioGetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);
@@ -1341,7 +1341,7 @@ otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aT
 /**
  * Function documented in platform/radio.h
  */
-otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);

--- a/examples/platforms/cc1352/radio.c
+++ b/examples/platforms/cc1352/radio.c
@@ -1330,6 +1330,28 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
 /**
  * Function documented in platform/radio.h
  */
+otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+/**
+ * Function documented in platform/radio.h
+ */
+otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+/**
+ * Function documented in platform/radio.h
+ */
 otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 {
     OT_UNUSED_VARIABLE(aInstance);

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -1162,7 +1162,7 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     return OT_ERROR_NONE;
 }
 
-otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+otError otPlatRadioGetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);
@@ -1170,7 +1170,7 @@ otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aT
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);

--- a/examples/platforms/cc2538/radio.c
+++ b/examples/platforms/cc2538/radio.c
@@ -1162,6 +1162,22 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     return OT_ERROR_NONE;
 }
 
+otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);

--- a/examples/platforms/cc2650/radio.c
+++ b/examples/platforms/cc2650/radio.c
@@ -1286,6 +1286,28 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
 /**
  * Function documented in platform/radio.h
  */
+otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+/**
+ * Function documented in platform/radio.h
+ */
+otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+/**
+ * Function documented in platform/radio.h
+ */
 otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 {
     OT_UNUSED_VARIABLE(aInstance);

--- a/examples/platforms/cc2650/radio.c
+++ b/examples/platforms/cc2650/radio.c
@@ -1286,7 +1286,7 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
 /**
  * Function documented in platform/radio.h
  */
-otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+otError otPlatRadioGetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);
@@ -1297,7 +1297,7 @@ otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aT
 /**
  * Function documented in platform/radio.h
  */
-otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);

--- a/examples/platforms/cc2652/radio.c
+++ b/examples/platforms/cc2652/radio.c
@@ -1310,6 +1310,28 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
 /**
  * Function documented in platform/radio.h
  */
+otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+/**
+ * Function documented in platform/radio.h
+ */
+otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+/**
+ * Function documented in platform/radio.h
+ */
 otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 {
     OT_UNUSED_VARIABLE(aInstance);

--- a/examples/platforms/cc2652/radio.c
+++ b/examples/platforms/cc2652/radio.c
@@ -1310,7 +1310,7 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
 /**
  * Function documented in platform/radio.h
  */
-otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+otError otPlatRadioGetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);
@@ -1321,7 +1321,7 @@ otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aT
 /**
  * Function documented in platform/radio.h
  */
-otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);

--- a/examples/platforms/efr32mg12/radio.c
+++ b/examples/platforms/efr32mg12/radio.c
@@ -966,6 +966,22 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     return OT_ERROR_NONE;
 }
 
+otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);

--- a/examples/platforms/efr32mg12/radio.c
+++ b/examples/platforms/efr32mg12/radio.c
@@ -966,7 +966,7 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     return OT_ERROR_NONE;
 }
 
-otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+otError otPlatRadioGetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);
@@ -974,7 +974,7 @@ otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aT
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);

--- a/examples/platforms/efr32mg21/radio.c
+++ b/examples/platforms/efr32mg21/radio.c
@@ -941,7 +941,7 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     return OT_ERROR_NONE;
 }
 
-otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+otError otPlatRadioGetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);
@@ -949,7 +949,7 @@ otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aT
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);

--- a/examples/platforms/efr32mg21/radio.c
+++ b/examples/platforms/efr32mg21/radio.c
@@ -941,6 +941,22 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     return OT_ERROR_NONE;
 }
 
+otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);

--- a/examples/platforms/gp712/radio.c
+++ b/examples/platforms/gp712/radio.c
@@ -350,6 +350,22 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
+otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);

--- a/examples/platforms/gp712/radio.c
+++ b/examples/platforms/gp712/radio.c
@@ -350,7 +350,7 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+otError otPlatRadioGetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);
@@ -358,7 +358,7 @@ otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aT
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);

--- a/examples/platforms/kw41z/radio.c
+++ b/examples/platforms/kw41z/radio.c
@@ -515,6 +515,22 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     return OT_ERROR_NONE;
 }
 
+otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);

--- a/examples/platforms/kw41z/radio.c
+++ b/examples/platforms/kw41z/radio.c
@@ -515,7 +515,7 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     return OT_ERROR_NONE;
 }
 
-otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+otError otPlatRadioGetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);
@@ -523,7 +523,7 @@ otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aT
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);

--- a/examples/platforms/nrf528xx/src/radio.c
+++ b/examples/platforms/nrf528xx/src/radio.c
@@ -560,7 +560,7 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     return OT_ERROR_NONE;
 }
 
-otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+otError otPlatRadioGetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
@@ -581,7 +581,7 @@ otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aT
     return error;
 }
 
-otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
 

--- a/examples/platforms/nrf528xx/src/radio.c
+++ b/examples/platforms/nrf528xx/src/radio.c
@@ -74,7 +74,8 @@
 
 enum
 {
-    NRF528XX_RECEIVE_SENSITIVITY = -100, // dBm
+    NRF528XX_RECEIVE_SENSITIVITY  = -100, // dBm
+    NRF528XX_MIN_CCA_ED_THRESHOLD = -94,  // dBm
 };
 
 static bool sDisabled;
@@ -575,7 +576,7 @@ otError otPlatRadioGetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t *aT
     {
         nrf_802154_cca_cfg_get(&ccaConfig);
         // The radio driver has no function to convert ED threshold to dBm
-        *aThreshold = (int8_t)ccaConfig.ed_threshold - 94;
+        *aThreshold = (int8_t)ccaConfig.ed_threshold + NRF528XX_MIN_CCA_ED_THRESHOLD;
     }
 
     return error;
@@ -589,7 +590,7 @@ otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aTh
     nrf_802154_cca_cfg_t ccaConfig;
 
     // The minimum value of ED threshold for radio driver is -94 dBm
-    if (aThreshold < (-94))
+    if (aThreshold < NRF528XX_MIN_CCA_ED_THRESHOLD)
     {
         error = OT_ERROR_INVALID_ARGS;
     }

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -109,7 +109,7 @@ static otPanId        sPanid;
 static bool           sPromiscuous = false;
 static bool           sTxWait      = false;
 static int8_t         sTxPower     = 0;
-static int8_t         sCCAEDThresh = -74;
+static int8_t         sCcaEdThresh = -74;
 
 static bool sSrcMatchEnabled = false;
 
@@ -805,7 +805,7 @@ otError otPlatRadioGetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t *aT
 {
     assert(aInstance != NULL);
 
-    *aThreshold = sCCAEDThresh;
+    *aThreshold = sCcaEdThresh;
 
     return OT_ERROR_NONE;
 }
@@ -814,7 +814,7 @@ otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aTh
 {
     assert(aInstance != NULL);
 
-    sCCAEDThresh = aThreshold;
+    sCcaEdThresh = aThreshold;
 
     return OT_ERROR_NONE;
 }

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -801,7 +801,7 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     return OT_ERROR_NONE;
 }
 
-otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+otError otPlatRadioGetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
 {
     assert(aInstance != NULL);
 
@@ -810,7 +810,7 @@ otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aT
     return OT_ERROR_NONE;
 }
 
-otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
 {
     assert(aInstance != NULL);
 

--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -109,6 +109,7 @@ static otPanId        sPanid;
 static bool           sPromiscuous = false;
 static bool           sTxWait      = false;
 static int8_t         sTxPower     = 0;
+static int8_t         sCCAEDThresh = -74;
 
 static bool sSrcMatchEnabled = false;
 
@@ -796,6 +797,24 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     assert(aInstance != NULL);
 
     sTxPower = aPower;
+
+    return OT_ERROR_NONE;
+}
+
+otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+{
+    assert(aInstance != NULL);
+
+    *aThreshold = sCCAEDThresh;
+
+    return OT_ERROR_NONE;
+}
+
+otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+{
+    assert(aInstance != NULL);
+
+    sCCAEDThresh = aThreshold;
 
     return OT_ERROR_NONE;
 }

--- a/examples/platforms/qpg6095/radio.c
+++ b/examples/platforms/qpg6095/radio.c
@@ -327,14 +327,14 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+otError otPlatRadioGetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);

--- a/examples/platforms/qpg6095/radio.c
+++ b/examples/platforms/qpg6095/radio.c
@@ -327,6 +327,20 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
+otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);

--- a/examples/platforms/samr21/radio.c
+++ b/examples/platforms/samr21/radio.c
@@ -652,7 +652,7 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     return OT_ERROR_NONE;
 }
 
-otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+otError otPlatRadioGetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);
@@ -660,7 +660,7 @@ otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aT
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aThreshold);

--- a/examples/platforms/samr21/radio.c
+++ b/examples/platforms/samr21/radio.c
@@ -652,6 +652,22 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     return OT_ERROR_NONE;
 }
 
+otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aThreshold);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -392,7 +392,7 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower);
  * @retval OT_ERROR_NOT_IMPLEMENTED  CCA ED threshold configuration via dBm is not implemented.
  *
  */
-otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold);
+otError otPlatRadioGetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold);
 
 /**
  * Set the radio's CCA ED threshold in dBm.
@@ -405,7 +405,7 @@ otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aT
  * @retval OT_ERROR_NOT_IMPLEMENTED  CCA ED threshold configuration via dBm is not implemented.
  *
  */
-otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold);
+otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold);
 
 /**
  * Get the status of promiscuous mode.

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -382,6 +382,32 @@ otError otPlatRadioGetTransmitPower(otInstance *aInstance, int8_t *aPower);
 otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower);
 
 /**
+ * Get the radio's CCA ED threshold in dBm.
+ *
+ * @param[in] aInstance    The OpenThread instance structure.
+ * @param[out] aThreshold  The CCA ED threshold in dBm.
+ *
+ * @retval OT_ERROR_NONE             Successfully retrieved the CCA ED threshold.
+ * @retval OT_ERROR_INVALID_ARGS     @p aThreshold was NULL.
+ * @retval OT_ERROR_NOT_IMPLEMENTED  CCA ED threshold configuration via dBm is not implemented.
+ *
+ */
+otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold);
+
+/**
+ * Set the radio's CCA ED threshold in dBm.
+ *
+ * @param[in] aInstance   The OpenThread instance structure.
+ * @param[in] aThreshold  The CCA ED threshold in dBm.
+ *
+ * @retval OT_ERROR_NONE             Successfully set the transmit power.
+ * @retval OT_ERROR_INVALID_ARGS     Given threshold is out of range.
+ * @retval OT_ERROR_NOT_IMPLEMENTED  CCA ED threshold configuration via dBm is not implemented.
+ *
+ */
+otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold);
+
+/**
  * Get the status of promiscuous mode.
  *
  * @param[in] aInstance  The OpenThread instance structure.

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -289,6 +289,34 @@ public:
     otError SetTransmitPower(int8_t aPower) { return otPlatRadioSetTransmitPower(GetInstance(), aPower); }
 
     /**
+     * This method gets the radio's CCA ED threshold in dBm.
+     *
+     * @param[in] aThreshold    The CCA ED threshold in dBm.
+     *
+     * @retval OT_ERROR_NONE             A reference to output the CCA ED threshold in dBm.
+     * @retval OT_ERROR_NOT_IMPLEMENTED  CCA ED threshold configuration via dBm is not implemented.
+     *
+     */
+    otError GetCCAEnergyDetectThreshold(int8_t &aThreshold)
+    {
+        return otPlatRadioGetCCAEnergyDetectThreshold(GetInstance(), &aThreshold);
+    }
+
+    /**
+     * This method sets the radio's CCA ED threshold in dBm.
+     *
+     * @param[in] aThreshold    The CCA ED threshold in dBm.
+     *
+     * @retval OT_ERROR_NONE             Successfully set the CCA ED threshold.
+     * @retval OT_ERROR_NOT_IMPLEMENTED  CCA ED threshold configuration via dBm is not implemented.
+     *
+     */
+    otError SetCCAEnergyDetectThreshold(int8_t &aThreshold)
+    {
+        return otPlatRadioSetCCAEnergyDetectThreshold(GetInstance(), aThreshold);
+    }
+
+    /**
      * This method gets the status of promiscuous mode.
      *
      * @retval TRUE   Promiscuous mode is enabled.

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -297,9 +297,9 @@ public:
      * @retval OT_ERROR_NOT_IMPLEMENTED  CCA ED threshold configuration via dBm is not implemented.
      *
      */
-    otError GetCCAEnergyDetectThreshold(int8_t &aThreshold)
+    otError GetCcaEnergyDetectThreshold(int8_t &aThreshold)
     {
-        return otPlatRadioGetCCAEnergyDetectThreshold(GetInstance(), &aThreshold);
+        return otPlatRadioGetCcaEnergyDetectThreshold(GetInstance(), &aThreshold);
     }
 
     /**
@@ -311,9 +311,9 @@ public:
      * @retval OT_ERROR_NOT_IMPLEMENTED  CCA ED threshold configuration via dBm is not implemented.
      *
      */
-    otError SetCCAEnergyDetectThreshold(int8_t &aThreshold)
+    otError SetCcaEnergyDetectThreshold(int8_t &aThreshold)
     {
-        return otPlatRadioSetCCAEnergyDetectThreshold(GetInstance(), aThreshold);
+        return otPlatRadioSetCcaEnergyDetectThreshold(GetInstance(), aThreshold);
     }
 
     /**

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -2079,7 +2079,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_PHY_CCA_THRESHOLD>(vo
     int8_t  threshold;
     otError error = OT_ERROR_NONE;
 
-    error = otPlatRadioGetCCAEnergyDetectThreshold(mInstance, &threshold);
+    error = otPlatRadioGetCcaEnergyDetectThreshold(mInstance, &threshold);
 
     if (error == OT_ERROR_NONE)
     {
@@ -2099,7 +2099,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_PHY_CCA_THRESHOLD>(vo
     otError error     = OT_ERROR_NONE;
 
     SuccessOrExit(error = mDecoder.ReadInt8(threshold));
-    error = otPlatRadioSetCCAEnergyDetectThreshold(mInstance, threshold);
+    error = otPlatRadioSetCcaEnergyDetectThreshold(mInstance, threshold);
 
 exit:
     return error;

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -2074,6 +2074,37 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_PHY_RX_SENSITIVITY>(v
     return mEncoder.WriteInt8(otPlatRadioGetReceiveSensitivity(mInstance));
 }
 
+template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_PHY_CCA_THRESHOLD>(void)
+{
+    int8_t  threshold;
+    otError error = OT_ERROR_NONE;
+
+    error = otPlatRadioGetCCAEnergyDetectThreshold(mInstance, &threshold);
+
+    if (error == OT_ERROR_NONE)
+    {
+        error = mEncoder.WriteInt8(threshold);
+    }
+    else
+    {
+        error = mEncoder.OverwriteWithLastStatusError(ThreadErrorToSpinelStatus(error));
+    }
+
+    return error;
+}
+
+template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_PHY_CCA_THRESHOLD>(void)
+{
+    int8_t  threshold = 0;
+    otError error     = OT_ERROR_NONE;
+
+    SuccessOrExit(error = mDecoder.ReadInt8(threshold));
+    error = otPlatRadioSetCCAEnergyDetectThreshold(mInstance, threshold);
+
+exit:
+    return error;
+}
+
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_PHY_TX_POWER>(void)
 {
     int8_t  power;

--- a/src/ncp/ncp_base_dispatcher.cpp
+++ b/src/ncp/ncp_base_dispatcher.cpp
@@ -86,6 +86,9 @@ NcpBase::PropertyHandler NcpBase::FindGetPropertyHandler(spinel_prop_key_t aKey)
     case SPINEL_PROP_PHY_RX_SENSITIVITY:
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_PHY_RX_SENSITIVITY>;
         break;
+    case SPINEL_PROP_PHY_CCA_THRESHOLD:
+        handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_PHY_CCA_THRESHOLD>;
+        break;
     case SPINEL_PROP_PHY_TX_POWER:
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_PHY_TX_POWER>;
         break;
@@ -692,6 +695,9 @@ NcpBase::PropertyHandler NcpBase::FindSetPropertyHandler(spinel_prop_key_t aKey)
 #endif
     case SPINEL_PROP_UNSOL_UPDATE_FILTER:
         handler = &NcpBase::HandlePropertySet<SPINEL_PROP_UNSOL_UPDATE_FILTER>;
+        break;
+    case SPINEL_PROP_PHY_CCA_THRESHOLD:
+        handler = &NcpBase::HandlePropertySet<SPINEL_PROP_PHY_CCA_THRESHOLD>;
         break;
     case SPINEL_PROP_PHY_TX_POWER:
         handler = &NcpBase::HandlePropertySet<SPINEL_PROP_PHY_TX_POWER>;

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -886,6 +886,14 @@ otError RadioSpinel::GetTransmitPower(int8_t &aPower)
     return error;
 }
 
+otError RadioSpinel::GetCCAEnergyDetectThreshold(int8_t &aThreshold)
+{
+    otError error = Get(SPINEL_PROP_PHY_CCA_THRESHOLD, SPINEL_DATATYPE_INT8_S, &aThreshold);
+
+    LogIfFail("Get CCA ED threshold failed", error);
+    return error;
+}
+
 int8_t RadioSpinel::GetRssi(void)
 {
     int8_t  rssi  = OT_RADIO_RSSI_INVALID;
@@ -954,6 +962,13 @@ otError RadioSpinel::SetTransmitPower(int8_t aPower)
 {
     otError error = Set(SPINEL_PROP_PHY_TX_POWER, SPINEL_DATATYPE_INT8_S, aPower);
     LogIfFail("Set transmit power failed", error);
+    return error;
+}
+
+otError RadioSpinel::SetCCAEnergyDetectThreshold(int8_t aThreshold)
+{
+    otError error = Set(SPINEL_PROP_PHY_CCA_THRESHOLD, SPINEL_DATATYPE_INT8_S, aThreshold);
+    LogIfFail("Set CCA ED threshold failed", error);
     return error;
 }
 
@@ -1679,6 +1694,19 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
 {
     OT_UNUSED_VARIABLE(aInstance);
     return sRadioSpinel.SetTransmitPower(aPower);
+}
+
+otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+{
+    assert(aThreshold != NULL);
+    OT_UNUSED_VARIABLE(aInstance);
+    return sRadioSpinel.GetTransmitPower(*aThreshold);
+}
+
+otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sRadioSpinel.GetCCAEnergyDetectThreshold(aThreshold);
 }
 
 int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -886,7 +886,7 @@ otError RadioSpinel::GetTransmitPower(int8_t &aPower)
     return error;
 }
 
-otError RadioSpinel::GetCCAEnergyDetectThreshold(int8_t &aThreshold)
+otError RadioSpinel::GetCcaEnergyDetectThreshold(int8_t &aThreshold)
 {
     otError error = Get(SPINEL_PROP_PHY_CCA_THRESHOLD, SPINEL_DATATYPE_INT8_S, &aThreshold);
 
@@ -965,7 +965,7 @@ otError RadioSpinel::SetTransmitPower(int8_t aPower)
     return error;
 }
 
-otError RadioSpinel::SetCCAEnergyDetectThreshold(int8_t aThreshold)
+otError RadioSpinel::SetCcaEnergyDetectThreshold(int8_t aThreshold)
 {
     otError error = Set(SPINEL_PROP_PHY_CCA_THRESHOLD, SPINEL_DATATYPE_INT8_S, aThreshold);
     LogIfFail("Set CCA ED threshold failed", error);
@@ -1696,17 +1696,17 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
     return sRadioSpinel.SetTransmitPower(aPower);
 }
 
-otError otPlatRadioGetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+otError otPlatRadioGetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
 {
     assert(aThreshold != NULL);
     OT_UNUSED_VARIABLE(aInstance);
     return sRadioSpinel.GetTransmitPower(*aThreshold);
 }
 
-otError otPlatRadioSetCCAEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
 {
     OT_UNUSED_VARIABLE(aInstance);
-    return sRadioSpinel.GetCCAEnergyDetectThreshold(aThreshold);
+    return sRadioSpinel.GetCcaEnergyDetectThreshold(aThreshold);
 }
 
 int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)

--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -163,6 +163,30 @@ public:
     otError SetTransmitPower(int8_t aPower);
 
     /**
+     * This method gets the radio's CCA ED threshold in dBm.
+     *
+     * @param[out]  aThreshold    The CCA ED threshold in dBm.
+     *
+     * @retval  OT_ERROR_NONE               Succeeded.
+     * @retval  OT_ERROR_BUSY               Failed due to another operation is on going.
+     * @retval  OT_ERROR_RESPONSE_TIMEOUT   Failed due to no response received from the transceiver.
+     *
+     */
+    otError GetCCAEnergyDetectThreshold(int8_t &aThreshold);
+
+    /**
+     * This method sets the radio's CCA ED threshold in dBm.
+     *
+     * @param[in]   aThreshold     The CCA ED threshold in dBm.
+     *
+     * @retval  OT_ERROR_NONE               Succeeded.
+     * @retval  OT_ERROR_BUSY               Failed due to another operation is on going.
+     * @retval  OT_ERROR_RESPONSE_TIMEOUT   Failed due to no response received from the transceiver.
+     *
+     */
+    otError SetCCAEnergyDetectThreshold(int8_t aThreshold);
+
+    /**
      * This method returns the radio sw version string.
      *
      * @returns A pointer to the radio version string.

--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -172,7 +172,7 @@ public:
      * @retval  OT_ERROR_RESPONSE_TIMEOUT   Failed due to no response received from the transceiver.
      *
      */
-    otError GetCCAEnergyDetectThreshold(int8_t &aThreshold);
+    otError GetCcaEnergyDetectThreshold(int8_t &aThreshold);
 
     /**
      * This method sets the radio's CCA ED threshold in dBm.
@@ -184,7 +184,7 @@ public:
      * @retval  OT_ERROR_RESPONSE_TIMEOUT   Failed due to no response received from the transceiver.
      *
      */
-    otError SetCCAEnergyDetectThreshold(int8_t aThreshold);
+    otError SetCcaEnergyDetectThreshold(int8_t aThreshold);
 
     /**
      * This method returns the radio sw version string.


### PR DESCRIPTION
Changes:
 - Radio interface simply passes calls to platform functions
 - Platform implementation for nRF52840 and nRF52833
 - Placeholders for other platforms (resulting with OT_ERROR_NOT_IMPLENTED)
 - Spinel property configuration handlers