### PR TITLE
[misc] coap typo, key-manager, netif

### DIFF
--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -225,7 +225,7 @@ public:
     /**
      * This method returns a pointer to the next resource.
      *
-     * @returns A Pointer to the next resource.
+     * @returns A pointer to the next resource.
      *
      */
     Resource *GetNext(void) const { return static_cast<Resource *>(mNext); }
@@ -233,7 +233,7 @@ public:
     /**
      * This method returns a pointer to the Uri-Path.
      *
-     * @returns A Pointer to the Uri-Path.
+     * @returns A pointer to the Uri-Path.
      *
      */
     const char *GetUriPath(void) const { return mUriPath; }
@@ -275,7 +275,7 @@ public:
     }
 
     /**
-     * This method append metadata to the message.
+     * This method appends metadata to the message.
      *
      * @param[in]  aMessage  A reference to the message.
      *
@@ -345,10 +345,11 @@ public:
     explicit ResponsesQueue(Instance &aInstance);
 
     /**
-     * Add given response to the cache.
+     * This method adds a given response to the cache.
      *
      * If matching response (the same Message ID, source endpoint address and port) exists in the cache given
      * response is not added.
+     *
      * The CoAP response is copied before it is added to the cache.
      *
      * @param[in]  aMessage      The CoAP response to add to the cache.
@@ -358,23 +359,23 @@ public:
     void EnqueueResponse(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     /**
-     * Remove the oldest response from the cache.
+     * This method removes the oldest response from the cache.
      *
      */
     void DequeueOldestResponse(void);
 
     /**
-     * Remove all responses from the cache.
+     * This method removes all responses from the cache.
      *
      */
     void DequeueAllResponses(void);
 
     /**
-     * Get a copy of CoAP response from the cache that matches given Message ID and source endpoint.
+     * This method gets a copy of CoAP response from the cache that matches a given Message ID and source endpoint.
      *
      * @param[in]  aRequest      The CoAP message containing Message ID.
      * @param[in]  aMessageInfo  The message info containing source endpoint address and port.
-     * @param[out] aResponse     A pointer to a copy of a cached CoAP response matching given arguments.
+     * @param[out] aResponse     A pointer to return a copy of a cached CoAP response matching given arguments.
      *
      * @retval OT_ERROR_NONE       Matching response found and successfully created a copy.
      * @retval OT_ERROR_NO_BUFS    Matching response found but there is not sufficient buffer to create a copy.
@@ -384,7 +385,7 @@ public:
     otError GetMatchedResponseCopy(const Message &aRequest, const Ip6::MessageInfo &aMessageInfo, Message **aResponse);
 
     /**
-     * Get a reference to the cached CoAP responses queue.
+     * This method gets a reference to the cached CoAP responses queue.
      *
      * @returns  A reference to the cached CoAP responses queue.
      *
@@ -398,12 +399,13 @@ private:
     };
 
     /**
-     * Check if CoAP response exists in the cache that matches given Message ID and source endpoint.
+     * This method checks whether a CoAP response exists in the cache that matches a given Message ID and source
+     * endpoint.
      *
      * @param[in]  aRequest      The CoAP message containing Message ID.
      * @param[in]  aMessageInfo  The message info containing source endpoint address and port.
      *
-     * @returns Matching cached response or NULL if not found.
+     * @returns A pointer to the matching cached response or NULL if not found.
      *
      */
     const Message *FindMatchedResponse(const Message &aRequest, const Ip6::MessageInfo &aMessageInfo) const;
@@ -444,7 +446,7 @@ public:
     typedef otError (*Sender)(CoapBase &aCoapBase, ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     /**
-     * This function pointer is called before CoAP server processing a CoAP packets.
+     * This function pointer is called before CoAP server processing a CoAP message.
      *
      * @param[in]   aMessage        A reference to the message.
      @ @param[in]   aMessageInfo    A reference to the message info associated with @p aMessage.
@@ -483,10 +485,11 @@ public:
      */
     void RemoveResource(Resource &aResource);
 
-    /* This function sets the default handler for unhandled CoAP requests.
+    /* This method sets the default handler for unhandled CoAP requests.
      *
      * @param[in]  aHandler   A function pointer that shall be called when an unhandled request arrives.
      * @param[in]  aContext   A pointer to arbitrary context information. May be NULL if not used.
+     *
      */
     void SetDefaultHandler(otCoapRequestHandler aHandler, void *aContext);
 
@@ -652,7 +655,7 @@ protected:
      *
      * @param[in]  aInstance        A reference to the OpenThread instance.
      * @param[in]  aSender          A function pointer to send CoAP message, which SHOULD be a static
-     *                              member method of a descendent of this class.
+     *                              member method of a descendant of this class.
      *
      */
     explicit CoapBase(Instance &aInstance, Sender aSender);

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -80,7 +80,7 @@ public:
         kMinHeaderLength    = 4,   ///< Minimum header length
         kMaxHeaderLength    = 512, ///< Maximum header length
         kDefaultTokenLength = 2,   ///< Default token length
-        kTypeOffset         = 4,   ///< The type offset in the first byte of a coap header
+        kTypeOffset         = 4,   ///< The type offset in the first byte of a CoAP header
     };
 
     /**
@@ -257,9 +257,9 @@ public:
     otError SetToken(uint8_t aTokenLength);
 
     /**
-     *  This method checks if Tokens in two CoAP headers are equal.
+     * This method checks if Tokens in two CoAP headers are equal.
      *
-     *  @param[in]  aMessage  A header to compare.
+     * @param[in]  aMessage  A header to compare.
      *
      * @retval TRUE   If two Tokens are equal.
      * @retval FALSE  If Tokens differ in length or value.

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -164,8 +164,8 @@ public:
 
 #ifdef MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
     /**
-     * This method sets the Pre-Shared Key (PSK) for DTLS sessions
-     * identified by a PSK.
+     * This method sets the Pre-Shared Key (PSK) for DTLS sessions identified by a PSK.
+     *
      * DTLS mode "TLS with AES 128 CCM 8" for Application CoAPS.
      *
      * @param[in]  aPsk          A pointer to the PSK.
@@ -198,8 +198,7 @@ public:
                         uint32_t       aPrivateKeyLength);
 
     /**
-     * This method sets the trusted top level CAs. It is needed for validate the
-     * certificate of the peer.
+     * This method sets the trusted top level CAs. It is needed for validate the certificate of the peer.
      *
      * DTLS mode "ECDHE ECDSA with AES 128 CCM 8" for Application CoAPS.
      *
@@ -228,21 +227,19 @@ public:
 #endif // MBEDTLS_BASE64_C
 
     /**
-     * This method sets the connected callback to indicate, when
-     * a Client connect to the CoAP Secure server.
+     * This method sets the connected callback to indicate, when a Client connect to the CoAP Secure server.
      *
-     * @param[in]  aCallback     A pointer to a function that will be called once DTLS connection is
-     * established.
+     * @param[in]  aCallback     A pointer to a function that will be called once DTLS connection is established.
      * @param[in]  aContext      A pointer to arbitrary context information.
      *
      */
     void SetClientConnectedCallback(ConnectedCallback aCallback, void *aContext);
 
     /**
-     * This method set the authentication mode for the coap secure connection.
-     * Disable or enable the verification of peer certificate.
+     * This method sets the authentication mode for the CoAP secure connection. It disables or enables the verification
+     * of peer certificate.
      *
-     * @param[in]  aVerifyPeerCertificate  true, if the peer certificate should verify.
+     * @param[in]  aVerifyPeerCertificate  true, if the peer certificate should be verified
      *
      */
     void SetSslAuthMode(bool aVerifyPeerCertificate);
