### PR TITLE
[mac] Adding <Set/Clear>TemporaryChannel() & GenerateRandomPanId()

### DIFF
--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -308,46 +308,26 @@ public:
     otError SetPanChannel(uint8_t aChannel);
 
     /**
-     * This method returns the IEEE 802.15.4 Radio Channel.
+     * This method sets the temporary IEEE 802.15.4 radio channel.
      *
-     * @returns The IEEE 802.15.4 Radio Channel.
+     * This method allows user to temporarily change the radio channel and use a different channel (during receive)
+     * instead of the PAN channel (from `SetPanChannel()`). A call to `ClearTemporaryChannel()` would clear the
+     * temporary channel and adopt the PAN channel again. The `SetTemporaryChannel()` can be used multiple times in row
+     * (before a call to `ClearTemporaryChannel()`) to change the temporary channel.
      *
-     */
-    uint8_t GetRadioChannel(void) const { return mRadioChannel; }
-
-    /**
-     * This method sets the IEEE 802.15.4 Radio Channel. It can only be called after successfully calling
-     * `AcquireRadioChannel()`.
+     * @param[in]  aChannel            A IEEE 802.15.4 channel.
      *
-     * @param[in]  aChannel  The IEEE 802.15.4 Radio Channel.
-     *
-     * @retval OT_ERROR_NONE           Successfully set the IEEE 802.15.4 Radio Channel.
+     * @retval OT_ERROR_NONE           Successfully set the temporary channel
      * @retval OT_ERROR_INVALID_ARGS   The @p aChannel is not in the supported channel mask.
-     * @retval OT_ERROR_INVALID_STATE  The acquisition ID is incorrect.
      *
      */
-    otError SetRadioChannel(uint16_t aAcquisitionId, uint8_t aChannel);
+    otError SetTemporaryChannel(uint8_t aChannel);
 
     /**
-     * This method acquires external ownership of the Radio channel so that future calls to `SetRadioChannel)()` will
-     * succeed.
-     *
-     * @param[out]  aAcquisitionId  The AcquisitionId that the caller should use when calling `SetRadioChannel()`.
-     *
-     * @retval OT_ERROR_NONE           Successfully acquired permission to Set the Radio Channel.
-     * @retval OT_ERROR_INVALID_STATE  Failed to acquire permission as the radio Channel has already been acquired.
+     * This method clears the use of a previously set temporary channel and adopts the PAN channel.
      *
      */
-    otError AcquireRadioChannel(uint16_t *aAcquisitionId);
-
-    /**
-     * This method releases external ownership of the radio Channel that was acquired with `AcquireRadioChannel()`. The
-     * channel will re-adopt the PAN Channel when this API is called.
-     *
-     * @retval OT_ERROR_NONE  Successfully released the IEEE 802.15.4 Radio Channel.
-     *
-     */
-    otError ReleaseRadioChannel(void);
+    void ClearTemporaryChannel(void);
 
     /**
      * This method returns the supported channel mask.
@@ -733,6 +713,7 @@ private:
     bool mRxOnWhenIdle : 1;
     bool mPromiscuous : 1;
     bool mBeaconsEnabled : 1;
+    bool mUsingTemporaryChannel : 1;
 #if OPENTHREAD_CONFIG_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS
     bool mShouldDelaySleep : 1;
     bool mDelayingSleep : 1;
@@ -745,7 +726,6 @@ private:
     PanId         mPanId;
     uint8_t       mPanChannel;
     uint8_t       mRadioChannel;
-    uint16_t      mRadioChannelAcquisitionId;
     ChannelMask   mSupportedChannelMask;
     ExtendedPanId mExtendedPanId;
     NetworkName   mNetworkName;

--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -42,6 +42,18 @@
 namespace ot {
 namespace Mac {
 
+PanId GenerateRandomPanId(void)
+{
+    PanId panId;
+
+    do
+    {
+        panId = Random::NonCrypto::GetUint16();
+    } while (panId == kPanIdBroadcast);
+
+    return panId;
+}
+
 void ExtAddress::GenerateRandom(void)
 {
     Random::NonCrypto::FillBuffer(m8, sizeof(ExtAddress));

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -74,6 +74,14 @@ typedef otPanId PanId;
 typedef otShortAddress ShortAddress;
 
 /**
+ * This function generates a random IEEE 802.15.4 PAN ID.
+ *
+ * @returns A randomly generated IEEE 802.15.4 PAN ID (excluding `kPanIdBroadcast`).
+ *
+ */
+PanId GenerateRandomPanId(void);
+
+/**
  * This structure represents an IEEE 802.15.4 Extended Address.
  *
  */

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -345,10 +345,7 @@ otError ActiveDataset::CreateNewNetwork(otOperationalDataset &aDataset)
     aDataset.mChannel     = preferredChannels.ChooseRandomChannel();
     aDataset.mChannelMask = supportedChannels.GetMask();
 
-    do
-    {
-        aDataset.mPanId = Random::NonCrypto::GetUint16();
-    } while (aDataset.mPanId == Mac::kPanIdBroadcast);
+    aDataset.mPanId = Mac::GenerateRandomPanId();
 
     snprintf(aDataset.mNetworkName.m8, sizeof(aDataset.mNetworkName), "OpenThread-%04x", aDataset.mPanId);
 

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -496,14 +496,7 @@ otError MeshForwarder::HandleFrameRequest(Mac::TxFrame &aFrame)
             // value.
             if (mSendMessage->GetPanId() == Mac::kPanIdBroadcast && Get<Mac::Mac>().GetPanId() == Mac::kPanIdBroadcast)
             {
-                uint16_t panid;
-
-                do
-                {
-                    panid = Random::NonCrypto::GetUint16();
-                } while (panid == Mac::kPanIdBroadcast);
-
-                Get<Mac::Mac>().SetPanId(panid);
+                Get<Mac::Mac>().SetPanId(Mac::GenerateRandomPanId());
             }
         }
 

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -513,7 +513,6 @@ private:
 
     Mac::ChannelMask mScanChannels;
     uint8_t          mScanChannel;
-    uint16_t         mMacRadioAcquisitionId;
     uint16_t         mRestorePanId;
     bool             mScanning;
 


### PR DESCRIPTION
This PR contains two smaller commits:

**[mac] Adding SetTemporaryChannel()/ClearTemporaryChannel()**
    
This commit adds new method in `Mac` namely `SetTemporaryChannel()` and `ClearTemporaryChannel()` to allow user to temporarily change the radio channel and use a different channel (during receive) instead of the PAN channel (from `SetPanChannel()`). A subsequent call to
`ClearTemporaryChannel()` would clear the temporary channel and adopt the PAN channel again. The new implementation replaces and simplifies the previous `<Acquire/Release>RadioChannel()` model.

**[mac] add Mac::GenerateRandomPanId()**
    
This commit adds a helper function `Mac::GenerateRandomPanId()` which generates a random PAN Identifier (excluding the broadcast PAN Id `kPanIdBroadcast`).
