### PR TITLE
[security] use Random::Crypto for challenge generation

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1973,7 +1973,7 @@ otError Mle::SendParentRequest(ParentRequestType aType)
     uint8_t      scanMask = 0;
     Ip6::Address destination;
 
-    Random::NonCrypto::FillBuffer(mParentRequest.mChallenge, sizeof(mParentRequest.mChallenge));
+    Random::Crypto::FillBuffer(mParentRequest.mChallenge, sizeof(mParentRequest.mChallenge));
 
     switch (aType)
     {
@@ -2300,7 +2300,7 @@ otError Mle::SendChildUpdateRequest(void)
     switch (mRole)
     {
     case OT_DEVICE_ROLE_DETACHED:
-        Random::NonCrypto::FillBuffer(mParentRequest.mChallenge, sizeof(mParentRequest.mChallenge));
+        Random::Crypto::FillBuffer(mParentRequest.mChallenge, sizeof(mParentRequest.mChallenge));
         SuccessOrExit(error = AppendChallenge(*message, mParentRequest.mChallenge, sizeof(mParentRequest.mChallenge)));
         break;
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -515,7 +515,7 @@ otError MleRouter::SendLinkRequest(Neighbor *aNeighbor)
 
     if (aNeighbor == NULL)
     {
-        Random::NonCrypto::FillBuffer(mChallenge, sizeof(mChallenge));
+        Random::Crypto::FillBuffer(mChallenge, sizeof(mChallenge));
 
         mChallengeTimeout = (((2 * kMaxResponseDelay) + kStateUpdatePeriod - 1) / kStateUpdatePeriod);
 
@@ -535,7 +535,7 @@ otError MleRouter::SendLinkRequest(Neighbor *aNeighbor)
         {
             uint8_t challenge[ChallengeTlv::kMaxSize];
 
-            Random::NonCrypto::FillBuffer(challenge, sizeof(challenge));
+            Random::Crypto::FillBuffer(challenge, sizeof(challenge));
             SuccessOrExit(error = AppendChallenge(*message, challenge, sizeof(challenge)));
         }
 

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -43,7 +43,7 @@ namespace ot {
 
 void Neighbor::GenerateChallenge(void)
 {
-    Random::NonCrypto::FillBuffer(mValidPending.mPending.mChallenge, sizeof(mValidPending.mPending.mChallenge));
+    Random::Crypto::FillBuffer(mValidPending.mPending.mChallenge, sizeof(mValidPending.mPending.mChallenge));
 }
 
 void Child::Clear(void)
@@ -243,7 +243,7 @@ exit:
 
 void Child::GenerateChallenge(void)
 {
-    Random::NonCrypto::FillBuffer(mAttachChallenge, sizeof(mAttachChallenge));
+    Random::Crypto::FillBuffer(mAttachChallenge, sizeof(mAttachChallenge));
 }
 
 void Router::Clear(void)


### PR DESCRIPTION
We shouldn't rely on `Random::NonCrypto` when generating the challenge values as we don't know it's imperfections. Instead `Random::Crypto` should be used because truly random challenge values are required.

Also, I wonder if we don't have other security-related randoms generated using `Random::NonCrypto`.
The most suspicious for me is the `Slaac::GetIidSecretKey` which may fall back to `Random::NonCrypto` without any fail notification.