### PR TITLE
[address-resolver] update EID-to-RLOC cache when attaching MTD child

### DIFF
--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -115,6 +115,20 @@ void AddressResolver::Remove(uint16_t aRloc16)
     }
 }
 
+void AddressResolver::Remove(const Ip6::Address &aEid)
+{
+    for (int i = 0; i < kCacheEntries; i++)
+    {
+        if (mCache[i].mState == Cache::kStateInvalid || mCache[i].mTarget != aEid)
+        {
+            continue;
+        }
+
+        InvalidateCacheEntry(mCache[i], kReasonRemovingEid);
+        break;
+    }
+}
+
 AddressResolver::Cache *AddressResolver::NewCacheEntry(void)
 {
     Cache *rval = NULL;
@@ -247,25 +261,6 @@ otError AddressResolver::UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAd
         }
 
         error = OT_ERROR_NONE;
-    }
-
-    return error;
-}
-
-otError AddressResolver::RemoveCacheEntry(const Ip6::Address &aEid)
-{
-    otError error = OT_ERROR_NOT_FOUND;
-
-    for (int i = 0; i < kCacheEntries; i++)
-    {
-        if (mCache[i].mState == Cache::kStateInvalid || mCache[i].mTarget != aEid)
-        {
-            continue;
-        }
-
-        InvalidateCacheEntry(mCache[i], kReasonRemovingEid);
-        error = OT_ERROR_NONE;
-        break;
     }
 
     return error;

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -174,6 +174,10 @@ const char *AddressResolver::ConvertInvalidationReasonToString(InvalidationReaso
     case kReasonEvictingForNewEntry:
         str = "evicting for new entry";
         break;
+
+    case kReasonRemovingEid:
+        str = "removing eid";
+        break;
     }
 
     return str;
@@ -243,6 +247,25 @@ otError AddressResolver::UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAd
         }
 
         error = OT_ERROR_NONE;
+    }
+
+    return error;
+}
+
+otError AddressResolver::RemoveCacheEntry(const Ip6::Address &aEid)
+{
+    otError error = OT_ERROR_NOT_FOUND;
+
+    for (int i = 0; i < kCacheEntries; i++)
+    {
+        if (mCache[i].mState == Cache::kStateInvalid || mCache[i].mTarget != aEid)
+        {
+            continue;
+        }
+
+        InvalidateCacheEntry(mCache[i], kReasonRemovingEid);
+        error = OT_ERROR_NONE;
+        break;
     }
 
     return error;

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -115,6 +115,17 @@ public:
     otError UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16);
 
     /**
+     * This method removes the cache entry for the EID.
+     *
+     * @param[in]  aEid               A reference to the EID.
+     *
+     * @retval OT_ERROR_NONE          Successfully removed the cache entry.
+     * @retval OT_ERROR_NOT_FOUND     No cache entry with @p aEid.
+     *
+     */
+    otError RemoveCacheEntry(const Ip6::Address &aEid);
+
+    /**
      * This method adds one cache entry for the EID.
      *
      * @param[in]  aEid               A reference to the EID.
@@ -197,6 +208,7 @@ private:
         kReasonRemovingRloc16,
         kReasonReceivedIcmpDstUnreachNoRoute,
         kReasonEvictingForNewEntry,
+        kReasonRemovingEid,
     };
 
     static const char *ConvertInvalidationReasonToString(InvalidationReason aReason);

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -103,6 +103,14 @@ public:
     void Remove(uint8_t aRouterId);
 
     /**
+     * This method removes the cache entry for the EID.
+     *
+     * @param[in]  aEid               A reference to the EID.
+     *
+     */
+    void Remove(const Ip6::Address &aEid);
+
+    /**
      * This method updates an existing cache entry for the EID.
      *
      * @param[in]  aEid               A reference to the EID.
@@ -113,17 +121,6 @@ public:
      *
      */
     otError UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16);
-
-    /**
-     * This method removes the cache entry for the EID.
-     *
-     * @param[in]  aEid               A reference to the EID.
-     *
-     * @retval OT_ERROR_NONE          Successfully removed the cache entry.
-     * @retval OT_ERROR_NOT_FOUND     No cache entry with @p aEid.
-     *
-     */
-    otError RemoveCacheEntry(const Ip6::Address &aEid);
 
     /**
      * This method adds one cache entry for the EID.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2049,7 +2049,7 @@ otError MleRouter::UpdateChildAddresses(const Message &aMessage, uint16_t aOffse
         }
 
         // Clear EID-to-RLOC cache for the unicast address registered by the child.
-        Get<AddressResolver>().RemoveCacheEntry(address);
+        Get<AddressResolver>().Remove(address);
     }
 
     if (registeredCount == 0)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2047,6 +2047,9 @@ otError MleRouter::UpdateChildAddresses(const Message &aMessage, uint16_t aOffse
 
             IgnoreReturnValue(iter.GetChild()->RemoveIp6Address(GetInstance(), address));
         }
+
+        // Clear EID-to-RLOC cache for the unicast address registered by the child.
+        Get<AddressResolver>().RemoveCacheEntry(address);
     }
 
     if (registeredCount == 0)


### PR DESCRIPTION
This commits removes deprecated EID-to-RLOC cache if there is entry for
the unicast address registered by MTD child in case this child switches
its parent.