### PR TITLE
[mac] set tx frame as empty when tx aborted during frame preparation

### DIFF
--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -250,7 +250,7 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, otError aError
             ExitNow();
         }
 
-        if (aChild.GetIndirectTxAttempts() < kMaxPollTriggeredTxAttempts)
+        if ((aChild.GetIndirectTxAttempts() < kMaxPollTriggeredTxAttempts) && !aFrame.IsEmpty())
         {
             // We save the frame counter, key id, and data sequence number of
             // current frame so we use the same values for the retransmission

--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -199,8 +199,11 @@ void DataPollSender::HandlePollSent(Mac::TxFrame &aFrame, otError aError)
 
     VerifyOrExit(mEnabled);
 
-    aFrame.GetDstAddr(macDest);
-    Get<MeshForwarder>().UpdateNeighborOnSentFrame(aFrame, aError, macDest);
+    if (!aFrame.IsEmpty())
+    {
+        aFrame.GetDstAddr(macDest);
+        Get<MeshForwarder>().UpdateNeighborOnSentFrame(aFrame, aError, macDest);
+    }
 
     if (Get<Mle::MleRouter>().GetParentCandidate()->GetState() == Neighbor::kStateInvalid)
     {

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -852,6 +852,15 @@ public:
     typedef String<kInfoStringSize> InfoString;
 
     /**
+     * This method indicates whether the frame is empty (no payload).
+     *
+     * @retval TRUE  The frame is empty (no PSDU payload).
+     * @retval FALSE The frame is not empty.
+     *
+     */
+    bool IsEmpty(void) const { return (mLength == 0); }
+
+    /**
      * This method initializes the MAC header.
      *
      * @param[in]  aFcf          The Frame Control field.

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -515,8 +515,11 @@ void IndirectSender::HandleSentFrameToChild(const Mac::TxFrame &aFrame,
         }
 #endif
 
-        aFrame.GetDstAddr(macDest);
-        Get<MeshForwarder>().LogMessage(MeshForwarder::kMessageTransmit, *message, &macDest, txError);
+        if (!aFrame.IsEmpty())
+        {
+            aFrame.GetDstAddr(macDest);
+            Get<MeshForwarder>().LogMessage(MeshForwarder::kMessageTransmit, *message, &macDest, txError);
+        }
 
         if (message->GetType() == Message::kTypeIp6)
         {

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -897,8 +897,11 @@ void MeshForwarder::HandleSentFrame(Mac::TxFrame &aFrame, otError aError)
 
     VerifyOrExit(mEnabled);
 
-    aFrame.GetDstAddr(macDest);
-    neighbor = UpdateNeighborOnSentFrame(aFrame, aError, macDest);
+    if (!aFrame.IsEmpty())
+    {
+        aFrame.GetDstAddr(macDest);
+        neighbor = UpdateNeighborOnSentFrame(aFrame, aError, macDest);
+    }
 
     VerifyOrExit(mSendMessage != NULL);
     assert(mSendMessage->GetDirectTransmission());


### PR DESCRIPTION
The TxDone callbacks can be invoked with `OT_ERROR_ABORT` from two
different paths: Either when OpenThread itself cannot prepare the tx
frame (e.g., message was removed while waiting for MAC to handle a tx
request and ask next layers to prepare the frame) or when the radio
platform itself need to abort the tx.

This commit changes the code such that in the first case, the frame
length is set to zero to mark it as empty. The empty frame helps
differentiate between the two cases and ensures that a previously tx
frame is not incorrectly used from the TxDone callbacks.

The TxDone callback handlers (in `MeshForwarder`, `DataPollHanlder`,
`IndirectSender` and `DataPollHandler` are updated to check for frame
not being empty when processing the frame.