### PR TITLE
[travis] disable arm-gcc-8 until compiler bug is fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,10 +106,12 @@ jobs:
       os: linux
       compiler: gcc
       script: .travis/script.sh
-    - env: BUILD_TARGET="arm-gcc-8"
-      os: linux
-      compiler: gcc
-      script: .travis/script.sh
+# Disable Arm GCC 8 until slow compile bug is fixed:
+# https://github.com/openthread/openthread/issues/4053
+#    - env: BUILD_TARGET="arm-gcc-8"
+#      os: linux
+#      compiler: gcc
+#      script: .travis/script.sh
     - env: BUILD_TARGET="posix" CC="gcc-5" CXX="g++-5"
       os: linux
       compiler: gcc


### PR DESCRIPTION
Bug fix will be included in next Arm GCC 8 release.
https://community.arm.com/developer/tools-software/oss-platforms/f/gnu-toolchain-forum/13503/gcc-g-version-8-very-slow-to-compile/159739#159739