### PR TITLE
[ncp] add support in spinel/NCP to generate PSKc from pass-phrase 

### DIFF
--- a/include/openthread/commissioner.h
+++ b/include/openthread/commissioner.h
@@ -403,25 +403,23 @@ uint16_t otCommissionerGetSessionId(otInstance *aInstance);
 otCommissionerState otCommissionerGetState(otInstance *aInstance);
 
 /**
- * This method generates PSKc.
+ * This helper function generates PSKc from a given pass-phrase, network name, and extended PAN Id.
  *
  * PSKc is used to establish the Commissioner Session.
  *
- * @param[in]  aInstance     A pointer to an OpenThread instance.
- * @param[in]  aPassPhrase   The commissioning passphrase.
+ * @param[in]  aPassPhrase   The commissioning pass-phrase.
  * @param[in]  aNetworkName  The network name for PSKc computation.
- * @param[in]  aExtPanId     The extended pan id for PSKc computation.
- * @param[out] aPskc         A pointer to the generated PSKc.
+ * @param[in]  aExtPanId     The extended PAN ID for PSKc computation.
+ * @param[out] aPskc         A pointer to variable to output the generated PSKc.
  *
  * @retval OT_ERROR_NONE          Successfully generate PSKc.
  * @retval OT_ERROR_INVALID_ARGS  If any of the input arguments is invalid.
  *
  */
