### PR TITLE
[debug] override any existing assert definitions

### DIFF
--- a/src/core/common/debug.hpp
+++ b/src/core/common/debug.hpp
@@ -56,6 +56,10 @@
 #define FILE_NAME __FILE__
 #endif
 
+#ifdef assert
+#undef assert
+#endif
+
 #define assert(cond)                               \
     do                                             \
     {                                              \
@@ -69,6 +73,10 @@
     } while (0)
 
 #else
+
+#ifdef assert
+#undef assert
+#endif
 
 #define assert(cond)  \
     do                \


### PR DESCRIPTION
This prevent build error if the platform drivers have already defined
the assert macro.