### PR TITLE
[build] add a gn based build and corresponding travis script

### DIFF
--- a/.gn
+++ b/.gn
@@ -1,0 +1,1 @@
+buildconfig = "//third_party/build_gn/BUILDCONFIG.gn"

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,9 @@ jobs:
       dist: trusty
       python: "2.7" # The old Android build system only supports python2
       script: .travis/script.sh
+    - env: BUILD_TARGET="gn-build" VERBOSE=1
+      os: linux
+      script: .travis/script.sh
     - env: BUILD_TARGET="posix-distcheck" VERBOSE=1 VIRTUAL_TIME=1
       os: linux
       compiler: clang

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -61,6 +61,27 @@ cd /tmp || die
         ) || die
     }
 
+    [ $BUILD_TARGET != gn-build ] || {
+        # Install ninja
+        (
+        cd $HOME
+        wget -O ninja.zip https://chrome-infra-packages.appspot.com/dl/infra/ninja/linux-amd64/+/latest
+        unzip -o ninja.zip
+        chmod a+x ninja && mkdir -p bin && mv -f ninja bin/ && export PATH=${HOME}/bin:$PATH
+        ninja --version
+        ) || die
+
+
+        # Get latest gn
+        (
+        cd $HOME
+        wget -O gn.zip https://chrome-infra-packages.appspot.com/dl/gn/gn/linux-amd64/+/latest
+        unzip -o gn.zip
+        chmod a+x gn && mv -f gn bin/
+        gn --version
+        ) || die
+    }
+
     [ $BUILD_TARGET != posix-app-pty ] || {
         sudo apt-get install socat expect || die
         JOBS=$(getconf _NPROCESSORS_ONLN)

--- a/.travis/check-gn-build
+++ b/.travis/check-gn-build
@@ -1,0 +1,43 @@
+#!/bin/sh
+#
+#  Copyright (c) 2019, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# Run this command on parent directory of openthread
+#
+
+set -e
+set -x
+
+main() {
+    gn gen gn-out
+    ninja -C gn-out
+    test -f gn-out/obj/lib-ot-core.a
+}
+
+main "$@"

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -102,6 +102,10 @@ python --version || die
     (cd .. && ${TRAVIS_BUILD_DIR}/.travis/check-android-build) || die
 }
 
