### PR TITLE
[efr32] fix LED gpio port and pin allocation for BRD4166A

### DIFF
--- a/examples/platforms/efr32mg12/brd4166a/hal-config.h
+++ b/examples/platforms/efr32mg12/brd4166a/hal-config.h
@@ -149,11 +149,11 @@
 // $[LED]
 #define BSP_LED_PRESENT                       (1)
 
-#define BSP_LED0_PIN                          (4)
-#define BSP_LED0_PORT                         (gpioPortF)
+#define BSP_LED0_PIN                          (8)
+#define BSP_LED0_PORT                         (gpioPortD)
 
-#define BSP_LED1_PIN                          (5)
-#define BSP_LED1_PORT                         (gpioPortF)
+#define BSP_LED1_PIN                          (9)
+#define BSP_LED1_PORT                         (gpioPortD)
 
 #define HAL_LED_ENABLE                        { 0, 1 }
 #define HAL_LED_COUNT                         (2)


### PR DESCRIPTION
Fix for Thunderboard Sense 2 (BRD4166A) LED GPIOs
This bug is inherited from SDK v2.6 bspconfig.h which is also incorrect.