### PR TITLE
[misc] add `Clear()` method (replacing memset() zero)

### DIFF
--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -45,7 +45,7 @@ namespace Coap {
 
 void Message::Init(void)
 {
-    memset(&GetHelpData(), 0, sizeof(GetHelpData()));
+    GetHelpData().Clear();
     SetVersion(kVersion1);
     SetOffset(0);
     GetHelpData().mHeaderLength = kMinHeaderLength;
@@ -211,7 +211,7 @@ const otCoapOption *Message::GetFirstOption(void)
 {
     const otCoapOption *option = NULL;
 
-    memset(&GetHelpData().mOption, 0, sizeof(GetHelpData().mOption));
+    GetHelpData().ClearOption();
 
     VerifyOrExit(GetLength() - GetHelpData().mHeaderOffset >= GetOptionStart());
 
@@ -346,7 +346,7 @@ otError Message::ParseHeader(void)
            sizeof(GetHelpData()) +
                static_cast<size_t>((reinterpret_cast<uint8_t *>(&GetHelpData()) - mBuffer.mHead.mData)));
 
-    memset(&GetHelpData(), 0, sizeof(GetHelpData()));
+    GetHelpData().Clear();
 
     GetHelpData().mHeaderOffset = GetOffset();
     Read(GetHelpData().mHeaderOffset, sizeof(GetHelpData().mHeader), &GetHelpData().mHeader);

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -585,6 +585,9 @@ private:
      */
     struct HelpData
     {
+        void Clear(void) { memset(this, 0, sizeof(*this)); }
+        void ClearOption(void) { memset(&mOption, 0, sizeof(mOption)); }
+
         Header       mHeader;
         otCoapOption mOption;
         uint16_t     mNextOptionOffset; ///< The byte offset for the next CoAP Option

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -86,6 +86,12 @@ public:
      */
     struct NetworkInfo
     {
+        /**
+         * This method clears the struct object (setting all the fields to zero).
+         *
+         */
+        void Clear(void) { memset(this, 0, sizeof(*this)); }
+
         uint8_t         mRole;                   ///< Current Thread role.
         uint8_t         mDeviceMode;             ///< Device mode setting.
         uint16_t        mRloc16;                 ///< RLOC16
@@ -103,6 +109,12 @@ public:
      */
     struct ParentInfo
     {
+        /**
+         * This method clears the struct object (setting all the fields to zero).
+         *
+         */
+        void Clear(void) { memset(this, 0, sizeof(*this)); }
+
         Mac::ExtAddress mExtAddress; ///< Extended Address
     };
 
@@ -112,6 +124,12 @@ public:
      */
     struct ChildInfo
     {
+        /**
+         * This method clears the struct object (setting all the fields to zero).
+         *
+         */
+        void Clear(void) { memset(this, 0, sizeof(*this)); }
+
         Mac::ExtAddress mExtAddress; ///< Extended Address
         uint32_t        mTimeout;    ///< Timeout
         uint16_t        mRloc16;     ///< RLOC16

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -44,7 +44,6 @@
 #include "common/locator-getters.hpp"
 #include "radio/radio.hpp"
 #include "utils/parse_cmdline.hpp"
-#include "utils/wrap_string.h"
 
 namespace ot {
 namespace FactoryDiags {
@@ -138,7 +137,7 @@ Diags::Diags(Instance &aInstance)
     , mTxLen(0)
     , mRepeatActive(false)
 {
-    memset(&mStats, 0, sizeof(mStats));
+    mStats.Clear();
 
     otPlatDiagChannelSet(mChannel);
     otPlatDiagTxPowerSet(mTxPower);
@@ -272,7 +271,7 @@ void Diags::ProcessStart(int aArgCount, char *aArgVector[], char *aOutput, size_
     SuccessOrExit(error = Get<Radio>().Receive(mChannel));
     SuccessOrExit(error = Get<Radio>().SetTransmitPower(mTxPower));
     otPlatDiagModeSet(true);
-    memset(&mStats, 0, sizeof(mStats));
+    mStats.Clear();
     snprintf(aOutput, aOutputMaxLen, "start diagnostics mode\r\nstatus 0x%02x\r\n", error);
 
 exit:
@@ -287,7 +286,7 @@ void Diags::ProcessStats(int aArgCount, char *aArgVector[], char *aOutput, size_
 
     if ((aArgCount == 1) && (strcmp(aArgVector[0], "clear") == 0))
     {
-        memset(&mStats, 0, sizeof(mStats));
+        mStats.Clear();
         snprintf(aOutput, aOutputMaxLen, "stats cleared\r\n");
     }
     else

--- a/src/core/diags/factory_diags.hpp
+++ b/src/core/diags/factory_diags.hpp
@@ -39,6 +39,7 @@
 #include <openthread/platform/radio.h>
 
 #include "common/locator.hpp"
+#include "utils/wrap_string.h"
 
 namespace ot {
 namespace FactoryDiags {
@@ -122,6 +123,8 @@ private:
 
     struct Stats
     {
+        void Clear(void) { memset(this, 0, sizeof(*this)); }
+
         uint32_t mReceivedPackets;
         uint32_t mSentPackets;
         int8_t   mFirstRssi;
@@ -147,7 +150,7 @@ private:
     static const struct Command sCommands[];
 
 #if !OPENTHREAD_RADIO
-    struct Stats mStats;
+    Stats mStats;
 
     otRadioFrame *mTxPacket;
     uint32_t      mTxPeriod;

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -121,7 +121,7 @@ Mac::Mac(Instance &aInstance)
     randomExtAddress.GenerateRandom();
 
     mCcaSuccessRateTracker.Reset();
-    memset(&mCounters, 0, sizeof(otMacCounters));
+    ResetCounters();
     mExtendedPanId.Clear();
 
     mSubMac.Enable();
@@ -1837,11 +1837,6 @@ void Mac::SetPromiscuous(bool aPromiscuous)
 
     mSubMac.SetRxOnWhenBackoff(mRxOnWhenIdle || mPromiscuous);
     UpdateIdleMode();
-}
-
-void Mac::ResetCounters(void)
-{
-    memset(&mCounters, 0, sizeof(mCounters));
 }
 
 int8_t Mac::GetNoiseFloor(void)

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -122,7 +122,7 @@ Mac::Mac(Instance &aInstance)
 
     mCcaSuccessRateTracker.Reset();
     memset(&mCounters, 0, sizeof(otMacCounters));
-    memset(&mExtendedPanId, 0, sizeof(ExtendedPanId));
+    mExtendedPanId.Clear();
 
     mSubMac.Enable();
 

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -567,7 +567,7 @@ public:
      * This method resets mac counters
      *
      */
-    void ResetCounters(void);
+    void ResetCounters(void) { memset(&mCounters, 0, sizeof(mCounters)); }
 
     /**
      * This method returns the MAC counter.

--- a/src/core/mac/mac_filter.cpp
+++ b/src/core/mac/mac_filter.cpp
@@ -234,7 +234,7 @@ otError Filter::GetNextRssIn(Iterator &aIterator, Entry &aEntry)
     // Return the default RssIn at the end of list
     if ((aIterator == OT_ARRAY_LENGTH(mFilterEntries)) && (mDefaultRssIn != kFixedRssDisabled))
     {
-        memset(&aEntry.mExtAddress, 0xff, OT_EXT_ADDRESS_SIZE);
+        static_cast<ExtAddress &>(aEntry.mExtAddress).Fill(0xff);
         aEntry.mRssIn = mDefaultRssIn;
         error         = OT_ERROR_NONE;
         aIterator++;

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -111,6 +111,20 @@ public:
     };
 
     /**
+     * This method clears the Extended Address (sets all bytes to zero).
+     *
+     */
+    void Clear(void) { Fill(0); }
+
+    /**
+     * This method fills all bytes of address with a given byte value.
+     *
+     * @param[in] aByte A byte value to fill address with.
+     *
+     */
+    void Fill(uint8_t aByte) { memset(this, aByte, sizeof(*this)); }
+
+    /**
      * This method generates a random IEEE 802.15.4 Extended Address.
      *
      */

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -462,6 +462,12 @@ public:
     typedef String<kInfoStringSize> InfoString;
 
     /**
+     * This method clears the Extended PAN Identifier (sets all bytes to zero).
+     *
+     */
+    void Clear(void) { memset(this, 0, sizeof(*this)); }
+
+    /**
      * This method evaluates whether or not the Extended PAN Identifiers match.
      *
      * @param[in]  aOther  The Extended PAN Id to compare.

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -61,7 +61,7 @@ SubMac::SubMac(Instance &aInstance)
     , mPcapCallbackContext(NULL)
     , mTimer(aInstance, &SubMac::HandleTimer, this)
 {
-    memset(mExtAddress.m8, 0, sizeof(mExtAddress));
+    mExtAddress.Clear();
 }
 
 otRadioCaps SubMac::GetCaps(void) const

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -355,6 +355,7 @@ BorderAgent::BorderAgent(Instance &aInstance)
     , mTimer(aInstance, HandleTimeout, this)
     , mState(OT_BORDER_AGENT_STATE_STOPPED)
 {
+    mCommissionerAloc.Clear();
     mCommissionerAloc.mPrefixLength       = 64;
     mCommissionerAloc.mPreferred          = true;
     mCommissionerAloc.mValid              = true;

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -76,6 +76,7 @@ Commissioner::Commissioner(Instance &aInstance)
 {
     memset(mJoiners, 0, sizeof(mJoiners));
 
+    mCommissionerAloc.Clear();
     mCommissionerAloc.mPrefixLength       = 64;
     mCommissionerAloc.mPreferred          = true;
     mCommissionerAloc.mValid              = true;

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -583,7 +583,7 @@ void Joiner::SendJoinerEntrustResponse(const Coap::Message &aRequest, const Ip6:
     SuccessOrExit(error = message->SetDefaultResponseHeader(aRequest));
     message->SetSubType(Message::kSubTypeJoinerEntrust);
 
-    memset(&responseInfo.mSockAddr, 0, sizeof(responseInfo.mSockAddr));
+    responseInfo.GetSockAddr().Clear();
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, responseInfo));
 
     SetState(OT_JOINER_STATE_JOINED);

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -227,7 +227,7 @@ otError Ip6::AddTunneledMplOption(Message &aMessage, Header &aHeader, MessageInf
     MessageInfo                messageInfo(aMessageInfo);
 
     // Use IP-in-IP encapsulation (RFC2473) and ALL_MPL_FORWARDERS address.
-    memset(&messageInfo.GetPeerAddr(), 0, sizeof(Address));
+    messageInfo.GetPeerAddr().Clear();
     messageInfo.GetPeerAddr().mFields.m16[0] = HostSwap16(0xff03);
     messageInfo.GetPeerAddr().mFields.m16[7] = HostSwap16(0x00fc);
 

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -268,7 +268,7 @@ otError Address::FromString(const char *aBuf)
     char        ch;
     uint8_t     d;
 
-    memset(mFields.m8, 0, 16);
+    Clear();
 
     dst--;
 

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -68,6 +68,12 @@ class NetifUnicastAddress : public otNetifAddress
 
 public:
     /**
+     * This method clears the object (setting all fields to zero).
+     *
+     */
+    void Clear(void) { memset(this, 0, sizeof(*this)); }
+
+    /**
      * This method returns the unicast address.
      *
      * @returns The unicast address.
@@ -120,6 +126,12 @@ class NetifMulticastAddress : public otNetifMulticastAddress
     friend class Netif;
 
 public:
+    /**
+     * This method clears the object (setting all fields to zero).
+     *
+     */
+    void Clear(void) { memset(this, 0, sizeof(*this)); }
+
     /**
      * This method returns the multicast address.
      *

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -67,6 +67,14 @@ public:
      * @returns A reference to the local socket address.
      *
      */
+    Address &GetSockAddr(void) { return *static_cast<Address *>(&mSockAddr); }
+
+    /**
+     * This method returns a reference to the local socket address.
+     *
+     * @returns A reference to the local socket address.
+     *
+     */
     const Address &GetSockAddr(void) const { return *static_cast<const Address *>(&mSockAddr); }
 
     /**

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -202,7 +202,13 @@ public:
      * This constructor initializes the object.
      *
      */
-    SockAddr(void) { memset(this, 0, sizeof(*this)); }
+    SockAddr(void) { Clear(); }
+
+    /**
+     * This method clears the object (sets all fields to zero).
+     *
+     */
+    void Clear(void) { memset(this, 0, sizeof(*this)); }
 
     /**
      * This method returns a reference to the IPv6 address.

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -75,8 +75,8 @@ otError UdpSocket::Open(otUdpReceive aHandler, void *aContext)
 {
     otError error = OT_ERROR_NONE;
 
-    memset(&mSockName, 0, sizeof(mSockName));
-    memset(&mPeerName, 0, sizeof(mPeerName));
+    GetSockName().Clear();
+    GetPeerName().Clear();
     mHandler = aHandler;
     mContext = aContext;
 
@@ -142,8 +142,8 @@ otError UdpSocket::Close(void)
 #endif
 
     Get<Udp>().RemoveSocket(*this);
-    memset(&mSockName, 0, sizeof(mSockName));
-    memset(&mPeerName, 0, sizeof(mPeerName));
+    GetSockName().Clear();
+    GetPeerName().Clear();
 
 #if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
 exit:

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -616,7 +616,7 @@ void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::Mes
 
             if (child.RemoveIp6Address(GetInstance(), targetTlv.GetTarget()) == OT_ERROR_NONE)
             {
-                memset(&destination, 0, sizeof(destination));
+                destination.Clear();
                 destination.mFields.m16[0] = HostSwap16(0xfe80);
                 destination.SetIid(child.GetExtAddress());
 

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -84,7 +84,7 @@ KeyManager::KeyManager(Instance &aInstance)
     , mIsPskcSet(false)
 {
     mMasterKey = static_cast<const MasterKey &>(kDefaultMasterKey);
-    memset(&mPskc, 0, sizeof(mPskc));
+    mPskc.Clear();
     ComputeKey(mKeySequence, mKey);
 }
 

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -98,6 +98,12 @@ class Pskc : public otPskc
 {
 public:
     /**
+     * This method clears the PSKc (sets all bytes to zero).
+     *
+     */
+    void Clear(void) { memset(this, 0, sizeof(*this)); }
+
+    /**
      * This method evaluates whether or not the Thread PSKc values match.
      *
      * @param[in]  aOther  The Thread PSKc to compare.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -118,16 +118,11 @@ Mle::Mle(Instance &aInstance)
     memset(&mParentLeaderData, 0, sizeof(mParentLeaderData));
     mParent.Clear();
     memset(&mChildIdRequest, 0, sizeof(mChildIdRequest));
-    memset(&mLinkLocal64, 0, sizeof(mLinkLocal64));
-    memset(&mMeshLocal64, 0, sizeof(mMeshLocal64));
-    memset(&mMeshLocal16, 0, sizeof(mMeshLocal16));
-    memset(&mLinkLocalAllThreadNodes, 0, sizeof(mLinkLocalAllThreadNodes));
-    memset(&mRealmLocalAllThreadNodes, 0, sizeof(mRealmLocalAllThreadNodes));
-    memset(&mLeaderAloc, 0, sizeof(mLeaderAloc));
     mParentCandidate.Clear();
     ResetCounters();
 
     // link-local 64
+    mLinkLocal64.Clear();
     mLinkLocal64.GetAddress().mFields.m16[0] = HostSwap16(0xfe80);
     mLinkLocal64.GetAddress().SetIid(Get<Mac::Mac>().GetExtAddress());
     mLinkLocal64.mPrefixLength = 64;
@@ -135,6 +130,7 @@ Mle::Mle(Instance &aInstance)
     mLinkLocal64.mValid        = true;
 
     // Leader Aloc
+    mLeaderAloc.Clear();
     mLeaderAloc.mPrefixLength       = 64;
     mLeaderAloc.mPreferred          = true;
     mLeaderAloc.mValid              = true;
@@ -146,8 +142,7 @@ Mle::Mle(Instance &aInstance)
     // Service Alocs
     for (size_t i = 0; i < OT_ARRAY_LENGTH(mServiceAlocs); i++)
     {
-        memset(&mServiceAlocs[i], 0, sizeof(mServiceAlocs[i]));
-
+        mServiceAlocs[i].Clear();
         mServiceAlocs[i].mPrefixLength               = 64;
         mServiceAlocs[i].mPreferred                  = true;
         mServiceAlocs[i].mValid                      = true;
@@ -165,6 +160,7 @@ Mle::Mle(Instance &aInstance)
     meshLocalPrefix.m8[7] = 0x00;
 
     // mesh-local 64
+    mMeshLocal64.Clear();
     Random::NonCrypto::FillBuffer(mMeshLocal64.GetAddress().mFields.m8 + OT_IP6_PREFIX_SIZE,
                                   OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE);
 
@@ -175,6 +171,7 @@ Mle::Mle(Instance &aInstance)
     mMeshLocal64.mScopeOverrideValid = true;
 
     // mesh-local 16
+    mMeshLocal16.Clear();
     mMeshLocal16.GetAddress().mFields.m16[4] = HostSwap16(0x0000);
     mMeshLocal16.GetAddress().mFields.m16[5] = HostSwap16(0x00ff);
     mMeshLocal16.GetAddress().mFields.m16[6] = HostSwap16(0xfe00);
@@ -189,11 +186,13 @@ Mle::Mle(Instance &aInstance)
     Get<Ip6::Mpl>().SetMatchingAddress(mMeshLocal16.GetAddress());
 
     // link-local all thread nodes
+    mLinkLocalAllThreadNodes.Clear();
     mLinkLocalAllThreadNodes.GetAddress().mFields.m16[0] = HostSwap16(0xff32);
     mLinkLocalAllThreadNodes.GetAddress().mFields.m16[6] = HostSwap16(0x0000);
     mLinkLocalAllThreadNodes.GetAddress().mFields.m16[7] = HostSwap16(0x0001);
 
     // realm-local all thread nodes
+    mRealmLocalAllThreadNodes.Clear();
     mRealmLocalAllThreadNodes.GetAddress().mFields.m16[0] = HostSwap16(0xff33);
     mRealmLocalAllThreadNodes.GetAddress().mFields.m16[6] = HostSwap16(0x0000);
     mRealmLocalAllThreadNodes.GetAddress().mFields.m16[7] = HostSwap16(0x0001);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -562,7 +562,7 @@ otError Mle::Discover(const Mac::ChannelMask &aScanChannels,
     tlv.SetLength(static_cast<uint8_t>(message->GetLength() - startOffset));
     message->Write(startOffset - sizeof(tlv), sizeof(tlv), &tlv);
 
-    memset(&destination, 0, sizeof(destination));
+    destination.Clear();
     destination.mFields.m16[0] = HostSwap16(0xff02);
     destination.mFields.m16[7] = HostSwap16(0x0002);
     SuccessOrExit(error = SendMessage(*message, destination));
@@ -1989,7 +1989,7 @@ otError Mle::SendParentRequest(ParentRequestType aType)
     SuccessOrExit(error = AppendTimeRequest(*message));
 #endif
 
-    memset(&destination, 0, sizeof(destination));
+    destination.Clear();
     destination.mFields.m16[0] = HostSwap16(0xff02);
     destination.mFields.m16[7] = HostSwap16(0x0002);
     SuccessOrExit(error = SendMessage(*message, destination));
@@ -2074,7 +2074,7 @@ otError Mle::SendChildIdRequest(void)
 
     mParentCandidate.SetState(Neighbor::kStateValid);
 
-    memset(&destination, 0, sizeof(destination));
+    destination.Clear();
     destination.mFields.m16[0] = HostSwap16(0xfe80);
     destination.SetIid(mParentCandidate.GetExtAddress());
     SuccessOrExit(error = SendMessage(*message, destination));
@@ -2220,7 +2220,7 @@ void Mle::HandleMessageTransmissionTimer(void)
 
             VerifyOrExit(mDataRequestAttempts < kMaxChildKeepAliveAttempts, BecomeDetached());
 
-            memset(&destination, 0, sizeof(destination));
+            destination.Clear();
             destination.mFields.m16[0] = HostSwap16(0xfe80);
             destination.SetIid(mParent.GetExtAddress());
 
@@ -2310,7 +2310,7 @@ otError Mle::SendChildUpdateRequest(void)
         break;
     }
 
-    memset(&destination, 0, sizeof(destination));
+    destination.Clear();
     destination.mFields.m16[0] = HostSwap16(0xfe80);
     destination.SetIid(mParent.GetExtAddress());
     SuccessOrExit(error = SendMessage(*message, destination));
@@ -2389,7 +2389,7 @@ otError Mle::SendChildUpdateResponse(const uint8_t *aTlvs, uint8_t aNumTlvs, con
         }
     }
 
-    memset(&destination, 0, sizeof(destination));
+    destination.Clear();
     destination.mFields.m16[0] = HostSwap16(0xfe80);
     destination.SetIid(mParent.GetExtAddress());
     SuccessOrExit(error = SendMessage(*message, destination));
@@ -2415,7 +2415,7 @@ otError Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce)
 {
     Ip6::Address destination;
 
-    memset(&destination, 0, sizeof(destination));
+    destination.Clear();
     destination.mFields.m16[0] = HostSwap16(0xff02);
     destination.mFields.m16[7] = HostSwap16(0x0001);
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -447,7 +447,7 @@ otError Mle::Store(void)
     otError               error = OT_ERROR_NONE;
     Settings::NetworkInfo networkInfo;
 
-    memset(&networkInfo, 0, sizeof(networkInfo));
+    networkInfo.Clear();
 
     if (IsAttached())
     {
@@ -465,7 +465,7 @@ otError Mle::Store(void)
         {
             Settings::ParentInfo parentInfo;
 
-            memset(&parentInfo, 0, sizeof(parentInfo));
+            parentInfo.Clear();
             parentInfo.mExtAddress = mParent.GetExtAddress();
 
             SuccessOrExit(error = Get<Settings>().SaveParentInfo(parentInfo));

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -114,8 +114,8 @@ Mle::Mle(Instance &aInstance)
 {
     otMeshLocalPrefix meshLocalPrefix;
 
-    memset(&mLeaderData, 0, sizeof(mLeaderData));
-    memset(&mParentLeaderData, 0, sizeof(mParentLeaderData));
+    mLeaderData.Clear();
+    mParentLeaderData.Clear();
     mParent.Clear();
     memset(&mChildIdRequest, 0, sizeof(mChildIdRequest));
     mParentCandidate.Clear();

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2604,8 +2604,8 @@ void MleRouter::SetSteeringData(const Mac::ExtAddress *aExtAddress)
     Mac::ExtAddress nullExtAddr;
     Mac::ExtAddress allowAnyExtAddr;
 
-    memset(nullExtAddr.m8, 0, sizeof(nullExtAddr.m8));
-    memset(allowAnyExtAddr.m8, 0xFF, sizeof(allowAnyExtAddr.m8));
+    nullExtAddr.Clear();
+    allowAnyExtAddr.Fill(0xff);
 
     mSteeringData.Init();
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -446,7 +446,7 @@ otError MleRouter::SendAdvertisement(void)
         break;
     }
 
-    memset(&destination, 0, sizeof(destination));
+    destination.Clear();
     destination.mFields.m16[0] = HostSwap16(0xff02);
     destination.mFields.m16[7] = HostSwap16(0x0001);
     SuccessOrExit(error = SendMessage(*message, destination));
@@ -472,7 +472,7 @@ otError MleRouter::SendLinkRequest(Neighbor *aNeighbor)
     Message *            message;
     Ip6::Address         destination;
 
-    memset(&destination, 0, sizeof(destination));
+    destination.Clear();
 
     VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandLinkRequest));
@@ -1920,7 +1920,7 @@ void MleRouter::SendParentResponse(Child *aChild, const ChallengeTlv &aChallenge
     SuccessOrExit(error = AppendConnectivity(*message));
     SuccessOrExit(error = AppendVersion(*message));
 
-    memset(&destination, 0, sizeof(destination));
+    destination.Clear();
     destination.mFields.m16[0] = HostSwap16(0xfe80);
     destination.SetIid(aChild->GetExtAddress());
 
@@ -2549,7 +2549,7 @@ void MleRouter::HandleNetworkDataUpdateRouter(void)
 
     VerifyOrExit(mRole == OT_DEVICE_ROLE_ROUTER || mRole == OT_DEVICE_ROLE_LEADER);
 
-    memset(&destination, 0, sizeof(destination));
+    destination.Clear();
     destination.mFields.m16[0] = HostSwap16(0xff02);
     destination.mFields.m16[7] = HostSwap16(0x0001);
 
@@ -2887,7 +2887,7 @@ otError MleRouter::SendChildIdResponse(Child &aChild)
     }
 #endif
 
-    memset(&destination, 0, sizeof(destination));
+    destination.Clear();
     destination.mFields.m16[0] = HostSwap16(0xfe80);
     destination.SetIid(aChild.GetExtAddress());
     SuccessOrExit(error = SendMessage(*message, destination));
@@ -2949,7 +2949,7 @@ otError MleRouter::SendChildUpdateRequest(Child &aChild)
         SuccessOrExit(error = AppendChallenge(*message, aChild.GetChallenge(), aChild.GetChallengeSize()));
     }
 
-    memset(&destination, 0, sizeof(destination));
+    destination.Clear();
     destination.mFields.m16[0] = HostSwap16(0xfe80);
     destination.SetIid(aChild.GetExtAddress());
     SuccessOrExit(error = SendMessage(*message, destination));
@@ -4687,7 +4687,7 @@ otError MleRouter::SendTimeSync(void)
 
     message->SetTimeSync(true);
 
-    memset(&destination, 0, sizeof(destination));
+    destination.Clear();
     destination.mFields.m16[0] = HostSwap16(0xff02);
     destination.mFields.m16[7] = HostSwap16(0x0001);
     SuccessOrExit(error = SendMessage(*message, destination));

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3566,7 +3566,7 @@ otError MleRouter::StoreChild(const Child &aChild)
 
     IgnoreReturnValue(RemoveStoredChild(aChild.GetRloc16()));
 
-    memset(&childInfo, 0, sizeof(childInfo));
+    childInfo.Clear();
     childInfo.mExtAddress = aChild.GetExtAddress();
     childInfo.mTimeout    = aChild.GetTimeout();
     childInfo.mRloc16     = aChild.GetRloc16();

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -977,6 +977,12 @@ class LeaderDataTlv : public Tlv
 {
 public:
     /**
+     * This method clears the object (setting all fields to zero).
+     *
+     */
+    void Clear(void) { memset(this, 0, sizeof(*this)); }
+
+    /**
      * This method initializes the TLV.
      *
      */

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -227,7 +227,7 @@ void Slaac::Update(UpdateMode aMode)
                         continue;
                     }
 
-                    memset(slaacAddr, 0, sizeof(*slaacAddr));
+                    slaacAddr->Clear();
                     memcpy(&slaacAddr->mAddress, &prefix.mPrefix, BitVectorBytes(prefix.mLength));
 
                     slaacAddr->mPrefixLength = prefix.mLength;


### PR DESCRIPTION
This PR contains a group of smaller commits related to adding/using `Clear()` method:
- [netif] add Clear() to netif unicast/multicast address types
- [mle-tlvs] add LeaderDataTlv::Clear()
- [ip6] use Ip6::Address::Clear() replacing memset to zero
- [mac-types] add Clear() and Fill() method to Mac::ExtAddress
- [mac-types] add Mac::ExtendedPanId::Clear() method
- [key-manager] add Pskc::Clear() method
- [socket] add SockAddr::Clear()
- [coap-message] add HelpData::Clear() method
- [factory-diags] add Diags::Stats::Clear() method
- [mac] use Mac::ResetCounters()
- [settings] add Clear() method for all setting structures