+[ $BUILD_TARGET != gn-build ] || {
+    (cd ${TRAVIS_BUILD_DIR} && .travis/check-gn-build) || die
+}
+
 build_cc1352() {
     git checkout -- . || die
     git clean -xfd || die

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,0 +1,221 @@
+#  Copyright (c) 2019, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+static_library("lib-ot-core") {
+
+ cflags_cc = [ "-Wno-non-virtual-dtor" ]
+
+ sources = [
+    "src/core/api/border_agent_api.cpp",
+    "src/core/api/border_router_api.cpp",
+    "src/core/api/channel_manager_api.cpp",
+    "src/core/api/channel_monitor_api.cpp",
+    "src/core/api/child_supervision_api.cpp",
+    "src/core/api/coap_api.cpp",
+    "src/core/api/coap_secure_api.cpp",
+    "src/core/api/commissioner_api.cpp",
+    "src/core/api/crypto_api.cpp",
+    "src/core/api/dataset_api.cpp",
+    "src/core/api/dataset_ftd_api.cpp",
+    "src/core/api/diags_api.cpp",
+    "src/core/api/dns_api.cpp",
+    "src/core/api/entropy_api.cpp",
+    "src/core/api/heap_api.cpp",
+    "src/core/api/icmp6_api.cpp",
+    "src/core/api/instance_api.cpp",
+    "src/core/api/ip6_api.cpp",
+    "src/core/api/jam_detection_api.cpp",
+    "src/core/api/joiner_api.cpp",
+    "src/core/api/link_api.cpp",
+    "src/core/api/link_raw_api.cpp",
+    "src/core/api/logging_api.cpp",
+    "src/core/api/message_api.cpp",
+    "src/core/api/netdata_api.cpp",
+    "src/core/api/network_time_api.cpp",
+    "src/core/api/random_crypto_api.cpp",
+    "src/core/api/random_noncrypto_api.cpp",
+    "src/core/api/server_api.cpp",
+    "src/core/api/sntp_api.cpp",
+    "src/core/api/tasklet_api.cpp",
+    "src/core/api/thread_api.cpp",
+    "src/core/api/thread_ftd_api.cpp",
+    "src/core/api/udp_api.cpp",
+    "src/core/coap/coap.cpp",
+    "src/core/coap/coap_message.cpp",
+    "src/core/coap/coap_secure.cpp",
+    "src/core/common/crc16.cpp",
+    "src/core/common/extension_example.cpp",
+    "src/core/common/instance.cpp",
+    "src/core/common/logging.cpp",
+    "src/core/common/message.cpp",
+    "src/core/common/notifier.cpp",
+    "src/core/common/random_manager.cpp",
+    "src/core/common/settings.cpp",
+    "src/core/common/string.cpp",
+    "src/core/common/tasklet.cpp",
+    "src/core/common/timer.cpp",
+    "src/core/common/tlvs.cpp",
+    "src/core/common/trickle_timer.cpp",
+    "src/core/crypto/aes_ccm.cpp",
+    "src/core/crypto/aes_ecb.cpp",
+    "src/core/crypto/ecdsa.cpp",
+    "src/core/crypto/hmac_sha256.cpp",
+    "src/core/crypto/mbedtls.cpp",
+    "src/core/crypto/pbkdf2_cmac.cpp",
+    "src/core/crypto/sha256.cpp",
+    "src/core/diags/factory_diags.cpp",
+    "src/core/mac/channel_mask.cpp",
+    "src/core/mac/data_poll_handler.cpp",
+    "src/core/mac/data_poll_sender.cpp",
+    "src/core/mac/link_raw.cpp",
+    "src/core/mac/mac.cpp",
+    "src/core/mac/mac_filter.cpp",
+    "src/core/mac/mac_frame.cpp",
+    "src/core/mac/mac_types.cpp",
+    "src/core/mac/sub_mac_callbacks.cpp",
+    "src/core/mac/sub_mac.cpp",
+    "src/core/meshcop/announce_begin_client.cpp",
+    "src/core/meshcop/border_agent.cpp",
+    "src/core/meshcop/commissioner.cpp",
+    "src/core/meshcop/dataset.cpp",
+    "src/core/meshcop/dataset_local.cpp",
+    "src/core/meshcop/dataset_manager.cpp",
+    "src/core/meshcop/dataset_manager_ftd.cpp",
+    "src/core/meshcop/dtls.cpp",
+    "src/core/meshcop/energy_scan_client.cpp",
+    "src/core/meshcop/joiner.cpp",
+    "src/core/meshcop/joiner_router.cpp",
+    "src/core/meshcop/leader.cpp",
+    "src/core/meshcop/meshcop.cpp",
+    "src/core/meshcop/meshcop_tlvs.cpp",
+    "src/core/meshcop/panid_query_client.cpp",
+    "src/core/meshcop/timestamp.cpp",
+    "src/core/net/dhcp6_client.cpp",
+    "src/core/net/dhcp6_server.cpp",
+    "src/core/net/dns_client.cpp",
+    "src/core/net/icmp6.cpp",
+    "src/core/net/ip6_address.cpp",
+    "src/core/net/ip6.cpp",
+    "src/core/net/ip6_filter.cpp",
+    "src/core/net/ip6_headers.cpp",
+    "src/core/net/ip6_mpl.cpp",
+    "src/core/net/netif.cpp",
+    "src/core/net/sntp_client.cpp",
+    "src/core/net/udp6.cpp",
+    "src/core/radio/radio_callbacks.cpp",
+    "src/core/radio/radio_platform.cpp",
+    "src/core/thread/address_resolver.cpp",
+    "src/core/thread/announce_begin_server.cpp",
+    "src/core/thread/announce_sender.cpp",
+    "src/core/thread/child_table.cpp",
+    "src/core/thread/device_mode.cpp",
+    "src/core/thread/energy_scan_server.cpp",
+    "src/core/thread/indirect_sender.cpp",
+    "src/core/thread/key_manager.cpp",
+    "src/core/thread/link_quality.cpp",
+    "src/core/thread/lowpan.cpp",
+    "src/core/thread/mesh_forwarder.cpp",
+    "src/core/thread/mesh_forwarder_ftd.cpp",
+    "src/core/thread/mesh_forwarder_mtd.cpp",
+    "src/core/thread/mle.cpp",
+    "src/core/thread/mle_router.cpp",
+    "src/core/thread/network_data.cpp",
+    "src/core/thread/network_data_leader.cpp",
+    "src/core/thread/network_data_leader_ftd.cpp",
+    "src/core/thread/network_data_local.cpp",
+    "src/core/thread/network_diagnostic.cpp",
+    "src/core/thread/panid_query_server.cpp",
+    "src/core/thread/router_table.cpp",
+    "src/core/thread/src_match_controller.cpp",
+    "src/core/thread/thread_netif.cpp",
+    "src/core/thread/time_sync_service.cpp",
+    "src/core/thread/topology.cpp",
+    "src/core/utils/channel_manager.cpp",
+    "src/core/utils/channel_monitor.cpp",
+    "src/core/utils/child_supervision.cpp",
+    "src/core/utils/heap.cpp",
+    "src/core/utils/jam_detector.cpp",
+    "src/core/utils/missing_strlcat.c",
+    "src/core/utils/missing_strlcpy.c",
+    "src/core/utils/missing_strnlen.c",
+    "src/core/utils/parse_cmdline.cpp",
+    "src/core/utils/slaac_address.cpp",
+    "src/ncp/hdlc.cpp",
+    "src/ncp/spinel.c",
+    "src/ncp/spinel_decoder.cpp",
+    "src/ncp/spinel_encoder.cpp",
+    "third_party/mbedtls/repo/library/md.c",
+    "third_party/mbedtls/repo/library/md_wrap.c",
+    "third_party/mbedtls/repo/library/memory_buffer_alloc.c",
+    "third_party/mbedtls/repo/library/platform.c",
+    "third_party/mbedtls/repo/library/platform_util.c",
+    "third_party/mbedtls/repo/library/sha256.c",
+    "third_party/mbedtls/repo/library/bignum.c",
+    "third_party/mbedtls/repo/library/ccm.c",
+    "third_party/mbedtls/repo/library/cipher.c",
+    "third_party/mbedtls/repo/library/cipher_wrap.c",
+    "third_party/mbedtls/repo/library/cmac.c",
+    "third_party/mbedtls/repo/library/ctr_drbg.c",
+    "third_party/mbedtls/repo/library/debug.c",
+    "third_party/mbedtls/repo/library/ecjpake.c",
+    "third_party/mbedtls/repo/library/ecp_curves.c",
+    "third_party/mbedtls/repo/library/entropy.c",
+    "third_party/mbedtls/repo/library/entropy_poll.c",
+    "third_party/mbedtls/repo/library/ssl_cookie.c",
+    "third_party/mbedtls/repo/library/ssl_ciphersuites.c",
+    "third_party/mbedtls/repo/library/ssl_cli.c",
+    "third_party/mbedtls/repo/library/ssl_srv.c",
+    "third_party/mbedtls/repo/library/ssl_ticket.c",
+    "third_party/mbedtls/repo/library/ssl_tls.c",
+    "third_party/mbedtls/repo/library/aes.c",
+    "third_party/mbedtls/repo/library/ecp.c"
+  ]
+
+  # Remove the example as it is not meant for compilation
+  sources -= [
+    "src/core/common/extension_example.cpp",
+  ]
+
+  include_dirs = [
+    "include",
+    "src",
+    "src/core",
+    "src/ncp",
+    "third_party",
+    "third_party/mbedtls",
+    "third_party/mbedtls/repo/include"
+  ]
+
+  defines = [
+    "MBEDTLS_CONFIG_FILE=\"mbedtls-config.h\"",
+    "OPENTHREAD_FTD=1",
+    "SPINEL_PLATFORM_HEADER=\"spinel_platform.h\"",
+    "OPENTHREAD_CONFIG_FILE=<openthread-config-android.h>",
+    "PACKAGE_NAME=\"OPENTHREAD-CORE\"",
+    "PACKAGE_VERSION=\"1.0.0\""
+  ]
+}

