### PR TITLE
[nrf528xx] fix make pretty problem

### DIFF
--- a/examples/platforms/nrf528xx/Makefile.am
+++ b/examples/platforms/nrf528xx/Makefile.am
@@ -42,11 +42,8 @@ endif
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 PRETTY_FILES              = \
-    src/*.c                 \
     src/platform-fem.h      \
     src/platform-nrf5.h     \
-    nrf52840/*.h            \
-    nrf52811/*.h            \
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am


### PR DESCRIPTION
When I run 'make pretty', I got the following error:

> 
> Making pretty in nrf528xx
> make[3]: *** No rule to make target 'src/*.c', needed by 'pretty'. Stop.
> make[2]: *** [/usr/local/google/home/irvingcl/Documents/git/openthread-1.2/examples/../third_party/nlbuild-autotools/repo/automake/post/rules/pretty.am:69: pretty-recursive] Error 1
> make[1]: *** [/usr/local/google/home/irvingcl/Documents/git/openthread-1.2/examples/../third_party/nlbuild-autotools/repo/automake/post/rules/pretty.am:69: pretty-recursive] Error 1

It seems that wildcard cannot be used here. It take src/*.c as a real file. So I removed the wildcard here. Maybe we need to add the exact file lists in the nrf52840/Makefile.am and nrf52811/Makefile.am.

@konradderda @bukepo 