### PR TITLE
[mac] check for no error on TxDone check for data poll frame

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1286,7 +1286,7 @@ void Mac::HandleTransmitDone(TxFrame &aFrame, RxFrame *aAckFrame, otError aError
         break;
 
     case kOperationTransmitPoll:
-        assert(aFrame.GetAckRequest());
+        assert((aError != OT_ERROR_NONE) || aFrame.GetAckRequest());
 
         if ((aError == OT_ERROR_NONE) && (aAckFrame != NULL))
         {


### PR DESCRIPTION
This commit changes the `assert` check for frame to have ack-request
bit set in `HandleTransmitDone()` when performing the operation
`kOperationTransmitPoll` to ensure there is no error. This handles
the case where the frame would not be prepared when a poll tx is
aborted.