@@ -291,7 +288,6 @@ public:
 
     /**
      * This method is used to pass UDP messages to the secure CoAP server.
-     * It can be used when messages are received other way that via server's socket.
      *
      * @param[in]  aMessage      A reference to the received message.
      * @param[in]  aMessageInfo  A reference to the message info associated with @p aMessage.

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -43,6 +43,7 @@
 #include "mac/mac.hpp"
 #include "mac/mac_types.hpp"
 #include "net/dhcp6.hpp"
+#include "net/netif.hpp"
 #include "net/udp6.hpp"
 
 namespace ot {
@@ -87,11 +88,11 @@ enum IaStatus
  */
 struct IdentityAssociation
 {
-    otNetifAddress mNetifAddress;      ///< the NetifAddress
-    uint32_t       mPreferredLifetime; ///< The preferred lifetime.
-    uint32_t       mValidLifetime;     ///< The valid lifetime.
-    uint16_t       mPrefixAgentRloc;   ///< Rloc of Prefix Agent
-    uint8_t        mStatus;            ///< Status of IdentityAssociation
+    Ip6::NetifUnicastAddress mNetifAddress;      ///< the NetifAddress
+    uint32_t                 mPreferredLifetime; ///< The preferred lifetime.
+    uint32_t                 mValidLifetime;     ///< The valid lifetime.
+    uint16_t                 mPrefixAgentRloc;   ///< Rloc of Prefix Agent
+    uint8_t                  mStatus;            ///< Status of IdentityAssociation
 };
 
 /**
@@ -120,7 +121,7 @@ private:
     void Start(void);
     void Stop(void);
 
-    static bool MatchNetifAddressWithPrefix(const otNetifAddress &aNetifAddress, const otIp6Prefix &aIp6Prefix);
+    static bool MatchNetifAddressWithPrefix(const Ip6::NetifUnicastAddress &aAddress, const otIp6Prefix &aIp6Prefix);
 
     otError Solicit(uint16_t aRloc16);
 

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -59,26 +59,6 @@ class Ip6;
  */
 
 /**
- * This class represents an IPv6 Link Address.
- *
- */
-class LinkAddress
-{
-public:
-    /**
-     * Hardware types.
-     *
-     */
-    enum HardwareType
-    {
-        kEui64 = 27,
-    };
-    HardwareType    mType;       ///< Link address type.
-    uint8_t         mLength;     ///< Length of link address.
-    Mac::ExtAddress mExtAddress; ///< Link address.
-};
-
-/**
  * This class implements an IPv6 network interface unicast address.
  *
  */

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -238,13 +238,7 @@ exit:
 
 void KeyManager::SetSecurityPolicyFlags(uint8_t aSecurityPolicyFlags)
 {
-    Notifier &notifier = Get<Notifier>();
-
-    if (!notifier.HasSignaled(OT_CHANGED_SECURITY_POLICY) || (mSecurityPolicyFlags != aSecurityPolicyFlags))
-    {
-        mSecurityPolicyFlags = aSecurityPolicyFlags;
-        notifier.Signal(OT_CHANGED_SECURITY_POLICY);
-    }
+    Get<Notifier>().Update(mSecurityPolicyFlags, aSecurityPolicyFlags, OT_CHANGED_SECURITY_POLICY);
 }
 
 void KeyManager::StartKeyRotationTimer(void)


### PR DESCRIPTION
This PR contains couple of smaller unrelated commits:
- [coap] fix typos 
- [key-manager] use Notifier::Update when changing security policy
- [netif] remove unused type LinkAddress
- [dhcp6-client] use NetifUnicastAddress in IdentityAssociation struct 

