### PR TITLE
[efr32] fix COAPS switch build error on mg12 and mg21

### DIFF
--- a/third_party/mbedtls/Makefile.am
+++ b/third_party/mbedtls/Makefile.am
@@ -55,6 +55,7 @@ libmbedcrypto_a_SOURCES                       = \
     repo/library/ecdh.c                         \
     repo/library/ecdsa.c                        \
     repo/library/ecjpake.c                      \
+    repo/library/ecp.c                          \
     repo/library/ecp_curves.c                   \
     repo/library/entropy.c                      \
     repo/library/entropy_poll.c                 \
@@ -79,14 +80,6 @@ libmbedcrypto_a_SOURCES                       = \
     repo/library/x509.c                         \
     repo/library/x509_crt.c                     \
     $(NULL)
-
-if !OPENTHREAD_EXAMPLES_EFR32MG12
-if !OPENTHREAD_EXAMPLES_EFR32MG21
-libmbedcrypto_a_SOURCES                      += \
-    repo/library/ecp.c                          \
-    $(NULL)
-endif
-endif
 
 if OPENTHREAD_BUILD_COVERAGE
 Dash                                          = -


### PR DESCRIPTION
third_party/mbedtls/ecp.c was excluded for mg12 and mg21.