### PR TITLE
[key-manager] only enable guard timer protection when switching to network key index

### DIFF
--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -168,11 +168,16 @@ void KeyManager::SetCurrentKeySequence(uint32_t aKeySequence)
 {
     VerifyOrExit(aKeySequence != mKeySequence, Get<Notifier>().SignalIfFirst(OT_CHANGED_THREAD_KEY_SEQUENCE_COUNTER));
 
-    // Check if the guard timer has expired if key rotation is requested.
-    if ((aKeySequence == (mKeySequence + 1)) && (mKeySwitchGuardTime != 0) && mKeyRotationTimer.IsRunning() &&
-        mKeySwitchGuardEnabled)
+    if ((aKeySequence == (mKeySequence + 1)) && mKeyRotationTimer.IsRunning())
     {
-        VerifyOrExit(mHoursSinceKeyRotation >= mKeySwitchGuardTime);
+        if (mKeySwitchGuardEnabled)
+        {
+            // Check if the guard timer has expired if key rotation is requested.
+            VerifyOrExit(mHoursSinceKeyRotation >= mKeySwitchGuardTime);
+            StartKeyRotationTimer();
+        }
+
+        mKeySwitchGuardEnabled = true;
     }
 
     mKeySequence = aKeySequence;
@@ -180,12 +185,6 @@ void KeyManager::SetCurrentKeySequence(uint32_t aKeySequence)
 
     mMacFrameCounter = 0;
     mMleFrameCounter = 0;
-
-    if (mKeyRotationTimer.IsRunning())
-    {
-        mKeySwitchGuardEnabled = true;
-        StartKeyRotationTimer();
-    }
 
     Get<Notifier>().Signal(OT_CHANGED_THREAD_KEY_SEQUENCE_COUNTER);
 

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -1081,7 +1081,6 @@ class OpenThread(IThci):
 
             # set Thread device mode with a given role
             self.__setDeviceMode(mode)
-            self.__setKeySwitchGuardTime(0)
 
             # start OpenThread
             self.__startOpenThread()
@@ -1648,6 +1647,9 @@ class OpenThread(IThci):
         print('%s call setKeySequenceCounter' % self.port)
         print(iKeySequenceValue)
         try:
+            # avoid key switch guard timer protection for reference device
+            self.__setKeySwitchGuardTime(0)
+
             cmd = 'keysequence counter %s' % str(iKeySequenceValue)
             if self.__sendCommand(cmd)[-1] == 'Done':
                 time.sleep(1)
@@ -1680,6 +1682,8 @@ class OpenThread(IThci):
         print(iIncrementValue)
         currentKeySeq = ''
         try:
+            # avoid key switch guard timer protection for reference device
+            self.__setKeySwitchGuardTime(0)
             currentKeySeq = self.getKeySequenceCounter()
             keySequence = int(currentKeySeq, 10) + iIncrementValue
             print(keySequence)

--- a/tools/harness-thci/OpenThread_WpanCtl.py
+++ b/tools/harness-thci/OpenThread_WpanCtl.py
@@ -1402,7 +1402,6 @@ class OpenThread_WpanCtl(IThci):
 
             # set Thread device mode with a given role
             self.__setDeviceMode(mode)
-            self.__setKeySwitchGuardTime(0)  # temporally
             time.sleep(0.1)
             # start OpenThreadWpan
             self.__startOpenThreadWpan()
@@ -1979,6 +1978,9 @@ class OpenThread_WpanCtl(IThci):
         print('%s call setKeySequenceCounter' % self.port)
         print(iKeySequenceValue)
         try:
+            # avoid key switch guard timer protection for reference device
+            self.__setKeySwitchGuardTime(0)
+
             cmd = WPANCTL_CMD + 'setprop Network:KeyIndex %s' % str(
                 iKeySequenceValue
             )
@@ -2015,6 +2017,9 @@ class OpenThread_WpanCtl(IThci):
         print(iIncrementValue)
         currentKeySeq = ''
         try:
+            # avoid key switch guard timer protection for reference device
+            self.__setKeySwitchGuardTime(0)
+
             currentKeySeq = self.getKeySequenceCounter()
             keySequence = int(currentKeySeq, 10) + iIncrementValue
             print(keySequence)


### PR DESCRIPTION
The first commit only enable guard timer protection when switching to network key index.
The second commit includes relative THCI updates considering possible further TP468 updates: allowing the initiate reference device to trigger possible multiple key sequence updates; and for DUT,  only default behavior is allowed, i.e. with the guard timer protection.
