### PR TITLE
[operational-dataset] only generate active dataset once

### DIFF
--- a/src/core/meshcop/dataset_local.hpp
+++ b/src/core/meshcop/dataset_local.hpp
@@ -81,6 +81,15 @@ public:
     bool IsSaved(void) const { return mSaved; }
 
     /**
+     * This method indicates whether an Active (Pending) Timestamp is present in the Active (Pending) Dataset.
+     *
+     * @retval TRUE  if an Active/Pending Timestamp is present.
+     * @retval FALSE if an Active/Pending Timestamp is not present.
+     *
+     */
+    bool IsTimestampPresent(void) const { return mTimestampPresent; }
+
+    /**
      * This method restores and retrieves the dataset from non-volatile memory.
      *
      * This method also sets the memory-cached timestamp for subsequent calls to `Compare()`.

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -391,7 +391,8 @@ public:
     /**
      * This method generate a default Active Operational Dataset.
      *
-     * @retval OT_ERROR_NONE  Successfully generated an Active Operational Dataset.
+     * @retval OT_ERROR_NONE           Successfully generated an Active Operational Dataset.
+     * @retval OT_ERROR_ALREADY        A valid Active Operational Dataset already exists.
      * @retval OT_ERROR_INVALID_STATE  Device is not currently attached to a network.
      *
      */

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -370,6 +370,7 @@ otError ActiveDataset::GenerateLocal(void)
     Dataset dataset(mLocal.GetType());
 
     VerifyOrExit(Get<Mle::MleRouter>().IsAttached(), error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(!mLocal.IsTimestampPresent(), error = OT_ERROR_ALREADY);
 
     mLocal.Read(dataset);
 


### PR DESCRIPTION
Add check to see if Active Timestamp already exists in the Active
Operational Dataset. If Active Timestamp exists, do not generate
Active Operational Dataset again.

Submitting this as an alternative proposal to #4258.