--- a/third_party/build_gn/BUILDCONFIG.gn
+++ b/third_party/build_gn/BUILDCONFIG.gn
@@ -1,0 +1,18 @@
+# Copyright 2014 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+if (target_os == "") {
+  target_os = host_os
+}
+if (target_cpu == "") {
+  target_cpu = host_cpu
+}
+if (current_cpu == "") {
+  current_cpu = target_cpu
+}
+if (current_os == "") {
+  current_os = target_os
+}
+
+set_default_toolchain("//third_party/build_gn/toolchain:gcc")

--- a/third_party/build_gn/README.md
+++ b/third_party/build_gn/README.md
@@ -1,0 +1,22 @@
+# build_gn
+
+## URL
+
+https://gn.googlesource.com/gn/+/refs/heads/master/examples/simple_build/build
+
+## License
+
+BSD 3-Clause
+
+## License File
+
+[LICENSE](https://gn.googlesource.com/gn/+/refs/heads/master/LICENSE)
+
+## Description
+
+gn is metabuild system that generates ninja files for further compilation 
+
+gn tool requires paths to all the toolchains to be used for compilation, for
+example compiler, linker etc. The toolchains in toolchain/BUILD.gn are from the
+examples repository for gn. BUILDCONFIG.gn is also trimmed down version from
+examples/simple_build/build/

--- a/third_party/build_gn/toolchain/BUILD.gn
+++ b/third_party/build_gn/toolchain/BUILD.gn
@@ -1,0 +1,74 @@
+# Copyright 2014 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+toolchain("gcc") {
+  tool("cc") {
+    depfile = "{{output}}.d"
+    command = "gcc -MMD -MF $depfile {{defines}} {{include_dirs}} {{cflags}} {{cflags_c}} -c {{source}} -o {{output}}"
+    depsformat = "gcc"
+    description = "CC {{output}}"
+    outputs = [
+      "{{source_out_dir}}/{{target_output_name}}.{{source_name_part}}.o",
+    ]
+  }
+  tool("cxx") {
+    depfile = "{{output}}.d"
+    command = "g++ -MMD -MF $depfile {{defines}} {{include_dirs}} {{cflags}} {{cflags_cc}} -c {{source}} -o {{output}}"
+    depsformat = "gcc"
+    description = "CXX {{output}}"
+    outputs = [
+      "{{source_out_dir}}/{{target_output_name}}.{{source_name_part}}.o",
+    ]
+  }
+  tool("alink") {
+    rspfile = "{{output}}.rsp"
+    command = "rm -f {{output}} && ar rcs {{output}} @$rspfile"
+    description = "AR {{target_output_name}}{{output_extension}}"
+    rspfile_content = "{{inputs}}"
+    outputs = [
+      "{{target_out_dir}}/{{target_output_name}}{{output_extension}}",
+    ]
+    default_output_extension = ".a"
+    output_prefix = "lib"
+  }
+  tool("solink") {
+    soname = "{{target_output_name}}{{output_extension}}"  # e.g. "libfoo.so".
+    sofile = "{{output_dir}}/$soname"
+    rspfile = soname + ".rsp"
+    command = "g++ -shared {{ldflags}} -o $sofile -Wl,-soname=$soname @$rspfile"
+    rspfile_content = "-Wl,--whole-archive {{inputs}} {{solibs}} -Wl,--no-whole-archive {{libs}}"
+    description = "SOLINK $soname"
+    # Use this for {{output_extension}} expansions unless a target manually
+    # overrides it (in which case {{output_extension}} will be what the target
+    # specifies).
+    default_output_extension = ".so"
+    # Use this for {{output_dir}} expansions unless a target manually overrides
+    # it (in which case {{output_dir}} will be what the target specifies).
+    default_output_dir = "{{root_out_dir}}"
+    outputs = [
+      sofile,
+    ]
+    link_output = sofile
+    depend_output = sofile
+    output_prefix = "lib"
+  }
+  tool("link") {
+    outfile = "{{target_output_name}}{{output_extension}}"
+    rspfile = "$outfile.rsp"
+    command = "g++ {{ldflags}} -o $outfile -Wl,--start-group @$rspfile {{solibs}} -Wl,--end-group {{libs}}"
+    description = "LINK $outfile"
+    default_output_dir = "{{root_out_dir}}"
+    rspfile_content = "{{inputs}}"
+    outputs = [
+      outfile,
+    ]
+  }
+  tool("stamp") {
+    command = "touch {{output}}"
+    description = "STAMP {{output}}"
+  }
+  tool("copy") {
+    command = "cp -af {{source}} {{output}}"
+    description = "COPY {{source}} {{output}}"
+  }
+}


### PR DESCRIPTION
The travis script ensures that build of an openthread-core build with gn
and ninja goes through. The run time is about 1 min.

Additional reviewers : @vaas-krish @abtink 