### PR TITLE
[efr32] add otSysEventSignalPending and NVIC priorities to efr32mg21

### DIFF
--- a/examples/platforms/efr32mg21/Makefile.am
+++ b/examples/platforms/efr32mg21/Makefile.am
@@ -46,6 +46,8 @@ libopenthread_efr32mg21_a_CPPFLAGS                                            = 
     -D__START=main                                                              \
     -D__STARTUP_CLEAR_BSS                                                       \
     -DPLATFORM_HEADER=\"@top_builddir@/third_party/silabs/gecko_sdk_suite/v2.6/platform/base/hal/micro/cortexm3/compiler/gcc.h\" \
+    -DEFR32_SERIES2_CONFIG1_MICRO                                               \
+    -DNVIC_CONFIG=\"platform/base/hal/micro/cortexm3/efm32/nvic-config.h\"      \
     -Wno-sign-compare                                                           \
     -DCORTEXM3                                                                  \
     -DPHY=EMBER_PHY_RAIL                                                        \

--- a/examples/platforms/efr32mg21/alarm.c
+++ b/examples/platforms/efr32mg21/alarm.c
@@ -68,6 +68,7 @@ static bool     sIsRunning = false;
 
 static void RAILCb_TimerExpired(RAIL_Handle_t aHandle)
 {
+    otSysEventSignalPending();
 }
 
 void efr32AlarmInit(void)

--- a/examples/platforms/efr32mg21/radio.c
+++ b/examples/platforms/efr32mg21/radio.c
@@ -34,6 +34,7 @@
 
 #include <assert.h>
 
+#include "openthread-system.h"
 #include <openthread/config.h>
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
@@ -718,6 +719,8 @@ static void processNextRxPacket(otInstance *aInstance)
         }
     }
 
+    otSysEventSignalPending();
+
 exit:
 
     if (packetHandle != RAIL_RX_PACKET_HANDLE_INVALID)
@@ -862,6 +865,8 @@ static void RAILCb_Generic(RAIL_Handle_t aRailHandle, RAIL_Events_t aEvents)
 #endif
         }
     }
+
+    otSysEventSignalPending();
 }
 
 otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration)
@@ -900,11 +905,14 @@ void efr32RadioProcess(otInstance *aInstance)
 #if RADIO_CONFIG_DEBUG_COUNTERS_SUPPORT
         sRailDebugCounters.mRailPlatRadioTxDoneCbCount++;
 #endif
+
+        otSysEventSignalPending();
     }
     else if (sEnergyScanMode == ENERGY_SCAN_MODE_ASYNC && sEnergyScanStatus == ENERGY_SCAN_STATUS_COMPLETED)
     {
         sEnergyScanStatus = ENERGY_SCAN_STATUS_IDLE;
         otPlatRadioEnergyScanDone(aInstance, sEnergyScanResultDbm);
+        otSysEventSignalPending();
 
 #if RADIO_CONFIG_DEBUG_COUNTERS_SUPPORT
         sRailDebugCounters.mRailEventEnergyScanCompleted++;

--- a/examples/platforms/efr32mg21/uart.c
+++ b/examples/platforms/efr32mg21/uart.c
@@ -34,6 +34,7 @@
 
 #include <stddef.h>
 
+#include "openthread-system.h"
 #include <openthread/platform/uart.h>
 
 #include "utils/code_utils.h"
@@ -106,11 +107,13 @@ static void receiveDone(UARTDRV_Handle_t aHandle, Ecode_t aStatus, uint8_t *aDat
     }
 
     UARTDRV_Receive(aHandle, aData, 1, receiveDone);
+    otSysEventSignalPending();
 }
 
 static void transmitDone(UARTDRV_Handle_t aHandle, Ecode_t aStatus, uint8_t *aData, UARTDRV_Count_t aCount)
 {
     sTransmitLength = 0;
+    otSysEventSignalPending();
 }
 
 static void processReceive(void)


### PR DESCRIPTION
Added otSysEventSignalPending to efr32mg21.
Initialization of the NVIC interrupt priority registers for the efr32mg21.