### PR TITLE
[efr32] move __START definition to Makefile-efr32mgxx makefiles

### DIFF
--- a/examples/Makefile-efr32mg12
+++ b/examples/Makefile-efr32mg12
@@ -112,6 +112,7 @@ COMMONCFLAGS                       := \
     -Os                               \
     -g                                \
     -I$(HAL_CONF_DIR)                 \
+    -D__START=main                    \
     -D$(MCU)                          \
     $(EFR32MG12_CONFIG_FILE_CPPFLAGS) \
     $(NULL)

--- a/examples/Makefile-efr32mg21
+++ b/examples/Makefile-efr32mg21
@@ -98,6 +98,7 @@ COMMONCFLAGS                       := \
     -Os                               \
     -g                                \
     -I$(HAL_CONF_DIR)                 \
+    -D__START=main                    \
     -D$(MCU)                          \
     $(EFR32MG21_CONFIG_FILE_CPPFLAGS) \
     $(NULL)

--- a/examples/platforms/efr32mg12/Makefile.am
+++ b/examples/platforms/efr32mg12/Makefile.am
@@ -43,8 +43,6 @@ EFR32_BOARD_DIR                               = $(shell echo $(BOARD) | tr A-Z a
 EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.6
 
 libopenthread_efr32mg12_a_CPPFLAGS                                            = \
-    -D__START=main                                                              \
-    -D__STARTUP_CLEAR_BSS                                                       \
     -DPLATFORM_HEADER=\"@top_builddir@/third_party/silabs/gecko_sdk_suite/v2.6/platform/base/hal/micro/cortexm3/compiler/gcc.h\" \
     -DNVIC_CONFIG=\"platform/base/hal/micro/cortexm3/efm32/nvic-config.h\"      \
     -Wno-sign-compare                                                           \

--- a/examples/platforms/efr32mg21/Makefile.am
+++ b/examples/platforms/efr32mg21/Makefile.am
@@ -43,8 +43,6 @@ EFR32_BOARD_DIR                               = $(shell echo $(BOARD) | tr A-Z a
 EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.6
 
 libopenthread_efr32mg21_a_CPPFLAGS                                            = \
-    -D__START=main                                                              \
-    -D__STARTUP_CLEAR_BSS                                                       \
     -DPLATFORM_HEADER=\"@top_builddir@/third_party/silabs/gecko_sdk_suite/v2.6/platform/base/hal/micro/cortexm3/compiler/gcc.h\" \
     -Wno-sign-compare                                                           \
     -DCORTEXM3                                                                  \

--- a/third_party/silabs/Makefile.am
+++ b/third_party/silabs/Makefile.am
@@ -57,7 +57,6 @@ EFR32_BOARD_DIR                             = $(shell echo $(BOARD) | tr A-Z a-z
 EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.6
 
 COMMONCPPFLAGS                                                                                = \
-    -D__START=main                                                                              \
     -D__STARTUP_CLEAR_BSS                                                                       \
     -I$(srcdir)                                                                                 \
     -I$(top_srcdir)/include                                                                     \


### PR DESCRIPTION
Moved the definition  of __START from third_party/silabs/Makefile.am.
This is to allow an external project to be built so that constructors are called at startup. This can be done by removing the nostartfiles configure option and __START definition from their makefile.

The mg12 and mg21 example makefiles within OpenThread continue to build with the nostartfiles option.
