### PR TITLE
[travis] add arm gcc 9 to build tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,10 @@ jobs:
 #      os: linux
 #      compiler: gcc
 #      script: .travis/script.sh
+    - env: BUILD_TARGET="arm-gcc-9"
+      os: linux
+      compiler: gcc
+      script: .travis/script.sh
     - env: BUILD_TARGET="posix" CC="gcc-5" CXX="g++-5"
       os: linux
       compiler: gcc

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -115,6 +115,13 @@ cd /tmp || die
         arm-none-eabi-gcc --version || die
     }
 
+    [ $BUILD_TARGET != arm-gcc-9 ] || {
+        wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/RC2.1/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 || die
+        tar xjf gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 || die
+        export PATH=/tmp/gcc-arm-none-eabi-9-2019-q4-major/bin:$PATH || die
+        arm-none-eabi-gcc --version || die
+    }
+
     [ $BUILD_TARGET != posix-32-bit -a $BUILD_TARGET != posix-mtd ] || {
         sudo apt-get install g++-multilib || die
     }

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -389,6 +389,21 @@ build_samr21() {
     build_samr21
 }
 
+[ $BUILD_TARGET != arm-gcc-9 ] || {
+    export PATH=/tmp/gcc-arm-none-eabi-9-2019-q4-major/bin:$PATH || die
+
+    build_cc1352
+    build_cc2538
+    build_cc2650
+    build_cc2652
+    build_kw41z
+    build_nrf52811
+    build_nrf52833
+    build_nrf52840
+    build_qpg6095
+    build_samr21
+}
+
 [ $BUILD_TARGET != posix ] || {
     git checkout -- . || die
     git clean -xfd || die

--- a/examples/platforms/cc1352/radio.c
+++ b/examples/platforms/cc1352/radio.c
@@ -1575,14 +1575,15 @@ otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const otExtAddress
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    otError error = OT_ERROR_NONE;
-    uint8_t idx   = rfCoreFindExtSrcMatchIdx((uint64_t *)aExtAddress);
+    otError  error      = OT_ERROR_NONE;
+    uint64_t extAddress = *(uint64_t *)aExtAddress;
+    uint8_t  idx        = rfCoreFindExtSrcMatchIdx(&extAddress);
 
     if (idx == CC1352_SRC_MATCH_NONE)
     {
         /* the entry does not exist already, add it */
         otEXPECT_ACTION((idx = rfCoreFindEmptyExtSrcMatchIdx()) != CC1352_SRC_MATCH_NONE, error = OT_ERROR_NO_BUFS);
-        sSrcMatchExtData.extAddrEnt[idx] = *((uint64_t *)aExtAddress);
+        sSrcMatchExtData.extAddrEnt[idx] = extAddress;
     }
 
     if (sReceiveCmd.status == ACTIVE || sReceiveCmd.status == IEEE_SUSPENDED)
@@ -1608,10 +1609,11 @@ otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const otExtAddre
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    otError error = OT_ERROR_NONE;
-    uint8_t idx;
+    otError  error      = OT_ERROR_NONE;
+    uint64_t extAddress = *(uint64_t *)aExtAddress;
+    uint8_t  idx;
 
-    otEXPECT_ACTION((idx = rfCoreFindExtSrcMatchIdx((uint64_t *)aExtAddress)) != CC1352_SRC_MATCH_NONE,
+    otEXPECT_ACTION((idx = rfCoreFindExtSrcMatchIdx(&extAddress)) != CC1352_SRC_MATCH_NONE,
                     error = OT_ERROR_NO_ADDRESS);
 
     if (sReceiveCmd.status == ACTIVE || sReceiveCmd.status == IEEE_SUSPENDED)

--- a/examples/platforms/cc2650/radio.c
+++ b/examples/platforms/cc2650/radio.c
@@ -1526,14 +1526,15 @@ otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const otExtAddress
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    otError error = OT_ERROR_NONE;
-    uint8_t idx   = rfCoreFindExtSrcMatchIdx((uint64_t *)aExtAddress);
+    otError  error      = OT_ERROR_NONE;
+    uint64_t extAddress = *(uint64_t *)aExtAddress;
+    uint8_t  idx        = rfCoreFindExtSrcMatchIdx(&extAddress);
 
     if (idx == CC2650_SRC_MATCH_NONE)
     {
         /* the entry does not exist already, add it */
         otEXPECT_ACTION((idx = rfCoreFindEmptyExtSrcMatchIdx()) != CC2650_SRC_MATCH_NONE, error = OT_ERROR_NO_BUFS);
-        sSrcMatchExtData.extAddrEnt[idx] = *((uint64_t *)aExtAddress);
+        sSrcMatchExtData.extAddrEnt[idx] = extAddress;
     }
 
     if (sReceiveCmd.status == ACTIVE || sReceiveCmd.status == IEEE_SUSPENDED)
@@ -1559,10 +1560,11 @@ otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const otExtAddre
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    otError error = OT_ERROR_NONE;
-    uint8_t idx;
+    otError  error      = OT_ERROR_NONE;
+    uint64_t extAddress = *(uint64_t *)aExtAddress;
+    uint8_t  idx;
 
-    otEXPECT_ACTION((idx = rfCoreFindExtSrcMatchIdx((uint64_t *)aExtAddress)) != CC2650_SRC_MATCH_NONE,
+    otEXPECT_ACTION((idx = rfCoreFindExtSrcMatchIdx(&extAddress)) != CC2650_SRC_MATCH_NONE,
                     error = OT_ERROR_NO_ADDRESS);
 
     if (sReceiveCmd.status == ACTIVE || sReceiveCmd.status == IEEE_SUSPENDED)

--- a/examples/platforms/cc2652/radio.c
+++ b/examples/platforms/cc2652/radio.c
@@ -1556,14 +1556,15 @@ otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const otExtAddress
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    otError error = OT_ERROR_NONE;
-    uint8_t idx   = rfCoreFindExtSrcMatchIdx((uint64_t *)aExtAddress);
+    otError  error      = OT_ERROR_NONE;
+    uint64_t extAddress = *(uint64_t *)aExtAddress;
+    uint8_t  idx        = rfCoreFindExtSrcMatchIdx(&extAddress);
 
     if (idx == CC2652_SRC_MATCH_NONE)
     {
         /* the entry does not exist already, add it */
         otEXPECT_ACTION((idx = rfCoreFindEmptyExtSrcMatchIdx()) != CC2652_SRC_MATCH_NONE, error = OT_ERROR_NO_BUFS);
-        sSrcMatchExtData.extAddrEnt[idx] = *((uint64_t *)aExtAddress);
+        sSrcMatchExtData.extAddrEnt[idx] = extAddress;
     }
 
     if (sReceiveCmd.status == ACTIVE || sReceiveCmd.status == IEEE_SUSPENDED)
@@ -1589,10 +1590,11 @@ otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const otExtAddre
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    otError error = OT_ERROR_NONE;
-    uint8_t idx;
+    otError  error      = OT_ERROR_NONE;
+    uint64_t extAddress = *(uint64_t *)aExtAddress;
+    uint8_t  idx;
 
-    otEXPECT_ACTION((idx = rfCoreFindExtSrcMatchIdx((uint64_t *)aExtAddress)) != CC2652_SRC_MATCH_NONE,
+    otEXPECT_ACTION((idx = rfCoreFindExtSrcMatchIdx(&extAddress)) != CC2652_SRC_MATCH_NONE,
                     error = OT_ERROR_NO_ADDRESS);
 
     if (sReceiveCmd.status == ACTIVE || sReceiveCmd.status == IEEE_SUSPENDED)


### PR DESCRIPTION
Also addresses potential unaligned pointer value flagged by Arm GCC 9 in cc1352, cc2650, and cc2652 example drivers.