-otError otCommissionerGeneratePskc(otInstance *           aInstance,
-                                   const char *           aPassPhrase,
+otError otCommissionerGeneratePskc(const char *           aPassPhrase,
                                    const char *           aNetworkName,
                                    const otExtendedPanId *aExtPanId,
-                                   uint8_t *              aPskc);
+                                   otPskc *               aPskc);
 
 /**
  * @}

--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -181,15 +181,12 @@ otCommissionerState otCommissionerGetState(otInstance *aInstance)
     return instance.Get<MeshCoP::Commissioner>().GetState();
 }
 
-otError otCommissionerGeneratePskc(otInstance *           aInstance,
-                                   const char *           aPassPhrase,
+otError otCommissionerGeneratePskc(const char *           aPassPhrase,
                                    const char *           aNetworkName,
                                    const otExtendedPanId *aExtPanId,
-                                   uint8_t *              aPskc)
+                                   otPskc *               aPskc)
 {
-    OT_UNUSED_VARIABLE(aInstance);
-
-    return MeshCoP::Commissioner::GeneratePskc(aPassPhrase, aNetworkName,
-                                               *static_cast<const Mac::ExtendedPanId *>(aExtPanId), aPskc);
+    return MeshCoP::Commissioner::GeneratePskc(
+        aPassPhrase, aNetworkName, *static_cast<const Mac::ExtendedPanId *>(aExtPanId), *static_cast<Pskc *>(aPskc));
 }
 #endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -1100,7 +1100,7 @@ exit:
 otError Commissioner::GeneratePskc(const char *              aPassPhrase,
                                    const char *              aNetworkName,
                                    const Mac::ExtendedPanId &aExtPanId,
-                                   uint8_t *                 aPskc)
+                                   Pskc &                    aPskc)
 {
     otError     error      = OT_ERROR_NONE;
     const char *saltPrefix = "Thread";
@@ -1122,7 +1122,7 @@ otError Commissioner::GeneratePskc(const char *              aPassPhrase,
     saltLen += static_cast<uint16_t>(strlen(aNetworkName));
 
     otPbkdf2Cmac(reinterpret_cast<const uint8_t *>(aPassPhrase), static_cast<uint16_t>(strlen(aPassPhrase)),
-                 reinterpret_cast<const uint8_t *>(salt), saltLen, 16384, OT_PSKC_MAX_SIZE, aPskc);
+                 reinterpret_cast<const uint8_t *>(salt), saltLen, 16384, OT_PSKC_MAX_SIZE, aPskc.m8);
 
 exit:
     return error;

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -48,6 +48,7 @@
 #include "meshcop/energy_scan_client.hpp"
 #include "meshcop/panid_query_client.hpp"
 #include "net/udp6.hpp"
+#include "thread/key_manager.hpp"
 #include "thread/mle.hpp"
 
 namespace ot {
@@ -218,7 +219,7 @@ public:
      * @param[in]  aPassPhrase   The commissioning passphrase.
      * @param[in]  aNetworkName  The network name for PSKc computation.
      * @param[in]  aExtPanId     The extended pan id for PSKc computation.
-     * @param[out] aPskc         A pointer to where the generated PSKc will be placed.
+     * @param[out] aPskc         A reference to a PSKc where the generated PSKc will be placed.
      *
      * @retval OT_ERROR_NONE          Successfully generate PSKc.
      * @retval OT_ERROR_INVALID_ARGS  If the length of passphrase is out of range.
@@ -227,7 +228,7 @@ public:
     static otError GeneratePskc(const char *              aPassPhrase,
                                 const char *              aNetworkName,
                                 const Mac::ExtendedPanId &aExtPanId,
-                                uint8_t *                 aPskc);
+                                Pskc &                    aPskc);
 
     /**
      * This method returns a reference to the AnnounceBeginClient instance.

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -936,6 +936,9 @@ bool NcpBase::HandlePropertySetForSpecialProperties(uint8_t aHeader, spinel_prop
 #endif
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
+    case SPINEL_PROP_MESHCOP_COMMISSIONER_GENERATE_PSKC:
+        ExitNow(aError = HandlePropertySet_SPINEL_PROP_MESHCOP_COMMISSIONER_GENERATE_PSKC(aHeader));
+
     case SPINEL_PROP_THREAD_COMMISSIONER_ENABLED:
         ExitNow(aError = HandlePropertySet_SPINEL_PROP_THREAD_COMMISSIONER_ENABLED(aHeader));
 #endif

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -413,6 +413,7 @@ protected:
 #endif
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
+    otError HandlePropertySet_SPINEL_PROP_MESHCOP_COMMISSIONER_GENERATE_PSKC(uint8_t aHeader);
     otError HandlePropertySet_SPINEL_PROP_THREAD_COMMISSIONER_ENABLED(uint8_t aHeader);
 #endif // OPENTHREAD_FTD
 

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -759,6 +759,32 @@ exit:
     return error;
 }
 
+otError NcpBase::HandlePropertySet_SPINEL_PROP_MESHCOP_COMMISSIONER_GENERATE_PSKC(uint8_t aHeader)
+{
+    otError        error = OT_ERROR_NONE;
+    const char *   passPhrase;
+    const char *   networkName;
+    const uint8_t *extPanIdData;
+    uint16_t       length;
+    otPskc         pskc;
+
+    SuccessOrExit(error = mDecoder.ReadUtf8(passPhrase));
+    SuccessOrExit(error = mDecoder.ReadUtf8(networkName));
+    SuccessOrExit(error = mDecoder.ReadDataWithLen(extPanIdData, length));
+    VerifyOrExit(length == sizeof(spinel_net_xpanid_t), error = OT_ERROR_PARSE);
+
+    SuccessOrExit(error = otCommissionerGeneratePskc(passPhrase, networkName,
+                                                     reinterpret_cast<const otExtendedPanId *>(extPanIdData), &pskc));
+
+    SuccessOrExit(
+        error = mEncoder.BeginFrame(aHeader, SPINEL_CMD_PROP_VALUE_IS, SPINEL_PROP_MESHCOP_COMMISSIONER_GENERATE_PSKC));
+    SuccessOrExit(error = mEncoder.WriteData(pskc.m8, sizeof(pskc)));
+    SuccessOrExit(error = mEncoder.EndFrame());
+
+exit:
+    return error;
+}
+
 // SPINEL_PROP_THREAD_COMMISSIONER_ENABLED is replaced by SPINEL_PROP_MESHCOP_COMMISSIONER_STATE. Please use the new
 // property. The old property/implementation remains for backward compatibility.
 

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1883,6 +1883,10 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "MESHCOP_COMMISSIONER_MGMT_SET";
         break;
 
+    case SPINEL_PROP_MESHCOP_COMMISSIONER_GENERATE_PSKC:
+        ret = "MESHCOP_COMMISSIONER_GENERATE_PSKC";
+        break;
+
     case SPINEL_PROP_CHANNEL_MANAGER_NEW_CHANNEL:
         ret = "CHANNEL_MANAGER_NEW_CHANNEL";
         break;

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -3208,6 +3208,29 @@ typedef enum
      */
     SPINEL_PROP_MESHCOP_COMMISSIONER_MGMT_SET = SPINEL_PROP_MESHCOP_EXT__BEGIN + 6,
 
