### PR TITLE
[efr32] Constructors now called during startup.

### DIFF
--- a/examples/Makefile-efr32mg12
+++ b/examples/Makefile-efr32mg12
@@ -138,7 +138,6 @@ CXXFLAGS                       += \
 LDFLAGS                        += \
     $(COMMONCFLAGS)               \
     $(target_LDFLAGS)             \
-    -nostartfiles                 \
     -specs=nano.specs             \
     -specs=nosys.specs            \
     -Wl,--gc-sections             \

--- a/examples/Makefile-efr32mg21
+++ b/examples/Makefile-efr32mg21
@@ -124,7 +124,6 @@ CXXFLAGS                       += \
 LDFLAGS                        += \
     $(COMMONCFLAGS)               \
     $(target_LDFLAGS)             \
-    -nostartfiles                 \
     -specs=nano.specs             \
     -specs=nosys.specs            \
     -Wl,--gc-sections             \

--- a/examples/platforms/efr32mg12/Makefile.am
+++ b/examples/platforms/efr32mg12/Makefile.am
@@ -43,8 +43,6 @@ EFR32_BOARD_DIR                               = $(shell echo $(BOARD) | tr A-Z a
 EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.6
 
 libopenthread_efr32mg12_a_CPPFLAGS                                            = \
-    -D__START=main                                                              \
-    -D__STARTUP_CLEAR_BSS                                                       \
     -DPLATFORM_HEADER=\"@top_builddir@/third_party/silabs/gecko_sdk_suite/v2.6/platform/base/hal/micro/cortexm3/compiler/gcc.h\" \
     -DNVIC_CONFIG=\"platform/base/hal/micro/cortexm3/efm32/nvic-config.h\"      \
     -Wno-sign-compare                                                           \

--- a/examples/platforms/efr32mg21/Makefile.am
+++ b/examples/platforms/efr32mg21/Makefile.am
@@ -43,8 +43,6 @@ EFR32_BOARD_DIR                               = $(shell echo $(BOARD) | tr A-Z a
 EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.6
 
 libopenthread_efr32mg21_a_CPPFLAGS                                            = \
-    -D__START=main                                                              \
-    -D__STARTUP_CLEAR_BSS                                                       \
     -DPLATFORM_HEADER=\"@top_builddir@/third_party/silabs/gecko_sdk_suite/v2.6/platform/base/hal/micro/cortexm3/compiler/gcc.h\" \
     -Wno-sign-compare                                                           \
     -DCORTEXM3                                                                  \

--- a/third_party/silabs/Makefile.am
+++ b/third_party/silabs/Makefile.am
@@ -57,7 +57,6 @@ EFR32_BOARD_DIR                             = $(shell echo $(BOARD) | tr A-Z a-z
 EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.6
 
 COMMONCPPFLAGS                                                                                = \
-    -D__START=main                                                                              \
     -D__STARTUP_CLEAR_BSS                                                                       \
     -I$(srcdir)                                                                                 \
     -I$(top_srcdir)/include                                                                     \


### PR DESCRIPTION
Removed gcc flags --nostartfiles and __START definition.
Reset_Handler calls mainCRTStartup to call constructors instead of calling main directly.