### PR TITLE
 [ncp] add support for clearing all/subset of counters

### DIFF
--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -752,6 +752,14 @@ int8_t otLinkConvertLinkQualityToRss(otInstance *aInstance, uint8_t aLinkQuality
 const otMacCounters *otLinkGetCounters(otInstance *aInstance);
 
 /**
+ * Reset the MAC layer counters.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ *
+ */
+void otLinkResetCounters(otInstance *aInstance);
+
+/**
  * This function pointer is called when an IEEE 802.15.4 frame is received.
  *
  * @note This callback is called after FCS processing and @p aFrame may not contain the actual FCS that was received.

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -731,6 +731,14 @@ otError otThreadSendDiagnosticReset(otInstance *        aInstance,
 const otIpCounters *otThreadGetIp6Counters(otInstance *aInstance);
 
 /**
+ * Reset the IPv6 counters.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ *
+ */
+void otThreadResetIp6Counters(otInstance *aInstance);
+
+/**
  * Get the Thread MLE counters.
  *
  * @param[in]  aInstance  A pointer to an OpenThread instance.

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -371,6 +371,13 @@ const otMacCounters *otLinkGetCounters(otInstance *aInstance)
     return &instance.Get<Mac::Mac>().GetCounters();
 }
 
+void otLinkResetCounters(otInstance *aInstance)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    instance.Get<Mac::Mac>().ResetCounters();
+}
+
 otError otLinkActiveScan(otInstance *             aInstance,
                          uint32_t                 aScanChannels,
                          uint16_t                 aScanDuration,

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -454,6 +454,13 @@ const otIpCounters *otThreadGetIp6Counters(otInstance *aInstance)
     return &instance.Get<MeshForwarder>().GetCounters();
 }
 
+void otThreadResetIp6Counters(otInstance *aInstance)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    instance.Get<MeshForwarder>().ResetCounters();
+}
+
 const otMleCounters *otThreadGetMleCounters(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -79,10 +79,7 @@ MeshForwarder::MeshForwarder(Instance &aInstance)
 {
     mFragTag = Random::NonCrypto::GetUint16();
 
-    mIpCounters.mTxSuccess = 0;
-    mIpCounters.mRxSuccess = 0;
-    mIpCounters.mTxFailure = 0;
-    mIpCounters.mRxFailure = 0;
+    ResetCounters();
 
 #if OPENTHREAD_FTD
     memset(mFragmentEntries, 0, sizeof(mFragmentEntries));

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -297,6 +297,12 @@ public:
      */
     const otIpCounters &GetCounters(void) const { return mIpCounters; }
 
+    /**
+     * This method resets the IP level counters.
+     *
+     */
+    void ResetCounters(void) { memset(&mIpCounters, 0, sizeof(mIpCounters)); }
+
 #if OPENTHREAD_FTD
     /**
      * This method returns a reference to the resolving queue.

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -296,6 +296,23 @@ NcpBase *NcpBase::GetNcpInstance(void)
     return sNcpInstance;
 }
 
+void NcpBase::ResetCounters(void)
+{
+    mFramingErrorCounter          = 0;
+    mRxSpinelFrameCounter         = 0;
+    mRxSpinelOutOfOrderTidCounter = 0;
+    mTxSpinelFrameCounter         = 0;
+
+#if OPENTHREAD_MTD || OPENTHREAD_FTD
+    mInboundSecureIpFrameCounter    = 0;
+    mInboundInsecureIpFrameCounter  = 0;
+    mOutboundSecureIpFrameCounter   = 0;
+    mOutboundInsecureIpFrameCounter = 0;
+    mDroppedOutboundIpFrameCounter  = 0;
+    mDroppedInboundIpFrameCounter   = 0;
+#endif
+}
+
 // ----------------------------------------------------------------------------
 // MARK: Serial Traffic Glue
 // ----------------------------------------------------------------------------

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -421,6 +421,8 @@ protected:
     otError HandlePropertySet_SPINEL_PROP_STREAM_RAW(uint8_t aHeader);
 #endif
 
+    void ResetCounters(void);
+
 #if OPENTHREAD_CONFIG_LEGACY_ENABLE
     void StartLegacy(void);
     void StopLegacy(void);

--- a/src/ncp/ncp_base_dispatcher.cpp
+++ b/src/ncp/ncp_base_dispatcher.cpp
@@ -513,6 +513,9 @@ NcpBase::PropertyHandler NcpBase::FindGetPropertyHandler(spinel_prop_key_t aKey)
     case SPINEL_PROP_CNTR_IP_RX_FAILURE:
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_CNTR_IP_RX_FAILURE>;
         break;
+    case SPINEL_PROP_CNTR_ALL_IP_COUNTERS:
+        handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_CNTR_ALL_IP_COUNTERS>;
+        break;
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     case SPINEL_PROP_THREAD_NETWORK_TIME:
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_NETWORK_TIME>;
@@ -890,6 +893,15 @@ NcpBase::PropertyHandler NcpBase::FindSetPropertyHandler(spinel_prop_key_t aKey)
 #endif
     case SPINEL_PROP_CNTR_RESET:
         handler = &NcpBase::HandlePropertySet<SPINEL_PROP_CNTR_RESET>;
+        break;
+    case SPINEL_PROP_CNTR_ALL_MAC_COUNTERS:
+        handler = &NcpBase::HandlePropertySet<SPINEL_PROP_CNTR_ALL_MAC_COUNTERS>;
+        break;
+    case SPINEL_PROP_CNTR_MLE_COUNTERS:
+        handler = &NcpBase::HandlePropertySet<SPINEL_PROP_CNTR_MLE_COUNTERS>;
+        break;
+    case SPINEL_PROP_CNTR_ALL_IP_COUNTERS:
+        handler = &NcpBase::HandlePropertySet<SPINEL_PROP_CNTR_ALL_IP_COUNTERS>;
         break;
 #if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
     case SPINEL_PROP_CHILD_SUPERVISION_CHECK_TIMEOUT:

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -2171,6 +2171,10 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "CNTR_MLE_COUNTERS";
         break;
 
+    case SPINEL_PROP_CNTR_ALL_IP_COUNTERS:
+        ret = "CNTR_ALL_IP_COUNTERS";
+        break;
+
     case SPINEL_PROP_NEST_STREAM_MFG:
         ret = "NEST_STREAM_MFG";
         break;

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -3531,10 +3531,12 @@ typedef enum
 
     SPINEL_PROP_CNTR__BEGIN = 0x500,
 
-    /// Counter reset behavior
-    /** Format: `C`
-     *  Writing a '1' to this property will reset
-     *  all of the counters to zero. */
+    /// Counter reset
+    /** Format: Empty (Write only).
+     *
+     * Writing to this property (with any value) will reset all MAC, MLE, IP, and NCP counters to zero.
+     *
+     */
     SPINEL_PROP_CNTR_RESET = SPINEL_PROP_CNTR__BEGIN + 0,
 
     /// The total number of transmissions.
@@ -3739,7 +3741,7 @@ typedef enum
     SPINEL_PROP_MSG_BUFFER_COUNTERS = SPINEL_PROP_CNTR__BEGIN + 400,
 
     /// All MAC related counters.
-    /** Format: t(A(L))t(A(L))  (Read-only)
+    /** Format: t(A(L))t(A(L))
      *
      * The contents include two structs, first one corresponds to
      * all transmit related MAC counters, second one provides the
@@ -3782,11 +3784,14 @@ typedef enum
      *   'L': RxErrSec             (The number of received packets with security error).
      *   'L': RxErrFcs             (The number of received packets with FCS error).
      *   'L': RxErrOther           (The number of received packets with other error).
+     *
+     * Writing to this property with any value would reset all MAC counters to zero.
+     *
      */
     SPINEL_PROP_CNTR_ALL_MAC_COUNTERS = SPINEL_PROP_CNTR__BEGIN + 401,
 
     /// Thread MLE counters.
-    /** Format: `SSSSSSSSS`  (Read-only)
+    /** Format: `SSSSSSSSS`
      *
      *   'S': DisabledRole                  (The number of times device entered OT_DEVICE_ROLE_DISABLED role).
      *   'S': DetachedRole                  (The number of times device entered OT_DEVICE_ROLE_DETACHED role).
@@ -3798,8 +3803,30 @@ typedef enum
      *   'S': BetterPartitionAttachAttempts (The number of attempts to attach to a better partition).
      *   'S': ParentChanges                 (The number of times device changed its parents).
      *
+     * Writing to this property with any value would reset all MLE counters to zero.
+     *
      */
     SPINEL_PROP_CNTR_MLE_COUNTERS = SPINEL_PROP_CNTR__BEGIN + 402,
+
+    /// Thread IPv6 counters.
+    /** Format: `t(LL)t(LL)`
+     *
+     * The contents include two structs, first one corresponds to
+     * all transmit related MAC counters, second one provides the
+     * receive related counters.
+     *
+     * The transmit structure includes:
+     *   'L': TxSuccess (The number of IPv6 packets successfully transmitted).
+     *   'L': TxFailure (The number of IPv6 packets failed to transmit).
+     *
+     * The receive structure includes:
+     *   'L': RxSuccess (The number of IPv6 packets successfully received).
+     *   'L': RxFailure (The number of IPv6 packets failed to receive).
+     *
+     * Writing to this property with any value would reset all IPv6 counters to zero.
+     *
+     */
+    SPINEL_PROP_CNTR_ALL_IP_COUNTERS = SPINEL_PROP_CNTR__BEGIN + 403,
 
     SPINEL_PROP_CNTR__END = 0x800,
 


### PR DESCRIPTION
This PR contains 3 related commits:

 **[ncp] add support for clearing all/subset of counters**
This commit adds support in NCP/spinel for clearing counters. It also adds new `PROP_CNTR_ALL_IP_COUNTERS` property to get all IPv6 counters. All (MAC, MLE, IPv6, and NCP) counters can be cleared by writing (`PROP_VALUE_SET` with any value) to `SPINEL_PROP_CNTR_RESET` property. A specific subset of counters (MAC, MLE, IP) can be cleared by writing (any value) to the corresponding spinel property (`PROP_CNTR_ALL_MAC_COUNTERS`, `PROP_CNTR_MLE_COUNTERS`, or    `PROP_CNTR_ALL_IP_COUNTERS`).

**[link] add public OT API otLinkResetCounters to reset MAC counters**

**[mesh-forwarder] add method ResetCounters to clear IP counter**
This commit also adds a public API `otThreadResetIp6Counters()`.

