### PR TITLE
[dataset-manager] append SecPolicyTlv when present, simplify checks, check len on read

### DIFF
--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -538,6 +538,15 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         SuccessOrExit(error = message->AppendTlv(pskc));
     }
 
+    if (aDataset.mComponents.mIsSecurityPolicyPresent)
+    {
+        SecurityPolicyTlv securityPolicy;
+        securityPolicy.Init();
+        securityPolicy.SetRotationTime(aDataset.mSecurityPolicy.mRotationTime);
+        securityPolicy.SetFlags(aDataset.mSecurityPolicy.mFlags);
+        SuccessOrExit(error = message->AppendTlv(securityPolicy));
+    }
+
     if (aLength > 0)
     {
         SuccessOrExit(error = message->Append(aTlvs, aLength));

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -210,10 +210,10 @@ otError DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInf
                 uint8_t value[Dataset::kMaxValueSize];
             } OT_TOOL_PACKED_END data;
 
-            aMessage.Read(offset, sizeof(Tlv), &data.tlv);
+            VerifyOrExit(aMessage.Read(offset, sizeof(Tlv), &data.tlv) == sizeof(Tlv));
             VerifyOrExit(data.tlv.GetLength() <= sizeof(data.value));
 
-            aMessage.Read(offset + sizeof(Tlv), data.tlv.GetLength(), data.value);
+            VerifyOrExit(aMessage.Read(offset + sizeof(Tlv), data.tlv.GetLength(), data.value) == data.tlv.GetLength());
 
             switch (data.tlv.GetType())
             {


### PR DESCRIPTION
This PR contains the following commits:

**[dataset-manager] append SecurityPolicyTlv when present**

This commit updates `DatasetManager::SendSetRequest()` to include the `SecurityPolicyTlv` when it is present in the dataset.

**[dataset-manager] simplify checks in HandleSet** 
    
This commit simplifies the `VerifyOrExit()`/`ExitNow()` failure checks in `DatasetManager::HandleSet()` by starting the `state` as `kReject` and setting to `kAccept` after all checks are passed.

**[dataset-manager] check the read length from message on reading TLVs**
