### PR TITLE
[network-data] fix prefix comparison / use reference param instead of pointer (during iter)

### DIFF
--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -110,7 +110,7 @@ otError otBorderRouterGetNextOnMeshPrefix(otInstance *           aInstance,
 
     assert(aIterator != NULL && aConfig != NULL);
 
-    return instance.Get<NetworkData::Local>().GetNextOnMeshPrefix(aIterator, aConfig);
+    return instance.Get<NetworkData::Local>().GetNextOnMeshPrefix(*aIterator, *aConfig);
 }
 
 otError otBorderRouterAddRoute(otInstance *aInstance, const otExternalRouteConfig *aConfig)
@@ -140,7 +140,7 @@ otError otBorderRouterGetNextRoute(otInstance *           aInstance,
 
     assert(aIterator != NULL && aConfig != NULL);
 
-    return instance.Get<NetworkData::Local>().GetNextExternalRoute(aIterator, aConfig);
+    return instance.Get<NetworkData::Local>().GetNextExternalRoute(*aIterator, *aConfig);
 }
 
 otError otBorderRouterRegister(otInstance *aInstance)

--- a/src/core/api/netdata_api.cpp
+++ b/src/core/api/netdata_api.cpp
@@ -58,7 +58,7 @@ otError otNetDataGetNextOnMeshPrefix(otInstance *           aInstance,
 
     VerifyOrExit(aIterator && aConfig, error = OT_ERROR_INVALID_ARGS);
 
-    error = instance.Get<NetworkData::Leader>().GetNextOnMeshPrefix(aIterator, aConfig);
+    error = instance.Get<NetworkData::Leader>().GetNextOnMeshPrefix(*aIterator, *aConfig);
 
 exit:
     return error;
@@ -71,7 +71,7 @@ otError otNetDataGetNextRoute(otInstance *aInstance, otNetworkDataIterator *aIte
 
     VerifyOrExit(aIterator && aConfig, error = OT_ERROR_INVALID_ARGS);
 
-    error = instance.Get<NetworkData::Leader>().GetNextExternalRoute(aIterator, aConfig);
+    error = instance.Get<NetworkData::Leader>().GetNextExternalRoute(*aIterator, *aConfig);
 
 exit:
     return error;

--- a/src/core/api/server_api.cpp
+++ b/src/core/api/server_api.cpp
@@ -78,7 +78,7 @@ otError otServerGetNextService(otInstance *aInstance, otNetworkDataIterator *aIt
 
     VerifyOrExit(aIterator && aConfig, error = OT_ERROR_INVALID_ARGS);
 
-    error = instance.Get<NetworkData::Local>().GetNextService(aIterator, aConfig);
+    error = instance.Get<NetworkData::Local>().GetNextService(*aIterator, *aConfig);
 
 exit:
     return error;
@@ -91,7 +91,7 @@ otError otServerGetNextLeaderService(otInstance *aInstance, otNetworkDataIterato
 
     VerifyOrExit(aIterator && aConfig, error = OT_ERROR_INVALID_ARGS);
 
-    error = instance.Get<NetworkData::Leader>().GetNextService(aIterator, aConfig);
+    error = instance.Get<NetworkData::Leader>().GetNextService(*aIterator, *aConfig);
 
 exit:
     return error;

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -70,10 +70,10 @@ bool Dhcp6Client::MatchNetifAddressWithPrefix(const Ip6::NetifUnicastAddress &aN
 
 void Dhcp6Client::UpdateAddresses(void)
 {
-    bool                  found    = false;
-    bool                  newAgent = false;
-    otNetworkDataIterator iterator;
-    otBorderRouterConfig  config;
+    bool                            found    = false;
+    bool                            newAgent = false;
+    NetworkData::Iterator           iterator;
+    NetworkData::OnMeshPrefixConfig config;
 
     // remove addresses directly if prefix not valid in network data
     for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mIdentityAssociations); i++)
@@ -86,9 +86,9 @@ void Dhcp6Client::UpdateAddresses(void)
         }
 
         found    = false;
-        iterator = OT_NETWORK_DATA_ITERATOR_INIT;
+        iterator = NetworkData::kIteratorInit;
 
-        while ((otNetDataGetNextOnMeshPrefix(&GetInstance(), &iterator, &config)) == OT_ERROR_NONE)
+        while (Get<NetworkData::Leader>().GetNextOnMeshPrefix(iterator, config) == OT_ERROR_NONE)
         {
             if (!config.mDhcp)
             {
@@ -110,9 +110,9 @@ void Dhcp6Client::UpdateAddresses(void)
     }
 
     // add IdentityAssociation for new configured prefix
-    iterator = OT_NETWORK_DATA_ITERATOR_INIT;
+    iterator = NetworkData::kIteratorInit;
 
-    while (otNetDataGetNextOnMeshPrefix(&GetInstance(), &iterator, &config) == OT_ERROR_NONE)
+    while (Get<NetworkData::Leader>().GetNextOnMeshPrefix(iterator, config) == OT_ERROR_NONE)
     {
         IdentityAssociation *ia = NULL;
 

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -57,11 +57,11 @@ Dhcp6Server::Dhcp6Server(Instance &aInstance)
 
 otError Dhcp6Server::UpdateService(void)
 {
-    otError               error  = OT_ERROR_NONE;
-    uint16_t              rloc16 = Get<Mle::MleRouter>().GetRloc16();
-    otNetworkDataIterator iterator;
-    otBorderRouterConfig  config;
-    Lowpan::Context       lowpanContext;
+    otError                         error  = OT_ERROR_NONE;
+    uint16_t                        rloc16 = Get<Mle::MleRouter>().GetRloc16();
+    NetworkData::Iterator           iterator;
+    NetworkData::OnMeshPrefixConfig config;
+    Lowpan::Context                 lowpanContext;
 
     // remove dhcp agent aloc and prefix delegation
     for (int i = 0; i < OPENTHREAD_CONFIG_DHCP6_SERVER_NUM_PREFIXES; i++)
@@ -73,9 +73,9 @@ otError Dhcp6Server::UpdateService(void)
             continue;
         }
 
-        iterator = OT_NETWORK_DATA_ITERATOR_INIT;
+        iterator = NetworkData::kIteratorInit;
 
-        while (Get<NetworkData::Leader>().GetNextOnMeshPrefix(&iterator, rloc16, &config) == OT_ERROR_NONE)
+        while (Get<NetworkData::Leader>().GetNextOnMeshPrefix(iterator, rloc16, config) == OT_ERROR_NONE)
         {
             if (!config.mDhcp)
             {
@@ -100,9 +100,9 @@ otError Dhcp6Server::UpdateService(void)
     }
 
     // add dhcp agent aloc and prefix delegation
-    iterator = OT_NETWORK_DATA_ITERATOR_INIT;
+    iterator = NetworkData::kIteratorInit;
 
-    while (Get<NetworkData::Leader>().GetNextOnMeshPrefix(&iterator, rloc16, &config) == OT_ERROR_NONE)
+    while (Get<NetworkData::Leader>().GetNextOnMeshPrefix(iterator, rloc16, config) == OT_ERROR_NONE)
     {
         if (!config.mDhcp)
         {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1589,7 +1589,7 @@ void Mle::UpdateServiceAlocs(void)
     uint16_t              serviceAloc        = 0;
     uint8_t               serviceId          = 0;
     int                   i                  = 0;
-    otNetworkDataIterator serviceIterator    = OT_NETWORK_DATA_ITERATOR_INIT;
+    NetworkData::Iterator serviceIterator    = NetworkData::kIteratorInit;
     int                   serviceAlocsLength = OT_ARRAY_LENGTH(mServiceAlocs);
 
     VerifyOrExit(mRole != OT_DEVICE_ROLE_DISABLED);
@@ -1608,7 +1608,7 @@ void Mle::UpdateServiceAlocs(void)
     }
 
     // Now add any missing service alocs which should be there, if there is enough space in mServiceAlocs
-    while (Get<NetworkData::Leader>().GetNextServiceId(&serviceIterator, rloc, &serviceId) == OT_ERROR_NONE)
+    while (Get<NetworkData::Leader>().GetNextServiceId(serviceIterator, rloc, serviceId) == OT_ERROR_NONE)
     {
         for (i = 0; i < serviceAlocsLength; i++)
         {

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -80,14 +80,12 @@ exit:
     return error;
 }
 
-otError NetworkData::GetNextOnMeshPrefix(otNetworkDataIterator *aIterator, otBorderRouterConfig *aConfig)
+otError NetworkData::GetNextOnMeshPrefix(Iterator &aIterator, OnMeshPrefixConfig &aConfig)
 {
     return GetNextOnMeshPrefix(aIterator, Mac::kShortAddrBroadcast, aConfig);
 }
 
-otError NetworkData::GetNextOnMeshPrefix(otNetworkDataIterator *aIterator,
-                                         uint16_t               aRloc16,
-                                         otBorderRouterConfig * aConfig)
+otError NetworkData::GetNextOnMeshPrefix(Iterator &aIterator, uint16_t aRloc16, OnMeshPrefixConfig &aConfig)
 {
     otError             error = OT_ERROR_NOT_FOUND;
     NetworkDataIterator iterator(aIterator);
@@ -131,18 +129,18 @@ otError NetworkData::GetNextOnMeshPrefix(otNetworkDataIterator *aIterator,
                 {
                     BorderRouterEntry *borderRouterEntry = borderRouter->GetEntry(index);
 
-                    memset(aConfig, 0, sizeof(*aConfig));
-                    memcpy(&aConfig->mPrefix.mPrefix, prefix->GetPrefix(), BitVectorBytes(prefix->GetPrefixLength()));
-                    aConfig->mPrefix.mLength = prefix->GetPrefixLength();
-                    aConfig->mPreference     = borderRouterEntry->GetPreference();
-                    aConfig->mPreferred      = borderRouterEntry->IsPreferred();
-                    aConfig->mSlaac          = borderRouterEntry->IsSlaac();
-                    aConfig->mDhcp           = borderRouterEntry->IsDhcp();
-                    aConfig->mConfigure      = borderRouterEntry->IsConfigure();
-                    aConfig->mDefaultRoute   = borderRouterEntry->IsDefaultRoute();
-                    aConfig->mOnMesh         = borderRouterEntry->IsOnMesh();
-                    aConfig->mStable         = borderRouter->IsStable();
-                    aConfig->mRloc16         = borderRouterEntry->GetRloc();
+                    memset(&aConfig, 0, sizeof(aConfig));
+                    memcpy(&aConfig.mPrefix.mPrefix, prefix->GetPrefix(), BitVectorBytes(prefix->GetPrefixLength()));
+                    aConfig.mPrefix.mLength = prefix->GetPrefixLength();
+                    aConfig.mPreference     = borderRouterEntry->GetPreference();
+                    aConfig.mPreferred      = borderRouterEntry->IsPreferred();
+                    aConfig.mSlaac          = borderRouterEntry->IsSlaac();
+                    aConfig.mDhcp           = borderRouterEntry->IsDhcp();
+                    aConfig.mConfigure      = borderRouterEntry->IsConfigure();
+                    aConfig.mDefaultRoute   = borderRouterEntry->IsDefaultRoute();
+                    aConfig.mOnMesh         = borderRouterEntry->IsOnMesh();
+                    aConfig.mStable         = borderRouter->IsStable();
+                    aConfig.mRloc16         = borderRouterEntry->GetRloc();
 
                     iterator.SaveTlvOffset(cur, mTlvs);
                     iterator.SaveSubTlvOffset(subCur, prefix->GetSubTlvs());
@@ -158,14 +156,12 @@ exit:
     return error;
 }
 
-otError NetworkData::GetNextExternalRoute(otNetworkDataIterator *aIterator, otExternalRouteConfig *aConfig)
+otError NetworkData::GetNextExternalRoute(Iterator &aIterator, ExternalRouteConfig &aConfig)
 {
     return GetNextExternalRoute(aIterator, Mac::kShortAddrBroadcast, aConfig);
 }
 
-otError NetworkData::GetNextExternalRoute(otNetworkDataIterator *aIterator,
-                                          uint16_t               aRloc16,
-                                          otExternalRouteConfig *aConfig)
+otError NetworkData::GetNextExternalRoute(Iterator &aIterator, uint16_t aRloc16, ExternalRouteConfig &aConfig)
 {
     otError             error = OT_ERROR_NOT_FOUND;
     NetworkDataIterator iterator(aIterator);
@@ -210,13 +206,13 @@ otError NetworkData::GetNextExternalRoute(otNetworkDataIterator *aIterator,
                 {
                     HasRouteEntry *hasRouteEntry = hasRoute->GetEntry(index);
 
-                    memset(aConfig, 0, sizeof(*aConfig));
-                    memcpy(&aConfig->mPrefix.mPrefix, prefix->GetPrefix(), BitVectorBytes(prefix->GetPrefixLength()));
-                    aConfig->mPrefix.mLength      = prefix->GetPrefixLength();
-                    aConfig->mPreference          = hasRouteEntry->GetPreference();
-                    aConfig->mStable              = hasRoute->IsStable();
-                    aConfig->mRloc16              = hasRouteEntry->GetRloc();
-                    aConfig->mNextHopIsThisDevice = (hasRouteEntry->GetRloc() == Get<Mle::MleRouter>().GetRloc16());
+                    memset(&aConfig, 0, sizeof(aConfig));
+                    memcpy(&aConfig.mPrefix.mPrefix, prefix->GetPrefix(), BitVectorBytes(prefix->GetPrefixLength()));
+                    aConfig.mPrefix.mLength      = prefix->GetPrefixLength();
+                    aConfig.mPreference          = hasRouteEntry->GetPreference();
+                    aConfig.mStable              = hasRoute->IsStable();
+                    aConfig.mRloc16              = hasRouteEntry->GetRloc();
+                    aConfig.mNextHopIsThisDevice = (hasRouteEntry->GetRloc() == Get<Mle::MleRouter>().GetRloc16());
 
                     iterator.SaveTlvOffset(cur, mTlvs);
                     iterator.SaveSubTlvOffset(subCur, prefix->GetSubTlvs());
@@ -233,12 +229,12 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-otError NetworkData::GetNextService(otNetworkDataIterator *aIterator, otServiceConfig *aConfig)
+otError NetworkData::GetNextService(Iterator &aIterator, ServiceConfig &aConfig)
 {
     return GetNextService(aIterator, Mac::kShortAddrBroadcast, aConfig);
 }
 
-otError NetworkData::GetNextService(otNetworkDataIterator *aIterator, uint16_t aRloc16, otServiceConfig *aConfig)
+otError NetworkData::GetNextService(Iterator &aIterator, uint16_t aRloc16, ServiceConfig &aConfig)
 {
     otError             error = OT_ERROR_NOT_FOUND;
     NetworkDataIterator iterator(aIterator);
@@ -279,18 +275,18 @@ otError NetworkData::GetNextService(otNetworkDataIterator *aIterator, uint16_t a
 
             if ((aRloc16 == Mac::kShortAddrBroadcast) || (server->GetServer16() == aRloc16))
             {
-                memset(aConfig, 0, sizeof(*aConfig));
+                memset(&aConfig, 0, sizeof(aConfig));
 
-                aConfig->mServiceID         = service->GetServiceID();
-                aConfig->mEnterpriseNumber  = service->GetEnterpriseNumber();
-                aConfig->mServiceDataLength = service->GetServiceDataLength();
+                aConfig.mServiceID         = service->GetServiceID();
+                aConfig.mEnterpriseNumber  = service->GetEnterpriseNumber();
+                aConfig.mServiceDataLength = service->GetServiceDataLength();
 
-                memcpy(&aConfig->mServiceData, service->GetServiceData(), service->GetServiceDataLength());
+                memcpy(&aConfig.mServiceData, service->GetServiceData(), service->GetServiceDataLength());
 
-                aConfig->mServerConfig.mStable           = server->IsStable();
-                aConfig->mServerConfig.mServerDataLength = server->GetServerDataLength();
-                memcpy(&aConfig->mServerConfig.mServerData, server->GetServerData(), server->GetServerDataLength());
-                aConfig->mServerConfig.mRloc16 = server->GetServer16();
+                aConfig.mServerConfig.mStable           = server->IsStable();
+                aConfig.mServerConfig.mServerDataLength = server->GetServerDataLength();
+                memcpy(&aConfig.mServerConfig.mServerData, server->GetServerData(), server->GetServerDataLength());
+                aConfig.mServerConfig.mRloc16 = server->GetServer16();
 
                 if (subCur->GetNext() >= cur->GetNext())
                 {
@@ -312,7 +308,7 @@ exit:
     return error;
 }
 
-otError NetworkData::GetNextServiceId(otNetworkDataIterator *aIterator, uint16_t aRloc16, uint8_t *aServiceId)
+otError NetworkData::GetNextServiceId(Iterator &aIterator, uint16_t aRloc16, uint8_t &aServiceId)
 {
     otError             error = OT_ERROR_NOT_FOUND;
     NetworkDataIterator iterator(aIterator);
@@ -353,7 +349,7 @@ otError NetworkData::GetNextServiceId(otNetworkDataIterator *aIterator, uint16_t
 
             if ((aRloc16 == Mac::kShortAddrBroadcast) || (server->GetServer16() == aRloc16))
             {
-                *aServiceId = service->GetServiceID();
+                aServiceId = service->GetServiceID();
 
                 if (subCur->GetNext() >= cur->GetNext())
                 {
@@ -378,17 +374,17 @@ exit:
 
 bool NetworkData::ContainsOnMeshPrefixes(NetworkData &aCompare, uint16_t aRloc16)
 {
-    otNetworkDataIterator outerIterator = OT_NETWORK_DATA_ITERATOR_INIT;
-    otBorderRouterConfig  outerConfig;
-    bool                  rval = true;
+    Iterator           outerIterator = kIteratorInit;
+    OnMeshPrefixConfig outerConfig;
+    bool               rval = true;
 
-    while (aCompare.GetNextOnMeshPrefix(&outerIterator, aRloc16, &outerConfig) == OT_ERROR_NONE)
+    while (aCompare.GetNextOnMeshPrefix(outerIterator, aRloc16, outerConfig) == OT_ERROR_NONE)
     {
-        otNetworkDataIterator innerIterator = OT_NETWORK_DATA_ITERATOR_INIT;
-        otBorderRouterConfig  innerConfig;
-        otError               error;
+        Iterator           innerIterator = kIteratorInit;
+        OnMeshPrefixConfig innerConfig;
+        otError            error;
 
-        while ((error = GetNextOnMeshPrefix(&innerIterator, aRloc16, &innerConfig)) == OT_ERROR_NONE)
+        while ((error = GetNextOnMeshPrefix(innerIterator, aRloc16, innerConfig)) == OT_ERROR_NONE)
         {
             if (memcmp(&outerConfig, &innerConfig, (sizeof(outerConfig) - sizeof(outerConfig.mRloc16))) == 0)
             {
@@ -408,17 +404,17 @@ exit:
 
 bool NetworkData::ContainsExternalRoutes(NetworkData &aCompare, uint16_t aRloc16)
 {
-    otNetworkDataIterator outerIterator = OT_NETWORK_DATA_ITERATOR_INIT;
-    otExternalRouteConfig outerConfig;
-    bool                  rval = true;
+    Iterator            outerIterator = kIteratorInit;
+    ExternalRouteConfig outerConfig;
+    bool                rval = true;
 
-    while (aCompare.GetNextExternalRoute(&outerIterator, aRloc16, &outerConfig) == OT_ERROR_NONE)
+    while (aCompare.GetNextExternalRoute(outerIterator, aRloc16, outerConfig) == OT_ERROR_NONE)
     {
-        otNetworkDataIterator innerIterator = OT_NETWORK_DATA_ITERATOR_INIT;
-        otExternalRouteConfig innerConfig;
-        otError               error;
+        Iterator            innerIterator = kIteratorInit;
+        ExternalRouteConfig innerConfig;
+        otError             error;
 
-        while ((error = GetNextExternalRoute(&innerIterator, aRloc16, &innerConfig)) == OT_ERROR_NONE)
+        while ((error = GetNextExternalRoute(innerIterator, aRloc16, innerConfig)) == OT_ERROR_NONE)
         {
             if (memcmp(&outerConfig, &innerConfig, sizeof(outerConfig)) == 0)
             {
@@ -439,17 +435,17 @@ exit:
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 bool NetworkData::ContainsServices(NetworkData &aCompare, uint16_t aRloc16)
 {
-    otNetworkDataIterator outerIterator = OT_NETWORK_DATA_ITERATOR_INIT;
-    otServiceConfig       outerConfig;
-    bool                  rval = true;
+    Iterator      outerIterator = kIteratorInit;
+    ServiceConfig outerConfig;
+    bool          rval = true;
 
-    while (aCompare.GetNextService(&outerIterator, aRloc16, &outerConfig) == OT_ERROR_NONE)
+    while (aCompare.GetNextService(outerIterator, aRloc16, outerConfig) == OT_ERROR_NONE)
     {
-        otNetworkDataIterator innerIterator = OT_NETWORK_DATA_ITERATOR_INIT;
-        otServiceConfig       innerConfig;
-        otError               error;
+        Iterator      innerIterator = kIteratorInit;
+        ServiceConfig innerConfig;
+        otError       error;
 
-        while ((error = GetNextService(&innerIterator, aRloc16, &innerConfig)) == OT_ERROR_NONE)
+        while ((error = GetNextService(innerIterator, aRloc16, innerConfig)) == OT_ERROR_NONE)
         {
             if ((outerConfig.mEnterpriseNumber == innerConfig.mEnterpriseNumber) &&
                 (outerConfig.mServiceDataLength == innerConfig.mServiceDataLength) &&

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -386,7 +386,7 @@ bool NetworkData::ContainsOnMeshPrefixes(NetworkData &aCompare, uint16_t aRloc16
 
         while ((error = GetNextOnMeshPrefix(innerIterator, aRloc16, innerConfig)) == OT_ERROR_NONE)
         {
-            if (memcmp(&outerConfig, &innerConfig, (sizeof(outerConfig) - sizeof(outerConfig.mRloc16))) == 0)
+            if (memcmp(&outerConfig, &innerConfig, sizeof(outerConfig)) == 0)
             {
                 break;
             }

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -84,6 +84,37 @@ namespace NetworkData {
  *
  */
 
+enum
+{
+    kIteratorInit = OT_NETWORK_DATA_ITERATOR_INIT, ///< Initializer for `Iterator` type.
+};
+
+/**
+ * This type represents a Iterator used to iterate through Network Data info (e.g., see `GetNextOnMeshPrefix()`)
+ *
+ */
+typedef otNetworkDataIterator Iterator;
+
+/**
+ * This type represents an On Mesh Prefix (Border Router) configuration.
+ *
+ */
+typedef otBorderRouterConfig OnMeshPrefixConfig;
+
+/**
+ * This type represents an External Route configuration.
+ *
+ */
+typedef otExternalRouteConfig ExternalRouteConfig;
+
+#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+/**
+ * This type represents a Service configuration.
+ *
+ */
+typedef otServiceConfig ServiceConfig;
+#endif
+
 /**
  * This class implements Network Data processing.
  *
@@ -138,91 +169,91 @@ public:
     /**
      * This method provides the next On Mesh prefix in the Thread Network Data.
      *
-     * @param[inout]  aIterator  A pointer to the Network Data iterator context.
-     * @param[out]    aConfig    A pointer to where the On Mesh Prefix information will be placed.
+     * @param[inout]  aIterator  A reference to the Network Data iterator.
+     * @param[out]    aConfig    A reference to a config variable where the On Mesh Prefix information will be placed.
      *
      * @retval OT_ERROR_NONE       Successfully found the next On Mesh prefix.
      * @retval OT_ERROR_NOT_FOUND  No subsequent On Mesh prefix exists in the Thread Network Data.
      *
      */
-    otError GetNextOnMeshPrefix(otNetworkDataIterator *aIterator, otBorderRouterConfig *aConfig);
+    otError GetNextOnMeshPrefix(Iterator &aIterator, OnMeshPrefixConfig &aConfig);
 
     /**
      * This method provides the next On Mesh prefix in the Thread Network Data for a given RLOC16.
      *
-     * @param[inout]  aIterator  A pointer to the Network Data iterator context.
+     * @param[inout]  aIterator  A reference to the Network Data iterator.
      * @param[in]     aRloc16    The RLOC16 value.
-     * @param[out]    aConfig    A pointer to where the On Mesh Prefix information will be placed.
+     * @param[out]    aConfig    A reference to a config variable where the On Mesh Prefix information will be placed.
      *
      * @retval OT_ERROR_NONE       Successfully found the next On Mesh prefix.
      * @retval OT_ERROR_NOT_FOUND  No subsequent On Mesh prefix exists in the Thread Network Data.
      *
      */
-    otError GetNextOnMeshPrefix(otNetworkDataIterator *aIterator, uint16_t aRloc16, otBorderRouterConfig *aConfig);
+    otError GetNextOnMeshPrefix(Iterator &aIterator, uint16_t aRloc16, OnMeshPrefixConfig &aConfig);
 
     /**
      * This method provides the next external route in the Thread Network Data.
      *
-     * @param[inout]  aIterator  A pointer to the Network Data iterator context.
-     * @param[out]    aConfig    A pointer to where the external route information will be placed.
+     * @param[inout]  aIterator  A reference to the Network Data iterator.
+     * @param[out]    aConfig    A reference to a config variable where the external route information will be placed.
      *
      * @retval OT_ERROR_NONE       Successfully found the next external route.
      * @retval OT_ERROR_NOT_FOUND  No subsequent external route exists in the Thread Network Data.
      *
      */
-    otError GetNextExternalRoute(otNetworkDataIterator *aIterator, otExternalRouteConfig *aConfig);
+    otError GetNextExternalRoute(Iterator &aIterator, ExternalRouteConfig &aConfig);
 
     /**
      * This method provides the next external route in the Thread Network Data for a given RLOC16.
      *
-     * @param[inout]  aIterator  A pointer to the Network Data iterator context.
+     * @param[inout]  aIterator  A reference to the Network Data iterator.
      * @param[in]     aRloc16    The RLOC16 value.
-     * @param[out]    aConfig    A pointer to where the external route information will be placed.
+     * @param[out]    aConfig    A reference to a config variable where the external route information will be placed.
      *
      * @retval OT_ERROR_NONE       Successfully found the next external route.
      * @retval OT_ERROR_NOT_FOUND  No subsequent external route exists in the Thread Network Data.
      *
      */
-    otError GetNextExternalRoute(otNetworkDataIterator *aIterator, uint16_t aRloc16, otExternalRouteConfig *aConfig);
+    otError GetNextExternalRoute(Iterator &aIterator, uint16_t aRloc16, ExternalRouteConfig &aConfig);
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     /**
      * This method provides the next service in the Thread Network Data.
      *
-     * @param[inout]  aIterator  A pointer to the Network Data iterator context.
-     * @param[out]    aConfig    A pointer to where the service information will be placed.
+     * @param[inout]  aIterator  A reference to the Network Data iterator.
+     * @param[out]    aConfig    A reference to a config variable where the service information will be placed.
      *
      * @retval OT_ERROR_NONE       Successfully found the next service.
      * @retval OT_ERROR_NOT_FOUND  No subsequent service exists in the Thread Network Data.
      *
      */
-    otError GetNextService(otNetworkDataIterator *aIterator, otServiceConfig *aConfig);
+    otError GetNextService(Iterator &aIterator, ServiceConfig &aConfig);
 
     /**
      * This method provides the next service in the Thread Network Data for a given RLOC16.
      *
-     * @param[inout]  aIterator  A pointer to the Network Data iterator context.
+     * @param[inout]  aIterator  A reference to the Network Data iterator.
      * @param[in]     aRloc16    The RLOC16 value.
-     * @param[out]    aConfig    A pointer to where the service information will be placed.
+     * @param[out]    aConfig    A reference to a config variable where the service information will be placed.
      *
      * @retval OT_ERROR_NONE       Successfully found the next service.
      * @retval OT_ERROR_NOT_FOUND  No subsequent service exists in the Thread Network Data.
      *
      */
-    otError GetNextService(otNetworkDataIterator *aIterator, uint16_t aRloc16, otServiceConfig *aConfig);
+    otError GetNextService(Iterator &aIterator, uint16_t aRloc16, ServiceConfig &aConfig);
 
     /**
      * This method provides the next service ID in the Thread Network Data for a given RLOC16.
      *
-     * @param[inout]  aIterator  A pointer to the Network Data iterator context.
+     * @param[inout]  aIterator  A reference to the Network Data iterator.
      * @param[in]     aRloc16    The RLOC16 value.
-     * @param[out]    aServiceID A pointer to where the service ID will be placed.
+     * @param[out]    aServiceID A reference to variable where the service ID will be placed.
      *
      * @retval OT_ERROR_NONE       Successfully found the next service.
      * @retval OT_ERROR_NOT_FOUND  No subsequent service exists in the Thread Network Data.
      *
      */
-    otError GetNextServiceId(otNetworkDataIterator *aIterator, uint16_t aRloc16, uint8_t *aServiceId);
+    otError GetNextServiceId(Iterator &aIterator, uint16_t aRloc16, uint8_t &aServiceId);
 #endif
 
     /**
@@ -480,17 +511,9 @@ private:
 
     class NetworkDataIterator
     {
-    private:
-        enum
-        {
-            kTlvPosition    = 0,
-            kSubTlvPosition = 1,
-            kEntryPosition  = 2,
-        };
-
     public:
-        explicit NetworkDataIterator(otNetworkDataIterator *aIterator)
-            : mIteratorBuffer(reinterpret_cast<uint8_t *>(aIterator))
+        explicit NetworkDataIterator(Iterator &aIterator)
+            : mIteratorBuffer(reinterpret_cast<uint8_t *>(&aIterator))
         {
         }
 
@@ -513,6 +536,13 @@ private:
         }
 
     private:
+        enum
+        {
+            kTlvPosition    = 0,
+            kSubTlvPosition = 1,
+            kEntryPosition  = 2,
+        };
+
         uint8_t *mIteratorBuffer;
     };
 

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -170,10 +170,10 @@ otError LeaderBase::GetRlocByContextId(uint8_t aContextId, uint16_t &aRloc16)
 
     if ((GetContext(aContextId, lowpanContext)) == OT_ERROR_NONE)
     {
-        otNetworkDataIterator iterator = OT_NETWORK_DATA_ITERATOR_INIT;
-        otBorderRouterConfig  config;
+        Iterator           iterator = kIteratorInit;
+        OnMeshPrefixConfig config;
 
-        while (GetNextOnMeshPrefix(&iterator, &config) == OT_ERROR_NONE)
+        while (GetNextOnMeshPrefix(iterator, config) == OT_ERROR_NONE)
         {
             if (otIp6PrefixMatch(&(config.mPrefix.mPrefix), reinterpret_cast<const otIp6Address *>(
                                                                 lowpanContext.mPrefix)) >= config.mPrefix.mLength)

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -142,10 +142,10 @@ exit:
 
 void Slaac::Update(UpdateMode aMode)
 {
-    otNetworkDataIterator     iterator;
-    otBorderRouterConfig      config;
-    Ip6::NetifUnicastAddress *slaacAddr;
-    bool                      found;
+    NetworkData::Iterator           iterator;
+    NetworkData::OnMeshPrefixConfig config;
+    Ip6::NetifUnicastAddress *      slaacAddr;
+    bool                            found;
 
     if (aMode & kModeRemove)
     {
@@ -163,9 +163,9 @@ void Slaac::Update(UpdateMode aMode)
 
             if (mEnabled)
             {
-                iterator = OT_NETWORK_DATA_ITERATOR_INIT;
+                iterator = NetworkData::kIteratorInit;
 
-                while (Get<NetworkData::Leader>().GetNextOnMeshPrefix(&iterator, &config) == OT_ERROR_NONE)
+                while (Get<NetworkData::Leader>().GetNextOnMeshPrefix(iterator, config) == OT_ERROR_NONE)
                 {
                     otIp6Prefix &prefix = config.mPrefix;
 
@@ -192,9 +192,9 @@ void Slaac::Update(UpdateMode aMode)
     {
         // Generate and add SLAAC addresses for any newly added on-mesh prefixes.
 
-        iterator = OT_NETWORK_DATA_ITERATOR_INIT;
+        iterator = NetworkData::kIteratorInit;
 
-        while (Get<NetworkData::Leader>().GetNextOnMeshPrefix(&iterator, &config) == OT_ERROR_NONE)
+        while (Get<NetworkData::Leader>().GetNextOnMeshPrefix(iterator, config) == OT_ERROR_NONE)
         {
             otIp6Prefix &prefix = config.mPrefix;
 

--- a/tests/unit/test_network_data.cpp
+++ b/tests/unit/test_network_data.cpp
@@ -36,6 +36,7 @@
 #include "test_util.hpp"
 
 namespace ot {
+namespace NetworkData {
 
 class TestNetworkData : public NetworkData::NetworkData
 {
@@ -48,7 +49,7 @@ public:
     }
 };
 
-void PrintExternalRouteConfig(const otExternalRouteConfig &aConfig)
+void PrintExternalRouteConfig(const ExternalRouteConfig &aConfig)
 {
     printf("\nprefix:");
 
@@ -61,8 +62,8 @@ void PrintExternalRouteConfig(const otExternalRouteConfig &aConfig)
            aConfig.mPreference, aConfig.mStable, aConfig.mNextHopIsThisDevice);
 }
 
-// Returns true if the two given otExternalRouteConfig match (intentionally ignoring mNextHopIsThisDevice).
-bool CompareExternalRouteConfig(const otExternalRouteConfig &aConfig1, const otExternalRouteConfig &aConfig2)
+// Returns true if the two given ExternalRouteConfig match (intentionally ignoring mNextHopIsThisDevice).
+bool CompareExternalRouteConfig(const ExternalRouteConfig &aConfig1, const ExternalRouteConfig &aConfig2)
 {
     return (memcmp(aConfig1.mPrefix.mPrefix.mFields.m8, aConfig2.mPrefix.mPrefix.mFields.m8,
                    sizeof(aConfig1.mPrefix.mPrefix)) == 0) &&
@@ -72,9 +73,9 @@ bool CompareExternalRouteConfig(const otExternalRouteConfig &aConfig1, const otE
 
 void TestNetworkDataIterator(void)
 {
-    ot::Instance *        instance;
-    otNetworkDataIterator iter = OT_NETWORK_DATA_ITERATOR_INIT;
-    otExternalRouteConfig config;
+    ot::Instance *      instance;
+    Iterator            iter = kIteratorInit;
+    ExternalRouteConfig config;
 
     instance = testInitInstance();
     VerifyOrQuit(instance != NULL, "Null OpenThread instance\n");
@@ -84,7 +85,7 @@ void TestNetworkDataIterator(void)
                                         0xFD, 0x00, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
                                         0xC8, 0x00, 0x40, 0x01, 0x03, 0x54, 0x00, 0x00};
 
-        otExternalRouteConfig routes[] = {
+        ExternalRouteConfig routes[] = {
             {
                 {{{{0xfd, 0x00, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}},
                  64},
@@ -111,7 +112,7 @@ void TestNetworkDataIterator(void)
 
         for (uint8_t i = 0; i < OT_ARRAY_LENGTH(routes); i++)
         {
-            SuccessOrQuit(netData.GetNextExternalRoute(&iter, &config), "GetNextExternalRoute() failed\n");
+            SuccessOrQuit(netData.GetNextExternalRoute(iter, config), "GetNextExternalRoute() failed\n");
             PrintExternalRouteConfig(config);
             VerifyOrQuit(CompareExternalRouteConfig(config, routes[i]) == true,
                          "external route config does not match expectation");
@@ -125,7 +126,7 @@ void TestNetworkDataIterator(void)
             0x31, 0x00, 0x02, 0x0F, 0x00, 0x40, 0xFD, 0x00, 0xAB, 0xBA, 0xCD, 0xDC, 0x00, 0x00, 0x00, 0x03, 0x10, 0x00,
             0x00, 0x03, 0x0E, 0x00, 0x20, 0xFD, 0x00, 0xAB, 0xBA, 0x01, 0x06, 0x54, 0x00, 0x00, 0x04, 0x00, 0x00};
 
-        otExternalRouteConfig routes[] = {
+        ExternalRouteConfig routes[] = {
             {{{{{0xfd, 0x00, 0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}}, 64},
              0x1000,
              1,
@@ -161,7 +162,7 @@ void TestNetworkDataIterator(void)
 
         for (uint8_t i = 0; i < OT_ARRAY_LENGTH(routes); i++)
         {
-            SuccessOrQuit(netData.GetNextExternalRoute(&iter, &config), "GetNextExternalRoute() failed\n");
+            SuccessOrQuit(netData.GetNextExternalRoute(iter, config), "GetNextExternalRoute() failed\n");
             PrintExternalRouteConfig(config);
             VerifyOrQuit(CompareExternalRouteConfig(config, routes[i]) == true,
                          "external route config does not match expectation");
@@ -171,12 +172,13 @@ void TestNetworkDataIterator(void)
     testFreeInstance(instance);
 }
 
+} // namespace NetworkData
 } // namespace ot
 
 #ifdef ENABLE_TEST_MAIN
 int main(void)
 {
-    ot::TestNetworkDataIterator();
+    ot::NetworkData::TestNetworkDataIterator();
 
     printf("\nAll tests passed\n");
     return 0;


### PR DESCRIPTION
This PR contains two related commits in `NetworkData`: 

**[network-data] change iterator methods to use reference instead of pointer**
    
This commit contains t changes the methods in `NetworkData` class used for iterating over on-mesh prefix, external router, etc (e.g.,`GetNextOnMeshPrefix`()) to use reference input variables instead of
pointer type variables.

-----------------

**[network-data] fix how the OnMeshPrefixConfig structs are compared**
    
This commit ensures the entire struct size is used when comparing two `OnMeshPrefixConfig` (`otBorderRouterConfig`) instances from `NetworkData::ContainsOnMeshPrefixes()` method.