+    // Thread Commissioner Generate PSKc
+    /** Format: `UUd` - Write only
+     *
+     * Required capability: SPINEL_CAP_THREAD_COMMISSIONER
+     *
+     * Writing to this property allows user to generate PSKc from a given commissioning pass-phrase, network name,
+     * extended PAN Id.
+     *
+     * Written value format is:
+     *
+     *   `U` : The commissioning pass-phrase.
+     *   `U` : Network Name.
+     *   `d` : Extended PAN ID.
+     *
+     * The response on success would be a `VALUE_IS` command with the PSKc with format below:
+     *
+     *   `D` : The PSKc
+     *
+     * On a failure a `LAST_STATUS` is emitted with the error status.
+     *
+     */
+    SPINEL_PROP_MESHCOP_COMMISSIONER_GENERATE_PSKC = SPINEL_PROP_MESHCOP_EXT__BEGIN + 7,
+
     SPINEL_PROP_MESHCOP_EXT__END = 0x1900,
 
     SPINEL_PROP_OPENTHREAD__BEGIN = 0x1900,

--- a/tests/unit/test_pskc.cpp
+++ b/tests/unit/test_pskc.cpp
@@ -40,7 +40,7 @@ static const otExtendedPanId sXPanId = {{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x0
 
 void TestMinimumPassphrase(void)
 {
-    uint8_t       pskc[OT_PSKC_MAX_SIZE];
+    ot::Pskc      pskc;
     const uint8_t expectedPskc[] = {0x44, 0x98, 0x8e, 0x22, 0xcf, 0x65, 0x2e, 0xee,
                                     0xcc, 0xd1, 0xe4, 0xc0, 0x1d, 0x01, 0x54, 0xf8};
     const char    passphrase[]   = "123456";
@@ -48,13 +48,13 @@ void TestMinimumPassphrase(void)
     SuccessOrQuit(ot::MeshCoP::Commissioner::GeneratePskc(passphrase, "OpenThread",
                                                           static_cast<const ot::Mac::ExtendedPanId &>(sXPanId), pskc),
                   "TestMinimumPassphrase failed to generate PSKc");
-    VerifyOrQuit(memcmp(pskc, expectedPskc, sizeof(pskc)) == 0, "TestMinimumPassphrase got wrong pskc");
+    VerifyOrQuit(memcmp(pskc.m8, expectedPskc, sizeof(pskc)) == 0, "TestMinimumPassphrase got wrong pskc");
     testFreeInstance(instance);
 }
 
 void TestMaximumPassphrase(void)
 {
-    uint8_t       pskc[OT_PSKC_MAX_SIZE];
+    ot::Pskc      pskc;
     const uint8_t expectedPskc[] = {0x9e, 0x81, 0xbd, 0x35, 0xa2, 0x53, 0x76, 0x2f,
                                     0x80, 0xee, 0x04, 0xff, 0x2f, 0xa2, 0x85, 0xe9};
     const char    passphrase[]   = "1234567812345678"
@@ -78,7 +78,7 @@ void TestMaximumPassphrase(void)
     SuccessOrQuit(ot::MeshCoP::Commissioner::GeneratePskc(passphrase, "OpenThread",
                                                           static_cast<const ot::Mac::ExtendedPanId &>(sXPanId), pskc),
                   "TestMaximumPassphrase failed to generate PSKc");
-    VerifyOrQuit(memcmp(pskc, expectedPskc, sizeof(pskc)) == 0, "TestMaximumPassphrase got wrong pskc");
+    VerifyOrQuit(memcmp(pskc.m8, expectedPskc, sizeof(pskc)) == 0, "TestMaximumPassphrase got wrong pskc");
     testFreeInstance(instance);
 }
 


### PR DESCRIPTION
This PR also contains a smaller change in APIs:

[commissioner] change GeneratePskc to use otPskc/Pskc types (#4294)

----
Related PR in wpantund: https://github.com/openthread/wpantund/pull/443